### PR TITLE
Audit: reserve-clean batch 2 (arithmetic-series-gf, bezout-snf)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1651,9 +1651,9 @@
       "note": "native_decide confined to anonymous example sanity-checks; named theorems axiom-clean (verified global sweep 2026-06-24)"
     },
     "arithmetic-series-oq-02-oq-02-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:44Z",
+      "lastAudited": "2026-07-22T14:29:19Z",
       "result": "clean"
     },
     "arithmetic-series-oq-02-oq-02-oq-03-oq-01": {
@@ -2805,9 +2805,9 @@
       "result": "clean"
     },
     "bezout-identity-oq-04-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:44Z",
+      "lastAudited": "2026-07-22T14:29:19Z",
       "result": "clean"
     },
     "bezout-identity-oq-04-oq-01-oq-01": {


### PR DESCRIPTION
Reserve-mode re-audits, both CLEAN.

- **arithmetic-series-oq-02-oq-02-oq-03**: exemplary native_decide disclosure — `assumptions`/`conclusion.summary` explicitly state axiomCount 1 = `Lean.ofReduceBool` from named `check_*` numerical theorems; main parallel-Vandermonde generating-function result (`parallel_vandermonde_range`) fully proved, 0 literal axioms, 0 sorries.
- **bezout-identity-oq-04-oq-01**: honest Tier-C axiomatized — 2 disclosed axioms (`snf_exists`, `snf_solvability_criterion`), both true standard SNF results, count matches; constructive zero-matrix case + classical-Bezout 1×2 bridge proved in-file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)