### PR TITLE
audit: re-verify erdos-689 clean (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15647,8 +15647,8 @@
     },
     "erdos-689": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:02Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T17:03:45Z",
       "result": "clean"
     },
     "erdos-69": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-689 (Erdős #689, double covering by prime congruence classes).

**Verdict: CLEAN.** All meta claims match the Lean source:
- 1 axiom `erdos_689_r_fold` — the genuinely-open conjecture in honest positive-existence form (not a `¬∃` masking). r=1/2/10 special cases all *derived* from it, not independently claimed.
- theoremCount 19, definitionCount 4 (`IsCoveredBy` is `@[reducible] def`), sorries 0, lineCount 239 — all accurate.
- 0 native_decide. Mertens divergence proved via disclosed Mathlib `not_summable_one_div_on_primes`.
- Badge `axiom`/status `axiomatized` correct; prose discloses the axiom and Mathlib reliance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)