### PR TITLE
audit: erdos-622 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15112,8 +15112,8 @@
     },
     "erdos-622": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:35Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T18:29:33Z",
       "result": "clean"
     },
     "erdos-622-oq-04": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-622 (queue drained, 0 unaudited).

**Result: CLEAN.** Counts verified against `proofs/Proofs/Erdos622Problem.lean`:
- axiomCount 3 ✓ (dkm_2025, erdos_observation, knn_few_cycles)
- definitionCount 13 ✓, theoremCount 0 ✓, sorries 0 ✓
- no native_decide, no True stubs

Axioms are satisfiable bounds (2 lower + 1 upper), not False-masking. status `axiomatized` / badge `axiom` honestly credit DKM 2025 as axiomatized; no overclaiming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)