### PR TITLE
Audit: fix stale meta.sorries (2→0) for erdos-751

### DIFF
--- a/src/data/proofs/erdos-751/meta.json
+++ b/src/data/proofs/erdos-751/meta.json
@@ -18,7 +18,7 @@
       "minimum-degree"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 751,
     "erdosUrl": "https://erdosproblems.com/751",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Integrity fix

**Proof**: erdos-751 (Cycle Lengths in 4-Chromatic Graphs)
**Problem**: The nested `meta` block claimed `"sorries": 2`, but the Lean file
(`Proofs/Erdos751Problem.lean`) contains **0 sorries** (confirmed via grep — no
`sorry` token anywhere, including comments). The fresher `leanFile` block and the
top-level field already reported `0`; this was classic two-meta-block drift.

Direction is safe (it understated completeness rather than overclaiming), but the
stale count caused the audit detector to re-flag this entry every cycle (5× so far).
This syncs the nested count to `0`.

## Evidence
- `grep -c '\bsorry\b' proofs/Proofs/Erdos751Problem.lean` → `0`
- meta.json before: line 21 `"sorries": 2`; lines 152/171 `"sorries": 0`
- meta.json after: all three `0`

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)