### PR TITLE
Fix: erdos-254 remove two FALSE axioms (powers of 2 fail growth/irrationality)

### DIFF
--- a/proofs/Proofs/Erdos254Problem.lean
+++ b/proofs/Proofs/Erdos254Problem.lean
@@ -145,13 +145,15 @@ axiom cassels_theorem :
 /-- The set of powers of 2: {1, 2, 4, 8, ...} -/
 def PowersOf2 : Set ℕ := {n | ∃ k, n = 2^k}
 
-/-- Powers of 2 satisfy the growth condition. -/
-axiom powers_of_2_growth :
-  HasGrowthCondition PowersOf2
-
-/-- Powers of 2 satisfy the irrationality condition. -/
-axiom powers_of_2_irrationality :
-  HasIrrationalityCondition PowersOf2
+/-
+Note. Powers of 2 do **not** satisfy the Erdős #254 hypotheses: they are far too
+sparse. Every dyadic interval `(x, 2x]` contains at most one power of 2, so the
+growth condition fails (`¬HasGrowthCondition PowersOf2` is provable); and at
+`θ = 1/2` the fractional distances `{θ·2^k}` vanish for all `k ≥ 1`, making the
+series summable, so the irrationality condition fails too. We therefore keep only
+the true statement about powers of 2 — that they represent every sufficiently
+large integer via binary expansion. (See issue #41263.)
+-/
 
 /-- Every sufficiently large n is a sum of distinct powers of 2 (binary representation). -/
 axiom powers_of_2_representation :
@@ -169,19 +171,18 @@ then every sufficiently large integer is a subset sum of A.
 
 Combines:
 1. Cassels's theorem under stronger hypotheses
-2. Powers of 2 as a concrete example satisfying all conditions
-3. Powers of 2 represent all sufficiently large integers
+2. Powers of 2 represent all sufficiently large integers (binary expansion)
+
+(Powers of 2 do **not** satisfy the growth/irrationality hypotheses — they are
+too sparse — so no such conjunct is claimed here. See issue #41263.)
 -/
 theorem erdos_254_summary :
     -- Cassels's theorem holds under stronger conditions
     (∀ A : Set ℕ, HasStrongGrowthCondition A →
       HasStrongIrrationalityCondition A → RepresentsAllLarge A) ∧
-    -- Powers of 2 satisfy both conditions
-    (HasGrowthCondition PowersOf2 ∧ HasIrrationalityCondition PowersOf2) ∧
-    -- Powers of 2 represent all large integers
+    -- Powers of 2 represent all large integers (binary expansion)
     RepresentsAllLarge PowersOf2 :=
   ⟨cassels_theorem,
-   ⟨powers_of_2_growth, powers_of_2_irrationality⟩,
    powers_of_2_representation⟩
 
 end Erdos254

--- a/src/data/proofs/erdos-254/meta.json
+++ b/src/data/proofs/erdos-254/meta.json
@@ -22,9 +22,9 @@
     "erdosNumber": 254,
     "erdosUrl": "https://erdosproblems.com/254",
     "erdosProblemStatus": "open",
-    "axiomCount": 4,
+    "axiomCount": 2,
     "lineCount": 187,
-    "assumptions": "4 axioms: cassels_theorem, powers_of_2_growth, powers_of_2_irrationality, powers_of_2_representation. 0 sorries.",
+    "assumptions": "2 axioms: cassels_theorem (Cassels's 1960 theorem under stronger hypotheses), powers_of_2_representation (every large integer is a sum of distinct powers of 2, by binary expansion). 0 sorries. Note: powers of 2 do NOT satisfy the growth/irrationality hypotheses (too sparse), so no such axiom is asserted — see issue #41263.",
     "mathlib_version": "4.31.0",
     "theoremCount": 1,
     "definitionCount": 13
@@ -33,12 +33,12 @@
     "historicalContext": "**Erdős Problem #254** was posed by Paul Erdős in 1961, connecting additive combinatorics with Diophantine approximation. Given $A \\subseteq \\mathbb{N}$ with (1) unbounded growth in dyadic intervals: $|A \\cap [x, 2x]| \\to \\infty$, and (2) an irrationality condition: $\\sum_{n \\in A} \\|\\theta n\\| = \\infty$ for all $\\theta \\in (0,1)$, Erdős conjectured every sufficiently large integer is a sum of distinct elements of $A$.\n\nJ.W.S. Cassels proved a related result in his 1960 paper 'On the representation of integers as the sums of distinct summands taken from a fixed set' (Acta Sci. Math. Szeged, 111-124). Cassels's theorem replaces condition (1) with the stronger logarithmic growth $|A \\cap [x, 2x]|/\\log\\log x \\to \\infty$ and uses the weaker $L^2$ condition $\\sum \\|\\theta n\\|^2 = \\infty$. His proof employs Fourier analysis on the circle $\\mathbb{R}/\\mathbb{Z}$, using the exponential sum $\\sum_{n \\in A} e^{2\\pi i \\theta n}$ to control the number of representations.\n\nThe problem in its original form remains **open**. The gap between Erdős's weak conditions and Cassels's stronger ones is the central challenge: Erdős requires no growth rate at all, only unboundedness, which is too weak for Cassels's Fourier-analytic approach to apply directly.",
     "problemStatement": "Let $A\\subseteq \\mathbb{N}$ be such that\\[\\lvert A\\cap [1,2x]\\rvert -\\lvert A\\cap [1,x]\\rvert \\to \\infty\\textrm{ as }x\\to \\infty\\]and\\[\\sum_{n\\in A} \\{ \\theta n\\}=\\infty\\]for every $\\theta\\in (0,1)$, where $\\{x\\}$ is the distance of $x$ from the nearest integer. Then every sufficiently large integer is the sum of distinct elements of $A$.\n\n\n\nCassels \\cite{Ca60} proved this under the alternative hypotheses\\[\\lim \\frac{\\lvert A\\cap [1,2x]\\rvert -\\lvert A\\cap [1,x]\\rvert}{\\log\\log x}=\\infty\\]and\\[\\sum_{n\\in A} \\{ \\theta n\\}^2=\\infty\\]for every $\\theta\\in (0,1)$.\n\n\n\n\nReferences\n\n\n[Ca60] Cassels, J. W. S., On the representation of integers as the sums of distinct summands taken from a fixed set. Acta Sci. Math. (Szeged) (1960), 111-124.",
     "text": "If A ⊆ ℕ has unbounded growth in dyadic intervals and Σ{θn} = ∞ for all θ ∈ (0,1), must every sufficiently large integer be a sum of distinct elements of A? Cassels (1960) proved a related result under stronger hypotheses.",
-    "proofStrategy": "The formalization defines the two key conditions (growth and irrationality) and states both Erdős's open conjecture and Cassels's proved theorem. The growth condition requires |A ∩ [1,2x]| - |A ∩ [1,x]| → ∞, ensuring A has elements spread across all dyadic intervals. The irrationality condition Σ{θn} = ∞ prevents A from being too concentrated modulo any irrational. Cassels's stronger version replaces these with logarithmic growth rate and L² summability. Powers of 2 serve as a concrete example satisfying all conditions.",
+    "proofStrategy": "The formalization defines the two key conditions (growth and irrationality) and states both Erdős's open conjecture and Cassels's proved theorem. The growth condition requires |A ∩ [1,2x]| - |A ∩ [1,x]| → ∞, ensuring A has elements spread across all dyadic intervals. The irrationality condition Σ{θn} = ∞ prevents A from being too concentrated modulo any irrational. Cassels's stronger version replaces these with logarithmic growth rate and L² summability. Powers of 2 illustrate the representation conclusion (every large integer is a sum of distinct powers of 2, by binary expansion), but note they do NOT satisfy the growth/irrationality hypotheses — they are too sparse.",
     "keyInsights": [
       "**Growth condition**: Requires unbounded elements in every dyadic interval [x, 2x], ensuring the set A spreads out at all scales",
       "**Irrationality condition**: Σ{θn} = ∞ for all θ ∈ (0,1) prevents A from concentrating near multiples of any irrational, connecting to equidistribution theory",
       "**Cassels's theorem**: Proved under strictly stronger hypotheses — logarithmic growth rate and L² summability — but Erdős's weaker conditions remain open",
-      "**Powers of 2 example**: The set {1, 2, 4, 8, ...} satisfies all conditions, and every positive integer is a sum of distinct powers of 2 (binary representation)",
+      "**Powers of 2 example**: Every positive integer is a sum of distinct powers of 2 (binary representation), illustrating the representation conclusion. Powers of 2 do NOT satisfy the growth/irrationality hypotheses (too sparse) — see issue #41263",
       "**Additive combinatorics meets Diophantine approximation**: The problem bridges two major branches of number theory"
     ],
     "prerequisites": [
@@ -108,8 +108,8 @@
       "title": "Examples",
       "startLine": 139,
       "endLine": 157,
-      "summary": "Powers of 2: $\\{2^k : k \\ge 0\\}$ satisfies both conditions and every positive integer has a binary representation as a sum of distinct powers.",
-      "mathContext": "Powers of 2: $\\{$2^{k}$ : k \\ge 0\\}$ satisfies both conditions and every positive integer has a binary representation as a sum of distinct powers."
+      "summary": "Powers of 2: $\\{2^k : k \\ge 0\\}$ — every positive integer has a binary representation as a sum of distinct powers, illustrating the representation conclusion. (They do NOT satisfy the growth/irrationality hypotheses; too sparse.)",
+      "mathContext": "Powers of 2: $\\{2^{k} : k \\ge 0\\}$ — every positive integer has a binary representation as a sum of distinct powers, illustrating the representation conclusion. (They do NOT satisfy the growth/irrationality hypotheses; too sparse.)"
     },
     {
       "id": "summary",
@@ -143,8 +143,8 @@
       "Set"
     ],
     "namespace": "Erdos254",
-    "lineCount": 187,
-    "axiomCount": 4,
+    "lineCount": 188,
+    "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 13,
     "path": "Proofs/Erdos254Problem.lean",


### PR DESCRIPTION
## Summary

Repairs the **inconsistent axioms** in `erdos-254` reported by the gallery integrity audit (#41263). Two of the four axioms asserted mathematically **false** statements about the concrete set `PowersOf2 = {n | ∃ k, n = 2^k}`, making the file logically inconsistent (`False` derivable).

## Root cause

Powers of 2 are far too sparse to satisfy the Erdős #254 hypotheses:

- **`powers_of_2_growth : HasGrowthCondition PowersOf2`** — FALSE. Every dyadic interval `(x, 2x]` contains at most one power of 2, so `countTo(2x) − countTo(x) ≤ 1` always; the growth condition (needs `≥ M` for every `M`) fails.
- **`powers_of_2_irrationality : HasIrrationalityCondition PowersOf2`** — FALSE. At `θ = 1/2`, `fracDist((1/2)·2^k) = 0` for all `k ≥ 1`, so the series is finitely supported → Summable, contradicting the `¬Summable` requirement.

The remaining two axioms are legitimate and retained: `cassels_theorem` (Cassels's 1960 result under stronger hypotheses) and `powers_of_2_representation` (binary expansion — TRUE).

## Changes

- **`proofs/Proofs/Erdos254Problem.lean`**: delete `powers_of_2_growth` and `powers_of_2_irrationality`; rewrite `erdos_254_summary` to drop the false `HasGrowthCondition ∧ HasIrrationalityCondition` conjunct (keeps `cassels_theorem` + `RepresentsAllLarge PowersOf2`, both true); add an explanatory note.
- **`src/data/proofs/erdos-254/meta.json`**: `axiomCount` 4 → 2; update `assumptions`, `proofStrategy`, key insight, Examples section, and `lineCount` to stop claiming powers of 2 satisfy the hypotheses.

## Evidence

- Before: 4 axioms, 2 of them false → kernel inconsistent.
- After: 2 axioms, both true. `erdos_254_summary` no longer references the deleted axioms.
- **Docker build**: `✔ Built Proofs.Erdos254Problem (2.4s)` — Build succeeded (8576 jobs).

Closes #41263
