### PR TITLE
audit(cycle47): 5 clean re-serves (divisibility-by-3, brouwer, kummer, erdos-909/70)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3722,9 +3722,9 @@
       "issues": []
     },
     "brouwer-fixed-point-oq-02-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:24Z",
+      "lastAudited": "2026-07-22T13:02:21Z",
       "result": "clean"
     },
     "brouwer-fixed-point-oq-04": {
@@ -7787,9 +7787,9 @@
       "result": "issues-fixed"
     },
     "divisibility-by-3-oq-04-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:24Z",
+      "lastAudited": "2026-07-22T13:01:43Z",
       "result": "clean"
     },
     "divisibility-by-three-oq-01": {
@@ -15730,9 +15730,9 @@
       "result": "clean"
     },
     "erdos-70-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:40Z",
+      "lastAudited": "2026-07-22T13:04:07Z",
       "result": "clean"
     },
     "erdos-700": {
@@ -17305,9 +17305,9 @@
       "result": "clean"
     },
     "erdos-909-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:40Z",
+      "lastAudited": "2026-07-22T13:03:21Z",
       "result": "clean"
     },
     "erdos-91": {
@@ -21554,9 +21554,9 @@
       "result": "clean"
     },
     "kummer-theorem-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:40Z",
+      "lastAudited": "2026-07-22T13:02:55Z",
       "result": "clean"
     },
     "kummer-theorem-oq-02-oq-03": {


### PR DESCRIPTION
Reserve-mode cycle 47 (queue drained, 4809/4809 audited). Re-served the 5 oldest entries (last audited 2026-05-04, 3× each). All clean — honest badges, matching counts, proper native_decide/axiom/Mathlib disclosure.

| slug | result | notes |
|------|--------|-------|
| divisibility-by-3-oq-04-oq-02 | clean | 0ax-decl/0sorry/22thm; 11 named native_decide → axiomCount=1 (`Lean.ofReduceBool`) disclosed in desc+conclusion+count; exemplary |
| brouwer-fixed-point-oq-02-oq-02 | clean | 0ax/0sorry/17 genuine analysis thms; `mathlib` badge conservatively understates originality |
| kummer-theorem-oq-02 | clean | 0ax/0sorry; qKummer genuinely proved over ℤ[X] (quotient formula+cyclotomic products+integral-domain cancel); not in Mathlib → `original` warranted |
| erdos-909-oq-01 | clean | 2ax/0sorry/10thm all match; product-dim inequality + Anderson-Keisler existence axioms disclosed & consistent; Tier-C honest |
| erdos-70-oq-01 | clean | 0ax/0sorry/14 ordinal-partition thms; non-degenerate PartitionArrow def; `wip` badge honest |

No integrity issues filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)