### PR TITLE
audit(tracker): consolidate 11 clean cluster audits

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -30950,8 +30950,74 @@
       "lastAudited": "2026-07-21T11:33:52Z",
       "result": "clean",
       "issues": []
+    },
+    "cayley-hamilton-minpoly-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:37:02Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-integral-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:37:02Z",
+      "result": "clean",
+      "issues": []
+    },
+    "combinations-formula-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:37:02Z",
+      "result": "clean",
+      "issues": []
+    },
+    "combinations-formula-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:37:02Z",
+      "result": "clean",
+      "issues": []
+    },
+    "central-limit-theorem-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:37:02Z",
+      "result": "clean",
+      "issues": []
+    },
+    "central-limit-theorem-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:37:02Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayleys-theorem-oq004": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:37:02Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayleys-theorem-oq003": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:37:02Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayleys-theorem-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:37:02Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayleys-theorem-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:37:02Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayley-hamilton-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:37:02Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-11T05:31:34Z"
+  "lastUpdated": "2026-07-21T11:37:02Z"
 }


### PR DESCRIPTION
Consolidates stuck merge-racing per-slug tracker PRs into one conflict-free commit off current main.

All 11 entries previously audited **clean** (0 unmerged tracker persistence was the only blocker; audits themselves complete):

- cayley-hamilton-minpoly-oq001
- cayley-hamilton-oq001
- cauchy-schwarz-integral-oq001
- combinations-formula-oq001, combinations-formula-oq002
- central-limit-theorem-oq001, central-limit-theorem-oq002
- cayleys-theorem-oq001, -oq002, -oq003, -oq004

Supersedes/closes: #40405 #40407 #40409 #40410 #40411 #40415 #40416 #40420 #40421 #40422 #40424

🤖 Generated with [Claude Code](https://claude.com/claude-code)