### PR TITLE
Research: erdos-1039-oq-05 — pin the second term's lower bound d₃ ≥ √3 (cube roots of unity, 0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
+++ b/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
@@ -609,4 +609,123 @@ theorem transfiniteDiameter_le_two_via_d2 :
   have := transfiniteDiameter_le 0
   rwa [transfiniteDiameterN_two] at this
 
+/-! ### The second term is sandwiched: `√3 ≤ d₃ ≤ 2`
+
+The `3`-point diameter is the geometric mean of the three pairwise gaps,
+`d₃(z) = (‖z₀-z₁‖·‖z₀-z₂‖·‖z₁-z₂‖)^{1/3}` (the normalising exponent
+`2/(n(n-1))` equals `1/3` at `n = 3`).  The equilateral triangle of cube roots of
+unity `{1, ω, ω²}` with `ω = -1/2 + (√3/2)i` lies on the unit circle and has all
+three gaps equal to `√3`, so its diameter is `((√3)³)^{1/3} = √3`.  This yields
+the sharp **lower bound** `d₃ ≥ √3`; combined with Fekete monotonicity
+`d₃ ≤ d₂ = 2` (`transfiniteDiameterN_succ_le`, `transfiniteDiameterN_two`) it
+sandwiches the second term of the sequence in `[√3, 2]`.
+
+The matching **upper bound** `d₃ = √3` — that no `3`-point configuration in the
+closed unit disc beats the inscribed equilateral triangle — is a genuine extremal
+optimisation (the `n = 3` case of the Fekete–Szegő theorem) and is *not*
+established here; only the elementary lower bound is. -/
+
+/-- The Euclidean norm of a complex number written in Cartesian form:
+`‖x + yi‖ = √(x² + y²)`. -/
+private theorem norm_mk_eq_sqrt (x y : ℝ) :
+    ‖(⟨x, y⟩ : ℂ)‖ = Real.sqrt (x ^ 2 + y ^ 2) := by
+  rw [← Real.sqrt_sq (norm_nonneg (⟨x, y⟩ : ℂ)), ← Complex.normSq_eq_norm_sq,
+    Complex.normSq_mk]
+  congr 1
+  ring
+
+/-- The spread product of a `3`-point configuration is the product of its three
+pairwise gaps `‖z₀-z₁‖·‖z₀-z₂‖·‖z₁-z₂‖` (the three pairs `i < j` in `Fin 3`). -/
+theorem spreadProduct_three (z : Fin 3 → ℂ) :
+    spreadProduct z = ‖z 0 - z 1‖ * ‖z 0 - z 2‖ * ‖z 1 - z 2‖ := by
+  unfold spreadProduct
+  rw [Fin.prod_univ_three]
+  have h0 : Finset.Ioi (0 : Fin 3) = {1, 2} := by decide
+  have h1 : Finset.Ioi (1 : Fin 3) = {2} := by decide
+  have h2 : Finset.Ioi (2 : Fin 3) = (∅ : Finset (Fin 3)) := by decide
+  rw [h0, h1, h2, Finset.prod_pair (by decide : (1 : Fin 3) ≠ 2),
+    Finset.prod_singleton, Finset.prod_empty, mul_one]
+
+/-- The `3`-point diameter is the geometric mean of the three pairwise gaps:
+the normalising exponent `2/(n(n-1))` equals `1/3` at `n = 3`. -/
+theorem discreteDiameter_three (z : Fin 3 → ℂ) :
+    discreteDiameter z
+      = (‖z 0 - z 1‖ * ‖z 0 - z 2‖ * ‖z 1 - z 2‖) ^ ((1 : ℝ) / 3) := by
+  rw [discreteDiameter, spreadProduct_three]
+  norm_num
+
+/-- **`d₃ ≥ √3`.**  The `3`-point transfinite diameter of the closed unit disc is
+at least `√3`, attained by the equilateral triangle of cube roots of unity
+`{1, ω, ω²}` with `ω = -1/2 + (√3/2)i`: all three pairwise gaps equal `√3`, so its
+`3`-point diameter is `((√3)³)^{1/3} = √3`.  Together with `d₃ ≤ d₂ = 2` this pins
+the second term of the sequence into `[√3, 2]`. -/
+theorem transfiniteDiameterN_three_ge : Real.sqrt 3 ≤ transfiniteDiameterN 3 := by
+  have hs2 : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  -- the equilateral triangle of cube roots of unity
+  set z : Fin 3 → ℂ := ![1, ⟨-1/2, Real.sqrt 3/2⟩, ⟨-1/2, -(Real.sqrt 3/2)⟩]
+    with hz_def
+  have e0 : z 0 = 1 := by simp [hz_def]
+  have e1 : z 1 = (⟨-1/2, Real.sqrt 3/2⟩ : ℂ) := by simp [hz_def]
+  have e2 : z 2 = (⟨-1/2, -(Real.sqrt 3/2)⟩ : ℂ) := by simp [hz_def]
+  -- the three pairwise gaps are all √3
+  have g01 : ‖z 0 - z 1‖ = Real.sqrt 3 := by
+    have hd : z 0 - z 1 = (⟨3/2, -(Real.sqrt 3/2)⟩ : ℂ) := by
+      rw [e0, e1, Complex.ext_iff]
+      norm_num [Complex.sub_re, Complex.sub_im]
+    rw [hd, norm_mk_eq_sqrt,
+      show ((3:ℝ)/2) ^ 2 + (-(Real.sqrt 3/2)) ^ 2 = (9 + Real.sqrt 3 ^ 2) / 4 by ring,
+      hs2]
+    norm_num
+  have g02 : ‖z 0 - z 2‖ = Real.sqrt 3 := by
+    have hd : z 0 - z 2 = (⟨3/2, Real.sqrt 3/2⟩ : ℂ) := by
+      rw [e0, e2, Complex.ext_iff]
+      norm_num [Complex.sub_re, Complex.sub_im]
+    rw [hd, norm_mk_eq_sqrt,
+      show ((3:ℝ)/2) ^ 2 + (Real.sqrt 3/2) ^ 2 = (9 + Real.sqrt 3 ^ 2) / 4 by ring,
+      hs2]
+    norm_num
+  have g12 : ‖z 1 - z 2‖ = Real.sqrt 3 := by
+    have hd : z 1 - z 2 = (⟨0, Real.sqrt 3⟩ : ℂ) := by
+      rw [e1, e2, Complex.ext_iff]
+      norm_num [Complex.sub_re, Complex.sub_im]
+    rw [hd, norm_mk_eq_sqrt,
+      show (0:ℝ) ^ 2 + Real.sqrt 3 ^ 2 = Real.sqrt 3 ^ 2 by ring, hs2]
+  -- the diameter of this configuration is exactly √3
+  have hdiam : discreteDiameter z = Real.sqrt 3 := by
+    rw [discreteDiameter_three, g01, g02, g12,
+      show Real.sqrt 3 * Real.sqrt 3 * Real.sqrt 3 = Real.sqrt 3 ^ (3 : ℕ) by ring,
+      ← Real.rpow_natCast (Real.sqrt 3) 3,
+      ← Real.rpow_mul (Real.sqrt_nonneg 3)]
+    norm_num
+  -- every vertex lies in the closed unit disc
+  have n0 : ‖z 0‖ ≤ 1 := by rw [e0]; simp
+  have n1 : ‖z 1‖ ≤ 1 := by
+    rw [e1, norm_mk_eq_sqrt,
+      show (-1/2:ℝ) ^ 2 + (Real.sqrt 3/2) ^ 2 = (1 + Real.sqrt 3 ^ 2) / 4 by ring, hs2,
+      show ((1:ℝ) + 3) / 4 = 1 by norm_num, Real.sqrt_one]
+  have n2 : ‖z 2‖ ≤ 1 := by
+    rw [e2, norm_mk_eq_sqrt,
+      show (-1/2:ℝ) ^ 2 + (-(Real.sqrt 3/2)) ^ 2 = (1 + Real.sqrt 3 ^ 2) / 4 by ring, hs2,
+      show ((1:ℝ) + 3) / 4 = 1 by norm_num, Real.sqrt_one]
+  have hmem : ∀ i, ‖z i‖ ≤ 1 := by
+    intro i; fin_cases i
+    · exact n0
+    · exact n1
+    · exact n2
+  -- √3 is realised as the diameter of a disc configuration, hence ≤ the sSup
+  have hin : Real.sqrt 3 ∈ unitDiscDiameters 3 := ⟨z, hmem, hdiam⟩
+  exact le_csSup (unitDiscDiameters_bddAbove (by norm_num)) hin
+
+/-- **The second term is sandwiched: `d₃ ∈ [√3, 2]`.**  The lower bound is
+`transfiniteDiameterN_three_ge` (cube roots of unity); the upper bound is Fekete
+monotonicity `d₃ ≤ d₂` (`transfiniteDiameterN_succ_le`) composed with the exact
+first term `d₂ = 2` (`transfiniteDiameterN_two`).  The exact value `d₃ = √3` needs
+the extremal upper bound and is not established here. -/
+theorem transfiniteDiameterN_three_mem_Icc :
+    transfiniteDiameterN 3 ∈ Set.Icc (Real.sqrt 3) 2 := by
+  refine ⟨transfiniteDiameterN_three_ge, ?_⟩
+  have h32 : transfiniteDiameterN 3 ≤ transfiniteDiameterN 2 :=
+    transfiniteDiameterN_succ_le (le_refl 2)
+  rwa [transfiniteDiameterN_two] at h32
+
 end Erdos1039TransfiniteDiameter

--- a/src/data/research/problems/erdos-1039-oq-05.json
+++ b/src/data/research/problems/erdos-1039-oq-05.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1039-oq-05",
   "title": "How does ρ(f) relate to the transfinite diameter of the root set and to the logarithmic capacity of the lemniscate complement?",
-  "phase": "ORIENT",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -48,7 +48,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Pinned the first exact term of the transfinite-diameter sequence, transfiniteDiameterN 2 = 2 (attained by antipodal ![1,-1]), plus spreadProduct_two/discreteDiameter_two helpers and transfiniteDiameter_le_two_via_d2 — all 0-axiom/0-sorry, host-verified [propext, Classical.choice, Quot.sound]. The elementary transfinite-diameter layer (spread, Fekete monotonicity dₙ₊₁≤dₙ at sup level, the ⨅ₙ limit ∈[0,2]) is now complete; sharp d=1 (log-capacity) stays deep-blocked (Fekete–Szegő).",
+    "progressSummary": "PROGRESS: elementary sharp-value program advanced — first exact term d₂=2 and now the second term lower bound d₃≥√3 (sandwich d₃∈[√3,2]), all 0-axiom. Remaining: extremal upper bounds (Fekete–Szegő) and the general roots-of-unity lower bound dₙ≥n^{1/(n-1)}. Parent Erdős #1039 OPEN.",
     "builtItems": [
       "Erdos1039TransfiniteDiameter.spreadProduct: the Vandermonde spread ∏_{i<j}‖zᵢ-zⱼ‖ (finite-n numerator of the transfinite diameter).",
       "Erdos1039TransfiniteDiameter.discreteDiameter: the n-point diameter dₙ(Z) = spreadProduct^{2/(n(n-1))}, the finite-n truncation of the transfinite diameter.",
@@ -67,7 +67,11 @@
       "transfiniteDiameter (def) + tendsto_transfiniteDiameterN: the n-point diameters d_{n+2} converge to d = ⨅ₙ d_{n+2} (antitone + bounded-below ⟹ tendsto_atTop_ciInf). Makes the transfinite diameter of the unit disc a genuine LIMIT, not just an infimum.",
       "transfiniteDiameter_mem_Icc: d ∈ [0,2]; transfiniteDiameter_le: d ≤ d_{n+2} for all n. All 0-axiom, host-verified v4.31.",
       "Fekete monotonicity (sup form) transfiniteDiameterN_succ_le was ALREADY DONE in-tree (knowledge Next#1 was stale).",
-      "spreadProduct_two, discreteDiameter_two, transfiniteDiameterN_two (=2), transfiniteDiameter_le_two_via_d2 in Erdos1039TransfiniteDiameter.lean (4 axiom-free)"
+      "spreadProduct_two, discreteDiameter_two, transfiniteDiameterN_two (=2), transfiniteDiameter_le_two_via_d2 in Erdos1039TransfiniteDiameter.lean (4 axiom-free)",
+      "transfiniteDiameterN_three_ge : √3 ≤ transfiniteDiameterN 3 (Erdos1039TransfiniteDiameter.lean, PR #40639, 0-axiom)",
+      "transfiniteDiameterN_three_mem_Icc : d₃ ∈ [√3, 2] (0-axiom)",
+      "spreadProduct_three / discreteDiameter_three : 3-point diameter = geometric mean of the three pairwise gaps (exponent 2/(n(n-1))=1/3 at n=3)",
+      "norm_mk_eq_sqrt : ‖x+yi‖ = √(x²+y²) helper"
     ],
     "insights": [
       "The finite discrete spread is entirely elementary and needs NO capacity infrastructure: it is a product of pairwise norms, equal to the modulus of the Vandermonde determinant, so it is host-verifiable Mathlib-only (no Docker).",
@@ -80,7 +84,8 @@
       "Fekete monotonicity LIFTS to the supremum level: defining dₙ = sup over n-point configs in the closed unit disc of discreteDiameter, the pointwise exists_deleteAt_discreteDiameter_ge gives transfiniteDiameterN_succ_le (d_{n+1} ≤ dₙ, n≥2) directly via csSup_le + le_csSup — no compactness API needed, only that the config values stay in the disc under deletion and that dₙ(Z)≤2 bounds the sup. The disc is the natural compact set (parent lemniscate roots lie in it).",
       "Limit existence (researcher-1, 2026-07-20): the transfinite diameter of the closed unit disc is now a well-defined real number d = limₙ dₙ = ⨅ₙ dₙ ∈ [0,2], via Mathlib tendsto_atTop_ciInf on the antitone (Fekete) bounded-below sequence. The SHARP value d = 1 (= logarithmic capacity of the disc) remains open: it needs the Fekete–Szegő theorem plus extremal root-of-unity configurations (spreadProduct of nth roots of unity → the discriminant), not yet formalized. The current upper bound is the coarse dₙ ≤ 2.",
       "d₂ = transfiniteDiameterN 2 = 2 EXACTLY: the 2-point diameter reduces to the single gap ‖z₀-z₁‖ (exponent 2/(n(n-1))=1 at n=2), max over the closed disc is 2, attained by antipodal ![1,-1]. Only elementary exact stage; sharp d=1 needs Fekete–Szegő.",
-      "Lean: collapse ∏ i:Fin 2, ∏ j∈Ioi i via Fin.prod_univ_two + (Finset.Ioi (0:Fin 2)={1}, Ioi (1:Fin 2)=∅) by decide; ![1,-1] value/membership goals by norm_num / fin_cases."
+      "Lean: collapse ∏ i:Fin 2, ∏ j∈Ioi i via Fin.prod_univ_two + (Finset.Ioi (0:Fin 2)={1}, Ioi (1:Fin 2)=∅) by decide; ![1,-1] value/membership goals by norm_num / fin_cases.",
+      "Second exact term d₃ is sandwiched in [√3, 2]: lower bound √3 attained by the equilateral triangle of cube roots of unity {1, ω, ω²} (all three pairwise gaps = √3, so diameter ((√3)³)^{1/3} = √3); upper bound from Fekete monotonicity d₃ ≤ d₂ = 2. Exact d₃ = √3 needs the Fekete–Szegő extremal upper bound (no 3-point disc config beats the inscribed equilateral triangle), NOT yet done."
     ],
     "mathlibGaps": [
       "Mathlib has no transfinite-diameter / logarithmic-capacity API; the n-point spread and its diameter had to be defined from scratch (done here). The limit d(Z)=limₙ dₙ and Fekete monotonicity are still absent."
@@ -89,7 +94,9 @@
       "Package d(disc) = ⨅ₙ transfiniteDiameterN n and show the sequence converges to it (Antitone + BddBelow ⟹ Tendsto to iInf).",
       "Define logarithmic capacity of the lemniscate complement and axiomatize cap=1 normalization for monic f (Fekete–Szegő).",
       "State ρ(f) ≳ g(d(Z),cap) as theorems/axioms citing Pommerenke/KLR.",
-      "Bridge spreadProduct to Erdos1039Problem.UnitDiscPolynomial.roots (needs Docker)."
+      "Bridge spreadProduct to Erdos1039Problem.UnitDiscPolynomial.roots (needs Docker).",
+      "Upper bound d₃ ≤ √3 (Fekete–Szegő extremal: maximise product of pairwise distances of 3 points in closed unit disc — equilateral triangle on boundary is extremal). This closes d₃ = √3 exactly.",
+      "General lower bound dₙ ≥ n^{1/(n-1)} via n-th roots of unity: spreadProduct(roots of unity) = n^{n/2} from ∏_{j≠0}(1-ω^j)=n (evaluate (xⁿ-1)/(x-1) at x=1). This gives d = limₙ dₙ ≥ 1, matching the sharp capacity value."
     ],
     "markdown": "# Knowledge Base: erdos-1039-oq-05\n\nInsights accumulated during research on relating ρ(f) to transfinite diameter and logarithmic capacity.\n\n---\n\n## Problem Understanding\n\nρ(f) is the inscribed-disc radius of the lemniscate interior {|f|<1}. The lemniscate {|f|=1} is the level-1 curve of the Green's function of the complement, so ρ(f) is potential-theoretic. Two capacity-type invariants attach to f: the transfinite diameter d of the root multiset, and the logarithmic capacity of {|f|≥1}.\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -175,6 +182,6 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1039TransfiniteDiameter.lean"
     }
   ],
-  "lastUpdate": "2026-07-20",
-  "nextAction": "Sharpen the transfinite diameter to its true value d = 1: (a) compute discreteDiameter of the n-th roots of unity via the Vandermonde/discriminant product (spreadProduct of roots of unity), giving a lower bound dₙ ≥ n^{1/(n-1)} → 1; (b) matching upper bound d ≤ 1 (needs a capacity/potential argument, likely axiomatize citing Fekete–Szegő). Then connect d(disc)=cap=1 to the Erdős-1039 radius bound ρ(f)."
+  "lastUpdate": "2026-07-21",
+  "nextAction": "Prove the extremal upper bound d₃ ≤ √3 (Fekete–Szegő: equilateral triangle on the boundary is extremal for 3 points) to close d₃ = √3 exactly; and/or the general roots-of-unity lower bound dₙ ≥ n^{1/(n-1)} via spreadProduct(n-th roots of unity) = n^{n/2}."
 }


### PR DESCRIPTION
## erdos-1039-oq-05 — pin the second exact term's lower bound: d₃ ≥ √3

Continues the transfinite-diameter programme for Erdős #1039 (OQ-05). Prior
sessions built the finite spread product, Fekete monotonicity (pointwise + sup
form), the limit `d = ⨅ₙ dₙ ∈ [0,2]`, and pinned the **first** exact term
`d₂ = 2`. This session pins the **lower bound of the second term**.

### Result

`transfiniteDiameterN_three_ge : √3 ≤ transfiniteDiameterN 3`

realised by the equilateral triangle of cube roots of unity `{1, ω, ω²}` with
`ω = -1/2 + (√3/2)i`. All three pairwise gaps equal `√3`, so its 3-point
diameter is `((√3)³)^{1/3} = √3`. Combined with Fekete monotonicity
`d₃ ≤ d₂ = 2` this sandwiches the second term:

`transfiniteDiameterN_three_mem_Icc : transfiniteDiameterN 3 ∈ [√3, 2]`

### New declarations (all axiom-free — propext/Classical.choice/Quot.sound only)

- `norm_mk_eq_sqrt` — `‖x + yi‖ = √(x²+y²)`
- `spreadProduct_three`, `discreteDiameter_three` — the 3-point diameter is the
  geometric mean of the three pairwise gaps (exponent `2/(n(n-1)) = 1/3` at `n=3`)
- `transfiniteDiameterN_three_ge` — `√3 ≤ d₃`
- `transfiniteDiameterN_three_mem_Icc` — `d₃ ∈ [√3, 2]`

### Scope / honesty

- Only the **lower bound** is proved. The matching upper bound `d₃ = √3` (that no
  3-point disc configuration beats the inscribed equilateral triangle) is the
  `n=3` case of the Fekete–Szegő extremal theorem and is **not** established here.
- The parent Erdős #1039 (`ρ(f) ≫ 1/n`) remains OPEN.
- `Erdos1039TransfiniteDiameter.lean` is a standalone research companion, not in
  the erdos-1039 gallery `additionalFiles`, so no gallery-meta count change.

Host-verified clean with `lake env lean` (v4.31.0, Mathlib-only import); axioms
confirmed via `#print axioms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
