### PR TITLE
Fix: disclose native_decide (Lean.ofReduceBool) in 10 axiomatized entries — tail batch (#41407)

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03/meta.json
@@ -28,7 +28,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "assumptions": "1 axiom: borsuk_ulam_general (Borsuk-Ulam theorem for n≥1). Former axioms no_retraction, brouwer_fixed_point, lusternik_schnirelmann proved from BU; ham_sandwich_general, odd_map_odd_degree converted to theorems.",
+    "assumptions": "1 axiom: borsuk_ulam_general (Borsuk-Ulam theorem for n≥1). Former axioms no_retraction, brouwer_fixed_point, lusternik_schnirelmann proved from BU; ham_sandwich_general, odd_map_odd_degree converted to theorems. Trust caveat: tverberg_6_fails use native_decide (Lean.ofReduceBool), so #print axioms lists Lean.ofReduceBool — a finite table lookup (tverbergStatusByR 6 = disproved), not the headline result, which rests on the axiom(s) above and stays kernel-checked.",
     "mathlibDependencies": [
       {
         "theorem": "intermediate_value_Icc",

--- a/src/data/proofs/bounded-prime-gaps-oq-04/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "assumptions": "1 axiom: bombieriVinogradov (Bombieri-Vinogradov theorem on primes in progressions). 0 sorries.",
+    "assumptions": "1 axiom: bombieriVinogradov (Bombieri-Vinogradov theorem on primes in progressions). 0 sorries. Trust caveat: total_effort_estimate use native_decide (Lean.ofReduceBool), so #print axioms lists Lean.ofReduceBool — a finite arithmetic estimate, not the headline result, which rests on the axiom(s) above and stays kernel-checked.",
     "mathlibDependencies": [
       {
         "theorem": "ArithmeticFunction.vonMangoldt",


### PR DESCRIPTION
Addresses part of #41407 (Gallery integrity: axiomatized entries omit `native_decide`/`Lean.ofReduceBool` from their `assumptions`).

## What

Ten `status: axiomatized` / `badge: axiom` gallery entries close named theorems with `native_decide`, which trusts the Lean compiler's kernel reduction and so depends on the `Lean.ofReduceBool` axiom (`#print axioms` lists it). Their `meta.assumptions` did not disclose this. Per the #41407 convention (these entries are ALREADY `axiomatized`, so DISCLOSE-only), each `assumptions` string gets a prose **Trust caveat** naming the specific `native_decide` theorem(s) and characterizing them as finite computational demonstrations — the headline result rests on the explicit `axiom` declarations already listed and stays kernel-checked.

**No `axiomCount` / `status` / `badge` changes** (these are not undisclosed axiom-count bumps like #41293 — the entries are already axiomatized).

## Entries (native_decide theorems disclosed)

| Slug | native_decide theorem(s) |
|------|--------------------------|
| bounded-prime-gaps-oq-01-oq-02 | quintuple_card, quintuple_le_12, eh_conditional_h_le_12, two_optimal_5_tuples |
| bounded-prime-gaps-oq-04 | total_effort_estimate |
| borsuk-ulam-oq-03 | tverberg_6_fails |
| erdos-393 | example_3_factorial |
| erdos-316 | minimalCounterexample_sum_lt_two |
| erdos-387 | schinzel_counterexample |
| erdos-184 | key_insight_log_star |
| erdos-1149 | countCoprimePairs_one |
| erdos-269 | twoThreeSmooth_card |
| erdos-436 | lambda_2_gaps |

## Evidence

- Each is a surgical 1-line edit to the `assumptions` string (10 files, +10/-10, no JSON reformatting).
- Verified each `native_decide` sits in a finite-demo named theorem (small value/table/cardinality check), not the headline — e.g. `tverberg_6_fails : tverbergStatusByR 6 = .disproved`, headline rests on `borsuk_ulam_general` axiom.
- Deduped by SLUG against all open `fix/mechanic-41407-*` PRs (#41434, #41438) and enricher #41436 — zero overlap.

Part of #41407.
