### PR TITLE
Fix: erdos-298 correct sections[] phantom declarations & line ranges

### DIFF
--- a/src/data/proofs/erdos-298/meta.json
+++ b/src/data/proofs/erdos-298/meta.json
@@ -101,74 +101,74 @@
     {
       "id": "background",
       "title": "Background",
-      "startLine": 40,
-      "endLine": 55,
-      "summary": "Unit fractions, Egyptian fractions, and density definitions.",
+      "startLine": 34,
+      "endLine": 48,
+      "summary": "Documentation comment on unit fractions, Egyptian fractions, and density (no declarations).",
       "mathContext": "Unit fractions: $1/n$. Egyptian fraction representation: $1 = 1/a_1 + \\\\cdots + 1/a_k$ with distinct $a_i$. Density: $\\\\bar{d}(A) = \\\\limsup |A \\\\cap [1,N]|/N > 0$."
     },
     {
       "id": "definitions",
       "title": "Core Definitions",
-      "startLine": 56,
-      "endLine": 90,
-      "summary": "countUpTo, densityRatio, HasPosDensity, unitFractionSum, etc.",
-      "mathContext": "$A(N) = |A \\\\cap [1,N]|$. $\\\\bar{d}(A) = \\\\limsup A(N)/N$. Unit fraction sum: $\\\\sum_{n \\\\in S} 1/n$ for finite $S \\\\subset A$."
+      "startLine": 50,
+      "endLine": 74,
+      "summary": "Axioms HasPosDensity, upperDensity; defs HasPosUpperDensity, unitFractionSum, SumsToOne, ContainsUnitSumSubset.",
+      "mathContext": "$\\\\bar{d}(A) = \\\\limsup |A \\\\cap [1,N]|/N$ (axiomatized). Unit fraction sum: $\\\\sum_{n \\\\in S} 1/n$ for finite $S \\\\subset A$; $A$ contains a unit-sum subset iff some finite $S \\\\subseteq A$ has $\\\\sum 1/n = 1$."
     },
     {
       "id": "examples",
       "title": "Unit Fraction Sum Examples",
-      "startLine": 91,
-      "endLine": 105,
-      "summary": "Examples: {2,3,6}, {2,4,5,20}, {3,4,5,6,20} all sum to 1.",
-      "mathContext": "$\\\\{2,3,6\\\\}$: $1/2+1/3+1/6=1$. $\\\\{2,4,5,20\\\\}$: $1/2+1/4+1/5+1/20=1$. Many Egyptian fraction representations of 1 exist."
+      "startLine": 76,
+      "endLine": 80,
+      "summary": "Documentation comment noting unit-fraction sums equal to 1 exist (no example declarations).",
+      "mathContext": "$\\\\{2,3,6\\\\}$: $1/2+1/3+1/6=1$. Many Egyptian fraction representations of 1 exist. These are described in prose only, not formalized."
     },
     {
       "id": "conjecture",
       "title": "The Erdős Conjecture",
-      "startLine": 106,
-      "endLine": 135,
-      "summary": "erdos_298_conjecture, bloom_2021, bloom_theorem.",
-      "mathContext": "Erdos-Graham conjecture: positive density $\\\\Rightarrow$ contains $S$ with $\\\\sum 1/n = 1$. SOLVED: Bloom (2021)."
+      "startLine": 82,
+      "endLine": 110,
+      "summary": "def erdos_298_conjecture, axiom bloom_2021, theorem bloom_theorem.",
+      "mathContext": "Erdős conjecture: positive density $\\\\Rightarrow$ contains $S$ with $\\\\sum 1/n = 1$. Encoded as the opaque axiom bloom_2021; SOLVED by Bloom (2021)."
     },
     {
       "id": "upper-density",
       "title": "Upper Density Version",
-      "startLine": 136,
-      "endLine": 163,
-      "summary": "Stronger version with upper density; bloom_2021_upper.",
-      "mathContext": "Stronger: holds for upper density (not just natural density). Bloom proves $\\\\bar{d}(A) > 0 \\\\Rightarrow \\\\exists S \\\\subset A$ with $\\\\sum 1/n = 1$."
+      "startLine": 112,
+      "endLine": 135,
+      "summary": "def erdos_298_upper_density, axiom pos_dens_implies_pos_upper, theorem upper_implies_natural.",
+      "mathContext": "Stronger: holds for upper density (not just natural density). upper_implies_natural derives the natural-density conjecture from the upper-density version via pos_dens_implies_pos_upper."
     },
     {
       "id": "density-props",
       "title": "Density Properties",
-      "startLine": 164,
-      "endLine": 183,
-      "summary": "Basic properties: monotonicity, finite sets have density 0.",
-      "mathContext": "Monotonicity: $A \\\\subseteq B \\\\Rightarrow \\\\bar{d}(A) \\\\leq \\\\bar{d}(B)$. Finite sets have density 0. $\\\\bar{d}(\\\\mathbb{N}) = 1$."
+      "startLine": 137,
+      "endLine": 141,
+      "summary": "Documentation comment on basic density properties (no declarations formalized).",
+      "mathContext": "Monotonicity: $A \\\\subseteq B \\\\Rightarrow \\\\bar{d}(A) \\\\leq \\\\bar{d}(B)$; finite sets have density 0. Described in prose only, not formalized."
     },
     {
       "id": "egyptian",
       "title": "Egyptian Fractions",
-      "startLine": 184,
-      "endLine": 203,
-      "summary": "HasEgyptianRep, egyptian_fraction_exists, one_has_egyptian_rep.",
+      "startLine": 143,
+      "endLine": 156,
+      "summary": "def HasEgyptianRep; the classical existence theorem is noted as a comment only.",
       "mathContext": "Every positive rational has an Egyptian fraction representation (greedy algorithm). The question asks when the representation can be found WITHIN the set $A$."
     },
     {
       "id": "quantitative",
       "title": "Quantitative Aspects",
-      "startLine": 204,
-      "endLine": 224,
-      "summary": "bloom_quantitative (finitary), sparse_counterexample.",
-      "mathContext": "Bloom quantitative: if $\\\\bar{d}(A) > \\\\delta$, there exists $S \\\\subset A \\\\cap [1, N(\\\\delta)]$ with $\\\\sum 1/n = 1$. Effective bound on $N$."
+      "startLine": 158,
+      "endLine": 171,
+      "summary": "Documentation comments on finitary bounds and sparse counterexamples (no declarations formalized).",
+      "mathContext": "Finitary version: if $|A| \\\\geq \\\\delta N$ for $A \\\\subseteq \\\\{1,\\\\dots,N\\\\}$ then $A$ contains a unit-sum subset for $N \\\\geq N(\\\\delta)$. Described in prose only, not formalized."
     },
     {
       "id": "formalization",
-      "title": "Lean 3 Formalization",
-      "startLine": 225,
+      "title": "Formalization Note & Final Theorem",
+      "startLine": 173,
       "endLine": 227,
-      "summary": "Reference to Bloom-Mehta formalization.",
-      "mathContext": "Bloom-Mehta: formal verification of the proof in Lean/Mathlib (partial). One of few Erdos problems with a machine-checked proof."
+      "summary": "Documentation of the Bloom–Mehta Lean 3 formalization and related problems #46/#47; theorem erdos_298_solved concludes the file.",
+      "mathContext": "Bloom & Mehta formalized the full proof in Lean 3 (~10,000 lines, github.com/b-mehta/unit-fractions). The final theorem erdos_298_solved := bloom_2021 records that Erdős #298 is solved (answer YES)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Fixes the phantom-declaration and drifted-line-range issue in `erdos-298`'s `sections[]` (issue #41216, LOW). Counts, badge, status, assumptions, and `proofStrategy` were already accurate and are **unchanged** — this is a `sections[]`-only rewrite matched to the actual `proofs/Proofs/Erdos298Problem.lean`.

## Phantom names removed (each grepped, 0 matches in the Lean file)

- `countUpTo`, `densityRatio` (definitions section) — density is axiomatized directly
- `bloom_2021_upper` (upper-density section)
- `egyptian_fraction_exists`, `one_has_egyptian_rep` (egyptian section)
- `bloom_quantitative`, `sparse_counterexample` (quantitative section)
- fabricated "example theorems" and monotonicity/finite-density props described as declarations — these are comment blocks, now labeled as documentation

## Line ranges realigned to actual blocks

| section | before | after |
|---|---|---|
| background | 40–55 | 34–48 (doc comment) |
| definitions | 56–90 | 50–74 |
| examples | 91–105 | 76–80 (doc comment) |
| conjecture | 106–135 | 82–110 |
| upper-density | 136–163 | 112–135 |
| density-props | 164–183 | 137–141 (doc comment) |
| egyptian | 184–203 | 143–156 |
| quantitative | 204–224 | 158–171 (doc comment) |
| formalization | 225–227 | 173–227 |

## Verification

Every declaration now named in a section summary was grep-confirmed to exist exactly once in the Lean file: `HasPosDensity`, `upperDensity`, `HasPosUpperDensity`, `unitFractionSum`, `SumsToOne`, `ContainsUnitSumSubset`, `erdos_298_conjecture`, `bloom_2021`, `bloom_theorem`, `erdos_298_upper_density`, `pos_dens_implies_pos_upper`, `upper_implies_natural`, `HasEgyptianRep`, `erdos_298_solved`. Comment-only blocks are now described as documentation, not declarations. JSON validated with `json.load`.

Same auto-generated phantom-section pattern already repaired for the sibling Egyptian-fraction cluster (erdos-30 #41212, erdos-305 #41209).

Closes #41216

🤖 Generated with [Claude Code](https://claude.com/claude-code)
