### PR TITLE
audit(tracker): de-moivre-oq001..oq010 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31064,6 +31064,66 @@
       "lastAudited": "2026-07-21T11:55:08Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "de-moivre-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:59:35Z",
+      "result": "clean",
+      "issues": []
+    },
+    "de-moivre-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:59:35Z",
+      "result": "clean",
+      "issues": []
+    },
+    "de-moivre-oq003": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:59:35Z",
+      "result": "clean",
+      "issues": []
+    },
+    "de-moivre-oq004": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:59:35Z",
+      "result": "clean",
+      "issues": []
+    },
+    "de-moivre-oq005": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:59:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "de-moivre-oq006": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:59:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "de-moivre-oq007": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:59:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "de-moivre-oq008": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:59:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "de-moivre-oq009": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:59:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "de-moivre-oq010": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T11:59:36Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Audit: de-moivre Chebyshev/DFT cluster (oq001–oq010)

10 never-audited `verified` gallery entries, full cluster. All integrity checks pass.

| slug | status/badge | sorry | axiom | native_decide | thm (match leanFile) |
|------|-------------|-------|-------|---------------|-----|
| oq001 | verified/mathlib | 0 | 0 | 0 | 7 ✓ |
| oq002 | verified/original | 0 | 0 | 0 | 7 ✓ |
| oq003 | verified/original | 0 | 0 | 0 | 9 ✓ |
| oq004 | verified/original | 0 | 0 | 0 | 7 ✓ |
| oq005 | verified/original | 0 | 0 | 0 | 4 ✓ |
| oq006 | verified/original | 0 | 0 | 0 | 7 ✓ |
| oq007 | verified/original | 0 | 0 | 0 | 9 ✓ |
| oq008 | verified/original | 0 | 0 | 0 | 3 ✓ |
| oq009 | verified/original | 0 | 0 | 0 | 7 ✓ |
| oq010 | verified/original | 0 | 0 | 0 | 8 ✓ |

**Verification (comment-stripped source):**
- No `sorry`/`admit`, no `axiom` declarations, no `native_decide` in any file. oq003 uses one kernel `decide` (adds 0 axioms, trust-neutral).
- Theorem/definition counts match each `leanFile` block exactly.
- Statements are substantive, not vacuous stubs: explicit Chebyshev U closed form vs Mathlib `Chebyshev.U`, the index map n↦Cₙ as a monoid/algebra homomorphism, 2-to-1 fiber structure (`¬injective` + `injOn`), the U·T Wronskian identity, degree/leading-coeff of U and real roots of T, and DFT unitarity/Parseval/isometry/order-four. No `: True` placeholders.

**Badges correct:** oq001 is `mathlib` (proves equality with Mathlib's `Polynomial.Chebyshev.U`); the rest are `original`, building genuine new constructions on top of the Mathlib Chebyshev API, which the prose discloses. No overclaim phrases ("first formalization"/"complete proof of De Moivre"). "0 axioms" prose is accurate.

Uncontested — 0 open PRs per slug.

---
Discovered during gallery integrity audit.