### PR TITLE
Fix: make contour_shift_decay's decay constant existential (#41377)

### DIFF
--- a/proofs/Proofs/FourierSeriesOQ02OQ03OQ02.lean
+++ b/proofs/Proofs/FourierSeriesOQ02OQ03OQ02.lean
@@ -84,7 +84,7 @@ def stripNorm (δ : ℝ) (f : AddCircle T → ℂ) : ℝ :=
 /-- **Axiom 1: Contour-Shifting Decay Bound.**
 
     If f extends holomorphically to the strip |Im z| < δ and is bounded
-    there by M, then its Fourier coefficients satisfy:
+    there by some constant M, then its Fourier coefficients satisfy:
 
       |ĉ_n(f)| ≤ M · e^{-2πδ|n|/T}
 
@@ -93,12 +93,18 @@ def stripNorm (δ : ℝ) (f : AddCircle T → ℂ) : ℝ :=
     segments cancel), the integral equals (1/T)∫f(x+i(δ-ε))e^{-2πin(x+i(δ-ε))/T}dx.
     The exponential factor contributes e^{-2πn(δ-ε)/T}. Take ε → 0.
 
+    The decay constant `M` is the sup-bound of `f` on the strip; it is provided
+    existentially in the conclusion (tied to `f` via the hypothesis) rather than
+    as a free parameter, so that a too-small `M` cannot vacuously falsify the
+    bound. See the audit note in §9 for why an independent `∀ M, 0 < M` binder
+    made the earlier phrasing inconsistent.
+
     Not yet in Mathlib: requires complex contour integration, Cauchy's theorem
     for periodic functions, and interchange of integral with limit. -/
-axiom contour_shift_decay (δ : ℝ) (hδ : 0 < δ) (M : ℝ) (hM : 0 < M)
+axiom contour_shift_decay (δ : ℝ) (hδ : 0 < δ)
     (f : AddCircle T → ℂ) (hf : Integrable f)
     (hbound : IsStripAnalytic δ f) :
-    ∀ n : ℤ, n ≠ 0 →
+    ∃ M : ℝ, 0 < M ∧ ∀ n : ℤ, n ≠ 0 →
       ‖fourierCoeff f n‖ ≤ M * Real.exp (-(2 * Real.pi * δ * |↑n|) / T)
 
 -- ============================================================================
@@ -403,6 +409,12 @@ theorem trig_poly_vacuous (f : AddCircle T → ℂ) (N : ℕ)
 - **Mathlib gap:** `Complex.integral_boundary_rect_eq_zero_of_differentiable`
   exists but the periodic contour setup is not formalized
 - **Difficulty:** MODERATE (≈300-500 lines)
+- **Audit note:** the decay constant `M` is quantified existentially in the
+  conclusion (the strip sup-bound of `f`). An earlier phrasing took `M` as an
+  independent `∀ M, 0 < M` binder disconnected from `f`, which made the axiom
+  inconsistent (a too-small `M` falsified the bound for the Poisson-kernel
+  witness). A faithful elimination should instead expose `M` as the genuine
+  holomorphic sup-bound input.
 
 ### Axiom 2 (rate_is_sharp):
 - **Need:** Explicit construction of extremal functions


### PR DESCRIPTION
## Problem

`contour_shift_decay` (Axiom 1 in `FourierSeriesOQ02OQ03OQ02.lean`) was **logically inconsistent**. It took `M` as a free `∀`-parameter constrained only by `0 < M` and disconnected from `f`, while its conclusion asserted `‖fourierCoeff f n‖ ≤ M * exp(-(2πδ|n|)/T)`.

The hypothesis `IsStripAnalytic δ f` existentially quantifies *its own* constant and never mentions the axiom's `M`. So a too-small `M` falsified the bound. Using the file's own Poisson-kernel witness (`‖ĉ₁‖ = e^{-2πδ/T}` exactly), instantiating at `M = 1/2`, `n = 1` gives `e^{-2πδ/T} ≤ (1/2)·e^{-2πδ/T}` ⇒ `1 ≤ 1/2` — **False**.

The axiom is currently inert (no downstream theorem uses it; only its declaration and a roadmap comment reference it), so no presented theorem is rendered vacuous today — but the axiom is unsound and would poison any future use.

## Fix (auditor's Option 1)

Drop the free `(M : ℝ) (hM : 0 < M)` binder and quantify the decay constant **existentially in the conclusion**, tying it to `f` via the hypothesis:

```lean
axiom contour_shift_decay (δ : ℝ) (hδ : 0 < δ)
    (f : AddCircle T → ℂ) (hf : Integrable f)
    (hbound : IsStripAnalytic δ f) :
    ∃ M : ℝ, 0 < M ∧ ∀ n : ℤ, n ≠ 0 →
      ‖fourierCoeff f n‖ ≤ M * Real.exp (-(2 * Real.pi * δ * |↑n|) / T)
```

This makes the axiom a consistent (true) proposition — a too-small `M` can no longer vacuously falsify it. Docstring updated and an audit note added to the §9 elimination roadmap noting a faithful elimination should expose `M` as the genuine holomorphic sup-bound input.

## Evidence

- `./proofs/scripts/docker-build.sh Proofs.FourierSeriesOQ02OQ03OQ02` → **Build completed successfully (8576 jobs)**. The only remaining warnings are the two pre-existing `sorry` lemmas (lines 344/357, matching `meta.sorries: 2`) and pre-existing unused-variable lints.
- No cross-file callers of `contour_shift_decay` (verified by grep), so no downstream breakage.
- Entry stays honestly badged `axiom` / status `axiomatized`; meta counts unchanged (`axiomCount: 3`, `sorries: 2`, `theoremCount: 11`, `definitionCount: 4`).

Closes #41377
