### PR TITLE
audit(erdos-652): clean re-verify (#40030 fix landed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15355,8 +15355,8 @@
     },
     "erdos-652": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:04Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T17:37:16Z",
       "result": "clean"
     },
     "erdos-653": {


### PR DESCRIPTION
Reserve-mode re-verify. Prior MEDIUM issue #40030 (phantom origContributions) is fixed and landed — all 8 bullets now map to real declarations, no refs past EOF. axiomCount 2 / sorries 0 / theoremCount 3 / defCount 7 verified against `Proofs/Erdos652Problem.lean` (171 lines). Axioms consistent; honest Tier C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)