### PR TITLE
Fix: erdos-327 vanDoorn_bound axiom threshold (resolves inconsistency)

### DIFF
--- a/proofs/Proofs/Erdos327Problem.lean
+++ b/proofs/Proofs/Erdos327Problem.lean
@@ -48,11 +48,16 @@ def ErdosProblem327 : Prop :=
 
 /- ## Van Doorn's bound -/
 
-/-- Van Doorn's result: if `|A| ≥ (25/28) * N`, then `A` contains `a ≠ b`
-with `a + b ∣ a * b`. -/
-axiom vanDoorn_bound (N : ℕ) (A : Finset ℕ) :
-    A ⊆ Finset.Icc 1 N → (25 * N ≤ 28 * A.card) →
-      ∃ a ∈ A, ∃ b ∈ A, a ≠ b ∧ a + b ∣ a * b
+/-- Van Doorn's result: for all sufficiently large `N`, if `|A| ≥ (25/28) * N`,
+then `A` contains `a ≠ b` with `a + b ∣ a * b`.
+
+The density bound is asymptotic, so the statement carries an explicit threshold
+`N₀`; without it the claim is false at small `N` (e.g. `N = 1`, `A = {1}`
+satisfies both hypotheses but the singleton has no distinct pair). -/
+axiom vanDoorn_bound :
+    ∃ N₀ : ℕ, ∀ (N : ℕ), N₀ ≤ N → ∀ (A : Finset ℕ),
+      A ⊆ Finset.Icc 1 N → (25 * N ≤ 28 * A.card) →
+        ∃ a ∈ A, ∃ b ∈ A, a ≠ b ∧ a + b ∣ a * b
 
 /- ## Variant: factor-of-2 condition -/
 


### PR DESCRIPTION
## Summary

Repairs the CRITICAL integrity issue in #41182: the sole axiom `vanDoorn_bound`
in `proofs/Proofs/Erdos327Problem.lean` was **inconsistent** — quantified over
all `N` with no lower bound, it was false at small `N` and let the kernel derive
`False`, compromising the entire gallery entry.

## Root cause

Van Doorn's 25/28 density result is **asymptotic**; encoding it as `∀ N` (no
threshold) makes it false at small `N`. Instantiate `N := 1`, `A := {1}`:
- `{1} ⊆ Finset.Icc 1 1` ✓
- `25 * 1 ≤ 28 * 1` → `25 ≤ 28` ✓
- Conclusion demands a distinct pair `a ≠ b` in the singleton `{1}` — impossible.

Same failure mode as erdos-36 / erdos-452.

## Fix

Added an explicit existential threshold `N₀` so the bound only applies for large `N`:

```lean
axiom vanDoorn_bound :
    ∃ N₀ : ℕ, ∀ (N : ℕ), N₀ ≤ N → ∀ (A : Finset ℕ),
      A ⊆ Finset.Icc 1 N → (25 * N ≤ 28 * A.card) →
        ∃ a ∈ A, ∃ b ∈ A, a ≠ b ∧ a + b ∣ a * b
```

The axiom is standalone (not referenced by any downstream declaration), so the
reshape does not affect other theorems.

## Validation

`./proofs/scripts/docker-build.sh Proofs.Erdos327Problem` → **Build succeeded**
(2969 jobs, exit 0; only pre-existing `push_neg`/unused-var warnings).

meta.json counts (1 axiom, 0 sorries, status `axiomatized`/badge `axiom`) remain
accurate — no metadata change needed.

Closes #41182

🤖 Generated with [Claude Code](https://claude.com/claude-code)
