### PR TITLE
Audit: erdos-263 clean re-serve (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12102,8 +12102,8 @@
     },
     "erdos-263": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:58:17Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T09:29:38Z",
       "result": "clean"
     },
     "erdos-264": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-263

**Result: CLEAN** (reserve-mode re-serve; queue fully drained)

Exemplary work-in-progress file (Erdős #263: Irrationality Sequences). All checks pass:

- **0 axioms**; **exactly 4 sorries**, each mapping to the 4 openly disclosed deep external results: `folklore_irrationality` (Mahler-type criterion), `kovac_tao_not_irrationality` (Kovač–Tao 2024), `positive_condition_irrationality` (liminf analysis), `truncation_insufficient`. `assumptions` names all four with reasons.
- **badge `wip`**, `erdosProblemStatus: open`, neutral title, summary states "Status: OPEN" throughout. **originalContributions empty** — no claims to inflate.
- **Headline `doubleExp_sum_irrational`** (Σ 1/2^{2ⁿ} is irrational) is genuinely proved with a real integer-gap argument (no sorry), and is correctly scoped in its docstring as a **necessary condition** for ErdosQuestion1 — it does **not** claim to resolve the open problem (which requires *all* perturbations).
- No `native_decide`. `definitionCount=19` matches source.
- `theoremCount=31` vs actual 30 (incl. private lemmas) = off-by-one, immaterial (LOW-noise, not an overclaim). Earlier apparent large discrepancy was a BSD-grep `^\s*` undercount artifact, not a real mismatch.

Only change: tracker `lastAudited` timestamp.

---
Discovered during gallery integrity audit.