### PR TITLE
Audit: hilbert-10-oq001 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31622,6 +31622,12 @@
       "lastAudited": "2026-07-21T14:16:31Z",
       "result": "clean",
       "issues": []
+    },
+    "hilbert-10-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T14:18:10Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean**.

**Proof**: hilbert-10-oq001 (`Proofs/Hilbert10OQ04OQ03OQ01OQ01.lean`, 113 lines)

**Verified against source**:
- 4 theorems, 0 definitions — matches `theoremCount: 4`, `definitionCount: 0`
- 0 sorries, 0 axioms — matches meta
- No native_decide. The two `by decide` calls are kernel `decide` inside anonymous `example`s (sanity checks 3x+5y=1, 6x+4y=10) — trust-neutral, excluded from theoremCount, do not introduce `Lean.ofReduceBool`. `assumptions` claim of "no native_decide" is accurate.
- `badge: original` defensible — `vecGcd_eq_finset_gcd` is a genuine original bridge lemma (induction identifying the parent's hand-rolled fold with Mathlib's `Finset.gcd`); all Mathlib lemmas used are disclosed in `mathlibDependencies`, and `originalContributions` are scoped to what this file proves. Forward direction honestly credited to the parent's `exists_vec_combo`.
- Title is qualified ("The Constructive Bézout Solver Matches Mathlib's Finset.gcd") — does **not** overclaim a solution to Hilbert's 10th problem despite the famous name (HIGH-risk feature handled correctly).
- Parent decls `vecGcd` and `exists_vec_combo` verified real in `Hilbert10OQ04OQ03OQ01.lean` — no phantom references.

No integrity issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)