### PR TITLE
audit: reland catalan-numbers oq001/oq002/oq004 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30758,6 +30758,24 @@
       "lastAudited": "2026-07-21T10:11:03Z",
       "result": "clean",
       "issues": []
+    },
+    "catalan-numbers-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:22:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "catalan-numbers-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:22:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "catalan-numbers-oq004": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:22:49Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Re-lands three clean audit tracker entries whose original PRs went CONFLICTING after sibling oq003 merged.

Supersedes #40360, #40361, #40363 (all conflicting; closing).

All build-verified clean per prior audit batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)