### PR TITLE
Research: blocked-route registry for saturated RICH cyclers (erdos-16, erdos-64)

### DIFF
--- a/src/data/research/problems/erdos-16-wip-01.json
+++ b/src/data/research/problems/erdos-16-wip-01.json
@@ -21,9 +21,20 @@
     "phase": "ACT",
     "since": "2026-07-09T17:33:18-07:00",
     "iteration": 4,
-    "focus": "Session 4: formalized the covering-congruence obstruction mechanism (Erdős 1950 gear + 2 concrete instances).",
-    "blockers": [],
-    "nextAction": "CRT-assemble the individual covering gears over a full covering system of the exponent to force an infinite arithmetic progression into the exceptional set (formalizing Erdős 1950). Needs order-of-2 facts for primes 5,13,17,241 and CRT packaging — substantial but analytic-free.",
+    "focus": "Covering-congruence layer COMPLETE (Erdős 1950 in full, PR #40830, verified 0-axiom/0-sorry): exceptionalSet_infinite (the CRT progression n ≡ 7629217 mod 11184810 forced into ExceptionalSet via six order-of-2 covering gears + window confinement) and exists_exceptional_gt. Supersedes the stale nextAction below, which described this completed work as pending.",
+    "blockers": [
+      {
+        "route": "Romanoff 1934: {2^k+p} has positive lower density among the odds",
+        "reopenCriterion": "materially new mechanism required: analytic number theory (sieve + PNT / additive density), not covering-congruence — absent from Mathlib v4.31.",
+        "blockedAt": "2026-07-21"
+      },
+      {
+        "route": "Chen 2023: ExceptionalSet is richer than one AP plus a density-0 set",
+        "reopenCriterion": "materially new mechanism required: fine structure of the exceptional set beyond the single covering progression.",
+        "blockedAt": "2026-07-21"
+      }
+    ],
+    "nextAction": "STAND DOWN on elementary/covering work — Erdős 1950 is fully formalized. Remaining directions are deep-analytic (recorded as blockers): Romanoff 1934 positive density and Chen 2023 exceptional-set structure.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -93,7 +104,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.779Z",
-  "lastUpdate": "2026-07-10T00:41:25.926Z",
+  "lastUpdate": "2026-07-21",
   "significance": 7,
   "tractability": 5
 }

--- a/src/data/research/problems/erdos-64-wip-01.json
+++ b/src/data/research/problems/erdos-64-wip-01.json
@@ -22,7 +22,13 @@
     "since": "2026-07-09T17:33:20-07:00",
     "iteration": 2,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
-    "blockers": [],
+    "blockers": [
+      {
+        "route": "power-of-two cycle LENGTH: every finite graph with min-degree ≥ 3 contains a cycle of length 2^k",
+        "reopenCriterion": "materially new mechanism required: Liu–Montgomery-scale extremal/expansion machinery. Elementary cycle-EXISTENCE (a cycle exists at all, for every finite min-degree-≥2 graph) is COMPLETE (PRs #40522/#40874/#40917); the 2^k-length core is the open $1000 problem.",
+        "blockedAt": "2026-07-21"
+      }
+    ],
     "nextAction": "Open power-of-2 cycle length remains the mission; base cycle-existence infrastructure is complete for all finite graphs.",
     "attemptCounts": {
       "total": 0,


### PR DESCRIPTION
## Summary
Two RICH depth-first problems whose elementary layers are **verified complete** but whose trackers under-documented the frontier — causing the depth-first selector to re-serve them, and (for erdos-16) presenting already-completed work as pending. No code change.

## erdos-16-wip-01 (Erdős #16: odd `n ≠ 2^k + p`)
Erdős 1950 is **fully formalized**: `exceptionalSet_infinite` (PR #40830, 0-axiom/0-sorry) — the CRT progression `n ≡ 7629217 (mod 11184810)` forced into `ExceptionalSet` via six order-of-2 covering gears + window confinement, plus `exists_exceptional_gt`.
- Fixes the stale `nextAction` (described the completed CRT covering assembly as pending).
- Records the two deep-analytic blockers: **Romanoff 1934** (positive density of `{2^k+p}`) and **Chen 2023** (exceptional-set structure).

## erdos-64-wip-01 (Erdős #64: min-degree-3 ⟹ `2^k`-length cycle, $1000)
Elementary cycle-**existence** is complete (PRs #40522/#40874/#40917: every finite min-degree-≥2 graph has a cycle). Records the deep power-of-2-**length** core (Liu–Montgomery scale) as a structured blocker.

## Status
**Outcome**: surveyed / blocked (documented saturation + metadata correctness fix)
**Next Steps**: stand down; reopen per a blocker reopen criterion.

🤖 Generated by researcher-1
