### PR TITLE
Enrich Explicit Factorization over Finite Fields and ℚ: add cross-references

### DIFF
--- a/src/data/proofs/bezout-identity-oq007/meta.json
+++ b/src/data/proofs/bezout-identity-oq007/meta.json
@@ -103,6 +103,21 @@
       "targetId": "bezout-identity-oq-02-oq-01",
       "relationship": "related",
       "description": "Grandparent. Derives the Fundamental Theorem of Arithmetic from Euclid's lemma; the Fermat factorization here is the polynomial analogue of 'every prime residue is a root', specialised to 𝔽_p."
+    },
+    {
+      "targetId": "frobenius-endomorphism-oq-01",
+      "relationship": "related",
+      "description": "Supplies the exact machinery of the Frobenius collapse here: the 'freshman's dream' additivity (x+y)^p = x^p + y^p (sub_pow_char) and Frobenius = identity over ZMod p (a^p = a). frobenius_factorization (X^p − a = (X − a)^p) is that endomorphism read at the level of polynomials — the inseparable extreme."
+    },
+    {
+      "targetId": "burnside-counting-oq-06",
+      "relationship": "related",
+      "description": "Proves Fermat's little theorem p ∣ k^p − k via cyclic necklace orbit counting — a combinatorial route to the same a^q = a fact that, read polynomially, is exactly fermat_factorization ('every element is a root of X^q − X'). Same theorem, orthogonal proof."
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "related",
+      "description": "Euler's generalization a^φ(n) ≡ 1 (mod n) of Fermat's little theorem. Over the field 𝔽_p the special case n = p (φ(p) = p − 1, so a^{p−1} = 1 for a ≠ 0, i.e. a^p = a) is precisely the root condition powering the Fermat factorization X^p − X = ∏_a (X − a)."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Enrichment: bezout-identity-oq007 — Explicit Factorization over Finite Fields and ℚ

Adds three genuine, topically-precise cross-references that the entry was
missing. The proof is centrally about Fermat's little theorem (read
polynomially) and the Frobenius endomorphism, yet previously linked only its
own parent/grandparent.

**New crossReferences (2 → 5, cap 20):**
- **frobenius-endomorphism-oq-01** — supplies the exact tools of
  `frobenius_factorization`: the freshman's dream `(x+y)^p = x^p + y^p`
  (`sub_pow_char`) and Frobenius = identity over `ZMod p` (`a^p = a`).
- **burnside-counting-oq-06** — proves Fermat's little theorem `p ∣ k^p − k`
  by necklace orbit counting: an orthogonal proof of the same `a^q = a` fact
  that, read polynomially, is `fermat_factorization`.
- **euler-totient** — Euler's generalization; the `n = p` case is precisely
  the root condition powering `X^p − X = ∏_a (X − a)`.

**Accuracy check (no changes needed):** `status: verified`, `badge: original`,
`axiomCount: 0`, `theoremCount: 6` all verified against
`Proofs/BezoutIdentityOQ02OQ01OQ01OQ02.lean` — 6 theorems, 0 sorries, 0 `axiom`
declarations, no `native_decide`/`decide`. Section line ranges and annotation
coverage (5 annotations spanning all 128 lines) confirmed complete.

No prose deleted; meta 11 KB → 12 KB (cap ~60 KB). The rest of the entry was
already at quality target, so this pass is scoped to the one real gap.
