### PR TITLE
Enrich automorphic-number-oq-01-oq-03-oq-02: extend Part I to cover stranded TenAdic setup

### DIFF
--- a/src/data/proofs/automorphic-number-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-03-oq-02/meta.json
@@ -152,9 +152,9 @@
     {
       "id": "padic-idempotents",
       "title": "Part I: The idempotents of ℤ_[p] and of ℤ₁₀ = ℤ₂ × ℤ₅",
-      "startLine": 48,
+      "startLine": 42,
       "endLine": 73,
-      "summary": "padicInt_idem_eq_zero_or_one: ℤ_[p] is an integral domain, so e·e=e gives e·(e−1)=0 and e ∈ {0,1}. TenAdic.idem_iff: an idempotent of a product is a pair of idempotents (Prod.ext_iff on multiplication), so the idempotents of ℤ₂ × ℤ₅ are exactly the four pairs (0,0),(1,0),(0,1),(1,1).",
+      "summary": "Setup: the Fact instances for the primes 2 and 5 and the abbreviation TenAdic := ℤ_[2] × ℤ_[5] modelling the 10-adic integers (legitimate since 10 = 2·5). padicInt_idem_eq_zero_or_one: ℤ_[p] is an integral domain, so e·e=e gives e·(e−1)=0 and e ∈ {0,1}. TenAdic.idem_iff: an idempotent of a product is a pair of idempotents (Prod.ext_iff on multiplication), so the idempotents of ℤ₂ × ℤ₅ are exactly the four pairs (0,0),(1,0),(0,1),(1,1).",
       "mathContext": "The 10-adic integers, modelled as ℤ₂ × ℤ₅, are a product of two local integral domains, hence have 2² = 4 idempotents — the limit set of the automorphic towers."
     },
     {


### PR DESCRIPTION
## Uncovered-declaration re-anchor: automorphic-number-oq-01-oq-03-oq-02

Three setup declarations sat before the first section's `startLine` (48),
stranded outside every section:

- `instance : Fact (Nat.Prime 2)` (L42) and `instance : Fact (Nat.Prime 5)` (L43)
- `abbrev TenAdic := ℤ_[2] × ℤ_[5]` (L46) — the very 10-adic type Part I studies

### Fix (coverage/accuracy only)

Extended **Part I** (`padic-idempotents`) `startLine` 48 → **42** so it covers
the ambient `Fact` prime instances and the `TenAdic` model, and noted them at the
head of the section summary. The section title already named `ℤ₁₀ = ℤ₂ × ℤ₅`, so
this only aligns the anchor with the content it already describes.

No `status` / `badge` / `axiomCount` / prose-claim changes. Verified with a
private uncovered-declaration scan (comment-stripping, monster-filtering)
reporting **0 uncovered declarations** and JSON validity.
