### PR TITLE
Enrich 5 entries: cover uncovered capstone theorems to EOF (gap 10-18)

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-10/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-10/meta.json
@@ -158,7 +158,7 @@
       "id": "step4-alternating",
       "title": "Step 4: Aₙ realized by restriction to the alternating subgroup",
       "startLine": 121,
-      "endLine": 157,
+      "endLine": 170,
       "summary": "Reuses permToFAut composed with the subgroup inclusion Aₙ ↪ Sₙ: altAction, altToFAut_injective, altFaithful, then realizeAn : Aₙ ≃* Gal(F/F^{Aₙ}), isGalois_An, and finrank_An : [F:F^{Aₙ}] = |Aₙ|."
     }
   ],

--- a/src/data/proofs/binary-gcd/meta.json
+++ b/src/data/proofs/binary-gcd/meta.json
@@ -79,7 +79,7 @@
       "id": "properties",
       "title": "Part III: Basic Properties",
       "startLine": 163,
-      "endLine": 174,
+      "endLine": 187,
       "summary": "Three one-liners: binaryGcd_comm via gcd_comm + correctness; binaryGcd_zero_left by simp; binaryGcd_zero_right by cases + simp.",
       "mathContext": "Commutativity: $\\text{binaryGcd}(a,b) = \\text{Nat.gcd}(a,b) = \\text{Nat.gcd}(b,a) = \\text{binaryGcd}(b,a)$, using correctness twice and Nat.gcd_comm. Zero cases follow directly from the base case equations of the definition."
     }

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json
@@ -68,7 +68,7 @@
       "id": "hierarchy-and-applications",
       "title": "Part IV: Hierarchy Summary and Applications",
       "startLine": 123,
-      "endLine": 151,
+      "endLine": 167,
       "summary": "Maps the dependency chain (Young → Hölder → embedding, Radon-Nikodým → surjectivity), proves the Cauchy-Schwarz bound on $L^2$ functions, and shows the Hölder embedding is isometric at $p=2$."
     }
   ],

--- a/src/data/proofs/derangements-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-03-oq-01-oq-02/meta.json
@@ -132,7 +132,7 @@
       "id": "concrete-values",
       "title": "Concrete Values",
       "startLine": 399,
-      "endLine": 410,
+      "endLine": 421,
       "summary": "error_n0_pos: D(0)/0! - 1/e = 1 - 1/e > 0 (instance of error_strict_pos_even 0). error_n1_neg: D(1)/1! - 1/e = -1/e < 0 (instance of error_strict_neg_odd 0). Concrete base cases confirming the sign alternation.",
       "mathContext": "$\\frac{D(0)}{0!} = 1 > \\frac{1}{e}$ and $\\frac{D(1)}{1!} = 0 < \\frac{1}{e}$."
     }

--- a/src/data/proofs/erdos-825/meta.json
+++ b/src/data/proofs/erdos-825/meta.json
@@ -98,7 +98,7 @@
       "id": "main-conjecture",
       "title": "Main Conjecture",
       "startLine": 81,
-      "endLine": 94,
+      "endLine": 106,
       "summary": "Erdős Problem 825: weird numbers have bounded abundancy, conjecturally C = 3.",
       "mathContext": "$\\exists C > 2: \\forall n,\\, \\sigma(n) > Cn \\implies \\text{IsSemiperfect}(n)$. Strengthened: $C = 3$ suffices. Equivalently, every weird number has $\\sigma(n)/n < 3$. Erdős prize: \\$25."
     }


### PR DESCRIPTION
Section-coverage enrichment pass (enricher-2), companion to #40423. Five more
gallery entries whose `meta.sections` stopped a few lines short of the Lean
file's final declarations (gap 10-18), leaving the closing theorems unrendered.
All five are **pure tail-extends** — the last section's summary already named the
uncovered declarations that sat past its `endLine`; only the `endLine` moved to
cover 1..EOF. No status/badge/axiomCount/summary changes.

- **abel-ruffini-galois-extensions-oq-10** — Step 4 157→170 (`isGalois_An`, `finrank_An`)
- **binary-gcd** — Part III 174→187 (`binaryGcd_zero_left`, `binaryGcd_zero_right`)
- **cauchy-schwarz-integral-oq-01-oq-01-oq-02** — Part IV 151→167 (`l2_cs`, `l2_dual_norm_tight`)
- **derangements-oq-03-oq-01-oq-02** — Concrete Values 410→421 (`error_n0_pos`, `error_n1_neg`)
- **erdos-825** — Main Conjecture 94→106 (`ErdosProblem825`, `ErdosProblem825_C3`)

All five verified `max(section.endLine) === wc -l`. Race-checked against fresh
origin/main immediately before push.
