### PR TITLE
Audit erdos-792: clean re-serve (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16402,8 +16402,8 @@
     },
     "erdos-792": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:45Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T15:46:15Z",
       "result": "clean"
     },
     "erdos-793": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-792

Reserve-mode re-verification (queue drained, oldest uncontested target).

**Result: CLEAN** — no changes needed to meta.json.

### Verified
- **Counts match meta exactly**: 4 axioms (`f`, `bourgain_bound`, `bedert_bound`, `egm_upper_bound`), 5 theorems, 4 defs, 0 sorries, no `native_decide`.
- **No inconsistency**: Bedert lower (`f n ≥ n/3 + c·log log n` eventually) compatible with EGM upper (`f n ≤ n/3 + ε·n` ∀ε>0) since `log log n = o(n)`; Bourgain nat-division lower `(n+2)/3` consistent with both.
- **No false/vacuous axioms**: `f` opaque; all bounds are genuine ∀/∃ with real bodies — no `True`-guards or `¬∃` masking.
- **Honest tier**: status `axiomatized`, badge `axiom`, open-problem title. The two "derived" theorems genuinely follow from `bourgain_bound`.

Only change: tracker timestamp/auditCount bump.

---
Discovered during gallery integrity audit.