### PR TITLE
Enrich 3 entries: re-anchor drifted/undercovered sections to 1..EOF

### DIFF
--- a/src/data/proofs/binary-gcd-oq-01-oq-04/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01-oq-04/meta.json
@@ -82,42 +82,58 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview: The Worst-Case Family (1, 2ⁿ − 1)",
+      "startLine": 1,
+      "endLine": 31,
+      "summary": "File header, imports, and the BinaryGcdOQ01 upper bound this entry sharpens. Goal: the family (1, 2ⁿ − 1) takes exactly n Binary-GCD steps, matching the general O(log b) bound up to a constant and pinning the worst case at Θ(log b).",
+      "mathContext": "The general bound $\\text{binaryGcdSteps}(a,b) \\le 2(\\log_2 a + \\log_2 b) + 2$ (from `BinaryGcdOQ01`) is shown tight: for $b = 2^n-1$ (odd, $\\log_2 b = n-1$ for $n\\ge 2$) the step count is exactly $n$, so the constant-factor slack is unavoidable. Key reductions: $2^n-1$ is odd, and $2^{n+1}-1 = 2(2^n-1)+1$."
+    },
+    {
       "id": "one-step-lemma",
       "title": "One-Step Reduction for Odd Inputs",
-      "startLine": 39,
-      "endLine": 49,
+      "startLine": 32,
+      "endLine": 51,
       "summary": "binaryGcdSteps_one_odd: binaryGcdSteps 1 (2k+1) = 1 + binaryGcdSteps 1 k. Proved by unfolding binaryGcdSteps.eq_3 and resolving three if-neg conditions plus arithmetic simplification.",
       "mathContext": "Binary GCD 'both odd' branch: $(1, 2k+1) \\xrightarrow{\\text{both odd}, 1 \\leq 2k+1} (1, (2k+1-1)/2) = (1, k)$. Three guards must be checked: $1 \\not\\equiv 0 \\pmod{2}$, $2k+1 \\not\\equiv 0 \\pmod{2}$, $1 \\not> 2k+1$. The Lean proof uses $\\texttt{if\\_neg}$ for each guard, then $\\texttt{omega}$ for the arithmetic $(2k+1-1)/2 = k$."
     },
     {
       "id": "arithmetic-setup",
       "title": "Arithmetic Identity for Powers of 2",
-      "startLine": 56,
-      "endLine": 59,
+      "startLine": 52,
+      "endLine": 61,
       "summary": "pow2_succ_sub_one: 2^(n+1) - 1 = 2·(2^n-1) + 1. Proved by ring + omega with pow_pos for positivity.",
       "mathContext": "$2^{n+1} - 1 = 2 \\cdot 2^n - 1 = 2(2^n-1) + 1$. In $\\mathbb{N}$, subtraction requires $0 < 2^n$ (from $\\texttt{pow\\_pos}$) to avoid underflow. The identity rewrites the inductive input $2^{n+1}-1$ as $2k+1$ with $k = 2^n-1$, enabling $\\texttt{binaryGcdSteps\\_one\\_odd}$."
     },
     {
       "id": "main-theorem",
       "title": "Exact Step Count",
-      "startLine": 77,
-      "endLine": 84,
+      "startLine": 62,
+      "endLine": 86,
       "summary": "binaryGcdSteps_one_pow2_sub_one: binaryGcdSteps 1 (2^n - 1) = n. Proof by induction: zero case by simp, succ case by rw + omega.",
       "mathContext": "Induction: base $\\text{binaryGcdSteps}(1, 0) = 0$; step $\\text{binaryGcdSteps}(1, 2^{n+1}-1) \\xrightarrow{\\text{decomp}} \\text{binaryGcdSteps}(1, 2(2^n-1)+1) \\xrightarrow{\\text{one-step}} 1 + \\text{binaryGcdSteps}(1, 2^n-1) \\xrightarrow{\\text{IH}} 1 + n = n+1$. Proof body: 4 lines."
     },
     {
       "id": "log-lower-bound",
       "title": "Logarithmic Lower Bound",
-      "startLine": 92,
-      "endLine": 144,
+      "startLine": 87,
+      "endLine": 141,
       "summary": "log₂(2^n-1) < n proved by contradiction via Nat.pow_log_le_self. Full bound: log₂(2^n-1) + 1 ≤ binaryGcdSteps 1 (2^n-1). For n≥2: exact equality log₂(2^n-1)+1 = n.",
       "mathContext": "Contradiction proof: assume $n \\leq \\lfloor\\log_2(2^n-1)\\rfloor$. Then $2^n \\leq 2^{\\lfloor\\log_2(2^n-1)\\rfloor} \\leq 2^n - 1$ (using $\\texttt{Nat.pow\\_log\\_le\\_self}$: $b^{\\lfloor\\log_b m\\rfloor} \\leq m$), which is impossible. For the exact equality: squeeze $n-1 \\leq \\lfloor\\log_2(2^n-1)\\rfloor < n$ via $\\texttt{Nat.log\\_mono\\_right}$ and $\\texttt{Nat.log\\_pow}$."
     },
     {
+      "id": "upper-bound-sandwich",
+      "title": "PART IV.5: Matching Upper Bound and the Two-Sided Sandwich",
+      "startLine": 142,
+      "endLine": 177,
+      "summary": "binaryGcdSteps_family_upper_bound specialises the general BinaryGcdOQ01 bound to the family (log₂ 1 = 0 collapses it to 2·log₂(2ⁿ−1)+2), and binaryGcdSteps_family_sandwich combines it with the log lower bound: L+1 ≤ binaryGcdSteps 1 (2ⁿ−1) ≤ 2L+2 with L = log₂(2ⁿ−1). This pins the count to a factor-2 window around log₂ b, proving Θ(log b).",
+      "mathContext": "With $L = \\lfloor\\log_2(2^n-1)\\rfloor$: the lower bound $L+1 \\le \\text{binaryGcdSteps}\\,1\\,(2^n-1)$ comes from the exact count $= n > L$, and the upper bound $\\le 2L+2$ is the specialised general bound (using $\\texttt{Nat.log\\_one\\_right}$: $\\log_2 1 = 0$). Together: $L+1 \\le \\text{steps} \\le 2L+2 = \\Theta(\\log_2 b)$."
+    },
+    {
       "id": "verifications",
       "title": "Computational Verification",
-      "startLine": 150,
-      "endLine": 157,
+      "startLine": 178,
+      "endLine": 194,
       "summary": "native_decide confirms binaryGcdSteps 1 (2^n-1) = n for n=1,2,3,4,6,8 and log₂(2^4-1)=3, log₂(2^8-1)=7.",
       "mathContext": "Spot checks: $\\text{binaryGcdSteps}(1, 255) = 8$ (n=8), $\\text{binaryGcdSteps}(1, 63) = 6$ (n=6), $\\lfloor\\log_2 255\\rfloor = 7 = n-1$. Proved by $\\texttt{native\\_decide}$ — Lean compiles and runs the computation natively, tracing all 8 reductions $(1,255) \\to (1,127) \\to \\cdots \\to (1,0)$."
     }

--- a/src/data/proofs/law-of-sines-oq-06/meta.json
+++ b/src/data/proofs/law-of-sines-oq-06/meta.json
@@ -103,9 +103,17 @@
       "id": "law-of-sines",
       "title": "Part VII: Law of Sines",
       "startLine": 237,
-      "endLine": 279,
+      "endLine": 283,
       "summary": "Derives a/sin(α) = b/sin(β) and a/sin(α) = c/sin(γ) by equating area formulas and canceling with mul_left_cancel₀.",
       "mathContext": "From $cb\\sin\\alpha = ca\\sin\\beta$: cancel $c$ via \\texttt{mul\\_left\\_cancel₀} to get $b\\sin\\alpha = a\\sin\\beta$, then \\texttt{div\\_eq\\_div\\_iff} gives $a/\\sin\\alpha = b/\\sin\\beta$."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 284,
+      "endLine": 313,
+      "summary": "Recaps the 0-axiom, 0-sorry development: the 2D Lagrange identity, the sin-angle/cross-product identity (via arccos → sin_arccos → Lagrange → sqrt_sq_eq_abs), the three vertex area formulas, sin positivity, and the law of sines a/sin α = b/sin β = c/sin γ obtained by equating areas and cancelling. Lists every proved lemma and the mathematical thread Area = ½cb sin α = ½ca sin β ⇒ a/sin α = b/sin β.",
+      "mathContext": "$\\text{Area} = \\tfrac12 cb\\sin\\alpha = \\tfrac12 ca\\sin\\beta = \\tfrac12 ba\\sin\\gamma \\Rightarrow \\dfrac{a}{\\sin\\alpha}=\\dfrac{b}{\\sin\\beta}=\\dfrac{c}{\\sin\\gamma}$, all from Mathlib primitives with `ring_nf`, `linarith`, and `mul_left_cancel₀`; no axioms, no sorries."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/pell-equation-oq-05/meta.json
+++ b/src/data/proofs/pell-equation-oq-05/meta.json
@@ -108,6 +108,14 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview: Norm Equations in Degree > 2",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "File docstring and imports. Pell x² − Dy² = 1 is the norm-one equation of ℚ(√D); this entry studies the degree-3 analogue over K = ℚ(∛2) = ℤ[t]/(t³−2), formalizing the concrete algebraic core (norm form, multiplicativity, the unit chain, the zero-or-infinite dichotomy, and a non-norm) while deferring the signature/Dirichlet unit-rank step Mathlib does not ship.",
+      "mathContext": "Pell $x^2 - Dy^2 = 1$ is $N_{\\mathbb{Q}(\\sqrt D)/\\mathbb{Q}}(x+y\\sqrt D)=1$, the rank-1 case of Dirichlet's unit theorem. Here $K=\\mathbb{Q}(\\sqrt[3]2)$, $N(a,b,c)=a^3+2b^3+4c^3-6abc$, and the deferred piece is the unit rank $r_1+r_2-1=1$ via signature $(r_1,r_2)=(1,1)$."
+    },
+    {
       "id": "cubic-norm-form",
       "title": "The Cubic Norm Form as a Determinant",
       "startLine": 47,
@@ -159,9 +167,17 @@
       "id": "recovering-pell",
       "title": "Recovering Classical Pell (Rank-1 Special Case)",
       "startLine": 369,
-      "endLine": 386,
+      "endLine": 385,
       "summary": "The quadratic (Pell) norm form qnorm p q = p² − 2q², its fundamental solution qnorm_fundamental (3² − 2·2² = 1), and the Brahmagupta chain qnorm_chain (17,12), (99,70), (577,408).",
       "mathContext": "The classical Pell equation is the real-quadratic (degree-2, unit-rank-1) shadow of the same multiplicative picture."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 386,
+      "endLine": 422,
+      "summary": "Recap of the seven-part formalization: the cubic norm form as a determinant, its multiplicativity, the fundamental unit u = ∛2 − 1 and the norm-1 Pell chain uᵏ, distinctness via the real embedding (infinitude of N = 1), the zero-or-infinite dichotomy for N = m (m ≠ 0), and non-surjectivity (7 is never a norm). Records the deferred signature/unit-rank step and the axiom/sorry counts (0/0).",
+      "mathContext": "The entry establishes: $N$ multiplicative, $N(u^k)=1$ with the chain injective (so $N=1$ has infinitely many solutions), the dichotomy that $N(\\xi)=m\\ne 0$ is either unsolvable or has an infinite unit-orbit of solutions, and that $7$ is a non-norm (anisotropic mod 7), giving $\\neg\\,\\text{Surjective}\\,N$. Deferred: unit rank via $\\#\\,\\text{InfinitePlace}(K)=2$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Section-coverage enrichment pass — re-anchor drifted/undercovered `sections` to cover the full Lean file (1..EOF). All three are pure `sections` edits; no `status`/`badge`/`axiomCount` changes (counts verified accurate). Diffs touch only the `sections` array.

**binary-gcd-oq-01-oq-04** (5→7 sections, covers 1..194)
- Added an Overview head section (1–31) for the docstring/imports.
- The "Computational Verification" section was mis-anchored at 150–157 (inside PART IV.5); re-anchored it to the actual `native_decide` block at PART V (178–194).
- Added the missing **PART IV.5** section (142–177) for `binaryGcdSteps_family_upper_bound` + `binaryGcdSteps_family_sandwich` (the two-sided Θ(log b) sandwich).
- `badge:axiom` / axiomCount 1 unchanged (native_decide `example`s ⇒ `Lean.ofReduceBool`).

**pell-equation-oq-05** (7→9 sections, covers 1..422)
- Added an Overview head section (1–46) for the docstring/imports.
- Added the uncovered `## Summary` tail (386–422). Verified/0-axiom unchanged.

**law-of-sines-oq-06** (7→8 sections, covers 1..313)
- Extended Part VII to include the `law_of_sines` theorem body, then added the uncovered `## Summary` tail (284–313). 0-axiom/0-sorry unchanged.

Each section preserves the existing `summary`/`mathContext`; only `startLine`/`endLine` were re-anchored, plus new head/tail/interior sections. Contiguity (`gap ∈ [0,2]`) and `maxEnd === wc` asserted programmatically.
