### PR TITLE
Enrich erdos-398: fix 'verified non-solutions' overclaim + disclose Lean.ofReduceBool (#41101)

### DIFF
--- a/src/data/proofs/erdos-398/meta.json
+++ b/src/data/proofs/erdos-398/meta.json
@@ -38,13 +38,13 @@
     "originalContributions": [
       "Formal statement of the OPEN Brocard-Ramanujan conjecture",
       "Verified the three known Brown numbers: (4,5), (5,11), (7,71)",
-      "Verified non-solutions for n = 0, 1, 2, 3, 6, 8",
+      "Computed n! + 1 for n = 0, 1, 2, 3, 6, 8 (non-squareness argued in prose only, not as proven theorems)",
       "Formalization of Overholt's conditional finiteness result",
       "Verified factorial dominates squares for small n"
     ],
     "axiomCount": 2,
     "lineCount": 227,
-    "assumptions": "2 axioms: WeakABC, overholt_finitude. See Lean source for complete statements.",
+    "assumptions": "2 explicit axioms: WeakABC, overholt_finitude (honest conditional axiomatization of Overholt 1993). Additionally, the 17 native_decide computations (Brown-number verifications, factorial values, factorial-dominates-squares facts) trust the Lean compiler and so depend on the Lean.ofReduceBool axiom — the arithmetic facts are not kernel-checked. See Lean source for complete statements.",
     "theoremCount": 19,
     "definitionCount": 3
   },
@@ -52,7 +52,7 @@
     "historicalContext": "The Brocard-Ramanujan conjecture is one of the oldest unsolved problems in number theory. Henri Brocard first posed it in 1876 and again in 1885, asking for which integers n is n! + 1 a perfect square. Srinivasa Ramanujan independently considered the same question.\n\nThree solutions are known: n = 4 (giving 5²), n = 5 (giving 11²), and n = 7 (giving 71²). These are called 'Brown numbers' after a 1974 paper by Paul Erdős and W. Obláth that connected them to this problem.\n\nErdős and Graham described the conjecture as 'almost certainly true but intractable at present.' Despite over 140 years of attention from mathematicians, no proof exists. Overholt (1993) showed that the ABC conjecture would imply only finitely many solutions exist, providing theoretical support for the conjecture.",
     "problemStatement": "**The Brocard-Ramanujan Conjecture**: Are the only natural numbers $n$ for which $n! + 1$ is a perfect square when $n = 4, 5, 7$?\n\nEquivalently: Are $(4, 5)$, $(5, 11)$, and $(7, 71)$ the only pairs $(n, m)$ satisfying $n! + 1 = m^2$?\n\n**Status**: OPEN\n\n**Known Results**:\n- Three solutions verified: $4! + 1 = 25 = 5^2$, $5! + 1 = 121 = 11^2$, $7! + 1 = 5041 = 71^2$\n- No additional solutions below $n = 10^9$ (computational search)\n- Overholt (1993): Only finitely many solutions under weak ABC conjecture",
     "text": "Are the only solutions to n! + 1 = m² when n = 4, 5, 7? This classic conjecture, dating to Brocard (1876) and Ramanujan, remains open despite computational verification to 10^9.",
-    "proofStrategy": "We formalize this OPEN problem by:\n\n1. **Defining Brown numbers**: A pair (n, m) with n! + 1 = m²\n\n2. **Verifying known solutions**: Using `native_decide` to confirm (4,5), (5,11), (7,71) satisfy the equation\n\n3. **Verifying non-solutions**: Computing n! + 1 for small n and showing they are not perfect squares\n\n4. **Stating the conjecture**: The set of n with n! + 1 a perfect square equals {4, 5, 7}\n\n5. **Conditional result**: Axiomatizing Overholt's theorem on finiteness under weak ABC",
+    "proofStrategy": "We formalize this OPEN problem by:\n\n1. **Defining Brown numbers**: A pair (n, m) with n! + 1 = m²\n\n2. **Verifying known solutions**: Using `native_decide` to confirm (4,5), (5,11), (7,71) satisfy the equation\n\n3. **Computing near-misses**: Using `native_decide` to compute n! + 1 for small non-solution n (0, 1, 2, 3, 6, 8); the argument that these values are not perfect squares is given in prose/docstrings, not as proven propositions\n\n4. **Stating the conjecture**: The set of n with n! + 1 a perfect square equals {4, 5, 7}\n\n5. **Conditional result**: Axiomatizing Overholt's theorem on finiteness under weak ABC",
     "keyInsights": [
       "**Brown numbers**: Pairs (n, m) with n! + 1 = m² are extremely rare. Only three are known in 140+ years of searching.",
       "**Factorial growth**: n! grows much faster than m², so 'near misses' become increasingly unlikely for large n.",


### PR DESCRIPTION
Enrichment / accuracy pass for erdos-398 (Brocard-Ramanujan), addressing gallery-integrity issue #41101. All changes are prose/meta only — no Lean source touched.

## Fixes

1. **"Verified non-solutions" overclaim** — the `factorial_N_plus_1` theorems only prove `n! + 1 = <value>` (e.g. `6! + 1 = 721`); they do **not** prove `¬ ∃ m, n! + 1 = m²`. No non-square theorem exists in the file. Reworded `originalContributions` to "Computed n! + 1 for n = 0,1,2,3,6,8 (non-squareness argued in prose only, not as proven theorems)" and reworded `proofStrategy` step 3 to match.

2. **native_decide / Lean.ofReduceBool disclosure** — 17 named theorems use `native_decide`, adding `Lean.ofReduceBool` to the trust base. `assumptions` previously listed only the 2 explicit axioms. Expanded it to disclose the compiled-code dependency.

## Counts (unchanged — verified correct)

- `axiomCount: 2` (literal `axiom` declarations: `WeakABC`, `overholt_finitude`) — `Lean.ofReduceBool` is disclosed in `assumptions` prose per the enricher prose-accuracy convention; these native_decide facts are auxiliary computations, not the headline result (the conjecture itself remains an unproven `def`).
- Badge `axiom` / status `open` correct.

Closes #41101
