### PR TITLE
Enrich erdos-551: re-anchor 13 sections to Part-divider boundaries

### DIFF
--- a/src/data/proofs/erdos-551/meta.json
+++ b/src/data/proofs/erdos-551/meta.json
@@ -57,103 +57,103 @@
       "title": "Problem Statement and Imports",
       "summary": "Documentation header with problem statement, Aristotle edit notes, threshold progression, related questions, and Mathlib imports for SimpleGraph and real analysis",
       "startLine": 1,
-      "endLine": 43,
+      "endLine": 63,
       "mathContext": "Prove $R(C_k, K_n) = (k-1)(n-1)+1$ for $k \\\\geq n \\\\geq 3$ (except $(3,3)$). Progressive thresholds: Bondy-Erdos $k > n^2$, Nikiforov $k \\\\geq 4n+2$."
     },
     {
       "id": "basic-defs",
       "title": "Graph Definitions: Cycles, Cliques, Containment",
       "summary": "cycleGraph C_k via modular adjacency, completeGraph K_n as top of lattice, ContainsCycle via injective embedding preserving cyclic adjacency, ContainsClique via clique Finset of given size",
-      "startLine": 56,
-      "endLine": 91,
+      "startLine": 64,
+      "endLine": 90,
       "mathContext": "Cycle graph $C_k$: $k$ vertices in a cycle ($k$-gon). Complete graph $K_n$: all $\\\\binom{n}{2}$ edges. ContainsCopy: subgraph isomorphism."
     },
     {
       "id": "ramsey",
       "title": "Ramsey Number R(C_k, K_n)",
       "summary": "RamseyNumber via Nat.find over existence of N with red C_k or blue K_n, RamseyProperty as the Ramsey property predicate, ramsey_is_min establishing minimality",
-      "startLine": 96,
-      "endLine": 144,
+      "startLine": 91,
+      "endLine": 139,
       "mathContext": "$R(C_k, K_n) = \\\\min N$ such that every red-blue coloring of $K_N$ contains red $C_k$ or blue $K_n$. Found via $\\\\text{Nat.find}$ on existence."
     },
     {
       "id": "conjecture",
       "title": "The Main Conjecture and Exception",
       "summary": "ConjecturedFormula (k-1)(n-1)+1, MainConjecture for k ≥ n ≥ 3 excluding (3,3), exception_3_3 showing R(C_3,K_3) = 6, formula_wrong_at_3_3 proved by native_decide",
-      "startLine": 145,
-      "endLine": 174,
+      "startLine": 140,
+      "endLine": 184,
       "mathContext": "Conjectured formula: $R(C_k, K_n) = (k-1)(n-1)+1$ for $k \\\\geq n \\\\geq 3$, $(k,n) \\\\neq (3,3)$. Exception: $R(K_3, K_3) = 6 \\\\neq 5$."
     },
     {
       "id": "lower-bound",
       "title": "Lower Bound: Disjoint Cliques Construction",
       "summary": "LowerBoundGraph partitions (k-1)(n-1) vertices into (n-1) copies of K_{k-1} via integer division, lower_bound_no_cycle (components too small), lower_bound_complement_no_clique (independence number n-1)",
-      "startLine": 191,
-      "endLine": 232,
+      "startLine": 185,
+      "endLine": 236,
       "mathContext": "Lower bound: $(k-1)(n-1)$ vertices, partitioned into $n-1$ copies of $K_{k-1}$ (all red within, all blue between). Contains no red $C_k$ and no blue $K_n$."
     },
     {
       "id": "bondy-erdos",
       "title": "Bondy-Erdős (1973): Quadratic Threshold",
       "summary": "bondy_erdos theorem for k > n²-2, BondyErdosThreshold definition, above_bondy_erdos_threshold corollary",
-      "startLine": 243,
-      "endLine": 267,
+      "startLine": 237,
+      "endLine": 271,
       "mathContext": "Bondy-Erdos (1973): formula holds for $k > n^2 - 2$. The first threshold result."
     },
     {
       "id": "nikiforov",
       "title": "Nikiforov (2005): Linear Threshold",
       "summary": "nikiforov theorem for k ≥ 4n+2, NikiforovThreshold definition, nikiforov_improves proved by omega for n ≥ 5",
-      "startLine": 278,
-      "endLine": 293,
+      "startLine": 272,
+      "endLine": 307,
       "mathContext": "Nikiforov (2005): formula holds for $k \\\\geq 4n + 2$. Significant improvement from $n^2$ to $4n$."
     },
     {
       "id": "kls",
       "title": "Keevash-Long-Skokan (2021): Near-Logarithmic Threshold",
       "summary": "keevash_long_skokan with existential constant C, KLSThreshold as log n / log log n, exp_one_lt_3 lemma via Taylor bounds, kls_improves PROVED by Aristotle for n ≥ 100",
-      "startLine": 312,
-      "endLine": 358,
+      "startLine": 308,
+      "endLine": 370,
       "mathContext": "Keevash-Long-Skokan: formula holds for $k \\\\geq C\\\\log n / \\\\log\\\\log n$ for some constant $C$. Near-optimal threshold."
     },
     {
       "id": "special-cases",
       "title": "Special Cases: Small Parameters and R(C_k, K_3)",
       "summary": "cycle_3_is_triangle (C_3 = K_3), ramsey_C4_K3 = 7, ramsey_C5_K3 = 9, ramsey_Ck_K3 = 2k-1 for k ≥ 4 (triangle case via Dirac's theorem)",
-      "startLine": 376,
-      "endLine": 420,
+      "startLine": 371,
+      "endLine": 419,
       "mathContext": "$R(C_4, K_3) = 7$, $R(C_5, K_3) = 9$. For $k \\\\geq 4$, $n = 3$: $R(C_k, K_3) = 2k-1$ (Faudree-Schelp)."
     },
     {
       "id": "related",
       "title": "Related Questions: SmallestValidK and MinRamseyValue",
       "summary": "SmallestValidK via Nat.find for threshold where formula holds, MinRamseyValue as infimum of R(C_k, K_n) over k ≥ n, min_ramsey_achieved existence",
-      "startLine": 425,
-      "endLine": 461,
+      "startLine": 420,
+      "endLine": 473,
       "mathContext": "SmallestValidK: the minimum $k$ where $(k-1)(n-1)+1$ holds for all $n$. Approaches 3 or 4 as theorems improve."
     },
     {
       "id": "monotonicity",
       "title": "Monotonicity Properties",
       "summary": "ramsey_mono_k and ramsey_mono_n (non-decreasing in both parameters), formula_mono PROVED showing ConjecturedFormula is monotone via nlinarith",
-      "startLine": 479,
-      "endLine": 511,
+      "startLine": 474,
+      "endLine": 517,
       "mathContext": "$R(C_k, K_n) \\\\leq R(C_{k+1}, K_n)$ and $R(C_k, K_n) \\\\leq R(C_k, K_{n+1})$. Non-decreasing in both parameters."
     },
     {
       "id": "upper-bound",
       "title": "Upper Bound: Path-Cycle Method",
       "summary": "upper_bound theorem R(C_k, K_n) ≤ (k-1)(n-1)+1 for k ≥ n ≥ 3 excluding (3,3), path_cycle_method establishing RamseyProperty for N ≥ (k-1)(n-1)+1",
-      "startLine": 522,
-      "endLine": 542,
+      "startLine": 518,
+      "endLine": 555,
       "mathContext": "$R(C_k, K_n) \\\\leq (k-1)(n-1)+1$ for $k \\\\geq n \\\\geq 3$, $(k,n) \\\\neq (3,3)$. Proved by stability + regularity arguments."
     },
     {
       "id": "summary",
       "title": "Main Theorem, Current Best, and Asymptotic Resolution",
       "summary": "main_theorem combining all progress (formula ↔ k ≥ SmallestValidK), current_best via KLS bound, solved_asymptotically showing formula holds for all but finitely many k per fixed n",
-      "startLine": 560,
-      "endLine": 603,
+      "startLine": 556,
+      "endLine": 599,
       "mathContext": "Conjectured: $R(C_k,K_n) = (k-1)(n-1)+1$ for $k \\\\geq n \\\\geq 3$, $(k,n) \\\\neq (3,3)$. Known thresholds: $k \\\\geq 4n+2$ (Nikiforov), $k \\\\geq C\\\\log n/\\\\log\\\\log n$ (KLS)."
     }
   ],


### PR DESCRIPTION
Re-anchoring pass for `erdos-551` (Erdős #551: R(C_k, K_n) Ramsey numbers).

## Problem
Every one of the 13 sections started ~3 lines **after** its `/- ## Part N -/`
divider banner. As a result the banner **and the first declaration of each
Part** were consistently orphaned into the gap between sections — outside any
section box. The stranded declarations:

| Decl | Line | Was in gap before |
|------|------|-------------------|
| `RamseyNumber` | 95 | Part II |
| `ConjecturedFormula` | 143 | Part III |
| `lower_bound` | 188 | Part IV |
| `bondy_erdos` | 240 | Part V |
| `nikiforov` | 275 | Part VI |
| `keevash_long_skokan` | 311 | Part VII |
| `cycle_3_is_triangle` | 374 | Part VIII |
| `SmallestValidK` | 423 | Part IX |
| `ramsey_mono_k` | 477 | Part X |
| `upper_bound` | 521 | Part XI |
| `main_theorem` | 559 | Part XII |

## Fix
Re-anchored each section to `[Part banner .. next banner − 1]`; the `header`
section now covers `1..63` and `summary` extends to EOF. No prose changed —
only `startLine`/`endLine`.

## Verification
- All **40** named declarations now land wholly within exactly one section (0 orphans).
- Section coverage is contiguous `1..599` (EOF).
- Section titles already mapped 1:1 onto the Part banners; summaries remain accurate.
