### PR TITLE
Enrich 4 entries: re-anchor drifted sections to cover stranded headline decls

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03-oq-01/meta.json
@@ -134,20 +134,20 @@
       "id": "ray-and-sandwich",
       "title": "Ray Property and Sandwich",
       "startLine": 79,
-      "endLine": 110,
+      "endLine": 106,
       "summary": "Every exponent above the critical one is admissible; the sandwich Ioi(c) ⊆ admissible ⊆ Ici(c)."
     },
     {
       "id": "monotonicity",
       "title": "Monotonicity under Domination",
-      "startLine": 112,
-      "endLine": 127,
+      "startLine": 107,
+      "endLine": 115,
       "summary": "Pointwise domination shrinks the admissible set and lowers the critical exponent."
     },
     {
       "id": "linnik-specialization",
       "title": "Linnik Specialization",
-      "startLine": 129,
+      "startLine": 116,
       "endLine": 144,
       "summary": "`linnikConstantOf` and `linnik_threshold` instantiating the abstract theory at the arithmetic-progression data."
     }

--- a/src/data/proofs/divisibility-rules-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-04-oq-01-oq-01/meta.json
@@ -124,20 +124,20 @@
       "id": "master",
       "title": "The Master Parametric Lemma",
       "startLine": 62,
-      "endLine": 94,
+      "endLine": 91,
       "summary": "dvd_iff_dvd_ofDigits_pow_ten: for any k, ε, and m ∣ 10^k − ε, m ∣ n ↔ (m:ℤ) ∣ ofDigits ε (digits (10^k) n). The two named tests dvd_iff_dvd_blockSum (ε=1) and dvd_iff_dvd_blockAltSum (ε=−1) specialize it and rewrite to explicit (alternating) block sums."
     },
     {
       "id": "families",
       "title": "Both Signs and All Widths, Packaged",
-      "startLine": 96,
-      "endLine": 103,
+      "startLine": 92,
+      "endLine": 99,
       "summary": "block_divisibility_families: one statement asserting that for every k the block sum tests every divisor of 10^k − 1 and the alternating block sum tests every divisor of 10^k + 1."
     },
     {
       "id": "congruence",
       "title": "Residue Identities",
-      "startLine": 105,
+      "startLine": 100,
       "endLine": 133,
       "summary": "modEq_blockSum and modEq_blockAltSum give the full congruences n ≡ blockSum k n and n ≡ blockAltSum k n modulo any m ∣ 10^k ∓ 1, from Nat.zmodeq_ofDigits_digits and the pivots 10^k ≡ ±1 (mod m)."
     },

--- a/src/data/proofs/erdos-812/meta.json
+++ b/src/data/proofs/erdos-812/meta.json
@@ -106,7 +106,7 @@
       "id": "main-questions",
       "title": "The Two Main Conjectures",
       "startLine": 64,
-      "endLine": 72,
+      "endLine": 75,
       "summary": "Defines `ratio_conjecture` ($R(n+1)/R(n) \\geq 1 + c$ eventually) and `quadratic_difference_conjecture` ($R(n+1) - R(n) \\geq Cn^2$ eventually). Both are `Prop` values.",
       "mathContext": "Formal definition: Defines `ratio_conjecture` ($R(n+1)/R(n) \\geq 1 + c$ eventually) and `quadratic_difference_conjecture` ($R(n+1) - R(n) \\geq Cn^2$ eventually). Both are `Prop` values."
     },
@@ -122,7 +122,7 @@
       "id": "twostep",
       "title": "Two-Step Bound from Problem #165",
       "startLine": 91,
-      "endLine": 93,
+      "endLine": 96,
       "summary": "Axiomatizes $R(n+2) - R(n) \\geq Cn^2/f(n)$ where $f$ is subpolynomial. Derived from $R(3,k) \\sim k^2/\\log k$ asymptotics.",
       "mathContext": "Axiomatizes $R(n+2) - R(n) \\geq Cn^2/f(n)$ where $f$ is subpolynomial. Derived from $R(3,k) \\sim $k^{2}$/\\log k$ asymptotics."
     },

--- a/src/data/proofs/gamma-reflection-formula-oq-01-oq-02/meta.json
+++ b/src/data/proofs/gamma-reflection-formula-oq-01-oq-02/meta.json
@@ -133,22 +133,22 @@
       "id": "docstring",
       "title": "Module Docstring: 1/Γ, the Entire Dual of Γ",
       "startLine": 1,
-      "endLine": 51,
+      "endLine": 54,
       "summary": "Frames 1/Γ as the canonical entire completion of the meromorphic Γ: where Γ has simple poles (the non-positive integers), 1/Γ has its zeros, and nowhere else. States what Mathlib already provides as separate facts (differentiable_one_div_Gamma, Gamma_eq_zero_iff) and the new packaging: entire function + exact zero set + countability + isolated zeros.",
       "mathContext": "$1/\\Gamma(s) = s\\,e^{\\gamma s}\\prod_{n\\ge1}(1 + s/n)e^{-s/n}$ (Weierstrass), entire with zeros exactly at $\\{0,-1,-2,\\dots\\}$."
     },
     {
       "id": "entire",
       "title": "1/Γ is Entire",
-      "startLine": 60,
-      "endLine": 76,
+      "startLine": 56,
+      "endLine": 72,
       "summary": "differentiable_invGamma re-exports that s ↦ (Γ s)⁻¹ is differentiable on all of ℂ; analyticAt_invGamma and analyticOnNhd_invGamma promote this to analyticity at every point and on Set.univ via Differentiable.analyticAt — i.e. 1/Γ is an entire function.",
       "mathContext": "Holomorphic on $\\mathbb C$ $\\Rightarrow$ analytic on $\\mathbb C$. $1/\\Gamma$ has removable behavior across the poles of $\\Gamma$."
     },
     {
       "id": "zero-set",
       "title": "The Zero Set is Exactly the Non-Positive Integers",
-      "startLine": 78,
+      "startLine": 73,
       "endLine": 110,
       "summary": "invGamma_eq_zero_iff: (Γ z)⁻¹ = 0 ↔ ∃ n, z = -n (via inv_eq_zero and Gamma_eq_zero_iff). invGamma_ne_zero_iff is the dual. zeroSet_invGamma packages the set equality {z | (Γ z)⁻¹ = 0} = nonposInt; nonposInt_eq_range and countable_zeroSet show that set is the range of n ↦ -n, hence countable.",
       "mathContext": "$\\{z : (\\Gamma z)^{-1} = 0\\} = \\{0,-1,-2,\\dots\\}$, a countable set."


### PR DESCRIPTION
Re-anchors drifted section boundaries in 4 gallery entries. In each, one
or more sections had `startLine`/`endLine` drifted a few lines late (or
short), so the section's own headline declaration — plus its docstring —
fell into the gap between sections, covered by no section at all. A
"covered by ANY section" scan flagged the stranded decls; each fix snaps
the boundaries to the `/-!`/`/-` banner and docstring positions the
summaries already describe.

Verified per file: valid JSON, no section overlaps/inversions, every
top-level decl now covered by exactly one section.

| Entry | Stranded decls | Fix |
|-------|----------------|-----|
| dirichlets-theorem-oq-03-oq-01 | `criticalExponent_mono`, `linnikConstantOf` | ray-and-sandwich 79-110→79-106, monotonicity 112-127→107-115, linnik-specialization 129-144→116-144 |
| divisibility-rules-oq-04-oq-01-oq-01 | `block_divisibility_families`, `modEq_blockSum` | master …-94→…-91, families 96-103→92-99, congruence 105-…→100-… (snap to `### Residue identities` banner) |
| erdos-812 | `quadratic_difference_conjecture`, `problem_165_bound` (axiom) | main-questions 64-72→64-75, twostep 91-93→91-96 |
| gamma-reflection-formula-oq-01-oq-02 | `nonposInt`, `invGamma_eq_zero_iff` | docstring 1-51→1-54, entire 60-76→56-72, zero-set 78-110→73-110 |

No status/badge/axiomCount/prose changes — pure section-anchor accuracy.
