### PR TITLE
Audit tracker: mark erdos-503 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14147,8 +14147,8 @@
     },
     "erdos-503": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:17Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T21:53:21Z",
       "result": "clean"
     },
     "erdos-504": {


### PR DESCRIPTION
erdos-503 re-audit clean: 6 real axioms (all declared & consistent, match literature: Kelly f(2)=6, Croft f(3)=8, Blokhuis/Alweiss/Weisenberg bounds), 2 theorems genuinely combine them, all origContribs map to real decls, no phantoms. Nit: 'norm_num' in prose but file uses `by decide` (trust-neutral, anon examples).