### PR TITLE
Enrich erdos-152: extend final section to cover ErdosProblem152Infinite

### DIFF
--- a/src/data/proofs/erdos-152/meta.json
+++ b/src/data/proofs/erdos-152/meta.json
@@ -113,7 +113,7 @@
       "id": "related-results",
       "title": "Section VII: Related Results — Gap Existence & Infinite Version",
       "startLine": 361,
-      "endLine": 493,
+      "endLine": 508,
       "summary": "gap_existence_pigeonhole: every Sidon set of size ≥ 5 has at least one isolated element, by a case analysis on the endpoints (2M always has no right neighbor; the second-smallest element handles the m=0 case) using difference injectivity. Closes with ErdosProblem152Infinite, the open infinite-set formulation. (Source mislabels this as a second 'Section VI'.)",
       "mathContext": "Bound: gap_existence_pigeonhole: every Sidon set of size ≥ 5 has at least one isolated element, by a case analysis on the endpoints (2M always has no right neighbor; the second-smallest element handles the m=0 case) using difference injectivity. Closes with ErdosProblem152Infinite, the open infinite-set formulation. (Source mislabels this as a second 'Section VI'.)"
     }


### PR DESCRIPTION
The final section (**Section VII: Related Results — Gap Existence & Infinite Version**) ended at line 493, but `def ErdosProblem152Infinite@504` — the open infinite-set formulation its own summary promises to \"close with\" — was left uncovered. Extended `endLine` to 508 (EOF). No status/badge/axiomCount change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)