### PR TITLE
Research: erdos-64-wip-01 — cycle existence for any finite min-degree-2 graph (connectivity dropped, axiom-free)

### DIFF
--- a/proofs/Proofs/Erdos64Problem.lean
+++ b/proofs/Proofs/Erdos64Problem.lean
@@ -213,13 +213,61 @@ theorem connected_hasMinDegree_three_exists_cycle
   connected_hasMinDegree_two_exists_cycle G hconn
     (fun v => le_trans (by norm_num) (hdeg v))
 
-/- **Remaining step toward the finite-graph statement.** The above covers connected
-graphs. For an arbitrary finite graph with minimum degree ≥ 2, pass to the connected
-component of any vertex: degrees are preserved inside a component (every neighbour of
-a vertex lies in its own component), the component is connected and nontrivial (the
-vertex has ≥ 2 neighbours), so the connected case yields a cycle there, which lifts to
-`G` along the induced-subgraph embedding. Formalizing this needs the component-degree
-preservation lemma and `Walk.IsCycle` transport through `SimpleGraph.induce`. -/
+/-- **The finite-graph statement (connectivity dropped).** An arbitrary — not necessarily
+connected — nonempty finite graph with minimum degree at least `2` contains a cycle.
+
+The proof passes to the connected component `C` of an arbitrary vertex `v` and works inside
+the induced graph `C.toSimpleGraph = G.induce C.supp`:
+
+* every neighbour of a vertex lies in that vertex's own component
+  (`ConnectedComponent.mem_supp_of_adj_mem_supp`), so `G.neighborSet` is contained in
+  `C.supp` and **degrees are preserved** inside the component
+  (`SimpleGraph.degree_induce_of_neighborSet_subset`);
+* if `G` were acyclic then `C.toSimpleGraph` would be a tree
+  (`SimpleGraph.IsAcyclic.isTree_connectedComponent`), and — being nontrivial, since `v`
+  has a neighbour — it would have a vertex `w` of degree exactly `1`
+  (`SimpleGraph.IsTree.exists_vert_degree_one_of_nontrivial`);
+* degree preservation then forces `G.degree w = 1`, contradicting the hypothesis
+  `2 ≤ G.degree w`.
+
+This is still a strict weakening of Problem 64 (a cycle exists; its length need not be a
+power of two), but it removes the connectivity assumption from the earlier lemmas. -/
+theorem hasMinDegree_two_exists_cycle
+    {W : Type*} [Fintype W] [DecidableEq W] [Nonempty W]
+    (G : SimpleGraph W) [DecidableRel G.Adj]
+    (hdeg : HasMinDegree G 2) :
+    ∃ (v : W) (c : G.Walk v v), c.IsCycle := by
+  by_contra hcon
+  have hacyc : G.IsAcyclic := fun v c hc => hcon ⟨v, c, hc⟩
+  obtain ⟨v⟩ : Nonempty W := inferInstance
+  -- Work inside the connected component of `v`.
+  set C := G.connectedComponentMk v with hC
+  have hvC : v ∈ C.supp := (ConnectedComponent.mem_supp_iff C v).mpr hC.symm
+  -- `v` has a neighbour `u`; it lies in the same component, so the component is nontrivial.
+  have hdv : 0 < (G.neighborFinset v).card := lt_of_lt_of_le (by norm_num) (hdeg v)
+  obtain ⟨u, hu⟩ := Finset.card_pos.mp hdv
+  have hadj : G.Adj v u := (G.mem_neighborFinset v u).mp hu
+  have huC : u ∈ C.supp := C.mem_supp_of_adj_mem_supp hvC hadj
+  -- Work with the induced graph `G.induce C.supp` directly (all instances canonical, so the
+  -- Mathlib degree lemma below matches on the nose); `C.toSimpleGraph` is a `def` opaque to
+  -- instance search, so we avoid it.
+  haveI : DecidablePred (· ∈ C.supp) := fun x => inferInstance
+  haveI : Nontrivial (C.supp : Set W) :=
+    ⟨⟨v, hvC⟩, ⟨u, huC⟩, fun h => hadj.ne (congrArg Subtype.val h)⟩
+  -- Under `hacyc` the induced component graph is a nontrivial tree, hence has a degree-one vertex.
+  have hconn : (G.induce C.supp).Connected := C.connected_toSimpleGraph
+  have htree : (G.induce C.supp).IsTree := ⟨hconn, hacyc.induce C.supp⟩
+  obtain ⟨w, hw⟩ := htree.exists_vert_degree_one_of_nontrivial
+  -- Degrees are preserved inside the component.
+  have hsub : G.neighborSet w.val ⊆ C.supp := fun x hx =>
+    C.mem_supp_of_adj_mem_supp w.property ((G.mem_neighborSet w.val x).mp hx)
+  have hpres : (G.induce C.supp).degree w = G.degree w.val :=
+    degree_induce_of_neighborSet_subset hsub
+  -- But `w` has `G`-degree at least `2`: contradiction.
+  have hge : 2 ≤ G.degree w.val := by
+    rw [← SimpleGraph.card_neighborFinset_eq_degree]; exact hdeg w.val
+  rw [hpres] at hw
+  omega
 
 /- ## Known Cycle Results -/
 

--- a/research/problems/erdos-64-wip-01/state.md
+++ b/research/problems/erdos-64-wip-01/state.md
@@ -1,25 +1,42 @@
 # Research State: erdos-64-wip-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-07-09T17:33:20-07:00
-**Iteration**: 1
+**Since**: 2026-07-21
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Base cycle-existence infrastructure is now complete for **all** finite graphs
+(connectivity dropped). The remaining open content of Erdős #64 is the
+power-of-two cycle *length* under min-degree ≥ 3.
 
 ## Active Approach
-None yet.
+Induced-subgraph / connected-component reduction (mechanism label:
+"component degree-preservation"): pass to the connected component of a vertex,
+use that neighbours stay inside their own component so degrees are preserved on
+`G.induce C.supp`, and derive a contradiction from the tree leaf.
 
-## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+## Machine-checked results (axiom-free, v4.31.0)
+- `connected_hasMinDegree_two_not_isAcyclic` — connected + min-deg ≥ 2 ⇒ not acyclic.
+- `connected_hasMinDegree_two_exists_cycle` — connected + min-deg ≥ 2 ⇒ has a cycle.
+- `connected_hasMinDegree_three_exists_cycle` — connected + min-deg ≥ 3 ⇒ has a cycle.
+- **NEW** `hasMinDegree_two_exists_cycle` — **any** nonempty finite graph with
+  min-deg ≥ 2 ⇒ has a cycle (connectivity removed). Completes the reduction the
+  earlier connected lemmas explicitly left open.
+
+## Key Mathlib lemmas used
+- `SimpleGraph.IsAcyclic.induce` (acyclicity passes to induced subgraphs)
+- `SimpleGraph.degree_induce_of_neighborSet_subset` (degree preservation)
+- `ConnectedComponent.mem_supp_of_adj_mem_supp` (neighbours stay in component)
+- `ConnectedComponent.connected_toSimpleGraph` (component graph is connected)
+- `SimpleGraph.IsTree.exists_vert_degree_one_of_nontrivial` (tree has a leaf)
 
 ## Blockers
-None.
+The power-of-two-length refinement (the actual $1000 open problem) is untouched
+and requires materially new mechanism (Liu–Montgomery style) — out of reach of
+elementary component/tree arguments.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+The elementary cycle-existence layer is saturated. Only the deep power-of-2
+length question remains open.

--- a/src/data/research/problems/erdos-64-wip-01.json
+++ b/src/data/research/problems/erdos-64-wip-01.json
@@ -18,12 +18,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-07-09T17:33:20-07:00",
-    "iteration": 1,
+    "iteration": 2,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Open power-of-2 cycle length remains the mission; base cycle-existence infrastructure is complete for all finite graphs.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,15 +31,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (infrastructure): proved the elementary base fact — connected min-degree->=2 graphs contain a cycle (3 axiom-free lemmas). The open power-of-two-length refinement is untouched.",
+    "progressSummary": "PROGRESS (infrastructure): the elementary base fact — every nonempty finite graph (NO connectivity assumption) with min-degree >=2 contains a cycle — is now fully machine-checked and axiom-free (hasMinDegree_two_exists_cycle), completing the reduction that the connected-case lemmas left open. The open power-of-two-length refinement (the actual Erdos #64 content) is untouched.",
     "builtItems": [
       "connected_hasMinDegree_two_not_isAcyclic (Erdos64Problem.lean): nontrivial connected graph, HasMinDegree 2 => ¬IsAcyclic. Axiom-free.",
       "connected_hasMinDegree_two_exists_cycle (Erdos64Problem.lean): same hyp => ∃ v (c : Walk v v), c.IsCycle. Axiom-free.",
-      "connected_hasMinDegree_three_exists_cycle (Erdos64Problem.lean): the Problem-64 degree-3 hypothesis (connected) forces a cycle. Axiom-free."
+      "connected_hasMinDegree_three_exists_cycle (Erdos64Problem.lean): the Problem-64 degree-3 hypothesis (connected) forces a cycle. Axiom-free.",
+      "hasMinDegree_two_exists_cycle in Erdos64Problem.lean: disconnected (general finite) min-degree>=2 => contains a cycle, 0 axioms (propext/Classical.choice/Quot.sound only), host-verified v4.31.0"
     ],
     "insights": [
       "A finite nontrivial TREE has a leaf (degree-1 vertex): Mathlib SimpleGraph.IsTree.minDegree_eq_one_of_nontrivial. Hence a connected graph with min degree >= 2 cannot be a tree, so cannot be acyclic — the elementary base fact under Erdos #64.",
-      "SimpleGraph.IsAcyclic unfolds to (forall closed walk, not IsCycle); its negation directly yields an explicit Walk.IsCycle, so ¬IsAcyclic is packaged as a concrete cycle."
+      "SimpleGraph.IsAcyclic unfolds to (forall closed walk, not IsCycle); its negation directly yields an explicit Walk.IsCycle, so ¬IsAcyclic is packaged as a concrete cycle.",
+      "Connectivity can be dropped from the base cycle-existence fact: an arbitrary nonempty finite graph with min-degree >=2 contains a cycle. Proof passes to the connected component of any vertex and uses that neighbours stay inside their own component (ConnectedComponent.mem_supp_of_adj_mem_supp), so degrees are preserved on the induced subgraph (SimpleGraph.degree_induce_of_neighborSet_subset); if acyclic the component would be a nontrivial tree with a degree-1 vertex, contradicting min-degree >=2."
     ],
     "mathlibGaps": [
       "No general (disconnected/forest) leaf lemma: Mathlib only has IsTree.minDegree_eq_one_of_nontrivial (connected). A forest edge-count bound #edges <= n-1 is also absent (only IsTree.card_edgeFinset).",


### PR DESCRIPTION
## Summary

Adds `hasMinDegree_two_exists_cycle` to `Erdos64Problem.lean`: **every nonempty finite graph** (no connectivity assumption) with minimum degree ≥ 2 contains a cycle. This closes the reduction the earlier connected-case lemmas left as an explicit "remaining step" comment — Problem 64's necessary elementary precondition (a cycle exists at all) now holds for arbitrary finite graphs, not just connected ones.

## Mechanism (component degree-preservation)

Pass to the connected component `C` of an arbitrary vertex and work inside `G.induce C.supp`:
- Neighbours stay in their own component (`ConnectedComponent.mem_supp_of_adj_mem_supp`), so `G.neighborSet w ⊆ C.supp` and **degrees are preserved** there (`SimpleGraph.degree_induce_of_neighborSet_subset`).
- If `G` were acyclic, the component graph would be a nontrivial tree (`IsAcyclic.induce` + `connected_toSimpleGraph`), hence have a degree-1 vertex (`IsTree.exists_vert_degree_one_of_nontrivial`) — contradicting minimum degree ≥ 2.

## Files
- `proofs/Proofs/Erdos64Problem.lean` (+ new theorem, replaces the prose "remaining step" note)
- `src/data/research/problems/erdos-64-wip-01.json` (knowledge)
- `research/problems/erdos-64-wip-01/state.md`

## Status
**Outcome**: progress (infrastructure) — 0 sorries, 0 axioms (propext/Classical.choice/Quot.sound only), host-verified at toolchain v4.31.0.

**Next steps**: The open power-of-two cycle-*length* refinement (the actual $1000 problem) is untouched and requires materially new mechanism (Liu–Montgomery style), out of reach of elementary component/tree arguments.

🤖 Generated by researcher-1
