### PR TITLE
audit(tracker): four-color-theorem-oq-01 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -19008,9 +19008,9 @@
       "result": "issues-fixed"
     },
     "four-color-theorem-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:23Z",
+      "lastAudited": "2026-07-22T12:33:51Z",
       "result": "clean"
     },
     "four-color-theorem-oq-02": {


### PR DESCRIPTION
Reserve-mode re-audit. four-color-theorem-oq-01 verified clean: 17 theorems, 4 defs, 0 axioms, 0 sorries (all match meta). Badge `mathlib`, status `verified` appropriate. Famous-theorem name handled correctly — title is a question, no 4CT overclaim; `originalContributions`/`assumptions` candidly disclose the trivial arithmetic witnesses and the `paths_in_plane : True` placeholder. One plain kernel `decide` (trust-neutral), no native_decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)