### PR TITLE
audit: erdos-635 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15219,8 +15219,8 @@
     },
     "erdos-635": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:04Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T18:00:31Z",
       "result": "clean"
     },
     "erdos-636": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-635 (reserve mode)

**Result: CLEAN.** Verified `meta.json` vs `proofs/Proofs/Erdos635Problem.lean`: axiomCount 1 ✓, sorries 0 ✓, theoremCount 15 ✓, 0 native_decide ✓, no True-stubs.

- Sole axiom `erdos_635 : ErdosConjecture635` axiomatizes the OPEN conjecture. `ErdosConjecture635` is a genuine statement (`∀ε>0 ∀t≥1 ∃N₀ ∀N≥N₀, f(N,t)≤(1/2+ε)·N`) — not a `¬∃`/vacuous-True masking form. Disclosed: docstring "axiomatized as it remains open", status `axiomatized`, badge `axiom`, erdosProblemStatus `open`.
- 15 theorems are genuine, incl. the fully-solved t=1 case (`f_t1`: f(N,1)=(N+1)/2, `oddSet` optimal), monotonicity, and density lemmas.
- Prose honest: "completely resolves the t=1 case" is accurate (t=1 proved); conclusion states "The general conjecture remains open." originalContributions mark each theorem "(proved)" and the conjecture a "definition". No overclaim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)