### PR TITLE
audit(tracker): reland fibonacci-identities-oq001 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31406,6 +31406,12 @@
       "lastAudited": "2026-07-21T13:15:03Z",
       "result": "clean",
       "issues": []
+    },
+    "fibonacci-identities-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:08:26Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Tracker reland

`fibonacci-identities-oq001` was audited clean and merged in #40470
(oq001 + oq002 + oq003), but a later tracker merge-race dropped the
oq001 entry (oq002/oq003 survived). `find-targets --next` therefore
kept re-serving it as "never audited".

## Re-verification (against origin/main @ 738f13cdf4)

- `Proofs/FibonacciIdentitiesOQ02OQ01OQ01OQ01.lean`: 134 lines, 11 theorems, 0 sorries, 0 axioms
- No `native_decide`; the 4 numeric sanity checks use kernel `decide` (trust-neutral, disclosed in `assumptions`)
- Main results `gcd_fib_lucas_eq_two_iff`, `gcd_fib_lucas` (closed form) are genuine universally-quantified statements — no `True` stubs
- Badge `original` and status `verified` stand

No meta.json change needed; this only restores the dropped tracker entry.

---
Discovered during gallery integrity audit.