### PR TITLE
Enrich: disclose native_decide (Lean.ofReduceBool) in 5 axiomatized entries — batch 4 (#41407)

### DIFF
--- a/src/data/proofs/erdos-1107-oq-02/meta.json
+++ b/src/data/proofs/erdos-1107-oq-02/meta.json
@@ -114,6 +114,7 @@
     "lineCount": 156,
     "sorries": 0,
     "path": "Proofs/Erdos1107OQ02.lean",
+    "assumptions": "1 axiom: squareful_sum_threshold (effective Heath-Brown — every n ≥ 120 is a sum of at most 3 squareful numbers; encodes the infinite continuation beyond the computational range). 0 sorries. Trust caveat: the *unconditional* finite results are closed by `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom (visible in `#print axioms`): the exceptional-set facts not_sum3_7/15/23/87/111/119 (and threshold_tight), the completeness check below_threshold_nonexceptions (every n < 120 outside {7,15,23,87,111,119} is representable), the finite range verifications range_120_200 … range_901_1000 (n ∈ [120,1000]), and the squareful-witness computations isSquareful_4/8/9/27/108 and threshold_120. These finite verifications therefore rest on compiler trust rather than the kernel; only the infinite continuation beyond the checked range is the stated axiom.",
     "definitionCount": 3,
     "theoremCount": 25
   }

--- a/src/data/proofs/erdos-647/meta.json
+++ b/src/data/proofs/erdos-647/meta.json
@@ -155,6 +155,7 @@
     "theoremCount": 26,
     "definitionCount": 11,
     "path": "Proofs/Erdos647Problem.lean",
+    "assumptions": "1 axiom: large_n_fail (for all n > 24, ¬ErdosCondition n — the hard 'no larger solutions' direction). 0 sorries. Trust caveat: the finite verifications establishing the *unconditional* positive results — twentyfour_satisfies (n = 24 meets the Erdős condition), twentyfour_highly_composite, highly_composite_examples, and the tau/mPlusTau/omega value tables — are closed by `native_decide` (via interval_cases over the τ table), which adds the `Lean.ofReduceBool` compiler-trust axiom (visible in `#print axioms`); these finite computations therefore shift trust for the concrete n = 24 witness from the kernel to the compiler. The structural results erdosCondition_iff_finset, obstruction, and asymptotic_implies_finite, and the omega-based twentyfive_fails / twentysix_fails, are kernel-checked and do not use native_decide.",
     "sorries": 0
   },
   "crossReferences": [


### PR DESCRIPTION
## Enrichment: disclose `native_decide` (`Lean.ofReduceBool`) — batch 4 of #41407

Extends the `assumptions` field of five **axiomatized** gallery entries with a
"Trust caveat" naming the `native_decide` theorems and characterizing
headline-vs-demonstration dependence, per the Axiom Integrity Policy (CLAUDE.md)
and the precedent PRs #41405 / #41415 / #41416 / #41418.

Each entry closes one or more **named** theorems with `native_decide` (which
adds `Lean.ofReduceBool`) while previously disclosing only its literal `axiom`
declarations. Per the fix convention this is **disclosure-only**: no
`axiomCount` / `status` / `badge` change.

| Entry | native_decide role | Feeds headline? |
|-------|--------------------|-----------------|
| erdos-647 | `twentyfour_satisfies`, `twentyfour_highly_composite`, τ/mPlusTau tables | **Yes** — the unconditional n=24 witness; disclosed as compiler-trust shift |
| erdos-1107-oq-02 | exceptional-set facts + `range_120_200 … range_901_1000` | **Yes** — the unconditional finite [120,1000] verification |
| erdos-823 | σ/φ coincidence witnesses (14/15, 33/35, 957/958) | No — finite demos; the two limit statements are axioms |
| erdos-472 | (3,5)-Ulam-prime term computations | No — illustrates the sequence; the "all odd primes" claim is the axiom |
| erdos-403 | explicit factorial-sum-power solution checks | No — exhibits solutions; finiteness is the axiom |

For erdos-647 / erdos-1107-oq-02 the `native_decide` results are genuine
*unconditional* finite theorems, so the caveat states plainly that trust for
those concrete claims shifts from the kernel to the compiler.

The critical axis stays clean: none of these is `verified` / `axiomCount: 0`, so
there is no axiom-freedom overclaim — only disclosure completeness.

Verified: all five `meta.json` parse; `leanFile.axiomCount` unchanged.
