### PR TITLE
audit(erdos-589): reserve re-audit — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14843,8 +14843,8 @@
     },
     "erdos-589": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:37Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T19:30:49Z",
       "result": "clean"
     },
     "erdos-59": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-589 (queue drained; oldest uncontested target).

**Verdict: CLEAN.** Tier C axiomatized proof, honestly disclosed.

- 4 axioms (Füredi upper `o(n)`, Füredi lower `√n·log n`, greedy `√n`, Balogh-Solymosi 2018 `n^(5/6+ε)`) — matches axiomCount.
- 14 theorems, 9 defs, 0 sorries (lone `sorry` hit is in a docstring), no native_decide.
- Axioms are consistent bound-axioms on a well-defined `g` (satisfiable sandwich; no False-masking).
- badge=axiom / status=axiomatized honest; `assumptions`/`proofStrategy` explicitly state the deep results are axiomatized; structural lemmas correctly labeled 'verified, 0 axioms'.

Only tracker JSON changed (auditCount 3→4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)