### PR TITLE
Enrich erdos-239: extend 2 section ends to cover stranded decls

### DIFF
--- a/src/data/proofs/erdos-239/meta.json
+++ b/src/data/proofs/erdos-239/meta.json
@@ -144,7 +144,7 @@
       "title": "Constant Function Example",
       "summary": "constOne with mean 1",
       "startLine": 181,
-      "endLine": 207
+      "endLine": 208
     },
     {
       "id": "liouville-mean",
@@ -167,7 +167,7 @@
       "title": "Summary",
       "summary": "erdos_239_summary, erdos_239_answer",
       "startLine": 240,
-      "endLine": 274,
+      "endLine": 278,
       "mathContext": "Mathematical content: erdos_239_summary, erdos_239_answer"
     }
   ],


### PR DESCRIPTION
Coverage/labeling-correctness pass for erdos-239 (uncovered-declaration vein).

Two named theorems fell outside every `sections[]` range:
- `constOne_mean` (line 208) — the 'Constant Function Example' section ended at 207, one line short of its own key theorem (summary already reads 'constOne with mean 1').
- `erdos_239_answer` (line 275) — the 'Summary' section ended at 274; its summary already names `erdos_239_answer`.

Fix: extend the two `endLine`s (207→208, 274→278). Sections stay contiguous, every named decl now falls in exactly one section, and both summaries were already accurate. Anchor-only diff, no prose changes.