### PR TITLE
Enrich erdos-830/erdos-873: disclose native_decide (ofReduceBool), fix false 'axiomatizes' prose

### DIFF
--- a/src/data/proofs/erdos-830/meta.json
+++ b/src/data/proofs/erdos-830/meta.json
@@ -42,10 +42,10 @@
     "originalContributions": [
       "Formal definition of amicable pairs using Mathlib's sigma function",
       "Machine-verified examples: (220,284), (1184,1210), (2620,2924)",
-      "Formal statements of Erdős and Pomerance upper bounds",
+      "Documentation of the Erdős and Pomerance upper bounds (recorded in source comments; not yet formalized as Lean statements)",
       "Counting function A(x) formalization"
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 142,
     "dateAdded": "2025-12-22",
     "prerequisites": [
@@ -55,11 +55,8 @@
       "Asymptotic density of number-theoretic sets"
     ],
     "assumptions": [
-      "infinitely_many_amicable_pairs: There exist infinitely many amicable pairs (OPEN)",
-      "amicable_lower_bound: A(x) > x^{1-o(1)} (OPEN)",
-      "erdos_amicable_bound: A(x) = o(x) (Erdős 1955)",
-      "pomerance_1981: A(x) ≤ x·exp(-(log x)^{1/3}) (Pomerance 1981)",
-      "pomerance_2015: A(x) ≤ x·exp(-(1/2+o(1))√(log x · log log x)) (Pomerance 2015)"
+      "Lean.ofReduceBool — the six divisor-sum equalities (sigma_220, sigma_284, sigma_1184, sigma_1210, sigma_2620, sigma_2924, from which the amicable-pair theorems follow) are discharged by `native_decide`, which trusts the Lean compiler's kernel evaluation of the `Decidable` instance rather than producing a checked proof term. This compiler-trust footprint is the only assumption the formalization introduces (there are no `axiom` declarations in the source).",
+      "The two open questions (infinitely many amicable pairs; A(x) > x^{1-o(1)}) and the known upper bounds (Erdős 1955: A(x) = o(x); Pomerance 1981: A(x) ≤ x·exp(-(log x)^{1/3}); Pomerance 2015: A(x) ≤ x·exp(-(1/2+o(1))√(log x · log log x))) are documented in the source as background context — they are NOT formalized as Lean axioms or theorems."
     ],
     "theoremCount": 9,
     "definitionCount": 3
@@ -68,7 +65,7 @@
     "historicalContext": "Amicable numbers have fascinated mathematicians since antiquity. The pair (220, 284) was known to the Pythagoreans and appears in Arabic and medieval European mathematical texts. The definition is elegant: two numbers are amicable if each equals the sum of the proper divisors (all divisors except the number itself) of the other.\n\nFor 220: proper divisors are 1, 2, 4, 5, 10, 11, 20, 22, 44, 55, 110, which sum to 284.\nFor 284: proper divisors are 1, 2, 4, 71, 142, which sum to 220.\n\nWhile thousands of amicable pairs are now known (discovered computationally), whether infinitely many exist remains one of the oldest unsolved problems in number theory. Erdős established the first non-trivial upper bound A(x) = o(x) in 1955, and Carl Pomerance made major improvements in 1981 and 2015.",
     "problemStatement": "Two natural numbers $a$ and $b$ are **amicable** if $\\sigma(a) = \\sigma(b) = a + b$, where $\\sigma(n)$ is the sum of all divisors of $n$.\n\n**Open Questions**:\n1. Are there infinitely many amicable pairs?\n2. If $A(x)$ counts amicable pairs with $1 \\leq a \\leq b \\leq x$, is $A(x) > x^{1-o(1)}$?\n\n**Known Upper Bounds** (SOLVED):\n- Erdős (1955): $A(x) = o(x)$\n- Pomerance (1981): $A(x) \\leq x \\cdot \\exp(-(\\log x)^{1/3})$\n- Pomerance (2015): $A(x) \\leq x \\cdot \\exp(-(\\frac{1}{2}+o(1))\\sqrt{\\log x \\cdot \\log\\log x})$",
     "text": "Are there infinitely many amicable pairs? Two numbers are amicable if each is the sum of the other's proper divisors, like 220 and 284.",
-    "proofStrategy": "Since the main questions are open, we cannot prove them. Our formalization:\n\n1. **Defines amicable pairs** using Mathlib's `ArithmeticFunction.sigma` for the sum of divisors\n2. **Verifies concrete examples** (220,284), (1184,1210), (2620,2924) using `native_decide`\n3. **Defines the counting function** A(x) formally\n4. **States the open conjectures** as axioms\n5. **Records proven upper bounds** (Erdős 1955, Pomerance 1981, 2015) as axioms pending full formalization",
+    "proofStrategy": "Since the main questions are open, we cannot prove them. Our formalization:\n\n1. **Defines amicable pairs** using Mathlib's `ArithmeticFunction.sigma` for the sum of divisors\n2. **Verifies concrete examples** (220,284), (1184,1210), (2620,2924) using `native_decide`\n3. **Defines the counting function** A(x) formally\n4. **Documents the open conjectures** in the source (as commentary — not formalized as axioms or theorems)\n5. **Records the proven upper bounds** (Erdős 1955, Pomerance 1981, 2015) in the source commentary, pending full formalization\n\nThe concrete divisor-sum checks in step 2 use `native_decide`, so the verified theorems carry the `Lean.ofReduceBool` compiler-trust axiom.",
     "keyInsights": [
       "**Sum of Divisors**: σ(n) = Σ_{d|n} d. For amicable (a,b): σ(a) = σ(b) = a+b, which means the 'excess' of each (σ(n)-n) equals the other number.",
       "**Ancient History**: The (220, 284) pair was known to Pythagoras (~500 BCE). The next pair (1184, 1210) wasn't found until 1866, by a 16-year-old Nicolo Paganini.",
@@ -113,7 +110,7 @@
       "title": "Open Questions",
       "startLine": 74,
       "endLine": 101,
-      "summary": "Axiomatizes the two main open conjectures: (1) infinitely many amicable pairs exist, (2) A(x) > x^{1-o(1)}.",
+      "summary": "Documents the two main open conjectures in source commentary: (1) infinitely many amicable pairs exist, (2) A(x) > x^{1-o(1)}. These are stated as context, not formalized as axioms or theorems.",
       "mathContext": "Conjecture 1: $|\\{(a,b) : \\text{IsAmicable}(a,b)\\}| = \\infty$. Conjecture 2: $\\forall \\varepsilon > 0,\\, A(x) \\geq x^{1-\\varepsilon}$ eventually."
     },
     {

--- a/src/data/proofs/erdos-873/meta.json
+++ b/src/data/proofs/erdos-873/meta.json
@@ -41,15 +41,15 @@
     ],
     "originalContributions": [
       "Definition of consecutive LCM counting function F(A,X,k)",
-      "Formal statement of the open conjecture",
-      "Axioms for Erdős-Szemerédi bounds on F(A,X,3)",
+      "Formal statement of the open conjecture as a `Prop` (`lcmConjecture`)",
+      "Documentation of the Erdős-Szemerédi bounds on F(A,X,3) (recorded in source comments; not formalized as axioms or theorems)",
       "Verified examples for natural and exponential sequences"
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 148,
     "assumptions": [
-      "erdos_szemeredi_upper: F(A,X,3) ≪ X^{1/3} log X for all strictly increasing A — Erdős-Szemerédi (1992)",
-      "erdos_szemeredi_lower: There exists A with F(A,X,3) ≫ X^{1/3} log X infinitely often — Erdős-Szemerédi (1992)"
+      "Lean.ofReduceBool — the named theorem `consecutiveLcm_powers_of_two` is discharged with `native_decide` in its base cases, which trusts the Lean compiler's kernel evaluation rather than producing a checked proof term. This compiler-trust footprint is the only assumption the formalization introduces (there are no `axiom` declarations in the source).",
+      "The Erdős-Szemerédi (1992) bounds for k=3 (upper F(A,X,3) ≪ X^{1/3} log X for all strictly increasing A; matching lower bound ≫ X^{1/3} log X infinitely often) are documented in the source as background context — they are NOT formalized as Lean axioms or theorems."
     ],
     "dateAdded": "2025-12-22",
     "prerequisites": [
@@ -65,7 +65,7 @@
     "historicalContext": "This problem was posed by Erdős and Szemerédi in their work on multiplicative properties of sequences. It asks about the fundamental question: how many consecutive terms of a sequence can have 'small' LCM?\n\nThe LCM of consecutive terms measures their multiplicative dependence. If terms share many prime factors, their LCM is relatively small. The question is whether, for any sequence, we can always find a window size k such that few k-tuples have LCM below any threshold X^ε.\n\nErdős and Szemerédi proved tight bounds for k=3: F(A,X,3) grows like X^(1/3) log X in the worst case. The general conjecture asks whether the exponent can be made arbitrarily small by increasing k.",
     "problemStatement": "**Conjecture (Erdős-Szemerédi)**: Let $A = \\{a_1 < a_2 < \\cdots\\} \\subseteq \\mathbb{N}$ and let $F(A,X,k)$ count positions $i$ where $[a_i, a_{i+1}, \\ldots, a_{i+k-1}] < X$ (LCM of $k$ consecutive terms).\n\nFor every $\\varepsilon > 0$, does there exist $k$ such that $F(A,X,k) < X^\\varepsilon$?\n\n**Status**: OPEN\n\n**Known**: For $k=3$, we have $F(A,X,3) \\ll X^{1/3} \\log X$ for all $A$, and this is tight.",
     "text": "Can the count of k-tuples with small LCM be made subpolynomial by choosing k large enough? An open problem of Erdős and Szemerédi on multiplicative structure of sequences.",
-    "proofStrategy": "We formalize the conjecture and known results:\n\n1. **Counting Function**: Define consecutiveLcm(a,i,k) as the LCM of k terms starting at position i, and F(a,X,k) as the count of positions where this LCM is less than X.\n\n2. **Monotonicity**: Prove that F decreases as k increases (more terms means larger LCM, so fewer qualify).\n\n3. **Conjecture Statement**: State the open problem asking whether F can always be made subpolynomial in X.\n\n4. **Known Bounds**: State the Erdős-Szemerédi theorem for k=3 as axioms.\n\n5. **Examples**: Verify behavior for specific sequences (naturals, powers of 2).",
+    "proofStrategy": "We formalize the conjecture and known results:\n\n1. **Counting Function**: Define consecutiveLcm(a,i,k) as the LCM of k terms starting at position i, and F(a,X,k) as the count of positions where this LCM is less than X.\n\n2. **Monotonicity**: Prove that F decreases as k increases (more terms means larger LCM, so fewer qualify).\n\n3. **Conjecture Statement**: State the open problem asking whether F can always be made subpolynomial in X.\n\n4. **Known Bounds**: Document the Erdős-Szemerédi theorem for k=3 in source commentary (not formalized as axioms or theorems).\n\n5. **Examples**: Verify behavior for specific sequences (naturals, powers of 2). The powers-of-2 theorem uses `native_decide`, so it carries the `Lean.ofReduceBool` compiler-trust axiom.",
     "keyInsights": [
       "**Multiplicative dependence**: The LCM measures how much consecutive terms share prime factors. Small LCM means high dependence.",
       "**Window size tradeoff**: Larger k means the LCM includes more terms, so it grows faster and F(A,X,k) shrinks.",
@@ -118,7 +118,7 @@
       "title": "Known Results",
       "startLine": 96,
       "endLine": 117,
-      "summary": "Axiomatizes Erdős-Szemerédi bounds for $k=3$: upper bound $F(A,X,3) \\ll X^{1/3} \\log X$ and matching lower bound showing tightness.",
+      "summary": "Documents the Erdős-Szemerédi bounds for $k=3$ in source commentary (not formalized): upper bound $F(A,X,3) \\ll X^{1/3} \\log X$ and matching lower bound showing tightness.",
       "mathContext": "$F(A,X,3) \\ll X^{1/3} \\log X$ for all $A$, and $\\exists A$ with $F(A,X,3) \\gg X^{1/3} \\log X$ infinitely often. The exponent $1/3$ is optimal for $k = 3$."
     },
     {


### PR DESCRIPTION
## Enrichment: axiom-integrity accuracy for erdos-830 and erdos-873

Both entries had `meta.axiomCount: 0` while their Lean files discharge **named theorems** with `native_decide` (→ `Lean.ofReduceBool`, not axiom-free), and several prose fields falsely claimed the open conjectures / known bounds were "stated as axioms" / "Axiomatizes" — but the source files contain **zero `axiom` declarations** (verified: `grep -c '^axiom '` = 0 for both).

### erdos-830 (Amicable Pairs)
- 6 substantive `native_decide` theorems: `sigma_220`, `sigma_284`, `sigma_1184`, `sigma_1210`, `sigma_2620`, `sigma_2924` (the amicable-pair verifications that are the entry's content).
- The infinitude/lower-bound conjectures and the Erdős/Pomerance upper bounds appear only in `/- -/` documentation comments.

### erdos-873 (LCM of Consecutive Sequence Terms)
- Named theorem `consecutiveLcm_powers_of_two` uses `native_decide` in its base cases. (The 3 other `native_decide` sites are `example` blocks — benign, not counted.)
- The Erdős–Szemerédi k=3 bounds appear only in comments (the comment literally says "We state this as an axiom" but no axiom is declared).

### Fixes (prose + count accuracy only — no Lean source change)
- `meta.axiomCount` 0 → 1 (reflects `Lean.ofReduceBool`); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations — policy-consistent).
- `assumptions` rewritten to disclose the `native_decide`/`ofReduceBool` compiler-trust footprint and to reframe the cited literature results as documented-not-formalized.
- `proofStrategy`, affected `sections[].summary`, and `originalContributions` no longer claim the conjectures/bounds are "as axioms" / "Axiomatizes".

`status` stays `axiomatized`, `badge` stays `wip`. Aligns with the native_decide disclosure pattern of #41293 / #41299 / #41306 / #41309 and the CLAUDE.md Axiom Integrity `native_decide` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
