### PR TITLE
Audit fix: erdos-534 remove phantom axiom/decl references from prose

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14396,9 +14396,9 @@
     },
     "erdos-534": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:15Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T21:16:59Z",
+      "result": "issues-fixed"
     },
     "erdos-535": {
       "agentId": "auditor-64117",

--- a/src/data/proofs/erdos-534/meta.json
+++ b/src/data/proofs/erdos-534/meta.json
@@ -53,14 +53,14 @@
     ],
     "originalContributions": [
       "interval, IsGCDIntersecting, ContainsN, maxGCDIntersecting definitions",
-      "multiplesOfSmallestPrime construction with size and intersecting axioms",
-      "evenMultiplesSharing construction with intersecting axiom",
+      "multiplesOfSmallestPrime construction (definition; size/intersecting property noted in comments, not formalized)",
+      "evenMultiplesSharing construction (definition; intersecting property noted in comments, not formalized)",
       "OriginalConjecture statement and original_conjecture_false axiom",
       "counterexample_exists axiom",
       "optimalFamily definition with 2qᵢ and product terms",
       "ahlswede_khachatrian_theorem axiom: correct characterization",
-      "prime_power_case and two_times_prime_case special cases",
-      "erdos_534_summary combining all main results"
+      "degenerate special cases (prime powers, 2p) described in comments, not formalized",
+      "erdos_534_summary combining the three axiomatized results"
     ],
     "axiomCount": 3,
     "lineCount": 131,
@@ -72,7 +72,7 @@
     "historicalContext": "Erdős and Graham posed this problem in their 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory': for a given N, find the largest subset A ⊆ {1,...,N} containing N where every pair of distinct elements shares a common factor greater than 1. The problem is an arithmetic analog of the classical Erdős-Ko-Rado theorem (1961), which characterizes maximum intersecting families of k-element subsets of an n-set. Here, 'intersecting' is replaced by the arithmetic condition gcd(a,b) > 1.\n\nErdős and Graham conjectured that the maximum is attained either by the multiples of the smallest prime factor p of N (giving ⌊N/p⌋ elements) or by the even numbers sharing a factor with N. This conjecture was natural: for prime powers N = p^k, multiples of p clearly give p^(k-1), and for even N with many small prime factors, the even-multiples construction performs well.\n\nHowever, Ahlswede and Khachatrian found a counterexample in 1992, showing that for certain N with multiple small prime factors, a more sophisticated construction beats both candidates. They then proved the complete characterization in 1996: the optimal family uses divisibility by elements from the set {2q₁,...,2qⱼ, q₁⋯qⱼ} where q₁ < ⋯ < qⱼ are the first j prime factors of N, and j is chosen optimally. This parallels their celebrated 'Complete Intersection Theorem' for Erdős-Ko-Rado problems, which similarly revealed that naive conjectures about extremal intersecting families can fail.",
     "problemStatement": "**Problem Statement (SOLVED)**\n\nWhat is the largest $A \\subseteq \\{1, \\ldots, N\\}$ containing $N$ such that $\\gcd(a, b) > 1$ for all distinct $a, b \\in A$?\n\n**Answer:** For $N = q_1^{k_1} \\cdots q_r^{k_r}$ (distinct primes $q_1 < \\cdots < q_r$), the maximum is achieved by integers that are multiples of at least one of $\\{2q_1, \\ldots, 2q_j, q_1 \\cdots q_j\\}$ for some optimal $1 \\leq j \\leq r$.\n\n**Note:** The original Erdős-Graham conjecture was wrong!",
     "text": "What is the largest subset A ⊆ {1,...,N} containing N such that gcd(a,b) > 1 for all distinct a,b ∈ A? Solved by Ahlswede-Khachatrian (1996) who proved the optimal sets use multiples of {2q₁,...,2qⱼ, q₁⋯qⱼ}.",
-    "proofStrategy": "The formalization proceeds in five stages:\n\n1. **Definitions**: interval, IsGCDIntersecting, ContainsN, maxGCDIntersecting — the basic framework for stating the extremal problem.\n\n2. **Simple constructions**: multiplesOfSmallestPrime and evenMultiplesSharing, with axioms for their GCD-intersecting property and sizes — the two candidates from the original conjecture.\n\n3. **Disproved conjecture**: OriginalConjecture is stated and axiomatized as false, with counterexample_exists witnessing a specific N where the optimal family exceeds both simple candidates.\n\n4. **Correct characterization**: optimalFamily encodes the Ahlswede-Khachatrian construction, and ahlswede_khachatrian_theorem axiomatizes that this achieves the maximum for all N > 1.\n\n5. **Special cases and summary**: prime_power_case and two_times_prime_case cover the degenerate cases, and erdos_534_summary packages everything into a single proved theorem.",
+    "proofStrategy": "The formalization proceeds in five stages:\n\n1. **Definitions**: interval, IsGCDIntersecting, ContainsN, maxGCDIntersecting — the basic framework for stating the extremal problem.\n\n2. **Simple constructions**: multiplesOfSmallestPrime and evenMultiplesSharing (definitions; their GCD-intersecting property and sizes are noted in comments, not formalized) — the two candidates from the original conjecture.\n\n3. **Disproved conjecture**: OriginalConjecture is stated and axiomatized as false, with counterexample_exists witnessing a specific N where the optimal family exceeds both simple candidates.\n\n4. **Correct characterization**: optimalFamily encodes the Ahlswede-Khachatrian construction, and ahlswede_khachatrian_theorem axiomatizes that this achieves the maximum for all N > 1.\n\n5. **Special cases and summary**: the degenerate cases (prime powers and N = 2p) are noted in comments (not formalized), and erdos_534_summary packages the three axiomatized results into a single theorem.",
     "keyInsights": [
       "**Original conjecture disproved**: The max is NOT simply N/p or even multiples sharing factor — Ahlswede-Khachatrian (1992) found counterexamples for N with multiple small prime factors",
       "**Optimal construction uses mixed divisibility**: The family {2q₁,...,2qⱼ, q₁⋯qⱼ} combines 'double-prime' divisors with a product divisor, a non-obvious structure",
@@ -96,7 +96,7 @@
     {
       "id": "simple-constructions",
       "title": "Simple Constructions",
-      "summary": "Defines multiplesOfSmallestPrime (all multiples of p = minFac(N)) and evenMultiplesSharing (even numbers sharing a factor with N), with axioms for size and GCD-intersecting property.",
+      "summary": "Defines multiplesOfSmallestPrime (all multiples of p = minFac(N)) and evenMultiplesSharing (even numbers sharing a factor with N); their size and GCD-intersecting property are noted in comments, not formalized.",
       "startLine": 52,
       "endLine": 74
     },
@@ -117,7 +117,7 @@
     {
       "id": "special-cases",
       "title": "Special Cases",
-      "summary": "Axiomatizes prime_power_case (maxGCDIntersecting(p^k) = p^(k-1)) and two_times_prime_case (maxGCDIntersecting(2p) = 2).",
+      "summary": "Comments note the degenerate special cases — maxGCDIntersecting(p^k) = p^(k-1) for prime powers and maxGCDIntersecting(2p) = 2 — but these are not formalized (no axioms or theorems).",
       "startLine": 110,
       "endLine": 121
     },


### PR DESCRIPTION
## Gallery integrity fix (LOW severity — phantom prose, honest counts)

**Proof**: erdos-534 (Maximum GCD-Intersecting Sets Containing N — SOLVED, Ahlswede-Khachatrian)

The file honestly axiomatizes the solved result: **3 axioms, 0 sorries, status=axiomatized, badge=axiom** — all counts in meta match the Lean source (`Proofs/Erdos534Problem.lean`). No inconsistency: the 3 axioms are TRUE historical statements (AK 1992 counterexample + 1996 characterization) and `erdos_534_summary` merely packages them.

### Problem: narrative fields named axioms/declarations that don't exist
Only 3 axioms exist (`original_conjecture_false`, `counterexample_exists`, `ahlswede_khachatrian_theorem`). But the prose claimed several more:

| Field | Phantom claim | Reality |
|---|---|---|
| originalContributions | "multiplesOfSmallestPrime ... with size and intersecting **axioms**" | only comments (lines 57–58) |
| originalContributions | "evenMultiplesSharing ... with intersecting **axiom**" | only a comment |
| originalContributions / proofStrategy / [special-cases] | **`prime_power_case`** and **`two_times_prime_case`** axioms | comment-only (lines 101–102); `grep` confirms neither name exists anywhere in `proofs/` |
| [simple-constructions] section | "with **axioms** for size and GCD-intersecting property" | none exist |

Had these been real, axiomCount would be 5, not 3. The counts were honest; the narrative overstated formalization scope.

### Fix
Rewrote the affected `originalContributions`, `proofStrategy`, and two section summaries to state these properties/special-cases are **noted in comments, not formalized**. `axiomCount` stays 3. JSON validated.

Tracker: erdos-534 marked `issues-fixed`.

---
Discovered during gallery integrity audit (reserve mode). Matches the recurring 53x/54x-cluster pattern of auto-generated prose inventing phantom bound/case lemmas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)