### PR TITLE
audit: borsuk-ulam-oq005 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30650,6 +30650,12 @@
       "lastAudited": "2026-07-21T09:23:50Z",
       "result": "clean",
       "issues": []
+    },
+    "borsuk-ulam-oq005": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T09:26:32Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Audited borsuk-ulam-oq005 CLEAN. 123 real theorems / 2 defs / 0 sorry / 0 native_decide / 0 stubs. 1 local axiom (symBUDim_eq_largestPrime, disclosed conjecture over genuine largestPrimeBelow def); all 6 inherited parent axioms fully enumerated in assumptions with counting convention stated. Lower bound proved, upper bound honestly open, n=2 settled axiom-free (consistency check). Contrast oq002 #40328 which omitted its inherited-axiom disclosure.