### PR TITLE
Gallery integrity: ptolemys-complex-proof overstates theorem count (phantom Complex.abs form)

### DIFF
--- a/proofs/Proofs/PtolemysComplexProof.lean
+++ b/proofs/Proofs/PtolemysComplexProof.lean
@@ -23,14 +23,13 @@ inequality is fundamentally about the multiplicative structure of ℂ and the tr
 
 ## Status
 - [x] Algebraic identity (over CommRing)
-- [x] Ptolemy's inequality (norm, abs, and dist forms)
+- [x] Ptolemy's inequality (norm and dist forms)
 - [x] Equality characterization (sufficient condition via proportionality)
 - [x] Complete — 0 sorries, 0 axioms
 
 ## Mathlib Dependencies
 - `norm_mul` : Multiplicativity of norm in normed fields
 - `norm_add_le` : Triangle inequality for norms
-- `Complex.norm_eq_abs` : Connection between ‖·‖ and Complex.abs
 - `dist_eq_norm` : Connection between dist and ‖·‖
 -/
 

--- a/src/data/proofs/ptolemys-complex-proof/meta.json
+++ b/src/data/proofs/ptolemys-complex-proof/meta.json
@@ -33,7 +33,7 @@
     "originalContributions": [
       "Complete complex-number proof of Ptolemy's inequality from the algebraic identity",
       "Generalization of the algebraic identity to arbitrary commutative rings",
-      "Three equivalent formulations: norm, Complex.abs, and metric distance",
+      "Two equivalent formulations: norm and metric distance",
       "Equality characterization: Ptolemy's equality holds when opposite-side products are positively proportional"
     ],
     "dateAdded": "2026-03-30",
@@ -92,8 +92,8 @@
       "title": "Alternative Formulations",
       "startLine": 82,
       "endLine": 101,
-      "summary": "Two equivalent formulations: using Complex.abs (via Complex.norm_eq_abs) and using dist (via dist_eq_norm).",
-      "mathContext": "Complex.abs and ‖·‖ agree on ℂ. The dist formulation dist(z₁,z₃)·dist(z₂,z₄) ≤ dist(z₁,z₂)·dist(z₃,z₄) + dist(z₂,z₃)·dist(z₁,z₄) connects directly to the classical geometric statement."
+      "summary": "One alternative formulation: using dist (via dist_eq_norm).",
+      "mathContext": "The dist formulation dist(z₁,z₃)·dist(z₂,z₄) ≤ dist(z₁,z₂)·dist(z₃,z₄) + dist(z₂,z₃)·dist(z₁,z₄) connects directly to the classical geometric statement."
     },
     {
       "id": "equality-characterization",
@@ -116,8 +116,8 @@
       "title": "Exported Theorems",
       "startLine": 145,
       "endLine": 145,
-      "summary": "#check verification of all six exported theorems.",
-      "mathContext": "Six theorems: ptolemy_algebraic_identity (CommRing), ptolemy_complex_identity (ℂ), ptolemy_inequality (norm), ptolemy_inequality_abs (Complex.abs), ptolemy_inequality_dist (dist), ptolemy_equality_of_proportional (equality characterization)."
+      "summary": "#check verification of all five exported theorems.",
+      "mathContext": "Five theorems: ptolemy_algebraic_identity (CommRing), ptolemy_complex_identity (ℂ), ptolemy_inequality (norm), ptolemy_inequality_dist (dist), ptolemy_equality_of_proportional (equality characterization)."
     }
   ],
   "crossReferences": [
@@ -158,7 +158,7 @@
     }
   ],
   "conclusion": {
-    "summary": "A complete complex-number proof of Ptolemy's inequality with equality characterization. Starting from a purely algebraic identity over any commutative ring, the inequality follows from multiplicativity of norm and the triangle inequality. The equality condition (when opposite-side products are positively proportional) is also proved. Six theorems, 0 sorries, 0 axioms.",
+    "summary": "A complete complex-number proof of Ptolemy's inequality with equality characterization. Starting from a purely algebraic identity over any commutative ring, the inequality follows from multiplicativity of norm and the triangle inequality. The equality condition (when opposite-side products are positively proportional) is also proved. Five theorems, 0 sorries, 0 axioms.",
     "implications": "**Theoretical Significance**: The complex-number proof reveals the algebraic essence of Ptolemy's theorem. While the geometric proof works with cospherical points and angle conditions, the algebraic proof needs only a commutative ring and a norm satisfying the triangle inequality. This explains why Ptolemy-type results appear in many settings beyond Euclidean geometry.\n\nThe inequality form is strictly more general than the equality: it holds for all four-point configurations in ℂ, with the geometric condition (concyclicity) characterizing when equality holds.",
     "openQuestions": [
       "Can the converse direction be proved: if Ptolemy's equality holds, are the opposite-side products necessarily positively proportional (equivalently, are the points concyclic)?",


### PR DESCRIPTION
## Integrity Issue

**Proof**: ptolemys-complex-proof
**Problem**: meta narrative claims **six theorems** and **three equivalent formulations (norm, Complex.abs, metric distance)**, naming a `ptolemy_inequality_abs` (Complex.abs) theorem that does not exist in the source.

## Evidence

**meta.json claimed**:
- originalContributions: "Three equivalent formulations: norm, Complex.abs, and metric distance"
- exports section: "all six exported theorems" / "Six theorems: ... ptolemy_inequality_abs (Complex.abs) ..."
- alternative-forms section: "Two equivalent formulations: using Complex.abs ... and using dist"
- conclusion.summary: "Six theorems, 0 sorries, 0 axioms."

**Lean file shows** (`proofs/Proofs/PtolemysComplexProof.lean`): exactly **five** theorems —
`ptolemy_algebraic_identity`, `ptolemy_complex_identity`, `ptolemy_inequality`, `ptolemy_inequality_dist`, `ptolemy_equality_of_proportional`. No `ptolemy_inequality_abs`; `Complex.norm_eq_abs` is never used (only `Real.norm_eq_abs`). Numeric `theoremCount` fields were already honest (5) — only the prose had drifted.

## Fix applied

- meta.json: "six theorems"→five, "three formulations"→two, dropped all `Complex.abs`/`ptolemy_inequality_abs` references.
- .lean docstring (comment-only, no build impact): removed the "abs form" checklist item and the unused `Complex.norm_eq_abs` dependency line.

The five real theorems remain correctly proved; badge (`original`), status (`verified`), sorries (0), axiomCount (0) are all accurate. Low severity — narrative inflation only, no proof-strength overclaim.

---
Discovered during gallery integrity audit.