### PR TITLE
Enrich: cover 8 stranded capstone decls (tail-undercoverage)

### DIFF
--- a/src/data/proofs/erdos-250/meta.json
+++ b/src/data/proofs/erdos-250/meta.json
@@ -101,7 +101,7 @@
       "id": "numerical",
       "title": "Related Results and Lambert Series",
       "startLine": 145,
-      "endLine": 173,
+      "endLine": 188,
       "summary": "Documents Nesterenko's broader algebraic independence results ($\\pi$, $e^\\pi$, $\\Gamma(1/4)$), discusses connections to modular function values, and defines the Lambert series representation `lambertSeries`."
     }
   ],

--- a/src/data/proofs/erdos-512/meta.json
+++ b/src/data/proofs/erdos-512/meta.json
@@ -188,7 +188,7 @@
       "id": "part11",
       "title": "Part XI: Summary",
       "startLine": 339,
-      "endLine": 368,
+      "endLine": 379,
       "summary": "Closing summary (SOLVED) and the headline theorems: `erdos_512` and `erdos_512_main` (Littlewood's conjecture holds, from `konyagin_theorem`), `erdos_512_solved` (the conjunction), and `konyagin_equals_mps` (both axioms establish the same result).",
       "mathContext": "$\\text{erdos\\_512}:\\text{LittlewoodConjecture}$ (SOLVED, two independent 1981 proofs)."
     }

--- a/src/data/proofs/erdos-746/meta.json
+++ b/src/data/proofs/erdos-746/meta.json
@@ -198,7 +198,7 @@
       "id": "summary",
       "title": "Summary: Problem Completely Solved",
       "startLine": 231,
-      "endLine": 262,
+      "endLine": 271,
       "summary": "Proves `erdos_746`, `erdos_746_main`, `erdos_746_precise`, `erdos_746_solved` — composing axioms to confirm the full resolution.",
       "mathContext": "SOLVED. Sharp threshold: $(1/2)n\\\\log n + (1/2)n\\\\log\\\\log n + cn$ with limiting probability $e^{-e^{-2c}}$. Coincides with connectivity threshold."
     }

--- a/src/data/proofs/erdos-957/meta.json
+++ b/src/data/proofs/erdos-957/meta.json
@@ -151,7 +151,7 @@
       "title": "Summary",
       "summary": "erdos_957_summary: main results and status",
       "startLine": 276,
-      "endLine": 320,
+      "endLine": 330,
       "mathContext": "Mathematical content: erdos_957_summary: main results and status"
     }
   ],

--- a/src/data/proofs/erdos-968/meta.json
+++ b/src/data/proofs/erdos-968/meta.json
@@ -154,7 +154,7 @@
       "id": "summary",
       "title": "Summary",
       "startLine": 203,
-      "endLine": 236,
+      "endLine": 245,
       "summary": "Overview of what we know and the open questions.",
       "mathContext": "Mathematical content: Overview of what we know and the open questions."
     }

--- a/src/data/proofs/erdos-969/meta.json
+++ b/src/data/proofs/erdos-969/meta.json
@@ -123,7 +123,7 @@
       "title": "Summary and Main Theorem",
       "summary": "erdos_969_summary combining all known bounds and open status",
       "startLine": 224,
-      "endLine": 225,
+      "endLine": 232,
       "mathContext": "Bound: erdos_969_summary combining all known bounds and open status"
     }
   ],

--- a/src/data/proofs/inverse-galois-a5-oq-03/meta.json
+++ b/src/data/proofs/inverse-galois-a5-oq-03/meta.json
@@ -121,7 +121,7 @@
       "id": "easy-half",
       "title": "The Easy Half of the Inverse Galois Problem",
       "startLine": 168,
-      "endLine": 192,
+      "endLine": 205,
       "summary": "Every Sₙ and Aₙ is a Galois group over ℚ (restatements of the axioms), plus the derived consistency result that ℤ/2 ≅ Sₙ ⧸ Aₙ is realizable via the proved quotient theorem."
     }
   ],

--- a/src/data/proofs/picks-theorem-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01/meta.json
@@ -123,7 +123,7 @@
       "id": "full-strategy",
       "title": "Part VI: Full Proof Strategy and Triangulation Gap",
       "startLine": 185,
-      "endLine": 206,
+      "endLine": 220,
       "summary": "Documents the remaining gap (primitive triangulation requires computational geometry) and proves `picks_from_triangulation`: given n primitive triangles and Pick's formula for the composite, the formula holds. This is the tautological conclusion that makes the inductive hypothesis explicit."
     }
   ],


### PR DESCRIPTION
Section-coverage pass over the single-stranded-decl tier.

Each of these 8 entries has its **final section end just short of a capstone/summary decl** that the section's own title/summary already references, so the headline result was covered by no section and omitted from the rendered section list. Pure `endLine` extensions to EOF:

| Entry | Section | Now covers |
|-------|---------|------------|
| erdos-746 | Summary: Problem Completely Solved | `theorem erdos_746_solved` @269 |
| erdos-957 | Summary | `def erdos_957_status` @327 |
| erdos-969 | Summary and Main Theorem | `def erdos_969_open_problem` @230 |
| erdos-512 | Part XI: Summary | `theorem konyagin_equals_mps` @375 |
| picks-theorem-oq-01 | Full Proof Strategy | `theorem picks_from_triangulation` @213 |
| inverse-galois-a5-oq-03 | The Easy Half | `theorem quotient_Sn_An_realizableOverRat` @201 |
| erdos-250 | Related Results and Lambert Series | `noncomputable def lambertSeries` @185 |
| erdos-968 | Summary | `theorem erdos_968_summary` @241 |

Each summary already named the decl (e.g. picks-theorem's summary reads "proves `picks_from_triangulation`" while the section ended 7 lines before it). Verified none were already covered on `origin/main` before pushing.

No `status`/`badge`/`axiomCount`/summary changes — pure section range fixes.
