### PR TITLE
audit(pythagorean-triples): fix phantom mainTheorems entry

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24122,10 +24122,10 @@
       "issues": []
     },
     "pythagorean-triples": {
-      "auditCount": 10,
+      "auditCount": 11,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:28Z",
-      "result": "clean"
+      "lastAudited": "2026-07-22T16:29:24Z",
+      "result": "issues-fixed"
     },
     "pythagorean-triples-oq-01": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/pythagorean-triples/meta.json
+++ b/src/data/proofs/pythagorean-triples/meta.json
@@ -206,10 +206,16 @@
   ],
   "mainTheorems": [
     {
-      "name": "pythagorean_triple_parametrization",
+      "name": "primitive_triples_are_classified",
       "type": "core",
-      "description": "All primitive Pythagorean triples are of the form (m^2-n^2, 2mn, m^2+n^2)",
-      "leanType": "primitive_triple a b c -> exists m n, a = m^2 - n^2 and b = 2*m*n and c = m^2 + n^2"
+      "description": "Every primitive Pythagorean triple has the parametric form (m^2-n^2, 2mn, m^2+n^2)",
+      "leanType": "PythagoreanTriple x y z -> Int.gcd x y = 1 -> h.IsPrimitiveClassified"
+    },
+    {
+      "name": "all_triples_are_classified",
+      "type": "core",
+      "description": "Every Pythagorean triple is a scalar multiple of a primitively classified triple",
+      "leanType": "PythagoreanTriple x y z -> h.IsClassified"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Integrity Issue

**Proof**: pythagorean-triples
**Problem**: `meta.json`'s `mainTheorems` array named a fabricated theorem `pythagorean_triple_parametrization` that does not exist anywhere in `Proofs/PythagoreanTriples.lean`.

## Evidence

**meta.json claims**: `mainTheorems[0].name = "pythagorean_triple_parametrization"` with a hand-written informal `leanType`.
**Lean file shows**: no such declaration (`grep -n pythagorean_triple_parametrization` returns nothing). The actual classification theorems are `primitive_triples_are_classified` and `all_triples_are_classified`, both wrappers around Mathlib's `PythagoreanTriple.isPrimitiveClassified_of_coprime` / `.classified`.

## Fix

Replaced the phantom entry with the two real theorems and their actual `leanType` signatures. Everything else in the entry was already accurate: 0 sorries, 0 axioms, theoremCount 15 / lineCount 260 match the source exactly, and the Mathlib-wrapper badge/disclosure (`badge: mathlib`, `originalContributions` scoped to bridge/examples) was already correct.

Also includes the routine `audit-tracker.json` update marking this entry re-audited (`issues-fixed`).

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)