### PR TITLE
Enrich erdos-470: cover stranded tail decls + fix mislabeled Summary section

### DIFF
--- a/src/data/proofs/erdos-470/meta.json
+++ b/src/data/proofs/erdos-470/meta.json
@@ -100,7 +100,7 @@
       "id": "smallest-weird",
       "title": "The Smallest Weird Number: 70",
       "startLine": 80,
-      "endLine": 116,
+      "endLine": 126,
       "summary": "Proves 70 is abundant (native_decide), not pseudoperfect (powerset exhaustion), and no number below 70 is weird (exhaustive computation). Formerly axiomatized, now fully proved.",
       "mathContext": "$\\sigma(70) = 144 > 140 = 2 \\times 70$. No subset of $\\{1,2,5,7,10,14,35\\}$ sums to 70."
     },
@@ -130,11 +130,11 @@
     },
     {
       "id": "summary",
-      "title": "Summary",
-      "startLine": 538,
+      "title": "Prime-Indexing Infrastructure and the Melfi Conditional",
+      "startLine": 525,
       "endLine": 566,
-      "summary": "The erdos_470 summary theorem combining: 70 is smallest weird, 70 is primitive weird, odd weird > 3465, positive density, Melfi conditional.",
-      "mathContext": "Combined theorem asserting all key established results about Erdős Problem #470."
+      "summary": "Prime-indexing helpers used by the conditional-infinitude results: nthPrime n = Nat.nth Nat.Prime n with nthPrime_zero (= 2) and nthPrime_prime, the primeGap definition, the melfi_conditional axiom (a prime-gap hypothesis implies infinitely many primitive weird numbers), and the WeirdSet = { n | IsWeird n } definition.",
+      "mathContext": "$\\text{nthPrime}(n) = p_{n}$ (Mathlib's $\\texttt{Nat.nth}$), $\\text{primeGap}(n) = p_{n+1} - p_n$. The Melfi conditional axiom: if $p_{n+1} - p_n < \\sqrt{p_n}/10$ eventually, then $\\text{PrimitiveWeirdSet}$ is infinite. $\\text{WeirdSet} := \\{ n \\mid \\text{IsWeird } n \\}$."
     },
     {
       "id": "density-axiom-main-theorem",


### PR DESCRIPTION
## Enrichment: erdos-470 tail coverage + mislabeled section fix

**Type:** Section re-anchoring + correcting a wrong title/summary

Two defects in the section map:

**1. End-drift.** "The Smallest Weird Number: 70" [80–116] stopped before its own
concluding results `no_weird_below_70` (118) and `smallest_weird_is_70` (125),
both of which its summary already describes. Extend end 116 → 126.

**2. Mislabeled section.** The section titled **"Summary"** [538–566] had a title
*and* a summary describing the `erdos_470` capstone theorem — but that theorem is
at line **591**, inside the *next* section ("Density Axiom and Main Theorem",
whose summary already covers it correctly). The real content of [538–566] is
prime-indexing infrastructure. Fixes:
- Retitle → **"Prime-Indexing Infrastructure and the Melfi Conditional"**
- Rewrite `summary` + `mathContext` to match the actual content
  (`nthPrime`/`nthPrime_zero`/`nthPrime_prime`, `primeGap`, the `melfi_conditional`
  axiom, `WeirdSet`)
- Extend start 538 → 525 to cover `nthPrime` (528) and `nthPrime_zero` (533)

Stranded top-level declarations: **4 → 0**. Sections remain contiguous and
non-overlapping; the genuine `## Summary` block and `erdos_470` stay in the
"Density Axiom and Main Theorem" section.
