### PR TITLE
Audit: erdos-327 issues-found (inconsistent axiom, #41182)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12623,9 +12623,9 @@
     },
     "erdos-327": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:24Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T07:33:45Z",
+      "result": "issues-found"
     },
     "erdos-327-oq-01": {
       "auditCount": 3,


### PR DESCRIPTION
Reserve-mode re-audit of erdos-327 surfaced a **CRITICAL** inconsistent axiom.

`vanDoorn_bound` is quantified over all N with no lower bound; at N=1, A={1} it forces a distinct pair inside a singleton ⇒ proves `False` (verified compiling). Filed #41182 for the mechanic.

Counts (1 axiom / 8 thm / 5 def / 0 sorry) are otherwise accurate. Tracker updated to issues-found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)