### PR TITLE
Research: erdos-89-wip-01 — general lower bound g(n) ≥ 2 for n ≥ 4 (axiom-free)

### DIFF
--- a/proofs/Proofs/Erdos89WIP01.lean
+++ b/proofs/Proofs/Erdos89WIP01.lean
@@ -675,4 +675,69 @@ arithmetic progression is again not extremal. -/
 theorem minDistinctDistances_four : minDistinctDistances 4 = 2 :=
   le_antisymm minDistinctDistances_four_le_two two_le_minDistinctDistances_four
 
+/-! ## The general lower bound `g(n) ≥ 2` for `n ≥ 4`
+
+The `g(4) ≥ 2` argument above uses only that a single-distance set of four points would
+be four mutually-equidistant points, impossible in the plane (`no_four_equidistant`).  That
+obstruction survives adding more points: any configuration of **at least** four points still
+contains a four-point subset, so it too determines at least two distances.  This upgrades
+`two_le_minDistinctDistances_four` from the single value `n = 4` to the whole linear regime
+`n ≥ 4`, and in particular pins `g(5) ≥ 2`. -/
+
+/-- **General lower bound `numDistinctDistances S ≥ 2` for `|S| ≥ 4`.**  A set of four or
+more points with only a single distinct distance would contain four mutually-equidistant
+points (`no_four_equidistant`), impossible in the plane.  So *every* configuration of at
+least four points determines at least two distances. -/
+theorem two_le_numDistinctDistances_of_four_le_card
+    (S : Finset (EuclideanSpace ℝ (Fin 2))) (hcard : 4 ≤ S.card) :
+    2 ≤ numDistinctDistances S := by
+  by_contra hlt
+  have hlt2 : numDistinctDistances S < 2 := not_le.mp hlt
+  have hge1 := one_le_numDistinctDistances_of_two_le_card S (by omega)
+  have heq1 : numDistinctDistances S = 1 := by omega
+  have hcard1 : (distinctDistances S).card = 1 := heq1
+  obtain ⟨r, hr⟩ := Finset.card_eq_one.mp hcard1
+  have hall : ∀ p ∈ S, ∀ q ∈ S, p ≠ q → Erdos89.dist p q = r := by
+    intro p hp q hq hpq
+    have hmem : Erdos89.dist p q ∈ distinctDistances S := by
+      rw [distinctDistances_eq_image, Finset.mem_image]
+      exact ⟨(p, q), Finset.mem_offDiag.mpr ⟨hp, hq, hpq⟩, rfl⟩
+    rw [hr, Finset.mem_singleton] at hmem
+    exact hmem
+  obtain ⟨T, hTsub, hTcard⟩ := Finset.exists_smaller_set S 4 hcard
+  rw [Finset.card_eq_four] at hTcard
+  obtain ⟨a, b, c, d, hab, hac, had, hbc, hbd, hcd, hTset⟩ := hTcard
+  have ha : a ∈ S := hTsub (by rw [hTset]; simp)
+  have hb : b ∈ S := hTsub (by rw [hTset]; simp)
+  have hc : c ∈ S := hTsub (by rw [hTset]; simp)
+  have hd : d ∈ S := hTsub (by rw [hTset]; simp)
+  exact no_four_equidistant hab
+    (hall a ha b hb hab) (hall a ha c hc hac) (hall a ha d hd had)
+    (hall b hb c hc hbc) (hall b hb d hd hbd) (hall c hc d hd hcd)
+
+/-- **General lower bound `g(n) ≥ 2` for `n ≥ 4`.**  Every `n`-point configuration with
+`n ≥ 4` determines at least two distances
+(`two_le_numDistinctDistances_of_four_le_card`), so the minimum over them is `≥ 2`.  This
+subsumes `two_le_minDistinctDistances_four` and pins the floor of Erdős's function across the
+whole linear regime. -/
+theorem two_le_minDistinctDistances {n : ℕ} (hn : 4 ≤ n) :
+    2 ≤ minDistinctDistances n := by
+  obtain ⟨S₀, hS₀⟩ := exists_card_eq n
+  have hne : {numDistinctDistances S |
+      (S : Finset (EuclideanSpace ℝ (Fin 2))) (_ : S.card = n)}.Nonempty :=
+    ⟨numDistinctDistances S₀, S₀, hS₀, rfl⟩
+  obtain ⟨S, hScard, hSeq⟩ := Nat.sInf_mem hne
+  show 2 ≤ minDistinctDistances n
+  unfold minDistinctDistances
+  rw [← hSeq]
+  exact two_le_numDistinctDistances_of_four_le_card S (by rw [hScard]; exact hn)
+
+/-- **Lower bound `g(5) ≥ 2`.**  Immediate from the general floor
+`two_le_minDistinctDistances`: a five-point set contains four points, which cannot be
+mutually equidistant in the plane.  (The matching upper bound `g(5) ≤ 2` is realized by the
+regular pentagon — two distinct distances, side and diagonal — and remains to be
+formalized.) -/
+theorem two_le_minDistinctDistances_five : 2 ≤ minDistinctDistances 5 :=
+  two_le_minDistinctDistances (by norm_num)
+
 end Erdos89

--- a/proofs/Proofs/Erdos89WIP01.lean
+++ b/proofs/Proofs/Erdos89WIP01.lean
@@ -704,7 +704,7 @@ theorem two_le_numDistinctDistances_of_four_le_card
       exact ⟨(p, q), Finset.mem_offDiag.mpr ⟨hp, hq, hpq⟩, rfl⟩
     rw [hr, Finset.mem_singleton] at hmem
     exact hmem
-  obtain ⟨T, hTsub, hTcard⟩ := Finset.exists_smaller_set S 4 hcard
+  obtain ⟨T, hTsub, hTcard⟩ := Finset.exists_subset_card_eq (s := S) (n := 4) hcard
   rw [Finset.card_eq_four] at hTcard
   obtain ⟨a, b, c, d, hab, hac, had, hbc, hbd, hcd, hTset⟩ := hTcard
   have ha : a ∈ S := hTsub (by rw [hTset]; simp)

--- a/research/problems/erdos-89-wip-01/knowledge.md
+++ b/research/problems/erdos-89-wip-01/knowledge.md
@@ -174,3 +174,39 @@ arithmetic re-ordering where `linarith` would need exact atom matches.
   pentagon realizes exactly 2 distances → g(5) ≤ 2). This is the natural next exact value.
 - `√n × √n` grid upper bound toward `g(n) = Θ(n/√(log n))` (deep, number-theoretic);
   Guth–Katz `Ω(n/log n)` lower bound stays imported.
+
+## Session 2026-07-21 (researcher-1) — general lower bound g(n) ≥ 2 for n ≥ 4
+
+**Mode**: build on g(4)=2. **Outcome**: progress — upgraded the `g(4) ≥ 2` lower bound
+from a single value to the **whole linear regime** `n ≥ 4`. Host-verified v4.31
+(docker-build exit 0; `#print axioms` = `[propext, Classical.choice, Quot.sound]` on all
+three new theorems; no sorry/native_decide).
+
+The `two_le_minDistinctDistances_four` proof used only that a single-distance 4-point set
+would be four mutually-equidistant points — `no_four_equidistant`, impossible in ℝ². That
+obstruction is monotone in the point count: any set with `4 ≤ |S|` contains a 4-point subset,
+so it too determines `≥ 2` distances.
+
+- `two_le_numDistinctDistances_of_four_le_card`: `4 ≤ S.card ⟹ 2 ≤ numDistinctDistances S`.
+  If `numDistinctDistances S = 1` all off-diagonal pairs share one value `r`; extract a
+  4-element subset `T ⊆ S` (`Finset.exists_subset_card_eq`, then `Finset.card_eq_four`) and
+  feed its six pairwise equalities to `no_four_equidistant`. Same body as the g(4) proof but
+  over an arbitrary large set rather than the sInf minimizer.
+- `two_le_minDistinctDistances {n} (hn : 4 ≤ n)`: `2 ≤ minDistinctDistances n`. Take the
+  achieved sInf minimizer `S` (`Nat.sInf_mem` on the nonempty witness set), `S.card = n ≥ 4`,
+  apply the card lemma.
+- `two_le_minDistinctDistances_five`: `2 ≤ minDistinctDistances 5` (corollary, `by norm_num`).
+
+**Gotcha**: `Finset.exists_smaller_set s i h` was renamed — v4.31 has
+`Finset.exists_subset_card_eq (hn : n ≤ s.card) : ∃ t ⊆ s, t.card = n` (implicit `s`, `n`).
+
+Now 23 theorems, 0 sorry, 0 axiom.
+
+### Next
+- **g(5) = 2**: lower bound `g(5) ≥ 2` is now done; the matching upper bound `g(5) ≤ 2`
+  is realized by the regular pentagon (its 10 pairs take exactly 2 values: side
+  `s²=(5−√5)/2` and diagonal `d²=(5+√5)/2`). Formalizing needs pentagon coordinates
+  (cos/sin 72° with nested radicals `√(10±2√5)`) and the cross-term `√(10+2√5)·√(10−2√5)=4√5`
+  — heavy but self-contained; this closes the third exact value.
+- `√n × √n` grid toward `g(n) = Θ(n/√(log n))` (deep, number-theoretic); Guth–Katz
+  `Ω(n/log n)` lower bound stays imported.

--- a/src/data/research/problems/erdos-89-wip-01.json
+++ b/src/data/research/problems/erdos-89-wip-01.json
@@ -20,10 +20,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-09T17:33:18-07:00",
-    "iteration": 2,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "iteration": 3,
+    "focus": "General lower bound g(n) ≥ 2 (n ≥ 4) proved; g(5) ≥ 2 as corollary.",
     "blockers": [],
-    "nextAction": "Exact g(4): the unit square gives 2 distinct distances (side + diagonal). Determine and prove g(4)=2. Or the sqrt(n)-grid upper bound (deep, number-theoretic).",
+    "nextAction": "Upper bound g(5) ≤ 2 via regular pentagon (2 distinct distances: side and diagonal) to close exact value g(5)=2. Heavy: nested-radical coordinates cos/sin 72°.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Exact values pinned: g(0)=g(1)=0, g(2)=1, g(3)=1, g(4)=2 (minDistinctDistances_four, axiom-free). Linear upper bound g(n) ≤ n−1 (AP) and the deep Guth–Katz Ω(n/log n) stays imported. Next: g(5) (lower bound needs ruling out a 1- or few-distance 5-set) and the √n×√n grid toward Θ(n/√(log n)).",
+    "progressSummary": "Exact values pinned: g(0)=g(1)=0, g(2)=1, g(3)=1, g(4)=2 (axiom-free). General lower bound g(n) ≥ 2 for all n ≥ 4 (two_le_minDistinctDistances), subsuming g(4)≥2 and pinning g(5)≥2. Linear upper bound g(n) ≤ n−1 (AP); deep Guth–Katz Ω(n/log n) imported. Next: g(5) UPPER bound g(5) ≤ 2 via the regular pentagon (side + diagonal = 2 distances) to close g(5)=2 — needs pentagon coordinate/nested-radical distance computation; and the √n×√n grid toward Θ(n/√(log n)).",
     "builtItems": [
       "Erdos89.dist_pos_of_ne in Erdos89WIP01.lean",
       "Erdos89.distinctDistances_eq_image (filter redundant) in Erdos89WIP01.lean",
@@ -55,7 +55,10 @@
       "dist_eqp01/02/12 all three pairwise distances = 1 (via Real.sq_sqrt for sqrt(3)^2=3)",
       "numDistinctDistances_eqTri = 1; minDistinctDistances_three: exact g(3)=1",
       "minDistinctDistances_four (Erdos89WIP01.lean): g(4)=2, axiom-free (propext/Classical.choice/Quot.sound only), host-verified v4.31.",
-      "no_four_equidistant, two_le_minDistinctDistances_four, minDistinctDistances_four_le_two, unitSquare + 6 sqpᵢ_ne + unitSquare_card + 6 dist_sqᵢⱼ (Erdos89WIP01.lean): unit-square upper bound and Gram/dimension lower bound for g(4)."
+      "no_four_equidistant, two_le_minDistinctDistances_four, minDistinctDistances_four_le_two, unitSquare + 6 sqpᵢ_ne + unitSquare_card + 6 dist_sqᵢⱼ (Erdos89WIP01.lean): unit-square upper bound and Gram/dimension lower bound for g(4).",
+      "two_le_numDistinctDistances_of_four_le_card in Erdos89WIP01.lean — |S|≥4 ⟹ numDistinctDistances S ≥ 2 (extract 4-subset via Finset.exists_subset_card_eq, then no_four_equidistant)",
+      "two_le_minDistinctDistances in Erdos89WIP01.lean — g(n) ≥ 2 for n ≥ 4",
+      "two_le_minDistinctDistances_five in Erdos89WIP01.lean — g(5) ≥ 2 corollary"
     ],
     "insights": [
       "distinctDistances S filters (·>0) over the off-diagonal image, but every off-diagonal pair (p≠q) already has ‖p−q‖>0, so the filter is redundant: distinctDistances S = S.offDiag.image (dist · ·). This removes the awkward filter for all downstream cardinality reasoning.",
@@ -67,7 +70,8 @@
       "g(3)=1 EXACT via equilateral triangle, strictly below the collinear-AP upper bound g(3)<=2, so the arithmetic progression is NOT extremal at n=3. Lower bound g(3)>=1 from one_le_numDistinctDistances_of_two_le_card + Nat.sInf_mem (nonempty witness eqTri).",
       "Distance-computation technique: dist_eqPts closed form via dist_eq_norm + EuclideanSpace.dist_eq + Fin.sum_univ_two + sq_abs; equilateral coords sqrt(3)^2=3 via Real.sq_sqrt; distinctDistances subset {1} by rcases over the 3x3 vertex pairs (diagonal killed by absurd rfl hne, off-diagonal by dist_eqpXX + dist_comm for reversed order).",
       "g(4) = 2 exactly (minDistinctDistances_four): second exact value of Erdős's distinct-distance function. Upper bound g(4) ≤ 2 from the unit square {(0,0),(1,0),(0,1),(1,1)} (distances {1, √2}); lower bound g(4) ≥ 2 because no 4 points in ℝ² are mutually equidistant. Strictly below the collinear-AP bound g(4) ≤ 3 — the AP is again not extremal (as at n=3).",
-      "no_four_equidistant: four points at a common positive pairwise distance r give three difference vectors (b−a,c−a,d−a) of norm r with pairwise inner product r²/2 (from ‖x−y‖²=2r²−2⟨x,y⟩=r²), a positive-definite Gram matrix ⟹ linearly independent ⟹ finrank ≥ 3, contradicting finrank ℝ (EuclideanSpace ℝ (Fin 2)) = 2. Linear independence extracted by taking inner products of Σgᵢ·vᵢ=0 against u,v,w and solving the Gram system via linear_combination (sum ⟹ Σg=0; each ⟹ (r²/2)gᵢ=0)."
+      "no_four_equidistant: four points at a common positive pairwise distance r give three difference vectors (b−a,c−a,d−a) of norm r with pairwise inner product r²/2 (from ‖x−y‖²=2r²−2⟨x,y⟩=r²), a positive-definite Gram matrix ⟹ linearly independent ⟹ finrank ≥ 3, contradicting finrank ℝ (EuclideanSpace ℝ (Fin 2)) = 2. Linear independence extracted by taking inner products of Σgᵢ·vᵢ=0 against u,v,w and solving the Gram system via linear_combination (sum ⟹ Σg=0; each ⟹ (r²/2)gᵢ=0).",
+      "General lower bound g(n) ≥ 2 for all n ≥ 4 (two_le_minDistinctDistances): the no_four_equidistant obstruction from the g(4) proof survives adding points, since any ≥4-point set contains a 4-point subset. Subsumes g(4)≥2 and pins g(5)≥2. Axiom-free."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for **erdos-89-wip-01** (completing the Erdős #89 distinct-distances formalization). Upgrades the existing exact-value lower bound `g(4) ≥ 2` to a **general lower bound `g(n) ≥ 2` for every `n ≥ 4`**, and derives `g(5) ≥ 2` as a corollary.

## Progress
Three new axiom-free theorems in `proofs/Proofs/Erdos89WIP01.lean`:

- `two_le_numDistinctDistances_of_four_le_card` — `4 ≤ |S| ⟹ 2 ≤ numDistinctDistances S`.
- `two_le_minDistinctDistances` — `4 ≤ n ⟹ 2 ≤ minDistinctDistances n` (i.e. `g(n) ≥ 2`).
- `two_le_minDistinctDistances_five` — `g(5) ≥ 2` (corollary).

## Findings
- The `g(4) ≥ 2` proof (`two_le_minDistinctDistances_four`) relied only on `no_four_equidistant` (no four mutually-equidistant points in ℝ²). That obstruction is monotone in the point count: any configuration with `|S| ≥ 4` contains a 4-point subset, so it too determines at least two distances. This generalizes the single value `n = 4` to the whole linear regime `n ≥ 4`, subsuming `two_le_minDistinctDistances_four`.
- Extraction of the 4-point subset uses `Finset.exists_subset_card_eq` (v4.31; the older `Finset.exists_smaller_set` was removed).
- The matching upper bound `g(5) ≤ 2` is realized by the regular pentagon (its 10 pairwise distances take exactly 2 values, side and diagonal); formalizing it needs nested-radical pentagon coordinates and is recorded as the next step.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.Erdos89WIP01` — exit 0 (v4.31).
- `#print axioms` on all three theorems = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. 0 sorry, 0 axiom, no `native_decide`.

## Status
**Outcome**: progress
**Next Steps**: upper bound `g(5) ≤ 2` via the regular pentagon to close the exact value `g(5) = 2`; `√n × √n` grid toward `Θ(n/√(log n))` (deep). Guth–Katz `Ω(n/log n)` stays imported.

🤖 Generated by researcher-1
