### PR TITLE
fix(tokens): align token-registry scripts to email-derived stem convention (#41051)

### DIFF
--- a/scripts/agents/check-token-registry.sh
+++ b/scripts/agents/check-token-registry.sh
@@ -1,58 +1,89 @@
 #!/bin/bash
 #
-# check-token-registry.sh - Verify the .env account registry agrees with
-#                           the actual token files in .loom/tokens/.
+# check-token-registry.sh - Verify the account registry agrees with the
+#                           actual token files in .loom/tokens/.
 #
 # Background
 # ----------
-# The Claude account pool is declared in .env as parallel triples:
+# The Claude account pool is declared as numbered ACCOUNT_* entries. Under the
+# claude-monitor migration (#41033/#41044/#41045) the PRIMARY source is
+# ~/.claude-monitor/accounts.env, which carries EMAIL + KEY only:
 #
-#     ACCOUNT_EMAIL_N       human label for account N (e.g. robb@example.com)
-#     ACCOUNT_KEY_N         the OAuth token value for account N   (SECRET)
-#     ACCOUNT_TOKEN_FILE_N  the token filename the registry claims for account N
+#     ACCOUNT_EMAIL_N       account email  (e.g. robb@2amlogic.com)
+#     ACCOUNT_KEY_N         the OAuth token value                    (SECRET)
+#     ACCOUNT_TOKEN_FILE_N  OPTIONAL explicit token filename (legacy .env only)
 #
-# But scripts/agents/claude-wrapper.sh bootstraps and rotates tokens
-# POSITIONALLY: it materialises ACCOUNT_KEY_N into ".loom/tokens/agent-N.token"
-# and selects by globbing "*.token". It never reads ACCOUNT_TOKEN_FILE_N.
+# scripts/agents/claude-wrapper.sh bootstraps + selects tokens by an
+# EMAIL-DERIVED stem (loom 0.12.0 derive_token_filename, rjwalters/loom#3699):
+# strip '.' and '-' from the email local-part, append '-<first-domain-label>',
+# lowercase, drop unsafe chars, then '.token'. Examples:
 #
-# If ACCOUNT_TOKEN_FILE_N holds semantic names (robb-2amlogic.token, ...) that
-# don't exist on disk, the registry's account -> token-file mapping is a dead
-# column: anything that trusts it to locate a specific account's token gets a
-# path that isn't there. See issue #38967.
+#     robb@2amlogic.com             -> robb-2amlogic.token
+#     r.j.walters@gmail.com         -> rjwalters-gmail.token
+#     robb@integratedplasmonics.com -> robb-integratedplasmonics.token
+#     agent-1@2amlogic.com          -> agent1-2amlogic.token
+#     agent-2@2amlogic.com          -> agent2-2amlogic.token
 #
-# This script makes that rot loud instead of silent. It FAILS (non-zero exit)
-# when any referenced ACCOUNT_TOKEN_FILE_N has no matching file under
-# .loom/tokens/. Wire it into CI / a pre-flight lint so the columns can't
-# drift apart again unnoticed.
+# The wrapper's ranking.json consumer ("Strategy 0", _derive_token_stem) joins
+# ranking emails to on-disk tokens by the SAME derivation. If the canonical
+# token file for an account is missing, the join silently falls through to
+# round-robin -- disabling smart claude-monitor balancing with no error.
 #
-# The honest, wrapper-consistent value for ACCOUNT_TOKEN_FILE_N is
-# "agent-N.token" (see scripts/agents/sync-token-registry.sh to regenerate it).
+# This script makes that rot loud. For each account it computes the canonical
+# token filename the wrapper actually uses -- the declared ACCOUNT_TOKEN_FILE_N
+# if a source provides one, else the email-derived stem -- and FAILS (non-zero)
+# when that file is missing under .loom/tokens/. The OLD positional convention
+# (agent-N.token) is DEPRECATED: it is no longer emitted, and is flagged if a
+# source still declares it. See issue #41051 (supersedes #38967).
+#
+# Source resolution (matches the wrapper's PRIMARY source):
+#   1. $ENV_FILE if set in the environment (explicit override), else
+#   2. ~/.claude-monitor/accounts.env (dir overridable via
+#      LOOM_CLAUDE_MONITOR_DIR, mirroring loom monitor.claude_monitor_dir()),
+#      else
+#   3. legacy <repo>/.env.
 #
 # SECURITY: this script never reads, prints, or logs ACCOUNT_KEY_* values or
-# token file contents. It only inspects filenames and existence.
+# token file contents. It only inspects emails, filenames, and existence.
 #
 # Usage:
 #   ./scripts/agents/check-token-registry.sh          # human-readable report
 #   ./scripts/agents/check-token-registry.sh --quiet  # only print on failure
 #
 # Exit codes:
-#   0  every ACCOUNT_TOKEN_FILE_N resolves to an existing token file
-#   1  one or more referenced token files are missing (registry is stale)
-#   2  usage / environment error (no .env, no tokens dir, etc.)
+#   0  every account's canonical token file exists (or no accounts declared)
+#   1  one or more canonical token files are missing (registry is stale)
+#   2  usage / environment error
 #
 
 set -uo pipefail
 
 REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
-ENV_FILE="${ENV_FILE:-$REPO_ROOT/.env}"
 TOKENS_DIR="${TOKENS_DIR:-$REPO_ROOT/.loom/tokens}"
 QUIET=false
+
+# Resolve the claude-monitor PRIMARY source (loom monitor.claude_monitor_dir()).
+if [[ -n "${LOOM_CLAUDE_MONITOR_DIR:-}" ]]; then
+    _MONITOR_ACCTS="$LOOM_CLAUDE_MONITOR_DIR/accounts.env"
+else
+    _MONITOR_ACCTS="$HOME/.claude-monitor/accounts.env"
+fi
+
+# Source resolution: explicit $ENV_FILE wins, else claude-monitor primary, else
+# legacy repo .env.
+if [[ -n "${ENV_FILE:-}" ]]; then
+    ENV_FILE="$ENV_FILE"
+elif [[ -f "$_MONITOR_ACCTS" ]]; then
+    ENV_FILE="$_MONITOR_ACCTS"
+else
+    ENV_FILE="$REPO_ROOT/.env"
+fi
 
 for arg in "$@"; do
     case "$arg" in
         --quiet|-q) QUIET=true ;;
         --help|-h)
-            sed -n '2,45p' "$0" | sed 's/^# \{0,1\}//'
+            sed -n '2,58p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *)
@@ -64,52 +95,94 @@ done
 
 say() { $QUIET || echo "$@"; }
 
+# loom 0.12.0 derive_token_filename (#3699): strip '.' and '-' from the email
+# local-part, append '-<first-domain-label>', lowercase, drop unsafe chars.
+# MUST match scripts/agents/claude-wrapper.sh (_bootstrap_derive_stem /
+# _derive_token_stem) exactly.
+derive_token_stem() {
+    local _email="$1" _local _domain _label
+    [[ "$_email" == *@* ]] || return 1
+    _local="${_email%@*}"
+    _domain="${_email#*@}"
+    _label="${_domain%%.*}"
+    [[ -n "$_local" && -n "$_label" ]] || return 1
+    _local=$(printf '%s' "$_local" | tr -d '.-')
+    printf '%s-%s' "$_local" "$_label" \
+        | tr '[:upper:]' '[:lower:]' \
+        | tr -cd 'a-z0-9._-'
+}
+
 if [[ ! -f "$ENV_FILE" ]]; then
-    echo "[check-token-registry] No .env file at $ENV_FILE — nothing to check." >&2
-    # Absence of .env is not a failure (e.g. a fresh clone / CI without secrets).
+    echo "[check-token-registry] No account source at $ENV_FILE — nothing to check." >&2
+    # Absence of a source is not a failure (e.g. a fresh clone / CI without secrets).
     exit 0
 fi
 
-if ! grep -q '^ACCOUNT_TOKEN_FILE_[0-9]\+=' "$ENV_FILE" 2>/dev/null; then
-    say "[check-token-registry] .env declares no ACCOUNT_TOKEN_FILE_* entries — nothing to check."
+# Enumerate account indices from ANY declared ACCOUNT_(EMAIL|KEY|TOKEN_FILE)_N.
+_indices=$(grep -oE '^ACCOUNT_(EMAIL|KEY|TOKEN_FILE)_[0-9]+=' "$ENV_FILE" 2>/dev/null \
+    | sed -E 's/^ACCOUNT_(EMAIL|KEY|TOKEN_FILE)_([0-9]+)=/\2/' | sort -un)
+
+if [[ -z "$_indices" ]]; then
+    say "[check-token-registry] $ENV_FILE declares no ACCOUNT_* entries — nothing to check."
     exit 0
 fi
+
+# Strip surrounding quotes / whitespace from a value (NEVER a secret here).
+_clean() {
+    local _v="$1"
+    _v="${_v%\"}"; _v="${_v#\"}"
+    _v="${_v%\'}"; _v="${_v#\'}"
+    printf '%s' "$_v" | tr -d '[:space:]'
+}
 
 missing=0
 checked=0
 declare -a referenced_basenames=()
 
-# Read each ACCOUNT_TOKEN_FILE_N=value line. Values may be quoted and may be a
-# bare basename or a path; we resolve bare names against $TOKENS_DIR.
-while IFS='=' read -r key val; do
-    n="${key#ACCOUNT_TOKEN_FILE_}"
-    [[ "$n" =~ ^[0-9]+$ ]] || continue
-    # Strip surrounding quotes / whitespace from the value (NOT a secret).
-    val="${val%\"}"; val="${val#\"}"
-    val="${val%\'}"; val="${val#\'}"
-    val="$(printf '%s' "$val" | tr -d '[:space:]')"
-    [[ -z "$val" ]] && continue
+for n in $_indices; do
+    _email=$(_clean "$(grep -E "^ACCOUNT_EMAIL_${n}=" "$ENV_FILE" | head -1 | cut -d= -f2-)")
+    _file=$(_clean "$(grep -E "^ACCOUNT_TOKEN_FILE_${n}=" "$ENV_FILE" | head -1 | cut -d= -f2-)")
+
+    # Canonical filename the wrapper uses: prefer a declared ACCOUNT_TOKEN_FILE_N,
+    # else derive from ACCOUNT_EMAIL_N. (Never agent-N.token.)
+    if [[ -n "$_file" ]]; then
+        _canon="$_file"
+    elif [[ -n "$_email" ]]; then
+        _stem=$(derive_token_stem "$_email") || _stem=""
+        if [[ -z "$_stem" ]]; then
+            echo "  MISS  account $n ('$_email'): cannot derive token filename" >&2
+            missing=$((missing + 1))
+            continue
+        fi
+        _canon="${_stem}.token"
+    else
+        # Neither a declared file nor an email: nothing resolvable for this index.
+        continue
+    fi
+
+    # Flag the deprecated positional convention if a source still declares it.
+    if [[ "$_canon" =~ ^agent-[0-9]+\.token$ ]]; then
+        echo "  WARN  account $n -> $_canon  [deprecated positional name; expected email-derived stem]" >&2
+    fi
 
     checked=$((checked + 1))
-
-    if [[ "$val" = /* ]]; then
-        resolved="$val"
+    if [[ "$_canon" = /* ]]; then
+        resolved="$_canon"
     else
-        resolved="$TOKENS_DIR/$val"
+        resolved="$TOKENS_DIR/$_canon"
     fi
     referenced_basenames+=("$(basename "$resolved")")
 
     if [[ -f "$resolved" ]]; then
-        say "  ok    account $n -> $val"
+        say "  ok    account $n (${_email:-?}) -> $_canon"
     else
-        echo "  MISS  account $n (ACCOUNT_EMAIL_$n) -> $val  [no such file under .loom/tokens/]" >&2
+        echo "  MISS  account $n (${_email:-?}) -> $_canon  [no such file under .loom/tokens/]" >&2
         missing=$((missing + 1))
     fi
-done < <(grep '^ACCOUNT_TOKEN_FILE_[0-9]\+=' "$ENV_FILE")
+done
 
-# Report token files on disk that no registry entry points at (orphans). This
-# is informational only and does not affect the exit code — the wrapper globs
-# the directory, so extra files are used, they're just undocumented.
+# Report token files on disk that no account points at (orphans). Informational
+# only — the wrapper globs the directory, so extra files are still used.
 if [[ -d "$TOKENS_DIR" ]]; then
     while IFS= read -r tok; do
         [[ -e "$tok" ]] || continue
@@ -118,19 +191,20 @@ if [[ -d "$TOKENS_DIR" ]]; then
         for ref in "${referenced_basenames[@]:-}"; do
             [[ "$ref" == "$b" ]] && { found=true; break; }
         done
-        $found || say "  note  $b exists on disk but no ACCOUNT_TOKEN_FILE_* references it"
+        $found || say "  note  $b exists on disk but no account references it"
     done < <(find "$TOKENS_DIR" -maxdepth 1 -name '*.token' 2>/dev/null | sort)
 fi
 
 if [[ $missing -gt 0 ]]; then
     echo "" >&2
-    echo "[check-token-registry] FAIL: $missing of $checked ACCOUNT_TOKEN_FILE_* entries" >&2
-    echo "  point at token files that do not exist under $TOKENS_DIR." >&2
-    echo "  The registry column is stale (see issue #38967)." >&2
-    echo "  Fix: run scripts/agents/sync-token-registry.sh to regenerate the" >&2
-    echo "  ACCOUNT_TOKEN_FILE_* values to the real positional agent-N.token names." >&2
+    echo "[check-token-registry] FAIL: $missing of $checked account(s) resolve to a" >&2
+    echo "  canonical token file that does not exist under $TOKENS_DIR." >&2
+    echo "  The registry is stale, or the pool has not been bootstrapped." >&2
+    echo "  Fix: re-run the wrapper to re-bootstrap the pool, or run" >&2
+    echo "  scripts/agents/sync-token-registry.sh to normalize ACCOUNT_TOKEN_FILE_*" >&2
+    echo "  to the email-derived convention." >&2
     exit 1
 fi
 
-say "[check-token-registry] OK: all $checked ACCOUNT_TOKEN_FILE_* entries resolve to existing token files."
+say "[check-token-registry] OK: all $checked account(s) resolve to existing token files."
 exit 0

--- a/scripts/agents/sync-token-registry.sh
+++ b/scripts/agents/sync-token-registry.sh
@@ -1,46 +1,98 @@
 #!/bin/bash
 #
-# sync-token-registry.sh - Make the .env account registry honest.
+# sync-token-registry.sh - Normalize a registry's ACCOUNT_TOKEN_FILE_* column
+#                          to the EMAIL-DERIVED token filename convention.
 #
-# Rewrites every ACCOUNT_TOKEN_FILE_N value in .env to the real, positional
-# token filename that scripts/agents/claude-wrapper.sh actually creates and
-# reads: "agent-N.token" (the same N as the account's ACCOUNT_KEY_N /
-# ACCOUNT_EMAIL_N). After running this, the registry's account -> token-file
-# mapping matches what is on disk, and check-token-registry.sh passes.
+# Under the claude-monitor migration (#41033/#41044/#41045) the token pool is
+# named by an EMAIL-DERIVED stem, NOT a positional agent-N.token. The wrapper
+# (scripts/agents/claude-wrapper.sh) bootstraps + selects tokens via loom
+# 0.12.0's derive_token_filename (rjwalters/loom#3699): strip '.' and '-' from
+# the email local-part, append '-<first-domain-label>', lowercase, drop unsafe
+# chars, then '.token'. Examples:
 #
-# Why this and not a rename of the token files?
-#   The token pool is LIVE. The wrapper bootstraps ACCOUNT_KEY_N into
-#   agent-N.token and rotates by globbing "*.token". Renaming those files (or
-#   changing the wrapper's naming) risks breaking the running pool. The safe
-#   fix is to correct the *documentation* column so it describes reality.
-#   See issue #38967.
+#     robb@2amlogic.com             -> robb-2amlogic.token
+#     r.j.walters@gmail.com         -> rjwalters-gmail.token
+#     robb@integratedplasmonics.com -> robb-integratedplasmonics.token
+#     agent-1@2amlogic.com          -> agent1-2amlogic.token
+#     agent-2@2amlogic.com          -> agent2-2amlogic.token
+#
+# The wrapper's ranking.json consumer ("Strategy 0") joins ranking emails to
+# on-disk tokens by this SAME derivation. If a registry's ACCOUNT_TOKEN_FILE_N
+# names a file that doesn't match (e.g. the OLD agent-N.token positional name),
+# the join finds nothing and silently falls through to round-robin, disabling
+# claude-monitor balancing. This script keeps the column honest.
+#
+# What it does
+# ------------
+# For each account N in the target registry that declares ACCOUNT_TOKEN_FILE_N,
+# it computes the canonical filename and rewrites the value if they differ:
+#   - If ACCOUNT_EMAIL_N is present, the canonical name is the email-derived
+#     stem ('<stem>.token'). This is the normal case and CORRECTS any stale /
+#     deprecated agent-N.token value.
+#   - If ACCOUNT_EMAIL_N is absent (nothing to derive from), the declared value
+#     is preferred (left unchanged).
+# It NEVER writes the deprecated positional agent-N.token name.
+#
+# Note: the claude-monitor PRIMARY source (~/.claude-monitor/accounts.env) is
+# EMAIL + KEY only and declares NO ACCOUNT_TOKEN_FILE_* column by design -- the
+# wrapper derives filenames from email. Running this against such a source is a
+# no-op (nothing to sync). It is meant for a LEGACY registry (e.g. <repo>/.env)
+# that still carries an ACCOUNT_TOKEN_FILE_* column.
+#
+# Why rewrite the column and not rename the token files?
+#   The token pool is LIVE. The wrapper writes/globs the email-derived .token
+#   files. Renaming those (or changing the wrapper) risks breaking the running
+#   pool. The safe fix is to correct the registry's documentation column so it
+#   describes reality. See issue #41051 (supersedes #38967).
 #
 # SECURITY
-#   - Operates ONLY on the ACCOUNT_TOKEN_FILE_N lines (filenames, never secrets).
+#   - Operates ONLY on ACCOUNT_TOKEN_FILE_N lines (filenames, never secrets).
 #   - Never reads, prints, or modifies ACCOUNT_KEY_N values.
-#   - .env is gitignored and must never be committed. This script edits it in
-#     place (with a timestamped .bak backup); it does not touch git.
+#   - The target file is gitignored and must never be committed. This script
+#     edits it in place (with a timestamped .bak backup); it does not touch git.
+#
+# Source resolution (matches the wrapper's PRIMARY source):
+#   1. $ENV_FILE if set in the environment (explicit override), else
+#   2. ~/.claude-monitor/accounts.env (dir overridable via
+#      LOOM_CLAUDE_MONITOR_DIR), else
+#   3. legacy <repo>/.env.
 #
 # Usage:
-#   ./scripts/agents/sync-token-registry.sh            # apply (writes .env)
+#   ./scripts/agents/sync-token-registry.sh            # apply (writes the file)
 #   ./scripts/agents/sync-token-registry.sh --dry-run  # preview, write nothing
 #
 # Exit codes:
-#   0  applied (or dry-run completed)
+#   0  applied (or dry-run completed / nothing to do)
 #   2  usage / environment error
 #
 
 set -uo pipefail
 
 REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
-ENV_FILE="${ENV_FILE:-$REPO_ROOT/.env}"
 DRY_RUN=false
+
+# Resolve the claude-monitor PRIMARY source (loom monitor.claude_monitor_dir()).
+if [[ -n "${LOOM_CLAUDE_MONITOR_DIR:-}" ]]; then
+    _MONITOR_ACCTS="$LOOM_CLAUDE_MONITOR_DIR/accounts.env"
+else
+    _MONITOR_ACCTS="$HOME/.claude-monitor/accounts.env"
+fi
+
+# Source resolution: explicit $ENV_FILE wins, else claude-monitor primary, else
+# legacy repo .env.
+if [[ -n "${ENV_FILE:-}" ]]; then
+    ENV_FILE="$ENV_FILE"
+elif [[ -f "$_MONITOR_ACCTS" ]]; then
+    ENV_FILE="$_MONITOR_ACCTS"
+else
+    ENV_FILE="$REPO_ROOT/.env"
+fi
 
 for arg in "$@"; do
     case "$arg" in
         --dry-run|-n) DRY_RUN=true ;;
         --help|-h)
-            sed -n '2,33p' "$0" | sed 's/^# \{0,1\}//'
+            sed -n '2,68p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *)
@@ -50,13 +102,40 @@ for arg in "$@"; do
     esac
 done
 
+# loom 0.12.0 derive_token_filename (#3699): strip '.' and '-' from the email
+# local-part, append '-<first-domain-label>', lowercase, drop unsafe chars.
+# MUST match scripts/agents/claude-wrapper.sh (_bootstrap_derive_stem /
+# _derive_token_stem) exactly.
+derive_token_stem() {
+    local _email="$1" _local _domain _label
+    [[ "$_email" == *@* ]] || return 1
+    _local="${_email%@*}"
+    _domain="${_email#*@}"
+    _label="${_domain%%.*}"
+    [[ -n "$_local" && -n "$_label" ]] || return 1
+    _local=$(printf '%s' "$_local" | tr -d '.-')
+    printf '%s-%s' "$_local" "$_label" \
+        | tr '[:upper:]' '[:lower:]' \
+        | tr -cd 'a-z0-9._-'
+}
+
+# Strip surrounding quotes / whitespace from a value (NEVER a secret here).
+_clean() {
+    local _v="$1"
+    _v="${_v%\"}"; _v="${_v#\"}"
+    _v="${_v%\'}"; _v="${_v#\'}"
+    printf '%s' "$_v" | tr -d '[:space:]'
+}
+
 if [[ ! -f "$ENV_FILE" ]]; then
-    echo "[sync-token-registry] No .env file at $ENV_FILE" >&2
+    echo "[sync-token-registry] No account source at $ENV_FILE" >&2
     exit 2
 fi
 
 if ! grep -q '^ACCOUNT_TOKEN_FILE_[0-9]\+=' "$ENV_FILE" 2>/dev/null; then
-    echo "[sync-token-registry] .env declares no ACCOUNT_TOKEN_FILE_* entries — nothing to do." >&2
+    echo "[sync-token-registry] $ENV_FILE declares no ACCOUNT_TOKEN_FILE_* entries —" >&2
+    echo "  nothing to sync. (Under claude-monitor, token filenames are email-derived;" >&2
+    echo "  the accounts.env source carries EMAIL + KEY only, by design.)" >&2
     exit 0
 fi
 
@@ -67,11 +146,22 @@ trap 'rm -f "$tmp"' EXIT
 while IFS= read -r line || [[ -n "$line" ]]; do
     if [[ "$line" =~ ^ACCOUNT_TOKEN_FILE_([0-9]+)= ]]; then
         n="${BASH_REMATCH[1]}"
-        want="agent-${n}.token"
-        # Current value (strip quotes/space) for reporting — never a secret.
-        cur="${line#*=}"
-        cur="${cur%\"}"; cur="${cur#\"}"; cur="${cur%\'}"; cur="${cur#\'}"
-        cur="$(printf '%s' "$cur" | tr -d '[:space:]')"
+        cur="$(_clean "${line#*=}")"
+
+        # Canonical name: email-derived when an ACCOUNT_EMAIL_N exists (the
+        # normal case; corrects deprecated agent-N.token). Otherwise keep the
+        # declared value (prefer it — nothing to derive from). Never agent-N.token.
+        _email=$(_clean "$(grep -E "^ACCOUNT_EMAIL_${n}=" "$ENV_FILE" | head -1 | cut -d= -f2-)")
+        want="$cur"
+        if [[ -n "$_email" ]]; then
+            _stem=$(derive_token_stem "$_email") || _stem=""
+            if [[ -n "$_stem" ]]; then
+                want="${_stem}.token"
+            else
+                echo "  warn  account $n ('$_email'): cannot derive; keeping '$cur'" >&2
+            fi
+        fi
+
         if [[ "$cur" != "$want" ]]; then
             echo "  account $n: $cur -> $want"
             changes=$((changes + 1))
@@ -88,7 +178,7 @@ if [[ $changes -eq 0 ]]; then
 fi
 
 if $DRY_RUN; then
-    echo "[sync-token-registry] --dry-run: $changes entr(y/ies) would change; .env left untouched."
+    echo "[sync-token-registry] --dry-run: $changes entr(y/ies) would change; file left untouched."
     exit 0
 fi
 


### PR DESCRIPTION
## Summary

`sync-token-registry.sh` and `check-token-registry.sh` still enforced/documented the **retired positional** convention (`ACCOUNT_KEY_N` → `agent-N.token`, ignoring `ACCOUNT_TOKEN_FILE_N`). Under the claude-monitor migration (#41033/#41044/#41045) the wrapper (`scripts/agents/claude-wrapper.sh`) bootstraps and selects tokens by an **email-derived stem** (loom 0.12.0 `derive_token_filename`). The stale scripts were inconsistent with the live pool: they would flag it wrongly, and if `sync` were applied it would rewrite `ACCOUNT_TOKEN_FILE_*` back to `agent-N.token`, breaking Strategy 0's email→stem ranking join (silent fallthrough to round-robin).

## Changes

- Both scripts now carry `derive_token_stem()` — identical to the wrapper's `_bootstrap_derive_stem` / `_derive_token_stem` (strip `.`/`-` from local-part, append `-<first-domain-label>`, lowercase, drop unsafe chars, `.token`).
- Canonical filename = declared `ACCOUNT_TOKEN_FILE_N` (prefer it), else derive from `ACCOUNT_EMAIL_N`. **Never emits `agent-N.token`.**
- Account source resolved like the wrapper's PRIMARY: `$ENV_FILE` override → `~/.claude-monitor/accounts.env` (`LOOM_CLAUDE_MONITOR_DIR`-aware) → legacy `<repo>/.env`.
- `check`: iterates accounts by email index, verifies the canonical token exists under `.loom/tokens/`, warns on any still-declared deprecated `agent-N.token`.
- `sync`: normalizes `ACCOUNT_TOKEN_FILE_*` to the email-derived name (corrects stale `agent-N.token`; keeps a declared value only when there's no email to derive from); no-ops on the EMAIL+KEY-only `accounts.env`. Keys are never read or modified.
- All stale docs/comments refreshed; supersedes #38967. The live wrapper contains no references to these scripts, so no wrapper change was needed.

## Verification

Against a stub of the live `~/.claude-monitor/accounts.env`, the five accounts derive to exactly the live pool names:

| email | derived token |
|---|---|
| robb@2amlogic.com | robb-2amlogic.token |
| r.j.walters@gmail.com | rjwalters-gmail.token |
| robb@integratedplasmonics.com | robb-integratedplasmonics.token |
| agent-1@2amlogic.com | agent1-2amlogic.token |
| agent-2@2amlogic.com | agent2-2amlogic.token |

- `check` passes when email-derived tokens exist; fails (exit 1) when only `agent-N.token` files are on disk.
- `sync` corrects a legacy `.env`'s `agent-N.token` values to the email-derived names, is idempotent, keeps `ACCOUNT_KEY_*` untouched, and no-ops on the EMAIL+KEY-only `accounts.env`.
- `bash -n` passes on both scripts (bash 3.2 / macOS).

No callers exist (grep of the repo); `scripts/lean/launch.sh` and `scripts/deploy/*` untouched.

Closes #41051

🤖 Generated with [Claude Code](https://claude.com/claude-code)
