### PR TITLE
Research: erdos-16-wip-01 — the exceptional set is infinite (Erdős 1950 in full)

### DIFF
--- a/proofs/Proofs/Erdos16Problem.lean
+++ b/proofs/Proofs/Erdos16Problem.lean
@@ -552,6 +552,64 @@ theorem covering_progression_mem_exceptionalSet {n : ℕ} (hodd : Odd n)
     n ∈ ExceptionalSet :=
   ⟨hodd, covering_obstruction_not_isRomanoff h3 h7 h5 h17 h13 h241 hsize⟩
 
+/-!
+## Erdős's infinite arithmetic progression: the exceptional set is infinite
+
+`covering_progression_mem_exceptionalSet` places every odd member of the CRT progression
+`n ≡ 7629217 (mod 11184810)` that also satisfies the size condition into `ExceptionalSet`.
+We now discharge the size condition for *infinitely many* members, yielding Erdős's 1950
+conclusion in full: `ExceptionalSet` is **infinite**.
+
+The number `7629217` is the unique residue mod `2M = 2·3·5·7·13·17·241 = 11184810` solving
+the six covering congruences together with oddness (verified by `omega` at each use).  The key
+observation that discharges the size condition cheaply: if `n` lies in the dyadic window
+`[2^m + 242, 2^{m+1})`, then any exponent `k` with `2^k < n` satisfies `k ≤ m`, so
+`n - 2^k ≥ n - 2^m ≥ 242 > 241` — no analysis of "the largest power of two below `n`" is
+needed.  Since each window has length `2^m - 242 ≥ 2M` for large `m`, the progression meets
+every such window, and the windows march off to infinity. -/
+
+/-- **For every bound `B` there is an exceptional integer exceeding `B`.**  Pick `m` with
+`2^m` large; the progression member in the window `[2^m + 242, 2^{m+1})` is odd, satisfies the
+six covering congruences (being `≡ 7629217 mod 11184810`), and meets the size condition
+automatically because every relevant exponent `k` has `2^k ≤ 2^m ≤ n - 242`. -/
+theorem exists_exceptional_gt (B : ℕ) : ∃ n, B < n ∧ n ∈ ExceptionalSet := by
+  set m : ℕ := B + 11184810 + 243 with hm
+  clear_value m
+  have hpm : m < 2 ^ m := Nat.lt_two_pow_self
+  have hbig : 242 + 11184810 ≤ 2 ^ m := by omega
+  have hBm : B < 2 ^ m := by omega
+  set L : ℕ := 2 ^ m + 242 with hL
+  have hLge : 7629217 ≤ L := by omega
+  -- The progression `7629217 + q · 2M` meets the window `[L, L + 2M)`.
+  obtain ⟨q, hnL, hnU⟩ :
+      ∃ q, L ≤ 7629217 + q * 11184810 ∧ 7629217 + q * 11184810 < L + 11184810 :=
+    ⟨(L - 7629217 + 11184810 - 1) / 11184810, by omega, by omega⟩
+  set n : ℕ := 7629217 + q * 11184810 with hn
+  have hpow : 2 ^ (m + 1) = 2 * 2 ^ m := by rw [pow_succ]; ring
+  have hnUB : n < 2 ^ (m + 1) := by omega
+  refine ⟨n, by omega, ?_⟩
+  refine covering_progression_mem_exceptionalSet (Nat.odd_iff.mpr (by omega))
+    (by omega) (by omega) (by omega) (by omega) (by omega) (by omega) ?_
+  -- Size condition: any `k` with `2^k < n` has `k ≤ m`, so `n - 2^k ≥ 242`.
+  intro k _ hkn
+  have hk2 : 2 ^ k < 2 ^ (m + 1) := by omega
+  have hkm : k ≤ m := by
+    by_contra hc
+    exact absurd hk2 (not_lt.mpr (Nat.pow_le_pow_right (by norm_num) (not_le.mp hc)))
+  have hle : 2 ^ k ≤ 2 ^ m := Nat.pow_le_pow_right (by norm_num) hkm
+  omega
+
+/-- **Erdős (1950): the exceptional set is infinite.**  The covering-congruence progression
+contributes infinitely many odd integers not of the form `2^k + p`, so
+`ExceptionalSet` is infinite.  (Chen (2023) later showed its structure is richer than a
+single progression plus a density-`0` set, but infinitude already follows from the covering
+construction alone.) -/
+theorem exceptionalSet_infinite : ExceptionalSet.Infinite := by
+  intro hfin
+  obtain ⟨B, hB⟩ := hfin.bddAbove
+  obtain ⟨n, hn, hmem⟩ := exists_exceptional_gt B
+  exact absurd (hB hmem) (by omega)
+
 /-
 ## Summary
 

--- a/research/problems/erdos-16-wip-01/knowledge.md
+++ b/research/problems/erdos-16-wip-01/knowledge.md
@@ -155,3 +155,37 @@ analytic, not a covering gap anymore): the wrapper showing infinitely many progr
 satisfy the size hypothesis `n − 2^k > 241` — i.e. Erdős's actual infinite-AP conclusion needs
 that near the top exponent `2^k` never lands within 241 of `n`, which the covering alone does not
 force. Romanoff 1934 density and Chen 2023 disproof remain analytic/deep.
+
+## Session 2026-07-21 (researcher-1-4) — the exceptional set is INFINITE (Erdős 1950 in full)
+
+**Mode**: upgrade the conditional covering construction to unconditional infinitude.
+**Outcome**: progress — 2 theorems, axiom-free (`#print axioms exceptionalSet_infinite` =
+`[propext, Classical.choice, Quot.sound]`), host-verified `lake env lean` exit 0, 0 warnings.
+theoremCount 36→38, lineCount 582→640.
+
+- **`exceptionalSet_infinite : ExceptionalSet.Infinite`** — Erdős's 1950 conclusion in full.
+  Proof: `Set.Finite.bddAbove` gives a bound `B`; `exists_exceptional_gt B` contradicts it.
+- **`exists_exceptional_gt (B) : ∃ n, B < n ∧ n ∈ ExceptionalSet`** — the engine. Pick
+  `m = B + 2M + 243` (so `2^m > m` via `Nat.lt_two_pow_self`, giving `2^m > B` and
+  `2^m ≥ 242 + 2M`). The CRT progression `n₀ + q·2M` (`n₀ = 7629217`, `2M = 11184810`) meets
+  the window `[2^m+242, 2^{m+1})`; that member is `> B`, odd, and satisfies the six covering
+  congruences (all by `omega` from `n = 7629217 + q·11184810` — `2M ≡ 0` mod each prime and
+  mod 2, `7629217` has the right residues). The size condition is DISCHARGED CHEAPLY: for the
+  window member, any `k` with `2^k < n < 2^{m+1}` has `k ≤ m` (else `2^{m+1} ≤ 2^k`), so
+  `2^k ≤ 2^m` and `n − 2^k ≥ (2^m+242) − 2^m = 242 > 241`.
+
+### Key idea (reusable)
+- **Window-based size discharge** avoids the messy "largest power of 2 below n" analysis:
+  confining `n` to `[2^m+242, 2^{m+1})` makes `hsize` a one-line consequence (`k ≤ m`).
+- The CRT witness `n₀ = 7629217 mod 11184810` (2·3·5·7·13·17·241) computed once (Python
+  `sympy.crt`); ALL six congruences + oddness fall out of `omega` on `n = 7629217 + q·2M`
+  because each modulus divides `2M` — no per-prime `ModEq.of_dvd` needed.
+- `set m := …; clear_value m` BEFORE any `ring`/`pow_succ` so tactics don't unfold `m` to the
+  literal sum (else "exponent exceeds threshold 256" warning on `2^(m+1)`).
+- AP-meets-window existence: `q := (L − n₀ + 2M − 1)/2M`, then `L ≤ n₀+q·2M < L+2M` both by
+  `omega` (division by the literal `2M` is within omega).
+
+### State of this node
+Erdős 1950 (covering ⟹ infinite exceptional AP) is now COMPLETE and unconditional. Remaining
+are the genuinely analytic/deep pieces, documented-only: Romanoff 1934 positive-density lower
+bound (sieve + PNT) and Chen 2023 disproof (exceptional set richer than one AP + density-0).

--- a/src/data/proofs/erdos-16/meta.json
+++ b/src/data/proofs/erdos-16/meta.json
@@ -237,9 +237,9 @@
       "BigOperators"
     ],
     "namespace": "Erdos16",
-    "lineCount": 582,
+    "lineCount": 640,
     "axiomCount": 0,
-    "theoremCount": 36,
+    "theoremCount": 38,
     "definitionCount": 11,
     "path": "Proofs/Erdos16Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-16-wip-01.json
+++ b/src/data/research/problems/erdos-16-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (session 5): Assembled the covering-congruence gears into the full Erdos 1950 obstruction covering_obstruction_not_isRomanoff — 8 new axiom-free theorems (theoremCount 28->36, lineCount 479->582). Any n satisfying the six CRT congruences over primes {3,5,7,13,17,241} and a size hypothesis n-2^k>241 is proved non-Romanoff, so the entire CRT arithmetic progression lies in the exceptional set. Remaining documented-only: the analytic wrapper showing infinitely many progression members meet the size hypothesis (Erdos's infinite-AP conclusion), Romanoff 1934 density, Chen 2023 disproof.",
+    "progressSummary": "PROGRESS (2026-07-21, researcher-1-4, host-verified 0-axiom): Formalized Erdős 1950 in FULL — ExceptionalSet is INFINITE (exceptionalSet_infinite), upgrading the prior conditional covering construction (covering_progression_mem_exceptionalSet, needs size hypothesis) to unconditional infinitude via exists_exceptional_gt. The CRT progression n≡7629217 (mod 11184810) meets every dyadic window [2^m+242,2^{m+1}) where the size condition holds automatically (k≤m ⟹ n−2^k≥242). theoremCount 36→38, lineCount 582→640. Remaining DEEP: Romanoff 1934 positive-density (analytic sieve+PNT) and Chen 2023 disproof (rich structure) stay documented-only.",
     "builtItems": [
       "isRomanoff_four_le, not_isRomanoff_one/three, one/three_mem_exceptionalSet in Erdos16Problem.lean",
       "isRomanoff_five, isRomanoff_seven, five_not_mem_exceptionalSet in Erdos16Problem.lean",
@@ -47,7 +47,9 @@
       "two_pow_mod_three, two_pow_modEq_of_dvd, covering_prime_not_prime_sub, not_prime_sub_even_mod_three, not_prime_sub_mod_seven in Proofs/Erdos16Problem.lean (session 4, axiom-free)",
       "two_pow_four_modEq_five, two_pow_eight_modEq_seventeen, two_pow_twelve_modEq_thirteen, two_pow_twentyfour_modEq_241 (order-of-2 gears) in Erdos16Problem.lean",
       "covering_obstruction_not_isRomanoff in Erdos16Problem.lean — the assembled Erdos 1950 covering obstruction (conditional on explicit size hypothesis)",
-      "covering_progression_mem_exceptionalSet in Erdos16Problem.lean — membership form for odd n"
+      "covering_progression_mem_exceptionalSet in Erdos16Problem.lean — membership form for odd n",
+      "exists_exceptional_gt (∀B ∃ exceptional n>B) in Erdos16Problem.lean",
+      "exceptionalSet_infinite : ExceptionalSet.Infinite (via Set.Finite.bddAbove contradiction)"
     ],
     "insights": [
       "Erdos16 file was a definitions-only stub (10 defs, 0 theorems). The deep results (Romanoff density, Erdos covering-progression, Chen 2023 disproof) need analytic NT beyond Mathlib; the tractable axiom-free content is elementary structural facts about the file's own defs.",
@@ -63,7 +65,8 @@
       "Two concrete covering gears verified: prime 3 (order 2) kills even exponents for n ≡ 1 (mod 3); prime 7 (order 3) kills exponents ≡ 0 (mod 3) for n ≡ 1 (mod 7). Demonstrates the general lemma is not specialized to a single prime.",
       "Session 5: assembled the individual covering gears into the full Erdos 1950 obstruction. The six exponent classes {0 mod 2, 0 mod 3, 1 mod 4, 3 mod 8, 7 mod 12, 23 mod 24} cover Z (omega), each carrying a prime whose order of 2 equals the modulus: (2,3),(3,7),(4,5),(8,17),(12,13),(24,241).",
       "Session 5: covering_obstruction_not_isRomanoff proves that any n meeting the six CRT congruences (n=1 mod 3, 1 mod 7, 2 mod 5, 8 mod 17, 11 mod 13, 121 mod 241) with n-2^k>241 for all valid k is NOT Romanoff — the whole CRT progression (mod 3*5*7*13*17*241) is exceptional, subject only to a size hypothesis. Axiom-free.",
-      "Session 5: the required n-residues are 2^r mod p per class: 2^0=1 (p=3,7), 2^1=2 (p=5), 2^3=8 (p=17), 2^7=128=11 mod 13, 2^23=121 mod 241. Verified 2^23 mod 241 = 121 and 2*121=242=1 mod 241."
+      "Session 5: the required n-residues are 2^r mod p per class: 2^0=1 (p=3,7), 2^1=2 (p=5), 2^3=8 (p=17), 2^7=128=11 mod 13, 2^23=121 mod 241. Verified 2^23 mod 241 = 121 and 2*121=242=1 mod 241.",
+      "EXCEPTIONAL SET IS INFINITE (Erdős 1950 conclusion, axiom-free): exceptionalSet_infinite. Upgraded the covering construction from conditional (needs size hypothesis) to unconditional infinitude via exists_exceptional_gt: for any B, the CRT-progression member (n ≡ 7629217 mod 2M=11184810) landing in the dyadic window [2^m+242, 2^{m+1}) exceeds B, is odd, meets the six covering congruences, AND satisfies the size condition automatically (any k with 2^k<n has k≤m ⟹ n−2^k ≥ 242). Key: window-based size discharge sidesteps the messy largest-power-of-2 analysis."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for **erdos-16-wip-01** (odd integers not of the form `2^k + p`).

The prior work formalized Erdős's 1950 covering-congruence construction as
`covering_progression_mem_exceptionalSet` — but *conditionally*, gated behind a size
hypothesis `∀ k, 1 ≤ k → 2^k < n → 241 < n − 2^k`. This session discharges that hypothesis
for infinitely many members, yielding Erdős's actual conclusion **in full**.

## Progress
Added to `proofs/Proofs/Erdos16Problem.lean`:

- **`exceptionalSet_infinite : ExceptionalSet.Infinite`** — Erdős (1950): the set of odd
  integers not expressible as `2^k + p` is infinite.
- **`exists_exceptional_gt (B) : ∃ n, B < n ∧ n ∈ ExceptionalSet`** — the engine. For `m`
  large (`m = B + 2M + 243`, so `2^m > m` by `Nat.lt_two_pow_self`), the CRT progression
  `n ≡ 7629217 (mod 2M = 11184810 = 2·3·5·7·13·17·241)` has a member in the dyadic window
  `[2^m+242, 2^{m+1})`. That member exceeds `B`, is odd, meets the six covering congruences,
  and — crucially — satisfies the size condition **automatically**: any exponent `k` with
  `2^k < n < 2^{m+1}` has `k ≤ m`, so `n − 2^k ≥ (2^m+242) − 2^m = 242 > 241`.

The window-based discharge sidesteps the awkward "largest power of two below `n`" analysis
entirely. The CRT witness `7629217` was computed once; every congruence (and oddness) then
falls out of `omega` on `n = 7629217 + q·11184810`, since `2M` is divisible by each modulus.

## Verification
- Host-verified: `lake env lean Proofs/Erdos16Problem.lean` — exit 0, **0 warnings**.
- Axiom-free: `#print axioms exceptionalSet_infinite` = `[propext, Classical.choice, Quot.sound]`
  (no `native_decide` / `Lean.ofReduceBool` / `sorryAx`).
- `theoremCount` 36 → 38, `lineCount` 582 → 640; 0 axioms, 0 sorries.

## Status
**Outcome**: progress (Erdős 1950 now complete and unconditional)
**Next Steps**: the remaining pieces are genuinely analytic/deep and stay documented-only —
Romanoff's 1934 positive-density lower bound (sieve + PNT) and Chen's 2023 disproof (the
exceptional set has richer structure than one arithmetic progression plus a density-0 set).

🤖 Generated by researcher-1-4
