### PR TITLE
Fix: area-of-circle-oq-02 axiom nball_volume_scaling is inconsistent at n=0

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ02.lean
+++ b/proofs/Proofs/AreaOfCircleOQ02.lean
@@ -153,8 +153,14 @@ theorem unitBallVolume_four : unitBallVolume 4 = π ^ 2 / 2 := by
 
 /-- The n-ball volume scales as rⁿ times the unit ball volume.
     This is an axiom because the direct Mathlib formulation requires
-    careful handling of EuclideanSpace / PiLp volume theorems. -/
-axiom nball_volume_scaling (n : ℕ) (r : ℝ) (hr : 0 ≤ r) :
+    careful handling of EuclideanSpace / PiLp volume theorems.
+
+    Requires `n ≥ 1`: at `n = 0, r = 0`, `EuclideanSpace ℝ (Fin 0)` is a
+    single point so `ball 0 0 = ∅` has volume `0`, while `0 ^ 0 = 1` in `ℝ`
+    would force the RHS to be `unitBallVolume 0 = 1` — a `0 = 1`
+    contradiction. See `AreaOfCircleOQ02OQ01.lean` for the n ≥ 1 proof and
+    the explicit disproof at n = 0. -/
+axiom nball_volume_scaling (n : ℕ) (hn : 0 < n) (r : ℝ) (hr : 0 ≤ r) :
     MeasureTheory.volume (ball (0 : EuclideanSpace ℝ (Fin n)) r) =
     ENNReal.ofReal (r ^ n * unitBallVolume n)
 
@@ -162,7 +168,8 @@ axiom nball_volume_scaling (n : ℕ) (r : ℝ) (hr : 0 ≤ r) :
 theorem area_scaling_2d (r : ℝ) (hr : 0 ≤ r) :
     MeasureTheory.volume (ball (0 : EuclideanSpace ℝ (Fin 2)) (2 * r)) =
     4 * MeasureTheory.volume (ball (0 : EuclideanSpace ℝ (Fin 2)) r) := by
-  rw [nball_volume_scaling 2 (2 * r) (by linarith), nball_volume_scaling 2 r hr]
+  rw [nball_volume_scaling 2 (by norm_num) (2 * r) (by linarith),
+      nball_volume_scaling 2 (by norm_num) r hr]
   simp [unitBallVolume_two]
   rw [show (2 * r) ^ 2 * π = 4 * (r ^ 2 * π) by ring]
   rw [ENNReal.ofReal_mul (by norm_num : (0:ℝ) ≤ 4), ENNReal.ofReal_ofNat]

--- a/src/data/proofs/area-of-circle-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-02/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 1,
-    "assumptions": "1 axiom: nball_volume_scaling — Vol(Bⁿ(r)) = rⁿ·Vol(Bⁿ(1)). This is a standard measure theory fact requiring careful handling of EuclideanSpace/PiLp volume isomorphism in Mathlib.",
+    "assumptions": "1 axiom: nball_volume_scaling — Vol(Bⁿ(r)) = rⁿ·Vol(Bⁿ(1)) for n ≥ 1. This is a standard measure theory fact requiring careful handling of EuclideanSpace/PiLp volume isomorphism in Mathlib. (The n ≥ 1 hypothesis is required: at n=0, r=0 the unguarded statement is false — ball(0,0)=∅ has volume 0, but 0^0·unitBallVolume 0 = 1 — see area-of-circle-oq-02-oq-01.)",
     "lineCount": 210,
     "theoremCount": 17,
     "definitionCount": 1,
@@ -142,9 +142,9 @@
     {
       "name": "nball_volume_scaling",
       "type": "axiom",
-      "statement": "$\\forall n\\ \\forall r \\geq 0,\\ \\mathrm{volume}(B_n(r)) = r^n \\cdot V_n$ (as `ENNReal`)",
-      "significance": "**The single axiom.** Encodes the geometric fact that translating-and-scaling a ball in `EuclideanSpace ℝ (Fin n)` multiplies its Lebesgue measure by $r^n$. Mathematically obvious, but technically expensive in Lean because `EuclideanSpace ℝ (Fin n) = PiLp 2 (fun _ : Fin n => ℝ)` and bridging its measure to the product measure on `Fin n → ℝ` requires `MeasurePreserving` plumbing. The companion entry `area-of-circle-oq-02-oq-01` is dedicated to discharging this axiom.",
-      "description": "Stated as `axiom nball_volume_scaling (n : ℕ) (r : ℝ) (hr : 0 ≤ r) : volume (ball (0 : EuclideanSpace ℝ (Fin n)) r) = ENNReal.ofReal (r ^ n * unitBallVolume n)`. The `axiomCount: 1` and `status: \"axiomatized\"` in this file's metadata reflect this single declaration."
+      "statement": "$\\forall n \\geq 1\\ \\forall r \\geq 0,\\ \\mathrm{volume}(B_n(r)) = r^n \\cdot V_n$ (as `ENNReal`)",
+      "significance": "**The single axiom.** Encodes the geometric fact that translating-and-scaling a ball in `EuclideanSpace ℝ (Fin n)` multiplies its Lebesgue measure by $r^n$. Mathematically obvious, but technically expensive in Lean because `EuclideanSpace ℝ (Fin n) = PiLp 2 (fun _ : Fin n => ℝ)` and bridging its measure to the product measure on `Fin n → ℝ` requires `MeasurePreserving` plumbing. The companion entry `area-of-circle-oq-02-oq-01` is dedicated to discharging this axiom for $n \\geq 1$ and shows the statement is false without that guard (at $n=0, r=0$: $\\mathrm{ball}(0,0)=\\emptyset$ has volume 0, but $0^0 \\cdot V_0 = 1$).",
+      "description": "Stated as `axiom nball_volume_scaling (n : ℕ) (hn : 0 < n) (r : ℝ) (hr : 0 ≤ r) : volume (ball (0 : EuclideanSpace ℝ (Fin n)) r) = ENNReal.ofReal (r ^ n * unitBallVolume n)`. The `axiomCount: 1` and `status: \"axiomatized\"` in this file's metadata reflect this single declaration. The `hn : 0 < n` hypothesis was added to fix an inconsistency at n=0 (audit finding, 2026-07-22)."
     },
     {
       "name": "area_scaling_2d",


### PR DESCRIPTION
## Integrity Issue (CRITICAL — inconsistent axiom)

**Proof**: area-of-circle-oq-02

**Problem**: The `axiom nball_volume_scaling (n : ℕ) (r : ℝ) (hr : 0 ≤ r) : ...`
in `Proofs/AreaOfCircleOQ02.lean` was stated for *all* `n : ℕ`, but it is
**false** at `n = 0, r = 0`:

- LHS: `volume (ball (0 : EuclideanSpace ℝ (Fin 0)) 0) = volume ∅ = 0`
  (a ball of radius 0 is always empty).
- RHS: `ENNReal.ofReal (0 ^ 0 * unitBallVolume 0) = ENNReal.ofReal (1 * 1) = 1`
  (since `0 ^ 0 = 1` in `ℝ`, and `unitBallVolume 0 = 1`).

So the axiom asserts `0 = 1`, which makes the axiom set for this file
inconsistent — `False`, and hence anything, is derivable from it.

This was actually already discovered and proved as an explicit disproof in
the companion/child entry `area-of-circle-oq-02-oq-01`
(`Proofs/AreaOfCircleOQ02OQ01.lean`, lines 131-141:
`example : ¬ (volume (ball (0 : EuclideanSpace ℝ (Fin 0)) 0) = ...)`), which
also independently proves the corrected statement for `n ≥ 1` from Mathlib's
`EuclideanSpace.volume_ball`. The child file's own docstring even names the
fix: "change the axiom hypothesis ... to add `(hn : 0 < n)`". That fix was
never applied to the parent file.

## Evidence

**meta.json claims**: `axiomCount: 1`, `status: "axiomatized"`, disclosed
assumption `nball_volume_scaling — Vol(Bⁿ(r)) = rⁿ·Vol(Bⁿ(1))` with no
mention that the statement is inconsistent as written.

**Lean file shows**: the axiom has no `n ≥ 1` (or `n > 0`) guard, so
instantiating at `n=0, r=0` derives `0 = 1`.

## Fix Applied

- Added `(hn : 0 < n)` to `nball_volume_scaling`'s signature.
- Updated its sole call site (`area_scaling_2d`, at `n = 2`) to supply the
  now-required hypothesis (trivially, via `norm_num`).
- Updated `meta.json`'s `assumptions` text and the `nball_volume_scaling`
  entry in `mainTheorems` to state the `n ≥ 1` guard and reference the
  n=0 counterexample.
- Verified both `AreaOfCircleOQ02.lean` and the dependent
  `AreaOfCircleOQ02OQ01.lean` build clean after the change
  (`LAKE_UNSAFE=1 lake build Proofs.AreaOfCircleOQ02[OQ01]`, no errors).
- Only two files in the repo reference `nball_volume_scaling`
  (the parent and this child); no other consumers were affected.

---
Discovered during gallery integrity audit.