### PR TITLE
audit: clean batch — geometric-series oq017/021–027 + hilbert-10-oq001 + greens-theorem-oq001 (10 entries)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31532,6 +31532,12 @@
       "lastAudited": "2026-07-21T13:31:45Z",
       "result": "clean",
       "issues": []
+    },
+    "geometric-series-oq017": {
+      "auditCount": 2,
+      "lastAudited": "2026-07-21T13:40:55Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31538,6 +31538,12 @@
       "lastAudited": "2026-07-21T13:40:55Z",
       "result": "clean",
       "issues": []
+    },
+    "geometric-series-oq021": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:41:54Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — all clean, verified against the Lean source on fresh main.

| entry | lines | thms | defs | ax | sorry | notes |
|---|---|---|---|---|---|---|
| geometric-series-oq017 | 191 | 2 | 0 | 0 | 0 | inverse Eulerian⇆Stirling pairing (merge-race dropped prior #40502 entry) |
| geometric-series-oq021 | 188 | 8 | 1 | 0 | 0 | infinite-limit moment recurrence (★∞) |
| geometric-series-oq022 | 145 | 5 | 0 | 0 | 0 | closed form of (★∞) via Eulerian polys |
| geometric-series-oq023 | 255 | 6 | 1 | 0 | 0 | analysis-free Eulerian recurrence (new Stirling binomial-transform identity) |
| geometric-series-oq024 | 125 | 5 | 0 | 0 | 0 | geometric limit from first principles |
| geometric-series-oq025 | 163 | 10 | 0 | 0 | 0 | multisection via Nat.divModEquiv |
| geometric-series-oq026 | 236 | 10 | 1 | 0 | 0 | converse residue multisection |
| geometric-series-oq027 | 205 | 6 | 0 | 0 | 0 | roots-of-unity multisection filter |
| hilbert-10-oq001 | 113 | 4 | 0 | 0 | 0 | vecGcd == Finset.gcd bridge; `by decide` only in anonymous examples (trust-neutral) |
| greens-theorem-oq001 | 538 | 10 | 0 | 0 | 0 | axiom-elimination of iteratedIntervalIntegral_order_independent (Fubini + perm decomposition) |

All badges `original`; no native_decide in theorems, no True stubs. Mathlib dependencies disclosed in each meta. Counts match meta exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)