### PR TITLE
audit: cantor-diagonalization oq003/oq004/oq005 (consolidated + meta fixes)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30734,6 +30734,24 @@
       "lastAudited": "2026-07-21T09:52:35Z",
       "result": "clean",
       "issues": []
+    },
+    "cantor-diagonalization-oq003": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:01:05Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cantor-diagonalization-oq004": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:01:05Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "cantor-diagonalization-oq005": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:01:05Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-incomplete-01-oq-01/meta.json
@@ -24,7 +24,9 @@
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "No axioms, no sorries. All 13 theorems fully proved. Uses only Classical (for a decidability instance inside a by_cases in exists_fixedPointFree_of_ne); no axiom declarations and no assumption-carrying structure fields. #print axioms reports only [propext, Classical.choice, Quot.sound] (several theorems depend on no axioms at all).",
-    "originalContributions": "The sharp characterization reflexive_iff_subsingleton_nonempty (A is reflexive ⟺ A is a nonempty subsingleton) packages the diagonal case of Lawvere's theorem as an iff, making explicit that the terminal object is the only reflexive object of Set — the categorical reason the untyped λ-calculus has no set-theoretic model. The abstract EvalStructure packaging unifies Lawvere, Cantor, and the fixed-point-free obstruction under one lemma.",
+    "originalContributions": [
+      "The sharp characterization reflexive_iff_subsingleton_nonempty (A is reflexive ⟺ A is a nonempty subsingleton) packages the diagonal case of Lawvere's theorem as an iff, making explicit that the terminal object is the only reflexive object of Set — the categorical reason the untyped λ-calculus has no set-theoretic model. The abstract EvalStructure packaging unifies Lawvere, Cantor, and the fixed-point-free obstruction under one lemma."
+    ],
     "mathlib_version": "4.31.0",
     "lineCount": 235,
     "theoremCount": 13,

--- a/src/data/proofs/cantor-diagonalization-oq004/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq004/meta.json
@@ -21,11 +21,13 @@
       "extension",
       "open-question"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "No axioms, no sorries. All 3 theorems fully proved. Uses only the foundational propext / Classical.choice / Quot.sound (via the Mathlib cardinal API); no axiom declarations and no assumption-carrying structure fields.",
-    "originalContributions": "Phrases the parent's Cantor obstruction at the cardinal level and shows the resulting strict gap #A < #(A → Prop) re-implies non-surjectivity (not_surjective_of_cardinality_gap), making explicit that the quantitative statement is strictly stronger than the qualitative one. The one-line reduction to Cardinal.cantor via the defeq A → Prop ≡ Set A is the point the parent's bespoke Lawvere development left unstated.",
+    "assumptions": "Core result via Mathlib: the strict gap #A < #(A → Prop) is Mathlib's Cardinal.cantor transported along Cardinal.mk_set (A → Prop is definitionally Set A). No axioms, no sorries. All 3 theorems fully proved. Uses only the foundational propext / Classical.choice / Quot.sound (via the Mathlib cardinal API); no axiom declarations and no assumption-carrying structure fields.",
+    "originalContributions": [
+      "Phrases the parent's Cantor obstruction at the cardinal level and shows the resulting strict gap #A < #(A → Prop) re-implies non-surjectivity (not_surjective_of_cardinality_gap), making explicit that the quantitative statement is strictly stronger than the qualitative one. The one-line reduction to Cardinal.cantor via the defeq A → Prop ≡ Set A is the point the parent's bespoke Lawvere development left unstated."
+    ],
     "mathlib_version": "4.31.0",
     "lineCount": 84,
     "theoremCount": 3,


### PR DESCRIPTION
Consolidated audit results for three `cantor-diagonalization` entries, in **one** PR to avoid audit-tracker merge-races. **Supersedes #40352 and #40355** (both closed).

## oq003 — Club Filter & Nonstationary Ideal — CLEAN
0 axioms / 0 sorries / no native_decide; 10 theorems + 1 def match meta; parent `IsClub`/`IsStationary` definitions genuine; badge `original` appropriate for the from-scratch binary-intersection + NS-ideal content.

## oq004 — Quantitative Cantor `#A < #(A → Prop)` — ISSUES-FIXED
1. **Page-crash (HIGH)**: `originalContributions` was a plain **string**; `src/types/proof.ts` types it `string[]` and `ProofOverview.tsx:244-251` does `.length>0` then `.map(...)` → `TypeError`, crashing the proof page. Wrapped in a single-element array. **Same fix applied to parent** `cantor-diagonalization-oq-03-oq-01-incomplete-01-oq-01` (only other of 4000 entries with this bug).
2. **Badge (MEDIUM)**: `original` → `mathlib`. All 3 theorems reduce to Mathlib's `Cardinal.cantor` (docstring: *"No new mathematics is required"*). Tier B. Added Mathlib-core qualifier to `assumptions`.

## oq005 — Cantor/Presheaf as Lawvere Instances — CLEAN
0 axioms / 0 sorries / no True-stubs; all 7 `originalContributions` name real decls. `LawvereCCC.lawvere_cantor`/`lawvere_fixedPoint` are **repo-internal** (parent file), not Mathlib, so badge `original` is appropriate. Only discrepancy is a harmless `theoremCount`/`definitionCount` undercount — left as-is per convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)