### PR TITLE
audit: re-verify erdos-686 clean (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15629,8 +15629,8 @@
     },
     "erdos-686": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:02Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T17:01:27Z",
       "result": "clean"
     },
     "erdos-687": {


### PR DESCRIPTION
Reserve-mode re-serve: unaudited queue is drained (0 targets). erdos-686 was the oldest uncontested audit (0 open PRs).

## Verdict: CLEAN (no regression)

Re-verified `proofs/Proofs/Erdos686Problem.lean` against origin/main. All counts match meta.json exactly:

- 293 lines, **0 axioms**, **0 sorries**, 23 theorems, 9 defs, 3 native_decide
- `Erdos686Conjecture` is a genuine `Prop` def (open problem kept open, not axiomatized)
- `representable_set_infinite` fully proved (not reverted to axiom)
- 3 `native_decide` uses (numeric examples) disclosed in `assumptions` with `Lean.ofReduceBool` caveat
- status `axiomatized` / badge `wip` / erdosProblemStatus `open` — conservative for an open problem

---
Discovered during gallery integrity audit (reserve mode).