### PR TITLE
Enrich 3 entries: re-anchor drifted/scrambled sections to 1..EOF

### DIFF
--- a/src/data/proofs/erdos-113/meta.json
+++ b/src/data/proofs/erdos-113/meta.json
@@ -80,75 +80,83 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "Module docstring: Erdos Problem #113 asks whether extremal numbers $\\mathrm{ex}(n;F)$ with the Erdos-Simonovits rational-exponent property force $F$ to be $2$-degenerate. States the conjecture, its 2023 disproof by Janzer, and the related Erdos problems #146/#147.",
+      "mathContext": "Erdos-Simonovits: $\\mathrm{ex}(n;F)=\\Theta(n^{\\alpha})$ with $\\alpha$ rational $\\Rightarrow F$ bipartite $2$-degenerate. Janzer (2023) disproves the general form."
+    },
+    {
       "id": "extremal-numbers",
       "title": "Extremal Numbers",
       "summary": "extremalNumber axiom, monotonicity, trivial upper bound",
-      "startLine": 42,
-      "endLine": 64,
+      "startLine": 43,
+      "endLine": 67,
       "mathContext": "Axiomatized: extremalNumber axiom, monotonicity, trivial upper bound"
     },
     {
       "id": "degeneracy",
       "title": "Graph Degeneracy",
       "summary": "isDegenerate axiom, existence, monotonicity, 2-degenerate characterization",
-      "startLine": 65,
-      "endLine": 90,
+      "startLine": 68,
+      "endLine": 98,
       "mathContext": "Axiomatized: isDegenerate axiom, existence, monotonicity, 2-degenerate characterization"
     },
     {
       "id": "bipartite",
       "title": "Bipartite Graphs",
       "summary": "isBipartite axiom, complete bipartite encoding, properties",
-      "startLine": 91,
-      "endLine": 108,
+      "startLine": 99,
+      "endLine": 118,
       "mathContext": "Axiomatized: isBipartite axiom, complete bipartite encoding, properties"
     },
     {
       "id": "kst-theorem",
       "title": "Kővári-Sós-Turán Theorem",
       "summary": "Upper bound for complete bipartite subgraphs, C_4 special case",
-      "startLine": 109,
-      "endLine": 129,
+      "startLine": 119,
+      "endLine": 142,
       "mathContext": "Bound: Upper bound for complete bipartite subgraphs, C_4 special case"
     },
     {
       "id": "asymptotics",
       "title": "Asymptotic Notation",
       "summary": "AsympLe definition, ≪ notation, transitivity for exponents",
-      "startLine": 130,
-      "endLine": 143,
+      "startLine": 143,
+      "endLine": 163,
       "mathContext": "Formal definition: AsympLe definition, ≪ notation, transitivity for exponents"
     },
     {
       "id": "conjecture",
       "title": "Erdős-Simonovits Conjecture",
       "summary": "ErdosSimonovitsConjecture definition, forward direction, backward direction (false)",
-      "startLine": 144,
-      "endLine": 180,
+      "startLine": 164,
+      "endLine": 198,
       "mathContext": "Formal definition: ErdosSimonovitsConjecture definition, forward direction, backward direction (false)"
     },
     {
       "id": "janzer",
       "title": "Janzer's Counterexample",
       "summary": "3-regular graphs not 2-degenerate, Janzer theorem, beats threshold",
-      "startLine": 181,
-      "endLine": 222,
+      "startLine": 199,
+      "endLine": 250,
       "mathContext": "Verified: 3-regular graphs not 2-degenerate, Janzer theorem, beats threshold"
     },
     {
       "id": "related",
       "title": "Related Results",
       "summary": "Füredi tight bounds, Erdős #146 Zarankiewicz, Erdős #147 Turán exponents",
-      "startLine": 223,
-      "endLine": 244,
+      "startLine": 251,
+      "endLine": 277,
       "mathContext": "Bound: Füredi tight bounds, Erdős #146 Zarankiewicz, Erdős #147 Turán exponents"
     },
     {
       "id": "main-theorem",
-      "title": "Main Results",
+      "title": "Part IX: Main Results Summary",
       "summary": "erdos_113 theorem (¬ErdosSimonovitsConjecture), forward still true, prize claimed",
-      "startLine": 245,
-      "endLine": 271,
+      "startLine": 278,
+      "endLine": 304,
       "mathContext": "Verified: erdos_113 theorem (¬ErdosSimonovitsConjecture), forward still true, prize claimed"
     }
   ],

--- a/src/data/proofs/erdos-230/meta.json
+++ b/src/data/proofs/erdos-230/meta.json
@@ -36,72 +36,72 @@
       "id": "imports-setup",
       "title": "Imports and Setup",
       "summary": "Imports Mathlib's complex analysis, normed fields, $\\sqrt{\\cdot}$, and Finset. Opens `Complex` and `Finset` namespaces within `Erdos230`.",
-      "startLine": 32,
-      "endLine": 42,
+      "startLine": 1,
+      "endLine": 43,
       "mathContext": "Mathematical content: Imports Mathlib's complex analysis, normed fields, $\\sqrt{\\cdot}$, and Finset. Opens `Complex` and `Finset` namespaces within `Erdos230`."
     },
     {
       "id": "unimodular",
       "title": "Unimodular Polynomials",
       "summary": "Defines the `UnimodularPolynomial` structure ($a_k \\in S^1$), polynomial evaluation $P(z) = \\sum a_k z^{k+1}$, and the sup norm $\\|P\\|_\\infty = \\sup_{|z|=1} |P(z)|$.",
-      "startLine": 43,
-      "endLine": 68,
+      "startLine": 44,
+      "endLine": 69,
       "mathContext": "Formal definition: Defines the `UnimodularPolynomial` structure ($a_k \\in S^1$), polynomial evaluation $P(z) = \\sum a_k z^{k+1}$, and the sup norm $\\|P\\|_\\infty = \\sup_{|z|=1} |P(z)|$."
     },
     {
       "id": "parseval",
       "title": "Parseval's Identity and Lower Bound",
       "summary": "Defines $L^2$ norm ($= \\sqrt{n}$ for unimodular $P$), proves Parseval's identity $\\|P\\|_2^2 = n$, and states the trivial lower bound $\\|P\\|_\\infty \\geq \\sqrt{n}$.",
-      "startLine": 69,
-      "endLine": 96,
+      "startLine": 70,
+      "endLine": 106,
       "mathContext": "Formal definition: Defines $L^2$ norm ($= \\sqrt{n}$ for unimodular $P$), proves Parseval's identity $\\|P\\|_2^2 = n$, and states the trivial lower bound $\\|P\\|_\\infty \\geq \\sqrt{n}$."
     },
     {
       "id": "conjecture",
       "title": "The False Erdős-Newman Conjecture",
       "summary": "Defines the conjecture $\\exists c > 0, \\forall P \\in \\mathcal{U}_n : \\|P\\|_\\infty \\geq (1+c)\\sqrt{n}$ and states its negation. The proof of falsity relies on Kahane's ultraflat construction.",
-      "startLine": 97,
-      "endLine": 120,
+      "startLine": 107,
+      "endLine": 128,
       "mathContext": "Formal definition: Defines the conjecture $\\exists c > 0, \\forall P \\in \\mathcal{U}_n : \\|P\\|_\\infty \\geq (1+c)\\sqrt{n}$ and states its negation. The proof of falsity relies on Kahane's ultraflat construction."
     },
     {
       "id": "kahane",
       "title": "Kahane's Ultraflat Polynomials (1980)",
       "summary": "Defines $\\varepsilon$-ultraflatness: $(1-\\varepsilon)\\sqrt{n} \\leq |P(z)| \\leq (1+\\varepsilon)\\sqrt{n}$ for all $|z|=1$. States Kahane's existence theorem and derives the disproof of the Erdős-Newman conjecture.",
-      "startLine": 121,
-      "endLine": 156,
+      "startLine": 129,
+      "endLine": 190,
       "mathContext": "Defines $\\varepsilon$-ultraflatness: $(1-\\varepsilon)\\sqrt{n} \\leq |P(z)| \\leq (1+\\varepsilon)\\sqrt{n}$ for all $|z|=1$. States Kahane's existence theorem and derives the disproof of the Erdős-Newman conjecture."
     },
     {
       "id": "korner",
       "title": "Körner's Construction (1980)",
       "summary": "Körner's stepping-stone result: unimodular polynomials with $c_1\\sqrt{n} \\leq |P(z)| \\leq c_2\\sqrt{n}$, achieving bounded oscillation ratio but not ultraflat behavior.",
-      "startLine": 158,
-      "endLine": 165,
+      "startLine": 191,
+      "endLine": 199,
       "mathContext": "Bound: Körner's stepping-stone result: unimodular polynomials with $c_1\\sqrt{n} \\leq |P(z)| \\leq c_2\\sqrt{n}$, achieving bounded oscillation ratio but not ultraflat behavior."
     },
     {
       "id": "bombieri-bourgain",
       "title": "Bombieri-Bourgain Improvement (2009)",
       "summary": "Quantitative ultraflat bound: $|P(z)| = \\sqrt{n} + O(n^{7/18} (\\log n)^{O(1)})$. Records the error exponent $7/18 \\approx 0.389$ as a rational constant.",
-      "startLine": 167,
-      "endLine": 181,
+      "startLine": 200,
+      "endLine": 215,
       "mathContext": "Quantitative ultraflat bound: $|P(z)| = \\sqrt{n} + $O(n^{7/18} (\\$\\log n$)$^{$O(1)$})$. Records the error exponent $7/18 \\approx 0.389$ as a rational constant."
     },
     {
       "id": "rudin-shapiro",
-      "title": "Rudin-Shapiro Polynomials",
+      "title": "Random Polynomial Heuristics (Rudin-Shapiro)",
       "summary": "Deterministic $\\pm 1$ polynomials with $\\|P\\|_\\infty \\leq 2\\sqrt{n}$. Controls the sup norm but not the minimum — not ultraflat. Connected to the Littlewood variant (Problem #228).",
-      "startLine": 183,
-      "endLine": 190,
+      "startLine": 216,
+      "endLine": 224,
       "mathContext": "Mathematical content: Deterministic $\\pm 1$ polynomials with $\\|P\\|_\\infty \\leq 2\\sqrt{n}$. Controls the sup norm but not the minimum — not ultraflat. Connected to the Littlewood variant (Problem #228)."
     },
     {
       "id": "summary",
       "title": "Summary Theorem",
       "summary": "Concluding theorem: $\\neg\\texttt{ErdosNewmanConjecture} \\wedge (\\forall P, \\|P\\|_\\infty \\geq \\sqrt{n})$. Together these establish $\\inf_{P \\in \\mathcal{U}_n} \\|P\\|_\\infty / \\sqrt{n} \\to 1$.",
-      "startLine": 192,
-      "endLine": 230,
+      "startLine": 225,
+      "endLine": 264,
       "mathContext": "Verified: Concluding theorem: $\\neg\\texttt{ErdosNewmanConjecture} \\wedge (\\forall P, \\|P\\|_\\infty \\geq \\sqrt{n})$. Together these establish $\\inf_{P \\in \\mathcal{U}_n} \\|P\\|_\\infty / \\sqrt{n} \\to 1$."
     }
   ],

--- a/src/data/proofs/erdos-380/meta.json
+++ b/src/data/proofs/erdos-380/meta.json
@@ -78,64 +78,64 @@
     {
       "id": "greatest-prime-factor",
       "title": "Greatest Prime Factor",
-      "startLine": 26,
-      "endLine": 64,
+      "startLine": 1,
+      "endLine": 58,
       "summary": "Defines greatestPrimeFactor concretely via Nat.primeFactors.max' (previously 4 axioms, now all proved). Proves gpf_prime (primality for n≥2), gpf_dvd (P(n) ∣ n), and gpf_largest (P(n) is the largest prime divisor).",
       "mathContext": "$P(n)=\\max\\{p\\text{ prime}: p\\mid n\\}$, computed from `Nat.primeFactors`. All three structural properties follow from the definition — no axioms."
     },
     {
       "id": "bad-intervals",
       "title": "Bad Intervals",
-      "startLine": 65,
-      "endLine": 78,
+      "startLine": 59,
+      "endLine": 71,
       "summary": "Defines IsBadInterval u v (requires u≤v and P(Π)² ∣ Π where Π = ∏_{m=u}^{v} m) and InBadInterval n (∃ u≤n≤v with [u,v] bad).",
       "mathContext": "An interval $[u,v]$ is bad if the greatest prime factor of its product $\\Pi=\\prod_{m=u}^v m$ divides $\\Pi$ with exponent $\\ge 2$."
     },
     {
       "id": "counting-functions",
       "title": "Counting Functions",
-      "startLine": 79,
-      "endLine": 89,
+      "startLine": 72,
+      "endLine": 83,
       "summary": "Defines badCount(x) = |{n ≤ x : InBadInterval n}| and gpfSquareCount(x) = |{n ∈ [2,x] : P(n)² ∣ n}|, both noncomputable.",
       "mathContext": "$B(x)=|\\{n\\le x: n\\text{ in a bad interval}\\}|$ and $G(x)=|\\{n\\le x: P(n)^2\\mid n\\}|$ — the densities compared in the conjecture."
     },
     {
       "id": "main-conjecture",
       "title": "Main Conjecture",
-      "startLine": 90,
-      "endLine": 99,
+      "startLine": 84,
+      "endLine": 93,
       "summary": "States ErdosProblem380 as ratio convergence B(x)/G(x) → 1 (using ℚ to avoid reals).",
       "mathContext": "Conjecture: $\\forall\\varepsilon>0,\\ \\exists x_0,\\ \\forall x\\ge x_0:\\ G(x)>0\\wedge|B(x)/G(x)-1|<\\varepsilon$, i.e. almost all bad integers come from $P(n)^2\\mid n$."
     },
     {
-      "id": "known-bounds",
-      "title": "Known Bounds",
-      "startLine": 100,
-      "endLine": 123,
-      "summary": "States the single axiom gpfSquare_asymptotic (the GPF-square count exceeds x^{1−ε}) and PROVES erdos_graham_lower (B(x) ≥ x^{1−ε} for large x) via the chain x^{1−ε} ≤ G(x) ≤ B(x) using badCount_ge_gpfSquareCount.",
-      "mathContext": "$B(x)>x^{1-\\varepsilon}$ for every $\\varepsilon>0$ and large $x$ — derived from $G(x)\\le B(x)$ and the asymptotic lower bound on $G(x)$ (the only axiom in the file)."
-    },
-    {
       "id": "bad-primes",
       "title": "Bad Intervals and Primes",
-      "startLine": 124,
-      "endLine": 268,
+      "startLine": 94,
+      "endLine": 269,
       "summary": "PROVES bad_interval_no_prime (short bad intervals v<2u contain no primes) and bad_interval_no_prime_general (any bad interval is prime-free), plus bad_interval_v_bound (v < 2u for bad [u,v], via Bertrand's postulate).",
       "mathContext": "If prime $p\\in[u,v]$ with $v<2p$ then $p$ appears once in $\\Pi$, so $P(\\Pi)=p$ divides $\\Pi$ only once — contradicting badness. Bertrand forces $v<2u$."
     },
     {
       "id": "singleton-intervals",
       "title": "Singleton Intervals",
-      "startLine": 269,
-      "endLine": 297,
+      "startLine": 270,
+      "endLine": 295,
       "summary": "Links singleton intervals to gpfSquareCount: singleton_bad_iff ([n,n] bad ⟺ P(n)² ∣ n), gpfSquare_in_bad (each such n is in bad interval [n,n]), and badCount_ge_gpfSquareCount (B(x) ≥ G(x)).",
       "mathContext": "$[n,n]$ is bad $\\iff P(n)^2\\mid n$, so the singletons inject $G(x)$ into the bad integers: $B(x)\\ge G(x)$."
     },
     {
+      "id": "known-bounds",
+      "title": "Known Bounds",
+      "startLine": 296,
+      "endLine": 321,
+      "summary": "States the single axiom gpfSquare_asymptotic (the GPF-square count exceeds x^{1−ε}) and PROVES erdos_graham_lower (B(x) ≥ x^{1−ε} for large x) via the chain x^{1−ε} ≤ G(x) ≤ B(x) using badCount_ge_gpfSquareCount.",
+      "mathContext": "$B(x)>x^{1-\\varepsilon}$ for every $\\varepsilon>0$ and large $x$ — derived from $G(x)\\le B(x)$ and the asymptotic lower bound on $G(x)$ (the only axiom in the file)."
+    },
+    {
       "id": "very-bad-intervals",
       "title": "Very Bad Intervals and Powerful Numbers",
-      "startLine": 298,
-      "endLine": 396,
+      "startLine": 322,
+      "endLine": 428,
       "summary": "Defines IsPowerful, IsVeryBadInterval, veryBadCount, powerfulCount. Proves veryBad_is_bad, veryBad_interval_no_prime, singleton_veryBad_iff ([n,n] very bad ⟺ n powerful), powerful_in_veryBad, and the counting_chain powerfulCount ≤ veryBadCount ≤ badCount with gpfSquareCount ≤ badCount. States VeryBadConjecture.",
       "mathContext": "A very bad interval has every prime dividing its product squared. Singleton $[n,n]$ very bad $\\iff n$ powerful; powerful numbers count $\\sim c\\sqrt{x}$, giving $\\text{powerfulCount}\\le\\text{veryBadCount}\\le\\text{badCount}$."
     }


### PR DESCRIPTION
Re-anchors drifted/scrambled gallery `meta.sections` to cover each Lean file `1..EOF`. Pure section-metadata edits (no status/badge/axiomCount changes). Each target re-verified stale on fresh `origin/main` immediately before push (dropped `cevas-theorem-oq-01-oq-03` and `erdos-679`, both already re-anchored by concurrent PRs).

- **erdos-230** (re-anchor): Parts V–VIII had drifted ~30 lines — "Körner"/"Bombieri"/"Rudin-Shapiro"/"Summary" sections anchored at 158/167/183/192 while the `## Part N` banners sit at 191/200/216/225. Re-anchored all parts to their banners (the Rudin–Shapiro discussion is a bullet inside Part VII "Random Polynomial Heuristics"), extended Kahane's Part IV to include `erdos_newman_false`, and covered the `erdos_230_summary` capstone @245.
- **erdos-113** (9→10): head module docstring 1-41 was uncovered (added **Overview**); Parts VIII/IX were drifted (Related Results @251, and the missing **Part IX: Main Results Summary** @278 holding `erdos_113`), previously swallowed into the wrong ranges.
- **erdos-380** (reorder + re-anchor): the section list was **scrambled** — "Known Bounds" was anchored at 100-123 but its `## Known bounds` banner is @296 (after Singleton Intervals @270), and "Bad Intervals and Primes" spanned 124-268 vs banner @94. Reordered sections to match the actual `/- ## ` banner sequence and extended the Very-Bad-Intervals section to cover `VeryBadConjecture` @423.

Contiguity asserted (`gap ∈ [0,2]`) and `maxEnd === wc` for every file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
