### PR TITLE
Audit: reserve-clean batch 3 (7 entries)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2829,15 +2829,15 @@
       "result": "clean"
     },
     "binary-gcd": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:44Z",
+      "lastAudited": "2026-07-22T14:32:32Z",
       "result": "clean"
     },
     "binary-gcd-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:44Z",
+      "lastAudited": "2026-07-22T14:32:32Z",
       "result": "clean"
     },
     "binary-gcd-oq-01-oq-01": {
@@ -3028,9 +3028,9 @@
       "result": "clean"
     },
     "binomial-theorem-oq-02-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:44Z",
+      "lastAudited": "2026-07-22T14:32:32Z",
       "result": "clean"
     },
     "binomial-theorem-oq-02-oq-02-oq-01": {
@@ -3281,9 +3281,9 @@
       "result": "clean"
     },
     "birthday-problem-oq-03-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:44Z",
+      "lastAudited": "2026-07-22T14:32:32Z",
       "result": "clean"
     },
     "birthday-problem-oq-03-oq-01-oq-01": {
@@ -3740,9 +3740,9 @@
       "result": "clean"
     },
     "brouwer-fixed-point-oq-04-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:44Z",
+      "lastAudited": "2026-07-22T14:32:32Z",
       "result": "clean"
     },
     "brouwer-fixed-point-oq-04-oq-03-oq-01": {
@@ -4136,9 +4136,9 @@
       "result": "clean"
     },
     "cantor-diagonalization-oq-03-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:44Z",
+      "lastAudited": "2026-07-22T14:32:33Z",
       "result": "clean"
     },
     "cantor-diagonalization-oq-03-oq-01-incomplete-01": {
@@ -20564,9 +20564,9 @@
       "result": "clean"
     },
     "hilbert-14-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:44Z",
+      "lastAudited": "2026-07-22T14:32:33Z",
       "result": "clean"
     },
     "hilbert-14-oq-02": {


### PR DESCRIPTION
Reserve-mode re-audits of the oldest 2026-05-04 entries — all 7 CLEAN. Highlights:

- **binary-gcd-oq-01**: exemplary `Lean.ofReduceBool` disclosure (native_decide step-count examples; symbolic Lamé bound proved).
- **brouwer-fixed-point-oq-04-oq-03**: honest Tier-C — 2 axioms (Kakutani finite-dim, Fan-Glicksberg) correctly stated with full hypotheses, count matches.
- **cantor-diagonalization-oq-03-oq-01**: verified/original accurate — the only `sorry` is a docstring note about an *alternative* categorical approach not taken; exported theorems complete.
- **hilbert-14-oq-01**: honest Tier-C survey — vacuous `grosshans_characterization` (True→True) / trivially-true Grosshans stubs are NOT surfaced publicly (mainTheorems empty, origContribs scope to genuine Reynolds-operator infra); True stubs disclosed in `assumptions`.
- binary-gcd, binomial-theorem-oq-02-oq-02, birthday-problem-oq-03-oq-01: 0 axiom/sorry/native_decide, badges accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)