### PR TITLE
audit(friendship-theorem-oq-03): clean re-serve

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -19209,9 +19209,9 @@
       "result": "clean"
     },
     "friendship-theorem-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:24Z",
+      "lastAudited": "2026-07-22T12:58:04Z",
       "result": "clean"
     },
     "friendship-theorem-oq-04": {


### PR DESCRIPTION
Clean re-serve. Verified: 0 sorries, 0 axioms, 0 native_decide (kernel `decide`), 11 theorems (line-33 grep hit is a docstring false positive), 7 defs — all match meta. Headline `friendship_theorem_fails_for_hypergraphs` is a genuine Fano-plane STS(7) counterexample. `originalContributions: None`, badge `mathlib` conservatively understates originality. General counting theorems are weak conditional identities but not overclaimed in meta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)