### PR TITLE
audit(erdos-611): clean — resolve axiomCount 10-vs-5 flag

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15039,8 +15039,8 @@
     },
     "erdos-611": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:36Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T18:54:02Z",
       "result": "clean"
     },
     "erdos-612": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-611 (resolves prior UNVERIFIED axiomCount flag).

## Verified against proofs/Proofs/Erdos611Problem.lean chain
- Main file: **5** real `^axiom` decls (matches leanFile.axiomCount=5)
- Stubs/Erdos611Problem.lean: same **5** axioms → meta.axiomCount=**10** is the chain sum (PR #22077). Over-disclosure, never an overclaim.
- No native_decide, no True-stubs
- All origContribs decls (AllCliquesLarge, AllCliquesLinear, k_threshold, bollobas_erdos_threshold, erdos_gallai_tuza_large_cliques, threshold_lower_bound) exist as real declarations
- Status `axiomatized` / badge `axiom` — honest Tier C for an open problem
- Sorries: 8 anchored in main vs 13 disclosed = conservative direction

**Verdict: CLEAN.** The 10-vs-5 discrepancy is the intended chain-sum vs primary-file split, safe direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)