### PR TITLE
Enrich erdos-794: re-anchor drifted sections to cover stranded tail decls

### DIFF
--- a/src/data/proofs/erdos-794/meta.json
+++ b/src/data/proofs/erdos-794/meta.json
@@ -160,7 +160,7 @@
       "title": "Edge Density and Frankl-Füredi",
       "summary": "turanDensityK4Minus = 2/7 (conjectured). frankl_furedi_lower axiom: density ≥ 2/7. turan_conjecture (1/4, disproved). current_conjecture (2/7, open upper bound).",
       "startLine": 198,
-      "endLine": 224,
+      "endLine": 226,
       "mathContext": "turanDensityK4Minus = 2/7 (conjectured). frankl_furedi_lower axiom: density $\\geq$ 2/7. turan_conjecture (1/4, disproved). current_conjecture (2/7, open upper bound)."
     },
     {
@@ -168,7 +168,7 @@
       "title": "Summary",
       "summary": "erdos_794_summary PROVED: ¬Conjecture ∧ (5-7 → K₄⁻) ∧ density ≥ 2/7. erdos_794 = ¬Erdos794Conjecture. Zero sorry entries in the entire file.",
       "startLine": 227,
-      "endLine": 256,
+      "endLine": 259,
       "mathContext": "erdos_794_summary PROVED: ¬Conjecture ∧ (5-7 $\\to$ K₄⁻) ∧ density $\\geq$ 2/7. erdos_794 = ¬Erdos794Conjecture. Zero sorry entries in the entire file."
     }
   ],


### PR DESCRIPTION
## Enrichment: erdos-794 (Erdős #794 — 3-uniform hypergraph edge density)

Two `sections` entries had drifted `endLine` anchors that stopped just short of declarations their own summaries already describe:

- **"Edge Density and Frankl-Füredi"** `[198-224]` — summary names `current_conjecture (2/7, open upper bound)`, but that `def` lives at **line 226**. Extended `endLine` 224 → **226**.
- **"Summary"** `[227-256]` — summary names `erdos_794 = ¬Erdos794Conjecture`, but that **main theorem** lives at **line 257** (with `end Erdos794` at 259). Extended `endLine` 256 → **259**.

No prose invented — anchors corrected to cover the decls the summaries already name. Uncovered-declaration scan now reports **0 stranded declarations** for erdos-794. JSON validated.
