### PR TITLE
audit(geometric-series-oq016): clean — Eulerian→Stirling identity

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31526,6 +31526,12 @@
       "lastAudited": "2026-07-21T13:30:00Z",
       "result": "clean",
       "issues": []
+    },
+    "geometric-series-oq016": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:31:45Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery integrity audit — clean

**Proof**: geometric-series-oq016 (The Combinatorial Eulerian → Stirling Identity)
**File**: `Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ06.lean`

All meta.json claims verified against the Lean source:

- **lineCount 217** ✓
- **theoremCount 4** ✓ — `term_binom`, `row_regroup`, `eulerian_stirling_succ` (private), `eulerian_stirling` (public). The 4 anonymous `example`s are correctly excluded.
- **definitionCount 0** ✓
- **axiomCount 0** ✓ — no `axiom` decls; imported parent (`…OQ01`) and sibling (`…OQ01OQ01`) files are also 0-axiom/0-sorry, so the transitive claim holds.
- **sorries 0** ✓ — only hit is the docstring word "sorry-free".
- **native_decide**: none. Concrete-row checks use kernel `decide`, honestly disclosed in the meta (no `Lean.ofReduceBool`).
- **badge `original` / status `verified`**: defensible. Genuine new combinatorial identity (Eulerian numbers absent from Mathlib); elementary Mathlib lemmas (Pascal, absorption, Stirling recurrence) are disclosed in `mathlibDependencies`.

Tracker entry added for `geometric-series-oq016`.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)