### PR TITLE
Research: erdos-510-wip-01 — θ=π alternating bound + sharp all-odd Chowla minimum

### DIFF
--- a/proofs/Proofs/Erdos510WIP01.lean
+++ b/proofs/Proofs/Erdos510WIP01.lean
@@ -21,7 +21,10 @@ infimum is fully provable from Mathlib.  This file establishes:
 * continuity of `θ ↦ cosineSum A θ`;
 * boundedness-below of the range, hence the basic `minCosineSum` bounds
   `−N ≤ minCosineSum A ≤ N` and `minCosineSum A ≤ cosineSum A θ`;
-* the exact value `minCosineSum {n} = −1` for `n ≥ 1`.
+* the exact value `minCosineSum {n} = −1` for `n ≥ 1`;
+* the alternating-sum bound `minCosineSum A ≤ ∑_{n ∈ A} (−1)ⁿ` (evaluation at
+  `θ = π`), and the **sharp** all-odd case `minCosineSum A = −A.card` when every
+  `n ∈ A` is odd — an explicit infinite family attaining the extreme `−N`.
 
 All results are `0`-axiom / `0`-sorry.  The genuinely open content — the
 `−c√N` lower bound — is untouched (it is the mission, not the scaffolding).
@@ -437,5 +440,31 @@ theorem minCosineSum_le_neg_half (A : Finset ℕ) (hA : 0 ∉ A) (hne : A.Nonemp
   rw [hcompute] at hnonneg
   have hpi : 0 < π := Real.pi_pos
   nlinarith [hnonneg, mul_pos hpi hNpos]
+
+/-! ## Evaluation at `θ = π`: the alternating-sum bound and the all-odd sharp case -/
+
+/-- **The minimum is bounded by the alternating sum.**  Evaluating at `θ = π`
+(`cosineSum_pi`) and using that `minCosineSum` is a pointwise lower bound gives
+`minCosineSum A ≤ ∑_{n ∈ A} (−1)ⁿ = #{even ∈ A} − #{odd ∈ A}` — a computable upper bound on the
+Chowla minimum for any frequency set, negative exactly when `A` has more odd than even
+elements. -/
+theorem minCosineSum_le_alternating (A : Finset ℕ) :
+    minCosineSum A ≤ ∑ n ∈ A, (-1 : ℝ) ^ n := by
+  have h := minCosineSum_le A π
+  rwa [cosineSum_pi] at h
+
+/-- **Sharp minimum for all-odd frequency sets.**  If every element of `A` is odd then each
+`cos(nπ) = −1`, so `cosineSum A π = −N`, which already meets the global lower bound
+`−N ≤ minCosineSum A`.  Hence `minCosineSum A = −A.card`: the all-odd sets are an explicit
+infinite family whose Chowla cosine sum attains the extreme value `−N` (far beyond the
+conjectured `−c√N`, but exactly), sharpening the singleton case `minCosineSum {n} = −1`. -/
+theorem minCosineSum_forall_odd (A : Finset ℕ) (hodd : ∀ n ∈ A, Odd n) :
+    minCosineSum A = -A.card := by
+  refine le_antisymm ?_ (neg_card_le_minCosineSum A)
+  have hsum : (∑ n ∈ A, (-1 : ℝ) ^ n) = -A.card := by
+    have hterm : ∀ n ∈ A, (-1 : ℝ) ^ n = -1 := fun n hn => (hodd n hn).neg_one_pow
+    rw [Finset.sum_congr rfl hterm, Finset.sum_const, nsmul_eq_mul, mul_neg_one]
+  have h := minCosineSum_le_alternating A
+  rwa [hsum] at h
 
 end Erdos510WIP01

--- a/research/problems/erdos-510-wip-01/knowledge.md
+++ b/research/problems/erdos-510-wip-01/knowledge.md
@@ -1,5 +1,25 @@
 # Knowledge Base: erdos-510-wip-01
 
+## Session 2026-07-21 (researcher-1) — θ=π alternating bound + sharp all-odd minimum
+
+Added 2 axiom-free theorems to `Erdos510WIP01.lean` (host-verified v4.31 fresh-parent-olean;
+`#print axioms` = propext/Classical.choice/Quot.sound):
+- `minCosineSum_le_alternating (A) : minCosineSum A ≤ ∑_{n∈A} (−1)ⁿ` — evaluate at θ=π
+  (`cosineSum_pi` already on file) + `minCosineSum_le`. Computable upper bound on the Chowla
+  minimum for any A (= #even − #odd), negative when A is odd-heavy.
+- `minCosineSum_forall_odd (A) (∀ n∈A, Odd n) : minCosineSum A = −A.card` — **sharp**. For
+  all-odd A each cos(nπ)=−1 so cosineSum A π = −N, meeting the global lower bound
+  `neg_card_le_minCosineSum`; `le_antisymm`. An explicit infinite family attaining the extreme
+  −N (≪ the conjectured −c√N, but exact), generalizing `minCosineSum {n} = −1`.
+
+Idiom: `(hodd n hn).neg_one_pow : (-1:ℝ)^n = -1`; then `Finset.sum_congr rfl · , sum_const,
+nsmul_eq_mul, mul_neg_one`.
+
+### Remaining open (unchanged)
+- Sharp `−c√N` bound (Bourgain/Ruzsa/Bedert) — deep imported, the genuine open mission.
+  Elementary sign structure + attainment (incl. the sharp all-odd extreme) is now complete.
+
+
 ## Session 2026-07-20 (researcher-1) — strict minCosineSum < 0 for nonempty positive-frequency sets
 
 **Mode**: build on the nonpositivity result. **Outcome**: progress — 2 axiom-free theorems,

--- a/src/data/research/problems/erdos-510-wip-01.json
+++ b/src/data/research/problems/erdos-510-wip-01.json
@@ -60,7 +60,8 @@
       "integral_cos_int_mul_eq_zero (Erdos510WIP01.lean): ℤ-frequency cos period integral = 0",
       "integral_cos_mul_cos (Erdos510WIP01.lean): orthogonality ∫cos(nθ)cos(mθ)=π·[n=m]",
       "integral_cosineSum_sq (Erdos510WIP01.lean): second moment ∫(cosineSum A)²=π·|A|",
-      "minCosineSum_le_neg_half (Erdos510WIP01.lean): minCosineSum A ≤ −1/2, all axiom-free"
+      "minCosineSum_le_neg_half (Erdos510WIP01.lean): minCosineSum A ≤ −1/2, all axiom-free",
+      "minCosineSum_le_alternating + minCosineSum_forall_odd in Erdos510WIP01.lean, 0-axiom host-verified v4.31"
     ],
     "insights": [
       "The trivial range of the cosine sum is [−N, N]; the conjectured extremal value −c√N sits strictly inside, so all elementary bounds are far from the truth — the content is entirely in the cancellation.",
@@ -71,7 +72,8 @@
       "Integral technique: intervalIntegral.integral_comp_mul_left (c!=0) reduces cos(n*theta) to n-inverse-scaled integral_cos = sin(n*2pi)-sin 0 = 0 (via Real.sin_nat_mul_pi with n*2pi = (2n)*pi); intervalIntegral.integral_finsetSum swaps finite sum and integral (each term Continuous.intervalIntegrable); intervalIntegral.integral_mono_on hab hf hg h + integral_const gives (2pi)*c bound; nlinarith [Real.two_pi_pos]. NOTE: needs imports Analysis.SpecialFunctions.Integrals.Basic + MeasureTheory.Integral.IntervalIntegral.Basic (the file did NOT import Mathlib fully).",
       "Second-moment/L² averaging gives a UNIFORM QUANTITATIVE bound minCosineSum A ≤ −1/2 for every nonempty positive-frequency A (minCosineSum_le_neg_half). Mechanism: first moment ∫₀^{2π}cosineSum=0 and second moment ∫₀^{2π}(cosineSum)²=π·N (integral_cosineSum_sq), plus the pointwise sandwich m≤f≤N, give ∫(f−m)(N−f)≥0 ⟹ −πN−2πmN≥0 ⟹ m≤−1/2. A fixed constant, materially DISTINCT from the still-open −c√N growth route.",
       "Orthogonality of cosine characters over a full period proved from scratch (integral_cos_mul_cos): ∫₀^{2π}cos(nθ)cos(mθ)=π·[n=m] for n,m≥1, via product-to-sum cos(nθ)cos(mθ)=½(cos((n+m)θ)+cos((n−m)θ)) and the ℤ-frequency period-integral vanishing integral_cos_int_mul_eq_zero.",
-      "Lean gotchas hit: (1) integral_congr+integral_div on a big integrand triggers a whnf timeout — rewrite the integrand as a funext function-equality then split with integral_add/integral_const_mul instead; (2) applying integral_cos_int_mul_eq_zero _ with a metavar k plus sub_ne_zero.mpr loops isDefEq — pin k=(n:ℤ)−(m:ℤ) explicitly; (3) (((n:ℤ)−(m:ℤ)):ℝ) elaborates to ↑↑n−↑↑m (difference of casts) not ↑(↑n−↑m) — normalize with Int.cast_sub/Int.cast_natCast."
+      "Lean gotchas hit: (1) integral_congr+integral_div on a big integrand triggers a whnf timeout — rewrite the integrand as a funext function-equality then split with integral_add/integral_const_mul instead; (2) applying integral_cos_int_mul_eq_zero _ with a metavar k plus sub_ne_zero.mpr loops isDefEq — pin k=(n:ℤ)−(m:ℤ) explicitly; (3) (((n:ℤ)−(m:ℤ)):ℝ) elaborates to ↑↑n−↑↑m (difference of casts) not ↑(↑n−↑m) — normalize with Int.cast_sub/Int.cast_natCast.",
+      "minCosineSum_forall_odd: all-odd frequency sets attain the extreme Chowla minimum minCosineSum A = −A.card (sharp; cos(nπ)=−1 for odd n meets neg_card lower bound). Plus minCosineSum_le_alternating: minCosineSum A ≤ ∑(−1)ⁿ = #even−#odd."
     ],
     "mathlibGaps": [
       "No direct reduction of an ℝ-infimum of a periodic continuous function to a min over a fundamental period; needs a toIcoMod-style mod-2π reduction to formalize attainment."


### PR DESCRIPTION
## Summary
Research session for `erdos-510-wip-01` (Chowla's cosine problem — the minimum of `cosineSum A θ = ∑_{n∈A} cos(nθ)`). Adds the evaluation-at-`θ=π` upper bound and a **sharp** exact-value result for all-odd frequency sets.

## Progress (0 sorry / 0 axiom, host-verified v4.31)
- **`minCosineSum_le_alternating`** — `minCosineSum A ≤ ∑_{n∈A} (−1)ⁿ` (= `#even(A) − #odd(A)`). Immediate from the existing `cosineSum_pi` evaluation plus the pointwise-lower-bound `minCosineSum_le`. A computable upper bound on the Chowla minimum for any `A`, negative exactly when `A` is odd-heavy.
- **`minCosineSum_forall_odd`** — if every `n ∈ A` is odd then `minCosineSum A = −A.card`. Each `cos(nπ) = −1`, so `cosineSum A π = −N`, meeting the global lower bound `−N ≤ minCosineSum A` (`neg_card_le_minCosineSum`); `le_antisymm` closes it. **Sharp**: the all-odd sets are an explicit infinite family attaining the extreme value `−N` (far beyond the conjectured `−c√N`, but exact), generalizing the singleton `minCosineSum {n} = −1`.

## Findings
- The elementary sign structure (`≤ 0`, strict `< 0`, attainment, `≤ −1/2`) plus this sharp all-odd attainment now fully cover the elementary layer; the genuine open content — the `−c√N` lower bound (Bourgain/Ruzsa/Bedert) — remains a deep imported result.

## Verification
`lake env lean Proofs/Erdos510WIP01.lean` exit 0; `#print axioms` on both new theorems = `[propext, Classical.choice, Quot.sound]`.

## Status
**Outcome**: progress — sharp all-odd minimum + alternating-sum bound.
**Next Steps**: the quantitative `−c√N` bound remains the deep open mission.

🤖 Generated by researcher-1