### PR TITLE
Research: erdos-85-wip-01 — explicit closed-form upper bound f(n) ≤ √n + 2

### DIFF
--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -719,4 +719,60 @@ theorem minDegreeForC4_six : minDegreeForC4 6 = 3 := by
   have hge : 3 ≤ minDegreeForC4 6 := three_le_minDegreeForC4 (by norm_num)
   omega
 
+/-!
+## An explicit `O(√n)` upper bound
+
+The counting bound `minDegreeForC4_le_of_choose_lt` gives `f(n) = O(√n)` only implicitly,
+through the choose inequality `C(n,2) < n · C(k,2)`.  We now unfold that into a clean,
+quotable **closed form** valid for every `n ≥ 1`:
+
+  `f(n) ≤ √n + 2`.
+
+This is the matching upper bound of the correct order — the true asymptotics are
+`f(n) = (1 + o(1))√n`, so the leading constant `1` here is sharp; only an additive `O(1)`
+is lost relative to the sharp Kővári–Sós–Turán constant `(1 + √(4n−3))/2`.  It dwarfs the
+elementary linear bound `f(n) ≤ n − 2`.
+-/
+
+/-- Divisibility helper: `m · (m − 1)` is always even (one of two consecutive integers is). -/
+private theorem two_dvd_mul_pred (m : ℕ) : 2 ∣ m * (m - 1) := by
+  rcases Nat.even_or_odd m with he | ho
+  · exact Dvd.dvd.mul_right he.two_dvd _
+  · exact Dvd.dvd.mul_left (Nat.Odd.sub_odd ho odd_one).two_dvd _
+
+/-- Doubling identity: `2 · C(m, 2) = m · (m − 1)` (the halving in `Nat.choose 2` is exact). -/
+private theorem two_mul_choose_two (m : ℕ) : 2 * m.choose 2 = m * (m - 1) := by
+  rw [Nat.choose_two_right]; exact Nat.mul_div_cancel' (two_dvd_mul_pred m)
+
+/-- **Arithmetic core of the counting bound.**  For `n ≥ 1`, the hypothesis `n ≤ k(k−1)`
+implies the strict cherry-vs-pair inequality `C(n,2) < n · C(k,2)` consumed by
+`minDegreeForC4_le_of_choose_lt`.  (Both `n(n−1)` and `k(k−1)` are even, so doubling
+reduces the claim to `n − 1 < k(k−1)`, which follows from `n ≤ k(k−1)`.) -/
+theorem choose_two_lt_of_le_mul_pred {n k : ℕ} (hn : 1 ≤ n) (h : n ≤ k * (k - 1)) :
+    n.choose 2 < n * k.choose 2 := by
+  have key : 2 * n.choose 2 < 2 * (n * k.choose 2) := by
+    rw [two_mul_choose_two n, mul_left_comm 2 n (k.choose 2), two_mul_choose_two k]
+    have hstep : n - 1 < k * (k - 1) := by omega
+    exact Nat.mul_lt_mul_of_pos_left hstep (by omega)
+  exact Nat.lt_of_mul_lt_mul_left key
+
+/-- **`n ≤ k(k−1)` forces `f(n) ≤ k`.**  A cleaner packaging of the counting bound: as soon
+as `k(k−1) ≥ n`, minimum degree `k` on `n` vertices already yields more cherries than vertex
+pairs, hence a `C₄`.  This is the reformulation that makes the `√n` order transparent. -/
+theorem minDegreeForC4_le_of_le_mul_pred {n k : ℕ} (hn : 1 ≤ n) (h : n ≤ k * (k - 1)) :
+    minDegreeForC4 n ≤ k :=
+  minDegreeForC4_le_of_choose_lt (choose_two_lt_of_le_mul_pred hn h)
+
+/-- **Explicit `O(√n)` upper bound: `f(n) ≤ √n + 2` for all `n ≥ 1`.**  Take `k = √n + 2`.
+Since `n < (√n + 1)²` we have `n ≤ (√n)² + 2√n`, while `k(k−1) = (√n + 2)(√n + 1) =
+(√n)² + 3√n + 2 ≥ n`, so `minDegreeForC4_le_of_le_mul_pred` applies.  The leading constant
+`1` matches the true `f(n) = (1 + o(1))√n`; only an additive constant is lost. -/
+theorem minDegreeForC4_le_sqrt {n : ℕ} (hn : 1 ≤ n) :
+    minDegreeForC4 n ≤ Nat.sqrt n + 2 := by
+  apply minDegreeForC4_le_of_le_mul_pred hn
+  have hlt : n < (Nat.sqrt n + 1) * (Nat.sqrt n + 1) := Nat.lt_succ_sqrt n
+  have hsub : Nat.sqrt n + 2 - 1 = Nat.sqrt n + 1 := by omega
+  rw [hsub]
+  nlinarith [hlt]
+
 end Erdos85

--- a/research/problems/erdos-85-wip-01/knowledge.md
+++ b/research/problems/erdos-85-wip-01/knowledge.md
@@ -252,3 +252,34 @@ The truth `f(n) = (1+o(1))√n` needs the **Kővári–Sós–Turán double coun
   vertices has `≥ ⌈21/2⌉ = 11 > 9` edges) — a genuine extremal input beyond the crude cherry
   count. This is the next exact value and the point where naive KST stops being sharp.
 - The general monotonicity core `f(n+1) ≥ f(n)` (the actual open Erdős question) stays open.
+
+## Session 2026-07-21 (researcher-1-4) — explicit closed-form upper bound f(n) ≤ √n + 2
+
+**Mode**: build on the KST cherry-count. **Outcome**: progress — 4 theorems (2 private helpers),
+axiom-free (`#print axioms` = `[propext, Classical.choice, Quot.sound]`, no `native_decide`),
+host-verified `lake env lean` exit 0. File 722→778 lines.
+
+Unfolded the implicit `O(√n)` of `minDegreeForC4_le_of_choose_lt` into a quotable **closed form**:
+
+- `minDegreeForC4_le_sqrt (hn : 1 ≤ n) : minDegreeForC4 n ≤ Nat.sqrt n + 2`. Take `k = √n + 2`:
+  `Nat.lt_succ_sqrt n` gives `n < (√n+1)²`, so `n ≤ (√n)²+2√n`, while
+  `k(k−1) = (√n+2)(√n+1) = (√n)²+3√n+2 ≥ n`; `nlinarith` closes it. Leading constant `1`
+  matches the true `f(n)=(1+o(1))√n`; only additive `O(1)` lost vs sharp `(1+√(4n−3))/2`.
+- `minDegreeForC4_le_of_le_mul_pred (hn : 1≤n) : n ≤ k(k−1) → minDegreeForC4 n ≤ k` — clean
+  reformulation of the counting bound; makes the `√n` order transparent (`k(k−1)≥n ≈ k≈√n`).
+- `choose_two_lt_of_le_mul_pred (hn : 1≤n) : n ≤ k(k−1) → C(n,2) < n·C(k,2)` — arithmetic
+  bridge to `minDegreeForC4_le_of_choose_lt`.
+
+### Reusable Lean recipe
+- `2 * m.choose 2 = m*(m−1)`: `rw [Nat.choose_two_right]; exact Nat.mul_div_cancel' h2dvd`
+  where `h2dvd : 2 ∣ m*(m−1)` (case `Even m` / `Odd m ⟹ Even (m−1)` via `Nat.Odd.sub_odd`).
+- Clear the `Nat.choose 2` floor-division by DOUBLING: prove `2*LHS < 2*RHS` then
+  `Nat.lt_of_mul_lt_mul_left`. Avoids fighting `/2` under `omega`/`nlinarith`.
+- `mul_left_comm 2 n (k.choose 2)` to move the `2` next to `k.choose 2` before rewriting.
+- Sqrt closed forms: `Nat.lt_succ_sqrt n : n < (√n+1)*(√n+1)` feeds `nlinarith` directly.
+
+### Next
+- Sharpen the additive constant toward `√n + 1` (holds when `n ≤ (√n)²+√n`, i.e. the lower
+  half of each `[s²+1, (s+1)²]` window); a case split on `n ≤ √n·(√n+1)` gives `√n+1` there.
+- `f(7)` exact needs `ex(7; C₄) = 9` (KST count only gives `f(7) ≤ 4`, cycle gives `≥ 3`).
+- The OPEN core remains eventual monotonicity `f(n+1) ≥ f(n)` — untouched.

--- a/src/data/proofs/erdos-85/meta.json
+++ b/src/data/proofs/erdos-85/meta.json
@@ -192,9 +192,9 @@
       "Topology"
     ],
     "namespace": "Erdos85",
-    "lineCount": 722,
+    "lineCount": 778,
     "axiomCount": 0,
-    "theoremCount": 27,
+    "theoremCount": 30,
     "definitionCount": 8,
     "path": "Proofs/Erdos85Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-85-wip-01.json
+++ b/src/data/research/problems/erdos-85-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Exact values f(4)=2, f(5)=3, f(6)=3 (all axiom-free). KST cherry-counting lemma containsC4_of_card_choose_two_lt (Σ C(deg v,2) > C(n,2) ⟹ C₄) gives the general upper bound minDegreeForC4_le_of_choose_lt (f(n) ≤ k when C(n,2) < n·C(k,2), i.e. n ≤ k(k−1)) — √n-order, first bound matching the true asymptotic order f(n)=(1+o(1))√n and beating linear n−2. Lower bounds f(n)≥3 (n≥5) from cycleGraph. Next: f(7) (KST gives f(7)≤3 since 7≤3·2? no 7>6; k=4 gives 7≤12 so f(7)≤4; true f(7)=3 needs sharper ex(7;C4)=9) and monotonicity core.",
+    "progressSummary": "Exact values f(4)=2, f(5)=3, f(6)=3 (axiom-free). KST cherry-counting bound minDegreeForC4_le_of_choose_lt now unfolds into an EXPLICIT closed form: minDegreeForC4_le_sqrt gives f(n) ≤ √n + 2 for all n≥1 via k=√n+2 (n<(√n+1)² ⟹ n≤k(k−1)). This is the matching upper bound of the true order f(n)=(1+o(1))√n — leading constant 1 sharp, additive O(1) loose. Lower bounds f(n)≥3 (n≥5) from cycleGraph. Next: sharpen additive constant toward √n+1 (holds when n≤√n²+√n); f(7) exact needs ex(7;C4); eventual-monotonicity (the OPEN core).",
     "builtItems": [
       "C4_adj_zero_one/one_two/two_three/three_zero (four cycle edges) in Erdos85Problem.lean",
       "C4_not_adj_zero_two (diagonal non-edge) in Erdos85Problem.lean",
@@ -45,7 +45,11 @@
       "three_le_minDegreeForC4 (Erdos85Problem.lean): ∀ n≥5, 3 ≤ minDegreeForC4 n — GENERAL lower bound f(n)≥3, generalises the C5 point-witness",
       "containsC4_of_card_choose_two_lt in Erdos85Problem.lean — pigeonhole KST lemma: C(|V|,2) < Σ_v C(deg v,2) ⟹ containsC4 (cherries = univ.sigma (N v).powersetCard 2, map ⟨v,e⟩↦e, Finset.exists_ne_map_eq_of_card_lt_of_maps_to)",
       "minDegreeForC4_le_of_choose_lt in Erdos85Problem.lean — n.choose 2 < n * k.choose 2 ⟹ f(n) ≤ k (KST √n-order upper bound)",
-      "minDegreeForC4_six in Erdos85Problem.lean — f(6) = 3 (third exact value; C(6,2)=15 < 18=6·C(3,2))"
+      "minDegreeForC4_six in Erdos85Problem.lean — f(6) = 3 (third exact value; C(6,2)=15 < 18=6·C(3,2))",
+      "two_dvd_mul_pred / two_mul_choose_two (2·C(m,2)=m(m−1)) helpers in Erdos85Problem.lean",
+      "choose_two_lt_of_le_mul_pred: n≤k(k−1) ⟹ C(n,2)<n·C(k,2) (arithmetic core of KST count)",
+      "minDegreeForC4_le_of_le_mul_pred: n≤k(k−1) ⟹ f(n)≤k (clean packaging of the counting bound)",
+      "minDegreeForC4_le_sqrt: f(n) ≤ Nat.sqrt n + 2 for n≥1 (explicit O(√n) upper bound)"
     ],
     "insights": [
       "Erdos85Problem.lean was a definitions-only stub (7 defs, 0 theorems). Asymptotics f(n)=(1+o(1))sqrt(n), f(4)=2, and the Ramsey reformulation need extremal graph theory beyond Mathlib; tractable axiom-free content is structural facts about C4, containsC4, and starGraph.",
@@ -62,7 +66,8 @@
       "minDegreeForC4_four: f(4) = 2 EXACTLY (first determined threshold value), combining star lower bound f(4)≥2 with n=4 case of the n-2 upper bound. Resolves the previously documented-only base case.",
       "Lean idiom: for a ∀G-with-[DecidableRel] statement, the sInf-membership pattern `apply Nat.sInf_le; intro G _ hmin` handles the instance binder cleanly. Non-neighbour cardinality via Finset.card_sdiff_add_card_eq_card (subset form) + omega; card_sdiff hypothesis-free in v4.31.",
       "minDegreeForC4_five: f(5) = 3 EXACTLY — the cycle lower bound f(5)≥3 (three_le_minDegreeForC4) meets the n-2 upper bound at n=5 (5-2=3). Second determined value, immediate corollary of the two new bounds.",
-      "Kővári–Sós–Turán cherry-counting: Σ_v C(deg v,2) counts paths of length 2; each is determined by centre + unordered endpoint pair. If the count exceeds C(|V|,2), pigeonhole gives a pair with two common neighbours = a C₄. This is the C₄/z(n;2,2) case of KST and drives the true √n-order threshold (f(n)=O(√n)), far beating the linear n−2 bound."
+      "Kővári–Sós–Turán cherry-counting: Σ_v C(deg v,2) counts paths of length 2; each is determined by centre + unordered endpoint pair. If the count exceeds C(|V|,2), pigeonhole gives a pair with two common neighbours = a C₄. This is the C₄/z(n;2,2) case of KST and drives the true √n-order threshold (f(n)=O(√n)), far beating the linear n−2 bound.",
+      "Explicit closed-form upper bound minDegreeForC4_le_sqrt: f(n) ≤ √n + 2 for all n ≥ 1 (axiom-free). Leading constant 1 matches the true f(n)=(1+o(1))√n; only an additive O(1) is lost vs the sharp KST constant (1+√(4n−3))/2. First quotable closed-form of the correct order for this entry."
     ],
     "mathlibGaps": [
       "Fin n has NO global CommRing instance (only scoped Fin.instCommRing via `open Fin.CommRing`, gated on NeZero n); needed for ring/linear_combination on cycleGraph differences"


### PR DESCRIPTION
## Summary
Research session for **erdos-85-wip-01** (minimum degree forcing a `C₄`; `f(n) = O(√n)`).

The prior work gave the Kővári–Sós–Turán cherry-counting bound
`minDegreeForC4_le_of_choose_lt` — but only *implicitly* `O(√n)`, through the
choose inequality `C(n,2) < n·C(k,2)`. This session unfolds it into a clean,
quotable **closed form** valid for every `n ≥ 1`.

## Progress
- **`minDegreeForC4_le_sqrt (hn : 1 ≤ n) : minDegreeForC4 n ≤ Nat.sqrt n + 2`** — the
  explicit `O(√n)` upper bound. Take `k = √n + 2`: `Nat.lt_succ_sqrt` gives
  `n < (√n+1)²`, hence `n ≤ (√n)²+2√n`, while `k(k−1) = (√n+2)(√n+1) = (√n)²+3√n+2 ≥ n`.
- `minDegreeForC4_le_of_le_mul_pred (hn : 1≤n) : n ≤ k(k−1) → minDegreeForC4 n ≤ k` —
  clean reformulation of the counting bound that makes the `√n` order transparent.
- `choose_two_lt_of_le_mul_pred` + `two_mul_choose_two` / `two_dvd_mul_pred` — the
  arithmetic bridge (`2·C(m,2)=m(m−1)`, doubling to clear the `Nat.choose 2` floor-division).

All in `proofs/Proofs/Erdos85Problem.lean` (722 → 778 lines).

## Findings
- The leading constant `1` is **sharp**: the true asymptotic is `f(n)=(1+o(1))√n`, so
  `√n + 2` matches the correct order; only an additive `O(1)` is lost relative to the
  sharp KST constant `(1+√(4n−3))/2`. It dwarfs the elementary linear `f(n) ≤ n − 2`.
- Recipe: clear `Nat.choose 2`'s floor-division by proving `2·LHS < 2·RHS` then
  `Nat.lt_of_mul_lt_mul_left`, rather than fighting `/2` under `omega`/`nlinarith`.

## Verification
- Host-verified: `lake env lean Proofs/Erdos85Problem.lean` exit 0 (v4.31.0).
- Axiom-free: `#print axioms minDegreeForC4_le_sqrt` = `[propext, Classical.choice, Quot.sound]`
  (no `native_decide` / `Lean.ofReduceBool` / `sorryAx`).

## Status
**Outcome**: progress
**Next Steps**: sharpen the additive constant toward `√n + 1` (holds on the lower half of
each `[s²+1,(s+1)²]` window); `f(7)` exact needs `ex(7;C₄)=9`; the OPEN core is eventual
monotonicity `f(n+1) ≥ f(n)`.

🤖 Generated by researcher-1-4
