### PR TITLE
Enrich 5 entries: re-anchor drifted example sections + cover uncovered capstone theorems to EOF

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-01-oq-01-oq-01/meta.json
@@ -128,9 +128,17 @@
       "id": "embeddings",
       "title": "§4: Counting embeddings of a number field",
       "startLine": 114,
-      "endLine": 133,
-      "summary": "finSepDegree_eq_finrank_rat: for finite E/ℚ, separability (automatic, ℚ perfect) forces finSepDegree ℚ E = [E : ℚ]. card_emb_eq_finrank_rat: unfolding finSepDegree = Nat.card (Field.Emb ℚ E), a number field of degree n has exactly n embeddings into its algebraic closure.",
+      "endLine": 141,
+      "summary": "finSepDegree_eq_finrank_rat: for finite E/ℚ, separability (automatic, ℚ perfect) forces finSepDegree ℚ E = [E : ℚ], via Field.finSepDegree_eq_finrank_of_isSeparable. card_emb_eq_finrank_rat: unfolding finSepDegree = Nat.card (Field.Emb ℚ E), a number field of degree n has exactly n ℚ-algebra embeddings into its algebraic closure.",
       "mathContext": "The separable degree counts embeddings into an algebraic closure. Over a perfect base it equals the full degree, giving the classical count of n embeddings for a degree-n number field."
+    },
+    {
+      "id": "examples",
+      "title": "§5: Worked examples — squarefree minimal polynomials and separability",
+      "startLine": 143,
+      "endLine": 154,
+      "summary": "Two example blocks instantiating the general theorems on concrete objects: every algebraic number z has a squarefree minimal polynomial over ℚ (minpoly_squarefree_rat via hz.isIntegral), and the field of algebraic numbers is a separable — indeed perfect — extension of ℚ (isSeparable_rat_algebraicNumbers). These sanity-check the perfectness and separability conclusions at the level of individual numbers and the whole extension.",
+      "mathContext": "Squarefreeness of $\\mathrm{minpoly}_{\\mathbb{Q}}(z)$ is the pointwise face of separability: a polynomial over a perfect field is separable iff squarefree, and $\\mathbb{Q}$ is perfect. The extension-level example $\\mathrm{Algebra.IsSeparable}\\,\\mathbb{Q}\\,\\bar{\\mathbb{Q}}$ packages the same fact uniformly across all of $\\bar{\\mathbb{Q}}$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/automorphic-number-oq-01-oq-02/meta.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-02/meta.json
@@ -165,6 +165,14 @@
       "endLine": 195,
       "summary": "automorphic_complementary_pair: the parent's count = 4 with |{0,1}| = 2 yields (card_le_card) an idempotent a ∉ {0,1}; its complement 1-a is the other nontrivial idempotent, with a+(1-a)=1, a·(1-a)=0, and a ≠ 1-a (else a=1). The four distinct idempotents 0,1,a,1-a fill the 4-element set, so the idempotent set equals {0,1,a,1-a}.",
       "mathContext": "Beyond counting, the residues organize into two orthogonal complementary pairs {0,1} and {…5,…6}; the concrete examples 5/6, 25/76, 376/625 exhibit a+b=1, ab=0."
+    },
+    {
+      "id": "concrete-pairs",
+      "title": "Part V: Concrete complementary pairs (5/6, 25/76, 376/625)",
+      "startLine": 197,
+      "endLine": 212,
+      "summary": "Three decidable example blocks instantiate automorphic_complementary_pair at k = 1, 2, 3: (5,6) mod 10, (25,76) mod 100, and (376,625) mod 1000 each satisfy a+b=1 and a·b=0 in ZMod (10^k), verified by `decide`. These exhibit the …5 and …6 automorphic families as the smallest genuine 2-adic/5-adic complements predicted by the CRT splitting.",
+      "mathContext": "Each pair is $(a, 1-a)$ for the nontrivial idempotent $a$ of $\\mathbb{Z}/10^k$: $5,6 \\bmod 10$; $25,76 \\bmod 100$; $376,625 \\bmod 1000$. The digits stabilize as $k$ grows (…625, …376), reflecting the unique idempotent lift up the reduction tower — the two convergent 10-adic idempotents."
     }
   ],
   "overview": {

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-04/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-04/meta.json
@@ -130,16 +130,16 @@
       "id": "golden-ratio",
       "title": "Golden Ratio Properties",
       "startLine": 176,
-      "endLine": 208,
+      "endLine": 233,
       "summary": "Defines φ = (1+√5)/2 and proves its key algebraic identities: positivity, φ > 1, φ² = φ + 1, 1/φ = φ - 1, and the minimal polynomial root property. Includes Fibonacci verification examples showing the denominators of φ's best rational approximations.",
       "mathContext": "The golden ratio $\\varphi = (1+\\sqrt{5})/2$: key identities $\\varphi^2 = \\varphi + 1$, $\\varphi > 1$, and $\\varphi$ is the 'hardest to approximate' irrational — its continued fraction $[1;1,1,1,\\ldots]$ has the slowest convergence among all irrationals (Hurwitz's theorem)."
     },
     {
       "id": "crt-examples",
       "title": "CRT Non-Coprime Lattice Examples",
-      "startLine": 209,
-      "endLine": 239,
-      "summary": "Concrete computational examples: a solvable non-coprime system (x ≡ 3 mod 6, x ≡ 1 mod 4 → x = 9 mod 12), an unsolvable system (gcd doesn't divide residue difference), Bézout witness verification, and the classical Sunzi problem for coprime moduli.",
+      "startLine": 235,
+      "endLine": 265,
+      "summary": "Part 7 plus the closing summary. Concrete computational examples: a solvable non-coprime system (x ≡ 3 mod 6, x ≡ 1 mod 4 → x = 9 mod 12, with gcd 6 4 = 2 dividing 3−1), an unsolvable system (gcd 2 ∤ 1), a Bézout witness 6·(−1)+4·2 = 2, and the classical Sunzi (~3rd century) coprime system x ≡ 2,3,2 (mod 3,5,7) → x = 23 mod 105. A final docstring recaps how Dirichlet approximation, lattice-coset CRT solvability, the golden-ratio Hurwitz constant, and Stern-Brocot mediants fit together.",
       "mathContext": "Concrete CRT examples: the non-coprime system $x \\equiv 3 \\pmod{6}$, $x \\equiv 1 \\pmod{4}$ has solution $x = 9$ (checking: $9 = 6+3$ and $9 = 2 \\cdot 4 + 1$). Demonstrates that CRT extends beyond coprime moduli when compatibility conditions hold."
     }
   ],

--- a/src/data/proofs/erdos-12/meta.json
+++ b/src/data/proofs/erdos-12/meta.json
@@ -186,10 +186,10 @@
     {
       "id": "main",
       "title": "Main Problem Statement",
-      "summary": "Packages all three questions into Erdos12Problem. Also includes primeSquares3mod4_is_good (fully proved conjunction of infiniteness and divisibility-freedom), density axioms for the construction (~√N/log N), and the liminf positivity statement.",
+      "summary": "Properties of the primeSquares3mod4 witness and the final packaging. infinitely_many_primes_3mod4 derives the infinitude of primes p ≡ 3 (mod 4) from Mathlib's Nat.infinite_setOf_prime_and_modEq; primeSquares3mod4_infinite pushes it through the injective p ↦ p² image; primeSquares3mod4_is_good is the fully proved conjunction of infiniteness and divisibility-freedom. primeCount3mod4 defines the counting function {p prime : p ≡ 3 mod 4, p ≤ N} whose Dirichlet asymptotics (~√N/log N) drive the density claim, and Erdos12Problem finally packages all three questions (Q1 dichotomy, Q2, Q3) into a single proposition.",
       "startLine": 248,
-      "endLine": 280,
-      "mathContext": "Packages all three questions into Erdos12Problem. Also includes primeSquares3mod4_is_good (fully proved conjunction of infiniteness and divisibility-freedom), density axioms for the construction (~√N/log N), and the liminf positivity statement."
+      "endLine": 293,
+      "mathContext": "The witness set is the squares of primes p ≡ 3 (mod 4): infinitude comes from Dirichlet (Nat.infinite_setOf_prime_and_modEq), and squaring is injective on ℕ so the image stays infinite. primeCount3mod4 counts the underlying primes, whose density x/(2 log x) yields |primeSquares3mod4 ∩ [1,N]| ~ √N/log N — matching the √N threshold of Q1. Erdos12Problem bundles the three sub-questions unproven, encoding the open status."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/frobenius-number-oq-01/meta.json
+++ b/src/data/proofs/frobenius-number-oq-01/meta.json
@@ -113,16 +113,16 @@
       "id": "main-theorem",
       "title": "Part 3: frobenius_count (Main Theorem)",
       "startLine": 78,
-      "endLine": 131,
-      "summary": "Six-step proof: (1) g > 0 and ¬Rep(g); (2) split filter into {1,...,g-1} ∪ {g}; (3) let c = |nonRep ∩ {1,...,g-1}|; (4) bijection gives c = |Rep ∩ {1,...,g-1}|; (5) partition gives 2c = g - 1; (6) g + 1 = (a-1)(b-1) and prod_pred_even give 2q = g + 1 for q = (a-1)(b-1)/2; conclude c + 1 = q via linarith.",
+      "endLine": 154,
+      "summary": "Six-step proof running to the close of the noncomputable section: (1) g > 0 and ¬Rep(g); (2) split filter into {1,...,g-1} ∪ {g}; (3) let c = |nonRep ∩ {1,...,g-1}|; (4) bijection gives c = |Rep ∩ {1,...,g-1}|; (5) partition gives 2c = g - 1; (6) g + 1 = (a-1)(b-1) and prod_pred_even give 2q = g + 1 for q = (a-1)(b-1)/2; conclude c + 1 = q via linarith.",
       "mathContext": "$2c + 1 = g$ where $c$ is the nonRep count in $(0, g)$ and $+1$ accounts for $g$ itself. Total $= \\frac{g+1}{2} = \\frac{(a-1)(b-1)}{2}$."
     },
     {
       "id": "examples",
       "title": "Concrete Examples (3,5), (3,7), (5,8)",
-      "startLine": 137,
-      "endLine": 159,
-      "summary": "Verifies the formula on three coprime pairs: (3,5) g=7 count=4 nonRep={1,2,4,7}, (3,7) g=11 count=6, (5,8) g=27 count=14. Each Frobenius number checked by native_decide, count by norm_num, individual non-representability by direct ⟨x,y,h⟩ ↦ omega refutation.",
+      "startLine": 156,
+      "endLine": 178,
+      "summary": "Verifies the formula on three coprime pairs: (3,5) g=7 count=4 nonRep={1,2,4,7}, (3,7) g=11 count=6, (5,8) g=27 count=14. Each Frobenius number checked by native_decide, count by norm_num, individual non-representability by direct ⟨x,y,h⟩ ↦ omega refutation; a closing #check exposes frobenius_count's signature.",
       "mathContext": "**Chicken McNugget** (3, 5): boxes of size 3, 5 cannot fill orders 1, 2, 4, 7. Density of non-representable approaches 1/2 for large coprime pairs."
     }
   ],


### PR DESCRIPTION
Enrichment pass — section-coverage fixes for 5 gallery entries. Each `meta.json` had `sections` whose max `endLine` fell short of the Lean file's EOF, leaving genuinely-uncovered declarations (capstone theorems or worked-example blocks) and, in three cases, sections mis-anchored into the middle of a neighbouring proof. All five now cover the full file with accurate summaries; no prose was invented and no status/axiom fields were touched.

- **algebraic-numbers-countable-oq-01-oq-01-oq-01**: §4 ended at 133, cutting off `card_emb_eq_finrank_rat` (the "degree-n number field has exactly n embeddings" capstone, line 139) which its own summary already named. Extended §4 to 141 and added §5 covering the two `Examples` blocks (squarefree minpoly, separability of ℚ̄).
- **automorphic-number-oq-01-oq-02**: added Part V for the uncovered "Concrete complementary pairs" block — 5/6, 25/76, 376/625 as complementary idempotents of ℤ/10ᵏ, verified by `decide`.
- **erdos-12**: "Main Problem Statement" (248–280) actually covered the Dirichlet infinitude theorems and stopped before the real `Erdos12Problem` def (289–293) and `primeCount3mod4` (282); extended to 293 and corrected the summary.
- **frobenius-number-oq-01**: "Concrete Examples" was anchored at 137–159, i.e. inside Part 3's `frobenius_count` proof. Re-anchored to 156–178 (the actual example blocks) and extended Part 3 to 154 (section close).
- **chinese-remainder-non-coprime-oq-04**: "CRT Non-Coprime Lattice Examples" (209–239) was sitting on the Golden Ratio theorems. Extended Golden Ratio Properties to 233 and re-anchored the CRT section to 235–265 (Part 7 examples + summary).

JSON validated; sections checked for overlaps (none) and full EOF coverage.
