### PR TITLE
auditor: erdos-460 reserve re-audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13809,8 +13809,8 @@
     },
     "erdos-460": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:20Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T22:42:17Z",
       "result": "clean"
     },
     "erdos-461": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-460 (Greedy Coprime Sieve Reciprocals).

**Result: clean.** Counts exact and narrative honest.

- axiomCount 1 ✓ (`eggleton_erdos_selfridge`, a_k < k^{2+ε} — genuine disclosed upper bound, no conflicting lower bound so no inconsistency)
- sorries 1 ✓ (`filtered_sum_implies_full`, line 243; other "sorry" hits are comments)
- theoremCount 21 ✓, definitionCount 9 ✓, lineCount 462 ✓, no native_decide
- All 26 declarations named in originalContributions/sections/proofStrategy exist in source (phantom-decl check for the 45x/46x cluster — this file is per-file pristine)
- Headline `ErdosProblem460` is a `Prop` def (open question, not falsely proved); status/badge honestly `axiomatized/axiom`

🤖 Generated with [Claude Code](https://claude.com/claude-code)