### PR TITLE
Enrich borsuk-ulam-oq-02-oq-01-oq-04: re-anchor section map to 7 PART dividers

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-04/meta.json
@@ -87,31 +87,31 @@
       "title": "Key Properties of the FH Index",
       "summary": "Proves point computation and sphere free action computation by rfl from definitions.",
       "startLine": 106,
-      "endLine": 123,
+      "endLine": 122,
       "mathContext": "Proved: $\\text{Index}_G(\\text{pt}) = H^*(BG)$ and $\\text{Index}_{\\mathbb{Z}/p}(S^{2n-1}) = (u^n)$ by definitional unfolding."
     },
     {
       "id": "bu-connection",
       "title": "Connection to BU Dimension",
       "summary": "Proves `fh_implies_buDim_lower_bound` and `fh_recovers_yang_borsuk` from parent axioms.",
-      "startLine": 131,
-      "endLine": 167,
+      "startLine": 123,
+      "endLine": 155,
       "mathContext": "Shows FH index computations recover $\\text{buDim}(p, 2n) = 2n - 1$ via Yang-Borsuk."
     },
     {
       "id": "composite-groups",
       "title": "FH for Composite Groups",
-      "summary": "Documents restriction maps (not yet formalized), proves `fh_z4_bound` and `fh_z6_bound` from parent monotonicity.",
-      "startLine": 168,
-      "endLine": 210,
+      "summary": "Proves `fh_recovers_monotonicity` (Part V), then documents restriction maps (not yet formalized) and proves the specific composite bounds `fh_z4_bound` and `fh_z6_bound` (Part VI) from parent monotonicity.",
+      "startLine": 156,
+      "endLine": 209,
       "mathContext": "Restriction maps $\\text{res}_p : H^*(B\\mathbb{Z}/n) \\to H^*(B\\mathbb{Z}/p)$ encode monotonicity algebraically."
     },
     {
       "id": "extensions",
       "title": "What FH Could Resolve",
-      "summary": "Documents product formula, discusses open questions about computability and non-cyclic groups.",
-      "startLine": 211,
-      "endLine": 230,
+      "summary": "Documents the product formula and open questions about computability and non-cyclic groups, then proves `fh_extends_monotonicity`: the FH framework subsumes monotonicity while adding restriction-map structure.",
+      "startLine": 210,
+      "endLine": 251,
       "mathContext": "Product formula $\\text{Index}(X \\times Y) \\supseteq \\text{Index}(X) \\cdot \\text{Index}(Y)$ and extensions to non-cyclic groups."
     }
   ],


### PR DESCRIPTION
## Section-map re-anchor (tail-with-decl vein)

`Proofs/BorsukUlamOQ02OQ01OQ04.lean` (251 lines, 7 PART dividers) had a 6-section
map that had drifted off the file's PART banners and stranded the capstone theorem:

| Section | Was | Now | Reason |
|---------|-----|-----|--------|
| key-properties (PART III) | 106–123 | 106–**122** | endLine sat on the PART IV banner |
| bu-connection (PART IV) | **131**–167 | **123**–**155** | missed the PART IV banner (123–125), spilled into PART V |
| composite-groups (PARTs V+VI) | 168–210 | **156**–**209** | now covers `fh_recovers_monotonicity@180` (PART V) + the z4/z6 bounds |
| extensions (PART VII) | 211–**230** | 210–**251** | capstone `fh_extends_monotonicity@245` and `end@251` were outside every section |

**Decisive test passes:** all 15 named declarations (structures, defs, theorems) now
land wholly inside their titled section (verified against the Lean source). Summaries
for the last two sections were extended to name `fh_recovers_monotonicity` and the
capstone `fh_extends_monotonicity`. No status/badge/axiomCount change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
