### PR TITLE
Enrich 3 entries: re-anchor drifted sections to cover stranded headline decls

### DIFF
--- a/src/data/proofs/erdos-105-oq-02/meta.json
+++ b/src/data/proofs/erdos-105-oq-02/meta.json
@@ -78,14 +78,14 @@
       "id": "bounds",
       "title": "§3: Threshold Function Bounds",
       "startLine": 102,
-      "endLine": 130,
+      "endLine": 132,
       "summary": "Axiomatizes f(n) ≥ cn (Beck-SzTr) and f(n) ≤ n (Xichuan/Hickerson).",
       "mathContext": "The lower bound $f(n) \\geq cn$ follows from Beck-Szemerédi-Trotter: with $\\leq cn$ obstacles, a rich unblocked line always exists. The upper bound $f(n) \\leq n$ follows since $n-3$ obstacles can block all rich lines (Xichuan 2024)."
     },
     {
       "id": "main",
       "title": "§4: Main Theorem — f(n) = Θ(n)",
-      "startLine": 132,
+      "startLine": 134,
       "endLine": 168,
       "summary": "Proves thresholdFunction = Θ(idFn) and resolves openProblem_exact_threshold.",
       "mathContext": "$c_1 n \\leq f(n) \\leq n$ for all $n$, so $f = \\Theta(n)$ with constants $c_1$ (from Beck-SzTr) and $c_2 = 1$."
@@ -94,7 +94,7 @@
       "id": "constant",
       "title": "§5: The Optimal Constant",
       "startLine": 170,
-      "endLine": 215,
+      "endLine": 222,
       "summary": "Defines c* = sSup{c : cn ≤ f(n) ∀n} and proves c* ∈ (0, 1].",
       "mathContext": "The optimal constant $c^* = \\sup\\{c > 0 : cn \\leq f(n)\\}$ is well-defined (nonempty set, bounded above by 1). Its precise value is the main open problem."
     },


### PR DESCRIPTION
Re-anchors drifted section boundaries in 3 gallery entries. In each, a
section's own headline declaration (plus its docstring) had drifted into
the gap between sections, covered by no section at all. A "covered by ANY
section" scan flagged the stranded decls; each fix snaps the boundaries to
the banner/docstring positions the section summaries already describe.

Verified per file: valid JSON, no section overlaps/inversions, every
top-level decl now covered by exactly one section.

| Entry | Stranded decls | Fix |
|-------|----------------|-----|
| borsuk-ulam-oq001 | `buDimFormula_four`, `small_n_not_exotic_shape` | equivalences 159→157 start, concrete-examples 179→177 start (each decl's proof body was already inside the section; the decl+docstring were one line above) |
| erdos-105-oq-02 | `threshold_upper_bound` (axiom), `optimalConstant_bounds` | §3 …-130→…-132 (cover the axiom), §4 132→134 start (was starting mid-axiom-body), §5 …-215→…-222 |
| elementary-quadratic-reciprocity-oq-03-oq-02-wip-01 | `kronecker_add_mul_left`, `kronecker2_conductor_eight` | §A end 77→88 (the two (·/n) theorems the §A summary names), §B start 79→90 (its own "Section B" banner), §C end 142→150 (the conductor-8 theorem §C names) |

No status/badge/axiomCount/prose changes — pure section-anchor accuracy.
