### PR TITLE
Enrich erdos-753: extend Summary Theorem section to cover erdos_753_summary

### DIFF
--- a/src/data/proofs/erdos-753/meta.json
+++ b/src/data/proofs/erdos-753/meta.json
@@ -153,7 +153,7 @@
       "id": "summary",
       "title": "Summary Theorem",
       "startLine": 265,
-      "endLine": 299,
+      "endLine": 312,
       "summary": "erdos_753_summary: PROVED conjunction of conjecture_false and alon_counterexample, packaging complete resolution of Problem #753.",
       "mathContext": "Mathematical content: erdos_753_summary: PROVED conjunction of conjecture_false and alon_counterexample, packaging complete resolution of Problem #753."
     }


### PR DESCRIPTION
The **Summary Theorem** section ended at line 299, leaving `erdos_753_summary@300` and `end@312` uncovered. Extended `endLine` to 312. No status/badge/axiomCount change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)