### PR TITLE
Audit: erdos-333 clean (reserve re-serve)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12688,8 +12688,8 @@
     },
     "erdos-333": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:24Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T07:29:25Z",
       "result": "clean"
     },
     "erdos-334": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-333 (Sparse Sumset Bases).

**Verdict: clean.**

- axiomCount 2 ✓ (`existence_of_counterexample`, `erdos_newman_squares`), both disclosed in `assumptions`
- theoremCount 3 ✓, definitionCount 14 ✓, 0 sorries ✓
- Honest Tier-C axiomatized disproof; badge `axiom`, status `axiomatized`
- Negation axiom (¬conjecture derived) — consistent, no false-axiom pattern
- No native_decide

Minor cosmetic note (not blocking): originalContributions labels the Theorem-2 axiom `erdos_newman_theorem2`, but the real decl is `existence_of_counterexample`. Counts and `assumptions` disclosure are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)