### PR TITLE
Enrich picks-theorem: re-anchor final section to cover lattice_width_x + export

### DIFF
--- a/src/data/proofs/picks-theorem/meta.json
+++ b/src/data/proofs/picks-theorem/meta.json
@@ -153,8 +153,8 @@
       "id": "applications",
       "title": "Applications and Lattice Width",
       "startLine": 422,
-      "endLine": 484,
-      "summary": "$O(1)$ area computation via `compute_area`. Lattice width bounds: $A \\leq w_x \\cdot w_y$. Export of main results.",
+      "endLine": 504,
+      "summary": "$O(1)$ area computation via `compute_area`. Lattice width in the $x$-direction (`lattice_width_x`) and the bound $A \\leq w_x \\cdot w_y$. A prior `area_bounded_by_box_axiom` was removed as inconsistent (it asserted $A \\leq w_x \\cdot w_y$ for all widths without a containment hypothesis, false at $w_x = w_y = 0$); a correct version requires $P$ to lie in the bounding box. Closes with the export of the main results ($\\texttt{\\#check}$).",
       "mathContext": "Area in $O(1)$ time: $A = i + \\tfrac{b}{2} - 1$ requires only two integer counts. Lattice width bound: $A \\leq w_x \\cdot w_y$ where $w_x = \\max x - \\min x$ and $w_y = \\max y - \\min y$ are the axis-aligned widths of $P$."
     }
   ],


### PR DESCRIPTION
## Section-coverage correction for `picks-theorem`

The final section **"Applications and Lattice Width"** was anchored `422–484`, but its own summary claims to cover "Lattice width bounds" and "Export of main results" — content that lives **after** line 484:

- `def lattice_width_x` (line 486) — the lattice-width definition the section is named for
- the note explaining why `area_bounded_by_box_axiom` was removed (inconsistent without a containment hypothesis)
- the `#check` export block (lines ~494–503) and `end PicksTheorem`

### Change
- `endLine` 484 → 504 (EOF), so the section actually covers the declaration it is named for and the export block.
- Summary expanded to name `lattice_width_x` and surface the removed-axiom caveat (a genuine, informative correction that was previously stranded in an uncovered comment).

No Lean or status/axiom changes; pure metadata coverage fix. JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
