### PR TITLE
Enrich: disclose native_decide (Lean.ofReduceBool) in 5 axiomatized entries

### DIFF
--- a/src/data/proofs/erdos-1059-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01/meta.json
@@ -102,7 +102,7 @@
         "relationship": "Sister file providing an independent decidability proof for AllFactorialSubtractionsComposite"
       }
     ],
-    "assumptions": "1 axiom: density_one_conjecture — asserts that the natural density of qualifying primes among all primes equals 1. Formally: for every k, there exists X such that for all x ≥ X, qualifyingPrimeCount(x) * (k+1) ≥ primeCount(x) * k.",
+    "assumptions": "1 axiom: density_one_conjecture — asserts that the natural density of qualifying primes among all primes equals 1. Formally: for every k, there exists X such that for all x ≥ X, qualifyingPrimeCount(x) * (k+1) ≥ primeCount(x) * k. Trust caveat: the concrete prime witnesses (prime_461/557/673/769, witness_461/557/673/769, six_prime_witnesses, checkCount_101…769) and the finite-stage facts three_not_qualifying, qualifyingPrimeCount_ge_six, qualifyingPrimeCount_pos are closed by `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom (visible in `#print axioms`) beyond the one stated axiom. Because qualifyingPrimeCount_pos and three_not_qualifying feed the unconditional 'density sandwich' theorem density_strictly_between (0 < C(x) < π(x) for x ≥ 101), that finite-stage claim shifts trust from the kernel to the compiler; the abstract structural lemmas (qualifyingPrimeCount_mono, factorialCheckCount_le_log, and the Selberg-conditional qualifyingPrimeCount_ge / qualifyingPrimes_infinite) are kernel-checked.",
     "theoremCount": 35,
     "definitionCount": 6
   },

--- a/src/data/proofs/erdos-201/meta.json
+++ b/src/data/proofs/erdos-201/meta.json
@@ -21,7 +21,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 1,
     "lineCount": 355,
-    "assumptions": "1 axiom: g3_5_eq. 0 sorries.",
+    "assumptions": "1 axiom: g3_5_eq. 0 sorries. Trust caveat: the concrete rank value `r3_5_eq` (rk 3 5 = 4) closes a Finset-cardinality step with `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom beyond the stated axiom; the abstract results are kernel-checked.",
     "mathlib_version": "4.31.0",
     "theoremCount": 21,
     "definitionCount": 7

--- a/src/data/proofs/erdos-290/meta.json
+++ b/src/data/proofs/erdos-290/meta.json
@@ -63,7 +63,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 263,
-    "assumptions": "2 axioms: van_doorn_main (van Doorn theorem: ErdosQuestion290), van_doorn_upper_bound (b(a) < 4.374a for a > 1). 0 sorries.",
+    "assumptions": "2 axioms: van_doorn_main (van Doorn theorem: ErdosQuestion290), van_doorn_upper_bound (b(a) < 4.374a for a > 1). 0 sorries. Trust caveat: the worked examples `example_calculation` (∑ 1/n over 3..5 = 47/60 and over 3..6 = 19/20) and `example_denominator_drop` are closed by `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom; these ℚ-arithmetic demonstrations underpin the concrete b_of_3_bound but not the two axiomatized van Doorn bounds.",
     "theoremCount": 7,
     "definitionCount": 21
   },

--- a/src/data/proofs/erdos-438/meta.json
+++ b/src/data/proofs/erdos-438/meta.json
@@ -113,7 +113,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 113,
-    "assumptions": "3 axioms: massias_construction_works (Massias construction has square-free sumset), kls_theorem (Khalfalah-Lodha-Szemerédi 2002 — 11/32 is sharp), massias_is_maximal (11 residues mod 32 is maximal). 0 sorries.",
+    "assumptions": "3 axioms: massias_construction_works (Massias construction has square-free sumset), kls_theorem (Khalfalah-Lodha-Szemerédi 2002 — 11/32 is sharp), massias_is_maximal (11 residues mod 32 is maximal). 0 sorries. Trust caveat: the supporting computation `squares_mod_32_count` (there are 7 quadratic residues mod 32) is closed by `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom; this residue-count demonstration does not feed the three axiomatized bounds.",
     "theoremCount": 2,
     "definitionCount": 7
   },

--- a/src/data/proofs/erdos-487/meta.json
+++ b/src/data/proofs/erdos-487/meta.json
@@ -32,7 +32,7 @@
       "Asymptotic notation (little-o)"
     ],
     "lineCount": 359,
-    "assumptions": "3 axioms: kleitman_1971, central_binomial_over_power_tends_to_zero, lcm_triple_in_dense_set. 0 sorries.",
+    "assumptions": "3 axioms: kleitman_1971, central_binomial_over_power_tends_to_zero, lcm_triple_in_dense_set. 0 sorries. Trust caveat: the concrete LCM-triple examples `multiples_of_6_example` (IsLCMTriple 12 18 36) and `even_numbers_example` (IsLCMTriple 4 6 12) close their final divisibility step with `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom; these demonstrations do not feed the three axiomatized density results.",
     "mathlib_version": "4.31.0",
     "theoremCount": 6,
     "definitionCount": 6


### PR DESCRIPTION
## Enrichment: axiom-integrity disclosure

Five **axiomatized** gallery entries close concrete named theorems with
`native_decide` but their `assumptions` field disclosed only the literal
`axiom` declarations — omitting the `Lean.ofReduceBool` compiler-trust axiom
that `native_decide` introduces. Per the Axiom Integrity Policy (CLAUDE.md),
`native_decide` on a substantive result must disclose `Lean.ofReduceBool`.

This extends each `assumptions` string with a "Trust caveat" naming the exact
`native_decide` theorems and characterizing headline-vs-demonstration
dependence, matching the merged disclosure convention (#40878 erdos-56,
#41083 erdos-410, #40741 erdos-646, #39668 erdos-686, #39432 erdos-699).

| Entry | native_decide named decls | Feeds headline? |
|-------|---------------------------|-----------------|
| erdos-1059-oq-01 | prime/witness_461…769, six_prime_witnesses, checkCount_*, three_not_qualifying, qualifyingPrimeCount_ge_six/_pos | **Yes** — the unconditional density sandwich `density_strictly_between` |
| erdos-438 | squares_mod_32_count | No — supporting residue count |
| erdos-201 | r3_5_eq (rk 3 5 = 4) | Concrete rank value |
| erdos-290 | example_calculation, example_denominator_drop | Underpins b_of_3_bound (concrete) |
| erdos-487 | multiples_of_6_example, even_numbers_example | No — LCM-triple demos |

**Prose-only.** `axiomCount`, `status`, and `badge` are unchanged: the
`native_decide` usages are confined to concrete demonstrations / finite-stage
facts, while the abstract and axiomatized results remain kernel-checked. This
follows the merged precedent of disclosing (not re-counting) the compiler-trust
dependency.

No Lean source changed; JSON validated.
