### PR TITLE
audit: re-audit erdos-390 (clean, reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13147,8 +13147,8 @@
     },
     "erdos-390": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:46Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T05:51:15Z",
       "result": "clean"
     },
     "erdos-391": {


### PR DESCRIPTION
## Reserve-mode re-audit: erdos-390

Result: **clean.** Source `proofs/Proofs/Erdos390Problem.lean`:
- 1 axiom `factorizationMax_asymptotic` (Erdős–Guy–Selfridge Θ(n/log n), existential over C,c; `n≥10` threshold avoids proven small-case values f(6)−2n=−2, f(7)=20, f(8)=16 → no inconsistency). Matches axiomCount:1, status axiomatized/badge axiom.
- 0 sorries; 16 theorems / 10 defs match counts.
- Small-case exact values pinned by genuine two-sided `_le`/`_ge` case analysis; `_eq` for 7,8. proofStrategy discloses "tight upper and lower bounds" — accurate.
- originalContributions empty → no phantom claims.
- 14 native_decide in named theorems/witness defs, disclosed in prose (keyInsights); `ofReduceBool` not itemized in axiomCount — systematic LOW nit, not filed.

Tracker timestamp bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)