### PR TITLE
Audit: erdos-316 clean (reserve re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12548,8 +12548,8 @@
     },
     "erdos-316": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:25Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T07:46:45Z",
       "result": "clean"
     },
     "erdos-317": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-316 (Partitioning Sets by Reciprocal Sums).

**Result: clean.** Verified against `proofs/Proofs/Erdos316Problem.lean`:
- theoremCount 4, definitionCount 1, axiomCount 1, sorries 0 — all match
- badge `axiom`/status `axiomatized` correct; the 1 axiom (Sándor's general-n case) disclosed in assumptions
- main disproof `erdos_316` (n=2 counterexample) kernel-checked via `decide +kernel` — no axiom, no native_decide
- axiom is a pure existential 'no'-direction result with a genuine n=2 witness — consistent
- originalContributions modest, no overclaim of the generalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)