### PR TITLE
Enrich 4 entries: re-anchor drifted/undercovered sections to 1..EOF

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
@@ -80,10 +80,18 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "File docstring and imports. Question: for which (n, q) does every nonderogatory M ∈ Mₙ(𝔽_q) have a cyclic vector, and does it fail when q ≤ n? This file proves the answer is \"all (n, q), no failure threshold\", delegating the primary-decomposition core to the WIP04/WIP05 companion files and keeping the annihilator/similarity lemmas standalone.",
+      "mathContext": "Nonderogatory means $\\mu_M = \\chi_M$ (minimal = characteristic polynomial). A cyclic vector $v$ makes $\\{v, Mv, \\dots, M^{n-1}v\\}$ a basis. The naive union-avoidance heuristic fails over small fields, yet the theorem still holds via module theory."
+    },
+    {
       "id": "definitions",
       "title": "§ I. Definitions",
       "startLine": 45,
-      "endLine": 52,
+      "endLine": 53,
       "summary": "Defines `IsCyclicVector M v` (no nonzero polynomial of degree < n annihilates v) and `IsNonderogatory M` (minpoly K M = M.charpoly), consistent with parent files.",
       "mathContext": "A vector $v \\in K^n$ is cyclic for $M$ if $\\{v, Mv, \\ldots, M^{n-1}v\\}$ is a basis, equivalently if no polynomial of degree $< n$ annihilates $v$ via $M$. A matrix is nonderogatory if its minimal polynomial coincides with its characteristic polynomial (both monic of degree $n$)."
     },
@@ -91,7 +99,7 @@
       "id": "similarity",
       "title": "§ II. Similarity Preserves Cyclic Vectors",
       "startLine": 54,
-      "endLine": 110,
+      "endLine": 111,
       "summary": "Proves aeval_conj (conjugation by P is an AlgHom, commuting with polynomial evaluation) and cyclic_vector_of_similar (v is cyclic for N iff P⁻¹v is cyclic for P⁻¹NP).",
       "mathContext": "If $M = P^{-1}NP$ and $w$ is cyclic for $N$, then $v = P^{-1}w$ is cyclic for $M$. The key fact: $p(P^{-1}NP) = P^{-1}p(N)P$ for any polynomial $p$, which holds because conjugation by $P$ is a $K$-algebra endomorphism."
     },
@@ -99,7 +107,7 @@
       "id": "annihilator",
       "title": "§ III. Annihilator Characterization (GCD Bezout)",
       "startLine": 112,
-      "endLine": 197,
+      "endLine": 207,
       "summary": "Proves annihilator_dvd_minpoly (GCD annihilation via Bezout, sorry-free) and cyclic_iff_ann_eq_minpoly (cyclic ↔ annihilator ideal = (minpoly)) for nonderogatory matrices.",
       "mathContext": "The annihilator ideal of $v$ is $\\{p \\in K[X] : p(M)v = 0\\}$, a principal ideal $(a_v)$ where $a_v \\mid \\mu_M$. For nonderogatory $M$ (with $\\deg \\mu_M = n$): $v$ is cyclic iff $a_v = \\mu_M$. The Bezout identity $\\gcd(p, \\mu) = Ap + B\\mu$ gives $\\gcd(p, \\mu)(M)v = 0$ whenever $p(M)v = 0$."
     },
@@ -107,7 +115,7 @@
       "id": "main-theorem",
       "title": "§ IV. Main Theorem (All Fields)",
       "startLine": 208,
-      "endLine": 240,
+      "endLine": 241,
       "summary": "States `nonderogatory_has_cyclic_vector_any_field` (delegated to WIP05, axiom-free / sorry-free) and the corollary `nonderogatory_has_cyclic_vector_finite_any_size` for finite fields. The proof routes through WIP04 (factored case) + WIP05 (UFD wrapper).",
       "mathContext": "Over any field $K$: nonderogatory $M \\in M_n(K)$ has a cyclic vector. The proof factors $\\mu_M = \\prod p_i^{e_i}$ via UFD on $K[X]$, builds primary vectors $v_i$ with $p_i^{e_i-1}(M)v_i \\neq 0$ and $p_i^{e_i}(M)v_i = 0$, and combines them via Bezout/CRT projections $\\pi_i = b_i F_i(M)$ to produce a cyclic vector $v = \\sum v_i$. No PID structure theorem or RCF is required."
     },
@@ -115,9 +123,17 @@
       "id": "f2-counterexample",
       "title": "§ V. F₂ Counterexample to Union Avoidance",
       "startLine": 242,
-      "endLine": 253,
+      "endLine": 254,
       "summary": "Proves F2_union_covers: every nonzero vector in F₂² lies in one of the 3 proper 1-dim subspaces, showing union avoidance fails for |K| ≤ n. The main theorem still holds by module theory.",
       "mathContext": "The 3 nonzero vectors of $\\mathbb{F}_2^2$ are $(1,0)$, $(0,1)$, $(1,1)$. Each 1-dimensional subspace over $\\mathbb{F}_2$ contains exactly 1 nonzero vector. So $\\mathbb{F}_2^2 \\setminus \\{0\\}$ is covered by 3 proper subspaces. For union avoidance, one needs $|K| > n$ (here $|K| = 2 \\leq 2 = n$), so the argument fails. Yet every nonderogatory $2 \\times 2$ matrix over $\\mathbb{F}_2$ still has a cyclic vector."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 255,
+      "endLine": 288,
+      "summary": "Recaps the result (theorem holds for all (n, q), no threshold), the 0-axiom/0-sorry status, and the seven proved lemmas: annihilator_dvd_minpoly, cyclic_iff_ann_eq_minpoly, aeval_conj, cyclic_vector_of_similar, F2_union_covers, and the two main theorems (delegating to WIP04 Bezout/CRT + WIP05 UFD factorization). Notes the removed companion-matrix lemmas that depended on a Mathlib-drift-affected file.",
+      "mathContext": "The main theorem is closed by factoring $\\mu_M = \\prod_i p_i^{e_i}$ (UFD on $K[X]$), building primary vectors, and combining via Bezout/CRT — no Rational Canonical Form needed, so the previously isolated `nonderogatory_similar_companion` sorry is eliminated."
     }
   ],
   "references": [

--- a/src/data/proofs/herons-formula-oq-01/meta.json
+++ b/src/data/proofs/herons-formula-oq-01/meta.json
@@ -62,10 +62,18 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview",
+      "startLine": 1,
+      "endLine": 29,
+      "summary": "File header and imports. Formalizes Brahmagupta's formula for the area of a cyclic quadrilateral and its reduction (d = 0) to Heron's formula, together with algebraic identities, non-negativity, special cases, an isoperimetric bound, and concrete checks. The area-equals-root identity itself is stated as an axiom (PART VII); everything else is proved.",
+      "mathContext": "Brahmagupta: a cyclic quadrilateral with sides $a,b,c,d$ and $s=(a+b+c+d)/2$ has area $\\sqrt{(s-a)(s-b)(s-c)(s-d)}$; setting $d=0$ recovers Heron's $\\sqrt{s(s-a)(s-b)(s-c)}$."
+    },
+    {
       "id": "definitions",
       "title": "Definitions",
       "startLine": 30,
-      "endLine": 41,
+      "endLine": 42,
       "summary": "Defines semiperimeter and Brahmagupta product for a quadrilateral.",
       "mathContext": "$s = (a+b+c+d)/2$, $(s-a)(s-b)(s-c)(s-d)$"
     },
@@ -80,15 +88,15 @@
     {
       "id": "heron-reduction",
       "title": "Reduction to Heron's Formula",
-      "startLine": 68,
-      "endLine": 88,
+      "startLine": 67,
+      "endLine": 86,
       "summary": "When d=0, Brahmagupta product equals Heron product: the degenerate quadrilateral is a triangle.",
       "mathContext": "$(s-a)(s-b)(s-c)(s-0) = s(s-a)(s-b)(s-c)$ with $s = (a+b+c)/2$"
     },
     {
       "id": "nonnegativity",
       "title": "Non-negativity",
-      "startLine": 90,
+      "startLine": 87,
       "endLine": 106,
       "summary": "Brahmagupta product is non-negative when all four generalized triangle inequalities hold.",
       "mathContext": "$(s-a)(s-b)(s-c)(s-d) \\geq 0$ when each side is at most the sum of the other three"
@@ -96,26 +104,34 @@
     {
       "id": "special-cases",
       "title": "Special Cases",
-      "startLine": 108,
-      "endLine": 135,
+      "startLine": 107,
+      "endLine": 133,
       "summary": "Rectangle: product = (ab)^2, area = ab. Square: product = a^4, area = a^2.",
       "mathContext": "For rectangle: $\\sqrt{(s-a)(s-b)(s-a)(s-b)} = ab$"
     },
     {
       "id": "isoperimetric",
       "title": "Isoperimetric Inequality",
-      "startLine": 137,
-      "endLine": 154,
+      "startLine": 134,
+      "endLine": 183,
       "summary": "Square maximizes area for fixed perimeter. Product <= ((a+b+c+d)/4)^4 by AM-GM.",
       "mathContext": "$(s-a)(s-b)(s-c)(s-d) \\leq \\left(\\frac{a+b+c+d}{4}\\right)^4$"
     },
     {
       "id": "axiom-examples",
-      "title": "Brahmagupta Formula and Examples",
-      "startLine": 156,
-      "endLine": 193,
-      "summary": "Axiomatized Brahmagupta formula and concrete examples: 3-4-5 triangle, unit square, 2x3 rectangle.",
-      "mathContext": "Numerical verification of the formula"
+      "title": "PART VII: The Brahmagupta Formula (Axiomatized)",
+      "startLine": 184,
+      "endLine": 204,
+      "summary": "The single axiom of the file: brahmagupta_formula asserts that the area of a cyclic quadrilateral with positive sides equals √((s−a)(s−b)(s−c)(s−d)). This is the one unproved assumption (badge: axiom, axiomCount 1) — the geometric area↔product identity — from which the surrounding algebraic results draw meaning.",
+      "mathContext": "$\\text{axiom }\\ \\mathrm{area} = \\sqrt{(s-a)(s-b)(s-c)(s-d)}$ for $a,b,c,d>0$ — the sole assumption; all other declarations are proved from Mathlib."
+    },
+    {
+      "id": "concrete-examples",
+      "title": "PART VIII: Concrete Examples",
+      "startLine": 205,
+      "endLine": 225,
+      "summary": "Numerical checks of the Brahmagupta product by `norm_num`/`decide`: the degenerate 3-4-5 triangle (product 36, area 6), the unit square (product 1, area 1), and the 2×3 rectangle (product 36, area 6).",
+      "mathContext": "$(s-a)(s-b)(s-c)(s-d)$ evaluates to $36$ for $(3,4,5,0)$, $1$ for $(1,1,1,1)$, and $36$ for $(2,3,2,3)$ — matching the known areas $6, 1, 6$."
     }
   ],
   "crossReferences": [

--- a/src/data/proofs/inclusion-exclusion-oq-04-oq-01-oq-02/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-04-oq-01-oq-02/meta.json
@@ -33,7 +33,7 @@
       "id": "partial-alternating-binomial",
       "title": "The Partial Alternating Binomial Sum",
       "startLine": 82,
-      "endLine": 111,
+      "endLine": 112,
       "mathContext": "$A(f,m) := \\sum_{j=0}^{m} (-1)^j \\binom{f}{j}, \\qquad A(0,m)=1, \\qquad A(f+1,m) = (-1)^m \\binom{f}{m}$",
       "summary": "altPartial f m is the truncated binomial expansion of (1-1)^f. altPartial_zero gives A(0,m)=1 (only the j=0 term survives). altPartial_succ is the Pascal telescoping A(f+1,m) = (-1)^m C(f,m), proved by induction on m using C(f+1,m+1) = C(f,m) + C(f,m+1); its sign (-1)^m and non-negative magnitude C(f,m) are the entire source of the Bonferroni one-sidedness."
     },
@@ -41,7 +41,7 @@
       "id": "truncated-sieve-reindex",
       "title": "The Truncated Sieve and Its Per-Permutation Reindexing",
       "startLine": 113,
-      "endLine": 229,
+      "endLine": 230,
       "mathContext": "$B(n,m) = \\sum_{k=0}^{m} (-1)^k \\binom{n}{k}(n-k)! = \\sum_{\\sigma \\in \\mathrm{Perm}(\\mathrm{Fin}\\,n)} A(f_\\sigma, m)$",
       "summary": "truncSieve_eq_subset_sum rewrites each binomial term C(n,k)(n-k)! as the sum over size-k subsets t of the crux count (-1)^|t|·#{σ fixing t pointwise}, reusing the parent's card_fixesOn. truncSieve_eq_sum_altPartial is the Fubini step: expanding the crux count as Σ_σ of indicators and exchanging the order of summation (Finset.sum_comm) lands on Σ_σ A(f_σ, m), since for fixed σ the subsets t fixed pointwise are exactly the subsets of the fixed-point set, of which there are C(f_σ, k)."
     },
@@ -49,9 +49,17 @@
       "id": "bonferroni-inequalities",
       "title": "Derangements and the Bonferroni Inequalities",
       "startLine": 231,
-      "endLine": 322,
+      "endLine": 324,
       "mathContext": "$(-1)^m\\,(B(n,m) - D_n) = \\sum_{\\sigma:\\,f_\\sigma \\ge 1} \\binom{f_\\sigma - 1}{m} \\ge 0$",
       "summary": "card_deranged_filter and numDerangements_eq_indicator_sum identify the derangements as the f=0 permutations, so D_n is the indicator sum Σ_σ [f_σ=0]. truncSieve_sub_numDerangements writes B(n,m) - D_n as Σ_σ (A(f_σ,m) - [f_σ=0]); neg_one_pow_mul_term_nonneg shows each term times (-1)^m is non-negative (0 for derangements, C(f-1,m) otherwise). The core neg_one_pow_mul_truncSieve_sub_nonneg gives (-1)^m(B-D_n) ≥ 0, whence bonferroni_even (D_n ≤ B(n,m) for even m) and bonferroni_odd (B(n,m) ≤ D_n for odd m). truncSieve_self confirms B(n,n) = D_n."
+    },
+    {
+      "id": "concrete-check",
+      "title": "Part V: Concrete Check (Axiom-Free)",
+      "startLine": 325,
+      "endLine": 358,
+      "summary": "Kernel-`decide`/`norm_num` sanity checks at n = 4: the truncated sieve values truncSieve 4 0..3 = 24, 0, 12, 8, the derangement count numDerangements 4 = 9, and the two Bonferroni bounds numDerangements 4 ≤ truncSieve 4 2 and truncSieve 4 3 ≤ numDerangements 4 — instantiating the even/odd inequalities. All by `decide`, so axiom-free (no native_decide).",
+      "mathContext": "$B(4,0)=24,\\ B(4,1)=0,\\ B(4,2)=12,\\ B(4,3)=8$ and $D_4=9$, illustrating $B(4,3) \\le D_4 \\le B(4,2)$ — the odd truncation under- and the even truncation over-estimates the derangement count."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/minkowski-fundamental-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-01-oq-01/meta.json
@@ -84,6 +84,14 @@
       "endLine": 195,
       "summary": "secondTheorem_lower_statement (companion scaffold), firstMinimum_pow_volume_le_of_secondTheorem (upper bound ⟹ λ₀ⁿ·vol ≤ 2ⁿ·covol), lower_le_lastMinimum_pow_volume_of_secondTheorem (lower bound ⟹ (2ⁿ/n!)·covol ≤ λₙ₋₁ⁿ·vol).",
       "mathContext": "Multiplying the bracket by the positive volume and chaining with the (granted) product bound reduces each side of Minkowski's two-sided second theorem to a statement about a single extreme minimum."
+    },
+    {
+      "id": "summary",
+      "title": "Summary: Bracketing the Product of Successive Minima",
+      "startLine": 196,
+      "endLine": 230,
+      "summary": "Recaps the 0-sorry, 0-axiom development: the extreme indices botIndex/topIndex, the order chain λ₀ ≤ λᵢ ≤ λₙ₋₁, non-negativity of the product, the bracketing λ₀ⁿ ≤ ∏ᵢ λᵢ ≤ λₙ₋₁ⁿ, and the reduction of Minkowski's second theorem to single-minimum volume bounds. States the honest scope: the analytic product bound itself is NOT proved here — only its order-theoretic bracketing and the reduction to single-minimum statements.",
+      "mathContext": "Delivered: $\\lambda_0^n \\le \\prod_i \\lambda_i \\le \\lambda_{n-1}^n$ and, granting the second theorem, $\\lambda_0^n\\,\\mathrm{vol}(S) \\le 2^n\\,\\mathrm{covol}(L)$ and $\\tfrac{2^n}{n!}\\,\\mathrm{covol}(L) \\le \\lambda_{n-1}^n\\,\\mathrm{vol}(S)$. Open: the product bound $\\prod_i \\lambda_i \\cdot \\mathrm{vol}(S) \\asymp \\mathrm{covol}(L)$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Section-coverage enrichment pass — re-anchor drifted/undercovered `sections` to cover the full Lean file (1..EOF). Pure `sections` edits; no `status`/`badge`/`axiomCount` changes (counts verified accurate). Diffs touch only the `sections` array; existing `summary`/`mathContext` preserved, only `startLine`/`endLine` re-anchored plus new head/tail/interior sections. Contiguity (`gap ∈ [0,2]`) and `maxEnd === wc` asserted programmatically.

**inclusion-exclusion-oq-04-oq-01-oq-02** (4→5 sections, covers 1..358)
- Added the uncovered **Part V: Concrete Check (axiom-free)** tail (325–358) — the `decide`/`norm_num` sanity checks at n = 4. 0-axiom `original` unchanged.

**cayley-hamilton-minpoly-oq-05-oq-01-oq-04** (5→7 sections, covers 1..288)
- Added an Overview head (1–44), extended § III to its true end (207, `cyclic_iff_ann_eq_minpoly`), and added the uncovered `## Summary` tail (255–288). 0-axiom `mathlib` unchanged.

**minkowski-fundamental-theorem-oq-01-oq-01** (5→6 sections, covers 1..230)
- Added the uncovered `## Summary` tail (196–230). 0-axiom `original` unchanged.

**herons-formula-oq-01** (7→9 sections, covers 1..225)
- The "axiom-examples" section was **mis-anchored** at 156–193 (that range is the tail of the isoperimetric proof); the actual axiom (`brahmagupta_formula`, PART VII) is at 184–204 and the concrete examples (PART VIII) at 205–225. Re-anchored: added an Overview head (1–29), extended the isoperimetric section to its true end (183), retitled the drifted section to **PART VII: The Brahmagupta Formula (Axiomatized)** (184–204), and split off **PART VIII: Concrete Examples** (205–225).
- `badge:axiom` / axiomCount 1 unchanged (`brahmagupta_formula` is a genuine `axiom`).
