### PR TITLE
Audit: erdos-548 CRITICAL inconsistent axioms (issue #40912)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14501,9 +14501,9 @@
     },
     "erdos-548": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:14Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T20:44:59Z",
+      "result": "issues-found"
     },
     "erdos-549": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Tracker update for erdos-548 audit → **issues-found** (CRITICAL).

Filed urgent issue #40912: `path_extremal` and `turan_path_formula` assign different closed forms to the same term `extremalNumber n (pathGraph m)` (`(m-2)*n/2` vs `(m-2)*(n-1)/2`). Instantiating at m=3, n=4 gives `2 = 1 → False`, so the trusted axiom set is inconsistent.

axiomCount 17 (8 primary + 9 Stubs) verified as an accurate aggregate; sorries 6 match; badge `axiom`/status `axiomatized`/open otherwise honest. The inconsistency is the sole (but critical) finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)