### PR TITLE
Enrich: disclose native_decide (Lean.ofReduceBool) in erdos-823 (#41407)

### DIFF
--- a/src/data/proofs/erdos-823/meta.json
+++ b/src/data/proofs/erdos-823/meta.json
@@ -83,7 +83,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 281,
-    "assumptions": "2 axioms: pollack_2015, erdos_phi_easy. 0 sorries.",
+    "assumptions": "2 axioms: pollack_2015, erdos_phi_easy. 0 sorries. Trust caveat: the finite σ/φ coincidence witnesses — sigma_one, the equal-σ pairs sigma_14_15 / sigma_33_35 / sigma_957_958 with their values sigma_14_value / sigma_15_value (and fiber_24_nonempty), and the equal-φ facts phi_1_2 / phi_3_4_6 — are closed by `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom (visible in `#print axioms`); these unconditional finite computations demonstrate specific coincidences but do not feed the two axiomatized limit statements. The structural lemmas sigma_prime / sigma_prime_power / sigma_multiplicative and the conditional erdos_823_solved are kernel-checked.",
     "theoremCount": 16,
     "definitionCount": 6
   },


### PR DESCRIPTION
## Enrichment: disclose `native_decide` (`Lean.ofReduceBool`) in erdos-823 (#41407)

Extends the `assumptions` field of **erdos-823** (axiomatized) with a Trust
caveat, per the Axiom Integrity Policy and the precedent PRs #41405 / #41418.

erdos-823 closes several **named** theorems with `native_decide` (which adds
`Lean.ofReduceBool`) while previously disclosing only its two `axiom`
declarations. The `native_decide` results are the finite σ/φ coincidence
witnesses — `sigma_14_15` / `sigma_33_35` / `sigma_957_958` (equal-σ pairs) with
their values, `fiber_24_nonempty`, and `phi_1_2` / `phi_3_4_6` — which
demonstrate specific coincidences but do **not** feed the two axiomatized limit
statements (`pollack_2015`, `erdos_phi_easy`). Disclosure-only: no
`axiomCount` / `status` / `badge` change.

Supersedes the erdos-823 portion of #41424; the other four entries in that batch
(erdos-647, erdos-1107-oq-02, erdos-472, erdos-403) were disclosed on `main` by
parallel PRs while this batch was in flight, so #41424 is being closed as
redundant.
