### PR TITLE
audit(erdos-606): issues-found — false Szemerédi–Trotter axiom (#40826)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14977,9 +14977,9 @@
     },
     "erdos-606": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:37Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T19:19:49Z",
+      "result": "issues-found"
     },
     "erdos-606-oq-01": {
       "auditCount": 1,


### PR DESCRIPTION
## Reserve-mode audit: erdos-606 — ISSUES FOUND

Round-robin re-serve of `erdos-606` (Erdős #606, Distinct Lines from n Points).

**Result: issues-found.** Filed CRITICAL issue #40826.

### Finding
Axiom `szemeredi_trotter_bound` quantifies over **arbitrary** `pts : Fin n → Point` and `lines : Fin m → Line` with **no distinctness hypotheses**. Instantiating with all points/lines coincident (`pts := fun _ => ℓ.p`, `lines := fun _ => ℓ`; `onLine ℓ.p ℓ` holds at t=0) gives `n·m` incidences → for n=m=100 the axiom asserts `10000 ≤ 4841.6` = **False**. The axiom set is therefore **inconsistent**.

### Rest of file clean
- Counts match: 12 axioms, 2 theorems, 10 defs, 0 sorries, 245 lines; badge `axiom` correct
- `erdos_606_solved` is derived from `erdos_salamon_characterization` (not the false axiom)
- No phantom origContribs; no native_decide

Persists tracker (auditCount 3→4, result issues-found).

---
Reserve-mode gallery integrity audit.