### PR TITLE
Enrich erdos-1034: re-anchor whole-map section drift + add Summary section

### DIFF
--- a/src/data/proofs/erdos-1034/meta.json
+++ b/src/data/proofs/erdos-1034/meta.json
@@ -60,7 +60,7 @@
       "id": "header",
       "title": "Module Header and Imports",
       "startLine": 1,
-      "endLine": 26,
+      "endLine": 83,
       "summary": "Module docstring documenting the problem statement, background, and references; single `import Mathlib` for full Mathlib access",
       "mathContext": "Problem #1034: in a graph with $> n^2/4$ edges (above Turan threshold), must there exist a triangle $T$ with $> (1/2 - o(1))n$ vertices each adjacent to 2+ vertices of $T$?"
     },
@@ -68,105 +68,113 @@
       "id": "graph-setup",
       "title": "Graph Setup",
       "summary": "$|E(G)|$, $\\lfloor n^2/4 \\rfloor$ Turán threshold, and `isAboveTuran` predicate",
-      "startLine": 27,
-      "endLine": 45,
+      "startLine": 84,
+      "endLine": 102,
       "mathContext": "$e(G) = |E(G)|$, Turan threshold $\\\\lfloor n^2/4 \\\\rfloor$. The predicate isAboveTuran means $e(G) > \\\\lfloor n^2/4 \\\\rfloor$."
     },
     {
       "id": "triangles",
       "title": "Triangles",
       "summary": "Triangle $T = (v_1, v_2, v_3)$ structure with pairwise adjacency and vertex set of cardinality 3",
-      "startLine": 46,
-      "endLine": 71,
+      "startLine": 103,
+      "endLine": 150,
       "mathContext": "Triangle $T = (v_1, v_2, v_3)$ with $v_iv_j \\\\in E(G)$ for all $i \\\\neq j$. By Turan theorem, any graph above the threshold contains at least one triangle."
     },
     {
       "id": "triangle-neighbors",
       "title": "Triangle Neighbors",
       "summary": "$\\text{goodNeighbors}(G, T) = \\{y \\notin T : |\\{v \\in T : y \\sim v\\}| \\ge 2\\}$ and cardinality",
-      "startLine": 72,
-      "endLine": 101,
+      "startLine": 151,
+      "endLine": 234,
       "mathContext": "$\\\\text{goodNeighbors}(G,T) = \\\\{y \\\\notin T : |N(y) \\\\cap T| \\\\geq 2\\\\}$ — vertices adjacent to at least 2 of the 3 triangle vertices."
     },
     {
       "id": "h-function",
       "title": "The Function h(n)",
       "summary": "$h(n) = \\max\\{k : \\forall G \\text{ above Turán}, \\exists T, |\\text{goodNeighbors}| \\ge k\\}$",
-      "startLine": 102,
-      "endLine": 123,
+      "startLine": 235,
+      "endLine": 268,
       "mathContext": "$h(n) = \\\\max\\\\{k : \\\\forall G \\\\text{ above Turan}, \\\\exists T, |\\\\text{goodNeighbors}(G,T)| \\\\geq k\\\\}$."
     },
     {
       "id": "conjecture",
       "title": "The Original Conjecture (DISPROVED)",
       "summary": "$\\neg\\,\\text{erdos\\_faudree\\_conjecture}$: conjecture $h(n) > (1/2)n$ is FALSE (Aristotle-proved negation)",
-      "startLine": 124,
-      "endLine": 142,
+      "startLine": 269,
+      "endLine": 283,
       "mathContext": "Erdos-Faudree conjecture: $h(n) > n/2$. DISPROVED. Ma-Tang: $h(n) \\\\leq (2-\\\\sqrt{5/2})n \\\\approx 0.419n < n/2$."
     },
     {
       "id": "ma-tang",
       "title": "Ma-Tang Counterexample",
       "summary": "$h(n) \\le (2 - \\sqrt{5/2})n \\approx 0.419n$ from Ma-Tang construction (axiomatized)",
-      "startLine": 143,
-      "endLine": 168,
+      "startLine": 284,
+      "endLine": 366,
       "mathContext": "Ma-Tang: $h(n) \\\\leq (2-\\\\sqrt{5/2})n \\\\approx 0.419n$. Extremal construction where every triangle has limited good-neighbor count."
     },
     {
       "id": "book-lower",
       "title": "Lower Bound via Books",
       "summary": "$h(n) \\ge n/6$ from book lemma: dense graphs have triangles with $\\ge n/6$ common neighbors",
-      "startLine": 169,
-      "endLine": 200,
+      "startLine": 367,
+      "endLine": 483,
       "mathContext": "Book lemma: $h(n) \\\\geq n/6$. Dense graphs have triangles with $\\\\geq n/6$ common neighbors."
     },
     {
       "id": "gap",
       "title": "The Gap",
       "summary": "$n/6 \\le h(n) \\le (2 - \\sqrt{5/2})n$ with gap $\\approx 0.252n$ (Aristotle-verified)",
-      "startLine": 201,
-      "endLine": 218,
+      "startLine": 484,
+      "endLine": 507,
       "mathContext": "$n/6 \\\\leq h(n) \\\\leq (2-\\\\sqrt{5/2})n$. Gap $\\\\approx 0.252n$."
     },
     {
       "id": "k4-free",
       "title": "K₄-free Variant",
       "summary": "$K_4$-free bound: $(2\\sqrt{3} - 3)n \\approx 0.464n > 0.419n$ (counterintuitively larger)",
-      "startLine": 219,
-      "endLine": 248,
+      "startLine": 508,
+      "endLine": 545,
       "mathContext": "$K_4$-free bound: $(2\\sqrt{3} - 3)n \\approx 0.464n > 0.419n$ (counterintuitively larger)"
     },
     {
       "id": "problem-905",
       "title": "Comparison with Problem 905",
       "summary": "Problem #1034 $\\implies$ Problem #905: good neighbors $\\implies$ high-degree triangle vertices",
-      "startLine": 249,
-      "endLine": 267,
+      "startLine": 546,
+      "endLine": 590,
       "mathContext": "Problem 1034 $\\\\Rightarrow$ Problem 905: good triangle neighbors implies high-degree triangle vertices."
     },
     {
       "id": "maximum",
       "title": "Maximum Good Neighbor Count",
       "summary": "$\\max_T |\\text{goodNeighbors}(G, T)|$ and Ma-Tang extremal graph characterization",
-      "startLine": 268,
-      "endLine": 284,
+      "startLine": 591,
+      "endLine": 619,
       "mathContext": "$\\\\max_T |\\\\text{goodNeighbors}(G,T)|$. The Ma-Tang graph achieves this at $(2-\\\\sqrt{5/2})n$."
     },
     {
       "id": "resolved",
       "title": "The Resolved Question",
       "summary": "Complete resolution: bounds $n/6 \\le h(n) \\le (2 - \\sqrt{5/2})n$, conjecture DISPROVED",
-      "startLine": 285,
-      "endLine": 304,
+      "startLine": 620,
+      "endLine": 675,
       "mathContext": "Status: conjecture DISPROVED. Bounds: $n/6 \\\\leq h(n) \\\\leq (2-\\\\sqrt{5/2})n$. Exact $h(n)$ remains OPEN."
     },
     {
       "id": "properties",
       "title": "Good Neighbor Properties",
       "summary": "Structural lemmas culminating in $\\text{book\\_subset\\_good}$: $T.\\text{vertices} \\subseteq \\text{goodNeighbors}$, $\\text{book\\_pages\\_are\\_good}$, and $\\text{book\\_subset\\_good}$ (a book's pages, when disjoint from $T$, are all good neighbors of $T$). Closes with the file-level Summary docstring recording the resolved status (DISPROVED by Ma-Tang) and the known bounds $\\tfrac16 n \\le h(n) \\le (2-\\sqrt{5/2})n \\approx 0.4189n$.",
-      "startLine": 305,
-      "endLine": 779,
+      "startLine": 676,
+      "endLine": 750,
       "mathContext": "Structural: triangle vertices are good neighbors of $T$. Book pages are subsets of good neighbors, so a large book around $T$ forces many good neighbors — the source of the $h(n) \\ge (1/6 - o(1))n$ lower bound."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 751,
+      "endLine": 780,
+      "summary": "Prose recap of the resolution. **Status: DISPROVED (Ma-Tang).** The Erdős–Faudree question — must every graph on $n$ vertices with $> n^2/4$ edges contain a triangle with $> (1/2 - o(1))n$ good neighbors? — is answered NO. Records the known bounds on the extremal function $h(n)$: lower $h(n) \\ge (1/6 - o(1))n$ (book lemma), upper $h(n) \\le (2 - \\sqrt{5/2} + o(1))n \\approx 0.4189n$ (Ma-Tang); the K₄-free variant upper bound $(2\\sqrt{3} - 3 + o(1))n \\approx 0.464n$; and the relation to Problems 905 and 1033.",
+      "mathContext": "Extremal function bounds: $\\tfrac{1}{6}n \\lesssim h(n) \\lesssim (2 - \\sqrt{5/2})n$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment: erdos-1034 section re-anchor (whole-map drift)

The `sections` map for **erdos-1034** (Erdős #1034, triangle good-neighbors)
was catastrophically drifted: all 14 sections were anchored 60–350 lines too
early. The titles matched the file's `## ` banners 1:1 in order, but the
anchors froze inside the first 304 lines while the proof file runs to 780,
and the last section **"Good Neighbor Properties" `[305-779]` swallowed 475
lines** — the book-lemma lower bound, the K₄-free variant, the resolved
question, and the entire `## Summary` block.

Re-anchored all 14 sections 1:1 to their banners (lines 84, 103, 151, 235,
269, 284, 367, 484, 508, 546, 591, 620, 676) and added the missing **Summary**
section (751–780 = EOF). Coverage is now contiguous `1..780`.

Existing summaries were already accurate to their titles, so only
`startLine`/`endLine` changed on the 14 sections; the Summary section is new.
No status/badge/axiom changes.
