### PR TITLE
Enrich abundant-number-oq-02-oq-01: extend membership section to cover mem_odd_three_free_abundant

### DIFF
--- a/src/data/proofs/abundant-number-oq-02-oq-01/meta.json
+++ b/src/data/proofs/abundant-number-oq-02-oq-01/meta.json
@@ -104,7 +104,7 @@
       "id": "sec-abn0201-membership",
       "title": "Oddness, Coprimality, and the Membership Certificate",
       "startLine": 96,
-      "endLine": 114,
+      "endLine": 127,
       "summary": "odd_N and not_three_dvd_N (kernel decide on modular reductions) establish the remaining two conditions; mem_odd_three_free_abundant bundles all three via the anonymous constructor to certify N as an upper bound for the least such number. A closing #print axioms audits that only propext / Classical.choice / Quot.sound appear — no Lean.ofReduceBool or sorryAx."
     }
   ],


### PR DESCRIPTION
The **Oddness, Coprimality, and the Membership Certificate** section ended at line 114, but the certificate theorem `mem_odd_three_free_abundant@118` it is named for — plus its `#print axioms` audit and `end@127` — were uncovered. Extended `endLine` to 127. No status/badge/axiomCount change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)