### PR TITLE
Audit fix: erdos-301 stale 'axiomatized' prose (0 axioms, bounds fully proved)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12408,9 +12408,9 @@
     },
     "erdos-301": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:25Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T08:15:49Z",
+      "result": "issues-fixed"
     },
     "erdos-302": {
       "agentId": "auditor-agent-re-audit",

--- a/src/data/proofs/erdos-301/meta.json
+++ b/src/data/proofs/erdos-301/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/301",
-    "status": "axiomatized",
+    "status": "open",
     "proofRepoPath": "Proofs/Erdos301Problem.lean",
     "tags": [
       "erdos",
@@ -31,7 +31,7 @@
     "historicalContext": "**Egyptian Fractions and Avoidance**\n\nEgyptian fractions — representations of rationals as sums of distinct unit fractions — date to the Rhind Papyrus (c. 1650 BCE). Erdős posed Problem 301 as a natural extremal question: how large can a subset of {1,...,N} be while avoiding all Egyptian fraction decompositions among its elements?\n\nThe trivial lower bound f(N) >= N/2 comes from the interval (N/2, N], whose elements have reciprocals too small to decompose within the set. Van Doorn improved the upper bound to (25/28 + o(1))N using divisibility patterns: identities like 1/(2a) = 1/(3a) + 1/(6a) force elements in arithmetic progressions to participate in decompositions.\n\nThe problem connects to **Erdős Problem 302** (Egyptian fraction representations) and **Problem 327** (sum-divides-product), forming a cluster of questions about the additive structure of unit fractions. Graham (2013) surveyed Erdős's extensive work on Egyptian fractions at the Erdős Centennial conference. Croot (2003) studied related coloring problems for unit fractions, establishing connections to the Hales-Jewett theorem.",
     "problemStatement": "Estimate f(N), the max |A| for A ⊆ {1,...,N} with no 1/a = Σ 1/bᵢ using distinct elements of A.",
     "text": "Maximum subset of {1,...,N} with no 1/a = 1/b₁+...+1/bₖ using distinct elements. Lower: N/2 (half-interval). Upper: (25/28)N (van Doorn). Conjecture: f(N) = (1/2+o(1))N.",
-    "proofStrategy": "We define HasEgyptianDecomp for unit fraction decomposition, EgyptFractionFree for avoidance, and maxEgyptFree as the extremal function. The main conjecture asserts f(N) ~ N/2. Lower and upper bounds are axiomatized. The hereditary property and base cases are proved directly in Lean.",
+    "proofStrategy": "We define HasEgyptianDecomp for unit fraction decomposition, EgyptFractionFree for avoidance, and maxEgyptFree as the extremal function. The main conjecture asserts f(N) ~ N/2 and is stated as an open Prop (not proved). The lower bound f(N) >= N/2, the trivial upper bound f(N) <= N (and a weakening of Van Doorn's (25/28+o(1))N bound), the hereditary property, and base cases are all proved directly in Lean with 0 axioms.",
     "keyInsights": [
       "Elements in **(N/2, N]** cannot have Egyptian fraction decompositions from the same interval, giving f(N) >= N/2",
       "**Van Doorn's 25/28 bound** uses forced patterns like {2a, 3a, 4a, 6a, 12a} where 1/(2a) = 1/(3a) + 1/(6a)",
@@ -95,7 +95,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem 301 on Egyptian fraction avoidance sets, with lower bound N/2, upper bound 25/28 * N, and the conjecture f(N) ~ N/2. Two theorems are fully proved (empty set and hereditary property), four results are axiomatized. Zero sorries.",
+    "summary": "The formalization captures Erdős Problem 301 on Egyptian fraction avoidance sets, with lower bound N/2, upper bound 25/28 * N, and the conjecture f(N) ~ N/2. The main conjecture is stated as an open Prop; all seven supporting theorems (the N/2 lower bound, the f(N) <= N and weakened Van Doorn upper bounds, and the empty/singleton/subset closure properties) are fully proved. Zero axioms, zero sorries.",
     "implications": "**Theoretical Significance**: Resolution would pin down the exact density of unit-fraction-free sets.\n\nThe hereditary structure suggests connections to Kruskal-Katona type bounds. Progress likely requires new tools for detecting forced Egyptian fraction patterns in dense sets, potentially drawing on techniques from additive combinatorics (sum-free sets, Schur numbers).",
     "openQuestions": [
       "Is f(N) = (1/2+o(1))N, or is the true density strictly greater than 1/2?",


### PR DESCRIPTION
## Audit result: ISSUES-FIXED

**Proof**: erdos-301 (Egyptian Fraction Avoidance Sets)

Reserve-mode re-audit surfaced stale narrative from a pre-upgrade version. The file has **0 axioms, 0 sorries** and all 7 supporting theorems are fully proved, but three metadata fields still described the bounds as axiomatized.

### Fixed (all safe-direction — prose understated the achievement)
- `meta.status`: `axiomatized` → `open` (0 axioms; conjecture stated as an open Prop, `erdosProblemStatus` already `open`, badge already `wip`).
- `overview.proofStrategy`: removed "Lower and upper bounds are axiomatized" — the N/2 lower bound (`maxEgyptFree_lower`), the trivial `f(N) <= N` (`maxEgyptFree_le`), and the weakened Van Doorn bound (`vanDoorn_upper`) are all proved in Lean.
- `conclusion.summary`: "Two theorems are fully proved … four results are axiomatized" → all seven theorems proved, zero axioms.

### Verified accurate (left unchanged)
- `axiomCount: 0`, `sorries: 0`, `theoremCount: 7`, `definitionCount: 4` all match the source.
- `sections[]` already describe the bounds with "PROVES" and correctly note `vanDoorn_upper` is a weakening of the true (25/28+o(1))N bound — no overclaim.
- Main conjecture `ErdosProblem301` is a bare `def … : Prop` (not proved) — honest.

---
Discovered during gallery integrity audit.
🤖 Generated with [Claude Code](https://claude.com/claude-code)