### PR TITLE
Research: erdos-117-wip-01 — h(1)=1 and n-commuting foundations for Erdős #117 (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos117WIP01.lean
+++ b/proofs/Proofs/Erdos117WIP01.lean
@@ -1,0 +1,79 @@
+/-
+  Erdős Problem #117 — Covering Groups by Abelian Subgroups: foundational facts (0-axiom).
+
+  Companion to `Erdos117Problem.lean`. That file defines the `n`-commuting
+  property, abelian subgroups, and the covering number
+  `h(n) = abelianCoverNumber n = sInf {k | every finite group with the
+  n-commuting property is covered by k abelian subgroups}`, and states Pyber's
+  exponential bounds `c₁ⁿ < h(n) < c₂ⁿ` only in prose. This file supplies the
+  elementary, machine-checkable facts the parent leaves out — in particular the
+  trivial base case `h(1) = 1` — while Pyber's deep bounds stay unformalized.
+
+  Main results (all axiom-free — `#print axioms` = propext/Classical.choice/Quot.sound):
+
+  * `not_hasNCommutingProperty_zero`  : no group has the `0`-commuting property
+                                        (a singleton has no distinct pair).
+  * `commGroup_hasNCommutingProperty` : every commutative group has the
+                                        `n`-commuting property for all `n ≥ 1`.
+  * `abelianCoverNumber_one`          : **`h(1) = 1`** — one abelian subgroup
+                                        (the whole group, which is abelian by the
+                                        `1`-commuting property) suffices, and zero
+                                        never does.
+
+  The open Erdős #117 (the exact base of the exponential growth of `h(n)`) and
+  Pyber's bounds are untouched.
+-/
+
+import Mathlib
+import Proofs.Erdos117Problem
+
+/-- **No group has the `0`-commuting property.** The property at `n = 0` demands a
+    distinct commuting pair inside *every* nonempty subset, but the singleton `{1}`
+    (card `1 > 0`) has no two distinct elements. -/
+theorem not_hasNCommutingProperty_zero {G : Type*} [Group G] :
+    ¬ HasNCommutingProperty G 0 := by
+  intro h
+  obtain ⟨x, y, hx, hy, hxy, _⟩ := h {1} (by simp)
+  simp only [Finset.mem_singleton] at hx hy
+  exact hxy (hx.trans hy.symm)
+
+/-- **Every commutative group has the `n`-commuting property for `n ≥ 1`.**
+    Immediate from the `n = 1` case (any subset of size `> 1` has two distinct,
+    hence commuting, elements) and monotonicity of the property in `n`. -/
+theorem commGroup_hasNCommutingProperty {G : Type*} [CommGroup G] {n : ℕ}
+    (hn : 1 ≤ n) : HasNCommutingProperty G n :=
+  hasNCommutingProperty_mono hn commGroup_hasNCommutingProperty_one
+
+/-- **`h(1) = 1`.** A group with the `1`-commuting property is abelian
+    (`commute_of_hasNCommutingProperty_one`), so the single subgroup `⊤` — abelian
+    and covering everything — witnesses `1 ∈` the covering set, giving `h(1) ≤ 1`.
+    Conversely `0` is never in the set: an empty family `Fin 0 → Subgroup G` cannot
+    cover the identity of the (nonempty) witness group `PUnit`, so `h(1) ≠ 0`. -/
+theorem abelianCoverNumber_one : abelianCoverNumber 1 = 1 := by
+  -- `abelianCoverNumber` quantifies over `Type*`, so the witnesses below must be
+  -- built inline at the set's fixed universe (a factored `Type*` lemma would
+  -- introduce a second, non-unifying universe).
+  unfold abelianCoverNumber
+  apply le_antisymm
+  · -- h(1) ≤ 1 : the single abelian subgroup `⊤` covers any group with the
+    -- `1`-commuting property (that group is abelian), so `1` is in the set.
+    apply Nat.sInf_le
+    intro G _ _ hprop
+    exact ⟨fun _ => ⊤,
+      fun _ x y _ _ => commute_of_hasNCommutingProperty_one hprop x y,
+      fun g => ⟨0, Subgroup.mem_top g⟩⟩
+  · -- h(1) ≥ 1 : `0` is not in the covering set, and the set is nonempty.
+    rw [Nat.one_le_iff_ne_zero, Ne, Nat.sInf_eq_zero]
+    push_neg
+    refine ⟨fun hmem => ?_, ?_⟩
+    · -- `0 ∈` set would cover `PUnit` by an empty family of subgroups — impossible.
+      simp only [Set.mem_setOf_eq] at hmem
+      obtain ⟨H, _, hcov⟩ := hmem PUnit commGroup_hasNCommutingProperty_one
+      obtain ⟨i, _⟩ := hcov PUnit.unit
+      exact i.elim0
+    · -- `push_neg` left the goal as `.Nonempty`; `1` belongs to the set.
+      refine ⟨1, ?_⟩
+      intro G _ _ hprop
+      exact ⟨fun _ => ⊤,
+        fun _ x y _ _ => commute_of_hasNCommutingProperty_one hprop x y,
+        fun g => ⟨0, Subgroup.mem_top g⟩⟩

--- a/research/problems/erdos-117-wip-01/knowledge.md
+++ b/research/problems/erdos-117-wip-01/knowledge.md
@@ -53,3 +53,39 @@ every size-`>n` subset has a commuting pair; `h(n)` is exponential (Pyber 1987).
 ### Still open
 `abelianCoverNumber` / `h(n)` and Pyber's exponential bounds `c₁^n < h(n) < c₂^n` (exact
 base open) are deep and unformalized — this session builds only elementary scaffolding.
+
+---
+
+## Session 2026-07-22 (researcher-1-3) — h(1)=1 + n-commuting foundations (0-axiom)
+
+**Mode**: FRESH (WEAK → ACT) · **Outcome**: progress — formalized the elementary
+base-case facts the parent `Erdos117Problem.lean` left in prose, as 3 axiom-free
+theorems in a new companion `proofs/Proofs/Erdos117WIP01.lean` (Docker-verified
+v4.31.0; `#print axioms` on all three = `[propext, Classical.choice, Quot.sound]`).
+
+- `not_hasNCommutingProperty_zero` — no group has the `0`-commuting property (the
+  singleton `{1}` has card `1 > 0` but no distinct pair). The property is vacuous
+  below `n = 1`.
+- `commGroup_hasNCommutingProperty {n} (hn : 1 ≤ n)` — every commutative group has
+  the `n`-commuting property for all `n ≥ 1` (via `hasNCommutingProperty_mono` on
+  the parent's `n = 1` case).
+- `abelianCoverNumber_one : abelianCoverNumber 1 = 1` — **the flagship `h(1) = 1`**,
+  exactly the trivial case the problem requests. `1 ∈` set via the single abelian
+  subgroup `⊤` (the group is abelian by `commute_of_hasNCommutingProperty_one`);
+  `0 ∉` set since an empty `Fin 0 → Subgroup PUnit` family can't cover `1`.
+  `le_antisymm (Nat.sInf_le …) (Nat.one_le_iff_ne_zero.mpr …)` with
+  `Nat.sInf_eq_zero`.
+
+**★GOTCHA (universe)**: `abelianCoverNumber` is **universe-polymorphic** — its body
+quantifies `∀ (G : Type*)`, so `abelianCoverNumber.{u} 1`. Membership witnesses
+must be built **inline** at the set's fixed universe `u`; a factored
+`have hcover : ∀ (G : Type*) …` introduces a **second** universe `u_2` that does
+NOT unify with the set's `u_1` (`Application type mismatch` at the `Nat.sInf_le`
+site + `constant has level params [u_1, u_2] but expected [u_1]`). `PUnit` is
+universe-polymorphic so `PUnit : Type u` supplies the witness group in any `u`.
+`push_neg` rewrites `s ≠ ∅` directly to `s.Nonempty` (no `Set.nonempty_iff_ne_empty`).
+
+**STILL OPEN / out of scope**: Pyber's exponential bounds `c₁ⁿ < h(n) < c₂ⁿ`
+(deep) and the OPEN exact base of the growth stay unformalized. `h(n)`
+well-definedness for general `n` (nonemptiness of the `sInf` argument) needs a
+uniform cover bound = the Pyber upper bound, so it is NOT elementary.

--- a/src/data/research/problems/erdos-117-wip-01.json
+++ b/src/data/research/problems/erdos-117-wip-01.json
@@ -18,7 +18,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ORIENT",
+    "phase": "ACT",
     "since": "2026-07-09T17:33:20-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
@@ -31,18 +31,28 @@
     }
   },
   "knowledge": {
-    "progressSummary": "FOUNDATIONS (researcher-1, 2026-07-20): developed the def-only Erdos117Problem.lean stub (Erdos Problem 117, covering groups by abelian subgroups, OPEN, h(n) exponential per Pyber 1987) with 7 axiom-free lemmas. Headline: commute_of_hasNCommutingProperty_one shows the n=1 case is EXACTLY commutativity (the size-2 subset {x,y} forces its only distinct pair to commute), matching the file TODO note h(1)=1. Plus hasNCommutingProperty_mono (monotone: larger n = weaker), commGroup_hasNCommutingProperty_one, isAbelianSubgroup_bot/_top_of_commGroup/_mono, and isAbelianSubgroup_iff_isMulCommutative bridging the local predicate to Mathlib IsMulCommutative (v4.31 rename of Subgroup.IsCommutative; setLike_mul_comm). File 62->128 lines, 0->7 theorems. abelianCoverNumber h(n) and Pyber exponential bounds remain deep/unformalized. Host-verified v4.31 lake env lean, exit 0; print axioms clean.",
+    "progressSummary": "PROGRESS: formalized the elementary/base-case facts the parent Erdos117Problem.lean left as prose — 3 axiom-free theorems in companion Erdos117WIP01.lean (Docker-verified v4.31, #print axioms = propext/Classical.choice/Quot.sound). Flagship: abelianCoverNumber_one (h(1)=1), exactly the trivial case the problem requests. Pyber exponential bounds c₁ⁿ<h(n)<c₂ⁿ and the OPEN exact base remain unformalized (deep).",
     "builtItems": [
       "commute_of_hasNCommutingProperty_one - HasNCommutingProperty G 1 implies all pairs commute (Erdos117Problem.lean)",
       "hasNCommutingProperty_mono - monotone, weaker at larger n (Erdos117Problem.lean)",
       "commGroup_hasNCommutingProperty_one; isAbelianSubgroup_bot / _top_of_commGroup / _mono (Erdos117Problem.lean)",
-      "isAbelianSubgroup_iff_isMulCommutative - bridges local IsAbelianSubgroup to Mathlib IsMulCommutative (Erdos117Problem.lean)"
+      "isAbelianSubgroup_iff_isMulCommutative - bridges local IsAbelianSubgroup to Mathlib IsMulCommutative (Erdos117Problem.lean)",
+      "Erdos117WIP01.lean: not_hasNCommutingProperty_zero (¬ HasNCommutingProperty G 0)",
+      "Erdos117WIP01.lean: commGroup_hasNCommutingProperty (CommGroup ⟹ n-commuting for all n≥1)",
+      "Erdos117WIP01.lean: abelianCoverNumber_one (h(1)=1) — the flagship base case"
     ],
     "insights": [
-      "Erdos117Problem.lean stub developed: the n=1 case of the n-commuting property is EXACTLY commutativity (commute_of_hasNCommutingProperty_one) - the two-element subset {x,y} forces every distinct pair to commute; plus monotonicity and abelian-subgroup closure lemmas. All axiom-free."
+      "Erdos117Problem.lean stub developed: the n=1 case of the n-commuting property is EXACTLY commutativity (commute_of_hasNCommutingProperty_one) - the two-element subset {x,y} forces every distinct pair to commute; plus monotonicity and abelian-subgroup closure lemmas. All axiom-free.",
+      "h(1)=1 is fully provable elementarily: the 1-commuting property makes G abelian (commute_of_hasNCommutingProperty_one), so ⊤ is a single abelian subgroup covering G (1 ∈ covering set); and 0 is never in the set since an empty Fin 0 → Subgroup family cannot cover the identity of PUnit. sInf via Nat.sInf_le + Nat.sInf_eq_zero.",
+      "No group has the 0-commuting property (singleton {1} has card 1>0 but no distinct pair) — the n-commuting property is vacuous below n=1.",
+      "abelianCoverNumber is universe-polymorphic (its body quantifies ∀ (G:Type*)); membership witnesses must be built INLINE at the set fixed universe — a factored Type* have introduces a second non-unifying universe (level-param mismatch)."
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Pyber upper/lower bounds c₁ⁿ<h(n)<c₂ⁿ stay as named assumptions (deep, exact base OPEN) — do NOT claim proved.",
+      "Optional: covering-set well-definedness for general n (nonemptiness of the sInf argument) needs a uniform cover bound = the deep Pyber upper bound; not elementary.",
+      "Optional: h(n)≥1 for all n via the same 0∉set argument (trivial generalization of the h(1)=1 lower half)."
+    ],
     "markdown": "# Knowledge Base: erdos-117-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [
@@ -64,7 +74,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.779Z",
-  "lastUpdate": "2026-07-10T00:41:25.926Z",
+  "lastUpdate": "2026-07-22",
   "significance": 6,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary

Research session for **erdos-117-wip-01** (Erdős Problem #117, covering groups by abelian subgroups; the exact base of `h(n)`'s exponential growth is OPEN). The parent `Erdos117Problem.lean` defines the `n`-commuting property, abelian subgroups, and the covering number `h(n) = abelianCoverNumber n` via `sInf`, but states the base/known facts only in prose. This PR formalizes the elementary, machine-checkable ones — in particular the trivial base case `h(1) = 1`.

## Progress

New file `proofs/Proofs/Erdos117WIP01.lean` (imports the parent). Docker-verified on v4.31.0; `#print axioms` on all three theorems = `[propext, Classical.choice, Quot.sound]` (0 assumptions).

- `not_hasNCommutingProperty_zero` — **no group has the `0`-commuting property** (the singleton `{1}` has card `1 > 0` but no distinct pair); the property is vacuous below `n = 1`.
- `commGroup_hasNCommutingProperty` — every commutative group has the `n`-commuting property for **all `n ≥ 1`** (the parent proved only `n = 1`; extended via `hasNCommutingProperty_mono`).
- `abelianCoverNumber_one` — **`h(1) = 1`**. The whole group `⊤` is a single abelian subgroup covering `G` (abelian by `commute_of_hasNCommutingProperty_one`), so `1 ∈` the covering set; and `0` is never in it, since an empty `Fin 0 → Subgroup PUnit` family cannot cover `PUnit`'s identity.

## Findings

- `abelianCoverNumber` is **universe-polymorphic** (its body quantifies `∀ (G : Type*)`), so the set-membership witnesses must be built **inline** at the set's fixed universe — a factored `have hcover : ∀ (G : Type*) …` introduces a second, non-unifying universe (level-param mismatch). `PUnit` supplies the witness group in any universe.
- `Nat.sInf`: `Nat.sInf_le` (upper) + `Nat.sInf_eq_zero` / `Nat.one_le_iff_ne_zero` (lower). `push_neg` rewrites `s ≠ ∅` directly to `s.Nonempty`.

## Status

**Outcome**: progress — the elementary base-case facts (including the flagship `h(1) = 1` the problem requests) are now formalized.

**Out of scope / still open** (deliberately untouched): Pyber's exponential bounds `c₁ⁿ < h(n) < c₂ⁿ` (deep) and the **OPEN** exact base of the growth remain unformalized; `h(n)` well-definedness for general `n` requires a uniform cover bound = Pyber's upper bound, so it is not elementary.

🤖 Generated by researcher-1-3
