### PR TITLE
Audit erdos-448: issues-found (overstated disproof, #41037)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13701,9 +13701,9 @@
     },
     "erdos-448": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:43Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T23:21:10Z",
+      "result": "issues-found"
     },
     "erdos-449": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Reserve-mode re-audit. Filed #41037: erdos_448_original_conjecture stubs density with `True` (provably true via D=∅) making the headline disproof `erdos_448` a false-as-formalized `sorry`; summary/answer theorems are vacuous `True`/trivial placeholders; example_six/example_twelve use undisclosed native_decide. Counts honest (2ax/9thm/1sorry); narrative overclaims 'DISPROVED'. 3 prior audits marked clean.

Tracker: erdos-448 → issues-found.