### PR TITLE
Enrich erdos-972: add Why the Problem is Hard section covering stranded vinogradovSet

### DIFF
--- a/src/data/proofs/erdos-972/meta.json
+++ b/src/data/proofs/erdos-972/meta.json
@@ -112,8 +112,15 @@
       "id": "vinogradov",
       "title": "Vinogradov's Theorem",
       "startLine": 93,
-      "endLine": 132,
+      "endLine": 124,
       "summary": "Related result and why it differs from the main problem"
+    },
+    {
+      "id": "why-hard",
+      "title": "Why the Problem is Hard",
+      "startLine": 125,
+      "endLine": 144,
+      "summary": "Defines vinogradovSet α = {p prime : ∃ n, p = ⌊αn⌋} — the primes that arise as floors ⌊αn⌋ — making explicit the distinction between Vinogradov's tractable question (are there infinitely many primes among the ⌊nα⌋?) and Erdős #972 (are there infinitely many primes p with ⌊pα⌋ prime?). A prose note records that the two sets are not always distinct — for α = 1 both equal the set of all primes — so the difficulty lies in the image of the primes under the floor map, not in prime-valued floors."
     },
     {
       "id": "examples",


### PR DESCRIPTION
## Enrichment: erdos-972 (Erdős Problem #972, primes p with ⌊pα⌋ prime)

**Gap fixed:** section coverage. `Erdos972Problem.lean` has a labelled `## Why the Problem is Hard` block (banner L125) whose declaration — `def vinogradovSet` (L137) — was stranded: the `Vinogradov's Theorem` section ran 93–132 (ending mid-way through the "Why hard" banner block) and the next section (`Examples`) began at 145, leaving 133–144 uncovered.

**Fix (sections only):**
- Trimmed `Vinogradov's Theorem` endLine 132 → 124 (stop at the `## Why the Problem is Hard` banner).
- Added a new **"Why the Problem is Hard"** section (125–144) summarizing `vinogradovSet α = {p prime : ∃ n, p = ⌊αn⌋}` and the distinction from Erdős's conjecture (including the α = 1 coincidence noted in the source).

**Integrity:** unchanged (`status`/`badge`/`axiomCount` untouched).
