### PR TITLE
Enrich sqrt2-from-axioms: add stranded Part 6 (Alternative Formulation) section

### DIFF
--- a/src/data/proofs/sqrt2-from-axioms/meta.json
+++ b/src/data/proofs/sqrt2-from-axioms/meta.json
@@ -95,6 +95,14 @@
       "mathContext": "The main result: no coprime integers $a, b$ satisfy $a^2 = 2b^2$. Proof: $a^2 = 2b^2 \\Rightarrow a^2$ even $\\Rightarrow a$ even $\\Rightarrow a = 2c \\Rightarrow 4c^2 = 2b^2 \\Rightarrow b^2$ even $\\Rightarrow b$ even, contradicting coprimality."
     },
     {
+      "id": "alternative-formulation",
+      "title": "Part 6: Alternative Formulation",
+      "startLine": 167,
+      "endLine": 187,
+      "summary": "sqrt2_no_rational_form: for any a, b with a^2 = 2b^2, either b = 0 or both a and b are even — the descent step stated without the coprimality hypothesis, exposing the parity dichotomy that drives the irrationality proof.",
+      "mathContext": "Restates the core of the argument as a dichotomy: $a^2 = 2b^2 \\Rightarrow b = 0 \\lor (2 \\mid a \\land 2 \\mid b)$. Iterating the 'both even' branch is the infinite-descent engine; the coprime version (`sqrt2_irrational`) is the special case $b > 0$."
+    },
+    {
       "id": "educational-notes",
       "title": "Educational Notes",
       "startLine": 188,


### PR DESCRIPTION
## Enrichment: sqrt2-from-axioms

Adds a stranded whole-Part section to the `sections` map of
`Proofs/Sqrt2IrrationalFromAxioms.lean`.

The map jumped from **"The Main Theorem"** (ends 166) directly to **"Educational
Notes"** (starts 188), skipping the file's **`PART 6: Alternative Formulation`**
banner (line 169) and stranding its theorem `sqrt2_no_rational_form`
(173-186) in an uncovered hole (167-187).

### Fix
Insert a **"Part 6: Alternative Formulation"** section covering **167-187**,
describing `sqrt2_no_rational_form` — the descent step stated as a parity
dichotomy (`a² = 2b² ⇒ b = 0 ∨ (2∣a ∧ 2∣b)`) without the coprimality hypothesis.

### Verification
- 6 sections, monotonic and non-overlapping; JSON validated.
- No status/axiom fields touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
