### PR TITLE
Audit laws-of-large-numbers-oq001: clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31742,6 +31742,12 @@
       "lastAudited": "2026-07-21T14:45:54Z",
       "result": "clean",
       "issues": []
+    },
+    "laws-of-large-numbers-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T14:47:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Tracker update: audited laws-of-large-numbers-oq001, clean. Silverman-Toeplitz sufficiency direction proved from scratch (ε-N analysis, no Mathlib shortcut), badge original, 3 theorems / 0 axioms / 0 sorries / no native_decide. Necessity direction correctly left as an open question — no iff overclaim. Cesàro derived as an instance.