### PR TITLE
Audit: jensen-inequality-oq007 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31694,6 +31694,12 @@
       "lastAudited": "2026-07-21T14:34:49Z",
       "result": "clean",
       "issues": []
+    },
+    "jensen-inequality-oq007": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T14:35:47Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean**.

**Proof**: jensen-inequality-oq007 (`Proofs/PowerMeanEqualityOQ.lean`, 176 lines)

- 5 theorem/lemma decls (`wsum_pos` private + `power_mean_eq_iff_pos`, `power_mean_lt_of_ne`, `am_eq_qm_iff`, `am_lt_qm_of_ne`), 0 defs, 0 sorries, 0 axioms, no native_decide (only docstring mention), 176 lines exact — all match meta.
- Genuine substantive result: the equality case of the power-mean inequality (M_r = M_t ⇔ data constant, 0<r<t) via strict Jensen, plus the AM=QM / AM<QM instances.
- Imported deps disclosed in `assumptions` and verified real: `weightedPowerMean`, `power_mean_monotone_pos` (`AmgmInequalityOQ03`); `jensen_eq_iff` (`JensenInequalityOQ01`).
- `badge: verified` conservative. No overclaim.

No integrity issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)