### PR TITLE
Track audit: picks-theorem-oq001 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31784,6 +31784,12 @@
       "lastAudited": "2026-07-21T15:05:36Z",
       "result": "clean",
       "issues": []
+    },
+    "picks-theorem-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T15:07:56Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit of **picks-theorem-oq001** (Pick Additivity Under Edge-Gluing S4).

## Result: clean ✅

Verified counts against `Proofs/PicksTheoremOQ01OQ01OQ01OQ02.lean`:
- 15 theorems, 17 defs/structures — match meta exactly
- 0 sorries (the lone `sorry` grep hit is a docstring "sorry-free" reference)
- 0 axiom declarations
- 0 native_decide; 4 kernel `decide` uses → no `Lean.ofReduceBool`

Claims are honestly scoped to the **edge-gluing additivity lemma**, not Pick's theorem itself. `pickInterior` is transparently the Pick *functional* (twiceArea/2 − B/2 + 1); the gap to a genuine interior-point count is acknowledged in the open questions. `signedDoubleArea_natAbs_eq_twiceArea` states its orientation hypotheses explicitly. Tier A, badge `original`, status `verified` — all appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)