### PR TITLE
Research: erdos-85-wip-01 — sharpen f(n) ≤ √n+1 on lower Beatty half + f(m²) ≤ m+1

### DIFF
--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -775,4 +775,44 @@ theorem minDegreeForC4_le_sqrt {n : ℕ} (hn : 1 ≤ n) :
   rw [hsub]
   nlinarith [hlt]
 
+/-!
+## Sharpening the additive constant: `f(n) ≤ √n + 1` on the lower Beatty half
+
+The bound `f(n) ≤ √n + 2` loses `1` in the additive constant relative to the sharp
+Kővári–Sós–Turán value `k₀(n) = ⌈(1 + √(4n−3))/2⌉ = least k with k(k−1) ≥ n`.  Writing
+`s = √n`, the counting bound `minDegreeForC4_le_of_le_mul_pred` uses `k = s + 1` exactly
+when `k(k−1) = s(s+1) ≥ n`, i.e. `n ≤ s(s+1)`.  This holds on the **lower half** of each
+gap `[s², (s+1)²)`, namely `s² ≤ n ≤ s² + s`; for those `n` we get the sharp
+`f(n) ≤ s + 1`.  (On the upper half `s² + s < n < (s+1)²` the choice `k = s + 1` fails and
+`√n + 2` is the best this counting argument gives.)  In particular every **perfect square**
+`n = m²` satisfies `m² ≤ m(m+1)`, so `f(m²) ≤ m + 1` — the additive constant is pinned to
+`+1` there, matching the true `f(n) = (1 + o(1))√n` up to the last additive unit.
+-/
+
+/-- **Sharpened `O(√n)` bound on the lower Beatty half: `f(n) ≤ √n + 1`** whenever
+`n ≤ √n · (√n + 1)`.  This is the sharp Kővári–Sós–Turán constant on the lower half of each
+interval `[s², (s+1)²)` with `s = √n`, improving `minDegreeForC4_le_sqrt` by one there.
+Take `k = √n + 1`; then `k(k−1) = (√n + 1)·√n ≥ n` is exactly the hypothesis. -/
+theorem minDegreeForC4_le_sqrt_add_one {n : ℕ} (hn : 1 ≤ n)
+    (hlow : n ≤ Nat.sqrt n * (Nat.sqrt n + 1)) :
+    minDegreeForC4 n ≤ Nat.sqrt n + 1 := by
+  apply minDegreeForC4_le_of_le_mul_pred hn
+  have hsub : Nat.sqrt n + 1 - 1 = Nat.sqrt n := by omega
+  rw [hsub]
+  -- goal `n ≤ (√n + 1) * √n`, hypothesis `n ≤ √n * (√n + 1)`
+  rw [Nat.mul_comm]
+  exact hlow
+
+/-- **The additive constant is `+1` on every perfect square: `f(m²) ≤ m + 1`** for `m ≥ 1.**
+Since `√(m²) = m` and `m² ≤ m(m + 1)`, the lower-half sharpening
+`minDegreeForC4_le_sqrt_add_one` applies with `s = m`.  This is the cleanest quotable form of
+the correct-order upper bound: on the squares the bound is `√n + 1`, one better than the
+general `√n + 2` and within a single additive unit of the true `(1 + o(1))√n`. -/
+theorem minDegreeForC4_le_sq {m : ℕ} (hm : 1 ≤ m) :
+    minDegreeForC4 (m * m) ≤ m + 1 := by
+  have hsqrt : Nat.sqrt (m * m) = m := Nat.sqrt_eq m
+  have hn : 1 ≤ m * m := Nat.one_le_iff_ne_zero.2 (by positivity)
+  have h := minDegreeForC4_le_sqrt_add_one hn (by rw [hsqrt]; nlinarith)
+  rwa [hsqrt] at h
+
 end Erdos85

--- a/src/data/research/problems/erdos-85-wip-01.json
+++ b/src/data/research/problems/erdos-85-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Exact values f(4)=2, f(5)=3, f(6)=3 (axiom-free). KST cherry-counting bound minDegreeForC4_le_of_choose_lt now unfolds into an EXPLICIT closed form: minDegreeForC4_le_sqrt gives f(n) ≤ √n + 2 for all n≥1 via k=√n+2 (n<(√n+1)² ⟹ n≤k(k−1)). This is the matching upper bound of the true order f(n)=(1+o(1))√n — leading constant 1 sharp, additive O(1) loose. Lower bounds f(n)≥3 (n≥5) from cycleGraph. Next: sharpen additive constant toward √n+1 (holds when n≤√n²+√n); f(7) exact needs ex(7;C4); eventual-monotonicity (the OPEN core).",
+    "progressSummary": "Exact values f(4)=2, f(5)=3, f(6)=3 (axiom-free). Upper bound f(n) ≤ √n+2 (minDegreeForC4_le_sqrt), NOW SHARPENED on the lower Beatty half to f(n) ≤ √n+1 when n ≤ √n·(√n+1) (minDegreeForC4_le_sqrt_add_one); corollary f(m²) ≤ m+1 pins the additive constant to +1 on all perfect squares, matching the true f(n)=(1+o(1))√n up to one additive unit. Lower bounds f(n)≥3 (n≥5). Next: upper-half n∈(s²+s,(s+1)²) still only √n+2 (needs a non-counting witness to sharpen); f(7) exact needs ex(7;C4); eventual-monotonicity (OPEN core).",
     "builtItems": [
       "C4_adj_zero_one/one_two/two_three/three_zero (four cycle edges) in Erdos85Problem.lean",
       "C4_not_adj_zero_two (diagonal non-edge) in Erdos85Problem.lean",
@@ -49,7 +49,9 @@
       "two_dvd_mul_pred / two_mul_choose_two (2·C(m,2)=m(m−1)) helpers in Erdos85Problem.lean",
       "choose_two_lt_of_le_mul_pred: n≤k(k−1) ⟹ C(n,2)<n·C(k,2) (arithmetic core of KST count)",
       "minDegreeForC4_le_of_le_mul_pred: n≤k(k−1) ⟹ f(n)≤k (clean packaging of the counting bound)",
-      "minDegreeForC4_le_sqrt: f(n) ≤ Nat.sqrt n + 2 for n≥1 (explicit O(√n) upper bound)"
+      "minDegreeForC4_le_sqrt: f(n) ≤ Nat.sqrt n + 2 for n≥1 (explicit O(√n) upper bound)",
+      "minDegreeForC4_le_sqrt_add_one (Erdos85Problem.lean): f(n) ≤ √n+1 on the lower Beatty half n ≤ √n·(√n+1), axiom-free",
+      "minDegreeForC4_le_sq (Erdos85Problem.lean): f(m²) ≤ m+1, axiom-free"
     ],
     "insights": [
       "Erdos85Problem.lean was a definitions-only stub (7 defs, 0 theorems). Asymptotics f(n)=(1+o(1))sqrt(n), f(4)=2, and the Ramsey reformulation need extremal graph theory beyond Mathlib; tractable axiom-free content is structural facts about C4, containsC4, and starGraph.",
@@ -67,7 +69,9 @@
       "Lean idiom: for a ∀G-with-[DecidableRel] statement, the sInf-membership pattern `apply Nat.sInf_le; intro G _ hmin` handles the instance binder cleanly. Non-neighbour cardinality via Finset.card_sdiff_add_card_eq_card (subset form) + omega; card_sdiff hypothesis-free in v4.31.",
       "minDegreeForC4_five: f(5) = 3 EXACTLY — the cycle lower bound f(5)≥3 (three_le_minDegreeForC4) meets the n-2 upper bound at n=5 (5-2=3). Second determined value, immediate corollary of the two new bounds.",
       "Kővári–Sós–Turán cherry-counting: Σ_v C(deg v,2) counts paths of length 2; each is determined by centre + unordered endpoint pair. If the count exceeds C(|V|,2), pigeonhole gives a pair with two common neighbours = a C₄. This is the C₄/z(n;2,2) case of KST and drives the true √n-order threshold (f(n)=O(√n)), far beating the linear n−2 bound.",
-      "Explicit closed-form upper bound minDegreeForC4_le_sqrt: f(n) ≤ √n + 2 for all n ≥ 1 (axiom-free). Leading constant 1 matches the true f(n)=(1+o(1))√n; only an additive O(1) is lost vs the sharp KST constant (1+√(4n−3))/2. First quotable closed-form of the correct order for this entry."
+      "Explicit closed-form upper bound minDegreeForC4_le_sqrt: f(n) ≤ √n + 2 for all n ≥ 1 (axiom-free). Leading constant 1 matches the true f(n)=(1+o(1))√n; only an additive O(1) is lost vs the sharp KST constant (1+√(4n−3))/2. First quotable closed-form of the correct order for this entry.",
+      "Sharpened the additive constant on the lower Beatty half: minDegreeForC4_le_sqrt_add_one gives f(n) ≤ √n+1 whenever n ≤ √n·(√n+1) (the sharp KST constant on the lower half of each gap [s²,(s+1)²)), improving √n+2 by one. Take k=√n+1; k(k−1)=(√n+1)·√n ≥ n is exactly the hypothesis.",
+      "Perfect-square corollary minDegreeForC4_le_sq: f(m²) ≤ m+1 for m≥1 (Nat.sqrt_eq gives √(m²)=m, and m² ≤ m(m+1)). Additive constant pinned to +1 on the squares — within a single unit of the true (1+o(1))√n. Cleanest quotable correct-order upper bound for the entry."
     ],
     "mathlibGaps": [
       "Fin n has NO global CommRing instance (only scoped Fin.instCommRing via `open Fin.CommRing`, gated on NeZero n); needed for ring/linear_combination on cycleGraph differences"


### PR DESCRIPTION
## Summary
Sharpens the additive constant in the Kővári–Sós–Turán upper bound for the C₄
min-degree threshold `f(n) = minDegreeForC4 n` (Erdős #85). The prior best was
`f(n) ≤ √n + 2` (`minDegreeForC4_le_sqrt`); this lands the sharp `√n + 1` on the
lower half of each gap.

## Progress
- **`minDegreeForC4_le_sqrt_add_one`**: `f(n) ≤ √n + 1` whenever `n ≤ √n·(√n+1)`.
  Writing `s = √n`, the counting bound `minDegreeForC4_le_of_le_mul_pred` uses
  `k = s+1` exactly when `k(k−1) = s(s+1) ≥ n`, i.e. on the lower half of each
  interval `[s², (s+1)²)`. This is the sharp KST additive constant there.
- **`minDegreeForC4_le_sq`**: `f(m²) ≤ m + 1` for all `m ≥ 1`. Since `√(m²) = m`
  and `m² ≤ m(m+1)`, the lower-half sharpening applies — the additive constant is
  pinned to `+1` on every perfect square, within a single unit of the true
  `f(n) = (1+o(1))√n`.

Both axiom-free, built on the existing counting infrastructure. Docker-verified
(`Built Proofs.Erdos85Problem`, 0 axioms, 0 sorries).

## Findings
- The counting argument gives the sharp `√n+1` on the **lower** half `s² ≤ n ≤ s²+s`
  but genuinely cannot beat `√n+2` on the **upper** half `s²+s < n < (s+1)²` (there
  `k=s+1` fails and `k=s+2` is forced). Closing the upper half needs a non-counting
  construction/witness, not more of the cherry-counting bound.

## Status
**Outcome**: progress
**Next Steps**: sharpen the upper Beatty half toward `√n+1` (needs a witness beyond
cherry-counting); `f(7)` exact needs `ex(7;C₄)`; eventual-monotonicity remains the
open core.

🤖 Generated by researcher-1