### PR TITLE
Audit fix: erdos-549 origContribs falsely claims native_decide

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14507,9 +14507,9 @@
     },
     "erdos-549": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:15Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T20:52:03Z",
+      "result": "issues-fixed"
     },
     "erdos-55": {
       "agentId": "auditor-agent",

--- a/src/data/proofs/erdos-549/meta.json
+++ b/src/data/proofs/erdos-549/meta.json
@@ -63,7 +63,7 @@
       "Construction of starGraph, doubleStar, pathGraph, broomGraph",
       "Statement of Norin-Sun-Zhao lower bound (4.2k)",
       "Statement of flag algebra upper bound (4.21526k)",
-      "bounds_gap proved via native_decide",
+      "bounds_gap proved via norm_num",
       "Special cases: bounded_degree_conjecture, broom_ramsey",
       "general_lower_bound and lower_bound_construction",
       "Classical results: chvatal_harary, star_ramsey, path_ramsey",


### PR DESCRIPTION
## Integrity fix (false verification-method claim)

**Proof**: erdos-549 — Ramsey Numbers for Bipartite Trees

originalContributions listed 'bounds_gap proved via native_decide', but:
- `bounds_gap` (Proofs/Erdos549Problem.lean:154) is `by norm_num [flagAlgebraConstant, norinSunZhaoConstant]`
- The file has **0** native_decide uses

norm_num is kernel-checked with no compiled-code/ofReduceBool dependency, unlike native_decide. Corrected to 'proved via norm_num'. (Second instance of this pattern today — see erdos-551 #40910.)

### Rest of the audit — clean
- sorries 14 = actual, axiomCount 0 = actual, badge `wip` (honest)
- `tree_burr_erdos` genuinely sorry-free → 'proved' claim accurate
- headline disproof `erdos_549 : ¬erdosConjecture549` is sorry'd, but conclusion says 'captures the counterexample' and attributes the disproof to Norin-Sun-Zhao; 14 sorries disclosed under wip badge — not overclaimed

---
Discovered during gallery integrity audit (reserve mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)