### PR TITLE
Enrich 2 entries: re-anchor drifted tail sections to EOF (batch 3)

### DIFF
--- a/src/data/proofs/erdos-533/meta.json
+++ b/src/data/proofs/erdos-533/meta.json
@@ -123,8 +123,8 @@
       "id": "open-question",
       "title": "The Open Question",
       "startLine": 356,
-      "endLine": 371,
-      "summary": "States the conjecture as a Prop erdos_533_conjecture δ (deliberately not an axiom, to avoid assuming the unknown): there exists c > 0 such that every K₅-free graph on n vertices with at least δn² edges has a triangle-free induced subgraph on ≥ c·n vertices.",
+      "endLine": 400,
+      "summary": "States the conjecture as a Prop erdos_533_conjecture δ (deliberately not an axiom, to avoid assuming the unknown): there exists c > 0 such that every K₅-free graph on n vertices with at least δn² edges has a triangle-free induced subgraph on ≥ c·n vertices. Also proves the supporting graph lemma degree_le (every vertex has degree ≤ n-1, via Finset.card_erase on the closed neighborhood) before stating the conjecture.",
       "mathContext": "$\\forall \\delta>0,\\ \\exists c>0$: every $K_5$-free $G$ with $\\ge \\delta n^2$ edges has a triangle-free induced subgraph of size $\\ge cn$."
     }
   ],

--- a/src/data/proofs/hilbert-13-oq-03/meta.json
+++ b/src/data/proofs/hilbert-13-oq-03/meta.json
@@ -105,7 +105,7 @@
       "id": "sec-final-verification",
       "title": "Final Verification",
       "startLine": 175,
-      "endLine": 182,
+      "endLine": 213,
       "summary": "A closing remark (recalling that Sternfeld's strictly-stronger uniform separation condition is the exact admissibility threshold, not formalised here) followed by a #check block re-exhibiting the five exported results — eq_of_feature_eq, feature_injective_of_universal, inner_injective_of_feature_injective, inner_functions_must_be_injective, feature_must_separate_points — and end Hilbert13OQ03.",
       "mathContext": "Type-level confirmation of the necessary-condition results; the exact Sternfeld admissibility threshold is explicitly out of scope."
     }


### PR DESCRIPTION
Enrichment pass (batch 3): re-anchor two entries whose final section's summary already described tail content but whose `endLine` anchor stopped short, leaving real declarations uncovered. Axiom counts verified accurate (hilbert-13-oq-03: 0 axioms/verified; erdos-533: 3 axioms/axiomatized).

- **hilbert-13-oq-03**: "Final Verification" ended at 182 while EOF is 213 — the `feature_must_separate_points` theorem (the strongest necessary separation statement) plus the necessity-vs-sufficiency closing remark (Sternfeld 1985) and `#check` block were uncovered. Extended to 213 (summary already described this content).
- **erdos-533**: "The Open Question" ended at 371 while EOF is 400 — the `degree_le` supporting lemma (degree ≤ n−1) and the `erdos_533_conjecture` Prop (deliberately a `Prop`, not an `axiom`, to avoid assuming the unknown) were uncovered. Extended to 400; summary now notes `degree_le`.

Both meta.json files validated as JSON. Sections now cover 1..EOF.
