### PR TITLE
Enrich erdos-400: re-anchor Proved Properties / Binomial sections to cover their lemmas

### DIFF
--- a/src/data/proofs/erdos-400/meta.json
+++ b/src/data/proofs/erdos-400/meta.json
@@ -124,21 +124,21 @@
       "id": "upper-bound",
       "title": "Erdős-Graham Upper Bound",
       "startLine": 71,
-      "endLine": 79,
+      "endLine": 81,
       "summary": "`gExcess_upper_bound` (axiom): $\\exists C > 0,\\, \\forall n \\ge 1,\\, g_k(n) \\le C \\log n$. Establishes logarithmic order of magnitude from $p$-adic valuation constraints."
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties (Proved)",
-      "startLine": 88,
-      "endLine": 151,
+      "startLine": 82,
+      "endLine": 149,
       "summary": "Three proved theorems: `factor_le_of_factorial_divides` (if $\\prod a_i! \\mid n!$ then each $a_i \\leq n$, by Finset divisibility and induction on $n$), `excess_set_bddAbove` (the excess set is bounded above by $k(n+1)$, a 25-line argument), `zero_mem_excess_set` (trivial tuple $(n,0,\\ldots,0)$ witnesses $0 \\in$ excess set), and `gExcess_nonneg` ($g_k(n) \\geq 0$ via `le_csSup`).",
       "mathContext": "Key: $\\prod a_i! \\mid n! \\Rightarrow a_i! \\mid \\prod a_j! \\mid n! \\Rightarrow a_i \\leq n$. Therefore excess $\\leq k \\cdot n - n = (k-1)n$. The trivial tuple $(n, 0, \\ldots, 0)$ has $n! \\cdot 1^{k-1} \\mid n!$ with excess $0$."
     },
     {
       "id": "binomial-connection",
       "title": "Binomial Connection for $k = 2$",
-      "startLine": 153,
+      "startLine": 150,
       "endLine": 168,
       "summary": "`g2_binomial_connection`: proves $g_2(n) = \\sup\\{a + b - n : a! \\cdot b! \\mid n!\\}$ by constructing a bijection between `Fin 2 → ℕ` tuples and pairs $(a, b)$ using `Fin.prod_univ_two` and the `![a, b]` matrix notation.",
       "mathContext": "$g_2(n) = \\sup\\{a + b - n : a! \\cdot b! \\mid n!\\}$. The condition $a! \\cdot b! \\mid n!$ is equivalent to $\\binom{a+b}{a} \\cdot (a+b)!/n! \\in \\mathbb{Z}$, connecting to Kummer's theorem on carries in base-$p$ addition."


### PR DESCRIPTION
## Summary

The undercoverage scan flagged two theorems stranded outside any section range, even though the section summaries already named them:

- **`factor_le_of_factorial_divides`** (lines 85–86) sat in the gap before §"Basic Properties (Proved)", whose `startLine` (88) began *six lines after its own `## Section V: Proved Properties` banner* (line 82).
- **`g2_binomial_connection`** (docstring 150, theorem 152) sat in the gap before §"Binomial Connection for k=2", whose `startLine` was 153.

Re-anchored three boundaries so every proved theorem is covered by the section that describes it:
- §"Erdős-Graham Upper Bound" `endLine` 79 → 81 (absorb the trailing Erdős–Graham `≪ log n` comment).
- §"Basic Properties (Proved)" `startLine` 88 → 82, `endLine` 151 → 149.
- §"Binomial Connection for k=2" `startLine` 153 → 150.

## Verification
- `meta.json` parses; 8 sections, no overlaps.
- Sections-coverage only — no status/badge/axiomCount changes, no content removed.
