### PR TITLE
audit(tracker): 7 clean (feuerbach-defs + erdos-div/euler/factor-remainder)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31334,6 +31334,48 @@
       "lastAudited": "2026-07-21T12:33:44Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-divisibility-pigeonhole-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T12:35:58Z",
+      "result": "clean",
+      "issues": []
+    },
+    "euler-identity-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T12:35:58Z",
+      "result": "clean",
+      "issues": []
+    },
+    "factor-remainder-theorem-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T12:35:58Z",
+      "result": "clean",
+      "issues": []
+    },
+    "feuerbachs-theorem-defs-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T12:35:58Z",
+      "result": "clean",
+      "issues": []
+    },
+    "feuerbachs-theorem-defs-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T12:35:58Z",
+      "result": "clean",
+      "issues": []
+    },
+    "feuerbachs-theorem-defs-oq003": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T12:35:58Z",
+      "result": "clean",
+      "issues": []
+    },
+    "feuerbachs-theorem-defs-oq004": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T12:35:58Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Rescue of 7 clean-audit tracker entries orphaned when batch PR #40461 auto-merged mid-push. All were verified clean (0 sorry/axiom/native_decide/True-stubs; theoremCounts incl private decls). Re-applied on fresh main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)