### PR TITLE
Audit: erdos-260 fix 'Proved convergence' prose on sorried theorem (LOW)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12084,9 +12084,9 @@
     },
     "erdos-260": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:58:17Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T09:37:35Z",
+      "result": "issues-fixed"
     },
     "erdos-261": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-260/meta.json
+++ b/src/data/proofs/erdos-260/meta.json
@@ -47,7 +47,7 @@
       "Stated superlogarithmic irrationality result",
       "Developed the n² sequence as a concrete example",
       "Stated the main conjecture: fast growth alone implies irrationality",
-      "Proved convergence of the series under fast growth"
+      "Stated convergence of the series (series_converges, proof sorried)"
     ],
     "axiomCount": 1,
     "lineCount": 269,


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-260

**Result: ISSUES-FIXED** (LOW — "Proved" prose on a sorried theorem)

`originalContributions` claimed **"Proved convergence of the series under fast growth"**, but:

- `series_converges` (line 71) is **sorried** (line 75).
- Its statement is convergence *for any increasing sequence*, not gated on fast growth.
- `seriesSum := Classical.choose (series_converges a)` rests on that sorry, so nothing about convergence is kernel-proved.

The `assumptions` field already correctly lists `series_converges` among the 3 sorries — only this one origContrib bullet overclaimed (self-contradicting the assumptions). Reworded to **"Stated convergence of the series (series_converges, proof sorried)"**.

Everything else is honest: `status: axiomatized`, `badge: axiom`, `erdosProblemStatus: open`, `sorries: 3` matches the 3 real sorries (series_converges, irrational_of_gaps_to_infinity, irrational_of_superlogarithmic), `axiomCount: 1` matches `erdos_260_conjecture` (open), no native_decide. `squareSeq_irrational` rests on the sorried gaps lemma but is only described as "a concrete example" (not claimed proved) — acceptable for an axiomatized file.

---
Discovered during gallery integrity audit.