### PR TITLE
audit(erdos-646): disclose native_decide (ofReduceBool) in example theorems

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15304,9 +15304,9 @@
     },
     "erdos-646": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:04Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T17:45:52Z",
+      "result": "issues-fixed"
     },
     "erdos-647": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-646/meta.json
+++ b/src/data/proofs/erdos-646/meta.json
@@ -69,7 +69,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 350,
-    "assumptions": "2 axioms: berend_existence (Berend — for any set S of primes, infinitely many n have all even p-adic valuations for p in S), berend_bounded_gaps (bounded gaps between such n). 0 sorries.",
+    "assumptions": "2 axioms: berend_existence (Berend — for any set S of primes, infinitely many n have all even p-adic valuations for p in S), berend_bounded_gaps (bounded gaps between such n). 0 sorries. Additionally, three illustrative example theorems (example_even_val_2_at_7, example_even_val_3_at_8, example_even_vals_at_31) verify concrete valuations via native_decide, introducing the Lean.ofReduceBool axiom into those results; the main theorem erdos_646 does not depend on them.",
     "mathlib_version": "4.31.0",
     "theoremCount": 10,
     "definitionCount": 6


### PR DESCRIPTION
Reserve-mode re-audit of erdos-646.

## Verification (all match source)
- **2 axioms**: `berend_existence`, `berend_bounded_gaps` = axiomCount 2 ✓
- **0 sorries** ✓ · **10 theorems**, **6 definitions** ✓
- Main theorem `erdos_646` derives `ErdosConjecture646` from `berend_existence` — Tier C, badge `axiom`, status `axiomatized`, correctly attributed to Berend (1997), not claimed as our proof ✓

## LOW finding (fixed)
Three **named** theorems — `example_even_val_2_at_7`, `example_even_val_3_at_8`, `example_even_vals_at_31` — use `native_decide`, injecting the `Lean.ofReduceBool` axiom. The `assumptions` field listed only the 2 Berend axioms and never mentioned `native_decide`. Added a disclosure note. The headline claim (`erdos_646`) does not depend on these examples, so trust of the main result is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)