### PR TITLE
Audit: jensen-inequality-oq002 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31664,6 +31664,12 @@
       "lastAudited": "2026-07-21T14:28:18Z",
       "result": "clean",
       "issues": []
+    },
+    "jensen-inequality-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T14:29:20Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean**.

**Proof**: jensen-inequality-oq002 (`Proofs/JensenInequalityOQ01OQ01OQ01OQ01OQ01.lean`, 170 lines)

- 6 theorem/lemma decls (`rpow_interp` private, `moment_nonneg`, `moment_pos`, `moment_interp_le`, `logConvexOn_moment`, `moment_lyapunov`) + 1 def (`moment`) — matches `theoremCount: 6`, `definitionCount: 1`. Private lemma correctly counted.
- 0 sorries, 0 axioms, no decide/native_decide, 170 lines — all match meta exactly.
- Genuine substantive original work: Lyapunov's inequality and log-convexity of the discrete weighted moment function A(t)=∑ wᵢxᵢᵗ, built on the parent's two-function Hölder `JensenHolder.inner_le_holder_two` (disclosed in docstring + `assumptions`, verified real).
- "Lyapunov's Inequality" famous name but the theorem is genuinely formalized; Mathlib-gap claim reasonable. `badge: verified` conservative. No overclaim.

No integrity issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)