### PR TITLE
audit(tracker): descartes-rule-of-signs-oq-01-oq-01 re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7380,9 +7380,9 @@
       "result": "clean"
     },
     "descartes-rule-of-signs-oq-01-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:22Z",
+      "lastAudited": "2026-07-22T12:22:11Z",
       "result": "clean"
     },
     "descartes-rule-of-signs-oq-01-oq-01-oq-02": {


### PR DESCRIPTION
Reserve-mode re-audit. Honest complex-root-theory exploration: 9 genuine Mathlib-proved theorems (conjugate root theorem, non-real root pairing, abstract Nat parity lemmas), 0 sorries / 0 axioms, badge `mathlib`, `originalContributions: None`. All named decls exist; Part 4 and keyInsights openly disclose the gap to the full Descartes parity result. Marking clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)