### PR TITLE
audit(erdos-603): reserve re-audit — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14959,8 +14959,8 @@
     },
     "erdos-603": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:37Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T19:24:20Z",
       "result": "clean"
     },
     "erdos-604": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-603 (queue drained; uncontested target).

## Verified
- **axiomCount 1** — `komjath_not1` (Komjáth ℵ₀-suffices for ≠1 case): faithful, disclosed upper-bound axiom, satisfiable (not False-masking). ✓
- **0 sorries**; only a kernel `decide` (trust-neutral, not native_decide). ✓
- **6 theorems** all have real proofs — no `True`-stubs, no vacuous `∃c>0` existentials. ✓
- **16 originalContributions** decls all present in source — no phantoms. ✓
- **definitionCount 19 / lineCount 287** both exact. ✓
- **status/badge** `axiomatized`/`axiom` (Tier C) correct; file honestly labels the ≠2 problem OPEN and does not claim to solve it.

Distinct from erdos-606 (false Szemerédi–Trotter axiom) and erdos-604 (vacuous existential) in this batch — erdos-603's single axiom is sound and properly credited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)