### PR TITLE
audit(cramers-rule-oq-01-oq-02): clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6663,9 +6663,9 @@
       "result": "clean"
     },
     "cramers-rule-oq-01-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:23Z",
+      "lastAudited": "2026-07-22T12:46:12Z",
       "result": "clean"
     },
     "cramers-rule-oq-01-oq-02-oq-01": {


### PR DESCRIPTION
Reserve-mode re-audit. Clean: 0 sorries/axioms/native_decide/True-stubs; 32 theorems & 470 lines match; genuine quasideterminant/non-commutative Cramer's rule proofs over DivisionRing; verified/mathlib badge honest. Tracker timestamp only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)