### PR TITLE
audit(tracker): erdos-1018/128/131 OQ children clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31142,6 +31142,30 @@
       "lastAudited": "2026-07-21T12:08:27Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-1018-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T12:17:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-128-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T12:17:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-131-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T12:17:14Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-131-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T12:17:14Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Audited 4 Erdős OQ children. All clean — counts match exactly, **0 axioms, 0 sorries**, no `native_decide`, no vacuous `True`-stubs.

| slug | result |
|---|---|
| erdos-131-oq001 | `davenport_constant_cyclic : IsLeast {m \| ∀ f, HasZeroSumSubseq f} n` — complete D(ℤ/nℤ)=n (pigeonhole upper + constant-1 lower witness). Exemplary. |
| erdos-131-oq002 | `davenport_rank2_lower : a+b−1 ≤ d` — lower bound only; docstring **honestly** notes Olson's matching upper bound is *not* formalized. |
| erdos-1018-oq001 | `splitGraph_choosability` — χ_ℓ(S_{n,k})=k+1 via k-degenerate⟹(k+1)-choosable **and** not-k-choosable. Both directions genuine. |
| erdos-128-oq001 | C₅-blow-up hereditarily clique-free; 18 thm/10 def, real structural content. |

`original` badges accurate. None claims to resolve an open Erdős problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)