### PR TITLE
Audit: jensen-inequality-oq001 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31658,6 +31658,12 @@
       "lastAudited": "2026-07-21T14:27:11Z",
       "result": "clean",
       "issues": []
+    },
+    "jensen-inequality-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T14:28:18Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean**.

**Proof**: jensen-inequality-oq001 (`Proofs/JensenInequalityOQ01OQ01OQ01OQ01.lean`, 134 lines)

- 3 theorems (`young_product`, `generalized_holder`, `inner_le_holder_two`), 0 defs, 0 sorries, 0 axioms, no decide/native_decide — all match meta exactly (134 lines).
- Genuine substantive original work: the n-exponent generalized Hölder inequality for finite sums, proved from scratch by the normalization argument; the pointwise engine (weighted AM–GM `Real.geom_mean_le_arith_mean_weighted`) is disclosed in the docstring and `assumptions`.
- Mathlib-gap claim ("ships only two-exponent discrete Hölder") is reasonable and hedged ("filling a gap"); no famous-theorem overclaim. `badge: verified` is conservative.

No integrity issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)