### PR TITLE
audit(gram-linear-independence-iff-oq001): clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31604,6 +31604,12 @@
       "lastAudited": "2026-07-21T13:59:50Z",
       "result": "clean",
       "issues": []
+    },
+    "gram-linear-independence-iff-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T14:08:11Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — clean

**Proof**: gram-linear-independence-iff-oq001 — Hadamard's Matrix Inequality: Row Form and the Uniform n^(n/2) Determinant Bound

Verified via `LAKE_UNSAFE=1 lake build` (embedded `#print axioms`):
- **axiomCount 0** — both main theorems depend only on `propext, Classical.choice, Quot.sound` (no custom axioms, no `sorryAx`, no `native_decide`/`ofReduceBool`)
- **sorries 0**, **theoremCount 8** (`col_apply` + 7 mainTheorems), **definitionCount 1** (`col`)
- **badge `original`** legitimate: row form and uniform n^(n/2) bound are genuinely absent from Mathlib, built on the author's own grandparent entry (`hadamard_inequality_euclidean`). Mathlib determinant lemmas (`det_transpose`, `det_conjTranspose`) honestly disclosed as tools, not credited as core work.
- Descriptions/leanTypes match actual declarations; dependency disclosed across overview, prerequisites, crossReferences.

No mismatches. Tracker updated.

---
Discovered during gallery integrity audit.