### PR TITLE
audit: fix erdos-682 phantom decl names in section prose

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15601,9 +15601,9 @@
     },
     "erdos-682": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:02Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T17:09:18Z",
+      "result": "issues-fixed"
     },
     "erdos-683": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-682/meta.json
+++ b/src/data/proofs/erdos-682/meta.json
@@ -130,8 +130,8 @@
       "title": "Prime Gaps",
       "startLine": 113,
       "endLine": 136,
-      "summary": "`primeGap n` ($g_n = p_{n+1} - p_n$), `gapInterval n` ($(p_n, p_{n+1})$), `gap_nonempty` for $n \\geq 2$",
-      "mathContext": "The prime gap $g_n = p_{n+1} - p_n$ and the open interval $(p_n, p_{n+1})$ of composite numbers between consecutive primes. By the Prime Number Theorem, $g_n \\sim \\log p_n$ on average, but individual gaps vary: the largest known gap of size $g$ near $p$ satisfies $g \\leq p^{0.525}$ unconditionally (Baker-Harman-Pintz). The theorem `gap_nonempty` shows $(p_n, p_{n+1}) \\neq \\emptyset$ for $n \\geq 2$."
+      "summary": "`primeGap n` ($g_n = p_{n+1} - p_n$), `gapInterval n` ($(p_n, p_{n+1})$); non-emptiness of the gap for $n \\geq 2$ is discussed in a comment (not formalized)",
+      "mathContext": "The prime gap $g_n = p_{n+1} - p_n$ and the open interval $(p_n, p_{n+1})$ of composite numbers between consecutive primes. By the Prime Number Theorem, $g_n \\sim \\log p_n$ on average, but individual gaps vary: the largest known gap of size $g$ near $p$ satisfies $g \\leq p^{0.525}$ unconditionally (Baker-Harman-Pintz). A comment notes that $(p_n, p_{n+1}) \\neq \\emptyset$ for $n \\geq 2$; this is not formalized as a theorem in the file."
     },
     {
       "id": "main-property",
@@ -146,7 +146,7 @@
       "title": "Erdős's Counterexample Construction",
       "startLine": 155,
       "endLine": 198,
-      "summary": "`primorial`, `dickson_special_case` (primes at $2183+30030d$, $2201+30030d$), `erdos_counterexample_condition`, infinitely many exceptions conditional on Dickson",
+      "summary": "Comment-only (not formalized): the primorial $13\\# = 30030$, Dickson's special case (primes at $2183+30030d$, $2201+30030d$), and Erdős's conditional counterexample giving infinitely many exceptions conditional on Dickson",
       "mathContext": "Erdős's conditional counterexample: the primorial $p\\# = \\prod_{q \\leq p} q$ guarantees that every integer in $[1, p\\#]$ shares a prime factor with $p\\#$. For $p = 13$: $13\\# = 30030$, and Dickson's conjecture predicts infinitely many $d$ where $2183 + 30030d$ and $2201 + 30030d$ are consecutive primes (gap 18). In such gaps, every composite $m$ satisfies $p(m) \\leq 13 < 18 = g_n$, giving infinitely many exceptions."
     },
     {
@@ -162,7 +162,7 @@
       "title": "Gafni-Tao Theorem (2025)",
       "startLine": 217,
       "endLine": 258,
-      "summary": "`exceptionalCount`, `gafni_tao_upper_bound` ($E(X) \\leq C \\cdot X/(\\log X)^2$), `gafni_tao_conditional_asymptotic`, `erdos682_answer`: YES",
+      "summary": "`exceptionalCount`, `gafni_tao_upper_bound` axiom ($E(X) \\leq C \\cdot X/(\\log X)^2$), the conditional asymptotic (comment-only, not formalized), `erdos682_answer`: YES",
       "mathContext": "The Gafni-Tao theorem (2025): $E(X) = |\\{n \\leq X : \\text{isExceptional}(n)\\}| \\leq C \\cdot X/(\\log X)^2$ for an absolute constant $C$. The bound $X/(\\log X)^2$ is tight: conditionally on the prime tuples conjecture, $E(X) \\sim c \\cdot X/(\\log X)^2$ for an explicit $c > 0$. The proof uses sieve methods to show primorial-based obstructions account for essentially all exceptions."
     },
     {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-682

**Result:** issues-fixed (LOW severity)

### Core metrics verified accurate
- axioms: 2 (`gafni_tao_upper_bound`, `gafni_tao_main_theorem`) ✓
- theorems: 8 ✓ · definitions: 10 ✓ · sorries: 0 ✓
- status `axiomatized` / badge `axiom` — correct Tier C (Gafni-Tao result axiomatized, several supporting theorems genuinely proved)
- top-level `originalContributions` honest (labels counterexample "not formalized")

### Issue found & fixed
`sections[]` prose referenced **comment-only concepts as declarations**:
- **prime-gaps**: `mathContext` asserted *"The theorem `gap_nonempty` shows (p_n,p_{n+1})≠∅ for n≥2"* — no such theorem exists (only a prose comment in Part III).
- **counterexample**: backticked `dickson_special_case`, `erdos_counterexample_condition`, `primorial` — all comment-only (Part V has no declarations).
- **gafni-tao**: named `gafni_tao_conditional_asymptotic` — comment-only (Part VII).

A prior audit cleaned the top-level `originalContributions` but left these section-prose phantoms. Reworded the three sections to mark the concepts as discussed-in-comments / not-formalized. No Lean source changes; no headline count changes.