### PR TITLE
Audit erdos-341: clean (honest partial formalization)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12777,8 +12777,8 @@
     },
     "erdos-341": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:23Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T06:58:12Z",
       "result": "clean"
     },
     "erdos-342": {


### PR DESCRIPTION
## Audit result: CLEAN

**Proof**: erdos-341 (Dickson's Sum-Free Extension — greedy sum-avoiding sequence periodicity)

Reserve/re-serve audit (queue drained). `status: axiomatized` with `axiomCount: 0` initially looked like the phantom-axiomatized pattern, but on inspection this is a legitimate partial formalization:

- Every `originalContributions` entry maps to a real declaration (`pairwiseSums`, `IsSumRepresentable`, `dicksonSeq`, `IsEventuallyPeriodic`, `erdos_341_conjecture`, singleton theorems).
- Counts match: 8 `theorem` + 3 private lemmas = 11 (theoremCount), 7 defs, **0 axioms, 0 sorries**.
- Main conjecture `erdos_341_conjecture` is a `def : Prop`, honestly labeled **OPEN** in `assumptions` and `erdosProblemStatus: open` — not claimed proved.
- Singleton case A₀={1} genuinely proved (odd numbers, constant diff 2).
- No native_decide, no True stubs.
- `status: axiomatized`/axiomCount 0 mismatch **understates** (badge `wip`); safe direction, not reportable.

Tracker: bump erdos-341 auditCount 3→4, result clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)