### PR TITLE
Track audit: pythagorean-triples-oq001 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31802,6 +31802,12 @@
       "lastAudited": "2026-07-21T15:13:35Z",
       "result": "clean",
       "issues": []
+    },
+    "pythagorean-triples-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T15:15:22Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit: `pythagorean-triples-oq001` — **clean**.

- 10 theorems, 0 defs, 0 axioms, 0 sorries, 181 lines — all match meta.json.
- All claims verified against source: `3 ∤ z` (three_not_dvd_hyp), `4 ∣` even leg, and the false "5 need not" half honestly refuted via the `(3,4,5)` counterexample (five_can_divide_hyp).
- Only `by decide` (kernel, trust-neutral) over small ZMod 3/5/8 — no native_decide; disclosed in docstring ("decide over small ZMods"). 0-axiom claim holds.
- Badge `original` appropriate — elementary number theory, not a Mathlib wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)