### PR TITLE
audit: borsuk-ulam-oq002 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30632,6 +30632,12 @@
       "lastAudited": "2026-07-21T09:17:07Z",
       "result": "issues-found",
       "issues": []
+    },
+    "borsuk-ulam-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T09:20:24Z",
+      "result": "issues-found",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Audited borsuk-ulam-oq002. Honestly axiomatized overall, but filed LOW issue #40328: (1) axiomCount:1 omits inherited buDim/buDim_mono axioms (sibling oq001 counts them transitively); (2) vacuous True-stub crt_axiom_vs_formula_conjecture inflates theoremCount:10.