### PR TITLE
audit(tracker): consolidate 10 clean entries (unblock merge-race)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31406,6 +31406,66 @@
       "lastAudited": "2026-07-21T13:15:03Z",
       "result": "clean",
       "issues": []
+    },
+    "fibonacci-identities-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:20:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "frobenius-endomorphism-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:20:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fundamental-theorem-algebra-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:20:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fundamental-theorem-algebra-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:20:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "gamma-reflection-formula-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:20:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "gcd-algorithm-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:20:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:20:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq003": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:20:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq004": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:20:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq005": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:20:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Folds 7 mutually-conflicting single-entry audit-tracker PRs into one to end the `audit-tracker.json` merge-race that was re-serving these slugs as "never audited."

All 10 slugs re-verified clean against `origin/main` (0 sorries, 0 axioms, no real `native_decide`, no `True` stubs; decl counts match meta):

| slug | thm | note | superseded PR |
|------|-----|------|---------------|
| fibonacci-identities-oq001 | 11 | kernel `decide` numeric checks | #40479 |
| frobenius-endomorphism-oq001 | 4 | | #40477 |
| fundamental-theorem-algebra-oq001 | 5 | | #40478 |
| fundamental-theorem-algebra-oq002 | 4 | | #40481 |
| gamma-reflection-formula-oq001 | 8 | | #40483 |
| gcd-algorithm-oq001 | 9 | `native_decide` only in a `--` comment | #40484 |
| geometric-series-oq002 | 9 | `@[simp]`/`private` prefixes (attr-tolerant count) | #40488 |
| geometric-series-oq003 | 6 | | #40488 |
| geometric-series-oq004 | 6 | | #40488 |
| geometric-series-oq005 | 3 | newly audited | — |

Closing the superseded PRs in favor of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)