### PR TITLE
Fix: erdos-376 remove phantom Kummer axiom claim from prose

### DIFF
--- a/src/data/proofs/erdos-376/meta.json
+++ b/src/data/proofs/erdos-376/meta.json
@@ -47,7 +47,7 @@
     ],
     "originalContributions": [
       "Definition of Is105Good and GoodSet105",
-      "Kummer's Theorem as axiom (prime power in binomial coefficients)",
+      "Kummer's-theorem digit characterization described in prose/definitions (not axiomatized)",
       "EGRS Theorem as axiom (two odd primes case)",
       "Verified corollaries for 15, 21, 35 coprimality",
       "Base-good sets: Base3Good, Base5Good, Base7Good",
@@ -56,7 +56,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 126,
-    "assumptions": "1 axiom: egrs_theorem. See Lean source for the complete statement.",
+    "assumptions": "1 axiom: egrs_theorem. See Lean source for the complete statement. The three small computational cases (one_is_good, two_not_good, four_not_good) are discharged by native_decide, which adds Lean.ofReduceBool to their individual axiom footprint (the main coprimality results do not use native_decide).",
     "theoremCount": 6,
     "definitionCount": 6
   },
@@ -64,7 +64,7 @@
     "historicalContext": "**Kummer's Theorem (1852)** connects binomial coefficient divisibility to digit carries: the exact power of prime p dividing C(m,k) equals the number of carries when adding k + (m-k) in base p.\n\n**EGRS Theorem (1975)**: Erdős, Graham, Ruzsa, and Straus proved that for any two odd primes p and q, infinitely many n have C(2n,n) coprime to pq.\n\n**The Open Case**: The question for THREE primes (105 = 3 × 5 × 7) remains **OPEN**.\n\n**Connection to Digits**: C(2n,n) coprime to p iff n has only 'small' digits (0, 1, ..., (p-1)/2) in base p. For 105, this means simultaneously:\n- Only digits {0,1} in base 3\n- Only digits {0,1,2} in base 5\n- Only digits {0,1,2,3} in base 7",
     "problemStatement": "Define the **central binomial coefficient** $C(2n,n) = \\binom{2n}{n}$.\n\n**Definition**: An integer $n$ is **105-good** if $\\gcd(C(2n,n), 105) = 1$.\n\n**Erdős Problem #376 (OPEN)**: Is the set of 105-good integers infinite?\n\n**Known Results**:\n- Two primes: SOLVED by EGRS (1975)\n- Three primes (105 = 3×5×7): **OPEN**\n\n**Equivalently**: Is $\\{n : n \\text{ has restricted digits in bases 3, 5, and 7}\\}$ infinite?",
     "text": "Are there infinitely many n such that C(2n,n) is coprime to 105 = 3×5×7? OPEN for three primes. EGRS (1975) solved the two-prime case.",
-    "proofStrategy": "We formalize this problem by:\n\n1. **Core definitions**: Is105Good, GoodSet105 using Nat.centralBinom and Nat.Coprime\n\n2. **Kummer's Theorem**: Axiomatize the connection between coprimality and digit representations\n\n3. **EGRS Theorem**: Axiomatize the two-prime result\n\n4. **Corollaries**: Prove infinitely many n coprime to 15, 21, 35 using EGRS\n\n5. **Digit characterization**: Define Base3Good, Base5Good, Base7Good\n\n6. **Computational verification**: Use native_decide for small cases",
+    "proofStrategy": "We formalize this problem by:\n\n1. **Core definitions**: Is105Good, GoodSet105 using Nat.centralBinom and Nat.Coprime\n\n2. **Kummer's Theorem**: Describe (in prose and definitions, not axiomatized) the connection between coprimality and digit representations\n\n3. **EGRS Theorem**: Axiomatize the two-prime result\n\n4. **Corollaries**: Prove infinitely many n coprime to 15, 21, 35 using EGRS\n\n5. **Digit characterization**: Define Base3Good, Base5Good, Base7Good\n\n6. **Computational verification**: Use native_decide for small cases",
     "keyInsights": [
       "**Kummer's Theorem key**: C(2n,n) coprime to p iff no carries when computing n + n in base p, i.e., all digits ≤ (p-1)/2.",
       "**Two primes solved**: EGRS construction works for any pq (odd primes). The three-prime case is fundamentally harder.",


### PR DESCRIPTION
## Summary

Fixes gallery integrity issue #41117 (LOW, prose/scope mismatch). The `originalContributions` and `proofStrategy` prose claimed **Kummer's Theorem is axiomatized**, but no such axiom exists in `proofs/Proofs/Erdos376Problem.lean`.

## Evidence

- Lean source has **exactly one** `axiom`: `egrs_theorem` (line 68). "Kummer" appears only in docstrings/comments (lines 13, 22, 50), never as `axiom`/`theorem`.
- `axiomCount: 1`, `assumptions`, and proof-strength claims were already accurate — only the *scope* prose overstated an axiomatization that was never written.

## Changes (meta.json prose only)

- `originalContributions[1]`: "Kummer's Theorem as axiom …" → "Kummer's-theorem digit characterization described in prose/definitions (not axiomatized)".
- `proofStrategy` step 2: "Axiomatize the connection…" → "Describe (in prose and definitions, not axiomatized) the connection…".
- `assumptions`: added a note that `one_is_good`/`two_not_good`/`four_not_good` use `native_decide` (adds `Lean.ofReduceBool` to their individual footprint; main results do not).

No change to `status`, `badge`, or `axiomCount` (all confirmed accurate by the audit).

Closes #41117
