### PR TITLE
research(erdos-117-wip-01): cyclic covers + covering-set structure (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos117WIP01Cover.lean
+++ b/proofs/Proofs/Erdos117WIP01Cover.lean
@@ -1,0 +1,124 @@
+/-
+  Erdős Problem #117 — Covering Groups by Abelian Subgroups:
+  cyclic covers and the structure of the covering set (0-axiom).
+
+  Companion to `Erdos117Problem.lean` / `Erdos117WIP01.lean` /
+  `Erdos117WIP01Mono.lean`.  The parent defines
+  `h(n) = abelianCoverNumber n = sInf {k | CoversWithAbelian k n}` where
+  `CoversWithAbelian k n` (from the `Mono` companion) says `k` abelian subgroups
+  cover *every* finite group with the `n`-commuting property; Pyber's exponential
+  bounds `c₁ⁿ < h(n) < c₂ⁿ` are stated only in prose.  Prior companions pin
+  `h(0) = 0`, `h(1) = 1`, the closure theory of the property, and monotonicity of
+  `h` in `n`.
+
+  This file adds two elementary pieces of the covering theory.
+
+  **1. Every group is a union of abelian (cyclic) subgroups.**  The single-element
+  subgroup `zpowers g` is abelian, and `g ∈ zpowers g`, so the family
+  `g ↦ zpowers g` covers `G` by abelian subgroups — *unconditionally*, for any
+  group.  This is the qualitative fact behind #117: the covering number `h(n)`
+  measures only *how many* abelian subgroups are needed uniformly, never *whether*
+  a cover exists for a fixed group (one always does, of size `≤ |G|`).
+
+  **2. The covering set `{k | CoversWithAbelian k n}` is a terminal segment.**
+  It is upward closed in `k` (pad a `k`-cover with copies of `⊥`), and — for
+  `n ≥ 1` — never contains `0` (the empty family cannot cover the nontrivial
+  witness `PUnit`).  Together with `Nat.sInf_mem` (the `Mono` companion) this
+  characterises the set as `[h(n), ∞)` whenever it is nonempty, and gives the
+  general lower bound `1 ≤ h(n)` for every `n ≥ 1` at which `h(n)` is
+  well-defined.
+
+  Main results (all axiom-free — `#print axioms` = propext/Classical.choice/Quot.sound):
+
+  * `isAbelianSubgroup_zpowers`     : the cyclic subgroup `zpowers g` is abelian.
+  * `exists_cyclic_abelian_cover`   : every group is covered by abelian (cyclic)
+                                      subgroups (the family `g ↦ zpowers g`).
+  * `coversWithAbelian_upward`      : `CoversWithAbelian · n` is upward closed in `k`.
+  * `not_coversWithAbelian_zero`    : for `n ≥ 1`, `0` abelian subgroups never cover.
+  * `one_le_abelianCoverNumber`     : for `n ≥ 1`, if `h(n)` is well-defined
+                                      (the covering set is nonempty) then `h(n) ≥ 1`.
+
+  The open Erdős #117 (the exact exponential base) and Pyber's bounds are untouched.
+
+  0 axioms, 0 sorries.
+-/
+
+import Mathlib
+import Proofs.Erdos117Problem
+import Proofs.Erdos117WIP01
+import Proofs.Erdos117WIP01Mono
+
+universe u
+
+/-- **Cyclic subgroups are abelian.**  Any two elements of `Subgroup.zpowers g`
+    are powers `g ^ a, g ^ b` of the single generator `g`, and powers of a fixed
+    element commute: `g ^ a * g ^ b = g ^ (a + b) = g ^ (b + a) = g ^ b * g ^ a`. -/
+theorem isAbelianSubgroup_zpowers {G : Type*} [Group G] (g : G) :
+    IsAbelianSubgroup G (Subgroup.zpowers g) := by
+  intro x y hx hy
+  rw [Subgroup.mem_zpowers_iff] at hx hy
+  obtain ⟨a, rfl⟩ := hx
+  obtain ⟨b, rfl⟩ := hy
+  rw [← zpow_add, ← zpow_add, add_comm]
+
+/-- **Every group is covered by abelian (cyclic) subgroups.**  The family
+    `g ↦ Subgroup.zpowers g` consists of abelian subgroups
+    (`isAbelianSubgroup_zpowers`) and covers `G`, since `g ∈ Subgroup.zpowers g`
+    for every `g`.  A cover therefore always exists for a *fixed* group — of size
+    at most `|G|` when `G` is finite — so the content of `h(n)` is the *uniform*
+    count over all groups with the `n`-commuting property, never mere existence. -/
+theorem exists_cyclic_abelian_cover {G : Type*} [Group G] :
+    ∃ H : G → Subgroup G,
+      (∀ i, IsAbelianSubgroup G (H i)) ∧ ∀ g : G, ∃ i, g ∈ H i :=
+  ⟨fun i => Subgroup.zpowers i, fun i => isAbelianSubgroup_zpowers i,
+    fun g => ⟨g, Subgroup.mem_zpowers g⟩⟩
+
+/-- **The covering set is upward closed in `k`.**  If `k` abelian subgroups cover
+    every finite group with the `n`-commuting property, then so do any `k' ≥ k`:
+    extend the covering family `H : Fin k → Subgroup G` to `Fin k'` by sending the
+    extra indices to the (abelian) trivial subgroup `⊥`.  The original cover still
+    reaches every element, and every subgroup in the extended family is abelian. -/
+theorem coversWithAbelian_upward {k k' n : ℕ} (hk : k ≤ k')
+    (h : CoversWithAbelian.{u} k n) : CoversWithAbelian.{u} k' n := by
+  intro G _ _ hn
+  obtain ⟨H, hAb, hCov⟩ := h G hn
+  refine ⟨fun j => if hj : (j : ℕ) < k then H ⟨j, hj⟩ else ⊥, ?_, ?_⟩
+  · intro j
+    by_cases hj : (j : ℕ) < k
+    · simp only [hj, dif_pos]; exact hAb _
+    · simp only [hj, dif_neg, not_false_iff]; exact isAbelianSubgroup_bot
+  · intro g
+    obtain ⟨i, hi⟩ := hCov g
+    have hlt : (i : ℕ) < k' := lt_of_lt_of_le i.2 hk
+    refine ⟨⟨i, hlt⟩, ?_⟩
+    -- beta-reduce the family application, then take the `< k` branch; the
+    -- resulting index `⟨↑i, i.2⟩` is defeq to `i` (structure eta), so `hi` closes it.
+    dsimp only
+    rw [dif_pos i.2]
+    exact hi
+
+/-- **`0` abelian subgroups never cover, for any threshold `n ≥ 1`.**  The empty
+    family `Fin 0 → Subgroup G` covers nothing, yet the commutative witness group
+    `PUnit` has the `n`-commuting property for every `n ≥ 1`
+    (`commGroup_hasNCommutingProperty`).  So `CoversWithAbelian 0 n` would force a
+    cover of `PUnit.unit` by no subgroups — impossible. -/
+theorem not_coversWithAbelian_zero {n : ℕ} (hn : 1 ≤ n) :
+    ¬ CoversWithAbelian.{u} 0 n := by
+  intro h
+  obtain ⟨H, _, hCov⟩ := h PUnit (commGroup_hasNCommutingProperty hn)
+  obtain ⟨i, _⟩ := hCov PUnit.unit
+  exact i.elim0
+
+/-- **General lower bound `h(n) ≥ 1` for `n ≥ 1`.**  Whenever `h(n)` is genuinely
+    well-defined — i.e. the covering set is nonempty rather than the `sInf ∅ = 0`
+    fallback — it is at least `1`, because `0` is never in the covering set
+    (`not_coversWithAbelian_zero`).  This complements `h(0) = 0`: the covering
+    number leaves `0` exactly at the `n = 0 → 1` step.  (For `n = 1` the set is
+    nonempty, recovering `abelianCoverNumber_one`'s lower half; for larger `n`,
+    nonemptiness of the set is exactly Pyber's unformalized upper bound.) -/
+theorem one_le_abelianCoverNumber {n : ℕ} (hn : 1 ≤ n)
+    (hne : ∃ k, CoversWithAbelian.{u} k n) :
+    1 ≤ abelianCoverNumber.{u} n := by
+  rw [abelianCoverNumber_eq_sInf, Nat.one_le_iff_ne_zero, Ne, Nat.sInf_eq_zero]
+  push_neg
+  exact ⟨not_coversWithAbelian_zero hn, hne⟩

--- a/src/data/research/problems/erdos-117-wip-01.json
+++ b/src/data/research/problems/erdos-117-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Def-only parent stub developed with axiom-free scaffolding: base values h(0)=0, h(1)=1 (Erdos117WIP01), n-commuting property closure theory (mono/injective/subgroup/mulEquiv/card_le), and now MONOTONICITY of h(n) in n (Erdos117WIP01Mono, conditional on finite-cover existence). Pyber's exponential bounds and the open exact base remain unformalized.",
+    "progressSummary": "PROGRESS: Added Erdos117WIP01Cover.lean (5 axiom-free theorems). Cyclic-cover existence (every group = union of abelian cyclic subgroups) + structure of the covering set (upward-closed terminal segment, 0 not in set for n>=1, general lower bound h(n)>=1). Prior: h(0)=0, h(1)=1, property closure theory, h monotone. Pyber exponential bounds c1^n < h(n) < c2^n remain deep/unformalized.",
     "builtItems": [
       "abelianCoverNumber_mono in Erdos117WIP01Mono.lean — h(n) is monotone nondecreasing: n<=m and a finite m-cover exists (exists k, CoversWithAbelian k m) => h(n) <= h(m). Crux coversWithAbelian_of_le: an m-cover is an n-cover since the n-commuting property implies the m-property (hasNCommutingProperty_mono). Nonemptiness hypothesis is honest (Nat.sInf empty = 0 convention; well-definedness of h(m) is Pyber's unformalized upper bound). CoversWithAbelian names the defining-set condition; abelianCoverNumber_eq_sInf is rfl. 0-axiom, docker 8578 jobs.",
       "commute_of_hasNCommutingProperty_one - HasNCommutingProperty G 1 implies all pairs commute (Erdos117Problem.lean)",
@@ -40,14 +40,22 @@
       "isAbelianSubgroup_iff_isMulCommutative - bridges local IsAbelianSubgroup to Mathlib IsMulCommutative (Erdos117Problem.lean)",
       "Erdos117WIP01.lean: not_hasNCommutingProperty_zero (¬ HasNCommutingProperty G 0)",
       "Erdos117WIP01.lean: commGroup_hasNCommutingProperty (CommGroup ⟹ n-commuting for all n≥1)",
-      "Erdos117WIP01.lean: abelianCoverNumber_one (h(1)=1) — the flagship base case"
+      "Erdos117WIP01.lean: abelianCoverNumber_one (h(1)=1) — the flagship base case",
+      "isAbelianSubgroup_zpowers — cyclic subgroup zpowers g is abelian (Erdos117WIP01Cover.lean)",
+      "exists_cyclic_abelian_cover — every group covered by abelian cyclic subgroups (Erdos117WIP01Cover.lean)",
+      "coversWithAbelian_upward — covering set upward-closed in k via bot-padding (Erdos117WIP01Cover.lean)",
+      "not_coversWithAbelian_zero — for n>=1, 0 subgroups never cover (PUnit witness) (Erdos117WIP01Cover.lean)",
+      "one_le_abelianCoverNumber — h(n)>=1 for n>=1 when covering set nonempty (Erdos117WIP01Cover.lean)"
     ],
     "insights": [
       "UNIVERSE gotcha (confirmed again): abelianCoverNumber and CoversWithAbelian are universe-polymorphic in the group universe (bodies quantify forall G:Type*), so the VALUE depends on u. Any monotonicity/set-algebra statement must pin one explicit `universe u` and annotate EVERY occurrence with .{u}; unannotated occurrences get independent universes => abelianCoverNumber.{u_1} vs .{u_3} and @h G application-type mismatch. A `universe` command takes a plain /- -/ comment, not a /-- -/ docstring.",
       "Erdos117Problem.lean stub developed: the n=1 case of the n-commuting property is EXACTLY commutativity (commute_of_hasNCommutingProperty_one) - the two-element subset {x,y} forces every distinct pair to commute; plus monotonicity and abelian-subgroup closure lemmas. All axiom-free.",
       "h(1)=1 is fully provable elementarily: the 1-commuting property makes G abelian (commute_of_hasNCommutingProperty_one), so ⊤ is a single abelian subgroup covering G (1 ∈ covering set); and 0 is never in the set since an empty Fin 0 → Subgroup family cannot cover the identity of PUnit. sInf via Nat.sInf_le + Nat.sInf_eq_zero.",
       "No group has the 0-commuting property (singleton {1} has card 1>0 but no distinct pair) — the n-commuting property is vacuous below n=1.",
-      "abelianCoverNumber is universe-polymorphic (its body quantifies ∀ (G:Type*)); membership witnesses must be built INLINE at the set fixed universe — a factored Type* have introduces a second non-unifying universe (level-param mismatch)."
+      "abelianCoverNumber is universe-polymorphic (its body quantifies ∀ (G:Type*)); membership witnesses must be built INLINE at the set fixed universe — a factored Type* have introduces a second non-unifying universe (level-param mismatch).",
+      "Every group (any G, not just finite) is a union of abelian cyclic subgroups: the family g ↦ Subgroup.zpowers g covers G, each zpowers g abelian. So a cover ALWAYS exists for a fixed group (size ≤ |G|); h(n) measures only the UNIFORM count over all n-commuting groups, never existence. (exists_cyclic_abelian_cover, Erdos117WIP01Cover.lean)",
+      "The covering set {k | CoversWithAbelian k n} is a terminal segment: upward-closed in k (pad a k-cover with copies of bot — coversWithAbelian_upward) and, for n>=1, never contains 0 (empty family cannot cover PUnit — not_coversWithAbelian_zero). With Nat.sInf_mem this pins it as [h(n),inf) when nonempty.",
+      "General lower bound h(n)>=1 for n>=1 whenever h(n) is well-defined (covering set nonempty). Complements h(0)=0: the covering number leaves 0 exactly at the n=0->1 step. For n>=2 nonemptiness of the set is precisely Pyber unformalized upper bound. (one_le_abelianCoverNumber)"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Erdős Problem #117 — Covering Groups by Abelian Subgroups

Adds `proofs/Proofs/Erdos117WIP01Cover.lean`: **5 axiom-free theorems** extending the elementary covering theory of `h(n)` (min # abelian subgroups covering any group with the `n`-commuting property). Erdős #117 is OPEN (Pyber: `c₁ⁿ < h(n) < c₂ⁿ`).

Prior companions pin `h(0)=0`, `h(1)=1`, the closure theory of the `n`-commuting property, and monotonicity of `h`. This session adds two pieces:

**1. Every group is a union of abelian (cyclic) subgroups.**
- `isAbelianSubgroup_zpowers` — the cyclic subgroup `zpowers g` is abelian (powers of one element commute).
- `exists_cyclic_abelian_cover` — the family `g ↦ zpowers g` covers any group by abelian subgroups. A cover therefore *always* exists for a fixed group (size `≤ |G|`); the content of `h(n)` is the **uniform** count over all `n`-commuting groups, never mere existence.

**2. The covering set `{k | CoversWithAbelian k n}` is a terminal segment.**
- `coversWithAbelian_upward` — upward closed in `k` (pad a `k`-cover with copies of `⊥`).
- `not_coversWithAbelian_zero` — for `n ≥ 1`, `0` subgroups never cover (empty family can't cover the `PUnit` witness).
- `one_le_abelianCoverNumber` — general lower bound `h(n) ≥ 1` for `n ≥ 1` whenever `h(n)` is well-defined (covering set nonempty). Complements `h(0)=0`: the covering number leaves `0` exactly at the `n=0→1` step.

Together with `Nat.sInf_mem` (from the `Mono` companion), (2) characterises the covering set as `[h(n), ∞)` when nonempty.

### Verification
- Docker-built (`docker-build.sh Proofs.Erdos117WIP01Cover`) on Lean v4.31.0 — build succeeds.
- `#print axioms` on all 5 theorems: only `propext` / `Classical.choice` / `Quot.sound` (no `sorry`, no `Lean.ofReduceBool`).

### Scope / honesty
Pyber's exponential bounds `c₁ⁿ < h(n) < c₂ⁿ` remain deep and **unformalized**; nonemptiness of the covering set for `n ≥ 2` is exactly that unformalized upper bound. This PR is elementary structural scaffolding, not progress on the open exponential-base question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
