### PR TITLE
Enrich erdos-1091: extend Part 7 Summary section to cover erdos_1091_summary

### DIFF
--- a/src/data/proofs/erdos-1091/meta.json
+++ b/src/data/proofs/erdos-1091/meta.json
@@ -146,7 +146,7 @@
       "id": "summary",
       "title": "Part 7: Summary",
       "startLine": 191,
-      "endLine": 195,
+      "endLine": 212,
       "summary": "`erdos_1091_summary` (verified): combines Voss ($\\geq 2$ guaranteed) and pentagonal wheel ($\\geq 3$ not guaranteed) into a single theorem.",
       "mathContext": "Verified: `erdos_1091_summary` (verified): combines Voss ($\\geq 2$ guaranteed) and pentagonal wheel ($\\geq 3$ not guaranteed) into a single theorem."
     }


### PR DESCRIPTION
The **Part 7: Summary** section ended at line 195 (covering only the docstring), leaving the headline theorem `erdos_1091_summary@197` and `end@212` outside every section. Extended the range to **191–212** so the entry's punchline theorem is visible in the outline. No status/badge/axiomCount change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)