### PR TITLE
audit: quadratic-reciprocity oq001 count fix + oq002/003 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31124,6 +31124,24 @@
       "lastAudited": "2026-07-21T11:59:36Z",
       "result": "clean",
       "issues": []
+    },
+    "elementary-quadratic-reciprocity-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T12:08:27Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "elementary-quadratic-reciprocity-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T12:08:27Z",
+      "result": "clean",
+      "issues": []
+    },
+    "elementary-quadratic-reciprocity-oq003": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T12:08:27Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq001/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq001/meta.json
@@ -22,7 +22,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 243,
-    "theoremCount": 11,
+    "theoremCount": 10,
     "definitionCount": 1,
     "dateAdded": "2026-05-07",
     "mathlibDependencies": [
@@ -76,7 +76,8 @@
       "MulChar.ringHomComp pattern for casting characters"
     ],
     "parentSlug": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01",
-    "rootSlug": "elementary-quadratic-reciprocity"
+    "rootSlug": "elementary-quadratic-reciprocity",
+    "assumptions": "None for the QR theorems (0 axioms, 0 sorries). Part VII contains four illustrative concrete-instance examples proved by native_decide; these are anonymous sanity checks and do not affect the axiom set of any named theorem (the QR theorems remain axiom-free)."
   },
   "leanFile": {
     "imports": [


### PR DESCRIPTION
Audited the three elementary-quadratic-reciprocity OQ children.

**oq001 (LOW fix applied)**
- `theoremCount` 11 → **10** (actual named theorems; verified by grep — only 10 `theorem` decls, lines 53–187).
- The 4 `native_decide` uses are all in anonymous Part VII `example`s (concrete Legendre-symbol sanity checks). They produce no reusable declaration and do **not** propagate `Lean.ofReduceBool` into any named theorem, so `axiomCount: 0` is accurate for the QR theorems. Disclosed this in `assumptions` for transparency.
- Core QR assembly is genuine (0 sorries/0 axioms); `mathlib` badge correct.

**oq002 (clean)** — 2 theorems match. Uses kernel `decide` (axiom-free). Explicitly avoids `legendreSym.quadratic_reciprocity`, so `original` badge is justified.

**oq003 (clean)** — 5 theorems (diagonal Jacobi sums are cyclotomic integers); no decide/axioms; `mathlib` correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)