### PR TITLE
Enrich lovasz-local-lemma-oq-04: fix overlapping/out-of-order tail sections

### DIFF
--- a/src/data/proofs/lovasz-local-lemma-oq-04/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-04/meta.json
@@ -89,25 +89,25 @@
       "mathContext": "Uses Finset.card_biUnion_le and Finset.card_erase_of_mem; the uniform bound feeds the symmetric threshold."
     },
     {
-      "id": "sec-degree-sharp",
-      "title": "Sharpness of the Degree Bound",
-      "startLine": 205,
-      "endLine": 223,
-      "summary": "tightVars (k=2 variables per event, D=3 events per variable, 5 events) and sharedDep_maxDegree_tight: the central event has degree exactly k·(D-1)=4, so sharedDep_maxDegree is tight. Proved by kernel decide (no native_decide)."
-    },
-    {
       "id": "sec-capstones",
       "title": "Part IV: Capstones — The Variable LLL",
       "startLine": 176,
-      "endLine": 204,
+      "endLine": 203,
       "summary": "variable_lll repackages the consequences along sharedDep; variable_lll_symmetric plugs the degree bound into the parent's symmetric_lll_complete to obtain the symmetric variable LLL at threshold T(k·(D−1)).",
       "mathContext": "Connects the variable model to the symmetric threshold theory of the parent file."
     },
     {
+      "id": "sec-degree-sharp",
+      "title": "Part V′: Sharpness of the Degree Bound",
+      "startLine": 204,
+      "endLine": 223,
+      "summary": "tightVars (k=2 variables per event, D=3 events per variable, 5 events) and sharedDep_maxDegree_tight: the central event has degree exactly k·(D-1)=4, so sharedDep_maxDegree is tight. Proved by kernel decide (no native_decide)."
+    },
+    {
       "id": "sec-union-bound",
       "title": "Part V: The Asymmetric LLL Beats the Union Bound",
-      "startLine": 205,
-      "endLine": 238,
+      "startLine": 224,
+      "endLine": 259,
       "summary": "asymLLL_beats_union_bound: for n > 2 an instance with ∑ P[A_i] > 1 yet positive avoidance product. asymLLL_asymmetric_weights: a concrete mutually-dependent two-event instance with distinct tight weights.",
       "mathContext": "Demonstrates the qualitative gain of the local lemma over the union bound and the genuine need for asymmetric weights."
     }


### PR DESCRIPTION
## Section-map re-anchor (tail-with-decl vein)

`Proofs/LovaszLocalLemmaOQ04.lean` (259 lines) had a broken tail section map:

- **Overlap:** `sec-degree-sharp` (205–223) and `sec-union-bound` (205–238) both began at line 205.
- **Out of order:** `sec-degree-sharp` was listed *before* `sec-capstones` (Part IV) in the array, so the TOC rendered Sharpness ahead of the Capstones it depends on.
- **Stranded tail:** the last section ended at 238, leaving `asymLLL_asymmetric_weights@250` and `end@259` uncovered.

Re-anchored to the file's four tail PART dividers and restored file order:

| Section | Was | Now |
|---------|-----|-----|
| Part IV — Capstones | 176–204 | 176–**203** |
| Part V′ — Sharpness | 205–223 | **204**–223 |
| Part V — Beats the Union Bound | 205–238 | **224**–**259** |

**Decisive test passes:** all 20 named declarations land wholly inside their titled
section, in file order (verified against the Lean source). No status/badge/axiomCount change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
