### PR TITLE
Fix: erdos-35 drop native_decide/ofReduceBool from erdos_35 (#41150)

### DIFF
--- a/proofs/Proofs/Erdos35Problem.lean
+++ b/proofs/Proofs/Erdos35Problem.lean
@@ -110,7 +110,7 @@ theorem schnirelmannDensity_le_one (A : Set ℕ) : d_s A ≤ 1 := by
   -- countingFunction A 1 ≤ 1 since we only count in {1}
   suffices h : countingFunction A 1 ≤ 1 by exact_mod_cast h
   unfold countingFunction
-  exact le_trans (Finset.card_filter_le _ _) (by native_decide)
+  exact le_trans (Finset.card_filter_le _ _) (by decide)
 
 /-- If 1 ∈ A, then d_s(A) > 0 is possible but not guaranteed. -/
 theorem density_pos_of_one_mem (A : Set ℕ) (h : 1 ∈ A) :
@@ -119,7 +119,7 @@ theorem density_pos_of_one_mem (A : Set ℕ) (h : 1 ∈ A) :
   simp only [Nat.cast_one, div_one]
   -- Finset.range 2 \ {0} = {1}, and 1 ∈ A, so filter gives {1} with card 1
   suffices hc : (Finset.filter (· ∈ A) (Finset.range 2 \ {0})).card = 1 by exact_mod_cast hc
-  have hset : Finset.range 2 \ {0} = ({1} : Finset ℕ) := by native_decide
+  have hset : Finset.range 2 \ {0} = ({1} : Finset ℕ) := by decide
   rw [hset, Finset.filter_singleton, if_pos h, Finset.card_singleton]
 
 /-- Adding a basis can only increase density. -/


### PR DESCRIPTION
## Problem

Issue #41150 (LOW): erdos-35's `assumptions` field claims "The main theorem
erdos_35 depends only on plunnecke_inequality", but `erdos_35` transitively
carried a `native_decide` (`Lean.ofReduceBool`-family) axiom from the trivial
`schnirelmannDensity_le_one` bound.

## Fix

Applied the auditor's **option 2** (preferred — makes the claim true rather than
documenting a wart). Both `native_decide` calls discharge trivial finite goals
and were replaced with plain kernel `decide`:

- `Erdos35Problem.lean:113` — `(Finset.range 2 \ {0}).card ≤ 1`
- `Erdos35Problem.lean:122` — `Finset.range 2 \ {0} = {1}`

`meta.json` is unchanged: `axiomCount` stays 2 (`plunnecke_inequality`,
`goldbach_conjecture`) and the `assumptions` field is now accurate.

## Evidence (host verify, `lake env lean`, exit 0)

Before: `#print axioms Erdos35.erdos_35` included
`schnirelmannDensity_le_one._native.native_decide.ax_1_2`.

After:
```
'Erdos35.erdos_35' depends on axioms:
  [propext, Classical.choice, Erdos35.plunnecke_inequality, Quot.sound]
'Erdos35.schnirelmannDensity_le_one' depends on axioms:
  [propext, Classical.choice, Quot.sound]
```

No `ofReduceBool`. The headline theorem now genuinely depends only on
`plunnecke_inequality` (modulo the standard foundational axioms).

Closes #41150
