### PR TITLE
Audit: erdos-279 issues-found — inconsistent generalized axiom (#41236)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12209,9 +12209,9 @@
     },
     "erdos-279": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:58:16Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T09:02:38Z",
+      "result": "issues-found"
     },
     "erdos-28": {
       "auditCount": 4,


### PR DESCRIPTION
Marks erdos-279 audit complete (issues-found). Filed CRITICAL soundness issue #41236: `ErdosProblem279_generalized` derives `False` (vacuous `True`-body density hypotheses satisfiable for `A=∅`, but `GeneralizedCovering ∅ 3` is false). Kernel-verified via scratch `#print axioms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)