### PR TITLE
Enrich sqrt2-from-axioms: add missing Coprimality section

### DIFF
--- a/src/data/proofs/sqrt2-from-axioms/meta.json
+++ b/src/data/proofs/sqrt2-from-axioms/meta.json
@@ -87,9 +87,17 @@
       "mathContext": "The key lemma: $n^2$ even $\\Rightarrow n$ even. Proved by contrapositive: $n$ odd $\\Rightarrow n = 2k+1 \\Rightarrow n^2 = 4k^2+4k+1$ odd."
     },
     {
+      "id": "coprimality",
+      "title": "Coprimality (Built from Scratch)",
+      "startLine": 124,
+      "endLine": 130,
+      "summary": "Defines Coprime a b as ¬(Even a ∧ Even b) — the minimal from-scratch notion of coprimality needed for the descent: two naturals are coprime here iff they are not both even. This is exactly the hypothesis contradicted by the main theorem, which shows any solution of a² = 2b² forces both a and b even.",
+      "mathContext": "$\\operatorname{Coprime}(a,b) := \\neg(\\operatorname{Even} a \\land \\operatorname{Even} b)$. Rather than the full gcd-based coprimality, the proof needs only the weaker 'not both even' predicate: infinite descent on the powers of $2$ dividing $a$ and $b$ is stopped precisely by ruling out a common factor of $2$."
+    },
+    {
       "id": "main-theorem",
       "title": "The Main Theorem",
-      "startLine": 133,
+      "startLine": 131,
       "endLine": 166,
       "summary": "No coprime solution to a^2 = 2b^2 exists.",
       "mathContext": "The main result: no coprime integers $a, b$ satisfy $a^2 = 2b^2$. Proof: $a^2 = 2b^2 \\Rightarrow a^2$ even $\\Rightarrow a$ even $\\Rightarrow a = 2c \\Rightarrow 4c^2 = 2b^2 \\Rightarrow b^2$ even $\\Rightarrow b$ even, contradicting coprimality."


### PR DESCRIPTION
## Enrichment: sqrt2-from-axioms section coverage

**Type:** Add a missing section (coverage gap)

PART 4 (Coprimality) of the Lean file had **no section entry at all** — the
banner and `def Coprime` (line 129) sat in an uncovered hole (123–132) between
"Key Lemma: Even Squares" [104–122] and "The Main Theorem" [133–166].

- **Added** section "Coprimality (Built from Scratch)" [124–130], covering
  `def Coprime a b := ¬(Even a ∧ Even b)` — the exact hypothesis the main
  theorem contradicts — with a `summary` and LaTeX `mathContext`.
- **Re-anchored** "The Main Theorem" start 133 → 131 so it includes its own
  `-- PART 5` banner.

Uncovered top-level declarations: **1 → 0** (the earlier "structure@31" flag was
a false positive — a word inside the module block comment). Sections remain
contiguous and non-overlapping; no existing content changed.
