### PR TITLE
Enrich: disclose native_decide (Lean.ofReduceBool) footprint in 5 more entries

### DIFF
--- a/src/data/proofs/erdos-11/meta.json
+++ b/src/data/proofs/erdos-11/meta.json
@@ -45,9 +45,9 @@
       "Statement of Granville-Soundararajan connection",
       "Axiomatization of computational verification bounds"
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 115,
-    "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
+    "assumptions": "No mathematical axioms and 0 sorries; previously cited axiom names were removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean. Compiler-trust disclosure: the concrete Wieferich-prime facts (known_wieferich_1093, known_wieferich_3511) are discharged with native_decide, so their axiom footprint includes Lean.ofReduceBool (kernel reduction trusts the compiled decision procedure). These are finite decidable computations and add no mathematical assumption; leanFile.axiomCount remains 0 (no literal axiom declarations).",
     "theoremCount": 10,
     "definitionCount": 8
   },

--- a/src/data/proofs/erdos-236/meta.json
+++ b/src/data/proofs/erdos-236/meta.json
@@ -51,9 +51,9 @@
       "Stated main conjecture f(n) = o(log n) formally",
       "Axiomatized Erdős lower bound and Vaughan sparsity bound"
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 175,
-    "assumptions": "0 axioms. 0 sorries. All results formalized without axioms.",
+    "assumptions": "No mathematical axioms and 0 sorries. Compiler-trust disclosure: the concrete f-values (f_nine, f_fifteen) are discharged with native_decide, so their axiom footprint includes Lean.ofReduceBool (kernel reduction trusts the compiled decision procedure; #print axioms lists Lean.ofReduceBool). These are finite decidable computations and add no mathematical assumption; leanFile.axiomCount remains 0 (no literal axiom declarations).",
     "theoremCount": 12,
     "definitionCount": 4
   },

--- a/src/data/proofs/erdos-267/meta.json
+++ b/src/data/proofs/erdos-267/meta.json
@@ -48,7 +48,7 @@
       "erdos_267_open by classical EM (decidability of open conjecture)",
       "pow_two_series_first_terms computation via native_decide"
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "prerequisites": [
       "Fibonacci sequence and recurrence relations",
       "Golden ratio and Binet's formula",
@@ -57,7 +57,7 @@
       "Geometric series comparison test"
     ],
     "lineCount": 224,
-    "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives.",
+    "assumptions": "No mathematical axioms and 0 sorries. Compiler-trust disclosure: pow_two_series_first_terms is discharged with native_decide, so its axiom footprint includes Lean.ofReduceBool (kernel reduction trusts the compiled decision procedure). This is a finite decidable computation and adds no mathematical assumption; leanFile.axiomCount remains 0 (no literal axiom declarations).",
     "mathlib_version": "4.31.0",
     "theoremCount": 12,
     "definitionCount": 5

--- a/src/data/proofs/erdos-325/meta.json
+++ b/src/data/proofs/erdos-325/meta.json
@@ -47,9 +47,9 @@
       "Statement of Wooley's partial result for k=3",
       "Context: Mahler-Erdős theorem for two-term sums"
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 126,
-    "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
+    "assumptions": "No mathematical axioms and 0 sorries; previously cited axiom names were removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean. Compiler-trust disclosure: the concrete sum-of-three-powers witnesses (three_isSumThreePower_two, three_isSumThreePower_three, twentynine_isSumThreePower_three) are discharged with native_decide, so their axiom footprint includes Lean.ofReduceBool (kernel reduction trusts the compiled decision procedure). These are finite decidable computations and add no mathematical assumption; leanFile.axiomCount remains 0 (no literal axiom declarations).",
     "theoremCount": 4,
     "definitionCount": 4
   },

--- a/src/data/proofs/erdos-422/meta.json
+++ b/src/data/proofs/erdos-422/meta.json
@@ -46,8 +46,8 @@
       "Defined WellDefinedAt and IsWellDefined predicates for well-definedness analysis",
       "Documented the four open questions (well-definedness, infinitely many missing integers, non-surjectivity, linear growth f(n) ≤ (1+ε)n) as comments in the Open Questions section — none are formalized as axioms or theorems, keeping the entry honestly open"
     ],
-    "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives.",
+    "axiomCount": 1,
+    "assumptions": "No mathematical axioms and 0 sorries. Compiler-trust disclosure: the concrete Hofstadter-sequence values (hofstadterF_one through hofstadterF_six) are discharged with native_decide, so their axiom footprint includes Lean.ofReduceBool (kernel reduction trusts the compiled decision procedure). These are finite decidable computations and add no mathematical assumption; leanFile.axiomCount remains 0 (no literal axiom declarations).",
     "lineCount": 93,
     "theoremCount": 7,
     "definitionCount": 4


### PR DESCRIPTION
## Enrichment: axiom-integrity prose accuracy (native_decide disclosure) — batch 2

Follow-up to #41293. Five more `axiomatized` gallery entries prove their **showcased concrete facts** with `native_decide` in named theorems, yet their `assumptions` prose claimed "0 axioms" / "proved from Lean primitives" / "formalized without axioms" / "axiom names removed".

Per the repo Axiom Integrity Policy: `native_decide` depends on `Lean.ofReduceBool` (`#print axioms` lists it — not axiom-free). When it discharges a substantive result the entry presents as established, `axiomCount ≥ 1` and the footprint must be disclosed.

| Entry | `native_decide`-proved named theorems |
|-------|----------------------------------------|
| erdos-236 | `f_nine`, `f_fifteen` |
| erdos-422 | `hofstadterF_one` … `hofstadterF_six` |
| erdos-267 | `pow_two_series_first_terms` |
| erdos-11 | `known_wieferich_1093`, `known_wieferich_3511` |
| erdos-325 | `three_isSumThreePower_two/three`, `twentynine_isSumThreePower_three` |

### Change
- `meta.axiomCount`: `0 → 1` (reflects `Lean.ofReduceBool`).
- `assumptions`: disclose the compiler-trust footprint; remove the inaccurate "axiom-free / from Lean primitives" wording.
- `leanFile.axiomCount` left at `0` (no literal `axiom` declarations — policy-consistent).
- `status` unchanged (already `axiomatized`); no mathematical assumption added — finite decidable computations, in principle replaceable by `decide`.

Prose-only + count accuracy; no Lean source changed. Mirrors #41293 / #41285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
