### PR TITLE
audit(cramers-rule-oq002): fix inaccurate 'no decide' assumptions prose

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31058,6 +31058,12 @@
       "lastAudited": "2026-07-21T11:49:35Z",
       "result": "clean",
       "issues": []
+    },
+    "cramers-rule-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:55:08Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/cramers-rule-oq002/meta.json
+++ b/src/data/proofs/cramers-rule-oq002/meta.json
@@ -52,7 +52,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 158,
-    "assumptions": "None. All ten theorems are fully proved with 0 axioms and 0 sorries (no native_decide, no decide). The parent cramer_solution supplies xᵢ = det(Aᵢ)/det A; det_fin_two, det_fin_three, updateCol_self, and updateCol_ne are invoked from Mathlib. The specialization to the entrywise closed forms is assembled here.",
+    "assumptions": "None. All ten theorems are fully proved with 0 axioms and 0 sorries (no native_decide; the only `decide` uses are kernel-checked `Fin` index-inequality literals, which add no axioms — verified via `#print axioms`, which shows only propext / Classical.choice / Quot.sound). The parent cramer_solution supplies xᵢ = det(Aᵢ)/det A; det_fin_two, det_fin_three, updateCol_self, and updateCol_ne are invoked from Mathlib. The specialization to the entrywise closed forms is assembled here.",
     "theoremCount": 10,
     "definitionCount": 0,
     "prerequisites": [


### PR DESCRIPTION
Gallery integrity audit: **cramers-rule-oq002** (Cramer's Rule 2×2/3×3 closed forms) — LOW issue found and fixed.

## Finding (LOW, trust-neutral)
The public `assumptions` field claimed **"no native_decide, no decide"**, but the Lean file uses `by decide` **8 times** (lines 52, 60, 92–93, 103–104, 114–115) to discharge `Fin` index inequalities. This contradicted the file's own `proofStrategy` and section summaries, which correctly describe the `decide` usage.

`decide` is kernel-checked and adds **no axioms** — `#print axioms` on the core theorems shows only `propext, Classical.choice, Quot.sound` — so this is trust-neutral (strictly safer than `native_decide`). But the "no decide" claim was factually false and self-contradictory within the meta.

## Fix
Reworded the `assumptions` parenthetical to accurately state the `decide` uses are kernel-checked `Fin` index-inequality literals adding no axioms.

## Verification (otherwise clean)
- **Counts match meta**: 10 theorems, 0 defs, 0 sorries, 0 axioms, 158 lines.
- **Build verified** (`lake build`).
- **No native_decide**; `#print axioms` foundational-only.
- **Badge `mathlib` justified**: core `cramer_solution` from parent + `det_fin_two`/`det_fin_three`/`updateCol_*` from Mathlib; `originalContributions` correctly scoped to the entrywise specialization bookkeeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)