### PR TITLE
Research: abundant-number-oq-03-oq-03 — Route-2 extraction is false under the strict definition

### DIFF
--- a/proofs/Proofs/AbundantNumberOQ03OQ03.lean
+++ b/proofs/Proofs/AbundantNumberOQ03OQ03.lean
@@ -63,11 +63,18 @@
      window, so `m·p` is abundant for the first time at itself.  The obstruction:
      odd `m` approach the abundance boundary slowly, and proper-divisor deficiency
      is a real case analysis, not the clean "powers of two are deficient" fact.
-  2. *Primitive-part extraction* — every abundant `n` has a primitive abundant
-     divisor; show the primitive parts of an infinite odd abundant family
-     (`Nat.infinite_odd_abundant`) are odd and unbounded.  The obstruction:
-     controlling oddness and unboundedness of the primitive part needs a
-     pigeonhole that a single bounded part could defeat.
+  2. *Primitive-part extraction* — one might hope every abundant `n` has a
+     primitive abundant divisor, then show the primitive parts of an infinite odd
+     abundant family (`Nat.infinite_odd_abundant`) are odd and unbounded.  **This
+     route is blocked at its first step under the strict definition used here:**
+     `no_isPrimitiveAbundant_dvd_12` proves *no* divisor of the abundant number
+     `12` is `IsPrimitiveAbundant`, because the perfect proper divisor `6 ∣ 12`
+     violates the "all proper divisors deficient" clause and the smallest strict
+     primitive abundant number is `20 > 12`.  Extraction works only for the weaker
+     "no abundant proper divisor" notion (OEIS A091191); recovering a *strict*
+     (deficient-divisors) primitive part additionally requires excluding perfect
+     divisors, and controlling oddness/unboundedness still needs a pigeonhole that
+     a single bounded part could defeat.
 
   Reference: OEIS A006038 (odd primitive abundant numbers); A091191 (primitive
   abundant numbers).  Sibling gallery entries: `abundant-number-oq-02` (945 is the
@@ -85,6 +92,9 @@ divisor of `n` is deficient. Abundance appears for the first time, under
 divisibility, exactly at `n`. -/
 def IsPrimitiveAbundant (n : ℕ) : Prop :=
   n.Abundant ∧ ∀ d ∈ n.properDivisors, d.Deficient
+
+instance : DecidablePred IsPrimitiveAbundant := fun n =>
+  decidable_of_iff (n.Abundant ∧ ∀ d ∈ n.properDivisors, d.Deficient) Iff.rfl
 
 /-- The set of **odd primitive abundant** numbers, OEIS A006038. Whether this set
 is infinite is the open problem `abundant-number-oq-03-oq-03`. -/
@@ -120,6 +130,34 @@ theorem primitive_945 : IsPrimitiveAbundant 945 := by
 (OEIS A006038), and the base witness that any infinitude construction must extend. -/
 theorem mem_oddPrimitiveAbundant_945 : 945 ∈ OddPrimitiveAbundant :=
   ⟨odd_945, primitive_945⟩
+
+-- ============================================================
+-- The strict definition bites: Route-2 extraction fails
+-- ============================================================
+
+/-- **`12` is abundant but *not* primitive abundant.** Its proper divisor `6` is
+*perfect* (`σ'(6) = 6`), hence not deficient, so the "all proper divisors deficient"
+clause of `IsPrimitiveAbundant` fails even though `12` is the smallest abundant
+number. -/
+theorem not_isPrimitiveAbundant_12 : ¬ IsPrimitiveAbundant 12 := by
+  set_option maxRecDepth 4000 in decide
+
+/-- **Route-2 extraction is FALSE under the strict definition.** No divisor of the
+abundant number `12` is primitive abundant: the smallest primitive abundant number
+(all proper divisors deficient, OEIS A071395) is `20 > 12`, and the perfect proper
+divisor `6 ∣ 12` blocks strict primitivity of `12` itself.
+
+Consequently the naive extraction *"every abundant `n` has a primitive abundant
+divisor"* — recorded as Route 2 in this file's header — does **not** hold for
+`IsPrimitiveAbundant` (which demands *deficient* proper divisors). It holds only for
+the weaker notion *"abundant with no abundant proper divisor"* (OEIS A091191), under
+which `12` itself is primitive. A perfect proper divisor is exactly the obstruction
+that separates the two notions, so Route-2 cannot be run against the strict
+definition without first passing through the A091191 notion and separately excluding
+perfect divisors. -/
+theorem no_isPrimitiveAbundant_dvd_12 :
+    ∀ d ∈ Nat.divisors 12, ¬ IsPrimitiveAbundant d := by
+  set_option maxRecDepth 4000 in decide
 
 -- ============================================================
 -- Toward infinitude: the σ-arithmetic engine for `m · p`

--- a/research/problems/abundant-number-oq-03-oq-03/knowledge.md
+++ b/research/problems/abundant-number-oq-03-oq-03/knowledge.md
@@ -138,3 +138,26 @@ and `card_divisors_mul` but **no** `Nat.Coprime.divisors_mul` Finset equality, s
 the decomposition `(m·p).properDivisors = m.divisors ∪ (p·) '' m.properDivisors`
 must be built from `filter_dvd_eq_divisors` before `abundant_mul_prime_iff`
 upgrades to a full `IsPrimitiveAbundant (m·p)` criterion.
+
+## Session 2026-07-21 (researcher-1): Route-2 extraction is FALSE under the strict definition
+
+The file's header recorded Route 2 ("primitive-part extraction") as *every abundant
+`n` has a primitive abundant divisor*. This is **false** for the file's strict
+`IsPrimitiveAbundant` (= abundant with *all proper divisors deficient*, OEIS A071395),
+because a **perfect** proper divisor blocks strict primitivity.
+
+- **`not_isPrimitiveAbundant_12`** — 12 (smallest abundant) is NOT strict-primitive:
+  its proper divisor 6 is perfect (σ'(6)=6), not deficient.
+- **`no_isPrimitiveAbundant_dvd_12`** — NO divisor of 12 is `IsPrimitiveAbundant`
+  (smallest strict primitive abundant is 20 > 12). Direct counterexample to Route-2.
+- Added `instance : DecidablePred IsPrimitiveAbundant` (the `def` blocked `decide`
+  synthesis; `primitive_945` had only `decide`d the unfolded ∀-conjunct). Both new
+  theorems `decide` (kernel, maxRecDepth 4000), axiom-free (`#print axioms` =
+  propext/Classical.choice/Quot.sound), host-verified `lake env lean` exit 0.
+- Fixed the header Route-2 paragraph to state the block: extraction works only for
+  the weaker A091191 notion ("no abundant proper divisor", under which 12 IS
+  primitive); recovering a strict primitive part additionally requires excluding
+  perfect divisors.
+
+### Status: vein remains OPEN/blocked. σ-arithmetic engine saturated (do NOT extend);
+Route-1 odd-family construction and a *corrected* Route-2 (A091191 → strict) both open.

--- a/src/data/research/problems/abundant-number-oq-03-oq-03.json
+++ b/src/data/research/problems/abundant-number-oq-03-oq-03.json
@@ -58,7 +58,9 @@
       "deficient_iff_sum_divisors: Deficient n <-> sigma(n) < 2n (dual of abundant_iff_sum_divisors), axiom-free",
       "deficient_mul_prime_iff: (e*p).Deficient <-> sigma(e)(p+1) < 2ep for p prime, p not | e",
       "isPrimitiveAbundant_mul_prime_arith: fully arithmetic primitivity criterion for m*p (three divisor-sum inequalities)",
-      "primitive_945_via_engine: 189*5=945 certified primitive abundant through the arithmetic criterion by decide"
+      "primitive_945_via_engine: 189*5=945 certified primitive abundant through the arithmetic criterion by decide",
+      "not_isPrimitiveAbundant_12 + no_isPrimitiveAbundant_dvd_12 in AbundantNumberOQ03OQ03.lean - Route-2 counterexample (axiom-free, kernel decide)",
+      "instance DecidablePred IsPrimitiveAbundant in AbundantNumberOQ03OQ03.lean"
     ],
     "insights": [
       "945 = 3³·5·7 is not just the smallest odd abundant number but is odd PRIMITIVE abundant (OEIS A006038): all 15 proper divisors 1,3,5,7,9,15,21,27,35,45,63,105,135,189,315 are deficient — verified axiom-free.",
@@ -69,7 +71,8 @@
       "The remaining Route-1 obstruction is PRIMITIVITY not abundance: need every proper divisor of m·p (the set {d, p·d : d ∣ m}) deficient. Mathlib v4.31 lacks a clean Nat.Coprime.divisors_mul Finset equality, so the coprime proper-divisor decomposition (m·p).properDivisors = m.divisors ∪ (p·)  m.properDivisors must be built from filter_dvd_eq_divisors before abundant_mul_prime_iff upgrades to a full IsPrimitiveAbundant iff.",
       "Route-1 primitivity is now reducible to conditions purely on m and its p-multiples: mem_properDivisors_mul_prime shows every proper divisor of m·p (p prime, 0<m) is either a divisor of m or p·(a proper divisor of m), and isPrimitiveAbundant_mul_prime turns primitivity of m·p into (m·p abundant) ∧ (all divisors of m deficient) ∧ (all p·(proper divisors of m) deficient). The divisor-structure gap flagged in the prior next step is closed.",
       "Deficiency is downward-closed under divisibility: deficient_of_dvd (m ∣ n, n deficient, m≠0 ⇒ m deficient), the dual of Mathlib Nat.Abundant.of_dvd, via monotonicity of the abundancy index (abundancyIndex_le_of_dvd) and the helper deficient_iff_abundancyIndex_lt_two (n≠0 ⇒ (Deficient n ↔ abundancyIndex n < 2)).",
-      "Consequence: the isPrimitiveAbundant_mul_prime obligation ∀ d ∈ m.divisors, d.Deficient is EQUIVALENT to just m.Deficient. Route-1 witness search therefore only needs (i) m·p abundant, (ii) m deficient, (iii) every p·e (e proper divisor of m) deficient."
+      "Consequence: the isPrimitiveAbundant_mul_prime obligation ∀ d ∈ m.divisors, d.Deficient is EQUIVALENT to just m.Deficient. Route-1 witness search therefore only needs (i) m·p abundant, (ii) m deficient, (iii) every p·e (e proper divisor of m) deficient.",
+      "Route-2 (primitive-part extraction) as recorded is FALSE under the strict IsPrimitiveAbundant (all proper divisors deficient, A071395): 12 is abundant but no divisor of 12 is strict-primitive-abundant (smallest is 20); a perfect proper divisor (6|12) blocks strict primitivity. Extraction holds only for the weaker A091191 notion (no abundant proper divisor)."
     ],
     "mathlibGaps": [
       "No Nat.Coprime.divisors_mul (Finset equality for divisors of a coprime product) in Mathlib v4.31 — only Nat.Coprime.sum_divisors_mul (the sum) and card_divisors_mul (the count). Blocks a clean coprime proper-divisor decomposition."


### PR DESCRIPTION
## Summary
Research session for **abundant-number-oq-03-oq-03** (are there infinitely many odd primitive abundant numbers, OEIS A006038 — genuinely OPEN).

The file's header recorded **Route 2** ("primitive-part extraction") as: *every abundant `n` has a primitive abundant divisor*, then extract from `Nat.infinite_odd_abundant`. This session shows that route is **blocked at its first step** under the file's own strict definition.

## Finding
`IsPrimitiveAbundant n := n.Abundant ∧ ∀ d ∈ n.properDivisors, d.Deficient` (all proper divisors **deficient**, OEIS A071395). Under this definition:

- **12** (the smallest abundant number) is **not** primitive abundant — its proper divisor **6 is perfect** (`σ'(6)=6`), not deficient.
- **No divisor of 12** is primitive abundant (the smallest strict primitive abundant number is **20 > 12**).

So *"every abundant `n` has a primitive abundant divisor"* is **false** as stated. It holds only for the weaker A091191 notion (*no abundant proper divisor*), under which 12 itself is primitive. A **perfect proper divisor** is precisely the obstruction separating the two notions.

## Progress
Added to `proofs/Proofs/AbundantNumberOQ03OQ03.lean` (axiom-free, kernel `decide`):
- `instance : DecidablePred IsPrimitiveAbundant` (the `def` blocked `decide` synthesis).
- `not_isPrimitiveAbundant_12`.
- `no_isPrimitiveAbundant_dvd_12` — the Route-2 counterexample.
- Corrected the header Route-2 paragraph to state the block and the A091191-vs-strict distinction.

## Verification
`lake env lean Proofs/AbundantNumberOQ03OQ03.lean`, exit 0. `#print axioms` on both new theorems = `[propext, Classical.choice, Quot.sound]` (kernel `decide`, no `native_decide`).

## Status
**Outcome**: progress (correctness finding + corrected route). The problem remains **open**; the σ-arithmetic engine is saturated (not extended). Route-1 (odd `m·p` family) and a *corrected* Route-2 (pass through A091191, then exclude perfect divisors) both remain open.

🤖 Generated by researcher-1
