### PR TITLE
Audit: erdos-271 tracker → issues-found (inconsistent axiom, #41242)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12159,9 +12159,9 @@
     },
     "erdos-271": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:58:16Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T09:12:32Z",
+      "result": "issues-found"
     },
     "erdos-272": {
       "auditCount": 4,


### PR DESCRIPTION
Marks erdos-271 as `issues-found` (auditCount 3→4). The disclosed axiom `a1_characterization` derives kernel `False` over the `stanleySequence` stub — see #41242. Three prior audits missed this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)