### PR TITLE
Fix: erdos-397 replace native_decide with decide to drop ofReduceBool (#41098)

### DIFF
--- a/proofs/Proofs/Erdos397Problem.lean
+++ b/proofs/Proofs/Erdos397Problem.lean
@@ -112,12 +112,12 @@ theorem C_zero : C 0 = 1 := by rfl
 theorem C_one : C 1 = 2 := by rfl
 
 /-- C(2) = 6 (the central binomial for n=2 is C(4,2) = 6) -/
-theorem C_two : C 2 = 6 := by native_decide
+theorem C_two : C 2 = 6 := by decide
 
 /-- C(3) = 20 (the central binomial for n=3 is C(6,3) = 20) -/
-theorem C_three : C 3 = 20 := by native_decide
+theorem C_three : C 3 = 20 := by decide
 
 /-- somaniC(2) = 8·4 + 8·2 + 1 = 49 -/
-theorem somaniC_two : somaniC 2 = 49 := by native_decide
+theorem somaniC_two : somaniC 2 = 49 := by decide
 
 end Erdos397


### PR DESCRIPTION
## Summary

Fixes gallery integrity issue #41098 (erdos-397): three named theorems used `native_decide`, which introduces the `Lean.ofReduceBool` axiom (shifting trust from the kernel to the compiler) — a dependency not disclosed in the `assumptions` field.

## Fix

Replaced `native_decide` with `decide` in the three tiny arithmetic facts (the auditor's **preferred** remediation):

- `C_two  : C 2 = 6`
- `C_three : C 3 = 20`
- `somaniC_two : somaniC 2 = 49`

`decide` reduces these in the kernel, so the proof is now kernel-pure with **no** `ofReduceBool`. The `assumptions` field ("2 axioms: erdos_397_disproved, somani_identity. 0 sorries.") is therefore already accurate — no metadata change required. The two remaining axioms (`erdos_397_disproved`, `somani_identity`) are unchanged and correctly disclosed.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos397Problem`:

```
✔ [8576/8576] Built Proofs.Erdos397Problem (18s)
Build completed successfully (8576 jobs).
```

Confirms `decide` terminates on `centralBinom` for n=2,3.

Closes #41098
