### PR TITLE
Track audit: summation-by-parts-oq001 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31838,6 +31838,12 @@
       "lastAudited": "2026-07-21T15:22:56Z",
       "result": "clean",
       "issues": []
+    },
+    "summation-by-parts-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T15:23:59Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit: `summation-by-parts-oq001` — **clean**.

- 4 theorems, 0 defs, 0 axioms, 0 sorries, 126 lines — all match meta.json.
- Elementary self-contained induction+ring proof of the general discrete Abel transform; corollaries (swap, telescope, geometric recovery) all follow by linear_combination/simp.
- No native_decide. Honestly discloses the related Mathlib `Finset.sum_range_by_parts` while proving this cleaner two-sequence formulation from scratch.
- Badge `original` appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)