### PR TITLE
Research: erdos-98-wip-01 — general closed-form lower bound k ≤ h n for n ≥ 3k−1

### DIFF
--- a/proofs/Proofs/Erdos98WIP01.lean
+++ b/proofs/Proofs/Erdos98WIP01.lean
@@ -1897,16 +1897,32 @@ theorem two_common_neighbours_dist
 The linear bound `n - 1 ≤ 3 · h n` (`three_mul_h_ge`) already pins several exact
 threshold values of `h` from below, with no imported theorem and no open conjecture. -/
 
-/-- **`h n ≥ 3` for `n ≥ 8`.** From `n - 1 ≤ 3 · h n`: at `n = 8` this reads `7 ≤ 3 · h 8`,
-forcing `h 8 ≥ 3` (since `3 · 2 = 6 < 7`); monotonicity carries it to all `n ≥ 8`.  The
-first place the elementary bound alone certifies three distinct distances. -/
-theorem three_le_h_of_eight_le (hn : 8 ≤ n) : 3 ≤ h n := by
+/-- **General elementary lower bound: `k ≤ h n` once `n ≥ 3·k − 1`.**  The linear
+counting bound `n − 1 ≤ 3 · h n` (`three_mul_h_ge`) yields, for *every* target `k`,
+that `h n ≥ k` as soon as `n ≥ 3·k − 1`: then `3 · h n ≥ n − 1 ≥ 3·k − 2 > 3·(k − 1)`,
+so `h n > k − 1`, i.e. `h n ≥ k`.  This single statement subsumes the entire ladder of
+concrete values below (`k = 3 ⇒ n ≥ 8`, `k = 4 ⇒ n ≥ 11`, `k = 5 ⇒ n ≥ 14`, …), each a
+one-line specialization — no case-by-case enumeration needed.  It is the sharpest
+*elementary* general lower bound on `h`; the conjectured super-linear rate `h n / n → ∞`
+(Erdős #98) is far beyond it and remains open. -/
+theorem le_h_of_three_mul_sub_one_le {k : ℕ} (hn : 3 * k - 1 ≤ n) : k ≤ h n := by
   have := three_mul_h_ge n; omega
 
-/-- **`h n ≥ 4` for `n ≥ 11`.** From `n - 1 ≤ 3 · h n`: at `n = 11` this reads `10 ≤ 3 · h 11`,
-forcing `h 11 ≥ 4` (since `3 · 3 = 9 < 10`); monotonicity carries it to all `n ≥ 11`. -/
-theorem four_le_h_of_eleven_le (hn : 11 ≤ n) : 4 ≤ h n := by
-  have := three_mul_h_ge n; omega
+/-- **`h n ≥ 3` for `n ≥ 8`.**  The `k = 3` case of `le_h_of_three_mul_sub_one_le`
+(`3·3 − 1 = 8`): the first place the elementary bound alone certifies three distinct
+distances. -/
+theorem three_le_h_of_eight_le (hn : 8 ≤ n) : 3 ≤ h n :=
+  le_h_of_three_mul_sub_one_le (by omega)
+
+/-- **`h n ≥ 4` for `n ≥ 11`.**  The `k = 4` case of `le_h_of_three_mul_sub_one_le`
+(`3·4 − 1 = 11`). -/
+theorem four_le_h_of_eleven_le (hn : 11 ≤ n) : 4 ≤ h n :=
+  le_h_of_three_mul_sub_one_le (by omega)
+
+/-- **`h n ≥ 5` for `n ≥ 14`.**  The `k = 5` case of `le_h_of_three_mul_sub_one_le`
+(`3·5 − 1 = 14`), the next rung above `four_le_h_of_eleven_le`. -/
+theorem five_le_h_of_fourteen_le (hn : 14 ≤ n) : 5 ≤ h n :=
+  le_h_of_three_mul_sub_one_le (by omega)
 
 /-! ## Reduction of `h 5 ≥ 3` to a two-distance structure
 

--- a/research/problems/erdos-98-wip-01/knowledge.md
+++ b/research/problems/erdos-98-wip-01/knowledge.md
@@ -901,3 +901,26 @@ equalities.
 - **All n**: failure locus `(3-collinear ∪ 4-concyclic)` is a finite union of proper
   algebraic subvarieties of `(ℝ²)ⁿ`; complement nonempty by a dimension/genericity argument
   (the deep constructive piece). Parent Erdős #98 (`h(n)/n → ∞`) remains OPEN.
+
+## Session 2026-07-21 (researcher-1) — general closed-form lower bound (consolidation)
+
+**Mode**: build on the mature file (h pinned for n≤5, general GP existence, ladder rungs).
+**Outcome**: progress — 1 new general theorem + consolidation, host-verified v4.31
+(`lake env lean` exit 0; warnings only, no errors/sorry/axiom).
+
+The lower-bound "ladder" (`three_le_h_of_eight_le`, `four_le_h_of_eleven_le`) consisted of
+per-rung `omega` specializations of the single linear counting bound
+`three_mul_h_ge : n − 1 ≤ 3 · h n`. Adding further rungs would be enumeration theater, so
+instead I proved the **general closed form** that subsumes the whole ladder:
+
+- `le_h_of_three_mul_sub_one_le {k} (hn : 3*k − 1 ≤ n) : k ≤ h n` — for every target `k`,
+  `h n ≥ k` as soon as `n ≥ 3k − 1`. Proof: from `3·h n ≥ n − 1 ≥ 3k − 2 > 3(k−1)`,
+  `omega` gives `h n ≥ k`. Axiom-free (only `three_mul_h_ge` + `omega`).
+- Rewrote `three_le_h_of_eight_le` / `four_le_h_of_eleven_le` as one-line `k=3` / `k=4`
+  specializations `le_h_of_three_mul_sub_one_le (by omega)`, and added
+  `five_le_h_of_fourteen_le` (`k=5`, `3·5−1=14`) as an illustrative rung.
+
+### Next (unchanged, deep)
+Improving the linear `(n−1)/3` bound toward the conjectured super-linear rate is the genuine
+open direction. The parent Erdős #98 (`h n / n → ∞`, even the weak `h n ≥ n`) is OPEN in
+mathematics; the elementary counting layer here is essentially saturated.

--- a/src/data/research/problems/erdos-98-wip-01.json
+++ b/src/data/research/problems/erdos-98-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: h 5 = 3 fully proved, docker-verified, axiom-free (h_five_eq_three). The C5-endgame was bypassed: 2-regularity gives constant row-sum of squared distances, and a centroid identity forces all 5 points equidistant from the centroid (concyclic), contradicting NoFourConcyclic. Only the asymptotic Erdos #98 conjecture remains open.",
+    "progressSummary": "COMPLETE through h 5 = 3 (axiom-free). Lower-bound frontier now consolidated: le_h_of_three_mul_sub_one_le gives the general elementary bound k ≤ h n for n ≥ 3k−1 (subsumes the whole ladder). Improving the linear (n−1)/3 bound toward the conjectured super-linear rate is the deep open direction (Erdős #98).",
     "builtItems": [
       "InGeneralPosition.injective in Erdos98WIP01.lean",
       "numDistinctDistances_le_offDiag (≤ n·(n−1)) in Erdos98WIP01.lean",
@@ -93,7 +93,8 @@
       "two_distance_row_sq_sum (Erdos98WIP01.lean): sum_k dist(Pm,Pk)^2 = 2a^2+2b^2 for every vertex m of a general-position two-distance PointConfig 5 (axiom-free, docker-verified).",
       "three_le_h_five (Erdos98WIP01.lean): 3 <= h 5, via centroid concyclicity contradicting NoFourConcyclic (axiom-free, maxHeartbeats 1600000, docker-verified).",
       "h_five_eq_three (Erdos98WIP01.lean): h 5 = 3, pinned exactly via le_antisymm h_five_le_three three_le_h_five (axiom-free, docker-verified).",
-      "two_common_neighbours_dist (Erdos98WIP01.lean:1782, axiom-free, docker-built 8577 jobs): in EuclideanSpace ℝ (Fin 2), dist p q = a ∧ dist x p = dist x q = dist y p = dist y q = a ∧ a>0 → x = y ∨ dist x y = a·√3. Discharges the intersecting-circle distance equations of the h 5 ≥ 3 degree-3 sub-cases."
+      "two_common_neighbours_dist (Erdos98WIP01.lean:1782, axiom-free, docker-built 8577 jobs): in EuclideanSpace ℝ (Fin 2), dist p q = a ∧ dist x p = dist x q = dist y p = dist y q = a ∧ a>0 → x = y ∨ dist x y = a·√3. Discharges the intersecting-circle distance equations of the h 5 ≥ 3 degree-3 sub-cases.",
+      "le_h_of_three_mul_sub_one_le (Erdos98WIP01.lean:~1901): general closed-form lower bound k ≤ h n for n ≥ 3k−1, axiom-free (omega from three_mul_h_ge). Existing rungs three_le_h_of_eight_le / four_le_h_of_eleven_le rewritten as one-line k=3/k=4 specializations; added five_le_h_of_fourteen_le (k=5)."
     ],
     "insights": [
       "Every positive pairwise distance comes from an off-diagonal ordered pair (dist>0 ⟹ points distinct ⟹ indices distinct), giving the clean upper bound numDistinctDistances P ≤ n·(n−1) via Finset.offDiag_card — the trivial ceiling of the h(n) envelope.",
@@ -145,7 +146,8 @@
       "a=b degenerate branch of the reduction is killed separately by no_four_equidistant_indices (5 mutually equidistant points impossible in the plane).",
       "Intersecting-circles rigidity (two_common_neighbours_dist): two points each at distance a from both endpoints of an a-length segment are equal or exactly a√3 apart — the two circle intersections are the far vertices of a two-equilateral-triangle rhombus. This is the exact metric fact behind the degree-3 sub-case circle equations (|YZ| = a√3).",
       "Clean planar-rigidity mechanism: with u=x−p, v=y−p, w=q−p (all norm a, ⟨u,w⟩=⟨v,w⟩=a²/2), the vector e=u+v−w is orthogonal to both w and d=u−v; if x≠y then d≠0, and e≠0 would make e,w,d three pairwise-orthogonal nonzero vectors (linearly independent) — impossible in dim 2. So e=0, i.e. u+v=w, forcing ⟨u,v⟩=−a²/2 and ‖x−y‖²=3a². Same regular-simplex-needs-dimension argument as no_four_mutually_equidistant, run one dimension lower.",
-      "Lean gotcha: simp only [inner_sub_left, inner_add_left, ...] canonicalizes ⟪u,v⟫ to a fixed argument order (⟪v,u⟫ here), so a follow-up rw [real_inner_comm .., htval] whose LHS is ⟪u,v⟫ fails to fire — finish such goals with linarith [htval, hc] (hc : ⟪v,u⟫=⟪u,v⟫) instead of orientation-sensitive rw. Also real_inner_comms explicit args are the reverse orientation; use real_inner_comm _ _ driven by the expected type. And explicit rw [inner_sub_right] over `set`-bound u:=x−p unfolds the local def (⟪u,u⟫→⟪u,x⟫−⟪u,p⟫); prefer simp only for the expansion."
+      "Lean gotcha: simp only [inner_sub_left, inner_add_left, ...] canonicalizes ⟪u,v⟫ to a fixed argument order (⟪v,u⟫ here), so a follow-up rw [real_inner_comm .., htval] whose LHS is ⟪u,v⟫ fails to fire — finish such goals with linarith [htval, hc] (hc : ⟪v,u⟫=⟪u,v⟫) instead of orientation-sensitive rw. Also real_inner_comms explicit args are the reverse orientation; use real_inner_comm _ _ driven by the expected type. And explicit rw [inner_sub_right] over `set`-bound u:=x−p unfolds the local def (⟪u,u⟫→⟪u,x⟫−⟪u,p⟫); prefer simp only for the expansion.",
+      "General elementary lower bound in closed form: le_h_of_three_mul_sub_one_le proves k ≤ h n for every target k as soon as n ≥ 3·k − 1 (from n−1 ≤ 3·h n = three_mul_h_ge, since then 3·h n ≥ 3k−2 > 3(k−1)). This single theorem subsumes the entire infinite ladder of concrete rungs (k=3⇒n≥8, k=4⇒n≥11, k=5⇒n≥14, …), replacing enumeration with the general statement — the sharpest elementary general lower bound on h; the conjectured super-linear rate h n/n → ∞ (Erdős #98) is far beyond it and stays open."
     ],
     "mathlibGaps": [
       "Classification of planar 2-distance sets (max 5 points = regular pentagon, unique up to similarity) is absent from Mathlib — needed for h 5 ≥ 3.",


### PR DESCRIPTION
## Summary
Research session for erdos-98-wip-01 (distinct-distances threshold `h`, Erdős #98).

## Progress
- **New general theorem** `le_h_of_three_mul_sub_one_le {k} (hn : 3*k − 1 ≤ n) : k ≤ h n` in `proofs/Proofs/Erdos98WIP01.lean`. For every target `k`, `h n ≥ k` as soon as `n ≥ 3·k − 1`, derived by `omega` from the elementary counting bound `three_mul_h_ge : n − 1 ≤ 3 · h n` (since then `3·h n ≥ n−1 ≥ 3k−2 > 3(k−1)`).
- This single statement **subsumes the entire infinite lower-bound ladder**. The previous per-rung theorems `three_le_h_of_eight_le` (n≥8⇒h≥3) and `four_le_h_of_eleven_le` (n≥11⇒h≥4) are rewritten as one-line `k=3`/`k=4` specializations; `five_le_h_of_fourteen_le` (`k=5`, `3·5−1=14`) added as an illustrative rung.
- Consolidation, not enumeration: replaces rung-by-rung theater with the general closed form.

## Findings
- The general bound is the sharpest *elementary* general lower bound on `h`. The conjectured super-linear rate `h n / n → ∞` (Erdős #98, even the weak `h n ≥ n`) is far beyond it and remains open — improving the linear `(n−1)/3` bound is the genuine deep direction.

## Verification
- Host-verified at toolchain v4.31.0 via `lake env lean` (fresh Mathlib-only parent olean `Proofs.Erdos98Problem`): **exit 0**, warnings only (pre-existing deprecations), **no errors, no sorry, no axiom**. The new theorems use only `three_mul_h_ge` (axiom-free) + `omega`.

## Status
**Outcome**: progress (consolidation of the lower-bound frontier)
**Next Steps**: improving the linear counting bound toward the conjectured super-linear rate — deep; elementary layer otherwise saturated.

🤖 Generated by researcher-1