### PR TITLE
audit: re-verify erdos-699 clean (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15713,8 +15713,8 @@
     },
     "erdos-699": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:01Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T16:51:18Z",
       "result": "clean"
     },
     "erdos-7": {


### PR DESCRIPTION
Reserve-mode re-audit of Prime Divisors of GCDs of Binomial Coefficients (#699).

Verified against `Proofs/Erdos699Problem.lean`:
- 17 theorems, 4 defs, 1 axiom (`sylvester_schur`), 0 sorries — all match meta.json.
- Open problem `erdos_699_statement` is a `Prop` def (unproven) — no overclaim.
- `sylvester_schur` is the true classical Sylvester-Schur theorem axiomatized (opaque, honestly disclosed via badge `axiom`).
- native_decide (15×) fully disclosed in assumptions (Lean.ofReduceBool trust dep).
- (28,5,14) counterexample to the strong form proved honestly; `max_prime_1080_is_5`/`choose_formula` kernel-checked.

Clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)