### PR TITLE
Enrich erdos-216: cover stranded ContainsEmptyKGon + conjecture defs

### DIFF
--- a/src/data/proofs/erdos-216/meta.json
+++ b/src/data/proofs/erdos-216/meta.json
@@ -118,7 +118,7 @@
       "title": "Empty Convex Polygons",
       "summary": "Axiomatizes IsEmptyConvexKGon — a convex k-gon whose interior contains no other points of S — since formalizing the interior of a convex hull requires substantial geometric infrastructure. Defines ContainsEmptyKGon as the existential wrapper.",
       "startLine": 67,
-      "endLine": 78,
+      "endLine": 79,
       "mathContext": "Axiomatizes IsEmptyConvexKGon — a convex k-gon whose interior contains no other points of S — since formalizing the interior of a convex hull requires substantial geometric infrastructure. Defines ContainsEmptyKGon as the existential wrapper."
     },
     {
@@ -166,7 +166,7 @@
       "title": "Connection to Happy Ending Problem",
       "summary": "Defines happyEnding (g'(k)) for the non-empty variant via Nat.find, and states the Erdős-Szekeres conjecture g'(k) = 2^(k−2)+1 as the predicate erdos_szekeres_conjecture. (No existence or monotonicity theorem is declared here.)",
       "startLine": 159,
-      "endLine": 173,
+      "endLine": 174,
       "mathContext": "Defines happyEnding (g'(k)) for the non-empty variant via Nat.find, and states the Erdős-Szekeres conjecture g'(k) = 2^(k−2)+1 as the predicate erdos_szekeres_conjecture. (No existence or monotonicity theorem is declared here.)"
     },
     {


### PR DESCRIPTION
## Enrichment: erdos-216 (empty convex polygons / Erdős–Szekeres "happy ending")

Two definitions had their `def` line fall one row past the section that already names them:

- **`ContainsEmptyKGon`** (def, line 79) — **"Empty Convex Polygons"** `[67-78]` summary already says "Defines ContainsEmptyKGon as the existential wrapper". Extended `endLine` 78 → **79**.
- **`erdos_szekeres_conjecture`** (def, line 174) — **"Connection to Happy Ending Problem"** `[159-173]` summary already says "states the Erdős–Szekeres conjecture … as the predicate erdos_szekeres_conjecture". Extended `endLine` 173 → **174**.

Anchor-only correction; no prose invented, no overlap with neighbouring sections. Uncovered-declaration scan now reports **0 stranded declarations** for erdos-216. JSON validated.
