### PR TITLE
Enrich 9 entries: cover uncovered inter-section lemma blocks + fix handshake section drift

### DIFF
--- a/src/data/proofs/area-of-circle-oq013/meta.json
+++ b/src/data/proofs/area-of-circle-oq013/meta.json
@@ -90,6 +90,14 @@
       "mathContext": "$\\omega_n = \\frac{\\pi^{n/2}}{\\Gamma(n/2+1)}$, $V_n(r) = \\omega_n r^n$, $S_n(r) = n\\omega_n r^{n-1}$. The key relationship: $S_n(r) = \\frac{d}{dr}V_n(r)$ — this is the mathematical content of Steiner's formula, immediate from the power rule."
     },
     {
+      "id": "sec-supporting-lemmas",
+      "title": "Supporting Lemmas: Unit-Ball Volume Values and Continuity",
+      "startLine": 84,
+      "endLine": 129,
+      "summary": "Concrete evaluations and regularity for the unit-ball volume constant and sphere area: unitBallVolume_nonneg (ω_n ≥ 0 from nonnegativity of the Gamma quotient), unitBallVolume_two (ω₂ = π) and unitBallVolume_three (ω₃ = 4π/3) computed via the Gamma-function values Γ(3/2)=√π/2 and Γ(5/2)=3√π/4, continuous_nSphereArea (Sₙ is continuous, a constant times a power), and nBallVol_zero (Vₙ(0)=0 for n ≥ 1).",
+      "mathContext": "Evaluating $\\omega_n = \\pi^{n/2}/\\Gamma(n/2+1)$ at small $n$ recovers the classical constants: $\\omega_2 = \\pi$ (area of the unit disc) and $\\omega_3 = \\tfrac{4}{3}\\pi$ (volume of the unit ball), using $\\Gamma(1/2)=\\sqrt{\\pi}$ and the recurrence $\\Gamma(x+1)=x\\Gamma(x)$. These lemmas supply the nonnegativity, continuity, and base-value facts consumed by the FTC-based volume recovery in Parts III–IV."
+    },
+    {
       "id": "sec-steiner",
       "title": "Part I: Steiner's Formula (Two Forms)",
       "startLine": 130,

--- a/src/data/proofs/erdos-1003-oq-03/meta.json
+++ b/src/data/proofs/erdos-1003-oq-03/meta.json
@@ -133,8 +133,16 @@
       "title": "Natural Density and Its Dichotomy",
       "summary": "HasNaturalDensity d (the ratio count/(N+1) → d), the ratio bounds in [0,1], then the two structural results: hasNaturalDensity_zero_of_finite (finiteness squeezes the density to 0) and infinite_of_pos_density (a positive density forces infinitude, by uniqueness of limits against the finite case).",
       "startLine": 125,
-      "endLine": 175,
+      "endLine": 185,
       "mathContext": "Finite $\\Rightarrow$ density $0$ (squeeze $0 \\le \\text{count}/(N+1) \\le C/(N+1) \\to 0$); density $> 0 \\Rightarrow$ infinite."
+    },
+    {
+      "id": "admissibility-constraints",
+      "title": "What an Answer Must Supply — Uniqueness and Range",
+      "summary": "The well-definedness constraints any candidate density value must satisfy: hasNaturalDensity_unique (uniqueness of limits — the question asks for a well-defined real, not merely some limit point), hasNaturalDensity_nonneg, hasNaturalDensity_le_one and hasNaturalDensity_mem_Icc (the value lies in [0,1]), pos_density_count_unbounded (positive density forces an unbounded counting function), and the capstone oq03_answer_constraints packaging these admissibility conditions (0 axioms, 0 sorries).",
+      "startLine": 186,
+      "endLine": 238,
+      "mathContext": "Any answer $d$ to OQ-03 must be a genuine limit (unique by uniqueness of limits) with $d \\in [0,1]$; and $d > 0$ already forces $\\text{count}(N) \\to \\infty$, tying a positive density to the open infinitude of $\\{n : \\varphi(n)=\\varphi(n+1)\\}$."
     },
     {
       "id": "upper-density",

--- a/src/data/proofs/erdos-1130/meta.json
+++ b/src/data/proofs/erdos-1130/meta.json
@@ -122,6 +122,14 @@
       "mathContext": "Docstring only: de Boor–Pinkus (1978) equioscillation characterization. No `axiom de_boor_pinkus` is declared in this section."
     },
     {
+      "id": "structural-properties",
+      "title": "Structural Properties: Lagrange Basis and Lebesgue Values",
+      "startLine": 78,
+      "endLine": 121,
+      "summary": "Verified structural facts about the interpolation data: `nodes_injective` (the interpolation nodes are pairwise distinct), the cardinal Lagrange-basis identities `lagrangeBasis_self` ($\\ell_k(x_k) = 1$) and `lagrangeBasis_other` ($\\ell_k(x_j) = 0$ for $j \\neq k$, since the factor $(x_j - x_j)/(x_k - x_j) = 0$), and `lebesgue_at_node` (the value of the Lebesgue function at each node). These are the pointwise properties on which the Υ-functional bounds rest.",
+      "mathContext": "The Lagrange basis $\\ell_k(x) = \\prod_{j\\neq k}\\frac{x - x_j}{x_k - x_j}$ satisfies the cardinal conditions $\\ell_k(x_j) = \\delta_{jk}$; at a node the Lebesgue function $\\Lambda(x) = \\sum_k |\\ell_k(x)|$ collapses to $1$. Distinctness of nodes ($x_j \\neq x_k$) is what makes the basis well-defined."
+    },
+    {
       "id": "main-result",
       "title": "Erdős Problem 1130 (Proved)",
       "startLine": 122,

--- a/src/data/proofs/erdos-335/meta.json
+++ b/src/data/proofs/erdos-335/meta.json
@@ -179,6 +179,22 @@
       "mathContext": "Sanity-check computations anchor the theory: $d(\\mathbb{N})=1$ and $d(A)=0$ for finite $A$, the latter shown by bounding $|A\\cap[1,N]|\\le|A|$ so the ratio $|A|/N\\to 0$."
     },
     {
+      "id": "singleton-translates",
+      "title": "Singleton Translates and Strict Density Bounds",
+      "startLine": 366,
+      "endLine": 416,
+      "summary": "Translation and boundary lemmas: Sumset_singleton_left/right (adding {k} translates A by k), density_additive_zero_singleton (the trivial pair ({0}, A) is always density-additive when d(A) exists), and the strict bounds density_additive_lt_one_left/right (in a density-additive pair where one side has positive density, the other side's density is < 1).",
+      "mathContext": "Adjoining a singleton $\\{k\\}$ acts by translation, $\\{k\\}+A = k+A$, which preserves density; the trivial pair $(\\{0\\},A)$ is therefore always density-additive. When both densities are positive the additivity constraint $d(A)+d(B)\\le 1$ becomes strict, $d(A)<1$ and $d(B)<1$."
+    },
+    {
+      "id": "nondegenerate-witness",
+      "title": "A Non-Degenerate Density-Additive Witness",
+      "startLine": 417,
+      "endLine": 460,
+      "summary": "Exhibits a genuine (both-sides-positive-density) example: exists_positive_density_additive_pair, and the concrete √2-rotation witness exists_self_additive_density_quarter whose set has density exactly 1/4 with an additive self-sumset, showing the additivity phenomenon is not confined to degenerate translate/complement pairs.",
+      "mathContext": "Beyond the trivial singleton translates, a concrete $\\sqrt{2}$-equidistribution witness has density exactly $1/4$ and is density-additive with itself ($d(A+A)=2d(A)=1/2$), certifying that positive-density additive pairs exist."
+    },
+    {
       "id": "schnirelmann-bridge",
       "title": "Bridge to Mathlib's Schnirelmann Density",
       "startLine": 461,

--- a/src/data/proofs/erdos-524/meta.json
+++ b/src/data/proofs/erdos-524/meta.json
@@ -83,6 +83,22 @@
       "mathContext": "The open problem: find $f(n)$ with $c_1 f(n) \\leq M_n(t) \\leq c_2 f(n)$ for all large $n$, a.s. Known: $f(n) = \\omega(n^{1/2-\\varepsilon})$ and $f(n) = O(\\sqrt{n/\\log\\log n})$. Conjecture: $f(n) = \\sqrt{n}$."
     },
     {
+      "id": "elementary-properties",
+      "title": "Elementary Properties of the Digits and Polynomial",
+      "startLine": 59,
+      "endLine": 87,
+      "summary": "Foundational pointwise identities: `binaryDigit_values` ($\\varepsilon_k \\in \\{1,-1\\}$) and `binaryDigit_cast_abs` ($|\\varepsilon_k| = 1$ as a real); then the polynomial's evaluation lemmas `randSignPoly_eval_zero` ($P_n(t,0)=0$), `randSignPoly_eval_one` ($P_n(t,1)=\\sum_k \\varepsilon_k$, the endpoint sum driving Erdős's lower bound), and `randSignPoly_succ` (the term-by-term recurrence $P_{n+1} = P_n + \\varepsilon_{n+1} x^{n+1}$).",
+      "mathContext": "Each sign is unimodular, $|\\varepsilon_k|=1$; the polynomial vanishes at $x=0$ and collapses to the Rademacher sum $\\sum_k \\varepsilon_k$ at $x=1$. The recurrence $P_{n+1}(t,x)-P_n(t,x)=\\varepsilon_{n+1}x^{n+1}$ underlies the 1-Lipschitz behavior of $M_n$ in $n$."
+    },
+    {
+      "id": "trivial-upper-bound",
+      "title": "Trivial Upper Bound |Pₙ| ≤ n",
+      "startLine": 88,
+      "endLine": 107,
+      "summary": "Proves `randSignPoly_abs_le`: for $|x| \\le 1$, $|P_n(t,x)| \\le n$, by bounding each of the $n$ terms $|\\varepsilon_k x^k| \\le 1$ and summing. This crude triangle-inequality bound is what certifies `BddAbove` for the `sSup` defining $M_n$ in the polyMax infrastructure below.",
+      "mathContext": "$|P_n(t,x)| = |\\sum_{k=1}^n \\varepsilon_k x^k| \\le \\sum_{k=1}^n |\\varepsilon_k||x|^k \\le n$ on $[-1,1]$, since every summand is at most $1$. Though far from the conjectured $\\sqrt{n}$, this bound is exactly what makes the supremum $M_n = \\sup_{[-1,1]}|P_n|$ well-defined."
+    },
+    {
       "id": "additional-properties",
       "title": "Additional Properties",
       "startLine": 108,

--- a/src/data/proofs/erdos-661/meta.json
+++ b/src/data/proofs/erdos-661/meta.json
@@ -76,9 +76,17 @@
       "mathContext": "Documents the lattice upper bound $f(2n) \\le C \\cdot n / \\sqrt{\\log n}$ as an informal source comment. It is NOT formalized as a Lean declaration."
     },
     {
+      "id": "basic-distance-bounds",
+      "title": "Conjecture Recap and Basic Distance-Set Bounds",
+      "startLine": 72,
+      "endLine": 103,
+      "summary": "Restates the Erdős #661 conjecture ($F(2n) = o(f(2n))$?) and the known Guth–Katz / lattice bounds as source comments, then proves two elementary facts about the bipartite distance set: `bipartiteDistSet_card_le` (its cardinality is bounded by the product |X|·|Y| of the two point sets) and `bipartiteDistSet_mono` (monotone under enlarging either side). These are the foundational counting lemmas underlying the extremal functions F and f.",
+      "mathContext": "The bipartite distance set $D(X,Y) = \\{d(x,y) : x\\in X, y\\in Y\\}$ satisfies $|D(X,Y)| \\le |X|\\,|Y|$ and is monotone: $X_1\\subseteq X_2, Y_1\\subseteq Y_2 \\Rightarrow D(X_1,Y_1)\\subseteq D(X_2,Y_2)$. These bound the number of distinct bipartite distances that the extremal quantities $F(2n), f(2n)$ count."
+    },
+    {
       "id": "lenz-construction",
       "title": "Part VII: Lenz Construction in ℝ⁴ (Verified)",
-      "startLine": 122,
+      "startLine": 104,
       "endLine": 164,
       "summary": "Formalizes and verifies Lenz's construction in $\\mathbb{R}^4$. Defines $\\text{Point4} = (\\mathbb{R}^2) \\times (\\mathbb{R}^2)$, squared distance $d_4^2$, and two orthogonal unit circles $C_1(\\theta) = (\\cos\\theta, \\sin\\theta, 0, 0)$, $C_2(\\phi) = (0, 0, \\cos\\phi, \\sin\\phi)$. Proves $d_4^2(C_1(\\theta), C_2(\\phi)) = 2$ for all $\\theta, \\phi$ (so all bipartite distances equal $\\sqrt{2}$, giving $F_4(2n) = 1$). Also proves both circles have unit norm. All 3 theorems fully verified (0 sorries).",
       "mathContext": "Verified: Lenz's theorem that two orthogonal unit circles in $\\mathbb{R}^4$ produce constant bipartite distance $\\sqrt{2}$. Proof uses the Pythagorean identity $\\sin^2\\theta + \\cos^2\\theta = 1$."

--- a/src/data/proofs/erdos-949/meta.json
+++ b/src/data/proofs/erdos-949/meta.json
@@ -84,6 +84,20 @@
       "summary": "Proves `sidon_not_implies_sum_free`: {1,2,4} is Sidon but not sum-free (1+1=2 ∈ S). Corrects a previously unsound axiom. Full case analysis verified."
     },
     {
+      "id": "sec-949-sidon-closure",
+      "title": "Sidon Set Closure Properties",
+      "startLine": 102,
+      "endLine": 127,
+      "summary": "Structural lemmas for the Sidon property: `sidon_subset` (the Sidon property is inherited by subsets) and `sidon_two_element` (every two-element set {a,b} with a ≠ b is Sidon, via exhaustive 16-case analysis over (x,y,z,w) ∈ {a,b}⁴ reducing each collision to a = b)."
+    },
+    {
+      "id": "sec-949-structural",
+      "title": "Structural Properties: Sum-Free and Sumset Lemmas",
+      "startLine": 128,
+      "endLine": 171,
+      "summary": "Basic closure and computation lemmas: `sum_free_empty`, `sum_free_singleton` (needs x ≠ 0, since {0} fails 0+0=0), `sum_free_subset`, `realSumset_mono`, `open_interval_sum_free` ((1/3,2/3) is sum-free as a+b > 2/3), plus sumset identities `realSumset_empty`, `realSumset_singleton` ({x} ↦ {2x}), `mem_realSumset_of_mem`, and `zero_not_sum_free`."
+    },
+    {
       "id": "sec-949-sidon-solved",
       "title": "Sidon Variant (Solved)",
       "startLine": 175,

--- a/src/data/proofs/handshake-lemma-oq-01/meta.json
+++ b/src/data/proofs/handshake-lemma-oq-01/meta.json
@@ -129,10 +129,26 @@
       "summary": "edge_upper_bound (the minimal edge deficiency 2|E| ≤ n·d − 1) and not_isRegularOfDegree_of_odd_mul / not_isRegularOfDegree_of_odd_odd (no d-regular graph when n·d is odd, in particular n and d both odd)."
     },
     {
+      "id": "sec-parity-even",
+      "title": "Even-Case Parity of the Deficiency",
+      "startLine": 125,
+      "endLine": 137,
+      "mathContext": "$\\mathrm{deficiency}\\,G\\,d \\equiv n\\cdot d \\pmod 2$; when $n\\cdot d$ is even the deficiency is even, the complement of the odd case.",
+      "summary": "deficiency_even_of_even: when n·d is even, the degree deficiency is even. Together with the odd-case result (deficiency_odd) this pins the parity of the deficiency to that of n·d in both cases, completing the parity dichotomy."
+    },
+    {
+      "id": "sec-strict-witness",
+      "title": "Strict Deficiency Witness and Vertex Counting",
+      "startLine": 138,
+      "endLine": 169,
+      "mathContext": "$n\\cdot d$ odd $\\Rightarrow \\exists v,\\ \\deg v < d$; and $\\#\\{v : \\deg v < d\\} \\le \\mathrm{deficiency}\\,G\\,d$, since each shortfall vertex contributes at least $1$ to the deficiency sum.",
+      "summary": "The vertex-level refinements of the lower bound: exists_degree_lt_of_odd (when n·d is odd, a concrete strictly-deficient vertex exists — the graph cannot be d-regular), and card_degree_lt_le_deficiency (the number of below-target vertices is at most the total deficiency, since each contributes ≥ 1 to the sum d·v − deg v)."
+    },
+    {
       "id": "sec-sharpness",
       "title": "Sharpness: the Floor is Attained",
-      "startLine": 125,
-      "endLine": 135,
+      "startLine": 170,
+      "endLine": 176,
       "mathContext": "Empty graph on $\\mathrm{Fin}\\,1$ with $d=1$: $n\\cdot d = 1$ odd, deficiency $=1$.",
       "summary": "deficiency_floor_attained certifies (by kernel decide) that the one-vertex empty graph with d = 1 attains deficiency exactly 1, so the lower bound cannot be improved; two examples confirm n·d = 1 is odd and all degrees are ≤ 1."
     },

--- a/src/data/proofs/sophie-germain/meta.json
+++ b/src/data/proofs/sophie-germain/meta.json
@@ -107,9 +107,17 @@
       "id": "safe-primes",
       "title": "Safe Prime Structure",
       "startLine": 214,
-      "endLine": 244,
+      "endLine": 249,
       "summary": "Properties of safe primes: q ≡ 11 (mod 12) and the Sophie Germain ↔ safe prime equivalence.",
       "mathContext": "$p > 3 \\wedge \\text{IsSophieGermainPrime}(p) \\implies (2p+1) \\equiv 11 \\pmod{12}$. Equivalence: $\\text{IsSophieGermainPrime}(p) \\iff \\text{Prime}(p) \\wedge \\text{IsSafePrime}(2p+1)$."
+    },
+    {
+      "id": "conjecture-and-elementary",
+      "title": "The Conjecture (Axiom) and Elementary Consequences",
+      "startLine": 250,
+      "endLine": 281,
+      "summary": "States the open Sophie Germain conjecture as the file's `axiom sophie_germain_conjecture : SophieGermainConjecture` (there are infinitely many Sophie Germain primes), then draws immediate consequences: `exists_sophie_germain_gt` (arbitrarily large Sophie Germain primes exist, directly from the axiom) and the elementary sanity checks `one_not_sg`, `zero_not_sg`, and `sophie_germain_ge_two` (every Sophie Germain prime is ≥ 2).",
+      "mathContext": "The infinitude of Sophie Germain primes is unproven; it is recorded here as the sole axiom `sophie_germain_conjecture`. Given it, $\\forall N,\\ \\exists p > N$ with $p$ Sophie Germain. The bookkeeping bounds ($0,1 \\notin$ SG, $p \\ge 2$) follow from primality of $p$."
     },
     {
       "id": "chain",


### PR DESCRIPTION
Enrichment pass (enricher-2): adds `sections` coverage for genuinely uncovered inter-section blocks of named lemmas. Detected via an inter-section-gap scan (contiguous ≥15-line gaps between consecutive sections containing ≥3 named `theorem`/`lemma`/`def` declarations, anchored to the Lean files' own `/- ## -/` banners).

Each new section maps a real block of the proof that no existing section described:

- **erdos-949** (`Erdos949Problem.lean`): the 102–171 block was entirely skipped (sections jumped [82–101] → [175–184]). Added **Sidon Set Closure Properties** (`sidon_subset`, `sidon_two_element`) and **Structural Properties: Sum-Free and Sumset Lemmas** (`sum_free_empty/singleton/subset`, `realSumset_mono`, `open_interval_sum_free`, sumset identities, `zero_not_sum_free`).
- **erdos-335** (`Erdos335Problem.lean`): the 364–460 block (two `/- ## -/` banners) was uncovered. Added **Singleton Translates and Strict Density Bounds** and **A Non-Degenerate Density-Additive Witness** (the √2-rotation witness of density 1/4).
- **erdos-1003-oq-03** (`Erdos1003OQ03.lean`): extended the `density` section anchor 175→185 (it already described `infinite_of_pos_density`, at line 179), and added **What an Answer Must Supply — Uniqueness and Range** (`hasNaturalDensity_unique/nonneg/le_one/mem_Icc`, `pos_density_count_unbounded`, `oq03_answer_constraints`).
- **erdos-524** (`Erdos524Problem.lean`): the 58–107 block was uncovered. Added **Elementary Properties of the Digits and Polynomial** and **Trivial Upper Bound |Pₙ| ≤ n**.
- **area-of-circle-oq013** (`AreaOfCircleOQ01OQ02OQ03OQ03.lean`): the SUPPORTING LEMMAS block (84–129) was uncovered. Added **Supporting Lemmas: Unit-Ball Volume Values and Continuity** (`unitBallVolume_two = π`, `unitBallVolume_three = 4π/3`, continuity, `nBallVol_zero`).

Pure `sections` navigation coverage with meaningful summaries + `mathContext`. No `status`/`badge`/`axiomCount`/prose changes. All 5 meta.json validated (parse + no section overlaps).

---

**Second batch (same vein, added to this PR):**

- **erdos-661** (`Erdos661Problem.lean`): added **Conjecture Recap and Basic Distance-Set Bounds** (72–103: `bipartiteDistSet_card_le/mono`) and re-anchored **Part VII: Lenz Construction** 122→104 (the `Point4`/`distSq4`/`lenzCircle1/2` declarations actually begin at 104).
- **erdos-1130** (`Erdos1130Problem.lean`): added **Structural Properties: Lagrange Basis and Lebesgue Values** (78–121: `nodes_injective`, `lagrangeBasis_self/other`, `lebesgue_at_node`).
- **sophie-germain** (`SophieGermain.lean`): extended Safe Prime Structure anchor to 249 and added **The Conjecture (Axiom) and Elementary Consequences** (250–281), disclosing `axiom sophie_germain_conjecture` and its consequences.
- **handshake-lemma-oq-01**: **drift fix** — the "Sharpness: the Floor is Attained" section was anchored at [125–135] but the `deficiency_floor_attained` theorem it describes is at line 170; re-anchored it to [170–176] and added **Even-Case Parity of the Deficiency** (125–137) and **Strict Deficiency Witness and Vertex Counting** (138–169) for the previously-uncovered theorems.

Total: **9 entries**, pure `sections` coverage/re-anchor with meaningful summaries + `mathContext`. No `status`/`badge`/`axiomCount`/prose-claim changes.
