### PR TITLE
Audit: inverse-galois-d4-oq001 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31646,6 +31646,12 @@
       "lastAudited": "2026-07-21T14:23:33Z",
       "result": "clean",
       "issues": []
+    },
+    "inverse-galois-d4-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T14:25:10Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean**.

**Proof**: inverse-galois-d4-oq001 (`Proofs/InverseGaloisD4OQ02OQ03OQ01OQ01.lean`, 77 lines)

- 1 theorem (`gal_card_quintic_eq_twenty`), 0 defs, 0 sorries, 0 axioms — matches `theoremCount: 1`. leanFile block is empty (stale), but the `meta` counts are accurate against source.
- The `native_decide` grep hit is a docstring line ("no native_decide"). The two real `decide` calls (Nat.Coprime 5 (φ 5), 5·φ(5)=20) are **kernel** `decide` — trust-neutral, add no `Lean.ofReduceBool`; `assumptions` discloses this and states `#print axioms` reports only propext/Classical.choice/Quot.sound. `axiomCount: 0` holds.
- **Dedup honestly disclosed**: the metacyclic ceiling (`gal_card_le_n_mul_totient`) and coprime pin (`gal_card_eq_n_mul_totient_of_coprime`) were merged upstream into `InverseGaloisD4OQ02.lean` (PR #31630) and removed here to repair the build; `assumptions` states the counts now cover only this file's own contribution. Both ancestor decls verified real (lines 295, 412).
- Title/description narrate the full metacyclic-bracket story; the file's own new result (the X⁵−p = F₂₀ pin) is genuinely proved here. No overclaim given the explicit dedup disclosure.

No integrity issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)