### PR TITLE
Enrich erdos-568: cover stranded graph-predicate defs

### DIFF
--- a/src/data/proofs/erdos-568/meta.json
+++ b/src/data/proofs/erdos-568/meta.json
@@ -46,7 +46,7 @@
       "id": "graph-infrastructure",
       "title": "Graph Infrastructure",
       "startLine": 26,
-      "endLine": 39,
+      "endLine": 40,
       "summary": "Defines $\\text{SGraph}(n)$ with symmetric irreflexive adjacency, edge counting $|E(G)|$, and the no-isolated-vertices condition $\\forall v,\\;\\deg(v) \\ge 1$.",
       "mathContext": "Formal definition: Defines $\\text{SGraph}(n)$ with symmetric irreflexive adjacency, edge counting $|E(G)|$, and the no-isolated-vertices condition $\\forall v,\\;\\deg(v) \\ge 1$."
     },
@@ -62,7 +62,7 @@
       "id": "graph-predicates",
       "title": "Tree and Complete Graph Predicates",
       "startLine": 52,
-      "endLine": 58,
+      "endLine": 59,
       "summary": "Defines trees ($|E| = n-1$, $n \\ge 1$) and complete graphs ($\\forall i \\ne j,\\;\\text{adj}(i,j)$) — the two extremes of graph density that appear in the hypothesis.",
       "mathContext": "Formal definition: Defines trees ($|E| = n-1$, $n \\ge 1$) and complete graphs ($\\forall i \\ne j,\\;\\text{adj}(i,j)$) — the two extremes of graph density that appear in the hypothesis."
     },


### PR DESCRIPTION
## Enrichment: erdos-568 (Erdős–Faudree–Rousseau–Schelp size-Ramsey linearity)

Two definitions had their `def` line fall one row past the section that already describes them in its summary (the docstring being the section's last covered line):

- **`NoIsolated`** (def, line 40) — **"Graph Infrastructure"** `[26-39]` summary already describes "the no-isolated-vertices condition ∀v, deg(v) ≥ 1". Extended `endLine` 39 → **40**.
- **`SGraph.IsComplete`** (def, line 59) — **"Tree and Complete Graph Predicates"** `[52-58]` summary already describes "complete graphs (∀ i ≠ j, adj(i,j))". Extended `endLine` 58 → **59**.

Anchor-only correction; no prose invented, no overlap with neighbouring sections. Uncovered-declaration scan now reports **0 stranded declarations** for erdos-568. JSON validated.
