### PR TITLE
audit: cauchy-group-theorem-oq005 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30758,6 +30758,12 @@
       "lastAudited": "2026-07-21T10:11:03Z",
       "result": "clean",
       "issues": []
+    },
+    "cauchy-group-theorem-oq005": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:19:36Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean** (exemplary).

**Proof**: cauchy-group-theorem-oq005 (Exponent–gcd image equality on a finite commutative monoid; units carry it, exponent detects group-likeness, order surrogate fails)

## Verification
- `LAKE_UNSAFE=1 lake build` succeeds.
- `#print axioms` on `exponent_ne_zero_iff_forall_isUnit`, `order_surrogate_fails_zmod4`, `not_isUnit_two_zmod4` → `[propext, Classical.choice, Quot.sound]`. The two `by decide` theorems carry **no** `ofReduceBool` — confirming kernel `decide`, not native_decide, as disclosed.
- No custom axioms, no sorries, no True stubs.

## Counts
- 0 defs, 185 lines, 0 axioms, 0 sorries — match.
- `theoremCount: 10` vs 11 named actual: harmless **undercount** (the `private zpow_exponent_eq_one'` helper). Not an overclaim.
- Badge `original` / `verified` appropriate. Notably **anti-overclaiming**: the file explicitly proves the naive `|M|`-order surrogate is *false* on the `ZMod 4` multiplicative monoid (cube image {0,1,3} ≠ full monoid), and honestly labels the exp-based full-monoid reading as degenerate/vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)