### PR TITLE
audit(binomial-theorem-oq-02-oq-01): clean re-serve

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2950,9 +2950,9 @@
       "result": "clean"
     },
     "binomial-theorem-oq-02-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:23Z",
+      "lastAudited": "2026-07-22T12:54:27Z",
       "result": "clean"
     },
     "binomial-theorem-oq-02-oq-01-oq-01": {


### PR DESCRIPTION
Clean re-serve audit. Tier-B mathlib bridge over `Finset.sum_pow_eq_sum_piAntidiag` (multinomial theorem). Verified: 0 sorries, 0 axioms, 0 native_decide, 0 True stubs; 14 theorems, 1 def, 481 lines — all match meta. Badge `mathlib` correct; `assumptions` discloses Mathlib reliance. Mean/variance/second-moment proofs are genuine derivative computations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)