### PR TITLE
Enrich erdos-1092: realign one-section-drifted anchors + cover fThreshold

### DIFF
--- a/src/data/proofs/erdos-1092/meta.json
+++ b/src/data/proofs/erdos-1092/meta.json
@@ -67,23 +67,23 @@
       "id": "chromatic-reduce",
       "title": "Chromatic Reduction by Edge Deletion",
       "startLine": 44,
-      "endLine": 53,
+      "endLine": 64,
       "summary": "Defines `CanReduceChromatic G k r`: existence of $\\leq k$ edge removals yielding $\\chi \\leq r$. Maintains symmetry by excluding both orientations of removed edges.",
       "mathContext": "Defines `CanReduceChromatic G k r`: existence of $\\leq k$ edge removals yielding $\\chi \\leq r$. Maintains symmetry by excluding both orientations of removed edges."
     },
     {
       "id": "threshold",
       "title": "The Threshold Function $f_r(n)$",
-      "startLine": 54,
-      "endLine": 63,
+      "startLine": 65,
+      "endLine": 85,
       "summary": "Defines `fThreshold r n` as $\\sup\\{k : \\text{local } k\\text{-reducibility} \\implies \\chi(G) \\leq r+1\\}$ via `sSup`. The central extremal quantity of the problem.",
       "mathContext": "Defines `fThreshold r n` as $\\sup\\{k : \\text{local } k\\text{-reducibility} \\implies \\chi(G) \\leq r+1\\}$ via `sSup`. The central extremal quantity of the problem."
     },
     {
       "id": "questions",
       "title": "The Main Conjectures",
-      "startLine": 64,
-      "endLine": 75,
+      "startLine": 86,
+      "endLine": 93,
       "summary": "Question 1: $f_2(n) \\gg n$ (super-linear growth for $r = 2$). Question 2: $f_r(n) \\gg_r rn$ for general $r \\geq 2$. Both disproved by Rödl (1982) and removed; only `True`-valued documentation notes remain.",
       "mathContext": "Question 1: $f_2(n) \\gg n$ (super-linear growth for $r = 2$). Question 2: $f_r(n) \\gg_r rn$ for general $r \\geq 2$. Both disproved by Rödl (1982) and removed; only `True`-valued documentation notes remain."
     },
@@ -91,7 +91,7 @@
       "id": "rodl-bounds",
       "title": "Rödl's Construction and Structural Properties",
       "startLine": 94,
-      "endLine": 160,
+      "endLine": 164,
       "summary": "Proved structural theorems: coloring self/monotonicity, CanReduceChromatic monotonicity in edges and colors. Documents removed unsound axioms (f_trivial_lower, erdos_744_connection, Rödl upper bound) with counterexamples. No axioms remain.",
       "mathContext": "Proved structural theorems: coloring self/monotonicity, CanReduceChromatic monotonicity in edges and colors. Documents removed unsound axioms (f_trivial_lower, erdos_744_connection, Rödl upper bound) with counterexamples. No axioms remain."
     }


### PR DESCRIPTION
## Enrichment: erdos-1092 (Erdős–Hajnal–Szemerédi chromatic-reduction threshold f_r(n))

Three consecutive sections had drifted by one section relative to the content their summaries describe, which also left `fThreshold` (the file's central definition) with no covering section. Re-anchored each section's line range to match its own summary text:

- **"Chromatic Reduction by Edge Deletion"** — summary defines `CanReduceChromatic` (line 57), which was just past the old range. `[44-53]` → **`[44-64]`** (now covers `CanReduceChromatic`'s full body).
- **"The Threshold Function f_r(n)"** — summary defines `fThreshold` (line 78), which was **stranded** in the old gap. `[54-63]` → **`[65-85]`** (the `## The Function f_r(n)` banner through the `fThreshold` def).
- **"The Main Conjectures"** — summary covers the disproved Q1/Q2 notes (the `## Erdős–Hajnal–Szemerédi Questions` banner at line 86). `[64-75]` → **`[86-93]`**.
- **"Rödl's Construction and Structural Properties"** `[94-160]` — the tail theorem `CanReduceChromatic_mono_r` (line 161, named in the summary as "CanReduceChromatic monotonicity … in colors") was one line past. Extended `endLine` 160 → **164** (EOF).

Ranges are now contiguous (44-64, 65-85, 86-93, 94-164) with no gaps or overlaps; summaries unchanged (the fix aligns ranges *to* the existing summaries). Uncovered-declaration scan now reports **0 stranded declarations** for erdos-1092. JSON validated.
