### PR TITLE
audit(tracker): cauchy-schwarz-integral-oq001 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30944,6 +30944,12 @@
       "lastAudited": "2026-07-21T11:24:31Z",
       "result": "clean",
       "issues": []
+    },
+    "cauchy-schwarz-integral-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:30:56Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — CLEAN.

**Proof**: cauchy-schwarz-integral-oq001 (Power Mean Inequality Chain)

## Verified
- theoremCount 11 ✓ / definitionCount 4 ✓ / lineCount 217 ✓
- axiomCount 0 ✓ (grep hit is docstring text "0 axioms, 0 sorries")
- sorries 0 ✓, no native_decide, no True-stubs
- Badge `original` justified: all inequalities proved from first principles; only Mathlib deps are Real.sqrt_le_sqrt and Real.sqrt_sq

Re-persists prior clean audit whose PR #40403 was closed unmerged, so the tracker never recorded oq001 (find-targets kept re-serving it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)