### PR TITLE
Enrich greens-theorem-oq-01: re-anchor drifted section map (recover Part III/IV banners)

### DIFF
--- a/src/data/proofs/greens-theorem-oq-01/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01/meta.json
@@ -100,7 +100,7 @@
     {
       "id": "greens-theorem-main",
       "title": "Green's Theorem (Main Proof)",
-      "startLine": 145,
+      "startLine": 116,
       "endLine": 202,
       "summary": "greens_theorem_concrete: under differentiability, integrability, and Fubini hypotheses, rectLineIntegral P Q a b c d = rectDoubleIntegral (∂Q/∂x - ∂P/∂y) a b c d. Eight steps: split inner integral, lift to outer, apply FTC for Q, split boundary terms, apply Fubini, apply FTC for P, split, ring arithmetic.",
       "mathContext": "$\\oint_{\\partial R} (P\\,dx + Q\\,dy) = \\iint_R \\left(\\frac{\\partial Q}{\\partial x} - \\frac{\\partial P}{\\partial y}\\right)dA$. Proved in 8 steps: (1-2) split and lift inner integral, (3) split outer, (4) FTC for $\\partial Q/\\partial x$, (5) split $Q$ terms, (6) Fubini swap, (7) FTC for $\\partial P/\\partial y$, (8) `ring`."
@@ -108,7 +108,7 @@
     {
       "id": "axiomatic-connection",
       "title": "Connection to Axiomatic Formulation",
-      "startLine": 217,
+      "startLine": 204,
       "endLine": 232,
       "summary": "concrete_matches_stub_zero: the concrete integrals agree with the abstract stubs on the zero field. area_double_integral: rectDoubleIntegral 1 a b c d = (b-a)*(d-c), proved concretely with integral_const. Shows our definitions compute correctly.",
       "mathContext": "Verification: $\\iint_R 1\\,dA = (b-a)(d-c)$ via `integral_const`. This confirms the iterated integral definition computes the correct area."


### PR DESCRIPTION
## Enrichment: greens-theorem-oq-01 — re-anchor drifted section map

Two sections were anchored to their theorem lines rather than their `## Part` banners,
stranding the banner + rich docstring above each:

- **greens-theorem-main** started at L145 (the `greens_theorem_concrete` line), leaving the
  Part III banner and the theorem's full 8-step docstring (L116–144) uncovered → re-anchored to **L116**.
- **axiomatic-connection** started at L217, leaving the Part IV banner + explanatory docstring
  (L204–215) uncovered → re-anchored to **L204**.

Section summaries already describe the recovered content accurately; only `startLine`s changed.
Annotation-only; no Lean source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
