### PR TITLE
Enrich erdos-874 + erdos-1172: cover uncovered summary-theorem tails (1..EOF)

### DIFF
--- a/src/data/proofs/erdos-1172/meta.json
+++ b/src/data/proofs/erdos-1172/meta.json
@@ -177,7 +177,7 @@
       "title": "Summary and Auxiliary Facts",
       "summary": "Packages all four questions into one conjunction and verifies consistency bounds on the targets appearing in Q2 and Q3.",
       "startLine": 195,
-      "endLine": 204,
+      "endLine": 241,
       "mathContext": "Four OPEN ordinal partition questions. Some are ZFC-independent. Known: EDM theorem and monotonicity consequences."
     }
   ],

--- a/src/data/proofs/erdos-874/meta.json
+++ b/src/data/proofs/erdos-874/meta.json
@@ -143,7 +143,7 @@
       "title": "Summary",
       "summary": "erdos_874 and erdos_874_answer main theorems",
       "startLine": 211,
-      "endLine": 227,
+      "endLine": 263,
       "mathContext": "Verified: erdos_874 and erdos_874_answer main theorems"
     }
   ],


### PR DESCRIPTION
Two pure `meta.json` section-coverage fixes (no `status`/`badge`/`axiomCount` changes). Both entries had a final "Summary" section whose own summary text names a main theorem that lived *past* the section's `endLine`, leaving the headline declaration uncovered. Extended each last section to EOF.

| Entry | Fix |
|-------|-----|
| erdos-874 | Summary section `endLine` 227→263 to cover `erdos_874_answer` (the $\forall\varepsilon>0$ main theorem the summary already describes). |
| erdos-1172 | Summary section `endLine` 204→241 to cover `q2_targets_lt_omega3`, the Q2/Q3 consistency-bound theorem the summary already references. |

Each verified `maxEnd === node-split-length` (gap 0) with no section overlaps before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
