### PR TITLE
audit(erdos-587): reserve re-audit — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14828,8 +14828,8 @@
     },
     "erdos-587": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:37Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T19:28:25Z",
       "result": "clean"
     },
     "erdos-588": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-587 (square-sum-free subsets; queue drained; uncontested).

## Verified
- **axiomCount 2** — `erdos_lower_bound` (Ω), `nguyen_vu_upper_bound` (O): both faithful to cited results, disclosed in `assumptions`. Lower bound is a genuine asymptotic (c fixed, then ∀ᶠN) — NOT a vacuous `∃c>0` post-instance bound. Mutually consistent. ✓
- **6 theorems** — `erdos_587_tight_bound` honestly combines the 2 axioms into the Θ bound; 5 structural/example theorems (`empty`, `singleton_iff`, `two/three_not_square`, `one_two_not`) are genuinely proved. 2 anonymous `example`s correctly excluded from count. `decide` is kernel (trust-neutral). ✓
- **definitionCount 2 / lineCount 155 / 0 sorries** — exact. ✓
- **originalContributions (3)** all real and correctly scoped. ✓
- **status/badge** `axiomatized`/`axiom` correct; main answer axiomatized not claimed proved. Prose 'we prove' scoped to auxiliaries; 'They proved' attributes Nguyen–Vu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)