### PR TITLE
audit: re-verify erdos-68 clean (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15583,8 +15583,8 @@
     },
     "erdos-68": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:02Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-21T17:13:57Z",
       "result": "clean"
     },
     "erdos-680": {


### PR DESCRIPTION
Reserve-mode re-verification of erdos-68 (Irrationality of Factorial Sum, OPEN Erdős problem).

**Verdict: CLEAN.** Counts match the Lean source exactly:
- axiomCount 1 — only `axiom erdos_68 : ErdosConjecture68` (the OPEN conjecture, disclosed)
- sorries 0, theoremCount 33, definitionCount 7, no native_decide
- status `axiomatized` / badge `axiom` correct for an open problem
- Section prose exemplary: Part 4 names the single axiom and states the conjecture is unproven

Perturbation_difference and eRelatedSum_value are now proved theorems (previously axioms), consistent with the `assumptions` note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)