### PR TITLE
Audit tracker: erdos-490-oq-01 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14050,9 +14050,9 @@
       "notes": "Re-audit CLEAN: meta status/badge/sorries/axiomCount all reconcile with Lean source. Sorry-count 'mismatches' from companion *Aristotle scaffolds are not counted (meta.sorries tracks main file). native_decide in erdos-1064 backs only illustrative examples with ofReduceBool disclosed; descartes axiomCount=1 = SturmReduction structure-encoded assumption, disclosed."
     },
     "erdos-490-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:18Z",
+      "lastAudited": "2026-07-22T10:01:37Z",
       "result": "clean"
     },
     "erdos-491": {


### PR DESCRIPTION
Reserve-mode re-audit. 0 sorries, 1 disclosed axiom (szemeredi_upper, matches axiomCount:1), 0 native_decide, 16 theorems (counts match). Verified the sibling dependency Erdos490.bound_is_optimal is axiom-free (uses only Mathlib Chebyshev, not the sibling's szemeredi_theorem axiom), so optimal_lower is genuinely 0-axiom as the meta claims. All originalContributions map to real theorems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)