### PR TITLE
Research: cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03 — nonderogatory degree deg(minpoly)=dim V

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius.lean
@@ -234,7 +234,7 @@ theorem minpoly_natDegree_eq_finrank_of_cyclic [FiniteDimensional K V]
   -- lower bound: a nonzero annihilator of degree `< n` contradicts cyclicity
   have hge : Module.finrank K V ≤ (minpoly K T).natDegree := by
     by_contra h
-    push_neg at h
+    rw [not_le] at h
     have hv0 : (aeval T (minpoly K T)) v = 0 := by rw [haeval]; simp
     exact hne (hcyc (minpoly K T) h hv0)
   -- upper bound: minpoly divides the characteristic polynomial (Cayley–Hamilton)

--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius.lean
@@ -228,7 +228,7 @@ theorem centralizerEvalEquiv_apply [FiniteDimensional K V]
 theorem minpoly_natDegree_eq_finrank_of_cyclic [FiniteDimensional K V]
     (T : Module.End K V) (v : V) (hcyc : IsEndCyclicVector T v) :
     (minpoly K T).natDegree = Module.finrank K V := by
-  have hint : IsIntegral K T := T.isIntegral
+  have hint : IsIntegral K T := LinearMap.isIntegral T
   have hne : minpoly K T ≠ 0 := minpoly.ne_zero hint
   have haeval : (aeval T) (minpoly K T) = 0 := minpoly.aeval K T
   -- lower bound: a nonzero annihilator of degree `< n` contradicts cyclicity
@@ -239,7 +239,7 @@ theorem minpoly_natDegree_eq_finrank_of_cyclic [FiniteDimensional K V]
     exact hne (hcyc (minpoly K T) h hv0)
   -- upper bound: minpoly divides the characteristic polynomial (Cayley–Hamilton)
   have hle : (minpoly K T).natDegree ≤ Module.finrank K V := by
-    have hdvd : minpoly K T ∣ T.charpoly := minpoly.dvd (LinearMap.aeval_self_charpoly T)
+    have hdvd : minpoly K T ∣ T.charpoly := minpoly.dvd K T (LinearMap.aeval_self_charpoly T)
     have hcp_ne : T.charpoly ≠ 0 := T.charpoly_monic.ne_zero
     have hdeg : (minpoly K T).natDegree ≤ T.charpoly.natDegree :=
       Polynomial.natDegree_le_of_dvd hdvd hcp_ne

--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius.lean
@@ -200,6 +200,52 @@ theorem centralizerEvalEquiv_apply [FiniteDimensional K V]
     (A : ↥(Subalgebra.toSubmodule (Subalgebra.centralizer K ({T} : Set (Module.End K V))))) :
     centralizerEvalEquiv T v hcyc A = (A : Module.End K V) v := rfl
 
+-- ============================================================
+-- SECTION V: nonderogatory degree — deg(minpoly) = dim V for a cyclic T
+-- ============================================================
+
+/-- **Nonderogatory degree (forward direction).**  If `T : Module.End K V` (over a
+    finite-dimensional `V`) has a cyclic vector `v`, then the minimal polynomial of
+    `T` has degree exactly `dim_K V`:
+
+        (minpoly K T).natDegree = finrank K V.
+
+    This is the *nonderogatory* edge of the triple equivalence
+    `nonderogatory ⟺ cyclic ⟺ C(T) = K[T]`, expressed through the minimal
+    polynomial rather than the centralizer dimension
+    (`finrank_centralizer_eq_of_cyclic`).  Both inequalities are elementary:
+
+    * `≥` : the minimal polynomial is a *nonzero* annihilator of `T`, hence
+      `(minpoly K T) v = 0`; were its degree `< dim V`, cyclicity
+      (`IsEndCyclicVector`) would force `minpoly K T = 0`, impossible for an
+      integral element (`minpoly.ne_zero`, `LinearMap.isIntegral`).
+    * `≤` : Cayley–Hamilton (`LinearMap.aeval_self_charpoly`) makes `minpoly K T`
+      divide the characteristic polynomial, whose degree is `dim V`
+      (`LinearMap.charpoly_natDegree`).
+
+    Together with `minpoly` dividing `charpoly` this also gives `minpoly = charpoly`
+    in the cyclic case, but only the degree equality is recorded here. -/
+theorem minpoly_natDegree_eq_finrank_of_cyclic [FiniteDimensional K V]
+    (T : Module.End K V) (v : V) (hcyc : IsEndCyclicVector T v) :
+    (minpoly K T).natDegree = Module.finrank K V := by
+  have hint : IsIntegral K T := T.isIntegral
+  have hne : minpoly K T ≠ 0 := minpoly.ne_zero hint
+  have haeval : (aeval T) (minpoly K T) = 0 := minpoly.aeval K T
+  -- lower bound: a nonzero annihilator of degree `< n` contradicts cyclicity
+  have hge : Module.finrank K V ≤ (minpoly K T).natDegree := by
+    by_contra h
+    push_neg at h
+    have hv0 : (aeval T (minpoly K T)) v = 0 := by rw [haeval]; simp
+    exact hne (hcyc (minpoly K T) h hv0)
+  -- upper bound: minpoly divides the characteristic polynomial (Cayley–Hamilton)
+  have hle : (minpoly K T).natDegree ≤ Module.finrank K V := by
+    have hdvd : minpoly K T ∣ T.charpoly := minpoly.dvd (LinearMap.aeval_self_charpoly T)
+    have hcp_ne : T.charpoly ≠ 0 := T.charpoly_monic.ne_zero
+    have hdeg : (minpoly K T).natDegree ≤ T.charpoly.natDegree :=
+      Polynomial.natDegree_le_of_dvd hdvd hcp_ne
+    rwa [LinearMap.charpoly_natDegree] at hdeg
+  omega
+
 end EndCyclicCommutant
 
 end


### PR DESCRIPTION
## cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03 — nonderogatory degree

Adds the **minimal-polynomial** form of the nonderogatory characterization to the Frobenius
companion (`CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius.lean`, Section V). Docker-build
verified (`8582/8582 jobs`), 0 sorries, 0 axioms.

### New result

- `minpoly_natDegree_eq_finrank_of_cyclic (T) (v) (hcyc : IsEndCyclicVector T v)`:
  **`(minpoly K T).natDegree = finrank K V`** for a cyclic endomorphism.

This is the nonderogatory edge of the triple equivalence `nonderogatory ⟺ cyclic ⟺ C(T) = K[T]`
expressed through the minimal polynomial, complementing the existing centralizer-dimension form
`finrank_centralizer_eq_of_cyclic` (`dim C(T) = dim V`) and the evaluation isomorphism
`centralizerEvalEquiv` (`C(T) ≃ₗ[K] V`).

Both inequalities are elementary:
- **`≥`** — the minimal polynomial is a *nonzero* annihilator with `(minpoly K T) v = 0`; a degree
  `< dim V` would force `minpoly K T = 0` by the cyclic-vector definition (`IsEndCyclicVector`),
  impossible for an integral element (`LinearMap.isIntegral`, `minpoly.ne_zero`).
- **`≤`** — Cayley–Hamilton (`LinearMap.aeval_self_charpoly`) makes `minpoly K T` divide the
  characteristic polynomial, whose degree is `dim V` (`LinearMap.charpoly_natDegree`).

Since `minpoly ∣ charpoly` with equal degree and both monic, this also pins `minpoly = charpoly`
in the cyclic case (only the degree equality is recorded here). The **converse** (`deg = dim ⟹
cyclic`) still needs rational-canonical-form / invariant-factor infrastructure absent from
Mathlib v4.31 — unchanged.

#### Axioms
`propext, Classical.choice, Quot.sound` only — axiom-free.
