### PR TITLE
Audit erdos-35: issues-found (native_decide accounting, #41150)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12837,9 +12837,9 @@
     },
     "erdos-35": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:22Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T06:44:48Z",
+      "result": "issues-found"
     },
     "erdos-350": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Tracker update marking erdos-35 audited (issues-found). Filed #41150: assumptions field claims erdos_35 depends only on plunnecke_inequality, but it transitively carries a native_decide (ofReduceBool) axiom via schnirelmannDensity_le_one (verified via #print axioms). LOW severity — native_decide is disclosed in section prose; fix is a meta wording update or decide-swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)