### PR TITLE
Audit: hilbert-17-oq001 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31634,6 +31634,12 @@
       "lastAudited": "2026-07-21T14:21:11Z",
       "result": "clean",
       "issues": []
+    },
+    "hilbert-17-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T14:22:19Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean**.

**Proof**: hilbert-17-oq001 (`Proofs/Hilbert17OQ01OQ01RootMultiplicity.lean`, 182 lines)

- 7 theorem decls (5 public headline + 2 private helpers `factor_at_root`, `rootMultiplicity_sq_add_sq_of_le`) — matches `theoremCount: 7`; private helpers correctly included in the count.
- 0 definitions, 0 sorries, 0 axioms, no native_decide — matches meta. The trailing `#print axioms` lines are self-audit commands, not axiom declarations.
- `badge: original` appropriate — genuine elementary from-scratch proof of the exact formula rootMult(u²+v²) = 2·min(rootMult u, rootMult v) and the even-multiplicity obstruction; only foundational Mathlib polynomial lemmas used.
- Grandparent decl `univariate_psd_is_two_sos_deg` (consumed by the PSD corollary) verified real in `Hilbert17OQ01OQ01.lean`.
- `originalContributions` all correspond to real named theorems.

No integrity issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)