### PR TITLE
Audit lagrange-theorem-oq002: clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31718,6 +31718,12 @@
       "lastAudited": "2026-07-21T14:41:20Z",
       "result": "clean",
       "issues": []
+    },
+    "lagrange-theorem-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T14:42:42Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Tracker update: audited lagrange-theorem-oq002, clean. Tier B orbit-stabilizer Nat.card generalisation, badge mathlib, 3 theorems / 0 axioms / 0 sorries, Mathlib lemma recovered as corollary.