### PR TITLE
Enrich prime-reciprocal-divergence-oq-03: re-anchor section map (fix mid-theorem split + uncovered theorem)

### DIFF
--- a/src/data/proofs/prime-reciprocal-divergence-oq-03/meta.json
+++ b/src/data/proofs/prime-reciprocal-divergence-oq-03/meta.json
@@ -86,43 +86,43 @@
     {
       "id": "definitions",
       "title": "Smooth and Rough Number Definitions",
-      "startLine": 54,
-      "endLine": 76,
+      "startLine": 53,
+      "endLine": 72,
       "summary": "Defines IsSmooth, IsRough, smoothSet, and primesUpTo."
     },
     {
       "id": "smooth-infrastructure",
       "title": "Squarefree Decomposition Infrastructure",
-      "startLine": 78,
-      "endLine": 177,
+      "startLine": 73,
+      "endLine": 172,
       "summary": "Defines sqfPart/sqRtPart via Nat.sq_mul_squarefree_of_pos. Proves key lemma: squarefree positive naturals with same prime divisors are equal. Defines smoothInj injection."
     },
     {
       "id": "smooth-count",
       "title": "Smooth Count Bound",
-      "startLine": 179,
-      "endLine": 243,
+      "startLine": 173,
+      "endLine": 238,
       "summary": "Proves |smoothSet N n| ≤ √n · 2^{π(N)} via injection into range(√n) × powerset(primesUpTo N). Fully proved, no sorries."
     },
     {
       "id": "rough-count",
       "title": "Counting Rough Numbers and Multiples",
-      "startLine": 245,
+      "startLine": 239,
       "endLine": 286,
       "summary": "Proves multiples_count (bijection with scaled range) and rough_count_bound. Fully proved."
     },
     {
       "id": "main-theorem",
       "title": "Infinitely Many Primes (Erdős's Argument)",
-      "startLine": 288,
-      "endLine": 353,
+      "startLine": 287,
+      "endLine": 347,
       "summary": "Proves infinitely_many_primes_erdos by contradiction and derives prime_reciprocals_unbounded."
     },
     {
       "id": "reciprocal-corollary-notes",
       "title": "Reciprocal Divergence Corollary and Proof-Path Notes",
-      "startLine": 354,
-      "endLine": 396,
+      "startLine": 348,
+      "endLine": 395,
       "summary": "prime_reciprocals_unbounded packages infinitely_many_primes_erdos as the statement that primes are unbounded (∀ N, ∃ p > N prime), the finite-form corollary underlying Σ 1/p = ∞. A closing PART V \"Notes\" block honestly separates what is proved (Euclid-style infinitude via the rough-number counting argument) from what is not (the full quantitative divergence Σ_{p≤x} 1/p ~ log log x), and compares this Erdős-style smooth-number path with the classical proofs.",
       "mathContext": "The rough-number count gives infinitude of primes; the reciprocal sum $\\sum_{p}1/p=\\infty$ follows from the same argument under $\\sum_{p>N}1/p<1/2$, but the sharp $\\sum_{p\\le x}1/p\\sim\\log\\log x$ is not formalised here."
     }


### PR DESCRIPTION
## Summary

Section re-anchor for `prime-reciprocal-divergence-oq-03`. The `sections[]` anchors had drifted off the file's five heavy `/-! ═` PART dividers (53, 73, 239, 287, 361), producing two genuine coverage defects (not just cosmetic drift).

## Defects fixed

1. **Mid-theorem split** — `smooth_count_bound` (theorem at line 173, proof body to 237) started inside the *"Squarefree Decomposition Infrastructure"* section `[78–177]`, with the rest of its proof in the *"Smooth Count Bound"* section `[179–243]`. The theorem the second section is **named for** lived partly in the previous section.
2. **Uncovered theorem** — `multiples_count` (theorem at line **244**) fell into the 1-line gap between `[179–243]` and `[245–286]` — covered by **no section at all**.
3. **EOF overshoot** — the final section ended at `396`, one past the actual EOF (`395`).

## Changes

| Section | Was | Now |
|---------|-----|-----|
| Imports and Proof Overview | 1–52 | 1–52 |
| Smooth and Rough Number Definitions | 54–76 | 53–72 |
| Squarefree Decomposition Infrastructure | 78–177 | 73–172 |
| Smooth Count Bound | 179–243 | 173–238 |
| Counting Rough Numbers and Multiples | 245–286 | 239–286 |
| Infinitely Many Primes (Erdős's Argument) | 288–353 | 287–347 |
| Reciprocal Divergence Corollary and Proof-Path Notes | 354–396 | 348–395 |

## Verification

- Sections now contiguous over `1..395` (EOF), no gaps/overlaps.
- Every named `def`/`theorem` lands inside its correctly-titled section — in particular `smooth_count_bound`→"Smooth Count Bound" and `multiples_count`→"Counting Rough Numbers and Multiples".
- Summaries unchanged: they already described the divider grouping ("Squarefree Infrastructure" never claimed `smooth_count_bound`; "Counting Rough" already claimed `multiples_count`).
- The `Infinitely Many Primes` / `Reciprocal Corollary` boundary moved to the `prime_reciprocals_unbounded` doc-comment (348) instead of splitting it mid-comment (354).
- No change to `status`/`badge`/`axiomCount`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
