### PR TITLE
Enrich erdos-291: drop phantom originalContribution wu_yan_conditional

### DIFF
--- a/src/data/proofs/erdos-291/meta.json
+++ b/src/data/proofs/erdos-291/meta.json
@@ -47,8 +47,7 @@
       "question_part1/part2: Formal problem statements",
       "steinerberger_criterion: Leading digit p-1 implies p divides gcd",
       "wolstenholme_theorem: H_{p-1} numerator divisible by p²",
-      "divisibility_characterization: Complete criterion",
-      "wu_yan_conditional: Schanuel implies density 1"
+      "divisibility_characterization: Complete criterion"
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 3,


### PR DESCRIPTION
Fixes gallery integrity issue #41219.

## Problem
`meta.json` `originalContributions` listed `wu_yan_conditional: Schanuel implies density 1`, but no such declaration exists in `proofs/Proofs/Erdos291Problem.lean` (`grep` → 0 matches). The Wu-Yan conditional result appears only in comment prose (lines 219-230), which explicitly states Schanuel's conjecture is *not* formalized (it requires complex-analysis infrastructure absent from Mathlib).

## Fix
Removed the phantom `wu_yan_conditional` entry. All remaining `originalContributions` (`L`, `H`, `a`, `harmonicGCD`, `question_part1/part2`, `steinerberger_criterion`, `wolstenholme_theorem`, `divisibility_characterization`) were grep-verified to correspond to real declarations. Axiom counts, sorries, and status were already accurate and are unchanged.

Prose-only metadata fix; no source or status change.
