### PR TITLE
audit(cauchy-group-theorem-oq001): mark clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30782,6 +30782,12 @@
       "lastAudited": "2026-07-21T10:30:03Z",
       "result": "clean",
       "issues": []
+    },
+    "cauchy-group-theorem-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:36:54Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Audit result: CLEAN

**Proof**: cauchy-group-theorem-oq001 — "Counting solutions to xⁿ = 1 in a cyclic group: exactly gcd(n, |G|)"

Verified meta.json against Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01.lean:

| Claim | Meta | File | ok |
|-------|------|------|----|
| theoremCount | 5 | 5 (line 145 is a docstring false-positive) | yes |
| axiomCount | 0 | 0 | yes |
| sorries | 0 | 0 | yes |
| badge | original | genuine new exact-count result | yes |
| status | verified | 0 axioms / 0 sorries / no True-stubs | yes |

- No native_decide / decide / admit / sorry.
- Prose is honest: repeatedly states Mathlib records only the one-sided bound IsCyclic.card_pow_eq_one_le (#{a | aⁿ = 1} <= n) and frames this entry as sharpening it to the exact value gcd(n, |G|). Mathlib dependencies exhaustively disclosed.
- original badge is defensible — the main theorem is not a single Mathlib call; the exact count, the arithmetic core lemma, and the subgroup identification are proved independently.

Tracker updated to record the clean audit (compact-oq001 id had no prior tracker entry).

---
Discovered during gallery integrity audit.