### PR TITLE
Enrich erdos-629: re-anchor drifted sections to cover stranded tail decls

### DIFF
--- a/src/data/proofs/erdos-629/meta.json
+++ b/src/data/proofs/erdos-629/meta.json
@@ -102,7 +102,7 @@
       "title": "Original Bounds: $2^{k-1} < n(k) < k^2 \\cdot 2^{k+2}$",
       "summary": "Proves `ert_lower_bound` (Aristotle) using the probabilistic method: bipartite graphs with $< 2^k$ vertices are $k$-choosable via random 2-partition of colors. States `ert_upper_bound` (sorry). Includes several auxiliary lemmas on bipartite partition structure and the probability bound.",
       "startLine": 633,
-      "endLine": 804,
+      "endLine": 815,
       "mathContext": "Proves `ert_lower_bound` (Aristotle) using the probabilistic method: bipartite graphs with $< 2^k$ vertices are $k$-choosable via random 2-partition of colors. Includes several auxiliary lemmas on bipartite partition structure and the probability bound."
     },
     {
@@ -126,7 +126,7 @@
       "title": "Complete Bipartite Graphs and Asymptotics",
       "summary": "Defines `completeBipartite m n` ($K_{m,n}$ on `Fin m ⊕ Fin n`). States `knn_list_chromatic` (sorry): $\\chi_L(K_{n,n}) \\approx \\log_2 n + 1$. States `n_exponential_growth` (sorry) and defines `ExactAsymptoticConjecture`: $n(k) = \\Theta(2^k \\cdot k^\\alpha)$.",
       "startLine": 847,
-      "endLine": 911,
+      "endLine": 924,
       "mathContext": "Defines `completeBipartite m n` ($K_{m,n}$ on `Fin m ⊕ Fin n`). States `knn_list_chromatic` (sorry): $\\chi_L(K_{n,n}) \\approx \\log_2 n + 1$. States `n_exponential_growth` (sorry) and defines `ExactAsymptoticConjecture`: $n(k) = \\Theta(2^k \\cdot k^\\alpha)$."
     }
   ],


### PR DESCRIPTION
## Enrichment: erdos-629 (Erdős #629 — list chromatic numbers of bipartite graphs)

Two `sections` entries in `meta.json` had drifted `endLine` anchors that fell short of the very declarations their summaries already describe:

- **"Original Bounds"** section `[633-804]` — its summary states it covers `ert_upper_bound` (`n(k) < k²·2^{k+2}`), but that theorem lives at **line 813**, stranded in the gap between this section and "Improved Bounds" `[816-…]`. Extended `endLine` 804 → **815** so the section covers the upper-bound theorem it names.
- **"Complete Bipartite Graphs and Asymptotics"** section `[847-911]` — its summary states it "defines `ExactAsymptoticConjecture`", but that capstone open-question `def` lives at **line 919**, stranded in the tail. Extended `endLine` 911 → **924** (EOF) to cover it.

No prose was invented — both summaries already accurately described the stranded decls; only the numeric anchors were corrected. Verified with the uncovered-declaration scan: erdos-629 now reports **0 stranded declarations**. JSON validated.
