### PR TITLE
Enrich erdos-1-oq-03: extend final section to cover stranded growth-rate theorems

### DIFF
--- a/src/data/proofs/erdos-1-oq-03/meta.json
+++ b/src/data/proofs/erdos-1-oq-03/meta.json
@@ -110,8 +110,8 @@
     {
       "id": "growth-rate",
       "title": "Growth Rate Properties",
-      "startLine": 232,
-      "endLine": 249,
+      "startLine": 229,
+      "endLine": 259,
       "summary": "Strict monotonicity and at-most-doubles bound for the sequence.",
       "mathContext": "$a_k < a_{k+1} \\leq 2 a_k$"
     }


### PR DESCRIPTION
Coverage/labeling-correctness pass (uncovered-declaration vein).

Two named theorems fell outside every `sections[]` range:
- `conwayGuy_strictMono` (250) and `conwayGuy_at_most_doubles` (256) — the 'Growth Rate Properties' section ended at 249, though its summary reads 'Strict monotonicity and at-most-doubles bound' (exactly these two).

Fix: extend the section to [229-259] — back to its `PART VI: Growth Rate` banner (229) and forward to EOF (259). Stays contiguous with the prior section (ends 228); every named decl now falls in exactly one section; summary already accurate. Anchor-only diff.