### PR TITLE
fix(denumerability-rationals-oq-04): correct nonexistent Mathlib lemma citation

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7096,10 +7096,10 @@
       "result": "clean"
     },
     "denumerability-rationals-oq-04": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:46Z",
-      "result": "clean"
+      "lastAudited": "2026-07-22T15:19:56Z",
+      "result": "issues-fixed"
     },
     "denumerability-rationals-oq-05": {
       "auditCount": 1,

--- a/src/data/proofs/denumerability-rationals-oq-04/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-04/meta.json
@@ -19,12 +19,12 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 145,
-    "assumptions": "0 axioms, 0 sorries. Core argument uses Mathlib's FTA (Polynomial.setOf_isRoot_finite) and Set.countable_iUnion. Fully constructive; choiceless_note documentation theorem was removed.",
+    "assumptions": "0 axioms, 0 sorries. Core argument uses Mathlib's FTA (Polynomial.finite_setOf_isRoot) and Set.countable_iUnion. Fully constructive; choiceless_note documentation theorem was removed.",
     "mathlibDependencies": [
       {
-        "theorem": "Polynomial.setOf_isRoot_finite",
+        "theorem": "Polynomial.finite_setOf_isRoot",
         "description": "Fundamental theorem of algebra: each nonzero polynomial has finitely many roots",
-        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic"
+        "module": "Mathlib.Algebra.Polynomial.Roots"
       },
       {
         "theorem": "Set.countable_iUnion",


### PR DESCRIPTION
## Summary
- `meta.json` cited `Polynomial.setOf_isRoot_finite` in module `Mathlib.FieldTheory.IsAlgClosed.Basic` as a Mathlib dependency. That lemma does not exist anywhere in Mathlib (verified by grepping the vendored Mathlib source and via `lake env lean`).
- The proof actually uses `Polynomial.finite_setOf_isRoot` (note reversed word order), defined in `Mathlib.Algebra.Polynomial.Roots`.
- Corrected the `mathlibDependencies` entry and the `assumptions` prose to cite the real lemma/module.

## Audit notes
- Re-verified the whole file: `lake env lean Proofs/DenumerabilityRationalsOQ04.lean` compiles with no errors.
- `#print axioms` on all 4 theorems (`nonzero_polys_countable`, `finitely_many_roots`, `algebraic_numbers_countable`, `algebraic_countable_type`) shows only `[propext, Classical.choice, Quot.sound]` — standard Mathlib background, matching the declared 0 axioms / 0 sorries.
- Investigated the file's "avoids the axiom of choice" narrative against the `Classical.choice` dependency shown above, but this turned out to be inconclusive/not a solid finding: even trivial Mathlib countability instances (e.g. `Countable (ℕ →₀ ℤ)`) pull in `Classical.choice` as an implementation artifact of the generic `Countable`/`Encodable` typeclass machinery, so its presence here doesn't reliably indicate the deeper "choiceless" mathematical claim is false. Not flagging that as an issue.
- No sorries, no axioms, decl names/counts (4 theorems, 1 definition) all match meta.json.

## Test plan
- [x] `lake env lean Proofs/DenumerabilityRationalsOQ04.lean` compiles cleanly
- [x] Confirmed `Polynomial.setOf_isRoot_finite` does not exist in vendored Mathlib source
- [x] Confirmed `Polynomial.finite_setOf_isRoot` exists in `Mathlib.Algebra.Polynomial.Roots` and matches the lemma actually invoked in the proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)