### PR TITLE
Audit: hall-marriage-theorem-oq001 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31616,6 +31616,12 @@
       "lastAudited": "2026-07-21T14:11:09Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "hall-marriage-theorem-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T14:16:31Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean**.

**Proof**: hall-marriage-theorem-oq001

**Verified against source** (`proofs/Proofs/HallMarriageTheoremOQ01OQ01OQ01OQ01.lean`, 127 lines):
- 4 theorems + 1 definition — matches `theoremCount: 4`, `definitionCount: 1`
- 0 sorries (only docstring mention) — matches `sorries: 0`
- 0 axioms — matches `axiomCount: 0`
- No native_decide (only docstring mention)
- `status: verified`, `badge: mathlib` — appropriate Tier B; description honestly credits Mathlib's `card_mul_le_card_mul` and `all_card_le_biUnion_card_iff_exists_injective`
- Parent-entry decls consumed (`deficiency_eq_zero_iff`, `maxTransversal_eq_card_of_deficiency_zero`, `transversalSizes`) all verified real in `HallMarriageTheoremOQ01OQ01OQ01.lean` — no phantom references

No integrity issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)