### PR TITLE
Audit fix: erdos-528 remove ~12 phantom decl references from prose

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14348,9 +14348,9 @@
     },
     "erdos-528": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:15Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T21:21:49Z",
+      "result": "issues-fixed"
     },
     "erdos-529": {
       "auditCount": 6,

--- a/src/data/proofs/erdos-528/meta.json
+++ b/src/data/proofs/erdos-528/meta.json
@@ -54,18 +54,15 @@
       "LatticePoint, Walk, areNeighbors definitions for ℤ^k",
       "isSAW predicate: startsAtOrigin ∧ isConnected ∧ isSelfAvoiding",
       "sawCount axiom: counting function f(n,k)",
-      "f_zero, f_one: base cases f(0,k)=1, f(1,k)=2k",
-      "limit_exists axiom (Hammersley-Morton 1954) via Fekete's lemma",
-      "connectiveConstant definition using Classical.choose",
-      "trivial_bounds theorem: k ≤ μ_k ≤ 2k-1",
-      "kesten_asymptotic and kesten_first_order axioms",
-      "conway_guttmann_lower, alm_upper, jsg_computation for C_2",
-      "large_k_limit, normalized_limit: asymptotic behavior as k → ∞",
-      "mu_honeycomb definition and honeycomb_exact axiom (Duminil-Copin/Smirnov)",
-      "mu2_closed_form_conjecture and irrationality_conjecture definitions",
-      "saw_counts_2d: exact enumeration for n ≤ 5 in 2D",
-      "critical_exponent_exists and gamma_2d_conjecture_value axioms",
-      "erdos_528_summary combining limit existence, bounds, and 2D results"
+      "limit_exists axiom (Hammersley-Morton 1954; submultiplicativity/Fekete argument taken as axiom, not proved)",
+      "connectiveConstant (μ_k) definition using Classical.choose",
+      "connective_lower_bound, connective_upper_bound axioms and trivial_bounds theorem: k ≤ μ_k ≤ 2k-1",
+      "kesten_asymptotic axiom: μ_k = 2k-1 - 1/(2k) + O(1/k²)",
+      "conway_guttmann_lower, alm_upper axioms and two_d_bounds theorem: 2.62 ≤ μ_2 ≤ 2.696",
+      "mu2_value definition: numeric C_2 = 2.6381585...",
+      "mu3_estimate, mu_honeycomb (= √(2+√2)) definitions (stated, not proved)",
+      "mu2_closed_form_conjecture and irrationality_conjecture Prop definitions (open)",
+      "erdos_528_summary theorem combining limit existence, trivial bounds, and 2D bounds"
     ],
     "axiomCount": 7,
     "lineCount": 196,
@@ -77,7 +74,7 @@
     "historicalContext": "**Erdős Problem #528: Connective Constant for Self-Avoiding Walks**\n\nA self-avoiding walk (SAW) is a path on a lattice that never revisits any vertex — this models polymers in chemistry and physics. The connective constant C_k = lim f(n,k)^{1/n} measures the exponential growth rate of the number of n-step SAWs in ℤ^k.\n\n**Historical Development:**\n- **Hammersley-Morton (1954):** Proved the limit C_k exists using submultiplicativity (f(m+n,k) ≤ f(m,k)·f(n,k)) and Fekete's lemma\n- **Kesten (1963):** Proved the asymptotic C_k = 2k-1 - 1/(2k) + O(1/k²), showing C_k is close to 2k-1 for large k\n- **Conway-Guttmann (1993):** Rigorous lower bound C_2 ≥ 2.62\n- **Alm (1993):** Rigorous upper bound C_2 ≤ 2.696\n- **Duminil-Copin-Smirnov (2012):** Proved the exact value μ_honeycomb = √(2+√2) for the honeycomb lattice, contributing to Smirnov's Fields Medal\n- **Jacobsen-Scullard-Guttmann (2016):** High-precision computation C_2 = 2.6381585303279... to 12+ decimal places\n\n**Key Insight:** The submultiplicativity of SAW counts is the crucial property guaranteeing the limit exists — it follows because concatenating two SAWs at the origin gives a walk that is at least as constrained as the two original walks.",
     "problemStatement": "**Problem Statement (OPEN)**\n\nLet $f(n,k)$ count self-avoiding walks of $n$ steps starting at the origin in $\\mathbb{Z}^k$.\n\n**Question:** Determine the connective constant:\n$$C_k = \\lim_{n \\to \\infty} f(n,k)^{1/n}$$\n\n**Known Results:**\n- Limit exists (Hammersley-Morton 1954)\n- Bounds: $k \\leq C_k \\leq 2k-1$\n- Kesten's asymptotic: $C_k = 2k-1 - \\frac{1}{2k} + O(k^{-2})$\n- 2D value: $C_2 = 2.6381585303279...$ (numerical, 12+ digits)\n- 2D bounds: $2.62 \\leq C_2 \\leq 2.696$ (rigorous)\n- Honeycomb: $\\mu_{\\text{hex}} = \\sqrt{2 + \\sqrt{2}}$ (exact, Duminil-Copin/Smirnov)\n\n**Status:** OPEN — exact closed forms unknown for all $k$",
     "text": "Let f(n,k) count n-step self-avoiding walks in ℤ^k. Determine C_k = lim f(n,k)^{1/n}. The limit EXISTS (Hammersley-Morton 1954) by submultiplicativity, bounds k ≤ C_k ≤ 2k-1, Kesten's asymptotic C_k = 2k-1-1/(2k)+O(1/k²), and C_2 = 2.6381585... numerically. Exact closed forms remain OPEN for all k.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **SAW Definitions (lines 37-68):**\n   - `LatticePoint k`: points in ℤ^k as `Fin k → ℤ`\n   - `areNeighbors`: differ by ±1 in exactly one coordinate\n   - `Walk k n`: sequence of n+1 lattice points\n   - `isSAW`: starts at origin, connected, self-avoiding\n\n2. **Counting and Submultiplicativity (lines 70-108):**\n   - `sawCount n k`: axiomatized counting function f(n,k)\n   - `submultiplicativity`: f(m+n,k) ≤ f(m,k)·f(n,k)\n   - `limit_exists`: Hammersley-Morton via Fekete's lemma\n   - `connectiveConstant k`: μ_k via Classical.choose\n\n3. **Bounds and Asymptotics (lines 110-144):**\n   - `trivial_bounds`: k ≤ μ_k ≤ 2k-1 (genuine theorem)\n   - `kesten_asymptotic`: μ_k = 2k-1 - 1/(2k) + O(1/k²)\n   - `kesten_first_order`: |μ_k - (2k-1)| ≤ 1/k\n\n4. **2D Case (lines 146-167):**\n   - Rigorous bounds: Conway-Guttmann, Alm\n   - High precision: JSG computation\n   - `two_d_bounds`: genuine theorem\n\n5. **Honeycomb and Conjectures (lines 186-225):**\n   - `mu_honeycomb`: exact √(2+√2)\n   - `honeycomb_exact`: existence with bounds\n   - Open conjectures: closed form, irrationality\n\n6. **Summary (lines 265-284):**\n   - `erdos_528_summary`: genuine theorem combining limit existence, bounds, and 2D results",
+    "proofStrategy": "**Formalization Approach** (196-line file; the connective constant and its bounds are axiomatized — this is an OPEN problem with 7 axioms and 3 genuine theorems)\n\n1. **SAW Definitions:**\n   - `LatticePoint k`: points in ℤ^k as `Fin k → ℤ`\n   - `areNeighbors`: differ by ±1 in exactly one coordinate\n   - `Walk k n`: sequence of n+1 lattice points\n   - `isSAW`: starts at origin, connected, self-avoiding\n\n2. **Counting and the Connective Constant:**\n   - `sawCount n k`: axiomatized counting function f(n,k)\n   - `limit_exists`: axiom asserting the Hammersley-Morton limit exists (the underlying submultiplicativity/Fekete argument is NOT formalized — it is taken as the axiom)\n   - `connectiveConstant k` (μ_k): defined via `Classical.choose (limit_exists ...)`\n\n3. **Bounds and Asymptotics:**\n   - `connective_lower_bound` / `connective_upper_bound`: axioms k ≤ μ_k ≤ 2k-1\n   - `trivial_bounds`: genuine theorem packaging the two bound axioms\n   - `kesten_asymptotic`: axiom μ_k = 2k-1 - 1/(2k) + O(1/k²) (no first-order corollary theorem is formalized)\n\n4. **2D Case:**\n   - `conway_guttmann_lower` / `alm_upper`: axioms 2.62 ≤ μ_2 ≤ 2.696\n   - `mu2_value`: numeric value 2.6381585... (definition only)\n   - `two_d_bounds`: genuine theorem packaging the two 2D bound axioms\n\n5. **Higher Dimensions, Honeycomb, Conjectures:**\n   - `mu3_estimate`, `mu_honeycomb` (= √(2+√2)): definitions only, not proved\n   - `mu2_closed_form_conjecture`, `irrationality_conjecture`: open conjectures stated as Prop definitions\n\n6. **Summary:**\n   - `erdos_528_summary`: genuine theorem combining limit existence, the trivial bounds, and the 2D bounds (all resting on the 7 axioms)",
     "keyInsights": [
       "**Submultiplicativity is Key:** f(m+n,k) ≤ f(m,k)·f(n,k) implies the limit exists by Fekete's lemma — concatenating SAWs gives an upper bound because the concatenation may not be self-avoiding",
       "**Trivial Bounds:** Lower bound k (at each step, can go in a new direction in each of k dimensions) and upper bound 2k-1 (at most 2k neighbors minus the one you came from)",
@@ -104,7 +101,7 @@
     {
       "id": "counting",
       "title": "Counting SAWs",
-      "summary": "sawCount axiom, f_zero, f_one base cases",
+      "summary": "sawCount axiom (counting function f(n,k)); no base-case lemmas are formalized",
       "startLine": 69,
       "endLine": 85,
       "mathContext": "The counting function $f(n,k) = |\\{\\text{SAWs of length } n \\text{ in } \\mathbb{Z}^k\\}|$. Base cases: $f(0,k) = 1$ (the trivial walk at the origin) and $f(1,k) = 2k$ (one step in each of $2k$ directions)."
@@ -112,7 +109,7 @@
     {
       "id": "limit-existence",
       "title": "Submultiplicativity and Limit Existence",
-      "summary": "submultiplicativity, limit_exists (Hammersley-Morton), connectiveConstant definition",
+      "summary": "limit_exists axiom (Hammersley-Morton; submultiplicativity/Fekete argument taken as the axiom, not formalized), connectiveConstant definition",
       "startLine": 86,
       "endLine": 106,
       "mathContext": "Submultiplicativity: $f(m+n, k) \\leq f(m,k) \\cdot f(n,k)$ (concatenating two SAWs may create self-intersections, so the count can only decrease). By Fekete's lemma applied to $\\log f(n,k)$, this implies $C_k = \\lim_{n \\to \\infty} f(n,k)^{1/n}$ exists (Hammersley–Morton 1954)."
@@ -128,7 +125,7 @@
     {
       "id": "kesten",
       "title": "Kesten's Asymptotic (1963)",
-      "summary": "kesten_asymptotic, kesten_first_order",
+      "summary": "kesten_asymptotic axiom: μ_k = 2k-1 - 1/(2k) + O(1/k²)",
       "startLine": 125,
       "endLine": 140,
       "mathContext": "Kesten's asymptotic (1963): $C_k = 2k - 1 - \\frac{1}{2k} + O(k^{-2})$ as $k \\to \\infty$. The leading correction $-1/(2k)$ comes from counting walks that attempt to backtrack; $|C_k - (2k-1)| \\leq 1/k$ provides a rigorous first-order bound."
@@ -136,7 +133,7 @@
     {
       "id": "two-dimensional",
       "title": "Two-Dimensional Case",
-      "summary": "mu2_value, conway_guttmann_lower, alm_upper, jsg_computation, two_d_bounds",
+      "summary": "mu2_value definition, conway_guttmann_lower and alm_upper axioms, two_d_bounds theorem",
       "startLine": 141,
       "endLine": 162,
       "mathContext": "For $k=2$: rigorous bounds $2.62 \\leq C_2 \\leq 2.696$ (Conway–Guttmann 1993, Alm 1993), and the high-precision value $C_2 = 2.6381585303279\\ldots$ (Jacobsen–Scullard–Guttmann 2016, 12+ decimal places). No closed form is known."
@@ -144,7 +141,7 @@
     {
       "id": "higher-dimensions",
       "title": "Higher Dimensions",
-      "summary": "mu3_estimate, large_k_limit, normalized_limit",
+      "summary": "mu3_estimate definition (numeric estimate; asymptotic-limit lemmas not formalized)",
       "startLine": 163,
       "endLine": 178,
       "mathContext": "For $k=3$: $C_3 \\approx 4.684$ (numerical). Asymptotically, $\\lim_{k \\to \\infty} C_k / (2k) = 1$, confirming that in high dimensions the self-avoidance constraint becomes negligible and $C_k$ approaches the non-backtracking constant $2k-1 \\sim 2k$."
@@ -152,7 +149,7 @@
     {
       "id": "honeycomb",
       "title": "Honeycomb Lattice",
-      "summary": "mu_honeycomb definition, mu_honeycomb_approx, honeycomb_exact",
+      "summary": "mu_honeycomb definition (= √(2+√2); stated, not proved — no approximation or existence theorem is formalized)",
       "startLine": 179,
       "endLine": 199,
       "mathContext": "The honeycomb lattice connective constant satisfies $\\mu_{\\text{hex}} = \\sqrt{2 + \\sqrt{2}} \\approx 1.8478$, proved exactly by Duminil-Copin and Smirnov (2012) using discrete holomorphicity (parafermionic observables). This is the only lattice for which an exact closed form is known; the proof contributed to Smirnov's Fields Medal work."
@@ -160,7 +157,7 @@
     {
       "id": "conjectures",
       "title": "Conjectures",
-      "summary": "mu2_closed_form_conjecture, irrationality_conjecture, mu2_irrationality_open_status",
+      "summary": "mu2_closed_form_conjecture, irrationality_conjecture (Prop definitions of open conjectures)",
       "startLine": 200,
       "endLine": 200,
       "mathContext": "Open questions: (1) Is $C_2$ algebraic, or does it have a closed form in terms of known constants? (2) Is $C_k$ irrational for $k \\geq 2$? Neither question is resolved for any $k$. The algebraic nature of $C_2$ is considered one of the most tantalizing open problems in combinatorics."


### PR DESCRIPTION
## Gallery integrity fix — phantom contributions/decls (honest counts)

**Proof**: erdos-528 (Connective Constant for Self-Avoiding Walks — OPEN)

Counts are honest and verified against `Proofs/Erdos528Problem.lean`: **7 axioms, 3 theorems, 13 definitions (12 `def` + `abbrev LatticePoint`), 0 sorries**, no `native_decide`. The 7 numeric/bound axioms are mutually consistent (μ₁=1 forced; μ₂ ∈ [2.62, 2.696] ⊂ trivial & Kesten ranges).

### Problem: prose invented ~12 declarations that don't exist
`grep` confirms none of these appear anywhere in the file, yet they were listed as contributions/axioms/theorems across `originalContributions`, `proofStrategy`, and 6 section summaries:

`f_zero`, `f_one`, `kesten_first_order`, `jsg_computation`, `large_k_limit`, `normalized_limit`, `honeycomb_exact`, `saw_counts_2d`, `critical_exponent_exists`, `gamma_2d_conjecture_value`, `mu_honeycomb_approx`, `mu2_irrationality_open_status`.

Four (`kesten_first_order`, `honeycomb_exact`, `critical_exponent_exists`, `gamma_2d_conjecture_value`) were described as **axioms** — had they existed, `axiomCount` would be 11, not 7. `proofStrategy` also cited fabricated line numbers (up to 284 in a 196-line file).

### Fix
Rewrote `originalContributions`, `proofStrategy`, and the 6 affected section summaries to list only the 23 real declarations, marking stated-but-unproved items (`mu_honeycomb`, `mu3_estimate`, the two conjecture Props) accurately. Counts unchanged. "submultiplicativity" retained only where it describes the mathematics (Hammersley-Morton/Fekete), not as a declaration name. JSON validated.

Tracker: erdos-528 marked `issues-fixed`.

---
Discovered during gallery integrity audit (reserve mode). Same auto-generated phantom-prose pattern as the 53x/54x cluster (cf. erdos-534 #40938).

🤖 Generated with [Claude Code](https://claude.com/claude-code)