### PR TITLE
audit: cauchy-interlacing-theorem-oq002 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30776,6 +30776,12 @@
       "lastAudited": "2026-07-21T10:22:49Z",
       "result": "clean",
       "issues": []
+    },
+    "cauchy-interlacing-theorem-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:30:03Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Clean audit. 16thm/4def/0ax/0sorry, 345 lines. No native_decide. Build-verified (deprecation warnings only). Headline theorems genuinely prove Poincaré separation λ_{k+m}≤μ_k≤λ_k. #print axioms = [propext, Classical.choice, Quot.sound] only. badge mathlib correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)