### PR TITLE
audit: erdos-667 re-verify clean (CRITICAL inconsistency fix confirmed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15488,8 +15488,8 @@
     },
     "erdos-667": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:03Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T17:23:03Z",
       "result": "clean"
     },
     "erdos-668": {


### PR DESCRIPTION
Reserve-mode re-audit. Uncontested. Prior CRITICAL integrity issue #40015 (inconsistent axiom set, False derivable at p=2) fixed by merged PR #40018.

## Result: CLEAN — fix verified

**Original defect**: `cpq_at_max (2≤p)` and `cpq_upper_ramsey (2≤p)` both fired at p=2, where `choose(p-1,2)+1 = choose(1,2)+1 = 1`, forcing `1 = cpq 2 1 ≤ 2/3` → kernel False.

**Fix (#40018)**: both `cpq_lower_ramsey` and `cpq_upper_ramsey` now require `3 ≤ p`.

**Verified precise & complete**:
- For p≥3, lower bound `1/(p-1) ≤ 2/(p+1)` upper bound holds (equality at p=3); at p=2, lower=1 > upper=2/3 — so p≥3 is exactly the cutoff that makes the two ramsey axioms mutually consistent.
- `cpq_at_max` asserts about q=`choose(p-1,2)+1`, which equals 1 only when p≤2; the ramsey/efrs axioms (q=1) now require p≥3 — ranges no longer overlap.
- p=3: axioms pin `cpq 3 1 = 1/2` and `cpq 3 2 = 1` — disjoint, consistent.

Counts all match meta: 4 axioms / 36 theorems (32 `theorem` + 4 `lemma`) / 6 defs / 0 sorry / 0 native_decide. (lineCount 517 vs actual 523 — stale undercount, harmless.) status `axiomatized`/badge `axiom` correct; 4 axioms are real published results (Ramsey bounds, EFRS, max-density).

🤖 Generated with [Claude Code](https://claude.com/claude-code)