### PR TITLE
Fix: erdos-373 reword originalContributions to definitions-only

### DIFF
--- a/src/data/proofs/erdos-373/meta.json
+++ b/src/data/proofs/erdos-373/meta.json
@@ -42,10 +42,10 @@
     ],
     "originalContributions": [
       "Verified all four conjectured solutions: 9!, 10! (two ways), 16!",
-      "Formalization of Erdos's reduction via prime factor bounds",
-      "Definition of ABC conjecture and Luca's conditional result",
-      "Hickerson's conjecture on complete classification",
-      "Suranyi's conjecture on two-factor solutions"
+      "Definition of maxPrimeFactor (object underlying Erdos's prime-factor reduction; the reduction P(n(n-1)) > 4 log n => S.Finite is not formalized)",
+      "Definition of ABCConjecture (Luca's conditional finiteness theorem ABCConjecture => S.Finite is not formalized)",
+      "Definition of hickersonSolutions (Hickerson's complete-classification conjecture represented as an object, not stated as a proposition)",
+      "Definition of TwoFactorSolutions (Suranyi's two-factor uniqueness conjecture represented as an object, not stated as a proposition)"
     ],
     "axiomCount": 1,
     "lineCount": 168,


### PR DESCRIPTION
## Summary

Fixes the `originalContributions` overclaim flagged in #41123. Four bullets described *definitions* of underlying objects as if the associated reductions/results/conjectures were formalized. They are not stated or proved in `proofs/Proofs/Erdos373Problem.lean` (verified: only `def maxPrimeFactor`, `def ABCConjecture`, `def hickersonSolutions`, `def TwoFactorSolutions` exist; no reduction theorem, no `ABCConjecture => S.Finite`, no conjecture Props).

## Before → After

- "Formalization of Erdos's reduction via prime factor bounds" → "Definition of maxPrimeFactor (object underlying Erdos's prime-factor reduction; the reduction P(n(n-1)) > 4 log n => S.Finite is not formalized)"
- "Definition of ABC conjecture and Luca's conditional result" → "Definition of ABCConjecture (Luca's conditional finiteness theorem ABCConjecture => S.Finite is not formalized)"
- "Hickerson's conjecture on complete classification" → "Definition of hickersonSolutions (Hickerson's complete-classification conjecture represented as an object, not stated as a proposition)"
- "Suranyi's conjecture on two-factor solutions" → "Definition of TwoFactorSolutions (Suranyi's two-factor uniqueness conjecture represented as an object, not stated as a proposition)"

The verified-solutions bullet is unchanged (accurate). Counts, badge (`wip`), status (`axiomatized`), and axiom disclosure are all already correct per the audit — no change needed there.

Metadata-only prose fix. JSON validated.

Closes #41123

🤖 Generated with [Claude Code](https://claude.com/claude-code)
