### PR TITLE
auditor: erdos-45 re-audit clean (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13716,8 +13716,8 @@
     },
     "erdos-45": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:43Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-21T23:24:29Z",
       "result": "clean"
     },
     "erdos-450": {


### PR DESCRIPTION
Reserve-mode re-audit (queue drained, 0 unaudited). erdos-45 counts verified exact against `proofs/Proofs/Erdos45Problem.lean`: 3 axioms, 3 theorems/lemmas, 5 defs, 0 sorries, 0 native_decide/decide. Bound axioms consistent; badge `axiom`/status `axiomatized` honest. Stale 'one sorry' prose in sections/proofStrategy is safe-direction (no overclaim). Tracker: auditCount 3→4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)