### PR TITLE
Enrich gelfond-schneider-oq-01: cover stranded irrational_log_two_div_log_three

### DIFF
--- a/src/data/proofs/gelfond-schneider-oq-01/meta.json
+++ b/src/data/proofs/gelfond-schneider-oq-01/meta.json
@@ -89,7 +89,7 @@
       "title": "ℚ-Linear Independence of log 2 and log 3",
       "summary": "irrational_log_three_div_log_two proves log 3 / log 2 ∉ ℚ unconditionally (a rational p/d forces 2^p = 3^d, impossible by parity); irrational_log_two_div_log_three derives the reciprocal as the independence hypothesis Baker's theorem needs for the bases 2, 3.",
       "startLine": 110,
-      "endLine": 156
+      "endLine": 166
     },
     {
       "id": "general-family",


### PR DESCRIPTION
## Enrichment: gelfond-schneider-oq-01 (Baker's theorem / ℚ-linear independence of log 2, log 3)

The **"ℚ-Linear Independence of log 2 and log 3"** section `[110-156]` already names `irrational_log_two_div_log_three` in its summary ("derives the reciprocal as the independence hypothesis Baker's theorem needs"), but that theorem lives at **line 157**, one line past the section's `endLine`. Extended `endLine` 156 → **166** so the section covers the theorem it describes (the next section, "The General Family", begins at 167).

Anchor-only correction; no prose invented. Uncovered-declaration scan now reports **0 stranded declarations** for gelfond-schneider-oq-01. JSON validated.
