### PR TITLE
Audit: erdos-1183 clean re-verify (0-ax kernel check)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10699,9 +10699,9 @@
       "result": "clean"
     },
     "erdos-1183": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:20Z",
+      "lastAudited": "2026-07-22T11:12:08Z",
       "result": "clean"
     },
     "erdos-119": {


### PR DESCRIPTION
Reserve re-audit of **erdos-1183** (Erdős #1183: Monochromatic Lattice Families).

## Result: CLEAN

Kernel-verified via `#print axioms` — main theorems depend only on `[propext, Classical.choice, Quot.sound]`; no `sorryAx`, no custom axioms:
- `erdos1183_f_lower_bound`
- `erdos1183_chain_bound`
- `erdos1183_F_ge_f`
- `exists_mono_color_class`

Verification notes:
- Counts match meta: 0 axioms, 0 sorries, no `native_decide`. Build succeeds (lint warnings only).
- Lower bound `f(n) ≥ ⌈(n+1)/2⌉` is **non-vacuous**: `le_csSup` membership is exactly the fully-proved chain/pigeonhole bound; achievable set defined as `∀ χ, ∃ F …`, bounded above by 2^n.
- Open conjectures stated as `Prop` definitions, not axioms — honest.
- Status `axiomatized`/badge `wip` is conservative (underclaiming) for a genuinely 0-axiom trivial bound; safe.

Tracker: auditCount 3→4, result clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)