### PR TITLE
audit(tracker): fair-games-theorem-oq-02 re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -18524,9 +18524,9 @@
       "result": "clean"
     },
     "fair-games-theorem-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:21Z",
+      "lastAudited": "2026-07-22T12:11:21Z",
       "result": "clean"
     },
     "fair-games-theorem-oq-02-oq-01": {


### PR DESCRIPTION
Reserve-mode re-audit. All 9 theorems genuine concrete examples of Gambler's Ruin (P=k/N, E[T]=k(N-k)) and doubling strategy (E[gain]=0), proven with induction/omega/nlinarith/norm_num. 0 sorries, 0 axioms, 0 True stubs, 0 native_decide. Parent-file dependency honestly disclosed. Counts match meta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)