### PR TITLE
Enrich 2 entries: re-anchor premature tail sections to EOF (sperner-ndim, erdos-741)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30650,6 +30650,12 @@
       "lastAudited": "2026-07-21T09:23:50Z",
       "result": "clean",
       "issues": []
+    },
+    "borsuk-ulam-oq005": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T09:26:32Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/erdos-741/meta.json
+++ b/src/data/proofs/erdos-741/meta.json
@@ -182,15 +182,15 @@
       "id": "connections",
       "title": "Connections Between Parts",
       "startLine": 323,
-      "endLine": 347,
-      "summary": "PROVES `part2_gives_non_syndetic` and `part2_contradicts_part1_for_basis` — relating the two conjectures (the basis form would force a non-syndetic complement, in tension with the density form).",
+      "endLine": 378,
+      "summary": "`basis_has_pos_density_sumset`: a basis of order 2 has a positive-density sumset (via `cofinite_density_one`). Then PROVES `part2_gives_non_syndetic` and `part2_contradicts_part1_for_basis` — relating the two conjectures (the basis form would force a non-syndetic complement, in tension with the density form).",
       "mathContext": "The basis conjecture implies a non-syndetic complement, linking the two forms."
     },
     {
       "id": "status",
       "title": "Problem Status",
-      "startLine": 348,
-      "endLine": 351,
+      "startLine": 379,
+      "endLine": 383,
       "summary": "Defines `erdos_741_status = \"OPEN\"` — both conjectures remain unresolved.",
       "mathContext": "Status: OPEN."
     }

--- a/src/data/proofs/sperner-ndim-mathlib-oq-01/meta.json
+++ b/src/data/proofs/sperner-ndim-mathlib-oq-01/meta.json
@@ -148,29 +148,29 @@
       "id": "freudenthal-cellcomplex",
       "title": "Part II.D: freudAdj, prefixSet_inj, and freudenthalCellComplex Assembly",
       "startLine": 304,
-      "endLine": 366,
+      "endLine": 401,
       "summary": "freudAdj: returns some(swapAdj l, k) when 0 < k < n, else none — the 'optional adjacency' that encodes the cube's geometric boundary. prefixSet_inj: prefix sets are injective in k by cardinality (from prefixSet_card_eq). freudenthalCellComplex: assembles the eight CellComplex fields — Simplex (FreudSimplex), decidableEq (inferInstance), fintype (freud_simplex_fintype), vertices (prefix sets), vertices_injective (prefixSet_inj), adj (freudAdj), adj_symm (swapAdj_invol), adj_vertices (swapAdj_prefixSet_eq), adj_ne (swapAdj_ne_self).",
       "mathContext": "The structure-assembly pattern: each field is a routine lemma, an instance, or `inferInstance`. Subtype.ext bridges FreudSimplex equality through the underlying list. With all helper lemmas proved, the assembly is purely mechanical wiring."
     },
     {
       "id": "freudenthal-sperner",
       "title": "Part II.E: freudenthal_sperner (Main Theorem)",
-      "startLine": 368,
-      "endLine": 373,
+      "startLine": 402,
+      "endLine": 409,
       "summary": "freudenthal_sperner: Sperner's lemma for the Freudenthal triangulation of [0,1]^n. One-line proof: apply SpernerAbstract.sperner to freudenthalCellComplex.",
       "mathContext": "**Sperner on the n-cube**: the combinatorial heart of Brouwer's fixed-point theorem (via KKM), Borsuk–Ulam (via signed Sperner / Tucker), and Su's envy-free cake-cutting algorithm."
     },
     {
       "id": "namespace-end",
       "title": "Namespace End",
-      "startLine": 375,
-      "endLine": 377,
+      "startLine": 410,
+      "endLine": 413,
       "summary": "Closes the FreudenthalInstance section and SpernerConcrete namespace.",
-      "mathContext": "14 theorems, 7 definitions, 0 axioms, 0 sorries, 377 lines — answers OQ-01 with two concrete CellComplex instances, all originally-axiomatized facts now proved."
+      "mathContext": "14 theorems, 7 definitions, 0 axioms, 0 sorries, 413 lines — answers OQ-01 with two concrete CellComplex instances, all originally-axiomatized facts now proved."
     }
   ],
   "conclusion": {
-    "summary": "Closes OQ-01 from `sperner-ndim-mathlib` with two concrete `CellComplex` instances and zero remaining axioms. **Part I (bridge)**: `toAbstractCellComplex` projects every existing `SpernerTriangulation` to a `CellComplex`, with abstract and concrete predicates `rfl`-equal, so `SpernerAbstract.sperner` applies directly. **Part II (Freudenthal)**: yields `freudenthalCellComplex n : CellComplex (Finset (Fin n)) n` with permutation-list simplices and prefix-set vertices. `freudenthal_sperner` is a one-line corollary. 14 theorems, 7 definitions, 0 axioms, 0 sorries, 377 lines — all four originally-axiomatized swapAdj facts are now proved as private theorems, three of them via a single `List.Perm` lemma (`swapAdj_perm`), and the Fintype instance via a `listToPerm`/`permList` round-trip with `Equiv.Perm (Fin n)`.",
+    "summary": "Closes OQ-01 from `sperner-ndim-mathlib` with two concrete `CellComplex` instances and zero remaining axioms. **Part I (bridge)**: `toAbstractCellComplex` projects every existing `SpernerTriangulation` to a `CellComplex`, with abstract and concrete predicates `rfl`-equal, so `SpernerAbstract.sperner` applies directly. **Part II (Freudenthal)**: yields `freudenthalCellComplex n : CellComplex (Finset (Fin n)) n` with permutation-list simplices and prefix-set vertices. `freudenthal_sperner` is a one-line corollary. 14 theorems, 7 definitions, 0 axioms, 0 sorries, 413 lines — all four originally-axiomatized swapAdj facts are now proved as private theorems, three of them via a single `List.Perm` lemma (`swapAdj_perm`), and the Fintype instance via a `listToPerm`/`permList` round-trip with `Equiv.Perm (Fin n)`.",
     "implications": "**The Freudenthal triangulation is the workhorse mesh of simplicial fixed-point algorithms** (Scarf 1967, Eaves 1972, Merrill 1972, van der Laan–Talman 1979) — the entire computational-economics literature on Walrasian-equilibrium computation, market-clearing, and KKT-system solving uses Freudenthal triangulations or close variants. Formalizing Sperner's lemma at this abstraction level is therefore the **correct prerequisite** for any verified Brouwer / Kakutani fixed-point algorithm, KKM-based existence proof for Nash equilibria, or Su-style envy-free fair-division algorithm. The bridge instance also gives a clean refactor path for the existing `SpernerNDim` infrastructure: future theorems can target the abstract `CellComplex` once and apply to every concrete triangulation. **Pedagogically**, the file demonstrates a useful **two-instance pattern** for closing 'is this abstraction non-vacuous' open questions: pair a *trivial* bridge instance (showing the abstraction subsumes existing structures) with a *substantive new* instance (showing the abstraction extends beyond them). Both are needed: the bridge proves no expressive power is lost, the new instance proves new expressive power is gained.",
     "openQuestions": [
       "**Closed.** The four `swapAdj` axioms (`swapAdj_nodup`, `swapAdj_prefixSet_eq`, `swapAdj_ne_self`, `freud_simplex_fintype`) are now proved as private theorems via `swapAdj_perm` + `Nodup.getElem_inj_iff` + a `listToPerm`/`permList` round-trip. Total cost: ~136 added lines (file 241 → 377), much less than the 400+ originally projected because the `List.Perm` factoring discharges three of the four axioms from one shared lemma.",


### PR DESCRIPTION
Enrichment pass — re-anchor two drifted `sections` arrays so each covers its Lean file to EOF. Section summaries were already accurate; anchors had drifted as the files grew. No prose/status/axiom claims changed.

### sperner-ndim-mathlib-oq-01 (`SpernerNDimMathlibOQ01.lean`, 413 lines)
The `namespace-end` section was anchored at 375–377, but the file's centerpiece sat past it: the `freudenthalCellComplex` def (367–401, the "Assembly" its own section title names) and the main theorem `freudenthal_sperner` (403–409). Also `freudenthal-sperner` was mis-anchored to 368–373, landing inside the middle of the `freudenthalCellComplex` def. Fixed: Part II.D → 304–401, Part II.E (freudenthal_sperner) → 402–409, namespace-end → 410–413. Corrected a stale "377 lines" → "413 lines" in `namespace-end.mathContext` and `conclusion.summary`.

### erdos-741 (`Erdos741Problem.lean`, 383 lines)
`status` was mis-anchored to 348–351 — inside the body of `basis_has_pos_density_sumset` — while the real "## Problem Status" banner and `erdos_741_status` def are at 379–383. The two connection theorems `part2_gives_non_syndetic` (360) and `part2_contradicts_part1_for_basis` (372), already named in the `connections` summary, were uncovered. Fixed: connections → 323–378 (also names `basis_has_pos_density_sumset`), status → 379–383.

Both verified: sections now cover 1..EOF (gap=1 trailing newline). JSON validated via parse. (erdos-897 was in this batch but is already enriched on `main`, so dropped.)
