### PR TITLE
Enrich 6 entries: re-anchor drifted sections + cover uncovered tails to EOF

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/meta.json
@@ -98,8 +98,16 @@
       "id": "chcv-oq02oq03-sec-consequences",
       "title": "Consequences: commutative centralizer and the K[T] inclusion",
       "startLine": 170,
-      "endLine": 197,
+      "endLine": 198,
       "summary": "end_commutant_commutative: two endomorphisms commuting with a cyclic T commute with each other (both are polynomials in T, which commute). aeval_end_commute: the trivial inclusion K[T] ⊆ centralizer(T); together with the main theorem this gives the exact equality centralizer(T) = K[T]."
+    },
+    {
+      "id": "chcv-oq02oq03-sec-adjoin",
+      "title": "Centralizer = K[T] as subalgebras",
+      "startLine": 199,
+      "endLine": 226,
+      "summary": "`end_centralizer_eq_adjoin`: for `T : Module.End K V` with a cyclic vector, the centralizer subalgebra `Subalgebra.centralizer K {T}` equals `Algebra.adjoin K {T} = K[T]`. Packages both inclusions — `commuting_end_is_polynomial` gives centralizer ⊆ K[T] (needs the cyclic vector) and `aeval_end_commute` the trivial K[T] ⊆ centralizer — into one canonical subalgebra equality consumers can use directly.",
+      "mathContext": "$\\{A:AT=TA\\}=K[T]=\\operatorname{adjoin}_K\\{T\\}$ as subalgebras of $\\operatorname{End}_K V$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-327-oq-01/meta.json
+++ b/src/data/proofs/erdos-327-oq-01/meta.json
@@ -55,40 +55,56 @@
       "id": "header-imports",
       "title": "Module Header and Imports",
       "startLine": 1,
-      "endLine": 25,
+      "endLine": 27,
       "summary": "Module header with imports, docstring, and namespace setup."
     },
     {
       "id": "construction",
       "title": "Explicit Construction",
-      "startLine": 26,
-      "endLine": 50,
+      "startLine": 28,
+      "endLine": 57,
       "summary": "Proves that (m(a'+b')a', m(a'+b')b') satisfies sum-divides-product for coprime a', b', and that the pair is distinct when a' ≠ b'.",
       "mathContext": "If $\\gcd(a', b') = 1$ and $m \\geq 1$, then $(m s a', m s b')$ with $s = a' + b'$ satisfies $(a+b) \\mid ab$ since $a+b = m s^2$ divides $a b = m^2 s^2 a' b'$."
     },
     {
       "id": "examples",
       "title": "Concrete Verified Examples",
-      "startLine": 52,
-      "endLine": 76,
+      "startLine": 58,
+      "endLine": 80,
       "summary": "Verifies 5 sum-dvd-prod pairs ((3,6), (4,12), (5,20), (6,12), (10,15)) and 2 non-examples ((2,3), (4,5)) by direct computation.",
       "mathContext": "$(3,6)$: from $(1,2)$ with $m=1$. $(4,12)$: from $(1,3)$ with $m=1$. $(10,15)$: from $(2,3)$ with $m=1$."
     },
     {
       "id": "classification",
       "title": "Classification of Small Pairs",
-      "startLine": 78,
-      "endLine": 86,
+      "startLine": 81,
+      "endLine": 90,
       "summary": "Proves that (3,6) is the smallest sum-dvd-prod pair by exhaustive check of all pairs with b ≤ 5.",
       "mathContext": "For all $1 \\leq a < b \\leq 5$, $(a+b) \\nmid ab$. The first pair is $(3,6)$ from coprime $(1,2)$."
     },
     {
       "id": "counting",
-      "title": "Pair Counting and Density",
-      "startLine": 88,
-      "endLine": 135,
-      "summary": "Defines sumDvdProdPairs and numSumDvdProdPairs, proves the count is 0 for N ≤ 5 and positive for N ≥ 6. States the density conjecture: pair count ~ C·N·log(N).",
+      "title": "Pair Counting",
+      "startLine": 91,
+      "endLine": 122,
+      "summary": "Defines `sumDvdProdPairs N` and `numSumDvdProdPairs N`; proves the count is 0 for N ≤ 5 (`numSumDvdProdPairs_small`) and strictly positive for N ≥ 6 (`numSumDvdProdPairs_pos`), since (3,6) already lies in {1,…,6}.",
       "mathContext": "$\\#\\{(a,b) : 1 \\leq a < b \\leq N,\\; (a+b) \\mid ab\\} = 0$ for $N \\leq 5$, positive for $N \\geq 6$, conjectured $\\Theta(N \\log N)$."
+    },
+    {
+      "id": "density-question",
+      "title": "Density Question",
+      "startLine": 123,
+      "endLine": 146,
+      "summary": "States the open asymptotic-density question via `pairCountAsymptotics`: the number of sum-divides-product pairs in {1,…,N} is conjectured to grow as Θ(N·log N). `SumDvdProdTriple N` records the conjectured bijection between such pairs and coprime triples (a′,b′,m).",
+      "mathContext": "$\\#\\{(a,b):1\\le a<b\\le N,\\ a{+}b\\mid ab\\}\\sim C\\,N\\log N$."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 147,
+      "endLine": 164,
+      "summary": "`construction_produces_valid_pairs`: the explicit map $(m,a′,b′)\\mapsto(m\\,s\\,a′,\\ m\\,s\\,b′)$ with $s=a′+b′$ always yields a valid distinct sum-divides-product pair, tying the construction, enumeration, and Θ(N log N) density heuristic together.",
+      "mathContext": "$m(a′+b′)a′ < m(a′+b′)b′$ and $(a+b)\\mid ab$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-395-oq-01/meta.json
+++ b/src/data/proofs/erdos-395-oq-01/meta.json
@@ -66,63 +66,63 @@
       "id": "header",
       "title": "Background and Imports",
       "startLine": 1,
-      "endLine": 31,
+      "endLine": 34,
       "summary": "States Erdős #395 OQ-01: the exact optimal constant $c$ in the reverse Littlewood–Offord bound $P(|\\sum\\varepsilon_i z_i|\\leq\\sqrt2)\\geq c/n$. HJNS (2024) prove $c>0$ exists but not its value. This file proves structural bounds, that the threshold-1 problem is false (now a theorem from a counterexample axiom), monotonicity, positivity of $c$, and rate tightness. Imports the parent `Erdos395Problem`.",
       "mathContext": "Optimal $c$ in $P(|\\sum\\varepsilon_i z_i|\\leq\\sqrt2)\\geq c/n$; exact value OPEN (HJNS 2024)."
     },
     {
       "id": "restored-axioms",
       "title": "§ 0. Restored Axioms",
-      "startLine": 32,
-      "endLine": 54,
+      "startLine": 35,
+      "endLine": 80,
       "summary": "Re-declares two AXIOMS the file depends on (removed from the parent in a cleanup): `counterexample_always_large` (the Carnielli–Carolino example has $|\\text{sum}|\\geq\\sqrt2$ for all sign vectors) and `extremal_example_tight` (the half-1s/half-$i$s example achieves probability $\\Theta(1/n)$).",
       "mathContext": "Axioms: counterexample $|\\text{sum}|\\geq\\sqrt2$; extremal example probability $\\Theta(1/n)$."
     },
     {
       "id": "optimal-constant",
       "title": "§ 1. The Optimal Constant",
-      "startLine": 55,
-      "endLine": 127,
+      "startLine": 81,
+      "endLine": 154,
       "summary": "Defines `optimalConstant` $c^*$ (the sSup of valid constants). PROVES `valid_constants_nonempty` (from HJNS 2024), `valid_constants_bddAbove` ($c\\leq1$, via $n=1$, $z=1$ giving probability $1$), and `optimal_constant_pos` ($c^*>0$).",
       "mathContext": "$c^*=\\sup\\{c>0:\\forall n,z\\ \\text{unit},\\ P\\geq c/n\\}$; $0<c^*\\leq1$."
     },
     {
       "id": "original-false",
       "title": "§ 2. Derivation: Original Problem is False",
-      "startLine": 128,
-      "endLine": 182,
+      "startLine": 155,
+      "endLine": 210,
       "summary": "PROVES `counterexample_exceeds_one` (the counterexample has $|\\text{sum}|\\geq\\sqrt2>1$) and `erdos_original_is_false_proved` (was an axiom): at $n=2$ the Carnielli–Carolino example $z_1=1,z_2=i$ has $|\\varepsilon_1+i\\varepsilon_2|\\geq\\sqrt2>1$ for all signs, so the threshold-1 count is $0$, refuting $\\geq c/n$.",
       "mathContext": "Threshold-1 problem FALSE: $n=2$, $z=(1,i)$ gives $|\\text{sum}|\\geq\\sqrt2>1$ always."
     },
     {
       "id": "monotonicity",
       "title": "§ 3. Monotonicity in Threshold",
-      "startLine": 183,
-      "endLine": 196,
+      "startLine": 211,
+      "endLine": 224,
       "summary": "PROVES `count_monotone_threshold`: $t_1\\leq t_2\\Rightarrow\\#\\{|\\text{sum}|\\leq t_1\\}\\leq\\#\\{|\\text{sum}|\\leq t_2\\}$.",
       "mathContext": "Count of small-sum sign vectors is monotone in the threshold."
     },
     {
       "id": "sqrt2-critical",
       "title": "§ 4. The √2 Threshold is Critical",
-      "startLine": 197,
-      "endLine": 210,
+      "startLine": 225,
+      "endLine": 238,
       "summary": "PROVES `sqrt2_is_critical`: the $1/n$ bound holds at threshold $\\sqrt2$ (HJNS) but fails at threshold $1$ (Carnielli–Carolino) — so $\\sqrt2$ is the boundary.",
       "mathContext": "$\\sqrt2$ critical: bound holds at $\\sqrt2$, fails at $1$."
     },
     {
       "id": "rate-tight",
       "title": "§ 5. Optimality of the 1/n Rate",
-      "startLine": 211,
-      "endLine": 230,
+      "startLine": 239,
+      "endLine": 258,
       "summary": "PROVES `rate_is_tight` (the extremal example has probability $\\Theta(1/n)$, so $1/n$ cannot improve to $1/n^{1-\\varepsilon}$, from `extremal_example_tight`) and `extremal_is_unit` (the extremal example uses unit vectors $1$ and $i$).",
       "mathContext": "Rate $1/n$ tight: extremal example probability $\\Theta(1/n)$."
     },
     {
       "id": "summary",
       "title": "§ 6. Summary",
-      "startLine": 231,
-      "endLine": 247,
+      "startLine": 259,
+      "endLine": 275,
       "summary": "PROVES `optimal_constant_summary`: $c>0$ exists (HJNS) and the $1/n$ rate is tight (extremal example); the exact value of $c$ remains OPEN.",
       "mathContext": "Summary: $c>0$ exists, rate $1/n$ tight; exact $c$ OPEN."
     }

--- a/src/data/proofs/erdos-964/meta.json
+++ b/src/data/proofs/erdos-964/meta.json
@@ -82,69 +82,69 @@
       "title": "The Divisor Function",
       "summary": "tau definition and basic properties",
       "startLine": 40,
-      "endLine": 72,
+      "endLine": 74,
       "mathContext": "Formal definition: tau definition and basic properties"
     },
     {
       "id": "ratios",
       "title": "Ratios of Consecutive Values",
       "summary": "divisorRatio, ratioSet definitions",
-      "startLine": 73,
-      "endLine": 90,
+      "startLine": 75,
+      "endLine": 92,
       "mathContext": "Formal definition: divisorRatio, ratioSet definitions"
     },
     {
       "id": "conjecture",
       "title": "The Conjecture",
       "summary": "isDenseInPositives, ErdosConjecture964",
-      "startLine": 91,
-      "endLine": 108,
+      "startLine": 93,
+      "endLine": 110,
       "mathContext": "Mathematical content: isDenseInPositives, ErdosConjecture964"
     },
     {
       "id": "eberhard",
       "title": "Eberhard's Theorem",
       "summary": "Main theorem and proof",
-      "startLine": 109,
-      "endLine": 154,
+      "startLine": 111,
+      "endLine": 188,
       "mathContext": "Verified: Main theorem and proof"
     },
     {
       "id": "examples",
       "title": "Examples",
       "summary": "Small examples and special cases",
-      "startLine": 155,
-      "endLine": 196,
+      "startLine": 189,
+      "endLine": 236,
       "mathContext": "Mathematical content: Small examples and special cases"
     },
     {
       "id": "ktuple",
       "title": "Prime k-Tuple Connection",
       "summary": "Conditional result",
-      "startLine": 197,
-      "endLine": 224
+      "startLine": 237,
+      "endLine": 258
     },
     {
       "id": "stronger",
       "title": "Stronger Results",
       "summary": "AllRationalsAppear",
-      "startLine": 225,
-      "endLine": 253
+      "startLine": 259,
+      "endLine": 289
     },
     {
       "id": "statistics",
       "title": "Statistics",
       "summary": "averageRatio, distribution",
-      "startLine": 254,
-      "endLine": 282,
+      "startLine": 290,
+      "endLine": 308,
       "mathContext": "Mathematical content: averageRatio, distribution"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_964, erdos_964_answer",
-      "startLine": 283,
-      "endLine": 312,
+      "startLine": 309,
+      "endLine": 340,
       "mathContext": "Mathematical content: erdos_964, erdos_964_answer"
     }
   ],

--- a/src/data/proofs/euler-identity-oq001/meta.json
+++ b/src/data/proofs/euler-identity-oq001/meta.json
@@ -103,10 +103,18 @@
   },
   "sections": [
     {
+      "id": "sec-overview",
+      "title": "Overview: Euler’s formula as a smooth Lie group exponential",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Module docstring framing the open question and its affirmative answer: the parent’s continuous homomorphism $t\\mapsto e^{it}$ is repackaged as Mathlib’s smooth (C∞, in fact analytic) Lie group exponential map `Circle.exp` on the circle group `S¹`, with Lie algebra the imaginary axis $i\\mathbb{R}$. Lists the four ingredients (bridge, smoothness, homomorphism, Lie algebra) and the 0-axiom / 0-sorry status.",
+      "mathContext": "$e^{it}:(\\mathbb{R},+)\\to S^1$ realised as the Lie group exponential; Lie algebra $\\mathfrak{u}(1)=i\\mathbb{R}$ with generator $i$."
+    },
+    {
       "id": "sec-bridge",
       "title": "§1. Bridge: the parent map is Mathlib's Lie group exponential",
       "startLine": 56,
-      "endLine": 67,
+      "endLine": 68,
       "summary": "Proves circleMap t = ↑(Circle.exp t), identifying the gallery construction with Mathlib's canonical circle exponential, the object carrying the smooth Lie group structure.",
       "concepts": [
         "complex exponential",
@@ -118,7 +126,7 @@
       "id": "sec-smoothness",
       "title": "§2. Smoothness: the C∞ (in fact analytic) Lie group exponential",
       "startLine": 69,
-      "endLine": 81,
+      "endLine": 82,
       "summary": "States contMDiff_circleExp_packaged: Circle.exp is ContMDiff of every order m, so C∞ (m = ∞) and analytic (m = ω), within Mathlib's LieGroup framework.",
       "concepts": [
         "ContMDiff",
@@ -131,7 +139,7 @@
       "id": "sec-homomorphism",
       "title": "§3. Homomorphism in the genuine circle group",
       "startLine": 83,
-      "endLine": 96,
+      "endLine": 97,
       "summary": "Proves circleExp_homomorphism (Circle.exp_add) and circleHom_coe_eq_circleExp, relating the parent's circleHom into ℂˣ to Mathlib's Circle.exp.",
       "concepts": [
         "group homomorphism",
@@ -143,7 +151,7 @@
       "id": "sec-lie-algebra",
       "title": "§4. Lie algebra iℝ: the left-invariant velocity field",
       "startLine": 98,
-      "endLine": 126,
+      "endLine": 127,
       "summary": "Proves the defining ODE γ'(t) = γ(t)·I (hasDerivAt_circleExp), the velocity at the identity γ'(0) = I (hasDerivAt_circleExp_zero), and that the generator lies on the imaginary axis (generator_mem_imaginary_axis).",
       "concepts": [
         "Lie algebra",
@@ -153,10 +161,18 @@
       ]
     },
     {
+      "id": "sec-lattice",
+      "title": "§4b. The integral lattice 2πℤ: kernel of the exponential",
+      "startLine": 128,
+      "endLine": 154,
+      "summary": "Proves `circleExp_eq_one_iff`: `Circle.exp t = 1 ↔ ∃ n : ℤ, t = n·(2π)`, identifying the kernel of the Lie group exponential as the integral lattice $2\\pi\\mathbb{Z}\\subseteq i\\mathbb{R}$. This period lattice realises the circle as the quotient $S^1\\cong\\mathbb{R}/2\\pi\\mathbb{Z}$ of its Lie algebra.",
+      "mathContext": "$\\ker(\\exp)=2\\pi\\mathbb{Z}$, hence $S^1\\cong\\mathbb{R}/2\\pi\\mathbb{Z}$."
+    },
+    {
       "id": "sec-summary",
       "title": "§5. Summary",
-      "startLine": 128,
-      "endLine": 147,
+      "startLine": 155,
+      "endLine": 176,
       "summary": "Bundles homomorphism, all-order smoothness, and the Lie algebra generator into the theorem main, the packaged answer to the open question.",
       "concepts": [
         "summary",

--- a/src/data/proofs/russell-1-plus-1-oq-04/meta.json
+++ b/src/data/proofs/russell-1-plus-1-oq-04/meta.json
@@ -73,7 +73,7 @@
       "id": "header",
       "title": "Module Header: Taxonomy Table and References",
       "startLine": 1,
-      "endLine": 57,
+      "endLine": 60,
       "summary": "Module docstring with full taxonomy table (six encodings × rule subset × step count), incomparability and ζ-dominance observations, and references (Coquand-Huet, de Moura-Ullrich, Principia Mathematica). Imports `Proofs.OnePlusOne` (no Mathlib).",
       "mathContext": "The taxonomy: ∅ (unfolded), {δ, ι} (Peano), {δ, ι, β} (raw recursor), {δ, β} (Church), {δ, ι} (binary), {δ, ι, ζ} (let-bound Peano). Step counts 0, 5, 6, 6, 3, 7 respectively. Church-Rosser ensures order-independence of the rule *set* (but not of the count). Two structural observations: rows 1 and 3 are incomparable in the subset order (no minimum); row 5 strictly dominates row 1 by {δ, ι} ⊊ {δ, ι, ζ}."
     },
@@ -81,7 +81,7 @@
       "id": "row-0-unfolded",
       "title": "Row 0 — Unfolded Baseline (Rules = ∅)",
       "startLine": 61,
-      "endLine": 69,
+      "endLine": 70,
       "summary": "`theorem row0_unfolded`: both sides are already in fully-applied constructor form `Peano.ℕ.succ (Peano.ℕ.succ Peano.ℕ.zero)`. Witnesses the bottom of the subset lattice: no reduction is required because the goal is already a syntactic identity.",
       "mathContext": "Goal: `succ (succ zero) = succ (succ zero)`. Closed by `Eq.refl _` without any kernel rewrite. `Rules(E) = ∅`, step count = 0."
     },
@@ -89,7 +89,7 @@
       "id": "row-1-peano-pattern",
       "title": "Row 1 — Pattern-Matched Peano (Rules = {δ, ι})",
       "startLine": 71,
-      "endLine": 82,
+      "endLine": 83,
       "summary": "`theorem row1_peano_pattern`: the parent file's encoding. Kernel sequence: δ unfolds `Peano.one`, `Peano.add`, `Peano.two`; ι reduces the two pattern-match clauses of `Peano.add`. 5 steps total. β is *hidden* inside ι because the equation compiler folds the case-split lambda.",
       "mathContext": "`Peano.one + Peano.one ▷_δ succ zero + succ zero ▷_ι succ (succ zero + zero) ▷_ι succ (succ zero) ≡ Peano.two`. δ unfolds the three abbreviations; ι reduces the recursive and base cases."
     },
@@ -97,7 +97,7 @@
       "id": "row-2-peano-recursor",
       "title": "Row 2 — Raw Recursor (Rules = {δ, ι, β})",
       "startLine": 84,
-      "endLine": 108,
+      "endLine": 109,
       "summary": "`noncomputable def addRec` via `Peano.ℕ.rec` with `(motive := fun _ => Peano.ℕ)`, then `theorem row2_peano_recursor`. The step function `fun _ acc => Peano.ℕ.succ acc` is a literal lambda, so β reappears as a separate rule. 6 steps total. Marked `noncomputable` because Lean's code generator does not support `Peano.ℕ.rec` with non-Prop motives at runtime — kernel reduction (for `rfl`) is unaffected.",
       "mathContext": "Kernel sequence: δ unfolds `addRec`, `one`, `two`; ι fires `Nat.rec_succ` then `Nat.rec_zero`; β applies the step function `fun _ acc => succ acc` twice. This row exposes the β-redex that pattern matching hides inside ι."
     },
@@ -105,7 +105,7 @@
       "id": "row-3-church",
       "title": "Row 3 — Church Numerals (Rules = {δ, β})",
       "startLine": 110,
-      "endLine": 136,
+      "endLine": 137,
       "summary": "Pure lambda calculus: `def Church : Type 1 := (α : Type) → (α → α) → α → α`. Church numerals `cOne`, `cTwo` and `cAdd := fun m n => fun α f x => m α f (n α f x)`. `theorem row3_church : cAdd cOne cOne = cTwo := rfl`. 6 steps: δ unfolds `cAdd`, `cOne` (twice), `cTwo`; β fires three nested lambda applications. **No ι** because there are no constructors to match — this is the structural incomparability with the Peano row.",
       "mathContext": "`Church` lives in `Type 1` because Π over `Type 0` raises the universe. `cAdd cOne cOne = fun α f x => cOne α f (cOne α f x) = fun α f x => f (f x) = cTwo` — purely β-reduction after δ-unfolding."
     },
@@ -113,7 +113,7 @@
       "id": "row-4-binary",
       "title": "Row 4 — Binary Naturals (Rules = {δ, ι})",
       "startLine": 138,
-      "endLine": 175,
+      "endLine": 176,
       "summary": "Little-endian binary representation: `inductive Bin = one | b0 | b1`. `Bin.succ` propagates carries via `b1 n → b0 n.succ`. `Bin.add` recurses on the second argument with three cases. `theorem row4_binary : Bin.add Bin.one Bin.one = Bin.b0 Bin.one := rfl` (`2 = 1·2 + 0` in little-endian). 3 steps — the shortest of any encoding for this specific input. Same rule subset as pattern-matched Peano `{δ, ι}` but a different step count and structurally distinct encoding.",
       "mathContext": "`Bin.add m .one = m.succ`; `Bin.one.succ = .b0 .one`. So `Bin.add Bin.one Bin.one ▷_{δ+ι} Bin.one.succ ▷_ι Bin.b0 Bin.one`. The shallow `1+1` depth is *illusory*: for `2^k + 2^k` the carry chain walks the bit-string, giving an `O(k)` ι-step count."
     },
@@ -121,7 +121,7 @@
       "id": "row-5-let",
       "title": "Row 5 — Let-Bound Peano (Rules = {δ, ι, ζ})",
       "startLine": 177,
-      "endLine": 222,
+      "endLine": 223,
       "summary": "`def addLet (n m : Peano.ℕ) := let n' := n; let m' := m; Peano.add n' m'`, then `theorem row5_let : addLet Peano.one Peano.one = Peano.two := rfl`. ζ-demonstrator row: 7 kernel steps (row 1's 5 plus two ζ-steps, one per `let`-binder). Necessity argument (no β/ι/δ rule has `let` in its LHS pattern, so without ζ the LHS is stuck at `let n' := one; let m' := one; Peano.add n' m'`) and sufficiency argument (after ζ fires the term reduces to row 1's LHS) documented in the docstring.",
       "mathContext": "`addLet one one ▷_δ (let n' := one; let m' := one; Peano.add n' m') ▷_ζ (let m' := one; Peano.add one m') ▷_ζ Peano.add one one ▷_{δ+ι+ι} Peano.two`. Isolates ζ as the fourth CIC primitive — not derivable from {β, ι, δ} on closed terms with let-bindings."
     },
@@ -129,9 +129,17 @@
       "id": "part-6-axiom-freedom",
       "title": "Part 6 — Axiom-Freedom Verification (#print axioms)",
       "startLine": 224,
-      "endLine": 249,
+      "endLine": 250,
       "summary": "Six `#print axioms` stanzas, one per row. Each produces a build-time info message confirming the corresponding theorem depends on no axioms — the *propositional* dual to the *reductional* taxonomy of Parts 1–5 plus §5. Doubles as a lightweight regression detector: if a future refactor introduces a `Classical.choice`/`propext`/`Quot.sound` dependency into any row, the build log will surface it by inspection.",
       "mathContext": "Each theorem's axiom set is queried by Lean's kernel introspection. Output for each row: `'<row_name>' does not depend on any axioms`. Establishes that the {β, ι, δ, ζ} reduction alphabet is *all that is needed* — no recourse to extensions of CIC."
+    },
+    {
+      "id": "part-7-schematic-transparency",
+      "title": "Part 7 — Schematic Transparency Lemmas",
+      "startLine": 251,
+      "endLine": 278,
+      "summary": "Strengthens two row witnesses from the single input `1+1` to all inputs: `addLet_eq_add` (the `let`-bound row-5 encoding is definitionally `Peano.add` for every n,m — ζ erases the binders with no residue) and `bin_add_one` (binary `_ + one` is exactly binary successor for every `m : Bin`). Both hold by `rfl`, with `#print axioms` confirming axiom-freedom.",
+      "mathContext": "`addLet n m = Peano.add n m` and `Bin.add m one = m.succ`, both by `rfl` (schematic ζ- and δι-transparency)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Re-anchors drifted section metadata and covers previously-uncovered file tails to EOF for 6 gallery entries. All changes are pure `meta.sections` re-anchors (contiguous `1..EOF`, verified `maxEnd === wc -l`); no `status`/`badge`/`axiomCount`/prose changes.

| Entry | Sections | Fix |
|-------|----------|-----|
| `euler-identity-oq001` | 5→7 | +Overview head; the section labeled "§5. Summary" was anchored on §4b content — split into real **§4b** (integral lattice `2πℤ` = kernel of `Circle.exp`) and **§5 Summary** (headline `main` theorem @163, previously uncovered) |
| `erdos-327-oq-01` | 5→7 | Split "Pair Counting and Density"; added **Density Question** (`pairCountAsymptotics`, `SumDvdProdTriple`) and **Summary** (`construction_produces_valid_pairs` @153) |
| `erdos-395-oq-01` | 8 re-anchor | Full drift: every `§ N` section anchored 25–50 lines ahead of its `-- § N` banner; §6 Summary (`optimal_constant_summary` @264) extended to EOF |
| `erdos-964` | 9 re-anchor | All `## Part I–IX` sections drifted; Part IX Summary (`erdos_964`, `erdos_964_answer`) extended to EOF |
| `russell-1-plus-1-oq-04` | 8→9 | +**Part 7 Schematic Transparency Lemmas** (`addLet_eq_add`, `bin_add_one`, uncovered @251–278) |
| `cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03` | 5→6 | Split capstone `end_centralizer_eq_adjoin` (centralizer = K[T], @203, uncovered) into its own section |

Verified each target against fresh `origin/main` immediately before push (none raced). JSON round-trips validate; encoding preserved (`useAscii=false` all six).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
