### PR TITLE
Enrich 3 entries: re-anchor drifted tail sections + cover uncovered capstone theorems

### DIFF
--- a/src/data/proofs/erdos-183/meta.json
+++ b/src/data/proofs/erdos-183/meta.json
@@ -151,17 +151,25 @@
     {
       "title": "Growth Rate Analysis",
       "startLine": 729,
-      "endLine": 757,
-      "summary": "Summary of bounds (bounds_summary theorem) and the related problem pointer (#483)",
-      "mathContext": "Bound: Summary of bounds and the enormous gap between exponential lower and factorial upper",
+      "endLine": 758,
+      "summary": "`bounds_summary`: packages the exponential lower bound (∃ c > 1, R(3;k) ≥ cᵏ) together with the factorial upper bound (∃ C, R(3;k) ≤ C·k!), quantifying the enormous gap between the two known bounds.",
+      "mathContext": "$c^k \\le R(3;k) \\le C\\,k!$ — the lower bound is exponential in $k$ while the upper bound is factorial, an exponentially wide window.",
       "id": "growth-rate-analysis"
     },
     {
-      "title": "Formal Statement",
-      "startLine": 758,
-      "endLine": 770,
-      "summary": "erdos_183_main combining existence and bounds (R3k_ge_three + R3k_factorial_upper)",
-      "mathContext": "Verified: Main theorem combining existence and bounds",
+      "title": "Connection to Other Problems (Part 8)",
+      "startLine": 759,
+      "endLine": 768,
+      "summary": "`relatedProblem`: records that R(3;k) connects to other Ramsey-theoretic quantities, pointing to related Erdős Problem #483.",
+      "mathContext": "R(3;k) sits in a family of hypergraph Ramsey quantities; Erdős Problem #483 is one directly related question.",
+      "id": "connection-other-problems"
+    },
+    {
+      "title": "Formal Statement (Part 9)",
+      "startLine": 769,
+      "endLine": 781,
+      "summary": "`erdos_183_main`: the precise formalization of Problem #183, combining existence (R3k_ge_three: R(3;k) ≥ 3 for k ≥ 1) with the factorial upper bound (R3k_factorial_upper) into a single proved statement.",
+      "mathContext": "$\\forall k \\ge 1,\\ R(3;k) \\ge 3$ and $\\exists C > 0,\\ R(3;k) \\le C\\,k!$ — the headline theorem of the file, fully proved.",
       "id": "formal-statement"
     }
   ],

--- a/src/data/proofs/erdos-348/meta.json
+++ b/src/data/proofs/erdos-348/meta.json
@@ -162,29 +162,29 @@
       "id": "pair-1-2",
       "title": "The (1,2) Pair",
       "startLine": 498,
-      "endLine": 514,
+      "endLine": 535,
       "summary": "Assembles `pair_1_2_valid`: Fibonacci is monotone, complete (`fib_complete`), 1-robust (axiom `fib_1_robust`), and not 2-robust (`fib_not_2_robust`), hence (1,2) ∈ validPairs.",
       "mathContext": "$(1,2) \\in \\mathrm{validPairs}$ via the Fibonacci sequence: complete, 1-robust (assumed), not 2-robust (proved)."
     },
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture",
-      "startLine": 515,
-      "endLine": 543,
+      "startLine": 536,
+      "endLine": 563,
       "summary": "States `erdos_348_characterization` (valid pairs are exactly {(m,m+1)} or are cut off below some k), the decidable-but-unknown `erdos_348_case_2_3`, the `IsStronglyRobust` notion, and a reference docstring on van Doorn's theorem (no strongly complete sequence is 2-robust) and bounded-gap facts.",
       "mathContext": "Conjecture: $\\mathrm{validPairs} = \\{(m,m+1)\\}$, or $\\exists k$ beyond which no consecutive pair is valid. Van Doorn: no *strongly* complete sequence is 2-robust."
     },
     {
       "id": "main-open-question",
       "title": "The Main Open Question",
-      "startLine": 544,
-      "endLine": 570,
+      "startLine": 564,
+      "endLine": 591,
       "summary": "Final formalization `erdos_348_main_problem`: either every consecutive pair (m, m+1) is valid, or there is a cutoff k beyond which consecutive pairs fail. The precise characterization of valid pairs — including whether (2,3) is valid for the weak completeness notion — remains open.",
       "mathContext": "Open: is $(2,3)$ valid for weak completeness? The full characterization of $\\mathrm{validPairs}$ is unknown."
     }
   ],
   "conclusion": {
-    "summary": "This 256-line formalization of Erdős Problem #348 defines completeness, robustness, and the valid pairs set, then constructs witnesses for (0,1) via powers of 2 and (1,2) via Fibonacci numbers. Van Doorn's theorem constrains the strongly complete case. The representation count and gap property provide structural context. The main conjecture is formalized as a disjunction about whether all (m, m+1) pairs are valid. Seven sorries remain, mostly in the Zeckendorf-based arguments.",
+    "summary": "This 591-line formalization of Erdős Problem #348 defines completeness, robustness, and the valid pairs set, then constructs witnesses for (0,1) via powers of 2 and (1,2) via Fibonacci numbers. Van Doorn's theorem constrains the strongly complete case. The representation count and gap property provide structural context. The main conjecture is formalized as a disjunction about whether all (m, m+1) pairs are valid. The development is sorry-free; its sole assumption is the axiom `fib_1_robust` (Fibonacci's 1-robustness, hence the axiom badge).",
     "implications": "**Theoretical Significance**: Resolution would reveal whether completeness robustness has a finite or infinite hierarchy.\n\nAn infinite hierarchy (all (m, m+1) valid) would require constructing increasingly resilient sequences — possibly using number-theoretic constructions with growing redundancy. A finite cutoff would establish a phase transition where robustness becomes qualitatively different, connecting to the theory of additive bases of finite order.",
     "openQuestions": [
       "Is (2, 3) valid for weak completeness — does there exist a complete sequence surviving any 2 deletions but not some 3?",

--- a/src/data/proofs/erdos-727/meta.json
+++ b/src/data/proofs/erdos-727/meta.json
@@ -133,25 +133,41 @@
       "id": "relationship",
       "title": "Relationship Between Problems",
       "startLine": 166,
-      "endLine": 192,
-      "summary": "Main conjecture implies EGRS variant.",
-      "mathContext": "Mathematical content: Main conjecture implies EGRS variant."
+      "endLine": 207,
+      "summary": "`main_conjecture_implies_egrs`: the main conjecture (for k ≥ 2) implies the weaker EGRS divisibility variant, so a positive answer to #727 subsumes the solved EGRS case.",
+      "mathContext": "If $((n+k)!)^2 \\mid (2n)!$ infinitely often, then $(n+k)!\\,(n+1)! \\mid (2n)!$ infinitely often — the main conjecture is at least as strong as the EGRS variant."
     },
     {
       "id": "erdos-bound",
-      "title": "Erdős's Related Result",
-      "startLine": 193,
-      "endLine": 209,
-      "summary": "The 1968 bound on factorial divisibility.",
-      "mathContext": "Bound: The 1968 bound on factorial divisibility."
+      "title": "Erdős's Related Result (1968 Bound)",
+      "startLine": 208,
+      "endLine": 225,
+      "summary": "`erdos_factorial_bound` (axiom): Erdős's 1968 result that if a!·b! | n! then a + b ≤ n + O(log n), stated qualitatively as the existence of a constant C with a + b ≤ n + C·log n. Bounds how large the factorial factors can be.",
+      "mathContext": "$a!\\,b! \\mid n! \\implies a + b \\le n + C\\log n$ for some constant $C$ — an upper bound on the size of factorial divisors."
+    },
+    {
+      "id": "numerical-evidence",
+      "title": "Numerical Evidence",
+      "startLine": 226,
+      "endLine": 248,
+      "summary": "Small-n divisibility checks for the k = 2 case ((n+2)!)² | (2n)!: n = 2, 3, 4 all fail, and the ratio (2n)!/((n+2)!)² grows with n, so exact divisibility requires prime-factorization analysis rather than direct computation. Includes the checked example ¬ divides_factorial 1 2.",
+      "mathContext": "For $k = 2$: $(4!)^2 = 576 \\nmid 24$, $(5!)^2 \\nmid 720$, $(6!)^2 \\nmid 40320$; the quotient $(2n)!/((n+2)!)^2$ grows, so no obvious infinitude."
+    },
+    {
+      "id": "why-interesting",
+      "title": "Why This Problem Is Interesting",
+      "startLine": 249,
+      "endLine": 270,
+      "summary": "Motivation and the `square_difficulty` marker: the squared factor ((n+k)!)² is what makes k ≥ 2 hard, tying the problem to factorial arithmetic, Catalan numbers, Legendre's prime-power formula, and analytic estimates. The sharp gap between the solved k = 1 and open k = 2 signals subtle number-theoretic phenomena.",
+      "mathContext": "The square in $((n+k)!)^2$ raises the divisibility threshold sharply; `square_difficulty` records why $k \\ge 2$ resists the $k = 1$ techniques."
     },
     {
       "id": "status-summary",
       "title": "Status Summary",
-      "startLine": 256,
-      "endLine": 278,
-      "summary": "Summary of what is solved and what remains open.",
-      "mathContext": "Mathematical content: Summary of what is solved and what remains open."
+      "startLine": 271,
+      "endLine": 293,
+      "summary": "`erdos_727_status`: the headline theorem packaging the state of the problem — the k = 1 case is solved (Balakran) and the EGRS variant holds, while the main k ≥ 2 question remains open. Summarizes what is proved versus assumed.",
+      "mathContext": "Formal status: $k = 1$ solved and EGRS variant infinite; the $k \\ge 2$ conjecture $((n+k)!)^2 \\mid (2n)!$ infinitely often is open."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Section-coverage enrichment pass (fresh origin/main scan, single-file undercoverage vein).

Each entry's `sections` array stopped short of / drifted from the file's real tail
declarations. Re-anchored to cover 1..EOF with accurate summaries and `$...$`
mathContext. No status/badge/axiomCount changes — verified each file's actual
axiom/sorry state first.

- **erdos-348** (`Erdos348Problem.lean`, 591 lines): the three tail sections each
  described declarations located past their `endLine` (pair_1_2_valid@520,
  erdos_348_characterization@545, erdos_348_main_problem def@587 were all
  uncovered). Re-anchored contiguously to EOF. Also fixed stale `conclusion.summary`
  prose: "256-line" → 591, and "Seven sorries remain" → the file is sorry-free
  (grep-verified; `meta.sorries: 0`), its sole assumption being the `fib_1_robust`
  axiom (hence the axiom badge).
- **erdos-727** (`Erdos727Problem.lean`, 293 lines, 9→11 sections): closed an
  interior hole (lines 210–255) that dropped the `erdos_factorial_bound` 1968-bound
  axiom, the numerical-evidence block, and the motivation/`square_difficulty`
  material; and covered the previously-uncovered `erdos_727_status` capstone
  theorem (line 285). Extended "Relationship Between Problems" to include
  `main_conjecture_implies_egrs`.
- **erdos-183** (`Erdos183Problem.lean`, 781 lines, 8→9 sections): "Formal Statement"
  was anchored at 758–770 but the `erdos_183_main` theorem it describes lives at
  776 (Part 9); re-anchored to 769–781. Added a "Connection to Other Problems"
  section (Part 8, `relatedProblem` → #483) and extended "Growth Rate Analysis" to
  fully include `bounds_summary`.

All three now cover their Lean file contiguously to EOF (verified via node parse +
contiguity check).
