### PR TITLE
Audit tracker: mark erdos-499 clean (reserve re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14106,8 +14106,8 @@
     },
     "erdos-499": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:17Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T21:56:45Z",
       "result": "clean"
     },
     "erdos-5": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-499 (Diagonals of Doubly Stochastic Matrices).

**Result: clean.** All counts verified accurate against the Lean source:
- axiomCount 4 ✓ (marcus_ree_theorem, marcus_minc_theorem, van_der_waerden, birkhoff_von_neumann)
- theoremCount 5 ✓, definitionCount 7 ✓, sorries 0 ✓, no native_decide ✓

All 4 axioms are genuine, correctly-stated TRUE published theorems, each guarded with n≠0 and IsDoublyStochastic hypotheses. No false/inconsistent axioms. Status `axiomatized` + badge `axiom` correctly classify this Tier C; the `assumptions` field honestly enumerates all 4 axioms.

Minor nit (not reportable): origContribs names `two_by_two_erdos499` but the decl is `two_by_two_diagonals` — descriptive mismatch that does not inflate claim strength.

🤖 Generated with [Claude Code](https://claude.com/claude-code)