### PR TITLE
research(erdos-751): complete minCycleLengthGap def, eliminate both sorries (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos751Problem.lean
+++ b/proofs/Proofs/Erdos751Problem.lean
@@ -30,6 +30,7 @@ import Mathlib.Combinatorics.SimpleGraph.Coloring.Vertex
 import Mathlib.Combinatorics.SimpleGraph.Girth
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Nat.Basic
+import Mathlib.Data.Nat.Lattice
 
 open SimpleGraph
 
@@ -90,7 +91,16 @@ def cycleLengths (G : SimpleGraph V) [DecidableRel G.Adj] : Set ℕ :=
 Given the cycle lengths, the minimum gap between consecutive lengths.
 -/
 noncomputable def minCycleLengthGap (lengths : Set ℕ) : ℕ :=
-  sorry -- Requires enumeration of consecutive pairs
+  sInf {d : ℕ | ∃ a ∈ lengths, ∃ b ∈ lengths, a < b ∧ d = b - a}
+
+/--
+**Minimum gap upper bound.**
+Any pair of distinct lengths in the set witnesses an upper bound on the minimum
+gap: the closest pair of elements is always a consecutive pair, so the minimum
+difference over all distinct pairs equals the minimum consecutive gap. -/
+theorem minCycleLengthGap_le {S : Set ℕ} {a b : ℕ} (ha : a ∈ S) (hb : b ∈ S)
+    (hab : a < b) : minCycleLengthGap S ≤ b - a :=
+  Nat.sInf_le ⟨a, ha, b, hb, hab, rfl⟩
 
 /-
 ## Part II: Key Relationships
@@ -183,7 +193,11 @@ theorem erdos_751 (G : SimpleGraph V) [DecidableRel G.Adj] :
   obtain ⟨m, m', hm, hm', hne, hgap1, hgap2⟩ := h
   -- The minimum gap is at most |m - m'| ≤ 2
   have hgap_bound : minCycleLengthGap (cycleLengths G) ≤ 2 := by
-    sorry -- Would need the full definition of minCycleLengthGap
+    rcases lt_or_gt_of_ne hne with h | h
+    · calc minCycleLengthGap (cycleLengths G) ≤ m' - m := minCycleLengthGap_le hm hm' h
+        _ ≤ 2 := by omega
+    · calc minCycleLengthGap (cycleLengths G) ≤ m - m' := minCycleLengthGap_le hm' hm h
+        _ ≤ 2 := by omega
   -- But hcontra says gap > 3, contradiction
   have := hcontra 3
   omega

--- a/proofs/Proofs/Erdos751Problem.lean
+++ b/proofs/Proofs/Erdos751Problem.lean
@@ -30,7 +30,7 @@ import Mathlib.Combinatorics.SimpleGraph.Coloring.Vertex
 import Mathlib.Combinatorics.SimpleGraph.Girth
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Nat.Basic
-import Mathlib.Data.Nat.Lattice
+import Mathlib.Order.Lattice.Nat
 
 open SimpleGraph
 

--- a/research/problems/erdos-751-incomplete-01/knowledge.md
+++ b/research/problems/erdos-751-incomplete-01/knowledge.md
@@ -1,0 +1,42 @@
+# erdos-751-incomplete-01 — session notes
+
+## 2026-07-22 (researcher-1) — sorry elimination + integrity finding
+
+**Problem:** Erdős #751 (cycle lengths in 4-chromatic graphs). `Erdos751Problem.lean`
+carried two `sorry`s:
+1. A **def-sorry**: `minCycleLengthGap (lengths : Set ℕ) : ℕ := sorry` (Aristotle skips
+   definition sorries, so it needed a human).
+2. A dependent **theorem-sorry** in `erdos_751`: `minCycleLengthGap (cycleLengths G) ≤ 2`.
+
+**Work done (0 new axioms, host-verified `lake env lean` v4.31, EXIT=0):**
+- Gave `minCycleLengthGap` a faithful total definition:
+  `sInf {d | ∃ a ∈ S, ∃ b ∈ S, a < b ∧ d = b - a}` — the minimum difference between
+  distinct elements, which equals the minimum *consecutive* gap (the closest pair is
+  always consecutive). Empty/singleton sets give `sInf ∅ = 0`.
+- Added foundational lemma `minCycleLengthGap_le : a ∈ S → b ∈ S → a < b →
+  minCycleLengthGap S ≤ b - a` via `Nat.sInf_le`.
+- Discharged the `hgap_bound` sorry: from two distinct close cycle lengths
+  `m, m'` with `|m − m'| ≤ 2`, `minCycleLengthGap_le` + `omega` give `≤ 2`.
+- Added `import Mathlib.Order.Lattice.Nat` (for `Nat.sInf`/`Nat.sInf_le`).
+
+Both file sorries are now gone; gallery meta updated (`sorries` 2→0, `theoremCount`
+6→7, `lineCount`, imports, `status` → `axiomatized`, `badge` → `axiom`).
+
+## Integrity finding (for auditor / mechanic)
+
+The pre-existing axiom
+`four_chromatic_minDeg (G) : chromaticNumber G = 4 → minDegree G ≥ 3`
+is **FALSE as literally stated**. Counterexample: take `K₄` and attach a pendant
+vertex (degree 1) to one of its vertices. The graph is still 4-chromatic (contains
+`K₄`) but its minimum degree is 1, not ≥ 3. The correct classical fact is that a
+4-chromatic graph has a *subgraph* (its 3-core / degeneracy witness) of minimum
+degree ≥ 3 — a global min-degree bound does not hold. The headline `erdos_751`
+theorem is nonetheless **true**, but it is currently derived through this unsound
+axiom. A faithful restatement would either (a) weaken the axiom to
+`∃ H ≤ G, minDegree H ≥ 3` and feed Bondy–Vince on `H`, or (b) route through the
+degeneracy/3-core, neither of which has ready Mathlib API.
+
+## Open (blocked)
+
+- `bondy_vince_theorem` (δ ≥ 3 ⇒ two cycle lengths differ by ≤ 2) — deep 1998
+  result, no Mathlib cycle-length-spectrum API. Left as an axiom.

--- a/src/data/proofs/erdos-751/meta.json
+++ b/src/data/proofs/erdos-751/meta.json
@@ -134,19 +134,22 @@
     "imports": [
       "Mathlib.Combinatorics.SimpleGraph.Basic",
       "Mathlib.Combinatorics.SimpleGraph.Connectivity.WalkCounting",
+      "Mathlib.Combinatorics.SimpleGraph.Coloring.Vertex",
+      "Mathlib.Combinatorics.SimpleGraph.Girth",
       "Mathlib.Data.Finset.Basic",
-      "Mathlib.Data.Nat.Basic"
+      "Mathlib.Data.Nat.Basic",
+      "Mathlib.Order.Lattice.Nat"
     ],
     "opens": [
       "SimpleGraph"
     ],
     "namespace": "Erdos751",
-    "lineCount": 235,
+    "lineCount": 257,
     "axiomCount": 2,
-    "theoremCount": 6,
+    "theoremCount": 7,
     "definitionCount": 3,
     "path": "Proofs/Erdos751Problem.lean",
-    "sorries": 2
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -165,5 +168,7 @@
       "description": "Related Erdős problem sharing themes: chromatic-number, cycles, graph-theory"
     }
   ],
-  "sorries": 2
+  "sorries": 0,
+  "status": "axiomatized",
+  "badge": "axiom"
 }

--- a/src/data/research/problems/erdos-751-incomplete-01.json
+++ b/src/data/research/problems/erdos-751-incomplete-01.json
@@ -16,11 +16,17 @@
     "goal": "Eliminate the 2 remaining sorry statement(s) in the parent formalization."
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-07-09T00:00:00.000Z",
     "iteration": 0,
     "focus": "Initial exploration of the problem.",
-    "blockers": [],
+    "blockers": [
+      {
+        "route": "eliminate axiom bondy_vince_theorem (delta>=3 => two cycle lengths differ by <=2)",
+        "reopenCriterion": "materially new mechanism required: deep 1998 result, no Mathlib API for cycle-length spectra",
+        "blockedAt": "2026-07-22"
+      }
+    ],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
       "total": 0,
@@ -29,12 +35,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AXIOM ELIMINATION (researcher-1, 2026-07-20): replaced 3 definition-axioms (chromaticNumber, girth, cycleLengths) with real Mathlib-backed definitions, axiom count 5→2. Remaining 2 axioms are deep: four_chromatic_minDeg and bondy_vince_theorem (Bondy–Vince 1998). 2 sorries remain (minCycleLengthGap def + its bound).",
+    "progressSummary": "PROGRESS: eliminated both sorries in Erdos751Problem.lean by giving minCycleLengthGap a faithful sInf definition and proving the gap<=2 bound (Nat.sInf_le), 0 new axioms, host-verified. Flagged that the pre-existing axiom four_chromatic_minDeg is false as stated (pendant-vertex counterexample) for auditor/mechanic follow-up.",
     "builtItems": [
-      "Erdos751Problem.lean: replaced 3 def-axioms (chromaticNumber, girth, cycleLengths) with Mathlib-backed real definitions; axiom 5→2. Host-verified v4.31.0 EXIT=0."
+      "Erdos751Problem.lean: replaced 3 def-axioms (chromaticNumber, girth, cycleLengths) with Mathlib-backed real definitions; axiom 5→2. Host-verified v4.31.0 EXIT=0.",
+      "minCycleLengthGap (Erdos751Problem.lean): faithful total def as sInf of pairwise differences {b-a | a<b, a,b in set} = minimum consecutive gap; replaces def-sorry",
+      "minCycleLengthGap_le (Erdos751Problem.lean): closest-pair upper bound via Nat.sInf_le; 0-axiom",
+      "erdos_751 hgap_bound sorry discharged: minCycleLengthGap (cycleLengths G) <= 2 from two close cycle lengths"
     ],
     "insights": [
-      "The chromaticNumber/girth/cycleLengths in Erdos751Problem.lean were DEFINITION axioms (opaque functions) that Mathlib actually provides: SimpleGraph.chromaticNumber (ℕ∞, use .toNat), SimpleGraph.girth (ℕ, via egirth.toNat), and cycleLengths as {n | ∃ v (c:G.Walk v v), c.IsCycle ∧ c.length=n}. All downstream usage is abstract (passed to the remaining axioms), so replacing the axioms with real defs compiles cleanly."
+      "The chromaticNumber/girth/cycleLengths in Erdos751Problem.lean were DEFINITION axioms (opaque functions) that Mathlib actually provides: SimpleGraph.chromaticNumber (ℕ∞, use .toNat), SimpleGraph.girth (ℕ, via egirth.toNat), and cycleLengths as {n | ∃ v (c:G.Walk v v), c.IsCycle ∧ c.length=n}. All downstream usage is abstract (passed to the remaining axioms), so replacing the axioms with real defs compiles cleanly.",
+      "Both file sorries eliminated (def-sorry + dependent theorem sorry), 0 new axioms. Host-verified lake env lean v4.31 EXIT=0.",
+      "INTEGRITY FINDING (for auditor/mechanic): axiom four_chromatic_minDeg : chromaticNumber G = 4 -> minDegree G >= 3 is FALSE as literally stated. Counterexample: K4 plus a pendant vertex is 4-chromatic but has minDegree 1. The correct classical fact is that a 4-chromatic graph has a SUBGRAPH (3-core) of min degree >= 3; the final erdos_751 theorem is true but is derived through this unsound global axiom."
     ],
     "mathlibGaps": [],
     "nextSteps": []


### PR DESCRIPTION
## Erdős #751 — complete `minCycleLengthGap`, eliminate both sorries

`proofs/Proofs/Erdos751Problem.lean` carried two `sorry`s. This PR removes both,
**axiom-free** (0 new axioms), host-verified with `lake env lean` (v4.31, exit 0).

### Changes
- **`minCycleLengthGap`** (was a `def`-sorry — Aristotle skips definition sorries)
  is given a faithful total definition:
  `sInf {d | ∃ a ∈ S, ∃ b ∈ S, a < b ∧ d = b − a}`.
  The minimum difference over distinct elements equals the minimum *consecutive*
  gap, since the closest pair is always consecutive. Empty/singleton sets give `0`.
- New foundational lemma **`minCycleLengthGap_le`** (`Nat.sInf_le`): any pair
  `a < b` in the set bounds the minimum gap by `b − a`.
- The dependent **`hgap_bound` sorry** inside `erdos_751` is discharged: two distinct
  cycle lengths within `2` of each other give `minCycleLengthGap (cycleLengths G) ≤ 2`.
- Added `import Mathlib.Order.Lattice.Nat`; synced gallery `meta.json`
  (`sorries` 2→0, `theoremCount` 6→7, `lineCount`, `status`→`axiomatized`,
  `badge`→`axiom`) and the research tracker + knowledge note.

### Integrity finding (for auditor / mechanic — not fixed here)
The pre-existing axiom `four_chromatic_minDeg : chromaticNumber G = 4 → minDegree G ≥ 3`
is **false as literally stated**: `K₄` with a pendant vertex is 4-chromatic yet has
minimum degree 1. The correct fact is that a 4-chromatic graph has a *subgraph*
(3-core) of min degree ≥ 3. The headline theorem is still true but is routed through
this unsound global axiom. Documented in the tracker/knowledge for follow-up; a proper
fix needs degeneracy/3-core API absent from Mathlib.

Remaining axioms (`bondy_vince_theorem`, `four_chromatic_minDeg`) are unchanged and
recorded as blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
