### PR TITLE
audit(tracker): chebyshev-bounds-oq001 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31016,8 +31016,14 @@
       "lastAudited": "2026-07-21T11:37:02Z",
       "result": "clean",
       "issues": []
+    },
+    "chebyshev-bounds-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:39:30Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-21T11:37:02Z"
+  "lastUpdated": "2026-07-21T11:39:30Z"
 }


### PR DESCRIPTION
Verified Tier A axiom-free proof of the weak Mertens bound |Σ μ(d)/d| ≤ 1. 7 theorems, 0 axioms, 0 sorries, 0 native_decide; leanFile counts match file exactly. status=verified/badge=original justified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)