### PR TITLE
Enrich 5 entries: re-anchor undercovered/drifted tail sections (1..EOF)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02/meta.json
@@ -274,7 +274,7 @@
       "id": "concrete-open-challenges",
       "title": "Part IX: Reference, Concrete Examples, and Full Ordering Problem",
       "startLine": 993,
-      "endLine": 1047,
+      "endLine": 1079,
       "summary": "#check @Ballot.ballot_problem as reference. Four norm_num examples: (3,1,1)→1/5, (5,2,1,1)→1/9, (5,0,0)→1, (4,3)→1/7. The full ordering open problem: P(a₁>a₂>...>aₘ throughout) = det||(aᵢ-aⱼ)/(aᵢ+aⱼ)|| via LGV. Definitions: pairwiseRatio a b := (a-b)/(a+b) and threeCandidateProduct a b c. Verification: threeCandidateProduct 4 2 1 = 1/15.",
       "mathContext": "Ballot.ballot_problem type: uniformOn (countedSequence p q) staysPositive = (↑p - ↑q)/(↑p + ↑q). The argument order (p q with q < p) differs from our usage (b a hab). threeCandidateProduct 4 2 1 = (2/6)·(1/3)·(3/5) = (1/3)·(1/3)·(3/5) = 1/15. The LGV determinant formula requires the Lindström-Gessel-Viennot lemma for non-intersecting lattice path counting."
     }

--- a/src/data/proofs/erdos-105-oq-05/meta.json
+++ b/src/data/proofs/erdos-105-oq-05/meta.json
@@ -111,25 +111,25 @@
     {
       "id": "two-flat-generalization",
       "title": "2-Flat Generalization",
-      "summary": "TwoFlat structure (affine plane in R^d), rich 2-flats, and the 2-flat blocking conjecture",
+      "summary": "TwoFlat structure (affine plane in R^d), rich 2-flats, and the 2-flat blocking conjecture richTwoFlatConjecture (for A ⊂ R^d with |A|=n≥d+2 in general position and ≤ n-(d+1) obstacles, an unblocked rich 2-flat exists)",
       "startLine": 107,
-      "endLine": 143,
+      "endLine": 156,
       "mathContext": "TwoFlat with base + 2 linearly independent directions; richTwoFlatConjecture asks about blocking rich 2-flats"
     },
     {
       "id": "monotonicity",
       "title": "Monotonicity Properties",
-      "summary": "Proved: fewer obstacles make it easier to find unblocked flats (for both lines and 2-flats)",
-      "startLine": 145,
-      "endLine": 160,
+      "summary": "Part VI. Proved: fewer obstacles make it easier to find unblocked flats — unblocked_monotone_line and unblocked_monotone_twoflat (B' ⊆ B and unblocked by B implies unblocked by B'), both discharged directly from the definition",
+      "startLine": 158,
+      "endLine": 174,
       "mathContext": "unblocked_monotone: B' subset B and L unblocked by B implies L unblocked by B'"
     },
     {
       "id": "dimension-reduction",
       "title": "Dimension Reduction",
-      "summary": "Counterexamples lift: if the conjecture fails in R^d, it also fails in R^(d+1)",
-      "startLine": 162,
-      "endLine": 170,
+      "summary": "Part VII. Counterexamples lift: counterexample_lifts states that if the higher-dim line conjecture fails in R^d (d≥2) it also fails in R^(d+1), since a counterexample embeds in higher dimensions. Closes with the file Summary block cataloguing the 4 theorems, 9 definitions, 0 axioms, 0 sorries.",
+      "startLine": 176,
+      "endLine": 206,
       "mathContext": "counterexample_lifts: embedding R^d into R^(d+1) preserves counterexample properties"
     }
   ],

--- a/src/data/proofs/erdos-1157/meta.json
+++ b/src/data/proofs/erdos-1157/meta.json
@@ -120,9 +120,9 @@
       "id": "main-statement",
       "title": "Problem Statement and Summary",
       "startLine": 343,
-      "endLine": 366,
-      "summary": "States full Problem #1157 as universal BES conjecture. Summary theorem combines Delcourt-Postle, Ruzsa-Szemerédi, and computed exponents.",
-      "mathContext": "Verified: States full Problem #1157 as universal BES conjecture. Summary theorem combines Delcourt-Postle, Ruzsa-Szemerédi, and computed exponents."
+      "endLine": 401,
+      "summary": "The resolved-case theorems and the formal Problem #1157 statement. erdos_1157_3uniform_resolved (f^(3)(n;k,s)=o(n²) for s≥3, k≥s+3, via Delcourt-Postle) and erdos_1157_case_716 (the (6,3) case via Ruzsa-Szemerédi). bes_monotone_in_k lifts an o(n²) bound from k₁ to any k₂≥k₁ using extremalNumber_mono_k. Part VIII states erdos_1157 := ∀ t r s k, BESConjecture t r s k (OPEN in full generality), the erdos_1157_summary theorem bundling the two resolved o(n²) bounds with the computed exponents besExponent 3 6 3 = 3/2 and besExponent 3 7 4 = 5/3, and bes_conjecture_3_uniform proving BESConjecture 2 3 s k for the 3-uniform t=2 case.",
+      "mathContext": "The Brown-Erdős-Sós function f^(r)(n;k,s) counts the maximum edges in an r-uniform hypergraph on n vertices with no s+... configuration spanning k vertices with s edges. Monotonicity in k is immediate from extremalNumber_mono_k plus le_trans on the little-o witness. The parameter constraint k ≥ (r-t)·s + t + 1 specializes at r=3, t=2 to k ≥ s+3, exactly Delcourt-Postle's condition, so bes_conjecture_3_uniform discharges BESConjecture 2 3 s k by omega on the hypotheses."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/puiseux-theorem-oq-02/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-02/meta.json
@@ -182,23 +182,23 @@
       "id": "sec-predicate",
       "title": "Part III: The Multivariate Puiseux Property",
       "startLine": 131,
-      "endLine": 179,
+      "endLine": 214,
       "summary": "Defines IsMultiPuiseuxSeries : (n : ℕ) → MultiHahnSeries n K → Prop by recursion. At level 0: True; at level n+1: (∃ d : ℕ+, exponents ∈ (1/d)·ℤ) ∧ (∀ coefficient recursively satisfies the predicate). Proves isMultiPuiseux_base (trivial) and isMultiPuiseux_zero (empty support + recursion). Both compile 0 sorries.",
       "mathContext": "IsMultiPuiseuxSeries captures elements of MultiHahnSeries n K whose support has a common denominator at every level of the iteration. This is the correct multivariate generalization of the Puiseux condition."
     },
     {
       "id": "sec-main-comment",
       "title": "Part IV: Multivariate Algebraic Closure (Documented)",
-      "startLine": 181,
-      "endLine": 213,
+      "startLine": 216,
+      "endLine": 248,
       "summary": "Documents the multivariate_puiseux_theorem (MultiHahnSeries n K is IsAlgClosed when K is algebraically closed and CharZero). The inductive structure is clear; the gap is that IsAlgClosed (HahnSeries ℚ K) is not yet in Mathlib 4.26. Recorded in comments with proof sketch.",
       "mathContext": "By induction on n: base case is K (algebraically closed by hypothesis); inductive step applies Puiseux's theorem to conclude HahnSeries ℚ (MultiHahnSeries n K) is algebraically closed. The induction also requires CharZero propagation."
     },
     {
       "id": "sec-properties",
       "title": "Part V: Properties of the Iterated Construction",
-      "startLine": 215,
-      "endLine": 238,
+      "startLine": 250,
+      "endLine": 273,
       "summary": "Proves single_variable_is_univariate: MultiHahnSeries 1 K = HahnSeries ℚ K (definitional equality, 0 sorry). Documents double_puiseux_redundant: HahnSeries ℚ (HahnSeries ℚ K) ≅ HahnSeries ℚ K as algebraically closed fields (requires algebraic closure uniqueness, not yet formalized).",
       "mathContext": "The single-variable case recovers the parent PuiseuxTheorem.lean exactly. The double-iteration redundancy follows from the uniqueness of algebraic closures up to isomorphism."
     }

--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -178,7 +178,7 @@
       "id": "walk-pairing-parity",
       "title": "Walk Pairing Parity and Main Existential",
       "startLine": 820,
-      "endLine": 948,
+      "endLine": 983,
       "summary": "Proves kuhnWalk_not_in_initial_visited (the walk result is never in the initial visited set), states the bdry_all_even_of_no_fc_walks axiom (under hfail, the boundary-door set B has even cardinality via the FPF involution τ), and derives kuhn_path_existential (∃ boundary door whose walk finds FC) and its wrapper kuhnPathStart_finds_fc_existential.",
       "mathContext": "The parity contradiction argument: if no boundary-door walk finds FC, the map τ: (s₀, Fin.last d) ↦ (kuhnPathStart s₀ (Fin.last d), Fin.last d) is a FPF involution on B, giving Even |B| — contradicting the odd boundary-door hypothesis. The τ∘τ=id step (walkTrace_reversal) is axiomatized as bdry_all_even_of_no_fc_walks."
     }


### PR DESCRIPTION
Enrichment pass — gap 30-40 undercoverage tier. Five gallery entries whose `sections` stopped short of the file's real tail declarations, or whose last sections had drifted off their `/- ## Part -/` banners. Re-anchored each to cover 1..EOF.

| Entry | Fix |
|-------|-----|
| `erdos-1157` | `main-statement` 366→401 — now covers Part VIII (`def erdos_1157`, `erdos_1157_summary`, `bes_conjecture_3_uniform`); enriched summary + mathContext |
| `sperner-ndim-oq-04` | `walk-pairing-parity` 948→983 — main existential theorems `kuhn_path_existential` + wrapper (summary already described them) |
| `ballot-problem-oq-01-oq-02` | `concrete-open-challenges` 1047→1079 — `pairwiseRatio`/`threeCandidateProduct` Part IX defs |
| `erdos-105-oq-05` | re-anchored 3 drifted sections to banners: two-flat→156, monotonicity→[158-174], dimension-reduction→[176-206] (`counterexample_lifts` + Summary) |
| `puiseux-theorem-oq-02` | re-anchored Parts III/IV/V: sec-predicate→[131-214] (`IsMultiPuiseuxSeries` + base/zero), sec-main-comment→[216-248], sec-properties→[250-273] |

Pure anchor re-alignment + summary deepening. No `status`/`badge`/`axiomCount` changes. All verified to cover 1..EOF (gap = trailing newline) with no section overlaps; JSON parse-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
