### PR TITLE
Enrich erdos-509: cover stranded compat shims + fix truncated summary

### DIFF
--- a/src/data/proofs/erdos-509/meta.json
+++ b/src/data/proofs/erdos-509/meta.json
@@ -84,6 +84,13 @@
   },
   "sections": [
     {
+      "id": "setup",
+      "title": "Setup and Compatibility Shims",
+      "summary": "Module docstring stating the problem, and the v4.31 compatibility shims Complex.abs (:= ‖·‖) and Complex.norm_eq_abs restoring the API removed from Mathlib.",
+      "startLine": 1,
+      "endLine": 39
+    },
+    {
       "id": "bounded-disc-cover",
       "title": "Bounded Disc Cover",
       "summary": "Structure and definition for disc covers with bounded total radius",
@@ -128,9 +135,9 @@
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "Summary theorem combining Cartan and Pommerenke bounds",
+      "summary": "Summary theorem erdos_509_summary combining the Cartan and Pommerenke bounds",
       "startLine": 173,
-      "endLine": 199
+      "endLine": 203
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Cover stranded compat shims + fix truncated summary in erdos-509

Two section-map defects:

- **Stranded head (1–39)**: the module docstring (problem statement) and the two
  v4.31 compatibility shims `Complex.abs` and `Complex.norm_eq_abs` (lines 34,
  37) had no section — the map started at line 40. Added a **Setup** section.
- **Truncated proof**: the final `summary` section ended at line 199, cutting
  off `erdos_509_summary` whose proof body runs to line 201 (`end` at 203).
  Extended the section to EOF.

Map now covers **1..203 contiguously** (verified: no gaps/overlaps, last
endLine = EOF, every declaration inside a section). Section map only — no
math/status/axiom changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
