### PR TITLE
Research: erdos-46-wip-01 — exact-cardinality reprs of 1 for every k≥3 (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos46Problem.lean
+++ b/proofs/Proofs/Erdos46Problem.lean
@@ -294,6 +294,40 @@ theorem exists_isUnitFractionRepr_card_ge (k : ℕ) :
       Finset.card_erase_of_mem hmS]
     omega
 
+/-- **Unit-fraction representations of `1` of every cardinality `k ≥ 3` exist.**
+Strengthening of `exists_isUnitFractionRepr_card_ge` from `k ≤ |S|` to `|S| = k`
+exactly. The split-largest step of `isUnitFractionRepr_replace` raises the
+cardinality by *exactly one* (it removes `m` and inserts the two distinct new
+denominators `m+1`, `m(m+1)`), so starting from the length-`3` base `{2, 3, 6}`
+every cardinality `≥ 3` is realised. (Cardinalities `0, 1, 2` are impossible:
+`two_le_card_of_isUnitFractionRepr` rules out `< 2`, and a two-element
+representation `1/a + 1/b = 1` with `a, b ≥ 2` forces `a = b = 2`, not a
+`Finset` of two *distinct* elements — so `3` is the exact minimum.) -/
+theorem exists_isUnitFractionRepr_card_eq (k : ℕ) (hk : 3 ≤ k) :
+    ∃ S : Finset ℕ, IsUnitFractionRepr S ∧ S.card = k := by
+  induction k, hk using Nat.le_induction with
+  | base => exact ⟨{2, 3, 6}, isUnitFractionRepr_two_three_six, by decide⟩
+  | succ k hk ih =>
+    obtain ⟨S, hS, hcard⟩ := ih
+    have hne : S.Nonempty := by rw [← Finset.card_pos]; omega
+    -- split the largest denominator `m`; the replacement adds exactly one element
+    set m := S.max' hne with hm_def
+    have hmS : m ∈ S := S.max'_mem hne
+    have hmax : ∀ a ∈ S, a ≤ m := fun a ha => S.le_max' a ha
+    have hm2 : 2 ≤ m := hS.1 m hmS
+    have h1 : m + 1 ∉ S := fun h => by have := hmax _ h; omega
+    have h2 : m * (m + 1) ∉ S := fun h => by have := hmax _ h; nlinarith
+    have hrepl := isUnitFractionRepr_replace hS hmS h1 h2
+    refine ⟨insert (m + 1) (insert (m * (m + 1)) (S.erase m)), hrepl, ?_⟩
+    have hne' : m + 1 ≠ m * (m + 1) := by nlinarith
+    have h2erase : m * (m + 1) ∉ S.erase m := fun h => h2 (Finset.mem_of_mem_erase h)
+    have h1insert : m + 1 ∉ insert (m * (m + 1)) (S.erase m) := by
+      simp only [Finset.mem_insert, not_or]
+      exact ⟨hne', fun h => h1 (Finset.mem_of_mem_erase h)⟩
+    rw [Finset.card_insert_of_notMem h1insert, Finset.card_insert_of_notMem h2erase,
+      Finset.card_erase_of_mem hmS]
+    omega
+
 /-- **There are infinitely many distinct unit-fraction representations of `1`.**
 Consequence of `exists_isUnitFractionRepr_card_ge`: the representations have
 unbounded cardinality, so the set of them cannot be finite (a finite family of

--- a/src/data/research/problems/erdos-46-wip-01.json
+++ b/src/data/research/problems/erdos-46-wip-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-46-wip-01",
   "title": "Complete the Erdős #46 Monochromatic Unit-Fraction Formalization",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -22,7 +22,18 @@
     "since": "2026-07-09T17:33:18-07:00",
     "iteration": 3,
     "focus": "Session 2: splitting identity (Fibonacci–Sylvester 1/n=1/(n+1)+1/(n(n+1))), telescoping form, concrete witness {2,3,6}, existence, and the term-replacement lengthening step (isUnitFractionRepr_replace). 5 axiom-free theorems, theoremCount 16→21, host-verified.",
-    "blockers": [],
+    "blockers": [
+      {
+        "route": "union/scaling assembly of large-min 1/c pieces into exactly 1",
+        "reopenCriterion": "materially new mechanism required (assembly reduces to representing a fixed unit fraction with min>N, which is equivalent-strength to the target)",
+        "blockedAt": "2026-07-21"
+      },
+      {
+        "route": "raise-minimum-by-one recursion on a repr of 1",
+        "reopenCriterion": "materially new mechanism required (removing the smallest term 1/m leaves needing a min>max repr of 1/m, equivalent-strength)",
+        "blockedAt": "2026-07-21"
+      }
+    ],
     "nextAction": "Croot's theorem (existence of monochromatic representation) is deep/unformalized — needs density/covering machinery from the 2003 paper. Elementary splitting/lengthening toolkit now in place; a full lengthening-to-infinity chain would need denominator-freshness bookkeeping.",
     "attemptCounts": {
       "total": 0,
@@ -31,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-1, 2026-07-21, host lake env lean EXIT=0, #print axioms=[propext,Classical.choice,Quot.sound] on all 4 new thms): added the TELESCOPING engine (sum_Ico_inv_mul_succ, isRatFractionRepr_telescope, exists_isRatFractionRepr_min_gt, injective_mul_succ). Realises the min-denominator>N regime for the positive-rational family 1/a−1/b. Remaining obstruction toward min>N repr of EXACTLY 1 is collision-free assembly (documented). Deep Croot 2003 monochromatic result stays unformalized.",
+    "progressSummary": "PROGRESS (researcher-1, 2026-07-21): added exists_isUnitFractionRepr_card_eq (exact cardinality k for all k≥3, 0-axiom). Established that the min>N-repr-of-exactly-1 target is NOT reachable by the union/scaling/telescoping engines: the natural assembly routes are equivalent-strength (recorded as blocked routes). Genuine remaining nugget = greedy-harmonic-plus-excess-adjustment or explicit Diophantine tuning. Deep Croot 2003 monochromatic result stays unformalized.",
     "builtItems": [
       "not_isUnitFractionRepr_singleton — no singleton represents 1 (Erdos46Problem.lean)",
       "two_le_card_of_isUnitFractionRepr — a UFR of 1 has >= 2 elements (Erdos46Problem.lean)",
@@ -44,7 +55,8 @@
       "sum_Ico_inv_mul_succ (Erdos46Problem.lean): ∑_{k∈[a,b)} 1/(k(k+1)) = 1/a − 1/b, telescoping via inv_mul_succ (0-axiom)",
       "isRatFractionRepr_telescope (Erdos46Problem.lean): pronic set {k(k+1):a≤k<b} represents 1/a−1/b, min denom ≥ a(a+1) (0-axiom)",
       "exists_isRatFractionRepr_min_gt (Erdos46Problem.lean): ∀ B L≥1, ∃ repr of a POSITIVE rational using exactly L denominators all > B (0-axiom)",
-      "injective_mul_succ (Erdos46Problem.lean): k↦k(k+1) injective on ℕ (strictMono_nat_of_lt_succ)"
+      "injective_mul_succ (Erdos46Problem.lean): k↦k(k+1) injective on ℕ (strictMono_nat_of_lt_succ)",
+      "exists_isUnitFractionRepr_card_eq in proofs/Proofs/Erdos46Problem.lean (|S|=k for all k≥3, 0-axiom, host-verified)"
     ],
     "insights": [
       "Erdos46Problem.lean stub developed: 13 axiom-free foundational lemmas on unit-fraction / rational representations and monochromatic sets (all [propext,Classical.choice,Quot.sound], no sorry/native_decide).",
@@ -53,13 +65,16 @@
       "Multiplicative scaling engine added: image under (t·) divides represented rational by t (Finset.sum_image with pairwise-injectivity from Nat.eq_of_mul_eq_mul_left; 1/(t·n)=(1/t)(1/n) via mul_inv then ring). Complements the additive union lemma; the two engines (additive-union + multiplicative-scale) are the assembly toolkit for disjoint-support reprs.",
       "Disjoint-chaining obstruction is collision-freeness, not the arithmetic: splitting the LARGEST denom leaves small heads {2,3} fixed (reprs share them); scaling a whole repr by different factors produces cross-copy denominator collisions; multiplicative/additive assembly of a min>N repr of 1 needs exact collision bookkeeping (open).",
       "Telescoping engine (pronic reciprocals) is the third construction primitive alongside additive-union and multiplicative-scaling: it BUILDS reprs from scratch and directly realises the min-denominator>N regime for positive-rational targets by starting the interval at a large a.",
-      "The min>N regime is now reached for the two-parameter family 1/a−1/b (a>B); the ONLY remaining gap toward pairwise-disjoint chaining is assembling a repr of EXACTLY 1 with min>N (collision-free), which telescoping alone does not give (its value 1/a−1/b < 1)."
+      "The min>N regime is now reached for the two-parameter family 1/a−1/b (a>B); the ONLY remaining gap toward pairwise-disjoint chaining is assembling a repr of EXACTLY 1 with min>N (collision-free), which telescoping alone does not give (its value 1/a−1/b < 1).",
+      "Exact-cardinality: unit-fraction reprs of 1 exist for EVERY cardinality k≥3, and 3 is the exact minimum (a 2-term 1/a+1/b=1 with a,b≥2 forces a=b=2, not distinct). Split-largest raises |S| by exactly 1.",
+      "EQUIVALENT-STRENGTH BLOCKER (min>N repr of exactly 1): every elementary bootstrap bottoms out at representing a fixed unit fraction 1/c with min>N. But scaling by t maps a min>M repr of 1 to a min>tM repr of 1/t, and two nested-scale disjoint 1/2-reprs union back to a min>N repr of 1 — so \"1/c with min>N\" and \"1 with min>N\" are equivalent strength. Hence the union-assembly and raise-min-by-one routes earn ZERO decomposition credit."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Assemble a repr of EXACTLY 1 with min denom > N collision-free: candidate = telescope-tail (1/a−1/b large-denom) glued to a large-denom repr of the leftover 1−(1/a−1/b) via isRatFractionRepr_union under a disjointness proof.",
       "Given exists_...(exactly 1, min>N), infinitely many PAIRWISE-DISJOINT reprs of 1 follow by chaining N_{i+1}=max S_i.",
-      "Deep monochromatic statement (Croot 2003) remains unformalized — needs density/covering machinery."
+      "Deep monochromatic statement (Croot 2003) remains unformalized — needs density/covering machinery.",
+      "min>N repr of exactly 1 needs a NON-bootstrap mechanism (greedy harmonic segment N+1..M with sum≥1 then a large-denominator excess-adjustment, OR an explicit Diophantine block-tuning). The union/scaling/telescoping engines alone cannot reach it (equivalent-strength). This is the genuine remaining nugget for ErdosProblem46_infinitely_many."
     ],
     "markdown": "# Knowledge Base: erdos-46-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## erdos-46-wip-01 — exact-cardinality unit-fraction representations of 1

Adds one 0-axiom, 0-sorry theorem to `proofs/Proofs/Erdos46Problem.lean` and
records a rigorous blocked-route finding in the knowledge tracker.

### New theorem
`exists_isUnitFractionRepr_card_eq (k : ℕ) (hk : 3 ≤ k) : ∃ S, IsUnitFractionRepr S ∧ S.card = k`

Strengthens the existing `exists_isUnitFractionRepr_card_ge` (`|S| ≥ k`) to
`|S| = k` **exactly**, for every `k ≥ 3`. The split-largest step
(`isUnitFractionRepr_replace`) raises cardinality by *exactly one* — it removes
the largest denominator `m` and inserts the two distinct new ones `m+1` and
`m(m+1)` — so starting from the length-3 base `{2, 3, 6}` every cardinality
`≥ 3` is realised. `3` is the exact minimum (`two_le_card_of_isUnitFractionRepr`
rules out `< 2`, and a two-term `1/a + 1/b = 1` with `a, b ≥ 2` forces
`a = b = 2`, not a two-element `Finset`).

### Verification
- Host `lake env lean Proofs/Erdos46Problem.lean` → **EXIT 0** (v4.31.0, Mathlib cache).
- `#print axioms exists_isUnitFractionRepr_card_eq` → `[propext, Classical.choice, Quot.sound]` only. **0 added axioms, 0 sorries.**

### Blocked-route finding (recorded in tracker, no code)
The flagged open step — a representation of **exactly 1** with every denominator
`> N` — is **not** reachable by the union / scaling / telescoping engines in this
file. Both natural routes (disjoint-union assembly of large-min `1/c` pieces, and
raise-minimum-by-one recursion) reduce to representing a *fixed* unit fraction
`1/c` with `min > N`. By scaling, that sub-problem is **equivalent-strength** to
the target itself (a `min > M` repr of 1 scales to a `min > tM` repr of `1/t`,
and two nested-scale disjoint `1/2`-reprs union back to a `min > N` repr of 1).
Per the equivalent-strength check these routes earn zero decomposition credit and
are logged as blocked routes. The genuine remaining nugget is a non-bootstrap
mechanism (greedy harmonic segment + large-denominator excess-adjustment, or
explicit Diophantine block-tuning).

The deep Croot 2003 monochromatic result remains unformalized.
