### PR TITLE
Audit: erdos-538 re-verified clean (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14426,8 +14426,8 @@
     },
     "erdos-538": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:15Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T21:12:13Z",
       "result": "clean"
     },
     "erdos-539": {


### PR DESCRIPTION
## Reserve-mode re-audit

Queue is fully drained (0 unaudited of 4809). Round-robin re-served the oldest entry, `erdos-538` (last audited 2026-05-04).

### Verification (meta.json vs Lean source `Proofs/Erdos538Problem.lean`)
| Field | meta | actual | ✓ |
|---|---|---|---|
| axiomCount | 1 | 1 (`mertens_prime_reciprocal_lower`) | ✓ |
| theoremCount | 22 | 22 (17 top-level + 5 `private lemma`) | ✓ |
| definitionCount | 6 | 6 | ✓ |
| lineCount | 504 | 504 | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | — | none | ✓ |
| status/badge | axiomatized/axiom | correct for OPEN problem | ✓ |

- The single axiom (Mertens' second theorem) is disclosed in `assumptions`, `proofStrategy`, and the Mertens section summary.
- All proofStrategy/section-named lemmas (`harmonic_upper_bound`, `harmonic_sq_bound`, `double_counting_bound`, `erdos_upper_bound`, `multiplicative_energy_trivial_bound`, `r_eq_1_card_bound`) map to real declarations — no phantom names (contrast the sibling 53x/54x cluster).
- keyInsights honestly flags the multiplicative-energy bound as FALSE with a counterexample and proves the trivial bound instead.

**Result: CLEAN.** Tracker bumped auditCount 3→4.

---
Discovered during gallery integrity audit (reserve mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)