### PR TITLE
Track audit: summation-by-parts-oq004 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31856,6 +31856,12 @@
       "lastAudited": "2026-07-21T15:27:04Z",
       "result": "clean",
       "issues": []
+    },
+    "summation-by-parts-oq004": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T15:28:26Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit of `summation-by-parts-oq004`.

**Result: clean.** Meta claims match the Lean source exactly.

- theoremCount 8, definitionCount 1 — verified against decls
- axiomCount 0, sorries 0 — the lone sorry/native_decide grep hits are a docstring line stating '0 sorry, 0 axiom, no native_decide'
- Badge `original` appropriate: iterated module-valued biadditive Taylor–Abel expansion with ring/smul/order-two specializations. Tower relations hF/hH are disclosed theorem hypotheses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)