### PR TITLE
Enrich ramsey-r4k-oq-01: re-anchor sections to fix ~16-line tail drift

### DIFF
--- a/src/data/proofs/ramsey-r4k-oq-01/meta.json
+++ b/src/data/proofs/ramsey-r4k-oq-01/meta.json
@@ -82,41 +82,41 @@
       "id": "definitions",
       "title": "Ramsey Number and Bound Axioms",
       "startLine": 21,
-      "endLine": 60,
+      "endLine": 58,
       "summary": "Opaque definition of ramseyR4k(k) as the actual Ramsey number, plus three axioms: classical binomial upper bound \u2264 C(k+2,3), AKS upper bound O(k\u00b3/log\u00b2k), and Mattheus-Verstra\u00ebte lower bound \u03a9(k\u00b3/log\u2074k)."
     },
     {
       "id": "log-basics",
       "title": "Logarithmic Basics for k \u2265 4",
-      "startLine": 64,
-      "endLine": 96,
+      "startLine": 59,
+      "endLine": 88,
       "summary": "Four lemmas establishing log k > 1 (using exp_one_lt_d9), log k > 0, (log k)\u00b2 > 1, and (log k)\u2074 > 0 for k \u2265 4. These underpin all subsequent structural results."
     },
     {
       "id": "aks-vs-cubic",
       "title": "AKS Bound vs Plain Cubic",
-      "startLine": 100,
-      "endLine": 120,
+      "startLine": 89,
+      "endLine": 109,
       "summary": "aks_bound_lt_cubic: C\u00b7k\u00b3/(log k)\u00b2 < C\u00b7k\u00b3 for k \u2265 4. The AKS bound is strictly better than the plain cubic by a factor of (log k)\u00b2. Also proves positivity of the AKS bound."
     },
     {
       "id": "gap-structure",
       "title": "Polylogarithmic Gap Structure",
-      "startLine": 124,
-      "endLine": 160,
+      "startLine": 110,
+      "endLine": 139,
       "summary": "The core structural results: r4k_gap_ratio proves the exact algebraic identity (upper)/(lower) = C/c\u00b7(log k)\u00b2. The gap between AKS and MV bounds is polylogarithmic \u2014 both bounds share k\u00b3 polynomial structure."
     },
     {
       "id": "log-exp-witnesses",
       "title": "Log Exponent Witnesses",
-      "startLine": 164,
-      "endLine": 178,
+      "startLine": 140,
+      "endLine": 158,
       "summary": "Formal witnesses for the log exponent bounds: upper exponent = 2 (AKS), lower exponent = 4 (MV). The open problem is determining the exact c \u2208 [2,4]."
     },
     {
       "id": "concrete-bounds",
       "title": "Concrete Classical Upper Bounds",
-      "startLine": 182,
+      "startLine": 159,
       "endLine": 187,
       "summary": "Classical binomial values C(6,3)=20, C(12,3)=220, C(22,3)=1540, C(52,3)=22100 for k=4,10,20,50 via native_decide. Also R(4,4) \u2264 20 and R(4,10) \u2264 220 from the classical bound."
     }


### PR DESCRIPTION
## Summary

Section anchors in `ramsey-r4k-oq-01/meta.json` had drifted relative to the Lean file's explicit `Part I`–`Part V` banner structure. Three declarations fell outside every `sections[]` range, and two sections (`Log Exponent Witnesses`, `Concrete Classical Upper Bounds`) pointed at the wrong Part entirely.

Uncovered before fix (private scan):
- `L98 theorem aks_bound_lt_cubic`
- `L121 theorem r4k_gap_ratio`
- `L180 theorem r4_4_le_20`

## Fix — snap each section to its Part banner

| Section | Before | After |
|---------|--------|-------|
| definitions | 21–60 | 21–58 |
| log-basics (Part I) | 64–96 | 59–88 |
| aks-vs-cubic (Part II) | 100–120 | 89–109 |
| gap-structure (Part III) | 124–160 | 110–139 |
| log-exp-witnesses (Part IV) | 164–178 | 140–158 |
| concrete-bounds (Part V) | 182–187 | 159–187 |

The existing summaries already described the intended content, so only line ranges changed — no prose, `status`, `badge`, or `axiomCount` edits. Coverage is now complete (scan reports 0 uncovered declarations).
