### PR TITLE
Audit: erdos-317 clean (reserve re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12554,8 +12554,8 @@
     },
     "erdos-317": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:25Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T07:44:53Z",
       "result": "clean"
     },
     "erdos-318": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-317 (Signed Unit Fraction Approximations).

**Result: clean.** Verified against `proofs/Proofs/Erdos317Problem.lean`:
- theoremCount 8, definitionCount 8, axiomCount 0, sorries 0 — all match source
- originalContributions map to real proved decls (weak_inequality genuinely proved via denominator-divisibility argument)
- native_decide (counterexample_small_n) disclosed by name in proofStrategy + section summaries + originalContributions
- badge `wip` correct for OPEN problem; Questions are Prop defs, not axioms

No overclaim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)