### PR TITLE
Fix: erdos-63 tie 2^n-cycle to G's adjacency (#40765)

### DIFF
--- a/proofs/Proofs/Erdos63Problem.lean
+++ b/proofs/Proofs/Erdos63Problem.lean
@@ -95,6 +95,13 @@ def InfGraph.inducedSubgraph (G : InfGraph V) (S : Set V) : InfGraph S where
   symm := fun u v h => G.symm u.val v.val h
   loopless := fun v => G.loopless v.val
 
+/-- `G` contains a cycle of length `k ≥ 3` **using its own adjacency**: an
+injective tuple of `k` vertices, consecutive (cyclically) ones adjacent in `G`.
+This ties the cycle to `G`, unlike an arbitrary graph on a vertex subset. -/
+def InfGraph.ContainsCycleLength (G : InfGraph V) (k : ℕ) : Prop :=
+  ∃ (_ : k ≥ 3) (vs : Fin k → V), Function.Injective vs ∧
+    ∀ i : Fin k, G.Adj (vs i) (vs (Fin.succMod (by omega : 0 < k) i))
+
 /- 
 **de Bruijn-Erdős Theorem**:
 If an infinite graph G has infinite chromatic number, then for every k,
@@ -144,8 +151,7 @@ the graph contains a cycle of length 2^n.
 -/
 def erdos_63_statement (G : InfGraph V) : Prop :=
   G.HasInfiniteChromaticNumber →
-    ∀ N : ℕ, ∃ n ≥ N, ∃ (S : Finset V) (H : SimpleGraph S),
-      ContainsCycleLength H (2^n)
+    ∀ N : ℕ, ∃ n ≥ N, G.ContainsCycleLength (2^n)
 
 /--
 **Main Theorem**: Erdős Problem 63 is true.
@@ -167,8 +173,7 @@ arbitrarily large powers of 2.
 -/
 theorem infinitely_many_power_cycles (G : InfGraph V)
     (hχ : G.HasInfiniteChromaticNumber) :
-    ∀ N : ℕ, ∃ n ≥ N, ∃ (S : Finset V) (H : SimpleGraph S),
-      ContainsCycleLength H (2^n) :=
+    ∀ N : ℕ, ∃ n ≥ N, G.ContainsCycleLength (2^n) :=
   erdos_63_theorem G hχ
 
 /- 
@@ -184,8 +189,7 @@ such as n² or even n log n.
 -/
 def generalized_conjecture (f : ℕ → ℕ) : Prop :=
   ∀ (W : Type) (G : InfGraph W), G.HasInfiniteChromaticNumber →
-    ∀ N : ℕ, ∃ n ≥ N, ∃ (S : Finset W) (H : SimpleGraph S),
-      ContainsCycleLength H (f n)
+    ∀ N : ℕ, ∃ n ≥ N, G.ContainsCycleLength (f n)
 
 /-- Squares form a strictly increasing sequence (for reference). -/
 theorem squares_strictly_increasing (n : ℕ) : (n + 2)^2 < (n + 3)^2 := by

--- a/src/data/proofs/erdos-63/meta.json
+++ b/src/data/proofs/erdos-63/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/63",
     "erdosProblemStatus": "solved",
     "axiomCount": 1,
-    "lineCount": 224,
+    "lineCount": 228,
     "prerequisites": [
       "Infinite graph theory",
       "Cycle lengths in graphs",
@@ -146,7 +146,7 @@
       "Finset"
     ],
     "namespace": "Erdos63",
-    "lineCount": 224,
+    "lineCount": 228,
     "axiomCount": 1,
     "theoremCount": 4,
     "definitionCount": 14,


### PR DESCRIPTION
## Fix: erdos-63 axiomatized statement now ties the 2^n-cycle to G

Closes #40765.

### Problem
The axiomatized `erdos_63_statement` quantified the 2^n-cycle over an
**arbitrary** graph `H : SimpleGraph S` unconnected to `G`'s adjacency:

```lean
∀ N, ∃ n ≥ N, ∃ (S : Finset V) (H : SimpleGraph S), ContainsCycleLength H (2^n)
```

This is trivially/vacuously true and formalizes none of the Erdős #63 content
(the auditor's finding — consistent, not kernel-unsound, but a
formalization-faithfulness overclaim). `infinitely_many_power_cycles` and
`generalized_conjecture` inherited the same defect.

### Fix
Added an `InfGraph.ContainsCycleLength` predicate that expresses the cycle via
`G`'s **own** adjacency (injective `vs : Fin k → V`, consecutive vertices
adjacent in `G`), mirroring the existing `SimpleGraph.ContainsCycleLength`:

```lean
def InfGraph.ContainsCycleLength (G : InfGraph V) (k : ℕ) : Prop :=
  ∃ (_ : k ≥ 3) (vs : Fin k → V), Function.Injective vs ∧
    ∀ i : Fin k, G.Adj (vs i) (vs (Fin.succMod (by omega : 0 < k) i))
```

`erdos_63_statement`, the corollary, and `generalized_conjecture` now use
`G.ContainsCycleLength (2^n)` — the cycle lives in `G`.

### Verification
- `./proofs/scripts/docker-build.sh Proofs.Erdos63Problem` → **Build succeeded**
  (axiom `erdos_63_theorem` still type-checks; corollary follows).
- meta.json `lineCount` 224 → 228 (both occurrences) to track the new size.
  Axiom/theorem/sorry counts unchanged (1 / 4 / 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
