### PR TITLE
feat(agents): universal ~/.claude/accounts.env account pool (home base, repo .env overrides)

### DIFF
--- a/scripts/agents/claude-wrapper.sh
+++ b/scripts/agents/claude-wrapper.sh
@@ -47,30 +47,52 @@ if [[ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
     _repo_root="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
     _tokens_dir="$_repo_root/.loom/tokens"
 
-    # Bootstrap: if .loom/tokens is missing/empty/broken-symlink but .env
-    # has ACCOUNT_KEY_N entries, materialize them into the tokens dir.
+    # Bootstrap: if .loom/tokens is missing/empty/broken-symlink, materialize
+    # the account pool from two layered sources, in precedence order:
+    #   1. ~/.claude/accounts.env  — the UNIVERSAL home-directory pool, shared
+    #      across every repo on this host (base layer).
+    #   2. $_repo_root/.env        — this repo's local accounts, which OVERRIDE
+    #      a home account at the same index N and ADD new indices (top layer).
+    # Layering is by positional index N: each source's ACCOUNT_KEY_N writes
+    # agent-N.token, and because the repo .env is applied SECOND it overwrites
+    # any home account sharing that N. Absent either file, the other still works;
+    # absent both, we fall through to the single-token path below.
     #
     # NOTE (see issue #38967): tokens are written POSITIONALLY as
     # "agent-N.token" using the index N from ACCOUNT_KEY_N. Selection/rotation
     # below globs "*.token", so the .token files are the source of truth. The
-    # .env ACCOUNT_TOKEN_FILE_N column is a human-facing label only and is NOT
+    # ACCOUNT_TOKEN_FILE_N column is a human-facing label only and is NOT
     # read here; to stay accurate it must equal "agent-N.token". Verify with
     # scripts/agents/check-token-registry.sh; regenerate with
     # scripts/agents/sync-token-registry.sh. Do NOT switch this to
     # ACCOUNT_TOKEN_FILE_N naming without migrating the live pool first.
+    _home_accts="${LOOM_ACCOUNTS_FILE:-$HOME/.claude/accounts.env}"
+    # Materialize every ACCOUNT_KEY_N= line from a file into agent-N.token.
+    _materialize_accounts() {
+        local _src="$1"
+        [[ -f "$_src" ]] && grep -q '^ACCOUNT_KEY_[0-9]\+=' "$_src" 2>/dev/null || return 1
+        local key val _n
+        while IFS='=' read -r key val; do
+            _n="${key#ACCOUNT_KEY_}"
+            [[ "$_n" =~ ^[0-9]+$ ]] || continue
+            printf '%s' "$val" | tr -d "'\"\n" > "$_tokens_dir/agent-$_n.token"
+            chmod 600 "$_tokens_dir/agent-$_n.token" 2>/dev/null || true
+        done < <(grep '^ACCOUNT_KEY_[0-9]\+=' "$_src")
+        return 0
+    }
     if [[ ! -d "$_tokens_dir" ]] || ! ls "$_tokens_dir"/*.token &>/dev/null 2>&1; then
         _env_file="$_repo_root/.env"
-        if [[ -f "$_env_file" ]] && grep -q '^ACCOUNT_KEY_[0-9]\+=' "$_env_file" 2>/dev/null; then
+        # Only rebuild the dir if at least one source has accounts.
+        if { [[ -f "$_home_accts" ]] && grep -q '^ACCOUNT_KEY_[0-9]\+=' "$_home_accts" 2>/dev/null; } \
+           || { [[ -f "$_env_file" ]] && grep -q '^ACCOUNT_KEY_[0-9]\+=' "$_env_file" 2>/dev/null; }; then
             # Replace whatever is at $_tokens_dir (broken symlink, etc) with a real dir.
             rm -f "$_tokens_dir" 2>/dev/null || true
             mkdir -p "$_tokens_dir" 2>/dev/null || true
-            while IFS='=' read -r key val; do
-                _n="${key#ACCOUNT_KEY_}"
-                [[ "$_n" =~ ^[0-9]+$ ]] || continue
-                printf '%s' "$val" | tr -d "'\"\n" > "$_tokens_dir/agent-$_n.token"
-                chmod 600 "$_tokens_dir/agent-$_n.token" 2>/dev/null || true
-            done < <(grep '^ACCOUNT_KEY_[0-9]\+=' "$_env_file")
-            echo "[wrapper] Bootstrapped $(ls "$_tokens_dir"/*.token 2>/dev/null | wc -l | tr -d ' ') OAuth tokens from .env" >&2
+            _home_n=0; _repo_n=0
+            _materialize_accounts "$_home_accts" && _home_n=$(grep -c '^ACCOUNT_KEY_[0-9]\+=' "$_home_accts" 2>/dev/null)
+            # Repo .env applied SECOND so its indices override the home layer.
+            _materialize_accounts "$_env_file" && _repo_n=$(grep -c '^ACCOUNT_KEY_[0-9]\+=' "$_env_file" 2>/dev/null)
+            echo "[wrapper] Bootstrapped $(ls "$_tokens_dir"/*.token 2>/dev/null | wc -l | tr -d ' ') OAuth tokens (home:$_home_n + repo:$_repo_n, repo overrides by index)" >&2
         fi
     fi
 


### PR DESCRIPTION
Centralizes the multi-account OAuth pool in a **universal home-directory file** so it's shared across repos on this host, instead of being duplicated in each repo's `.env`.

## Behavior
The token-pool bootstrap in `scripts/agents/claude-wrapper.sh` now materializes accounts from two **layered** sources, in precedence order:

1. **`~/.claude/accounts.env`** — the universal home pool (base layer, shared across repos).
2. **`$REPO_ROOT/.env`** — this repo's local accounts, which **override** a home account at the same index `N` and **add** new indices (top layer).

Layering is by positional index `N` (the existing `agent-N.token` scheme, unchanged). Repo `.env` is applied second, so its indices win. Absent either file, the other still works; absent both, it falls through to the single-token `.env` path. Path overridable via `LOOM_ACCOUNTS_FILE`.

Downstream ranking / allowlist / selection logic is **untouched**.

## Verification
- Layering unit test: home{1,2,3} + repo{2-override,4-add} → agent-1=home1, agent-2=repo-override, agent-3=home3, agent-4=repo-add ✓
- **Lossless migration:** materializing from `~/.claude/accounts.env` reconstitutes all 13 live pool tokens **byte-identical** (sha match, 0 mismatches) ✓
- `bash -n` clean.

## Operator steps (outside this PR, host-local)
- `~/.claude/accounts.env` created (13 accounts, `chmod 600`, never committed) — done.
- After merge: strip `ACCOUNT_KEY_*`/`ACCOUNT_EMAIL_*`/`ACCOUNT_TOKEN_FILE_*` from `lean-genius/.env` so home is the single source (the live fleet is unaffected — `.loom/tokens/` is already materialized, and re-bootstrap now reads home).

## Notes
- `claude-wrapper.sh` is lean-genius-local, so this repo benefits immediately; other repos need the same bootstrap tweak (or a shared sourced snippet) — a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)