### PR TITLE
audit(greens-theorem-oq001): clean — axiom-elimination lemma

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31598,8 +31598,14 @@
       "lastAudited": "2026-07-21T13:53:15Z",
       "result": "clean",
       "issues": []
+    },
+    "greens-theorem-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T13:59:50Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-21T13:53:15Z"
+  "lastUpdated": "2026-07-21T13:59:50Z"
 }


### PR DESCRIPTION
Audited **greens-theorem-oq001** (`iteratedIntervalIntegral_order_independent`) — **clean**.

Despite the slug, this entry does not claim to prove Green's theorem: the title ("Axiom Elimination: iteratedIntervalIntegral_order_independent") and description scope it precisely to eliminating one axiom from the parent Green's-theorem proof.

- **General-n theorem**: order independence of iterated interval integrals under any `Equiv.Perm (Fin n)`, proved via `Equiv.Perm.swap_induction_on` + a swap-decomposition; 2D/3D cases are corollaries (not the whole result).
- **Counts match meta**: 538 lines, 10 theorems/lemmas, **0 sorry / 0 axiom / 0 native_decide**.
- **Dependency disclosed**: Mathlib Fubini core `MeasureTheory.integral_integral_swap` is listed in `mathlibDependencies` and credited in the overview's historical context.
- **Badge `original`** is defensible over a disclosed Mathlib specialization (cf. #40124 precedent): the permutation-induction / swap-decomposition infrastructure is genuinely the file's own work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)