### PR TITLE
Research: erdos-751-incomplete-01 — prove chromatic-degeneracy lemma, eliminate false axiom (2→1)

### DIFF
--- a/proofs/Proofs/Erdos751Problem.lean
+++ b/proofs/Proofs/Erdos751Problem.lean
@@ -31,6 +31,8 @@ import Mathlib.Combinatorics.SimpleGraph.Basic
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.WalkCounting
 import Mathlib.Combinatorics.SimpleGraph.Coloring.Vertex
 import Mathlib.Combinatorics.SimpleGraph.Girth
+import Mathlib.Combinatorics.SimpleGraph.Maps
+import Mathlib.Combinatorics.SimpleGraph.Paths
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Nat.Basic
 import Mathlib.Order.Lattice.Nat
@@ -128,18 +130,190 @@ For any graph G with at least one vertex:
 More importantly for us:
   If χ(G) ≥ k, then G has a subgraph with minimum degree ≥ k - 1.
 -/
-/--
-**Chromatic–degeneracy lemma (subgraph form):**
-Every graph with chromatic number 4 contains a subgraph `H ≤ G` of minimum
-degree at least 3. The bound holds on a *subgraph*, **not** on the global
-minimum degree of `G`: e.g. `K₄` plus an isolated vertex is 4-chromatic yet has
-global minimum degree 0.
+/-- A graph on an empty vertex type is `n`-colorable for every `n`. -/
+theorem colorable_of_isEmpty {W : Type*} [IsEmpty W] (H : SimpleGraph W) (n : ℕ) :
+    H.Colorable n :=
+  ⟨Coloring.mk (fun v => isEmptyElim v) (fun {v} _ _ => isEmptyElim v)⟩
 
-This is the standard chromatic–degeneracy fact: `χ(G) ≥ k` implies `G` has a
-subgraph of minimum degree `≥ k − 1` (equivalently, degeneracy `≥ k − 1`). -/
-axiom four_chromatic_subgraph_minDeg (G : SimpleGraph V) [DecidableRel G.Adj] :
-    chromaticNumber G = 4 →
-    ∃ (H : SimpleGraph V) (_ : DecidableRel H.Adj), H ≤ G ∧ minDegree H ≥ 3
+/-- A graph whose (file) chromatic number is `4` is not 3-colorable. -/
+theorem not_colorable_three_of_chromaticNumber_four (G : SimpleGraph V)
+    [DecidableRel G.Adj] (hchi : chromaticNumber G = 4) : ¬ G.Colorable 3 := by
+  intro hcol
+  have hle : SimpleGraph.chromaticNumber G ≤ (3 : ℕ) := hcol.chromaticNumber_le
+  have h3 : ((3 : ℕ) : ℕ∞) ≠ ⊤ := by simp
+  have hton := ENat.toNat_le_toNat hle h3
+  unfold chromaticNumber at hchi
+  simp at hton
+  omega
+
+/-- **Greedy extension step**: if `v ∈ t` has fewer than `3` neighbours inside
+`t` and the graph induced on `t.erase v` is 3-colorable, then so is the graph
+induced on `t` — colour `v` with a colour unused by its (at most two)
+neighbours. -/
+theorem colorable_of_erase_colorable (G : SimpleGraph V) [DecidableRel G.Adj]
+    {t : Finset V} {v : V} (hv : v ∈ t)
+    (hdeg : (t.filter (fun u => G.Adj v u)).card < 3)
+    (hcol : (G.induce (↑(t.erase v) : Set V)).Colorable 3) :
+    (G.induce (↑t : Set V)).Colorable 3 := by
+  obtain ⟨C⟩ := hcol
+  -- the colours used by neighbours of `v` inside `t.erase v`
+  set N : Finset V := (t.erase v).filter (fun u => G.Adj v u) with hN
+  have hNsub : ∀ u ∈ N, u ∈ t.erase v := fun u hu => (Finset.mem_filter.mp hu).1
+  set used : Finset (Fin 3) :=
+    N.attach.image (fun u => C ⟨u.1, Finset.mem_coe.mpr (hNsub u.1 u.2)⟩) with hused
+  have husedcard : used.card < 3 := by
+    have h1 : used.card ≤ N.attach.card := Finset.card_image_le
+    have h1' : N.attach.card = N.card := Finset.card_attach
+    have h2 : N.card ≤ (t.filter (fun u => G.Adj v u)).card := by
+      apply Finset.card_le_card
+      intro u hu
+      rw [hN, Finset.mem_filter] at hu
+      rw [Finset.mem_filter]
+      exact ⟨Finset.mem_of_mem_erase hu.1, hu.2⟩
+    omega
+  -- a free colour exists
+  obtain ⟨c, hc⟩ : ∃ c : Fin 3, c ∉ used := by
+    by_contra hcon
+    have hall : used = Finset.univ := by
+      apply Finset.eq_univ_iff_forall.mpr
+      intro c
+      by_contra hcc
+      exact hcon ⟨c, hcc⟩
+    rw [hall, Finset.card_univ] at husedcard
+    simp at husedcard
+  -- extend the colouring by giving `v` the free colour
+  refine ⟨Coloring.mk (fun x => if hx : x.1 = v then c else
+    C ⟨x.1, Finset.mem_coe.mpr
+      (Finset.mem_erase.mpr ⟨hx, Finset.mem_coe.mp x.2⟩)⟩) ?_⟩
+  rintro ⟨a, ha⟩ ⟨b, hb⟩ hadj
+  have hadj' : G.Adj a b := hadj
+  by_cases hav : a = v <;> by_cases hbv : b = v
+  · subst hav
+    subst hbv
+    exact absurd hadj' G.irrefl
+  · simp only [dif_pos hav, dif_neg hbv]
+    have hbN : b ∈ N := by
+      rw [hN, Finset.mem_filter]
+      exact ⟨Finset.mem_erase.mpr ⟨hbv, Finset.mem_coe.mp hb⟩, hav ▸ hadj'⟩
+    intro heq
+    apply hc
+    rw [heq]
+    exact Finset.mem_image.mpr ⟨⟨b, hbN⟩, Finset.mem_attach _ _, rfl⟩
+  · simp only [dif_pos hbv, dif_neg hav]
+    have haN : a ∈ N := by
+      rw [hN, Finset.mem_filter]
+      exact ⟨Finset.mem_erase.mpr ⟨hav, Finset.mem_coe.mp ha⟩,
+        (show G.Adj a v from hbv ▸ hadj').symm⟩
+    intro heq
+    apply hc
+    rw [← heq]
+    exact Finset.mem_image.mpr ⟨⟨a, haN⟩, Finset.mem_attach _ _, rfl⟩
+  · simp only [dif_neg hav, dif_neg hbv]
+    exact C.valid hadj'
+
+/-- **Critical-subgraph extraction**: any vertex set whose induced subgraph is
+not 3-colorable contains a nonempty subset in which every vertex has at least
+`3` neighbours *inside the subset*. Strong induction on the vertex set: a
+vertex with fewer than 3 internal neighbours can be removed without making the
+induced graph 3-colorable (`colorable_of_erase_colorable`). -/
+theorem exists_min_subset_of_not_colorable (G : SimpleGraph V)
+    [DecidableRel G.Adj] :
+    ∀ t : Finset V, ¬ (G.induce (↑t : Set V)).Colorable 3 →
+    ∃ s : Finset V, s.Nonempty ∧
+      ∀ v ∈ s, 3 ≤ (s.filter (fun u => G.Adj v u)).card := by
+  intro t
+  induction t using Finset.strongInduction with
+  | _ t ih =>
+    intro hncol
+    by_cases hall : ∀ v ∈ t, 3 ≤ (t.filter (fun u => G.Adj v u)).card
+    · refine ⟨t, ?_, hall⟩
+      rcases Finset.eq_empty_or_nonempty t with rfl | hne
+      · exfalso
+        apply hncol
+        haveI : IsEmpty ↥((↑(∅ : Finset V)) : Set V) := by
+          constructor
+          rintro ⟨x, hx⟩
+          simp at hx
+        exact colorable_of_isEmpty _ 3
+      · exact hne
+    · simp only [not_forall, not_le] at hall
+      obtain ⟨v, hvt, hdeg⟩ := hall
+      exact ih (t.erase v) (Finset.erase_ssubset hvt)
+        (fun hcol => hncol (colorable_of_erase_colorable G hvt hdeg hcol))
+
+/--
+**Chromatic–degeneracy lemma (PROVED, sound induced-subgraph form):**
+Every graph with chromatic number 4 contains a nonempty vertex set `s` in which
+every vertex has at least `3` neighbours *inside `s`* — i.e. the subgraph
+induced on `s` has minimum degree at least 3.
+
+The bound is on the *induced subgraph*: a previous formalization asserted
+`∃ H ≤ G, minDegree H ≥ 3` with `minDegree` ranging over **all** of `V`, which
+is false (for `K₄` plus an isolated vertex every subgraph `H ≤ G` on the same
+vertex type keeps the isolated vertex at degree 0). This statement quantifies
+the degree only over the extracted vertex set, which is the correct classical
+fact — and it is proved here (formerly an axiom): take a vertex-minimal subset
+whose induced subgraph is not 3-colorable; each of its vertices must have `≥ 3`
+internal neighbours, else greedy extension of a 3-colouring of the smaller set
+would 3-colour it. -/
+theorem four_chromatic_subgraph_minDeg (G : SimpleGraph V) [DecidableRel G.Adj]
+    (hchi : chromaticNumber G = 4) :
+    ∃ s : Finset V, s.Nonempty ∧
+      ∀ v ∈ s, 3 ≤ (s.filter (fun u => G.Adj v u)).card := by
+  apply exists_min_subset_of_not_colorable G Finset.univ
+  intro hcol
+  apply not_colorable_three_of_chromaticNumber_four G hchi
+  obtain ⟨C⟩ := hcol
+  exact ⟨C.comp ⟨fun v => ⟨v, by simp⟩, fun {a b} h => h⟩⟩
+
+/-- The degree of a vertex in the graph induced on `↑s` equals the number of
+its neighbours inside `s`. -/
+theorem degree_induce_eq_filter_card (G : SimpleGraph V) [DecidableRel G.Adj]
+    (s : Finset V) [DecidableRel (G.induce (↑s : Set V)).Adj]
+    (x : ↥(↑s : Set V)) :
+    (G.induce (↑s : Set V)).degree x = (s.filter (fun u => G.Adj x.1 u)).card := by
+  show ((G.induce (↑s : Set V)).neighborFinset x).card = _
+  apply Finset.card_bij (fun y _ => y.1)
+  · intro y hy
+    rw [SimpleGraph.mem_neighborFinset] at hy
+    rw [Finset.mem_filter]
+    exact ⟨Finset.mem_coe.mp y.2, hy⟩
+  · intro y1 h1 y2 h2 heq
+    exact Subtype.ext heq
+  · intro u hu
+    rw [Finset.mem_filter] at hu
+    exact ⟨⟨u, Finset.mem_coe.mpr hu.1⟩,
+      by rw [SimpleGraph.mem_neighborFinset]; exact hu.2, rfl⟩
+
+/-- If every vertex of `s` has at least 3 neighbours inside `s`, the graph
+induced on `s` has minimum degree at least 3. -/
+theorem minDegree_induce_ge (G : SimpleGraph V) [DecidableRel G.Adj]
+    (s : Finset V) [Nonempty ↥(↑s : Set V)]
+    [DecidableRel (G.induce (↑s : Set V)).Adj]
+    (h : ∀ v ∈ s, 3 ≤ (s.filter (fun u => G.Adj v u)).card) :
+    minDegree (G.induce (↑s : Set V)) ≥ 3 := by
+  unfold minDegree
+  apply Finset.le_min'
+  intro y hy
+  rw [Finset.mem_image] at hy
+  obtain ⟨x, _, rfl⟩ := hy
+  rw [degree_induce_eq_filter_card]
+  exact h x.1 (Finset.mem_coe.mp x.2)
+
+/-- Every cycle of the graph induced on `s` is a cycle of `G`: the induced
+graph embeds into `G`, and cycles map to cycles along injective
+homomorphisms. -/
+theorem cycleLengths_induce_subset (G : SimpleGraph V) [DecidableRel G.Adj]
+    (s : Set V) [DecidableRel (G.induce s).Adj] :
+    cycleLengths (G.induce s) ⊆ cycleLengths G := by
+  rintro n ⟨v, c, hcyc, hlen⟩
+  let f : G.induce s ↪g G :=
+    (induceUnivIso G).toEmbedding.comp (G.induceHomOfLE (Set.subset_univ s))
+  have hinj : Function.Injective (f.toHom : ↥s → V) := f.injective
+  refine ⟨f.toHom v, c.map f.toHom, ?_, ?_⟩
+  · exact (Walk.map_isCycle_iff_of_injective hinj).mpr hcyc
+  · rw [Walk.length_map]
+    exact hlen
 
 /-
 ## Part III: Bondy-Vince Theorem
@@ -182,10 +356,16 @@ theorem erdos_751_chromatic_4 (G : SimpleGraph V) [DecidableRel G.Adj] :
     ∃ m m' : ℕ, m ∈ cycleLengths G ∧ m' ∈ cycleLengths G ∧ m ≠ m' ∧
       (m : ℤ) - m' ≤ 2 ∧ (m' : ℤ) - m ≤ 2 := by
   intro hchi
-  obtain ⟨H, hH, hle, hminH⟩ := four_chromatic_subgraph_minDeg G hchi
-  letI := hH
-  obtain ⟨m, m', hm, hm', hne, hg1, hg2⟩ := bondy_vince_theorem H hminH
-  exact ⟨m, m', cycleLengths_mono hle hm, cycleLengths_mono hle hm', hne, hg1, hg2⟩
+  obtain ⟨s, hne, hdeg⟩ := four_chromatic_subgraph_minDeg G hchi
+  haveI : Nonempty ↥((↑s : Set V)) :=
+    ⟨⟨hne.choose, Finset.mem_coe.mpr hne.choose_spec⟩⟩
+  letI : DecidableRel (G.induce (↑s : Set V)).Adj :=
+    fun a b => decidable_of_iff (G.Adj a.1 b.1) induce_adj.symm
+  have hmin : minDegree (G.induce (↑s : Set V)) ≥ 3 := minDegree_induce_ge G s hdeg
+  obtain ⟨m, m', hm, hm', hnem, hg1, hg2⟩ :=
+    bondy_vince_theorem (G.induce (↑s : Set V)) hmin
+  exact ⟨m, m', cycleLengths_induce_subset G _ hm,
+    cycleLengths_induce_subset G _ hm', hnem, hg1, hg2⟩
 
 /--
 **Erdős Problem #751: Part 2**
@@ -239,14 +419,16 @@ theorem min_degree_3_cycle_gap (G : SimpleGraph V) [DecidableRel G.Adj] :
 
 /--
 **Why Chromatic Number 4 Implies a Dense Subgraph:**
-A graph with χ(G) = 4 must contain a subgraph of minimum degree ≥ 3
-(the chromatic–degeneracy lemma). The bound holds on the subgraph, not on the
-global minimum degree of `G` (an isolated vertex forces the latter to 0).
+A graph with χ(G) = 4 must contain a nonempty vertex set on which the induced
+subgraph has minimum degree ≥ 3 (the chromatic–degeneracy lemma, proved above).
+The bound holds inside the extracted vertex set, not on the global minimum
+degree of `G` (an isolated vertex forces the latter to 0).
 -/
 theorem chromatic_4_implies_subgraph_min_deg_3 (G : SimpleGraph V)
     [DecidableRel G.Adj] :
     chromaticNumber G = 4 →
-    ∃ (H : SimpleGraph V) (_ : DecidableRel H.Adj), H ≤ G ∧ minDegree H ≥ 3 :=
+    ∃ s : Finset V, s.Nonempty ∧
+      ∀ v ∈ s, 3 ≤ (s.filter (fun u => G.Adj v u)).card :=
   four_chromatic_subgraph_minDeg G
 
 /-
@@ -273,9 +455,10 @@ theorem erdos_751_summary (G : SimpleGraph V) [DecidableRel G.Adj] :
     (minDegree G ≥ 3 →
       ∃ m m' : ℕ, m ∈ cycleLengths G ∧ m' ∈ cycleLengths G ∧ m ≠ m' ∧
         (m : ℤ) - m' ≤ 2 ∧ (m' : ℤ) - m ≤ 2) ∧
-    -- Connection: χ = 4 implies a subgraph of min degree ≥ 3
+    -- Connection: χ = 4 implies an induced subgraph of min degree ≥ 3
     (chromaticNumber G = 4 →
-      ∃ (H : SimpleGraph V) (_ : DecidableRel H.Adj), H ≤ G ∧ minDegree H ≥ 3) :=
+      ∃ s : Finset V, s.Nonempty ∧
+        ∀ v ∈ s, 3 ≤ (s.filter (fun u => G.Adj v u)).card) :=
   ⟨erdos_751_chromatic_4 G, min_degree_3_cycle_gap G,
     chromatic_4_implies_subgraph_min_deg_3 G⟩
 

--- a/research/problems/erdos-751-incomplete-01/knowledge.md
+++ b/research/problems/erdos-751-incomplete-01/knowledge.md
@@ -40,3 +40,44 @@ degeneracy/3-core, neither of which has ready Mathlib API.
 
 - `bondy_vince_theorem` (δ ≥ 3 ⇒ two cycle lengths differ by ≤ 2) — deep 1998
   result, no Mathlib cycle-length-spectrum API. Left as an axiom.
+
+## 2026-07-22 (researcher-1, session 2) — AXIOM ELIMINATED: chromatic–degeneracy lemma PROVED (2→1 axioms)
+
+**Integrity finding (second round):** the #41481 repair `four_chromatic_subgraph_minDeg`
+(`∃ H ≤ G, minDegree H ≥ 3`, H on the SAME vertex type) was STILL false as stated —
+`minDegree` is `Finset.min'` over `Finset.univ`, i.e. over **all** of `V`, so for
+`K₄ ⊕ isolated-vertex` every `H ≤ G` keeps the isolated vertex at degree 0. The
+axiom was instantiable to `False` (V := Fin 5).
+
+**Fix + proof (0 new axioms, host-verified v4.31, EXIT=0):** restated in sound
+induced-subgraph form and **proved it from Mathlib** — the file's axiom count
+drops 2 → 1 (only the deep `bondy_vince_theorem` remains):
+
+- `four_chromatic_subgraph_minDeg` (now a THEOREM): `χ(G) = 4 → ∃ s : Finset V,
+  s.Nonempty ∧ ∀ v ∈ s, 3 ≤ #(s.filter (G.Adj v ·))`.
+- Engine: `exists_min_subset_of_not_colorable` — strong induction
+  (`Finset.strongInduction`) extracting a vertex-minimal non-3-colorable subset;
+  `colorable_of_erase_colorable` — greedy extension: a vertex with < 3 internal
+  neighbours gets a colour from `Fin 3` unused by its ≤ 2 neighbours
+  (`used.card < 3 → used ≠ univ → ∃ free colour`).
+- `not_colorable_three_of_chromaticNumber_four` (via `Colorable.chromaticNumber_le`
+  + `ENat.toNat_le_toNat`), `colorable_of_isEmpty`.
+- Bridges: `degree_induce_eq_filter_card` (`Finset.card_bij` on `neighborFinset`),
+  `minDegree_induce_ge`, `cycleLengths_induce_subset` (embedding
+  `(induceUnivIso G).toEmbedding.comp (G.induceHomOfLE (Set.subset_univ s))` +
+  `Walk.map_isCycle_iff_of_injective` + `Walk.length_map`).
+- Headline theorems rewired: `#print axioms erdos_751` =
+  `[propext, Classical.choice, Erdos751.bondy_vince_theorem, Quot.sound]`.
+
+**Idioms (v4.31):** `G.loopless`/`G.symm` are now `Std.Irrefl`/`Std.Symm`
+structure instances, NOT functions — use `G.irrefl : ¬G.Adj v v` and
+`Adj.symm`; `induceHomOfLE` takes `G` explicitly (`G.induceHomOfLE h`);
+`SimpleGraph.mem_neighborFinset.mpr` fails name resolution — use
+`by rw [SimpleGraph.mem_neighborFinset]; exact _`; `(G.induce s).Adj` is defeq
+`G.Adj` so `have hadj' : G.Adj a b := hadj` avoids all `induce_adj` rewriting;
+`DecidableRel (G.induce ↑s).Adj := fun a b => decidable_of_iff (G.Adj a.1 b.1)
+induce_adj.symm`.
+
+## Open (blocked, unchanged)
+
+- `bondy_vince_theorem` — deep 1998 result, no Mathlib cycle-length-spectrum API.

--- a/src/data/proofs/erdos-751/meta.json
+++ b/src/data/proofs/erdos-751/meta.json
@@ -45,23 +45,25 @@
       "minDegree and maxDegree definitions for SimpleGraph",
       "chromaticNumber, girth, cycleLengths definitions (stubbed)",
       "minCycleLengthGap definition for consecutive cycle analysis",
-      "four_chromatic_subgraph_minDeg axiom: chi = 4 implies a subgraph H <= G with min degree >= 3",
+      "four_chromatic_subgraph_minDeg THEOREM (axiom eliminated): chi = 4 implies a nonempty vertex set whose induced subgraph has min degree >= 3, proved by critical-subgraph extraction (strong induction + greedy 3-coloring extension)",
       "bondy_vince_theorem axiom: min degree >= 3 implies close cycles",
       "erdos_751_chromatic_4: main theorem for chi = 4",
       "erdos_751_with_girth: girth doesn't help",
-      "erdos_751_summary: combined results"
+      "erdos_751_summary: combined results",
+      "colorable_of_erase_colorable / exists_min_subset_of_not_colorable: greedy coloring-extension engine over induced subgraphs",
+      "degree_induce_eq_filter_card, minDegree_induce_ge, cycleLengths_induce_subset: bridges from the extracted vertex set to bondy_vince_theorem and back into G"
     ],
-    "axiomCount": 2,
-    "lineCount": 280,
-    "assumptions": "2 axioms: four_chromatic_subgraph_minDeg (χ(G)=4 ⟹ G has a subgraph H ≤ G with minDegree H ≥ 3 — the chromatic–degeneracy lemma; the bound is on a subgraph, NOT the global minimum degree, which an isolated vertex can force to 0) and bondy_vince_theorem (Bondy–Vince 1998: minDegree ≥ 3 ⟹ two cycle lengths differ by ≤ 2) — both deep graph-theory results. The subgraph's close cycles lift to G via the verified cycleLengths_mono lemma. 0 sorries. The chromaticNumber, girth, and cycleLengths definitions were previously axiomatized; they are now defined from Mathlib (SimpleGraph.chromaticNumber.toNat, SimpleGraph.girth, and the set of cycle-walk lengths respectively).",
-    "theoremCount": 8,
-    "definitionCount": 3
+    "axiomCount": 1,
+    "lineCount": 465,
+    "assumptions": "1 axiom: bondy_vince_theorem (Bondy–Vince 1998: minDegree ≥ 3 ⟹ two cycle lengths differ by ≤ 2) — a deep graph-theory result with no Mathlib cycle-length-spectrum API. The chromatic–degeneracy lemma four_chromatic_subgraph_minDeg (χ(G)=4 ⟹ a nonempty vertex set s in which every vertex has ≥ 3 neighbours inside s, i.e. the induced subgraph has minimum degree ≥ 3) is now PROVED from Mathlib via a critical-subgraph argument (take a vertex-minimal subset whose induced graph is not 3-colorable; greedy extension shows each of its vertices has ≥ 3 internal neighbours). A previous formulation quantified minDegree over the whole vertex type, which was false as stated (K₄ plus an isolated vertex); the proved statement bounds degrees inside the extracted set. The subgraph's close cycles lift to G via the verified cycleLengths_induce_subset lemma. 0 sorries.",
+    "theoremCount": 16,
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "**Erdos Problem #751: Cycle Lengths in Graphs**\n\nThis problem explores the structure of cycles in graphs with chromatic constraints.\n\n**Key History:**\n- Erdos posed the question about cycle length gaps in 4-chromatic graphs\n- Bondy and Vince (1998): Proved the key result about minimum degree 3\n- The result is tight: K_4 has cycles of lengths 3 and 4 (gap = 1)\n\n**Mathematical Setting:**\n- Chromatic number chi(G) = minimum colors for proper vertex coloring\n- Girth = length of shortest cycle\n- Minimum degree delta(G) = smallest vertex degree\n\n**Key Connection:**\nChromatic number and degeneracy are related: chi(G) >= k implies G contains a subgraph of minimum degree >= k - 1. So chi(G) = 4 forces a subgraph with delta >= 3 (not the global minimum degree, which an isolated vertex can force to 0).",
     "problemStatement": "**Problem Statement (SOLVED)**\n\nLet G be a graph with chromatic number chi(G) = 4. If m_1 < m_2 < ... are the lengths of cycles in G, can min(m_{i+1} - m_i) be arbitrarily large? Can this happen if the girth of G is large?\n\n**Answer: NO**\n\nBondy and Vince (1998) proved that every graph with minimum degree >= 3 has two cycles whose lengths differ by at most 2.\n\nSince chi(G) = 4 implies G has a subgraph of minimum degree >= 3, the answer follows (the two close cycles in that subgraph are also cycles in G). Large girth doesn't help.",
     "text": "For graphs with chromatic number 4, can consecutive cycle lengths have arbitrarily large gaps? Answer: NO - Bondy-Vince (1998) proved min degree >= 3 implies two cycles differ by at most 2.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Graph Foundations:** Define minDegree, maxDegree, chromaticNumber, girth, cycleLengths using Mathlib's SimpleGraph.\n\n2. **Key Relationship:** Axiomatize the chromatic–degeneracy lemma: chi(G) = 4 implies a subgraph H <= G with minDegree(H) >= 3 (the bound is on a subgraph, not the global minimum degree).\n\n3. **Bondy-Vince Theorem:** Axiomatize that minDegree >= 3 implies existence of two cycles with length difference <= 2.\n\n4. **Main Results:** Derive that chi(G) = 4 implies close cycles, with or without girth constraints.\n\n5. **Summary:** Combine all results showing the answer is NO.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Graph Foundations:** Define minDegree, maxDegree, chromaticNumber, girth, cycleLengths using Mathlib's SimpleGraph.\n\n2. **Key Relationship:** PROVE the chromatic–degeneracy lemma: chi(G) = 4 implies a nonempty vertex set s in which every vertex has >= 3 neighbours inside s (minimum degree of the induced subgraph). Proof: take a vertex-minimal subset whose induced graph is not 3-colorable; a vertex with < 3 internal neighbours could be removed and the 3-coloring extended greedily.\n\n3. **Bondy-Vince Theorem:** Axiomatize (the file's only remaining axiom) that minDegree >= 3 implies existence of two cycles with length difference <= 2.\n\n4. **Main Results:** Derive that chi(G) = 4 implies close cycles, with or without girth constraints.\n\n5. **Summary:** Combine all results showing the answer is NO.",
     "keyInsights": [
       "**Chromatic-Degree Connection:** chi(G) = 4 forces a subgraph of minimum degree >= 3",
       "**Bondy-Vince Theorem:** min degree >= 3 gives cycles differing by <= 2",
@@ -79,48 +81,48 @@
     {
       "id": "graph-foundations",
       "title": "Graph Theory Foundations",
-      "summary": "minDegree, maxDegree, chromaticNumber, girth, cycleLengths definitions",
-      "startLine": 37,
-      "endLine": 87
+      "summary": "minDegree, maxDegree, chromaticNumber, girth, cycleLengths, minCycleLengthGap definitions",
+      "startLine": 44,
+      "endLine": 109
     },
     {
       "id": "key-relationships",
       "title": "Key Relationships",
-      "summary": "four_chromatic_subgraph_minDeg axiom: chi(G) = 4 implies a subgraph H <= G with minDegree(H) >= 3",
-      "startLine": 88,
-      "endLine": 107
+      "summary": "cycleLengths_mono; chromatic-degeneracy lemma four_chromatic_subgraph_minDeg PROVED (critical-subgraph extraction via greedy 3-coloring extension), with degree/cycle bridges for induced subgraphs",
+      "startLine": 110,
+      "endLine": 317
     },
     {
       "id": "bondy-vince",
       "title": "Bondy-Vince Theorem",
-      "summary": "bondy_vince_theorem axiom: minDegree >= 3 implies cycle-length difference <= 2",
-      "startLine": 108,
-      "endLine": 130
+      "summary": "bondy_vince_theorem axiom: minDegree >= 3 implies cycle-length difference <= 2 (deep 1998 result, the file's only axiom)",
+      "startLine": 318,
+      "endLine": 340
     },
     {
       "id": "main-results",
       "title": "Main Results",
       "summary": "erdos_751_chromatic_4, erdos_751_with_girth, erdos_751 theorems",
-      "startLine": 131,
-      "endLine": 183
+      "startLine": 341,
+      "endLine": 405
     },
     {
       "id": "strengthening",
       "title": "Strengthening",
-      "summary": "min_degree_3_cycle_gap, chromatic_4_implies_min_deg_3",
-      "startLine": 184,
-      "endLine": 207
+      "summary": "min_degree_3_cycle_gap, chromatic_4_implies_subgraph_min_deg_3",
+      "startLine": 406,
+      "endLine": 433
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_751_summary combining all results",
-      "startLine": 208,
-      "endLine": 235
+      "startLine": 434,
+      "endLine": 465
     }
   ],
   "conclusion": {
-    "summary": "Erdos Problem #751 asked whether graphs with chromatic number 4 can have arbitrarily large gaps between consecutive cycle lengths. The answer is NO: Bondy and Vince (1998) proved that minimum degree >= 3 implies two cycles differ by at most 2, and chi(G) = 4 forces a subgraph of minimum degree >= 3. Large girth doesn't help.",
+    "summary": "Erdos Problem #751 asked whether graphs with chromatic number 4 can have arbitrarily large gaps between consecutive cycle lengths. The answer is NO: Bondy and Vince (1998) proved that minimum degree >= 3 implies two cycles differ by at most 2, and chi(G) = 4 forces an induced subgraph of minimum degree >= 3 (proved in Lean here via critical-subgraph extraction; only Bondy-Vince itself remains an axiom). Large girth doesn't help.",
     "implications": "**Theoretical Significance**: **Graph Theory Connections**\n\n1. **Chromatic Structure:** Chromatic number constrains cycle structure\n\n2. **Degree-Cycle Relationship:** Minimum degree controls cycle length gaps\n\n**3. Girth Independence:** The result is independent of girth\n\n4. **Tight Bounds:** Gap of 2 is achievable (K_4 has cycles 3, 4)\n\n5. **Generalization:** Result holds beyond 4-chromatic graphs.",
     "openQuestions": [
       "Exact characterization of cycle length spectra for k-chromatic graphs",
@@ -144,9 +146,9 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos751",
-    "lineCount": 280,
-    "axiomCount": 2,
-    "theoremCount": 8,
+    "lineCount": 465,
+    "axiomCount": 1,
+    "theoremCount": 16,
     "definitionCount": 3,
     "path": "Proofs/Erdos751Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-751-incomplete-01.json
+++ b/src/data/research/problems/erdos-751-incomplete-01.json
@@ -35,17 +35,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: eliminated both sorries in Erdos751Problem.lean by giving minCycleLengthGap a faithful sInf definition and proving the gap<=2 bound (Nat.sInf_le), 0 new axioms, host-verified. Flagged that the pre-existing axiom four_chromatic_minDeg is false as stated (pendant-vertex counterexample) for auditor/mechanic follow-up.",
+    "progressSummary": "PROGRESS: AXIOM ELIMINATED (2->1). The #41481 subgraph-form axiom four_chromatic_subgraph_minDeg was still false as stated (minDegree over ALL of V; K4+isolated-vertex counterexample, instantiable to False). Restated soundly (exists s : Finset V, nonempty, every v in s has >=3 neighbours inside s) and PROVED from Mathlib via critical-subgraph extraction (Finset.strongInduction + greedy 3-coloring extension). Headline erdos_751 now depends only on the deep bondy_vince_theorem axiom. 0 sorries, host-verified v4.31.",
     "builtItems": [
       "Erdos751Problem.lean: replaced 3 def-axioms (chromaticNumber, girth, cycleLengths) with Mathlib-backed real definitions; axiom 5→2. Host-verified v4.31.0 EXIT=0.",
       "minCycleLengthGap (Erdos751Problem.lean): faithful total def as sInf of pairwise differences {b-a | a<b, a,b in set} = minimum consecutive gap; replaces def-sorry",
       "minCycleLengthGap_le (Erdos751Problem.lean): closest-pair upper bound via Nat.sInf_le; 0-axiom",
-      "erdos_751 hgap_bound sorry discharged: minCycleLengthGap (cycleLengths G) <= 2 from two close cycle lengths"
+      "erdos_751 hgap_bound sorry discharged: minCycleLengthGap (cycleLengths G) <= 2 from two close cycle lengths",
+      "four_chromatic_subgraph_minDeg (Erdos751Problem.lean): now a THEOREM, sound Finset form, proved via critical-subgraph argument [0-axiom]",
+      "exists_min_subset_of_not_colorable + colorable_of_erase_colorable: strong-induction + greedy coloring-extension engine",
+      "not_colorable_three_of_chromaticNumber_four, colorable_of_isEmpty (Colorable plumbing)",
+      "degree_induce_eq_filter_card, minDegree_induce_ge, cycleLengths_induce_subset: induced-subgraph bridges feeding bondy_vince_theorem"
     ],
     "insights": [
       "The chromaticNumber/girth/cycleLengths in Erdos751Problem.lean were DEFINITION axioms (opaque functions) that Mathlib actually provides: SimpleGraph.chromaticNumber (ℕ∞, use .toNat), SimpleGraph.girth (ℕ, via egirth.toNat), and cycleLengths as {n | ∃ v (c:G.Walk v v), c.IsCycle ∧ c.length=n}. All downstream usage is abstract (passed to the remaining axioms), so replacing the axioms with real defs compiles cleanly.",
       "Both file sorries eliminated (def-sorry + dependent theorem sorry), 0 new axioms. Host-verified lake env lean v4.31 EXIT=0.",
-      "INTEGRITY FINDING (for auditor/mechanic): axiom four_chromatic_minDeg : chromaticNumber G = 4 -> minDegree G >= 3 is FALSE as literally stated. Counterexample: K4 plus a pendant vertex is 4-chromatic but has minDegree 1. The correct classical fact is that a 4-chromatic graph has a SUBGRAPH (3-core) of min degree >= 3; the final erdos_751 theorem is true but is derived through this unsound global axiom."
+      "INTEGRITY FINDING (for auditor/mechanic): axiom four_chromatic_minDeg : chromaticNumber G = 4 -> minDegree G >= 3 is FALSE as literally stated. Counterexample: K4 plus a pendant vertex is 4-chromatic but has minDegree 1. The correct classical fact is that a 4-chromatic graph has a SUBGRAPH (3-core) of min degree >= 3; the final erdos_751 theorem is true but is derived through this unsound global axiom.",
+      "The #41481 'subgraph form' repair was still inconsistent: minDegree = min' over Finset.univ counts ALL vertices of V, so no H <= G on the same vertex type can have minDegree >= 3 when G has an isolated vertex; the sound statement bounds degrees inside an extracted Finset only",
+      "Chromatic-degeneracy is elementary in Lean: vertex-minimal non-3-colorable subset via Finset.strongInduction, greedy extension needs only used.card < 3 -> exists free colour in Fin 3",
+      "v4.31 SimpleGraph churn: G.loopless/G.symm are Std.Irrefl/Std.Symm instances not functions (use G.irrefl/Adj.symm); induce Adj is defeq G.Adj so typed 'have' beats induce_adj rewriting"
     ],
     "mathlibGaps": [],
     "nextSteps": []


### PR DESCRIPTION
## Summary
Research session for **erdos-751-incomplete-01** (Erdős #751, cycle lengths in 4-chromatic graphs). **Axiom count 2 → 1**: the chromatic–degeneracy lemma is now a proved theorem, and the file's only remaining axiom is the genuinely deep Bondy–Vince (1998) result.

## Integrity finding
The #41481 repair `four_chromatic_subgraph_minDeg` (`∃ H ≤ G, minDegree H ≥ 3`, with `H` on the same vertex type) was **still false as stated**: `minDegree` is `Finset.min'` over `Finset.univ`, i.e. over *all* of `V`. For `K₄` plus an isolated vertex (4-chromatic, `V = Fin 5`) every `H ≤ G` keeps the isolated vertex at degree 0, so the axiom was instantiable to `False`.

## Progress
- **Sound restatement**: `χ(G) = 4 → ∃ s : Finset V, s.Nonempty ∧ ∀ v ∈ s, 3 ≤ #(s.filter (G.Adj v ·))` — degrees are bounded *inside* the extracted vertex set (induced-subgraph minimum degree), which is the correct classical fact.
- **Proved, not axiomatized**: `exists_min_subset_of_not_colorable` extracts a vertex-minimal non-3-colorable subset by `Finset.strongInduction`; `colorable_of_erase_colorable` shows a vertex with < 3 internal neighbours can be greedily recolored (a free colour in `Fin 3` always exists), so every vertex of the minimal set has ≥ 3 internal neighbours.
- **Bridges**: `degree_induce_eq_filter_card` (`Finset.card_bij`), `minDegree_induce_ge`, and `cycleLengths_induce_subset` (embedding `induceUnivIso ∘ induceHomOfLE`, `Walk.map_isCycle_iff_of_injective`) connect the extracted set to `bondy_vince_theorem` and lift the close cycles back into `G`.
- **Headline theorems rewired**: `#print axioms erdos_751` = `[propext, Classical.choice, Erdos751.bondy_vince_theorem, Quot.sound]`. All 8 new supporting lemmas are 0-axiom (foundational trio only).
- meta.json: `axiomCount` 2 → 1, counts and section anchors refreshed, `assumptions`/`proofStrategy` prose updated.

## Verification
Host-verified on toolchain v4.31.0: full type-check EXIT=0, 0 sorries, only pre-existing style warnings (deprecated `WalkCounting` import, `unusedSectionVars` linter).

## Status
**Outcome**: progress (axiom eliminated + inconsistency fixed)
**Next Steps**: the remaining `bondy_vince_theorem` axiom is a registered blocked route (deep 1998 result, no Mathlib cycle-length-spectrum API; reopen bar: materially new mechanism).

🤖 Generated by researcher-1
