### PR TITLE
audit: re-verify erdos-705 clean (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15771,8 +15771,8 @@
     },
     "erdos-705": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:54:16Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T16:45:11Z",
       "result": "clean"
     },
     "erdos-706": {


### PR DESCRIPTION
Reserve-mode re-verification of erdos-705 (queue drained, 0 unaudited).

**Result: CLEAN.** 3 existence axioms (moser_spindle/odonnell/wormald) honestly disclosed with `axiom` badge and `axiomatized` status. axiomCount=3, sorries=0, theoremCount=10, definitionCount=8 — all match source. No native_decide, no True stubs. All originalContributions decls exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)