### PR TITLE
Fix: disclose native_decide (Lean.ofReduceBool) in bounded-prime-gaps-oq-01-oq-02

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "lineCount": 219,
     "theoremCount": 25,
     "definitionCount": 3,
-    "assumptions": "1 axiom: maynard_tao_sieve_eh — the EH-conditional Maynard-Tao sieve result: for any admissible 5-tuple H with all elements ≤ D, infinitely many prime gaps ≤ D exist. This axiom encodes the Elliott-Halberstam conjecture (distribution of primes in APs up to modulus x^{1/2}) combined with the Maynard-Tao sieve framework.",
+    "assumptions": "1 axiom: maynard_tao_sieve_eh — the EH-conditional Maynard-Tao sieve result: for any admissible 5-tuple H with all elements ≤ D, infinitely many prime gaps ≤ D exist. This axiom encodes the Elliott-Halberstam conjecture (distribution of primes in APs up to modulus x^{1/2}) combined with the Maynard-Tao sieve framework. 0 sorries. Trust caveat: the finite admissible-tuple facts (quintuple_card, quintuple_le_12, two_optimal_5_tuples, and the two `native_decide` sub-checks inside eh_conditional_h_le_12) are closed by `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom (visible in `#print axioms`). These are finite verifications of specific 5-tuples, not the headline EH-conditional gap bound, which rests on the stated axiom maynard_tao_sieve_eh.",
     "mathlibDependencies": [
       {
         "theorem": "Nat.nth",


### PR DESCRIPTION
## Problem

Straggler from the #41407 disclosure vein ("91 axiomatized entries omit native_decide (Lean.ofReduceBool)"). The sibling entries in this cluster (`bounded-prime-gaps-oq-03`, `-oq-04`) received the Trust caveat in earlier batches, but `bounded-prime-gaps-oq-01-oq-02` was missed — its `assumptions` field still omitted `Lean.ofReduceBool` even though the source closes four named theorems with `native_decide`:

- `quintuple_card` (line 39)
- `quintuple_le_12` (line 42)
- `eh_conditional_h_le_12` — two `native_decide` sub-checks (lines 53–54)
- `two_optimal_5_tuples` (line 162)

## Fix

Prose-only: append the standard Trust caveat to `meta.assumptions`, mirroring the merged sibling `bounded-prime-gaps-oq-03`. Discloses that `native_decide` adds `Lean.ofReduceBool`, noting these are finite 5-tuple verifications, not the headline EH-conditional gap bound (which rests on the stated axiom `maynard_tao_sieve_eh`).

## Not changed (already correct per #41407 policy)

- `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 1` — unchanged; the entry was already axiomatized via `maynard_tao_sieve_eh`. Per the #41407 policy this is a disclose-only fix, no count/status bump.

## Evidence

```
$ grep -n native_decide proofs/Proofs/BoundedPrimeGapsOQ01OQ02.lean   # 39,42,53,54,162
$ git show origin/main:src/data/proofs/bounded-prime-gaps-oq-01-oq-02/meta.json | grep -c ofReduceBool   # 0 (before)
```
