### PR TITLE
research(erdos-30-wip-01): exact values h(7)=h(8)=h(9)=4 (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos30WIP01.lean
+++ b/proofs/Proofs/Erdos30WIP01.lean
@@ -410,4 +410,40 @@ theorem sidonNumber_six : sidonNumber 6 = 4 := by
   · calc 4 = ({0, 1, 4, 6} : Finset ℕ).card := by decide
       _ ≤ sidonNumber 6 := sidonNumber_ge_card (by decide) isSidonSet_0_1_4_6
 
+/-- `h(7) = 4`: the counting bound rules out a 5-element Sidon set
+(`5·4 = 20 > 14 = 2·7`), and `{0,1,4,6} ⊆ {0,…,7}` still attains `4`.
+
+Unlike `h(6)`, the quadratic `m² ≤ 2·7 + m` has its real root at `(1+√57)/2 ≈ 4.27`,
+so `nlinarith` needs the integrality step `5 ≤ m` (from `4 < m` over `ℕ`) to exclude
+the real gap `(4, 4.27]`. -/
+theorem sidonNumber_seven : sidonNumber 7 = 4 := by
+  refine le_antisymm (sidonNumber_le_of_sq fun m hm => ?_) ?_
+  · by_contra hc; rw [not_le] at hc
+    have h5 : 5 ≤ m := hc
+    nlinarith [hm, h5]
+  · calc 4 = ({0, 1, 4, 6} : Finset ℕ).card := by decide
+      _ ≤ sidonNumber 7 := sidonNumber_ge_card (by decide) isSidonSet_0_1_4_6
+
+/-- `h(8) = 4`: `5·4 = 20 > 16 = 2·8` still blocks a 5-element Sidon set, and
+`{0,1,4,6} ⊆ {0,…,8}` attains `4`. -/
+theorem sidonNumber_eight : sidonNumber 8 = 4 := by
+  refine le_antisymm (sidonNumber_le_of_sq fun m hm => ?_) ?_
+  · by_contra hc; rw [not_le] at hc
+    have h5 : 5 ≤ m := hc
+    nlinarith [hm, h5]
+  · calc 4 = ({0, 1, 4, 6} : Finset ℕ).card := by decide
+      _ ≤ sidonNumber 8 := sidonNumber_ge_card (by decide) isSidonSet_0_1_4_6
+
+/-- `h(9) = 4`: `5·4 = 20 > 18 = 2·9` blocks a 5-element Sidon set, and
+`{0,1,4,6} ⊆ {0,…,9}` attains `4`.  `h(10)` is the first value where the counting
+bound goes slack (`5·4 = 20 = 2·10` admits `m = 5`), so the table's easy stretch
+ends here — a 5-element Sidon set first fits at `N = 11` (`{0,1,4,9,11}`). -/
+theorem sidonNumber_nine : sidonNumber 9 = 4 := by
+  refine le_antisymm (sidonNumber_le_of_sq fun m hm => ?_) ?_
+  · by_contra hc; rw [not_le] at hc
+    have h5 : 5 ≤ m := hc
+    nlinarith [hm, h5]
+  · calc 4 = ({0, 1, 4, 6} : Finset ℕ).card := by decide
+      _ ≤ sidonNumber 9 := sidonNumber_ge_card (by decide) isSidonSet_0_1_4_6
+
 end Erdos30

--- a/src/data/research/problems/erdos-30-wip-01.json
+++ b/src/data/research/problems/erdos-30-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Two-sided elementary theory now includes EXACT small values h(0..6)=1,2,2,3,3,3,4 (sharp counting bound + optimal explicit sets) alongside upper sqrt(2N)+1 and lower unbounded(log). Remaining DEEP: N^{1/4} refinement, Singer sqrt(N) lower bound, $1000 conjecture.",
+    "progressSummary": "PROGRESS (researcher-1-3, 2026-07-22): extended the exact sidonNumber table to h(7)=h(8)=h(9)=4 (previously through h(6)=4). Counting bound tight through N=9; N=10 first slack (needs exhaustive lower bound). Two-sided elementary bounds stand: upper floor-sqrt(2N)+1 / sharp counting; lower unbounded(log2) via powers of two. DEEP: sharp sqrt(N) construction (Singer), N^{1/4} refinement, $1000 conjecture remain.",
     "builtItems": [
       "Erdos30WIP01.lean: diffMap_injOn (Set.InjOn of difference map on Sidon off-diagonal)",
       "Erdos30WIP01.lean: sidon_offDiag_card_le (|A.offDiag| ≤ 2N for Sidon A ⊆ {0..N})",
@@ -43,7 +43,8 @@
       "two_pow_add_inj (Erdos30WIP01.lean): 2^i+2^j=2^p+2^q (sorted) => exponents match [0-axiom]",
       "sidonNumber_two_pow_ge (Erdos30WIP01.lean): k+1 <= sidonNumber (2^k) [0-axiom]",
       "sidonNumber_unbounded (Erdos30WIP01.lean): forall M, exists N, M <= sidonNumber N [0-axiom]",
-      "Erdos30WIP01.lean: exact initial Sidon numbers sidonNumber_zero..six — h(0..6)=1,2,2,3,3,3,4. Sharp counting bound sidon_card_sq_le matched to optimal explicit Sidon sets {0},{0,1},{0,1,3},{0,1,4,6}. Reusable helpers sidonNumber_ge_card (lower from explicit set) + sidonNumber_le_of_sq (sharp upper via quadratic, tighter than floor-sqrt). 0-axiom docker-verified v4.31."
+      "Erdos30WIP01.lean: exact initial Sidon numbers sidonNumber_zero..six — h(0..6)=1,2,2,3,3,3,4. Sharp counting bound sidon_card_sq_le matched to optimal explicit Sidon sets {0},{0,1},{0,1,3},{0,1,4,6}. Reusable helpers sidonNumber_ge_card (lower from explicit set) + sidonNumber_le_of_sq (sharp upper via quadratic, tighter than floor-sqrt). 0-axiom docker-verified v4.31.",
+      "sidonNumber_seven/eight/nine = 4 — exact values via counting upper + {0,1,4,6} witness (Erdos30WIP01.lean, 0-axiom)"
     ],
     "insights": [
       "Erdős–Turán upper bound is provable elementarily via difference-map injectivity: for a Sidon set A the map (a,b)↦a−b is injective on the off-diagonal (a−b=c−d ⇒ a+d=c+b ⇒ pair matches by the Sidon property), its image is nonzero integers in [−N,N] (2N of them), so |A.offDiag|=|A|²−|A| ≤ 2N.",
@@ -51,7 +52,8 @@
       "Mathlib has NO Sidon/B₂-set API and no roots-of-unity/Vandermonde discriminant product; the counting bound is best built from Finset.offDiag_card, Int.card_Icc, and Nat.le_sqrt.",
       "Powers of two {2^0,...,2^k} form a Sidon set (isSidonSet_two_pow_range): sum-injectivity via 2-adic parity (two_pow_add_inj) — factor out 2^min, then odd-vs-even cofactor / 2-vs->=4 forces exponents to match.",
       "sidonNumber_two_pow_ge: h(2^k) >= k+1, so sidonNumber is UNBOUNDED (sidonNumber_unbounded). First growing lower bound in the file (previously only trivial h(N)>=1). Only logarithmic — sharp sqrt(N) growth needs Singer/perfect-difference-set constructions absent from Mathlib.",
-      "h(N) exact for N<=6 is a non-strict step function 1,2,2,3,3,3,4; the elementary quadratic bound |A|(|A|-1)<=2N is TIGHT here (floor-sqrt(2N)+1 is NOT, e.g. it gives h(5)<=4 but truth is 3). Optimal witnesses are perfect rulers/difference sets: {0,1,3} (N<=5), {0,1,4,6} (N=6, diffs 1..6 exhaust)."
+      "h(N) exact for N<=6 is a non-strict step function 1,2,2,3,3,3,4; the elementary quadratic bound |A|(|A|-1)<=2N is TIGHT here (floor-sqrt(2N)+1 is NOT, e.g. it gives h(5)<=4 but truth is 3). Optimal witnesses are perfect rulers/difference sets: {0,1,3} (N<=5), {0,1,4,6} (N=6, diffs 1..6 exhaust).",
+      "Exact-value table extended to h(7)=h(8)=h(9)=4: counting bound sidonNumber_le_of_sq blocks a 5-element Sidon set (5*4=20 > 2N for N<=9), and {0,1,4,6}<=range(N+1) attains 4. h(10) is the first slack point (5*4=20=2*10 admits m=5); a 5-element Sidon set first fits at N=11 ({0,1,4,9,11}). For N>=7 nlinarith needs the integrality step 5<=m since the quadratic real root exceeds 4. (Erdos30WIP01.lean, 0-axiom)"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Erdős Problem #30 (Sidon sets) — exact values `h(7)=h(8)=h(9)=4`

Extends the exact `sidonNumber` table in `Erdos30WIP01.lean` (previously computed through `h(6)=4`) by three more values, reusing the existing sharp counting bound `sidonNumber_le_of_sq` and the optimal witness `{0,1,4,6}`:

- `sidonNumber_seven`, `sidonNumber_eight`, `sidonNumber_nine` — all `= 4`.

The counting bound `5·4 = 20 > 2N` rules out a 5-element Sidon set for `N ≤ 9`, and `{0,1,4,6} ⊆ {0,…,N}` attains size `4`. So `h(N) = 4` for `N ∈ {6,7,8,9}`.

`h(10)` is the first value where the counting bound goes slack (`5·4 = 20 = 2·10` admits `m = 5`), so this easy stretch of the table ends here — a 5-element Sidon set first fits at `N = 11` (`{0,1,4,9,11}`), and pinning `h(10)` would need an exhaustive lower-bound argument.

### Proof note
Unlike `h(6)` (whose quadratic `m² ≤ 2·6 + m` has real root exactly `4`), for `N ≥ 7` the real root exceeds `4` (e.g. `(1+√57)/2 ≈ 4.27` at `N=7`), so `nlinarith` needs the integrality step `5 ≤ m` (from `4 < m` over `ℕ`) to exclude the real gap `(4, root]`.

### Verification
- Docker-built (`docker-build.sh Proofs.Erdos30WIP01`) on Lean v4.31.0 — succeeds.
- `#print axioms` on all three theorems: only `propext` / `Classical.choice` / `Quot.sound` (no `sorry`, no `Lean.ofReduceBool`).

### Scope
Elementary table extension only. The sharp `√N`-order construction (Singer / perfect-difference sets), the `N^{1/4}` refinement, and the open `$1000` conjecture remain unformalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
