### PR TITLE
Enrich arithmetic-series-oq-02-oq-02-oq-03: re-anchor Part drift + cover stranded Part V

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03/meta.json
@@ -84,46 +84,54 @@
       "title": "Simplicial Numbers",
       "summary": "Restated definitions and the hockey stick identity from the parent file",
       "startLine": 24,
-      "endLine": 55,
+      "endLine": 54,
       "mathContext": "Simplicial numbers $S_k(n) = \\binom{n+k}{k}$ with Pascal recurrence and the hockey stick: $\\sum_{i=0}^n S_k(i) = S_{k+1}(n)$."
     },
     {
       "id": "power-series-framework",
       "title": "Formal Power Series Framework",
       "summary": "Defines the geometric series and negative binomial generating function",
-      "startLine": 60,
-      "endLine": 75,
+      "startLine": 55,
+      "endLine": 70,
       "mathContext": "Define $g = \\sum x^n \\in \\mathbb{N}[[x]]$ and $\\text{negBin}(k) = g^{k+1} = (1-x)^{-(k+1)}$."
     },
     {
       "id": "coefficient-extraction",
       "title": "Coefficient Extraction",
       "summary": "The n-th coefficient of negBin(k) is C(n+k, k)",
-      "startLine": 80,
-      "endLine": 108,
+      "startLine": 71,
+      "endLine": 104,
       "mathContext": "Prove $[x^n] g^{k+1} = \\binom{n+k}{k}$ by induction on $k$. The inductive step uses the Cauchy product ($[x^n](fg) = \\sum_{i+j=n} [x^i]f \\cdot [x^j]g$) and the hockey stick identity."
     },
     {
       "id": "product-formula",
       "title": "The Algebraic Product Formula",
       "summary": "negBin(a) · negBin(b) = negBin(a+b+1) by exponent addition",
-      "startLine": 113,
-      "endLine": 124,
+      "startLine": 105,
+      "endLine": 123,
       "mathContext": "The core algebraic identity: $g^{a+1} \\cdot g^{b+1} = g^{(a+1)+(b+1)} = g^{a+b+2}$. This is just `pow_add` in the power series monoid — the entire combinatorial content of the Vandermonde identity reduced to one line of algebra."
     },
     {
       "id": "vandermonde-derivation",
       "title": "Deriving the Vandermonde Identity",
       "summary": "Extract coefficients from both sides of negBin_mul",
-      "startLine": 129,
-      "endLine": 160,
+      "startLine": 124,
+      "endLine": 157,
       "mathContext": "Extracting $[x^n]$ from both sides of `negBin_mul`: LHS gives $\\sum_{i+j=n} \\binom{i+a}{a}\\binom{j+b}{b}$ (Cauchy product), RHS gives $\\binom{n+a+b+1}{a+b+1}$ (coeff_negBin). QED."
+    },
+    {
+      "id": "range-sum-form",
+      "title": "Range-Sum Form (Matching Parent)",
+      "summary": "parallel_vandermonde_range: recasts the antidiagonal identity into the familiar range-sum form ∑_{i=0}^{n} S_a(i)·S_b(n-i) = S_{a+b+1}(n) that matches the parent file's statement, via Finset.Nat.sum_antidiagonal_eq_sum_range_succ.",
+      "startLine": 158,
+      "endLine": 169,
+      "mathContext": "$\\sum_{i=0}^{n} \\binom{i+a}{a}\\binom{(n-i)+b}{b} = \\binom{n+a+b+1}{a+b+1}$ — the range-indexed form, obtained from the antidiagonal sum by `sum_antidiagonal_eq_sum_range_succ`."
     },
     {
       "id": "verification",
       "title": "Concrete Verification",
       "summary": "Numerical checks via native_decide: `simplicial 3 3 = 20` and the antidiagonal convolution `∑ simplicial 1 p.1 · simplicial 1 p.2 = 20` over `antidiagonal 3`.",
-      "startLine": 167,
+      "startLine": 170,
       "endLine": 182,
       "mathContext": "Verification: $a=b=1, n=3$ gives $(1 \\cdot 4) + (2 \\cdot 3) + (3 \\cdot 2) + (4 \\cdot 1) = 20 = \\binom{6}{3}$."
     },


### PR DESCRIPTION
## Summary

Section anchors in `arithmetic-series-oq-02-oq-02-oq-03/meta.json` had drifted 5–11 lines off the Lean file's explicit `Part I`–`Part VI` banner structure. Two declarations fell outside every `sections[]` range, and `Part V: Range-Sum Form` (holding `parallel_vandermonde_range`) had no section at all.

Uncovered before fix (private scan):
- `L76 theorem coeff_geom`
- `L163 theorem parallel_vandermonde_range`

## Fix — snap each section to its Part banner + add Part V

| Section | Before | After |
|---------|--------|-------|
| simplicial-numbers | 24–55 | 24–54 |
| power-series-framework (Part I) | 60–75 | 55–70 |
| coefficient-extraction (Part II) | 80–108 | 71–104 |
| product-formula (Part III) | 113–124 | 105–123 |
| vandermonde-derivation (Part IV) | 129–160 | 124–157 |
| **range-sum-form (Part V)** | *(missing)* | **158–169 (new)** |
| verification (Part VI) | 167–182 | 170–182 |
| summary | 183–208 | 183–208 |

The existing summaries already described the intended content; only line ranges changed, plus one new section covering `parallel_vandermonde_range`. No prose, `status`, `badge`, or `axiomCount` edits. Scan now reports 0 uncovered declarations.
