### PR TITLE
Enrich erdos-404: re-anchor tail sections off the digit-sum proof body onto PART banners

### DIFF
--- a/src/data/proofs/erdos-404/meta.json
+++ b/src/data/proofs/erdos-404/meta.json
@@ -131,31 +131,31 @@
       "id": "part-iva-digit-sum-identity",
       "title": "Part IV-A: The Digit-Sum Identity and Valuation Bounds",
       "startLine": 97,
-      "endLine": 288,
+      "endLine": 301,
       "summary": "Defines baseDigitSum and proves the digit-sum identity legendreSum_digitSum_identity (legendreSum(n,p)·(p−1) + baseDigitSum(n,p) = n) by telescoping, then the valuation envelopes padic_val_factorial_upper (ν_p(n!)·(p−1) ≤ n), padic_val_factorial_lower, and the asymptotic padic_val_factorial_asymp (ν_p(n!)/n → 1/(p−1)).",
       "mathContext": "The digit-sum identity is the quantitative engine behind the linear growth of ν_p(n!): writing n in base p, Legendre's formula gives v_p(n!) = (n − s_p(n))/(p−1) with s_p(n) = baseDigitSum, yielding both the exact value and the upper/lower bounds that pin the asymptotic density 1/(p−1)."
     },
     {
       "id": "factorial-structure",
       "title": "Structure of Factorial Sums",
-      "startLine": 289,
-      "endLine": 296,
+      "startLine": 302,
+      "endLine": 309,
       "summary": "Modular structure and factorization of factorial sums",
       "mathContext": "The key factorization: $a_1! + a_2! = a_1!(1 + a_2!/a_1!)$ since $a_1! \\mid a_2!$ when $a_1 \\leq a_2$. So $v_p(a_1! + a_2!) = v_p(a_1!) + v_p(1 + a_2!/a_1!)$. The second term depends on the $p$-adic structure of the ratio."
     },
     {
       "id": "examples",
       "title": "Examples",
-      "startLine": 297,
-      "endLine": 302,
+      "startLine": 310,
+      "endLine": 315,
       "summary": "Three proved examples: 2³ | 2!+3!, 3 | 1!+2!, and 3² | 1!+2!+3!",
       "mathContext": "$2! + 3! = 2 + 6 = 8 = 2^3$, so $v_2(2!+3!) = 3$. Also $1! + 2! = 3$, so $v_3 = 1$. And $1!+2!+3! = 9 = 3^2$. These are verified by `native_decide`."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 303,
-      "endLine": 310,
+      "startLine": 316,
+      "endLine": 323,
       "summary": "Proved conjunction of Lin's bounds",
       "mathContext": "The summary theorem packages $f(2,2) \\leq 254 \\wedge (\\forall s,\\; \\neg(2^{255} \\mid \\text{factorialSum}(s)))$ via ⟨lin_bound, lin_bound_meaning⟩."
     }


### PR DESCRIPTION
## Section-map re-anchor (tail-with-decl vein)

`Proofs/Erdos404Problem.lean` (323 lines) had its three tail sections shifted ~13 lines
early, so they sat **inside Part IV-A's proof body** rather than on the file's PART banners:

| Section | Was | Now | Real banner |
|---------|-----|-----|-------------|
| Part IV-A: Digit-Sum Identity | 97–288 | 97–**301** | proof runs to line 300 |
| Structure of Factorial Sums | 289–296 | **302**–**309** | `Part V` @302, `factorial_sum_factored@305` |
| Examples | 297–302 | **310**–**315** | `Part VI` @310 |
| Summary | 303–310 | **316**–**323** | `Part VII` @316, `erdos_404_summary@318` |

**Decisive test passes:** all 20 named declarations land wholly in a section with no
overlaps (verified against the Lean source). No status/badge/axiomCount change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
