### PR TITLE
Fix: central-limit-theorem-oq-02 drop phantom 1-sorry claim

### DIFF
--- a/.loom/tokens
+++ b/.loom/tokens
@@ -1,0 +1,1 @@
+/Users/rwalters/GitHub/lean-genius/.loom/tokens

--- a/proofs/Proofs/CentralLimitTheoremOQ02.lean
+++ b/proofs/Proofs/CentralLimitTheoremOQ02.lean
@@ -926,10 +926,11 @@ AXIOMATIZED (deep results):
 - Martingale CLT (McLeish 1974) — characteristic function method
 - CLT for α-mixing sequences (Ibragimov 1962) — long-run variance
 
-REMAINING SORRIES (3):
-- independent_implies_zero_mixing: nested ciSup of zeros = 0 (ℝ ConditionallyCompleteLattice)
-- i.i.d. Lindeberg condition: dominated convergence for truncated moments
-- i.i.d. Lyapunov condition: moment computation with rpow decay
+REMAINING SORRIES (0):
+All three formerly-remaining sorries are now fully proved in this file:
+- independent_implies_zero_mixing: nested ciSup of zeros = 0 (ℝ ConditionallyCompleteLattice) ✓
+- i.i.d. Lindeberg condition: dominated convergence for truncated moments ✓
+- i.i.d. Lyapunov condition: moment computation with rpow decay ✓
 -/
 
 end CentralLimitTheoremOQ02

--- a/src/data/proofs/central-limit-theorem-oq-02/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-02/meta.json
@@ -22,7 +22,7 @@
     "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 1,
-    "assumptions": "1 axiom: martingale_clt (McLeish 1974, Brown 1971) — the martingale CLT itself, stating that MDA satisfying Lindeberg condition and conditional variance convergence has row sums converging in distribution to Gaussian. Requires characteristic function methods and deep martingale theory not yet formalized in Mathlib. 1 sorry: nested ciSup of zeros = 0 for independent sequences (independent_implies_zero_mixing). (The i.i.d. Lindeberg condition and the i.i.d. Lyapunov condition, formerly sorries, are now fully proved in the main file.)",
+    "assumptions": "1 axiom: martingale_clt (McLeish 1974, Brown 1971) — the martingale CLT itself, stating that MDA satisfying Lindeberg condition and conditional variance convergence has row sums converging in distribution to Gaussian. Requires characteristic function methods and deep martingale theory not yet formalized in Mathlib. 0 sorries: the nested-ciSup independence lemma (independent_implies_zero_mixing), the i.i.d. Lindeberg condition, and the i.i.d. Lyapunov condition — all formerly sorries — are now fully proved in the main file.",
     "lineCount": 935,
     "theoremCount": 23,
     "definitionCount": 14,


### PR DESCRIPTION
## Problem

`central-limit-theorem-oq-02` claimed a remaining `sorry` that no longer exists.

- **meta.json** `assumptions` text stated *"1 sorry: nested ciSup of zeros = 0 for independent sequences (independent_implies_zero_mixing)"*.
- **Proofs/CentralLimitTheoremOQ02.lean** trailing summary comment stated *"REMAINING SORRIES (3)"* listing `independent_implies_zero_mixing`, the i.i.d. Lindeberg condition, and the i.i.d. Lyapunov condition.

Both are stale. All three lemmas are fully proved in the primary file:
- `independent_implies_zero_mixing` — proved at lines 495–537 (nested `iSup` collapse of constant `0`, no sorry).
- i.i.d. Lindeberg and Lyapunov conditions — already proved (noted in the sibling `CentralLimitTheoremOQ02OQ02.lean` header).

## Evidence

```
$ grep -nE '\bsorry\b' Proofs/CentralLimitTheoremOQ02.lean
905:PROVED (fully, no sorry):     # comment only — 0 real sorries
$ grep -c '^axiom ' Proofs/CentralLimitTheoremOQ02.lean
1                                 # martingale_clt (Billingsley Thm 35.12)
```

`meta.sorries` was already `0` and `axiomCount` is `1` (`martingale_clt`); `status: axiomatized` is correct. Only the descriptive prose overclaimed a sorry.

## Fix

Prose-only:
- meta.json `assumptions`: replaced the phantom "1 sorry" clause with "0 sorries" plus a note that all three formerly-remaining sorries are now proved.
- Primary `.lean` trailing comment: `REMAINING SORRIES (3)` → `REMAINING SORRIES (0)` with the three items marked ✓.

No Lean code or theorem changed; comment/JSON-string only, so no rebuild required. `meta.json` validated as parseable JSON.
