### PR TITLE
Enrich 4 entries: re-anchor drifted sections + extend over uncovered tails

### DIFF
--- a/src/data/proofs/combinations-formula-oq-03/meta.json
+++ b/src/data/proofs/combinations-formula-oq-03/meta.json
@@ -178,7 +178,7 @@
       "id": "fano-verifications",
       "title": "Integer Verifications and Fano Plane",
       "startLine": 718,
-      "endLine": 751,
+      "endLine": 780,
       "summary": "Six concrete verifications: [5,2]_1 = 10, [6,3]_1 = 20, [10,4]_1 = 210 (specialization); [3]_2 = 7 (points of Fano plane), [4]_3 = 40 (q-numbers); [3,1]_2 = 7 (lines of Fano plane), [4,2]_2 = 35 (subspaces of F_2^4). All by `native_decide` or `simp`.",
       "mathContext": "The Fano plane is $\\text{PG}(2, \\mathbb{F}_2)$: a projective plane with 7 points and 7 lines, each line containing 3 points and each point on 3 lines. Its point count is $[3]_2 = 1 + 2 + 4 = 7$ and its line count is $\\binom{3}{1}_2 = [3]_2 = 7$. The 35 two-dimensional subspaces of $\\mathbb{F}_2^4$ are the lines and planes of $\\text{PG}(3, \\mathbb{F}_2)$."
     }

--- a/src/data/proofs/erdos-1144/meta.json
+++ b/src/data/proofs/erdos-1144/meta.json
@@ -167,7 +167,7 @@
       "id": "pinch",
       "title": "Growth Rate Pinch Theorem",
       "startLine": 211,
-      "endLine": 226,
+      "endLine": 253,
       "summary": "The main proved result: if the conjecture holds, combined with Atherfold's bound, the growth rate is pinned between C₁√N and C₂√N(log N)^{1+ε}. Proof extracts C₁=1 and C₂ from Atherfold.",
       "mathContext": "The main proved result: if the conjecture holds, combined with Atherfold's bound, the growth rate is pinned between C₁$\\sqrt{N}$ and C₂$\\sqrt{N}$(log N)^{1+ε}. Proof extracts C₁=1 and C₂ from Atherfold."
     }

--- a/src/data/proofs/erdos-558/meta.json
+++ b/src/data/proofs/erdos-558/meta.json
@@ -82,95 +82,95 @@
       "title": "Module Header and Imports",
       "summary": "Module docstring stating Erdős Problem #558 — determine the multicolor Ramsey number $R(K_{s,t};k)$, the least $m$ such that every $k$-colouring of $K_m$ contains a monochromatic $K_{s,t}$ — with status partially solved (asymptotics known). Imports `SimpleGraph` basics/cliques, Finset, and real power functions; `namespace Erdos558`; `open SimpleGraph`.",
       "startLine": 1,
-      "endLine": 35,
+      "endLine": 36,
       "mathContext": "Background: Chung-Graham (1975) gave general bounds and $R(K_{2,2};k)=(1+o(1))k^2$; Alon-Rónyai-Szabó (1999) gave $R(K_{3,3};k)=(1+o(1))k^3$ and $k^t$ growth when $s\\ge(t-1)!+1$. Unlike $R(K_n;2)$, these grow polynomially in $k$."
     },
     {
       "id": "definitions",
       "title": "Part 1: Basic Definitions",
       "summary": "Defines `CompleteBipartite` with $K[s,t]$ notation, `vertexCount` $=s+t$, `edgeCount` $=st$, `EdgeColoring m k` as $\\mathrm{Fin}\\,m\\to\\mathrm{Fin}\\,m\\to\\mathrm{Fin}\\,k$, and `hasMonochromaticBipartite` (disjoint $S,T$ with all cross edges one colour). Axiomatizes `ramseyBipartite` with $R(G;k)$ notation.",
-      "startLine": 36,
-      "endLine": 72,
+      "startLine": 37,
+      "endLine": 73,
       "mathContext": "One structure, five definitions, one axiom (`ramseyBipartite`, the Ramsey number itself)."
     },
     {
       "id": "basic-properties",
       "title": "Part 2: Basic Properties",
       "summary": "Section banner noting that the Ramsey number is well-defined and monotone. Exposition placeholder; declares no Lean content.",
-      "startLine": 73,
-      "endLine": 78,
+      "startLine": 74,
+      "endLine": 79,
       "mathContext": "Empty docstring banner (no definitions, theorems, or axioms)."
     },
     {
       "id": "chung-graham",
       "title": "Part 3: Chung-Graham Bounds (1975)",
       "summary": "Defines the explicit bound functions `chungGrahamLower` and `chungGrahamUpper`, and axiomatizes `chung_graham_bounds`: for $s,t\\ge1$, $k\\ge2$, $\\texttt{chungGrahamLower}\\le R(K[s,t];k)\\le\\texttt{chungGrahamUpper}$.",
-      "startLine": 79,
-      "endLine": 99,
+      "startLine": 80,
+      "endLine": 100,
       "mathContext": "Two definitions and one axiom (`chung_graham_bounds`). The lower bound has the form $\\sim k^{(st-1)/(s+t)}$; the upper bound $\\sim (t-1)(k+k^{1/s})^s$."
     },
     {
       "id": "k22",
       "title": "Part 4: The Case K_{2,2} (Four-Cycle)",
       "summary": "Defines $C_4 = K[2,2]$ and axiomatizes `ramsey_K22`: $R(C_4;k)=\\Theta(k^2)$, i.e. $\\exists c_1,c_2>0$ with $c_1k^2\\le R(C_4;k)\\le c_2k^2$ for $k\\ge2$ (Chung-Graham 1975).",
-      "startLine": 100,
-      "endLine": 113,
+      "startLine": 101,
+      "endLine": 114,
       "mathContext": "One definition and one axiom (`ramsey_K22`)."
     },
     {
       "id": "k33",
       "title": "Part 5: The Case K_{3,3}",
       "summary": "Defines $K_{3,3}=K[3,3]$ and axiomatizes `ramsey_K33`: $R(K_{3,3};k)=\\Theta(k^3)$ (Alon-Rónyai-Szabó 1999, via norm-graph constructions).",
-      "startLine": 114,
-      "endLine": 127,
+      "startLine": 115,
+      "endLine": 128,
       "mathContext": "One definition and one axiom (`ramsey_K33`)."
     },
     {
       "id": "ars-general",
       "title": "Part 6: The General Theorem of Alon-Rónyai-Szabó",
       "summary": "Defines the threshold `criticalS(t) = (t-1)!+1` and axiomatizes `alon_ronyai_szabo`: when $s\\ge(t-1)!+1$ and $t\\ge2$, $R(K[s,t];k)=\\Theta(k^t)$.",
-      "startLine": 128,
-      "endLine": 142,
+      "startLine": 129,
+      "endLine": 143,
       "mathContext": "One definition and one axiom (`alon_ronyai_szabo`), the general $k^t$-growth result above the factorial threshold."
     },
     {
       "id": "statement",
       "title": "Part 7: Erdős Problem #558 Statement",
       "summary": "Proves `erdos_558`: for $s,t\\ge1$, $k\\ge2$, the Chung-Graham bounds hold, and if additionally $s\\ge(t-1)!+1$ the exponent is exactly $t$. Assembled by `constructor` from `chung_graham_bounds` and `alon_ronyai_szabo`.",
-      "startLine": 143,
-      "endLine": 161,
+      "startLine": 144,
+      "endLine": 189,
       "mathContext": "One theorem combining the Part 3 and Part 6 axioms; no new axioms here."
     },
     {
       "id": "norm-graphs",
       "title": "Part 8: Norm Graphs and Lower Bounds",
       "summary": "Section banner for the algebraic (norm-graph) constructions giving tight lower bounds. Exposition placeholder; declares no Lean content.",
-      "startLine": 162,
-      "endLine": 167,
+      "startLine": 190,
+      "endLine": 195,
       "mathContext": "Empty docstring banner."
     },
     {
       "id": "specific-values",
       "title": "Part 9: Specific Values and Bounds",
       "summary": "Section banner for specific values and numeric bounds of $R(K_{s,t};k)$. Exposition placeholder; declares no Lean content.",
-      "startLine": 168,
-      "endLine": 171,
+      "startLine": 196,
+      "endLine": 199,
       "mathContext": "Empty docstring banner."
     },
     {
       "id": "extremal-connection",
       "title": "Part 10: Connection to Extremal Graph Theory",
       "summary": "Section banner relating these Ramsey numbers to extremal (Turán-type) graph theory. Exposition placeholder; declares no Lean content.",
-      "startLine": 172,
-      "endLine": 175,
+      "startLine": 200,
+      "endLine": 203,
       "mathContext": "Empty docstring banner."
     },
     {
       "id": "summary",
       "title": "Part 11: Summary",
       "summary": "Concluding part: `erdos_558_summary` bundles the three asymptotic results — $R(C_4;k)\\sim k^2$, $R(K_{3,3};k)\\sim k^3$, and $R(K[s,t];k)=\\Theta(k^t)$ for $s\\ge(t-1)!+1$ — directly from `ramsey_K22`, `ramsey_K33`, and `alon_ronyai_szabo`.",
-      "startLine": 176,
-      "endLine": 194,
+      "startLine": 204,
+      "endLine": 222,
       "mathContext": "One theorem. Net file axioms (5): `ramseyBipartite`, `chung_graham_bounds`, `ramsey_K22`, `ramsey_K33`, `alon_ronyai_szabo`."
     }
   ],

--- a/src/data/proofs/erdos-864/meta.json
+++ b/src/data/proofs/erdos-864/meta.json
@@ -97,7 +97,7 @@
       "id": "reflected-construction",
       "title": "Reflected Construction: Validity Proof and Quantitative Lower Bound",
       "startLine": 506,
-      "endLine": 806,
+      "endLine": 834,
       "summary": "The largest section (300 lines): reflected_construction_valid proves that B union (N-B) is almost-Sidon when B is Sidon in {1,...,N/3}. The proof analyzes collision structure showing any repeated sum must equal N (the only cross-pair collision from b+(N-b)=N). Closes with reflected_construction_bound: maxAlmostSidon N >= 2*|B| for any Sidon B in {1,...,N/3}.",
       "mathContext": "The reflected construction B union (N-B): for B Sidon in [1,N/3] and b in B, N-b lies in [2N/3, N-1] disjoint from B. Cross-pair sums: b + (N-b') = N only if b = b' (since B is Sidon). Same-side sums from B are distinct (Sidon property). Same-side sums from N-B: (N-b) + (N-b') = 2N - (b+b') are also distinct (Sidon). So the only repeated sum is N, confirming at most one collision."
     }


### PR DESCRIPTION
Enrichment pass: re-anchor a drifted section list and extend three sections over their previously-uncovered declaration tails. Each entry's `max(section.endLine)` fell short of the Lean file length.

**Per-entry:**
- **erdos-558** — the section list was systematically drifted: "Part 7 Statement" stopped at 161 though the statement runs to 189, and Parts 8–11 (Norm Graphs, Specific Values, Extremal Connection, Summary + `erdos_558_summary`) were anchored ~28 lines early onto earlier content. Re-anchored all 12 sections to their `## Part N` banners, 1..EOF.
- **combinations-formula-oq-03** — extended the "Integer Verifications and Fano Plane" section over the trailing q=1 / q=2 numerical `example` checks (751→780).
- **erdos-864** — extended the "Reflected Construction" section over its own quantitative-bound tail (`reflected_subset_Icc` + `reflected_construction_bound`, the `maxAlmostSidon N ≥ 2|B|` result the section title already promises), 806→834.
- **erdos-1144** — extended the "Growth Rate Pinch Theorem" section over `conjecture_and_atherfold_pinch`, which its summary already described (226→253).

Pure section re-anchoring — no prose/`status`/`badge`/`axiomCount` changes. Every section verified `maxEnd === wc` and contiguous. (A fifth candidate, erdos-395-oq-01, was dropped: a concurrent enricher re-anchored it to EOF first.)
