### PR TITLE
Audit: re-verify ptolemys-complex-proof clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23975,9 +23975,9 @@
       "issues": []
     },
     "ptolemys-complex-proof": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:43Z",
+      "lastAudited": "2026-07-22T14:38:29Z",
       "result": "clean"
     },
     "ptolemys-complex-proof-oq-01": {


### PR DESCRIPTION
Reserve-mode re-audit of the oldest tracker entry (queue drained, all 4809 audited).

**Result: CLEAN.** The prior phantom-theorem issue (#41463, `ptolemy_inequality_abs`) is fixed. Source `PtolemysComplexProof.lean` has exactly 5 theorems (names match the exports section), 0 sorries, 0 axioms, no native_decide. meta.json prose consistently says "Five theorems".

Tracker: bump auditCount 3→4, lastAudited timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)