### PR TITLE
audit(tracker): descartes-rule-of-signs-oq-04 re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7473,9 +7473,9 @@
       "result": "clean"
     },
     "descartes-rule-of-signs-oq-04": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:21Z",
+      "lastAudited": "2026-07-22T12:17:47Z",
       "result": "clean"
     },
     "det-conjugate-transpose-oq-01": {


### PR DESCRIPTION
Reserve-mode re-serve. verified/mathlib/0ax/0 sorries confirmed against source; headline theorem non-vacuous. Clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)