### PR TITLE
Audit tracker: erdos-559 re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14579,8 +14579,8 @@
     },
     "erdos-559": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:38Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T20:13:53Z",
       "result": "clean"
     },
     "erdos-56": {


### PR DESCRIPTION
Reserve-mode re-verification (queue drained).

**Finding:** clean. Tier-C scaffold for Erdős #563[sic #559] size-Ramsey landscape — 11 defs, 9 theorems all `sorry`'d + 1 sorry in sizeRamsey's Nat.find witness = 10 sorries. Meta counts (thm 9 / ax 0 / sorry 10 / def 11) match the file exactly. Badge `wip`; `assumptions` discloses '10 sorries remain'; `conclusion` uses 'captures'.

Section 'proved/proving' wording attributes to the literature (each sorry commented with its author/year) and describes stated theorems, not Lean completion. No trust inflation — viewer sees wip + 10 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)