### PR TITLE
Fix: disclose native_decide (Lean.ofReduceBool) in 6 axiomatized entries (#41407)

### DIFF
--- a/src/data/proofs/erdos-379/meta.json
+++ b/src/data/proofs/erdos-379/meta.json
@@ -54,7 +54,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 178,
-    "assumptions": "3 axioms: witness_divisibility (divisibility property of witness sequence), S_witness_bound (S(3^{2^m}) ≥ m), erdos_379 (limsup of S(n) is infinite). 0 sorries.",
+    "assumptions": "3 axioms: witness_divisibility (divisibility property of witness sequence), S_witness_bound (S(3^{2^m}) ≥ m), erdos_379 (limsup of S(n) is infinite). 0 sorries. Trust caveat: the concrete examples (example_n3_div, example_n9_C91/C92/C93_value, example_84_not_div_9) and the erdos_379_summary demonstration are closed by native_decide, which adds the compiler-trust axiom Lean.ofReduceBool (beyond propext/Classical.choice/Quot.sound). These verify finite instances; the headline growth results rest on the witness_divisibility/S_witness_bound/erdos_379 axioms and stay kernel-checked.",
     "theoremCount": 7,
     "definitionCount": 5
   },

--- a/src/data/proofs/erdos-408/meta.json
+++ b/src/data/proofs/erdos-408/meta.json
@@ -53,7 +53,7 @@
     "dateAdded": "2026-01-22",
     "axiomCount": 5,
     "lineCount": 394,
-    "assumptions": "5 axioms: pillai_lower_bound, pillai_upper_bound, shapiro_multiplicativity, ElliottHalberstam, egps_conditional. 0 sorries.",
+    "assumptions": "5 axioms: pillai_lower_bound, pillai_upper_bound, shapiro_multiplicativity, ElliottHalberstam, egps_conditional. 0 sorries. Trust caveat: the concrete Pillai-function examples example_f2 … example_f7_step1 are closed by native_decide, which adds the compiler-trust axiom Lean.ofReduceBool (beyond propext/Classical.choice/Quot.sound). These are finite demonstrations of f(n) for small n; the abstract results rest on the five stated axioms and remain kernel-checked.",
     "theoremCount": 17,
     "definitionCount": 9
   },

--- a/src/data/proofs/erdos-430/meta.json
+++ b/src/data/proofs/erdos-430/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/430",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "assumptions": "1 axiom: erdos_430_conjecture (the open conjecture: composites appear for large n). 0 sorries. Equivalence with Problem #385 fully proved. Sequence termination proved: greedySeq n n = 0. Small-n positive witnesses: hasComposite for n ∈ {5, 7, 9} (verified by native_decide; smallest n with composite n-1).",
+    "assumptions": "1 axiom: erdos_430_conjecture (the open conjecture: composites appear for large n). 0 sorries. Equivalence with Problem #385 fully proved. Sequence termination proved: greedySeq n n = 0. Small-n positive witnesses: hasComposite for n ∈ {5, 7, 9} (verified by native_decide; smallest n with composite n-1). Trust caveat: the small-n witnesses hasComposite_5/7/9 and example_n8 use native_decide, which adds the compiler-trust axiom Lean.ofReduceBool (beyond propext/Classical.choice/Quot.sound). These are finite demonstrations; the open-conjecture headline erdos_430_conjecture is an axiom independent of native_decide.",
     "lineCount": 275,
     "mathlib_version": "4.31.0",
     "theoremCount": 13,

--- a/src/data/proofs/erdos-731/meta.json
+++ b/src/data/proofs/erdos-731/meta.json
@@ -39,7 +39,7 @@
         "module": "Mathlib.Order.WellFounded"
       }
     ],
-    "assumptions": "1 axiom declaration: prime_divides_central_iff (Kummer's carry characterization: p | C(2n,n) iff some base-p digit of n is ≥ ⌈p/2⌉). Proved: choose_dvd_lcm (C(N,k) divides lcm(1,...,N+1), via Nat.factorization_choose_le_log), upper_bound_trivial (least non-divisor ≤ 2n+1, by contradiction using choose_dvd_lcm), two_divides_central (Pascal+symmetry), bertrand_central (Bertrand+dvd_choose_add), central_binom_lower (binomial sum+max term). Note: choose_dvd_lcm and upper_bound_trivial are NOT axioms — both are fully proved theorems in the file.",
+    "assumptions": "1 axiom declaration: prime_divides_central_iff (Kummer's carry characterization: p | C(2n,n) iff some base-p digit of n is ≥ ⌈p/2⌉). Proved: choose_dvd_lcm (C(N,k) divides lcm(1,...,N+1), via Nat.factorization_choose_le_log), upper_bound_trivial (least non-divisor ≤ 2n+1, by contradiction using choose_dvd_lcm), two_divides_central (Pascal+symmetry), bertrand_central (Bertrand+dvd_choose_add), central_binom_lower (binomial sum+max term). Note: choose_dvd_lcm and upper_bound_trivial are NOT axioms — both are fully proved theorems in the file. Trust caveat: the concrete central-binomial value/counterexample checks (centralBinom_zero … centralBinom_five, small_primes_divide_false, least_nondiv_counterexample) are closed by native_decide, which adds the compiler-trust axiom Lean.ofReduceBool (beyond propext/Classical.choice/Quot.sound). These are finite-stage demonstrations; the abstract theorems and the headline Kummer characterization axiom prime_divides_central_iff remain kernel-checked.",
     "mathlib_version": "4.31.0",
     "theoremCount": 32,
     "definitionCount": 3


### PR DESCRIPTION
## Disclose `native_decide` (Lean.ofReduceBool) — batch of 6 (part of #41407)

Six axiomatized entries close **named** theorems/defs with `native_decide`
but their `assumptions` field omitted the `Lean.ofReduceBool` compiler-trust
axiom that `native_decide` introduces. This extends each `assumptions` string
with a "Trust caveat" per the precedented convention (#41405, #41083, #40741,
#39668, #39432).

### Entries fixed
| slug | named native_decide decls | headline |
|------|---------------------------|----------|
| erdos-390 | factorizationMax_3_le…8_le (vf3…vf8 witnesses) | asymptotic axiom |
| erdos-342 | ulam_0…ulam_11 value checks | ulamSeq axioms |
| erdos-430 | hasComposite_5/7/9, example_n8 | open-conjecture axiom |
| erdos-731 | centralBinom_zero…five, small_primes_divide_false, least_nondiv_counterexample | Kummer axiom |
| erdos-379 | example_n3_div, example_n9_C9*, example_84_not_div_9, erdos_379_summary | growth axioms |
| erdos-408 | example_f2…example_f7_step1 | 5 Pillai axioms |

In every case `native_decide` is confined to concrete finite-stage
demonstrations; the abstract/headline results stay kernel-checked. Per the
precedent this is **disclosure-only** — no change to `axiomCount`/`status`/
`badge` (all already `axiomatized`).

### Evidence
Detector before/after (nearest-preceding-decl scan, comments stripped):
```
before: ofReduceBool_disclosed=False  (all 6, named native_decide > 0, example=0)
after:  ofReduceBool_disclosed=True   (all 6)
```
All six meta.json files validated as parseable JSON.

Part of #41407 (batch; PR #41405 covered a separate 5).
