### PR TITLE
Track audit: urysohns-lemma-oq001 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31862,6 +31862,12 @@
       "lastAudited": "2026-07-21T15:28:26Z",
       "result": "clean",
       "issues": []
+    },
+    "urysohns-lemma-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T15:29:43Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit of `urysohns-lemma-oq001` (Norm-Preserving Tietze Extension).

**Result: clean.** Meta claims match the Lean source.

- theoremCount 3, def 0, axiomCount 0, sorries 0 — verified
- No native_decide/decide
- Imports parent `UrysohnsLemmaOQ01OQ01OQ01`; uses its `tietze_extension_via_tsum` (real theorem, line 132); parent has no axiom decls → transitive axiomCount 0 holds
- Badge `original` appropriate: sharpens the parent's sup-bound to the equality ‖G‖=‖f‖, adds a universal lower bound and norm-minimality — new results on repo infra, parent construction properly credited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)