### PR TITLE
Research: erdos-507-wip-01 — quantitative decay heilbronn n = O(1/n), limit → 0

### DIFF
--- a/proofs/Proofs/Erdos507WIP01.lean
+++ b/proofs/Proofs/Erdos507WIP01.lean
@@ -47,7 +47,15 @@ of the atomic building block `triangleArea`:
 * the resulting sandwich `heilbronn 3 ∈ [3√3/4, 3/2] ≈ [1.299, 1.5]`
   (`heilbronn_three_mem_Icc`) — the conjectured exact value is the lower
   endpoint `3√3/4`, and the remaining gap is the sharp inscribed-triangle upper
-  bound `heilbronn 3 ≤ 3√3/4`.
+  bound `heilbronn 3 ≤ 3√3/4`;
+* **quantitative decay** `heilbronn n = O(1/n)`: a spread/box area bound
+  (`triangleArea_le_spread` — three points within a `w × h` box span area
+  `≤ w·h`) plus a `Finset` pigeonhole over `⌊(x+1)·m/2⌋₊` vertical strips give
+  `heilbronn n ≤ 4/m` whenever `2(m+1) < n` (`heilbronn_le_four_div`), hence
+  `heilbronn n → 0` (`heilbronn_tendsto_zero`).  This is the first bound
+  exhibiting genuine decay — all the bounds above are constant in `n` — and
+  formalizes the elementary "`α(n) ≪ 1/n`" pigeonhole remark of the problem
+  statement.
 
 All results are `0`-axiom / `0`-sorry.
 
@@ -55,6 +63,7 @@ Reference: <https://erdosproblems.com/507>
 -/
 
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Combinatorics.Pigeonhole
 import Mathlib.Data.Finset.Card
 import Mathlib.Data.Real.Basic
 import Mathlib.Tactic
@@ -585,5 +594,157 @@ sharp maximal-inscribed-triangle upper bound `heilbronn 3 ≤ 3√3/4`. -/
 theorem heilbronn_three_mem_Icc :
     heilbronn 3 ∈ Set.Icc (3 * Real.sqrt 3 / 4) (3 / 2) :=
   ⟨heilbronn_three_ge, heilbronn_le_three_halves 3 (by norm_num)⟩
+
+/-! ## Quantitative decay: `heilbronn n = O(1/n)`
+
+All the upper bounds above (`heilbronn n ≤ 3`, `≤ 3/2`) are *constant* in `n` —
+they witness finiteness but not decay.  The elementary pigeonhole argument
+sketched in the problem statement shows that Heilbronn's function actually
+**decays**: cut the unit disk into `m + 1` vertical strips of width `2/m`; once
+`2(m+1) < n`, some strip must contain three of the `n` points, and three points
+sharing a strip of width `2/m` and height `2` span a triangle of area at most
+`(2/m)·2 = 4/m`.  Hence `heilbronn n ≤ 4/m` for every admissible `m`, so
+`heilbronn n → 0`.  This is qualitatively stronger than the constant bounds:
+combined with `heilbronn_antitone` it shows Heilbronn's function is a strictly
+decaying-to-zero sequence, matching the (much finer) known asymptotic
+`α(n) = n^{−β+o(1)}` with `7/6 ≤ β ≤ 2` at the crudest exponent level. -/
+
+/-- **Spread bound for the triangle area.**  If the `x`-coordinates of `p, q`
+lie within `w` of `r.1` and their `y`-coordinates within `h` of `r.2`, then the
+triangle `p q r` has area at most `w · h`.  Proof: the shoelace signed area
+equals the `2×2` determinant `(p₁−r₁)(q₂−r₂) − (q₁−r₁)(p₂−r₂)`, whose two
+products are each `≤ w·h` in absolute value, so `|signed area| ≤ 2wh` and
+`triangleArea = |signed area| / 2 ≤ wh`. -/
+theorem triangleArea_le_spread (p q r : ℝ × ℝ) {w h : ℝ}
+    (hpx : |p.1 - r.1| ≤ w) (hqx : |q.1 - r.1| ≤ w)
+    (hpy : |p.2 - r.2| ≤ h) (hqy : |q.2 - r.2| ≤ h)
+    (hw : 0 ≤ w) :
+    triangleArea p q r ≤ w * h := by
+  have hA : |(p.1 - r.1) * (q.2 - r.2)| ≤ w * h := by
+    rw [abs_mul]; exact mul_le_mul hpx hqy (abs_nonneg _) hw
+  have hB : |(q.1 - r.1) * (p.2 - r.2)| ≤ w * h := by
+    rw [abs_mul]; exact mul_le_mul hqx hpy (abs_nonneg _) hw
+  have key : |(p.1 - r.1) * (q.2 - r.2) - (q.1 - r.1) * (p.2 - r.2)|
+      ≤ |(p.1 - r.1) * (q.2 - r.2)| + |(q.1 - r.1) * (p.2 - r.2)| := by
+    have h := abs_add_le ((p.1 - r.1) * (q.2 - r.2)) (-((q.1 - r.1) * (p.2 - r.2)))
+    rwa [abs_neg, ← sub_eq_add_neg] at h
+  unfold triangleArea
+  have hid : p.1 * (q.2 - r.2) + q.1 * (r.2 - p.2) + r.1 * (p.2 - q.2)
+      = (p.1 - r.1) * (q.2 - r.2) - (q.1 - r.1) * (p.2 - r.2) := by ring
+  rw [hid]
+  linarith [key, hA, hB]
+
+/-- **Same-strip `x`-spread bound.**  If two points `pt₁, pt₂` (both with
+`x`-coordinate `≥ −1`) fall in the same strip `⌊(x+1)·m/2⌋₊`, their
+`x`-coordinates differ by at most `2/m`, stated division-free as
+`|pt₁.1 − pt₂.1| · m ≤ 2`.  Equal `⌊·⌋₊` forces both `(x+1)m/2` into a common
+unit interval `[j, j+1)`. -/
+private theorem strip_spread {pt₁ pt₂ : ℝ × ℝ} {m : ℕ}
+    (h₁ : -1 ≤ pt₁.1) (h₂ : -1 ≤ pt₂.1)
+    (hfe : ⌊(pt₁.1 + 1) * m / 2⌋₊ = ⌊(pt₂.1 + 1) * m / 2⌋₊) :
+    |pt₁.1 - pt₂.1| * m ≤ 2 := by
+  have hnn1 : (0 : ℝ) ≤ (pt₁.1 + 1) * m / 2 :=
+    div_nonneg (mul_nonneg (by linarith) (Nat.cast_nonneg m)) (by norm_num)
+  have hnn2 : (0 : ℝ) ≤ (pt₂.1 + 1) * m / 2 :=
+    div_nonneg (mul_nonneg (by linarith) (Nat.cast_nonneg m)) (by norm_num)
+  have l1 := Nat.floor_le hnn1
+  have u1 := Nat.lt_floor_add_one ((pt₁.1 + 1) * m / 2)
+  have l2 := Nat.floor_le hnn2
+  have u2 := Nat.lt_floor_add_one ((pt₂.1 + 1) * m / 2)
+  rw [hfe] at l1 u1
+  have goalform : |pt₁.1 - pt₂.1| * (m : ℝ) = |(pt₁.1 - pt₂.1) * m| := by
+    rw [abs_mul, Nat.abs_cast]
+  have hDm : (pt₁.1 - pt₂.1) * (m : ℝ)
+      = 2 * ((pt₁.1 + 1) * m / 2) - 2 * ((pt₂.1 + 1) * m / 2) := by ring
+  rw [goalform, abs_le]
+  constructor
+  · rw [hDm]; linarith [l1, u2]
+  · rw [hDm]; linarith [u1, l2]
+
+/-- **Pigeonhole decay bound.**  For every number of strips `m ≥ 1` with
+`2(m + 1) < n`, Heilbronn's function satisfies `heilbronn n ≤ 4/m`.  Since the
+right-hand side can be made arbitrarily small by taking `m` (hence `n`) large,
+this is the first bound exhibiting genuine decay `heilbronn n → 0` (all previous
+uniform bounds are constant).  Proof: in any witnessing `n`-point configuration,
+map each point to its strip index `⌊(x+1)·m/2⌋₊ ∈ {0,…,m}`; as `(m+1)·2 < n`,
+some strip holds three distinct points (`Finset` pigeonhole), and those three —
+sharing a strip of width `2/m` and lying in the disk (height `≤ 2`) — span a
+triangle of area `≤ (2/m)·2 = 4/m` (`triangleArea_le_spread`), bounding the
+admissible `α`. -/
+theorem heilbronn_le_four_div (n m : ℕ) (hm : 1 ≤ m) (hmn : 2 * (m + 1) < n) :
+    heilbronn n ≤ 4 / m := by
+  have hmR : (0 : ℝ) < m := by exact_mod_cast hm
+  unfold heilbronn
+  apply Real.sSup_le
+  · rintro α ⟨P, hcard, hdisk, hbound⟩
+    -- Each point maps to its vertical strip index in `{0, …, m}`.
+    have hmaps : ∀ pt ∈ P, ⌊(pt.1 + 1) * m / 2⌋₊ ∈ Finset.range (m + 1) := by
+      intro pt hpt
+      rw [Finset.mem_range]
+      have hx : |pt.1| ≤ 1 := unitDisk_abs_fst_le hdisk hpt
+      have hxn : -1 ≤ pt.1 := (abs_le.mp hx).1
+      have hx1 : pt.1 ≤ 1 := (abs_le.mp hx).2
+      have hnn : (0 : ℝ) ≤ (pt.1 + 1) * m / 2 :=
+        div_nonneg (mul_nonneg (by linarith) (Nat.cast_nonneg m)) (by norm_num)
+      have h2m : (pt.1 + 1) * (m : ℝ) ≤ 2 * m :=
+        mul_le_mul_of_nonneg_right (by linarith) hmR.le
+      exact (Nat.floor_lt hnn).mpr (by push_cast; linarith [h2m])
+    have hcardgt : (Finset.range (m + 1)).card * 2 < P.card := by
+      rw [Finset.card_range, hcard]; omega
+    obtain ⟨y, -, hy3⟩ :=
+      Finset.exists_lt_card_fiber_of_mul_lt_card_of_maps_to hmaps hcardgt
+    -- The fiber (points in one strip) has `> 2` elements: extract three distinct.
+    obtain ⟨a, b, c, ha, hb, hc, hab, hac, hbc⟩ := Finset.two_lt_card_iff.mp hy3
+    simp only [Finset.mem_filter] at ha hb hc
+    obtain ⟨haP, hay⟩ := ha
+    obtain ⟨hbP, hby⟩ := hb
+    obtain ⟨hcP, hcy⟩ := hc
+    have hxa : -1 ≤ a.1 := (abs_le.mp (unitDisk_abs_fst_le hdisk haP)).1
+    have hxb : -1 ≤ b.1 := (abs_le.mp (unitDisk_abs_fst_le hdisk hbP)).1
+    have hxc : -1 ≤ c.1 := (abs_le.mp (unitDisk_abs_fst_le hdisk hcP)).1
+    -- `x`-spread within the strip: `|Δx| · m ≤ 2`, i.e. `|Δx| ≤ 2/m`.
+    have hwa : |a.1 - c.1| ≤ 2 / m := by
+      rw [le_div_iff₀ hmR]; exact strip_spread hxa hxc (by rw [hay, hcy])
+    have hwb : |b.1 - c.1| ≤ 2 / m := by
+      rw [le_div_iff₀ hmR]; exact strip_spread hxb hxc (by rw [hby, hcy])
+    -- `y`-spread across the disk: `|Δy| ≤ 2`.
+    have hya : |a.2 - c.2| ≤ 2 := by
+      have g1 := abs_le.mp (unitDisk_abs_snd_le hdisk haP)
+      have g2 := abs_le.mp (unitDisk_abs_snd_le hdisk hcP)
+      rw [abs_le]; constructor <;> linarith [g1.1, g1.2, g2.1, g2.2]
+    have hyb : |b.2 - c.2| ≤ 2 := by
+      have g1 := abs_le.mp (unitDisk_abs_snd_le hdisk hbP)
+      have g2 := abs_le.mp (unitDisk_abs_snd_le hdisk hcP)
+      rw [abs_le]; constructor <;> linarith [g1.1, g1.2, g2.1, g2.2]
+    have harea : triangleArea a b c ≤ 2 / m * 2 :=
+      triangleArea_le_spread a b c hwa hwb hya hyb (by positivity)
+    have hα : α ≤ triangleArea a b c := hbound a haP b hbP c hcP hab hbc hac
+    have heq : (2 : ℝ) / m * 2 = 4 / m := by ring
+    linarith [hα, harea, heq]
+  · positivity
+
+/-- **Heilbronn's function tends to `0`.**  A direct consequence of the
+pigeonhole decay bound `heilbronn n ≤ 4/m` (`heilbronn_le_four_div`): given
+`ε > 0`, pick `m > 4/ε`; then for all `n > 2(m+1)` we have
+`0 ≤ heilbronn n ≤ 4/m < ε`.  This is the qualitative content the constant
+bounds `heilbronn n ≤ 3/2` cannot supply — Heilbronn's function is a genuinely
+null sequence (consistent with the known `α(n) = n^{−β+o(1)}`, `7/6 ≤ β ≤ 2`). -/
+theorem heilbronn_tendsto_zero :
+    Filter.Tendsto heilbronn Filter.atTop (nhds 0) := by
+  rw [Metric.tendsto_atTop]
+  intro ε hε
+  obtain ⟨m, hm⟩ := exists_nat_gt (4 / ε)
+  have hmpos : 0 < m := by
+    exact_mod_cast lt_of_le_of_lt (by positivity : (0 : ℝ) ≤ 4 / ε) hm
+  refine ⟨2 * (m + 1) + 1, fun n hn => ?_⟩
+  have hmn : 2 * (m + 1) < n := by omega
+  have hbound := heilbronn_le_four_div n m hmpos hmn
+  have hpos := heilbronn_nonneg n (by omega)
+  have h4m : 4 / (m : ℝ) < ε := by
+    rw [div_lt_iff₀ (show (0 : ℝ) < m by exact_mod_cast hmpos)]
+    rw [div_lt_iff₀ hε] at hm
+    linarith [hm]
+  rw [Real.dist_eq, sub_zero, abs_of_nonneg hpos]
+  linarith [hbound, h4m]
 
 end Erdos507WIP01

--- a/research/problems/erdos-507-wip-01/knowledge.md
+++ b/research/problems/erdos-507-wip-01/knowledge.md
@@ -7,6 +7,59 @@ Heilbronn's triangle problem, **OPEN**: the exponent `β` with
 (Komlós–Pintz–Szemerédi, Cohen–Pohoata–Zakharov) are untouched; this file builds
 the elementary geometry of `triangleArea` and `minTriangleArea`/`heilbronn`.
 
+## Session 2026-07-21 (researcher-1) — quantitative decay `heilbronn n = O(1/n)` + limit `→ 0`
+
+**Mode**: continue RICH node. **Outcome**: progress — 3 new public declarations
+(+ 1 private helper), **host-verified v4.31** (`lake env lean` exit 0, 0
+warnings; `#print axioms` on all three = `[propext, Classical.choice,
+Quot.sound]`, 0 sorry / 0 axiom / no native_decide). First bound exhibiting
+**genuine decay** — every prior upper bound (`≤ 3`, `≤ 3/2`) is *constant* in
+`n`; this proves Heilbronn's function is a null sequence. Formalizes the
+elementary "`α(n) ≪ 1/n` pigeonhole" remark of the problem statement (present in
+prose, never formalized).
+
+### What I added
+- `triangleArea_le_spread (p q r) (|Δx|≤w, |Δy|≤h anchored at r, 0≤w) : area ≤ w·h`
+  — **spread/box area bound**. Key: the shoelace signed area equals the `2×2`
+  determinant `(p₁−r₁)(q₂−r₂) − (q₁−r₁)(p₂−r₂)` (one `ring` step), each product
+  `≤ w·h` in abs, so `|E| ≤ 2wh` and `area = |E|/2 ≤ wh`.
+- `strip_spread` (private) : equal strip index `⌊(x+1)·m/2⌋₊` forces
+  `|Δx|·m ≤ 2` (both `(x+1)m/2` in a common `[j,j+1)`; `Nat.floor_le` +
+  `Nat.lt_floor_add_one`). Stated division-free to dodge cast/division pain.
+- `heilbronn_le_four_div (n m) (1≤m) (2(m+1)<n) : heilbronn n ≤ 4/m` — the
+  pigeonhole upper bound. Map each of the `n` points to its vertical strip index
+  in `{0,…,m}`; `(m+1)·2 < n` ⇒ some strip holds 3 distinct points
+  (`Finset.exists_lt_card_fiber_of_mul_lt_card_of_maps_to`); those three, sharing
+  a width-`2/m` strip in a height-`2` disk, span area `≤ (2/m)·2 = 4/m`
+  (`triangleArea_le_spread`), bounding the admissible `α` via `Real.sSup_le`.
+- `heilbronn_tendsto_zero : Tendsto heilbronn atTop (𝓝 0)` — ε–N directly:
+  pick `m > 4/ε` (`exists_nat_gt`), then `n > 2(m+1)` ⇒
+  `0 ≤ heilbronn n ≤ 4/m < ε` (`Metric.tendsto_atTop`, `Real.dist_eq`).
+
+### Key findings / reusable Lean recipe
+- **Determinant form `E = (p₁−r₁)(q₂−r₂) − (q₁−r₁)(p₂−r₂)`** (vs the origin-based
+  `(p×q)+(q×r)+(r×p)` used for the `3/2` bound) is the right handle for *local*
+  (box/strip) area bounds — anchoring at a vertex turns the spread hypotheses
+  into two `|·|≤w·h` products directly.
+- **Pigeonhole → thin triangle** in Lean: strip map `⌊(pt.1+1)·m/2⌋₊` into
+  `Finset.range (m+1)` (maps-to via `Nat.floor_lt`); `#t·2 < #s` gives a fiber
+  with `> 2` elements; `Finset.two_lt_card_iff` extracts the distinct triple;
+  `simp only [Finset.mem_filter]` recovers `∈ P ∧ strip = y`.
+- **Division-free spread lemma** (`|Δx|·m ≤ 2` not `|Δx| ≤ 2/m`): keeps the floor
+  arithmetic linear (`linarith` after `rw [abs_mul, Nat.abs_cast]` and a `ring`
+  identity `Δx·m = 2·y₁ − 2·y₂`); convert to `2/m` at the call site with
+  `le_div_iff₀`.
+- The `4/m` **constant is not tight** (the box bound loses the triangle-≤-½-box
+  factor and the strip count is `~n/2`); the sharp Heilbronn asymptotic is
+  `α(n) = n^{−β+o(1)}`, `7/6 ≤ β ≤ 2` — deep, out of scope here.
+
+### Next steps
+- Sharp constant/exponent (`α(n) ≍ (log n)/n²` lower, `n^{−7/6}` upper) remain
+  deep-blocked (KPS/CPZ); the elementary layer is now essentially complete:
+  well-definedness, monotonicity, the `n=3` sandwich `[3√3/4, 3/2]`, and decay
+  `→ 0`. Only the sharp `heilbronn 3 ≤ 3√3/4` upper bound (largest inscribed
+  triangle, ~500-line optimization) is a plausible next elementary target.
+
 ## Session 2026-07-21 (researcher-1) — improved upper bound `heilbronn n ≤ 3/2` + sandwich at n=3
 
 **Mode**: continue RICH node. **Outcome**: progress — 4 new public declarations,

--- a/research/problems/erdos-507-wip-01/state.md
+++ b/research/problems/erdos-507-wip-01/state.md
@@ -28,11 +28,13 @@ needed). Bound `heilbronn n` (`n ≥ 3`) via `Real.sSup_le` + `triangleArea_le_t
 
 ## Next Action
 
-Sharpen the `n=3` lower bound toward the exact `heilbronn 3 = 3√3/4` (largest
-inscribed triangle); the upper half needs a max-inscribed-triangle bound, likely
-not session-sized. Otherwise the deep `α(n)` exponent bounds (KPS/CPZ) remain
-out of scope.
+Elementary layer is now essentially complete: well-definedness, monotonicity,
+the `n=3` sandwich `[3√3/4, 3/2]`, and **quantitative decay** `heilbronn n ≤ 4/m`
+(`heilbronn_le_four_div`) hence `heilbronn n → 0` (`heilbronn_tendsto_zero`, added
+2026-07-21). Remaining plausible elementary target: the sharp
+`heilbronn 3 ≤ 3√3/4` (largest inscribed triangle, ~500-line optimization). The
+deep `α(n)` exponent bounds (KPS/CPZ, `7/6 ≤ β ≤ 2`) remain out of scope.
 
 ## Attempt Counts
 
-- Total attempts: 3
+- Total attempts: 4

--- a/src/data/research/problems/erdos-507-wip-01.json
+++ b/src/data/research/problems/erdos-507-wip-01.json
@@ -46,7 +46,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Foundational Heilbronn toolkit complete. n=3 now SANDWICHED: 3√3/4 ≤ heilbronn 3 ≤ 3/2 (heilbronn_three_mem_Icc). Sharp lower bound heilbronn 3 ≥ 3√3/4 = conjectured exact value; improved upper bound heilbronn n ≤ 3/2 (was ≤3) via origin-determinant decomposition E=(p×q)+(q×r)+(r×p) + Lagrange. Open: sharp upper bound heilbronn 3 ≤ 3√3/4 (maximal-inscribed-triangle optimization), and the deep α(n) exponent bounds (KPS/CPZ).",
+    "progressSummary": "Foundational Heilbronn toolkit + quantitative decay. n=3 SANDWICHED 3√3/4 ≤ heilbronn 3 ≤ 3/2. NEW (2026-07-21): heilbronn n ≤ 4/m for 2(m+1)<n (pigeonhole over vertical strips, heilbronn_le_four_div) ⇒ heilbronn n → 0 (heilbronn_tendsto_zero) — first bound showing genuine DECAY (all prior bounds constant in n); formalizes the elementary α(n)≪1/n remark. Open: sharp heilbronn 3 ≤ 3√3/4, and the deep α(n) exponent bounds (KPS/CPZ, 7/6≤β≤2).",
     "builtItems": [
       "triangleArea_nonneg in Erdos507WIP01.lean",
       "triangleArea_swap_left / triangleArea_swap_right / triangleArea_cyclic (permutation symmetry)",
@@ -72,7 +72,11 @@
       "abs_cross_le_one (Erdos507WIP01.lean): |a₁b₂−a₂b₁| ≤ 1 for a,b in unit disk (Lagrange identity + |a|²|b|² ≤ 1), 0-axiom",
       "triangleArea_le_three_halves (Erdos507WIP01.lean): improved uniform area bound ≤ 3/2 via E=(p×q)+(q×r)+(r×p) and abs_cross_le_one — sharpens triangleArea_le_three (≤3)",
       "heilbronn_le_three_halves (Erdos507WIP01.lean): heilbronn n ≤ 3/2 for n≥3, sharpens heilbronn_le_three",
-      "heilbronn_three_mem_Icc (Erdos507WIP01.lean): sandwich heilbronn 3 ∈ [3√3/4, 3/2] ≈ [1.299,1.5], 0-axiom, docker-verified v4.31"
+      "heilbronn_three_mem_Icc (Erdos507WIP01.lean): sandwich heilbronn 3 ∈ [3√3/4, 3/2] ≈ [1.299,1.5], 0-axiom, docker-verified v4.31",
+      "triangleArea_le_spread in Erdos507WIP01.lean: three points within a w×h box span area ≤ w·h (determinant identity + abs_mul bounds), 0-axiom",
+      "strip_spread (private) in Erdos507WIP01.lean: equal strip index ⌊(x+1)·m/2⌋₊ ⇒ |Δx|·m ≤ 2, 0-axiom",
+      "heilbronn_le_four_div in Erdos507WIP01.lean: heilbronn n ≤ 4/m for 1≤m, 2(m+1)<n (Finset pigeonhole), 0-axiom",
+      "heilbronn_tendsto_zero in Erdos507WIP01.lean: Tendsto heilbronn atTop (𝓝 0), 0-axiom"
     ],
     "insights": [
       "The signed shoelace area p₁(q₂−r₂)+q₁(r₂−p₂)+r₁(p₂−q₂) is alternating: transpositions negate it (area invariant via abs_neg), cyclic rotations fix it — giving full S₃ symmetry after the absolute value.",
@@ -92,7 +96,9 @@
       "heilbronn 3 ≥ 3√3/4 (heilbronn_three_ge): sharp lower bound at n=3 via the equilateral triangle inscribed in the unit circle — (1,0),(−1/2,√3/2),(−1/2,−√3/2), all on the boundary, every ordering has triangleArea = 3√3/4 (the largest triangle inscribable in a radius-1 disk). Strengthens the crude right-triangle witness heilbronn 3 ≥ 1/2 to the conjectured EXACT value; the matching upper bound heilbronn 3 ≤ 3√3/4 (open here) would pin heilbronn 3 = 3√3/4, improving the current crude ≤ 3.",
       "The signed shoelace area equals a sum of three origin-based 2×2 determinants: E = (p×q)+(q×r)+(r×p) with a×b := a₁b₂−a₂b₁ (verified by ring). Each determinant is twice the signed area of triangle O-a-b.",
       "|a×b| ≤ 1 for unit-disk a,b via Lagrange: (a×b)² = |a|²|b|² − ⟨a,b⟩² ≤ |a|²|b|² ≤ 1; nlinarith needs sq_nonneg ⟨a,b⟩ plus the product bound |a|²|b|²≤1. This gives |E| ≤ 3 (abs_add_le twice + gcongr), hence area ≤ 3/2 — strictly better than the summand-wise ≤3.",
-      "The upper bound 3/2 is NOT sharp (true max |E|=3√3/2≈2.598, area 3√3/4≈1.299): the three determinants cannot be simultaneously maximal. Closing to the sharp 3√3/4 needs the central-angle constraint (angles subtended at O sum to 2π when O is interior) + Jensen on sin over [0,π] + an O-exterior case split — the genuine open optimization."
+      "The upper bound 3/2 is NOT sharp (true max |E|=3√3/2≈2.598, area 3√3/4≈1.299): the three determinants cannot be simultaneously maximal. Closing to the sharp 3√3/4 needs the central-angle constraint (angles subtended at O sum to 2π when O is interior) + Jensen on sin over [0,π] + an O-exterior case split — the genuine open optimization.",
+      "Quantitative decay heilbronn n = O(1/n): pigeonhole over ⌊(x+1)·m/2⌋₊ vertical strips gives heilbronn n ≤ 4/m whenever 2(m+1)<n (heilbronn_le_four_div), hence heilbronn n → 0 (heilbronn_tendsto_zero). First non-constant upper bound; formalizes the α(n)≪1/n pigeonhole remark of the problem statement.",
+      "Reusable recipe: the determinant form E=(p₁−r₁)(q₂−r₂)−(q₁−r₁)(p₂−r₂) (anchored at a vertex) is the right handle for LOCAL box/strip area bounds — spread hypotheses |Δx|≤w,|Δy|≤h collapse to two |·|≤w·h products (triangleArea_le_spread: area ≤ w·h)."
     ],
     "mathlibGaps": [
       "No off-the-shelf lemma reduces the nested membership biInf of minTriangleArea to a single ciInf_le; the junk-value semantics of ⨅ over unsatisfiable membership binders must be handled explicitly (done here via ciInf_le_of_le descent).",


### PR DESCRIPTION
## Summary
Research session for `erdos-507-wip-01` (Heilbronn's triangle problem foundations). Adds the **first bound exhibiting genuine decay** of Heilbronn's function: `heilbronn n → 0`. Every prior upper bound in the file (`≤ 3`, `≤ 3/2`) is *constant* in `n`; this formalizes the elementary "`α(n) ≪ 1/n` pigeonhole" remark stated in the problem prose but never formalized.

## Progress (all 0 sorry / 0 axiom, host-verified v4.31)
- **`triangleArea_le_spread`** — three points within a `w × h` box span area `≤ w·h`. Key: the shoelace signed area equals the `2×2` determinant `(p₁−r₁)(q₂−r₂) − (q₁−r₁)(p₂−r₂)` (one `ring` step), each product `≤ w·h` in absolute value.
- **`strip_spread`** (private) — points sharing a strip index `⌊(x+1)·m/2⌋₊` have `|Δx|·m ≤ 2` (both `(x+1)m/2` land in a common `[j, j+1)`; `Nat.floor_le` + `Nat.lt_floor_add_one`), stated division-free to keep the floor arithmetic linear.
- **`heilbronn_le_four_div`** — `heilbronn n ≤ 4/m` whenever `1 ≤ m` and `2(m+1) < n`. Map each of the `n` points to its vertical strip index in `{0,…,m}`; `(m+1)·2 < n` forces some strip to hold three distinct points (`Finset.exists_lt_card_fiber_of_mul_lt_card_of_maps_to`); those three, sharing a width-`2/m` strip in a height-`2` disk, span area `≤ (2/m)·2 = 4/m` (`triangleArea_le_spread`), bounding the admissible `α` via `Real.sSup_le`.
- **`heilbronn_tendsto_zero`** — `Tendsto heilbronn atTop (𝓝 0)`. ε–N directly: pick `m > 4/ε`, then `n > 2(m+1)` gives `0 ≤ heilbronn n ≤ 4/m < ε`.

Files: `proofs/Proofs/Erdos507WIP01.lean` (+ knowledge/state/tracker).

## Findings
- The origin-based determinant `E = (p×q)+(q×r)+(r×p)` (used for the `3/2` bound) is the wrong handle for *local* area bounds; the vertex-anchored form `(p₁−r₁)(q₂−r₂)−(q₁−r₁)(p₂−r₂)` collapses spread hypotheses to two `|·| ≤ w·h` products directly.
- The `4/m` constant is deliberately not tight (loses the triangle-≤-½-box factor and uses `~n/2` strips); the sharp asymptotic `α(n) = n^{−β+o(1)}`, `7/6 ≤ β ≤ 2` (KPS/CPZ) is deep and out of scope.

## Verification
`lake env lean Proofs/Erdos507WIP01.lean` exit 0, 0 warnings; `#print axioms` on all three public results = `[propext, Classical.choice, Quot.sound]` (no sorry, no `native_decide`, no `Lean.ofReduceBool`).

## Status
**Outcome**: progress — elementary layer now covers well-definedness, monotonicity, the `n=3` sandwich `[3√3/4, 3/2]`, and decay `→ 0`.
**Next Steps**: the sharp `heilbronn 3 ≤ 3√3/4` (largest-inscribed-triangle optimization, ~500 lines) is the remaining plausible elementary target; deep `α(n)` exponent bounds remain blocked.

🤖 Generated by researcher-1