### PR TITLE
Research: erdos-326-wip-01 — growth-limit tail-invariance + sub-quadratic ⟹ limit 0 (3 axiom-free thms)

### DIFF
--- a/proofs/Proofs/Erdos326WIP01.lean
+++ b/proofs/Proofs/Erdos326WIP01.lean
@@ -33,7 +33,13 @@ ratio and its limit:
   `HasNoGrowthLimit` — the reusable engine behind the oscillation direction;
 * both growth-limit predicates are non-vacuous: an exactly-quadratic
   enumeration `bₖ = c·k²` has growth limit `c`, while an enumeration whose
-  quadratic coefficient oscillates between `1` and `2` has **no** growth limit.
+  quadratic coefficient oscillates between `1` and `2` has **no** growth limit;
+* the growth limit is a **tail invariant** (`hasGrowthLimit_congr'`: agreeing
+  eventually ⟹ same growth-limit behaviour), and a **sub-quadratically**
+  enumerated sequence `bₖ ≤ C·k` has growth limit `0`
+  (`hasGrowthLimit_zero_of_linear_bound`, with the identity enumeration `bₖ = k`
+  as concrete order-`1` witness) — so non-convergence requires honestly
+  quadratic growth.
 
 All results are `0`-axiom / `0`-sorry.
 
@@ -579,5 +585,66 @@ theorem hasNoGrowthLimit_oscillating : HasNoGrowthLimit oscillating := by
   have hx1 : x = 1 := tendsto_nhds_unique heven heven1
   rw [hx2] at hx1
   norm_num at hx1
+
+/-! ## The growth limit is a tail invariant; sub-quadratic growth ⟹ limit `0`
+
+Two structural facts complementing the convergent (`hasGrowthLimit_quadratic`)
+and non-convergent (`hasNoGrowthLimit_oscillating`) examples above:
+
+* the growth limit depends only on the **tail** of the enumeration — two
+  sequences that agree eventually have the same growth-limit behaviour
+  (`hasGrowthLimit_congr'`).  This is exactly what makes modifying a basis on a
+  finite prefix irrelevant to its `bₖ/k²` limit, a prerequisite for any
+  sub-basis argument;
+* a **sub-quadratically** enumerated sequence converges — to `0`.  If `bₖ ≤ C·k`
+  (linear growth, as for an order-`1` basis such as `ℕ` itself) then
+  `bₖ/k² ≤ C/k → 0`, so `HasGrowthLimit b 0` (`hasGrowthLimit_zero_of_linear_bound`),
+  realized concretely by the identity enumeration `bₖ = k`
+  (`hasGrowthLimit_id_zero`).  So genuine non-convergence à la Erdős #326 can only
+  arise from honestly quadratic growth — the ratio cannot oscillate while the
+  numerator stays `o(k²)`.
+
+All results remain `0`-axiom / `0`-sorry. -/
+
+/-- **The growth limit is a tail invariant.**  If two enumerations agree
+eventually (`b =ᶠ[atTop] b'`) then their growth ratios agree eventually, so one
+has growth limit `x` iff the other does.  In particular modifying an enumeration
+on finitely many indices leaves every growth-limit statement unchanged. -/
+theorem hasGrowthLimit_congr' {b b' : ℕ → ℕ} {x : ℝ} (h : b =ᶠ[atTop] b') :
+    HasGrowthLimit b x ↔ HasGrowthLimit b' x := by
+  have hg : growthRatio b =ᶠ[atTop] growthRatio b' := by
+    filter_upwards [h] with k hk
+    simp only [growthRatio, hk]
+  unfold HasGrowthLimit
+  exact ⟨fun H => H.congr' hg, fun H => H.congr' hg.symm⟩
+
+/-- **A sub-quadratically enumerated sequence has growth limit `0`.**  If
+`bₖ ≤ C·k` for all `k` (linear growth), then `bₖ/k² ≤ C/k → 0`, and since the
+ratio is nonnegative the squeeze gives `HasGrowthLimit b 0`.  This is the
+convergent-to-`0` counterpart of `hasGrowthLimit_quadratic`: a numerator that is
+`O(k)` cannot make the ratio oscillate or diverge. -/
+theorem hasGrowthLimit_zero_of_linear_bound (b : ℕ → ℕ) (C : ℕ)
+    (h : ∀ k, b k ≤ C * k) : HasGrowthLimit b 0 := by
+  have hle : ∀ k, growthRatio b k ≤ (C : ℝ) / k := by
+    intro k
+    rcases Nat.eq_zero_or_pos k with hk | hk
+    · subst hk; simp [growthRatio_zero]
+    · have hkR : (0 : ℝ) < (k : ℝ) := by exact_mod_cast hk
+      have hkne : (k : ℝ) ≠ 0 := ne_of_gt hkR
+      have hbk : (b k : ℝ) ≤ (C : ℝ) * k := by exact_mod_cast h k
+      rw [growthRatio]
+      calc (b k : ℝ) / (k : ℝ) ^ 2 ≤ (C : ℝ) * k / (k : ℝ) ^ 2 := by gcongr
+        _ = (C : ℝ) / k := by rw [pow_two, mul_div_mul_right _ _ hkne]
+  refine squeeze_zero (growthRatio_nonneg b) hle ?_
+  exact tendsto_const_div_atTop_nhds_zero_nat _
+
+/-- **Concrete convergent order-`1` enumeration.**  The identity enumeration
+`bₖ = k` — the increasing enumeration of `ℕ` itself, an order-`1` additive basis
+(`isAddBasisOfOrder_univ_one`) — has growth ratio `k/k² = 1/k → 0`, hence growth
+limit `0`.  Contrast `hasGrowthLimit_quadratic` (limit `c`) and
+`hasNoGrowthLimit_oscillating` (no limit): sparser (linear) bases sit at the
+`0` end of the growth spectrum. -/
+theorem hasGrowthLimit_id_zero : HasGrowthLimit (fun k => k) 0 :=
+  hasGrowthLimit_zero_of_linear_bound _ 1 (fun k => by simp)
 
 end Erdos326

--- a/research/problems/erdos-326-wip-01/knowledge.md
+++ b/research/problems/erdos-326-wip-01/knowledge.md
@@ -182,3 +182,38 @@ count↔nth bridge (no `Infinite` hypothesis). `nlinarith [hk]` closes
 
 The elementary density/growth-upper-bound layer is now **saturated**; only the
 deep oscillation dichotomy remains open.
+
+## Session 2026-07-21 (researcher-1) — tail-invariance + sub-quadratic ⟹ limit 0
+
+Added 3 axiom-free theorems to `Erdos326WIP01.lean` (host-verified v4.31.0 via
+fresh-parent-olean; `#print axioms` = propext/Classical.choice/Quot.sound on all three;
+theoremCount → 34 `theorem`/`lemma` decls). Fleshes out the growth-limit *spectrum*
+complementing the existing convergent (`hasGrowthLimit_quadratic`, limit `c`) and
+non-convergent (`hasNoGrowthLimit_oscillating`) examples:
+
+- `hasGrowthLimit_congr' {b b'} (h : b =ᶠ[atTop] b') : HasGrowthLimit b x ↔ HasGrowthLimit b' x`
+  — the growth limit is a **tail invariant**. Proof: `b =ᶠ b'` ⟹ `growthRatio b =ᶠ growthRatio b'`
+  (`filter_upwards … simp [growthRatio, hk]`), then `Tendsto.congr'` both ways. This is the
+  prerequisite that modifying a basis on a finite prefix cannot change its `bₖ/k²` limit — needed
+  by any future sub-basis construction.
+- `hasGrowthLimit_zero_of_linear_bound (b C) (h : ∀ k, b k ≤ C*k) : HasGrowthLimit b 0`
+  — a **sub-quadratically** enumerated sequence converges to 0. Proof: `growthRatio b k ≤ C/k`
+  (gcongr on numerator `b k ≤ C·k`, then `mul_div_mul_right` to collapse `C·k/k² = C/k`), squeeze
+  between `growthRatio_nonneg` and `tendsto_const_div_atTop_nhds_zero_nat`.
+- `hasGrowthLimit_id_zero : HasGrowthLimit (fun k => k) 0` — concrete order-1 witness (identity
+  enumeration bₖ=k, ℕ itself is an order-1 basis). Sits at the `0` end of the growth spectrum.
+
+**Take-away for the OPEN direction:** genuine non-convergence à la #326 can only arise from
+honestly quadratic growth — the ratio cannot oscillate/diverge while the numerator stays `o(k²)`.
+
+### Idioms / gotchas
+- `div_le_div_iff` is GONE (unknown identifier) in v4.31 — do the numerator comparison with `gcongr`
+  and collapse the fraction with `mul_div_mul_right a b (hc : c ≠ 0) : a*c/(b*c) = a/b`
+  (after `rw [pow_two]`) instead of a single cross-multiply lemma.
+- `tendsto_const_div_atTop_nhds_zero_nat (C : ℝ) : Tendsto (fun n : ℕ => C/n) atTop (𝓝 0)` exists —
+  the clean base for squeeze-to-zero of `k`-indexed ratios.
+- Same fresh-parent-olean host-verify recipe: `lake env lean -o …/Proofs/Erdos326Problem.olean
+  Proofs/Erdos326Problem.lean` first (parent is Mathlib-only), then `lake env lean Proofs/Erdos326WIP01.lean`.
+
+### Remaining open (unchanged)
+- The subset-basis oscillation dichotomy (deep, structured blocker: materially new mechanism required).

--- a/src/data/research/problems/erdos-326-wip-01.json
+++ b/src/data/research/problems/erdos-326-wip-01.json
@@ -26,9 +26,9 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-07-20T13:00:00-07:00",
-    "iteration": 3,
-    "focus": "Axiom-free foundational lemmas on IsAddBasis / IsAddBasisOfOrder / growthRatio.",
+    "since": "2026-07-21T22:00:00-07:00",
+    "iteration": 4,
+    "focus": "Axiom-free foundational lemmas on IsAddBasis / IsAddBasisOfOrder / growthRatio and its limit.",
     "blockers": [
       {
         "route": "the subset-basis oscillation dichotomy via elementary density",
@@ -36,9 +36,9 @@
         "blockedAt": "2026-07-20"
       }
     ],
-    "nextAction": "Elementary density/growth-upper-bound layer is now saturated (√n density + b_k=O(k^2) both machine-checked). Only the deep oscillation dichotomy (materially new mechanism required) remains open.",
+    "nextAction": "Growth-ratio limit layer now records: boundedness (b_k=O(k^2)), a two-subsequence non-convergence criterion, non-vacuity of both limit predicates, and (this session) tail-invariance of the growth limit plus sub-quadratic (linear) growth => limit 0. Only the deep oscillation dichotomy (materially new mechanism required) remains open.",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 1,
       "approachesTried": 1
     }


### PR DESCRIPTION
## Summary

Advances **erdos-326-wip-01** (Erdős #326 — additive bases and non-convergent `bₖ/k²`) with **3 axiom-free, host-verified** theorems that flesh out the growth-limit spectrum in `proofs/Proofs/Erdos326WIP01.lean`.

The deep OPEN core (subset-basis oscillation dichotomy) is untouched and remains a structured blocker; this session strengthens the elementary layer around `HasGrowthLimit`.

## New theorems (all `#print axioms` = propext / Classical.choice / Quot.sound)

- `hasGrowthLimit_congr'` — the growth limit is a **tail invariant**: enumerations agreeing eventually (`b =ᶠ[atTop] b'`) share growth-limit behaviour. Prerequisite for any sub-basis argument that alters a finite prefix.
- `hasGrowthLimit_zero_of_linear_bound` — a **sub-quadratically** enumerated sequence (`bₖ ≤ C·k`) has growth limit `0`, via the squeeze `0 ≤ bₖ/k² ≤ C/k → 0`.
- `hasGrowthLimit_id_zero` — concrete order-`1` witness (identity enumeration `bₖ = k`).

Together with the existing `hasGrowthLimit_quadratic` (limit `c`) and `hasNoGrowthLimit_oscillating` (no limit), these pin the take-away: **non-convergence à la #326 requires honestly quadratic growth** — the ratio cannot oscillate or diverge while the numerator stays `o(k²)`.

## Verification

- Host-verified under Lean v4.31.0 via the fresh-parent-olean recipe (rebuild Mathlib-only parent `Erdos326Problem.olean`, then typecheck the child). Child compiles with **0 errors / 0 sorries / 0 warnings**.
- `#print axioms` confirms all three new results are axiom-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
