### PR TITLE
Audit erdos-355: clean (faithful axiomatized formalization)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12873,8 +12873,8 @@
     },
     "erdos-355": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:22Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T06:40:21Z",
       "result": "clean"
     },
     "erdos-356": {


### PR DESCRIPTION
## Audit result: CLEAN

**Proof**: erdos-355 (Lacunary Sequences and Rational Representation, van Doorn–Kovač 2025)

erdos-355 status `axiomatized`, badge `axiom`. Verified honest:
- **2 axioms disclosed** (`vanDoorn_Kovac_theorem`, `lambda_two_fails`), matching `axiomCount: 2`. Both faithfully state the genuine 2025 results (positive direction for λ∈(1,2) + sharpness at λ=2); neither is instantiable to kernel False.
- **0 sorries, 0 native_decide**; counts match (15 theorems + 7 defs = 22 decls).
- Actually **fully proves** the powers-of-2 boundary (`powers_of_two_gaps` + triadic-rational lemmas) rather than relying only on the axiom — under-claims if anything.
- originalContributions, proofStrategy, keyInsights all faithful.
- "Aristotle failed to load" comments naming `harmonicSorry*` axioms are stale comment cruft, not real declarations; not reflected in meta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)