### PR TITLE
Audit: erdos-27 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12147,8 +12147,8 @@
     },
     "erdos-27": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:58:16Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T09:07:15Z",
       "result": "clean"
     },
     "erdos-270": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-27 (4th audit; 3 prior clean).

**Result: CLEAN** — honest Tier-C axiomatized disproof.

- 4 axioms (matches meta): erdos_27_ffkpy, growing_C_achieves, averaging_bound_exists, bbmst_2024 — all disclosed in assumptions.
- 0 sorries, no native_decide, 11 theorems, 18 defs — all counts match.
- Consistency-checked each axiom (empty/modulus-1 boundary systems): none derive False.
- Badge `axiom`/status `axiomatized` correct; no axiom-masking; description accurately says disproved by FFKPY (genuinely solved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)