### PR TITLE
Research: erdos-46-wip-01 — divisor-sum bridge to the pseudoperfect/practical-number route (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos46Problem.lean
+++ b/proofs/Proofs/Erdos46Problem.lean
@@ -470,3 +470,81 @@ theorem exists_isRatFractionRepr_min_gt (B L : ℕ) (hL : 1 ≤ L) :
     have hka : a ≤ k := (Finset.mem_Ico.mp hk).1
     have hkn : k ≤ k * (k + 1) := Nat.le_mul_of_pos_right k (by omega)
     omega
+
+/-! ## Divisor-sum bridge: the pseudoperfect / practical-number attack surface
+
+The three engines above (additive union, multiplicative scaling, telescoping) all
+reshape or build representations whose target value stays *below* `1`; the open crux
+toward `ErdosProblem46_infinitely_many` is a representation of *exactly* `1` with
+minimum denominator `> N`. This section opens a structurally different attack surface
+by translating that crux into multiplicative number theory.
+
+If `T` is a set of distinct divisors of a positive integer `M` with
+`∑_{d ∈ T} d = M` (so `M` is *pseudoperfect via `T`*), then dividing through by `M`
+turns the divisor sum into a unit-fraction representation of `1`: each `d ∈ T`
+contributes `1/(M/d)`, and `∑ 1/(M/d) = (∑ d)/M = 1`. The denominators are the
+cofactors `{M/d : d ∈ T}`, so the minimum denominator is `M / max T` — it exceeds
+`N` exactly when every chosen divisor `d` satisfies `N · d < M`, i.e. `d < M/N`.
+
+This reduces "represent `1` with min denominator `> N`" to "write `M` as a sum of
+distinct divisors of `M`, each `< M/N`", for some `M`. The reduction is an
+**equivalence** (conversely, from any Egyptian representation `S` of `1`, taking
+`M = lcm S` and `d_s = M/s` gives distinct divisors of `M` summing to `M`), so per
+the equivalent-strength rule it earns **no decomposition credit** toward the open
+crux. It is recorded here as infrastructure that exposes the divisor /
+practical-number route: with the crux phrased as divisor sums, Mathlib's
+`Nat.divisors` machinery becomes available, and the genuine open content becomes a
+practical-number completeness fact (producing an `M` with enough *small* divisors
+summing exactly to `M`). -/
+
+/-- **Divisor-sum bridge.** If every element of `T` divides `M` with `2 * d ≤ M`
+(equivalently the cofactor `M/d ≥ 2`) and `∑_{d ∈ T} d = M > 0`, then the set of
+cofactors `{M/d : d ∈ T}` is a unit-fraction representation of `1`.  The cofactor
+map `d ↦ M/d` is injective on divisors of `M`, and each term equals `1/(M/d) = d/M`,
+so the reciprocals sum to `(∑ d)/M = 1`. -/
+theorem isUnitFractionRepr_of_divisorSum {M : ℕ} (hM : 1 ≤ M) {T : Finset ℕ}
+    (hdvd : ∀ d ∈ T, d ∣ M) (hle : ∀ d ∈ T, 2 * d ≤ M)
+    (hsum : T.sum id = M) :
+    IsUnitFractionRepr (T.image (fun d => M / d)) := by
+  have hM0 : M ≠ 0 := by omega
+  have hdpos : ∀ d ∈ T, 0 < d := by
+    intro d hd
+    rcases Nat.eq_zero_or_pos d with rfl | hpos
+    · exact absurd (Nat.eq_zero_of_zero_dvd (hdvd 0 hd)) hM0
+    · exact hpos
+  -- the cofactor map is injective on divisors of `M` (left inverse `q ↦ M/q`)
+  have hinj : ∀ x ∈ T, ∀ y ∈ T, M / x = M / y → x = y := by
+    intro x hx y hy h
+    have i₁ : M / (M / x) = x := Nat.div_div_self (hdvd x hx) hM0
+    have i₂ : M / (M / y) = y := Nat.div_div_self (hdvd y hy) hM0
+    rw [← i₁, ← i₂, h]
+  refine ⟨?_, ?_⟩
+  · -- every cofactor denominator is at least `2`
+    intro n hn
+    rw [Finset.mem_image] at hn
+    obtain ⟨d, hd, rfl⟩ := hn
+    exact (Nat.le_div_iff_mul_le (hdpos d hd)).mpr (hle d hd)
+  · -- the reciprocals of the cofactors sum to `1`
+    rw [Finset.sum_image hinj]
+    have hterm : ∀ d ∈ T, (1 : ℚ) / ((M / d : ℕ) : ℚ) = (d : ℚ) / (M : ℚ) := by
+      intro d hd
+      rw [Nat.cast_div (hdvd d hd) (by exact_mod_cast (hdpos d hd).ne'), one_div_div]
+    rw [Finset.sum_congr rfl hterm, ← Finset.sum_div,
+      show (∑ d ∈ T, (d : ℚ)) = (M : ℚ) from by rw [← Nat.cast_sum]; exact_mod_cast hsum,
+      div_self (by exact_mod_cast hM0 : (M : ℚ) ≠ 0)]
+
+/-- **Minimum-denominator criterion for the divisor-sum bridge.** If every chosen
+divisor of `M` satisfies `N * d < M` (i.e. `d < M/N`), then every cofactor
+denominator `M/d` exceeds `N`.  Combined with `isUnitFractionRepr_of_divisorSum`, a
+pseudoperfect decomposition of `M` into distinct divisors all below `M/N` yields a
+representation of `1` with minimum denominator `> N` — the open crux, now phrased
+entirely in terms of divisor sums. -/
+theorem divisorSum_min_gt {M N : ℕ} {T : Finset ℕ}
+    (hdvd : ∀ d ∈ T, d ∣ M) (hlt : ∀ d ∈ T, N * d < M) :
+    ∀ n ∈ T.image (fun d => M / d), N < n := by
+  intro n hn
+  rw [Finset.mem_image] at hn
+  obtain ⟨d, hd, rfl⟩ := hn
+  have hMeq : M / d * d = M := Nat.div_mul_cancel (hdvd d hd)
+  have hcmp : N * d < M / d * d := by rw [hMeq]; exact hlt d hd
+  exact lt_of_mul_lt_mul_right hcmp (Nat.zero_le d)

--- a/src/data/research/problems/erdos-46-wip-01.json
+++ b/src/data/research/problems/erdos-46-wip-01.json
@@ -18,7 +18,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ORIENT",
+    "phase": "ACT",
     "since": "2026-07-09T17:33:18-07:00",
     "iteration": 3,
     "focus": "Session 2: splitting identity (Fibonacci–Sylvester 1/n=1/(n+1)+1/(n(n+1))), telescoping form, concrete witness {2,3,6}, existence, and the term-replacement lengthening step (isUnitFractionRepr_replace). 5 axiom-free theorems, theoremCount 16→21, host-verified.",
@@ -56,7 +56,8 @@
       "isRatFractionRepr_telescope (Erdos46Problem.lean): pronic set {k(k+1):a≤k<b} represents 1/a−1/b, min denom ≥ a(a+1) (0-axiom)",
       "exists_isRatFractionRepr_min_gt (Erdos46Problem.lean): ∀ B L≥1, ∃ repr of a POSITIVE rational using exactly L denominators all > B (0-axiom)",
       "injective_mul_succ (Erdos46Problem.lean): k↦k(k+1) injective on ℕ (strictMono_nat_of_lt_succ)",
-      "exists_isUnitFractionRepr_card_eq in proofs/Proofs/Erdos46Problem.lean (|S|=k for all k≥3, 0-axiom, host-verified)"
+      "exists_isUnitFractionRepr_card_eq in proofs/Proofs/Erdos46Problem.lean (|S|=k for all k≥3, 0-axiom, host-verified)",
+      "Divisor-sum bridge (Erdos46Problem.lean): isUnitFractionRepr_of_divisorSum — distinct divisors T of M with 2d≤M and Σ_{d∈T}d=M yield IsUnitFractionRepr {M/d}; divisorSum_min_gt — N·d<M ∀d∈T forces every denominator M/d > N. Host-verified v4.31.0, #print axioms = [propext, Classical.choice, Quot.sound] (0 added axioms, 0 sorries)."
     ],
     "insights": [
       "Erdos46Problem.lean stub developed: 13 axiom-free foundational lemmas on unit-fraction / rational representations and monochromatic sets (all [propext,Classical.choice,Quot.sound], no sorry/native_decide).",
@@ -67,14 +68,16 @@
       "Telescoping engine (pronic reciprocals) is the third construction primitive alongside additive-union and multiplicative-scaling: it BUILDS reprs from scratch and directly realises the min-denominator>N regime for positive-rational targets by starting the interval at a large a.",
       "The min>N regime is now reached for the two-parameter family 1/a−1/b (a>B); the ONLY remaining gap toward pairwise-disjoint chaining is assembling a repr of EXACTLY 1 with min>N (collision-free), which telescoping alone does not give (its value 1/a−1/b < 1).",
       "Exact-cardinality: unit-fraction reprs of 1 exist for EVERY cardinality k≥3, and 3 is the exact minimum (a 2-term 1/a+1/b=1 with a,b≥2 forces a=b=2, not distinct). Split-largest raises |S| by exactly 1.",
-      "EQUIVALENT-STRENGTH BLOCKER (min>N repr of exactly 1): every elementary bootstrap bottoms out at representing a fixed unit fraction 1/c with min>N. But scaling by t maps a min>M repr of 1 to a min>tM repr of 1/t, and two nested-scale disjoint 1/2-reprs union back to a min>N repr of 1 — so \"1/c with min>N\" and \"1 with min>N\" are equivalent strength. Hence the union-assembly and raise-min-by-one routes earn ZERO decomposition credit."
+      "EQUIVALENT-STRENGTH BLOCKER (min>N repr of exactly 1): every elementary bootstrap bottoms out at representing a fixed unit fraction 1/c with min>N. But scaling by t maps a min>M repr of 1 to a min>tM repr of 1/t, and two nested-scale disjoint 1/2-reprs union back to a min>N repr of 1 — so \"1/c with min>N\" and \"1 with min>N\" are equivalent strength. Hence the union-assembly and raise-min-by-one routes earn ZERO decomposition credit.",
+      "Divisor-sum reformulation of the open crux: repr of 1 with min>N ⟺ some M is a sum of distinct divisors each < M/N (forward = isUnitFractionRepr_of_divisorSum; converse via M=lcm S, d_s=M/s). Being an iff, the reduction is EQUIVALENT-STRENGTH (no decomposition credit), but it re-expresses the crux in multiplicative NT where Nat.divisors is available. The residual open content is a practical-number completeness fact: exhibit M with enough SMALL divisors (all < M/N) summing exactly to M. This is a materially new mechanism distinct from the two blocked bootstrap routes (union/scaling, raise-min-by-one)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Assemble a repr of EXACTLY 1 with min denom > N collision-free: candidate = telescope-tail (1/a−1/b large-denom) glued to a large-denom repr of the leftover 1−(1/a−1/b) via isRatFractionRepr_union under a disjointness proof.",
       "Given exists_...(exactly 1, min>N), infinitely many PAIRWISE-DISJOINT reprs of 1 follow by chaining N_{i+1}=max S_i.",
       "Deep monochromatic statement (Croot 2003) remains unformalized — needs density/covering machinery.",
-      "min>N repr of exactly 1 needs a NON-bootstrap mechanism (greedy harmonic segment N+1..M with sum≥1 then a large-denominator excess-adjustment, OR an explicit Diophantine block-tuning). The union/scaling/telescoping engines alone cannot reach it (equivalent-strength). This is the genuine remaining nugget for ErdosProblem46_infinitely_many."
+      "min>N repr of exactly 1 needs a NON-bootstrap mechanism (greedy harmonic segment N+1..M with sum≥1 then a large-denominator excess-adjustment, OR an explicit Diophantine block-tuning). The union/scaling/telescoping engines alone cannot reach it (equivalent-strength). This is the genuine remaining nugget for ErdosProblem46_infinitely_many.",
+      "Practical-number route (materially new mechanism): find an explicit infinite family of M (e.g. factorials/primorials, which are practical) admitting a distinct-divisor decomposition Σd=M using only divisors below M/N, for N→∞. Formalize small-divisor practical-number completeness for that family, then combine with isUnitFractionRepr_of_divisorSum + divisorSum_min_gt to close exact-1-with-min>N, unlocking pairwise-disjoint chaining toward ErdosProblem46_infinitely_many."
     ],
     "markdown": "# Knowledge Base: erdos-46-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Erdős Problem 46 — divisor-sum bridge (0-axiom)

Opens a **structurally new attack surface** for the one remaining open crux of
`erdos-46-wip-01` (a representation of *exactly* `1` with minimum denominator `> N`,
the prerequisite for pairwise-disjoint chaining toward
`ErdosProblem46_infinitely_many`), by translating it into multiplicative number theory.

### New theorems (`proofs/Proofs/Erdos46Problem.lean`)

- **`isUnitFractionRepr_of_divisorSum`** — if `T` is a set of distinct divisors of `M`
  with `2·d ≤ M` for each `d ∈ T` and `∑_{d∈T} d = M > 0`, then the cofactor set
  `{M/d : d ∈ T}` is a unit-fraction representation of `1`. (The cofactor map `d ↦ M/d`
  is injective on divisors of `M`; each term equals `1/(M/d) = d/M`, so the reciprocals
  sum to `(∑ d)/M = 1`.)
- **`divisorSum_min_gt`** — if additionally `N·d < M` for each `d ∈ T`, every cofactor
  denominator `M/d` exceeds `N`.

Together: a decomposition of `M` into distinct divisors all below `M/N` yields a repr
of `1` with min denominator `> N`, phrasing the crux entirely in divisor-sum terms
(`Nat.divisors` machinery now applies).

### Honesty note (equivalent-strength)

The reduction is an **equivalence** (converse: `M = lcm S`, `d_s = M/s`), so per the
equivalent-strength rule it earns **no decomposition credit** — it is recorded as
*infrastructure*. The genuine open content is a **practical-number completeness** fact:
exhibit `M` with enough *small* divisors (all `< M/N`) summing exactly to `M`
(recorded as the next step). This is a materially new mechanism, distinct from the two
already-blocked bootstrap routes (union/scaling assembly, raise-min-by-one recursion).

### Verification
- Host `lake env lean Proofs/Erdos46Problem.lean` → **EXIT 0** (v4.31.0), no errors.
- `#print axioms` for both new theorems → `[propext, Classical.choice, Quot.sound]`
  → **0 added axioms, 0 sorries**.

### Files
- `proofs/Proofs/Erdos46Problem.lean` (+2 theorems, +1 doc section)
- `src/data/research/problems/erdos-46-wip-01.json` (phase ORIENT→ACT; +1 built, +1 insight, +1 next step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
