### PR TITLE
Enrich divisibility-rules-oq-01-oq-01-oq-01: re-anchor sections to PART banners

### DIFF
--- a/src/data/proofs/divisibility-rules-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-01-oq-01-oq-01/meta.json
@@ -89,47 +89,47 @@
       "id": "zmod-bridge",
       "title": "ZMod Bridge: b^k % d = 1 ↔ (b:ZMod d)^k = 1",
       "startLine": 34,
-      "endLine": 49,
+      "endLine": 48,
       "summary": "pow_mod_one_iff_ZMod_pow_eq_one: proved by ZMod.natCast_eq_natCast_iff and push_cast. Forward: unfold ModEq and apply. Backward: push_cast to convert, then rewrite.",
       "mathContext": "The key bridge between ℕ modular arithmetic and ZMod ring theory."
     },
     {
       "id": "period-characterization",
       "title": "Period Characterization via orderOf",
-      "startLine": 51,
-      "endLine": 55,
+      "startLine": 49,
+      "endLine": 53,
       "summary": "period_iff_orderOf_dvd: 10^k % d = 1 ↔ orderOf(10:ZMod d) ∣ k. One-line proof via Iff.trans.",
       "mathContext": "Combines the ZMod bridge with orderOf_dvd_iff_pow_eq_one."
     },
     {
       "id": "euler-order",
       "title": "Euler's Theorem and orderOf Positivity",
-      "startLine": 61,
-      "endLine": 79,
+      "startLine": 54,
+      "endLine": 77,
       "summary": "pow_totient_eq_one: (b:ZMod d)^φ(d) = 1 via ZMod.unitOfCoprime and ZMod.pow_totient. orderOf_pos_of_coprime: 0 < orderOf via Nat.pos_of_dvd_of_pos.",
       "mathContext": "Euler's theorem gives the existence of a period; Nat.pos_of_dvd_of_pos derives positivity without IsOfFinOrder."
     },
     {
       "id": "minimal-period",
       "title": "Minimality of orderOf",
-      "startLine": 97,
-      "endLine": 115,
+      "startLine": 94,
+      "endLine": 113,
       "summary": "orderOf_is_minimal_period: three-part bundle (positive, achieves period, minimal). orderOf_le_of_period: any k with 10^k ≡ 1 has orderOf ≤ k.",
       "mathContext": "Minimality follows from orderOf_dvd_of_pow_eq_one and Nat.le_of_dvd."
     },
     {
       "id": "digit-rule-application",
       "title": "Applying the Period to the Digit-Block Rule",
-      "startLine": 82,
-      "endLine": 92,
+      "startLine": 78,
+      "endLine": 93,
       "summary": "digit_block_rule_of_orderOf_dvd: when orderOf ∣ k, the rule d ∣ n ↔ d ∣ block-sum holds via Nat.modEq_digits_sum. digit_block_rule_at_orderOf specializes to the minimal period k₀ = orderOf.",
       "mathContext": "Nat.modEq_digits_sum gives n ≡ digit-block-sum (mod d) when the base 10^k ≡ 1 (mod d). The period condition converts to the mod condition via period_iff_orderOf_dvd."
     },
     {
       "id": "base-b-generalization",
       "title": "Generalization to Base b",
-      "startLine": 118,
-      "endLine": 140,
+      "startLine": 114,
+      "endLine": 141,
       "summary": "period_iff_orderOf_dvd_base_b and orderOf_base_b_is_minimal_period: same results for arbitrary base b with gcd(d,b)=1.",
       "mathContext": "The 10-specific results are immediate specializations of the base-b versions. For base 8 and d=7: 8 ≡ 1 (mod 7), so the minimal period is 1 (digit-sum rule in base 8)."
     },


### PR DESCRIPTION
## Section re-anchor (stranded-decl coverage fix)

The `/tmp/scan_uncov.mjs` "covered by ANY section" scan flagged two headline
theorems with **no covering section**:

- `period_iff_orderOf_dvd` (line 50) — the decl the **period-characterization** section is titled for
- `pow_totient_eq_one` (line 59) — the lead decl of the **euler-order** section

Every section had drifted: it started one line *inside* its headline decl's
body (leaving the docstring + `theorem` keyword uncovered) and its `endLine`
grabbed the *following* `-- PART` banner. Re-anchored all seven sections to the
`-- PART N` dividers so each is contiguous and every top-level decl is covered
by its correctly-titled section.

| Section | Before | After |
|---------|--------|-------|
| zmod-bridge | 34–49 | 34–48 |
| period-characterization | 51–55 | 49–53 |
| euler-order | 61–79 | 54–77 |
| minimal-period | 97–115 | 94–113 |
| digit-rule-application | 82–92 | 78–93 |
| base-b-generalization | 118–140 | 114–141 |
| concrete-examples | 142–167 | (unchanged) |

Verified: 0 stranded top-level decls, no section overlaps. No `status` / `badge`
/ `axiomCount` / summary changes — line-anchor fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
