### PR TITLE
Research: erdos-18-wip-01 — exact index value hErdos(2^k)=k (axiom-free)

### DIFF
--- a/proofs/Proofs/Erdos18WIP01.lean
+++ b/proofs/Proofs/Erdos18WIP01.lean
@@ -1520,10 +1520,13 @@ theorem two_pow_sub_one_card_ge {k : ℕ} {T : Finset ℕ}
   have hTP : T ⊆ P := by
     intro x hxT
     have hxle : x ≤ 2 ^ k - 1 := by
-      have hh := Finset.single_le_sum (f := id) (fun i _ => Nat.zero_le i) hxT
-      simpa [hsum] using hh
+      have hh : x ≤ T.sum id := by
+        have hs := Finset.single_le_sum (f := id) (fun i _ => Nat.zero_le i) hxT
+        simpa using hs
+      rw [hsum] at hh
+      exact hh
     have hxdvd : x ∣ 2 ^ k := (Nat.mem_divisors.mp (hT hxT)).1
-    obtain ⟨j, hjk, rfl⟩ := (Nat.dvd_prime_pow Nat.prime_two).mp hxdvd
+    obtain ⟨j, _hjk, rfl⟩ := (Nat.dvd_prime_pow Nat.prime_two).mp hxdvd
     have hjlt : j < k := by
       by_contra hjc
       rw [not_lt] at hjc

--- a/proofs/Proofs/Erdos18WIP01.lean
+++ b/proofs/Proofs/Erdos18WIP01.lean
@@ -1489,6 +1489,108 @@ theorem one_le_hErdos {m : ℕ} (hm : 2 ≤ m) : 1 ≤ hErdos m := by
         unfold hErdos
         exact Finset.le_sup (by rw [Finset.mem_range]; omega)
 
+/- ## An exact `hErdos` value: powers of two
+
+`hErdos(2^k) = k`. This is the first *exact* value of the corrected Erdős #18 index,
+and it is extremal: `k = log₂(2^k)` is the *largest* the index can be for a number of
+that size (it always satisfies `hErdos m ≤ h m ≤ d(m)` and here `d(2^k) = k+1`). Powers
+of two are the worst case for the index — the diametric opposite of the conjectured
+factorial behaviour `hErdos(n!) < n^{o(1)}` (Vose), which this vein leaves deep. -/
+
+/-- The proper power-of-two divisors `{2^0,…,2^{k-1}}` of `2^k` sum to `2^k − 1`. -/
+theorem sum_image_two_pow_range (k : ℕ) :
+    ((Finset.range k).image (2 ^ ·)).sum id = 2 ^ k - 1 := by
+  rw [Finset.sum_image (fun a _ b _ h => Nat.pow_right_injective (le_refl 2) h)]
+  cases k with
+  | zero => simp
+  | succ n => simpa using sum_range_two_pow n
+
+/-- **Any distinct-divisor representation of `2^k − 1` uses at least `k` divisors.**
+The divisors of `2^k` are `2^0,…,2^k`; a set summing to `2^k − 1 < 2^k` cannot use `2^k`,
+so it lies in `{2^0,…,2^{k-1}}`, which sums to *exactly* `2^k − 1`. Dropping any one of
+those `k` powers strictly lowers the sum, so all `k` are required. -/
+theorem two_pow_sub_one_card_ge {k : ℕ} {T : Finset ℕ}
+    (hT : T ⊆ divisors (2 ^ k)) (hsum : T.sum id = 2 ^ k - 1) : k ≤ T.card := by
+  set P := (Finset.range k).image (2 ^ ·) with hP
+  have hPcard : P.card = k := by
+    rw [hP, Finset.card_image_of_injective _ (Nat.pow_right_injective (le_refl 2)),
+      Finset.card_range]
+  have hPsum : P.sum id = 2 ^ k - 1 := sum_image_two_pow_range k
+  -- Every element of `T` is a proper power of two, so `T ⊆ P`.
+  have hTP : T ⊆ P := by
+    intro x hxT
+    have hxle : x ≤ 2 ^ k - 1 := by
+      have hh := Finset.single_le_sum (f := id) (fun i _ => Nat.zero_le i) hxT
+      simpa [hsum] using hh
+    have hxdvd : x ∣ 2 ^ k := (Nat.mem_divisors.mp (hT hxT)).1
+    obtain ⟨j, hjk, rfl⟩ := (Nat.dvd_prime_pow Nat.prime_two).mp hxdvd
+    have hjlt : j < k := by
+      by_contra hjc
+      rw [not_lt] at hjc
+      have h1 : 2 ^ k ≤ 2 ^ j := Nat.pow_le_pow_right (by norm_num) hjc
+      have h2 : 1 ≤ 2 ^ k := Nat.one_le_two_pow
+      omega
+    rw [hP, Finset.mem_image]
+    exact ⟨j, Finset.mem_range.mpr hjlt, rfl⟩
+  -- If `|T| < k = |P|`, `T` misses a power, dropping its sum below `2^k − 1`.
+  by_contra hlt
+  rw [not_le] at hlt
+  have hcardlt : T.card < P.card := by rw [hPcard]; exact hlt
+  have hne : T ≠ P := fun h => by rw [h] at hcardlt; exact lt_irrefl _ hcardlt
+  obtain ⟨x, hxP, hxnT⟩ := Finset.exists_of_ssubset (lt_of_le_of_ne hTP hne)
+  have hxpos : 0 < x :=
+    Nat.pos_of_mem_divisors (image_two_pow_subset_divisors k hxP)
+  have hkey : T.sum id < P.sum id :=
+    Finset.sum_lt_sum_of_subset hTP hxP hxnT hxpos (fun j _ _ => Nat.zero_le _)
+  rw [hsum, hPsum] at hkey
+  exact lt_irrefl _ hkey
+
+/-- **Upper half of `hErdos(2^k) = k`.** Every `j < 2^k` is a sum of at most `k` powers
+of two (its binary digits), so `repLength (2^k) j ≤ k`. -/
+theorem repLength_two_pow_le {k j : ℕ} (hj : j < 2 ^ k) : repLength (2 ^ k) j ≤ k := by
+  obtain ⟨S, hS, hsum⟩ := repr_lt_two_pow k j hj
+  have hScard : S.card ≤ k :=
+    calc S.card ≤ ((Finset.range k).image (2 ^ ·)).card := Finset.card_le_card hS
+      _ ≤ (Finset.range k).card := Finset.card_image_le
+      _ = k := Finset.card_range k
+  calc repLength (2 ^ k) j ≤ S.card :=
+        Nat.sInf_le ⟨S, hS.trans (image_two_pow_subset_divisors k), rfl, hsum⟩
+    _ ≤ k := hScard
+
+/-- **Exact `hErdos` for powers of two: `hErdos(2^k) = k`.** The corrected Erdős #18
+index of `2^k` equals its `log₂` — the *maximum* possible for a number of that size.
+Upper bound: each `j < 2^k` needs at most its `k` binary digits (`repLength_two_pow_le`).
+Lower bound: the all-ones value `2^k − 1` needs all `k` powers `2^0,…,2^{k-1}`
+(`two_pow_sub_one_card_ge`). -/
+theorem hErdos_two_pow (k : ℕ) : hErdos (2 ^ k) = k := by
+  refine le_antisymm ?_ ?_
+  · unfold hErdos
+    apply Finset.sup_le
+    intro j hj
+    rw [Finset.mem_range] at hj
+    exact repLength_two_pow_le hj
+  · rcases Nat.eq_zero_or_pos k with hk0 | hkpos
+    · rw [hk0]; exact Nat.zero_le _
+    · have hk1 : 1 ≤ 2 ^ k - 1 := by
+        have h2 : 2 ≤ 2 ^ k :=
+          calc 2 = 2 ^ 1 := (pow_one 2).symm
+            _ ≤ 2 ^ k := Nat.pow_le_pow_right (by norm_num) hkpos
+        omega
+      have hklt : 2 ^ k - 1 < 2 ^ k := by
+        have : 1 ≤ 2 ^ k := Nat.one_le_two_pow
+        omega
+      have hk_le : k ≤ repLength (2 ^ k) (2 ^ k - 1) := by
+        unfold repLength
+        apply le_csInf
+        · obtain ⟨T, hTsub, hTsum⟩ := (two_pow_practical k).2 (2 ^ k - 1) hk1 hklt
+          exact ⟨T.card, T, hTsub, rfl, hTsum⟩
+        · rintro t ⟨T, hTsub, rfl, hTsum⟩
+          exact two_pow_sub_one_card_ge hTsub hTsum
+      calc k ≤ repLength (2 ^ k) (2 ^ k - 1) := hk_le
+        _ ≤ hErdos (2 ^ k) := by
+            unfold hErdos
+            exact Finset.le_sup (Finset.mem_range.mpr hklt)
+
 /-- **Erdős #18, Part 2 ($250), corrected.** The prize question `h(n!) < n^{o(1)}`
 stated over the correct index `hErdos`. Contrast `conjecture_part2_weak`, which is
 *false* for the parent's universal-set `h` (`factorial_le_two_pow_h`). -/

--- a/src/data/research/problems/erdos-18-wip-01.json
+++ b/src/data/research/problems/erdos-18-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: First theorems about the divisor-completeness index h (parent \"Known Bounds on h(m)\" section was empty). Proved the information-theoretic lower bound m<=2^(h m) and upper bound h(m)<=d(m), pinning log2 m <= h(m) <= d(m) (0-axiom, Docker-verified v4.31). Surfaced a definition defect: the file h is the universal-representing-set size (>=log2 m), NOT the Erdos prize quantity (max single-value representation length, Vose <<sqrt(log m)); consequently conjecture_part2_weak (h(n!)<n^eps) is false as stated for this h (factorial_le_two_pow_h). Recommended mechanic follow-up: rename parent h, add max-length index for the conjectures.",
+    "progressSummary": "PROGRESS: hErdos index now has its FIRST EXACT value hErdos(2^k)=k (log2 extreme, powers of two are worst case). Complements sandwich 1<=hErdos<=h<=d(m). Deep/open: hErdos(n!)<n^{o(1)} (Vose); residual mechanic = rename parent h->hCover.",
     "builtItems": [
       "decidableIsRepresentable / decidableIsPractical instances (Erdos18Problem.lean)",
       "zero_isRepresentable, one_isRepresentable, isRepresentable_self, isRepresentable_le_sigma, mem_divisors_le (Erdos18Problem.lean)",
@@ -46,7 +46,8 @@
       "sum_range_two_pow, sum_divisors_two_pow, two_pow_mul_practical_of_le, euclid_form_practical, four_ninety_six_practical in Erdos18WIP01.lean (all 0-axiom: propext/Classical.choice/Quot.sound; Docker-built 8577 jobs)",
       "le_two_pow_h (Erdos18WIP01.lean): m <= 2^(h m) for practical m [0-axiom]",
       "h_le_card_divisors (Erdos18WIP01.lean): h m <= d(m) for practical m [0-axiom]",
-      "factorial_le_two_pow_h (Erdos18WIP01.lean): n! <= 2^(h n!) [0-axiom]"
+      "factorial_le_two_pow_h (Erdos18WIP01.lean): n! <= 2^(h n!) [0-axiom]",
+      "Erdos18WIP01.lean: hErdos_two_pow — EXACT hErdos(2^k)=k, first exact value of the corrected Erdos #18 index. Upper repLength_two_pow_le (binary digits, <=k), lower two_pow_sub_one_card_ge (2^k-1 all-ones needs all k powers). Helper sum_image_two_pow_range. 0-axiom docker-verified v4.31."
     ],
     "insights": [
       "Erdos18Problem.lean stub developed: representability (IsRepresentable) and practicality (IsPractical) are DECIDABLE via a finite powerset search over the divisor set — a single decision procedure subsuming all future example checks; all lemmas axiom-free (plain kernel decide, no native_decide/Lean.ofReduceBool).",
@@ -62,7 +63,8 @@
       "Proved (Erdos18WIP01, 0-axiom): le_two_pow_h : IsPractical m -> m <= 2^(h m). Information-theoretic: a size-(h m) representing set has only 2^(h m) subset sums yet must realise the m values 0..m-1. Hence h(m) >= log2 m for the file h.",
       "Corollary factorial_le_two_pow_h : n! <= 2^(h n!). Since log2(n!)=Theta(n log n) is superpolynomial, the parent conjecture_part2_weak (h(n!)<n^eps) is FALSE as written for the file s universal-set h.",
       "Proved h_le_card_divisors : IsPractical m -> h m <= (divisors m).card (upper bound d(m)). Together: log2 m <= h m <= d(m) for the file h.",
-      "Erdos18OQ01.lean already proves subadditivity h(mn)<=h(m)+h(n) for this universal-set h (correct for that quantity), so the def cannot simply be replaced: mechanic should RENAME the parent h to the universal-set index and introduce the max-representation-length index for the conjectures."
+      "Erdos18OQ01.lean already proves subadditivity h(mn)<=h(m)+h(n) for this universal-set h (correct for that quantity), so the def cannot simply be replaced: mechanic should RENAME the parent h to the universal-set index and introduce the max-representation-length index for the conjectures.",
+      "hErdos(2^k)=k=log2(2^k) is the MAXIMAL value of the Erdos #18 index for a number of that size (hErdos m <= h m <= d(m); d(2^k)=k+1). Powers of two are the WORST case for the index — extremal opposite of the deep conjectured factorial behaviour hErdos(n!)<n^{o(1)} (Vose). First exact hErdos family value."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Erdős #18 (practical numbers, $250): exact index value hErdos(2^k) = k

Adds the **first exact value** of the corrected Erdős #18 index `hErdos` to
`Erdos18WIP01.lean`: for every `k`,

```
hErdos(2^k) = k .
```

Axiom-free, docker-verified on Lean v4.31.

### Significance

`hErdos m` (introduced in #41358) is the *worst case over `k < m` of the fewest
divisors of `m` needed to represent `k`* — the quantity the prize conjectures actually
concern (the parent's universal-set `h` over-counts). This value is **extremal**:
`k = log₂(2^k)` is the *largest* the index can be for a number of that size (always
`hErdos m ≤ h m ≤ d(m)`, and `d(2^k) = k+1`). Powers of two are the **worst case** for
the index — the diametric opposite of the conjectured factorial behaviour
`hErdos(n!) < n^{o(1)}` (Vose), which this vein leaves deep.

### Proof structure

- **`repLength_two_pow_le`** (upper): every `j < 2^k` is a sum of at most its `k` binary
  digits, reusing the existing `repr_lt_two_pow`, so `repLength (2^k) j ≤ k`.
- **`two_pow_sub_one_card_ge`** (lower): any distinct-divisor representation of the
  all-ones value `2^k − 1` must use all `k` powers `2^0,…,2^{k-1}`. The divisors of `2^k`
  are `2^0,…,2^k`; a set summing to `2^k − 1 < 2^k` cannot use `2^k`, so it lies inside
  `{2^0,…,2^{k-1}}` (which sums to exactly `2^k − 1`); dropping any one power strictly
  lowers the sum.
- **`sum_image_two_pow_range`** — helper: the proper power-of-two divisors sum to `2^k − 1`.

### Scope

The membership theory of practical numbers is already saturated; this is on the
`hErdos`-index frontier. The deep parts remain untouched: `hErdos(n!) < n^{o(1)}` (Vose)
stays a conjecture `Prop`, and the residual mechanic task (rename the parent's `h` →
`hCover`) is unaffected.

Verification: `./proofs/scripts/docker-build.sh Proofs.Erdos18WIP01` → success,
0 axioms, 0 sorries, no `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
