### PR TITLE
Audit: erdos-318 clean (reserve re-serve)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12560,8 +12560,8 @@
     },
     "erdos-318": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:25Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T07:38:52Z",
       "result": "clean"
     },
     "erdos-319": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-318 (Signed Unit Fractions / Property P₁, PARTIALLY SOLVED).

**Result: clean — exemplary.** All meta counts match source exactly:
- 3 axioms, all honestly labeled published literature results (Erdős–Straus 1975, Sattler 1975, Sattler 1982) — status `axiomatized` / badge `axiom` = correct Tier C
- 0 sorries, 0 native_decide, 8 theorems, 14 defs, 543 lines
- `counterexample_fails_P1` genuinely PROVEN via parity obstruction (`odd_unit_sum_ne_even_unit`); not axiomatized
- Open squares case correctly left as an unproven `def` — deliberately NOT axiomatized, with a docstring documenting removal of a prior mathematically-incorrect `¬∃ proof, True` axiom
- Axioms consistent: no arithmetic progression coincides with the proven-failing counterexample set (odds ∪ {2m})

🤖 Generated with [Claude Code](https://claude.com/claude-code)