### PR TITLE
Audit: brouwer-oq001 (re-add) + burnside-counting-oq002 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30716,6 +30716,18 @@
       "lastAudited": "2026-07-21T09:48:35Z",
       "result": "clean",
       "issues": []
+    },
+    "brouwer-fixed-point-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T09:49:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "burnside-counting-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T09:50:11Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Re-adds brouwer-fixed-point-oq001 (dropped by a tracker merge-race in #40344) and marks burnside-counting-oq002 clean (verified/original, 0 axioms/sorries, no real native_decide, 7 substantive theorems).

🤖 Generated with [Claude Code](https://claude.com/claude-code)