### PR TITLE
Audit tracker: dirichlets-theorem-oq-02-oq-01 issues-found (#41304)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7620,10 +7620,10 @@
       "result": "clean"
     },
     "dirichlets-theorem-oq-02-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:19Z",
-      "result": "clean"
+      "lastAudited": "2026-07-22T10:36:38Z",
+      "result": "issues-found"
     },
     "dirichlets-theorem-oq-03": {
       "auditCount": 5,


### PR DESCRIPTION
Filed #41304: GRH consequence enumeration overstates — improved PNT-for-AP, Linnik least-prime, and class-number consequences are not formalized (only √x logx<x and q²log²q<q^5 trivial inequalities; primeCountAP has no theorems). Core GRH formalization + Siegel-zero elimination honest. MEDIUM.