### PR TITLE
Fix: erdos-548 inconsistent axioms — correct turan_path_formula RHS

### DIFF
--- a/proofs/Proofs/Erdos548Problem.lean
+++ b/proofs/Proofs/Erdos548Problem.lean
@@ -284,9 +284,9 @@ axiom erdos_gallai_matching (n k : ℕ) (G : SimpleGraph (Fin n)) [DecidableRel 
 /-- The Turán number for paths. -/
 noncomputable def turanPath (n k : ℕ) : ℕ := extremalNumber n (pathGraph k)
 
-/-- Turán number for P_k is (k-2)(n-1)/2 for n ≥ k-1. -/
+/-- Turán number for P_k is (k-2)n/2 for n ≥ k-1 (Erdős–Gallai). -/
 axiom turan_path_formula (n k : ℕ) (hn : n ≥ k - 1) (hk : k ≥ 2) :
-    turanPath n k = (k - 2) * (n - 1) / 2
+    turanPath n k = (k - 2) * n / 2
 
 /- ## Part X: Open Status -/
 


### PR DESCRIPTION
## Summary

Repairs the CRITICAL inconsistent-axiom-set finding in `proofs/Proofs/Erdos548Problem.lean` (erdos-548, Erdős–Sós Conjecture).

`turan_path_formula` assigned `(k-2)*(n-1)/2` to `turanPath n k`, which is definitionally `extremalNumber n (pathGraph k)`. The sibling axiom `path_extremal` assigns `(k-2)*n/2` to that same term (via `pathGraph (k+1)` with `k → k-1`). The two disagree, so the trusted axiom set is inconsistent and the kernel can derive `False`.

### Before (m=3, n=4)
- `path_extremal 4 2` → `extremalNumber 4 (pathGraph 3) = (2-1)*4/2 = 2`
- `turan_path_formula 4 3` → `turanPath 4 3 = (3-2)*(4-1)/2 = 1`
- `turanPath 4 3` ≡ `extremalNumber 4 (pathGraph 3)` definitionally ⇒ `2 = 1 → False`

### After
```lean
axiom turan_path_formula (n k : ℕ) (hn : n ≥ k - 1) (hk : k ≥ 2) :
    turanPath n k = (k - 2) * n / 2
```
Both axioms now agree on `(k-2)*n/2`, matching the standard Erdős–Gallai extremal number for the path `P_k` (`⌊(k-2)n/2⌋`, achieved by disjoint `K_{k-1}` cliques).

## Verification
- Same-type (`ℕ`) RHS edit; typechecks identically.
- `turan_path_formula` / `turanPath` are referenced **nowhere** else in the file or repo, so the change is build-safe (no dependent proof relies on the old value).
- Docstring updated to match.

Note: PR #40913 only updated the audit tracker (issues-found) — it did not touch the Lean source. This is the actual code repair.

Closes #40912
