### PR TITLE
Fix: erdos-457 remove phantom axioms from meta prose

### DIFF
--- a/src/data/proofs/erdos-457/meta.json
+++ b/src/data/proofs/erdos-457/meta.json
@@ -57,10 +57,10 @@
     ],
     "originalContributions": [
       "consecutiveProduct definition: ∏(n+i) for i in [1,k]",
-      "consecutiveProduct_pos axiom: positivity of consecutive products",
+      "consecutiveProduct_pos theorem: positivity of consecutive products (proved)",
       "small_primes_divide axiom: primes ≤ k divide k consecutive integers",
-      "q definition: smallest prime not dividing the consecutive product",
-      "q_prime, q_not_dvd, q_minimal axioms: properties of q(n,k)",
+      "q definition: smallest prime not dividing the consecutive product, via Nat.find with an inline existence proof",
+      "erdos_457 axiom: the main conjecture, axiomatized as open",
       "ErdosConjecture457 definition: main conjecture with Set.Infinite",
       "ErdosConjecture457_q definition: equivalent q formulation",
       "UpperBoundConjecture definition: q < (1-ε)(log n)² eventually",
@@ -76,7 +76,7 @@
     "historicalContext": "**Erdős Problem #457** was posed by Erdős and Pomerance in the late 1970s, appearing in [Er79d] and [ErGr80, p.91]. The problem explores a fundamental question about the prime factorization of products of consecutive integers: how many small primes can simultaneously divide such a product? This sits at the intersection of multiplicative number theory, sieve methods, and smooth number theory.\n\nThe key function q(n, k) — the least prime not dividing ∏_{i=1}^{k}(n+i) — was introduced to make the problem precise. Since any k consecutive integers contain a multiple of every prime p ≤ k, we trivially have q(n, k) > k. For k = ⌊log n⌋, the question becomes: how much larger than log(n) can q be? Erdős and Pomerance showed that choosing n as a product of primes between log(n) and (2+o(1))log(n) gives q(n, log n) ≥ (2+o(1))log(n), but whether a fixed ε > 0 improvement over the factor 2 is possible remains open.\n\nThe problem is related to Erdős Problem #663, which also concerns prime divisors of consecutive products. Both problems connect to the broader study of smooth numbers (numbers whose prime factors are all small) and the distribution of primes in short intervals. The OEIS sequence A391668 is related to this problem.",
     "problemStatement": "**Problem Statement (OPEN)**\n\nIs there some $\\varepsilon > 0$ such that infinitely many $n$ have all primes $p \\leq (2 + \\varepsilon) \\log n$ dividing $\\prod_{i=1}^{\\lfloor \\log n \\rfloor} (n + i)$?\n\n**Equivalent formulation:** Let $q(n, k)$ be the least prime not dividing $\\prod_{i=1}^k (n+i)$. Is $q(n, \\lfloor \\log n \\rfloor) \\geq (2 + \\varepsilon) \\log n$ infinitely often?\n\n**Known:** $q(n, \\lfloor \\log n \\rfloor) \\geq (2 + o(1)) \\log n$ is achievable.\n\n**Open sub-question:** Is $q(n, \\lfloor \\log n \\rfloor) < (1 - \\varepsilon)(\\log n)^2$ for all large $n$?",
     "text": "Is there ε > 0 such that infinitely many n have all primes p ≤ (2+ε)log(n) dividing the product of ⌊log n⌋ consecutive integers starting at n+1? Equivalently, is q(n, log n) ≥ (2+ε)log(n) infinitely often? Open.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Consecutive Product:** Define ∏(n+i) using Finset.Icc and Finset.prod. Axiomatize positivity and the basic fact that primes ≤ k divide k consecutive integers.\n\n2. **Function q(n,k):** Define using Nat.find with a constructive existence proof (there always exists a prime not dividing a finite product). Axiomatize primality, non-divisibility, and minimality.\n\n3. **Main Conjecture:** ErdosConjecture457 uses Set.Infinite to express \"infinitely many n\" and quantifies over all primes below the threshold. The equivalent q-formulation is stated separately with an equivalence axiom.\n\n4. **Known Results:** The (2+o(1)) construction and the \"2 barrier\" significance are axiomatized. The upper bound sub-question uses Filter.atTop for \"eventually.\"\n\n5. **Connections:** Smooth number definition and the relationship to Problem #663 provide mathematical context.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Consecutive Product:** Define ∏(n+i) using Finset.Icc and Finset.prod. Positivity is proved (consecutiveProduct_pos); the basic fact that primes ≤ k divide k consecutive integers is axiomatized (small_primes_divide).\n\n2. **Function q(n,k):** Define using Nat.find with a constructive existence proof (there always exists a prime not dividing a finite product). Its defining properties follow from Nat.find directly — no separate axioms.\n\n3. **Main Conjecture:** ErdosConjecture457 uses Set.Infinite to express \"infinitely many n\" and quantifies over all primes below the threshold; it is axiomatized as open (erdos_457). The equivalent q-formulation is stated separately as a plain definition (ErdosConjecture457_q).\n\n4. **Known Results:** The (2+o(1)) construction and the \"2 barrier\" significance are recorded as expository comments. The upper bound sub-question is a definition (UpperBoundConjecture) using Filter.atTop for \"eventually.\"\n\n5. **Connections:** Smooth number definition (IsSmooth) and the relationship to Problem #663 provide mathematical context.",
     "keyInsights": [
       "**The 2 Barrier:** The known construction achieves q ≥ (2+o(1))log(n), but crossing to a fixed (2+ε) requires fundamentally new ideas — this is the central difficulty",
       "**Trivial Lower Bound:** Among k consecutive integers, every prime p ≤ k has a multiple, so q(n,k) > k always holds — the question is how much further we can go",
@@ -95,16 +95,16 @@
       "title": "Part I: Consecutive Products",
       "startLine": 38,
       "endLine": 63,
-      "summary": "Defines consecutiveProduct(n, k). Axioms for positivity and small_primes_divide (primes ≤ k divide the product).",
-      "mathContext": "Defines consecutiveProduct(n, k). Axioms for positivity and small_primes_divide (primes $\\leq$ k divide the product)."
+      "summary": "Defines consecutiveProduct(n, k). Theorem consecutiveProduct_pos (positivity, proved). Axiom small_primes_divide (primes ≤ k divide the product).",
+      "mathContext": "Defines consecutiveProduct(n, k). Theorem consecutiveProduct_pos (positivity, proved). Axiom small_primes_divide (primes $\\leq$ k divide the product)."
     },
     {
       "id": "smallest-prime",
       "title": "Part II: The Smallest Non-Dividing Prime",
       "startLine": 64,
       "endLine": 91,
-      "summary": "Defines q(n, k) via Nat.find. Axioms: q_prime, q_not_dvd, q_minimal, q_lower_trivial.",
-      "mathContext": "Formal definition: Defines q(n, k) via Nat.find. Axioms: q_prime, q_not_dvd, q_minimal, q_lower_trivial."
+      "summary": "Defines q(n, k) via Nat.find, with an inline proof that a non-dividing prime always exists. No axioms in this section.",
+      "mathContext": "Formal definition: q(n, k) via Nat.find, with an inline proof that a non-dividing prime always exists (Nat.exists_infinite_primes). No axioms in this section."
     },
     {
       "id": "main-conjecture",
@@ -119,32 +119,32 @@
       "title": "Part IV: Equivalent Formulation via q(n, k)",
       "startLine": 113,
       "endLine": 129,
-      "summary": "ErdosConjecture457_q and conjecture_equivalence axiom.",
-      "mathContext": "Axiomatized: ErdosConjecture457_q and conjecture_equivalence axiom."
+      "summary": "Defines ErdosConjecture457_q, the equivalent q-formulation. Definition plus expository comment; no axiom.",
+      "mathContext": "Defines ErdosConjecture457_q, the equivalent q-formulation. Definition plus expository comment; no axiom."
     },
     {
       "id": "construction",
       "title": "Part V: Known Construction — The (2 + o(1)) Barrier",
       "startLine": 130,
       "endLine": 155,
-      "summary": "construction_lower axiom: (2+o(1))log(n) achievable. two_barrier_significance axiom.",
-      "mathContext": "Axiomatized: construction_lower axiom: (2+o(1))log(n) achievable. two_barrier_significance axiom."
+      "summary": "Expository comment on the known construction: q(n, log n) ≥ (2+o(1))log(n) via a product of primes in [log n, (2+o(1))log n]. No declarations.",
+      "mathContext": "Expository comment on the known construction: q(n, log n) ≥ (2+o(1))log(n) via a product of primes in [log n, (2+o(1))log n]. No declarations."
     },
     {
       "id": "upper-bound",
       "title": "Part VI: Upper Bound Sub-Question",
       "startLine": 156,
       "endLine": 171,
-      "summary": "UpperBoundConjecture: q < (1-ε)(log n)² eventually. Axiom erdos_457_upper.",
-      "mathContext": "UpperBoundConjecture: q < (1-ε)($\\log n$)² eventually. Axiom erdos_457_upper."
+      "summary": "Defines UpperBoundConjecture: q < (1-ε)(log n)² eventually (Filter.atTop). Definition only; no axiom.",
+      "mathContext": "Defines UpperBoundConjecture: q < (1-ε)($\\log n$)² eventually (Filter.atTop). Definition only; no axiom."
     },
     {
       "id": "smooth-numbers",
       "title": "Part VII: Connection to Smooth Numbers",
       "startLine": 172,
       "endLine": 181,
-      "summary": "IsSmooth definition. consecutive_product_smooth_support axiom.",
-      "mathContext": "Formal definition: IsSmooth definition. consecutive_product_smooth_support axiom."
+      "summary": "Defines IsSmooth (y-smooth numbers: all prime factors ≤ y). Definition only; no axiom.",
+      "mathContext": "Formal definition: IsSmooth (y-smooth numbers: all prime factors $\\leq$ y). Definition only; no axiom."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Metadata prose fix for **erdos-457** (Erdős Problem #457). No Lean source change.

The auditor found `sections[]` summaries, `originalContributions[]`, and `proofStrategy` naming ~8 axioms that do not exist in `proofs/Proofs/Erdos457Problem.lean`, plus mislabeling the proved theorem `consecutiveProduct_pos` as an axiom. Severity LOW (it invented extra assumptions — the safe direction — rather than overclaiming), but a factual mismatch against the source.

## Evidence

Actual file contains exactly:
- 2 axioms: `small_primes_divide`, `erdos_457`
- 2 theorems: `consecutiveProduct_pos` (proved), `erdos_457_t1_solved` (`:= erdos_457`)
- 6 defs, 0 sorries

Phantom axioms removed from prose: `q_prime`, `q_not_dvd`, `q_minimal`, `q_lower_trivial`, `conjecture_equivalence`, `construction_lower`, `two_barrier_significance`, `erdos_457_upper`, `consecutive_product_smooth_support`.

## Changes

- **Part I**: `consecutiveProduct_pos` relabeled proved theorem (was "axiom").
- **Part II**: `q` described as `Nat.find` definition with inline existence proof; dropped four nonexistent q-property axioms.
- **Parts IV–VII**: described as definitions + expository comments; removed five phantom axioms.
- **originalContributions**: relabeled `consecutiveProduct_pos` as theorem, removed phantom q-axioms, added the real `erdos_457` axiom.
- **proofStrategy**: corrected the two false axiomatization claims for internal consistency.

Numeric counts (2 axioms, 2 theorems, 6 defs, 0 sorries), `axiomatized` status, and `axiom` badge were already accurate and are unchanged. JSON validated.

Closes #41009
