### PR TITLE
Fix: correct star_ramsey_lower to resolve inconsistent axiom base (erdos-557)

### DIFF
--- a/proofs/Proofs/Erdos557Problem.lean
+++ b/proofs/Proofs/Erdos557Problem.lean
@@ -89,9 +89,12 @@ axiom two_color_tree_ramsey : ∀ n : ℕ, 2 ≤ n → ∀ (T : ErdosTree n),
 axiom ramseyTree_mono_k : ∀ n : ℕ, ∀ (T : ErdosTree n), ∀ k : ℕ,
     ramseyTree n T k ≤ ramseyTree n T (k + 1)
 
-/-- Star lower bound: R(S_n; k) ≥ k·(n-1) + 1 for n ≥ 2, k ≥ 1.
-    Proves the conjecture is tight: the additive constant cannot be better than O(k). -/
+/-- Star lower bound: R(S_n; k) ≥ k·(n-2) + 2 for n ≥ 2, k ≥ 1.
+    This is the Burr–Roberts multicolor star bound (each color-degree ≤ n-2 avoids a
+    monochromatic K_{1,n-1}). It is consistent with the 2-color upper bound `2n-2`
+    (at k = 2 it gives exactly `2n-2`) and still proves the conjecture is tight:
+    `k·(n-2) + 2 = k·n - 2k + 2`, so the additive constant cannot be better than O(k). -/
 axiom star_ramsey_lower : ∀ (n : ℕ) (hn : 2 ≤ n) (k : ℕ), 1 ≤ k →
-    k * (n - 1) + 1 ≤ ramseyTree n (starTree n (by omega)) k
+    k * (n - 2) + 2 ≤ ramseyTree n (starTree n (by omega)) k
 
 /- ## Connection to Burr–Erdős -/


### PR DESCRIPTION
## Fix: inconsistent axiom base in erdos-557

Resolves the CRITICAL soundness issue in #40891. Two axioms in
`proofs/Proofs/Erdos557Problem.lean` were jointly contradictory, letting the
kernel derive `False` and making every statement in the file vacuous.

### Root cause
`star_ramsey_lower` asserted `R(S_n; k) ≥ k·(n-1) + 1`. Since
`two_color_tree_ramsey` quantifies over **arbitrary** trees `T`, it applies to
`starTree n _`, giving `R(S_n; 2) ≤ 2n-2`. At `k = 2` the lower bound demanded
`2n-1 ≤ R ≤ 2n-2`, i.e. `False` (e.g. `n=2`: `3 ≤ R ≤ 2`).

### Fix
Corrected `star_ramsey_lower` to the standard Burr–Roberts multicolor star
bound `k·(n-2) + 2` (each color-degree ≤ n-2 avoids a monochromatic
`K_{1,n-1}`):

```
-    k * (n - 1) + 1 ≤ ramseyTree n (starTree n (by omega)) k
+    k * (n - 2) + 2 ≤ ramseyTree n (starTree n (by omega)) k
```

### Consistency check
- `k = 2`: `2(n-2)+2 = 2n-2` ≤ upper bound `2n-2` — equality, no contradiction.
- `n = 2, k = 2`: `2·0 + 2 = 2` ≤ `2` — consistent.
- Still proves tightness: `k·(n-2)+2 = k·n − 2k + 2`, so the additive constant
  is still `O(k)` (matching the axiom's stated purpose).

Docstring updated to match. meta.json counts (5 axioms / 0 theorems / 0 sorries)
were already accurate — this was a soundness bug, not a counting bug — so no
metadata change.

Closes #40891
