### PR TITLE
Enrich 3 entries (derangements-oq-02, cantor CH oq-01-oq-01, erdos-1127): re-anchor drifted section maps, recover uncovered Parts

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01/meta.json
@@ -103,52 +103,84 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Imports and Problem Statement",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Imports (Mathlib, Proofs.ContinuumHypothesis), the research question (does a cardinal κ with ℵ₀ < κ < 2^ℵ₀ exist?), and its answer sketch: independent of ZFC, ZFC-provable facts vs. the axiomatized independence framework, with references to Gödel, Cohen, Easton, and Kanamori.",
+      "mathContext": "Research question: is there $\\kappa$ with $\\aleph_0 < \\kappa < 2^{\\aleph_0}$? Answer: undecidable in ZFC — no under CH, yes ($\\kappa = \\aleph_1$) under ¬CH."
+    },
+    {
       "id": "cardinal-basics",
-      "title": "Cardinal Arithmetic Basics",
-      "startLine": 51,
-      "endLine": 76,
-      "summary": "Proves $\\aleph_0 < \\aleph_1$ and $\\aleph_1 \\leq 2^{\\aleph_0}$ from Mathlib's cardinal and successor APIs.",
+      "title": "Part I — Cardinal Arithmetic Basics",
+      "startLine": 49,
+      "endLine": 74,
+      "summary": "Proves $\\aleph_0 < \\aleph_1$ and $\\aleph_1 \\leq 2^{\\aleph_0}$ from Mathlib's cardinal and successor APIs, plus strict monotonicity of the aleph hierarchy (aleph_strictly_increasing).",
       "mathContext": "$\\aleph_1 = \\text{succ}(\\aleph_0)$ is the smallest uncountable cardinal. By Cantor's theorem $\\aleph_0 < 2^{\\aleph_0}$, so $\\aleph_1 \\leq 2^{\\aleph_0}$ (successor is least upper bound)."
     },
     {
       "id": "under-ch",
-      "title": "Under CH: No Intermediate",
-      "startLine": 82,
-      "endLine": 112,
+      "title": "Part II — Under CH: No Intermediate",
+      "startLine": 75,
+      "endLine": 107,
       "summary": "Proves CH → no intermediate cardinal exists. Under CH, the continuum is the successor of $\\aleph_0$, so every uncountable subset of $\\mathbb{R}$ has the full cardinality of the continuum.",
       "mathContext": "CH says $2^{\\aleph_0} = \\aleph_1$. Since $\\aleph_1 = \\text{succ}(\\aleph_0)$, there's no cardinal strictly between $\\aleph_0$ and $\\aleph_1$ by the definition of successor."
     },
     {
       "id": "under-not-ch",
-      "title": "Under ¬CH: Explicit Intermediates",
-      "startLine": 118,
-      "endLine": 147,
-      "summary": "Proves ¬CH → $\\aleph_1$ is an explicit intermediate cardinal. If $2^{\\aleph_0} \\neq \\aleph_1$, then $2^{\\aleph_0} > \\aleph_1$, giving $\\aleph_0 < \\aleph_1 < 2^{\\aleph_0}$.",
+      "title": "Part III — Under ¬CH: Explicit Intermediates",
+      "startLine": 108,
+      "endLine": 137,
+      "summary": "Proves ¬CH → $\\aleph_1$ is an explicit intermediate cardinal (not_ch_has_intermediate), and that ¬CH yields multiple intermediates (not_ch_multiple_intermediates). If $2^{\\aleph_0} \\neq \\aleph_1$, then $2^{\\aleph_0} > \\aleph_1$, giving $\\aleph_0 < \\aleph_1 < 2^{\\aleph_0}$.",
       "mathContext": "$\\aleph_1 \\leq 2^{\\aleph_0}$ always holds. ¬CH means $\\neq$, so the inequality is strict."
     },
     {
       "id": "independence",
-      "title": "The Independence Result",
-      "startLine": 153,
-      "endLine": 179,
-      "summary": "Combines results: intermediate exists ↔ ¬CH, and both are consistent with ZFC. This is the complete answer.",
+      "title": "Part IV — The Independence Result",
+      "startLine": 138,
+      "endLine": 164,
+      "summary": "Combines results: intermediate_cardinal_independent (the statement is independent of ZFC) and intermediate_iff_not_ch (an intermediate exists ↔ ¬CH).",
       "mathContext": "The combination of Gödel (Con(ZFC) → Con(ZFC+CH)) and Cohen (Con(ZFC) → Con(ZFC+¬CH)) shows the question is undecidable. Both answers are mathematically valid."
     },
     {
       "id": "constraints",
-      "title": "König's Constraint and Easton's Theorem",
-      "startLine": 185,
-      "endLine": 216,
-      "summary": "States König's cofinality constraint (cf(2^{ℵ₀}) > ℵ₀) and Easton's completeness theorem (these are the only constraints).",
+      "title": "Part V — König's Constraint and Easton's Theorem",
+      "startLine": 165,
+      "endLine": 197,
+      "summary": "States König's cofinality constraint (KonigConstraint: cf(2^{ℵ₀}) > ℵ₀) and Easton's completeness theorem (easton_consistent_values: these are the only constraints on 2^{ℵ₀}).",
       "mathContext": "König: $2^{\\aleph_0} \\neq \\aleph_\\omega$ (cofinality too small). Easton: for any regular $\\kappa \\geq \\aleph_1$, there's a model with $2^{\\aleph_0} = \\kappa$. Together: ZFC pins down $2^{\\aleph_0}$ to regular uncountable cardinals $\\geq \\aleph_1$."
     },
     {
+      "id": "large-cardinals",
+      "title": "Part VI — Large Cardinals and CH",
+      "startLine": 198,
+      "endLine": 230,
+      "summary": "Expository discussion of whether large-cardinal axioms settle CH: measurable/supercompact cardinals leave CH open, Martin's Axiom is compatible with both CH and ¬CH, PFA implies 2^{ℵ₀} = ℵ₂ (Todorcevic–Veličković), and Woodin's program. Bottom line: no known large-cardinal axiom settles CH by itself.",
+      "mathContext": "No large-cardinal axiom of the form ``there exists a κ with property P'' decides $2^{\\aleph_0}$; forcing can change the continuum while preserving such axioms."
+    },
+    {
+      "id": "characterization",
+      "title": "Part VII — Characterization Theorem",
+      "startLine": 231,
+      "endLine": 260,
+      "summary": "complete_answer: the definitive answer to the research question, bundling (1) intermediate cardinal exists ↔ ¬CH, (2) both CH and ¬CH are relatively consistent with ZFC, and (3) under ¬CH, ℵ₁ is an explicit intermediate. Proof inlines the ℵ₁-witness argument to avoid depending on Exists.choose being defeq to the witness.",
+      "mathContext": "$\\big((\\exists \\kappa,\\ \\aleph_0 < \\kappa < 2^{\\aleph_0}) \\iff \\neg\\text{CH}\\big) \\wedge \\text{Con}(\\text{CH}) \\wedge \\text{Con}(\\neg\\text{CH}) \\wedge \\big(\\neg\\text{CH} \\to \\aleph_0 < \\aleph_1 < 2^{\\aleph_0}\\big)$."
+    },
+    {
       "id": "gch",
-      "title": "The GCH Picture",
-      "startLine": 258,
-      "endLine": 295,
-      "summary": "Under GCH, no intermediate cardinals exist at ANY level ($\\aleph_\\alpha$ to $\\aleph_{\\alpha+1}$). Conversely, intermediate cardinals at level 0 imply ¬GCH.",
+      "title": "Part VIII — The GCH Picture",
+      "startLine": 261,
+      "endLine": 287,
+      "summary": "Under GCH, no intermediate cardinals exist at ANY level (gch_no_intermediates_anywhere: $\\aleph_\\alpha$ to $\\aleph_{\\alpha+1}$). Conversely, intermediate cardinals at level 0 imply ¬GCH (not_gch_from_intermediate).",
       "mathContext": "GCH: $2^{\\aleph_\\alpha} = \\aleph_{\\alpha+1}$ for all $\\alpha$. Since $\\aleph_{\\alpha+1} = \\text{succ}(\\aleph_\\alpha)$, no cardinals can fit between them."
+    },
+    {
+      "id": "verification",
+      "title": "Part IX — Verification",
+      "startLine": 288,
+      "endLine": 301,
+      "summary": "#check statements confirming the type signatures of the nine principal results (aleph_one_gt_aleph_zero through not_gch_from_intermediate), and closes the CantorDiagOQ01OQ01 namespace.",
+      "mathContext": "Kernel-checked type signatures document that each stated theorem elaborates; the independence-flavored results rest on the axiomatized framework imported from ContinuumHypothesis."
     }
   ],
   "crossReferences": [

--- a/src/data/proofs/derangements-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-02/meta.json
@@ -121,12 +121,20 @@
       "id": "section-iii",
       "title": "The Bijection",
       "startLine": 96,
-      "endLine": 150,
-      "summary": "permSupportEqEquiv: explicit Equiv between {σ | σ.support = S} and derangements ↑S. card_perms_with_support_eq: cardinality equals numDerangements |S|. card_perms_with_kfixed: main S(n,k) = C(n,k)·D(n-k) theorem.",
+      "endLine": 141,
+      "summary": "permSupportEqEquiv: explicit Equiv between {σ | σ.support = S} and derangements ↑S, built from subtypePerm (forward) and ofSubtype (backward) with proved round-trips. card_perms_with_support_eq: each support class has cardinality numDerangements |S|.",
       "mathContext": "$\\{\\sigma \\mid \\sigma.\\text{support} = S\\} \\cong \\text{derangements}(S)$, so $|\\{\\sigma \\mid \\sigma.\\text{support} = S\\}| = D(|S|)$."
     },
     {
       "id": "section-iv",
+      "title": "Main Counting Theorem",
+      "startLine": 142,
+      "endLine": 193,
+      "summary": "card_perms_with_kfixed: the central result S(n,k) = C(n,k)·D(n-k). Rewrites |Fix(σ)| = k as |support| = n-k, decomposes {σ | |support| = n-k} as a disjoint biUnion over (n-k)-element subsets S (Finset.card_biUnion with pairwise disjointness by support), counts each class as D(n-k) via card_perms_with_support_eq, then evaluates the constant sum with Finset.card_powersetCard and Nat.choose_symm to turn C(n,n-k) into C(n,k).",
+      "mathContext": "$|\\{\\sigma \\mid |\\text{Fix}(\\sigma)| = k\\}| = \\sum_{|S| = n-k} |\\{\\sigma \\mid \\sigma.\\text{support} = S\\}| = \\binom{n}{n-k}\\, D(n-k) = \\binom{n}{k}\\, D(n-k)$."
+    },
+    {
+      "id": "section-v",
       "title": "Concrete Verifications",
       "startLine": 194,
       "endLine": 242,
@@ -134,7 +142,7 @@
       "mathContext": "$S(3,0)=2, S(3,1)=3, S(3,2)=0, S(3,3)=1$. Check: $2+3+0+1 = 6 = 3!$."
     },
     {
-      "id": "section-v",
+      "id": "section-vi",
       "title": "Special Cases",
       "startLine": 243,
       "endLine": 300,
@@ -142,7 +150,7 @@
       "mathContext": "$S(n,0) = D(n)$, $S(n,n) = 1$, $S(n,n-1) = 0$ (no permutation has exactly $n-1$ fixed points)."
     },
     {
-      "id": "section-vi",
+      "id": "section-vii",
       "title": "Algebraic Identity",
       "startLine": 301,
       "endLine": 357,

--- a/src/data/proofs/erdos-1127/meta.json
+++ b/src/data/proofs/erdos-1127/meta.json
@@ -139,12 +139,28 @@
       "mathContext": "Mathematical content: Erdős-Hajnal: finite partition fails without CH"
     },
     {
+      "id": "countable-vs-finite",
+      "title": "Part VIII: The Countable vs Finite Distinction",
+      "startLine": 210,
+      "endLine": 219,
+      "summary": "Key insight: CH lets the countable decomposition succeed, yet without CH even a finite decomposition fails. The finite-to-countable transition is the crux of the problem.",
+      "mathContext": "Under CH a countable partition of $\\mathbb{R}^n$ into distinct-distance sets exists; under $\\neg$CH the Erdős–Hajnal obstruction already blocks finite partitions."
+    },
+    {
+      "id": "related-concepts",
+      "title": "Part IX: Related Concepts",
+      "startLine": 220,
+      "endLine": 236,
+      "summary": "numDistinctDistances: for a finite point set, counts distinct pairwise distances (via powersetCard 2), and notes the related Erdős distinct-distances problem (n points determine Ω(n/√log n) distinct distances).",
+      "mathContext": "$\\text{numDistinctDistances}(S) = |\\{\\,d(p,q) : \\{p,q\\} \\subseteq S\\,\\}|$; the Erdős distinct-distances bound is $\\Omega(n/\\sqrt{\\log n})$."
+    },
+    {
       "id": "summary",
-      "title": "Summary",
+      "title": "Part X: Summary",
       "startLine": 237,
       "endLine": 279,
-      "summary": "Main theorem and key results combined",
-      "mathContext": "Verified: Main theorem and key results combined"
+      "summary": "Main theorem and key results combined: Erdős Problem #1127 is solved assuming CH — ℝⁿ admits a countable decomposition into sets with distinct pairwise distances.",
+      "mathContext": "Verified: under CH, $\\mathbb{R}^n = \\bigsqcup_{k} S_k$ with each $S_k$ realizing distinct pairwise distances."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Section-map re-anchoring pass covering two gallery entries whose maps had drifted
away from their Lean files, stranding capstone theorems in uncovered holes.

## 1. derangements-oq-02 (Partial Derangements: S(n,k) = C(n,k)·D(n-k))
The file has 7 `## Section` banners (I–VII), but the map collapsed Sections III+IV
into one "The Bijection" entry (96–150) whose summary falsely claimed to cover the
main theorem `card_perms_with_kfixed` — which actually lives at 159–193, outside the
range. Fix: trim "The Bijection" to 96–141, add **Main Counting Theorem** (§IV,
142–193), and re-id/re-title the trailing sections (§V Concrete Verifications, §VI
Special Cases, §VII Algebraic Identity) to match the banners. Full 1..357 coverage.

## 2. cantor-diagonalization-oq-01-oq-01 (Continuum Hypothesis independence)
The file has 9 `PART` banners but the map had only 6 drifted entries, leaving PART VI
(Large Cardinals and CH), PART VII (Characterization Theorem — the capstone
`complete_answer`, described in-file as "the definitive answer to the research
question"), and PART IX (Verification) with no section. `complete_answer` sat in an
uncovered hole (217–257). Fix: re-anchor all sections 1:1 to their PART banners, add a
header section plus the three missing Parts, preserving existing summaries. Full
1..301 coverage.

No Lean, prose, or axiom-accounting changes in either entry — section maps only.
Annotations already covered both main theorems.

## 3. erdos-1127 (Distinct-distance decomposition of ℝⁿ)
The file has 10 `## Part` banners but the map skipped PART VIII (The Countable vs
Finite Distinction) and PART IX (Related Concepts — the `numDistinctDistances`
def), leaving lines 210–236 in an uncovered hole between "The Necessity of CH" and
"Summary". Added the two missing Part sections and relabeled Summary as Part X.
Full 1..279 coverage (excluding leading imports).
