### PR TITLE
audit(erdos-1162): fix contradictory 'machine-checked' claim for build-blocked small cases

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10535,10 +10535,10 @@
       "result": "clean"
     },
     "erdos-1162": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:20Z",
-      "result": "clean"
+      "lastAudited": "2026-07-22T11:57:01Z",
+      "result": "issues-fixed"
     },
     "erdos-1165": {
       "auditCount": 4,
@@ -10561,9 +10561,9 @@
       "note": "2026-07-09 audit CLEAN: 2 axioms (erdos_1167_conjecture OPEN, erdos_rado_theorem); the apparent 3rd axiom is comment prose (\"axiom count from 3 to 2\"); infinite_ramsey now genuinely proved."
     },
     "erdos-1168": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:20Z",
+      "lastAudited": "2026-07-22T11:55:10Z",
       "result": "clean"
     },
     "erdos-1168-oq-01": {

--- a/src/data/proofs/erdos-1162/meta.json
+++ b/src/data/proofs/erdos-1162/meta.json
@@ -152,7 +152,7 @@
       "summary": "Ledger of the formalization's assumptions: five auxiliary axioms (numSubgroups and f(1)–f(4)) were eliminated in favour of concrete definitions and native_decide, leaving the single deep axiom roney_dougal_tracey and zero sorries.",
       "startLine": 207,
       "endLine": 220,
-      "mathContext": "Remaining assumption: the published Roney-Dougal-Tracey (2025) asymptotic, encoded as $\\texttt{axiom roney\\_dougal\\_tracey}$. All small-case values $f(1),\\dots,f(4)$ are machine-checked via $\\texttt{native\\_decide}$ (hence rely on $\\texttt{Lean.ofReduceBool}$)."
+      "mathContext": "Remaining assumption: the published Roney-Dougal-Tracey (2025) asymptotic, encoded as $\\texttt{axiom roney\\_dougal\\_tracey}$. The small-case values $f(2),\\dots,f(4)$ are $\\textit{intended}$ to be discharged by $\\texttt{native\\_decide}$ (which would rely on $\\texttt{Lean.ofReduceBool}$), but the file is build-blocked (issue #39058): the $S_4$ subgroup-lattice enumeration is compile-infeasible, so these values are $\\textit{not}$ currently machine-checked. Only $f(1)$ is proved (Subsingleton→Unique)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Integrity fix

**Proof**: erdos-1162 (badge=axiom, status=axiomatized)

**Problem**: `sections[8].mathContext` stated *"All small-case values f(1),…,f(4) are machine-checked via native_decide"*, directly contradicting `meta.assumptions`, which discloses the file is **build-blocked (#39058)**: the S₄ subgroup-lattice enumeration is compile-infeasible, so f(2)–f(4) are **not** machine-checked and the entry is not verified end-to-end.

**Fix**: reworded mathContext to state f(2)–f(4) are *intended* to be discharged by native_decide but are not currently machine-checked due to the build block; only f(1) is proved.

Also confirms the prior phantom-decl issue (#41340, `numSubgroupsElem2`) is resolved by merged #41341 — all 8 originalContributions decls now exist; axiomCount=1 matches the single `axiom roney_dougal_tracey`; 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)