### PR TITLE
Audit: erdos-398 issues-found (non-solutions overclaim #41101)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13306,9 +13306,9 @@
     },
     "erdos-398": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:46Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T05:37:19Z",
+      "result": "issues-found"
     },
     "erdos-399": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Reserve re-serve of erdos-398 (Brocard-Ramanujan, OPEN). Open conjecture correctly kept as unproven def; counts verified. Filed #41101 (LOW-MED): originalContribs 'Verified non-solutions' overstates — factorial_N_plus_1 thms only compute n!+1, no non-square theorem exists; plus 17 native_decide ofReduceBool absent from assumptions. Tracker only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)