### PR TITLE
Fix: disclose native_decide (Lean.ofReduceBool) in 7 axiomatized entries — batch 3

### DIFF
--- a/src/data/proofs/erdos-1055/meta.json
+++ b/src/data/proofs/erdos-1055/meta.json
@@ -21,7 +21,7 @@
     "sourceUrl": "https://erdosproblems.com/1055",
     "erdosUrl": "https://erdosproblems.com/1055",
     "axiomCount": 2,
-    "assumptions": "2 axioms: infinitely_many_in_each_class (infinitely many primes per class, OPEN), class_density_subpolynomial (class-r primes have n^o(1) density, known but hard to formalize). The competing Erdős (p_r^{1/r} → ∞) and Selfridge (p_r^{1/r} bounded) conjectures are stated as defs with a proved mutual exclusivity theorem.",
+    "assumptions": "2 axioms: infinitely_many_in_each_class (infinitely many primes per class, OPEN), class_density_subpolynomial (class-r primes have n^o(1) density, known but hard to formalize). The competing Erdős (p_r^{1/r} → ∞) and Selfridge (p_r^{1/r} bounded) conjectures are stated as defs with a proved mutual exclusivity theorem. Trust caveat: the concrete class-membership computations (class_2 … class_1021, least_class_1 … least_class_5, many_class1/2/3_primes, class_nonprime_4/6) are closed by native_decide, which adds the compiler-trust axiom Lean.ofReduceBool (beyond propext/Classical.choice/Quot.sound). These are finite verifications of individual primes' classes; the headline infinitude/density results rest on the infinitely_many_in_each_class and class_density_subpolynomial axioms and the mutual-exclusivity theorem stays kernel-checked.",
     "lineCount": 254,
     "theoremCount": 35,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-913/meta.json
+++ b/src/data/proofs/erdos-913/meta.json
@@ -21,7 +21,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 1,
     "lineCount": 347,
-    "assumptions": "1 axiom: infinite_8p_sq_minus_1_primes (Bunyakovsky-type conjecture: infinitely many primes p with 8p²-1 also prime). Both conditional results (8p²-1 path and Mersenne path) and all exponent structure lemmas are fully proved.",
+    "assumptions": "1 axiom: infinite_8p_sq_minus_1_primes (Bunyakovsky-type conjecture: infinitely many primes p with 8p²-1 also prime). Both conditional results (8p²-1 path and Mersenne path) and all exponent structure lemmas are fully proved. Trust caveat: the concrete examples (example_n3, example_n7, example_n8, example_n31, example_n71, example_n127) and exponent_structure are closed by native_decide, which adds the compiler-trust axiom Lean.ofReduceBool (beyond propext/Classical.choice/Quot.sound). These are finite verifications; the headline infinitude claim rests on the infinite_8p_sq_minus_1_primes axiom and the conditional/exponent lemmas stay kernel-checked.",
     "mathlib_version": "4.31.0",
     "theoremCount": 16,
     "definitionCount": 6


### PR DESCRIPTION
## Disclosure-completeness for `native_decide` (#41407, batch 3)

Extends the `assumptions` field of 7 axiomatized gallery entries with a **Trust caveat** naming the `native_decide`-closed named theorems and the compiler-trust axiom `Lean.ofReduceBool` they introduce, per the Axiom Integrity Policy.

Prose-only fix — **no** change to `axiomCount`/`status`/`badge`, matching the established precedent (#41405, #41409, #41410, #41411, #41413, and per-entry #40878/#41083/#40741/#39668/#39432). Each entry's `native_decide` uses are finite-stage demonstrations; the headline results remain carried by the stated axioms and stay kernel-checked.

### Entries (all confirmed: status=axiomatized, no prior ofReduceBool disclosure, named native_decide present)
| slug | named native_decide decls | headline axioms (kernel-checked) |
|------|---------------------------|----------------------------------|
| erdos-1055 | class_* / least_class_* / many_classN_primes / class_nonprime_* (28) | infinitely_many_in_each_class, class_density_subpolynomial |
| erdos-48 | totient_* / sumDivisors_* / pair_* / *_is_common (27) | ford_luca_pomerance, commonValues_infinite, garaev_improvement |
| erdos-470 | *_semiperfect / no_odd_abundant_* / weird_836 (26) | liddy_riedl_6_primes, melfi_conditional, benkoski_erdos_density |
| erdos-414 | orbit_*_merges_with_1 / h_one … h_ten (20) | erdos_414_conjecture |
| erdos-913 | example_n* / exponent_structure (8) | infinite_8p_sq_minus_1_primes |
| erdos-423 | consSeq_* / verify_* (16) | excess_nondecreasing, excess_unbounded, infinitely_many_missing |
| erdos-1004 | totient_eq_*_iff / collision_* (16) | eps87_theorem, longer_runs_need_larger_n, distinct_totients_asymptotic |

### Evidence
- Detector: strip comments, nearest preceding `theorem|lemma|def|instance` before each `native_decide`, filter out `example` — all 7 have ≥8 named non-example sites.
- `ofReduceBool` absent from each meta.json before this change.
- All 7 meta.json validate as JSON; diffs are one line each (append to `assumptions`).

No overlap with in-flight #41405/#41409/#41410/#41411/#41413/#41414/#41415/#41416.

Part of #41407.
