### PR TITLE
audit(tracker): composition-parts-choose-oq001 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31052,6 +31052,12 @@
       "lastAudited": "2026-07-21T11:46:53Z",
       "result": "clean",
       "issues": []
+    },
+    "composition-parts-choose-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:49:35Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit: **composition-parts-choose-oq001** — clean.

## Verification
- **Counts match meta**: 4 theorems, 0 defs, 0 sorries, 0 axioms, 123 lines.
- **No native_decide**. `#print axioms` on all four theorems (`sum_pow_card`, `parts_genfun`, `parts_genfun_eval_one`, `parts_genfun_binomial`) shows only `propext, Classical.choice, Quot.sound` → `axiomCount: 0` accurate and disclosed.
- **Build verified** (`lake build`).
- **Theorem types match prose**: subset gen function `(t+1)^m`, part-count PGF `t·(1+t)^(n−1)`, count `2^(n−1)` at t=1, binomial coefficient form.
- **Parent decls real**: `gapsEquiv`, `length_eq_card_gaps` are genuine declarations in `CompositionPartsChooseOQ01OQ01`.
- **Badge `original` justified** (Tier A): genuine original content built on the parent gap bijection; Mathlib dependencies (`prod_add`, `add_pow`, `Equiv.sum_comp`) disclosed, not masked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)