### PR TITLE
Enrich 3 entries: cover uncovered declaration/survey tails to EOF

### DIFF
--- a/src/data/proofs/erdos-1021-oq-01/meta.json
+++ b/src/data/proofs/erdos-1021-oq-01/meta.json
@@ -85,9 +85,16 @@
       "id": "lower-bound",
       "title": "Probabilistic Lower Bound",
       "startLine": 130,
-      "endLine": 165,
+      "endLine": 169,
       "summary": "Axiomatizes the probabilistic lower bound ex(n,G_k) ≥ c·n^{3/2-1/(k-1)}. Proves the lower bound exponent is < 3/2 and approaches 3/2 as k → ∞.",
       "mathContext": "$\\mathrm{ex}(n, G_k) \\geq c \\cdot n^{3/2 - 1/(k-1)}$. The exponent $3/2 - 1/(k-1) \\to 3/2$ as $k \\to \\infty$."
+    },
+    {
+      "id": "context",
+      "title": "Part VI: The OQ-01 in Context",
+      "startLine": 170,
+      "endLine": 193,
+      "summary": "Survey framing of OQ-01's status: k = 3 is SOLVED (ex(n, G_3) ≍ ex(n, C_6) ≪ n^{7/6} < n^{3/2}) while k ≥ 4 is OPEN (even the weak o(n^{3/2}) bound is unknown). Records the KST trivial upper bound ≪ n^{3/2} and the probabilistic lower bound ≥ c·n^{3/2 − 1/(k−1)}, and inventories the file itself: 2 provable results, 2 axiomatic results (KST bound, probabilistic lower bound), and 3 remaining `sorry` results — an honest 'SURVEY + INFRASTRUCTURE' status marker."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-770/meta.json
+++ b/src/data/proofs/erdos-770/meta.json
@@ -123,9 +123,16 @@
       "id": "fermat-formula",
       "title": "Fermat Formula and Unboundedness",
       "startLine": 497,
-      "endLine": 531,
+      "endLine": 540,
       "summary": "PROVED: `hMinK_prime_minus_one` — for every prime $p$, $h(p-1) = p$. PROVED: `hMinK_succ_of_prime` — $h(n) = n+1$ iff $n+1$ is prime (formal statement). PROVED: `hMinK_unbounded` — for any $M$, $\\exists n$ with $h(n) > M$.",
       "mathContext": "For prime $p$: (i) $h(p-1) \\leq p$ because $\\gcd(2^{p-1}-1, \\ldots, p^{p-1}-1) = 1$ by `gcdPowerSeq_at_succ_eq_one`. (ii) $h(p-1) \\geq p$: for any $k < p$, Fermat gives $p \\mid \\gcd(2^{p-1}-1, \\ldots, k^{p-1}-1)$ so the gcd is not 1. Unboundedness follows: for any $M$, take a prime $p > M$ (by `Nat.exists_infinite_primes`); then $h(p-1) = p > M$."
+    },
+    {
+      "id": "open-question-axioms",
+      "title": "Open-Question Axioms: Q1 (Density) and Q3 (Dominant Prime)",
+      "startLine": 541,
+      "endLine": 559,
+      "summary": "The two genuinely-open questions, stated as axioms. `erdos_770_q1`: for each prime p the natural density of {n : hMinK n = p} exists (OPEN — needs density theory for multiplicative functions). `erdos_770_q3`: for large n, hMinK n is determined by the largest prime p with (p−1) ∣ n (OPEN — no proof in the literature). These are the assumptions that keep the entry `axiomatized`; Q2 (unboundedness) is proved above, not axiomatized."
     }
   ],
   "overview": {

--- a/src/data/proofs/konigsberg-oq-02-oq-01/meta.json
+++ b/src/data/proofs/konigsberg-oq-02-oq-01/meta.json
@@ -153,8 +153,15 @@
       "id": "sec-walk-split-hierholzer",
       "title": "Part VIII: walk_split_at and Full Hierholzer Assembly",
       "startLine": 716,
-      "endLine": 954,
+      "endLine": 951,
       "summary": "walk_closed, vertex_with_unused_arc, walk_split_at (List.take/drop), circuit splicing machinery, and directed_euler_circuit_sufficient_corrected — final Hierholzer algorithm via WF induction on arcCount"
+    },
+    {
+      "id": "sec-results-summary",
+      "title": "Results Summary and Verification",
+      "startLine": 952,
+      "endLine": 983,
+      "summary": "Closing `### Results` inventory (0 sorries): the proved lemmas (`maximal_balanced_trail_is_circuit`, `Walk.splice`/`splice_nodup`, `removeArcList_arcCount`/`_balanced`, `nodup_arcs_length_le`, `isEulerian_of_length_eq`, and the main `directed_euler_circuit_sufficient_corrected`), the formerly-sorry'd sub-lemmas now discharged (`nodup_circuit_exists_of_outDeg_pos`, `vertex_with_unused_arc`, `walk_split_at`), and a Bug-Found note recording that the parent file's `directed_euler_circuit_sufficient` axiom has a missing strong-connectivity hypothesis. Ends with a `#check` export block over the key declarations."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass: cover previously-uncovered declaration and survey tails to EOF.

**Per-entry:**
- **erdos-770** (9→10) — the "Fermat Formula and Unboundedness" section's summary already claimed `hMinK_unbounded`, but that theorem lived past its `endLine`; extended the section to include it, and added a dedicated section for the two genuinely-open axioms `erdos_770_q1` (density of {n : hMinK n = p}) and `erdos_770_q3` (dominant-prime characterization). Stays `axiomatized` on those axioms — Q2 (unboundedness) is the proved half.
- **konigsberg-oq-02-oq-01** (9→10) — Part VIII was overshooting two lines into the closing `### Results` block; trimmed it and gave the results inventory + `#check` export block its own **Results Summary and Verification** section (includes the Bug-Found note about the parent file's axiom with a missing strong-connectivity hypothesis).
- **erdos-1021-oq-01** (5→6) — extended the probabilistic lower-bound section over its `sorry` tail and added the **Part VI: The OQ-01 in Context** survey section (k=3 solved / k≥4 open, KST and probabilistic bounds, honest 2-proved / 2-axiom / 3-sorry inventory).

Pure section re-anchoring — no prose/`status`/`badge`/`axiomCount` changes. Every section verified `maxEnd === wc`; the two contiguity WARNs are pre-existing interior holes left untouched.
