### PR TITLE
Enrich erdos-1100: fix stale 'two remaining sorries' prose

### DIFF
--- a/src/data/proofs/erdos-1100/meta.json
+++ b/src/data/proofs/erdos-1100/meta.json
@@ -97,8 +97,8 @@
       "title": "Question 3: Growth of g(k)",
       "startLine": 187,
       "endLine": 231,
-      "summary": "Defines g(k) as the supremum of τ⊥(n) over squarefree n with ω(n) = k, axiomatizes the Erdős–Simonovits bounds, and proves g_exponential_growth (with two sorries for the limit arguments).",
-      "mathContext": "Formal definition: Defines g(k) as the supremum of τ⊥(n) over squarefree n with ω(n) = k, axiomatizes the Erdős–Simonovits bounds, and proves g_exponential_growth (with two sorries for the limit arguments)."
+      "summary": "Defines g(k) as the supremum of τ⊥(n) over squarefree n with ω(n) = k, axiomatizes the Erdős–Simonovits bounds, and proves g_exponential_growth by deriving its asymptotic lower bound (approaching √2) and eventual upper bound directly from the axiomatized Erdős–Simonovits bounds (no sorries).",
+      "mathContext": "Formal definition: Defines g(k) as the supremum of τ⊥(n) over squarefree n with ω(n) = k, axiomatizes the Erdős–Simonovits bounds, and proves g_exponential_growth by deriving its asymptotic lower bound (approaching √2) and eventual upper bound directly from the axiomatized Erdős–Simonovits bounds (no sorries)."
     },
     {
       "id": "examples",
@@ -126,7 +126,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures all three questions of Erdős Problem 1100 about τ⊥(n), the count of coprime consecutive divisor pairs. The known results — the trivial lower bound, its infinite tightness, and the Erdős–Hall and Erdős–Simonovits bounds — are axiomatized, and the exponential growth theorem for g(k) is partially proved with two remaining sorries for limit arguments.",
+    "summary": "The formalization captures all three questions of Erdős Problem 1100 about τ⊥(n), the count of coprime consecutive divisor pairs. The known results — the trivial lower bound, its infinite tightness, and the Erdős–Hall and Erdős–Simonovits bounds — are axiomatized, and the exponential growth theorem for g(k) is proved by deriving its asymptotic lower and eventual upper bounds directly from the axiomatized Erdős–Simonovits bounds (0 sorries).",
     "implications": "**Theoretical Significance**: Understanding τ⊥(n) would illuminate the fine structure of divisor lattices and how prime factorizations constrain the ordering of divisors.\n\nThe function τ⊥ connects to questions about the complexity of divisor sequences that arise in multiplicative number theory and combinatorial optimization on Boolean lattices. Determining the exact exponential base for g(k) would resolve a question at the intersection of extremal combinatorics and number theory.",
     "openQuestions": [
       "Does $\\tau^{\\perp}(n)/\\omega(n) \\to \\infty$ for almost all $n$? By the Hardy–Ramanujan theorem, $\\omega(n) \\approx \\log \\log n$ for almost all $n$, so this asks whether $\\tau^{\\perp}(n)$ typically exceeds $\\log \\log n$ by an unbounded factor.",


### PR DESCRIPTION
## Enrichment: erdos-1100 — remove stale "two remaining sorries" prose

`Erdos1100ProblemProvable.lean` is `status: axiomatized` with **3 axioms**
(`tau_perp_lower_bound`, `erdos_hall_max_lower_bound`, `erdos_simonovits_bounds`)
and **0 sorries** (the `meta.assumptions` field already states this). The
`g_exponential_growth` theorem (lines 216–230) is **fully proved** — it derives
its asymptotic lower bound (approaching √2) and eventual upper bound directly
from the `erdos_simonovits_bounds` axiom via `obtain`/`refine`/`linarith`, with
no `sorry` tactics.

### Changes (prose only — no status/badge/axiomCount change)
Three fields still claimed `g_exponential_growth` carries "two sorries for the
limit arguments":
- `sections[5].summary`
- `sections[5].mathContext`
- `conclusion.summary`

Updated all three to describe the theorem as proved by deriving the bounds from
the axiomatized Erdős–Simonovits result. No Lean source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
