### PR TITLE
Audit: erdos-282 clean (open problem as Prop; Fibonacci axiomatized)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12245,8 +12245,8 @@
     },
     "erdos-282": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:58:16Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T08:54:36Z",
       "result": "clean"
     },
     "erdos-283": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-282 (reserve mode) — CLEAN

Verified against `Proofs/Erdos282Problem.lean`:
- `status: axiomatized`, `badge: axiom`, `erdosProblemStatus: open` — description says OPEN.
- The **actual open problem** (`SteinOddGreedyConjecture`) is a `Prop` definition, **not axiomatized** (likewise `ErdosGrahamSquaresConjecture`, `GrahamRepresentability`). No false "solved" claim.
- `axiomCount: 1` matches the single `axiom fibonacci_greedy_terminates` — Fibonacci's classical 1202 termination result over ℕ\{0}, load-bearing and well-established.
- `sorries: 0`, no `native_decide`.
- `theoremCount: 8` accurate (6 public theorems + 2 private lemmas).
- `greedyStep_mem` / `greedyStep_le` genuinely proved via `Nat.find_spec` ("both were axioms, now fully proved" prose is accurate). Definitional theorems (`representable_iff_greedy = Iff.rfl`, `greedy_implies_representable`) honestly labeled "by definition".

Tracker updated to record the clean audit.

---
Discovered during gallery integrity audit (reserve/round-robin re-serve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)