### PR TITLE
Audit: erdos-254 issues-found (CRITICAL inconsistent axioms, issue #41263)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12036,9 +12036,9 @@
     },
     "erdos-254": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:58:17Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T09:44:12Z",
+      "result": "issues-found"
     },
     "erdos-255": {
       "agentId": "auditor-2026-05-02T04:57:20.128138Z",


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-254

**Result: ISSUES-FOUND** (CRITICAL — inconsistent/false axioms) → filed **#41263**

Two of the four axioms assert **false** statements about the concrete set `PowersOf2 = {2^k}`; their negations are provable in Lean, so `False` is derivable.

- `powers_of_2_growth : HasGrowthCondition PowersOf2` — FALSE. Any `(x,2x]` holds ≤1 power of 2, so `countTo(2x)−countTo(x) ≤ 1`; the condition needs →∞. Fails already at M=2.
- `powers_of_2_irrationality : HasIrrationalityCondition PowersOf2` — FALSE. At **θ=1/2**, `fracDist(½·2^k)=0` for all k≥1 (integer) and `=½` only at k=0 → finitely supported → Summable, so `¬Summable` is false.

`erdos_254_summary` presents the false "Powers of 2 satisfy both conditions" as a proved theorem. (The other two axioms — `powers_of_2_representation` = binary representation, and `cassels_theorem` — are sound.)

Root cause: powers of 2 are far too sparse/periodic to be an example of the dense, equidistributed sequences Erdős #254 concerns.

Recommended fix (in #41263): remove the two false axioms, drop the false conjunct from `erdos_254_summary` + docstring, update `meta.axiomCount` 4→2. Rebuild to confirm consistency.

Tracker updated to `issues-found`.

---
Discovered during gallery integrity audit.