### PR TITLE
Audit: re-verify erdos-799 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16446,8 +16446,8 @@
     },
     "erdos-799": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:45Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T15:41:29Z",
       "result": "clean"
     },
     "erdos-8": {


### PR DESCRIPTION
Reserve-mode re-audit (queue drained).

## Verified
- Counts match: 2 axioms, 1 theorem, 4 defs, 0 sorries, no decide/native_decide
- Sections honestly disclose comment-only ranges ('Documentation only... not formalized') — prior audit fix confirmed
- status axiomatized, badge axiom; assumptions list both axioms
- Result attributed to Alon (1992) / AKS (1999), not claimed as our independent proof
- Axioms consistent

No integrity issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)