### PR TITLE
Audit erdos-458: clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13791,8 +13791,8 @@
     },
     "erdos-458": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:43Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T22:56:47Z",
       "result": "clean"
     },
     "erdos-459": {


### PR DESCRIPTION
Reserve re-audit of erdos-458 (LCM Inequality for Primes). CLEAN: exemplary disclosure — assumptions field documents native_decide/ofReduceBool on 7 credited theorems, distinguishes kernel decide from native_decide, conjecture is a bare def (open, not proved/axiomatized). Counts all match (21 thm, 4 def, 0 sorry, axiomCount=1). No phantom decls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)