### PR TITLE
fix(seeker): enforce cycle interval floor via CYCLE_MIN_SECONDS

### DIFF
--- a/scripts/research/launch-seeker.sh
+++ b/scripts/research/launch-seeker.sh
@@ -322,8 +322,14 @@ launch_agent() {
     # Per-role override: SEEKER_CLAUDE_MODEL > CLAUDE_MODEL > wrapper default.
     local wrapper_script="$REPO_ROOT/scripts/agents/claude-wrapper.sh"
     local seeker_model="${SEEKER_CLAUDE_MODEL:-${CLAUDE_MODEL:-claude-opus-4-8}}"
+    # Enforce the check interval as a floor between cycles. Seeker usually finds
+    # the pool adequate and stands down in under a minute; without a floor the
+    # wrapper busy-loops and re-invokes Claude every ~40s-1m instead of every
+    # INTERVAL minutes, burning quota on no-op cycles (same fix as herald; see
+    # scripts/herald/launch-agent.sh).
+    local cycle_min_seconds=$((INTERVAL * 60))
     tmux new-session -d -s "$SESSION_NAME" -c "$WORKTREE_PATH" \
-        "ENHANCER_ID=seeker REPO_ROOT=$WORKTREE_PATH CLAUDE_MODEL=$seeker_model $wrapper_script --daemon --prompt 'You are the seeker agent. Read $prompt_file for your instructions, then start the selection loop.' --log '$LOG_FILE'"
+        "ENHANCER_ID=seeker REPO_ROOT=$WORKTREE_PATH CLAUDE_MODEL=$seeker_model CYCLE_MIN_SECONDS=$cycle_min_seconds $wrapper_script --daemon --prompt 'You are the seeker agent. Read $prompt_file for your instructions, then start the selection loop.' --log '$LOG_FILE'"
 
     print_success "Launched seeker agent"
     echo ""


### PR DESCRIPTION
## Summary
- Seeker's `launch-seeker.sh` never passed `CYCLE_MIN_SECONDS` to the claude-wrapper daemon loop, so whenever the candidate pool was adequate (the common case, stand-down in well under a minute), the wrapper busy-looped and re-invoked Claude on `opus-4-8` roughly every 40s-1m instead of the intended 30-minute `SEEKER_INTERVAL`.
- Observed live in `.loom/logs/seeker.log` on 2026-07-22: dozens of near-identical "pool adequate, no selection needed" cycles firing back-to-back for hours.
- Herald hit this exact failure mode already and carries the fix (`scripts/herald/launch-agent.sh`); this mirrors that pattern for seeker — `cycle_min_seconds=$((INTERVAL * 60))` passed as an env var so the wrapper sleeps out the remainder of the interval after a fast cycle.

## Test plan
- [ ] Relaunch seeker (`./scripts/research/launch-seeker.sh --stop` then `./scripts/research/launch-seeker.sh`) and confirm `.loom/logs/seeker.log` shows ~30 minutes between daemon cycles instead of ~1 minute.