### PR TITLE
audit: harmonic-divergence-oq-04 clean (reserve re-serve)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -20322,9 +20322,9 @@
       "result": "clean"
     },
     "harmonic-divergence-oq-04": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:42Z",
+      "lastAudited": "2026-07-22T14:03:52Z",
       "result": "clean"
     },
     "harmonic-divergence-oq-05": {


### PR DESCRIPTION
Reserve-mode re-audit of `harmonic-divergence-oq-04` (queue drained).

**Result: clean.** Honest Tier-B Mathlib wrapper.
- badge `mathlib`, status `verified`, 0 axioms / 0 sorries — all confirmed against `Proofs/HarmonicDivergenceOQ04.lean`.
- No `sorry`/`axiom`/`native_decide`/`admit` in source.
- theoremCount 9 matches; originalContributions all exist and honestly labeled ("wrapped Mathlib iff", contrapositive, etc.).
- Core result via `summable_condensed_iff_of_nonneg`; description honestly states it wraps Mathlib.

Minor non-blocking note: section prose calls imports 'minimal footprint' (PSeries + InfiniteSum.Basic) but file uses `import Mathlib`; cosmetic, non-overclaiming — not filed.