### PR TITLE
Fix: disclose native_decide (Lean.ofReduceBool) in erdos-410 meta

### DIFF
--- a/src/data/proofs/erdos-410/meta.json
+++ b/src/data/proofs/erdos-410/meta.json
@@ -57,7 +57,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 371,
-    "assumptions": "2 axiom(s): robin_inequality (equivalent to RH), average_sigma (deep analytic NT). conjecture_equiv_exp was proved from limit theory.",
+    "assumptions": "2 axiom(s): robin_inequality (equivalent to RH), average_sigma (deep analytic NT). conjecture_equiv_exp was proved from limit theory. Additionally, ~22 standalone concrete-demo theorems (σ values sigma_one..sigma_twentyeight, perfect/abundant/deficient/aliquot examples, sigmaIterate computations) are closed by `native_decide`, which introduces the `Lean.ofReduceBool` axiom; these demos are not dependencies of the headline results (erdos_410_statement, conjecture_equiv_exp) or the 2 disclosed analytic axioms, so no headline claim relies on kernel reduction.",
     "theoremCount": 42,
     "definitionCount": 7
   },


### PR DESCRIPTION
## Summary

Metadata-only prose disclosure fix for the LOW gallery-integrity finding in #41080.

`Proofs/Erdos410Problem.lean` uses `native_decide` in ~22 **named** theorems (confirmed: 22 occurrences), but `meta.json` disclosed 0 mentions and the `assumptions` string listed only the 2 analytic axioms (`robin_inequality`, `average_sigma`). Named `native_decide` theorems propagate the `Lean.ofReduceBool` axiom to downstream dependents, so it must be disclosed.

## Fix

Appended a `native_decide` / `Lean.ofReduceBool` disclosure to `meta.assumptions`, noting that the affected theorems are standalone concrete demos (σ values, perfect/abundant/deficient/aliquot examples, iterate computations) that the headline results and 2 disclosed axioms do not depend on.

Per the auditor and the Axiom Integrity Policy, no count changes are warranted: these are non-substantive demos, so `axiomCount: 2`, `sorries: 0`, `status: axiomatized`, and `badge: axiom` all remain correct. This mirrors erdos-414's prose disclosure and matches the sibling fixes for erdos-416 (#41074) / erdos-417 (#41071).

## Evidence

Before: `assumptions` had 0 mentions of native_decide.
After: `assumptions` discloses ~22 native_decide demo theorems introducing `Lean.ofReduceBool`, explicitly scoped as non-headline.

JSON validated.

Closes #41080
