### PR TITLE
Fix: eliminate native_decide in erdos-939 (kernel proofs, #41407)

### DIFF
--- a/proofs/Proofs/Erdos939Problem.lean
+++ b/proofs/Proofs/Erdos939Problem.lean
@@ -180,13 +180,15 @@ theorem lander_parkin_counterexample : ¬EulerConjecture := by
   · norm_num
   use {27, 84, 110, 133}
   constructor
-  · native_decide
+  · decide
   use 144
-  native_decide
+  rw [Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+    Finset.sum_insert (by decide), Finset.sum_singleton]
+  norm_num
 
 /-- Direct verification of the Lander-Parkin identity -/
 theorem lander_parkin_identity :
-    27^5 + 84^5 + 110^5 + 133^5 = 144^5 := by native_decide
+    27^5 + 84^5 + 110^5 + 133^5 = 144^5 := by norm_num
 
 /-
 ## Connection to r-Powerful Numbers


### PR DESCRIPTION
## Fix: eliminate `native_decide` in erdos-939 (part of #41407)

`Erdos939Problem.lean` used `native_decide` for 3 finite verifications of the
Lander-Parkin counterexample (27^5+84^5+110^5+133^5 = 144^5). Each pulls in the
`Lean.ofReduceBool` compiler-trust axiom, which `meta.assumptions` omits (it
lists only the `cambie_r5_example` axiom). This eliminates the trust dependency
with kernel-checked proofs so the meta becomes correct as-is.

### Changes (`proofs/Proofs/Erdos939Problem.lean`)
| Line | Goal | Before | After |
|------|------|--------|-------|
| 183 | `{27,84,110,133}.card = 4` | `native_decide` | `decide` |
| 185 | `∑ s ∈ {27,84,110,133}, s^5 = 144^5` | `native_decide` | `Finset.sum_insert` expansion + `norm_num` |
| 189 | `27^5+84^5+110^5+133^5 = 144^5` | `native_decide` | `norm_num` |

These are finite verifications of the counterexample, not the headline result —
erdos-939 rests on the `cambie_r5_example` axiom. Eliminating `native_decide`
removes the undisclosed `Lean.ofReduceBool` dependency **without changing
`axiomCount`** (still 1). No meta.json change needed.

### Evidence
- `grep native_decide Erdos939Problem.lean` → none (was 3).
- Host-verified against the repo's pinned Mathlib (`lake env lean`): compiles
  with only a pre-existing `push_neg` deprecation warning, no errors.

Addresses part of #41407 (erdos-939 was reserved as an elimination candidate,
not a disclose-only entry).
