### PR TITLE
fix(erdos-438): remove phantom axiom names from originalContributions/sections

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13618,9 +13618,9 @@
     },
     "erdos-438": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:44Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T04:21:40Z",
+      "result": "issues-fixed"
     },
     "erdos-439": {
       "agentId": "auditor-agent-claude-2026-05-27",

--- a/src/data/proofs/erdos-438/meta.json
+++ b/src/data/proofs/erdos-438/meta.json
@@ -59,13 +59,13 @@
     ],
     "originalContributions": [
       "Definition of IsSquare, sumset, IsSquareFreeSumset, maxSquareFreeDensity",
-      "Mod 3 construction and correctness axioms",
+      "Section header for a simple mod-3 construction (Part 2 is an empty banner; no declarations)",
       "Massias residues definition and construction",
       "Axiom: massias_construction_works (square-free property)",
-      "Axiom: los_upper_bound (0.475N, Lagarias-Odlyzko-Shearer)",
+      "Lagarias-Odlyzko-Shearer 0.475N bound noted in source comments only (no Lean declaration)",
       "Axiom: kls_theorem (11/32 tight bound, Khalfalah-Lodha-Szemerédi)",
       "Definition: squares_mod_32 with proved cardinality (native_decide)",
-      "Axiom: massias_avoids_squares and massias_is_maximal (optimality)",
+      "Axiom: massias_is_maximal (optimality: at most 11 residues mod 32 avoid square sums)",
       "Summary theorem combining construction, upper bound, and maximality"
     ],
     "mathContext": {
@@ -156,7 +156,7 @@
       "title": "Simple mod $3$ Construction",
       "startLine": 58,
       "endLine": 74,
-      "summary": "Axiomatizes: squares are $0$ or $1 \\pmod{3}$, so $\\{n : n \\equiv 1 \\pmod{3}\\}$ gives square-free sumset (since $1+1 \\equiv 2 \\pmod{3}$). Achieves density $\\approx N/3$."
+      "summary": "Empty section banner (no declarations). The mathematical remark — squares are $0$ or $1 \\pmod{3}$, so $\\{n : n \\equiv 1 \\pmod{3}\\}$ gives a square-free sumset of density $\\approx N/3$ — is not formalized in the file."
     },
     {
       "id": "massias",


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-438 (reserve mode)

**Result:** issues-fixed (LOW–MEDIUM — phantom narrative; counts honest).

Correctly Tier-C: `badge=axiom`, `status=axiomatized`, **3 axioms** (massias_construction_works, kls_theorem, massias_is_maximal), **0 sorries**, 2 thm / 7 def — all verified. The one `native_decide` (named `squares_mod_32_count`) is properly disclosed in originalContributions/keyTechniques/proofStrategy.

**Issue — narrative names axioms that do not exist:**
- originalContributions: `Axiom: los_upper_bound` — no such declaration (only a `[LOS83]` source comment; the "Upper Bounds" section itself already notes "no Lean declaration exists").
- originalContributions: `massias_avoids_squares` — no such axiom.
- originalContributions: "Mod 3 construction and correctness axioms" — Part 2 is an empty section banner with no declarations.
- Section "Simple mod 3 Construction": claims it "Axiomatizes" the mod-3 fact, but the part contains no declarations.

axiomCount (3) is honest; the narrative implied 5–6 axioms.

**Fix:** corrected the entries to reflect the 3 real axioms; the LOS bound and mod-3 remark are now described as commentary only. No code, count, badge, or status changes. Includes the audit-tracker completion entry.

---
Discovered during gallery integrity audit.