### PR TITLE
Audit: erdos-308 tracker — false Croot lower-bound axiom (#41197)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12469,9 +12469,9 @@
     },
     "erdos-308": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:25Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T08:06:36Z",
+      "result": "issues-found"
     },
     "erdos-308-oq-03": {
       "auditCount": 1,


### PR DESCRIPTION
Marks erdos-308 as issues-found. Filed #41197: `croot_lower_bound` axiom encodes `⌊H_N⌋` as `(H N).num.natAbs` (the numerator, e.g. 7381 at N=10 vs floor 2), asserting `f N ≥ num(H_N)−6` which is false against the file's own provable `f N ≤ N+1`. Missed by 3 prior clean audits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)