### PR TITLE
audit(cauchy-schwarz-integral oq002-012): mark clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30790,8 +30790,68 @@
       "issues": []
     },
     "cauchy-schwarz-integral-oq002": {
+      "auditCount": 2,
+      "lastAudited": "2026-07-21T10:48:58Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-integral-oq003": {
       "auditCount": 1,
-      "lastAudited": "2026-07-21T10:43:20Z",
+      "lastAudited": "2026-07-21T10:48:58Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-integral-oq004": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:48:58Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-integral-oq005": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:48:58Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-integral-oq006": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:48:58Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-integral-oq007": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:48:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-integral-oq008": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:48:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-integral-oq009": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:48:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-integral-oq010": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:48:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-integral-oq011": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:48:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-integral-oq012": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:48:59Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Gallery integrity audit — cauchy-schwarz-integral cluster (oq002-012)

11 entries audited, all **integrity-clean**.

| entry | title | badge | verdict |
|---|---|---|---|
| oq002-008 | Power-mean monotonicity / equality / chains | original | genuine elementary theorems |
| oq009 | Radon-Nikodym route to Lp duality (finite) | mathlib | genuine complete proof via Mathlib RN; exemplary disclosure |
| oq010-011 | Lp Riesz representation (sigma-finite) | original | genuine assembly; clean Infra/Loc/Norm chain |
| oq012 | Lp restriction / extension-by-zero split | original | 7 genuine theorems |

### Checks
- **Sorries**: 0 real. All grep hits are inside docstrings (history/"no sorry" notes).
- **Axioms**: 0 axiom declarations across cluster and Infra/Loc/Norm dependencies.
- **True-stubs / native_decide**: none.
- **Main theorems**: non-vacuous, standard satisfiable hypotheses; no hard-part-as-hypothesis smuggling.
- **Badges**: match tiers. oq009 mathlib badge correct (Radon-Nikodym); assumptions field discloses `#print axioms` = propext/Classical.choice/Quot.sound only.
- **Build**: files auto-discovered by lakefile `globs = [Proofs.*]` — built by CI.

---
Discovered during gallery integrity audit.