### PR TITLE
Research: erdos-326-wip-01 — squeeze criterion for growth limit (convergent-direction engine, 0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos326WIP01.lean
+++ b/proofs/Proofs/Erdos326WIP01.lean
@@ -31,6 +31,11 @@ ratio and its limit:
   (`hasNoGrowthLimit_of_two_subseq_limits`): two strictly-monotone index
   subsequences along which the growth ratio tends to distinct limits force
   `HasNoGrowthLimit` — the reusable engine behind the oscillation direction;
+* its convergent-direction companion, a **squeeze criterion**
+  (`hasGrowthLimit_of_le_of_le`): an enumeration eventually sandwiched
+  `a ≤ b ≤ c` between two enumerations of the *same* growth limit `x` inherits
+  that limit `x` (`growthRatio_mono` gives the pointwise ratio comparison), with
+  the exactly-quadratic instance `hasGrowthLimit_of_between_quadratic`;
 * both growth-limit predicates are non-vacuous: an exactly-quadratic
   enumeration `bₖ = c·k²` has growth limit `c`, while an enumeration whose
   quadratic coefficient oscillates between `1` and `2` has **no** growth limit;
@@ -646,5 +651,49 @@ limit `0`.  Contrast `hasGrowthLimit_quadratic` (limit `c`) and
 `0` end of the growth spectrum. -/
 theorem hasGrowthLimit_id_zero : HasGrowthLimit (fun k => k) 0 :=
   hasGrowthLimit_zero_of_linear_bound _ 1 (fun k => by simp)
+
+/-! ## A squeeze criterion for convergence
+
+The convergent-direction companion of `hasNoGrowthLimit_of_two_subseq_limits`: if
+an enumeration `b` is sandwiched between two enumerations `a ≤ b ≤ c` (eventually)
+whose growth ratios both converge to the **same** limit `x`, then `b/k²` also
+converges to `x`.  This is the natural comparison principle for the open direction
+of #326 — a sub-basis enumeration is pointwise squeezed by controlling sequences,
+and if those pin the same quadratic coefficient the sub-basis cannot oscillate. -/
+
+/-- **Growth ratio is monotone in the enumeration.**  A pointwise-larger
+numerator gives a pointwise-larger growth ratio (division by the nonnegative
+`k²`). -/
+theorem growthRatio_mono {a b : ℕ → ℕ} {k : ℕ} (h : a k ≤ b k) :
+    growthRatio a k ≤ growthRatio b k := by
+  have : (a k : ℝ) ≤ (b k : ℝ) := by exact_mod_cast h
+  unfold growthRatio; gcongr
+
+/-- **Squeeze criterion for a growth limit.**  If `a k ≤ b k ≤ c k` holds
+eventually and both `a` and `c` have growth limit `x`, then `b` has growth limit
+`x` as well.  The two bounding ratios trap `growthRatio b` between two sequences
+converging to `x`, so `tendsto_of_tendsto_of_tendsto_of_le_of_le'` forces the
+squeeze.  Convergent-direction counterpart of
+`hasNoGrowthLimit_of_two_subseq_limits`. -/
+theorem hasGrowthLimit_of_le_of_le {a b c : ℕ → ℕ} {x : ℝ}
+    (hab : ∀ᶠ k in atTop, a k ≤ b k) (hbc : ∀ᶠ k in atTop, b k ≤ c k)
+    (ha : HasGrowthLimit a x) (hc : HasGrowthLimit c x) : HasGrowthLimit b x := by
+  have e1 : ∀ᶠ k in atTop, growthRatio a k ≤ growthRatio b k := by
+    filter_upwards [hab] with k hk using growthRatio_mono hk
+  have e2 : ∀ᶠ k in atTop, growthRatio b k ≤ growthRatio c k := by
+    filter_upwards [hbc] with k hk using growthRatio_mono hk
+  exact tendsto_of_tendsto_of_tendsto_of_le_of_le' ha hc e1 e2
+
+/-- **Sandwich between two exactly-quadratic enumerations with the same
+coefficient.**  If `c·k² ≤ b k ≤ c·k²` — more usefully, if `b` is eventually
+trapped between two enumerations both of growth limit `c` — then `b` has growth
+limit `c`.  Concrete instance of `hasGrowthLimit_of_le_of_le` against the
+exactly-quadratic witnesses `hasGrowthLimit_quadratic`: any enumeration pinned
+between `c·k²` and `c·k²` from below/above inherits the limit `c`. -/
+theorem hasGrowthLimit_of_between_quadratic (b : ℕ → ℕ) (c : ℕ)
+    (hlo : ∀ᶠ k in atTop, c * k ^ 2 ≤ b k)
+    (hhi : ∀ᶠ k in atTop, b k ≤ c * k ^ 2) : HasGrowthLimit b (c : ℝ) :=
+  hasGrowthLimit_of_le_of_le hlo hhi (hasGrowthLimit_quadratic c)
+    (hasGrowthLimit_quadratic c)
 
 end Erdos326

--- a/research/problems/erdos-326-wip-01/knowledge.md
+++ b/research/problems/erdos-326-wip-01/knowledge.md
@@ -217,3 +217,35 @@ honestly quadratic growth — the ratio cannot oscillate/diverge while the numer
 
 ### Remaining open (unchanged)
 - The subset-basis oscillation dichotomy (deep, structured blocker: materially new mechanism required).
+
+## Session 2026-07-22 (researcher-1-3) — squeeze criterion (convergent-direction engine)
+
+Added 3 axiom-free decls to `Erdos326WIP01.lean` (host-verified v4.31.0 via
+fresh-parent-olean; `#print axioms` = propext/Classical.choice/Quot.sound on all
+three). The **convergent-direction companion** of the existing non-convergence
+engine `hasNoGrowthLimit_of_two_subseq_limits`:
+
+- `growthRatio_mono {a b k} (h : a k ≤ b k) : growthRatio a k ≤ growthRatio b k` —
+  ratio monotone in the numerator (cast `a k ≤ b k` to ℝ, `unfold growthRatio; gcongr`
+  handles division by the nonneg `k²`). Reusable pointwise comparison.
+- `hasGrowthLimit_of_le_of_le {a b c x} (hab : ∀ᶠ k, a k ≤ b k) (hbc : ∀ᶠ k, b k ≤ c k)
+  (ha : HasGrowthLimit a x) (hc : HasGrowthLimit c x) : HasGrowthLimit b x` — the
+  squeeze. `filter_upwards` the two eventual `≤` through `growthRatio_mono`, then
+  `tendsto_of_tendsto_of_tendsto_of_le_of_le' ha hc e1 e2` traps `growthRatio b`.
+  Directly serves the OPEN direction: a sub-basis enumeration is pointwise squeezed
+  by controlling sequences; same quadratic coefficient top and bottom ⟹ it converges.
+- `hasGrowthLimit_of_between_quadratic (b c) (hlo : ∀ᶠ k, c*k² ≤ b k)
+  (hhi : ∀ᶠ k, b k ≤ c*k²) : HasGrowthLimit b c` — concrete instance against the
+  exactly-quadratic witnesses `hasGrowthLimit_quadratic c` on both sides.
+
+### Idioms
+- Growth-ratio numerator comparison: `exact_mod_cast h` (ℕ `≤` → ℝ `≤`), `unfold
+  growthRatio; gcongr` — `gcongr` discharges `x/k² ≤ y/k²` from `x ≤ y` with nonneg denom.
+- `tendsto_of_tendsto_of_tendsto_of_le_of_le' hg hh hgf hfh` is the eventual-`≤`
+  squeeze (bounds converge to same limit, `∀ᶠ` inequalities) — cleaner than `squeeze_zero`
+  when the common limit is a general `x` (not `0`).
+
+### Remaining open (unchanged)
+- The subset-basis oscillation dichotomy — deep structured blocker; both the
+  non-convergence engine and this squeeze engine are the *final steps* of any such
+  construction, the construction itself is the hard part.


### PR DESCRIPTION
## erdos-326-wip-01 — squeeze criterion for the growth limit (convergent-direction engine)

Adds the **convergent-direction companion** of the existing non-convergence engine
`hasNoGrowthLimit_of_two_subseq_limits` to `Proofs/Erdos326WIP01.lean`. All new
results are **0-axiom / 0-sorry**, host-verified on `v4.31.0` via the
fresh-parent-olean recipe (`#print axioms` = `propext / Classical.choice / Quot.sound`).

### New declarations (3)

- `growthRatio_mono {a b k} (h : a k ≤ b k) : growthRatio a k ≤ growthRatio b k`
  — the growth ratio `bₖ/k²` is monotone in the numerator (division by the
  nonnegative `k²`). Reusable pointwise comparison.
- `hasGrowthLimit_of_le_of_le` — if `a k ≤ b k ≤ c k` holds eventually and both
  `a`, `c` have growth limit `x`, then `b` has growth limit `x`. Proof squeezes
  `growthRatio b` between `growthRatio a → x` and `growthRatio c → x` via
  `tendsto_of_tendsto_of_tendsto_of_le_of_le'`.
- `hasGrowthLimit_of_between_quadratic` — concrete instance: an enumeration
  eventually trapped between `c·k²` and `c·k²` has growth limit `c`
  (both bounds supplied by `hasGrowthLimit_quadratic`).

### Why it matters for #326

Erdős #326 (open) asks whether every order-2 additive basis contains a sub-basis
`B ⊆ A` whose ratio `bₖ/k²` fails to converge. A sub-basis enumeration is
pointwise squeezed by controlling sequences; this criterion is the tool that
certifies the **convergent** outcome — the exact dual of the two-subsequence
non-convergence engine already in the file. Both are the final step of any such
construction; the construction itself remains the deep open core (untouched).

Reference: <https://erdosproblems.com/326>
