### PR TITLE
Enrich schroeder-bernstein-oq-02: extend Main Theorems section to cover both main theorems

### DIFF
--- a/src/data/proofs/schroeder-bernstein-oq-02/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-02/meta.json
@@ -123,8 +123,8 @@
       "id": "main-theorem",
       "title": "Main Theorems",
       "startLine": 188,
-      "endLine": 207,
-      "summary": "Full Schroeder-Bernstein theorem recovered via the Knaster-Tarski construction.",
+      "endLine": 220,
+      "summary": "Full Schroeder-Bernstein theorem recovered via the Knaster-Tarski construction. Also proves fixedSet_characterization: the fixed-point partition is explicit and inspectable.",
       "mathContext": "Combining injectivity and surjectivity: given injections $f : \\alpha \\hookrightarrow \\beta$ and $g : \\beta \\hookrightarrow \\alpha$, there exists a bijection $\\alpha \\simeq \\beta$, constructed explicitly via the Knaster-Tarski fixed point."
     }
   ],


### PR DESCRIPTION
The **Main Theorems** section ended at line 207 — the *start* line of `knasterTarski_schroeder_bernstein` — so that theorem's body plus `fixedSet_characterization@214` and both trailing `end`s (218, 220) were uncovered. Extended `endLine` to 220 and noted `fixedSet_characterization` in the summary. No status/badge/axiomCount change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)