### PR TITLE
Research: erdos-326-wip-01 — two-subsequence criterion for HasNoGrowthLimit

### DIFF
--- a/proofs/Proofs/Erdos326WIP01.lean
+++ b/proofs/Proofs/Erdos326WIP01.lean
@@ -27,6 +27,10 @@ ratio and its limit:
   (the `growthRatio` restatement of the `bₖ = O(k²)` bound);
 * the growth limit is unique, and existence of a limit contradicts
   `HasNoGrowthLimit`;
+* a **two-subsequence criterion** for non-convergence
+  (`hasNoGrowthLimit_of_two_subseq_limits`): two strictly-monotone index
+  subsequences along which the growth ratio tends to distinct limits force
+  `HasNoGrowthLimit` — the reusable engine behind the oscillation direction;
 * both growth-limit predicates are non-vacuous: an exactly-quadratic
   enumeration `bₖ = c·k²` has growth limit `c`, while an enumeration whose
   quadratic coefficient oscillates between `1` and `2` has **no** growth limit.
@@ -149,6 +153,33 @@ theorem hasNoGrowthLimit_iff (b : ℕ → ℕ) :
     HasNoGrowthLimit b ↔ ¬ ∃ x, HasGrowthLimit b x := by
   unfold HasNoGrowthLimit
   rw [not_exists]
+
+/-! ## A two-subsequence criterion for non-convergence
+
+The standard route to `HasNoGrowthLimit` is to exhibit two subsequences of the
+growth ratio converging to **different** limits: since a convergent sequence has
+*every* subsequence converging to the same limit, two distinct subsequential
+limits preclude convergence.  This is exactly the mechanism behind the oscillating
+toy example below (`growthRatio_oscillating_odd`/`_even` give subsequential limits
+`2` and `1`), and it is the reusable tool the open oscillation direction of #326
+(building a sub-basis whose ratio does not converge) must ultimately consume. -/
+
+/-- **Two-subsequence criterion for `HasNoGrowthLimit`.**  If the growth ratio
+restricted to two subsequences `φ, ψ` (strictly monotone index maps, hence cofinal)
+converges to distinct limits `L ≠ L'`, then `b` has no growth limit.  A growth limit
+`x` would force *both* subsequences to converge to `x` (a subsequence of a convergent
+sequence shares its limit), giving `L = x = L'`. -/
+theorem hasNoGrowthLimit_of_two_subseq_limits {b : ℕ → ℕ} {φ ψ : ℕ → ℕ} {L L' : ℝ}
+    (hφ : StrictMono φ) (hψ : StrictMono ψ)
+    (hL : Tendsto (fun k => growthRatio b (φ k)) atTop (𝓝 L))
+    (hL' : Tendsto (fun k => growthRatio b (ψ k)) atTop (𝓝 L'))
+    (hLL' : L ≠ L') : HasNoGrowthLimit b := by
+  intro x hx
+  have e1 : Tendsto (fun k => growthRatio b (φ k)) atTop (𝓝 x) :=
+    hx.comp hφ.tendsto_atTop
+  have e2 : Tendsto (fun k => growthRatio b (ψ k)) atTop (𝓝 x) :=
+    hx.comp hψ.tendsto_atTop
+  exact hLL' ((tendsto_nhds_unique e1 hL).symm.trans (tendsto_nhds_unique e2 hL'))
 
 /-! ## Bounded-order bases are infinite -/
 

--- a/research/problems/erdos-326-wip-01/knowledge.md
+++ b/research/problems/erdos-326-wip-01/knowledge.md
@@ -1,5 +1,30 @@
 # Knowledge Base: erdos-326-wip-01
 
+## Session 2026-07-21 (researcher-1) — two-subsequence non-convergence criterion
+
+Added `hasNoGrowthLimit_of_two_subseq_limits` to `Erdos326WIP01.lean` (1 thm, 0 ax,
+0 sorry, host-verified v4.31.0 fresh-parent-olean; `#print axioms` =
+propext/Classical.choice/Quot.sound). The **reusable engine** for the OPEN oscillation
+direction of #326: if the growth ratio along two strictly-monotone index subsequences
+`φ, ψ` tends to distinct limits `L ≠ L'`, then `HasNoGrowthLimit b`.
+
+- Proof: a growth limit `x` forces both subsequences to `x`
+  (`hx.comp hφ.tendsto_atTop` — a subsequence of a convergent sequence shares its limit,
+  `StrictMono.tendsto_atTop` cofinality), so `tendsto_nhds_unique` gives `L = x = L'`,
+  contradicting `hLL'`.
+- This generalizes the ad-hoc `hasNoGrowthLimit_oscillating` (whose odd/even subsequences
+  hit `2` and `1`); any future sub-basis construction proving non-convergence consumes it.
+
+### Idioms
+- Subsequence-shares-limit: `hx.comp hφ.tendsto_atTop` where `hφ : StrictMono φ`
+  (`StrictMono.tendsto_atTop : Tendsto φ atTop atTop` for `φ : ℕ → ℕ`).
+- `tendsto_nhds_unique e1 e2 : x = y` (ℝ is T2, `atTop` NeBot).
+
+### Remaining open (unchanged)
+- Constructing, for an arbitrary order-2 basis `A`, a sub-basis `B ⊆ A` whose ratio
+  oscillates (two subsequential limits) — the deep OPEN core of #326. The criterion above
+  is the final step of any such construction; the construction itself is the hard part.
+
 ## Session 2026-07-21 (researcher-1) — `bₖ = O(k²)` as `growthRatio` boundedness (bridge)
 
 Closed the standing "bridge `bₖ=O(k²)` to `growthRatio` boundedness" open item. Added

--- a/src/data/research/problems/erdos-326-wip-01.json
+++ b/src/data/research/problems/erdos-326-wip-01.json
@@ -61,7 +61,8 @@
       "oscillating (def) + growthRatio_oscillating_odd/even — explicit sequence with ratio 2 on odds, 1 on evens",
       "hasNoGrowthLimit_oscillating — HasNoGrowthLimit is non-vacuous: oscillating sequence has no growth limit",
       "IsAddBasisOfOrder.two_nth_le_quadratic + two_nth_le_mul_sq in Erdos326WIP01.lean: order-2 basis enumeration b_k=Nat.nth(.∈A) satisfies b_k ≤ N+(k+1)^2 and b_k ≤ (N+4)k^2 (k≥1). 0 axioms (propext/Classical.choice/Quot.sound), host-verified v4.31.0",
-      "IsAddBasisOfOrder.two_growthRatio_le / two_growthRatio_mem_Icc / two_growthRatio_bddAbove in Erdos326WIP01.lean (axiom-free, host-verified v4.31.0)"
+      "IsAddBasisOfOrder.two_growthRatio_le / two_growthRatio_mem_Icc / two_growthRatio_bddAbove in Erdos326WIP01.lean (axiom-free, host-verified v4.31.0)",
+      "hasNoGrowthLimit_of_two_subseq_limits in Erdos326WIP01.lean: two-subsequence non-convergence criterion, 0-axiom host-verified v4.31"
     ],
     "insights": [
       "The basis predicates form a monotone lattice: raising the order or enlarging the set preserves the basis property — the atomic order theory underlying any basis-comparison argument.",
@@ -74,7 +75,8 @@
       "Non-convergence is realized elementarily by oscillating the quadratic coefficient between 1 and 2; the odd/even index maps both tend to atTop so any limit would be forced to equal both 2 and 1 (tendsto_nhds_unique twice).",
       "Idiom: ∀ᶠ equality must be typed as f =ᶠ[l] g (EventuallyEq) for .symm/.congr' dot notation to resolve; the bare ∀ᶠ (Eventually) head symbol blocks it.",
       "The b_k = O(k^2) growth upper bound for order-2 bases is now machine-checked axiom-free (two_nth_le_quadratic: Nat.nth (.∈A) k ≤ N + (k+1)^2; two_nth_le_mul_sq: ≤ (N+4)·k^2 for k≥1). This is the standard consequence of the √n density bound (Key Observation 1): with n = N+(k+1)^2 the density (n+1-N ≤ (|S|+1)^2) forces k < |S| ≤ count(.∈A)(n+1), so Nat.nth (.∈A) k < n+1 via Nat.nth_lt_of_lt_count. No deep input; the oscillation dichotomy stays open.",
-      "growthRatio bₖ/k² of an order-2 basis enumeration (Nat.nth) is bounded above: eventually ≤ C (two_growthRatio_le), eventually in [0,C] (two_growthRatio_mem_Icc), and its full range is BddAbove (two_growthRatio_bddAbove) — the growthRatio restatement of bₖ=O(k²). First results connecting growthRatio to the real basis enumeration rather than toy sequences."
+      "growthRatio bₖ/k² of an order-2 basis enumeration (Nat.nth) is bounded above: eventually ≤ C (two_growthRatio_le), eventually in [0,C] (two_growthRatio_mem_Icc), and its full range is BddAbove (two_growthRatio_bddAbove) — the growthRatio restatement of bₖ=O(k²). First results connecting growthRatio to the real basis enumeration rather than toy sequences.",
+      "hasNoGrowthLimit_of_two_subseq_limits: two strictly-monotone index subsequences of growthRatio with distinct limits ⇒ HasNoGrowthLimit. Reusable engine for the OPEN oscillation direction of #326; generalizes the ad-hoc oscillating example. Idiom: hx.comp hφ.tendsto_atTop (subsequence shares limit) + tendsto_nhds_unique."
     ],
     "mathlibGaps": [
       "No packaged bₖ = O(k²) bound for order-2 additive bases; would need a density-counting argument (|A ∩ [0,n]| ≥ c√n) not currently in Mathlib."


### PR DESCRIPTION
## Summary
Research session for `erdos-326-wip-01` (Erdős #326: order-2 additive bases and non-convergent `bₖ/k²`). Adds the reusable **two-subsequence criterion** for `HasNoGrowthLimit` — the mechanism any proof of the open oscillation direction must ultimately use.

## Progress (0 sorry / 0 axiom, host-verified v4.31)
- **`hasNoGrowthLimit_of_two_subseq_limits`** — if the growth ratio `growthRatio b` restricted to two strictly-monotone index subsequences `φ, ψ` converges to **distinct** limits `L ≠ L'`, then `HasNoGrowthLimit b`. Proof: a growth limit `x` would force both subsequences to converge to `x` (`hx.comp hφ.tendsto_atTop` — a subsequence of a convergent sequence shares its limit, using `StrictMono.tendsto_atTop` cofinality), so `tendsto_nhds_unique` gives `L = x = L'`, contradicting `L ≠ L'`.

## Findings
- This generalizes the file's ad-hoc `hasNoGrowthLimit_oscillating` (whose odd/even subsequences hit `2` and `1`): the criterion recovers it and every future sub-basis non-convergence construction consumes it as its final step.
- The remaining OPEN core of #326 — constructing, for an arbitrary order-2 basis `A`, a sub-basis `B ⊆ A` whose ratio has two subsequential limits — is unchanged and deep; this lemma is the terminal step of any such construction, not the construction itself.

## Verification
`lake env lean Proofs/Erdos326WIP01.lean` exit 0, 0 warnings; `#print axioms hasNoGrowthLimit_of_two_subseq_limits` = `[propext, Classical.choice, Quot.sound]`.

## Status
**Outcome**: progress — reusable non-convergence criterion for the oscillation direction.
**Next Steps**: the sub-basis oscillation construction (deep, open).

🤖 Generated by researcher-1