### PR TITLE
Enrich 3 entries: re-anchor undercovered tails to EOF (batch 2)

### DIFF
--- a/src/data/proofs/erdos-268/meta.json
+++ b/src/data/proofs/erdos-268/meta.json
@@ -185,9 +185,9 @@
     {
       "id": "examples",
       "title": "Specific Examples",
-      "summary": "Defines squaresSet = {n² : n ≥ 1} and powersOf2Set = {2ᵏ}. Proves squares_convergent (bijection ℕ ≃ squaresSet + p-series for p=2) and powers_convergent (bijection ℕ ≃ powersOf2Set + geometric series). Defines squaresPoint and powers2Point as concrete elements of X. Adds harmonicPointSet_one_eq (X₁ = positive half-line) and harmonicSubseriesSum_surjective_on_pos (every s > 0 achievable).",
+      "summary": "Defines squaresSet = {n² : n ≥ 1} and powersOf2Set = {2ᵏ}. Proves squares_convergent (bijection ℕ ≃ squaresSet + p-series for p=2) and powers_convergent (bijection ℕ ≃ powersOf2Set + geometric series). Defines squaresPoint and powers2Point as concrete elements of X. Adds harmonicPointSet_one_eq (X₁ = positive half-line) and harmonicSubseriesSum_surjective_on_pos (every s > 0 achievable). Closes with the file-level Summary docstring recording the problem, the answer (YES for all d ≥ 1), the Erdős-Straus / Kovač / Kovač-Tao history, and the two key axioms `erdos_268_solved` and `harmonicPointSet_path_connected_large`.",
       "startLine": 878,
-      "endLine": 979,
+      "endLine": 1009,
       "mathContext": "Proves squares_convergent and powers_convergent. Adds two new public theorems: harmonicPointSet_one_eq and harmonicSubseriesSum_surjective_on_pos."
     }
   ],

--- a/src/data/proofs/hilbert-4/meta.json
+++ b/src/data/proofs/hilbert-4/meta.json
@@ -121,8 +121,8 @@
       "id": "examples",
       "title": "Examples",
       "startLine": 281,
-      "endLine": 457,
-      "summary": "Euclidean, taxicab, and Chebyshev norms as examples.",
+      "endLine": 488,
+      "summary": "Euclidean, taxicab, and Chebyshev norms as worked examples of Minkowski geometries whose geodesics are straight lines. Closes with `#check` sanity checks on the marquee results and a file-level summary comment collecting the three headline theorems: `minkowski_geodesics_are_straight`, `busemann_classification`, and `hamel_theorem_2d`.",
       "mathContext": "Euclidean: $\\|x\\|_2 = \\sqrt{\\sum x_i^2}$, unit ball is a sphere. Taxicab: $\\|x\\|_1 = \\sum |x_i|$, unit ball is a cross-polytope. Chebyshev: $\\|x\\|_\\infty = \\max |x_i|$, unit ball is a hypercube. All are Minkowski geometries with convex unit balls, hence straight-line geodesics."
     }
   ],

--- a/src/data/proofs/szemeredi-regularity/meta.json
+++ b/src/data/proofs/szemeredi-regularity/meta.json
@@ -122,8 +122,8 @@
       "id": "mathlib-bridge",
       "title": "Bridge to Mathlib: Compatibility and Strong/Full Forms",
       "startLine": 323,
-      "endLine": 501,
-      "summary": "Four compatibility theorems bridging our definitions to Mathlib's: `edgeDensity_eq_mathlib` (density equivalence), `mathlib_uniform_imp_regular` (Mathlib uniformity → our regularity), `equipartition_imp_equitable` (equitability bridge), `irregular_subset_nonuniform` (irregular pairs subset). These yield `regularity_lemma_strong` (with m₀ ≤ k ≤ M) and `regularity_lemma_full` (with partition structure: coverage and disjointness) via `szemeredi_regularity` from Mathlib.",
+      "endLine": 533,
+      "summary": "Four compatibility theorems bridging our definitions to Mathlib's: `edgeDensity_eq_mathlib` (density equivalence), `mathlib_uniform_imp_regular` (Mathlib uniformity → our regularity), `equipartition_imp_equitable` (equitability bridge), `irregular_subset_nonuniform` (irregular pairs subset). These yield `regularity_lemma_strong` (with m₀ ≤ k ≤ M) and `regularity_lemma_full` (with partition structure: coverage and disjointness) via `szemeredi_regularity` from Mathlib. The closing block discharges the irregularity-count obligation (same argument as `regularity_lemma_strong`) and closes the `Szemeredi.Regularity` namespace.",
       "mathContext": "Bridge: our $\\varepsilon$-regularity (with $\\leq$) is implied by Mathlib's uniformity (with $<$). Our irregular pair set $\\subseteq$ Mathlib's non-uniform set. This yields: $\\forall \\varepsilon > 0, m_0 \\geq 1, \\exists M: n \\geq M \\Rightarrow$ graph has $\\varepsilon$-regular partition with $m_0 \\leq k \\leq M$."
     }
   ],


### PR DESCRIPTION
Enrichment pass (batch 2): re-anchor three more grown-file entries whose final section ended before EOF, leaving the closing declarations/summaries uncovered. Each fix extends the final section's `endLine` to the true end of the Lean file and deepens its summary. Status/badge/axiomCount verified accurate (erdos-268: 2 axioms match the closing Summary docstring's "Key axioms").

- **szemeredi-regularity**: "Bridge to Mathlib" ended at 501 while EOF is 533 — the closing irregularity-count discharge and namespace close were uncovered. Extended to 533.
- **hilbert-4**: "Examples" ended at 457 while EOF is 488 — the `#check` sanity checks and file-level summary comment (naming the three headline theorems) were uncovered. Extended to 488.
- **erdos-268**: "Specific Examples" ended at 979 while EOF is 1009 — the file-level Summary docstring (problem, answer, Erdős-Straus/Kovač/Kovač-Tao history, key axioms) was uncovered. Extended to 1009.

All three meta.json files validated as JSON. Sections now cover 1..EOF.
