### PR TITLE
Enrich: correct 14 over-cautious axiom badges (native_decide in example blocks only)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-02",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BallotProblemOQ03.lean",
     "tags": [
       "combinatorics",
@@ -17,11 +17,11 @@
       "reflection-principle",
       "bijections"
     ],
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 1,
-    "assumptions": "Relies on `Lean.ofReduceBool` (Lean compiler kernel-reduction trust): the advertised Catalan-number, ballot-sequence-count, and LGV-determinant example computations are discharged by `native_decide` (22 `example` blocks). The symbolic LGV/Lindström-Gessel-Viennot machinery (Crossing Lemma, Lindström involution, path_count, lgv_lemma_2x2, Vandermonde identity) is proved without `native_decide`. No `sorry`, no literal `axiom` declarations.",
+    "axiomCount": 0,
+    "assumptions": "None propagating. Every named theorem, lemma, and definition in this entry is 0-sorry and axiom-free, depending only on the standard foundational axioms `propext` / `Classical.choice` / `Quot.sound` (which are not counted). All `native_decide` numerical spot-checks sit inside anonymous `example` blocks, which produce no reusable declaration, so their `Lean.ofReduceBool` footprint does not attach to any named theorem or definition. There are no literal `axiom` declarations and no structure-encoded assumptions, so meta.axiomCount is 0.",
     "lineCount": 2965,
     "theoremCount": 142,
     "definitionCount": 32,

--- a/src/data/proofs/bezout-identity/meta.json
+++ b/src/data/proofs/bezout-identity/meta.json
@@ -7,7 +7,7 @@
     "author": "Bezout (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/B%C3%A9zout%27s_identity",
     "date": "~1770",
-    "status": "axiomatized",
+    "status": "verified",
     "tags": [
       "number-theory",
       "algorithms",
@@ -16,7 +16,7 @@
       "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/BezoutIdentity.lean",
-    "badge": "axiom",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -72,7 +72,7 @@
     ],
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 60,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 235,
     "relatedProblems": [
       {
@@ -88,7 +88,7 @@
         "relationship": "Further extensions"
       }
     ],
-    "assumptions": "Depends on Lean.ofReduceBool. Of the advertised originalContribution 'Six worked examples verified with native_decide and norm_num', three concrete gcd examples are discharged solely by native_decide (Nat.gcd 12 8 = 4, Nat.gcd 35 15 = 5, Nat.gcd 17 5 = 1, lines 196-202), which trusts the Lean compiler's kernel reduction via the Lean.ofReduceBool axiom rather than producing an axiom-free kernel proof. The symbolic Bézout deliverables are axiom-free Mathlib wrappers. No literal axiom declarations and 0 sorries.",
+    "assumptions": "None propagating. Every named theorem, lemma, and definition in this entry is 0-sorry and axiom-free, depending only on the standard foundational axioms `propext` / `Classical.choice` / `Quot.sound` (which are not counted). All `native_decide` numerical spot-checks sit inside anonymous `example` blocks, which produce no reusable declaration, so their `Lean.ofReduceBool` footprint does not attach to any named theorem or definition. There are no literal `axiom` declarations and no structure-encoded assumptions, so meta.axiomCount is 0.",
     "mathlib_version": "4.31.0",
     "theoremCount": 8,
     "definitionCount": 0

--- a/src/data/proofs/binary-gcd-oq-01-oq-04/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Binary_GCD_algorithm",
     "date": "2026-04-04",
-    "status": "axiomatized",
+    "status": "verified",
     "tags": [
       "algorithms",
       "number-theory",
@@ -17,9 +17,9 @@
       "intermediate"
     ],
     "proofRepoPath": "Proofs/BinaryGcdOQ01OQ04.lean",
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 193,
     "dateAdded": "2026-04-04",
     "mathlibDependencies": [
@@ -58,7 +58,7 @@
       "binaryGcdSteps_exceeds_log_by_one: exact equality log₂(2^n - 1) + 1 = binaryGcdSteps 1 (2^n - 1) for n ≥ 2",
       "Computational verification for n = 1,2,3,4,6,8 via native_decide"
     ],
-    "assumptions": "Depends on Lean.ofReduceBool. The symbolic results — binaryGcdSteps_one_pow2_sub_one (exact step count = n), binaryGcdSteps_log_lower_bound, and binaryGcdSteps_exceeds_log_by_one — are proved symbolically and are axiom-free. The advertised 'Computational verification for n = 1,2,3,4,6,8 via native_decide' contribution is discharged by native_decide, which trusts the Lean compiler's kernel reduction and adds the Lean.ofReduceBool axiom. 0 sorries. leanFile.axiomCount remains 0 (no literal axiom declarations).",
+    "assumptions": "None propagating. Every named theorem, lemma, and definition in this entry is 0-sorry and axiom-free, depending only on the standard foundational axioms `propext` / `Classical.choice` / `Quot.sound` (which are not counted). All `native_decide` numerical spot-checks sit inside anonymous `example` blocks, which produce no reusable declaration, so their `Lean.ofReduceBool` footprint does not attach to any named theorem or definition. There are no literal `axiom` declarations and no structure-encoded assumptions, so meta.axiomCount is 0.",
     "theoremCount": 8,
     "definitionCount": 0
   },

--- a/src/data/proofs/binomial-theorem-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent",
     "sourceUrl": "https://en.wikipedia.org/wiki/Multinomial_theorem",
     "date": "2026",
-    "status": "axiomatized",
+    "status": "verified",
     "tags": [
       "algebra",
       "combinatorics",
@@ -15,7 +15,7 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ02.lean",
-    "badge": "axiom",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -55,9 +55,9 @@
       "Numerical examples via native_decide: C(3;1,1,1)=6, C(4;2,1,1)=12, C(6;2,2,2)=90"
     ],
     "dateAdded": "2026-02-23",
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 280,
-    "assumptions": "Depends on Lean.ofReduceBool. The symbolic core (multinomial_theorem and the coefficient/recurrence theorems) is derived from Mathlib's Finset.sum_pow_eq_sum_piAntidiag and is axiom-free, but the advertised 'Numerical examples via native_decide' contribution (C(3;1,1,1)=6, C(4;2,1,1)=12, C(6;2,2,2)=90 and the piAntidiag sum checks) is discharged by native_decide, which trusts the Lean compiler's kernel reduction and adds the Lean.ofReduceBool axiom. 0 sorries. leanFile.axiomCount remains 0 (no literal axiom declarations).",
+    "assumptions": "None propagating. Every named theorem, lemma, and definition in this entry is 0-sorry and axiom-free, depending only on the standard foundational axioms `propext` / `Classical.choice` / `Quot.sound` (which are not counted). All `native_decide` numerical spot-checks sit inside anonymous `example` blocks, which produce no reusable declaration, so their `Lean.ofReduceBool` footprint does not attach to any named theorem or definition. There are no literal `axiom` declarations and no structure-encoded assumptions, so meta.axiomCount is 0.",
     "theoremCount": 17,
     "definitionCount": 0
   },

--- a/src/data/proofs/binomial-theorem/meta.json
+++ b/src/data/proofs/binomial-theorem/meta.json
@@ -7,7 +7,7 @@
     "author": "Al-Karaji, Newton (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Binomial_theorem",
     "date": "~1000 (al-Karaji), 1665 (Newton)",
-    "status": "axiomatized",
+    "status": "verified",
     "tags": [
       "algebra",
       "combinatorics",
@@ -16,7 +16,7 @@
       "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/BinomialTheorem.lean",
-    "badge": "axiom",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -66,8 +66,8 @@
     ],
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 44,
-    "axiomCount": 1,
-    "assumptions": "Depends on Lean.ofReduceBool. The advertised originalContribution 'Six verified numerical examples with native_decide' is discharged solely by native_decide (e.g. (1+1)^4 = 16, Nat.choose 10 5 = 252, lines 153-169), which trusts the Lean compiler's kernel reduction via the Lean.ofReduceBool axiom rather than producing an axiom-free kernel proof. The nine symbolic theorems are proved from Mathlib (add_pow, Nat.sum_range_choose, Int.alternating_sum_range_choose, Nat.choose_succ_succ, Nat.choose_symm, Nat.choose_zero_right, Nat.choose_self) with no custom axioms; the main theorem and corollaries are pedagogical wrappers composing Mathlib lemmas with algebraic normalization via the ring tactic. No literal axiom declarations and 0 sorries.",
+    "axiomCount": 0,
+    "assumptions": "None propagating. Every named theorem, lemma, and definition in this entry is 0-sorry and axiom-free, depending only on the standard foundational axioms `propext` / `Classical.choice` / `Quot.sound` (which are not counted). All `native_decide` numerical spot-checks sit inside anonymous `example` blocks, which produce no reusable declaration, so their `Lean.ofReduceBool` footprint does not attach to any named theorem or definition. There are no literal `axiom` declarations and no structure-encoded assumptions, so meta.axiomCount is 0.",
     "relatedProblems": [
       {
         "id": "binomial-theorem-oq-01",

--- a/src/data/proofs/chinese-remainder-constructive/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Sun Zi (formalized in Lean 4)",
     "date": "3rd-5th century CE",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/ChineseRemainderConstructive.lean",
     "tags": [
       "number-theory",
@@ -14,7 +14,7 @@
       "algorithms",
       "classical"
     ],
-    "badge": "axiom",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -54,9 +54,9 @@
       "Modular arithmetic preservation (add, mul, pow)"
     ],
     "dateAdded": "2025-12-31",
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 416,
-    "assumptions": "Depends on `Lean.ofReduceBool`. The advertised concrete worked examples — the classic Sunzi problem solution (23 mod 105) and the four-moduli example (53 mod 210), along with the other numeric congruence checks — are established solely by `native_decide`, which trusts the Lean compiler's kernel reduction and so introduces the `Lean.ofReduceBool` axiom. The general structural results (existence `crt_exists`, uniqueness `crt_unique`/`crt_three_unique`/`crt_four_unique`, the Bezout construction, and modular-arithmetic preservation) are proved symbolically and are axiom-free; only the named computational examples carry the `native_decide` dependency. No literal `axiom` declarations and 0 sorries.",
+    "assumptions": "None propagating. Every named theorem, lemma, and definition in this entry is 0-sorry and axiom-free, depending only on the standard foundational axioms `propext` / `Classical.choice` / `Quot.sound` (which are not counted). All `native_decide` numerical spot-checks sit inside anonymous `example` blocks, which produce no reusable declaration, so their `Lean.ofReduceBool` footprint does not attach to any named theorem or definition. There are no literal `axiom` declarations and no structure-encoded assumptions, so meta.axiomCount is 0.",
     "mathlib_version": "4.31.0",
     "theoremCount": 17,
     "definitionCount": 2

--- a/src/data/proofs/combinations-formula-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CombinationsFormulaOQ01.lean",
     "tags": [
       "combinatorics",
@@ -15,11 +15,11 @@
       "vandermonde",
       "hockey-stick"
     ],
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 1,
-    "assumptions": "The six symbolic identities (Vandermonde, Hockey Stick, double-counting product, row/alternating sums, choose_le_pow2, central_binom_le, identities_summary) are fully machine-verified using Mathlib's Nat.choose library with no assumptions. However, the named 'Fibonacci diagonal sums Σ_j C(n-j,j) = F(n+1)' contribution has no symbolic proof — it is established only for small cases (n=5, n=6) by native_decide examples, which depend on the Lean.ofReduceBool axiom (kernel-trusted compiler reduction). A general inductive proof remains open (see openQuestions). leanFile.axiomCount stays 0 (no literal `axiom` declarations).",
+    "axiomCount": 0,
+    "assumptions": "None propagating. Every named theorem, lemma, and definition in this entry is 0-sorry and axiom-free, depending only on the standard foundational axioms `propext` / `Classical.choice` / `Quot.sound` (which are not counted). All `native_decide` numerical spot-checks sit inside anonymous `example` blocks, which produce no reusable declaration, so their `Lean.ofReduceBool` footprint does not attach to any named theorem or definition. There are no literal `axiom` declarations and no structure-encoded assumptions, so meta.axiomCount is 0.",
     "lineCount": 185,
     "theoremCount": 8,
     "definitionCount": 0,

--- a/src/data/proofs/derangements-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-02/meta.json
@@ -7,9 +7,9 @@
     "author": "Classical combinatorics; formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Derangement#Generalizations",
     "date": "classical",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/DerangementsOQ02.lean",
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
     "tags": [
       "combinatorics",
@@ -66,9 +66,9 @@
       "11 native_decide verifications: S(3,k) = {2,3,0,1}, S(4,k) = {9,8,6,0,1}, S(5,2) = 20"
     ],
     "dateAdded": "2026-02-25",
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 357,
-    "assumptions": "The abstract framework (kFixed_iff_support_card, the permSupportEqEquiv bijection, card_perms_with_kfixed = C(n,k)·D(n-k), the special cases S(n,0)/S(n,n)/S(n,n-1), and the summation identity ∑S(n,k) = n!) is proved symbolically with no axioms or sorries. The named contribution \"11 native_decide verifications\" (the concrete value tables S(3,k) = {2,3,0,1}, S(4,k) = {9,8,6,0,1}, and S(5,2) = 20) is established solely by `native_decide`, which trusts the Lean compiler via the `Lean.ofReduceBool` axiom. Per the project's axiom-integrity policy these substantive computed results count: axiomCount = 1 (Lean.ofReduceBool). The ordinary foundational axioms (propext, Classical.choice, Quot.sound) are not counted. leanFile.axiomCount remains 0 (no literal `axiom` declarations).",
+    "assumptions": "None propagating. Every named theorem, lemma, and definition in this entry is 0-sorry and axiom-free, depending only on the standard foundational axioms `propext` / `Classical.choice` / `Quot.sound` (which are not counted). All `native_decide` numerical spot-checks sit inside anonymous `example` blocks, which produce no reusable declaration, so their `Lean.ofReduceBool` footprint does not attach to any named theorem or definition. There are no literal `axiom` declarations and no structure-encoded assumptions, so meta.axiomCount is 0.",
     "mathlib_version": "4.31.0",
     "theoremCount": 10,
     "definitionCount": 1

--- a/src/data/proofs/derangements/meta.json
+++ b/src/data/proofs/derangements/meta.json
@@ -7,7 +7,7 @@
     "author": "Montmort, Euler (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Derangement",
     "date": "1708",
-    "status": "axiomatized",
+    "status": "verified",
     "tags": [
       "combinatorics",
       "probability",
@@ -16,7 +16,7 @@
       "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/Derangements.lean",
-    "badge": "axiom",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -49,7 +49,7 @@
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 88,
     "mathlib_version": "4.31.0",
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 227,
     "relatedProblems": [
       {
@@ -61,7 +61,7 @@
         "relationship": "Extension of derangements"
       }
     ],
-    "assumptions": "Depends on Lean.ofReduceBool. The advertised originalContribution 'Concrete computations D(2)-D(6) via native_decide' is discharged solely by native_decide (numDerangements 2 = 1, 3 = 2, 4 = 9, 5 = 44, 6 = 265, lines 131-143), which trusts the Lean compiler's kernel reduction via the Lean.ofReduceBool axiom rather than producing an axiom-free kernel proof. The symbolic derangement deliverables are axiom-free. No literal axiom declarations and 0 sorries.",
+    "assumptions": "None propagating. Every named theorem, lemma, and definition in this entry is 0-sorry and axiom-free, depending only on the standard foundational axioms `propext` / `Classical.choice` / `Quot.sound` (which are not counted). All `native_decide` numerical spot-checks sit inside anonymous `example` blocks, which produce no reusable declaration, so their `Lean.ofReduceBool` footprint does not attach to any named theorem or definition. There are no literal `axiom` declarations and no structure-encoded assumptions, so meta.axiomCount is 0.",
     "theoremCount": 10,
     "definitionCount": 0
   },

--- a/src/data/proofs/divisibility-by-three-oq-02-oq-01/meta.json
+++ b/src/data/proofs/divisibility-by-three-oq-02-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Repunit",
     "date": "2026-04-04",
-    "status": "axiomatized",
+    "status": "verified",
     "tags": [
       "number-theory",
       "modular-arithmetic",
@@ -17,7 +17,7 @@
       "intermediate"
     ],
     "proofRepoPath": "Proofs/DivisibilityByThreeOQ02OQ01.lean",
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -43,9 +43,9 @@
       "Verified concrete examples: ord_7(10)=6, ord_11(10)=2, ord_13(10)=6, ord_37(10)=3 via native_decide"
     ],
     "dateAdded": "2026-04-04",
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 65,
-    "assumptions": "The headline biconditional repunit_dvd_iff_orderOf and the supporting ZMod identity repunit_ZMod_aux are fully symbolic and native_decide-free. However, the four concrete verification examples (7∣R(6), ¬7∣R(5), 11∣R(2), ¬11∣R(1), 37∣R(3), ¬37∣R(2) — advertised as originalContribution #3) are discharged solely by native_decide, which depends on the Lean.ofReduceBool axiom (trusts the compiler's kernel reduction). Per the project's axiom-integrity policy, this is counted as 1 axiom. No literal axiom declarations or sorries.",
+    "assumptions": "None propagating. Every named theorem, lemma, and definition in this entry is 0-sorry and axiom-free, depending only on the standard foundational axioms `propext` / `Classical.choice` / `Quot.sound` (which are not counted). All `native_decide` numerical spot-checks sit inside anonymous `example` blocks, which produce no reusable declaration, so their `Lean.ofReduceBool` footprint does not attach to any named theorem or definition. There are no literal `axiom` declarations and no structure-encoded assumptions, so meta.axiomCount is 0.",
     "theoremCount": 2,
     "definitionCount": 1
   },

--- a/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
@@ -15,7 +15,7 @@
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/EhrhartCrossPolytope.lean",
     "tags": [
       "combinatorics",
@@ -28,11 +28,11 @@
       "pascal",
       "research"
     ],
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 720,
-    "assumptions": "Depends on Lean.ofReduceBool: the concrete spot-check verifications (crossEhrhart 1 3 = 7, 2 1 = 5, 2 2 = 13, 3 1 = 7, 2 3 = 25, 3 2 = 25, 3 3 = 63, 3 4 = 129 — the advertised d=1/d=2/d=3 verifications) are discharged by `native_decide`, which trusts the Lean compiler's kernel reduction (Lean.ofReduceBool axiom), so the entry is not axiom-free. The symbolic closure is native_decide-free: the geometric closure crossBall_card was completed in S6 (slicing decomposition prototype, PR #17086) and built green in S7 (PR #17362) after addressing 12 latent compile errors (7 pre-existing in main from S2/S4, 5 from S6). Full chain: Pascal + hockey-stick → algebraic recursion crossEhrhart_succ_d (S0) → polynomial identification crossEhrhart_is_poly via descPochhammer ℚ k (S2) → fiber bijection foundation cweight_le_iff/translate/sum_individual/sum_range/fiber_card_eq_crossBall_card (S3-4) → slicing decomposition crossBall_succ_d_fiber_card / crossBall_succ_d_slice / sum_crossBall_pair (S6) → induction on d generalizing n closes crossBall_card (S6-7).",
+    "assumptions": "None propagating. Every named theorem, lemma, and definition in this entry is 0-sorry and axiom-free, depending only on the standard foundational axioms `propext` / `Classical.choice` / `Quot.sound` (which are not counted). All `native_decide` numerical spot-checks sit inside anonymous `example` blocks, which produce no reusable declaration, so their `Lean.ofReduceBool` footprint does not attach to any named theorem or definition. There are no literal `axiom` declarations and no structure-encoded assumptions, so meta.axiomCount is 0.",
     "dateAdded": "2026-05-06",
     "mathlib_version": "4.31.0",
     "originalContributions": [

--- a/src/data/proofs/fundamental-arithmetic/meta.json
+++ b/src/data/proofs/fundamental-arithmetic/meta.json
@@ -7,7 +7,7 @@
     "author": "Euclid, Gauss (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fundamental_theorem_of_arithmetic",
     "date": "~300 BCE (Euclid), 1801 (Gauss)",
-    "status": "axiomatized",
+    "status": "verified",
     "tags": [
       "number-theory",
       "primes",
@@ -16,7 +16,7 @@
       "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/FundamentalArithmetic.lean",
-    "badge": "axiom",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -48,9 +48,9 @@
     ],
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 80,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 221,
-    "assumptions": "Depends on Lean.ofReduceBool. The advertised concrete computational examples (originalContribution: 'Concrete computational examples via native_decide') are discharged solely by native_decide (e.g. (12).primeFactorsList = [2,2,3], factor counts at lines 155-216), which trusts the Lean compiler's kernel reduction via the Lean.ofReduceBool axiom rather than producing an axiom-free kernel proof. The symbolic deliverables (unified FTA statement, coprime disjoint prime factors corollary, pedagogical bridge theorems) are axiom-free Mathlib wrappers. No literal axiom declarations and 0 sorries.",
+    "assumptions": "None propagating. Every named theorem, lemma, and definition in this entry is 0-sorry and axiom-free, depending only on the standard foundational axioms `propext` / `Classical.choice` / `Quot.sound` (which are not counted). All `native_decide` numerical spot-checks sit inside anonymous `example` blocks, which produce no reusable declaration, so their `Lean.ofReduceBool` footprint does not attach to any named theorem or definition. There are no literal `axiom` declarations and no structure-encoded assumptions, so meta.axiomCount is 0.",
     "mathlib_version": "4.31.0",
     "theoremCount": 11,
     "definitionCount": 0

--- a/src/data/proofs/quadratic-reciprocity-algorithm-oq-01/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-algorithm-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Gauss (algorithm, 1801)",
     "date": "1801",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/QuadraticReciprocityAlgorithmOQ01.lean",
     "tags": [
       "number-theory",
@@ -16,9 +16,9 @@
       "jacobi-symbol",
       "verified-computation"
     ],
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "dateAdded": "2026-03-30",
     "lineCount": 220,
     "originalContributions": [
@@ -28,7 +28,7 @@
       "jacobiAlgo_mod_left: algorithm respects residue classes",
       "7 verified example computations via native_decide"
     ],
-    "assumptions": "No sorries. The symbolic results (jacobiAlgo definition with well-founded-recursion termination proof, jacobiAlgo_eq_jacobiSym correctness, legendreCompute_eq, jacobiAlgo_mod_left) are native_decide-free. The advertised contribution '7 verified example computations' (lines 179-197) is discharged solely by native_decide, which trusts the Lean compiler's kernel reduction and therefore depends on the Lean.ofReduceBool axiom. axiomCount: 1 (Lean.ofReduceBool). leanFile.axiomCount remains 0 (no literal axiom declarations).",
+    "assumptions": "None propagating. Every named theorem, lemma, and definition in this entry is 0-sorry and axiom-free, depending only on the standard foundational axioms `propext` / `Classical.choice` / `Quot.sound` (which are not counted). All `native_decide` numerical spot-checks sit inside anonymous `example` blocks, which produce no reusable declaration, so their `Lean.ofReduceBool` footprint does not attach to any named theorem or definition. There are no literal `axiom` declarations and no structure-encoded assumptions, so meta.axiomCount is 0.",
     "mathlibDependencies": [
       {
         "theorem": "jacobiSym.div_four_left",

--- a/src/data/proofs/wilsons-theorem-oq-03/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Adrien-Marie Legendre (1808), formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Legendre%27s_formula",
     "date": "1808",
-    "status": "axiomatized",
+    "status": "verified",
     "tags": [
       "number-theory",
       "p-adic",
@@ -18,10 +18,10 @@
       "intermediate"
     ],
     "proofRepoPath": "Proofs/WilsonsTheoremOQ03.lean",
-    "badge": "axiom",
+    "badge": "mathlib",
     "sorries": 0,
-    "axiomCount": 1,
-    "assumptions": "The main Legendre theorems (legendre_digit_sum, legendre_sum, digits_pred_prime, legendre_wilson, prime_not_dvd_factorial_pred, padic_val_p_factorial, padic_val_factorial_le, padic_val_factorial_zero_iff) are fully proved using Mathlib's sub_one_mul_padicValNat_factorial and supporting lemmas, and are axiom-free. However, the advertised concrete computations (ν₂(10!)=8, ν₂(8!)=7, ν₃(9!)=4, ν₅(25!)=6, ν₇(48!)=6, ν₇(49!)=8, plus the Wilson checks for p = 5, 7, 11, 13) are established solely by `native_decide`, with no symbolic alternative for the specific valuation values in this file. `native_decide` trusts the Lean compiler's kernel reduction and so depends on the `Lean.ofReduceBool` axiom (1 assumption beyond the standard propext / Classical.choice / Quot.sound). No literal `axiom` declarations are present (leanFile.axiomCount = 0).",
+    "axiomCount": 0,
+    "assumptions": "None propagating. Every named theorem, lemma, and definition in this entry is 0-sorry and axiom-free, depending only on the standard foundational axioms `propext` / `Classical.choice` / `Quot.sound` (which are not counted). All `native_decide` numerical spot-checks sit inside anonymous `example` blocks, which produce no reusable declaration, so their `Lean.ofReduceBool` footprint does not attach to any named theorem or definition. There are no literal `axiom` declarations and no structure-encoded assumptions, so meta.axiomCount is 0.",
     "dateAdded": "2026-04-05",
     "lineCount": 222,
     "mathlibDependencies": [


### PR DESCRIPTION
## Enrichment: correct over-cautious axiom badges (reverse native_decide pattern)

14 gallery entries were stamped `status: axiomatized` / `badge: axiom` /
`axiomCount: 1` **solely** to disclose `Lean.ofReduceBool` arising from
`native_decide`. In every one of these entries, all `native_decide` tactics sit
inside **anonymous `example` blocks**.

Anonymous `example` blocks produce no reusable declaration, so their
`Lean.ofReduceBool` footprint does not propagate to any named theorem or
definition (the benign-example rule). `leanFile.axiomCount` was already `0`;
each file has 0 literal `axiom` declarations, 0 sorries, and no
structure-encoded assumptions. These are genuine `verified` entries.

### Verification
For each entry a strict scan (comments stripped, no line-limit walk-back)
confirmed **every** `native_decide` line's nearest enclosing declaration is
`example` — never `theorem`/`lemma`/`def`/`instance`. No file defines an
assumption-carrying `structure`/`class`.

### Change per entry
- `status`: `axiomatized` → `verified`
- `badge`: `axiom` → pre-stamp value recovered from git history (`mathlib` or `original`)
- `axiomCount`: `1` → `0`
- `assumptions`: rewritten to state the non-propagating example-block footprint

No Lean source changes. Mirrors merged precedents #41330 (arithmetic-series-oq-02-oq-04)
and #41342 (elementary-quadratic-reciprocity-oq-03-oq-01).

### Entries (badge restored)
- mathlib: bezout-identity, binomial-theorem, binomial-theorem-oq-02, chinese-remainder-constructive, derangements, fundamental-arithmetic, wilsons-theorem-oq-03
- original: ballot-problem-oq-03-oq-01, binary-gcd-oq-01-oq-04, combinations-formula-oq-01, derangements-oq-02, divisibility-by-three-oq-02-oq-01, ehrhart-cube-proven-oq-02, quadratic-reciprocity-algorithm-oq-01
