### PR TITLE
fix(lean-status): count deployer's real merge queue, not just loom:pr (#39651)

### DIFF
--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -1826,8 +1826,19 @@ get_work_queue_stats() {
         aristotle_candidates=$(timeout 10 ./scripts/aristotle/find-candidates.sh --count 2>/dev/null || echo "0")
     fi
 
-    # PRs ready to merge
-    ready_prs=$(timeout 10 gh pr list --label "loom:pr" --json number 2>/dev/null | jq 'length' 2>/dev/null || echo "0")
+    # PRs in the deployer's real merge queue (#39651).
+    # Counting only `loom:pr` masked a 537-PR backlog during the #39649 deployer
+    # outage: math agents (Researcher/Enricher/Aristotle/Auditor) do NOT label
+    # their PRs `loom:pr` — the deployer merges them by their content labels
+    # (enrichment/research/loom:auditor/aristotle-integration) directly. Count
+    # every OPEN PR carrying any deployer-merged label (math labels + loom:pr) so
+    # a stalled deployer surfaces as a large number here, not 0. One API call,
+    # OR-filtered in jq; `timeout 10` + `|| echo 0` keep a slow/failing gh safe.
+    ready_prs=$(timeout 10 gh pr list --state open --limit 1000 --json labels 2>/dev/null \
+        | jq '[.[] | select(any(.labels[].name;
+              . == "loom:pr" or . == "enrichment" or . == "research"
+              or . == "loom:auditor" or . == "aristotle-integration"))] | length' 2>/dev/null \
+        || echo "0")
 
     echo "$enrichment_targets $candidates $aristotle_jobs $aristotle_candidates $ready_prs"
 }


### PR DESCRIPTION
## Summary
Fixes the `/lean status` **"PRs ready to merge"** metric, which counted only PRs labeled `loom:pr`. Per `CLAUDE.md`, math agents (Researcher/Enricher/Aristotle/Auditor) do **not** label their PRs `loom:pr` — the deployer merges them by content labels (`enrichment`/`research`/`loom:auditor`/`aristotle-integration`). So the metric ignored the deployer's real merge queue.

During the 7-day deployer outage (#39649), 537 open, mostly-mergeable math PRs were queued, yet this line read **0** the entire time — the metric that should have screamed "huge backlog" said everything was fine.

## Change
In `scripts/lean/launch.sh` `get_work_queue_stats()` (~line 1829), `ready_prs` now counts every **open** PR carrying any deployer-merged label (`loom:pr` + the four math labels) via a single `gh pr list --state open` call, OR-filtered in `jq`. The `timeout 10` guard and `|| echo 0` fallback are preserved so a slow/failing `gh` cannot break status.

Diff is tightly scoped to the `ready_prs` metric — the daemon session-loop / agent-liveness logic (edited concurrently in #39652) is untouched.

## Verification
- `bash -n scripts/lean/launch.sh` passes.
- Live against this repo:
  - Old metric (`loom:pr` only): **0**
  - New metric (deployer merge queue): **10** (of 21 open PRs; remainder are `loom:review-requested` judge-gated or unlabeled)
- During a 537-PR math backlog, those PRs all carry math labels, so this metric would report ~537, not 0 — the backlog becomes visible from `/lean status`.

Closes #39651
