### PR TITLE
Enrich erdos-696: re-anchor drifted sections, add head

### DIFF
--- a/src/data/proofs/erdos-696/meta.json
+++ b/src/data/proofs/erdos-696/meta.json
@@ -51,7 +51,7 @@
       "prime_chain_is_divisor_chain theorem: every prime chain is a divisor chain"
     ],
     "axiomCount": 2,
-    "lineCount": 306,
+    "lineCount": 307,
     "assumptions": "2 axioms: h_le_H (h(n) ≤ H(n) for all n), h_tends_to_infinity (h(n) → ∞ almost surely, van Doorn). 0 sorries. Note: logStar is a placeholder stub (constant 0), so ErdosNormalOrderConjecture is only a statement relative to that stub, not a formalization of the iterated logarithm. The h(n) ≤ ω(n) upper bound is described in comments only, not formalized as a theorem.",
     "theoremCount": 3,
     "definitionCount": 9
@@ -75,83 +75,91 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Header, Problem Statement, and Imports",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "File header for Erdős problem #696 — the normal order of the longest prime-divisor chain function h(n) and the longest divisor chain H(n) — with references and the `import Mathlib` / `namespace Erdos696` preamble.",
+      "mathContext": "For $n$, $h(n)$ is the length of the longest chain $1 = d_0 \\mid d_1 \\mid \\dots$ of prime-ratio steps, and $H(n)$ the longest divisor chain; Erdős conjectured their normal order is $\\sim \\log\\log n / \\log\\log\\log n$-type behaviour."
+    },
+    {
       "id": "functions",
       "title": "The Functions h(n) and H(n)",
       "summary": "Definitions of prime chains, divisor chains, and the functions h and H",
-      "startLine": 43,
-      "endLine": 86,
+      "startLine": 39,
+      "endLine": 82,
       "mathContext": "Formal definition: Definitions of prime chains, divisor chains, and the functions h and H"
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
       "summary": "h(n) ≤ H(n), base cases h(1) and h(p)",
-      "startLine": 87,
-      "endLine": 115,
+      "startLine": 83,
+      "endLine": 109,
       "mathContext": "h(n) $\\leq$ H(n), base cases h(1) and h(p)"
     },
     {
       "id": "iterated-log",
       "title": "The Iterated Logarithm",
       "summary": "Definition of log*(n) and its slow growth",
-      "startLine": 116,
-      "endLine": 139,
+      "startLine": 110,
+      "endLine": 131,
       "mathContext": "Formal definition: Definition of log*(n) and its slow growth"
     },
     {
       "id": "conjectures",
       "title": "Erdős's Conjectures",
       "summary": "h(n) → ∞, normal order, ratio H/h conjectures",
-      "startLine": 140,
-      "endLine": 166,
+      "startLine": 132,
+      "endLine": 158,
       "mathContext": "h(n) $\\to$ ∞, normal order, ratio H/h conjectures"
     },
     {
       "id": "chains",
       "title": "Why These Chains?",
       "summary": "Multiplicative group connection, Sophie Germain, Cunningham chains",
-      "startLine": 167,
-      "endLine": 199,
+      "startLine": 159,
+      "endLine": 185,
       "mathContext": "Mathematical content: Multiplicative group connection, Sophie Germain, Cunningham chains"
     },
     {
       "id": "examples",
       "title": "Examples",
       "summary": "h(6), h(30), h(2310) computed",
-      "startLine": 200,
-      "endLine": 222,
+      "startLine": 186,
+      "endLine": 205,
       "mathContext": "Mathematical content: h(6), h(30), h(2310) computed"
     },
     {
       "id": "comparison",
       "title": "Comparison h(n) vs H(n)",
       "summary": "Why H(n) can be much larger, composites give flexibility",
-      "startLine": 223,
-      "endLine": 250,
+      "startLine": 206,
+      "endLine": 226,
       "mathContext": "Mathematical content: Why H(n) can be much larger, composites give flexibility"
     },
     {
       "id": "upper-bounds",
       "title": "Upper Bounds",
       "summary": "h(n) ≤ ω(n) and H(n) ≤ log₂(n)",
-      "startLine": 251,
-      "endLine": 274,
+      "startLine": 227,
+      "endLine": 245,
       "mathContext": "h(n) $\\leq$ ω(n) and H(n) $\\leq$ log₂(n)"
     },
     {
       "id": "van-doorn",
       "title": "The van Doorn Result",
       "summary": "Proof that h(n) → ∞ for almost all n",
-      "startLine": 275,
-      "endLine": 297,
+      "startLine": 246,
+      "endLine": 263,
       "mathContext": "Proof that h(n) $\\to$ ∞ for almost all n"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_696_status and summary theorems",
-      "startLine": 298,
-      "endLine": 310,
+      "startLine": 264,
+      "endLine": 307,
       "mathContext": "Verified: erdos_696_status and summary theorems"
     }
   ],
@@ -181,7 +189,7 @@
       "Filter"
     ],
     "namespace": "Erdos696",
-    "lineCount": 310,
+    "lineCount": 307,
     "axiomCount": 2,
     "theoremCount": 3,
     "definitionCount": 9,


### PR DESCRIPTION
## Section anchor re-anchoring (full drift + missing head)

`erdos-696` (`Erdos696Problem.lean`, 307 lines) had all 10 `sections` anchored
ahead of the content they describe, with the drift growing toward the tail
(≈ +33 lines by the end) so the final section overshot EOF:

- **"The van Doorn Result"** claimed 275–297 vs its `## Part IX` banner @247.
- **"Summary"** claimed 298–310, past EOF (306).
- Head lines 1–38 (docstring + imports) were uncovered.

Re-anchored the 10 sections to their `## Part I`–`## Part X` banner `/-` opens
and added a missing head section (1–38) for contiguous 1..EOF coverage. Fixed
stale `leanFile.lineCount` 310 → 307. No `status` / `badge` / `axiomCount` changes.
