### PR TITLE
Audit erdos-340-greedy-sidon: clean (axiom-free, verified badge accurate)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12759,8 +12759,8 @@
     },
     "erdos-340-greedy-sidon": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:24Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T07:03:39Z",
       "result": "clean"
     },
     "erdos-340-greedy-sidon-oq-05": {


### PR DESCRIPTION
## Audit result: CLEAN

**Proof**: erdos-340-greedy-sidon (status/badge: `verified`, 0 axioms, 0 sorries)

Reserve-mode re-audit (queue drained). Verified against `proofs/Proofs/Erdos340GreedySidon.lean` (648 lines, matches lineCount):

- **0 axioms** — no `^axiom` declarations, no axiom-carrying structures/classes (none present). Axiom-free claim accurate.
- **0 sorries / 0 admit / 0 native_decide / 0 True stubs** — confirmed by grep.
- **Greedy construction genuine** — `sidon_exists_extension` (explicit witness `2·sup(A)+1`), `nextSidon` (Nat.find), `greedyPair`/`greedySidonSeq` real recursive defs; `greedySidonSeq_strictMono`, `greedySidonSeq_isSidon`, `greedySeqSet_isSidon` are real theorems (formerly axioms), non-vacuous.
- **Bound theorems non-vacuous** — `sidon_lower_bound` (max' ≥ n(n-1)/2), `sidon_upper_bound_weak` (card ≤ sqrt(2N)+1) have proper hypotheses.
- **No phantom decls** — all 18 spot-checked `originalContributions` names exist as real declarations.

Minor (non-reportable): `theoremCount` 24 vs actual 25 (incl. private) — stale undercount, harmless.

`verified` badge and axiom-free narrative are accurate.

---
Discovered during gallery integrity audit.