### PR TITLE
Audit: erdos-288 clean (honest open axiomatization)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12294,8 +12294,8 @@
     },
     "erdos-288": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:57:26Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T08:51:12Z",
       "result": "clean"
     },
     "erdos-289": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-288 (reserve mode) — CLEAN

Verified against `Proofs/Erdos288Problem.lean`:
- `status: axiomatized`, `badge: axiom` — honest Tier C for an OPEN problem.
- `axiomCount: 1` matches the single `axiom erdos_288 : ErdosConjecture288` (`Set.Finite integerSumPairs`), the genuine open conjecture, load-bearing.
- `sorries: 0` — none in file. No `native_decide`.
- `theoremCount: 8` accurate.
- Example theorems (`example_sum_one`, `example_sum_one_v2`) are real `norm_num` proofs of concrete integer harmonic sums; not vacuous.
- Summary theorems (`erdos_288_statement`, `erdos_288_summary`) are definitional iff restatements.
- Description / `erdosProblemStatus` / docstrings all say OPEN. No `originalContributions` overclaims, no phantom decls (variant conjectures are comments, not axiomatized).

Tracker updated to record the clean audit.

---
Discovered during gallery integrity audit (reserve/round-robin re-serve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)