### PR TITLE
research(erdos-98-wip-01): monotonicity-sharpened small-n lower bounds (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos98WIP01Thresholds.lean
+++ b/proofs/Proofs/Erdos98WIP01Thresholds.lean
@@ -1,0 +1,61 @@
+/-
+  Erdős Problem #98 — Distinct distances in general position:
+  monotonicity-sharpened small-`n` lower bounds (0-axiom).
+
+  Companion to `Erdos98WIP01.lean`, which pins the exact values `h 2 = h 3 = 1`,
+  `h 4 = 2`, `h 5 = 3`, proves `h` is monotone (`h_mono`), and gives the general
+  elementary ladder `le_h_of_three_mul_sub_one_le : 3 * k - 1 ≤ n → k ≤ h n`.
+
+  The ladder is the sharpest *uniform* elementary lower bound, but for a fixed
+  small `n` an exact base value combined with monotonicity beats it.  In
+  particular the ladder yields `3 ≤ h n` only from `n ≥ 8` (`k = 3` needs
+  `n ≥ 3·3 - 1 = 8`), whereas `h 5 = 3` together with `h_mono` gives `3 ≤ h n`
+  for *every* `n ≥ 5`.  This file records those sharpened thresholds, filling the
+  `n ∈ {5, 6, 7}` gap the ladder leaves open — the current best-known lower bounds
+  for `h 6` and `h 7`.
+
+  * `two_le_h_of_four_le`   : `4 ≤ n → 2 ≤ h n`   (from `h 4 = 2`, monotone).
+  * `three_le_h_of_five_le` : `5 ≤ n → 3 ≤ h n`   (from `h 5 = 3`, monotone).
+  * `three_le_h_six` / `three_le_h_seven` : the `n = 6, 7` instances the ladder
+    cannot reach.
+
+  These are honest corollaries, not new mechanisms: pinning `h 6 = 3` (or proving
+  `h 6 ≥ 4`) is a genuinely open direction — it needs either an explicit
+  general-position 6-point 3-distance configuration (whose existence is itself
+  open; the regular hexagon and pentagon-plus-centre are disqualified by the
+  no-four-concyclic condition) or incidence-geometry machinery beyond Mathlib.
+
+  0 axioms, 0 sorries — `#print axioms` = propext / Classical.choice / Quot.sound.
+-/
+
+import Mathlib
+import Proofs.Erdos98WIP01
+
+namespace Erdos98WIP01
+
+/-- **`2 ≤ h n` for every `n ≥ 4.`**  Immediate from the exact value `h 4 = 2` and
+    monotonicity of `h`: adding points (in general position) can only increase the
+    minimum number of distinct distances. -/
+theorem two_le_h_of_four_le {n : ℕ} (hn : 4 ≤ n) : 2 ≤ h n := by
+  have := h_mono hn
+  rwa [h_four] at this
+
+/-- **`3 ≤ h n` for every `n ≥ 5.`**  From the exact value `h 5 = 3` and
+    monotonicity.  This sharpens the general ladder bound
+    `le_h_of_three_mul_sub_one_le`, which only reaches `3 ≤ h n` from `n ≥ 8`;
+    monotonicity closes the `n ∈ {5, 6, 7}` gap. -/
+theorem three_le_h_of_five_le {n : ℕ} (hn : 5 ≤ n) : 3 ≤ h n := by
+  have := h_mono hn
+  rwa [h_five_eq_three] at this
+
+/-- **`3 ≤ h 6.`**  The current best-known lower bound for six points in general
+    position, obtained purely from `h 5 = 3` and monotonicity — the ladder bound
+    does not reach `3` until `n ≥ 8`.  Whether `h 6 = 3` (equivalently, whether a
+    general-position 6-point set with only 3 distinct distances exists) is open. -/
+theorem three_le_h_six : 3 ≤ h 6 := three_le_h_of_five_le (by norm_num)
+
+/-- **`3 ≤ h 7.`**  Likewise from `h 5 = 3` and monotonicity; still below the
+    ladder's `n ≥ 8` threshold. -/
+theorem three_le_h_seven : 3 ≤ h 7 := three_le_h_of_five_le (by norm_num)
+
+end Erdos98WIP01

--- a/src/data/research/problems/erdos-98-wip-01.json
+++ b/src/data/research/problems/erdos-98-wip-01.json
@@ -42,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE through h 5 = 3 (axiom-free). Lower-bound frontier now consolidated: le_h_of_three_mul_sub_one_le gives the general elementary bound k ≤ h n for n ≥ 3k−1 (subsumes the whole ladder). Improving the linear (n−1)/3 bound toward the conjectured super-linear rate is the deep open direction (Erdős #98).",
+    "progressSummary": "COMPLETE through h 5 = 3 (axiom-free). General ladder le_h_of_three_mul_sub_one_le (k<=h(n) for n>=3k-1) subsumes the uniform lower-bound ladder. Added (2026-07-22, researcher-1-3) Erdos98WIP01Thresholds.lean: monotonicity-sharpened small-n bounds filling the ladder gap — 3<=h(n) for all n>=5 (ladder only reaches n>=8), giving 3<=h(6),3<=h(7) as best-known. Deep open: super-linear rate (Guth-Katz, absent from Mathlib) and exact h(6) (needs open 6-point 3-distance config).",
     "builtItems": [
       "InGeneralPosition.injective in Erdos98WIP01.lean",
       "numDistinctDistances_le_offDiag (≤ n·(n−1)) in Erdos98WIP01.lean",
@@ -105,7 +105,8 @@
       "three_le_h_five (Erdos98WIP01.lean): 3 <= h 5, via centroid concyclicity contradicting NoFourConcyclic (axiom-free, maxHeartbeats 1600000, docker-verified).",
       "h_five_eq_three (Erdos98WIP01.lean): h 5 = 3, pinned exactly via le_antisymm h_five_le_three three_le_h_five (axiom-free, docker-verified).",
       "two_common_neighbours_dist (Erdos98WIP01.lean:1782, axiom-free, docker-built 8577 jobs): in EuclideanSpace ℝ (Fin 2), dist p q = a ∧ dist x p = dist x q = dist y p = dist y q = a ∧ a>0 → x = y ∨ dist x y = a·√3. Discharges the intersecting-circle distance equations of the h 5 ≥ 3 degree-3 sub-cases.",
-      "le_h_of_three_mul_sub_one_le (Erdos98WIP01.lean:~1901): general closed-form lower bound k ≤ h n for n ≥ 3k−1, axiom-free (omega from three_mul_h_ge). Existing rungs three_le_h_of_eight_le / four_le_h_of_eleven_le rewritten as one-line k=3/k=4 specializations; added five_le_h_of_fourteen_le (k=5)."
+      "le_h_of_three_mul_sub_one_le (Erdos98WIP01.lean:~1901): general closed-form lower bound k ≤ h n for n ≥ 3k−1, axiom-free (omega from three_mul_h_ge). Existing rungs three_le_h_of_eight_le / four_le_h_of_eleven_le rewritten as one-line k=3/k=4 specializations; added five_le_h_of_fourteen_le (k=5).",
+      "two_le_h_of_four_le, three_le_h_of_five_le, three_le_h_six, three_le_h_seven — monotonicity-sharpened small-n lower bounds (Erdos98WIP01Thresholds.lean, 0-axiom)"
     ],
     "insights": [
       "Every positive pairwise distance comes from an off-diagonal ordered pair (dist>0 ⟹ points distinct ⟹ indices distinct), giving the clean upper bound numDistinctDistances P ≤ n·(n−1) via Finset.offDiag_card — the trivial ceiling of the h(n) envelope.",
@@ -158,7 +159,8 @@
       "Intersecting-circles rigidity (two_common_neighbours_dist): two points each at distance a from both endpoints of an a-length segment are equal or exactly a√3 apart — the two circle intersections are the far vertices of a two-equilateral-triangle rhombus. This is the exact metric fact behind the degree-3 sub-case circle equations (|YZ| = a√3).",
       "Clean planar-rigidity mechanism: with u=x−p, v=y−p, w=q−p (all norm a, ⟨u,w⟩=⟨v,w⟩=a²/2), the vector e=u+v−w is orthogonal to both w and d=u−v; if x≠y then d≠0, and e≠0 would make e,w,d three pairwise-orthogonal nonzero vectors (linearly independent) — impossible in dim 2. So e=0, i.e. u+v=w, forcing ⟨u,v⟩=−a²/2 and ‖x−y‖²=3a². Same regular-simplex-needs-dimension argument as no_four_mutually_equidistant, run one dimension lower.",
       "Lean gotcha: simp only [inner_sub_left, inner_add_left, ...] canonicalizes ⟪u,v⟫ to a fixed argument order (⟪v,u⟫ here), so a follow-up rw [real_inner_comm .., htval] whose LHS is ⟪u,v⟫ fails to fire — finish such goals with linarith [htval, hc] (hc : ⟪v,u⟫=⟪u,v⟫) instead of orientation-sensitive rw. Also real_inner_comms explicit args are the reverse orientation; use real_inner_comm _ _ driven by the expected type. And explicit rw [inner_sub_right] over `set`-bound u:=x−p unfolds the local def (⟪u,u⟫→⟪u,x⟫−⟪u,p⟫); prefer simp only for the expansion.",
-      "General elementary lower bound in closed form: le_h_of_three_mul_sub_one_le proves k ≤ h n for every target k as soon as n ≥ 3·k − 1 (from n−1 ≤ 3·h n = three_mul_h_ge, since then 3·h n ≥ 3k−2 > 3(k−1)). This single theorem subsumes the entire infinite ladder of concrete rungs (k=3⇒n≥8, k=4⇒n≥11, k=5⇒n≥14, …), replacing enumeration with the general statement — the sharpest elementary general lower bound on h; the conjectured super-linear rate h n/n → ∞ (Erdős #98) is far beyond it and stays open."
+      "General elementary lower bound in closed form: le_h_of_three_mul_sub_one_le proves k ≤ h n for every target k as soon as n ≥ 3·k − 1 (from n−1 ≤ 3·h n = three_mul_h_ge, since then 3·h n ≥ 3k−2 > 3(k−1)). This single theorem subsumes the entire infinite ladder of concrete rungs (k=3⇒n≥8, k=4⇒n≥11, k=5⇒n≥14, …), replacing enumeration with the general statement — the sharpest elementary general lower bound on h; the conjectured super-linear rate h n/n → ∞ (Erdős #98) is far beyond it and stays open.",
+      "Monotonicity sharpens small-n lower bounds beyond the ladder: le_h_of_three_mul_sub_one_le reaches 3<=h(n) only from n>=8, but h(5)=3 + h_mono gives 3<=h(n) for ALL n>=5, filling the n in {5,6,7} gap. three_le_h_six / three_le_h_seven are the current best-known lower bounds for h(6),h(7). (Erdos98WIP01Thresholds.lean, 0-axiom)"
     ],
     "mathlibGaps": [
       "Classification of planar 2-distance sets (max 5 points = regular pentagon, unique up to similarity) is absent from Mathlib — needed for h 5 ≥ 3.",


### PR DESCRIPTION
## Erdős Problem #98 — monotonicity-sharpened small-`n` lower bounds

Adds `proofs/Proofs/Erdos98WIP01Thresholds.lean` (4 axiom-free theorems) filling a gap the general ladder leaves open. The existing `Erdos98WIP01.lean` proves the exact values `h 2 = h 3 = 1`, `h 4 = 2`, `h 5 = 3`, monotonicity `h_mono`, and the ladder `le_h_of_three_mul_sub_one_le : 3·k - 1 ≤ n → k ≤ h n`.

The ladder reaches `3 ≤ h n` only from `n ≥ 8` (`k = 3` needs `n ≥ 8`). But `h 5 = 3` + monotonicity gives `3 ≤ h n` for **every `n ≥ 5`**, closing the `n ∈ {5, 6, 7}` gap:

- `two_le_h_of_four_le` — `2 ≤ h n` for `n ≥ 4`.
- `three_le_h_of_five_le` — `3 ≤ h n` for `n ≥ 5`.
- `three_le_h_six`, `three_le_h_seven` — the `n = 6, 7` instances, the **current best-known lower bounds** for `h 6` and `h 7`, unreachable by the ladder.

### Strength / honesty
These are honest corollaries of exact base values + `h_mono`, **not new mechanisms**. Pinning `h 6 = 3` (or proving `h 6 ≥ 4`) is genuinely open — it needs either an explicit general-position 6-point 3-distance configuration (existence itself open; regular hexagon and pentagon-plus-centre are disqualified by no-four-concyclic) or incidence-geometry machinery beyond Mathlib. The super-linear rate (Guth–Katz) also remains out of reach. Both are recorded blocked routes.

### Verification
- Docker-built (`docker-build.sh Proofs.Erdos98WIP01Thresholds`) on Lean v4.31.0 — succeeds.
- `#print axioms` on all theorems: only `propext` / `Classical.choice` / `Quot.sound` (no `sorry`, no `Lean.ofReduceBool`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
