### PR TITLE
audit(descartes-oq-02-oq-01): fix false 'True placeholder' conclusion + axiom-proved overclaim

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7437,10 +7437,10 @@
       "result": "clean"
     },
     "descartes-rule-of-signs-oq-02-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:23Z",
-      "result": "clean"
+      "lastAudited": "2026-07-22T12:38:57Z",
+      "result": "issues-fixed"
     },
     "descartes-rule-of-signs-oq-02-oq-01-oq-02": {
       "auditCount": 3,

--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
@@ -27,7 +27,7 @@
     "relatedProblems": [
       {
         "id": "descartes-rule-of-signs-oq-02",
-        "relationship": "Proves the budan_upper_bound_axiom from OQ-02"
+        "relationship": "Proves the building blocks and the natDegree=0 base case (budan_upper_bound_natDegree_zero) of the budan_upper_bound_axiom from OQ-02; the full axiom remains open"
       }
     ],
     "theoremCount": 10,
@@ -206,7 +206,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This file establishes the foundational building blocks for Budan's upper bound theorem: constant and linear polynomial bounds (proved), Rolle's theorem for polynomials (proved), IVT-based root existence (proved), and documented placeholders for the sign-change accounting and inductive step. The three proved theorems are sound; the two placeholder theorems prove `True` to document proof architecture without introducing unsound assumptions.",
+    "summary": "This file establishes the foundational building blocks for Budan's upper bound theorem: iterated-derivative infrastructure (degree bound and vanishing beyond natDegree, proved), constant and linear polynomial root bounds (proved), Rolle's theorem for polynomials (proved), IVT-based root existence (proved), and the natDegree=0 base case budan_upper_bound_natDegree_zero (proved). All 10 theorems are genuinely proved with 0 axioms and 0 sorries; the remaining sign-change accounting and inductive step are documented in comment blocks (§2–§4) rather than placeholder theorems, so no unsound assumptions are introduced. The full budan_upper_bound_axiom is not yet discharged.",
     "implications": "Budan's theorem is the algorithmic heart of real root isolation: computer algebra systems use V_p(a) - V_p(b) as a quick upper bound on roots in (a,b] to bisect intervals. The theorem also implies Descartes' Rule (sign changes in coefficients = upper bound on positive roots) as a corollary. A complete Lean formalization would: (1) give a verified foundation for root isolation algorithms, (2) enable formal proofs of Sturm's theorem as a tighter cousin, and (3) contribute to Mathlib's polynomial root-counting infrastructure.",
     "openQuestions": [
       "Sign-change accounting: Formalize the lemma relating V_p(x) and V_{p'}(x) across a root of p — this is the heart of the induction and requires careful analysis of how sign variations change when a root is factored out",


### PR DESCRIPTION
## Gallery integrity fix

**Proof**: descartes-rule-of-signs-oq-02-oq-01 ("Proving Budan's Upper Bound in Lean")

### Problem 1 — stale/false conclusion.summary
The `conclusion.summary` stated:
> "The three proved theorems are sound; the two placeholder theorems prove `True` to document proof architecture without introducing unsound assumptions."

The Lean source (`Proofs/DescartesRuleOfSignsOQ02OQ01.lean`) has **10 genuinely-proved theorems** (+1 def), **0 axioms, 0 sorries, and NO `True` stubs**. The remaining sign-change accounting and inductive step live in **comment blocks (§2–§4)**, exactly as `keyInsights` and `assumptions` already state. The summary described a superseded version. Corrected to match the file.

### Problem 2 — relatedProblems overclaim
`relatedProblems[0].relationship` read "Proves the budan_upper_bound_axiom from OQ-02". The file only discharges the `natDegree=0` slice (`budan_upper_bound_natDegree_zero`); the full axiom remains open (as `crossReferences` and `proofStrategy` correctly note). Reworded to scope the claim.

No source or badge/status change: `verified` / `original` / 0 axioms / 0 sorries all remain accurate for what the file proves.

---
Discovered during gallery integrity audit (reserve mode). Severity: LOW (prose accuracy).