### PR TITLE
Enrich 3 entries: cover uncovered capstone/tail declarations (1..EOF)

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-03-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-01/meta.json
@@ -295,7 +295,7 @@
       "title": "Section XXV: Summary of Tucker's Lemma Contribution",
       "summary": "Final summary of what is proved (discrete IVT, Tucker 1D, cycle and parity lemmas) versus what remains axiomatized (full 2D Tucker), and the infrastructure contributed.",
       "startLine": 1128,
-      "endLine": 1163,
+      "endLine": 1198,
       "mathContext": "Recap: discrete IVT and Tucker 1D are fully proved; tucker_2d remains an axiom; parity/sign-change infrastructure is contributed."
     }
   ],

--- a/src/data/proofs/erdos-1098-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1098-oq-01-oq-01/meta.json
@@ -85,9 +85,9 @@
     {
       "id": "main-results",
       "title": "Axioms and Main Theorems",
-      "summary": "three_clique_index_ge_four (axiom), S3_omega_three (axiom), three_clique_necessary_conditions (proved)",
+      "summary": "three_clique_index_ge_four (axiom), S3_omega_three (axiom), three_clique_necessary_conditions (proved: a 3-clique yields a nonCommuting pair, elements outside the center, and index ≥ 4). Closes with the capstone corollary erdos_1098_oq01_oq01 combining existence (S₃ achieves ω=3 with no 4-clique) and necessity (any 3-clique forces (Subgroup.center G).index ≥ 4).",
       "startLine": 126,
-      "endLine": 170,
+      "endLine": 206,
       "mathContext": "Combines coset separation, center exclusion, and Neumann-style index bound"
     }
   ],

--- a/src/data/proofs/sum-of-kth-powers-oq-01/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-01/meta.json
@@ -112,9 +112,9 @@
       "id": "completeness",
       "title": "Completeness Theorem",
       "startLine": 151,
-      "endLine": 159,
-      "summary": "All five formulas packaged as a single completeness theorem.",
-      "mathContext": "Conjunction of all five Faulhaber formulas"
+      "endLine": 193,
+      "summary": "faulhaber_completeness packages all five power-sum formulas (k∈{1,2,3,4,5}) as a single conjunction, each discharged from the unified Bernoulli identity with no induction, answering OQ-01. Closes with the Numerical Verification block: norm_num examples at n=4 for k=2 (14), k=3 (36), k=4 (98), k=5 (276).",
+      "mathContext": "Conjunction of all five Faulhaber formulas ∑_{i<n} i^k, each a special case of ∑_{i<n} i^k = (1/(k+1)) ∑_{j≤k} C(k+1,j) B_j n^{k+1-j}. The example blocks evaluate the closed forms at n=4 to cross-check the Bernoulli-derived polynomials."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass — gap 30-40 undercoverage tier (batch B). Three entries whose last `section` stopped before the file's final theorem or verification block. Re-anchored each to cover 1..EOF.

| Entry | Fix |
|-------|-----|
| `sum-of-kth-powers-oq-01` | `completeness` 159→193 — now covers `faulhaber_completeness` (all five power-sum formulas) + the Numerical Verification example block |
| `borsuk-ulam-oq-03-oq-01` | `tucker-contribution-summary` 1163→1198 — Section XXV summary body + `tucker_lemma_summary` marker |
| `erdos-1098-oq-01-oq-01` | `main-results` 170→206 — capstone corollary `erdos_1098_oq01_oq01` (S₃ achieves ω=3 with no 4-clique; any 3-clique forces center index ≥ 4); enriched summary |

Pure anchor extension + summary deepening. No `status`/`badge`/`axiomCount` changes. All cover 1..EOF; JSON parse-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
