### PR TITLE
Audit: erdos-divisibility-pigeonhole-oq001 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31336,8 +31336,8 @@
       "issues": []
     },
     "erdos-divisibility-pigeonhole-oq001": {
-      "auditCount": 1,
-      "lastAudited": "2026-07-21T12:35:58Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-21T12:41:19Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
Gallery integrity audit — CLEAN.

**Verified:** 15 theorem/lemma decls + 1 def (matches theoremCount:15, definitionCount:1), lineCount 195, 0 sorries, 0 axioms, no `native_decide`, no True stubs. All prose-cited declarations (card_chains, fiber_chain, antichain_card_le, topHalf_antichain, card_topHalf, max_antichain_eq, chain_cover_card_eq_max_antichain, recovers_even_case) exist and are non-vacuous. Badge `original` defensible (chain-decomposition formalized over Mathlib's odd-part interface, deps disclosed); status `verified` justified.

Tracker-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)