### PR TITLE
Enrich amgm-inequality-oq-03-oq-03-oq-01: cover stranded power-mean definition

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-03-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-03-oq-01/meta.json
@@ -89,9 +89,17 @@
   },
   "sections": [
     {
+      "id": "definitions",
+      "title": "Definitions: The Power Mean M_r",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "Module setup and the central definition: the unweighted power mean M(r) = ((∑ xᵢʳ)/n)^(1/r), together with the cardinality helpers hN_pos and hN_ne asserting the vertex count n = |ι| is positive (nonzero) as a real.",
+      "mathContext": "$M_r(x) = \\left(\\frac{1}{n}\\sum_i x_i^r\\right)^{1/r}$ for a finite nonempty index type $\\iota$ with $n = |\\iota|$; hN_pos/hN_ne record $0 < (n:\\mathbb{R})$ and $(n:\\mathbb{R}) \\ne 0$."
+    },
+    {
       "id": "helpers",
       "title": "Helper Lemmas",
-      "startLine": 40,
+      "startLine": 36,
       "endLine": 74,
       "summary": "tendsto_rpow_inv_atTop (c^{1/r} → 1 as r → +∞) and rpow_le_rpow_of_nonpos (monotone rpow for nonpositive exponents).",
       "mathContext": "$c^{r^{-1}} = e^{(\\log c)/r} \\to e^0 = 1$ as $r \\to +\\infty$ (continuity of $\\exp$ at 0). For $0 < a \\leq b$ and $z \\leq 0$: $b^z \\leq a^z$ (proved via $z = -(-z)$ and `rpow_neg`)."


### PR DESCRIPTION
## Cover the stranded power-mean definition in amgm-inequality-oq-03-oq-03-oq-01

The `sections` map began at line 40 ("Helper Lemmas"), leaving lines 1–39
uncovered — including the **central definition** of the object the whole file
studies:

- `M (r) = ((∑ xᵢʳ)/n)^(1/r)` — the unweighted power mean (line 27), and
- `hN_pos` / `hN_ne`, the cardinality helpers (lines 30–33).

These had no gallery outline entry. Added a leading **Definitions** section
(lines 1–35) and extended the Helper Lemmas section to start at line 36 so it
owns its "Section 1" banner comment. The map now covers **1..272 contiguously**
(verified: no gaps/overlaps, last endLine = EOF, every declaration inside a
section).

Section map only — no math/status/axiom changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
