### PR TITLE
Audit: erdos-253 clean re-serve (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12030,8 +12030,8 @@
     },
     "erdos-253": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:58:17Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T09:39:02Z",
       "result": "clean"
     },
     "erdos-254": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-253

**Result: CLEAN** (reserve-mode re-serve)

Honest Tier-C axiomatized *disproved* problem (Subset Sums in Arithmetic Progressions; Cassels 1960).

- **1 axiom** `erdos_253_disproved : ¬∀ a, (∀n, 0<a n) → HasAPRepresentationProperty a → HasRatioTendingToOne a → (subsetSums (range a))ᶜ.Finite`.
- **Disproof-axiom consistency verified**: the inner ∀ is genuinely **false** (Cassels' counterexample) and its hypotheses are **satisfiable** (e.g. aₙ=n satisfies AP-representation-property + ratio→1 + positivity, with finite complement). So the inner ∀ is a meaningful false statement — the negation axiom is **sound and non-vacuous**, not the vacuous-`¬Conj` trap.
- **0 sorries, no native_decide.** 4 theorems (`zero_mem_subsetSums`, `mem_subsetSums_of_mem`, `nat_is_infinite_AP`, `evens_is_infinite_AP` — all genuinely proved) + 4 defs match counts.
- `originalContributions` all map to real decls ("Formal statement of…", "Definition of…", "Verified examples: ℕ and evens as infinite APs"). status/badge `axiomatized`/`axiom`, `disproved`.

Only change: tracker `lastAudited` timestamp.

---
Discovered during gallery integrity audit.