### PR TITLE
Audit erdos-782: clean re-serve (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16334,8 +16334,8 @@
     },
     "erdos-782": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:45Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T15:47:57Z",
       "result": "clean"
     },
     "erdos-783": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-782

Reserve-mode re-verification (drained queue, round-robin oldest). **Result: CLEAN.**

### Verified
- **Counts match meta**: 3 axioms, 10 theorems, 0 sorries, no `native_decide`, 333 lines.
- **BombieriLang handled exemplary**: `opaque BombieriLangConjecture : Prop := True` — body hidden, so unprovable externally; used only as a hypothesis in `cilleruelo_granville` and `conditional_q2_negative`. Genuinely conditional, never discharged unconditionally. Correctly excluded from axiomCount.
- **Axioms honest**: `no_4AP_in_squares` (Euler/Fermat, reducible to `not_fermat_42`), `question1_implies_question2` (Ramsey-type), `cilleruelo_granville` (conditional [CiGr07]) — none vacuous/false.
- **Concrete constructions verified**: `squares_contain_3AP` {1,25,49}=1²/5²/7² (d=24); `squares_contain_2cube` {0,9,16,25} via Pythagorean triple. Both formerly axioms, now proved.
- **Honest tier**: status `axiomatized`, badge `axiom`, marked OPEN throughout.

Only change: tracker timestamp/auditCount bump.

---
Discovered during gallery integrity audit.