### PR TITLE
audit(tracker): area-of-circle-oq-03-oq-03 re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1390,9 +1390,9 @@
       "result": "clean"
     },
     "area-of-circle-oq-03-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:22Z",
+      "lastAudited": "2026-07-22T12:27:05Z",
       "result": "clean"
     },
     "area-of-circle-oq-03-oq-03-oq-02": {


### PR DESCRIPTION
Reserve-mode re-audit (queue drained; 4th pass on oldest).

**Result: clean.** 0 sorries, 0 axioms, 0 native_decide; 14 theorems match meta `theoremCount`. Badge `mathlib` correct.

The 4 ellipse theorems are algebraic tautologies (`ring`/`rfl`), but the meta explicitly discloses this as "a genuine gap in the current formalization" (proofStrategy + keyInsights), and `originalContributions` lists only the genuinely-proved geometric-series/exhaustion theorems. Honest disclosure — no overclaim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)