### PR TITLE
audit-tracker: erdos-721 re-audit clean (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15881,8 +15881,8 @@
     },
     "erdos-721": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:54:15Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-21T16:19:19Z",
       "result": "clean"
     },
     "erdos-722": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-721 (Van der Waerden W(3,k)). Verified against `proofs/Proofs/Erdos721Problem.lean`:

- 6 axioms (W, graham_conjecture_false, green/hunter lower bounds, schoen/bloom_sisask upper bounds) = axiomCount 6 ✓
- 3 theorems, all honest packagings of axioms (no vacuous True-stubs) = theoremCount 3 ✓
- 2 defs, 0 sorries, no native_decide ✓
- status `axiomatized`, badge `axiom` correct
- Prose correctly flags small values / 3-AP / Szemerédi as prose-only (prior #39365 phantom-decl fix holds)

Clean. Tracker updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)