### PR TITLE
audit(erdos-65): badge mathlib->infrastructure (sole theorem is trivial 1/k>0)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15331,9 +15331,9 @@
     },
     "erdos-65": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:04Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T17:39:58Z",
+      "result": "issues-fixed"
     },
     "erdos-65-oq-03": {
       "auditCount": 3,

--- a/src/data/proofs/erdos-65/meta.json
+++ b/src/data/proofs/erdos-65/meta.json
@@ -15,14 +15,14 @@
       "extremal-combinatorics",
       "cycles"
     ],
-    "badge": "mathlib",
+    "badge": "infrastructure",
     "sorries": 0,
     "erdosNumber": 65,
     "erdosUrl": "https://erdosproblems.com/65",
     "erdosProblemStatus": "partially-solved",
     "axiomCount": 0,
     "lineCount": 217,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "None (0 axioms, 0 sorries). Infrastructure formalization only: definitions for cycle-length sets, edge density, and the open minimization question (Erdos65Question), plus one trivial positivity lemma (odd_cycle_positive_contribution: 1/k > 0). The core GKS logarithmic lower bound is background context, not formalized.",
     "mathlib_version": "4.31.0",
     "theoremCount": 1,
     "definitionCount": 9


### PR DESCRIPTION
## Audit: erdos-65 (Cycle Lengths in Dense Graphs) — MEDIUM

The file's **only theorem** `odd_cycle_positive_contribution` proves the triviality `(1:ℝ)/k > 0` for `k ≥ 3` (via `positivity`), with an *unused* `Odd k` hypothesis. The actual Erdős #65 content — the GKS logarithmic reciprocal-sum bound and the bipartite minimization question — is **not formalized**: only comments, definitions, and the open-question `def Erdos65Question`.

Badge was `mathlib` (Tier B = "core argument relies on a Mathlib theorem"), but there is **no core theorem** here — this is Tier D infrastructure.

**Fixes:**
- `badge`: `mathlib` → `infrastructure`
- `assumptions`: reworded from "Fully verified with 0 axioms and 0 sorries" to state the GKS bound is background context, not formalized.

status `verified` kept (valid convention for infrastructure files that compile clean — cf. puiseux/brouwer/angle-trisection). Prose (`proofStrategy`, `conclusion`) was already honest and attributes GKS/Liu-Montgomery to original authors. axiomCount 0 / sorries 0 / theoremCount 1 / defCount 9 verified against source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)