### PR TITLE
Enrich 5 proofs: extend trailing sections to cover stranded main theorems

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01/meta.json
@@ -173,7 +173,7 @@
       "id": "sec-corollaries",
       "title": "General Corollaries and Jacobi-Trudi",
       "startLine": 99,
-      "endLine": 130,
+      "endLine": 139,
       "summary": "nxn_lgv_corollary for strictly monotone source/target arrays (StrictMono replaces fin_cases wellFormed proof); jacobi_trudi_interpretation connecting to symmetric function theory.",
       "mathContext": "nxn_lgv_corollary: wellFormed := by intro i j hij; exact hs.lt hij uses StrictMono.lt directly. jacobi_trudi_interpretation: s_λ = det[h_{λᵢ-i+j}] via RSK correspondence and LGV."
     }

--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-02-oq-01/meta.json
@@ -128,7 +128,7 @@
       "id": "specializations",
       "title": "First- and Second-Order Specializations",
       "startLine": 135,
-      "endLine": 146,
+      "endLine": 154,
       "summary": "bernoulli_first_order (k = 1): 1 + n·a ≤ (1+a)ⁿ; bernoulli_second_order (k = 2): 1 + n·a + C(n,2)·a² ≤ (1+a)ⁿ — both one-line instances via Finset.sum_range_succ.",
       "mathContext": "$k=1$: $1 + na \\le (1+a)^n$; $k=2$: $1 + na + \\binom{n}{2}a^2 \\le (1+a)^n$."
     }

--- a/src/data/proofs/erdos-1002-oq-01/meta.json
+++ b/src/data/proofs/erdos-1002-oq-01/meta.json
@@ -87,7 +87,7 @@
       "title": "innerSum_periodic_rational: Assembling the Periodicity Proof",
       "summary": "Main public theorem: for rational α=p/q with q≥1, the inner sum satisfies S(p/q, n+q) = S(p/q, n) + S(p/q, q). Proof: unfold innerSum, apply Finset.sum_range_add (splitting Σ_{k<n+q} = Σ_{k<n} + Σ_{k<q} shifted by n), then cyclic_sum_periodic to show the shifted q-sum equals the unshifted q-sum.",
       "startLine": 129,
-      "endLine": 138,
+      "endLine": 148,
       "mathContext": "`Finset.sum_range_add` gives: Σ_{k<n+q} f(k) = Σ_{k<n} f(k) + Σ_{k<q} f(n+k). The remaining goal is Σ_{k<q} f(n+k) = Σ_{k<q} f(k) where f(k) = deviation(p/q·(k+1)). `cyclic_sum_periodic` closes this using deviation_rational_periodic. Note: gcd(p,q)=1 is not actually used — the proof works for any integers p and naturals q≥1. The coprimality assumption is inherited from the parent axiom but is mathematically redundant here."
     }
   ],

--- a/src/data/proofs/erdos-388/meta.json
+++ b/src/data/proofs/erdos-388/meta.json
@@ -85,7 +85,7 @@
       "id": "factorial-and-trivial",
       "title": "Factorial Connection and Trivial Solutions",
       "startLine": 101,
-      "endLine": 110,
+      "endLine": 112,
       "summary": "The factorial identity $\\text{consecutiveProduct}(m,k) \\cdot m! = (m+k)!$ and the trivial reflexivity solution (excluded by the disjointness constraint)."
     }
   ],

--- a/src/data/proofs/fourier-series-oq-02-oq-03/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-03/meta.json
@@ -81,7 +81,7 @@
       "id": "sec-sharpness",
       "title": "Section 3: Sharpness of the Constant 1/2",
       "startLine": 98,
-      "endLine": 131,
+      "endLine": 136,
       "summary": "Prose-only description of sharpness (no formalized axioms). Proved: small_alpha_bound (α=0 gives constant O(1) bound) and lipschitz_gives_linear_decay (α=1 gives O(1/n) decay). Sharpness via extremal sawtooth functions is stated in comments but not machine-verified.",
       "mathContext": "Boundary cases: $\\alpha=0$: $\\text{decayBound}(C,0,n) = C/2$ (no $n$-dependence, since $x^0=1$). $\\alpha=1$: $\\text{decayBound}(C,1,n) = CT/(4|n|)$ ($O(1/|n|)$ Lipschitz decay). Sharpness: $\\forall \\varepsilon > 0,\\,\\exists f \\in \\text{Hölder}_\\alpha(C):\\;|\\hat{c}_n(f)| \\ge (1/2-\\varepsilon)\\cdot C \\cdot \\left(\\tfrac{T}{2|n|}\\right)^\\alpha$. Extremal construction: sawtooth $f_\\alpha(x) = |x|^\\alpha \\operatorname{sgn}(x)$ on $[-T/2,\\,T/2]$, extended periodically, saturates the Hölder bound."
     }


### PR DESCRIPTION
## Section re-anchor pass (batch 2): cover stranded main theorems

Continuation of the coverage scan (each declaration tested against every
`sections` range). Five more entries had their **main/summary theorem**
drift just past the final section's `endLine`, so it rendered in no
section of the gallery view. The existing section summaries already
described the stranded theorem — only the `endLine` needed extending to
end-of-file.

| Entry | Section | Change | Now-covered decl |
|---|---|---|---|
| `erdos-388` | factorial-and-trivial | `101-110` → `101-112` | `trivial_equal_product` |
| `fourier-series-oq-02-oq-03` | sec-sharpness | `98-131` → `98-136` | `lipschitz_gives_linear_decay` |
| `ballot-problem-oq-03-oq-01-oq-01` | sec-corollaries | `99-130` → `99-139` | `jacobi_trudi_interpretation` |
| `erdos-1002-oq-01` | periodicity-main | `129-138` → `129-148` | `innerSum_periodic_rational` |
| `bernoulli-inequality-oq-01-oq-02-oq-01` | specializations | `135-146` → `135-154` | `bernoulli_second_order` |

Pure coverage fixes — no Lean source, `status`, `badge`, or `axiomCount`
changes. Verified: all five re-parse as JSON and no longer report stranded
declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
