### PR TITLE
Track audit: roth-theorem-k3-oq002 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31820,6 +31820,12 @@
       "lastAudited": "2026-07-21T15:17:51Z",
       "result": "clean",
       "issues": []
+    },
+    "roth-theorem-k3-oq002": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T15:18:47Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit: `roth-theorem-k3-oq002` — **clean**.

- 4 theorems, 1 def (`mulUnit`), 0 axioms, 0 sorries, 132 lines — all match meta.json.
- Tier-D infrastructure: affine covariance of Λ_k (`kAPCount_affine`) with dilation/translation corollaries. Does not claim to prove Roth/Szemerédi — famous name qualified.
- No `native_decide`; import chain (RothTheoremOQ03OQ01… lineage) is axiom/sorry-free, so transitive 0-axiom claim holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)