### PR TITLE
Enrich 5 entries: cover uncovered capstone theorems + re-anchor drifted sections

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq001/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq001/meta.json
@@ -67,41 +67,41 @@
     {
       "id": "modulus",
       "title": "§2: Modulus and Phase",
-      "startLine": 58,
-      "endLine": 82,
+      "startLine": 57,
+      "endLine": 87,
       "summary": "Proves |φ(t)| = exp(-σ²t²/2), strict decay for σ²>0, and unit modulus for point masses.",
       "mathContext": "$|\\varphi(t)| = |\\exp(z)| = \\exp(\\Re(z)) = \\exp(-\\sigma^2 t^2/2)$. For $\\sigma^2 > 0$ and $t \\neq 0$: $-\\sigma^2 t^2/2 < 0$ so $|\\varphi(t)| < 1$."
     },
     {
       "id": "product",
       "title": "§3: Product Formula (Independent Sum)",
-      "startLine": 84,
-      "endLine": 104,
+      "startLine": 88,
+      "endLine": 113,
       "summary": "Product and power formulas encoding that independent Gaussian sums are Gaussian.",
       "mathContext": "$\\varphi_{\\mu_1,\\sigma_1^2} \\cdot \\varphi_{\\mu_2,\\sigma_2^2} = \\varphi_{\\mu_1+\\mu_2,\\sigma_1^2+\\sigma_2^2}$ from $\\exp(a)\\exp(b) = \\exp(a+b)$."
     },
     {
       "id": "symmetry",
       "title": "§4: Symmetry Properties",
-      "startLine": 106,
-      "endLine": 122,
+      "startLine": 114,
+      "endLine": 138,
       "summary": "Conjugate symmetry φ(-t) = conj(φ(t)) and real-valuedness for centered Gaussians.",
       "mathContext": "$\\varphi(-t) = \\overline{\\varphi(t)}$ because the Gaussian density is real-valued."
     },
     {
       "id": "scaling",
       "title": "§5: Scaling and Standardization",
-      "startLine": 124,
-      "endLine": 148,
+      "startLine": 139,
+      "endLine": 170,
       "summary": "Standard Gaussian φ(t) = exp(-t²/2) and scaling relationship φ_{0,σ²}(t) = φ_{0,1}(σt).",
       "mathContext": "Standardization: $(X-\\mu)/\\sigma \\sim N(0,1)$ gives $\\varphi_{0,1}(t) = \\exp(-t^2/2)$."
     },
     {
       "id": "clt",
       "title": "§6: CLT Connection",
-      "startLine": 150,
-      "endLine": 170,
-      "summary": "Gaussian stability: Sₙ/√n ~ N(0,1) via characteristic function algebra.",
+      "startLine": 171,
+      "endLine": 191,
+      "summary": "`clt_gaussian_stable`: the CLT connection — proves gaussianCharFn 0 n (t/√n) = gaussianCharFn 0 1 t, i.e. Sₙ/√n has the standard-Gaussian characteristic function exp(-t²/2), the simplest special case of the CLT (Gaussians are stable).",
       "mathContext": "$\\varphi_{0,n}(t/\\sqrt{n}) = \\exp(-n \\cdot t^2/(2n)) = \\exp(-t^2/2) = \\varphi_{0,1}(t)$."
     }
   ],

--- a/src/data/proofs/erdos-14/meta.json
+++ b/src/data/proofs/erdos-14/meta.json
@@ -108,6 +108,14 @@
       "endLine": 93,
       "summary": "For $A \\subseteq \\{1,\\ldots,N\\}$, $\\exists A$ with $f_A(N) < 2^{3/2}\\sqrt{N}$. The constant $2\\sqrt{2}$ may be optimal.",
       "mathContext": "For $A \\subseteq \\{1,\\ldots,N\\}$, $\\exists A$ with $f_A(N) < $$2^{{3/2}$}$\\sqrt{N}$. The constant $2\\sqrt{2}$ may be optimal."
+    },
+    {
+      "id": "structural-observations",
+      "title": "Structural Observations",
+      "startLine": 94,
+      "endLine": 109,
+      "summary": "`non_unique_monotone`: proves the non-unique sum count `nonUniqueSumCountInf A N` is monotonically non-decreasing in N (M ≤ N ⟹ count M ≤ count N), via `Set.ncard_le_ncard` on the nested difference sets. A preceding comment records the Sidon-set heuristic: a Sidon A has ≤ √N + O(N^{1/4}) elements up to N, so its sumset misses ~N integers.",
+      "mathContext": "$M \\le N \\implies \\mathrm{nonUniqueSumCount}(A,M) \\le \\mathrm{nonUniqueSumCount}(A,N)$ — the count of non-uniquely-represented sums grows with the window, proved by monotonicity of `Set.ncard` on nested `Icc` differences."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-313/meta.json
+++ b/src/data/proofs/erdos-313/meta.json
@@ -49,7 +49,7 @@
     "originalContributions": [
       "erdos313Solutions: set of (m, P) pairs satisfying the equation",
       "IsPrimaryPseudoperfect: predicate for primary pseudoperfect numbers",
-      "erdos_313_conjecture and primary_pseudoperfect_infinite: infinitude axioms",
+      "IsPrimaryPseudoperfect predicate defined; the infinitude conjecture stated (in a comment, not as an axiom or Prop)",
       "Five verified examples: m = 2, 6, 42, 1806, 47058",
       "product_constraint: m = ∏P in any solution",
       "uniqueness: at most one prime set per m",
@@ -88,29 +88,29 @@
       "id": "examples",
       "title": "Verified Examples",
       "startLine": 62,
-      "endLine": 79,
-      "summary": "Records the first 5 known solutions as axioms: $m = 2$ ($P = \\{2\\}$), $m = 6$ ($P = \\{2,3\\}$), $m = 42$ ($P = \\{2,3,7\\}$), $m = 1806$ ($P = \\{2,3,7,43\\}$), $m = 47058$ ($P = \\{2,3,11,23,31\\}$). The Sylvester-like pattern breaks at $m = 47058$."
+      "endLine": 104,
+      "summary": "Proves (not axiomatizes) the first 5 known solutions as theorems, each discharged by `decide`/`norm_num`: $m = 2$ ($P = \\{2\\}$), $m = 6$ ($P = \\{2,3\\}$), $m = 42$ ($P = \\{2,3,7\\}$), $m = 1806$ ($P = \\{2,3,7,43\\}$), $m = 47058$ ($P = \\{2,3,11,23,31\\}$). The Sylvester-like pattern breaks at $m = 47058$."
     },
     {
       "id": "structure",
       "title": "Structural Properties",
-      "startLine": 80,
-      "endLine": 96,
-      "summary": "States **product_constraint** ($m = \\prod P$), **uniqueness** (at most one $P$ per $m$), and **at_least_eight** ($\\geq 8$ primary pseudoperfect numbers known). These structural results show the solution map $(m, P) \\mapsto m$ is injective."
+      "startLine": 105,
+      "endLine": 112,
+      "summary": "Documents (as comment observations, not formal theorems) the **product constraint** ($m = \\prod P$), **uniqueness** (each solution $P$ is determined by $m$'s prime factorization), and the list of **at least 8 known** primary pseudoperfect numbers (2, 6, 42, 1806, 47058, 2214502422, 52495396602, …)."
     },
     {
       "id": "egyptian",
       "title": "Egyptian Fraction Connection",
-      "startLine": 97,
-      "endLine": 104,
-      "summary": "States **egyptian_fraction_form**: $\\sum 1/p + 1/m = 1$, rewriting the primary pseudoperfect equation as an Egyptian fraction decomposition of $1$ with distinct denominators, connecting to Problems #282–285."
+      "startLine": 113,
+      "endLine": 122,
+      "summary": "Proves **egyptian_fraction_form**: for any solution $(m, P)$, $\\sum_{p \\in P} 1/p + 1/m = 1$, rewriting the primary-pseudoperfect equation $\\sum 1/p = 1 - 1/m$ as an Egyptian-fraction decomposition of $1$ with distinct denominators (all but possibly $m$ prime)."
     }
   ],
   "overview": {
     "historicalContext": "**Erdős Problem #313: Primary Pseudoperfect Numbers**\n\nErdős and Graham posed this problem in their 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory*. It asks whether there are infinitely many integers $m \\geq 2$ such that the reciprocals of $m$'s prime divisors sum to $1 - 1/m$.\n\n**The Equation:**\nFor a squarefree integer $m = p_1 p_2 \\cdots p_k$ with distinct prime factors, the condition is $\\sum_{i=1}^k 1/p_i = 1 - 1/m$, equivalently $\\sum_{i=1}^k 1/p_i + 1/m = 1$. This is an Egyptian fraction representation of $1$ where all but one denominator is prime.\n\n**Known Solutions (OEIS A054377):**\nExactly 8 primary pseudoperfect numbers are known:\n- $m = 2$: $1/2 = 1 - 1/2$\n- $m = 6 = 2 \\cdot 3$: $1/2 + 1/3 = 1 - 1/6$\n- $m = 42 = 2 \\cdot 3 \\cdot 7$: $1/2 + 1/3 + 1/7 = 1 - 1/42$\n- $m = 1806 = 2 \\cdot 3 \\cdot 7 \\cdot 43$: $1/2 + 1/3 + 1/7 + 1/43 = 1 - 1/1806$\n- $m = 47058 = 2 \\cdot 3 \\cdot 11 \\cdot 23 \\cdot 31$\n- $m = 2214502422$, $m = 52495396602$, and a 31-digit number\n\n**The Sylvester-Like Pattern:**\nThe first four terms $(2, 6, 42, 1806)$ follow a Sylvester-like recursion: $m_{k+1} \\approx m_k^2$. However, this pattern breaks at $m = 47058$, which uses the entirely different prime set $\\{2, 3, 11, 23, 31\\}$ instead of extending $\\{2, 3, 7, 43\\}$.\n\n**Connection to Pseudoperfect Numbers:**\nThe name comes from the analogy with *pseudoperfect* (or *semiperfect*) numbers, where some subset of divisors sums to $n$. Here, the sum of reciprocal *prime* factors plays a role analogous to the abundancy index $\\sigma(n)/n$.\n\n**Butske-Jaje-Mayernik (2000):**\nThe most systematic study was by Butske, Jaje, and Mayernik, who verified computationally that no 9th primary pseudoperfect number exists below large bounds and studied the equation's structure via graph theory.\n\n**Current Status:**\nThe problem remains OPEN. No proof of infinitude or finiteness exists. The super-exponential growth of known solutions makes computational search increasingly difficult.",
     "problemStatement": "Are there infinitely many integers $m \\geq 2$ such that $\\sum_{p \\mid m,\\, p \\text{ prime}} 1/p = 1 - 1/m$?\n\nEquivalently: are there infinitely many squarefree $m$ whose prime factorization $m = p_1 \\cdots p_k$ satisfies $1/p_1 + \\cdots + 1/p_k + 1/m = 1$?",
     "text": "Are there infinitely many m such that ∑ 1/p = 1 − 1/m for some set of distinct primes P? These m are called primary pseudoperfect numbers. Only 8 are known (OEIS A054377). Each m equals the product of its primes.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Solution Set:** Define `erdos313Solutions` as pairs $(m, P)$ satisfying the equation with $m \\geq 2$, $P$ nonempty, all primes, and the rational sum condition.\n\n2. **Primary Pseudoperfect:** Define `IsPrimaryPseudoperfect n` as the existential projection.\n\n3. **Main Conjecture:** State infinitude of both solutions and primary pseudoperfect numbers.\n\n4. **Verified Examples:** Record the first 5 known solutions ($m = 2, 6, 42, 1806, 47058$) as axioms.\n\n5. **Structural Properties:** State the product constraint ($m = \\prod P$), uniqueness of $P$, and the count of at least 8 known solutions.\n\n6. **Egyptian Fraction Connection:** State the reformulation as $\\sum 1/p + 1/m = 1$.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Solution Set:** Define `erdos313Solutions` as pairs $(m, P)$ satisfying the equation with $m \\geq 2$, $P$ nonempty, all primes, and the rational sum condition.\n\n2. **Primary Pseudoperfect:** Define `IsPrimaryPseudoperfect n` as the existential projection.\n\n3. **Main Conjecture:** State infinitude of both solutions and primary pseudoperfect numbers.\n\n4. **Verified Examples:** Prove the first 5 known solutions ($m = 2, 6, 42, 1806, 47058$) as theorems, each discharged by `decide`/`norm_num` (not axiomatized).\n\n5. **Structural Properties:** Document (in comments) the product constraint ($m = \\prod P$), uniqueness of $P$, and the count of at least 8 known solutions.\n\n6. **Egyptian Fraction Connection:** Prove `egyptian_fraction_form`, the reformulation $\\sum 1/p + 1/m = 1$.",
     "keyInsights": [
       "**Product Constraint:** In any solution, $m$ must equal the product of all primes in $P$. This follows from clearing denominators and applying unique factorization. It means primary pseudoperfect numbers are exactly the squarefree numbers satisfying the equation.",
       "**Uniqueness:** At most one prime set $P$ works for each $m$, since $P$ is determined by $m$'s prime factorization. This makes the counting problem well-defined: asking for infinitely many solutions is the same as asking for infinitely many $m$.",
@@ -124,7 +124,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Erdős Problem #313 asks whether there are infinitely many primary pseudoperfect numbers — integers $m$ whose prime reciprocals sum to $1 - 1/m$. The formalization captures the solution set, the primary pseudoperfect predicate, five verified examples, structural constraints (product and uniqueness), the count of 8 known solutions, and the Egyptian fraction connection. The 105-line Lean file has 0 sorries, with all results axiomatized.",
+    "summary": "Erdős Problem #313 asks whether there are infinitely many primary pseudoperfect numbers — integers $m$ whose prime reciprocals sum to $1 - 1/m$. The formalization captures the solution set, the primary pseudoperfect predicate, five verified examples, structural constraints (product and uniqueness), the count of 8 known solutions, and the Egyptian fraction connection. The 122-line Lean file has 0 sorries and 0 axioms: the five example solutions and `egyptian_fraction_form` are fully proved, while the `axiomatized` status reflects only that the infinitude conjecture itself is stated (as a Prop) but not yet formalized.",
     "implications": "**Theoretical Significance**: **Connections and Implications**\n\n1. **Egyptian Fraction Cluster:** Primary pseudoperfect numbers are special Egyptian fractions of $1$ with mostly-prime denominators. This connects to the broader Erdős Egyptian fraction program: #282 (greedy termination), #283 (polynomial denominators), #284 (maximum denominators), #285 (asymptotics).\n\n2. **Number-Theoretic Depth:** The product constraint $m = \\prod P$ means primary pseudoperfect numbers are squarefree, and the equation becomes a constraint on which subsets of primes have reciprocal sums close to $1$.\n\nThis connects to the theory of the prime harmonic series and Mertens' theorem ($\\sum_{p \\leq x} 1/p \\approx \\log \\log x$).\n\n3. **Pseudoperfect Number Theory:** The problem bridges unit fraction theory and the classical theory of perfect and pseudoperfect numbers. The abundancy index $\\sigma(n)/n$ for primary pseudoperfect $m$ satisfies a special identity.\n\n4. **Computational Challenges:** The super-exponential growth of known solutions ($m_8$ has 31 digits) makes exhaustive search for a 9th term computationally challenging. Graph-theoretic methods (Butske-Jaje-Mayernik) offer structured search strategies.",
     "openQuestions": [
       "**The Main Question:** Are there infinitely many primary pseudoperfect numbers, or only finitely many?",

--- a/src/data/proofs/erdos-385/meta.json
+++ b/src/data/proofs/erdos-385/meta.json
@@ -167,8 +167,16 @@
       "title": "Why This Is Hard",
       "summary": "Connections to prime distribution, sieve theory, Siegel zeros",
       "startLine": 156,
-      "endLine": 175,
+      "endLine": 179,
       "mathContext": "Mathematical content: Connections to prime distribution, sieve theory, Siegel zeros"
+    },
+    {
+      "id": "derived-results",
+      "title": "Derived Results",
+      "summary": "`finitely_many_exceptions`: proves that Question 1 (F(n) > n eventually) implies the set {n : F(n) ≤ n} is finite. The proof extracts the eventual threshold N from the `Filter.eventually_atTop` witness and bounds the exception set inside `Set.Iio N`.",
+      "startLine": 180,
+      "endLine": 195,
+      "mathContext": "$\\text{Question 1} \\implies \\{n : F(n) \\le n\\}$ is finite: every exception lies below the eventual threshold $N$, so the set embeds in $\\{0,\\ldots,N-1\\}$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-554/meta.json
+++ b/src/data/proofs/erdos-554/meta.json
@@ -107,6 +107,22 @@
       "startLine": 94,
       "endLine": 110,
       "summary": "The simplest open case C_5 and proof it follows from the full conjecture."
+    },
+    {
+      "id": "chromatic-relation",
+      "title": "Part VI: Relation to Graph Chromatic Number",
+      "startLine": 111,
+      "endLine": 125,
+      "summary": "`erdos_question_chromatic_3`: records the connection between the Ramsey ratio and chromatic-number questions, phrasing the k = 3 instance as a Prop that ties odd-cycle Ramsey growth to colorability constraints.",
+      "mathContext": "The ratio $R(C_{2n+1};k)/R(K_3;k)$ is linked to how chromatic thresholds grow with the number of colors $k$; `erdos_question_chromatic_3` states this for the $k = 3$ case."
+    },
+    {
+      "id": "summary",
+      "title": "Part VII: Summary",
+      "startLine": 126,
+      "endLine": 128,
+      "summary": "Closing summary of the formalization: the conjecture, the verified classical 2-color results, and the open asymptotic ratio question.",
+      "mathContext": "Recap: $R(C_{2n+1};k)/R(K_3;k) \\to 0$ is conjectured; only classical 2-color values are proved, the limit remains open."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Section-coverage enrichment pass (fresh origin/main scan, single-file undercoverage
vein — tail declarations left uncovered or mis-anchored). No status/badge/axiomCount
changes; verified each file's actual axiom/sorry state first.

- **erdos-385** (`Erdos385Problem.lean`): added a "Derived Results" section for the
  proved `finitely_many_exceptions` theorem (Question 1 ⟹ `{n : F(n) ≤ n}` finite),
  which sat under its own `## Derived Results` banner past the last covered section.
- **erdos-554** (`Erdos554Problem.lean`, 5→7 sections): covered the two uncovered
  final Parts — Part VI (Relation to Graph Chromatic Number, `erdos_question_chromatic_3`)
  and Part VII (Summary).
- **erdos-14** (`Erdos14Problem.lean`): added a "Structural Observations" section for
  the proved `non_unique_monotone` theorem (the non-unique sum count is monotone
  non-decreasing in N).
- **central-limit-theorem-oq001** (`CentralLimitTheoremOQ01OQ02OQ01OQ01.lean`):
  re-anchored systematic tail drift — §2–§6 were each anchored 4–22 lines before the
  theorems they describe, so §6 "CLT Connection" covered the §5 scaling helpers rather
  than `clt_gaussian_stable` (line 182). Now aligned to the author's Part banners,
  contiguous to EOF.
- **erdos-313** (`Erdos313Problem.lean`): re-anchored the drifted tail (the
  examples/structure/egyptian sections each pointed at the wrong declarations —
  "Structural Properties" landed on `solution_1806`/`solution_47058`, "Egyptian Fraction
  Connection" on a solution proof). Also corrected false "as axioms" prose:
  the five `solution_*` theorems and `egyptian_fraction_form` are **proved**
  (`decide`/`norm_num`), the file has **0 axioms**, and the infinitude conjecture is
  comment-only (not a named axiom/Prop). Fixed stale "105-line" → 122 and a
  contributions entry citing non-existent decls.

All five now cover their Lean file contiguously to EOF (verified via node JSON parse +
contiguity check).
