### PR TITLE
Fix: erdos-398 correct 'verified non-solutions' overclaim + disclose native_decide (#41101)

### DIFF
--- a/src/data/proofs/erdos-398/meta.json
+++ b/src/data/proofs/erdos-398/meta.json
@@ -38,13 +38,13 @@
     "originalContributions": [
       "Formal statement of the OPEN Brocard-Ramanujan conjecture",
       "Verified the three known Brown numbers: (4,5), (5,11), (7,71)",
-      "Verified non-solutions for n = 0, 1, 2, 3, 6, 8",
+      "Computed n! + 1 for n = 0, 1, 2, 3, 6, 8 (non-squareness argued in prose only, not proven)",
       "Formalization of Overholt's conditional finiteness result",
       "Verified factorial dominates squares for small n"
     ],
     "axiomCount": 2,
     "lineCount": 227,
-    "assumptions": "2 axioms: WeakABC, overholt_finitude. See Lean source for complete statements.",
+    "assumptions": "2 axioms: WeakABC, overholt_finitude. Additionally, the arithmetic facts use `native_decide`, which relies on the `Lean.ofReduceBool` axiom (trusts the compiler's kernel reduction). See Lean source for complete statements.",
     "theoremCount": 19,
     "definitionCount": 3
   },
@@ -52,7 +52,7 @@
     "historicalContext": "The Brocard-Ramanujan conjecture is one of the oldest unsolved problems in number theory. Henri Brocard first posed it in 1876 and again in 1885, asking for which integers n is n! + 1 a perfect square. Srinivasa Ramanujan independently considered the same question.\n\nThree solutions are known: n = 4 (giving 5²), n = 5 (giving 11²), and n = 7 (giving 71²). These are called 'Brown numbers' after a 1974 paper by Paul Erdős and W. Obláth that connected them to this problem.\n\nErdős and Graham described the conjecture as 'almost certainly true but intractable at present.' Despite over 140 years of attention from mathematicians, no proof exists. Overholt (1993) showed that the ABC conjecture would imply only finitely many solutions exist, providing theoretical support for the conjecture.",
     "problemStatement": "**The Brocard-Ramanujan Conjecture**: Are the only natural numbers $n$ for which $n! + 1$ is a perfect square when $n = 4, 5, 7$?\n\nEquivalently: Are $(4, 5)$, $(5, 11)$, and $(7, 71)$ the only pairs $(n, m)$ satisfying $n! + 1 = m^2$?\n\n**Status**: OPEN\n\n**Known Results**:\n- Three solutions verified: $4! + 1 = 25 = 5^2$, $5! + 1 = 121 = 11^2$, $7! + 1 = 5041 = 71^2$\n- No additional solutions below $n = 10^9$ (computational search)\n- Overholt (1993): Only finitely many solutions under weak ABC conjecture",
     "text": "Are the only solutions to n! + 1 = m² when n = 4, 5, 7? This classic conjecture, dating to Brocard (1876) and Ramanujan, remains open despite computational verification to 10^9.",
-    "proofStrategy": "We formalize this OPEN problem by:\n\n1. **Defining Brown numbers**: A pair (n, m) with n! + 1 = m²\n\n2. **Verifying known solutions**: Using `native_decide` to confirm (4,5), (5,11), (7,71) satisfy the equation\n\n3. **Verifying non-solutions**: Computing n! + 1 for small n and showing they are not perfect squares\n\n4. **Stating the conjecture**: The set of n with n! + 1 a perfect square equals {4, 5, 7}\n\n5. **Conditional result**: Axiomatizing Overholt's theorem on finiteness under weak ABC",
+    "proofStrategy": "We formalize this OPEN problem by:\n\n1. **Defining Brown numbers**: A pair (n, m) with n! + 1 = m²\n\n2. **Verifying known solutions**: Using `native_decide` to confirm (4,5), (5,11), (7,71) satisfy the equation\n\n3. **Computing small cases**: Computing n! + 1 for small n (0,1,2,3,6,8); the non-squareness (values lying strictly between consecutive squares) is argued in the docstrings, not proven as a proposition\n\n4. **Stating the conjecture**: The set of n with n! + 1 a perfect square equals {4, 5, 7}\n\n5. **Conditional result**: Axiomatizing Overholt's theorem on finiteness under weak ABC",
     "keyInsights": [
       "**Brown numbers**: Pairs (n, m) with n! + 1 = m² are extremely rare. Only three are known in 140+ years of searching.",
       "**Factorial growth**: n! grows much faster than m², so 'near misses' become increasingly unlikely for large n.",
@@ -95,8 +95,8 @@
       "title": "Small Cases: Non-Solutions",
       "startLine": 77,
       "endLine": 114,
-      "summary": "Verification that n = 0, 1, 2, 3, 6, 8 are not Brown numbers.",
-      "mathContext": "Mathematical content: Verification that n = 0, 1, 2, 3, 6, 8 are not Brown numbers."
+      "summary": "Computes n! + 1 for n = 0, 1, 2, 3, 6, 8; non-squareness is argued in the docstrings, not proven.",
+      "mathContext": "Mathematical content: Computes n! + 1 for n = 0, 1, 2, 3, 6, 8; non-squareness argued in prose, not proven."
     },
     {
       "id": "conjecture",
@@ -132,7 +132,7 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #398, the Brocard-Ramanujan conjecture, which asks whether n! + 1 = m² has only the three known solutions n = 4, 5, 7. We verify these solutions and several non-solutions, state the conjecture formally, and include Overholt's conditional finiteness result.",
+    "summary": "We formalize Erdős Problem #398, the Brocard-Ramanujan conjecture, which asks whether n! + 1 = m² has only the three known solutions n = 4, 5, 7. We verify these solutions, compute several small non-solution cases (non-squareness argued in prose), state the conjecture formally, and include Overholt's conditional finiteness result.",
     "implications": "The Brocard-Ramanujan conjecture, if proven, would demonstrate the extreme rarity of factorial-square coincidences. Its connection to the ABC conjecture suggests deep links between additive and multiplicative number theory.",
     "openQuestions": [
       "Are 4, 5, 7 the only Brown numbers? (The main conjecture)",


### PR DESCRIPTION
Fixes #41101.

## Problem
The auditor found two trust/accounting overclaims in erdos-398 (Brocard–Ramanujan, OPEN):

1. **"Verified non-solutions for n = 0, 1, 2, 3, 6, 8"** overstates the formalized content. The `factorial_N_plus_1` theorems only compute `n! + 1` (e.g. `6! + 1 = 721`); they do **not** prove non-squareness. The "lies strictly between consecutive squares" reasoning appears only in docstrings, never as a proven proposition.
2. `native_decide` (used by the arithmetic theorems) adds `Lean.ofReduceBool` to the trust base, but `assumptions` did not disclose it.

## Fix (metadata-only, no Lean source change)
- Reword `originalContributions`, `proofStrategy` step 3, the `non-solutions` section summary, and the conclusion to say the small cases are **computed** (non-squareness argued in prose only).
- Disclose `Lean.ofReduceBool` in `assumptions`.

Verified against `proofs/Proofs/Erdos398Problem.lean` lines 77–114: the theorems are pure factorial computations. Status `open` / badge `axiom` / axiomCount 2 remain correct.
