### PR TITLE
Fix erdos-658: relabel vacuous density_hales_jewett placeholder honestly

### DIFF
--- a/proofs/Proofs/Erdos658Problem.lean
+++ b/proofs/Proofs/Erdos658Problem.lean
@@ -169,16 +169,16 @@ from 1 to k, or are fixed.
 def CombLine (n k : ℕ) : Type := Unit  -- Placeholder for the complex definition
 
 /--
-**Density Hales-Jewett Theorem (Furstenberg-Katznelson 1991):**
-For any δ > 0 and k, there exists n = n(δ, k) such that
-every δ-dense subset of [k]ⁿ contains a combinatorial line.
-
-This is one of the deepest results in additive combinatorics.
+**Vacuous placeholder for the Density Hales-Jewett Theorem
+(Furstenberg-Katznelson 1991).** The genuine theorem (dense subsets of [k]ⁿ
+contain a combinatorial line) is deep, but the axiom below is NOT it: its
+conclusion is `True`, so it is trivially provable and asserts nothing. It is a
+stub, not load-bearing (`erdos_658` uses `graham_axis_aligned_true`, not this).
 -/
 axiom density_hales_jewett :
     ∀ δ : ℚ, δ > 0 → ∀ k : ℕ, k ≥ 2 →
       ∃ n₀ : ℕ, ∀ n ≥ n₀,
-        True  -- Simplified: dense sets in [k]ⁿ have combinatorial lines
+        True  -- Vacuous placeholder, NOT the real DHJ statement
 
 /- 
 **Reduction to Hales-Jewett:**

--- a/src/data/proofs/erdos-658/meta.json
+++ b/src/data/proofs/erdos-658/meta.json
@@ -50,13 +50,13 @@
       "density definition: |A|/N² ratio",
       "GrahamConjectureAxisAligned: formal statement of the conjecture",
       "graham_axis_aligned_true axiom: the main result",
-      "density_hales_jewett axiom: the underlying deep theorem (Furstenberg-Katznelson 1991)",
+      "density_hales_jewett axiom: vacuous True-bodied placeholder gesturing at the Furstenberg-Katznelson 1991 theorem (asserts nothing mathematical; not load-bearing)",
       "erdos_658 theorem: main result",
       "erdos_658_answer theorem: final answer"
     ],
     "axiomCount": 2,
     "lineCount": 285,
-    "assumptions": "2 axioms: graham_axis_aligned_true (main result), density_hales_jewett (Furstenberg-Katznelson 1991). 0 sorries.",
+    "assumptions": "2 axioms: graham_axis_aligned_true (main result, axiomatizes the genuinely-solved GrahamConjectureAxisAligned); density_hales_jewett (vacuous True-bodied placeholder gesturing at Furstenberg-Katznelson 1991, not load-bearing). 0 sorries.",
     "theoremCount": 6,
     "definitionCount": 8
   },
@@ -64,7 +64,7 @@
     "historicalContext": "**Erdős Problem #658: Squares in Dense Grid Subsets**\n\nThis problem, attributed to Graham, asks a natural geometric question: if you have enough points in an N×N grid, must some four of them form the vertices of a square?\n\n**Key History:**\n- Graham: Posed the problem for axis-aligned squares\n- Erdős [Er97e]: Included in his list of favorite unsolved problems (ambiguous about axis-alignment)\n- Furstenberg-Katznelson (1991): Proved qualitatively via the density Hales-Jewett theorem\n- Solymosi (2004): Gave the first quantitative proof with explicit bounds\n\n**Mathematical Setting:**\nThe problem connects discrete geometry with additive combinatorics. The proof uses the density Hales-Jewett theorem, one of the deepest results in the field, showing that dense sets in high-dimensional spaces must contain combinatorial structures.",
     "problemStatement": "**Problem Statement (Proved)**\n\nLet $\\delta > 0$ and $N$ be sufficiently large depending on $\\delta$. Is it true that if $A \\subseteq \\{1,\\ldots,N\\}^2$ has $|A| \\geq \\delta N^2$ then $A$ must contain the vertices of a square?\n\n**Answer: YES**\n\nFurstenberg and Katznelson (1991) proved this follows from the density Hales-Jewett theorem. Solymosi (2004) gave explicit (but very large, tower-type) bounds on N₀(δ).",
     "text": "Do dense subsets of the N×N grid contain squares? YES, proved via density Hales-Jewett (Furstenberg-Katznelson 1991), with quantitative bounds by Solymosi (2004).",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Grid and Squares:** Define the N×N grid and what it means for four points to form a square\n\n2. **Density:** Define δ-dense subsets where |A| ≥ δN²\n\n3. **Main Conjecture:** State GrahamConjectureAxisAligned formally\n\n4. **Key Axioms:**\n   - graham_axis_aligned_true: The main theorem\n   - density_hales_jewett: The underlying deep result (Furstenberg-Katznelson 1991)\n\n5. **Connections:** Link to Hales-Jewett and higher-dimensional generalizations",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Grid and Squares:** Define the N×N grid and what it means for four points to form a square\n\n2. **Density:** Define δ-dense subsets where |A| ≥ δN²\n\n3. **Main Conjecture:** State GrahamConjectureAxisAligned formally\n\n4. **Key Axioms:**\n   - graham_axis_aligned_true: The main theorem\n   - density_hales_jewett: A vacuous True-bodied placeholder gesturing at the Furstenberg-Katznelson 1991 result (not load-bearing; the genuine combinatorial-line statement is left as future work)\n\n5. **Connections:** Link to Hales-Jewett and higher-dimensional generalizations",
     "keyInsights": [
       "**Density Forces Structure:** Sufficiently dense sets in grids must contain geometric patterns like squares",
       "**Hales-Jewett Connection:** The proof reduces to the density Hales-Jewett theorem, a cornerstone of additive combinatorics",
@@ -109,7 +109,7 @@
       "summary": "CombLine placeholder def, density_hales_jewett axiom",
       "startLine": 169,
       "endLine": 201,
-      "mathContext": "Axiomatized: density_hales_jewett axiom (Furstenberg-Katznelson 1991). CombLine is a placeholder definition; the reduction to Hales-Jewett is discussed in comments only, not formalized."
+      "mathContext": "density_hales_jewett is a vacuous True-bodied placeholder axiom gesturing at the Furstenberg-Katznelson 1991 theorem — it asserts nothing mathematical and is not load-bearing. CombLine is a placeholder definition; the reduction to Hales-Jewett is discussed in comments only, not formalized."
     },
     {
       "id": "solymosi-bounds",


### PR DESCRIPTION
## Problem

Issue #40724 (LOW): in `erdos-658`, the axiom `density_hales_jewett` has a
vacuous `True` body — the proposition is trivially provable (`n₀ = 0`) and
asserts nothing mathematical — yet it was presented as "**the underlying deep
theorem** (Furstenberg-Katznelson 1991)" in meta `originalContributions`,
`assumptions`, and `proofStrategy`, and its Lean docstring called it "one of the
deepest results in additive combinatorics." It is also not load-bearing:
`erdos_658` proves `GrahamConjectureAxisAligned` via `graham_axis_aligned_true`,
not this axiom.

## Fix (option b: honest relabel)

Prose-only relabel across the Lean docstring and `meta.json`, describing
`density_hales_jewett` accurately as a vacuous `True`-bodied placeholder that
gestures at the Furstenberg-Katznelson theorem but is not it and is not
load-bearing.

**Before** (Lean docstring): "Density Hales-Jewett Theorem … This is one of the
deepest results in additive combinatorics."
**After**: "Vacuous placeholder for the Density Hales-Jewett Theorem … the axiom
below is NOT it: its conclusion is `True`, so it is trivially provable and
asserts nothing … not load-bearing."

meta.json: `originalContributions`, `assumptions`, `proofStrategy`, and the
Density-Hales-Jewett section `mathContext` updated to match.

## Notes

- `axiomCount: 2` **unchanged** — the auditor confirmed it correct; both axioms
  remain disclosed. `status: axiomatized` / badge `axiom` unchanged.
- Net-zero line change in the Lean file (6+/6−), so no gallery
  annotation-anchor drift; `meta.json` validated as JSON.

Closes #40724
