### PR TITLE
Enrich poincare-conjecture: cover stranded compactness helper + summary theorem

### DIFF
--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -169,14 +169,14 @@
       "id": "consequences",
       "title": "Consequences and Applications",
       "startLine": 298,
-      "endLine": 343,
+      "endLine": 346,
       "summary": "**Proves** corollaries: `trivial_pi1_implies_sphere`, `poincare_of_trivial_pi1` (bridging FundamentalGroup), contrapositive, and dichotomy.",
       "mathContext": "Corollaries: pi_1(M) = 0 implies M ~ S^3 (the conjecture). Both directions: classification."
     },
     {
       "id": "sphere-properties",
       "title": "Generalized $n$-Sphere Properties",
-      "startLine": 351,
+      "startLine": 347,
       "endLine": 377,
       "summary": "**Proves** connectedness, path-connectedness, nonemptiness, and compactness of $S^n \\subset \\mathbb{R}^{n+1}$ for all $n$.",
       "mathContext": "S^3: connected, path-connected, compact, non-empty. All proved from Mathlib."
@@ -249,7 +249,7 @@
       "id": "summary",
       "title": "Summary of Verified Results",
       "startLine": 629,
-      "endLine": 17663,
+      "endLine": 17684,
       "summary": "Catalogues all proved results (15+) and axiomatized components (~12), with `#check` statements verifying each declaration.",
       "mathContext": "SOLVED (Perelman 2003). Simply connected closed 3-manifold ~ S^3. Via Ricci flow with surgery."
     }


### PR DESCRIPTION
## Enrichment: poincare-conjecture

Two declarations fell outside every section in an otherwise well-covered file:

- **`compact_of_homeomorphic`** (theorem, line 348) — a compactness-transfer helper (`X ≃ₜ Y`, `CompactSpace X ⟹ CompactSpace Y`) sitting between "Consequences and Applications" `[298-343]` and "Generalized n-Sphere Properties" `[351-377]`. Since `[351-377]` explicitly "**Proves** … compactness of Sⁿ" and this lemma is the tool for that, pulled its `startLine` 351 → **347** to cover it; also extended `[298-343]` 343 → **346** to absorb its own trailing proof lines.
- **`part_c_summary`** (theorem, line 17676) — the panorama length-count capstone, stranded just past "Summary of Verified Results" `[629-17663]`. Extended `endLine` 17663 → **17684** (EOF).

Anchor-only corrections; no prose invented, no overlaps. Uncovered-declaration scan now reports **0 stranded declarations** for poincare-conjecture. JSON validated.
