### PR TITLE
Enrich 4 entries: re-anchor drifted tail sections + cover uncovered tails (1..EOF)

### DIFF
--- a/src/data/proofs/erdos-317/meta.json
+++ b/src/data/proofs/erdos-317/meta.json
@@ -117,12 +117,28 @@
       "mathContext": "Kovac and van Doorn showed that for all large $n$, signs $\\delta_k$ exist with $0 < |\\sum \\delta_k/k| \\leq 2^{-n \\cdot (\\log\\log\\log n)^{1+o(1)}/\\log n}$. This is sub-exponential in $n$ — much larger than $c/2^n$ — suggesting Q1 may be false."
     },
     {
-      "id": "summary",
-      "title": "Summary Theorem",
-      "summary": "The proved theorem `erdos_317_summary` combines the weak inequality with the small-$n$ counterexample, packaging the known results into a single statement.",
+      "id": "existence-nonzero-sums",
+      "title": "Existence of Nonzero Signed Sums",
+      "summary": "The all-ones sign function `allOnesDelta n = fun _ => 1` and the proved theorems `allOnesDelta_isSign` (it is a valid sign function), `allOnes_sum_pos` (for n ≥ 1 its signed sum is strictly positive — it is the n-th harmonic number, shown positive via Finset.sum_pos), and `nonzero_signed_sum_exists` (for every n ≥ 1 some sign function yields a nonzero signed sum, witnessed trivially by the harmonic number). Establishes that the nonemptiness hypothesis of Question 2 is never vacuous.",
       "startLine": 105,
-      "endLine": 158,
-      "mathContext": "The summary theorem states: (1) for all $n$ and all sign functions $\\delta$, $|\\sum \\delta_k/k| \\geq 1/\\text{lcm}(1,\\ldots,n)$ (weak inequality), AND (2) there exists a sign function at $n = 4$ achieving equality. This is the provable content of the file; Questions 1 and 2 remain open."
+      "endLine": 130,
+      "mathContext": "Taking $\\delta_k = 1$ for all $k$ gives $\\sum \\delta_k/(k+1) = H_n = \\sum_{k=1}^{n} 1/k > 0$, the harmonic number, so a nonzero signed sum always exists. This shows the set of nonzero sums is nonempty for every $n \\ge 1$, so asking for its infimum (Questions 1 and 2) is well-posed."
+    },
+    {
+      "id": "weak-inequality",
+      "title": "Weak Inequality (Part V)",
+      "summary": "Proved theorem `weak_inequality`: every nonzero signed unit fraction sum satisfies |∑ δ_k/(k+1)| ≥ 1/lcm(1,…,n). The proof clears the trivial L=0 case, then shows L·S is an integer m (each denominator k+1 divides L=lcm_1_to_n n via Finset.dvd_lcm, so field_simp/push_cast/ring reduce each term to an integer), deduces m ≠ 0 from S ≠ 0, and concludes via 1 ≤ |m| = |L·S| = |S|·L (an omega bound on the integer m, then div_le_iff₀). This is the provable half of Question 2 — the strict version is what fails for small n.",
+      "startLine": 132,
+      "endLine": 173,
+      "mathContext": "Since each $k+1 \\mid \\operatorname{lcm}(1,\\ldots,n) =: L$, the quantity $L\\cdot S$ is an integer $m$; when $S \\neq 0$, $m \\neq 0$ so $|m| \\ge 1$, giving $|S| = |m|/L \\ge 1/L = 1/\\operatorname{lcm}(1,\\ldots,n)$. The strict inequality $>$ is what Question 2 asks and what fails at $n=4$."
+    },
+    {
+      "id": "summary",
+      "title": "Summary Theorem (Part VI)",
+      "summary": "The proved theorem `erdos_317_summary` combines the weak inequality, the small-n counterexample, and the existence result into a single statement, packaging the file's provable content.",
+      "startLine": 175,
+      "endLine": 192,
+      "mathContext": "The summary theorem states: (1) for all $n$ and all sign functions $\\delta$, $|\\sum \\delta_k/(k+1)| \\geq 1/\\text{lcm}(1,\\ldots,n)$ (weak inequality); (2) there exists a sign function at $n = 4$ achieving equality (so the strict inequality of Question 2 fails); and (3) for every $n \\ge 1$ a nonzero signed sum exists. This is the provable content of the file; Questions 1 and 2 remain open."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/leibniz-pi-oq-04/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-04/meta.json
@@ -108,6 +108,14 @@
       "endLine": 116,
       "summary": "Every x ∈ (0,1) pairs with the unique y = (1−x)/(1+x) > 0 to give a two-term π/4 identity; Euler's is the case x = 1/2.",
       "mathContext": "For $x \\in (0,1)$, $\\arctan x + \\arctan\\frac{1-x}{1+x} = \\pi/4$. The partner map $x \\mapsto (1-x)/(1+x)$ is an involution on $(-1,1)$ fixing $0$."
+    },
+    {
+      "id": "three-term-companion",
+      "title": "A Three-Term Machin Companion Needing Two Folds",
+      "startLine": 118,
+      "endLine": 151,
+      "summary": "Beyond the two-term Euler identity, π/4 also decomposes as arctan(1/3) + arctan(1/4) + arctan(2/9), assembled by iterating the arctangent addition law until the combined argument is exactly 1. Two reusable warm-up folds are proved first — fold_half_fifth (arctan(1/2) + arctan(1/5) = arctan(7/9), with xy = 1/10 < 1) and fold_third_fourth (arctan(1/3) + arctan(1/4) = arctan(7/11), with xy = 1/12 < 1) — each via arctan_add and a norm_num check of the addition-law argument. The main result machin_three_term then chains fold_third_fourth with a second fold arctan(7/11) + arctan(2/9) = arctan 1 (since (7/11)(2/9) = 14/99 < 1 and (7/11 + 2/9)/(1 − 14/99) = 1), closing with arctan_one. This illustrates that unlike the two-term family, a genuinely three-term Machin-type identity requires more than one application of the tangent addition formula.",
+      "mathContext": "$\\arctan\\frac13 + \\arctan\\frac14 + \\arctan\\frac29 = \\frac\\pi4$. Each fold uses $\\arctan x + \\arctan y = \\arctan\\frac{x+y}{1-xy}$ valid when $xy < 1$; the final argument $\\frac{7/11 + 2/9}{1 - (7/11)(2/9)} = 1$ so $\\arctan 1 = \\pi/4$."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Section-coverage + prose-accuracy enrichment pass. **No `status`/`badge`/`axiomCount` changes** — purely re-anchoring drifted section line-ranges and adding sections for genuine uncovered tail declarations, so each entry's `sections` array now covers its Lean file to EOF.

Found via the authoritative undercoverage scan (fresh `origin/main`, `checked=4788`, gap 30-40 tier). Two entries (erdos-317, erdos-105-oq-05) had **mid-file drift** — later sections whose line anchors lagged behind their true content — not just missing tail-appends, so the fix re-anchored interior sections rather than only extending the last one.

| Entry | Fix |
|-------|-----|
| **leibniz-pi-oq-04** | add "Three-Term Machin Companion" section (118-151): `fold_half_fifth`, `fold_third_fourth`, `machin_three_term` |
| **sum-of-kth-powers-oq-01** | extend specific-formulas→149; re-anchor completeness to cover `faulhaber_completeness` (151-169); add "Numerical Verification" (171-193) |
| **erdos-317** | replace mislabeled "summary" (105-158, text described `erdos_317_summary` but range covered all-ones/weak-inequality material) with three correctly-anchored sections: existence-nonzero-sums (105-130), weak-inequality (132-173), summary at its true home (175-192) |
| **erdos-105-oq-05** | re-anchor drifted Parts IV–VII (`higher_dim_d2_is_original` now covered 86-113; 2-flat 115-156; monotonicity 158-174; dimension-reduction 176-185) + add Summary section (187-206) |

**Verified:** for all 4, `max(endLine) == last content line`, zero section overlaps, JSON parses.

**Race note:** a 5th entry (hermite-sawtooth-identity-oq-02) was in the original push but **dropped** after rebasing onto current `origin/main` — its identical "Eisenstein lattice-point count" tail section had already landed concurrently via #40322. Branch is now based on the post-#40322 main.
