### PR TITLE
Enrich 2 entries: re-anchor drifted sections to banners (1..EOF)

### DIFF
--- a/src/data/proofs/cevas-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-01-oq-03/meta.json
@@ -82,42 +82,50 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview: Routh’s Theorem for the Standard Triangle",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "File docstring and setup: the standard triangle A=(0,0), B=(1,0), C=(0,1) with cevian parameters d, e, f ∈ (0,1), and the goal — Routh’s theorem giving the area of the inner cevian triangle PQR as an explicit rational function of d, e, f, verified with 0 axioms and 0 sorries.",
+      "mathContext": "For cevian parameters $d,e,f\\in(0,1)$ on the standard triangle, Routh’s theorem gives $\\frac{[PQR]}{[ABC]} = \\frac{(def-(1-d)(1-e)(1-f))^2}{(1-e+de)(1-f+ef)(1-d+fd)}$."
+    },
+    {
       "id": "denominators",
       "title": "Denominator Positivity",
-      "startLine": 40,
-      "endLine": 54,
+      "startLine": 44,
+      "endLine": 59,
       "summary": "Three positivity lemmas: w₁ = 1-e+de > 0, w₂ = 1-f+ef > 0, w₃ = 1-d+fd > 0. Proved by nlinarith from d,e,f ∈ (0,1).",
       "mathContext": "$w_1 = 1-e+de = 1-e(1-d) > 0$ for $d,e \\in (0,1)$."
     },
     {
       "id": "vertices",
       "title": "Inner Triangle Vertex Formulas",
-      "startLine": 56,
-      "endLine": 70,
+      "startLine": 60,
+      "endLine": 75,
       "summary": "Explicit coordinates of P (AD∩BE), Q (BE∩CF), R (CF∩AD) as rational functions of d, e, f.",
       "mathContext": "$P = \\left(\\frac{(1-d)(1-e)}{w_1}, \\frac{d(1-e)}{w_1}\\right)$, $Q = \\left(\\frac{ef}{w_2}, \\frac{(1-e)(1-f)}{w_2}\\right)$, $R = \\left(\\frac{f(1-d)}{w_3}, \\frac{fd}{w_3}\\right)$."
     },
     {
       "id": "membership",
       "title": "Cevian Membership Proofs",
-      "startLine": 72,
-      "endLine": 128,
+      "startLine": 76,
+      "endLine": 133,
       "summary": "Six membership theorems proving P ∈ AD∩BE, Q ∈ BE∩CF, R ∈ CF∩AD. Each uses an explicit parameter witness and field_simp + ring.",
       "mathContext": "P lies on AD with parameter $t = (1-e)/w_1$, and on BE with parameter $t = d/w_1$."
     },
     {
       "id": "main",
       "title": "Routh's Theorem — Main Formula",
-      "startLine": 130,
-      "endLine": 151,
+      "startLine": 134,
+      "endLine": 177,
       "summary": "routh_theorem_std: signedArea(P,Q,R) = routhRatio(d,e,f) × signedArea(A,B,C). Proved by field_simp + ring after establishing denominator nonvanishing.",
       "mathContext": "$\\frac{\\text{Area}(PQR)}{\\text{Area}(ABC)} = \\frac{(def-(1-d)(1-e)(1-f))^2}{w_1 w_2 w_3}$."
     },
     {
       "id": "applications",
       "title": "Corollaries and Applications",
-      "startLine": 153,
-      "endLine": 228,
+      "startLine": 178,
+      "endLine": 260,
       "summary": "Explicit area form, 1/7 verification (d=e=f=1/3), concurrent degeneration (area=0 iff Ceva), nonnegativity, asymmetric example (1/10), zero condition equivalence.",
       "mathContext": "Special case $d=e=f=1/3$: $\\text{Area}(PQR)/\\text{Area}(ABC) = 1/7$. Ceva condition gives ratio $= 0$."
     }

--- a/src/data/proofs/erdos-679/meta.json
+++ b/src/data/proofs/erdos-679/meta.json
@@ -115,91 +115,107 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview",
+      "startLine": 1,
+      "endLine": 29,
+      "summary": "File header and imports. Erdős #679 asks, for the number-of-distinct-prime-factors function ω(n), whether infinitely many n admit some k with ω(n−k) exceeding the (1+ε)·log k/log log k threshold. This WIP file lays out the ω/Ω machinery, the main conjecture, the disproven stronger form, special cases, heuristics, and the density dichotomy.",
+      "mathContext": "$\\omega(n) = |\\{p : p \\mid n\\}|$; normal order $\\omega(n)\\sim \\log\\log n$ (Hardy–Ramanujan). The question concerns large values of $\\omega(n-k)$ relative to $(1+\\varepsilon)\\log k/\\log\\log k$."
+    },
+    {
       "id": "omega",
       "title": "The ω Function",
       "summary": "Defines ω(n) = |primeFactors(n)| via `Nat.primeFactors.card`. Proves ω(1) = 0, ω(p) = 1, ω(p^k) = 1, and additivity ω(mn) = ω(m) + ω(n) for coprime m, n.",
       "startLine": 30,
-      "endLine": 52,
+      "endLine": 58,
       "mathContext": "Formal definition: Defines ω(n) = |primeFactors(n)| via `Nat.primeFactors.card`. Proves ω(1) = 0, ω(p) = 1, ω(p^k) = 1, and additivity ω(mn) = ω(m) + ω(n) for coprime m, n."
     },
     {
       "id": "hardy-ramanujan",
       "title": "Hardy-Ramanujan Normal Order",
       "summary": "Formalizes the normal order theorem: ω(n) ~ log log n for almost all n. Also bounds the maximum: max ω(n≤x) ≤ 2 log x / log log x.",
-      "startLine": 53,
-      "endLine": 73,
+      "startLine": 59,
+      "endLine": 79,
       "mathContext": "Formalizes the normal order theorem: ω(n) ~ log $\\log n$ for almost all n. Also bounds the maximum: max ω(n$\\leq$x) $\\leq$ 2 log x / log log x."
     },
     {
       "id": "main",
       "title": "The Main Question",
       "summary": "Defines the threshold (1+ε) log k / log log k, the SatisfiesProperty predicate, and the MainConjecture: infinitely many n satisfy the property. Notes the problem is OPEN.",
-      "startLine": 74,
-      "endLine": 91,
+      "startLine": 80,
+      "endLine": 97,
       "mathContext": "Formal definition: Defines the threshold (1+ε) log k / log log k, the SatisfiesProperty predicate, and the MainConjecture: infinitely many n satisfy the property. Notes the problem is OPEN."
     },
     {
       "id": "stronger",
       "title": "Stronger Version (Disproven)",
       "summary": "Defines StrongerVersion with O(1) error and proves it FALSE. Gives quantitative lower bound: ∃ c > 0, ∀ large n, ∃ k: ω(n-k) ≥ threshold + c·log k/(log log k)².",
-      "startLine": 92,
-      "endLine": 110,
+      "startLine": 98,
+      "endLine": 116,
       "mathContext": "Defines StrongerVersion with $O(1)$ error and proves it FALSE. Gives quantitative lower bound: ∃ c > 0, ∀ large n, ∃ k: ω(n-k) $\\geq$ threshold + c·log k/(log log k)²."
     },
     {
       "id": "bigomega",
       "title": "The Ω Function Variant",
       "summary": "Defines Ω(n) counting prime factors with multiplicity, proves Ω ≥ ω, and states the analogous question with threshold log₂ k.",
-      "startLine": 111,
-      "endLine": 129,
+      "startLine": 117,
+      "endLine": 143,
       "mathContext": "Defines Ω(n) counting prime factors with multiplicity, proves Ω $\\geq$ ω, and states the analogous question with threshold log₂ k."
     },
     {
       "id": "special",
       "title": "Special Cases",
       "summary": "Analyzes n = 2^m (powers of 2) and n = primorial(r) = p₁···pᵣ. Shows both fail the property — some k always gives large ω(n-k).",
-      "startLine": 130,
-      "endLine": 144,
+      "startLine": 144,
+      "endLine": 180,
       "mathContext": "Analyzes n = $2^{m}$ (powers of 2) and n = primorial(r) = p₁···pᵣ. Shows both fail the property — some k always gives large ω(n-k)."
     },
     {
       "id": "lower",
       "title": "Lower Bounds",
       "summary": "For any n ≥ 10, some k gives ω(n-k) ≥ (log log n)/2. The set of k with ω(n-k) ≤ 2 has density < 1.",
-      "startLine": 145,
-      "endLine": 158,
+      "startLine": 181,
+      "endLine": 194,
       "mathContext": "For any n $\\geq$ 10, some k gives ω(n-k) $\\geq$ (log $\\log n$)/2. The set of k with ω(n-k) $\\leq$ 2 has density < 1."
     },
     {
       "id": "related",
       "title": "Related Problems",
       "summary": "Placeholder connections to Problem #248 (bounded ω(n+k), solved by Tao-Teräväinen) and Problem #413 (ω-barriers).",
-      "startLine": 159,
-      "endLine": 168,
+      "startLine": 195,
+      "endLine": 204,
       "mathContext": "Bound: Placeholder connections to Problem #248 (bounded ω(n+k), solved by Tao-Teräväinen) and Problem #413 (ω-barriers)."
     },
     {
       "id": "heuristics",
       "title": "Probabilistic Heuristics",
       "summary": "Random n should not satisfy the property. Expected count of special n ≤ x is heuristically ~ x/log x. Computational evidence: no n ≤ 10^6 satisfies the property for ε = 0.1.",
-      "startLine": 169,
-      "endLine": 189,
+      "startLine": 205,
+      "endLine": 215,
       "mathContext": "Random n should not satisfy the property. Expected count of special n $\\leq$ x is heuristically ~ x/log x. Computational evidence: no n $\\leq$ $10^{6}$ satisfies the property for ε = 0.1."
+    },
+    {
+      "id": "computational",
+      "title": "Part X: Computational Evidence",
+      "startLine": 216,
+      "endLine": 225,
+      "summary": "The ComputationalEvidence predicate and smallestExample : Option ℕ record that no n ≤ 10⁶ satisfies the property in exhaustive search — consistent with the heuristic that special n, if any, are very sparse.",
+      "mathContext": "No $n \\le 10^6$ realizes the threshold-exceeding property; `smallestExample = none` at the searched range, supporting zero (or near-zero) density."
     },
     {
       "id": "dichotomy",
       "title": "Key Dichotomy",
       "summary": "Either infinitely many special n exist (MainConjecture) or there is a uniform lower bound: ∀ large n, ∃ k with ω(n-k) ≥ (1+c) threshold.",
-      "startLine": 190,
-      "endLine": 198,
+      "startLine": 226,
+      "endLine": 234,
       "mathContext": "Either infinitely many special n exist (MainConjecture) or there is a uniform lower bound: ∀ large n, ∃ k with ω(n-k) $\\geq$ (1+c) threshold."
     },
     {
       "id": "density",
       "title": "Density Considerations",
       "summary": "If special n exist, their count is at most x/log x (zero density). Asks whether density is even x^α for α < 1.",
-      "startLine": 199,
-      "endLine": 251,
+      "startLine": 235,
+      "endLine": 285,
       "mathContext": "Mathematical content: If special n exist, their count is at most x/log x (zero density). Asks whether density is even x^α for α < 1."
     }
   ],


### PR DESCRIPTION
Section-coverage enrichment pass — re-anchor drifted `sections` to the author's own banners and cover the full Lean file (1..EOF). Pure `sections` edits; existing `summary`/`mathContext` preserved (only `startLine`/`endLine` re-anchored plus new head/interior sections). No `status`/`badge`/`axiomCount` changes. Contiguity (`gap ∈ [0,2]`) and `maxEnd === wc` asserted programmatically.

**cevas-theorem-oq-01-oq-03** (5→6 sections, covers 1..260)
- Added an Overview head (1–43). Fixed the PART IV/V boundary: `routh_theorem_std` (the main Routh formula) sat in the "Corollaries" section though it is PART IV — re-anchored PART IV to 134–177 and PART V (Corollaries) to 178–260, which also covers the previously-uncovered tail corollaries (`routhRatio_nonneg`, `routh_asymmetric_example`, `routh_zero_iff`). 0-axiom `original` unchanged.

**erdos-679** (11→13 sections, covers 1..285)
- Full drift re-anchor: every section title was ~30–40 lines ahead of its actual `/- ## Part N -/` banner (e.g. "Lower Bounds" was pinned at 145–158 but PART VII is at 181). Re-anchored all twelve parts to their banners, added an Overview head (1–29) and the missing **Part X: Computational Evidence** (216–225), and covered the PART XII density tail (252–285). 0-axiom `wip` unchanged.
