### PR TITLE
Audit: re-verify erdos-795 clean (0 axioms, 13 theorems, 14 sorries)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16420,8 +16420,8 @@
     },
     "erdos-795": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:45Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T15:43:59Z",
       "result": "clean"
     },
     "erdos-796": {


### PR DESCRIPTION
## Audit: erdos-795 (reserve-mode re-verify)

Queue drained (0 unaudited); re-served oldest uncontested entry.

**Verdict: CLEAN** — honestly-disclosed WIP scaffold.

| Field | meta | actual |
|-------|------|--------|
| sorries | 14 | 14 ✓ |
| axiomCount | 0 | 0 ✓ |
| theoremCount | 13 | 13 ✓ (14th grep hit is docstring prose, line 490) |
| definitionCount | 7 | 7 ✓ |
| badge | wip | appropriate ✓ |

- No True stubs, no `native_decide`.
- Only genuinely-proved theorem is `raghavan_error_is_smaller` (line 353); prose correctly says it's "the only non-sorry theorem".
- False `Sidon → DSP` direction was removed with an explicit counterexample note.
- "SOLVED" wording tracks literature status (`erdosProblemStatus: solved`), not a Lean claim; conclusion honestly notes only the error comparison is proved.
- "Aristotle failed to load" comments are stale annotation cruft, not compile errors.

Only change: tracker timestamp/count for erdos-795.

🤖 Generated with [Claude Code](https://claude.com/claude-code)