### PR TITLE
Audit erdos-769 (reserve): re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16234,8 +16234,8 @@
     },
     "erdos-769": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:46Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T15:55:14Z",
       "result": "clean"
     },
     "erdos-77": {


### PR DESCRIPTION
Re-verified erdos-769 (Cube Dissection into Homothetic Cubes) in reserve mode.

- 5 axioms / 3 theorems / 0 sorries / 0 native_decide — all disclosed
- badge `axiom` / status `axiomatized` / open — correct tier
- Axioms mutually consistent (n=2: Hadwiger `c(n)≥2^n+2^{n-1}` gives c(2)≥6 = `c_of_2`)
- Uncontested, unchanged from prior clean audit

Tracker timestamp bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)