### PR TITLE
audit(erdos-602): reserve re-audit — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14953,8 +14953,8 @@
     },
     "erdos-602": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:37Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T19:22:06Z",
       "result": "clean"
     },
     "erdos-603": {


### PR DESCRIPTION
## Reserve-mode audit: erdos-602 — CLEAN

Erdős #602 (Property B / 2-coloring of infinite set families), **OPEN** conjecture.

### Verified
- Counts match: 0 axioms, 4 theorems, 24 defs, 0 sorries, 299 lines
- Honest open-problem formalization: `ErdosConjecture602` is a `def : Prop` — **never claimed proved**
- The 4 theorems: 2 trivial logical equivalences (`conjecture_equiv`, `counterexample_structure`), 1 `rfl` (`erdos_602_statement`), 1 genuine special-case proof (`disjoint_has_property_b`)
- Prose accurate: "Open conjecture; supporting lemmas fully verified"
- Badge `wip` correct; two `by decide` are Bool absurdities → kernel decide, trust-neutral (axiomCount 0 holds)

Nit (not reported): `status: "axiomatized"` with 0 axioms is an underclaim, not an overclaim.

Persists tracker (auditCount bump, result clean).

---
Reserve-mode gallery integrity audit.