### PR TITLE
audit: erdos-629 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15162,8 +15162,8 @@
     },
     "erdos-629": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:35Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T18:14:26Z",
       "result": "clean"
     },
     "erdos-63": {


### PR DESCRIPTION
Reserve-mode audit of erdos-629 (List Chromatic Number of Bipartite Graphs).

**Result: CLEAN.** Counts reconcile: 0 axioms / 7 sorries / 37 theorems / 923 lines / 0 native_decide (75 kernel `decide` = trust-neutral). Honest wip (badge `wip`, open problem): proofStrategy and conclusion explicitly list the 6 proved results and enumerate the sorried hard bounds (n(3)=14, ERT/RS/HMT bounds, K_{n,n}, exponential growth) — no sorried theorem is claimed as proven.

Nit only (not fixed): prose says '8 remaining sorries' while the file has 7 (meta.sorries=7 is correct) — safe-direction understatement, not an overclaim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)