### PR TITLE
Audit erdos-340: clean (honest Tier-C, greedy Sidon growth)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12753,8 +12753,8 @@
     },
     "erdos-340": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:24Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T07:00:12Z",
       "result": "clean"
     },
     "erdos-340-greedy-sidon": {


### PR DESCRIPTION
## Audit result: CLEAN

**Proof**: erdos-340 (Growth of the greedy Sidon / Mian-Chowla sequence — OPEN)

Reserve/re-serve audit. Counts verified: 5 axioms, 7 theorems, 4 defs, **0 sorries**, no native_decide — all match meta.

### Axiom consistency
- Lower bound Ω(N^⅓) and Erdős–Turán upper bound O(√N+N^¼) both use existential constants; asymptotically N^⅓ < N^½, jointly satisfiable, no instantiable contradiction.
- Growth conjecture + diffset-density axioms carry existential N₀/N thresholds → inconsistency-safe.
- `greedy_sidon_values` pins the true OEIS A005282 terms, consistent with the proved strict-mono + Sidon theorems.

### Axiom→theorem upgrade verified
`greedy_sidon_strict_mono` and `greedy_sidon_is_sidon` (formerly axioms) are genuinely proved from the sInf definition via the explicit `2·sup+1` Sidon-extension witness; no sorry. The `assumptions` claim of a 7→5 axiom reduction is honest.

Disclosures accurate: `status: axiomatized`, `badge: axiom`, `erdosProblemStatus: open`.

Tracker: bump erdos-340 auditCount 3→4, result clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)