### PR TITLE
Audit tracker: erdos-751 issues-found (#41466)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16114,9 +16114,9 @@
     },
     "erdos-751": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-24T23:17:45Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-22T14:19:11Z",
+      "result": "issues-found"
     },
     "erdos-752": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Marks erdos-751 as issues-found. Integrity issue #41466: axiom `four_chromatic_minDeg` is false against the upgraded real Mathlib definitions (χ=4 does not force global minDegree≥3; K₄⊕isolated vertex counterexample). Also notes stale `sorries:2` (actual 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)