### PR TITLE
Enrich erdos-542: snap section boundaries to banners, cover stranded decls

### DIFF
--- a/src/data/proofs/erdos-542/meta.json
+++ b/src/data/proofs/erdos-542/meta.json
@@ -114,27 +114,27 @@
       "id": "main-results",
       "title": "Schinzel-Szekeres Theorem",
       "startLine": 37,
-      "endLine": 49,
+      "endLine": 46,
       "summary": "States `ErdosProblem542`: $\\sum 1/a \\le 31/30$ under the LCM condition. Axiomatizes the tight example $\\{2,3,5\\}$ with $1/2 + 1/3 + 1/5 = 31/30$ and its validity for $n = 5$."
     },
     {
       "id": "chen-bound",
       "title": "Chen's Stronger Bound (1996)",
-      "startLine": 52,
+      "startLine": 47,
       "endLine": 62,
       "summary": "States `ChenBound`: for $n > 172509$, $\\sum 1/a < 1/3 + 1/4 + 1/5 + 1/7 + 1/11 = 4699/4620$. Proves the rational equality via `norm_num`."
     },
     {
       "id": "maximal-sets",
       "title": "Maximal Sets Conjecture",
-      "startLine": 66,
-      "endLine": 79,
+      "startLine": 63,
+      "endLine": 75,
       "summary": "States `MaximalSetsConjecture`: only $\\{2,3,5\\}$ and $\\{3,4,5,7,11\\}$ achieve $\\sum 1/a > 1$. Axiomatizes that $\\{3,4,5,7,11\\}$ has sum $> 1$ and satisfies the LCM condition for $n = 11$."
     },
     {
       "id": "structural",
       "title": "Structural Properties and Final Theorem",
-      "startLine": 83,
+      "startLine": 76,
       "endLine": 97,
       "summary": "documents in source comments `lcm_condition_no_divisibility` (no Lean declaration exists) ($a \\mid b \\implies b > n$, i.e., $A$ is an antichain). Proves `singleton_satisfies_lcm` (vacuous satisfaction) and `reciprocal_sum_singleton` ($\\sum_{\\{a\\}} 1/x = 1/a$). `schinzel_szekeres_solves_542` axiomatizes the full resolution."
     }


### PR DESCRIPTION
## Summary

Coverage fix for `erdos-542` (Reciprocal Sums Under LCM Constraints). Two top-level declarations sat outside all sections due to section boundaries drifting off their `## ...` banners:

- `def ChenBound` (line 51) — the `chen-bound` section started at 52
- `theorem singleton_satisfies_lcm` (line 81) — the `structural` section started at 83

## Change (meta.json `sections` boundaries only)

Snapped each affected section start to its banner comment, yielding a clean partition:

| Section | Old | New |
|---------|-----|-----|
| main-results | 37–49 | 37–46 |
| chen-bound | 52–62 | 47–62 (banner @47, covers `ChenBound`) |
| maximal-sets | 66–79 | 63–75 (banner @63) |
| structural | 83–97 | 76–97 (banner @76, covers `singleton_satisfies_lcm`) |

Every top-level declaration is now covered by exactly one section (verified via stranded-decl scan). No summary or status changes.
