### PR TITLE
audit: mark fundamental-theorem-algebra-oq001 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31400,6 +31400,12 @@
       "lastAudited": "2026-07-21T12:56:29Z",
       "result": "clean",
       "issues": []
+    },
+    "fundamental-theorem-algebra-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:06:22Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Clean audit of `fundamental-theorem-algebra-oq001` (Gal(L/K) ≃* Multiplicative (ZMod 2) for every quadratic Galois extension).

**Findings:** clean — an exemplar of honest disclosure.
- 5 theorems + 3 noncomputable defs → matches `theoremCount: 5`, `definitionCount: 3` (the 3 `instance`s aren't counted — safe undercount); `lineCount: 143`.
- 0 ax / 0 sorry, no native_decide; noncomputable via Classical.choice (disclosed, adds no axioms).
- Title properly qualified ("for Every Quadratic Galois Extension") — does not claim the full real-closed-field generalization.
- The docstring explicitly admits the proof is "one line of mathematics" (`IsGalois.card_aut_eq_finrank` + `mulEquivOfPrimeCardEq`), credits every Mathlib lemma, and isolates the out-of-reach Artin–Schreier input rather than hiding it.
- Badge `original`: core leans on Mathlib but the genuine degree-2+Galois generalization framing is fully disclosed → acceptable per fleet precedent (#40124). No narrative overstatement.

Note: full compile not run locally (Mathlib not built); static inspection per fleet practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)