### PR TITLE
Enrich greens-theorem-oq-02: cover stranded unitCircle_diameter_bound

### DIFF
--- a/src/data/proofs/greens-theorem-oq-02/meta.json
+++ b/src/data/proofs/greens-theorem-oq-02/meta.json
@@ -116,7 +116,7 @@
       "id": "unit-circle",
       "title": "Part V: Unit Circle Example",
       "startLine": 452,
-      "endLine": 518,
+      "endLine": 533,
       "summary": "unitCircle def, unitCircle_lipschitz (K=1, proved via sup_le for product edist), unitCircle_closed (γ(0)=γ(2π) from cos/sin periodicity), unitCircleCurve instance, unitCircle_diameter_bound.",
       "mathContext": "$\\gamma(t) = (\\cos t, \\sin t)$ is Lipschitz-1 since $\\text{edist}(\\cos x, \\cos y) \\leq \\text{edist}(x,y)$ and $\\text{edist}(\\sin x, \\sin y) \\leq \\text{edist}(x,y)$ by Mathlib's `lipschitzWith_cos` and `lipschitzWith_sin`. The product edist is $\\leq \\sup$, closed by `sup_le`."
     }


### PR DESCRIPTION
## Summary

Coverage fix for `greens-theorem-oq-02`. The `unit-circle` section (Part V) had `endLine: 518`, which fell inside the docstring of `unitCircle_diameter_bound` (theorem at lines 522–531), stranding that final theorem outside all sections — despite the section's `summary` already listing `unitCircle_diameter_bound`.

## Change

Single edit: `sections["unit-circle"].endLine` `518 → 533` (EOF), so Part V now covers its entire content including the diameter bound (`dist(γ(s), γ(t)) ≤ K·T = 2π`). Every top-level declaration is now covered by exactly one section (verified via stranded-decl scan). No prose or status changes.
