### PR TITLE
Fix: erdos-305 correct sections[] phantom axioms

### DIFF
--- a/src/data/proofs/erdos-305/meta.json
+++ b/src/data/proofs/erdos-305/meta.json
@@ -97,21 +97,21 @@
     {
       "id": "d-functions",
       "title": "The D(a,b) and D(b) Functions",
-      "summary": "Defines maxDenominator (Finset.sup), D_ab (minimax over representations — partially defined with Nat.find), D_ab_value (axiom for proper minimality), and D_b (max over numerators 1 ≤ a < b).",
+      "summary": "Defines maxDenominator (Finset.sup), D_ab (minimax over representations, sInf-based), and D_b (max over numerators 1 ≤ a < b).",
       "startLine": 79,
       "endLine": 118
     },
     {
       "id": "bounds",
       "title": "Known Bounds",
-      "summary": "Four key bounds axiomatized: trivial D(b) ≥ b, prime lower bound D(p) ≫ p log p, Bleicher-Erdős D(b) ≪ b(log b)², Yokota D(b) ≪ b(log b)(log log b)⁴(log log log b)², and Liu-Sawhney D(b) ≪ b(log b)(log log b)³. Plus the conjecture formalization and solution (sorry for asymptotic comparison).",
+      "summary": "Defines erdos305Conjecture (D(b) ≪ b(log b)^{1+ε}) and states erdos_305_solved, whose proof is a sorry for the asymptotic comparison. No bound axioms are formalized here; the Yokota/Liu-Sawhney bounds are described only in docstrings.",
       "startLine": 119,
       "endLine": 186
     },
     {
       "id": "greedy",
       "title": "The Greedy Algorithm",
-      "summary": "Implements greedyStep (ceiling division + remainder computation), axiomatizes termination, and demonstrates suboptimality via the 2/9 = 1/5 + 1/45 vs 1/6 + 1/18 example.",
+      "summary": "Defines greedyStep (ceiling division + remainder computation) for the Fibonacci-Sylvester algorithm, followed by the erdos305Problem restatement and summary re-exports of erdos_305_solved.",
       "startLine": 186,
       "endLine": 186
     }


### PR DESCRIPTION
## Summary

Fixes gallery integrity issue #41207 (LOW): three `sections[]` summaries in `erdos-305/meta.json` described declarations that do not exist in `proofs/Proofs/Erdos305Problem.lean`, overstating the formalized scope. Headline counts/status were already correct and are unchanged.

## Evidence

The Lean file contains exactly ONE axiom (`egyptian_representation_exists`, line 72) and ONE sorry (`erdos_305_solved`, line 126). No `D_ab_value`, no bound axioms, no termination axiom exist (grep-confirmed).

## Changes (sections[] only)

- **d-functions**: dropped phantom "D_ab_value (axiom for proper minimality)"; now lists only `maxDenominator`, `D_ab` (sInf-based), `D_b`.
- **bounds**: replaced "Four key bounds axiomatized …" with an accurate description — the section defines `erdos305Conjecture` and states `erdos_305_solved` with a `sorry`; the Yokota/Liu-Sawhney bounds appear only in docstrings.
- **greedy**: dropped "axiomatizes termination"; now describes only the `greedyStep` def plus `erdos305Problem`/summary re-exports.

No change to status/badge/counts (`axiomCount:1`, `sorries:1` remain accurate).

Closes #41207
