### PR TITLE
Fix: erdos-494 origContributions reflect comment-only scope

### DIFF
--- a/src/data/proofs/erdos-494/meta.json
+++ b/src/data/proofs/erdos-494/meta.json
@@ -44,10 +44,10 @@
       "Formal definition of k-sum multiset for finite sets in Complex",
       "Definition of KSumDeterminesSet: uniqueness property for cardinality n",
       "Axiomatization of Selfridge-Straus k=2 characterization (power of 2)",
-      "Axiomatization of Selfridge-Straus k=3 (|A| > 6) and k=4 (|A| > 12) results",
+      "Documentation of Selfridge-Straus k=3 (|A| > 6) and k=4 (|A| > 12) special cases (comments)",
       "Axiomatization of Gordon-Fraenkel-Straus main theorem (eventually for k > 2)",
-      "Counterexamples: Kruyt (|A| = k rotation) and Tao (|A| = 2k negation)",
-      "Steinerberger's product version counterexample"
+      "Discussion of Kruyt (|A| = k rotation) and Tao (|A| = 2k negation) small-set counterexamples (comments)",
+      "Discussion of Steinerberger's product-version counterexample (comment; prodMultiset defined)"
     ],
     "axiomCount": 2,
     "lineCount": 207,


### PR DESCRIPTION
## Metadata Narrative Fix

`erdos-494` `meta.originalContributions` claimed three axiomatizations/formalizations that do not exist as Lean declarations. The file `proofs/Proofs/Erdos494Problem.lean` has exactly **2 axioms** (`selfridge_straus_k2_not_power2`, `gordon_fraenkel_straus_main`); the k=3/k=4 results and all counterexamples are `/- ... -/` comment prose only.

### Before → After

- "Axiomatization of Selfridge-Straus k=3 (|A| > 6) and k=4 (|A| > 12) results" → "Documentation of Selfridge-Straus k=3 (|A| > 6) and k=4 (|A| > 12) special cases (comments)"
- "Counterexamples: Kruyt (|A| = k rotation) and Tao (|A| = 2k negation)" → "Discussion of Kruyt ... and Tao ... small-set counterexamples (comments)"
- "Steinerberger's product version counterexample" → "Discussion of Steinerberger's product-version counterexample (comment; prodMultiset defined)"

### Evidence
- `grep -nE '^axiom ' proofs/Proofs/Erdos494Problem.lean` → only lines 74, 136 (2 axioms).
- k=3/k=4: comment block lines ~86–89. Kruyt/Tao: comment block lines ~102–122. Steinerberger: comment lines ~149–154 (`prodMultiset` defined at 146, but the counterexample itself is not stated/proved).

No change to counts (axiomCount 2, theoremCount 1, definitionCount 6), badge (`axiom`), or status (`axiomatized`) — those were already accurate.

Closes #40965
