### PR TITLE
Fix: erdos-394 restrict strict_decrease_property to 2≤k (remove inconsistent axiom)

### DIFF
--- a/proofs/Proofs/Erdos394Problem.lean
+++ b/proofs/Proofs/Erdos394Problem.lean
@@ -193,10 +193,16 @@ Does t_{n-3}(n!) have any special structure?
 /--
 **The Strict Decrease Property:**
 For infinitely many n, is it true that
-  t_k(n!) < t_{k-1}(n!) - 1 for all 1 ≤ k < n?
+  t_k(n!) < t_{k-1}(n!) - 1 for all 2 ≤ k < n?
+
+The range starts at k = 2 so that the comparison term `t (k-1)` stays within the
+well-defined range (k-1 ≥ 1). At k = 1 the term would be `t 0`, which is the
+junk value 0 by the `k ≥ 1` guard in `t`, making the inequality vacuously false;
+the intended Selfridge statement compares consecutive `t_k` only where both are
+meaningful.
 -/
 def strict_decrease_property (n : ℕ) : Prop :=
-  ∀ k : ℕ, 1 ≤ k → k < n →
+  ∀ k : ℕ, 2 ≤ k → k < n →
     t k n.factorial + 1 < t (k - 1) n.factorial
 
 /--


### PR DESCRIPTION
## Summary

Fixes the **CRITICAL inconsistent axiom** in `erdos-394` reported in #41106. The
axiom `selfridge_n_10 : strict_decrease_property 10` was **false**, making
`Proofs/Erdos394Problem.lean` logically inconsistent (kernel derives `False`).

## Root cause

`strict_decrease_property n` quantified over `1 ≤ k < n`:

```lean
∀ k : ℕ, 1 ≤ k → k < n → t k n.factorial + 1 < t (k - 1) n.factorial
```

At the boundary `k = 1` this asserts `t 1 (10!) + 1 < t 0 (10!)`. But
`t 0 (10!) = 0` (the `k ≥ 1` guard in `t` fails, returning the junk value `0`),
while `t 1 (10!) ≥ 1`, so the axiom claims `(≥1) + 1 < 0` — impossible in ℕ.
The property was unsatisfiable for every `n ≥ 2`.

## Fix

Restrict the quantifier range to `2 ≤ k < n` (the issue's recommended fix), so
the comparison term `t (k-1)` never hits the junk `t 0` (now `k-1 ≥ 1`, the
guard holds). This is the intended Selfridge statement, which compares
consecutive `t_k` only where both are meaningful. The axiom becomes a legitimate
stated assumption rather than a contradiction. Docstring updated to explain the
`k = 1` degeneracy.

## Validation

`./proofs/scripts/docker-build.sh Proofs.Erdos394Problem` →
`Built Proofs.Erdos394Problem (8.1s)` / `Build completed successfully`.

The k=1 instantiation that previously derived `False` no longer type-checks
against the property (range now starts at k=2), so the module is consistent.

Status/badge remain `axiomatized`/`axiom` (the file still carries stated
assumptions), which is correct.

Closes #41106
