### PR TITLE
audit: mark gcd-algorithm-oq001 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31400,6 +31400,12 @@
       "lastAudited": "2026-07-21T12:56:29Z",
       "result": "clean",
       "issues": []
+    },
+    "gcd-algorithm-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:13:44Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Audit result: CLEAN

`gcd-algorithm-oq001` — Lamé's theorem in closed form: the Euclidean
step count is ≤ log_φ(b) + 1 (equivalently ≤ (3/2)·log₂(b) + 1).

### Verification (against origin/main @ 738f13cdf4)
- `Proofs/GCDAlgorithmOQ01OQ03OQ01OQ01.lean`: 199 lines, 9 theorems, 0 definitions — matches meta
- 0 sorries, 0 axiom declarations — matches
- No `native_decide`; kernel `decide` only on concrete Fibonacci values (`fib 2 = 1`, `fib 3 = 2`, `fib 6 < fib 7`) — trust-neutral, and the `assumptions` prose correctly states "No native_decide anywhere"
- Main results genuine, non-vacuous: `euclidSteps_le_logb` (`euclidSteps a b = n → (n:ℝ) ≤ logb φ b + 1`) and `euclidSteps_le_log2` (the textbook ~1.44·log₂b bound with explicit 3/2) — real satisfiable hypotheses, demonstrated by the worst-case sanity check
- `euclidSteps` (defined in `BinaryGcdOQ01.lean`), the parent's worst-case identity, and `goldenPhi` infrastructure all confirmed present and disclosed
- HIGH-risk famous-theorem title check: "Lamé's Theorem in Closed Form" accurately describes the formalized step-count bound — no overclaim
- Badge `original` justified

Status `verified` / badge `original` stand. No meta changes needed.

---
Gallery integrity audit.