### PR TITLE
Fix: disclose native_decide (Lean.ofReduceBool) in 8 axiomatized entries — batch 6 (#41407)

### DIFF
--- a/src/data/proofs/collatz-structured/meta.json
+++ b/src/data/proofs/collatz-structured/meta.json
@@ -32,7 +32,7 @@
     "dateAdded": "2025-12-31",
     "axiomCount": 1,
     "lineCount": 207,
-    "assumptions": "1 axiom: collatz_conjecture. See Lean source for the complete statement.",
+    "assumptions": "1 axiom: collatz_conjecture. See Lean source for the complete statement. Trust caveat: the finite Collatz-trajectory verifications in `three_reaches_one`, `five_reaches_one`, `six_reaches_one`, `seven_reaches_one`, `nine_reaches_one`, and `twentyseven_reaches_one` are closed by `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom (visible in `#print axioms`); the Collatz conjecture itself rests on the stated axiom `collatz_conjecture`.",
     "mathlib_version": "4.31.0",
     "theoremCount": 18,
     "definitionCount": 4

--- a/src/data/proofs/erdos-1033/meta.json
+++ b/src/data/proofs/erdos-1033/meta.json
@@ -53,7 +53,7 @@
     "relatedProblems": [],
     "axiomCount": 3,
     "lineCount": 1058,
-    "assumptions": "3 axioms (erdos_laskar_upper, erdos_laskar_lower, fan_lower). 0 sorries (h_as_min, turan_plus_one, h_four, h_spec all proved). Note: erdos_laskar_upper and fan_lower axioms are too strong for small n (asymptotic results stated as universal).",
+    "assumptions": "3 axioms (erdos_laskar_upper, erdos_laskar_lower, fan_lower). 0 sorries (h_as_min, turan_plus_one, h_four, h_spec all proved). Note: erdos_laskar_upper and fan_lower axioms are too strong for small n (asymptotic results stated as universal). Trust caveat: the finite graph computations in `turan_plus_one` and `h_three` (concrete edge-count and vertex-degree facts of a small explicit graph) are closed by `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom (visible in `#print axioms`); the h(n) bounds themselves rest on the stated axioms and stay kernel-checked.",
     "theoremCount": 28,
     "definitionCount": 20,
     "additionalFiles": [

--- a/src/data/proofs/erdos-1056/meta.json
+++ b/src/data/proofs/erdos-1056/meta.json
@@ -27,7 +27,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 223,
-    "assumptions": "1 axiom: erdos_1056_conjecture (main conjecture — for every k ≥ 2 there exists a solution). k=2 (p=11) and k=3 (p=17) cases fully proved by native_decide. Wilson constraint proved via Mathlib.",
+    "assumptions": "1 axiom: erdos_1056_conjecture (main conjecture — for every k ≥ 2 there exists a solution). k=2 (p=11) and k=3 (p=17) cases fully proved by native_decide. Wilson constraint proved via Mathlib. Trust caveat: the finite k=2 (p=11) and k=3 (p=17) case verifications in `erdos_k2`, `makowski_k3`, `known_solutions_use_odd_primes`, `wilson_constraint_11`, and `wilson_constraint_17` are closed by `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom (visible in `#print axioms`); the general conjecture rests on the stated axiom `erdos_1056_conjecture`.",
     "mathlib_version": "4.31.0",
     "theoremCount": 15,
     "definitionCount": 4,

--- a/src/data/proofs/erdos-1063/meta.json
+++ b/src/data/proofs/erdos-1063/meta.json
@@ -53,7 +53,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 190,
-    "assumptions": "3 axioms: erdos_selfridge_nondivisibility (Erdős-Selfridge impossibility result), monier_factorial_bound (n_k ≤ k!), cambie_lcm_bound (n_k ≤ k·lcm(2,...,k-1)). Former threshold axioms proved and eliminated. Unified threshold_exists theorem (k ≥ 2) added to combine small-case witnesses with Monier's bound into one uniform existence statement.",
+    "assumptions": "3 axioms: erdos_selfridge_nondivisibility (Erdős-Selfridge impossibility result), monier_factorial_bound (n_k ≤ k!), cambie_lcm_bound (n_k ≤ k·lcm(2,...,k-1)). Former threshold axioms proved and eliminated. Unified threshold_exists theorem (k ≥ 2) added to combine small-case witnesses with Monier's bound into one uniform existence statement. Trust caveat: the finite threshold evaluations in `threshold_k2`\u2013`threshold_k5` (concrete small-k values) are closed by `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom (visible in `#print axioms`); the general bounds rest on the stated axioms and stay kernel-checked.",
     "theoremCount": 6,
     "definitionCount": 5
   },

--- a/src/data/proofs/erdos-1106/meta.json
+++ b/src/data/proofs/erdos-1106/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 4,
     "lineCount": 246,
-    "assumptions": "4 axiom(s). No sorries.",
+    "assumptions": "4 axiom(s). No sorries. Trust caveat: the finite partition-function evaluations in `partition_small_values`, `example_F5`, and `F_one`\u2013`F_four` are closed by `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom (visible in `#print axioms`); these are concrete small-value checks, while the headline result rests on the stated axioms.",
     "mathlib_version": "4.31.0",
     "theoremCount": 9,
     "definitionCount": 7

--- a/src/data/proofs/erdos-219/meta.json
+++ b/src/data/proofs/erdos-219/meta.json
@@ -49,7 +49,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 148,
-    "assumptions": "1 axiom: green_tao_theorem. 0 sorries.",
+    "assumptions": "1 axiom: green_tao_theorem. 0 sorries. Trust caveat: the finite primality checks for the explicit arithmetic progressions in `is_prime_ap_3_5_7` and `is_prime_ap_5_11_17_23_29` are closed by `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom (visible in `#print axioms`); the general result rests on the stated axiom `green_tao_theorem`.",
     "theoremCount": 7,
     "definitionCount": 4
   },

--- a/src/data/proofs/erdos-299/meta.json
+++ b/src/data/proofs/erdos-299/meta.json
@@ -55,7 +55,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 384,
-    "assumptions": "1 axiom (bloom_theorem: Bloom's 2021 result on positive density sets). 0 sorries.",
+    "assumptions": "1 axiom (bloom_theorem: Bloom's 2021 result on positive density sets). 0 sorries. Trust caveat: the finite Egyptian-fraction identity checks in `egyptian_236` and `egyptian_2_4_6_12` are closed by `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom (visible in `#print axioms`); the density result rests on the stated axiom `bloom_theorem`.",
     "theoremCount": 10,
     "definitionCount": 7
   },

--- a/src/data/proofs/erdos-384/meta.json
+++ b/src/data/proofs/erdos-384/meta.json
@@ -31,7 +31,7 @@
       "Basic Lean 4 tactics (native_decide, norm_num, interval_cases)"
     ],
     "lineCount": 231,
-    "assumptions": "1 axiom: ecklund_1969 (Ecklund 1969 — C(n,k) has a small prime divisor except for (7,3)). 0 sorries.",
+    "assumptions": "1 axiom: ecklund_1969 (Ecklund 1969 — C(n,k) has a small prime divisor except for (7,3)). 0 sorries. Trust caveat: the finite exceptional-case computations in `choose_7_3` and `minPrimeDivisor_35` (concrete C(7,3)=35 and its least prime divisor) are closed by `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom (visible in `#print axioms`); the general result rests on the stated axiom `ecklund_1969`.",
     "theoremCount": 12,
     "definitionCount": 8
   },


### PR DESCRIPTION
## Summary

Batch 6 of the #41407 backlog: 8 **axiomatized** gallery entries close one or more **named** theorems with `native_decide` (which introduces the `Lean.ofReduceBool` compiler-trust axiom, visible in `#print axioms`) but their `meta.assumptions` omitted that disclosure.

Per the established convention for #41407 (precedent PRs #41405/#41409/#41411/#41416/#41418/#41421/#41423), this is **disclosure-only**: each `assumptions` string gets a "Trust caveat" naming the specific `native_decide` theorems and characterizing them as finite demonstrations, while the headline conjectures rest on the stated `axiom` declarations and stay kernel-checked. **No change to `axiomCount`/`status`/`badge`** — all entries are already `status: "axiomatized"`.

## Entries (all confirmed axiomatized, no prior `ofReduceBool` disclosure)

| Slug | Named `native_decide` theorems (finite demos) |
|------|-----------------------------------------------|
| erdos-1033 | `turan_plus_one`, `h_three` (small-graph edge/degree facts) |
| erdos-1106 | `partition_small_values`, `example_F5`, `F_one`–`F_four` |
| erdos-1063 | `threshold_k2`–`threshold_k5` |
| erdos-1056 | `erdos_k2`, `makowski_k3`, `known_solutions_use_odd_primes`, `wilson_constraint_11/17` |
| erdos-384 | `choose_7_3`, `minPrimeDivisor_35` |
| erdos-299 | `egyptian_236`, `egyptian_2_4_6_12` |
| erdos-219 | `is_prime_ap_3_5_7`, `is_prime_ap_5_11_17_23_29` |
| collatz-structured | `three/five/six/seven/nine/twentyseven_reaches_one` |

## Evidence

- Each entry's headline claim rests on explicit `axiom` declarations (`ecklund_1969`, `bloom_theorem`, `green_tao_theorem`, `collatz_conjecture`, `erdos_1056_conjecture`, etc.); `native_decide` is confined to finite-stage demonstrations.
- Surgical single-line text edits — `git diff --stat` shows exactly 1 insertion/1 deletion per file (no JSON reformatting noise).
- All 8 meta.json files re-parse as valid JSON with `Lean.ofReduceBool` present.

Deduped by slug against open PRs #41409/#41424/#41425/#41413 and the covered-so-far set — no overlap.

Part of #41407.
