### PR TITLE
Enrich erdos-104: cover stranded open-problem definition (erdos104OpenProblem)

### DIFF
--- a/src/data/proofs/erdos-104/meta.json
+++ b/src/data/proofs/erdos-104/meta.json
@@ -112,8 +112,16 @@
       "title": "Known Values",
       "summary": "maxUnitCircles extremal function (OEIS A003829) and exact values: f(3) = 1, f(4) = 4, f(5) = 8, f(6) = 13",
       "startLine": 288,
-      "endLine": 317,
+      "endLine": 323,
       "mathContext": "Mathematical content: maxUnitCircles extremal function (OEIS A003829) and exact values: f(3) = 1, f(4) = 4, f(5) = 8, f(6) = 13"
+    },
+    {
+      "id": "open-problem",
+      "title": "The Open Problem",
+      "summary": "`erdos104OpenProblem := erdos104Conjecture`: the main open question packaged as a `Prop`. The exact growth rate of the maximum number of unit circles through ≥3 points of an n-point set remains unknown — the conjectured O(n^{3/2}) bound is not proved.",
+      "startLine": 325,
+      "endLine": 332,
+      "mathContext": "The definition `erdos104OpenProblem : Prop := erdos104Conjecture` exposes the headline conjecture as a named target. It is a definitional alias, carrying no proof obligation, that pins the file's central unresolved statement."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
The definition `erdos104OpenProblem@332` — the file's headline conjecture aliased as a `Prop` — and the `## The Open Problem` banner sat past the last section (**Known Values**, ended 317), leaving the central unresolved statement out of the outline.

Extended **Known Values** to 323 (covering all f(k) exact-value comments) and added a **The Open Problem** section (325–332). The stranded def now lands in a titled section. No status/badge/axiomCount change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)