### PR TITLE
Enrich little-wedderburn-oq-02-oq-02: extend fiber section over stranded setup instances

### DIFF
--- a/src/data/proofs/little-wedderburn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/little-wedderburn-oq-02-oq-02/meta.json
@@ -109,9 +109,9 @@
     {
       "id": "fiber",
       "title": "Conjugate Count: deg Roots per Minimal Polynomial",
-      "startLine": 46,
+      "startLine": 40,
       "endLine": 91,
-      "summary": "Nfield defines the degree-d count via the minimal-polynomial image. card_minpoly_fiber proves the elements of GF(p^m) sharing a given minimal polynomial g number exactly deg g, identifying the fibre with the (separable, splitting) root set of g. mdeg_dvd shows every such degree divides m.",
+      "summary": "Setup: the ambient prime p (variable [Fact p.Prime]) and the noncomputable DecidableEq/Fintype instances on (ZMod p)[X] and GaloisField p m that make the Finset image/filter counts below well-defined. Nfield defines the degree-d count via the minimal-polynomial image. card_minpoly_fiber proves the elements of GF(p^m) sharing a given minimal polynomial g number exactly deg g, identifying the fibre with the (separable, splitting) root set of g. mdeg_dvd shows every such degree divides m.",
       "mathContext": "$\\#\\{y : \\mathrm{minpoly}\\,y = g\\} = \\deg g$, and $\\deg g \\mid m$."
     },
     {


### PR DESCRIPTION
## Uncovered-declaration re-anchor: little-wedderburn-oq-02-oq-02

Three `noncomputable local instance` declarations sat in the gap between the
docstring section (ends L34) and the fiber section (starts L46), stranded
outside every section:

- `instDecEqPoly : DecidableEq ((ZMod p)[X])` (L42)
- `instFintypeGF : Fintype (GaloisField p m)` (L43)
- `instDecEqGF : DecidableEq (GaloisField p m)` (L44)

These instances exist precisely to make the `Finset.image`/`filter`/`card`
counts in `Nfield` and `card_minpoly_fiber` well-defined.

### Fix (coverage/accuracy only)

Extended the **fiber** section `startLine` 46 → **40** so it covers the ambient
`variable (p) [Fact p.Prime]` and the three decidability/finiteness instances,
and noted them at the head of the section summary.

No `status` / `badge` / `axiomCount` / prose-claim changes. Verified with a
private uncovered-declaration scan reporting **0 uncovered declarations** and
JSON validity.
