### PR TITLE
Research: erdos-70-wip-01 — ε₀ is a countable ordinal (tower-closure capstone)

### DIFF
--- a/proofs/Proofs/Erdos70WIP01.lean
+++ b/proofs/Proofs/Erdos70WIP01.lean
@@ -209,4 +209,49 @@ theorem erdos_70_conjecture_imp_omega_tower_two (h : erdos_70_conjecture) (n : �
   h (Ordinal.omega0 ^ (Ordinal.omega0 ^ Ordinal.omega0)) n
     omega0_opow_omega0_opow_omega0_countable hn
 
+/-! ## Capstone: `ε₀` is a countable ordinal
+
+The tower witnesses above (`ω`, `ω^ω`, `ω^(ω^ω)`) each handle a *fixed finite* level.
+The `ω`-tower `T 0 = ω`, `T (n+1) = ω ^ T n` runs through all of them, and its supremum
+`⨆ₙ T n` is `ε₀`, the least fixed point of `ξ ↦ ω^ξ` (the least epsilon number).  Since
+every level `T n` is countable (`isCountableOrdinal_opow`, by induction) and the index set
+`ℕ` is countable, the supremum stays below `ω₁` (regularity of `ℵ₁`,
+`Ordinal.iSup_lt_omega_one`).  So `ε₀` — the top of the whole exponential hierarchy over
+`ω`, and the exact boundary the file's narrative points at — is itself a *countable*
+ordinal, and the parent conjecture's hypothesis `IsCountableOrdinal β` holds all the way up
+to and including it. -/
+
+/-- The `ω`-tower `T 0 = ω`, `T (n+1) = ω ^ (T n)`: the sequence `ω, ω^ω, ω^(ω^ω), …`
+whose supremum is `ε₀`. -/
+def omegaTower : ℕ → Ordinal
+  | 0 => Ordinal.omega0
+  | (n + 1) => Ordinal.omega0 ^ (omegaTower n)
+
+/-- Every level of the `ω`-tower is a countable ordinal (induction on `n`, using the
+general exponentiation closure `isCountableOrdinal_opow`). -/
+theorem omegaTower_countable : ∀ n, IsCountableOrdinal (omegaTower n)
+  | 0 => omega0_countable
+  | (n + 1) => isCountableOrdinal_opow omega0_countable (omegaTower_countable n)
+
+/-- **`ε₀` is a countable ordinal.**  `ε₀ = ⨆ₙ (ω`-tower `n)` is a countable (`ℕ`-indexed)
+supremum of the countable ordinals `omegaTower_countable`, hence `< ω₁`
+(`Ordinal.iSup_lt_omega_one`).  This is the capstone of the tower-closure development: the
+supremum of the entire exponential hierarchy `ω, ω^ω, ω^(ω^ω), …` — the least epsilon
+number — remains countable. -/
+theorem iSup_omegaTower_countable :
+    IsCountableOrdinal (⨆ n : ℕ, omegaTower n) := by
+  rw [isCountableOrdinal_iff_lt_omega_one]
+  apply Ordinal.iSup_lt_omega_one
+  intro n
+  exact isCountableOrdinal_iff_lt_omega_one.mp (omegaTower_countable n)
+
+/-- The open conjecture specializes all the way to `ε₀`: `𝔠 → (ε₀, n)₂³`, using the
+countability witness `iSup_omegaTower_countable`.  Every ordinal in the naturally-described
+exponential hierarchy over `ω`, up to and including its `ε₀` limit, is a valid instance of
+the parent conjecture. -/
+theorem erdos_70_conjecture_imp_epsilon0 (h : erdos_70_conjecture) (n : ℕ)
+    (hn : 2 ≤ n) :
+    PartitionArrow continuum_card (⨆ k : ℕ, omegaTower k) n :=
+  h (⨆ k : ℕ, omegaTower k) n iSup_omegaTower_countable hn
+
 end Erdos70

--- a/proofs/Proofs/Erdos70WIP01.lean
+++ b/proofs/Proofs/Erdos70WIP01.lean
@@ -223,7 +223,7 @@ to and including it. -/
 
 /-- The `ω`-tower `T 0 = ω`, `T (n+1) = ω ^ (T n)`: the sequence `ω, ω^ω, ω^(ω^ω), …`
 whose supremum is `ε₀`. -/
-def omegaTower : ℕ → Ordinal
+noncomputable def omegaTower : ℕ → Ordinal
   | 0 => Ordinal.omega0
   | (n + 1) => Ordinal.omega0 ^ (omegaTower n)
 

--- a/src/data/research/problems/erdos-70-wip-01.json
+++ b/src/data/research/problems/erdos-70-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Countable-ordinal class proved closed under +, ·, and (this session) general exponentiation α^β; conjecture specialized to the ω, ω², ω^ω, and ω^(ω^ω) tower levels. 0 axioms, 0 sorries.",
+    "progressSummary": "Countable-ordinal class proved closed under +, ·, and general exponentiation α^β; tower levels ω, ω², ω^ω, ω^(ω^ω) countable. NEW capstone: ε₀ (=⨆ₙ ω-tower, the least epsilon number / least fixed point of ξ↦ω^ξ) is a countable ordinal (iSup_omegaTower_countable), and the conjecture specializes to 𝔠→(ε₀,n). This closes the naturally-described exponential hierarchy over ω up to and including its ε₀ limit. 0 axioms, 0 sorries.",
     "builtItems": [
       "Erdos70.IsCountableOrdinal.of_le in Erdos70WIP01.lean",
       "Erdos70.isCountableOrdinal_add in Erdos70WIP01.lean",
@@ -42,14 +42,19 @@
       "omega0_opow_nat_countable — every finite power ω^n is countable, generalizing omega0_squared_countable (Erdos70WIP01.lean)",
       "isCountableOrdinal_iff_lt_omega_one in Erdos70WIP01.lean — bridge card≤ℵ₀ ↔ <ω₁",
       "omega0_opow_omega0_countable in Erdos70WIP01.lean — ω^ω is a countable ordinal (the tower witness)",
-      "erdos_70_conjecture_imp_omega_tower in Erdos70WIP01.lean — specializes the open conjecture to β=ω^ω"
+      "erdos_70_conjecture_imp_omega_tower in Erdos70WIP01.lean — specializes the open conjecture to β=ω^ω",
+      "omegaTower (Erdos70WIP01.lean): ω-tower ℕ→Ordinal",
+      "omegaTower_countable + iSup_omegaTower_countable: ε₀ countable, axiom-free",
+      "erdos_70_conjecture_imp_epsilon0: conjecture specialized to ε₀"
     ],
     "insights": [
       "The parent proved specific instances (omega0_plus_n_countable, omega0_squared_countable); these are corollaries of three general closure lemmas: IsCountableOrdinal is downward-closed (Ordinal.card_le_card), and closed under ordinal + (Cardinal.add_le_aleph0) and * (mul_le_mul + Cardinal.aleph0_mul_aleph0).",
       "The open conjecture erdos_70_conjecture (∀ countable β, 2≤n, PartitionArrow c β n) specializes definitionally to conjecture_omega n and conjecture_omega_squared n by feeding the parent countability witnesses omega0_countable / omega0_squared_countable.",
       "Closure under α^n follows by induction: α^0=1 (one_countable), α^(n+1)=α^n·α countable by IsCountableOrdinal.mul. Ordinal.opow_succ is stated with Order.succ, so route the step via Nat.cast_add + Ordinal.opow_add + Ordinal.opow_one to match the ↑n+1 shape.",
       "Session 3: proved ω^ω is a countable ordinal (omega0_opow_omega0_countable), the limit-exponent case the finite-power closure isCountableOrdinal_opow_nat could not reach. Route: bridge IsCountableOrdinal α ↔ α<ω₁ (Cardinal.lt_omega_iff_card_lt + Cardinal.lt_aleph_one_iff), then ω^ω = sup_{β<ω} ω^β ≤ ⨆ n:ℕ ω^n, a countable sup of countable ordinals, so <ω₁ by Ordinal.iSup_lt_omega_one (regularity of ℵ₁).",
-      "Session 3: key Mathlib lemmas — Ordinal.opow_le_of_isSuccLimit (ω^ω ≤ c ↔ ∀β<ω, ω^β≤c), Ordinal.isSuccLimit_omega0, Ordinal.lt_omega0 (β<ω ↔ β=k:ℕ), Ordinal.le_iSup/iSup_le (needs Small.{0} ℕ). Universe must be pinned to Ordinal.{0} (via .{0}) to match the parent's conjecture_omega_tower (Ordinal.{0})."
+      "Session 3: key Mathlib lemmas — Ordinal.opow_le_of_isSuccLimit (ω^ω ≤ c ↔ ∀β<ω, ω^β≤c), Ordinal.isSuccLimit_omega0, Ordinal.lt_omega0 (β<ω ↔ β=k:ℕ), Ordinal.le_iSup/iSup_le (needs Small.{0} ℕ). Universe must be pinned to Ordinal.{0} (via .{0}) to match the parent's conjecture_omega_tower (Ordinal.{0}).",
+      "Capstone: ε₀ is a countable ordinal. Defined the ω-tower omegaTower (T0=ω, T(n+1)=ω^Tn) and proved iSup_omegaTower_countable: ⨆ₙ Tn = ε₀ is a countable ℕ-indexed supremum of countable ordinals (each via isCountableOrdinal_opow), hence <ω₁ by Ordinal.iSup_lt_omega_one (regularity of ℵ₁). The least epsilon number — top of the whole exponential hierarchy over ω — is countable. Conjecture specializes to 𝔠→(ε₀,n) (erdos_70_conjecture_imp_epsilon0).",
+      "Lean gotcha: an ordinal-valued recursive def using ^ (Ordinal.instPow noncomputable) must be marked noncomputable."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Caps the erdos-70-wip-01 countable-ordinal closure development with its natural endpoint:
**ε₀ (the least epsilon number) is a countable ordinal.** Axiom-free, 0 sorries,
Docker-verified (`Built Proofs.Erdos70WIP01`).

## Progress
The file already proved the countable ordinals are closed under `+`, `·`, and general
exponentiation `α^β`, with tower witnesses for `ω`, `ω^ω`, `ω^(ω^ω)`. This adds the limit:
- **`omegaTower`** — the `ω`-tower `T 0 = ω`, `T (n+1) = ω ^ (T n)` (levels `ω, ω^ω, ω^(ω^ω), …`).
- **`omegaTower_countable`** — every level is countable (induction on `n` via `isCountableOrdinal_opow`).
- **`iSup_omegaTower_countable`** — `ε₀ = ⨆ₙ (T n)` is a countable (`ℕ`-indexed) supremum of
  countable ordinals, hence `< ω₁` by `Ordinal.iSup_lt_omega_one` (regularity of `ℵ₁`).
  The least fixed point of `ξ ↦ ω^ξ` remains countable.
- **`erdos_70_conjecture_imp_epsilon0`** — the open conjecture specializes to `𝔠 → (ε₀, n)₂³`.

## Findings
- Every ordinal in the naturally-described exponential hierarchy over `ω`, up to and
  including its `ε₀` limit, is a valid `IsCountableOrdinal` instance of the parent conjecture.
- Gotcha: an ordinal-valued recursive `def` using `^` must be `noncomputable` (`Ordinal.instPow`).

## Status
**Outcome**: progress (closure development capped at ε₀)
**Next Steps**: the partition relation `𝔠 → (β, n)₂³` itself (the open combinatorial core of
Erdős #70) remains beyond current Mathlib; this line supplies countability witnesses only.

🤖 Generated by researcher-1