### PR TITLE
Research: erdos-18-wip-01 — Euclid-form family (σ(2^k), even perfect numbers practical)

### DIFF
--- a/proofs/Proofs/Erdos18WIP01.lean
+++ b/proofs/Proofs/Erdos18WIP01.lean
@@ -1124,4 +1124,75 @@ theorem succ_mul_self_practical {n : ℕ} (h : IsPractical n) :
     Finset.single_le_sum (f := fun d => d) (fun i _ => Nat.zero_le i) hnmem
   omega
 
+/- ## Powers of two as a multiplier base: the Euclid-form family
+
+The Stewart–Sierpiński sufficient condition `mul_practical_of_le_succ_sigma` is at its
+sharpest when the practical base is a power of two, because there the divisor sum
+`σ(2^k)` is *exactly* `2^{k+1} − 1` (the geometric series `1 + 2 + ⋯ + 2^k`). This yields
+a clean, easily-applied criterion and, as a corollary, the practicality of every even
+perfect number.
+
+* `sum_range_two_pow` / `sum_divisors_two_pow` — `σ(2^k) = 2^{k+1} − 1`.
+* `two_pow_mul_practical_of_le` — for every `1 ≤ n ≤ 2^{k+1}`, the number `2^k · n` is
+  practical. This is a strict generalisation of `two_mul_practical` (the case `n = 2`) and
+  of the ad-hoc families `two_pow_mul_six_practical`.
+* `euclid_form_practical` — `2^k · (2^{k+1} − 1)` is practical for every `k`. When
+  `2^{k+1} − 1` is a Mersenne prime this is *precisely* Euclid's even perfect number
+  (`k = 1 → 6`, `k = 2 → 28`, `k = 4 → 496`, …), so **every even perfect number is
+  practical** — recovering `twentyeight_practical` as the uniform special case `k = 2`.
+
+All results are axiom-free. -/
+
+/-- **Geometric series of powers of two.** `∑_{i=0}^{k} 2^i = 2^{k+1} − 1`. -/
+theorem sum_range_two_pow (k : ℕ) :
+    ∑ i ∈ Finset.range (k + 1), 2 ^ i = 2 ^ (k + 1) - 1 := by
+  induction k with
+  | zero => simp
+  | succ n ih =>
+    rw [Finset.sum_range_succ, ih]
+    have h1 : 1 ≤ 2 ^ (n + 1) := Nat.one_le_two_pow
+    have h2 : 2 ^ (n + 2) = 2 ^ (n + 1) + 2 ^ (n + 1) := by rw [pow_succ]; ring
+    omega
+
+/-- **The divisor sum of a power of two.** `σ(2^k) = ∑_{d ∣ 2^k} d = 2^{k+1} − 1`. The
+divisors of `2^k` are exactly `{2^0, 2^1, …, 2^k}`, whose sum is the geometric series
+`sum_range_two_pow`. -/
+theorem sum_divisors_two_pow (k : ℕ) :
+    ∑ d ∈ divisors (2 ^ k), d = 2 ^ (k + 1) - 1 := by
+  rw [divisors, Nat.sum_divisors_prime_pow Nat.prime_two]
+  exact sum_range_two_pow k
+
+/-- **Sharp power-of-two multiplier criterion.** For every `1 ≤ n ≤ 2^{k+1}`, the number
+`2^k · n` is practical. Immediate from `mul_practical_of_le_succ_sigma` applied to the
+practical base `2^k`, since `1 + σ(2^k) = 2^{k+1}`. Generalises `two_mul_practical`
+(`n = 2`). -/
+theorem two_pow_mul_practical_of_le {k n : ℕ} (hn1 : 1 ≤ n) (hn : n ≤ 2 ^ (k + 1)) :
+    IsPractical (2 ^ k * n) := by
+  have hbase : IsPractical (2 ^ k) := two_pow_practical k
+  have hσ : n ≤ 1 + ∑ d ∈ divisors (2 ^ k), d := by
+    rw [sum_divisors_two_pow]
+    have h1 : 1 ≤ 2 ^ (k + 1) := Nat.one_le_two_pow
+    omega
+  have hres := mul_practical_of_le_succ_sigma hbase hn1 hσ
+  rwa [Nat.mul_comm n (2 ^ k)] at hres
+
+/-- **Euclid-form numbers are practical.** `2^k · (2^{k+1} − 1)` is practical for every
+`k`. When `2^{k+1} − 1` is prime this is the even perfect number of Euclid's construction,
+so this theorem shows in particular that **every even perfect number is practical**. -/
+theorem euclid_form_practical (k : ℕ) :
+    IsPractical (2 ^ k * (2 ^ (k + 1) - 1)) := by
+  have hge : 2 ≤ 2 ^ (k + 1) := by
+    calc 2 = 2 ^ 1 := (pow_one 2).symm
+      _ ≤ 2 ^ (k + 1) := Nat.pow_le_pow_right (by norm_num) (by omega)
+  apply two_pow_mul_practical_of_le
+  · omega
+  · omega
+
+/-- **`496` is practical** — the third even perfect number, `496 = 2^4 · (2^5 − 1) = 16·31`,
+as the Euclid-form instance `k = 4`. -/
+theorem four_ninety_six_practical : IsPractical 496 := by
+  have h := euclid_form_practical 4
+  norm_num at h
+  exact h
+
 end Erdos18

--- a/research/problems/erdos-18-wip-01/knowledge.md
+++ b/research/problems/erdos-18-wip-01/knowledge.md
@@ -136,3 +136,47 @@ growth (`conjecture_part1/2`, the $250 `h(n!) < n^{o(1)}`) remains unformalized 
   corollary of `mul_practical_of_le_succ_sigma` with multiplier `n+1`: `n ∣ n` ⟹ `σ(n) ≥ n`
   ⟹ `n+1 ≤ σ(n)+1`. Iterating gives the fast-growing family `2 → 6 → 42 → …` (practical
   analogue of Sylvester's sequence). Clean, unblocked.
+
+## Session 2026-07-22 (researcher-1-3) — Euclid-form family: σ(2^k) and even perfect numbers are practical
+
+**Mode**: BUILD on the merged Stewart–Sierpiński layer. **Outcome**: progress — 5 new
+axiom-free theorems in `Erdos18WIP01.lean` (`#print axioms` = propext/Classical.choice/
+Quot.sound for all; Docker-built, 8577 jobs, only pre-existing warnings).
+
+The multiplicative sufficient condition `mul_practical_of_le_succ_sigma` is sharpest over a
+power-of-two base, because there σ is a closed geometric series:
+
+- `sum_range_two_pow (k) : ∑ i ∈ range (k+1), 2^i = 2^(k+1) − 1` — trivial induction
+  (`Finset.sum_range_succ` + `pow_succ` + `omega`).
+- `sum_divisors_two_pow (k) : ∑ d ∈ divisors (2^k), d = 2^(k+1) − 1` — via
+  `Nat.sum_divisors_prime_pow Nat.prime_two` (divisors of a prime power are `{p^i : i≤k}`)
+  then the geometric series. **New named σ fact.**
+- `two_pow_mul_practical_of_le {k n} (1 ≤ n) (n ≤ 2^(k+1)) : IsPractical (2^k * n)` — the
+  sharp criterion: `1 + σ(2^k) = 2^(k+1)`, feed to `mul_practical_of_le_succ_sigma` (base
+  `2^k`), `mul_comm` to reorder. Strictly generalises `two_mul_practical` (`n = 2`).
+- `euclid_form_practical (k) : IsPractical (2^k * (2^(k+1) − 1))` — the Euclid shape.
+  Whenever `2^(k+1) − 1` is a Mersenne prime this IS the even perfect number, so **every
+  even perfect number is practical** (`k=1→6, k=2→28, k=4→496`). Uniform recovery of
+  `twentyeight_practical`.
+- `four_ninety_six_practical : IsPractical 496` — `k=4` instance by `norm_num`.
+
+### Idiom notes (v4.31)
+- `Nat.sum_divisors_prime_pow` (additive `to_additive` of `prod_divisors_prime_pow`) gives
+  `∑ x ∈ (p^k).divisors, f x = ∑ x ∈ range (k+1), f (p^x)`; with `f = id` and `p = 2` this
+  is the divisor sum of a power of two. Needs `rw [divisors]` first to unfold the parent's
+  `divisors n := n.divisors` def.
+- `Nat.one_le_two_pow : 1 ≤ 2^n` and `Nat.pow_le_pow_right (by norm_num) (h : a ≤ b)` for
+  `2^1 ≤ 2^(k+1)` monotonicity feeding `omega`.
+- `mul_practical_of_le_succ_sigma` returns `IsPractical (n * m)`; reorder to `m * n` with
+  `rw [Nat.mul_comm n (2^k)] at hres`.
+
+### Caveat / dead-end
+- The Euclid–Euler classification (`even n ∧ Perfect n ↔ ∃k, Prime(2^{k+1}−1) ∧ n =
+  2^k(2^{k+1}−1)`) is **absent from the in-repo Mathlib** (no `mersenne`-perfect theorems,
+  only `def mersenne`), so "every even perfect number is practical" is stated as prose
+  motivation on `euclid_form_practical`, not as a standalone Lean theorem over `Nat.Perfect`.
+
+### Still open (unchanged, deep)
+`h(m)` growth — `conjecture_part1`, `conjecture_part2_weak/strong`, the $250
+`h(n!) < n^{o(1)}` — remains unformalized. Next elementary bricks: primorial practicality
+(needs Bertrand + σ-multiplicativity bookkeeping), density/counting (deep, Weingartner).

--- a/src/data/research/problems/erdos-18-wip-01.json
+++ b/src/data/research/problems/erdos-18-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Stewart–Sierpiński practicality criterion closed into a genuine iff (practical_iff_divisor_chain) — divisor-coin-chain characterisation, 0-axiom. Prime-factorisation form and h(m) growth remain open.",
+    "progressSummary": "PROGRESS: Added the Euclid-form family to Erdos18WIP01.lean — σ(2^k)=2^{k+1}−1, the sharp criterion 2^k·n practical for 1≤n≤2^{k+1}, and euclid_form_practical (⟹ every even perfect number is practical). 0-axiom, Docker-verified. h(m) growth ($250 open question) remains unformalized.",
     "builtItems": [
       "decidableIsRepresentable / decidableIsPractical instances (Erdos18Problem.lean)",
       "zero_isRepresentable, one_isRepresentable, isRepresentable_self, isRepresentable_le_sigma, mem_divisors_le (Erdos18Problem.lean)",
@@ -42,14 +42,19 @@
       "infinite_practicalNumbers in Erdos18WIP01.lean: PracticalNumbers.Infinite",
       "two_dvd_of_practical / even_of_practical in Erdos18WIP01.lean: practical m>=3 => 2 | m (necessary condition)",
       "divisor_chain_of_practical / practical_of_divisor_chain_condition / practical_iff_divisor_chain in Erdos18WIP01.lean (necessary + sufficient divisor-gap condition, iff)",
-      "succ_mul_self_practical: n practical ⟹ n(n+1) practical (0-axiom corollary of Stewart–Sierpiński)"
+      "succ_mul_self_practical: n practical ⟹ n(n+1) practical (0-axiom corollary of Stewart–Sierpiński)",
+      "sum_range_two_pow, sum_divisors_two_pow, two_pow_mul_practical_of_le, euclid_form_practical, four_ninety_six_practical in Erdos18WIP01.lean (all 0-axiom: propext/Classical.choice/Quot.sound; Docker-built 8577 jobs)"
     ],
     "insights": [
       "Erdos18Problem.lean stub developed: representability (IsRepresentable) and practicality (IsPractical) are DECIDABLE via a finite powerset search over the divisor set — a single decision procedure subsuming all future example checks; all lemmas axiom-free (plain kernel decide, no native_decide/Lean.ofReduceBool).",
       "Powers of two are an INFINITE family of practical numbers: every k<2^n is a sum of distinct divisors {2^0,...,2^{n-1}} of 2^n by binary representation (repr_lt_two_pow, proved by strong induction on n). This lifts the parents finite decide-checked examples (4,6,8) to a uniform structural theorem two_pow_practical.",
       "Consequently there are INFINITELY MANY practical numbers (infinite_practicalNumbers: PracticalNumbers.Infinite), via injectivity of n |-> 2^n on the practical set.",
       "Matching NECESSARY condition: any practical m>=3 is even (two_dvd_of_practical / even_of_practical). To represent 2 as a sum of distinct divisors of m, since 1 is the only divisor below 2, the divisor 2 itself must be used, so 2 | m. Proof: a subset of positive divisors summing to 2 is forced to be {2} (each element <=2 by single_le_sum, so S subset {1,2}; sum 2 rules out subsets of {1}).",
-      "Full Stewart–Sierpiński characterisation as an iff: practical_iff_divisor_chain — m practical ⟺ 1≤m ∧ every divisor d ≤ 1 + sum of smaller divisors (coin-chain condition), 0-axiom"
+      "Full Stewart–Sierpiński characterisation as an iff: practical_iff_divisor_chain — m practical ⟺ 1≤m ∧ every divisor d ≤ 1 + sum of smaller divisors (coin-chain condition), 0-axiom",
+      "sum_divisors_two_pow: σ(2^k)=∑_{d∣2^k}d=2^{k+1}−1 via Nat.sum_divisors_prime_pow (2 prime) + geometric series sum_range_two_pow (induction)",
+      "two_pow_mul_practical_of_le: for 1≤n≤2^{k+1}, 2^k·n is practical — sharp specialisation of mul_practical_of_le_succ_sigma to the power-of-two base (1+σ(2^k)=2^{k+1}); generalises two_mul_practical",
+      "euclid_form_practical: 2^k·(2^{k+1}−1) practical ∀k; when 2^{k+1}−1 is a Mersenne prime this is Euclids even perfect number, so EVERY EVEN PERFECT NUMBER IS PRACTICAL (6,28,496,... uniform). Note: Mathlib in-repo lacks the Euclid-Euler classification, so the perfect-number statement lives in prose/motivation, not as a Lean theorem",
+      "four_ninety_six_practical: 496=2^4·31 practical (k=4 instance, norm_num)"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for **erdos-18-wip-01** (Erdős Problem #18, practical numbers, $250). Extends `proofs/Proofs/Erdos18WIP01.lean` with the **Euclid-form family**, building on the already-merged Stewart–Sierpiński multiplicative layer.

## Progress
Five new theorems, all axiom-free (`#print axioms` = `[propext, Classical.choice, Quot.sound]`), Docker-built (`docker-build.sh Proofs.Erdos18WIP01`, exit 0, 8577 jobs):

- `sum_range_two_pow` — the geometric series `∑_{i=0}^{k} 2^i = 2^{k+1} − 1`.
- `sum_divisors_two_pow` — **`σ(2^k) = ∑_{d ∣ 2^k} d = 2^{k+1} − 1`**, via `Nat.sum_divisors_prime_pow` (divisors of a prime power) + the geometric series.
- `two_pow_mul_practical_of_le` — **sharp power-of-two multiplier criterion**: for every `1 ≤ n ≤ 2^{k+1}`, the number `2^k · n` is practical. Immediate from `mul_practical_of_le_succ_sigma` on the base `2^k` since `1 + σ(2^k) = 2^{k+1}`. Strictly generalises the existing `two_mul_practical` (`n = 2`).
- `euclid_form_practical` — **`2^k · (2^{k+1} − 1)` is practical for every `k`.** When `2^{k+1} − 1` is a Mersenne prime this is exactly Euclid's even perfect number, so this shows **every even perfect number is practical** (`k=1 → 6`, `k=2 → 28`, `k=4 → 496`, …), recovering `twentyeight_practical` as the uniform special case.
- `four_ninety_six_practical` — `IsPractical 496` (the `k = 4` instance, by `norm_num`).

## Findings
- Over a power-of-two base the Stewart–Sierpiński σ-bound becomes a closed form, giving a clean, easily-applied practicality criterion.
- **Caveat:** the Euclid–Euler classification of even perfect numbers is absent from the in-repo Mathlib (only `def mersenne`, no perfect-number theorems), so the "every even perfect number is practical" statement is documented as prose motivation on `euclid_form_practical` rather than as a standalone theorem over `Nat.Perfect`.

## Status
**Outcome**: progress
**Next Steps**: primorial practicality (needs Bertrand + σ-multiplicativity bookkeeping); the `h(m)` growth questions (`conjecture_part1/2`, the $250 `h(n!) < n^{o(1)}`) remain unformalized and deep.

🤖 Generated by researcher-1
