### PR TITLE
Enrich 6 entries: section re-anchors + cover uncovered decl blocks

### DIFF
--- a/src/data/proofs/burnside-counting-oq-03/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03/meta.json
@@ -108,8 +108,8 @@
       "id": "sec-necklaces",
       "title": "§6-7: Necklace Application and General Formula",
       "startLine": 364,
-      "endLine": 402,
-      "summary": "Derives 6 binary 4-necklaces (24/4 = 6). States polya_necklace_formula_statement: assuming Burnside and the fixed-point formula, conclude n · necklace_count = Σ k^gcd(r,n).",
+      "endLine": 440,
+      "summary": "Derives 6 binary 4-necklaces (24/4 = 6). States polya_necklace_formula_statement: assuming Burnside and the fixed-point formula, conclude n · necklace_count = Σ k^gcd(r,n). Then proves the closed forms in both indexings: polya_necklace_divisor_formula (n·#necklaces = Σ_{d∣n} φ(n/d)·k^d), polya_necklace_formula_of_burnside, and polya_necklace_divisor_formula_of_burnside (the same identities discharged from the Burnside hypothesis).",
       "mathContext": "$\\#\\text{necklaces}(4,2) = 24/4 = 6$. General: $n \\cdot \\#\\text{necklaces}(n,k) = \\sum_{r=0}^{n-1} k^{\\gcd(r,n)} = \\sum_{d \\mid n} \\varphi(n/d) \\cdot k^d$."
     },
     {

--- a/src/data/proofs/erdos-470/meta.json
+++ b/src/data/proofs/erdos-470/meta.json
@@ -108,8 +108,8 @@
       "id": "odd-weird",
       "title": "Open Question 1: Odd Weird Numbers",
       "startLine": 127,
-      "endLine": 401,
-      "summary": "Formal statement of the odd weird question. Systematically proves that each of the first 5 odd abundant numbers (945, 1575, 2205, 2835, 3465) is semiperfect, with no odd abundant in each gap, establishing that any odd weird > 3465. Axiomatizes Liddy-Riedl's 6-prime-divisor bound.",
+      "endLine": 425,
+      "summary": "Formal statement of the odd weird question. Systematically proves that each of the first odd abundant numbers (945, 1575, 2205, 2835, 3465, …, 5775) is semiperfect, with no odd abundant in each gap — culminating in fifty775_semiperfect, no_odd_abundant_5356_to_5775, and odd_weird_gt_5775, so any odd weird number exceeds 5775. Axiomatizes Liddy-Riedl's 6-prime-divisor bound.",
       "mathContext": "Odd abundant numbers up to 3465: $945 = 3^3 \\times 5 \\times 7$, $1575 = 3^2 \\times 5^2 \\times 7$, $2205 = 3^2 \\times 5 \\times 7^2$, $2835 = 3^4 \\times 5 \\times 7$, $3465 = 3^2 \\times 5 \\times 7 \\times 11$. All semiperfect. Any odd weird $n > 3465$."
     },
     {


### PR DESCRIPTION
Six gallery entries with drifted section maps surfaced by the inter-section-gap scan (≥3 uncovered named decls in a ≥15-line gap between sorted sections). All fixes are pure metadata — no status/badge/axiomCount changes.

## Full re-anchors (systematic one-Part drift)
- **`ballot-problem-oq-01-oq-02-oq-04`** — every section drifted by ~one Part; `fiber-argument` was mislabeled onto Part III counterexample content while the real Part IV (`projection_ambiguity`, `fiber_argument_fails`) sat uncovered. Re-anchored all 7 sections to their real `## Part N` banners (contiguous 57..352).
- **`erdos-523`** — whole back-half drifted; the four capstone theorems (`erdos_523`, `erdos_523_constant`, `erdos_523_main`, `erdos_523_solved`) were stranded in a degenerate single-line "Summary". Re-anchored all 11 sections 1:1 to their `## Part N` banners (contiguous 39..239).
- **`cauchy-schwarz-integral-oq006`** — map drifted ~4-8 lines and **omitted Part II entirely**; added the missing **Positivity Lemmas** section (`whm_pos`, `wgm_pos`, `wam_pos`, `wqm_nonneg`) and re-anchored the other six (contiguous 43..221).

## End-line extensions (uncovered tail decls)
- **`burnside-counting-oq-03`** — §6-7 extended to cover the three Pólya necklace-formula theorems.
- **`bounded-prime-gaps-oq-02`** — Non-Vacuity extended to cover the zero-functional models (`EHAtLevel_zero`, `levelMonotone_zero`, `elliottHalberstam_zero`).
- **`erdos-470`** — Open Question 1 extended to cover the 5775 odd-weird ascent (`odd_weird_gt_5775` et al.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
