### PR TITLE
Enrich erdos-8-oq-02: extend Headline Resolution section to cover erdos_8_oq02_resolution

### DIFF
--- a/src/data/proofs/erdos-8-oq-02/meta.json
+++ b/src/data/proofs/erdos-8-oq-02/meta.json
@@ -155,7 +155,7 @@
       "id": "sec-06-resolution",
       "title": "Summary and Headline Resolution",
       "startLine": 259,
-      "endLine": 296,
+      "endLine": 311,
       "summary": "erdos_8_oq02_resolution packages the answer to oq-02: from the minimum-modulus bound there exists a small-separating colouring defeating every covering system, and any such colouring needs ≥ B colours."
     }
   ],


### PR DESCRIPTION
The section titled **Summary and Headline Resolution** ended at line 296 — leaving the headline theorem `erdos_8_oq02_resolution@302` (the very resolution its summary describes) and `end@311` outside the section. Extended `endLine` to 311. No status/badge/axiomCount change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)