### PR TITLE
Track audit: roth-theorem-k3-oq001 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31814,6 +31814,12 @@
       "lastAudited": "2026-07-21T15:16:23Z",
       "result": "clean",
       "issues": []
+    },
+    "roth-theorem-k3-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T15:17:51Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit: `roth-theorem-k3-oq001` — **clean**.

- 5 theorems, 1 def (`reflectShift`), 0 axioms, 0 sorries, 134 lines — all match meta.json.
- Tier-D infrastructure: proves translation-invariance (`kAPCount_translate`) and reflection symmetry (`kAPCount_reflect`) of the k-AP counting operator Λ_k. Does NOT claim to prove Roth/Szemerédi — famous name properly qualified in title/description.
- No `native_decide`; import chain (RothTheoremOQ03OQ01OQ01 → RothTheoremOQ03OQ01) is axiom/sorry-free, so transitive 0-axiom claim holds.
- Badge `verified` is a standard gallery badge (450 entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)