### PR TITLE
Audit: erdos-533 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14390,8 +14390,8 @@
     },
     "erdos-533": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:15Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T21:03:01Z",
       "result": "clean"
     },
     "erdos-534": {


### PR DESCRIPTION
Tracker update: erdos-533 audited CLEAN. Counts accurate (3 ax/0 sorry/27 thm/10 def/400 ln); 3 axioms all genuinely-true published results (Turán K5-free bound tight at n=4, EHSSS + K4-free partial results), correctly disclosed; main conjecture correctly a Prop (not axiom) with explanatory docstring; assumptions field exemplary; no phantom decls. Reserve pass.