### PR TITLE
Gallery integrity: erdos-505 fix phantom-axiom section summary

### DIFF
--- a/src/data/proofs/erdos-505/meta.json
+++ b/src/data/proofs/erdos-505/meta.json
@@ -57,7 +57,7 @@
       "title": "Header and Imports (continued)",
       "startLine": 14,
       "endLine": 25,
-      "summary": "Continuation: remaining proofs and definitions in this section."
+      "summary": "Continuation of the module docstring listing the known results, followed by the Mathlib imports (Real.Basic, Finset.Basic, InnerProductSpace.Basic). No declarations in this range."
     },
     {
       "id": "core-definitions",
@@ -78,7 +78,7 @@
       "title": "Low-Dimensional Positive Results",
       "startLine": 57,
       "endLine": 60,
-      "summary": "Axioms: Borsuk's conjecture holds for n = 2 (classical) and n = 3 (Eggleston 1955)."
+      "summary": "Four empty section headers (Low-Dimensional Results, Kahn–Kalai Counterexample, Bounds on α(n), Status of Intermediate Dimensions) marking where the known results are discussed. No Lean declarations follow — the results (n ≤ 3 true, n ≥ 64 false, the quantitative bounds) are recorded in the module docstring as background only; they are not axiomatized or proved."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
**Proof**: erdos-505 (Borsuk's Conjecture)

**Problem**: The `low-dim` section summary states "Axioms: Borsuk's conjecture holds for n = 2 (classical) and n = 3 (Eggleston 1955)", but lines 57-60 of `Proofs/Erdos505Problem.lean` are four empty section headers with **no Lean declarations**. The file has exactly one axiom (`borsukNumber`) — the n=2 and n=3 axioms named in the summary do not exist. The `section-14` summary also claimed nonexistent "proofs".

**Evidence**: `grep '^axiom'` → one hit (`borsukNumber`). axiomCount=1 is correct; the section narrative invented 2 more.

**Fix**: Rewrote both section summaries to describe the empty headers / docstring background honestly. Counts unchanged (1 axiom, 4 defs, 0 theorems, 0 sorries all accurate).

---
Discovered during gallery integrity audit.