### PR TITLE
Enrich 3 entries: extend final sections to cover uncovered headline tails

### DIFF
--- a/src/data/proofs/erdos-1095-oq-01/meta.json
+++ b/src/data/proofs/erdos-1095-oq-01/meta.json
@@ -148,7 +148,7 @@
       "title": "Part 7: Problem Statement (OPEN)",
       "summary": "States the open conjecture formally: `ErdosAsymptoticConjecture` (the limit $\\log g(k)/(k/\\log k)\\to c>0$ via `Filter.Tendsto`) and the weaker super-polynomial `ErdosProblem1095OQ01`. Closes with `example` checks confirming the proved concrete values $g(1..6)$, then ends the namespace.",
       "startLine": 443,
-      "endLine": 475,
+      "endLine": 498,
       "mathContext": "Open: $\\log g(k)/(k/\\log k)\\to c$ for some $c>0$, placing $g(k)$ between polynomial and exponential growth."
     }
   ],

--- a/src/data/proofs/erdos-537/meta.json
+++ b/src/data/proofs/erdos-537/meta.json
@@ -155,7 +155,7 @@
       "title": "Main Results",
       "summary": "Final theorems: $\\text{erdos\\_537}$ (alias for disproof), $\\text{erdos\\_537\\_summary}$ combining counterexample existence with the negation of the conjecture",
       "startLine": 247,
-      "endLine": 276,
+      "endLine": 299,
       "mathContext": "Verified: Final theorems: $\\text{erdos\\_537}$ (alias for disproof), $\\text{erdos\\_537\\_summary}$ combining counterexample existence with the negation of the conjecture"
     }
   ],

--- a/src/data/proofs/erdos-682/meta.json
+++ b/src/data/proofs/erdos-682/meta.json
@@ -105,7 +105,7 @@
       "id": "header",
       "title": "Problem Overview",
       "startLine": 1,
-      "endLine": 32,
+      "endLine": 43,
       "summary": "Header: rough numbers in prime gaps, Erdős's counterexample via $13\\# = 30030$, Gafni-Tao (2025) resolution, arXiv:2508.06463",
       "mathContext": "Overview of Erdős Problem #682: does every prime gap $(p_n, p_{n+1})$ contain a $g_n$-rough number, where $g_n = p_{n+1} - p_n$? Erdős's conditional counterexample uses the primorial $13\\# = 2 \\cdot 3 \\cdot 5 \\cdot 7 \\cdot 11 \\cdot 13 = 30030$, which ensures every integer in $[2184, 2200]$ has a prime factor $\\leq 13$. Gafni-Tao (2025, arXiv:2508.06463) resolved the problem affirmatively."
     },
@@ -185,7 +185,7 @@
       "id": "summary",
       "title": "Summary",
       "startLine": 319,
-      "endLine": 344,
+      "endLine": 368,
       "summary": "`erdos_682_summary` (Gafni-Tao bound + affirmative answer), `erdos_682` main theorem",
       "mathContext": "Main results: `erdos_682_summary` combines the Gafni-Tao bound $E(X) \\ll X/(\\log X)^2$ with the affirmative answer to Problem #682; `erdos_682` packages the full theorem statement. The resolution shows that while Dickson-type obstructions create infinitely many exceptions, they are sparse enough for the property to hold for almost all $n$."
     }


### PR DESCRIPTION
Extends three entries' final `meta.sections` to reach EOF, covering previously-uncovered headline declarations at the file tail. In each case the existing section summary already described the uncovered decls — only the `endLine` lagged the content. Pure line-number extends (contiguous `1..EOF`, `maxEnd === wc -l`); no `status`/`badge`/`axiomCount`/summary/prose changes.

| Entry | Change | Newly covered |
|-------|--------|---------------|
| `erdos-682` | Summary `344→368` (+ closed head import gap) | `erdos_682` @363 (final "SOLVED" restatement) |
| `erdos-537` | Main Results `276→299` | `erdos_537` @284 (disproof alias), `erdos_537_summary` @291 |
| `erdos-1095-oq-01` | Part 7 (OPEN) `475→498` | `ErdosAsymptoticConjecture` @480, `ErdosProblem1095OQ01` @486, concrete `g(1..6)` example checks |

Verified against fresh `origin/main` immediately before push (none raced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
