### PR TITLE
audit: cauchy-group-theorem-oq007 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30776,6 +30776,12 @@
       "lastAudited": "2026-07-21T10:22:49Z",
       "result": "clean",
       "issues": []
+    },
+    "cauchy-group-theorem-oq007": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:24:53Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Clean audit. 12thm/0def/0ax/0sorry (all match meta), 212 lines. No native_decide (kernel decide only). Build-verified — #print axioms = [propext, Classical.choice, Quot.sound] only. Exemplary: explicitly proves the monoid converse fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)