### PR TITLE
Enrich 5 entries: cover uncovered summary/conclusion tails to EOF

### DIFF
--- a/src/data/proofs/abel-ruffini-oq004/meta.json
+++ b/src/data/proofs/abel-ruffini-oq004/meta.json
@@ -137,6 +137,14 @@
       "endLine": 202,
       "summary": "derived_length_gap (A₄'s series reaches ⊥, A₅'s never does), a4_exact_derived_length (length of A₄ is exactly 2), and derived_length_sequence (the derived-length profile 1,2,∞ for A₃,A₄,A₅, with A₃ abelian by a decide computation).",
       "mathContext": "The gap theorem juxtaposes a finite-length witness for A₄ with the universal non-reachability for A₅. The sequence theorem records the discontinuity: derived lengths 0,0,0 (A₀,A₁,A₂ trivial), 1 (A₃ ≅ ℤ/3 abelian), 2 (A₄), then ∞ from A₅ onward — the precise location of the Abel–Ruffini threshold."
+    },
+    {
+      "id": "summary",
+      "title": "Summary: Theorem Ledger and Axiom Status",
+      "startLine": 203,
+      "endLine": 232,
+      "summary": "Closing docstring tabulating all 11 proved theorems (A₄ non-abelian; its derived series reaching ⊥ at length exactly 2; A₅ perfect with derived series never leaving ⊤, hence infinite derived length; and the derived-length profile 0,0,0,1,2,∞ across A₀–A₅) and confirming 0 sorries, 0 axioms. Notes that `a4_derived2_eq_bot` reuses the parent's identification of ⁅A₄,A₄⁆ with the Klein four-group V₄ via kernel `decide` (no `native_decide`), so the whole chain is genuinely axiom-free.",
+      "mathContext": "11 theorems, 0 sorries, 0 axioms. $\\langle A_4, A_4 \\rangle = V_4$ (Klein four-group) is abelian, so $D^2(A_4) = \\bot$ by kernel `decide`; $A_5$ is perfect ($\\langle A_5, A_5 \\rangle = \\top$), so its derived series is constant at $\\top$ and never reaches $\\bot$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03/meta.json
@@ -122,10 +122,18 @@
     {
       "id": "verification",
       "title": "Concrete Verification",
-      "summary": "Numerical checks via native_decide",
+      "summary": "Numerical checks via native_decide: `simplicial 3 3 = 20` and the antidiagonal convolution `∑ simplicial 1 p.1 · simplicial 1 p.2 = 20` over `antidiagonal 3`.",
       "startLine": 167,
-      "endLine": 178,
+      "endLine": 182,
       "mathContext": "Verification: $a=b=1, n=3$ gives $(1 \\cdot 4) + (2 \\cdot 3) + (3 \\cdot 2) + (4 \\cdot 1) = 20 = \\binom{6}{3}$."
+    },
+    {
+      "id": "summary",
+      "title": "Summary: The Generating-Function Proof",
+      "summary": "Closing docstring on the generating-function route to the parallel Vandermonde identity: define negBin(k) = (∑ xⁿ)^{k+1} as a formal power series, prove its n-th coefficient is C(n+k, k) (induction + 1D hockey stick), reduce the identity to negBin(a)·negBin(b) = negBin(a+b+1) — literally `pow_add` — then extract coefficients. This replaces the parent file's nested induction on (b, n) with a trivial algebraic identity in the power-series ring, shifting the combinatorial work to the coefficient-extraction lemma. (The numerical checks use native_decide, so the entry is axiomatized via Lean.ofReduceBool.)",
+      "startLine": 183,
+      "endLine": 208,
+      "mathContext": "$\\mathrm{negBin}(k) = \\left(\\sum_n x^n\\right)^{k+1}$ with $[x^n]\\,\\mathrm{negBin}(k) = \\binom{n+k}{k}$; the identity $\\mathrm{negBin}(a)\\cdot\\mathrm{negBin}(b) = \\mathrm{negBin}(a+b+1)$ is `pow_add`, and coefficient extraction yields the Vandermonde convolution."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/buffons-needle-oq-02-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-02/meta.json
@@ -150,6 +150,14 @@
       "endLine": 346,
       "summary": "Helix and great circle examples. A helix of arc length 2π√(r²+h²) has expected crossings π√(r²+h²)/d.",
       "mathContext": "Helix: $L = 2\\pi\\sqrt{r^2+h^2}$, $E = \\pi\\sqrt{r^2+h^2}/d$. Great circle: $L = 2\\pi R$, $E = \\pi R/d$."
+    },
+    {
+      "id": "conclusion",
+      "title": "Conclusion: Scope of the Axiomatization",
+      "startLine": 347,
+      "endLine": 377,
+      "summary": "Closing docstring: the 3D smooth Buffon noodle formula E = L/(2d) is formalized with 2 axioms (smooth3DExpectedCrossings, smooth3D_buffon_eq) and 0 sorries, with verified consequences (shape independence, monotonicity, nonnegativity, approximation convergence, dimension comparison, Lipschitz stability). Explains why a full formalization is axiomatized: it would require the Grassmannian Gr(2,3), the invariant Haar measure on Gr(2,3) ≅ S², a crossing-count function, and the Cauchy–Crofton identity — beyond current Mathlib. The crossing factor α₃ = 1/2 (sphere average of |cos φ|) determines the 3D formula just as α₂ = 2/π governs the 2D case.",
+      "mathContext": "Axiomatized because Gr(2,3), its Haar measure, and Cauchy–Crofton are not yet in Mathlib. Crossing factor $\\alpha_3 = \\mathbb{E}_{S^2}[|\\cos\\varphi|] = \\tfrac12$ gives $E = L/(2d)$, mirroring $\\alpha_2 = 2/\\pi$ in the 2D case; the smooth extension follows by approximation and continuity."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/cevas-theorem-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-04-oq-01/meta.json
@@ -155,6 +155,14 @@
       "endLine": 184,
       "summary": "The uniform assignment (all masses 1) with uniform_total = n+1 and uniform_ratio = n/(n+1) — the centroid of the n-simplex, the symmetric point where every complement fraction is equal.",
       "mathContext": "Uniform masses: $\\mathrm{total} = n+1$, $\\mathrm{ratio}\\ i = \\dfrac{n}{n+1}$ (the centroid)."
+    },
+    {
+      "id": "summary",
+      "title": "Summary and Next Steps",
+      "startLine": 185,
+      "endLine": 214,
+      "summary": "Closing docstring recapping the n-dimensional development: `MassPoint n` for n+1 positive vertex masses, the complement fraction `ratio i` ∈ (0,1), the Ceva sum identity ∑ ratio i = n, the uniform-mass centroid ratio n/(n+1), and the n=2 check ∑ = 2 — with 0 sorries, 0 axioms, ~10 theorems, 4 definitions. Lists next-iteration candidates: a triangle bridge to the parent `MassPointCeva.MassPoint`, constructive existence of masses from a valid ratio profile, and connecting to Mathlib's affine cevian concurrency.",
+      "mathContext": "$n$-dim mass-point summary: $\\sum_i \\mathrm{ratio}\\ i = n$ with each $\\mathrm{ratio}\\ i \\in (0,1)$; uniform masses give the centroid $\\tfrac{n}{n+1}$. Open follow-ups: bridge to the 2-dimensional parent, a constructive converse (masses from a ratio profile with $\\sum r_i = n$), and geometric cevian concurrency."
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-1006-oq-04/meta.json
+++ b/src/data/proofs/erdos-1006-oq-04/meta.json
@@ -105,6 +105,14 @@
       "endLine": 163,
       "summary": "`coloringOrientation_acyclic_via_rank`: restates OQ03's acyclicity result through the rank lens. `every_graph_has_robust`: restates OQ03's main theorem. Both delegate to OQ03 directly.",
       "mathContext": "Acyclicity follows from rank strictness: any directed path $v_0 \\to v_1 \\to \\cdots \\to v_n$ satisfies $\\text{col}(v_0) < \\text{col}(v_1) < \\cdots < \\text{col}(v_n)$, preventing cycles."
+    },
+    {
+      "id": "summary",
+      "title": "Summary: The Graded-DAG Structure",
+      "startLine": 164,
+      "endLine": 193,
+      "summary": "Closing docstring indexing the file's five parts and their theorems: Part I level structure (`coloringOrientation_rank_strict`, `_has_rank`, `_rank_lt_k`), Part II sources/sinks (`color_zero_no_in_arc`, `color_max_no_out_arc`), Part III arc direction (`_arc_iff`, `_no_back_arc`, `_exactly_one_arc`), Part IV no same-level arcs (`_different_colors`), Part V consistency (`_acyclic_via_rank`, `every_graph_has_robust`). Key insight: the coloring orientation is a graded DAG — level = color value, every arc goes level-up, sources at level 0 and sinks at level k-1.",
+      "mathContext": "Graded DAG: $\\mathrm{level}(v) = \\mathrm{col}(v)$, all arcs go $\\mathrm{col}(u) < \\mathrm{col}(w)$; sources at level $0$, sinks at level $k-1$. The rank-based formulation gives a clean algebraic characterization of the orientation from the coloring."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Adds a final `sections` entry (and, where needed, extends the prior one) to five gallery proofs whose section list stopped before a substantive closing summary/conclusion docstring, so coverage now reaches EOF. `meta.json` `sections` only; no Lean code touched. All files stay well under the 60 KB cap.

## abel-ruffini-oq004 (232 lines)
New **Summary: Theorem Ledger and Axiom Status** (203-232) — 11-theorem ledger + axiom-status note. Verified: 0 `axiom` decls, both `native_decide` hits are in comments → genuinely axiom-free, matching `verified` / `axiomCount: 0`.

## cevas-theorem-oq-04-oq-01 (214 lines)
New **Summary and Next Steps** (185-214) — n-dim mass-point recap (∑ ratio i = n, centroid n/(n+1)) + listed follow-ups.

## buffons-needle-oq-02-oq-02 (377 lines)
New **Conclusion: Scope of the Axiomatization** (347-377) — 2-axiom scope note (`smooth3DExpectedCrossings`, `smooth3D_buffon_eq`), matching `axiomatized` / `axiomCount: 2`.

## arithmetic-series-oq-02-oq-02-oq-03 (208 lines)
Extended **Concrete Verification** to 182 (antidiagonal native_decide check) and added **Summary: The Generating-Function Proof** (183-208) — negBin power-series route to the parallel Vandermonde identity. Summary notes the native_decide dependency (entry is `axiomatized` via `Lean.ofReduceBool`) rather than repeating the docstring's informal "0 axioms".

## erdos-1006-oq-04 (193 lines)
New **Summary: The Graded-DAG Structure** (164-193) — five-part theorem ledger + graded-DAG key insight.

Coverage after: all five reach EOF. JSON validated via node parse; `pnpm build` skipped to avoid the ~2135-file regeneration noise.
