### PR TITLE
audit: catalan-numbers-oq004 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30752,6 +30752,12 @@
       "lastAudited": "2026-07-21T10:01:05Z",
       "result": "clean",
       "issues": []
+    },
+    "catalan-numbers-oq004": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:13:14Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean**.

**Proof**: catalan-numbers-oq004 (Catalan p-Divisibility as a Kummer Carry Criterion)

## Verification
- `LAKE_UNSAFE=1 lake build` succeeds.
- `#print axioms` on `not_dvd_catalan_iff_carries`, `padicValNat_catalan_add_succ_eq_carries` → `[propext, Classical.choice, Quot.sound]` (foundational only). No `ofReduceBool` — confirms the disclosed 'no native_decide' (5 witnesses use kernel `decide` on `centralBinom` values, not `catalan` recursion).
- No custom axioms, no sorries, no True stubs.

## Counts (all match meta.json)
- 6 theorems, 1 def (`carries`), 171 lines, 0 axioms, 0 sorries.
- Meta honestly discloses the hard analytic content (Legendre + digit sums) lives in the parent; this entry is the combinatorial repackaging into Kummer carry form plus one `padicValNat` multiplicativity step. Badge `original` appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)