### PR TITLE
audit: erdos-675 re-verify clean (false-axiom fix confirmed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15550,8 +15550,8 @@
     },
     "erdos-675": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:02Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-21T17:17:22Z",
       "result": "clean"
     },
     "erdos-676": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-675 (queue drained, 0 unaudited).

## Result: CLEAN

Prior integrity issue #39935 (false axiom via vacuous `True`-body guard) was fixed by merged PR #39941. Re-verified against current `Proofs/Erdos675Problem.lean`:

| Field | meta.json | actual | match |
|-------|-----------|--------|-------|
| lineCount | 136 | 136 | ✓ |
| axiomCount | 1 | 1 | ✓ |
| theoremCount | 3 | 3 | ✓ |
| definitionCount | 12 | 12 | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |

The axiom `brun_sieve_translation_primeSquares : HasTranslationProperty (bFreeSet primeSquares)` is now specialized to the squarefree case (bFreeSet primeSquares = squarefree numbers), a genuinely true statement. The old general B-free version guarded by a vacuous `True` reciprocal-sum condition (which admitted B = all primes ⇒ bFreeSet = {1}, false) has been removed. Docstring + proofStrategy disclose this honestly. Status `axiomatized` / badge `axiom` correct (Tier C); the three open conjectures are stated as unproved `def` Props, not claimed proved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)