### PR TITLE
audit: re-verify erdos-696 clean (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15695,8 +15695,8 @@
     },
     "erdos-696": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:01Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T16:53:56Z",
       "result": "clean"
     },
     "erdos-697": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-696 (queue drained, 0 unaudited).

**Result: CLEAN.** Honest Tier C axiomatized entry.

- 2 axioms (`h_le_H`, `h_tends_to_infinity`) — both true statements (h≤H; van Doorn's density result), disclosed as axioms; badge `axiom`, status `axiomatized`.
- 3 theorems / 9 defs / 0 sorries — all match meta.
- No `decide`/`native_decide`.
- `logStar` stub (`fun _ => 0`) and the two conjecture `Prop`s explicitly disclosed in meta; not claimed as proved.

Minor cosmetic nit (not fixed): `leanFile.lineCount` 310 vs actual 306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)