### PR TITLE
Enrich erdos-1020: extend The Open Problem section to cover r4Conjecture

### DIFF
--- a/src/data/proofs/erdos-1020/meta.json
+++ b/src/data/proofs/erdos-1020/meta.json
@@ -145,7 +145,7 @@
       "title": "The Open Problem",
       "summary": "Restates the open status: `erdos1020OpenProblem` ($=$ the matching conjecture) and `r4Conjecture` (the still-open $r=4$ case), the smallest unresolved instance.",
       "startLine": 308,
-      "endLine": 326,
+      "endLine": 338,
       "mathContext": "OPEN for all $r\\ge4$; the $r=4$ case is the smallest unresolved instance."
     }
   ],


### PR DESCRIPTION
The **The Open Problem** section ended at line 326 — covering `erdos1020OpenProblem@326` but leaving `def r4Conjecture@329` (the specific open r = 4 case) and `end@338` uncovered. Extended `endLine` to 338 and noted `r4Conjecture` in the summary. No status/badge/axiomCount change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)