### PR TITLE
Research: erdos-18-wip-01 — exact hErdos 6 = 2, hErdos 12 = 3 via upper-half divisor gap (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos18WIP01.lean
+++ b/proofs/Proofs/Erdos18WIP01.lean
@@ -1859,5 +1859,188 @@ def conjecture_part1_erdos : Prop :=
     Set.Infinite { m : ℕ | IsPractical m ∧
       (hErdos m : ℝ) < (Real.log (Real.log m)) ^ C }
 
+/- ## The upper-half divisor gap: `hErdos m = 1` exactly at `m = 2`, and the
+first composite exact values
+
+No divisor of `m` lies strictly between `m/2` and `m`: a proper divisor `d < m`
+has cofactor at least `2`, so `2d ≤ m`. Hence any target `k` with `m < 2k` and
+`k < m` is not itself a divisor, and every distinct-divisor representation of it
+needs at least **two** divisors. Taking `k = m − 1` (for `m ≥ 3`) pins
+`hErdos m ≥ 2`, so the corrected index equals `1` exactly at `m = 2`
+(`hErdos_eq_one_iff`) — the complete list of small values starts
+`hErdos 1 = 0`, `hErdos 2 = 1`, and `≥ 2` from then on.
+
+The same gap argument yields the first exact values beyond the extremal powers
+of two (`hErdos_two_pow`):
+
+* `hErdos 6 = 2` — the first practical number that is not a power of two. Upper
+  bound: six explicit minimum representations (`4 = 1+3`, `5 = 2+3`). Lower
+  bound: `k = 5` lies in the gap `(3, 6)`.
+* `hErdos 12 = 3` — the subadditivity `hErdos(2·6) ≤ hErdos 2 + hErdos 6` is
+  **tight** here: `k = 11` genuinely needs three divisors (`11 = 1 + 4 + 6`;
+  the largest two-divisor sum below `12` is `4 + 6 = 10`), confirmed by a finite
+  kernel check over the 64 subsets of `divisors 12`. Note the counting bound
+  `lt_hErdos_of_pow_lt` gives only `hErdos 12 ≥ 2` (`(d(12)+1)^1 = 7 < 12 ≤ 49`),
+  so the combinatorial gap argument is strictly sharper here. -/
+
+/-- Any witness set bounds `repLength`: if `T ⊆ divisors m` sums to `k`, then
+`repLength m k ≤ |T|`. -/
+theorem repLength_le_of_witness {m k : ℕ} {T : Finset ℕ} (hsub : T ⊆ divisors m)
+    (hsum : T.sum id = k) : repLength m k ≤ T.card :=
+  Nat.sInf_le ⟨T, hsub, rfl, hsum⟩
+
+/-- **No divisor in the upper half**: a proper divisor `d < m` satisfies
+`2d ≤ m` — its cofactor is at least `2`. -/
+theorem two_mul_le_of_dvd_of_lt {d m : ℕ} (hdvd : d ∣ m) (hlt : d < m) :
+    2 * d ≤ m := by
+  obtain ⟨c, rfl⟩ := hdvd
+  rcases c with _ | _ | c
+  · omega
+  · omega
+  · have h2 : d * 2 ≤ d * (c + 1 + 1) := Nat.mul_le_mul (le_refl d) (by omega)
+    omega
+
+/-- **Two divisors are needed in the upper half**: if `T ⊆ divisors m` sums to
+`k` with `m < 2k` and `k < m`, then `|T| ≥ 2`. Indeed `k ≥ 1` (so `T ≠ ∅`), and
+a singleton `{d}` would make `k = d` a divisor lying in the forbidden interval
+`(m/2, m)` (`two_mul_le_of_dvd_of_lt`). -/
+theorem two_le_card_of_sum_upper_half {m k : ℕ} {T : Finset ℕ}
+    (hsub : T ⊆ divisors m) (hsum : T.sum id = k) (hk2 : m < 2 * k)
+    (hkm : k < m) : 2 ≤ T.card := by
+  by_contra hlt
+  rw [not_le] at hlt
+  rcases Finset.eq_empty_or_nonempty T with rfl | hne
+  · rw [Finset.sum_empty] at hsum
+    omega
+  · have hcard1 : T.card = 1 := by
+      have hpos := Finset.card_pos.mpr hne
+      omega
+    obtain ⟨d, rfl⟩ := Finset.card_eq_one.mp hcard1
+    rw [Finset.sum_singleton, id_eq] at hsum
+    subst hsum
+    have hdvd : d ∣ m :=
+      (Nat.mem_divisors.mp (hsub (Finset.mem_singleton_self d))).1
+    have hhalf := two_mul_le_of_dvd_of_lt hdvd hkm
+    omega
+
+/-- **Lower bound from the upper-half gap**: for practical `m`, any target in
+the open upper half (`m < 2k`, `k < m`) has `repLength m k ≥ 2`. -/
+theorem two_le_repLength_of_upper_half {m k : ℕ} (hm : IsPractical m)
+    (hk2 : m < 2 * k) (hkm : k < m) : 2 ≤ repLength m k := by
+  unfold repLength
+  apply le_csInf
+  · obtain ⟨T, hTsub, hTsum⟩ := hm.2 k (by omega) hkm
+    exact ⟨T.card, T, hTsub, rfl, hTsum⟩
+  · rintro t ⟨T, hTsub, rfl, hTsum⟩
+    exact two_le_card_of_sum_upper_half hTsub hTsum hk2 hkm
+
+/-- **`hErdos m ≥ 2` for practical `m ≥ 3`**: the value `k = m − 1` lies in the
+upper-half gap. Together with `one_le_hErdos` this pins all small values of the
+corrected index. -/
+theorem two_le_hErdos {m : ℕ} (hm : IsPractical m) (hm3 : 3 ≤ m) :
+    2 ≤ hErdos m := by
+  have h1 : 2 ≤ repLength m (m - 1) :=
+    two_le_repLength_of_upper_half hm (by omega) (by omega)
+  calc 2 ≤ repLength m (m - 1) := h1
+    _ ≤ hErdos m := by
+        unfold hErdos
+        exact Finset.le_sup (Finset.mem_range.mpr (by omega))
+
+/-- `hErdos 1 = 0`: the only value to cover is `k = 0`, handled by `∅`. -/
+theorem hErdos_one : hErdos 1 = 0 := by
+  unfold hErdos
+  simp [Finset.range_one, repLength_zero]
+
+/-- `hErdos 2 = 1` — the power-of-two formula at `k = 1`. -/
+theorem hErdos_two : hErdos 2 = 1 := by
+  have h := hErdos_two_pow 1
+  norm_num at h
+  exact h
+
+/-- **`hErdos m = 1` exactly at `m = 2`** (over practical `m`): `m = 1` gives
+index `0`, and every practical `m ≥ 3` needs two divisors somewhere
+(`two_le_hErdos`). -/
+theorem hErdos_eq_one_iff {m : ℕ} (hm : IsPractical m) :
+    hErdos m = 1 ↔ m = 2 := by
+  constructor
+  · intro h1
+    by_contra hne
+    have hm1 : 1 ≤ m := hm.1
+    rcases Nat.lt_or_ge m 3 with hlt | hge
+    · interval_cases m
+      · rw [hErdos_one] at h1
+        omega
+      · exact hne rfl
+    · have h2 := two_le_hErdos hm hge
+      omega
+  · rintro rfl
+    exact hErdos_two
+
+/-- **`hErdos 6 = 2`** — the first exact value of the corrected index at a
+practical number that is not a power of two. Upper bound: every `k < 6` has a
+representation by at most two divisors of `6` (`4 = 1+3`, `5 = 2+3`). Lower
+bound: `k = 5` lies in the upper-half gap `(3, 6)`. -/
+theorem hErdos_six : hErdos 6 = 2 := by
+  refine le_antisymm ?_ ?_
+  · unfold hErdos
+    apply Finset.sup_le
+    intro k hk
+    rw [Finset.mem_range] at hk
+    interval_cases k
+    · rw [repLength_zero]
+      omega
+    · exact (repLength_le_of_witness (T := {1}) (by decide) (by decide)).trans
+        (by decide)
+    · exact (repLength_le_of_witness (T := {2}) (by decide) (by decide)).trans
+        (by decide)
+    · exact (repLength_le_of_witness (T := {3}) (by decide) (by decide)).trans
+        (by decide)
+    · exact (repLength_le_of_witness (T := {1, 3}) (by decide) (by decide)).trans
+        (by decide)
+    · exact (repLength_le_of_witness (T := {2, 3}) (by decide) (by decide)).trans
+        (by decide)
+  · calc 2 ≤ repLength 6 5 :=
+          two_le_repLength_of_upper_half six_practical (by omega) (by omega)
+      _ ≤ hErdos 6 := by
+          unfold hErdos
+          exact Finset.le_sup (Finset.mem_range.mpr (by omega))
+
+/-- `12` is practical — via the decision procedure. -/
+theorem twelve_practical : IsPractical 12 := by decide
+
+/-- **Kernel check**: every subset of `divisors 12 = {1,2,3,4,6,12}` summing to
+`11` has at least three elements — the largest two-divisor sum below `12` is
+`4 + 6 = 10`. A finite `decide` over the 64 subsets. -/
+theorem three_le_card_of_sum_eleven :
+    ∀ T ∈ (divisors 12).powerset, T.sum id = 11 → 3 ≤ T.card := by decide
+
+/-- `repLength 12 11 ≥ 3`: the target `11` genuinely needs three divisors. -/
+theorem three_le_repLength_twelve_eleven : 3 ≤ repLength 12 11 := by
+  unfold repLength
+  apply le_csInf
+  · obtain ⟨T, hTsub, hTsum⟩ := twelve_practical.2 11 (by omega) (by omega)
+    exact ⟨T.card, T, hTsub, rfl, hTsum⟩
+  · rintro t ⟨T, hTsub, rfl, hTsum⟩
+    exact three_le_card_of_sum_eleven T (Finset.mem_powerset.mpr hTsub) hTsum
+
+/-- **`hErdos 12 = 3`: subadditivity is tight.** Upper bound:
+`hErdos(2·6) ≤ hErdos 2 + hErdos 6 = 1 + 2` (`hErdos_mul_le`). Lower bound:
+`k = 11` needs three divisors (`three_le_repLength_twelve_eleven`). The counting
+bound `lt_hErdos_of_pow_lt` gives only `hErdos 12 ≥ 2` here, so the tight value
+comes from the combinatorial check, and the subadditive upper bound is attained
+with equality at the factorisation `12 = 2 · 6`. -/
+theorem hErdos_twelve : hErdos 12 = 3 := by
+  refine le_antisymm ?_ ?_
+  · have h : hErdos (2 * 6) ≤ hErdos 2 + hErdos 6 :=
+      hErdos_mul_le two_practical six_practical
+    rw [hErdos_two, hErdos_six] at h
+    calc hErdos 12 = hErdos (2 * 6) := by norm_num
+      _ ≤ 1 + 2 := h
+      _ = 3 := by norm_num
+  · calc 3 ≤ repLength 12 11 := three_le_repLength_twelve_eleven
+      _ ≤ hErdos 12 := by
+          unfold hErdos
+          exact Finset.le_sup (Finset.mem_range.mpr (by omega))
+
 end Erdos18
 

--- a/research/problems/erdos-18-wip-01/knowledge.md
+++ b/research/problems/erdos-18-wip-01/knowledge.md
@@ -284,3 +284,31 @@ Vose's deep hErdos(n!)≪√log(n!) (still out of reach).
 
 NEXT: exact hErdos on other extremal families, hErdos lower bounds via prime
 factorisation, or the deep Vose bound (blocked at elementary layer).
+
+## 2026-07-22 (researcher-1) — UPPER-HALF GAP: hErdos m = 1 iff m = 2; hErdos 6 = 2, hErdos 12 = 3
+
+Shipped the upper-half divisor gap and the first exact composite values of the
+corrected index into `Erdos18WIP01.lean` (0-axiom, host-verified v4.31):
+- `two_mul_le_of_dvd_of_lt`: proper divisor d < m has 2d ≤ m — **no divisor of m
+  lies strictly in (m/2, m)**.
+- `two_le_card_of_sum_upper_half` / `two_le_repLength_of_upper_half`: any k with
+  m < 2k, k < m needs ≥ 2 divisors (k ≠ 0 and k is not itself a divisor).
+- `two_le_hErdos`: practical m ≥ 3 ⟹ hErdos m ≥ 2 (take k = m−1).
+- `hErdos_one` (=0), `hErdos_two` (=1), `hErdos_eq_one_iff`: **hErdos m = 1 ↔ m = 2**
+  over practical m — small values fully pinned.
+- `hErdos_six = 2`: first exact value at a non-power-of-two. Upper: 6 explicit
+  minimum reps via new `repLength_le_of_witness` (4=1+3, 5=2+3, each `by decide`
+  side conditions). Lower: k=5 in the gap (3,6).
+- `hErdos_twelve = 3`: **subadditivity hErdos(2·6) ≤ hErdos 2 + hErdos 6 is TIGHT**.
+  Lower via `three_le_card_of_sum_eleven` — kernel `decide` over the 64 subsets of
+  divisors 12 (largest 2-divisor sum below 12 is 4+6=10); `twelve_practical` by decide.
+  Counting bound `lt_hErdos_of_pow_lt` only gives ≥ 2 here — gap argument strictly sharper.
+
+Idioms: after `rcases c with _ | _ | c` state helper products as `d * (c + 1 + 1)`
+(NOT `d * (c + 2)`) or omega sees distinct atoms; `le_csInf` still needs
+`unfold repLength` first; witness bounds compose as
+`(repLength_le_of_witness (T := {2,3}) (by decide) (by decide)).trans (by decide)`.
+
+NEXT: exact hErdos on 2^a·3 family or hErdos 24/30; a general lower-bound engine
+(iterating the gap argument below m/2?); or the deep Vose hErdos(n!) < n^{o(1)}
+(still blocked at elementary layer).

--- a/src/data/research/problems/erdos-18-wip-01.json
+++ b/src/data/research/problems/erdos-18-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: hErdos index now has (a) exact value hErdos(2^k)=k, (b) sandwich 1<=hErdos<=h<=d(m), and (c) SUBADDITIVITY hErdos(a*b)<=hErdos a+hErdos b + corollary hErdos(m^k)<=k*hErdos m (PR #41475, 0-axiom). Deep/open: hErdos(n!)<n^{o(1)} (Vose); residual mechanic = rename parent h->hCover.",
+    "progressSummary": "PROGRESS: hErdos index has exact values hErdos(2^k)=k, hErdos 6=2, hErdos 12=3 (subadditivity TIGHT at 2*6), characterization hErdos m=1 iff m=2 via upper-half divisor gap (no divisor in (m/2,m)), sandwich 1<=hErdos<=h<=d(m), subadditivity + m<=(d(m)+1)^hErdos counting lower bound (all 0-axiom). Deep/open: hErdos(n!)<n^{o(1)} (Vose); residual mechanic = rename parent h->hCover.",
     "builtItems": [
       "decidableIsRepresentable / decidableIsPractical instances (Erdos18Problem.lean)",
       "zero_isRepresentable, one_isRepresentable, isRepresentable_self, isRepresentable_le_sigma, mem_divisors_le (Erdos18Problem.lean)",
@@ -48,7 +48,10 @@
       "h_le_card_divisors (Erdos18WIP01.lean): h m <= d(m) for practical m [0-axiom]",
       "factorial_le_two_pow_h (Erdos18WIP01.lean): n! <= 2^(h n!) [0-axiom]",
       "Erdos18WIP01.lean: hErdos_two_pow — EXACT hErdos(2^k)=k, first exact value of the corrected Erdos #18 index. Upper repLength_two_pow_le (binary digits, <=k), lower two_pow_sub_one_card_ge (2^k-1 all-ones needs all k powers). Helper sum_image_two_pow_range. 0-axiom docker-verified v4.31.",
-      "repLength_mul_le, hErdos_mul_le, hErdos_pow_le (hErdos(m^k)<=k*hErdos m, tight at m=2), repLength_zero, repLength_spec in Erdos18WIP01.lean (0-axiom)"
+      "repLength_mul_le, hErdos_mul_le, hErdos_pow_le (hErdos(m^k)<=k*hErdos m, tight at m=2), repLength_zero, repLength_spec in Erdos18WIP01.lean (0-axiom)",
+      "repLength_le_of_witness, two_mul_le_of_dvd_of_lt, two_le_card_of_sum_upper_half, two_le_repLength_of_upper_half in Erdos18WIP01.lean (upper-half gap engine)",
+      "two_le_hErdos (practical m>=3), hErdos_one, hErdos_two, hErdos_eq_one_iff in Erdos18WIP01.lean",
+      "hErdos_six (=2, first non-2-power exact value), twelve_practical, three_le_card_of_sum_eleven (kernel decide over 64 subsets), three_le_repLength_twelve_eleven, hErdos_twelve (=3, subadditivity tight) in Erdos18WIP01.lean"
     ],
     "insights": [
       "Erdos18Problem.lean stub developed: representability (IsRepresentable) and practicality (IsPractical) are DECIDABLE via a finite powerset search over the divisor set — a single decision procedure subsuming all future example checks; all lemmas axiom-free (plain kernel decide, no native_decide/Lean.ofReduceBool).",
@@ -66,7 +69,10 @@
       "Proved h_le_card_divisors : IsPractical m -> h m <= (divisors m).card (upper bound d(m)). Together: log2 m <= h m <= d(m) for the file h.",
       "Erdos18OQ01.lean already proves subadditivity h(mn)<=h(m)+h(n) for this universal-set h (correct for that quantity), so the def cannot simply be replaced: mechanic should RENAME the parent h to the universal-set index and introduce the max-representation-length index for the conjectures.",
       "hErdos(2^k)=k=log2(2^k) is the MAXIMAL value of the Erdos #18 index for a number of that size (hErdos m <= h m <= d(m); d(2^k)=k+1). Powers of two are the WORST case for the index — extremal opposite of the deep conjectured factorial behaviour hErdos(n!)<n^{o(1)} (Vose). First exact hErdos family value.",
-      "hErdos is SUBADDITIVE over products: hErdos(a*b) <= hErdos a + hErdos b for practical a,b (PR #41475). Correct-index counterpart of the parent Erdos18OQ01 subadditivity, which held only for the over-counting universal-set h."
+      "hErdos is SUBADDITIVE over products: hErdos(a*b) <= hErdos a + hErdos b for practical a,b (PR #41475). Correct-index counterpart of the parent Erdos18OQ01 subadditivity, which held only for the over-counting universal-set h.",
+      "Upper-half divisor gap: no divisor of m lies strictly in (m/2, m) (proper divisor has cofactor >= 2), so any k with m<2k<2m needs >= 2 divisors in every distinct-divisor representation",
+      "hErdos m = 1 exactly at m = 2 (over practical m): m=1 gives 0, and k=m-1 forces hErdos >= 2 for practical m>=3",
+      "hErdos 12 = 3 shows subadditivity hErdos(a*b)<=hErdos a+hErdos b is TIGHT at 12=2*6; the counting bound lt_hErdos_of_pow_lt only gives hErdos 12 >= 2, so the combinatorial gap argument is strictly sharper at small scales"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for **erdos-18-wip-01** (practical numbers, corrected Erdős #18 index `hErdos`). Adds the **upper-half divisor gap** lower-bound engine and the first exact values of the corrected index beyond powers of two — all 0-axiom (`propext`/`Classical.choice`/`Quot.sound` only; kernel `decide`, no `native_decide`).

## Progress
- `two_mul_le_of_dvd_of_lt` — no divisor of `m` lies strictly in `(m/2, m)` (proper divisor has cofactor ≥ 2)
- `two_le_card_of_sum_upper_half` / `two_le_repLength_of_upper_half` — any target in the open upper half needs ≥ 2 divisors
- `two_le_hErdos` — practical `m ≥ 3` has `hErdos m ≥ 2` (take `k = m − 1`)
- `hErdos_one` (= 0), `hErdos_two` (= 1), `hErdos_eq_one_iff` — **`hErdos m = 1` iff `m = 2`** over practical `m`; small values fully pinned
- `hErdos_six = 2` — first exact value at a non-power-of-two (six explicit witness representations via new `repLength_le_of_witness`; lower bound `k = 5` in the gap `(3, 6)`)
- `hErdos_twelve = 3` — **subadditivity `hErdos(2·6) ≤ hErdos 2 + hErdos 6` is TIGHT**; lower bound `three_le_card_of_sum_eleven` by kernel `decide` over the 64 subsets of `divisors 12` (largest two-divisor sum below 12 is 4+6 = 10)

## Findings
- The gap argument is strictly sharper than the counting bound `lt_hErdos_of_pow_lt` at small scales (that bound only gives `hErdos 12 ≥ 2`).
- Files: `proofs/Proofs/Erdos18WIP01.lean` (+183, now 2046 lines), knowledge tracker + problem JSON updated.
- Verification: host-verified on toolchain v4.31.0 (fresh parent olean + full type-check, exit 0, no sorries); `#print axioms` on all 8 new theorems shows foundational axioms only.

## Status
**Outcome**: progress
**Next Steps**: exact `hErdos` on the `2^a·3` family or `hErdos 24/30`; a general lower-bound engine iterating the gap argument below `m/2`; deep Vose `hErdos(n!) < n^{o(1)}` remains blocked at the elementary layer.

🤖 Generated by researcher-1
