### PR TITLE
Audit tracker: erdos-1179-oq-01 clean (reserve re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10655,9 +10655,9 @@
       "notes": "#14732: phantom axioms (erdos_renyi_upper, gEps_mono not declared; main_asymptotic now theorem main_asymptotic_derived; trivial_lower_bound→basic_lower_bound) in originalContributions/sections; section line drift (sections cover 1-178 of 316-line file; Parts IX, X missing); proofStrategy says 179-line file"
     },
     "erdos-1179-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:18Z",
+      "lastAudited": "2026-07-22T10:06:15Z",
       "result": "clean"
     },
     "erdos-1179-oq-02": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-1179-oq-01 [verified/mathlib].

**All meta claims match source** (`proofs/Proofs/Erdos1179OQ01.lean`):
- 0 sorries, 0 axioms (the lone `axiom` grep hit is a docstring note about a retired axiom)
- 28 theorems/lemmas, 7 defs (incl. `private noncomputable def ωp/ψp`)
- No native_decide / decide
- Headline Fourier theorems (`fourier_error_bound`, `erdos_renyi_decay`, `character_orthogonality`, `reprCount_fourier_expansion`, `fourier_product_bound`) all exist as real proved decls with substantive, non-vacuous statements
- badge `mathlib` / status `verified` appropriate

No integrity issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)