### PR TITLE
Enrich erdos-419: rewrite stale sections to match the actual Lean file

### DIFF
--- a/src/data/proofs/erdos-419/meta.json
+++ b/src/data/proofs/erdos-419/meta.json
@@ -168,68 +168,60 @@
   ],
   "sections": [
     {
-      "id": "imports",
-      "title": "Imports and Namespace",
-      "summary": "Imports Mathlib's `NumberTheory.Divisors`, `ArithmeticFunction`, `Nat.Factorial.Basic`, `Padics.PadicVal`, and `SpecificLimits.Basic`. Opens `Nat` and `ArithmeticFunction` namespaces.",
-      "startLine": 22,
-      "endLine": 30,
-      "mathContext": "Mathematical content: Imports Mathlib's `NumberTheory.Divisors`, `ArithmeticFunction`, `Nat.Factorial.Basic`, `Padics.PadicVal`, and `SpecificLimits.Basic`. Opens `Nat` and `ArithmeticFunction` namespaces."
+      "id": "header",
+      "title": "Problem Statement and Imports",
+      "summary": "Module docstring stating Erdős #419 (limit points of τ((n+1)!)/τ(n!)) and its answer {1} ∪ {1 + 1/k : k ≥ 1} = {1, 2, 3/2, 4/3, ...}, with background on the prime-factorization heuristic. Imports Mathlib's `NumberTheory.Divisors`, `Nat.Factorial.Basic`, and `SpecificLimits.Basic`; opens `Nat` and `ArithmeticFunction`.",
+      "startLine": 1,
+      "endLine": 29,
+      "mathContext": "Determine the set of limit points of $\\tau((n+1)!)/\\tau(n!)$, where $\\tau$ is the divisor-counting function. Answer (solved): $\\{1\\} \\cup \\{1 + 1/k : k \\ge 1\\}$."
     },
     {
-      "id": "definitions",
-      "title": "Basic Definitions",
-      "summary": "Defines $\\tau(n) = |\\{d : d \\mid n\\}|$ via `n.divisors.card`, axiomatizes the multiplicative formula $\\tau(n) = \\prod_{p \\mid n} (v_p(n) + 1)$, and defines the factorial divisor ratio $\\tau((n+1)!)/\\tau(n!) \\in \\mathbb{Q}$.",
-      "startLine": 37,
-      "endLine": 48,
-      "mathContext": "Defines $\\tau(n) = |\\{d : d \\mid n\\}|$ via `n.divisors.card`, axiomatizes the multiplicative formula $\\tau(n) = \\prod_{p \\mid n} (v_p(n) + 1)$, and defines the factorial divisor ratio $\\tau((n+1)!)/\\tau(n!) \\in \\mathbb{Q}$."
+      "id": "basic-definitions",
+      "title": "Part 1 — Basic Definitions",
+      "summary": "Defines $\\tau(n) = |\\{d : d \\mid n\\}|$ via `n.divisors.card` (a plain definition, not an axiom) and `factorialDivisorRatio n` $= \\tau((n+1)!)/\\tau(n!) \\in \\mathbb{Q}$, guarded to equal 1 on the degenerate factorial-zero case.",
+      "startLine": 31,
+      "endLine": 43,
+      "mathContext": "$\\tau(n) = |\\{d : d \\mid n\\}|$ and the studied ratio $\\tau((n+1)!)/\\tau(n!)$, formalized as a rational-valued function of $n$."
     },
     {
       "id": "ratio-formula",
-      "title": "The Ratio Formula",
-      "summary": "Defines `padicValFactorial` via Legendre's formula $v_p(n!) = \\sum_{i \\ge 1} \\lfloor n/p^i \\rfloor$, axiomatizes the identity with `padicValNat`, and states the key product formula: $\\tau((n+1)!)/\\tau(n!) = \\prod_{p \\mid n+1} (1 + v_p(n+1)/(v_p(n!)+1))$.",
-      "startLine": 56,
-      "endLine": 71,
-      "mathContext": "Defines `padicValFactorial` via Legendre's formula $v_p(n!) = \\sum_{i \\ge 1} \\lfloor n/p^i \\rfloor$, axiomatizes the identity with `padicValNat`, and states the key product formula: $\\tau((n+1)!)/\\tau(n!) = \\prod_{p \\mid n+1} (1 + v_p(n+1)/(v_p(n!)+1))$."
+      "title": "Part 2 — The Ratio Formula",
+      "summary": "Defines `padicValFactorial p n` $= \\sum_{i < n} \\lfloor n/p^{i+1} \\rfloor$, the Legendre-formula expression for $v_p(n!)$, which is the engine relating the divisor ratio to the prime factorization of $n+1$.",
+      "startLine": 45,
+      "endLine": 52,
+      "mathContext": "Legendre's formula $v_p(n!) = \\sum_{i \\ge 1} \\lfloor n/p^i \\rfloor$, giving $\\tau((n+1)!)/\\tau(n!) = \\prod_{p \\mid n+1} \\bigl(1 + v_p(n+1)/(v_p(n!)+1)\\bigr)$."
     },
     {
-      "id": "prime-bounds",
-      "title": "Prime Factorization Bounds",
-      "summary": "Axiomatizes three bounds: $\\omega(n) < \\log_2 n$, $v_p(n) < \\log_2 n$, and at most one prime $p \\mid n+1$ with $p > n^{2/3}$. These control the product structure of the ratio.",
-      "startLine": 79,
-      "endLine": 88,
-      "mathContext": "Formal definition: Axiomatizes three bounds: $\\omega(n) < \\log_2 n$, $v_p(n) < \\log_2 n$, and at most one prime $p \\mid n+1$ with $p > n^{2/3}$. These control the product structure of the ratio."
-    },
-    {
-      "id": "small-primes",
-      "title": "Small Primes Contribution",
-      "summary": "Shows the product over primes $p \\le n^{2/3}$ satisfies $1 \\le S \\le 1 + (\\log n)^2/n^{1/3} \\to 1$. Each factor is $1 + O(\\log n / n^{1/3})$ by Legendre's bound $v_p(n!) \\ge n/p \\ge n^{1/3}$.",
-      "startLine": 96,
-      "endLine": 108,
-      "mathContext": "Shows the product over primes $p \\le n^{2/3}$ satisfies $1 \\le S \\le 1 + (\\$\\log n$)^2/n^{1/3} \\to 1$. Each factor is $1 + $O(\\$\\log n$ / n^{1/3})$$ by Legendre's bound $v_p(n!) \\ge n/p \\ge n^{1/3}$."
-    },
-    {
-      "id": "large-primes",
-      "title": "Large Prime Contribution",
-      "summary": "If $p > n^{2/3}$ divides $n+1$, then $v_p(n+1) = 1$ (since $p^2 > n+1$) and $v_p(n!) = k-1$ where $n+1 = pk$. The factor is $(k+1)/k = 1 + 1/k$. When $n+1$ is prime ($k=1$), the ratio $\\approx 2$.",
-      "startLine": 116,
-      "endLine": 122,
-      "mathContext": "If $p > n^{2/3}$ divides $n+1$, then $v_p(n+1) = 1$ (since $p^2 > n+1$) and $v_p(n!) = k-1$ where $n+1 = pk$. The factor is $(k+1)/k = 1 + 1/k$. When $n+1$ is prime ($k=1$), the ratio $\\approx 2$."
+      "id": "proof-strategy",
+      "title": "Parts 3–5 — Proof Strategy: Small/Large Prime Dichotomy",
+      "summary": "Expository banners (no Lean declarations) outlining the argument: bound the prime factors of n+1, then split into small primes p ≤ n^(2/3) — whose huge factorial valuations make their contribution → 1 — and at most one large prime p > n^(2/3), which contributes the factor 1 + 1/k when n+1 = pk.",
+      "startLine": 54,
+      "endLine": 67,
+      "mathContext": "Small primes ($p \\le n^{2/3}$): $v_p(n!) \\ge n/p \\ge n^{1/3}$ so each factor is $1 + O(\\log n / n^{1/3}) \\to 1$. Large prime ($p > n^{2/3}$, at most one): $n+1 = pk \\Rightarrow$ factor $(k+1)/k = 1 + 1/k$."
     },
     {
       "id": "limit-points",
-      "title": "The Set of Limit Points",
-      "summary": "Defines $L = \\{1\\} \\cup \\{1 + 1/k : k \\ge 1\\}$ and axiomatizes: $1 \\in L$ (smooth numbers), $1+1/k \\in L$ (Dirichlet's theorem ensures infinitely many $n+1 = pk$), and $L$ contains all limit points.",
-      "startLine": 130,
-      "endLine": 150,
-      "mathContext": "Formal definition: Defines $L = \\{1\\} \\cup \\{1 + 1/k : k \\ge 1\\}$ and axiomatizes: $1 \\in L$ (smooth numbers), $1+1/k \\in L$ (Dirichlet's theorem ensures infinitely many $n+1 = pk$), and $L$ contains all limit points."
+      "title": "Part 6 — The Set of Limit Points",
+      "summary": "Defines `limitPointSet` $L = \\{1\\} \\cup \\{1 + 1/k : k \\ge 1\\}$ with `example` computations (1+1/1=2, 1+1/2=3/2, ...), then states the three axioms capturing the solved result: `one_is_limit_point` (1 is a limit point, via smooth n+1), `one_plus_reciprocal_is_limit_point` (each 1+1/k is a limit point, via Dirichlet's theorem), and `only_these_limit_points` (no other rational limit points).",
+      "startLine": 69,
+      "endLine": 95,
+      "mathContext": "$L = \\{1\\} \\cup \\{1 + 1/k : k \\ge 1\\}$. The three axioms assert existence of the two families of limit points and completeness (no others), which is the content proved by Erdős–Graham–Ivić–Pomerance (1996)."
     },
     {
-      "id": "examples",
-      "title": "Examples and Concrete Cases",
-      "summary": "Four cases: $n+1$ prime $\\Rightarrow$ ratio $\\approx 2$; $n+1 = 2p \\Rightarrow \\approx 3/2$; $n+1 = 3p \\Rightarrow \\approx 4/3$; $n+1$ smooth $\\Rightarrow \\approx 1$. Verified: $1+1/1=2$, $1+1/2=3/2$, $1+1/3=4/3$, $1+1/4=5/4$.",
-      "startLine": 158,
-      "endLine": 165,
-      "mathContext": "Four cases: $n+1$ prime $\\Rightarrow$ ratio $\\approx 2$; $n+1 = 2p \\Rightarrow \\approx 3/2$; $n+1 = 3p \\Rightarrow \\approx 4/3$; $n+1$ smooth $\\Rightarrow \\approx 1$. Verified: $1+1/1=2$, $1+1/2=3/2$, $1+1/3=4/3$, $1+1/4=5/4$."
+      "id": "main-theorem",
+      "title": "Parts 7–8 — Characterization Theorem",
+      "summary": "`sawhney_characterization`: a proved iff theorem stating that x is a limit point of the ratio ⟺ x ∈ L. The forward direction is `only_these_limit_points`; the reverse dispatches the two cases (x = 1 and x = 1 + 1/k) to the corresponding existence axioms.",
+      "startLine": 97,
+      "endLine": 122,
+      "mathContext": "$\\forall x \\in \\mathbb{Q}$: $\\bigl(\\forall \\varepsilon>0,\\ |\\text{ratio}(n) - x| < \\varepsilon\\ \\text{frequently}\\bigr) \\iff x \\in L$."
+    },
+    {
+      "id": "summary",
+      "title": "Parts 9–10 — Summary and Solution",
+      "summary": "`limit_set_properties` proves L contains 1, contains every 1+1/k, and has all elements ≥ 1 (so 1 is the unique accumulation point). `erdos_419_summary` packages the full solution: the iff characterization together with existence of both limit-point families.",
+      "startLine": 124,
+      "endLine": 162,
+      "mathContext": "$L$ is a countable closed set with unique accumulation point 1 (homeomorphic to $\\omega + 1$). `erdos_419_summary` conjoins `sawhney_characterization`, `one_is_limit_point`, and `one_plus_reciprocal_is_limit_point`."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

The `erdos-419` `sections[]` array described an **older, longer version** of `Proofs/Erdos419Problem.lean`. Several summaries claimed axioms/lemmas that **do not exist** in the current 162-line file, and the anchors had drifted so five declarations fell outside every section.

### Stale/false content removed

| Section | Claimed | Reality |
|---------|---------|---------|
| `definitions` | "axiomatizes the multiplicative formula τ(n)=∏(v_p+1)" | `tau`/`factorialDivisorRatio` are plain `def`s; no such axiom |
| `ratio-formula` | "axiomatizes the identity with padicValNat" | `padicValFactorial` is a `def`; no axiom; also mis-anchored [56-71] away from L51 |
| `prime-bounds` | "Axiomatizes three bounds ω(n)<log₂n, v_p(n)<log₂n…" | **No such axioms exist**; range [79-88] actually held `example`s + `one_is_limit_point` |
| `small-primes` / `large-primes` | proved-lemma summaries | No such decls; ranges were banner comments / proof body |
| `limit-points` | "Defines L and axiomatizes…" at [130-150] | `limitPointSet` is at L75, axioms at L85-93; [130-150] held `limit_set_properties` |
| `examples` | "Four cases…" at [158-165] | The `example` blocks are at L79-82; [158-165] held `erdos_419_summary` (over-running EOF=162) |

Uncovered declarations: `padicValFactorial` (L51), `limitPointSet` (L75), `one_plus_reciprocal_is_limit_point` (L89), `only_these_limit_points` (L93), `erdos_419_summary` (L155).

### New sections (aligned to the file's Part 1–10 banners)

`header` [1-29] · Part 1 `basic-definitions` [31-43] · Part 2 `ratio-formula` [45-52] · Parts 3–5 `proof-strategy` [54-67] (now correctly described as **expository banners with no Lean decls**, not axiomatized lemmas) · Part 6 `limit-points` [69-95] (`limitPointSet` + `example`s + the 3 real axioms) · Parts 7–8 `main-theorem` [97-122] (`sawhney_characterization`) · Parts 9–10 `summary` [124-162] (`limit_set_properties`, `erdos_419_summary`).

Every declaration is now covered and every summary reflects the actual file. `axiomCount` was already correctly 3; no `status`/`badge`/`axiomCount` change. JSON validated; scan confirms zero uncovered declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
