### PR TITLE
Audit erdos-753 (reserve): re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16126,8 +16126,8 @@
     },
     "erdos-753": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:54:07Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T16:05:07Z",
       "result": "clean"
     },
     "erdos-754": {


### PR DESCRIPTION
Reserve re-audit of erdos-753 (queue drained).

## Verification
- Axioms: 2 (listChromaticNumber opaque fn, alon_counterexample bound) — matches ✓
- Theorems: 3 (complement_complement, conjecture_false, erdos_753_summary) ✓
- Definitions: 6 ✓ · Sorries: 0 ✓ · lineCount 312
- Badge `axiom` / status `axiomatized` correct (Tier C: core counterexample axiomatized)
- No axiom inconsistency: opaque listChromaticNumber + existential Alon bound are satisfiable
- conjecture_false genuinely DERIVES ¬ERTConjecture (10-step asymptotic proof), not axiomatized
- origContribs honestly disclaims Parts V-VIII as comment-only, not Lean decls

**Result: clean.** Exemplary honest disclosure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)