### PR TITLE
audit: erdos-327-oq-01 clean re-serve (sum-dvd-prod parametrization, 0ax/6thm)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12628,9 +12628,9 @@
       "result": "issues-found"
     },
     "erdos-327-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:41Z",
+      "lastAudited": "2026-07-22T13:26:50Z",
       "result": "clean"
     },
     "erdos-327-oq-01-oq-04": {


### PR DESCRIPTION
Reserve-mode audit (queue drained 4809/4809), uncontested.

**Verdict: CLEAN.** `Proofs/Erdos327OQ01.lean` — 6 thm / 4 def / 0 ax / 0 sorry, matches meta.

- All 6 theorems genuinely proved: construction (forward), distinctness, smallest-pair (b≤5 exhausted), count=0 for N≤5, count>0 for N≥6.
- `pairCountAsymptotics` and `SumDvdProdTriple` are unproven `Prop` defs under an explicit *Open Question* heading — correct open-problem framing, not asserted as theorems.
- "Parametrization of all pairs" is mathematically accurate; the completeness/bijectivity direction is transparently disclosed as unproven (`conclusion.openQuestions` #3: 'leaves it as a Prop'). Safe-direction prose.
- Distinct sub-entry from the inconsistent `vanDoorn_bound` main-327 entry (#41182, closed) — no cross-contamination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)