### PR TITLE
audit: catalan-numbers-oq001 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30752,6 +30752,12 @@
       "lastAudited": "2026-07-21T10:01:05Z",
       "result": "clean",
       "issues": []
+    },
+    "catalan-numbers-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:07:23Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean**.

**Proof**: catalan-numbers-oq001 (Generalized ballot / cycle-lemma count C(2n,n) − C(2n,n+k) via André's reflection)

## Verification
- `LAKE_UNSAFE=1 lake build` succeeds (deprecation warnings only).
- `#print axioms` on `card_goodPathsK_add`, `card_goodPathsK_one`, `card_badPathsK` → `[propext, Classical.choice, Quot.sound]` (foundational only). No sorry/axiom leaks from the reused parent `CatalanAndreReflection` infrastructure.
- No custom axioms, no `native_decide` (`by decide` on `Nat.choose` is kernel decide), no sorries, no True stubs.

## Counts (all match meta.json)
- 15 theorems/lemmas, 6 defs, 259 lines, 0 axioms, 0 sorries.
- Badge `original` and status `verified` appropriate: genuine k-depth generalization of the reflection bijection (via `Finset.card_bij'`), recovering `catalan n` at k=1; not a single-Mathlib-theorem wrapper.
- Prose accurately describes the André reflection and the concrete C(6,3)−C(6,5)=14 instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)