### PR TITLE
Audit: erdos-273 clean re-serve (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12170,8 +12170,8 @@
     },
     "erdos-273": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:58:16Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T09:16:46Z",
       "result": "clean"
     },
     "erdos-274": {


### PR DESCRIPTION
Reserve-mode re-audit (queue drained, 0 unaudited). erdos-273 verified clean: 13 theorems all proved, 0 axioms, 0 sorries, no native_decide. All originalContributions map to real proved decls; open problem `ErdosProblem273` correctly left as a Prop. Tracker auditCount 3→4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)