### PR TITLE
Enrich erdos-1057: cover stranded Korselt-corollaries tail (sections)

### DIFF
--- a/src/data/proofs/erdos-1057/meta.json
+++ b/src/data/proofs/erdos-1057/meta.json
@@ -180,8 +180,16 @@
       "title": "Deeper Structural Properties",
       "summary": "Additional verified results: minimum prime $\\geq 3$, distinct prime factors (from squarefree), product-of-primes decomposition, multiplicity-one factorization, Korselt congruence $n \\equiv 1 \\pmod{p-1}$, double congruence, and all seven small Carmichaels have exactly 3 prime factors.",
       "startLine": 728,
-      "endLine": 1099,
+      "endLine": 1094,
       "mathContext": "Additional verified results: minimum prime $\\geq 3$, distinct prime factors (from squarefree), product-of-primes decomposition, multiplicity-one factorization, Korselt congruence $n \\equiv 1 \\pmod{p-1}$, double congruence, and all seven small Carmichaels have exactly 3 prime factors."
+    },
+    {
+      "id": "korselt-corollaries",
+      "title": "Cube-Root Prime Bound, LCM Korselt, and the Nine-Carmichael Census",
+      "summary": "Sharper consequences of the Korselt condition plus an extended verification. carmichael_smallest_prime_cube_le: the least prime factor $p_1$ satisfies $p_1^3 \\leq n$ (so $p_1 \\leq n^{1/3}$), since a Carmichael number is squarefree with $\\geq 3$ prime factors each $\\geq p_1$, giving $n = \\prod_{q} q \\geq p_1^{|\\text{primeFactors}|} \\geq p_1^3$. carmichael_prod_pred_dvd_pow: $\\prod_{p\\mid n}(p-1) \\mid (n-1)^k$ with $k$ the number of prime factors. carmichael_lcm_dvd: the combined Korselt condition $\\operatorname{lcm}\\{p-1 : p \\mid n\\} \\mid (n-1)$. carmichael_mod_lcm: the strong congruence $n \\equiv 1 \\pmod{\\operatorname{lcm}\\{p-1\\}}$. Closes with smallCarmichaelsExtended (OEIS A002997, first nine) and nine_carmichaels_verified certifying all nine by decision.",
+      "startLine": 1095,
+      "endLine": 1164,
+      "mathContext": "The cube-root bound $p_1^3 \\leq n$ makes the heuristic $p_1 \\leq n^{1/3}$ rigorous from squarefreeness and the $\\geq 3$-prime-factor count; the LCM form $\\operatorname{lcm}\\{p-1 : p \\mid n\\} \\mid (n-1)$ is the tightest packaging of Korselt, strictly sharpening the per-prime $(p-1)\\mid(n-1)$ into the single congruence $n \\equiv 1 \\pmod{\\operatorname{lcm}\\{p-1\\}}$, and the census extends the verified list from seven to the first nine Carmichael numbers."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
## Enrichment: erdos-1057 (Carmichael numbers / Erdős #1057)

**Gap:** section-map undercoverage. The final section `deeper-structure` ended at line **1099** (mid-theorem, cutting `carmichael_smallest_prime_cube_le`), leaving lines **1100–1164** of the 1164-line Lean file with no covering section — a coherent stranded tail of Korselt corollaries.

**Fix (surgical, sections only):**
- Retarget `deeper-structure` endLine `1099 → 1094` (clean end after `carmichael_korselt_via_primeFactors`).
- Add a `korselt-corollaries` section covering `1095–1164`, summarizing the six stranded declarations:
  - `carmichael_smallest_prime_cube_le` — least prime factor satisfies p₁³ ≤ n
  - `carmichael_prod_pred_dvd_pow` — ∏(p−1) ∣ (n−1)ᵏ
  - `carmichael_lcm_dvd` — lcm{p−1 : p∣n} ∣ (n−1)
  - `carmichael_mod_lcm` — n ≡ 1 (mod lcm{p−1})
  - `smallCarmichaelsExtended` + `nine_carmichaels_verified` — extended nine-Carmichael census

Section map now covers the full file (gap 0, no overlaps). No status/badge/axiom changes; entry remains `verified`, 0 axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
