### PR TITLE
audit: catalan-numbers-oq003 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30752,6 +30752,12 @@
       "lastAudited": "2026-07-21T10:01:05Z",
       "result": "clean",
       "issues": []
+    },
+    "catalan-numbers-oq003": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:11:03Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean**.

**Proof**: catalan-numbers-oq003 (Catalan-triangle row sums = catalan(p+1))

## Verification
- `LAKE_UNSAFE=1 lake build` succeeds.
- `#print axioms` on `ballot_row_sum`, `catalan_succ_eq_choose_sub` → `[propext, Classical.choice, Quot.sound]` (foundational only). No leaks from parent.
- No custom axioms, no `native_decide` (2 sanity checks use kernel `decide`), no sorries, no True stubs.

## Counts
- 0 defs, 161 lines, 0 axioms, 0 sorries — match.
- `theoremCount: 4` vs 5 named theorems actual: harmless **undercount** (the v4.31 compat shim `Nat.Ico_succ_right` sits outside the `CatalanRowSum` namespace; meta counts the 4 namespace results). Undercounts are stale-but-safe — not an overclaim.
- Badge `original` and status `verified` appropriate: genuine hockey-stick (Zhu Shijie) + Pascal derivation, independent of the recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)