### PR TITLE
audit(tracker): mark geometric-series-oq007..oq015 clean (Eulerian triangle cluster)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31472,6 +31472,60 @@
       "lastAudited": "2026-07-21T13:27:00Z",
       "result": "clean",
       "issues": []
+    },
+    "geometric-series-oq007": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:30:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq008": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:30:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq009": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:30:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq010": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:30:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq011": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:30:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq012": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:30:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq013": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:30:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq014": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:30:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq015": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:30:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Nine Eulerian-triangle closed-form / explicit-formula follow-ups (oq007–oq015), all re-verified clean against `origin/main`:

- decl counts match meta (attr-tolerant: `@[simp]`/`private`/`lemma` prefixes accounted for)
- **0 sorries, 0 axioms, no `native_decide`, no `True` stubs** in every file
- genuine inductive / `Finset` proofs (`ring`, `linear_combination`, `induction`); `decide` uses are kernel-level (trust-neutral)
- badge `original` justified: from-scratch combinatorial identities building on parent columns, not Mathlib wrappers

Spot-checked full proof bodies of oq006 (`eulerian_col_three`), oq007 (`eulerian_eq_explicit`), and oq014 (`eulerian_explicit`) — all genuine formalizations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)