### PR TITLE
Enrich erdos-428: re-anchor section map (fix stranded requires-infinite theorem)

### DIFF
--- a/src/data/proofs/erdos-428/meta.json
+++ b/src/data/proofs/erdos-428/meta.json
@@ -187,15 +187,15 @@
       "id": "finite-density-zero",
       "title": "Finite Sets Have Zero Prime Density",
       "startLine": 163,
-      "endLine": 186,
+      "endLine": 203,
       "summary": "Proves `finite_set_zero_density`: a finite set $A$ has $\\liminf \\text{primeDensityRatio}(A, n) = 0$. The squeeze argument: $0 \\leq \\text{ratio} \\leq |A|/\\pi(n)$, and $|A|/\\pi(n) \\to 0$ since $\\pi(n) \\to \\infty$.",
       "mathContext": "For finite $A$ with $|A| = M$: $|A \\cap [1,n]|/\\pi(n) \\leq M/\\pi(n) \\to 0$. This uses `squeeze_zero` and the prime counting divergence."
     },
     {
       "id": "requires-infinite",
       "title": "Problem #428 Requires an Infinite Set",
-      "startLine": 188,
-      "endLine": 196,
+      "startLine": 204,
+      "endLine": 215,
       "summary": "Proves `erdos428_requires_infinite`: any set satisfying Problem #428 (positive prime density of all-prime offsets) must be infinite. By contradiction: a finite set has zero density (from `finite_set_zero_density`), contradicting the positive liminf.",
       "mathContext": "The proof: if $A$ were finite, $\\liminf \\text{primeDensityRatio} = 0$ by the squeeze lemma, contradicting $\\liminf > 0$. So any solution $A$ must be infinite."
     }


### PR DESCRIPTION
Section-map re-anchor for `erdos-428` (any solution to Erdős #428 must use an infinite set).

**Defect (navigation correctness, not scored):** the last two `sections[]` ranges had drifted so the eponymous conclusion theorem was invisible in the gallery outline:

- `finite-density-zero` claimed lines 163–186, but `finite_set_zero_density`'s proof body actually runs to **line 203** — the section cut off most of its proof.
- `requires-infinite` claimed lines 188–196, but that range sits **inside `finite_set_zero_density`'s proof body**; the actual `erdos428_requires_infinite` theorem (lines 206–215) was **entirely uncovered**.

**Fix (mechanical re-anchor, prose/status/axiomCount untouched):**

| section | old | new | decl covered |
|---|---|---|---|
| finite-density-zero | 163–186 | 163–203 | finite_set_zero_density@185 (full proof) |
| requires-infinite | 188–196 | 204–215 | **erdos428_requires_infinite@206** (to EOF) |

Both named theorems now land wholly inside their titled sections, and coverage runs to EOF (215). The existing summaries already described these theorems accurately, so only `startLine`/`endLine` changed. Verified JSON valid.
