### PR TITLE
research(erdos-30-wip-01): h(10)=4 via perfect-ruler parity obstruction (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos30WIP01.lean
+++ b/proofs/Proofs/Erdos30WIP01.lean
@@ -486,7 +486,8 @@ theorem sum_offDiag_fst (A : Finset ℕ) :
   have hprod : ∑ p ∈ A ×ˢ A, (p.1 : ℤ) = (A.card : ℤ) * ∑ a ∈ A, (a : ℤ) := by
     rw [Finset.sum_product, Finset.mul_sum]
     refine Finset.sum_congr rfl (fun a _ => ?_)
-    rw [Finset.sum_const, nsmul_eq_mul]
+    rw [show (∑ y ∈ A, ((a, y).1 : ℤ)) = ∑ _y ∈ A, (a : ℤ) from rfl,
+      Finset.sum_const, nsmul_eq_mul]
   have hdiag : ∑ p ∈ A.diag, (p.1 : ℤ) = ∑ a ∈ A, (a : ℤ) := by
     simp [Finset.sum_diag]
   rw [hprod, hdiag] at hsplit
@@ -540,7 +541,9 @@ theorem no_sidon_card_five_range_eleven (A : Finset ℕ)
     rw [hP, ← Finset.filter_image, himageFull]; decide
   -- Hence the sum of positive differences is `1 + 2 + ⋯ + 10 = 55`.
   have hsum55 : ∑ p ∈ P, diffMap p = 55 := by
-    rw [← Finset.sum_image hinjP, hPimg]; decide
+    have hsi := Finset.sum_image (f := fun d : ℤ => d) hinjP
+    rw [hPimg] at hsi
+    rw [← hsi]; decide
   -- Structural parity: `∑ p₁ + ∑ p₂ = ∑_{offDiag} p₁ = 4·∑A`, hence even.
   have hS1S2 : ∑ p ∈ P, (p.1 : ℤ) + ∑ p ∈ P, (p.2 : ℤ)
              = ∑ p ∈ A.offDiag, (p.1 : ℤ) := by
@@ -567,7 +570,7 @@ theorem no_sidon_card_five_range_eleven (A : Finset ℕ)
         simp only [diffMap] at hlt
         refine ⟨⟨h2, h1, fun h => hne h.symm⟩, ?_⟩
         show ¬ 0 < (a.2 : ℤ) - (a.1 : ℤ); omega
-    rw [key, hswap]; ring
+    rw [key, hswap]
   have heven : Even (∑ p ∈ P, diffMap p) := by
     have hval : ∑ p ∈ P, diffMap p = ∑ p ∈ P, (p.1 : ℤ) - ∑ p ∈ P, (p.2 : ℤ) := by
       simp only [diffMap]; rw [Finset.sum_sub_distrib]

--- a/proofs/Proofs/Erdos30WIP01.lean
+++ b/proofs/Proofs/Erdos30WIP01.lean
@@ -446,4 +446,181 @@ theorem sidonNumber_nine : sidonNumber 9 = 4 := by
   · calc 4 = ({0, 1, 4, 6} : Finset ℕ).card := by decide
       _ ≤ sidonNumber 9 := sidonNumber_ge_card (by decide) isSidonSet_0_1_4_6
 
+/-! ### `h(10) = 4` — breaking the counting wall with a parity argument
+
+For `N ≤ 9` the counting bound `|A|² ≤ 2N + |A|` alone forces `|A| ≤ 4`.  At `N = 10`
+it goes slack: `5·4 = 20 = 2·10` admits a 5-element set.  A genuinely new obstruction
+is needed, and it is a clean parity fact.
+
+A 5-element Sidon set `A ⊆ {0,…,10}` has `C(5,2) = 10` *distinct* ordered positive
+differences `a − b` (`a > b`), all lying in `{1,…,10}`; being 10 distinct values in a
+10-element set they are **exactly** `{1,…,10}` — a *perfect difference set* / perfect
+ruler.  Their sum is therefore `1 + 2 + ⋯ + 10 = 55`, which is **odd**.
+
+But the sum of the ordered positive differences is always **even**: writing
+`S₁ = ∑_{a>b} a` and `S₂ = ∑_{a>b} b`, the sum is `S₁ − S₂`, while `S₁ + S₂` equals
+`∑_{(a,b) ∈ offDiag} a = (|A| − 1)·∑A = 4·∑A` (each element is a first coordinate of
+`|A| − 1` ordered pairs).  Hence `S₁ − S₂ = 4·∑A − 2·S₂` is even.  Even ≠ 55, so no
+such set exists and `h(10) = 4`.  A perfect ruler with 5 marks does not exist. -/
+
+/-- **General size bound helper.** If every Sidon subset of `{0,…,N}` has size at most
+`B`, then `h(N) = sidonNumber N ≤ B`.  (The counting-based `sidonNumber_le_of_sq` is the
+special case `B = ⌊…⌋`; this form accepts any pointwise size argument.) -/
+theorem sidonNumber_le_of_card {N B : ℕ}
+    (h : ∀ A : Finset ℕ, A ⊆ Finset.range (N + 1) → IsSidonSet A → A.card ≤ B) :
+    sidonNumber N ≤ B := by
+  unfold sidonNumber
+  apply Finset.sup_le
+  intro A hA
+  simp only [Finset.mem_filter, Finset.mem_powerset] at hA
+  exact h A hA.1 hA.2
+
+/-- **Off-diagonal first-coordinate sum.** `∑_{(a,b) ∈ A.offDiag} a = (|A| − 1)·∑A`:
+each `a ∈ A` is the first coordinate of exactly `|A| − 1` ordered off-diagonal pairs.
+(Computed as `∑_{A×A} a − ∑_{diag} a = |A|·∑A − ∑A`.) -/
+theorem sum_offDiag_fst (A : Finset ℕ) :
+    ∑ p ∈ A.offDiag, (p.1 : ℤ) = ((A.card : ℤ) - 1) * ∑ a ∈ A, (a : ℤ) := by
+  have hsplit : ∑ p ∈ A ×ˢ A, (p.1 : ℤ)
+      = ∑ p ∈ A.diag, (p.1 : ℤ) + ∑ p ∈ A.offDiag, (p.1 : ℤ) := by
+    rw [← Finset.diag_union_offDiag A, Finset.sum_union (Finset.disjoint_diag_offDiag A)]
+  have hprod : ∑ p ∈ A ×ˢ A, (p.1 : ℤ) = (A.card : ℤ) * ∑ a ∈ A, (a : ℤ) := by
+    rw [Finset.sum_product, Finset.mul_sum]
+    refine Finset.sum_congr rfl (fun a _ => ?_)
+    have hc : ∀ b, ((a, b).1 : ℤ) = (a : ℤ) := fun _ => rfl
+    simp_rw [hc, Finset.sum_const, nsmul_eq_mul]
+  have hdiag : ∑ p ∈ A.diag, (p.1 : ℤ) = ∑ a ∈ A, (a : ℤ) := by
+    simp [Finset.sum_diag]
+  rw [hprod, hdiag] at hsplit
+  have hoff : ∑ p ∈ A.offDiag, (p.1 : ℤ)
+      = (A.card : ℤ) * ∑ a ∈ A, (a : ℤ) - ∑ a ∈ A, (a : ℤ) := by linarith
+  rw [hoff]; ring
+
+/-- **No 5-element Sidon set fits in `{0,…,10}`** — the perfect-ruler parity obstruction.
+Such a set would have `10` distinct positive differences exhausting `{1,…,10}` (sum `55`,
+odd), yet the sum of ordered positive differences is always even. -/
+theorem no_sidon_card_five_range_eleven (A : Finset ℕ)
+    (hsub : A ⊆ Finset.range 11) (hA : IsSidonSet A) : A.card ≤ 4 := by
+  by_contra hcard
+  rw [not_le] at hcard
+  -- Counting caps the size at 5, so a violating set has exactly 5 elements.
+  have hup : A.card * A.card ≤ 20 + A.card := by
+    have := sidon_card_sq_le 10 hsub hA; omega
+  have hc5 : A.card = 5 := by
+    have h5 : 5 ≤ A.card := hcard
+    by_contra hne
+    have h6 : 6 ≤ A.card := by omega
+    have hmul : 6 * A.card ≤ A.card * A.card := Nat.mul_le_mul h6 (le_refl A.card)
+    omega
+  -- `P` = ordered pairs `(a,b)` with `a > b`: the positive-difference pairs.
+  set P := A.offDiag.filter (fun p => p.2 < p.1) with hP
+  have hPsub : P ⊆ A.offDiag := Finset.filter_subset _ _
+  have hinjP : Set.InjOn diffMap ↑P :=
+    (diffMap_injOn hA).mono (Finset.coe_subset.mpr hPsub)
+  -- Both coordinates of any off-diagonal pair are `≤ 10`.
+  have hle10 : ∀ p ∈ A.offDiag, p.1 ≤ 10 ∧ p.2 ≤ 10 := by
+    intro p hp
+    rw [Finset.mem_offDiag] at hp
+    have h1 := hsub hp.1
+    have h2 := hsub hp.2.1
+    rw [Finset.mem_range] at h1 h2
+    omega
+  -- Positive differences land in `[1,10]`.
+  have hmaps : ∀ p ∈ P, diffMap p ∈ Finset.Icc (1 : ℤ) 10 := by
+    intro p hp
+    rw [hP, Finset.mem_filter] at hp
+    obtain ⟨hpoff, hlt⟩ := hp
+    have hb := hle10 p hpoff
+    rw [Finset.mem_Icc]
+    simp only [diffMap]
+    constructor <;> omega
+  -- `|P| = 10`: `P` and its swap are the two equal halves of the 20-element off-diagonal.
+  have hoffcard : A.offDiag.card = 20 := by
+    rw [Finset.offDiag_card, hc5]
+  have hpart := Finset.card_filter_add_card_filter_not A.offDiag (fun p => p.2 < p.1)
+  have hfeq : A.offDiag.filter (fun p => ¬ p.2 < p.1)
+            = A.offDiag.filter (fun p => p.1 < p.2) := by
+    apply Finset.filter_congr
+    intro p hp
+    rw [Finset.mem_offDiag] at hp
+    obtain ⟨_, _, hne⟩ := hp
+    constructor <;> intro <;> omega
+  have hswapcard : (A.offDiag.filter (fun p => p.1 < p.2)).card
+                 = (A.offDiag.filter (fun p => p.2 < p.1)).card := by
+    apply Finset.card_nbij' Prod.swap Prod.swap
+    · intro p hp
+      rw [Finset.mem_filter, Finset.mem_offDiag] at hp ⊢
+      obtain ⟨⟨h1, h2, hne⟩, hlt⟩ := hp
+      exact ⟨⟨h2, h1, fun h => hne h.symm⟩, by simp only [Prod.swap]; omega⟩
+    · intro p hp
+      rw [Finset.mem_filter, Finset.mem_offDiag] at hp ⊢
+      obtain ⟨⟨h1, h2, hne⟩, hlt⟩ := hp
+      exact ⟨⟨h2, h1, fun h => hne h.symm⟩, by simp only [Prod.swap]; omega⟩
+    · intro p _; simp [Prod.swap]
+    · intro p _; simp [Prod.swap]
+  have hcardP : P.card = 10 := by
+    rw [hP] at hoffcard hpart ⊢
+    rw [hfeq, hswapcard] at hpart
+    omega
+  -- The image of `P` under `diffMap` is exactly `{1,…,10}`.
+  have hDsub : P.image diffMap ⊆ Finset.Icc (1 : ℤ) 10 := by
+    intro d hd
+    rw [Finset.mem_image] at hd
+    obtain ⟨p, hp, rfl⟩ := hd
+    exact hmaps p hp
+  have hcardimg : (P.image diffMap).card = 10 := by
+    rw [Finset.card_image_of_injOn hinjP, hcardP]
+  have hIcc : (Finset.Icc (1 : ℤ) 10).card = 10 := by decide
+  have hDeq : P.image diffMap = Finset.Icc (1 : ℤ) 10 :=
+    Finset.eq_of_subset_of_card_le hDsub (by rw [hcardimg, hIcc])
+  -- Sum of the positive differences is `1 + ⋯ + 10 = 55`.
+  have himg_sum : ∑ d ∈ P.image diffMap, d = ∑ p ∈ P, diffMap p :=
+    Finset.sum_image hinjP
+  have hsum55 : ∑ p ∈ P, diffMap p = 55 := by
+    rw [← himg_sum, hDeq]; decide
+  -- Structural parity: `∑ p₁ + ∑ p₂ = ∑_{offDiag} p₁ = 4·∑A` is even.
+  have hS1S2 : ∑ p ∈ P, (p.1 : ℤ) + ∑ p ∈ P, (p.2 : ℤ)
+             = ∑ p ∈ A.offDiag, (p.1 : ℤ) := by
+    have hfa := Finset.sum_filter_add_sum_filter_not A.offDiag
+      (fun p => p.2 < p.1) (fun p => (p.1 : ℤ))
+    have hswap : ∑ p ∈ A.offDiag.filter (fun p => ¬ p.2 < p.1), (p.1 : ℤ)
+               = ∑ p ∈ P, (p.2 : ℤ) := by
+      rw [hP]
+      refine Finset.sum_nbij' Prod.swap Prod.swap ?_ ?_ ?_ ?_ ?_
+      · intro q hq
+        rw [Finset.mem_filter, Finset.mem_offDiag] at hq ⊢
+        obtain ⟨⟨h1, h2, hne⟩, hnlt⟩ := hq
+        exact ⟨⟨h2, h1, fun h => hne h.symm⟩, by simp only [Prod.swap]; omega⟩
+      · intro p hp
+        rw [Finset.mem_filter, Finset.mem_offDiag] at hp ⊢
+        obtain ⟨⟨h1, h2, hne⟩, hlt⟩ := hp
+        exact ⟨⟨h2, h1, fun h => hne h.symm⟩, by simp only [Prod.swap]; omega⟩
+      · intro q _; simp [Prod.swap]
+      · intro p _; simp [Prod.swap]
+      · intro q _; simp only [Prod.swap]
+    rw [hswap] at hfa
+    rw [← hP] at hfa
+    linarith [hfa]
+  have heven : Even (∑ p ∈ P, diffMap p) := by
+    have hval : ∑ p ∈ P, diffMap p = ∑ p ∈ P, (p.1 : ℤ) - ∑ p ∈ P, (p.2 : ℤ) := by
+      simp only [diffMap]; rw [Finset.sum_sub_distrib]
+    have hoff := sum_offDiag_fst A
+    rw [hc5] at hoff
+    have h4 : ∑ p ∈ P, (p.1 : ℤ) + ∑ p ∈ P, (p.2 : ℤ) = 4 * ∑ a ∈ A, (a : ℤ) := by
+      rw [hS1S2, hoff]; norm_num
+    rw [hval]
+    refine ⟨2 * ∑ a ∈ A, (a : ℤ) - ∑ p ∈ P, (p.2 : ℤ), ?_⟩
+    linarith [h4]
+  rw [hsum55] at heven
+  exact absurd heven (by norm_num)
+
+/-- `h(10) = 4` — the first value past the counting wall.  A perfect ruler with 5 marks
+would be required for `h(10) = 5` and none exists (`no_sidon_card_five_range_eleven`);
+`{0,1,4,6} ⊆ {0,…,10}` still attains `4`. -/
+theorem sidonNumber_ten : sidonNumber 10 = 4 := by
+  refine le_antisymm ?_ ?_
+  · exact sidonNumber_le_of_card
+      (fun A hsub hA => no_sidon_card_five_range_eleven A hsub hA)
+  · calc 4 = ({0, 1, 4, 6} : Finset ℕ).card := by decide
+      _ ≤ sidonNumber 10 := sidonNumber_ge_card (by decide) isSidonSet_0_1_4_6
+
 end Erdos30

--- a/proofs/Proofs/Erdos30WIP01.lean
+++ b/proofs/Proofs/Erdos30WIP01.lean
@@ -486,7 +486,7 @@ theorem sum_offDiag_fst (A : Finset ℕ) :
   have hprod : ∑ p ∈ A ×ˢ A, (p.1 : ℤ) = (A.card : ℤ) * ∑ a ∈ A, (a : ℤ) := by
     rw [Finset.sum_product, Finset.mul_sum]
     refine Finset.sum_congr rfl (fun a _ => ?_)
-    have hc : ∀ b, ((a, b).1 : ℤ) = (a : ℤ) := fun _ => rfl
+    have hc : ∀ b : ℕ, ((a, b).1 : ℤ) = (a : ℤ) := fun _ => rfl
     simp_rw [hc, Finset.sum_const, nsmul_eq_mul]
   have hdiag : ∑ p ∈ A.diag, (p.1 : ℤ) = ∑ a ∈ A, (a : ℤ) := by
     simp [Finset.sum_diag]
@@ -536,7 +536,7 @@ theorem no_sidon_card_five_range_eleven (A : Finset ℕ)
   -- `|P| = 10`: `P` and its swap are the two equal halves of the 20-element off-diagonal.
   have hoffcard : A.offDiag.card = 20 := by
     rw [Finset.offDiag_card, hc5]
-  have hpart := Finset.card_filter_add_card_filter_not A.offDiag (fun p => p.2 < p.1)
+  have hpart := Finset.card_filter_add_card_filter_not (s := A.offDiag) (fun p => p.2 < p.1)
   have hfeq : A.offDiag.filter (fun p => ¬ p.2 < p.1)
             = A.offDiag.filter (fun p => p.1 < p.2) := by
     apply Finset.filter_congr

--- a/proofs/Proofs/Erdos30WIP01.lean
+++ b/proofs/Proofs/Erdos30WIP01.lean
@@ -486,8 +486,7 @@ theorem sum_offDiag_fst (A : Finset ℕ) :
   have hprod : ∑ p ∈ A ×ˢ A, (p.1 : ℤ) = (A.card : ℤ) * ∑ a ∈ A, (a : ℤ) := by
     rw [Finset.sum_product, Finset.mul_sum]
     refine Finset.sum_congr rfl (fun a _ => ?_)
-    have hc : ∀ b : ℕ, ((a, b).1 : ℤ) = (a : ℤ) := fun _ => rfl
-    simp_rw [hc, Finset.sum_const, nsmul_eq_mul]
+    rw [Finset.sum_const, nsmul_eq_mul]
   have hdiag : ∑ p ∈ A.diag, (p.1 : ℤ) = ∑ a ∈ A, (a : ℤ) := by
     simp [Finset.sum_diag]
   rw [hprod, hdiag] at hsplit
@@ -511,95 +510,64 @@ theorem no_sidon_card_five_range_eleven (A : Finset ℕ)
     have h6 : 6 ≤ A.card := by omega
     have hmul : 6 * A.card ≤ A.card * A.card := Nat.mul_le_mul h6 (le_refl A.card)
     omega
-  -- `P` = ordered pairs `(a,b)` with `a > b`: the positive-difference pairs.
-  set P := A.offDiag.filter (fun p => p.2 < p.1) with hP
+  -- `P` = the positive-difference ordered pairs `(a, b)` with `a > b` (i.e. `diffMap > 0`).
+  set P := A.offDiag.filter (fun p => 0 < diffMap p) with hP
   have hPsub : P ⊆ A.offDiag := Finset.filter_subset _ _
-  have hinjP : Set.InjOn diffMap ↑P :=
-    (diffMap_injOn hA).mono (Finset.coe_subset.mpr hPsub)
-  -- Both coordinates of any off-diagonal pair are `≤ 10`.
-  have hle10 : ∀ p ∈ A.offDiag, p.1 ≤ 10 ∧ p.2 ≤ 10 := by
+  have hfull : Set.InjOn diffMap ↑A.offDiag := diffMap_injOn hA
+  have hinjP : Set.InjOn diffMap ↑P := hfull.mono (Finset.coe_subset.mpr hPsub)
+  have hoffcard : A.offDiag.card = 20 := by rw [Finset.offDiag_card, hc5]
+  -- `diffMap` sends the off-diagonal onto the 20 nonzero integers of `[-10, 10]`.
+  have hmapsFull : ∀ p ∈ A.offDiag, diffMap p ∈ (Finset.Icc (-10 : ℤ) 10).erase 0 := by
     intro p hp
     rw [Finset.mem_offDiag] at hp
-    have h1 := hsub hp.1
-    have h2 := hsub hp.2.1
-    rw [Finset.mem_range] at h1 h2
-    omega
-  -- Positive differences land in `[1,10]`.
-  have hmaps : ∀ p ∈ P, diffMap p ∈ Finset.Icc (1 : ℤ) 10 := by
-    intro p hp
-    rw [hP, Finset.mem_filter] at hp
-    obtain ⟨hpoff, hlt⟩ := hp
-    have hb := hle10 p hpoff
-    rw [Finset.mem_Icc]
+    obtain ⟨hp1, hp2, hpne⟩ := hp
+    have hb1 := hsub hp1; have hb2 := hsub hp2
+    rw [Finset.mem_range] at hb1 hb2
+    rw [Finset.mem_erase, Finset.mem_Icc]
     simp only [diffMap]
-    constructor <;> omega
-  -- `|P| = 10`: `P` and its swap are the two equal halves of the 20-element off-diagonal.
-  have hoffcard : A.offDiag.card = 20 := by
-    rw [Finset.offDiag_card, hc5]
-  have hpart := Finset.card_filter_add_card_filter_not (s := A.offDiag) (fun p => p.2 < p.1)
-  have hfeq : A.offDiag.filter (fun p => ¬ p.2 < p.1)
-            = A.offDiag.filter (fun p => p.1 < p.2) := by
-    apply Finset.filter_congr
-    intro p hp
-    rw [Finset.mem_offDiag] at hp
-    obtain ⟨_, _, hne⟩ := hp
-    constructor <;> intro <;> omega
-  have hswapcard : (A.offDiag.filter (fun p => p.1 < p.2)).card
-                 = (A.offDiag.filter (fun p => p.2 < p.1)).card := by
-    apply Finset.card_nbij' Prod.swap Prod.swap
-    · intro p hp
-      rw [Finset.mem_filter, Finset.mem_offDiag] at hp ⊢
-      obtain ⟨⟨h1, h2, hne⟩, hlt⟩ := hp
-      exact ⟨⟨h2, h1, fun h => hne h.symm⟩, by simp only [Prod.swap]; omega⟩
-    · intro p hp
-      rw [Finset.mem_filter, Finset.mem_offDiag] at hp ⊢
-      obtain ⟨⟨h1, h2, hne⟩, hlt⟩ := hp
-      exact ⟨⟨h2, h1, fun h => hne h.symm⟩, by simp only [Prod.swap]; omega⟩
-    · intro p _; simp [Prod.swap]
-    · intro p _; simp [Prod.swap]
-  have hcardP : P.card = 10 := by
-    rw [hP] at hoffcard hpart ⊢
-    rw [hfeq, hswapcard] at hpart
-    omega
-  -- The image of `P` under `diffMap` is exactly `{1,…,10}`.
-  have hDsub : P.image diffMap ⊆ Finset.Icc (1 : ℤ) 10 := by
-    intro d hd
-    rw [Finset.mem_image] at hd
-    obtain ⟨p, hp, rfl⟩ := hd
-    exact hmaps p hp
-  have hcardimg : (P.image diffMap).card = 10 := by
-    rw [Finset.card_image_of_injOn hinjP, hcardP]
-  have hIcc : (Finset.Icc (1 : ℤ) 10).card = 10 := by decide
-  have hDeq : P.image diffMap = Finset.Icc (1 : ℤ) 10 :=
-    Finset.eq_of_subset_of_card_le hDsub (by rw [hcardimg, hIcc])
-  -- Sum of the positive differences is `1 + ⋯ + 10 = 55`.
-  have himg_sum : ∑ d ∈ P.image diffMap, d = ∑ p ∈ P, diffMap p :=
-    Finset.sum_image hinjP
+    exact ⟨fun h => hpne (by omega), by omega, by omega⟩
+  have hcardErase : ((Finset.Icc (-10 : ℤ) 10).erase 0).card = 20 := by
+    rw [Finset.card_erase_of_mem (by decide), Int.card_Icc]; decide
+  have himageFull : A.offDiag.image diffMap = (Finset.Icc (-10 : ℤ) 10).erase 0 := by
+    refine Finset.eq_of_subset_of_card_le (fun d hd => ?_) ?_
+    · rw [Finset.mem_image] at hd
+      obtain ⟨p, hp, rfl⟩ := hd
+      exact hmapsFull p hp
+    · rw [Finset.card_image_of_injOn hfull, hoffcard]
+      exact le_of_eq hcardErase
+  -- The positive differences are exactly `{1, …, 10}` (a perfect difference set).
+  have hPimg : P.image diffMap = Finset.Icc (1 : ℤ) 10 := by
+    rw [hP, ← Finset.filter_image, himageFull]; decide
+  -- Hence the sum of positive differences is `1 + 2 + ⋯ + 10 = 55`.
   have hsum55 : ∑ p ∈ P, diffMap p = 55 := by
-    rw [← himg_sum, hDeq]; decide
-  -- Structural parity: `∑ p₁ + ∑ p₂ = ∑_{offDiag} p₁ = 4·∑A` is even.
+    rw [← Finset.sum_image hinjP, hPimg]; decide
+  -- Structural parity: `∑ p₁ + ∑ p₂ = ∑_{offDiag} p₁ = 4·∑A`, hence even.
   have hS1S2 : ∑ p ∈ P, (p.1 : ℤ) + ∑ p ∈ P, (p.2 : ℤ)
              = ∑ p ∈ A.offDiag, (p.1 : ℤ) := by
-    have hfa := Finset.sum_filter_add_sum_filter_not A.offDiag
-      (fun p => p.2 < p.1) (fun p => (p.1 : ℤ))
-    have hswap : ∑ p ∈ A.offDiag.filter (fun p => ¬ p.2 < p.1), (p.1 : ℤ)
+    have key : ∑ p ∈ A.offDiag, (p.1 : ℤ)
+        = ∑ p ∈ P, (p.1 : ℤ)
+          + ∑ p ∈ A.offDiag.filter (fun p => ¬ 0 < diffMap p), (p.1 : ℤ) := by
+      rw [hP]
+      exact (Finset.sum_filter_add_sum_filter_not A.offDiag
+        (fun p => 0 < diffMap p) (fun p => (p.1 : ℤ))).symm
+    have hswap : ∑ p ∈ A.offDiag.filter (fun p => ¬ 0 < diffMap p), (p.1 : ℤ)
                = ∑ p ∈ P, (p.2 : ℤ) := by
       rw [hP]
-      refine Finset.sum_nbij' Prod.swap Prod.swap ?_ ?_ ?_ ?_ ?_
-      · intro q hq
-        rw [Finset.mem_filter, Finset.mem_offDiag] at hq ⊢
-        obtain ⟨⟨h1, h2, hne⟩, hnlt⟩ := hq
-        exact ⟨⟨h2, h1, fun h => hne h.symm⟩, by simp only [Prod.swap]; omega⟩
-      · intro p hp
-        rw [Finset.mem_filter, Finset.mem_offDiag] at hp ⊢
-        obtain ⟨⟨h1, h2, hne⟩, hlt⟩ := hp
-        exact ⟨⟨h2, h1, fun h => hne h.symm⟩, by simp only [Prod.swap]; omega⟩
-      · intro q _; simp [Prod.swap]
-      · intro p _; simp [Prod.swap]
-      · intro q _; simp only [Prod.swap]
-    rw [hswap] at hfa
-    rw [← hP] at hfa
-    linarith [hfa]
+      refine Finset.sum_nbij' Prod.swap Prod.swap ?_ ?_
+        (fun a _ => Prod.swap_swap a) (fun a _ => Prod.swap_swap a) (fun a _ => rfl)
+      · intro a ha
+        rw [Finset.mem_filter, Finset.mem_offDiag] at ha ⊢
+        obtain ⟨⟨h1, h2, hne⟩, hlt⟩ := ha
+        simp only [diffMap, not_lt] at hlt
+        refine ⟨⟨h2, h1, fun h => hne h.symm⟩, ?_⟩
+        show 0 < (a.2 : ℤ) - (a.1 : ℤ); omega
+      · intro a ha
+        rw [Finset.mem_filter, Finset.mem_offDiag] at ha ⊢
+        obtain ⟨⟨h1, h2, hne⟩, hlt⟩ := ha
+        simp only [diffMap] at hlt
+        refine ⟨⟨h2, h1, fun h => hne h.symm⟩, ?_⟩
+        show ¬ 0 < (a.2 : ℤ) - (a.1 : ℤ); omega
+    rw [key, hswap]; ring
   have heven : Even (∑ p ∈ P, diffMap p) := by
     have hval : ∑ p ∈ P, diffMap p = ∑ p ∈ P, (p.1 : ℤ) - ∑ p ∈ P, (p.2 : ℤ) := by
       simp only [diffMap]; rw [Finset.sum_sub_distrib]
@@ -608,8 +576,7 @@ theorem no_sidon_card_five_range_eleven (A : Finset ℕ)
     have h4 : ∑ p ∈ P, (p.1 : ℤ) + ∑ p ∈ P, (p.2 : ℤ) = 4 * ∑ a ∈ A, (a : ℤ) := by
       rw [hS1S2, hoff]; norm_num
     rw [hval]
-    refine ⟨2 * ∑ a ∈ A, (a : ℤ) - ∑ p ∈ P, (p.2 : ℤ), ?_⟩
-    linarith [h4]
+    exact ⟨2 * ∑ a ∈ A, (a : ℤ) - ∑ p ∈ P, (p.2 : ℤ), by linarith [h4]⟩
   rw [hsum55] at heven
   exact absurd heven (by norm_num)
 

--- a/research/problems/erdos-30-wip-01/knowledge.md
+++ b/research/problems/erdos-30-wip-01/knowledge.md
@@ -65,3 +65,50 @@ refinement (Erdős–Turán exact form `√N + N^{1/4} + 1`, and Lindström/BFR/
 improvements), Singer's projective-plane LOWER bound `h(N) ≥ (1−o(1))√N` (deep
 finite geometry), and the OPEN `$1000` Erdős–Turán conjecture (error `≤ N^ε` for
 all `ε > 0`) which stays a `Prop`.
+
+## Session 2026-07-22 (researcher-1-3) — h(10)=4 past the counting wall (perfect-ruler parity)
+
+Added 4 axiom-free theorems to `Erdos30WIP01.lean` (Docker-verified v4.31.0, 8577 jobs;
+`#print axioms` = propext/Classical.choice/Quot.sound on all headline results; no
+sorry/native_decide/axiom):
+
+- `sidonNumber_ten : sidonNumber 10 = 4` — the **first exact value past the counting wall**.
+  For N<=9 the counting bound |A|^2 <= 2N+|A| alone forces |A|<=4; at N=10 it goes slack
+  (5*4 = 20 = 2*10), so a genuinely new obstruction is needed.
+- `no_sidon_card_five_range_eleven : A ⊆ range 11 → IsSidonSet A → A.card <= 4` — the crux,
+  a **perfect-ruler parity argument**. A 5-element Sidon set in {0,...,10} has C(5,2)=10
+  distinct positive differences a-b, all in {1,...,10}; being 10 distinct values in a
+  10-element set they are EXACTLY {1,...,10} (a perfect difference set / perfect ruler),
+  summing to 1+...+10 = 55 (odd). But the sum of ordered positive differences is always
+  EVEN: S1-S2 with S1+S2 = sum_{offDiag} p.1 = (|A|-1)*sum A = 4*sum A (each element is a
+  first coordinate of |A|-1 ordered pairs), so S1-S2 = 4*sum A - 2*S2 is even. Even != 55.
+- `sidonNumber_le_of_card` — general helper: (∀ Sidon A ⊆ {0..N}, |A|<=B) → h(N)<=B.
+- `sum_offDiag_fst : sum_{p∈A.offDiag} p.1 = (|A|-1)*sum A` — reusable off-diagonal
+  first-coordinate sum (via A×A = diag ⊔ offDiag; sum_product - sum_diag).
+
+### Lean idioms / gotchas (all cost Docker cycles)
+- Positive-difference SET = {1..10} WITHOUT computing |P|: take the FULL off-diagonal image
+  `A.offDiag.image diffMap = (Icc (-10) 10).erase 0` (eq_of_subset_of_card_le, 20=20 via
+  offDiag_card+card_erase_of_mem+Int.card_Icc), then `Finset.filter_image` turns
+  `P.image diffMap = (offDiag.image diffMap).filter (0<·) = ((Icc -10 10).erase 0).filter(0<·)
+  = Icc 1 10` — closed by `decide` on concrete ℤ finsets. Avoids the swap-bijection card count.
+- `Finset.card_nbij'` uses `Set.MapsTo` (coe-membership, painful); `Finset.sum_nbij'` uses
+  plain `∀ a ∈ s, i a ∈ t` — MUCH cleaner. Used sum_nbij' with i=j=Prod.swap for the
+  swap identity `sum_{offDiag.filter ¬(0<diffMap)} p.1 = sum_P p.2`; left/right_inv =
+  `Prod.swap_swap`, value goal = `rfl` (`(swap a).2` defeq `a.1`), membership via
+  `show 0 < (a.2:ℤ)-(a.1:ℤ); omega` (defeq reduces `(swap a).1`/`.2`).
+- `sum_product` leaves body `((a,y).1:ℤ)` (contains bound var y) so `Finset.sum_const`
+  WON'T fire; first fold via `rw [show (∑ y∈A,((a,y).1:ℤ)) = ∑ _y∈A,(a:ℤ) from rfl]`.
+- `Finset.sum_image` needs the SUMMAND `f` pinned (`(f := fun d:ℤ => d)`) — Lean can't infer
+  it (higher-order); then `rw [← hsi]` to fold `∑_P diffMap → ∑_{image} id`.
+- `Finset.sum_filter_add_sum_filter_not s p f` (s,p,f all EXPLICIT) vs
+  `Finset.card_filter_add_card_filter_not (s := ...) p` (s IMPLICIT) — inconsistent arg style.
+- `Finset.eq_of_subset_of_card_le (h:s⊆t)(h2:#t<=#s) : s=t`.
+
+### Remaining open (unchanged mission)
+- h(11)=5 next (witness {0,1,4,9,11}); table continues by case analysis but each new value
+  past the wall needs its own exhaustive/parity argument.
+- Sharp `-c*sqrt(N)`... (Sidon: polynomial sqrt(N)-order LOWER bound, Singer perfect-difference
+  sets) needs modular Sidon infrastructure Mathlib lacks. The $1000 N^{1/4}-error conjecture
+  stays a Prop. Elementary two-sided (upper sqrt(2N)+1, lower log via powers-of-two) + exact
+  table h(0..10) is the provable envelope.

--- a/src/data/research/problems/erdos-30-wip-01.json
+++ b/src/data/research/problems/erdos-30-wip-01.json
@@ -23,7 +23,7 @@
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
     "blockers": [],
-    "nextAction": "Elementary two-sided understanding now in place: upper h(N)<=sqrt(2N)+1 (Erdos-Turan) and lower h(N) unbounded via powers-of-two (log N). NEXT (harder): a polynomial sqrt(N)-order lower-bound construction (Singer/perfect difference sets, or the Erdos-Turan {2ip + (i^2 mod p)} construction) — needs modular-arithmetic Sidon infrastructure absent from Mathlib. The open N^{1/4}-error Erdos-Turan conjecture ($1000) stays a Prop.",
+    "nextAction": "Exact table now extends past the counting wall to h(10)=4 (sidonNumber_ten), proved by the perfect-ruler parity obstruction (no 5-element Sidon set in {0,...,10}: its 10 distinct positive differences would exhaust {1,...,10}, sum 55 odd, but the sum of ordered positive differences is always even = 4*sum A). Reusable helpers added: sidonNumber_le_of_card, sum_offDiag_fst (offDiag first-coordinate sum = (|A|-1)*sum A). Counting bound alone caps at h(9); h(10) is the first value needing a genuinely new obstruction. NEXT (harder): h(11)=5 (needs the witness {0,1,4,9,11}) then h(12),h(13)... via case analysis, OR the polynomial sqrt(N)-order lower-bound construction (Singer/perfect difference sets) needing modular Sidon infrastructure absent from Mathlib. The open N^{1/4}-error Erdos-Turan conjecture ($1000) stays a Prop.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,


### PR DESCRIPTION
## Summary

Extends the exact Sidon-number table past the counting wall: **`sidonNumber_ten : sidonNumber 10 = 4`**, the first value where the elementary counting bound `|A|² ≤ 2N + |A|` goes slack (`5·4 = 20 = 2·10`) and a genuinely new obstruction is required.

The obstruction is a clean **perfect-ruler parity argument** (`no_sidon_card_five_range_eleven`):

- A 5-element Sidon set `A ⊆ {0,…,10}` has `C(5,2) = 10` distinct positive differences `a − b`, all in `{1,…,10}`. Being 10 distinct values in a 10-element set, they are **exactly** `{1,…,10}` — a perfect difference set / perfect ruler — summing to `1 + 2 + ⋯ + 10 = 55`, which is **odd**.
- But the sum of the ordered positive differences is always **even**: `S₁ − S₂` where `S₁ + S₂ = ∑_{(a,b) ∈ A.offDiag} a = (|A| − 1)·∑A = 4·∑A` (each element is the first coordinate of `|A| − 1` ordered pairs). Hence `S₁ − S₂ = 4·∑A − 2·S₂` is even.
- Even ≠ 55, so no such set exists; combined with the witness `{0,1,4,6} ⊆ {0,…,10}`, `h(10) = 4`. (Equivalently: no perfect ruler with 5 marks exists.)

## New theorems (all 0-axiom)

- `sidonNumber_ten : sidonNumber 10 = 4`
- `no_sidon_card_five_range_eleven` — the parity crux
- `sum_offDiag_fst : ∑_{p ∈ A.offDiag} p.1 = (|A| − 1)·∑A` — reusable off-diagonal first-coordinate sum
- `sidonNumber_le_of_card` — general size-bound helper

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos30WIP01` → **Build completed successfully (8577 jobs)**
- `#print axioms` on `sidonNumber_ten`, `no_sidon_card_five_range_eleven`, `sum_offDiag_fst` = `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `Lean.ofReduceBool`)
- No `sorry` / `native_decide` / `axiom` declarations

## Context

Continues the exact table `h(0..9)` (#41376, #41403). `h(10)` was the documented "wall" — counting caps at `h(9)`; this is the first value proved by a new mechanism. Mission remainder (polynomial `√N` lower bound / the open `N^{1/4}`-error Erdős–Turán conjecture, $1000) stays deep and needs modular Sidon infrastructure absent from Mathlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
