### PR TITLE
Audit: erdos-604 - katzTardos_bound is vacuous w.r.t. its exponent

### DIFF
--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -63,13 +63,13 @@
     "assumptions": "No axioms. 1 sorry remaining: integerLattice_pinnedDistances (deep constructive existence). maxPinnedDistances and pinnedDistance_le are now sorry-free.",
     "mathlib_version": "4.31.0",
     "theoremCount": 6,
-    "definitionCount": 11
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "The pinned distance problem is a stronger variant of the famous Erdős distinct distances problem (#89). Rather than counting all distinct pairwise distances in a point set, it asks: must some point 'see' many different distances to other points?\n\nErdős posed this across multiple papers from 1957 to 1997, offering a $500 prize. The integer lattice {1,...,√n} × {1,...,√n} shows the answer cannot exceed O(n/√log n), suggesting this might be the truth. The 'unpinned' version of the problem was famously resolved by Guth and Katz in 2015 using the polynomial method and algebraic geometry, achieving the near-optimal Ω(n/log n) bound, but their techniques have not yet been adapted to give the optimal pinned result. Katz and Tardos obtained the best known pinned lower bound of n^{(48-14e)/(55-16e)} ≈ n^{0.864} in 2004 using entropy methods.",
     "problemStatement": "Given n distinct points A ⊂ ℝ², must there exist a point x ∈ A such that:\n\n|{d(x,y) : y ∈ A, y ≠ x}| ≫ n^(1-o(1))?\n\nOr even |{d(x,y) : y ∈ A}| ≫ n/√(log n)?\n\nThe 'pinned point' x has this many distinct distances to other points in the set.",
     "text": "Given n distinct points in the plane, must some point have nearly n distinct distances to other points? The 'pinned' version of the distinct distances problem. OPEN with $500 prize.",
-    "proofStrategy": "This formalization:\n\n1. Defines `pinnedDistances x A` as the set of distances from x to points in A\n2. States the weak conjecture (exponent 1-ε) and strong conjecture (n/√log n)\n3. Formalizes the Katz-Tardos bound with exponent c ≈ 0.864\n4. Proves basic structural results connecting pinned to total distances\n\nThe main conjectures remain OPEN with substantial sorries marking unproven claims.",
+    "proofStrategy": "This formalization:\n\n1. Defines `pinnedDistances x A` as the set of distances from x to points in A\n2. States the weak conjecture (exponent 1-ε) and strong conjecture (n/√log n)\n3. Defines the Katz-Tardos exponent c ≈ 0.864. Note: the `katzTardos_bound` theorem existentially quantifies its multiplicative constant *after* fixing A, so it states only a weak (non-uniform) pinned-count bound — it does NOT formalize the actual Katz-Tardos lower bound (which requires a constant uniform over all A).\n4. Proves basic structural results (pinned count ≥ 1, ≤ n−1, pinned ⊆ all-distances)\n\nThe main conjectures remain OPEN. `integerLattice_pinnedDistances` (the optimal-construction upper bound) is `sorry`; `erdos_604_open` is a `P ↔ P` placeholder, not a proof of the conjecture.",
     "keyInsights": [
       "**Pinned vs Total:** Counting distances from one 'pinned' point is harder than counting all pairwise distances, yet gives useful lower bounds.",
       "**Integer Lattice Barrier:** The √n × √n integer grid has O(n/√log n) representable distances, setting the conjectured upper bound.",
@@ -131,7 +131,7 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize the pinned distance problem, defining the conjecture that every n-point set has a point seeing nearly n^(1-o(1)) distinct distances. The Katz-Tardos bound (exponent 0.864) is stated, and basic structural properties are proved. The main conjecture remains one of the deepest open problems in discrete geometry.",
+    "summary": "We formalize the pinned distance problem, defining the conjecture that every n-point set has a point seeing nearly n^(1-o(1)) distinct distances. The Katz-Tardos exponent (≈ 0.864) is defined and basic structural properties are proved (pinned count ≥ 1, ≤ n−1, pinned ⊆ all-distances); the actual uniform Katz-Tardos lower bound is not yet formalized. The main conjecture remains one of the deepest open problems in discrete geometry.",
     "implications": "**Theoretical Significance**: This problem connects to:\n\n1. **Distinct Distances (#89):** The 'unpinned' version solved by Guth-Katz\n**2. Sum-Product Phenomena:** Additive/multiplicative structure in distance sets\n3. **Incidence Geometry:** Connections to point-line incidences\n4. **Algebraic Methods:** Polynomial method techniques from Elekes, Guth-Katz.",
     "openQuestions": [
       "Prove the exponent approaches 1 (the $500 prize!)",
@@ -189,7 +189,7 @@
     "lineCount": 227,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 11,
+    "definitionCount": 10,
     "path": "Proofs/Erdos604Problem.lean",
     "sorries": 1
   },


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-604 (Erdős #604: Pinned Distance Problem, **OPEN**, \$500)
**Severity**: MEDIUM — inequality≠theorem (vacuous existential) + def overcount

## Problem

`katzTardos_bound` is stated as:
```
∃ x ∈ A, ∃ c > 0, (pinnedDistanceCount x A : ℝ) ≥ c * (A.card : ℝ) ^ katzTardosExponent
```
The multiplicative constant `c` is existentially quantified **after** `A` is fixed. For a fixed `A`, `A.card ^ katzTardosExponent` is a fixed positive real and the max pinned count is ≥ 1, so the statement is trivially true for every `A` (the proof literally chooses `c = avg / n^exponent`). The exponent `katzTardosExponent ≈ 0.864` is **decorative** — the theorem would hold for any exponent. It does **not** formalize the Katz-Tardos lower bound, which requires a constant uniform over all `A`.

meta `proofStrategy` claimed *"Formalizes the Katz-Tardos bound with exponent c ≈ 0.864"* and `conclusion` said the bound "is stated" — overstating what is proved.

## Fix

- `proofStrategy` / `conclusion`: reworded to state the exponent is *defined* while the actual uniform Katz-Tardos bound is *not* formalized; noted `integerLattice_pinnedDistances` is `sorry` and `erdos_604_open` is a `P ↔ P` placeholder.
- `definitionCount` 11 → 10 (the extra count was the commented-out `maxPinnedDistances` block).

No change to badge (`wip`), status (`open`), axiomCount (0), sorries (1), theoremCount (6) — all accurate.

**Follow-up for mechanic**: the in-file docstring above `katzTardos_bound` calls it *"The Katz-Tardos theorem (2004)... best known lower bound"* — recommend softening that comment to match.

---
Discovered during gallery integrity audit.