### PR TITLE
Track audit: pell-equation-oq002 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31778,6 +31778,12 @@
       "lastAudited": "2026-07-21T15:03:30Z",
       "result": "clean",
       "issues": []
+    },
+    "pell-equation-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T15:05:36Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Integrity audit of pell-equation-oq002 (⟨a⟩ as ordered group ≃o (ℤ,<)): **clean**. Builds green on current main, 12 theorems + 4 defs, 0 axioms/sorries, kernel axioms clean, genuine non-vacuous OrderIso construction, counts+status+badge correct.