### PR TITLE
audit(tracker): cayley-hamilton-minpoly-oq001 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30944,6 +30944,12 @@
       "lastAudited": "2026-07-21T11:24:31Z",
       "result": "clean",
       "issues": []
+    },
+    "cayley-hamilton-minpoly-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:32:28Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — CLEAN (honest axiomatization).

**Proof**: cayley-hamilton-minpoly-oq001 (Skolem-Noether for CSAs)

## Verified
- theoremCount 14 ✓ / definitionCount 2 ✓ / lineCount 393 ✓ / sorries 0 ✓
- axiomCount 1 ✓ — single axiom `skolemNoether_module_iso`, a TRUE non-vacuous existence statement (module iso via Wedderburn-Artin), disclosed with proof sketch + effort estimate
- Badge `axiom` / status `axiomatized` correctly Tier C; `skolemNoether_general` prose accurately says 'proved from the axiom'
- No sorries, no native_decide, no True-stubs

Re-persists prior clean audit whose PR #40400 was closed unmerged (tracker never recorded it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)