### PR TITLE
Enrich erdos-1008-oq-01: disclose native_decide (Lean.ofReduceBool) footprint

### DIFF
--- a/src/data/proofs/erdos-1008-oq-01/meta.json
+++ b/src/data/proofs/erdos-1008-oq-01/meta.json
@@ -26,7 +26,7 @@
     "erdosProblemStatus": "open-question",
     "axiomCount": 1,
     "lineCount": 374,
-    "assumptions": "One axiom: cfs_admissible_exists (Conlon-Fox-Sudakov main theorem). folkman_upper_bound now proved via completeGraph(Fin 2) specialization. 15 theorems fully proved.",
+    "assumptions": "One mathematical axiom: cfs_admissible_exists (Conlon-Fox-Sudakov main theorem) — this is the sole substantive assumption and the source of the axiom badge. folkman_upper_bound is now proved via a completeGraph(Fin 2) specialization; 15 theorems are fully proved. Additional compiler-trust disclosure: three theorems — folkman_upper_bound, optimal_constant_pos, and optimal_constant_bounds (which composes both) — discharge the trivial helper fact (completeGraph (Fin 2)).edgeFinset.card = 1 with native_decide, so their axiom footprint also includes Lean.ofReduceBool (kernel reduction trusts the compiler). This affects only a 2-vertex edge-count computation, not the substantive mathematics, and is kernel-decidable (replaceable by decide); it does not raise the mathematical assumption count.",
     "mathlib_version": "4.31.0",
     "theoremCount": 15,
     "definitionCount": 6


### PR DESCRIPTION
## Summary

Prose-disclosure enrichment addressing gallery integrity issue #41282 (LOW severity, `loom:auditor`).

The `meta.assumptions` field previously disclosed only the single mathematical axiom (`cfs_admissible_exists`, Conlon–Fox–Sudakov). It did not disclose that three publicly-presented theorems transitively depend on `Lean.ofReduceBool` (compiler trust) via `native_decide`:

- `folkman_upper_bound` (L220) — `native_decide` at L227
- `optimal_constant_pos` (L250) — `native_decide` at L259
- `optimal_constant_bounds` (L282) — composes both, inherits the dependency

Both `native_decide` calls discharge the same trivial helper `(completeGraph (Fin 2)).edgeFinset.card = 1` (K₂ has one edge).

## Change

Updated `meta.assumptions` to explicitly disclose the `native_decide` / `Lean.ofReduceBool` footprint, clarifying that:
- it affects only a trivial 2-vertex edge-count computation, not the substantive mathematics;
- it is kernel-decidable (replaceable by `decide`);
- it does **not** raise the mathematical assumption count.

The entry is already correctly `axiomatized` (`axiomCount: 1`, `badge: axiom`) for the substantive axiom, so status/badge/count are unchanged — this is the auditor's option 2 (disclosure).

## Scope note

The auditor's preferred option 1 (swap `native_decide`→`decide` in the `.lean` source) and refreshing the stale L368 docstring are source changes requiring a Docker build — mechanic territory, left for a follow-up. This disclosure alone makes the published metadata honest, which resolves the accuracy concern the issue raises.

JSON validated; file is 11.7 KB (well under the 60 KB cap). No `.lean` source touched.

Closes #41282

🤖 Generated with [Claude Code](https://claude.com/claude-code)
