### PR TITLE
Fix: correct stale native_decide parenthetical in divisibility-by-3-oq-03 summary

### DIFF
--- a/src/data/proofs/divisibility-by-3-oq-03/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-03/meta.json
@@ -104,7 +104,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The digital root is fully formalized in Lean 4 with 21 theorems, 0 axiom declarations (native_decide relies on Lean.ofReduceBool), and 0 sorries. The closed-form O(1) formula, idempotency, divisibility characterizations by 3 and 9, and the additive/multiplicative homomorphism properties are all proved. The `Nat.modEq_nine_digits_sum` Mathlib lemma provides the foundational congruence.",
+    "summary": "The digital root is fully formalized in Lean 4 with 21 theorems, 0 axiom declarations, and 0 sorries (kernel-verified: no native_decide/Lean.ofReduceBool dependency). The closed-form O(1) formula, idempotency, divisibility characterizations by 3 and 9, and the additive/multiplicative homomorphism properties are all proved. The `Nat.modEq_nine_digits_sum` Mathlib lemma provides the foundational congruence.",
     "implications": "The multiplicative homomorphism `dr(a·b) = dr(dr(a)·dr(b))` is the formal basis of 'casting out nines': to check if a multiplication $a \\times b = c$ is correct, compute $dr(a) \\times dr(b)$ and compare to $dr(c)$ — any discrepancy reveals an error. This was a standard pre-calculator arithmetic check for centuries. The formalization provides a verified foundation for understanding why this works (the mod 9 ring structure) and its limitations (it cannot detect errors that preserve the mod 9 value, e.g., transposing digits that sum to the same value).",
     "openQuestions": [
       "Can the proof be extended to show that digitalRoot is a ring homomorphism from ℤ/9ℤ to {1,...,9}? The additive and multiplicative homomorphism properties are proved, but the formal ring homomorphism statement would require setting up the appropriate ring structure on the 9-element set.",


### PR DESCRIPTION
## Follow-up to #41451 (integrity issue #41446)

The core integrity fix for `divisibility-by-3-oq-03` — `status: verified`,
`badge: mathlib`, `axiomCount: 0`, corrected `assumptions` — landed via #41451
(merged). But the `conclusion.summary` field retained a stale, self-contradictory
parenthetical:

**Before:**
> "...21 theorems, 0 axiom declarations **(native_decide relies on Lean.ofReduceBool)**, and 0 sorries."

**After:**
> "...21 theorems, 0 axiom declarations, and 0 sorries **(kernel-verified: no native_decide/Lean.ofReduceBool dependency)**."

### Evidence
- `grep -c native_decide proofs/Proofs/DivisibilityBy3OQ03.lean` → **0**
- main's `meta.assumptions` already states: *"no `native_decide`/`Lean.ofReduceBool` dependency"*
- The old parenthetical directly contradicted the merged `verified`/`0-axiom` status and would be re-flagged on the next audit re-serve.

Metadata-only, minimal diff. JSON validated. Closes #41446.
