### PR TITLE
Enrich 4 proofs: re-anchor sections to cover stranded decls

### DIFF
--- a/src/data/proofs/erdos-1059-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-02-oq-01/meta.json
@@ -68,39 +68,39 @@
     {
       "id": "definitions",
       "title": "Definitions (Self-Contained Copy)",
-      "startLine": 52,
-      "endLine": 66,
+      "startLine": 50,
+      "endLine": 58,
       "summary": "AllFactorialSubtractionsComposite: for all k with k! < n, n-k! is composite (≥2, not prime)."
     },
     {
       "id": "counterexample",
       "title": "The l=3 Counterexample",
-      "startLine": 68,
-      "endLine": 91,
+      "startLine": 59,
+      "endLine": 89,
       "summary": "Six failure lemmas: p7_fails through p23_fails. Each shows a specific k where p - k! is prime.",
       "mathContext": "Primes in I(3)=(6,24]: {7,11,13,17,19,23}. Each fails at k=2 (subtract 2!) or k=3 (subtract 6)."
     },
     {
       "id": "witness",
       "title": "Qualifying Prime in I(4): p = 101",
-      "startLine": 104,
-      "endLine": 123,
+      "startLine": 90,
+      "endLine": 122,
       "summary": "p101_prime, p101_qualifying: 101 is prime and satisfies AllFactorialSubtractionsComposite. Verified by interval_cases + norm_num.",
       "mathContext": "101-0!=100=4·25, 101-2!=99=9·11, 101-6=95=5·19, 101-24=77=7·11. All composite ≥2."
     },
     {
       "id": "corrected-axiom",
       "title": "Corrected Selberg Density Axiom (l ≥ 4)",
-      "startLine": 138,
-      "endLine": 140,
+      "startLine": 123,
+      "endLine": 139,
       "summary": "selberg_density_corrected: for l≥4, I(l) contains a qualifying prime. Still needs Brun-Titchmarsh for general proof.",
       "mathContext": "Verified for l=4 (p=101). General l≥5 requires Selberg sieve (not in Mathlib)."
     },
     {
       "id": "main-theorem",
       "title": "Main Theorem: Infinitely Many Qualifying Primes",
-      "startLine": 148,
-      "endLine": 157,
+      "startLine": 140,
+      "endLine": 155,
       "summary": "infinitely_many_qualifying_primes: for any n, find qualifying prime p > n using l = n+4.",
       "mathContext": "Uses n < n+4 ≤ (n+4)! < p via selberg_density_corrected."
     }

--- a/src/data/proofs/erdos-14-unique-sums/meta.json
+++ b/src/data/proofs/erdos-14-unique-sums/meta.json
@@ -86,14 +86,14 @@
     {
       "id": "sec-repcount",
       "title": "Part I: Representation Counting",
-      "startLine": 43,
-      "endLine": 63,
+      "startLine": 40,
+      "endLine": 60,
       "summary": "Defines repCount (ways to write n as a+b with a≤b), uniqueSums, uniqueSums' (ExistsUnique formulation), sumset, nonUniqueSums."
     },
     {
       "id": "sec-counting-functions",
       "title": "Part II: Counting Functions",
-      "startLine": 65,
+      "startLine": 61,
       "endLine": 77,
       "summary": "Defines nonUniqueCount A N (the main U(N) function), multiRepCount (sums with ≥2 representations), missingCount (missing sums)."
     },

--- a/src/data/proofs/fourier-series/meta.json
+++ b/src/data/proofs/fourier-series/meta.json
@@ -196,7 +196,7 @@
     {
       "id": "uniform-convergence",
       "title": "Uniform Convergence",
-      "startLine": 361,
+      "startLine": 352,
       "endLine": 375,
       "summary": "Proves that if $\\sum|c_n| < \\infty$ (summable coefficients), the Fourier series converges uniformly via `hasSum_fourier_series_of_summable`.",
       "mathContext": "If $\\sum_{n \\in \\mathbb{Z}} |c_n| < \\infty$ (absolutely summable coefficients), then $f(x) = \\sum c_n e_n(x)$ converges uniformly. This requires smoothness: $f \\in C^1 \\Rightarrow c_n = O(1/|n|)$ (integration by parts), so $\\sum|c_n| < \\infty$ if $c_n = O(1/|n|^{1+\\epsilon})$."
@@ -204,7 +204,7 @@
     {
       "id": "uniqueness-riemann-lebesgue",
       "title": "Uniqueness and Riemann-Lebesgue",
-      "startLine": 411,
+      "startLine": 394,
       "endLine": 450,
       "summary": "Proves uniqueness: same Fourier coefficients $\\Rightarrow$ same $L^2$ function (via `HasSum.unique`). States the Riemann-Lebesgue lemma: $c_n \\to 0$ as $|n| \\to \\infty$ (axiomatized).",
       "mathContext": "Uniqueness: $c_n(f) = c_n(g)\\ \\forall n \\Rightarrow f = g$ in $L^2$. Proof: both have the same Fourier series, which converges to both in $L^2$, so $f = g$ by `HasSum.unique`. Riemann-Lebesgue (axiom): $c_n(f) \\to 0$ as $|n| \\to \\infty$ for all $f \\in L^2$. The classical proof uses density of $C^1$ functions."

--- a/src/data/proofs/godel-first-incompleteness-oq01-oq-04/meta.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01-oq-04/meta.json
@@ -79,7 +79,7 @@
       "id": "infrastructure",
       "title": "Basic Formula Infrastructure",
       "startLine": 47,
-      "endLine": 62,
+      "endLine": 64,
       "description": "Defines Formula, neg, godelNum, and Prov — the same simplified model as OQ-01.",
       "summary": "Formula structure with code:Nat, negation, Gödel numbering, and provability formula constructor."
     },
@@ -111,17 +111,25 @@
       "id": "main-theorems",
       "title": "Incompleteness Theorems",
       "startLine": 158,
-      "endLine": 208,
+      "endLine": 198,
       "description": "G_not_provable, neg_G_not_provable, first_incompleteness, and G_undecidable.",
       "summary": "The full incompleteness theorem suite, now derived from the cleaner 5-axiom basis."
     },
     {
       "id": "generality",
       "title": "Generality of the Diagonal Lemma",
-      "startLine": 211,
-      "endLine": 228,
+      "startLine": 199,
+      "endLine": 218,
       "description": "Additional fixed-point instances showing the Diagonal Lemma applies beyond just ¬Prov.",
       "summary": "prov_fixed_point_exists and consistency_sentence_exists as other Diagonal Lemma instances."
+    },
+    {
+      "id": "forward-self-reference",
+      "title": "Forward Direction of Self-Reference",
+      "startLine": 219,
+      "endLine": 234,
+      "description": "G_self_reference_fwd: the forward half of OQ-01’s biconditional axiom, derived rather than assumed.",
+      "summary": "Derives (⊢ G) → ¬(⊢ Prov(⌈G⌉)) — the only direction needed for incompleteness — replacing OQ-01’s full self-reference axiom."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Re-anchors gallery `meta.json` sections so every named Lean declaration falls inside exactly one section. Found via the uncovered-decl scan (the decisive "covered by ANY section" test against fresh `origin/main`). All changes are pure section-anchor edits (line numbers) plus one added section — **no prose, status, badge, or axiom counts touched**.

| Entry | Fix |
|-------|-----|
| **erdos-1059-oq-02-oq-01** | Full re-anchor of Parts I–V to their `/-! ## Part N` banners (Part IV was mis-anchored to `[138-140]`, missing the whole corrected-axiom block). Covers `p7_fails`, `p101_prime`, `infinitely_many_qualifying_primes`. |
| **erdos-14-unique-sums** | Part I `[43-63]→[40-60]` (covers `repCount`); Part II start `65→61` (`nonUniqueCount` was split across the Part II banner — decl on the docstring side, section starting inside the body). |
| **fourier-series** | Uniform Convergence start `361→352` (`hasSum_fourier_uniform`); Uniqueness start `411→394` (`fourier_coeffs_determine_function`, inside `section Corollaries`). |
| **godel-first-incompleteness-oq01-oq-04** | Infra end `62→64` (`neg`); main-theorems end `208→198` + generality start `211→199` (pulls `prov_fixed_point_exists`/`arb_fixed_point_exists` under the Part 7 banner); **adds** a Part 8 section for `G_self_reference_fwd`. |

**Verification:** all four `meta.json` parse; the uncovered-decl scan now reports **zero** stranded decls for each; no new section overlaps introduced (the pre-existing 1-line `end FourierSeries` overlap on line 450 is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
