### PR TITLE
Gallery integrity: erdos-56 undisclosed native_decide (ofReduceBool)

### DIFF
--- a/src/data/proofs/erdos-56/meta.json
+++ b/src/data/proofs/erdos-56/meta.json
@@ -59,7 +59,7 @@
       "Extremal combinatorics",
       "Number-theoretic density"
     ],
-    "assumptions": "1 axiom: erdos_56_disproved. See Lean source for the complete statement.",
+    "assumptions": "1 axiom: erdos_56_disproved. Additionally, two demonstration theorems (two_four_not_coprime, gcd_two_four) use native_decide, which adds the Lean.ofReduceBool compiler-trust axiom; these verified examples do not feed the main result. See Lean source for the complete statement.",
     "theoremCount": 7,
     "definitionCount": 3
   },


### PR DESCRIPTION
## Integrity Issue (LOW)

**Proof**: erdos-56 (Erdős Problem #56: Weakly Divisible Sets)
**Problem**: Two named theorems use `native_decide` — introducing the `Lean.ofReduceBool` compiler-trust axiom — but the meta disclosed only the single mathematical axiom.

## Evidence

**meta.json claimed**: `axiomCount: 1`, `assumptions: "1 axiom: erdos_56_disproved. See Lean source..."` — no mention of native_decide.

**Lean file shows** (`proofs/Proofs/Erdos56Problem.lean`):
```
129: theorem two_four_not_coprime : ¬Nat.Coprime 2 4 := by native_decide
132: theorem gcd_two_four : Nat.gcd 2 4 = 2 := by native_decide
```
`native_decide` shifts trust from the kernel to compiled code (`Lean.ofReduceBool`).

## Fix applied

Added a prose disclosure to `assumptions` naming both theorems and the `ofReduceBool` dependency, noting these verified examples do not feed the main result. `axiomCount` left at 1 (mathematical axioms), consistent with repo convention of disclosing native_decide in prose.

## Everything else verified clean

- Counts honest: 1 axiom, 7 theorems, 3 defs, 0 sorries, 134 lines.
- `erdos_56_disproved` axiomatizes the **negation** of Erdős's conjecture — a true, consistent statement (Ahlswede–Khachatrian counterexample at k=212), not false/inconsistent masking. Indexing (`nth Nat.Prime`, N≥p_k) faithful.
- Badge `axiom` / status `axiomatized` / `erdosProblemStatus: disproved` all correct (Tier C).
- All `originalContributions` map to real declarations.

Follow-up (optional, for lean-mechanic): both examples could use kernel `decide` instead of `native_decide` on these tiny literals, removing `ofReduceBool` entirely.

---
Discovered during gallery integrity audit.