### PR TITLE
audit(cauchy-schwarz oq001-005): mark clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30884,6 +30884,36 @@
       "lastAudited": "2026-07-21T10:53:53Z",
       "result": "clean",
       "issues": []
+    },
+    "cauchy-schwarz-oq001": {
+      "auditCount": 2,
+      "lastAudited": "2026-07-21T11:05:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-oq002": {
+      "auditCount": 2,
+      "lastAudited": "2026-07-21T11:05:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-oq003": {
+      "auditCount": 2,
+      "lastAudited": "2026-07-21T11:05:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-oq004": {
+      "auditCount": 2,
+      "lastAudited": "2026-07-21T11:05:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-oq005": {
+      "auditCount": 2,
+      "lastAudited": "2026-07-21T11:05:36Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Audit result: CLEAN

Audited the `cauchy-schwarz-oq001`..`oq005` cluster (never-audited oqNNN ids with no prior tracker entry).

| id | title | status/badge | ax | sorry | verdict |
|----|-------|------|----|----|----|
| oq001 | Robertson–Schrödinger Uncertainty Relation | verified/original | 0 | 0 | genuine full inequality |
| oq002 | Projection as sum of rank-one projectors | verified/verified | 0 | 0 | 12 substantive theorems |
| oq003 | Entropic Uncertainty (min-entropy + eigenstate Maassen–Uffink) | verified/original | 0 | 0 | honestly scoped, interpolation gap disclosed |
| oq004 | Parseval Completeness iff over RCLike | verified/mathlib | 0 | 0 | badge correctly mathlib (HilbertBasis reliance) |
| oq005 | Kittaneh's Numerical-Radius Inequality | verified/original | 0 | 0 | genuine Buzano-based proof |

## Checks
- Real sorries: 0 in all files (anchored grep).
- Axiom decls: none; `axiomCount: 0` accurate.
- native_decide: none real (the one grep hit in oq004 is a docstring disclosure "no native_decide").
- True stubs: none (all `trivial` hits are prose in comments).
- theorem/def counts match meta for all five.
- Titles match formalized claims; oq003 carries the "Eigenstate Case" qualifier and discloses the full theorem needs Riesz–Thorin interpolation absent from Mathlib.
- oq004 `mathlib` badge is appropriate — forward direction projects Mathlib's bilinear Parseval identity; originalContributions limited to the bridge/packaging.

No integrity issues found.

---
Discovered during gallery integrity audit.