### PR TITLE
Enrich 3 entries: re-anchor systematically drifted sections to true banners

### DIFF
--- a/src/data/proofs/collatz-cycles-oq-04/meta.json
+++ b/src/data/proofs/collatz-cycles-oq-04/meta.json
@@ -71,55 +71,55 @@
       "id": "part-ii-cyclic-successor",
       "title": "Part II: The Cyclic Successor Bijection",
       "startLine": 52,
-      "endLine": 60,
+      "endLine": 85,
       "summary": "Defines `cyclicSucc`, the permutation i ↦ (i+1) mod j of Fin j (with explicit inverse i ↦ (i+j−1) mod j), making the cyclic shift a bijection — the key fact that lets the index reordering cancel in the product.",
       "mathContext": "$\\mathrm{cyclicSucc} : \\mathrm{Fin}\\,j \\simeq \\mathrm{Fin}\\,j,\\ i \\mapsto (i+1)\\bmod j$, a cyclic permutation."
     },
     {
       "id": "part-iii-product-identities",
       "title": "Part III: Key Product Identities",
-      "startLine": 61,
-      "endLine": 73,
+      "startLine": 86,
+      "endLine": 98,
       "summary": "Two product lemmas: `prod_perm_eq` (a product over a permuted index equals the original, via Equiv.prod_comp) and `prod_two_pow` (∏ᵢ 2^{mᵢ} = 2^{∑ᵢ mᵢ}).",
       "mathContext": "$\\prod_i f(\\sigma i) = \\prod_i f(i)$ for any permutation $\\sigma$, and $\\prod_i 2^{m_i} = 2^{\\sum_i m_i}$."
     },
     {
       "id": "part-iv-product-equation",
       "title": "Part IV: The Product Equation",
-      "startLine": 74,
-      "endLine": 95,
+      "startLine": 99,
+      "endLine": 121,
       "summary": "The main theorem `cycle_product_equation`: ∏ᵢ(3nᵢ+1) = 2^M·∏ᵢ nᵢ. Proof multiplies the step relations, splits the product (Finset.prod_mul_distrib), then applies the two Part III identities — the cyclic shift bijection reindexes ∏ n_{σ(i)} back to ∏ nᵢ.",
       "mathContext": "$\\prod_i (3 n_i + 1) = \\left(\\prod_i 2^{m_i}\\right)\\left(\\prod_i n_{\\sigma(i)}\\right) = 2^M \\prod_i n_i$."
     },
     {
       "id": "part-v-halving-constraint",
       "title": "Part V: The Halving Constraint",
-      "startLine": 96,
-      "endLine": 145,
+      "startLine": 122,
+      "endLine": 171,
       "summary": "Proves `prod_step_gt` (∏(3nᵢ+1) > 3^j·∏nᵢ for positive nᵢ, by induction on j) and combines it with the product equation to get `halving_constraint`: 2^M > 3^j for every cycle.",
       "mathContext": "Since $3n_i + 1 > 3 n_i$, $\\ \\prod_i(3n_i+1) > 3^j \\prod_i n_i$; with the product equation this forces $2^M > 3^j$."
     },
     {
       "id": "part-vi-no-power-equality",
       "title": "Part VI: No Power Equality",
-      "startLine": 146,
-      "endLine": 163,
+      "startLine": 172,
+      "endLine": 189,
       "summary": "Parity argument: `odd_three_pow` (3^j is odd) and `no_power_eq` (2^M ≠ 3^j for M > 0, since 2^M is even while 3^j is odd).",
       "mathContext": "$3^j \\equiv 1 \\pmod 2$, so for $M \\geq 1$ the even number $2^M$ cannot equal the odd $3^j$."
     },
     {
       "id": "part-vii-min-cycle-length",
       "title": "Part VII: Minimum Cycle Length",
-      "startLine": 164,
-      "endLine": 180,
+      "startLine": 190,
+      "endLine": 206,
       "summary": "Derives the cycle-length lower bound: `two_pow_lt_three_pow` (2^j < 3^j) and `cycle_M_gt_j` (combining 2^M > 3^j with 3^j > 2^j and 2^M ≠ 3^j gives M ≥ j+1).",
       "mathContext": "$2^M > 3^j > 2^j$ together with $2^M \\neq 3^j$ yields $M \\geq j+1$ total halvings."
     },
     {
       "id": "part-viii-connection-oq02",
       "title": "Part VIII: Connection to CollatzCycles.lean (OQ-02)",
-      "startLine": 181,
-      "endLine": 209,
+      "startLine": 207,
+      "endLine": 234,
       "summary": "Recovers the specific small-j results of the companion OQ-02 file as corollaries of the general bound: `min_halvings_j1` through `min_halvings_j4` give the minimum halving counts for j = 1,2,3,4, now uniformly implied by M ≥ j+1.",
       "mathContext": "The cases $j=1,2,3,4$ (min halvings $\\geq j+1$) follow uniformly from `cycle_M_gt_j`, unifying the per-case arguments of CollatzCycles.lean."
     }

--- a/src/data/proofs/hilbert-9-reciprocity-oq-01/meta.json
+++ b/src/data/proofs/hilbert-9-reciprocity-oq-01/meta.json
@@ -104,32 +104,32 @@
     {
       "id": "irreducibility-input",
       "title": "The Arithmetic Input: Irreducibility over ℚ",
-      "startLine": 61,
-      "endLine": 65,
+      "startLine": 73,
+      "endLine": 88,
       "summary": "cyclotomic_irreducible_rat packages Polynomial.cyclotomic.irreducible_rat: the n-th cyclotomic polynomial is irreducible over ℚ. This is the single hypothesis that promotes the embedding Gal(ℚ(ζ_n)/ℚ) ↪ (ℤ/n)ˣ to an isomorphism.",
       "mathContext": "$\\Phi_n(X) \\text{ is irreducible over } \\mathbb{Q}.$"
     },
     {
       "id": "reciprocity-isomorphism",
       "title": "The Reciprocity Isomorphism and its Explicit Action",
-      "startLine": 67,
-      "endLine": 84,
+      "startLine": 89,
+      "endLine": 103,
       "summary": "galEquivUnits builds the isomorphism Gal(ℚ(ζ_n)/ℚ) ≃* (ℤ/n)ˣ from IsCyclotomicExtension.autEquivPow. galEquivUnits_apply_spec records the pointwise action ζ^(galEquivUnits σ).val = σ ζ via IsPrimitiveRoot.autToPow_spec.",
       "mathContext": "$\\mathrm{Gal}(\\mathbb{Q}(\\zeta_n)/\\mathbb{Q}) \\cong (\\mathbb{Z}/n\\mathbb{Z})^\\times, \\quad \\sigma(\\zeta) = \\zeta^{t}.$"
     },
     {
       "id": "group-structure",
       "title": "Homomorphism Properties and Abelianness",
-      "startLine": 86,
-      "endLine": 104,
+      "startLine": 104,
+      "endLine": 124,
       "summary": "galEquivUnits_one and galEquivUnits_mul record that the reciprocity map carries the identity to 1 and composition to multiplication of residues. gal_mul_comm deduces that the Galois group is abelian from the commutativity of (ℤ/n)ˣ.",
       "mathContext": "$\\sigma\\tau = \\tau\\sigma \\text{ for all } \\sigma,\\tau \\in \\mathrm{Gal}(\\mathbb{Q}(\\zeta_n)/\\mathbb{Q}).$"
     },
     {
       "id": "degree-and-instances",
       "title": "Degree Formula and Concrete Instances",
-      "startLine": 106,
-      "endLine": 136,
+      "startLine": 125,
+      "endLine": 161,
       "summary": "card_gal_eq_totient transports cardinality along galEquivUnits and applies ZMod.card_units_eq_totient to get |Gal(ℚ(ζ_n)/ℚ)| = φ(n). card_gal_five, card_gal_seven, card_gal_eight compute φ(5)=4, φ(7)=6, φ(8)=4, the last the first non-cyclic cyclotomic Galois group over ℚ.",
       "mathContext": "$|\\mathrm{Gal}(\\mathbb{Q}(\\zeta_n)/\\mathbb{Q})| = \\varphi(n).$"
     }

--- a/src/data/proofs/vietas-formulas-oq-03-oq-01/meta.json
+++ b/src/data/proofs/vietas-formulas-oq-03-oq-01/meta.json
@@ -85,55 +85,55 @@
       "id": "preamble",
       "title": "Module Header and Imports",
       "startLine": 1,
-      "endLine": 26,
+      "endLine": 31,
       "summary": "Module docstring explaining the generalization strategy: derive Newton's identities for arbitrary n variables from Mathlib's MvPolynomial.mul_esymm_eq_sum via evaluation. Imports MvPolynomial.Symmetric.NewtonIdentities and opens MvPolynomial, Finset namespaces.",
       "mathContext": "The file proves the general Newton identity $k \\cdot e_k(x) = (-1)^{k+1} \\sum_{a+b=k,\\,a<k} (-1)^a e_a(x) p_b(x)$ for $x : \\text{Fin}\\ n \\to R$ in any commutative ring $R$, by specializing Mathlib's abstract MvPolynomial identity via the evaluation homomorphism aeval."
     },
     {
       "id": "concrete-defs",
       "title": "Concrete Definitions",
-      "startLine": 27,
-      "endLine": 42,
+      "startLine": 32,
+      "endLine": 46,
       "summary": "Defines `powerSum k x = ∑ᵢ (x i)^k` and `elemSymm k x = ∑_{|S|=k} ∏_{i∈S} x i` for functions `x : Fin n → R`.",
       "mathContext": "These are the standard concrete forms of symmetric functions, operating on tuples rather than abstract polynomial rings."
     },
     {
       "id": "eval-bridge",
       "title": "Evaluation Bridge",
-      "startLine": 44,
-      "endLine": 58,
+      "startLine": 47,
+      "endLine": 73,
       "summary": "Proves that `aeval x (psum k) = powerSum k x` and `aeval x (esymm k) = elemSymm k x`. These bridge lemmas connect abstract MvPolynomial identities to concrete computations.",
       "mathContext": "The evaluation homomorphism aeval : MvPolynomial σ R →ₐ[R] R sends X i ↦ x i and preserves all ring operations, so it commutes with sums, products, and powers."
     },
     {
       "id": "general-newton",
       "title": "General Newton's Identities",
-      "startLine": 60,
-      "endLine": 102,
+      "startLine": 74,
+      "endLine": 123,
       "summary": "The main results: newton_identity (elementary symmetric form) and newton_identity_psum (power sum form), both for arbitrary n. Derived from Mathlib's MvPolynomial.mul_esymm_eq_sum via evaluation.",
       "mathContext": "k · eₖ(x) = (-1)^{k+1} · Σ_{a+b=k, a<k} (-1)^a · eₐ(x) · p_b(x). This single theorem subsumes all the individual identities from VietasFormulasOQ03.lean."
     },
     {
       "id": "basic-props",
       "title": "Basic Properties",
-      "startLine": 104,
-      "endLine": 118,
+      "startLine": 124,
+      "endLine": 141,
       "summary": "Elementary properties: e₀ = 1, e₁ = Σxᵢ, p₁ = Σxᵢ, and the first Newton identity p₁ = e₁.",
       "mathContext": "These are the base cases that anchor the Newton recurrence."
     },
     {
       "id": "specializations",
       "title": "Specializations to Small n",
-      "startLine": 120,
-      "endLine": 143,
+      "startLine": 142,
+      "endLine": 167,
       "summary": "Ring-verified specializations for n=2 (p₂ = e₁² − 2e₂), n=3 (p₃ = e₁p₂ − e₂p₁ + 3e₃), and n=4 (p₄ = e₁p₃ − e₂p₂ + e₃p₁ − 4e₄), showing consistency with VietasFormulasOQ03.lean.",
       "mathContext": "These concrete identities are the same ones proved case-by-case in the parent file, now available as specializations of the general theorem."
     },
     {
       "id": "vieta-connection",
       "title": "Vieta's Formulas Connection",
-      "startLine": 145,
-      "endLine": 168,
+      "startLine": 168,
+      "endLine": 194,
       "summary": "Vieta product formulas ∏(t − xᵢ) expanded for degrees 2, 3, 4, connecting polynomial coefficients to elementary symmetric polynomials.",
       "mathContext": "Vieta gives coefficients as (−1)^k · eₖ. Newton's identities then recover all power sums from those coefficients."
     }


### PR DESCRIPTION
## Enrichment: re-anchor systematically drifted sections

Three gallery entries had `sections` line-anchors that had drifted **~15–25 lines behind** their true code banners — the Lean files grew but the `startLine`/`endLine` were never updated. The section *summaries* were already accurate (they name the right theorems); only the anchors were stale, so the gallery's line-highlight was cutting off the very declarations each section describes.

| Entry | Drift | Fix |
|-------|-------|-----|
| **collatz-cycles-oq-04** | Parts III–VIII pointed ~25 lines early; Part VIII (endLine 209) cut off `min_halvings_j1..j4` (lines 211–233) | Re-anchored Parts II–VIII to their true `## Part` banners; now covers 1..234 contiguously |
| **vietas-formulas-oq-03-oq-01** | Every section from "Concrete Definitions" on drifted ~14–26 lines; "Vieta's Formulas Connection" (endLine 168) cut off `vieta_product_two/three/four` (174–189) | Re-anchored all 7 sections; covers 1..194 |
| **hilbert-9-reciprocity-oq-01** | All 4 sections pointed ~15–25 lines early (first section anchored into the header docstring at 61 instead of the theorem at 81); "Degree Formula" (endLine 136) cut off `card_gal_five/seven/eight` (137–155) | Re-anchored to true decl ranges; covers 73..161 |

Each section is now contiguous with the next (no internal gaps) and ends before the namespace `end`. **No content, status, badge, or axiomCount changes** — this is purely an accuracy fix to the line anchors so the gallery highlight matches the summaries.

Verified: JSON parses; no anchor exceeds file EOF; anchors match the actual `theorem`/`def`/`## Part` banner lines in each `.lean` file.
