### PR TITLE
Audit: erdos-546 CRITICAL false axiom cycle_edge_count (issue #40915)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14486,9 +14486,9 @@
     },
     "erdos-546": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:14Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T20:48:16Z",
+      "result": "issues-found"
     },
     "erdos-547": {
       "agentId": "auditor-erdos-547-phantom-narrative",


### PR DESCRIPTION
Tracker update for erdos-546 audit → **issues-found** (CRITICAL).

Filed urgent issue #40915: `cycleGraph` is misdefined — the `% n` in its adjacency is a no-op on `Fin n`, so it has no wrap-around edge and is actually `pathGraph` (`n-1` edges). The axiom `cycle_edge_count : edgeCount (cycleGraph n hn) = n` is therefore false; combined with `path_edge_count` via the provable `pathGraph n = cycleGraph n`, it derives `n-1 = n → False`.

axiomCount 10 verified; sorries 0; badge `axiom`/status axiomatized otherwise honest. The false axiom is the critical finding. Recommended fix in the issue: `((i.val+1) % n = j.val) ∨ ((j.val+1) % n = i.val)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)