### PR TITLE
Fix: eliminate native_decide in erdos-939 (kernel proofs, #41407)

### DIFF
--- a/proofs/Proofs/Erdos649Problem.lean
+++ b/proofs/Proofs/Erdos649Problem.lean
@@ -73,7 +73,7 @@ private lemma gpf_mem_factors' {n : ℕ} (hn : n > 1) :
   simp [this]
 
 /-- P(1) = 0 by convention. Proved by computation. -/
-theorem gpf_one : P(1) = 0 := by native_decide
+theorem gpf_one : P(1) = 0 := by simp [greatestPrimeFactor]
 
 /-- P(m) divides m for m > 1. Proved from Mathlib's primeFactorsList API. -/
 theorem gpf_divides (m : ℕ) (hm : m > 1) : P(m) ∣ m :=
@@ -317,7 +317,7 @@ Since ord_7(2) = 3, which is odd, 2^k ≡ -1 (mod 7) has no solution.
 -/
 theorem odd_order_no_minus_one : ∀ k : ℕ, (2 ^ k : ZMod 7) ≠ -1 := by
   intro k
-  have h6 : (-1 : ZMod 7) = 6 := by native_decide
+  have h6 : (-1 : ZMod 7) = 6 := by decide
   rw [h6]
   exact two_power_mod_seven k
 
@@ -340,7 +340,7 @@ theorem erdos_649 : ¬ErdosConjecture649 := by
   intro hconj
   -- The conjecture claims all (p, q) pairs work
   -- But (2, 7) has no solution
-  have hp7 : Nat.Prime 7 := by native_decide
+  have hp7 : Nat.Prime 7 := by norm_num
   have h27 := hconj 2 7 Nat.prime_two hp7
   obtain ⟨n, hn_pos, hPn, hPn1⟩ := h27
   have hfalse := no_solution_2_7

--- a/proofs/Proofs/Erdos649Problem.lean
+++ b/proofs/Proofs/Erdos649Problem.lean
@@ -73,7 +73,7 @@ private lemma gpf_mem_factors' {n : ℕ} (hn : n > 1) :
   simp [this]
 
 /-- P(1) = 0 by convention. Proved by computation. -/
-theorem gpf_one : P(1) = 0 := by simp [greatestPrimeFactor]
+theorem gpf_one : P(1) = 0 := by native_decide
 
 /-- P(m) divides m for m > 1. Proved from Mathlib's primeFactorsList API. -/
 theorem gpf_divides (m : ℕ) (hm : m > 1) : P(m) ∣ m :=
@@ -317,7 +317,7 @@ Since ord_7(2) = 3, which is odd, 2^k ≡ -1 (mod 7) has no solution.
 -/
 theorem odd_order_no_minus_one : ∀ k : ℕ, (2 ^ k : ZMod 7) ≠ -1 := by
   intro k
-  have h6 : (-1 : ZMod 7) = 6 := by decide
+  have h6 : (-1 : ZMod 7) = 6 := by native_decide
   rw [h6]
   exact two_power_mod_seven k
 
@@ -340,7 +340,7 @@ theorem erdos_649 : ¬ErdosConjecture649 := by
   intro hconj
   -- The conjecture claims all (p, q) pairs work
   -- But (2, 7) has no solution
-  have hp7 : Nat.Prime 7 := by norm_num
+  have hp7 : Nat.Prime 7 := by native_decide
   have h27 := hconj 2 7 Nat.prime_two hp7
   obtain ⟨n, hn_pos, hPn, hPn1⟩ := h27
   have hfalse := no_solution_2_7

--- a/proofs/Proofs/Erdos939Problem.lean
+++ b/proofs/Proofs/Erdos939Problem.lean
@@ -180,13 +180,13 @@ theorem lander_parkin_counterexample : ¬EulerConjecture := by
   · norm_num
   use {27, 84, 110, 133}
   constructor
-  · native_decide
+  · decide
   use 144
-  native_decide
+  norm_num [Finset.sum_insert, Finset.mem_insert, Finset.mem_singleton, Finset.sum_singleton]
 
 /-- Direct verification of the Lander-Parkin identity -/
 theorem lander_parkin_identity :
-    27^5 + 84^5 + 110^5 + 133^5 = 144^5 := by native_decide
+    27^5 + 84^5 + 110^5 + 133^5 = 144^5 := by norm_num
 
 /-
 ## Connection to r-Powerful Numbers


### PR DESCRIPTION
## Summary

Part of #41407 (axiomatized entries whose `native_decide` calls silently pull in
`Lean.ofReduceBool` without disclosure). Instead of merely disclosing, this
**eliminates** the `native_decide` in `erdos-939` by replacing it with
kernel-checked tactics — removing the `ofReduceBool` dependency entirely.

## Changes (`proofs/Proofs/Erdos939Problem.lean`)

- `lander_parkin_counterexample`: Finset card check `native_decide → decide`;
  the `∑ s ∈ {27,84,110,133}, s^5 = 144^5` step
  `native_decide → norm_num [Finset.sum_insert, Finset.mem_insert, Finset.mem_singleton, Finset.sum_singleton]`
- `lander_parkin_identity` (`27^5+84^5+110^5+133^5 = 144^5`): `native_decide → norm_num`

The entry stays `axiomatized` on its genuine `axiom cambie_r5_example` (the r=5
existence example); this change only removes the trivial finite-computation
`native_decide` calls, so no `meta.json` change is needed (axiomCount stays 1).

## Evidence

- `./proofs/scripts/docker-build.sh Proofs.Erdos939Problem` → **Build succeeded** (only pre-existing `push_neg` deprecation warning).
- `grep -c native_decide Erdos939Problem.lean` → **0**.

## Scope note

The sibling `erdos-649` elimination (same issue) is handled by the concurrently-opened
PR #41456; this PR was narrowed to erdos-939 to avoid a duplicate.

Part of #41407
