### PR TITLE
Enrich erdos-240: re-anchor systematically drifted section map (Parts II-VIII → banners)

### DIFF
--- a/src/data/proofs/erdos-240/meta.json
+++ b/src/data/proofs/erdos-240/meta.json
@@ -115,55 +115,55 @@
       "title": "Enumeration and Gaps",
       "summary": "smoothEnum axioms, gap definition",
       "startLine": 69,
-      "endLine": 101,
+      "endLine": 99,
       "mathContext": "Formal definition: smoothEnum axioms, gap definition"
     },
     {
       "id": "main-question",
       "title": "The Main Question",
       "summary": "gapsTendToInfinity, erdos240Question",
-      "startLine": 102,
-      "endLine": 119,
+      "startLine": 100,
+      "endLine": 117,
       "mathContext": "Mathematical content: gapsTendToInfinity, erdos240Question"
     },
     {
       "id": "polya-theorem",
       "title": "Pólya's Theorem (1918)",
       "summary": "polya_theorem, polya_corollary axioms",
-      "startLine": 120,
-      "endLine": 139,
+      "startLine": 118,
+      "endLine": 131,
       "mathContext": "Verified: polya_theorem, polya_corollary axioms"
     },
     {
       "id": "finite-p",
       "title": "Finite P Case",
       "summary": "finite_P_unbounded_gaps, tijdeman_finite_bound",
-      "startLine": 140,
-      "endLine": 167,
+      "startLine": 132,
+      "endLine": 154,
       "mathContext": "Bound: finite_P_unbounded_gaps, tijdeman_finite_bound"
     },
     {
       "id": "tijdeman-main",
       "title": "Tijdeman's Main Theorem",
       "summary": "tijdeman_main_theorem, erdos240_answer",
-      "startLine": 168,
-      "endLine": 197,
+      "startLine": 155,
+      "endLine": 224,
       "mathContext": "Verified: tijdeman_main_theorem, erdos240_answer"
     },
     {
       "id": "construction",
       "title": "Construction Ideas",
       "summary": "tijdeman_construction, singleton_large_gaps",
-      "startLine": 198,
-      "endLine": 227,
+      "startLine": 225,
+      "endLine": 258,
       "mathContext": "Mathematical content: tijdeman_construction, singleton_large_gaps"
     },
     {
       "id": "related",
       "title": "Related Results",
       "summary": "stormer_theorem, abc_connection, smooth_in_progressions",
-      "startLine": 228,
-      "endLine": 255,
+      "startLine": 259,
+      "endLine": 283,
       "mathContext": "Verified: stormer_theorem, abc_connection, smooth_in_progressions"
     },
     {


### PR DESCRIPTION
## Enrichment: erdos-240 — re-anchor systematically drifted section map

Sections II–VIII of `Erdos240Problem.lean` had drifted off their `## Part N` banner blocks,
so the line ranges no longer matched the declarations each summary names:

- **Tijdeman's Main Theorem** ended at L197, cutting off the second half of the
  `erdos240_answer` proof (which runs to L223).
- **Construction Ideas** (L198–227) and **Related Results** (L228–255) were anchored
  ~30 lines *before* their banners (L226, L260), landing on the wrong declarations —
  "Related Results" actually pointed at Part VII's `singleton_large_gaps`.

Re-anchored all seven drifted sections 1:1 to their Part banner blocks:
II→[69–99], III→[100–117], IV→[118–131], V→[132–154], VI→[155–224], VII→[225–258], VIII→[259–283].
Section titles/summaries were already correct; only line ranges changed. Annotation-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
