### PR TITLE
Enrich erdos-952: extend 2 section ends to cover stranded decls

### DIFF
--- a/src/data/proofs/erdos-952/meta.json
+++ b/src/data/proofs/erdos-952/meta.json
@@ -113,7 +113,7 @@
       "title": "Known Negative Results",
       "summary": "tsuchimura axiom, jordan_rabung, gethner_et_al, not_canEscapeMoat_small, canEscapeMoat_mono",
       "startLine": 151,
-      "endLine": 185,
+      "endLine": 199,
       "mathContext": "Tsuchimura (2005): no walk with norm < 27. Jordan-Rabung and Gethner et al. are weaker results following from Tsuchimura."
     },
     {
@@ -137,7 +137,7 @@
       "title": "Variants and Status",
       "summary": "EisensteinMoatProblem, erdos_952_status, attribution_note",
       "startLine": 297,
-      "endLine": 348,
+      "endLine": 358,
       "mathContext": "EisensteinMoatProblem is a placeholder: its body reuses the Gaussian moat definition over ℤ[i] rather than formalizing Eisenstein primes in ℤ[ω] (a genuine ℤ[ω] version is future work). HigherDimensionalMoat is likewise a scaffold (n = n). Status: OPEN. Attribution: Motzkin, Gordon et al. (1963)."
     }
   ],


### PR DESCRIPTION
## Enrichment: extend section ends to cover stranded decls (erdos-952)

Two sections' `endLine` stopped short of their trailing declarations,
leaving four named decls outside any section:

| Decl | Line | Section (title) | Was |
|------|------|-----------------|-----|
| `not_canEscapeMoat_small` | 189 | Known Negative Results | ended 185 |
| `canEscapeMoat_mono` | 194 | Known Negative Results | ended 185 |
| `erdos_952_status` | 353 | Variants and Status | ended 348 |
| `attribution_note` | 356 | Variants and Status | ended 348 |

### Fix
Extended "Known Negative Results" end `185 → 199` (up to the next section's
start at 200) and "Variants and Status" end `348 → 358` (end of namespace).
Both stranded pairs match their sections' titles — the two moat-escape
negative results and the two status declarations.

### Verification
- Every named declaration is covered by exactly one section (0 stranded,
  0 double-covered)
- Titles/summaries unchanged
- Diff is anchor-only (2 numeric changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
