### PR TITLE
Fix: morleys-theorem conclusion falsely claims main theorem axiomatized

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -22972,10 +22972,10 @@
       "issues": []
     },
     "morleys-theorem": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:28Z",
-      "result": "clean"
+      "lastAudited": "2026-07-22T16:03:14Z",
+      "result": "issues-fixed"
     },
     "morleys-theorem-oq-01": {
       "auditCount": 3,

--- a/src/data/proofs/morleys-theorem/meta.json
+++ b/src/data/proofs/morleys-theorem/meta.json
@@ -143,7 +143,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Morley's theorem is formalized using Conway's backward proof in complex coordinates. The TriangleAngles structure captures the angle-sum constraint, cube roots of unity define the equilateral Morley triangle, and the symmetric side length formula 8R·sin(α/3)·sin(β/3)·sin(γ/3) encodes the equilateral property. Two trigonometric identities are proved from Mathlib; the main theorem is axiomatized.",
+    "summary": "Morley's theorem is fully proved via the sine rule / cosine rule method: the symmetric side length formula 8R·sin(α/3)·sin(β/3)·sin(γ/3) is derived for all three Morley sides and shown equal, proving the equilateral property (0 axioms, 0 sorries). Conway's backward construction with cube roots of unity is also proved and retained for geometric context, but the main theorem's derivation uses the trigonometric identities, not the complex-coordinate approach.",
     "implications": "**Theoretical Significance**: The formalization demonstrates how complex coordinates elegantly combine algebraic and geometric reasoning.\n\nThe TriangleAngles structure and backward construction provide a reusable framework for formalizing other triangle-center theorems (Napoleon's theorem, Feuerbach's theorem). The connection between Morley's theorem and angle trisection impossibility links classical geometry to Galois theory.",
     "openQuestions": [
       "Can Napoleon's theorem (equilateral triangles on sides → centroids form equilateral) be formalized using the TriangleAngles framework?",


### PR DESCRIPTION
## Integrity Issue

**Proof**: morleys-theorem
**Problem**: `conclusion.summary` claims "the main theorem is axiomatized" and that the proof uses "Conway's backward proof in complex coordinates." Both are stale/false.

## Evidence

**meta.json claimed**: "Two trigonometric identities are proved from Mathlib; the main theorem is axiomatized." (conclusion.summary), while `axiomCount: 0`, `sorries: 0`, `status: "verified"` elsewhere in the same file.

**Lean file shows**: `morleys_theorem_equilateral` (MorleysTheorem.lean:419-431) is fully proved:
```lean
theorem morleys_theorem_equilateral (t : TriangleAngles) (R : ℝ) :
    ... := by
  obtain ⟨h1, h2, h3⟩ := morleys_theorem_side_formula t R
  exact ⟨by linarith, by linarith⟩
```
via `morleys_theorem_side_formula` (line 384), itself proved via `morley_arm_cosine_rule` + `cosine_rule_identity` — the sine-rule/cosine-rule method. No `axiom`, no `sorry` anywhere in the file (grep confirms). This matches `proofStrategy` and the `sections[].summary` fields, which correctly describe the sine/cosine-rule method and note Conway's construction is "retained for context" — only `conclusion.summary` was stale.

## Fix Applied

Rewrote `conclusion.summary` to describe the actual proof method (sine/cosine rule) and state 0 axioms/0 sorries, dropping the false "axiomatized" claim and the incorrect Conway-backward-proof attribution.

---
Discovered during gallery integrity audit (reserve mode, queue drained 0/4809 unaudited).