### PR TITLE
Enrich erdos-303: re-anchor full-file section drift to banners, cover stranded erdos303_true axiom

### DIFF
--- a/src/data/proofs/erdos-303/meta.json
+++ b/src/data/proofs/erdos-303/meta.json
@@ -82,48 +82,48 @@
       "id": "header",
       "title": "Problem Statement",
       "startLine": 1,
-      "endLine": 24,
+      "endLine": 54,
       "summary": "Introduction to the monochromatic unit fraction problem"
     },
     {
       "id": "equation",
       "title": "The Unit Fraction Equation",
-      "startLine": 32,
-      "endLine": 54,
+      "startLine": 55,
+      "endLine": 81,
       "summary": "Definition of 1/a = 1/b + 1/c and equivalence with bc = a(b+c)"
     },
     {
       "id": "examples",
       "title": "Examples of Solutions",
-      "startLine": 55,
-      "endLine": 83,
+      "startLine": 82,
+      "endLine": 110,
       "summary": "Verified concrete solutions: (2,3,6), (3,4,12), (4,5,20), (6,7,42)"
     },
     {
       "id": "colouring",
       "title": "Finite Colourings",
-      "startLine": 84,
-      "endLine": 107,
+      "startLine": 111,
+      "endLine": 135,
       "summary": "Definitions of finite colouring and monochromaticity"
     },
     {
       "id": "theorem",
       "title": "Brown-Rödl Theorem (SOLVED)",
-      "startLine": 108,
-      "endLine": 139,
-      "summary": "The main result as an axiom"
+      "startLine": 136,
+      "endLine": 173,
+      "summary": "The main result stated as axioms: brownRodl_theorem, erdos303Statement, and erdos303_true"
     },
     {
       "id": "sketch",
       "title": "Proof Sketch",
-      "startLine": 140,
-      "endLine": 164,
+      "startLine": 174,
+      "endLine": 225,
       "summary": "Why the theorem is true: infinite solutions and Ramsey arguments"
     },
     {
       "id": "density",
       "title": "Connection to Density Version",
-      "startLine": 190,
+      "startLine": 226,
       "endLine": 258,
       "summary": "Relation to Erdős #302 and the general pattern"
     }


### PR DESCRIPTION
## Enrichment: erdos-303 (Erdős Problem #303, Monochromatic Unit Fraction Solutions)

**Gap fixed:** full-file section drift. Every `sections[]` range in `meta.json` sat ~20 lines *above* the `## …` markdown banner block it describes. The tell: the `theorem` section (summary "The main result as an axiom") was ranged 108–139, but the Brown–Rödl material — `brownRodl_theorem` (L156), `erdos303Statement` (L161), and the key `axiom erdos303_true` (L172) — physically lives at 136–173, inside what the meta labelled the "Proof Sketch" range. As a result `erdos303_true` (the "the statement is true" axiom) was stranded outside every section.

**Fix (section re-anchor only, summaries preserved):** snapped all 7 sections to their `##` banner blocks so the file is covered 1–258 with no gaps:

| section | before | after |
|---|---|---|
| Problem Statement | 1–24 | 1–54 |
| The Unit Fraction Equation | 32–54 | 55–81 |
| Examples of Solutions | 55–83 | 82–110 |
| Finite Colourings | 84–107 | 111–135 |
| Brown-Rödl Theorem (SOLVED) | 108–139 | 136–173 |
| Proof Sketch | 140–164 | 174–225 |
| Connection to Density Version | 190–258 | 226–258 |

Also expanded the Brown-Rödl summary to name the three axiom/def declarations it now correctly spans.

**Integrity:** unchanged — `status: axiomatized`, `badge: axiom`, `axiomCount: 2` (`brownRodl_theorem`, `erdos303_true`) still accurate.
