### PR TITLE
Audit lagrange-theorem-oq003: clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31724,6 +31724,12 @@
       "lastAudited": "2026-07-21T14:42:42Z",
       "result": "clean",
       "issues": []
+    },
+    "lagrange-theorem-oq003": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T14:43:37Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Tracker update: audited lagrange-theorem-oq003, clean. Tier B Nat.card orbit-counting index identity, badge mathlib, 4 theorems / 0 axioms / 0 sorries. Exemplary honest handling of the finiteness distinction between routes.