### PR TITLE
Audit: brouwer-fixed-point-oq001 & oq002 clean (axiom footprints verified)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30728,6 +30728,12 @@
       "lastAudited": "2026-07-21T09:50:11Z",
       "result": "clean",
       "issues": []
+    },
+    "brouwer-fixed-point-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T09:39:40Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — 2 entries clean

Both build-verified via `#print axioms`. Folded into one PR to avoid a tracker merge-race.

### brouwer-fixed-point-oq001 — "Eliminating retraction_construction"
- `#print axioms brouwer_fixed_point_explicit` → `[propext, Brouwer.no_retraction_axiom, Classical.choice, Quot.sound]`: exactly one custom axiom, does **NOT** depend on `retraction_construction` → the 2→1 reduction is genuine. `retraction_construction_theorem` is axiom-free.
- `no_retraction_axiom` (`¬∃ r : Retraction n, True`, n≥1) is the genuine Brouwer no-retraction theorem (needs degree theory); the `, True` is idiomatic "a Retraction exists", not a vacuous guard.
- Meta matches: 17 thm / 3 def / 0 sorry, axiomCount 1, status axiomatized, badge axiom.

### brouwer-fixed-point-oq002 — "The Honest Continuity Hypothesis"
- `#print axioms ham_sandwich_standard_of_scalar_continuity_on` (headline) → `[propext, BorsukUlam.no_continuous_odd_nonzero_on_sphere, Classical.choice, Quot.sound]`: exactly one custom axiom (the disclosed Borsuk-Ulam degree-theory core), no `sorryAx`, no `ofReduceBool`.
- The topological bridge `sphereExtend_continuous` is genuinely **axiom-free**, as claimed. On-sphere continuity is a genuine explicit `ContinuousOn` hypothesis (not smuggled as an axiom); theorems conclude real bisection existence (not vacuous).
- Meta matches: 11 thm / 1 def / 0 sorry, axiomCount 1, status axiomatized, badge axiom.

No issues found in either. Tracker updated for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)