### PR TITLE
audit: cauchy-group-theorem-oq004 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30758,6 +30758,12 @@
       "lastAudited": "2026-07-21T10:11:03Z",
       "result": "clean",
       "issues": []
+    },
+    "cauchy-group-theorem-oq004": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:18:30Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean**.

**Proof**: cauchy-group-theorem-oq004 (The exponent governs the power map: range(x↦xⁿ)=range(x↦x^gcd(n,exp G)) in every group)

## Verification
- `LAKE_UNSAFE=1 lake build` succeeds.
- `#print axioms` on `range_pow_eq_range_pow_gcd_exponent`, `card_range_mul_card_ker_powMonoidHom` → `[propext, Classical.choice, Quot.sound]` (foundational only).
- No custom axioms, no `native_decide`, no sorries, no True stubs.

## Counts (all match meta.json)
- 6 theorems (top-level), 0 defs, 153 lines, 0 axioms, 0 sorries.
- Badge `original` and status `verified` appropriate: genuinely strengthens the parent OQ — image equality now via a single Bézout identity valid in **any** group (no commutativity/finiteness), with `Monoid.exponent` the correct invariant. Scope claims (any group vs abelian vs finite abelian) honestly delineated per theorem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)