### PR TITLE
audit: re-verify erdos-701 clean (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15743,8 +15743,8 @@
     },
     "erdos-701": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:01Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T16:49:07Z",
       "result": "clean"
     },
     "erdos-702": {


### PR DESCRIPTION
Reserve-mode re-audit of Chvátal's Conjecture (#701).

Verified against `Proofs/Erdos701Problem.lean`:
- 7 theorems, 8 definitions, 0 axioms, 0 sorries — all match meta.json.
- `ChvatalConjecture` is a `Prop` def (stated, not proved/axiomatized) — no overclaim.
- Status `axiomatized`/badge `wip`, description 'OPEN with partial results' — honestly signals unresolved.
- No True stubs, no native_decide.

Clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)