### PR TITLE
Enrich fourier-series-oq-02: correct stale 'axiomatized infrastructure' prose

### DIFF
--- a/src/data/proofs/fourier-series-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02/meta.json
@@ -243,7 +243,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization establishes the optimal Fourier coefficient decay rate for Hölder continuous functions: ‖ĉ_n‖ = O(1/|n|^α) for α-Hölder f, proved via the half-period translation trick. The main theorem is proved from axiomatized analytical infrastructure (difference formula, integral bounds). The formalization also establishes optimality, a partial converse via Sobolev embedding, and places the result in the full regularity-decay hierarchy from L² through analytic.",
+    "summary": "This formalization establishes the optimal Fourier coefficient decay rate for Hölder continuous functions: ‖ĉ_n‖ = O(1/|n|^α) for α-Hölder f, proved via the half-period translation trick. The main theorem is proved from fully-verified analytical infrastructure — the half-period difference formula (`fourierCoeff_difference_formula`) and the integral bounds (`integral_product_bound`) are established as lemmas, not axioms, so the entry is axiom-free. The formalization also establishes optimality, a partial converse via Sobolev embedding, and places the result in the full regularity-decay hierarchy from L² through analytic.",
     "implications": "**Theoretical Significance**: The Hölder decay theorem is a cornerstone of harmonic analysis, quantifying the fundamental principle that smoothness ↔ spectral decay.\n\nThe half-period translation trick generalizes to prove decay rates in other settings (torus, locally compact abelian groups). The critical threshold α = 1/2 connects to Sobolev embedding theory and the circle of ideas around Carleson's theorem.",
     "openQuestions": [
       "Can riemannLebesgue_of_holder be proved from Mathlib's Riemann-Lebesgue for L¹ (Hölder → continuous → integrable)?",


### PR DESCRIPTION
## Prose-accuracy fix (axiom integrity)

`conclusion.summary` stated:

> The main theorem is proved from **axiomatized** analytical infrastructure (difference formula, integral bounds).

This is stale and internally contradictory. In `FourierSeriesOQ02.lean` both pieces of "infrastructure" are **proved theorems**, not axioms:

- **difference formula** → `fourierCoeff_difference_formula` (theorem, L127)
- **integral bounds** → `integral_product_bound` (theorem, L199)

The file has **0 axioms / 0 sorries / 0 native_decide**, and every other meta field already says so (`assumptions: "0 axioms — fully proved"`, section summaries "no axioms or sorries", "All proved — no axioms"). Companion files `FourierSeriesOQ02OQ04.lean` (0 ax/0 sorries) are also axiom-free.

Corrected the one stale sentence to name the two lemmas and affirm the entry is axiom-free. No status/badge/axiomCount change needed — those are already correct (`verified` / `original` / `axiomCount: 0`).
