### PR TITLE
audit(tracker): cramers-rule-oq001 clean (consolidated v3)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31166,6 +31166,12 @@
       "lastAudited": "2026-07-21T12:17:14Z",
       "result": "clean",
       "issues": []
+    },
+    "cramers-rule-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T12:27:07Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Persists the clean audit tracker entry for `cramers-rule-oq001` on top of fresh `origin/main` so `find-targets --next` stops re-serving this uncontested id.

## Re-verification (reserve mode)
- 0 real `sorry` (3 grep hits are docstring prose: "sorry-free", "strategic sorry")
- 0 axioms, 0 `native_decide`, no `True` stubs
- meta: status=verified, badge=original, sorries=0, axiomCount=0, theoremCount=13 — matches file
- Quasideterminant `qdetF`/`qdetN_step`; badge `original` legit (real bordered-determinant crux)

Supersedes stuck conflicting PRs #40456 and #40452 (both DIRTY against current main tracker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)