### PR TITLE
Audit: erdos-266 clean re-serve (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12123,8 +12123,8 @@
     },
     "erdos-266": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:58:17Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T09:31:07Z",
       "result": "clean"
     },
     "erdos-267": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-266

**Result: CLEAN** (reserve-mode re-serve)

Honest Tier-C axiomatized *disproved* problem (Erdős #266: Shifted Sums / Stolarsky's conjecture).

- **2 axioms**, both genuine Kovač–Tao (2024) results and openly credited:
  - `stolarsky_conjecture_false : ¬StolarskyConjecture` — **sound**: the conjecture is genuinely false (Kovač–Tao disproof) and non-vacuous (summable positive-integer sequences exist, e.g. 2ⁿ, so `StolarskyConjecture` is not vacuously provable). This is **not** the vacuous-`¬Conj`/false-disproof trap.
  - `kovac_tao_all_rationals` — ∃-witness sequence with all-rational-shift property; mutually consistent with (indeed implies) the first axiom.
- **0 sorries**, **no native_decide**, **theoremCount=3** (erdos_266, harmonic_diverges, sum_reciprocal_squares_summable; two anonymous `example`s not counted), **defs=1** (StolarskyConjecture) — all match source.
- `originalContributions` correctly scoped as "Formal **statement** of…" / "Statement of…" — no proof overclaim; all referenced decls present.
- status/badge `axiomatized`/`axiom`, `erdosProblemStatus: disproved`; `assumptions` discloses "2 axioms. No sorries."

Only change: tracker `lastAudited` timestamp.

---
Discovered during gallery integrity audit.