### PR TITLE
Research: elementary-quadratic-reciprocity-oq-03-oq-02-wip-01 — χ₈ autocorrelation + translation-invariant L² norm

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01.lean
@@ -278,4 +278,62 @@ theorem kronecker2_sq_sum_period :
     Nat.cast_zero, Nat.cast_one]
   decide
 
+/-- **Translation-invariant `L²`-norm: `∑_{a=0}^{7} (c+a/2)² = 4` for every `c`.**
+
+        ∀ c, ∑_{a = 0}^{7} kronecker2 (c + a) * kronecker2 (c + a) = 4.
+
+    The parent's `kronecker2_sq_sum_period` proves the second moment over the base window
+    `[0, 8)`; this is the full self-orthogonality statement — the `L²`-norm of `χ₈` over
+    *every* length-`8` window is `φ(8) = 4` (the `c = 0` case recovers the parent lemma).
+    It is the diagonal counterpart of the mean-zero `kronecker2_sum_shifted_period`: any
+    `8` consecutive integers contain exactly four units mod `2`, each contributing
+    `(±1)² = 1` (`kronecker2_sq`), the four evens contributing `0`.  Together they give the
+    translation-invariant orthogonality `⟨χ₈(c+·), χ₈(c+·)⟩ = φ(8)` that fixes the modulus
+    of the Gauss sum `|τ(χ₈)|² = 8` independently of where the period window is centred. -/
+theorem kronecker2_sq_sum_shifted_period (c : ℤ) :
+    (∑ a ∈ Finset.range 8, kronecker2 (c + a) * kronecker2 (c + a)) = 4 := by
+  simp only [kronecker2_sq, Finset.sum_range_succ, Finset.sum_range_zero,
+    Nat.cast_ofNat, Nat.cast_zero, Nat.cast_one, add_zero, zero_add]
+  split_ifs <;> omega
+
+/-- **Anti-period autocorrelation: `∑_{a=0}^{7} (a/2)·(a+4/2) = −4`.**
+
+        ∑_{a = 0}^{7} kronecker2 a * kronecker2 (a + 4) = -4.
+
+    The shift-`4` autocorrelation of `χ₈` is `−4`, the exact negative of the diagonal
+    self-orthogonality `kronecker2_sq_sum_period` (shift `0`, value `+4`).  Immediate from
+    the anti-periodicity `kronecker2_add_four` (`(a+4/2) = −(a/2)`): every term becomes
+    `(a/2)·(−(a/2)) = −(a/2)²`.  Together `C(0) = 4` and `C(4) = −4` pin down the two
+    non-zero values of the length-`8` autocorrelation `C(t) = ∑_a χ₈(a) χ₈(a+t)` of the
+    conductor-`8` character — the correlation data underlying `|τ(χ₈)|² = 8`. -/
+theorem kronecker2_autocorr_four :
+    (∑ a ∈ Finset.range 8, kronecker2 (a : ℤ) * kronecker2 ((a : ℤ) + 4)) = -4 := by
+  have h : ∀ a ∈ Finset.range 8,
+      kronecker2 (a : ℤ) * kronecker2 ((a : ℤ) + 4)
+        = (-1) * (kronecker2 (a : ℤ) * kronecker2 (a : ℤ)) := by
+    intro a _
+    rw [kronecker2_add_four]; ring
+  rw [Finset.sum_congr rfl h, ← Finset.mul_sum, kronecker2_sq_sum_period]
+  norm_num
+
+/-- **Translation-invariant anti-period autocorrelation: `∑_{a=0}^{7} (c+a/2)·(c+a+4/2) = −4`.**
+
+        ∀ c, ∑_{a = 0}^{7} kronecker2 (c + a) * kronecker2 (c + a + 4) = -4.
+
+    The shift-`4` autocorrelation of `χ₈` is `−4` over *every* period window, not just
+    `[0, 8)` (`c = 0` recovers `kronecker2_autocorr_four`).  Same one-line mechanism —
+    anti-periodicity `kronecker2_add_four` turns each term into `−(c+a/2)²` — now reduced
+    against the translation-invariant `L²`-norm `kronecker2_sq_sum_shifted_period`.  This is
+    the off-diagonal, re-centring-invariant orthogonality the Gauss-sum evaluation uses when
+    it shifts the correlation window to an arbitrary residue. -/
+theorem kronecker2_autocorr_four_shifted (c : ℤ) :
+    (∑ a ∈ Finset.range 8, kronecker2 (c + a) * kronecker2 (c + a + 4)) = -4 := by
+  have h : ∀ a ∈ Finset.range 8,
+      kronecker2 (c + a) * kronecker2 (c + a + 4)
+        = (-1) * (kronecker2 (c + a) * kronecker2 (c + a)) := by
+    intro a _
+    rw [kronecker2_add_four]; ring
+  rw [Finset.sum_congr rfl h, ← Finset.mul_sum, kronecker2_sq_sum_shifted_period]
+  norm_num
+
 end KroneckerSymbol

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/meta.json
@@ -40,10 +40,10 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 17,
+    "theoremCount": 20,
     "defCount": 0,
     "definitionCount": 0,
-    "lineCount": 281,
+    "lineCount": 339,
     "dateAdded": "2026-07-11",
     "assumptions": "0 axioms, 0 sorries — every result is machine-verified from the parent file's public API (propext, Classical.choice, Quot.sound only; the two kronecker2 results use only propext). Status is kept 'wip'/'axiomatized' to match the parent: the file proves genuine new lemmas (numerator periodicity of (a/n) for odd positive n via kronecker_congr_left / kronecker_add_mul_left / kronecker_periodic_left, and full period-8 periodicity of the (a/2) character via kronecker2_congr / kronecker2_add_mul_eight, plus the exact conductor 8 / primitivity of (·/2) via kronecker2_not_period_four / kronecker2_not_period_two / kronecker2_conductor_eight) but the broader open target — wiring kronecker2 into the definition at even moduli and generalized quadratic reciprocity for arbitrary fundamental discriminants — remains unformalized, exactly as documented in the parent's module note. Nothing new is assumed. Section E adds three further machine-verified results with no new assumptions: the anti-periodicity kronecker2_add_four ((a+4/2) = -(a/2), the sharp form of 'period 8 does not descend to 4'), the translation-invariant orthogonality kronecker2_sum_shifted_period (the mean of (·/2) over ANY full period vanishes, generalizing the parent-window kronecker2_sum_period), and the self-orthogonality kronecker2_sq_sum_period (∑ (a/2)² = φ(8) = 4 over a period) — all derived from the anti-periodicity and decidable residue arithmetic (propext, Classical.choice, Quot.sound only).",
     "mathlibDependencies": [


### PR DESCRIPTION
## elementary-quadratic-reciprocity-oq-03-oq-02-wip-01 — χ₈ autocorrelation & translation-invariant L²-norm

Extends **Section E** (orthogonality of the conductor-8 character `χ₈ = (·/2)`) of
`ElementaryQuadraticReciprocityOQ03OQ02WIP01.lean` with the autocorrelation data feeding the
Gauss-sum identity `|τ(χ₈)|² = 8`.  Docker-build verified (`2970/2970 jobs`), 0 sorries, 0 axioms.

### New results (all off the parent's public API + this file's anti-periodicity)

- `kronecker2_sq_sum_shifted_period (c)` — **translation-invariant L²-norm**:
  `∑_{a=0}^{7} (c+a/2)² = 4` for *every* window offset `c` (generalizes the parent-window
  `kronecker2_sq_sum_period`, `c = 0`). Any 8 consecutive integers contain exactly 4 units
  mod 2, each contributing `(±1)² = 1` via `kronecker2_sq`.
- `kronecker2_autocorr_four` — **anti-period autocorrelation**: `∑_{a=0}^{7} (a/2)·(a+4/2) = −4`,
  the exact negative of the diagonal `C(0) = +4`. One line off anti-periodicity
  `kronecker2_add_four` (`(a+4/2) = −(a/2)`).
- `kronecker2_autocorr_four_shifted (c)` — the shift-4 autocorrelation is `−4` over *every*
  period window, the re-centring-invariant form used when the Gauss-sum evaluation shifts the
  correlation window.

Together with the existing mean-zero (`kronecker2_sum_shifted_period`) and diagonal
(`kronecker2_sq_sum_period`) relations, these give the two non-zero values `C(0)=4`, `C(4)=−4`
of the length-8 autocorrelation `C(t)=∑_a χ₈(a)χ₈(a+t)` — the correlation data underlying
`|τ(χ₈)|² = 8` on the Gauss-sum route to generalized quadratic reciprocity.

Meta: `theoremCount` 17 → 20, `lineCount` 281 → 339.

#### Axioms
`propext, Classical.choice, Quot.sound` only (no `native_decide`) — axiom-free, matching every
sibling in the file.
