### PR TITLE
Audit: jensen-inequality-oq003 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31670,6 +31670,12 @@
       "lastAudited": "2026-07-21T14:29:20Z",
       "result": "clean",
       "issues": []
+    },
+    "jensen-inequality-oq003": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T14:30:24Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean**.

**Proof**: jensen-inequality-oq003 (`Proofs/JensenInequalityOQ01OQ01OQ01OQ01OQ01OQ01.lean`, 216 lines)

- 4 theorem/lemma decls (`normalized_amgm_sum_eq_one_iff`, `moment_interp_eq_iff`, `moment_interp_lt_of_not_const`, `moment_lyapunov_eq_iff`), 0 defs, 0 sorries, 0 axioms, no decide/native_decide, 216 lines — all match meta exactly.
- Genuine substantive original work: pins the equality case of Lyapunov's interpolation inequality (equality ⇔ data constant, for distinct exponents), avoiding the general Hölder equality case by reducing to the two-variable AM–GM equality case + `Finset.sum_eq_sum_iff_of_le`.
- Imported engine decls disclosed in `assumptions` and verified real: `amgm_two_weighted_eq_iff` (grandparent `JensenInequalityOQ01OQ01`), `moment_interp_le`/`moment_pos`/`moment` (parent `...OQ01OQ01`).
- `badge: verified` conservative. No overclaim.

No integrity issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)