### PR TITLE
Research: erdos-507-wip-01 — sharp lower bound heilbronn 3 ≥ 3√3/4

### DIFF
--- a/proofs/Proofs/Erdos507WIP01.lean
+++ b/proofs/Proofs/Erdos507WIP01.lean
@@ -427,4 +427,64 @@ reason the monotonicity lemmas are stated only from `n = 3` onward. -/
 theorem heilbronn_three_pos : 0 < heilbronn 3 :=
   lt_of_lt_of_le (by norm_num) heilbronn_three_ge_half
 
+/-! ## The sharp lower bound at `n = 3` -/
+
+/-- **`heilbronn 3 ≥ 3√3/4`.**  The equilateral triangle inscribed in the unit circle,
+`(1,0), (−1/2, √3/2), (−1/2, −√3/2)`, has all three vertices on the boundary of the unit
+disk, and every ordering of its vertices has `triangleArea` equal to `3√3/4` — the area of
+the largest triangle inscribable in a radius-`1` disk.  Hence `3√3/4` is admissible for the
+`sSup` defining `heilbronn 3`.  This sharpens the crude right-triangle witness
+`heilbronn 3 ≥ 1/2` to the *conjectured exact value*: the matching upper bound
+`heilbronn 3 ≤ 3√3/4` (every unit-disk triangle has area `≤ 3√3/4`) would pin
+`heilbronn 3 = 3√3/4`, improving the current `heilbronn 3 ≤ 3`. -/
+theorem heilbronn_three_ge : 3 * Real.sqrt 3 / 4 ≤ heilbronn 3 := by
+  have h3 : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  have hsqrt_pos : 0 < Real.sqrt 3 := Real.sqrt_pos.mpr (by norm_num)
+  -- every ordering of the inscribed equilateral triangle has area `3√3/4`
+  have hval : triangleArea ((1 : ℝ), (0 : ℝ)) (-(1/2), Real.sqrt 3 / 2)
+      (-(1/2), -(Real.sqrt 3 / 2)) = 3 * Real.sqrt 3 / 4 := by
+    unfold triangleArea
+    rw [show ((1:ℝ), (0:ℝ)).1 * (((-(1/2) : ℝ), Real.sqrt 3 / 2).2
+              - ((-(1/2):ℝ), -(Real.sqrt 3 / 2)).2)
+          + ((-(1/2):ℝ), Real.sqrt 3 / 2).1 * (((-(1/2):ℝ), -(Real.sqrt 3 / 2)).2
+              - ((1:ℝ),(0:ℝ)).2)
+          + ((-(1/2):ℝ), -(Real.sqrt 3 / 2)).1 * (((1:ℝ),(0:ℝ)).2
+              - ((-(1/2):ℝ), Real.sqrt 3 / 2).2)
+          = 3 * Real.sqrt 3 / 2 from by ring]
+    rw [abs_of_nonneg (by positivity)]
+    ring
+  unfold heilbronn
+  refine le_csSup (heilbronn_defining_bddAbove 3 (by norm_num)) ?_
+  refine ⟨{((1 : ℝ), (0 : ℝ)), (-(1/2), Real.sqrt 3 / 2), (-(1/2), -(Real.sqrt 3 / 2))},
+    ?_, ?_, ?_⟩
+  · -- the three vertices are distinct, so the configuration has cardinality `3`
+    rw [Finset.card_eq_three]
+    refine ⟨((1:ℝ),(0:ℝ)), (-(1/2), Real.sqrt 3 / 2), (-(1/2), -(Real.sqrt 3 / 2)),
+      ?_, ?_, ?_, rfl⟩
+    · intro h; rw [Prod.ext_iff] at h; norm_num at h
+    · intro h; rw [Prod.ext_iff] at h; norm_num at h
+    · intro h; rw [Prod.ext_iff] at h; have h2 := h.2; linarith [hsqrt_pos]
+  · -- each vertex lies in the closed unit disk (all three on the boundary)
+    intro p hp
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hp
+    rcases hp with rfl | rfl | rfl
+    · show (1:ℝ) ^ 2 + (0:ℝ) ^ 2 ≤ 1; norm_num
+    · show (-(1/2):ℝ) ^ 2 + (Real.sqrt 3 / 2) ^ 2 ≤ 1; nlinarith [h3]
+    · show (-(1/2):ℝ) ^ 2 + (-(Real.sqrt 3 / 2)) ^ 2 ≤ 1; nlinarith [h3]
+  · -- every ordered distinct triple has area `3√3/4 ≥ 3√3/4` (permutation-invariant)
+    intro p hp q hq r hr hpq hqr hpr
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hp hq hr
+    rcases hp with rfl | rfl | rfl <;> rcases hq with rfl | rfl | rfl <;>
+        rcases hr with rfl | rfl | rfl <;>
+      first
+        | exact absurd rfl hpq
+        | exact absurd rfl hqr
+        | exact absurd rfl hpr
+        | exact ge_of_eq hval
+        | (rw [triangleArea_swap_right]; exact ge_of_eq hval)
+        | (rw [triangleArea_swap_left]; exact ge_of_eq hval)
+        | (rw [triangleArea_cyclic]; exact ge_of_eq hval)
+        | (rw [triangleArea_cyclic, triangleArea_cyclic]; exact ge_of_eq hval)
+        | (rw [triangleArea_swap_left, triangleArea_cyclic]; exact ge_of_eq hval)
+
 end Erdos507WIP01

--- a/research/problems/erdos-507-wip-01/knowledge.md
+++ b/research/problems/erdos-507-wip-01/knowledge.md
@@ -157,3 +157,38 @@ Shoelace `triangleArea` geometry: nonnegativity, full `S₃` permutation symmetr
 (signed-area alternation), the three degenerate cases, collinearity ⟺ zero area,
 explicit value `1/2`, unit-disk coordinate bounds `|p_i| ≤ 1`, and the uniform
 bound `triangleArea ≤ 3`. All 0 sorry / 0 axiom.
+
+## Session 2026-07-21 (researcher-1) — sharp lower bound heilbronn 3 ≥ 3√3/4
+
+**Mode**: strengthen the crude `heilbronn 3 ≥ 1/2` witness. **Outcome**: progress —
+the lower bound at `n = 3` is now **sharp** (equal to the conjectured exact value),
+host-verified v4.31 (`lake env lean` exit 0, 0 warnings in the new block;
+`#print axioms heilbronn_three_ge` = `[propext, Classical.choice, Quot.sound]`).
+
+`heilbronn_three_ge : 3 * Real.sqrt 3 / 4 ≤ heilbronn 3`. Witness = the equilateral
+triangle inscribed in the unit circle, `(1,0), (−1/2, √3/2), (−1/2, −√3/2)` — all three
+vertices on the boundary of the unit disk (`(−1/2)² + (√3/2)² = 1/4 + 3/4 = 1`, via
+`Real.sq_sqrt`), and every ordering of the vertices has `triangleArea = 3√3/4` (the largest
+triangle inscribable in a radius-1 disk). So `3√3/4` is admissible for the `sSup` defining
+`heilbronn 3` (`le_csSup` + `heilbronn_defining_bddAbove`), strengthening the right-triangle
+bound `heilbronn 3 ≥ 1/2`.
+
+**Recipe** (reusable for concrete-config `heilbronn` lower bounds):
+- Compute the canonical-ordering area ONCE: `unfold triangleArea;
+  rw [show <projected signed expr> = 3√3/2 from by ring]` (★`ring` sees through the
+  `(a,b).1`/`.2` projections of literal pairs — no manual `Prod.fst` reduction needed),
+  then `rw [abs_of_nonneg (by positivity)]; ring`.
+- Discharge the other 5 ordered triples by permutation-invariance: `triangleArea_swap_left`,
+  `triangleArea_swap_right`, `triangleArea_cyclic` inside a `first | …` combinator, each
+  branch `rw [<perm chain>]; exact ge_of_eq hval` (any ordering reaches the canonical in
+  ≤ 2 swap/cyclic rewrites; a failed `exact` rolls back the `rw`, so ordering is safe).
+- Distinctness of the `Real.sqrt`-coordinate pair via `Prod.ext_iff` then `linarith` on the
+  `.2` component against `Real.sqrt_pos`.
+
+### Next
+- **Matching upper bound `heilbronn 3 ≤ 3√3/4`** would pin `heilbronn 3 = 3√3/4` exactly.
+  Requires "every triangle with vertices in the unit disk has area ≤ 3√3/4" — a genuine
+  optimization (the current file only has the crude `triangleArea_le_three`, area ≤ 3). Not
+  obviously session-sized; the sharp bound follows from the inscribed-equilateral being the
+  area-maximizer, which needs a real argument.
+- Deep `α(n)` exponent bounds (KPS lower, CPZ upper) remain open (literature: `7/6 ≤ β ≤ 2`).

--- a/src/data/research/problems/erdos-507-wip-01.json
+++ b/src/data/research/problems/erdos-507-wip-01.json
@@ -46,7 +46,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Extended Proofs/Erdos507WIP01.lean (24→26 declarations, 0 sorry / 0 axiom, VERIFIED axiom-free [propext, Classical.choice, Quot.sound], host-verified no-Docker). Added a concrete positive lower bound at n=3: heilbronn_three_ge_half (heilbronn 3 ≥ 1/2, from the unit right triangle whose every ordering has area 1/2) and heilbronn_three_pos (0 < heilbronn 3). This separates heilbronn 3 from the junk value heilbronn 2 = 0, showing the n ≥ 3 hypothesis on the monotonicity lemmas is forced. The deep α(n) growth exponent (7/6 ≤ β ≤ 2) remains open.",
+    "progressSummary": "Foundational Heilbronn toolkit complete (triangleArea geometry, unit-disk bounds, minTriangleArea/heilbronn junk-value semantics, heilbronn_le_three, antitone/succ_le monotonicity, heilbronn_three_pos). Lower bound at n=3 now SHARP: heilbronn 3 ≥ 3√3/4 (= conjectured exact value). Open: matching upper bound heilbronn 3 ≤ 3√3/4 (largest-triangle-in-disk optimization), and the deep α(n) exponent bounds (KPS/CPZ).",
     "builtItems": [
       "triangleArea_nonneg in Erdos507WIP01.lean",
       "triangleArea_swap_left / triangleArea_swap_right / triangleArea_cyclic (permutation symmetry)",
@@ -67,7 +67,8 @@
       "heilbronn_antitone in Erdos507WIP01.lean — full antitonicity on {n≥3} via Nat.le_induction",
       "heilbronn_mem_Icc in Erdos507WIP01.lean — sandwich 0 ≤ heilbronn n ≤ 3 for n≥3 (PR #39991), 0-axiom",
       "heilbronn_three_ge_half (1/2 ≤ heilbronn 3) in Proofs/Erdos507WIP01.lean",
-      "heilbronn_three_pos (0 < heilbronn 3) in Proofs/Erdos507WIP01.lean"
+      "heilbronn_three_pos (0 < heilbronn 3) in Proofs/Erdos507WIP01.lean",
+      "heilbronn_three_ge (Erdos507WIP01.lean): heilbronn 3 ≥ 3√3/4, axiom-free (propext/Classical.choice/Quot.sound), host-verified v4.31. Area computed once for the canonical ordering (unfold triangleArea; rw show <signed> = 3√3/2 by ring; abs_of_nonneg; ring); the other 5 ordered triples reduced to it via the permutation lemmas triangleArea_swap_left/right/cyclic inside a first-combinator."
     ],
     "insights": [
       "The signed shoelace area p₁(q₂−r₂)+q₁(r₂−p₂)+r₁(p₂−q₂) is alternating: transpositions negate it (area invariant via abs_neg), cyclic rotations fix it — giving full S₃ symmetry after the absolute value.",
@@ -83,7 +84,8 @@
       "heilbronn 3 ≥ 1/2 via the explicit unit right triangle (0,0),(1,0),(0,1): all six orderings of its distinct vertices have triangleArea = 1/2 (triangleArea_unit + permutation lemmas), so 1/2 lies in the defining sSup set; le_csSup with heilbronn_defining_bddAbove gives the bound.",
       "Finset.card_eq_three is the clean way to certify a 3-point real config has cardinality 3 (avoids decide, which fails on DecidableEq ℝ): provide the three points plus pairwise inequalities via simp [Prod.ext_iff].",
       "For an ∀-over-a-3-element-Finset distinct-triple bound, rcases each membership (Finset.mem_insert/mem_singleton) three-ways (27 cases) and discharge with first | exact absurd rfl h<pair> | (unfold triangleArea; norm_num) — the 21 repeated-vertex cases die on the distinctness hyps, the 6 genuine permutations compute to 1/2.",
-      "heilbronn 3 > 0 = heilbronn 2 confirms Heilbronn is NOT monotone across the 2→3 boundary, so the n ≥ 3 hypothesis on the monotonicity lemmas is forced, not cosmetic."
+      "heilbronn 3 > 0 = heilbronn 2 confirms Heilbronn is NOT monotone across the 2→3 boundary, so the n ≥ 3 hypothesis on the monotonicity lemmas is forced, not cosmetic.",
+      "heilbronn 3 ≥ 3√3/4 (heilbronn_three_ge): sharp lower bound at n=3 via the equilateral triangle inscribed in the unit circle — (1,0),(−1/2,√3/2),(−1/2,−√3/2), all on the boundary, every ordering has triangleArea = 3√3/4 (the largest triangle inscribable in a radius-1 disk). Strengthens the crude right-triangle witness heilbronn 3 ≥ 1/2 to the conjectured EXACT value; the matching upper bound heilbronn 3 ≤ 3√3/4 (open here) would pin heilbronn 3 = 3√3/4, improving the current crude ≤ 3."
     ],
     "mathlibGaps": [
       "No off-the-shelf lemma reduces the nested membership biInf of minTriangleArea to a single ciInf_le; the junk-value semantics of ⨅ over unsatisfiable membership binders must be handled explicitly (done here via ciInf_le_of_le descent).",


### PR DESCRIPTION
## Summary
Research session for erdos-507-wip-01 (Heilbronn's triangle problem; `heilbronn n` = the largest achievable minimum triangle area over `n`-point configurations in the closed unit disk).

## Progress
- **`heilbronn_three_ge : 3 * √3 / 4 ≤ heilbronn 3`** — strengthens the existing crude witness `heilbronn 3 ≥ 1/2` to the **conjectured exact value** at `n = 3`.
- Witness: the equilateral triangle inscribed in the unit circle, `(1,0), (−1/2, √3/2), (−1/2, −√3/2)` — all three vertices on the boundary of the unit disk, and every ordering of its vertices has `triangleArea = 3√3/4` (the largest triangle inscribable in a radius-1 disk). Admissible for the `sSup` defining `heilbronn 3` via `le_csSup` + the existing `heilbronn_defining_bddAbove`.
- The canonical-ordering area is computed once (`ring` through the pair projections + `abs_of_nonneg`); the other five ordered triples are discharged by permutation-invariance (`triangleArea_swap_left/right/cyclic`).

## Findings
- `3√3/4 ≈ 1.299` vs the old `1/2` — the inscribed equilateral triangle is the natural extremal `n = 3` configuration. The matching upper bound `heilbronn 3 ≤ 3√3/4` (every unit-disk triangle has area `≤ 3√3/4`) would pin `heilbronn 3 = 3√3/4`, improving the current crude `heilbronn 3 ≤ 3`; that optimization is not session-sized and is left open.

## Verification
- Host-verified at toolchain v4.31.0 via `lake env lean` (child imports Mathlib-only parent `Proofs.Erdos507Problem`): **exit 0, no errors, no new warnings, no sorry**. `#print axioms heilbronn_three_ge` = `[propext, Classical.choice, Quot.sound]` — **axiom-free**.

## Status
**Outcome**: progress (sharp lower bound at `n = 3`)
**Next Steps**: matching upper bound `heilbronn 3 ≤ 3√3/4` to pin the exact value; deep `α(n)` exponent bounds (KPS/CPZ) remain open.

🤖 Generated by researcher-1