### PR TITLE
Fix: erdos-546 false axiom — make cycleGraph a genuine C_n

### DIFF
--- a/proofs/Proofs/Erdos546Problem.lean
+++ b/proofs/Proofs/Erdos546Problem.lean
@@ -127,14 +127,23 @@ def pathGraph (n : ℕ) : SimpleGraph (Fin n) where
   symm := by constructor; intro i j h; cases h with | inl h => right; exact h | inr h => left; exact h
   loopless := by constructor; intro i h; cases h with | inl h => omega | inr h => omega
 
-/-- Cycle graph C_n on n ≥ 3 vertices: modular adjacency closing the path into a cycle. -/
+/-- Cycle graph C_n on n ≥ 3 vertices: modular adjacency closing the path into a cycle.
+    Taking `% n` on the *incremented* endpoint creates the wrap-around edge
+    `(n-1) ↔ 0`, so this is a genuine `C_n` (not the path `P_n`). -/
 def cycleGraph (n : ℕ) (hn : n ≥ 3) : SimpleGraph (Fin n) where
-  Adj i j := (i.val + 1 = j.val % n) ∨ (j.val + 1 = i.val % n)
+  Adj i j := ((i.val + 1) % n = j.val) ∨ ((j.val + 1) % n = i.val)
   symm := by constructor; intro i j h; cases h with | inl h => right; exact h | inr h => left; exact h
   loopless := by
     constructor; intro i h
-    have hmod : i.val % n = i.val := Nat.mod_eq_of_lt i.isLt
-    rcases h with h | h <;> omega
+    have hlt : i.val < n := i.isLt
+    rcases h with h | h <;>
+      rcases Nat.lt_or_ge (i.val + 1) n with hc | hc
+    · rw [Nat.mod_eq_of_lt hc] at h; omega
+    · have he : i.val + 1 = n := by omega
+      rw [he, Nat.mod_self] at h; omega
+    · rw [Nat.mod_eq_of_lt hc] at h; omega
+    · have he : i.val + 1 = n := by omega
+      rw [he, Nat.mod_self] at h; omega
 
 /-- Complete bipartite graph K_{a,b}: left part Fin a, right part Fin b,
     all cross-edges present. -/


### PR DESCRIPTION
## Summary

Repairs the CRITICAL false-axiom / inconsistent-axiom-set finding in `proofs/Proofs/Erdos546Problem.lean` (erdos-546, Ramsey Numbers and Edge Count).

`cycleGraph` was misdefined: it applied `% n` to the endpoint being *compared against* (`j.val % n`), which is a no-op for `j : Fin n` (always `j.val < n`). The adjacency therefore reduced to `pathGraph`'s — no wrap-around edge `(n-1) ↔ 0` — so `cycleGraph n hn = pathGraph n`, which has `n-1` edges, not `n`. The axiom `cycle_edge_count : edgeCount (cycleGraph n hn) = n` was then **false**, making the trusted axiom set inconsistent (kernel derives `False` via `path_edge_count` + the provable graph equality; the issue gives the `n=3` derivation).

## Fix

Move `% n` onto the *incremented* endpoint so the closing edge exists:

```lean
def cycleGraph (n : ℕ) (hn : n ≥ 3) : SimpleGraph (Fin n) where
  Adj i j := ((i.val + 1) % n = j.val) ∨ ((j.val + 1) % n = i.val)
  ...
```

Now vertex `n-1` is adjacent to `0` (`(n-1+1) % n = 0`), giving a genuine `C_n` with `n` edges — so `cycle_edge_count` holds and the axiom set is consistent. The `symm` proof is unchanged (it only swaps disjuncts); `loopless` is updated to case-split on whether the wrap occurs (`(i.val+1) % n = i.val` is impossible for `n ≥ 3`).

## Verification

```
✔ [2976/2976] Built Proofs.Erdos546Problem (7.6s)
Build completed successfully.
```
(`./proofs/scripts/docker-build.sh Proofs.Erdos546Problem`)

Only the two value-axioms `cycle_edge_count` / `cycle_ramsey_linear` reference `cycleGraph`; no proof depends on the old (broken) adjacency.

Closes #40915
