### PR TITLE
audit(tracker): platonic-solids-oq-02 re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23655,9 +23655,9 @@
       "result": "clean"
     },
     "platonic-solids-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:21Z",
+      "lastAudited": "2026-07-22T12:03:14Z",
       "result": "clean"
     },
     "platonic-solids-oq-02-oq-01": {


### PR DESCRIPTION
Re-verify of the Archimedean solids classification during gallery integrity audit (queue drained → round-robin oldest).

**Result: clean.** 22 theorems, 32 defs, 237 lines, 0 real sorries / 0 axiom decls. `status=axiomatized` / `badge=wip` correctly reflects the disclosed `True`-stub `archimedean_classification`. `native_decide` + `Lean.ofReduceBool` footprint disclosed in assumptions. `axiomCount:1` is a safe overcount (the True-stub placeholder). All originalContributions map to real declarations; angle-defect computations are non-vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)