### PR TITLE
Enrich binomial-theorem-oq-02-oq-01-oq-03: remove phantom (sorry) from strategy summary

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/meta.json
@@ -46,7 +46,7 @@
       "title": "Module Header: Covariance of Multinomial Components",
       "startLine": 1,
       "endLine": 52,
-      "summary": "Imports five Mathlib modules and two parent proof files (BinomialTheoremOQ02OQ01OQ02 for the marginal PMF, BinomialTheoremOQ03 for the binomial mean). The docblock states the open question, the answer (Cov(Xᵢ,Xⱼ) = -npᵢpⱼ), the intuition (fixed total forces negative correlation), and a three-step proof strategy: mean via fiber grouping, cross-moment via MGF differentiation (sorry), and covariance by ring arithmetic."
+      "summary": "Imports five Mathlib modules and two parent proof files (BinomialTheoremOQ02OQ01OQ02 for the marginal PMF, BinomialTheoremOQ03 for the binomial mean). The docblock states the open question, the answer (Cov(Xᵢ,Xⱼ) = -npᵢpⱼ), the intuition (fixed total forces negative correlation), and a three-step proof strategy: mean via fiber grouping, cross-moment via MGF differentiation, and covariance by ring arithmetic. All three steps are fully proved in this file (0 sorries)."
     },
     {
       "id": "setup",


### PR DESCRIPTION
## Enrichment: prose accuracy fix (phantom sorry)

`src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03` is `status: verified`, `badge: original`, `sorries: 0`, `axiomCount: 0`, and the Lean source `Proofs/BinomialTheoremOQ02OQ01OQ03.lean` contains **0 `sorry`s**.

Its `sections[0]` summary, however, described the proof strategy as:

> mean via fiber grouping, cross-moment via MGF differentiation **(sorry)**, and covariance by ring arithmetic.

That `(sorry)` tag is a stale phantom describing an earlier development state. It directly contradicts:
- `sections[3]` — titled "Cross-Moment E[XᵢXⱼ] = n(n-1)pᵢpⱼ **(Complete Proof)**", describing the full lines 137–332 MGF-differentiation proof,
- `sections[5]` — "the four proved results ... **0 axioms, 0 sorries**", and
- the Lean source docblock's Proof Strategy step 2, which fully describes the cross-moment derivation with no sorry.

Fix: drop the misleading `(sorry)` and note explicitly that all three strategy steps are fully proved (0 sorries).

Prose-only change — no status/badge/axiomCount/source change.
