### PR TITLE
Research: erdos-64-wip-01 — bridge Walk.IsCycle to ContainsCycleLength (length-indexed predicate)

### DIFF
--- a/proofs/Proofs/Erdos64Problem.lean
+++ b/proofs/Proofs/Erdos64Problem.lean
@@ -269,6 +269,69 @@ theorem hasMinDegree_two_exists_cycle
   rw [hpres] at hw
   omega
 
+/- ## Bridge to the length-indexed `ContainsCycleLength` predicate
+
+The cycle-existence lemmas above deliver a `SimpleGraph.Walk.IsCycle` witness, whereas
+`erdos_64_conjecture` is phrased with this file's own `ContainsCycleLength` predicate
+(an injective `Fin k → V` with cyclic `Fin.succMod` adjacency). The lemma below converts
+between them, so the machine-checked existence results become statements about a concrete
+cycle *length* — the quantity Problem 64 is ultimately about. -/
+
+/-- **`Walk.IsCycle` ⟹ `ContainsCycleLength`.** Any explicit cycle `c : G.Walk v v` gives a
+`ContainsCycleLength G c.length` witness: the vertices `c.getVert 0, …, c.getVert (c.length-1)`
+are pairwise distinct (`SimpleGraph.Walk.IsCycle.getVert_injOn'`) and cyclically adjacent
+(`SimpleGraph.Walk.adj_getVert_succ`), the wrap-around edge closing because
+`c.getVert c.length = v = c.getVert 0`. -/
+theorem isCycle_containsCycleLength
+    {W : Type*} [Fintype W] [DecidableEq W]
+    (G : SimpleGraph W) [DecidableRel G.Adj]
+    {v : W} (c : G.Walk v v) (hc : c.IsCycle) :
+    ContainsCycleLength G c.length := by
+  refine ⟨hc.three_le_length, fun i => c.getVert i.val, ?_, ?_⟩
+  · -- injectivity: `getVert` is injective on `{i | i ≤ c.length - 1}`
+    intro i j hij
+    apply Fin.ext
+    exact hc.getVert_injOn'
+      (by simp only [Set.mem_setOf_eq]; omega)
+      (by simp only [Set.mem_setOf_eq]; omega)
+      hij
+  · -- cyclic adjacency `c.getVert i` — `c.getVert ((i+1) % c.length)`
+    intro i
+    have hi : i.val < c.length := i.isLt
+    show G.Adj (c.getVert i.val) (c.getVert ((i.val + 1) % c.length))
+    by_cases hlast : i.val + 1 = c.length
+    · -- final vertex wraps to `c.getVert 0 = v = c.getVert c.length`
+      have h0 : (i.val + 1) % c.length = 0 := by rw [hlast]; exact Nat.mod_self _
+      rw [h0, c.getVert_zero]
+      have hadj := c.adj_getVert_succ hi
+      rwa [hlast, c.getVert_length] at hadj
+    · have hlt : i.val + 1 < c.length := by omega
+      rw [Nat.mod_eq_of_lt hlt]
+      exact c.adj_getVert_succ hi
+
+/-- A nonempty finite graph with minimum degree at least `2` contains a cycle of some
+**concrete length** `k ≥ 3` in the `ContainsCycleLength` encoding (obtained by measuring the
+length of the cycle from `hasMinDegree_two_exists_cycle`). This is the elementary,
+axiom-free precondition of Problem 64 restated in the predicate the conjecture uses. -/
+theorem hasMinDegree_two_containsCycleLength
+    {W : Type*} [Fintype W] [DecidableEq W] [Nonempty W]
+    (G : SimpleGraph W) [DecidableRel G.Adj]
+    (hdeg : HasMinDegree G 2) :
+    ∃ k : ℕ, k ≥ 3 ∧ ContainsCycleLength G k := by
+  obtain ⟨v, c, hc⟩ := hasMinDegree_two_exists_cycle G hdeg
+  exact ⟨c.length, hc.three_le_length, isCycle_containsCycleLength G c hc⟩
+
+/-- The Problem-64 hypothesis (minimum degree ≥ `3`) yields a cycle of some concrete length
+`k ≥ 3` (in the `ContainsCycleLength` encoding). Problem 64 asks the **open** question of
+whether `k` can be chosen to be a power of two `2^m` with `m ≥ 2`; this lemma proves the
+strict weakening "some length works" and does not resolve the conjecture. -/
+theorem hasMinDegree_three_containsCycleLength
+    {W : Type*} [Fintype W] [DecidableEq W] [Nonempty W]
+    (G : SimpleGraph W) [DecidableRel G.Adj]
+    (hdeg : HasMinDegree G 3) :
+    ∃ k : ℕ, k ≥ 3 ∧ ContainsCycleLength G k :=
+  hasMinDegree_two_containsCycleLength G (fun v => le_trans (by norm_num) (hdeg v))
+
 /- ## Known Cycle Results -/
 
 /- 

--- a/research/problems/erdos-64-wip-01/knowledge.md
+++ b/research/problems/erdos-64-wip-01/knowledge.md
@@ -72,3 +72,44 @@ File 205→268 lines, theoremCount 3→6.
 - Bridge the file's custom `ContainsCycleLength` (`Fin.succMod` encoding) to Mathlib
   `Walk.IsCycle` so cycle-*length* statements become expressible.
 - The open core (some cycle of length `2^k`) stays deep/imported (Liu–Montgomery).
+
+## Session 2026-07-21 (researcher-1-4) — bridge Walk.IsCycle → ContainsCycleLength
+
+**Mode**: depth-first on a MODERATE node; elementary cycle-EXISTENCE layer (connected
+`connected_hasMinDegree_two_exists_cycle` and disconnected `hasMinDegree_two_exists_cycle`)
+was already SATURATED. **Outcome**: progress (infrastructure, verified 0-axiom).
+
+Closed the honest "Next" gap those lemmas left: they produce a `SimpleGraph.Walk.IsCycle`
+witness, but `erdos_64_conjecture` is stated with this file's own `ContainsCycleLength`
+predicate (an injective `Fin k → V` with `Fin.succMod` cyclic adjacency). Added the bridge:
+
+- `isCycle_containsCycleLength` — for any `c : G.Walk v v` with `c.IsCycle`,
+  `ContainsCycleLength G c.length`. Take `vs i = c.getVert i.val` on `Fin c.length`:
+  injective via `SimpleGraph.Walk.IsCycle.getVert_injOn'` (`InjOn getVert {i | i ≤ length-1}`);
+  cyclic adjacency via `SimpleGraph.Walk.adj_getVert_succ`, the wrap edge `length-1 → 0`
+  closing because `c.getVert c.length = v = c.getVert 0` (`getVert_length`, `getVert_zero`).
+- `hasMinDegree_two_containsCycleLength` / `hasMinDegree_three_containsCycleLength` —
+  min-degree ≥ 2 (resp. the Problem-64 degree-3 hypothesis) on a nonempty finite graph
+  ⟹ `∃ k ≥ 3, ContainsCycleLength G k`. Just measures `c.length` of the cycle from
+  `hasMinDegree_two_exists_cycle`. This restates the elementary precondition of Problem 64
+  in the exact predicate the conjecture uses; the open content is that `k` can be taken a
+  power of two `2^m`.
+
+### Key Mathlib lemmas (getVert enumeration of a cycle)
+- `IsCycle.getVert_injOn'` : `Set.InjOn p.getVert {i | i ≤ p.length - 1}` (the clean one for
+  a `Fin p.length` index; `getVert_injOn` uses `1 ≤ i ≤ length`, off by the endpoint).
+- `Walk.adj_getVert_succ (hi : i < p.length) : G.Adj (p.getVert i) (p.getVert (i+1))`.
+- `Walk.getVert_zero`, `Walk.getVert_length` close the wrap-around edge.
+- `Fin.succMod _ i |>.val` reduces definitionally to `(i.val + 1) % k`; a `show` with that
+  RHS lets `Nat.mod_eq_of_lt` / `Nat.mod_self` split the interior vs wrap cases.
+
+### Verification
+Host-verified (`lake env lean`, Lean v4.31.0, exit 0, no warnings). `#print axioms` for all
+three = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`.
+File 316→379 lines.
+
+### Next
+- The open core (some cycle of length `2^k`) stays deep/imported (Liu–Montgomery). No
+  elementary path remains for the *length = power-of-two* refinement.
+- Optional: a girth/`egirth` restatement (`SimpleGraph.girth_le_length`) is now within reach
+  but adds little beyond the existing `∃ k ≥ 3` bound.

--- a/src/data/research/problems/erdos-64-wip-01.json
+++ b/src/data/research/problems/erdos-64-wip-01.json
@@ -31,17 +31,21 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (infrastructure): the elementary base fact — every nonempty finite graph (NO connectivity assumption) with min-degree >=2 contains a cycle — is now fully machine-checked and axiom-free (hasMinDegree_two_exists_cycle), completing the reduction that the connected-case lemmas left open. The open power-of-two-length refinement (the actual Erdos #64 content) is untouched.",
+    "progressSummary": "PROGRESS (infrastructure): the cycle-existence layer is now connected to the length-indexed ContainsCycleLength predicate used by erdos_64_conjecture. isCycle_containsCycleLength converts any Walk.IsCycle into ContainsCycleLength G c.length; hasMinDegree_two/three_containsCycleLength then give that any min-degree>=2 (resp. degree-3, Problem 64 hypothesis) finite graph contains a cycle of some concrete length k>=3 in that predicate. All axiom-free ([propext, Classical.choice, Quot.sound], no sorryAx). Open power-of-two-length core untouched.",
     "builtItems": [
       "connected_hasMinDegree_two_not_isAcyclic (Erdos64Problem.lean): nontrivial connected graph, HasMinDegree 2 => ¬IsAcyclic. Axiom-free.",
       "connected_hasMinDegree_two_exists_cycle (Erdos64Problem.lean): same hyp => ∃ v (c : Walk v v), c.IsCycle. Axiom-free.",
       "connected_hasMinDegree_three_exists_cycle (Erdos64Problem.lean): the Problem-64 degree-3 hypothesis (connected) forces a cycle. Axiom-free.",
-      "hasMinDegree_two_exists_cycle in Erdos64Problem.lean: disconnected (general finite) min-degree>=2 => contains a cycle, 0 axioms (propext/Classical.choice/Quot.sound only), host-verified v4.31.0"
+      "hasMinDegree_two_exists_cycle in Erdos64Problem.lean: disconnected (general finite) min-degree>=2 => contains a cycle, 0 axioms (propext/Classical.choice/Quot.sound only), host-verified v4.31.0",
+      "isCycle_containsCycleLength (Erdos64Problem.lean) — Walk.IsCycle c => ContainsCycleLength G c.length, axiom-free",
+      "hasMinDegree_two_containsCycleLength / hasMinDegree_three_containsCycleLength (Erdos64Problem.lean) — min-degree cycle-existence in the length-indexed predicate, axiom-free"
     ],
     "insights": [
       "A finite nontrivial TREE has a leaf (degree-1 vertex): Mathlib SimpleGraph.IsTree.minDegree_eq_one_of_nontrivial. Hence a connected graph with min degree >= 2 cannot be a tree, so cannot be acyclic — the elementary base fact under Erdos #64.",
       "SimpleGraph.IsAcyclic unfolds to (forall closed walk, not IsCycle); its negation directly yields an explicit Walk.IsCycle, so ¬IsAcyclic is packaged as a concrete cycle.",
-      "Connectivity can be dropped from the base cycle-existence fact: an arbitrary nonempty finite graph with min-degree >=2 contains a cycle. Proof passes to the connected component of any vertex and uses that neighbours stay inside their own component (ConnectedComponent.mem_supp_of_adj_mem_supp), so degrees are preserved on the induced subgraph (SimpleGraph.degree_induce_of_neighborSet_subset); if acyclic the component would be a nontrivial tree with a degree-1 vertex, contradicting min-degree >=2."
+      "Connectivity can be dropped from the base cycle-existence fact: an arbitrary nonempty finite graph with min-degree >=2 contains a cycle. Proof passes to the connected component of any vertex and uses that neighbours stay inside their own component (ConnectedComponent.mem_supp_of_adj_mem_supp), so degrees are preserved on the induced subgraph (SimpleGraph.degree_induce_of_neighborSet_subset); if acyclic the component would be a nontrivial tree with a degree-1 vertex, contradicting min-degree >=2.",
+      "Bridged the cycle-EXISTENCE layer to the length-indexed ContainsCycleLength predicate (in which erdos_64_conjecture is phrased): isCycle_containsCycleLength converts any Walk.IsCycle c into ContainsCycleLength G c.length. Mechanism = getVert enumeration: vs i = c.getVert i.val is injective on Fin c.length via IsCycle.getVert_injOn'; cyclic adjacency via adj_getVert_succ, wrap-around closing because c.getVert c.length = v = c.getVert 0.",
+      "hasMinDegree_two/three_containsCycleLength: min-degree>=2 (resp. 3) finite graph contains a cycle of some CONCRETE length k>=3 in the ContainsCycleLength encoding. This restates the elementary precondition of Problem 64 in the exact predicate the conjecture uses; the open content is that k can be chosen a power of two 2^m."
     ],
     "mathlibGaps": [
       "No general (disconnected/forest) leaf lemma: Mathlib only has IsTree.minDegree_eq_one_of_nontrivial (connected). A forest edge-count bound #edges <= n-1 is also absent (only IsTree.card_edgeFinset).",


### PR DESCRIPTION
## Summary

Bridges the machine-checked cycle-**existence** layer of `erdos-64-wip-01` to the
length-indexed `ContainsCycleLength` predicate in which `erdos_64_conjecture` is
actually phrased. Prior work (PRs #40522, #40874) proved that any min-degree-≥2 finite
graph contains a `SimpleGraph.Walk.IsCycle` witness, but that witness was never connected
to the file's own `ContainsCycleLength` (an injective `Fin k → V` with `Fin.succMod`
cyclic adjacency) — so the results could not be stated as facts about a cycle *length*,
the quantity Erdős #64 is about. This PR closes that gap.

## New theorems (all axiom-free)

- **`isCycle_containsCycleLength`** — any `c : G.Walk v v` with `c.IsCycle` yields
  `ContainsCycleLength G c.length`. The vertices `vs i = c.getVert i.val` on `Fin c.length`
  are injective (`SimpleGraph.Walk.IsCycle.getVert_injOn'`) and cyclically adjacent
  (`SimpleGraph.Walk.adj_getVert_succ`), the wrap-around edge closing because
  `c.getVert c.length = v = c.getVert 0`.
- **`hasMinDegree_two_containsCycleLength`** / **`hasMinDegree_three_containsCycleLength`** —
  a nonempty finite graph with min degree ≥ 2 (resp. the Problem-64 degree-3 hypothesis)
  contains a cycle of some concrete length `k ≥ 3` in the `ContainsCycleLength` encoding.

This restates the elementary precondition of Problem 64 in the exact predicate the
conjecture uses. The **open** content — that `k` can be chosen a power of two `2^m`,
`m ≥ 2` (Liu–Montgomery scale) — remains untouched and is not claimed.

## Verification

- Host-verified: `lake env lean Proofs/Erdos64Problem.lean`, Lean v4.31.0, exit 0, no warnings.
- `#print axioms` for all three new theorems = `[propext, Classical.choice, Quot.sound]`
  — no `sorryAx`, no `Lean.ofReduceBool`.
- File 316 → 379 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
