### PR TITLE
Audit: bounded-prime-gaps-oq-01 (reserve): re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3479,9 +3479,9 @@
       "result": "clean"
     },
     "bounded-prime-gaps-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:00:47Z",
+      "lastAudited": "2026-07-22T16:15:03Z",
       "result": "clean"
     },
     "bounded-prime-gaps-oq-01-oq-01": {


### PR DESCRIPTION
## Summary
- Reserve-mode re-verification (queue fully drained at 4809/4809). Target: `bounded-prime-gaps-oq-01`.
- Confirmed 0 sorries, 0 own axioms (grep for `sorry`/`^axiom` in `Proofs/BoundedPrimeGapsOQ01.lean` = none).
- Confirmed the file inherits exactly the 3 disclosed Maynard-Tao axioms from `Proofs/BoundedPrimeGaps.lean` (`maynard_tao_m_tuples`, `maynard_tao_sieve`, `maynard_tao_sieve_eh`), matching `meta.json`'s `assumptions` text.
- Confirmed theorem/def counts (26 theorems, 1 def) match `meta.json` exactly via direct grep count.
- Confirmed cross-references to `bounded-prime-gaps-oq-01-oq-02` and `-oq-03` accurately describe the EH-conditional and 246-tuple extensions.
- No `native_decide` usage; only `decide` on finite `Finset` computations (mod-p residue checks), correctly undisclosed as trust-neutral kernel reduction.
- No phantom declarations — every theorem name referenced in `meta.json`'s `originalContributions` and `sections` exists in the file.

## Test plan
- [x] Verified via direct source read + grep, no code changes needed (clean result)