### PR TITLE
Enrich gelfond-schneider: re-anchor section map to true PART dividers (+Part I)

### DIFF
--- a/src/data/proofs/gelfond-schneider/meta.json
+++ b/src/data/proofs/gelfond-schneider/meta.json
@@ -114,55 +114,62 @@
       "id": "imports-setup",
       "title": "Imports and Setup",
       "startLine": 1,
-      "endLine": 113,
+      "endLine": 112,
       "summary": "Imports Mathlib's algebraic number theory (`IsAlgebraic`, `Transcendental`), complex exponentiation (`Complex.cpow`), irrationality (`Irrational`), and special functions. Sets `noncomputable section` and opens relevant namespaces.",
       "mathContext": "Imports Mathlib's `IsAlgebraic`, `Transcendental`, and complex exponential definitions. The Gelfond-Schneider theorem (1934): if $a$ and $b$ are algebraic numbers with $a \\neq 0, 1$ and $b$ irrational, then $a^b$ is transcendental. Resolves Hilbert's seventh problem."
     },
     {
       "id": "axiom-catalog",
       "title": "Axiom Catalog",
-      "startLine": 126,
-      "endLine": 202,
+      "startLine": 113,
+      "endLine": 198,
       "summary": "Five technical axioms bridging real and complex analysis: `real_cpow_eq_rpow` (real/complex power compatibility), Euler's identity `neg_one_cpow_neg_I` $(-1)^{-i} = e^\\pi$, cube root properties (`cbrt_two_algebraic`, `cbrt_two_irrational`), and the Hermite-Lindemann corollary `log_algebraic_transcendental`. Two former axioms — `real_algebraic_to_complex_algebraic` and `transcendental_of_complex_eq_real` — are now **proved** theorems (via `isAlgebraic_algebraMap_iff` and `transcendental_algebraMap_iff`).",
       "mathContext": "Five technical axioms bridging real and complex analysis: `real_cpow_eq_rpow` (real power equals complex power for positive base), `neg_one_cpow_neg_I` (Euler's identity), `cbrt_two_algebraic`/`cbrt_two_irrational`, and `log_algebraic_transcendental` (Hermite-Lindemann corollary). The two coercion lemmas `real_algebraic_to_complex_algebraic` (algebraic over $\\mathbb{R}$ implies algebraic over $\\mathbb{C}$) and `transcendental_of_complex_eq_real` are proved theorems, not axioms. The complex Gelfond-Schneider statement itself is the sixth axiom (see the main-theorem section)."
     },
     {
+      "id": "basic-definitions",
+      "title": "Part I: Basic Definitions",
+      "startLine": 199,
+      "endLine": 218,
+      "summary": "Recalls the core notions the theorem is stated over: a complex number is *algebraic* when it is a root of a nonzero polynomial in $\\mathbb{Q}[X]$ (`IsAlgebraic`), *transcendental* when it is not (`Transcendental`), a real is *irrational* when not rational (`Irrational`), and complex exponentiation is $a^b = \\exp(b\\log a)$ (`Complex.cpow`). Highlights the key hypothesis subtlety: Gelfond-Schneider needs the exponent $b$ to be algebraic yet *not rational* — for algebraic numbers \"irrational\" precisely means \"not in $\\mathbb{Q}$\"."
+    },
+    {
       "id": "main-theorem",
       "title": "The Gelfond-Schneider Theorem",
-      "startLine": 228,
-      "endLine": 276,
+      "startLine": 219,
+      "endLine": 271,
       "summary": "States the complex Gelfond-Schneider theorem as an axiom: $a^b$ is transcendental for algebraic $a \\neq 0, 1$ and algebraic irrational $b$. **Proves** the real version `gelfond_schneider_real` by lifting to $\\mathbb{C}$ and transferring transcendence back.",
       "mathContext": "The Gelfond-Schneider theorem stated as an axiom: for $a, b \\in \\mathbb{C}$ algebraic with $a \\neq 0, 1$ and $b \\notin \\mathbb{Q}$, the power $a^b$ is transcendental. This implies: $2^{\\sqrt{2}}$ (Gelfond-Schneider constant), $e^\\pi = (-1)^{-i}$ (Gelfond's constant), and $(\\sqrt{2})^{\\sqrt{2}}$ are all transcendental."
     },
     {
       "id": "corollaries",
       "title": "Famous Corollaries",
-      "startLine": 283,
-      "endLine": 396,
+      "startLine": 272,
+      "endLine": 391,
       "summary": "Proves $2^{\\sqrt{2}}$, $e^\\pi = (-1)^{-i}$, $(\\sqrt{2})^{\\sqrt{2}}$, and $2^{\\sqrt[3]{2}}$ are transcendental. Each follows by verifying the hypotheses of `gelfond_schneider_real`. The $e^\\pi$ proof uses Euler's identity cleverly.",
       "mathContext": "Concrete transcendence results: $2^{\\sqrt{2}}$ ($a = 2$, $b = \\sqrt{2}$), $e^\\pi = (-1)^{-i}$ ($a = -1 = e^{i\\pi}$, $b = -i$), $(\\sqrt{2})^{\\sqrt{2}}$ (Gelfond-Schneider constant), and $2^{\\sqrt[3]{2}}$. Each instantiates the main theorem with specific algebraic bases and irrational exponents."
     },
     {
       "id": "connections",
       "title": "Connections to Hermite-Lindemann",
-      "startLine": 397,
-      "endLine": 446,
+      "startLine": 392,
+      "endLine": 441,
       "summary": "Discusses the relationship: $a^b = e^{b \\log a}$, so Hermite-Lindemann (if $\\alpha$ is algebraic nonzero, $e^\\alpha$ is transcendental) implies $\\log$ of algebraic $\\neq 1$ is transcendental. States Baker's 1966 generalization to linear forms in logarithms.",
       "mathContext": "The identity $a^b = e^{b \\log a}$ connects Gelfond-Schneider to Hermite-Lindemann: if $\\alpha$ is algebraic and nonzero, $e^\\alpha$ is transcendental. Gelfond-Schneider handles the case where the exponent is algebraic irrational rather than algebraic nonzero, extending the transcendence landscape."
     },
     {
       "id": "proof-techniques",
       "title": "Proof Techniques (Pedagogical)",
-      "startLine": 447,
-      "endLine": 513,
+      "startLine": 442,
+      "endLine": 508,
       "summary": "Describes the Gelfond-Schneider method: (1) assume $a^b$ algebraic, (2) construct auxiliary function $f(z) = \\sum p(m,n) a^{mz} a^{bnz}$, (3) apply Siegel's lemma for integer coefficients, (4) count zeros via analytic function theory, (5) derive contradiction.",
       "mathContext": "The Gelfond-Schneider proof method: (1) assume $a^b$ is algebraic, (2) construct an auxiliary function $f(z) = \\sum P_{ij} a^{iz} z^j$ vanishing to high order at $0, 1, 2, \\ldots, T$, (3) use Schwarz's lemma to bound $|f|$, (4) derive a contradiction from the growth rate vs. vanishing. This auxiliary function technique became standard in transcendence theory."
     },
     {
       "id": "open-problems",
       "title": "Open Problems",
-      "startLine": 514,
-      "endLine": 557,
+      "startLine": 509,
+      "endLine": 555,
       "summary": "Lists open questions: is $e^e$ transcendental? $\\pi^e$? $2^e$? States Schanuel's conjecture: if $z_1, \\ldots, z_n$ are $\\mathbb{Q}$-linearly independent, then $\\mathrm{trdeg}_{\\mathbb{Q}} \\mathbb{Q}(z_i, e^{z_i}) \\geq n$.",
       "mathContext": "Open questions: is $e^e$ transcendental? Is $\\pi^e$? Is $2^e$? Schanuel's conjecture would resolve all of these: it asserts that if $\\alpha_1, \\ldots, \\alpha_n$ are $\\mathbb{Q}$-linearly independent complex numbers, then $\\text{trdeg}_{\\mathbb{Q}}(\\alpha_1, \\ldots, \\alpha_n, e^{\\alpha_1}, \\ldots, e^{\\alpha_n}) \\geq n$."
     }


### PR DESCRIPTION
## Section-map re-anchoring (navigation correctness)

`gelfond-schneider`'s `sections[]` line ranges had drifted from the Lean
file's actual `/-! ═ PART …` dividers in `Proofs/GelfondSchneider.lean`
(EOF 555):

- **Anchors drifted 4-25 lines** — e.g. Axiom Catalog claimed 126-202 but
  the AXIOM CATALOG divider opens at 113 and PART I opens at 199; the main
  theorem claimed 228-276 vs PART II @ 219.
- **Part I: Basic Definitions (199-218) had no section at all** — the
  definitions block was invisible in the gallery outline.
- **Coverage gaps**: lines 114-125 and 203-227 fell between sections.
- **EOF overshoot**: the last section ended at 557, past the true EOF 555.

Fix: re-anchored all seven existing sections to their PART-divider
boundaries, added the stranded `Part I: Basic Definitions` section, and made
the map contiguous over `1..555` (gap 0, first start 1, last end = EOF).
All existing summaries/mathContext preserved; only line ranges changed plus
the one new section. No prose/status/axiomCount edits.
