### PR TITLE
audit(cantors-theorem-oq-01-oq-01): clean re-serve

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4244,9 +4244,9 @@
       "result": "clean"
     },
     "cantors-theorem-oq-01-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:23Z",
+      "lastAudited": "2026-07-22T12:52:29Z",
       "result": "clean"
     },
     "cantors-theorem-oq-01-oq-02": {


### PR DESCRIPTION
Reserve-mode re-audit of `cantors-theorem-oq-01-oq-01` (|𝒫(ℝ)| = ℵ₂ characterization).

**Verdict: CLEAN.** Tier-B, correctly badged `mathlib`.

- 10 theorems + 2 defs (matches meta); 0 sorries, 0 axioms
- Checked parent `CantorsTheoremOQ01.lean` for transitive axioms/sorries — **none**; `GCH_at_continuum`/`CH` are genuine `Prop` defs, not axioms; helper resolves to Mathlib's `Cardinal.aleph_one_le_continuum`
- No `native_decide`. The headline is a *conditional* iff (holds ⟺ CH ∧ GCH_at_continuum), not an unconditional ZFC-independent claim — title "Complete Characterization" is accurate
- `originalContributions: None` — honestly conservative

Only change: audit-tracker timestamp bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)