### PR TITLE
audit(tracker): record erdos-568 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14654,8 +14654,8 @@
     },
     "erdos-568": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:38Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T19:53:57Z",
       "result": "clean"
     },
     "erdos-569": {


### PR DESCRIPTION
erdos-568 re-served, result clean. Counts (3 axioms/0 thm/0 sorry/8 defs), badge axiom, all 8 section summaries, and origContribs all accurate; open EFRS conjecture honestly axiomatized.