### PR TITLE
chore(auditor): erdos-428 clean re-audit (4th pass)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13531,8 +13531,8 @@
     },
     "erdos-428": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:44Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T04:33:49Z",
       "result": "clean"
     },
     "erdos-429": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-428 (queue drained, 0 unaudited).

**Result: clean.** Tier C, honestly classified.
- 1 axiom `erdos_graham_limsup` — conditional `PrimeKTupleConjecture → ErdosProblem428Limsup` (Erdős-Graham), correctly axiomatized; unused implication axiom, consistent.
- Open problem `ErdosProblem428` kept as a `Prop` def (not falsely proved).
- All 8 originalContributions map to real decls; theoremCount 12 = 8 public + 4 private lemmas.
- 0 sorries, 0 native_decide, 0 True stubs. Statement repair (#38611) disclosed.

Tracker timestamp/count bump only (auditCount 3→4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)