### PR TITLE
Audit tracker: erdos-557 issues-found (inconsistent axioms, #40891)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14567,9 +14567,9 @@
     },
     "erdos-557": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:38Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T20:17:40Z",
+      "result": "issues-found"
     },
     "erdos-558": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Reserve-mode re-verify of erdos-557 found the axiom base is **inconsistent**: `star_ramsey_lower` and `two_color_tree_ramsey` contradict on the star at n=2, k=2 (`3 ≤ R ≤ 2`), so the file derives kernel `False`. Filed CRITICAL issue #40891 for the mechanic. This PR only updates the audit tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)