### PR TITLE
Enrich 4 entries: cover uncovered corollary/capstone theorems to EOF

### DIFF
--- a/src/data/proofs/ballot-problem-oq003/meta.json
+++ b/src/data/proofs/ballot-problem-oq003/meta.json
@@ -117,7 +117,7 @@
       "id": "corollaries",
       "title": "Corollaries: All-Events, Complement, Union",
       "startLine": 160,
-      "endLine": 198,
+      "endLine": 223,
       "summary": "uniformOn_preserves_all_events: universal quantification over all P. uniformOn_complement_transfer: the complement T\\P is also transferred. uniformOn_union_transfer: finite unions P∪Q are transferred.",
       "mathContext": "The main theorem immediately gives: complements, unions, and all Boolean combinations of events are preserved. This confirms that the map f is probability-preserving in the fullest sense for the discrete uniform distribution."
     }

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-02/meta.json
@@ -183,6 +183,12 @@
       "startLine": 145,
       "endLine": 171,
       "summary": "embed_of_two: the embedding generalized to any alphabet with two distinct values b₀ ≠ b₁ via the if-then-else characteristic function, still propext-free. succ_fixedPointFree: the successor on ℕ is fixed-point free (n + 1 ≠ n). no_surjection_to_nat: Cantor over the alphabet ℕ, an infinite-alphabet instance of the engine, demonstrating that no_surjection_of_fpf is uniform in the alphabet."
+    },
+    {
+      "title": "Part 5 — Cantor over ℕ and axiom audit",
+      "startLine": 172,
+      "endLine": 195,
+      "summary": "no_surjection_to_nat lifts the diagonal argument to the infinite alphabet ℕ via the fixed-point-free successor (succ_fixedPointFree), showing the engine no_surjection_of_fpf handles arbitrary alphabets, not just Bool. The closing #print axioms audit machine-records that every headline theorem (lawvere, no_surjection_of_fpf, no_surjection_to_bool, embed_bool_injective, predicative_cantor, embed_of_two, no_surjection_to_nat) depends on no axioms at all — not even propext / Classical.choice / Quot.sound — so the propext-free, choice-free claim is verified on every build."
     }
   ]
 }

--- a/src/data/proofs/erdos-1202/meta.json
+++ b/src/data/proofs/erdos-1202/meta.json
@@ -99,15 +99,15 @@
       "id": "axiom",
       "title": "Main Axiom: Threshold Result",
       "startLine": 74,
-      "endLine": 88,
+      "endLine": 99,
       "summary": "The axiom `erdos_1202_threshold` encodes the solved result: ∃ c > 0 such that for all n > 1, m > √(n log n), and prime sets S with |S| ≥ m²/(n log n), there exists T ⊆ S with |T| ≥ c · m²/(n log n) satisfying the structural property. Axiomatized due to source corruption preventing recovery of the exact property.",
       "mathContext": "`erdos_1202_threshold` (axiom): $\\exists c > 0, \\forall n > 1, m > \\sqrt{n \\log n},\\, \\forall S\\, (\\text{IsPrimeSet}),\\, |S| \\geq m^2/(n \\log n) \\Rightarrow \\exists T \\subseteq S,\\, |T| \\geq c \\cdot m^2/(n \\log n) \\land P(T)$, where $P(T)$ is the unknown structural property. Axiomatized because: (1) the source problem is corrupted so $P$ is unrecoverable; (2) the analytic proof (likely via large sieve or Selberg's $\\Lambda^2$ sieve) requires machinery not yet in Mathlib. The constant $c$ is absolute (independent of $\\varepsilon, \\eta$) based on the $\\gg_c$ notation."
     },
     {
       "id": "theorem",
       "title": "Main Theorem",
-      "startLine": 90,
-      "endLine": 97,
+      "startLine": 100,
+      "endLine": 122,
       "summary": "Theorem `erdos_1202` states the main result and follows directly from the axiom. The theorem confirms the threshold m²/(n log n) governs the existence of large structured prime subsets, matching the problem's answer on erdosproblems.com.",
       "mathContext": "`erdos_1202` is a one-line theorem wrapping `erdos_1202_threshold`: given the same hypotheses ($n > 1$, `growthCondition`, `IsPrimeSet S`, $|S| \\geq \\text{asympThreshold}$), it applies the axiom. The theorem serves as the public interface: the axiom provides the witness $c$ and subset $T$, while the theorem confirms the result matches the solved status on erdosproblems.com. Since the structural property $P(T)$ is opaque, this is a 'placeholder theorem' — correct in form but incomplete in mathematical content until the source is recovered."
     }


### PR DESCRIPTION
Enrichment pass — section coverage for 4 gallery entries whose `meta.sections`
left corollary/capstone theorems uncovered past the last section (three are the
reliable sub-class where the section *summary already names* a theorem sitting
past its `endLine`). **Pure section re-anchoring**: no `status` / `badge` /
`axiomCount` / prose changes; each file verified `max(endLine) === wc -l`
(pre-existing banner-spacing gaps/overlaps between untouched sections unchanged).

| Entry | change |
|-------|--------|
| `lagrange-theorem-oq-01-oq-02` | *Corollaries* extended over `A4_no_index2_subgroup` + `lagrange_converse_fails` (@129/141) — the Part IV corollaries its summary already named |
| `ballot-problem-oq003` | *Corollaries* extended over the complement/union transfer lemmas (`uniformOn_union_transfer` @207) it already named |
| `erdos-1202` | `axiom` extended to the full threshold-axiom signature (@99); `theorem` re-anchored to the `## Main Theorem` banner to cover `erdos_1202` (@112) + `#check`, which sat past its old `endLine` |
| `cantor-diagonalization-oq-03-oq-02` | +*Part 5* section for `no_surjection_to_nat` (Cantor over ℕ) and the closing `#print axioms` audit block verifying the propext-free / choice-free claim |

Verified against fresh `origin/main` immediately before push (none raced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
