### PR TITLE
audit: catalan-numbers-oq002 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30752,6 +30752,12 @@
       "lastAudited": "2026-07-21T10:01:05Z",
       "result": "clean",
       "issues": []
+    },
+    "catalan-numbers-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:09:19Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean**.

**Proof**: catalan-numbers-oq002 (Catalan-triangle recurrence B(p,q)=B(p−1,q)+B(p,q−1) via ballot closed form + Pascal's rule)

## Verification
- `LAKE_UNSAFE=1 lake build` succeeds (deprecation warnings only).
- `#print axioms` on `ballot_recurrence`, `ballot_recurrence_diag` → `[propext, Classical.choice, Quot.sound]` (foundational only). No sorry/axiom leaks from the parent `CatalanNumbersOQ01OQ01OQ02` (ballot, ballot_genuine, ballot_eq_zero_of_lt).
- No custom axioms, no `native_decide` (3 sanity checks use kernel `decide` on Nat.choose), no sorries, no True stubs.

## Counts (all match meta.json)
- 2 theorems, 0 defs, 103 lines, 0 axioms, 0 sorries.
- Badge `original` and status `verified` appropriate: genuine binomial-algebra derivation (Pascal's rule), not a single-Mathlib-theorem wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)