### PR TITLE
Fix: tighten erdos-459 f_lower_bound to u ≥ 2 (remove inconsistent axiom)

### DIFF
--- a/proofs/Proofs/Erdos459Problem.lean
+++ b/proofs/Proofs/Erdos459Problem.lean
@@ -116,9 +116,11 @@ noncomputable def f_alt (u : ℕ) : ℕ :=
 ## Part III: Trivial Bounds
 -/
 
-/-- Lower bound: f(u) ≥ u + 2 for u ≥ 1.
-    Reason: u + 1 has a prime factor not dividing u (namely, a prime factor of u + 1). -/
-axiom f_lower_bound (u : ℕ) (hu : u ≥ 1) : f u ≥ u + 2
+/-- Lower bound: f(u) ≥ u + 2 for u ≥ 2.
+    Reason: u + 1 has a prime factor not dividing u (namely, a prime factor of u + 1).
+    (Requires `u ≥ 2`: `f` uses a junk value at `u = 1`, where `f 1 = 1 < 3`, so the
+    bound is only mathematically meaningful — and consistent — for `u ≥ 2`.) -/
+axiom f_lower_bound (u : ℕ) (hu : u ≥ 2) : f u ≥ u + 2
 
 /-- Upper bound: f(u) ≤ u² for u ≥ 2.
     Reason: u² has the same prime factors as u. -/
@@ -126,7 +128,7 @@ axiom f_upper_bound (u : ℕ) (hu : u ≥ 2) : f u ≤ u * u
 
 /-- The trivial bounds: u + 2 ≤ f(u) ≤ u² for u ≥ 2. -/
 theorem trivial_bounds (u : ℕ) (hu : u ≥ 2) : u + 2 ≤ f u ∧ f u ≤ u * u :=
-  ⟨f_lower_bound u (le_trans (by norm_num) hu), f_upper_bound u hu⟩
+  ⟨f_lower_bound u hu, f_upper_bound u hu⟩
 
 /-
 ## Part IV: Special Cases (Cambie)


### PR DESCRIPTION
## Fix: erdos-459 inconsistent axiom `f_lower_bound`

The auditor (#41005) found that `axiom f_lower_bound (u : ℕ) (hu : u ≥ 1) : f u ≥ u + 2`
was **logically inconsistent** with the concrete definition of `f`, which uses a junk
value `f 1 = 1` at `u = 1`. At `u = 1` the axiom asserts `f 1 ≥ 3` while `f 1 = 1`,
so `boom : False` was derivable in the kernel — every downstream result rested on an
unsound axiom base.

### Change (minimal, per auditor recommendation)

- Tighten the hypothesis to `u ≥ 2` so the axiom never touches the `u = 1` junk branch:
  ```lean
  axiom f_lower_bound (u : ℕ) (hu : u ≥ 2) : f u ≥ u + 2
  ```
- Simplify the sole caller `trivial_bounds` (already requires `u ≥ 2`):
  ```lean
  ⟨f_lower_bound u hu, f_upper_bound u hu⟩   -- was: f_lower_bound u (le_trans (by norm_num) hu)
  ```

`f_lower_bound` is used in exactly two places (its declaration and `trivial_bounds`),
and `trivial_bounds` already carries `u ≥ 2`, so no mathematical content is lost — the
lower bound is only meaningful for `u ≥ 2` since `f(1)` is a junk value. The other bound
axioms (`f_upper_bound`, `f_prime`, `f_minimal_case`) already avoid the `u = 1` branch.

### Validation

`./proofs/scripts/docker-build.sh Proofs.Erdos459Problem` → **Build succeeded** (8576 jobs).

Counts unchanged (6 axioms, 9 theorems, 6 defs, 0 sorries); `axiomatized` status/`axiom`
badge remain accurate. Metadata needs no change.

Closes #41005
