### PR TITLE
audit: mark fundamental-theorem-algebra-oq002 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31400,6 +31400,12 @@
       "lastAudited": "2026-07-21T12:56:29Z",
       "result": "clean",
       "issues": []
+    },
+    "fundamental-theorem-algebra-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:10:35Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Audit result: CLEAN

`fundamental-theorem-algebra-oq002` — rigidity/identification of the
Gal(ℂ/ℝ) ≃ Multiplicative(ZMod 2) isomorphism with Mathlib's generic
`zmodCyclicMulEquiv`.

### Verification (against origin/main @ 738f13cdf4)
- `Proofs/FundamentalTheoremAlgebraOQ04OQ03OQ01OQ02.lean`: 112 lines, 4 theorems + 1 def — matches meta (theoremCount 4, definitionCount 1, lineCount 112)
- 0 sorries, 0 axiom declarations — matches
- No `native_decide`; no kernel `decide` in this file
- All 4 theorems are genuine (rigidity `any_equiv_ofAdd_one`/`eq_galoisGroupEquivZMod2_symm`, identification `mathlibGaloisIso_eq`, generator `mathlibGaloisIso_ofAdd_one`) — no `True` stubs
- `Classical.choice` enters only through Mathlib's `zmodCyclicMulEquiv`; honestly disclosed in `assumptions` and not counted against the 0-axiom status (foundational axiom, standard convention)
- Parent-file dependencies (`galoisGroupEquivZMod2`, `eq_one_or_conjAe`, `zmod2_eq_one_or`, `galoisGroupEquivZMod2_symm_ofAdd_one`, `card_galoisGroup_eq_two`, `ofAdd_one_ne_one`) all confirmed present — no phantom references
- Badge `original` justified: the rigidity theorem is genuine new content, and the Mathlib dependency is fully disclosed

Status `verified` / badge `original` stand. No meta changes needed.

---
Gallery integrity audit.