### PR TITLE
audit(tracker): mark cauchy-group cluster oq003-007 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30794,6 +30794,36 @@
       "lastAudited": "2026-07-21T10:43:20Z",
       "result": "clean",
       "issues": []
+    },
+    "cauchy-group-theorem-oq003": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:53:53Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-group-theorem-oq004": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:53:53Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-group-theorem-oq005": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:53:53Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-group-theorem-oq006": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:53:53Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-group-theorem-oq007": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T10:53:53Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean** (5 entries).

Power-map cluster under `cauchy-group-theorem` (parent oq001/oq002 verified separately). All rely on the verified parent chain + Mathlib; no result is a bare Mathlib wrapper.

| id | thm | ax | sorry | notes |
|----|-----|----|-------|-------|
| oq003 | 7 | 0 | 0 | kernel/image recovery, fibre partition |
| oq004 | 6 | 0 | 0 | exponent governs power map |
| oq005 | 10 | 0 | 0 | monoid extension; honest ZMod4 counterexamples |
| oq006 | 8 | 0 | 0 | constant fibre sizes on abelian groups |
| oq007 | 12 | 0 | 0 | monoid dichotomy, `converse_fails` demonstrated |

## Verification
- Decl counts match meta exactly (oq005's stray "theorem" grep hit was a docstring word).
- No `sorry`/`admit`; no `native_decide` — the `decide` uses are kernel-level (ZMod 4 facts).
- Counterexample theorems (`order_surrogate_fails_zmod4`, `converse_fails`) are honesty-positive: they demonstrate where the cyclic form breaks rather than overclaiming.
- Badge `original` / status `verified` defensible: the counting/partition results are genuine, not single Mathlib theorems.

These `oqNNN` ids had no tracker entries (only `-oq-01…` compound keys), causing perpetual re-serve; this persists the clean results.

---
Discovered during gallery integrity audit.