### PR TITLE
Enrich dissection-of-cubes-oq-02-oq-02: snap Part VI/IX starts to cover tetAngle/octAngle defs

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
@@ -137,14 +137,14 @@
       "id": "cube-zero",
       "title": "Part V: Cube Dehn Invariant is Zero",
       "startLine": 174,
-      "endLine": 181,
+      "endLine": 178,
       "summary": "**Proved.** $D(\\text{cube}) = 12a \\otimes [\\pi/2] = 0$ since $\\pi/2 = (1/2)\\pi$ is a rational multiple of $\\pi$.",
       "mathContext": "$D(\\text{cube}) = 0$ because all 12 cube edges have dihedral angle $\\pi/2$, which is rational $\\times \\pi$."
     },
     {
       "id": "irrational-angles",
       "title": "Part VI-VII: Irrational Angles and Tetrahedron D ≠ 0",
-      "startLine": 187,
+      "startLine": 180,
       "endLine": 252,
       "summary": "Defines `tetAngle = arccos(1/3)`. Niven's theorem (cross-referenced from parent file) shows $\\arccos(1/3)/\\pi \\notin \\mathbb{Q}$, so $[\\arccos(1/3)]$ has infinite order. Flatness of $\\mathbb{R}$ over $\\mathbb{Z}$ (now proved, not assumed) gives $D(\\text{tet}) = 6a \\otimes [\\arccos(1/3)] \\neq 0$.",
       "mathContext": "$\\arccos(1/3)/\\pi$ irrational (Niven) $\\Rightarrow$ $[\\arccos(1/3)]$ has infinite order $\\Rightarrow$ $6a \\otimes [\\arccos(1/3)] \\neq 0$ by flatness."
@@ -153,14 +153,14 @@
       "id": "hilbert-third",
       "title": "Part VIII: Hilbert's Third Problem",
       "startLine": 258,
-      "endLine": 285,
+      "endLine": 282,
       "summary": "**Proved.** $D(\\text{cube}) = 0 \\neq D(\\text{tet})$, so the cube and regular tetrahedron are not scissors congruent.",
       "mathContext": "$D(\\text{cube}) = 0$ and $D(\\text{tet}) \\neq 0 \\Rightarrow$ cube $\\not\\cong_{\\text{sc}}$ tetrahedron."
     },
     {
       "id": "octahedron",
       "title": "Part IX: Octahedron Computation",
-      "startLine": 291,
+      "startLine": 284,
       "endLine": 328,
       "summary": "Uses $\\arccos(-1/3) = \\pi - \\arccos(1/3)$ to show $[\\arccos(-1/3)] = -[\\arccos(1/3)]$. Therefore $D(\\text{oct}) = -D(\\text{tet}) \\neq 0$.",
       "mathContext": "$[\\arccos(-1/3)] = [\\pi] - [\\arccos(1/3)] = -[\\arccos(1/3)]$ since $[\\pi] = 0$."


### PR DESCRIPTION
## Uncovered-declaration re-anchor: dissection-of-cubes-oq-02-oq-02

The two dihedral-angle definitions that open Parts VI and IX drifted outside
every section, because the preceding sections overshot into the following
`-- Part` banners:

- `tetAngle = arccos(1/3)` (L185) — `cube-zero` overshot to L181 (swallowing the
  Part VI banner); `irrational-angles` started at L187
- `octAngle = arccos(-1/3)` (L289) — `hilbert-third` overshot to L285 (swallowing
  the Part IX banner); `octahedron` started at L291

### Fix (coverage/accuracy only)

| Section | Before | After |
|---------|--------|-------|
| cube-zero | 174–181 | **174–178** |
| irrational-angles | 187–252 | **180–252** (Part VI banner) |
| hilbert-third | 258–285 | **258–282** |
| octahedron | 291–328 | **284–328** (Part IX banner) |

Both extended sections' summaries already defined these angles ("Defines
tetAngle = arccos(1/3)" / "Uses arccos(-1/3)"). No `status` / `badge` /
`axiomCount` / prose changes. Verified with a private uncovered-declaration scan
reporting **0 uncovered declarations** and JSON validity.
