### PR TITLE
Fix: e-transcendental-oq-01 assumptions field falsely claims e+π resolved from Nesterenko

### DIFF
--- a/src/data/proofs/e-transcendental-oq-01/meta.json
+++ b/src/data/proofs/e-transcendental-oq-01/meta.json
@@ -65,7 +65,7 @@
     "dateAdded": "2026-02-23",
     "axiomCount": 1,
     "lineCount": 538,
-    "assumptions": "1 axiom: nesterenko_algebraic_independence (Nesterenko 1996: π, e^π, Γ(1/4) are algebraically independent over ℚ). Former open problem axioms schanuel_conjecture, e_plus_pi_transcendental, e_times_pi_transcendental, e_plus_pi_irrational now proved as theorems from Nesterenko's theorem.",
+    "assumptions": "1 axiom: nesterenko_algebraic_independence (Nesterenko 1996: π, e^π, Γ(1/4) are algebraically independent over ℚ). From this axiom the file derives one unconditional new transcendence result: π + e^π is transcendental (pi_plus_exp_pi_transcendental). The transcendence of e + π and e·π, and the irrationality of e + π, remain OPEN — they are formalized only as CONDITIONAL theorems (e_plus_pi_transcendental_from_independence, e_times_pi_transcendental_from_independence, e_plus_pi_irrational_from_independence) whose hypothesis is the unproven algebraic independence of e and π (which would follow from Schanuel's Conjecture, itself unproven and not axiomatized here).",
     "mathlib_version": "4.31.0",
     "definitionCount": 2
   },


### PR DESCRIPTION
## Problem

The `assumptions` field of `e-transcendental-oq-01` (an **open question** — "Is e + π transcendental?") overclaimed that the open problem is resolved:

> "Former open problem axioms schanuel_conjecture, e_plus_pi_transcendental, e_times_pi_transcendental, e_plus_pi_irrational now proved as theorems from Nesterenko's theorem."

This is false and contradicts the rest of the meta (problemStatement, proofStrategy, keyInsights all correctly present e+π as OPEN — those fields were already corrected in a prior commit; the `assumptions` field was missed).

## Evidence (from `proofs/Proofs/ETranscendentalOQ01.lean`)

- **One** axiom only: `nesterenko_algebraic_independence` (π, e^π, Γ(1/4) alg. independent). `grep -c "^axiom"` = 1. There is **no** `schanuel_conjecture` axiom.
- `pi_plus_exp_pi_transcendental` (line 311) — proved **unconditionally** from Nesterenko. This is the only new unconditional transcendence result. Note it is **π + e^π**, not **e + π**.
- `e_plus_pi_transcendental_from_independence` (line 407), `e_times_pi_transcendental_from_independence` (line 440), `e_plus_pi_irrational_from_independence` (line 475) — all take hypothesis `h_ind : e_pi_algebraicallyIndependent`, i.e. they are **CONDITIONAL** on the unproven algebraic independence of e and π (which would follow from Schanuel's Conjecture). They are NOT derived from Nesterenko — Nesterenko concerns e^π ≈ 23.14, not e ≈ 2.71.

## Fix

Metadata-only. Rewrote the `assumptions` field to accurately state: Nesterenko yields π+e^π transcendental unconditionally; e+π/e·π transcendence and e+π irrationality remain OPEN, formalized only as conditional theorems. No Lean source or status/badge/axiomCount change (`axiomCount: 1` was already correct).
