### PR TITLE
fix(launchers): reclaim same-branch worktree so singleton agents don't silently die (#39649)

### DIFF
--- a/scripts/aristotle/launch-agent.sh
+++ b/scripts/aristotle/launch-agent.sh
@@ -133,11 +133,19 @@ create_worktree() {
         git worktree remove "$WORKTREE_PATH" --force 2>/dev/null || rm -rf "$WORKTREE_PATH"
     fi
 
+    # Free the branch if a stale/locked/legacy worktree still holds it at another
+    # path (e.g. left by the /Volumes/Stripe migration). Without this, the
+    # `git branch -D` below is a no-op (can't delete a checked-out branch) and
+    # the `git worktree add` dies silently under `set -e` (issue #39649).
+    reclaim_branch_worktree "$BRANCH_NAME" "$WORKTREE_PATH" || \
+        log_worktree_fatal "$LOG_FILE" "could not reclaim '$BRANCH_NAME' from a stale worktree (see 'git worktree list')"
+
     git branch -D "$BRANCH_NAME" 2>/dev/null || true
 
     print_info "Creating worktree..."
     mkdir -p "$(dirname "$WORKTREE_PATH")"
-    git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main
+    git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main 2>/dev/null || \
+        log_worktree_fatal "$LOG_FILE" "worktree setup failed for '$BRANCH_NAME' at $WORKTREE_PATH (branch may be checked out elsewhere; see 'git worktree list')"
 
     # Symlink .lake for fast Lean builds
     if [[ -d "$REPO_ROOT/proofs/.lake" ]] && [[ -d "$WORKTREE_PATH/proofs" ]]; then

--- a/scripts/auditor/launch-agent.sh
+++ b/scripts/auditor/launch-agent.sh
@@ -108,13 +108,21 @@ create_worktree() {
 
     print_info "Creating worktree for auditor at $WORKTREE_PATH..."
 
-    # Try to create worktree
+    # Free the branch if a stale/locked/legacy worktree still holds it at another
+    # path (e.g. left by the /Volumes/Stripe migration); otherwise every add
+    # below fails and this backgrounded launcher dies silently (issue #39649).
+    reclaim_branch_worktree "$BRANCH_NAME" "$WORKTREE_PATH" || \
+        log_worktree_fatal "$LOG_FILE" "could not reclaim '$BRANCH_NAME' from a stale worktree (see 'git worktree list')"
+
+    # Try to create worktree. The final attempt must NOT die silently under
+    # `set -e` (backgrounded launcher, invisible non-zero exit — issue #39649).
     git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main 2>/dev/null || {
         # Branch might exist, try to use it
         git worktree add "$WORKTREE_PATH" "$BRANCH_NAME" 2>/dev/null || {
             # Remove and recreate branch
             git branch -D "$BRANCH_NAME" 2>/dev/null || true
-            git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main
+            git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main 2>/dev/null || \
+                log_worktree_fatal "$LOG_FILE" "worktree setup failed for '$BRANCH_NAME' at $WORKTREE_PATH (branch may be checked out elsewhere; see 'git worktree list')"
         }
     }
 

--- a/scripts/deploy/launch-agent.sh
+++ b/scripts/deploy/launch-agent.sh
@@ -122,13 +122,23 @@ create_worktree() {
 
     print_info "Creating worktree for deployer at $WORKTREE_PATH..."
 
-    # Try to create worktree
+    # Free the branch if a stale/locked/legacy worktree still holds it at another
+    # path (e.g. the /Volumes/Stripe migration orphaned the locked
+    # .loom/worktrees/deployer, blocking every `git worktree add` below and
+    # silently killing this launcher — the 7-day deployer outage, issue #39649).
+    reclaim_branch_worktree "$BRANCH_NAME" "$WORKTREE_PATH" || \
+        log_worktree_fatal "$LOG_FILE" "could not reclaim '$BRANCH_NAME' from a stale worktree (see 'git worktree list')"
+
+    # Try to create worktree. The final attempt must NOT die silently under
+    # `set -e`: the daemon backgrounds this launcher, so an un-logged non-zero
+    # exit leaves the deployer dead with no trace (issue #39649).
     git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main 2>/dev/null || {
         # Branch might exist, try to use it
         git worktree add "$WORKTREE_PATH" "$BRANCH_NAME" 2>/dev/null || {
             # Remove and recreate branch
             git branch -D "$BRANCH_NAME" 2>/dev/null || true
-            git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main
+            git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main 2>/dev/null || \
+                log_worktree_fatal "$LOG_FILE" "worktree setup failed for '$BRANCH_NAME' at $WORKTREE_PATH (branch may be checked out elsewhere; see 'git worktree list')"
         }
     }
 

--- a/scripts/lib/worktree-cleanup.sh
+++ b/scripts/lib/worktree-cleanup.sh
@@ -57,6 +57,151 @@ _wc_log() {
     return 0
 }
 
+# Always-on stderr logger for branch-reclaim actions. Unlike _wc_log this is NOT
+# gated by WORKTREE_CLEANUP_VERBOSE: reclaiming (or refusing to reclaim) a
+# branch worktree is a rare, significant action that must always be visible in
+# the daemon/keeper log. Goes to stderr so it never pollutes captured stdout.
+_wc_reclaim_log() {
+    echo "worktree-reclaim: $*" >&2
+    return 0
+}
+
+# reclaim_branch_worktree <branch> <target_path>
+#
+# A singleton agent (deployer, seeker, auditor, mechanic, aristotle,
+# peer-reviewer, ...) always checks out a FIXED branch (e.g. feature/deployer)
+# at a FIXED target worktree path. If that branch is already checked out at some
+# OTHER worktree path — typically a stale/locked/legacy path left behind by a
+# worktree-root migration (e.g. the /Volumes/Stripe move that orphaned the
+# locked .loom/worktrees/deployer, issue #39649) — then EVERY `git worktree add`
+# for the branch fails ("already checked out"/"a branch named ... already
+# exists"). Under `set -euo pipefail` the launcher then dies BEFORE creating its
+# tmux session. Because the daemon backgrounds the launcher (`launcher &`), the
+# non-zero exit is invisible and the agent stays dead across every respawn — the
+# 7-day deployer outage that motivated this helper.
+#
+# This function FREES the branch: it finds the worktree (if any) holding
+# <branch> at a path other than <target_path>, then unlock + `remove --force` +
+# prune so the branch can be checked out at the target.
+#
+# Deliberately different from remove_own_worktree, which PRESERVES locked
+# worktrees (guard 2). Here the locked legacy worktree is EXACTLY what must be
+# reclaimed, so locks are overridden by design. Safety is instead bounded by:
+#   - Only a worktree holding the SAME branch is ever touched.
+#   - The target path itself is never removed (it is the intended home; if the
+#     branch is already there this is a no-op success).
+#   - The primary/main checkout is never removed (a singleton-agent branch is
+#     never the main working tree; guarded explicitly).
+#   - Uncommitted or unpushed work triggers a LOUD warning but does NOT abort:
+#     these singleton branches are ephemeral (reset to origin/main every cycle),
+#     so a blocking stale worktree must be cleared for the agent to run at all.
+#     The warning makes the (rare) trade-off visible in the log.
+#
+# Return codes:
+#   0 - branch was already free, already at the target, or a blocking worktree
+#       was successfully reclaimed.
+#   1 - a blocking worktree was found but the branch is still held by a
+#       non-target worktree afterwards (reclaim failed). Callers should treat
+#       this as fatal and log it (do not let it die silently under set -e).
+reclaim_branch_worktree() {
+    local branch="$1"
+    local target_path="$2"
+    local ref="refs/heads/$branch"
+
+    if [[ -z "$branch" ]]; then
+        _wc_reclaim_log "no branch given; nothing to reclaim"
+        return 0
+    fi
+
+    local target_real
+    target_real="$(cd "$target_path" 2>/dev/null && pwd -P || echo "$target_path")"
+
+    # The primary/main checkout is the FIRST worktree in porcelain output. Never
+    # reclaim it even if it somehow reports the branch.
+    local main_path main_real
+    main_path="$(git worktree list --porcelain 2>/dev/null \
+        | awk '/^worktree /{print substr($0,10); exit}')"
+    main_real="$(cd "$main_path" 2>/dev/null && pwd -P || echo "$main_path")"
+
+    # Paths (0+) currently holding <branch>.
+    local holders
+    holders="$(git worktree list --porcelain 2>/dev/null | awk -v ref="$ref" '
+        /^worktree /{ p=substr($0,10) }
+        /^branch /{ if (substr($0,8)==ref) print p }')"
+
+    [[ -z "$holders" ]] && return 0
+
+    local holder holder_real
+    while IFS= read -r holder; do
+        [[ -z "$holder" ]] && continue
+        holder_real="$(cd "$holder" 2>/dev/null && pwd -P || echo "$holder")"
+
+        # Already at the intended home: nothing to reclaim.
+        [[ "$holder_real" == "$target_real" ]] && continue
+
+        # Never remove the primary/main checkout.
+        if [[ "$holder_real" == "$main_real" ]]; then
+            _wc_reclaim_log "refusing to reclaim main checkout ($holder) for branch $branch"
+            continue
+        fi
+
+        # Surface (but do not abort on) unique work.
+        if [[ -n "$(git -C "$holder" status --porcelain 2>/dev/null)" ]]; then
+            _wc_reclaim_log "WARNING: reclaiming worktree with UNCOMMITTED changes: $holder (branch $branch)"
+        fi
+        if git -C "$holder" rev-parse --abbrev-ref --symbolic-full-name '@{u}' &>/dev/null; then
+            if [[ -n "$(git -C "$holder" log --oneline '@{u}..HEAD' 2>/dev/null)" ]]; then
+                _wc_reclaim_log "WARNING: reclaiming worktree with UNPUSHED commits: $holder (branch $branch)"
+            fi
+        fi
+
+        _wc_reclaim_log "reclaiming stale worktree holding '$branch': $holder -> freeing for $target_path"
+        git worktree unlock "$holder" 2>/dev/null || true
+        if ! git worktree remove --force "$holder" 2>/dev/null; then
+            # git may refuse (already-gone dir, etc.); fall back to on-disk
+            # removal for a directory git no longer resolves.
+            rm -rf "$holder" 2>/dev/null || true
+        fi
+        git worktree prune 2>/dev/null || true
+    done <<< "$holders"
+
+    # Verify the branch is no longer held by any NON-target worktree.
+    local still hr
+    still="$(git worktree list --porcelain 2>/dev/null | awk -v ref="$ref" '
+        /^worktree /{ p=substr($0,10) }
+        /^branch /{ if (substr($0,8)==ref) print p }')"
+    while IFS= read -r holder; do
+        [[ -z "$holder" ]] && continue
+        hr="$(cd "$holder" 2>/dev/null && pwd -P || echo "$holder")"
+        [[ "$hr" == "$target_real" ]] && continue
+        _wc_reclaim_log "ERROR: branch '$branch' still checked out at $holder after reclaim"
+        return 1
+    done <<< "$still"
+
+    return 0
+}
+
+# log_worktree_fatal <log_file> <message...>
+#
+# Emit a FATAL launch-failure line to BOTH stderr and the given daemon/keeper
+# log, then `exit 1`. Singleton-agent launchers are backgrounded by the daemon
+# (`launcher &`), so a bare non-zero exit under `set -euo pipefail` is invisible
+# — the agent is dead but the daemon believes it launched (issue #39649). Route
+# every worktree-setup failure through this so a dead launcher always leaves a
+# trace in .loom/logs/<agent>.log.
+log_worktree_fatal() {
+    local log_file="$1"; shift
+    local msg="$*"
+    local line
+    line="$(date '+%Y-%m-%d %H:%M:%S') [launch-agent] FATAL: $msg"
+    echo "$line" >&2
+    if [[ -n "$log_file" ]]; then
+        mkdir -p "$(dirname "$log_file")" 2>/dev/null || true
+        echo "$line" >> "$log_file" 2>/dev/null || true
+    fi
+    exit 1
+}
+
 # would_remove_own_worktree <worktree_path>
 #
 # Predicate-only variant of the guards used by remove_own_worktree. Runs the

--- a/scripts/mechanic/launch-agent.sh
+++ b/scripts/mechanic/launch-agent.sh
@@ -108,13 +108,21 @@ create_worktree() {
 
     print_info "Creating worktree for mechanic at $WORKTREE_PATH..."
 
-    # Try to create worktree
+    # Free the branch if a stale/locked/legacy worktree still holds it at another
+    # path (e.g. left by the /Volumes/Stripe migration); otherwise every add
+    # below fails and this backgrounded launcher dies silently (issue #39649).
+    reclaim_branch_worktree "$BRANCH_NAME" "$WORKTREE_PATH" || \
+        log_worktree_fatal "$LOG_FILE" "could not reclaim '$BRANCH_NAME' from a stale worktree (see 'git worktree list')"
+
+    # Try to create worktree. The final attempt must NOT die silently under
+    # `set -e` (backgrounded launcher, invisible non-zero exit — issue #39649).
     git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main 2>/dev/null || {
         # Branch might exist, try to use it
         git worktree add "$WORKTREE_PATH" "$BRANCH_NAME" 2>/dev/null || {
             # Remove and recreate branch
             git branch -D "$BRANCH_NAME" 2>/dev/null || true
-            git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main
+            git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main 2>/dev/null || \
+                log_worktree_fatal "$LOG_FILE" "worktree setup failed for '$BRANCH_NAME' at $WORKTREE_PATH (branch may be checked out elsewhere; see 'git worktree list')"
         }
     }
 

--- a/scripts/peer-reviewer/launch-agent.sh
+++ b/scripts/peer-reviewer/launch-agent.sh
@@ -103,10 +103,17 @@ create_worktree() {
 
     print_info "Creating worktree for ${AGENT_ID} at $WORKTREE_PATH..."
 
+    # Free the branch if a stale/locked/legacy worktree still holds it at another
+    # path (e.g. left by the /Volumes/Stripe migration); otherwise every add
+    # below fails and this backgrounded launcher dies silently (issue #39649).
+    reclaim_branch_worktree "$BRANCH_NAME" "$WORKTREE_PATH" || \
+        log_worktree_fatal "$LOG_FILE" "could not reclaim '$BRANCH_NAME' from a stale worktree (see 'git worktree list')"
+
     git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main 2>/dev/null || {
         git worktree add "$WORKTREE_PATH" "$BRANCH_NAME" 2>/dev/null || {
             git branch -D "$BRANCH_NAME" 2>/dev/null || true
-            git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main
+            git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main 2>/dev/null || \
+                log_worktree_fatal "$LOG_FILE" "worktree setup failed for '$BRANCH_NAME' at $WORKTREE_PATH (branch may be checked out elsewhere; see 'git worktree list')"
         }
     }
 

--- a/scripts/research/launch-seeker.sh
+++ b/scripts/research/launch-seeker.sh
@@ -40,6 +40,11 @@ REPO_ROOT="$(find_repo_root)"
 # worktree.root override; default $REPO_ROOT/.loom/worktrees).
 # shellcheck source=../lib/worktree-root.sh
 source "$REPO_ROOT/scripts/lib/worktree-root.sh"
+# Shared branch-reclaim + fatal-logging helpers (reclaim_branch_worktree,
+# log_worktree_fatal) so a stale/locked worktree holding feature/seeker can't
+# silently kill this backgrounded launcher (issue #39649).
+# shellcheck source=../lib/worktree-cleanup.sh
+source "$REPO_ROOT/scripts/lib/worktree-cleanup.sh"
 WORKTREES_DIR="$(loom_worktree_root "$REPO_ROOT")"
 LOGS_DIR="$REPO_ROOT/.loom/logs"
 SIGNALS_DIR="$REPO_ROOT/.loom/signals"
@@ -120,13 +125,21 @@ create_worktree() {
 
     print_info "Creating worktree for seeker at $WORKTREE_PATH..."
 
-    # Try to create worktree
+    # Free the branch if a stale/locked/legacy worktree still holds it at another
+    # path (e.g. left by the /Volumes/Stripe migration); otherwise every add
+    # below fails and this backgrounded launcher dies silently (issue #39649).
+    reclaim_branch_worktree "$BRANCH_NAME" "$WORKTREE_PATH" || \
+        log_worktree_fatal "$LOG_FILE" "could not reclaim '$BRANCH_NAME' from a stale worktree (see 'git worktree list')"
+
+    # Try to create worktree. The final attempt must NOT die silently under
+    # `set -e` (backgrounded launcher, invisible non-zero exit — issue #39649).
     git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main 2>/dev/null || {
         # Branch might exist, try to use it
         git worktree add "$WORKTREE_PATH" "$BRANCH_NAME" 2>/dev/null || {
             # Remove and recreate branch
             git branch -D "$BRANCH_NAME" 2>/dev/null || true
-            git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main
+            git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main 2>/dev/null || \
+                log_worktree_fatal "$LOG_FILE" "worktree setup failed for '$BRANCH_NAME' at $WORKTREE_PATH (branch may be checked out elsewhere; see 'git worktree list')"
         }
     }
 


### PR DESCRIPTION
Closes #39649

## Problem
A singleton-agent launcher (`scripts/deploy/launch-agent.sh` and siblings) checks out a fixed branch (e.g. `feature/deployer`) at a fixed target worktree path via a 3-tier `create_worktree` fallback. When that branch was **already checked out at a DIFFERENT (stale/locked/legacy) path** — left behind by the `/Volumes/Stripe` worktree-root migration — all three `git worktree add` attempts failed and the final **un-redirected** add threw under `set -euo pipefail`, killing the launcher **before** it created its tmux session. The daemon backgrounds the launcher (`launcher &`), so the non-zero exit was invisible and the agent stayed dead across every 30-min respawn. This caused a **7-day deployer outage** with a growing, unnoticed PR backlog.

## Fix
Two new functions in the shared helper `scripts/lib/worktree-cleanup.sh`:

- **`reclaim_branch_worktree <branch> <target_path>`** — finds any worktree holding `<branch>` at a path other than the target (`git worktree list --porcelain`) and reclaims it: `git worktree unlock` + `remove --force` + `prune`, freeing the branch. It **deliberately overrides locks** (unlike `remove_own_worktree`, which preserves them) because the locked legacy worktree is exactly what must be reclaimed. Safety bounds:
  - only ever touches a worktree holding the **same branch**;
  - never removes the **target path** (no-op success if the branch is already there);
  - never removes the **primary/main checkout** (guarded explicitly);
  - **warns** (does not abort) on uncommitted/unpushed work — these singleton branches are reset to `origin/main` every cycle, so a blocking stale worktree must be cleared for the agent to run; the warning makes the rare trade-off visible.
- **`log_worktree_fatal <log_file> <msg>`** — logs a `FATAL` line to **both stderr and the daemon log**, then `exit 1`, so a dead launcher leaves a trace instead of dying silently.

Every singleton launcher now calls `reclaim_branch_worktree` before its `add` attempts and routes final `add` failure through `log_worktree_fatal`:
`deploy`, `auditor`, `mechanic`, `aristotle`, `peer-reviewer`, and `research/launch-seeker` (which also now sources the shared lib).

Untouched per issue constraints: `scripts/lean/launch.sh` and any `*token-registry*`.

## Testing
Isolated-repo test (bare remote + main checkout + locked legacy worktree holding `feature/deployer`), 13/13 assertions pass:
- control: bare `git worktree add` fails while the branch is held elsewhere;
- reclaim frees the branch (legacy dir removed) and the subsequent add **succeeds**;
- no-op success when the branch is already at target / not held anywhere;
- refuses to reclaim the main checkout;
- `log_worktree_fatal` writes to log **and** stderr and exits 1.

`bash -n` and `shellcheck` clean on all 7 files under macOS bash 3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
