### PR TITLE
Research: erdos-18-wip-01 — full Stewart–Sierpiński characterisation (practical iff divisor coin-chain, 0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos18WIP01.lean
+++ b/proofs/Proofs/Erdos18WIP01.lean
@@ -1017,4 +1017,84 @@ theorem eighteen_practical : IsPractical 18 := by
   norm_num at this
   exact this
 
+/- ## The full Stewart–Sierpiński characterisation (an `iff`)
+
+The sufficiency engine `finset_chain_covers` and the sharp-representability lemma
+`representable_le_sigma_of_practical` together pin practicality down to a single
+*divisor-gap* condition on the divisor set, giving a complete characterisation:
+
+  `m` is practical  ⟺  `1 ≤ m` and every divisor `d ∣ m` satisfies
+  `d ≤ 1 + ∑_{e ∣ m, e < d} e`.
+
+The condition says the sorted divisors `1 = d₁ < d₂ < … < d_τ = m` form a *coin chain*:
+each divisor is at most one more than the sum of all smaller divisors, so no gap in the
+subset-sum reachability ever opens. This is precisely Stewart's/Sierpiński's criterion,
+here in its purely divisor-theoretic (rather than prime-factorisation) form.
+
+* `divisor_chain_of_practical` — the **necessary** half: extracted from the coin-chain
+  argument already used inside `representable_le_sigma_of_practical`. If `d ∣ m` with
+  `d ≥ 2`, then `d − 1 < m` is a distinct-divisor sum (practicality), and every divisor it
+  uses is `≤ d − 1 < d`, so those smaller divisors already sum to `≥ d − 1`.
+* `practical_of_divisor_chain_condition` — the **sufficient** half: `finset_chain_covers`
+  on the full divisor set covers `[0, σ(m)] ⊇ [0, m)`, hence every `1 ≤ k < m` is
+  representable.
+* `practical_iff_divisor_chain` — the two directions packaged as an `iff`. -/
+
+/-- **Necessary divisor-gap condition.** If `m` is practical then every divisor `d ∣ m`
+satisfies `d ≤ 1 + ∑_{e ∣ m, e < d} e`: to represent `d − 1 < m` only divisors `< d` are
+available, so they already sum to at least `d − 1`. This is the converse of the coin-chain
+sufficiency `finset_chain_covers`. -/
+theorem divisor_chain_of_practical {m : ℕ} (h : IsPractical m) :
+    ∀ d ∈ divisors m, d ≤ 1 + ∑ e ∈ (divisors m).filter (· < d), e := by
+  obtain ⟨hm1, hrep⟩ := h
+  intro s hs
+  have hsmem : s ∈ m.divisors := by rw [divisors] at hs; exact hs
+  have hsdvd : s ∣ m := (Nat.mem_divisors.mp hsmem).1
+  have hspos : 1 ≤ s := Nat.pos_of_mem_divisors hsmem
+  have hsm : s ≤ m := Nat.le_of_dvd hm1 hsdvd
+  rcases Nat.lt_or_ge s 2 with h1 | h2
+  · omega
+  · set k := s - 1 with hk
+    have hk1 : 1 ≤ k := by omega
+    have hkm : k < m := by omega
+    obtain ⟨T, hT, hTsum⟩ := hrep k hk1 hkm
+    have hTsub : T ⊆ (divisors m).filter (· < s) := by
+      intro x hx
+      rw [Finset.mem_filter]
+      have hxle : x ≤ k := by
+        have := Finset.single_le_sum (f := id) (fun i _ => Nat.zero_le i) hx
+        rwa [hTsum, id_eq] at this
+      exact ⟨hT hx, by omega⟩
+    have hsum_le : ∑ t ∈ T, t ≤ ∑ t ∈ (divisors m).filter (· < s), t :=
+      Finset.sum_le_sum_of_subset hTsub
+    have hbridge : ∑ t ∈ T, t = k := by simpa [id_eq] using hTsum
+    omega
+
+/-- **Sufficient divisor-gap condition.** If `1 ≤ m` and every divisor `d ∣ m` satisfies
+`d ≤ 1 + ∑_{e ∣ m, e < d} e`, then `m` is practical. The full divisor set is a coin chain,
+so `finset_chain_covers` represents every `k ≤ σ(m)`, in particular every `1 ≤ k < m`. -/
+theorem practical_of_divisor_chain_condition {m : ℕ} (hm1 : 1 ≤ m)
+    (hchain : ∀ d ∈ divisors m, d ≤ 1 + ∑ e ∈ (divisors m).filter (· < d), e) :
+    IsPractical m := by
+  refine ⟨hm1, ?_⟩
+  intro k hk1 hkm
+  have hmmem : m ∈ divisors m := by
+    rw [divisors]; exact Nat.mem_divisors.mpr ⟨dvd_refl _, by omega⟩
+  have hksig : k ≤ ∑ d ∈ divisors m, d := by
+    have hmle : m ≤ ∑ d ∈ divisors m, d :=
+      Finset.single_le_sum (f := fun d => d) (fun i _ => Nat.zero_le i) hmmem
+    omega
+  obtain ⟨T, hT, hTsum⟩ := finset_chain_covers (divisors m) hchain k hksig
+  exact ⟨T, hT, by simpa [id_eq] using hTsum⟩
+
+/-- **Stewart–Sierpiński characterisation.** `m` is practical iff `1 ≤ m` and its divisors
+form a coin chain: every divisor `d` is at most `1 +` the sum of the strictly smaller
+divisors. Combines `divisor_chain_of_practical` (necessity) and
+`practical_of_divisor_chain_condition` (sufficiency). -/
+theorem practical_iff_divisor_chain {m : ℕ} :
+    IsPractical m ↔
+      1 ≤ m ∧ ∀ d ∈ divisors m, d ≤ 1 + ∑ e ∈ (divisors m).filter (· < d), e :=
+  ⟨fun h => ⟨h.1, divisor_chain_of_practical h⟩,
+    fun ⟨hm1, hchain⟩ => practical_of_divisor_chain_condition hm1 hchain⟩
+
 end Erdos18

--- a/proofs/Proofs/Erdos18WIP01.lean
+++ b/proofs/Proofs/Erdos18WIP01.lean
@@ -1110,4 +1110,18 @@ theorem practical_iff_divisor_chain {m : ℕ} :
   ⟨fun h => ⟨h.1, divisor_chain_of_practical h⟩,
     fun ⟨hm1, hchain⟩ => practical_of_divisor_chain_condition hm1 hchain⟩
 
+/-- **Consecutive-integer closure.** If `n` is practical then so is `n·(n+1)`. Immediate
+from the Stewart–Sierpiński sufficient condition with multiplier `n + 1`: since `n ∣ n`,
+`σ(n) ≥ n`, hence `n + 1 ≤ σ(n) + 1`. Iterating produces a rapidly growing family
+(`2 → 6 → 42 → …`), the "practical" analogue of Sylvester's sequence. -/
+theorem succ_mul_self_practical {n : ℕ} (h : IsPractical n) :
+    IsPractical ((n + 1) * n) := by
+  refine mul_practical_of_le_succ_sigma h (by omega) ?_
+  have hn1 : 1 ≤ n := h.1
+  have hnmem : n ∈ divisors n := by
+    rw [divisors]; exact Nat.mem_divisors.mpr ⟨dvd_refl _, by omega⟩
+  have hnle : n ≤ ∑ d ∈ divisors n, d :=
+    Finset.single_le_sum (f := fun d => d) (fun i _ => Nat.zero_le i) hnmem
+  omega
+
 end Erdos18

--- a/proofs/Proofs/Erdos18WIP01.lean
+++ b/proofs/Proofs/Erdos18WIP01.lean
@@ -113,6 +113,19 @@
     always holds). It reaches `18 = 2·3²` (`eighteen_practical`), which `practical_mul`
     cannot — `18`'s only nontrivial factorisation `2·9` has the non-practical `9`.
 
+  The characterisation is then closed into a genuine *iff*:
+
+  * `divisor_chain_of_practical` — the **necessary** divisor-gap condition: for practical
+    `m`, every divisor `d ∣ m` obeys `d ≤ 1 + ∑_{e ∣ m, e < d} e` (to represent `d − 1 < m`
+    only smaller divisors are available). The converse of the `finset_chain_covers`
+    sufficiency, previously used only as an inline step inside
+    `representable_le_sigma_of_practical`.
+  * `practical_of_divisor_chain_condition` — the **sufficient** direction packaged from
+    `finset_chain_covers` on the full divisor set.
+  * `practical_iff_divisor_chain` — **`m` practical ⟺ `1 ≤ m` and its divisors form a coin
+    chain** (each divisor `≤ 1 +` the sum of the smaller divisors). This is the full
+    Stewart–Sierpiński characterisation in purely divisor-theoretic form.
+
   All results are axiom-free (`#print axioms` = `[propext, Classical.choice,
   Quot.sound]`) and contain no `sorry`.
 -/

--- a/research/problems/erdos-18-wip-01/knowledge.md
+++ b/research/problems/erdos-18-wip-01/knowledge.md
@@ -100,3 +100,33 @@ The parent established practicality only for the finite `decide`-checked example
 `h(n!) < n^{o(1)}` question — remain unformalized. Natural next elementary bricks:
 Stewart–Sierpiński necessary structure (`p ≤ σ(small divisors)+1` for the least
 non-dividing prime `p`), the Stewart product-closure criterion, and practicality of `n!`.
+
+## Session 2026-07-22 (researcher-1-3): Full Stewart–Sierpiński characterisation (iff)
+
+Closed the practicality criterion into a genuine **iff** in `Erdos18WIP01.lean`
+(0-axiom, `#print axioms` = propext/Classical.choice/Quot.sound, Docker-built):
+
+- `divisor_chain_of_practical` — **necessary** divisor-gap condition: for practical `m`,
+  every divisor `d ∣ m` obeys `d ≤ 1 + ∑_{e ∣ m, e < d} e`. Mechanism: `d − 1 < m` is a
+  distinct-divisor sum (practicality), and each coin used is `≤ d − 1 < d`
+  (`Finset.single_le_sum`), so the smaller divisors already sum to `≥ d − 1`. This is the
+  converse of the coin-chain sufficiency — previously it existed only as the inline
+  `hchain` block inside `representable_le_sigma_of_practical`; now a named theorem.
+- `practical_of_divisor_chain_condition` — **sufficient** direction: `finset_chain_covers`
+  on the full `divisors m` covers `[0, σ(m)] ⊇ [0, m)` (since `m ∈ divisors m` ⟹ `σ ≥ m`).
+- `practical_iff_divisor_chain` — `IsPractical m ↔ 1 ≤ m ∧ ∀ d ∈ divisors m,
+  d ≤ 1 + ∑_{e ∣ m, e < d} e`. The full Stewart–Sierpiński characterisation in
+  divisor-theoretic (not prime-factorisation) form. The `1 ≤ m` conjunct is essential:
+  `m = 0` has `divisors 0 = ∅` so the chain condition is vacuously true but `0` is not
+  practical.
+
+### Idiom notes
+- Reused the exact `hchain` derivation from `representable_le_sigma_of_practical` verbatim
+  as `divisor_chain_of_practical`'s body — a clean refactor target for a future dedup.
+- Sufficiency needs `k ≤ ∑ divisors m`: bound `m ≤ σ(m)` via `Finset.single_le_sum` on
+  `m ∈ divisors m`, then `omega` against `k < m`.
+
+### Remaining open (unchanged, deep)
+The prime-factorisation form (`p₁ = 2`, `pᵢ ≤ σ(∏_{j<i} pⱼ^aⱼ)+1`) would follow from this
+divisor-chain iff plus a sorted-prime bookkeeping layer — mechanical but sizeable. `h(m)`
+growth (`conjecture_part1/2`, the $250 `h(n!) < n^{o(1)}`) remains unformalized and deep.

--- a/research/problems/erdos-18-wip-01/knowledge.md
+++ b/research/problems/erdos-18-wip-01/knowledge.md
@@ -130,3 +130,9 @@ Closed the practicality criterion into a genuine **iff** in `Erdos18WIP01.lean`
 The prime-factorisation form (`p₁ = 2`, `pᵢ ≤ σ(∏_{j<i} pⱼ^aⱼ)+1`) would follow from this
 divisor-chain iff plus a sorted-prime bookkeeping layer — mechanical but sizeable. `h(m)`
 growth (`conjecture_part1/2`, the $250 `h(n!) < n^{o(1)}`) remains unformalized and deep.
+
+### Follow-on (same PR #41201): consecutive-integer closure
+- `succ_mul_self_practical` — `n practical ⟹ (n+1)·n practical` (0-axiom). One-line
+  corollary of `mul_practical_of_le_succ_sigma` with multiplier `n+1`: `n ∣ n` ⟹ `σ(n) ≥ n`
+  ⟹ `n+1 ≤ σ(n)+1`. Iterating gives the fast-growing family `2 → 6 → 42 → …` (practical
+  analogue of Sylvester's sequence). Clean, unblocked.

--- a/src/data/research/problems/erdos-18-wip-01.json
+++ b/src/data/research/problems/erdos-18-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "STRUCTURAL (researcher-1, 2026-07-22T05:59:07Z): added Erdos18WIP01.lean (imports Proofs.Erdos18Problem) with the first results covering infinitely many m at once, all 0-axiom (#print axioms = [propext,Classical.choice,Quot.sound]), Docker-verified (8577 jobs) + host-verified. (1) two_pow_practical: every power of two is practical, via repr_lt_two_pow (binary representation, strong induction). (2) infinite_practicalNumbers: there are infinitely many practical numbers. (3) two_dvd_of_practical/even_of_practical: a matching necessary condition, every practical m>=3 is even. This lifts the parents finite decide-checked examples to uniform structural theorems. The h(m) growth conjectures (Erdos #18 Parts 1-2, $250) remain open/unformalized.",
+    "progressSummary": "PROGRESS: Stewart–Sierpiński practicality criterion closed into a genuine iff (practical_iff_divisor_chain) — divisor-coin-chain characterisation, 0-axiom. Prime-factorisation form and h(m) growth remain open.",
     "builtItems": [
       "decidableIsRepresentable / decidableIsPractical instances (Erdos18Problem.lean)",
       "zero_isRepresentable, one_isRepresentable, isRepresentable_self, isRepresentable_le_sigma, mem_divisors_le (Erdos18Problem.lean)",
@@ -40,13 +40,15 @@
       "repr_lt_two_pow in Erdos18WIP01.lean: every k<2^n is a sum of distinct powers of two from {2^0..2^{n-1}} (binary-representation induction)",
       "two_pow_practical in Erdos18WIP01.lean: IsPractical (2^n) for all n (infinite family)",
       "infinite_practicalNumbers in Erdos18WIP01.lean: PracticalNumbers.Infinite",
-      "two_dvd_of_practical / even_of_practical in Erdos18WIP01.lean: practical m>=3 => 2 | m (necessary condition)"
+      "two_dvd_of_practical / even_of_practical in Erdos18WIP01.lean: practical m>=3 => 2 | m (necessary condition)",
+      "divisor_chain_of_practical / practical_of_divisor_chain_condition / practical_iff_divisor_chain in Erdos18WIP01.lean (necessary + sufficient divisor-gap condition, iff)"
     ],
     "insights": [
       "Erdos18Problem.lean stub developed: representability (IsRepresentable) and practicality (IsPractical) are DECIDABLE via a finite powerset search over the divisor set — a single decision procedure subsuming all future example checks; all lemmas axiom-free (plain kernel decide, no native_decide/Lean.ofReduceBool).",
       "Powers of two are an INFINITE family of practical numbers: every k<2^n is a sum of distinct divisors {2^0,...,2^{n-1}} of 2^n by binary representation (repr_lt_two_pow, proved by strong induction on n). This lifts the parents finite decide-checked examples (4,6,8) to a uniform structural theorem two_pow_practical.",
       "Consequently there are INFINITELY MANY practical numbers (infinite_practicalNumbers: PracticalNumbers.Infinite), via injectivity of n |-> 2^n on the practical set.",
-      "Matching NECESSARY condition: any practical m>=3 is even (two_dvd_of_practical / even_of_practical). To represent 2 as a sum of distinct divisors of m, since 1 is the only divisor below 2, the divisor 2 itself must be used, so 2 | m. Proof: a subset of positive divisors summing to 2 is forced to be {2} (each element <=2 by single_le_sum, so S subset {1,2}; sum 2 rules out subsets of {1})."
+      "Matching NECESSARY condition: any practical m>=3 is even (two_dvd_of_practical / even_of_practical). To represent 2 as a sum of distinct divisors of m, since 1 is the only divisor below 2, the divisor 2 itself must be used, so 2 | m. Proof: a subset of positive divisors summing to 2 is forced to be {2} (each element <=2 by single_le_sum, so S subset {1,2}; sum 2 rules out subsets of {1}).",
+      "Full Stewart–Sierpiński characterisation as an iff: practical_iff_divisor_chain — m practical ⟺ 1≤m ∧ every divisor d ≤ 1 + sum of smaller divisors (coin-chain condition), 0-axiom"
     ],
     "mathlibGaps": [],
     "nextSteps": [

--- a/src/data/research/problems/erdos-18-wip-01.json
+++ b/src/data/research/problems/erdos-18-wip-01.json
@@ -41,7 +41,8 @@
       "two_pow_practical in Erdos18WIP01.lean: IsPractical (2^n) for all n (infinite family)",
       "infinite_practicalNumbers in Erdos18WIP01.lean: PracticalNumbers.Infinite",
       "two_dvd_of_practical / even_of_practical in Erdos18WIP01.lean: practical m>=3 => 2 | m (necessary condition)",
-      "divisor_chain_of_practical / practical_of_divisor_chain_condition / practical_iff_divisor_chain in Erdos18WIP01.lean (necessary + sufficient divisor-gap condition, iff)"
+      "divisor_chain_of_practical / practical_of_divisor_chain_condition / practical_iff_divisor_chain in Erdos18WIP01.lean (necessary + sufficient divisor-gap condition, iff)",
+      "succ_mul_self_practical: n practical ⟹ n(n+1) practical (0-axiom corollary of Stewart–Sierpiński)"
     ],
     "insights": [
       "Erdos18Problem.lean stub developed: representability (IsRepresentable) and practicality (IsPractical) are DECIDABLE via a finite powerset search over the divisor set — a single decision procedure subsuming all future example checks; all lemmas axiom-free (plain kernel decide, no native_decide/Lean.ofReduceBool).",


### PR DESCRIPTION
## erdos-18-wip-01 — Full Stewart–Sierpiński characterisation (an `iff`)

Closes the practicality criterion into a genuine **iff** on `Erdos18WIP01.lean`.
The sufficiency engine (`finset_chain_covers`) and sharp representability
(`representable_le_sigma_of_practical`) were already present, but the *necessary*
divisor-gap condition existed only as an inline `have` inside the sharp-representability
proof. This PR extracts it as a named theorem and packages both directions:

- **`divisor_chain_of_practical`** (necessary) — for practical `m`, every divisor
  `d ∣ m` satisfies `d ≤ 1 + ∑_{e ∣ m, e < d} e`. To represent `d − 1 < m` only divisors
  `< d` are available (`Finset.single_le_sum`), so they already sum to `≥ d − 1`.
- **`practical_of_divisor_chain_condition`** (sufficient) — `finset_chain_covers` on the
  full divisor set covers `[0, σ(m)] ⊇ [0, m)`.
- **`practical_iff_divisor_chain`** — `IsPractical m ↔ 1 ≤ m ∧ ∀ d ∈ divisors m,
  d ≤ 1 + ∑_{e ∣ m, e < d} e`. The full Stewart–Sierpiński criterion in divisor-theoretic
  (not prime-factorisation) form. The `1 ≤ m` conjunct is essential — `m = 0` has
  `divisors 0 = ∅`, making the chain condition vacuously true while `0` is not practical.

### Verification
- Docker build (`Proofs.Erdos18WIP01`): **succeeded** (only pre-existing deprecation warnings).
- `#print axioms Erdos18.practical_iff_divisor_chain` = `[propext, Classical.choice, Quot.sound]` — **0 axioms, no sorry**.

### Remaining open
The prime-factorisation form (`p₁ = 2`, `pᵢ ≤ σ(∏_{j<i} pⱼ^aⱼ)+1`) follows from this
divisor-chain iff plus sorted-prime bookkeeping (mechanical, sizeable). The `h(m)` growth
questions remain unformalized and deep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Added: consecutive-integer closure
- **`succ_mul_self_practical`** — `n` practical ⟹ `n·(n+1)` practical (0-axiom). One-line corollary of the criterion with multiplier `n+1` (`n ∣ n` ⟹ `σ(n) ≥ n`). Iterating gives the growing family `2 → 6 → 42 → …` (practical analogue of Sylvester's sequence). `#print axioms` = `[propext, Classical.choice, Quot.sound]`.
