### PR TITLE
Audit: erdos-545 re-serve clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14480,8 +14480,8 @@
     },
     "erdos-545": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:14Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T20:50:16Z",
       "result": "clean"
     },
     "erdos-546": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-545 → **clean**.

Honest Tier-C scaffold (badge axiom / open):
- axiomCount 4 = 2 primary + 2 Stubs (verified); 12 sorries match
- originalContributions empty; description/conclusion honestly disclose counterexamples for m∈{2,3,4,5,7,8,9} + open asymptotic version + 'All 12 sorries involve non-trivial results'
- opaque `ramseyNumberMaxGraph` axiom makes `counterexamples_exist` non-falsifiable — no inconsistency (contrast today's 546/548 which had false value-axioms over concrete defs)
- concrete Ramsey theorems (R(3)=6, R(4)=18) sorry'd with correct intended values; no 'Proves' overclaim

Tracker bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)