### PR TITLE
audit(tracker): erdos-1178 re-verified clean after #41338 fix

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10642,9 +10642,9 @@
       "result": "clean"
     },
     "erdos-1178": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:20Z",
+      "lastAudited": "2026-07-22T11:53:37Z",
       "result": "clean"
     },
     "erdos-1179": {


### PR DESCRIPTION
Re-audit of erdos-1178 in reserve mode. Prior tracker 'clean' was 2026-05-04, predating the native_decide issue #41338 filed today. Confirmed remediated: #41352 removed native_decide (kernel proof), axiomCount 3 matches 3 axioms, 0 sorries, badge=axiom, status=axiomatized (honest Tier C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)