### PR TITLE
Fix: borsuk-ulam-oq002 integrity — transitive axiomCount 1→3 + drop vacuous True-stub (#40328)

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ02OQ01OQ01OQ02OQ03.lean
+++ b/proofs/Proofs/BorsukUlamOQ02OQ01OQ01OQ02OQ03.lean
@@ -173,18 +173,16 @@ theorem buDim_fifteen_eq_max (d : ℕ) :
 -- PART 5: Relationship to Full Formula Conjecture
 -- ============================================================
 
-/-- The CRT axiom for semiprimes implies the formula conjecture for semiprimes,
-    which is a STRICT weakening of the full `buDim_le_formula`.
+/- The CRT axiom for semiprimes implies the formula conjecture for semiprimes,
+   which is a STRICT weakening of the full `buDim_le_formula`.
 
-    The full formula conjecture covers:
-    - Prime powers p^k (k ≥ 2): NOT covered by CRT axiom
-    - Semiprimes pq: covered by CRT axiom
-    - General composite numbers: NOT covered by CRT axiom
+   The full formula conjecture covers:
+   - Prime powers p^k (k ≥ 2): NOT covered by CRT axiom
+   - Semiprimes pq: covered by CRT axiom
+   - General composite numbers: NOT covered by CRT axiom
 
-    So: CRT axiom ⊊ formula conjecture (strictly weaker for n with p² | n).
-    The CRT axiom suffices to prove everything in the semiprime case. -/
-theorem crt_axiom_vs_formula_conjecture :
-    True := trivial
+   So: CRT axiom ⊊ formula conjecture (strictly weaker for n with p² | n).
+   The CRT axiom suffices to prove everything in the semiprime case. -/
 
 /-
 ## Summary

--- a/src/data/proofs/borsuk-ulam-oq002/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq002/meta.json
@@ -20,10 +20,10 @@
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-05-04",
-    "axiomCount": 1,
-    "assumptions": "buDim_crt_semiprime: For distinct primes p, q, buDim(pq, d) ≤ max(buDim(p,d), buDim(q,d)). Motivated by the CRT isomorphism ℤ/pqℤ ≅ ℤ/pℤ × ℤ/qℤ for distinct primes. Estimated proof: ~200 lines using Smith theory for cyclic prime-order groups.",
-    "lineCount": 212,
-    "theoremCount": 10,
+    "axiomCount": 3,
+    "assumptions": "3 axioms (transitive). New local axiom: buDim_crt_semiprime — for distinct primes p, q, buDim(pq, d) ≤ max(buDim(p,d), buDim(q,d)); motivated by the CRT isomorphism ℤ/pqℤ ≅ ℤ/pℤ × ℤ/qℤ; estimated proof ~200 lines using Smith theory for cyclic prime-order groups. Inherited from the parent buDim framework (BorsukUlamOQ02OQ01.lean): buDim (axiom defining the BU dimension function, used throughout) and buDim_mono (subgroup monotonicity, used in the lower-bound theorems). #print axioms on the main results therefore lists these 3 math axioms. The full-formula axiom buDim_le_formula is NOT used (this entry replaces it with the weaker buDim_crt_semiprime). Note: leanFile.axiomCount counts only the single local axiom declaration.",
+    "lineCount": 210,
+    "theoremCount": 9,
     "definitionCount": 0,
     "additionalFiles": [
       "Proofs/BorsukUlamOQ02OQ01OQ01OQ02OQ03OQ01.lean"
@@ -104,12 +104,12 @@
       "id": "part5-comparison-and-summary",
       "title": "Part 5: CRT vs Full Formula Conjecture, Summary",
       "startLine": 172,
-      "endLine": 212,
-      "summary": "Discussion of the strict inclusion CRT axiom ⊊ formula conjecture (CRT fails for prime powers p^k). A trivial theorem `crt_axiom_vs_formula_conjecture` serves as a Lean anchor. The closing docstring summarizes all 10 theorems, 1 axiom, and 0 sorries, and explains why the CRT axiom is the minimal assumption for the semiprime case."
+      "endLine": 210,
+      "summary": "Discussion of the strict inclusion CRT axiom ⊊ formula conjecture (CRT fails for prime powers p^k). The closing docstring summarizes all 9 theorems, the local CRT axiom, and 0 sorries, and explains why the CRT axiom is the minimal assumption for the semiprime case."
     }
   ],
   "conclusion": {
-    "summary": "This file establishes $\\text{buDim}(pq, d) = \\max(\\text{buDim}(p,d), \\text{buDim}(q,d))$ for distinct primes $p, q$ using one axiom (CRT compatibility) and zero sorries. The lower bound is proved axiom-free from monotonicity. The CRT compatibility axiom is the minimal new assumption for the semiprime case, strictly weaker than the full formula conjecture. Ten theorems cover lower bounds, the equality, the formula conjecture for semiprimes, non-existence of exotic representations, and concrete cases for $n = 6, 10, 15$.",
+    "summary": "This file establishes $\\text{buDim}(pq, d) = \\max(\\text{buDim}(p,d), \\text{buDim}(q,d))$ for distinct primes $p, q$ using one axiom (CRT compatibility) and zero sorries. The lower bound is proved axiom-free from monotonicity. The CRT compatibility axiom is the minimal new assumption for the semiprime case, strictly weaker than the full formula conjecture. Nine theorems cover lower bounds, the equality, the formula conjecture for semiprimes, non-existence of exotic representations, and concrete cases for $n = 6, 10, 15$.",
     "implications": "The result clarifies the axiomatic structure of the BU dimension formula for cyclic groups. For the semiprime case, the CRT decomposition is the right tool — not the full machinery of Smith theory. This suggests a hierarchical proof strategy: prove the CRT axiom for semiprimes first, handle prime powers via Smith theory separately, and then combine for general squarefree $n$. The absence of exotic representations for $\\mathbb{Z}/pq\\mathbb{Z}$ suggests that if exotic behavior exists at all in the BU dimension framework, it must arise from prime power cyclic groups rather than from products of distinct primes.",
     "openQuestions": [
       "Can `buDim_crt_semiprime` be proved in Lean using Smith theory for prime-order groups? The proof would use: (1) the CRT isomorphism $\\mathbb{Z}/pq\\mathbb{Z} \\cong \\mathbb{Z}/p\\mathbb{Z} \\times \\mathbb{Z}/q\\mathbb{Z}$, (2) factorization of equivariant maps through the product, (3) BU dimension of a product action bounded by max of factor dimensions. Estimated effort: ~200 lines.",
@@ -121,8 +121,8 @@
     "path": "Proofs/BorsukUlamOQ02OQ01OQ01OQ02OQ03.lean",
     "axiomCount": 1,
     "sorries": 0,
-    "lineCount": 212,
-    "theoremCount": 10,
+    "lineCount": 210,
+    "theoremCount": 9,
     "definitionCount": 0,
     "additionalFiles": [
       "Proofs/BorsukUlamOQ02OQ01OQ01OQ02OQ03OQ01.lean"


### PR DESCRIPTION
Fixes the two integrity discrepancies reported in #40328 for **borsuk-ulam-oq002**. The entry was already honest (`badge: axiom` / `status: axiomatized`); only the counts/disclosure were imprecise.

## 1. axiomCount undercounted inherited (transitive) axioms
`meta.axiomCount` was `1`, disclosing only the local `buDim_crt_semiprime`. The main results also transitively depend on genuine parent `axiom` declarations from `BorsukUlamOQ02OQ01.lean`:
- `buDim` (the axiomatized BU dimension function, used throughout)
- `buDim_mono` (used in the lower-bound theorems)

`#print axioms` on the main results therefore lists 3 math axioms. This mirrors the sibling **oq001**, which already counts inherited buDim-framework axioms transitively.

- `meta.axiomCount`: 1 → **3**
- `assumptions`: rewritten to enumerate the 3 transitive axioms (local `buDim_crt_semiprime` + inherited `buDim`, `buDim_mono`), noting the full-formula axiom `buDim_le_formula` is NOT used, and that `leanFile.axiomCount` continues to count only the single local literal `axiom` declaration.

## 2. Vacuous True-stub inflated theoremCount
`theorem crt_axiom_vs_formula_conjecture : True := trivial` proved nothing (its content lived in the docstring) yet was one of the `theoremCount: 10`.

- Removed the stub; its prose is preserved as a plain `/- ... -/` comment (the preceding `/--` doc-comment converted to `/-`).
- `theoremCount`: 10 → **9** (meta + leanFile), `lineCount`: 212 → **210**, last section `endLine` 212 → 210, and prose "10/Ten theorems" → "9/Nine theorems".

## Verification
- `grep -cE '^(theorem|lemma) '` → **9** (was 10); `grep -c '^axiom '` → **1** local; `wc -l` → **210**.
- meta.json parses (`python3 json.load`).
- Lean change is a deletion of an unreferenced `theorem _ : True := trivial` plus a doc-comment→comment conversion — cannot affect compilation of a previously-compiling file (no downstream references; no parent oleans present locally to rebuild).

Closes #40328
