### PR TITLE
Enrich 9 entries: cover uncovered capstone theorems + re-anchor drifted kaprekar sections

### DIFF
--- a/src/data/proofs/bezout-identity-oq010/meta.json
+++ b/src/data/proofs/bezout-identity-oq010/meta.json
@@ -136,7 +136,7 @@
       "id": "sec-inert",
       "title": "Part VI: Inert Prime Classification",
       "startLine": 234,
-      "endLine": 323,
+      "endLine": 335,
       "summary": "no_sum_form_mod8 (decide, 64-case check), inert_prime_neg2 for p ≡ 5 or 7 (mod 8), concrete examples 5 and 7. Also three_splits (3 = (1+√-2)(1-√-2)) and two_ramifies (2 = -(√-2)²)."
     },
     {


### PR DESCRIPTION
Section-coverage enrichment pass (enricher-2). Nine gallery entries whose
`sections` arrays stopped short of the Lean file's final declarations (gap 10-18
tail-undercoverage), leaving real capstone/summary theorems unrendered. Each
`meta.sections` now covers 1..EOF; **no** status/badge/axiomCount changes (all
counts pre-verified accurate — only section ranges/summaries touched).

Pure tail-extend (last section's summary already named the uncovered theorem past its `endLine`):
- **bezout-identity-oq010** — sec-inert 323→335 (`seven_is_inert`, `three_splits`, `two_ramifies`)
- **erdos-827** — structural-properties 279→290 (`generalPosition_subset`, `nkExists_of_axioms`)
- **intermediate-value-theorem-oq-01** — part-v 124→136 (`bisect_10_width`, `bisect_20_error`)
- **erdos-110** — summary 261→276 (`erdos_110`, `erdos_110_summary`)
- **erdos-358** — Part IX summary-theorems 608→623 (`erdos_358_open`, `erdos_358_status`)

Tail-extend + summary refresh:
- **erdos-1058** — summary 165→181, noted capstone `erdos_1058_status` / `erdos_1058_solved`
- **erdos-331** — Part X summary 223→235, fixed stale line numbers (212/215/218 → 223/226/229) for `erdos_331`/`erdos_331_main`/`erdos_331_ruzsa`

New section:
- **erdos-467** — added "Problem Summary" (266-278) covering `erdos_467_status` + `coverage_exceeds_target`

Drift re-anchor:
- **kaprekar-constant-oq-01** — last three sections were anchored ~10 lines ahead of their decls ("Uniqueness"@95-101 actually held the convergence theorems; the two headline theorems `kaprekar_unique_fixed`/`kaprekar_bound_sharp` sat past EOF-13). Re-anchored Bounded-Convergence 83→104, Uniqueness 105-112, Sharpness 113-121; summaries were already accurate.

All nine verified `max(section.endLine) === wc -l` with no new interior gaps.
Race-checked every target against fresh origin/main immediately before push.
