### PR TITLE
Audit erdos-343: clean (honest Tier-C axiomatized)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12792,8 +12792,8 @@
     },
     "erdos-343": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:23Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T06:55:45Z",
       "result": "clean"
     },
     "erdos-344": {


### PR DESCRIPTION
## Audit result: CLEAN

**Proof**: erdos-343 (Subcompleteness of Dense Multisets, Szemerédi-Vu 2006)

Verified during gallery integrity audit (reserve/re-serve; queue drained, oldest uncontested).

### Checks
- **Counts match**: 3 axioms, 3 theorems, 8 defs, 0 sorries — all match meta `axiomCount`/`theoremCount`/`definitionCount`/`sorries`.
- **No native_decide/decide**, no sorry/admit.
- **Axiom consistency**: `folkman_counterexample` (∃ sublinear-density non-subcomplete set) cannot be fed into `szemeredi_vu_2006` (requires *positive lower density* ≥ c·N); the counterexample witness has only sublinear N^(1-ε) growth, so no contradiction is derivable. Axioms reflect true mathematics and are jointly consistent.
- **Honest disclosure**: `status: axiomatized`, `badge: axiom`, proofStrategy/assumptions/originalContributions all explicitly label the 3 axioms. "SOLVED" refers to the attributed literature result, not an independent formalization.
- Exponents use real ε (rpow), not the Nat-division parse bug.

Tracker: bump erdos-343 auditCount 3→4, result clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)