### PR TITLE
Track audit: pythagorean-triples-oq002 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31808,6 +31808,12 @@
       "lastAudited": "2026-07-21T15:15:22Z",
       "result": "clean",
       "issues": []
+    },
+    "pythagorean-triples-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T15:16:23Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit: `pythagorean-triples-oq002` — **clean**.

- 16 theorems, 1 def, 0 axioms, 0 sorries, 158 lines — all match meta.json.
- Sharpness claims verified: `universal_iff_dvd_sixty` (exact characterization: universal divisors = divisors of 60), `sixty_isGreatest` (genuine `IsGreatest`), and prime-power maximality (`not_universal_eight/nine/twentyfive/onehundredtwenty`) via the `(3,4,5)` product-60 witness.
- Only kernel `by decide` over small ZMod 3/5/8 — no native_decide; disclosed in docstring. 0-axiom claim holds.
- Badge `original` appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)