### PR TITLE
Audit: erdos-323 clean (reserve re-serve)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12599,8 +12599,8 @@
     },
     "erdos-323": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:24Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T07:31:13Z",
       "result": "clean"
     },
     "erdos-324": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-323 (sums of m k-th powers).

**Verdict: clean.**

- axiomCount 1 ✓ (`landau_two_squares`), disclosed in `assumptions`. Lower-bound-only axiom; consistent (no competing upper bound), true weakening of Landau's asymptotic.
- theoremCount 5 ✓ — all genuinely proved, non-vacuous
- definitionCount 6 ✓; conjecture parts are `Prop` definitions, correctly not claimed as proved
- Real-valued exponents in conjectures (no Nat-division exponent bug); no native_decide, 0 sorries
- Status `axiomatized` / badge `axiom` — honest Tier-C

Note (not blocking): originalContributions labels the proven theorems `first_power_count` and `power_sum_count_mono` as "axioms". This understates (implies more is assumed than actually is) — safe direction, not an overclaim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)