### PR TITLE
audit: cauchy-group-theorem-oq001 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30758,6 +30758,12 @@
       "lastAudited": "2026-07-21T10:11:03Z",
       "result": "clean",
       "issues": []
+    },
+    "cauchy-group-theorem-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:15:12Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean**.

**Proof**: cauchy-group-theorem-oq001 (Counting solutions to xⁿ=1 in a cyclic group: exactly gcd(n,|G|))

## Verification
- `LAKE_UNSAFE=1 lake build` succeeds.
- `#print axioms card_pow_eq_one_eq_gcd` → `[propext, Classical.choice, Quot.sound]` (foundational only).
- No custom axioms, no `native_decide`, no sorries, no True stubs.

## Badge / delegation check
- Meta claims Mathlib only records the one-sided bound. **Verified**: `IsCyclic.card_pow_eq_one_le` (Cyclic/Basic.lean:313) is exactly `#{a | aⁿ=1} ≤ n`; Mathlib has no sharp `= gcd(n,|G|)` count for a general finite cyclic group. The file's `card_pow_eq_one_eq_gcd` (with the n=0 case and the from-scratch number-theoretic core `div_gcd_dvd_of_dvd_mul`) is genuine original work on Mathlib primitives.
- Badge `original` and status `verified` appropriate; Frobenius framing (cyclic base/extremal case) honest.

## Counts (all match meta.json)
- 5 theorems, 0 defs, 165 lines, 0 axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)