### PR TITLE
Track audit: summation-by-parts-oq003 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31850,6 +31850,12 @@
       "lastAudited": "2026-07-21T15:25:57Z",
       "result": "clean",
       "issues": []
+    },
+    "summation-by-parts-oq003": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T15:27:04Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit of `summation-by-parts-oq003`.

**Result: clean.** Meta claims match the Lean source exactly.

- theoremCount 4, definitionCount 0 — verified against decls
- axiomCount 0, sorries 0 — no axioms/sorries/True stubs
- No native_decide/decide
- Badge `original` appropriate: generalizes the parent Abel transform to arbitrary biadditive pairings (dropping commutativity), with three correctly-stated specializations (ring, module-valued smul, order-swapped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)