### PR TITLE
Fix: erdos-494 origContributions reflect comment-only scope

### DIFF
--- a/src/data/proofs/erdos-494/meta.json
+++ b/src/data/proofs/erdos-494/meta.json
@@ -44,10 +44,10 @@
       "Formal definition of k-sum multiset for finite sets in Complex",
       "Definition of KSumDeterminesSet: uniqueness property for cardinality n",
       "Axiomatization of Selfridge-Straus k=2 characterization (power of 2)",
-      "Axiomatization of Selfridge-Straus k=3 (|A| > 6) and k=4 (|A| > 12) results",
+      "Documentation of Selfridge-Straus k=3 (|A| > 6) and k=4 (|A| > 12) special cases (comments)",
       "Axiomatization of Gordon-Fraenkel-Straus main theorem (eventually for k > 2)",
-      "Counterexamples: Kruyt (|A| = k rotation) and Tao (|A| = 2k negation)",
-      "Steinerberger's product version counterexample"
+      "Discussion of Kruyt (|A| = k rotation) and Tao (|A| = 2k negation) small-set counterexamples (comments)",
+      "Discussion of Steinerberger's product-version counterexample (comment; prodMultiset defined)"
     ],
     "axiomCount": 2,
     "lineCount": 207,


### PR DESCRIPTION
## Summary

Fixes the narrative-scope overclaim in `erdos-494` `originalContributions` flagged by the gallery integrity auditor (#40965). Counts, badge (`axiom`), and status (`axiomatized`) were already accurate — this is a LOW narrative fix only.

## Evidence

`proofs/Proofs/Erdos494Problem.lean` contains exactly **2 axioms** (verified against `origin/main`):
- `selfridge_straus_k2_not_power2` (line 74)
- `gordon_fraenkel_straus_main` (line 136)

The three reworded entries describe results that appear **only in comments**, never as Lean declarations:
- k=3 (|A|>6) / k=4 (|A|>12): docstring comment (line 10) — no axiom
- Kruyt / Tao counterexamples: comments (lines 12, 105, 115) — not formalized
- Steinerberger product-version: comment (line 149); `prodMultiset` is a `def` but the counterexample is not stated/proved

## Change

Reworded 3 `originalContributions` strings from "Axiomatization…/Counterexamples…" to "Documentation…/Discussion…" to reflect their comment-only status. No change to `axiomCount` (2), `theoremCount` (1), `definitionCount` (6), badge, or status.

Closes #40965
