### PR TITLE
Research: erdos-326-wip-01 — growth-limit functional properties + two-parameter oscillating family (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos326WIP01.lean
+++ b/proofs/Proofs/Erdos326WIP01.lean
@@ -696,4 +696,97 @@ theorem hasGrowthLimit_of_between_quadratic (b : ℕ → ℕ) (c : ℕ)
   hasGrowthLimit_of_le_of_le hlo hhi (hasGrowthLimit_quadratic c)
     (hasGrowthLimit_quadratic c)
 
+/-! ## Order and algebra of the growth-limit functional
+
+Beyond uniqueness (`HasGrowthLimit.unique`) and the squeeze principle
+(`hasGrowthLimit_of_le_of_le`), the growth limit behaves as a well-structured
+functional on enumerations:
+
+* it is **monotone** — an eventually-pointwise-smaller enumeration has a
+  smaller (or equal) growth limit (`HasGrowthLimit.mono`).  Together with
+  uniqueness and the squeeze this makes `{unique, monotone, squeeze}` a complete
+  order-theoretic toolkit for reasoning about the limit;
+* it is **linear under scaling** — multiplying every term by a constant `c`
+  scales the limit by `c` (`HasGrowthLimit.const_mul`); and
+* **non-convergence is a tail invariant** (`hasNoGrowthLimit_congr'`), the dual
+  of `hasGrowthLimit_congr'` — so, exactly as for the convergent case, a
+  sub-basis may be modified on a finite prefix without affecting whether its
+  `bₖ/k²` oscillates.
+
+All results are `0`-axiom. -/
+
+/-- **Monotonicity of the growth limit.**  If `a k ≤ b k` holds eventually and
+both enumerations have growth limits, the limits are ordered the same way:
+`x ≤ y`.  Pointwise domination of the numerators passes to the ratios
+(`growthRatio_mono`) and then, in the limit, to the coefficients. -/
+theorem HasGrowthLimit.mono {a b : ℕ → ℕ} {x y : ℝ}
+    (hab : ∀ᶠ k in atTop, a k ≤ b k) (ha : HasGrowthLimit a x)
+    (hb : HasGrowthLimit b y) : x ≤ y := by
+  have hle : ∀ᶠ k in atTop, growthRatio a k ≤ growthRatio b k := by
+    filter_upwards [hab] with k hk using growthRatio_mono hk
+  exact le_of_tendsto_of_tendsto ha hb hle
+
+/-- **The growth limit scales linearly.**  Multiplying every term of the
+enumeration by a constant `c` multiplies the growth ratio, hence the limit, by
+`c`: from `HasGrowthLimit b x` we get `HasGrowthLimit (c·b) (c·x)`.  The `c = 0`
+case gives the constant-`0` enumeration with limit `0`, and `c = 1` is the
+identity. -/
+theorem HasGrowthLimit.const_mul {b : ℕ → ℕ} {x : ℝ} (h : HasGrowthLimit b x)
+    (c : ℕ) : HasGrowthLimit (fun k => c * b k) ((c : ℝ) * x) := by
+  have hgr : ∀ k, growthRatio (fun k => c * b k) k = (c : ℝ) * growthRatio b k := by
+    intro k; unfold growthRatio; push_cast; ring
+  exact Filter.Tendsto.congr (fun k => (hgr k).symm) (Filter.Tendsto.const_mul (c : ℝ) h)
+
+/-- **Non-convergence is a tail invariant.**  If two enumerations agree
+eventually then one has *no* growth limit iff the other does — the
+non-convergent dual of `hasGrowthLimit_congr'`.  This is what lets a sub-basis
+construction ignore any finite prefix when arranging `bₖ/k²` to oscillate. -/
+theorem hasNoGrowthLimit_congr' {b b' : ℕ → ℕ} (h : b =ᶠ[atTop] b') :
+    HasNoGrowthLimit b ↔ HasNoGrowthLimit b' := by
+  unfold HasNoGrowthLimit
+  refine ⟨fun H x hx => H x ((hasGrowthLimit_congr' h).mpr hx),
+    fun H x hx => H x ((hasGrowthLimit_congr' h).mp hx)⟩
+
+/-! ## A two-parameter oscillating family
+
+The single oscillating example (`oscillating`, coefficients `1` and `2`)
+generalises to an enumeration `oscPair c₁ c₂` whose quadratic coefficient
+alternates between *any* two naturals `c₁` (even indices) and `c₂` (odd
+indices).  Whenever `c₁ ≠ c₂` it realizes `HasNoGrowthLimit`, so the full
+integer spectrum of coefficient gaps is attainable — not just the `{1,2}` gap.
+`oscillating` is the instance `oscPair 1 2`. -/
+
+/-- An enumeration whose quadratic coefficient alternates between `c₁` (even
+indices) and `c₂` (odd indices): `bₖ = c₁·k²` for even `k`, `c₂·k²` for odd. -/
+def oscPair (c₁ c₂ : ℕ) (k : ℕ) : ℕ := (if k % 2 = 0 then c₁ else c₂) * k ^ 2
+
+/-- On even indices the two-parameter oscillating growth ratio is `c₁`. -/
+theorem growthRatio_oscPair_even (c₁ c₂ m : ℕ) :
+    growthRatio (oscPair c₁ c₂) (2 * m + 2) = (c₁ : ℝ) := by
+  have hval : oscPair c₁ c₂ (2 * m + 2) = c₁ * (2 * m + 2) ^ 2 := by
+    unfold oscPair; rw [if_pos (show (2 * m + 2) % 2 = 0 from by omega)]
+  exact growthRatio_eq (oscPair c₁ c₂) c₁ (2 * m + 2) (by omega) hval
+
+/-- On odd indices the two-parameter oscillating growth ratio is `c₂`. -/
+theorem growthRatio_oscPair_odd (c₁ c₂ m : ℕ) :
+    growthRatio (oscPair c₁ c₂) (2 * m + 1) = (c₂ : ℝ) := by
+  have hval : oscPair c₁ c₂ (2 * m + 1) = c₂ * (2 * m + 1) ^ 2 := by
+    unfold oscPair; rw [if_neg (show ¬ (2 * m + 1) % 2 = 0 from by omega)]
+  exact growthRatio_eq (oscPair c₁ c₂) c₂ (2 * m + 1) (by omega) hval
+
+/-- **The two-parameter oscillating enumeration has no growth limit whenever
+`c₁ ≠ c₂`.**  Its growth ratio equals the constant `c₁` on the (cofinal) even
+indices and `c₂` on the odd ones, so the two-subsequence criterion applies with
+distinct limits.  Generalises `hasNoGrowthLimit_oscillating` (the `c₁ = 1`,
+`c₂ = 2` case) to every pair of distinct coefficients. -/
+theorem hasNoGrowthLimit_oscPair {c₁ c₂ : ℕ} (h : c₁ ≠ c₂) :
+    HasNoGrowthLimit (oscPair c₁ c₂) := by
+  refine hasNoGrowthLimit_of_two_subseq_limits
+    (φ := fun m => 2 * m + 2) (ψ := fun m => 2 * m + 1)
+    (L := (c₁ : ℝ)) (L' := (c₂ : ℝ))
+    (by intro a b hab; dsimp only; omega) (by intro a b hab; dsimp only; omega)
+    ?_ ?_ (by exact_mod_cast h)
+  · simp only [growthRatio_oscPair_even]; exact tendsto_const_nhds
+  · simp only [growthRatio_oscPair_odd]; exact tendsto_const_nhds
+
 end Erdos326

--- a/research/problems/erdos-326-wip-01/knowledge.md
+++ b/research/problems/erdos-326-wip-01/knowledge.md
@@ -249,3 +249,17 @@ engine `hasNoGrowthLimit_of_two_subseq_limits`:
 - The subset-basis oscillation dichotomy — deep structured blocker; both the
   non-convergence engine and this squeeze engine are the *final steps* of any such
   construction, the construction itself is the hard part.
+
+## 2026-07-22 (researcher-1-3, PR #41480) — growth-limit functional properties
+
+Added to Erdos326WIP01.lean (0-axiom, Docker 8577 jobs):
+- HasGrowthLimit.mono (limit monotone under eventual pointwise ≤),
+  HasGrowthLimit.const_mul (limit scales by constant c),
+  hasNoGrowthLimit_congr' (non-convergence tail-invariant, dual of
+  hasGrowthLimit_congr'). {unique,monotone,squeeze} now a complete order toolkit.
+- oscPair c₁ c₂ + growthRatio_oscPair_even/_odd + hasNoGrowthLimit_oscPair:
+  two-parameter oscillating family (no limit iff c₁≠c₂), generalizes the {1,2}
+  `oscillating` example (oscillating = oscPair 1 2) to full coefficient spectrum.
+
+Elementary layer now further saturated. Deep OPEN core unchanged: sub-basis
+oscillation dichotomy needs a materially new mechanism.

--- a/src/data/research/problems/erdos-326-wip-01.json
+++ b/src/data/research/problems/erdos-326-wip-01.json
@@ -44,7 +44,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: bₖ=O(k²) fully bridged to growthRatio boundedness (3 axiom-free lemmas tying growthRatio to the actual order-2-basis enumeration Nat.nth; range is BddAbove). Only the open non-convergence/oscillation dichotomy of #326 remains.",
+    "progressSummary": "PROGRESS: growth-spectrum toolkit now has {unique,monotone,squeeze} order structure + const-scaling + non-convergence tail-invariance + two-parameter oscillating family oscPair (PR #41480, 0-axiom). Deep OPEN core: sub-basis oscillation dichotomy (materially new mechanism required).",
     "builtItems": [
       "IsAddBasisOfOrder.mono_order / .mono_set in Erdos326WIP01.lean",
       "IsAddBasis.mono",
@@ -76,7 +76,8 @@
       "Idiom: ∀ᶠ equality must be typed as f =ᶠ[l] g (EventuallyEq) for .symm/.congr' dot notation to resolve; the bare ∀ᶠ (Eventually) head symbol blocks it.",
       "The b_k = O(k^2) growth upper bound for order-2 bases is now machine-checked axiom-free (two_nth_le_quadratic: Nat.nth (.∈A) k ≤ N + (k+1)^2; two_nth_le_mul_sq: ≤ (N+4)·k^2 for k≥1). This is the standard consequence of the √n density bound (Key Observation 1): with n = N+(k+1)^2 the density (n+1-N ≤ (|S|+1)^2) forces k < |S| ≤ count(.∈A)(n+1), so Nat.nth (.∈A) k < n+1 via Nat.nth_lt_of_lt_count. No deep input; the oscillation dichotomy stays open.",
       "growthRatio bₖ/k² of an order-2 basis enumeration (Nat.nth) is bounded above: eventually ≤ C (two_growthRatio_le), eventually in [0,C] (two_growthRatio_mem_Icc), and its full range is BddAbove (two_growthRatio_bddAbove) — the growthRatio restatement of bₖ=O(k²). First results connecting growthRatio to the real basis enumeration rather than toy sequences.",
-      "hasNoGrowthLimit_of_two_subseq_limits: two strictly-monotone index subsequences of growthRatio with distinct limits ⇒ HasNoGrowthLimit. Reusable engine for the OPEN oscillation direction of #326; generalizes the ad-hoc oscillating example. Idiom: hx.comp hφ.tendsto_atTop (subsequence shares limit) + tendsto_nhds_unique."
+      "hasNoGrowthLimit_of_two_subseq_limits: two strictly-monotone index subsequences of growthRatio with distinct limits ⇒ HasNoGrowthLimit. Reusable engine for the OPEN oscillation direction of #326; generalizes the ad-hoc oscillating example. Idiom: hx.comp hφ.tendsto_atTop (subsequence shares limit) + tendsto_nhds_unique.",
+      "Growth-limit functional is MONOTONE (HasGrowthLimit.mono), LINEAR under constant scaling (HasGrowthLimit.const_mul), and non-convergence is a TAIL INVARIANT (hasNoGrowthLimit_congr); two-parameter oscillating family oscPair c1 c2 realizes HasNoGrowthLimit for all c1!=c2 (PR #41480)."
     ],
     "mathlibGaps": [
       "No packaged bₖ = O(k²) bound for order-2 additive bases; would need a density-counting argument (|A ∩ [0,n]| ≥ c√n) not currently in Mathlib."


### PR DESCRIPTION
## Summary

Extends the growth-spectrum layer of Erdős #326 (additive bases, growth ratio
`bₖ/k²`) in `proofs/Proofs/Erdos326WIP01.lean` with the **order/algebra
structure of the `HasGrowthLimit` functional** and a **parameterized
non-convergence family**. All results **0-axiom** (Docker-verified, 8577 jobs).

## New results

Order/algebra of the growth-limit functional:
- `HasGrowthLimit.mono` — eventual pointwise `a k ≤ b k` with both limits ⟹
  `x ≤ y`. The limit functional is **monotone**; with `HasGrowthLimit.unique`
  and the squeeze `hasGrowthLimit_of_le_of_le` this completes a
  `{unique, monotone, squeeze}` order toolkit.
- `HasGrowthLimit.const_mul` — scaling every term by `c` scales the limit by `c`
  (`HasGrowthLimit b x ⟹ HasGrowthLimit (c·b) (c·x)`).
- `hasNoGrowthLimit_congr'` — **non-convergence is a tail invariant** (the dual
  of the existing `hasGrowthLimit_congr'`): agreeing eventually ⟹ same
  oscillation status. This is what lets a sub-basis construction ignore any
  finite prefix when arranging `bₖ/k²` to oscillate.

Two-parameter oscillating family:
- `oscPair c₁ c₂` — coefficient alternates between `c₁` (even indices) and `c₂`
  (odd), with `growthRatio_oscPair_even/_odd` giving the constant subsequential
  ratios, and `hasNoGrowthLimit_oscPair` (for `c₁ ≠ c₂`) via the two-subsequence
  criterion. Generalizes the fixed `{1,2}`-gap `oscillating` example to the
  **entire integer coefficient-gap spectrum** (`oscillating = oscPair 1 2`).

## Why it matters

The non-convergence direction of #326 (constructing a sub-basis whose `bₖ/k²`
oscillates) ultimately consumes exactly these tools: a comparison/monotonicity
principle, prefix-invariance of oscillation, and a supply of oscillating
witnesses across the full coefficient spectrum. This rounds out the reusable
elementary toolkit while the deep sub-basis existence question stays open.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos326WIP01` — build succeeded
(8577 jobs). No `sorry`, `axiom`, `decide`, or `native_decide` in the new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
