### PR TITLE
audit(cycle48): 2 more clean re-serves — chinese-remainder-crt, lagrange-oq-02

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6074,9 +6074,9 @@
       "issues": []
     },
     "chinese-remainder-constructive-oq-04-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:40Z",
+      "lastAudited": "2026-07-22T13:15:03Z",
       "result": "clean"
     },
     "chinese-remainder-constructive-oq-04-oq-04": {
@@ -21798,9 +21798,9 @@
       "issues": []
     },
     "lagrange-theorem-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:41Z",
+      "lastAudited": "2026-07-22T13:15:03Z",
       "result": "clean"
     },
     "lagrange-theorem-oq-02-oq-01": {


### PR DESCRIPTION
Reserve-mode re-serves (queue drained). Both verified against Lean source — no issues.

- **chinese-remainder-constructive-oq-04-oq-03** [verified/original]: 10 theorems (incl. 1 private), 0 sorry/0 axiom/0 native_decide. `ed_crt_list_sufficient` is a genuine induction over the modulus list reducing to a 2-moduli base step; necessity/iff/uniqueness all proved from Euclidean-domain gcd primitives. All 7 `originalContributions` exist and are substantive — genuinely original, not a Mathlib CRT wrapper. `original` badge correct.
- **lagrange-theorem-oq-02** [verified/mathlib]: 15 theorems, 0 sorry/0 axiom/0 native_decide. Orbit-stabilizer composed from Mathlib's orbit-quotient equivalence + index formula (badge/contribs disclose this honestly). Named consequences (`card_fixedPoints_mod_prime`, `center_nontrivial_of_pgroup`, `lagrange`) all present; description's "implies Burnside/class equation" is math context, not a formalization claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)