### PR TITLE
audit(tracker): cevas-theorem-oq001 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30938,6 +30938,12 @@
       "lastAudited": "2026-07-21T11:16:11Z",
       "result": "clean",
       "issues": []
+    },
+    "cevas-theorem-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:24:31Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Records clean audit of **cevas-theorem-oq001** (Cayley–Klein projective unification of Ceva's theorem across the three constant-curvature geometries).

- 22 theorems, 5 definitions (structure `CKCevianConfig` + 4 defs), 0 axioms, 0 sorries — all match meta.json
- No decide/native_decide, no True stubs; build-verified (sole unused-variable linter warning)
- Not a placeholder: metric-realization lemmas (`gSph_sqrt_BD/DC`, `spherical/hyperbolic_side_ratio_metric`) prove the abstract factor equals genuine geodesic side lengths, so the side-ratio = β/α is real geometric content
- Concurrency ⟺ weight-balance is the established criterion inherited from the parent hyperbolic-Ceva entry; docstring shorthand is consistent with that chain
- Badge `original` defensible

Tracker-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)