### PR TITLE
Fix: disclose native_decide (Lean.ofReduceBool) in 6 axiomatized entries — batch 4

### DIFF
--- a/src/data/proofs/erdos-1107-oq-02/meta.json
+++ b/src/data/proofs/erdos-1107-oq-02/meta.json
@@ -30,7 +30,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 156,
-    "assumptions": "1 axiom: squareful_sum_threshold (every n ≥ 120 is a sum of 3 squareful numbers). Computationally verified up to 1000.",
+    "assumptions": "1 axiom: squareful_sum_threshold (every n ≥ 120 is a sum of 3 squareful numbers). Computationally verified up to 1000. Trust caveat: the concrete squareful checks (isSquareful_4/8/9/27/108), the small-n non-representability witnesses (not_sum3_7 … not_sum3_119), and the finite-range scans (range_120_200 … range_901_1000, below_threshold_nonexceptions, threshold_120) are closed by native_decide, which adds the compiler-trust axiom Lean.ofReduceBool (beyond propext/Classical.choice/Quot.sound). These are finite verifications; the headline all-n≥120 claim rests on the squareful_sum_threshold axiom and stays kernel-checked.",
     "theoremCount": 25,
     "definitionCount": 3
   },

--- a/src/data/proofs/erdos-1107/meta.json
+++ b/src/data/proofs/erdos-1107/meta.json
@@ -42,7 +42,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 170,
-    "assumptions": "1 axiom: erdos_1107 (general r-powerful sum conjecture, open for r>2). Heath-Brown squareful case (r=2) now proved as corollary.",
+    "assumptions": "1 axiom: erdos_1107 (general r-powerful sum conjecture, open for r>2). Heath-Brown squareful case (r=2) now proved as corollary. Trust caveat: the concrete fullness/sum witnesses (isFull_four/eight/nine/thirtySix, sum_example_13, sum_example_17) are closed by native_decide, which adds the compiler-trust axiom Lean.ofReduceBool (beyond propext/Classical.choice/Quot.sound). These are finite demonstrations; the headline general r-powerful claim rests on the erdos_1107 axiom and stays kernel-checked.",
     "theoremCount": 12,
     "definitionCount": 2
   },

--- a/src/data/proofs/erdos-259/meta.json
+++ b/src/data/proofs/erdos-259/meta.json
@@ -48,7 +48,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 239,
-    "assumptions": "2 axioms: series_summable, chen_ruzsa_irrationality. 0 sorries.",
+    "assumptions": "2 axioms: series_summable, chen_ruzsa_irrationality. 0 sorries. Trust caveat: the concrete Möbius-value checks (moebius_two, moebius_three, moebius_four, moebius_five, moebius_six, moebius_nine, moebius_ten) are closed by native_decide, which adds the compiler-trust axiom Lean.ofReduceBool (beyond propext/Classical.choice/Quot.sound). These are finite verifications; the headline summability/irrationality results rest on the series_summable and chen_ruzsa_irrationality axioms and stay kernel-checked.",
     "theoremCount": 14,
     "definitionCount": 4
   },

--- a/src/data/proofs/erdos-403/meta.json
+++ b/src/data/proofs/erdos-403/meta.json
@@ -52,7 +52,7 @@
       "erdos_403 theorem: main finiteness result"
     ],
     "axiomCount": 1,
-    "assumptions": "1 axiom: lin_theorem_finiteness (Lin theorem — the set of exceptions is finite). 0 sorries.",
+    "assumptions": "1 axiom: lin_theorem_finiteness (Lin theorem — the set of exceptions is finite). 0 sorries. Trust caveat: the concrete solution/verification checks (check_m2, check_m3, solution_m7, three_solution_m1/m2/m3/m6, maximal_solution_elements) are closed by native_decide, which adds the compiler-trust axiom Lean.ofReduceBool (beyond propext/Classical.choice/Quot.sound). These are finite verifications for small m; the headline finiteness claim rests on the lin_theorem_finiteness axiom and stays kernel-checked.",
     "lineCount": 339,
     "theoremCount": 15,
     "definitionCount": 8

--- a/src/data/proofs/erdos-472/meta.json
+++ b/src/data/proofs/erdos-472/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 1,
     "lineCount": 327,
-    "assumptions": "1 axiom: ulam35_contains_all_odd_primes_conjecture. See Lean source for the complete statement.",
+    "assumptions": "1 axiom: ulam35_contains_all_odd_primes_conjecture. See Lean source for the complete statement. Trust caveat: the concrete Ulam (3,5)-sequence checks (ulam35_first_terms, ulam35_term2 … ulam35_term7, ulam35_extends_8) are closed by native_decide, which adds the compiler-trust axiom Lean.ofReduceBool (beyond propext/Classical.choice/Quot.sound). These are finite verifications of initial sequence terms; the headline all-odd-primes claim rests on the ulam35_contains_all_odd_primes_conjecture axiom and stays kernel-checked.",
     "mathlib_version": "4.31.0",
     "theoremCount": 30,
     "definitionCount": 8

--- a/src/data/proofs/erdos-647/meta.json
+++ b/src/data/proofs/erdos-647/meta.json
@@ -52,7 +52,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 324,
-    "assumptions": "1 axiom(s) and 0 sorry(s). The axiom `large_n_fail` encodes the open conjecture that no n > 24 satisfies the Erdős condition.",
+    "assumptions": "1 axiom(s) and 0 sorry(s). The axiom `large_n_fail` encodes the open conjecture that no n > 24 satisfies the Erdős condition. Trust caveat: the concrete τ/ω and m+τ value checks (tau_one … tau_twentyfour, omega_one … omega_twentyfour, mPlusTau_12 … mPlusTau_24, highly_composite_examples, twentyfour_highly_composite, twentyfour_satisfies) are closed by native_decide, which adds the compiler-trust axiom Lean.ofReduceBool (beyond propext/Classical.choice/Quot.sound). These are finite verifications for small n; the headline no-large-n claim is the open axiom large_n_fail and does not depend on native_decide.",
     "theoremCount": 26,
     "definitionCount": 11
   },


### PR DESCRIPTION
## Disclosure-completeness for `native_decide` (#41407, batch 4)

Extends the `assumptions` field of 6 axiomatized gallery entries with a **Trust caveat** naming the `native_decide`-closed named theorems and the compiler-trust axiom `Lean.ofReduceBool` they introduce, per the Axiom Integrity Policy.

Prose-only fix — **no** change to `axiomCount`/`status`/`badge`, matching the established precedent (#41405, #41409, #41410, #41411, #41413, #41418, and per-entry #40878/#41083/#40741/#39668/#39432). Each entry's `native_decide` uses are finite-stage demonstrations; the headline results remain carried by the stated axioms and stay kernel-checked.

### Entries (all confirmed: status=axiomatized, no prior ofReduceBool disclosure, named native_decide present)
| slug | native_decide demos | headline axioms (kernel-checked) |
|------|--------------------|----------------------------------|
| erdos-647 | tau_*/omega_*/mPlusTau_* highly-composite checks (17) | large_n_fail |
| erdos-1107-oq-02 | isSquareful_*/not_sum3_*/range_* scans (22) | squareful_sum_threshold |
| erdos-1107 | isFull_*/sum_example_* (8) | erdos_1107 |
| erdos-472 | ulam35_term*/ulam35_extends_8 (8) | ulam35_contains_all_odd_primes_conjecture |
| erdos-403 | check_m*/solution_m*/three_solution_m* (8) | lin_theorem_finiteness |
| erdos-259 | moebius_* value checks (7) | series_summable, chen_ruzsa_irrationality |

### Evidence
- Detector: strip comments, nearest preceding `theorem|lemma|def|instance` before each `native_decide`, filter out `example` — all 6 have ≥7 named non-example sites.
- `ofReduceBool` absent from each meta.json before this change.
- All 6 meta.json validate as JSON; diffs are one line each (append to `assumptions`).

No overlap with in-flight #41405/#41409/#41410/#41411/#41413/#41414/#41415/#41416/#41418.

Part of #41407.
