### PR TITLE
Audit lebesgue-measure-oq001: clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31748,6 +31748,12 @@
       "lastAudited": "2026-07-21T14:47:00Z",
       "result": "clean",
       "issues": []
+    },
+    "lebesgue-measure-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T14:48:15Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Tracker update: audited lebesgue-measure-oq001, clean. Oscillation of Thomae's function = 1/q, from-scratch formalization, badge original, 13 theorems/lemmas + 1 def / 0 axioms / 0 sorries / no native_decide. Counts exact; Mathlib oscillation framework used, quantitative result proved independently.