### PR TITLE
Enrich cayley-hamilton-oq-02-oq-01: re-anchor leading sections to decl boundaries

### DIFF
--- a/src/data/proofs/cayley-hamilton-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-02-oq-01/meta.json
@@ -70,34 +70,34 @@
       "id": "module-doc",
       "title": "Module Documentation: Putzer's Algorithm and the Algebraic Core",
       "startLine": 4,
-      "endLine": 52,
+      "endLine": 61,
       "summary": "Header stating Putzer's identity e^{tA} = ∑ₖ Pₖ(t)ρ_{k-1}, the triangular ODE system for Pₖ, the four algebraic results proved here, and an explicit note that the analytic completion is deferred."
     },
     {
       "id": "rho-def",
       "title": "The Putzer partial product ρ",
-      "startLine": 61,
-      "endLine": 73,
+      "startLine": 62,
+      "endLine": 83,
       "summary": "Ordered recursion ρ₀ = 1, ρ_{k+1} = ρₖ·(A - λₖ•1) (rho), with rho_zero and rho_succ. Defined recursively to avoid requiring a CommMonoid instance on matrices."
     },
     {
       "id": "commutation",
       "title": "Commutation of A with the partial products",
-      "startLine": 75,
-      "endLine": 89,
+      "startLine": 84,
+      "endLine": 99,
       "summary": "commute_A_factor (A commutes with each A - λᵢ•1) and commute_A_rho (A commutes with every ρₖ, by induction), giving A·ρₖ = ρₖ·A."
     },
     {
       "id": "telescoping",
       "title": "The key telescoping identity",
-      "startLine": 91,
-      "endLine": 98,
+      "startLine": 100,
+      "endLine": 107,
       "summary": "A_mul_rho: A·ρₖ = ρ_{k+1} + λₖ•ρₖ, the algebraic engine of the derivative computation Ṁ = A·M."
     },
     {
       "id": "truncation",
       "title": "Cayley–Hamilton truncation",
-      "startLine": 100,
+      "startLine": 108,
       "endLine": 132,
       "summary": "aeval_X_sub_C, the bridge lemma rho_eq_aeval_prod (ρₖ = aeval A ∏(X - C λᵢ)), and rho_card (ρₙ = 0 when χ_A splits), via Matrix.aeval_self_charpoly."
     },


### PR DESCRIPTION
## Leading-section re-anchor (stranded-decl + mislabel fix)

`/tmp/scan_uncov.mjs` flagged two uncovered decls:

- `def rho` (line 74) — the Putzer partial product **rho-def** is titled for
- `lemma commute_A_rho` (line 90) — named in **commutation**'s summary

The first five sections were each shifted one decl too high, so several
mislabelled their content: `telescoping` ("The key telescoping identity",
titled for `A_mul_rho`) actually covered `A_comm_rho`, and `truncation`
swallowed the telescoping lemma `A_mul_rho`. Re-anchored the five leading
sections to their docstring boundaries:

| Section | Before | After |
|---------|--------|-------|
| module-doc | 4–52 | 4–61 |
| rho-def | 61–73 | 62–83 |
| commutation | 75–89 | 84–99 |
| telescoping | 91–98 | 100–107 |
| truncation | 100–132 | 108–132 |

The four `/-! ##`-divider sections (concatenation-law, two-sided-telescoping,
algebraic-derivative-bridge, algebraic-initial-condition) were already
correct and are unchanged. Verified: 0 stranded decls, no overlaps. No
`status` / `badge` / `axiomCount` / summary-text changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
