### PR TITLE
audit: erdos-370 (clean, reserve re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13001,8 +13001,8 @@
     },
     "erdos-370": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:47Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T06:07:56Z",
       "result": "clean"
     },
     "erdos-371": {


### PR DESCRIPTION
Reserve-mode re-audit (unaudited queue drained → round-robin oldest).

**Result: clean.** Counts honest: 1 axiom (`dickman_density`) + 2 sorries match the file exactly. Both main infinitude theorems (`erdos_370_infinitely_many`, `erdos_370`) correctly disclosed as sorry'd; status=axiomatized/badge=axiom appropriate.

LOW / safe-direction nits only (not blocking):
- proofStrategy is stale — claims `gpf`/`steinerberger_factorization` axiomatized, but both are now proved (understates strength).
- `dickman_density` is a vacuous, unused axiom (`∃ρ, ρ>0 ∧ ρ≤1`) described as a "deep analytic result"; disclosed + badge=axiom → no inflation.
- native_decide in named `gpf_63/gpf_64/gpf_le_one` disclosed in section prose but ofReduceBool absent from assumptions accounting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)