### PR TITLE
Research: erdos-18-wip-01 — correct Erdős #18 index hErdos + re-homed conjectures (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos18WIP01.lean
+++ b/proofs/Proofs/Erdos18WIP01.lean
@@ -1387,4 +1387,121 @@ Erdős max-representation-length index (Vose `≪ √log m`) the prize concerns.
 theorem factorial_le_two_pow_h (n : ℕ) : n ! ≤ 2 ^ h (n !) :=
   le_two_pow_h (factorial_practical n)
 
+/- ## The corrected Erdős #18 index `hErdos` (max-representation-length)
+
+The parent `h m` is the **universal representing-set size** — the fewest divisors
+that jointly represent *every* `1 ≤ k < m`. `le_two_pow_h` / `factorial_le_two_pow_h`
+show it is superpolynomial on factorials (`m ≤ 2 ^ h m`), so it is *not* the quantity
+Erdős Problem #18 concerns. The prize index (Vose 1985, `≪ √(log m)` infinitely often)
+is the **worst-case fewest-divisors** count: for each `k` take the *minimum* number of
+divisors of `m` summing to `k`, then the *maximum* over `1 ≤ k < m`.
+
+This section supplies the correct definition and the elementary sandwich
+`1 ≤ hErdos m ≤ h m ≤ d(m)` for practical `m ≥ 2` — pinning the corrected index
+below the (over-counting) universal-set index — and re-homes the two prize
+conjectures onto `hErdos`. The deep upper bound (`hErdos(n!)` polynomially small,
+Vose/Erdős) is stated as a conjecture `Prop`, not proved here. -/
+
+/-- `repLength m k` — the fewest divisors of `m` whose distinct sum is `k`
+(`0` at `k = 0`, via the empty set). -/
+noncomputable def repLength (m k : ℕ) : ℕ :=
+  sInf { t : ℕ | ∃ T : Finset ℕ, T ⊆ divisors m ∧ T.card = t ∧ T.sum id = k }
+
+/-- `hErdos m` — the Erdős #18 index: the worst case, over `1 ≤ k < m`, of the
+fewest divisors of `m` needed to represent `k`, i.e. `max_{k < m} repLength m k`.
+This — not the universal-set `h` — is the quantity the prize conjectures concern. -/
+noncomputable def hErdos (m : ℕ) : ℕ :=
+  (Finset.range m).sup (fun k => repLength m k)
+
+/-- For practical `m` and `1 ≤ k < m` the minimum is attained: there is a divisor
+set of size exactly `repLength m k` summing to `k`. -/
+theorem repLength_spec {m k : ℕ} (hm : IsPractical m) (hk1 : 1 ≤ k) (hkm : k < m) :
+    ∃ T : Finset ℕ, T ⊆ divisors m ∧ T.card = repLength m k ∧ T.sum id = k := by
+  have hmem : repLength m k ∈ { t : ℕ | ∃ T : Finset ℕ, T ⊆ divisors m ∧
+      T.card = t ∧ T.sum id = k } := by
+    apply Nat.sInf_mem
+    obtain ⟨T, hTsub, hTsum⟩ := hm.2 k hk1 hkm
+    exact ⟨T.card, T, hTsub, rfl, hTsum⟩
+  exact hmem
+
+/-- **`repLength m k ≤ h m`** for `k < m`. The universal representing set of size
+`h m` already represents each individual `k`, so the per-`k` minimum never exceeds
+it. -/
+theorem repLength_le_h {m k : ℕ} (hm : IsPractical m) (hkm : k < m) :
+    repLength m k ≤ h m := by
+  have hne : { s : ℕ | ∃ S : Finset ℕ, S ⊆ divisors m ∧ S.card = s ∧
+      ∀ k, 1 ≤ k → k < m → ∃ T : Finset ℕ, T ⊆ S ∧ T.sum id = k }.Nonempty :=
+    ⟨(divisors m).card, divisors m, Finset.Subset.refl _, rfl,
+      fun k hk1 hkm => hm.2 k hk1 hkm⟩
+  obtain ⟨S, hSdvd, hScard, hScov⟩ := Nat.sInf_mem hne
+  have hScard' : S.card = h m := hScard
+  rcases Nat.eq_zero_or_pos k with h0 | hpos
+  · calc repLength m k ≤ 0 :=
+          Nat.sInf_le ⟨∅, Finset.empty_subset _, Finset.card_empty, by simp [h0]⟩
+      _ ≤ h m := Nat.zero_le _
+  · obtain ⟨T, hTS, hTsum⟩ := hScov k hpos hkm
+    calc repLength m k ≤ T.card :=
+          Nat.sInf_le ⟨T, hTS.trans hSdvd, rfl, hTsum⟩
+      _ ≤ S.card := Finset.card_le_card hTS
+      _ = h m := hScard'
+
+/-- **`hErdos m ≤ h m`** for practical `m`: the corrected index is dominated by the
+universal-set index — formal confirmation that the parent `h` over-counts. -/
+theorem hErdos_le_h {m : ℕ} (hm : IsPractical m) : hErdos m ≤ h m := by
+  unfold hErdos
+  apply Finset.sup_le
+  intro k hk
+  rw [Finset.mem_range] at hk
+  exact repLength_le_h hm hk
+
+/-- **`hErdos m ≤ d(m)`** for practical `m`, chaining `hErdos_le_h` with
+`h_le_card_divisors`. -/
+theorem hErdos_le_card_divisors {m : ℕ} (hm : IsPractical m) :
+    hErdos m ≤ (divisors m).card :=
+  (hErdos_le_h hm).trans (h_le_card_divisors hm)
+
+/-- Representing `1` needs at least one divisor (the empty set sums to `0`), so for
+`m ≥ 2` we have `1 ≤ repLength m 1`. -/
+theorem one_le_repLength_one {m : ℕ} (hm : 2 ≤ m) : 1 ≤ repLength m 1 := by
+  rcases Nat.eq_zero_or_pos (repLength m 1) with h0 | h1
+  · exfalso
+    have hmem : repLength m 1 ∈ { t : ℕ | ∃ T : Finset ℕ, T ⊆ divisors m ∧
+        T.card = t ∧ T.sum id = 1 } := by
+      apply Nat.sInf_mem
+      refine ⟨1, {1}, ?_, ?_, ?_⟩
+      · intro x hx
+        simp only [Finset.mem_singleton] at hx
+        subst hx
+        exact Nat.one_mem_divisors.mpr (by omega)
+      · simp
+      · simp
+    rw [h0] at hmem
+    obtain ⟨T, _, hTcard, hTsum⟩ := hmem
+    rw [Finset.card_eq_zero] at hTcard
+    subst hTcard
+    simp at hTsum
+  · exact h1
+
+/-- **`1 ≤ hErdos m`** for `m ≥ 2`: representing `k = 1` already costs one divisor. -/
+theorem one_le_hErdos {m : ℕ} (hm : 2 ≤ m) : 1 ≤ hErdos m := by
+  calc 1 ≤ repLength m 1 := one_le_repLength_one hm
+    _ ≤ hErdos m := by
+        unfold hErdos
+        exact Finset.le_sup (by rw [Finset.mem_range]; omega)
+
+/-- **Erdős #18, Part 2 ($250), corrected.** The prize question `h(n!) < n^{o(1)}`
+stated over the correct index `hErdos`. Contrast `conjecture_part2_weak`, which is
+*false* for the parent's universal-set `h` (`factorial_le_two_pow_h`). -/
+def conjecture_part2_weak_erdos : Prop :=
+  ∀ ε : ℝ, ε > 0 →
+    ∃ N : ℕ, ∀ n ≥ N, (hErdos n.factorial : ℝ) < n ^ ε
+
+/-- **Erdős #18, Part 1, corrected** — infinitely many practical `m` whose correct
+index `hErdos m` is doubly-logarithmically bounded. -/
+def conjecture_part1_erdos : Prop :=
+  ∃ C : ℝ, C > 0 ∧
+    Set.Infinite { m : ℕ | IsPractical m ∧
+      (hErdos m : ℝ) < (Real.log (Real.log m)) ^ C }
+
 end Erdos18
+

--- a/research/problems/erdos-18-wip-01/knowledge.md
+++ b/research/problems/erdos-18-wip-01/knowledge.md
@@ -213,3 +213,55 @@ conjectures.
 Practicality-membership theory (Stewart–Sierpiński iff, factorials, primorials,
 Euclid-form perfect numbers, `2^a·3^b`, `2^a·5^b`) is **saturated** — the live
 frontier is now the `h`-index formalization above, blocked on the mechanic def fix.
+
+## Session 2026-07-22 (researcher-1-3) — corrected Erdős #18 index `hErdos` + re-homed conjectures
+
+**Mode**: BUILD on the #41350 defect finding. **Outcome**: progress — 7 new
+axiom-free declarations in `Erdos18WIP01.lean` (`#print axioms` =
+propext/Classical.choice/Quot.sound for `hErdos_le_h`, `one_le_hErdos`,
+`hErdos_le_card_divisors`, `repLength_spec`; Docker-built, 8577 jobs, only
+pre-existing `push_neg` deprecation warnings at 547/841).
+
+#41350 showed the parent `h m` (universal representing-set size) is the *wrong*
+index for Erdős #18: `m ≤ 2^{h m}` makes it superpolynomial on factorials, whereas
+the prize quantity (Vose 1985, `≪ √log m` i.o.) is the worst-case *fewest*-divisors
+count. This session defines that correct index and pins it below the parent's:
+
+- `repLength m k := sInf { t | ∃ T ⊆ divisors m, |T| = t ∧ T.sum id = k }` — the
+  fewest divisors of `m` summing to `k` (`0` at `k=0`).
+- `hErdos m := (range m).sup (fun k => repLength m k)` — `max_{k<m} repLength m k`,
+  the Erdős #18 index.
+- `repLength_spec` — for practical `m`, `1≤k<m`, the min is attained (a divisor set
+  of size exactly `repLength m k` sums to `k`). Via `Nat.sInf_mem` on `hm.2 k`.
+- `repLength_le_h {k<m}` — the universal set of size `h m` represents each `k`
+  individually, so `repLength m k ≤ h m` (k=0 via ∅; else the covering `T⊆S`,
+  `Finset.card_le_card`). Mirrors the `le_two_pow_h` universal-set extraction.
+- **`hErdos_le_h`** (practical `m`) — `Finset.sup_le` over `repLength_le_h`. Formal
+  confirmation that the parent `h` *over-counts* the true index.
+- `hErdos_le_card_divisors` — chains with parent's `h_le_card_divisors` (d(m) bound).
+- `one_le_repLength_one` (`m≥2`) — `k=1` needs ≥1 divisor (∅ sums to 0; `{1}` is the
+  witness that the sInf set is nonempty and excludes 0).
+- **`one_le_hErdos`** (`m≥2`) — `Finset.le_sup` at `k=1`. Sandwich complete:
+  `1 ≤ hErdos m ≤ h m ≤ d(m)` for practical `m≥2`.
+- `conjecture_part2_weak_erdos` / `conjecture_part1_erdos` — the two prize
+  conjectures re-stated over `hErdos` (correct home; parent's `conjecture_part2_weak`
+  is *false* for the universal-set `h` by `factorial_le_two_pow_h`).
+
+**Honesty**: the deep direction — `hErdos(n!)` polynomially small (Vose/Erdős) — is
+NOT proved; it stays a conjecture `Prop`. This session supplies only the correct
+*definition* and the elementary sandwich; it does not resolve any part of #18.
+
+### Idiom notes (v4.31)
+- `repLength_spec` must route through membership: state it as `∃ T, …`, prove
+  `repLength m k ∈ {t | …}` by `apply Nat.sInf_mem` then `exact` the membership
+  (defeq to the ∃-goal). `apply Nat.sInf_mem` directly on an ∃-goal fails (unifies
+  against `sInf ?s ∈ ?s`, not the unfolded existential).
+- `hErdos` is a `Finset.sup` over `range m`; `Finset.sup_le` / `Finset.le_sup` after
+  `unfold hErdos`. Lower bound: pull out `k=1` with `Finset.le_sup (mem_range)`.
+
+### Still open (unchanged, deep) + remaining mechanic follow-up
+Parent `Erdos18Problem.lean` still names the universal-set index `h` and points
+`conjecture_part1/part2_weak/part2_strong` at it; `Erdos18OQ01.lean` subadditivity
+also depends on that `h`. Renaming the parent `h`→`hCover` and repointing the parent
+conjectures at `hErdos` is a mechanic edit across parent+OQ01 (behaviour-preserving).
+The deep `hErdos(n!) < n^{o(1)}` bound (Vose) remains unformalized.

--- a/src/data/research/problems/erdos-18-wip-01.json
+++ b/src/data/research/problems/erdos-18-wip-01.json
@@ -23,7 +23,7 @@
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
     "blockers": [],
-    "nextAction": "MECHANIC/AUDITOR follow-up: the parent Erdos18Problem.lean h (universal-set size) misformalizes the Erdos #18 prize quantity (max representation length); rename it (e.g. hCover) and define the correct h for conjecture_part1/part2_weak/part2_strong. Erdos18OQ01 subadditivity depends on the universal-set h. Practicality-membership theory (Stewart-Sierpinski iff, factorials, primorials, Euclid-form, 2^a3^b, 2^a5^b) is saturated.",
+    "nextAction": "The correct Erdos #18 index is now formalized in Erdos18WIP01.lean: repLength m k (fewest divisors of m summing to k) and hErdos m = max_{k<m} repLength m k, with the axiom-free sandwich 1 <= hErdos m <= h m <= d(m) for practical m>=2 (hErdos_le_h confirms the parent's universal-set h over-counts) and the prize conjectures re-homed onto hErdos (conjecture_part1_erdos, conjecture_part2_weak_erdos). RESIDUAL mechanic follow-up: rename the parent Erdos18Problem.lean h -> hCover and repoint its conjecture_part1/part2_weak/part2_strong (and the Erdos18OQ01 subadditivity) at hErdos. DEEP/open: hErdos(n!) < n^{o(1)} (Vose 1985, ~sqrt log m i.o.) unformalized. Practicality-membership theory saturated.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,


### PR DESCRIPTION
## erdos-18-wip-01 — the correct Erdős #18 index `hErdos`

Builds directly on the definition-defect finding in #41350: the parent
`Erdos18Problem.lean` `h m` is the **universal representing-set size** (fewest
divisors jointly representing *every* `1 ≤ k < m`). `le_two_pow_h` /
`factorial_le_two_pow_h` show `m ≤ 2^{h m}`, so it is superpolynomial on
factorials — hence *not* the quantity Erdős #18 concerns. The prize index (Vose
1985, `≪ √(log m)` infinitely often) is the **worst-case fewest-divisors** count.

This PR formalizes that correct index and pins it below the parent's (all
axiom-free, Docker-built, 8577 jobs):

| decl | statement |
|------|-----------|
| `repLength m k` | `sInf { t | ∃ T ⊆ divisors m, |T|=t ∧ T.sum id = k }` — fewest divisors of `m` summing to `k` |
| `hErdos m` | `(range m).sup (repLength m)` = `max_{k<m} repLength m k` — the Erdős #18 index |
| `repLength_spec` | for practical `m`, `1≤k<m`, the minimum is attained |
| `repLength_le_h` / `hErdos_le_h` | **`hErdos m ≤ h m`** — the parent index over-counts |
| `hErdos_le_card_divisors` | chains to the `d(m)` bound |
| `one_le_repLength_one` / `one_le_hErdos` | `1 ≤ hErdos m` for `m ≥ 2` |
| `conjecture_part1_erdos` / `conjecture_part2_weak_erdos` | the two prize conjectures re-homed onto the correct index |

Net: the axiom-free sandwich **`1 ≤ hErdos m ≤ h m ≤ d(m)`** for practical `m ≥ 2`,
and a well-defined home for the conjectures (the parent's `conjecture_part2_weak`
is *false* for the universal-set `h` by `factorial_le_two_pow_h`).

### Honesty
The deep direction — `hErdos(n!)` polynomially small (Vose/Erdős) — is **not**
proved; it remains a conjecture `Prop`. This PR supplies only the correct
*definition* and elementary bounds; it does not resolve any part of #18.

`#print axioms` for `hErdos_le_h`, `one_le_hErdos`, `hErdos_le_card_divisors`,
`repLength_spec` = `[propext, Classical.choice, Quot.sound]` — no `sorry`, no
`native_decide`.

### Residual mechanic follow-up (not in this PR)
Rename the parent `Erdos18Problem.lean` `h`→`hCover` and repoint its
`conjecture_part1/part2_weak/part2_strong` (and `Erdos18OQ01` subadditivity,
which is correct for the universal-set `h`) at `hErdos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
