### PR TITLE
Audit: jensen-inequality-oq005 clean (LOW cross-ref nit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31682,6 +31682,12 @@
       "lastAudited": "2026-07-21T14:31:42Z",
       "result": "clean",
       "issues": []
+    },
+    "jensen-inequality-oq005": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T14:33:53Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean** (one LOW documentation nit, not filed).

**Proof**: jensen-inequality-oq005 (`Proofs/JensenInequalityOQ01OQ01OQ01OQ03.lean`, 95 lines)

- 4 theorems (`rpow_pow_inv` private + `Lpnorm_smul`, `Lpnorm_eq_zero_iff`, `minkowski_finset_eq_of_common_ray`) + 1 def (`Lpnorm`) — matches `theoremCount: 4`, `definitionCount: 1`.
- 0 sorries, 0 axioms, no native_decide (only docstring mention), 95 lines exact — all match meta.
- Self-contained (re-declares `Lpnorm`, imports only Mathlib). Proves positive homogeneity, definiteness, and saturation-on-a-common-ray; **honestly scopes** the saturation as the "easy half" and notes the converse (equality ⇒ proportionality, needs p>1) is **left open**. No overclaim; `badge: verified` conservative.

**LOW nit (not filed):** the module docstring names sibling `JensenInequalityOQ01OQ01OQ01OQ02` as proving the finite-family Minkowski inequality, but that file is actually the AM–HM entry (namespace `WeightedAMHM`, theorems `weighted_amhm_*`). Stale/misdirected internal cross-reference — does not affect this self-contained entry's own kernel-verified claims, so not worth a mechanic issue.

No integrity overclaim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)