### PR TITLE
Research: szemeredi-regularity-oq-04 — density gap forbids a doubly-trivial split (0-axiom)

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04SplitProper.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04SplitProper.lean
@@ -1,0 +1,95 @@
+/-
+  Szemerédi Regularity Lemma — OQ-04: the density gap forces a *nontrivial* split.
+
+  `MassFloor.lean` (S14) shrank the item-1 dichotomy's constructive obligation to
+  the two nonemptiness facts the mass floors do NOT reach — the complement pieces
+  `A₂ = A ∖ A₁`, `B₂ = B ∖ B₁` of the sharp `2×2` split.  The mass floors
+  `eps·|A| ≤ |A₁|` pin the *deviating corner* `A₁, B₁` from below but say nothing
+  about whether `A₁` exhausts `A` (`A₂ = ∅`).  State (S14):
+
+    "A₂, B₂ nonemptiness is the properness content `A₁ ⊊ A` … which the flat mass
+     floor alone does not see."
+
+  This file supplies what the *analytic* data — the `eps`-density gap — genuinely
+  does force: the split cannot be **doubly** trivial.  If both complement pieces
+  were empty then `A₁ = A` and `B₁ = B`, so the deviating corner `(A₁, B₁)` would
+  coincide with the parent pair `(A, B)` and its density deviation
+  `|d(A₁,B₁) − d(A,B)|` would be `0` — contradicting the `eps`-gap for `eps > 0`.
+
+  * `gap_forces_complement_nonempty` — split shape + `0 < eps` + the `eps`-gap ⟹
+    `A₂.Nonempty ∨ B₂.Nonempty`.  Purely elementary: a `by_contra` collapses both
+    empties into `A₁ = A`, `B₁ = B`, and the gap becomes `eps ≤ 0`.
+
+  * `exists_sharp_split_nontrivial_of_not_afksFineRegular` — reruns
+    `exists_sharp_split_of_not_afksFineRegular` (Dichotomy, S11) and appends the
+    disjunction, so the extracted sharp split is certified to split at least one
+    parent block properly whenever the fine tolerance `E` is positive.
+
+  What this leaves: the *symmetric* both-pieces-nonempty demand of
+  `isWitnessedSharpStep_of_split_of_gap` is genuinely NOT met by the analytic data
+  — when one corner exhausts its block (say `A₁ = A`) the honest refinement is the
+  asymmetric 3-piece split `{A, B₁, B₂}`, not the 4-piece `{A₁, A₂, B₁, B₂}`.
+  Certifying that degenerate branch needs an asymmetric witnessed-step packaging,
+  not a further nonemptiness lemma.  This lemma pins the residual to exactly that
+  one degenerate side.
+
+  0 axioms, 0 sorries.
+
+  Reference: Alon–Fischer–Krivelevich–Szegedy, "Efficient testing of large graphs",
+  Combinatorica 20 (2000).
+-/
+import Mathlib
+import Proofs.SzemerediRegularityOQ04Dichotomy
+
+namespace Szemeredi.RegularityOQ04SplitProper
+
+open Classical Szemeredi.Core Szemeredi.RegularityOQ04Dichotomy
+  Szemeredi.RegularityOQ04ToleranceBridge
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- **The density gap forbids a doubly-trivial split.**  Given a disjoint `2×2`
+    split `A₁ ∪ A₂ = A`, `B₁ ∪ B₂ = B` whose deviating corner `(A₁, B₁)` differs
+    in density from the parent pair `(A, B)` by at least `eps > 0`, at least one
+    complement piece is nonempty: `A₂.Nonempty ∨ B₂.Nonempty`.
+
+    If both were empty then `A₁ = A` and `B₁ = B`, so
+    `edgeDensity G A₁ B₁ = edgeDensity G A B` and the gap `eps ≤ 0` — impossible. -/
+theorem gap_forces_complement_nonempty
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    {A B A₁ A₂ B₁ B₂ : Finset V} {eps : ℚ}
+    (hsplitA : A₁ ∪ A₂ = A) (hsplitB : B₁ ∪ B₂ = B)
+    (heps : 0 < eps)
+    (hgap : eps ≤ |edgeDensity G A₁ B₁ - edgeDensity G A B|) :
+    A₂.Nonempty ∨ B₂.Nonempty := by
+  by_contra h
+  push_neg at h
+  obtain ⟨hA2e, hB2e⟩ := h
+  have hAeq : A₁ = A := by rw [← hsplitA, hA2e, Finset.union_empty]
+  have hBeq : B₁ = B := by rw [← hsplitB, hB2e, Finset.union_empty]
+  rw [hAeq, hBeq, sub_self, abs_zero] at hgap
+  exact absurd hgap (not_le.mpr heps)
+
+/-- **Extracted sharp split splits at least one block properly.**  The S11
+    `exists_sharp_split_of_not_afksFineRegular` witness, augmented (for `0 < E`)
+    with `A₂.Nonempty ∨ B₂.Nonempty` via `gap_forces_complement_nonempty`.  So a
+    fine partition failing AFKS-fine-regularity yields a sharp `2×2` split in which
+    the deviating corner does not exhaust *both* parent blocks. -/
+theorem exists_sharp_split_nontrivial_of_not_afksFineRegular
+    (G : SimpleGraph V) [DecidableRel G.Adj] (ε E : ℚ) (hε : 0 ≤ ε) (hE : 0 < E)
+    (parts : Finset (Finset V))
+    (hequit : ∀ P Q : Finset V, P ∈ parts → Q ∈ parts → (P.card : ℤ) - Q.card ≤ 1)
+    (hnot : ¬ IsAFKSFineRegular G ε E parts) :
+    ∃ A B A₁ A₂ B₁ B₂ : Finset V,
+      A ∈ parts ∧ B ∈ parts ∧ A ≠ B ∧
+      A₁ ∪ A₂ = A ∧ B₁ ∪ B₂ = B ∧ Disjoint A₁ A₂ ∧ Disjoint B₁ B₂ ∧
+      E * A.card ≤ (A₁.card : ℚ) ∧ E * B.card ≤ (B₁.card : ℚ) ∧
+      E ≤ |edgeDensity G A₁ B₁ - edgeDensity G A B| ∧
+      (A₂.Nonempty ∨ B₂.Nonempty) := by
+  obtain ⟨A, B, A₁, A₂, B₁, B₂, hA, hB, hAB, hsA, hsB, hdA, hdB,
+    hmA, hmB, hgap⟩ :=
+    exists_sharp_split_of_not_afksFineRegular G ε E hε parts hequit hnot
+  exact ⟨A, B, A₁, A₂, B₁, B₂, hA, hB, hAB, hsA, hsB, hdA, hdB, hmA, hmB, hgap,
+    gap_forces_complement_nonempty G hsA hsB hE hgap⟩
+
+end Szemeredi.RegularityOQ04SplitProper

--- a/research/problems/szemeredi-regularity-oq-04/state.md
+++ b/research/problems/szemeredi-regularity-oq-04/state.md
@@ -6,6 +6,30 @@
 **Since**: 2026-07-08T19:18:01-07:00
 **Iteration**: 3
 
+## Status (S16, researcher-1, 2026-07-22) — DENSITY GAP forbids a doubly-trivial split
+
+New file `SzemerediRegularityOQ04SplitProper.lean` (2 thm, 0 ax, 0 sorry, docker-VERIFIED,
+8581 jobs; `#print axioms = [propext, Classical.choice, Quot.sound]` on both). Supplies the
+piece of the S14 residual that the *analytic* data genuinely does force: the sharp split
+cannot be **doubly** trivial. S14/S15 derived the deviating-corner nonemptiness (`A₁, B₁`)
+from the mass floors but left the complement pieces `A₂ = A∖A₁`, `B₂ = B∖B₁` uncontrolled —
+the properness content `A₁ ⊊ A` the flat mass floor does not see.
+
+- `gap_forces_complement_nonempty` — from the disjoint `2×2` split shape (`A₁∪A₂=A`,
+  `B₁∪B₂=B`), `0 < eps`, and the `eps`-density gap `eps ≤ |d(A₁,B₁) − d(A,B)|`, derive
+  `A₂.Nonempty ∨ B₂.Nonempty`. Elementary `by_contra`: both empties collapse to `A₁ = A`,
+  `B₁ = B`, so `d(A₁,B₁) = d(A,B)` and the gap becomes `eps ≤ 0`, contradicting `eps > 0`.
+- `exists_sharp_split_nontrivial_of_not_afksFineRegular` — reruns S11's
+  `exists_sharp_split_of_not_afksFineRegular` and appends the disjunction (for `0 < E`), so
+  the extracted sharp split is certified to split at least one parent block properly.
+
+**What this leaves:** the *symmetric* both-pieces-nonempty demand of
+`isWitnessedSharpStep_of_split_of_gap` (S14) is genuinely NOT met by the analytic data — when
+one corner exhausts its block (e.g. `A₁ = A`, `A₂ = ∅`) the honest refinement is the
+asymmetric **3-piece** split `{A, B₁, B₂}`, not the 4-piece `{A₁, A₂, B₁, B₂}`. Certifying
+that degenerate branch needs an asymmetric witnessed-step packaging (a new predicate), not a
+further nonemptiness lemma. The residual is now pinned to exactly that one degenerate side.
+
 ## Status (S14, researcher-1, 2026-07-22) — A₁/B₁ PIECE-NONEMPTINESS derived from mass floors
 
 New file `SzemerediRegularityOQ04MassFloor.lean` (2 thm, 0 ax, 0 sorry, docker-VERIFIED,

--- a/src/data/research/problems/szemeredi-regularity-oq-04.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-04.json
@@ -26,8 +26,9 @@
     "nextAction": "Reconstruct the energy-increment step (epsilon-irregular refinement raises partitionEnergy by >= delta) from split_energy_excess_bound, then assemble the outer AFKS loop using partitionEnergy_no_infinite_increments as termination certificate."
   },
   "knowledge": {
-    "progressSummary": "AFKS strong regularity lemma: energy-increment (item 1) + two-level packaging (item 2) + outer-loop assembly modulo dichotomy (item 3, Outer) all DONE; S11 closed the dichotomy analytic core (sharp 2×2 split exists); S12 (isWitnessedSharpStep_of_split) discharges the reusable chain/freshness bookkeeping, reducing the residual to a purely constructive obligation: exhibit the refinement chain with the four new blocks pairwise distinct and ∉R. Remaining genuine crux = the recursive chain construction + its flat freshness (degenerate empty-piece collisions).",
+    "progressSummary": "AFKS strong regularity lemma: energy-increment (item 1) + two-level packaging (item 2) + outer-loop assembly modulo dichotomy (item 3, Outer) all DONE; S11 closed the analytic realizability core; S12-S15 discharged chain/freshness bookkeeping and derived the deviating-corner (A1,B1) nonemptiness from the mass floors. S16: the density gap forbids a DOUBLY-trivial split (A2 or B2 nonempty). Residual is pinned to the single degenerate side (one corner exhausts its block -> asymmetric 3-piece refinement).",
     "builtItems": [
+      "gap_forces_complement_nonempty in SzemerediRegularityOQ04SplitProper.lean (S16) — the eps-density gap |d(A1,B1)-d(A,B)| >= eps > 0 forbids a doubly-trivial split: A2.Nonempty OR B2.Nonempty (both empty would force A1=A,B1=B, gap=0). exists_sharp_split_nontrivial_of_not_afksFineRegular appends this disjunction to the S11 extracted sharp split.",
       "edgeDensity_union_mul in SzemerediRegularityOQ04Energy.lean — weighted-average identity |A1cupA2||B|d = |A1||B|d1+|A2||B|d2 for disjoint A-split (reusable public API; previously trapped inside density_sq_convex proof).",
       "pairEnergy def + pairEnergy_split_mono — one-sided refinement never decreases the normalized pair energy (|A||B|/n^2)d^2; transports density_sq_convex to partitionEnergy units.",
       "pairEnergy_split_gain — quantitative energy increment: |d1-d2|>=delta gives gain >= (|A1||A2|/(|A1|+|A2|))(|B|/n^2)delta^2 (the AFKS Cauchy-Schwarz boost).",
@@ -89,6 +90,7 @@
       "isWitnessedSharpStep_of_split_of_nonempty in SzemerediRegularityOQ04Freshness.lean: freshness-free packaging — full IsWitnessedSharpStep from split data + mass floors + gap + nonemptiness of the four pieces. 0-axiom, docker-VERIFIED."
     ],
     "insights": [
+      "The complement pieces A2=A\\A1, B2=B\\B1 of the AFKS sharp 2x2 split are NOT both forced nonempty by the analytic data: the density gap only forbids BOTH being empty (S16). When one corner exhausts its block (A1=A) the honest refinement is the asymmetric 3-piece split {A,B1,B2}; the 4-piece IsWitnessedSharpStep shape (S14 isWitnessedSharpStep_of_split_of_gap) requires an asymmetric-step packaging for that degenerate branch, not a further nonemptiness lemma.",
       "partitionEnergy IS the standard size-weighted energy |Pi||Pj|/n^2 d^2 (SzemerediCore:63), NOT 1/k^2. The abandoned energy_increment_step note in SzemerediRegularity (lines 212-219) rests on a false premise; refinement monotonicity is genuine and now proven per-pair.",
       "The weighted-average d(A1cupA2,B)=(|A1|d1+|A2|d2)/(|A1|+|A2|) plus split_energy_identity/excess_bound give the increment purely; scaling by |B|/n^2>=0 lifts density_sq_convex into the normalized energy.",
       "The whole-partition energy JUMP reduces to a SINGLE strengthened block: only the row block against R needs the gain; diagonal and column blocks contribute nonneg increments by monotonicity, so linarith[h1,h2gain,h3] assembles exactly as the mono proof plus the gain atom.",
@@ -125,6 +127,7 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
+      "Handle the ONE degenerate side left by S16: define an asymmetric 3-piece witnessed-step predicate (IsWitnessedSharpStep3) for when A1=A (only B splits), and case-split the dichotomy on gap_forces_complement_nonempty. Likely elementary-layer saturated for the symmetric 4-piece shape.",
       "Package the sharp split into the exact IsWitnessedSharpStep chain shape (parts n = insert A (insert B R); parts(n+1)=insert A₁ (insert A₂ (insert B₁ (insert B₂ R)))) with fresh-block side-conditions — this needs a recursively CONSTRUCTED refinement chain, not an arbitrary given one, so exists_afksTwoLevel_of_dichotomy may need reformulating to build parts internally.",
       "Discharge freshness: A₁,A₂,B₁,B₂ ∉ each other / R via card or membership disjointness of the split pieces."
     ],
@@ -326,6 +329,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediRegularityOQ04PartitionGain.lean"
+    },
+    {
+      "path": "Proofs/SzemerediRegularityOQ04SplitProper.lean",
+      "filename": "SzemerediRegularityOQ04SplitProper.lean",
+      "lineCount": 95,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediRegularityOQ04SplitProper.lean"
     }
   ],
   "lastUpdate": "2026-07-12"


### PR DESCRIPTION
## szemeredi-regularity-oq-04 — density gap forbids a doubly-trivial split

New file `SzemerediRegularityOQ04SplitProper.lean` (2 theorems, **0 axioms, 0 sorries**, docker-verified, 8581 jobs; `#print axioms = [propext, Classical.choice, Quot.sound]` on both).

### Context
The AFKS strong-regularity tower's item-1 dichotomy was reduced (S14, `MassFloor.lean`) to two nonemptiness facts the mass floors do **not** reach: the complement pieces `A₂ = A∖A₁`, `B₂ = B∖B₁` of the sharp `2×2` split. The mass floors `eps·|A| ≤ |A₁|` pin the *deviating corner* `A₁, B₁` from below but say nothing about whether `A₁` exhausts `A`.

### What this adds
- **`gap_forces_complement_nonempty`** — the analytic data genuinely forbids a *doubly*-trivial split. From the disjoint `2×2` split shape (`A₁∪A₂=A`, `B₁∪B₂=B`), `0 < eps`, and the `eps`-density gap `eps ≤ |d(A₁,B₁) − d(A,B)|`, derive `A₂.Nonempty ∨ B₂.Nonempty`. Elementary `by_contra`: both empties collapse to `A₁ = A`, `B₁ = B`, so `d(A₁,B₁) = d(A,B)` and the gap becomes `eps ≤ 0`, contradicting `eps > 0`.
- **`exists_sharp_split_nontrivial_of_not_afksFineRegular`** — reruns S11's `exists_sharp_split_of_not_afksFineRegular` and appends the disjunction (for `0 < E`), certifying the extracted sharp split splits at least one parent block properly.

### What this leaves (honest)
The *symmetric* both-pieces-nonempty demand of `isWitnessedSharpStep_of_split_of_gap` (S14) is **not** met by the analytic data. When one corner exhausts its block (e.g. `A₁ = A`, `A₂ = ∅`), the honest refinement is the asymmetric **3-piece** split `{A, B₁, B₂}`, not the 4-piece `{A₁, A₂, B₁, B₂}`. Certifying that degenerate branch needs an asymmetric witnessed-step packaging (a new predicate), not a further nonemptiness lemma. The residual is now pinned to exactly that one degenerate side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
