### PR TITLE
Enrich erdos-987: cover stranded main theorem with a closing section

### DIFF
--- a/src/data/proofs/erdos-987/meta.json
+++ b/src/data/proofs/erdos-987/meta.json
@@ -185,6 +185,14 @@
       "startLine": 224,
       "endLine": 234,
       "mathContext": "Defines sequence discrepancy as sup over intervals of |empirical - expected| proportion, then axiomatizes the Erdős-Turán inequality: D_n ≤ 1/K + Σ|Sₙ(k)|/(kn), the quantitative bridge between exponential sums and equidistribution."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Main Theorem: erdos_987",
+      "summary": "The capstone `erdos_987` theorem packages the three headline facts as a conjunction: Aₖ grows unboundedly for every unit-interval sequence (`erdos_987_unbounded`), Aₖ ≥ C√k infinitely often (`clunie_sqrt_bound`), and some sequence achieves Aₖ ≤ k (`clunie_upper_construction`). Assembled by ⟨·,·,·⟩ from the three supporting results.",
+      "startLine": 235,
+      "endLine": 245,
+      "mathContext": "The capstone `erdos_987` theorem packages the three headline facts as a conjunction: Aₖ grows unboundedly for every unit-interval sequence (`erdos_987_unbounded`), Aₖ ≥ C√k infinitely often (`clunie_sqrt_bound`), and some sequence achieves Aₖ ≤ k (`clunie_upper_construction`). Assembled by ⟨·,·,·⟩ from the three supporting results."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment: erdos-987 (growth of Aₖ for unit-interval sequences)

The capstone `erdos_987` theorem (lines 236-242) — which packages the three headline results (`erdos_987_unbounded` ∧ `clunie_sqrt_bound` ∧ `clunie_upper_construction`) into one conjunction — sat stranded past the last section, "Connection to Discrepancy Theory" `[224-234]`. Rather than mis-extend that topic-specific section, added a dedicated closing section **"Main Theorem: erdos_987"** `[235-245]` describing the assembly.

The only declaration now outside a section is the `noncomputable def Complex.abs` v4.31 migration compat shim at line 34 (header preamble above the `namespace`, alongside `import Mathlib`) — intentionally left as non-mathematical boilerplate. JSON validated.
