### PR TITLE
audit(erdos-581): fix phantom decl names in section summaries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14783,9 +14783,9 @@
     },
     "erdos-581": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:38Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T19:43:30Z",
+      "result": "issues-fixed"
     },
     "erdos-582": {
       "agentId": "auditor-agent",

--- a/src/data/proofs/erdos-581/meta.json
+++ b/src/data/proofs/erdos-581/meta.json
@@ -89,18 +89,18 @@
     {
       "id": "f-function",
       "title": "The Function f(m)",
-      "summary": "maxBipartiteEdges axiom, f axiom",
+      "summary": "f axiom (max bipartite subgraph size described in comments)",
       "startLine": 71,
       "endLine": 95,
-      "mathContext": "Axiomatized: maxBipartiteEdges axiom, f axiom"
+      "mathContext": "Axiomatized: f axiom. Bipartite-subgraph-size is described in a comment, not a separate declaration."
     },
     {
       "id": "trivial-bounds",
       "title": "Trivial Bounds",
-      "summary": "half_edges_bipartite: any graph has m/2 bipartite edges",
+      "summary": "Trivial m/2 bipartite bound (documented in comments, not formalized)",
       "startLine": 96,
       "endLine": 112,
-      "mathContext": "Mathematical content: half_edges_bipartite: any graph has m/2 bipartite edges"
+      "mathContext": "Comment only: the trivial m/2 bipartite lower bound is described via a proof sketch; no declaration is present."
     },
     {
       "id": "alon-upper",
@@ -129,10 +129,10 @@
     {
       "id": "related",
       "title": "Related Results",
-      "summary": "general_graph_bound, Mantel's theorem, Kővári-Sós-Turán",
+      "summary": "Comparison to general graphs, Mantel's theorem, Kővári-Sós-Turán (documented in comments)",
       "startLine": 197,
       "endLine": 234,
-      "mathContext": "Verified: general_graph_bound, Mantel's theorem, Kővári-Sós-Turán"
+      "mathContext": "Comment only: connections to the general-graph m/2 bound, Mantel's theorem, and Kővári-Sós-Turán are described in comments; none are formalized declarations."
     },
     {
       "id": "main-results",


### PR DESCRIPTION
## Gallery integrity audit — erdos-581

**Result:** issues-fixed (LOW severity, section-prose only)

### Verified accurate (no change)
- `status: axiomatized`, `badge: axiom` — appropriate for this SOLVED-but-axiomatized problem
- `axiomCount: 3` matches source: `f`, `alon_upper_bound`, `alon_lower_bound`
- `theoremCount: 5`, `definitionCount: 7`, `sorries: 0` — all match `proofs/Proofs/Erdos581Problem.lean`
- `originalContributions` reference only real declarations
- Axiom set is consistent (opaque `f`; upper/lower bounds jointly satisfiable with c₁≤c₂ — not False-masking)

### Fixed
`sections[]` summaries/mathContext named declarations that exist **only as comments** (0 occurrences in the Lean file):
- `maxBipartiteEdges axiom` (f-function section)
- `half_edges_bipartite` (trivial-bounds section)
- `general_graph_bound`, and comment-only classical results Mantel / Kővári-Sós-Turán labeled **"Verified:"** (related section)

Corrected these to state the ranges are documented in comments, not formalized declarations. Top-level public claims were already honest; this only tightens section-level prose.

---
Discovered during gallery integrity audit.