### PR TITLE
Enrich erdos-557: re-anchor sections to cover stranded axioms + fix stale star bound

### DIFF
--- a/src/data/proofs/erdos-557/meta.json
+++ b/src/data/proofs/erdos-557/meta.json
@@ -33,7 +33,7 @@
       "title": "Problem Statement and Imports",
       "summary": "Documentation header with problem statement, star lower bound, path results, Burr-Erdős connection, references, and Mathlib imports for SimpleGraph.",
       "startLine": 1,
-      "endLine": 27,
+      "endLine": 28,
       "mathContext": "Conjecture: $\\exists C, \\forall T, k: R(T; k) \\leq kn + C$ where $T$ is a tree on $n$ vertices."
     },
     {
@@ -41,32 +41,32 @@
       "title": "Core Definitions: Trees, Colorings, Ramsey Numbers",
       "summary": "Tree structure on Fin n, EdgeColoring as m→m→Fin k, HasMonochromaticCopy via injective embedding with uniform color, noncomputable multicolorRamseyTree, axiomatized ramseyTree.",
       "startLine": 29,
-      "endLine": 51,
+      "endLine": 53,
       "mathContext": "$R(T; k) = \\min\\{m : \\text{every } k\\text{-coloring of } K_m \\text{ contains a monochromatic copy of } T\\}$."
     },
     {
       "id": "main-conjecture",
       "title": "Erdős Problem #557: Linear Bound Conjecture (OPEN)",
       "summary": "Axiom erdos_557_conjecture: ∃ C, ∀ n, ∀ T (tree on n vertices), ∀ k ≥ 1, ramseyTree n T k ≤ k·n + C.",
-      "startLine": 53,
+      "startLine": 54,
       "endLine": 61,
       "mathContext": "$\\exists C \\in \\mathbb{N}, \\forall T \\text{ tree on } n \\text{ vertices}, \\forall k \\geq 1: R(T; k) \\leq kn + C$."
     },
     {
       "id": "star-construction",
       "title": "Star Graph and Lower Bound",
-      "summary": "starTree defines K_{1,n-1} with center vertex 0; star_ramsey_lower: R(S_n;k) ≥ k(n-1)+1 (shows conjecture is tight).",
-      "startLine": 63,
-      "endLine": 78,
-      "mathContext": "$R(K_{1,n-1}; k) \\geq k(n-1) + 1$: extremal coloring partitions $k(n-1)$ vertices into $k$ groups of $n-1$, each group monochromatically colored."
+      "summary": "starTree defines the star graph S_n = K_{1,n-1} on Fin n with center vertex 0 (adjacency: exactly one endpoint is 0); symmetry and looplessness are discharged by case analysis.",
+      "startLine": 62,
+      "endLine": 81,
+      "mathContext": "$S_n = K_{1,n-1}$ has one center joined to $n-1$ leaves. The multicolor star lower bound $R(K_{1,n-1};k) \\geq k(n-2)+2$ follows because a coloring giving every vertex color-degree $\\leq n-2$ in each color avoids a monochromatic $K_{1,n-1}$."
     },
     {
       "id": "known-results",
       "title": "Known Results: 2-Color Bound, Monotonicity, Star Lower Bound",
-      "summary": "Axioms: two_color_tree_ramsey (R(T;2) ≤ 2n-2), ramseyTree_mono_k (monotone in k), star_ramsey_lower (R(S_n;k) ≥ k(n-1)+1).",
-      "startLine": 80,
-      "endLine": 95,
-      "mathContext": "$R(T; 2) \\leq 2n-2$ (classical); $R(T; k) \\leq R(T; k+1)$ (monotonicity); $R(K_{1,n-1}; k) \\geq k(n-1)+1$ (pigeonhole lower bound)."
+      "summary": "Axioms: two_color_tree_ramsey (R(T;2) ≤ 2n-2), ramseyTree_mono_k (monotone in k), star_ramsey_lower (R(S_n;k) ≥ k(n-2)+2, the Burr–Roberts multicolor star bound). Ends with the Burr–Erdős connection banner.",
+      "startLine": 82,
+      "endLine": 100,
+      "mathContext": "$R(T; 2) \\leq 2n-2$ (classical); $R(T; k) \\leq R(T; k+1)$ (monotonicity); $R(K_{1,n-1}; k) \\geq k(n-2)+2$ (Burr–Roberts). At $k=2$ this gives exactly $2n-2$, matching the upper bound."
     }
   ],
   "overview": {


### PR DESCRIPTION
Enrichment pass for `erdos-557` (Multicolor Ramsey Numbers of Trees).

**Section coverage (stranded-axiom vein).** Two `axiom` declarations sat in inter-section gaps, covered by no section:
- `axiom ramseyTree` @52 fell between `core-definitions` (ended @51) and `main-conjecture` (started @53).
- `axiom star_ramsey_lower` @97 fell past `known-results` (ended @95).

Re-anchored all 5 sections contiguously (1..EOF) to the `/- ## ` banners, file order preserved:
`header [1-28]`, `core-definitions [29-53]`, `main-conjecture [54-61]`, `star-construction [62-81]`, `known-results [82-100]`. Both axioms are now covered.

**Stale prose fix (two-for-one).** #40893 corrected `star_ramsey_lower` to `k·(n-2)+2` in the Lean source, but the meta summaries/mathContext still claimed the old `k(n-1)+1`. Updated `star-construction` and `known-results` to `k(n-2)+2` (Burr–Roberts multicolor star bound; at k=2 it gives exactly 2n-2, matching the upper bound).

Also corrected the `star-construction` summary, which wrongly attributed `star_ramsey_lower` to that section — lines 62-81 contain only `starTree`; the axiom is declared later under Known Special Cases.

No changes to `status`/`badge`/`axiomCount` (meta.axiomCount=5 remains accurate: 5 axioms in the file).
