### PR TITLE
Fix: disclose native_decide (Lean.ofReduceBool) in 7 axiomatized entries — batch 9

### DIFF
--- a/src/data/proofs/erdos-1149/meta.json
+++ b/src/data/proofs/erdos-1149/meta.json
@@ -90,7 +90,7 @@
       "Divisibility and powers (dvd_pow_self)"
     ],
     "lineCount": 335,
-    "assumptions": "1 axiom (bergelson_richter). The Bergelson-Richter theorem is axiomatized (deep ergodic theory); random_coprime_density proved via BaselProblemOQ04OQ03 Möbius+Tannery.",
+    "assumptions": "1 axiom (bergelson_richter). The Bergelson-Richter theorem is axiomatized (deep ergodic theory); random_coprime_density proved via BaselProblemOQ04OQ03 Möbius+Tannery. Trust caveat: theorem countCoprimePairs_one (line 196) is closed by native_decide, which adds the Lean.ofReduceBool compiler-trust axiom (#print axioms); it verifies the finite base case countCoprimePairs 1 = 1, not the axiomatized Bergelson-Richter density.",
     "theoremCount": 18,
     "definitionCount": 5,
     "additionalFiles": [

--- a/src/data/proofs/erdos-184/meta.json
+++ b/src/data/proofs/erdos-184/meta.json
@@ -57,7 +57,7 @@
     ],
     "axiomCount": 5,
     "lineCount": 253,
-    "assumptions": "5 axioms: decompNumber, lower_bound_from_bipartite, bucic_montgomery_bound, conlon_fox_sudakov, coverNumber. 0 sorries.",
+    "assumptions": "5 axioms: decompNumber, lower_bound_from_bipartite, bucic_montgomery_bound, conlon_fox_sudakov, coverNumber. 0 sorries. Trust caveat: theorem key_insight_log_star (line 251) is closed by native_decide, which adds the Lean.ofReduceBool compiler-trust axiom (#print axioms); it verifies finite iterated-logarithm values (logStar 65536 = 4, logStar 4 = 2), not the headline decomposition bounds.",
     "theoremCount": 2,
     "definitionCount": 10
   },

--- a/src/data/proofs/erdos-269/meta.json
+++ b/src/data/proofs/erdos-269/meta.json
@@ -67,7 +67,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 303,
-    "assumptions": "3 axiom(s): erdos_269 (main conjecture, OPEN), erdos_269_infinite (infinite P case), erdos_269_distinct (distinct LCM case). Former axiom smoothSeq_zero now proved.",
+    "assumptions": "3 axiom(s): erdos_269 (main conjecture, OPEN), erdos_269_infinite (infinite P case), erdos_269_distinct (distinct LCM case). Former axiom smoothSeq_zero now proved. Trust caveat: theorem twoThreeSmooth_card (line 214) is closed by native_decide, which adds the Lean.ofReduceBool compiler-trust axiom (#print axioms); it verifies the finite fact ({2,3} : Finset).card = 2, not the headline conjecture.",
     "theoremCount": 15,
     "definitionCount": 9
   },

--- a/src/data/proofs/erdos-316/meta.json
+++ b/src/data/proofs/erdos-316/meta.json
@@ -65,7 +65,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 116,
-    "assumptions": "1 axiom: erdos_316_generalized — Sándor's 1997 generalization that for every n ≥ 2, there exists a finite A ⊆ ℕ\\{1} with ∑1/k < n that cannot be n-partitioned with all parts summing to < 1. The n=2 case (erdos_316) is proved computationally; the general case is axiomatized.",
+    "assumptions": "1 axiom: erdos_316_generalized — Sándor's 1997 generalization that for every n ≥ 2, there exists a finite A ⊆ ℕ\\{1} with ∑1/k < n that cannot be n-partitioned with all parts summing to < 1. The n=2 case (erdos_316) is proved computationally; the general case is axiomatized. Trust caveat: theorem minimalCounterexample_sum_lt_two (line 43) is closed by native_decide, which adds the Lean.ofReduceBool compiler-trust axiom (#print axioms); it checks the finite reciprocal-sum inequality < 2 for the minimal counterexample, not the axiomatized general case.",
     "theoremCount": 4,
     "definitionCount": 1
   },

--- a/src/data/proofs/erdos-387/meta.json
+++ b/src/data/proofs/erdos-387/meta.json
@@ -47,7 +47,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 103,
-    "assumptions": "1 axiom: erdos_387_conjecture. See Lean source for the complete statement.",
+    "assumptions": "1 axiom: erdos_387_conjecture. See Lean source for the complete statement. Trust caveat: theorem schinzel_counterexample (line 45) is closed by native_decide, which adds the Lean.ofReduceBool compiler-trust axiom (#print axioms); it verifies Schinzel's finite counterexample (99215-i does not divide C(99215,15) for i < 15), not the open main conjecture.",
     "theoremCount": 2,
     "definitionCount": 0
   },

--- a/src/data/proofs/erdos-393/meta.json
+++ b/src/data/proofs/erdos-393/meta.json
@@ -56,7 +56,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 175,
-    "assumptions": "4 axioms: f_exists, berend_osgood_1992, bpz_2023, luca_2002. 0 sorries.",
+    "assumptions": "4 axioms: f_exists, berend_osgood_1992, bpz_2023, luca_2002. 0 sorries. Trust caveat: theorem example_3_factorial (line 88) is closed by native_decide, which adds the Lean.ofReduceBool compiler-trust axiom (#print axioms); it checks the finite identity 3! = 2·3, not the headline conjecture.",
     "theoremCount": 4,
     "definitionCount": 12
   },

--- a/src/data/proofs/erdos-436/meta.json
+++ b/src/data/proofs/erdos-436/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/436",
     "erdosProblemStatus": "partially-solved",
     "axiomCount": 9,
-    "assumptions": "9 axioms: lambda_2_2, lambda_3_2, lambda_4_2, lambda_5_2, lambda_6_2, lambda_7_2, and 3 more. 0 sorries.",
+    "assumptions": "9 axioms: lambda_2_2, lambda_3_2, lambda_4_2, lambda_5_2, lambda_6_2, lambda_7_2, and 3 more. 0 sorries. Trust caveat: theorem lambda_2_gaps (line 562) is closed by native_decide, which adds the Lean.ofReduceBool compiler-trust axiom (#print axioms); it verifies the finite gap values between the tabulated Λ(k,2) constants, not the headline finiteness/growth claims.",
     "lineCount": 686,
     "mathlib_version": "4.31.0",
     "theoremCount": 49,


### PR DESCRIPTION
## Problem (part of #41407)

Seven **axiomatized** gallery entries close a named theorem with `native_decide`, which trusts the Lean compiler and adds the `Lean.ofReduceBool` axiom (visible via `#print axioms`), yet their `meta.assumptions` did not disclose it.

## Fix (disclose-only)

Per the #41407 convention: these entries are already `status: "axiomatized"` / `badge: "axiom"` with the headline resting on explicit `axiom` declarations, so the native_decide theorems are **finite demonstrations**, not the headline result. Appended a one-line "Trust caveat" to `meta.assumptions` naming the specific theorem, line, and finite fact. **No change** to `axiomCount` / `status` / `badge`.

| slug | native_decide theorem (line) | finite fact |
|------|------------------------------|-------------|
| erdos-436 | `lambda_2_gaps` (562) | gap values between Λ(k,2) constants |
| erdos-393 | `example_3_factorial` (88) | 3! = 2·3 |
| erdos-387 | `schinzel_counterexample` (45) | 99215−i ∤ C(99215,15), i<15 |
| erdos-316 | `minimalCounterexample_sum_lt_two` (43) | reciprocal sum < 2 |
| erdos-269 | `twoThreeSmooth_card` (214) | {2,3}.card = 2 |
| erdos-184 | `key_insight_log_star` (251) | logStar 65536=4, logStar 4=2 |
| erdos-1149 | `countCoprimePairs_one` (196) | countCoprimePairs 1 = 1 |

Evidence: each is `status: axiomatized`, `badge: axiom`, `ofReduceBool` previously absent from assumptions; native_decide confirmed in a NAMED theorem (0 `example`). Surgical 1-line edits (7 files / 1 line each), JSON validated. Deduped by slug vs all open PRs (none touched these).

Part of #41407
