### PR TITLE
Enrich erdos-109: re-anchor drifted section map + add stranded 'Strengthenings' section

### DIFF
--- a/src/data/proofs/erdos-109/meta.json
+++ b/src/data/proofs/erdos-109/meta.json
@@ -78,39 +78,47 @@
       "id": "density-defs",
       "title": "Density Definitions",
       "startLine": 31,
-      "endLine": 94,
-      "summary": "Define counting function, upper/lower density, and prove lower ≤ upper density.",
-      "mathContext": "Define counting function, upper/lower density, and prove lower ≤ upper density."
+      "endLine": 110,
+      "summary": "Define counting function, upper/lower density, and prove lower ≤ upper density (plus posLowerDensity_implies_posUpperDensity).",
+      "mathContext": "Define counting function, upper/lower density, and prove lower ≤ upper density (plus posLowerDensity_implies_posUpperDensity)."
     },
     {
       "id": "sumset-defs",
       "title": "Sumset Definitions",
-      "startLine": 95,
-      "endLine": 117,
+      "startLine": 111,
+      "endLine": 133,
       "summary": "Define sumsets B + C with notation, prove zero membership and commutativity.",
       "mathContext": "Define sumsets B + C with notation, prove zero membership and commutativity."
     },
     {
       "id": "main-theorem",
       "title": "The Erdős Sumset Conjecture",
-      "startLine": 118,
-      "endLine": 144,
+      "startLine": 134,
+      "endLine": 160,
       "summary": "State the conjecture as ErdosSumsetConjecture and axiomatize the Moreira-Richter-Robertson theorem.",
       "mathContext": "State the conjecture as ErdosSumsetConjecture and axiomatize the Moreira-Richter-Robertson theorem."
     },
     {
       "id": "consequences",
       "title": "Consequences",
-      "startLine": 145,
-      "endLine": 182,
+      "startLine": 161,
+      "endLine": 199,
       "summary": "Prove that sets containing infinite sumsets are infinite, and that positive density sets are infinite.",
       "mathContext": "Prove that sets containing infinite sumsets are infinite, and that positive density sets are infinite."
     },
     {
+      "id": "strengthenings",
+      "title": "Stronger Sumset Conjecture",
+      "startLine": 200,
+      "endLine": 224,
+      "summary": "State StrongerSumsetConjecture: the infinite sets B, C can additionally be chosen with arbitrarily large prescribed gaps between consecutive elements, showing the sumset structure is robust. Includes a remark connecting the result to Szemerédi's theorem (both extract additive structure from positive density, but sumsets vs. arithmetic progressions).",
+      "mathContext": "The strengthening quantifies over a growth function $f : \\mathbb{N} \\to \\mathbb{N}$ and demands $B$ with gaps $b_2 - b_1 \\ge f(b_1)$, so the extracted sumset structure survives arbitrary sparsification of $B$. This is complementary to Szemerédi's theorem, which forces arbitrarily long arithmetic progressions rather than an infinite sumset $B +_s C$."
+    },
+    {
       "id": "examples",
       "title": "Examples",
-      "startLine": 208,
-      "endLine": 437,
+      "startLine": 225,
+      "endLine": 438,
       "summary": "Verify that ℕ has full density, define even numbers, and prove even + even ⊆ even.",
       "mathContext": "Verify that ℕ has full density, define even numbers, and prove even + even ⊆ even."
     }


### PR DESCRIPTION
## Summary

`erdos-109` (Erdős Sumset Conjecture) had a drifted section map plus a **whole missing section**. The file's `## ` banners define six blocks, but only five sections existed, and each was anchored below its banner:

- The **`## Strengthenings` block** (banner line 200, containing `StrongerSumsetConjecture` at 207 and a Szemerédi-connection remark) had **no section at all** — it sat in an uncovered hole (183–207) together with the tail of *Consequences* (`posUpperDensity_infinite`, 195).
- *Density Definitions* stopped at 94, stranding `posLowerDensity_implies_posUpperDensity` (104).
- *Examples* stopped at 437, missing `end Erdos109` (438).

## Fix

Re-anchored all sections 1:1 to their `## ` banners for contiguous **31..438** coverage and added the missing section:

| Section | Banner | Old | New |
|---|---|---|---|
| Density Definitions | 47 | 31–94 | 31–110 |
| Sumset Definitions | 111 | 95–117 | 111–133 |
| The Erdős Sumset Conjecture | 134 | 118–144 | 134–160 |
| Consequences | 161 | 145–182 | 161–199 |
| **Stronger Sumset Conjecture** *(new)* | 200 | — | 200–224 |
| Examples | 225 | 208–437 | 225–438 |

The new *Stronger Sumset Conjecture* section gets a substantive summary + mathContext (the growth-function strengthening `b₂ − b₁ ≥ f(b₁)` and its contrast with Szemerédi's theorem). The *Density Definitions* summary was extended to name `posLowerDensity_implies_posUpperDensity` (now in range).

No Lean, `status`, `badge`, or `axiomCount` changes — the entry stays `axiomatized` with 1 axiom (`moreira_richter_robertson`). Existing titles/summaries preserved.
