### PR TITLE
audit(erdos-572): fix phantom decl names in origContribs and sections

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14705,9 +14705,9 @@
     },
     "erdos-572": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:38Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T19:47:40Z",
+      "result": "issues-fixed"
     },
     "erdos-573": {
       "agentId": "auditor-agent-tracker",

--- a/src/data/proofs/erdos-572/meta.json
+++ b/src/data/proofs/erdos-572/meta.json
@@ -50,7 +50,7 @@
       "erdosConjectureLowerBound definition: the conjecture",
       "erdos_572_k3, erdos_572_k5 theorems: partial solutions",
       "luwExponent, conjecturedExponent: exponent comparison",
-      "erdos_klein_c4, odd_cycle_extremal: related results"
+      "Related results (Erdős–Klein C₄ bound, odd-cycle extremal function): documented in comments, not formalized declarations"
     ],
     "axiomCount": 3,
     "lineCount": 303,
@@ -96,7 +96,7 @@
     {
       "id": "known-results",
       "title": "Known Results",
-      "summary": "bondy_simonovits_upper, benson_k3, benson_k5, lazebnik_ustimenko_woldar axioms",
+      "summary": "benson_k3, benson_k5, lazebnik_ustimenko_woldar axioms (Bondy-Simonovits upper bound documented in comments)",
       "startLine": 90,
       "endLine": 143,
       "mathContext": "c_1 n^{1+2/(3k-3+\\nu)} \\leq \\mathrm{ex}(n; C_{2k}) \\leq c_2 k n^{1+1/k},\\quad \\nu = [2 \\mid k]"
@@ -120,7 +120,7 @@
     {
       "id": "special-cases",
       "title": "Special Cases",
-      "summary": "erdos_klein_c4 for C_4, odd_cycle_extremal for odd cycles",
+      "summary": "Erdős–Klein C₄ bound and odd-cycle extremal function (documented in comments, not formalized)",
       "startLine": 233,
       "endLine": 272,
       "mathContext": "\\mathrm{ex}(n; C_4) \\sim \\tfrac{1}{2}n^{3/2};\\quad \\mathrm{ex}(n; C_{2k+1}) = \\lfloor n^2/4 \\rfloor"


### PR DESCRIPTION
Gallery integrity audit — erdos-572 (Even-cycle extremal lower bound, PARTIALLY SOLVED).

**Result: issues-fixed.**

### Fixed (phantom declarations — 0 occurrences in the Lean file)
- `originalContributions` claimed `erdos_klein_c4, odd_cycle_extremal: related results` — both are **comment-only** (Parts VI/VII are pure docstrings, no declarations)
- section "Known Results" listed `bondy_simonovits_upper` as an axiom — **comment-only** (the only axioms are `benson_k3`, `benson_k5`, `lazebnik_ustimenko_woldar`)
- section "Special Cases" named the same two phantom decls

### Verified accurate (no change)
- axiomCount 3, theoremCount 8, definitionCount 7, 0 sorries — all match source
- Axioms are lower-bound existence claims (consistent); `erdos_572_k3`/`erdos_572_k5` proven from Benson (4/3=1+1/3, 6/5=1+1/5); conjecture is a Prop def with general case open
- status `axiomatized`/`partially-solved`, badge `axiom`, tags include `partially-solved` — honest

---
Discovered during gallery integrity audit.