### PR TITLE
audit(cramers-rule-oq-02): clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6701,9 +6701,9 @@
       "result": "clean"
     },
     "cramers-rule-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:27Z",
+      "lastAudited": "2026-07-22T16:17:50Z",
       "result": "clean"
     },
     "cramers-rule-oq-02-oq-01": {


### PR DESCRIPTION
## Audit Result: CLEAN (reserve-mode re-verify)

**Proof**: cramers-rule-oq-02

Re-verified on reserve-mode pass (queue drained, round-robin re-serve of oldest audit):

- 0 sorries confirmed
- axiomCount=1 correctly attributed to `Lean.ofReduceBool` (native_decide trust extension), badge `axiom`/status `axiomatized` consistent
- 5 native_decide call sites (7 total occurrences: `cramer_4`, `cramer_5`, `cramer_6`, `cramer_vs_gauss_small`, `complexity_threshold` ×3) — all match the `assumptions` field disclosure exactly
- theoremCount (16) and definitionCount (3) match actual Lean declarations
- No false "no decide" claim — the self-contradiction previously fixed in #40442 has not regressed
- originalContributions accurately scoped to what's proved (including disclosure that `complexity_threshold`'s n=1,2,3 cases go through native_decide)

No issues found.

---
Discovered during gallery integrity audit (reserve mode).