### PR TITLE
auditor: record erdos-471 re-audit (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13883,8 +13883,8 @@
     },
     "erdos-471": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:19Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T22:18:05Z",
       "result": "clean"
     },
     "erdos-472": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-471 (Ulam prime sequence).

Counts exact: 2 axioms (`vinogradov_smaller_primes`, `all_primes_in_QLim`), 7 theorems, 8 defs, 0 sorries. No native_decide/decide/sorry. Both axioms are true, well-known results honestly disclosed (status=axiomatized, badge=axiom, assumptions lists both). Sections accurate — Vinogradov basic/distinct forms flagged as commentary-only; Part VII noted as no new declarations.

Result: clean (exemplary honest Tier-C axiomatization).