### PR TITLE
Fix: erdos-1008-oq-01 replace native_decide with decide

### DIFF
--- a/proofs/Proofs/Erdos1008OQ01.lean
+++ b/proofs/Proofs/Erdos1008OQ01.lean
@@ -224,7 +224,7 @@ theorem folkman_upper_bound : optimalConstant ≤ 1 := by
     intro c hc
     obtain ⟨H, hdr, hsub, _, hge⟩ := hc.2 (Fin 2) (completeGraph (Fin 2))
     letI := hdr
-    have hone : (completeGraph (Fin 2)).edgeFinset.card = 1 := by native_decide
+    have hone : (completeGraph (Fin 2)).edgeFinset.card = 1 := by decide
     have hle : H ≤ completeGraph (Fin 2) := hsub
     have hH_sub : H.edgeFinset ⊆ (completeGraph (Fin 2)).edgeFinset := by
       intro e he; rw [SimpleGraph.mem_edgeFinset] at he ⊢
@@ -256,7 +256,7 @@ theorem optimal_constant_pos : optimalConstant > 0 := by
     obtain ⟨H, hdr, hsub, _, hge⟩ := hc.2 (Fin 2) (completeGraph (Fin 2))
     letI := hdr
     -- completeGraph (Fin 2) has 1 edge
-    have hone : (completeGraph (Fin 2)).edgeFinset.card = 1 := by native_decide
+    have hone : (completeGraph (Fin 2)).edgeFinset.card = 1 := by decide
     -- H is a subgraph, so H has ≤ 1 edge
     have hle : H ≤ completeGraph (Fin 2) := hsub
     have hH_sub : H.edgeFinset ⊆ (completeGraph (Fin 2)).edgeFinset := by
@@ -365,7 +365,7 @@ This file establishes:
 - c4free_of_subgraph: C₄-freeness is hereditary (proved)
 - empty_isC4Free: the empty graph is C₄-free (proved)
 - folkman_ratio: the Folkman ratio equals 1 (proved via real arithmetic)
-- Upper bound c* ≤ 1 (axiomatized - requires full KST formalization)
+- Upper bound c* ≤ 1 (fully proved via completeGraph (Fin 2) specialization)
 - Lower bound c* > 0 (axiomatized - this IS the CFS14 theorem)
 
 Open: determine the exact value of c* ∈ (0, 1].


### PR DESCRIPTION
## Summary

Fixes gallery integrity issue #41282 (LOW severity): three publicly-presented
theorems in `erdos-1008-oq-01` transitively depended on the undisclosed
`Lean.ofReduceBool` (compiler-trust) axiom via `native_decide`, while meta.json
discloses only "One axiom" (`cfs_admissible_exists`).

## Change

Applied the auditor's **preferred** fix: replaced both `native_decide` with
`decide`.

- L227 `folkman_upper_bound`: `(completeGraph (Fin 2)).edgeFinset.card = 1`
- L259 `optimal_constant_pos`: same computation
- (`optimal_constant_bounds` composes both and inherits the fix)

The computation is a 2-vertex graph — kernel-decidable — so `decide` discharges
it without shifting trust to compiled code. This eliminates `Lean.ofReduceBool`
from the axiom footprint entirely, so meta's `axiomCount: 1` / "One axiom"
disclosure is now accurate **with no metadata change**.

Also refreshed a stale summary docstring: "Upper bound c* ≤ 1 (axiomatized ...)"
→ "fully proved via completeGraph (Fin 2) specialization" (understatement the
auditor flagged as worth refreshing).

## Evidence

Host-verified against Mathlib cache:
```
lake env lean Proofs/Erdos1008OQ01.lean → VERIFY_OK
```
(only a pre-existing `push_neg` deprecation warning, unrelated.)

Closes #41282
