### PR TITLE
audit: erdos-36 issues-found (inconsistent axioms #41134)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12909,9 +12909,9 @@
     },
     "erdos-36": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:22Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T06:23:42Z",
+      "result": "issues-found"
     },
     "erdos-360": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
CRITICAL: erdos-36 axiom set is inconsistent. `upper_bound` asserts the Haugland asymptotic bound `M(N)/N < 0.380876` for **all** N≥1, but this is violated at small N, and the file proves `M 1 = 1` (`small_values`). Instantiating at N=1 yields `1 < 0.380876` → `False`.

Confirmed by compiling `theorem inconsistent_false : False` against the built module (depends on `upper_bound` + `small_values` native_decide axiom).

Filed urgent issue #41134 with recommended threshold-guarded / limit-based fix. Tracker: erdos-36 → issues-found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)