### PR TITLE
Audit erdos-417 (reserve): clean, prior native_decide #41068 resolved

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13453,8 +13453,8 @@
     },
     "erdos-417": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:45Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T05:09:43Z",
       "result": "clean"
     },
     "erdos-418": {


### PR DESCRIPTION
## Reserve-mode audit: erdos-417

Queue drained (0 unaudited); round-robin re-serve of oldest audit.

**Verdict: CLEAN** (was issues-found LOW #41068 for undisclosed native_decide).

### Findings
- Prior LOW issue (#41068, undisclosed native_decide on 2 named totient-value demos) is **resolved** — file now uses only a single kernel `decide` (line 243, trust-neutral). No `native_decide`/`ofReduceBool` remain.
- 1 axiom `erdos_417_conjecture : erdos417ConjectureInfinite` — Erdős's open conjecture (V(x)/V'(x) → ∞), clearly disclosed. Matches `leanFile.axiomCount = 1`.
- 0 sorries (matches meta).
- `erdos_417_ratio_gt_one` legitimately **derives** from the conjecture axiom (not independently claimed).
- `erdos_417_summary` restates only the trivial proven inequality `V' x ≤ V x`.
- Prior inconsistent `erdos417LimitExists` correctly kept as a `def` (not axiomatized), with an explanatory NOTE — no false/inconsistent axiom.
- Prose is conservative and honest ("remains completely open"); `proofStrategy`/`originalContributions` are absent → no phantom decls.

Tracker updated: auditCount 3→4, result clean.

---
Discovered during gallery integrity audit (reserve mode).