### PR TITLE
Enrich greens-theorem-oq-02: cover stranded unitCircle_diameter_bound

### DIFF
--- a/src/data/proofs/greens-theorem-oq-02/meta.json
+++ b/src/data/proofs/greens-theorem-oq-02/meta.json
@@ -116,7 +116,7 @@
       "id": "unit-circle",
       "title": "Part V: Unit Circle Example",
       "startLine": 452,
-      "endLine": 518,
+      "endLine": 533,
       "summary": "unitCircle def, unitCircle_lipschitz (K=1, proved via sup_le for product edist), unitCircle_closed (γ(0)=γ(2π) from cos/sin periodicity), unitCircleCurve instance, unitCircle_diameter_bound.",
       "mathContext": "$\\gamma(t) = (\\cos t, \\sin t)$ is Lipschitz-1 since $\\text{edist}(\\cos x, \\cos y) \\leq \\text{edist}(x,y)$ and $\\text{edist}(\\sin x, \\sin y) \\leq \\text{edist}(x,y)$ by Mathlib's `lipschitzWith_cos` and `lipschitzWith_sin`. The product edist is $\\leq \\sup$, closed by `sup_le`."
     }


### PR DESCRIPTION
## Enrichment: greens-theorem-oq-02 (Green's theorem for L¹ curl fields / Whitney)

The **"Part V: Unit Circle Example"** section `[452-518]` already names `unitCircle_diameter_bound` in its summary, but that theorem lives at **line 522** (with `end GreensTheoremOQ02` at 533), stranded past the section's `endLine`. Extended `endLine` 518 → **533** (EOF) so the section covers the diameter-bound theorem it describes.

Anchor-only correction; no prose invented. Uncovered-declaration scan now reports **0 stranded declarations** for greens-theorem-oq-02. JSON validated.
