### PR TITLE
Fix: eliminate native_decide in Erdos939Problem via kernel proofs

### DIFF
--- a/proofs/Proofs/Erdos939Problem.lean
+++ b/proofs/Proofs/Erdos939Problem.lean
@@ -180,13 +180,13 @@ theorem lander_parkin_counterexample : ¬EulerConjecture := by
   · norm_num
   use {27, 84, 110, 133}
   constructor
-  · native_decide
+  · decide
   use 144
-  native_decide
+  decide
 
 /-- Direct verification of the Lander-Parkin identity -/
 theorem lander_parkin_identity :
-    27^5 + 84^5 + 110^5 + 133^5 = 144^5 := by native_decide
+    27^5 + 84^5 + 110^5 + 133^5 = 144^5 := by norm_num
 
 /-
 ## Connection to r-Powerful Numbers


### PR DESCRIPTION
## Problem

`proofs/Proofs/Erdos939Problem.lean` closed three named theorems with `native_decide`, which trusts the Lean compiler's kernel reduction and adds `Lean.ofReduceBool` to `#print axioms`. The entry's `meta.assumptions` did not disclose this trust dependency (it only lists the `cambie_r5_example` axiom). Per issue #41407 this is an integrity gap.

Since all three facts are trivially kernel-provable, the preferred fix is **elimination** (convert to kernel tactics) rather than disclosure — this genuinely drops the `Lean.ofReduceBool` dependency.

## Fix (Lean source only)

- `lander_parkin_counterexample`: Finset `card` goal + Finset `sum` goal → `decide` (kernel)
- `lander_parkin_identity` (`27^5 + 84^5 + 110^5 + 133^5 = 144^5`): pure `Nat` arithmetic → `norm_num` (kernel)

`grep native_decide` → **none** remaining.

## Validation

- `./proofs/scripts/docker-build.sh Proofs.Erdos939Problem` → **Build succeeded** (8576 jobs). Only warning is a pre-existing `push_neg` deprecation, untouched by this change.

No `meta.json` change needed: the meta never claimed `Lean.ofReduceBool`, and `axiomCount`/`status`/`badge` are unaffected (the headline still rests on the `cambie_r5_example` axiom).

Refs #41407
