### PR TITLE
Enrich erdos-320/224/237/basel-oq-04-oq-03: remove stale phantom (sorry) prose

### DIFF
--- a/src/data/proofs/basel-problem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-04-oq-03/meta.json
@@ -113,7 +113,7 @@
       "title": "The Möbius Decomposition Identity",
       "startLine": 206,
       "endLine": 269,
-      "summary": "States countCoprimePairs(N) = Σ_{d≤N} μ(d)⌊N/d⌋². The proof is complete except for one sorry: the finite sum exchange (finite Fubini argument). All other steps use previously proved lemmas.",
+      "summary": "States countCoprimePairs(N) = Σ_{d≤N} μ(d)⌊N/d⌋². The proof is complete: the finite sum exchange (finite Fubini argument, discharged by Finset.sum_comm) and all other steps use previously proved lemmas.",
       "mathContext": "$|\\{(m,n)\\in[N]^2:\\gcd(m,n)=1\\}| = \\sum_{d=1}^N \\mu(d)\\lfloor N/d\\rfloor^2$ — the central combinatorial identity. The sum exchange counts triples $(m,n,d)$ with $1\\le m,n\\le N$ and $d|\\gcd(m,n)$."
     },
     {

--- a/src/data/proofs/erdos-224/meta.json
+++ b/src/data/proofs/erdos-224/meta.json
@@ -99,10 +99,10 @@
     {
       "id": "extremal-config",
       "title": "The Extremal Configuration",
-      "summary": "Defines **hypercubeVertices** $= \\{0,1\\}^d$ (sorry), axiomatizes **hypercube_card** ($= 2^d$) and **hypercube_obtuse_free**, and proves **hypercube_extremal**.",
+      "summary": "Defines **hypercubeVertices** $= \\{0,1\\}^d$ and proves **hypercube_card** ($= 2^d$), **hypercube_obtuse_free**, and **hypercube_extremal**. The configuration's optimality rests on the single stated axiom **danzer_grunbaum**.",
       "startLine": 118,
       "endLine": 152,
-      "mathContext": "Defines **hypercubeVertices** $= \\{0,1\\}^d$ (sorry), axiomatizes **hypercube_card** ($= $2^{d}$$) and **hypercube_obtuse_free**, and proves **hypercube_extremal**."
+      "mathContext": "Defines **hypercubeVertices** $= \\{0,1\\}^d$ and proves **hypercube_card** ($= 2^d$), **hypercube_obtuse_free**, and **hypercube_extremal**. The configuration's optimality rests on the single stated axiom **danzer_grunbaum**."
     },
     {
       "id": "hypercube-angles",

--- a/src/data/proofs/erdos-237/meta.json
+++ b/src/data/proofs/erdos-237/meta.json
@@ -118,7 +118,7 @@
     {
       "id": "chen-ding",
       "title": "Chen and Ding's Theorem",
-      "summary": "Axiomatizes chen_ding_2022: every infinite set has unbounded representation count. Derives erdos_conjecture_true by showing log-density implies infinitude (with one sorry for the Set.Infinite deduction from bounded intersection cardinality).",
+      "summary": "Axiomatizes chen_ding_2022: every infinite set has unbounded representation count. Derives erdos_conjecture_true by showing log-density implies infinitude; the Set.Infinite deduction from bounded intersection cardinality is proved in full (no remaining sorry).",
       "startLine": 105,
       "endLine": 158,
       "mathContext": "Chen-Ding (2022): resolved the conjecture. Every infinite $A \\subseteq \\mathbb{N}$ has $\\limsup f_A(n) = \\infty$."

--- a/src/data/proofs/erdos-320/meta.json
+++ b/src/data/proofs/erdos-320/meta.json
@@ -112,8 +112,8 @@
       "title": "Part III: Bleicher-Erdős Lower Bound (1975)",
       "startLine": 83,
       "endLine": 97,
-      "summary": "Axiomatizes the 1975 lower bound: log S(N) ≥ (N/log N)(log 2 · ∏ log_i N) for k ≥ 4 and log_k(N) ≥ k. The constant log 2 arises from binary choices among prime denominators. The derived theorem lower_bound_growth (sorry) extracts the simpler corollary S(N) ≥ exp(N/log N).",
-      "mathContext": "Axiomatizes the 1975 lower bound: log S(N) ≥ (N/log N)(log 2 · ∏ log_i N) for k ≥ 4 and log_k(N) ≥ k. The constant log 2 arises from binary choices among prime denominators. The derived theorem lower_bound_growth (sorry) extracts the simpler corollary S(N) ≥ exp(N/log N)."
+      "summary": "Axiomatizes the 1975 lower bound: log S(N) ≥ (N/log N)(log 2 · ∏ log_i N) for k ≥ 4 and log_k(N) ≥ k. The constant log 2 arises from binary choices among prime denominators. The proved theorem lower_bound_growth extracts the simpler corollary S(N) ≥ exp(N/log N) (derived from the stated erdos_320_open_bounds axiom, not a remaining sorry).",
+      "mathContext": "Axiomatizes the 1975 lower bound: log S(N) ≥ (N/log N)(log 2 · ∏ log_i N) for k ≥ 4 and log_k(N) ≥ k. The constant log 2 arises from binary choices among prime denominators. The proved theorem lower_bound_growth extracts the simpler corollary S(N) ≥ exp(N/log N) (derived from the stated erdos_320_open_bounds axiom, not a remaining sorry)."
     },
     {
       "id": "upper-bound",
@@ -168,8 +168,8 @@
       "title": "Part X: Growth Rate Analysis",
       "startLine": 205,
       "endLine": 218,
-      "summary": "Defines asymptotic_exponent(N) = N/log N as the leading term of log S(N). The theorem log_S_leading_term (sorry) asserts sandwich bounds c₁ · N/log N ≤ log S(N) ≤ c₂ · (N/log N) · log log N, showing N/log N ~ π(N) is the leading behavior.",
-      "mathContext": "Defines asymptotic_exponent(N) = N/log N as the leading term of log S(N). The theorem log_S_leading_term (sorry) asserts sandwich bounds c₁ · N/log N ≤ log S(N) ≤ c₂ · (N/log N) · log log N, showing N/log N ~ π(N) is the leading behavior."
+      "summary": "Defines asymptotic_exponent(N) = N/log N as the leading term of log S(N). The proved theorem log_S_leading_term asserts sandwich bounds c₁ · N/log N ≤ log S(N) ≤ c₂ · (N/log N) · log log N, showing N/log N ~ π(N) is the leading behavior.",
+      "mathContext": "Defines asymptotic_exponent(N) = N/log N as the leading term of log S(N). The proved theorem log_S_leading_term asserts sandwich bounds c₁ · N/log N ≤ log S(N) ≤ c₂ · (N/log N) · log log N, showing N/log N ~ π(N) is the leading behavior."
     },
     {
       "id": "summary",


### PR DESCRIPTION
Enrichment pass — prose-accuracy fixes across four entries.

Fresh gallery scan for phantom `(sorry)` prose (meta.sorries=0 but section
summaries tagging specific named declarations `(sorry)`) surfaced four entries
whose Lean files are genuinely sorry-free (`grep '\bsorry\b'` = 0) yet carried
stale tags describing now-proved theorems:

| Entry | Stale claim | Ground truth |
|-------|-------------|--------------|
| erdos-320 | `lower_bound_growth (sorry)`, `log_S_leading_term (sorry)` | both proved from the stated `erdos_320_open_bounds` axiom |
| erdos-224 | `hypercubeVertices (sorry)`, "axiomatizes `hypercube_card`/`hypercube_obtuse_free`" | def is complete; both are **proved** theorems — only `danzer_grunbaum` is an axiom |
| erdos-237 | "with one sorry for the Set.Infinite deduction" | the `Set.Infinite` deduction in `erdos_conjecture_true` is proved in full |
| basel-problem-oq-04-oq-03 | "complete except for one sorry: the finite sum exchange" | sum exchange discharged by `Finset.sum_comm` (0 axioms, 0 sorries) |

Prose-only accuracy fix. No Lean source, `status`, `badge`, or count changes.
Companion to the same live vein as #41379 (binomial-theorem-oq-02-oq-01-oq-03).
