### PR TITLE
Research: erdos-64-wip-01 — connected min-degree-2 graphs contain a cycle (3 axiom-free lemmas)

### DIFF
--- a/proofs/Proofs/Erdos64Problem.lean
+++ b/proofs/Proofs/Erdos64Problem.lean
@@ -186,7 +186,8 @@ theorem connected_hasMinDegree_two_not_isAcyclic
   have h2 : 2 ≤ G.minDegree := by
     apply SimpleGraph.le_minDegree_of_forall_le_degree
     intro v
-    simpa [SimpleGraph.degree] using hdeg v
+    rw [← SimpleGraph.card_neighborFinset_eq_degree]
+    exact hdeg v
   omega
 
 /-- A nontrivial connected graph with minimum degree at least `2` contains a cycle
@@ -196,10 +197,9 @@ theorem connected_hasMinDegree_two_exists_cycle
     (G : SimpleGraph W) [DecidableRel G.Adj]
     (hconn : G.Connected) (hdeg : HasMinDegree G 2) :
     ∃ (v : W) (c : G.Walk v v), c.IsCycle := by
-  have h := connected_hasMinDegree_two_not_isAcyclic G hconn hdeg
-  unfold SimpleGraph.IsAcyclic at h
-  push_neg at h
-  exact h
+  by_contra hcon
+  exact connected_hasMinDegree_two_not_isAcyclic G hconn hdeg
+    (fun v c hc => hcon ⟨v, c, hc⟩)
 
 /-- The Problem-64 hypothesis (minimum degree ≥ `3`) forces at least one cycle, for
 connected graphs. The **open** content of Problem 64 is that some such cycle can be

--- a/proofs/Proofs/Erdos64Problem.lean
+++ b/proofs/Proofs/Erdos64Problem.lean
@@ -158,6 +158,69 @@ def degree_3_conjecture : Prop :=
 
 -- Note: degree_3_conjecture and erdos_64_conjecture are semantically identical.
 
+/- ## Cycle Existence from Minimum Degree (foundational, machine-checked)
+
+These lemmas establish the *base fact* that underlies Problem 64: a graph with
+minimum degree ≥ 2 must contain **some** cycle. Problem 64 asks the far stronger
+(open) question of whether some cycle has length a power of two; the necessary
+elementary precondition — that a cycle exists at all — is proved here in full,
+axiom-free.
+
+The mechanism is the "a tree has a leaf" phenomenon: a finite nontrivial tree
+always has a vertex of degree exactly one (`SimpleGraph.IsTree.minDegree_eq_one_of_nontrivial`),
+so a connected graph in which *every* vertex has degree ≥ 2 cannot be a tree,
+hence (being connected) cannot be acyclic. `SimpleGraph.IsAcyclic` unfolds to
+"no closed walk is a cycle", so its negation hands back an explicit cycle. -/
+
+/-- A nontrivial connected graph with minimum degree at least `2` is **not acyclic**:
+if it were, connectivity would make it a tree, and a nontrivial tree has a vertex
+of degree `1`, contradicting the degree bound. -/
+theorem connected_hasMinDegree_two_not_isAcyclic
+    {W : Type*} [Fintype W] [Nontrivial W]
+    (G : SimpleGraph W) [DecidableRel G.Adj]
+    (hconn : G.Connected) (hdeg : HasMinDegree G 2) :
+    ¬ G.IsAcyclic := by
+  intro hacyc
+  have htree : G.IsTree := ⟨hconn, hacyc⟩
+  have h1 : G.minDegree = 1 := htree.minDegree_eq_one_of_nontrivial
+  have h2 : 2 ≤ G.minDegree := by
+    apply SimpleGraph.le_minDegree_of_forall_le_degree
+    intro v
+    simpa [SimpleGraph.degree] using hdeg v
+  omega
+
+/-- A nontrivial connected graph with minimum degree at least `2` contains a cycle
+(an explicit closed walk that is a `SimpleGraph.Walk.IsCycle`). -/
+theorem connected_hasMinDegree_two_exists_cycle
+    {W : Type*} [Fintype W] [Nontrivial W]
+    (G : SimpleGraph W) [DecidableRel G.Adj]
+    (hconn : G.Connected) (hdeg : HasMinDegree G 2) :
+    ∃ (v : W) (c : G.Walk v v), c.IsCycle := by
+  have h := connected_hasMinDegree_two_not_isAcyclic G hconn hdeg
+  unfold SimpleGraph.IsAcyclic at h
+  push_neg at h
+  exact h
+
+/-- The Problem-64 hypothesis (minimum degree ≥ `3`) forces at least one cycle, for
+connected graphs. The **open** content of Problem 64 is that some such cycle can be
+taken to have length `2^k`; this lemma isolates the elementary part (a cycle exists),
+which is a strict weakening of the conjecture and does not resolve it. -/
+theorem connected_hasMinDegree_three_exists_cycle
+    {W : Type*} [Fintype W] [Nontrivial W]
+    (G : SimpleGraph W) [DecidableRel G.Adj]
+    (hconn : G.Connected) (hdeg : HasMinDegree G 3) :
+    ∃ (v : W) (c : G.Walk v v), c.IsCycle :=
+  connected_hasMinDegree_two_exists_cycle G hconn
+    (fun v => le_trans (by norm_num) (hdeg v))
+
+/- **Remaining step toward the finite-graph statement.** The above covers connected
+graphs. For an arbitrary finite graph with minimum degree ≥ 2, pass to the connected
+component of any vertex: degrees are preserved inside a component (every neighbour of
+a vertex lies in its own component), the component is connected and nontrivial (the
+vertex has ≥ 2 neighbours), so the connected case yields a cycle there, which lifts to
+`G` along the induced-subgraph embedding. Formalizing this needs the component-degree
+preservation lemma and `Walk.IsCycle` transport through `SimpleGraph.induce`. -/
+
 /- ## Known Cycle Results -/
 
 /- 

--- a/research/problems/erdos-64-wip-01/knowledge.md
+++ b/research/problems/erdos-64-wip-01/knowledge.md
@@ -19,3 +19,56 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session 2026-07-21 (researcher-1) — connected min-degree-2 graphs contain a cycle
+
+**Mode**: FRESH (EMPTY greenfield node, phase OBSERVE→ACT). **Outcome**: progress
+(infrastructure, verified 0-axiom).
+
+Erdős #64 ("does every finite graph with min degree ≥ 3 contain a cycle of length
+2^k, k≥2?") is OPEN ($1000). The power-of-two-LENGTH content is deep (Liu–Montgomery
+scale). This session proved the *elementary precondition* that any such cycle presumes —
+that a cycle exists at all — for the connected case. Added 3 axiom-free theorems to
+`Erdos85`-style toolkit reuse in `Erdos64Problem.lean`:
+
+- `connected_hasMinDegree_two_not_isAcyclic` — nontrivial connected `G`, `HasMinDegree G 2`
+  ⟹ `¬ G.IsAcyclic`. Proof: connected + acyclic ⟹ `G.IsTree`; a nontrivial tree has
+  `minDegree = 1` (`SimpleGraph.IsTree.minDegree_eq_one_of_nontrivial`, the "tree has a
+  leaf" fact), contradicting `2 ≤ G.minDegree` (from `le_minDegree_of_forall_le_degree`).
+- `connected_hasMinDegree_two_exists_cycle` — same hypotheses ⟹ `∃ v (c : G.Walk v v),
+  c.IsCycle`. `IsAcyclic` unfolds to "no closed walk is a cycle", so its negation is a
+  concrete cycle (`by_contra` + rebuild the `IsAcyclic` witness from `¬∃`).
+- `connected_hasMinDegree_three_exists_cycle` — the Problem-64 degree-3 hypothesis
+  (connected) forces a cycle (`3 ≥ 2` weakening).
+
+### Lean gotchas (recorded)
+- `simp [SimpleGraph.degree]` to turn `2 ≤ G.degree v` into `2 ≤ (neighborFinset v).card`
+  **blows `maxRecDepth`**. Use `rw [← SimpleGraph.card_neighborFinset_eq_degree]` instead
+  (clean, no recursion).
+- `push_neg` is **deprecated** in v4.31 (warns, suggests `push Not`). Avoided entirely:
+  `by_contra hcon; exact not_isAcyclic … (fun v c hc => hcon ⟨v,c,hc⟩)` reconstructs the
+  `IsAcyclic` witness directly.
+- `SimpleGraph.IsTree` is a structure `extends connected : G.Connected` with field
+  `isAcyclic`; build it with the anonymous constructor `⟨hconn, hacyc⟩`.
+
+### Verification
+Host-verified (`lake env lean`, Lean v4.31.0, exit 0, no warnings). `#print axioms` for all
+three = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`.
+File 205→268 lines, theoremCount 3→6.
+
+### Mathlib gaps found
+- Only the CONNECTED leaf lemma exists (`IsTree.minDegree_eq_one_of_nontrivial`); no general
+  forest leaf lemma, and no forest edge-count bound `#edges ≤ n−1` (only `IsTree.card_edgeFinset`).
+- No pre-existing `minDegree ⟹ contains-cycle` result in Mathlib — this lemma is novel.
+
+### Next
+- **General finite-graph case** (the honest remaining step): pass to the connected component
+  of any vertex (degrees preserved inside a component ⟹ min degree ≥ 2 survives; component is
+  connected + nontrivial), apply the connected lemma, lift the cycle to `G` through the
+  induced-subgraph embedding (`Walk.IsCycle` transport via `SimpleGraph.induce`). Needs the
+  component-degree-preservation lemma.
+- Bridge the file's custom `ContainsCycleLength` (`Fin.succMod` encoding) to Mathlib
+  `Walk.IsCycle` so cycle-*length* statements become expressible.
+- The open core (some cycle of length `2^k`) stays deep/imported (Liu–Montgomery).

--- a/src/data/proofs/erdos-64/meta.json
+++ b/src/data/proofs/erdos-64/meta.json
@@ -270,9 +270,9 @@
       "Finset"
     ],
     "namespace": "Erdos64",
-    "lineCount": 205,
+    "lineCount": 268,
     "axiomCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 6,
     "definitionCount": 12,
     "path": "Proofs/Erdos64Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-64-wip-01.json
+++ b/src/data/research/problems/erdos-64-wip-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-64-wip-01",
   "title": "Complete the Lean Formalization of Erdős #64 (Power-of-Two Cycles in Min-Degree-3 Graphs)",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -31,11 +31,25 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "PROGRESS (infrastructure): proved the elementary base fact — connected min-degree->=2 graphs contain a cycle (3 axiom-free lemmas). The open power-of-two-length refinement is untouched.",
+    "builtItems": [
+      "connected_hasMinDegree_two_not_isAcyclic (Erdos64Problem.lean): nontrivial connected graph, HasMinDegree 2 => ¬IsAcyclic. Axiom-free.",
+      "connected_hasMinDegree_two_exists_cycle (Erdos64Problem.lean): same hyp => ∃ v (c : Walk v v), c.IsCycle. Axiom-free.",
+      "connected_hasMinDegree_three_exists_cycle (Erdos64Problem.lean): the Problem-64 degree-3 hypothesis (connected) forces a cycle. Axiom-free."
+    ],
+    "insights": [
+      "A finite nontrivial TREE has a leaf (degree-1 vertex): Mathlib SimpleGraph.IsTree.minDegree_eq_one_of_nontrivial. Hence a connected graph with min degree >= 2 cannot be a tree, so cannot be acyclic — the elementary base fact under Erdos #64.",
+      "SimpleGraph.IsAcyclic unfolds to (forall closed walk, not IsCycle); its negation directly yields an explicit Walk.IsCycle, so ¬IsAcyclic is packaged as a concrete cycle."
+    ],
+    "mathlibGaps": [
+      "No general (disconnected/forest) leaf lemma: Mathlib only has IsTree.minDegree_eq_one_of_nontrivial (connected). A forest edge-count bound #edges <= n-1 is also absent (only IsTree.card_edgeFinset).",
+      "No pre-existing minDegree => contains-cycle result in Mathlib SimpleGraph."
+    ],
+    "nextSteps": [
+      "General finite-graph case: pass to the connected component of any vertex (degrees preserved inside a component), apply the connected lemma there, lift the cycle to G via the induced-subgraph embedding (Walk.IsCycle transport through SimpleGraph.induce). Needs component-degree-preservation lemma.",
+      "Bridge the file's custom ContainsCycleLength (Fin.succMod encoding) to Mathlib Walk.IsCycle so cycle-LENGTH statements become expressible.",
+      "The open core (some cycle has length 2^k) requires Liu-Montgomery-scale machinery; out of reach elementarily."
+    ],
     "markdown": "# Knowledge Base: erdos-64-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [


### PR DESCRIPTION
## Erdős Problem #64 — cycle existence from minimum degree (foundational)

**Problem #64** (OPEN, $1000): does every finite graph with minimum degree ≥ 3 contain a cycle of length `2^k` for some `k ≥ 2`? The power-of-two-**length** content is deep (Liu–Montgomery-scale) and untouched here.

This PR proves the *elementary precondition* that any such cycle presumes — that a cycle exists at all — for the **connected** case. Three axiom-free theorems added to `Erdos64Problem.lean`:

- `connected_hasMinDegree_two_not_isAcyclic` — nontrivial connected `G` with `HasMinDegree G 2` ⟹ `¬ G.IsAcyclic`. Connected + acyclic would make `G` a tree, but a nontrivial tree has a leaf (`SimpleGraph.IsTree.minDegree_eq_one_of_nontrivial` gives `minDegree = 1`), contradicting `2 ≤ minDegree`.
- `connected_hasMinDegree_two_exists_cycle` — same hypotheses ⟹ `∃ v (c : G.Walk v v), c.IsCycle` (an explicit cycle, since `IsAcyclic` is "no closed walk is a cycle").
- `connected_hasMinDegree_three_exists_cycle` — the Problem-64 degree-3 hypothesis (connected) forces a cycle.

### Honesty / scope
- This is **infrastructure**, a strict weakening of the conjecture (existence of *some* cycle, not a power-of-two-length one). It does **not** resolve #64.
- Covers **connected** graphs only. The general finite-graph reduction (pass to a connected component, lift the cycle through the induced-subgraph embedding) is documented in-file and in the tracker as the next step — it needs a component-degree-preservation lemma absent from Mathlib.
- No pre-existing `minDegree ⟹ contains-cycle` lemma exists in Mathlib, so these are novel.

### Verification
Host-verified (`lake env lean`, Lean v4.31.0, exit 0, no warnings). `#print axioms` for all three = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. File 205→268 lines, theoremCount 3→6, axiomCount 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
