### PR TITLE
Enrich erdos-566: re-anchor 4 sections to cover stranded decls

### DIFF
--- a/src/data/proofs/erdos-566/meta.json
+++ b/src/data/proofs/erdos-566/meta.json
@@ -47,30 +47,30 @@
       "id": "graph-definitions",
       "title": "Graph Structure and Edge Counting",
       "startLine": 25,
-      "endLine": 33,
+      "endLine": 36,
       "summary": "Defines simple graphs via symmetric irreflexive adjacency on $\\text{Fin}\\;n$ and edge counting $|E(G)| = |\\{(u,v) : u < v \\land \\text{adj}(u,v)\\}|$.",
       "mathContext": "Formal definition: Defines simple graphs via symmetric irreflexive adjacency on $\\text{Fin}\\;n$ and edge counting $|E(G)| = |\\{(u,v) : u < v \\land \\text{adj}(u,v)\\}|$."
     },
     {
       "id": "sparsity-definitions",
       "title": "Sparsity and Nondegeneracy Conditions",
-      "startLine": 35,
-      "endLine": 45,
+      "startLine": 37,
+      "endLine": 48,
       "summary": "Defines $(2k-3)$-sparsity ($\\forall S,\\;|E(G[S])| \\le 2|S|-3$) and the no-isolated-vertices condition ($\\forall v,\\;\\deg(v) \\ge 1$), the two key hypotheses in the conjecture.",
       "mathContext": "Formal definition: Defines $(2k-3)$-sparsity ($\\forall S,\\;|E(G[S])| \\le 2|S|-3$) and the no-isolated-vertices condition ($\\forall v,\\;\\deg(v) \\ge 1$), the two key hypotheses in the conjecture."
     },
     {
       "id": "size-ramsey-def",
       "title": "Size Ramsey Number",
-      "startLine": 47,
-      "endLine": 51,
+      "startLine": 49,
+      "endLine": 54,
       "summary": "Defines $\\hat{r}(G,H)$ as the minimum edge count in a graph $F$ such that every 2-coloring of $E(F)$ yields a monochromatic $G$ or $H$. Axiomatized since the actual construction requires Ramsey theory.",
       "mathContext": "Defines $\\hat{r}(G,H)$ as the minimum edge count in a graph $F$ such that every 2-coloring of $E(F)$ yields a monochromatic $G$ or $H$. Axiomatized since the actual construction requires Ramsey theory."
     },
     {
       "id": "main-conjecture",
       "title": "Main Conjecture (Problem #566)",
-      "startLine": 53,
+      "startLine": 55,
       "endLine": 62,
       "summary": "States the open conjecture: $(2k-3)$-sparse $G$ $\\implies$ $\\exists c > 0$ such that $\\hat{r}(G,H) \\le c \\cdot |E(H)|$ for all $H$ without isolated vertices. Formalized as an axiom since the problem is unresolved.",
       "mathContext": "States the open conjecture: $(2k-3)$-sparse $G$ $\\implies$ $\\exists c > 0$ such that $\\hat{r}(G,H) \\le c \\cdot |E(H)|$ for all $H$ without isolated vertices. Formalized as an axiom since the problem is unresolved."


### PR DESCRIPTION
## Enrichment: re-anchor sections to cover stranded decls (erdos-566)

Sections 3–5 each ended one line before their closing definition, and
section 6 ("Main Conjecture") started at line 53 — *inside* `sizeRamsey`'s
proof body — leaving three named declarations outside any section:

| Decl | Line | Section |
|------|------|---------|
| `edgeCount` | 34 | Graph Structure and Edge Counting |
| `NoIsolated` | 46 | Sparsity and Nondegeneracy Conditions |
| `sizeRamsey` | 52 | Size Ramsey Number |

### Fix
Re-anchored the definition-bearing sections to be contiguous and to contain
each decl whole:

`[25,36] [37,48] [49,54]`, and moved "Main Conjecture" `startLine 53 → 55`
(the `## Main Question` banner, off the `sizeRamsey` body).

### Verification
- Every named declaration is covered by exactly one section (0 stranded,
  0 double-covered, no overlaps)
- Titles/summaries unchanged
- Diff is anchor-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
