### PR TITLE
Enrich cauchy-schwarz-oq-03-oq-01: recover stranded Hölder reverse-direction lemma

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03-oq-01/meta.json
@@ -140,9 +140,9 @@
     {
       "id": "holder-equality",
       "title": "General Hölder Equality (Finite Sums)",
-      "summary": "Reduces Hölder equality to pointwise Young equality: sum of deficits = 0 forces each deficit = 0. Normalized and general cases with both directions.",
+      "summary": "Reduces Hölder equality to pointwise Young equality: sum of deficits = 0 forces each deficit = 0. Normalized and general cases with both directions, closing with `power_prop_implies_holder_eq_normalized` — the reverse direction on normalized vectors ($\\sum f_i^p=\\sum g_i^q=1$ and $f_i^p=g_i^q$ pointwise $\\Rightarrow \\sum f_ig_i=1$), obtained by summing the vanishing Young deficits.",
       "startLine": 462,
-      "endLine": 600,
+      "endLine": 625,
       "mathContext": "Equality in Hölder: $\\sum f_ig_i = \\left(\\sum f_i^p\\right)^{1/p}\\left(\\sum g_i^q\\right)^{1/q} \\iff \\exists c > 0,\\, f_i^p = c \\cdot g_i^q$ for all $i$ (power proportionality)."
     },
     {


### PR DESCRIPTION
## Summary

The **"General Hölder Equality (Finite Sums)"** section ended at line 600, leaving `power_prop_implies_holder_eq_normalized` (lines 602-625) stranded in a section hole before Part VIII.

That theorem is the **normalized reverse direction** of Hölder equality: if $\sum f_i^p = \sum g_i^q = 1$ and $f_i^p = g_i^q$ pointwise, then $\sum f_i g_i = 1$ (proved by summing the vanishing Young deficits). It plainly belongs to the General Hölder Equality section, whose summary already advertised "both directions."

## Change (`meta.json` sections only)

- Extend `holder-equality` section endLine **600 → 625** to cover the stranded lemma.
- Name the lemma in the section summary.

Section map now covers lines 26-835 contiguously (no holes). No Lean source changed; JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
