### PR TITLE
Enrich erdos-ko-rado-oq-02: re-anchor section map to cover core definitions

### DIFF
--- a/src/data/proofs/erdos-ko-rado-oq-02/meta.json
+++ b/src/data/proofs/erdos-ko-rado-oq-02/meta.json
@@ -68,10 +68,18 @@
   },
   "sections": [
     {
+      "id": "definitions",
+      "title": "Definitions: Intersecting Families and the Star",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Module docstring plus the two core objects (verbatim from the parent entry): IsIntersectingFamily A k — a family of k-subsets of Fin n that is uniform of size k with pairwise non-empty intersection — and Star x k, the family of all k-subsets containing a fixed center x. These are the extremal-set-theory objects the whole file reasons about.",
+      "mathContext": "The star $\\mathrm{Star}(x,k) = \\{S : |S| = k, x \\in S\\}$ is the canonical intersecting family; Erdős–Ko–Rado says it is largest when $n \\ge 2k$."
+    },
+    {
       "id": "bridge",
       "title": "Bridging to Mathlib's Predicates",
-      "startLine": 51,
-      "endLine": 65,
+      "startLine": 50,
+      "endLine": 66,
       "summary": "sized_of_isIntersectingFamily and intersecting_of_isIntersectingFamily translate the parent's IsIntersectingFamily into Set.Sized k and Set.Intersecting.",
       "mathContext": "The bespoke 'uniform size k, pairwise nonempty intersection' predicate is Mathlib's Set.Sized + Set.Intersecting."
     },
@@ -86,18 +94,26 @@
     {
       "id": "sharpness",
       "title": "Sharpness: the Star Attains the Bound",
-      "startLine": 86,
-      "endLine": 138,
+      "startLine": 85,
+      "endLine": 137,
       "summary": "star_is_intersecting and star_card (the erase-the-center bijection) show the star has exactly C(n-1,k-1) members.",
       "mathContext": "The star is the extremal family; deleting the center bijects onto (k-1)-subsets."
     },
     {
       "id": "exact-max",
       "title": "The Exact Maximum",
-      "startLine": 140,
-      "endLine": 170,
-      "summary": "ekr_isGreatest pins the maximum at C(n-1,k-1) (IsGreatest); ekr_max_6_3 = 10 and ekr_max_4_2 = 3 instantiate it.",
-      "mathContext": "Combining the axiom-free upper bound with star sharpness gives the full extremal statement."
+      "startLine": 138,
+      "endLine": 153,
+      "summary": "ekr_isGreatest pins the maximum at C(n-1,k-1) (IsGreatest): the axiom-free upper bound ekr_bound together with the star's exact cardinality shows C(n-1,k-1) is both an upper bound and attained.",
+      "mathContext": "Combining the axiom-free upper bound with star sharpness gives the full extremal statement $\\max |A| = \\binom{n-1}{k-1}$."
+    },
+    {
+      "id": "concrete-instances",
+      "title": "Concrete Instances",
+      "startLine": 154,
+      "endLine": 171,
+      "summary": "ekr_max_6_3 = 10 and ekr_max_4_2 = 3 instantiate the general theorem at (n,k) = (6,3) and (4,2), turning the abstract IsGreatest statement into concrete numeric maxima.",
+      "mathContext": "$\\binom{5}{2} = 10$ and $\\binom{3}{1} = 3$ are the largest intersecting families of 3-subsets of $[6]$ and 2-subsets of $[4]$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

The section map for `erdos-ko-rado-oq-02` (Erdős–Ko–Rado, de-axiomatized via Kruskal–Katona) started at line 51, so the two **central EKR objects** — `IsIntersectingFamily` and `Star` (lines 42/47) — and the module docstring were invisible in the gallery outline.

## Change (section map only)

| # | Section | Before | After |
|---|---------|--------|-------|
| 0 | **Definitions: Intersecting Families and the Star** (new) | — | 1–49 |
| 1 | Bridging to Mathlib's Predicates | 51–65 | 50–66 |
| 2 | The Upper Bound, Axiom-Free | 67–84 | 67–84 |
| 3 | Sharpness: the Star Attains the Bound | 86–138 | 85–137 |
| 4 | The Exact Maximum | 140–170 | 138–153 |
| 5 | **Concrete Instances** (split off) | — | 154–171 |

Each section now includes its `/- ## …` banner; the new Definitions section covers the module docstring + the two core `def`s, and the merged final section is split into the general `ekr_isGreatest` theorem vs the concrete `ekr_max_6_3` / `ekr_max_4_2` instances. Contiguous 1–171, no gaps/overlaps.

No changes to prose, annotations, or `status`/`badge`/`axiomCount` (verified, 0 axioms — accurate).

(Recreated on a dedicated branch; the earlier #40542 shared a branch with #40539 and was closed.)
