### PR TITLE
Fix: erdos-417 replace native_decide with kernel-checked totient_prime

### DIFF
--- a/proofs/Proofs/Erdos417Problem.lean
+++ b/proofs/Proofs/Erdos417Problem.lean
@@ -96,7 +96,7 @@ theorem two_is_totient_value : IsTotientValue 2 := by
   use 3
   constructor
   · omega
-  · native_decide
+  · exact totient_prime (show Nat.Prime 3 by norm_num)
 
 /-- Odd numbers > 1 are not totient values.
 
@@ -139,7 +139,7 @@ theorem four_is_totient_value : IsTotientValue 4 := by
   use 5
   constructor
   · omega
-  · native_decide
+  · exact totient_prime (show Nat.Prime 5 by norm_num)
 
 /-- V'(x) ≥ 1 for x ≥ 1: since φ(1) = 1, the value 1 is always in the image. -/
 theorem V'_pos (x : ℕ) (hx : x ≥ 1) : V' x ≥ 1 := by


### PR DESCRIPTION
## Problem

Issue #41068: two **named public theorems** in `proofs/Proofs/Erdos417Problem.lean` were proved with `native_decide`:

- `two_is_totient_value` (line 99) — `totient 3 = 2`
- `four_is_totient_value` (line 142) — `totient 5 = 4`

Because they are named (not anonymous `example`s), `#print axioms` reports `Lean.ofReduceBool` for them and any dependents. `meta.json` `assumptions` disclosed only the single open-conjecture axiom, understating the trust base.

## Fix

Both 3 and 5 are prime, so `totient p = p - 1` by `Nat.totient_prime` — a kernel-checked rewrite that mirrors the file's existing `prime_pred_totient_value` idiom (line 233-235):

```lean
-- before
· native_decide
-- after
· exact totient_prime (show Nat.Prime 3 by norm_num)   -- resp. Nat.Prime 5
```

This eliminates the `Lean.ofReduceBool` dependency entirely, so no `meta.json` disclosure is needed — the existing `assumptions` (1 axiom, 0 sorries) stays accurate.

## Evidence

Docker build clean:
```
⚠ [8576/8576] Built Proofs.Erdos417Problem (19s)
Build completed successfully (8576 jobs).
```
(Only warning is a pre-existing `push_neg` deprecation at line 115, unrelated.)

Closes #41068
