### PR TITLE
Enrich 5 proofs: re-anchor section boundaries to cover stranded key theorems

### DIFF
--- a/src/data/proofs/basel-problem-oq-13/meta.json
+++ b/src/data/proofs/basel-problem-oq-13/meta.json
@@ -105,14 +105,14 @@
       "id": "even-part",
       "title": "hasSum_even_zeta_four — ∑ 1/(2k)⁴ = π⁴/1440",
       "startLine": 35,
-      "endLine": 46,
+      "endLine": 43,
       "summary": "Rewrites 1/(2k)⁴ = (1/16)(1/k⁴) and scales ζ(4) by 1/16.",
       "mathContext": "The even-indexed fourth-power terms form a sixteenth-scaled copy of ζ(4)."
     },
     {
       "id": "odd-part",
       "title": "hasSum_odd_zeta_four — ∑ 1/(2k+1)⁴ = π⁴/96",
-      "startLine": 48,
+      "startLine": 44,
       "endLine": 62,
       "summary": "Odd subseries summable via Summable.comp_injective with k ↦ 2k+1; reassemble ζ(4) = even + odd through HasSum.even_add_odd, then HasSum.unique against hasSum_zeta_four forces π⁴/1440 + (odd) = π⁴/90, so linarith gives the odd sum = π⁴/96.",
       "mathContext": "The lambda value λ(4), recovered by uniqueness as ζ(4) minus its even part: π⁴/90 − π⁴/1440 = π⁴/96."

--- a/src/data/proofs/conjugacy-class-equation-oq-01-oq-02/meta.json
+++ b/src/data/proofs/conjugacy-class-equation-oq-01-oq-02/meta.json
@@ -106,14 +106,14 @@
       "id": "noncentral-prime-pow",
       "title": "Noncentral Classes Have Size a Positive Power of p",
       "startLine": 59,
-      "endLine": 80,
+      "endLine": 74,
       "summary": "noncentral_class_card_eq_prime_pow: with |G| = pⁿ (IsPGroup.iff_card), a class size divides pⁿ so equals pᵏ (Nat.dvd_prime_pow); a noncentral carrier is a nontrivial set with more than one element, forcing k > 0.",
       "mathContext": "Noncentral $\\Rightarrow |x| = p^k,\\ k > 0 \\Rightarrow p \\mid |x|$."
     },
     {
       "id": "center-nontrivial",
       "title": "The Center Is Nontrivial",
-      "startLine": 82,
+      "startLine": 75,
       "endLine": 113,
       "summary": "center_nontrivial_of_isPGroup: p ∣ |G| and p ∣ Σ (noncentral sum, via finsum→Finset and Finset.dvd_sum) give p ∣ |Z(G)| through the class equation and Nat.dvd_sub; with |Z(G)| > 0 and p ≥ 2, conclude 1 < |Z(G)| and Nontrivial (center G).",
       "mathContext": "$p \\mid |Z(G)|,\\ |Z(G)| > 0 \\Rightarrow 1 < |Z(G)|$."

--- a/src/data/proofs/cramers-rule-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-04-oq-01/meta.json
@@ -137,14 +137,14 @@
       "id": "adjugate-identity",
       "title": "Section I: The Adjugate-Reflexive Identity",
       "startLine": 37,
-      "endLine": 45,
+      "endLine": 42,
       "summary": "adjugate_charmatrix_mul: adj(xI − A)·(xI − A) = χ_A(x)·I over R[X], the OQ's explicit target — adjugate_mul applied to the characteristic matrix.",
       "mathContext": "The algebraic heart of Cayley–Hamilton, an instance of the universal adjugate identity adj(B)·B = (det B)·I."
     },
     {
       "id": "cayley-hamilton",
       "title": "Section II: Cayley–Hamilton and Its Consequence",
-      "startLine": 47,
+      "startLine": 43,
       "endLine": 58,
       "summary": "cayley_hamilton (χ_A(A) = 0, from aeval_self_charpoly) and minpoly_dvd_charpoly (minpoly ∣ charpoly over a field).",
       "mathContext": "The matrix satisfies its characteristic polynomial; the minimal polynomial divides it."

--- a/src/data/proofs/sum-of-divisors-oq-04/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-04/meta.json
@@ -105,14 +105,14 @@
       "id": "primes",
       "title": "σ and τ on Primes and Prime Powers",
       "startLine": 36,
-      "endLine": 56,
+      "endLine": 53,
       "summary": "sigma_one_prime (σ(p) = p+1), sigma_zero_prime (τ(p) = 2), sigma_one_prime_pow_mul (the closed geometric form σ(pⁱ)·(p−1) = pⁱ⁺¹−1).",
       "mathContext": "$\\sigma(p) = p+1$, $\\tau(p) = 2$, $(p-1)\\sigma(p^i) = p^{i+1}-1$."
     },
     {
       "id": "multiplicative",
       "title": "Multiplicativity and Perfection",
-      "startLine": 58,
+      "startLine": 54,
       "endLine": 69,
       "summary": "sigma_one_two_primes (σ(pq) = (p+1)(q+1) via multiplicativity) and perfect_iff_sigma_one (Perfect n ↔ σ(n) = 2n).",
       "mathContext": "$\\sigma(pq) = (p+1)(q+1)$ and $\\mathrm{Perfect}(n) \\iff \\sigma(n) = 2n$."

--- a/src/data/proofs/szemeredi-full-oq-02/meta.json
+++ b/src/data/proofs/szemeredi-full-oq-02/meta.json
@@ -95,14 +95,14 @@
       "id": "k3-isLittleO",
       "title": "k=3 Sequence IsLittleO",
       "startLine": 85,
-      "endLine": 97,
+      "endLine": 87,
       "summary": "**Proved.** `ap_free_density_isLittleO_k3`: any sequence of 3-AP-free sets has density o(N), stated as IsLittleO. Derived from szemeredi_vanishing_density via isLittleO_iff_tendsto.",
       "mathContext": "IsLittleO atTop (fun N => (A N).card : ℝ) (fun N => N). The zero case (N=0): A 0 ⊆ range 0 = ∅ so (A 0).card = 0, validating the hypothesis of isLittleO_iff_tendsto."
     },
     {
       "id": "main-theorem",
       "title": "Main Density Theorem",
-      "startLine": 99,
+      "startLine": 88,
       "endLine": 115,
       "summary": "**Proved.** `szemeredi_density_full`: alias for szemeredi_vanishing_density — the full Szemerédi density theorem for all k ≥ 1.",
       "mathContext": "Filter.Tendsto (fun N => (A N).card / N) atTop (nhds 0) for any k ≥ 1 sequence of k-AP-free sets. Single axiom: szemeredi_k_ge_4 for k ≥ 4."


### PR DESCRIPTION
Section-coverage re-anchor pass. Ran the stranded-declaration scan (each named
decl tested against every `sections` range, block-comments stripped). This batch
fixes 5 entries where a named theorem — often the **main/key** result — had
drifted into the one-line crack between two abutting sections, making it
invisible in the gallery's sectioned view.

Each fix is a pure boundary correction: shrink the trailing section's `endLine`
and extend the following section's `startLine` back to the stranded theorem's
docstring. In every case the target section's existing summary **already names**
the theorem being pulled in, so no summary rewrites were needed.

| Entry | Stranded decl | Now in section |
|-------|---------------|----------------|
| `sum-of-divisors-oq-04` | `sigma_one_two_primes` | `multiplicative` |
| `conjugacy-class-equation-oq-01-oq-02` | `center_nontrivial_of_isPGroup` | `center-nontrivial` |
| `szemeredi-full-oq-02` | `szemeredi_density_full` (main thm) | `main-theorem` (+ `/-!` banner) |
| `cramers-rule-oq-04-oq-01` | `cayley_hamilton` | `cayley-hamilton` |
| `basel-problem-oq-13` | `hasSum_odd_zeta_four` | `odd-part` |

**Verification**: all 5 `meta.json` re-parse; rescan confirms zero stranded
decls remain and no section overlaps were introduced (closed gaps abut cleanly).

No Lean source, `status`, `badge`, or `axiomCount` was touched — pure coverage fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
