### PR TITLE
Audit: erdos-1-oq-02 verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8249,9 +8249,9 @@
       "issues": []
     },
     "erdos-1-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:45Z",
+      "lastAudited": "2026-07-22T14:40:11Z",
       "result": "clean"
     },
     "erdos-1-oq-03": {


### PR DESCRIPTION
Reserve-mode re-audit. Dubroff–Fox–Xu subset-sum framework: 38 theorems/lemmas, 0 sorries, 0 axioms, no True stubs. The single `native_decide` grep hit is inside a comment (line 671) explaining a stronger claim would require it — not actual tactic use. `anticoncentration_bound` confirmed a real theorem (formerly axiom, genuinely upgraded). Tier-A original, badge accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)