### PR TITLE
Fix: erdos-293 gate false upper-bound axiom asymptotically (#41224)

### DIFF
--- a/proofs/Proofs/Erdos293Problem.lean
+++ b/proofs/Proofs/Erdos293Problem.lean
@@ -75,9 +75,13 @@ axiom vanDoorn_Tang_lower_bound :
 
 /- ## Known Upper Bounds -/
 
-/-- Elementary upper bound: v(k) ≤ k · c₀^{2^k}. -/
+/-- Elementary upper bound: v(k) ≤ k · c₀^{2^k} for all sufficiently large k.
+The bound holds asymptotically; it is *false* at small k (e.g. at k = 1 it would
+force v(1) ≤ c₀² ≈ 1.60, contradicting v(1) = 2), so it must be stated with a
+threshold k₀ rather than for all k > 0. Coupling an all-k form with the lower
+bound derives False (see gallery audit #41224). -/
 axiom elementary_upper_bound :
-    ∀ k : ℕ, k > 0 →
+    ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ →
       (v k : ℝ) ≤ k * vardiConstant ^ (2^k : ℕ)
 
 /-  Maximum denominator bound: in any k-term decomposition,
@@ -108,12 +112,14 @@ so the first missing denominator is 4. -/
 /- ## Summary -/
 
 /-- **Erdős Problem #293 Summary.**
-Current best bounds on v(k): e^{ck²} ≤ v(k) ≤ k · c₀^{2^k}.
-The gap (e^{k²} vs e^{2^k}) is one of the largest in combinatorics. -/
+Current best bounds on v(k): e^{ck²} ≤ v(k) (for all k > 0), and v(k) ≤ k · c₀^{2^k}
+for all sufficiently large k. The gap (e^{k²} vs e^{2^k}) is one of the largest in
+combinatorics. The upper bound is asymptotic — it fails at small k — so the two
+bounds are stated over compatible ranges and do not jointly derive False. -/
 theorem erdos_293_summary :
     (∃ c : ℝ, c > 0 ∧ ∀ k : ℕ, k > 0 →
       (v k : ℝ) ≥ Real.exp (c * k^2)) ∧
-    (∀ k : ℕ, k > 0 →
+    (∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ →
       (v k : ℝ) ≤ k * vardiConstant ^ (2^k : ℕ)) :=
   ⟨vanDoorn_Tang_lower_bound, elementary_upper_bound⟩
 


### PR DESCRIPTION
## Summary

Fixes the CRITICAL integrity issue in #41224: the two bound axioms in
`Erdos293Problem.lean` were mutually **inconsistent**, deriving `False` and
making every theorem (including `erdos_293_summary`) logically vacuous.

## Root cause

`elementary_upper_bound` asserted `v(k) ≤ k·c₀^{2^k}` for **all** `k > 0`, but
this is false at small `k`. At `k = 1` it forces `v(1) ≤ c₀² ≈ 1.60 < 2`, hence
`v(1) ≤ 1`; while `vanDoorn_Tang_lower_bound` (and the file's own comment,
`v(1) = 2`) forces `v(1) ≥ 2`. Contradiction.

## Fix (minimal)

Gate the upper bound with an existential threshold, matching how it actually
holds asymptotically:

```lean
-- before
axiom elementary_upper_bound :
    ∀ k : ℕ, k > 0 → (v k : ℝ) ≤ k * vardiConstant ^ (2^k : ℕ)
-- after
axiom elementary_upper_bound :
    ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ → (v k : ℝ) ≤ k * vardiConstant ^ (2^k : ℕ)
```

A prover obtains only an opaque witness `k₀` and can no longer instantiate the
bound at `k = 1`, so `False` is no longer derivable. `erdos_293_summary` is
updated to the corresponding existential form and is now a genuine
combined-bounds result. The lower bound is left as `∀ k > 0` (it is not the
false axiom); axiom count is unchanged (still 3), so `meta.json` needs no edit.

## Evidence

- `./proofs/scripts/docker-build.sh Proofs.Erdos293Problem` → **Build succeeded**
  (`✔ Built Proofs.Erdos293Problem`).
- The auditor's `erdos293_axioms_inconsistent : False` no longer type-checks: it
  instantiated `elementary_upper_bound 1`, which is now ill-typed (the axiom is
  an existential, not a universal).

Closes #41224
