### PR TITLE
Audit erdos-757 (reserve): re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16150,8 +16150,8 @@
     },
     "erdos-757": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:54:07Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T16:03:23Z",
       "result": "clean"
     },
     "erdos-758": {


### PR DESCRIPTION
Reserve re-audit of erdos-757 (queue drained).

## Verification
- Theorems: 8 (sidon_empty, sidon_singleton, zero_mem_differenceSet, differenceSet_symmetric, almostSidon_of_sidon, zero_admissible, neg_admissible, admissible_nonempty) — all real decls, matches ✓
- Definitions: 5 (IsSidon, differenceSet, AlmostSidon, IsAdmissible, IsB2Sequence) ✓
- Axioms: 0 ✓ · Sorries: 0 ✓ · lineCount 244
- Prose honest: origContribs explicitly says Gyárfás-Lehel bounds are 'documented as prose commentary, not axiomatized'; erdosProblemStatus 'open'; conclusion states exact value 'remains OPEN'
- No phantom comment-only decls (prior flag resolved)

**Result: clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)