### PR TITLE
audit: cantor-diagonalization-oq-04 clean (reserve re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4172,9 +4172,9 @@
       "issues": []
     },
     "cantor-diagonalization-oq-04": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:19Z",
+      "lastAudited": "2026-07-22T11:02:20Z",
       "result": "clean"
     },
     "cantor-diagonalization-oq-04-oq-01": {


### PR DESCRIPTION
Reserve re-audit of cantor-diagonalization-oq-04 (Lawvere fixed-point, retraction version). Verified: 14 theorems, 3 defs + 1 structure, 0 axioms, 0 sorries, 0 native_decide, 307 lines — all match meta.json. Badge `mathlib` appropriate; Classical choice disclosed in prose. No overclaim. Tracker updated to clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)