### PR TITLE
auditor: record erdos-473 re-audit (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13895,8 +13895,8 @@
     },
     "erdos-473": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:19Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T22:19:36Z",
       "result": "clean"
     },
     "erdos-474": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-473 (prime sum permutations, Odlyzko).

Counts exact: 5 axioms, 2 theorems, 8 defs, 0 sorries. No native_decide/sorry. Axioms jointly consistent and disclosed (status=axiomatized, badge=axiom).

LOW nit (not blocking): origContrib 'greedySeq axiomatization with initial condition and recurrence' — greedySeq is an opaque `axiom greedySeq : ℕ → ℕ`; the a₁=1 initial condition and min-recurrence appear only in comment blocks, not in any axiom. Not a proof-strength overclaim.

Result: clean.