### PR TITLE
audit: erdos-368 disclose native_decide/ofReduceBool in concrete examples

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12983,9 +12983,9 @@
     },
     "erdos-368": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:21Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T06:13:41Z",
+      "result": "issues-fixed"
     },
     "erdos-369": {
       "auditCount": 4,

--- a/src/data/proofs/erdos-368/meta.json
+++ b/src/data/proofs/erdos-368/meta.json
@@ -68,7 +68,7 @@
       }
     ],
     "lineCount": 354,
-    "assumptions": "5 axioms: F_eq_max, polya_theorem, mahler_bound, schinzel_upper, pasten_bound. 0 sorries.",
+    "assumptions": "5 axioms: F_eq_max, polya_theorem, mahler_bound, schinzel_upper, pasten_bound. 0 sorries. The concrete-value theorems F_one through F_eight and F_small_values are proved by native_decide, so they additionally depend on Lean.ofReduceBool (compiled-code evaluation); the headline erdos_368_summary depends only on the four bound axioms, not on native_decide.",
     "theoremCount": 14,
     "definitionCount": 12
   },


### PR DESCRIPTION
Reserve-mode re-audit. **Result: issues-fixed (LOW).**

**Verified sound:** 5 axioms confirmed (`F_eq_max`, `polya_theorem`, `mahler_bound`, `schinzel_upper`, `pasten_bound`); 0 sorries. `F_eq_max` is a *true* fact (coprime ⇒ primeFactors of product = union). The four asymptotic bound axioms are each `∀ n ≥ N` with **existential N**, so they cannot be instantiated at a small n to force a contradiction — no inconsistency. `erdos_368_summary` = `⟨polya, mahler, pasten, schinzel⟩`, axioms only.

**Fix:** 9 *named* theorems (`F_one`…`F_eight`, `F_small_values`) use `native_decide` → each carries `Lean.ofReduceBool`, previously undisclosed (meta said only "5 axioms, 0 sorries"). Named theorems propagate the axiom (unlike anonymous `example`s). Updated `assumptions` to disclose the ofReduceBool dependency and note the headline summary does not rely on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)