### PR TITLE
Research: erdos-30-wip-01 — powers-of-two Sidon set ⟹ sidonNumber unbounded

### DIFF
--- a/proofs/Proofs/Erdos30WIP01.lean
+++ b/proofs/Proofs/Erdos30WIP01.lean
@@ -207,4 +207,103 @@ theorem sidonNumber_mono {N M : ℕ} (h : N ≤ M) : sidonNumber N ≤ sidonNumb
   rw [Finset.mem_range] at hxN ⊢
   omega
 
+/- ## A growing Sidon family: powers of two (a lower bound on `h(N)`)
+
+The results above bound `h(N)` from *above* by `√(2N) + 1`, but the only lower
+bound so far is the trivial `1 ≤ h(N)` (the singleton). Here we supply a genuine
+*growing* lower bound: the `k + 1` powers `{2^0, 2^1, …, 2^k}` form a Sidon set
+inside `{0, …, 2^k}`, so `h(2^k) ≥ k + 1`. In particular `h(N)` is unbounded
+(`sidonNumber_unbounded`). This is only a logarithmic bound — far from the sharp
+`√N` growth (which needs Singer/perfect-difference-set constructions, absent from
+Mathlib) — but it is the first proof in this file that `h(N) → ∞`. -/
+
+/-- **Powers of two have distinct pairwise sums.** If `2^i + 2^j = 2^p + 2^q` with
+`i ≤ j` and `p ≤ q` and `i ≤ p`, then `(i, j) = (p, q)`. The 2-adic valuation of the
+smaller exponent must match (else one side is odd and the other even, or one side is
+`2` while the other is `≥ 4`), forcing `i = p`; cancelling then gives `j = q`. -/
+private theorem two_pow_add_inj {i j p q : ℕ} (hij : i ≤ j) (hpq : p ≤ q)
+    (hip : i ≤ p) (h : 2 ^ i + 2 ^ j = 2 ^ p + 2 ^ q) : i = p ∧ j = q := by
+  have hiq : i ≤ q := hip.trans hpq
+  have hi_p : i = p := by
+    by_contra hne
+    have hlt : i < p := lt_of_le_of_ne hip hne
+    have e1 : 2 ^ i + 2 ^ j = 2 ^ i * (1 + 2 ^ (j - i)) := by
+      rw [Nat.mul_add, Nat.mul_one, ← pow_add, Nat.add_sub_cancel' hij]
+    have e2 : 2 ^ p + 2 ^ q = 2 ^ i * (2 ^ (p - i) + 2 ^ (q - i)) := by
+      rw [Nat.mul_add, ← pow_add, ← pow_add, Nat.add_sub_cancel' hip,
+        Nat.add_sub_cancel' hiq]
+    rw [e1, e2] at h
+    have hcancel : 1 + 2 ^ (j - i) = 2 ^ (p - i) + 2 ^ (q - i) :=
+      Nat.eq_of_mul_eq_mul_left (by positivity) h
+    have hPpos : 0 < p - i := by omega
+    have hQpos : 0 < q - i := by omega
+    have hReven : Even (2 ^ (p - i) + 2 ^ (q - i)) :=
+      (Nat.even_pow.mpr ⟨even_two, by omega⟩).add (Nat.even_pow.mpr ⟨even_two, by omega⟩)
+    rcases Nat.eq_zero_or_pos (j - i) with hj0 | hjpos
+    · rw [hj0] at hcancel
+      have h2p : 2 ≤ 2 ^ (p - i) := by
+        calc 2 = 2 ^ 1 := (pow_one 2).symm
+          _ ≤ 2 ^ (p - i) := Nat.pow_le_pow_right (by norm_num) hPpos
+      have h2q : 2 ≤ 2 ^ (q - i) := by
+        calc 2 = 2 ^ 1 := (pow_one 2).symm
+          _ ≤ 2 ^ (q - i) := Nat.pow_le_pow_right (by norm_num) hQpos
+      simp only [pow_zero] at hcancel
+      omega
+    · have hLodd : Odd (1 + 2 ^ (j - i)) := by
+        rw [Nat.add_comm]
+        exact Even.add_one (Nat.even_pow.mpr ⟨even_two, by omega⟩)
+      rw [hcancel] at hLodd
+      rw [Nat.even_iff] at hReven
+      rw [Nat.odd_iff] at hLodd
+      omega
+  refine ⟨hi_p, ?_⟩
+  subst hi_p
+  have hjq : 2 ^ j = 2 ^ q := by omega
+  exact Nat.pow_right_injective (by norm_num) hjq
+
+/-- **The powers `{2^0, …, 2^k}` form a Sidon set.** -/
+theorem isSidonSet_two_pow_range (k : ℕ) :
+    IsSidonSet ((Finset.range (k + 1)).image (2 ^ ·)) := by
+  intro a b c d ha hb hc hd hab hcd heq
+  simp only [Finset.mem_image, Finset.mem_range] at ha hb hc hd
+  obtain ⟨i, _, rfl⟩ := ha
+  obtain ⟨j, _, rfl⟩ := hb
+  obtain ⟨p, _, rfl⟩ := hc
+  obtain ⟨q, _, rfl⟩ := hd
+  have hij : i ≤ j := (Nat.pow_le_pow_iff_right (by norm_num)).mp hab
+  have hpq : p ≤ q := (Nat.pow_le_pow_iff_right (by norm_num)).mp hcd
+  rcases le_total i p with hip | hpi
+  · obtain ⟨hi, hj⟩ := two_pow_add_inj hij hpq hip heq
+    exact ⟨by rw [hi], by rw [hj]⟩
+  · obtain ⟨hp, hq⟩ := two_pow_add_inj hpq hij hpi heq.symm
+    exact ⟨by rw [hp], by rw [hq]⟩
+
+/-- **`{2^0, …, 2^k}` sits inside `{0, …, 2^k}`.** -/
+theorem two_pow_range_subset (k : ℕ) :
+    (Finset.range (k + 1)).image (2 ^ ·) ⊆ Finset.range (2 ^ k + 1) := by
+  intro x hx
+  simp only [Finset.mem_image, Finset.mem_range] at hx
+  obtain ⟨i, hi, rfl⟩ := hx
+  rw [Finset.mem_range]
+  have : 2 ^ i ≤ 2 ^ k := Nat.pow_le_pow_right (by norm_num) (by omega)
+  omega
+
+/-- **Lower bound `h(2^k) ≥ k + 1`.** The `k + 1` distinct powers `{2^0, …, 2^k}` are a
+Sidon subset of `{0, …, 2^k}`, so the Sidon number of `2^k` is at least their count. -/
+theorem sidonNumber_two_pow_ge (k : ℕ) : k + 1 ≤ sidonNumber (2 ^ k) := by
+  have hcard : ((Finset.range (k + 1)).image (2 ^ ·)).card = k + 1 := by
+    rw [Finset.card_image_of_injective _ (Nat.pow_right_injective (by norm_num)),
+      Finset.card_range]
+  unfold sidonNumber
+  rw [← hcard]
+  apply Finset.le_sup
+  simp only [Finset.mem_filter, Finset.mem_powerset]
+  exact ⟨two_pow_range_subset k, isSidonSet_two_pow_range k⟩
+
+/-- **The Sidon number is unbounded.** For every `M` there is an `N` with
+`h(N) ≥ M` (take `N = 2^M`, giving `h(2^M) ≥ M + 1`). So `h(N) → ∞`, a qualitative
+lower complement to the `√(2N) + 1` upper bound. -/
+theorem sidonNumber_unbounded : ∀ M : ℕ, ∃ N : ℕ, M ≤ sidonNumber N :=
+  fun M => ⟨2 ^ M, (Nat.le_succ M).trans (sidonNumber_two_pow_ge M)⟩
+
 end Erdos30

--- a/src/data/research/problems/erdos-30-wip-01.json
+++ b/src/data/research/problems/erdos-30-wip-01.json
@@ -23,7 +23,7 @@
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Elementary two-sided understanding now in place: upper h(N)<=sqrt(2N)+1 (Erdos-Turan) and lower h(N) unbounded via powers-of-two (log N). NEXT (harder): a polynomial sqrt(N)-order lower-bound construction (Singer/perfect difference sets, or the Erdos-Turan {2ip + (i^2 mod p)} construction) — needs modular-arithmetic Sidon infrastructure absent from Mathlib. The open N^{1/4}-error Erdos-Turan conjecture ($1000) stays a Prop.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,19 +31,25 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: formalized the Erdős–Turán (1941) counting UPPER bound as 6 axiom-free theorems (Erdos30WIP01.lean, Docker-verified v4.31, #print axioms = propext/Classical.choice/Quot.sound). Bounds the gallery Sidon number: h(N) = sidonNumber N ≤ ⌊√(2N)⌋+1 ≤ √(2N)+1. The parent Erdos30Problem.lean previously left ALL bounds in comments/axioms; this converts the classical upper bound into genuine theorems. The N^{1/4} refinement and the OPEN Erdős–Turán conjecture (whether error ≤ N^ε) remain untouched.",
+    "progressSummary": "PROGRESS: Added the first GROWING lower bound / unboundedness for the Sidon number. Powers of two {2^0..2^k} are a Sidon set (isSidonSet_two_pow_range, sum-injectivity by 2-adic parity), giving h(2^k) >= k+1 and hence sidonNumber unbounded (sidonNumber_unbounded). Complements the existing Erdos-Turan upper bound h(N) <= sqrt(2N)+1; brackets 1 <= h(N) with an explicit growing family. 0-axiom, Docker-verified v4.31. The bound is only logarithmic — the sharp sqrt(N) growth (Singer difference sets) stays deep/unformalized.",
     "builtItems": [
       "Erdos30WIP01.lean: diffMap_injOn (Set.InjOn of difference map on Sidon off-diagonal)",
       "Erdos30WIP01.lean: sidon_offDiag_card_le (|A.offDiag| ≤ 2N for Sidon A ⊆ {0..N})",
       "Erdos30WIP01.lean: sidon_card_sq_le (|A|² ≤ 2N + |A|)",
       "Erdos30WIP01.lean: sidon_card_le_sqrt (|A| ≤ ⌊√(2N)⌋+1)",
       "Erdos30WIP01.lean: sidonNumber_le_sqrt (h(N) ≤ ⌊√(2N)⌋+1) — bounds the gallery Sidon number",
-      "Erdos30WIP01.lean: sidonNumber_le_real ((h(N):ℝ) ≤ √(2N)+1)"
+      "Erdos30WIP01.lean: sidonNumber_le_real ((h(N):ℝ) ≤ √(2N)+1)",
+      "isSidonSet_two_pow_range (Erdos30WIP01.lean): {2^0..2^k} is Sidon [0-axiom]",
+      "two_pow_add_inj (Erdos30WIP01.lean): 2^i+2^j=2^p+2^q (sorted) => exponents match [0-axiom]",
+      "sidonNumber_two_pow_ge (Erdos30WIP01.lean): k+1 <= sidonNumber (2^k) [0-axiom]",
+      "sidonNumber_unbounded (Erdos30WIP01.lean): forall M, exists N, M <= sidonNumber N [0-axiom]"
     ],
     "insights": [
       "Erdős–Turán upper bound is provable elementarily via difference-map injectivity: for a Sidon set A the map (a,b)↦a−b is injective on the off-diagonal (a−b=c−d ⇒ a+d=c+b ⇒ pair matches by the Sidon property), its image is nonzero integers in [−N,N] (2N of them), so |A.offDiag|=|A|²−|A| ≤ 2N.",
       "Clean √-form: |A|² ≤ 2N + |A| gives (|A|−1)² ≤ |A|(|A|−1) ≤ 2N, hence |A| ≤ Nat.sqrt(2N)+1; passes to the supremum sidonNumber via Finset.sup_le, giving h(N) ≤ ⌊√(2N)⌋+1 ~ √(2N).",
-      "Mathlib has NO Sidon/B₂-set API and no roots-of-unity/Vandermonde discriminant product; the counting bound is best built from Finset.offDiag_card, Int.card_Icc, and Nat.le_sqrt."
+      "Mathlib has NO Sidon/B₂-set API and no roots-of-unity/Vandermonde discriminant product; the counting bound is best built from Finset.offDiag_card, Int.card_Icc, and Nat.le_sqrt.",
+      "Powers of two {2^0,...,2^k} form a Sidon set (isSidonSet_two_pow_range): sum-injectivity via 2-adic parity (two_pow_add_inj) — factor out 2^min, then odd-vs-even cofactor / 2-vs->=4 forces exponents to match.",
+      "sidonNumber_two_pow_ge: h(2^k) >= k+1, so sidonNumber is UNBOUNDED (sidonNumber_unbounded). First growing lower bound in the file (previously only trivial h(N)>=1). Only logarithmic — sharp sqrt(N) growth needs Singer/perfect-difference-set constructions absent from Mathlib."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary

First **growing lower bound** for the Sidon number `h(N) = sidonNumber N` in
`Erdos30WIP01.lean`. The file already had the Erdős–Turán *upper* bound
`h(N) ≤ √(2N)+1`, but its only lower bound was the trivial `h(N) ≥ 1` (the
singleton). This adds an explicit growing family proving `h(N) → ∞`.

The `k+1` powers `{2^0, 2^1, …, 2^k}` form a Sidon set inside `{0,…,2^k}`, so
`h(2^k) ≥ k+1`. All axiom-free, Docker-verified (Lean v4.31):

| Theorem | Statement |
|---|---|
| `isSidonSet_two_pow_range` | `IsSidonSet ((range (k+1)).image (2^·))` |
| `two_pow_add_inj` | `2^i+2^j = 2^p+2^q` (sorted, `i≤p`) ⟹ `(i,j)=(p,q)` |
| `sidonNumber_two_pow_ge` | `k+1 ≤ sidonNumber (2^k)` |
| `sidonNumber_unbounded` | `∀ M, ∃ N, M ≤ sidonNumber N` |

`#print axioms` on all three headline results = `[propext, Classical.choice, Quot.sound]`.

## Mechanism

`two_pow_add_inj` is the crux: `2^i+2^j = 2^p+2^q` with `i≤j`, `p≤q`, `i≤p`.
Factor out `2^i`; the cofactor `1 + 2^(j-i)` is odd (when `j>i`) or `2` (when `j=i`),
while the other side `2^(p-i)+2^(q-i)` is even (or `≥4`) when `i<p`. The parity /
size clash forces `i=p`, then cancelling gives `j=q`.

## Honesty note

This is only a **logarithmic** lower bound (`h(2^k) ≥ k+1 ≈ log₂ N`), far from the
sharp `√N` growth. The polynomial `√N`-order construction (Singer / perfect-difference
sets, or the Erdős–Turán `{2ip + (i² mod p)}` construction) needs modular-arithmetic
Sidon infrastructure that Mathlib lacks, and stays a documented next step. The open
`N^{1/4}`-error Erdős–Turán conjecture (\$1000) remains a `Prop` in the parent file,
untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
