### PR TITLE
Enrich erdos-353: reword phantom parallelogram counterexample axiom (#41152)

### DIFF
--- a/src/data/proofs/erdos-353/meta.json
+++ b/src/data/proofs/erdos-353/meta.json
@@ -48,7 +48,7 @@
       "HasCongruentSides for polygons",
       "Configuration existence predicates (HasTriangleWithArea, etc.)",
       "Koizumi's three main theorems as axioms",
-      "Kovač's parallelogram counterexample axiom",
+      "IsParallelogram predicate (Kovač's parallelogram counterexample is stated in prose only, not formalized as an axiom or theorem)",
       "Kovač-Predojević cyclic quadrilateral theorem"
     ],
     "axiomCount": 4,


### PR DESCRIPTION
Fixes the integrity issue in #41152.

## Problem
`meta.originalContributions` listed "Kovač's parallelogram counterexample axiom" as a contribution, but no such axiom (or theorem) exists in `Erdos353Problem.lean`.

## Verification (against origin/main)
`grep '^axiom'` finds exactly 4 axioms — `koizumi_isosceles_trapezoid`, `koizumi_isosceles_triangle`, `koizumi_right_triangle`, `kovac_predojevic_cyclic`. None concerns a parallelogram. The parallelogram counterexample appears only in prose (header bullet line 26, comment block lines 224–228, summary docstring line 409). The only parallelogram code is `def IsParallelogram` (line 104), a predicate with no theorem/axiom asserting the counterexample.

## Fix
Reword the bullet from "Kovač's parallelogram counterexample axiom" to "IsParallelogram predicate (Kovač's parallelogram counterexample is stated in prose only, not formalized as an axiom or theorem)".

`status: axiomatized`, `badge: axiom`, `axiomCount: 4`, and `assumptions` were already honest and are left unchanged.