### PR TITLE
Enrich erdos-103-oq-02: re-anchor 8 sections to PART banners

### DIFF
--- a/src/data/proofs/erdos-103-oq-02/meta.json
+++ b/src/data/proofs/erdos-103-oq-02/meta.json
@@ -104,62 +104,62 @@
       "id": "header",
       "title": "Problem Overview and Imports",
       "startLine": 1,
-      "endLine": 56,
+      "endLine": 58,
       "summary": "Documents Erdős #103 OQ-02 and the audit finding: the parent's raw count is degenerate, and supplies the corrected congruence count. Imports Mathlib and the parent file Erdos103Problem.",
       "mathContext": "Weak conjecture (open): $\\exists N, \\forall n \\geq N, h(n) \\geq 2$, where $h$ should count optimal configurations up to congruence."
     },
     {
       "id": "translation-isometry",
       "title": "Translation as a Distance-Preserving Map",
-      "startLine": 58,
-      "endLine": 67,
+      "startLine": 59,
+      "endLine": 74,
       "summary": "Defines Ptranslate (shift every point by v) and proves pointDist is translation-invariant: the coordinate differences are unchanged by a common shift.",
       "mathContext": "$d(p+v, q+v) = \\sqrt{((p_1+v_1)-(q_1+v_1))^2 + \\cdots} = d(p,q)$."
     },
     {
       "id": "translate-optimal",
       "title": "Translation Preserves Optimality",
-      "startLine": 69,
-      "endLine": 101,
+      "startLine": 75,
+      "endLine": 108,
       "summary": "Proves translation preserves the diameter (the double supremum of pairwise distances is unchanged) and minimum separation, hence carries optimal configurations to optimal configurations.",
       "mathContext": "Since every pairwise distance is preserved, $\\mathrm{diam}(P+v) = \\mathrm{diam}(P)$ and $\\mathrm{IsOptimal}(P) \\Rightarrow \\mathrm{IsOptimal}(P+v)$."
     },
     {
       "id": "infinitude",
       "title": "The Optimal Set is Infinite When Nonempty",
-      "startLine": 103,
-      "endLine": 124,
+      "startLine": 109,
+      "endLine": 131,
       "summary": "For n ≥ 1, builds an injection t ↦ (P₀ shifted by (t,0)) from ℝ into the optimal subtype: distinct shifts move the 0-th point to distinct positions. Hence the optimal subtype is infinite.",
       "mathContext": "$t \\mapsto P_0(\\cdot) + (t,0)$ is injective into the optimal set, and $\\mathbb{R}$ is infinite, so the optimal set is infinite."
     },
     {
       "id": "degeneracy",
       "title": "The Raw Count h(n) is Identically Zero",
-      "startLine": 126,
-      "endLine": 154,
+      "startLine": 132,
+      "endLine": 161,
       "summary": "Proves h(n) = 0 for all n ≥ 1: the optimal subtype is empty or infinite, and Nat.card is 0 in both cases. Concludes the parent's literal WeakConjecture is false.",
       "mathContext": "$h(n) = \\mathrm{Nat.card}\\,\\{P : \\mathrm{IsOptimal}\\,n\\,P\\} = 0$ for $n \\geq 1$, so $\\neg(\\exists N, \\forall n \\geq N,\\ h(n) \\geq 2)$."
     },
     {
       "id": "corrected-count",
       "title": "The Corrected Count: Congruence Classes",
-      "startLine": 156,
-      "endLine": 196,
+      "startLine": 162,
+      "endLine": 203,
       "summary": "Defines the congruence setoid on optimal configurations and hCong(n) := Nat.card of the quotient — the intended incongruent count. Shows all translates of a configuration share one class, so the quotient collapses the translation-infinitude.",
       "mathContext": "$h_{\\mathrm{Cong}}(n) = \\mathrm{Nat.card}\\,(\\{P : \\mathrm{IsOptimal}\\,n\\,P\\} / {\\cong})$. Translates of $P$ are congruent, hence one class."
     },
     {
       "id": "verification",
       "title": "Conjecture Hierarchy (Corrected)",
-      "startLine": 198,
-      "endLine": 221,
+      "startLine": 204,
+      "endLine": 215,
       "summary": "States the corrected weak conjecture `WeakConjectureCorrect` against `hCong`, and proves `correct_main_implies_weak`: the corrected main conjecture ($\\forall C, \\exists N, \\forall n \\ge N,\\ h_{\\mathrm{Cong}}(n) > C$) implies the corrected weak conjecture.",
       "mathContext": "Corrected weak conjecture: $\\exists N, \\forall n \\ge N,\\ h_{\\mathrm{Cong}}(n) \\ge 2$ — the genuinely open statement. It follows from the corrected main conjecture by instantiating $C = 1$."
     },
     {
       "id": "non-degeneracy",
       "title": "Non-Degeneracy of the Corrected Count",
-      "startLine": 222,
+      "startLine": 216,
       "endLine": 265,
       "summary": "Part 7 shows the correction repairs the degeneracy: `optimalQuotient_nonempty_of_exists` (the quotient is nonempty whenever an optimal configuration exists), `hCong_pos_of_finite` ($h_{\\mathrm{Cong}}(n) \\ge 1$ given finitely many classes), and `hCong_strictly_exceeds_raw` ($h(n) = 0 < 1 \\le h_{\\mathrm{Cong}}(n)$). A closing `#check` block exports the eight headline results.",
       "mathContext": "The contrast with `h_eq_zero` is exact: only an *infinite* quotient can drag $\\mathrm{Nat.card}(\\text{Quotient})$ to $0$, never emptiness, so under the finiteness hypothesis the congruence count is well-behaved — which is precisely why $h_{\\mathrm{Cong}}$, not the raw cardinality, is the right object for the open Erdős question."


### PR DESCRIPTION
Re-anchoring pass for `erdos-103-oq-02` (Erdős #103, corrected optimal-count question).

## Problem
The 8 section boundaries were shifted: each section ended on the *docstring* of
its final theorem, and the following section began *inside that theorem's proof
body*. Four declarations were split across section edges:

| Split decl | Line | Belongs to |
|------------|------|-----------|
| `pointDist_add_right` | 68 | PART 1 (translation-isometry) |
| `translate_optimal` (section namesake) | 102 | PART 2 (translate-optimal) |
| `raw_weak_conjecture_false` | 155 | PART 4 (degeneracy) |
| `translates_same_class` | 197 | PART 5 (corrected-count) |

## Fix
Re-anchored every section to its `-- ===` / `-- PART N` comment-banner block.
No prose changed.

## Verification
- All **17** named declarations now land in exactly one section (0 splits/orphans).
- Coverage contiguous `1..265` (EOF).
