### PR TITLE
Audit: erdos-285 clean (honest axiomatized; Martin 2000)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12266,8 +12266,8 @@
     },
     "erdos-285": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:58:16Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T08:53:05Z",
       "result": "clean"
     },
     "erdos-286": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-285 (reserve mode) — CLEAN

Verified against `Proofs/Erdos285Problem.lean`:
- `status: axiomatized`, `badge: axiom` for a solved problem — Martin (2000) credited in description, proofStrategy ("We formalize"), and axiom docstring. No "we proved"/"first formalization" overclaims.
- `axiomCount: 1` matches the single `axiom martin_egyptian_fractions` (the asymptotic equality f(k)=(1+o(1))·e/(e-1)·(k+1)), load-bearing.
- `sorries: 0`, no `native_decide`.
- `theoremCount: 21` accurate.
- Derived theorems are genuine: `egyptianConstant` bounds (3/2 < e/(e-1) < 2, and identity 1+1/(e-1)) via `Real.exp_one` bounds; concrete `ValidLengths` witnesses (k=0,2,3,4,5; k=1∉); `f_ge_succ` (f(k)≥k+1) proved **independent of the axiom** via `strict_mono_last_ge_succ`.

Tracker updated to record the clean audit.

---
Discovered during gallery integrity audit (reserve/round-robin re-serve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)