### PR TITLE
Fix: erdos-293 gate elementary_upper_bound asymptotically (remove inconsistent axioms)

### DIFF
--- a/proofs/Proofs/Erdos293Problem.lean
+++ b/proofs/Proofs/Erdos293Problem.lean
@@ -75,9 +75,13 @@ axiom vanDoorn_Tang_lower_bound :
 
 /- ## Known Upper Bounds -/
 
-/-- Elementary upper bound: v(k) ≤ k · c₀^{2^k}. -/
+/-- Elementary upper bound: for all sufficiently large k, v(k) ≤ k · c₀^{2^k}.
+The bound carries a threshold k₀ because the closed form holds only
+asymptotically: at k = 1 it gives k · c₀^{2^k} ≈ 1.60 < 2, yet v(1) = 2. A
+literal `∀ k > 0` form would therefore be false at k = 1, and — combined with the
+lower bound, which forces v(1) ≥ 2 — would make the axiom set inconsistent. -/
 axiom elementary_upper_bound :
-    ∀ k : ℕ, k > 0 →
+    ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ →
       (v k : ℝ) ≤ k * vardiConstant ^ (2^k : ℕ)
 
 /-  Maximum denominator bound: in any k-term decomposition,
@@ -108,12 +112,13 @@ so the first missing denominator is 4. -/
 /- ## Summary -/
 
 /-- **Erdős Problem #293 Summary.**
-Current best bounds on v(k): e^{ck²} ≤ v(k) ≤ k · c₀^{2^k}.
+Current best bounds on v(k): e^{ck²} ≤ v(k) for all k > 0, and
+v(k) ≤ k · c₀^{2^k} for all sufficiently large k.
 The gap (e^{k²} vs e^{2^k}) is one of the largest in combinatorics. -/
 theorem erdos_293_summary :
     (∃ c : ℝ, c > 0 ∧ ∀ k : ℕ, k > 0 →
       (v k : ℝ) ≥ Real.exp (c * k^2)) ∧
-    (∀ k : ℕ, k > 0 →
+    (∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ →
       (v k : ℝ) ≤ k * vardiConstant ^ (2^k : ℕ)) :=
   ⟨vanDoorn_Tang_lower_bound, elementary_upper_bound⟩
 

--- a/src/data/proofs/erdos-293/meta.json
+++ b/src/data/proofs/erdos-293/meta.json
@@ -62,7 +62,7 @@
     "historicalContext": "Egyptian fractions — sums of distinct unit fractions — have been studied since the Rhind Mathematical Papyrus (c. 1650 BCE). Erdős and Bleicher initiated the modern study of which denominators can appear in k-term decompositions of 1 in their 1975 paper, proving that v(k) grows at least as fast as k!.\n\nThe function v(k) captures a subtle combinatorial question: given k terms, what is the smallest denominator that is 'too large' to ever participate in a unit fraction decomposition of 1? The answer depends on the intricate interplay between denominator sizes and the constraint that their unit fractions sum to exactly 1.\n\nRecent progress by van Doorn and Tang (2025) dramatically improved the lower bound to e^{ck²}, far exceeding the factorial bound. However, the upper bound v(k) ≤ k · c₀^{2^k} (where c₀ ≈ 1.26408 is the Vardi constant) remains exponentially larger. The gap between e^{k²} and e^{2^k} is one of the largest in combinatorics, and Erdős conjectured the true growth rate is doubly exponential.",
     "problemStatement": "Let v(k) be the minimal positive integer not appearing as a denominator in any k-term Egyptian fraction decomposition 1 = 1/n₁ + ... + 1/nₖ with distinct n₁ < ... < nₖ. Estimate v(k).\n\n**Status: OPEN** — current bounds: e^{ck²} ≤ v(k) ≤ k · c₀^{2^k}.",
     "text": "Let v(k) be the smallest integer not appearing in any k-term Egyptian fraction decomposition of 1. Current bounds: e^{ck²} ≤ v(k) ≤ k·c₀^{2^k}. The enormous gap remains open.",
-    "proofStrategy": "The formalization axiomatizes v(k) with three properties (positivity, non-membership, minimality) instead of using Nat.find with sorry. The Vardi sequence and constant are defined constructively, with vardiSeq_values proved by simp. Both lower bounds (Bleicher-Erdős and van Doorn-Tang) and the upper bound are axiomatized. The summary theorem packages both bounds via exact.",
+    "proofStrategy": "The formalization axiomatizes v(k) as an opaque natural-number-valued function (axiom v (k : ℕ) : ℕ) rather than defining it via Nat.find with sorry, since proving existence requires bounding the denominators. The Vardi sequence and constant are defined constructively, with vardiSeq_values proved by simp. The van Doorn–Tang lower bound (v(k) ≥ e^{ck²} for all k > 0) and the elementary upper bound are axiomatized; the upper bound is stated asymptotically (for k ≥ some threshold k₀) because its closed form k·c₀^{2^k} lies below the true value at small k (≈ 1.60 < v(1) = 2) — a literal ∀ k > 0 form would be false at k = 1 and, together with the lower bound, would make the axiom set inconsistent. The summary theorem packages both bounds.",
     "keyInsights": [
       "**The Vardi sequence** uₙ = uₙ₋₁(uₙ₋₁ + 1) controls the upper bound via the Vardi constant c₀ ≈ 1.26408",
       "**van Doorn-Tang (2025)** improved the lower bound from k! to e^{ck²}, a huge leap",
@@ -102,7 +102,7 @@
       "title": "Known Upper Bounds",
       "startLine": 93,
       "endLine": 106,
-      "summary": "Elementary bound v(k) ≤ k · c₀^{2^k} and max denominator bound"
+      "summary": "Elementary bound v(k) ≤ k · c₀^{2^k} (asymptotic, for k ≥ some k₀) and max denominator bound"
     },
     {
       "id": "conjectures",


### PR DESCRIPTION
Fixes gallery integrity issue #41224 (CRITICAL).

## Problem
The two bound axioms on `v : ℕ → ℕ` in `Erdos293Problem.lean` were mutually **inconsistent**, so `False` was derivable and every theorem (including `erdos_293_summary`) was logically vacuous:

- `elementary_upper_bound` : `∀ k > 0, (v k : ℝ) ≤ k · c₀^(2^k)` — at `k = 1` gives `v 1 ≤ c₀² ≈ 1.60 < 2`, i.e. `v 1 ≤ 1`.
- `vanDoorn_Tang_lower_bound` : `∃ c > 0, ∀ k > 0, (v k : ℝ) ≥ exp(c·k²)` — at `k = 1` gives `v 1 ≥ exp c > 1`, i.e. `v 1 ≥ 2`.

`v 1 ≤ 1` ∧ `v 1 ≥ 2` ⇒ contradiction.

## Root cause
Only the **upper bound** is false: its closed form `k · c₀^(2^k)` holds only asymptotically (at `k = 1` it is ≈ 1.60, below the true `v(1) = 2`). The lower bound is fine as stated — `v(1) = 2 ≥ exp(c)` for small `c`.

## Fix
Gate the upper bound with a threshold, matching how it actually holds:

```lean
axiom elementary_upper_bound :
    ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ →
      (v k : ℝ) ≤ k * vardiConstant ^ (2^k : ℕ)
```

The `k = 1` instantiation path is gone, so the axiom set is now satisfiable (e.g. `v(k) = ⌈exp(c·k²)⌉` with small `c` satisfies both once `k₀` is large enough, since `c₀^(2^k)` eventually dominates `exp(c·k²)`). `erdos_293_summary`'s second conjunct is updated to the asymptotic form; the lower bound is left `∀ k > 0` (already consistent).

Also corrected `meta.json` `proofStrategy`, which described phantom "positivity / non-membership / minimality" axioms — the file has a single opaque `axiom v (k : ℕ) : ℕ` — and the upper-bounds section summary to note the asymptotic gating.

## Verification
`./proofs/scripts/docker-build.sh Proofs.Erdos293Problem` → **Built successfully (8576 jobs)**. `status`/`badge`/`axiomCount` unchanged (`axiomatized` / `axiom` / 3) and remain accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
