### PR TITLE
Enrich buffons-noodle-oq-03-oq-01: cover the three stranded core definitions

### DIFF
--- a/src/data/proofs/buffons-noodle-oq-03-oq-01/meta.json
+++ b/src/data/proofs/buffons-noodle-oq-03-oq-01/meta.json
@@ -181,7 +181,7 @@
       "id": "module-overview",
       "title": "Overview: the crossing factor in closed form",
       "startLine": 1,
-      "endLine": 73,
+      "endLine": 82,
       "summary": "Frames the goal: evaluate αₙ = E_{S^{n-1}}|u₁|, carried as a parameter by the parent noodle file, in closed form. Recalls the spherical→angular reduction (marginal density (1-t²)^{(n-3)/2}, t = cos θ) that expresses αₙ (with m = n-2) as the ratio of the trigonometric integrals N(m) = ∫₀^π |cos θ| sin^m θ and D(m) = ∫₀^π sin^m θ, and notes the open question's off-by-one in the dimension. Defines sinPowIntegral, crossingIntegral, crossingFactor."
     },
     {


### PR DESCRIPTION
## Summary

The three core `noncomputable def`s — `sinPowIntegral` (D(m)), `crossingIntegral` (N(m)), and `crossingFactor` (α) — sit at lines 74–81, in the gap between the `module-overview` section (ended at 73) and the `numerator` section (starts at 83), so they fell outside every `sections[]` range.

Uncovered before fix (private scan):
- `L75 def sinPowIntegral`
- `L78 def crossingIntegral`
- `L81 def crossingFactor`

## Fix

The `module-overview` summary already ends with "Defines sinPowIntegral, crossingIntegral, crossingFactor", so its stated scope already includes them — only the `endLine` fell short. Extended `module-overview` from `73` → `82`. No new section, no prose or metadata changes. Scan now reports 0 uncovered declarations.
