### PR TITLE
Fix: formalize charpoly = X^4 for cayley-hamilton-minpoly-oq-02-oq-02

### DIFF
--- a/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ02.lean
+++ b/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ02.lean
@@ -238,6 +238,43 @@ theorem same_minpoly :
   rw [minpoly_matA, minpoly_matB]
 
 -- ============================================================
+-- PART 3b: Same Characteristic Polynomial (X⁴)
+-- ============================================================
+
+/-- The characteristic polynomial of matA is X⁴.
+
+    A nilpotent 4×4 matrix has characteristic polynomial X⁴. Formally,
+    `Matrix.isNilpotent_charpoly_sub_pow_of_isNilpotent` shows
+    `charpoly A - X ^ (card (Fin 4))` is nilpotent; since K[X] over a
+    field is an integral domain (hence reduced), the only nilpotent is
+    0, so `charpoly A = X ^ 4`. -/
+theorem charpoly_matA :
+    (matA : Matrix (Fin 4) (Fin 4) K).charpoly = X ^ 4 := by
+  have hnil : IsNilpotent (matA : Matrix (Fin 4) (Fin 4) K) :=
+    ⟨2, by rw [pow_two]; exact matA_sq_zero⟩
+  have h := Matrix.isNilpotent_charpoly_sub_pow_of_isNilpotent hnil
+  rw [Fintype.card_fin] at h
+  have hz : (matA : Matrix (Fin 4) (Fin 4) K).charpoly - X ^ 4 = 0 := h.eq_zero
+  exact sub_eq_zero.mp hz
+
+/-- The characteristic polynomial of matB is X⁴. Same argument as matA. -/
+theorem charpoly_matB :
+    (matB : Matrix (Fin 4) (Fin 4) K).charpoly = X ^ 4 := by
+  have hnil : IsNilpotent (matB : Matrix (Fin 4) (Fin 4) K) :=
+    ⟨2, by rw [pow_two]; exact matB_sq_zero⟩
+  have h := Matrix.isNilpotent_charpoly_sub_pow_of_isNilpotent hnil
+  rw [Fintype.card_fin] at h
+  have hz : (matB : Matrix (Fin 4) (Fin 4) K).charpoly - X ^ 4 = 0 := h.eq_zero
+  exact sub_eq_zero.mp hz
+
+/-- Both matrices have the same characteristic polynomial (X⁴). Together with
+    `same_minpoly`, this completes the shared-invariants half of the
+    counterexample: A and B share both minimal and characteristic polynomial. -/
+theorem same_charpoly :
+    (matA : Matrix (Fin 4) (Fin 4) K).charpoly = (matB : Matrix (Fin 4) (Fin 4) K).charpoly := by
+  rw [charpoly_matA, charpoly_matB]
+
+-- ============================================================
 -- PART 4: NOT SIMILAR (Main Result)
 -- ============================================================
 

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "cayley-hamilton-minpoly-oq-02-oq-02",
   "title": "Counterexample: Same Minpoly and Charpoly, Not Similar",
   "slug": "cayley-hamilton-minpoly-oq-02-oq-02",
-  "description": "A concrete counterexample to the converse of similarity invariance: two 4x4 nilpotent matrices (Jordan types [2,2] and [2,1,1]) share the same minimal polynomial X^2 and characteristic polynomial X^4, yet are not similar. The Lean file formalizes the shared minimal polynomial (X^2) and non-similarity; the shared characteristic polynomial X^4 holds classically for any 4x4 nilpotent matrix but is documented, not separately proved. Non-similarity is proved by showing any intertwining matrix has determinant zero.",
+  "description": "A concrete counterexample to the converse of similarity invariance: two 4x4 nilpotent matrices (Jordan types [2,2] and [2,1,1]) share the same minimal polynomial X^2 and characteristic polynomial X^4, yet are not similar. The Lean file formalizes the shared minimal polynomial (X^2), the shared characteristic polynomial (X^4, derived from 4x4 nilpotency), and non-similarity. Non-similarity is proved by showing any intertwining matrix has determinant zero.",
   "meta": {
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Jordan_normal_form#Uniqueness",
@@ -51,22 +51,22 @@
       }
     ],
     "originalContributions": [
-      "Concrete 4x4 counterexample: Jordan types [2,2] vs [2,1,1] share minpoly X^2 (formalized); the shared charpoly X^4 follows from 4x4 nilpotency but is documented rather than separately formalized",
+      "Concrete 4x4 counterexample: Jordan types [2,2] vs [2,1,1] share minpoly X^2 and charpoly X^4 (both formalized), yet are not similar",
       "Intertwining constraint extraction: AP = PB forces 6 zero entries in P",
       "Pigeonhole determinant argument: every Leibniz term has a zero factor",
       "Non-similarity theorem: no invertible intertwiner exists (det = 0 vs unit)"
     ],
     "dateAdded": "2026-03-27",
     "axiomCount": 0,
-    "lineCount": 397,
-    "assumptions": "None. All theorems fully proved including minpoly computations via UFD divisor classification and intertwining constraint extraction via Fin 4 case analysis. Note: the advertised characteristic-polynomial equality charpoly(A) = charpoly(B) = X^4 is a classical consequence of 4x4 nilpotency and appears in the file's documentation, but is not separately formalized as a theorem; the formalized invariants are the minimal polynomial (X^2) and non-similarity.",
+    "lineCount": 434,
+    "assumptions": "None. All theorems fully proved: minpoly computations via UFD divisor classification, the characteristic-polynomial equality charpoly(A) = charpoly(B) = X^4 via Matrix.isNilpotent_charpoly_sub_pow_of_isNilpotent together with the reducedness of K[X] (an integral domain), and intertwining constraint extraction via Fin 4 case analysis. The formalized invariants are the minimal polynomial (X^2), the characteristic polynomial (X^4), and non-similarity.",
     "mathlib_version": "4.31.0",
-    "theoremCount": 16,
+    "theoremCount": 19,
     "definitionCount": 2
   },
   "overview": {
     "historicalContext": "The question of when two matrices are similar is a central problem in linear algebra. Frobenius (1878) and Weierstrass showed that the rational canonical form (invariant factors) completely determines the similarity class. The Jordan normal form over algebraically closed fields gives an equivalent description via elementary divisors.\n\nIt is well-known that the minimal and characteristic polynomials are necessary but NOT sufficient invariants for similarity. The standard counterexample uses 4x4 nilpotent matrices of different Jordan types but the same minimal and characteristic polynomials.",
-    "problemStatement": "**Open Question**: Can the converse be formalized: if two matrices have the same minimal polynomial and characteristic polynomial, are they similar?\n\n**Answer**: NO. This file provides a concrete counterexample over any field K.\n\nMatrices A (Jordan type [2,2]) and B (Jordan type [2,1,1]) satisfy:\n- minpoly(A) = minpoly(B) = X^2\n- charpoly(A) = charpoly(B) = X^4\n- A is NOT similar to B\n\nThe Lean file formalizes the minimal-polynomial equality (X^2) and non-similarity. The characteristic-polynomial equality X^4 is a classical consequence of 4x4 nilpotency and is stated in the file's documentation but not established by a separate theorem.",
+    "problemStatement": "**Open Question**: Can the converse be formalized: if two matrices have the same minimal polynomial and characteristic polynomial, are they similar?\n\n**Answer**: NO. This file provides a concrete counterexample over any field K.\n\nMatrices A (Jordan type [2,2]) and B (Jordan type [2,1,1]) satisfy:\n- minpoly(A) = minpoly(B) = X^2\n- charpoly(A) = charpoly(B) = X^4\n- A is NOT similar to B\n\nThe Lean file formalizes the minimal-polynomial equality (X^2), the characteristic-polynomial equality (X^4), and non-similarity. The charpoly result is derived from 4x4 nilpotency via Matrix.isNilpotent_charpoly_sub_pow_of_isNilpotent and the fact that K[X] over a field is reduced.",
     "text": "A concrete counterexample to the converse of similarity invariance. Two 4x4 nilpotent matrices share the same minimal and characteristic polynomial but are not similar, because any intertwining matrix must have determinant zero.",
     "proofStrategy": "**Non-similarity via intertwining analysis**: If B = P^{-1}AP, then AP = PB. The structure of A and B forces rows 1 and 3 of P to have nonzero entries only in column 1. In the Leibniz determinant formula, every permutation requires three column indices (0, 2, 3) to map to the 2-element set {0, 2}, which is impossible by pigeonhole. So det(P) = 0 for any intertwiner, and no invertible P exists.",
     "keyInsights": [
@@ -118,18 +118,26 @@
       "mathContext": "Since $A^2 = 0$, $\\text{minpoly}(A) \\mid X^2$. Since $A \\neq 0$, $\\text{minpoly}(A) \\nmid X$. The only monic divisors of $X^2$ are $\\{1, X, X^2\\}$; ruling out $1$ and $X$ gives $\\text{minpoly}(A) = X^2$."
     },
     {
+      "id": "same-charpoly",
+      "title": "Same Characteristic Polynomial X^4",
+      "startLine": 240,
+      "endLine": 275,
+      "summary": "Proves charpoly(A) = charpoly(B) = X^4. Both matrices are nilpotent (A^2 = B^2 = 0), and Matrix.isNilpotent_charpoly_sub_pow_of_isNilpotent shows charpoly - X^(card) is nilpotent; since K[X] over a field is an integral domain (hence reduced), that nilpotent is 0, giving charpoly = X^4.",
+      "mathContext": "For a nilpotent $M$ over a field $K$, $\\text{charpoly}(M) - X^{\\dim} $ is nilpotent in $K[X]$. Because $K[X]$ is an integral domain it is reduced, so its only nilpotent is $0$: $\\text{charpoly}(A) = \\text{charpoly}(B) = X^4$."
+    },
+    {
       "id": "not-similar",
       "title": "Non-Similarity (Main Result)",
-      "startLine": 234,
-      "endLine": 350,
+      "startLine": 277,
+      "endLine": 395,
       "summary": "Proves A and B are not similar via the intertwining matrix argument: AP = PB forces det(P) = 0. Uses pigeonhole on the Leibniz formula.",
       "mathContext": "If $B = P^{-1}AP$ then $AP = PB$. Entry analysis shows $P_{1j} = P_{3j} = 0$ for $j \\neq 1$. In $\\det(P) = \\sum_\\sigma \\text{sgn}(\\sigma) \\prod_i P_{\\sigma(i),i}$, each term needs $\\sigma(\\{0,2,3\\}) \\subseteq \\{0,2\\}$, impossible by pigeonhole."
     },
     {
       "id": "summary",
       "title": "Summary: The Converse of Similarity Invariance",
-      "startLine": 352,
-      "endLine": 390,
+      "startLine": 396,
+      "endLine": 433,
       "summary": "Closing summary (PART 5): records that cayley-hamilton-minpoly-oq-02 proved similar matrices share a minimal polynomial, while this file proves the converse fails. Tabulates the two Jordan types A = J2(0)+J2(0) and B = J2(0)+J1(0)+J1(0) with equal characteristic polynomial X^4 and minimal polynomial X^2 but distinct invariant factors, explains why (the minimal polynomial sees only the largest block per eigenvalue), names invariant factors / Jordan type as the correct similarity invariant, and lists open follow-ups (rational canonical form, Jordan normal form, full classification).",
       "mathContext": "The minimal polynomial records the largest Jordan block size per eigenvalue and the characteristic polynomial records the total ($\\sum$ of block sizes); neither captures the full block-size distribution. Over an algebraically closed field, $A \\sim B$ iff they share invariant factors (equivalently elementary divisors / Jordan type). Here $A$ has invariant factors $(X^2, X^2)$ and $B$ has $(X^2, X, X)$: same largest factor (minpoly) and same product (charpoly), but different factors, so $A \\nsim B$."
     }
@@ -153,9 +161,9 @@
       "Polynomial"
     ],
     "namespace": "SimilarCounterexample",
-    "lineCount": 397,
+    "lineCount": 434,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 19,
     "definitionCount": 2,
     "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Applies the auditor's **preferred** fix for integrity issue #41314 on **cayley-hamilton-minpoly-oq-02-oq-02**: the "share the same characteristic polynomial X^4" claim, previously present only in comments/docstrings, is now a genuinely formalized theorem.

## What was wrong

The entry advertised a counterexample to "same minpoly **and charpoly** ⇒ similar", but only the minimal-polynomial equality and non-similarity were formalized. The charpoly X^4 equality — half the headline invariant-matching claim — appeared only in prose. An interim enricher PR (#41325) took the lighter path (qualifying the wording as "documented, not separately proved"). This PR instead does the preferred fix and formalizes it.

## Change

**Lean** (`proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ02.lean`), new PART 3b:
- `charpoly_matA : matA.charpoly = X ^ 4`
- `charpoly_matB : matB.charpoly = X ^ 4`
- `same_charpoly : matA.charpoly = matB.charpoly`

Proof: both matrices are nilpotent (`A^2 = B^2 = 0`, already proved). `Matrix.isNilpotent_charpoly_sub_pow_of_isNilpotent` gives `IsNilpotent (charpoly - X ^ card)`; since `K[X]` over a field is an integral domain (hence reduced via `isReduced_of_noZeroDivisors`), that nilpotent is `0`, so `charpoly = X ^ 4`. No new axioms, no sorries.

**meta.json**: removed the now-obsolete "documented, not separately proved" qualifications from `description`, `originalContributions[0]`, `assumptions`, and `overview.problemStatement` (charpoly X^4 is now formalized); bumped `theoremCount` 16→19 and `lineCount` 397→434; added a `same-charpoly` section and re-anchored `not-similar`/`summary` (shifted +37 by the insertion).

## Verification

`./proofs/scripts/docker-build.sh Proofs.CayleyHamiltonMinpolyOQ02OQ02` → **Build completed successfully (2969 jobs)**. Only pre-existing warnings (`push_neg` deprecation, unused simp args); no errors from the new theorems. Status remains `verified` / `original`, axiomCount 0, sorries 0.

Closes #41314
