### PR TITLE
Enrich 4 entries: re-anchor drifted section maps + cover uncovered lemma blocks

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-04/meta.json
@@ -63,54 +63,54 @@
       "id": "definitions",
       "title": "Definitions for Weighted Ballot",
       "startLine": 51,
-      "endLine": 73,
-      "summary": "WeightSeq (List ℚ), partialSums (scanl), isGoodWeighted (all partial sums positive), Decidable instance."
+      "endLine": 81,
+      "summary": "Part I: WeightSeq (List ℚ), partialSums (scanl), isGoodWeighted (all partial sums positive), Decidable instance."
     },
     {
       "id": "partial-sum-lemmas",
       "title": "Partial Sum Lemmas",
-      "startLine": 75,
-      "endLine": 101,
-      "summary": "partialSums_nil, partialSums_singleton, partialSums_two, singleton_good_iff, two_good_iff.",
+      "startLine": 82,
+      "endLine": 139,
+      "summary": "Part II: partialSums_nil, partialSums_singleton, partialSums_two, partialSums_three; singleton_good_iff, two_good_iff, three_good_iff (the decidable good-ordering criterion used to enumerate the counterexample).",
       "mathContext": "partialSums [w₁, w₂] = [w₁, w₁+w₂]; isGoodWeighted [w₁,w₂] ↔ 0 < w₁ ∧ 0 < w₁+w₂."
     },
     {
       "id": "counterexample",
       "title": "Counterexample: Classical Formula Fails",
-      "startLine": 103,
-      "endLine": 152,
-      "summary": "Six orderings of [2,1,-2] enumerated. Two are good. Actual P = 1/3 ≠ 1/5 = classical formula.",
+      "startLine": 140,
+      "endLine": 210,
+      "summary": "Part III: all six orderings of [2,1,-2] resolved (ordering1_good..ordering6_not_good), counterexample_good_count establishes exactly two are good (native_decide), and classical_formula_prediction/formula_fails/classical_formula_incorrect show the true P = 2/6 = 1/3 differs from the classical (3−2)/(3+2) = 1/5.",
       "mathContext": "W_A = 2+1 = 3, W_B = 2. Formula: (3-2)/(3+2) = 1/5. Actual: 2/6 = 1/3."
     },
     {
       "id": "fiber-argument",
       "title": "The Fiber Argument Breaks",
-      "startLine": 154,
-      "endLine": 182,
-      "summary": "projection_ambiguity: [2,-1] is good but [1,-2] is not, despite same ±1 pattern. fiber_argument_fails: existential witness.",
+      "startLine": 211,
+      "endLine": 247,
+      "summary": "Part IV: projection_ambiguity: [2,-1] is good but [1,-2] is not, despite same ±1 pattern. fiber_argument_fails: existential witness.",
       "mathContext": "The parent's key invariant (equal fiber sizes) fails for non-uniform weights."
     },
     {
       "id": "one-vs-one",
       "title": "1-vs-1 Case: Exact Analysis",
-      "startLine": 207,
-      "endLine": 245,
-      "summary": "Analyzes one A-vote vs one B-vote: exactly 1/2 of orderings are good regardless of weights. Shows classical formula = 1/2 iff wA = 3wB.",
+      "startLine": 248,
+      "endLine": 287,
+      "summary": "Part V: analyzes one A-vote vs one B-vote: exactly 1/2 of orderings are good regardless of weights. Shows classical formula = 1/2 iff wA = 3wB.",
       "mathContext": "For 1-vs-1: $P = 1/2$ always, but $(w_A - w_B)/(w_A + w_B) = 1/2 \\Leftrightarrow w_A = 3w_B$."
     },
     {
       "id": "scaled-case",
       "title": "Scaled Ballot Expression",
-      "startLine": 247,
+      "startLine": 288,
       "endLine": 329,
       "summary": "Defines scaledBallotFormula (ap−bq)/(ap+bq) and proves its basic algebra: scaled_degenerates (recovers the classical (a−b)/(a+b) at p = q = 1), scaled_formula_pos (positive when ap > bq), and scaled_formula_le_one (bounded by 1). Emphasises that this closed form is NOT the actual probability for the weighted/scaled ballot process.",
       "mathContext": "$(ap-bq)/(ap+bq)$ degenerates to $(a-b)/(a+b)$ when $p = q = 1$. But it does not equal the actual ballot probability in general."
     },
     {
       "id": "open-directions",
-      "title": "Part VI: Open Directions",
+      "title": "Open Directions",
       "startLine": 330,
-      "endLine": 352,
+      "endLine": 351,
       "summary": "A closing discussion of what a genuine weighted ballot theorem would require — a recurrence or reflection argument for biased steps — and how the scaled formula relates to the classical Bertrand ballot problem, framing the remaining open directions.",
       "mathContext": "The weighted analogue of $P=(a-b)/(a+b)$ for step-biases $p,q$ is not $(ap-bq)/(ap+bq)$ in general; the true probability needs a biased reflection principle."
     }

--- a/src/data/proofs/cauchy-schwarz-integral-oq006/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq006/meta.json
@@ -75,49 +75,57 @@
     {
       "id": "definitions",
       "title": "Weighted Mean Definitions",
-      "summary": "Four noncomputable defs: WHM, WGM, WAM, WQM",
+      "summary": "Part I: four noncomputable defs WHM, WGM, WAM, WQM (weighted harmonic, geometric, arithmetic, quadratic means of a, b with weights w₁, w₂)",
       "startLine": 40,
-      "endLine": 55,
+      "endLine": 58,
       "mathContext": "$\\text{WHM}(a,b) = (w_1/a + w_2/b)^{-1}$, $\\text{WGM}(a,b) = a^{w_1} b^{w_2}$, $\\text{WAM}(a,b) = w_1 a + w_2 b$, $\\text{WQM}(a,b) = \\sqrt{w_1 a^2 + w_2 b^2}$."
+    },
+    {
+      "id": "positivity",
+      "title": "Positivity Lemmas",
+      "summary": "Part II: whm_pos, wgm_pos, wam_pos (strict positivity for positive inputs and weights) and wqm_nonneg (nonnegativity), each discharged by `positivity` after unfolding. These guard the reciprocal and inversion steps that follow.",
+      "startLine": 59,
+      "endLine": 83,
+      "mathContext": "For $a,b>0$ and $w_1,w_2>0$: $\\text{WHM},\\text{WGM},\\text{WAM}>0$; and $\\text{WQM}\\ge 0$ whenever $w_1,w_2\\ge 0$. Positivity of WHM/WGM is needed to invoke $\\text{inv\\_le\\_comm}_0$ in the HM–GM step."
     },
     {
       "id": "wgm-le-wam",
       "title": "WGM ≤ WAM (Weighted AM-GM)",
-      "summary": "One-liner from Mathlib's Real.geom_mean_le_arith_mean2_weighted",
-      "startLine": 76,
-      "endLine": 84,
+      "summary": "Part III: wgm_le_wam — one-liner from Mathlib's Real.geom_mean_le_arith_mean2_weighted",
+      "startLine": 84,
+      "endLine": 95,
       "mathContext": "$a^{w_1} b^{w_2} \\le w_1 a + w_2 b$ for $a,b \\ge 0$, $w_1,w_2 \\ge 0$, $w_1+w_2=1$."
     },
     {
       "id": "wam-le-wqm",
       "title": "WAM ≤ WQM (Jensen for f(x) = x²)",
-      "summary": "Jensen identity: w₁a² + w₂b² - (w₁a + w₂b)² = w₁w₂(a-b)² ≥ 0",
-      "startLine": 87,
-      "endLine": 110,
+      "summary": "Part IV: weighted_variance_nonneg then wam_le_wqm. Jensen identity: w₁a² + w₂b² − (w₁a + w₂b)² = w₁w₂(a−b)² ≥ 0",
+      "startLine": 96,
+      "endLine": 118,
       "mathContext": "$w_1 a + w_2 b \\le \\sqrt{w_1 a^2 + w_2 b^2}$. Key: $(w_1 a + w_2 b)^2 \\le w_1 a^2 + w_2 b^2$ with gap $w_1 w_2 (a-b)^2 \\ge 0$."
     },
     {
       "id": "whm-le-wgm",
       "title": "WHM ≤ WGM (Reciprocal + Inversion)",
-      "summary": "Apply WGM ≤ WAM to (1/a, 1/b); use inv_le_comm₀ to flip",
-      "startLine": 113,
-      "endLine": 145,
+      "summary": "Part V: whm_le_wgm — apply WGM ≤ WAM to (1/a, 1/b); use inv_le_comm₀ to flip",
+      "startLine": 119,
+      "endLine": 162,
       "mathContext": "$(w_1/a + w_2/b)^{-1} \\le a^{w_1} b^{w_2}$. Apply AM-GM to $(1/a, 1/b)$: $(1/a)^{w_1}(1/b)^{w_2} \\le w_1/a + w_2/b$, i.e., $\\text{WGM}^{-1} \\le \\text{WHM}^{-1}$. Inversion reverses: $\\text{WHM} \\le \\text{WGM}$."
     },
     {
       "id": "main-chain",
       "title": "Main Chain Theorem",
-      "summary": "WHM ≤ WGM ≤ WAM ≤ WQM combined",
-      "startLine": 148,
-      "endLine": 156,
+      "summary": "Part VI: weighted_mean_chain — WHM ≤ WGM ≤ WAM ≤ WQM combined",
+      "startLine": 163,
+      "endLine": 177,
       "mathContext": "Full weighted power mean chain for $a,b > 0$ and $w_1, w_2 > 0$ with $w_1 + w_2 = 1$."
     },
     {
       "id": "specialization",
       "title": "Unweighted Chain as Special Case",
-      "summary": "w₁ = w₂ = 1/2 recovers HM ≤ GM ≤ AM ≤ QM",
-      "startLine": 159,
-      "endLine": 210,
+      "summary": "Part VII: whm_half_eq_hm, wgm_half_eq_gm, wam_half_eq_am, wqm_half_eq_qm evaluate each weighted mean at w₁ = w₂ = 1/2, and unweighted_chain_from_weighted recovers HM ≤ GM ≤ AM ≤ QM",
+      "startLine": 178,
+      "endLine": 219,
       "mathContext": "At $w_1 = w_2 = 1/2$: $\\text{WHM} = 2ab/(a+b)$, $\\text{WGM} = \\sqrt{ab}$, $\\text{WAM} = (a+b)/2$, $\\text{WQM} = \\sqrt{(a^2+b^2)/2}$."
     }
   ],

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02/meta.json
@@ -75,6 +75,14 @@
       "mathContext": "Defines the LevyTriplet structure (γ, σ², ν_total) with nonnegativity constraints and the InfDivisible structure encoding a characteristic exponent with continuity, normalization, and associated triplet."
     },
     {
+      "id": "khintchine-exponents",
+      "title": "Lévy–Khintchine Exponent Definitions",
+      "startLine": 57,
+      "endLine": 72,
+      "summary": "Defines the three canonical characteristic exponents entering the Lévy–Khintchine formula: gaussianExponent ψ(t) = iμt − σ²t²/2, poissonExponent ψ(t) = λ(e^{it} − 1), and compoundPoissonExponent ψ(t) = λ(E[e^{itX}] − 1) for a jump characteristic function. These are the building blocks assembled into full triplets in the sections that follow.",
+      "mathContext": "$\\psi_{\\text{Gauss}}(t) = i\\mu t - \\sigma^2 t^2/2$; $\\psi_{\\text{Poisson}}(t) = \\lambda(e^{it}-1)$; $\\psi_{\\text{cPoisson}}(t) = \\lambda(\\mathbb{E}[e^{itX}]-1)$, all valued in $\\mathbb{C}$."
+    },
+    {
       "id": "gaussian-triplet",
       "title": "Gaussian Triplet Properties",
       "startLine": 73,

--- a/src/data/proofs/erdos-1082/meta.json
+++ b/src/data/proofs/erdos-1082/meta.json
@@ -81,72 +81,80 @@
     {
       "id": "points-distances",
       "title": "Points and Distances in ℝ²",
-      "summary": "Point2D type, coordinate extraction, distance functions",
+      "summary": "Part I: Point2D type, coordinate extraction (Point2D.x/y), and the squared/actual distance functions distSq and dist'.",
       "startLine": 38,
-      "endLine": 58,
+      "endLine": 59,
       "mathContext": "Mathematical content: Point2D type, coordinate extraction, distance functions"
+    },
+    {
+      "id": "distance-properties",
+      "title": "Distance Properties",
+      "summary": "Part II: basic metric lemmas for distSq and dist' — nonnegativity (distSq_nonneg, dist'_nonneg), symmetry (distSq_comm, dist'_comm), vanishing on the diagonal (distSq_self, dist'_self), the identity-of-indiscernibles distSq_eq_zero_iff, and strict positivity for distinct points (distSq_pos_of_ne, dist'_pos_of_ne).",
+      "startLine": 60,
+      "endLine": 121,
+      "mathContext": "$\\mathrm{distSq}(p,q) \\ge 0$, $\\mathrm{distSq}(p,q) = \\mathrm{distSq}(q,p)$, $\\mathrm{distSq}(p,p)=0$, and $\\mathrm{distSq}(p,q)=0 \\iff p=q$; hence $\\mathrm{distSq}(p,q)>0$ for $p\\ne q$."
     },
     {
       "id": "general-position",
       "title": "General Position",
-      "summary": "areCollinear predicate and inGeneralPosition definition",
-      "startLine": 59,
-      "endLine": 70,
+      "summary": "Part III: areCollinear predicate, its permutation invariance (areCollinear_cycle, areCollinear_swap23), the inGeneralPosition definition (no three collinear), and its monotonicity under subsets.",
+      "startLine": 122,
+      "endLine": 151,
       "mathContext": "Formal definition: areCollinear predicate and inGeneralPosition definition"
     },
     {
       "id": "counting-distances",
       "title": "Counting Distinct Distances",
-      "summary": "distinctDistances, distancesFromPoint, numDistancesFromPoint",
-      "startLine": 71,
-      "endLine": 86,
+      "summary": "Part IV: distinctDistances, distancesFromPoint, numDistancesFromPoint, and the bound numDistancesFromPoint_le_distinctDistances relating single-point counts to the global count.",
+      "startLine": 152,
+      "endLine": 181,
       "mathContext": "Mathematical content: distinctDistances, distancesFromPoint, numDistancesFromPoint"
     },
     {
       "id": "szemeredi",
       "title": "Szemerédi's Theorem",
-      "summary": "The n/3 bound and the inverse result for no k collinear",
-      "startLine": 87,
-      "endLine": 107,
+      "summary": "Part V: the n/3 distinct-distances bound and the inverse result for configurations with no k collinear points.",
+      "startLine": 182,
+      "endLine": 196,
       "mathContext": "Bound: The n/3 bound and the inverse result for no k collinear"
     },
     {
       "id": "conjectures",
       "title": "The Conjectures",
-      "summary": "Conjecture1 (total) and Conjecture2 (single point) formal definitions",
-      "startLine": 108,
-      "endLine": 128,
-      "mathContext": "Formal definition: Conjecture1 (total) and Conjecture2 (single point) formal definitions"
+      "summary": "Part VI: Conjecture1 (total, ≥ n/2 distinct distances) and Conjecture2 (single point, ≥ n/2) formal definitions, plus conjecture2_implies_conjecture1 (the single-point form is stronger) and conjecture1_strengthens_szemeredi (it improves the n/3 bound to n/2).",
+      "startLine": 197,
+      "endLine": 234,
+      "mathContext": "Formal definition: Conjecture1 (total) and Conjecture2 (single point); $\\text{C2} \\Rightarrow \\text{C1} \\Rightarrow$ the $n/2$ bound $\\ge$ Szemerédi's $n/3$."
     },
     {
       "id": "counterexample",
       "title": "Xichuan's Counterexample",
-      "summary": "The 42-point construction disproving Conjecture2",
-      "startLine": 129,
-      "endLine": 155,
+      "summary": "Part VII: the 42-point construction disproving Conjecture2 (conjecture2_false), the resulting counterexample_gap, and counterexample_consistent_with_szemeredi showing it respects the n/3 bound.",
+      "startLine": 235,
+      "endLine": 276,
       "mathContext": "Mathematical content: The 42-point construction disproving Conjecture2"
     },
     {
-      "id": "open-problem",
-      "title": "The Remaining Open Problem",
-      "summary": "erdos_1082_status theorem summarizing current state",
-      "startLine": 156,
-      "endLine": 177,
-      "mathContext": "Verified: erdos_1082_status theorem summarizing current state"
+      "id": "gap-analysis",
+      "title": "The Gap Between n/3 and n/2",
+      "summary": "Part VIII: div3_le_div2 (n/3 ≤ n/2), szemeredi_weaker_than_conjecture1, and the remark conjecture2_false_does_not_imply_conjecture1_false_note — refuting the stronger single-point Conjecture2 leaves the total Conjecture1 open.",
+      "startLine": 277,
+      "endLine": 309,
+      "mathContext": "$\\lfloor n/3\\rfloor \\le \\lfloor n/2\\rfloor$; the counterexample kills C2 but Conjecture1 (the $n/2$ total bound) remains open."
     },
     {
       "id": "related-results",
-      "title": "Related Results",
-      "summary": "Guth-Katz, 3D generalizations",
-      "startLine": 178,
-      "endLine": 209,
+      "title": "Connection to Erdős Problem #89",
+      "summary": "Part IX: the link to Erdős #89 (the distinct-distances problem), including the Guth–Katz near-optimal n/log n lower bound and higher-dimensional generalizations.",
+      "startLine": 310,
+      "endLine": 319,
       "mathContext": "Mathematical content: Guth-Katz, 3D generalizations"
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "Final summary theorem",
-      "startLine": 234,
+      "summary": "Part X: the erdos_1082_status theorem summarizing the current state — Conjecture2 disproved, Conjecture1 open, Szemerédi's n/3 bound the best unconditional result.",
+      "startLine": 320,
       "endLine": 342,
       "mathContext": "Verified: Final summary theorem"
     }


### PR DESCRIPTION
Enrichment pass fixing **drifted / incomplete section maps** — sections whose line anchors pointed at the wrong Lean code, plus genuinely-uncovered named-declaration blocks. Discovered via a fresh-origin/main inter-section + tail undercoverage scan; content verified against the actual `.lean` source.

### cauchy-schwarz-integral-oq006
- Full re-anchor: the section map was drifted (e.g. "WGM ≤ WAM" pointed at the positivity block, not the theorem). Re-anchored all seven sections to their real `Part N` banners.
- **Added** a "Positivity Lemmas" section (Part II: `whm_pos`, `wgm_pos`, `wam_pos`, `wqm_nonneg`) that no section covered, and extended the definitions section to include `WQM`.

### ballot-problem-oq-01-oq-02-oq-04
- Pure line-anchor drift: every section carried the correct summary but was anchored ~1 part too early ("The Fiber Argument Breaks" pointed at the counterexample orderings; "1-vs-1 Case" pointed at the fiber argument; etc.). Re-anchored all seven sections to the real Part I–VI banners.

### central-limit-theorem-oq-01-oq-02
- **Added** a "Lévy–Khintchine Exponent Definitions" section (Part I tail: `gaussianExponent`, `poissonExponent`, `compoundPoissonExponent`) that sat uncovered between the triplet-structure section and the Gaussian-triplet section.

### erdos-1082
- Full re-anchor of the 10-part map (anchors were drifted early and two parts had no section). **Added** "Distance Properties" (Part II metric lemmas) and "The Gap Between n/3 and n/2" (Part VIII), retitled the Erdős #89 connection section, and deepened summaries for the conjectures / counterexample / summary sections. Claims (Conjecture1 = ⌊n/2⌋ total bound, 42-point/20-distance counterexample, Guth–Katz Ω(n/log n)) verified against source.

No status/badge/axiomCount changes — these are coverage/accuracy fixes to `sections` only. `pnpm build` intentionally skipped (regenerates ~2135 unrelated files as noise); each `meta.json` validated as parseable JSON.
