### PR TITLE
Fix: erdos-304 tighten originalContributions to declared content

### DIFF
--- a/src/data/proofs/erdos-304/meta.json
+++ b/src/data/proofs/erdos-304/meta.json
@@ -43,11 +43,11 @@
     "originalContributions": [
       "Definition of unitFractionExpressible as the set of valid representation sizes",
       "Axiomatization of N(a,b) and N(b) as minimal collection sizes",
-      "Formalization of Erdős (1950) lower and upper bounds",
+      "Formalization of the Erdős (1950) lower bound as an axiom (upper bound stated informally in comments)",
       "Formalization of Vose (1985) improved upper bound",
       "Statement of the main open conjecture",
-      "Average case lower bound formalization",
-      "Connection to Erdős Problem #293 via N(b-1,b)"
+      "Axiomatization of the average quantity N̄(a,b) (`averageCollection`); its lower bound noted informally",
+      "Definition of N(b-1,b) (`almostOneCollection`); relation to Erdős Problem #293 noted informally"
     ],
     "axiomCount": 5,
     "lineCount": 192,


### PR DESCRIPTION
## Summary

Tightens three `originalContributions` bullets in `erdos-304/meta.json` that described comment-only content as "formalization"/"formalized", overstating what the Lean file actually declares. Fix per auditor issue #41204 (LOW). No change to counts, status (`axiomatized`), badge (`axiom`), or `assumptions` — those are accurate.

## Changes (prose only)

- **#3** `"Formalization of Erdős (1950) lower and upper bounds"` → `"Formalization of the Erdős (1950) lower bound as an axiom (upper bound stated informally in comments)"` — only `erdos_1950_lower_bound` is declared; the Erdős upper bound is comment-only (lines 91–94).
- **#6** `"Average case lower bound formalization"` → `"Axiomatization of the average quantity N̄(a,b) (\`averageCollection\`); its lower bound noted informally"` — only `axiom averageCollection : ℕ → ℚ` is declared; the lower bound is comment-only (lines 131–133).
- **#7** `"Connection to Erdős Problem #293 via N(b-1,b)"` → `"Definition of N(b-1,b) (\`almostOneCollection\`); relation to Erdős Problem #293 noted informally"` — `almostOneCollection` is defined (line 142), but the #293 bridge is comment-only.

## Evidence

```
$ grep -nE "^axiom erdos_1950_lower_bound|^axiom averageCollection" proofs/Proofs/Erdos304Problem.lean
88:axiom erdos_1950_lower_bound :
129:axiom averageCollection : ℕ → ℚ
$ grep -n almostOneCollection proofs/Proofs/Erdos304Problem.lean
142:noncomputable def almostOneCollection (b : ℕ) : ℕ := smallestCollection (b - 1) b
```

JSON validated with `json.load`.

Closes #41204
