### PR TITLE
audit(tracker): fibonacci-identities oq001 + oq002 + oq003 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31388,6 +31388,12 @@
       "lastAudited": "2026-07-21T12:54:19Z",
       "result": "clean",
       "issues": []
+    },
+    "fibonacci-identities-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T12:53:05Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31394,6 +31394,12 @@
       "lastAudited": "2026-07-21T12:53:05Z",
       "result": "clean",
       "issues": []
+    },
+    "fibonacci-identities-oq003": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T12:56:29Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Three Tier A clean audits (Fibonacci–Lucas strand). All `lake build` clean; all main theorems depend only on propext/Classical.choice/Quot.sound.

## oq001 — Exact gcd(Fₙ,Lₙ) = 2 ⟺ 3∣n, else 1
11 thm / 0 def / 0 ax / 0 sorries. 8 kernel `decide` (finite cases), disclosed as no-ofReduceBool/no-native_decide. Badge `original` (parity 3-periodicity; `fib_even_iff` absent from Mathlib).

## oq002 — Degree-2 Fibonacci–Lucas relations
6 thm / 0 def / 0 ax / 0 sorries. 3 kernel `decide` in anonymous examples. Mathlib `Nat.fib_two_mul*` disclosed; Lucas identities absent from Mathlib → badge `original` defensible.

## oq003 — Degree-2 identities for a general Lucas sequence
18 thm (incl 4 `@[simp]`) / 4 def / 0 ax / 0 sorries. From-scratch U(P,Q)/V(P,Q) infrastructure, degree-2 identities in full generality, specialized to Fibonacci/Lucas at (1,−1). Badge `original` fully justified.

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)