### PR TITLE
Audit: erdos-256 remove 4 phantom axiom originalContributions (LOW)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12048,9 +12048,9 @@
     },
     "erdos-256": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:58:17Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-07-22T09:53:01Z",
+      "result": "issues-fixed"
     },
     "erdos-257": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-256/meta.json
+++ b/src/data/proofs/erdos-256/meta.json
@@ -55,12 +55,8 @@
       "belov_konyagin_bound axiom: log f(n) ≪ (log n)⁴",
       "erdos_256_answer theorem: ¬ErdosQuestion256",
       "fDistinct definition for distinct exponents",
-      "bourgain_chang_bound axiom for f*(n)",
       "chowlaMinimum definition (Problem #510 connection)",
-      "atkinson_chowla_connection axiom",
-      "product_at_root_of_unity theorem",
-      "primitive_root_lower_bound axiom",
-      "bounds_summary axiom"
+      "product_at_root_of_unity theorem"
     ],
     "axiomCount": 2,
     "prerequisites": [


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-256

**Result: ISSUES-FIXED** (LOW — phantom axiom origContributions)

`originalContributions` listed **4 axioms that exist nowhere** in `Erdos256Problem.lean` (zero occurrences, not even as comments):
- `bourgain_chang_bound axiom for f*(n)`
- `atkinson_chowla_connection axiom`
- `primitive_root_lower_bound axiom`
- `bounds_summary axiom`

Only **2 real axioms** exist: `erdos_szekeres_lower` (L73) and `belov_konyagin_bound` (L120). `axiomCount=2` and `assumptions` were already honest — this is the "counts honest, narrative fabricates" pattern (cf. erdos-262 #41256). A prior audit even documented in a section summary that `primitive_root_lower_bound` has "no Lean declaration exists", yet the origContribs list was left uncleaned.

**Fix**: removed the 4 phantom entries (kept the 10 that map to real decls).

Consistency of the 2 real axioms verified (this is a *solved*/disproved problem): the Erdős–Szekeres lower bound `f(n) > √(2n)` and Belov–Konyagin polylog upper bound `log f(n) ≤ C(log n)⁴` are mutually consistent; `erdos_256_answer : ¬ErdosQuestion256` is genuinely derived (n^c beats (log n)⁴), no sorry, no native_decide.

---
Discovered during gallery integrity audit.