### PR TITLE
Research: erdos-98-wip-01 — intersecting-circles rigidity lemma (toward h 5 ≥ 3)

### DIFF
--- a/proofs/Proofs/Erdos98WIP01.lean
+++ b/proofs/Proofs/Erdos98WIP01.lean
@@ -1754,6 +1754,136 @@ theorem no_four_equidistant_indices {P : PointConfig n} {i j k l : Fin n} {r : �
     False :=
   no_four_mutually_equidistant hr hij hik hil hjk hjl hkl
 
+/-! ## Intersecting-circles rigidity: two common `a`-neighbours of an `a`-apart pair
+
+The `h 5 ≥ 3` degree-`3` sub-cases reduce to the metric geometry of two circles of
+equal radius `a` whose centres are themselves `a` apart.  The following lemma pins that
+geometry exactly: **two points each at distance `a` from both endpoints of a segment of
+length `a` are either equal or exactly `a√3` apart** — the two intersection points of the
+two circles are the far vertices of the rhombus built from two equilateral triangles, at
+distance `2·(a√3/2) = a√3`.
+
+The proof is planar rigidity.  Write `u = x − p`, `v = y − p`, `w = q − p`; all three have
+norm `a`, and `⟨u,w⟩ = ⟨v,w⟩ = a²/2` (each of `x, y` is `a` from both `p` and `q`).  The
+vector `e = u + v − w` is orthogonal to both `w` and `d = u − v` (direct inner-product
+computation).  If `x ≠ y` then `d ≠ 0`; were `e ≠ 0`, the three pairwise-orthogonal nonzero
+vectors `e, w, d` would be linearly independent — impossible in the `2`-dimensional plane
+(`LinearIndependent.fintype_card_le_finrank`: `3 ≤ 2`).  Hence `e = 0`, i.e. `u + v = w`;
+taking norms gives `⟨u,v⟩ = −a²/2`, whence `‖x − y‖² = ‖u − v‖² = 3a²` and `dist x y = a√3`.
+This is the same "regular simplex needs dimension" mechanism as `no_four_mutually_equidistant`,
+run one dimension lower. -/
+open scoped InnerProductSpace in
+/-- **Two common `a`-neighbours of an `a`-apart pair are equal or `a√3` apart.** In
+`EuclideanSpace ℝ (Fin 2)`, if `dist p q = a` and both `x` and `y` are at distance `a`
+from `p` and from `q` (with `a > 0`), then either `x = y` or `dist x y = a · √3`.  Two
+circles of radius `a` with centres `a` apart meet in at most two points, and those two
+points are `a√3` apart.  This discharges the intersecting-circle distance equations that
+arise in the degree-`3` sub-cases of the `h 5 ≥ 3` classification. -/
+theorem two_common_neighbours_dist
+    {p q x y : EuclideanSpace ℝ (Fin 2)} {a : ℝ} (ha : 0 < a)
+    (hpq : dist p q = a)
+    (hxp : dist x p = a) (hxq : dist x q = a)
+    (hyp : dist y p = a) (hyq : dist y q = a) :
+    x = y ∨ dist x y = a * Real.sqrt 3 := by
+  set u : EuclideanSpace ℝ (Fin 2) := x - p with hudef
+  set v : EuclideanSpace ℝ (Fin 2) := y - p with hvdef
+  set w : EuclideanSpace ℝ (Fin 2) := q - p with hwdef
+  set d : EuclideanSpace ℝ (Fin 2) := u - v with hddef
+  set e : EuclideanSpace ℝ (Fin 2) := u + v - w with hedef
+  -- Edge-vector norms are all `a`.
+  have hnu : ‖u‖ = a := by rw [hudef, ← dist_eq_norm]; exact hxp
+  have hnv : ‖v‖ = a := by rw [hvdef, ← dist_eq_norm]; exact hyp
+  have hnw : ‖w‖ = a := by rw [hwdef, ← dist_eq_norm, dist_comm]; exact hpq
+  -- Self inner products.
+  have euu : inner ℝ u u = a ^ 2 := by rw [real_inner_self_eq_norm_sq, hnu]
+  have evv : inner ℝ v v = a ^ 2 := by rw [real_inner_self_eq_norm_sq, hnv]
+  have eww : inner ℝ w w = a ^ 2 := by rw [real_inner_self_eq_norm_sq, hnw]
+  -- Cross inner products with `w` are `a²/2` (each of `x, y` is `a` from both `p` and `q`).
+  have euw : inner ℝ u w = a ^ 2 / 2 := by
+    have hn : ‖u - w‖ = a := by
+      rw [show u - w = x - q from by rw [hudef, hwdef]; abel, ← dist_eq_norm]; exact hxq
+    have h := norm_sub_sq_real u w
+    rw [hn, hnu, hnw] at h; linarith
+  have evw : inner ℝ v w = a ^ 2 / 2 := by
+    have hn : ‖v - w‖ = a := by
+      rw [show v - w = y - q from by rw [hvdef, hwdef]; abel, ← dist_eq_norm]; exact hyq
+    have h := norm_sub_sq_real v w
+    rw [hn, hnv, hnw] at h; linarith
+  have ewu : inner ℝ w u = a ^ 2 / 2 := by rw [real_inner_comm]; exact euw
+  have ewv : inner ℝ w v = a ^ 2 / 2 := by rw [real_inner_comm]; exact evw
+  -- `e = u + v − w` is orthogonal to `w` and to `d = u − v`; `d` is orthogonal to `w`.
+  have hew : inner ℝ e w = 0 := by
+    rw [hedef]; simp only [inner_sub_left, inner_add_left, euw, evw, eww]; ring
+  have hed : inner ℝ e d = 0 := by
+    rw [hedef, hddef]
+    simp only [inner_sub_left, inner_add_left, inner_sub_right, inner_add_right,
+      euu, evv, ewu, ewv]
+    rw [real_inner_comm v u]; ring
+  have hdw : inner ℝ d w = 0 := by
+    rw [hddef]; simp only [inner_sub_left, euw, evw]; ring
+  have hwe : inner ℝ w e = 0 := by rw [real_inner_comm]; exact hew
+  have hde : inner ℝ d e = 0 := by rw [real_inner_comm]; exact hed
+  have hwd : inner ℝ w d = 0 := by rw [real_inner_comm]; exact hdw
+  rcases eq_or_ne x y with hxy | hxy
+  · exact Or.inl hxy
+  · right
+    -- `x ≠ y` forces `u ≠ v`, hence `d ≠ 0`.
+    have huv_ne : u ≠ v := by
+      rw [hudef, hvdef]; intro h; exact hxy (sub_left_inj.mp h)
+    have hd_ne : d ≠ 0 := by rw [hddef]; exact sub_ne_zero.mpr huv_ne
+    have hdd : (0 : ℝ) < inner ℝ d d := by
+      rw [real_inner_self_eq_norm_sq]; exact pow_pos (norm_pos_iff.mpr hd_ne) 2
+    -- The obstruction `e` must vanish: else `e, w, d` are three orthogonal nonzero
+    -- vectors, impossible in the `2`-dimensional plane.
+    have he0 : e = 0 := by
+      by_contra he_ne
+      have hee : (0 : ℝ) < inner ℝ e e := by
+        rw [real_inner_self_eq_norm_sq]; exact pow_pos (norm_pos_iff.mpr he_ne) 2
+      have hli : LinearIndependent ℝ ![e, w, d] := by
+        rw [Fintype.linearIndependent_iff]
+        intro g hg
+        rw [Fin.sum_univ_three] at hg
+        simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+          Matrix.cons_val_two, Matrix.tail_cons] at hg
+        have hg0 : g 0 = 0 := by
+          have h := congrArg (fun z => (inner ℝ z e : ℝ)) hg
+          simp only [inner_add_left, real_inner_smul_left, inner_zero_left, hwe, hde,
+            mul_zero, add_zero] at h
+          exact (mul_eq_zero.mp h).resolve_right hee.ne'
+        have hg1 : g 1 = 0 := by
+          have h := congrArg (fun z => (inner ℝ z w : ℝ)) hg
+          simp only [inner_add_left, real_inner_smul_left, inner_zero_left, hew, hdw,
+            mul_zero, zero_add, add_zero] at h
+          rw [eww] at h
+          exact (mul_eq_zero.mp h).resolve_right (pow_pos ha 2).ne'
+        have hg2 : g 2 = 0 := by
+          have h := congrArg (fun z => (inner ℝ z d : ℝ)) hg
+          simp only [inner_add_left, real_inner_smul_left, inner_zero_left, hed, hwd,
+            mul_zero, zero_add, add_zero] at h
+          exact (mul_eq_zero.mp h).resolve_right hdd.ne'
+        intro i
+        fin_cases i <;> assumption
+      have hcard := hli.fintype_card_le_finrank
+      rw [finrank_euclideanSpace_fin] at hcard
+      simp only [Fintype.card_fin] at hcard
+      omega
+    -- From `e = 0`: `u + v = w`, so `⟨u,v⟩ = −a²/2` and `‖d‖² = 3a²`.
+    have hsum : u + v = w := sub_eq_zero.mp (by rw [← hedef]; exact he0)
+    have htval : inner ℝ u v = -(a ^ 2) / 2 := by
+      have h : inner ℝ (u + v) (u + v) = a ^ 2 := by rw [hsum, eww]
+      simp only [inner_add_left, inner_add_right, euu, evv] at h
+      rw [real_inner_comm v u] at h; linarith
+    have hd2 : inner ℝ d d = 3 * a ^ 2 := by
+      rw [hddef]
+      simp only [inner_sub_left, inner_sub_right, euu, evv]
+      rw [real_inner_comm v u, htval]; ring
+    have hnd2 : ‖d‖ ^ 2 = 3 * a ^ 2 := by rw [← real_inner_self_eq_norm_sq]; exact hd2
+    have hnd : ‖d‖ = a * Real.sqrt 3 := by
+      rw [← Real.sqrt_sq (norm_nonneg d), hnd2, mul_comm (3 : ℝ) (a ^ 2),
+        Real.sqrt_mul (sq_nonneg a), Real.sqrt_sq ha.le]
+    have hxyd : x - y = d := by rw [hddef, hudef, hvdef]; abel
+    rw [dist_eq_norm, hxyd]; exact hnd
+
 /-! ## Concrete unconditional lower-bound values of `h`
 
 The linear bound `n - 1 ≤ 3 · h n` (`three_mul_h_ge`) already pins several exact

--- a/proofs/Proofs/Erdos98WIP01.lean
+++ b/proofs/Proofs/Erdos98WIP01.lean
@@ -1815,10 +1815,11 @@ theorem two_common_neighbours_dist
   have hew : inner ℝ e w = 0 := by
     rw [hedef]; simp only [inner_sub_left, inner_add_left, euw, evw, eww]; ring
   have hed : inner ℝ e d = 0 := by
+    have hc : inner ℝ v u = inner ℝ u v := real_inner_comm v u
     rw [hedef, hddef]
-    simp only [inner_sub_left, inner_add_left, inner_sub_right, inner_add_right,
+    simp only [inner_sub_left, inner_add_left, inner_sub_right,
       euu, evv, ewu, ewv]
-    rw [real_inner_comm v u]; ring
+    rw [hc]; ring
   have hdw : inner ℝ d w = 0 := by
     rw [hddef]; simp only [inner_sub_left, euw, evw]; ring
   have hwe : inner ℝ w e = 0 := by rw [real_inner_comm]; exact hew
@@ -1869,14 +1870,14 @@ theorem two_common_neighbours_dist
       omega
     -- From `e = 0`: `u + v = w`, so `⟨u,v⟩ = −a²/2` and `‖d‖² = 3a²`.
     have hsum : u + v = w := sub_eq_zero.mp (by rw [← hedef]; exact he0)
+    have hc : inner ℝ v u = inner ℝ u v := real_inner_comm v u
     have htval : inner ℝ u v = -(a ^ 2) / 2 := by
       have h : inner ℝ (u + v) (u + v) = a ^ 2 := by rw [hsum, eww]
       simp only [inner_add_left, inner_add_right, euu, evv] at h
-      rw [real_inner_comm v u] at h; linarith
+      linarith
     have hd2 : inner ℝ d d = 3 * a ^ 2 := by
-      rw [hddef]
-      simp only [inner_sub_left, inner_sub_right, euu, evv]
-      rw [real_inner_comm v u, htval]; ring
+      rw [hddef, inner_sub_left, inner_sub_right, inner_sub_right, euu, evv, hc, htval]
+      ring
     have hnd2 : ‖d‖ ^ 2 = 3 * a ^ 2 := by rw [← real_inner_self_eq_norm_sq]; exact hd2
     have hnd : ‖d‖ = a * Real.sqrt 3 := by
       rw [← Real.sqrt_sq (norm_nonneg d), hnd2, mul_comm (3 : ℝ) (a ^ 2),

--- a/proofs/Proofs/Erdos98WIP01.lean
+++ b/proofs/Proofs/Erdos98WIP01.lean
@@ -1876,8 +1876,9 @@ theorem two_common_neighbours_dist
       simp only [inner_add_left, inner_add_right, euu, evv] at h
       linarith
     have hd2 : inner ℝ d d = 3 * a ^ 2 := by
-      rw [hddef, inner_sub_left, inner_sub_right, inner_sub_right, euu, evv, hc, htval]
-      ring
+      rw [hddef]
+      simp only [inner_sub_left, inner_sub_right, euu, evv]
+      linarith [htval, hc]
     have hnd2 : ‖d‖ ^ 2 = 3 * a ^ 2 := by rw [← real_inner_self_eq_norm_sq]; exact hd2
     have hnd : ‖d‖ = a * Real.sqrt 3 := by
       rw [← Real.sqrt_sq (norm_nonneg d), hnd2, mul_comm (3 : ℝ) (a ^ 2),

--- a/proofs/Proofs/Erdos98WIP01.lean
+++ b/proofs/Proofs/Erdos98WIP01.lean
@@ -1815,7 +1815,7 @@ theorem two_common_neighbours_dist
   have hew : inner ℝ e w = 0 := by
     rw [hedef]; simp only [inner_sub_left, inner_add_left, euw, evw, eww]; ring
   have hed : inner ℝ e d = 0 := by
-    have hc : inner ℝ v u = inner ℝ u v := real_inner_comm v u
+    have hc : inner ℝ v u = inner ℝ u v := real_inner_comm _ _
     rw [hedef, hddef]
     simp only [inner_sub_left, inner_add_left, inner_sub_right,
       euu, evv, ewu, ewv]
@@ -1870,7 +1870,7 @@ theorem two_common_neighbours_dist
       omega
     -- From `e = 0`: `u + v = w`, so `⟨u,v⟩ = −a²/2` and `‖d‖² = 3a²`.
     have hsum : u + v = w := sub_eq_zero.mp (by rw [← hedef]; exact he0)
-    have hc : inner ℝ v u = inner ℝ u v := real_inner_comm v u
+    have hc : inner ℝ v u = inner ℝ u v := real_inner_comm _ _
     have htval : inner ℝ u v = -(a ^ 2) / 2 := by
       have h : inner ℝ (u + v) (u + v) = a ^ 2 := by rw [hsum, eww]
       simp only [inner_add_left, inner_add_right, euu, evv] at h

--- a/research/problems/erdos-98-wip-01/knowledge.md
+++ b/research/problems/erdos-98-wip-01/knowledge.md
@@ -1,5 +1,54 @@
 # Knowledge Base: erdos-98-wip-01
 
+## Session 2026-07-21 (researcher-1) — intersecting-circles rigidity: two common a-neighbours are equal or a√3 apart
+
+**Mode**: REVISIT (continue, RICH). **Outcome**: progress — a new axiom-free planar-rigidity
+lemma that discharges the intersecting-circle distance equations of the `h 5 ≥ 3` degree-`3`
+sub-cases. **docker-built** `Proofs.Erdos98WIP01` OK ("Build completed successfully (8577
+jobs)"; 0 sorry / 0 axiom / no `native_decide`; new proof uses only standard Mathlib inner-
+product + finrank machinery, so foundational axioms only).
+
+The prior session left two concrete geometric residuals for `h 5 ≥ 3`. This session closes
+the **first-named next step**: *"two circles of radius `a` at centre-distance `a` meet at
+points `a√3` apart"*, as reusable `EuclideanSpace ℝ (Fin 2)` algebra.
+
+**Lean result added** (`proofs/Proofs/Erdos98WIP01.lean:1782`):
+
+- **`two_common_neighbours_dist`** (axiom-free): if `dist p q = a` and both `x` and `y` are
+  at distance `a` from `p` and from `q` (with `a > 0`), then `x = y ∨ dist x y = a·√3`. Two
+  circles of radius `a` with centres `a` apart meet in ≤ 2 points, at distance `a√3`.
+
+**Mechanism (rigorous).** Write `u = x−p`, `v = y−p`, `w = q−p`; all have norm `a`, and
+`⟨u,w⟩ = ⟨v,w⟩ = a²/2` (from `‖u−w‖ = ‖x−q‖ = a`, `norm_sub_sq_real`). The vector
+`e = u+v−w` is orthogonal to both `w` and `d = u−v` (direct inner-product expansion). If
+`x ≠ y` then `d ≠ 0`; were `e ≠ 0`, then `e, w, d` would be three **pairwise-orthogonal
+nonzero** vectors, hence linearly independent — impossible in the `2`-dimensional plane
+(`LinearIndependent.fintype_card_le_finrank`: `3 ≤ 2`). So `e = 0`, i.e. `u+v = w`; taking
+norms of `u+v` gives `⟨u,v⟩ = −a²/2`, whence `‖x−y‖² = ‖u−v‖² = 3a²`. Same
+regular-simplex-needs-dimension argument as `no_four_mutually_equidistant`, run one dimension
+lower.
+
+**Reusable Lean notes.** (i) `simp only [inner_sub_left, inner_add_left, …]` canonicalizes
+`⟪u,v⟫` to a fixed argument order (`⟪v,u⟫`), so a follow-up `rw [real_inner_comm .., htval]`
+with LHS `⟪u,v⟫` won't fire — finish with `linarith [htval, hc]` (`hc : ⟪v,u⟫=⟪u,v⟫`).
+(ii) `real_inner_comm`'s explicit args are the *reverse* orientation; use `real_inner_comm _ _`
+driven by the expected type. (iii) explicit `rw [inner_sub_right]` over a `set`-bound
+`u := x−p` unfolds the local def (`⟪u,u⟫ ↦ ⟪u,x⟫−⟪u,p⟫`); prefer `simp only` for the
+expansion, then a linear closer.
+
+**Honest delta.** Did **not** prove `h 5 ≥ 3` (still open). +1 axiom-free reusable geometric
+lemma that *unlocks* the degree-`3` sub-cases (the last-remaining named gap for those cases
+was exactly this circle-intersection algebra). The all-degree-2 (`C₅`) case —
+"equilateral + equidiagonal convex pentagon ⇒ concyclic" — is still open. Axiom count
+unchanged (0). Bounds remain `2 ≤ h 5 ≤ 3`. Phase `ACT`.
+
+**Files modified**: `proofs/Proofs/Erdos98WIP01.lean`,
+`src/data/research/problems/erdos-98-wip-01.json`, this file.
+
+**Next**: use `two_common_neighbours_dist` to finish the degree-`3` sub-case contradictions;
+then the `C₅` concyclicity fact closes `h 5 ≥ 3`.
+
+
 ## Session 2026-07-21 (researcher-1) — h 5 ≥ 3 reduced to pentagon rigidity: 2-distance reduction + degree structure
 
 **Mode**: REVISIT (continue, RICH). **Outcome**: progress — rigorous reduction of the open

--- a/src/data/research/problems/erdos-98-wip-01.json
+++ b/src/data/research/problems/erdos-98-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: h 5 ≥ 3 rigorously reduced to pentagon rigidity; 2-distance reduction + per-vertex degree structure (1–3) proved axiom-free. Bounds remain 2 ≤ h 5 ≤ 3.",
+    "progressSummary": "PROGRESS: h 5 ≥ 3 reduced to pentagon rigidity; 2-distance reduction + per-vertex degree structure (1–3) + intersecting-circles rigidity (two common a-neighbours are equal or a√3 apart, two_common_neighbours_dist) all proved axiom-free. Residual: degree-3 sub-case closure (now unlocked) + all-degree-2 equilateral-equidiagonal-pentagon-concyclic. Bounds remain 2 ≤ h 5 ≤ 3.",
     "builtItems": [
       "InGeneralPosition.injective in Erdos98WIP01.lean",
       "numDistinctDistances_le_offDiag (≤ n·(n−1)) in Erdos98WIP01.lean",
@@ -82,7 +82,8 @@
       "three_le_h_of_eight_le (Erdos98WIP01.lean): n ≥ 8 → 3 ≤ h n, from three_mul_h_ge.",
       "four_le_h_of_eleven_le (Erdos98WIP01.lean): n ≥ 11 → 4 ≤ h n, from three_mul_h_ge.",
       "exists_two_distances_of_numDistinct_le_two (Erdos98WIP01.lean): injective PointConfig with numDistinctDistances ≤ 2 is a 2-distance set — ∃ a b>0 covering every pairwise distance. Axiom-free, all n.",
-      "two_distance_near_degree_bounds (Erdos98WIP01.lean): general-position 2-distance PointConfig 5 has 1 ≤ (short-distance degree) ≤ 3 at every vertex. Axiom-free."
+      "two_distance_near_degree_bounds (Erdos98WIP01.lean): general-position 2-distance PointConfig 5 has 1 ≤ (short-distance degree) ≤ 3 at every vertex. Axiom-free.",
+      "two_common_neighbours_dist (Erdos98WIP01.lean:1782, axiom-free, docker-built 8577 jobs): in EuclideanSpace ℝ (Fin 2), dist p q = a ∧ dist x p = dist x q = dist y p = dist y q = a ∧ a>0 → x = y ∨ dist x y = a·√3. Discharges the intersecting-circle distance equations of the h 5 ≥ 3 degree-3 sub-cases."
     ],
     "insights": [
       "Every positive pairwise distance comes from an off-diagonal ordered pair (dist>0 ⟹ points distinct ⟹ indices distinct), giving the clean upper bound numDistinctDistances P ≤ n·(n−1) via Finset.offDiag_card — the trivial ceiling of the h(n) envelope.",
@@ -116,15 +117,18 @@
       "Degree structure of a general-position 5-point 2-distance set (distances a<b): by card_fiber_dist_le_three each point has a-degree and b-degree in {1,2,3}; the a-graph is either 2-regular (C5, pentagon-type) or has a degree-3 vertex.",
       "Four mutually equidistant points cannot lie in the plane (regular tetrahedron needs dim 3): the 3 edge vectors from one vertex have Gram matrix r²·[[1,½,½],[½,1,½],[½,½,1]] (det r⁶/2 ≠ 0), hence linearly independent, contradicting finrank(EuclideanSpace ℝ (Fin 2))=2.",
       "h 5 ≥ 3 reduces exactly to refuting a general-position 2-distance PointConfig 5. The pigeonhole/no-4-concyclic frame stalls at C₅ (the pentagon pattern): the short-distance graph of any counterexample has min-degree ≥1, max-degree ≤3, and no K₄ in graph or complement — constraints C₅ satisfies. The sole residual is geometric (pentagon rigidity: equilateral+equidiagonal pentagon is regular, hence concyclic), NOT combinatorial.",
-      "Per-vertex degree structure of a general-position 2-distance 5-set: each vertex has exactly 1–3 short-distance neighbours. Both the a-circle and b-circle around a vertex hold ≤3 of the other 4 points (card_fiber_dist_le_three from no-4-concyclic), and the 4 others split between them, forcing 4−3 ≤ deg_a ≤ 3."
+      "Per-vertex degree structure of a general-position 2-distance 5-set: each vertex has exactly 1–3 short-distance neighbours. Both the a-circle and b-circle around a vertex hold ≤3 of the other 4 points (card_fiber_dist_le_three from no-4-concyclic), and the 4 others split between them, forcing 4−3 ≤ deg_a ≤ 3.",
+      "Intersecting-circles rigidity (two_common_neighbours_dist): two points each at distance a from both endpoints of an a-length segment are equal or exactly a√3 apart — the two circle intersections are the far vertices of a two-equilateral-triangle rhombus. This is the exact metric fact behind the degree-3 sub-case circle equations (|YZ| = a√3).",
+      "Clean planar-rigidity mechanism: with u=x−p, v=y−p, w=q−p (all norm a, ⟨u,w⟩=⟨v,w⟩=a²/2), the vector e=u+v−w is orthogonal to both w and d=u−v; if x≠y then d≠0, and e≠0 would make e,w,d three pairwise-orthogonal nonzero vectors (linearly independent) — impossible in dim 2. So e=0, i.e. u+v=w, forcing ⟨u,v⟩=−a²/2 and ‖x−y‖²=3a². Same regular-simplex-needs-dimension argument as no_four_mutually_equidistant, run one dimension lower.",
+      "Lean gotcha: simp only [inner_sub_left, inner_add_left, ...] canonicalizes ⟪u,v⟫ to a fixed argument order (⟪v,u⟫ here), so a follow-up rw [real_inner_comm .., htval] whose LHS is ⟪u,v⟫ fails to fire — finish such goals with linarith [htval, hc] (hc : ⟪v,u⟫=⟪u,v⟫) instead of orientation-sensitive rw. Also real_inner_comms explicit args are the reverse orientation; use real_inner_comm _ _ driven by the expected type. And explicit rw [inner_sub_right] over `set`-bound u:=x−p unfolds the local def (⟪u,u⟫→⟪u,x⟫−⟪u,p⟫); prefer simp only for the expansion."
     ],
     "mathlibGaps": [
       "Classification of planar 2-distance sets (max 5 points = regular pentagon, unique up to similarity) is absent from Mathlib — needed for h 5 ≥ 3."
     ],
     "nextSteps": [
-      "Close h 5 ≥ 3: prove pentagon rigidity — a general-position 2-distance PointConfig 5 whose short-distance graph is C₅ is the regular pentagon, whose 5 vertices are concyclic, contradicting NoFourConcyclic. Needs coordinate geometry (equilateral+equidiagonal ⇒ regular).",
-      "Alternatively enumerate the short-distance graph via two_distance_near_degree_bounds + no_four_equidistant_indices (min-deg≥1, max-deg≤3, K₄-free graph and complement on 5 vertices ⇒ C₅), then apply pentagon rigidity to the single surviving case.",
-      "Abstract the Gram/dimension argument: equilateral set in ℝ^d has ≤ d+1 points (generalizes no_four_mutually_equidistant via ∑-of-inner-products, no determinant needed)."
+      "Apply two_common_neighbours_dist to close the degree-3 sub-cases of h 5 ≥ 3: a degree-3 vertex p with a-neighbours X,Y,Z where some pair (e.g. XY) is at distance b — the two b-far points among {X,Y,Z} are common a-neighbours of p and of each others partner, so their separation is forced to a√3, and combining with the two-distance constraint {a,b} pins b/a and yields a concyclic/collinear contradiction.",
+      "Remaining all-degree-2 (C₅) case: prove an equilateral + equidiagonal convex pentagon is concyclic (regular), contradicting NoFourConcyclic. This is the last geometric fact for h 5 ≥ 3.",
+      "Consider a reusable ‖x−y‖ formula for the two intersection points as a function of a and the centre distance (generalize a from the equal-radius equal-centre-distance case), to handle mixed a/b degree-3 configurations."
     ],
     "markdown": "# Knowledge Base: erdos-98-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Adds one axiom-free planar-rigidity lemma to `Proofs/Erdos98WIP01.lean` on the critical path to the open lower bound **`h 5 ≥ 3`** (no general-position 5-point set is a 2-distance set).

**`two_common_neighbours_dist`** — in `EuclideanSpace ℝ (Fin 2)`: if `dist p q = a` and both `x` and `y` are at distance `a` from `p` and from `q` (with `a > 0`), then `x = y ∨ dist x y = a * √3`. Two circles of radius `a` whose centres are `a` apart meet in at most two points, and those two points are exactly `a√3` apart (the far vertices of the two-equilateral-triangle rhombus).

This is the concrete "next step" named by the previous session: it discharges the intersecting-circle distance equations arising in the **degree-3 sub-cases** of the `h 5 ≥ 3` classification.

## Mechanism

Write `u = x−p`, `v = y−p`, `w = q−p` (all of norm `a`, with `⟨u,w⟩ = ⟨v,w⟩ = a²/2`). The vector `e = u+v−w` is orthogonal to both `w` and `d = u−v`. If `x ≠ y` then `d ≠ 0`; were `e ≠ 0`, the three pairwise-orthogonal nonzero vectors `e, w, d` would be linearly independent — impossible in the 2-dimensional plane (`LinearIndependent.fintype_card_le_finrank`: `3 ≤ 2`). Hence `e = 0`, i.e. `u+v = w`, forcing `⟨u,v⟩ = −a²/2` and `‖x−y‖² = 3a²`. This is the same "regular simplex needs its dimension" argument as the file's `no_four_mutually_equidistant`, run one dimension lower.

## Verification

- **docker-built** `Proofs.Erdos98WIP01`: "Build completed successfully (8577 jobs)".
- 0 sorries, 0 `axiom` declarations, no `native_decide` — foundational axioms only (`propext` / `Classical.choice` / `Quot.sound`).

## Honest status

Does **not** prove `h 5 ≥ 3` (still open). This is `+1` reusable geometric lemma that unlocks the degree-3 sub-cases; the all-degree-2 (`C₅`) case — "equilateral + equidiagonal convex pentagon ⇒ concyclic" — remains open. Bounds unchanged: `2 ≤ h 5 ≤ 3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
