### PR TITLE
Fix: erdos-279 make density predicates opaque to remove inconsistent generalized axiom

### DIFF
--- a/proofs/Proofs/Erdos279Problem.lean
+++ b/proofs/Proofs/Erdos279Problem.lean
@@ -39,16 +39,23 @@ def CoversEventually (a : ResidueChoice) (k : ℕ) : Prop :=
 
 /- ## Density Conditions for Generalization -/
 
-/-- A set A ⊆ ℕ has counting function ≫ N/log N -/
-def HasPrimeLikeDensity (A : Set ℕ) : Prop :=
-  ∃ c : ℚ, 0 < c ∧
-    -- |A ∩ [1,N]| ≥ c · N / log N for large N
-    True
+/-- A set A ⊆ ℕ has counting function ≫ N/log N: `|A ∩ [1,N]| ≥ c · N / log N`
+    for some `c > 0` and all large `N`.
 
-/-- The log-log condition: Σ_{n∈A, n≤N} 1/n − log log N → ∞ -/
-def HasLogLogDivergence (A : Set ℕ) : Prop :=
-  -- Σ_{n∈A, n≤N} 1/n exceeds log log N by an unbounded amount
-  True
+    Left `opaque` rather than given a `True` placeholder body on purpose: a
+    trivially-provable body would make `ErdosProblem279_generalized` instantiable
+    at junk sets (e.g. `A = ∅`), for which `GeneralizedCovering A k` is provably
+    false — instantiating the axiom there would derive `False` (kernel
+    inconsistency, issue #41236). Keeping the predicate opaque means it cannot be
+    discharged for any set until a genuine density formalization replaces it, so
+    the generalized axiom remains an honest, consistent Tier-C scaffold. -/
+opaque HasPrimeLikeDensity (A : Set ℕ) : Prop
+
+/-- The log-log condition: `Σ_{n∈A, n≤N} 1/n − log log N → ∞`.
+
+    Also left `opaque` (not a `True` placeholder) for the same soundness reason
+    as `HasPrimeLikeDensity` above — see issue #41236. -/
+opaque HasLogLogDivergence (A : Set ℕ) : Prop
 
 /- ## The Erdős Problem -/
 

--- a/src/data/proofs/erdos-279/meta.json
+++ b/src/data/proofs/erdos-279/meta.json
@@ -28,13 +28,13 @@
       }
     ],
     "axiomCount": 2,
-    "lineCount": 79,
+    "lineCount": 86,
     "originalContributions": [
       "Formal statement of Erdős Problem 279 as an existential over residue choices for prime moduli",
       "Generalization to arbitrary sets with prime-like density and log-log divergence conditions",
       "Clean separation of the covering property (IsCoveredBy, CoversEventually) from the density hypotheses"
     ],
-    "assumptions": "2 axioms: ErdosProblem279 (main conjecture for k ≥ 3) and ErdosProblem279_generalized (generalization to dense sets). Both are open conjectures. The density conditions HasPrimeLikeDensity and HasLogLogDivergence use placeholder True bodies.",
+    "assumptions": "2 axioms: ErdosProblem279 (main conjecture for k ≥ 3) and ErdosProblem279_generalized (generalization to dense sets). Both are open conjectures. The density conditions HasPrimeLikeDensity and HasLogLogDivergence are left opaque (not defined) rather than given trivially-true placeholder bodies: a True body would make ErdosProblem279_generalized instantiable at junk sets such as A = ∅, where GeneralizedCovering A k is provably false, yielding a kernel inconsistency (issue #41236). Keeping the predicates opaque means the generalized axiom cannot be discharged until a genuine density formalization replaces them, so the module stays a consistent Tier-C scaffold.",
     "mathlib_version": "4.31.0",
     "theoremCount": 1,
     "definitionCount": 6
@@ -88,8 +88,8 @@
       "title": "Density Conditions for Generalization",
       "startLine": 48,
       "endLine": 60,
-      "summary": "Defines two density conditions for the generalized conjecture: HasPrimeLikeDensity requiring |A ∩ [1,N]| ≥ c·N/log N for some c > 0 (matching the prime counting function up to a constant), and HasLogLogDivergence requiring that Σ_{n∈A,n≤N} 1/n exceeds log log N by an unbounded amount. Both are currently placeholder definitions.",
-      "mathContext": "Two density conditions isolating the essential properties of primes: (1) $|A \\cap [1,N]| \\geq c \\cdot N/\\log N$ matches the PNT ($\\pi(N) \\sim N/\\log N$). (2) $\\sum_{n \\in A, n \\leq N} 1/n - \\log\\log N \\to \\infty$ matches Mertens' theorem ($\\sum_{p \\leq N} 1/p \\sim \\log\\log N$). Both use placeholder `True` bodies pending formalization of asymptotic counting in Lean."
+      "summary": "Declares two density conditions for the generalized conjecture: HasPrimeLikeDensity requiring |A ∩ [1,N]| ≥ c·N/log N for some c > 0 (matching the prime counting function up to a constant), and HasLogLogDivergence requiring that Σ_{n∈A,n≤N} 1/n exceeds log log N by an unbounded amount. Both are left opaque (undefined) rather than given trivially-true bodies — a True body would make ErdosProblem279_generalized instantiable at junk sets like A = ∅ where GeneralizedCovering fails, deriving False (issue #41236). Opacity keeps the generalized axiom honest until a genuine asymptotic formalization replaces the predicates.",
+      "mathContext": "Two density conditions isolating the essential properties of primes: (1) $|A \\cap [1,N]| \\geq c \\cdot N/\\log N$ matches the PNT ($\\pi(N) \\sim N/\\log N$). (2) $\\sum_{n \\in A, n \\leq N} 1/n - \\log\\log N \\to \\infty$ matches Mertens' theorem ($\\sum_{p \\leq N} 1/p \\sim \\log\\log N$). Both are declared `opaque` (no body) pending formalization of asymptotic counting in Lean; an earlier `True` placeholder body was load-bearing and made the generalized axiom inconsistent."
     },
     {
       "id": "conjectures",
@@ -119,7 +119,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 79,
+    "lineCount": 86,
     "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 6,


### PR DESCRIPTION
## Summary

Fixes the CRITICAL kernel inconsistency in erdos-279 reported in #41236: the
axiom `ErdosProblem279_generalized` could be instantiated at junk sets (e.g.
`A = ∅`), for which `GeneralizedCovering A k` is provably false — yielding a
proof of `False`.

## Root cause

The two density hypotheses had trivially-true placeholder bodies that never
mentioned `A`:

```lean
def HasPrimeLikeDensity (A : Set ℕ) : Prop := ∃ c : ℚ, 0 < c ∧ True   -- trivially True
def HasLogLogDivergence (A : Set ℕ) : Prop := True                     -- trivially True
```

So `HasPrimeLikeDensity ∅` and `HasLogLogDivergence ∅` were both provable, and
feeding them to the generalized axiom produced `GeneralizedCovering ∅ k`, which
is false (no `n ∈ ∅`). Kernel-verified `: False` in the issue.

## Fix (auditor's recommended interim scaffold — option 2)

Make both predicates `opaque` so they carry no trivially-provable body and cannot
be discharged for any set until a genuine density formalization replaces them:

```lean
opaque HasPrimeLikeDensity (A : Set ℕ) : Prop
opaque HasLogLogDivergence (A : Set ℕ) : Prop
```

The generalized axiom is now an honest, consistent Tier-C scaffold: it can no
longer be instantiated (its hypotheses are unprovable), so no `False` can be
derived. The consistent prime-case axiom `ErdosProblem279` is untouched.

## Evidence

- **Before**: `HasPrimeLikeDensity ∅ := ⟨1, by norm_num, trivial⟩` and
  `HasLogLogDivergence ∅ := trivial` were provable → `False` (issue #41236).
- **After**: both predicates are opaque; those constructions no longer typecheck,
  so the axiom cannot be instantiated at `∅` (or anything else).
- **Docker build**: `./proofs/scripts/docker-build.sh Proofs.Erdos279Problem` →
  `✔ Built Proofs.Erdos279Problem`, exit 0.

## Metadata

Updated `meta.json` `assumptions` and the `density-conditions` section prose to
describe the predicates as load-bearing `opaque` declarations (not benign `True`
placeholders), and bumped `lineCount` 79 → 86 for the added docstrings.

Closes #41236
