### PR TITLE
Fix: dirichlets-theorem-oq-02-oq-01 description overstates unformalized GRH consequences

### DIFF
--- a/proofs/Proofs/DirichletsTheoremOQ02OQ01.lean
+++ b/proofs/Proofs/DirichletsTheoremOQ02OQ01.lean
@@ -31,7 +31,7 @@ We axiomatize GRH and prove its consequences rigorously.
 
 ## Status
 
-Axiomatized (GRH is an open conjecture). 0 sorry, 13 axiom.
+Axiomatized (GRH is an open conjecture). 0 sorry, 4 axioms.
 -/
 
 import Mathlib.NumberTheory.LSeries.PrimesInAP

--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "dirichlets-theorem-oq-02-oq-01",
   "title": "Generalized Riemann Hypothesis for Dirichlet L-functions",
   "slug": "dirichlets-theorem-oq-02-oq-01",
-  "description": "The Generalized Riemann Hypothesis (GRH) asserts that all non-trivial zeros of Dirichlet L-functions L(s, χ) lie on the critical line Re(s) = 1/2. We formalize GRH, prove equivalences between formulations, and axiomatize its dramatic consequences: improved PNT for arithmetic progressions (error O(√x log x)), effective Linnik bound (least prime O(q² log² q)), elimination of Siegel zeros, and effective class number bounds.",
+  "description": "The Generalized Riemann Hypothesis (GRH) asserts that all non-trivial zeros of Dirichlet L-functions L(s, χ) lie on the critical line Re(s) = 1/2. We formalize GRH over Mathlib's Dirichlet L-functions, prove the GRH ↔ right-half-plane-zero-free equivalence via an axiomatized functional symmetry, and derive Siegel-zero elimination and an effective L(1, χ) positivity bound (from an axiomatized effective lower bound). Sublinearity facts (√x·log x < x; q²·log²q < q⁵) motivate the improved PNT-for-AP and Linnik exponents, but the prime-counting error term, least-prime bound, and class-number consequences are not themselves formalized.",
   "meta": {
     "author": "Open (Riemann 1859 for ζ; Piltz 1884 for L-functions; Montgomery-Vaughan for character sums)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Generalized_Riemann_hypothesis",


### PR DESCRIPTION
## Fix

Scopes the `dirichlets-theorem-oq-02-oq-01` (GRH) description to what is actually formalized, and corrects a stale docstring axiom count.

### Metadata (description)
The old description claimed GRH's four "dramatic consequences" are axiomatized/formalized. Per the audit, three are not:
- **Improved PNT for AP** — `primeCountAP` is defined but referenced by zero theorems; `GRH_error_sublinear` only proves `√x·log x < x`.
- **Effective Linnik / least prime** — no least-prime decl; `GRH_least_prime_improves_linnik` only proves `q²·log²q < q⁵`.
- **Effective class number bounds** — absent entirely.
- **Siegel-zero elimination** — genuinely formalized (`GRH_no_siegel_zeros`). ✓

Reworded to name only what exists (GRH definition, GRH ↔ right-half equivalence, Siegel-zero elimination, effective L(1,χ) bound) and to describe the sublinearity facts as *motivating* rather than *establishing* the PNT/Linnik consequences.

### Docstring
Module docstring said `0 sorry, 13 axiom`; file has 4 axioms (`axiomCount: 4`). Corrected to `0 sorry, 4 axioms`.

Status `axiomatized` / badge `axiom` remain appropriate — no change. Comment/description-only edit, no Lean rebuild required.

Closes #41304
