### PR TITLE
audit-tracker: erdos-717 re-audit clean (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15849,8 +15849,8 @@
     },
     "erdos-717": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:54:16Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T16:22:19Z",
       "result": "clean"
     },
     "erdos-718": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-717 (χ vs subdivision number; Fox-Lee-Sudakov). Verified vs `proofs/Proofs/Erdos717Problem.lean`:

- 4 axioms (chromaticNumber, subdivisionNumber, catlin_counterexamples, fox_lee_sudakov_theorem) = axiomCount 4 ✓
- 3 theorems (erdos717_answer, erdos_717_summary, erdos_717), honest packagings of axioms = theoremCount 3 ✓
- 6 definitions, 0 sorries, no native_decide ✓
- status `axiomatized`, badge `axiom` correct
- erdos_717_summary contains a `True ∧` conjunct for the Erdős-Fajtlowicz lower bound — explicitly disclosed in originalContributions as 'comments only, not formalized'. Honest documented non-claim, not a hidden stub.

Clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)