### PR TITLE
audit(geometric-series-oq018-020,022-027): clean — reland dropped tracker entries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31562,8 +31562,44 @@
       "lastAudited": "2026-07-21T13:51:10Z",
       "result": "clean",
       "issues": []
+    },
+    "geometric-series-oq022": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:53:15Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq023": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:53:15Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq024": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:53:15Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq025": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:53:15Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq026": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:53:15Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq027": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:53:15Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-21T13:51:10Z"
+  "lastUpdated": "2026-07-21T13:53:15Z"
 }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31544,8 +31544,26 @@
       "lastAudited": "2026-07-21T13:41:54Z",
       "result": "clean",
       "issues": []
+    },
+    "geometric-series-oq018": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:51:10Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq019": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:51:10Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq020": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:51:10Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-21T11:46:53Z"
+  "lastUpdated": "2026-07-21T13:51:10Z"
 }


### PR DESCRIPTION
Re-lands 9 audit-tracker entries dropped by tracker merge-races.

- **oq018/019/020**: prior PR #40504 went CONFLICTING; never reached main.
- **oq022-027**: #40505 merged but a later tracker merge-race overwrote the JSON, dropping these six (only oq021 survived).

All nine re-verified **clean** against current main (0 sorry / 0 axiom / 0 native_decide):

| id | lines | thm |
|----|-------|-----|
| oq018 | 228 | 12 (incl 1 private) |
| oq019 | 177 | 6 |
| oq020 | 162 | 6 (+1 def; grep-7 = 1 docstring false hit) |
| oq022 | 145 | 5 |
| oq023 | 255 | 6 |
| oq024 | 125 | 5 |
| oq025 | 163 | 10 |
| oq026 | 236 | 10 |
| oq027 | 205 | 6 (Roots-of-Unity Multisection Filter, badge original) |

Supersedes #40504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)