### PR TITLE
Enrich 3 entries: re-anchor drifted tail sections to EOF

### DIFF
--- a/src/data/proofs/erdos-1063/meta.json
+++ b/src/data/proofs/erdos-1063/meta.json
@@ -116,12 +116,20 @@
       "mathContext": "Monier: $n_k \\leq k!$; Cambie: $n_k \\leq k \\cdot \\text{lcm}(2,\\ldots,k-1) \\leq e^{(1+o(1))k}$; open: $\\exists C,\\, n_k \\leq k^C$?"
     },
     {
+      "id": "unified-existence",
+      "title": "Problem Statement & Unified Existence",
+      "startLine": 133,
+      "endLine": 163,
+      "summary": "`ErdosProblem1063` proposition (the formal open statement) and Part V.5 `threshold_exists`: for every $k \\geq 2$ a threshold $n_k$ exists — bare existence with no size bound, via `monier_factorial_bound` for $k \\geq 3$ and `threshold_k2` for $k = 2$",
+      "mathContext": "`ErdosProblem1063` proposition (the formal open statement) and Part V.5 `threshold_exists`: for every $k \\geq 2$ a threshold $n_k$ exists — bare existence with no size bound, via `monier_factorial_bound` for $k \\geq 3$ and `threshold_k2` for $k = 2$"
+    },
+    {
       "id": "summary",
       "title": "Summary",
-      "startLine": 133,
-      "endLine": 159,
-      "summary": "`erdos_1063_summary`: combines Erdős-Selfridge nondivisibility with Monier bound via `exact ⟨..., ...⟩`",
-      "mathContext": "`erdos_1063_summary`: combines Erdős-Selfridge nondivisibility with Monier bound via `exact ⟨..., ...⟩`"
+      "startLine": 164,
+      "endLine": 191,
+      "summary": "`erdos_1063_summary`: bundles the Erdős–Selfridge non-divisibility ($\\forall k \\geq 2,\\, n \\geq 2k : \\text{divisibilityCount}(n,k) < k$) with Monier's factorial bound ($n_k \\leq k!$) via `exact ⟨..., ...⟩`; the growth rate — polynomial versus exponential — remains OPEN",
+      "mathContext": "`erdos_1063_summary`: bundles the Erdős–Selfridge non-divisibility ($\\forall k \\geq 2,\\, n \\geq 2k : \\text{divisibilityCount}(n,k) < k$) with Monier's factorial bound ($n_k \\leq k!$) via `exact ⟨..., ...⟩`; the growth rate — polynomial versus exponential — remains OPEN"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-162/meta.json
+++ b/src/data/proofs/erdos-162/meta.json
@@ -88,24 +88,31 @@
     },
     {
       "id": "derived",
-      "title": "Derived Results",
+      "title": "Part VI: Derived Results",
       "startLine": 181,
-      "endLine": 185,
-      "summary": "Proves half_is_extremal: F(n,1/2) ≤ F(n,α) directly from monotonicity axiom."
+      "endLine": 193,
+      "summary": "The Θ(log n) sandwich `discrepancy_theta_log` (F(n,α) bounded above and below by constant multiples of log n) and `half_is_extremal`: F(n,1/2) ≤ F(n,α), extracted from the monotonicity axiom."
     },
     {
       "id": "main-conjecture",
-      "title": "Main Conjecture",
-      "startLine": 187,
-      "endLine": 199,
-      "summary": "Defines ErdosProblem162: F(n,α)/log n → c_α via ε-δ convergence for every 0 < α ≤ 1/2."
+      "title": "Part VII: Main Conjecture",
+      "startLine": 194,
+      "endLine": 207,
+      "summary": "Defines `ErdosProblem162`: for every 0 < α ≤ 1/2 there is a constant c_α > 0 with F(n,α)/log n → c_α, stated via ε-δ convergence — strictly stronger than the Θ(log n) bounds, asserting a definite limit rather than mere boundedness."
     },
     {
       "id": "examples",
-      "title": "Computational Examples",
-      "startLine": 201,
-      "endLine": 213,
-      "summary": "Verifies C(1,2)=0, C(2,2)=1, C(4,2)=6, C(8,2)=28 via native_decide."
+      "title": "Part VIII: Computational Examples",
+      "startLine": 208,
+      "endLine": 220,
+      "summary": "Concrete edge counts K_n = C(n,2): verifies C(1,2)=0, C(2,2)=1, C(4,2)=6, C(8,2)=28 via native_decide (benign — `example` blocks, not part of the axiomatized claim)."
+    },
+    {
+      "id": "summary",
+      "title": "Summary & Connections",
+      "startLine": 221,
+      "endLine": 244,
+      "summary": "Status recap: F(n,α) = Θ(log n) is known (probabilistic method for the lower bound, counting for the upper); the OPEN part is convergence of the ratio to a limit c_α and determining c_α. Interpolates between Ramsey numbers (α near 0) and discrepancy theory (α = 1/2); related to Erdős #617."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-249-oq-01/meta.json
+++ b/src/data/proofs/erdos-249-oq-01/meta.json
@@ -105,9 +105,16 @@
     {
       "id": "tighter-interval-2",
       "title": "Part VII: Second Tightening (87/64, 351/256) and 4/3 Exclusion",
-      "summary": "Terms n=7..10 computed exactly. partial_sum_11 = 87/64. Tail splitting at n=11 gives upper bound < 351/256. totientPowerSum_ne_four_thirds proved since 87/64 > 4/3.",
+      "summary": "Terms n=7..10 computed exactly. partial_sum_11 = 87/64. Tail splitting at n=11 gives upper bound < 351/256. `totientPowerSum_ne_four_thirds` proved since 87/64 > 4/3 (261/192 vs 256/192).",
       "startLine": 205,
-      "endLine": 303
+      "endLine": 311
+    },
+    {
+      "id": "summary",
+      "title": "§ Summary: The Interval (87/64, 351/256)",
+      "summary": "Collects the tight bounds $87/64 < \\sum \\varphi(n)/2^n < 351/256$ (value $\\approx 1.368$, width $3/256 \\approx 0.012$): the sum is not an integer, half-integer, quarter-integer, nor $4/3$. Status: OPEN — irrationality of the value remains unknown despite the narrow pinning.",
+      "startLine": 312,
+      "endLine": 334
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Re-anchors drifted/undercovered tail sections in three gallery entries so `sections` covers each Lean file to EOF. All changes are `meta.json` `sections` only; no Lean code touched.

## erdos-1063 (`Proofs/Erdos1063Problem.lean`, 191 lines)
The "Summary" section's summary described `erdos_1063_summary` (line 183) but its anchor stopped at 159, leaving Part V.5 (`threshold_exists`) and all of Part VI uncovered. Split into:
- **Problem Statement & Unified Existence** (133-163): `ErdosProblem1063` proposition + `threshold_exists`.
- **Summary** (164-191): the real `erdos_1063_summary` capstone theorem.

## erdos-249-oq-01 (`Proofs/Erdos249OQ01.lean`, 334 lines)
- Extended **Part VII** (205→311) to include `totientPowerSum_ne_four_thirds`, which its own title already references.
- Added **§ Summary** (312-334): the tight-interval recap (87/64, 351/256).

## erdos-162 (`Proofs/Erdos162Problem.lean`, 245 lines)
Three tail sections had summaries pointing past their ranges (main-conjecture described the `def` at 202 while ending at 199; examples described the C(n,2) `native_decide` checks at 212-220 while ending at 213). Re-anchored to their Part banners:
- Part VI: Derived Results (181-193)
- Part VII: Main Conjecture (194-207)
- Part VIII: Computational Examples (208-220)
- Summary & Connections (221-244)

Coverage after: all three reach EOF (gap 0/0/1, the last being a trailing blank line). Pre-existing blank-line gaps between Parts left intact. JSON validated via node parse; `pnpm build` skipped to avoid the ~2135-file regeneration noise.
