### PR TITLE
Audit: kummer-theorem-oq-01 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21542,9 +21542,9 @@
       "note": "native_decide confined to anonymous example sanity-checks; named theorems axiom-clean (verified global sweep 2026-06-24)"
     },
     "kummer-theorem-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:46Z",
+      "lastAudited": "2026-07-22T14:46:24Z",
       "result": "clean"
     },
     "kummer-theorem-oq-01-oq-01": {


### PR DESCRIPTION
Reserve-mode re-audit (queue drained).

**Result: clean.** Honest Tier-B/infrastructure entry.
- 3 theorems, 0 axioms, 0 sorries — match the Lean file. `multinomial_eq_prod_choose` delegates to companion `KummerTheoremOQ01Aristotle.lean` (also axiom/sorry-free, 10 real decls).
- No native_decide, no True stubs.
- The p-adic valuation = base-p carries result is NOT formalized (deferred as a file comment). This is explicitly disclosed in proofStrategy, keyInsights, AND conclusion.summary — no false-formalization claim, no pipeline inflation.
- status `verified` correctly scopes to the 3 proved algebraic-decomposition theorems; badge `mathlib` fits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)