### PR TITLE
Enrich 6 entries: re-anchor drifted tails + cover uncovered capstone theorems to EOF

### DIFF
--- a/src/data/proofs/bezout-identity-oq010/meta.json
+++ b/src/data/proofs/bezout-identity-oq010/meta.json
@@ -138,6 +138,13 @@
       "startLine": 234,
       "endLine": 323,
       "summary": "no_sum_form_mod8 (decide, 64-case check), inert_prime_neg2 for p ≡ 5 or 7 (mod 8), concrete examples 5 and 7. Also three_splits (3 = (1+√-2)(1-√-2)) and two_ramifies (2 = -(√-2)²)."
+    },
+    {
+      "id": "sec-concrete-examples",
+      "title": "Concrete Prime Examples in ℤ[√-2]",
+      "startLine": 324,
+      "endLine": 335,
+      "summary": "Concrete verifications of the three splitting behaviours of small rational primes in ℤ[√-2]: `seven_is_inert` shows 7 stays prime (inert), `three_splits` factors 3 = (1+√-2)·(1-√-2) since 1²+2·1²=3 (split), and `two_ramifies` gives 2 = -(√-2)² since N(√-2)=2 (ramified). Together with `five_is_inert` from Part VI these exhibit inert, split, and ramified primes explicitly, each discharged by kernel `decide`."
     }
   ],
   "sorries": 0,

--- a/src/data/proofs/erdos-110/meta.json
+++ b/src/data/proofs/erdos-110/meta.json
@@ -145,15 +145,15 @@
       "title": "Properties of the Counterexample",
       "summary": "LambieHansonGraph structure and existence",
       "startLine": 208,
-      "endLine": 235,
+      "endLine": 249,
       "mathContext": "The `LambieHansonGraph` structure packages the counterexample's properties: (1) $\\chi(G) = \\aleph_1$ exactly, (2) it defeats all proposed bounds $F$, and (3) by de Bruijn-Erdős, $n$-chromatic subgraphs still exist for all $n$ — they just cannot be uniformly bounded in size. The graph-theoretic compactness theorem shows why local (finite) colorability implies global colorability but cannot control subgraph sizes."
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_110 and erdos_110_summary theorems",
-      "startLine": 236,
-      "endLine": 261,
+      "startLine": 250,
+      "endLine": 276,
       "mathContext": "Erdős Problem #110 is DISPROVED: the Erdős-Hajnal-Szemerédi conjecture (1982) is false in ZFC. Shelah (2005) showed consistency, Lambie-Hanson (2020) proved it outright. The de Bruijn-Erdős theorem guarantees existence of $n$-chromatic subgraphs but cannot be made uniform over $\\aleph_1$-chromatic graphs."
     }
   ],

--- a/src/data/proofs/erdos-358/meta.json
+++ b/src/data/proofs/erdos-358/meta.json
@@ -142,14 +142,14 @@
       "title": "Part VIII: Current Status",
       "summary": "Both questions OPEN, what is known, Erdos quote",
       "startLine": 581,
-      "endLine": 599,
+      "endLine": 613,
       "mathContext": "Mathematical content: Both questions OPEN, what is known, Erdos quote"
     },
     {
       "id": "summary-theorems",
       "title": "Part IX: Summary Theorems",
-      "startLine": 600,
-      "endLine": 608,
+      "startLine": 614,
+      "endLine": 623,
       "summary": "The packaged status theorem erdos_358_status: the strong conjecture implies the weak one (strong_implies_weak) and the strong conjecture is decidable-in-principle (excluded middle), tying the formalization together.",
       "mathContext": "$\\texttt{Erdos358Strong} \\Rightarrow \\texttt{Erdos358Weak}$, and $\\texttt{Erdos358Strong} \\lor \\lnot\\texttt{Erdos358Strong}$."
     }

--- a/src/data/proofs/erdos-467/meta.json
+++ b/src/data/proofs/erdos-467/meta.json
@@ -132,6 +132,13 @@
       "startLine": 241,
       "endLine": 265,
       "summary": "Two structural constraints on any dual covering. `zero_assign_no_dual_cover` proves the zero assignment cannot achieve dual coverage (n=1 is uncovered). `dual_cover_needs_unit_class` proves any dual covering requires both A and B to contain a prime with assignment congruent to 1 mod p — a direct constraint on the class selection."
+    },
+    {
+      "id": "problem-summary",
+      "title": "Problem Summary",
+      "startLine": 266,
+      "endLine": 278,
+      "summary": "Records the problem status and the elementary observation underlying it. `erdos_467_status = \"OPEN\"` documents that no proof or disproof of Erdős #467 is known, and `coverage_exceeds_target` proves the trivial-but-essential fact that every n ≥ 2 has a prime factor (via `has_prime_factor`), the starting point for any prime-based dual-covering argument."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/intermediate-value-theorem-oq-01/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-01/meta.json
@@ -111,7 +111,7 @@
       "id": "part-v",
       "title": "Part V: Concrete Examples",
       "startLine": 113,
-      "endLine": 124,
+      "endLine": 136,
       "summary": "sqrt2_between_1_and_2 via Real.sqrt witness with monotonicity bounds. bisect_10_width and bisect_20_error: concrete convergence rate computations via norm_num.",
       "mathContext": "Concrete application: $\\sqrt{2} \\in (1, 2)$ since $1^2 < 2 < 2^2$. Bisection examples: 10 steps narrow to width $\\approx 0.00098$, 20 steps to $\\approx 9.5 \\times 10^{-7}$. Demonstrates the algorithm's linear convergence rate."
     }

--- a/src/data/proofs/kaprekar-constant-oq-01/meta.json
+++ b/src/data/proofs/kaprekar-constant-oq-01/meta.json
@@ -93,39 +93,39 @@
       "id": "kaprekar-map",
       "title": "The Kaprekar Map by Pure Arithmetic",
       "startLine": 52,
-      "endLine": 78,
+      "endLine": 89,
       "summary": "Defines sortAsc4 (a five-comparator sorting network for four naturals), kaprekarStep (extract digits by /,%; sort; recombine descending minus ascending), and NonRepdigit (digits not all equal), with a Decidable instance for NonRepdigit.",
       "mathContext": "For ascending digits w ≤ x ≤ y ≤ z, T(n) = (z·1000+y·100+x·10+w) − (w·1000+x·100+y·10+z). The network (a,b)(c,d)(a,c)(b,d)(b,c) sorts four inputs using only min/max."
     },
     {
       "id": "fixed-point",
       "title": "6174 is a Fixed Point",
-      "startLine": 80,
-      "endLine": 81,
+      "startLine": 90,
+      "endLine": 92,
       "summary": "kaprekar_fixed: T(6174) = 6174, checked by kernel `decide` (no native_decide, so this single fact is axiom-free).",
       "mathContext": "7641 − 1467 = 6174."
     },
     {
       "id": "convergence",
       "title": "Bounded Convergence to 6174",
-      "startLine": 83,
-      "endLine": 93,
+      "startLine": 93,
+      "endLine": 104,
       "summary": "kaprekar_converges_all enumerates over Finset.range 10000 (native_decide) that every non-repdigit reaches 6174 in seven steps; kaprekar_converges repackages it for an arbitrary n < 10000.",
       "mathContext": "Since 6174 is fixed, T^[7](n) = 6174 is exactly 'reaches 6174 within 7 steps'."
     },
     {
       "id": "uniqueness",
       "title": "Uniqueness of the Fixed Point",
-      "startLine": 95,
-      "endLine": 101,
+      "startLine": 105,
+      "endLine": 112,
       "summary": "kaprekar_unique_fixed: among non-repdigit four-digit strings, 6174 is the only fixed point of T. Derived symbolically (no native_decide) from kaprekar_converges via Function.iterate_fixed — a fixed point is unchanged by seven iterations, which equal 6174.",
       "mathContext": "∀ n < 10000, NonRepdigit n → T(n) = n → n = 6174."
     },
     {
       "id": "sharpness",
       "title": "Sharpness of the Seven-Step Bound",
-      "startLine": 103,
-      "endLine": 108,
+      "startLine": 113,
+      "endLine": 121,
       "summary": "kaprekar_bound_sharp: there exists a non-repdigit n < 10000 with T^[6](n) ≠ 6174, so six steps do not always suffice and the bound 7 is tight. Proved by exhibiting the single witness 0014 and kernel `decide` (no native_decide).",
       "mathContext": "∃ n < 10000, NonRepdigit n ∧ T^[6](n) ≠ 6174; witness n = 14 (0014), with T^[6](14) = 4176."
     }


### PR DESCRIPTION
Enriches 6 gallery entries by re-anchoring drifted section ranges and covering uncovered capstone theorems out to EOF. Productive vein is now the **gap 12-18 tail-decl tier** (the gap>=18 tier is drained to giant-hub false positives + known monsters). All changes are pure `sections` re-anchors/extensions — no `status`/`badge`/`axiomCount`/prose changes, no encoding noise.

- **bezout-identity-oq010** (6->7): added "Concrete Prime Examples in Z[sqrt-2]" section covering `seven_is_inert`, `three_splits`, `two_ramifies` (324-335), exhibiting the three splitting behaviours (inert/split/ramified) of small primes.
- **erdos-358**: re-anchored Part VIII Current Status (->613) and Part IX Summary Theorems to its actual `## Part IX` banner @614 (`erdos_358_status`, 614-623) — the section was drifted ~14 lines.
- **erdos-467** (8->9): added "Problem Summary" section covering `erdos_467_status` + `coverage_exceeds_target` (266-278).
- **kaprekar-constant-oq-01**: re-anchored the back-half sections, all drifted ~10 lines off their declarations (fixed-point/convergence/uniqueness/sharpness). Summaries were already accurate; only line anchors lagged. Now covers `kaprekar_bound_sharp`@116 through EOF.
- **intermediate-value-theorem-oq-01**: extended Part V over `bisect_10_width`/`bisect_20_error` (the summary already named both; 124->136).
- **erdos-110**: extended "Properties of the Counterexample" over `lambie_hanson_graph_exists`@240 and re-anchored "Summary" to the Part XI banner @250, covering `erdos_110` + `erdos_110_summary` (250-276).

Each target verified against fresh origin/main immediately before push (none raced); `maxEnd === wc` asserted for all six.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
