### PR TITLE
Enrich erdos-416: fix phantom 'axiomatized' narrative + disclose native_decide

### DIFF
--- a/src/data/proofs/erdos-416/meta.json
+++ b/src/data/proofs/erdos-416/meta.json
@@ -23,7 +23,7 @@
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/416",
     "date": "",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos416Problem.lean",
     "tags": [
       "erdos",
@@ -39,7 +39,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 0,
     "lineCount": 148,
-    "assumptions": "No axioms. Historical bounds and open questions are stated as definitions/Prop, not axiom declarations.",
+    "assumptions": "No `axiom` declarations. The four historical bounds (Pillai, Erdős, Maier–Pomerance, Ford) appear only as `/- ... -/` comment blocks — they are neither axiomatized nor formally stated. The open questions are `Prop` definitions (`Tendsto`), stated but not proved. Two small witness lemmas (`two_is_totient`, `four_is_totient`) are discharged by `native_decide`, which relies on the `Lean.ofReduceBool` axiom (trust shifts from the kernel to compiled code for those two existence checks).",
     "mathlib_version": "4.31.0",
     "theoremCount": 6,
     "definitionCount": 4
@@ -48,7 +48,7 @@
     "historicalContext": "This problem concerns the **range of Euler's totient function** $\\varphi$. Not every positive integer is a totient value — for instance, $\\varphi(m)$ is even for all $m > 2$, so 3, 5, 7, ... are never totient values (the only odd totient value is 1).\n\n**Pillai (1929)** first proved that totient values have density 0: $V(x) = o(x)$, meaning most integers are not in the image of $\\varphi$. **Erdős (1935)** refined this to $V(x) = x \\cdot (\\log x)^{-1+o(1)}$, showing the density decays like $1/\\log x$ up to sub-polynomial corrections.\n\n**Maier and Pomerance (1988)** achieved a more precise formula: $V(x) = \\frac{x}{\\log x} \\cdot e^{(C+o(1))(\\log\\log\\log x)^2}$ for an explicit constant $C > 0$, revealing that the correction factor involves the triple logarithm. **Kevin Ford (1998)** obtained the tightest known bounds in his paper \"The distribution of totients\" (Ramanujan Journal), determining $V(x)$ up to constant factors with a formula involving $\\log\\log\\log x$ and $\\log\\log\\log\\log x$.\n\nDespite these remarkable results, the two specific questions Erdős asked remain open: whether $V(2x)/V(x) \\to 2$ (the doubling ratio) and whether an asymptotic formula $V(x) \\sim f(x)$ exists. Ford's $\\Theta$-bounds are not precise enough to answer either.",
     "problemStatement": "Let $V(x)$ count the number of $n \\le x$ such that $\\varphi(m) = n$ has a solution (i.e., $n$ is in the range of the totient function). (i) Does $V(2x)/V(x) \\to 2$ as $x \\to \\infty$? (ii) Is there an asymptotic formula for $V(x)$?",
     "text": "Let V(x) count the number of n ≤ x such that φ(m) = n is solvable. Does V(2x)/V(x) → 2? Is there an asymptotic formula for V(x)? Despite remarkable progress by Pillai, Erdős, Maier-Pomerance, and Ford, both questions remain open.",
-    "proofStrategy": "The formalization defines $V(x)$ as the cardinality of $\\{n \\in [1, \\lfloor x \\rfloor] : \\exists\\, m,\\, \\varphi(m) = n\\}$ using `Finset.Icc` and `Finset.filter`. Basic properties (nonnegativity, monotonicity, small totient witnesses) are proved. The four historical bounds — Pillai's $o(x)$, Erdős's $(\\log x)^{-1+o(1)}$, Maier–Pomerance's triple-log formula, and Ford's tight $\\Theta$-bounds — are axiomatized using Lean's `Asymptotics` library (`=o`, `=Θ`). The open questions are expressed as `Prop` definitions using `Tendsto` for limits.",
+    "proofStrategy": "The formalization defines $V(x)$ as the cardinality of $\\{n \\in [1, \\lfloor x \\rfloor] : \\exists\\, m,\\, \\varphi(m) = n\\}$ using `Finset.Icc` and `Finset.filter`. Basic properties (nonnegativity, monotonicity, small totient witnesses — the last two via `native_decide`) are proved. The four historical bounds — Pillai's $o(x)$, Erdős's $(\\log x)^{-1+o(1)}$, Maier–Pomerance's triple-log formula, and Ford's tight $\\Theta$-bounds — are **documented in `/- ... -/` comment blocks only**; they are neither axiomatized nor formally stated (no `axiom` declarations and no `=o`/`=Θ` `Asymptotics` statements appear in the file). The open questions are expressed as `Prop` definitions using `Tendsto` for limits, stated but not proved.",
     "keyInsights": [
       "**Totient values have density zero**: $V(x) = o(x)$ (Pillai 1929) — most integers are NOT in the image of $\\varphi$, since $\\varphi(m)$ is even for $m > 2$ and has additional multiplicative constraints",
       "**The density decays logarithmically**: $V(x) \\approx x/\\log x$ up to iterated-logarithm corrections — the totient image is sparse but not extremely so, comparable to the density of primes",
@@ -100,7 +100,7 @@
       "title": "Known Bounds",
       "startLine": 75,
       "endLine": 118,
-      "summary": "Four historical bounds axiomatized: Pillai $V = o(\\mathrm{id})$ (1929), Erdős $V(x) = x(\\log x)^{-1+o(1)}$ (1935), Maier–Pomerance with triple-log correction (1988), and Ford's tight $\\Theta$-bounds with quadruple logarithms (1998)."
+      "summary": "Four historical bounds documented in comment blocks (not axiomatized, not formally stated): Pillai $V = o(\\mathrm{id})$ (1929), Erdős $V(x) = x(\\log x)^{-1+o(1)}$ (1935), Maier–Pomerance with triple-log correction (1988), and Ford's tight $\\Theta$-bounds with quadruple logarithms (1998)."
     },
     {
       "id": "open-questions",


### PR DESCRIPTION
Resolves the two LOW-severity gallery-integrity nits in #41072 for **erdos-416** (Counting Totient Values). Both are prose/disclosure fixes — the honest counts (`axiomCount: 0`, `sorries: 0`, open problem kept OPEN as `Prop`) are unchanged and correct.

## 1. Phantom "axiomatized" narrative
The four historical bounds (Pillai / Erdős / Maier–Pomerance / Ford) appear in the Lean file only as `/- ... -/` comment blocks — there are **no** `axiom` declarations and **no** `=o`/`=Θ` `Asymptotics` statements. The prose claimed they were "axiomatized using Lean's `Asymptotics` library." Fixed in:
- `meta.status`: `axiomatized` → `formalized` (nothing is axiomatized; matches sibling `badge: wip` open-problem scaffolds and the auditor's scaffold-descriptor suggestion)
- `overview.proofStrategy`: bounds are "documented in comment blocks only", not axiomatized/formally stated
- `sections[known-bounds].summary`: same correction

## 2. Undisclosed `native_decide`
`two_is_totient` and `four_is_totient` are **named** theorems discharged by `native_decide`, so `Lean.ofReduceBool` enters their axiom footprint. Now disclosed in `assumptions` and noted in `proofStrategy`.

`axiomCount` stays **0**: these are trivial existence witnesses (`∃ m, φ(m)=2` / `=4`) in an open-problem scaffold, not a substantive result the entry presents as verified — consistent with the auditor's LOW severity and recommended fix.

Closes #41072.
