### PR TITLE
Enrich erdos-348: remove 3 phantom 'known results' from originalContributions (#41155)

### DIFF
--- a/src/data/proofs/erdos-348/meta.json
+++ b/src/data/proofs/erdos-348/meta.json
@@ -55,9 +55,7 @@
       "ValidPairs set characterization as formal set comprehension",
       "Powers of 2 witness (0,1) validity: PROVED completeness (binary representation by strong induction) and non-1-robustness (even-sum argument: all 2^i for i≥1 are even)",
       "Fibonacci sequence witness (1,2) validity with Zeckendorf-based completeness",
-      "Van Doorn's theorem formalized: no strongly complete sequence is 2-robust",
-      "Representation count function and equivalence with completeness",
-      "Gap property: complete sequences have eventually bounded gaps",
+      "Fibonacci-specific instance proved: fib_not_2_robust (removing the two indices 0,1 breaks completeness); the general Van Doorn theorem (no strongly complete sequence is 2-robust) is noted in prose only, not formalized",
       "Main conjecture as disjunction: all (m,m+1) valid or cutoff exists"
     ],
     "axiomCount": 1,


### PR DESCRIPTION
Fixes the integrity issue in #41155.

## Problem
`meta.originalContributions` listed three results as formalized contributions that exist only in a comment block the source itself labels **"Known results (not formalized, for reference)"** (`Erdos348Problem.lean` lines 558–563).

## Verification (against origin/main)
- **Van Doorn's theorem**: no general theorem exists. The only related decl is `theorem fib_not_2_robust : NotRobust fib 2` (line 508) — a single Fibonacci witness (removes indices {0,1}), NOT the general "no strongly complete sequence is 2-robust". The general statement is comment-only (line 559).
- **representationCount**: no such `def` — `grep` finds `representationCount` only in the line-562 comment.
- **Gap property**: no theorem/def, comment-only (line 561).

## Fix
- Reword the Van Doorn bullet to the real `fib_not_2_robust` instance, explicitly noting the general theorem is prose-only.
- Drop the "Representation count function" bullet (no such def).
- Drop the "Gap property" bullet (comment-only).

The honest parts (`axiomCount: 1` for `fib_1_robust`, `sorries: 0`, status/badge, and the real `powersOf2_complete`/`fib_complete`/`pair_*_valid` theorems) are unchanged.