### PR TITLE
Enrich: disclose native_decide (Lean.ofReduceBool) in 5 axiomatized entries (#41407)

### DIFF
--- a/src/data/proofs/erdos-1054/meta.json
+++ b/src/data/proofs/erdos-1054/meta.json
@@ -45,7 +45,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 612,
-    "assumptions": "1 axiom: tao_disproves_part_i. See Lean source for the complete statement.",
+    "assumptions": "1 axiom: tao_disproves_part_i. See Lean source for the complete statement. Trust caveat: the concrete `computeF`/`f_*_eq` value computations (small n) are closed by `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom; these finite demonstrations do not feed the axiomatized result `tao_disproves_part_i`.",
     "theoremCount": 52,
     "definitionCount": 8
   },

--- a/src/data/proofs/erdos-1057/meta.json
+++ b/src/data/proofs/erdos-1057/meta.json
@@ -69,7 +69,7 @@
     "dateAdded": "2026-01-19",
     "axiomCount": 1,
     "lineCount": 1164,
-    "assumptions": "1 axiom: infinitely_many_carmichaels (Alford–Granville–Pomerance infinitude of Carmichael numbers). 0 sorries. Korselt's 1899 criterion is now fully proved in both directions (korselt_forward and korselt_backward).",
+    "assumptions": "1 axiom: infinitely_many_carmichaels (Alford–Granville–Pomerance infinitude of Carmichael numbers). 0 sorries. Korselt's 1899 criterion is now fully proved in both directions (korselt_forward and korselt_backward). Trust caveat: the concrete Carmichael demonstrations — the `primeFactors`/`factorization_*` computations for 561, 1105, 1729, …, the `∀ n : Fin 561, isCarmichaelCheck n.val = false` scan, and the `card = 5`/`card = 7` distinctness checks underpinning the finite 'there exist ≥5 (≥7) Carmichael numbers' theorems — are closed by `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom; these finite witnesses do not feed the axiomatized infinitude claim `infinitely_many_carmichaels`.",
     "theoremCount": 67,
     "definitionCount": 14
   },

--- a/src/data/proofs/erdos-205/meta.json
+++ b/src/data/proofs/erdos-205/meta.json
@@ -61,7 +61,7 @@
       "Hardy-Ramanujan and Erdős-Kac theorems on average/typical Ω(n)"
     ],
     "lineCount": 444,
-    "assumptions": "6 axioms: barreto_leeham_counterexample, threshold_dominates_loglog, romanoff_positive_density, and 3 more. See Lean source for complete statements.",
+    "assumptions": "6 axioms: barreto_leeham_counterexample, threshold_dominates_loglog, romanoff_positive_density, and 3 more. See Lean source for complete statements. Trust caveat: the concrete demonstrations — the 12 `bigOmega_*` values, `erdosCoveringModulus_val = 5592405`, the `pow2_mod_*` multiplicative-order computations, and the `not_prime_*` checks — are closed by `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom; these finite verifications support the covering-system illustration and do not feed the six axiomatized bounds.",
     "mathlib_version": "4.31.0",
     "theoremCount": 44,
     "definitionCount": 9

--- a/src/data/proofs/erdos-248/meta.json
+++ b/src/data/proofs/erdos-248/meta.json
@@ -43,7 +43,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 133,
-    "assumptions": "1 axiom: erdos_248. See Lean source for the complete statement.",
+    "assumptions": "1 axiom: erdos_248. See Lean source for the complete statement. Trust caveat: the concrete demonstrations `omega_one`/`omega_two`/`omega_six`/`omega_thirty` (small ω values) and `smooth_tail_n1_k1`..`smooth_tail_n1_k5` (finite smooth-tail bound checks) are closed by `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom; these finite computations illustrate the construction and do not feed the axiomatized infinitude claim `erdos_248`.",
     "theoremCount": 11,
     "definitionCount": 2
   },

--- a/src/data/proofs/erdos-413/meta.json
+++ b/src/data/proofs/erdos-413/meta.json
@@ -64,7 +64,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 1117,
-    "assumptions": "1 axiom: erdos_413_conjecture (open). Two former axioms (erdos_expProd_positive_density, selfridge_bigOmega_barrier) converted to Prop defs — known results not used by any theorem.",
+    "assumptions": "1 axiom: erdos_413_conjecture (open). Two former axioms (erdos_expProd_positive_density, selfridge_bigOmega_barrier) converted to Prop defs — known results not used by any theorem. Trust caveat: the concrete F-barrier witnesses (the `isBarrierBool_sound`/`isBarrierBool_complete` applications for `omegaC`, `bigOmegaC`, and `expProdC`) are discharged by `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom; these finite barrier verifications are demonstrations and do not feed the axiomatized conjecture `erdos_413_conjecture`.",
     "mathlib_version": "4.31.0",
     "theoremCount": 109,
     "definitionCount": 19


### PR DESCRIPTION
## Disclose native_decide (Lean.ofReduceBool) in 5 axiomatized entries

Part of #41407. These 5 axiomatized entries close one or more **named**
theorems with `native_decide` but their `assumptions` field disclosed only
their literal `axiom` declarations, omitting the `Lean.ofReduceBool`
compiler-trust axiom that `native_decide` introduces (per the Axiom Integrity
Policy in CLAUDE.md).

| Entry | native_decide named decls | headline dependence |
|-------|---------------------------|---------------------|
| erdos-248 | `omega_*` small ω values, `smooth_tail_n1_k*` bound checks | demonstration only |
| erdos-413 | F-barrier witnesses (`isBarrierBool_sound/complete` for omegaC/bigOmegaC/expProdC) | demonstration only |
| erdos-205 | 12 `bigOmega_*`, `erdosCoveringModulus_val`, `pow2_mod_*`, `not_prime_*` | demonstration only |
| erdos-1057 | `primeFactors`/`factorization_*`, `isCarmichaelCheck` scan, `card=5/7` distinctness | demonstration only |
| erdos-1054 | `computeF`/`f_*_eq` small-n values | demonstration only |

In every case the `native_decide` results are concrete finite-stage
demonstrations; the axiomatized headline result is a declared `axiom`
(kernel-level), not established via `native_decide`.

### Fix convention (prose-only, precedented)
Extends each `assumptions` string with a "Trust caveat" naming the specific
`native_decide` theorems and the `Lean.ofReduceBool` dependency, matching merged
PR #41405 (erdos-1059-oq-01/438/201/290/487) and #40878/#41083/#40741/#39668/#39432.

**No change** to `axiomCount`/`status`/`badge`: the precedent discloses (does not
re-count) the compiler-trust dependency, since `native_decide` is confined to
finite demos while the axiomatized results stay declared/kernel-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
