### PR TITLE
Audit tracker: erdos-517 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14254,8 +14254,8 @@
     },
     "erdos-517": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:15Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T21:29:28Z",
       "result": "clean"
     },
     "erdos-518": {


### PR DESCRIPTION
Reserve re-audit of erdos-517. Clean Tier C — meta counts accurate (1 axiom, 3 thm, 3 def, 0 sorry), correct badge. Stale 'Aristotle failed to load' comment names a phantom harmonicSorry731341 axiom that does not exist in the file (cruft only). Bookkeeping.