### PR TITLE
Fix: erdos-751 restate false four_chromatic_minDeg axiom to true subgraph form

### DIFF
--- a/proofs/Proofs/Erdos751Problem.lean
+++ b/proofs/Proofs/Erdos751Problem.lean
@@ -13,11 +13,14 @@ Answer: NO
 
 Bondy and Vince (1998) proved that every graph with minimum degree at least 3
 has two cycles whose lengths differ by at most 2. Since every graph with
-chromatic number 4 has minimum degree at least 3, the answer follows.
+chromatic number 4 contains a subgraph of minimum degree at least 3, the
+answer follows (the two close cycles in that subgraph are also cycles in G).
 
 Key Insight:
-The chromatic number lower bounds the minimum degree (χ(G) ≤ Δ(G) + 1, and
-more relevantly, minimum degree at least χ(G) - 1 for graphs with χ(G) ≥ 2).
+The chromatic number controls degeneracy: χ(G) ≤ Δ(G) + 1, and more relevantly,
+a graph with χ(G) ≥ k contains a subgraph of minimum degree ≥ k − 1. (The bound
+is on a subgraph, not the global minimum degree of G, which an isolated vertex
+can force to 0.)
 
 References:
 - Bondy, Vince (1998): "Cycles in a graph whose lengths differ by one or two"
@@ -106,7 +109,16 @@ theorem minCycleLengthGap_le {S : Set ℕ} {a b : ℕ} (ha : a ∈ S) (hb : b �
 ## Part II: Key Relationships
 -/
 
-/- 
+/--
+**Cycle lengths are monotone under subgraphs.**
+If `H ≤ G`, every cycle of `H` is a cycle of `G` (via `Walk.mapLe`), so the set
+of cycle lengths of `H` is contained in that of `G`. -/
+theorem cycleLengths_mono {G H : SimpleGraph V} [DecidableRel G.Adj]
+    [DecidableRel H.Adj] (h : H ≤ G) : cycleLengths H ⊆ cycleLengths G := by
+  rintro n ⟨v, c, hcyc, hlen⟩
+  exact ⟨v, c.mapLe h, (Walk.mapLe_isCycle h).mpr hcyc, by simpa using hlen⟩
+
+/-
 **Chromatic Number and Minimum Degree:**
 For any graph G with at least one vertex:
   χ(G) ≤ Δ(G) + 1 (greedy coloring bound)
@@ -115,12 +127,17 @@ More importantly for us:
   If χ(G) ≥ k, then G has a subgraph with minimum degree ≥ k - 1.
 -/
 /--
-**Alternative formulation:**
-Every graph with chromatic number 4 contains a subgraph of minimum degree 3.
-In fact, for χ(G) = 4, we need minimum degree at least 3.
--/
-axiom four_chromatic_minDeg (G : SimpleGraph V) [DecidableRel G.Adj] :
-    chromaticNumber G = 4 → minDegree G ≥ 3
+**Chromatic–degeneracy lemma (subgraph form):**
+Every graph with chromatic number 4 contains a subgraph `H ≤ G` of minimum
+degree at least 3. The bound holds on a *subgraph*, **not** on the global
+minimum degree of `G`: e.g. `K₄` plus an isolated vertex is 4-chromatic yet has
+global minimum degree 0.
+
+This is the standard chromatic–degeneracy fact: `χ(G) ≥ k` implies `G` has a
+subgraph of minimum degree `≥ k − 1` (equivalently, degeneracy `≥ k − 1`). -/
+axiom four_chromatic_subgraph_minDeg (G : SimpleGraph V) [DecidableRel G.Adj] :
+    chromaticNumber G = 4 →
+    ∃ (H : SimpleGraph V) (_ : DecidableRel H.Adj), H ≤ G ∧ minDegree H ≥ 3
 
 /-
 ## Part III: Bondy-Vince Theorem
@@ -163,8 +180,10 @@ theorem erdos_751_chromatic_4 (G : SimpleGraph V) [DecidableRel G.Adj] :
     ∃ m m' : ℕ, m ∈ cycleLengths G ∧ m' ∈ cycleLengths G ∧ m ≠ m' ∧
       (m : ℤ) - m' ≤ 2 ∧ (m' : ℤ) - m ≤ 2 := by
   intro hchi
-  have hminDeg : minDegree G ≥ 3 := four_chromatic_minDeg G hchi
-  exact bondy_vince_theorem G hminDeg
+  obtain ⟨H, hH, hle, hminH⟩ := four_chromatic_subgraph_minDeg G hchi
+  letI := hH
+  obtain ⟨m, m', hm, hm', hne, hg1, hg2⟩ := bondy_vince_theorem H hminH
+  exact ⟨m, m', cycleLengths_mono hle hm, cycleLengths_mono hle hm', hne, hg1, hg2⟩
 
 /--
 **Erdős Problem #751: Part 2**
@@ -217,14 +236,16 @@ theorem min_degree_3_cycle_gap (G : SimpleGraph V) [DecidableRel G.Adj] :
   bondy_vince_theorem G
 
 /--
-**Why Chromatic Number 4 Implies Minimum Degree 3:**
-A graph with χ(G) = 4 must have a vertex of degree ≥ 3.
-Actually, it must have minimum degree ≥ 3 (otherwise we could
-color greedily with fewer colors).
+**Why Chromatic Number 4 Implies a Dense Subgraph:**
+A graph with χ(G) = 4 must contain a subgraph of minimum degree ≥ 3
+(the chromatic–degeneracy lemma). The bound holds on the subgraph, not on the
+global minimum degree of `G` (an isolated vertex forces the latter to 0).
 -/
-theorem chromatic_4_implies_min_deg_3 (G : SimpleGraph V) [DecidableRel G.Adj] :
-    chromaticNumber G = 4 → minDegree G ≥ 3 :=
-  four_chromatic_minDeg G
+theorem chromatic_4_implies_subgraph_min_deg_3 (G : SimpleGraph V)
+    [DecidableRel G.Adj] :
+    chromaticNumber G = 4 →
+    ∃ (H : SimpleGraph V) (_ : DecidableRel H.Adj), H ≤ G ∧ minDegree H ≥ 3 :=
+  four_chromatic_subgraph_minDeg G
 
 /-
 ## Part VI: Summary
@@ -235,8 +256,8 @@ theorem chromatic_4_implies_min_deg_3 (G : SimpleGraph V) [DecidableRel G.Adj] :
 
 Summary of results:
 1. Bondy-Vince: δ(G) ≥ 3 ⟹ two cycles differ by at most 2
-2. χ(G) = 4 ⟹ δ(G) ≥ 3
-3. Therefore: χ(G) = 4 ⟹ gap ≤ 2
+2. χ(G) = 4 ⟹ G has a subgraph H ≤ G with δ(H) ≥ 3
+3. Therefore: χ(G) = 4 ⟹ gap ≤ 2 (the close cycles in H are cycles in G)
 
 The answer is NO - the gap cannot be arbitrarily large, and large
 girth doesn't help either.
@@ -250,8 +271,10 @@ theorem erdos_751_summary (G : SimpleGraph V) [DecidableRel G.Adj] :
     (minDegree G ≥ 3 →
       ∃ m m' : ℕ, m ∈ cycleLengths G ∧ m' ∈ cycleLengths G ∧ m ≠ m' ∧
         (m : ℤ) - m' ≤ 2 ∧ (m' : ℤ) - m ≤ 2) ∧
-    -- Connection: χ = 4 implies min degree ≥ 3
-    (chromaticNumber G = 4 → minDegree G ≥ 3) :=
-  ⟨erdos_751_chromatic_4 G, min_degree_3_cycle_gap G, chromatic_4_implies_min_deg_3 G⟩
+    -- Connection: χ = 4 implies a subgraph of min degree ≥ 3
+    (chromaticNumber G = 4 →
+      ∃ (H : SimpleGraph V) (_ : DecidableRel H.Adj), H ≤ G ∧ minDegree H ≥ 3) :=
+  ⟨erdos_751_chromatic_4 G, min_degree_3_cycle_gap G,
+    chromatic_4_implies_subgraph_min_deg_3 G⟩
 
 end Erdos751

--- a/proofs/Proofs/Erdos751Problem.lean
+++ b/proofs/Proofs/Erdos751Problem.lean
@@ -116,7 +116,9 @@ of cycle lengths of `H` is contained in that of `G`. -/
 theorem cycleLengths_mono {G H : SimpleGraph V} [DecidableRel G.Adj]
     [DecidableRel H.Adj] (h : H ≤ G) : cycleLengths H ⊆ cycleLengths G := by
   rintro n ⟨v, c, hcyc, hlen⟩
-  exact ⟨v, c.mapLe h, (Walk.mapLe_isCycle h).mpr hcyc, by simpa using hlen⟩
+  refine ⟨v, c.mapLe h, (Walk.mapLe_isCycle h).mpr hcyc, ?_⟩
+  have hlm : (c.mapLe h).length = c.length := c.length_map (Hom.ofLE h)
+  rw [hlm]; exact hlen
 
 /-
 **Chromatic Number and Minimum Degree:**

--- a/src/data/proofs/erdos-751/meta.json
+++ b/src/data/proofs/erdos-751/meta.json
@@ -18,7 +18,7 @@
       "minimum-degree"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 751,
     "erdosUrl": "https://erdosproblems.com/751",
     "erdosProblemStatus": "solved",
@@ -45,25 +45,25 @@
       "minDegree and maxDegree definitions for SimpleGraph",
       "chromaticNumber, girth, cycleLengths definitions (stubbed)",
       "minCycleLengthGap definition for consecutive cycle analysis",
-      "four_chromatic_minDeg axiom: chi = 4 implies min degree >= 3",
+      "four_chromatic_subgraph_minDeg axiom: chi = 4 implies a subgraph H <= G with min degree >= 3",
       "bondy_vince_theorem axiom: min degree >= 3 implies close cycles",
       "erdos_751_chromatic_4: main theorem for chi = 4",
       "erdos_751_with_girth: girth doesn't help",
       "erdos_751_summary: combined results"
     ],
     "axiomCount": 2,
-    "lineCount": 235,
-    "assumptions": "2 axioms: four_chromatic_minDeg (χ(G)=4 ⟹ minDegree ≥ 3) and bondy_vince_theorem (Bondy–Vince 1998: minDegree ≥ 3 ⟹ two cycle lengths differ by ≤ 2) — both deep graph-theory results. 2 sorries (minCycleLengthGap definition and its ≤2 bound). The chromaticNumber, girth, and cycleLengths definitions were previously axiomatized; they are now defined from Mathlib (SimpleGraph.chromaticNumber.toNat, SimpleGraph.girth, and the set of cycle-walk lengths respectively).",
-    "theoremCount": 6,
+    "lineCount": 280,
+    "assumptions": "2 axioms: four_chromatic_subgraph_minDeg (χ(G)=4 ⟹ G has a subgraph H ≤ G with minDegree H ≥ 3 — the chromatic–degeneracy lemma; the bound is on a subgraph, NOT the global minimum degree, which an isolated vertex can force to 0) and bondy_vince_theorem (Bondy–Vince 1998: minDegree ≥ 3 ⟹ two cycle lengths differ by ≤ 2) — both deep graph-theory results. The subgraph's close cycles lift to G via the verified cycleLengths_mono lemma. 0 sorries. The chromaticNumber, girth, and cycleLengths definitions were previously axiomatized; they are now defined from Mathlib (SimpleGraph.chromaticNumber.toNat, SimpleGraph.girth, and the set of cycle-walk lengths respectively).",
+    "theoremCount": 8,
     "definitionCount": 3
   },
   "overview": {
-    "historicalContext": "**Erdos Problem #751: Cycle Lengths in Graphs**\n\nThis problem explores the structure of cycles in graphs with chromatic constraints.\n\n**Key History:**\n- Erdos posed the question about cycle length gaps in 4-chromatic graphs\n- Bondy and Vince (1998): Proved the key result about minimum degree 3\n- The result is tight: K_4 has cycles of lengths 3 and 4 (gap = 1)\n\n**Mathematical Setting:**\n- Chromatic number chi(G) = minimum colors for proper vertex coloring\n- Girth = length of shortest cycle\n- Minimum degree delta(G) = smallest vertex degree\n\n**Key Connection:**\nChromatic number and minimum degree are related: chi(G) >= delta(G)/(delta(G)-1) + 1 implies chi(G) = 4 needs delta(G) >= 3.",
-    "problemStatement": "**Problem Statement (SOLVED)**\n\nLet G be a graph with chromatic number chi(G) = 4. If m_1 < m_2 < ... are the lengths of cycles in G, can min(m_{i+1} - m_i) be arbitrarily large? Can this happen if the girth of G is large?\n\n**Answer: NO**\n\nBondy and Vince (1998) proved that every graph with minimum degree >= 3 has two cycles whose lengths differ by at most 2.\n\nSince chi(G) = 4 implies minimum degree >= 3, the answer follows. Large girth doesn't help.",
+    "historicalContext": "**Erdos Problem #751: Cycle Lengths in Graphs**\n\nThis problem explores the structure of cycles in graphs with chromatic constraints.\n\n**Key History:**\n- Erdos posed the question about cycle length gaps in 4-chromatic graphs\n- Bondy and Vince (1998): Proved the key result about minimum degree 3\n- The result is tight: K_4 has cycles of lengths 3 and 4 (gap = 1)\n\n**Mathematical Setting:**\n- Chromatic number chi(G) = minimum colors for proper vertex coloring\n- Girth = length of shortest cycle\n- Minimum degree delta(G) = smallest vertex degree\n\n**Key Connection:**\nChromatic number and degeneracy are related: chi(G) >= k implies G contains a subgraph of minimum degree >= k - 1. So chi(G) = 4 forces a subgraph with delta >= 3 (not the global minimum degree, which an isolated vertex can force to 0).",
+    "problemStatement": "**Problem Statement (SOLVED)**\n\nLet G be a graph with chromatic number chi(G) = 4. If m_1 < m_2 < ... are the lengths of cycles in G, can min(m_{i+1} - m_i) be arbitrarily large? Can this happen if the girth of G is large?\n\n**Answer: NO**\n\nBondy and Vince (1998) proved that every graph with minimum degree >= 3 has two cycles whose lengths differ by at most 2.\n\nSince chi(G) = 4 implies G has a subgraph of minimum degree >= 3, the answer follows (the two close cycles in that subgraph are also cycles in G). Large girth doesn't help.",
     "text": "For graphs with chromatic number 4, can consecutive cycle lengths have arbitrarily large gaps? Answer: NO - Bondy-Vince (1998) proved min degree >= 3 implies two cycles differ by at most 2.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Graph Foundations:** Define minDegree, maxDegree, chromaticNumber, girth, cycleLengths using Mathlib's SimpleGraph.\n\n2. **Key Relationship:** Axiomatize that chi(G) = 4 implies minDegree(G) >= 3.\n\n3. **Bondy-Vince Theorem:** Axiomatize that minDegree >= 3 implies existence of two cycles with length difference <= 2.\n\n4. **Main Results:** Derive that chi(G) = 4 implies close cycles, with or without girth constraints.\n\n5. **Summary:** Combine all results showing the answer is NO.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Graph Foundations:** Define minDegree, maxDegree, chromaticNumber, girth, cycleLengths using Mathlib's SimpleGraph.\n\n2. **Key Relationship:** Axiomatize the chromatic–degeneracy lemma: chi(G) = 4 implies a subgraph H <= G with minDegree(H) >= 3 (the bound is on a subgraph, not the global minimum degree).\n\n3. **Bondy-Vince Theorem:** Axiomatize that minDegree >= 3 implies existence of two cycles with length difference <= 2.\n\n4. **Main Results:** Derive that chi(G) = 4 implies close cycles, with or without girth constraints.\n\n5. **Summary:** Combine all results showing the answer is NO.",
     "keyInsights": [
-      "**Chromatic-Degree Connection:** chi(G) = 4 forces minimum degree >= 3",
+      "**Chromatic-Degree Connection:** chi(G) = 4 forces a subgraph of minimum degree >= 3",
       "**Bondy-Vince Theorem:** min degree >= 3 gives cycles differing by <= 2",
       "**Girth Irrelevant:** Large girth doesn't change the conclusion",
       "**Gap Bound:** The gap between consecutive cycle lengths is always <= 2",
@@ -86,7 +86,7 @@
     {
       "id": "key-relationships",
       "title": "Key Relationships",
-      "summary": "four_chromatic_minDeg axiom: chi(G) = 4 implies minDegree(G) >= 3",
+      "summary": "four_chromatic_subgraph_minDeg axiom: chi(G) = 4 implies a subgraph H <= G with minDegree(H) >= 3",
       "startLine": 88,
       "endLine": 107
     },
@@ -120,7 +120,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdos Problem #751 asked whether graphs with chromatic number 4 can have arbitrarily large gaps between consecutive cycle lengths. The answer is NO: Bondy and Vince (1998) proved that minimum degree >= 3 implies two cycles differ by at most 2, and chi(G) = 4 forces minimum degree >= 3. Large girth doesn't help.",
+    "summary": "Erdos Problem #751 asked whether graphs with chromatic number 4 can have arbitrarily large gaps between consecutive cycle lengths. The answer is NO: Bondy and Vince (1998) proved that minimum degree >= 3 implies two cycles differ by at most 2, and chi(G) = 4 forces a subgraph of minimum degree >= 3. Large girth doesn't help.",
     "implications": "**Theoretical Significance**: **Graph Theory Connections**\n\n1. **Chromatic Structure:** Chromatic number constrains cycle structure\n\n2. **Degree-Cycle Relationship:** Minimum degree controls cycle length gaps\n\n**3. Girth Independence:** The result is independent of girth\n\n4. **Tight Bounds:** Gap of 2 is achievable (K_4 has cycles 3, 4)\n\n5. **Generalization:** Result holds beyond 4-chromatic graphs.",
     "openQuestions": [
       "Exact characterization of cycle length spectra for k-chromatic graphs",
@@ -144,9 +144,9 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos751",
-    "lineCount": 257,
+    "lineCount": 280,
     "axiomCount": 2,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 3,
     "path": "Proofs/Erdos751Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Fixes the **inconsistent (globally false) axiom** flagged by the gallery integrity audit in `erdos-751` (Cycle Lengths in 4-Chromatic Graphs).

### 1. CRITICAL — false axiom restated to the true subgraph form

The axiom asserted, against the real Mathlib-based definitions:

```lean
axiom four_chromatic_minDeg (G : SimpleGraph V) [DecidableRel G.Adj] :
    chromaticNumber G = 4 → minDegree G ≥ 3
```

This is **globally false**: `K₄` plus an isolated vertex is 4-chromatic yet has global `minDegree = 0`. An inconsistent axiom makes every downstream theorem unsound (derived from a false hypothesis) rather than a valid reduction.

Restated as the true **chromatic–degeneracy lemma** (matching the file's own comment):

```lean
axiom four_chromatic_subgraph_minDeg (G : SimpleGraph V) [DecidableRel G.Adj] :
    chromaticNumber G = 4 →
    ∃ (H : SimpleGraph V) (_ : DecidableRel H.Adj), H ≤ G ∧ minDegree H ≥ 3
```

The bound is on a **subgraph** `H ≤ G`, not the global minimum degree. This is threaded through the downstream theorems via a new **verified** (0-axiom) lemma:

```lean
theorem cycleLengths_mono {G H : SimpleGraph V} [DecidableRel G.Adj]
    [DecidableRel H.Adj] (h : H ≤ G) : cycleLengths H ⊆ cycleLengths G
```

(cycles of `H` are cycles of `G` via `Walk.mapLe`), so the two close cycle lengths Bondy–Vince gives in `H` are genuine cycle lengths in `G`. `erdos_751_chromatic_4`, `erdos_751`, `erdos_751_with_girth`, and `erdos_751_summary` are now sound. `chromatic_4_implies_min_deg_3` (whose conclusion `minDegree G ≥ 3` was also false to state) is renamed to `chromatic_4_implies_subgraph_min_deg_3` with the subgraph conclusion.

`axiomCount` stays 2 (`four_chromatic_subgraph_minDeg`, `bondy_vince_theorem`) — both faithful statements of deep graph-theory results.

### 2. LOW — stale bookkeeping

- `meta.json` `sorries: 2 → 0` (the file has 0 sorries; `minCycleLengthGap` is defined via `sInf` and `minCycleLengthGap_le` is proven).
- Removed the "2 sorries" clause and corrected all prose asserting the false global `χ=4 ⟹ minDegree ≥ 3` implication (assumptions, proofStrategy, keyInsights, historicalContext, problemStatement, summary, section/annotation summaries) to the subgraph statement.
- Updated stale `lineCount`/`theoremCount`.

## Validation

- `./proofs/scripts/docker-build.sh Proofs.Erdos751Problem` → **Build completed successfully (1168 jobs)**. 2 axioms, 0 sorries.

Closes #41466
