### PR TITLE
Research: erdos-1039-oq-05 — d₄ ≥ 4^{1/3} lower bound (square of 4th roots of unity, 0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
+++ b/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
@@ -728,4 +728,137 @@ theorem transfiniteDiameterN_three_mem_Icc :
     transfiniteDiameterN_succ_le (le_refl 2)
   rwa [transfiniteDiameterN_two] at h32
 
+/-! ### The third term `d₄ ≥ 4^{1/3}`: the square of fourth roots of unity
+
+The `4`-point diameter is the geometric mean of the `6` pairwise gaps,
+`d₄(z) = (∏_{i<j}‖zᵢ-zⱼ‖)^{1/6}` (the normalising exponent `2/(n(n-1))` equals
+`1/6` at `n = 4`).  The square `{1, i, -1, -i}` of fourth roots of unity has four
+side gaps equal to `√2` and two diagonal gaps equal to `2`, so its spread product
+is `(√2)⁴·2² = 16` and its diameter is `16^{1/6} = 4^{1/3}`.  This yields the sharp
+**lower bound** `d₄ ≥ 4^{1/3}`.
+
+Together with `d₂ = 2 = 2^{1/(2-1)}` (`transfiniteDiameterN_two`) and
+`d₃ ≥ √3 = 3^{1/(3-1)}` (`transfiniteDiameterN_three_ge`), the value `4^{1/3} =
+4^{1/(4-1)}` makes the general pattern `dₙ ≥ n^{1/(n-1)}` (roots of unity,
+Vandermonde discriminant `n^{n/2}`) visible; that general lower bound — which
+gives `d = limₙ dₙ ≥ 1`, matching the logarithmic capacity of the disc — is the
+next milestone (`spreadProduct` of the `n`-th roots of unity `= n^{n/2}` via the
+derivative-at-a-root formula `∏_{j≠k}(ζᵏ-ζʲ) = n·ζ^{k(n-1)}`).  The matching
+upper bound `d₄ = 4^{1/3}` needs the Fekete–Szegő extremal theorem and is not
+established here. -/
+
+/-- The spread product of a `4`-point configuration is the product of its six
+pairwise gaps (the six pairs `i < j` in `Fin 4`). -/
+theorem spreadProduct_four (z : Fin 4 → ℂ) :
+    spreadProduct z = ‖z 0 - z 1‖ * ‖z 0 - z 2‖ * ‖z 0 - z 3‖ *
+      (‖z 1 - z 2‖ * ‖z 1 - z 3‖) * ‖z 2 - z 3‖ := by
+  unfold spreadProduct
+  rw [Fin.prod_univ_four]
+  have h0 : Finset.Ioi (0 : Fin 4) = {1, 2, 3} := by decide
+  have h1 : Finset.Ioi (1 : Fin 4) = {2, 3} := by decide
+  have h2 : Finset.Ioi (2 : Fin 4) = {3} := by decide
+  have h3 : Finset.Ioi (3 : Fin 4) = (∅ : Finset (Fin 4)) := by decide
+  rw [h0, h1, h2, h3,
+    Finset.prod_insert (by decide : (1 : Fin 4) ∉ ({2, 3} : Finset (Fin 4))),
+    Finset.prod_pair (by decide : (2 : Fin 4) ≠ 3),
+    Finset.prod_pair (by decide : (2 : Fin 4) ≠ 3),
+    Finset.prod_singleton, Finset.prod_empty, mul_one]
+  ring
+
+/-- The `4`-point diameter is the geometric mean of the six pairwise gaps:
+the normalising exponent `2/(n(n-1))` equals `1/6` at `n = 4`. -/
+theorem discreteDiameter_four (z : Fin 4 → ℂ) :
+    discreteDiameter z = (‖z 0 - z 1‖ * ‖z 0 - z 2‖ * ‖z 0 - z 3‖ *
+      (‖z 1 - z 2‖ * ‖z 1 - z 3‖) * ‖z 2 - z 3‖) ^ ((1 : ℝ) / 6) := by
+  rw [discreteDiameter, spreadProduct_four]
+  norm_num
+
+/-- **`d₄ ≥ 4^{1/3}`.**  The `4`-point transfinite diameter of the closed unit disc
+is at least `4^{1/3}`, attained by the square of fourth roots of unity
+`{1, i, -1, -i}`: its four side gaps equal `√2` and its two diagonal gaps equal `2`,
+so its spread product is `(√2)⁴·2² = 16` and its `4`-point diameter is
+`16^{1/6} = 4^{1/3}`.  This is the third term of the sharp lower bound
+`dₙ ≥ n^{1/(n-1)}` (after `d₂ = 2` and `d₃ ≥ √3`). -/
+theorem transfiniteDiameterN_four_ge : (4 : ℝ) ^ ((1 : ℝ) / 3) ≤ transfiniteDiameterN 4 := by
+  have hs2 : Real.sqrt 2 ^ 2 = 2 := Real.sq_sqrt (by norm_num)
+  -- the square of fourth roots of unity
+  set z : Fin 4 → ℂ := ![1, ⟨0, 1⟩, ⟨-1, 0⟩, ⟨0, -1⟩] with hz_def
+  have e0 : z 0 = 1 := by simp [hz_def]
+  have e1 : z 1 = (⟨0, 1⟩ : ℂ) := by simp [hz_def]
+  have e2 : z 2 = (⟨-1, 0⟩ : ℂ) := by simp [hz_def]
+  have e3 : z 3 = (⟨0, -1⟩ : ℂ) := by simp [hz_def]
+  -- the four side gaps are √2, the two diagonal gaps are 2
+  have g01 : ‖z 0 - z 1‖ = Real.sqrt 2 := by
+    have hd : z 0 - z 1 = (⟨1, -1⟩ : ℂ) := by
+      rw [e0, e1, Complex.ext_iff]; norm_num [Complex.sub_re, Complex.sub_im]
+    rw [hd, norm_mk_eq_sqrt, show (1 : ℝ) ^ 2 + (-1 : ℝ) ^ 2 = 2 by norm_num]
+  have g02 : ‖z 0 - z 2‖ = 2 := by
+    have hd : z 0 - z 2 = (⟨2, 0⟩ : ℂ) := by
+      rw [e0, e2, Complex.ext_iff]; norm_num [Complex.sub_re, Complex.sub_im]
+    rw [hd, norm_mk_eq_sqrt, show (2 : ℝ) ^ 2 + (0 : ℝ) ^ 2 = 2 ^ 2 by norm_num,
+      Real.sqrt_sq (by norm_num : (0 : ℝ) ≤ 2)]
+  have g03 : ‖z 0 - z 3‖ = Real.sqrt 2 := by
+    have hd : z 0 - z 3 = (⟨1, 1⟩ : ℂ) := by
+      rw [e0, e3, Complex.ext_iff]; norm_num [Complex.sub_re, Complex.sub_im]
+    rw [hd, norm_mk_eq_sqrt, show (1 : ℝ) ^ 2 + (1 : ℝ) ^ 2 = 2 by norm_num]
+  have g12 : ‖z 1 - z 2‖ = Real.sqrt 2 := by
+    have hd : z 1 - z 2 = (⟨1, 1⟩ : ℂ) := by
+      rw [e1, e2, Complex.ext_iff]; norm_num [Complex.sub_re, Complex.sub_im]
+    rw [hd, norm_mk_eq_sqrt, show (1 : ℝ) ^ 2 + (1 : ℝ) ^ 2 = 2 by norm_num]
+  have g13 : ‖z 1 - z 3‖ = 2 := by
+    have hd : z 1 - z 3 = (⟨0, 2⟩ : ℂ) := by
+      rw [e1, e3, Complex.ext_iff]; norm_num [Complex.sub_re, Complex.sub_im]
+    rw [hd, norm_mk_eq_sqrt, show (0 : ℝ) ^ 2 + (2 : ℝ) ^ 2 = 2 ^ 2 by norm_num,
+      Real.sqrt_sq (by norm_num : (0 : ℝ) ≤ 2)]
+  have g23 : ‖z 2 - z 3‖ = Real.sqrt 2 := by
+    have hd : z 2 - z 3 = (⟨-1, 1⟩ : ℂ) := by
+      rw [e2, e3, Complex.ext_iff]; norm_num [Complex.sub_re, Complex.sub_im]
+    rw [hd, norm_mk_eq_sqrt, show (-1 : ℝ) ^ 2 + (1 : ℝ) ^ 2 = 2 by norm_num]
+  -- the numeric identity `16^{1/6} = 4^{1/3}`
+  have hnum : (16 : ℝ) ^ ((1 : ℝ) / 6) = (4 : ℝ) ^ ((1 : ℝ) / 3) := by
+    rw [show (16 : ℝ) = (4 : ℝ) ^ (2 : ℕ) by norm_num, ← Real.rpow_natCast (4 : ℝ) 2,
+      ← Real.rpow_mul (by norm_num : (0 : ℝ) ≤ 4)]
+    norm_num
+  -- the diameter of the square is exactly 4^{1/3}
+  have hdiam : discreteDiameter z = (4 : ℝ) ^ ((1 : ℝ) / 3) := by
+    rw [discreteDiameter_four, g01, g02, g03, g12, g13, g23]
+    have hp16 : Real.sqrt 2 * 2 * Real.sqrt 2 * (Real.sqrt 2 * 2) * Real.sqrt 2
+        = (16 : ℝ) := by
+      have e : Real.sqrt 2 * 2 * Real.sqrt 2 * (Real.sqrt 2 * 2) * Real.sqrt 2
+          = (Real.sqrt 2 ^ 2) ^ 2 * 4 := by ring
+      rw [e, hs2]; norm_num
+    rw [hp16, hnum]
+  -- every vertex lies in the closed unit disc
+  have n0 : ‖z 0‖ ≤ 1 := by rw [e0]; simp
+  have n1 : ‖z 1‖ ≤ 1 := by
+    rw [e1, norm_mk_eq_sqrt, show (0 : ℝ) ^ 2 + (1 : ℝ) ^ 2 = 1 by norm_num, Real.sqrt_one]
+  have n2 : ‖z 2‖ ≤ 1 := by
+    rw [e2, norm_mk_eq_sqrt, show (-1 : ℝ) ^ 2 + (0 : ℝ) ^ 2 = 1 by norm_num, Real.sqrt_one]
+  have n3 : ‖z 3‖ ≤ 1 := by
+    rw [e3, norm_mk_eq_sqrt, show (0 : ℝ) ^ 2 + (-1 : ℝ) ^ 2 = 1 by norm_num, Real.sqrt_one]
+  have hmem : ∀ i, ‖z i‖ ≤ 1 := by
+    intro i; fin_cases i
+    · exact n0
+    · exact n1
+    · exact n2
+    · exact n3
+  -- 4^{1/3} is realised as the diameter of a disc configuration, hence ≤ the sSup
+  have hin : (4 : ℝ) ^ ((1 : ℝ) / 3) ∈ unitDiscDiameters 4 := ⟨z, hmem, hdiam⟩
+  exact le_csSup (unitDiscDiameters_bddAbove (by norm_num)) hin
+
+/-- **The third term is bounded below: `d₄ ≥ 4^{1/3}`, and `d₄ ∈ [4^{1/3}, 2]`.**  The
+lower bound is `transfiniteDiameterN_four_ge` (square of fourth roots of unity); the
+upper bound is Fekete monotonicity `d₄ ≤ d₂ = 2` (`transfiniteDiameterN_succ_le`
+twice, composed with `transfiniteDiameterN_two`).  The exact value `d₄ = 4^{1/3}`
+needs the extremal upper bound and is not established here. -/
+theorem transfiniteDiameterN_four_mem_Icc :
+    transfiniteDiameterN 4 ∈ Set.Icc ((4 : ℝ) ^ ((1 : ℝ) / 3)) 2 := by
+  refine ⟨transfiniteDiameterN_four_ge, ?_⟩
+  have h43 : transfiniteDiameterN 4 ≤ transfiniteDiameterN 3 :=
+    transfiniteDiameterN_succ_le (by norm_num)
+  have h32 : transfiniteDiameterN 3 ≤ transfiniteDiameterN 2 :=
+    transfiniteDiameterN_succ_le (le_refl 2)
+  rw [transfiniteDiameterN_two] at h32
+  linarith
+
 end Erdos1039TransfiniteDiameter

--- a/research/problems/erdos-1039-oq-05/knowledge.md
+++ b/research/problems/erdos-1039-oq-05/knowledge.md
@@ -1,5 +1,44 @@
 # Knowledge Base: erdos-1039-oq-05
 
+## Session 2026-07-21 (researcher-1) — third term `d₄ ≥ 4^{1/3}` (0-axiom)
+
+**Mode**: REVISIT (RICH, live vein) · **Outcome**: progress — added the third exact
+lower-bound term to the sharp-value program, Docker-verified v4.31.
+
+Following the d₃ ≥ √3 term (PR #40639), the natural next milestone was d₄, which makes
+the general pattern `dₙ ≥ n^{1/(n-1)}` visible from three data points.
+
+**New content** (`proofs/Proofs/Erdos1039TransfiniteDiameter.lean`, +~140 lines, all
+`#print axioms` = `[propext, Classical.choice, Quot.sound]`, Docker build succeeded):
+- `spreadProduct_four` — the `4`-point spread is the product of the six pairwise gaps
+  (Fin-4 `Ioi` expansion, mirrors `spreadProduct_three`).
+- `discreteDiameter_four` — `d₄(z) = (∏ gaps)^{1/6}` (exponent `2/(4·3) = 1/6`).
+- `transfiniteDiameterN_four_ge` — **`d₄ ≥ 4^{1/3}`**, attained by the square
+  `{1, i, -1, -i}` of fourth roots of unity: four side gaps `√2`, two diagonal gaps `2`,
+  spread product `(√2)⁴·2² = 16`, diameter `16^{1/6} = 4^{1/3}` (base-4 rpow identity
+  `16^{1/6} = 4^{1/3}` via `Real.rpow_mul`).
+- `transfiniteDiameterN_four_mem_Icc` — `d₄ ∈ [4^{1/3}, 2]` (lower bound + Fekete
+  `d₄ ≤ d₃ ≤ d₂ = 2`).
+
+The three terms now read `d₂ = 2 = 2^{1/1}`, `d₃ ≥ √3 = 3^{1/2}`, `d₄ ≥ 4^{1/3}`,
+i.e. `dₙ ≥ n^{1/(n-1)}`.
+
+**Next (general result, route now fully scoped).** The general lower bound
+`dₙ ≥ n^{1/(n-1)}` (which gives `d = limₙ dₙ ≥ 1 =` logarithmic capacity of the disc,
+item-1 structural value) reduces to `spreadProduct(nth roots of unity) = n^{n/2}`. All
+Mathlib pieces are located: `Complex.isPrimitiveRoot_exp`, `X_pow_sub_C_eq_prod`
+(`X^n-1 = ∏(X - ζ^i)`), `eval_multiset_prod_X_sub_C_derivative`
+(`∏_{j≠k}(ζ^k-ζ^j) = eval ζ^k of derivative = n·(ζ^k)^{n-1}`, norm `n`). The one piece
+to build locally (~40 lines) is the off-diagonal identity
+`∏_k ∏_{j≠k} ‖z k - z j‖ = spreadProduct²` (`univ.erase i = Iio i ∪ Ioi i` disjoint,
+`Finset.prod_comm` to swap `Iio ↔ Ioi`, `norm_sub_rev`). Estimated ~200 lines total,
+0-axiom.
+
+### Files modified
+- `proofs/Proofs/Erdos1039TransfiniteDiameter.lean` (+d₄ section)
+
+---
+
 ## Session 2026-07-20 (researcher-1, iter 5) — first exact term `d₂ = 2`
 
 **Mode**: continue a RICH node; the elementary transfinite-diameter scaffolding

--- a/src/data/research/problems/erdos-1039-oq-05.json
+++ b/src/data/research/problems/erdos-1039-oq-05.json
@@ -48,7 +48,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: elementary sharp-value program advanced — first exact term d₂=2 and now the second term lower bound d₃≥√3 (sandwich d₃∈[√3,2]), all 0-axiom. Remaining: extremal upper bounds (Fekete–Szegő) and the general roots-of-unity lower bound dₙ≥n^{1/(n-1)}. Parent Erdős #1039 OPEN.",
+    "progressSummary": "PROGRESS: elementary sharp-value program now has THREE exact lower-bound terms d2=2, d3>=sqrt3, d4>=4^(1/3) (all 0-axiom), making the general pattern d_n>=n^(1/(n-1)) visible. Next: the general roots-of-unity lower bound (route fully scoped, ~200 lines) which yields d=lim_n d_n>=1. Remaining beyond: extremal upper bounds (Fekete-Szego). Parent Erdos #1039 OPEN.",
     "builtItems": [
       "Erdos1039TransfiniteDiameter.spreadProduct: the Vandermonde spread ∏_{i<j}‖zᵢ-zⱼ‖ (finite-n numerator of the transfinite diameter).",
       "Erdos1039TransfiniteDiameter.discreteDiameter: the n-point diameter dₙ(Z) = spreadProduct^{2/(n(n-1))}, the finite-n truncation of the transfinite diameter.",
@@ -71,7 +71,8 @@
       "transfiniteDiameterN_three_ge : √3 ≤ transfiniteDiameterN 3 (Erdos1039TransfiniteDiameter.lean, PR #40639, 0-axiom)",
       "transfiniteDiameterN_three_mem_Icc : d₃ ∈ [√3, 2] (0-axiom)",
       "spreadProduct_three / discreteDiameter_three : 3-point diameter = geometric mean of the three pairwise gaps (exponent 2/(n(n-1))=1/3 at n=3)",
-      "norm_mk_eq_sqrt : ‖x+yi‖ = √(x²+y²) helper"
+      "norm_mk_eq_sqrt : ‖x+yi‖ = √(x²+y²) helper",
+      "spreadProduct_four / discreteDiameter_four / transfiniteDiameterN_four_ge / transfiniteDiameterN_four_mem_Icc in Erdos1039TransfiniteDiameter.lean -- d4 in [4^(1/3), 2], 0-axiom (propext/Classical.choice/Quot.sound), Docker-verified."
     ],
     "insights": [
       "The finite discrete spread is entirely elementary and needs NO capacity infrastructure: it is a product of pairwise norms, equal to the modulus of the Vandermonde determinant, so it is host-verifiable Mathlib-only (no Docker).",
@@ -85,10 +86,12 @@
       "Limit existence (researcher-1, 2026-07-20): the transfinite diameter of the closed unit disc is now a well-defined real number d = limₙ dₙ = ⨅ₙ dₙ ∈ [0,2], via Mathlib tendsto_atTop_ciInf on the antitone (Fekete) bounded-below sequence. The SHARP value d = 1 (= logarithmic capacity of the disc) remains open: it needs the Fekete–Szegő theorem plus extremal root-of-unity configurations (spreadProduct of nth roots of unity → the discriminant), not yet formalized. The current upper bound is the coarse dₙ ≤ 2.",
       "d₂ = transfiniteDiameterN 2 = 2 EXACTLY: the 2-point diameter reduces to the single gap ‖z₀-z₁‖ (exponent 2/(n(n-1))=1 at n=2), max over the closed disc is 2, attained by antipodal ![1,-1]. Only elementary exact stage; sharp d=1 needs Fekete–Szegő.",
       "Lean: collapse ∏ i:Fin 2, ∏ j∈Ioi i via Fin.prod_univ_two + (Finset.Ioi (0:Fin 2)={1}, Ioi (1:Fin 2)=∅) by decide; ![1,-1] value/membership goals by norm_num / fin_cases.",
-      "Second exact term d₃ is sandwiched in [√3, 2]: lower bound √3 attained by the equilateral triangle of cube roots of unity {1, ω, ω²} (all three pairwise gaps = √3, so diameter ((√3)³)^{1/3} = √3); upper bound from Fekete monotonicity d₃ ≤ d₂ = 2. Exact d₃ = √3 needs the Fekete–Szegő extremal upper bound (no 3-point disc config beats the inscribed equilateral triangle), NOT yet done."
+      "Second exact term d₃ is sandwiched in [√3, 2]: lower bound √3 attained by the equilateral triangle of cube roots of unity {1, ω, ω²} (all three pairwise gaps = √3, so diameter ((√3)³)^{1/3} = √3); upper bound from Fekete monotonicity d₃ ≤ d₂ = 2. Exact d₃ = √3 needs the Fekete–Szegő extremal upper bound (no 3-point disc config beats the inscribed equilateral triangle), NOT yet done.",
+      "d4 = 4^(1/3): the square {1,i,-1,-i} of 4th roots of unity has four side gaps sqrt2 and two diagonal gaps 2, so spreadProduct = (sqrt2)^4 * 2^2 = 16 and discreteDiameter = 16^(1/6) = 4^(1/3). Confirms the pattern d_n >= n^(1/(n-1)) at the third term (d2=2^(1/1), d3=3^(1/2), d4=4^(1/3))."
     ],
     "mathlibGaps": [
-      "Mathlib has no transfinite-diameter / logarithmic-capacity API; the n-point spread and its diameter had to be defined from scratch (done here). The limit d(Z)=limₙ dₙ and Fekete monotonicity are still absent."
+      "Mathlib has no transfinite-diameter / logarithmic-capacity API; the n-point spread and its diameter had to be defined from scratch (done here). The limit d(Z)=limₙ dₙ and Fekete monotonicity are still absent.",
+      "General d_n >= n^(1/(n-1)) crux spreadProduct(nth roots of unity) = n^(n/2): Mathlib HAS the pieces -- X_pow_sub_C_eq_prod (X^n-1 = prod (X - zeta^i)), eval_multiset_prod_X_sub_C_derivative (prod_{j!=k}(r-a) = eval r of derivative), Complex.isPrimitiveRoot_exp. To build locally: the off-diagonal <-> spreadProduct^2 identity prod_i prod_{j!=i} norm(z i - z j) = spreadProduct^2 (via Finset.prod_comm on Iio/Ioi + norm_sub_rev)."
     ],
     "nextSteps": [
       "Package d(disc) = ⨅ₙ transfiniteDiameterN n and show the sequence converges to it (Antitone + BddBelow ⟹ Tendsto to iInf).",
@@ -96,7 +99,7 @@
       "State ρ(f) ≳ g(d(Z),cap) as theorems/axioms citing Pommerenke/KLR.",
       "Bridge spreadProduct to Erdos1039Problem.UnitDiscPolynomial.roots (needs Docker).",
       "Upper bound d₃ ≤ √3 (Fekete–Szegő extremal: maximise product of pairwise distances of 3 points in closed unit disc — equilateral triangle on boundary is extremal). This closes d₃ = √3 exactly.",
-      "General lower bound dₙ ≥ n^{1/(n-1)} via n-th roots of unity: spreadProduct(roots of unity) = n^{n/2} from ∏_{j≠0}(1-ω^j)=n (evaluate (xⁿ-1)/(x-1) at x=1). This gives d = limₙ dₙ ≥ 1, matching the sharp capacity value."
+      "GENERAL LOWER BOUND d_n >= n^(1/(n-1)) (item-1 structural: gives d = lim_n d_n >= 1 = logarithmic capacity of the disc). Route fully scoped: (1) zeta = Complex.isPrimitiveRoot_exp n, z k = zeta^k, injective; (2) X_pow_sub_C_eq_prod: X^n-1 = prod_{i in range n}(X - zeta^i); (3) eval_multiset_prod_X_sub_C_derivative at zeta^k with derivative(X^n-1) = n*X^(n-1) gives prod_{j!=k}(zeta^k - zeta^j) = n*(zeta^k)^(n-1), norm = n; (4) off-diagonal identity prod_k prod_{j!=k} norm(z k - z j) = spreadProduct^2 (univ.erase i = Iio i union Ioi i disjoint, Finset.prod_comm to swap Iio<->Ioi, norm_sub_rev) gives spreadProduct = n^(n/2); (5) discreteDiameter = (n^(n/2))^(2/(n(n-1))) = n^(1/(n-1)), le_csSup. Est ~200 lines, 0-axiom."
     ],
     "markdown": "# Knowledge Base: erdos-1039-oq-05\n\nInsights accumulated during research on relating ρ(f) to transfinite diameter and logarithmic capacity.\n\n---\n\n## Problem Understanding\n\nρ(f) is the inscribed-disc radius of the lemniscate interior {|f|<1}. The lemniscate {|f|=1} is the level-1 curve of the Green's function of the complement, so ρ(f) is potential-theoretic. Two capacity-type invariants attach to f: the transfinite diameter d of the root multiset, and the logarithmic capacity of {|f|≥1}.\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Adds the **third exact lower-bound term** to the elementary sharp-value program for
Erdős #1039 (OQ-05, transfinite-diameter route): **`d₄ ≥ 4^{1/3}`**, the 4-point
transfinite diameter of the closed unit disc.

The three terms now proved form a clear pattern:

| n | dₙ lower bound | = |
|---|---|---|
| 2 | `d₂ = 2` | `2^{1/1}` |
| 3 | `d₃ ≥ √3` | `3^{1/2}` |
| 4 | `d₄ ≥ 4^{1/3}` | `4^{1/3}` |

i.e. `dₙ ≥ n^{1/(n-1)}`, the extremal roots-of-unity bound whose limit is the
logarithmic capacity `1` of the disc.

## What's proved (`proofs/Proofs/Erdos1039TransfiniteDiameter.lean`, +~140 lines)

- `spreadProduct_four` — the 4-point spread product is the product of the six pairwise gaps.
- `discreteDiameter_four` — `d₄(z) = (∏ gaps)^{1/6}` (normalising exponent `2/(4·3) = 1/6`).
- `transfiniteDiameterN_four_ge` — **`d₄ ≥ 4^{1/3}`**, attained by the square
  `{1, i, -1, -i}` of fourth roots of unity: four side gaps `√2`, two diagonal gaps `2`,
  spread product `(√2)⁴·2² = 16`, diameter `16^{1/6} = 4^{1/3}`.
- `transfiniteDiameterN_four_mem_Icc` — `d₄ ∈ [4^{1/3}, 2]` (lower bound + Fekete
  monotonicity `d₄ ≤ d₃ ≤ d₂ = 2`).

## Verification

- **Docker-verified**: `./proofs/scripts/docker-build.sh Proofs.Erdos1039TransfiniteDiameter` succeeds.
- **0-axiom**: `#print axioms` on both new top-level theorems =
  `[propext, Classical.choice, Quot.sound]`. No `sorry`, no `native_decide` (`decide`
  used only for Fin-4 `Finset` facts, which does not add axioms).

## Scope / honesty

This does **not** resolve the OPEN parent Erdős #1039. It adds one more exact term of the
lower-bound sequence. The matching upper bound `d₄ = 4^{1/3}` needs the Fekete–Szegő
extremal theorem and is **not** claimed here. The general lower bound `dₙ ≥ n^{1/(n-1)}`
(route now fully scoped in the tracker: `X_pow_sub_C_eq_prod` +
`eval_multiset_prod_X_sub_C_derivative` + an off-diagonal↔spreadProduct² identity) is the
documented next milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
