### PR TITLE
Audit: jensen-inequality-oq006 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31688,6 +31688,12 @@
       "lastAudited": "2026-07-21T14:33:53Z",
       "result": "clean",
       "issues": []
+    },
+    "jensen-inequality-oq006": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T14:34:49Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean**.

**Proof**: jensen-inequality-oq006 (`Proofs/JensenInequalityOQ01OQ01OQ01OQ04.lean`, 131 lines)

- 6 theorems (`sum_term_nonneg`, `powerMean_nonneg`, `powerMean_one`, `powerMean_le_powerMean`, `arith_mean_le_powerMean`, `qm_am_inequality`) + 1 def (`powerMean`) — matches `theoremCount: 6`, `definitionCount: 1`.
- 0 sorries, 0 axioms, no native_decide (single grep hit is the docstring), 131 lines exact — all match meta.
- Self-contained (imports only Mathlib). Genuine substantive result: monotonicity of the weighted power mean in the exponent (0<p≤q ⟹ M_p ≤ M_q) with QM–AM corollary; Jensen building block `Real.rpow_arith_mean_le_arith_mean_rpow` disclosed in docstring + `assumptions`.
- Mathlib-gap claim reasonable; `badge: verified` conservative. No overclaim.

No integrity issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)