### PR TITLE
Audit tracker: cramers-rule-oq-03 clean (reserve re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6731,9 +6731,9 @@
       "issues": []
     },
     "cramers-rule-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:18Z",
+      "lastAudited": "2026-07-22T10:19:32Z",
       "result": "clean"
     },
     "cramers-rule-oq-04": {


### PR DESCRIPTION
Reserve-mode re-audit of `cramers-rule-oq-03` (queue drained, 4809/4809 audited).

**Result: clean.** Main file `CramersRuleOQ03.lean`: 8 theorems, 3 defs (matches meta), 0 sorries, 0 axioms, no native_decide. All originalContributions map to real proved declarations; `status: verified` justified. Additional quaternion file also clean. Badge `mathlib` mildly under-credits genuinely-original quasideterminant proofs (safe direction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)