### PR TITLE
Audit: erdos-269 clean re-serve (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12141,8 +12141,8 @@
     },
     "erdos-269": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:58:16Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T09:25:29Z",
       "result": "clean"
     },
     "erdos-27": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-269

**Result: CLEAN** (reserve-mode re-serve; queue fully drained 4809/4809)

Honest Tier-C axiomatized open problem (LCM Series Irrationality). Every integrity check passes:

- **axiomCount=3** matches the 3 `axiom` decls: `erdos_269` (main conjecture, OPEN), `erdos_269_infinite` (solved infinite-P case), `erdos_269_distinct` (solved distinct-terms case). All openly disclosed in `assumptions`.
- **0 sorries** (none in source).
- **definitionCount=9**, **theoremCount=15** — both match the source exactly.
- **originalContributions**: all 11 named decls exist in the Lean file (no phantom/comment-only claims).
- **Axiom consistency**: all three are legitimate open/solved-conjecture axiomatizations — no concrete-instantiation / no-threshold-bound inconsistency pattern; irrationality is preserved under the `n=0,1` constant prefix, so no derivable `False`.
- **Status/badge** `axiomatized`/`axiom`; description states OPEN for finite P. No axiom masking, no delegation opacity, no inequality-as-theorem inflation.
- Minor (not actionable): one `native_decide` proving trivial `card {2,3}=2` (not a headline result; trust-neutral for an axiom-badged file).

Only change: tracker `lastAudited` timestamp.

---
Discovered during gallery integrity audit.