### PR TITLE
Enrich erdos-546: cover stranded axiom declaration lines

### DIFF
--- a/src/data/proofs/erdos-546/meta.json
+++ b/src/data/proofs/erdos-546/meta.json
@@ -51,7 +51,7 @@
       "id": "ramsey-numbers",
       "title": "Ramsey Numbers (Axiomatized)",
       "startLine": 57,
-      "endLine": 69,
+      "endLine": 70,
       "summary": "Axiomatizes ramseyNumber R(H) and ramseyNumberColors R_r(H) as functions, avoiding the complex subgraph-embedding formalism",
       "mathContext": "R(H) = min N: any 2-coloring of K_N contains mono copy of H."
     },
@@ -67,7 +67,7 @@
       "id": "bipartite-case",
       "title": "Bipartite Case (AKS 2003)",
       "startLine": 93,
-      "endLine": 100,
+      "endLine": 101,
       "summary": "Axiomatizes aks_bipartite_bound: R(G) ≤ 2^{O(√m)} for bipartite G, proved 8 years before the general case",
       "mathContext": "AKS 2003: bipartite R(G) ≤ 2^{O(√m)} via dependent random choice."
     },


### PR DESCRIPTION
## Enrichment: erdos-546 (Ramsey numbers of sparse/bounded-degree graphs — Sudakov)

Two axiom declarations whose docstrings sat inside a section had their `axiom` line fall one row past the section `endLine` (the section already names them in its summary):

- **"Ramsey Numbers (Axiomatized)"** `[57-69]` — summary names `ramseyNumberColors`, whose `axiom` line is **70**. Extended `endLine` 69 → **70**.
- **"Bipartite Case (AKS 2003)"** `[93-100]` — summary names `aks_bipartite_bound`, whose `axiom` line is **101**. Extended `endLine` 100 → **101**.

Anchor-only correction; no prose invented, no overlap with neighbouring sections. Uncovered-declaration scan now reports **0 stranded declarations** for erdos-546. JSON validated.
