### PR TITLE
Research: erdos-18-wip-01 — bounds on h(m) + h-definition defect finding

### DIFF
--- a/proofs/Proofs/Erdos18WIP01.lean
+++ b/proofs/Proofs/Erdos18WIP01.lean
@@ -1325,4 +1325,66 @@ theorem two_hundred_ten_practical : IsPractical 210 := by
   have he : primorial 7 = 210 := by decide
   rwa [he] at h
 
+/- ## Bounds on the divisor-completeness index `h`
+
+`h m` (defined in the parent `Erdos18Problem.lean`) is the least size of a
+*single* set `S` of divisors of `m` from which every `1 ≤ k < m` can be
+assembled as a subset sum — the size of a "universal representing set". This
+section supplies the first theorems about it (the parent's "Known Bounds on
+h(m)" section is otherwise empty), pinning it between a logarithm and the
+divisor count: `log₂ m ≤ h m ≤ d(m)`.
+
+**Caveat — this is not the Erdős prize quantity.** Erdős #18 concerns a
+*different* index: the maximum over `k < m` of the *fewest* divisors needed to
+represent that particular `k` (Vose 1985: infinitely many `m` with that index
+`≪ √(log m)`). The parent `h` is the universal-set size, which
+`le_two_pow_h` below shows is always `≥ log₂ m`. In particular the parent's
+`conjecture_part2_weak` (`h(n!) < n^ε`) is *false as stated for this `h`*, since
+`log₂(n!) = Θ(n log n)` is superpolynomial (see `factorial_le_two_pow_h`). The
+subadditivity theorem in `Erdos18OQ01.lean` is correct for this universal-set
+`h`, so the resolution is to *rename* the parent `h` and introduce the
+max-representation-length index for the conjectures (mechanic follow-up). -/
+
+/-- **Upper bound `h m ≤ d(m)`.** For practical `m`, the full divisor set already
+represents every `1 ≤ k < m`, so a universal representing set needs no more
+divisors than `m` has. -/
+theorem h_le_card_divisors {m : ℕ} (hm : IsPractical m) :
+    h m ≤ (divisors m).card := by
+  apply Nat.sInf_le
+  exact ⟨divisors m, Finset.Subset.refl _, rfl, fun k hk1 hkm => hm.2 k hk1 hkm⟩
+
+/-- **Lower bound `m ≤ 2 ^ h m`.** A universal representing set `S` of size `h m`
+admits only `2 ^ |S|` distinct subset sums, yet these must realise the `m`
+values `0, 1, …, m − 1`. Hence `log₂ m ≤ h m`. -/
+theorem le_two_pow_h {m : ℕ} (hm : IsPractical m) :
+    m ≤ 2 ^ h m := by
+  have hne : { s : ℕ | ∃ S : Finset ℕ, S ⊆ divisors m ∧ S.card = s ∧
+      ∀ k, 1 ≤ k → k < m → ∃ T : Finset ℕ, T ⊆ S ∧ T.sum id = k }.Nonempty :=
+    ⟨(divisors m).card, divisors m, Finset.Subset.refl _, rfl,
+      fun k hk1 hkm => hm.2 k hk1 hkm⟩
+  obtain ⟨S, hSdvd, hScard, hScov⟩ := Nat.sInf_mem hne
+  have hScard' : S.card = h m := hScard
+  have hsub : Finset.range m ⊆ (S.powerset).image (fun T => T.sum id) := by
+    intro k hk
+    rw [Finset.mem_range] at hk
+    rcases Nat.eq_zero_or_pos k with hk0 | hk1
+    · exact Finset.mem_image.mpr ⟨∅, Finset.mem_powerset.mpr (Finset.empty_subset _),
+        by simp [hk0]⟩
+    · obtain ⟨T, hTS, hTsum⟩ := hScov k hk1 hk
+      exact Finset.mem_image.mpr ⟨T, Finset.mem_powerset.mpr hTS, hTsum⟩
+  calc m = (Finset.range m).card := (Finset.card_range m).symm
+    _ ≤ ((S.powerset).image (fun T => T.sum id)).card := Finset.card_le_card hsub
+    _ ≤ (S.powerset).card := Finset.card_image_le
+    _ = 2 ^ S.card := Finset.card_powerset S
+    _ = 2 ^ h m := by rw [hScard']
+
+/-- **Consequence for factorials.** Applying `le_two_pow_h` to `n !` (practical by
+`factorial_practical`): the universal representing-set index satisfies
+`n ! ≤ 2 ^ h (n !)`. Because `log₂(n!) = Θ(n log n)` is superpolynomial in `n`,
+this refutes the parent's `conjecture_part2_weak` (`h(n!) < n^ε`) *for this `h`* —
+formal evidence that the parent `h` is the universal-set size rather than the
+Erdős max-representation-length index (Vose `≪ √log m`) the prize concerns. -/
+theorem factorial_le_two_pow_h (n : ℕ) : n ! ≤ 2 ^ h (n !) :=
+  le_two_pow_h (factorial_practical n)
+
 end Erdos18

--- a/research/problems/erdos-18-wip-01/knowledge.md
+++ b/research/problems/erdos-18-wip-01/knowledge.md
@@ -180,3 +180,36 @@ power-of-two base, because there σ is a closed geometric series:
 `h(m)` growth — `conjecture_part1`, `conjecture_part2_weak/strong`, the $250
 `h(n!) < n^{o(1)}` — remains unformalized. Next elementary bricks: primorial practicality
 (needs Bertrand + σ-multiplicativity bookkeeping), density/counting (deep, Weingartner).
+
+---
+
+## Session 2026-07-22 (researcher-1): first bounds on h(m) + definition-defect finding
+
+Added three 0-axiom theorems to `Erdos18WIP01.lean` (Docker-verified v4.31,
+`#print axioms` = propext/Classical.choice/Quot.sound), populating the parent's
+previously-empty "Known Bounds on h(m)" section:
+
+- `h_le_card_divisors : IsPractical m → h m ≤ (divisors m).card` — the full
+  divisor set represents everything, so `h m ≤ d(m)`.
+- `le_two_pow_h : IsPractical m → m ≤ 2 ^ h m` — information-theoretic: a size-`h m`
+  universal representing set has only `2^(h m)` subset sums, which must realise the
+  `m` values `0,…,m-1`. So `log₂ m ≤ h m`. Proof: `range m ⊆ image (·.sum id)
+  S.powerset`, then `card_le_card`/`card_image_le`/`card_powerset`.
+- `factorial_le_two_pow_h : n ! ≤ 2 ^ h (n !)` — corollary via `factorial_practical`.
+
+**Definition defect (mechanic/auditor lead).** The parent `Erdos18Problem.lean:99`
+defines `h m` as the *minimum size of a single universal representing set* of
+divisors. That is **not** the Erdős #18 prize quantity, which is the *maximum over
+`k<m` of the fewest divisors needed to represent that `k`* (Vose 1985: infinitely
+many `m` with that index `≪ √(log m)`). The universal-set `h` satisfies
+`h(m) ≥ log₂ m` (`le_two_pow_h`); since `log₂(n!) = Θ(n log n)` is superpolynomial,
+`conjecture_part2_weak` (`h(n!)<n^ε`) is **false as written** for this `h`
+(`factorial_le_two_pow_h` is formal evidence). `Erdos18OQ01.lean` proves
+subadditivity `h(mn) ≤ h(m)+h(n)`, which IS correct for the universal-set index, so
+the def cannot simply be swapped — the fix is to **rename** the parent `h`
+(e.g. `hCover`) and introduce the max-representation-length index for the three
+conjectures.
+
+Practicality-membership theory (Stewart–Sierpiński iff, factorials, primorials,
+Euclid-form perfect numbers, `2^a·3^b`, `2^a·5^b`) is **saturated** — the live
+frontier is now the `h`-index formalization above, blocked on the mechanic def fix.

--- a/src/data/research/problems/erdos-18-wip-01.json
+++ b/src/data/research/problems/erdos-18-wip-01.json
@@ -23,7 +23,7 @@
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "MECHANIC/AUDITOR follow-up: the parent Erdos18Problem.lean h (universal-set size) misformalizes the Erdos #18 prize quantity (max representation length); rename it (e.g. hCover) and define the correct h for conjecture_part1/part2_weak/part2_strong. Erdos18OQ01 subadditivity depends on the universal-set h. Practicality-membership theory (Stewart-Sierpinski iff, factorials, primorials, Euclid-form, 2^a3^b, 2^a5^b) is saturated.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added the Euclid-form family to Erdos18WIP01.lean — σ(2^k)=2^{k+1}−1, the sharp criterion 2^k·n practical for 1≤n≤2^{k+1}, and euclid_form_practical (⟹ every even perfect number is practical). 0-axiom, Docker-verified. h(m) growth ($250 open question) remains unformalized.",
+    "progressSummary": "PROGRESS: First theorems about the divisor-completeness index h (parent \"Known Bounds on h(m)\" section was empty). Proved the information-theoretic lower bound m<=2^(h m) and upper bound h(m)<=d(m), pinning log2 m <= h(m) <= d(m) (0-axiom, Docker-verified v4.31). Surfaced a definition defect: the file h is the universal-representing-set size (>=log2 m), NOT the Erdos prize quantity (max single-value representation length, Vose <<sqrt(log m)); consequently conjecture_part2_weak (h(n!)<n^eps) is false as stated for this h (factorial_le_two_pow_h). Recommended mechanic follow-up: rename parent h, add max-length index for the conjectures.",
     "builtItems": [
       "decidableIsRepresentable / decidableIsPractical instances (Erdos18Problem.lean)",
       "zero_isRepresentable, one_isRepresentable, isRepresentable_self, isRepresentable_le_sigma, mem_divisors_le (Erdos18Problem.lean)",
@@ -43,7 +43,10 @@
       "two_dvd_of_practical / even_of_practical in Erdos18WIP01.lean: practical m>=3 => 2 | m (necessary condition)",
       "divisor_chain_of_practical / practical_of_divisor_chain_condition / practical_iff_divisor_chain in Erdos18WIP01.lean (necessary + sufficient divisor-gap condition, iff)",
       "succ_mul_self_practical: n practical ⟹ n(n+1) practical (0-axiom corollary of Stewart–Sierpiński)",
-      "sum_range_two_pow, sum_divisors_two_pow, two_pow_mul_practical_of_le, euclid_form_practical, four_ninety_six_practical in Erdos18WIP01.lean (all 0-axiom: propext/Classical.choice/Quot.sound; Docker-built 8577 jobs)"
+      "sum_range_two_pow, sum_divisors_two_pow, two_pow_mul_practical_of_le, euclid_form_practical, four_ninety_six_practical in Erdos18WIP01.lean (all 0-axiom: propext/Classical.choice/Quot.sound; Docker-built 8577 jobs)",
+      "le_two_pow_h (Erdos18WIP01.lean): m <= 2^(h m) for practical m [0-axiom]",
+      "h_le_card_divisors (Erdos18WIP01.lean): h m <= d(m) for practical m [0-axiom]",
+      "factorial_le_two_pow_h (Erdos18WIP01.lean): n! <= 2^(h n!) [0-axiom]"
     ],
     "insights": [
       "Erdos18Problem.lean stub developed: representability (IsRepresentable) and practicality (IsPractical) are DECIDABLE via a finite powerset search over the divisor set — a single decision procedure subsuming all future example checks; all lemmas axiom-free (plain kernel decide, no native_decide/Lean.ofReduceBool).",
@@ -54,7 +57,12 @@
       "sum_divisors_two_pow: σ(2^k)=∑_{d∣2^k}d=2^{k+1}−1 via Nat.sum_divisors_prime_pow (2 prime) + geometric series sum_range_two_pow (induction)",
       "two_pow_mul_practical_of_le: for 1≤n≤2^{k+1}, 2^k·n is practical — sharp specialisation of mul_practical_of_le_succ_sigma to the power-of-two base (1+σ(2^k)=2^{k+1}); generalises two_mul_practical",
       "euclid_form_practical: 2^k·(2^{k+1}−1) practical ∀k; when 2^{k+1}−1 is a Mersenne prime this is Euclids even perfect number, so EVERY EVEN PERFECT NUMBER IS PRACTICAL (6,28,496,... uniform). Note: Mathlib in-repo lacks the Euclid-Euler classification, so the perfect-number statement lives in prose/motivation, not as a Lean theorem",
-      "four_ninety_six_practical: 496=2^4·31 practical (k=4 instance, norm_num)"
+      "four_ninety_six_practical: 496=2^4·31 practical (k=4 instance, norm_num)",
+      "The parent files (Erdos18Problem.lean:99) define h(m) as the MINIMUM SIZE of a single universal representing set of divisors covering every 1<=k<m. This is NOT the Erdos #18 prize quantity, which is the MAX over k<m of the FEWEST divisors needed to represent that particular k (Vose 1985: infinitely many m with that index <<sqrt(log m)).",
+      "Proved (Erdos18WIP01, 0-axiom): le_two_pow_h : IsPractical m -> m <= 2^(h m). Information-theoretic: a size-(h m) representing set has only 2^(h m) subset sums yet must realise the m values 0..m-1. Hence h(m) >= log2 m for the file h.",
+      "Corollary factorial_le_two_pow_h : n! <= 2^(h n!). Since log2(n!)=Theta(n log n) is superpolynomial, the parent conjecture_part2_weak (h(n!)<n^eps) is FALSE as written for the file s universal-set h.",
+      "Proved h_le_card_divisors : IsPractical m -> h m <= (divisors m).card (upper bound d(m)). Together: log2 m <= h m <= d(m) for the file h.",
+      "Erdos18OQ01.lean already proves subadditivity h(mn)<=h(m)+h(n) for this universal-set h (correct for that quantity), so the def cannot simply be replaced: mechanic should RENAME the parent h to the universal-set index and introduce the max-representation-length index for the conjectures."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary

First theorems about the **divisor-completeness index `h`** of Erdős Problem #18
(practical numbers). The parent `Erdos18Problem.lean` defines `h m` but leaves its
"Known Bounds on h(m)" section empty; this adds three axiom-free, Docker-verified
(Lean v4.31) bounds to `Erdos18WIP01.lean`, pinning `log₂ m ≤ h(m) ≤ d(m)`:

| Theorem | Statement |
|---|---|
| `h_le_card_divisors` | `IsPractical m → h m ≤ (divisors m).card` |
| `le_two_pow_h` | `IsPractical m → m ≤ 2 ^ h m` (info-theoretic: `h(m) ≥ log₂ m`) |
| `factorial_le_two_pow_h` | `n! ≤ 2 ^ h (n!)` |

`#print axioms` on all three = `[propext, Classical.choice, Quot.sound]` (0 extra axioms).

## Definition-defect finding (mechanic/auditor follow-up)

`le_two_pow_h` formally establishes that the parent's `h` is the **minimum size of a
single universal representing set** of divisors — a quantity that is always
`≥ log₂ m`. This is **not** the Erdős #18 prize quantity, which is the *maximum over
`k<m` of the fewest divisors needed to represent that particular `k`* (Vose 1985:
infinitely many `m` with that index `≪ √(log m)`).

Consequence: since `log₂(n!) = Θ(n log n)` is superpolynomial, the parent's
`conjecture_part2_weak` (`h(n!) < n^ε`) is **false as written** for this `h`
(`factorial_le_two_pow_h` is the formal witness). `Erdos18OQ01.lean` already proves
subadditivity `h(mn) ≤ h(m)+h(n)`, which *is* correct for the universal-set index, so
the def cannot simply be swapped. **Recommended fix**: rename the parent `h` (e.g.
`hCover`) and introduce the max-representation-length index for the three conjecture
Props. Documented in `research/problems/erdos-18-wip-01/knowledge.md`.

The practicality-membership theory (Stewart–Sierpiński `iff`, factorials, primorials,
Euclid-form perfect numbers, `2^a·3^b`, `2^a·5^b`) is saturated; the `h`-index
formalization is the live frontier, now blocked on the mechanic def fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
