### PR TITLE
Enrich 5 entries: re-anchor drifted/undercovered sections to 1..EOF

### DIFF
--- a/src/data/proofs/sperner-ndim-oq-03/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-03/meta.json
@@ -126,7 +126,7 @@
       "id": "brouwer-fpt",
       "title": "Section VIII: Brouwer Fixed Point Theorem",
       "startLine": 400,
-      "endLine": 452,
+      "endLine": 484,
       "summary": "Proves brouwer_simplex: the Brouwer fixed point theorem for the standard d-simplex — every continuous self-map has a fixed point — by a compactness argument on the sequence of approximate fixed points.",
       "mathContext": "The standard compactness argument: approximate fixed points form a sequence in the compact simplex, so a subsequence converges, and the limit is an exact fixed point by continuity."
     }


### PR DESCRIPTION
Enrichment pass — pure `sections` coverage/re-anchor for 5 gallery entries. No `status`, `badge`, `axiomCount`, or prose-claim changes; every last section now reaches its Lean file's last content line and all anchors align to real `/- ## -/` banners.

## erdos-533 — full re-anchor (systematic drift)
The entire back half of the section list was anchored ~27 lines too early (content was inserted around the Basic Properties block but the anchors were never updated). Re-anchored each section to its actual banner:
- Basic Properties 64..210 → 66..237
- Neighborhood Structure 211..268 → 238..295
- Turán-Type Bounds 269..287 → 296..314
- Known Partial Results 288..306 → 315..333
- Partial Resolution 307..331 → 334..358
- Strategy: Neighborhood Approach 332..355 → 359..384 (now covers `degree_le`, which the summary already described)
- The Open Question 356..371 → 385..400 (`erdos_533_conjecture` def through EOF)
- (+ minor tightening of Problem Statement / Definitions / SimpleGraph Bridge anchors)

## Tail undercoverage (last section ended short of EOF)
- **lebesgue-measure-oq-06**: §VI Relationship to Amenability 1517 → 1553 (covers the `free_group_paradoxical` / `free_group_not_amenable` proof tail)
- **szemeredi-counting**: Quantitative Triangle Removal 1196 → 1230
- **sperner-ndim-oq-03**: §VIII Brouwer Fixed Point Theorem 452 → 484
- **szemeredi-regularity**: Bridge to Mathlib 501 → 533

All sections verified contiguous and within EOF via node JSON parse.
