### PR TITLE
Enrich 5 entries: re-anchor drifted/undercovered sections to cover uncovered tails (1..EOF)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq005/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq005/meta.json
@@ -113,6 +113,13 @@
       "startLine": 146,
       "endLine": 158,
       "mathContext": "$\\forall a,b > 0: \\min(a,b) \\le \\text{HM}(a,b) \\le \\text{GM}(a,b) \\le \\text{AM}(a,b) \\le \\text{QM}(a,b) \\le \\max(a,b)$. The 5-link power mean chain in full generality for two positive reals."
+    },
+    {
+      "id": "automation-assessment",
+      "title": "Automation Assessment",
+      "startLine": 160,
+      "endLine": 187,
+      "summary": "Tabular comparison of the tactic scripts in this file against the parent proof for all five mean inequalities. Documents that for HM ≤ GM, GM ≤ AM, and AM ≤ QM the ring-normalizes-to-a-square then positivity approach removes every manually supplied sq_nonneg witness the parent needed, while min ≤ HM and QM ≤ max (case splits and linear factors rather than pure squares) use structured mul_nonneg factor bounds; concludes the core chain HM ≤ GM ≤ AM ≤ QM is fully hint-free."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/divisibility-by-3-oq-03/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-03/meta.json
@@ -91,9 +91,16 @@
       "id": "examples",
       "title": "§ 5. Computational Examples",
       "startLine": 227,
-      "endLine": 244,
+      "endLine": 247,
       "summary": "Five norm_num examples verifying the formula: dr(123)=6, dr(9999)=9, dr(1)=1, dr(10)=1, dr(18)=9.",
       "mathContext": "All proved by `unfold digitalRootFormula; norm_num` — the closed-form definition unfolds to arithmetic that `norm_num` verifies directly. These examples test boundary cases: dr(9999)=9 (multiple of 9), dr(10)=1 (crossing decade), dr(18)=9 (two-digit multiple of 9)."
+    },
+    {
+      "id": "summary-api",
+      "title": "§ 6. Summary and Public API",
+      "startLine": 249,
+      "endLine": 273,
+      "summary": "Docstring summary of the O(1) digital-root construction (13 proved theorems: digitSum_mod9, digitalRoot range/zero/single, congruence n ≡ dr(n) (mod 9), idempotence, div9/div3 characterizations, additive and multiplicative homomorphism laws, five concrete examples) and the resolution of the former decreasing_by sorry via Nat.sum_digits_lt, followed by #check exports of the public API (digitalRootFormula, digitalRoot_idempotent, digitalRoot_div3)."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-327/meta.json
+++ b/src/data/proofs/erdos-327/meta.json
@@ -100,8 +100,8 @@
     {
       "id": "variant",
       "title": "Factor-of-2 Variant",
-      "startLine": 55,
-      "endLine": 70,
+      "startLine": 56,
+      "endLine": 69,
       "summary": "Defines `ErdosProblem327_variant` conjecturing $o(N)$ size under `SumNotDvdTwoProd`.  The unit fraction equivalence `sumDvdProd_iff_unitFraction` linking $(a+b) \\mid ab$ to $1/a + 1/b = 1/c$ over $\\mathbb{Q}$ is fully proved earlier in the file.",
       "mathContext": "$\\text{SumNotDvdTwoProd}(A) \\iff \\forall a, b \\in A,\\, a \\ne b \\implies (a+b) \\nmid (2ab)$. Conjecture: $\\forall \\varepsilon > 0,\\, |A| < \\varepsilon N$ for large $N$, i.e., $|A| = o(N)$."
     },
@@ -117,7 +117,7 @@
       "id": "structural",
       "title": "Coprime and GCD Characterizations",
       "startLine": 111,
-      "endLine": 168,
+      "endLine": 198,
       "summary": "Proves `coprime_sumNotDvdProd` (coprime pairs avoid the condition, via Euclid's lemma), `sumNotDvdProd_of_pairwise_coprime` (corollary for pairwise coprime sets), and `sumDvdProd_iff_reduced_divides_gcd` (the GCD reduction $(a'+b') \\mid d$, fully proved via coprimality argument).",
       "mathContext": "If $\\gcd(a,b) = 1$ then $\\gcd(a, a+b) = 1$, so $(a+b) \\mid ab$ implies $(a+b) \\mid b$ by Euclid's lemma, contradicting $a+b > b$.  The GCD reduction writes $a = da', b = db'$ and shows $(a+b) \\mid ab \\iff (a'+b') \\mid d$ via $\\gcd(a'+b', a'b') = 1$."
     }

--- a/src/data/proofs/erdos-357/meta.json
+++ b/src/data/proofs/erdos-357/meta.json
@@ -118,23 +118,23 @@
       "id": "conjecture",
       "title": "The Main Conjecture",
       "startLine": 71,
-      "endLine": 82,
-      "summary": "Erdos357Conjecture := (f · : ℝ) =o[atTop] (· : ℝ): f(n) = o(n). The central open question.",
+      "endLine": 109,
+      "summary": "Erdos357Conjecture := (f · : ℝ) =o[atTop] (· : ℝ): f(n) = o(n), the central open question. Also states the ratio-limit reformulation Erdos357ConjectureAlt (f(n)/n → 0) and proves the two equivalent (conjecture_equiv, via Asymptotics.isLittleO_iff_tendsto' since n is eventually nonzero along atTop).",
       "mathContext": "Uses Mathlib's IsLittleO at atTop. Since g(n) = Θ(n), the conjecture asserts strict monotonicity fundamentally limits the sequence length."
     },
     {
       "id": "known-results",
       "title": "Known Results (Axiomatized)",
-      "startLine": 84,
-      "endLine": 114,
+      "startLine": 111,
+      "endLine": 141,
       "summary": "Three axioms: weisenberg_lower_bound (f(n) ≥ (2+o(1))√n via B₂), hegyvari_bounds ((1/3+o(1))n ≤ g(n) ≤ (2/3+o(1))n), infinite_set_lower_density_zero (proved: liminf #{A∩[1,n]}/n = 0 for infinite A).",
       "mathContext": "Weisenberg's bound exploits the B₂⊆distinct-consecutive-sums inclusion and Erdős–Turán (1941). Hegyvári (1986) uses a probabilistic/greedy construction for the lower bound and averaging for the upper. Lower density 0 follows from a counting argument on sums."
     },
     {
       "id": "open-conjectures",
       "title": "Open Conjectures for Infinite Sets",
-      "startLine": 116,
-      "endLine": 135,
+      "startLine": 143,
+      "endLine": 164,
       "summary": "InfiniteDensityZeroConjecture: #{A∩[1,n]}/n → 0 for any infinite A with distinct sums (open, stronger than lower density 0). InfiniteSumConvergesConjecture: Σ 1/A(k) < ∞ (open). g_ge_f_Remark: f(n) ≤ g(n) recorded as a Prop for future formalization.",
       "mathContext": "Both infinite-set conjectures strengthen the proved lower-density-0 result. Sum convergence Σ 1/a_k < ∞ implies faster-than-linear spacing, a strong sparsity assertion."
     }

--- a/src/data/proofs/erdos-69/meta.json
+++ b/src/data/proofs/erdos-69/meta.json
@@ -106,17 +106,17 @@
       "id": "tao-identity",
       "title": "Tao's Identity (Proved by Aristotle)",
       "startLine": 91,
-      "endLine": 164,
+      "endLine": 193,
       "summary": "`tao_identity : omegaSum = primeSum` — the central combinatorial identity, proved by Aristotle via automated proof search. The proof rewrites $\\omega(n)$ as $\\sum_{p|n} 1$, performs a Fubini-style summation interchange (justified by absolute convergence via `Summable.tsum_comm`), and applies `geometric_sum_over_multiples` to each inner sum.",
       "mathContext": "$\\sum_{n \\geq 2} \\frac{\\omega(n)}{2^n} = \\sum_{n \\geq 2} \\frac{\\sum_{p|n} 1}{2^n} = \\sum_p \\sum_{k \\geq 1} \\frac{1}{2^{pk}} = \\sum_p \\frac{1}{2^p - 1}$\n\nThe summation interchange is the mathematical core — it requires absolute convergence of the double sum, proved by comparing $\\omega(n)/2^n \\leq n/2^n$ (since $\\omega(n) \\leq n$) and showing $\\sum n/2^n$ converges via the ratio test with limit $1/2$."
     },
     {
       "id": "irrationality",
       "title": "Irrationality and Main Theorem",
-      "startLine": 165,
-      "endLine": 188,
-      "summary": "`primeSum_irrational : Irrational primeSum` is the deep analytic result (sorry — Tao-Teräväinen 2025, beyond current Mathlib). `erdos_69 : Irrational omegaSum` combines `tao_identity` and `primeSum_irrational` in a two-line proof: rewrite via the identity, then apply irrationality.",
-      "mathContext": "The final proof: `rw [tao_identity]; exact primeSum_irrational`. This two-line argument is the entire reduction of Problem 69 to Problem 257 — the combinatorial identity does all the work, and the deep analytic number theory is encapsulated in the single sorry."
+      "startLine": 195,
+      "endLine": 219,
+      "summary": "`primeSum_irrational : Irrational primeSum` is the deep analytic result (axiom — Tao-Teräväinen 2025, beyond current Mathlib). `erdos_69 : Irrational omegaSum` combines `tao_identity` and `primeSum_irrational` in a two-line proof: rewrite via the identity, then apply irrationality.",
+      "mathContext": "The final proof: `rw [tao_identity]; exact primeSum_irrational`. This two-line argument is the entire reduction of Problem 69 to Problem 257 — the combinatorial identity does all the work, and the deep analytic number theory is encapsulated in the single axiom."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Section-coverage / prose-accuracy enrichment pass. Each entry's `sections` array left the tail of its Lean file uncovered (or carried a drifted anchor whose summary described content past its `endLine`). Re-anchored to cover 1..EOF. **No `status`/`badge`/`axiomCount` changes.**

- **divisibility-by-3-oq-03**: `§ 5. Computational Examples` stopped at 244 but its summary already claims `dr(18)=9` (`example_18` @246) → extended to 247; added `§ 6. Summary and Public API` (249-273) covering the summary docstring + `#check` exports.
- **erdos-357**: three-section drift — `The Main Conjecture` anchored 71-82 but the `Erdos357Conjecture` def + Alt formulation + `conjecture_equiv` run to 109; `Known Results (Axiomatized)` anchored 84-114 while its three axioms (weisenberg/hegyvari/lower-density) are at 111-141; `Open Conjectures for Infinite Sets` anchored 116-135 while the two conjecture defs + `g_ge_f_Remark` it describes are at 143-164. Re-anchored all three; extended the Main Conjecture summary to mention the alt formulation/equivalence.
- **erdos-69**: `Tao's Identity` proof actually runs to 193 (was cut at 164); `Irrationality and Main Theorem` re-anchored 165-188 → 195-219 (holds `axiom primeSum_irrational` @207 + `theorem erdos_69` @215). Also fixed stale prose: the summary/mathContext called `primeSum_irrational` a "sorry" but it is an `axiom` (badge already `axiom`).
- **erdos-327**: `Coprime and GCD Characterizations` stopped at 168 mid-docstring; its summary names `sumDvdProd_iff_reduced_divides_gcd` (@174-198) → extended to 198. Also fixed two pre-existing 1-line boundary overlaps (Van Doorn / Factor-of-2 / Basic Properties).
- **cauchy-schwarz-integral-oq005**: added `Automation Assessment` section (160-187) covering the tactic-comparison docstring block.

All five verified: `max(section.endLine) == last content line`, no section overlaps.
