### PR TITLE
fix(daemon): route completion signals to canonical dir so session_stats increment (#41047)

### DIFF
--- a/.lean/scripts/research.sh
+++ b/.lean/scripts/research.sh
@@ -16,6 +16,12 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 RESEARCH_DIR="$REPO_ROOT/research"
+
+# Canonical (main-checkout) completions dir shared with the lean daemon so
+# problem-selected signals land where the daemon reads them, not in a throwaway
+# worktree's gitignored .loom/ (#41047).
+# shellcheck source=../../scripts/lib/completions-dir.sh
+source "$REPO_ROOT/scripts/lib/completions-dir.sh"
 TEMPLATES_DIR="$RESEARCH_DIR/templates"
 PROBLEMS_DIR="$RESEARCH_DIR/problems"
 
@@ -480,7 +486,8 @@ EOF
         "$REGISTRY_FILE" > "$tmp" && mv "$tmp" "$REGISTRY_FILE"
 
     # Create completion signal for daemon stats tracking (problem selected for research)
-    local completions_dir="$REPO_ROOT/.loom/signals/completions"
+    local completions_dir
+    completions_dir="$(resolve_completions_dir)"
     mkdir -p "$completions_dir"
     touch "$completions_dir/problem-selected-$slug-$(date +%s)"
 
@@ -696,7 +703,8 @@ EOF
             "$REGISTRY_FILE" > "$tmp" && mv "$tmp" "$REGISTRY_FILE"
 
         # Create completion signal for daemon stats tracking (problem selected for research)
-        local completions_dir="$REPO_ROOT/.loom/signals/completions"
+        local completions_dir
+        completions_dir="$(resolve_completions_dir)"
         mkdir -p "$completions_dir"
         touch "$completions_dir/problem-selected-$slug-$(date +%s)"
 
@@ -774,7 +782,8 @@ EOF
     register_problem "$slug" "OBSERVE" "$path_type"
 
     # Create completion signal for daemon stats tracking (problem selected for research)
-    local completions_dir="$REPO_ROOT/.loom/signals/completions"
+    local completions_dir
+    completions_dir="$(resolve_completions_dir)"
     mkdir -p "$completions_dir"
     touch "$completions_dir/problem-selected-$slug-$(date +%s)"
 

--- a/scripts/aristotle/retrieve-integrate.sh
+++ b/scripts/aristotle/retrieve-integrate.sh
@@ -19,6 +19,11 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Canonical completion-signal directory resolver (shared with the lean daemon
+# so proof-integrated signals land where the daemon reads them -- #41047).
+# shellcheck source=../lib/completions-dir.sh
+source "$SCRIPT_DIR/../lib/completions-dir.sh"
 JOBS_FILE="$PROJECT_ROOT/research/aristotle-jobs.json"
 RESULTS_DIR="$PROJECT_ROOT/aristotle-results/new"
 PROCESSED_DIR="$PROJECT_ROOT/aristotle-results/processed"
@@ -426,8 +431,12 @@ integrate_solution() {
                 update_job_status_with_theorems "$project_id" "integrated" "$outcome_note" "$theorems_proved"
                 update_job_verification "$project_id" "$verification"
 
-                # Create completion signal for daemon stats tracking
-                local completions_dir="$PROJECT_ROOT/.loom/signals/completions"
+                # Create completion signal for daemon stats tracking. Resolve the
+                # canonical (main-checkout) completions dir so the daemon actually
+                # sees it -- writing to this worktree's .loom/ would be invisible
+                # (#41047).
+                local completions_dir
+                completions_dir="$(resolve_completions_dir)"
                 mkdir -p "$completions_dir"
                 touch "$completions_dir/proof-integrated-$problem_id-$(date +%s)"
             fi

--- a/scripts/aristotle/submit-batch.sh
+++ b/scripts/aristotle/submit-batch.sh
@@ -30,6 +30,11 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Canonical completion-signal directory resolver (shared with the lean daemon
+# so proof-submitted signals land where the daemon reads them -- #41047).
+# shellcheck source=../lib/completions-dir.sh
+source "$SCRIPT_DIR/../lib/completions-dir.sh"
 JOBS_FILE="$PROJECT_ROOT/research/aristotle-jobs.json"
 FIND_CANDIDATES="$SCRIPT_DIR/find-candidates.sh"
 PREPROCESS="$SCRIPT_DIR/preprocess-for-aristotle.sh"
@@ -475,8 +480,11 @@ submit_file() {
          )
        }]' "$JOBS_FILE" > "$tmp_file" && mv "$tmp_file" "$JOBS_FILE"
 
-    # Create completion signal for daemon stats tracking
-    local completions_dir="$PROJECT_ROOT/.loom/signals/completions"
+    # Create completion signal for daemon stats tracking. Resolve the canonical
+    # (main-checkout) completions dir so the daemon actually sees it -- writing
+    # to this worktree's .loom/ would be invisible (#41047).
+    local completions_dir
+    completions_dir="$(resolve_completions_dir)"
     mkdir -p "$completions_dir"
     touch "$completions_dir/proof-submitted-$problem_id-$(date +%s)"
 

--- a/scripts/deploy/sync-and-deploy.sh
+++ b/scripts/deploy/sync-and-deploy.sh
@@ -69,6 +69,11 @@ find_repo_root() {
 
 REPO_ROOT="$(find_repo_root)"
 
+# Canonical completion-signal directory resolver (shared with the lean daemon
+# so deployment signals land where the daemon reads them -- #41047).
+# shellcheck source=../lib/completions-dir.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/completions-dir.sh"
+
 # Resolved worktree base (LOOM_WORKTREE_ROOT env var / .loom/config.json
 # worktree.root override; default $REPO_ROOT/.loom/worktrees).
 # shellcheck source=../lib/worktree-root.sh
@@ -1117,8 +1122,11 @@ deploy_website() {
         # Prune old deployments, keeping only the latest N
         prune_old_deployments
 
-        # Create completion signal for daemon stats tracking
-        local completions_dir="$REPO_ROOT/.loom/signals/completions"
+        # Create completion signal for daemon stats tracking. Resolve the
+        # canonical (main-checkout) completions dir so the daemon actually sees
+        # it -- writing to this worktree's .loom/ would be invisible (#41047).
+        local completions_dir
+        completions_dir="$(resolve_completions_dir)"
         mkdir -p "$completions_dir"
         touch "$completions_dir/deployment-$(date +%s)"
     else

--- a/scripts/enricher/claim-target.sh
+++ b/scripts/enricher/claim-target.sh
@@ -35,7 +35,14 @@ REPO_ROOT="${REPO_ROOT:-$(find_repo_root)}"
 CLAIMS_DIR="$REPO_ROOT/.lean/state/enrichment-claims"
 TRACKER_FILE="$REPO_ROOT/src/data/proofs/enrichment-tracker.json"
 FIND_TARGETS="$REPO_ROOT/scripts/enricher/find-targets.ts"
-COMPLETIONS_DIR="$REPO_ROOT/.loom/signals/completions"
+
+# Canonical (main-checkout) completions dir shared with the lean daemon. When
+# this runs standalone (REPO_ROOT unset -> find_repo_root returns the worktree),
+# a worktree-local .loom/ would be invisible to the daemon, so enrichment
+# signals would never increment session_stats (#41047).
+# shellcheck source=../lib/completions-dir.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/completions-dir.sh"
+COMPLETIONS_DIR="$(resolve_completions_dir)"
 
 # Defaults
 TTL_MINUTES="${CLAIM_TTL:-90}"

--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -30,6 +30,13 @@ source "$_LAUNCH_SCRIPT_DIR/../lib/worktree-cleanup.sh"
 # shellcheck source=../lib/worktree-root.sh
 source "$_LAUNCH_SCRIPT_DIR/../lib/worktree-root.sh"
 
+# Canonical completion-signal directory resolver. Producers (enricher,
+# researcher, deployer, aristotle) run in worktrees; the daemon consumes signals
+# from the main checkout. Both sides must resolve the SAME
+# .loom/signals/completions or session_stats never increment (#41047).
+# shellcheck source=../lib/completions-dir.sh
+source "$_LAUNCH_SCRIPT_DIR/../lib/completions-dir.sh"
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -1845,8 +1852,13 @@ update_daemon_state() {
 # Helper: Process completion signals and update session stats
 # Agents create signal files when they complete work, daemon consumes them and updates counters
 process_completion_signals() {
+    # Resolve the canonical completions directory (shared main checkout), NOT a
+    # daemon-cwd-relative path -- producers in worktrees write here too (#41047).
+    local comp_dir
+    comp_dir="$(resolve_completions_dir)"
+
     # Ensure completions directory exists
-    mkdir -p "$COMPLETIONS_DIR/archive"
+    mkdir -p "$comp_dir/archive"
 
     local enriched=0
     local proofs=0
@@ -1856,12 +1868,12 @@ process_completion_signals() {
     local researched=0
 
     # Count signals by type (use find to avoid glob expansion issues)
-    enriched=$(find "$COMPLETIONS_DIR" -maxdepth 1 -name 'enrichment-completed-*' -type f 2>/dev/null | wc -l | tr -d ' ')
-    proofs=$(find "$COMPLETIONS_DIR" -maxdepth 1 -name 'proof-submitted-*' -type f 2>/dev/null | wc -l | tr -d ' ')
-    integrated=$(find "$COMPLETIONS_DIR" -maxdepth 1 -name 'proof-integrated-*' -type f 2>/dev/null | wc -l | tr -d ' ')
-    selected=$(find "$COMPLETIONS_DIR" -maxdepth 1 -name 'problem-selected-*' -type f 2>/dev/null | wc -l | tr -d ' ')
-    deploys=$(find "$COMPLETIONS_DIR" -maxdepth 1 -name 'deployment-*' -type f 2>/dev/null | wc -l | tr -d ' ')
-    researched=$(find "$COMPLETIONS_DIR" -maxdepth 1 -name 'research-completed-*' -type f 2>/dev/null | wc -l | tr -d ' ')
+    enriched=$(find "$comp_dir" -maxdepth 1 -name 'enrichment-completed-*' -type f 2>/dev/null | wc -l | tr -d ' ')
+    proofs=$(find "$comp_dir" -maxdepth 1 -name 'proof-submitted-*' -type f 2>/dev/null | wc -l | tr -d ' ')
+    integrated=$(find "$comp_dir" -maxdepth 1 -name 'proof-integrated-*' -type f 2>/dev/null | wc -l | tr -d ' ')
+    selected=$(find "$comp_dir" -maxdepth 1 -name 'problem-selected-*' -type f 2>/dev/null | wc -l | tr -d ' ')
+    deploys=$(find "$comp_dir" -maxdepth 1 -name 'deployment-*' -type f 2>/dev/null | wc -l | tr -d ' ')
+    researched=$(find "$comp_dir" -maxdepth 1 -name 'research-completed-*' -type f 2>/dev/null | wc -l | tr -d ' ')
 
     local total=$((enriched + proofs + integrated + selected + deploys + researched))
 
@@ -1889,12 +1901,12 @@ process_completion_signals() {
         daemon_log "INFO" "Stats updated: +$enriched enriched, +$proofs proofs, +$integrated integrated, +$selected selected, +$deploys deploys, +$researched researched"
 
         # Archive signals (preserve for debugging but don't recount)
-        find "$COMPLETIONS_DIR" -maxdepth 1 -type f -name 'enrichment-completed-*' -exec mv {} "$COMPLETIONS_DIR/archive/" \; 2>/dev/null || true
-        find "$COMPLETIONS_DIR" -maxdepth 1 -type f -name 'proof-submitted-*' -exec mv {} "$COMPLETIONS_DIR/archive/" \; 2>/dev/null || true
-        find "$COMPLETIONS_DIR" -maxdepth 1 -type f -name 'proof-integrated-*' -exec mv {} "$COMPLETIONS_DIR/archive/" \; 2>/dev/null || true
-        find "$COMPLETIONS_DIR" -maxdepth 1 -type f -name 'problem-selected-*' -exec mv {} "$COMPLETIONS_DIR/archive/" \; 2>/dev/null || true
-        find "$COMPLETIONS_DIR" -maxdepth 1 -type f -name 'deployment-*' -exec mv {} "$COMPLETIONS_DIR/archive/" \; 2>/dev/null || true
-        find "$COMPLETIONS_DIR" -maxdepth 1 -type f -name 'research-completed-*' -exec mv {} "$COMPLETIONS_DIR/archive/" \; 2>/dev/null || true
+        find "$comp_dir" -maxdepth 1 -type f -name 'enrichment-completed-*' -exec mv {} "$comp_dir/archive/" \; 2>/dev/null || true
+        find "$comp_dir" -maxdepth 1 -type f -name 'proof-submitted-*' -exec mv {} "$comp_dir/archive/" \; 2>/dev/null || true
+        find "$comp_dir" -maxdepth 1 -type f -name 'proof-integrated-*' -exec mv {} "$comp_dir/archive/" \; 2>/dev/null || true
+        find "$comp_dir" -maxdepth 1 -type f -name 'problem-selected-*' -exec mv {} "$comp_dir/archive/" \; 2>/dev/null || true
+        find "$comp_dir" -maxdepth 1 -type f -name 'deployment-*' -exec mv {} "$comp_dir/archive/" \; 2>/dev/null || true
+        find "$comp_dir" -maxdepth 1 -type f -name 'research-completed-*' -exec mv {} "$comp_dir/archive/" \; 2>/dev/null || true
     fi
 }
 
@@ -1997,7 +2009,7 @@ cmd_daemon() {
     rm -f "$STOP_SIGNAL_FILE" 2>/dev/null || true
 
     # Ensure completions directory exists for session stats tracking
-    mkdir -p "$COMPLETIONS_DIR/archive"
+    mkdir -p "$(resolve_completions_dir)/archive"
 
     # Write PID file
     mkdir -p "$(dirname "$DAEMON_PID_FILE")"

--- a/scripts/lean/update-stats.sh
+++ b/scripts/lean/update-stats.sh
@@ -100,7 +100,15 @@ find_repo_root() {
 }
 
 REPO_ROOT="$(find_repo_root)"
-COMPLETIONS_DIR="$REPO_ROOT/.loom/signals/completions"
+
+# Resolve the canonical (main-checkout) completions dir shared with the lean
+# daemon. find_repo_root returns the *worktree* root when run inside an agent
+# worktree, whose gitignored .loom/ the daemon never reads -- so signals dropped
+# there (e.g. the seeker's problem-selected) never increment session_stats
+# (#41047). The resolver anchors on the git common dir instead.
+# shellcheck source=../lib/completions-dir.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/completions-dir.sh"
+COMPLETIONS_DIR="$(resolve_completions_dir)"
 
 # Validate signal type
 validate_signal_type() {

--- a/scripts/lib/completions-dir.sh
+++ b/scripts/lib/completions-dir.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# completions-dir.sh - Canonical location for daemon completion signals.
+#
+# Source this file, then call `resolve_completions_dir` to get the ONE
+# directory where completion signals must live so the lean daemon can see
+# them:
+#
+#     .../.loom/signals/completions
+#
+# Why this exists
+# ---------------
+# Completion signals are produced by agents (enricher, researcher, deployer,
+# aristotle) that run inside *git worktrees*, and consumed by the lean daemon
+# running in the *main checkout*. `.loom/` is per-worktree, gitignored runtime
+# state, so a signal written to a worktree's `.loom/signals/completions` is
+# invisible to the daemon reading the main checkout's directory -- the
+# `session_stats` counters (Deployments / enriched / research / proofs) then
+# never increment (issue #41047).
+#
+# The fix is a single source of truth: anchor on the git *common* dir. From any
+# linked worktree, `git rev-parse --git-common-dir` returns the absolute path to
+# the main repository's `.git`; from the main checkout it returns a path we
+# normalise via `--show-toplevel`. Either way every script resolves to the SAME
+# main-checkout `.loom/signals/completions`.
+#
+# Producers and the daemon consumer must both use this resolver so they agree.
+
+# Resolve the canonical completions directory (absolute path). Falls back to a
+# repo-relative path only when git metadata is unavailable.
+resolve_completions_dir() {
+    local common root
+    if common="$(git rev-parse --git-common-dir 2>/dev/null)"; then
+        case "$common" in
+            /*)
+                # Linked worktree: common dir is the absolute main `.git`.
+                root="$(cd "$(dirname "$common")" && pwd)"
+                ;;
+            *)
+                # Main checkout: common dir is relative; the working-tree top
+                # is the main root.
+                root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+                ;;
+        esac
+    else
+        root="$(pwd)"
+    fi
+    printf '%s/.loom/signals/completions\n' "$root"
+}

--- a/scripts/research/claim-problem.sh
+++ b/scripts/research/claim-problem.sh
@@ -47,6 +47,12 @@ find_repo_root() {
 }
 
 REPO_ROOT="$(find_repo_root)"
+
+# Canonical completion-signal directory resolver (shared with the lean daemon
+# so research-completed signals land where the daemon reads them -- #41047).
+# shellcheck source=../lib/completions-dir.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/completions-dir.sh"
+
 CLAIMS_DIR="$REPO_ROOT/research/claims"
 POOL_FILE="$REPO_ROOT/.lean/state/candidate-pool.json"
 PROBLEMS_DIR="$REPO_ROOT/src/data/research/problems"
@@ -539,9 +545,12 @@ update_problem_status() {
 
     with_pool_lock _update_problem_status_inner
 
-    # Create completion signal when problem is marked completed
+    # Create completion signal when problem is marked completed. Resolve the
+    # canonical (main-checkout) completions dir so the daemon actually sees it --
+    # writing to this worktree's .loom/ would be invisible (#41047).
     if [[ "$new_status" == "completed" ]]; then
-        local completions_dir="$REPO_ROOT/.loom/signals/completions"
+        local completions_dir
+        completions_dir="$(resolve_completions_dir)"
         mkdir -p "$completions_dir"
         touch "$completions_dir/research-completed-$problem_id-$(date +%s)"
     fi


### PR DESCRIPTION
Closes #41047

## Root cause

Completion signals are **produced** by agents that run inside **git worktrees**
(enricher, researcher, deployer, aristotle, seeker) and **consumed** by the lean
daemon running in the **main checkout** (`process_completion_signals` in
`scripts/lean/launch.sh`).

Every producer resolved its signals directory to a *worktree-local* path:

| Producer | Signal | Resolved `completions_dir` to | Anchored on |
|----------|--------|-------------------------------|-------------|
| `scripts/deploy/sync-and-deploy.sh` | `deployment` | `$REPO_ROOT/.loom/signals/completions` | `find_repo_root` → **worktree** |
| `scripts/research/claim-problem.sh` | `research-completed` | `$REPO_ROOT/.loom/signals/completions` | `find_repo_root` → **worktree** |
| `scripts/aristotle/submit-batch.sh` | `proof-submitted` | `$PROJECT_ROOT/.loom/signals/completions` | script location → **worktree** |
| `scripts/aristotle/retrieve-integrate.sh` | `proof-integrated` | `$PROJECT_ROOT/.loom/signals/completions` | script location → **worktree** |
| `scripts/enricher/claim-target.sh` | `enrichment-completed` | `$REPO_ROOT/.loom/signals/completions` | `find_repo_root` → **worktree** |
| `scripts/lean/update-stats.sh` (seeker) | `problem-selected` | `$REPO_ROOT/.loom/signals/completions` | `find_repo_root` → **worktree** |
| `.lean/scripts/research.sh` (×3) | `problem-selected` | `$REPO_ROOT/.loom/signals/completions` | script location → **worktree** |

Because `.loom/` is **per-worktree, gitignored runtime state**, a signal written
to a worktree's `.loom/signals/completions` is in a *different directory* from
the one the daemon scans (the main checkout's, via a cwd-relative
`COMPLETIONS_DIR=".loom/signals/completions"`). The daemon never saw those
signals, and they were discarded when the worktree was reaped. Hence
`session_stats` — Deployments, `entries_enriched`, `research_completed`,
`proofs_submitted`, `proofs_integrated`, `problems_selected` — stayed flat
(`Deployments: 23`) despite confirmed real activity.

The counting and `jq` increment logic in `process_completion_signals` was
**correct all along**; the producer and consumer simply disagreed on *which*
`.loom/signals/completions` to use.

## Fix

New shared resolver `scripts/lib/completions-dir.sh` → `resolve_completions_dir`,
which anchors on the git **common dir**:

```sh
common="$(git rev-parse --git-common-dir)"   # linked worktree -> absolute main .git
# main checkout -> relative; normalise via --show-toplevel
```

From any linked worktree this yields the **main checkout's**
`.loom/signals/completions`; from the main checkout it yields the same path. Both
the daemon consumer and **every** producer now source the resolver, so they always
agree.

Verified in a worktree at `/Volumes/Stripe/lean-genius/issue-41047`:

```
resolve_completions_dir -> /Users/rwalters/GitHub/lean-genius/.loom/signals/completions   # from worktree
resolve_completions_dir -> /Users/rwalters/GitHub/lean-genius/.loom/signals/completions   # from main checkout
```

## Files changed

- **`scripts/lib/completions-dir.sh`** (new) — shared canonical resolver
- `scripts/lean/launch.sh` — `process_completion_signals` (count + archive) and daemon init use `resolve_completions_dir`
- `scripts/deploy/sync-and-deploy.sh` — deployment signal → canonical dir
- `scripts/research/claim-problem.sh` — `research-completed` → canonical dir
- `scripts/aristotle/submit-batch.sh` — `proof-submitted` → canonical dir
- `scripts/aristotle/retrieve-integrate.sh` — `proof-integrated` → canonical dir
- `scripts/enricher/claim-target.sh` — `enrichment-completed` → canonical dir (also robust when run standalone with `REPO_ROOT` unset)
- `scripts/lean/update-stats.sh` — seeker `problem-selected` → canonical dir
- `.lean/scripts/research.sh` — `problem-selected` (×3) → canonical dir

## Testing

- `bash -n` passes on all changed scripts.
- Resolver converges to the main-checkout dir from both a worktree and the main checkout (above).
- End-to-end increment simulation (drop signals into the canonical dir, run the daemon's count+`jq`):

  ```
  BEFORE: {"entries_enriched":0,...,"deployments":23,"research_completed":0}
  AFTER:  {"entries_enriched":1,...,"deployments":24,"research_completed":1}
  ```

## Scope

Scoped to stats-signal **routing** only. Does **not** touch
`update_daemon_state`'s state-file existence / self-heal handling, which is
#41048 (worked concurrently).

`scripts/erdos/claim-stub.sh` emits `stub-enhanced-*`, but the daemon does not
count that signal type and the Erdos Enhancer is legacy/complete, so it is
intentionally left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
