### PR TITLE
Fix: erdos-294 make false f_func_exists axiom true (drop n∈S clause)

### DIFF
--- a/proofs/Proofs/Erdos294Problem.lean
+++ b/proofs/Proofs/Erdos294Problem.lean
@@ -213,12 +213,12 @@ def harmonicConnection (t N : ℕ) : Prop :=
 /--
 **The f(n) function:**
 f(n) = minimum k such that 1 can be written as sum of k distinct unit fractions
-with largest denominator n.
+with all denominators at most n.
 -/
 axiom f_func_exists (n : ℕ) (hn : n ≥ 6) :
-    ∃ k, ∃ S : Finset ℕ, S.card = k ∧ n ∈ S ∧
+    ∃ k, ∃ S : Finset ℕ, S.card = k ∧
       (∀ m ∈ S, m ≤ n) ∧ egyptianSum S = 1
-  -- For n ≥ 6, such representations exist (e.g., {2, 3, 6} for n=6)
+  -- For n ≥ 6, such representations exist (e.g., {2, 3, 6}, all ≤ n)
 
 noncomputable def f_func (n : ℕ) (hn : n ≥ 6) : ℕ :=
   Nat.find (f_func_exists n hn)

--- a/src/data/proofs/erdos-294/meta.json
+++ b/src/data/proofs/erdos-294/meta.json
@@ -133,7 +133,7 @@
       "title": "Part VII: Related Functions",
       "startLine": 207,
       "endLine": 228,
-      "summary": "Introduces the f(n) function (minimum number of distinct unit fractions summing to 1 with largest denominator n), axiomatizes its existence for n ≥ 6, and notes its relationship to t(N)."
+      "summary": "Introduces the f(n) function (minimum number of distinct unit fractions summing to 1 with all denominators at most n), axiomatizes its existence for n ≥ 6, and notes its relationship to t(N)."
     },
     {
       "id": "sec-greedy",


### PR DESCRIPTION
## Problem

Auditor issue #41213: the disclosed axiom `f_func_exists` in `Erdos294Problem.lean` is **mathematically false**.

```lean
axiom f_func_exists (n : ℕ) (hn : n ≥ 6) :
    ∃ k, ∃ S : Finset ℕ, S.card = k ∧ n ∈ S ∧
      (∀ m ∈ S, m ≤ n) ∧ egyptianSum S = 1
```

With `n ∈ S`, this claims that for **every** `n ≥ 6` there is an Egyptian representation of 1 whose **largest denominator is exactly n**. This is false at `n = 7`: after the forced `1/7`, the rest must sum to `6/7` from a subset of `{1/2,1/3,1/4,1/5,1/6}`, whose subset sums are all of the form `k/60`; `6/7 = 360/7·(1/60)` has no integer `k`, so no such `S` exists. (It is not used by the headline theorems `erdos_294` / `erdos_294_summary`, which rest on `liu_sawhney_2024`, so there was no kernel inconsistency — but the gallery asserted a false axiom.)

## Fix

Recommended fix #1 from the issue: **drop the `n ∈ S` clause**. The axiom then reads "for `n ≥ 6`, 1 is representable using denominators `≤ n`", which is **true** (e.g. `{2,3,6}`, all `≤ n`) and is the well-defined domain of `f(n)` used by `f_func`.

- `proofs/Proofs/Erdos294Problem.lean`: removed `n ∈ S ∧` from the axiom; docstring "largest denominator n" → "all denominators at most n".
- `src/data/proofs/erdos-294/meta.json`: aligned the Part VII section summary to the corrected phrasing.

`axiomCount` stays 4 — this repairs a false axiom into a true one rather than removing an assumption. `assumptions` string ("f(n) exists for n>=6") remains accurate.

Closes #41213
