### PR TITLE
Fix: disclose native_decide (ofReduceBool) in 5 axiomatized entries — batch 2 (#41407)

### DIFF
--- a/src/data/proofs/erdos-1053/meta.json
+++ b/src/data/proofs/erdos-1053/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/1053",
     "dateAdded": "2025-01-15",
     "axiomCount": 1,
-    "assumptions": "1 axiom: robin_inequality_conditional. 0 sorries.",
+    "assumptions": "1 axiom: robin_inequality_conditional. 0 sorries. Trust caveat: named computation theorems — sigma_one (σ(1)=1, used by IsKPerfect_one_iff), perfect_examples (6,28,496,8128 are 2-perfect) and triperfect_examples (120,672,523776 are 3-perfect) — close via `native_decide`, which relies on the `Lean.ofReduceBool` compiler-trust axiom (not counted in the axiom total above). These are finite k-perfect verifications; the robin_inequality_conditional axiom is unaffected.",
     "badge": "axiom",
     "proofRepoPath": "Proofs/Erdos1053Problem.lean",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/erdos-1139/meta.json
+++ b/src/data/proofs/erdos-1139/meta.json
@@ -52,7 +52,7 @@
     "axiomCount": 2,
     "theoremCount": 16,
     "lineCount": 192,
-    "assumptions": "2 axioms: erdos_1139 (the open conjecture: lim sup gap/log k = ∞) and hardy_ramanujan_asymptotic (Landau-Ramanujan density: π₂(N) ~ cN log log N / log N). 16 theorems fully proved.",
+    "assumptions": "2 axioms: erdos_1139 (the open conjecture: lim sup gap/log k = ∞) and hardy_ramanujan_asymptotic (Landau-Ramanujan density: π₂(N) ~ cN log log N / log N). 16 theorems fully proved. Trust caveat: named demonstration facts — four_isAlmostPrime (Ω(4)=2), eight_not_almostPrime (Ω(8)=3>2) and a bigOmega 8 = 3 step — close via `native_decide`, which relies on the `Lean.ofReduceBool` compiler-trust axiom (not counted in the axiom total above). These are finite almost-prime checks; the erdos_1139 conjecture and hardy_ramanujan_asymptotic axioms remain kernel-checked.",
     "definitionCount": 6
   },
   "overview": {

--- a/src/data/proofs/erdos-167/meta.json
+++ b/src/data/proofs/erdos-167/meta.json
@@ -29,7 +29,7 @@
       "linear programming relaxation"
     ],
     "lineCount": 276,
-    "assumptions": "1 axiom: IsPlanar. 0 sorries.",
+    "assumptions": "1 axiom: IsPlanar. 0 sorries. Trust caveat: the finite tightness witnesses k4_tight and k5_tight (existence of specific small graphs on Fin 4 / Fin 5 achieving the packing/covering bound) close via `native_decide`, which relies on the `Lean.ofReduceBool` compiler-trust axiom (not counted in the axiom total above). These are finite small-case demonstrations; the IsPlanar axiom and the abstract Tuza-bound lemmas remain kernel-checked.",
     "mathlib_version": "4.31.0",
     "theoremCount": 4,
     "definitionCount": 7

--- a/src/data/proofs/erdos-252/meta.json
+++ b/src/data/proofs/erdos-252/meta.json
@@ -48,7 +48,7 @@
     ],
     "axiomCount": 5,
     "lineCount": 216,
-    "assumptions": "5 axioms: erdos_252_k0 through erdos_252_k4 (irrationality of divisorPowerSum for k=0..4).",
+    "assumptions": "5 axioms: erdos_252_k0 through erdos_252_k4 (irrationality of divisorPowerSum for k=0..4). Trust caveat: three named computation theorems — sigma_1_six (σ₁(6)=12), sigma_0_six (σ₀(6)=4) and sigma_2_two (σ₂(2)=5) — close via `native_decide`, which relies on the `Lean.ofReduceBool` compiler-trust axiom (not counted in the axiom total above). These are self-contained finite divisor-power values; the erdos_252_k0..k4 irrationality axioms remain the sole assumptions.",
     "theoremCount": 7,
     "definitionCount": 5
   },

--- a/src/data/proofs/erdos-969/meta.json
+++ b/src/data/proofs/erdos-969/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 2,
     "lineCount": 232,
-    "assumptions": "2 axioms: elementary_upper_bound, evelyn_linfoot_lower_bound. 0 sorries.",
+    "assumptions": "2 axioms: elementary_upper_bound, evelyn_linfoot_lower_bound. 0 sorries. Trust caveat: three named computation theorems — Q_one (Q(1)=1), Q_ten (Q(10)=7) and Q_twenty (Q(20)=13) — close via `native_decide`, which relies on the `Lean.ofReduceBool` compiler-trust axiom (not counted in the axiom total above). These are self-contained finite Q-values; the elementary_upper_bound and evelyn_linfoot_lower_bound axioms are unaffected.",
     "mathlib_version": "4.31.0",
     "theoremCount": 11,
     "definitionCount": 7


### PR DESCRIPTION
## Disclose `native_decide` (`Lean.ofReduceBool`) — batch 2 of 5 (part of #41407)

Extends the `assumptions` field of 5 more axiomatized entries with a **Trust
caveat** naming the theorems closed via `native_decide` and disclosing the
`Lean.ofReduceBool` compiler-trust axiom, per the precedented prose-only
convention (#41405, #40878, #41083, #40741).

### Entries fixed
| slug | named native_decide theorems | disclosure-only? |
|------|------------------------------|------------------|
| erdos-252 | `sigma_1_six`, `sigma_0_six`, `sigma_2_two` | ✅ finite σ-values |
| erdos-969 | `Q_one`, `Q_ten`, `Q_twenty` | ✅ finite Q-values |
| erdos-1139 | `four_isAlmostPrime`, `eight_not_almostPrime` | ✅ finite Ω-checks |
| erdos-1053 | `sigma_one`, `perfect_examples`, `triperfect_examples` | ✅ finite k-perfect checks |
| erdos-167 | `k4_tight`, `k5_tight` | ✅ finite small-graph witnesses |

### Verification
Per-file inspection confirms every `native_decide` site is a **finite
demonstration/computation fact** (divisor-power values, Q-values, almost-prime
checks, k-perfect verifications, small-graph tightness witnesses), never an
abstract headline claim — so the convention applies: `axiomCount`/`status`/
`badge` are **unchanged**, disclosure-only. Each diff is a single-line append to
`meta.assumptions`.

Part of #41407.
