### PR TITLE
Audit erdos-335: issues-found (CRITICAL inconsistent axiom, #41168)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12717,9 +12717,9 @@
     },
     "erdos-335": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:24Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T07:08:04Z",
+      "result": "issues-found"
     },
     "erdos-336": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Marks erdos-335 audited with result `issues-found`.

CRITICAL: axiom `weyl_equidistribution` is logically inconsistent — its target measure `μX` is a free parameter unconnected to `X`, so `asympDensity (FractionalPartSet θ X)` (one fixed real) can be equated to any value in [0,1], yielding `0 = 1`. Verified: `theorem inconsistent_335 : False` compiles; `#print axioms` → depends only on `weyl_equidistribution` + standard axioms. Filed as #41168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)