### PR TITLE
audit: erdos-638 fix stale 'axiomatized' status

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15241,9 +15241,9 @@
     },
     "erdos-638": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:34Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T18:06:03Z",
+      "result": "issues-fixed"
     },
     "erdos-639": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-638/meta.json
+++ b/src/data/proofs/erdos-638/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/638",
-    "status": "axiomatized",
+    "status": "open",
     "proofRepoPath": "Proofs/Erdos638Problem.lean",
     "tags": [
       "erdos",


### PR DESCRIPTION
Reserve-mode audit of erdos-638.

**Result: issues-fixed (LOW).** The file is genuinely axiom-free and substantive — 0 axioms / 0 sorries / 0 native_decide / 10 real theorems (8 public + 2 private), including the full n-colour triangle Ramsey theorem proved by induction, plus positive (`complete_omega_finite_ramsey`) and negative (`complete_omega_no_nat_ramsey`, via a min-coloring counterexample) partial results. Counts reconcile.

**Fix:** `status` was still `"axiomatized"` despite `axiomCount: 0` — stale from the disclosed axiom→wip upgrade (`assumptions` prose already documents it). Set `status` → `"open"` to match badge `wip` and `erdosProblemStatus: "open"`. The open conjecture `ErdosProblem638` is correctly left as a `def` (not axiomatized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)