### PR TITLE
Enrich lagrange-four-squares-oq-04-oq-01: re-anchor sections I/II to cover stranded decls

### DIFF
--- a/src/data/proofs/lagrange-four-squares-oq-04-oq-01/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-04-oq-01/meta.json
@@ -60,15 +60,15 @@
     {
       "id": "definitions",
       "title": "Section I: Predicates",
-      "startLine": 41,
-      "endLine": 47,
+      "startLine": 38,
+      "endLine": 44,
       "summary": "Defines IsSumOfThreeSquares and IsSumOfFourSquares as the obvious existential predicates over ℕ.",
       "mathContext": "S₃ = {n : ∃ a b c, a²+b²+c² = n}, S₄ = {n : ∃ a b c d, a²+b²+c²+d² = n}."
     },
     {
       "id": "mod8-obstruction",
       "title": "Section II: The mod-8 Obstruction",
-      "startLine": 49,
+      "startLine": 45,
       "endLine": 70,
       "summary": "Proves sq_mod_eight (every square is ≡ 0,1,4 mod 8), three_sq_not_seven_mod_eight (a sum of three squares is never ≡ 7 mod 8), and the corollary not_isSumOfThreeSquares_of_seven_mod_eight.",
       "mathContext": "a² mod 8 ∈ {0,1,4} ⟹ (a²+b²+c²) mod 8 ≠ 7."


### PR DESCRIPTION
Coverage/labeling-correctness pass (uncovered-declaration vein).

Two named decls fell outside every `sections[]` range, and a content banner was misfiled:
- `IsSumOfThreeSquares` (line 39) — Section I 'Predicates' started at 41, covering only `IsSumOfFourSquares`, though its summary names both.
- `sq_mod_eight` (line 48) — Section II 'The mod-8 Obstruction' started at 49; the theorem and its `### The mod-8 obstruction` banner (line 45) sat in the gap / inside Section I.

Fix: re-anchor Section I to [38-44] (both predicate defs) and Section II to [45-70] (banner through the obstruction lemmas). Sections stay contiguous, every named decl now falls in exactly one section, and both summaries were already accurate. Anchor-only diff.