### PR TITLE
Enrich 3 entries: re-anchor undercovered capstone tails to EOF

### DIFF
--- a/src/data/proofs/erdos-1034/meta.json
+++ b/src/data/proofs/erdos-1034/meta.json
@@ -163,10 +163,10 @@
     {
       "id": "properties",
       "title": "Good Neighbor Properties",
-      "summary": "$T.\\text{vertices} \\subseteq \\text{goodNeighbors}$ and $\\text{bookPages} \\subseteq \\text{goodNeighbors}$ structural lemmas",
+      "summary": "Structural lemmas culminating in $\\text{book\\_subset\\_good}$: $T.\\text{vertices} \\subseteq \\text{goodNeighbors}$, $\\text{book\\_pages\\_are\\_good}$, and $\\text{book\\_subset\\_good}$ (a book's pages, when disjoint from $T$, are all good neighbors of $T$). Closes with the file-level Summary docstring recording the resolved status (DISPROVED by Ma-Tang) and the known bounds $\\tfrac16 n \\le h(n) \\le (2-\\sqrt{5/2})n \\approx 0.4189n$.",
       "startLine": 305,
-      "endLine": 744,
-      "mathContext": "Structural: triangle vertices are good neighbors of $T$. Book pages are subsets of good neighbors."
+      "endLine": 779,
+      "mathContext": "Structural: triangle vertices are good neighbors of $T$. Book pages are subsets of good neighbors, so a large book around $T$ forces many good neighbors — the source of the $h(n) \\ge (1/6 - o(1))n$ lower bound."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -133,8 +133,8 @@
       "id": "amenability",
       "title": "§VI: Relationship to Amenability",
       "startLine": 964,
-      "endLine": 1517,
-      "summary": "Defines IsAmenable and develops Tarski's group-theoretic source of the paradox. Proves int_amenable (ℤ is amenable via Cesàro window-shift), the free-group word-set cover lemmas (free_group_cover_a/b and disjointness), free_group_paradoxical (F₂ is paradoxical under its own left regular action), and free_group_not_amenable. All fully proved, no sorry.",
+      "endLine": 1553,
+      "summary": "Defines IsAmenable and develops Tarski's group-theoretic source of the paradox. Proves int_amenable (ℤ is amenable via Cesàro window-shift), the free-group word-set cover lemmas (free_group_cover_a/b and disjointness), free_group_paradoxical (F₂ is paradoxical under its own left regular action), and the capstone free_group_not_amenable. The final theorem assumes a left-invariant finitely-additive probability measure μ on F₂ and derives 2 ≤ 1: the two covers F₂ = W(a) ⊔ a·W(a⁻¹) = W(b) ⊔ b·W(b⁻¹) force μ(W_a)+μ(W_ainv)=1 and μ(W_b)+μ(W_binv)=1, while the four word-start sets are pairwise disjoint subsets of F₂ so their measures sum ≤ 1 — contradiction. All fully proved, no sorry.",
       "mathContext": "A group $G$ is amenable iff $\\exists \\mu: 2^G \\to [0,\\infty]$ with $\\mu(G)=1$, finite additivity, and left-invariance $\\mu(gA) = \\mu(A)$. $\\mathbb{Z}$ is amenable via the Cesàro density $\\mu_N(A) = |A \\cap \\{-N,\\dots,N\\}|/(2N+1)$ (shift changes the count by $\\le |n|$, vanishing along an ultrafilter). $F_2$ is not amenable: $F_2 = W(a) \\sqcup aW(a^{-1}) = W(b) \\sqcup bW(b^{-1})$ gives two paradoxical coverings — exactly Tarski's equivalence between non-amenability and paradoxicality."
     }
   ],

--- a/src/data/proofs/szemeredi-counting/meta.json
+++ b/src/data/proofs/szemeredi-counting/meta.json
@@ -132,8 +132,8 @@
       "id": "quantitative-removal",
       "title": "Quantitative Triangle Removal via Regularity",
       "startLine": 537,
-      "endLine": 1196,
-      "summary": "The main quantitative result: `triangle_removal_quantitative` constructs explicit $\\gamma(\\delta)$ using the Regularity Lemma. **Fully proved.** Applies `regularity_with_finpartition` to get a Finpartition, removes edges from irregular and sparse pairs (h_irreg and h_sparse budget lemmas proved), then uses `counting_lemma` to show any remaining triangle yields many triangles — contradicting the $\\gamma n^3$ bound.",
+      "endLine": 1230,
+      "summary": "The main quantitative result: `triangle_removal_quantitative` constructs explicit $\\gamma(\\delta)$ using the Regularity Lemma. **Fully proved.** Applies `regularity_with_finpartition` to get a Finpartition, removes edges from irregular and sparse pairs (h_irreg and h_sparse budget lemmas proved), then uses `counting_lemma` to show any remaining triangle yields many triangles — contradicting the $\\gamma n^3$ bound. The closing calc block makes the contradiction explicit: a surviving regular, dense triangle triple forces at least $(1-2\\varepsilon)\\varepsilon^3(n/2M)^3 = 2\\gamma n^3 > \\gamma n^3$ triangles, so `linarith` closes the goal.",
       "mathContext": "$\\forall \\delta > 0, \\exists \\gamma = \\gamma(\\delta, M(\\varepsilon))$: $T(G) \\leq \\gamma n^3$ implies $G$ can be made triangle-free by removing $\\leq \\delta n^2$ edges. The proof is constructive: $\\gamma$ depends on the regularity bound $M(\\varepsilon)$ and $\\varepsilon = \\delta/6$."
     }
   ],


### PR DESCRIPTION
Enrichment pass: re-anchor three grown-file entries whose final section ended well before EOF, leaving the capstone declarations uncovered. Each fix extends the final section's `endLine` to the true end of the Lean file and deepens its summary to describe the now-covered content. No prose accuracy issues found in status/badge/axiomCount.

- **lebesgue-measure-oq-06** (Banach-Tarski): §VI "Relationship to Amenability" ended at 1517 while EOF is 1553 — the capstone `free_group_not_amenable` theorem (the 2 ≤ 1 contradiction from the two paradoxical covers of F₂) was uncovered. Extended to 1553; summary now walks through the disjoint word-start cover argument.
- **erdos-1034** (Triangle Neighbors): "Good Neighbor Properties" ended at 744 while EOF is 779 — the final `book_subset_good` lemma plus the file-level Summary docstring (resolved status + h(n) bounds) were uncovered. Extended to 779.
- **szemeredi-counting** (Counting/Removal Lemma): "Quantitative Triangle Removal" ended at 1196 while EOF is 1230 — the closing calc block that makes the γn³ contradiction explicit was uncovered. Extended to 1230.

All three meta.json files validated as JSON. Sections now cover 1..EOF.
