### PR TITLE
Research: erdos-117-wip-01 — collapse at n=2 and h(2)=1 (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos117WIP01Two.lean
+++ b/proofs/Proofs/Erdos117WIP01Two.lean
@@ -79,11 +79,14 @@ theorem exists_three_pairwise_noncommuting {G : Type*} [Group G]
   have hne_ab : a ≠ b := fun hc => hab (by rw [hc])
   have hb1 : b ≠ 1 := fun hc => hab (by rw [hc, mul_one, one_mul])
   have ha1 : a ≠ 1 := fun hc => hab (by rw [hc, mul_one, one_mul])
-  have hne_a_ab : a ≠ a * b := fun hc => hb1 (self_eq_mul_right.mp hc)
-  have hne_b_ab : b ≠ a * b := fun hc => ha1 (self_eq_mul_left.mp hc)
+  have hne_a_ab : a ≠ a * b := fun hc =>
+    hb1 (mul_left_cancel (a := a) (by rw [mul_one]; exact hc)).symm
+  have hne_b_ab : b ≠ a * b := fun hc =>
+    ha1 (mul_right_cancel (b := b) (by rw [one_mul]; exact hc)).symm
   refine ⟨{a, b, a * b}, ?_, ?_⟩
-  · rw [Finset.card_insert_of_not_mem (by simp [hne_ab, hne_a_ab]),
-      Finset.card_insert_of_not_mem (by simp [hne_b_ab]), Finset.card_singleton]
+  · rw [Finset.card_insert_of_notMem (by simp [hne_ab, hne_a_ab]),
+      Finset.card_insert_of_notMem (by simp [hne_b_ab]), Finset.card_singleton]
+    omega
   · intro x hx y hy hxy
     simp only [Finset.mem_insert, Finset.mem_singleton] at hx hy
     rcases hx with rfl | rfl | rfl <;> rcases hy with rfl | rfl | rfl

--- a/proofs/Proofs/Erdos117WIP01Two.lean
+++ b/proofs/Proofs/Erdos117WIP01Two.lean
@@ -1,0 +1,182 @@
+/-
+  Erdős Problem #117 — Covering Groups by Abelian Subgroups: the collapse at
+  `n = 2` and the second exact value `h(2) = 1` (0-axiom).
+
+  Companion to `Erdos117Problem.lean` / `Erdos117WIP01.lean` /
+  `Erdos117WIP01Mono.lean` / `Erdos117WIP01Cover.lean`.  The parent defines
+  `h(n) = abelianCoverNumber n = sInf {k | every finite group with the
+  n-commuting property is covered by k abelian subgroups}` and states Pyber's
+  exponential bounds `c₁ⁿ < h(n) < c₂ⁿ` only in prose.  Prior companions pin
+  `h(0) = 0`, `h(1) = 1`, the closure theory of the property, monotonicity of
+  `h`, and the terminal-segment structure of the covering set.
+
+  This file settles the next rung of the ladder: **`h(2) = 1`**.  The reason is
+  a genuine (if small) piece of group theory: in ANY non-abelian group, a single
+  non-commuting pair `a, b` already spawns a *three-element pairwise
+  non-commuting set* `{a, b, a*b}` — a 3-clique in the non-commuting graph.
+  (`a` and `a*b` commute iff `a*b = b*a`, by cancellation; likewise `b` and
+  `a*b`.)  Consequently the `2`-commuting property — "every 3-subset contains a
+  commuting pair" — already forces the group to be abelian, exactly like the
+  `1`-commuting property: the hierarchy COLLAPSES at `n = 2`.  One abelian
+  subgroup (the whole group) then covers, and `h(2) = 1` unconditionally.
+
+  Main results (all axiom-free — `#print axioms` = propext/Classical.choice/Quot.sound):
+
+  * `exists_three_pairwise_noncommuting` : a non-abelian group contains a
+                                        3-element subset with NO distinct
+                                        commuting pair (`{a, b, a*b}`).
+  * `hasNCommutingProperty_two_iff`   : the `2`-commuting property is *exactly*
+                                        commutativity.
+  * `hasNCommutingProperty_two_iff_one` : the `n = 2` and `n = 1` properties
+                                        coincide — the first collapse of the
+                                        hierarchy.
+  * `abelianCoverNumber_two`          : **`h(2) = 1`** — the second exact value
+                                        of the covering number.
+  * `abelianCoverNumber_one_eq_two`   : `h(1) = h(2)` — the ladder is flat
+                                        across the collapse.
+
+  Where the collapse STOPS: at `n = 3` the property is strictly weaker than
+  commutativity.  The quaternion group `Q₈` is non-abelian yet has the
+  `3`-commuting property — its non-commuting graph has clique number 3, since
+  any clique picks at most one element from each of `{±i}, {±j}, {±k}` — and
+  needs three abelian subgroups (`⟨i⟩ ∪ ⟨j⟩ ∪ ⟨k⟩` covers; two cannot, as
+  `4 + 4 - |intersection ⊇ {±1}| ≤ 6 < 8`).  So `h(3) ≥ 3`: the first
+  genuinely non-abelian threshold, left for a future session.  The open
+  Erdős #117 (the exact exponential base) and Pyber's bounds are untouched.
+
+  0 axioms, 0 sorries.
+-/
+
+import Mathlib
+import Proofs.Erdos117Problem
+import Proofs.Erdos117WIP01
+
+/-- **A non-abelian group contains three pairwise non-commuting elements.**
+    Given `a * b ≠ b * a`, the subset `{a, b, a * b}` has cardinality 3 and no
+    distinct commuting pair:
+
+    * `a, b` do not commute by hypothesis;
+    * `a, a*b` commute iff `a*(a*b) = (a*b)*a` iff (left-cancelling `a`)
+      `a*b = b*a` — excluded;
+    * `b, a*b` commute iff `b*(a*b) = (a*b)*b` iff (right-cancelling `b`)
+      `b*a = a*b` — excluded.
+
+    Distinctness is automatic: `a = b` would commute, `a = a*b` forces `b = 1`
+    (central), `b = a*b` forces `a = 1` (central).  This is the 3-clique in the
+    non-commuting graph that every non-abelian group carries. -/
+theorem exists_three_pairwise_noncommuting {G : Type*} [Group G]
+    (h : ∃ a b : G, a * b ≠ b * a) :
+    ∃ S : Finset G, 2 < S.card ∧
+      ∀ x ∈ S, ∀ y ∈ S, x ≠ y → x * y ≠ y * x := by
+  classical
+  obtain ⟨a, b, hab⟩ := h
+  -- The three pairwise non-commutation facts (each by cancellation).
+  have hab' : a * (a * b) ≠ (a * b) * a := fun hc =>
+    hab (mul_left_cancel (by rw [hc, mul_assoc]))
+  have hbb' : b * (a * b) ≠ (a * b) * b := fun hc =>
+    hab (mul_right_cancel (by rw [← mul_assoc] at hc; exact hc)).symm
+  -- Distinctness of the three elements.
+  have hne_ab : a ≠ b := fun hc => hab (by rw [hc])
+  have hb1 : b ≠ 1 := fun hc => hab (by rw [hc, mul_one, one_mul])
+  have ha1 : a ≠ 1 := fun hc => hab (by rw [hc, mul_one, one_mul])
+  have hne_a_ab : a ≠ a * b := fun hc => hb1 (self_eq_mul_right.mp hc)
+  have hne_b_ab : b ≠ a * b := fun hc => ha1 (self_eq_mul_left.mp hc)
+  refine ⟨{a, b, a * b}, ?_, ?_⟩
+  · rw [Finset.card_insert_of_not_mem (by simp [hne_ab, hne_a_ab]),
+      Finset.card_insert_of_not_mem (by simp [hne_b_ab]), Finset.card_singleton]
+  · intro x hx y hy hxy
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hx hy
+    rcases hx with rfl | rfl | rfl <;> rcases hy with rfl | rfl | rfl
+    · exact absurd rfl hxy
+    · exact hab
+    · exact hab'
+    · exact fun hc => hab hc.symm
+    · exact absurd rfl hxy
+    · exact hbb'
+    · exact fun hc => hab' hc.symm
+    · exact fun hc => hbb' hc.symm
+    · exact absurd rfl hxy
+
+/-- **The `2`-commuting property is exactly commutativity.**  Forward: a
+    non-abelian group carries a 3-element pairwise non-commuting subset
+    (`exists_three_pairwise_noncommuting`), which violates the property at
+    threshold `2`.  Backward: in a commutative group any subset of size `> 2`
+    has two distinct (hence commuting) elements.  So the `n = 2` case adds
+    nothing over `n = 1` — the hierarchy's first collapse. -/
+theorem hasNCommutingProperty_two_iff {G : Type*} [Group G] :
+    HasNCommutingProperty G 2 ↔ ∀ x y : G, x * y = y * x := by
+  constructor
+  · intro h
+    by_contra hc
+    push_neg at hc
+    obtain ⟨S, hcard, hnc⟩ := exists_three_pairwise_noncommuting hc
+    obtain ⟨x, y, hx, hy, hxy, hcomm⟩ := h S hcard
+    exact hnc x hx y hy hxy hcomm
+  · intro h S hS
+    obtain ⟨x, hx, y, hy, hxy⟩ :=
+      Finset.one_lt_card.mp (lt_trans one_lt_two hS)
+    exact ⟨x, y, hx, hy, hxy, h x y⟩
+
+/-- **The `n = 2` and `n = 1` commuting properties coincide.**  Both are exactly
+    commutativity (`hasNCommutingProperty_two_iff`,
+    `hasNCommutingProperty_one_iff`).  Note the contrast with the definitional
+    monotonicity (`hasNCommutingProperty_mono` gives only `1`-property ⟹
+    `2`-property): the reverse implication is the group-theoretic content.  The
+    coincidence STOPS at `n = 3`, where `Q₈` is a non-abelian group with the
+    `3`-commuting property. -/
+theorem hasNCommutingProperty_two_iff_one {G : Type*} [Group G] :
+    HasNCommutingProperty G 2 ↔ HasNCommutingProperty G 1 :=
+  hasNCommutingProperty_two_iff.trans hasNCommutingProperty_one_iff.symm
+
+/-- **`h(2) = 1`.**  A group with the `2`-commuting property is abelian
+    (`hasNCommutingProperty_two_iff`), so the single subgroup `⊤` covers it:
+    `1` is in the covering set and `h(2) ≤ 1`.  Conversely `0` is not in the
+    set (the empty family cannot cover `PUnit`, which has the `2`-commuting
+    property), and the set is nonempty, so `h(2) ≥ 1`.  Together with
+    `abelianCoverNumber_one` this makes the ladder `h(0) = 0, h(1) = h(2) = 1`
+    — flat across the collapse — before Pyber's exponential growth takes over. -/
+theorem abelianCoverNumber_two : abelianCoverNumber 2 = 1 := by
+  -- As in `abelianCoverNumber_one`: `abelianCoverNumber` quantifies over
+  -- `Type*`, so witnesses are built inline at the set's fixed universe.
+  unfold abelianCoverNumber
+  apply le_antisymm
+  · -- h(2) ≤ 1 : the single abelian subgroup `⊤` covers any group with the
+    -- `2`-commuting property (that group is abelian).
+    apply Nat.sInf_le
+    intro G _ _ hprop
+    exact ⟨fun _ => ⊤,
+      fun _ x y _ _ => hasNCommutingProperty_two_iff.mp hprop x y,
+      fun g => ⟨0, Subgroup.mem_top g⟩⟩
+  · -- h(2) ≥ 1 : `0` is not in the covering set, and the set is nonempty.
+    rw [Nat.one_le_iff_ne_zero, Ne, Nat.sInf_eq_zero]
+    push_neg
+    refine ⟨fun hmem => ?_, ?_⟩
+    · -- `0 ∈` set would cover `PUnit` by an empty family of subgroups.
+      simp only [Set.mem_setOf_eq] at hmem
+      obtain ⟨H, _, hcov⟩ :=
+        hmem PUnit (commGroup_hasNCommutingProperty one_le_two)
+      obtain ⟨i, _⟩ := hcov PUnit.unit
+      exact i.elim0
+    · -- The set is nonempty: `1` belongs to it.
+      refine ⟨1, ?_⟩
+      intro G _ _ hprop
+      exact ⟨fun _ => ⊤,
+        fun _ x y _ _ => hasNCommutingProperty_two_iff.mp hprop x y,
+        fun g => ⟨0, Subgroup.mem_top g⟩⟩
+
+/-- **`h(1) = h(2)`.**  The covering number is flat across the collapse: both
+    thresholds constrain exactly the abelian groups, and one subgroup covers.
+    (First strict growth can only occur at `n = 3` or later; `Q₈` shows
+    `h(3) ≥ 3` — the covering number jumps once genuinely non-abelian groups
+    satisfy the property.) -/
+theorem abelianCoverNumber_one_eq_two :
+    abelianCoverNumber 1 = abelianCoverNumber 2 := by
+  rw [abelianCoverNumber_one, abelianCoverNumber_two]
+
+-- Axiom audit: everything above is axiom-free
+-- (expected: propext, Classical.choice, Quot.sound only).
+#print axioms exists_three_pairwise_noncommuting
+#print axioms hasNCommutingProperty_two_iff
+#print axioms hasNCommutingProperty_two_iff_one
+#print axioms abelianCoverNumber_two
+#print axioms abelianCoverNumber_one_eq_two

--- a/research/problems/erdos-117-wip-01/state.md
+++ b/research/problems/erdos-117-wip-01/state.md
@@ -6,6 +6,29 @@
 **Since**: 2026-07-09T17:33:20-07:00
 **Iteration**: 3
 
+## Status (researcher-1, 2026-07-22, session 2) — COLLAPSE AT n=2, h(2)=1
+
+New file `Erdos117WIP01Two.lean` (5 thm, 0 ax, 0 sorry, docker-verified). The second exact
+value of the ladder: **h(2) = 1**, via the first collapse of the property hierarchy.
+
+- `exists_three_pairwise_noncommuting` — the crux: any non-commuting pair `a, b` spawns the
+  3-element pairwise non-commuting set `{a, b, a*b}` (a 3-clique in the non-commuting graph;
+  `a` vs `a*b` commute iff `ab=ba` by left cancellation, `b` vs `a*b` by right cancellation;
+  distinctness forced: `a = a*b ⟹ b = 1` central).
+- `hasNCommutingProperty_two_iff` — the 2-commuting property ("every 3-subset has a commuting
+  pair") is *exactly* commutativity.
+- `hasNCommutingProperty_two_iff_one` — n=2 and n=1 properties coincide (reverse of the
+  definitional monotonicity is the mathematical content).
+- `abelianCoverNumber_two` — **h(2) = 1** (same inline-witness `sInf` pattern as h(1)=1,
+  universe gotcha applies).
+- `abelianCoverNumber_one_eq_two` — the ladder is flat across the collapse: h(0)=0, h(1)=h(2)=1.
+
+**Where the collapse stops (next session's target)**: Q₈ is non-abelian with the 3-commuting
+property (clique number of its non-commuting graph is 3 — a clique takes at most one of each
+`{±i}, {±j}, {±k}`), and no 2 abelian subgroups cover Q₈ (abelian subgroups have order ≤ 4,
+`4+4−|{±1} ⊆ shared| ≤ 6 < 8`). So **h(3) ≥ 3** — first genuinely non-abelian rung. Mathlib
+has `QuaternionGroup`. h(3) ≤ 3 would need a classification — likely blocked.
+
 ## Status (researcher-1, 2026-07-22) — MONOTONICITY of the covering number h(n)
 
 New file `Erdos117WIP01Mono.lean` (1 def, 3 thm, 0 ax, 0 sorry, docker-VERIFIED, 8578 jobs;

--- a/src/data/research/problems/erdos-117-wip-01.json
+++ b/src/data/research/problems/erdos-117-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added Erdos117WIP01Cover.lean (5 axiom-free theorems). Cyclic-cover existence (every group = union of abelian cyclic subgroups) + structure of the covering set (upward-closed terminal segment, 0 not in set for n>=1, general lower bound h(n)>=1). Prior: h(0)=0, h(1)=1, property closure theory, h monotone. Pyber exponential bounds c1^n < h(n) < c2^n remain deep/unformalized.",
+    "progressSummary": "PROGRESS: Added Erdos117WIP01Two.lean (5 axiom-free theorems). The hierarchy collapses at n=2: 2-commuting property ⟺ commutativity via the {a,b,ab} 3-clique in the non-commuting graph, hence h(2)=1 and h(1)=h(2). Ladder now h(0)=0, h(1)=h(2)=1 exact. Prior: closure theory, h monotonicity (conditional), cyclic covers, covering-set terminal-segment structure. Next elementary rung: Q8 ⟹ h(3)≥3 (needs QuaternionGroup formalization). Deep: Pyber bounds unformalized.",
     "builtItems": [
       "abelianCoverNumber_mono in Erdos117WIP01Mono.lean — h(n) is monotone nondecreasing: n<=m and a finite m-cover exists (exists k, CoversWithAbelian k m) => h(n) <= h(m). Crux coversWithAbelian_of_le: an m-cover is an n-cover since the n-commuting property implies the m-property (hasNCommutingProperty_mono). Nonemptiness hypothesis is honest (Nat.sInf empty = 0 convention; well-definedness of h(m) is Pyber's unformalized upper bound). CoversWithAbelian names the defining-set condition; abelianCoverNumber_eq_sInf is rfl. 0-axiom, docker 8578 jobs.",
       "commute_of_hasNCommutingProperty_one - HasNCommutingProperty G 1 implies all pairs commute (Erdos117Problem.lean)",
@@ -45,7 +45,8 @@
       "exists_cyclic_abelian_cover — every group covered by abelian cyclic subgroups (Erdos117WIP01Cover.lean)",
       "coversWithAbelian_upward — covering set upward-closed in k via bot-padding (Erdos117WIP01Cover.lean)",
       "not_coversWithAbelian_zero — for n>=1, 0 subgroups never cover (PUnit witness) (Erdos117WIP01Cover.lean)",
-      "one_le_abelianCoverNumber — h(n)>=1 for n>=1 when covering set nonempty (Erdos117WIP01Cover.lean)"
+      "one_le_abelianCoverNumber — h(n)>=1 for n>=1 when covering set nonempty (Erdos117WIP01Cover.lean)",
+      "Erdos117WIP01Two.lean: exists_three_pairwise_noncommuting, hasNCommutingProperty_two_iff, hasNCommutingProperty_two_iff_one, abelianCoverNumber_two (h(2)=1), abelianCoverNumber_one_eq_two — 0 axioms, 0 sorries"
     ],
     "insights": [
       "UNIVERSE gotcha (confirmed again): abelianCoverNumber and CoversWithAbelian are universe-polymorphic in the group universe (bodies quantify forall G:Type*), so the VALUE depends on u. Any monotonicity/set-algebra statement must pin one explicit `universe u` and annotate EVERY occurrence with .{u}; unannotated occurrences get independent universes => abelianCoverNumber.{u_1} vs .{u_3} and @h G application-type mismatch. A `universe` command takes a plain /- -/ comment, not a /-- -/ docstring.",
@@ -55,14 +56,16 @@
       "abelianCoverNumber is universe-polymorphic (its body quantifies ∀ (G:Type*)); membership witnesses must be built INLINE at the set fixed universe — a factored Type* have introduces a second non-unifying universe (level-param mismatch).",
       "Every group (any G, not just finite) is a union of abelian cyclic subgroups: the family g ↦ Subgroup.zpowers g covers G, each zpowers g abelian. So a cover ALWAYS exists for a fixed group (size ≤ |G|); h(n) measures only the UNIFORM count over all n-commuting groups, never existence. (exists_cyclic_abelian_cover, Erdos117WIP01Cover.lean)",
       "The covering set {k | CoversWithAbelian k n} is a terminal segment: upward-closed in k (pad a k-cover with copies of bot — coversWithAbelian_upward) and, for n>=1, never contains 0 (empty family cannot cover PUnit — not_coversWithAbelian_zero). With Nat.sInf_mem this pins it as [h(n),inf) when nonempty.",
-      "General lower bound h(n)>=1 for n>=1 whenever h(n) is well-defined (covering set nonempty). Complements h(0)=0: the covering number leaves 0 exactly at the n=0->1 step. For n>=2 nonemptiness of the set is precisely Pyber unformalized upper bound. (one_le_abelianCoverNumber)"
+      "General lower bound h(n)>=1 for n>=1 whenever h(n) is well-defined (covering set nonempty). Complements h(0)=0: the covering number leaves 0 exactly at the n=0->1 step. For n>=2 nonemptiness of the set is precisely Pyber unformalized upper bound. (one_le_abelianCoverNumber)",
+      "COLLAPSE AT n=2: the 2-commuting property is exactly commutativity — in any non-abelian group a non-commuting pair a,b spawns the 3-element pairwise non-commuting set {a,b,ab} (a vs ab commute iff ab=ba by left cancellation; b vs ab iff ba=ab by right cancellation; distinctness forced since a=ab ⟹ b=1 central). So the n=2 threshold adds nothing over n=1, and h(2)=1 unconditionally.",
+      "Where the collapse stops: Q8 is non-abelian with the 3-commuting property (non-commuting graph clique number 3: a clique picks at most one of each {±i},{±j},{±k}), and no 2 abelian subgroups cover Q8 (abelian subgroups have order ≤4; 4+4−|shared ⊇ {±1}| ≤ 6 < 8). So h(3) ≥ 3 — first genuinely non-abelian rung, NOT yet formalized."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "h(n) monotonicity done (conditional on m-cover existence). Remaining elementary targets are thin: possibly h(n) >= 1 for n>=1 given a cover exists (>=1 abelian subgroup needed), or specialize mono to concrete small pairs. Deep: Pyber upper bound (well-definedness / nonemptiness of the sInf set for general n) and the exponential base are NOT elementary.",
-      "Pyber upper/lower bounds c₁ⁿ<h(n)<c₂ⁿ stay as named assumptions (deep, exact base OPEN) — do NOT claim proved.",
-      "Optional: covering-set well-definedness for general n (nonemptiness of the sInf argument) needs a uniform cover bound = the deep Pyber upper bound; not elementary.",
-      "Optional: h(n)≥1 for all n via the same 0∉set argument (trivial generalization of the h(1)=1 lower half)."
+      "h(3) ≥ 3 via Q8: formalize (i) Q8 has the 3-commuting property (clique number 3 of its non-commuting graph), (ii) no 2 abelian subgroups cover Q8 (order counting: abelian subgroups of Q8 have order ≤ 4). Mathlib has QuaternionGroup 2 = Q8. Meaty but elementary — best candidate for next session.",
+      "h(3) ≤ 3 would need a classification of groups with 3-commuting property — NOT elementary, likely blocked.",
+      "Pyber upper/lower bounds c₁ⁿ<h(n)<c₂ⁿ stay unformalized (deep, exact base OPEN) — do NOT claim proved.",
+      "Well-definedness of h(n) for general n (nonemptiness of the sInf set) = Pyber upper bound; not elementary."
     ],
     "markdown": "# Knowledge Base: erdos-117-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary
Research session for erdos-117-wip-01 (Erdős #117 — covering groups by abelian subgroups). New companion file `Erdos117WIP01Two.lean` settles the second exact value of the covering-number ladder: **h(2) = 1**, via the first collapse of the n-commuting-property hierarchy.

## Progress
- `exists_three_pairwise_noncommuting` — any non-commuting pair a, b spawns the 3-element pairwise non-commuting set {a, b, a*b} (a 3-clique in the non-commuting graph of every non-abelian group; commuting with a*b is excluded by left/right cancellation, distinctness is forced since a = a*b would make b = 1 central).
- `hasNCommutingProperty_two_iff` — the 2-commuting property ("every 3-subset contains a commuting pair") is exactly commutativity.
- `hasNCommutingProperty_two_iff_one` — the n = 2 and n = 1 properties coincide; the reverse of the definitional monotonicity is the mathematical content.
- `abelianCoverNumber_two` — **h(2) = 1** (inline-witness sInf pattern from `abelianCoverNumber_one`).
- `abelianCoverNumber_one_eq_two` — the ladder is flat across the collapse: h(0) = 0, h(1) = h(2) = 1.

Docker-verified (8578 jobs): 0 sorries, 0 axioms; `#print axioms` = propext/Classical.choice/Quot.sound for all 5 theorems (in-file audit lines included).

## Findings
- The hierarchy collapses at n = 2 and the collapse stops at n = 3: Q8 is non-abelian with the 3-commuting property (its non-commuting graph has clique number 3), and no 2 abelian subgroups cover Q8 — so h(3) >= 3 is the first genuinely non-abelian rung (documented in prose, not yet formalized; Mathlib has `QuaternionGroup`).
- Pyber's exponential bounds and the open exact base remain untouched, as before.

## Files
- `proofs/Proofs/Erdos117WIP01Two.lean` (new, 5 theorems, 0-axiom)
- `research/problems/erdos-117-wip-01/state.md`, `src/data/research/problems/erdos-117-wip-01.json` (session tracking)

## Status
**Outcome**: progress
**Next Steps**: h(3) >= 3 via Q8 (3-commuting property + no-2-cover order counting) — best candidate for next session.

🤖 Generated by researcher-1 (worktree researcher-1-3)
