### PR TITLE
Research: erdos-70-wip-01 — reduce formalized conjecture to infinite Ramsey (converse direction)

### DIFF
--- a/proofs/Proofs/Erdos70WIP01.lean
+++ b/proofs/Proofs/Erdos70WIP01.lean
@@ -254,4 +254,70 @@ theorem erdos_70_conjecture_imp_epsilon0 (h : erdos_70_conjecture) (n : ℕ)
     PartitionArrow continuum_card (⨆ k : ℕ, omegaTower k) n :=
   h (⨆ k : ℕ, omegaTower k) n iSup_omegaTower_countable hn
 
+/-! ## The single missing ingredient: infinite Ramsey for 3-uniform 2-colourings
+
+Every result above runs *from* the conjecture *to* a special case (it assumes
+`erdos_70_conjecture` and specializes `β`).  This section runs the other way: it
+identifies the *one* partition-calculus fact that would establish the whole
+formalized conjecture at a stroke, uniformly in `β`, and proves the reduction.
+
+That fact is the **infinite Ramsey theorem** for 2-colourings of 3-element
+subsets: on any continuum-sized `S`, some colour class admits an *infinite*
+homogeneous set.  It is a classical theorem but is **absent from Mathlib v4.31**
+(there is no infinite Ramsey / hypergraph-partition development — see
+`Mathlib.Combinatorics`, which stops at Hales–Jewett, Hindman, and finite
+pigeonhole).  The reduction below shows it is the sole obstruction.
+
+**Faithfulness caveat.**  Because the parent's `HasOrderTypeAtLeast` is the
+*cardinality* surrogate `α.card ≤ #H` (an explicitly "simplified version", see
+`Erdos70Problem.lean`), the colour-0 disjunct is met by any set of cardinality
+`≥ ℵ₀`.  Consequently the *formalized* conjecture is **strictly weaker** than the
+genuine partition relation `𝔠 → (β, n)₂³` of Erdős #70, which demands a colour-0
+homogeneous set of true order type `β`.  The reduction proves the formalized
+statement is in fact a *theorem modulo infinite Ramsey* — it does **not** settle
+the real order-type problem, which remains open. -/
+
+/-- **The missing ingredient.**  Infinite Ramsey for 2-colourings of 3-element
+subsets of a continuum-sized set: some colour class has an *infinite* homogeneous
+set.  A classical theorem, but not present in Mathlib v4.31; carried here as a
+named hypothesis rather than an `axiom` so the reduction stays assumption-free. -/
+def InfiniteRamsey3 : Prop :=
+  ∀ (S : Type) [DecidableEq S] (_ : Cardinal.mk S = continuum_card) (c : Coloring S 3 2),
+    ∃ (H : Set S) (i : Fin 2), H.Infinite ∧ IsHomogeneous H 3 c i
+
+/-- **Reduction of the whole formalized conjecture to one Ramsey fact.**
+`InfiniteRamsey3` implies `erdos_70_conjecture` — uniformly in every countable
+`β` and every `2 ≤ n` — under the file's cardinality surrogate for order type.
+
+Given a 2-colouring of the 3-subsets of a continuum-sized `S`, take the infinite
+homogeneous set `H` supplied by `InfiniteRamsey3`.
+* If its colour is `0`, `H` witnesses the left disjunct: it is homogeneous, and
+  `β.card ≤ ℵ₀ ≤ #H` (`β` countable; `H` infinite), so `HasOrderTypeAtLeast S H β`.
+* If its colour is `1`, any `n`-element finite subset of the infinite `H` witnesses
+  the right disjunct (`Set.Infinite.exists_subset_card_eq`), homogeneous because a
+  subset of an `IsHomogeneous` set is homogeneous. -/
+theorem infiniteRamsey3_imp_conjecture (h : InfiniteRamsey3) : erdos_70_conjecture := by
+  intro β n hβ _hn S _ hS c
+  obtain ⟨H, i, hHinf, hHom⟩ := h S hS c
+  fin_cases i
+  · -- colour 0: the infinite homogeneous set meets the order-type (cardinality) side
+    refine Or.inl ⟨H, ?_, hHom⟩
+    have hcard : Cardinal.aleph0 ≤ Cardinal.mk H :=
+      Cardinal.aleph0_le_mk_iff.mpr (Set.infinite_coe_iff.mpr hHinf)
+    exact le_trans hβ hcard
+  · -- colour 1: any n-subset of the infinite homogeneous set meets the size side
+    obtain ⟨t, hts, htc⟩ := hHinf.exists_subset_card_eq n
+    refine Or.inr ⟨t, htc.ge, ?_⟩
+    intro s hs hsub
+    exact hHom s hs (subset_trans (Finset.coe_subset.mpr hsub) hts)
+
+/-- Contrapositive packaging: a genuine counterexample to the formalized conjecture
+would refute infinite Ramsey for 3-uniform 2-colourings.  Since the latter is a
+theorem, this reconfirms that the *formalized* conjecture (cardinality surrogate)
+cannot have a counterexample — the open content lives entirely in the gap between
+`HasOrderTypeAtLeast` and true order type. -/
+theorem counterexample_imp_not_infiniteRamsey3
+    (h : erdos_70_counterexample) : ¬ InfiniteRamsey3 :=
+  fun hR => conjecture_xor_counterexample.mp (infiniteRamsey3_imp_conjecture hR) h
+
 end Erdos70

--- a/research/problems/erdos-70-wip-01/knowledge.md
+++ b/research/problems/erdos-70-wip-01/knowledge.md
@@ -171,3 +171,47 @@ countable-ordinal class is now proved closed under all three ordinal operations
 Erdős #70 itself (positive partition relation for general countable β) remains OPEN —
 the Erdős–Rado result `𝔠 → (ω+n, 4)₂³` needs partition-calculus machinery absent from
 Mathlib v4.31. The ordinal-arithmetic countability toolkit is now complete.
+
+## Session 2026-07-21 (researcher-1): reduction to infinite Ramsey (the converse direction)
+
+Every prior session ran `erdos_70_conjecture → special case β` (assume the
+conjecture, specialize the exponent up to ε₀). This session adds the **converse
+ingredient direction**: isolates the single fact that would prove the whole
+formalized conjecture uniformly in β, and proves the reduction. Added to
+`Proofs/Erdos70WIP01.lean` (theoremCount 16→18 incl. 1 new `def`; still 0 axioms,
+0 sorries; host-verified fresh-parent-olean + `lake env lean` exit 0; `#print axioms`
+= `[propext, Classical.choice, Quot.sound]` on both new theorems).
+
+- **`InfiniteRamsey3` (def)** — the infinite Ramsey theorem for 2-colourings of
+  3-element subsets of a continuum-sized `S`: some colour class has an *infinite*
+  homogeneous set. Classical, but **absent from Mathlib v4.31** (no infinite
+  Ramsey / hypergraph-partition dev; `Mathlib.Combinatorics` stops at
+  Hales–Jewett, Hindman, finite pigeonhole). Carried as a named hypothesis, NOT
+  an `axiom`, so the reduction stays assumption-free.
+- **`infiniteRamsey3_imp_conjecture`** — `InfiniteRamsey3 → erdos_70_conjecture`,
+  uniformly in every countable β and 2 ≤ n. Colour 0: the infinite homogeneous
+  set meets the (cardinality-surrogate) order-type side via `β.card ≤ ℵ₀ ≤ #H`
+  (`Cardinal.aleph0_le_mk_iff` + `Set.infinite_coe_iff`). Colour 1: any n-subset
+  (`Set.Infinite.exists_subset_card_eq`) meets the size side, homogeneous because
+  subsets of an `IsHomogeneous` set are homogeneous.
+- **`counterexample_imp_not_infiniteRamsey3`** — contrapositive packaging via the
+  parent's `conjecture_xor_counterexample`.
+
+### KEY FAITHFULNESS FINDING (auditor-relevant)
+The parent's `HasOrderTypeAtLeast S H α := α.card ≤ #H` is the **cardinality
+surrogate** (parent labels it a "simplified version"), so the colour-0 disjunct
+is satisfied by ANY set of cardinality ≥ ℵ₀. Under this surrogate the *formalized*
+`erdos_70_conjecture` is **strictly weaker** than the genuine order-type partition
+relation `𝔠 → (β, n)₂³` of Erdős #70, and is in fact a **theorem modulo infinite
+Ramsey** (this reduction proves it). The genuine open content of Erdős #70 lives
+entirely in the gap between the cardinality surrogate and TRUE order type β — a
+homogeneous set of size ℵ₀ need not have order type ω², ω^ω, …. The tower-closure
+development (ω…ε₀) specializes the *surrogate* statement only.
+
+### Next Steps
+- To formalize the REAL problem, strengthen `HasOrderTypeAtLeast` to genuine order
+  type (there is a well-order on H of type ≥ α), then the reduction breaks and the
+  true partition calculus (Erdős–Rado) is required — genuinely open/blocked.
+- Building `InfiniteRamsey3` itself (infinite Ramsey for 3-uniform 2-colourings)
+  from Mathlib's infinite pigeonhole is a self-contained ~200–400 line project
+  and would discharge the surrogate conjecture outright. Blocked route until then.

--- a/src/data/research/problems/erdos-70-wip-01.json
+++ b/src/data/research/problems/erdos-70-wip-01.json
@@ -22,7 +22,18 @@
     "since": "2026-07-09T17:33:19-07:00",
     "iteration": 3,
     "focus": "Session 4: general closure isCountableOrdinal_opow — countable ordinals closed under α^β for arbitrary countable α,β (transfinite induction on exponent + iSup_lt_omega_one/regularity of ℵ₁). Plus omega0_opow_omega0_opow_omega0_countable (ω^(ω^ω), 2nd tower level) and its conjecture specialization. 0 axioms, host-verified.",
-    "blockers": [],
+    "blockers": [
+      {
+        "route": "true order-type partition relation (Erdos-Rado partition calculus)",
+        "reopenCriterion": "materially new mechanism required (Mathlib gains order-type-preserving homogeneous-set machinery)",
+        "blockedAt": "2026-07-21"
+      },
+      {
+        "route": "build infinite Ramsey for 3-uniform 2-colourings from infinite pigeonhole",
+        "reopenCriterion": "self-contained ~200-400 line construction; discharges the surrogate conjecture but not the true order-type problem",
+        "blockedAt": "2026-07-21"
+      }
+    ],
     "nextAction": "Frontier: Erdős #70 itself (general countable β) OPEN — Erdős–Rado positive result 𝔠→(ω+n,4)₂³ needs partition-calculus machinery absent from Mathlib. Ordinal-arithmetic countability toolkit now complete (+, ·, ^ all closed; towers below ε₀ free).",
     "attemptCounts": {
       "total": 0,
@@ -31,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Countable-ordinal class proved closed under +, ·, and general exponentiation α^β; tower levels ω, ω², ω^ω, ω^(ω^ω) countable. NEW capstone: ε₀ (=⨆ₙ ω-tower, the least epsilon number / least fixed point of ξ↦ω^ξ) is a countable ordinal (iSup_omegaTower_countable), and the conjecture specializes to 𝔠→(ε₀,n). This closes the naturally-described exponential hierarchy over ω up to and including its ε₀ limit. 0 axioms, 0 sorries.",
+    "progressSummary": "Reduction direction added: the WHOLE formalized conjecture reduces to (and follows from) infinite Ramsey for 3-uniform 2-colourings, uniformly in beta. Faithfulness finding: the cardinality-surrogate HasOrderTypeAtLeast makes the formalized statement a theorem-modulo-Ramsey, strictly weaker than the genuine order-type Erdos #70. 0 axioms, 0 sorries.",
     "builtItems": [
       "Erdos70.IsCountableOrdinal.of_le in Erdos70WIP01.lean",
       "Erdos70.isCountableOrdinal_add in Erdos70WIP01.lean",
@@ -45,7 +56,10 @@
       "erdos_70_conjecture_imp_omega_tower in Erdos70WIP01.lean — specializes the open conjecture to β=ω^ω",
       "omegaTower (Erdos70WIP01.lean): ω-tower ℕ→Ordinal",
       "omegaTower_countable + iSup_omegaTower_countable: ε₀ countable, axiom-free",
-      "erdos_70_conjecture_imp_epsilon0: conjecture specialized to ε₀"
+      "erdos_70_conjecture_imp_epsilon0: conjecture specialized to ε₀",
+      "InfiniteRamsey3 (def) in Erdos70WIP01.lean - named hypothesis for infinite Ramsey on 3-subsets of a continuum-sized set",
+      "infiniteRamsey3_imp_conjecture in Erdos70WIP01.lean - InfiniteRamsey3 implies erdos_70_conjecture uniformly in countable beta (0 axioms)",
+      "counterexample_imp_not_infiniteRamsey3 in Erdos70WIP01.lean - contrapositive packaging"
     ],
     "insights": [
       "The parent proved specific instances (omega0_plus_n_countable, omega0_squared_countable); these are corollaries of three general closure lemmas: IsCountableOrdinal is downward-closed (Ordinal.card_le_card), and closed under ordinal + (Cardinal.add_le_aleph0) and * (mul_le_mul + Cardinal.aleph0_mul_aleph0).",
@@ -54,7 +68,9 @@
       "Session 3: proved ω^ω is a countable ordinal (omega0_opow_omega0_countable), the limit-exponent case the finite-power closure isCountableOrdinal_opow_nat could not reach. Route: bridge IsCountableOrdinal α ↔ α<ω₁ (Cardinal.lt_omega_iff_card_lt + Cardinal.lt_aleph_one_iff), then ω^ω = sup_{β<ω} ω^β ≤ ⨆ n:ℕ ω^n, a countable sup of countable ordinals, so <ω₁ by Ordinal.iSup_lt_omega_one (regularity of ℵ₁).",
       "Session 3: key Mathlib lemmas — Ordinal.opow_le_of_isSuccLimit (ω^ω ≤ c ↔ ∀β<ω, ω^β≤c), Ordinal.isSuccLimit_omega0, Ordinal.lt_omega0 (β<ω ↔ β=k:ℕ), Ordinal.le_iSup/iSup_le (needs Small.{0} ℕ). Universe must be pinned to Ordinal.{0} (via .{0}) to match the parent's conjecture_omega_tower (Ordinal.{0}).",
       "Capstone: ε₀ is a countable ordinal. Defined the ω-tower omegaTower (T0=ω, T(n+1)=ω^Tn) and proved iSup_omegaTower_countable: ⨆ₙ Tn = ε₀ is a countable ℕ-indexed supremum of countable ordinals (each via isCountableOrdinal_opow), hence <ω₁ by Ordinal.iSup_lt_omega_one (regularity of ℵ₁). The least epsilon number — top of the whole exponential hierarchy over ω — is countable. Conjecture specializes to 𝔠→(ε₀,n) (erdos_70_conjecture_imp_epsilon0).",
-      "Lean gotcha: an ordinal-valued recursive def using ^ (Ordinal.instPow noncomputable) must be marked noncomputable."
+      "Lean gotcha: an ordinal-valued recursive def using ^ (Ordinal.instPow noncomputable) must be marked noncomputable.",
+      "FAITHFULNESS: parent HasOrderTypeAtLeast is the cardinality surrogate (alpha.card <= #H), so the formalized erdos_70_conjecture is strictly WEAKER than the true order-type relation and is a theorem-modulo-infinite-Ramsey; the open content of Erdos #70 lives in the gap between cardinality and true order type",
+      "Infinite Ramsey for 3-uniform 2-colourings is ABSENT from Mathlib v4.31 (Combinatorics stops at Hales-Jewett/Hindman/finite pigeonhole); it is the single missing ingredient for the surrogate conjecture"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for **erdos-70-wip-01** (Erdős Problem #70, partition calculus).

Every prior session ran the implication `erdos_70_conjecture → special case β` (assume the conjecture, specialize the exponent up through the ω-tower to ε₀). This session adds the **converse ingredient direction**: it isolates the *single* fact that would establish the whole formalized conjecture uniformly in β, and proves the reduction. Axiom-free.

## Progress
Added to `proofs/Proofs/Erdos70WIP01.lean` (host-verified, 0 axioms, 0 sorries):

- **`InfiniteRamsey3`** (def) — the infinite Ramsey theorem for 2-colourings of 3-element subsets of a continuum-sized set: some colour class has an *infinite* homogeneous set. Classical, but **absent from Mathlib v4.31** (`Mathlib.Combinatorics` stops at Hales–Jewett, Hindman, finite pigeonhole). Carried as a **named hypothesis, not an `axiom`**, so the reduction stays assumption-free.
- **`infiniteRamsey3_imp_conjecture`** — `InfiniteRamsey3 → erdos_70_conjecture`, uniformly in every countable β and every `2 ≤ n`. Colour 0 meets the (surrogate) order-type side via `β.card ≤ ℵ₀ ≤ #H`; colour 1 meets the size side via an n-subset of the infinite homogeneous set.
- **`counterexample_imp_not_infiniteRamsey3`** — contrapositive packaging via the parent's `conjecture_xor_counterexample`.

## Findings
**Faithfulness finding (auditor-relevant).** The parent's `HasOrderTypeAtLeast S H α := α.card ≤ #H` is the **cardinality surrogate** (the parent labels it a "simplified version"), so the colour-0 disjunct is met by any set of cardinality ≥ ℵ₀. Under this surrogate the *formalized* `erdos_70_conjecture` is **strictly weaker** than the genuine order-type partition relation `𝔠 → (β, n)₂³` of Erdős #70, and is in fact a **theorem modulo infinite Ramsey** — which this reduction proves. The genuine open content of Erdős #70 lives entirely in the gap between the cardinality surrogate and true order type. The existing tower-closure development (ω…ε₀) specializes the *surrogate* statement only.

## Verification
Fresh parent olean (`lake env lean -o`) + `lake env lean Proofs/Erdos70WIP01.lean`, exit 0. `#print axioms` on both new theorems = `[propext, Classical.choice, Quot.sound]`.

## Status
**Outcome**: progress (structural reduction + faithfulness finding)
**Next Steps**: (1) strengthen `HasOrderTypeAtLeast` to genuine order type — then the reduction breaks and true Erdős–Rado partition calculus is required (open/blocked); (2) building `InfiniteRamsey3` itself from Mathlib's infinite pigeonhole is a self-contained ~200–400 line project that would discharge the surrogate conjecture. Both recorded as blocked routes in the tracker.

🤖 Generated by researcher-1
