### PR TITLE
Research: erdos-117-wip-01 — monotonicity of the covering number h(n) (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos117WIP01Mono.lean
+++ b/proofs/Proofs/Erdos117WIP01Mono.lean
@@ -1,0 +1,92 @@
+/-
+  Erdős Problem #117 — Covering Groups by Abelian Subgroups: monotonicity of h(n).
+
+  Companion to `Erdos117Problem.lean` / `Erdos117WIP01.lean`.  The parent defines
+  `h(n) = abelianCoverNumber n = sInf {k | every finite group with the n-commuting
+  property is covered by k abelian subgroups}` and states Pyber's exponential
+  bounds `c₁ⁿ < h(n) < c₂ⁿ` only in prose.  `Erdos117WIP01.lean` pins the base
+  values `h(0) = 0`, `h(1) = 1` and the closure theory of the property.
+
+  This file adds the elementary **structural monotonicity** of `h` in `n`.  The
+  `n`-commuting property is *weaker* for larger `n` (`hasNCommutingProperty_mono`),
+  so the class of groups constrained by the covering condition *grows* with `n`.
+  Hence a fixed budget of `k` abelian subgroups that covers every group with the
+  `m`-property (`m ≥ n`) a fortiori covers every group with the `n`-property:
+  `CoversWithAbelian k m → CoversWithAbelian k n`.  Passing to the `sInf`, `h` is
+  monotone nondecreasing — **whenever the larger index admits a finite cover at
+  all** (the honest hypothesis, since the unconditional well-definedness of `h(m)`
+  is exactly Pyber's unformalized upper bound; with the `Nat.sInf ∅ = 0`
+  convention, an ill-defined `h(m) = 0` would otherwise defeat monotonicity).
+
+  Main results (all axiom-free — `#print axioms` = propext/Classical.choice/Quot.sound):
+
+  * `CoversWithAbelian k n`          : the membership condition of `abelianCoverNumber`'s
+                                       defining set, named for reuse.
+  * `abelianCoverNumber_eq_sInf`     : `h(n) = sInf {k | CoversWithAbelian k n}` (`rfl`).
+  * `coversWithAbelian_of_le`        : a cover for the `m`-property is a cover for the
+                                       `n`-property when `n ≤ m` (the crux — uses
+                                       `hasNCommutingProperty_mono`).
+  * `abelianCoverNumber_mono`        : `n ≤ m` and a finite `m`-cover exists ⟹
+                                       `h(n) ≤ h(m)`.
+
+  The open Erdős #117 (the exact exponential base) and Pyber's bounds are untouched.
+
+  0 axioms, 0 sorries.
+-/
+
+import Mathlib
+import Proofs.Erdos117Problem
+import Proofs.Erdos117WIP01
+
+/- The universe of the ambient groups.  `abelianCoverNumber` is
+   universe-polymorphic in this parameter (its body quantifies `∀ (G : Type*)`),
+   and — because the value is an `sInf` over the class of groups in that universe
+   — the statements below fix `u` explicitly so every occurrence lives in the
+   *same* universe.  (Mixing universes yields the `abelianCoverNumber.{u_1}` vs
+   `.{u_3}` application-type mismatch.) -/
+universe u
+
+/-- **The covering condition, named.**  `CoversWithAbelian k n` holds when `k`
+    abelian subgroups suffice to cover *every* finite group (in universe `u`) with
+    the `n`-commuting property.  This is exactly the membership predicate of the
+    set whose `sInf` defines `abelianCoverNumber.{u} n`. -/
+def CoversWithAbelian (k n : ℕ) : Prop :=
+  ∀ (G : Type u) [Group G] [Fintype G],
+    HasNCommutingProperty G n →
+    ∃ H : Fin k → Subgroup G,
+      (∀ i, IsAbelianSubgroup G (H i)) ∧ ∀ g : G, ∃ i, g ∈ H i
+
+/-- `abelianCoverNumber.{u} n` is the `sInf` of the `CoversWithAbelian.{u} · n`
+    set — definitionally, since `CoversWithAbelian k n` unfolds to the set's
+    condition at the same universe `u`. -/
+theorem abelianCoverNumber_eq_sInf (n : ℕ) :
+    abelianCoverNumber.{u} n = sInf {k | CoversWithAbelian.{u} k n} := rfl
+
+/-- **A cover for the harder (larger `n`) constraint covers the easier one.**
+    If `n ≤ m` and `k` abelian subgroups cover every finite group with the
+    `m`-commuting property, then they cover every finite group with the
+    `n`-commuting property: the `n`-property *implies* the `m`-property
+    (`hasNCommutingProperty_mono`), so any `n`-property group is already handled. -/
+theorem coversWithAbelian_of_le {k n m : ℕ} (hnm : n ≤ m)
+    (h : CoversWithAbelian.{u} k m) : CoversWithAbelian.{u} k n := by
+  intro G _ _ hn
+  exact h G (hasNCommutingProperty_mono hnm hn)
+
+/-- **Monotonicity of the covering number.**  For `n ≤ m`, if some finite budget
+    of abelian subgroups covers every group with the `m`-commuting property
+    (`∃ k, CoversWithAbelian k m` — the defining set is nonempty, i.e. `h(m)` is
+    genuinely well-defined rather than the `sInf ∅ = 0` fallback), then
+    `h(n) ≤ h(m)`.
+
+    Proof: the defining set for `m` is `⊆` that for `n` (`coversWithAbelian_of_le`);
+    `h(m)`, being its `sInf` and the set nonempty, is a member, hence a member of
+    the `n`-set, so `h(n) = sInf(n-set) ≤ h(m)`. -/
+theorem abelianCoverNumber_mono {n m : ℕ} (hnm : n ≤ m)
+    (hne : ∃ k, CoversWithAbelian.{u} k m) :
+    abelianCoverNumber.{u} n ≤ abelianCoverNumber.{u} m := by
+  have hsub : {k | CoversWithAbelian.{u} k m} ⊆ {k | CoversWithAbelian.{u} k n} :=
+    fun _ hk => coversWithAbelian_of_le hnm hk
+  have hneSet : {k | CoversWithAbelian.{u} k m}.Nonempty := hne
+  have hmem : abelianCoverNumber.{u} m ∈ {k | CoversWithAbelian.{u} k m} :=
+    Nat.sInf_mem hneSet
+  exact Nat.sInf_le (hsub hmem)

--- a/research/problems/erdos-117-wip-01/state.md
+++ b/research/problems/erdos-117-wip-01/state.md
@@ -1,13 +1,41 @@
 # Research State: erdos-117-wip-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
 **Since**: 2026-07-09T17:33:20-07:00
-**Iteration**: 1
+**Iteration**: 3
+
+## Status (researcher-1, 2026-07-22) — MONOTONICITY of the covering number h(n)
+
+New file `Erdos117WIP01Mono.lean` (1 def, 3 thm, 0 ax, 0 sorry, docker-VERIFIED, 8578 jobs;
+`#print axioms = [propext, Classical.choice, Quot.sound]`). Adds the elementary structural
+monotonicity of `h(n) = abelianCoverNumber n` in `n`, building on `Erdos117WIP01.lean`'s
+base values (`h(0)=0`, `h(1)=1`) and closure theory.
+
+- `CoversWithAbelian k n` — names the membership condition of `abelianCoverNumber`'s defining
+  set (`k` abelian subgroups cover every finite group with the `n`-commuting property).
+- `abelianCoverNumber_eq_sInf` — `h(n) = sInf {k | CoversWithAbelian k n}` (`rfl`).
+- `coversWithAbelian_of_le` — the crux: for `n ≤ m`, an `m`-cover is an `n`-cover (the
+  `n`-property *implies* the `m`-property via the parent's `hasNCommutingProperty_mono`).
+- `abelianCoverNumber_mono` — `n ≤ m` + a finite `m`-cover exists (`∃ k, CoversWithAbelian k m`)
+  ⟹ `h(n) ≤ h(m)`. The nonemptiness hypothesis is honest: unconditional monotonicity fails
+  under the `Nat.sInf ∅ = 0` convention when `h(m)` is ill-defined (Pyber's upper bound /
+  well-definedness is unformalized). Via `Nat.sInf_mem` + `Nat.sInf_le` on the set inclusion.
+
+**★GOTCHA (universe)**: `abelianCoverNumber` and `CoversWithAbelian` are universe-polymorphic
+in the group universe (bodies quantify `∀ (G : Type*)`); the value depends on `u`. Every
+occurrence must be pinned to a single explicit `universe u` with `.{u}` annotations, else
+Lean assigns independent universes → `abelianCoverNumber.{u_1}` vs `.{u_3}` /
+`@h G` application-type mismatches. Also: `/- -/` (not `/-- -/`) before a `universe` command.
+
+**STILL OPEN / out of scope**: Pyber's exponential bounds `c₁ⁿ < h(n) < c₂ⁿ` and the OPEN
+exact growth base stay unformalized; `h(n)` well-definedness for general `n` = the Pyber upper
+bound (nonemptiness of the `sInf` argument), NOT elementary.
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Elementary axiom-free scaffolding of the def-only parent stub (base values, closure, and now
+monotonicity of `h`). Deep Pyber bounds remain out of reach.
 
 ## Active Approach
 None yet.

--- a/src/data/research/problems/erdos-117-wip-01.json
+++ b/src/data/research/problems/erdos-117-wip-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-117-wip-01",
   "title": "Completing the Lean Formalization of Erdős #117 (Covering Groups by Abelian Subgroups)",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -31,8 +31,9 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: formalized the elementary/base-case facts the parent Erdos117Problem.lean left as prose — 3 axiom-free theorems in companion Erdos117WIP01.lean (Docker-verified v4.31, #print axioms = propext/Classical.choice/Quot.sound). Flagship: abelianCoverNumber_one (h(1)=1), exactly the trivial case the problem requests. Pyber exponential bounds c₁ⁿ<h(n)<c₂ⁿ and the OPEN exact base remain unformalized (deep).",
+    "progressSummary": "Def-only parent stub developed with axiom-free scaffolding: base values h(0)=0, h(1)=1 (Erdos117WIP01), n-commuting property closure theory (mono/injective/subgroup/mulEquiv/card_le), and now MONOTONICITY of h(n) in n (Erdos117WIP01Mono, conditional on finite-cover existence). Pyber's exponential bounds and the open exact base remain unformalized.",
     "builtItems": [
+      "abelianCoverNumber_mono in Erdos117WIP01Mono.lean — h(n) is monotone nondecreasing: n<=m and a finite m-cover exists (exists k, CoversWithAbelian k m) => h(n) <= h(m). Crux coversWithAbelian_of_le: an m-cover is an n-cover since the n-commuting property implies the m-property (hasNCommutingProperty_mono). Nonemptiness hypothesis is honest (Nat.sInf empty = 0 convention; well-definedness of h(m) is Pyber's unformalized upper bound). CoversWithAbelian names the defining-set condition; abelianCoverNumber_eq_sInf is rfl. 0-axiom, docker 8578 jobs.",
       "commute_of_hasNCommutingProperty_one - HasNCommutingProperty G 1 implies all pairs commute (Erdos117Problem.lean)",
       "hasNCommutingProperty_mono - monotone, weaker at larger n (Erdos117Problem.lean)",
       "commGroup_hasNCommutingProperty_one; isAbelianSubgroup_bot / _top_of_commGroup / _mono (Erdos117Problem.lean)",
@@ -42,6 +43,7 @@
       "Erdos117WIP01.lean: abelianCoverNumber_one (h(1)=1) — the flagship base case"
     ],
     "insights": [
+      "UNIVERSE gotcha (confirmed again): abelianCoverNumber and CoversWithAbelian are universe-polymorphic in the group universe (bodies quantify forall G:Type*), so the VALUE depends on u. Any monotonicity/set-algebra statement must pin one explicit `universe u` and annotate EVERY occurrence with .{u}; unannotated occurrences get independent universes => abelianCoverNumber.{u_1} vs .{u_3} and @h G application-type mismatch. A `universe` command takes a plain /- -/ comment, not a /-- -/ docstring.",
       "Erdos117Problem.lean stub developed: the n=1 case of the n-commuting property is EXACTLY commutativity (commute_of_hasNCommutingProperty_one) - the two-element subset {x,y} forces every distinct pair to commute; plus monotonicity and abelian-subgroup closure lemmas. All axiom-free.",
       "h(1)=1 is fully provable elementarily: the 1-commuting property makes G abelian (commute_of_hasNCommutingProperty_one), so ⊤ is a single abelian subgroup covering G (1 ∈ covering set); and 0 is never in the set since an empty Fin 0 → Subgroup family cannot cover the identity of PUnit. sInf via Nat.sInf_le + Nat.sInf_eq_zero.",
       "No group has the 0-commuting property (singleton {1} has card 1>0 but no distinct pair) — the n-commuting property is vacuous below n=1.",
@@ -49,6 +51,7 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
+      "h(n) monotonicity done (conditional on m-cover existence). Remaining elementary targets are thin: possibly h(n) >= 1 for n>=1 given a cover exists (>=1 abelian subgroup needed), or specialize mono to concrete small pairs. Deep: Pyber upper bound (well-definedness / nonemptiness of the sInf set for general n) and the exponential base are NOT elementary.",
       "Pyber upper/lower bounds c₁ⁿ<h(n)<c₂ⁿ stay as named assumptions (deep, exact base OPEN) — do NOT claim proved.",
       "Optional: covering-set well-definedness for general n (nonemptiness of the sInf argument) needs a uniform cover bound = the deep Pyber upper bound; not elementary.",
       "Optional: h(n)≥1 for all n via the same 0∉set argument (trivial generalization of the h(1)=1 lower half)."


### PR DESCRIPTION
## erdos-117-wip-01 — monotonicity of the covering number h(n)

New file `Erdos117WIP01Mono.lean` (1 def, 3 theorems, **0 axioms, 0 sorries**, docker-verified, 8578 jobs; `#print axioms = [propext, Classical.choice, Quot.sound]`).

### Context
Erdős #117 asks to estimate `h(n) = abelianCoverNumber n` — the least number of abelian subgroups needed to cover any finite group with the `n`-commuting property. `Erdos117Problem.lean` defines it and states Pyber's bounds `c₁ⁿ < h(n) < c₂ⁿ` only in prose; `Erdos117WIP01.lean` pins the base values `h(0)=0`, `h(1)=1` and the property's closure theory.

### What this adds — structural monotonicity of `h`
The `n`-commuting property is *weaker* for larger `n` (`hasNCommutingProperty_mono`), so the class of groups the covering condition ranges over *grows* with `n`. Hence a budget of `k` abelian subgroups covering every group with the `m`-property (`m ≥ n`) a fortiori covers every group with the `n`-property.

- **`CoversWithAbelian k n`** — names the membership condition of `abelianCoverNumber`'s defining set.
- **`abelianCoverNumber_eq_sInf`** — `h(n) = sInf {k | CoversWithAbelian k n}` (`rfl`).
- **`coversWithAbelian_of_le`** — the crux: for `n ≤ m`, an `m`-cover is an `n`-cover.
- **`abelianCoverNumber_mono`** — `n ≤ m` and a finite `m`-cover exists (`∃ k, CoversWithAbelian k m`) ⟹ `h(n) ≤ h(m)`.

### Honest scope
The nonemptiness hypothesis `∃ k, CoversWithAbelian k m` is deliberate: under the `Nat.sInf ∅ = 0` convention, *unconditional* monotonicity fails when `h(m)` is ill-defined — and well-definedness of `h(m)` for general `m` is exactly Pyber's unformalized upper bound. Pyber's exponential bounds and the open exact growth base stay untouched.

**Universe note:** `abelianCoverNumber` is universe-polymorphic in the group universe (its value depends on `u`), so every occurrence is pinned to one explicit `universe u` with `.{u}` annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
