### PR TITLE
Enrich 4 proofs: re-anchor sections to cover stranded decls

### DIFF
--- a/src/data/proofs/conjugacy-class-equation-oq-01/meta.json
+++ b/src/data/proofs/conjugacy-class-equation-oq-01/meta.json
@@ -85,23 +85,23 @@
       "id": "header",
       "title": "Module Header and Setup",
       "startLine": 1,
-      "endLine": 38,
+      "endLine": 36,
       "summary": "Module docstring stating the per-class class equation and listing the Mathlib vehicles. Mathlib import, open MulAction Subgroup ConjAct, namespace, and the variable {G : Type*} [Group G].",
       "mathContext": "$|\\mathrm{class}(g)|\\cdot|C_G(g)| = |G|$, so $|\\mathrm{class}(g)| \\mid |G|$."
     },
     {
       "id": "orbit-stabilizer",
       "title": "Orbit–Stabilizer for Conjugation",
-      "startLine": 40,
-      "endLine": 56,
+      "startLine": 37,
+      "endLine": 54,
       "summary": "conjClass_card_mul_card_centralizer: identify the class with the conjugation orbit, rewrite its size as the stabilizer index (index_stabilizer), identify the stabilizer with the centralizer (stabilizer_eq_centralizer), and apply index_mul_card transported along ConjAct.toConjAct.",
       "mathContext": "$|\\mathrm{class}(g)|\\cdot|C_G(g)| = |G|$."
     },
     {
       "id": "index-form",
       "title": "Class Size = Index of the Centralizer",
-      "startLine": 58,
-      "endLine": 66,
+      "startLine": 55,
+      "endLine": 64,
       "summary": "conjClass_card_eq_index_centralizer: |class(g)| = [G : C_G(g)], proved by rewriting through stabilizer_eq_centralizer, orbit_eq_carrier_conjClasses, and index_stabilizer.",
       "mathContext": "$|\\mathrm{class}(g)| = [G : C_G(g)]$."
     },
@@ -109,7 +109,7 @@
       "id": "divisibility",
       "title": "Per-Class Divisibility",
       "startLine": 65,
-      "endLine": 69,
+      "endLine": 70,
       "summary": "conjClass_card_dvd_card: |class(g)| ∣ |G| as an immediate corollary of the product identity, the divisibility witness being the centralizer order as explicit cofactor. This is the per-class form Mathlib leaves implicit and the engine behind the p-group-center and Sylow corollaries.",
       "mathContext": "$|\\mathrm{class}(g)| \\mid |G|$, with cofactor $|C_G(g)|$."
     },
@@ -117,7 +117,7 @@
       "id": "s3-example",
       "title": "Concrete Instance: S₃",
       "startLine": 71,
-      "endLine": 79,
+      "endLine": 81,
       "summary": "The closing example specializes to S₃ = Equiv.Perm (Fin 3) (order 3! = 6 by kernel decide), showing every conjugacy class size divides 6 — the three classes have sizes 1, 2, 3.",
       "mathContext": "$|S_3| = 6$; class sizes $1, 2, 3$ each divide $6$."
     }

--- a/src/data/proofs/erdos-1003-oq-04/meta.json
+++ b/src/data/proofs/erdos-1003-oq-04/meta.json
@@ -90,7 +90,7 @@
       "title": "Definitions — the #1003 set, the run-length family, and the OQ-04 target",
       "summary": "ConsecutiveEqualTotients = {n | φ(n)=φ(n+1)} (A001274), ConsecutiveKEqualTotients k = {n | ∀ i ≤ k, φ n = φ(n+i)} (the run-length hierarchy), FourConsecutiveEqualTotients (the OQ-04 target), and oq04_infinitude_conjecture (the open Infinite statement). They mirror the parent #1003 entry verbatim.",
       "startLine": 64,
-      "endLine": 85,
+      "endLine": 86,
       "mathContext": "$\\text{CKE}\\,k = \\{n \\mid \\forall i \\le k,\\ \\varphi(n)=\\varphi(n+i)\\}$; the OQ-04 target is the $k=3$ slice."
     },
     {
@@ -98,7 +98,7 @@
       "title": "§1 The Run Reduction — a run is a block of consecutive #1003 solutions",
       "summary": "mem_cke_iff_run telescopes CKE k membership to the vanishing of all k adjacent differences (induction on run length). mem_cke_iff_consecutive_cet reads this as: n, …, n+k-1 all lie in A001274. fcet_eq_cke_three and mem_fcet_iff_three_consecutive specialize k = 3: a four-run at n is exactly n, n+1, n+2 being three consecutive members of A001274.",
       "startLine": 87,
-      "endLine": 148,
+      "endLine": 149,
       "mathContext": "$n \\in \\text{CKE}\\,k \\iff \\forall i<k,\\ \\varphi(n+i)=\\varphi(n+i+1)$; four-run at $n \\iff n,n+1,n+2 \\in$ A001274."
     },
     {

--- a/src/data/proofs/erdos-1181/meta.json
+++ b/src/data/proofs/erdos-1181/meta.json
@@ -103,7 +103,7 @@
       "id": "core-definitions",
       "title": "Part I: Core Definitions",
       "startLine": 31,
-      "endLine": 55,
+      "endLine": 58,
       "summary": "Defines consecutiveProduct and proves positivity. Shared infrastructure with Problem #457.",
       "mathContext": "Defines ∏_{i=1}^k (n+i) using Finset.Icc and proves consecutiveProduct_pos."
     },
@@ -159,7 +159,7 @@
       "id": "summary",
       "title": "Part VIII: Summary",
       "startLine": 264,
-      "endLine": 290,
+      "endLine": 293,
       "summary": "erdos_1181_main theorem. The (1+o(1)) vs (1-c) gap is the central open question.",
       "mathContext": "The gap between the trivial (1+o(1)) and conjectured (1-c) represents genuine content about prime distribution."
     }

--- a/src/data/proofs/erdos-357/meta.json
+++ b/src/data/proofs/erdos-357/meta.json
@@ -102,7 +102,7 @@
       "id": "function-f",
       "title": "The Function f(n)",
       "startLine": 41,
-      "endLine": 51,
+      "endLine": 52,
       "summary": "Defines f(n) = sSup{k | ∃ a : Fin k → ℤ, range a ⊆ [1,n], StrictMono a, HasDistinctSums a}. Noncomputable via sSup.",
       "mathContext": "f(n) is the maximum k for strictly increasing integer sequences in [1,n] with all consecutive sums distinct."
     },
@@ -110,7 +110,7 @@
       "id": "variants-g-h",
       "title": "Variants g(n) and h(n)",
       "startLine": 53,
-      "endLine": 69,
+      "endLine": 70,
       "summary": "g(n): unrestricted sequences (no monotonicity), elements in ℕ. h(n): weakly increasing sequences (Monotone), elements in ℤ. Both defined via sSup.",
       "mathContext": "f(n) ≤ h(n) ≤ g(n) since each relaxes monotonicity constraints. g(n) = Θ(n) vs conjectured f(n) = o(n)."
     },


### PR DESCRIPTION
## Enrichment: re-anchor sections to cover stranded declarations

The uncovered-decl scan (decisive "covered by ANY section" test against fresh `origin/main`) flagged four gallery entries with named declarations stranded outside every section. All pure anchor fixes — section summaries already describe the now-covered decls, so no prose changed.

| Entry | Fix |
|-------|-----|
| **conjugacy-class-equation-oq-01** | Full re-anchor of all 5 sections to docstring boundaries `[1-36][37-54][55-64][65-70][71-81]` — covers `conjClass_card_mul_card_centralizer@39` and `conjClass_card_eq_index_centralizer@57`, and closes a pre-existing `[58-66]`/`[65-69]` overlap |
| **erdos-357** | End-drift: "The Function f(n)" `51→52` (`def f`); "Variants g(n) and h(n)" `69→70` (`def h`) |
| **erdos-1003-oq-04** | End-drift: "Definitions" `85→86` (`FourConsecutiveEqualTotients`); "§1 The Run Reduction" `148→149` (`mem_fcet_iff_three_consecutive`) |
| **erdos-1181** | "Part I: Core Definitions" `55→58` (core `def q`); "Part VIII: Summary" `290→293` (`erdos_1181_main`) |

**Verified:** all four parse as JSON, the scan reports **zero** stranded decls per file, and no new section overlaps. Diff is a clean 4-file, +13/−13 (anchor-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
