### PR TITLE
audit(erdos-560): remove phantom origContribs/section decls

### DIFF
--- a/src/data/proofs/erdos-560/meta.json
+++ b/src/data/proofs/erdos-560/meta.json
@@ -54,11 +54,9 @@
       "erdos_rousseau_lower_bound axiom: (1/60)n^2*2^n",
       "upper_bound axiom: (3/2)n^3*2^n",
       "size_ramsey_bounds combined theorem",
-      "cfw_general_lower: CFW 2023 general result",
-      "cfw_asymptotic: asymptotic bounds",
-      "cfw_conjecture: conjectured n^3*2^n",
-      "size_ramsey_monotone and size_ramsey_lower properties",
-      "classicalRamseyNumber and relationship",
+      "CFW 2023 results (general lower bound, asymptotics, conjecture) documented as comments, not formalized",
+      "size_ramsey_monotone_bipartite axiom",
+      "classicalRamseyNumber definition",
       "bounds_gap analysis showing O(n) factor",
       "erdos_560_summary main results"
     ],
@@ -114,10 +112,10 @@
     {
       "id": "cfw-results",
       "title": "Conlon-Fox-Wigderson Results",
-      "summary": "cfw_general_lower, cfw_asymptotic, cfw_conjecture",
+      "summary": "CFW 2023 general lower bound, asymptotics, and conjecture (documented as comments, not formalized)",
       "startLine": 150,
       "endLine": 183,
-      "mathContext": "Mathematical content: cfw_general_lower, cfw_asymptotic, cfw_conjecture"
+      "mathContext": "Mathematical content: CFW 2023 results stated in comments; no declarations"
     },
     {
       "id": "basic-properties",
@@ -138,10 +136,10 @@
     {
       "id": "bounds-gap",
       "title": "Gap Analysis",
-      "summary": "bounds_gap theorem, cfw_implies_tight_lower",
+      "summary": "bounds_gap theorem (cfw_implies_tight_lower discussed in comments only)",
       "startLine": 239,
       "endLine": 265,
-      "mathContext": "Verified: bounds_gap theorem, cfw_implies_tight_lower"
+      "mathContext": "Verified: bounds_gap theorem; CFW tightness implication in comments only"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Gallery integrity fix

**Proof**: erdos-560 (Size Ramsey Number of Complete Bipartite Graphs)
**Problem**: `originalContributions` and two `sections[]` summaries named declarations that exist only as comment prose in `Proofs/Erdos560Problem.lean`, not as actual Lean declarations.

### Phantom decls (comment-only, not formalized)
- `cfw_general_lower`, `cfw_asymptotic`, `cfw_conjecture` — CFW 2023 results, lines 156–171 are all `/- ... -/` comments
- `size_ramsey_lower` — comment-only
- `cfw_implies_tight_lower` — comment-only (lines 235–238)
- `size_ramsey_monotone` — misnamed; actual decl is `size_ramsey_monotone_bipartite`

### Honest, unchanged
Counts verified against the file and are all correct:
- 5 axioms (embedding_preserves_edges, erdos_rousseau_lower_bound, upper_bound, thetaNotation, size_ramsey_monotone_bipartite)
- 3 theorems, 6 definitions, 0 sorries, 0 native_decide
- badge `axiom`, status `axiomatized` — appropriate for this open problem

This PR only rewords the contributions/section summaries to match what is actually declared.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)