### PR TITLE
Enrich sqrt2-minpoly-oq-01: cover stranded boundary theorems

### DIFF
--- a/src/data/proofs/sqrt2-minpoly-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-01/meta.json
@@ -93,7 +93,7 @@
     {
       "id": "degree-results",
       "title": "Part IV: Algebraic Degree and Field Extension Degree",
-      "startLine": 74,
+      "startLine": 73,
       "endLine": 88,
       "summary": "Derives natDegree(minpoly ℚ (√n)) = 2 and [ℚ(√n) : ℚ] = 2 as corollaries.",
       "mathContext": "`adjoin_nthRoot_finrank 2 n p`: the degree-2 field extension result. `{1, √n}` is a ℚ-basis of ℚ(√n)."
@@ -109,7 +109,7 @@
     {
       "id": "examples",
       "title": "Part VI: Concrete Examples",
-      "startLine": 102,
+      "startLine": 100,
       "endLine": 131,
       "summary": "Eight explicit minimal polynomial theorems: √2, √3, √5, √6, √7, √10, √12, √20. Each proved by applying the squarefree factor main theorem.",
       "mathContext": "Each proof: `minpoly_sqrt_of_sqfree_factor n p (by norm_num) ...`. Note √12 uses p=3 (not p=2 since 4|12), √20 uses p=5 (not p=2 since 4|20)."


### PR DESCRIPTION
## Enrichment: sqrt2-minpoly-oq-01 (minimal polynomial of √n)

Two theorems sat in one-off gaps between adjacent Part sections — each is the first declaration of the section that describes it, but the section's `startLine` began one/two lines too late:

- **`minpoly_sqrt_natDegree`** (line 73, the "natDegree = 2" result) fell in the gap before **"Part IV: Algebraic Degree and Field Extension Degree"** `[74-88]`, whose summary is precisely "Derives natDegree(minpoly ℚ (√n)) = 2". Pulled `startLine` 74 → **73**.
- **`minpoly_sqrt_two`** (line 101, the first of the eight concrete examples) fell in the gap before **"Part VI: Concrete Examples"** `[102-131]`, whose summary lists "√2, √3, …" — the √2 case being exactly this theorem. Pulled `startLine` 102 → **100** (grabbing its docstring too).

Anchor-only corrections; no prose invented, no overlaps introduced. Uncovered-declaration scan now reports **0 stranded declarations** for sqrt2-minpoly-oq-01. JSON validated.
