### PR TITLE
Enrich chinese-remainder-oq-04-oq-02: cover stranded canonical bridge theorem

### DIFF
--- a/src/data/proofs/chinese-remainder-constructive-oq-04-oq-02/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04-oq-02/meta.json
@@ -114,8 +114,8 @@
       "id": "canonical",
       "title": "Canonical Solution = ZMod Preimage",
       "startLine": 79,
-      "endLine": 116,
-      "summary": "Three theorems establishing that the minimal CRT solution equals the ZMod.val of the ring-theoretic preimage: val_lt, satisfies, and the canonical bridge theorem.",
+      "endLine": 138,
+      "summary": "Establishes that the minimal CRT solution equals the ZMod.val of the ring-theoretic preimage: bounding (val_lt) and congruence (satisfies) lemmas, chineseRemainder_symm_satisfies (the preimage of (a,b) under the CRT iso solves the congruence system), culminating in the canonical bridge theorem crt_min_eq_chineseRemainder_val — the unique minimal solution in [0, m·n) equals ZMod.val of the inverse-iso preimage.",
       "mathContext": "Let w = (ZMod.chineseRemainder h).symm (a, b). Then ZMod.val w < m*n (by ZMod.val_lt) and Satisfies (ZMod.val w) [(a,m),(b,n)] (by natCast_zmod_val + apply_symm_apply)."
     },
     {


### PR DESCRIPTION
## Enrichment: chinese-remainder-constructive-oq-04-oq-02

Boundary-correctness fix in the `sections` map of
`Proofs/ChineseRemainderConstructiveOQ04OQ02.lean`.

The **"Canonical Solution = ZMod Preimage"** section ended at line **116**, yet
its own summary already claimed to cover *"the canonical bridge theorem."* That
theorem — `crt_min_eq_chineseRemainder_val` (the unique minimal solution in
`[0, m·n)` equals `ZMod.val` of the inverse-iso preimage) at lines 122-138 —
was actually stranded in an **uncovered hole (117-138)**, together with the
supporting lemma `chineseRemainder_symm_satisfies`.

### Fix
Extend the section's `endLine` **116 → 138** (up to the `## Section 4` banner at
139) so the range matches the content the summary describes, and expand the
summary to name both previously-stranded lemmas.

### Verification
- Sections remain monotonic and non-overlapping.
- No status/axiom fields touched; JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
