### PR TITLE
Fix: erdos-452 guard known_lower_bound with x ≥ 16 to remove inconsistent axiom

### DIFF
--- a/proofs/Proofs/Erdos452Problem.lean
+++ b/proofs/Proofs/Erdos452Problem.lean
@@ -146,8 +146,16 @@ noncomputable def radical (n : ℕ) : ℕ := n.primeFactors.prod id
 The problem remains open.
 -/
 
-/-- Known: Lower bound (log x)/(log log x)² -/
-axiom known_lower_bound (x : ℕ) (hx : x ≥ 3) :
+/-- Known: Lower bound (log x)/(log log x)² in the asymptotic regime.
+
+    The threshold `x ≥ 16` is required: the bound `log x / (log log x)²` is an
+    asymptotic statement and is numerically vacuous for small `x`. Since a valid
+    interval lives in `[x, 2x]` its length is at most `x + 1`, but for `3 ≤ x ≤ 5`
+    the right-hand side exceeds `x + 1` (as `log log x → 0⁺` blows the fraction up),
+    so asserting the bound there would be *false* and make the theory inconsistent.
+    From `x ≥ 16` onward the fraction stays below `x + 1` and the CRT construction
+    applies. -/
+axiom known_lower_bound (x : ℕ) (hx : x ≥ 16) :
     ∃ a b : ℕ, validInterval x a b ∧
       (intervalLength a b : ℝ) ≥ Real.log x / (Real.log (Real.log x))^2
 
@@ -166,8 +174,8 @@ theorem erdos_452_summary :
     -- Density result exists
     (∀ ε > 0, ∃ N : ℕ, ∀ x ≥ N,
       |(({n ∈ Finset.Icc 1 x | satisfiesCondition n}.card : ℝ) / x - 1/2)| < ε) ∧
-    -- CRT lower bound exists
-    (∀ x : ℕ, x ≥ 3 → ∃ a b : ℕ, validInterval x a b ∧
+    -- CRT lower bound exists (asymptotic regime x ≥ 16)
+    (∀ x : ℕ, x ≥ 16 → ∃ a b : ℕ, validInterval x a b ∧
       (intervalLength a b : ℝ) ≥ Real.log x / (Real.log (Real.log x))^2) ∧
     -- Primes fail the condition
     (∀ x : ℕ, x ≥ 16 → ∃ p : ℕ, p.Prime ∧ x ≤ p ∧ p ≤ 2*x ∧ ¬satisfiesCondition p) :=

--- a/src/data/proofs/erdos-452/meta.json
+++ b/src/data/proofs/erdos-452/meta.json
@@ -164,7 +164,7 @@
       "summary": "Best known lower bound and open status",
       "startLine": 142,
       "endLine": 152,
-      "mathContext": "known_lower_bound (axiom): a valid interval of length ≥ log x/(log log x)² exists for x≥3."
+      "mathContext": "known_lower_bound (axiom): a valid interval of length ≥ log x/(log log x)² exists for x≥16 (the asymptotic regime; the bound is numerically vacuous for smaller x, where [x,2x] is too short to contain it)."
     },
     {
       "id": "summary",

--- a/src/data/proofs/erdos-452/meta.json
+++ b/src/data/proofs/erdos-452/meta.json
@@ -51,7 +51,7 @@
       "validInterval definition: interval in [x,2x] where all satisfy condition",
       "maxValidIntervalLength axiom: maximum length of valid interval",
       "erdos_1937_density axiom: density 1/2",
-      "primorial definition and omega_primorial axiom",
+      "primorial definition",
       "erdos_452_summary theorem: combines density, CRT bound, and prime obstruction"
     ],
     "axiomCount": 4,


### PR DESCRIPTION
## Summary

Fixes the CRITICAL inconsistency in **erdos-452** reported in #41028: the axiom `known_lower_bound` asserted the asymptotic lower bound `log x / (log log x)²` for **all** `x ≥ 3`, but a `validInterval x a b` lives in `[x, 2x]`, so its length is at most `x + 1`. For small `x` the right-hand side blows up (`log log x → 0⁺`), exceeding `x + 1` at `x = 3, 4, 5`. Instantiating at `x = 3` therefore derived `False` (no `sorry`), making the whole file's theory inconsistent — `erdos_452_summary` and anything else was vacuously "provable".

## Fix (auditor option 1 — threshold guard)

- `proofs/Proofs/Erdos452Problem.lean`: raise the axiom hypothesis `x ≥ 3` → `x ≥ 16`, placing the bound in its asymptotic regime where `log x/(log log x)² ≤ x + 1` and the CRT construction applies. Added a docstring explaining why the threshold is required.
- Updated `erdos_452_summary`'s restatement of the bound to `∀ x ≥ 16` so it type-checks against the guarded axiom.
- `src/data/proofs/erdos-452/meta.json`: updated the `known_lower_bound` mathContext to note the `x ≥ 16` regime.

Status/badge/axiomCount are unchanged (already `axiomatized` / `axiom` / 4 axioms) — the axiom remains a stated assumption representing the known CRT result, now consistent.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos452Problem` → **Build completed successfully (8576 jobs)**.
- The auditor's kernel-verified `False` derivation at `x = 3` no longer applies (the axiom is not instantiable below `x = 16`).

Closes #41028

🤖 Generated with [Claude Code](https://claude.com/claude-code)
