### PR TITLE
Fix: disclose native_decide (Lean.ofReduceBool) in 5 axiomatized entries — batch 3 (#41407)

### DIFF
--- a/src/data/proofs/erdos-1004/meta.json
+++ b/src/data/proofs/erdos-1004/meta.json
@@ -22,7 +22,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 3,
     "lineCount": 609,
-    "assumptions": "Three axioms: EPS87 upper bound (eps87_theorem: consolidated existential for constant, threshold, and bound), existence of fixed-length distinct runs (longer_runs_need_larger_n), and asymptotic count of distinct totient values (distinct_totients_asymptotic, Erdős 1935/Ford 1998). eps87_constant, eps87_threshold derived as noncomputable defs; eps87_constant_pos, eps87_upper_bound derived as theorems. 0 sorries remain.",
+    "assumptions": "Three axioms: EPS87 upper bound (eps87_theorem: consolidated existential for constant, threshold, and bound), existence of fixed-length distinct runs (longer_runs_need_larger_n), and asymptotic count of distinct totient values (distinct_totients_asymptotic, Erdős 1935/Ford 1998). eps87_constant, eps87_threshold derived as noncomputable defs; eps87_constant_pos, eps87_upper_bound derived as theorems. 0 sorries remain. Trust caveat: the finite verification theorems (totient_eq_one_iff, totient_eq_two_iff, totient_eq_four_iff totient-fiber enumerations, collision_1_2, collision_3_4) are closed by native_decide, which adds the Lean.ofReduceBool compiler-trust axiom (visible via #print axioms). These discharge only concrete finite totient computations demonstrating small fibers and collisions; the headline results rest on the three stated axioms above and stay kernel-checked.",
     "mathlib_version": "4.31.0",
     "theoremCount": 30,
     "definitionCount": 15

--- a/src/data/proofs/erdos-414/meta.json
+++ b/src/data/proofs/erdos-414/meta.json
@@ -49,7 +49,8 @@
     ],
     "axiomCount": 1,
     "assumptions": [
-      "erdos_414_conjecture: ∀ m, n ≥ 1, ∃ i, j: h^i(m) = h^j(n) — all orbits eventually merge (main open question)"
+      "erdos_414_conjecture: ∀ m, n ≥ 1, ∃ i, j: h^i(m) = h^j(n) — all orbits eventually merge (main open question)",
+      "Trust caveat: the finite verification theorems (h_one/two/three/four/five/six/seven/eight/nine/ten function values, orbit_1_start, orbit_2/…/10_merges_with_1) are closed by native_decide, which adds the Lean.ofReduceBool compiler-trust axiom (visible via #print axioms). These discharge only concrete finite orbit computations demonstrating that small starting values merge; the headline claim (erdos_414_conjecture) is an abstract axiom and stays kernel-checked."
     ],
     "lineCount": 303,
     "theoremCount": 34,

--- a/src/data/proofs/erdos-423/meta.json
+++ b/src/data/proofs/erdos-423/meta.json
@@ -29,7 +29,7 @@
       "Set.Infinite and natural density concepts"
     ],
     "lineCount": 409,
-    "assumptions": "Compiles green on Lean v4.31 (autoImplicit off, verified via docker-build.sh) with 0 sorries following the Class A Lean-source repair in PR #39078 (the earlier #39061 audit finding is resolved). Stated assumptions: 3 axioms: excess_nondecreasing, excess_unbounded, infinitely_many_missing.",
+    "assumptions": "Compiles green on Lean v4.31 (autoImplicit off, verified via docker-build.sh) with 0 sorries following the Class A Lean-source repair in PR #39078 (the earlier #39061 audit finding is resolved). Stated assumptions: 3 axioms: excess_nondecreasing, excess_unbounded, infinitely_many_missing. Trust caveat: the finite verification theorems (consSeq_zero/one/two/three/four/five/six/seven values, verify_three/five/six/eight/ten/eleven, consSeq_succ_gt, consSeq_strictMono_initial) and the ErdosQuestion423_convergence def are closed by native_decide, which adds the Lean.ofReduceBool compiler-trust axiom (visible via #print axioms). These discharge only concrete finite sequence computations demonstrating initial behavior; the headline results rest on the three stated axioms above and stay kernel-checked.",
     "mathlib_version": "4.31.0",
     "theoremCount": 42,
     "definitionCount": 9

--- a/src/data/proofs/erdos-470/meta.json
+++ b/src/data/proofs/erdos-470/meta.json
@@ -65,7 +65,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 602,
-    "assumptions": "3 axioms: liddy_riedl_6_primes (odd weird has ≥6 prime divisors), melfi_conditional (prime gap hypothesis implies infinitely many primitive weirds), benkoski_erdos_density (weird numbers have positive density). All deep results; no routine axioms remain.",
+    "assumptions": "3 axioms: liddy_riedl_6_primes (odd weird has ≥6 prime divisors), melfi_conditional (prime gap hypothesis implies infinitely many primitive weirds), benkoski_erdos_density (weird numbers have positive density). All deep results; no routine axioms remain. Trust caveat: the finite verification theorems (seventy_is_abundant, seventy_not_pseudoperfect, no_weird_below_70, weird_836, nine45_odd_abundant, the *_semiperfect witnesses, and the no_odd_abundant_below_945/…/no_odd_abundant_5776_to_5985 range checks) are closed by native_decide, which adds the Lean.ofReduceBool compiler-trust axiom (visible via #print axioms). These discharge only concrete finite abundance/weird/semiperfect computations demonstrating specific witnesses and ranges; the headline results rest on the three stated axioms above and stay kernel-checked.",
     "theoremCount": 42,
     "definitionCount": 14
   },

--- a/src/data/proofs/erdos-48/meta.json
+++ b/src/data/proofs/erdos-48/meta.json
@@ -61,7 +61,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 480,
-    "assumptions": "3 axioms: ford_luca_pomerance (Ford-Luca-Pomerance — totient-sigma pairs are infinite), commonValues_infinite (common values of φ and σ are infinite), garaev_improvement (Garaev improvement). 0 sorries.",
+    "assumptions": "3 axioms: ford_luca_pomerance (Ford-Luca-Pomerance — totient-sigma pairs are infinite), commonValues_infinite (common values of φ and σ are infinite), garaev_improvement (Garaev improvement). 0 sorries. Trust caveat: the finite verification theorems (totient_one/two/three/four/five/seven/thirteen, sumDivisors_two/three/four/five/six/eleven, pair_2_1/pair_5_3/pair_7_5/pair_13_6/pair_13_11, one/four/six/twelve_is_common, six_is_perfect, at_least_five_pairs) are closed by native_decide, which adds the Lean.ofReduceBool compiler-trust axiom (visible via #print axioms). These discharge only concrete finite φ/σ computations demonstrating small common values; the headline infinitude claims rest on the three stated axioms above and stay kernel-checked.",
     "theoremCount": 40,
     "definitionCount": 7
   },


### PR DESCRIPTION
## Summary

Batch 3 of the #41407 native_decide disclosure backlog. Extends the
`assumptions` field of 5 axiomatized gallery entries with a **Trust caveat**
naming the `native_decide`-closed theorems and characterizing them as finite
demonstration facts.

| slug | named native_decide decls (finite verification) | headline (kernel-checked axioms) |
|------|---------------------------------------------------|----------------------------------|
| erdos-48 | totient_*/sumDivisors_*/pair_*/*_is_common/six_is_perfect/at_least_five_pairs | ford_luca_pomerance, commonValues_infinite, garaev_improvement |
| erdos-470 | seventy_is_abundant, weird_836, *_semiperfect, no_odd_abundant_* ranges | liddy_riedl_6_primes, melfi_conditional, benkoski_erdos_density |
| erdos-414 | h_one…h_ten, orbit_*_merges_with_1 | erdos_414_conjecture |
| erdos-423 | consSeq_*, verify_*, ErdosQuestion423_convergence | excess_nondecreasing, excess_unbounded, infinitely_many_missing |
| erdos-1004 | totient_eq_{one,two,four}_iff, collision_1_2/3_4 | eps87_theorem, longer_runs_need_larger_n, distinct_totients_asymptotic |

## Convention (prose-only, per #41407)

- No `axiomCount` / `status` / `badge` change — matches the issue's fix
  convention. Every entry's headline result is carried by explicit `axiom`
  declarations that stay abstract/kernel-checked; `native_decide` only
  discharges concrete finite computations (specific totient/sigma values,
  orbit merges, semiperfect/abundant checks, sequence values), which add the
  `Lean.ofReduceBool` compiler-trust axiom.
- Verified each entry is `status: "axiomatized"` and lacked any `ofReduceBool`
  mention before this change.
- Surgical single-line edits per meta (no jq round-trip reformatting).

Slugs chosen to avoid overlap with in-flight PRs #41405/#41409/#41410/#41411/#41413/#41414/#41415/#41416.

Closes part of #41407.
