### PR TITLE
Audit: hilbert-10-oq002 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31628,6 +31628,12 @@
       "lastAudited": "2026-07-21T14:18:10Z",
       "result": "clean",
       "issues": []
+    },
+    "hilbert-10-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T14:21:11Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean**.

**Proof**: hilbert-10-oq002 (`Proofs/Hilbert10OQ04OQ03OQ02OQ01.lean`, 149 lines)

- 3 theorems + 1 def (`decidableSolvableOfSmith` Decidable instance) — matches `theoremCount: 3`, `definitionCount: 1`
- 0 sorries, 0 axioms, no native_decide — matches meta
- Genuine Tier-A original work: diagonal decoupling, unimodular reduction, and composed invariant-factor criterion all proved from scratch.
- **No overclaim despite "Deciding Linear Systems" / Hilbert-10 framing**: the `assumptions` field and module docstring prominently scope the results to *square* systems and take the Smith normal form (U, V, d with U·A·V = diagonal d) as GIVEN DATA — producing the SNF is explicitly flagged as the one remaining gap Mathlib does not expose. Every theorem carries the SNF as explicit hypotheses; the `Decidable` instance is parameterized by them.
- `badge: verified` is a standard gallery badge (458 entries use it).
- All 5 `originalContributions` correspond to real named decls / the worked example.

No integrity issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)