### PR TITLE
Audit erdos-347: clean (faithful axiomatized existential)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12819,8 +12819,8 @@
     },
     "erdos-347": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:23Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T06:53:34Z",
       "result": "clean"
     },
     "erdos-348": {


### PR DESCRIPTION
Tracker: erdos-347 audited clean. 1 axiom (erdos347_affirmative) matches count, faithfully states the actual problem existential (monotone seq, ratio limit 2, cofinite subseqs density-1 subset sums), consistent + non-vacuous. 13 theorems all proved (structural + honest consequences of the axiom), 0 sorries, no native_decide, origContribs map to real decls. Includes an honest correction note (subsetSums_add was incorrect → subsetSums_insert). Honest Tier-C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)