### PR TITLE
Audit: bounded-prime-gaps-oq001 clean (D(6)=16 axiom-free verified)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30656,6 +30656,12 @@
       "lastAudited": "2026-07-21T09:26:32Z",
       "result": "clean",
       "issues": []
+    },
+    "bounded-prime-gaps-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T09:30:32Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — clean

**Proof**: bounded-prime-gaps-oq001 — "Minimum Admissible Diameter D(6) = 16"

Re-serve audit. Entry makes a strong headline integrity claim (**axiom-free AND native_decide-free, fully kernel-checked**), so it was build-verified.

## Verification

- **Build**: `lake build Proofs.BoundedPrimeGapsOQ03OQ01OQ01OQ01` succeeds (deprecation warnings only).
- **`#print axioms`** on all four theorems (`minAdmissibleDiameter_6`, `admissible_6tuple_diam_ge_16`, `diam_witness`, `admissible_6tuple_0_4_6_10_12_16`) returns only `[propext, Classical.choice, Quot.sound]`:
  - No `Lean.ofReduceBool` → **native_decide-free confirmed** (all `native_decide` mentions are in comments).
  - No custom axioms → **axiomCount 0 correct**.
  - No `sorryAx` → **0 sorries correct**.
- Meta matches file exactly: 4 theorems, 0 definitions, 0 sorries, 254 lines.
- Tier A / badge `original` justified: genuine from-scratch symbolic argument (parity → mod-3 pinning → mod-5 obstruction); Mathlib supplies only Finset/`csInf` infrastructure. Proof strategy matches the code line-by-line.

No issues found. Tracker updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)