### PR TITLE
Enrich erdos-393: add Part 9 Summary section for the erdos_393 status theorem

### DIFF
--- a/src/data/proofs/erdos-393/meta.json
+++ b/src/data/proofs/erdos-393/meta.json
@@ -140,8 +140,16 @@
       "title": "Density Results",
       "summary": "Density zero and sparse values theorems",
       "startLine": 153,
-      "endLine": 162,
+      "endLine": 160,
       "mathContext": "Verified: Density zero and sparse values theorems"
+    },
+    {
+      "id": "summary",
+      "title": "Part 9: Summary",
+      "summary": "erdos_393: the headline status theorem packaging all three results — F_m(N) = o(N) for each m ≥ 1 (Berend-Osgood 1992), the power saving F_m(N) ≪ N^{33/34} (BPZ 2023), and the conditional f(n) → ∞ under the ABC conjecture (Luca 2002).",
+      "startLine": 161,
+      "endLine": 175,
+      "mathContext": "The theorem `erdos_393` is a conjunction of the three main results, proved by `⟨berend_osgood_1992, bpz_2023, luca_2002⟩`. It records the current status of Erdős #393: unconditional density/power-saving bounds plus the ABC-conditional divergence f(n) → ∞."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
The headline theorem `erdos_393@166` — packaging Berend-Osgood (o(N) density), BPZ (N^{33/34} power saving), and the ABC-conditional f(n) → ∞ — sat in the `## Part 9: Summary` block past the last section (**Density Results**, whose `endLine` 162 even fell inside the Part 9 banner comment).

Trimmed **Density Results** to 160 and added a **Part 9: Summary** section (161–175). The status theorem now lands in a titled section. No status/badge/axiomCount change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)