### PR TITLE
Audit tracker: mark erdos-520 clean (reserve re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14284,8 +14284,8 @@
     },
     "erdos-520": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:16Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T21:32:02Z",
       "result": "clean"
     },
     "erdos-521": {


### PR DESCRIPTION
Reserve re-audit of erdos-520 (Rademacher Multiplicative Functions).

**Result: clean.** Definitions-only infrastructure file: 0 theorems, 0 axioms, 0 sorries, 5 definitions (structure + 4 defs) — all counts match meta. No True stubs, no native_decide. Cautious labeling (status=axiomatized, badge=wip, erdosProblemStatus=open); conjecture explicitly OPEN. Minor nit only: originalContributions describes comment-only Wintner/Harper content, within tolerance for a wip/open entry.

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)