### PR TITLE
audit: mark erdos-1015-oq-05 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8844,9 +8844,9 @@
       "result": "clean"
     },
     "erdos-1015-oq-05": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:46Z",
+      "lastAudited": "2026-07-22T15:07:20Z",
       "result": "clean"
     },
     "erdos-1015-oq-05-oq-01": {


### PR DESCRIPTION
Reserve-mode re-audit tracker update.

**Result:** clean. Genuine axiom-elimination file (badge `original`).

Verified against `proofs/Proofs/Erdos1015OQ05.lean`:
- theoremCount 13 ✓, definitionCount 1 ✓, 0 axioms, 0 sorries, no native_decide in-file ✓
- Re-proves Erdős-Szekeres R(t,t)≤4^t via Pascal induction; derives `ramseyNumber` via `Nat.find` over the honestly-proved `ramsey_theorem`
- Parent `RamseysTheorem.lean` dependency chain is axiom/native_decide/sorry-free; parent's native_decide is confined to unreferenced concrete-value theorems and its lone axiom (`multicolor_ramsey_exists`) is not in this chain
- Narrative honestly states 6 axioms remain in parent file ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)