### PR TITLE
Audit: erdos-303 clean (honest axiomatized Brown-Rödl)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12420,8 +12420,8 @@
     },
     "erdos-303": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:25Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T08:10:18Z",
       "result": "clean"
     },
     "erdos-304": {


### PR DESCRIPTION
## Audit result: CLEAN

**Proof**: erdos-303 (Monochromatic Unit Fraction Solutions, Brown–Rödl 1991)

Reserve-mode re-audit (queue drained, 0 unaudited). Honest Tier-C axiomatized proof.

### Verified
- **2 axioms** (`brownRodl_theorem`, `erdos303_true`) declared plainly, matching `axiomCount: 2`. Both assert the genuine (true, published) Brown–Rödl theorem in two formulations — consistent, honestly labeled as axioms. Badge `axiom`, status `axiomatized`.
- 0 real sorries; `harmonicSorry*` only in stale Aristotle "failed to load" cruft comments.
- theoremCount 8, definitionCount 8 — both match the file.
- originalContributions all backed by real declarations (examples via `norm_num`, infinite family `1/n=1/(n+1)+1/(n(n+1))` via `field_simp;ring`, equivalences).

### Note (not reportable)
keyInsights claims examples are "verified by `native_decide`", but the file uses `norm_num`/`field_simp` — no `native_decide` present. This is the *safe direction* (kernel-checked `norm_num` > compiled `native_decide`); understates trust rather than overclaiming.

---
Discovered during gallery integrity audit.
🤖 Generated with [Claude Code](https://claude.com/claude-code)