### PR TITLE
Fix: erdos-751 restate false four_chromatic_minDeg axiom (subgraph min-degree) + stale sorry count

### DIFF
--- a/proofs/Proofs/Erdos751Problem.lean
+++ b/proofs/Proofs/Erdos751Problem.lean
@@ -12,12 +12,14 @@ if the girth of G is large?
 Answer: NO
 
 Bondy and Vince (1998) proved that every graph with minimum degree at least 3
-has two cycles whose lengths differ by at most 2. Since every graph with
-chromatic number 4 has minimum degree at least 3, the answer follows.
+has two cycles whose lengths differ by at most 2. Every graph with chromatic
+number 4 contains a subgraph H with minimum degree at least 3, and every cycle
+of H is a cycle of G, so the answer follows.
 
 Key Insight:
-The chromatic number lower bounds the minimum degree (χ(G) ≤ Δ(G) + 1, and
-more relevantly, minimum degree at least χ(G) - 1 for graphs with χ(G) ≥ 2).
+The chromatic number lower bounds the degeneracy: a graph with χ(G) ≥ k always
+contains a subgraph of minimum degree ≥ k - 1 (the bound is on a subgraph, not
+on G itself — a 4-chromatic graph can still have low-degree vertices).
 
 References:
 - Bondy, Vince (1998): "Cycles in a graph whose lengths differ by one or two"
@@ -115,12 +117,31 @@ More importantly for us:
   If χ(G) ≥ k, then G has a subgraph with minimum degree ≥ k - 1.
 -/
 /--
-**Alternative formulation:**
-Every graph with chromatic number 4 contains a subgraph of minimum degree 3.
-In fact, for χ(G) = 4, we need minimum degree at least 3.
--/
+**Chromatic number and degeneracy (subgraph minimum degree):**
+The true chromatic–degeneracy result: if `χ(G) ≥ k` then `G` contains a subgraph
+`H ≤ G` with minimum degree `≥ k - 1`. For `χ(G) = 4` this gives a subgraph of
+minimum degree `≥ 3`.
+
+The bound is on a **subgraph**, not on `G` itself. A 4-chromatic graph can have
+low-degree vertices — e.g. `K₄` together with a pendant vertex is 4-chromatic yet
+has `δ(G) = 1` — so the naïve statement `χ(G) = 4 → minDegree G ≥ 3` is false. The
+color-critical (equivalently, greedy/degeneracy) argument always yields a subgraph
+`H` with `δ(H) ≥ 3`, and every cycle of `H` is a cycle of `G` (see
+`cycleLengths_mono`), which is exactly what the Bondy–Vince reduction needs. -/
 axiom four_chromatic_minDeg (G : SimpleGraph V) [DecidableRel G.Adj] :
-    chromaticNumber G = 4 → minDegree G ≥ 3
+    chromaticNumber G = 4 →
+    ∃ (H : SimpleGraph V) (inst : DecidableRel H.Adj),
+      H ≤ G ∧ @minDegree V _ _ _ H inst ≥ 3
+
+/--
+**Cycle lengths are monotone under subgraph inclusion.**
+Every cycle of a subgraph `H ≤ G` is a cycle of `G`: map the cycle walk along the
+inclusion (which is injective and length-preserving). This lets us transfer the
+Bondy–Vince conclusion from the min-degree-3 subgraph back to `G`. -/
+theorem cycleLengths_mono {G H : SimpleGraph V} [DecidableRel G.Adj]
+    [DecidableRel H.Adj] (h : H ≤ G) : cycleLengths H ⊆ cycleLengths G := by
+  rintro n ⟨v, c, hc, rfl⟩
+  exact ⟨v, c.mapLe h, hc.mapLe h, by simp⟩
 
 /-
 ## Part III: Bondy-Vince Theorem
@@ -163,8 +184,10 @@ theorem erdos_751_chromatic_4 (G : SimpleGraph V) [DecidableRel G.Adj] :
     ∃ m m' : ℕ, m ∈ cycleLengths G ∧ m' ∈ cycleLengths G ∧ m ≠ m' ∧
       (m : ℤ) - m' ≤ 2 ∧ (m' : ℤ) - m ≤ 2 := by
   intro hchi
-  have hminDeg : minDegree G ≥ 3 := four_chromatic_minDeg G hchi
-  exact bondy_vince_theorem G hminDeg
+  obtain ⟨H, inst, hHG, hHdeg⟩ := four_chromatic_minDeg G hchi
+  haveI := inst
+  obtain ⟨m, m', hm, hm', hne, h1, h2⟩ := bondy_vince_theorem H hHdeg
+  exact ⟨m, m', cycleLengths_mono hHG hm, cycleLengths_mono hHG hm', hne, h1, h2⟩
 
 /--
 **Erdős Problem #751: Part 2**
@@ -217,13 +240,15 @@ theorem min_degree_3_cycle_gap (G : SimpleGraph V) [DecidableRel G.Adj] :
   bondy_vince_theorem G
 
 /--
-**Why Chromatic Number 4 Implies Minimum Degree 3:**
-A graph with χ(G) = 4 must have a vertex of degree ≥ 3.
-Actually, it must have minimum degree ≥ 3 (otherwise we could
-color greedily with fewer colors).
+**Why Chromatic Number 4 Yields a Minimum-Degree-3 Subgraph:**
+A graph with χ(G) = 4 must contain a subgraph `H ≤ G` with minimum degree ≥ 3
+(otherwise we could color greedily with fewer colors). Note the bound is on the
+subgraph, not on `G` itself.
 -/
 theorem chromatic_4_implies_min_deg_3 (G : SimpleGraph V) [DecidableRel G.Adj] :
-    chromaticNumber G = 4 → minDegree G ≥ 3 :=
+    chromaticNumber G = 4 →
+    ∃ (H : SimpleGraph V) (inst : DecidableRel H.Adj),
+      H ≤ G ∧ @minDegree V _ _ _ H inst ≥ 3 :=
   four_chromatic_minDeg G
 
 /-
@@ -234,8 +259,8 @@ theorem chromatic_4_implies_min_deg_3 (G : SimpleGraph V) [DecidableRel G.Adj] :
 **Erdős Problem #751: SOLVED**
 
 Summary of results:
-1. Bondy-Vince: δ(G) ≥ 3 ⟹ two cycles differ by at most 2
-2. χ(G) = 4 ⟹ δ(G) ≥ 3
+1. Bondy-Vince: δ(H) ≥ 3 ⟹ two cycles differ by at most 2
+2. χ(G) = 4 ⟹ ∃ subgraph H ≤ G with δ(H) ≥ 3 (whose cycles are cycles of G)
 3. Therefore: χ(G) = 4 ⟹ gap ≤ 2
 
 The answer is NO - the gap cannot be arbitrarily large, and large
@@ -250,8 +275,10 @@ theorem erdos_751_summary (G : SimpleGraph V) [DecidableRel G.Adj] :
     (minDegree G ≥ 3 →
       ∃ m m' : ℕ, m ∈ cycleLengths G ∧ m' ∈ cycleLengths G ∧ m ≠ m' ∧
         (m : ℤ) - m' ≤ 2 ∧ (m' : ℤ) - m ≤ 2) ∧
-    -- Connection: χ = 4 implies min degree ≥ 3
-    (chromaticNumber G = 4 → minDegree G ≥ 3) :=
+    -- Connection: χ = 4 yields a subgraph of min degree ≥ 3
+    (chromaticNumber G = 4 →
+      ∃ (H : SimpleGraph V) (inst : DecidableRel H.Adj),
+        H ≤ G ∧ @minDegree V _ _ _ H inst ≥ 3) :=
   ⟨erdos_751_chromatic_4 G, min_degree_3_cycle_gap G, chromatic_4_implies_min_deg_3 G⟩
 
 end Erdos751

--- a/proofs/Proofs/Erdos751Problem.lean
+++ b/proofs/Proofs/Erdos751Problem.lean
@@ -131,7 +131,7 @@ color-critical (equivalently, greedy/degeneracy) argument always yields a subgra
 axiom four_chromatic_minDeg (G : SimpleGraph V) [DecidableRel G.Adj] :
     chromaticNumber G = 4 →
     ∃ (H : SimpleGraph V) (inst : DecidableRel H.Adj),
-      H ≤ G ∧ @minDegree V _ _ _ H inst ≥ 3
+      H ≤ G ∧ @minDegree V _ _ H inst ≥ 3
 
 /--
 **Cycle lengths are monotone under subgraph inclusion.**
@@ -141,7 +141,7 @@ Bondy–Vince conclusion from the min-degree-3 subgraph back to `G`. -/
 theorem cycleLengths_mono {G H : SimpleGraph V} [DecidableRel G.Adj]
     [DecidableRel H.Adj] (h : H ≤ G) : cycleLengths H ⊆ cycleLengths G := by
   rintro n ⟨v, c, hc, rfl⟩
-  exact ⟨v, c.mapLe h, hc.mapLe h, by simp⟩
+  exact ⟨v, c.mapLe h, hc.mapLe h, Walk.length_map (Hom.ofLE h) c⟩
 
 /-
 ## Part III: Bondy-Vince Theorem
@@ -185,7 +185,7 @@ theorem erdos_751_chromatic_4 (G : SimpleGraph V) [DecidableRel G.Adj] :
       (m : ℤ) - m' ≤ 2 ∧ (m' : ℤ) - m ≤ 2 := by
   intro hchi
   obtain ⟨H, inst, hHG, hHdeg⟩ := four_chromatic_minDeg G hchi
-  haveI := inst
+  letI := inst
   obtain ⟨m, m', hm, hm', hne, h1, h2⟩ := bondy_vince_theorem H hHdeg
   exact ⟨m, m', cycleLengths_mono hHG hm, cycleLengths_mono hHG hm', hne, h1, h2⟩
 
@@ -248,7 +248,7 @@ subgraph, not on `G` itself.
 theorem chromatic_4_implies_min_deg_3 (G : SimpleGraph V) [DecidableRel G.Adj] :
     chromaticNumber G = 4 →
     ∃ (H : SimpleGraph V) (inst : DecidableRel H.Adj),
-      H ≤ G ∧ @minDegree V _ _ _ H inst ≥ 3 :=
+      H ≤ G ∧ @minDegree V _ _ H inst ≥ 3 :=
   four_chromatic_minDeg G
 
 /-
@@ -278,7 +278,7 @@ theorem erdos_751_summary (G : SimpleGraph V) [DecidableRel G.Adj] :
     -- Connection: χ = 4 yields a subgraph of min degree ≥ 3
     (chromaticNumber G = 4 →
       ∃ (H : SimpleGraph V) (inst : DecidableRel H.Adj),
-        H ≤ G ∧ @minDegree V _ _ _ H inst ≥ 3) :=
+        H ≤ G ∧ @minDegree V _ _ H inst ≥ 3) :=
   ⟨erdos_751_chromatic_4 G, min_degree_3_cycle_gap G, chromatic_4_implies_min_deg_3 G⟩
 
 end Erdos751

--- a/src/data/proofs/erdos-751/meta.json
+++ b/src/data/proofs/erdos-751/meta.json
@@ -18,7 +18,7 @@
       "minimum-degree"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 751,
     "erdosUrl": "https://erdosproblems.com/751",
     "erdosProblemStatus": "solved",
@@ -45,25 +45,26 @@
       "minDegree and maxDegree definitions for SimpleGraph",
       "chromaticNumber, girth, cycleLengths definitions (stubbed)",
       "minCycleLengthGap definition for consecutive cycle analysis",
-      "four_chromatic_minDeg axiom: chi = 4 implies min degree >= 3",
+      "four_chromatic_minDeg axiom: chi = 4 implies a subgraph H <= G with min degree >= 3",
+      "cycleLengths_mono theorem: cycles of a subgraph H <= G are cycles of G (0 axioms)",
       "bondy_vince_theorem axiom: min degree >= 3 implies close cycles",
       "erdos_751_chromatic_4: main theorem for chi = 4",
       "erdos_751_with_girth: girth doesn't help",
       "erdos_751_summary: combined results"
     ],
     "axiomCount": 2,
-    "lineCount": 235,
-    "assumptions": "2 axioms: four_chromatic_minDeg (χ(G)=4 ⟹ minDegree ≥ 3) and bondy_vince_theorem (Bondy–Vince 1998: minDegree ≥ 3 ⟹ two cycle lengths differ by ≤ 2) — both deep graph-theory results. 2 sorries (minCycleLengthGap definition and its ≤2 bound). The chromaticNumber, girth, and cycleLengths definitions were previously axiomatized; they are now defined from Mathlib (SimpleGraph.chromaticNumber.toNat, SimpleGraph.girth, and the set of cycle-walk lengths respectively).",
-    "theoremCount": 6,
+    "lineCount": 284,
+    "assumptions": "2 axioms: four_chromatic_minDeg (χ(G)=4 ⟹ ∃ subgraph H ≤ G with minDegree H ≥ 3 — the true chromatic–degeneracy statement; the naïve χ(G)=4 ⟹ minDegree G ≥ 3 is false, e.g. K₄ plus a pendant vertex) and bondy_vince_theorem (Bondy–Vince 1998: minDegree ≥ 3 ⟹ two cycle lengths differ by ≤ 2) — both deep graph-theory results. 0 sorries. The transfer of cycle lengths from the min-degree-3 subgraph back to G is the proven theorem cycleLengths_mono (0 axioms). The chromaticNumber, girth, and cycleLengths definitions were previously axiomatized; they are now defined from Mathlib (SimpleGraph.chromaticNumber.toNat, SimpleGraph.girth, and the set of cycle-walk lengths respectively).",
+    "theoremCount": 7,
     "definitionCount": 3
   },
   "overview": {
-    "historicalContext": "**Erdos Problem #751: Cycle Lengths in Graphs**\n\nThis problem explores the structure of cycles in graphs with chromatic constraints.\n\n**Key History:**\n- Erdos posed the question about cycle length gaps in 4-chromatic graphs\n- Bondy and Vince (1998): Proved the key result about minimum degree 3\n- The result is tight: K_4 has cycles of lengths 3 and 4 (gap = 1)\n\n**Mathematical Setting:**\n- Chromatic number chi(G) = minimum colors for proper vertex coloring\n- Girth = length of shortest cycle\n- Minimum degree delta(G) = smallest vertex degree\n\n**Key Connection:**\nChromatic number and minimum degree are related: chi(G) >= delta(G)/(delta(G)-1) + 1 implies chi(G) = 4 needs delta(G) >= 3.",
-    "problemStatement": "**Problem Statement (SOLVED)**\n\nLet G be a graph with chromatic number chi(G) = 4. If m_1 < m_2 < ... are the lengths of cycles in G, can min(m_{i+1} - m_i) be arbitrarily large? Can this happen if the girth of G is large?\n\n**Answer: NO**\n\nBondy and Vince (1998) proved that every graph with minimum degree >= 3 has two cycles whose lengths differ by at most 2.\n\nSince chi(G) = 4 implies minimum degree >= 3, the answer follows. Large girth doesn't help.",
+    "historicalContext": "**Erdos Problem #751: Cycle Lengths in Graphs**\n\nThis problem explores the structure of cycles in graphs with chromatic constraints.\n\n**Key History:**\n- Erdos posed the question about cycle length gaps in 4-chromatic graphs\n- Bondy and Vince (1998): Proved the key result about minimum degree 3\n- The result is tight: K_4 has cycles of lengths 3 and 4 (gap = 1)\n\n**Mathematical Setting:**\n- Chromatic number chi(G) = minimum colors for proper vertex coloring\n- Girth = length of shortest cycle\n- Minimum degree delta(G) = smallest vertex degree\n\n**Key Connection:**\nChromatic number and degeneracy are related: a graph with chi(G) = 4 always contains a subgraph H with delta(H) >= 3 (the bound is on a subgraph, not on G itself).",
+    "problemStatement": "**Problem Statement (SOLVED)**\n\nLet G be a graph with chromatic number chi(G) = 4. If m_1 < m_2 < ... are the lengths of cycles in G, can min(m_{i+1} - m_i) be arbitrarily large? Can this happen if the girth of G is large?\n\n**Answer: NO**\n\nBondy and Vince (1998) proved that every graph with minimum degree >= 3 has two cycles whose lengths differ by at most 2.\n\nSince chi(G) = 4 implies a subgraph of minimum degree >= 3, whose cycles are also cycles of G, the answer follows. Large girth doesn't help.",
     "text": "For graphs with chromatic number 4, can consecutive cycle lengths have arbitrarily large gaps? Answer: NO - Bondy-Vince (1998) proved min degree >= 3 implies two cycles differ by at most 2.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Graph Foundations:** Define minDegree, maxDegree, chromaticNumber, girth, cycleLengths using Mathlib's SimpleGraph.\n\n2. **Key Relationship:** Axiomatize that chi(G) = 4 implies minDegree(G) >= 3.\n\n3. **Bondy-Vince Theorem:** Axiomatize that minDegree >= 3 implies existence of two cycles with length difference <= 2.\n\n4. **Main Results:** Derive that chi(G) = 4 implies close cycles, with or without girth constraints.\n\n5. **Summary:** Combine all results showing the answer is NO.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Graph Foundations:** Define minDegree, maxDegree, chromaticNumber, girth, cycleLengths using Mathlib's SimpleGraph.\n\n2. **Key Relationship:** Axiomatize that chi(G) = 4 implies the existence of a subgraph H <= G with minDegree(H) >= 3 (the true chromatic-degeneracy result; the bound is on a subgraph, not on G itself).\n\n3. **Bondy-Vince Theorem:** Axiomatize that minDegree >= 3 implies existence of two cycles with length difference <= 2.\n\n4. **Cycle Transfer:** Prove (0 axioms) that cycles of a subgraph H <= G are cycles of G (cycleLengths_mono), so the Bondy-Vince conclusion for H transfers to G.\n\n5. **Main Results:** Derive that chi(G) = 4 implies close cycles, with or without girth constraints.\n\n6. **Summary:** Combine all results showing the answer is NO.",
     "keyInsights": [
-      "**Chromatic-Degree Connection:** chi(G) = 4 forces minimum degree >= 3",
+      "**Chromatic-Degree Connection:** chi(G) = 4 forces a subgraph of minimum degree >= 3 (not G itself)",
       "**Bondy-Vince Theorem:** min degree >= 3 gives cycles differing by <= 2",
       "**Girth Irrelevant:** Large girth doesn't change the conclusion",
       "**Gap Bound:** The gap between consecutive cycle lengths is always <= 2",
@@ -86,7 +87,7 @@
     {
       "id": "key-relationships",
       "title": "Key Relationships",
-      "summary": "four_chromatic_minDeg axiom: chi(G) = 4 implies minDegree(G) >= 3",
+      "summary": "four_chromatic_minDeg axiom: chi(G) = 4 implies a subgraph H <= G with minDegree(H) >= 3; cycleLengths_mono: cycles of H are cycles of G",
       "startLine": 88,
       "endLine": 107
     },
@@ -120,7 +121,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdos Problem #751 asked whether graphs with chromatic number 4 can have arbitrarily large gaps between consecutive cycle lengths. The answer is NO: Bondy and Vince (1998) proved that minimum degree >= 3 implies two cycles differ by at most 2, and chi(G) = 4 forces minimum degree >= 3. Large girth doesn't help.",
+    "summary": "Erdos Problem #751 asked whether graphs with chromatic number 4 can have arbitrarily large gaps between consecutive cycle lengths. The answer is NO: Bondy and Vince (1998) proved that minimum degree >= 3 implies two cycles differ by at most 2, and chi(G) = 4 forces a subgraph of minimum degree >= 3 (whose cycles are cycles of G). Large girth doesn't help.",
     "implications": "**Theoretical Significance**: **Graph Theory Connections**\n\n1. **Chromatic Structure:** Chromatic number constrains cycle structure\n\n2. **Degree-Cycle Relationship:** Minimum degree controls cycle length gaps\n\n**3. Girth Independence:** The result is independent of girth\n\n4. **Tight Bounds:** Gap of 2 is achievable (K_4 has cycles 3, 4)\n\n5. **Generalization:** Result holds beyond 4-chromatic graphs.",
     "openQuestions": [
       "Exact characterization of cycle length spectra for k-chromatic graphs",
@@ -144,9 +145,9 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos751",
-    "lineCount": 257,
+    "lineCount": 284,
     "axiomCount": 2,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 3,
     "path": "Proofs/Erdos751Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Repairs the integrity issue in **erdos-751** (Cycle Lengths in 4-Chromatic Graphs): the axiom `four_chromatic_minDeg` was **globally false** against the real Mathlib definitions, and the meta sorry count was stale.

Closes #41466.

## 1. CRITICAL — false axiom restated as the true subgraph statement

The old axiom asserted:

    axiom four_chromatic_minDeg (G) [DecidableRel G.Adj] :
        chromaticNumber G = 4 → minDegree G ≥ 3

This is false: `K₄` plus a pendant/isolated vertex is 4-chromatic yet has global minimum degree 1 (or 0), so the axiom is inconsistent and made the derived theorems unsound.

Restated as the true chromatic–degeneracy result (which the file's own comments already described, lines 109–120):

    axiom four_chromatic_minDeg (G) [DecidableRel G.Adj] :
        chromaticNumber G = 4 →
        ∃ (H : SimpleGraph V) (inst : DecidableRel H.Adj),
          H ≤ G ∧ @minDegree V _ _ H inst ≥ 3

The Bondy–Vince reduction is threaded through the subgraph by a **new, 0-axiom proven theorem** `cycleLengths_mono`: every cycle of a subgraph `H ≤ G` is a cycle of `G` (map the cycle walk along the inclusion via `Walk.mapLe` / `IsCycle.mapLe`, length-preserving via `Walk.length_map`). `erdos_751_chromatic_4`, `chromatic_4_implies_min_deg_3`, and `erdos_751_summary` were updated to consume the subgraph form.

## 2. LOW — stale sorry count

`meta.sorries` was `2`; the Lean file has **0** sorries. Set to `0` and removed the "2 sorries" clause from `assumptions`. Updated prose (assumptions, proofStrategy, keyInsights, conclusion, historicalContext) that repeated the false "χ=4 ⟹ minDegree G ≥ 3" claim to the subgraph form. Bumped line/theorem counts.

`axiomCount` remains **2** (`four_chromatic_minDeg`, `bondy_vince_theorem`), `status: axiomatized`, `badge: axiom` — unchanged.

## Validation

- `./proofs/scripts/docker-build.sh Proofs.Erdos751Problem` → **Build succeeded** (1168 jobs), 0 sorries, 2 axioms.
- meta.json is valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
