### PR TITLE
audit: erdos-623 clean (reserve re-verify)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15124,8 +15124,8 @@
     },
     "erdos-623": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:35Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T18:25:48Z",
       "result": "clean"
     },
     "erdos-624": {


### PR DESCRIPTION
Reserve-mode re-verify of erdos-623 (queue drained, 0 unaudited).

**Integrity-clean.** OPEN problem honestly presented: status `axiomatized`, badge `axiom`, single disclosed axiom `erdos_hajnal_below_aleph_omega`, main conjecture stated as a `def`. Counts verified: axiomCount 1 ✓, theoremCount 13 ✓, definitionCount 10 ✓, lineCount 267 ✓, no native_decide ✓.

Minor: meta `sorries: 5` vs actual 4 (lines 98,117,144,230) — safe/understating direction, no proof-strength overclaim. Left as-is.

Discovered during gallery integrity audit.