### PR TITLE
Enrich 3 entries: cover uncovered conjecture/summary tails (1..EOF)

### DIFF
--- a/src/data/proofs/collatz-cycles/meta.json
+++ b/src/data/proofs/collatz-cycles/meta.json
@@ -62,45 +62,53 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview",
+      "startLine": 1,
+      "endLine": 26,
+      "summary": "File header and imports. OQ-02 studies cycles of the Collatz map: the file proves the map has no fixed points and no 2-cycles (over ℕ, forcing n = 0), identifies the unique 1→4→2→1 cycle through 1, establishes structural monotonicity/contraction facts, the 2^M > 3^j halving constraint on hypothetical cycle lengths, and native_decide verification that 1–20 all reach 1.",
+      "mathContext": "Collatz map $T(n) = n/2$ if $n$ even, $3n+1$ if $n$ odd. The Collatz conjecture asserts every orbit reaches 1; this file proves no short cycles exist and the arithmetic constraint $2^M > 3^j$ any nontrivial cycle would need."
+    },
+    {
       "id": "section-collatz-def",
       "title": "Part I: The Collatz Function and Iteration Framework",
       "startLine": 27,
-      "endLine": 51,
+      "endLine": 52,
       "summary": "Defines collatz (parity split: n/2 or 3n+1), proves simp lemmas (collatz_zero, collatz_one, collatz_even, collatz_odd, collatz_two_mul), defines collatzIter using Function.iterate, and defines IsPeriodic as the conjunction k ≥ 1 ∧ collatzIter k n = n."
     },
     {
       "id": "section-no-fixpoint",
       "title": "Part II: No Fixed Points",
       "startLine": 53,
-      "endLine": 64,
+      "endLine": 65,
       "summary": "collatz_no_fixpoint: collatz(n) = n implies n = 0. Proof by contradiction with parity case analysis: even n gives n/2 = n → n = 0; odd n gives 3n+1 = n → n = -1, impossible in ℕ."
     },
     {
       "id": "section-no-two-cycle",
       "title": "Part III: No 2-Cycles",
       "startLine": 66,
-      "endLine": 88,
+      "endLine": 89,
       "summary": "collatz_no_two_cycle: collatz²(n) = n implies n = 0. Nested parity analysis: 3 cases (even/even, even/odd, odd). Odd case: (3n+1)/2 = n requires n = -1; even/even: n/4 = n requires n = 0; even/odd: 3(n/2)+1 = n requires n = -2."
     },
     {
       "id": "section-period-three",
       "title": "Part IV: The Unique Cycle Through 1",
       "startLine": 90,
-      "endLine": 112,
+      "endLine": 113,
       "summary": "orbit_of_one (native_decide: 1→4→2→1), one_period_is_three (IsPeriodic 1 3 ∧ minimality via interval_cases k ∈ {1,2}), orbit_one_elements (all three steps by simp [collatz]). Establishes {1,2,4} as the unique known Collatz cycle."
     },
     {
       "id": "section-structural",
       "title": "Part V: Structural Properties — Monotonicity and 3/4 Contraction",
       "startLine": 114,
-      "endLine": 152,
+      "endLine": 153,
       "summary": "collatz_odd_growth (odd n → collatz(n) > n), collatz_even_decrease (even n ≥ 2 → collatz(n) < n), odd_step_halve_le (one-step bound). three_steps_mod4_eq1 computes 3 steps for n ≡ 1 mod 4 → (3n+1)/4. three_quarter_contraction proves (3n+1)/4 < n for n ≥ 2, establishing local contraction."
     },
     {
       "id": "section-halving",
       "title": "Part VI: The 2^M > 3^j Halving Constraint",
       "startLine": 154,
-      "endLine": 189,
+      "endLine": 190,
       "summary": "min_halvings_j_odd for j = 1,2,3,4: proves 2^M > 3^j → M ≥ ⌈j·log₂3⌉ via interval_cases. min_cycle_length_j1 through j4: minimum cycle period = j + M ≥ 3, 6, 8, 11 respectively. Establishes Lagarias-Eliahou type constraints on hypothetical non-trivial cycles."
     },
     {
@@ -109,6 +117,14 @@
       "startLine": 191,
       "endLine": 222,
       "summary": "ReachesOne n := ∃ k, collatzIter k n = 1. small_numbers_reach_one: proves all n ∈ [1,20] reach 1 by interval_cases + providing explicit step counts (0 to 20) with native_decide verification."
+    },
+    {
+      "id": "summary",
+      "title": "Part VIII: Summary and Verification",
+      "startLine": 223,
+      "endLine": 257,
+      "summary": "Recaps the results (no fixed points, no 2-cycles, the unique cycle through 1, structural contraction, the 2^M > 3^j length constraint, and small-number verification) and the final #print axioms verification block confirming the axiom-free status.",
+      "mathContext": "Summary of the eight parts: over ℕ the only Collatz cycle reachable here is $1 \\to 4 \\to 2 \\to 1$; any hypothetical odd cycle with $j$ odd steps needs $M \\ge \\lceil j\\log_2 3\\rceil$ halvings, and $n = 1,\\dots,20$ all reach 1."
     }
   ],
   "crossReferences": [

--- a/src/data/proofs/erdos-1055/meta.json
+++ b/src/data/proofs/erdos-1055/meta.json
@@ -72,7 +72,7 @@
       "id": "verified-values",
       "title": "Verified Class Values and Least Primes",
       "startLine": 93,
-      "endLine": 129,
+      "endLine": 130,
       "summary": "Verifies $c(2)=1, c(13)=2, c(37)=3, c(73)=4, c(1021)=5$ by $\\texttt{native\\_decide}$. Confirms least primes $p_r$ from OEIS A005113. All computed without axioms.",
       "mathContext": "$c(2) = 1$ ($3 = 3^1$), $c(13) = 2$ ($14 = 2 \\cdot 7$, $c(7) = 1$ since $8 = 2^3$), $c(37) = 3$ ($38 = 2 \\cdot 19$, $c(19) = 2$ since $20 = 2^2 \\cdot 5$, $c(5) = 1$ since $6 = 2 \\cdot 3$). Chain: $p_r^{1/r} \\in \\{2, 3.61, 3.33, 2.92, 4.01\\}$."
     },
@@ -80,17 +80,25 @@
       "id": "structural",
       "title": "Structural Properties and Concrete Evidence",
       "startLine": 131,
-      "endLine": 200,
+      "endLine": 207,
       "summary": "Proves key structural results: class monotonicity ($c(q) < c(p)$ for nonSmooth factors), class-1 characterization ($c(p)=1 \\iff p+1$ is $3$-smooth), positivity ($c(p) \\ge 1$ for primes), and concrete evidence for infinitude (counting primes in classes 1-3 via native_decide).",
       "mathContext": "Monotonicity: $q \\mid (p+1), q \\notin \\{2,3\\} \\implies c(q) < c(p)$. Class-1 characterization: $c(p) = 1 \\iff p + 1 = 2^a \\cdot 3^b$ ($p+1$ is 3-smooth). Positivity: $c(p) \\geq 1$ for all primes $p$."
     },
     {
       "id": "conjectures",
       "title": "Main Conjectures (OPEN)",
-      "startLine": 202,
-      "endLine": 222,
+      "startLine": 208,
+      "endLine": 233,
       "summary": "States the four OPEN conjectures as axioms: infinitude of each class, Erdős growth conjecture ($p_r^{1/r} \\to \\infty$), Selfridge bounded conjecture ($p_r^{1/r}$ bounded), and subpolynomial density of each class. Note Erdős and Selfridge conjectures are mutually exclusive.",
       "mathContext": "Four axioms: (1) $|\\{p \\leq n : c(p) = r\\}| \\to \\infty$; (2) Erdős: $p_r^{1/r} \\to \\infty$; (3) Selfridge: $\\exists C, p_r^{1/r} \\leq C$; (4) $|\\{p \\leq n : c(p) = r\\}| = n^{o(1)}$. Note (2) and (3) are mutually exclusive."
+    },
+    {
+      "id": "mutex-density",
+      "title": "Mutual Exclusivity and Sub-Polynomial Density",
+      "startLine": 234,
+      "endLine": 255,
+      "summary": "erdos_selfridge_mutex proves the Erdős growth conjecture and Selfridge boundedness conjecture cannot both hold (they force contradictory asymptotics for the least prime in each class), and class_density_subpolynomial is the axiom asserting each class has sub-polynomial counting density.",
+      "mathContext": "The two conjectures are mutually exclusive: unbounded growth of the least class-r prime (Erdős) contradicts a uniform bound (Selfridge). The density axiom posits $\\#\\{p \\le x : c(p)=r\\} = x^{o(1)}$ for each fixed class $r \\ge 1$."
     }
   ],
   "overview": {

--- a/src/data/proofs/partition-theorem-oq-02/meta.json
+++ b/src/data/proofs/partition-theorem-oq-02/meta.json
@@ -83,14 +83,14 @@
       "title": "The Two Families and Glaisher's Bridge",
       "summary": "Recalls Mathlib's restricted n (¬ m ∣ ·) (no part divisible by m) and countRestricted n m (each part used < m times), and Glaisher's theorem equating their cardinalities. The repetition family countRestricted is nested in its bound m, which countRestricted_mono records.",
       "startLine": 70,
-      "endLine": 84
+      "endLine": 86
     },
     {
       "id": "main-monotonicity",
       "title": "Modulus Monotonicity via Glaisher",
       "summary": "card_restricted_not_dvd_mono: for 0 < m ≤ m', #(restricted n (¬ m ∣ ·)) ≤ #(restricted n (¬ m' ∣ ·)). Proved by rewriting both sides through Glaisher's equality to the nested repetition family and applying card_le_card. The divisibility families themselves are incomparable, so Glaisher is essential.",
       "startLine": 87,
-      "endLine": 95
+      "endLine": 96
     },
     {
       "id": "consequences",
@@ -98,6 +98,14 @@
       "summary": "Names the m=3 Glaisher identity, then specializes the monotonicity at 2 ≤ 3 to bound Euler's odd-part count, and restates it on the distinct-parts side via Euler's theorem.",
       "startLine": 97,
       "endLine": 122
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 123,
+      "endLine": 153,
+      "summary": "Recaps the 0-axiom (beyond Mathlib foundations), 0-sorry results: countRestricted_mono, card_restricted_not_dvd_mono (modulus monotonicity), the m = 3 Glaisher identity, and the Euler odd/distinct bounds. States the structural point — the divisibility-restricted families {no part divisible by m} are pairwise incomparable, so count-monotonicity is invisible on the divisibility side and is recovered by transporting through Glaisher to the nested repetition-restricted families. Ends with #print axioms verification.",
+      "mathContext": "Monotonicity $\\#R_m(n) \\le \\#R_{m'}(n)$ for $0 < m \\le m'$ (with $R_m = \\{$no part divisible by $m\\}$) is not visible directly (the $R_m$ are incomparable); Glaisher's bijection to $\\{$each part used $< m$ times$\\}$, which ARE nested, supplies it."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Section-coverage enrichment pass — cover uncovered conjecture/summary tails and extend drifted sections to 1..EOF. Pure `sections` edits; existing `summary`/`mathContext` preserved (only `startLine`/`endLine` re-anchored plus new tail/head sections). No `status`/`badge`/`axiomCount` changes. Contiguity (`gap ∈ [0,2]`) and `maxEnd === wc` asserted programmatically.

**erdos-1055** (6→7 sections, covers 1..255)
- Extended the "Structural Properties" section to include the concrete-evidence theorems (`many_class1/2/3_primes`), re-anchored "Main Conjectures" to its banner, and added a **Mutual Exclusivity and Sub-Polynomial Density** tail (234–255): the proved `erdos_selfridge_mutex` and the `class_density_subpolynomial` axiom, which were entirely uncovered.

**collatz-cycles** (7→9 sections, covers 1..257)
- Added an Overview head (1–26) and the uncovered **Part VIII: Summary and Verification** tail (223–257, including the `#print axioms` block).

**partition-theorem-oq-02** (4→5 sections, covers 1..153)
- Added the uncovered `## Summary` tail (123–153) recapping the modulus-monotonicity result and the Glaisher bridge, plus the `#print axioms` verification.
