### PR TITLE
Enrich 3 entries: re-anchor drifted tail sections + cover uncovered general-formula block

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-02/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-02/meta.json
@@ -134,17 +134,17 @@
     {
       "id": "bv-eh",
       "title": "Bombieri–Vinogradov and Elliott–Halberstam",
-      "summary": "BV := EHAtLevel D (1/2), EH := all levels θ<1, and EH ⟹ BV (and the [1/2,1) restriction)",
+      "summary": "BV := EHAtLevel D (1/2), EH := all levels θ<1. The implication block: eHAtLevel_of_elliottHalberstam (EH gives the bound at every level), bombieriVinogradov_of_elliottHalberstam (EH ⟹ BV), bombieriVinogradov_of_EHAtLevel (for level-monotone D, the bound at any θ≥1/2 already gives BV), and elliottHalberstam_iff_levels_near_one (EH is equivalent to its restriction to levels near 1).",
       "startLine": 95,
-      "endLine": 133,
+      "endLine": 166,
       "mathContext": "$\\mathrm{BV}(D) := \\mathrm{EHAtLevel}(D,1/2)$, $\\mathrm{EH}(D) := \\forall \\theta\\in(0,1),\\ \\mathrm{EHAtLevel}(D,\\theta)$; $\\mathrm{EH}\\Rightarrow\\mathrm{BV}$, and EH is equivalent to its restriction to $\\theta\\in[1/2,1)$."
     },
     {
       "id": "non-vacuity",
       "title": "Non-Vacuity: the Zero Functional",
-      "summary": "The zero functional satisfies the full hierarchy, certifying the predicates are satisfiable",
-      "startLine": 135,
-      "endLine": 154,
+      "summary": "The zero functional satisfies the full hierarchy, certifying the predicates are satisfiable: EHAtLevel_zero (D≡0 meets the level-θ bound at every θ, with C=1), levelMonotone_zero (trivially level-monotone), and elliottHalberstam_zero (D≡0 is a concrete witness that ElliottHalberstam ∧ LevelMonotone is consistent).",
+      "startLine": 167,
+      "endLine": 185,
       "mathContext": "$D\\equiv 0$ is level-monotone and satisfies $\\mathrm{EHAtLevel}$ at every level (take $C=1$, using $x>0$ and $(\\log x)^A>0$ for $x\\ge 2$), hence models the full Elliott–Halberstam hierarchy."
     },
     {

--- a/src/data/proofs/burnside-counting-oq-03/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03/meta.json
@@ -113,6 +113,14 @@
       "mathContext": "$\\#\\text{necklaces}(4,2) = 24/4 = 6$. General: $n \\cdot \\#\\text{necklaces}(n,k) = \\sum_{r=0}^{n-1} k^{\\gcd(r,n)} = \\sum_{d \\mid n} \\varphi(n/d) \\cdot k^d$."
     },
     {
+      "id": "sec-general-necklace-formulas",
+      "title": "§7 (cont.): General Necklace Formulas from Burnside",
+      "startLine": 403,
+      "endLine": 440,
+      "summary": "The general divisor-sum and self-contained necklace formulas for arbitrary n, k. polya_necklace_divisor_formula combines the statement-level formula with polya_sum_identity to give n · necklace_count = Σ_{d|n} φ(n/d) · k^d, generalizing the n=4,k=2 instance. polya_necklace_formula_of_burnside and polya_necklace_divisor_formula_of_burnside then discharge the fixed-point hypothesis internally (via this file's fully general polya_cyclic_fixed_count), so the sum-of-gcd-powers form and the divisor-sum form each follow from Burnside's lemma ALONE — the counting hypothesis is the only remaining input.",
+      "mathContext": "From $n\\cdot\\#\\text{necklaces} = \\sum_{r<n} k^{\\gcd(r,n)}$ (statement form) and the reindexing $\\sum_{r<n} k^{\\gcd(r,n)} = \\sum_{d\\mid n}\\varphi(n/d)k^d$, one gets $n\\cdot\\#\\text{necklaces}(n,k) = \\sum_{d\\mid n}\\varphi(n/d)\\,k^d$. Because $|\\mathrm{Fix}(r)| = k^{\\gcd(r,n)}$ is proved here for all $n,k$, the fixed-point premise is automatic and Burnside's orbit-count identity is the sole hypothesis."
+    },
+    {
       "id": "sec-fixedpoint-corollaries",
       "title": "§8: General Fixed-Point Corollaries (kernel-checked)",
       "startLine": 441,

--- a/src/data/proofs/erdos-523/meta.json
+++ b/src/data/proofs/erdos-523/meta.json
@@ -139,42 +139,42 @@
     {
       "id": "l2-analysis",
       "title": "$L^2$ Analysis and Maximum-to-$L^2$ Gap",
-      "startLine": 148,
-      "endLine": 164,
-      "summary": "Defines `L2Norm` via integration over the circle. Axiomatizes $\\|f\\|_2 = \\sqrt{n+1}$ (Parseval) and the lower bound $M \\geq \\sqrt{n \\log n}/2$, quantifying the $\\sqrt{\\log n}$ gap between $L^2$ and $L^\\infty$ norms.",
-      "mathContext": "Defines `L2Norm` via integration over the circle. Axiomatizes $\\|f\\|_2 = \\sqrt{n+1}$ (Parseval) and the lower bound $M \\geq \\sqrt{n \\log n}/2$, quantifying the $\\sqrt{\\log n}$ gap between $L^2$ and $L^\\infty$ norms."
+      "startLine": 143,
+      "endLine": 154,
+      "summary": "Defines `L2Norm` (root-mean-square of $|f|$ over the unit circle, via a circle integral of $\\|f(e^{i\\theta})\\|^2$) and `kahaneConnection` (random $\\pm 1$ polynomials as a special case of Kahane's random Fourier series). Source comments record $\\|f\\|_2 = \\sqrt{n+1}$ (Parseval) and that the maximum modulus exceeds the $L^2$ norm by a $\\sqrt{\\log n}$ factor.",
+      "mathContext": "$\\|f\\|_2^2 = \\frac{1}{2\\pi}\\int_0^{2\\pi} |f(e^{i\\theta})|^2\\, d\\theta = \\sum_k |\\varepsilon_k|^2 = n+1$ (Parseval, since $|\\varepsilon_k| = 1$), whereas $\\max_{|z|=1}|f(z)| \\asymp \\sqrt{n \\log n}$; the ratio is the $\\sqrt{\\log n}$ gap between the $L^2$ and $L^\\infty$ norms."
     },
     {
       "id": "littlewood",
       "title": "Littlewood Polynomials",
-      "startLine": 170,
-      "endLine": 183,
-      "summary": "Defines `IsLittlewood` (polynomials with $\\pm 1$ coefficients), `LittlewoodProblem` (deterministic extremal question), and documents in source comments `typical_littlewood` (no Lean declaration exists) (most Littlewood polynomials have $\\max \\approx \\sqrt{n \\log n}$).",
-      "mathContext": "Defines `IsLittlewood` (polynomials with $\\pm 1$ coefficients), `LittlewoodProblem` (deterministic extremal question), and documents in source comments `typical_littlewood` (no Lean declaration exists) (most Littlewood polynomials have $\\max \\approx \\sqrt{n \\log n}$)."
+      "startLine": 159,
+      "endLine": 171,
+      "summary": "Defines `IsLittlewood` (polynomials whose coefficients are all $\\pm 1$) and `LittlewoodProblem` (the deterministic extremal question: minimize $\\max_{|z|=1}|p(z)|$ over Littlewood polynomials, a flatness problem). A source comment records that most Littlewood polynomials have $\\max \\approx \\sqrt{n \\log n}$, so the random model captures typical deterministic behavior.",
+      "mathContext": "$p$ is Littlewood iff $p_k \\in \\{+1,-1\\}$ for all $k \\le n$. The random $\\pm 1$ ensemble is the uniform measure on the $2^{n+1}$ Littlewood polynomials, so almost-sure statements about $M_n$ describe the typical (majority) deterministic Littlewood polynomial."
     },
     {
       "id": "bounds",
       "title": "Upper and Lower Bounds",
-      "startLine": 189,
-      "endLine": 203,
-      "summary": "Matching bounds: `upper_bound_high_prob` ($\\max \\leq (1+\\varepsilon)\\sqrt{n \\log n}$ w.h.p.) and `lower_bound_high_prob` ($\\max \\geq (1-\\varepsilon)\\sqrt{n \\log n}$ w.h.p.). Notes proof techniques: chaining for upper, second moment for lower.",
-      "mathContext": "Matching bounds: `upper_bound_high_prob` ($\\max \\leq (1+\\varepsilon)\\sqrt{n \\log n}$ w.h.p.) and `lower_bound_high_prob` ($\\max \\geq (1-\\varepsilon)\\sqrt{n \\log n}$ w.h.p.)."
+      "startLine": 176,
+      "endLine": 186,
+      "summary": "Records the matching high-probability bounds $\\max \\le (1+\\varepsilon)\\sqrt{n \\log n}$ and $\\max \\ge (1-\\varepsilon)\\sqrt{n \\log n}$ as source comments, and defines `halaszProofSketch` naming the two techniques Halász combined: a chaining / covering-number argument for the upper bound and a second-moment / correlation analysis for the lower bound.",
+      "mathContext": "$\\mathbb{P}\\big(M_n \\le (1+\\varepsilon)\\sqrt{n \\log n}\\big) \\to 1$ and $\\mathbb{P}\\big(M_n \\ge (1-\\varepsilon)\\sqrt{n \\log n}\\big) \\to 1$ as $n \\to \\infty$; together they pin $M_n/\\sqrt{n \\log n} \\to 1$ in probability, and Halász upgraded this to almost-sure convergence."
     },
     {
       "id": "related",
       "title": "Related Problems",
-      "startLine": 210,
-      "endLine": 222,
-      "summary": "Defines `RudinConjecture` (minimum max over Littlewood polynomials), `mahlerMeasure` (geometric mean on circle), and `szegoConnection` (Toeplitz determinant link).",
-      "mathContext": "Formal definition: Defines `RudinConjecture` (minimum max over Littlewood polynomials), `mahlerMeasure` (geometric mean on circle), and `szegoConnection` (Toeplitz determinant link)."
+      "startLine": 192,
+      "endLine": 205,
+      "summary": "Defines `RudinConjecture` (the minimum of $\\max_{|z|=1}|p(z)|$ over Littlewood polynomials, conjecturally $\\Theta(\\sqrt{n})$ — the opposite extreme from the typical $\\sqrt{n\\log n}$), `mahlerMeasure` (exponential of the log-average of $|f|$ on the circle), and `szegoConnection` (Mahler measure as the geometric mean on the circle, linking to Szegő's theorem).",
+      "mathContext": "Rudin's flatness question asks for $\\min_p \\max_{|z|=1}|p(z)|$ over Littlewood $p$; the Mahler measure $M(f) = \\exp\\!\\big(\\frac{1}{2\\pi}\\int_0^{2\\pi} \\log|f(e^{i\\theta})|\\, d\\theta\\big)$ is the geometric mean on the circle, so $\\log M(f)$ is the Szegő/entropy functional bounded above by $\\log \\|f\\|_2$."
     },
     {
       "id": "summary",
       "title": "Summary: SOLVED",
-      "startLine": 238,
+      "startLine": 211,
       "endLine": 238,
-      "summary": "Four concluding theorems: `erdos_523`, `erdos_523_constant` ($C = 1$), `erdos_523_main`, and `erdos_523_solved`. **Status: Completely solved by Halasz (1973).**",
-      "mathContext": "Verified: Four concluding theorems: `erdos_523`, `erdos_523_constant` ($C = 1$), `erdos_523_main`, and `erdos_523_solved`. **Status: Completely solved by Halasz (1973).**"
+      "summary": "Four concluding theorems: `erdos_523` (the question resolved via `erdos_523_answer`), `erdos_523_constant` (the constant is exactly $C = 1$), `erdos_523_main`, and `erdos_523_solved`. **Status: completely solved by Halász (1973).**",
+      "mathContext": "The formalized answer: $\\max_{|z|=1}|f(z)| = (1 + o(1))\\sqrt{n \\log n}$ almost surely, i.e. the Erdős constant is $C = 1$. `erdos_523_constant` packages the existential witness $C = 1 \\land \\text{ErdosQuestion523}$, and `erdos_523_solved` closes the file."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Section-coverage enrichment pass across three gallery entries. All three had genuine
coverage defects surfaced by an inter-section gap scan (≥3 uncovered decls in a ≥15-line
gap between sorted sections).

## erdos-523 — whole-tail drift + stale summaries
Parts VII–XI had accumulating anchor drift (sections shifted +8 → +30 lines past their
true `## Part` banners) **and** stale summaries describing declarations that no longer
exist (phantom `upper_bound_high_prob`/`lower_bound_high_prob` theorems; a non-existent
Parseval axiom). Re-anchored `l2-analysis`, `littlewood`, `bounds`, `related`, and
`summary` to their actual decl ranges, rewrote each summary to match the real content,
and replaced the degenerate duplicate `mathContext` fields with genuine LaTeX. The
capstone theorems (`erdos_523`, `erdos_523_constant`, `erdos_523_main`,
`erdos_523_solved`, lines 211–238) were previously uncovered (Summary anchored 238–238).

## bounded-prime-gaps-oq-02 — drift + uncovered EH⟹BV block
The four EH⟹BV theorems (`eHAtLevel_of_elliottHalberstam` … `elliottHalberstam_iff_levels_near_one`,
lines 134–166) were uncovered, while `non-vacuity` was anchored at 135–154 — pointing at
those very theorems rather than the zero-functional theorems its summary describes.
Extended `bv-eh` (95→166) to cover the EH⟹BV block it already summarizes, and re-anchored
`non-vacuity` to the real zero-functional theorems (`EHAtLevel_zero`, `levelMonotone_zero`,
`elliottHalberstam_zero`, 167–185).

## burnside-counting-oq-03 — uncovered general-formula block
Inserted a new section `§7 (cont.): General Necklace Formulas from Burnside` covering
lines 403–440 (`polya_necklace_divisor_formula`, `polya_necklace_formula_of_burnside`,
`polya_necklace_divisor_formula_of_burnside`) — the arbitrary-n,k divisor-sum and
Burnside-only necklace formulas, previously falling in the gap between §6-7 and §8.

No Lean source changed; JSON validated with `JSON.parse`. Section ranges are contiguous
and non-overlapping in all three files.
