### PR TITLE
Fix stale annotation proofId in bezout-identity-oq007

### DIFF
--- a/src/data/proofs/bezout-identity-oq007/annotations.json
+++ b/src/data/proofs/bezout-identity-oq007/annotations.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "ann-bezout-fp-header",
-    "proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-02",
+    "proofId": "bezout-identity-oq007",
     "range": { "startLine": 1, "endLine": 50 },
     "type": "concept",
     "title": "Making Abstract Factorization Explicit over 𝔽_p and ℚ",
@@ -23,7 +23,7 @@
   },
   {
     "id": "ann-bezout-fp-fermat",
-    "proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-02",
+    "proofId": "bezout-identity-oq007",
     "range": { "startLine": 51, "endLine": 73 },
     "type": "insight",
     "title": "From Root Multiset to Product Factorization",
@@ -40,7 +40,7 @@
   },
   {
     "id": "ann-bezout-fp-zmod",
-    "proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-02",
+    "proofId": "bezout-identity-oq007",
     "range": { "startLine": 74, "endLine": 90 },
     "type": "technique",
     "title": "Specializing to 𝔽_p in One Rewrite",
@@ -57,7 +57,7 @@
   },
   {
     "id": "ann-bezout-fp-frobenius",
-    "proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-02",
+    "proofId": "bezout-identity-oq007",
     "range": { "startLine": 91, "endLine": 100 },
     "type": "insight",
     "title": "The Frobenius Collapse: One Root, Multiplicity p",
@@ -74,7 +74,7 @@
   },
   {
     "id": "ann-bezout-fp-contrast",
-    "proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-02",
+    "proofId": "bezout-identity-oq007",
     "range": { "startLine": 102, "endLine": 128 },
     "type": "insight",
     "title": "Where Fermat Factorization Fails: ℚ vs 𝔽_p",


### PR DESCRIPTION
## Data-integrity fix (no content inflation)

`bezout-identity-oq007` is already at quality target (deep historicalContext, 5 full annotations, complete section coverage, accurate `verified`/`axiomCount: 0`). Rather than inflate it, this PR repairs a real defect.

**Problem:** all 5 annotations in `annotations.json` carried `"proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-02"` — the pre-rename folder name, which no longer exists. The folder and `meta.id`/`slug` are `bezout-identity-oq007`.

**Why it matters:** every other gallery entry's annotation `proofId` matches its folder slug, and the field keys the comment system (`CommentSection` → `fetchComments(proofId, …)`), so comments filed from these annotations bound to a non-existent proof id.

**Change:** realign all 5 `proofId` values to `bezout-identity-oq007`. JSON validated with `node`. No other fields touched.
