### PR TITLE
Fix: erdos-4 reword phantom-theorem section summaries (#41095)

### DIFF
--- a/src/data/proofs/erdos-4/meta.json
+++ b/src/data/proofs/erdos-4/meta.json
@@ -171,7 +171,7 @@
     {
       "id": "simple-properties",
       "title": "Simple Properties",
-      "summary": "**gap_0** = 1 (the only odd gap), **prime_gap_pos**, and **average_gap_asymptotic** ($p_n/(n\\log n) \\to 1$ via PNT).",
+      "summary": "A section-banner placeholder (the range is a comment only, with no declarations). It marks where elementary observations would go — e.g. that $g_1 = 1$ is the only odd prime gap, that gaps are positive, and that the average gap satisfies $p_n/(n\\log n) \\to 1$ by the PNT — but these are unformalized narrative notes, not theorems in the file.",
       "mathContext": "$g_0 = p_1 - p_0 = 3 - 2 = 1$ (only odd gap). $g_n \\geq 1$ for all $n$. Average: $\\sum_{k<n} g_k / n = p_n / n \\sim \\log n$ by PNT.",
       "startLine": 158,
       "endLine": 159
@@ -179,7 +179,7 @@
     {
       "id": "comparison",
       "title": "Comparison of Bounds",
-      "summary": "**erdos_function_growth**: $f(n) < (\\log n)^{1+\\varepsilon}$ eventually. **improved_stronger**: the FGKMT function dominates the original, $f(n) \\leq f'(n)$ for $n \\geq 100$ — fully proved by case-splitting on whether $\\log\\log\\log n \\lessgtr 1$.",
+      "summary": "**improved_stronger**: the FGKMT function dominates the original, $f(n) \\leq f'(n)$ for $n \\geq 100$ — fully proved by case-splitting on whether $\\log\\log\\log n \\lessgtr 1$. The section also comments on the heuristic that $f(n) < (\\log n)^{1+\\varepsilon}$ eventually (narrative only, not a formalized theorem).",
       "mathContext": "$f(n) < (\\log n)^{1+\\varepsilon}$ eventually for any $\\varepsilon > 0$. The FGKMT improved function $f'(n)$ satisfies $f'(n) / f(n) \\to \\infty$.",
       "startLine": 160,
       "endLine": 216


### PR DESCRIPTION
Fixes narrative-only integrity issue on erdos-4: three `sections[]` summaries named theorems that do not exist as declarations in `proofs/Proofs/Erdos4Problem.lean`.

## Evidence

The file has exactly 2 theorems (`erdos_4_solved`, `improved_stronger`), 1 axiom (`maynard_theorem`), 0 sorries. Decl grep for all four named phantoms returns 0:

- `gap_0` → 0
- `prime_gap_pos` → 0
- `average_gap_asymptotic` → 0
- `erdos_function_growth` → 0

The `simple-properties` section range (lines 158-159) is literally an empty comment banner (`/- ## Simple Properties -/` + blank line).

## Fix (prose-only)

- **simple-properties**: reworded to state it is a section-banner placeholder and that gap_0 / prime_gap_pos / average_gap_asymptotic are unformalized narrative observations, not theorems.
- **comparison**: dropped the phantom `erdos_function_growth`; reframed the `(log n)^{1+ε}` growth heuristic as narrative. `improved_stronger` (the one genuinely proved theorem there) is retained.

No count/badge/status changes — axiomCount (1), theoremCount (2), sorries (0), badge (`axiom`) are all correct and unchanged.

Closes #41095

🤖 Generated with [Claude Code](https://claude.com/claude-code)
