### PR TITLE
Fix: erdos-494 origContributions reflect comment-only scope (#40965)

### DIFF
--- a/src/data/proofs/erdos-494/meta.json
+++ b/src/data/proofs/erdos-494/meta.json
@@ -44,10 +44,10 @@
       "Formal definition of k-sum multiset for finite sets in Complex",
       "Definition of KSumDeterminesSet: uniqueness property for cardinality n",
       "Axiomatization of Selfridge-Straus k=2 characterization (power of 2)",
-      "Axiomatization of Selfridge-Straus k=3 (|A| > 6) and k=4 (|A| > 12) results",
+      "Documentation of Selfridge-Straus k=3 (|A| > 6) and k=4 (|A| > 12) special cases (comments)",
       "Axiomatization of Gordon-Fraenkel-Straus main theorem (eventually for k > 2)",
-      "Counterexamples: Kruyt (|A| = k rotation) and Tao (|A| = 2k negation)",
-      "Steinerberger's product version counterexample"
+      "Discussion of Kruyt (|A| = k rotation) and Tao (|A| = 2k negation) small-set counterexamples (comments)",
+      "Discussion of Steinerberger's product-version counterexample (comment; prodMultiset defined)"
     ],
     "axiomCount": 2,
     "lineCount": 207,


### PR DESCRIPTION
## Summary

Rewords three `originalContributions` entries in `erdos-494/meta.json` to reflect that they are documentation/discussion in `/- ... -/` block comments, not formalized Lean declarations. Fixes the narrative-scope overclaim flagged in #40965 (LOW severity).

## Evidence

`proofs/Proofs/Erdos494Problem.lean` contains exactly **2 axioms**:
- `selfridge_straus_k2_not_power2` (line 74, k=2 case)
- `gordon_fraenkel_straus_main` (line 136, GFS main, k>2)

The reworded entries were previously claiming axiomatizations/counterexamples that exist only as prose:
- k=3/k=4 Selfridge-Straus: `/- -/` comment at line ~86 (not axiomatized)
- Kruyt/Tao counterexamples: comments at lines ~105/115 (not formalized)
- Steinerberger product version: comment at line ~149; `prodMultiset` is defined but the counterexample is not stated/proved

## Scope

Metadata-only, one entry. Counts (axiomCount 2, theoremCount 1, definitionCount 6), badge `axiom`, and status `axiomatized` are all accurate and unchanged.

Closes #40965
