### PR TITLE
Fix: disclose native_decide (Lean.ofReduceBool) in 6 axiomatized entries — batch 5

### DIFF
--- a/src/data/proofs/erdos-185/meta.json
+++ b/src/data/proofs/erdos-185/meta.json
@@ -66,7 +66,7 @@
       "Arithmetic progressions and additive combinatorics"
     ],
     "lineCount": 1104,
-    "assumptions": "2 axioms: density_hales_jewett_k3, meshulam_upper_bound. 0 sorries.",
+    "assumptions": "2 axioms: density_hales_jewett_k3, meshulam_upper_bound. 0 sorries. Trust caveat: the small-value theorems f3_1, f3_2, f3_3 (f₃(1)=2, f₃(2)=4, f₃(3)=9) close by native_decide, adding the Lean.ofReduceBool compiler-trust axiom; these are finite computations, not the headline f3_is_little_o (which rests on the density_hales_jewett_k3 axiom and stays kernel-checked).",
     "theoremCount": 73,
     "definitionCount": 31
   },

--- a/src/data/proofs/erdos-243/meta.json
+++ b/src/data/proofs/erdos-243/meta.json
@@ -49,7 +49,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 128,
-    "assumptions": "2 axioms: erdos_243, sylvester_sum_reciprocals. See Lean source for complete statements.",
+    "assumptions": "2 axioms: erdos_243, sylvester_sum_reciprocals. See Lean source for complete statements. Trust caveat: the finite Sylvester-sequence values sylvester_1, sylvester_2, sylvester_3, sylvester_4 and sylvester_strictMono_small close by native_decide, adding the Lean.ofReduceBool compiler-trust axiom; these are finite computations, not the headline erdos_243 (which stays an explicit axiom, kernel-checked).",
     "theoremCount": 8,
     "definitionCount": 4
   },

--- a/src/data/proofs/erdos-250/meta.json
+++ b/src/data/proofs/erdos-250/meta.json
@@ -47,7 +47,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 188,
-    "assumptions": "2 axioms: sigma_series_summable, nesterenko_irrationality. 0 sorries.",
+    "assumptions": "2 axioms: sigma_series_summable, nesterenko_irrationality. 0 sorries. Trust caveat: the finite divisor-sum values sigma_one, sigma_two, sigma_three, sigma_four, sigma_six, sigma_twelve close by native_decide, adding the Lean.ofReduceBool compiler-trust axiom; these are finite computations, not the headline nesterenko_irrationality (which stays an explicit axiom, kernel-checked).",
     "theoremCount": 10,
     "definitionCount": 3
   },

--- a/src/data/proofs/erdos-283/meta.json
+++ b/src/data/proofs/erdos-283/meta.json
@@ -52,7 +52,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 157,
-    "assumptions": "2 axioms: graham_theorem, alekseyev_theorem. 0 sorries.",
+    "assumptions": "2 axioms: graham_theorem, alekseyev_theorem. 0 sorries. Trust caveat: the finite examples egyptian_example_236, egyptian_example_2_4_6_12, alekseyev_example, and trivial_egyptian close by native_decide, adding the Lean.ofReduceBool compiler-trust axiom; these are finite demonstrations, not the headline graham_theorem/alekseyev_theorem (which stay explicit axioms, kernel-checked).",
     "theoremCount": 7,
     "definitionCount": 4
   },

--- a/src/data/proofs/erdos-286/meta.json
+++ b/src/data/proofs/erdos-286/meta.json
@@ -53,7 +53,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 263,
-    "assumptions": "2 axioms: croot_theorem, representation_monotone. 0 sorries.",
+    "assumptions": "2 axioms: croot_theorem, representation_monotone. 0 sorries. Trust caveat: the finite examples example_k3 and example_k4 close by native_decide, adding the Lean.ofReduceBool compiler-trust axiom; these are finite demonstrations, not the headline croot_theorem (which stays an explicit axiom, kernel-checked).",
     "theoremCount": 8,
     "definitionCount": 7
   },

--- a/src/data/proofs/erdos-406/meta.json
+++ b/src/data/proofs/erdos-406/meta.json
@@ -59,7 +59,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 352,
-    "assumptions": "1 axiom: saye_computation (Saye 2022 computational verification for n ≤ 5.9×10²¹, deep). ErdosProblem406 and variant are defs, not axioms.",
+    "assumptions": "1 axiom: saye_computation (Saye 2022 computational verification for n ≤ 5.9×10²¹, deep). ErdosProblem406 and variant are defs, not axioms. Trust caveat: the finite membership demos one_in_ternarySparse, four_in_ternarySparse, pow2_8_in_ternarySparse and the bounded-range checks sparse_complete_to_15, sparse_classification_known_range, dense_complete_to_15 close by native_decide, adding the Lean.ofReduceBool compiler-trust axiom; these are finite computations, not the headline saye_computation axiom (which stays kernel-checked).",
     "theoremCount": 19,
     "definitionCount": 6
   },


### PR DESCRIPTION
## Disclose `native_decide` (`Lean.ofReduceBool`) — batch 5 of #41407

Six **axiomatized** gallery entries close one or more **named** theorems with
`native_decide` but their `meta.assumptions` omitted the `Lean.ofReduceBool`
compiler-trust axiom. Per the Axiom Integrity Policy, `native_decide` adds that
axiom and must be disclosed.

**Prose-only, precedented convention** (matches #40878/#41083/#40741/#39668/#39432
and merged batches #41405/#41409/#41411/#41421): these entries are already
`status: "axiomatized"`, so this appends a **"Trust caveat"** to `assumptions`
naming the specific `native_decide` theorems and characterizing them as finite
demonstrations, distinct from the kernel-checked headline (explicit `axiom`
decls). **No `axiomCount`/`status`/`badge` change.**

| slug | native_decide theorems (all finite demos) | headline axiom(s), kernel-checked |
|------|-------------------------------------------|-----------------------------------|
| erdos-185 | f3_1, f3_2, f3_3 (small cap-set values) | density_hales_jewett_k3 / meshulam_upper_bound |
| erdos-243 | sylvester_1..4, sylvester_strictMono_small | erdos_243 / sylvester_sum_reciprocals |
| erdos-250 | sigma_one/two/three/four/six/twelve | nesterenko_irrationality |
| erdos-283 | egyptian_example_236/_2_4_6_12, alekseyev_example, trivial_egyptian | graham_theorem / alekseyev_theorem |
| erdos-286 | example_k3, example_k4 | croot_theorem |
| erdos-406 | one/four/pow2_8_in_ternarySparse, sparse_complete_to_15, sparse_classification_known_range, dense_complete_to_15 | saye_computation |

Each `native_decide` was confirmed via nearest-preceding-decl scan to sit in a
finite-computation theorem, not the headline result.

### Evidence
- Before: 6 `assumptions` strings had no `ofReduceBool`.
- After: each extended with a Trust caveat; `git diff --stat` = 6 files, 1 line each.
- All 6 meta.json validated with `json.load`.

Part of #41407 (does not close it — backlog continues).
