### PR TITLE
audit: triangular-reciprocals-oq-01 clean (reserve re-serve)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -26307,9 +26307,9 @@
       "note": "native_decide confined to anonymous example sanity-checks; named theorems axiom-clean (verified global sweep 2026-06-24)"
     },
     "triangular-reciprocals-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:43Z",
+      "lastAudited": "2026-07-22T14:06:56Z",
       "result": "clean"
     },
     "triangular-reciprocals-oq-02": {


### PR DESCRIPTION
Reserve-mode re-audit (queue drained).

**Result: clean.**
- 10 theorems + 3 defs — matches theoremCount:10. 0 axioms, 0 sorries, no native_decide.
- badge `mathlib` appropriate (Mathlib-backed result = square_reciprocals_summable via Real.summable_nat_rpow).
- All 4 originalContributions map to real decls, honestly scoped: description claims convergence of *square* reciprocals only; general k-gonal convergence is prose remark ('implies by comparison'), never claimed formalized. No inequality-as-theorem/pipeline inflation.