### PR TITLE
audit: erdos-745 — stop labeling vacuous stub theorems 'Verified' in section maps

### DIFF
--- a/src/data/proofs/erdos-745/meta.json
+++ b/src/data/proofs/erdos-745/meta.json
@@ -108,7 +108,7 @@
       "summary": "komlos_sulyok_szemeredi, second_largest bounds, erdos_745 theorem",
       "startLine": 158,
       "endLine": 207,
-      "mathContext": "Verified: komlos_sulyok_szemeredi, second_largest bounds, erdos_745 theorem"
+      "mathContext": "komlos_sulyok_szemeredi, second_largest_lower_bound, and erdos_745 are placeholder stub theorems (∃ c, c > 0), not formalizations of the O(log n) / Ω(log n) bounds"
     },
     {
       "id": "component-structure",
@@ -132,7 +132,7 @@
       "summary": "erdos_745_summary, erdos_745_answer, component_gap theorems",
       "startLine": 268,
       "endLine": 298,
-      "mathContext": "Verified: erdos_745_summary, erdos_745_answer, component_gap theorems"
+      "mathContext": "erdos_745_summary and erdos_745_answer are placeholder stub theorems (∃ c, c > 0); component_gap_exponents proves only the trivial numeric fact criticalExponent > 0. None formalize the Θ(log n) result"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Integrity fix (reserve-mode re-audit)

**Proof**: erdos-745 (Second Largest Component of Random Graphs)
**Severity**: LOW — residual section-map overclaim after prior top-level fixes (#39294, #39862)

## Problem

All 7 "theorems" in this file are vacuous existential stubs (`∃ c, c > 0`), correctly disclosed at the top level (badge `wip`, status `axiomatized`, `assumptions`/`originalContributions`/`proofStrategy` all flag them as placeholder stubs). But two **section** `mathContext` strings still labeled those same stubs as **"Verified:"** — including the `kss-theorem` section carrying the headline Komlós–Sulyok–Szemerédi result and the `erdos_745` main theorem. This was inconsistent with the parallel `giant-component` section, which already honestly says its `critical_giant_size` stub "is a placeholder stub theorem ... not a formalization."

## Evidence (Lean source)

- `komlos_sulyok_szemeredi : ∃ c : ℝ, c > 0` (stub)
- `second_largest_lower_bound : ∃ c : ℝ, c > 0` (stub)
- `erdos_745 : (∃ c, c > 0) ∧ (∃ c, c > 0)` (stub)
- `erdos_745_summary : (∀ n ≥ 1, ∃ c, c > 0 ∧ True) ∧ ...` (stub)
- `erdos_745_answer : ∃ c₁ c₂, 0 < c₁ ∧ c₁ < c₂` (stub)
- `component_gap_exponents : criticalExponent > 0` (trivial `norm_num`)

## Fix

Rewrote the `kss-theorem` and `summary` section `mathContext` strings to disclose that these are placeholder stubs, mirroring the `giant-component` section. No count/status/badge changes (all already accurate: 7 stub theorems, 8 defs, 0 axioms, 0 sorries).

---
Discovered during gallery integrity audit.