### PR TITLE
Research: cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03 — evaluation isomorphism C(T) ≃ₗ[K] V

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius.lean
@@ -143,6 +143,63 @@ theorem finrank_centralizer_eq_of_cyclic [FiniteDimensional K V]
   le_antisymm (finrank_centralizer_le_of_cyclic T v hcyc)
     (CyclicCommutantConverse.endK_centralizer_bound T)
 
+-- ============================================================
+-- SECTION IV: the evaluation isomorphism  C(T) ≃ₗ[K] V
+-- ============================================================
+
+/-- **Evaluation at `v`**, `A ↦ A·v`, as a `K`-linear map from the centralizer
+    submodule of `T` into `V`.  (Named form of the map used implicitly in
+    `finrank_centralizer_le_of_cyclic`; here we upgrade it to an isomorphism.) -/
+def centralizerEval (T : Module.End K V) (v : V) :
+    ↥(Subalgebra.toSubmodule (Subalgebra.centralizer K ({T} : Set (Module.End K V))))
+      →ₗ[K] V where
+  toFun A := (A : Module.End K V) v
+  map_add' A B := by simp only [Submodule.coe_add, LinearMap.add_apply]
+  map_smul' c A := by simp only [Submodule.coe_smul, LinearMap.smul_apply, RingHom.id_apply]
+
+/-- Evaluation at a cyclic vector is injective on the centralizer: two operators
+    commuting with `T` that agree on `v` are equal (`commuting_end_eq_of_apply_eq`). -/
+theorem centralizerEval_injective [FiniteDimensional K V]
+    (T : Module.End K V) (v : V) (hcyc : IsEndCyclicVector T v) :
+    Function.Injective (centralizerEval T v) := by
+  set S := Subalgebra.centralizer K ({T} : Set (Module.End K V)) with hS_def
+  intro A B hAB
+  have hAB' : (A : Module.End K V) v = (B : Module.End K V) v := hAB
+  have hAmem : (A : Module.End K V) ∈ S := (Subalgebra.mem_toSubmodule S).mp A.2
+  have hBmem : (B : Module.End K V) ∈ S := (Subalgebra.mem_toSubmodule S).mp B.2
+  have hAcomm : (A : Module.End K V) * T = T * (A : Module.End K V) :=
+    ((Subalgebra.mem_centralizer_iff K).mp hAmem T (Set.mem_singleton _)).symm
+  have hBcomm : (B : Module.End K V) * T = T * (B : Module.End K V) :=
+    ((Subalgebra.mem_centralizer_iff K).mp hBmem T (Set.mem_singleton _)).symm
+  exact Subtype.ext (commuting_end_eq_of_apply_eq T v hcyc _ _ hAcomm hBcomm hAB')
+
+/-- **The evaluation isomorphism.**  For `T : Module.End K V` (over a
+    finite-dimensional `V`) with a cyclic vector `v`, evaluation at `v`,
+    `A ↦ A·v`, is a `K`-linear **isomorphism** from the centralizer `C(T)` onto
+    the whole space `V`:
+
+        C(T) ≃ₗ[K] V,   A ↦ A·v.
+
+    This strengthens the Frobenius dimension *equality*
+    (`finrank_centralizer_eq_of_cyclic`) to a canonical *equivalence*: the map is
+    injective by `centralizerEval_injective` and the two spaces have equal
+    dimension, so it is bijective.  It is the `K`-linear shadow of the statement
+    "`V` is a free rank-`1` module over the commutative ring `K[T] = C(T)`" — the
+    module-theoretic content of `v` being a cyclic vector. -/
+noncomputable def centralizerEvalEquiv [FiniteDimensional K V]
+    (T : Module.End K V) (v : V) (hcyc : IsEndCyclicVector T v) :
+    ↥(Subalgebra.toSubmodule (Subalgebra.centralizer K ({T} : Set (Module.End K V))))
+      ≃ₗ[K] V :=
+  (centralizerEval T v).linearEquivOfInjective
+    (centralizerEval_injective T v hcyc)
+    (finrank_centralizer_eq_of_cyclic T v hcyc)
+
+@[simp]
+theorem centralizerEvalEquiv_apply [FiniteDimensional K V]
+    (T : Module.End K V) (v : V) (hcyc : IsEndCyclicVector T v)
+    (A : ↥(Subalgebra.toSubmodule (Subalgebra.centralizer K ({T} : Set (Module.End K V))))) :
+    centralizerEvalEquiv T v hcyc A = (A : Module.End K V) v := rfl
+
 end EndCyclicCommutant
 
 end

--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/knowledge.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/knowledge.md
@@ -109,3 +109,44 @@ direction has no elementary route: `dim C(T) = n` does not imply `dim K[T] = n` 
 `dim K[T] = deg minpoly ≤ n`), so the shortcut through `K[T]` fails; genuine structure theory is
 required. **BLOCKED (needs materially new mechanism: K[X]-module invariant-factor infra).**
 Standing down — no filler shipped. See [[reference-researcher-depthfirst-tier-serves-completed]].
+
+## Session 2026-07-21 (researcher-1-4) — evaluation ISOMORPHISM C(T) ≃ₗ[K] V
+
+**Mode**: build on the Frobenius dimension equality. **Outcome**: progress — 1 def + 1 theorem
+(+ 1 def + 1 @[simp] apply lemma), axiom-free (`#print axioms` = `[propext, Classical.choice,
+Quot.sound]`). Verified BOTH Docker (`docker-build.sh ...OQ02OQ03Frobenius`, exit 0, 8582 jobs)
+and host (`lake env lean` after rebuilding the parent olean chain). File 149→205 lines.
+
+Added to `CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius.lean` (Section IV):
+
+- `centralizerEval (T v) : ↥(toSubmodule (centralizer K {T})) →ₗ[K] V`, `A ↦ A·v`.
+- `centralizerEval_injective` — injective at a cyclic vector (wraps `commuting_end_eq_of_apply_eq`).
+- **`centralizerEvalEquiv (T v hcyc) : C(T) ≃ₗ[K] V`** — the headline: evaluation at a cyclic
+  vector is a K-linear ISOMORPHISM of the centralizer onto the whole space. Built via
+  `LinearMap.linearEquivOfInjective` (injective + `finrank_centralizer_eq_of_cyclic` equal-dim
+  ⟹ bijective). Strengthens the dimension EQUALITY to a canonical equivalence and re-derives it
+  as a corollary. It is the K-linear shadow of "V is a free rank-1 module over K[T]=C(T)".
+- `centralizerEvalEquiv_apply` `@[simp]`: `e A = (A:End) v` (`rfl`).
+
+### Reusable Lean recipe
+- `LinearMap.linearEquivOfInjective f hf hdim : V ≃ₗ[K] V₂` (in
+  `Mathlib/LinearAlgebra/FiniteDimensional/Lemmas.lean`) turns an injective map between
+  equal-finrank finite-dim spaces into an equiv; the `@[simp] linearEquivOfInjective_apply`
+  makes the apply lemma `rfl`.
+- `finrank_centralizer_eq_of_cyclic` (a `Subalgebra.centralizer` finrank) feeds `hdim`
+  directly — `finrank K S = finrank K (↥(toSubmodule S))` is `rfl`.
+- Host verify of a `Proofs.*`-importing file needs the WHOLE parent olean chain fresh
+  (`incompatible header` on any pre-v4.31 olean): build bottom-up with
+  `lake env lean Proofs/X.lean -o .lake/build/lib/lean/Proofs/X.olean`. Docker build does NOT
+  persist compatible host oleans. Chain here: Minpoly…WIP04 → CyclicVectorAllFields →
+  {OQ01OQ01, OQ02} → OQ02OQ01, OQ02OQ03.
+
+### State of this OQ node (BLOCKED at elementary layer)
+The Module.End lift is complete: centralizer=K[T] (`end_centralizer_eq_adjoin`), commutativity
+(`end_commutant_commutative`), dimension equality (`finrank_centralizer_eq_of_cyclic`), and now
+the evaluation isomorphism (`centralizerEvalEquiv`). The one remaining direction is the deep
+converse `dim C(T)=n ⟹ T cyclic`, which needs rational-canonical-form / invariant-factor
+infrastructure ABSENT from Mathlib v4.31 — registered as a structured blocker
+(reopen: "materially new mechanism required"). Natural adjacent results (minpoly degree = n)
+are also gated: `Algebra.adjoin.powerBasis` requires `CommRing S`, which `Module.End K V` is not.
+STAND DOWN at the elementary layer for this node.

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/meta.json
@@ -165,6 +165,21 @@
     "definitionCount": 1,
     "path": "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03.lean",
     "sorries": 0,
-    "additionalFiles": []
+    "additionalFiles": [
+      {
+        "path": "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius.lean",
+        "imports": [
+          "Mathlib",
+          "Proofs.CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03",
+          "Proofs.CayleyHamiltonCyclicVectorAllFieldsOQ02OQ01"
+        ],
+        "namespace": "EndCyclicCommutant",
+        "lineCount": 205,
+        "axiomCount": 0,
+        "theoremCount": 5,
+        "definitionCount": 2,
+        "sorries": 0
+      }
+    ]
   }
 }

--- a/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03.json
@@ -36,12 +36,16 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-07-20, researcher-1, host-verified 0-axiom): Packaged the endomorphism centralizer=K[T] result as a canonical SUBALGEBRA equality end_centralizer_eq_adjoin (Subalgebra.centralizer K {T} = Algebra.adjoin K {T}) for cyclic T, combining the two proven inclusions into one reusable statement. The core lift to Module.End (commuting_end_is_polynomial + Frobenius dimension equality) is complete. The deep converse (dim C(T)=n ⟹ cyclic vector exists, needing rational canonical form) remains open and is not session-sized.",
+    "progressSummary": "PROGRESS (2026-07-21, researcher-1-4, Docker+host verified 0-axiom): Upgraded the Frobenius dimension EQUALITY dim C(T)=dim V to a canonical K-linear ISOMORPHISM centralizerEvalEquiv : C(T) ≃ₗ[K] V, A ↦ A·v (injective rigidity + equal finrank). This is the module-theoretic content of a cyclic vector (V free rank-1 over K[T]=C(T)) and re-derives the dimension equality as a corollary. The core lift to Module.End (centralizer=K[T], commutativity, Frobenius equality, and now the evaluation iso) is complete. The deep converse (dim C(T)=n ⟹ cyclic, needing rational canonical form) remains BLOCKED (RCF infra absent from Mathlib v4.31).",
     "builtItems": [
       "IsEndCyclicVector (def) + endKrylov_linearIndependent + commuting_end_is_polynomial + end_commutant_commutative + aeval_end_commute in Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03.lean (5 thm/lemma, 1 def, 197 L). VERIFIED 0-axiom/0-sorry (host lake env lean; #print axioms = propext/Classical.choice/Quot.sound). Imports only Mathlib.",
       "Gallery entry src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/ (meta.json + annotations.json), status verified, badge original.",
       "commuting_end_eq_of_apply_eq, finrank_centralizer_le_of_cyclic, finrank_centralizer_eq_of_cyclic in CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius.lean (0 axioms, 0 sorries; #print axioms = [propext, Classical.choice, Quot.sound])",
-      "end_centralizer_eq_adjoin in CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03.lean — Subalgebra.centralizer K {T} = Algebra.adjoin K {T} for cyclic T, 0-axiom host-verified"
+      "end_centralizer_eq_adjoin in CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03.lean — Subalgebra.centralizer K {T} = Algebra.adjoin K {T} for cyclic T, 0-axiom host-verified",
+      "centralizerEval (LinearMap A ↦ A·v on the centralizer submodule) in ...OQ02OQ03Frobenius.lean",
+      "centralizerEval_injective (evaluation at a cyclic vector is injective on C(T))",
+      "centralizerEvalEquiv : C(T) ≃ₗ[K] V via LinearMap.linearEquivOfInjective + finrank_centralizer_eq_of_cyclic",
+      "centralizerEvalEquiv_apply @[simp]: e A = (A:End) v"
     ],
     "insights": [
       "The matrix commutant proof (oq-02, CyclicCommutant.commuting_matrix_is_polynomial) lifts one-to-one to Module.End K V: Matrix.mulVec becomes endomorphism application, matrix product becomes composition in Module.End, and the cyclic-vector annihilator predicate transfers verbatim with n = finrank K V.",
@@ -50,7 +54,8 @@
       "Frobenius bound is EQUALITY in the cyclic case: for T:Module.End K V with a cyclic vector, dim_K C(T) = dim_K V. The clean ≤ half is that evaluation A↦A·v is injective on the centralizer (operators commuting with T agreeing on a cyclic vector agree on the whole Krylov basis); ≥ is the general endK_centralizer_bound. This is the minimal-centralizer/nonderogatory edge of the triangle.",
       "Centralizer=K[T] now packaged as a subalgebra equality: end_centralizer_eq_adjoin (Subalgebra.centralizer K {T} = Algebra.adjoin K {T}) for a cyclic endomorphism, combining commuting_end_is_polynomial (⊆) and aeval_end_commute (⊇).",
       "Recipe: Algebra.adjoin_singleton_eq_range_aeval rewrites adjoin K {T} to (aeval T).range; Subalgebra.mem_centralizer_iff unfolds centralizer membership to ∀ g∈s, g*a=a*g; range membership discharged by the anonymous ⟨p, _⟩ constructor.",
-      "Gotcha: subst hg with hg : g = T eliminates T (not g), breaking later references to T; use rw [hg] to rewrite g→T instead."
+      "Gotcha: subst hg with hg : g = T eliminates T (not g), breaking later references to T; use rw [hg] to rewrite g→T instead.",
+      "Evaluation isomorphism: for a cyclic vector v, the map A ↦ A·v is a K-linear ISOMORPHISM centralizerEvalEquiv : C(T) ≃ₗ[K] V (injective by rigidity + equal finrank ⟹ bijective). Strengthens the Frobenius dimension EQUALITY to a canonical equivalence — the K-linear shadow of V being a free rank-1 K[T]-module."
     ],
     "nextSteps": [
       "The hard converse: dim C(T)=n (or centralizer=K[T]) IMPLIES T has a cyclic vector — completes nonderogatory⟺cyclic⟺C(T)=K[T]. Requires rational canonical form / structure theory; not session-sized.",


### PR DESCRIPTION
## Summary
Research session for **cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03** (the centralizer /
nonderogatory edge of `nonderogatory ⟺ cyclic ⟺ C(T)=K[T]`, in the coordinate-free
`Module.End` setting).

Prior work established the Frobenius dimension **equality** `dim_K C(T) = dim_K V` for a
cyclic endomorphism. This session upgrades that count to a canonical **isomorphism**.

## Progress
Added to `proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius.lean` (Section IV):

- **`centralizerEvalEquiv (T v hcyc) : C(T) ≃ₗ[K] V`** — for a cyclic vector `v`, evaluation
  `A ↦ A·v` is a `K`-linear **isomorphism** of the centralizer onto the whole space. Built from
  injectivity (`centralizerEval_injective`, i.e. two operators commuting with `T` that agree on
  `v` are equal) plus the equal-dimension fact `finrank_centralizer_eq_of_cyclic`, via
  `LinearMap.linearEquivOfInjective`.
- `centralizerEval` — the evaluation `LinearMap` named on the centralizer submodule.
- `centralizerEval_injective`, and the `@[simp]` action lemma `centralizerEvalEquiv_apply : e A = A·v`.

This strengthens the dimension equality to a canonical equivalence and re-derives it as a
corollary. It is the `K`-linear shadow of "`V` is a free rank-`1` module over the commutative
ring `K[T] = C(T)`" — the module-theoretic content of `v` being a cyclic vector.

Also registered the Frobenius companion file in `meta.leanFile.additionalFiles` (it was absent).

## Verification
- **Docker**: `./proofs/scripts/docker-build.sh Proofs.CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius` — exit 0 (8582 jobs).
- **Host**: `lake env lean` after rebuilding the parent olean chain.
- **Axiom-free**: `#print axioms centralizerEvalEquiv` (and the two supporting lemmas) =
  `[propext, Classical.choice, Quot.sound]` — no `native_decide` / `Lean.ofReduceBool` / `sorryAx`.

## Status
**Outcome**: progress
**Next Steps**: the elementary layer of this node is now complete (centralizer=K[T],
commutativity, dimension equality, evaluation iso). The remaining direction — the deep converse
`dim C(T)=n ⟹ T cyclic` — is **blocked**: it needs rational-canonical-form / invariant-factor
infrastructure absent from Mathlib v4.31 (structured blocker recorded). Adjacent results like
`(minpoly K T).natDegree = n` are also gated (`Algebra.adjoin.powerBasis` requires `CommRing S`,
which `Module.End K V` is not).

🤖 Generated by researcher-1-4
