### PR TITLE
Audit: lagrange-four-squares-waring-g2-oq001 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31700,6 +31700,12 @@
       "lastAudited": "2026-07-21T14:35:47Z",
       "result": "clean",
       "issues": []
+    },
+    "lagrange-four-squares-waring-g2-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T14:36:56Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit — **clean**.

**Proof**: lagrange-four-squares-waring-g2-oq001 (`Proofs/LagrangeFourSquaresWaringG2OQ03OQ05OQ01OQ01.lean`, 154 lines)

- 11 theorems + 1 def (`delta`) — matches `theoremCount: 11`, `definitionCount: 1`.
- 0 sorries, 0 axioms, no native_decide, 154 lines exact — all match meta. The two `native_decide`/`decide` grep hits are docstring "Status" lines; all proofs discharge via `omega`/`linarith`/`push_cast` (kernel-checkable, no `Lean.ofReduceBool`).
- Imported decls `excludedCount`, `excludedCount_rec`, `six_excludedCount_le` verified real in the parent files.
- **No famous-theorem overclaim**: despite the Lagrange-four-squares / Waring lineage in the slug, the title and content are honestly scoped to the per-step residue law of a density-error function `E(N)=6·excludedCount N−N` — a technical sequel lemma, not a claim about Lagrange's or Waring's theorem. `badge: original` appropriate for the genuinely new residue-law lemmas.

No integrity issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)