### PR TITLE
audit(erdos-590): reserve re-audit — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14858,8 +14858,8 @@
     },
     "erdos-590": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:37Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T19:32:53Z",
       "result": "clean"
     },
     "erdos-591": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-590 (queue drained; oldest uncontested target).

**Verdict: CLEAN.** Tier C axiomatized proof, exemplary honest disclosure.

- 5 axioms: opaque `OrdinalRamseyProperty` predicate + Specker (±), Chang, Milner-Larson — all correctly counted in axiomCount.
- 14 theorems, 2 defs, 0 sorries, no native_decide, 235 lines — all match meta.
- No False-masking: asserted/negated Ramsey-property arguments (ω², {ω^n:n≥3}, ω^ω) never collide → satisfiable axiom set.
- Prose honest: every axiom explicitly labeled 'as an axiom'; `chang_omega_omega` called 'the main result as an axiom, erdos_590_solved a trivial wrapper'; Mathlib-proved ordinal-arithmetic lemmas separated; badge=axiom/status=axiomatized.

Only tracker JSON changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)