### PR TITLE
audit: erdos-62 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15094,8 +15094,8 @@
     },
     "erdos-62": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:36Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T18:31:18Z",
       "result": "clean"
     },
     "erdos-620": {


### PR DESCRIPTION
Reserve-mode re-audit (queue drained). **CLEAN.**

Counts verified vs `proofs/Proofs/Erdos62Problem.lean`: axiomCount 3 (oddCycle, oddCycle_chromatic, erdos_hajnal_shelah — the known Erdős-Hajnal-Shelah results), theoremCount 3, definitionCount 13, sorries 0, no native_decide.

The OPEN conjecture is stated only as Prop-valued `def`s (erdos_62_conjecture_strong/weak/generalized) — not proved or axiomatized. Only the χ=3 odd-cycle consequence is proved, honestly framed as the open χ=3→χ=4 gap. status/badge/erdosProblemStatus all honestly OPEN/axiomatized; no overclaiming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)