### PR TITLE
research(erdos-510-wip-01): dilation invariance of the Chowla cosine minimum (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos510WIP01.lean
+++ b/proofs/Proofs/Erdos510WIP01.lean
@@ -467,4 +467,50 @@ theorem minCosineSum_forall_odd (A : Finset ℕ) (hodd : ∀ n ∈ A, Odd n) :
   have h := minCosineSum_le_alternating A
   rwa [hsum] at h
 
+/-! ## Dilation invariance: reduction to primitive frequency sets
+
+Scaling every frequency by a common factor `d ≥ 1` (`A ↦ d·A := A.image (d · ·)`)
+leaves the whole Chowla cosine minimum unchanged: dilating the frequencies merely
+rescales the angle (`θ ↦ d·θ`), and since `θ` ranges over all of `ℝ` this is a
+bijective reparametrisation of the range.  This is the standard structural reduction
+that lets one assume `gcd A = 1` (a *primitive* set) when studying `minCosineSum`. -/
+
+/-- **Dilation rescales the angle.**  For a scaling factor `d ≠ 0`, the cosine sum of
+the dilated set `d·A = A.image (d · ·)` at angle `θ` equals the cosine sum of `A` at
+the scaled angle `d·θ`:  `∑_{n∈A} cos((d n) θ) = ∑_{n∈A} cos(n (d θ))`. -/
+theorem cosineSum_dilate {d : ℕ} (hd : d ≠ 0) :
+    cosineSum (A.image (fun n => d * n)) θ = cosineSum A ((d : ℝ) * θ) := by
+  unfold cosineSum
+  rw [Finset.sum_image]
+  · refine Finset.sum_congr rfl (fun n _ => ?_)
+    congr 1
+    push_cast
+    ring
+  · intro a _ b _ hab
+    exact Nat.eq_of_mul_eq_mul_left (Nat.pos_of_ne_zero hd) hab
+
+/-- **The Chowla cosine minimum is dilation-invariant.**  For any scaling factor
+`d ≥ 1`, `minCosineSum (d·A) = minCosineSum A`.  The range of `cosineSum (d·A)` equals
+the range of `cosineSum A` (the map `θ ↦ d·θ` is a surjection of `ℝ` onto itself when
+`d ≠ 0`), so the two infima coincide.  Consequently every frequency set has the same
+minimum as its primitive core `A / gcd A`, reducing the general problem to primitive
+sets. -/
+theorem minCosineSum_dilate {d : ℕ} (hd : d ≠ 0) :
+    minCosineSum (A.image (fun n => d * n)) = minCosineSum A := by
+  have hrange : Set.range (cosineSum (A.image (fun n => d * n)))
+      = Set.range (cosineSum A) := by
+    ext y
+    simp only [Set.mem_range]
+    constructor
+    · rintro ⟨θ, rfl⟩
+      exact ⟨(d : ℝ) * θ, (cosineSum_dilate A θ hd).symm⟩
+    · rintro ⟨φ, rfl⟩
+      refine ⟨φ / d, ?_⟩
+      rw [cosineSum_dilate A (φ / d) hd]
+      congr 1
+      field_simp
+  show sInf (Set.range (cosineSum (A.image (fun n => d * n))))
+      = sInf (Set.range (cosineSum A))
+  rw [hrange]
+
 end Erdos510WIP01

--- a/research/problems/erdos-510-wip-01/knowledge.md
+++ b/research/problems/erdos-510-wip-01/knowledge.md
@@ -1,5 +1,28 @@
 # Knowledge Base: erdos-510-wip-01
 
+## Session 2026-07-22 (researcher-1) — dilation invariance (reduction to primitive sets)
+
+Added 2 axiom-free theorems to `Erdos510WIP01.lean` (host-verified v4.31, `lake env lean` exit 0;
+`#print axioms` = [propext, Classical.choice, Quot.sound]; no sorry/native_decide):
+- `cosineSum_dilate (d ≠ 0) : cosineSum (A.image (d*·)) θ = cosineSum A (d*θ)` — dilating every
+  frequency by `d` merely rescales the angle. Proof: `Finset.sum_image` (injectivity of `n↦d*n`
+  for `d≠0` via `Nat.eq_of_mul_eq_mul_left`) + `(d*n)*θ = n*(d*θ)`.
+- `minCosineSum_dilate (d ≠ 0) : minCosineSum (A.image (d*·)) = minCosineSum A` — **the Chowla
+  cosine minimum is dilation-invariant**. `Set.range (cosineSum (d·A)) = Set.range (cosineSum A)`
+  since `θ↦d·θ` surjects `ℝ` onto itself (`d≠0`); the two infima (`sInf ∘ range`, by defeq of
+  `iInf`) coincide. This is the standard reduction letting one assume `gcd A = 1` (a *primitive*
+  set): every set has the same minimum as its primitive core `A/gcd A`.
+
+Idiom: `minCosineSum X = sInf (Set.range (cosineSum X))` holds by `rfl`/`show` (`iInf f :=
+sInf (range f)`), so range equality transports directly to `sInf` equality — no `ciInf` reindex
+lemma needed (ℝ is only conditionally complete, so `Function.Surjective.iInf_comp` does NOT apply).
+
+### Remaining open (unchanged)
+- Sharp `−c√N` bound (Bourgain/Ruzsa/Bedert) — deep imported, the genuine open mission. The
+  elementary sign structure + attainment + all-odd sharp extreme + dilation invariance are done.
+
+# Knowledge Base: erdos-510-wip-01
+
 ## Session 2026-07-21 (researcher-1) — θ=π alternating bound + sharp all-odd minimum
 
 Added 2 axiom-free theorems to `Erdos510WIP01.lean` (host-verified v4.31 fresh-parent-olean;


### PR DESCRIPTION
## Summary

Adds **dilation invariance** of the Chowla cosine minimum to `Erdos510WIP01.lean` — the standard structural reduction of Erdős problem #510 to *primitive* (gcd = 1) frequency sets. Two axiom-free theorems:

- `cosineSum_dilate (d ≠ 0)` : `cosineSum (A.image (d·)) θ = cosineSum A (d·θ)`. Dilating every frequency by `d` merely rescales the angle. Proof: `Finset.sum_image` (injectivity of `n ↦ d·n` via `Nat.eq_of_mul_eq_mul_left`) plus `(d·n)·θ = n·(d·θ)`.
- `minCosineSum_dilate (d ≠ 0)` : `minCosineSum (A.image (d·)) = minCosineSum A`. The Chowla minimum is invariant under a common scaling of all frequencies. `Set.range (cosineSum (d·A)) = Set.range (cosineSum A)` because `θ ↦ d·θ` surjects `ℝ` onto itself, so the two infima (`sInf ∘ range`, by `iInf` defeq) coincide.

Mathematically this says every frequency set has the same cosine minimum as its primitive core `A / gcd A`, so the general problem reduces to the case `gcd A = 1`.

## Verification

- Host-verified v4.31: `lake env lean Proofs/Erdos510WIP01.lean` exits 0, no errors.
- `#print axioms` for both new theorems = `[propext, Classical.choice, Quot.sound]` — 0-axiom, 0-sorry, no `native_decide`.

## Scope / honesty

This is a modest **structural** addition. The genuine open mission of #510 — the sharp `−c√N` lower bound (Chowla; Bourgain / Ruzsa / Bedert) — is a deep imported result and remains untouched. The elementary layer (sign structure, attainment, all-odd sharp extreme, and now dilation invariance) is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
