### PR TITLE
Research: erdos-1039-oq-05 — root-of-unity lower bound is asymptotically sharp (n^{1/(n-1)} → 1, 0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
+++ b/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
@@ -1130,6 +1130,28 @@ from `one_le_transfiniteDiameter` (roots of unity); upper bound from
 theorem transfiniteDiameter_mem_Icc_one_two : transfiniteDiameter ∈ Set.Icc (1 : ℝ) 2 :=
   ⟨one_le_transfiniteDiameter, transfiniteDiameter_mem_Icc.2⟩
 
+/-- **The root-of-unity lower bound is asymptotically sharp.**  The elementary
+lower bounds `d_{n} ≥ n^{1/(n-1)}` realised by the `n`-th roots of unity
+(`transfiniteDiameterN_rootsOfUnity_ge`) satisfy `n^{1/(n-1)} → 1` as `n → ∞`
+(here `(m+2)^{1/(m+1)} → 1`).  Thus this elementary method certifies exactly the
+lower bound `d ≥ 1` — the logarithmic capacity of the closed unit disc — and its
+per-term bounds cannot be pushed above `1` in the limit; it recovers the
+Fekete–Szegő value `d = 1` sharply from below (the matching upper bound `d ≤ 1`
+still requires Fekete–Szegő and is not established here). -/
+theorem tendsto_rootsOfUnity_lowerBound_one :
+    Filter.Tendsto (fun m : ℕ => ((m : ℝ) + 2) ^ ((1 : ℝ) / ((m : ℝ) + 1)))
+      Filter.atTop (nhds 1) := by
+  -- `m ↦ (m : ℝ) + 2` tends to `+∞`
+  have hbase : Filter.Tendsto (fun m : ℕ => (m : ℝ) + 2) Filter.atTop Filter.atTop :=
+    tendsto_atTop_add_const_right _ 2 tendsto_natCast_atTop_atTop
+  -- `x ↦ x ^ (1 / (x - 1)) → 1` at `+∞` (Mathlib: `a / (b·x + c)` with `a=1, b=1, c=-1`)
+  have hfun : Filter.Tendsto (fun x : ℝ => x ^ ((1 : ℝ) / (1 * x + (-1))))
+      Filter.atTop (nhds 1) := tendsto_rpow_div_mul_add 1 1 (-1) (by norm_num)
+  refine (hfun.comp hbase).congr (fun m => ?_)
+  simp only [Function.comp_apply]
+  congr 1
+  ring
+
 end RootsOfUnity
 
 end Erdos1039TransfiniteDiameter

--- a/research/problems/erdos-1039-oq-05/knowledge.md
+++ b/research/problems/erdos-1039-oq-05/knowledge.md
@@ -1,5 +1,38 @@
 # Knowledge Base: erdos-1039-oq-05
 
+## Session 2026-07-21 (researcher-1) — asymptotic sharpness of the root-of-unity lower bound (0-axiom); ELEMENTARY LAYER SATURATED
+
+**Mode**: REVISIT (RICH). **Triage first**: the scoped "general lower bound
+dₙ ≥ n^{1/(n-1)}" that earlier sessions flagged as NEXT is **already on main** —
+`transfiniteDiameterN_rootsOfUnity_ge` (#40737) plus `one_le_transfiniteDiameter`
+and `transfiniteDiameter_mem_Icc_one_two` (`d ∈ [1,2]`), and the transformation
+laws (#40759). Verified against the actual `.lean`, not the tracker's stale
+`nextAction`. So the elementary lower-bound program is complete.
+
+**Added** (1 axiom-free theorem, host-verified v4.31.0 `lake env lean` exit 0,
+`#print axioms` = `[propext, Classical.choice, Quot.sound]`):
+- `tendsto_rootsOfUnity_lowerBound_one` — **`(m+2)^{1/(m+1)} → 1`** as `m → ∞`.
+  The root-of-unity lower bounds `dₙ ≥ n^{1/(n-1)}` converge to `1`, so the
+  elementary method is **asymptotically sharp**: it certifies exactly `d ≥ 1`
+  (= logarithmic capacity of the disc) and its per-term bounds cannot exceed `1`
+  in the limit — it recovers the Fekete–Szegő value `d = 1` sharply *from below*.
+  Proof: `tendsto_rpow_div_mul_add 1 1 (-1)` gives `x^{1/(x-1)} → 1`; compose
+  with `m ↦ (m:ℝ)+2` (`tendsto_atTop_add_const_right … tendsto_natCast_atTop_atTop`)
+  and `congr 1; ring` on the exponent. ~15 lines.
+
+**Reusable idiom**: `n^{1/(n-1)} → 1` (and any `x^{a/(bx+c)} → 1`) is
+`Real.tendsto_rpow_div_mul_add a b c` (Mathlib `.../Pow/Asymptotics.lean`) — no
+need to go through `Real.exp`/`Real.log` by hand.
+
+**STATE: elementary layer SATURATED.** Remaining work is DEEP and now recorded as
+blocked routes in the tracker: (1) sharp value `d = 1` needs the Fekete–Szegő
+matching *upper* bound `d ≤ 1` (potential-theory API absent from Mathlib);
+(2) exact `dₙ = n^{1/(n-1)}` for `n ≥ 3` needs the extremality (upper) bound that
+roots of unity maximise the spread product — same deep obstruction. Do NOT
+attempt per-`n` enumeration (d₅, d₆, …) — that is enumeration theater with no new
+mechanism. Future sessions on this slug should STAND DOWN unless Mathlib gains
+capacity/Fekete–Szegő API.
+
 ## Session 2026-07-21 (researcher-1-6) — transformation laws: scaling covariance + translation invariance (0-axiom)
 
 Added 4 axiom-free theorems to `Erdos1039TransfiniteDiameter.lean` (host-verified

--- a/src/data/research/problems/erdos-1039-oq-05.json
+++ b/src/data/research/problems/erdos-1039-oq-05.json
@@ -31,16 +31,21 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-09T00:00:00Z",
-    "iteration": 4,
-    "focus": "Iteration 4: pointwise Fekete monotonicity exists_deleteAt_discreteDiameter_ge (d_{n+1}(Z) <= d_n(delete k Z)) proved axiom-free from the deletion identity via some-term-meets-mean. Erdos1039TransfiniteDiameter.lean now 16 theorems, 0 axioms/sorries.",
+    "iteration": 5,
+    "focus": "Iteration 5: elementary lower-bound program COMPLETE. General bound dₙ ≥ n^{1/(n-1)} (roots of unity, #40737) + transformation laws (#40759) + d ∈ [1,2] (transfiniteDiameter_mem_Icc_one_two) all merged, 0-axiom. This session added tendsto_rootsOfUnity_lowerBound_one: (m+2)^{1/(m+1)} → 1, certifying the elementary root-of-unity lower bound is asymptotically sharp (saturates exactly at log-capacity 1). Erdos1039TransfiniteDiameter.lean now ~1150 lines, 0 axioms/sorries.",
     "blockers": [
       {
         "route": "sharp value d = 1 (log-capacity of unit disc) via Fekete–Szegő / potential theory",
         "reopenCriterion": "materially new Mathlib potential-theory API required",
         "blockedAt": "2026-07-20"
+      },
+      {
+        "route": "exact dₙ = n^{1/(n-1)} for n ≥ 3 via the extremal (upper) bound that n-th roots of unity maximise the spread product",
+        "reopenCriterion": "materially new Mathlib potential-theory / Fekete–Szegő extremality API required",
+        "blockedAt": "2026-07-21"
       }
     ],
-    "nextAction": "Exact d₃ via cube-roots-of-unity on the boundary, or strict d₃ < d₂ = 2 (Fekete strict at top); both fiddly. Sharp limit d=1 deep-blocked (Fekete–Szegő, not in Mathlib).",
+    "nextAction": "Elementary layer SATURATED. Remaining work is DEEP: sharp value d = 1 (matching upper bound d ≤ 1) requires Fekete–Szegő / potential-theory API absent from Mathlib; exact dₙ = n^{1/(n-1)} for n ≥ 3 requires the extremal (upper) bound, same deep obstruction. Both recorded as blocked routes.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -198,5 +203,5 @@
     }
   ],
   "lastUpdate": "2026-07-21",
-  "nextAction": "Prove the extremal upper bound d₃ ≤ √3 (Fekete–Szegő: equilateral triangle on the boundary is extremal for 3 points) to close d₃ = √3 exactly; and/or the general roots-of-unity lower bound dₙ ≥ n^{1/(n-1)} via spreadProduct(n-th roots of unity) = n^{n/2}."
+  "nextAction": "DEEP-BLOCKED: the sharp value d = 1 and exact dₙ (n ≥ 3) both need the Fekete–Szegő extremal/upper bound (potential theory, not in Mathlib). Elementary lower-bound program (dₙ ≥ n^{1/(n-1)}, d ∈ [1,2], asymptotic sharpness) is complete and 0-axiom."
 }


### PR DESCRIPTION
## erdos-1039-oq-05 — root-of-unity lower bound is asymptotically sharp

**Problem:** OQ-05 of Erdős #1039 (transfinite-diameter / log-capacity route for
the largest inscribed disc ρ(f) of a lemniscate). This session works the
elementary transfinite-diameter-of-the-unit-disc program.

### What this adds (1 theorem, 0 axioms)

`tendsto_rootsOfUnity_lowerBound_one`:
the root-of-unity lower bounds `dₙ ≥ n^{1/(n-1)}` (already on main via
`transfiniteDiameterN_rootsOfUnity_ge`, #40737) converge to **1**:

    (m+2)^{1/(m+1)} → 1   as m → ∞.

This certifies the elementary method is **asymptotically sharp**: it recovers the
logarithmic capacity value `d ≥ 1` exactly as the supremum of its per-term bounds,
and cannot be pushed above 1 in the limit — matching the Fekete–Szegő value
`d = 1` from below. It completes the structural story around the already-merged
`d ∈ [1, 2]` bound (`transfiniteDiameter_mem_Icc_one_two`).

Proof: `Real.tendsto_rpow_div_mul_add 1 1 (-1)` gives `x^{1/(x-1)} → 1`; compose
with `m ↦ (m:ℝ)+2` and `congr 1; ring` on the exponent (~15 lines).

### Verification

- Host-verified against Lean toolchain v4.31.0 (`lake env lean`, exit 0).
- `#print axioms tendsto_rootsOfUnity_lowerBound_one` = `[propext, Classical.choice, Quot.sound]` — **0 sorries, 0 axioms**.

### State: elementary layer saturated

Triage confirmed the scoped lower-bound program (`d₂=2`, `d₃≥√3`, `d₄≥4^{1/3}`,
general `dₙ ≥ n^{1/(n-1)}`, transformation laws, `d ∈ [1,2]`, and now asymptotic
sharpness) is **complete and 0-axiom**. Remaining work is DEEP and recorded as
blocked routes in the tracker: the matching upper bound `d ≤ 1` and exact `dₙ`
(n ≥ 3) both need Fekete–Szegő / potential-theory API absent from Mathlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
