### PR TITLE
audit: erdos-371 (clean, reserve re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13007,8 +13007,8 @@
     },
     "erdos-371": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:21Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T06:11:13Z",
       "result": "clean"
     },
     "erdos-372": {


### PR DESCRIPTION
Reserve-mode re-audit (queue drained). **Result: clean.**

- 4 axioms confirmed (`teravanen_2018`, `ElliottHalberstamForFriable : Prop`, `wang_2021`, `dickman : ℝ→ℝ`); meta `assumptions` names exactly these. All sound: literature theorem, opaque-Prop EH *hypothesis* (not asserted true), Wang *conditional* result, uninterpreted function. No inconsistency.
- 2 sorries confirmed (`teravanen_complement`, `theoretical_density_zero`); count matches.
- No native_decide; all P-value/membership lemmas genuinely proved. theoremCount=18 matches.
- Conjecture kept as `def`; density-1/2 available only via `erdos_371_from_elliott_halberstam = wang_2021 h` (conditional). status=axiomatized/badge=axiom honest. origContribs empty → no phantoms.
- LOW nit: trailing summary docstring names a nonexistent `erdos_pomerance_1978_*` axiom (comment-only; public meta accurate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)