### PR TITLE
audit-tracker: erdos-716 re-audit clean (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15843,8 +15843,8 @@
     },
     "erdos-716": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:54:15Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T16:21:05Z",
       "result": "clean"
     },
     "erdos-717": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-716 (Ruzsa-Szemerédi (6,3)-problem). Verified vs `proofs/Proofs/Erdos716Problem.lean`:

- 5 axioms (extremalHypergraph, ruzsa_szemeredi_theorem, ex63_upper/lower_bound, roth_r3) = axiomCount 5 ✓
- 3 theorems, all honest packagings of axioms (erdos_716 := ruzsa_szemeredi_theorem, type = erdos716Problem defeq) = theoremCount 3 ✓
- 13 definitions (12 def + 1 structure Hypergraph3) = definitionCount 13 ✓
- 0 sorries, no native_decide ✓
- status `axiomatized`, badge `axiom`, assumptions prose accurate

Clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)