### PR TITLE
audit(tracker): mark cauchy-group-theorem-oq002 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30794,6 +30794,12 @@
       "lastAudited": "2026-07-21T10:43:20Z",
       "result": "clean",
       "issues": []
+    },
+    "cauchy-group-theorem-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:51:41Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean**.

**Proof**: cauchy-group-theorem-oq002 (Counting solutions of xⁿ = g)

## Verification
- **Decls**: 6 theorems, 0 defs, 0 axioms — matches meta (`theoremCount: 6`, `axiomCount: 0`, `definitionCount: 0`).
- **Sorries**: 0 (no `sorry`/`admit`); no `native_decide` (kernel-verified).
- **Core content** (`card_pow_eq_eq_card_pow_one`): coset-bijection cardinality argument proved from scratch; Mathlib calls (`card_image_of_injective`, `IsCyclic.card_powMonoidHom_range/ker`, `Subgroup.eq_of_le_of_card_ge`) are supporting API, not the theorem itself.
- **Transitive check**: parent dependency `card_pow_eq_one_eq_gcd` is itself a real, sorry-free, axiom-free theorem.
- Badge `original` / status `verified` are defensible — the count #{xⁿ=g} = gcd(n,|G|)-or-0 is not a single Mathlib theorem.

`oq002` had no tracker entry (only `oq001` + compound keys), causing perpetual re-serve; this persists the clean result.

---
Discovered during gallery integrity audit.