### PR TITLE
Enrich hilbert-20-oq-01: re-anchor sections to cover stranded declarations

### DIFF
--- a/src/data/proofs/hilbert-20-oq-01/meta.json
+++ b/src/data/proofs/hilbert-20-oq-01/meta.json
@@ -94,31 +94,31 @@
       "id": "local-solvability",
       "title": "Local Solvability Axiomatization",
       "startLine": 78,
-      "endLine": 98,
+      "endLine": 105,
       "summary": "Axiomatizes `IsLocallySolvable` (since distribution theory is not yet in Mathlib) and the principal type condition (`IsPrincipalType`). An operator is locally solvable at $x_0$ if $Pu = f$ has a distribution solution near $x_0$ for every smooth $f$.",
       "mathContext": "$P$ is locally solvable at $x_0$ iff $\\forall f \\in C^\\infty$, $\\exists u \\in \\mathcal{D}'$: $Pu = f$ in a neighborhood of $x_0$. Principal type: $p_m(x, \\xi) = 0 \\Rightarrow \\nabla_\\xi p_m \\neq 0$ (non-degenerate)."
     },
     {
       "id": "condition-psi",
       "title": "Bicharacteristic Curves and Condition (Ψ)",
-      "startLine": 100,
-      "endLine": 136,
+      "startLine": 106,
+      "endLine": 149,
       "summary": "Concrete structure `BicharacteristicCurve` for curves $(x(t), \\xi(t))$ along which the principal symbol vanishes and $\\xi \\neq 0$. Defines `Im(p_m)` along curves, a bridge theorem, and formalizes condition (Ψ): the imaginary part cannot change sign from $-$ to $+$ along bicharacteristics of $\\text{Re}(p_m)$.",
       "mathContext": "$(x(t), \\xi(t))$ is bicharacteristic if $p_m(x(t), \\xi(t)) = 0$ and $\\xi(t) \\neq 0$. Condition (Ψ): $\\exists t_1 < t_2 < t_3$ with $\\text{Im}(p_m) < 0$ at $t_1$, $= 0$ at $t_2$, $> 0$ at $t_3$ is forbidden."
     },
     {
       "id": "the-nirenberg-treves-theorem",
       "title": "The Nirenberg-Treves Characterization",
-      "startLine": 138,
-      "endLine": 172,
+      "startLine": 150,
+      "endLine": 183,
       "summary": "Single biconditional axiom `nirenberg_treves` encodes the full characterization (Hörmander 1960 + Dencker 2006). The Hörmander necessity direction and Dencker sufficiency direction are derived as proved theorems from this axiom. The 43-year gap between conjecture (1963) and proof (2006) reflects the depth of Dencker's result.",
       "mathContext": "For $P$ of principal type: $P$ locally solvable $\\iff$ $p_m$ satisfies condition (Ψ). Single axiom `nirenberg_treves`; `hormander_necessity` ($\\text{locally solvable} \\Rightarrow \\Psi$) and `dencker_sufficiency` ($\\Psi \\Rightarrow \\text{locally solvable}$) are proved theorems."
     },
     {
       "id": "special-cases",
       "title": "Special Cases: Elliptic and Real-Symbol Operators",
-      "startLine": 174,
-      "endLine": 211,
+      "startLine": 184,
+      "endLine": 221,
       "summary": "Proved theorems: `real_symbol_satisfies_psi` (operators with real principal symbol satisfy condition (Ψ) since $\\text{Im}(p_m) = 0$ always), `elliptic_satisfies_psi` (elliptic operators satisfy (Ψ) vacuously — no bicharacteristics exist), `elliptic_locally_solvable` (elliptic principal-type operators are locally solvable, combining (Ψ) with Dencker sufficiency).",
       "mathContext": "Real symbol: $p_m$ real $\\Rightarrow \\text{Im}(p_m) = 0 \\Rightarrow$ (Ψ) trivially. Elliptic: $p_m(x, \\xi) \\neq 0$ for $\\xi \\neq 0 \\Rightarrow$ no bicharacteristics $\\Rightarrow$ (Ψ) vacuously $\\Rightarrow$ locally solvable."
     }


### PR DESCRIPTION
## Summary

Section anchors in `hilbert-20-oq-01/meta.json` had drifted 6–12 lines off the Lean file's `Part III`/`IV`/`V` banner structure, leaving three declarations outside every `sections[]` range.

Uncovered before fix (private scan):
- `L99 def IsPrincipalType`
- `L173 theorem dencker_sufficiency`
- `L216 theorem elliptic_locally_solvable`

## Fix — extend/snap sections to their content

| Section | Before | After |
|---------|--------|-------|
| local-solvability | 78–98 | 78–105 |
| condition-psi (Part III) | 100–136 | 106–149 |
| the-nirenberg-treves-theorem (Part IV) | 138–172 | 150–183 |
| special-cases (Part V) | 174–211 | 184–221 |

`local-solvability` now covers the principal-type definition it already describes; the Part III–V sections were snapped to their banners so `dencker_sufficiency`, `nirenberg_treves_characterization`, and `elliptic_locally_solvable` fall inside their sections. Summaries already matched the intended content — only line ranges changed. No prose, `status`, `badge`, or `axiomCount` edits. Scan now reports 0 uncovered declarations.
