### PR TITLE
audit: mark geometric-series-oq002/003/004 clean (Eulerian numbers cluster)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31406,6 +31406,24 @@
       "lastAudited": "2026-07-21T13:15:03Z",
       "result": "clean",
       "issues": []
+    },
+    "geometric-series-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:16:57Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq003": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:16:57Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq004": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:16:57Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Audit result: CLEAN (3 entries)

The Eulerian-numbers chain under `geometric-series`.

### oq002 — Eulerian polynomial coefficients (`GeometricSeriesOQ07OQ01OQ01OQ01.lean`)
- 192 lines; **9 theorems + 1 def** — matches meta. (3 are `@[simp] theorem` decls; the attribute-prefixed lines are easy to miss with an anchored grep.)
- 0 sorries, 0 axioms. Kernel `decide` only in two anonymous `example` sanity checks (trust-neutral; no `native_decide`)

### oq003 — Worpitzky row sum + low-column closed forms (`…OQ01OQ01.lean`)
- 125 lines; 6 theorems — matches meta. 0 sorries, 0 axioms
- Flagship `eulerian_row_sum : ∑ⱼ ⟨n,j⟩ = n!`, `eulerian_col_one : ⟨n,1⟩ = 2ⁿ−n−1`, `eulerian_col_two` — all genuine, real inductions

### oq004 — Mean / second moment / variance of the descent statistic (`…OQ01OQ01OQ01.lean`)
- 212 lines; 6 theorems — matches meta. 0 sorries, 0 axioms; kernel `decide` only in concrete-row corroboration
- Flagship `eulerian_first_moment`, `eulerian_second_moment`, `eulerian_variance` — genuine formulas via `linear_combination`

### Cross-cutting checks
- Every `sorry` grep hit is the docstring phrase "`sorry`-free" — false positive, no real sorries
- No `native_decide` in any file
- All statuses `verified` / badges `original` stand; no meta changes needed

---
Gallery integrity audit.