### PR TITLE
Fix: disclose native_decide (Lean.ofReduceBool) in 7 axiomatized entries — batch 7

### DIFF
--- a/src/data/proofs/erdos-1007/meta.json
+++ b/src/data/proofs/erdos-1007/meta.json
@@ -24,7 +24,7 @@
     "erdosProblemStatus": "solved",
     "axiomCount": 4,
     "lineCount": 131,
-    "assumptions": "4 axioms: hasUnitEmbedding_exists, min_edges_dimension_4, k33_unique_minimum, and 1 more. See Lean source for complete statements.",
+    "assumptions": "4 axioms: hasUnitEmbedding_exists, min_edges_dimension_4, k33_unique_minimum, and 1 more. See Lean source for complete statements. Trust caveat: the named theorem `k6_has_15_edges` is closed by `native_decide`, which introduces the `Lean.ofReduceBool` compiler-trust axiom (kernel-external); it verifies the finite computation Nat.choose 6 2 = 15, a finite demonstration, while the headline result rests on the explicit axiom declaration(s) above and stays kernel-checked.",
     "mathlib_version": "4.31.0",
     "theoremCount": 3,
     "definitionCount": 4

--- a/src/data/proofs/erdos-60/meta.json
+++ b/src/data/proofs/erdos-60/meta.json
@@ -58,7 +58,7 @@
       "Kővári-Sós-Turán theorem",
       "Zarankiewicz problem"
     ],
-    "assumptions": "8 axiom(s). No sorries. 0 sorries remain.(s) remain.",
+    "assumptions": "8 axiom(s). No sorries. 0 sorries remain.(s) remain. Trust caveat: the named theorem `K4_minus_edge_card` is closed by `native_decide`, which introduces the `Lean.ofReduceBool` compiler-trust axiom (kernel-external); it verifies a finite edge-set decidability check on K₄ minus an edge, a finite demonstration, while the headline result rests on the explicit axiom declaration(s) above and stays kernel-checked.",
     "theoremCount": 10,
     "definitionCount": 12
   },

--- a/src/data/proofs/erdos-824/meta.json
+++ b/src/data/proofs/erdos-824/meta.json
@@ -55,7 +55,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 235,
-    "assumptions": "1 axiom: h_superlinear. 0 sorries.",
+    "assumptions": "1 axiom: h_superlinear. 0 sorries. Trust caveat: the named theorem `example_coprime_pair` is closed by `native_decide`, which introduces the `Lean.ofReduceBool` compiler-trust axiom (kernel-external); it verifies the finite fact σ(14) = σ(15), a finite demonstration, while the headline result rests on the explicit axiom declaration(s) above and stays kernel-checked.",
     "theoremCount": 5,
     "definitionCount": 10
   },

--- a/src/data/proofs/erdos-829/meta.json
+++ b/src/data/proofs/erdos-829/meta.json
@@ -57,7 +57,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 197,
-    "assumptions": "2 axioms: mordell_unbounded, stewart_2008. 0 sorries.",
+    "assumptions": "2 axioms: mordell_unbounded, stewart_2008. 0 sorries. Trust caveat: the named theorem `hardy_ramanujan_1729` is closed by `native_decide`, which introduces the `Lean.ofReduceBool` compiler-trust axiom (kernel-external); it verifies the finite fact cubeRepresentations 1729 = 2 (the Hardy–Ramanujan number), a finite demonstration, while the headline result rests on the explicit axiom declaration(s) above and stays kernel-checked.",
     "theoremCount": 4,
     "definitionCount": 6
   },

--- a/src/data/proofs/erdos-884/meta.json
+++ b/src/data/proofs/erdos-884/meta.json
@@ -67,7 +67,7 @@
       "allPairsSum_le_tau_mul_consecutive: sum-level bound S_all ≤ (τ-1)·S_consec"
     ],
     "axiomCount": 1,
-    "assumptions": "1 axiom: erdos_884 (the OPEN main conjecture). All 8 supporting axioms eliminated: divisorList_pairwise_lt, mem_divisorList_iff, consecutiveGap_pos, generalGap_pos, divisors_6, divisors_prime, prime_case_equality, gap_lower_bound — all proved. numDivisors_mul_coprime sorry also proved via σ��� multiplicativity.",
+    "assumptions": "1 axiom: erdos_884 (the OPEN main conjecture). All 8 supporting axioms eliminated: divisorList_pairwise_lt, mem_divisorList_iff, consecutiveGap_pos, generalGap_pos, divisors_6, divisors_prime, prime_case_equality, gap_lower_bound — all proved. numDivisors_mul_coprime sorry also proved via σ��� multiplicativity. Trust caveat: the named theorem `divisors_6` is closed by `native_decide`, which introduces the `Lean.ofReduceBool` compiler-trust axiom (kernel-external); it verifies the finite computation divisorList 6 = [1, 2, 3, 6], a finite demonstration, while the headline result rests on the explicit axiom declaration(s) above and stays kernel-checked.",
     "lineCount": 606,
     "theoremCount": 38,
     "definitionCount": 9

--- a/src/data/proofs/erdos-930/meta.json
+++ b/src/data/proofs/erdos-930/meta.json
@@ -50,7 +50,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 149,
-    "assumptions": "1 axiom: six_not_isPower. 0 sorries.",
+    "assumptions": "1 axiom: six_not_isPower. 0 sorries. Trust caveat: the named theorem `product_2_3_not_power` is closed by `native_decide`, which introduces the `Lean.ofReduceBool` compiler-trust axiom (kernel-external); it verifies the finite computation ∏_{2≤m≤3} m = 6, a finite demonstration, while the headline result rests on the explicit axiom declaration(s) above and stays kernel-checked.",
     "theoremCount": 5,
     "definitionCount": 4
   },

--- a/src/data/proofs/erdos-982/meta.json
+++ b/src/data/proofs/erdos-982/meta.json
@@ -64,7 +64,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 336,
-    "assumptions": "4 axioms: moser_bound, nppz_bound, regular_polygon_distances, stronger_conjecture_is_false. 3 sorries.",
+    "assumptions": "4 axioms: moser_bound, nppz_bound, regular_polygon_distances, stronger_conjecture_is_false. 3 sorries. Trust caveat: the named theorem `gap_value` is closed by `native_decide`, which introduces the `Lean.ofReduceBool` compiler-trust axiom (kernel-external); it verifies the finite value currentGap 1 = 5/36, a finite demonstration, while the headline result rests on the explicit axiom declaration(s) above and stays kernel-checked.",
     "theoremCount": 6,
     "definitionCount": 9,
     "additionalFiles": [


### PR DESCRIPTION
Discloses the `Lean.ofReduceBool` compiler-trust axiom (introduced by `native_decide`) in 7 axiomatized gallery entries from the #41407 backlog. Prose-only, precedented convention (#41405/#40878/#41083/#41409/#41426): append a "Trust caveat" to `meta.assumptions`; **no change** to `axiomCount`/`status`/`badge` — all entries are already `status: axiomatized`, `badge: axiom`, and each `native_decide` is confined to a single finite-demonstration named theorem while the headline claim rests on explicit `axiom` declarations that stay kernel-checked.

| slug | native_decide theorem | finite fact |
|------|----------------------|-------------|
| erdos-982 | `gap_value` | currentGap 1 = 5/36 |
| erdos-930 | `product_2_3_not_power` | ∏_{2≤m≤3} m = 6 |
| erdos-884 | `divisors_6` | divisorList 6 = [1,2,3,6] |
| erdos-829 | `hardy_ramanujan_1729` | cubeRepresentations 1729 = 2 |
| erdos-824 | `example_coprime_pair` | σ(14) = σ(15) |
| erdos-60 | `K4_minus_edge_card` | K₄-minus-edge edge-set decidability |
| erdos-1007 | `k6_has_15_edges` | Nat.choose 6 2 = 15 |

Each was verified on `origin/main`: `status: axiomatized`, no prior `ofReduceBool` mention, exactly one named (non-`example`) `native_decide` decl. Surgical 1-line edits (7 files, 7 insertions/7 deletions). Dedup'd by slug against all open #41407 PRs (#41426/25/24/23/13/09).

Part of #41407.
