### PR TITLE
Enrich furstenberg-correspondence-oq-03-oq-01: cover stranded core definitions E and badFamily

### DIFF
--- a/src/data/proofs/furstenberg-correspondence-oq-03-oq-01/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-03-oq-01/meta.json
@@ -152,6 +152,14 @@
   },
   "sections": [
     {
+      "id": "definitions",
+      "title": "Setup: The Even Integers and the badFamily Counterexample",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Module docstring plus the two objects the counterexample turns on: E = {n : ℤ | Even n}, the positive-density set that will avoid the pattern, and badFamily = ![0, 2X+1], a two-point polynomial family whose second polynomial has a nonzero constant term (p₁(0) = 1). Because badFamily lies outside Bergelson–Leibman's NoConstantTerm hypothesis, E can dodge every configuration it generates.",
+      "mathContext": "$E = 2\\mathbb{Z}$ has density $\\tfrac12$; `badFamily` $= (0,\\ 2X+1)$ has $p_1(0) = 1 \\neq 0$, so it is inadmissible for the polynomial Szemerédi theorem."
+    },
+    {
       "id": "out-of-scope",
       "title": "badFamily is Outside Bergelson–Leibman's Scope",
       "startLine": 54,


### PR DESCRIPTION
## Summary

The section map for `furstenberg-correspondence-oq-03-oq-01` (the `NoConstantTerm` hypothesis is necessary in polynomial Szemerédi) started at line 54, so the **two core objects of the counterexample** were invisible in the gallery outline:

- `E : Set ℤ := {n | Even n}` (line 46) — the positive-density avoiding set
- `badFamily : Fin 2 → ℤ[X] := ![0, 2*X+1]` (line 51) — the inadmissible family

## Change (section map only)

Added one section, preserving the file's existing banner-excluded gap style (each `/-!` banner line sits in a 1-line gap between sections):

| Section | Range |
|---------|-------|
| **Setup: The Even Integers and the badFamily Counterexample** (new) | 1–52 |
| badFamily is Outside Bergelson–Leibman's Scope | 54–62 |
| … (unchanged) | … |
| The Constant Term is the Only Obstruction | 128–141 |

Coverage now runs from line 1 to EOF (141). No changes to prose, annotations, or `status`/`badge`/`axiomCount`.
