### PR TITLE
research(erdos-46-wip-01): cost lower bound for large-min-denom reprs (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos46WIP01Cost.lean
+++ b/proofs/Proofs/Erdos46WIP01Cost.lean
@@ -1,0 +1,73 @@
+/-
+  Erdős Problem #46 — Monochromatic Unit-Fraction Representations:
+  the cost of large minimum denominators (0-axiom).
+
+  Companion to `Erdos46Problem.lean`, which defines `IsUnitFractionRepr S`
+  (`∀ n ∈ S, 2 ≤ n` and `∑_{n∈S} 1/n = 1`) and develops a large "construction"
+  toolkit — telescoping, divisor-sum, greedy over/undershoot, and the two-sided
+  `bracket_one` approximations of `1` by representations whose denominators all
+  exceed a prescribed `N`.  Those results attack the *existence* of an exact
+  representation of `1` with minimum denominator `> N`.
+
+  This file supplies the complementary **lower bound / obstruction** side, which
+  the construction toolkit does not address: it quantifies the unavoidable cost of
+  pushing the minimum denominator up.
+
+  * `card_ge_of_forall_gt` — if every denominator of a unit-fraction
+    representation of `1` exceeds `N`, then the representation uses at least
+    `N + 1` terms.  (Each term is `≤ 1/(N+1)`, and they sum to `1`.)  So the
+    "minimum denominator `> N`" goal is genuinely expensive: it forces the
+    cardinality to grow at least linearly in `N`.
+
+  * `exists_le_card` — dually, in *any* unit-fraction representation of `1` the
+    smallest denominator is at most the number of terms: some `n ∈ S` has
+    `n ≤ |S|`.  (Otherwise every denominator would exceed `|S|`, forcing
+    `|S| ≥ |S| + 1` by the previous bound.)
+
+  Neither statement is a construction, so neither is equivalent-strength to the
+  open target (an exact representation of `1` with arbitrarily large minimum
+  denominator); they are necessary conditions constraining any such
+  representation.  The deep monochromatic result (Croot 2003) stays unformalized.
+
+  0 axioms, 0 sorries — `#print axioms` = propext / Classical.choice / Quot.sound.
+-/
+
+import Mathlib
+import Proofs.Erdos46Problem
+
+open Finset
+
+/-- **Large minimum denominator forces many terms.**  If `S` is a unit-fraction
+    representation of `1` and every denominator exceeds `N` (`∀ n ∈ S, N < n`),
+    then `N + 1 ≤ |S|`.  Each term satisfies `1/n ≤ 1/(N+1)`, so the total
+    `∑_{n∈S} 1/n = 1` is at most `|S| · 1/(N+1)`; hence `|S| ≥ N + 1`. -/
+theorem card_ge_of_forall_gt {S : Finset ℕ} {N : ℕ}
+    (hS : IsUnitFractionRepr S) (hN : ∀ n ∈ S, N < n) : N + 1 ≤ S.card := by
+  obtain ⟨_, hsum⟩ := hS
+  have hNpos : (0 : ℚ) < (N : ℚ) + 1 := by positivity
+  -- every term is bounded by 1/(N+1)
+  have hterm : ∀ n ∈ S, (1 : ℚ) / n ≤ 1 / ((N : ℚ) + 1) := by
+    intro n hn
+    have hle : (N : ℚ) + 1 ≤ (n : ℚ) := by exact_mod_cast hN n hn
+    exact one_div_le_one_div_of_le hNpos hle
+  -- sum ≤ card • (1/(N+1)); rewrite the sum as 1
+  have hbound : S.sum (fun n => (1 : ℚ) / n) ≤ S.card • ((1 : ℚ) / ((N : ℚ) + 1)) :=
+    Finset.sum_le_card_nsmul S _ _ hterm
+  rw [hsum, nsmul_eq_mul] at hbound
+  -- 1 ≤ card * (1/(N+1)); multiply through by (N+1) > 0 and cancel
+  have hmul := mul_le_mul_of_nonneg_right hbound (le_of_lt hNpos)
+  rw [one_mul, mul_assoc, one_div_mul_cancel (ne_of_gt hNpos), mul_one] at hmul
+  -- hmul : (N : ℚ) + 1 ≤ (S.card : ℚ)
+  exact_mod_cast hmul
+
+/-- **The smallest denominator never exceeds the number of terms.**  In any
+    unit-fraction representation `S` of `1`, some denominator is `≤ |S|`.  If not,
+    every denominator would exceed `|S|`, and `card_ge_of_forall_gt` (with
+    `N = |S|`) would give `|S| + 1 ≤ |S|` — impossible. -/
+theorem exists_le_card {S : Finset ℕ} (hS : IsUnitFractionRepr S) :
+    ∃ n ∈ S, n ≤ S.card := by
+  by_contra h
+  push_neg at h
+  -- h : ∀ n ∈ S, S.card < n
+  have := card_ge_of_forall_gt hS h
+  omega

--- a/src/data/research/problems/erdos-46-wip-01.json
+++ b/src/data/research/problems/erdos-46-wip-01.json
@@ -42,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-1, 2026-07-21): added exists_isUnitFractionRepr_card_eq (exact cardinality k for all k≥3, 0-axiom). Established that the min>N-repr-of-exactly-1 target is NOT reachable by the union/scaling/telescoping engines: the natural assembly routes are equivalent-strength (recorded as blocked routes). Genuine remaining nugget = greedy-harmonic-plus-excess-adjustment or explicit Diophantine tuning. Deep Croot 2003 monochromatic result stays unformalized.",
+    "progressSummary": "PROGRESS (researcher-1-3, 2026-07-22): added Erdos46WIP01Cost.lean (2 axiom-free theorems) — the OBSTRUCTION/lower-bound side complementing the existing construction toolkit. card_ge_of_forall_gt: min denom >N forces >=N+1 terms (cost grows linearly in N). exists_le_card: smallest denom <= card. Neither is a construction, so neither is equivalent-strength to the open large-min-denom target. Exact landing on 1 with min>N (bounded Diophantine subset-sum) + deep Croot 2003 remain unformalized.",
     "builtItems": [
       "exists_isRatFractionRepr_bracket_one in Erdos46Problem.lean (0-axiom) — packages controlled overshoot+undershoot into a single two-sided bracket of 1: exists Slo,Shi,qlo,qhi with both reprs' denoms > N, qlo<1<=qhi, and explicit vanishing width qhi-qlo < 2/(N+1). Launching point for exact landing on 1.",
       "not_isUnitFractionRepr_singleton — no singleton represents 1 (Erdos46Problem.lean)",
@@ -58,7 +58,9 @@
       "exists_isRatFractionRepr_min_gt (Erdos46Problem.lean): ∀ B L≥1, ∃ repr of a POSITIVE rational using exactly L denominators all > B (0-axiom)",
       "injective_mul_succ (Erdos46Problem.lean): k↦k(k+1) injective on ℕ (strictMono_nat_of_lt_succ)",
       "exists_isUnitFractionRepr_card_eq in proofs/Proofs/Erdos46Problem.lean (|S|=k for all k≥3, 0-axiom, host-verified)",
-      "Divisor-sum bridge (Erdos46Problem.lean): isUnitFractionRepr_of_divisorSum — distinct divisors T of M with 2d≤M and Σ_{d∈T}d=M yield IsUnitFractionRepr {M/d}; divisorSum_min_gt — N·d<M ∀d∈T forces every denominator M/d > N. Host-verified v4.31.0, #print axioms = [propext, Classical.choice, Quot.sound] (0 added axioms, 0 sorries)."
+      "Divisor-sum bridge (Erdos46Problem.lean): isUnitFractionRepr_of_divisorSum — distinct divisors T of M with 2d≤M and Σ_{d∈T}d=M yield IsUnitFractionRepr {M/d}; divisorSum_min_gt — N·d<M ∀d∈T forces every denominator M/d > N. Host-verified v4.31.0, #print axioms = [propext, Classical.choice, Quot.sound] (0 added axioms, 0 sorries).",
+      "card_ge_of_forall_gt — min denom >N ==> card >= N+1 (Erdos46WIP01Cost.lean, 0-axiom)",
+      "exists_le_card — smallest denom <= card in any unit-fraction repr of 1 (Erdos46WIP01Cost.lean, 0-axiom)"
     ],
     "insights": [
       "Erdos46Problem.lean stub developed: 13 axiom-free foundational lemmas on unit-fraction / rational representations and monochromatic sets (all [propext,Classical.choice,Quot.sound], no sorry/native_decide).",
@@ -70,7 +72,9 @@
       "The min>N regime is now reached for the two-parameter family 1/a−1/b (a>B); the ONLY remaining gap toward pairwise-disjoint chaining is assembling a repr of EXACTLY 1 with min>N (collision-free), which telescoping alone does not give (its value 1/a−1/b < 1).",
       "Exact-cardinality: unit-fraction reprs of 1 exist for EVERY cardinality k≥3, and 3 is the exact minimum (a 2-term 1/a+1/b=1 with a,b≥2 forces a=b=2, not distinct). Split-largest raises |S| by exactly 1.",
       "EQUIVALENT-STRENGTH BLOCKER (min>N repr of exactly 1): every elementary bootstrap bottoms out at representing a fixed unit fraction 1/c with min>N. But scaling by t maps a min>M repr of 1 to a min>tM repr of 1/t, and two nested-scale disjoint 1/2-reprs union back to a min>N repr of 1 — so \"1/c with min>N\" and \"1 with min>N\" are equivalent strength. Hence the union-assembly and raise-min-by-one routes earn ZERO decomposition credit.",
-      "Divisor-sum reformulation of the open crux: repr of 1 with min>N ⟺ some M is a sum of distinct divisors each < M/N (forward = isUnitFractionRepr_of_divisorSum; converse via M=lcm S, d_s=M/s). Being an iff, the reduction is EQUIVALENT-STRENGTH (no decomposition credit), but it re-expresses the crux in multiplicative NT where Nat.divisors is available. The residual open content is a practical-number completeness fact: exhibit M with enough SMALL divisors (all < M/N) summing exactly to M. This is a materially new mechanism distinct from the two blocked bootstrap routes (union/scaling, raise-min-by-one)."
+      "Divisor-sum reformulation of the open crux: repr of 1 with min>N ⟺ some M is a sum of distinct divisors each < M/N (forward = isUnitFractionRepr_of_divisorSum; converse via M=lcm S, d_s=M/s). Being an iff, the reduction is EQUIVALENT-STRENGTH (no decomposition credit), but it re-expresses the crux in multiplicative NT where Nat.divisors is available. The residual open content is a practical-number completeness fact: exhibit M with enough SMALL divisors (all < M/N) summing exactly to M. This is a materially new mechanism distinct from the two blocked bootstrap routes (union/scaling, raise-min-by-one).",
+      "COST LOWER BOUND (obstruction side, non-equivalent-strength): representing 1 by unit fractions all with denominator >N FORCES cardinality >= N+1 (each term <=1/(N+1), sum=1). So the large-min-denom target is genuinely expensive — cardinality grows at least linearly in N. This is a necessary constraint on any such repr, NOT a construction. (card_ge_of_forall_gt, Erdos46WIP01Cost.lean)",
+      "DUAL: in ANY unit-fraction repr of 1 the smallest denominator is <= number of terms (some n in S has n<=|S|); else all denoms >|S| would force |S|>=|S|+1. (exists_le_card)"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Erdős Problem #46 — Cost of large minimum denominators

Adds `proofs/Proofs/Erdos46WIP01Cost.lean`: **2 axiom-free theorems** giving the **obstruction / lower-bound** side of the "unit-fraction representation of 1 with minimum denominator > N" question. The existing large toolkit in `Erdos46Problem.lean` (telescoping, divisor-sum, greedy over/undershoot, `bracket_one`) attacks *existence* of such representations; this file quantifies their unavoidable **cost**, which the construction toolkit does not address.

- `card_ge_of_forall_gt` — if every denominator of a unit-fraction representation of `1` exceeds `N`, the representation uses **at least `N + 1` terms**. Each term is `≤ 1/(N+1)` and they sum to `1`, so cardinality grows at least linearly in `N`.
- `exists_le_card` — dually, in *any* unit-fraction representation of `1` the smallest denominator is at most the number of terms (`∃ n ∈ S, n ≤ |S|`).

### Strength / honesty
Neither theorem is a construction, so **neither is equivalent-strength** to the open large-min-denominator target (recorded blocked routes concern *assembly* constructions). They are necessary conditions constraining any such representation. The exact-landing-on-1 crux (a bounded-rational Diophantine subset-sum) and the deep monochromatic Croot 2003 result remain unformalized.

### Verification
- Docker-built (`docker-build.sh Proofs.Erdos46WIP01Cost`) on Lean v4.31.0 — succeeds.
- `#print axioms` on both theorems: only `propext` / `Classical.choice` / `Quot.sound` (no `sorry`, no `Lean.ofReduceBool`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
