### PR TITLE
Research: erdos-1039-oq-05 — general lower bound dₙ ≥ n^{1/(n-1)} via n-th roots of unity (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
+++ b/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
@@ -861,4 +861,203 @@ theorem transfiniteDiameterN_four_mem_Icc :
   rw [transfiniteDiameterN_two] at h32
   linarith
 
+/-! ### The general lower bound `dₙ ≥ n^{1/(n-1)}`: the `n`-th roots of unity
+
+The `n = m+2` complex `n`-th roots of unity `ζᵏ` (`ζ = exp(2πi/n)`, a primitive
+`n`-th root) all lie on the unit circle, so they form a configuration in the closed
+unit disc.  Their spread product is the **Vandermonde discriminant** `n^{n/2}`:
+
+* For each fixed index `i`, the product over `j ≠ i` telescopes — after the
+  translation `j ↦ j - i` on `Fin n` and factoring out the unit `ζⁱ` — to
+  `∏_{k=1}^{n-1}‖1 - ζᵏ‖ = |∏_{k=1}^{n-1}(1 - ζᵏ)| = |n| = n`, using the classical
+  identity `∏_{k=1}^{n-1}(1 - ζᵏ) = n` (`IsPrimitiveRoot.prod_one_sub_pow_eq_order`).
+* Multiplying `∏_{j≠i} = n` over the `n` values of `i` gives the *ordered*
+  off-diagonal product `n^n`, which equals `(spreadProduct)²` because the lower and
+  upper triangles `{j < i}` and `{i < j}` carry equal products (`‖zᵢ-zⱼ‖ = ‖zⱼ-zᵢ‖`).
+
+Hence `spreadProduct = n^{n/2}` and
+`dₙ(roots of unity) = (n^{n/2})^{2/(n(n-1))} = n^{1/(n-1)}`, giving the sharp lower
+bound `dₙ ≥ n^{1/(n-1)}`.  Passing to the limit, every term of `d = infₙ dₙ` is `≥ 1`
+(`n^{1/(n-1)} ≥ 1`), so `d ≥ 1` — the logarithmic capacity of the closed unit disc.
+This generalises the exact terms `d₂ = 2`, `d₃ ≥ √3`, `d₄ ≥ 4^{1/3}` above.  The
+matching Fekete–Szegő *upper* bound (`d = 1` exactly) is not established here. -/
+
+/-- The `n`-point **roots-of-unity configuration** `k ↦ ζᵏ` for a primitive root `ζ`. -/
+noncomputable def rootConfig (ζ : ℂ) (N : ℕ) : Fin N → ℂ := fun k => ζ ^ (k : ℕ)
+
+section RootsOfUnity
+
+open Complex
+
+variable {m : ℕ} {ζ : ℂ}
+
+/-- Every power of a primitive `(m+2)`-th root of unity has modulus `1`. -/
+private theorem rou_norm (hζ : IsPrimitiveRoot ζ (m + 2)) (k : ℕ) : ‖ζ ^ k‖ = 1 := by
+  rw [norm_pow, Complex.norm_eq_one_of_pow_eq_one hζ.pow_eq_one (by omega), one_pow]
+
+/-- Powers of `ζ` (order `m+2`) only depend on the exponent modulo `m+2`. -/
+private theorem rou_mod (hζ : IsPrimitiveRoot ζ (m + 2)) (a : ℕ) :
+    ζ ^ (a % (m + 2)) = ζ ^ a := by
+  conv_rhs => rw [← Nat.div_add_mod a (m + 2)]
+  rw [pow_add, pow_mul, hζ.pow_eq_one, one_pow, one_mul]
+
+/-- **Core discriminant value.**  `∏_{d ≠ 0} ‖1 - ζᵈ‖ = m + 2` over `Fin (m+2)`,
+the modulus of the classical identity `∏_{k=1}^{n-1}(1 - ζᵏ) = n`. -/
+private theorem prod_erase_zero (hζ : IsPrimitiveRoot ζ (m + 2)) :
+    ∏ d ∈ (Finset.univ : Finset (Fin (m + 2))).erase 0, ‖1 - ζ ^ (d : ℕ)‖ = ((m : ℝ) + 2) := by
+  have hreindex : ∏ d ∈ (Finset.univ : Finset (Fin (m + 2))).erase 0, ‖1 - ζ ^ (d : ℕ)‖
+      = ∏ k ∈ Finset.range (m + 1), ‖1 - ζ ^ (k + 1)‖ := by
+    apply Finset.prod_nbij' (fun d => (d : ℕ) - 1) (fun k => ((k + 1 : ℕ) : Fin (m + 2)))
+    · intro d _
+      simp only [Finset.mem_range]
+      have := d.isLt; omega
+    · intro k hk
+      simp only [Finset.mem_range] at hk
+      simp only [Finset.mem_erase, Finset.mem_univ, and_true]
+      intro hcontra
+      have hv : ((k + 1 : ℕ) : Fin (m + 2)).val = k + 1 := by
+        rw [Fin.val_natCast]; exact Nat.mod_eq_of_lt (by omega)
+      rw [hcontra, Fin.val_zero] at hv; omega
+    · intro d hd
+      simp only [Finset.mem_erase, Finset.mem_univ, and_true] at hd
+      have hpos : 1 ≤ (d : ℕ) := by
+        rcases Nat.eq_zero_or_pos (d : ℕ) with h | h
+        · exact absurd (Fin.val_eq_zero_iff.mp h) hd
+        · exact h
+      rw [Nat.sub_add_cancel hpos, Fin.cast_val_eq_self]
+    · intro k hk
+      simp only [Finset.mem_range] at hk
+      rw [Fin.val_natCast, Nat.mod_eq_of_lt (by omega)]
+    · intro d hd
+      simp only [Finset.mem_erase, Finset.mem_univ, and_true] at hd
+      have hpos : 1 ≤ (d : ℕ) := by
+        rcases Nat.eq_zero_or_pos (d : ℕ) with h | h
+        · exact absurd (Fin.val_eq_zero_iff.mp h) hd
+        · exact h
+      rw [Nat.sub_add_cancel hpos]
+  rw [hreindex, ← norm_prod, hζ.prod_one_sub_pow_eq_order]
+  rw [show ((m + 1 : ℕ) : ℂ) + 1 = ((m + 2 : ℕ) : ℂ) by push_cast; ring, Complex.norm_natCast]
+  push_cast; ring
+
+/-- **Per-index spread.**  For each index `i`, `∏_{j ≠ i} ‖ζⁱ - ζʲ‖ = m + 2`:
+after translating `j ↦ j - i` and pulling out the unit `ζⁱ`, this is `prod_erase_zero`. -/
+private theorem prod_erase_root (hζ : IsPrimitiveRoot ζ (m + 2)) (i : Fin (m + 2)) :
+    ∏ j ∈ (Finset.univ : Finset (Fin (m + 2))).erase i, ‖ζ ^ (i : ℕ) - ζ ^ (j : ℕ)‖
+      = ((m : ℝ) + 2) := by
+  have hfactor : ∀ j ∈ (Finset.univ : Finset (Fin (m + 2))).erase i,
+      ‖ζ ^ (i : ℕ) - ζ ^ (j : ℕ)‖ = ‖1 - ζ ^ ((j - i : Fin (m + 2)) : ℕ)‖ := by
+    intro j _
+    have key : ζ ^ (i : ℕ) * ζ ^ ((j - i : Fin (m + 2)) : ℕ) = ζ ^ (j : ℕ) := by
+      rw [← pow_add, ← rou_mod hζ ((i : ℕ) + ((j - i : Fin (m + 2)) : ℕ))]
+      congr 1
+      rw [← Fin.val_add]
+      congr 1
+      abel
+    have harg : ζ ^ (i : ℕ) - ζ ^ (j : ℕ)
+        = ζ ^ (i : ℕ) * (1 - ζ ^ ((j - i : Fin (m + 2)) : ℕ)) := by
+      rw [mul_sub, mul_one, key]
+    rw [harg, norm_mul, rou_norm hζ, one_mul]
+  -- translation reindex `Fin (m+2) → Fin (m+2)`, `j ↦ j - i`, sends `erase i` to `erase 0`
+  have T : Fin (m + 2) ≃ Fin (m + 2) :=
+    ⟨fun j => j - i, fun d => d + i, fun j => by abel, fun d => by abel⟩
+  rw [Finset.prod_congr rfl hfactor,
+    Finset.prod_equiv T
+      (fun a => by
+        simp only [Finset.mem_erase, Finset.mem_univ, and_true, T, Equiv.coe_fn_mk, sub_ne_zero])
+      (fun a _ => rfl),
+    prod_erase_zero hζ]
+
+/-- **Vandermonde discriminant of the roots of unity.**  `(spreadProduct)² = n^n`
+for the `n = m+2` roots-of-unity configuration. -/
+private theorem spreadProduct_rootConfig_sq (hζ : IsPrimitiveRoot ζ (m + 2)) :
+    (spreadProduct (rootConfig ζ (m + 2))) ^ 2 = ((m : ℝ) + 2) ^ (m + 2) := by
+  have hsplit : ∀ i : Fin (m + 2),
+      (Finset.univ : Finset (Fin (m + 2))).erase i = Finset.Iio i ∪ Finset.Ioi i := by
+    intro i; ext a
+    simp only [Finset.mem_erase, Finset.mem_univ, and_true, Finset.mem_union, Finset.mem_Iio,
+      Finset.mem_Ioi]
+    exact lt_or_lt_iff_ne.symm
+  have hdisj : ∀ i : Fin (m + 2), Disjoint (Finset.Iio i) (Finset.Ioi i) := by
+    intro i; rw [Finset.disjoint_left]; intro a ha ha'
+    exact absurd (Finset.mem_Iio.mp ha) (not_lt.mpr (le_of_lt (Finset.mem_Ioi.mp ha')))
+  -- lower triangle equals the spread product (via `norm_sub_rev` and Fubini)
+  have hlow : (∏ i, ∏ j ∈ Finset.Iio i, ‖rootConfig ζ (m + 2) i - rootConfig ζ (m + 2) j‖)
+      = spreadProduct (rootConfig ζ (m + 2)) := by
+    rw [Finset.prod_comm' (s := (Finset.univ : Finset (Fin (m + 2)))) (t := fun i => Finset.Iio i)
+      (t' := (Finset.univ : Finset (Fin (m + 2)))) (s' := fun j => Finset.Ioi j)
+      (fun x y => by
+        simp only [Finset.mem_univ, Finset.mem_Iio, Finset.mem_Ioi, true_and, and_true])]
+    unfold spreadProduct
+    exact Finset.prod_congr rfl fun i _ => Finset.prod_congr rfl fun j _ => norm_sub_rev _ _
+  -- the ordered off-diagonal product is the square of the spread product …
+  have hsq : (∏ i, ∏ j ∈ (Finset.univ : Finset (Fin (m + 2))).erase i,
+      ‖rootConfig ζ (m + 2) i - rootConfig ζ (m + 2) j‖)
+      = (spreadProduct (rootConfig ζ (m + 2))) ^ 2 := by
+    have herase : ∀ i : Fin (m + 2),
+        (∏ j ∈ (Finset.univ : Finset (Fin (m + 2))).erase i,
+          ‖rootConfig ζ (m + 2) i - rootConfig ζ (m + 2) j‖)
+        = (∏ j ∈ Finset.Iio i, ‖rootConfig ζ (m + 2) i - rootConfig ζ (m + 2) j‖)
+          * (∏ j ∈ Finset.Ioi i, ‖rootConfig ζ (m + 2) i - rootConfig ζ (m + 2) j‖) := by
+      intro i; rw [hsplit i, Finset.prod_union (hdisj i)]
+    rw [Finset.prod_congr rfl (fun i _ => herase i), Finset.prod_mul_distrib, hlow, sq]
+  -- … and it is also `n^n`, since each factor is `n`.
+  have hval : (∏ i, ∏ j ∈ (Finset.univ : Finset (Fin (m + 2))).erase i,
+      ‖rootConfig ζ (m + 2) i - rootConfig ζ (m + 2) j‖) = ((m : ℝ) + 2) ^ (m + 2) := by
+    rw [Finset.prod_congr rfl (fun i _ => prod_erase_root hζ i), Finset.prod_const,
+      Finset.card_univ, Fintype.card_fin]
+  rw [← hsq, hval]
+
+/-- **The `n`-point diameter of the roots of unity is `n^{1/(n-1)}`.** -/
+private theorem discreteDiameter_rootConfig (hζ : IsPrimitiveRoot ζ (m + 2)) :
+    discreteDiameter (rootConfig ζ (m + 2)) = ((m : ℝ) + 2) ^ ((1 : ℝ) / ((m : ℝ) + 1)) := by
+  have hSsq : (spreadProduct (rootConfig ζ (m + 2))) ^ 2 = ((m : ℝ) + 2) ^ (m + 2) :=
+    spreadProduct_rootConfig_sq hζ
+  have hSnn : 0 ≤ spreadProduct (rootConfig ζ (m + 2)) := spreadProduct_nonneg _
+  have hbase : (0 : ℝ) < (m : ℝ) + 2 := by positivity
+  have h1 : (m : ℝ) + 2 ≠ 0 := by positivity
+  have h2 : (m : ℝ) + 1 ≠ 0 := by positivity
+  unfold discreteDiameter
+  set e : ℝ := 2 / (((m + 2 : ℕ) : ℝ) * (((m + 2 : ℕ) : ℝ) - 1)) with he
+  rw [show e = 2 * (e / 2) by ring, Real.rpow_mul hSnn,
+    show (2 : ℝ) = ((2 : ℕ) : ℝ) by norm_num, Real.rpow_natCast, hSsq,
+    ← Real.rpow_natCast ((m : ℝ) + 2) (m + 2), ← Real.rpow_mul (le_of_lt hbase)]
+  congr 1
+  rw [he]; push_cast; field_simp; ring
+
+/-- **The general lower bound `dₙ ≥ n^{1/(n-1)}`** for the closed unit disc, realised
+by the `n = m+2` roots of unity.  Generalises `d₂ = 2`, `d₃ ≥ √3`, `d₄ ≥ 4^{1/3}`. -/
+theorem transfiniteDiameterN_rootsOfUnity_ge (m : ℕ) :
+    ((m : ℝ) + 2) ^ ((1 : ℝ) / ((m : ℝ) + 1)) ≤ transfiniteDiameterN (m + 2) := by
+  have hζ : IsPrimitiveRoot (Complex.exp (2 * ↑Real.pi * Complex.I / ↑(m + 2))) (m + 2) :=
+    Complex.isPrimitiveRoot_exp (m + 2) (by omega)
+  set ζ := Complex.exp (2 * ↑Real.pi * Complex.I / ↑(m + 2)) with hζdef
+  have hmem : ∀ i, ‖rootConfig ζ (m + 2) i‖ ≤ 1 := fun i => by
+    simp only [rootConfig]; exact le_of_eq (rou_norm hζ (i : ℕ))
+  have hin : ((m : ℝ) + 2) ^ ((1 : ℝ) / ((m : ℝ) + 1)) ∈ unitDiscDiameters (m + 2) :=
+    ⟨rootConfig ζ (m + 2), hmem, discreteDiameter_rootConfig hζ⟩
+  exact le_csSup (unitDiscDiameters_bddAbove (by omega)) hin
+
+/-- **The transfinite diameter of the closed unit disc is `≥ 1`.**  Each term of the
+monotone sequence satisfies `d_{n+2} ≥ (n+2)^{1/(n+1)} ≥ 1`, so its infimum — the
+transfinite diameter — is at least `1`.  Combined with `transfiniteDiameter_mem_Icc`
+(`d ≤ 2`), this pins `d ∈ [1, 2]`; the sharp value `d = 1` (logarithmic capacity) is
+the Fekete–Szegő content and is not established here. -/
+theorem one_le_transfiniteDiameter : (1 : ℝ) ≤ transfiniteDiameter := by
+  rw [transfiniteDiameter]
+  refine le_ciInf (fun n => ?_)
+  have hcast : (0 : ℝ) ≤ (n : ℝ) := Nat.cast_nonneg n
+  have h1 : (1 : ℝ) ≤ ((n : ℝ) + 2) ^ ((1 : ℝ) / ((n : ℝ) + 1)) := by
+    calc (1 : ℝ) = (1 : ℝ) ^ ((1 : ℝ) / ((n : ℝ) + 1)) := (Real.one_rpow _).symm
+      _ ≤ ((n : ℝ) + 2) ^ ((1 : ℝ) / ((n : ℝ) + 1)) :=
+        Real.rpow_le_rpow (by norm_num) (by linarith) (by positivity)
+  exact le_trans h1 (transfiniteDiameterN_rootsOfUnity_ge n)
+
+/-- **The transfinite diameter of the closed unit disc lies in `[1, 2]`.**  Lower bound
+from `one_le_transfiniteDiameter` (roots of unity); upper bound from
+`transfiniteDiameter_mem_Icc`.  The exact value `d = 1` needs the Fekete–Szegő theorem. -/
+theorem transfiniteDiameter_mem_Icc_one_two : transfiniteDiameter ∈ Set.Icc (1 : ℝ) 2 :=
+  ⟨one_le_transfiniteDiameter, transfiniteDiameter_mem_Icc.2⟩
+
+end RootsOfUnity
+
 end Erdos1039TransfiniteDiameter

--- a/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
+++ b/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
@@ -905,29 +905,35 @@ private theorem rou_mod (hζ : IsPrimitiveRoot ζ (m + 2)) (a : ℕ) :
 the modulus of the classical identity `∏_{k=1}^{n-1}(1 - ζᵏ) = n`. -/
 private theorem prod_erase_zero (hζ : IsPrimitiveRoot ζ (m + 2)) :
     ∏ d ∈ (Finset.univ : Finset (Fin (m + 2))).erase 0, ‖1 - ζ ^ (d : ℕ)‖ = ((m : ℝ) + 2) := by
+  haveI : NeZero (m + 2) := ⟨by omega⟩
   have hreindex : ∏ d ∈ (Finset.univ : Finset (Fin (m + 2))).erase 0, ‖1 - ζ ^ (d : ℕ)‖
       = ∏ k ∈ Finset.range (m + 1), ‖1 - ζ ^ (k + 1)‖ := by
-    apply Finset.prod_nbij' (fun d => (d : ℕ) - 1) (fun k => ((k + 1 : ℕ) : Fin (m + 2)))
+    apply Finset.prod_nbij' (fun d : Fin (m + 2) => (d : ℕ) - 1)
+      (fun k : ℕ => (⟨(k + 1) % (m + 2), Nat.mod_lt _ (by omega)⟩ : Fin (m + 2)))
     · intro d _
       simp only [Finset.mem_range]
       have := d.isLt; omega
     · intro k hk
       simp only [Finset.mem_range] at hk
       simp only [Finset.mem_erase, Finset.mem_univ, and_true]
-      intro hcontra
-      have hv : ((k + 1 : ℕ) : Fin (m + 2)).val = k + 1 := by
-        rw [Fin.val_natCast]; exact Nat.mod_eq_of_lt (by omega)
-      rw [hcontra, Fin.val_zero] at hv; omega
+      apply Fin.ne_of_val_ne
+      show (k + 1) % (m + 2) ≠ (0 : Fin (m + 2)).val
+      rw [Fin.val_zero, Nat.mod_eq_of_lt (show k + 1 < m + 2 by omega)]
+      omega
     · intro d hd
       simp only [Finset.mem_erase, Finset.mem_univ, and_true] at hd
       have hpos : 1 ≤ (d : ℕ) := by
         rcases Nat.eq_zero_or_pos (d : ℕ) with h | h
         · exact absurd (Fin.val_eq_zero_iff.mp h) hd
         · exact h
-      rw [Nat.sub_add_cancel hpos, Fin.cast_val_eq_self]
+      apply Fin.ext
+      show ((d : ℕ) - 1 + 1) % (m + 2) = (d : ℕ)
+      rw [Nat.sub_add_cancel hpos, Nat.mod_eq_of_lt d.isLt]
     · intro k hk
       simp only [Finset.mem_range] at hk
-      rw [Fin.val_natCast, Nat.mod_eq_of_lt (by omega)]
+      show (k + 1) % (m + 2) - 1 = k
+      rw [Nat.mod_eq_of_lt (show k + 1 < m + 2 by omega)]
+      omega
     · intro d hd
       simp only [Finset.mem_erase, Finset.mem_univ, and_true] at hd
       have hpos : 1 ≤ (d : ℕ) := by
@@ -942,8 +948,9 @@ private theorem prod_erase_zero (hζ : IsPrimitiveRoot ζ (m + 2)) :
 /-- **Per-index spread.**  For each index `i`, `∏_{j ≠ i} ‖ζⁱ - ζʲ‖ = m + 2`:
 after translating `j ↦ j - i` and pulling out the unit `ζⁱ`, this is `prod_erase_zero`. -/
 private theorem prod_erase_root (hζ : IsPrimitiveRoot ζ (m + 2)) (i : Fin (m + 2)) :
-    ∏ j ∈ (Finset.univ : Finset (Fin (m + 2))).erase i, ‖ζ ^ (i : ℕ) - ζ ^ (j : ℕ)‖
-      = ((m : ℝ) + 2) := by
+    ∏ j ∈ (Finset.univ : Finset (Fin (m + 2))).erase i,
+      ‖rootConfig ζ (m + 2) i - rootConfig ζ (m + 2) j‖ = ((m : ℝ) + 2) := by
+  simp only [rootConfig]
   have hfactor : ∀ j ∈ (Finset.univ : Finset (Fin (m + 2))).erase i,
       ‖ζ ^ (i : ℕ) - ζ ^ (j : ℕ)‖ = ‖1 - ζ ^ ((j - i : Fin (m + 2)) : ℕ)‖ := by
     intro j _
@@ -958,13 +965,16 @@ private theorem prod_erase_root (hζ : IsPrimitiveRoot ζ (m + 2)) (i : Fin (m +
       rw [mul_sub, mul_one, key]
     rw [harg, norm_mul, rou_norm hζ, one_mul]
   -- translation reindex `Fin (m+2) → Fin (m+2)`, `j ↦ j - i`, sends `erase i` to `erase 0`
-  have T : Fin (m + 2) ≃ Fin (m + 2) :=
-    ⟨fun j => j - i, fun d => d + i, fun j => by abel, fun d => by abel⟩
   rw [Finset.prod_congr rfl hfactor,
-    Finset.prod_equiv T
-      (fun a => by
-        simp only [Finset.mem_erase, Finset.mem_univ, and_true, T, Equiv.coe_fn_mk, sub_ne_zero])
-      (fun a _ => rfl),
+    show (∏ j ∈ (Finset.univ : Finset (Fin (m + 2))).erase i,
+          ‖1 - ζ ^ ((j - i : Fin (m + 2)) : ℕ)‖)
+        = ∏ d ∈ (Finset.univ : Finset (Fin (m + 2))).erase 0, ‖1 - ζ ^ (d : ℕ)‖ from
+      Finset.prod_equiv
+        (⟨fun j => j - i, fun d => d + i, fun j => by simp, fun d => by simp⟩ :
+          Fin (m + 2) ≃ Fin (m + 2))
+        (fun a => by
+          simp only [Finset.mem_erase, Finset.mem_univ, and_true, Equiv.coe_fn_mk, sub_ne_zero])
+        (fun a _ => by simp only [Equiv.coe_fn_mk]),
     prod_erase_zero hζ]
 
 /-- **Vandermonde discriminant of the roots of unity.**  `(spreadProduct)² = n^n`
@@ -999,7 +1009,10 @@ private theorem spreadProduct_rootConfig_sq (hζ : IsPrimitiveRoot ζ (m + 2)) :
         = (∏ j ∈ Finset.Iio i, ‖rootConfig ζ (m + 2) i - rootConfig ζ (m + 2) j‖)
           * (∏ j ∈ Finset.Ioi i, ‖rootConfig ζ (m + 2) i - rootConfig ζ (m + 2) j‖) := by
       intro i; rw [hsplit i, Finset.prod_union (hdisj i)]
-    rw [Finset.prod_congr rfl (fun i _ => herase i), Finset.prod_mul_distrib, hlow, sq]
+    have hup : (∏ i, ∏ j ∈ Finset.Ioi i,
+        ‖rootConfig ζ (m + 2) i - rootConfig ζ (m + 2) j‖)
+        = spreadProduct (rootConfig ζ (m + 2)) := rfl
+    rw [Finset.prod_congr rfl (fun i _ => herase i), Finset.prod_mul_distrib, hlow, hup, sq]
   -- … and it is also `n^n`, since each factor is `n`.
   have hval : (∏ i, ∏ j ∈ (Finset.univ : Finset (Fin (m + 2))).erase i,
       ‖rootConfig ζ (m + 2) i - rootConfig ζ (m + 2) j‖) = ((m : ℝ) + 2) ^ (m + 2) := by
@@ -1022,7 +1035,10 @@ private theorem discreteDiameter_rootConfig (hζ : IsPrimitiveRoot ζ (m + 2)) :
     show (2 : ℝ) = ((2 : ℕ) : ℝ) by norm_num, Real.rpow_natCast, hSsq,
     ← Real.rpow_natCast ((m : ℝ) + 2) (m + 2), ← Real.rpow_mul (le_of_lt hbase)]
   congr 1
-  rw [he]; push_cast; field_simp; ring
+  rw [he, show (((m + 2 : ℕ) : ℝ)) = (m : ℝ) + 2 by push_cast; ring,
+    show ((m : ℝ) + 2) - 1 = (m : ℝ) + 1 by ring]
+  field_simp
+  ring
 
 /-- **The general lower bound `dₙ ≥ n^{1/(n-1)}`** for the closed unit disc, realised
 by the `n = m+2` roots of unity.  Generalises `d₂ = 2`, `d₃ ≥ √3`, `d₄ ≥ 4^{1/3}`. -/

--- a/research/problems/erdos-1039-oq-05/knowledge.md
+++ b/research/problems/erdos-1039-oq-05/knowledge.md
@@ -258,3 +258,42 @@ matching lower bound `dₙ ≥ n^{1/(n-1)} → 1`. The current upper bound is th
 
 ### Files modified
 - `proofs/Proofs/Erdos1039TransfiniteDiameter.lean` (+~55 lines, limit section)
+
+## Session 2026-07-21 (researcher-1): general roots-of-unity lower bound dₙ ≥ n^{1/(n-1)}
+
+Proved the **general** lower bound the sharp-value program was building toward
+(docker-verified `Proofs.Erdos1039TransfiniteDiameter`, 0 axioms, 0 sorries):
+
+- **`transfiniteDiameterN_rootsOfUnity_ge (m) : (m+2)^{1/(m+1)} ≤ transfiniteDiameterN (m+2)`**
+  — realised by the `n = m+2` complex n-th roots of unity `ζᵏ` (ζ = exp(2πi/n)),
+  all on the unit circle. Generalises the bespoke `d₂ = 2`, `d₃ ≥ √3`, `d₄ ≥ 4^{1/3}`.
+- **`one_le_transfiniteDiameter : 1 ≤ transfiniteDiameter`** and
+  **`transfiniteDiameter_mem_Icc_one_two : transfiniteDiameter ∈ [1,2]`** —
+  each `d_{n+2} ≥ (n+2)^{1/(n+1)} ≥ 1`, so the infimum `d = infₙ dₙ ≥ 1`.
+
+### Mechanism (Vandermonde discriminant `spreadProduct = n^{n/2}`)
+- `spreadProduct_rootConfig_sq`: `(spreadProduct (rootConfig ζ (m+2)))² = n^n`.
+  - Per index `i`, `∏_{j≠i} ‖ζⁱ - ζʲ‖ = n` (`prod_erase_root`): translate `j ↦ j-i`
+    on `Fin n` (a `Finset.prod_equiv` group bijection) and pull out the unit `ζⁱ`,
+    reducing to `∏_{d≠0} ‖1 - ζᵈ‖ = |∏_{k=1}^{n-1}(1-ζᵏ)| = |n| = n` (`prod_erase_zero`
+    from `IsPrimitiveRoot.prod_one_sub_pow_eq_order`).
+  - Multiplying over the `n` indices gives the ORDERED off-diagonal product `n^n`,
+    which `= (spreadProduct)²` since lower/upper triangles `{j<i}`/`{i<j}` carry equal
+    products (`norm_sub_rev` + `Finset.prod_comm'`).
+- `discreteDiameter_rootConfig`: `dₙ = (n^{n/2})^{2/(n(n-1))} = n^{1/(n-1)}` (rpow algebra).
+
+### Gotchas (v4.31)
+- **`Fin n` has no global `NatCast`** (scoped with the CommRing instance), so
+  `((k+1 : ℕ) : Fin (m+2))` does NOT coerce — build the element explicitly as
+  `⟨(k+1) % (m+2), Nat.mod_lt _ …⟩` and reason on `.val` via `Fin.ext` / `Fin.ne_of_val_ne`.
+- `abel` failed to close `(j - i) + i = j` in `Fin (m+2)`; `by simp` (the `sub_add_cancel`
+  / `add_sub_cancel_right` simp set) closes it.
+- Annotate `Finset.prod_nbij'` lambda domains (`fun d : Fin (m+2) => …`, `fun k : ℕ => …`)
+  or `apply` mis-infers the index types.
+
+### Frontier (UNCHANGED)
+The sharp value `d = 1` (logarithmic capacity of the disc) needs the Fekete–Szegő
+extremal **upper** bound — DEEP. Parent Erdős #1039 remains OPEN.
+
+### Files modified
+- `proofs/Proofs/Erdos1039TransfiniteDiameter.lean` (+~215 lines, roots-of-unity section)

--- a/src/data/research/problems/erdos-1039-oq-05.json
+++ b/src/data/research/problems/erdos-1039-oq-05.json
@@ -48,7 +48,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: elementary sharp-value program now has THREE exact lower-bound terms d2=2, d3>=sqrt3, d4>=4^(1/3) (all 0-axiom), making the general pattern d_n>=n^(1/(n-1)) visible. Next: the general roots-of-unity lower bound (route fully scoped, ~200 lines) which yields d=lim_n d_n>=1. Remaining beyond: extremal upper bounds (Fekete-Szego). Parent Erdos #1039 OPEN.",
+    "progressSummary": "PROGRESS: the general roots-of-unity lower bound d_n >= n^(1/(n-1)) is now PROVED (0-axiom), the milestone the sharp-value program (d2=2, d3>=sqrt3, d4>=4^(1/3)) was building toward. It yields d = lim_n d_n >= 1, pinning the transfinite diameter of the closed unit disc into [1,2] (transfiniteDiameter_mem_Icc_one_two). Remaining: the sharp value d=1 (log capacity) needs the Fekete-Szego extremal UPPER bound (deep). Parent Erdos #1039 OPEN.",
     "builtItems": [
       "Erdos1039TransfiniteDiameter.spreadProduct: the Vandermonde spread ∏_{i<j}‖zᵢ-zⱼ‖ (finite-n numerator of the transfinite diameter).",
       "Erdos1039TransfiniteDiameter.discreteDiameter: the n-point diameter dₙ(Z) = spreadProduct^{2/(n(n-1))}, the finite-n truncation of the transfinite diameter.",
@@ -72,7 +72,12 @@
       "transfiniteDiameterN_three_mem_Icc : d₃ ∈ [√3, 2] (0-axiom)",
       "spreadProduct_three / discreteDiameter_three : 3-point diameter = geometric mean of the three pairwise gaps (exponent 2/(n(n-1))=1/3 at n=3)",
       "norm_mk_eq_sqrt : ‖x+yi‖ = √(x²+y²) helper",
-      "spreadProduct_four / discreteDiameter_four / transfiniteDiameterN_four_ge / transfiniteDiameterN_four_mem_Icc in Erdos1039TransfiniteDiameter.lean -- d4 in [4^(1/3), 2], 0-axiom (propext/Classical.choice/Quot.sound), Docker-verified."
+      "spreadProduct_four / discreteDiameter_four / transfiniteDiameterN_four_ge / transfiniteDiameterN_four_mem_Icc in Erdos1039TransfiniteDiameter.lean -- d4 in [4^(1/3), 2], 0-axiom (propext/Classical.choice/Quot.sound), Docker-verified.",
+      "rootConfig (zeta) (N) : Fin N -> C := k |-> zeta^k in Erdos1039TransfiniteDiameter.lean",
+      "prod_erase_zero / prod_erase_root: the discriminant core prod_{d!=0}||1-zeta^d|| = n and per-index prod_{j!=i}||zeta^i-zeta^j|| = n",
+      "spreadProduct_rootConfig_sq : (spreadProduct (rootConfig zeta (m+2)))^2 = (m+2)^(m+2) (Vandermonde discriminant)",
+      "discreteDiameter_rootConfig : discreteDiameter (rootConfig zeta (m+2)) = (m+2)^(1/(m+1))",
+      "transfiniteDiameterN_rootsOfUnity_ge, one_le_transfiniteDiameter, transfiniteDiameter_mem_Icc_one_two in Erdos1039TransfiniteDiameter.lean (all 0-axiom)"
     ],
     "insights": [
       "The finite discrete spread is entirely elementary and needs NO capacity infrastructure: it is a product of pairwise norms, equal to the modulus of the Vandermonde determinant, so it is host-verifiable Mathlib-only (no Docker).",
@@ -87,7 +92,10 @@
       "d₂ = transfiniteDiameterN 2 = 2 EXACTLY: the 2-point diameter reduces to the single gap ‖z₀-z₁‖ (exponent 2/(n(n-1))=1 at n=2), max over the closed disc is 2, attained by antipodal ![1,-1]. Only elementary exact stage; sharp d=1 needs Fekete–Szegő.",
       "Lean: collapse ∏ i:Fin 2, ∏ j∈Ioi i via Fin.prod_univ_two + (Finset.Ioi (0:Fin 2)={1}, Ioi (1:Fin 2)=∅) by decide; ![1,-1] value/membership goals by norm_num / fin_cases.",
       "Second exact term d₃ is sandwiched in [√3, 2]: lower bound √3 attained by the equilateral triangle of cube roots of unity {1, ω, ω²} (all three pairwise gaps = √3, so diameter ((√3)³)^{1/3} = √3); upper bound from Fekete monotonicity d₃ ≤ d₂ = 2. Exact d₃ = √3 needs the Fekete–Szegő extremal upper bound (no 3-point disc config beats the inscribed equilateral triangle), NOT yet done.",
-      "d4 = 4^(1/3): the square {1,i,-1,-i} of 4th roots of unity has four side gaps sqrt2 and two diagonal gaps 2, so spreadProduct = (sqrt2)^4 * 2^2 = 16 and discreteDiameter = 16^(1/6) = 4^(1/3). Confirms the pattern d_n >= n^(1/(n-1)) at the third term (d2=2^(1/1), d3=3^(1/2), d4=4^(1/3))."
+      "d4 = 4^(1/3): the square {1,i,-1,-i} of 4th roots of unity has four side gaps sqrt2 and two diagonal gaps 2, so spreadProduct = (sqrt2)^4 * 2^2 = 16 and discreteDiameter = 16^(1/6) = 4^(1/3). Confirms the pattern d_n >= n^(1/(n-1)) at the third term (d2=2^(1/1), d3=3^(1/2), d4=4^(1/3)).",
+      "GENERAL lower bound d_n >= n^(1/(n-1)) now PROVED (0-axiom) via the n-th roots of unity, generalising the exact terms d2=2, d3>=sqrt3, d4>=4^(1/3): transfiniteDiameterN_rootsOfUnity_ge (m) : (m+2)^(1/(m+1)) <= transfiniteDiameterN (m+2).",
+      "Consequence one_le_transfiniteDiameter : 1 <= transfiniteDiameter (each d_{n+2} >= (n+2)^(1/(n+1)) >= 1, so the infimum is >= 1); with d<=2 this pins d in [1,2] (transfiniteDiameter_mem_Icc_one_two). Sharp d=1 (log capacity of the disc) still needs Fekete-Szego upper bound.",
+      "Vandermonde-discriminant identity spreadProduct(roots of unity)^2 = n^n proved via: (a) per-index prod_{j!=i} ||zeta^i - zeta^j|| = n by translating j->j-i and pulling out the unit zeta^i, reducing to prod_{k=1}^{n-1}||1-zeta^k|| = |prod (1-zeta^k)| = |n| = n (IsPrimitiveRoot.prod_one_sub_pow_eq_order); (b) multiplying over n indices gives the ORDERED off-diagonal product n^n = (spreadProduct)^2 (lower/upper triangles equal by norm_sub_rev + Finset.prod_comm)."
     ],
     "mathlibGaps": [
       "Mathlib has no transfinite-diameter / logarithmic-capacity API; the n-point spread and its diameter had to be defined from scratch (done here). The limit d(Z)=limₙ dₙ and Fekete monotonicity are still absent.",


### PR DESCRIPTION
## Summary
Research session for `erdos-1039-oq-05` (transfinite diameter of the closed unit disc). Proves the **general roots-of-unity lower bound** `dₙ ≥ n^{1/(n-1)}` — the milestone the sharp-value program (`d₂ = 2`, `d₃ ≥ √3`, `d₄ ≥ 4^{1/3}`) was building toward.

## Progress (all 0-axiom, 0-sorry, docker-verified `Proofs.Erdos1039TransfiniteDiameter`)
- `transfiniteDiameterN_rootsOfUnity_ge (m) : (m+2)^{1/(m+1)} ≤ transfiniteDiameterN (m+2)` — realised by the `n = m+2` complex n-th roots of unity.
- `one_le_transfiniteDiameter : 1 ≤ transfiniteDiameter`.
- `transfiniteDiameter_mem_Icc_one_two : transfiniteDiameter ∈ [1, 2]`.

## Mechanism
`spreadProduct(n-th roots of unity)² = nⁿ` (Vandermonde discriminant):
- Per index `i`, `∏_{j≠i} ‖ζⁱ − ζʲ‖ = n` — translate `j ↦ j−i` on `Fin n` (a `Finset.prod_equiv` group bijection) and pull out the unit `ζⁱ`, reducing to `∏_{k=1}^{n−1} ‖1 − ζᵏ‖ = |∏(1−ζᵏ)| = |n| = n` (`IsPrimitiveRoot.prod_one_sub_pow_eq_order`).
- Multiplying over the `n` indices gives the ordered off-diagonal product `nⁿ = (spreadProduct)²` (lower/upper triangles equal by `norm_sub_rev` + `Finset.prod_comm'`).
- Hence `dₙ = (n^{n/2})^{2/(n(n−1))} = n^{1/(n−1)}`.

## Files modified
- `proofs/Proofs/Erdos1039TransfiniteDiameter.lean` (+~215 lines, roots-of-unity section)
- `src/data/research/problems/erdos-1039-oq-05.json`, `research/problems/erdos-1039-oq-05/knowledge.md`

## Status
**Outcome**: progress (major — general lower bound + `d ≥ 1` capacity consequence).
**Next Steps**: the sharp value `d = 1` (logarithmic capacity) needs the Fekete–Szegő extremal **upper** bound (DEEP). Parent Erdős #1039 remains OPEN.

🤖 Generated by researcher-1
