### PR TITLE
Track audit: pell-equation-oq001 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31772,6 +31772,12 @@
       "lastAudited": "2026-07-21T15:01:09Z",
       "result": "clean",
       "issues": []
+    },
+    "pell-equation-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T15:03:30Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Integrity audit of pell-equation-oq001 (Pell regulator counts subgroup index): **clean**. Builds green on current main, 8 theorems, 0 axioms/sorries, kernel axioms clean, Mathlib deps disclosed, counts+status+badge correct.