### PR TITLE
Enrich 5 proofs: re-anchor sections to cover stranded main theorems

### DIFF
--- a/src/data/proofs/erdos-1156/meta.json
+++ b/src/data/proofs/erdos-1156/meta.json
@@ -111,9 +111,9 @@
     {
       "id": "q2-placeholder",
       "title": "Question 2: Anti-Concentration (Placeholder)",
-      "summary": "Trivially proved placeholder for the anti-concentration question",
+      "summary": "Declares `erdos_1156_q2_conjecture`, an explicit honesty placeholder for the anti-concentration question: its conclusion is `∀ n, True`, so the statement is trivially inhabited (`fun _ _ => ⟨fun _ => 0, fun _ => trivial⟩`) and carries no mathematical content. A faithful formalization would use MeasureTheory to express $\\Pr[|\\chi(G) - f(n)| < \\omega(n)] < 1/2$; the docstring records this gap rather than overclaiming a proof.",
       "startLine": 116,
-      "endLine": 124,
+      "endLine": 130,
       "mathContext": "erdos_1156_q2_conjecture theorem (body is True, proved trivially)"
     }
   ],

--- a/src/data/proofs/erdos-1206/meta.json
+++ b/src/data/proofs/erdos-1206/meta.json
@@ -72,7 +72,7 @@
       "id": "main-result",
       "title": "Part II: Deriving the Solution to Erdős #1206",
       "startLine": 79,
-      "endLine": 102,
+      "endLine": 112,
       "summary": "PROVES `sidon_in_cubes` and `erdos_1206` (0 sorries) from the axiom: the cube set $\\{1^3,\\dots,N^3\\}$ (`cubeSet N`) contains Sidon subsets of size $\\geq c\\sqrt N$ for all large $N$. The derivation extracts the window from `gabdullin_konyagin_2024`, embeds it via `nearTopCubes ⊆ cubeSet`, and bounds its cardinality with `Finset.card_image_le`; the small-$N$ case uses the empty set.",
       "mathContext": "$\\exists c>0:\\ \\forall^\\infty N,\\ \\exists S\\subseteq\\text{cubeSet}(N),\\ \\text{IsSidon}(S)\\wedge |S|\\geq c\\sqrt N$. `erdos_1206` is definitionally `sidon_in_cubes`, restating it as the resolution of the problem."
     }

--- a/src/data/proofs/erdos-397/meta.json
+++ b/src/data/proofs/erdos-397/meta.json
@@ -102,8 +102,8 @@
       "id": "examples",
       "title": "Verified Examples",
       "startLine": 87,
-      "endLine": 119,
-      "summary": "Compute concrete values of central binomials and Somani's parameter."
+      "endLine": 124,
+      "summary": "Compute concrete values of the central binomial coefficients and Somani's parameter by `native_decide`, e.g. `C_three : C 3 = 20` (the central binomial $\\binom{6}{3}$) and `somaniC_two : somaniC 2 = 49` ($8\\cdot 4 + 8\\cdot 2 + 1$). These anchor the abstract Somani family in checkable arithmetic."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-588/meta.json
+++ b/src/data/proofs/erdos-588/meta.json
@@ -131,7 +131,14 @@
       "title": "Part III: The $k \\ge 4$ Case (Open)",
       "summary": "Documents the open k ≥ 4 case via docstring remarks only. The Solymosi-Stojaković lower bound $n^{2-c/\\sqrt{\\log n}}$ and Erdős's $o(n^2)$ conjecture are described in comments; no axioms or theorems are declared in this range.",
       "startLine": 62,
-      "endLine": 79
+      "endLine": 72
+    },
+    {
+      "id": "main-theorem",
+      "title": "Part IV: Main Theorem",
+      "summary": "States and proves `erdos_588`, the packaged resolution of the formalized content: there is a constant $C>0$ with $|f_3(n) - n^2/6| \\le C\\,n$ for all $n \\ge 3$. The proof is `sylvester_k3` — i.e. the machine-checked claim is exactly the resolved $k=3$ case, while the $k \\ge 4$ conjecture (the $\\$100$ prize) remains open and appears only in the docstring. This honestly scopes what the Lean file proves versus what Erdős asked.",
+      "startLine": 73,
+      "endLine": 88
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-895-counterexample-fin18/meta.json
+++ b/src/data/proofs/erdos-895-counterexample-fin18/meta.json
@@ -104,7 +104,7 @@
       "id": "no-triple-and-package",
       "title": "No Distinct Independent Additive Triple, and the Packaged Witness",
       "startLine": 100,
-      "endLine": 111,
+      "endLine": 122,
       "summary": "ce895_no_distinct_independent_additive_triple proves by `decide` that G895 has no independent additive triple among three DISTINCT vertices a, b, a+b, and counterexample_fin18 bundles this with triangle-freeness into the existential sharp-threshold witness ∃ G, IsTriangleFree G ∧ ¬∃ a b c, …",
       "mathContext": "$\\neg\\exists a,b,c$ distinct with $a{+}b{=}c$ pairwise non-adjacent; combined with triangle-freeness gives $\\exists G$, the corrected counterexample."
     }


### PR DESCRIPTION
## Section re-anchor pass: cover stranded main theorems

A coverage scan (each declaration tested against every `sections` range)
found five gallery entries whose **main/summary theorem** had drifted past
the last section's `endLine` — so it rendered in no section of the gallery
sectioned view. Each fix extends (or splits) the trailing section to cover
the theorem; summaries already named it, or are deepened here.

| Entry | Change | Now-covered decl |
|---|---|---|
| `erdos-1206` | main-result `79-102` → `79-112` | `erdos_1206` |
| `erdos-895-counterexample-fin18` | `100-111` → `100-122` | `counterexample_fin18` + `#print axioms` |
| `erdos-1156` | q2-placeholder `116-124` → `116-130`; deeper summary | `erdos_1156_q2_conjecture` (True-typed honesty placeholder) |
| `erdos-397` | examples `87-119` → `87-124`; summary names values | `somaniC_two` |
| `erdos-588` | split k4-open `62-79` → `62-72` (was swallowing the Part IV banner) + new main-theorem `73-88` | `erdos_588` |

Pure coverage/summary fixes — no Lean source, `status`, `badge`, or
`axiomCount` changes. Verified: all five re-parse as JSON and no longer
report stranded declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
