### PR TITLE
Audit: erdos-553 re-serve clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14540,8 +14540,8 @@
     },
     "erdos-553": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:14Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T20:35:16Z",
       "result": "clean"
     },
     "erdos-554": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-553 (queue drained, round-robin oldest).

**Verdict: CLEAN** — all-sorry Tier-C scaffold, fully disclosed.

- sorries: 15 claimed = 15 actual
- axiomCount: 0 = actual; True stubs: 0; native_decide: 0
- theoremCount: 12 = actual
- badge `wip` (honest for all-sorry scaffold)
- Prose uses statement/definition language ('Statement of', 'Formal definition', 'formalization captures/includes') — no 'Proves' overclaim on sorry'd theorems; 'Solved by Alon-Rödl' attributes to authors.

Tracker bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)