### PR TITLE
audit: re-verify erdos-687 clean (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15635,8 +15635,8 @@
     },
     "erdos-687": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-07-21T16:59:22Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-21T17:06:06Z",
       "result": "clean"
     },
     "erdos-688": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-687 (Erdős #687, Jacobsthal function / $1,000 prize).

**Verdict: CLEAN.** Integrity dimensions all accurate:
- 4 axioms (`jacobsthalY_eq_jacobsthal_sub_one`, `iwaniec_upper`, `fgkmt_lower`, `maier_pomerance_conjecture`) — all honest positive statements (known results + named conjecture + CRT equivalence), none vacuous-True or false `¬∃`. Matches axiomCount 4.
- $1,000 conjecture `erdos_687_conjecture` honestly *conditionally derived* from the M-P axiom (disclosed in prose + docstring + badge `axiom`/status `axiomatized`).
- theoremCount 26 = 21 public + 5 private lemmas (correct, includes private per convention). 0 sorries, 0 native_decide.

Nit (non-reportable, safe direction): conclusion.summary says "149 lines" but file is 547 — an understatement, not an overclaim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)