### PR TITLE
Audit erdos-411 (reserve): clean, exemplary native_decide/ofReduceBool disclosure

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13411,8 +13411,8 @@
     },
     "erdos-411": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:45Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T05:12:53Z",
       "result": "clean"
     },
     "erdos-412": {


### PR DESCRIPTION
## Reserve-mode audit: erdos-411

Queue drained; round-robin re-serve. **Verdict: CLEAN** (exemplary disclosure).

### Findings
- 14 `native_decide` uses inside **named** theorems (`doubling_r2_n10/n94`, `steinerberger_eq_n{10,94,4,6,14,70}`, `interval_cases` inside `ratio3_738_aux`/`ratio4_*_aux`) → propagate `Lean.ofReduceBool`.
- **Fully disclosed**: `keyInsights` states the concrete solutions are "discharged by `native_decide`, which depends on the `Lean.ofReduceBool` axiom (hence status `axiomatized`)"; `conclusion.summary` = "0 axiom declarations (native_decide relies on Lean.ofReduceBool), 0 sorries"; `assumptions` enumerates the affected named results. Status = `axiomatized`.
- 0 literal `axiom` decls (matches `leanFile.axiomCount = 0`), 0 sorries.
- Main conjecture `ErdosProblem411` kept open (only known solutions proved); external work (Steinerberger 2025 arXiv:2504.08023, Cambie) credited.
- All prose-named decls (`cambie_ratio4_148646`, `ratio3_738_aux`, `steinerberger_r2_sufficient`, `iteratedTotientStep_two`, `doubling_propagation`, `GeneralRatioRelation`, …) exist in the file → no phantoms.

Contrast: prior undisclosed-native_decide LOW findings in the erdos-41x cluster (#41080 for 410, #41068 for 417). 411 is the correct disclosure model.

Tracker: result clean.

---
Gallery integrity audit (reserve mode).