### PR TITLE
Fix: disclose full native_decide/ofReduceBool scope in wolstenholme-theorem-oq-01 assumptions

### DIFF
--- a/src/data/proofs/wolstenholme-theorem-oq-01/meta.json
+++ b/src/data/proofs/wolstenholme-theorem-oq-01/meta.json
@@ -62,7 +62,7 @@
       "Axiom elimination: cb_16843 proved via choose_fast, reducing axiom count from 4 to 3"
     ],
     "dateAdded": "2026-03-28",
-    "assumptions": "3 axiom(s): cb_2124679 (binomial too large for native_decide in reasonable time), no_wp_below_billion (McIntosh-Roettger 2007 search), bernoulli_characterization (McIntosh 1995 equivalence). cb_16843 proved via choose_fast + native_decide. No sorries.",
+    "assumptions": "3 axiom(s): cb_2124679 (binomial too large for native_decide in reasonable time), no_wp_below_billion (McIntosh-Roettger 2007 search), bernoulli_characterization (McIntosh 1995 equivalence). Additionally, native_decide (relying on the Lean.ofReduceBool compiled-evaluation trust axiom) is used in 8 places across 6 named theorems: prime_16843 and prime_2124679 (primality), cb_16843 (the mod p⁴ congruence, via choose_fast), wp_ge_five (refuting IsWP 2 and IsWP 3), and isWieferich_1093 / isWieferich_3511 (the two Wieferich witnesses). Consequently the headline results isWP_16843 and at_least_two_wp depend on Lean.ofReduceBool; #print axioms lists it. No sorries.",
     "prerequisites": [
       "Binomial coefficients and Wolstenholme's theorem",
       "Bernoulli numbers and irregular primes",


### PR DESCRIPTION
## Summary

Metadata-only fix for the LOW integrity issue in #41310. The `assumptions` field of `wolstenholme-theorem-oq-01` attributed `native_decide` (and its `Lean.ofReduceBool` trust axiom) to a single lemma (`cb_16843`), but the file uses `native_decide` in 8 places across 6 named theorems, so the trust base for the headline results was under-disclosed.

## Evidence

`grep -n native_decide proofs/Proofs/WolstenholmeTheoremOQ01.lean` (excluding the docstring at line 35):

- L72 `prime_16843`, L75 `prime_2124679` — primality
- L80 `cb_16843` — mod p⁴ congruence (already disclosed)
- L147–148 `wp_ge_five` — refuting `IsWP 2` / `IsWP 3`
- L235 `isWieferich_1093`, L239 `isWieferich_3511` — Wieferich witnesses

Consequently `isWP_16843` and `at_least_two_wp` depend on `Lean.ofReduceBool` via both `prime_16843` and `cb_16843`.

## Change

Expanded the `assumptions` string to disclose the full native_decide / ofReduceBool scope. The 3 mathematical axioms, `status: axiomatized`, and `badge: axiom` are already correct and unchanged (this is an accounting/disclosure fix only). The minor `theoremCount` 24 vs 25 undercount is left for the next enrichment pass (safe undercount).

Closes #41310
