### PR TITLE
Fix: divisibility-by-3-oq-03 clean kernel verification (drop false native_decide claim)

### DIFF
--- a/src/data/proofs/divisibility-by-3-oq-03/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Classical result",
     "sourceUrl": "https://en.wikipedia.org/wiki/Digital_root",
     "date": "Classical",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/DivisibilityBy3OQ03.lean",
     "tags": [
       "number-theory",
@@ -17,10 +17,10 @@
       "algorithms",
       "research"
     ],
-    "badge": "axiom",
+    "badge": "mathlib",
     "sorries": 0,
-    "axiomCount": 1,
-    "assumptions": "0 literal `axiom` declarations and 0 sorries. The load-bearing supporting lemma digitSum_le_self discharges its n<10 base cases with `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms`; per the project's native_decide policy this entry is therefore `axiomatized` with meta.axiomCount 1 (`Lean.ofReduceBool`). The ordinary foundational axioms (propext, Classical.choice, Quot.sound) are not counted. Otherwise uses Mathlib's Nat.sum_digits_lt and digit/modular-arithmetic API.",
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries. Kernel-verified: `#print axioms` lists only the standard foundational axioms (propext, Classical.choice, Quot.sound), which the project does not count. There is no `native_decide`/`Lean.ofReduceBool` dependency — the supporting lemma digitSum_le_self is discharged by Mathlib's `Nat.digit_sum_le`. Core digit-sum and modular-arithmetic facts (`Nat.modEq_nine_digits_sum`, `Nat.digit_sum_le`, `Nat.sub_one_mul_sum_log_div_pow_eq_sub_sum_digits`) come from Mathlib.",
     "lineCount": 273,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Problem

meta.json for `divisibility-by-3-oq-03` claimed a `native_decide` / `Lean.ofReduceBool` trust dependency (`status: axiomatized`, `badge: axiom`, `axiomCount: 1`) that does not exist in the Lean source.

## Evidence

**Lean file** (`proofs/Proofs/DivisibilityBy3OQ03.lean`):
- `grep native_decide` → **none**; no bare `decide` either.
- `digitSum_le_self` (line 35) is proved by `Nat.digit_sum_le 10 n`, NOT `native_decide`.
- 0 sorries, 0 literal `axiom` declarations.
- The `native_decide` claim is stale from a pre-v4.31 version (file was reworked to use Mathlib's digit-sum API).

**Kernel `#print axioms`** (per auditor #41446): only `propext / Classical.choice / Quot.sound` — the standard foundational axioms the project does not count. No `Lean.ofReduceBool`.

## Fix (meta.json only)

- `status`: `axiomatized` → `verified`
- `badge`: `axiom` → `mathlib`
- `axiomCount`: `1` → `0`
- `assumptions`: removed the false `native_decide`/`Lean.ofReduceBool` paragraph; replaced with an accurate kernel-verified description.

Direction note: the old label *understated* trust (the safe direction), but was factually contradicted by `#print axioms`.

Closes #41446
