### PR TITLE
feat(fleet): per-role model tiering (research=fable, mechanic=opus, rest=sonnet)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ aristotle-results/llm-mapping-cache.json
 .loom/tmp/
 .loom/sweep-checkpoint/
 .loom/config.json
+.loom/model-config.env
 .loom-managed
 research/*.pid
 research/*.log

--- a/.loom/model-config.env.example
+++ b/.loom/model-config.env.example
@@ -1,0 +1,22 @@
+# Per-role model tiering for the lean fleet (host-local; copy to .loom/model-config.env).
+# Sourced by scripts/lean/daemon-keeper.sh so every agent inherits it at spawn.
+# Resolution chain per role: <ROLE>_<slot>_CLAUDE_MODEL > <ROLE>_CLAUDE_MODEL > CLAUDE_MODEL > wrapper default (opus).
+# Model aliases resolve to: fable=claude-fable-5, opus=claude-opus-4-8, sonnet=claude-sonnet-5, haiku=claude-haiku-4-5-20251001.
+#
+# Current tiering rationale:
+#   - researcher -> FABLE: open-frontier proof work benefits most from the frontier model's imaginative leaps.
+#   - mechanic   -> OPUS:  proof REPAIR is largely known-idiom pattern-matching; strong but not frontier.
+#   - all others -> SONNET: enrichment/audit/deploy/seek/test/herald/aristotle are lighter or mechanical.
+# Roles without a per-role hook (aristotle, tester) inherit the global CLAUDE_MODEL default (sonnet).
+
+export CLAUDE_MODEL="claude-sonnet-5"                 # global default → everything not overridden below
+export RESEARCHER_CLAUDE_MODEL="claude-fable-5"       # research: frontier
+export MECHANIC_CLAUDE_MODEL="claude-opus-4-8"        # proof repair: opus
+
+# Explicit sonnet pins (redundant with the global, but self-documenting per role):
+export ENRICHER_CLAUDE_MODEL="claude-sonnet-5"
+export AUDITOR_CLAUDE_MODEL="claude-sonnet-5"
+export DEPLOYER_CLAUDE_MODEL="claude-sonnet-5"
+export SEEKER_CLAUDE_MODEL="claude-sonnet-5"
+export HERALD_CLAUDE_MODEL="claude-sonnet-5"
+export REVIEWER_CLAUDE_MODEL="claude-sonnet-5"

--- a/scripts/lean/daemon-keeper.sh
+++ b/scripts/lean/daemon-keeper.sh
@@ -37,6 +37,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$REPO_ROOT"
 
+# Per-role model tiering (gitignored, host-local — see .loom/model-config.env.example).
+# Exports CLAUDE_MODEL (global default) + <ROLE>_CLAUDE_MODEL overrides that the
+# daemon reads at agent-spawn time (resolution chain: <ROLE>_<slot> > <ROLE> >
+# CLAUDE_MODEL > wrapper default). Sourced here so the whole fleet inherits it and
+# it survives daemon crash/respawn. Absent → wrapper default (opus) for all roles.
+if [[ -f "$REPO_ROOT/.loom/model-config.env" ]]; then
+    # shellcheck disable=SC1091
+    source "$REPO_ROOT/.loom/model-config.env"
+fi
+
 DAEMON="$SCRIPT_DIR/launch.sh"
 SIGNALS_DIR=".loom/signals"
 STOP_SIGNAL_FILE="$SIGNALS_DIR/stop-lean-daemon"


### PR DESCRIPTION
## Context
The lean fleet ran **every role on Opus 4.8** — no differentiation. This adds host-local per-role model tiering so the frontier model goes where it pays off and cheaper models handle lighter/mechanical roles.

## Tiering
| Role | Model | Why |
|------|-------|-----|
| researcher | **fable** (`claude-fable-5`) | Open-frontier proof work — novel strategies benefit most from the frontier model |
| mechanic | **opus** (`claude-opus-4-8`) | Proof *repair* is largely known-idiom pattern-matching (v4.31 drift, `interval_cases`, native_decide→axiomatized) — strong but not frontier |
| enricher, auditor, deployer, seeker, tester, herald, aristotle | **sonnet** (`claude-sonnet-5`) | Enrichment/audit/deploy/select/poll/post — lighter or mechanical |

## Mechanism
- `scripts/lean/daemon-keeper.sh` sources `.loom/model-config.env` (host-local, gitignored) at startup, so the whole fleet inherits the models at agent spawn. Resolution chain unchanged: `<ROLE>_<slot>_CLAUDE_MODEL > <ROLE>_CLAUDE_MODEL > CLAUDE_MODEL > wrapper default`.
- Global `CLAUDE_MODEL=claude-sonnet-5` covers roles with no per-role hook (aristotle, tester); two per-role overrides (researcher→fable, mechanic→opus).
- Tracked **`.loom/model-config.env.example`** documents the mechanism + aliases; the real file is gitignored.
- **Absent config → unchanged** (wrapper default opus for all) — safe, reversible by editing one file.

## Verified
- `bash -n` clean (keeper + config); resolution confirmed: research→fable, mechanic→opus, all others→sonnet ✓
- `.loom/model-config.env` gitignored; `.example` tracked ✓

## Note
Loom's cheap-first default retune is **measurement-gated** (rjwalters/loom#3702/#3706 — flip only on per-role success/cost data). We have no per-role metrics in the lean fleet, so this is an operator judgment call, trivially reversible. A future follow-up could add per-role metrics before further tuning enricher/auditor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)