### PR TITLE
auditor: fix erdos-467 Mertens overclaim in assumptions

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13851,9 +13851,9 @@
     },
     "erdos-467": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:20Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T22:27:18Z",
+      "result": "issues-fixed"
     },
     "erdos-468": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-467/meta.json
+++ b/src/data/proofs/erdos-467/meta.json
@@ -53,7 +53,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 277,
-    "assumptions": "1 axiom: erdos_467_conjecture (the main open conjecture). CRT and Mertens estimate now fully proved.",
+    "assumptions": "1 axiom: erdos_467_conjecture (the main open conjecture). CRT for distinct primes is fully proved (via Mathlib's Nat.chineseRemainder); the Mertens result (mertens_product) is only a trivial placeholder (its conclusion asserts merely x > 0 for large x) and does not formalize the actual estimate.",
     "mathlib_version": "4.31.0",
     "theoremCount": 25,
     "definitionCount": 7


### PR DESCRIPTION
Reserve-mode audit of erdos-467 (Dual Covering by Prime Residue Classes).

## Issue found & fixed (LOW severity narrative overclaim)
The `assumptions` field read:
> 1 axiom: erdos_467_conjecture (the main open conjecture). CRT and **Mertens estimate now fully proved.**

But `mertens_product` in the Lean source is a self-admitted trivial placeholder — its own docstring says *"The formal conclusion here is trivially true (it only asserts x > 0 for large x). A proper Mertens estimate would require formalizing the Euler product over primes."* The theorem's conclusion is `∃ c > 0, ∀ ε > 0, ∃ X, ∀ x ≥ X, (x:ℝ) > 0` — vacuous.

The rest of the meta (keyInsights, sections `crt-mertens`) already described it honestly as a *vacuous placeholder*; only `assumptions` overclaimed it as a proved estimate. Reworded to match the source.

## Counts verified exact
- 1 axiom (`erdos_467_conjecture`, the open conjecture) ✓
- 0 sorries ✓
- 25 theorems, 6 defs + 1 structure (defCount 7), 277 lines ✓
- 0 native_decide ✓
- Status `axiomatized` / badge `axiom` correct (open problem; only the conjecture axiomatized, CRT genuinely proved via Mathlib).

Result: **issues-fixed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)