### PR TITLE
Fix: erdos-308 encode Croot bounds via ⌊H N⌋ not num(H_N)

### DIFF
--- a/proofs/Proofs/Erdos308Problem.lean
+++ b/proofs/Proofs/Erdos308Problem.lean
@@ -158,7 +158,7 @@ The second-order term involves (log log N)²/log N.
 axiom croot_lower_bound :
     ∃ N₀ : ℕ, ∀ N ≥ N₀,
       -- f(N) ≥ floor of (H_N - 9/2 · (log log N)² / log N) asymptotically
-      f N ≥ (H N).num.natAbs - 1 - 5
+      (f N : ℤ) ≥ ⌊H N⌋ - 6
 
 /--
 **Croot's Upper Bound (1999):**
@@ -169,7 +169,7 @@ The gap from H_N is at least half a second-order term.
 axiom croot_upper_bound :
     ∃ N₀ : ℕ, ∀ N ≥ N₀,
       -- f(N) ≤ floor of (H_N - 1/2 · (log log N)² / log N) asymptotically
-      f N ≤ (H N).num.natAbs
+      (f N : ℤ) ≤ ⌊H N⌋
 
 /- 
 **Croot's Main Theorem (1999):**
@@ -257,8 +257,8 @@ involving (log log N)²/log N.
 -/
 theorem erdos_308_summary :
     -- Croot's bounds
-    (∃ N₀ : ℕ, ∀ N ≥ N₀, f N ≥ (H N).num.natAbs - 1 - 5) ∧
-    (∃ N₀ : ℕ, ∀ N ≥ N₀, f N ≤ (H N).num.natAbs) ∧
+    (∃ N₀ : ℕ, ∀ N ≥ N₀, (f N : ℤ) ≥ ⌊H N⌋ - 6) ∧
+    (∃ N₀ : ℕ, ∀ N ≥ N₀, (f N : ℤ) ≤ ⌊H N⌋) ∧
     -- Contiguity holds for large N
     (∃ N₀ : ℕ, ∀ N ≥ N₀, question2 N) := by
   constructor


### PR DESCRIPTION
## Problem

The `croot_lower_bound` / `croot_upper_bound` axioms in `Erdos308Problem.lean`
encoded the intended `⌊H_N⌋` bounds using `(H N).num.natAbs` — the *numerator
of the reduced harmonic fraction* (~lcm(1..N)), not the floor.

This made **`croot_lower_bound` mathematically false**: it asserted, for all
large N, `f N ≥ num(H_N) − 6` (e.g. `f 10 ≥ 7375`), while the file's own
`f` definition forces `f N ≤ N+1` for every N. An inconsistent axiom taints
`erdos_308_summary` / `erdos_308`.

| N  | `(H N).num` | `⌊H N⌋` |
|----|-------------|---------|
| 4  | 25          | 2       |
| 10 | 7381        | 2       |

## Fix

Replace the numerator encoding with `Int.floor` (`⌊H N⌋`), casting `f N` to `ℤ`,
in both axioms and the matching `erdos_308_summary` conjuncts:

```lean
axiom croot_lower_bound : ∃ N₀ : ℕ, ∀ N ≥ N₀, (f N : ℤ) ≥ ⌊H N⌋ - 6
axiom croot_upper_bound : ∃ N₀ : ℕ, ∀ N ≥ N₀, (f N : ℤ) ≤ ⌊H N⌋
```

With the floor, `f(N) ≥ ⌊H_N⌋ − 6` is consistent with `f(N) ≤ N+1`
(since `⌊H_N⌋ ~ ln N`) and actually states Croot's result. Axiom count
unchanged (3); status remains `axiomatized` (Tier C). The gallery prose
already described the `⌊H_N⌋` bounds, so no meta.json change is needed.

## Evidence

`./proofs/scripts/docker-build.sh Proofs.Erdos308Problem` →
`✔ Built Proofs.Erdos308Problem` / `Build completed successfully`.

Closes #41197
