### PR TITLE
Audit: erdos-552 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14534,8 +14534,8 @@
     },
     "erdos-552": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:14Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T20:31:14Z",
       "result": "clean"
     },
     "erdos-553": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-552 (R(C₄,Sₙ), open $100 Erdős problem).

**Verified against meta:** 11 theorems, 16 defs, 12 sorries, 0 axioms, 231 lines — all exact matches. No native_decide, no True stubs, no false/inconsistent axioms (0 axioms). All theorems are honest sorry'd goals for known literature bounds (Parsons 1975, BEFRS 1989); the Erdős question is formalized as `Prop` definitions, not falsely proved. Meta explicitly discloses OPEN status, $100 prize, and 12 remaining sorries. Badge `wip` correct.

Result: **clean**.