### PR TITLE
Enrich cauchy-schwarz-integral-oq005: cover stranded mean definitions

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq005/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq005/meta.json
@@ -67,6 +67,14 @@
   },
   "sections": [
     {
+      "id": "definitions",
+      "title": "Definitions: The Four Means",
+      "summary": "Module setup and the four power-mean definitions on positive reals: HM (harmonic, 2ab/(a+b)), GM (geometric, √(ab)), AM (arithmetic, (a+b)/2), and QM (quadratic, √((a²+b²)/2)). The file establishes the full chain min ≤ HM ≤ GM ≤ AM ≤ QM ≤ max.",
+      "startLine": 1,
+      "endLine": 54,
+      "mathContext": "Formal definitions: $\\mathrm{HM} = \\frac{2ab}{a+b}$, $\\mathrm{GM} = \\sqrt{ab}$, $\\mathrm{AM} = \\frac{a+b}{2}$, $\\mathrm{QM} = \\sqrt{\\frac{a^2+b^2}{2}}$."
+    },
+    {
       "id": "min-le-hm",
       "title": "min ≤ HM",
       "summary": "Case split proof using mul_nonneg; gap = a*(b-a) after ring",


### PR DESCRIPTION
## Cover stranded core definitions in cauchy-schwarz-integral-oq005

The `sections` map in `meta.json` began at line 56 ("Step 1: min ≤ HM"),
leaving lines 1–55 uncovered — the module docstring plus the **four core
power-mean definitions** the whole proof is about:

- `HM` (harmonic), `GM` (geometric), `AM` (arithmetic), `QM` (quadratic) at
  lines 51–54.

These had no gallery outline entry. Added a leading **Definitions** section
covering lines 1–54, matching the file's existing 1-line inter-section gap
style (verified: every declaration lands in a section; last section ends at
EOF 187).

Section map only — no changes to math, status, badge, or axiom count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
