### PR TITLE
Enrich erdos-455: fix systemic section drift (4 sections anchored below their banners)

### DIFF
--- a/src/data/proofs/erdos-455/meta.json
+++ b/src/data/proofs/erdos-455/meta.json
@@ -126,27 +126,27 @@
       "id": "open-conjecture",
       "title": "The Open Conjecture",
       "startLine": 71,
-      "endLine": 88,
+      "endLine": 82,
       "summary": "States Erdős's full conjecture as an abstract `Prop` and proves equivalence: the conjecture holds iff $\\mathrm{Tendsto}(q_n/n^2, \\mathrm{atTop}, \\mathrm{atTop})$ for all monotone-gap prime sequences."
     },
     {
       "id": "consequences",
       "title": "Consequences of Richter's Bound",
-      "startLine": 96,
-      "endLine": 103,
+      "startLine": 83,
+      "endLine": 94,
       "summary": "Derives $\\exists c > 0,\\, \\forall^\\mathrm{f} n,\\, q_n \\geq c \\cdot n^2$ from the liminf bound, establishing eventual quadratic growth."
     },
     {
       "id": "structural-properties",
       "title": "Structural Properties",
-      "startLine": 111,
-      "endLine": 124,
+      "startLine": 95,
+      "endLine": 115,
       "summary": "Proves `gaps_pos` (strict monotonicity implies positive gaps), `first_prime_ge_two` and `all_ge_two` (primality implies $q_n \\geq 2$) using Mathlib's `Nat.Prime.two_le`."
     },
     {
       "id": "restrictiveness",
       "title": "Alternative Characterization",
-      "startLine": 137,
+      "startLine": 116,
       "endLine": 142,
       "summary": "Proves `nonDecGaps_alt`: the non-decreasing gaps condition is equivalent to $\\forall n \\geq 1,\\, q(n+1) - q(n) \\geq q(n) - q(n-1)$. The $n = 0$ case is trivial by `simp`."
     }


### PR DESCRIPTION
## Summary

The undercoverage scan surfaced two stranded lemmas (`first_prime_ge_two`, `nonDecGaps_alt`); investigating revealed a **systemic** drift — every section from "The Open Conjecture" onward was anchored ~13 lines *below* its actual `## ...` banner. The gallery therefore highlighted the wrong line ranges: e.g. §"Consequences of Richter's Bound" (anchored 96–103) was sitting on the "Structure of Monotone-Gap Prime Sequences" banner + `gaps_pos`, while the real Consequences content (banner @84) went uncovered.

Re-anchored all four to their banners (ranges verified against `grep '^## '` + decl positions):

| Section | Old | New |
|---|---|---|
| The Open Conjecture | 71–88 | 71–82 |
| Consequences of Richter's Bound | 96–103 | 83–94 |
| Structural Properties | 111–124 | 95–115 |
| Alternative Characterization | 137–142 | 116–142 |

Now contiguous and gap-free; `first_prime_ge_two` (107) and `nonDecGaps_alt` (127) are covered by the sections whose summaries already named them.

## Verification
- `meta.json` parses; 7 sections, no overlaps.
- Sections-coverage only — no status/badge/axiomCount changes, no content removed.
