### PR TITLE
audit: ramseys-theorem-oq-04 clean (reserve re-serve)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24401,9 +24401,9 @@
       "result": "clean"
     },
     "ramseys-theorem-oq-04": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:43Z",
+      "lastAudited": "2026-07-22T14:08:34Z",
       "result": "clean"
     },
     "ramseys-theorem-oq-04-oq-01": {


### PR DESCRIPTION
Reserve-mode re-audit (queue drained).

**Result: clean.** Honest Tier-C axiomatized entry.
- 1 axiom `hypergraph_ramsey_k2` — matches axiomCount:1. Genuine hypergraph Ramsey existence bound (k≥2), hypotheses correct (n≥k), consistent/non-vacuous.
- 0 sorries, no native_decide. 15 theorems + 1 axiom = theoremCount:16.
- Main thm `hypergraph_ramsey_exists`: k=1 genuinely proved via pigeonhole_ramsey (real proof), k≥2 via disclosed axiom.
- autoImplicit-masked free `n` (issue #39077) confirmed fixed — all vars explicitly bound, property non-trivial.
- All 11 originalContributions map to real decls; badge `axiom`/status `axiomatized` correct; disclosure exemplary.