### PR TITLE
audit(erdos-648): clean re-verify

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15316,8 +15316,8 @@
     },
     "erdos-648": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:03Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T17:32:48Z",
       "result": "clean"
     },
     "erdos-649": {


### PR DESCRIPTION
## Audit: erdos-648 (Decreasing Greatest Prime Factors)

Reserve-mode re-verification (queue drained, 0 unaudited). No regression since prior clean audit.

**Verified against `proofs/Proofs/Erdos648Problem.lean` (373 lines):**
- axiomCount 3 ✓ — `cambie_lower_bound`, `cambie_upper_bound`, `cambie_asymptotic_conjecture`
- sorries 0 ✓
- theoremCount 41 ✓
- definitionCount 9 ✓
- native_decide ×11 — disclosed in `assumptions` with ofReduceBool caveat; main Θ-result `erdos_648` depends only on the two Cambie axioms ✓
- status `axiomatized` / badge `axiom` — honest Tier C axiomatization ✓

Tracker-only change (marks erdos-648 audited/clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)