### PR TITLE
Audit: erdos-408 clean (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13384,8 +13384,8 @@
     },
     "erdos-408": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:45Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T05:18:25Z",
       "result": "clean"
     },
     "erdos-409": {


### PR DESCRIPTION
Reserve-mode audit. erdos-408 (Iterated Totient) is CLEAN: 5 axioms / 0 sorries / 17 thm / 9 def all match meta. Tier-C axiomatized open problem, status/badge correct, native_decide disclosed. Stale section prose describes removed axioms+sorry (file was upgraded to real proofs) — safe direction, not reportable. Tracker timestamp advanced so queue moves on.

Discovered during gallery integrity audit.