### PR TITLE
Enrich: disclose native_decide (Lean.ofReduceBool) in erdos-841 (#41407)

### DIFF
--- a/src/data/proofs/erdos-841/meta.json
+++ b/src/data/proofs/erdos-841/meta.json
@@ -29,7 +29,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 169,
-    "assumptions": "4 axioms: t, trivial_lower_bound, selfridge_equality, selfridge_upper_bound. 0 sorries.",
+    "assumptions": "4 axioms: t, trivial_lower_bound, selfridge_equality, selfridge_upper_bound. 0 sorries. Trust caveat: the single named theorem example_t6_product (6 · 8 · 12 = 24 · 24, the finite witness underlying the t_6 = 6 example) is closed by `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom (visible in `#print axioms`); this concrete arithmetic identity illustrates the t_6 case but does not feed the four axiomatized bounds.",
     "mathlibDependencies": [
       {
         "theorem": "Nat.primeFactors_nonempty",


### PR DESCRIPTION
## Enrichment: disclose `native_decide` (`Lean.ofReduceBool`) in erdos-841 (#41407)

Extends the `assumptions` field of **erdos-841** (axiomatized) with a Trust
caveat, per the Axiom Integrity Policy and the precedent PRs #41405 / #41418.

erdos-841 closes one **named** theorem with `native_decide` — `example_t6_product`
(`6 * 8 * 12 = 24 * 24`), the finite witness underlying the `t_6 = 6` example —
while previously disclosing only its four `axiom` declarations. `native_decide`
adds `Lean.ofReduceBool`; this concrete arithmetic identity illustrates the t_6
case but does not feed the four axiomatized bounds (`t`, `trivial_lower_bound`,
`selfridge_equality`, `selfridge_upper_bound`). Disclosure-only: no
`axiomCount` / `status` / `badge` change.

Verified against current `main`: the file still lacked the disclosure and no
competing PR was open.
