### PR TITLE
Enrich: add Overview head sections covering 4 stranded core definitions

### DIFF
--- a/src/data/proofs/buffons-needle-oq007/meta.json
+++ b/src/data/proofs/buffons-needle-oq007/meta.json
@@ -50,9 +50,17 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "The Open Question and Setup",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Module docstring: the open question of proving the Buffon crossing-factor asymptotic αₙ ~ √(2/(πn)) directly from the telescoping products (even Eₘ, odd Oₘ) rather than via Stirling's formula, plus imports, the linter option, and namespace.",
+      "mathContext": "$\\alpha_n = \\mathbb{E}_{S^{n-1}}[|u_1|]$ with recurrence $\\alpha_{n+2} = \\tfrac{n}{n+1}\\alpha_n$, $\\alpha_2 = 2/\\pi$, $\\alpha_3 = 1/2$; the goal is $\\alpha_n \\sim \\sqrt{2/(\\pi n)}$."
+    },
+    {
       "id": "defs-closed-forms",
       "title": "Crossing Factor, Products, and Closed Forms",
-      "startLine": 56,
+      "startLine": 52,
       "endLine": 132,
       "summary": "Re-declares the crossing factor alpha_n and the even/odd telescoping products E_m, O_m, with positivity and successor lemmas, then the closed forms alpha_{2m+2} = (2/pi) E_m and alpha_{2m+3} = (1/2) O_m relating the crossing factor to the products.",
       "mathContext": "alpha_{2m+2} = (2/pi) prod_{j<m}(2j+2)/(2j+3); alpha_{2m+3} = (1/2) prod_{j<m}(2j+3)/(2j+4)."

--- a/src/data/proofs/cayley-hamilton-reduction-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-01/meta.json
@@ -86,9 +86,17 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview: Efficient Reduction for Sparse Matrices",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Module docstring: the open question of making the Cayley–Hamilton reduction aeval A p = aeval A (p %ₘ charpoly A) efficient for sparse matrices, answered positively for upper-triangular, block-triangular, and nilpotent structures, with imports and namespace.",
+      "mathContext": "For structured sparsity the charpoly cost drops from $O(n^3)$ (dense determinant) to $O(n)$ (upper-triangular: $\\prod_i (X - M_{ii})$) or $O(nk)$ (block-triangular with k blocks)."
+    },
+    {
       "id": "general",
       "title": "General Results",
-      "startLine": 58,
+      "startLine": 55,
       "endLine": 71,
       "summary": "Matrix charpoly is always monic (wrapper theorem for Mathlib's charpoly_monic)."
     },

--- a/src/data/proofs/matrix-similarity-invariants-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/matrix-similarity-invariants-oq-01-oq-01-oq-02/meta.json
@@ -85,6 +85,14 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview and the Similarity Relation",
+      "startLine": 1,
+      "endLine": 62,
+      "summary": "Module docstring framing the open question — upgrade the companion entry's equality of kernel dimensions to an explicit functorial kernel isomorphism kerEquiv : ker B ≃ₗ[K] ker A — plus imports, namespace, and the core relation Similar (B = P·A·P⁻¹ for an invertible P).",
+      "mathContext": "$A \\sim B \\iff \\exists P \\in (\\mathrm{Matrix}\\,n\\,n\\,K)^\\times,\\ B = P A P^{-1}$. Conjugation is a change of basis carrying $\\ker B$ to $\\ker A$ via $x \\mapsto P^{-1} \\cdot x$."
+    },
+    {
       "id": "intertwine",
       "title": "The Conjugation Identities",
       "startLine": 63,

--- a/src/data/proofs/stirling-formula-oq-02-oq-01/meta.json
+++ b/src/data/proofs/stirling-formula-oq-02-oq-01/meta.json
@@ -92,6 +92,14 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview and the Log-Approximation Definition",
+      "startLine": 1,
+      "endLine": 61,
+      "summary": "Module docstring: the continuous Stirling formula Γ(x+1) ~ √(2πx)·(x/e)^x and its log form, derived from log-convexity of Γ (Bohr–Mollerup) with no Laplace method — plus imports, namespace, and the core def logApprox y = ½·log(2πy) + y·log y − y.",
+      "mathContext": "$\\mathrm{logApprox}(y) = \\tfrac12\\log(2\\pi y) + y\\log y - y = \\log\\bigl(\\sqrt{2\\pi y}\\,(y/e)^y\\bigr)$; the target is $\\log\\Gamma(x+1) - \\mathrm{logApprox}(x) \\to 0$."
+    },
+    {
       "id": "part-1-error-estimate",
       "title": "PART 1: Elementary Error Estimate",
       "startLine": 62,


### PR DESCRIPTION
Section-coverage pass (head-undercoverage sub-class).

In each of these 4 entries the first section began *after* the module docstring, imports, and the file's **core definition**, so that definition — and the problem statement — were covered by no section and omitted from the rendered section list. Added a concise `Overview` head section, extending section 1's `startLine` where the stranded decl matches its theme:

| Entry | Fix | Now covers |
|-------|-----|------------|
| matrix-similarity-invariants-oq-01-oq-01-oq-02 | +Overview [1-62] | `def Similar` @60 |
| stirling-formula-oq-02-oq-01 | +Overview [1-61] | `noncomputable def logApprox` @59 |
| buffons-needle-oq007 | +Overview [1-51], §1 start 56→52 | `noncomputable def crossingFactor` @55 |
| cayley-hamilton-reduction-oq-01 | +Overview [1-54], §1 start 58→55 | `theorem matrix_charpoly_monic` @56 |

Each head summary reflects the actual module docstring (the open question and the core definition). Verified none were already covered on `origin/main` before pushing; all sections remain contiguous to EOF.

No `status`/`badge`/`axiomCount` changes — section coverage only.
