### PR TITLE
audit: cauchy-group-theorem-oq002 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30758,6 +30758,12 @@
       "lastAudited": "2026-07-21T10:11:03Z",
       "result": "clean",
       "issues": []
+    },
+    "cauchy-group-theorem-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:16:42Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean**.

**Proof**: cauchy-group-theorem-oq002 (Counting solutions of xⁿ=g: gcd(n,|G|) when g is an n-th power, else 0)

## Verification
- `LAKE_UNSAFE=1 lake build` succeeds.
- `#print axioms` on `card_pow_eq_cyclic`, `card_pow_eq_cyclic_effective` → `[propext, Classical.choice, Quot.sound]` (foundational only).
- No custom axioms, no `native_decide`, no sorries, no True stubs.

## Counts (all match meta.json)
- 6 theorems, 0 defs, 188 lines, 0 axioms, 0 sorries.
- Badge `original` and status `verified` appropriate: genuine generalization of the parent's xⁿ=1 count via coset bijection (left-translation) + Mathlib's `IsCyclic.card_powMonoidHom_range/ker`; effective n-th-power test derived honestly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)