### PR TITLE
Audit lagrange-theorem-oq004: clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31730,6 +31730,12 @@
       "lastAudited": "2026-07-21T14:43:37Z",
       "result": "clean",
       "issues": []
+    },
+    "lagrange-theorem-oq004": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T14:44:33Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Tracker update: audited lagrange-theorem-oq004, clean. Tier B packaged exposition over Mathlib's IsPGroup API, badge mathlib, 5 theorems / 0 axioms / 0 sorries. Wrappers honestly disclosed.