### PR TITLE
audit: mark geometric-series-oq001 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31400,6 +31400,12 @@
       "lastAudited": "2026-07-21T12:56:29Z",
       "result": "clean",
       "issues": []
+    },
+    "geometric-series-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:15:03Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Audit result: CLEAN

`geometric-series-oq001` — the Neumann series for a perturbed unit x − t
(closed form for `(x − t)⁻¹` when `‖x⁻¹·t‖ < 1`).

### Verification (against origin/main @ 738f13cdf4)
- `Proofs/GeometricSeriesOQ02OQ03OQ01OQ03.lean`: 182 lines, 8 theorems, 0 definitions — matches meta
- 0 sorries, 0 axiom declarations — matches; `#print axioms` reports only propext/Classical.choice/Quot.sound
- No `native_decide`, no `decide`
- Main results genuine and non-vacuous: `neumann_series_sub` (closed form), `hasSum_neumann_series_sub`, two-sided inverse `neumann_sub_mul_left`/`right` — all carry the real norm hypothesis `‖x⁻¹·t‖ < 1`
- Badge `mathlib` (Tier B) correctly credits the Mathlib machinery it builds on (`geom_series_eq_inverse`, `isUnit_one_sub_of_norm_lt_one`, `Units.oneSub`, `Ring.inverse_unit`, …) — honest attribution, not claimed as independent

Status `verified` / badge `mathlib` stand. No meta changes needed.

---
Gallery integrity audit.