### PR TITLE
Fix: sqrt2-examples drop phantom irrationality mainTheorems entry

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25269,10 +25269,10 @@
       "issues": []
     },
     "sqrt2-examples": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:29Z",
-      "result": "clean"
+      "lastAudited": "2026-07-22T16:36:38Z",
+      "result": "issues-fixed"
     },
     "sqrt2-examples-oq-01": {
       "auditCount": 3,

--- a/src/data/proofs/sqrt2-examples/meta.json
+++ b/src/data/proofs/sqrt2-examples/meta.json
@@ -184,10 +184,16 @@
   ],
   "mainTheorems": [
     {
-      "name": "sqrt2_irrational_variants",
+      "name": "square_nonneg",
       "type": "core",
-      "description": "Multiple proof variants of irrationality of sqrt(2)",
-      "leanType": "Irrational (Real.sqrt 2)"
+      "description": "The square of any integer is non-negative",
+      "leanType": "0 ≤ n * n"
+    },
+    {
+      "name": "imp_trans",
+      "type": "core",
+      "description": "Implication is transitive",
+      "leanType": "(P → Q) → (Q → R) → (P → R)"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Integrity Issue

**Proof**: sqrt2-examples
**Problem**: `mainTheorems` in meta.json claimed a `sqrt2_irrational_variants` theorem with `leanType: "Irrational (Real.sqrt 2)"` — this is a phantom declaration copy-pasted from the sibling `sqrt2-irrational` gallery entry (its `mainTheorems` entry is `sqrt2_irrational` / `Irrational (Real.sqrt 2)`, nearly identical).

## Evidence

**meta.json claimed**: main theorem is `sqrt2_irrational_variants : Irrational (Real.sqrt 2)`, described as "Multiple proof variants of irrationality of sqrt(2)".

**Lean file shows** (`proofs/Proofs/Sqrt2.lean`, 48 lines): only two theorems exist — `square_nonneg (n : ℤ) : 0 ≤ n * n` and `imp_trans (P Q R : Prop) : (P → Q) → (Q → R) → (P → R)`. No irrationality result, no `Real.sqrt` reference anywhere in the file. This file is a pedagogical tactic-demo file, unrelated in content to the sqrt(2)-irrationality claim.

All other fields (badge `mathlib`, 0 axioms, 0 sorries, theoremCount 2, `originalContributions`, `overview`) already correctly describe the actual file content — only `mainTheorems` had drifted, presumably from a copy/adapt of the sibling entry.

## Fix

Replaced the phantom entry with the two theorems the file actually proves: `square_nonneg` and `imp_trans`.

---
Discovered during gallery integrity audit (reserve-mode re-serve, queue fully drained: 4809/4809 audited, 0 issues at scan time).