### PR TITLE
Track audit: wilsons-theorem-oq001 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31880,6 +31880,12 @@
       "lastAudited": "2026-07-21T15:32:20Z",
       "result": "clean",
       "issues": []
+    },
+    "wilsons-theorem-oq001": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-21T15:33:33Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Gallery integrity audit of `wilsons-theorem-oq001` (Kempner–Smarandache S(p^k) via Legendre).

**Result: clean.** Meta claims match the Lean source.

- theoremCount 10, definitionCount 1 (S), axiomCount 0, sorries 0 — verified
- No native_decide/decide, no True stubs
- Badge `original` appropriate: Mathlib has no Kempner–Smarandache material; results are original derivations on disclosed Mathlib Legendre infra. Scope honest: S(p^k)=p·k proved to hold *iff k≤p* (linear range + sharp failure boundary), not overclaimed as a universal closed form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)