### PR TITLE
Enrich shannon-entropy-oq-03: extend Consequences section to cover stranded conditional_mi_nonneg

### DIFF
--- a/src/data/proofs/shannon-entropy-oq-03/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03/meta.json
@@ -96,7 +96,7 @@
       "title": "Consequences of SSA",
       "id": "consequences",
       "startLine": 68,
-      "endLine": 92,
+      "endLine": 109,
       "summary": "Three three-variable corollaries derived from strong subadditivity by linear rearrangement (linarith), not present in the parent file: conditioning_reduces_entropy_general (H(X|Y,Z) ≤ H(X|Y), extra conditioning cannot increase entropy), conditioning_reduces_entropy_general′ (H(Z|X,Y) ≤ H(Z|Y), the X↔Z dual), and conditional_mi_nonneg (I(X;Z|Y) ≥ 0, the conditional mutual information is non-negative).",
       "mathContext": "SSA implies (1) $H(X|Y,Z) \\leq H(X|Y)$ and (2) $I(X;Z|Y) = H(X,Y) + H(Y,Z) - H(X,Y,Z) - H(Y) \\geq 0$."
     },


### PR DESCRIPTION
## Enrichment: shannon-entropy-oq-03 (Strong Subadditivity of Shannon Entropy)

**Gap fixed:** section coverage. The `Consequences of SSA` section describes **three** corollaries — its summary explicitly names `conditioning_reduces_entropy_general` (L75), `conditioning_reduces_entropy_general′` (L91), and `conditional_mi_nonneg` (I(X;Z|Y) ≥ 0, L103). But the section was ranged 68–92, so the third corollary `conditional_mi_nonneg` fell in the gap before the next section (`Conditional mutual information`, starting at the `## ` banner on L110) and was stranded outside every section.

**Fix:** extended the `consequences` section endLine 92 → 109, so it now spans all three corollaries it already documents, up to (but not into) the next `##` banner. Summary and mathContext unchanged.

**Integrity:** axiom-free entry; no `status`/`badge`/`axiomCount` change.
