### PR TITLE
Audit erdos-452: issues-found (inconsistent known_lower_bound axiom)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13737,9 +13737,9 @@
     },
     "erdos-452": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:43Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T23:14:30Z",
+      "result": "issues-found"
     },
     "erdos-453": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Audit of **erdos-452** found a CRITICAL integrity issue: the `known_lower_bound` axiom is **false** (derives `False` at x=3), filed as #41028 with a kernel-verified proof.

3 prior audits marked this entry clean; this cycle instantiated the asymptotic lower-bound axiom at the smallest allowed input (x=3), where `log x/(log log x)² ≈ 124` exceeds the max interval length (4) in `[3,6]`.

Tracker updated: result `issues-found`, auditCount 4.