### PR TITLE
Enrich erdos-535, erdos-789: re-anchor uniformly-drifted sections

### DIFF
--- a/src/data/proofs/erdos-535/meta.json
+++ b/src/data/proofs/erdos-535/meta.json
@@ -23,7 +23,7 @@
     "erdosUrl": "https://erdosproblems.com/535",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 207,
+    "lineCount": 208,
     "assumptions": "2 axioms: abbott_hanson_upper_bound, erdos_lower_bound. 0 sorries.",
     "mathlib_version": "4.31.0",
     "theoremCount": 2,
@@ -52,87 +52,87 @@
       "title": "Imports and Setup",
       "summary": "File header stating Erdős #535 (GCD-free r-subsets): estimate f_r(N), the largest A ⊆ {1,...,N} with no r elements sharing a common pairwise gcd. Records the known bounds, Erdős's conjecture, the sunflower connection, and the Mathlib imports.",
       "startLine": 1,
-      "endLine": 42,
+      "endLine": 38,
       "mathContext": "Open problem: bound f_r(N) for r ≥ 3. Upper N^{1/2+o(1)} (Abbott-Hanson 1970), lower N^{c/log log N} (Erdős 1964)."
     },
     {
       "id": "basic-definitions",
       "title": "Part 1: Basic Definitions",
       "summary": "Defines HasNoRGCDSubset and the alternative HasNoGCDClique predicates, IsSubsetOfInterval, and f r N as the supremum of |A| over subsets of {1,...,N} avoiding an r-element common-pairwise-gcd set.",
-      "startLine": 43,
-      "endLine": 65,
+      "startLine": 39,
+      "endLine": 61,
       "mathContext": "f(r,N) = sSup { |A| : A ⊆ {1,...,N}, no r elements of A share a common pairwise gcd d }."
     },
     {
       "id": "trivial-bounds",
       "title": "Part 2: Trivial Bounds",
       "summary": "Expository: the trivial bound f_r(N) ≤ N, and why r = 2 is degenerate so r ≥ 3 is the interesting regime.",
-      "startLine": 66,
-      "endLine": 75,
+      "startLine": 62,
+      "endLine": 71,
       "mathContext": "Trivial range f_r(N) ≤ N; r = 2 is impossible, so the problem starts at r ≥ 3."
     },
     {
       "id": "erdos-upper-1964",
       "title": "Part 3: Erdős's Original Upper Bound (1964)",
       "summary": "Expository note on Erdős's first non-trivial upper bound f_r(N) ≤ N^{3/4+o(1)}, later superseded by Abbott-Hanson.",
-      "startLine": 76,
-      "endLine": 85,
+      "startLine": 72,
+      "endLine": 81,
       "mathContext": "Erdős (1964): f_r(N) ≤ N^{3/4+o(1)}, the first sub-linear upper bound."
     },
     {
       "id": "abbott-hanson-upper",
       "title": "Part 4: Abbott-Hanson Upper Bound (1970)",
       "summary": "States abbott_hanson_upper_bound as an axiom (f_r(N) ≤ C·N^{1/2+ε} for r ≥ 3) and proves exponent_improvement (3/4 > 1/2) by norm_num, recording that this is the best known upper bound.",
-      "startLine": 86,
-      "endLine": 104,
+      "startLine": 82,
+      "endLine": 100,
       "mathContext": "Abbott-Hanson (1970): for r ≥ 3, ∃ C>0 such that ∀ε>0, eventually f_r(N) ≤ C·N^{1/2+ε}."
     },
     {
       "id": "erdos-lower-1964",
       "title": "Part 5: Erdős's Lower Bound (1964)",
       "summary": "States erdos_lower_bound as an axiom: f_3(N) > N^{c/log log N} for some c > 0, a quasi-polynomial lower bound growing slower than N^ε yet faster than any poly-log.",
-      "startLine": 105,
-      "endLine": 120,
+      "startLine": 101,
+      "endLine": 116,
       "mathContext": "Erdős (1964): ∃ c>0, eventually f_3(N) > N^{c/log log N}."
     },
     {
       "id": "the-gap",
       "title": "Part 6: The Gap Between Bounds",
       "summary": "Describes the enormous gap between the polynomial upper bound N^{1/2+o(1)} and the quasi-polynomial lower bound, and defines ErdosConjecture asserting the lower bound is essentially tight.",
-      "startLine": 121,
-      "endLine": 139,
+      "startLine": 117,
+      "endLine": 135,
       "mathContext": "ErdosConjecture: ∀ r≥3, eventually f_r(N) ≤ C·N^{c/log log N}, which would close the gap to quasi-polynomial."
     },
     {
       "id": "sunflower-connection",
       "title": "Part 7: Connection to Sunflower Problem",
       "summary": "Expository: a strengthened sunflower conjecture (removing the k! factor from the Erdős-Rado bound) would imply Erdős's conjecture for this problem; cross-references Problems #20 and #536.",
-      "startLine": 140,
-      "endLine": 153,
+      "startLine": 136,
+      "endLine": 149,
       "mathContext": "A sunflower conjecture without the k! Erdős-Rado factor would resolve the f_r(N) conjecture."
     },
     {
       "id": "small-cases",
       "title": "Part 8: Small Cases and Examples",
       "summary": "Expository: exact small values such as f_3(6)=4 ({1,2,3,5}) and f_3(10)=5, and why the primes-plus-one set {1} ∪ {p ≤ N} (size ≈ N/log N) is worse than the lower bound.",
-      "startLine": 154,
-      "endLine": 164,
+      "startLine": 150,
+      "endLine": 160,
       "mathContext": "Worked small cases: f_3(6)=4, f_3(10)=5; the prime-based construction is suboptimal."
     },
     {
       "id": "proof-techniques",
       "title": "Part 9: Proof Techniques",
       "summary": "Expository survey of the three main methods: counting (Erdős), gcd-graph Turán bounds (Abbott-Hanson), and multiplicative constructions for lower bounds, plus the additive-multiplicative dichotomy that makes the problem hard.",
-      "startLine": 165,
-      "endLine": 182,
+      "startLine": 161,
+      "endLine": 178,
       "mathContext": "Methods: pair-counting, Turán-type clique bounds on the gcd graph, and multiplicative/sieve constructions."
     },
     {
       "id": "summary",
       "title": "Part 10: Summary",
       "summary": "Proves erdos_535_summary, bundling the Abbott-Hanson upper bound and the Erdős lower bound into a single conjunction discharged from the two stated axioms; restates the OPEN status and conjecture.",
-      "startLine": 183,
-      "endLine": 211,
+      "startLine": 179,
+      "endLine": 208,
       "mathContext": "erdos_535_summary: conjunction of the Abbott-Hanson upper and Erdős lower bounds, proved from the two axioms."
     }
   ],
@@ -161,7 +161,7 @@
       "Finset"
     ],
     "namespace": "Erdos535",
-    "lineCount": 207,
+    "lineCount": 208,
     "axiomCount": 2,
     "theoremCount": 2,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-789/meta.json
+++ b/src/data/proofs/erdos-789/meta.json
@@ -62,7 +62,7 @@
     "erdosUrl": "https://erdosproblems.com/789",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 238,
+    "lineCount": 239,
     "assumptions": "3 axioms: h, straus_1966_upper, erdos_choi_1974_lower. 0 sorries.",
     "theoremCount": 4,
     "definitionCount": 7
@@ -91,111 +91,111 @@
       "id": "header",
       "title": "Problem Statement and Imports",
       "startLine": 1,
-      "endLine": 40,
+      "endLine": 36,
       "summary": "Module docstring stating Erdős Problem #789 (the growth rate of h(n), the largest sum-length-free subset) and Mathlib imports.",
       "mathContext": "Erdős #789 asks for the asymptotic growth of h(n): the size of the largest subset B of {1,...,n} in which no two distinct subsets have the same sum and the same number of terms. The problem remains open."
     },
     {
       "id": "basic-definitions",
       "title": "Basic Definitions",
-      "startLine": 41,
-      "endLine": 61,
+      "startLine": 37,
+      "endLine": 57,
       "summary": "SumRep structure, SumLengthFree property",
       "mathContext": "SumRep structure, SumLengthFree property"
     },
     {
       "id": "h-function",
       "title": "The Function h(n)",
-      "startLine": 62,
-      "endLine": 75,
+      "startLine": 58,
+      "endLine": 71,
       "summary": "Definition and existence axioms for h(n)",
       "mathContext": "Definition and existence axioms for h(n)"
     },
     {
       "id": "upper-bounds",
       "title": "Upper Bounds",
-      "startLine": 76,
-      "endLine": 90,
+      "startLine": 72,
+      "endLine": 86,
       "summary": "Erdős n^{5/6}, Straus √n (best known)",
       "mathContext": "Erdős n^{5/6}, Straus √n (best known)"
     },
     {
       "id": "lower-bounds",
       "title": "Lower Bounds",
-      "startLine": 91,
-      "endLine": 105,
+      "startLine": 87,
+      "endLine": 101,
       "summary": "Erdős n^{1/3}, Choi (n log n)^{1/3} (best known)",
       "mathContext": "Erdős n^{1/3}, Choi (n log n)^{1/3} (best known)"
     },
     {
       "id": "gap",
       "title": "The Gap and Combined Bounds",
-      "startLine": 106,
-      "endLine": 119,
+      "startLine": 102,
+      "endLine": 115,
       "summary": "Combined bounds theorem: (n log n)^{1/3} ≪ h(n) ≪ √n",
       "mathContext": "Combined bounds theorem: (n log n)^{1/3} ≪ h(n) ≪ √n"
     },
     {
       "id": "erdos-construction",
       "title": "Erdős's Construction",
-      "startLine": 120,
-      "endLine": 130,
+      "startLine": 116,
+      "endLine": 126,
       "summary": "Erdős's probabilistic construction for the lower bound, and Choi's refinement.",
       "mathContext": "Documents Erdős's probabilistic lower-bound construction: for random α ∈ [0,1], take B = {a ∈ A : {αa} lies in a short interval around n^{-1/3}}, giving expected |B| ≈ n^{1/3} that is likely sum-length-free; followed by Choi's improvement via more careful analysis."
     },
     {
       "id": "sidon",
       "title": "Connection to Sidon Sets",
-      "startLine": 131,
-      "endLine": 141,
+      "startLine": 127,
+      "endLine": 137,
       "summary": "IsSidonSet definition; connection noted in docstrings only, not formalized",
       "mathContext": "IsSidonSet definition"
     },
     {
       "id": "related-problems",
       "title": "Related Problems",
-      "startLine": 142,
-      "endLine": 149,
+      "startLine": 138,
+      "endLine": 145,
       "summary": "Connections to neighbouring Erdős problems #186 (sum-free sets) and #874.",
       "mathContext": "Notes the relationship between h(n) and Erdős Problem #186 (sum-free sets) and Problem #874; these connections are recorded as docstrings, not formalized."
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
-      "startLine": 150,
-      "endLine": 156,
+      "startLine": 146,
+      "endLine": 152,
       "summary": "Small-n behaviour: h(1) = 1 trivially, with explicit bounds available for small sets.",
       "mathContext": "For n = 1, h(1) = 1 trivially; for small sets explicit bounds on the largest sum-length-free subset can be computed directly."
     },
     {
       "id": "examples",
       "title": "Computational Examples",
-      "startLine": 157,
-      "endLine": 178,
+      "startLine": 153,
+      "endLine": 174,
       "summary": "√1000 and √10^6 via native_decide",
       "mathContext": "√1000 and √10^6 via native_decide"
     },
     {
       "id": "conjectures",
       "title": "Conjectures",
-      "startLine": 179,
-      "endLine": 196,
+      "startLine": 175,
+      "endLine": 192,
       "summary": "The conjectured growth rates for h(n), packaged as possible_growth_rates.",
       "mathContext": "Defines possible_growth_rates capturing three plausible asymptotic scenarios for h(n): (1) h(n) ~ n^{1/2} (the Straus upper bound is tight), (2) h(n) ~ n^α for some 1/3 < α < 1/2, or (3) h(n) grows slower than any power of n. Determining the correct exponent is the open problem."
     },
     {
       "id": "proof-techniques",
       "title": "Proof Techniques",
-      "startLine": 197,
-      "endLine": 206,
+      "startLine": 193,
+      "endLine": 202,
       "summary": "Survey of the methods behind the bounds: counting arguments, the probabilistic method, and Diophantine approximation.",
       "mathContext": "Summarizes the proof techniques: the upper bound uses a counting argument on sum representations, the lower bound uses the probabilistic method with fractional parts, and Diophantine approximation underlies Erdős's construction."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 207,
-      "endLine": 242,
+      "startLine": 203,
+      "endLine": 239,
       "summary": "Main theorem combining bounds, problem OPEN",
       "mathContext": "Main theorem combining bounds, problem OPEN"
     }
@@ -224,7 +224,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos789",
-    "lineCount": 238,
+    "lineCount": 239,
     "axiomCount": 3,
     "theoremCount": 4,
     "definitionCount": 7,


### PR DESCRIPTION
## Section anchor re-anchoring (uniform drift, swallowed banners)

Two entries with the same defect: all `sections` anchored ~3 lines *after* their
`## Part N` banners, so each section's `endLine` overran into the next Part's
banner block and the final "Summary" section overshot end-of-file.

- **erdos-535** (`Erdos535Problem.lean`, 208 lines): Summary claimed 183–211 (EOF 208); re-anchored 11 sections to `## Part 1`–`## Part 10` banner `/-` opens.
- **erdos-789** (`Erdos789Problem.lean`, 239 lines): Summary claimed 207–242 (EOF 239); re-anchored 14 sections to `## Part I`–`## Part XIII` banner `/-` opens.

Both re-anchored (head section included) for contiguous 1..EOF coverage. No
`status` / `badge` / `axiomCount` changes.
