### PR TITLE
Research: erdos-18-wip-01 — powers of two are practical (infinite family) + practical m≥3 is even

### DIFF
--- a/proofs/Proofs/Erdos18WIP01.lean
+++ b/proofs/Proofs/Erdos18WIP01.lean
@@ -1,0 +1,140 @@
+/-
+  Erdős Problem #18 — Practical Numbers: an infinite family + a necessary condition
+
+  Source: https://erdosproblems.com/18
+  Parent: `Proofs/Erdos18Problem.lean` (defines `IsPractical`, `IsRepresentable`,
+  `divisors`, `PracticalNumbers` and a handful of finite `decide`-checked examples).
+
+  A positive integer `m` is *practical* if every `1 ≤ k < m` is a sum of distinct
+  divisors of `m`. The parent file establishes practicality only for the finitely
+  many worked examples `1, 2, 4, 6, 8` (each by `decide`). This file supplies the
+  first *structural* results — statements covering infinitely many `m` at once:
+
+  * `repr_lt_two_pow` — every `k < 2^n` is a sum of distinct powers of two drawn
+    from `{2^0, …, 2^{n-1}}` (the finite binary-representation lemma).
+  * `two_pow_practical` — **every power of two is practical**. This is an
+    infinite family of practical numbers, proved once and for all rather than
+    case-by-case.
+  * `infinite_practicalNumbers` — **there are infinitely many practical numbers**
+    (the powers of two, via injectivity of `n ↦ 2^n`).
+  * `two_dvd_of_practical` / `even_of_practical` — a matching *necessary* condition:
+    any practical `m ≥ 3` is even (to represent `2`, the divisor `2` itself must be
+    used, since `1` is the only smaller divisor).
+
+  All results are axiom-free (`#print axioms` = `[propext, Classical.choice,
+  Quot.sound]`) and contain no `sorry`.
+-/
+
+import Mathlib
+import Proofs.Erdos18Problem
+
+open Set Finset Function Nat
+
+namespace Erdos18
+
+/- ## An infinite family: powers of two are practical -/
+
+/-- Every `k < 2^n` is a sum of distinct powers of two drawn from `{2^0, …, 2^{n-1}}`.
+This is the finite binary-representation fact underlying practicality of `2^n`. -/
+theorem repr_lt_two_pow : ∀ (n k : ℕ), k < 2 ^ n →
+    ∃ S : Finset ℕ, S ⊆ (Finset.range n).image (2 ^ ·) ∧ S.sum id = k := by
+  intro n
+  induction n with
+  | zero =>
+    intro k hk
+    simp only [pow_zero, Nat.lt_one_iff] at hk
+    subst hk
+    exact ⟨∅, by simp, by simp⟩
+  | succ n ih =>
+    intro k hk
+    have hrs : (Finset.range n).image (2 ^ ·) ⊆ (Finset.range (n + 1)).image (2 ^ ·) := by
+      apply Finset.image_subset_image
+      intro x hx
+      rw [Finset.mem_range] at hx ⊢
+      omega
+    by_cases hkn : k < 2 ^ n
+    · obtain ⟨S, hS, hsum⟩ := ih k hkn
+      exact ⟨S, hS.trans hrs, hsum⟩
+    · rw [not_lt] at hkn
+      have h2 : 2 ^ (n + 1) = 2 ^ n + 2 ^ n := by rw [pow_succ]; ring
+      have hk' : k - 2 ^ n < 2 ^ n := by omega
+      obtain ⟨S, hS, hsum⟩ := ih (k - 2 ^ n) hk'
+      have hnotmem : 2 ^ n ∉ S := by
+        intro hmem
+        have hx := hS hmem
+        rw [Finset.mem_image] at hx
+        obtain ⟨i, hi, hie⟩ := hx
+        rw [Finset.mem_range] at hi
+        have : (2 : ℕ) ^ i < 2 ^ n := Nat.pow_lt_pow_right (by norm_num) hi
+        omega
+      refine ⟨insert (2 ^ n) S, ?_, ?_⟩
+      · rw [Finset.insert_subset_iff]
+        refine ⟨?_, hS.trans hrs⟩
+        rw [Finset.mem_image]
+        exact ⟨n, Finset.mem_range.mpr (Nat.lt_succ_self n), rfl⟩
+      · rw [Finset.sum_insert hnotmem, hsum]
+        simp only [id_eq]
+        omega
+
+/-- The powers `{2^i : i < n}` are all divisors of `2^n`. -/
+theorem image_two_pow_subset_divisors (n : ℕ) :
+    (Finset.range n).image (2 ^ ·) ⊆ divisors (2 ^ n) := by
+  intro x hx
+  rw [Finset.mem_image] at hx
+  obtain ⟨i, hi, rfl⟩ := hx
+  rw [Finset.mem_range] at hi
+  show (2 : ℕ) ^ i ∈ (2 ^ n).divisors
+  rw [Nat.mem_divisors]
+  exact ⟨pow_dvd_pow 2 (le_of_lt hi), by positivity⟩
+
+/-- **Every power of two is practical.** An infinite family of practical numbers,
+proved uniformly (contrast the parent's finite `decide`-checked examples). -/
+theorem two_pow_practical (n : ℕ) : IsPractical (2 ^ n) := by
+  refine ⟨Nat.one_le_pow n 2 (by norm_num), ?_⟩
+  intro k _ hkm
+  obtain ⟨S, hS, hsum⟩ := repr_lt_two_pow n k hkm
+  exact ⟨S, hS.trans (image_two_pow_subset_divisors n), hsum⟩
+
+/-- **There are infinitely many practical numbers** — namely the powers of two. -/
+theorem infinite_practicalNumbers : PracticalNumbers.Infinite := by
+  apply Set.infinite_of_injective_forall_mem
+    (f := fun n : ℕ => 2 ^ n) (Nat.pow_right_injective (le_refl 2))
+  intro n
+  exact two_pow_practical n
+
+/- ## A matching necessary condition: practical `m ≥ 3` is even -/
+
+/-- **A practical number `m ≥ 3` is even.** To represent `2` as a sum of distinct
+divisors of `m`, since `1` is the only divisor below `2`, the divisor `2` itself
+must appear — hence `2 ∣ m`. -/
+theorem two_dvd_of_practical {m : ℕ} (hm : 3 ≤ m) (h : IsPractical m) : 2 ∣ m := by
+  obtain ⟨S, hS, hsum⟩ := h.2 2 (by omega) (by omega)
+  have hsub12 : S ⊆ {1, 2} := by
+    intro x hx
+    have hxdiv : x ∈ m.divisors := hS hx
+    have hxpos : 1 ≤ x := Nat.pos_of_mem_divisors hxdiv
+    have hxle : x ≤ 2 := by
+      have hle := Finset.single_le_sum (f := id) (fun i _ => Nat.zero_le i) hx
+      rw [hsum, id_eq] at hle
+      exact hle
+    interval_cases x <;> simp
+  have h2mem : 2 ∈ S := by
+    by_contra h2
+    have hS1 : S ⊆ {1} := by
+      intro x hx
+      have hx12 := hsub12 hx
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hx12 ⊢
+      rcases hx12 with h1 | h2'
+      · exact h1
+      · exact absurd (h2' ▸ hx) h2
+    have hle : S.sum id ≤ ({1} : Finset ℕ).sum id := Finset.sum_le_sum_of_subset hS1
+    rw [hsum, Finset.sum_singleton, id_eq] at hle
+    omega
+  exact (Nat.mem_divisors.mp (hS h2mem)).1
+
+/-- Restated: a practical number `m ≥ 3` is `Even`. -/
+theorem even_of_practical {m : ℕ} (hm : 3 ≤ m) (h : IsPractical m) : Even m := by
+  obtain ⟨c, hc⟩ := two_dvd_of_practical hm h
+  exact ⟨c, by omega⟩
+
+end Erdos18

--- a/research/problems/erdos-18-wip-01/knowledge.md
+++ b/research/problems/erdos-18-wip-01/knowledge.md
@@ -53,3 +53,50 @@ sum of distinct divisors of `m`; the open questions concern the growth of `h(m)`
 `h(m)` and its growth (`conjecture_part1`, `conjecture_part2_weak/strong`, the $250
 `h(n!) < n^{o(1)}` question) are deep and unformalized — this session builds only the
 elementary decidable scaffolding around the definitions.
+
+## Session 2026-07-22 (researcher-1-3) — first STRUCTURAL results: powers of two + infinitude + even necessary condition
+
+**Mode**: BUILD on the def-only foundations. **Outcome**: progress — new file
+`proofs/Proofs/Erdos18WIP01.lean` (imports `Proofs.Erdos18Problem`), 5 theorems, all
+axiom-free (`#print axioms` = `[propext, Classical.choice, Quot.sound]`, no `sorry`, no
+`native_decide`). Verified BOTH Docker (`docker-build.sh Proofs.Erdos18WIP01`, exit 0,
+8577 jobs) and host (`lake env lean` after building the Mathlib-only parent olean).
+
+The parent established practicality only for the finite `decide`-checked examples
+`1,2,4,6,8`. This session gives the first results covering **infinitely many `m` at once**:
+
+- `repr_lt_two_pow (n k) (hk : k < 2^n)` — every `k < 2^n` is a sum of distinct powers of
+  two drawn from `{2^0,…,2^{n-1}}`. Proof: strong induction on `n`; in the step, if
+  `k < 2^n` use IH directly, else `2^n ≤ k < 2·2^n` so `k − 2^n < 2^n`, apply IH to
+  `k − 2^n`, then `insert (2^n)` (disjoint because every element used is `< 2^n`).
+- `image_two_pow_subset_divisors (n)` — `{2^i : i<n} ⊆ (2^n).divisors` (`pow_dvd_pow`).
+- **`two_pow_practical (n) : IsPractical (2^n)`** — every power of two is practical.
+- **`infinite_practicalNumbers : PracticalNumbers.Infinite`** — infinitely many practical
+  numbers, via `Set.infinite_of_injective_forall_mem` with `f = (2 ^ ·)` and
+  `Nat.pow_right_injective (le_refl 2)`.
+- **`two_dvd_of_practical (hm : 3 ≤ m) (h : IsPractical m) : 2 ∣ m`** + `even_of_practical`
+  — a matching NECESSARY condition. To represent `2`, since `1` is the only divisor `< 2`,
+  the divisor `2` itself must appear. Proof idiom: `Finset.single_le_sum` bounds each
+  summand `≤ 2`, so the representing set `S ⊆ {1,2}`; `sum = 2` rules out `S ⊆ {1}`
+  (`Finset.sum_le_sum_of_subset` + `Finset.sum_singleton`), forcing `2 ∈ S ⊆ divisors m`.
+
+### Reusable v4.31 Lean idioms (host `lake env lean` EXIT=0)
+- **Binary-representation induction**: to represent `k < 2^n` as distinct powers of two,
+  strong-induct on `n`; step splits on `k < 2^n` vs `2^n ≤ k`, peeling `2^n` via
+  `Finset.insert_subset_iff` + `Finset.sum_insert hnotmem`. Disjointness `2^n ∉ S` from
+  every element `< 2^n` (`Nat.pow_lt_pow_right (by norm_num) hi` + `omega`).
+- **`2^(n+1) = 2^n + 2^n`** to feed `omega`: `by rw [pow_succ]; ring` (omega can't do pow).
+- **Range-image monotonicity**: `Finset.image_subset_image (by intro x hx; rw [Finset.mem_range] at hx ⊢; omega)`
+  — cleaner than `Finset.range_subset.mpr` (which mis-elaborated the `.mpr` argument here).
+- **`Even m` from `2 ∣ m`** (no `Nat.even_iff_two_dvd` in v4.31): `obtain ⟨c,hc⟩ := hdvd; exact ⟨c, by omega⟩`.
+- **`Set.infinite_of_injective_forall_mem`** (needs `[Infinite α]` domain): pass injectivity
+  (`Nat.pow_right_injective (le_refl 2)`) then `∀ a, f a ∈ s`.
+- **Necessary-condition idiom** "subset of positive divisors summing to `c` is forced":
+  `Finset.single_le_sum (fun i _ => Nat.zero_le i) hx` + `rw [hsum, id_eq]` bounds each
+  element `≤ c`; `interval_cases` + membership then pins the set.
+
+### Still open (unchanged, deep)
+`h(m)` and its growth — `conjecture_part1`, `conjecture_part2_weak/strong`, the $250
+`h(n!) < n^{o(1)}` question — remain unformalized. Natural next elementary bricks:
+Stewart–Sierpiński necessary structure (`p ≤ σ(small divisors)+1` for the least
+non-dividing prime `p`), the Stewart product-closure criterion, and practicality of `n!`.

--- a/src/data/research/problems/erdos-18-wip-01.json
+++ b/src/data/research/problems/erdos-18-wip-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-18-wip-01",
   "title": "Complete the Lean Formalization of Erdős Problem #18 (Practical Numbers and h(n!))",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -18,7 +18,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ORIENT",
+    "phase": "ACT",
     "since": "2026-07-09T17:33:19-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
@@ -31,18 +31,29 @@
     }
   },
   "knowledge": {
-    "progressSummary": "FOUNDATIONS (researcher-1, 2026-07-20): developed the def-only Erdos18Problem.lean stub (Erdos Problem 18, practical numbers, $250 open) with 13 axiom-free lemmas + 2 Decidable instances. Key deliverable: IsRepresentable and IsPractical are DECIDABLE (search the powerset of Nat.divisors) — a reusable decision procedure that discharges example checks by plain kernel `decide` (four/six/eight_practical, not_practical_three/five), staying axiom-free (no native_decide). Plus basic witnesses/bounds: zero/one/self representable, representable <= sigma(m), divisors <= m, isPractical_pos, not_isPractical_zero. File 187->261 lines, 2->15 theorems. The h(m) growth conjectures (Parts 1-2) remain open/unformalized. Host-verified v4.31 lake env lean, exit 0; #print axioms = [propext,Classical.choice,Quot.sound].",
+    "progressSummary": "STRUCTURAL (researcher-1, 2026-07-22T05:59:07Z): added Erdos18WIP01.lean (imports Proofs.Erdos18Problem) with the first results covering infinitely many m at once, all 0-axiom (#print axioms = [propext,Classical.choice,Quot.sound]), Docker-verified (8577 jobs) + host-verified. (1) two_pow_practical: every power of two is practical, via repr_lt_two_pow (binary representation, strong induction). (2) infinite_practicalNumbers: there are infinitely many practical numbers. (3) two_dvd_of_practical/even_of_practical: a matching necessary condition, every practical m>=3 is even. This lifts the parents finite decide-checked examples to uniform structural theorems. The h(m) growth conjectures (Erdos #18 Parts 1-2, $250) remain open/unformalized.",
     "builtItems": [
       "decidableIsRepresentable / decidableIsPractical instances (Erdos18Problem.lean)",
       "zero_isRepresentable, one_isRepresentable, isRepresentable_self, isRepresentable_le_sigma, mem_divisors_le (Erdos18Problem.lean)",
       "four/six/eight_practical + not_practical_three/five via decide (Erdos18Problem.lean)",
-      "isPractical_pos, not_isPractical_zero, mem_practicalNumbers_iff (Erdos18Problem.lean)"
+      "isPractical_pos, not_isPractical_zero, mem_practicalNumbers_iff (Erdos18Problem.lean)",
+      "repr_lt_two_pow in Erdos18WIP01.lean: every k<2^n is a sum of distinct powers of two from {2^0..2^{n-1}} (binary-representation induction)",
+      "two_pow_practical in Erdos18WIP01.lean: IsPractical (2^n) for all n (infinite family)",
+      "infinite_practicalNumbers in Erdos18WIP01.lean: PracticalNumbers.Infinite",
+      "two_dvd_of_practical / even_of_practical in Erdos18WIP01.lean: practical m>=3 => 2 | m (necessary condition)"
     ],
     "insights": [
-      "Erdos18Problem.lean stub developed: representability (IsRepresentable) and practicality (IsPractical) are DECIDABLE via a finite powerset search over the divisor set — a single decision procedure subsuming all future example checks; all lemmas axiom-free (plain kernel decide, no native_decide/Lean.ofReduceBool)."
+      "Erdos18Problem.lean stub developed: representability (IsRepresentable) and practicality (IsPractical) are DECIDABLE via a finite powerset search over the divisor set — a single decision procedure subsuming all future example checks; all lemmas axiom-free (plain kernel decide, no native_decide/Lean.ofReduceBool).",
+      "Powers of two are an INFINITE family of practical numbers: every k<2^n is a sum of distinct divisors {2^0,...,2^{n-1}} of 2^n by binary representation (repr_lt_two_pow, proved by strong induction on n). This lifts the parents finite decide-checked examples (4,6,8) to a uniform structural theorem two_pow_practical.",
+      "Consequently there are INFINITELY MANY practical numbers (infinite_practicalNumbers: PracticalNumbers.Infinite), via injectivity of n |-> 2^n on the practical set.",
+      "Matching NECESSARY condition: any practical m>=3 is even (two_dvd_of_practical / even_of_practical). To represent 2 as a sum of distinct divisors of m, since 1 is the only divisor below 2, the divisor 2 itself must be used, so 2 | m. Proof: a subset of positive divisors summing to 2 is forced to be {2} (each element <=2 by single_le_sum, so S subset {1,2}; sum 2 rules out subsets of {1})."
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Prove more of the Stewart-Sierpinski necessary structure: if m>=2 practical and p is the least prime not dividing m, then p <= sigma(divisors of m below p)+1 (the classical inductive characterization).",
+      "Show practical numbers are closed under the Stewart product criterion (m practical, n<=sigma(m)+1 => m*n practical) for specific families.",
+      "Formalize that factorials n! are practical (a concrete infinite family beyond powers of two)."
+    ],
     "markdown": "# Knowledge Base: erdos-18-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [
@@ -63,7 +74,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.780Z",
-  "lastUpdate": "2026-07-10T00:41:25.926Z",
+  "lastUpdate": "2026-07-22T05:59:07Z",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary
Research session for **erdos-18-wip-01** (Erdős Problem #18 — practical numbers, $250 open).
Adds the first *structural* results, lifting the parent file's finite `decide`-checked
examples (`1,2,4,6,8`) to statements covering infinitely many `m` at once.

## Progress
New file `proofs/Proofs/Erdos18WIP01.lean` (imports `Proofs.Erdos18Problem`), 5 theorems:

- `repr_lt_two_pow` — every `k < 2^n` is a sum of distinct powers of two from `{2^0,…,2^{n-1}}` (binary representation, strong induction).
- `two_pow_practical` — **every power of two is practical** (an infinite family).
- `infinite_practicalNumbers` — **there are infinitely many practical numbers**.
- `two_dvd_of_practical` / `even_of_practical` — matching **necessary condition**: any practical `m ≥ 3` is even (to represent `2`, the divisor `2` itself must be used).

## Verification
- **Docker**: `docker-build.sh Proofs.Erdos18WIP01` → exit 0, 8577 jobs.
- **Host**: `lake env lean` after building the Mathlib-only parent olean → exit 0.
- **Axioms**: all 5 theorems `#print axioms` = `[propext, Classical.choice, Quot.sound]` — 0 axioms, 0 `sorry`, no `native_decide`.

## Findings
- The infinitude of practical numbers follows for free once powers of two are handled: `n ↦ 2^n` is injective into the practical set.
- The even necessary condition is sharp at the boundary (`1, 2` are practical but `< 3`; `4, 6, 8, …` even).

## Status
**Outcome**: progress — first infinite-family + necessary-condition results.
**Next Steps**: Stewart–Sierpiński necessary structure (least non-dividing prime bound), Stewart product-closure criterion, practicality of `n!`. The `h(m)` growth conjectures (Parts 1–2, $250) remain deep/open.

🤖 Generated by researcher-1-3
