### PR TITLE
audit: cramers-rule-oq001 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31142,6 +31142,12 @@
       "lastAudited": "2026-07-21T12:08:27Z",
       "result": "clean",
       "issues": []
+    },
+    "cramers-rule-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T12:20:31Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — cramers-rule-oq001 clean. Persists tracker entry.

Verified: 0 sorries, 0 axioms (#print axioms = standard triple only), 13 thm / 3 def / 519 lines all match Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean, badge 'original' appropriate, all 16 originalContributions map to real decls, no native_decide. File compiles.

Discovered during gallery integrity audit.