### PR TITLE
Fix: erdos-543 remove 6 phantom declaration names from meta prose

### DIFF
--- a/src/data/proofs/erdos-543/meta.json
+++ b/src/data/proofs/erdos-543/meta.json
@@ -56,12 +56,10 @@
       "IsSpanningSet predicate and equivalence with Set.univ",
       "spanningProbability formalization via k-subset counting",
       "f axiomatized as the worst-case spanning threshold",
-      "erdos_renyi_upper_bound: f(N) ≤ log₂ N + O(log log N)",
       "LittleOConjecture and ErdosCounterConjecture formal statements",
       "conjectures_complementary: proved logical negation equivalence",
       "chatgpt_tang_disproof: ErdosCounterConjecture holds",
       "little_o_conjecture_false: derived from disproof + complementarity",
-      "erdos_hall_lower: intermediate lower bound on log log log N",
       "erdos_543_summary: combines disproof and negation"
     ],
     "axiomCount": 2,
@@ -101,26 +99,26 @@
     {
       "id": "f-definition",
       "title": "The Function f(N)",
-      "summary": "spanningProbability, f axiom, f_le_card",
+      "summary": "spanningProbability, f axiom",
       "startLine": 59,
       "endLine": 75,
-      "mathContext": "Axiomatized: spanningProbability, f axiom, f_le_card"
+      "mathContext": "Axiomatized: spanningProbability, f axiom"
     },
     {
       "id": "elementary",
       "title": "Elementary Properties",
-      "summary": "empty_spanning_iff, spanning_of_generators",
+      "summary": "spanning_of_generators",
       "startLine": 76,
       "endLine": 83,
-      "mathContext": "Mathematical content: empty_spanning_iff, spanning_of_generators"
+      "mathContext": "Mathematical content: spanning_of_generators"
     },
     {
       "id": "erdos-renyi",
       "title": "Erdős-Rényi Upper Bound",
-      "summary": "erdos_renyi_upper_bound: f(N) ≤ log₂ N + O(log log N)",
+      "summary": "Descriptive commentary: the Erdős-Rényi upper bound f(N) ≤ log₂ N + O(log log N) is discussed but not formalized",
       "startLine": 84,
       "endLine": 94,
-      "mathContext": "erdos_renyi_upper_bound: f(N) $\\leq$ log₂ N + $O(log log N)$"
+      "mathContext": "Commentary only (no formalized declaration): f(N) $\\leq$ log₂ N + $O(log log N)$"
     },
     {
       "id": "conjecture-disproof",
@@ -133,18 +131,18 @@
     {
       "id": "lower-bounds",
       "title": "Lower Bounds",
-      "summary": "naive_lower_bound, erdos_hall_lower",
+      "summary": "Descriptive commentary: the information-theoretic naive lower bound and the Erdős-Hall log log log N bound are discussed but not formalized",
       "startLine": 133,
       "endLine": 141,
-      "mathContext": "Bound: naive_lower_bound, erdos_hall_lower"
+      "mathContext": "Commentary only (no formalized declarations)"
     },
     {
       "id": "special-cases",
       "title": "Special Cases and Summary",
-      "summary": "cyclic_spanning_characterization, prime_full_spanning; erdos_543_summary (the packaged main result: ErdosCounterConjecture ∧ ¬LittleOConjecture)",
+      "summary": "cyclic_spanning_characterization; erdos_543_summary (the packaged main result: ErdosCounterConjecture ∧ ¬LittleOConjecture)",
       "startLine": 142,
       "endLine": 167,
-      "mathContext": "Mathematical content: cyclic_spanning_characterization, prime_full_spanning, erdos_543_summary"
+      "mathContext": "Mathematical content: cyclic_spanning_characterization, erdos_543_summary"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Metadata-only fix for the gallery integrity issue in #40921. `originalContributions` and several `sections[].summary`/`mathContext` fields named 6 declarations that do not exist in `proofs/Proofs/Erdos543Problem.lean` — they referred only to comment-prose ranges.

The numeric counts (axiomCount 2, theoremCount 6, definitionCount 5, 0 sorries) were already honest; only the prose overclaimed. Status/badge (`axiomatized`/`axiom`) unchanged.

## Changes (meta.json only)

- Removed `erdos_renyi_upper_bound: ...` and `erdos_hall_lower: ...` from `originalContributions` (unformalized math results — commentary, not declarations).
- `f-definition` section: dropped `f_le_card`.
- `elementary` section: dropped `empty_spanning_iff` (kept `spanning_of_generators`).
- `erdos-renyi` section: reframed as descriptive commentary (no formalized `erdos_renyi_upper_bound`).
- `lower-bounds` section: reframed as descriptive commentary (no `naive_lower_bound`/`erdos_hall_lower`).
- `special-cases` section: dropped `prime_full_spanning` (kept `cyclic_spanning_characterization`).

## Evidence

Grep-verified against the Lean file: all 6 names (`erdos_renyi_upper_bound`, `erdos_hall_lower`, `f_le_card`, `empty_spanning_iff`, `naive_lower_bound`, `prime_full_spanning`) have no `axiom`/`theorem`/`lemma`/`def` declaration. The 6 real theorems, 2 axioms, 5 defs all remain named accurately. JSON validated with `python3 -m json.tool`.

Closes #40921
