### PR TITLE
Fix: erdos-291 drop phantom originalContribution wu_yan_conditional

### DIFF
--- a/src/data/proofs/erdos-291/meta.json
+++ b/src/data/proofs/erdos-291/meta.json
@@ -47,8 +47,7 @@
       "question_part1/part2: Formal problem statements",
       "steinerberger_criterion: Leading digit p-1 implies p divides gcd",
       "wolstenholme_theorem: H_{p-1} numerator divisible by p²",
-      "divisibility_characterization: Complete criterion",
-      "wu_yan_conditional: Schanuel implies density 1"
+      "divisibility_characterization: Complete criterion"
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 3,


### PR DESCRIPTION
## Summary

Removes the single phantom `originalContributions` entry `"wu_yan_conditional: Schanuel implies density 1"` from `erdos-291` (issue #41219, LOW). No corresponding declaration exists in `proofs/Proofs/Erdos291Problem.lean` — the Wu-Yan / Schanuel conditional density result is only prose in a comment block (lines 219–230), which explicitly states it is *not* formalized ("Schanuel's conjecture is not formalized here as it requires complex analysis infrastructure not available in Mathlib").

## Verification

- `grep -E "(theorem|lemma|def|axiom|example) wu_yan_conditional"` → 0 matches; no `wu_yan`/`schanuel` density declaration anywhere (all hits are comments).
- The other 8 `originalContributions` entries (`L`, `H`, `harmonicGCD`, `steinerberger_criterion`, `wolstenholme_theorem`, `divisibility_characterization`, plus the two question-statement defs) each grep-confirmed to a real declaration — left untouched.
- Counts, status, axioms (2 literal + `ofReduceBool`), and 0 sorries are accurate and unchanged. JSON validated with `json.load`.

Same phantom-originalContribution prose vein as erdos-353/348/356.

Closes #41219

🤖 Generated with [Claude Code](https://claude.com/claude-code)
