### PR TITLE
Enrich descartes-rule-of-signs-oq-02-oq-04: cover stranded midpoint helper lemmas

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-04/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-04/meta.json
@@ -90,9 +90,9 @@
     {
       "id": "soundness",
       "title": "Containment and Soundness",
-      "startLine": 116,
+      "startLine": 107,
       "endLine": 175,
-      "summary": "vasIsolate_isolated_subset (each isolated interval ⊆ (a,b]); vasIsolate_isolated_one_root (each isolated interval is nondegenerate and holds exactly one root).",
+      "summary": "Opens the Correctness section with the two midpoint helper lemmas lt_mid / mid_lt (a < (a+b)/2 < b for a < b), used throughout the bisection arguments. vasIsolate_isolated_subset (each isolated interval ⊆ (a,b]); vasIsolate_isolated_one_root (each isolated interval is nondegenerate and holds exactly one root).",
       "mathContext": "Induction over the bisection tree, discharging leaves with the unique-root certificate."
     },
     {


### PR DESCRIPTION
## Uncovered-declaration re-anchor: descartes-rule-of-signs-oq-02-oq-04

Two private midpoint helper lemmas sat in the gap between the `algorithm`
section (ended L105) and the `soundness` section (started L116, at its first
public theorem), stranded outside every section:

- `lt_mid` (L112) — `a < (a+b)/2` for `a < b`
- `mid_lt` (L114) — `(a+b)/2 < b` for `a < b`

These feed the bisection-tree containment/soundness proofs.

### Fix (coverage/accuracy only)

Extended the **soundness** section `startLine` 116 → **107** so it opens at the
`section Correctness` banner and covers both helpers, and noted them at the head
of the summary.

No `status` / `badge` / `axiomCount` / prose changes. Verified with a private
uncovered-declaration scan reporting **0 uncovered declarations** and JSON
validity.
