### PR TITLE
Enrich hilbert-16: re-anchor section map to PART dividers (un-orphan theorems)

### DIFF
--- a/src/data/proofs/hilbert-16/meta.json
+++ b/src/data/proofs/hilbert-16/meta.json
@@ -64,79 +64,79 @@
       "title": "Polynomial Vector Fields",
       "summary": "Defines `Plane` as `EuclideanSpace \\mathbb{R} (\\text{Fin}\\; 2)$, `VectorField` as $\\mathbb{R}^2 \\to \\mathbb{R}^2$, and `PolynomialVectorField n` as a structure with two `MvPolynomial (Fin 2) \\mathbb{R}` components $P, Q$ satisfying `totalDegree \\leq n$. Provides `eval` and `toVectorField` functions.",
       "startLine": 85,
-      "endLine": 113,
+      "endLine": 114,
       "mathContext": "Defines `Plane` as `EuclideanSpace \\mathbb{R} (\\text{Fin}\\; 2)$, `VectorField` as $\\mathbb{R}^2 \\to \\mathbb{R}^2$, and `PolynomialVectorField n` as a structure with two `MvPolynomial (Fin 2) \\mathbb{R}` components $P, Q$ satisfying `totalDegree \\leq n$."
     },
     {
       "id": "trajectories",
       "title": "Trajectories and Periodic Orbits",
       "summary": "Defines `Trajectory F` as a $C^1$ curve $\\gamma: \\mathbb{R} \\to \\mathbb{R}^2$ satisfying $\\gamma'(t) = F(\\gamma(t))$. Defines `isPeriodic` ($\\exists T > 0, \\gamma(t+T) = \\gamma(t)$), `minimalPeriod`, `orbit` (the image $\\gamma(\\mathbb{R})$), and `isPeriodicOrbit`.",
-      "startLine": 114,
-      "endLine": 143,
+      "startLine": 115,
+      "endLine": 144,
       "mathContext": "Defines `Trajectory F` as a $C^1$ curve $\\gamma: \\mathbb{R} \\to \\mathbb{R}^2$ satisfying $\\gamma'(t) = F(\\gamma(t))$. Defines `isPeriodic` ($\\exists T > 0, \\gamma(t+T) = \\gamma(t)$), `minimalPeriod`, `orbit` (the image $\\gamma(\\mathbb{R})$), and `isPeriodicOrbit`."
     },
     {
       "id": "limit-cycles",
       "title": "Limit Cycles",
       "summary": "Defines `isIsolatedPeriodicOrbit` (periodic orbit with an $\\varepsilon$-neighborhood containing no other periodic orbits), `isLimitCycle` (synonym), `limitCycles F` (the set of all limit cycles), and counting predicates `hasAtMostLimitCycles` and `hasExactlyLimitCycles` using `Set.ncard`.",
-      "startLine": 144,
-      "endLine": 174,
+      "startLine": 145,
+      "endLine": 175,
       "mathContext": "Defines `isIsolatedPeriodicOrbit` (periodic orbit with an $\\varepsilon$-neighborhood containing no other periodic orbits), `isLimitCycle` (synonym), `limitCycles F` (the set of all limit cycles), and counting predicates `hasAtMostLimitCycles` and `hasExactlyLimitCycles` using `Set.ncard`."
     },
     {
       "id": "hilbert-number",
       "title": "The Hilbert Number H(n)",
       "summary": "Defines $H(n) = \\sup_F |\\{\\text{limit cycles of } F\\}|$ as `HilbertNumber n := \\iSup (F : PolynomialVectorField n), (limitCycles F.toVectorField).ncard` valued in $\\mathbb{N}_{\\infty}$. Proves `HilbertNumber_ge_iff`: $k \\leq H(n) \\iff \\exists F$ with $\\geq k$ limit cycles.",
-      "startLine": 175,
-      "endLine": 207,
+      "startLine": 176,
+      "endLine": 208,
       "mathContext": "Defines $H(n) = \\sup_F |\\{\\text{limit cycles of } F\\}|$ as `HilbertNumber n := \\iSup (F : PolynomialVectorField n), (limitCycles F.toVectorField).ncard` valued in $\\mathbb{N}_{\\infty}$. Proves `HilbertNumber_ge_iff`: $k \\leq H(n) \\iff \\exists F$ with $\\geq k$ limit cycles."
     },
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture",
       "summary": "States `Hilbert16_MainConjecture`: $\\forall n \\geq 1, \\exists k \\in \\mathbb{N}: H(n) = k$. This is the full statement of Hilbert's 16th Problem (Part B).",
-      "startLine": 208,
-      "endLine": 223,
+      "startLine": 209,
+      "endLine": 224,
       "mathContext": "Mathematical content: States `Hilbert16_MainConjecture`: $\\forall n \\geq 1, \\exists k \\in \\mathbb{N}: H(n) = k$. This is the full statement of Hilbert's 16th Problem (Part B)."
     },
     {
       "id": "linear-case",
       "title": "H(1) = 0: The Linear Case",
       "summary": "Defines `LinearVectorField` with matrix representation, converts to `PolynomialVectorField 1` via `toPolynomialVectorField`. Axiomatizes that linear systems have no limit cycles (`linear_no_limit_cycles_axiom`) based on eigenvalue phase portrait analysis (nodes, saddles, foci, centers). Proves `H1_eq_zero : HilbertNumber 1 = 0`.",
-      "startLine": 224,
-      "endLine": 307,
+      "startLine": 225,
+      "endLine": 311,
       "mathContext": "Defines `LinearVectorField` with matrix representation, converts to `PolynomialVectorField 1` via `toPolynomialVectorField`. Axiomatizes that linear systems have no limit cycles (`linear_no_limit_cycles_axiom`) based on eigenvalue phase portrait analysis (nodes, saddles, foci, centers)."
     },
     {
       "id": "lower-bounds",
       "title": "Known Lower Bounds",
       "summary": "Axiomatizes `H2_ge_4` (Shi Songling 1980, '(3,1) distribution' of limit cycles in a quadratic system) and `H3_ge_13` (cubic systems with $\\geq 13$ limit cycles). These are constructive results requiring computer-assisted verification.",
-      "startLine": 308,
-      "endLine": 353,
+      "startLine": 312,
+      "endLine": 357,
       "mathContext": "Axiomatizes `H2_ge_4` (Shi Songling 1980, '(3,1) distribution' of limit cycles in a quadratic system) and `H3_ge_13` (cubic systems with $\\geq 13$ limit cycles)."
     },
     {
       "id": "finiteness",
       "title": "Ecalle-Ilyashenko Finiteness Theorem",
       "summary": "Axiomatizes `Ecalle_Ilyashenko`: $\\forall n, \\exists k: H(n) = k$. The 1991-92 independent proofs by Ecalle (resurgent functions) and Ilyashenko (Dulac map asymptotics) fixed gaps in Dulac's 1923 claim, each exceeding 500 pages. Gives finiteness but **no effective bound**.",
-      "startLine": 354,
-      "endLine": 390,
+      "startLine": 358,
+      "endLine": 394,
       "mathContext": "Axiomatizes `Ecalle_Ilyashenko`: $\\forall n, \\exists k: H(n) = k$."
     },
     {
       "id": "poincare-bendixson",
       "title": "Poincare-Bendixson Theory",
       "summary": "Defines `omegaLimitSet` ($\\bigcap_T \\overline{\\gamma([T,\\infty))}$), `isEquilibrium`, `equilibria`. Axiomatizes the **Poincare-Bendixson theorem**: if $\\omega(\\gamma)$ is bounded and contains no equilibria, it is a periodic orbit. Also axiomatizes that limit cycles arise as $\\omega$-limits of spiraling trajectories.",
-      "startLine": 391,
-      "endLine": 458,
+      "startLine": 395,
+      "endLine": 462,
       "mathContext": "Defines `omegaLimitSet` ($\\bigcap_T \\overline{\\gamma([T,\\infty))}$), `isEquilibrium`, `equilibria`. Axiomatizes the **Poincare-Bendixson theorem**: if $\\omega(\\gamma)$ is bounded and contains no equilibria, it is a periodic orbit. Also axiomatizes that limit cycles arise as $\\omega$-limits of spiraling trajectories."
     },
     {
       "id": "related-problems",
       "title": "Related Problems and Context",
       "summary": "Defines `Hilbert16_PartA` (topology of real algebraic curve ovals), `Smale13` (same as Hilbert 16 Main Conjecture). Axiomatizes Hopf bifurcation: a one-parameter family of quadratic systems transitions from 0 to 1 limit cycle at a critical parameter value. The summary theorem synthesizes all known results.",
-      "startLine": 459,
-      "endLine": 565,
+      "startLine": 463,
+      "endLine": 569,
       "mathContext": "Defines `Hilbert16_PartA` (topology of real algebraic curve ovals), `Smale13` (same as Hilbert 16 Main Conjecture). Axiomatizes Hopf bifurcation: a one-parameter family of quadratic systems transitions from 0 to 1 limit cycle at a critical parameter value."
     }
   ],


### PR DESCRIPTION
## Section-map re-anchoring (navigation correctness)

`hilbert-16`'s back-half `sections[]` anchors were drifted ~4 lines early of
the `/-! ═ PART …` dividers in `Proofs/Hilbert16.lean` (EOF 569), which
orphaned each Part's own theorem into the following section:

- **Part VI "H(1) = 0"** ended at line 307, but its theorem
  `H1_eq_zero` is at line 310 — pushed into "Known Lower Bounds".
- **Part VII "Known Lower Bounds"** ended at 353 vs `H3_ge_13` at 356.
- **Part VIII "Ecalle-Ilyashenko"** ended at 390 vs `Ecalle_Ilyashenko`
  at 393.
- **Part IX "Poincaré-Bendixson"** ended at 458, splitting
  `limit_cycle_as_omega_limit` (lines 458-461) across the boundary.
- The last section stopped at **565**, leaving lines **566-569** (the
  `#check` block and `end Hilbert16`) uncovered.

Fix: re-anchored all sections to their divider openers
(85 / 115 / 145 / 176 / 209 / 225 / 312 / 358 / 395 / 463) so every theorem
sits inside the section that names it, and the map is contiguous over
`1..569` (first start 1, last end = EOF). Only `startLine`/`endLine`
changed — all titles/summaries preserved. No prose/status/axiomCount edits.
