### PR TITLE
fix(erdos-420): rational exponent 4/9 parsed as Nat=0, axiom formalized wrong function

### DIFF
--- a/proofs/Proofs/Erdos420Problem.lean
+++ b/proofs/Proofs/Erdos420Problem.lean
@@ -31,6 +31,7 @@ import Mathlib.NumberTheory.Divisors
 import Mathlib.Data.Nat.Factorial.Basic
 import Mathlib.Data.Real.Basic
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Order.Interval.Set.Basic
 
 open Nat BigOperators Finset Real
@@ -145,7 +146,7 @@ lim_{n→∞} F(n^{4/9}, n) = ∞
 The exponent 4/9 can be improved slightly.
 -/
 axiom four_ninths_gives_infinity :
-    ∀ M : ℝ, ∃ N : ℕ, ∀ n : ℕ, n ≥ N → F (fun n => (n : ℝ)^(4/9)) n > M
+    ∀ M : ℝ, ∃ N : ℕ, ∀ n : ℕ, n ≥ N → F (fun n => (n : ℝ) ^ ((4 : ℝ) / 9)) n > M
 
 /- 
 **EGIP96 Theorem 3:**
@@ -227,7 +228,7 @@ theorem erdos_420 :
     -- lim F(√n, n) = ∞
     (∀ M : ℝ, ∃ N : ℕ, ∀ n : ℕ, n ≥ N → F (fun n => Real.sqrt n) n > M) ∧
     -- lim F(n^{4/9}, n) = ∞
-    (∀ M : ℝ, ∃ N : ℕ, ∀ n : ℕ, n ≥ N → F (fun n => (n : ℝ)^(4/9)) n > M) :=
+    (∀ M : ℝ, ∃ N : ℕ, ∀ n : ℕ, n ≥ N → F (fun n => (n : ℝ) ^ ((4 : ℝ) / 9)) n > M) :=
   ⟨sqrt_gives_infinity, four_ninths_gives_infinity⟩
 
 /-
@@ -269,7 +270,7 @@ for any g(n) → ∞.
 theorem erdos_420_summary :
     -- F(√n, n) → ∞ and F(n^{4/9}, n) → ∞
     (∀ M : ℝ, ∃ N : ℕ, ∀ n : ℕ, n ≥ N → F (fun n => Real.sqrt n) n > M) ∧
-    (∀ M : ℝ, ∃ N : ℕ, ∀ n : ℕ, n ≥ N → F (fun n => (n : ℝ)^(4/9)) n > M) ∧
+    (∀ M : ℝ, ∃ N : ℕ, ∀ n : ℕ, n ≥ N → F (fun n => (n : ℝ) ^ ((4 : ℝ) / 9)) n > M) ∧
     -- Bounded gaps consequence
     (∀ g : ℕ → ℝ, (∀ M, ∃ N, ∀ n ≥ N, g n > M) →
       ∀ M : ℝ, ∃ᶠ n in Filter.atTop, F g n > M) :=

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13477,9 +13477,9 @@
     },
     "erdos-420": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:45Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T04:41:17Z",
+      "result": "issues-fixed"
     },
     "erdos-421": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Integrity fix (formalization defect)

**Proof**: erdos-420 (Divisor Function Ratios for Factorials)

**Problem**: The axiom `four_ninths_gives_infinity` and the headline theorems `erdos_420` / `erdos_420_summary` were written with `(n : ℝ)^(4/9)`. Lean elaborated the unascripted literal `4/9` as **ℕ**, so `4/9 = 0` and the function was `(n:ℝ)^0 = 1` — **not** `n^{4/9}`.

Consequence: instead of the intended (true) EGIP96 result `lim F(n^{4/9}, n) = ∞`, the axiom actually asserted `F(fun _ => 1, n) → ∞`, i.e. `τ((n+1)!)/τ(n!) → ∞`. That statement is **false** — the ratio equals 2 at every prime step (n+1 prime ⇒ τ((n+1)!) = 2·τ(n!)), so it does not tend to ∞.

**Verification**: `example : (fun n : ℕ => (n:ℝ)^(4/9)) = (fun _ => 1) := by funext n; norm_num` compiles, and `#check` reports `(4/9 : ℕ)`.

**Fix**: Exponent written as `(4 : ℝ)/9` (real division → `Real.rpow`), plus the `Mathlib.Analysis.SpecialFunctions.Pow.Real` import for the `HPow ℝ ℝ ℝ` instance. File now compiles cleanly (`lake env lean`, exit 0) and the axiom genuinely formalizes the `n^{4/9}` result.

Meta needs no change (it already described the intended n^{4/9} result; counts stay 4 axioms / 5 theorems / 0 sorries). Rest of audit clean: all originalContributions map to real decls, other 3 axioms consistent, Tier C badge correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)