### PR TITLE
Enrich erdos-109-oq-01: re-anchor drifted Part III-V sections

### DIFF
--- a/src/data/proofs/erdos-109-oq-01/meta.json
+++ b/src/data/proofs/erdos-109-oq-01/meta.json
@@ -80,31 +80,31 @@
       "id": "sumset-gap-strengthening",
       "title": "Part III: Sumset Gap Strengthening",
       "startLine": 86,
-      "endLine": 254,
+      "endLine": 244,
       "summary": "Defines the conjecture predicates GapControlledSumset and SyndeticSumsetQuestion and proves sumset_density_constraint, the gap-controlled strengthening of the sumset structure statement.",
       "mathContext": "Whether $B+C$ inherits gap-control / syndeticity from density hypotheses on $B,C$."
     },
     {
       "id": "ip-sets-hindman",
       "title": "Part IV: Connection to IP Sets (Hindman's Theorem)",
-      "startLine": 255,
-      "endLine": 378,
+      "startLine": 245,
+      "endLine": 370,
       "summary": "Defines IsIPSet (finite-sums set) and IsIPStar, states Hindman's theorem as an axiom (hindman_theorem: any finite coloring of ℕ has a monochromatic IP set) plus posUpperDensity_ipStar, and proves ip_set_sumset_structure.",
       "mathContext": "Hindman: any finite coloring of ℕ admits a monochromatic IP set (set of finite sums of an infinite sequence)."
     },
     {
       "id": "further-results",
       "title": "Part V: Further Results on IP Sets and Gap Conditions",
-      "startLine": 379,
-      "endLine": 439,
+      "startLine": 371,
+      "endLine": 433,
       "summary": "Further proved consequences: ip_set_nonempty, ip_set_infinite, thick_infinite, hindman_two_color (the 2-coloring corollary), and sumset_subset_iff.",
       "mathContext": "Corollaries tying IP-sets, thickness, and sumset inclusion together."
     },
     {
       "id": "summary",
       "title": "Part V: Summary",
-      "startLine": 440,
-      "endLine": 473,
+      "startLine": 434,
+      "endLine": 468,
       "summary": "Closing summary docstring (What's Proved with 0 sorries, the list of 3 axioms — posUpperDensity_piecewiseSyndetic, hindman_theorem, posUpperDensity_ipStar — and Mathematical Status); closes namespace Erdos109OQ01.",
       "mathContext": "Status: 8 theorems proved, 0 sorries, 3 axioms (piecewise-syndetic density, Hindman, IP*-density)."
     }


### PR DESCRIPTION
## Section anchor re-anchoring (drifted past-EOF anchors)

`erdos-109-oq-01` (`Erdos109OQ01.lean`, 468 lines) had drifted back-half `sections`
whose final `endLine` pointed past end-of-file (473 > 468):

- **Part III** claimed 86–254, swallowing the Part IV banner at line 245.
- **Part IV** was anchored at 255 (+9 past its `## Part IV` banner @245) and ran to 378, swallowing the Part V banner @371.
- **Part V (Further Results)** claimed 379–439 vs its banner @371.
- **Part V: Summary** claimed 440–473, overshooting EOF.

Re-anchored the four back-half sections to their `## Part N` banner `/-` opens
(Part III 86–244, Part IV 245–370, Part V 371–433, Summary 434–468) for
contiguous 1..468 coverage. Header / Part I / Part II were already correct and
untouched. No `status` / `badge` / `axiomCount` changes.
