### PR TITLE
Enrich erdos-709: re-anchor sections, cover Parts X-XI

### DIFF
--- a/src/data/proofs/erdos-709/meta.json
+++ b/src/data/proofs/erdos-709/meta.json
@@ -65,7 +65,7 @@
     "erdosUrl": "https://erdosproblems.com/709",
     "erdosProblemStatus": "open",
     "axiomCount": 4,
-    "lineCount": 225,
+    "lineCount": 226,
     "assumptions": "4 axioms: f (extremal function f(n)), lower_bound_log (f(n) ≥ (log n)^c for some c > 0), upper_bound_sqrt (f(n) ≤ C·√n), g (related function g(n) from Problem 708). 0 sorries.",
     "theoremCount": 2,
     "definitionCount": 8
@@ -90,75 +90,99 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Header, Problem Statement, and Imports",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "File header for Erdős problem #709 — a covering / interval problem concerning the function f(n) (Erdős–Surányi 1959) — with references and the `import Mathlib` / `namespace Erdos709` preamble.",
+      "mathContext": "Erdős #709 studies $f(n)$, tied to covering properties of intervals; see the Erdős–Surányi (1959) bounds developed in Part IV."
+    },
+    {
       "id": "basic-definitions",
       "title": "Basic Definitions",
       "summary": "ValidSet, maxElem, Interval structures",
-      "startLine": 42,
-      "endLine": 63,
+      "startLine": 37,
+      "endLine": 58,
       "mathContext": "Formal definition: ValidSet, maxElem, Interval structures"
     },
     {
       "id": "covering",
       "title": "The Covering Property",
       "summary": "Covering structure and HasCovering predicate",
-      "startLine": 64,
-      "endLine": 80,
+      "startLine": 59,
+      "endLine": 75,
       "mathContext": "Formal definition: Covering structure and HasCovering predicate"
     },
     {
       "id": "f-function",
       "title": "The Function f(n)",
       "summary": "f definition and sufficiency axioms",
-      "startLine": 81,
-      "endLine": 102,
+      "startLine": 76,
+      "endLine": 92,
       "mathContext": "Formal definition: f definition and sufficiency axioms"
     },
     {
       "id": "bounds",
       "title": "Known Bounds",
       "summary": "Erdős-Surányi 1959 lower and upper bounds combined",
-      "startLine": 103,
-      "endLine": 122,
+      "startLine": 93,
+      "endLine": 112,
       "mathContext": "Bound: Erdős-Surányi 1959 lower and upper bounds combined"
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
       "summary": "f(1) = 1, f(2) ≤ 2",
-      "startLine": 123,
-      "endLine": 132
+      "startLine": 113,
+      "endLine": 116
     },
     {
       "id": "properties",
       "title": "Properties of f",
       "summary": "Monotonicity and logarithmic growth",
-      "startLine": 133,
-      "endLine": 142,
+      "startLine": 117,
+      "endLine": 120,
       "mathContext": "Mathematical content: Monotonicity and logarithmic growth"
     },
     {
       "id": "problem-708",
       "title": "Connection to Problem 708",
       "summary": "Related g(n) function with distinct objectives",
-      "startLine": 143,
-      "endLine": 167,
+      "startLine": 121,
+      "endLine": 132,
       "mathContext": "Mathematical content: Related g(n) function with distinct objectives"
     },
     {
       "id": "open-problem",
       "title": "The Open Problem",
       "summary": "Conjecture about true growth rate with openness axioms",
-      "startLine": 168,
-      "endLine": 201,
+      "startLine": 133,
+      "endLine": 155,
       "mathContext": "Axiomatized: Conjecture about true growth rate with openness axioms"
     },
     {
       "id": "proof-techniques",
       "title": "Proof Techniques",
       "summary": "Prime CRT lower bound and Hall's theorem upper bound",
-      "startLine": 202,
-      "endLine": 230,
+      "startLine": 156,
+      "endLine": 170,
       "mathContext": "Verified: Prime CRT lower bound and Hall's theorem upper bound"
+    },
+    {
+      "id": "examples",
+      "title": "Part X: Examples",
+      "startLine": 171,
+      "endLine": 192,
+      "summary": "Worked examples and decidable sanity checks — an interval-length covering example and `native_decide` evaluations of `Nat.sqrt` at 100 and 10000.",
+      "mathContext": "Concrete instances illustrating the covering property and $f(n)$ growth."
+    },
+    {
+      "id": "summary",
+      "title": "Part XI: Summary",
+      "startLine": 193,
+      "endLine": 226,
+      "summary": "Closing summary with the headline `erdos_709_statement` capturing the status of Erdős problem #709; closes namespace Erdos709.",
+      "mathContext": "erdos_709_statement: the formal statement summarising the open covering/interval problem."
     }
   ],
   "conclusion": {
@@ -185,7 +209,7 @@
       "Finset"
     ],
     "namespace": "Erdos709",
-    "lineCount": 225,
+    "lineCount": 226,
     "axiomCount": 4,
     "theoremCount": 2,
     "definitionCount": 8,


### PR DESCRIPTION
## Section anchor re-anchoring (heavy drift + uncovered tail Parts)

`erdos-709` (`Erdos709Problem.lean`, 226 lines) had its 9 `sections` increasingly
drifted ahead of their `## Part N` banners and stopped at Part IX:

- **"Proof Techniques"** claimed 202–230 vs its `## Part IX` banner @157, overshooting EOF.
- **Parts X (Examples) and XI (Summary)** — the latter holding `erdos_709_statement` @218 — had no sections.

Re-anchored the 9 existing sections to their `## Part I`–`## Part IX` banner `/-`
opens, added a head section (1–36) and two tail sections for Parts X–XI →
contiguous 1..226 coverage (9 → 12 sections). No `status` / `badge` /
`axiomCount` changes.
