### PR TITLE
Enrich erdos-356: remove phantom axioms from narrative (#41144)

### DIFF
--- a/src/data/proofs/erdos-356/meta.json
+++ b/src/data/proofs/erdos-356/meta.json
@@ -50,14 +50,13 @@
       "consecutiveSubsum definition: sum of a contiguous slice of a sequence",
       "consecutiveSums definition: Finset of all consecutive subsums",
       "distinctConsecutiveSums: cardinality of the consecutive sums Finset",
-      "trivialSequence: the sequence {1,...,n} as a baseline",
-      "trivial_collision_structure: arithmetic structure causes sub-quadratic growth",
+      "trivialSequence: the sequence {1,...,n} as a baseline (documented to achieve only O(n) distinct sums)",
       "isValidSequence: strictly increasing and bounded by n",
       "erdosGrahamConjecture: formal statement of the cn² conjecture",
       "beker_theorem axiom: the conjecture is true (Beker 2023)",
       "permutationConjecture and konieczny_theorem axiom (Konieczny 2015)",
       "erdos357Question: related consecutive-integers variant",
-      "upper_bound and lower_bound_exists axioms: Θ(n²) growth",
+      "Θ(n²) growth documented via prose comments on the upper bound k(k+1)/2 and Beker's matching lower bound",
       "erdos_356_solved: combined main result theorem"
     ],
     "axiomCount": 2,
@@ -70,7 +69,7 @@
     "historicalContext": "Erdős Problem #356 originates from the Erdős-Graham collaboration on combinatorial number theory [ErGr80]. The question asks whether carefully chosen strictly increasing sequences can achieve quadratically many distinct consecutive subsums — far more than the trivial sequence {1, 2, ..., n}, which achieves only O(n) distinct values due to arithmetic structure causing sum collisions.\n\nThe problem connects to broader themes in additive combinatorics: how does the structure of a set affect the richness of its sumset? The trivial sequence fails because arithmetic progressions produce highly regular sums with many coincidences. Breaking this regularity is the key to achieving quadratic growth.\n\nKonieczny (2015) first showed that permutations of {1,...,n} can achieve cn² distinct consecutive sums, solving a related variant. Beker (2023) then settled the original problem, proving that strictly increasing sequences bounded by n can also achieve cn² distinct sums. This resolved the problem in the affirmative.",
     "problemStatement": "**Problem Statement (SOLVED)**\n\nIs there some constant $c > 0$ such that for all sufficiently large $n$, there exist integers $a_1 < a_2 < \\cdots < a_k \\leq n$ with at least $cn^2$ distinct integers of the form $\\sum_{u \\leq i \\leq v} a_i$ (consecutive subsums)?\n\n**Answer: YES** — proved by Adrian Beker (2023).\n\nThe trivial sequence $\\{1, 2, \\ldots, n\\}$ fails (only $O(n)$ distinct sums). Konieczny (2015) proved the permutation variant. Beker (2023) proved the original strictly increasing version.",
     "text": "Is there c > 0 such that strictly increasing sequences a₁ < ... < aₖ ≤ n can achieve cn² distinct consecutive sums? YES, proved by Beker (2023).",
-    "proofStrategy": "The formalization defines consecutive subsums and the counting function distinctConsecutiveSums. The trivial sequence {1,...,n} is shown to fail via axiom. The main concepts — strictly increasing sequences, valid sequences, and the Erdős-Graham conjecture — are formalized as Lean definitions. Beker's theorem and Konieczny's theorem are axiomatized since their proofs require deep combinatorial constructions beyond Mathlib. Upper and lower bounds establish that the growth rate is Θ(n²). A summary theorem combines both results.",
+    "proofStrategy": "The formalization defines consecutive subsums and the counting function distinctConsecutiveSums. The trivial sequence {1,...,n} is defined and its O(n) failure discussed in prose commentary (not itself formalized as a lemma). The main concepts — strictly increasing sequences, valid sequences, and the Erdős-Graham conjecture — are formalized as Lean definitions. The file's mathematical content rests on exactly two axioms, beker_theorem and konieczny_theorem, which encode Beker's and Konieczny's theorems since their proofs require deep combinatorial constructions beyond Mathlib. The matching upper bound k(k+1)/2 and Beker's lower bound cn² are documented in prose comments to explain the Θ(n²) growth rate, but are not themselves axiomatized. The summary theorem erdos_356_solved combines both axioms.",
     "keyInsights": [
       "**Trivial Failure**: The sequence {1,...,n} achieves only O(n) distinct consecutive sums due to arithmetic regularity — sums (v-u+1)(v+u)/2 collide frequently",
       "**Spacing Principle**: To achieve cn² distinct sums, elements must be spaced to break arithmetic regularity and minimize sum collisions",
@@ -98,8 +97,8 @@
       "title": "Part II: The Trivial Sequence",
       "startLine": 62,
       "endLine": 92,
-      "summary": "trivialSequence {1,...,n}. Axioms: trivial_fails (O(n) distinct sums), trivial_collision_structure (sub-quadratic).",
-      "mathContext": "trivialSequence {1,...,n}. Axioms: trivial_fails ($O(n)$ distinct sums), trivial_collision_structure (sub-quadratic)."
+      "summary": "Defines trivialSequence {1,...,n}; prose comments explain its O(n) distinct-sum failure from arithmetic collisions.",
+      "mathContext": "Formal definition: trivialSequence {1,...,n}. Accompanying comments note it achieves only $O(n)$ distinct sums (sub-quadratic) due to arithmetic regularity."
     },
     {
       "id": "increasing-sequences",
@@ -130,24 +129,24 @@
       "title": "Part VI: Construction Insights",
       "startLine": 170,
       "endLine": 184,
-      "summary": "beker_construction_yields_quadratic: explicit constant exists with c < 1.",
-      "mathContext": "Mathematical content: beker_construction_yields_quadratic: explicit constant exists with c < 1."
+      "summary": "Prose commentary on Beker's construction principle: spacing elements to break arithmetic regularity and avoid sum collisions.",
+      "mathContext": "Mathematical content (documentation comments): Beker's construction spreads consecutive subsums apart via number-theoretic techniques, avoiding the collisions of arithmetic progressions."
     },
     {
       "id": "related-problems",
       "title": "Part VII: Related Problems",
       "startLine": 185,
       "endLine": 210,
-      "summary": "Connections to Problems #34, #357. permutation_implies_increasing axiom. erdos357Question definition.",
-      "mathContext": "Formal definition: Connections to Problems #34, #357. permutation_implies_increasing axiom. erdos357Question definition."
+      "summary": "Prose connections to Problems #34 (permutations) and #357; defines erdos357Question for the consecutive-integers variant.",
+      "mathContext": "Comments relate #356 to Problem #34 (any permutation of {1,...,n} is a valid sequence, so #34 is strictly harder) and to Problem #357, which is formalized as the erdos357Question definition."
     },
     {
       "id": "bounds",
       "title": "Part VIII: Upper and Lower Bounds",
       "startLine": 211,
       "endLine": 232,
-      "summary": "upper_bound axiom (k(k+1)/2). lower_bound_exists axiom (cn² achievable).",
-      "mathContext": "Axiomatized: upper_bound axiom (k(k+1)/2). lower_bound_exists axiom (cn² achievable)."
+      "summary": "Prose comments on the Θ(n²) growth rate: upper bound k(k+1)/2 subsums, matching cn² lower bound from Beker.",
+      "mathContext": "Documentation comments (not axiomatized): a length-k sequence has at most $k(k+1)/2$ consecutive subsums, and Beker supplies a matching $cn^2$ lower bound, giving growth $\\Theta(n^2)$."
     },
     {
       "id": "summary",


### PR DESCRIPTION
## Enrichment: erdos-356 phantom-axiom cleanup

Fixes gallery-integrity issue #41144. `meta.originalContributions`,
`overview.proofStrategy`, and four `sections` summaries/mathContexts named
axioms/declarations that do **not** exist anywhere in
`Proofs/Erdos356Problem.lean`.

### Verified against `origin/main` Lean source
The file has exactly **2 axioms** (`beker_theorem`, `konieczny_theorem`),
11 defs, 2 theorems (`erdos_356_solved`, `erdos_356`). `grep` for each of
these names returns **0 matches**:

- `trivial_collision_structure`, `trivial_fails` (Part II)
- `beker_construction_yields_quadratic` (Part VI)
- `permutation_implies_increasing` (Part VII)
- `upper_bound`, `lower_bound_exists` (Part VIII)

These are the auto-generated phantom-lemma pattern (cf. erdos-544/539/534).
The trivial-sequence O(n) failure and the Θ(n²) upper/lower bounds appear
**only as prose `/- -/` comments**, not as formalized lemmas or axioms.

### Changes (prose only)
Reworded the affected fields to describe the actual documentation comments
instead of naming nonexistent axioms. Trust-critical fields
(`axiomCount=2`, `status=axiomatized`, `badge=axiom`, `assumptions` naming
only the 2 real axioms) were already correct and are **unchanged**.

JSON validated; file 12 KB (well under caps).
