### PR TITLE
Fix: disclose native_decide (Lean.ofReduceBool) in 2 Königsberg entries

### DIFF
--- a/src/data/proofs/konigsberg-oq-04/meta.json
+++ b/src/data/proofs/konigsberg-oq-04/meta.json
@@ -19,7 +19,7 @@
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 1,
-    "assumptions": "1 axiom: best_theorem (the BEST theorem counting directed Eulerian circuits via Matrix Tree Theorem; axiomatized pending Mathlib formalization of the arborescence-bijection proof).",
+    "assumptions": "1 axiom: best_theorem (the BEST theorem counting directed Eulerian circuits via Matrix Tree Theorem; axiomatized pending Mathlib formalization of the arborescence-bijection proof). Trust caveat: 4 named theorems close with `native_decide`, introducing the `Lean.ofReduceBool` compiler-trust axiom — BEST-formula products and K3 degree/balance computations on fixed finite digraphs (`tri_best_consistent`, `k3_outDeg`, `k3_balanced`, `k3_best_consistent`, lines 128-259). These are decidable finite-graph computations feeding the worked demonstrations; the headline Eulerian-circuit-count result rests on the explicit `best_theorem` axiom and is otherwise kernel-checked.",
     "lineCount": 340,
     "theoremCount": 9,
     "definitionCount": 11


### PR DESCRIPTION
## Summary

Part of #41407. Discloses the `Lean.ofReduceBool` compiler-trust axiom
introduced by `native_decide` in two axiomatized Königsberg entries:

- `konigsberg-oq-02` — 14 `native_decide` theorems
- `konigsberg-oq-04` — 4 `native_decide` theorems

## Evidence

Both files use `native_decide` only for **decidable finite-graph computations**
on fixed small digraphs:

- **oq-02**: out/in-degree and arc-count theorems (`tri_outDegree`,
  `tri_inDegree`, `tri_arcCount`, `sqDir_*`, `unbal_A_*`, `path_A/B/C_*`,
  lines 532–669). The headline directed-Euler existence results rest on the two
  explicit axioms `directed_euler_circuit_sufficient` /
  `directed_euler_path_sufficient`.
- **oq-04**: BEST-formula products and K3 degree/balance (`tri_best_consistent`,
  `k3_outDeg`, `k3_balanced`, `k3_best_consistent`, lines 128–259). The headline
  Eulerian-circuit count rests on the explicit `best_theorem` axiom.

Previously each `assumptions` disclosed only its explicit axioms, omitting
`Lean.ofReduceBool`.

## Change

Prose-only Trust caveat per the #41407 convention. `axiomCount`
(2 / 1), `status` (`axiomatized`), `badge` (`axiom`) **unchanged** — precedent
(#41405 etc.) discloses rather than re-counts, since `native_decide` is confined
to finite demos while the abstract results stay kernel-checked.

`konigsberg-oq-01-oq-02` (also in the #41407 list) is **deliberately excluded**:
it is a #39061 build-blocked "NOT machine-verified" entry whose `native_decide`
theorems are not confirmed to compile.

Metadata-only; JSON round-trip, no Lean rebuild required.

Part of #41407
