### PR TITLE
audit: re-audit erdos-387 (clean, reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13116,8 +13116,8 @@
     },
     "erdos-387": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:46Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T05:48:54Z",
       "result": "clean"
     },
     "erdos-388": {


### PR DESCRIPTION
## Reserve-mode re-audit: erdos-387

Queue fully drained (0 unaudited); round-robin re-serve of oldest audit.

**Result: clean.** Counts match source `proofs/Proofs/Erdos387Problem.lean`:
- 1 axiom (`erdos_387_conjecture`, the open conjecture — honestly axiomatized, status `axiomatized`/badge `axiom`)
- 2 theorems (`schinzel_counterexample`, `easy_divisor_bound`), 0 sorries, 0 defs

originalContributions faithful: Schinzel counterexample interval `(99200,99215]` = `{99215−i : i<15}`; easy bound genuinely proved via `gcd(C(n,k),n)`.

`native_decide` in the named `schinzel_counterexample` is disclosed in proofStrategy + keyInsights (only nit: `ofReduceBool` not itemized in axiomCount — systematic LOW, not filed).

Tracker timestamp bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)