### PR TITLE
Enrich area-of-circle-oq010: re-anchor drifted section run

### DIFF
--- a/src/data/proofs/area-of-circle-oq010/meta.json
+++ b/src/data/proofs/area-of-circle-oq010/meta.json
@@ -169,35 +169,35 @@
       "id": "integrands",
       "title": "The Speed and Area Integrands",
       "startLine": 1,
-      "endLine": 69,
+      "endLine": 64,
       "summary": "speedFn x y u = √(x'(u)² + y'(u)²) is the arc-length integrand (its integral over a period is the circumference); areaFn x y u = x(u)·y'(u) − y(u)·x'(u) is the Green's-theorem integrand (its integral over a period is twice the signed area). The two invariance theorems are stated about these."
     },
     {
       "id": "part-i",
       "title": "Periodicity of the Derivative",
-      "startLine": 71,
-      "endLine": 104,
+      "startLine": 65,
+      "endLine": 99,
       "summary": "periodic_deriv: if f is T-periodic then so is deriv f, using only deriv_comp_add_const and the period identity (no differentiability hypothesis). speedFn_periodic and areaFn_periodic lift periodicity of the coordinates to the two integrands — the property that lets the period-shift lemma close both integrals."
     },
     {
       "id": "part-ii",
       "title": "Chain Rule for Coordinate Compositions",
-      "startLine": 106,
-      "endLine": 112,
+      "startLine": 100,
+      "endLine": 107,
       "summary": "deriv_coord_comp packages the chain rule (x∘φ)'(t) = x'(φ t)·φ'(t) for C¹ data, the pointwise identity that exposes the Jacobian factor φ' in both integrands."
     },
     {
       "id": "part-iii",
       "title": "Arc Length Invariance",
-      "startLine": 114,
-      "endLine": 154,
+      "startLine": 108,
+      "endLine": 149,
       "summary": "arclength_reparam_invariant: factor the speed of γ∘φ as φ'·(speed∘φ) — using φ' ≥ 0 to drop the absolute value under the square root (Real.sqrt_sq) — substitute u = φ(t) via integral_comp_mul_deriv, and collapse the resulting one-period integral [φ0, φ0+2π] back to [0,2π] with the period-shift lemma."
     },
     {
       "id": "part-iv",
       "title": "Signed Area Invariance",
-      "startLine": 156,
-      "endLine": 196,
+      "startLine": 150,
+      "endLine": 191,
       "summary": "signed_area_reparam_invariant: the same change of variables, but the φ' factor enters linearly so NO monotonicity hypothesis on φ is needed. Equality of the Green's-theorem integrals over a period yields equality of the signed areas of γ∘φ and γ."
     }
   ]


### PR DESCRIPTION
Systemic section-boundary drift: all five sections were anchored 5–6 lines below their `/-! ##` banners, stranding two theorems in inter-section gaps and pushing the last section past EOF.

**Undercoverage:** `theorem periodic_deriv` (line 70) fell in the gap between §"The Speed and Area Integrands" (ended 69) and §"Periodicity of the Derivative" (started 71); `theorem arclength_reparam_invariant` (line 113) fell between §"Chain Rule" (ended 112) and §"Arc Length Invariance" (started 114). The last section also ended at 196 while the file is only 191 lines. (`deriv_coord_comp`@103 was likewise sitting in §"Periodicity" rather than its own §"Chain Rule".)

**Fix — re-anchored all five sections to contiguous, banner-aligned ranges** (summaries already matched the corrected content; no status/badge/axiomCount change):

| Section | Before | After |
|---------|--------|-------|
| The Speed and Area Integrands | 1–69 | 1–64 |
| Periodicity of the Derivative | 71–104 | 65–99 (now covers periodic_deriv@70) |
| Chain Rule for Coordinate Compositions | 106–112 | 100–107 (now covers deriv_coord_comp@103) |
| Arc Length Invariance | 114–154 | 108–149 (now covers arclength_reparam_invariant@113) |
| Signed Area Invariance | 156–196 | 150–191 (no longer past EOF) |

Every top-level decl is now inside exactly one section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
