### PR TITLE
audit: erdos-366 (reserve re-serve, clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12971,8 +12971,8 @@
     },
     "erdos-366": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:22Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T06:19:49Z",
       "result": "clean"
     },
     "erdos-367": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-366 (queue drained, uncontested target).

## Verified clean
- 13 theorems (11 public + 2 private), 6 defs, 0 axioms, 0 sorries
- No `native_decide`, no True stubs, no `sorry`
- All `originalContributions` map to genuinely proved theorems (8/9/12167/12168 fullness via `norm_num`/`dvd_or_dvd`, `IsKFull.mono`, def equivalence)
- Open conjecture `erdos_366_conjecture` stated as a `def` (introduces no assumption); narrative says OPEN throughout; badge `wip` appropriate

Tracker: auditCount 3→4, result clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)