### PR TITLE
Audit erdos-406 (reserve): clean, native_decide + Saye axiom disclosed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13369,8 +13369,8 @@
     },
     "erdos-406": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:45Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T05:14:47Z",
       "result": "clean"
     },
     "erdos-407": {


### PR DESCRIPTION
## Reserve-mode audit: erdos-406

Queue drained; round-robin re-serve. **Verdict: CLEAN.**

### Findings
- 1 axiom `saye_computation` (Saye 2022: for 16≤n≤5.9×10²¹, 2^n has all three ternary digits) — disclosed in docstring + `originalContributions`. Matches `leanFile.axiomCount = 1`.
- 5 `native_decide` in named theorems (`one/four/pow2_8_in_ternarySparse`, `sparse_complete_to_15` via `interval_cases`+`native_decide`) — **disclosed**: sections[4] "PROVES the three known elements via `native_decide`", sections[7] "via `interval_cases`+`native_decide`".
- 0 sorries; no other axioms/stubs.
- Consistency: known sparse elements are n ∈ {0,2,8}, all < 16, so no conflict with the Saye axiom's [16, 5.9×10²¹] exclusion range — no inconsistency.
- Main conjecture `ErdosProblem406` (finiteness) kept open (stated, not proved); `sparse_classification_known_range` scoped to the known range. Honest self-correction noted in originalContributions[7] ({1,3,5,7,15}→{0,1,2,3,4,15} after Mathlib v4.26.0).

Disclosure meets the bar (native_decide named as method); does not name `Lean.ofReduceBool` explicitly like the exemplar erdos-411, but that is above-and-beyond, not required.

Tracker: result clean.

---
Gallery integrity audit (reserve mode).