### PR TITLE
audit(greens-theorem-oq-01-oq-01): clean re-serve

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -20104,9 +20104,9 @@
       "result": "clean"
     },
     "greens-theorem-oq-01-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:24Z",
+      "lastAudited": "2026-07-22T12:50:23Z",
       "result": "clean"
     },
     "greens-theorem-oq-01-oq-01-oq-01": {


### PR DESCRIPTION
Reserve-mode re-audit of `greens-theorem-oq-01-oq-01` (Fubini bridge for Green's theorem).

**Verdict: CLEAN.** Tier-B Mathlib bridge, correctly badged `mathlib`.

- 4 real theorems (matches `theoremCount`): `intervalIntegral_swap`, `greens_fubini_eliminated`, `fubini_of_continuous`, `greens_fubini_for_C1`
- 0 sorries, 0 axioms, no `native_decide`/`decide`, no True stubs
- Core swap via Mathlib's `integral_integral_swap`; integrability via `ContinuousOn.integrableOn_compact` — both disclosed in `assumptions`
- `originalContributions` honestly scoped to the interval→set-integral bridge + application/sufficient-condition wrappers; no overclaim

Only change: audit-tracker timestamp bump (auditCount 3→4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)