### PR TITLE
audit: erdos-63 issues-found (#40765)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15168,9 +15168,9 @@
     },
     "erdos-63": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:34Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T18:09:13Z",
+      "result": "issues-found"
     },
     "erdos-630": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Reserve-mode audit of erdos-63.

**Result: issues-found (MEDIUM)** — filed #40765. Counts reconcile (1 axiom / 0 sorries / 4 theorems / 224 lines), but the axiomatized `erdos_63_statement` quantifies the 2^n-cycle over an **arbitrary** graph `H : SimpleGraph S` unconnected to `G`'s adjacency, making it trivially/vacuously true — it does not formalize the Erdős #63 theorem it is presented as. Consistent (not kernel-unsound), but a formalization-faithfulness overclaim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)