### PR TITLE
Enrich algebraic-numbers-countable-oq-04: re-anchor section map to PART dividers

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-04/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-04/meta.json
@@ -80,47 +80,47 @@
       "id": "sec-arithmetic",
       "title": "Part I: Elementary Arithmetic — Irrationality of log2(3)",
       "startLine": 129,
-      "endLine": 294,
+      "endLine": 300,
       "summary": "Proves 2^p ≠ 3^q for positive p, q using Nat.Prime.dvd_of_dvd_pow. Derives positivity and nonvanishing of log 2 and log 3. Proves irrationality of log2(3) = log 3 / log 2. Proves Q-linear independence of {log 2, log 3}.",
       "mathContext": "Central lemma: 2^p ≠ 3^q for p, q >= 1. If 2^p = 3^q then dvd_pow_self gives 2 | 2^p = 3^q, so Nat.Prime.dvd_of_dvd_pow gives 2 | 3, contradicted by decide. Irrationality: rational log2(3) = n/d implies 3^d = 2^n, contradiction."
     },
     {
       "id": "sec-baker-axioms",
       "title": "Part II: Baker Theorem Axiom Catalog",
-      "startLine": 295,
-      "endLine": 400,
+      "startLine": 301,
+      "endLine": 401,
       "summary": "Three axioms: baker_homogeneous (Q-independent logs remain Q-bar-independent), baker_inhomogeneous (with constant term), baker_quantitative (explicit lower bound). Each axiom documented with mathematical justification.",
       "mathContext": "Main type: for linearly independent logs of algebraic a_i, any algebraic linear combination with not-all-zero coefficients is nonzero. Quantitative: |sum b_i log a_i| > B^{-C} for explicit C."
     },
     {
       "id": "sec-corollaries",
       "title": "Part III: Key Corollaries from Baker",
-      "startLine": 401,
-      "endLine": 543,
+      "startLine": 402,
+      "endLine": 544,
       "summary": "Corollaries: log2(3) is transcendental (Baker n=2 case), Q-bar-linear independence of {log 2, log 3}, n=1 case connecting to Gelfond-Schneider.",
       "mathContext": "Transcendence of log2(3): assume beta = log2(3) algebraic. Then beta*log2 - log3 = 0 with beta, -1 algebraic and log2, log3 Q-independent. Baker says this sum is nonzero. Contradiction."
     },
     {
       "id": "sec-four-exponentials",
       "title": "Part IV: Four Exponentials Conjecture (Open Problem)",
-      "startLine": 544,
-      "endLine": 590,
+      "startLine": 545,
+      "endLine": 591,
       "summary": "Documentation-only section: states the Four Exponentials Conjecture as a central open problem in transcendence theory not resolved by Baker, contrasted with the proved Six Exponentials theorem. No formal statements (axioms or theorems) are introduced — the conjecture is described in commentary.",
       "mathContext": "Four Exponentials: if z1, z2 are Q-linearly independent and w1, w2 are Q-linearly independent, then at least one of e^{z_i w_j} (4 values) is transcendental. Six Exponentials (proved) requires three z's and two w's; the gap from 6 to 4 is the open problem."
     },
     {
       "id": "sec-baker-wustholz",
       "title": "Part V: Baker-Wustholz Quantitative Theorem",
-      "startLine": 591,
-      "endLine": 633,
+      "startLine": 592,
+      "endLine": 638,
       "summary": "States Baker-Wustholz 1993 theorem with explicit constant C(n,d). Documents improvement from Baker 1966 to Baker-Wustholz 1993. Applications to Thue equations, Mordell equation, S-unit equations.",
       "mathContext": "Baker-Wustholz bound: log|Lambda| > -C(n,d) * prod_i log(A_i) * log(B) where C(n,d) = 18*(n+1)! * n^{n+1} * (32d)^{n+2} * log(2nd)."
     },
     {
       "id": "sec-baker-quantitative",
       "title": "Part VI: Baker Quantitative Theorem as a Derived Consequence",
-      "startLine": 634,
-      "endLine": 758,
+      "startLine": 639,
+      "endLine": 763,
       "summary": "Proves baker_quantitative (effective lower bound |Lambda| > B^(-C)) as a theorem derived from baker_homogeneous (Lambda != 0) and baker_wustholz_bound (explicit log lower bound). Reduces axiom count from 4 to 3.",
       "mathContext": "Key derivation: integers b_i are algebraic (isAlgebraic_int), so baker_homogeneous gives Lambda != 0. Height witnesses A_i = alpha_i + 1 satisfy 1 < A_i and log|alpha_i| <= log(A_i). Baker-Wustholz gives log|Lambda| > -C0 * prod log(A_i) * log(B). Setting C = C0 * prod log(A_i) > 0 and converting via Real.log_rpow gives B^(-C) < |Lambda|."
     }


### PR DESCRIPTION
## Section-map re-anchoring (navigation correctness)

`algebraic-numbers-countable-oq-04`'s `sections[]` ranges had drifted a few
lines early of the `/-! ═ PART …` dividers in
`Proofs/AlgebraicNumbersCountableOQ04.lean` (EOF 763), so two section
boundaries fell **inside theorem bodies**:

- **Part I** ended at line 294 — but that is mid-proof of
  `log2_log3_rat_indep` (line 251, whose proof runs to 299). Clicking Part I
  cut the theorem; the tail (295-300) was mis-attributed to Part II.
- **Part V** ended at line 633 — mid-body of the Baker-Wüstholz bound
  (`baker_wustholz_bound`, line 621, running to ~636). Its tail (634-638)
  was mis-attributed to Part VI.
- The final section stopped at **758**, leaving lines **759-763**
  (`end BakerQuantitative … end -- noncomputable section`) uncovered.

Fix: re-anchored all six PART sections to their `/-! ═` divider openers
(129 / 301 / 402 / 545 / 592 / 639) so no section splits a declaration and
the map is contiguous over `1..763` (first start 1, last end = EOF). Only
`startLine`/`endLine` changed — all titles/summaries/mathContext preserved.
No prose/status/axiomCount edits.
