### PR TITLE
Enrich erdos-733: extend Summary section to cover erdos_733_answer

### DIFF
--- a/src/data/proofs/erdos-733/meta.json
+++ b/src/data/proofs/erdos-733/meta.json
@@ -157,9 +157,9 @@
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "erdos_733_summary theorem (L252) and erdos_733_answer theorem (L267): complete solution summary.",
+      "summary": "erdos_733_summary theorem (L252) and erdos_733_answer theorem (L279): complete solution summary.",
       "startLine": 252,
-      "endLine": 274,
+      "endLine": 286,
       "mathContext": "Erdős #733 fully resolved: $f(n) = \\exp(\\Theta(\\sqrt{n}))$ by Szemerédi-Trotter (1983)."
     }
   ],


### PR DESCRIPTION
The **Summary** section ended at line 274, but `erdos_733_answer@279` (which its own summary lists — with a stale \"L267\" reference) and `end@286` were uncovered. Extended `endLine` to 286 and corrected the reference to L279. No status/badge/axiomCount change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)