### PR TITLE
Research: erdos-510-wip-01 — quantitative bound minCosineSum A ≤ −1/2 (second moment)

### DIFF
--- a/proofs/Proofs/Erdos510WIP01.lean
+++ b/proofs/Proofs/Erdos510WIP01.lean
@@ -347,7 +347,9 @@ theorem integral_cos_mul_cos {n m : ℕ} (hn : 1 ≤ n) (hm : 1 ≤ m) :
       rw [intervalIntegral.integral_const, smul_eq_mul]; ring
     · rw [if_neg hnm,
         show ((n : ℝ) - (m : ℝ)) = (((n : ℤ) - (m : ℤ)) : ℝ) by push_cast; ring]
-      exact integral_cos_int_mul_eq_zero _ (sub_ne_zero.mpr (by exact_mod_cast hnm))
+      refine integral_cos_int_mul_eq_zero ((n : ℤ) - (m : ℤ)) ?_
+      rw [sub_ne_zero]
+      exact_mod_cast hnm
   rw [hfun, intervalIntegral.integral_add hI1 hI2,
       intervalIntegral.integral_const_mul, intervalIntegral.integral_const_mul, hsum, hdiff]
   by_cases hnm : n = m

--- a/proofs/Proofs/Erdos510WIP01.lean
+++ b/proofs/Proofs/Erdos510WIP01.lean
@@ -417,13 +417,17 @@ theorem minCosineSum_le_neg_half (A : Finset ℕ) (hA : 0 ∉ A) (hne : A.Nonemp
     intro θ _
     exact mul_nonneg (by linarith [hlow θ]) (by linarith [hupp θ])
   -- Evaluate that integral in closed form.
+  have hneg2 : IntervalIntegrable (fun θ => -(g θ) ^ 2) MeasureTheory.volume 0 (2 * π) :=
+    hg2_int.neg
+  have hcm : IntervalIntegrable (fun θ => (N + m) * g θ) MeasureTheory.volume 0 (2 * π) :=
+    hg_int.const_mul _
   have hA1 : IntervalIntegrable (fun θ => -(g θ) ^ 2 + (N + m) * g θ)
-      MeasureTheory.volume 0 (2 * π) := hg2_int.neg.add (hg_int.const_mul _)
+      MeasureTheory.volume 0 (2 * π) := hneg2.add hcm
   have hcompute : (∫ θ in (0 : ℝ)..(2 * π), (g θ - m) * (N - g θ)) = -(π * N) - 2 * π * m * N := by
     rw [intervalIntegral.integral_congr
           (fun θ _ => show (g θ - m) * (N - g θ) = -(g θ) ^ 2 + (N + m) * g θ - m * N by ring),
         intervalIntegral.integral_sub hA1 intervalIntegrable_const,
-        intervalIntegral.integral_add hg2_int.neg (hg_int.const_mul _),
+        intervalIntegral.integral_add hneg2 hcm,
         intervalIntegral.integral_neg, intervalIntegral.integral_const_mul,
         intervalIntegral.integral_const, I1, I2]
     simp only [smul_eq_mul]; ring

--- a/proofs/Proofs/Erdos510WIP01.lean
+++ b/proofs/Proofs/Erdos510WIP01.lean
@@ -345,11 +345,11 @@ theorem integral_cos_mul_cos {n m : ℕ} (hn : 1 ≤ n) (hm : 1 ≤ m) :
       have h0 : (n : ℝ) - (m : ℝ) = 0 := by rw [hnm]; ring
       simp only [h0, zero_mul, Real.cos_zero]
       rw [intervalIntegral.integral_const, smul_eq_mul]; ring
-    · rw [if_neg hnm,
-        show ((n : ℝ) - (m : ℝ)) = (((n : ℤ) - (m : ℤ)) : ℝ) by push_cast; ring]
-      refine integral_cos_int_mul_eq_zero ((n : ℤ) - (m : ℤ)) ?_
-      rw [sub_ne_zero]
-      exact_mod_cast hnm
+    · rw [if_neg hnm]
+      have hk : ((n : ℤ) - (m : ℤ)) ≠ 0 := by rw [sub_ne_zero]; exact_mod_cast hnm
+      have h := integral_cos_int_mul_eq_zero ((n : ℤ) - (m : ℤ)) hk
+      rw [Int.cast_sub, Int.cast_natCast, Int.cast_natCast] at h
+      exact h
   rw [hfun, intervalIntegral.integral_add hI1 hI2,
       intervalIntegral.integral_const_mul, intervalIntegral.integral_const_mul, hsum, hdiff]
   by_cases hnm : n = m

--- a/proofs/Proofs/Erdos510WIP01.lean
+++ b/proofs/Proofs/Erdos510WIP01.lean
@@ -283,4 +283,152 @@ theorem exists_angle_cosineSum_neg (A : Finset ℕ) (hA : 0 ∉ A) (hne : A.None
   obtain ⟨θ₀, hθ₀⟩ := exists_eq_minCosineSum A
   exact ⟨θ₀, hθ₀.trans_lt (minCosineSum_neg A hA hne)⟩
 
+/-! ## A quantitative uniform bound: `minCosineSum A ≤ −1/2`
+
+The strict bound `minCosineSum A < 0` above is qualitative.  A **second-moment / L²
+averaging** argument upgrades it to a *uniform quantitative constant*: every nonempty
+positive-frequency set satisfies `minCosineSum A ≤ −1/2`.  The mechanism is orthogonality
+of the characters `cos(nθ)` over a full period:
+
+* first moment  `∫₀^{2π} cosineSum A = 0`                    (`integral_cosineSum_eq_zero`);
+* second moment `∫₀^{2π} (cosineSum A)² = π · N`             (`integral_cosineSum_sq`).
+
+Writing `f = cosineSum A`, `m = minCosineSum A`, `N = |A|`, the sum obeys the pointwise
+sandwich `m ≤ f ≤ N`, so `(f − m)(N − f) ≥ 0` pointwise and its period integral is
+nonnegative.  Expanding, `∫(f − m)(N − f) = −πN − 2πmN ≥ 0`, and dividing by `2πN > 0`
+gives `m ≤ −1/2`.  This is a *fixed constant* — it does **not** grow like `√N` — so it is a
+genuinely different (and unblocked) result from the deep `−c√N` lower bound, which stays
+open. -/
+
+/-- A single nonzero-integer-frequency cosine integrates to zero over a full period.  The
+`ℤ`-frequency generalisation of `integral_cos_mul_eq_zero`, needed for the orthogonality
+relation where the difference frequency `n − m` can be negative. -/
+theorem integral_cos_int_mul_eq_zero (k : ℤ) (hk : k ≠ 0) :
+    ∫ θ in (0 : ℝ)..(2 * π), Real.cos ((k : ℝ) * θ) = 0 := by
+  have hck : (k : ℝ) ≠ 0 := Int.cast_ne_zero.mpr hk
+  rw [intervalIntegral.integral_comp_mul_left (f := fun x => Real.cos x) hck, integral_cos]
+  have h1 : Real.sin ((k : ℝ) * (2 * π)) = 0 := by
+    rw [show (k : ℝ) * (2 * π) = ((2 * k : ℤ) : ℝ) * π by push_cast; ring]
+    exact Real.sin_int_mul_pi (2 * k)
+  rw [mul_zero, h1, Real.sin_zero, sub_zero, smul_zero]
+
+/-- **Orthogonality of the cosine characters over a full period.**  For positive
+frequencies `n, m ≥ 1`,
+  `∫₀^{2π} cos(nθ)·cos(mθ) dθ = π` if `n = m` and `0` otherwise.
+Proof by the product-to-sum identity `cos(nθ)cos(mθ) = ½(cos((n+m)θ) + cos((n−m)θ))`: the
+`(n+m)`-term always integrates to `0` (positive frequency), while the `(n−m)`-term is
+`cos 0 = 1` (integral `2π`) exactly when `n = m` and integrates to `0` otherwise. -/
+theorem integral_cos_mul_cos {n m : ℕ} (hn : 1 ≤ n) (hm : 1 ≤ m) :
+    (∫ θ in (0 : ℝ)..(2 * π), Real.cos ((n : ℝ) * θ) * Real.cos ((m : ℝ) * θ))
+      = if n = m then π else 0 := by
+  have hpts : ∀ θ : ℝ, Real.cos ((n : ℝ) * θ) * Real.cos ((m : ℝ) * θ)
+      = (Real.cos (((n : ℝ) + (m : ℝ)) * θ) + Real.cos (((n : ℝ) - (m : ℝ)) * θ)) / 2 := by
+    intro θ
+    have e1 : ((n : ℝ) + (m : ℝ)) * θ = (n : ℝ) * θ + (m : ℝ) * θ := by ring
+    have e2 : ((n : ℝ) - (m : ℝ)) * θ = (n : ℝ) * θ - (m : ℝ) * θ := by ring
+    rw [e1, e2, Real.cos_add, Real.cos_sub]; ring
+  have hI1 : IntervalIntegrable (fun θ => Real.cos (((n : ℝ) + (m : ℝ)) * θ))
+      MeasureTheory.volume 0 (2 * π) :=
+    (Real.continuous_cos.comp (continuous_const.mul continuous_id)).intervalIntegrable _ _
+  have hI2 : IntervalIntegrable (fun θ => Real.cos (((n : ℝ) - (m : ℝ)) * θ))
+      MeasureTheory.volume 0 (2 * π) :=
+    (Real.continuous_cos.comp (continuous_const.mul continuous_id)).intervalIntegrable _ _
+  rw [intervalIntegral.integral_congr (fun θ _ => hpts θ),
+      intervalIntegral.integral_div, intervalIntegral.integral_add hI1 hI2]
+  have hsum : (∫ θ in (0 : ℝ)..(2 * π), Real.cos (((n : ℝ) + (m : ℝ)) * θ)) = 0 := by
+    rw [show ((n : ℝ) + (m : ℝ)) = ((n + m : ℕ) : ℝ) by push_cast; ring]
+    exact integral_cos_mul_eq_zero (by omega)
+  have hdiff : (∫ θ in (0 : ℝ)..(2 * π), Real.cos (((n : ℝ) - (m : ℝ)) * θ))
+      = if n = m then 2 * π else 0 := by
+    by_cases hnm : n = m
+    · rw [if_pos hnm]
+      have h0 : (n : ℝ) - (m : ℝ) = 0 := by rw [hnm]; ring
+      simp only [h0, zero_mul, Real.cos_zero]
+      rw [intervalIntegral.integral_const, smul_eq_mul]; ring
+    · rw [if_neg hnm,
+        show ((n : ℝ) - (m : ℝ)) = (((n : ℤ) - (m : ℤ)) : ℝ) by push_cast; ring]
+      exact integral_cos_int_mul_eq_zero _ (sub_ne_zero.mpr (by exact_mod_cast hnm))
+  rw [hsum, zero_add, hdiff]
+  by_cases hnm : n = m
+  · rw [if_pos hnm, if_pos hnm]; ring
+  · rw [if_neg hnm, if_neg hnm]; norm_num
+
+/-- **The second moment of the Chowla cosine sum: `∫₀^{2π} (cosineSum A)² = π · |A|`.**
+Expand the square as the double sum `∑_{n,m} cos(nθ)cos(mθ)`, integrate term by term, and
+apply orthogonality (`integral_cos_mul_cos`): only the diagonal `n = m` survives, each
+contributing `π`, for a total of `π · |A|`.  (Requires `0 ∉ A` so every frequency is
+`≥ 1`.) -/
+theorem integral_cosineSum_sq (A : Finset ℕ) (hA : 0 ∉ A) :
+    ∫ θ in (0 : ℝ)..(2 * π), (cosineSum A θ) ^ 2 = π * A.card := by
+  have hexp : ∀ θ : ℝ, (cosineSum A θ) ^ 2
+      = ∑ n ∈ A, ∑ m ∈ A, Real.cos ((n : ℝ) * θ) * Real.cos ((m : ℝ) * θ) := by
+    intro θ
+    rw [sq]
+    simp only [cosineSum]
+    rw [Finset.sum_mul_sum]
+  have hcont : ∀ n : ℕ, Continuous (fun θ : ℝ => Real.cos ((n : ℝ) * θ)) :=
+    fun n => Real.continuous_cos.comp (continuous_const.mul continuous_id)
+  have hintprod : ∀ n m : ℕ, IntervalIntegrable
+      (fun θ => Real.cos ((n : ℝ) * θ) * Real.cos ((m : ℝ) * θ)) MeasureTheory.volume 0 (2 * π) :=
+    fun n m => ((hcont n).mul (hcont m)).intervalIntegrable _ _
+  have hintinner : ∀ n : ℕ, IntervalIntegrable
+      (fun θ => ∑ m ∈ A, Real.cos ((n : ℝ) * θ) * Real.cos ((m : ℝ) * θ))
+      MeasureTheory.volume 0 (2 * π) :=
+    fun n => (continuous_finset_sum A (fun m _ => (hcont n).mul (hcont m))).intervalIntegrable _ _
+  rw [intervalIntegral.integral_congr (fun θ _ => hexp θ),
+      intervalIntegral.integral_finsetSum A (fun n _ => hintinner n)]
+  have hstep : ∀ n ∈ A,
+      (∫ θ in (0 : ℝ)..(2 * π), ∑ m ∈ A, Real.cos ((n : ℝ) * θ) * Real.cos ((m : ℝ) * θ))
+        = ∑ m ∈ A, if n = m then π else (0 : ℝ) := by
+    intro n hn
+    rw [intervalIntegral.integral_finsetSum A (fun m _ => hintprod n m)]
+    refine Finset.sum_congr rfl (fun m hm => ?_)
+    exact integral_cos_mul_cos (Nat.one_le_iff_ne_zero.mpr (fun h => hA (h ▸ hn)))
+      (Nat.one_le_iff_ne_zero.mpr (fun h => hA (h ▸ hm)))
+  rw [Finset.sum_congr rfl hstep]
+  have hdiag : ∀ n ∈ A, (∑ m ∈ A, if n = m then π else (0 : ℝ)) = π := by
+    intro n hn
+    rw [Finset.sum_ite_eq A n (fun _ => (π : ℝ)), if_pos hn]
+  rw [Finset.sum_congr rfl hdiag, Finset.sum_const, nsmul_eq_mul]
+  ring
+
+/-- **Uniform quantitative bound: `minCosineSum A ≤ −1/2`** for every nonempty
+positive-frequency set.  Second-moment argument: with `f = cosineSum A`, `m = minCosineSum A`,
+`N = |A|`, the first and second moments are `∫f = 0` and `∫f² = πN`, and `m ≤ f ≤ N`
+pointwise.  Hence `∫(f − m)(N − f) ≥ 0`; expanding gives `−πN − 2πmN ≥ 0`, so `m ≤ −1/2`.
+A fixed constant (not the deep `−c√N` growth), and strictly sharper than `minCosineSum_neg`. -/
+theorem minCosineSum_le_neg_half (A : Finset ℕ) (hA : 0 ∉ A) (hne : A.Nonempty) :
+    minCosineSum A ≤ -1 / 2 := by
+  set g := cosineSum A with hg
+  set m := minCosineSum A with hm
+  set N : ℝ := (A.card : ℝ) with hN
+  have hNpos : 0 < N := by rw [hN]; exact_mod_cast Finset.card_pos.mpr hne
+  have I1 : ∫ θ in (0 : ℝ)..(2 * π), g θ = 0 := integral_cosineSum_eq_zero A hA
+  have I2 : ∫ θ in (0 : ℝ)..(2 * π), (g θ) ^ 2 = π * N := integral_cosineSum_sq A hA
+  have hlow : ∀ θ, m ≤ g θ := fun θ => minCosineSum_le A θ
+  have hupp : ∀ θ, g θ ≤ N := fun θ => cosineSum_le_card A θ
+  have hg_int : IntervalIntegrable g MeasureTheory.volume 0 (2 * π) :=
+    (continuous_cosineSum A).intervalIntegrable _ _
+  have hg2_int : IntervalIntegrable (fun θ => (g θ) ^ 2) MeasureTheory.volume 0 (2 * π) :=
+    ((continuous_cosineSum A).pow 2).intervalIntegrable _ _
+  -- The nonnegative integrand `(f − m)(N − f)`.
+  have hnonneg : 0 ≤ ∫ θ in (0 : ℝ)..(2 * π), (g θ - m) * (N - g θ) := by
+    apply intervalIntegral.integral_nonneg (by positivity)
+    intro θ _
+    exact mul_nonneg (by linarith [hlow θ]) (by linarith [hupp θ])
+  -- Evaluate that integral in closed form.
+  have hA1 : IntervalIntegrable (fun θ => -(g θ) ^ 2 + (N + m) * g θ)
+      MeasureTheory.volume 0 (2 * π) := hg2_int.neg.add (hg_int.const_mul _)
+  have hcompute : (∫ θ in (0 : ℝ)..(2 * π), (g θ - m) * (N - g θ)) = -(π * N) - 2 * π * m * N := by
+    rw [intervalIntegral.integral_congr
+          (fun θ _ => show (g θ - m) * (N - g θ) = -(g θ) ^ 2 + (N + m) * g θ - m * N by ring),
+        intervalIntegral.integral_sub hA1 intervalIntegrable_const,
+        intervalIntegral.integral_add hg2_int.neg (hg_int.const_mul _),
+        intervalIntegral.integral_neg, intervalIntegral.integral_const_mul,
+        intervalIntegral.integral_const, I1, I2]
+    simp only [smul_eq_mul]; ring
+  rw [hcompute] at hnonneg
+  have hpi : 0 < π := Real.pi_pos
+  nlinarith [hnonneg, mul_pos hpi hNpos]
+
 end Erdos510WIP01

--- a/proofs/Proofs/Erdos510WIP01.lean
+++ b/proofs/Proofs/Erdos510WIP01.lean
@@ -318,24 +318,23 @@ frequencies `n, m ≥ 1`,
 Proof by the product-to-sum identity `cos(nθ)cos(mθ) = ½(cos((n+m)θ) + cos((n−m)θ))`: the
 `(n+m)`-term always integrates to `0` (positive frequency), while the `(n−m)`-term is
 `cos 0 = 1` (integral `2π`) exactly when `n = m` and integrates to `0` otherwise. -/
-set_option maxHeartbeats 800000 in
 theorem integral_cos_mul_cos {n m : ℕ} (hn : 1 ≤ n) (hm : 1 ≤ m) :
     (∫ θ in (0 : ℝ)..(2 * π), Real.cos ((n : ℝ) * θ) * Real.cos ((m : ℝ) * θ))
       = if n = m then π else 0 := by
-  have hpts : ∀ θ : ℝ, Real.cos ((n : ℝ) * θ) * Real.cos ((m : ℝ) * θ)
-      = (Real.cos (((n : ℝ) + (m : ℝ)) * θ) + Real.cos (((n : ℝ) - (m : ℝ)) * θ)) / 2 := by
-    intro θ
+  -- product-to-sum, as a function equality (avoids `integral_congr`/`integral_div` whnf blowup)
+  have hfun : (fun θ : ℝ => Real.cos ((n : ℝ) * θ) * Real.cos ((m : ℝ) * θ))
+      = fun θ => (1 / 2) * Real.cos (((n : ℝ) + (m : ℝ)) * θ)
+                 + (1 / 2) * Real.cos (((n : ℝ) - (m : ℝ)) * θ) := by
+    funext θ
     have e1 : ((n : ℝ) + (m : ℝ)) * θ = (n : ℝ) * θ + (m : ℝ) * θ := by ring
     have e2 : ((n : ℝ) - (m : ℝ)) * θ = (n : ℝ) * θ - (m : ℝ) * θ := by ring
     rw [e1, e2, Real.cos_add, Real.cos_sub]; ring
-  have hI1 : IntervalIntegrable (fun θ => Real.cos (((n : ℝ) + (m : ℝ)) * θ))
+  have hI1 : IntervalIntegrable (fun θ => (1 / 2) * Real.cos (((n : ℝ) + (m : ℝ)) * θ))
       MeasureTheory.volume 0 (2 * π) :=
-    (Real.continuous_cos.comp (continuous_const.mul continuous_id)).intervalIntegrable _ _
-  have hI2 : IntervalIntegrable (fun θ => Real.cos (((n : ℝ) - (m : ℝ)) * θ))
+    ((Real.continuous_cos.comp (continuous_const.mul continuous_id)).const_mul _).intervalIntegrable _ _
+  have hI2 : IntervalIntegrable (fun θ => (1 / 2) * Real.cos (((n : ℝ) - (m : ℝ)) * θ))
       MeasureTheory.volume 0 (2 * π) :=
-    (Real.continuous_cos.comp (continuous_const.mul continuous_id)).intervalIntegrable _ _
-  rw [intervalIntegral.integral_congr (fun θ _ => hpts θ),
-      intervalIntegral.integral_div, intervalIntegral.integral_add hI1 hI2]
+    ((Real.continuous_cos.comp (continuous_const.mul continuous_id)).const_mul _).intervalIntegrable _ _
   have hsum : (∫ θ in (0 : ℝ)..(2 * π), Real.cos (((n : ℝ) + (m : ℝ)) * θ)) = 0 := by
     rw [show ((n : ℝ) + (m : ℝ)) = ((n + m : ℕ) : ℝ) by push_cast; ring]
     exact integral_cos_mul_eq_zero (by omega)
@@ -349,10 +348,11 @@ theorem integral_cos_mul_cos {n m : ℕ} (hn : 1 ≤ n) (hm : 1 ≤ m) :
     · rw [if_neg hnm,
         show ((n : ℝ) - (m : ℝ)) = (((n : ℤ) - (m : ℤ)) : ℝ) by push_cast; ring]
       exact integral_cos_int_mul_eq_zero _ (sub_ne_zero.mpr (by exact_mod_cast hnm))
-  rw [hsum, zero_add, hdiff]
+  rw [hfun, intervalIntegral.integral_add hI1 hI2,
+      intervalIntegral.integral_const_mul, intervalIntegral.integral_const_mul, hsum, hdiff]
   by_cases hnm : n = m
   · rw [if_pos hnm, if_pos hnm]; ring
-  · rw [if_neg hnm, if_neg hnm]; norm_num
+  · rw [if_neg hnm, if_neg hnm]; ring
 
 /-- **The second moment of the Chowla cosine sum: `∫₀^{2π} (cosineSum A)² = π · |A|`.**
 Expand the square as the double sum `∑_{n,m} cos(nθ)cos(mθ)`, integrate term by term, and

--- a/proofs/Proofs/Erdos510WIP01.lean
+++ b/proofs/Proofs/Erdos510WIP01.lean
@@ -318,6 +318,7 @@ frequencies `n, m ≥ 1`,
 Proof by the product-to-sum identity `cos(nθ)cos(mθ) = ½(cos((n+m)θ) + cos((n−m)θ))`: the
 `(n+m)`-term always integrates to `0` (positive frequency), while the `(n−m)`-term is
 `cos 0 = 1` (integral `2π`) exactly when `n = m` and integrates to `0` otherwise. -/
+set_option maxHeartbeats 800000 in
 theorem integral_cos_mul_cos {n m : ℕ} (hn : 1 ≤ n) (hm : 1 ≤ m) :
     (∫ θ in (0 : ℝ)..(2 * π), Real.cos ((n : ℝ) * θ) * Real.cos ((m : ℝ) * θ))
       = if n = m then π else 0 := by
@@ -374,14 +375,14 @@ theorem integral_cosineSum_sq (A : Finset ℕ) (hA : 0 ∉ A) :
   have hintinner : ∀ n : ℕ, IntervalIntegrable
       (fun θ => ∑ m ∈ A, Real.cos ((n : ℝ) * θ) * Real.cos ((m : ℝ) * θ))
       MeasureTheory.volume 0 (2 * π) :=
-    fun n => (continuous_finset_sum A (fun m _ => (hcont n).mul (hcont m))).intervalIntegrable _ _
+    fun n => (continuous_finsetSum A (fun m _ => (hcont n).mul (hcont m))).intervalIntegrable _ _
   rw [intervalIntegral.integral_congr (fun θ _ => hexp θ),
-      intervalIntegral.integral_finsetSum A (fun n _ => hintinner n)]
+      intervalIntegral.integral_finsetSum (fun n _ => hintinner n)]
   have hstep : ∀ n ∈ A,
       (∫ θ in (0 : ℝ)..(2 * π), ∑ m ∈ A, Real.cos ((n : ℝ) * θ) * Real.cos ((m : ℝ) * θ))
         = ∑ m ∈ A, if n = m then π else (0 : ℝ) := by
     intro n hn
-    rw [intervalIntegral.integral_finsetSum A (fun m _ => hintprod n m)]
+    rw [intervalIntegral.integral_finsetSum (fun m _ => hintprod n m)]
     refine Finset.sum_congr rfl (fun m hm => ?_)
     exact integral_cos_mul_cos (Nat.one_le_iff_ne_zero.mpr (fun h => hA (h ▸ hn)))
       (Nat.one_le_iff_ne_zero.mpr (fun h => hA (h ▸ hm)))

--- a/src/data/research/problems/erdos-510-wip-01.json
+++ b/src/data/research/problems/erdos-510-wip-01.json
@@ -44,7 +44,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-07-20, researcher-1, VERIFIED 0-axiom host, print axioms = propext/Classical.choice/Quot.sound): minCosineSum A <= 0 for positive-frequency sets (0 not in A), via integral over full period = 0 (integral_cosineSum_eq_zero) and constant <= pointwise. Prior work: minCosineSum attained (exists_eq_minCosineSum), two-sided bounds, minCosineSum{n}=-1. Remaining: sharp -c*sqrt(N) bound (deep: Bourgain/Ruzsa/Bedert) and the Sidon sqrt(N)-optimality example.",
+    "progressSummary": "minCosineSum A ≤ 0 (integral avg) and strict <0 for nonempty positive-frequency A were established; NOW upgraded to a UNIFORM QUANTITATIVE constant minCosineSum A ≤ −1/2 (minCosineSum_le_neg_half) via a second-moment/L² argument: first moment ∫cosineSum=0, second moment ∫(cosineSum)²=π·N (integral_cosineSum_sq, from orthogonality integral_cos_mul_cos), and the sandwich m≤f≤N. Axiom-free. This is a materially new mechanism distinct from the still-open/blocked −c√N growth route (which needs Bourgain/Ruzsa/Bedert). Remaining: the sharp −c√N lower bound and the Sidon √N-optimality example.",
     "builtItems": [
       "cosineSum_empty / cosineSum_singleton / cosineSum_insert in Erdos510WIP01.lean",
       "cosineSum_zero_angle (cosineSum A 0 = N), cosineSum_pi (= ∑(−1)ⁿ)",
@@ -56,7 +56,11 @@
       "exists_eq_minCosineSum (Erdos510WIP01.lean): the infimum minCosineSum A is attained at a concrete angle, via periodicity + compactness of [0,2π] (2026-07-20)",
       "integral_cos_mul_eq_zero: integral over 0..2pi of cos(n*theta) = 0 for n>=1 (Erdos510WIP01.lean)",
       "integral_cosineSum_eq_zero: integral over 0..2pi of cosineSum A = 0 when 0 not in A",
-      "minCosineSum_nonpos: minCosineSum A <= 0 for positive-frequency sets (0 not in A)"
+      "minCosineSum_nonpos: minCosineSum A <= 0 for positive-frequency sets (0 not in A)",
+      "integral_cos_int_mul_eq_zero (Erdos510WIP01.lean): ℤ-frequency cos period integral = 0",
+      "integral_cos_mul_cos (Erdos510WIP01.lean): orthogonality ∫cos(nθ)cos(mθ)=π·[n=m]",
+      "integral_cosineSum_sq (Erdos510WIP01.lean): second moment ∫(cosineSum A)²=π·|A|",
+      "minCosineSum_le_neg_half (Erdos510WIP01.lean): minCosineSum A ≤ −1/2, all axiom-free"
     ],
     "insights": [
       "The trivial range of the cosine sum is [−N, N]; the conjectured extremal value −c√N sits strictly inside, so all elementary bounds are far from the truth — the content is entirely in the cancellation.",
@@ -64,7 +68,10 @@
       "Continuity + 2π-periodicity make minCosineSum an attained minimum, not merely an infimum; formalizing attainment is the natural next structural step.",
       "The θ=0 value N and θ=π value ∑(−1)ⁿ give cheap explicit witnesses bracketing the infimum.",
       "minCosineSum A <= 0 for 0 not in A: the average of cosineSum over a full period is 0, and minCosineSum is a pointwise lower bound, so integrating the constant gives 2pi*minCosineSum <= 0. This is the elementary sign fact behind Chowla (a positive-frequency cosine sum must dip to 0 or below).",
-      "Integral technique: intervalIntegral.integral_comp_mul_left (c!=0) reduces cos(n*theta) to n-inverse-scaled integral_cos = sin(n*2pi)-sin 0 = 0 (via Real.sin_nat_mul_pi with n*2pi = (2n)*pi); intervalIntegral.integral_finsetSum swaps finite sum and integral (each term Continuous.intervalIntegrable); intervalIntegral.integral_mono_on hab hf hg h + integral_const gives (2pi)*c bound; nlinarith [Real.two_pi_pos]. NOTE: needs imports Analysis.SpecialFunctions.Integrals.Basic + MeasureTheory.Integral.IntervalIntegral.Basic (the file did NOT import Mathlib fully)."
+      "Integral technique: intervalIntegral.integral_comp_mul_left (c!=0) reduces cos(n*theta) to n-inverse-scaled integral_cos = sin(n*2pi)-sin 0 = 0 (via Real.sin_nat_mul_pi with n*2pi = (2n)*pi); intervalIntegral.integral_finsetSum swaps finite sum and integral (each term Continuous.intervalIntegrable); intervalIntegral.integral_mono_on hab hf hg h + integral_const gives (2pi)*c bound; nlinarith [Real.two_pi_pos]. NOTE: needs imports Analysis.SpecialFunctions.Integrals.Basic + MeasureTheory.Integral.IntervalIntegral.Basic (the file did NOT import Mathlib fully).",
+      "Second-moment/L² averaging gives a UNIFORM QUANTITATIVE bound minCosineSum A ≤ −1/2 for every nonempty positive-frequency A (minCosineSum_le_neg_half). Mechanism: first moment ∫₀^{2π}cosineSum=0 and second moment ∫₀^{2π}(cosineSum)²=π·N (integral_cosineSum_sq), plus the pointwise sandwich m≤f≤N, give ∫(f−m)(N−f)≥0 ⟹ −πN−2πmN≥0 ⟹ m≤−1/2. A fixed constant, materially DISTINCT from the still-open −c√N growth route.",
+      "Orthogonality of cosine characters over a full period proved from scratch (integral_cos_mul_cos): ∫₀^{2π}cos(nθ)cos(mθ)=π·[n=m] for n,m≥1, via product-to-sum cos(nθ)cos(mθ)=½(cos((n+m)θ)+cos((n−m)θ)) and the ℤ-frequency period-integral vanishing integral_cos_int_mul_eq_zero.",
+      "Lean gotchas hit: (1) integral_congr+integral_div on a big integrand triggers a whnf timeout — rewrite the integrand as a funext function-equality then split with integral_add/integral_const_mul instead; (2) applying integral_cos_int_mul_eq_zero _ with a metavar k plus sub_ne_zero.mpr loops isDefEq — pin k=(n:ℤ)−(m:ℤ) explicitly; (3) (((n:ℤ)−(m:ℤ)):ℝ) elaborates to ↑↑n−↑↑m (difference of casts) not ↑(↑n−↑m) — normalize with Int.cast_sub/Int.cast_natCast."
     ],
     "mathlibGaps": [
       "No direct reduction of an ℝ-infimum of a periodic continuous function to a min over a fundamental period; needs a toIcoMod-style mod-2π reduction to formalize attainment."


### PR DESCRIPTION
## Summary
Upgrades the qualitative `minCosineSum A < 0` (Chowla's cosine problem, Erdős #510)
to a **uniform quantitative constant** `minCosineSum A ≤ −1/2`, via a second-moment /
L² averaging argument. Axiom-free, Docker-verified (`Built Proofs.Erdos510WIP01`).

## Progress
New lemmas in `Erdos510WIP01.lean`:
- **`integral_cos_int_mul_eq_zero`** — a nonzero-integer-frequency cosine integrates to
  `0` over a full period (the ℤ generalisation of the existing `integral_cos_mul_eq_zero`).
- **`integral_cos_mul_cos`** — orthogonality of the cosine characters:
  `∫₀^{2π} cos(nθ)·cos(mθ) = π·[n = m]` for `n, m ≥ 1`, via product-to-sum.
- **`integral_cosineSum_sq`** — the second moment `∫₀^{2π} (cosineSum A)² = π·|A|`
  (`0 ∉ A`), by expanding the square and applying orthogonality (only the diagonal survives).
- **`minCosineSum_le_neg_half`** — `minCosineSum A ≤ −1/2` for every nonempty
  positive-frequency `A`. With `f = cosineSum A`, `m = minCosineSum A`, `N = |A|`:
  moments `∫f = 0`, `∫f² = πN`, and the sandwich `m ≤ f ≤ N` give `∫(f − m)(N − f) ≥ 0`,
  i.e. `−πN − 2πmN ≥ 0`, hence `m ≤ −1/2`.

## Findings
- The bound is a **fixed constant**, not `√N` growth, so it is a genuinely different
  (and unblocked) result from the deep `−c√N` lower bound (Bourgain/Ruzsa/Bedert), which
  stays open and is registered as a blocked route.
- Lean gotchas recorded in the knowledge tracker: `integral_congr`+`integral_div` on a
  large integrand triggers a `whnf` timeout (rewrite the integrand as a `funext` function
  equality and split with `integral_add`/`integral_const_mul` instead); a metavariable
  frequency `k` plus `sub_ne_zero.mpr` loops `isDefEq` (pin `k = (n:ℤ) − (m:ℤ)`);
  `(((n:ℤ) − (m:ℤ)) : ℝ)` elaborates to `↑↑n − ↑↑m`, normalize with `Int.cast_sub`/`Int.cast_natCast`.

## Status
**Outcome**: progress
**Next Steps**: the sharp `−c√N` lower bound (deep, blocked) and the Sidon `√N`-optimality
example remain the open core.

🤖 Generated by researcher-1