### PR TITLE
Fix: eliminate native_decide in erdos-649 (kernel proofs, #41407)

### DIFF
--- a/proofs/Proofs/Erdos649Problem.lean
+++ b/proofs/Proofs/Erdos649Problem.lean
@@ -72,8 +72,9 @@ private lemma gpf_mem_factors' {n : ℕ} (hn : n > 1) :
     List.getLast?_eq_getLast hne
   simp [this]
 
-/-- P(1) = 0 by convention. Proved by computation. -/
-theorem gpf_one : P(1) = 0 := by native_decide
+/-- P(1) = 0 by convention. Proved from Mathlib's `primeFactorsList_one`. -/
+theorem gpf_one : P(1) = 0 := by
+  simp [greatestPrimeFactor, Nat.primeFactorsList_one]
 
 /-- P(m) divides m for m > 1. Proved from Mathlib's primeFactorsList API. -/
 theorem gpf_divides (m : ℕ) (hm : m > 1) : P(m) ∣ m :=
@@ -317,7 +318,7 @@ Since ord_7(2) = 3, which is odd, 2^k ≡ -1 (mod 7) has no solution.
 -/
 theorem odd_order_no_minus_one : ∀ k : ℕ, (2 ^ k : ZMod 7) ≠ -1 := by
   intro k
-  have h6 : (-1 : ZMod 7) = 6 := by native_decide
+  have h6 : (-1 : ZMod 7) = 6 := by decide
   rw [h6]
   exact two_power_mod_seven k
 
@@ -340,7 +341,7 @@ theorem erdos_649 : ¬ErdosConjecture649 := by
   intro hconj
   -- The conjecture claims all (p, q) pairs work
   -- But (2, 7) has no solution
-  have hp7 : Nat.Prime 7 := by native_decide
+  have hp7 : Nat.Prime 7 := by norm_num
   have h27 := hconj 2 7 Nat.prime_two hp7
   obtain ⟨n, hn_pos, hPn, hPn1⟩ := h27
   have hfalse := no_solution_2_7


### PR DESCRIPTION
## Fix: eliminate `native_decide` in erdos-649 (part of #41407)

`Erdos649Problem.lean` used `native_decide` for 3 finite helper facts, each of
which pulls in the `Lean.ofReduceBool` compiler-trust axiom. `meta.assumptions`
lists only the 4 explicit axioms and omits `ofReduceBool`. Rather than disclose
the trust dependency, this eliminates it with kernel-checked proofs so the meta
becomes correct as-is.

### Changes (`proofs/Proofs/Erdos649Problem.lean`)
| Line | Fact | Before | After |
|------|------|--------|-------|
| 76 | `gpf_one : P(1) = 0` | `native_decide` | `simp [greatestPrimeFactor, Nat.primeFactorsList_one]` |
| 320 | `(-1 : ZMod 7) = 6` | `native_decide` | `decide` (small `Fintype`) |
| 343 | `Nat.Prime 7` | `native_decide` | `norm_num` |

These are minor helper facts, not the headline result — `erdos_649` (the
disproof) rests on the 4 explicit `axiom` declarations (`gpf_eq_two_iff`,
`consecutive_gpf_divides`, `tong_theorem`, `mahler_growth`). Eliminating
`native_decide` removes the undisclosed `Lean.ofReduceBool` dependency **without
changing `axiomCount`** (still 4). No meta.json change needed.

### Evidence
- `grep native_decide Erdos649Problem.lean` → none (was 3).
- Host-verified against the repo's pinned Mathlib (`lake env lean`): compiles
  with only pre-existing deprecation warnings (`List.getLast?_eq_getLast`,
  `push_neg`), no errors.

Addresses part of #41407 (erdos-649 was reserved as an elimination candidate,
not a disclose-only entry).
