### PR TITLE
Research: erdos-89-wip-01 — g(6) ≤ 3 via regular pentagon + circumcentre (axiom-free)

### DIFF
--- a/proofs/Proofs/Erdos89WIP01.lean
+++ b/proofs/Proofs/Erdos89WIP01.lean
@@ -953,4 +953,170 @@ Combined with `g(0)=g(1)=0, g(2)=g(3)=1, g(4)=2`, this completes the exact table
 theorem minDistinctDistances_five : minDistinctDistances 5 = 2 :=
   le_antisymm minDistinctDistances_five_le_two two_le_minDistinctDistances_five
 
+/-!
+### The regular pentagon plus its centre: `g(6) ≤ 3`
+
+Adding the circumcentre `O = (0,0)` to the regular pentagon of circumradius `4`
+gives a `6`-point configuration.  Every pentagon vertex has norm `4`, so each of
+the five new distances `O Pᵢ` equals the circumradius `4`.  The ten intra-pentagon
+distances are the two values `√(40 − 8√5)` (side) and `√(40 + 8√5)` (diagonal)
+already computed for `g(5) = 2`.  Hence the whole configuration realizes only the
+three distances `{4, √(40 − 8√5), √(40 + 8√5)}`, giving `g(6) ≤ 3`.
+
+This is the upper half of the conjectured value `g(6) = 3`.  The matching lower
+bound `g(6) ≥ 3` is equivalent to the sharp planar statement "a two-distance set
+in `ℝ²` has at most `5` points" (Kelly / Erdős), which lies strictly beyond the
+Larman–Rogers–Seidel ceiling `≤ (d+1)(d+2)/2 = 6` available by the elementary
+rank bound and is left as the open lower-bound direction.
+-/
+
+/-- The circumcentre `O = (0,0)` of the regular pentagon. -/
+noncomputable def pentCenter : EuclideanSpace ℝ (Fin 2) := !₂[0, 0]
+
+-- Each pentagon vertex lies at distance `4` (the circumradius) from the centre.
+
+theorem dist_centerP0 : Erdos89.dist pentCenter pentP0 = 4 := by
+  rw [pentCenter, pentP0, dist_eqPts]
+  rw [show ((0 : ℝ) - 4) ^ 2 + ((0 : ℝ) - 0) ^ 2 = 4 ^ 2 by norm_num,
+    Real.sqrt_sq (by norm_num)]
+theorem dist_centerP1 : Erdos89.dist pentCenter pentP1 = 4 := by
+  rw [pentCenter, pentP1, dist_eqPts]
+  rw [show ((0 : ℝ) - (Real.sqrt 5 - 1)) ^ 2 + ((0 : ℝ) - Real.sqrt (10 + 2 * Real.sqrt 5)) ^ 2
+      = 4 ^ 2 by linear_combination pent_s_sq + pent_t1_sq, Real.sqrt_sq (by norm_num)]
+theorem dist_centerP2 : Erdos89.dist pentCenter pentP2 = 4 := by
+  rw [pentCenter, pentP2, dist_eqPts]
+  rw [show ((0 : ℝ) - -(Real.sqrt 5 + 1)) ^ 2 + ((0 : ℝ) - Real.sqrt (10 - 2 * Real.sqrt 5)) ^ 2
+      = 4 ^ 2 by linear_combination pent_s_sq + pent_t2_sq, Real.sqrt_sq (by norm_num)]
+theorem dist_centerP3 : Erdos89.dist pentCenter pentP3 = 4 := by
+  rw [pentCenter, pentP3, dist_eqPts]
+  rw [show ((0 : ℝ) - -(Real.sqrt 5 + 1)) ^ 2 + ((0 : ℝ) - -Real.sqrt (10 - 2 * Real.sqrt 5)) ^ 2
+      = 4 ^ 2 by linear_combination pent_s_sq + pent_t2_sq, Real.sqrt_sq (by norm_num)]
+theorem dist_centerP4 : Erdos89.dist pentCenter pentP4 = 4 := by
+  rw [pentCenter, pentP4, dist_eqPts]
+  rw [show ((0 : ℝ) - (Real.sqrt 5 - 1)) ^ 2 + ((0 : ℝ) - -Real.sqrt (10 + 2 * Real.sqrt 5)) ^ 2
+      = 4 ^ 2 by linear_combination pent_s_sq + pent_t1_sq, Real.sqrt_sq (by norm_num)]
+
+-- The centre is distinct from every vertex (all vertices have norm `4 ≠ 0`).
+
+theorem pentCenter_ne_pentP0 : pentCenter ≠ pentP0 := by
+  intro h; have h0 := congrArg (fun p => p 0) h
+  simp only [pentCenter, pentP0, Matrix.cons_val_zero] at h0; norm_num at h0
+theorem pentCenter_ne_pentP1 : pentCenter ≠ pentP1 := by
+  intro h; have h1 := congrArg (fun p => p 1) h
+  simp only [pentCenter, pentP1, Matrix.cons_val_one, Matrix.cons_val_zero] at h1
+  have hu : (0 : ℝ) < Real.sqrt (10 + 2 * Real.sqrt 5) := Real.sqrt_pos.mpr (by positivity)
+  linarith
+theorem pentCenter_ne_pentP2 : pentCenter ≠ pentP2 := by
+  intro h; have h0 := congrArg (fun p => p 0) h
+  simp only [pentCenter, pentP2, Matrix.cons_val_zero] at h0
+  have := Real.sqrt_nonneg 5; linarith
+theorem pentCenter_ne_pentP3 : pentCenter ≠ pentP3 := by
+  intro h; have h0 := congrArg (fun p => p 0) h
+  simp only [pentCenter, pentP3, Matrix.cons_val_zero] at h0
+  have := Real.sqrt_nonneg 5; linarith
+theorem pentCenter_ne_pentP4 : pentCenter ≠ pentP4 := by
+  intro h; have h1 := congrArg (fun p => p 1) h
+  simp only [pentCenter, pentP4, Matrix.cons_val_one, Matrix.cons_val_zero] at h1
+  have hu : (0 : ℝ) < Real.sqrt (10 + 2 * Real.sqrt 5) := Real.sqrt_pos.mpr (by positivity)
+  linarith
+
+/-- The regular pentagon together with its circumcentre, a `6`-point configuration. -/
+noncomputable def pentagonPlusCenter : Finset (EuclideanSpace ℝ (Fin 2)) :=
+  {pentCenter, pentP0, pentP1, pentP2, pentP3, pentP4}
+
+/-- The configuration has six distinct points. -/
+theorem pentagonPlusCenter_card : pentagonPlusCenter.card = 6 := by
+  rw [pentagonPlusCenter, Finset.card_insert_of_notMem, Finset.card_insert_of_notMem,
+    Finset.card_insert_of_notMem, Finset.card_insert_of_notMem, Finset.card_insert_of_notMem,
+    Finset.card_singleton]
+  · simp only [Finset.mem_singleton]; exact pentP3_ne_pentP4
+  · simp only [Finset.mem_insert, Finset.mem_singleton, not_or]
+    exact ⟨pentP2_ne_pentP3, pentP2_ne_pentP4⟩
+  · simp only [Finset.mem_insert, Finset.mem_singleton, not_or]
+    exact ⟨pentP1_ne_pentP2, pentP1_ne_pentP3, pentP1_ne_pentP4⟩
+  · simp only [Finset.mem_insert, Finset.mem_singleton, not_or]
+    exact ⟨pentP0_ne_pentP1, pentP0_ne_pentP2, pentP0_ne_pentP3, pentP0_ne_pentP4⟩
+  · simp only [Finset.mem_insert, Finset.mem_singleton, not_or]
+    exact ⟨pentCenter_ne_pentP0, pentCenter_ne_pentP1, pentCenter_ne_pentP2,
+      pentCenter_ne_pentP3, pentCenter_ne_pentP4⟩
+
+/-- **The pentagon-plus-centre determines at most three distances.**  Every pairwise
+distance is a pentagon side `√(40−8√5)`, a pentagon diagonal `√(40+8√5)`, or a
+centre-to-vertex spoke `4` (the circumradius). -/
+theorem numDistinctDistances_pentagonPlusCenter_le_three :
+    numDistinctDistances pentagonPlusCenter ≤ 3 := by
+  have hsub : distinctDistances pentagonPlusCenter ⊆
+      ({Real.sqrt (40 - 8 * Real.sqrt 5), Real.sqrt (40 + 8 * Real.sqrt 5), (4 : ℝ)}
+        : Finset ℝ) := by
+    rw [distinctDistances_eq_image]
+    intro d hd
+    rw [Finset.mem_image] at hd
+    obtain ⟨⟨p, q⟩, hpq, rfl⟩ := hd
+    rw [Finset.mem_offDiag] at hpq
+    obtain ⟨hp, hq, hne⟩ := hpq
+    simp only [pentagonPlusCenter, Finset.mem_insert, Finset.mem_singleton] at hp hq
+    simp only [Finset.mem_insert, Finset.mem_singleton]
+    rcases hp with rfl | rfl | rfl | rfl | rfl | rfl <;>
+      rcases hq with rfl | rfl | rfl | rfl | rfl | rfl <;>
+      first
+        | exact absurd rfl hne
+        | (right; right; exact dist_centerP0)
+        | (right; right; exact dist_centerP1)
+        | (right; right; exact dist_centerP2)
+        | (right; right; exact dist_centerP3)
+        | (right; right; exact dist_centerP4)
+        | (right; right; rw [dist_comm']; exact dist_centerP0)
+        | (right; right; rw [dist_comm']; exact dist_centerP1)
+        | (right; right; rw [dist_comm']; exact dist_centerP2)
+        | (right; right; rw [dist_comm']; exact dist_centerP3)
+        | (right; right; rw [dist_comm']; exact dist_centerP4)
+        | (left; exact dist_pent01)
+        | (left; exact dist_pent12)
+        | (left; exact dist_pent23)
+        | (left; exact dist_pent34)
+        | (left; exact dist_pent40)
+        | (left; rw [dist_comm']; exact dist_pent01)
+        | (left; rw [dist_comm']; exact dist_pent12)
+        | (left; rw [dist_comm']; exact dist_pent23)
+        | (left; rw [dist_comm']; exact dist_pent34)
+        | (left; rw [dist_comm']; exact dist_pent40)
+        | (right; left; exact dist_pent02)
+        | (right; left; exact dist_pent03)
+        | (right; left; exact dist_pent13)
+        | (right; left; exact dist_pent14)
+        | (right; left; exact dist_pent24)
+        | (right; left; rw [dist_comm']; exact dist_pent02)
+        | (right; left; rw [dist_comm']; exact dist_pent03)
+        | (right; left; rw [dist_comm']; exact dist_pent13)
+        | (right; left; rw [dist_comm']; exact dist_pent14)
+        | (right; left; rw [dist_comm']; exact dist_pent24)
+  calc numDistinctDistances pentagonPlusCenter
+      ≤ ({Real.sqrt (40 - 8 * Real.sqrt 5), Real.sqrt (40 + 8 * Real.sqrt 5), (4 : ℝ)}
+          : Finset ℝ).card := Finset.card_le_card hsub
+    _ ≤ 3 := by
+        have h1 := Finset.card_insert_le (Real.sqrt (40 - 8 * Real.sqrt 5))
+          ({Real.sqrt (40 + 8 * Real.sqrt 5), (4 : ℝ)} : Finset ℝ)
+        have h2 := Finset.card_insert_le (Real.sqrt (40 + 8 * Real.sqrt 5))
+          ({(4 : ℝ)} : Finset ℝ)
+        simp only [Finset.card_singleton] at h2
+        omega
+
+/-- **Upper bound `g(6) ≤ 3`.**  The regular pentagon plus its circumcentre is a
+`6`-point witness with at most three distinct distances.  This is the upper half of the
+conjectured value `g(6) = 3`; the lower bound `g(6) ≥ 3` is the sharp planar two-distance
+statement (a two-distance set in `ℝ²` has `≤ 5` points), beyond the elementary rank
+ceiling. -/
+theorem minDistinctDistances_six_le_three : minDistinctDistances 6 ≤ 3 :=
+  le_trans (minDistinctDistances_le_of_card_eq pentagonPlusCenter_card)
+    numDistinctDistances_pentagonPlusCenter_le_three
+
+/-- **Sandwich `2 ≤ g(6) ≤ 3`.**  The lower bound is the general floor lifted through
+monotonicity (`g(6) ≥ g(5) = 2`); the upper bound is the pentagon-plus-centre witness.
+Pinning `g(6) = 3` requires the sharp two-distance-set bound, left open. -/
+theorem minDistinctDistances_six_mem_Icc :
+    minDistinctDistances 6 ∈ Set.Icc 2 3 := by
+  refine ⟨?_, minDistinctDistances_six_le_three⟩
+  calc 2 = minDistinctDistances 5 := minDistinctDistances_five.symm
+    _ ≤ minDistinctDistances 6 := minDistinctDistances_mono (by norm_num)
+
 end Erdos89

--- a/proofs/Proofs/Erdos89WIP01.lean
+++ b/proofs/Proofs/Erdos89WIP01.lean
@@ -1040,6 +1040,7 @@ theorem pentagonPlusCenter_card : pentagonPlusCenter.card = 6 := by
     exact ⟨pentCenter_ne_pentP0, pentCenter_ne_pentP1, pentCenter_ne_pentP2,
       pentCenter_ne_pentP3, pentCenter_ne_pentP4⟩
 
+set_option maxHeartbeats 1600000 in
 /-- **The pentagon-plus-centre determines at most three distances.**  Every pairwise
 distance is a pentagon side `√(40−8√5)`, a pentagon diagonal `√(40+8√5)`, or a
 centre-to-vertex spoke `4` (the circumradius). -/

--- a/research/problems/erdos-89-wip-01/knowledge.md
+++ b/research/problems/erdos-89-wip-01/knowledge.md
@@ -4,6 +4,51 @@ Insights accumulated during research on this problem.
 
 ---
 
+## Session 2026-07-21 (researcher-1) — upper bound `g(6) ≤ 3` (regular pentagon + circumcentre)
+
+**Mode**: continue RICH node (g(5)=2 was the previous milestone). **Outcome**:
+progress — added the next rung of the exact table, `g(6) ≤ 3`, Docker-verified
+(`Proofs.Erdos89WIP01`, 8577 jobs), all new decls `#print axioms` =
+`[propext, Classical.choice, Quot.sound]` (0 sorry / 0 axiom).
+
+### What I added (`proofs/Proofs/Erdos89WIP01.lean`, +~150 lines)
+- `pentCenter := !₂[0,0]` — the circumcentre of the (circumradius-4) regular pentagon.
+- `dist_centerP0..4 : Erdos89.dist pentCenter pentPᵢ = 4` — each vertex is at the
+  circumradius from the centre. `rw [pentCenter, pentPᵢ, dist_eqPts]` then rewrite the
+  radicand to `4^2` by `linear_combination pent_s_sq (+ pent_t1_sq | + pent_t2_sq)`,
+  finish `Real.sqrt_sq`. (P0 needs no `linear_combination`, just `norm_num`.)
+- `pentCenter_ne_pentPᵢ` — centre distinct from each vertex (norm 4 ≠ 0), by a coord
+  projection + `Real.sqrt_nonneg`/`sqrt_pos`.
+- `pentagonPlusCenter` (6 points) + `pentagonPlusCenter_card = 6`.
+- `numDistinctDistances_pentagonPlusCenter_le_three` — the 15 pairwise distances lie in
+  `{√(40−8√5), √(40+8√5), 4}`, mirroring the g(5) `numDistinctDistances_pentagon_le_two`
+  proof but with a 6×6 `rcases` and the 3-element target set. **Needed
+  `set_option maxHeartbeats 1600000 in` (before the docstring)** — the 36-case ×
+  ~30-alternative `first |` combinator overruns the 200000 default (isDefEq/whnf timeout).
+- `minDistinctDistances_six_le_three : g(6) ≤ 3` (via `minDistinctDistances_le_of_card_eq`).
+- `minDistinctDistances_six_mem_Icc : g(6) ∈ [2,3]` — floor from monotonicity
+  `g(6) ≥ g(5) = 2` (`minDistinctDistances_mono`), ceiling the pentagon+centre witness.
+
+### Key findings / reusable recipe
+- **Centre-to-vertex = circumradius reuse**: the pentagon+centre config recycles ALL ten
+  g(5) side/diagonal distance lemmas; only the 5 spokes are new, and they collapse to the
+  single value `4` because each vertex has norm exactly `4` (radicand → `16 = 4²`).
+- The `first |`-combinator distance-dispatch scales O(pairs × alternatives): 5-pt pentagon
+  (25×20) fits default heartbeats, 6-pt (36×30) does NOT — bump to ~1.6M.
+
+### Why only the upper bound (the remaining gap)
+- `g(6) = 3` is conjectural; the matching **lower bound `g(6) ≥ 3`** is equivalent to the
+  SHARP planar statement "a two-distance set in `ℝ²` has ≤ 5 points" (Kelly/Erdős). The
+  elementary Larman–Rogers–Seidel rank bound only gives `≤ (d+1)(d+2)/2 = 6` for `d=2`,
+  which does NOT exclude a 6-point two-distance set — so `g(6) ≥ 3` needs the extra
+  Blokhuis-type refinement and is left open (documented in the file docstring).
+
+### Next steps
+- `g(6) ≥ 3` via the sharp two-distance ≤ 5 bound (deep).
+- `√n×√n` integer grid toward the conjectured `Θ(n/√(log n))` rate.
+
+---
+
 ## Problem Understanding
 
 [Initial observations about the problem will be recorded here]

--- a/src/data/research/problems/erdos-89-wip-01.json
+++ b/src/data/research/problems/erdos-89-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Exact table pinned through n=5 (axiom-free): g(0)=g(1)=0, g(2)=g(3)=1, g(4)=2, g(5)=2. g(5)=2 closed this session via the regular pentagon (minDistinctDistances_five): circumradius-4 vertices (±(√5∓1), ±√(10±2√5)) give exactly 2 squared distances 40∓8√5 (5 sides / 5 diagonals) ⇒ g(5) ≤ 2, matching the general floor g(5) ≥ 2 (two_le_minDistinctDistances_five). Linear upper bound g(n) ≤ n−1 (AP); deep Guth–Katz Ω(n/log n) imported. Next: g(6) (needs a 6-point construction; no 2-distance 6-set exists in the plane so g(6) ≥ 3, upper bound is a real construction) and the √n×√n grid toward Θ(n/√(log n)).",
+    "progressSummary": "PROGRESS (2026-07-21, researcher-1): g(6) ≤ 3 shipped axiom-free via the regular pentagon plus its circumcentre (minDistinctDistances_six_le_three; Docker-verified). The 5 centre-to-vertex spokes all equal the circumradius 4, and the 10 intra-pentagon distances reuse the g(5)=2 side/diagonal values, so the 6-point config realizes exactly the 3 distances {4, √(40−8√5), √(40+8√5)}. Combined with monotonicity g(6) ≥ g(5) = 2 this sandwiches g(6) ∈ [2,3] (minDistinctDistances_six_mem_Icc). Exact table still pinned through n=5: g(0)=g(1)=0, g(2)=g(3)=1, g(4)=g(5)=2. Pinning g(6)=3 needs the sharp two-distance-set ≤ 5-points bound (deep, beyond LRS rank ≤ 6).",
     "builtItems": [
       "Erdos89.dist_pos_of_ne in Erdos89WIP01.lean",
       "Erdos89.distinctDistances_eq_image (filter redundant) in Erdos89WIP01.lean",
@@ -63,7 +63,12 @@
       "pentP0..pentP4, pentagon (regular-pentagon config, circumradius 4) in Erdos89WIP01.lean",
       "dist_pent01/12/23/34/40 (=√(40−8√5) sides) and dist_pent02/03/13/14/24 (=√(40+8√5) diagonals) in Erdos89WIP01.lean",
       "pentagon_card = 5 (10 pairwise pentP_i ≠ pentP_j lemmas) in Erdos89WIP01.lean",
-      "numDistinctDistances_pentagon_le_two, minDistinctDistances_five_le_two, minDistinctDistances_five : minDistinctDistances 5 = 2 in Erdos89WIP01.lean"
+      "numDistinctDistances_pentagon_le_two, minDistinctDistances_five_le_two, minDistinctDistances_five : minDistinctDistances 5 = 2 in Erdos89WIP01.lean",
+      "pentCenter + dist_centerP0..4: each pentagon vertex is at distance 4 (circumradius) from the centre O=(0,0), via dist_eqPts + linear_combination pent_s_sq/pent_t1_sq/pent_t2_sq (Erdos89WIP01.lean)",
+      "pentagonPlusCenter (6-point config) + pentagonPlusCenter_card = 6",
+      "numDistinctDistances_pentagonPlusCenter_le_three: the 15 pairwise distances lie in {4, √(40−8√5), √(40+8√5)} ⇒ ≤ 3 (Erdos89WIP01.lean)",
+      "minDistinctDistances_six_le_three: g(6) ≤ 3 (axiom-free)",
+      "minDistinctDistances_six_mem_Icc: sandwich g(6) ∈ [2,3] (floor via monotonicity g(6) ≥ g(5) = 2)"
     ],
     "insights": [
       "distinctDistances S filters (·>0) over the off-diagonal image, but every off-diagonal pair (p≠q) already has ‖p−q‖>0, so the filter is redundant: distinctDistances S = S.offDiag.image (dist · ·). This removes the awkward filter for all downstream cardinality reasoning.",
@@ -78,13 +83,15 @@
       "no_four_equidistant: four points at a common positive pairwise distance r give three difference vectors (b−a,c−a,d−a) of norm r with pairwise inner product r²/2 (from ‖x−y‖²=2r²−2⟨x,y⟩=r²), a positive-definite Gram matrix ⟹ linearly independent ⟹ finrank ≥ 3, contradicting finrank ℝ (EuclideanSpace ℝ (Fin 2)) = 2. Linear independence extracted by taking inner products of Σgᵢ·vᵢ=0 against u,v,w and solving the Gram system via linear_combination (sum ⟹ Σg=0; each ⟹ (r²/2)gᵢ=0).",
       "General lower bound g(n) ≥ 2 for all n ≥ 4 (two_le_minDistinctDistances): the no_four_equidistant obstruction from the g(4) proof survives adding points, since any ≥4-point set contains a 4-point subset. Subsumes g(4)≥2 and pins g(5)≥2. Axiom-free.",
       "g(5) = 2 CLOSED (axiom-free): the regular pentagon is the planar 2-distance witness for the g(5) ≤ 2 upper bound, matching the general floor g(5) ≥ 2.",
-      "Nested-radical distance computation is tractable via congr 1 + linear_combination: for pentagon of circumradius 4 the squared distances are 40∓8√5, and the only nonlinear identity needed is t1·t2 = 4√5 (t1=√(10+2√5), t2=√(10−2√5)), from (10+2√5)(10−2√5)=80=(4√5)²."
+      "Nested-radical distance computation is tractable via congr 1 + linear_combination: for pentagon of circumradius 4 the squared distances are 40∓8√5, and the only nonlinear identity needed is t1·t2 = 4√5 (t1=√(10+2√5), t2=√(10−2√5)), from (10+2√5)(10−2√5)=80=(4√5)².",
+      "g(6) ≤ 3 realized by regular pentagon + circumcentre: 10 intra-pentagon distances reuse the g(5) side/diagonal values; 5 centre-to-vertex spokes all equal the circumradius 4 ⇒ exactly 3 distinct distances.",
+      "The matching lower bound g(6) ≥ 3 is equivalent to the SHARP planar two-distance statement (a 2-distance set in ℝ² has ≤ 5 points, Kelly/Erdős), which is strictly beyond the elementary Larman–Rogers–Seidel rank ceiling ≤ (d+1)(d+2)/2 = 6 — so g(6) = 3 stays the open lower-bound direction."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Exact g(4): the unit square (0,0),(1,0),(0,1),(1,1) has distances {1, sqrt2} -> 2 distinct; g(4)>=2 needs ruling out a 4-point set with 1 distance (a regular simplex, impossible in R^2). Prove g(4)=2.",
-      "sqrt(n) x sqrt(n) grid upper bound toward g(n)=Theta(n/sqrt(log n)) - deep, needs the number-theoretic count of distinct distances in a square grid.",
-      "Guth-Katz Omega(n/log n) lower bound stays an imported assumption."
+      "g(6) ≥ 3: prove no 6-point two-distance set exists in ℝ² (sharp two-distance bound ≤ 5 pts) — deep, beyond the LRS rank ≤ 6 ceiling.",
+      "g(6) upper: alternatively a 3-distance 6-set (e.g. regular hexagon, or 5-pt 2-distance + 1) — pentagon+centre already gives ≤ 3.",
+      "√n×√n integer grid toward the conjectured Θ(n/√(log n)) rate."
     ],
     "markdown": "# Knowledge Base: erdos-89-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Adds the next rung of the exact table for Erdős #89's distinct-distance function
`g(n) = minDistinctDistances n` (minimum number of distinct pairwise distances over
all `n`-point planar sets): the **upper bound `g(6) ≤ 3`**, via the regular pentagon
plus its circumcentre.

Previously pinned (axiom-free) in `Erdos89WIP01.lean`: `g(0)=g(1)=0`, `g(2)=g(3)=1`,
`g(4)=2`, `g(5)=2` (regular pentagon). This PR builds directly on that pentagon.

## Construction

Take the regular pentagon of circumradius `4` centred at the origin, and add the
centre `O = (0,0)` as a sixth point:

- Each vertex has norm exactly `4`, so all five **centre-to-vertex spokes** equal the
  circumradius `4`.
- The ten **intra-pentagon** distances are the two already-proven values
  `√(40 − 8√5)` (side) and `√(40 + 8√5)` (diagonal).

Hence the 6-point configuration realizes exactly the three distances
`{4, √(40 − 8√5), √(40 + 8√5)}`, giving `g(6) ≤ 3`.

## New declarations (all `#print axioms` = `[propext, Classical.choice, Quot.sound]`)

- `pentCenter`, `dist_centerP0..4` — each spoke equals the circumradius `4`.
- `pentCenter_ne_pentP0..4`, `pentagonPlusCenter`, `pentagonPlusCenter_card = 6`.
- `numDistinctDistances_pentagonPlusCenter_le_three` — the 15 pairwise distances lie in
  a 3-element set.
- `minDistinctDistances_six_le_three` — **`g(6) ≤ 3`**.
- `minDistinctDistances_six_mem_Icc` — sandwich **`g(6) ∈ [2,3]`** (floor via monotonicity
  `g(6) ≥ g(5) = 2`).

## Scope / honesty

Only the **upper** half of the conjectured `g(6) = 3`. The matching lower bound
`g(6) ≥ 3` is equivalent to the sharp planar statement "a two-distance set in `ℝ²` has
at most `5` points" (Kelly/Erdős), which lies strictly beyond the elementary
Larman–Rogers–Seidel rank ceiling `≤ (d+1)(d+2)/2 = 6` — left as the open lower-bound
direction and documented in the file.

## Verification

- Docker build `Proofs.Erdos89WIP01` succeeds (8577 jobs).
- `#print axioms` on all new results: `[propext, Classical.choice, Quot.sound]` — 0 sorry,
  0 axiom.
