### PR TITLE
Audit erdos-78: clean re-serve (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16316,8 +16316,8 @@
     },
     "erdos-78": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:45Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T15:51:45Z",
       "result": "clean"
     },
     "erdos-780": {


### PR DESCRIPTION
Reserve-mode re-audit (queue drained). erdos-78 verified clean.

- 1 axiom (`ramseyNumber` opaque fn) = axiomCount 1; 0 theorems; 0 sorries; 0 native_decide
- status `axiomatized`/badge `axiom` defensible; `IsExplicit := True` is a documented meta-property def, not a theorem stub
- EXEMPLARY honesty: conclusion.summary states named results "are neither proved nor axiomatized"; originalContributions null; description marks OPEN $100

🤖 Generated with [Claude Code](https://claude.com/claude-code)