### PR TITLE
auditor: record erdos-472 re-audit (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13889,8 +13889,8 @@
     },
     "erdos-472": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:19Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T22:25:26Z",
       "result": "clean"
     },
     "erdos-473": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-472 (Ulam Prime Sequences).

## Verification
All meta.json counts match `Proofs/Erdos472Problem.lean` exactly:
- **0 sorries** ✓
- **1 axiom**: `ulam35_contains_all_odd_primes_conjecture` (matches `assumptions`) ✓
- **30 theorems**, **8 defs**, **327 lines** ✓
- **8 native_decide** uses — all disclosed in proofStrategy + keyInsights ✓

## Integrity
- Status `axiomatized` / badge `axiom` — correct Tier C. Main conjecture `ErdosProblem472` is defined but not proved; the sole axiom is the positively-stated open conjecture (honest, not a false/inconsistent negation).
- Conclusion states the problem "remains open." No overclaiming.
- All section- and origContrib-named declarations exist in the file.

Result: **clean**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)