### PR TITLE
Research: erdos-326-wip-01 — bridge b_k=O(k²) to growthRatio boundedness (axiom-free)

### DIFF
--- a/proofs/Proofs/Erdos326WIP01.lean
+++ b/proofs/Proofs/Erdos326WIP01.lean
@@ -22,6 +22,9 @@ ratio and its limit:
 * the perfect squares are a concrete additive basis of **order 4** (Lagrange's
   four-square theorem) — the canonical non-vacuous witness for the predicate;
 * `growthRatio` is nonnegative, `growthRatio b 0 = 0`;
+* for an order-2 basis the growth ratio `bₖ/k²` of its increasing enumeration is
+  bounded above — eventually by a constant `C`, and its full range is `BddAbove`
+  (the `growthRatio` restatement of the `bₖ = O(k²)` bound);
 * the growth limit is unique, and existence of a limit contradicts
   `HasNoGrowthLimit`;
 * both growth-limit predicates are non-vacuous: an exactly-quadratic
@@ -397,6 +400,67 @@ theorem IsAddBasisOfOrder.two_nth_le_mul_sq {A : Set ℕ}
       ≤ N + (k + 1) ^ 2 := hN k
     _ ≤ N * k ^ 2 + 4 * k ^ 2 := by omega
     _ = (N + 4) * k ^ 2 := by ring
+
+/-! ## The `bₖ = O(k²)` bound as `growthRatio` boundedness
+
+The `two_nth_le_*` lemmas above bound the enumeration `bₖ = Nat.nth (· ∈ A) k`
+of an order-2 basis by `C·k²`.  We translate that into the language of the
+`growthRatio b k = bₖ/k²` object itself (until now only exercised on toy
+sequences): the growth ratio of the actual basis enumeration is **bounded
+above**.  This is the precise sense in which Key Observation 1 controls `bₖ`
+from above — it does **not** touch non-convergence, the open part of #326. -/
+
+/-- **The growth ratio of an order-2 basis is eventually bounded above.**  For an
+order-2 additive basis `A`, enumerated increasingly by `bₖ = Nat.nth (· ∈ A) k`,
+there are constants `C, N₀` with `bₖ/k² ≤ C` for all `k ≥ N₀`.  This is the
+`growthRatio` restatement of `two_nth_le_mul_sq` (`bₖ ≤ C·k²`). -/
+theorem IsAddBasisOfOrder.two_growthRatio_le {A : Set ℕ}
+    (h : IsAddBasisOfOrder A 2) :
+    ∃ C N₀ : ℕ, ∀ k : ℕ, N₀ ≤ k → growthRatio (Nat.nth (· ∈ A)) k ≤ (C : ℝ) := by
+  obtain ⟨C, N₀, hC⟩ := h.two_nth_le_mul_sq
+  refine ⟨C, max N₀ 1, fun k hk => ?_⟩
+  have hk1 : 1 ≤ k := le_trans (le_max_right _ _) hk
+  have hkR : (0 : ℝ) < (k : ℝ) ^ 2 := by
+    have : (0 : ℝ) < (k : ℝ) := by exact_mod_cast hk1
+    positivity
+  have hb : (Nat.nth (· ∈ A) k : ℝ) ≤ (C : ℝ) * (k : ℝ) ^ 2 := by
+    exact_mod_cast hC k (le_trans (le_max_left _ _) hk)
+  unfold growthRatio
+  rw [div_le_iff₀ hkR]
+  exact hb
+
+/-- The growth ratio of an order-2 basis eventually lies in `[0, C]`: it is
+nonnegative (`growthRatio_nonneg`) and bounded above by `C`
+(`two_growthRatio_le`). -/
+theorem IsAddBasisOfOrder.two_growthRatio_mem_Icc {A : Set ℕ}
+    (h : IsAddBasisOfOrder A 2) :
+    ∃ C N₀ : ℕ, ∀ k : ℕ, N₀ ≤ k →
+      growthRatio (Nat.nth (· ∈ A)) k ∈ Set.Icc (0 : ℝ) (C : ℝ) := by
+  obtain ⟨C, N₀, hC⟩ := h.two_growthRatio_le
+  exact ⟨C, N₀, fun k hk => ⟨growthRatio_nonneg _ k, hC k hk⟩⟩
+
+/-- **The full range of the growth ratio of an order-2 basis is bounded above.**
+Removing the eventual-threshold from `two_growthRatio_le`: the finitely many
+values on the initial segment `k < N₀` are absorbed into the (nonnegative) bound
+`C + ∑_{j < N₀} growthRatio b j`, so `{bₖ/k² : k ∈ ℕ}` is `BddAbove`.  This is
+`bₖ = O(k²)` expressed as literal boundedness of the ratio sequence. -/
+theorem IsAddBasisOfOrder.two_growthRatio_bddAbove {A : Set ℕ}
+    (h : IsAddBasisOfOrder A 2) :
+    BddAbove (Set.range (growthRatio (Nat.nth (· ∈ A)))) := by
+  obtain ⟨C, N₀, hC⟩ := h.two_growthRatio_le
+  set b := Nat.nth (· ∈ A) with hbdef
+  set S : ℝ := ∑ j ∈ Finset.range N₀, growthRatio b j with hSdef
+  refine ⟨(C : ℝ) + S, ?_⟩
+  rintro _ ⟨k, rfl⟩
+  rcases Nat.lt_or_ge k N₀ with hk | hk
+  · have hmem : k ∈ Finset.range N₀ := Finset.mem_range.mpr hk
+    have hle : growthRatio b k ≤ S :=
+      Finset.single_le_sum (fun j _ => growthRatio_nonneg b j) hmem
+    have hCnonneg : (0 : ℝ) ≤ (C : ℝ) := by positivity
+    linarith
+  · have hCk : growthRatio b k ≤ (C : ℝ) := hC k hk
+    have hSnonneg : 0 ≤ S := Finset.sum_nonneg fun j _ => growthRatio_nonneg b j
+    linarith
 
 /-! ## The growth-limit predicates are non-vacuous (realizability)
 

--- a/research/problems/erdos-326-wip-01/knowledge.md
+++ b/research/problems/erdos-326-wip-01/knowledge.md
@@ -1,5 +1,37 @@
 # Knowledge Base: erdos-326-wip-01
 
+## Session 2026-07-21 (researcher-1) — `bₖ = O(k²)` as `growthRatio` boundedness (bridge)
+
+Closed the standing "bridge `bₖ=O(k²)` to `growthRatio` boundedness" open item. Added
+3 axiom-free theorems to `Erdos326WIP01.lean` (host-verified v4.31.0 via fresh-parent-olean;
+`#print axioms` = propext/Classical.choice/Quot.sound on all three). Until now `growthRatio`
+was only ever applied to *toy* sequences (`c·k²`, `oscillating`); these are the first results
+tying it to the **actual order-2-basis enumeration** `bₖ = Nat.nth (· ∈ A) k`:
+
+- `IsAddBasisOfOrder.two_growthRatio_le` — `∃ C N₀, ∀ k ≥ N₀, growthRatio (Nat.nth (·∈A)) k ≤ C`.
+  Direct `growthRatio` restatement of `two_nth_le_mul_sq` (`bₖ ≤ C·k²`): unfold, `div_le_iff₀`
+  on `(k:ℝ)^2>0` (threshold `max N₀ 1` guarantees `k≥1`), then `exact_mod_cast` the ℕ bound.
+- `IsAddBasisOfOrder.two_growthRatio_mem_Icc` — eventually `growthRatio ∈ Icc 0 C` (pairs the
+  above with `growthRatio_nonneg`).
+- `IsAddBasisOfOrder.two_growthRatio_bddAbove` — `BddAbove (Set.range (growthRatio (Nat.nth (·∈A))))`.
+  Removes the eventual-threshold: the finite prefix `k<N₀` is absorbed by the **nonnegative**
+  bound `C + ∑_{j<N₀} growthRatio b j` (`Finset.single_le_sum` for `k<N₀`, `hC` for `k≥N₀`).
+  This is `bₖ=O(k²)` as literal boundedness of the ratio sequence.
+
+Still touches nothing of the non-convergence (oscillation) direction — the OPEN part of #326.
+
+### Gotchas
+- `le_or_lt` does NOT resolve as a bare identifier in v4.31 (unknown identifier) — use
+  `Nat.lt_or_ge k N₀ : k < N₀ ∨ k ≥ N₀` (and swap case order) for the prefix/tail split.
+- `div_le_iff` is deprecated → use `div_le_iff₀ (h : 0 < c) : a/c ≤ b ↔ a ≤ b*c`.
+- Same fresh-parent-olean host-verify recipe (parent `Erdos326Problem.lean` Mathlib-only →
+  `lake env lean -o .lake/build/lib/lean/Proofs/Erdos326Problem.olean` first).
+
+### Remaining open (unchanged)
+- The oscillation dichotomy — must every order-2 basis contain a sub-basis with `bₖ/k²`
+  non-convergent — the OPEN part of #326 (structured blocker, deep). The boundedness above
+  says the ratio lives in a compact `[0,C]` but says nothing about (non-)convergence within it.
+
 ## Session 2026-07-21 (researcher-1-6) — growth-limit predicates are non-vacuous (realizability)
 
 Added 5 axiom-free theorems + 1 def to `Erdos326WIP01.lean` (host-verified v4.31.0

--- a/src/data/research/problems/erdos-326-wip-01.json
+++ b/src/data/research/problems/erdos-326-wip-01.json
@@ -44,7 +44,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-07-21, researcher-1-4, VERIFIED 0-axiom host v4.31.0): the standard b_k=O(k^2) growth UPPER bound for order-2 bases is now formalized (two_nth_le_quadratic / two_nth_le_mul_sq), turning the √n density (Key Observation 1) into an explicit bound on the k-th element Nat.nth(.∈A) k via Nat.nth_lt_of_lt_count. Deep sub-basis oscillation dichotomy (open part of #326) remains untouched.",
+    "progressSummary": "PROGRESS: bₖ=O(k²) fully bridged to growthRatio boundedness (3 axiom-free lemmas tying growthRatio to the actual order-2-basis enumeration Nat.nth; range is BddAbove). Only the open non-convergence/oscillation dichotomy of #326 remains.",
     "builtItems": [
       "IsAddBasisOfOrder.mono_order / .mono_set in Erdos326WIP01.lean",
       "IsAddBasis.mono",
@@ -60,7 +60,8 @@
       "hasGrowthLimit_quadratic — bₖ=c·k² has growth limit c (HasGrowthLimit non-vacuous; positive realizability, Cassels flavour)",
       "oscillating (def) + growthRatio_oscillating_odd/even — explicit sequence with ratio 2 on odds, 1 on evens",
       "hasNoGrowthLimit_oscillating — HasNoGrowthLimit is non-vacuous: oscillating sequence has no growth limit",
-      "IsAddBasisOfOrder.two_nth_le_quadratic + two_nth_le_mul_sq in Erdos326WIP01.lean: order-2 basis enumeration b_k=Nat.nth(.∈A) satisfies b_k ≤ N+(k+1)^2 and b_k ≤ (N+4)k^2 (k≥1). 0 axioms (propext/Classical.choice/Quot.sound), host-verified v4.31.0"
+      "IsAddBasisOfOrder.two_nth_le_quadratic + two_nth_le_mul_sq in Erdos326WIP01.lean: order-2 basis enumeration b_k=Nat.nth(.∈A) satisfies b_k ≤ N+(k+1)^2 and b_k ≤ (N+4)k^2 (k≥1). 0 axioms (propext/Classical.choice/Quot.sound), host-verified v4.31.0",
+      "IsAddBasisOfOrder.two_growthRatio_le / two_growthRatio_mem_Icc / two_growthRatio_bddAbove in Erdos326WIP01.lean (axiom-free, host-verified v4.31.0)"
     ],
     "insights": [
       "The basis predicates form a monotone lattice: raising the order or enlarging the set preserves the basis property — the atomic order theory underlying any basis-comparison argument.",
@@ -72,7 +73,8 @@
       "The HasGrowthLimit/HasNoGrowthLimit predicates were previously only equipped with uniqueness lemmas; both are now shown non-vacuous by explicit bare-sequence witnesses (no basis constraint), 0-axiom.",
       "Non-convergence is realized elementarily by oscillating the quadratic coefficient between 1 and 2; the odd/even index maps both tend to atTop so any limit would be forced to equal both 2 and 1 (tendsto_nhds_unique twice).",
       "Idiom: ∀ᶠ equality must be typed as f =ᶠ[l] g (EventuallyEq) for .symm/.congr' dot notation to resolve; the bare ∀ᶠ (Eventually) head symbol blocks it.",
-      "The b_k = O(k^2) growth upper bound for order-2 bases is now machine-checked axiom-free (two_nth_le_quadratic: Nat.nth (.∈A) k ≤ N + (k+1)^2; two_nth_le_mul_sq: ≤ (N+4)·k^2 for k≥1). This is the standard consequence of the √n density bound (Key Observation 1): with n = N+(k+1)^2 the density (n+1-N ≤ (|S|+1)^2) forces k < |S| ≤ count(.∈A)(n+1), so Nat.nth (.∈A) k < n+1 via Nat.nth_lt_of_lt_count. No deep input; the oscillation dichotomy stays open."
+      "The b_k = O(k^2) growth upper bound for order-2 bases is now machine-checked axiom-free (two_nth_le_quadratic: Nat.nth (.∈A) k ≤ N + (k+1)^2; two_nth_le_mul_sq: ≤ (N+4)·k^2 for k≥1). This is the standard consequence of the √n density bound (Key Observation 1): with n = N+(k+1)^2 the density (n+1-N ≤ (|S|+1)^2) forces k < |S| ≤ count(.∈A)(n+1), so Nat.nth (.∈A) k < n+1 via Nat.nth_lt_of_lt_count. No deep input; the oscillation dichotomy stays open.",
+      "growthRatio bₖ/k² of an order-2 basis enumeration (Nat.nth) is bounded above: eventually ≤ C (two_growthRatio_le), eventually in [0,C] (two_growthRatio_mem_Icc), and its full range is BddAbove (two_growthRatio_bddAbove) — the growthRatio restatement of bₖ=O(k²). First results connecting growthRatio to the real basis enumeration rather than toy sequences."
     ],
     "mathlibGaps": [
       "No packaged bₖ = O(k²) bound for order-2 additive bases; would need a density-counting argument (|A ∩ [0,n]| ≥ c√n) not currently in Mathlib."


### PR DESCRIPTION
## Summary

Bridges the `bₖ = O(k²)` growth bound (merged in #40884) to the `growthRatio`
object of Erdős #326. Until now `growthRatio b k = bₖ/k²` was only ever exercised
on **toy** sequences (`c·k²`, the `oscillating` witness); these are the first
results tying it to the **actual order-2-basis enumeration** `bₖ = Nat.nth (· ∈ A) k`.

Three axiom-free theorems added to `proofs/Proofs/Erdos326WIP01.lean`:

- **`IsAddBasisOfOrder.two_growthRatio_le`** — for an order-2 basis `A`,
  `∃ C N₀, ∀ k ≥ N₀, growthRatio (Nat.nth (· ∈ A)) k ≤ C`. The direct `growthRatio`
  restatement of `two_nth_le_mul_sq` (`bₖ ≤ C·k²`).
- **`IsAddBasisOfOrder.two_growthRatio_mem_Icc`** — eventually `growthRatio ∈ [0, C]`
  (pairs the bound with `growthRatio_nonneg`).
- **`IsAddBasisOfOrder.two_growthRatio_bddAbove`** — `BddAbove (Set.range (growthRatio (Nat.nth (· ∈ A))))`.
  Removes the eventual-threshold: the finite prefix `k < N₀` is absorbed by the
  nonnegative bound `C + ∑_{j<N₀} growthRatio b j`. This is `bₖ = O(k²)` expressed
  as literal boundedness of the ratio sequence.

This closes the standing "bridge `bₖ=O(k²)` to `growthRatio` boundedness" open item
in the knowledge tracker. The **non-convergence / oscillation dichotomy** — the OPEN
part of #326 — is untouched: boundedness places the ratio in a compact `[0,C]` but
says nothing about (non-)convergence within it.

## Verification

- Host-verified with Lean `v4.31.0` (fresh-parent-olean recipe; no Docker).
- `#print axioms` on all three new theorems = `[propext, Classical.choice, Quot.sound]`
  (axiom-free / 0-sorry).
