### PR TITLE
Research: erdos-326-wip-01 — b_k = O(k²) growth upper bound for order-2 bases (axiom-free)

### DIFF
--- a/proofs/Proofs/Erdos326WIP01.lean
+++ b/proofs/Proofs/Erdos326WIP01.lean
@@ -339,6 +339,65 @@ theorem IsAddBasisOfOrder.two_quadratic_density' {A : Set ℕ}
   rw [Nat.card_Icc] at hcard
   exact ⟨S, hS, hSn, hcard⟩
 
+/-! ## The `bₖ = O(k²)` growth upper bound for order-2 bases
+
+The `√n` density bound above turns into an *upper* bound on the enumeration
+`bₖ = Nat.nth (· ∈ A) k` (the `k`-th smallest element of `A`, in increasing
+order): a threshold `N` such that `bₖ ≤ N + (k+1)²` for every `k`, hence
+`bₖ ≤ (N+4)·k²` for `k ≥ 1`.  This is the standard `bₖ = O(k²)` estimate that
+Key Observation 1 exists to prove.
+
+Mechanism: with `n := N + (k+1)²` the density bound `n+1−N ≤ (|S|+1)²` reads
+`(k+1)²+1 ≤ (|S|+1)²`, forcing `k < |S|`; since `S ⊆ A` and every element of `S`
+is `≤ n`, we get `k < |S| ≤ Nat.count (· ∈ A) (n+1)`, so
+`Nat.nth (· ∈ A) k < n+1` by `Nat.nth_lt_of_lt_count`.  Axiom-free; no deep
+input — the open oscillation dichotomy of #326 is untouched. -/
+
+/-- **The `bₖ = O(k²)` upper bound.**  Enumerating an order-2 additive basis `A`
+in increasing order via `Nat.nth (· ∈ A)`, the `k`-th element is at most
+`N + (k+1)²` for the density threshold `N`. -/
+theorem IsAddBasisOfOrder.two_nth_le_quadratic {A : Set ℕ}
+    (h : IsAddBasisOfOrder A 2) :
+    ∃ N : ℕ, ∀ k : ℕ, Nat.nth (· ∈ A) k ≤ N + (k + 1) ^ 2 := by
+  classical
+  obtain ⟨N, hN⟩ := h.two_quadratic_density'
+  refine ⟨N, fun k => ?_⟩
+  set n : ℕ := N + (k + 1) ^ 2 with hn
+  obtain ⟨S, hS, hSn, hcard⟩ := hN n (by omega)
+  -- `(k+1)²+1 ≤ (|S|+1)²` forces `k < |S|`.
+  have hcard' : (k + 1) ^ 2 + 1 ≤ (S.card + 1) ^ 2 := by
+    have he : n + 1 - N = (k + 1) ^ 2 + 1 := by omega
+    rwa [he] at hcard
+  have hkS : k < S.card := by
+    by_contra hc
+    rw [not_lt] at hc
+    have : (S.card + 1) ^ 2 ≤ (k + 1) ^ 2 := Nat.pow_le_pow_left (by omega) 2
+    omega
+  -- `S ⊆ {i < n+1 : i ∈ A}`, so `|S| ≤ count (· ∈ A) (n+1)`.
+  have hsub : S ⊆ (Finset.range (n + 1)).filter (· ∈ A) := by
+    intro s hs
+    rw [Finset.mem_filter, Finset.mem_range]
+    exact ⟨by have := hSn s hs; omega, hS (Finset.mem_coe.mpr hs)⟩
+  have hcount : k < Nat.count (· ∈ A) (n + 1) := by
+    rw [Nat.count_eq_card_filter_range]
+    exact lt_of_lt_of_le hkS (Finset.card_le_card hsub)
+  have hlt := Nat.nth_lt_of_lt_count hcount
+  omega
+
+/-- The `k`-th element of an order-2 basis is `≤ C·k²` for `k ≥ 1`
+(`bₖ = O(k²)`, the standard growth estimate of Key Observation 1). -/
+theorem IsAddBasisOfOrder.two_nth_le_mul_sq {A : Set ℕ}
+    (h : IsAddBasisOfOrder A 2) :
+    ∃ C N₀ : ℕ, ∀ k : ℕ, N₀ ≤ k → Nat.nth (· ∈ A) k ≤ C * k ^ 2 := by
+  obtain ⟨N, hN⟩ := h.two_nth_le_quadratic
+  refine ⟨N + 4, 1, fun k hk => ?_⟩
+  have e1 : (k + 1) ^ 2 ≤ 4 * k ^ 2 := by nlinarith [hk]
+  have e2 : N ≤ N * k ^ 2 := by nlinarith [hk]
+  calc Nat.nth (· ∈ A) k
+      ≤ N + (k + 1) ^ 2 := hN k
+    _ ≤ N * k ^ 2 + 4 * k ^ 2 := by omega
+    _ = (N + 4) * k ^ 2 := by ring
+
 /-! ## The growth-limit predicates are non-vacuous (realizability)
 
 The lemmas above about `HasGrowthLimit`/`HasNoGrowthLimit` (uniqueness of the

--- a/research/problems/erdos-326-wip-01/knowledge.md
+++ b/research/problems/erdos-326-wip-01/knowledge.md
@@ -98,3 +98,30 @@ where `S = T.erase 0` collects the nonzero coordinates. Hence
   `bₖ/k²` non-convergent — the OPEN part of #326 (structured blocker). The density
   bound above controls `bₖ` from above but says nothing about non-convergence.
 - `HasGrowthLimit`/`HasNoGrowthLimit` bridge to explicit enumeration boundedness.
+
+## Session 2026-07-21 (researcher-1-4): b_k = O(k²) upper bound
+
+Turned the √n density (Key Observation 1) into the standard **b_k = O(k²)**
+growth upper bound for the increasing enumeration `b_k = Nat.nth (· ∈ A) k`:
+
+- `IsAddBasisOfOrder.two_nth_le_quadratic` — `∃ N, ∀ k, Nat.nth (· ∈ A) k ≤ N + (k+1)²`.
+- `IsAddBasisOfOrder.two_nth_le_mul_sq` — `∃ C N₀, ∀ k ≥ N₀, Nat.nth (· ∈ A) k ≤ C·k²`
+  (with `C = N+4`, `N₀ = 1`).
+
+Both 0-axiom (propext/Classical.choice/Quot.sound), host-verified v4.31.0.
+
+**Mechanism.** Take `n := N + (k+1)²`. The density form `n+1−N ≤ (|S|+1)²`
+(`two_quadratic_density'`) reads `(k+1)²+1 ≤ (|S|+1)²`, forcing `k < |S|`
+(via `Nat.pow_le_pow_left` contrapositive + `omega`). Since `S ⊆ A` with all
+elements `≤ n`, `S ⊆ (range (n+1)).filter (· ∈ A)`, so
+`k < |S| ≤ Nat.count (· ∈ A) (n+1)` (`Nat.count_eq_card_filter_range`,
+`Finset.card_le_card`). Then `Nat.nth_lt_of_lt_count` gives
+`Nat.nth (· ∈ A) k < n+1`, i.e. `≤ n`. No infiniteness needed.
+
+**Idioms.** `Nat.nth_lt_of_lt_count : k < count p n → nth p k < n` is the exact
+count↔nth bridge (no `Infinite` hypothesis). `nlinarith [hk]` closes
+`(k+1)² ≤ 4k²` and `N ≤ N·k²` for `k ≥ 1`; then `omega` (atoms `(k+1)²`, `k²`,
+`N·k²`) + `ring` finish the `≤ (N+4)k²` calc.
+
+The elementary density/growth-upper-bound layer is now **saturated**; only the
+deep oscillation dichotomy remains open.

--- a/src/data/research/problems/erdos-326-wip-01.json
+++ b/src/data/research/problems/erdos-326-wip-01.json
@@ -27,7 +27,7 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-20T13:00:00-07:00",
-    "iteration": 2,
+    "iteration": 3,
     "focus": "Axiom-free foundational lemmas on IsAddBasis / IsAddBasisOfOrder / growthRatio.",
     "blockers": [
       {
@@ -36,7 +36,7 @@
         "blockedAt": "2026-07-20"
       }
     ],
-    "nextAction": "Formalize the standard bₖ = O(k²) upper bound for order-2 bases (density ≥ c√n ⟹ k-th element ≤ Ck²); triangular numbers as an order-3 basis if Gauss Eureka is in Mathlib. Deep oscillation content stays open.",
+    "nextAction": "Elementary density/growth-upper-bound layer is now saturated (√n density + b_k=O(k^2) both machine-checked). Only the deep oscillation dichotomy (materially new mechanism required) remains open.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -44,7 +44,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-07-21, researcher-1-6, VERIFIED 0-axiom host v4.31.0): the growth-limit predicates are now realizable — hasGrowthLimit_quadratic (bₖ=c·k²→c) and hasNoGrowthLimit_oscillating (coefficient oscillates 1↔2, no limit). theoremCount 20→25 (+1 def). Deep sub-basis oscillation dichotomy (open part of #326) untouched.",
+    "progressSummary": "PROGRESS (2026-07-21, researcher-1-4, VERIFIED 0-axiom host v4.31.0): the standard b_k=O(k^2) growth UPPER bound for order-2 bases is now formalized (two_nth_le_quadratic / two_nth_le_mul_sq), turning the √n density (Key Observation 1) into an explicit bound on the k-th element Nat.nth(.∈A) k via Nat.nth_lt_of_lt_count. Deep sub-basis oscillation dichotomy (open part of #326) remains untouched.",
     "builtItems": [
       "IsAddBasisOfOrder.mono_order / .mono_set in Erdos326WIP01.lean",
       "IsAddBasis.mono",
@@ -59,7 +59,8 @@
       "growthRatio_eq — growth ratio of an exactly-quadratic enumeration bₖ=c·k² equals c at any k≠0 (Erdos326WIP01.lean)",
       "hasGrowthLimit_quadratic — bₖ=c·k² has growth limit c (HasGrowthLimit non-vacuous; positive realizability, Cassels flavour)",
       "oscillating (def) + growthRatio_oscillating_odd/even — explicit sequence with ratio 2 on odds, 1 on evens",
-      "hasNoGrowthLimit_oscillating — HasNoGrowthLimit is non-vacuous: oscillating sequence has no growth limit"
+      "hasNoGrowthLimit_oscillating — HasNoGrowthLimit is non-vacuous: oscillating sequence has no growth limit",
+      "IsAddBasisOfOrder.two_nth_le_quadratic + two_nth_le_mul_sq in Erdos326WIP01.lean: order-2 basis enumeration b_k=Nat.nth(.∈A) satisfies b_k ≤ N+(k+1)^2 and b_k ≤ (N+4)k^2 (k≥1). 0 axioms (propext/Classical.choice/Quot.sound), host-verified v4.31.0"
     ],
     "insights": [
       "The basis predicates form a monotone lattice: raising the order or enlarging the set preserves the basis property — the atomic order theory underlying any basis-comparison argument.",
@@ -70,7 +71,8 @@
       "The √n density lower bound for order-2 bases (Key Observation 1) is now machine-checked axiom-free — the elementary counting core behind b_k=O(k²). The remaining open content is the growth/oscillation dichotomy (Erdős #326 proper), which this bound does not touch: it bounds b_k above but says nothing about the non-convergence of b_k/k² for a sub-basis.",
       "The HasGrowthLimit/HasNoGrowthLimit predicates were previously only equipped with uniqueness lemmas; both are now shown non-vacuous by explicit bare-sequence witnesses (no basis constraint), 0-axiom.",
       "Non-convergence is realized elementarily by oscillating the quadratic coefficient between 1 and 2; the odd/even index maps both tend to atTop so any limit would be forced to equal both 2 and 1 (tendsto_nhds_unique twice).",
-      "Idiom: ∀ᶠ equality must be typed as f =ᶠ[l] g (EventuallyEq) for .symm/.congr' dot notation to resolve; the bare ∀ᶠ (Eventually) head symbol blocks it."
+      "Idiom: ∀ᶠ equality must be typed as f =ᶠ[l] g (EventuallyEq) for .symm/.congr' dot notation to resolve; the bare ∀ᶠ (Eventually) head symbol blocks it.",
+      "The b_k = O(k^2) growth upper bound for order-2 bases is now machine-checked axiom-free (two_nth_le_quadratic: Nat.nth (.∈A) k ≤ N + (k+1)^2; two_nth_le_mul_sq: ≤ (N+4)·k^2 for k≥1). This is the standard consequence of the √n density bound (Key Observation 1): with n = N+(k+1)^2 the density (n+1-N ≤ (|S|+1)^2) forces k < |S| ≤ count(.∈A)(n+1), so Nat.nth (.∈A) k < n+1 via Nat.nth_lt_of_lt_count. No deep input; the oscillation dichotomy stays open."
     ],
     "mathlibGaps": [
       "No packaged bₖ = O(k²) bound for order-2 additive bases; would need a density-counting argument (|A ∩ [0,n]| ≥ c√n) not currently in Mathlib."


### PR DESCRIPTION
## Summary

Turns the √n density bound (Key Observation 1, `two_quadratic_density'`) into the standard **b_k = O(k²)** growth *upper* bound on the increasing enumeration `b_k = Nat.nth (· ∈ A) k` of an order-2 additive basis `A` — the estimate Key Observation 1 exists to prove.

## New theorems (`Erdos326WIP01.lean`)
- `IsAddBasisOfOrder.two_nth_le_quadratic` — `∃ N, ∀ k, Nat.nth (· ∈ A) k ≤ N + (k+1)²`
- `IsAddBasisOfOrder.two_nth_le_mul_sq` — `∃ C N₀, ∀ k ≥ N₀, Nat.nth (· ∈ A) k ≤ C·k²` (C = N+4, N₀ = 1)

## Mechanism
With `n := N + (k+1)²`, the density form `n+1−N ≤ (|S|+1)²` reads `(k+1)²+1 ≤ (|S|+1)²`, forcing `k < |S|`. Since `S ⊆ A` with all elements `≤ n`, we get `k < |S| ≤ Nat.count (· ∈ A) (n+1)` (`Nat.count_eq_card_filter_range`), so `Nat.nth (· ∈ A) k < n+1` by `Nat.nth_lt_of_lt_count`. No infiniteness hypothesis needed.

## Files
- `proofs/Proofs/Erdos326WIP01.lean` (+2 theorems + section)
- `src/data/research/problems/erdos-326-wip-01.json` (knowledge)
- `research/problems/erdos-326-wip-01/knowledge.md`

## Status
**Outcome**: progress (infrastructure) — 0 sorries, 0 axioms (propext/Classical.choice/Quot.sound only), host-verified at toolchain v4.31.0 (parent olean rebuilt fresh).

**Next steps**: The elementary density / growth-upper-bound layer is now saturated. Only the deep sub-basis oscillation dichotomy (the open part of Erdős #326, requiring materially new mechanism) remains.

🤖 Generated by researcher-1
