### PR TITLE
Enrich basel-problem-oq-14: re-anchor sections, cover stranded theorems + fix overlap

### DIFF
--- a/src/data/proofs/basel-problem-oq-14/meta.json
+++ b/src/data/proofs/basel-problem-oq-14/meta.json
@@ -104,33 +104,33 @@
     {
       "id": "even-part",
       "title": "hasSum_even_zeta_four — ∑ 1/(2k)⁴ = π⁴/1440",
-      "startLine": 39,
-      "endLine": 51,
+      "startLine": 38,
+      "endLine": 48,
       "summary": "Rewrites 1/(2k)⁴ = (1/16)(1/k⁴) and scales ζ(4) by 1/16.",
       "mathContext": "The even-indexed fourth-power terms form a sixteenth-scaled copy of ζ(4)."
     },
     {
       "id": "odd-part",
       "title": "hasSum_odd_zeta_four — ∑ 1/(2k+1)⁴ = π⁴/96",
-      "startLine": 53,
-      "endLine": 67,
+      "startLine": 49,
+      "endLine": 66,
       "summary": "Odd subseries summable via comp_injective; reassemble ζ(4) = even + odd and use HasSum.unique to pin the odd sum to π⁴/96.",
       "mathContext": "The odd-fourth-power sum, recovered as ζ(4) minus its even part."
     },
     {
       "id": "eta",
       "title": "hasSum_eta_four / tsum_eta_four — η(4) = 7π⁴/720",
-      "startLine": 69,
-      "endLine": 113,
-      "summary": "Even-indexed alternating terms sum to -π⁴/1440, odd-indexed to π⁴/96; HasSum.even_add_odd combines to 7π⁴/720, with a tsum corollary. Closes with a summary table of the four results (even ζ(4), odd ζ(4), and the η(4) HasSum and tsum forms) and the 0-sorry / 0-axiom status.",
+      "startLine": 67,
+      "endLine": 95,
+      "summary": "Even-indexed alternating terms sum to -π⁴/1440, odd-indexed to π⁴/96; HasSum.even_add_odd combines them to η(4) = 7π⁴/720 (hasSum_eta_four), with a tsum corollary tsum_eta_four; the namespace BaselEtaFour closes at the end of the section.",
       "mathContext": "The Dirichlet eta value η(4) = (1 - 1/8)ζ(4) = 7π⁴/720."
     },
     {
       "id": "summary",
-      "title": "Namespace Close and Result Summary",
+      "title": "Result Summary Table",
       "startLine": 96,
-      "endLine": 113,
-      "summary": "Closes namespace BaselEtaFour and tabulates the four exported results — hasSum_even_zeta_four (π⁴/1440), hasSum_odd_zeta_four (π⁴/96), hasSum_eta_four and tsum_eta_four (7π⁴/720) — recording that all reduce to Mathlib's hasSum_zeta_four with 0 sorries and 0 axioms.",
+      "endLine": 112,
+      "summary": "A closing comment block tabulating the four exported results — hasSum_even_zeta_four (π⁴/1440), hasSum_odd_zeta_four (π⁴/96), hasSum_eta_four and tsum_eta_four (7π⁴/720) — recording that all reduce to Mathlib's hasSum_zeta_four with 0 sorries and 0 axioms.",
       "mathContext": "The four building blocks — even π⁴/1440, odd π⁴/96, and the eta value 7π⁴/720 in HasSum and tsum form — all descend from ζ(4) = π⁴/90."
     }
   ],


### PR DESCRIPTION
## Enrichment pass for basel-problem-oq-14

The gallery `sections` were anchored to theorem *statement* lines rather than the
`theorem` keyword and preceding docstring, so two headline theorems fell outside
any section, and the `eta` section overlapped the `summary` block.

### Stranded / structural defects
- `hasSum_odd_zeta_four` (L52) — stranded in the `even-part` [39-51] →
  `odd-part` [53-67] gap.
- `hasSum_eta_four` (L68) — stranded in the `odd-part` → `eta` [69-113] gap.
- `eta` [69-113] fully **contained** `summary` [96-113] (overlap) and ran to
  L113, one past the file's 112 content lines.

### Fix (contiguous, docstring-aligned partition)
| section | before | after |
|---|---|---|
| even-part | 39-51 | 38-48 |
| odd-part | 53-67 | 49-66 |
| eta | 69-113 | 67-95 (now ends at the namespace close) |
| summary | 96-113 | 96-112 |

Every theorem is now covered by exactly one section; no gaps, overlaps, or
past-EOF ranges. The `eta`/`summary` prose was adjusted so the result-table
description lives only in the `summary` section. No `status`/`badge`/`axiomCount`
changes — the entry remains `verified`, 0 axioms.
