### PR TITLE
Research: erdos-85-wip-01 — KST cherry-counting bound + f(6)=3 (axiom-free)

### DIFF
--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -686,8 +686,8 @@ theorem containsC4_of_card_choose_two_lt {V : Type*} [Fintype V] [DecidableEq V]
   have av'x : G.Adj v' x := (G.mem_neighborFinset v' x).mp hxv'
   have av'y : G.Adj v' y := (G.mem_neighborFinset v' y).mp hyv'
   exact containsC4_of_rim avx.symm avy av'y.symm av'x hxy hvv
-    (G.ne_of_adj avx).symm (G.ne_of_adj avy).symm
-    (G.ne_of_adj av'x).symm (G.ne_of_adj av'y).symm
+    (G.ne_of_adj avx) (G.ne_of_adj avy)
+    (G.ne_of_adj av'x) (G.ne_of_adj av'y)
 
 /-- **The counting upper bound on the threshold.**  If `C(n, 2) < n · C(k, 2)` then every
 `n`-vertex graph of minimum degree `≥ k` has more than `C(n, 2)` cherries, hence a `C₄`; so

--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -618,4 +618,105 @@ theorem minDegreeForC4_five : minDegreeForC4 5 = 3 := by
   have hge : 3 ≤ minDegreeForC4 5 := three_le_minDegreeForC4 (by norm_num)
   omega
 
+/-! ## The Kővári–Sós–Turán counting bound
+
+The upper bounds above (`f(n) ≤ n − 2`) are linear, far from the truth `f(n) = (1+o(1))√n`.
+The real mechanism is a double count of **cherries** (paths of length two): a vertex `v` of
+degree `d` is the centre of `C(d, 2)` cherries, and a cherry `x–v–y` is determined by its
+centre together with its *unordered* endpoint pair `{x, y}`.  If the total number of cherries
+`∑_v C(deg v, 2)` exceeds the number `C(|V|, 2)` of available endpoint pairs, two distinct
+cherries share an endpoint pair — i.e. some pair `{x, y}` has two common neighbours `v ≠ v'`,
+which is exactly a `4`-cycle `x–v–y–v'–x`.  This is the Kővári–Sós–Turán argument at its
+simplest (the `C₄` / `z(n; 2, 2)` case), and it drives the true `√n`-order threshold. -/
+
+/-- **Cherry-counting forces a `C₄`.**  If the number of cherries `∑_v C(deg v, 2)` strictly
+exceeds the number `C(|V|, 2)` of unordered vertex pairs, then `G` contains a `4`-cycle.
+Proof: the cherries `⟨v, e⟩` (centre `v`, endpoint pair `e ⊆ N(v)`, `|e| = 2`) form a Finset
+of size `∑_v C(deg v, 2)`; the map `⟨v, e⟩ ↦ e` lands in the `C(|V|, 2)` two-element vertex
+subsets, so by pigeonhole two distinct cherries `⟨v, e⟩ ≠ ⟨v', e⟩` share their endpoint pair.
+Then `v ≠ v'` are two common neighbours of the pair `e = {x, y}`, giving the rim
+`x–v–y–v'–x`. -/
+theorem containsC4_of_card_choose_two_lt {V : Type*} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (h : (Fintype.card V).choose 2 < ∑ v : V, (G.degree v).choose 2) :
+    containsC4 V G := by
+  classical
+  -- The Finset of cherries: centre `v` with a two-element subset `e ⊆ N(v)`.
+  set C : Finset (Σ _ : V, Finset V) :=
+    univ.sigma (fun v => (G.neighborFinset v).powersetCard 2) with hC
+  -- Its cardinality is exactly the cherry count `∑_v C(deg v, 2)`.
+  have hCcard : C.card = ∑ v : V, (G.degree v).choose 2 := by
+    rw [hC, Finset.card_sigma]
+    refine Finset.sum_congr rfl (fun v _ => ?_)
+    rw [Finset.card_powersetCard, G.card_neighborFinset_eq_degree]
+  -- The endpoint-pair map lands in the two-element subsets of `V`.
+  set T : Finset (Finset V) := (univ : Finset V).powersetCard 2 with hT
+  have hTcard : T.card = (Fintype.card V).choose 2 := by
+    rw [hT, Finset.card_powersetCard, Finset.card_univ]
+  have hmaps : ∀ p ∈ C, p.2 ∈ T := by
+    intro p hp
+    rw [hC, Finset.mem_sigma] at hp
+    rw [hT, Finset.mem_powersetCard]
+    exact ⟨Finset.subset_univ _, (Finset.mem_powersetCard.mp hp.2).2⟩
+  have hlt : T.card < C.card := by rw [hTcard, hCcard]; exact h
+  -- Pigeonhole: two distinct cherries with the same endpoint pair.
+  obtain ⟨p, hp, q, hq, hpq, hfe⟩ :=
+    Finset.exists_ne_map_eq_of_card_lt_of_maps_to hlt hmaps
+  obtain ⟨v, e⟩ := p
+  obtain ⟨v', e'⟩ := q
+  simp only at hfe
+  subst hfe
+  -- Different cherries with equal endpoint pair ⟹ different centres.
+  have hvv : v ≠ v' := by
+    rintro rfl; exact hpq rfl
+  -- Unpack `e ⊆ N(v)`, `e ⊆ N(v')`, `|e| = 2`.
+  rw [hC, Finset.mem_sigma] at hp hq
+  obtain ⟨-, hpe⟩ := hp
+  obtain ⟨-, hqe⟩ := hq
+  obtain ⟨hsubv, hecard⟩ := Finset.mem_powersetCard.mp hpe
+  obtain ⟨hsubv', -⟩ := Finset.mem_powersetCard.mp hqe
+  obtain ⟨x, y, hxy, rfl⟩ := Finset.card_eq_two.mp hecard
+  have hxv : x ∈ G.neighborFinset v := hsubv (by simp)
+  have hyv : y ∈ G.neighborFinset v := hsubv (by simp)
+  have hxv' : x ∈ G.neighborFinset v' := hsubv' (by simp)
+  have hyv' : y ∈ G.neighborFinset v' := hsubv' (by simp)
+  -- The four rim adjacencies of `x–v–y–v'–x`.
+  have avx : G.Adj v x := (G.mem_neighborFinset v x).mp hxv
+  have avy : G.Adj v y := (G.mem_neighborFinset v y).mp hyv
+  have av'x : G.Adj v' x := (G.mem_neighborFinset v' x).mp hxv'
+  have av'y : G.Adj v' y := (G.mem_neighborFinset v' y).mp hyv'
+  exact containsC4_of_rim avx.symm avy av'y.symm av'x hxy hvv
+    (G.ne_of_adj avx).symm (G.ne_of_adj avy).symm
+    (G.ne_of_adj av'x).symm (G.ne_of_adj av'y).symm
+
+/-- **The counting upper bound on the threshold.**  If `C(n, 2) < n · C(k, 2)` then every
+`n`-vertex graph of minimum degree `≥ k` has more than `C(n, 2)` cherries, hence a `C₄`; so
+`f(n) ≤ k`.  This is the Kővári–Sós–Turán ceiling: since `C(n,2) < n · C(k,2)` holds as soon
+as `n ≤ k(k−1)`, it gives `f(n) = O(√n)`, matching the true order and far beating the linear
+`f(n) ≤ n − 2`. -/
+theorem minDegreeForC4_le_of_choose_lt {n k : ℕ}
+    (h : n.choose 2 < n * k.choose 2) : minDegreeForC4 n ≤ k := by
+  apply Nat.sInf_le
+  intro G _ hmin
+  apply containsC4_of_card_choose_two_lt
+  rw [Fintype.card_fin]
+  calc n.choose 2
+      < n * k.choose 2 := h
+    _ = ∑ _v : Fin n, k.choose 2 := by
+        rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, smul_eq_mul]
+    _ ≤ ∑ v : Fin n, (G.degree v).choose 2 :=
+        Finset.sum_le_sum fun v _ =>
+          Nat.choose_le_choose 2 (le_trans hmin (G.minDegree_le_degree v))
+
+/-- **A third exact value: `f(6) = 3`.**  The lower half `f(6) ≥ 3` is the `6`-cycle witness
+(`three_le_minDegreeForC4`).  The upper half `f(6) ≤ 3` is the counting bound
+`minDegreeForC4_le_of_choose_lt`: `C(6,2) = 15 < 18 = 6 · C(3,2)`, so minimum degree `3` on
+six vertices already yields more cherries than vertex pairs, forcing a `C₄`.  Note the linear
+bound `f(6) ≤ 6 − 2 = 4` is *not* sharp here — it is the Kővári–Sós–Turán count that pins the
+value, the first place the two upper bounds diverge. -/
+theorem minDegreeForC4_six : minDegreeForC4 6 = 3 := by
+  have hle : minDegreeForC4 6 ≤ 3 := minDegreeForC4_le_of_choose_lt (by decide)
+  have hge : 3 ≤ minDegreeForC4 6 := three_le_minDegreeForC4 (by norm_num)
+  omega
+
 end Erdos85

--- a/research/problems/erdos-85-wip-01/knowledge.md
+++ b/research/problems/erdos-85-wip-01/knowledge.md
@@ -212,3 +212,43 @@ lineCount 496 → 610, theoremCount 19 → 23.
   bound gives only f(5) ≤ 3 at n=5 (since 5−2=3), so **f(5) = 3 is now also within reach**
   by combining `minDegreeForC4_le_sub_two` (n=5) with `three_le_minDegreeForC4`!
 - Monotonicity core and the √n asymptotics remain genuinely open / documented-only.
+
+## Session 2026-07-21 (researcher-1) — KST cherry-counting bound + f(6) = 3 (third exact value)
+
+**Mode**: REVISIT (RICH). **Outcome**: progress (verified, 0-axiom) — the first upper bound
+of the *correct order* `√n`, and the third exact value `f(6) = 3`. Docker-build exit 0,
+`#print axioms` = `[propext, Classical.choice, Quot.sound]` on all three new theorems (no
+sorry/native_decide). theoremCount 24 → 27, lineCount 621 → 722.
+
+The linear bounds (`f(n) ≤ n − 2`) never reach `f(6) = 3` — at `n = 6` they give only `≤ 4`.
+The truth `f(n) = (1+o(1))√n` needs the **Kővári–Sós–Turán double count of cherries**:
+
+- **`containsC4_of_card_choose_two_lt`** (the KST heart): `C(|V|,2) < Σ_v C(deg v,2) ⟹ C₄`.
+  Model cherries as `C := univ.sigma (fun v => (G.neighborFinset v).powersetCard 2)` — an
+  element `⟨v, e⟩` is a centre `v` with a 2-element endpoint set `e ⊆ N(v)`. Then
+  `C.card = Σ_v C(deg v, 2)` (`Finset.card_sigma`, `Finset.card_powersetCard`,
+  `card_neighborFinset_eq_degree`). The endpoint map `⟨v,e⟩ ↦ e` lands in
+  `univ.powersetCard 2` (card `C(|V|,2)`). `Finset.exists_ne_map_eq_of_card_lt_of_maps_to`
+  gives two distinct cherries `⟨v,e⟩ ≠ ⟨v',e⟩` with the same `e`; distinctness + equal `e`
+  forces `v ≠ v'`, so `e = {x,y}` has two common neighbours `v, v'`, i.e. the rim
+  `x–v–y–v'–x` (fed to the existing `containsC4_of_rim`).
+- **`minDegreeForC4_le_of_choose_lt`**: `n.choose 2 < n * k.choose 2 ⟹ f(n) ≤ k`. If `δ ≥ k`
+  then every `(deg v).choose 2 ≥ k.choose 2` (`Nat.choose_le_choose`), so
+  `Σ ≥ n·C(k,2) > C(n,2)`. The hypothesis holds whenever `n ≤ k(k−1)`, giving `f(n) = O(√n)`.
+- **`minDegreeForC4_six`**: `f(6) = 3`. Upper `C(6,2)=15 < 18 = 6·C(3,2)` ⟹ `f(6) ≤ 3`
+  (`by decide`); lower `three_le_minDegreeForC4`.
+
+### Lean idioms (recorded)
+- Sigma-indexed Finset for "structure with a chosen sub-object": `univ.sigma (fun v => …)`;
+  `Finset.card_sigma` sums the fibres, `Finset.card_powersetCard s n = s.card.choose n`.
+- Pigeonhole: `Finset.exists_ne_map_eq_of_card_lt_of_maps_to (hc : t.card < s.card) (hf : ∀
+  a ∈ s, f a ∈ t) : ∃ x ∈ s, ∃ y ∈ s, x ≠ y ∧ f x = f y`.
+- `ne_of_adj G h : u ≠ v` for `h : G.Adj u v` — the direction is `u ≠ v` (no `.symm` for the
+  `b ≠ a` / `d ≠ c` rim inequalities when the adjacency is `Adj v x`).
+
+### Next
+- **f(7) = 3?**: the KST count gives only `f(7) ≤ 4` (`7 ≤ 4·3 = 12`, but `7 > 3·2 = 6`); the
+  true `f(7) = 3` needs the sharper C₄-free edge bound `ex(7; C₄) = 9` (min degree 3 on 7
+  vertices has `≥ ⌈21/2⌉ = 11 > 9` edges) — a genuine extremal input beyond the crude cherry
+  count. This is the next exact value and the point where naive KST stops being sharp.
+- The general monotonicity core `f(n+1) ≥ f(n)` (the actual open Erdős question) stays open.

--- a/src/data/proofs/erdos-85/meta.json
+++ b/src/data/proofs/erdos-85/meta.json
@@ -192,9 +192,9 @@
       "Topology"
     ],
     "namespace": "Erdos85",
-    "lineCount": 621,
+    "lineCount": 722,
     "axiomCount": 0,
-    "theoremCount": 24,
+    "theoremCount": 27,
     "definitionCount": 8,
     "path": "Proofs/Erdos85Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-85-wip-01.json
+++ b/src/data/research/problems/erdos-85-wip-01.json
@@ -20,10 +20,10 @@
   "currentState": {
     "phase": "ORIENT",
     "since": "2026-07-09T17:33:20-07:00",
-    "iteration": 2,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "iteration": 4,
+    "focus": "KST cherry-counting bound formalized; f(6)=3 pinned (third exact value).",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "f(7): KST count gives only f(7) ≤ 4 (7 ≤ 4·3); true value f(7)=3 needs the sharper ex(7;C4)=9 edge bound (min-degree-3-on-7 has 11+ edges > 9). Also the general monotonicity core stays open.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-07-21, researcher-1, VERIFIED 0-axiom host v4.31.0): proved the FIRST TWO exact threshold values f(4)=2 (minDegreeForC4_four) and f(5)=3 (minDegreeForC4_five) plus the sharpened general upper bound f(n)≤n-2 for n≥4 (minDegreeForC4_le_sub_two), via containsC4_of_minDegree_ge (min-degree n-2 forces a C4: non-adjacent pair ⟹ ≥2 common neighbours) and the reusable rim-embedding helper containsC4_of_rim. 24 axiom-free theorems (was 19). Deep results (KST √n scale, monotonicity) remain documented-only.",
+    "progressSummary": "Exact values f(4)=2, f(5)=3, f(6)=3 (all axiom-free). KST cherry-counting lemma containsC4_of_card_choose_two_lt (Σ C(deg v,2) > C(n,2) ⟹ C₄) gives the general upper bound minDegreeForC4_le_of_choose_lt (f(n) ≤ k when C(n,2) < n·C(k,2), i.e. n ≤ k(k−1)) — √n-order, first bound matching the true asymptotic order f(n)=(1+o(1))√n and beating linear n−2. Lower bounds f(n)≥3 (n≥5) from cycleGraph. Next: f(7) (KST gives f(7)≤3 since 7≤3·2? no 7>6; k=4 gives 7≤12 so f(7)≤4; true f(7)=3 needs sharper ex(7;C4)=9) and monotonicity core.",
     "builtItems": [
       "C4_adj_zero_one/one_two/two_three/three_zero (four cycle edges) in Erdos85Problem.lean",
       "C4_not_adj_zero_two (diagonal non-edge) in Erdos85Problem.lean",
@@ -42,7 +42,10 @@
       "one_le_starGraph_minDegree, two_le_minDegreeForC4, starGraph_decidableAdj in Erdos85Problem.lean — f(n+1)≥2 lower bound, 0-axiom host-verified",
       "cycleGraph_not_containsC4 (Erdos85Problem.lean): ∀ n≥5, ¬ containsC4 (Fin n) (cycleGraph n) — axiom-free, uses open Fin.CommRing for linear_combination/ring on Fin n",
       "two_le_cycleGraph_minDegree (Erdos85Problem.lean): ∀ n≥3, 2 ≤ (cycleGraph n).minDegree (Cn is 2-regular)",
-      "three_le_minDegreeForC4 (Erdos85Problem.lean): ∀ n≥5, 3 ≤ minDegreeForC4 n — GENERAL lower bound f(n)≥3, generalises the C5 point-witness"
+      "three_le_minDegreeForC4 (Erdos85Problem.lean): ∀ n≥5, 3 ≤ minDegreeForC4 n — GENERAL lower bound f(n)≥3, generalises the C5 point-witness",
+      "containsC4_of_card_choose_two_lt in Erdos85Problem.lean — pigeonhole KST lemma: C(|V|,2) < Σ_v C(deg v,2) ⟹ containsC4 (cherries = univ.sigma (N v).powersetCard 2, map ⟨v,e⟩↦e, Finset.exists_ne_map_eq_of_card_lt_of_maps_to)",
+      "minDegreeForC4_le_of_choose_lt in Erdos85Problem.lean — n.choose 2 < n * k.choose 2 ⟹ f(n) ≤ k (KST √n-order upper bound)",
+      "minDegreeForC4_six in Erdos85Problem.lean — f(6) = 3 (third exact value; C(6,2)=15 < 18=6·C(3,2))"
     ],
     "insights": [
       "Erdos85Problem.lean was a definitions-only stub (7 defs, 0 theorems). Asymptotics f(n)=(1+o(1))sqrt(n), f(4)=2, and the Ramsey reformulation need extremal graph theory beyond Mathlib; tractable axiom-free content is structural facts about C4, containsC4, and starGraph.",
@@ -58,7 +61,8 @@
       "minDegreeForC4_le_sub_two: f(n) ≤ n-2 for n≥4, sharpening the crude complete-graph bound f(n) ≤ n-1.",
       "minDegreeForC4_four: f(4) = 2 EXACTLY (first determined threshold value), combining star lower bound f(4)≥2 with n=4 case of the n-2 upper bound. Resolves the previously documented-only base case.",
       "Lean idiom: for a ∀G-with-[DecidableRel] statement, the sInf-membership pattern `apply Nat.sInf_le; intro G _ hmin` handles the instance binder cleanly. Non-neighbour cardinality via Finset.card_sdiff_add_card_eq_card (subset form) + omega; card_sdiff hypothesis-free in v4.31.",
-      "minDegreeForC4_five: f(5) = 3 EXACTLY — the cycle lower bound f(5)≥3 (three_le_minDegreeForC4) meets the n-2 upper bound at n=5 (5-2=3). Second determined value, immediate corollary of the two new bounds."
+      "minDegreeForC4_five: f(5) = 3 EXACTLY — the cycle lower bound f(5)≥3 (three_le_minDegreeForC4) meets the n-2 upper bound at n=5 (5-2=3). Second determined value, immediate corollary of the two new bounds.",
+      "Kővári–Sós–Turán cherry-counting: Σ_v C(deg v,2) counts paths of length 2; each is determined by centre + unordered endpoint pair. If the count exceeds C(|V|,2), pigeonhole gives a pair with two common neighbours = a C₄. This is the C₄/z(n;2,2) case of KST and drives the true √n-order threshold (f(n)=O(√n)), far beating the linear n−2 bound."
     ],
     "mathlibGaps": [
       "Fin n has NO global CommRing instance (only scoped Fin.instCommRing via `open Fin.CommRing`, gated on NeZero n); needed for ring/linear_combination on cycleGraph differences"


### PR DESCRIPTION
## Summary
Research session for **erdos-85-wip-01** (Erdős #85, minimum degree forcing a C₄). Formalizes the **Kővári–Sós–Turán cherry-counting argument** — the first upper bound of the *correct order* `√n` — and uses it to pin the third exact value **f(6) = 3**.

## Progress
Three new axiom-free theorems in `proofs/Proofs/Erdos85Problem.lean`:

- `containsC4_of_card_choose_two_lt` — **the KST heart**: `C(|V|,2) < Σ_v C(deg v,2) ⟹ containsC4`. Cherries `⟨v,e⟩` (centre `v`, endpoint pair `e ⊆ N(v)`, `|e|=2`) form a Finset of size `Σ_v C(deg v,2)`; the endpoint-pair map lands in the `C(|V|,2)` vertex pairs, so pigeonhole yields two cherries sharing an endpoint pair — a pair with two common neighbours, i.e. a `4`-cycle.
- `minDegreeForC4_le_of_choose_lt` — `n.choose 2 < n·k.choose 2 ⟹ f(n) ≤ k`. Holds whenever `n ≤ k(k−1)`, giving `f(n) = O(√n)`, matching the true asymptotic order and far beating the linear `f(n) ≤ n−2`.
- `minDegreeForC4_six` — **f(6) = 3**. Upper `C(6,2)=15 < 18 = 6·C(3,2)`; lower the 6-cycle witness.

## Findings
- The linear bounds (`f(n) ≤ n−2`) give only `f(6) ≤ 4` — the counting argument is genuinely needed to reach `3`. This is the first `n` where the two upper bounds diverge.
- Lean modelling: cherries as `univ.sigma (fun v => (G.neighborFinset v).powersetCard 2)`; `Finset.card_sigma` + `Finset.card_powersetCard` give the count; pigeonhole via `Finset.exists_ne_map_eq_of_card_lt_of_maps_to`. The C₄ is assembled through the existing `containsC4_of_rim` helper.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.Erdos85Problem` — exit 0 (v4.31).
- `#print axioms` on all three theorems = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. 0 sorry, 0 axiom, no `native_decide`.

## Status
**Outcome**: progress
**Next Steps**: `f(7) = 3` needs the sharper C₄-free edge bound `ex(7;C₄)=9` (naive KST gives only `≤ 4`); the general monotonicity core `f(n+1) ≥ f(n)` (the open Erdős question) stays open.

🤖 Generated by researcher-1
