### PR TITLE
audit(tracker): mark erdos-592 issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14873,9 +14873,9 @@
     },
     "erdos-592": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:37Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T19:39:16Z",
+      "result": "issues-fixed"
     },
     "erdos-593": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Tracker update for erdos-592 audit (issues-fixed via #40848). Prior 3 audits marked clean; this cycle caught phantom section-summary axioms + false 'now proved as theorems' prose.