### PR TITLE
Fix: erdos-448 narrative overclaim — disclose sorry'd disproof + native_decide

### DIFF
--- a/src/data/proofs/erdos-448/meta.json
+++ b/src/data/proofs/erdos-448/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-448",
   "title": "Erdős Problem #448: Divisors in Dyadic Intervals",
   "slug": "erdos-448",
-  "description": "Is τ⁺(n) < ε·τ(n) for almost all n? NO (DISPROVED) - Erdős-Tenenbaum showed exceptions have positive density.",
+  "description": "Is τ⁺(n) < ε·τ(n) for almost all n? NO — disproved by Erdős-Tenenbaum (1981); exceptions have positive density. (The formal disproof is NOT formalized here: the Lean file is a scaffold whose conjecture stubs the density condition as `True` and leaves the negation as `sorry`.)",
   "meta": {
     "author": "Erdős-Tenenbaum (1981 disproof), Ford (2008 asymptotic)",
     "sourceUrl": "https://erdosproblems.com/448",
@@ -49,14 +49,14 @@
       "tau definition: standard divisor counting function",
       "inDyadicInterval definition: membership in [2^k, 2^(k+1))",
       "tauPlus definition: count of occupied dyadic intervals",
-      "erdos_448_original_conjecture: the disproved statement",
+      "erdos_448_original_conjecture: scaffold of the conjecture statement (density condition stubbed as `True`, so the Prop is vacuously satisfiable)",
       "fordAlpha constant: α ≈ 0.08607",
       "Concrete examples for n = 6, 12, 210",
-      "erdos_448 theorem: the conjecture is false"
+      "erdos_448: formal statement of the conjecture's negation — proof deferred (`sorry`); the disproof is NOT formalized"
     ],
     "axiomCount": 2,
     "lineCount": 307,
-    "assumptions": "2 axioms: tauPlus_le_tau (τ⁺(n) ≤ τ(n) for n ≥ 1), fordAlpha_approx (Ford constant 0.086 < α < 0.087). 1 sorry.",
+    "assumptions": "2 axioms: tauPlus_le_tau (τ⁺(n) ≤ τ(n) for n ≥ 1), fordAlpha_approx (Ford constant 0.086 < α < 0.087). 1 sorry (the deferred negation `erdos_448`). Also uses `Lean.ofReduceBool` via `native_decide` in the named example theorems example_six and example_twelve (compiled-code trust).",
     "theoremCount": 9,
     "definitionCount": 5
   },
@@ -64,7 +64,7 @@
     "historicalContext": "**Erdős Problem #448: Divisors in Dyadic Intervals**\n\nThis problem asks about the distribution of divisors across dyadic intervals [2^k, 2^(k+1)). The key question is whether divisors of most integers cluster into relatively few such intervals.\n\n**Historical Development:**\n- **Erdős (original problem)**: Asked if τ⁺(n) < ε·τ(n) for almost all n\n- **Erdős-Tenenbaum (1981)**: DISPROVED the conjecture, showing exceptions have positive upper density ≍ ε^(1-o(1))\n- **Hall-Tenenbaum (1988)**: Refined to upper density ≪ ε·log(2/ε) and proved τ⁺(n)/τ(n) has a distribution function\n- **Ford (2008)**: Found the precise asymptotic for Στ⁺(n)\n\n**Key Insight:**\nThe conjecture failed because divisors don't concentrate as much as expected. For many integers, divisors spread fairly evenly across dyadic intervals, keeping τ⁺(n) comparable to τ(n).",
     "problemStatement": "**Problem Statement (Disproved)**\n\nLet $\\tau(n)$ count the divisors of $n$ and $\\tau^+(n)$ count the number of $k$ such that $n$ has a divisor in $[2^k, 2^{k+1})$. Is it true that, for all $\\epsilon > 0$,\n$$\\tau^+(n) < \\epsilon \\cdot \\tau(n)$$\nfor almost all $n$?\n\n**Answer: NO (DISPROVED)**\n\nErdős and Tenenbaum (1981) showed this is FALSE:\n- The upper density of counterexamples is $\\asymp \\epsilon^{1-o(1)}$\n- Hall-Tenenbaum (1988) refined this to $\\ll \\epsilon \\log(2/\\epsilon)$\n\n**Ford's Asymptotic (2008):**\n$$\\sum_{n \\leq x} \\tau^+(n) \\asymp x \\frac{(\\log x)^{1-\\alpha}}{(\\log\\log x)^{3/2}}$$\nwhere $\\alpha = 1 - \\frac{1 + \\log\\log 2}{\\log 2} \\approx 0.08607$.",
     "text": "Is τ⁺(n) < ε·τ(n) for almost all n? NO (DISPROVED) - Erdős-Tenenbaum showed exceptions have positive density.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Definitions:** Define τ(n) as divisor count, dyadic interval membership, and τ⁺(n) as count of occupied intervals\n\n2. **Basic Properties:** Prove τ⁺(n) ≤ τ(n) and τ⁺(n) ≤ log₂(n) + 1\n\n3. **The Conjecture:** State the original (false) conjecture about density-1 concentration\n\n4. **Disproof:** Axiomatize Erdős-Tenenbaum's result that exceptions have positive density\n\n5. **Refinements:** Include Hall-Tenenbaum bounds and distribution function existence\n\n6. **Ford's Result:** State the asymptotic for the sum of τ⁺, including the Ford constant α\n\n7. **Examples:** Concrete calculations for small values showing the spread",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Definitions:** Define τ(n) as divisor count, dyadic interval membership, and τ⁺(n) as count of occupied intervals\n\n2. **Basic Properties:** Prove τ⁺(n) ≤ τ(n) and τ⁺(n) ≤ log₂(n) + 1\n\n3. **The Conjecture:** State the original (false) conjecture about density-1 concentration\n\n4. **Disproof (scaffold only):** State the negation `¬ erdos_448_original_conjecture` as `theorem erdos_448 := by sorry` — the Erdős-Tenenbaum disproof is NOT formalized. Because the conjecture's density condition is stubbed as `True`, the stated Prop is vacuously satisfiable and its negation is documentation scaffold, not a formal disproof.\n\n5. **Refinements:** Include Hall-Tenenbaum bounds and distribution function existence\n\n6. **Ford's Result:** State the asymptotic for the sum of τ⁺, including the Ford constant α\n\n7. **Examples:** Concrete calculations for small values showing the spread",
     "keyInsights": [
       "**τ⁺(n)**: Counts dyadic intervals [2^k, 2^(k+1)) containing at least one divisor of n",
       "**Concentration Question**: Does τ⁺(n)/τ(n) → 0 for almost all n? Answer: NO",


### PR DESCRIPTION
## Summary

Repairs the gallery integrity issue in erdos-448 (#41037): the entry presented a **disproved** result as if the disproof were formalized, when in fact the Lean file is a scaffold — the conjecture stubs its density condition with `True` (making the Prop vacuously satisfiable), and the "disproof" theorem `erdos_448 : ¬ erdos_448_original_conjecture` is left as `sorry`. Two named example theorems also use `native_decide` (undisclosed `Lean.ofReduceBool`).

Metadata-only fix — counts (2 axioms / 9 theorems / 1 sorry, status `axiomatized`, badge `axiom`) were already honest; only the narrative overstated. The Lean source is unchanged, so no kernel behavior changes.

## Changes (`src/data/proofs/erdos-448/meta.json`)

- **description**: keep the (true) historical "disproved by Erdős–Tenenbaum" framing but state plainly that the formal disproof is NOT formalized — the file is a scaffold with the density condition stubbed as `True` and the negation left as `sorry`.
- **originalContributions**: relabel `erdos_448_original_conjecture` as a scaffold (density condition stubbed as `True`); relabel `erdos_448 theorem: the conjecture is false` → "formal statement of the negation — proof deferred (`sorry`); disproof NOT formalized".
- **proofStrategy step 4**: "Axiomatize Erdős-Tenenbaum's result" → "State the negation as `sorry` (scaffold only); disproof not formalized; conjecture's density condition stubbed as `True`".
- **assumptions**: disclose `Lean.ofReduceBool` via `native_decide` in `example_six` / `example_twelve`.

## Evidence

Before → after (verbatim source unchanged):
- `def erdos_448_original_conjecture := ∀ ε > 0, ∃ D, (∀ n ∈ D, …) ∧ True` — vacuously satisfiable (take `D = ∅`).
- `theorem erdos_448 : ¬ erdos_448_original_conjecture := by intro h; sorry`.
- `theorem example_six : τ(6) = 4 := by native_decide` (and `example_twelve`).

JSON validates; single-file diff.

Closes #41037
