### PR TITLE
Audit erdos-337: issues-found (phantom origContribs, #41173)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12729,9 +12729,9 @@
     },
     "erdos-337": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:24Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T07:20:07Z",
+      "result": "issues-found"
     },
     "erdos-338": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Tracker update for erdos-337 audit (reserve mode re-serve).

Result: issues-found. Filed #41173 (LOW) — originalContributions and section summaries name nonexistent declarations `ruzsa_turjanyi_positive`, `plunnecke_ruzsa`, `construction_insight`; the first overclaims a proved positive 3-fold result that is only a bare ratio def (`scaledSumsetRatio`). Axiom/sorry/theorem counts, status, and badge are honest.