### PR TITLE
Enrich cantor-diagonalization-oq004: line-anchor non-conformant sections

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq004/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq004/meta.json
@@ -87,20 +87,32 @@
   ],
   "sections": [
     {
-      "title": "The open question",
-      "content": "The parent entry recovered Cantor's theorem qualitatively — no e : A → (A → Prop) is surjective — as an instance of Lawvere's fixed-point theorem. Its third open question asks for the quantitative form: the strict cardinality gap #A < #(A → Prop), an inequality between cardinals rather than a statement about the non-existence of a surjection."
+      "id": "the-open-question",
+      "title": "The Open Question",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Module docstring, imports, and namespace setup. Frames the target: the parent entry recovered Cantor's theorem qualitatively — no e : A → (A → Prop) is surjective — as an instance of Lawvere's fixed-point theorem. Its third open question asks for the quantitative form, the strict cardinality gap #A < #(A → Prop), an inequality between cardinals rather than a statement about the non-existence of a surjection."
     },
     {
-      "title": "Power-set form",
-      "content": "cardinality_gap_set : #A < #(Set A). Rewriting #(Set A) = 2^#A with Cardinal.mk_set reduces the goal to Cardinal.cantor (#A), the cardinal-arithmetic Cantor theorem a < 2^a."
+      "id": "power-set-form",
+      "title": "Power-set Form",
+      "startLine": 52,
+      "endLine": 58,
+      "summary": "cardinality_gap_set : #A < #(Set A). Rewriting #(Set A) = 2^#A with Cardinal.mk_set reduces the goal to Cardinal.cantor (#A), the cardinal-arithmetic Cantor theorem a < 2^a."
     },
     {
-      "title": "Predicate form",
-      "content": "cardinality_gap : #A < #(A → Prop). Since Set A is definitionally A → Prop, this is literally cardinality_gap_set A — the exact statement requested by the open question."
+      "id": "predicate-form",
+      "title": "Predicate Form",
+      "startLine": 59,
+      "endLine": 65,
+      "summary": "cardinality_gap : #A < #(A → Prop). Since Set A is definitionally A → Prop, this is literally cardinality_gap_set A — the exact statement requested by the open question."
     },
     {
-      "title": "The gap is strictly stronger",
-      "content": "not_surjective_of_cardinality_gap re-derives the parent's non-surjectivity from the gap: a surjection A ↠ (A → Prop) would force #(A → Prop) ≤ #A (Cardinal.mk_le_of_surjective), contradicting #A < #(A → Prop). Thus the quantitative statement subsumes the qualitative one."
+      "id": "gap-strictly-stronger",
+      "title": "The Gap Is Strictly Stronger",
+      "startLine": 66,
+      "endLine": 85,
+      "summary": "not_surjective_of_cardinality_gap re-derives the parent's non-surjectivity from the gap: a surjection A ↠ (A → Prop) would force #(A → Prop) ≤ #A (Cardinal.mk_le_of_surjective), contradicting #A < #(A → Prop). A definitional-equality sanity-check example and #check lines close the file. Thus the quantitative statement subsumes the qualitative one."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment: cantor-diagonalization-oq004 (Quantitative Cantor)

**Gap:** schema non-conformance. The four `sections` used a legacy `{title, content}` shape with **no `id`, `startLine`, `endLine`, or `summary`** — they violate the `ProofSection` type (`src/types/proof.ts:450`, which requires all five fields), so the `TableOfContents` renderer had no line anchors to build jump links. This entry was one of ~20 gallery entries (out of 4809) still on this legacy shape.

**Fix:** convert to the canonical schema — add stable `id`s, map each conceptual section to its actual Lean line range, and move the prose into `summary`:
- `the-open-question` → 1–51 (module docstring, imports, namespace)
- `power-set-form` → 52–58 (`cardinality_gap_set`)
- `predicate-form` → 59–65 (`cardinality_gap`)
- `gap-strictly-stronger` → 66–85 (`not_surjective_of_cardinality_gap`, sanity `example`, `#check`s)

Sections now cover the full 85-line file contiguously with valid line anchors. All prose preserved; no math/status/axiom change (`verified`, 0 axioms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
