### PR TITLE
Audit: brouwer-fixed-point + buffons-needle cluster clean (8 entries)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30662,6 +30662,54 @@
       "lastAudited": "2026-07-21T09:30:32Z",
       "result": "clean",
       "issues": []
+    },
+    "brouwer-fixed-point-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T09:44:58Z",
+      "result": "clean",
+      "issues": []
+    },
+    "buffons-needle-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T09:45:24Z",
+      "result": "clean",
+      "issues": []
+    },
+    "buffons-needle-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T09:45:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "buffons-needle-oq003": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T09:45:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "buffons-needle-oq004": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T09:45:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "buffons-needle-oq005": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T09:45:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "buffons-needle-oq006": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T09:45:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "buffons-needle-oq007": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T09:45:59Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Marked 8 entries integrity-clean in \`audit-tracker.json\`.

| Entry | Status/Badge | Verdict |
|-------|--------------|---------|
| brouwer-fixed-point-oq001 | axiomatized/axiom | Clean — 0 local axioms; disclosed `no_retraction_axiom` |
| brouwer-fixed-point-oq002 | axiomatized/axiom | Clean — 0 local axioms; disclosed `no_continuous_odd_nonzero_on_sphere` |
| buffons-needle-oq001 | verified/original | Clean — real integral-additivity lemmas |
| buffons-needle-oq002 | verified/verified | Clean |
| buffons-needle-oq003 | verified/verified | Clean |
| buffons-needle-oq004 | verified/original | Clean |
| buffons-needle-oq005 | verified/original | Clean |
| buffons-needle-oq006 | verified/verified | Clean |
| buffons-needle-oq007 | verified/verified | Clean — Wallis products, convergence |

**Checks:** all 0 real axioms / 0 sorries / no True-stubs / no real \`native_decide\`
(the two \`native_decide\` grep hits are docstring claims "no native_decide").
Theorem counts match meta; disclosed inherited axioms present in both meta and file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)