### PR TITLE
Fix: dirichlets-theorem-oq-02-oq-01 description overstates unformalized GRH consequences

### DIFF
--- a/proofs/Proofs/DirichletsTheoremOQ02OQ01.lean
+++ b/proofs/Proofs/DirichletsTheoremOQ02OQ01.lean
@@ -31,7 +31,7 @@ We axiomatize GRH and prove its consequences rigorously.
 
 ## Status
 
-Axiomatized (GRH is an open conjecture). 0 sorry, 13 axiom.
+Axiomatized (GRH is an open conjecture). 0 sorry, 4 axioms.
 -/
 
 import Mathlib.NumberTheory.LSeries.PrimesInAP

--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "dirichlets-theorem-oq-02-oq-01",
   "title": "Generalized Riemann Hypothesis for Dirichlet L-functions",
   "slug": "dirichlets-theorem-oq-02-oq-01",
-  "description": "The Generalized Riemann Hypothesis (GRH) asserts that all non-trivial zeros of Dirichlet L-functions L(s, χ) lie on the critical line Re(s) = 1/2. We formalize GRH, prove equivalences between formulations, and axiomatize its dramatic consequences: improved PNT for arithmetic progressions (error O(√x log x)), effective Linnik bound (least prime O(q² log² q)), elimination of Siegel zeros, and effective class number bounds.",
+  "description": "The Generalized Riemann Hypothesis (GRH) asserts that all non-trivial zeros of Dirichlet L-functions L(s, χ) lie on the critical line Re(s) = 1/2. We formalize GRH over Mathlib's Dirichlet L-functions, prove the GRH ↔ right-half-plane-zero-free equivalence via an axiomatized functional symmetry, and derive Siegel-zero elimination and an effective L(1, χ) positivity bound (from an axiomatized effective lower bound). Sublinearity facts (√x·log x < x; q²·log²q < q⁵) motivate the improved PNT-for-AP and Linnik exponents, but the prime-counting error term, least-prime bound, and class-number consequences are not themselves formalized.",
   "meta": {
     "author": "Open (Riemann 1859 for ζ; Piltz 1884 for L-functions; Montgomery-Vaughan for character sums)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Generalized_Riemann_hypothesis",


### PR DESCRIPTION
## Problem (#41304)

The gallery `description` for `dirichlets-theorem-oq-02-oq-01` claimed the entry "axiomatize[s] its dramatic consequences: improved PNT for arithmetic progressions (error O(√x log x)), effective Linnik bound (least prime O(q² log² q)), elimination of Siegel zeros, and effective class number bounds." Only some of these are actually formalized; the PNT-for-AP error term, least-prime bound, and class-number consequences are not. The Lean docstring also carried a stale "13 axiom" count.

## Fix (prose/metadata only)

**meta.json `description`** — rewritten to state exactly what is formalized:
- GRH ↔ right-half-plane-zero-free equivalence (`GRH_iff_right_half`) via an axiomatized functional symmetry (`L_function_functional_symmetry`)
- Siegel-zero elimination (`GRH_no_siegel_zeros`)
- effective L(1, χ) positivity bound (`GRH_L_one_pos`) from an axiomatized effective lower bound (`GRH_effective_L_one_bound`)
- notes that the sublinearity facts only *motivate* the PNT-AP/Linnik exponents; the error term, least-prime bound, and class-number consequences are **not** themselves formalized.

**Lean docstring** — `0 sorry, 13 axiom.` → `0 sorry, 4 axioms.` (file has exactly 4 `axiom` declarations; `meta.axiomCount` already reads 4).

No code/definition changes; comment- and JSON-only. `axiomCount` and `status: axiomatized` are unchanged and already correct.

Closes #41304
