### PR TITLE
audit: re-verify erdos-683 clean (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15607,8 +15607,8 @@
     },
     "erdos-683": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:02Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T17:11:23Z",
       "result": "clean"
     },
     "erdos-684": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-683 (reserve mode re-verify)

**Result:** clean

erdos-683 was previously INCONSISTENT (#39980) and fixed in #39985. Re-served in reserve mode; confirmed the fix is intact with no regression.

### Verified
- `largestPrimeDivisor n := n.primeFactors.max' …` — genuine largest prime divisor (not `Nat.find`/least)
- `axiom sylvester_schur : P n k > k` — legitimate axiomatization of the true theorem (P is the genuine max)
- `theorem P_maximal` proves real maximality via `Finset.le_max'`
- counts: **2 axioms** (sylvester_schur, erdos_1955_bound), **7 theorems**, **0 sorries**, **0 native_decide**
- status `axiomatized` / badge `axiom` — honest (open problem; Sylvester-Schur + Erdős-1955 axiomatized, clearly attributed)
- `originalContributions` and section prose reference only real declarations; comment-only content is labeled as such

Minor (not fixed, out of integrity scope): internal docstrings on `P_is_prime`/`P_divides` still say "Proved from Nat.find_spec" (proofs now use `Finset.max'_mem`) — a stale code comment, not a public gallery claim.