### PR TITLE
Audit: erdos-4 issues-found (phantom section decls #41095)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13318,9 +13318,9 @@
     },
     "erdos-4": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:46Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T05:32:26Z",
+      "result": "issues-found"
     },
     "erdos-40": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Reserve-mode re-serve of erdos-4. All counts verified honest (1 axiom `maynard_theorem`, 2 theorems, 16 defs, 0 sorries, no native_decide; `maynard_theorem` soundly axiomatizes the genuine solved result).

Filed #41095 (LOW): `sections[]` summaries name 4+ nonexistent theorems — notably the empty `simple-properties` section (lines 158-159) claims `gap_0`/`prime_gap_pos`/`average_gap_asymptotic`, and `comparison` names `erdos_function_growth`. Narrative-only; counts/badge/status unaffected.

Updates audit-tracker.json only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)