### PR TITLE
feat(lean-daemon): detect & alert when a configured agent has no running session

### DIFF
--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -74,6 +74,14 @@ STUCK_CPU_THRESHOLD="0.5"
 DEFAULT_DAEMON_INTERVAL=60
 RESPAWN_COOLDOWN_SECONDS=300  # 5 minutes between respawns of same agent
 
+# Persistent-missing-session alerting (#39652). A configured agent whose session
+# is absent for a single cycle is routine (mid-respawn, cooldown). Only after
+# this many CONSECUTIVE cycles below target does the daemon escalate from a
+# routine "pool gap" INFO to a MISSING WARN and surface a red row in
+# `/lean health` / `/lean status`. Kept small so a genuine multi-cycle outage
+# (e.g. the deployer that went unnoticed for 7 days) is caught within minutes.
+MISSING_SESSION_ALERT_CYCLES=3
+
 # Default pool sizes
 # Balanced team: 5 researchers (continuous), 8 support agents (sleeping between cycles)
 # ~72 active min/hr across 9 accounts = ~8 min/hr per account
@@ -1104,6 +1112,44 @@ get_agent_status() {
     echo "RUNNING"
 }
 
+# Helper: Render red MISSING rows for configured agents with no live session (#39652).
+# Compares the daemon's pool config (STATE_FILE .config) against live tmux
+# sessions and prints a table row for each configured-but-absent agent. Sets
+# the global MISSING_AGENTS_FOUND to the number of missing agents. Callable even
+# when NO other agent sessions are live, so a configured agent that is the only
+# thing that should be running (and isn't) is still surfaced.
+MISSING_AGENTS_FOUND=0
+print_missing_agent_rows() {
+    MISSING_AGENTS_FOUND=0
+    { [[ -f "$STATE_FILE" ]] && jq empty "$STATE_FILE" >/dev/null 2>&1; } || return 0
+
+    local aristotle_scaled_local=0
+    is_aristotle_scaled_to_zero && aristotle_scaled_local=1
+
+    local htype hcfg hrun hcyc cyc_note
+    for htype in enricher researcher aristotle auditor seeker deployer herald mechanic tester; do
+        hcfg=$(jq -r ".config.${htype} // 0" "$STATE_FILE" 2>/dev/null || echo 0)
+        [[ "$hcfg" =~ ^[0-9]+$ ]] || hcfg=0
+        [[ "$hcfg" -ge 1 ]] || continue
+        # Aristotle scale-to-zero (issue #22471) is an intentional absence.
+        if [[ "$htype" == "aristotle" ]] && [[ "$aristotle_scaled_local" -eq 1 ]]; then
+            continue
+        fi
+        hrun=$(count_agent_sessions "$htype")
+        if [[ "$hrun" -lt "$hcfg" ]]; then
+            MISSING_AGENTS_FOUND=$((MISSING_AGENTS_FOUND + 1))
+            # Consecutive-cycle count recorded by the daemon, if available.
+            hcyc=$(jq -r --arg t "$htype" \
+                '(.missing_agents // []) | map(select(.type == $t)) | .[0].missing_cycles // empty' \
+                "$STATE_FILE" 2>/dev/null || echo "")
+            cyc_note=""
+            [[ -n "$hcyc" ]] && cyc_note=" ${hcyc} cycles"
+            printf "%-22s %-8s %-10s %-7s %-5s %-6s " "$htype" "-" "-" "-" "-" "-"
+            echo -e "${RED}MISSING${NC} (configured:${hcfg} running:${hrun})${cyc_note}"
+        fi
+    done
+}
+
 # Command: health - Show agent process health
 cmd_health() {
     echo -e "${BOLD}Agent Health Check${NC}"
@@ -1113,6 +1159,17 @@ cmd_health() {
     sessions=$(get_all_agent_sessions)
 
     if [[ -z "$sessions" ]]; then
+        # No live sessions at all -- but configured agents may still be MISSING
+        # (e.g. the whole pool died). Surface those before returning (#39652).
+        print_missing_agent_rows
+        if [[ "$MISSING_AGENTS_FOUND" -gt 0 ]]; then
+            echo ""
+            echo -e "Summary: ${RED}$MISSING_AGENTS_FOUND missing${NC} (configured agents with no live session)"
+            echo ""
+            echo -e "${YELLOW}Configured agent(s) have no live session. The launcher may be dying silently (#39649).${NC}"
+            echo -e "${YELLOW}Check the daemon log ($DAEMON_LOG_FILE) and restart the daemon if needed.${NC}"
+            return 0
+        fi
         echo "No agent tmux sessions found."
         return 0
     fi
@@ -1246,6 +1303,12 @@ cmd_health() {
         echo -e "${YELLOW}SCALED_TO_ZERO${NC} (idle queue)"
     fi
 
+    # Surface CONFIGURED agents that have no live session (#39652). Previously
+    # health simply omitted them (get_all_agent_sessions only enumerates live
+    # sessions), which let the deployer stay dead for 7 days unnoticed.
+    print_missing_agent_rows
+    local missing_count=$MISSING_AGENTS_FOUND
+
     echo ""
     local summary="Summary: ${GREEN}$running_count running${NC}, ${completed_count} completed"
     if [[ $idle_count -gt 0 ]]; then
@@ -1257,6 +1320,9 @@ cmd_health() {
     if [[ $failing_count -gt 0 ]]; then
         summary+=", ${RED}$failing_count failing${NC}"
     fi
+    if [[ $missing_count -gt 0 ]]; then
+        summary+=", ${RED}$missing_count missing${NC}"
+    fi
     summary+=", ${RED}$stuck_count stuck${NC}"
     echo -e "$summary"
 
@@ -1267,6 +1333,11 @@ cmd_health() {
     if [[ $failing_count -gt 0 ]]; then
         echo ""
         echo -e "${YELLOW}Failing agents detected (${CONSECUTIVE_FAILURE_THRESHOLD}+ consecutive failures). Check logs and restart.${NC}"
+    fi
+    if [[ $missing_count -gt 0 ]]; then
+        echo ""
+        echo -e "${YELLOW}Configured agent(s) have no live session. The launcher may be dying silently (#39649).${NC}"
+        echo -e "${YELLOW}Check the daemon log ($DAEMON_LOG_FILE) and restart the daemon if needed.${NC}"
     fi
 
     return $stuck_count
@@ -1343,6 +1414,82 @@ set_last_respawn() {
         LAST_RESPAWN_TIME[$session]="$epoch"
     else
         echo "$epoch" > "/tmp/lean-daemon-respawn-${session}"
+    fi
+}
+
+# Consecutive-cycles-missing counter per agent type (#39652). Same bash 4+
+# associative array with a bash 3 /tmp fallback as LAST_RESPAWN_TIME above.
+declare -A MISSING_CYCLE_COUNT 2>/dev/null || true
+
+# Helper: Get consecutive-missing cycle count for an agent type
+get_missing_cycles() {
+    local type="$1"
+    if declare -p MISSING_CYCLE_COUNT &>/dev/null 2>&1; then
+        echo "${MISSING_CYCLE_COUNT[$type]:-0}"
+    else
+        local cache_file="/tmp/lean-daemon-missing-${type}"
+        if [[ -f "$cache_file" ]]; then cat "$cache_file"; else echo "0"; fi
+    fi
+}
+
+# Helper: Set consecutive-missing cycle count for an agent type
+set_missing_cycles() {
+    local type="$1"
+    local count="$2"
+    if declare -p MISSING_CYCLE_COUNT &>/dev/null 2>&1; then
+        MISSING_CYCLE_COUNT[$type]="$count"
+    else
+        echo "$count" > "/tmp/lean-daemon-missing-${type}"
+    fi
+}
+
+# Helper: Count live tmux sessions for an agent type (#39652).
+# Used by both the daemon detection loop and `cmd_health` so the two agree on
+# what "running" means for each agent family.
+count_agent_sessions() {
+    local type="$1"
+    local count=0
+    local i
+    case "$type" in
+        enricher)
+            for i in $(seq 1 "$MAX_ENRICHER"); do
+                tmux has-session -t "enricher-$i" 2>/dev/null && count=$((count + 1))
+            done ;;
+        researcher)
+            for i in $(seq 1 "$MAX_RESEARCHER"); do
+                tmux has-session -t "researcher-$i" 2>/dev/null && count=$((count + 1))
+            done ;;
+        mechanic)
+            for i in 1 2 3; do
+                tmux has-session -t "mechanic-$i" 2>/dev/null && count=$((count + 1))
+            done
+            tmux has-session -t "mechanic-agent" 2>/dev/null && count=$((count + 1)) ;;
+        aristotle) tmux has-session -t "aristotle-agent" 2>/dev/null && count=1 ;;
+        auditor)   tmux has-session -t "auditor-agent" 2>/dev/null && count=1 ;;
+        seeker)    tmux has-session -t "seeker-agent" 2>/dev/null && count=1 ;;
+        deployer)  tmux has-session -t "deployer" 2>/dev/null && count=1 ;;
+        herald)    tmux has-session -t "herald-agent" 2>/dev/null && count=1 ;;
+        tester)    tmux has-session -t "tester-agent" 2>/dev/null && count=1 ;;
+    esac
+    echo "$count"
+}
+
+# Helper: Persist the set of persistently-missing agents to STATE_FILE (#39652).
+# Consumed by `cmd_health` / `status.sh` so the absence stays visible between
+# daemon cycles and after the daemon exits. Argument is a compact JSON array of
+# {type, configured, running, missing_cycles} objects (may be "[]").
+write_missing_agents() {
+    local missing_json="$1"
+    [[ -f "$STATE_FILE" ]] || return 0
+    jq empty "$STATE_FILE" >/dev/null 2>&1 || return 0
+    local tmp
+    tmp=$(mktemp)
+    if jq --argjson missing "$missing_json" \
+          '.missing_agents = $missing' \
+          "$STATE_FILE" > "$tmp" 2>/dev/null; then
+        mv "$tmp" "$STATE_FILE"
+    else
+        rm -f "$tmp"
     fi
 }
 
@@ -2447,6 +2594,62 @@ cmd_daemon() {
             done
         fi
 
+        # 2c. Persistent-missing-session detection & alerting (#39652).
+        # The pool-gap respawns above try to bring absent agents back every
+        # cycle, but when the launcher dies silently (#39649) a CONFIGURED
+        # agent can stay session-less indefinitely with only routine INFO
+        # "pool gap" noise -- exactly how the deployer went unnoticed for 7
+        # days. Track how many CONSECUTIVE cycles each configured agent has
+        # stayed below target; once it crosses the threshold, escalate to a
+        # WARN and persist a MISSING record that /lean health & /lean status
+        # render as a red row instead of silently omitting the agent.
+        local tester_active=0
+        tmux has-session -t "tester-agent" 2>/dev/null && tester_active=1
+        local missing_json="[]"
+        local mtype mactive mtarget mcycles
+        for _pair in \
+            "enricher $enricher_active $enricher" \
+            "researcher $researcher_active $researcher" \
+            "aristotle $aristotle_active $aristotle" \
+            "auditor $auditor_active $auditor" \
+            "seeker $seeker_active $seeker" \
+            "deployer $deployer_active $deployer" \
+            "herald $herald_active $herald" \
+            "mechanic $mechanic_active $mechanic" \
+            "tester $tester_active $tester"; do
+            read -r mtype mactive mtarget <<< "$_pair"
+
+            # Only configured agents (target >= 1) can be "missing".
+            if [[ "$mtarget" -lt 1 ]]; then
+                set_missing_cycles "$mtype" 0
+                continue
+            fi
+
+            # Aristotle scale-to-zero (issue #22471) is an intentional absence,
+            # not a failed launch -- don't false-alarm on it.
+            if [[ "$mtype" == "aristotle" ]] && [[ -f "$ARISTOTLE_SCALED_MARKER" ]]; then
+                set_missing_cycles "$mtype" 0
+                continue
+            fi
+
+            if [[ "$mactive" -lt "$mtarget" ]]; then
+                mcycles=$(get_missing_cycles "$mtype")
+                mcycles=$((mcycles + 1))
+                set_missing_cycles "$mtype" "$mcycles"
+                if [[ "$mcycles" -ge "$MISSING_SESSION_ALERT_CYCLES" ]]; then
+                    daemon_log "WARN" "Agent '$mtype' MISSING: configured=$mtarget running=$mactive for $mcycles consecutive cycles (respawn attempted, session still absent)"
+                    missing_json=$(echo "$missing_json" | jq -c \
+                        --arg t "$mtype" --argjson cfg "$mtarget" \
+                        --argjson run "$mactive" --argjson cyc "$mcycles" \
+                        '. += [{type: $t, configured: $cfg, running: $run, missing_cycles: $cyc}]' \
+                        2>/dev/null || echo "$missing_json")
+                fi
+            else
+                set_missing_cycles "$mtype" 0
+            fi
+        done
+        write_missing_agents "$missing_json"
+
         # 3. Work queue assessment (with timeout protection)
         local queue_stats
         queue_stats=$(get_work_queue_stats)
@@ -3303,4 +3506,9 @@ main() {
     esac
 }
 
-main "$@"
+# Only run main when executed directly, not when sourced (e.g. by tests such as
+# scripts/tests/daemon-missing-agent.test.sh, which exercise the missing-session
+# detection helpers in isolation). #39652.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/lean/status.sh
+++ b/scripts/lean/status.sh
@@ -275,6 +275,11 @@ gather_status() {
     fi
 
     if $JSON_OUTPUT; then
+        # Persistently-missing configured agents recorded by the daemon (#39652).
+        local missing_agents_json="[]"
+        if [[ -f "$STATE_FILE" ]] && jq empty "$STATE_FILE" >/dev/null 2>&1; then
+            missing_agents_json=$(jq -c '.missing_agents // []' "$STATE_FILE" 2>/dev/null || echo "[]")
+        fi
         # Output as JSON
         cat <<EOF
 {
@@ -334,6 +339,7 @@ gather_status() {
       "sessions": $(printf '%s\n' "${mechanic_sessions[@]:-}" | jq -R -s -c 'split("\n") | map(select(length > 0))')
     }
   },
+  "missing_agents": $missing_agents_json,
   "session_stats": {
     "entries_enriched": $entries_enriched,
     "proofs_submitted": $proofs_submitted,
@@ -510,6 +516,24 @@ EOF
             done
         else
             echo -e "    ${BOLD}Mechanic:${NC} ${YELLOW}0 active${NC}"
+        fi
+
+        # Persistently-missing configured agents (#39652). The daemon records a
+        # .missing_agents array when a configured agent has had no live session
+        # for several consecutive cycles (e.g. a silently-dying launcher). Surface
+        # it loudly instead of leaving it buried in the "0 active" rows above.
+        if [[ -f "$STATE_FILE" ]] && jq empty "$STATE_FILE" >/dev/null 2>&1; then
+            local missing_rows
+            missing_rows=$(jq -r \
+                '(.missing_agents // [])
+                 | map("      \(.type): configured \(.configured), running \(.running) (\(.missing_cycles) cycles)")
+                 | .[]' \
+                "$STATE_FILE" 2>/dev/null || echo "")
+            if [[ -n "$missing_rows" ]]; then
+                echo ""
+                echo -e "    ${RED}MISSING (configured but no session):${NC}"
+                echo -e "${RED}${missing_rows}${NC}"
+            fi
         fi
         echo ""
 

--- a/scripts/tests/daemon-missing-agent.test.sh
+++ b/scripts/tests/daemon-missing-agent.test.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+# Isolated harness for the configured-but-missing-session detection added to
+# scripts/lean/launch.sh (issue #39652).
+#
+# Background: the lean daemon had `deployer: 1` in its config yet no deployer
+# tmux session existed for ~7 days, and nothing surfaced it -- `/lean health`
+# just omitted the row and the daemon log stayed silent. These tests exercise
+# the new helpers that make a persistent absence VISIBLE:
+#   - count_agent_sessions    : live tmux sessions per agent type
+#   - print_missing_agent_rows: red MISSING rows in `/lean health`
+#   - get/set_missing_cycles  : consecutive-cycle escalation counter
+#   - write_missing_agents    : persists the missing set into STATE_FILE
+# plus a replica of the daemon's detection loop showing that a WARN fires only
+# after MISSING_SESSION_ALERT_CYCLES consecutive absent cycles (no false alarm
+# for a normally-running agent).
+#
+# Run: bash scripts/tests/daemon-missing-agent.test.sh
+# Exits non-zero if any assertion fails.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LAUNCH="$SCRIPT_DIR/../lean/launch.sh"
+
+# --- Fake tmux -------------------------------------------------------------
+# FAKE_SESSIONS is a space-separated list of "live" session names. The launch.sh
+# helpers only depend on `tmux has-session -t <name>`; everything else is a
+# no-op success.
+FAKE_SESSIONS=""
+tmux() {
+    case "${1:-}" in
+        has-session)
+            local name="${3:-}"
+            local s
+            for s in $FAKE_SESSIONS; do
+                [[ "$s" == "$name" ]] && return 0
+            done
+            return 1
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
+# Source launch.sh WITHOUT running main (source guard added in #39652).
+# shellcheck source=../lean/launch.sh
+source "$LAUNCH"
+
+# Redirect state to a throwaway sandbox so we never touch real daemon state.
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+STATE_FILE="$SANDBOX/lean-daemon-state.json"
+ARISTOTLE_SCALED_MARKER="$SANDBOX/aristotle-scaled-to-zero"
+DAEMON_LOG_FILE="$SANDBOX/daemon.log"
+
+# Strip ANSI color codes so assertions match plain text.
+strip_ansi() { sed $'s/\x1b\\[[0-9;]*m//g'; }
+
+PASS=0
+FAIL=0
+ok()   { echo "  ok: $1"; PASS=$((PASS + 1)); }
+bad()  { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_contains() { # <desc> <haystack> <needle>
+    if printf '%s' "$2" | grep -qF -- "$3"; then ok "$1"; else
+        bad "$1 -- expected to contain: $3"
+        printf '        got: %s\n' "$2"
+    fi
+}
+assert_not_contains() { # <desc> <haystack> <needle>
+    if printf '%s' "$2" | grep -qF -- "$3"; then
+        bad "$1 -- expected NOT to contain: $3"
+        printf '        got: %s\n' "$2"
+    else ok "$1"; fi
+}
+assert_eq() { # <desc> <actual> <expected>
+    if [[ "$2" == "$3" ]]; then ok "$1"; else
+        bad "$1 -- expected '$3', got '$2'"
+    fi
+}
+
+write_state() { # <deployer_cfg> <researcher_cfg>
+    cat > "$STATE_FILE" <<EOF
+{ "config": { "deployer": $1, "researcher": $2, "enricher": 0, "aristotle": 0,
+  "auditor": 0, "seeker": 0, "herald": 0, "mechanic": 0, "tester": 0 } }
+EOF
+}
+
+echo "== count_agent_sessions =="
+FAKE_SESSIONS=""
+assert_eq "deployer absent -> 0" "$(count_agent_sessions deployer)" "0"
+FAKE_SESSIONS="deployer"
+assert_eq "deployer present -> 1" "$(count_agent_sessions deployer)" "1"
+FAKE_SESSIONS="researcher-1 researcher-3"
+assert_eq "two researchers present -> 2" "$(count_agent_sessions researcher)" "2"
+
+# Run print_missing_agent_rows directly in the current shell (redirect to a
+# file, NOT a pipe or $() subshell) so its MISSING_AGENTS_FOUND global survives;
+# read the rendered rows back from the file afterwards.
+echo "== print_missing_agent_rows: configured deployer, no session =="
+write_state 1 0
+FAKE_SESSIONS=""
+print_missing_agent_rows > "$SANDBOX/rows.txt"
+out="$(strip_ansi < "$SANDBOX/rows.txt")"
+assert_contains "renders a MISSING deployer row" "$out" "MISSING"
+assert_contains "shows configured:1 running:0" "$out" "configured:1 running:0"
+assert_eq "MISSING_AGENTS_FOUND == 1" "$MISSING_AGENTS_FOUND" "1"
+
+echo "== print_missing_agent_rows: no false alarm when running =="
+write_state 1 0
+FAKE_SESSIONS="deployer"
+print_missing_agent_rows > "$SANDBOX/rows.txt"
+out="$(strip_ansi < "$SANDBOX/rows.txt")"
+assert_not_contains "no MISSING row when deployer runs" "$out" "MISSING"
+assert_eq "MISSING_AGENTS_FOUND == 0" "$MISSING_AGENTS_FOUND" "0"
+
+echo "== print_missing_agent_rows: not-configured agent is never MISSING =="
+write_state 0 0
+FAKE_SESSIONS=""
+print_missing_agent_rows >/dev/null
+assert_eq "config all zero -> 0 missing" "$MISSING_AGENTS_FOUND" "0"
+
+echo "== write_missing_agents persists to STATE_FILE =="
+write_state 1 0
+write_missing_agents '[{"type":"deployer","configured":1,"running":0,"missing_cycles":3}]'
+persisted="$(jq -r '.missing_agents[0].type' "$STATE_FILE")"
+assert_eq "missing_agents[0].type == deployer" "$persisted" "deployer"
+cyc="$(jq -r '.missing_agents[0].missing_cycles' "$STATE_FILE")"
+assert_eq "missing_agents[0].missing_cycles == 3" "$cyc" "3"
+
+echo "== cmd_health surfaces MISSING when the whole pool is dead =="
+write_state 1 0
+FAKE_SESSIONS=""   # get_all_agent_sessions returns empty -> empty-branch path
+health_out="$(cmd_health 2>/dev/null | strip_ansi)"
+assert_contains "health shows MISSING deployer row" "$health_out" "MISSING"
+assert_contains "health shows configured:1 running:0" "$health_out" "configured:1 running:0"
+
+echo "== daemon detection loop: WARN only after N consecutive absent cycles =="
+# Replicate the escalation the daemon cycle performs for one agent type.
+write_state 1 0
+set_missing_cycles deployer 0
+warned=""
+simulate_cycle() { # <active> <target>
+    local mactive="$1" mtarget="$2" mc
+    if [[ "$mactive" -lt "$mtarget" ]]; then
+        mc=$(get_missing_cycles deployer); mc=$((mc + 1)); set_missing_cycles deployer "$mc"
+        if [[ "$mc" -ge "$MISSING_SESSION_ALERT_CYCLES" ]]; then
+            daemon_log "WARN" "Agent 'deployer' MISSING: configured=$mtarget running=$mactive for $mc consecutive cycles" >> "$DAEMON_LOG_FILE"
+            warned=yes
+        fi
+    else
+        set_missing_cycles deployer 0
+    fi
+}
+assert_eq "threshold default is 3" "$MISSING_SESSION_ALERT_CYCLES" "3"
+warned=""; : > "$DAEMON_LOG_FILE"
+simulate_cycle 0 1   # cycle 1
+assert_eq "cycle 1: no warn yet" "$warned" ""
+simulate_cycle 0 1   # cycle 2
+assert_eq "cycle 2: no warn yet" "$warned" ""
+simulate_cycle 0 1   # cycle 3 -> threshold
+assert_eq "cycle 3: warn fired" "$warned" "yes"
+assert_contains "daemon log has WARN MISSING" "$(cat "$DAEMON_LOG_FILE")" "WARN: Agent 'deployer' MISSING"
+
+echo "== a single mid-respawn cycle does not false-alarm, and recovery resets =="
+set_missing_cycles deployer 0
+warned=""
+simulate_cycle 0 1   # absent one cycle
+simulate_cycle 1 1   # came back -> reset
+assert_eq "one absent cycle then recovery: no warn" "$warned" ""
+assert_eq "counter reset to 0 after recovery" "$(get_missing_cycles deployer)" "0"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #39652

## Problem
The lean daemon had `deployer: 1` in its config yet **no deployer tmux session existed for ~7 days**, and nothing surfaced it: `/lean health` silently omitted the row (`get_all_agent_sessions` only enumerates *live* sessions) and the daemon log stayed quiet. This is the observability companion to #39649 (which addresses *why* the launcher died) — this makes the **absence visible**.

## What changed (`scripts/lean/launch.sh`)
**Detection (daemon cycle).** After the existing pool-gap respawn pass, each cycle now compares every configured agent (`config.<type> >= 1`) against its live tmux session count and tracks how many **consecutive** cycles it has stayed below target:
- New `get_missing_cycles` / `set_missing_cycles` counters (bash-4 assoc array with a bash-3 `/tmp` fallback, mirroring the existing `LAST_RESPAWN_TIME` pattern).
- Escalates from the routine `pool gap` INFO to a **`MISSING` WARN** only after `MISSING_SESSION_ALERT_CYCLES` (=3) consecutive absent cycles, so a single mid-respawn / cooldown cycle never false-alarms. Aristotle scale-to-zero (#22471) is treated as an intentional absence.
- Persists the missing set to `STATE_FILE` (`.missing_agents`) via `write_missing_agents` so it survives between cycles and after the daemon exits.

**Surfacing.**
- `/lean health`: new `print_missing_agent_rows` renders a red `MISSING (configured:1 running:0)` row for every configured-but-absent agent — including when the *whole* pool is dead (previously an early return hid it) — plus a summary count and an advisory pointing at #39649 and the daemon log.
- `/lean status` (`status.sh`): reads `.missing_agents` and prints a red MISSING block; JSON output gains a top-level `missing_agents` array.

Reuses the daemon's existing per-agent respawn machinery; this adds **detection + logging + a status row only** — no new auto-remediation (that's #39649 / launcher-reclaim territory). Coordinates around, and does not touch, the `get_work_queue_stats` `ready_prs` metric (#39651) or the `recreate_daemon_state` / `update_daemon_state` self-heal (#41048).

## Testing
- `bash -n` passes on both scripts; `shellcheck -S error` clean.
- New `scripts/tests/daemon-missing-agent.test.sh` — 20 assertions, all passing. Stubs `tmux` and verifies:
  - `count_agent_sessions` per agent family,
  - the red `MISSING` health row appears for a configured/absent deployer (and when the whole pool is dead),
  - **no false alarm** for a normally-running agent,
  - `STATE_FILE` persistence of `.missing_agents`,
  - a WARN fires **only** after 3 consecutive absent cycles and the counter **resets** on recovery.
- A source guard around `main "$@"` lets the test source `launch.sh` in isolation (consistent with the repo's other sourced-and-tested scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
