### PR TITLE
Audit lagrange-theorem-oq001: clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31712,6 +31712,12 @@
       "lastAudited": "2026-07-21T14:40:03Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "lagrange-theorem-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T14:41:20Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Tracker update: audited lagrange-theorem-oq001, clean. Tier B Mathlib generalisation, badge mathlib, 2 theorems / 0 axioms / 0 sorries, claims honestly scoped.