### PR TITLE
Research: erdos-326-wip-01 — growth-limit predicates are non-vacuous (realizability)

### DIFF
--- a/proofs/Proofs/Erdos326WIP01.lean
+++ b/proofs/Proofs/Erdos326WIP01.lean
@@ -23,7 +23,10 @@ ratio and its limit:
   four-square theorem) — the canonical non-vacuous witness for the predicate;
 * `growthRatio` is nonnegative, `growthRatio b 0 = 0`;
 * the growth limit is unique, and existence of a limit contradicts
-  `HasNoGrowthLimit`.
+  `HasNoGrowthLimit`;
+* both growth-limit predicates are non-vacuous: an exactly-quadratic
+  enumeration `bₖ = c·k²` has growth limit `c`, while an enumeration whose
+  quadratic coefficient oscillates between `1` and `2` has **no** growth limit.
 
 All results are `0`-axiom / `0`-sorry.
 
@@ -335,5 +338,92 @@ theorem IsAddBasisOfOrder.two_quadratic_density' {A : Set ℕ}
   obtain ⟨S, hS, hSn, hcard⟩ := hN n hn
   rw [Nat.card_Icc] at hcard
   exact ⟨S, hS, hSn, hcard⟩
+
+/-! ## The growth-limit predicates are non-vacuous (realizability)
+
+The lemmas above about `HasGrowthLimit`/`HasNoGrowthLimit` (uniqueness of the
+limit, and that having a limit excludes `HasNoGrowthLimit`) say nothing about
+whether *either* predicate is ever satisfiable.  Here we exhibit explicit
+enumerations realizing each side, so the predicates are not vacuous:
+
+* an exactly-quadratic enumeration `bₖ = c·k²` has growth limit `c`
+  (`hasGrowthLimit_quadratic`);
+* an enumeration whose quadratic coefficient oscillates between `1` and `2`
+  has **no** growth limit (`hasNoGrowthLimit_oscillating`).
+
+The oscillating example is exactly the `bₖ/k²`-non-convergence phenomenon that
+Erdős #326 conjectures must be attainable on a *sub-basis* of every order-2
+basis; here it is realized by a bare sequence (with no basis constraint), which
+is elementary.  All results remain `0`-axiom / `0`-sorry. -/
+
+/-- The growth ratio of an exactly-quadratic enumeration `bₖ = c·k²` at any
+`k ≠ 0` equals the coefficient `c`. -/
+theorem growthRatio_eq (b : ℕ → ℕ) (c k : ℕ) (hk : k ≠ 0)
+    (hval : b k = c * k ^ 2) : growthRatio b k = (c : ℝ) := by
+  unfold growthRatio
+  rw [hval]
+  have hkR : (k : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hk
+  rw [div_eq_iff (pow_ne_zero 2 hkR)]
+  push_cast
+  ring
+
+/-- **A quadratic enumeration has a growth limit.**  If `bₖ = c·k²` exactly then
+`bₖ/k² → c`, so `HasGrowthLimit` is non-vacuous (for every coefficient `c`, in
+particular the positive ones, matching the flavour of Cassels' `aₖ/k² → x`
+construction — though here `b` is a bare sequence, not a genuine basis). -/
+theorem hasGrowthLimit_quadratic (c : ℕ) :
+    HasGrowthLimit (fun k => c * k ^ 2) (c : ℝ) := by
+  have hev : (fun k => growthRatio (fun k => c * k ^ 2) k) =ᶠ[atTop] fun _ => (c : ℝ) := by
+    filter_upwards [eventually_gt_atTop 0] with k hk
+    exact growthRatio_eq _ c k (by omega) rfl
+  exact tendsto_const_nhds.congr' hev.symm
+
+/-- An explicit enumeration whose quadratic coefficient alternates: `bₖ = k²` for
+even `k` and `bₖ = 2k²` for odd `k`.  Its growth ratio therefore oscillates
+between `1` and `2`. -/
+def oscillating (k : ℕ) : ℕ := (k % 2 + 1) * k ^ 2
+
+/-- On odd indices the oscillating growth ratio is `2`. -/
+theorem growthRatio_oscillating_odd (m : ℕ) :
+    growthRatio oscillating (2 * m + 1) = 2 := by
+  have hval : oscillating (2 * m + 1) = 2 * (2 * m + 1) ^ 2 := by
+    unfold oscillating; rw [show (2 * m + 1) % 2 = 1 from by omega]
+  have h := growthRatio_eq oscillating 2 (2 * m + 1) (by omega) hval
+  simpa using h
+
+/-- On even indices the oscillating growth ratio is `1`. -/
+theorem growthRatio_oscillating_even (m : ℕ) :
+    growthRatio oscillating (2 * m + 2) = 1 := by
+  have hval : oscillating (2 * m + 2) = 1 * (2 * m + 2) ^ 2 := by
+    unfold oscillating; rw [show (2 * m + 2) % 2 = 0 from by omega]
+  have h := growthRatio_eq oscillating 1 (2 * m + 2) (by omega) hval
+  simpa using h
+
+/-- **`HasNoGrowthLimit` is non-vacuous.**  The oscillating enumeration has no
+growth limit: its ratio equals `2` on the (unboundedly many) odd indices and `1`
+on the even ones, so any candidate limit would have to be both `2` and `1`.  This
+realizes the `bₖ/k²`-non-convergence phenomenon central to Erdős #326 (here for a
+plain sequence, with the deep sub-basis existence question untouched). -/
+theorem hasNoGrowthLimit_oscillating : HasNoGrowthLimit oscillating := by
+  intro x hx
+  -- the odd and even index maps both tend to `atTop`
+  have godd : Tendsto (fun m : ℕ => 2 * m + 1) atTop atTop :=
+    tendsto_atTop_atTop.mpr fun b => ⟨b, fun a ha => by omega⟩
+  have geven : Tendsto (fun m : ℕ => 2 * m + 2) atTop atTop :=
+    tendsto_atTop_atTop.mpr fun b => ⟨b, fun a ha => by omega⟩
+  -- along odd indices the ratio is the constant `2`, so `x = 2`
+  have hodd : Tendsto (fun m : ℕ => growthRatio oscillating (2 * m + 1)) atTop (𝓝 x) :=
+    hx.comp godd
+  have hodd2 : Tendsto (fun m : ℕ => growthRatio oscillating (2 * m + 1)) atTop (𝓝 2) := by
+    simp only [growthRatio_oscillating_odd]; exact tendsto_const_nhds
+  have hx2 : x = 2 := tendsto_nhds_unique hodd hodd2
+  -- along even indices the ratio is the constant `1`, so `x = 1`
+  have heven : Tendsto (fun m : ℕ => growthRatio oscillating (2 * m + 2)) atTop (𝓝 x) :=
+    hx.comp geven
+  have heven1 : Tendsto (fun m : ℕ => growthRatio oscillating (2 * m + 2)) atTop (𝓝 1) := by
+    simp only [growthRatio_oscillating_even]; exact tendsto_const_nhds
+  have hx1 : x = 1 := tendsto_nhds_unique heven heven1
+  rw [hx2] at hx1
+  norm_num at hx1
 
 end Erdos326

--- a/research/problems/erdos-326-wip-01/knowledge.md
+++ b/research/problems/erdos-326-wip-01/knowledge.md
@@ -1,5 +1,41 @@
 # Knowledge Base: erdos-326-wip-01
 
+## Session 2026-07-21 (researcher-1-6) — growth-limit predicates are non-vacuous (realizability)
+
+Added 5 axiom-free theorems + 1 def to `Erdos326WIP01.lean` (host-verified v4.31.0
+via fresh-parent-olean; `#print axioms` = propext/Classical.choice/Quot.sound on all
+new results; theoremCount 20→25):
+
+- `growthRatio_eq (b c k) (hk : k≠0) (hval : b k = c*k^2) : growthRatio b k = c` —
+  the reusable "value pins the ratio" lemma (`div_eq_iff (pow_ne_zero 2 …)` + `push_cast; ring`).
+- `hasGrowthLimit_quadratic (c) : HasGrowthLimit (fun k => c*k^2) c` — an exactly-quadratic
+  enumeration converges (eventually constant `=ᶠ`, `tendsto_const_nhds.congr'`). Positive
+  realizability of `HasGrowthLimit` (the Cassels-flavour convergent case, for a bare sequence).
+- `oscillating k := (k%2+1)*k^2` — ratio `2` on odds, `1` on evens
+  (`growthRatio_oscillating_odd/even`, both via `growthRatio_eq` after `rw [show …%2=… from by omega]`).
+- `hasNoGrowthLimit_oscillating : HasNoGrowthLimit oscillating` — NON-vacuous `HasNoGrowthLimit`.
+  Both index maps `2m+1`, `2m+2` tend to `atTop` (`tendsto_atTop_atTop.mpr fun b => ⟨b, …omega⟩`),
+  compose with the hypothetical limit (`hx.comp`), collapse each to a constant via the odd/even
+  ratio lemma, then `tendsto_nhds_unique` twice forces `x=2` AND `x=1` → `norm_num`.
+
+This is exactly the `bₖ/k²`-non-convergence phenomenon Erdős #326 conjectures for a
+*sub-basis* — realized here for a plain sequence (no basis constraint); the deep sub-basis
+oscillation dichotomy is untouched.
+
+### Gotchas
+- A `∀ᶠ k, f k = g k` hypothesis must be *typed* as `f =ᶠ[atTop] g` (EventuallyEq) for
+  `.symm`/`.congr'` dot-notation to resolve — the bare `∀ᶠ` (Filter.Eventually) head symbol
+  blocks the field projection (`Invalid field notation … atTop.1 {x | …}`).
+- `rw [show (2*m+1)%2 = 1 from by omega]` then the goal `(1+1)*…=2*…` closes by `rw`'s trailing
+  `rfl` (Nat literal `1+1` reduces to `2`); a following `ring` errors "No goals".
+- Same fresh-parent-olean host-verify recipe as prior sessions (parent Mathlib-only →
+  `lake env lean -o .lake/build/lib/lean/Proofs/Erdos326Problem.olean` first).
+
+### Remaining open (unchanged)
+- Bridge `HasGrowthLimit` to explicit enumeration boundedness (`bₖ=O(k²)` as growthRatio boundedness).
+- The oscillation dichotomy — must every order-2 basis contain a sub-basis with `bₖ/k²`
+  non-convergent — the OPEN part of #326 (structured blocker, deep).
+
 ## Session 2026-07-20 (researcher-1) — squares are NOT an order-3 basis (order = exactly 4)
 
 Added 3 axiom-free lemmas to `Erdos326WIP01.lean` (host-verified v4.31.0 via fresh-parent-olean;

--- a/src/data/research/problems/erdos-326-wip-01.json
+++ b/src/data/research/problems/erdos-326-wip-01.json
@@ -44,7 +44,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-07-20, researcher-1, VERIFIED 0-axiom host): formalized Key Observation 1 of the parent — an order-2 additive basis is quadratically dense (IsAddBasisOfOrder.two_quadratic_density / '). For every n≥N there is a finite S⊆A of elements ≤n with |Icc N n| ≤ (|S|+1)², i.e. the counting function up to n is ≥√(n+1-N)-1 (the √n density behind b_k=O(k²)), via an injection of [N,n] into padded summand pairs. 20 axiom-free theorems. The deep oscillation dichotomy (the open part of #326) is untouched and remains a structured blocker.",
+    "progressSummary": "PROGRESS (2026-07-21, researcher-1-6, VERIFIED 0-axiom host v4.31.0): the growth-limit predicates are now realizable — hasGrowthLimit_quadratic (bₖ=c·k²→c) and hasNoGrowthLimit_oscillating (coefficient oscillates 1↔2, no limit). theoremCount 20→25 (+1 def). Deep sub-basis oscillation dichotomy (open part of #326) untouched.",
     "builtItems": [
       "IsAddBasisOfOrder.mono_order / .mono_set in Erdos326WIP01.lean",
       "IsAddBasis.mono",
@@ -55,7 +55,11 @@
       "Squares (the set {m^2}), isAddBasisOfOrder_squares_four, isAddBasis_squares in Erdos326WIP01.lean (session 2, axiom-free [propext, Classical.choice, Quot.sound])",
       "IsAddBasisOfOrder.infinite (Erdos326WIP01.lean): a bounded-order additive basis is infinite, via Set.Finite.bddAbove + sum ≤ k·M ceiling (2026-07-20)",
       "mem_squares_mod_eight, not_isAddBasisOfOrder_squares_three, not_isAddBasisOfOrder_squares_of_le_three in Erdos326WIP01.lean (0 axioms, 0 sorries; host-verified v4.31.0 via fresh-parent-olean; #print axioms clean)",
-      "IsAddBasisOfOrder.two_quadratic_density + .two_quadratic_density' (Erdos326WIP01.lean): an order-2 additive basis is quadratically dense — ∃N, ∀n≥N ∃ finite S⊆A with elements ≤n and |Icc N n| ≤ (|S|+1)² (equivalently n+1-N ≤ (|S|+1)², so the counting function up to n is ≥√(n+1-N)-1). Formalizes the parent's stated Key Observation 1 behind b_k=O(k²). Proof: pad each m∈[N,n] to an ordered summand pair (a_m,b_m)∈(A∪{0})²; m↦(a_m,b_m) is injective (sum recovers m), so [N,n] injects into (S∪{0})². Axiom-free (propext/Choice/Quot), host-verified v4.31 via fresh-parent-olean (2026-07-20)."
+      "IsAddBasisOfOrder.two_quadratic_density + .two_quadratic_density' (Erdos326WIP01.lean): an order-2 additive basis is quadratically dense — ∃N, ∀n≥N ∃ finite S⊆A with elements ≤n and |Icc N n| ≤ (|S|+1)² (equivalently n+1-N ≤ (|S|+1)², so the counting function up to n is ≥√(n+1-N)-1). Formalizes the parent's stated Key Observation 1 behind b_k=O(k²). Proof: pad each m∈[N,n] to an ordered summand pair (a_m,b_m)∈(A∪{0})²; m↦(a_m,b_m) is injective (sum recovers m), so [N,n] injects into (S∪{0})². Axiom-free (propext/Choice/Quot), host-verified v4.31 via fresh-parent-olean (2026-07-20).",
+      "growthRatio_eq — growth ratio of an exactly-quadratic enumeration bₖ=c·k² equals c at any k≠0 (Erdos326WIP01.lean)",
+      "hasGrowthLimit_quadratic — bₖ=c·k² has growth limit c (HasGrowthLimit non-vacuous; positive realizability, Cassels flavour)",
+      "oscillating (def) + growthRatio_oscillating_odd/even — explicit sequence with ratio 2 on odds, 1 on evens",
+      "hasNoGrowthLimit_oscillating — HasNoGrowthLimit is non-vacuous: oscillating sequence has no growth limit"
     ],
     "insights": [
       "The basis predicates form a monotone lattice: raising the order or enlarging the set preserves the basis property — the atomic order theory underlying any basis-comparison argument.",
@@ -63,15 +67,17 @@
       "growthRatio b 0 = 0 by the ℝ junk convention x/0 = 0 — worth pinning so downstream limit arguments can ignore the k=0 term.",
       "The perfect squares are a concrete additive basis of order 4 (Lagrange four-square theorem, Nat.sum_four_squares) — the canonical non-vacuous witness for IsAddBasisOfOrder. Order 4 is the correct order: numbers of the form 4^a(8b+7) (e.g. 7,15,23,28) are never sums of three squares, so squares are not an order-3 basis (that stronger negative needs Legendre three-square, deeper).",
       "The additive-basis order of the perfect squares is EXACTLY 4: Lagrange gives order 4, and order 3 fails because 8N+7 ≡ 7 mod 8 is never a sum of ≤3 squares. This is the EASY (necessary) direction of Legendre three-square — no full Legendre needed, just squares ≡ 0/1/4 mod 8 and no three summing to 7 mod 8, a decide over ZMod 8.",
-      "The √n density lower bound for order-2 bases (Key Observation 1) is now machine-checked axiom-free — the elementary counting core behind b_k=O(k²). The remaining open content is the growth/oscillation dichotomy (Erdős #326 proper), which this bound does not touch: it bounds b_k above but says nothing about the non-convergence of b_k/k² for a sub-basis."
+      "The √n density lower bound for order-2 bases (Key Observation 1) is now machine-checked axiom-free — the elementary counting core behind b_k=O(k²). The remaining open content is the growth/oscillation dichotomy (Erdős #326 proper), which this bound does not touch: it bounds b_k above but says nothing about the non-convergence of b_k/k² for a sub-basis.",
+      "The HasGrowthLimit/HasNoGrowthLimit predicates were previously only equipped with uniqueness lemmas; both are now shown non-vacuous by explicit bare-sequence witnesses (no basis constraint), 0-axiom.",
+      "Non-convergence is realized elementarily by oscillating the quadratic coefficient between 1 and 2; the odd/even index maps both tend to atTop so any limit would be forced to equal both 2 and 1 (tendsto_nhds_unique twice).",
+      "Idiom: ∀ᶠ equality must be typed as f =ᶠ[l] g (EventuallyEq) for .symm/.congr' dot notation to resolve; the bare ∀ᶠ (Eventually) head symbol blocks it."
     ],
     "mathlibGaps": [
       "No packaged bₖ = O(k²) bound for order-2 additive bases; would need a density-counting argument (|A ∩ [0,n]| ≥ c√n) not currently in Mathlib."
     ],
     "nextSteps": [
-      "The b_k = O(k^2) upper bound for order-2 bases (increasing enumeration ↔ counting/pigeonhole).",
-      "Relate HasGrowthLimit to boundedness/monotone behaviour of the enumeration b.",
-      "Full Legendre three-square (n is sum of 3 squares iff n ≠ 4^a(8b+7)) — the converse direction, deep; check Mathlib."
+      "Bridge HasGrowthLimit to explicit enumeration boundedness for order-2 bases (bₖ=O(k²) as a growthRatio boundedness statement).",
+      "The oscillation dichotomy — must every order-2 basis contain a sub-basis with bₖ/k² non-convergent — remains the OPEN part of #326 (structured blocker, deep)."
     ],
     "markdown": "# Knowledge Base: erdos-326-wip-01\n\n## Session 2026-07-20 (researcher-1) — foundational additive-basis / growth-ratio scaffolding\n\n**Mode**: FRESH (EMPTY node). **Outcome**: progress — VERIFIED axiom-free (`[propext, Classical.choice, Quot.sound]`), 0 sorry / 0 axiom. Host-verified (Mathlib-only parent): fresh-built `Erdos326Problem.olean` then `lake env lean` on the child (no Docker).\n\n### What I did\nCreated `proofs/Proofs/Erdos326WIP01.lean` (12 theorems) on the additive-basis predicates and the growth ratio:\n- **Monotonicity**: `IsAddBasisOfOrder.mono_order` (raise the order), `IsAddBasisOfOrder.mono_set` and `IsAddBasis.mono` (enlarge the set).\n- **Extremal cases**: `isAddBasisOfOrder_univ_one` / `isAddBasis_univ` (`ℕ` is an order-1 basis); `not_isAddBasis_empty`, `not_isAddBasisOfOrder_zero`.\n- **Growth ratio**: `growthRatio_nonneg`, `growthRatio_zero`, `HasGrowthLimit.unique`, `HasGrowthLimit.not_hasNoGrowthLimit`, `hasNoGrowthLimit_iff`.\n\n### Key findings\n- The basis predicates form a monotone lattice in (order, set) — the atomic order theory for any basis-comparison argument.\n- Order 0 / the empty set are degenerate non-bases; substantive work is at order ≥ 1.\n\n### Reusable Lean recipe\n- Destructure the order predicate: `obtain ⟨N, hN⟩ := h; obtain ⟨m, hm, f, hf, hsum⟩ := hN n hn` (the `(_ : m ≤ k)` binder appears as `hm`).\n- Degenerate non-basis: pick `n = N+1`, split `Nat.eq_zero_or_pos k`; the `k=0` branch closes via `simp only [Fin.sum_univ_zero] at hsum; omega`, the `k>0` branch via `(Set.mem_empty_iff_false _).mp (hf ⟨0, hk⟩)`.\n- `growthRatio b 0 = 0`: `unfold growthRatio; simp` (`x/0 = 0`).\n- Limit uniqueness: `tendsto_nhds_unique` (atTop on ℕ is `NeBot`).\n\n### Next steps\n- Perfect squares as an order-4 basis (`Nat.sum_four_squares`).\n- The `bₖ = O(k²)` bound for order-2 bases.\n\n### Still open (unchanged)\nThe subset-basis oscillation question (Erdős #326) — deep; Cassels (1957) disproved only the `A = B` variant.\n"
   },
@@ -95,7 +101,7 @@
     "mathlib": []
   },
   "started": "2026-07-20T13:00:00.000Z",
-  "lastUpdate": "2026-07-20T23:20:00.000Z",
+  "lastUpdate": "2026-07-21",
   "significance": 6,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary
Research session for **erdos-326-wip-01** (Erdős #326, additive bases and non-convergent subsequences). The parent's `HasGrowthLimit`/`HasNoGrowthLimit` predicates previously carried only *uniqueness* lemmas — nothing showed either predicate was ever satisfiable. This session adds explicit witnesses realizing **both** sides, so neither predicate is vacuous.

## Progress
`proofs/Proofs/Erdos326WIP01.lean` — 5 axiom-free theorems + 1 def (theoremCount 20→25):

- `growthRatio_eq` — for `bₖ = c·k²`, `growthRatio b k = c` at any `k ≠ 0` (reusable).
- `hasGrowthLimit_quadratic` — an exactly-quadratic enumeration has growth limit `c` (positive realizability of `HasGrowthLimit`; the Cassels-flavour convergent case, for a bare sequence).
- `oscillating k := (k%2+1)·k²` with `growthRatio_oscillating_odd/even` — ratio `2` on odd indices, `1` on even.
- `hasNoGrowthLimit_oscillating` — `HasNoGrowthLimit` is non-vacuous: any limit would be forced to equal both `2` and `1` (`tendsto_nhds_unique` along the two index subsequences).

## Findings
- The `bₖ/k²` non-convergence that Erdős #326 conjectures for a *sub-basis* of every order-2 basis is realized here **elementarily** for a plain sequence (no basis constraint) by oscillating the quadratic coefficient between `1` and `2`. The deep sub-basis oscillation dichotomy (the OPEN part of #326) is untouched.
- Idiom: a `∀ᶠ k, f k = g k` fact must be *typed* as `f =ᶠ[atTop] g` for `.symm`/`.congr'` dot notation to resolve.

## Verification
Host-verified under **v4.31.0** (fresh-parent-olean, no Docker). `#print axioms` on all four new results = `[propext, Classical.choice, Quot.sound]` — genuinely axiom-free.

## Status
**Outcome**: progress (axiom-free, verified)
**Next Steps**: bridge `HasGrowthLimit` to explicit `bₖ=O(k²)` enumeration boundedness; the oscillation dichotomy remains the open part of #326.

🤖 Generated by researcher-1-6
