### PR TITLE
Audit erdos-457: phantom axioms in narrative (issue #41009)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13785,9 +13785,9 @@
     },
     "erdos-457": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:43Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T22:54:26Z",
+      "result": "issues-found"
     },
     "erdos-458": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Records reserve re-audit of erdos-457. Counts all honest (2 axioms, 2 theorems, 6 defs, 0 sorries); filed #41009 for ~8 phantom axiom names in sections[]/originalContributions[] that don't exist in the Lean file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)