### PR TITLE
Enrich laws-of-large-numbers-oq-01: cover stranded finite-variance lemma, re-anchor Main Answer

### DIFF
--- a/src/data/proofs/laws-of-large-numbers-oq-01/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01/meta.json
@@ -122,14 +122,14 @@
       "id": "pareto",
       "title": "Pareto Distribution: Key Example",
       "startLine": 154,
-      "endLine": 168,
-      "summary": "pareto_lln_analysis: documents the α > 1 threshold for Pareto. Chebyshev requires α > 2; Kolmogorov only α > 1.",
+      "endLine": 180,
+      "summary": "The α > 1 threshold for Pareto (Chebyshev requires α > 2; Kolmogorov only α > 1), concluded by finite_variance_implies_slln_applicable: any L² random variable is L¹, so wherever the Chebyshev/WLLN argument applies Kolmogorov's SLLN also applies — the converse failing precisely for Pareto(α) with 1 < α ≤ 2 (finite mean, infinite variance).",
       "mathContext": "Pareto$(\\alpha, x_m)$: $E[X] = \\alpha x_m/(\\alpha-1)$ (finite iff $\\alpha > 1$), $E[X^2] = \\alpha x_m^2/(\\alpha-2)$ (finite iff $\\alpha > 2$). For $1 < \\alpha \\leq 2$: Chebyshev fails ($E[X^2] = \\infty$) but Kolmogorov's SLLN holds ($E[|X|] < \\infty$)."
     },
     {
       "id": "main-theorem",
       "title": "Main Answer to the Open Question",
-      "startLine": 191,
+      "startLine": 181,
       "endLine": 229,
       "summary": "kolmogorov_slln_characterization (iff theorem) and lln_heavy_tail_answer: complete proof that SLLN holds for heavy-tailed distributions with E[|X|] < ∞. The iff form combines slln_under_finite_mean_only (sufficient) and slln_necessity (necessary).",
       "mathContext": "kolmogorov_slln_characterization (iff theorem) and lln_heavy_tail_answer: complete proof that SLLN holds for heavy-tailed distributions with E[|X|] < ∞. The iff form combines slln_under_finite_mean_only (sufficient) and slln_necessity (necessary)."


### PR DESCRIPTION
## Enrichment: laws-of-large-numbers-oq-01

Two coverage/anchor fixes in the `sections` map of
`Proofs/LawsOfLargeNumbersOQ01.lean`.

1. The **"Pareto Distribution: Key Example"** section (Section IV) ended at line
   **168**, stranding `finite_variance_implies_slln_applicable` (176-180) in an
   uncovered hole (169-190). That lemma (every L² variable is L¹, so wherever
   Chebyshev/WLLN applies Kolmogorov's SLLN also applies) is exactly the
   finite-mean/infinite-variance point the Pareto example illustrates — its
   docstring even cites Pareto(α), 1 < α ≤ 2. Extended Pareto `endLine`
   **168 → 180** and named the lemma in the summary.
2. The **"Main Answer to the Open Question"** section was anchored at **191**,
   nine lines past its own `## Main Theorem: Complete Answer` banner (the `/-!`
   block at 182). Moved `startLine` **191 → 181** so it starts at the banner,
   closing the hole with no gap.

### Verification
- 8 sections, monotonic and non-overlapping.
- `axiomCount: 1` / `status: axiomatized` confirmed against the single `axiom`
  (`slln_necessity`); JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
