### PR TITLE
Research: erdos-85-wip-01 — degenerate small values f(1)=1, f(2)=2, f(3)=3 (axiom-free)

### DIFF
--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -334,13 +334,17 @@ theorem minDegreeForC4_eq_self_of_le_three {n : ℕ} (h1 : 1 ≤ n) (h3 : n ≤ 
   have hup : ∀ (G : SimpleGraph (Fin n)) [DecidableRel G.Adj],
       G.minDegree ≤ n - 1 := by
     intro G _
-    refine le_trans (G.minDegree_le_degree ⟨0, by omega⟩) ?_
+    set v0 : Fin n := ⟨0, by omega⟩ with hv0
+    refine le_trans (G.minDegree_le_degree v0) ?_
     rw [← G.card_neighborFinset_eq_degree]
-    refine le_trans (Finset.card_le_card ?_) ?_
-    · intro x hx
+    have hsub : G.neighborFinset v0 ⊆ Finset.univ.erase v0 := by
+      intro x hx
       exact Finset.mem_erase.mpr
         ⟨(G.ne_of_adj ((G.mem_neighborFinset _ _).mp hx)).symm, Finset.mem_univ x⟩
-    · rw [Finset.card_erase_of_mem (Finset.mem_univ _), Finset.card_univ, Fintype.card_fin]
+    calc (G.neighborFinset v0).card
+        ≤ (Finset.univ.erase v0).card := Finset.card_le_card hsub
+      _ = n - 1 := by
+          rw [Finset.card_erase_of_mem (Finset.mem_univ _), Finset.card_univ, Fintype.card_fin]
   -- The complete graph attains minimum degree `n − 1`.
   have htop : n - 1 ≤ (⊤ : SimpleGraph (Fin n)).minDegree := by
     apply le_minDegree_of_forall_le_degree
@@ -353,12 +357,18 @@ theorem minDegreeForC4_eq_self_of_le_three {n : ℕ} (h1 : 1 ≤ n) (h3 : n ≤ 
   -- Assemble via antisymmetry on the defining `sInf`.
   unfold minDegreeForC4
   apply le_antisymm
-  · exact Nat.sInf_le (fun G _ hmin => absurd (le_trans hmin (hup G)) (by omega))
-  · apply le_csInf ⟨n, fun G _ hmin => absurd (le_trans hmin (hup G)) (by omega)⟩
-    intro k hk
-    by_contra hlt
-    push_neg at hlt
-    exact hfree _ (hk _ (le_trans (show k ≤ n - 1 by omega) htop))
+  · apply Nat.sInf_le
+    intro G _ hmin
+    exact absurd (le_trans hmin (hup G)) (by omega)
+  · apply le_csInf
+    · refine ⟨n, ?_⟩
+      intro G _ hmin
+      exact absurd (le_trans hmin (hup G)) (by omega)
+    · intro k hk
+      by_contra hlt
+      rw [not_le] at hlt
+      exact hfree (⊤ : SimpleGraph (Fin n))
+        (hk (⊤ : SimpleGraph (Fin n)) (le_trans (show k ≤ n - 1 by omega) htop))
 
 /-- **The star has minimum degree at least `1`.**  In `K_{1,n}` on `Fin (n+1)` the
 centre `0` is adjacent to every leaf and each leaf is adjacent to the centre, so

--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -224,6 +224,15 @@ theorem containsC4_four_le_card {V : Type*} [Fintype V] {G : SimpleGraph V}
   obtain ⟨f, hinj, _⟩ := h
   simpa using Fintype.card_le_of_injective f hinj
 
+/-- **No `C₄` below four vertices.**  The contrapositive of
+`containsC4_four_le_card`: a host graph on fewer than four vertices cannot carry a
+4-cycle, because `containsC4` supplies an injection `Fin 4 ↪ V`.  This is the
+degenerate boundary of the whole degree-threshold question — for `n < 4` the
+predicate "forces a `C₄`" can only hold vacuously. -/
+theorem not_containsC4_of_card_lt_four {V : Type*} [Fintype V] {G : SimpleGraph V}
+    (h : Fintype.card V < 4) : ¬ containsC4 V G :=
+  fun hc => absurd (containsC4_four_le_card hc) (by omega)
+
 /-- **Complete graphs on `≥ 4` vertices contain a `C₄`.**  Embed `Fin 4 ↪ Fin n`
 by `Fin.castLE`; every cycle edge joins two *distinct* vertices, and in `⊤` all
 distinct vertices are adjacent.  This is the extremal counterpart to
@@ -301,6 +310,55 @@ theorem minDegreeForC4_le_sub_one {n : ℕ} (hn : 4 ≤ n) :
   intro G _ hmin
   rw [eq_top_of_minDegree_ge G hmin]
   exact completeGraph_containsC4 hn
+
+/-- **Degenerate small cases: `f(n) = n` for `1 ≤ n ≤ 3`.**  When `n < 4` *no*
+graph on `Fin n` can contain a `C₄` at all (`not_containsC4_of_card_lt_four`), so
+the defining threshold "minimum degree `≥ k` forces a `C₄`" holds only *vacuously*
+— precisely for those `k` no graph attains.  The largest minimum degree attainable
+on `Fin n` is `n − 1` (realised by the complete graph `⊤`, and never exceeded since
+`deg v ≤ n − 1`), so the least `k` with no graph reaching it is `k = n`.  Hence
+`f(1) = 1`, `f(2) = 2`, `f(3) = 3`, completing the exact-value table below the first
+genuine case `f(4) = 2`.  (These are boundary values where a 4-cycle is impossible,
+not evidence about the `√n` growth, which begins at `n ≥ 4`.) -/
+theorem minDegreeForC4_eq_self_of_le_three {n : ℕ} (h1 : 1 ≤ n) (h3 : n ≤ 3) :
+    minDegreeForC4 n = n := by
+  haveI : Nonempty (Fin n) := ⟨⟨0, by omega⟩⟩
+  haveI hdec : DecidableRel (⊤ : SimpleGraph (Fin n)).Adj := fun i j => by
+    rw [top_adj]; infer_instance
+  -- No graph on `Fin n` contains a `C₄` (too few vertices).
+  have hfree : ∀ (G : SimpleGraph (Fin n)) [DecidableRel G.Adj],
+      ¬ containsC4 (Fin n) G := by
+    intro G _
+    exact not_containsC4_of_card_lt_four (by rw [Fintype.card_fin]; omega)
+  -- Every graph on `Fin n` has minimum degree at most `n − 1`.
+  have hup : ∀ (G : SimpleGraph (Fin n)) [DecidableRel G.Adj],
+      G.minDegree ≤ n - 1 := by
+    intro G _
+    refine le_trans (G.minDegree_le_degree ⟨0, by omega⟩) ?_
+    rw [← G.card_neighborFinset_eq_degree]
+    refine le_trans (Finset.card_le_card ?_) ?_
+    · intro x hx
+      exact Finset.mem_erase.mpr
+        ⟨(G.ne_of_adj ((G.mem_neighborFinset _ _).mp hx)).symm, Finset.mem_univ x⟩
+    · rw [Finset.card_erase_of_mem (Finset.mem_univ _), Finset.card_univ, Fintype.card_fin]
+  -- The complete graph attains minimum degree `n − 1`.
+  have htop : n - 1 ≤ (⊤ : SimpleGraph (Fin n)).minDegree := by
+    apply le_minDegree_of_forall_le_degree
+    intro v
+    have hnb : (⊤ : SimpleGraph (Fin n)).neighborFinset v = Finset.univ.erase v := by
+      ext x
+      simp [SimpleGraph.mem_neighborFinset, top_adj, Finset.mem_erase, ne_comm]
+    rw [← SimpleGraph.card_neighborFinset_eq_degree, hnb,
+      Finset.card_erase_of_mem (Finset.mem_univ v), Finset.card_univ, Fintype.card_fin]
+  -- Assemble via antisymmetry on the defining `sInf`.
+  unfold minDegreeForC4
+  apply le_antisymm
+  · exact Nat.sInf_le (fun G _ hmin => absurd (le_trans hmin (hup G)) (by omega))
+  · apply le_csInf ⟨n, fun G _ hmin => absurd (le_trans hmin (hup G)) (by omega)⟩
+    intro k hk
+    by_contra hlt
+    push_neg at hlt
+    exact hfree _ (hk _ (le_trans (show k ≤ n - 1 by omega) htop))
 
 /-- **The star has minimum degree at least `1`.**  In `K_{1,n}` on `Fin (n+1)` the
 centre `0` is adjacent to every leaf and each leaf is adjacent to the centre, so

--- a/src/data/proofs/erdos-85/meta.json
+++ b/src/data/proofs/erdos-85/meta.json
@@ -216,9 +216,9 @@
       "Topology"
     ],
     "namespace": "Erdos85",
-    "lineCount": 778,
+    "lineCount": 886,
     "axiomCount": 0,
-    "theoremCount": 30,
+    "theoremCount": 34,
     "definitionCount": 8,
     "path": "Proofs/Erdos85Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-85-wip-01.json
+++ b/src/data/research/problems/erdos-85-wip-01.json
@@ -52,7 +52,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Exact values f(4)=2, f(5)=3, f(6)=3 (axiom-free). Upper bound f(n) ≤ √n+2 (minDegreeForC4_le_sqrt), NOW SHARPENED on the lower Beatty half to f(n) ≤ √n+1 when n ≤ √n·(√n+1) (minDegreeForC4_le_sqrt_add_one); corollary f(m²) ≤ m+1 pins the additive constant to +1 on all perfect squares, matching the true f(n)=(1+o(1))√n up to one additive unit. Lower bounds f(n)≥3 (n≥5). Next: upper-half n∈(s²+s,(s+1)²) still only √n+2 (needs a non-counting witness to sharpen); f(7) exact needs ex(7;C4); eventual-monotonicity (OPEN core).",
+    "progressSummary": "PROGRESS: Exact-value table now complete for 1<=n<=6 (f(1)=1,f(2)=2,f(3)=3 degenerate + f(4)=2,f(5)=3,f(6)=3). Elementary vein remains SATURATED above n=6: f(7)=3 needs ex(7;C4) edge bound, f(10)=4 needs Petersen, asymptotic/monotonicity DEEP (see currentState.blockers).",
     "builtItems": [
       "C4_adj_zero_one/one_two/two_three/three_zero (four cycle edges) in Erdos85Problem.lean",
       "C4_not_adj_zero_two (diagonal non-edge) in Erdos85Problem.lean",
@@ -72,7 +72,8 @@
       "minDegreeForC4_le_of_le_mul_pred: n≤k(k−1) ⟹ f(n)≤k (clean packaging of the counting bound)",
       "minDegreeForC4_le_sqrt: f(n) ≤ Nat.sqrt n + 2 for n≥1 (explicit O(√n) upper bound)",
       "minDegreeForC4_le_sqrt_add_one (Erdos85Problem.lean): f(n) ≤ √n+1 on the lower Beatty half n ≤ √n·(√n+1), axiom-free",
-      "minDegreeForC4_le_sq (Erdos85Problem.lean): f(m²) ≤ m+1, axiom-free"
+      "minDegreeForC4_le_sq (Erdos85Problem.lean): f(m²) ≤ m+1, axiom-free",
+      "minDegreeForC4_eq_self_of_le_three (Erdos85Problem.lean): f(n)=n for 1<=n<=3 — degenerate small-n exact values (no C4 possible below 4 vertices), completing the exact-value table below f(4)=2. Helper not_containsC4_of_card_lt_four (contrapositive of containsC4_four_le_card). 0-axiom, docker-verified v4.31."
     ],
     "insights": [
       "Erdos85Problem.lean was a definitions-only stub (7 defs, 0 theorems). Asymptotics f(n)=(1+o(1))sqrt(n), f(4)=2, and the Ramsey reformulation need extremal graph theory beyond Mathlib; tractable axiom-free content is structural facts about C4, containsC4, and starGraph.",
@@ -92,7 +93,8 @@
       "Kővári–Sós–Turán cherry-counting: Σ_v C(deg v,2) counts paths of length 2; each is determined by centre + unordered endpoint pair. If the count exceeds C(|V|,2), pigeonhole gives a pair with two common neighbours = a C₄. This is the C₄/z(n;2,2) case of KST and drives the true √n-order threshold (f(n)=O(√n)), far beating the linear n−2 bound.",
       "Explicit closed-form upper bound minDegreeForC4_le_sqrt: f(n) ≤ √n + 2 for all n ≥ 1 (axiom-free). Leading constant 1 matches the true f(n)=(1+o(1))√n; only an additive O(1) is lost vs the sharp KST constant (1+√(4n−3))/2. First quotable closed-form of the correct order for this entry.",
       "Sharpened the additive constant on the lower Beatty half: minDegreeForC4_le_sqrt_add_one gives f(n) ≤ √n+1 whenever n ≤ √n·(√n+1) (the sharp KST constant on the lower half of each gap [s²,(s+1)²)), improving √n+2 by one. Take k=√n+1; k(k−1)=(√n+1)·√n ≥ n is exactly the hypothesis.",
-      "Perfect-square corollary minDegreeForC4_le_sq: f(m²) ≤ m+1 for m≥1 (Nat.sqrt_eq gives √(m²)=m, and m² ≤ m(m+1)). Additive constant pinned to +1 on the squares — within a single unit of the true (1+o(1))√n. Cleanest quotable correct-order upper bound for the entry."
+      "Perfect-square corollary minDegreeForC4_le_sq: f(m²) ≤ m+1 for m≥1 (Nat.sqrt_eq gives √(m²)=m, and m² ≤ m(m+1)). Additive constant pinned to +1 on the squares — within a single unit of the true (1+o(1))√n. Cleanest quotable correct-order upper bound for the entry.",
+      "Below 4 vertices no graph contains C4, so f(n) is degenerate: the threshold set is {k | no graph on Fin n reaches min-degree k} and max attainable min-degree is n-1 (complete graph), giving f(n)=n for 1<=n<=3. Not evidence about sqrt(n) growth (begins at n>=4)."
     ],
     "mathlibGaps": [
       "Fin n has NO global CommRing instance (only scoped Fin.instCommRing via `open Fin.CommRing`, gated on NeZero n); needed for ring/linear_combination on cycleGraph differences"


### PR DESCRIPTION
## Erdős #85 (min degree forcing C₄): degenerate small-value completion

Completes the exact-value table for `f(n) = minDegreeForC4 n` below the first
genuine case `f(4) = 2`, adding the three degenerate boundary values.

### New results (both axiom-free, docker-verified on Lean v4.31)

- **`not_containsC4_of_card_lt_four`** — a reusable helper: the contrapositive of
  the existing `containsC4_four_le_card`. A host graph on fewer than four vertices
  cannot contain a 4-cycle.
- **`minDegreeForC4_eq_self_of_le_three`** — `f(n) = n` for `1 ≤ n ≤ 3`, giving
  `f(1) = 1`, `f(2) = 2`, `f(3) = 3`.

### Why `f(n) = n` for `n ≤ 3`

For `n < 4` **no** graph on `Fin n` contains a C₄ at all, so the defining
threshold "min-degree `≥ k` forces a C₄" holds only *vacuously* — exactly for those
`k` that no graph attains. The largest attainable minimum degree on `Fin n` is
`n − 1` (realised by the complete graph `⊤`, never exceeded since `deg v ≤ n − 1`),
so the least `k` no graph reaches is `k = n`.

These are honest boundary values where a 4-cycle is impossible — **not** evidence
about the `√n` growth, which only begins at `n ≥ 4`. The exact-value table is now
complete for `1 ≤ n ≤ 6` (`f(4)=2, f(5)=3, f(6)=3` were already proved).

### Scope / non-goals

The elementary vein remains saturated above `n = 6`: `f(7)=3` needs a C₄-free edge
bound `ex(7;C₄)`, `f(10)=4` needs the Petersen graph, and the asymptotic
`f(n)=(1+o(1))√n` and the monotonicity core (the actual open question) stay DEEP.
These are recorded as structured blockers in the tracker.

Verification: `./proofs/scripts/docker-build.sh Proofs.Erdos85Problem` → success,
0 axioms, 0 sorries, no `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
