### PR TITLE
Track audit: spectral-trace-det-eigenvalues-oq001 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31826,6 +31826,12 @@
       "lastAudited": "2026-07-21T15:18:47Z",
       "result": "clean",
       "issues": []
+    },
+    "spectral-trace-det-eigenvalues-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T15:21:05Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit: `spectral-trace-det-eigenvalues-oq001` — **clean** (build-verified).

- 9 theorems, 2 defs (`e2`,`e3`), 0 axioms, 0 sorries, 250 lines — all match meta.json.
- **Build verified**: `lake build` succeeds; embedded `#print axioms` on trace_fourth_fin_four / trace_fourth_eq_sum_fourth_eigenvalues / charpoly_coeff_two_eq_e2 / det_fin_four all = [propext, Classical.choice, Quot.sound] — no ofReduceBool, no sorryAx.
- Grandparent import (SpectralTraceDetEigenvaluesOQ01) is axiom/sorry-free.
- Badge `original` appropriate — builds `det_fin_four` (absent from Mathlib) and Newton's p₄ identity; famous "Newton's identity" name properly scoped, spectral upgrade reuses disclosed grandparent infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)