### PR TITLE
audit(erdos-644): clean re-serve

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15289,8 +15289,8 @@
     },
     "erdos-644": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:04Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T17:43:14Z",
       "result": "clean"
     },
     "erdos-645": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-644 (queue drained, oldest uncontested).

## Verification
- **3 axioms** (`question1_open`, `question2_open`, `main_conjecture_open`) = meta axiomCount 3 ✓
- **16 sorries** = meta sorries 16 ✓
- **19 theorems**, **16 definitions**, **279 lines** all match ✓
- No `native_decide` ✓
- Axioms assert the open conjectures *true* (Tier C axiomatized); badge `axiom`, status `axiomatized`, assumptions field discloses "3 axiom(s) and 16 sorry(s)". Not `¬∃`-style false-masking. Prose frames as OPEN throughout.

**Result: clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)