### PR TITLE
Enrich euler-polyhedral-oq-02-oq-01: re-anchor coarse 5-section map to full-file 17-section coverage

### DIFF
--- a/src/data/proofs/euler-polyhedral-oq-02-oq-01/meta.json
+++ b/src/data/proofs/euler-polyhedral-oq-02-oq-01/meta.json
@@ -46,7 +46,7 @@
   "overview": {
     "historicalContext": "The Gauss-Bonnet theorem is the cornerstone of the relationship between differential geometry (local curvature) and topology (global Euler characteristic). Gauss (1827) proved the local version; Bonnet (1848) proved the global integral formula for surfaces. Chern (1944) gave the intrinsic proof and extended it to all even-dimensional manifolds (the Chern-Gauss-Bonnet theorem).\n\nThe formula ∫_M K dA = 2πχ(M) says the total Gaussian curvature is a topological invariant: it doesn't change under metric deformations, only under topological surgery. This is why the sphere (χ=2) must have positive curvature, the torus (χ=0) can be flat, and higher-genus surfaces (χ<0) must have negative curvature.\n\nSince Mathlib 4.26.0 lacks Riemannian metrics and integration on manifolds, this formalization axiomatizes the theorem as a structure field and proves the many interesting consequences — genus determination, curvature sign constraints, Girard's formula, Gauss-Bonnet with boundary, Poincaré-Hopf, and Morse inequalities.",
     "problemStatement": "**Smooth Gauss-Bonnet theorem**: For a compact orientable Riemannian 2-manifold M without boundary:\n∫_M K dA = 2π · χ(M)\n\nwhere K is the Gaussian curvature and χ(M) = 2 - 2g is the Euler characteristic (g = genus).\n\n**Axiomatized as**: `gauss_bonnet : totalCurvature = 2 * π * chi` in `CompactRiemannianSurface`.",
-    "text": "A 786-line axiomatized treatment of smooth Gauss-Bonnet theory. The file defines 9 axiomatized structures (CompactRiemannianSurface, OrientableClosedSurface, CompactSurfaceWithBoundary, GeodesicPolygon, ConstCurvatureGeodesicPolygon, GeodesicTriangle, ChernGaussBonnetManifold, VectorFieldOnSurface, MorseFunctionOnSurface) and proves 61 theorems about curvature-topology relations, special surfaces, Girard's formula, Poincaré-Hopf, and Morse theory.",
+    "text": "An 810-line axiomatized treatment of smooth Gauss-Bonnet theory. The file defines 9 axiomatized structures (CompactRiemannianSurface, OrientableClosedSurface, CompactSurfaceWithBoundary, GeodesicPolygon, ConstCurvatureGeodesicPolygon, GeodesicTriangle, ChernGaussBonnetManifold, VectorFieldOnSurface, MorseFunctionOnSurface) and proves 61 theorems about curvature-topology relations, special surfaces, Girard's formula, Poincaré-Hopf, and Morse theory.",
     "proofStrategy": "**Architecture**: Axiomatize the main theorems as structure fields (since Riemannian geometry is not in Mathlib 4.26.0). Each structure carries the minimal set of axioms needed for the subsequent theorems:\n\n**CompactRiemannianSurface**: has `gauss_bonnet : totalCurvature = 2 * π * chi`. Theorems about curvature sign (positive → positive χ), topological invariance, and metric independence follow immediately.\n\n**OrientableClosedSurface**: extends CompactRiemannianSurface with `chi_genus : chi = 2 - 2 * genus`. Genus determination from curvature: genus = 1 - ∫K dA / (4π). Special cases: sphere (genus=0, ∫K=4π), torus (genus=1, ∫K=0), hyperbolic surfaces (genus≥2, ∫K<0).\n\n**Geodesic polygon/triangle structures**: encode the Gauss-Bonnet formula for bounded regions. Girard's formula (spherical excess = K·Area for geodesic triangles) follows as a one-line consequence.\n\n**Poincaré-Hopf**: VectorFieldOnSurface with `poincare_hopf : Σ index(v) = chi` enables index theory — the sum of vector field indices equals the Euler characteristic.\n\n**Morse theory**: MorseFunctionOnSurface encodes the Morse inequalities (Betti numbers ≤ critical point counts, and their alternating sum = χ).",
     "keyInsights": [
       "**Curvature determines topology**: The three cases partition closed surfaces: ∫K > 0 ⟺ genus 0 (sphere); ∫K = 0 ⟺ genus 1 (torus); ∫K < 0 ⟺ genus ≥ 2 (hyperbolic). All three follow immediately from the Gauss-Bonnet axiom and χ = 2 - 2g.",
@@ -219,40 +219,136 @@
       "mathContext": "Architecture choice: encode the seven structure-field axioms (gauss_bonnet, chi_genus, gauss_bonnet_boundary, gauss_bonnet_polygon, curvature_is_K_area, gauss_bonnet_triangle, poincare_hopf) as fields of typeclass-style structures. Future-proof: any Mathlib Riemannian-geometry refactor only has to prove the 7 axioms; all 60 downstream theorems remain stable."
     },
     {
-      "id": "sec-compact-riemannian",
-      "title": "Compact Riemannian Surface and Basic Gauss-Bonnet (L36–200)",
+      "id": "sec-surface-structures",
+      "title": "Axiomatized Surface Structures (L36–68)",
       "startLine": 36,
-      "endLine": 200,
-      "summary": "CompactRiemannianSurface: axiomatized with gauss_bonnet field. OrientableClosedSurface: extends with chi_genus. genus_from_total_curvature: genus = 1 - ∫K/(4π). positive/negative/zero_curvature_chi: curvature sign determines χ sign. sphere/torus/double_torus_total_curvature: ∫K = 4π, 0, -4π. positive_curvature_is_sphere, zero_curvature_is_torus, negative_curvature_high_genus.",
-      "mathContext": "The Gauss-Bonnet theorem partitions closed orientable surfaces into three topological types by curvature sign: $\\int K\\,dA > 0 \\iff g=0$ (sphere), $=0 \\iff g=1$ (torus), $<0 \\iff g\\geq 2$ (hyperbolic surfaces)."
+      "endLine": 68,
+      "summary": "`CompactRiemannianSurface` (L47): a compact orientable Riemannian 2-manifold without boundary, carrying fields `chi` (Euler characteristic), `totalCurvature` ($\\int_M K\\,dA$), `area > 0`, and the axiom field `gauss_bonnet : totalCurvature = 2\\pi\\chi`. `OrientableClosedSurface` (L63) extends it with a `genus` field and the axiom `chi_genus : chi = 2 - 2\\,genus`.",
+      "mathContext": "These two structures fix the axiomatic base: everything downstream is derived from the two structure-field axioms $\\int_M K\\,dA = 2\\pi\\chi$ (Gauss-Bonnet) and $\\chi = 2-2g$ (classification of closed orientable surfaces). No Riemannian geometry from Mathlib is used, so the file is self-contained modulo these assumptions."
     },
     {
-      "id": "sec-bonnet-chern-boundary",
-      "title": "Bonnet Diameter, Smooth/Discrete Agreement, Chern, and Boundary (L200–465)",
-      "startLine": 200,
-      "endLine": 465,
-      "summary": "averageCurvature definition + sphere_uniform_curvature, unit_sphere_curvature corollary; bonnet_genus_zero (positive lower-bound curvature ⇒ sphere, the diameter-comparison ancestor of the Bonnet-Myers theorem); smooth_discrete_agreement (smooth-Gauss-Bonnet $\\chi$ matches the discrete polyhedral-Euler $V - E + F$, plus sphere/torus/double-torus instances); ChernGaussBonnetManifold (L331): Chern's 1944 intrinsic generalization to all even-dimensional manifolds via the Pfaffian of the curvature 2-form on the orthonormal frame bundle; CompactSurfaceWithBoundary (L452): boundary form $\\int_M K\\,dA + \\int_{\\partial M} \\kappa_g\\,ds = 2\\pi\\chi$.",
-      "mathContext": "Two technical highlights here: (1) Chern's intrinsic generalization $\\int_M \\mathrm{Pf}(\\Omega) = (2\\pi)^n \\chi(M)$ on $2n$-manifolds, which removes the embedding dependency of Bonnet's 1848 proof; (2) the boundary Gauss-Bonnet $\\int_M K\\,dA + \\int_{\\partial M} \\kappa_g\\,ds = 2\\pi\\chi(M)$ where $\\kappa_g$ is geodesic curvature — the form needed for the polygonal sub-section."
+      "id": "sec-curvature-determines-genus",
+      "title": "Total Curvature Determines Genus (L69–87)",
+      "startLine": 69,
+      "endLine": 87,
+      "summary": "`total_curvature_genus` (L70): $\\int_M K\\,dA = 4\\pi(1-g)$. `genus_from_total_curvature` (L77): inverts this to $g = 1 - \\dfrac{\\int_M K\\,dA}{4\\pi}$, recovering the genus uniquely from the integrated curvature.",
+      "mathContext": "Combining $\\int K\\,dA = 2\\pi\\chi$ with $\\chi = 2-2g$ gives $\\int K\\,dA = 4\\pi(1-g)$ — a purely topological quantity read off from a metric integral, the sharpest expression of Gauss's *Theorema Egregium* at global scale."
     },
     {
-      "id": "sec-geodesic-polygon",
-      "title": "Geodesic Polygons, Triangles, and Girard's Formula (L465–620)",
-      "startLine": 465,
-      "endLine": 620,
-      "summary": "GeodesicPolygon: gauss_bonnet_polygon field (∫K + Σθ_ext = 2π). ConstCurvatureGeodesicPolygon: curvature_is_K_area. GeodesicTriangle: gauss_bonnet_triangle (K·Area = α+β+γ−π). girard_formula: Area = (α+β+γ−π)/K. interior_angle_sum: Σθ_int = (n-2)π + K·Area. spherical_triangle theorems.",
-      "mathContext": "Girard's theorem (1629): the area of a spherical triangle equals its angular excess $\\alpha+\\beta+\\gamma-\\pi$ (on the unit sphere). For a Euclidean triangle (K=0), $\\alpha+\\beta+\\gamma = \\pi$. For a hyperbolic triangle (K=-1), $\\alpha+\\beta+\\gamma < \\pi$."
+      "id": "sec-gauss-bonnet-invariance",
+      "title": "Gauss-Bonnet Theorem and Metric Invariance (L88–110)",
+      "startLine": 88,
+      "endLine": 110,
+      "summary": "`gauss_bonnet_theorem` (L89): the headline $\\int_M K\\,dA = 2\\pi\\chi(M)$. `total_curvature_topological_invariant` (L95): two surfaces with equal $\\chi$ have equal total curvature. `curvature_metric_independent` (L102): total curvature is independent of the chosen Riemannian metric.",
+      "mathContext": "The metric-independence corollary is the conceptual payload: although $K$ depends heavily on the metric, its integral is a homotopy invariant. This is the prototype of every later index/characteristic-class theorem in the file."
+    },
+    {
+      "id": "sec-curvature-sign-chi",
+      "title": "Curvature Sign Determines Euler Characteristic (L111–138)",
+      "startLine": 111,
+      "endLine": 138,
+      "summary": "`positive_curvature_positive_chi` (L112), `negative_curvature_negative_chi` (L120), `zero_curvature_zero_chi` (L128): the sign of $\\int_M K\\,dA$ matches the sign of $\\chi(M)$, partitioning closed orientable surfaces into the three sign regimes.",
+      "mathContext": "The Gauss-Bonnet theorem trichotomizes closed orientable surfaces by curvature sign: $\\int K\\,dA > 0 \\iff \\chi > 0$ (sphere), $=0 \\iff \\chi = 0$ (torus), $<0 \\iff \\chi < 0$ (higher genus)."
+    },
+    {
+      "id": "sec-special-surfaces",
+      "title": "Total Curvature of Sphere, Torus, and Genus-g (L139–173)",
+      "startLine": 139,
+      "endLine": 173,
+      "summary": "`sphere_total_curvature` (L140): $\\int_{S^2} K\\,dA = 4\\pi$. `torus_total_curvature` (L148): $0$. `double_torus_total_curvature` (L156): $-4\\pi$. `genus_g_total_curvature` (L165): general $4\\pi(1-g)$.",
+      "mathContext": "These are the canonical instances $g = 0, 1, 2, g$ of $\\int K\\,dA = 4\\pi(1-g)$, exhibiting the arithmetic-progression spacing $4\\pi, 0, -4\\pi, \\dots$ of total curvature across the genus tower."
+    },
+    {
+      "id": "sec-curvature-forces-genus",
+      "title": "Curvature Sign Forces the Topological Type (L174–201)",
+      "startLine": 174,
+      "endLine": 201,
+      "summary": "`positive_curvature_is_sphere` (L175): $\\int K\\,dA > 0 \\Rightarrow g=0$. `zero_curvature_is_torus` (L182): $=0 \\Rightarrow g=1$. `negative_curvature_high_genus` (L189): $<0 \\Rightarrow g \\geq 2$.",
+      "mathContext": "The converse direction of the trichotomy: the integrated curvature does not merely correlate with topology, it *determines* the diffeomorphism type of a closed orientable surface (which is fixed by its genus alone)."
+    },
+    {
+      "id": "sec-average-curvature",
+      "title": "Average Gaussian Curvature (L202–239)",
+      "startLine": 202,
+      "endLine": 239,
+      "summary": "`averageCurvature` (L203): $K_{\\mathrm{avg}} = \\int_M K\\,dA / \\mathrm{Area}(M)$. `average_curvature_formula` (L207), `sphere_uniform_curvature` (L212), `unit_sphere_curvature` (L219): unit $S^2$ has $K \\equiv 1$. `torus_zero_average_curvature` (L229): a torus averages to $0$.",
+      "mathContext": "Average curvature $K_{\\mathrm{avg}} = 4\\pi(1-g)/\\mathrm{Area}$ separates the intrinsic (topological) numerator from the metric-dependent (area) denominator, quantifying how genus constrains the mean bending of a surface at fixed area."
+    },
+    {
+      "id": "sec-pointwise-bonnet",
+      "title": "Pointwise Curvature Constraints and Bonnet's Theorem (L240–282)",
+      "startLine": 240,
+      "endLine": 282,
+      "summary": "`everywhere_positive_curvature_is_sphere` (L242), `everywhere_negative_curvature_high_genus` (L247), `everywhere_zero_curvature_is_torus` (L252): pointwise sign hypotheses on $K$ pin the genus. `area_bound_positive_curvature` (L262) and `bonnet_genus_zero` (L274): a uniform positive lower bound $K \\geq K_{\\min} > 0$ forces $g = 0$ and bounds the area.",
+      "mathContext": "`bonnet_genus_zero` is the topological shadow of the Bonnet–Myers theorem: a positive curvature *lower bound* (not just positive integral) compactifies the surface into a sphere and caps its diameter/area, the diameter-comparison ancestor of Ricci-curvature rigidity."
+    },
+    {
+      "id": "sec-discrete-agreement",
+      "title": "Agreement with Discrete Gauss-Bonnet (L283–318)",
+      "startLine": 283,
+      "endLine": 318,
+      "summary": "`smooth_discrete_agreement` (L297): the smooth invariant $2\\pi\\chi$ equals the discrete polyhedral angle-defect sum $\\sum_v \\delta(v) = 2\\pi\\chi$ proved in `EulerPolyhedralOQ02.lean`. `sphere_agreement`, `torus_agreement`, `double_torus_agreement` (L304–312): both give $4\\pi, 0, -4\\pi$.",
+      "mathContext": "The smooth $\\int K\\,dA$ is the refinement limit of the discrete angle defect $\\sum_v \\delta(v)$: as a triangulation of $M$ is refined, vertex defects concentrate into the continuous curvature density, so smooth and polyhedral Gauss-Bonnet are two faces of one invariant."
+    },
+    {
+      "id": "sec-chern-gauss-bonnet",
+      "title": "Chern-Gauss-Bonnet Generalization and χ Consequences (L319–387)",
+      "startLine": 319,
+      "endLine": 387,
+      "summary": "`ChernGaussBonnetManifold` (L331): even-dimensional generalization $\\int_M \\mathrm{Pf}(\\Omega) = (2\\pi)^n\\chi(M)$. `chern_gb_surface` (L344): reduces to classical Gauss-Bonnet when $\\dim = 2$. `sphere_chi_two` (L357), `torus_chi_zero` (L362), `chi_from_genus` (L368), `same_genus_same_chi` (L374), `same_genus_same_curvature` (L380).",
+      "mathContext": "Chern's 1944 intrinsic proof $\\int_M \\mathrm{Pf}(\\Omega) = (2\\pi)^n\\chi(M)$ on $2n$-manifolds removes the embedding dependence of Bonnet's 1848 argument via the Pfaffian of the curvature 2-form on the orthonormal frame bundle — the birth of Chern–Weil theory and characteristic classes."
+    },
+    {
+      "id": "sec-concrete-examples",
+      "title": "Concrete Example Surfaces (L388–437)",
+      "startLine": 388,
+      "endLine": 437,
+      "summary": "Explicit constructions: `standardSphere` (L390, genus 0, area $4\\pi$, total curvature $4\\pi$), `flatTorus a b` (L400, genus 1, area $ab$, curvature $0$), `hyperbolicGenus2` (L410, genus 2, area $4\\pi$, curvature $-4\\pi$). Verifications `standardSphere_avg_curvature` (L420), `flatTorus_avg_curvature` (L425), `hyperbolicGenus2_avg_curvature` (L430).",
+      "mathContext": "Instantiating the abstract structure with the three archetypal surfaces confirms the machinery is non-vacuous and reproduces the classical curvature integrals $4\\pi(1-g)$ for $g = 0, 1, 2$."
+    },
+    {
+      "id": "sec-boundary-polygons",
+      "title": "Gauss-Bonnet with Boundary and Geodesic Polygons (L438–515)",
+      "startLine": 438,
+      "endLine": 515,
+      "summary": "`CompactSurfaceWithBoundary` (L452): boundary form $\\int_M K\\,dA + \\int_{\\partial M}\\kappa_g\\,ds = 2\\pi\\chi$. `closed_surface_from_boundary` (L466). `GeodesicPolygon` (L473): `gauss_bonnet_polygon` axiom $\\int K + \\sum \\theta_{\\mathrm{ext}} = 2\\pi$. `ConstCurvatureGeodesicPolygon` (L490), `const_curv_polygon_formula` (L497), `interior_angle_sum` (L505): $\\sum \\theta_{\\mathrm{int}} = (n-2)\\pi + K\\cdot\\mathrm{Area}$.",
+      "mathContext": "The boundary term $\\int_{\\partial M}\\kappa_g\\,ds$ (geodesic curvature of the boundary) is what makes Gauss-Bonnet apply to surfaces-with-boundary and geodesic polygons; setting geodesic edges ($\\kappa_g = 0$) collapses it to the angle-excess formulas of the next section."
+    },
+    {
+      "id": "sec-geodesic-triangles-girard",
+      "title": "Geodesic Triangles and Girard's Formula (L516–616)",
+      "startLine": 516,
+      "endLine": 616,
+      "summary": "`GeodesicTriangle` (L525): `gauss_bonnet_triangle` axiom $K\\cdot\\mathrm{Area} = \\alpha+\\beta+\\gamma-\\pi$. `girard_formula` (L547): $\\mathrm{Area} = (\\alpha+\\beta+\\gamma-\\pi)/K$. `unit_sphere_triangle_area` (L554), `positive_curvature_angle_excess` (L561), `flat_angle_sum_pi` (L567), `negative_curvature_angle_deficit` (L574), `hemisphere_area` (L582), `hyperbolic_triangle_area` (L592), `hyperbolic_triangle_area_bound` (L600), `hyperbolic_ideal_triangle_limit` (L608).",
+      "mathContext": "Girard's theorem (1629): a spherical triangle's area equals its angular excess $\\alpha+\\beta+\\gamma-\\pi$. Sign of $K$ dictates the regime — excess ($K>0$), exactly $\\pi$ ($K=0$, Euclidean), deficit ($K<0$, hyperbolic) — with ideal hyperbolic triangles approaching the maximal area $\\pi/|K|$."
     },
     {
       "id": "sec-poincare-hopf",
-      "title": "Poincaré-Hopf Index Theorem and Morse Theory (L620–786)",
-      "startLine": 620,
-      "endLine": 786,
-      "summary": "VectorFieldOnSurface: poincare_hopf field (Σ index(v) = χ). Applications: hairy_ball_type (no non-vanishing field on sphere), torus_vector_field_index (total index 0), euler_char_from_vector_field. MorseFunctionOnSurface: Morse inequalities (β_k ≤ c_k) and Euler characteristic formula (Σ(-1)^k c_k = χ).",
-      "mathContext": "Poincaré-Hopf: the sum of indices of all singular points of a smooth vector field on a compact manifold equals the Euler characteristic. For the sphere ($\\chi=2$), every vector field must have total index 2. The 'hairy ball theorem' follows: no non-vanishing smooth vector field exists on $S^2$."
+      "title": "Poincaré-Hopf Index Theorem (L617–714)",
+      "startLine": 617,
+      "endLine": 714,
+      "summary": "`VectorFieldOnSurface` (L638): `poincare_hopf` axiom $\\sum_i \\mathrm{index}(z_i) = \\chi$. `totalIndex` (L651), `noZeros` (L654), `nonvanishing_index` (L658), `hairy_ball` (L668), `sphere_no_nonvanishing_field` (L675), `torus_admits_nonvanishing_field` (L683), `positive_chi_has_zeros` (L689), `negative_chi_has_zeros` (L698), `nonvanishing_iff_chi_zero` (L707).",
+      "mathContext": "Poincaré-Hopf: the summed indices of the zeros of any smooth vector field on a compact surface equal $\\chi(M)$. The hairy-ball theorem is the case $\\chi(S^2)=2\\neq0$; `nonvanishing_iff_chi_zero` shows a nowhere-vanishing field exists iff $\\chi = 0$, i.e. only on the torus."
+    },
+    {
+      "id": "sec-morse-theory",
+      "title": "Morse Theory Connection (L715–775)",
+      "startLine": 715,
+      "endLine": 775,
+      "summary": "`MorseFunctionOnSurface` (L725): critical points weighted by index reproduce $\\chi$. `sphere_morse_critical_points` (L738), `sphere_height_function` (L746), `torus_morse_lower_bound` (L751), `torus_standard_morse` (L759), `genus_g_morse_bound` (L764): a Morse function on a genus-$g$ surface has at least $2g+2$ critical points.",
+      "mathContext": "The Morse relation $\\sum_k (-1)^k c_k = \\chi$ and the weak Morse inequalities $c_k \\geq \\beta_k$ give a third computation of the Euler characteristic — from the critical points of a generic height function — tying curvature (Gauss-Bonnet), vector fields (Poincaré-Hopf), and functions (Morse) to one topological invariant."
+    },
+    {
+      "id": "sec-summary",
+      "title": "Summary of the Formalization (L776–810)",
+      "startLine": 776,
+      "endLine": 810,
+      "summary": "Closing docstring recapping the smooth Gauss-Bonnet formalization: the 9 axiomatized structures, the ~60 derived consequences spanning genus determination, curvature-topology duality, Girard's formula, boundary Gauss-Bonnet, Poincaré-Hopf, and Morse theory, and the `end SmoothGaussBonnet` namespace close (L810).",
+      "mathContext": "The three theorems Gauss-Bonnet, Poincaré-Hopf, and Morse each independently compute $\\chi(M)$ — via curvature, vector-field zeros, and critical points respectively — an early appearance of the unity later formalized by the Atiyah-Singer index theorem."
     }
   ],
   "conclusion": {
-    "summary": "A 786-line axiomatized formalization of smooth Gauss-Bonnet theory. The 9 structures encode 9 mathematical axioms (the main theorems that require Riemannian geometry not yet in Mathlib). The 60 consequences cover genus determination, curvature-topology duality, Girard's formula, Gauss-Bonnet with boundary, Poincaré-Hopf, and Morse inequalities.",
+    "summary": "An 810-line axiomatized formalization of smooth Gauss-Bonnet theory. The 9 structures encode 9 mathematical axioms (the main theorems that require Riemannian geometry not yet in Mathlib). The 60 consequences cover genus determination, curvature-topology duality, Girard's formula, Gauss-Bonnet with boundary, Poincaré-Hopf, and Morse inequalities.",
     "implications": "The structural axiomatization provides a clean interface for Gauss-Bonnet consequences: any future Mathlib formalization of Riemannian geometry can simply prove that compact Riemannian surfaces satisfy the `CompactRiemannianSurface` axioms, and all 61 theorems here become available immediately. This is a common 'future-proof' strategy for formalizing deep theorems.",
     "openQuestions": [
       "Formalize Riemannian metrics in Lean 4 to prove the gauss_bonnet axiom from first principles (requires: tangent bundles, covariant derivatives, Gaussian curvature formula, Stokes' theorem on manifolds)",


### PR DESCRIPTION
## Enrichment: euler-polyhedral-oq-02-oq-01 (Smooth Gauss-Bonnet)

**Section-coverage re-anchor.** This entry's `sections` array lumped the
810-line `EulerPolyhedralOQ02OQ01.lean` into just **5 coarse blocks** — one
spanning 265 lines (L200–465) mixing Bonnet, Chern, discrete agreement, and
boundary — and stopped at L786, leaving the closing summary docstring
(L776–810) entirely uncovered. Its sibling entry
`euler-polyhedral-formula-oq-02-oq-01`, sharing the same Lean file, already
resolves it into 19 fine sections, confirming the coarse map is stale
under-coverage rather than a deliberate presentation.

### Changes
- Re-anchored to **17 per-topic sections** following the file's actual `/-`
  banners (L40, 283, 319, 438, 516, 617, 715, 776) and declaration groupings.
  Sections are contiguous and now cover **L1–810** (verified: no gaps/overlaps).
- Each new section carries an accurate `summary` (naming the theorems/structures
  it contains with line numbers) and a `mathContext` giving the mathematical
  substance (Theorema Egregium, curvature-sign trichotomy, Bonnet–Myers shadow,
  Chern–Weil/Pfaffian, Girard's excess, Poincaré-Hopf, Morse relation).
- Corrected two stale "786-line" prose references to "810-line" (`meta.lineCount`
  already reads 810).

No `status`/`badge`/`axiomCount` changes — the 9 structure-encoded axioms and
`axiomatized` status are accurate and preserved. `meta.json` is 35 KB (well
under the 60 KB cap).
