### PR TITLE
audit: erdos-617 remove phantom axiom from originalContributions

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15076,9 +15076,9 @@
     },
     "erdos-617": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:36Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T18:38:09Z",
+      "result": "issues-fixed"
     },
     "erdos-618": {
       "agentId": "auditor-cycle-21-erdos-618",

--- a/src/data/proofs/erdos-617/meta.json
+++ b/src/data/proofs/erdos-617/meta.json
@@ -50,7 +50,6 @@
       "r_3_solved axiom (Erdős-Gyárfás 1999)",
       "r_4_solved axiom (Erdős-Gyárfás 1999)",
       "r_2_false axiom (counterexample)",
-      "r_squared_balanced axiom (tightness)",
       "erdos_617_summary theorem"
     ],
     "axiomCount": 4,


### PR DESCRIPTION
## Gallery integrity audit — erdos-617

**Result:** issues-fixed (LOW severity, phantom declaration)

### Finding
`originalContributions` listed `"r_squared_balanced axiom (tightness)"`, but no such axiom exists in `Proofs/Erdos617Problem.lean`.

The file contains exactly **4 axioms**: `coloursUsed`, `r_3_solved`, `r_4_solved`, `r_2_false` — which correctly match `axiomCount: 4` and the `assumptions` field. Only the prose contribution list invented a fifth "axiom".

### Verification (all clean)
- sorries: 0 (matches) · axiomCount: 4 (matches) · theoremCount: 2 (matches: `edge_count_clique`, `erdos_617_summary`)
- Axioms are consistent, not False-masking: `coloursUsed` is an opaque uninterpreted function; the three result-axioms constrain it at disjoint type indices `(10,3,4)`, `(17,4,5)`, `(5,2,3)` — no kernel contradiction.
- status `axiomatized` / badge `axiom` / erdosStatus `open` — honest Tier C, no overclaiming.

### Fix
Removed the phantom `r_squared_balanced axiom (tightness)` entry from `originalContributions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)