### PR TITLE
Enrich matrix-posdef-sqrt-oq-01-oq-01-oq-01: line-anchor legacy sections

### DIFF
--- a/src/data/proofs/matrix-posdef-sqrt-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/matrix-posdef-sqrt-oq-01-oq-01-oq-01/meta.json
@@ -78,17 +78,23 @@
     {
       "id": "operator-absolute-value",
       "title": "The operator absolute value |A| = √(AᴴA)",
-      "description": "Defines the modulus absValue A = CFC.sqrt (Aᴴ·A) and records its structure: positive semidefinite (absValue_posSemidef), Hermitian (absValue_isHermitian), the defining identity |A|² = AᴴA (absValue_mul_self), the form |A|ᴴ·|A| = AᴴA (absValue_conjTranspose_mul_self), and uniqueness as the PSD square root of AᴴA (absValue_unique)."
+      "startLine": 1,
+      "endLine": 80,
+      "summary": "Module docstring, imports, and namespace, then the modulus absValue A = CFC.sqrt (Aᴴ·A) and its structure: positive semidefinite (absValue_posSemidef), Hermitian (absValue_isHermitian), the defining identity |A|² = AᴴA (absValue_mul_self), the form |A|ᴴ·|A| = AᴴA (absValue_conjTranspose_mul_self), and uniqueness as the PSD square root of AᴴA (absValue_unique)."
     },
     {
       "id": "quadratic-form",
       "title": "The fundamental quadratic-form identity",
-      "description": "For any matrix M and vector x, the Hermitian quadratic form of Mx collapses to the form of MᴴM on x: star (M *ᵥ x) ⬝ᵥ (M *ᵥ x) = star x ⬝ᵥ ((Mᴴ·M) *ᵥ x) (star_mulVec_dotProduct_self), a pure matrix-algebra computation."
+      "startLine": 81,
+      "endLine": 89,
+      "summary": "For any matrix M and vector x, the Hermitian quadratic form of Mx collapses to the form of MᴴM on x: star (M *ᵥ x) ⬝ᵥ (M *ᵥ x) = star x ⬝ᵥ ((Mᴴ·M) *ᵥ x) (star_mulVec_dotProduct_self), a pure matrix-algebra computation."
     },
     {
       "id": "norm-preservation",
       "title": "Norm preservation ‖Ax‖ = ‖|A|x‖",
-      "description": "A and its modulus induce the same quadratic form ⟨Ax,Ax⟩ = ⟨|A|x,|A|x⟩ (absValue_star_mulVec_dotProduct); via star y ⬝ᵥ y = ∑ᵢ‖yᵢ‖² (dotProduct_star_self) this descends to the Euclidean-norm identity ∑ᵢ‖(Ax)ᵢ‖² = ∑ᵢ‖(|A|x)ᵢ‖² (absValue_normSq_eq)."
+      "startLine": 90,
+      "endLine": 118,
+      "summary": "A and its modulus induce the same quadratic form ⟨Ax,Ax⟩ = ⟨|A|x,|A|x⟩ (absValue_star_mulVec_dotProduct); via star y ⬝ᵥ y = ∑ᵢ‖yᵢ‖² (dotProduct_star_self) this descends to the Euclidean-norm identity ∑ᵢ‖(Ax)ᵢ‖² = ∑ᵢ‖(|A|x)ᵢ‖² (absValue_normSq_eq)."
     }
   ],
   "openQuestions": [


### PR DESCRIPTION
## Enrichment: matrix-posdef-sqrt-oq-01-oq-01-oq-01 (operator absolute value / norm preservation)

**Gap:** schema non-conformance (same legacy-section vein as #40567). The three `sections` used a legacy `{id, title, description}` shape — **no `startLine`/`endLine`, and `description` instead of `summary`** — so they violate the `ProofSection` type (`src/types/proof.ts:450`) and the `TableOfContents` renderer had no line anchors.

**Fix:** add line ranges mapping each section to its Lean block and rename `description` → `summary`:
- `operator-absolute-value` → 1–80 (docstring, imports, `absValue` def + 5 structure theorems through `absValue_unique`)
- `quadratic-form` → 81–89 (`star_mulVec_dotProduct_self`)
- `norm-preservation` → 90–118 (`absValue_star_mulVec_dotProduct`, `dotProduct_star_self`, `absValue_normSq_eq`)

Full 118-line file covered contiguously with valid anchors. Prose preserved; no math/status/axiom change (`verified`, 0 axioms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
