### PR TITLE
audit(tracker): cayleys-theorem-oq002 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30932,6 +30932,12 @@
       "lastAudited": "2026-07-21T10:51:41Z",
       "result": "clean",
       "issues": []
+    },
+    "cayleys-theorem-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:13:13Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Records clean audit of **cayleys-theorem-oq002** (Infinite converse to Cayley: #H = #α).

- 5 theorems, 0 definitions, 0 axioms, 0 sorries — all match meta.json
- No decide/native_decide, no True stubs
- Build-verified; `#print axioms` = propext / Classical.choice / Quot.sound only
- Honest framing: correctly notes parent's Nat.card statement is vacuous for infinite α and this refines it to Cardinal.mk; badge `original` defensible

Tracker-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)