### PR TITLE
audit: cauchy-group-theorem-oq003 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30758,6 +30758,12 @@
       "lastAudited": "2026-07-21T10:11:03Z",
       "result": "clean",
       "issues": []
+    },
+    "cauchy-group-theorem-oq003": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:17:32Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean**.

**Proof**: cauchy-group-theorem-oq003 (gcd(n,m) recovers the power map: same kernel, same image, fibre partition)

## Verification
- `LAKE_UNSAFE=1 lake build` succeeds.
- `#print axioms` on `card_image_pow`, `range_pow_eq_range_pow_gcd` → `[propext, Classical.choice, Quot.sound]` (foundational only).
- No custom axioms, no `native_decide`, no sorries, no True stubs.

## Counts (all match meta.json)
- 7 theorems, 0 defs, 165 lines, 0 axioms, 0 sorries.
- Badge `original` and status `verified` appropriate: genuine structural results (kernel/image recovery, fibre partition #(n-th powers)·gcd=m) assembled on the parent's count via `IsCyclic.card_powMonoidHom_range`, `Finset.card_eq_sum_card_image`, `Subgroup.eq_of_le_of_card_ge`. Kernel statement honestly scoped to any finite group; image/partition to cyclic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)