### PR TITLE
audit: re-verify erdos-708 clean (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15789,8 +15789,8 @@
     },
     "erdos-708": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:54:16Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T16:43:14Z",
       "result": "clean"
     },
     "erdos-709": {


### PR DESCRIPTION
Reserve-mode re-audit. **erdos-708** (Erdős #708, open $100 problem).

- 5 axioms match meta axiomCount; badge `axiom`/status `axiomatized`/erdosStatus `open`
- open conjecture stated only as unproved `def`s; theorems assert only known values + published lower bound
- axiom bodies consistent (no false/vacuous guard)
- native_decide in anonymous `example` only — trust-neutral, disclosed in assumptions
- 0 sorries, 0 True stubs

**Verdict: clean** (exemplary open-problem handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)