### PR TITLE
Track audit: ptolemys-theorem-oq001 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31790,6 +31790,12 @@
       "lastAudited": "2026-07-21T15:07:56Z",
       "result": "clean",
       "issues": []
+    },
+    "ptolemys-theorem-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T15:09:48Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit: `ptolemys-theorem-oq001` — **clean**.

- 5 theorems, 0 axioms, 0 sorries, 0 defs, 161 lines — all match meta.json.
- No `native_decide`/`decide`; only `sorry` grep hit is the docstring phrase "0-sorry".
- Badge `original` defensible: proves genuinely new circle↔line inner-product statements from Mathlib primitives, with all Mathlib dependencies disclosed.
- `#print axioms` claim (propext, Classical.choice, Quot.sound only) consistent with the axiom/sorry-free source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)