### PR TITLE
Enrich lagrange-theorem-oq-01-oq-03-oq-01: cover stranded hall_lift_of_coprime block

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-01/meta.json
@@ -79,7 +79,7 @@
       "id": "lifting-step-existence",
       "title": "The Lifting Step (Existence Form)",
       "startLine": 145,
-      "endLine": 154,
+      "endLine": 167,
       "summary": "hall_lift_of_coprime: the clean existence statement — if N ⊴ G is normal with |N| coprime to d and G/N has a subgroup of order d, then so does G. Obtained by forgetting the containment in the subgroup form.",
       "mathContext": "$N \\trianglelefteq G,\\ \\gcd(|N|,d)=1,\\ (\\exists Q \\le G/N,\\ |Q|=d) \\implies \\exists K \\le G,\\ |K| = d.$"
     },


### PR DESCRIPTION
Section-boundary drift left a 13-line block uncovered — the §"The Lifting Step (Existence Form)" range ended at line 154, *mid-proof* of `hall_lift_of_coprime_subgroup`, stranding the rest of that proof plus the entire `hall_lift_of_coprime` theorem (docstring 158–161, theorem 162–167).

`hall_lift_of_coprime`@162 is exactly the theorem the section summary names ("the clean existence statement"), yet it sat outside all sections.

**Fix:** extend §"The Lifting Step (Existence Form)" endLine 154 → 167 (ending just before the `-- Part II` banner at line 169). No status/badge/axiomCount change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
