### PR TITLE
fix(erdos-427): correct false 'verified examples' + axiom-as-theorem mislabel

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13525,9 +13525,9 @@
     },
     "erdos-427": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:44Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T04:30:13Z",
+      "result": "issues-fixed"
     },
     "erdos-428": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-427/meta.json
+++ b/src/data/proofs/erdos-427/meta.json
@@ -56,8 +56,8 @@
       "Definition of primeSum for consecutive prime sums",
       "Formal statement of Erdős #427 as erdos_427_statement",
       "Statement of Shiu's theorem on strings of congruent primes",
-      "Theorem connecting Shiu to Erdős #427 (erdos_427_of_shiu)",
-      "Verified examples: 2+3=5 divisible by 5, sum of first 9 primes = 100 divisible by 10",
+      "Axiom connecting Shiu to Erdős #427 (erdos_427_of_shiu — Pilatte's reduction is axiomatized, not proved)",
+      "Illustrative arithmetic examples in comments only (e.g. 2+3=5, first 9 primes sum to 100); not Lean-verified, since nthPrime is an uninterpreted axiom with no value assignments",
       "Connection to Dirichlet's theorem on primes in arithmetic progressions"
     ],
     "axiomCount": 3,
@@ -75,7 +75,7 @@
       "**Shiu's theorem is the key**: This deep result about prime distribution shows that primes can appear in arbitrarily long consecutive runs within any arithmetic progression. It vastly strengthens Dirichlet's theorem.",
       "**The 'steering' argument**: By finding a block of consecutive primes all congruent to 1 (mod d), we can add exactly the right number of them to make the total sum divisible by d. This is Pilatte's elegant observation.",
       "**Why a = 1 works**: We use gcd(1, d) = 1 for any d, so Shiu applies. Primes congruent to 1 (mod d) are 'neutral' - adding k of them increases the sum by exactly k (mod d).",
-      "**Computational verification**: Small cases can be checked directly. For d = 5: 2+3 = 5. For d = 7: 2+3+5+7+11 = 28 = 4*7. For d = 10: first 9 primes sum to 100.",
+      "**Illustrative small cases** (arithmetic shown in comments, not machine-checked — nthPrime is an uninterpreted axiom): d = 5: 2+3 = 5; d = 7: 2+3+5+7+11 = 28 = 4*7; d = 10: first 9 primes sum to 100.",
       "**Connection to Dirichlet**: Dirichlet's theorem (1837) showed infinitely many primes in each arithmetic progression. Shiu (2000) showed consecutive primes can cluster in progressions, a much stronger statement.",
       "**The problem illustrates prime 'randomness'**: Primes behave sufficiently 'randomly' modulo d that their sums hit all residue classes, but proving this rigorously requires sophisticated tools like Shiu's theorem."
     ],


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-427 (reserve mode)

**Result:** issues-fixed (MEDIUM — false verification claim).

Counts verified: **3 axioms** (nthPrime, shiu_theorem, erdos_427_of_shiu), **0 sorries**, 7 thm / 5 def, no native_decide. The axiom set is consistent (the real prime function models `shiu_theorem` and Pilatte's reduction). Honest Tier-C: status=axiomatized, badge=axiom, and `assumptions` correctly lists all 3 axioms.

**Issue — claims verification that does not (and cannot) exist:**
- `originalContributions`: "Verified examples: 2+3=5 divisible by 5, sum of first 9 primes = 100 divisible by 10" and `keyInsights`: "Computational verification: Small cases can be checked directly." But these examples are **comment-only** (lines 168-188) — there are no Lean `example`s — and they are **unprovable** in this file because `nthPrime` is an *uninterpreted* axiom with no value assignments (`nthPrime 0 = 2` is not derivable, so `primeSum` cannot be evaluated).
- `originalContributions` called `erdos_427_of_shiu` a "Theorem," but it is an `axiom` (line 154 — Pilatte's reduction is axiomatized, not proved). `assumptions` already labels it correctly.

### Fix
Reworded the two "verified/computational" claims to "illustrative arithmetic in comments, not machine-checked (nthPrime is uninterpreted)"; relabeled `erdos_427_of_shiu` as an axiom. No code, count, badge, or status changes.

---
Discovered during gallery integrity audit.