### PR TITLE
audit: mark geometric-series-oq006 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31466,6 +31466,12 @@
       "lastAudited": "2026-07-21T13:20:00Z",
       "result": "clean",
       "issues": []
+    },
+    "geometric-series-oq006": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:27:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
`eulerian_col_three` — genuine induction proof of the ℤ closed form for the fourth column of the Eulerian triangle (OEIS A000498), cleared of its /6:

`6·⟨n,3⟩ = 6·4ⁿ − 6·(n+1)·3ⁿ + 3·n·(n+1)·2ⁿ − (n−1)·n·(n+1)`

- 1 theorem, **0 axioms, 0 sorries**, no `native_decide`, no `True` stubs.
- Real inductive proof via the definitional recurrence + parent's `eulerian_col_two`; careful honest handling of truncated ℕ subtraction.
- meta (verified / original / 0ax / 0sorry / 1 thm) matches the file exactly.
- Badge `original` justified: settles an explicit column-three follow-up from scratch, not a Mathlib wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)