### PR TITLE
Track audit: ptolemys-theorem-oq002 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31796,6 +31796,12 @@
       "lastAudited": "2026-07-21T15:09:48Z",
       "result": "clean",
       "issues": []
+    },
+    "ptolemys-theorem-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T15:13:35Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit: `ptolemys-theorem-oq002` — **clean** (exemplary).

- 12 theorems, 2 defs, 0 axioms, 0 sorries, 373 lines — all match meta.json.
- **Build verified**: `lake build` succeeds (only `push_neg` deprecation warnings).
- **`#print axioms` confirmed**: both `positive_ratio_implies_cyclic_order_thm` and `ptolemy_equality_implies_ccw_or_cw_axiomfree` depend only on [propext, Classical.choice, Quot.sound] — no sorryAx, no ofReduceBool.
- Transitive imports (`PtolemysComplexProofOQ01`, `PtolemysTheoremOQ01`) are axiom-free and sorry-free.
- Genuinely discharges the parent leaf's `positive_ratio_implies_cyclic_order` axiom as a full theorem; local restatement of `FourDistinct`/`IsCWOrder` and the insulated parent-leaf Mathlib drift are honestly disclosed. Badge `original` appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)