### PR TITLE
Research: erdos-30-wip-01 — Erdős–Turán counting upper bound for Sidon sets (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos30WIP01.lean
+++ b/proofs/Proofs/Erdos30WIP01.lean
@@ -1,0 +1,142 @@
+/-
+  Erdős Problem #30: Sidon Sets — the Erdős–Turán counting upper bound (0-axiom).
+
+  Companion to `Erdos30Problem.lean`. That file defines `IsSidonSet`,
+  `HasDistinctSums`, and the Sidon number `sidonNumber N = h(N)` (the maximum
+  size of a Sidon set inside {0,1,…,N}), but leaves the actual bounds on `h(N)`
+  in comments or as axioms. This file closes the elementary half of that gap:
+  the classical Erdős–Turán (1941) *upper* bound, in the clean counting form.
+
+  Main results (all axiom-free — `#print axioms` = propext/Classical.choice/Quot.sound):
+
+  * `diffMap_injOn`         : on a Sidon set the difference map (a,b) ↦ a − b is
+                              injective over the off-diagonal.
+  * `sidon_offDiag_card_le` : a Sidon set A ⊆ {0,…,N} has |A|(|A|−1) ≤ 2N
+                              (stated via `offDiag`, whose card is |A|² − |A|).
+  * `sidon_card_sq_le`      : |A|² ≤ 2N + |A|.
+  * `sidon_card_le_sqrt`    : |A| ≤ ⌊√(2N)⌋ + 1.
+  * `sidonNumber_le_sqrt`   : h(N) = sidonNumber N ≤ ⌊√(2N)⌋ + 1.
+  * `sidonNumber_le_real`   : (h(N) : ℝ) ≤ √(2N) + 1  — the √N shape of Erdős–Turán.
+
+  The mechanism: for a Sidon set the differences a − b (a ≠ b) are all distinct
+  (a − b = c − d rewrites to a + d = c + b, and the Sidon property forces the
+  pair to match), and they are nonzero integers in [−N, N], of which there are
+  exactly 2N. So the number |A|(|A|−1) of ordered off-diagonal pairs is ≤ 2N.
+
+  The open Erdős–Turán conjecture — that the N^{1/4} error term can be reduced to
+  N^ε for every ε > 0 ($1000 prize) — is untouched, and stays a `Prop` in the
+  parent file. This file only supplies the provable √(2N) upper envelope.
+-/
+
+import Mathlib
+import Proofs.Erdos30Problem
+
+open Finset
+
+namespace Erdos30
+
+/-- The signed difference map underlying the Erdős–Turán counting argument. -/
+private def diffMap (p : ℕ × ℕ) : ℤ := (p.1 : ℤ) - (p.2 : ℤ)
+
+/-- **Injectivity of the difference map on a Sidon set.**
+    If `a − b = c − d` with `a,b,c,d` in a Sidon set `A` and `a ≠ b`, `c ≠ d`,
+    then `(a,b) = (c,d)`. The equation `a − b = c − d` is `a + d = c + b`, and the
+    Sidon property (`HasDistinctSums`) forces `{a,d} = {c,b}`; the diagonal branch
+    `a = b` is excluded on the off-diagonal. -/
+theorem diffMap_injOn {A : Finset ℕ} (hA : IsSidonSet A) :
+    Set.InjOn diffMap ↑A.offDiag := by
+  intro p hp q hq hpq
+  rw [Finset.mem_coe, Finset.mem_offDiag] at hp hq
+  obtain ⟨hp1, hp2, hpne⟩ := hp
+  obtain ⟨hq1, hq2, hqne⟩ := hq
+  -- Turn `a − b = c − d` into the sum equation `p.1 + q.2 = q.1 + p.2`.
+  have hsum : p.1 + q.2 = q.1 + p.2 := by
+    have : (p.1 : ℤ) + q.2 = q.1 + p.2 := by
+      simp only [diffMap] at hpq; omega
+    exact_mod_cast this
+  have hds := (sidon_iff_distinct_sums A).mp hA
+  rcases hds p.1 q.2 q.1 p.2 hp1 hq2 hq1 hp2 hsum with ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · exact Prod.ext h1 h2.symm
+  · exact absurd h1 hpne
+
+/-- **Erdős–Turán counting bound (off-diagonal form).**
+    A Sidon set `A ⊆ {0,…,N}` has `|A|² − |A| = |A.offDiag| ≤ 2N`. -/
+theorem sidon_offDiag_card_le {A : Finset ℕ} (N : ℕ)
+    (hsub : A ⊆ Finset.range (N + 1)) (hA : IsSidonSet A) :
+    A.offDiag.card ≤ 2 * N := by
+  -- The difference map sends the off-diagonal into the 2N nonzero integers in [−N, N].
+  have hmaps : ∀ p ∈ A.offDiag, diffMap p ∈ (Finset.Icc (-(N : ℤ)) N).erase 0 := by
+    intro p hp
+    rw [Finset.mem_offDiag] at hp
+    obtain ⟨hp1, hp2, hpne⟩ := hp
+    have hb1 : p.1 ≤ N := by
+      have := hsub hp1; rwa [Finset.mem_range, Nat.lt_succ_iff] at this
+    have hb2 : p.2 ≤ N := by
+      have := hsub hp2; rwa [Finset.mem_range, Nat.lt_succ_iff] at this
+    rw [Finset.mem_erase, Finset.mem_Icc]
+    refine ⟨?_, ?_, ?_⟩
+    · simp only [diffMap]; intro h; exact hpne (by omega)
+    · simp only [diffMap]; omega
+    · simp only [diffMap]; omega
+  have hinj : Set.InjOn diffMap ↑A.offDiag := diffMap_injOn hA
+  have hcard := Finset.card_le_card_of_injOn diffMap hmaps hinj
+  have h0mem : (0 : ℤ) ∈ Finset.Icc (-(N : ℤ)) N := by rw [Finset.mem_Icc]; omega
+  have hScard : ((Finset.Icc (-(N : ℤ)) N).erase 0).card = 2 * N := by
+    rw [Finset.card_erase_of_mem h0mem, Int.card_Icc]; omega
+  omega
+
+/-- **Erdős–Turán counting bound (square form).**
+    A Sidon set `A ⊆ {0,…,N}` satisfies `|A|² ≤ 2N + |A|`. -/
+theorem sidon_card_sq_le {A : Finset ℕ} (N : ℕ)
+    (hsub : A ⊆ Finset.range (N + 1)) (hA : IsSidonSet A) :
+    A.card * A.card ≤ 2 * N + A.card := by
+  have h := sidon_offDiag_card_le N hsub hA
+  rw [Finset.offDiag_card] at h
+  omega
+
+/-- **Erdős–Turán upper bound (√ form).**
+    A Sidon set `A ⊆ {0,…,N}` has size at most `⌊√(2N)⌋ + 1`. -/
+theorem sidon_card_le_sqrt {A : Finset ℕ} (N : ℕ)
+    (hsub : A ⊆ Finset.range (N + 1)) (hA : IsSidonSet A) :
+    A.card ≤ Nat.sqrt (2 * N) + 1 := by
+  have hcard := sidon_card_sq_le N hsub hA
+  -- (|A| − 1)² ≤ |A|(|A| − 1) = |A|² − |A| ≤ 2N.
+  have key : (A.card - 1) * (A.card - 1) ≤ 2 * N := by
+    rcases Nat.eq_zero_or_pos A.card with h0 | h0
+    · simp [h0]
+    · obtain ⟨m, hm⟩ : ∃ m, A.card = m + 1 := ⟨A.card - 1, by omega⟩
+      rw [hm] at hcard ⊢
+      have e : (m + 1) * (m + 1) = m * m + 2 * m + 1 := by ring
+      rw [e] at hcard
+      simp only [Nat.add_sub_cancel]
+      omega
+  have hsqrt : A.card - 1 ≤ Nat.sqrt (2 * N) := Nat.le_sqrt.mpr key
+  omega
+
+/-- **Erdős–Turán bound on the Sidon number** `h(N) = sidonNumber N ≤ ⌊√(2N)⌋ + 1`.
+    Every Sidon set in `{0,…,N}` obeys `sidon_card_le_sqrt`, and `h(N)` is the
+    supremum of their sizes, so the bound passes to the supremum. -/
+theorem sidonNumber_le_sqrt (N : ℕ) : sidonNumber N ≤ Nat.sqrt (2 * N) + 1 := by
+  unfold sidonNumber
+  apply Finset.sup_le
+  intro A hA
+  simp only [Finset.mem_filter, Finset.mem_powerset] at hA
+  exact sidon_card_le_sqrt N hA.1 hA.2
+
+/-- **Erdős–Turán bound in real form**: `h(N) ≤ √(2N) + 1`, the `√N` envelope. -/
+theorem sidonNumber_le_real (N : ℕ) :
+    (sidonNumber N : ℝ) ≤ Real.sqrt (2 * N) + 1 := by
+  have h := sidonNumber_le_sqrt N
+  have hnr : (Nat.sqrt (2 * N) : ℝ) ≤ Real.sqrt (2 * N) := by
+    rw [show (Nat.sqrt (2 * N) : ℝ) = Real.sqrt ((Nat.sqrt (2 * N) : ℝ) ^ 2) from
+      (Real.sqrt_sq (by positivity)).symm]
+    apply Real.sqrt_le_sqrt
+    have hle : (Nat.sqrt (2 * N)) ^ 2 ≤ 2 * N := Nat.sqrt_le' (2 * N)
+    calc (Nat.sqrt (2 * N) : ℝ) ^ 2 = ((Nat.sqrt (2 * N) ^ 2 : ℕ) : ℝ) := by push_cast; ring
+      _ ≤ ((2 * N : ℕ) : ℝ) := by exact_mod_cast hle
+      _ = 2 * (N : ℝ) := by push_cast; ring
+  calc (sidonNumber N : ℝ) ≤ ((Nat.sqrt (2 * N) + 1 : ℕ) : ℝ) := by exact_mod_cast h
+    _ = (Nat.sqrt (2 * N) : ℝ) + 1 := by push_cast; ring
+    _ ≤ Real.sqrt (2 * N) + 1 := by linarith [hnr]
+
+end Erdos30

--- a/research/problems/erdos-30-wip-01/knowledge.md
+++ b/research/problems/erdos-30-wip-01/knowledge.md
@@ -19,3 +19,49 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session 2026-07-22 (researcher-1-3) — Erdős–Turán counting UPPER bound (0-axiom)
+
+**Mode**: FRESH (EMPTY → ACT) · **Outcome**: progress — converted the classical
+Erdős–Turán (1941) upper bound from parent-file comments/axioms into 6 axiom-free
+theorems in a new companion `proofs/Proofs/Erdos30WIP01.lean` (Docker-verified
+v4.31.0; `#print axioms` on all six = `[propext, Classical.choice, Quot.sound]`).
+
+**Mechanism** (difference-map counting, the clean route — avoids the fiddly
+sum-over-{2,…,2N} bookkeeping):
+- For a Sidon set `A`, the map `diffMap (a,b) = (a:ℤ) − b` is **injective on the
+  off-diagonal** (`diffMap_injOn`): `a − b = c − d` rewrites to `a + d = c + b`,
+  and `HasDistinctSums` forces `{a,d} = {c,b}`; the branch `a = b` is killed by
+  off-diagonality. Uses the parent's `sidon_iff_distinct_sums`.
+- The image lands in the `2N` nonzero integers of `Icc (−N) N` (via
+  `Int.card_Icc` + `Finset.card_erase_of_mem`), so
+  `A.offDiag.card ≤ 2N` (`sidon_offDiag_card_le`), and
+  `Finset.offDiag_card : |A.offDiag| = |A|² − |A|` gives `|A|² ≤ 2N + |A|`
+  (`sidon_card_sq_le`).
+- Squeeze `(|A|−1)² ≤ |A|(|A|−1) ≤ 2N` then `Nat.le_sqrt` ⟹
+  `|A| ≤ ⌊√(2N)⌋ + 1` (`sidon_card_le_sqrt`).
+- `Finset.sup_le` passes the per-set bound to the supremum:
+  `sidonNumber N ≤ ⌊√(2N)⌋ + 1` (`sidonNumber_le_sqrt`), and a `Real.sqrt_sq` /
+  `Real.sqrt_le_sqrt` cast gives `(sidonNumber N : ℝ) ≤ √(2N) + 1`
+  (`sidonNumber_le_real`) — the `√N` shape of Erdős–Turán.
+
+**Reusable idioms (v4.31)**:
+- `obtain ⟨m, rfl⟩ : ∃ m, A.card = m + 1` FAILS (`subst` on a non-variable
+  `A.card`); use `obtain ⟨m, hm⟩ … ; rw [hm] at hcard ⊢` instead.
+- `Nat.le_sqrt : m ≤ Nat.sqrt n ↔ m * m ≤ n`; `Nat.sqrt_le' n : Nat.sqrt n ^ 2 ≤ n`.
+- `Int.card_Icc : #(Icc a b) = (b + 1 − a).toNat` — `omega` closes the `.toNat`
+  arithmetic after `Finset.card_erase_of_mem`.
+- `(Nat.sqrt n : ℝ) ≤ Real.sqrt n` via `rw [← Real.sqrt_sq (positivity)]` then
+  `Real.sqrt_le_sqrt` + `exact_mod_cast (Nat.sqrt_le' n)`.
+
+**Mathlib gap**: no Sidon/B₂-set API, no roots-of-unity/Vandermonde discriminant
+product — build the counting bound from `Finset.offDiag_card` / `Int.card_Icc` /
+`Nat.le_sqrt`.
+
+**STILL OPEN / out of scope** (untouched, honest): the `N^{1/4}` constant
+refinement (Erdős–Turán exact form `√N + N^{1/4} + 1`, and Lindström/BFR/CHO
+improvements), Singer's projective-plane LOWER bound `h(N) ≥ (1−o(1))√N` (deep
+finite geometry), and the OPEN `$1000` Erdős–Turán conjecture (error `≤ N^ε` for
+all `ε > 0`) which stays a `Prop`.

--- a/src/data/research/problems/erdos-30-wip-01.json
+++ b/src/data/research/problems/erdos-30-wip-01.json
@@ -18,7 +18,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-07-09T17:33:20-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
@@ -31,11 +31,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: formalized the Erdős–Turán (1941) counting UPPER bound as 6 axiom-free theorems (Erdos30WIP01.lean, Docker-verified v4.31, #print axioms = propext/Classical.choice/Quot.sound). Bounds the gallery Sidon number: h(N) = sidonNumber N ≤ ⌊√(2N)⌋+1 ≤ √(2N)+1. The parent Erdos30Problem.lean previously left ALL bounds in comments/axioms; this converts the classical upper bound into genuine theorems. The N^{1/4} refinement and the OPEN Erdős–Turán conjecture (whether error ≤ N^ε) remain untouched.",
+    "builtItems": [
+      "Erdos30WIP01.lean: diffMap_injOn (Set.InjOn of difference map on Sidon off-diagonal)",
+      "Erdos30WIP01.lean: sidon_offDiag_card_le (|A.offDiag| ≤ 2N for Sidon A ⊆ {0..N})",
+      "Erdos30WIP01.lean: sidon_card_sq_le (|A|² ≤ 2N + |A|)",
+      "Erdos30WIP01.lean: sidon_card_le_sqrt (|A| ≤ ⌊√(2N)⌋+1)",
+      "Erdos30WIP01.lean: sidonNumber_le_sqrt (h(N) ≤ ⌊√(2N)⌋+1) — bounds the gallery Sidon number",
+      "Erdos30WIP01.lean: sidonNumber_le_real ((h(N):ℝ) ≤ √(2N)+1)"
+    ],
+    "insights": [
+      "Erdős–Turán upper bound is provable elementarily via difference-map injectivity: for a Sidon set A the map (a,b)↦a−b is injective on the off-diagonal (a−b=c−d ⇒ a+d=c+b ⇒ pair matches by the Sidon property), its image is nonzero integers in [−N,N] (2N of them), so |A.offDiag|=|A|²−|A| ≤ 2N.",
+      "Clean √-form: |A|² ≤ 2N + |A| gives (|A|−1)² ≤ |A|(|A|−1) ≤ 2N, hence |A| ≤ Nat.sqrt(2N)+1; passes to the supremum sidonNumber via Finset.sup_le, giving h(N) ≤ ⌊√(2N)⌋+1 ~ √(2N).",
+      "Mathlib has NO Sidon/B₂-set API and no roots-of-unity/Vandermonde discriminant product; the counting bound is best built from Finset.offDiag_card, Int.card_Icc, and Nat.le_sqrt."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Optional: sharpen the constant toward √N + N^{1/4} + 1 (Erdős–Turán 1941) — needs the finer sum-counting over {2,…,2N}; the √(2N)+1 form is the clean elementary envelope.",
+      "Lower bound side: Singer/Bose difference-set construction giving h(N) ≥ (1−o(1))√N is DEEP (finite projective geometry) — keep axiomatized.",
+      "The Erdős–Turán conjecture (error N^ε for all ε>0, $1000) stays OPEN as a Prop; do NOT claim proved."
+    ],
     "markdown": "# Knowledge Base: erdos-30-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [
@@ -56,7 +71,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.781Z",
-  "lastUpdate": "2026-07-10T00:41:25.927Z",
+  "lastUpdate": "2026-07-22",
   "significance": 8,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary

Research session for **erdos-30-wip-01** (Erdős Problem #30, Sidon sets, $1000). The parent `Erdos30Problem.lean` defines `IsSidonSet` and the Sidon number `sidonNumber N = h(N)` but leaves **all** bounds on `h(N)` in comments or as axioms. This PR closes the elementary half of that gap: the classical **Erdős–Turán (1941) upper bound**, as genuine axiom-free theorems.

## Progress

New file `proofs/Proofs/Erdos30WIP01.lean` (imports the parent, reuses its `sidon_iff_distinct_sums` and `sidonNumber`). Docker-verified on v4.31.0; `#print axioms` on all six theorems = `[propext, Classical.choice, Quot.sound]` (0 assumptions).

- `diffMap_injOn` — the difference map `(a,b) ↦ (a:ℤ) − b` is injective on a Sidon set's off-diagonal (`a − b = c − d ⇒ a + d = c + b`, and the Sidon property forces the pair to match; the diagonal branch `a = b` is excluded).
- `sidon_offDiag_card_le` — for Sidon `A ⊆ {0,…,N}`, `|A.offDiag| ≤ 2N` (the image is the `2N` nonzero integers of `Icc(−N,N)`).
- `sidon_card_sq_le` — `|A|² ≤ 2N + |A|` (via `Finset.offDiag_card`).
- `sidon_card_le_sqrt` — `|A| ≤ ⌊√(2N)⌋ + 1` (squeeze `(|A|−1)² ≤ |A|(|A|−1) ≤ 2N` + `Nat.le_sqrt`).
- `sidonNumber_le_sqrt` — **`h(N) = sidonNumber N ≤ ⌊√(2N)⌋ + 1`** (`Finset.sup_le` passes the per-set bound to the supremum).
- `sidonNumber_le_real` — `(h(N) : ℝ) ≤ √(2N) + 1`, the `√N` shape of Erdős–Turán.

## Findings

- **Mechanism**: the difference-map counting route (distinct nonzero differences in `[−N, N]`) is cleaner in Lean than the sum-over-`{2,…,2N}` route — it avoids triangle-counting and stays a single `Finset.card_le_card_of_injOn`.
- **Mathlib gap**: no Sidon / B₂-set API, and no roots-of-unity / Vandermonde discriminant product; the bound is built from `Finset.offDiag_card`, `Int.card_Icc`, `Nat.le_sqrt`.

## Status

**Outcome**: progress — the classical upper bound is now formalized and honestly bounds the gallery Sidon number `h(N)`.

**Out of scope / still open** (deliberately untouched): the `N^{1/4}` constant refinement (exact `√N + N^{1/4} + 1`, and Lindström/BFR/CHO improvements), Singer's projective-plane **lower** bound `h(N) ≥ (1−o(1))√N` (deep finite geometry), and the **OPEN $1000 Erdős–Turán conjecture** (error `≤ N^ε` for all `ε > 0`), which remains a `Prop` in the parent file.

🤖 Generated by researcher-1-3
