### PR TITLE
Enrich erdos-648: re-anchor 12 fully-drifted sections

### DIFF
--- a/src/data/proofs/erdos-648/meta.json
+++ b/src/data/proofs/erdos-648/meta.json
@@ -82,7 +82,7 @@
       }
     ],
     "axiomCount": 3,
-    "lineCount": 378,
+    "lineCount": 374,
     "assumptions": "3 axiom(s) (Cambie's bounds + asymptotic conjecture), 0 sorries. The greatest-prime-factor function P(n) is defined constructively (via Mathlib's `Nat.primeFactorsList`) with its four key properties proved, not axiomatized. Concrete GPF evaluations (e.g. gpf_four, gpf_ten, gpf_sixtyfour) use `native_decide`, so the small-case lower bounds (g_ge_two/three/four, length_four_exists) additionally trust the Lean compiler (`ofReduceBool`-class native_decide axioms) beyond the kernel; the main Θ-result `erdos_648` depends only on the two Cambie axioms. See the Lean source for details.",
     "theoremCount": 41,
     "definitionCount": 9
@@ -111,96 +111,96 @@
       "id": "imports",
       "title": "Imports and Namespace",
       "summary": "Imports Mathlib modules for `Nat.Prime`, `Nat.Factorization`, `Finset`, `Real.Sqrt`, and `Real.log`. Opens `Nat` and `Finset` namespaces within the `Erdos648` namespace.",
-      "startLine": 33,
-      "endLine": 42,
+      "startLine": 1,
+      "endLine": 38,
       "mathContext": "Mathematical content: Imports Mathlib modules for `Nat.Prime`, `Nat.Factorization`, `Finset`, `Real.Sqrt`, and `Real.log`. Opens `Nat` and `Finset` namespaces within the `Erdos648` namespace."
     },
     {
       "id": "gpf",
       "title": "Greatest Prime Factor $P(n)$",
       "summary": "Defines `gpf n` as $P(n)$ constructively (the last element of Mathlib's `Nat.primeFactorsList`, returning 0 for $n \\le 1$) and proves — not axiomatizes — four key properties: $P(p) = p$ for primes, $P(n) \\mid n$, $P(n)$ is prime, and $P(n)$ is maximal among prime divisors. The boundary cases $P(0) = P(1) = 0$ are discharged by `native_decide`.",
-      "startLine": 43,
-      "endLine": 81,
+      "startLine": 39,
+      "endLine": 120,
       "mathContext": "Defines `gpf n` as $P(n)$ constructively (the last element of Mathlib's `Nat.primeFactorsList`, returning 0 for $n \\le 1$) and proves — not axiomatizes — four key properties: $P(p) = p$ for primes, $P(n) \\mid n$, $P(n)$ is prime, and $P(n)$ is maximal among prime divisors. The boundary cases $P(0) = P(1) = 0$ are discharged by `native_decide`."
     },
     {
       "id": "examples",
       "title": "Concrete GPF Computations",
       "summary": "Verifies $P(n)$ for eleven small integers: $P(2) = 2$, $P(3) = 3$, $P(4) = 2$, $P(6) = 3$, $P(8) = 2$, $P(9) = 3$, $P(10) = 5$, $P(12) = 3$, $P(16) = 2$, $P(27) = 3$, $P(64) = 2$. Demonstrates the key pattern that prime powers $p^k$ have $P(p^k) = p$. The composite/prime-power evaluations are discharged by `native_decide` (compiler-trusted), which propagates an `ofReduceBool`-class axiom into the small-case lower bounds.",
-      "startLine": 82,
-      "endLine": 118,
+      "startLine": 121,
+      "endLine": 157,
       "mathContext": "Verifies $P(n)$ for eleven small integers: $P(2) = 2$, $P(3) = 3$, $P(4) = 2$, $P(6) = 3$, $P(8) = 2$, $P(9) = 3$, $P(10) = 5$, $P(12) = 3$, $P(16) = 2$, $P(27) = 3$, $P(64) = 2$. Demonstrates the key pattern that prime powers $p^k$ have $P(p^k) = p$. The composite/prime-power evaluations are discharged by `native_decide` (compiler-trusted), which propagates an `ofReduceBool`-class axiom into the small-case lower bounds."
     },
     {
       "id": "sequences",
       "title": "GPF-Descending Sequence Definitions",
       "summary": "Defines `isGPFDescendingSeq` (strictly increasing values with strictly decreasing GPFs via `List.Chain'`), `isValidGPFSeq` (bounded in $[2, n)$), and the extremal function $g(n) = \\sup\\{|\\text{seq}| : \\text{isValidGPFSeq}\\, n\\, \\text{seq}\\}$.",
-      "startLine": 119,
-      "endLine": 148,
+      "startLine": 158,
+      "endLine": 170,
       "mathContext": "Defines `isGPFDescendingSeq` (strictly increasing values with strictly decreasing GPFs via `List.Chain'`), `isValidGPFSeq` (bounded in $[2, n)$), and the extremal function $g(n) = \\sup\\{|\\text{seq}| : \\text{isValidGPFSeq}\\, n\\, \\text{seq}\\}$."
     },
     {
       "id": "example-sequences",
       "title": "Example GPF-Descending Sequences",
       "summary": "Proves three concrete examples: $[3, 4]$ with GPFs $[3, 2]$, $[7, 9, 16]$ with GPFs $[7, 3, 2]$, and $[7, 10, 27, 64]$ with GPFs $[7, 5, 3, 2]$. Each is verified by rewriting GPF values and using `omega`.",
-      "startLine": 149,
-      "endLine": 199,
+      "startLine": 171,
+      "endLine": 191,
       "mathContext": "Proves three concrete examples: $[3, 4]$ with GPFs $[3, 2]$, $[7, 9, 16]$ with GPFs $[7, 3, 2]$, and $[7, 10, 27, 64]$ with GPFs $[7, 5, 3, 2]$."
     },
     {
       "id": "lower-bounds",
       "title": "Small Lower Bounds on $g(n)$",
       "summary": "Proves that $g(n) \\ge 1$ for $n \\ge 3$, $g(n) \\ge 2$ for $n \\ge 5$, $g(n) \\ge 3$ for $n \\ge 17$, and $g(n) \\ge 4$ for $n \\ge 65$, using the example sequences as witnesses (via `g_bddAbove` / `le_csSup`). The proofs are sorry-free but rely on `native_decide` GPF evaluations for the concrete witnesses.",
-      "startLine": 200,
-      "endLine": 219,
+      "startLine": 192,
+      "endLine": 250,
       "mathContext": "Mathematical content: Proves that $g(n) \\ge 1$ for $n \\ge 3$, $g(n) \\ge 2$ for $n \\ge 5$, $g(n) \\ge 3$ for $n \\ge 17$, and $g(n) \\ge 4$ for $n \\ge 65$, using the example sequences as witnesses (via `g_bddAbove` / `le_csSup`). The proofs are sorry-free but rely on `native_decide` GPF evaluations for the concrete witnesses."
     },
     {
       "id": "smooth",
       "title": "Smooth Numbers",
       "summary": "Defines `isSmooth B n` ($P(n) \\le B$, i.e., $n$ is $B$-smooth/friable). Proves (sorry-free, from the established GPF properties) that $2^k$ is 2-smooth and $p^k$ is $p$-smooth for any prime $p$ with $k \\ge 1$.",
-      "startLine": 220,
-      "endLine": 241,
+      "startLine": 251,
+      "endLine": 278,
       "mathContext": "Defines `isSmooth B n` ($P(n) \\le B$, i.e., $n$ is $B$-smooth/friable). Proves (sorry-free, from the established GPF properties) that $$2^{k}$$ is 2-smooth and $p^k$ is $p$-smooth for any prime $p$ with $k \\ge 1$."
     },
     {
       "id": "cambie",
       "title": "Cambie's Theorem: $g(n) \\asymp \\sqrt{n/\\log n}$",
       "summary": "Axiomatizes Cambie's lower bound ($g(n) \\ge c_1\\sqrt{n/\\log n}$ with $c_1 \\ge 2$) and upper bound ($g(n) \\le c_2\\sqrt{n/\\log n}$ with $c_2 \\le 2\\sqrt{2}$). The main theorem `cambie_main` combines both directions into a $\\Theta$-bound, proved by extracting and repacking the axiomatized constants.",
-      "startLine": 242,
-      "endLine": 279,
+      "startLine": 279,
+      "endLine": 302,
       "mathContext": "Axiomatizes Cambie's lower bound ($g(n) \\ge c_1\\sqrt{n/\\log n}$ with $c_1 \\ge 2$) and upper bound ($g(n) \\le c_2\\sqrt{n/\\log n}$ with $c_2 \\le 2\\sqrt{2}$). The main theorem `cambie_main` combines both directions into a $\\Theta$-bound, proved by extracting and repacking the axiomatized constants."
     },
     {
       "id": "constant",
       "title": "The Asymptotic Constant Question",
       "summary": "Axiomatizes Cambie's conjecture that $g(n)/\\sqrt{n/\\log n} \\to c$ for some $c \\in [2, 2\\sqrt{2}]$ using `Filter.Tendsto`. Defines `c_lower = 2` and `c_upper = 2\\sqrt{2}`, and proves $2\\sqrt{2} < 3$ via `nlinarith`.",
-      "startLine": 280,
-      "endLine": 310,
+      "startLine": 303,
+      "endLine": 322,
       "mathContext": "Axiomatizes Cambie's conjecture that $g(n)/\\sqrt{n/\\log n} \\to c$ for some $c \\in [2, 2\\sqrt{2}]$ using `Filter.Tendsto`. Defines `c_lower = 2` and `c_upper = 2\\sqrt{2}`, and proves $2\\sqrt{2} < 3$ via `nlinarith`."
     },
     {
       "id": "construction",
       "title": "Construction Strategy",
       "summary": "Documents the construction principle: pick descending primes $p_1 > \\cdots > p_k$, then find representatives with $P(a_i) = p_i$ and $a_1 < \\cdots < a_k$. Smaller primes allow larger powers, enabling the increasing-value condition. Defines `primePowerSequence` as a concrete example.",
-      "startLine": 311,
-      "endLine": 335,
+      "startLine": 323,
+      "endLine": 329,
       "mathContext": "Documents the construction principle: pick descending primes $p_1 > \\cdots > p_k$, then find representatives with $P(a_i) = p_i$ and $a_1 < \\cdots < a_k$. Defines `primePowerSequence` as a concrete example."
     },
     {
       "id": "related-functions",
       "title": "Smallest Prime Factor and Duality",
       "summary": "Defines the smallest prime factor $p(n) = n.\\text{minFac}$, axiomatizes $p(n) \\le P(n)$, and proves $p(p) = P(p) = p$ for primes. Introduces the dual problem of increasing-SPF sequences.",
-      "startLine": 336,
-      "endLine": 353,
+      "startLine": 330,
+      "endLine": 342,
       "mathContext": "Formal definition: Defines the smallest prime factor $p(n) = n.\\text{minFac}$, axiomatizes $p(n) \\le P(n)$, and proves $p(p) = P(p) = p$ for primes. Introduces the dual problem of increasing-SPF sequences."
     },
     {
       "id": "main-results",
       "title": "Main Results Summary",
       "summary": "Packages the solution: `erdos_648_summary` states both bounds, `erdos_648` gives the full $\\Theta$-result, and `length_four_exists` provides a concrete verified witness that $g(100) \\ge 4$ using $[7, 10, 27, 64]$.",
-      "startLine": 354,
-      "endLine": 378,
+      "startLine": 343,
+      "endLine": 374,
       "mathContext": "Packages the solution: `erdos_648_summary` states both bounds, `erdos_648` gives the full $\\Theta$-result, and `length_four_exists` provides a concrete verified witness that $g(100) \\ge 4$ using $[7, 10, 27, 64]$."
     }
   ],
@@ -227,7 +227,7 @@
       "Finset"
     ],
     "namespace": "Erdos648",
-    "lineCount": 378,
+    "lineCount": 374,
     "axiomCount": 3,
     "theoremCount": 41,
     "definitionCount": 9,


### PR DESCRIPTION
## Section anchor re-anchoring (full drift, past-EOF tail)

`erdos-648` (`Erdos648Problem.lean`, 374 lines) had all 12 `sections` drifted
~40 lines ahead of the content they describe, with the final section overshooting
EOF (378 > 374).

The clearest symptom: **"Concrete GPF Computations"** claimed lines 82–118, but
that range actually holds the *general* GPF theorems `gpf_prime`, `gpf_dvd`,
`gpf_is_prime`, `gpf_max` — the concrete `gpf_two … gpf_sixtyfour` computations
it describes live at 126–156.

Re-anchored all 12 sections to their `## Part I`–`## Part X` banner `/-` opens
(header 1–38; splitting the Part IX region into "Construction Strategy" @323–329
for `primePowerSequence` and "Smallest Prime Factor and Duality" @330–342 for the
`spf` lemmas) for contiguous 1..374 coverage. Fixed stale `lineCount` 378 → 374.
No `status` / `badge` / `axiomCount` changes.
