### PR TITLE
audit: erdos-615 reserve re-audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15064,8 +15064,8 @@
     },
     "erdos-615": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:36Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T18:43:51Z",
       "result": "clean"
     },
     "erdos-616": {


### PR DESCRIPTION
## Reserve-mode re-audit: erdos-615 (Ramsey-Turán #615, Fox-Loh-Zhao)

Queue drained (0 unaudited) → round-robin re-serve of oldest audit. Result: **clean**.

### Verified
- **2 axioms** (`erdos_615_false`, `rt_linear`) — matches `axiomCount: 2`; both real & disclosed
- **3 theorems**, **11 defs**, **0 sorries**, **0 native_decide** — all match meta
- Disproof `¬erdos_615_conjecture` is **sound** — negates a genuine `∃c>0,∀ᶠn` statement, matches Fox-Loh-Zhao (2015) answer (NO); axioms cover disjoint regimes (n/log n vs linear εn), no joint inconsistency
- Status `axiomatized` / badge `axiom` honest; Fox-Loh-Zhao credited; `originalContributions` all real decls

### Minor nit (not fixed — cosmetic)
Some `sections[]` summaries name comment-block topics (`ehss_upper_bound`, `sudakov_upper_bound`, `fox_loh_zhao_lower_bound`, `turan_k4`, `rt_turan_bound`, `simonovits_sos_construction`) as if declarations. They are `/- -/` comment blocks only. Headline counts/status/badge are accurate, so no overstatement of formalization strength.

Tracker: auditCount 3→4, result clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)