### PR TITLE
audit(descartes-rule-of-signs-oq-01-oq-02): mark clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7398,9 +7398,9 @@
       "issues": []
     },
     "descartes-rule-of-signs-oq-01-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:46Z",
+      "lastAudited": "2026-07-22T15:10:36Z",
       "result": "clean"
     },
     "descartes-rule-of-signs-oq-01-oq-03": {


### PR DESCRIPTION
## Summary
- Audited `descartes-rule-of-signs-oq-01-oq-02` (round-robin re-serve; queue was fully drained).
- Verified axiom count (1), theorem count (13), sorry count (0) all match the Lean source.
- The single axiom `sign_variation_parity_under_positive_root` is a genuine, non-vacuous hard lemma (sanity-checked against concrete polynomial examples); honestly disclosed via `status: "axiomatized"` and `badge: "axiom"`.
- No native_decide, no True-stubs. All cross-referenced gallery ids and named theorems verified to exist.
- Marked `clean` in audit-tracker.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)