### PR TITLE
Fix: erdos-337 remove phantom declaration names from meta.json

### DIFF
--- a/src/data/proofs/erdos-337/meta.json
+++ b/src/data/proofs/erdos-337/meta.json
@@ -61,10 +61,8 @@
       "erdos_conjecture_false: proved theorem with contradiction argument",
       "generalizedConjecture: h-fold version",
       "ruzsa_turjanyi_generalization: h-fold also fails",
-      "scaledSumsetRatio: 3-fold scaled version",
-      "ruzsa_turjanyi_positive: scaled 3-fold version is true",
+      "scaledSumsetRatio: DEFINES the 3-fold scaled ratio |3A ∩ [1,3N]|/|A ∩ [1,N]| (positive result stated informally in prose, not proved)",
       "scaledConjecture: open 2-fold scaled version",
-      "plunnecke_ruzsa: upper bound context",
       "erdos_337_summary: summary combining all results"
     ],
     "dateAdded": "2026-01-19",
@@ -158,7 +156,7 @@
       "title": "Positive Result: Scaled Version",
       "startLine": 165,
       "endLine": 182,
-      "summary": "`scaledSumsetRatio` and `ruzsa_turjanyi_positive`: $|3A \\cap [1,3N]|/|A \\cap [1,N]| \\to \\infty$ IS true for sparse bases",
+      "summary": "`scaledSumsetRatio` DEFINES the 3-fold scaled ratio $|3A \\cap [1,3N]|/|A \\cap [1,N]|$; the positive result that it $\\to \\infty$ for sparse bases is stated informally in prose, not formalized as a theorem",
       "mathContext": "Ruzsa-Turjanyi positive: $|3A \\\\cap [1,3N]| / |A \\\\cap [1,N]| \\\\to \\\\infty$ for any sparse basis. Three-fold sumsets always grow relative to the basis."
     },
     {
@@ -174,7 +172,7 @@
       "title": "Why the Conjecture Fails",
       "startLine": 205,
       "endLine": 227,
-      "summary": "`construction_insight`: collisions in $A+A$ limit growth; sparsity alone is insufficient for sumset expansion",
+      "summary": "Prose commentary (no Lean declaration): collisions in $A+A$ limit growth; sparsity alone is insufficient for sumset expansion",
       "mathContext": "Collisions in $A+A$ limit growth: if $a_1+b_1 = a_2+b_2$ frequently, the sumset can be nearly as sparse as $A$. Turjanyi constructs $A$ with maximal collision rate."
     },
     {
@@ -182,7 +180,7 @@
       "title": "Plünnecke-Ruzsa Context",
       "startLine": 228,
       "endLine": 248,
-      "summary": "`plunnecke_ruzsa`: $|hA| \\leq |A|^h$ gives upper bounds but no lower bounds; the gap allows bounded ratios",
+      "summary": "Prose commentary (no Lean declaration): $|hA| \\leq |A|^h$ gives upper bounds but no lower bounds; the gap allows bounded ratios",
       "mathContext": "Plunnecke-Ruzsa: $|hA| \\\\leq |A+A|^h / |A|^{h-1}$. Gives upper bounds on sumset growth but no lower bounds for the ratio question."
     },
     {


### PR DESCRIPTION
## Summary

Fixes gallery integrity issue #41173. `originalContributions` and three `sections` summaries in `src/data/proofs/erdos-337/meta.json` named Lean declarations that do not exist in `proofs/Proofs/Erdos337Problem.lean`, and one entry overclaimed a *proved* positive result that is not even stated.

## Evidence

Actual top-level declarations (grep `^(axiom|theorem|def|noncomputable def)` on `origin/main`): `countingFunction, isLittleO, isSparse, sumset, hFoldSumset, isAdditiveBasis, isAdditiveBasisFiniteOrder, erdosConjecture, turjanyi_counterexample, erdos_conjecture_false, generalizedConjecture, ruzsa_turjanyi_generalization, scaledSumsetRatio, scaledConjecture, scaled_conjecture_open, erdos_337_summary, erdos_337, historical_note`.

Phantom names removed / corrected:
- **`ruzsa_turjanyi_positive`** — no such declaration. Only `scaledSumsetRatio` exists, a `noncomputable def` computing the ratio; it does not prove convergence to ∞. Removed the overclaiming `originalContributions` entry and rewrote the existing `scaledSumsetRatio` entry + `positive-result` section summary to say the positive result is stated informally in prose, not proved.
- **`plunnecke_ruzsa`** — no such declaration (Part VIII is prose only). Removed the `originalContributions` entry; rewrote the `plunnecke` section summary as prose commentary.
- **`construction_insight`** — no such declaration (prose only). Rewrote the `intuition` section summary as prose commentary.

Counts unchanged and honest: axiomCount 3, 0 sorries, theoremCount 4, status=axiomatized / badge=axiom. Metadata-only change; JSON validated.

Closes #41173
