### PR TITLE
Audit: erdos-262 fix phantom originalContributions (LOW)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12096,9 +12096,9 @@
     },
     "erdos-262": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:58:17Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T09:33:15Z",
+      "result": "issues-fixed"
     },
     "erdos-263": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-262/meta.json
+++ b/src/data/proofs/erdos-262/meta.json
@@ -54,11 +54,6 @@
       "erdos_1975: 2^{2^n} is irrationality sequence (axiom)",
       "factorial_not_irrationality: n! is NOT (axiom)",
       "hančl_condition: limsup (log log a_n)/n ≥ 1",
-      "hančl_theorem: necessary condition (axiom)",
-      "double_exponential_necessary: lower bound on growth (axiom)",
-      "hančl_criterion: general criterion for non-irrationality sequences",
-      "slower_growth_fails: sub-doubly-exponential growth fails (axiom)",
-      "double_exp_ratio: spacing property (axiom)",
       "erdos_262_summary: combining example and counterexample"
     ],
     "dateAdded": "2026-01-19",


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-262

**Result: ISSUES-FIXED** (LOW — phantom `originalContributions`)

`originalContributions` listed **5 fabricated declarations** that exist nowhere in `Erdos262Problem.lean` (zero occurrences — not even as comment text):

| Claimed origContrib | Reality |
|---|---|
| `hančl_theorem: necessary condition (axiom)` | no decl — only a docstring above `def hančl_condition` |
| `double_exponential_necessary: lower bound on growth (axiom)` | comment-only (Part IV header) |
| `hančl_criterion: general criterion…` | comment-only (Part V header) |
| `slower_growth_fails: …fails (axiom)` | comment-only (Part V corollary) |
| `double_exp_ratio: spacing property (axiom)` | comment-only (Part VI header) |

Four were falsely tagged **"(axiom)"**, claiming axioms that don't exist. The actual file has exactly **2 axioms** (`erdos_1975`, `factorial_not_irrationality`), and `axiomCount=2` + the `assumptions` field were **honest** — only the narrative inflated (the "counts honest, narrative fabricates ~half" pattern).

**Fix**: removed the 5 phantom entries; kept the 9 that map to real decls (8 defs + 1 theorem + the 2 real axioms). All other checks pass: 0 sorries, no native_decide, theoremCount=1/defs=8 match source, status/badge `axiomatized`/`axiom` `solved`.

---
Discovered during gallery integrity audit.