### PR TITLE
Research: erdos-116-wip-01 — lemniscate area is strictly positive (axiom-free)

### DIFF
--- a/proofs/Proofs/Erdos116WIP01.lean
+++ b/proofs/Proofs/Erdos116WIP01.lean
@@ -132,4 +132,40 @@ theorem volume_realProd_sublevelSet_lt_top (P : UnitDiskPoly n) :
   rw [hmp.measure_preimage P.measurableSet_sublevelSet.nullMeasurableSet]
   exact P.volume_sublevelSet_lt_top
 
+/-! ## Positivity of the 2D Lebesgue measure
+
+For positive degree, `Sₚ` is a *nonempty open* set (it contains every root), and a
+nonempty open set in the plane has strictly positive Lebesgue measure.  Combined with
+finiteness this pins the volume in `(0, ⊤)`, so the parent's `sublevelMeasure` (a
+`.toReal`) is not merely well-defined but genuinely **positive** — the lemniscate area
+is a real nonzero quantity, never the `⊤ ↦ 0` truncation nor a degenerate `0`. -/
+
+/-- **`0 < volume Sₚ`** (`ℂ`-side) for positive degree.  `Sₚ` is open
+(`isOpen_sublevelSet`) and nonempty (`sublevelSet_nonempty`, it contains a root); a
+nonempty open set has positive volume (`volume` is an open-positive measure on `ℂ`). -/
+theorem volume_sublevelSet_pos (P : UnitDiskPoly n) (hn : 0 < n) :
+    0 < volume P.sublevelSet :=
+  (isOpen_sublevelSet P).measure_pos volume (P.sublevelSet_nonempty hn)
+
+/-- **`0 < volume` of the parent's `ℝ × ℝ` sublevel set** for positive degree,
+transported from the `ℂ`-side positivity across the volume-preserving equivalence
+`ℂ ≃ᵐ ℝ × ℝ` (mirror of `volume_realProd_sublevelSet_lt_top`). -/
+theorem volume_realProd_sublevelSet_pos (P : UnitDiskPoly n) (hn : 0 < n) :
+    0 < volume {p : ℝ × ℝ | Complex.abs (P.eval ⟨p.1, p.2⟩) < 1} := by
+  rw [P.realProd_sublevelSet_eq_preimage]
+  have hmp := Complex.volume_preserving_equiv_real_prod.symm Complex.measurableEquivRealProd
+  rw [hmp.measure_preimage P.measurableSet_sublevelSet.nullMeasurableSet]
+  exact P.volume_sublevelSet_pos hn
+
+/-- **The lemniscate area is strictly positive.**  For a positive-degree polynomial the
+parent's `sublevelMeasure` — the `.toReal` of the planar volume of `{|p| < 1}` — is
+`> 0`: the volume is positive (`volume_realProd_sublevelSet_pos`) and finite
+(`volume_realProd_sublevelSet_lt_top`), so its `.toReal` is a genuine positive real.
+Together with `sublevelMeasure_nonneg` this shows `0 < sublevelMeasure P` sharply. -/
+theorem sublevelMeasure_pos (P : UnitDiskPoly n) (hn : 0 < n) :
+    0 < sublevelMeasure P := by
+  rw [sublevelMeasure]
+  exact ENNReal.toReal_pos (P.volume_realProd_sublevelSet_pos hn).ne'
+    (P.volume_realProd_sublevelSet_lt_top).ne
+
 end UnitDiskPoly

--- a/research/problems/erdos-116-wip-01/knowledge.md
+++ b/research/problems/erdos-116-wip-01/knowledge.md
@@ -2,6 +2,32 @@
 
 Insights accumulated during research on this problem.
 
+## Session 2026-07-21 (researcher-1) — strict positivity of the lemniscate area
+
+The prior "elementary layer saturated" note (open/measurable/bounded/finite) missed one
+genuinely-elementary gap: **strict positivity** of the measure. Prior work proved
+`μ ≥ 0` and `μ < ⊤`; a *nonempty open* set in the plane has *positive* Lebesgue measure,
+pinning the volume in `(0, ⊤)` so the parent `sublevelMeasure` (`.toReal`) is genuinely
+nonzero, not the `⊤ ↦ 0` truncation nor a degenerate `0`. Added 3 axiom-free theorems to
+`Erdos116WIP01.lean` (host-verified v4.31.0; `#print axioms` = propext/Classical.choice/
+Quot.sound on all three):
+
+- `volume_sublevelSet_pos` (`ℂ`-side, `0<n`) — `0 < volume Sₚ` from
+  `(isOpen_sublevelSet P).measure_pos volume (sublevelSet_nonempty P hn)`
+  (ℂ `volume` is an `IsOpenPosMeasure`, so the instance resolves with no extra hypotheses).
+- `volume_realProd_sublevelSet_pos` (parent `ℝ×ℝ`-side) — transported across the
+  volume-preserving `ℂ ≃ᵐ ℝ×ℝ`, exact mirror of `volume_realProd_sublevelSet_lt_top`
+  (`realProd_sublevelSet_eq_preimage` + `MeasurePreserving.measure_preimage` on the
+  `nullMeasurableSet`).
+- `sublevelMeasure_pos` (`0<n`) — `0 < sublevelMeasure P` via `ENNReal.toReal_pos`
+  fed the positivity (`.ne'`) and finiteness (`.ne`) facts. Sharpens `sublevelMeasure_nonneg`.
+
+### Remaining open (unchanged)
+- The DEEP quantitative bounds — KLR `c/log n` lower, Pólya `π` upper, the
+  `1/log n` vs `1/log log n` gap — need logarithmic-potential / area-of-lemniscate
+  machinery absent from Mathlib v4.31. Positivity/finiteness give `0 < μ < ⊤` but no
+  quantitative control. Elementary well-definedness layer is now truly complete.
+
 ---
 
 ## Session 2026-07-20 (researcher-1, iter 1 ACT) — sublevel set open / measurable / bounded


### PR DESCRIPTION
## Summary

Sharpens the measure-well-definedness layer of Erdős #116 (Erdős–Herzog–Piranian:
area of the lemniscate `Sₚ = {z : |p(z)| < 1}` for monic `p` with roots in the closed
unit disc). Prior work established that the planar measure is nonnegative and **finite**;
this PR adds the missing **strict positivity**. A nonempty open set in the plane has
positive Lebesgue measure, so `volume(Sₚ)` is pinned in `(0, ⊤)` and the parent's
`sublevelMeasure` (a `.toReal`) is a genuine nonzero real — never the `⊤ ↦ 0`
truncation nor a degenerate `0`.

Three axiom-free theorems added to `proofs/Proofs/Erdos116WIP01.lean`:

- **`volume_sublevelSet_pos`** (`ℂ`-side, `0 < n`) — `0 < volume Sₚ`: `Sₚ` is open
  (`isOpen_sublevelSet`) and nonempty (`sublevelSet_nonempty`, it contains a root), and
  `volume` is an open-positive measure on `ℂ`.
- **`volume_realProd_sublevelSet_pos`** (parent `ℝ×ℝ`-side) — transported across the
  volume-preserving equivalence `ℂ ≃ᵐ ℝ×ℝ` (exact mirror of the existing
  `volume_realProd_sublevelSet_lt_top`).
- **`sublevelMeasure_pos`** — `0 < sublevelMeasure P` for positive degree, via
  `ENNReal.toReal_pos` fed the positivity and finiteness facts. Sharpens the existing
  `sublevelMeasure_nonneg`.

Together with finiteness this completes the elementary well-definedness layer:
`0 < μ < ⊤`. The **deep quantitative bounds** (KLR `c/log n` lower, Pólya `π` upper) are
untouched — they need logarithmic-potential / area-of-lemniscate machinery absent from
Mathlib v4.31.

## Verification

- Host-verified with Lean `v4.31.0` (fresh-parent-olean recipe; no Docker).
- `#print axioms` on all three new theorems = `[propext, Classical.choice, Quot.sound]`
  (axiom-free / 0-sorry).
