### PR TITLE
Audit erdos-445: clean (honest Tier-C axiomatization)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13680,8 +13680,8 @@
     },
     "erdos-445": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:43Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T23:18:01Z",
       "result": "clean"
     },
     "erdos-446": {


### PR DESCRIPTION
## Reserve-mode re-audit: erdos-445 (Multiplicative Inverses in Short Intervals)

Queue fully drained (0 unaudited); re-auditing oldest uncontested target.

**Verdict: CLEAN** (4th audit; 3 prior all clean).

### Verification
- **Axioms: 5** ✓ — `heilbronn_threshold`, `heilbronn_unpublished`, `KloostermanSum`, `weil_bound`, `heath_brown_2000`. All opaque-symbol or existence-threshold claims (`∃ P₀, ∀ p > P₀`); none pin a concrete computable def to a false value → no small-case inconsistency.
- **Theorems: 3** ✓ — `heath_brown_threshold`, `current_knowledge`, `erdos_445_summary` (all derive trivially from disclosed axioms; `erdos_445_summary` only *packages* known results, no overclaim).
- **Defs: 6** in-namespace ✓ · **Sorries: 0** ✓ · **native_decide: none** ✓
- All `originalContributions` and section decl names map to real declarations — no phantom decls.
- Status `axiomatized` / badge `axiom` correctly reflect Tier C; description correctly states OPEN for c ∈ (1/2, 3/4].

Tracker: auditCount 3→4, result clean.