### PR TITLE
audit: mark frobenius-endomorphism-oq001 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31400,6 +31400,12 @@
       "lastAudited": "2026-07-21T12:56:29Z",
       "result": "clean",
       "issues": []
+    },
+    "frobenius-endomorphism-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:05:03Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Clean gallery-integrity audit of `frobenius-endomorphism-oq001` (Frobenius power subgroups recover the divisor lattice: ⟨frob^e⟩ ≤ ⟨frob^d⟩ ⇔ d∣e).

**Findings:** clean.
- 4 theorems → matches `theoremCount: 4`; 0 defs; `lineCount: 150`.
- `sorries: 0`, `axiomCount: 0`, no native_decide; only kernel-sound tactics.
- Parent-supplied `frob` (noncomputable abbrev) and `orderOf_frob` exist in `FrobeniusEndomorphismOQ02.lean` and are 0-sorry/0-axiom (its only grep hit is a docstring).
- Badge `original` justified: the new content is the arithmetic argument turning membership `g^e ∈ ⟨g^d⟩` into divisibility `d ∣ e` (for d ∣ orderOf g) and its Frobenius/Galois specialization; Mathlib cyclic-group machinery reliance fully disclosed in `assumptions`. Prose matches declarations.

Note: full compile not run locally (Mathlib not built); static inspection per fleet practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)