### PR TITLE
Audit: de-moivre-oq-03-oq-01 issues-found (rational_exponent_multivalued overclaim)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6983,10 +6983,10 @@
       "result": "clean"
     },
     "de-moivre-oq-03-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:45Z",
-      "result": "clean"
+      "lastAudited": "2026-07-22T14:49:29Z",
+      "result": "issues-found"
     },
     "de-moivre-oq-03-oq-01-oq-01": {
       "auditCount": 1,


### PR DESCRIPTION
Tracker update. Audited de-moivre-oq-03-oq-01: counts honest (4 thms, 1 axiom weyl_equidistribution, 0 sorries, disclosed True stub, badge axiom) but rational_exponent_multivalued is a vacuous existential (rfl tautology) while prose claims it proves q **distinct** q-th roots. Filed #41485.

🤖 Generated with [Claude Code](https://claude.com/claude-code)