### PR TITLE
Enrich 2 entries: cover uncovered summary/capstone theorems to EOF

### DIFF
--- a/src/data/proofs/erdos-1058/meta.json
+++ b/src/data/proofs/erdos-1058/meta.json
@@ -116,8 +116,8 @@
       "id": "summary",
       "title": "Summary",
       "startLine": 137,
-      "endLine": 165,
-      "summary": "Combined result: finiteness + complete classification",
+      "endLine": 181,
+      "summary": "Combined result: finiteness + complete classification. `erdos_1058_status` packages the two halves — the Erdős–Stewart conjecture (only finitely many solutions) and the exact classification {1,2,3,4,5} — while `erdos_1058_solved` restates the finiteness, both discharged from Luca’s 2001 theorem.",
       "mathContext": "Combined status: finiteness (Luca 2001) + complete list $\\{1,2,3,4,5\\}$. The result demonstrates that super-exponential growth of $n!$ forces $n!+1$ to acquire diverse prime factors, making restricted factorization impossible for large $n$."
     }
   ],

--- a/src/data/proofs/erdos-827/meta.json
+++ b/src/data/proofs/erdos-827/meta.json
@@ -135,7 +135,7 @@
       "title": "Structural Properties",
       "summary": "Utility theorems: distSq_comm, distSq_self, distSq_nonneg, distSq_eq_zero_iff, generalPosition_subset, allDistinctCircumradii_subset (heredity), and nkExists_of_axioms.",
       "startLine": 239,
-      "endLine": 279
+      "endLine": 290
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Two gallery entries enriched by extending their final section over uncovered summary/capstone theorems. Both were already named in the section summary but sat past its `endLine`. Pure `sections` extensions — no `status`/`badge`/`axiomCount`/prose-status changes, no encoding noise.

- **erdos-1058**: extended "Summary" over `erdos_1058_status` (packages the Erdős–Stewart finiteness claim + exact classification {1,2,3,4,5}) and `erdos_1058_solved` (165->181); refreshed the terse one-line summary to name both theorems.
- **erdos-827**: extended "Structural Properties" over `generalPosition_subset` and the capstone `nkExists_of_axioms` (proves `NkExists k` for all k ≥ 3) (279->290) — both were already listed in the section summary.

Context: this was a 7-entry gap-12–18 batch, but 5 targets (abel-ruffini-galois-extensions-oq-10, binary-gcd, cauchy-schwarz-integral-oq-01-oq-01-oq-02, derangements-oq-03-oq-01-oq-02, erdos-825) were re-anchored to EOF by concurrent enrichers between scan and push; the per-target `git show origin/main` pre-push diff caught and dropped all five. These two survived and were re-verified unraced immediately before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
