### PR TITLE
Enrich 4 entries: cover uncovered tail declarations + fix erdos-897 section overlap (1..EOF)

### DIFF
--- a/src/data/proofs/erdos-391/meta.json
+++ b/src/data/proofs/erdos-391/meta.json
@@ -151,7 +151,7 @@
       "title": "Summary",
       "summary": "erdos_391_summary theorem assembling all four main results",
       "startLine": 191,
-      "endLine": 227,
+      "endLine": 260,
       "mathContext": "Verified: erdos_391_summary theorem assembling all four main results"
     }
   ],

--- a/src/data/proofs/erdos-897/meta.json
+++ b/src/data/proofs/erdos-897/meta.json
@@ -110,7 +110,7 @@
       "id": "restricted",
       "title": "Restricted Variants",
       "startLine": 93,
-      "endLine": 124,
+      "endLine": 106,
       "summary": "Definitions of strongly/completely additive and corresponding variants."
     },
     {
@@ -131,7 +131,7 @@
       "id": "reduction",
       "title": "Reduction for Completely Additive Functions",
       "startLine": 175,
-      "endLine": 210,
+      "endLine": 243,
       "summary": "Reduction theorem: for completely additive f, the prime-power hypothesis is equivalent to f(p)/log p being unbounded over primes."
     }
   ],

--- a/src/data/proofs/morleys-theorem-oq-01/meta.json
+++ b/src/data/proofs/morleys-theorem-oq-01/meta.json
@@ -104,9 +104,9 @@
     {
       "id": "trig-identities",
       "title": "Trig Identities for Computation",
-      "summary": "Product-to-sum, cos(α₃+β₃) = cos(π/3-γ₃)",
+      "summary": "Product-to-sum, cos(α₃+β₃) = cos(π/3-γ₃), and cos_pi_third_sub (the cos(π/3 − θ) expansion used in the angle computation).",
       "startLine": 232,
-      "endLine": 260
+      "endLine": 293
     }
   ],
   "conclusion": {

--- a/src/data/proofs/picks-theorem-oq-02/meta.json
+++ b/src/data/proofs/picks-theorem-oq-02/meta.json
@@ -96,11 +96,19 @@
     },
     {
       "id": "applications",
-      "title": "Special Cases and Pick's Formula",
+      "title": "Special Cases and Concrete Examples",
       "startLine": 187,
-      "endLine": 215,
-      "summary": "segment_coprime (2 endpoints), segment_diagonal (a+1 points), three concrete examples, pick_edge_contribution and interior_segment_count for Pick's theorem boundary formula.",
-      "mathContext": "$B = \\sum_i \\gcd(|\\Delta x_i|, |\\Delta y_i|)$, with each edge contributing $\\text{card} - 1 = \\gcd(a,b)$."
+      "endLine": 231,
+      "summary": "Membership characterization plus special cases: segment_coprime (2 endpoints), segment_diagonal (a+1 points), and three concrete lattice-point counts (segment_4_6 = 3, segment_3_5 = 2, segment_6_9 = 4).",
+      "mathContext": "$|\\text{segmentPoints}(a,b)| = \\gcd(a,b) + 1$; concrete evaluations verify the count."
+    },
+    {
+      "id": "pick-boundary-formula",
+      "title": "Part VIII: Pick's Boundary Formula",
+      "startLine": 232,
+      "endLine": 248,
+      "summary": "pick_edge_contribution (each edge contributes gcd(|Δx|,|Δy|) to the boundary count) and interior_segment_count (interior lattice points on a segment number gcd(a,b) − 1), assembling the boundary term B of Pick's theorem.",
+      "mathContext": "$B = \\sum_i \\gcd(|\\Delta x_i|, |\\Delta y_i|)$, with each edge contributing $\\text{card} - 1 = \\gcd(a,b)$ and $\\gcd(a,b) - 1$ interior points."
     }
   ],
   "references": [


### PR DESCRIPTION
Four pure `meta.json` section-coverage fixes (no `status`/`badge`/`axiomCount` changes). Each entry's final section stopped short of tail declarations its own summary already describes; extended (or split at a real `Part` banner) to cover 1..EOF.

| Entry | Fix |
|-------|-----|
| erdos-391 | Summary `endLine` 227→260 — covers `erdos_391_summary` (assembles all four main results). |
| erdos-897 | Reduction section 210→243 — covers `completelyAdditive_unboundedOnPrimePowers_iff`. Also fixed a **pre-existing** section overlap (Restricted-Variants 124→106, which collided with Classical-Examples @107; the Lean banner starts at 108). |
| picks-theorem-oq-02 | Split the over-broad "Special Cases and Pick's Formula" into **Special Cases and Concrete Examples** (187–231) + **Part VIII: Pick's Boundary Formula** (232–248) at the actual `PART VIII` banner; covers `pick_edge_contribution` + `interior_segment_count`. |
| morleys-theorem-oq-01 | Trig-Identities section 260→293 — covers `cos_pi_third_sub` (the cos(π/3 − θ) expansion). |

Each verified `maxEnd === node-split-length` (gap 0) with no section overlaps before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
