### PR TITLE
Audit: re-verify erdos-838 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16751,8 +16751,8 @@
     },
     "erdos-838": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:14:52Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T15:38:38Z",
       "result": "clean"
     },
     "erdos-839": {


### PR DESCRIPTION
Reserve-mode re-audit (unaudited queue drained, 0 remaining).

## Verified
- **Axioms: 5** (`isConvexSubset`, `f`, `erdos_lower_bound`, `erdos_upper_bound`, `f_superpolynomial`) — matches `axiomCount: 5`
- **Theorems: 2** (`erdos_bounds`, `erdos_838_summary`) — matches `theoremCount: 2`
- **Definitions: 6** — matches
- **Sorries: 0**, no `native_decide`
- Status `axiomatized`, badge `axiom` — honest for an OPEN problem
- Axioms consistent (no false/vacuous-guard axioms; lower/upper bounds satisfiable, f abstract)

No integrity issues. Tracker timestamp bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)