### PR TITLE
Audit: jensen-inequality-oq004 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31676,6 +31676,12 @@
       "lastAudited": "2026-07-21T14:30:24Z",
       "result": "clean",
       "issues": []
+    },
+    "jensen-inequality-oq004": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T14:31:42Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean**.

**Proof**: jensen-inequality-oq004 (`Proofs/JensenInequalityOQ01OQ01OQ01OQ02.lean`, 124 lines)

- 5 theorems (`prod_rpow_inv`, `harm_le_geom` private + `weighted_amhm_le`, `weighted_amhm_eq_iff`, `weighted_amhm_lt_of_ne`), 0 defs, 0 sorries, 0 axioms — matches `theoremCount: 5`; private helpers counted.
- 124 lines exact. The single `native_decide`/`decide` grep hit is the docstring "no native_decide" line — no real use.
- Genuine from-scratch proof of the weighted AM–HM inequality (M₋₁ ≤ M₁ rung) + equality/strict cases, via two applications of the parent's weighted AM–GM. Parent decls `weighted_amgm_le` / `weighted_amgm_eq_iff` (`JensenInequalityOQ01.lean`) disclosed and verified real.
- `badge: original` appropriate; Mathlib-gap claim reasonable. No overclaim.

No integrity issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)