### PR TITLE
Enrich erdos-546/548/558/606/667: re-anchor audit-drifted sections to Part banners

### DIFF
--- a/src/data/proofs/erdos-546/meta.json
+++ b/src/data/proofs/erdos-546/meta.json
@@ -75,39 +75,39 @@
       "id": "multicolor",
       "title": "Multi-Color Generalization (Open)",
       "startLine": 102,
-      "endLine": 115,
+      "endLine": 121,
       "summary": "MultiColorConjecture and ThreeColorConjecture: does R_r(G) ≤ 2^{O(√m)} for r ≥ 3? Complement argument fails for 3+ colors",
       "mathContext": "OPEN: r ≥ 3 color Ramsey. Complement fails."
     },
     {
       "id": "specific-graphs",
       "title": "Specific Graph Classes",
-      "startLine": 117,
-      "endLine": 147,
+      "startLine": 122,
+      "endLine": 163,
       "summary": "Defines pathGraph P_n, cycleGraph C_n, completeBipartite K_{a,b}; axiomatizes edge count formulas n-1 and n",
       "mathContext": "P_n: n-1 edges. C_n: n edges. K_{a,b}: ab edges."
     },
     {
       "id": "sparse-bounds",
       "title": "Ramsey Bounds for Sparse Graphs",
-      "startLine": 149,
-      "endLine": 165,
+      "startLine": 164,
+      "endLine": 182,
       "summary": "Axiomatizes path_ramsey_linear (R(P_n) ≤ 2n-1), cycle_ramsey_linear (R(C_n) ≤ 2n-1), and probabilistic_lower_bound (R(G) ≥ c√m)",
       "mathContext": "Paths/cycles: linear R. Probabilistic: R(G) ≥ c√m."
     },
     {
       "id": "problem-545",
       "title": "Connection to Problem #545",
-      "startLine": 167,
-      "endLine": 175,
+      "startLine": 183,
+      "endLine": 192,
       "summary": "Problem545Conjecture: precise exponent R(G) ≤ C_ε · 2^{(1/2+ε) log m} refinement of Sudakov",
       "mathContext": "#545: precise exponent. Related open problem."
     },
     {
       "id": "main-results",
       "title": "Main Results",
-      "startLine": 177,
-      "endLine": 199,
+      "startLine": 193,
+      "endLine": 212,
       "summary": "erdos_546_solved (= sudakov_theorem) and erdos_546_tight (combining upper and lower bounds into Θ(√m) statement)",
       "mathContext": "SOLVED: R(G) = 2^{Θ(√m)}. Upper: Sudakov. Lower: probabilistic."
     }

--- a/src/data/proofs/erdos-548/meta.json
+++ b/src/data/proofs/erdos-548/meta.json
@@ -57,79 +57,79 @@
       "id": "trees",
       "title": "Part I: Trees",
       "startLine": 46,
-      "endLine": 87,
+      "endLine": 101,
       "summary": "Defines `IsTree` (connected + acyclic), axiomatizes the edge count formula $|E| = |V| - 1$. Constructs `pathGraph` on `Fin n` with consecutive-integer adjacency and `starGraph` $K_{1,k}$ with center-leaf adjacency. Both include inline proofs of `symm` and `loopless`.",
       "mathContext": "Defines `IsTree` (connected + acyclic), axiomatizes the edge count formula $|E| = |V| - 1$. Constructs `pathGraph` on `Fin n` with consecutive-integer adjacency and `starGraph` $K_{1,k}$ with center-leaf adjacency."
     },
     {
       "id": "subgraph-containment",
       "title": "Part II: Subgraph Containment",
-      "startLine": 88,
-      "endLine": 97,
+      "startLine": 102,
+      "endLine": 111,
       "summary": "Defines `ContainsSubgraph G H` via an injective graph homomorphism preserving edges, and `TreeFree G T` as its negation. This formalizes the standard notion of subgraph isomorphism used in extremal graph theory.",
       "mathContext": "Defines `ContainsSubgraph G H` via an injective graph homomorphism preserving edges, and `TreeFree G T` as its negation. This formalizes the standard notion of subgraph isomorphism used in extremal graph theory."
     },
     {
       "id": "edge-counting",
       "title": "Part III: Edge Counting and Average Degree",
-      "startLine": 98,
-      "endLine": 117,
+      "startLine": 112,
+      "endLine": 131,
       "summary": "Defines `edgeCount`, states the handshaking lemma $\\sum \\deg = 2|E|$, and defines `avgDegree` over $\\mathbb{Q}$. Proves the equivalence between average degree $> k-1$ and edge count $> (k-1)n/2$ formulations.",
       "mathContext": "Defines `edgeCount`, states the handshaking lemma $\\sum \\deg = 2|E|$, and defines `avgDegree` over $\\mathbb{Q}$. Proves the equivalence between average degree $> k-1$ and edge count $> (k-1)n/2$ formulations."
     },
     {
       "id": "main-conjecture",
       "title": "Part IV: The Erdos-Sos Conjecture",
-      "startLine": 118,
-      "endLine": 142,
+      "startLine": 132,
+      "endLine": 157,
       "summary": "States the conjecture in two equivalent forms: `ErdosSosConjecture` with generic vertex types and strict edge inequality, and `Erdos548Statement` with `Fin n` and the original $\\ge (k-1)n/2 + 1$ phrasing.",
       "mathContext": "States the conjecture in two equivalent forms: `ErdosSosConjecture` with generic vertex types and strict edge inequality, and `Erdos548Statement` with `Fin n` and the original $\\ge (k-1)n/2 + 1$ phrasing."
     },
     {
       "id": "known-results",
       "title": "Part V: Known Partial Results",
-      "startLine": 143,
-      "endLine": 210,
+      "startLine": 158,
+      "endLine": 227,
       "summary": "Axiomatizes four partial results: trivial bound ($n(k-1)+1$ edges), Brandt-Dobson (girth $\\ge 5$), Sacle-Wozniak ($C_4$-free), and Wang-Li-Liu (complement girth $\\ge 5$). Defines `girth`, `hasGirthAtLeast`, `C4Free`, and `complement` with inline proofs.",
       "mathContext": "Axiomatizes four partial results: trivial bound ($n(k-1)+1$ edges), Brandt-Dobson (girth $\\ge 5$), Sacle-Wozniak ($C_4$-free), and Wang-Li-Liu (complement girth $\\ge 5$). Defines `girth`, `hasGirthAtLeast`, `C4Free`, and `complement` with inline proofs."
     },
     {
       "id": "extremal-function",
       "title": "Part VI: Extremal Function",
-      "startLine": 211,
-      "endLine": 223,
+      "startLine": 228,
+      "endLine": 240,
       "summary": "Defines $\\text{ex}(n, T)$ via `sSup` over $T$-free graphs. States that the conjecture implies the uniform bound $\\text{ex}(n, T) \\le (k-1)n/2$ for all trees with $k$ edges.",
       "mathContext": "Formal definition: Defines $\\text{ex}(n, T)$ via `sSup` over $T$-free graphs. States that the conjecture implies the uniform bound $\\text{ex}(n, T) \\le (k-1)n/2$ for all trees with $k$ edges."
     },
     {
       "id": "special-trees",
       "title": "Part VII: Special Trees",
-      "startLine": 224,
-      "endLine": 236,
+      "startLine": 241,
+      "endLine": 253,
       "summary": "Contrasts paths (extremal: $\\text{ex}(n, P_{k+1}) = (k-1)n/2$ exactly) with stars (easy: pigeonhole gives a vertex of degree $\\ge k$ when $|E| \\ge kn/2$). Paths are the tightest case; stars are trivial.",
       "mathContext": "Contrasts paths (extremal: $\\text{ex}(n, P_{k+1}) = (k-1)n/2$ exactly) with stars (easy: pigeonhole gives a vertex of degree $\\ge k$ when $|E| \\ge kn/2$)."
     },
     {
       "id": "komlos-sos",
       "title": "Part VIII: Large k Result",
-      "startLine": 237,
-      "endLine": 250,
+      "startLine": 254,
+      "endLine": 267,
       "summary": "Axiomatizes the Komlos-Sos-Szemeredi result: the conjecture holds for all $k \\ge k_0$ for some absolute constant $k_0$. Uses the regularity-blow-up method; exact threshold unknown, full proof unpublished.",
       "mathContext": "Axiomatizes the Komlos-Sos-Szemeredi result: the conjecture holds for all $k \\ge k_0$ for some absolute constant $k_0$."
     },
     {
       "id": "related-theorems",
       "title": "Part IX: Related Theorems",
-      "startLine": 251,
-      "endLine": 273,
+      "startLine": 268,
+      "endLine": 290,
       "summary": "Axiomatizes the Erdos-Gallai matching theorem (max edges without $(k+1)$-matching) and the Turan number for paths $\\text{ex}(n, P_k) = (k-2)(n-1)/2$. Both provide context for the tree Turan problem.",
       "mathContext": "Verified: Axiomatizes the Erdos-Gallai matching theorem (max edges without $(k+1)$-matching) and the Turan number for paths $\\text{ex}(n, P_k) = (k-2)(n-1)/2$. Both provide context for the tree Turan problem."
     },
     {
       "id": "open-status",
       "title": "Part X: Open Status",
-      "startLine": 274,
-      "endLine": 319,
+      "startLine": 291,
+      "endLine": 336,
       "summary": "States the conjecture's open status as a tautological disjunction $P \\lor \\neg P$. The conjecture is marked 'falsifiable' but no counterexample has been found despite extensive computational search.",
       "mathContext": "Mathematical content: States the conjecture's open status as a tautological disjunction $P \\lor \\neg P$. The conjecture is marked 'falsifiable' but no counterexample has been found despite extensive computational search."
     }

--- a/src/data/proofs/erdos-558/meta.json
+++ b/src/data/proofs/erdos-558/meta.json
@@ -106,71 +106,71 @@
       "title": "Part 3: Chung-Graham Bounds (1975)",
       "summary": "Defines the explicit bound functions `chungGrahamLower` and `chungGrahamUpper`, and axiomatizes `chung_graham_bounds`: for $s,t\\ge1$, $k\\ge2$, $\\texttt{chungGrahamLower}\\le R(K[s,t];k)\\le\\texttt{chungGrahamUpper}$.",
       "startLine": 80,
-      "endLine": 100,
+      "endLine": 107,
       "mathContext": "Two definitions and one axiom (`chung_graham_bounds`). The lower bound has the form $\\sim k^{(st-1)/(s+t)}$; the upper bound $\\sim (t-1)(k+k^{1/s})^s$."
     },
     {
       "id": "k22",
       "title": "Part 4: The Case K_{2,2} (Four-Cycle)",
       "summary": "Defines $C_4 = K[2,2]$ and axiomatizes `ramsey_K22`: $R(C_4;k)=\\Theta(k^2)$, i.e. $\\exists c_1,c_2>0$ with $c_1k^2\\le R(C_4;k)\\le c_2k^2$ for $k\\ge2$ (Chung-Graham 1975).",
-      "startLine": 101,
-      "endLine": 114,
+      "startLine": 108,
+      "endLine": 121,
       "mathContext": "One definition and one axiom (`ramsey_K22`)."
     },
     {
       "id": "k33",
       "title": "Part 5: The Case K_{3,3}",
       "summary": "Defines $K_{3,3}=K[3,3]$ and axiomatizes `ramsey_K33`: $R(K_{3,3};k)=\\Theta(k^3)$ (Alon-Rónyai-Szabó 1999, via norm-graph constructions).",
-      "startLine": 115,
-      "endLine": 128,
+      "startLine": 122,
+      "endLine": 135,
       "mathContext": "One definition and one axiom (`ramsey_K33`)."
     },
     {
       "id": "ars-general",
       "title": "Part 6: The General Theorem of Alon-Rónyai-Szabó",
       "summary": "Defines the threshold `criticalS(t) = (t-1)!+1` and axiomatizes `alon_ronyai_szabo`: when $s\\ge(t-1)!+1$ and $t\\ge2$, $R(K[s,t];k)=\\Theta(k^t)$.",
-      "startLine": 129,
-      "endLine": 143,
+      "startLine": 136,
+      "endLine": 150,
       "mathContext": "One definition and one axiom (`alon_ronyai_szabo`), the general $k^t$-growth result above the factorial threshold."
     },
     {
       "id": "statement",
       "title": "Part 7: Erdős Problem #558 Statement",
       "summary": "Proves `erdos_558`: for $s,t\\ge1$, $k\\ge2$, the Chung-Graham bounds hold, and if additionally $s\\ge(t-1)!+1$ the exponent is exactly $t$. Assembled by `constructor` from `chung_graham_bounds` and `alon_ronyai_szabo`.",
-      "startLine": 144,
-      "endLine": 189,
+      "startLine": 151,
+      "endLine": 172,
       "mathContext": "One theorem combining the Part 3 and Part 6 axioms; no new axioms here."
     },
     {
       "id": "norm-graphs",
       "title": "Part 8: Norm Graphs and Lower Bounds",
       "summary": "Section banner for the algebraic (norm-graph) constructions giving tight lower bounds. Exposition placeholder; declares no Lean content.",
-      "startLine": 190,
-      "endLine": 195,
+      "startLine": 173,
+      "endLine": 178,
       "mathContext": "Empty docstring banner."
     },
     {
       "id": "specific-values",
       "title": "Part 9: Specific Values and Bounds",
       "summary": "Section banner for specific values and numeric bounds of $R(K_{s,t};k)$. Exposition placeholder; declares no Lean content.",
-      "startLine": 196,
-      "endLine": 199,
+      "startLine": 179,
+      "endLine": 182,
       "mathContext": "Empty docstring banner."
     },
     {
       "id": "extremal-connection",
       "title": "Part 10: Connection to Extremal Graph Theory",
       "summary": "Section banner relating these Ramsey numbers to extremal (Turán-type) graph theory. Exposition placeholder; declares no Lean content.",
-      "startLine": 200,
-      "endLine": 203,
+      "startLine": 183,
+      "endLine": 186,
       "mathContext": "Empty docstring banner."
     },
     {
       "id": "summary",
       "title": "Part 11: Summary",
       "summary": "Concluding part: `erdos_558_summary` bundles the three asymptotic results — $R(C_4;k)\\sim k^2$, $R(K_{3,3};k)\\sim k^3$, and $R(K[s,t];k)=\\Theta(k^t)$ for $s\\ge(t-1)!+1$ — directly from `ramsey_K22`, `ramsey_K33`, and `alon_ronyai_szabo`.",
-      "startLine": 204,
-      "endLine": 222,
+      "startLine": 187,
+      "endLine": 204,
       "mathContext": "One theorem. Net file axioms (5): `ramseyBipartite`, `chung_graham_bounds`, `ramsey_K22`, `ramsey_K33`, `alon_ronyai_szabo`."
     }
   ],

--- a/src/data/proofs/erdos-606/meta.json
+++ b/src/data/proofs/erdos-606/meta.json
@@ -54,63 +54,63 @@
       "id": "header-imports",
       "title": "Header and Imports",
       "startLine": 1,
-      "endLine": 42,
+      "endLine": 45,
       "summary": "Problem statement, timeline, references, and Mathlib imports",
       "mathContext": "#606: achievable line counts for n points in R^2. Solved by Erdős-Salamon 1988."
     },
     {
       "id": "points-lines",
       "title": "Points and Lines in ℝ²",
-      "startLine": 44,
-      "endLine": 75,
+      "startLine": 46,
+      "endLine": 69,
       "summary": "`Point` (EuclideanSpace ℝ (Fin 2)), `PointConfig n` (injective map), `Line` (two distinct points), `onLine`, `maxLines = n(n-1)/2`",
       "mathContext": "n distinct points. Line: parametric. maxLines = C(n,2)."
     },
     {
       "id": "collinearity",
       "title": "Collinearity and Configurations",
-      "startLine": 77,
-      "endLine": 103,
+      "startLine": 70,
+      "endLine": 89,
       "summary": "`Collinear`, `AllCollinear`, `GeneralPosition`, `IsOrdinaryLine` — the geometric predicates used in all main theorems",
       "mathContext": "Collinear: 3 points on common line. Ordinary line: exactly 2 config points."
     },
     {
       "id": "line-count-axioms",
       "title": "Line Count Function (Axiomatized)",
-      "startLine": 105,
-      "endLine": 131,
+      "startLine": 90,
+      "endLine": 112,
       "summary": "Axioms: `numDistinctLines` (function), `numDistinctLines_collinear` (→1), `numDistinctLines_general_position` (→C(n,2)), `numDistinctLines_min_noncollinear` (≥n)",
       "mathContext": "numDistinctLines axiomatized. Collinear→1, GenPos→C(n,2), NonCol≥n."
     },
     {
       "id": "sylvester-gallai",
       "title": "Sylvester-Gallai Theorem",
-      "startLine": 133,
-      "endLine": 143,
+      "startLine": 113,
+      "endLine": 121,
       "summary": "Axiom `sylvester_gallai`: non-collinear points determine an ordinary line (exactly 2 config points). Gallai proved this in 1944.",
       "mathContext": "Sylvester-Gallai (1944): non-collinear ⟹ ∃ ordinary line with exactly 2 points."
     },
     {
       "id": "achievable-counts",
       "title": "The Achievable Line Counts",
-      "startLine": 145,
-      "endLine": 191,
+      "startLine": 122,
+      "endLine": 153,
       "summary": "`AchievableLineCounts n` definition; axioms for gaps (C(n,2)-1 and C(n,2)-3), achievable value C(n,2)-2, Erdős density result for [cn^{3/2}, C(n,2)-4]",
       "mathContext": "Gaps: C(n,2)-1 and C(n,2)-3. C(n,2)-2 achievable. Density in [cn^{3/2}, C(n,2)-4]."
     },
     {
       "id": "beck-szemeredi",
       "title": "Beck's Theorem and Szemerédi-Trotter",
-      "startLine": 193,
-      "endLine": 222,
+      "startLine": 154,
+      "endLine": 183,
       "summary": "Axiom `beck_theorem`: n/100 collinear or n²/10000 lines. Axiom `szemeredi_trotter_bound`: I(P,L) ≤ 10(nm)^(2/3)+n+m",
       "mathContext": "Beck (1983): dichotomy. ST (1983): I≤C(nm)^(2/3)+n+m."
     },
     {
       "id": "complete-characterization",
       "title": "Complete Characterization and Main Theorems",
-      "startLine": 224,
-      "endLine": 243,
+      "startLine": 184,
+      "endLine": 254,
       "summary": "Axiom `erdos_salamon_characterization`; proved theorems `erdos_606_solved` and `min_lines_noncollinear`",
       "mathContext": "Erdős-Salamon: {1}∪[n,C(n,2)]\\{C(n,2)-1, C(n,2)-3}. SOLVED."
     }

--- a/src/data/proofs/erdos-667/meta.json
+++ b/src/data/proofs/erdos-667/meta.json
@@ -176,7 +176,7 @@
       "id": "structural-consequences",
       "title": "Part IX: Structural Consequences",
       "startLine": 468,
-      "endLine": 515,
+      "endLine": 523,
       "summary": "General gap-structure results. `cpq_total_gap` ($c(p,q_{\\max})-c(p,1)\\geq1-2/(p+1)$), `cpq_gap_pos` (the gap is strictly positive), `erdos667_at_least_one_strict_step` (there is at least one strict increase, namely at the top via EFRS), and `erdos667_summary` packaging all known results (Ramsey interval, $c$ at max $=1$, weak monotonicity, top gap).",
       "mathContext": "$c(p,q_{\\max})-c(p,1)\\geq1-2/(p+1)>0$; at least one strict step (at $q=\\binom{p-1}{2}$)."
     }


### PR DESCRIPTION
## Enrichment: re-anchor audit-drifted sections

Two gallery entries whose `sections` line ranges had drifted out of sync with their Lean files. In both, the section **summaries and titles are already accurate** — only `startLine`/`endLine` were stale, leaving named declarations stranded outside the range that describes them and the file tail uncovered.

### erdos-546
PR #40919 (false-axiom audit) inserted ~9 lines at `cycleGraph`, drifting everything below. Re-anchored `multicolor` → `main-results` to the `## Part VI–VIII` / `## Main Results` banners:
- `completeBipartite`, `path_edge_count`, `cycle_edge_count` (named in the "Specific Graph Classes" summary) were stranded below its old `147` end → now covered by `122–163`.
- `path_ramsey_linear`/`cycle_ramsey_linear`/`probabilistic_lower_bound`, `Problem545Conjecture`, and both `erdos_546_solved`/`erdos_546_tight` re-aligned.
- Also folded `ThreeColorConjecture` into the Multi-Color section.
- Coverage now runs to EOF (was 13 lines short).

### erdos-548
Every section from Part II onward had drifted **10–17 lines early** (pre-existing); each section's title already names the correct Part, so this is a pure snap to the `## Part I–X` banners. Coverage now runs to EOF (was 17 lines short).

Verified: both `meta.json` parse; section ranges contiguous through EOF; every declaration named in a summary now falls within its section. No prose, status, badge, or axiomCount changes.


### erdos-558 (added)
Audit #40905 (scope `chung_graham_bounds` to `t>=2`) shortened the file. Part 3 stopped at 100, stranding `chung_graham_bounds`@102; Parts 8-11 over-anchored **past EOF** (maxEnd 222 > 204 lines). Summaries were accurate (Parts 8-10 are explicit "exposition placeholder, no Lean decl") → snapped all ranges to the `## Part 3-11` banners. Contiguous through EOF.


### erdos-606 (added)
The 8 sections had drifted progressively **late** (file shortened over edits incl. audit #40839): "Beck's + Szemerédi-Trotter" (193-222) contained neither `beck_theorem`@161 nor `szemeredi_trotter_bound`@176, and the final section's named theorems (`erdos_606_solved`@204, `min_lines_noncollinear`@221) fell *outside* its 224-243 range. Snapped all sections to the `## Part I-X` banners (final section absorbs the Part X trailing-exposition banner). Contiguous through EOF.


### erdos-667 (added)
Part IX "Structural Consequences" names `erdos667_summary` in its summary but `endLine` 515 cut that theorem off (it spans 509-521) and left the file end uncovered. Extended `endLine` 515→523 (EOF).
