### PR TITLE
Enrich erdos-1100, erdos-658: re-anchor drifted past-EOF sections

### DIFF
--- a/src/data/proofs/erdos-1100/meta.json
+++ b/src/data/proofs/erdos-1100/meta.json
@@ -56,71 +56,71 @@
       "id": "header-and-imports",
       "title": "Header, References, and Imports",
       "startLine": 1,
-      "endLine": 37,
+      "endLine": 40,
       "summary": "Problem statement documenting the three questions and known results, followed by Mathlib imports for naturals, primes, factorization, finite sets, reals, logarithms, and real powers.",
       "mathContext": "Mathematical content: Problem statement documenting the three questions and known results, followed by Mathlib imports for naturals, primes, factorization, finite sets, reals, logarithms, and real powers."
     },
     {
       "id": "divisor-functions",
       "title": "Divisor Functions",
-      "startLine": 38,
-      "endLine": 58,
+      "startLine": 41,
+      "endLine": 61,
       "summary": "Defines divisorList (sorted divisors of n), tau (divisor count τ(n)), and omega (distinct prime factor count ω(n)) using Finset filtering and sorting.",
       "mathContext": "Formal definition: Defines divisorList (sorted divisors of n), tau (divisor count τ(n)), and omega (distinct prime factor count ω(n)) using Finset filtering and sorting."
     },
     {
       "id": "coprime-consecutive-divisors",
       "title": "Coprime Consecutive Divisors",
-      "startLine": 59,
-      "endLine": 163,
+      "startLine": 62,
+      "endLine": 140,
       "summary": "Defines tauPerp (τ⊥(n)), proves divisors_of_prime and divisorList_prime, then proves tau_perp_equality_infinitely_often via prime witnesses (τ⊥(p) = 1 = ω(p)).",
       "mathContext": "Defines tauPerp (τ⊥(n)), proves divisors_of_prime and divisorList_prime, then proves tau_perp_equality_infinitely_often via prime witnesses (τ⊥(p) = 1 = ω(p))."
     },
     {
       "id": "question-1-almost-all-growth",
       "title": "Question 1: Almost All Growth",
-      "startLine": 164,
-      "endLine": 183,
+      "startLine": 141,
+      "endLine": 160,
       "summary": "Formalizes Question 1 as a natural density statement: for every M > 0, the density of n with τ⊥(n)/ω(n) < M tends to zero.",
       "mathContext": "Mathematical content: Formalizes Question 1 as a natural density statement: for every M > 0, the density of n with τ⊥(n)/ω(n) < M tends to zero."
     },
     {
       "id": "question-2-upper-bound",
       "title": "Question 2: Upper Bound",
-      "startLine": 184,
-      "endLine": 209,
+      "startLine": 161,
+      "endLine": 186,
       "summary": "Formalizes Question 2 (sub-polylogarithmic growth of τ⊥) and axiomatizes the Erdős–Hall lower bound on max_{n<x} τ⊥(n).",
       "mathContext": "Axiomatized: Formalizes Question 2 (sub-polylogarithmic growth of τ⊥) and axiomatizes the Erdős–Hall lower bound on max_{n<x} τ⊥(n)."
     },
     {
       "id": "question-3-growth-of-g-k",
       "title": "Question 3: Growth of g(k)",
-      "startLine": 210,
-      "endLine": 254,
+      "startLine": 187,
+      "endLine": 231,
       "summary": "Defines g(k) as the supremum of τ⊥(n) over squarefree n with ω(n) = k, axiomatizes the Erdős–Simonovits bounds, and proves g_exponential_growth (with two sorries for the limit arguments).",
       "mathContext": "Formal definition: Defines g(k) as the supremum of τ⊥(n) over squarefree n with ω(n) = k, axiomatizes the Erdős–Simonovits bounds, and proves g_exponential_growth (with two sorries for the limit arguments)."
     },
     {
       "id": "examples",
       "title": "Worked Examples",
-      "startLine": 255,
-      "endLine": 280,
+      "startLine": 232,
+      "endLine": 257,
       "summary": "Concrete examples for n = 6 (τ⊥ = 2 = ω, equality case) and n = 12 (τ⊥ = 3 > ω = 2, strict inequality), with ω verified by native_decide.",
       "mathContext": "Bound: Concrete examples for n = 6 (τ⊥ = 2 = ω, equality case) and n = 12 (τ⊥ = 3 > ω = 2, strict inequality), with ω verified by native_decide."
     },
     {
       "id": "why-this-problem-is-hard",
       "title": "Structural Difficulty",
-      "startLine": 281,
-      "endLine": 295,
+      "startLine": 258,
+      "endLine": 272,
       "summary": "Commentary on why the problem is hard: coprimality of consecutive divisors depends delicately on the factorization of n, creating intricate combinatorial constraints on the divisor lattice.",
       "mathContext": "Mathematical content: Commentary on why the problem is hard: coprimality of consecutive divisors depends delicately on the factorization of n, creating intricate combinatorial constraints on the divisor lattice."
     },
     {
       "id": "summary",
       "title": "Problem Summary Theorem",
-      "startLine": 296,
-      "endLine": 331,
+      "startLine": 273,
+      "endLine": 309,
       "summary": "The erdos_1100_summary theorem combines the three known results (lower bound, equality infinitely often, Erdős–Hall extremal bound) into a single conjunction, proved directly from the axioms.",
       "mathContext": "Verified: The erdos_1100_summary theorem combines the three known results (lower bound, equality infinitely often, Erdős–Hall extremal bound) into a single conjunction, proved directly from the axioms."
     }
@@ -246,7 +246,7 @@
       "Finset"
     ],
     "namespace": "Erdos1100",
-    "lineCount": 331,
+    "lineCount": 309,
     "axiomCount": 3,
     "theoremCount": 7,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-658/meta.json
+++ b/src/data/proofs/erdos-658/meta.json
@@ -80,67 +80,75 @@
   },
   "sections": [
     {
+      "id": "header-imports",
+      "title": "Header, Problem Statement, and Imports",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "File header documenting Erdős problem #658 — Graham's conjecture that any subset of the N×N grid with positive density contains the four corners of an axis-aligned square — together with references and the `import Mathlib` / `namespace Erdos658` preamble.",
+      "mathContext": "The problem asks whether every $A \\subseteq [N]^2$ with $|A| \\ge \\delta N^2$ must contain four points forming an axis-aligned square $\\{(x,y),(x+d,y),(x,y+d),(x+d,y+d)\\}$ for some $d \\ge 1$."
+    },
+    {
       "id": "definitions",
       "title": "Basic Definitions",
       "summary": "grid, isAxisAlignedSquare, containsAxisAlignedSquare, density, isDense",
-      "startLine": 47,
-      "endLine": 114,
+      "startLine": 43,
+      "endLine": 110,
       "mathContext": "Mathematical content: grid, isAxisAlignedSquare, containsAxisAlignedSquare, density, isDense"
     },
     {
       "id": "graham-conjecture",
       "title": "Graham's Conjecture",
       "summary": "GrahamConjectureAxisAligned definition and main theorem",
-      "startLine": 115,
-      "endLine": 138,
+      "startLine": 111,
+      "endLine": 134,
       "mathContext": "Formal definition: GrahamConjectureAxisAligned definition and main theorem"
     },
     {
       "id": "main-result",
       "title": "Main Result",
       "summary": "erdos_658 theorem (via graham_axis_aligned_true axiom)",
-      "startLine": 139,
-      "endLine": 168,
+      "startLine": 135,
+      "endLine": 157,
       "mathContext": "Axiomatized: erdos_658 theorem follows directly from graham_axis_aligned_true axiom"
     },
     {
       "id": "hales-jewett",
       "title": "Density Hales-Jewett",
       "summary": "CombLine placeholder def, density_hales_jewett axiom",
-      "startLine": 169,
-      "endLine": 201,
+      "startLine": 158,
+      "endLine": 188,
       "mathContext": "density_hales_jewett is a vacuous True-bodied placeholder axiom gesturing at the Furstenberg-Katznelson 1991 theorem — it asserts nothing mathematical and is not load-bearing. CombLine is a placeholder definition; the reduction to Hales-Jewett is discussed in comments only, not formalized."
     },
     {
       "id": "solymosi-bounds",
       "title": "Bounds and Small Cases",
       "summary": "Solymosi quantitative bounds discussed in comments only",
-      "startLine": 202,
-      "endLine": 229,
+      "startLine": 189,
+      "endLine": 204,
       "mathContext": "Solymosi (2004) tower-type bounds on N₀(δ) are described in section comments but not formalized as axioms in this file."
     },
     {
       "id": "examples",
       "title": "Small Cases and Examples",
       "summary": "density_threshold_3x3",
-      "startLine": 230,
-      "endLine": 266,
+      "startLine": 205,
+      "endLine": 223,
       "mathContext": "Mathematical content: density_threshold_3x3. Non-square-free configurations for small N are discussed in comments only, not formalized."
     },
     {
       "id": "generalizations",
       "title": "Generalizations",
       "summary": "higher_dimensional_cubes",
-      "startLine": 267,
-      "endLine": 290,
+      "startLine": 224,
+      "endLine": 244,
       "mathContext": "Mathematical content: higher_dimensional_cubes. Tilted (non-axis-aligned) squares are discussed in comments only, not formalized."
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_658_summary, erdos_658_answer theorems",
-      "startLine": 291,
-      "endLine": 299,
+      "startLine": 245,
+      "endLine": 285,
       "mathContext": "Verified: erdos_658_summary, erdos_658_answer theorems"
     }
   ],


### PR DESCRIPTION
## Section anchor re-anchoring (broken past-EOF anchors)

Both gallery entries had drifted `sections` whose final `endLine` pointed **past
end-of-file**, and whose back-half sections were anchored 2–40 lines ahead of the
`## Part N` banners they describe.

### erdos-1100 (`Erdos1100ProblemProvable.lean`, 309 lines)
- Sections drifted increasingly toward the tail; last section claimed `endLine: 331` (EOF is 309).
- Re-anchored all 9 sections contiguously 1..309 to their `## Part I`–`## Part VIII` banners (`erdos_1100_summary@294` now correctly under "Problem Summary Theorem").
- Fixed stale `leanFile.lineCount` 331 → 309.

### erdos-658 (`Erdos658Problem.lean`, 285 lines)
- Last section ("Summary") claimed `endLine: 299` (EOF is 285); head lines 1–42 were uncovered.
- Re-anchored 8 sections to `## Part I`–`## Part VIII` banners and added a missing head section (1–42) → 9 sections, full 1..285 coverage.

No `status` / `badge` / `axiomCount` changes — pure section-anchor accuracy fix.
Verified each section range holds the declarations its summary describes.
