### PR TITLE
Track audit: urysohns-lemma-oq003 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31874,6 +31874,12 @@
       "lastAudited": "2026-07-21T15:31:19Z",
       "result": "clean",
       "issues": []
+    },
+    "urysohns-lemma-oq003": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T15:32:20Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit of `urysohns-lemma-oq003` (explicit modulus of convergence for Urysohn–Tietze series).

**Result: clean.** Meta claims match the Lean source.

- theoremCount 5, def 0, axiomCount 0, sorries 0 — verified (lone sorry grep hit is docstring)
- No native_decide/decide; imports axiom-free parent; parent decls (gbcf, tietze_extension_via_tsum, summable_geo) exist
- Badge `original` appropriate: genuine new explicit (2/3)ⁿ·M geometric modulus of uniform convergence; packaged theorem literally proves ‖G‖=‖f‖ plus the tail bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)