### PR TITLE
audit: erdos-485-oq-02 clean re-serve (sumset f(k)→∞ framework, 0ax/10thm)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14000,9 +14000,9 @@
       "result": "clean"
     },
     "erdos-485-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:41Z",
+      "lastAudited": "2026-07-22T13:22:57Z",
       "result": "clean"
     },
     "erdos-486": {


### PR DESCRIPTION
Reserve-mode re-verify of `erdos-485-oq-02` (queue drained 4809/4809).

**Verdict: CLEAN.** Tier-B `mathlib`/`verified`.

- Counts match meta exactly: 10 thm / 2 def / 0 axiom / 0 sorry / 0 native_decide / 0 True-stubs.
- All 6 `originalContributions` map to real, fully-proved decls.
- `sumset_card_lower_bound` (|A+A|≥2|A|−1) proved from first principles (min/max chain, not axiomatized).
- Open-question framing honest throughout; only the positive-coefficient case is claimed proved, general case explicitly OPEN.
- Soft spots (title 'Combinatorial Proof of f(k)→∞', conclusion '8 proved theorems' vs 10, 'modulo sumset bound') all **under-claim** → safe direction, not reportable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)