### PR TITLE
Fix: repair false szemeredi_trotter_bound axiom in erdos-606 (#40826)

### DIFF
--- a/proofs/Proofs/Erdos606Problem.lean
+++ b/proofs/Proofs/Erdos606Problem.lean
@@ -165,12 +165,21 @@ axiom beck_theorem (n : ℕ) (hn : n ≥ 100) (cfg : PointConfig n) :
 /- ## Part VII: Szemerédi-Trotter Incidence Bound -/
 
 /-- **Szemerédi-Trotter Theorem** (1983): The number of incidences between
-    n points and m lines in ℝ² is at most O((nm)^(2/3) + n + m). -/
-axiom szemeredi_trotter_bound (n m : ℕ) :
-    ∀ (pts : Fin n → Point) (lines : Fin m → Line),
-      let incidences := (Finset.univ ×ˢ Finset.univ).filter
-        fun p => onLine (pts p.1) (lines p.2)
-      (incidences.card : ℝ) ≤ 10 * ((n : ℝ) * m) ^ ((2 : ℝ) / 3) + n + m
+    n **distinct** points and m **distinct** lines in ℝ² is at most
+    O((nm)^(2/3) + n + m).
+
+    The distinctness hypotheses are essential: `hpts` requires the points to be
+    genuinely distinct, and `hlines` requires the lines to be pairwise distinct
+    **as geometric lines** (two `Line` structs coincide iff they have the same
+    point set). Without them the bound is trivially false — e.g. all `n·m`
+    incidences collapse onto a single point/line where the RHS is smaller. -/
+axiom szemeredi_trotter_bound (n m : ℕ)
+    (pts : Fin n → Point) (lines : Fin m → Line)
+    (hpts : Function.Injective pts)
+    (hlines : ∀ i j, i ≠ j → ¬ (∀ x, onLine x (lines i) ↔ onLine x (lines j))) :
+    let incidences := (Finset.univ ×ˢ Finset.univ).filter
+      fun p => onLine (pts p.1) (lines p.2)
+    (incidences.card : ℝ) ≤ 10 * ((n : ℝ) * m) ^ ((2 : ℝ) / 3) + n + m
 
 /- ## Part VIII: Complete Characterization -/
 

--- a/src/data/proofs/erdos-606/meta.json
+++ b/src/data/proofs/erdos-606/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/606",
     "erdosProblemStatus": "solved",
     "axiomCount": 12,
-    "lineCount": 245,
+    "lineCount": 254,
     "assumptions": "12 axioms: numDistinctLines, numDistinctLines_collinear, numDistinctLines_general_position, numDistinctLines_min_noncollinear, sylvester_gallai, not_achievable_max_minus_1, not_achievable_max_minus_3, achievable_max_minus_2, erdos_density_result, beck_theorem, szemeredi_trotter_bound, erdos_salamon_characterization. 0 sorries.",
     "mathlib_version": "4.31.0",
     "theoremCount": 2,
@@ -160,7 +160,7 @@
       "Real"
     ],
     "namespace": "Erdos606",
-    "lineCount": 245,
+    "lineCount": 254,
     "axiomCount": 12,
     "theoremCount": 2,
     "definitionCount": 10,


### PR DESCRIPTION
## Summary

Repairs the **false axiom** `szemeredi_trotter_bound` in `erdos-606`
(`proofs/Proofs/Erdos606Problem.lean`), flagged by the gallery integrity audit
in #40826. As stated, the axiom quantified over **arbitrary** point/line
families with no distinctness hypotheses, so instantiating all points and all
lines to coincide gives `incidences.card = n·m = 10000` while the RHS is
`≈ 4842`, deriving `False` and making the whole file's axiom set inconsistent.

## Fix

Added the missing distinctness hypotheses so the axiom matches the real
Szemerédi–Trotter theorem:

- `hpts : Function.Injective pts` — the points are genuinely distinct.
- `hlines : ∀ i j, i ≠ j → ¬ (∀ x, onLine x (lines i) ↔ onLine x (lines j))` —
  the lines are pairwise distinct **as geometric lines** (equal point sets ⟹
  same line).

The audit's own suggested minimal fix (`Function.Injective lines` on the `Line`
struct) is **insufficient**, as it itself noted: distinct `Line` structs can
denote the same geometric line (infinitely many `(p,q)` parametrizations of one
line), so the coincident-line counterexample survives. Using point-set equality
for line distinctness closes that gap, so the axiom is now a faithful statement
of the real theorem rather than a false blanket claim.

The axiom is not applied by any theorem in the file (`erdos_606_solved` derives
from `erdos_salamon_characterization`), so no downstream proof changes.

## Evidence

- Before: `axiom szemeredi_trotter_bound (n m : ℕ) : ∀ (pts …) (lines …), … ≤ …`
  (no distinctness → derives `False`).
- After: `axiom szemeredi_trotter_bound (n m : ℕ) (pts …) (lines …) (hpts …)
  (hlines …) : … ≤ …`.
- Host-verified: `lake env lean Proofs/Erdos606Problem.lean` compiles with no
  errors (only a pre-existing `Set.mem_diff` deprecation warning).
- `meta.json` `lineCount` updated 245 → 254 to match; axiom/theorem/def counts,
  badge (`axiom`), and status (`axiomatized`) all remain correct and unchanged.

Note: a broken legacy duplicate `proofs/Proofs/Stubs/Erdos606Problem.lean`
carries the same defective axiom but does not compile (pre-existing Decidability
and `⟨…⟩` errors, unrelated to this issue) and is not the gallery-tracked file;
left untouched to keep this repair minimal.

Closes #40826
