### PR TITLE
Enrich: cover 5 stranded decls in interior section holes

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03-oq-02-oq-01/meta.json
@@ -91,7 +91,7 @@
       "id": "reverse-holder",
       "title": "Reverse Holder Inequality (0 < p < 1)",
       "summary": "reverse_holder: for nonnegative u and strictly positive v, (sum u^p)^(1/p) * (sum v^(p/(p-1)))^(1/(p/(p-1))) <= sum u*v. Derived from forward Holder applied to the conjugate pair P = 1/p, P' = 1/(1-p) on f = (uv)^p, g = v^(-p).",
-      "startLine": 78,
+      "startLine": 65,
       "endLine": 142,
       "mathContext": "The engine. Forward Holder with $f_i = (u_iv_i)^p$, $g_i = v_i^{-p}$ gives $\\sum u_i^p \\leq (\\sum u_iv_i)^p(\\sum v_i^q)^{1-p}$; raising to $1/p$ and reorganising yields reverse Holder. The conjugate exponent $q = p/(p-1)$ is negative."
     },

--- a/src/data/proofs/erdos-228/meta.json
+++ b/src/data/proofs/erdos-228/meta.json
@@ -113,6 +113,13 @@
       "summary": "Equivalent statement with explicit bounds."
     },
     {
+      "id": "historical",
+      "title": "Historical Context",
+      "startLine": 114,
+      "endLine": 128,
+      "summary": "Historical note: Littlewood posed the flat-polynomial problem (1966); Erdős popularized it as the 'Littlewood conjecture', with partial results through the 2010s and the full BBMST resolution in 2019. `littlewood_original` is a True-valued placeholder recording the historical statement."
+    },
+    {
       "id": "related",
       "title": "Related Problems",
       "startLine": 129,

--- a/src/data/proofs/erdos-627/meta.json
+++ b/src/data/proofs/erdos-627/meta.json
@@ -165,14 +165,14 @@
       "title": "Explicit Constructions",
       "summary": "Defines Mycielski graphs ($\\omega = 2$, $\\chi = k$) and Kneser graphs $K(n,k)$. Axiomatizes Lovász's theorem $\\chi(K(n,k)) = n - 2k + 2$ (1978, via Borsuk-Ulam).",
       "startLine": 185,
-      "endLine": 204,
+      "endLine": 208,
       "mathContext": "Formal definition: Defines Mycielski graphs ($\\omega = 2$, $\\chi = k$) and Kneser graphs $K(n,k)$. Axiomatizes Lovász's theorem $\\chi(K(n,k)) = n - 2k + 2$ (1978, via Borsuk-Ulam)."
     },
     {
       "id": "main-status",
       "title": "Main Problem Status",
       "summary": "Combines the Erdős asymptotic and Tutte-Zykov construction into `erdos_627_status`, proving both hold simultaneously. Includes `#check` commands for key axioms.",
-      "startLine": 224,
+      "startLine": 209,
       "endLine": 236,
       "mathContext": "Axiomatized: Combines the Erdős asymptotic and Tutte-Zykov construction into `erdos_627_status`, proving both hold simultaneously. Includes `#check` commands for key axioms."
     }

--- a/src/data/proofs/erdos-878/meta.json
+++ b/src/data/proofs/erdos-878/meta.json
@@ -106,7 +106,7 @@
       "id": "conjecture-F",
       "title": "Conjecture on F(n)",
       "summary": "Conjecture_F_almost_all",
-      "startLine": 172,
+      "startLine": 156,
       "endLine": 181
     },
     {

--- a/src/data/proofs/erdos-928/meta.json
+++ b/src/data/proofs/erdos-928/meta.json
@@ -149,14 +149,14 @@
       "title": "Elliott-Halberstam Conjecture",
       "summary": "elliott_halberstam_conjecture",
       "startLine": 208,
-      "endLine": 219,
+      "endLine": 223,
       "mathContext": "EH conjecture: $\\sum_{q \\le x^{1-\\varepsilon}} \\max_{(a,q)=1} |\\pi(x;q,a) - \\text{li}(x)/\\varphi(q)| \\ll x/(\\log x)^A$. Strengthens Bombieri-Vinogradov ($q \\le x^{1/2}$)."
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_928_summary, erdos_928 main theorem",
-      "startLine": 239,
+      "startLine": 224,
       "endLine": 259,
       "mathContext": "OPEN unconditionally. Known: $\\infty$-many exist, log density $= \\rho(1/\\alpha)\\rho(1/\\beta)$, natural density $= \\rho(1/\\alpha)\\rho(1/\\beta)$ conditional on EH. The gap between logarithmic and natural density is the core difficulty."
     }


### PR DESCRIPTION
Section-coverage pass (interior-hole sub-class).

In each entry a decl — together with its `/- ## banner -/` and docstring — fell in a gap between two sections because the adjacent section was anchored *past* its own banner. Re-anchored the boundaries (and added one missing section):

| Entry | Fix | Now covers |
|-------|-----|------------|
| erdos-627 | `Main Problem Status` start 224→209 (banner @209), prev end 204→208 | `theorem erdos_627_status` @223 |
| erdos-928 | `Part X: Summary` start 239→224 (banner @224), prev end 219→223 | `theorem erdos_928_summary` @234 |
| erdos-878 | `Conjecture on F(n)` start 172→156 (banner @165) | `def Conjecture_F_almost_all` @169 |
| cauchy-schwarz-oq-03-oq-02-oq-01 | `Reverse Holder Inequality` start 78→65 (docstring @66) | `theorem reverse_holder` @76 |
| erdos-228 | added missing `Historical Context` section [114-128] | `theorem littlewood_original` @126 |

Verified none were already covered on `origin/main` before pushing; all sections remain contiguous.

No `status`/`badge`/`axiomCount` changes — section coverage only.
