### PR TITLE
audit(tracker): combinations-formula-oq001 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30944,6 +30944,12 @@
       "lastAudited": "2026-07-21T11:24:31Z",
       "result": "clean",
       "issues": []
+    },
+    "combinations-formula-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:27:44Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Records clean audit of **combinations-formula-oq001** (Lucas analogue of Cassini's identity).

- 4 theorems, 0 definitions, 0 axioms, 0 sorries — all match meta.json
- No native_decide (two kernel `decide` base cases, kernel-checked); no True stubs
- Build-verified; `#print axioms lucas_cassini` = propext / Classical.choice / Quot.sound only
- Genuinely answers the parent entry's open question (L(n−1)L(n+1)−L(n)²=(−1)^{n−1}·5); Mathlib has no such lemma; badge `original` correct

Tracker-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)