### PR TITLE
Gallery integrity: fix erdos-1098-oq-01 phantom mainTheorems

### DIFF
--- a/src/data/proofs/erdos-1098-oq-01/meta.json
+++ b/src/data/proofs/erdos-1098-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-1098-oq-01",
   "title": "Groups with Small Clique Number in the Non-Commuting Graph",
   "slug": "erdos-1098-oq-01",
-  "description": "Characterizes groups with small clique number ω in the non-commuting graph Γ(G). Proves: ω(Γ(G)) = 0 iff G abelian, center elements excluded from large cliques, clique elements lie in different cosets of Z(G), finite index center implies finite clique number. All theorems fully proved (0 sorries, 0 axioms).",
+  "description": "Characterizes groups with small clique number ω in the non-commuting graph Γ(G). Proves: ω(Γ(G)) = 0 iff G abelian, ω = 1 is impossible, center elements are excluded from cliques of size ≥ 2, and abelian groups have clique number ≤ 1. All 8 theorems fully proved (0 sorries, 0 axioms). The coset-injection bound and the finite-index-implies-finite-clique direction remain open questions for this entry (see openQuestions); they are formalized only in the sibling entry erdos-1098, and there modulo an axiom.",
   "meta": {
     "author": "Neumann (1976); Abdollahi-Akbari-Maimani (2006)",
     "sourceUrl": "https://erdosproblems.com/1098",
@@ -105,16 +105,16 @@
       "leanType": "biconditional"
     },
     {
-      "name": "clique_different_cosets",
+      "name": "center_not_in_clique",
       "type": "core",
-      "description": "Clique elements lie in different cosets of Z(G)",
-      "leanType": "∀ g h ∈ clique, g⁻¹*h ∉ Z(G)"
+      "description": "Center elements cannot appear in any clique of size ≥ 2",
+      "leanType": "z ∈ Z(G) → IsClique S → 2 ≤ S.card → z ∉ S"
     },
     {
-      "name": "finite_index_implies_finite_clique",
+      "name": "abelian_clique_bound",
       "type": "core",
-      "description": "[G:Z(G)] < ∞ implies ω(Γ(G)) < ∞",
-      "leanType": "Subgroup.index (center G) finite → clique number finite"
+      "description": "In an abelian group every clique has size ≤ 1",
+      "leanType": "(∀ g h, g*h = h*g) → IsClique S → S.card ≤ 1"
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-1098-oq-01 (Groups with Small Clique Number in the Non-Commuting Graph)
**File**: `proofs/Proofs/Erdos1098OQ01.lean`
**Problem**: `mainTheorems` and `description` claim two theorems as proved "core" results of this entry, but neither exists in this entry's Lean file.

## Evidence

`meta.json` mainTheorems listed (type `core`):
- `clique_different_cosets` — "Clique elements lie in different cosets of Z(G)"
- `finite_index_implies_finite_clique` — "[G:Z(G)] < ∞ implies ω(Γ(G)) < ∞"

description said: *"Proves: … clique elements lie in different cosets of Z(G), finite index center implies finite clique number. All theorems fully proved (0 sorries, 0 axioms)."*

But `Erdos1098OQ01.lean` contains only 8 theorems: `nonCommuting_iff`, `nonCommuting_symm`, `center_commutes`, `center_not_nonCommuting`, `clique_zero_iff_abelian`, `singleton_not_clique_two`, `center_not_in_clique`, `abelian_clique_bound`. Neither phantom theorem is present.

Both named theorems live only in the **sibling** entry `erdos-1098` (`Proofs/Erdos1098Problem.lean`, lines 182 / 241), where they additionally rely on an `axiom neumann_theorem` — so they are neither in this file nor axiom-free.

Self-contradiction: this entry's own `conclusion.openQuestions` already state these results are unproven ("Can clique_size_bound … be proved in Lean…?", "Can Neumann's full theorem … be proved…?").

The Lean file itself is clean: 8 theorems, 0 axioms, 0 sorries, no `native_decide`.

## Fix (this PR)

- Remove the two phantom mainTheorems; replace with theorems actually proved here (`center_not_in_clique`, `abelian_clique_bound`).
- Correct `description` to list only what this file proves, and note the coset/finite-index results remain open questions (formalized only in sibling `erdos-1098`, there modulo an axiom).

No Lean source changes; counts (8 theorems / 0 axioms / 0 sorries) unchanged and accurate.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)