### PR TITLE
audit(tracker): combinations-formula-oq002 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30944,6 +30944,12 @@
       "lastAudited": "2026-07-21T11:24:31Z",
       "result": "clean",
       "issues": []
+    },
+    "combinations-formula-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:28:52Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Records clean audit of **combinations-formula-oq002** (two-coefficient closed form for the quadratically-weighted partial alternating binomial sum).

- 4 theorems, 0 definitions, 0 axioms, 0 sorries — all match meta.json
- No native_decide (two kernel `decide` sanity-check examples, not counted as theorems); no True stubs
- Build-verified
- Genuinely answers the parent entry's open question via k²=k(k−1)+k row-shift mechanism; badge `original` correct

Tracker-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)