### PR TITLE
Enrich 4 entries: cover uncovered capstone theorems + re-anchor drifted sections

### DIFF
--- a/src/data/proofs/cayley-hamilton-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-01-oq-03/meta.json
@@ -158,6 +158,14 @@
       "endLine": 264,
       "summary": "expPolyCoeff_depends_only_on_minpoly (similar matrices give same p_k), matrixExp_in_span (exp(tM) ∈ span{I,...,M^{d-1}}), matrixExp_zero_eq_one (consistency check), matrixExp_atMost_n_terms (n-term bound via minpoly_dvd_charpoly).",
       "mathContext": "The span membership follows from the polynomial form. The n-term bound uses deg(minpoly) ≤ deg(charpoly) = n. The minpoly-only dependence is the basis for the spectral viewpoint: exp(tM) is determined by the spectrum of M (with multiplicities matching the minimal, not characteristic, polynomial)."
+    },
+    {
+      "id": "degree-bound",
+      "title": "Degree Bound: at most n terms",
+      "startLine": 265,
+      "endLine": 288,
+      "summary": "matrixExp_atMost_n_terms sharpens the polynomial representation to the dimension bound: exp(t·M) is a linear combination of I, M, …, M^(n-1) with n = Fintype.card n, since deg(minpoly M) ≤ deg(charpoly M) = n (minpoly_dvd_charpoly + charpoly_natDegree_eq_dim). Terms beyond the minimal polynomial degree vanish, extending the sum from d to n. matrixExp_zero_eq_one records the base case exp 0 = 1.",
+      "mathContext": "$\\exp(tM) = \\sum_{k=0}^{n-1} c_k(t)\\,M^k$ with $n = \\dim$, because $\\deg(\\operatorname{minpoly} M) \\le \\deg(\\operatorname{charpoly} M) = n$ by Cayley–Hamilton."
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-389/meta.json
+++ b/src/data/proofs/erdos-389/meta.json
@@ -83,15 +83,15 @@
       "title": "Mehta's Computation",
       "summary": "Records Bhavik Mehta's result: $\\texttt{minimalK}(4) = 207$, meaning $4 \\cdot 5 \\cdots 210 \\mid 211 \\cdot 212 \\cdots 417$. Proves minimality: no $k \\in [1, 206]$ works.",
       "startLine": 72,
-      "endLine": 83,
+      "endLine": 94,
       "mathContext": "Mehta: $\\text{minimalK}(4) = 207$. Product $4 \\cdot 5 \\cdots 210 \\mid 211 \\cdots 417$."
     },
     {
       "id": "ratio",
       "title": "Ratio Interpretation",
       "summary": "Expresses the divisibility as $\\prod_{i=0}^{k-1} \\frac{n+k+i}{n+i} \\in \\mathbb{Z}$. Establishes the identity $(n)_k = k! \\binom{n+k-1}{k}$ connecting to binomial coefficients and Kummer's theorem.",
-      "startLine": 84,
-      "endLine": 98,
+      "startLine": 95,
+      "endLine": 122,
       "mathContext": "Ratio form: $\\prod_{i=0}^{k-1} \\frac{n+k+i}{n+i} \\in \\mathbb{Z}$. Equivalently $\\binom{n+2k-1}{k} / \\binom{n+k-1}{k} \\in \\mathbb{Z}$."
     }
   ],

--- a/src/data/proofs/inverse-galois-a5-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-a5-oq-01/meta.json
@@ -120,6 +120,13 @@
       "startLine": 82,
       "endLine": 108,
       "summary": "Given an unramified prime Q over a rational prime with 3 ∣ inertiaDegIn, the arithmetic Frobenius arithFrobAt ℤ q.Gal Q has order divisible by 3 (via the bridge), hence 3 ∣ Fintype.card q.Gal."
+    },
+    {
+      "id": "bridge-instantiation",
+      "title": "Bridge Instantiation for the A₅ Quintic",
+      "startLine": 109,
+      "endLine": 135,
+      "summary": "three_dvd_gal_card_of_bridge is the instantiated capstone for the A₅ quintic: given an unramified prime Q of 𝒪_{SplittingField} over a nonzero rational prime whose inertia degree is divisible by 3, the arithmetic Frobenius arithFrobAt has order equal to that inertia degree (DedekindFrobeniusBridge.orderOf_arithFrobAt_eq_inertiaDegIn), so 3 ∣ orderOf(Frob) ∣ |Gal|. This discharges three_dvd_gal_card through the abstract Dedekind–Frobenius bridge, together with the IsInvariant instance on the ring of integers."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/lebesgue-measure-oq-05/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-05/meta.json
@@ -112,9 +112,17 @@
       "id": "regularity-and-conditioning",
       "title": "Pointwise Regularity and Conditional Expectation as a Density",
       "startLine": 146,
-      "endLine": 202,
+      "endLine": 200,
       "summary": "Pointwise regularity of the density — rnDeriv_lt_top_ae / rnDeriv_ne_top_ae (dμ/dν < ∞ and ≠ ∞, ν-a.e.), rnDeriv_pos_ae (0 < dμ/dν, μ-a.e. for μ ≪ ν), and inv_rnDeriv_ae ((dμ/dν)⁻¹ = dν/dμ, μ-a.e.) — followed by condExp_ae_eq_signed_rnDeriv, identifying the conditional expectation μ[f|m] with the signed Radon–Nikodym derivative of the f-weighted measure trimmed to the sub-σ-algebra m.",
       "mathContext": "The density is a.e. finite ($d\\mu/d\\nu < \\infty$, $\\nu$-a.e.) and, for $\\mu \\ll \\nu$, strictly positive $\\mu$-a.e. with pointwise inverse $(d\\mu/d\\nu)^{-1} = d\\nu/d\\mu$ ($\\mu$-a.e.). Conditional expectation is itself a density: $\\mu[f\\mid m] =^{ae}_\\mu \\mathrm{rnDeriv}\\big((\\mu.\\mathrm{withDensity}_v\\, f).\\mathrm{trim}\\,m,\\ \\mu.\\mathrm{trim}\\,m\\big)$, placing conditioning inside the same Radon–Nikodym calculus (Mathlib's rnDeriv_ae_eq_condExp)."
+    },
+    {
+      "id": "conditional-expectation",
+      "title": "Conditional Expectation as a Radon–Nikodym Derivative",
+      "startLine": 201,
+      "endLine": 229,
+      "summary": "condExp_ae_eq_signed_rnDeriv places conditional expectation inside the Radon–Nikodym calculus: for a sub-σ-algebra m ≤ m₀ with ρ.trim σ-finite and f integrable, the conditional expectation ρ[f|m] equals ρ-a.e. the signed Radon–Nikodym derivative of the f-weighted measure ρ.withDensityᵥ f trimmed to m, with respect to ρ trimmed to m. A thin wrapper over Mathlib's rnDeriv_ae_eq_condExp, recorded as the probabilistic face of the σ-finite Radon–Nikodym package.",
+      "mathContext": "$\\rho[f\\mid m] = \\dfrac{d\\,(\\rho.\\mathrm{withDensity}_v f)\\!\\restriction_m}{d\\,\\rho\\!\\restriction_m}$ $\\rho$-a.e., the signed Radon–Nikodym derivative trimmed to the sub-σ-algebra $m$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass — section coverage for 4 gallery entries whose `meta.sections`
left a capstone theorem uncovered past the last section (or had drifted).
**Pure section re-anchoring**: no `status` / `badge` / `axiomCount` / prose
changes; each file verified `max(endLine) === wc -l` (pre-existing banner-spacing
gaps between untouched sections are unchanged).

| Entry | change |
|-------|--------|
| `cayley-hamilton-oq-01-oq-03` | +*Degree Bound* section for `matrixExp_atMost_n_terms` (@266) — the dimension-bound sharpening `exp(t·M) = ∑_{k<n} c_k M^k` via `deg(minpoly) ≤ deg(charpoly) = n` — left uncovered past *Corollaries* |
| `inverse-galois-a5-oq-01` | +*Bridge Instantiation* section for the A₅-quintic capstone `three_dvd_gal_card_of_bridge` (@116) uncovered past `main-result` |
| `lebesgue-measure-oq-05` | +*Conditional Expectation as a Radon–Nikodym Derivative* section for `condExp_ae_eq_signed_rnDeriv` (@221); regularity section trimmed off the new banner it over-reached |
| `erdos-389` | `mehta` extended over `mehta_n4_minimality`; `ratio` re-anchored to the `## Ratio Interpretation` banner (@95) to cover `consecutiveProd_binomial` (@112), the $(n)_k = k!\binom{n+k-1}{k}$ identity its summary already named |

Verified against fresh `origin/main` immediately before push (none raced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
