### PR TITLE
Audit erdos-759 (reserve): re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16162,8 +16162,8 @@
     },
     "erdos-759": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:46Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T15:56:48Z",
       "result": "clean"
     },
     "erdos-76": {


### PR DESCRIPTION
Re-verified erdos-759 (Cochromatic Number on Surfaces, Gimbel-Thomassen) in reserve mode.

- 6 axioms / 3 theorems / 0 sorries / 0 native_decide — all disclosed
- badge `axiom` / status `axiomatized` / erdosStatus solved — correct
- Axioms consistent (Gimbel-Thomassen two-sided Θ(√n/log n) implies gimbel_lower_bound)
- `_prop` defs correctly marked "not used in proofs"; `isEmbeddableOn := True` placeholder disclosed
- Uncontested, unchanged from prior clean audit

Tracker timestamp bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)