### PR TITLE
Audit tracker: erdos-1095-oq-01 clean (reserve re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9845,9 +9845,9 @@
       "result": "clean"
     },
     "erdos-1095-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:18Z",
+      "lastAudited": "2026-07-22T10:08:41Z",
       "result": "clean"
     },
     "erdos-1096": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-1095-oq-01 [axiomatized/wip].

**All meta claims match source** (`proofs/Proofs/Erdos1095OQ01Problem.lean`):
- 0 sorries, 0 axioms, 37 theorems, 5 defs — all match
- 0 native_decide (21 `decide`, kernel-checked, for concrete g(k) values)
- `gFunc_exists` proved constructively via `KummerTheoremOQ03.choose_coprime_of_no_carries` (a real theorem in an **axiom-free** companion file) → the 0-axiom claim holds transitively
- Main conjectures (`ErdosAsymptoticConjecture`, `ErdosProblem1095OQ01`) correctly stated as open `def : Prop`, not asserted as theorems → status `axiomatized`/`wip` is conservative/honest
- No vacuous True stubs; origContributions=None

No integrity issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)