### PR TITLE
Enrich bezout-identity-oq012: extend prime-norm section to cover prime_of_prime_norm

### DIFF
--- a/src/data/proofs/bezout-identity-oq012/meta.json
+++ b/src/data/proofs/bezout-identity-oq012/meta.json
@@ -106,7 +106,7 @@
       "id": "sec-prime-norm",
       "title": "Prime norm ⟹ irreducible (and prime)",
       "startLine": 89,
-      "endLine": 120,
+      "endLine": 134,
       "summary": "irreducible_of_prime_norm: |N(z)| prime ⟹ z irreducible for any d, via norm multiplicativity and |N(·)| = 1 ⟺ unit (both unconditional). prime_of_prime_norm upgrades to primality in the UFD range −2 ≤ d < 0 using irreducible_iff_prime."
     }
   ],


### PR DESCRIPTION
The **Prime norm ⟹ irreducible (and prime)** section ended at line 120, but `prime_of_prime_norm@126` — exactly the prime-norm ⟹ prime result the section is named for — and `end@134` were uncovered. Extended `endLine` to 134. No status/badge/axiomCount change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)