### PR TITLE
fix(erdos-421): disclose native_decide (ofReduceBool) in two counterexample theorems

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13483,9 +13483,9 @@
     },
     "erdos-421": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:44Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T04:36:35Z",
+      "result": "issues-fixed"
     },
     "erdos-422": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-421/meta.json
+++ b/src/data/proofs/erdos-421/meta.json
@@ -62,7 +62,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 591,
-    "assumptions": "1 axiom: selfridge_construction (deep result). 0 sorries — all lemmas fully proved.",
+    "assumptions": "1 axiom: selfridge_construction (deep result). 0 sorries. Additionally, two counterexample theorems (natSeq_not_distinct, pow2Seq_not_distinct) verify concrete interval-product collisions via native_decide, which adds the Lean.ofReduceBool compiler-trust axiom to those results; the main results do not depend on them.",
     "theoremCount": 25,
     "definitionCount": 20
   },


### PR DESCRIPTION
## Integrity fix (LOW severity)

**Proof**: erdos-421 (Distinct Products in Dense Sequences)

**Problem**: Two named theorems — `natSeq_not_distinct` and `pow2Seq_not_distinct` — prove concrete interval-product collisions via `native_decide`, which introduces the `Lean.ofReduceBool` compiler-trust axiom into those results. The `assumptions` field said "0 sorries — all lemmas fully proved" with no mention of the compiler-trust dependency.

**Fix**: Updated `assumptions` to disclose the native_decide usage and note that the main results do not depend on those two theorems — matching the established house style (cf. erdos-56, erdos-646, erdos-648).

Rest of the audit is clean: `ErdosConjecture421` kept as a `Prop` def (open, not falsely proved), 25 theorems = theoremCount, 1 axiom (`selfridge_construction`) = axiomCount, all originalContributions map to real decls.

Meta-only change + tracker bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)