### PR TITLE
Enrich erdos-718: re-anchor final two sections to cover stranded decls

### DIFF
--- a/src/data/proofs/erdos-718/meta.json
+++ b/src/data/proofs/erdos-718/meta.json
@@ -144,15 +144,15 @@
       "title": "Minors vs Subdivisions",
       "summary": "Minor relationship and subdivision-implies-minor (documented in comments, not formalized)",
       "startLine": 135,
-      "endLine": 148,
+      "endLine": 139,
       "mathContext": "Minor relationship and subdivision-implies-minor are comment-only prose, not declarations"
     },
     {
       "id": "main-results",
       "title": "Main Results",
       "summary": "erdos_718_solved, erdos_718_summary, and erdos_718 theorems",
-      "startLine": 163,
-      "endLine": 177,
+      "startLine": 140,
+      "endLine": 176,
       "mathContext": "Verified: erdos_718_solved, erdos_718_summary, and erdos_718 theorems"
     }
   ],


### PR DESCRIPTION
Coverage/labeling-correctness pass (uncovered-declaration vein).

Two named theorems fell outside every `sections[]` range:
- `erdos_718_solved` (line 151) and `erdos_718_summary` (line 155) — the 'Main Results' section started at 163, in the middle of `erdos_718_summary`'s proof, though its summary names both theorems.

Root cause: 'Minors vs Subdivisions' ran to line 148, swallowing the `## The Main Theorem` banner (line 140) and the opening of the `erdos_718_solved` docstring, while 'Main Results' began too late at 163.

Fix: re-anchor 'Minors vs Subdivisions' to [135-139] and 'Main Results' to [140-176] (banner through EOF). Sections stay contiguous, every named decl now falls in exactly one section, and both summaries were already accurate. Anchor-only diff.