### PR TITLE
Fix: erdos-354 trim unformalized literature results from originalContributions

### DIFF
--- a/src/data/proofs/erdos-354/meta.json
+++ b/src/data/proofs/erdos-354/meta.json
@@ -50,10 +50,7 @@
       "Definition of IsRepresentable for sum representations",
       "Definition of IsComplete (all large integers representable)",
       "Definition of IsDyadicRational (m/2ⁿ form)",
-      "Hegyvári's positive result (dyadic + non-dyadic → complete)",
-      "Hegyvári's negative result (α ≥ 2, β = 2ᵏα → not complete)",
-      "Van Doorn's result (α < 2 < β < 3 → complete)",
-      "Recent Jiang-Ma and Fang-He negative results",
+      "Hegyvári's negative result (α ≥ 2, β = 2ᵏα → not complete), axiomatized as hegyvari_not_complete",
       "Generalized conjecture for base γ ∈ (1, 2)"
     ],
     "axiomCount": 1,


### PR DESCRIPTION
## Summary

Fixes the LOW-severity gallery-integrity issue in `erdos-354` (#41141): `meta.originalContributions` listed three literature results that exist only as prose comments in the Lean file, with no formalized def/axiom/theorem backing them.

## Change

Removed the three comment-only bullets from `originalContributions`:
- "Hegyvári's positive result (dyadic + non-dyadic → complete)" (comment at lines 85–89, no decl)
- "Van Doorn's result (α < 2 < β < 3 → complete)" (comment at line 104, no decl)
- "Recent Jiang-Ma and Fang-He negative results" (comment at line 114, no decl)

Also clarified the retained negative-result bullet to note it is the axiomatized `hegyvari_not_complete`. The remaining bullets now reflect what is actually formalized (the definitions + the axiomatized negative result). The removed literature context is still present in `overview.keyInsights` and the historical context, so no information is lost.

No changes to trust-critical fields — `axiomCount=1`, `sorries=0`, `theoremCount=1`, `definitionCount=7`, `badge=axiom`, `status=axiomatized` were already honest and match the Lean file.

## Validation

`meta.json` parses cleanly (`json.load`); `originalContributions` now has 6 entries.

Closes #41141
