### PR TITLE
Enrich erdos-1147: add missing Part VIII section covering stranded diophantine_set_infinite axiom

### DIFF
--- a/src/data/proofs/erdos-1147/meta.json
+++ b/src/data/proofs/erdos-1147/meta.json
@@ -140,9 +140,17 @@
       "id": "conjecture",
       "title": "Conjecture and Disproof",
       "startLine": 174,
-      "endLine": 188,
+      "endLine": 191,
       "summary": "Erdos1147Conjecture definition and erdos_1147_false theorem.",
       "mathContext": "Formal definition: Erdos1147Conjecture definition and erdos_1147_false theorem."
+    },
+    {
+      "id": "connection-density",
+      "title": "Connection Between Diophantine Approximation and Density",
+      "startLine": 192,
+      "endLine": 206,
+      "summary": "The diophantine_set_infinite axiom records that for any irrational α > 0 the Diophantine set {n : ‖αn²‖ < 1/log n} is infinite — a consequence of Dirichlet's approximation theorem. Yet, as the disproof shows, this set is too sparse and too irregularly distributed to serve as an additive basis of order 2 for almost every α, so infinitude alone does not yield the basis property.",
+      "mathContext": "Axiomatized: infinitude of the Diophantine set follows from Dirichlet ($\\exists^\\infty n,\\ \\|\\alpha n^2\\| < 1/n$), but sparsity obstructs the order-2 basis property that Erdős #1147 conjectured."
     },
     {
       "id": "summary",


### PR DESCRIPTION
## Enrichment: erdos-1147 (Erdős Problem #1147)

**Gap fixed:** section coverage. The Lean file `Erdos1147Problem.lean` has a labeled `Part VIII: Connection Between Diophantine Approximation and Density` (banner at L193) whose only declaration — `axiom diophantine_set_infinite` (L201) — was **stranded outside every `sections[]` range**: the sections jumped from `Conjecture and Disproof` (174–188) straight to `Summary` (210–234), leaving 189–209 uncovered.

**Changes (sections only, no prose accretion):**
- Extended the `conjecture` section endLine 188 → 191 to include the full `erdos_1147_false` proof body.
- Added a new `connection-density` section (192–206) covering Part VIII, summarizing the `diophantine_set_infinite` axiom (infinitude via Dirichlet's approximation theorem) and why infinitude alone does not yield the order-2 basis property.

**Integrity:** `axiomCount: 4` already counts this axiom (`konieczny_disproof`, `konieczny_generalized`, `sqrt2_not_basis`, `diophantine_set_infinite`); `status: axiomatized`, `badge: axiom` unchanged. No axiom claims altered.
