### PR TITLE
Fix erdos-63: tie axiomatized 2^n-cycle statement to G's adjacency

### DIFF
--- a/proofs/Proofs/Erdos63Problem.lean
+++ b/proofs/Proofs/Erdos63Problem.lean
@@ -95,6 +95,16 @@ def InfGraph.inducedSubgraph (G : InfGraph V) (S : Set V) : InfGraph S where
   symm := fun u v h => G.symm u.val v.val h
   loopless := fun v => G.loopless v.val
 
+/-- An `InfGraph` `G` contains a cycle of length `k ≥ 3` if there are `k`
+    distinct vertices `vs 0, …, vs (k-1)` forming a cycle **via `G`'s own
+    adjacency** (each consecutive pair, cyclically, is a `G`-edge).
+
+    Note the cycle is required in `G` itself, not in an arbitrary graph on a
+    vertex subset — this is what ties the statement to `G`. -/
+def InfGraph.ContainsCycleLength (G : InfGraph V) (k : ℕ) : Prop :=
+  ∃ (hk : k ≥ 3) (vs : Fin k → V), Function.Injective vs ∧
+    ∀ i : Fin k, G.Adj (vs i) (vs (Fin.succMod (by omega : 0 < k) i))
+
 /- 
 **de Bruijn-Erdős Theorem**:
 If an infinite graph G has infinite chromatic number, then for every k,
@@ -140,12 +150,11 @@ Every graph with infinite chromatic number contains a cycle of length 2^n
 for infinitely many n.
 
 The statement is formalized as: for every N, there exists n ≥ N such that
-the graph contains a cycle of length 2^n.
+`G` itself contains a cycle of length 2^n (via `G`'s adjacency).
 -/
 def erdos_63_statement (G : InfGraph V) : Prop :=
   G.HasInfiniteChromaticNumber →
-    ∀ N : ℕ, ∃ n ≥ N, ∃ (S : Finset V) (H : SimpleGraph S),
-      ContainsCycleLength H (2^n)
+    ∀ N : ℕ, ∃ n ≥ N, G.ContainsCycleLength (2^n)
 
 /--
 **Main Theorem**: Erdős Problem 63 is true.
@@ -167,8 +176,7 @@ arbitrarily large powers of 2.
 -/
 theorem infinitely_many_power_cycles (G : InfGraph V)
     (hχ : G.HasInfiniteChromaticNumber) :
-    ∀ N : ℕ, ∃ n ≥ N, ∃ (S : Finset V) (H : SimpleGraph S),
-      ContainsCycleLength H (2^n) :=
+    ∀ N : ℕ, ∃ n ≥ N, G.ContainsCycleLength (2^n) :=
   erdos_63_theorem G hχ
 
 /- 
@@ -184,8 +192,7 @@ such as n² or even n log n.
 -/
 def generalized_conjecture (f : ℕ → ℕ) : Prop :=
   ∀ (W : Type) (G : InfGraph W), G.HasInfiniteChromaticNumber →
-    ∀ N : ℕ, ∃ n ≥ N, ∃ (S : Finset W) (H : SimpleGraph S),
-      ContainsCycleLength H (f n)
+    ∀ N : ℕ, ∃ n ≥ N, G.ContainsCycleLength (f n)
 
 /-- Squares form a strictly increasing sequence (for reference). -/
 theorem squares_strictly_increasing (n : ℕ) : (n + 2)^2 < (n + 3)^2 := by


### PR DESCRIPTION
## Summary

Fixes the gallery integrity issue in erdos-63: the axiomatized statement of the solved Erdős #63 result was **trivially/vacuously true** because it asserted nothing about cycles *in G*.

## The defect

`erdos_63_statement` concluded with an existential over an **arbitrary** graph on a vertex subset:

```lean
∃ (S : Finset V) (H : SimpleGraph S), ContainsCycleLength H (2^n)
```

`H` had no connection to `G` (not `G.inducedSubgraph`, and `G.Adj` never appeared). So the proposition read "for infinitely many n, some graph on some finite vertex set has a 2^n-cycle" — true independent of `G` (take `H` a cycle graph on `2^n` vertices). The axiom captured none of the Erdős #63 content, and the corollary `infinitely_many_power_cycles` inherited the defect.

## The fix

Introduce `InfGraph.ContainsCycleLength` — a cycle of length `k ≥ 3` via **G's own adjacency**:

```lean
def InfGraph.ContainsCycleLength (G : InfGraph V) (k : ℕ) : Prop :=
  ∃ (hk : k ≥ 3) (vs : Fin k → V), Function.Injective vs ∧
    ∀ i : Fin k, G.Adj (vs i) (vs (Fin.succMod (by omega : 0 < k) i))
```

and use it in:
- `erdos_63_statement` → `∀ N, ∃ n ≥ N, G.ContainsCycleLength (2^n)`
- the `infinitely_many_power_cycles` corollary
- the parallel `generalized_conjecture` (same free-`H` defect)

The statement now genuinely says: for infinitely many `n`, `G` itself contains a `2^n`-cycle — matching the meta.json prose and the Liu–Montgomery theorem. The axiom remains consistent (it is the true theorem).

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos63Problem` → **Build succeeded** (axiom type-checks; corollary derives).

Closes #40765
