### PR TITLE
Fix: taylor-sincos-convergence phantom mainTheorems entry

### DIFF
--- a/src/data/proofs/taylor-sincos-convergence/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence/meta.json
@@ -215,10 +215,16 @@
   ],
   "mainTheorems": [
     {
-      "name": "sin_taylor",
+      "name": "sinPartialSum_tendsto",
       "type": "core",
-      "description": "Taylor series for sin(x) converges for all x",
-      "leanType": "HasSum (fun n => (-1)^n * x^(2*n+1) / (2*n+1)!) (Real.sin x)"
+      "description": "Taylor partial sums for sin(x) converge to sin(x) for all x",
+      "leanType": "Tendsto (fun n => sinPartialSum n x) atTop (𝓝 (Real.sin x))"
+    },
+    {
+      "name": "cosPartialSum_tendsto",
+      "type": "core",
+      "description": "Taylor partial sums for cos(x) converge to cos(x) for all x",
+      "leanType": "Tendsto (fun n => cosPartialSum n x) atTop (𝓝 (Real.cos x))"
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
## Integrity Issue

**Proof**: taylor-sincos-convergence
**Problem**: `meta.json`'s `mainTheorems` array cites a theorem `sin_taylor` with
Lean type `HasSum (fun n => (-1)^n * x^(2*n+1) / (2*n+1)!) (Real.sin x)`. This
declaration does not exist anywhere in `Proofs/TaylorSinCosConvergence.lean` —
no `sin_taylor` name, and no `HasSum` statement at all.

## Evidence

**meta.json claims**: main theorem `sin_taylor : HasSum (...) (Real.sin x)`
**Lean file shows**: the file proves `sinPartialSum_tendsto` (`Tendsto (fun n
=> sinPartialSum n x) atTop (𝓝 (Real.sin x))`) and, separately,
`summable_sinSeries` (`Summable (sinSeries x)`), but never combines these into
a single `HasSum` statement linking the explicit alternating series to
`Real.sin x`.

Rest of the entry is accurate: badge `axiom`/status `axiomatized` correctly
discloses the 2 axioms (`sin_taylor_remainder_bound`,
`cos_taylor_remainder_bound`), sorries (0), axiomCount (2), theoremCount (31),
and definitionCount (4) all match the source exactly.

## Fix

Replaced the phantom `mainTheorems` entry with the two theorems that actually
exist and match the file's real (disclosed) proof strategy:
`sinPartialSum_tendsto` and `cosPartialSum_tendsto`.

---
Discovered during gallery integrity audit (reserve-mode re-audit).