### PR TITLE
Enrich 4 proofs: re-anchor sections to cover stranded decls

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02/meta.json
@@ -136,14 +136,22 @@
       "title": "Countable Ordinals as Iio(ω₁)",
       "summary": "Defines IsCountableOrdinal α ↔ α.card ≤ ℵ₀. Proves α < ω₁ ↔ IsCountableOrdinal α via Cardinal.lt_ord, and derives that the set of countable ordinals equals Set.Iio omega1.",
       "startLine": 123,
-      "endLine": 143,
+      "endLine": 148,
       "mathContext": "$\\{\\alpha \\in \\text{Ord} : \\alpha.\\text{card} \\leq \\aleph_0\\} = \\{\\alpha : \\alpha < \\omega_1\\}$ — every countable ordinal lies below $\\omega_1$, and conversely."
+    },
+    {
+      "id": "zero-countable",
+      "title": "Zero is a Countable Ordinal",
+      "summary": "Proves zero_lt_omega1: the ordinal 0 lies strictly below ω₁, since 0 is countable (its cardinality is 0 ≤ ℵ₀). A base case confirming the initial segment Iio(ω₁) is nonempty.",
+      "startLine": 149,
+      "endLine": 156,
+      "mathContext": "$0 < \\omega_1$ because $0$ is a countable ordinal ($|0| = 0 \\leq \\aleph_0$)."
     },
     {
       "id": "diagonal-argument",
       "title": "The Cantor Diagonal Argument",
       "summary": "Proves cantor_diagonal_countable_ordinals: for any f : ℕ → Ordinal with all f(n) < omega1, there exists β < omega1 exceeding all f(n). Uses sSup of range f plus ordinal successor.",
-      "startLine": 155,
+      "startLine": 157,
       "endLine": 194,
       "mathContext": "For $f : \\mathbb{N} \\to \\text{Ord}$ with $f(n) < \\omega_1$, let $\\beta = \\sup\\{f(n)\\} + 1$. Then $\\beta < \\omega_1$ (countable sup of countable ordinals is countable) and $\\beta > f(n)$ for all $n$."
     },

--- a/src/data/proofs/erdos-135/meta.json
+++ b/src/data/proofs/erdos-135/meta.json
@@ -61,7 +61,7 @@
       "id": "basic-definitions",
       "title": "Points and Distances",
       "summary": "Point, sqDist, distinctDistances, distanceCount definitions",
-      "startLine": 48,
+      "startLine": 38,
       "endLine": 64,
       "mathContext": "Formal definition: Point, sqDist, distinctDistances, distanceCount definitions"
     },


### PR DESCRIPTION
## Enrichment: re-anchor sections to cover stranded declarations

The "covered by ANY section" uncovered-decl scan flagged four gallery
entries with named declarations (theorem/def/abbrev) that fall outside
every `meta.sections` range, so the gallery renders them uncovered.
All fixes are pure section-anchor adjustments — no `.lean` changes, no
status/badge/axiomCount changes. Existing section summaries already
describe the now-covered declarations.

| Entry | Fix |
|-------|-----|
| **erdos-1-oq-03** | Extend "Growth Rate Properties" 232–249 → 229–260 (pull start to PART VI banner, extend to EOF) covering `conwayGuy_strictMono`, `conwayGuy_at_most_doubles`. |
| **erdos-135** | Pull "Points and Distances" start 48 → 38 to cover the `Point` abbrev and `distinctDistances` def under the `## Definitions` banner. |
| **thue-morse-oq-01** | Fix an overlap ("Base Recurrences" 57–91 → 57–82, "Consecutive Pairs and Powers of Two" 83–98 → 83–101) and re-anchor "Prouhet-Tarry-Escott Block Identities" 114–144 → 102–147 to its own `/-!` banner, covering `thueMorse_four_mul` and `thueMorse_four_mul_add_one`. |
| **cantor-diagonalization-oq-02** | Extend "Countable Ordinals as Iio(w1)" 123–143 → 123–148 for `countable_ordinals_eq_Iio`; add the missing Part 6 "Zero is a Countable Ordinal" section (149–156) for `zero_lt_omega1`; shift "The Cantor Diagonal Argument" start 155 → 157. |

Verified: all four parse as JSON, no section overlaps, and the decisive
scan (every named decl in exactly one section) now reports zero stranded
declarations for each entry.
