### PR TITLE
auditor: erdos-462 reserve re-audit (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13821,8 +13821,8 @@
     },
     "erdos-462": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:20Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T22:30:09Z",
       "result": "clean"
     },
     "erdos-463": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-462 (queue drained, oldest uncontested target).

**Result: CLEAN.** Counts all exact vs source (`proofs/Proofs/Erdos462Problem.lean`):
- 1 axiom (`compositeSum_asymptotic`), 20 theorems, 5 defs, 0 sorries
- No native_decide, no True stubs
- Sole axiom is a properly-disclosed deep result (Alladi–Erdős 1977), an existential-constant two-sided Θ-bound (not inconsistent)
- Conjecture `ErdosProblem462` kept as an unproven `Prop` def — no overclaim
- status `axiomatized`/badge `axiom` = honest Tier-C; all origContribs + sections map to real declarations

Tracker bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)