### PR TITLE
Audit: erdos-257 clean re-serve (reserve mode)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12054,8 +12054,8 @@
     },
     "erdos-257": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:58:17Z",
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T09:40:44Z",
       "result": "clean"
     },
     "erdos-258": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-257

**Result: CLEAN** (reserve-mode re-serve)

Honest Tier-C axiomatized open problem (Irrationality of Lambert Sums ∑ 1/(2ⁿ−1)).

- **3 axioms, all sound & consistent** (all disclosed in `assumptions`):
  - `lambert_series_identity` (`lambertSum univ = divisorSum`) — true classical identity ∑1/(2ⁿ−1)=∑d(n)/2ⁿ; the n=0 junk terms are 0 on both sides.
  - `erdos_divisor_sum_irrational` (`Irrational divisorSum`) — Erdős 1948, a true theorem.
  - `erdos_257_conjecture` (`∀ A infinite → Irrational (lambertSum A)`) — the conjectured-true answer to the **open** general case; no provable counterexample exists (an infinite A has infinitely many n≥1 giving a genuine positive series), so this is the standard open-conjecture axiomatization, **not** the ¬∃-answer/false-axiom trap.
- Lone theorem `full_lambert_sum_irrational` transparently derived from the two axioms (`rw [lambert_series_identity]; exact erdos_divisor_sum_irrational`); docstring correctly labels it a corollary.
- All `native_decide` uses (lines 105–121) are **anonymous `example`s** (divisor-count and Mersenne-number demos) → trust-neutral, do not propagate to any named result.
- 0 sorries; counts match (3 ax / 1 thm / 2 defs); all 4 `originalContributions` map to real decls. status/badge `axiomatized`/`axiom`, `open`.

Only change: tracker `lastAudited` timestamp.

---
Discovered during gallery integrity audit.