### PR TITLE
audit: erdos-674 re-verify clean (honest wip scaffold)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15544,8 +15544,8 @@
     },
     "erdos-674": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:03Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T17:20:35Z",
       "result": "clean"
     },
     "erdos-675": {


### PR DESCRIPTION
Reserve-mode re-audit (queue drained). Uncontested.

## Result: CLEAN

`Proofs/Erdos674Problem.lean` — honest work-in-progress scaffold. 22 of 25 theorems are `sorry` (only `koX_gt_one`/`koY_gt_one`/`koZ_gt_one` are proved via norm_num).

| Field | meta | actual | match |
|-------|------|--------|-------|
| lineCount | 283 | 283 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| theoremCount | 25 | 25 | ✓ |
| definitionCount | 13 | 13 | ✓ |
| sorries | 22 | 22 | ✓ |
| native_decide | — | 0 | ✓ |

Disclosure is thorough and honest:
- `badge: wip` (correct for sorry-heavy file), `assumptions` states "22 sorry(s) remain", `proofStrategy` says "The 22 sorries represent deep arithmetic results".
- Every section explicitly labels its sorries "(proof deferred, `sorry`)" — avoids the "Proves X" overclaim failure mode.
- Description/keyInsights/conclusion attribute results historically (Ko 1940, Dem'janenko 1975), not as our proofs.

Nit (not filed): conclusion says "284 lines" vs actual 283 — harmless off-by-one. Consistent with prior wip-scaffold audits (erdos-715, erdos-660).

🤖 Generated with [Claude Code](https://claude.com/claude-code)