### PR TITLE
Audit tracker: law-of-cosines-oq-01 issues-found (#41301)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21925,10 +21925,10 @@
       "issues": []
     },
     "law-of-cosines-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:20Z",
-      "result": "clean"
+      "lastAudited": "2026-07-22T10:33:09Z",
+      "result": "issues-found"
     },
     "law-of-cosines-oq-01-oq-01": {
       "auditCount": 1,


### PR DESCRIPTION
Filed #41301: description claims full sin·sin·cos(C) trig form as proved, but `angleC` is defined-but-unused and the proved theorem uses a raw inner-product cross term. MEDIUM claim-scoping overstatement.