### PR TITLE
Audit: erdos-324 clean (reserve re-serve)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12605,8 +12605,8 @@
     },
     "erdos-324": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:24Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T07:36:56Z",
       "result": "clean"
     },
     "erdos-325": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-324 (Distinct Polynomial Pair Sums, OPEN).

**Result: clean.** All meta counts match the Lean source exactly:
- 1 axiom (`min_degree_for_distinct`, disclosed) — conditional & consistent
- 0 sorries, 0 native_decide (8 kernel `by decide` = trust-neutral)
- 14 theorems, 7 defs, 303 lines — all match meta
- status `axiomatized` / badge `axiom` = correct Tier C
- All 18 originalContributions map to real declarations

Minor non-reportable note: `proofStrategy` calls the n=2,3,4 failures 'axiomatized' when they're actually proved theorems — understates strength (safe direction); `assumptions` field is fresh and correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)