### PR TITLE
Fix: poincare-conjecture meta.axiomCount 34→32 (match 32 literal axioms)

### DIFF
--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -16,7 +16,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 34,
+    "axiomCount": 32,
     "assumptions": "32 axioms: perelman_finite_extinction, generalized_poincare_high_dim, poincare_dim_4, poincare_dim_2, sphere_n_simply_connected, ConnectedSum, and 26 more. 0 sorries. Trust caveat: 61 named theorems are discharged by native_decide (e.g. thurston_geometry_count, spherical_platonic_count, lens_L51_L52_not_homeo_criterion, quarter_pinching_sharpness), which trusts the Lean compiler's kernel reduction and introduces the Lean.ofReduceBool axiom (not reflected in axiomCount, which counts mathematical assumptions). These are finite demonstrations — small enumerations of Thurston geometries, Platonic tilings, lens-space and exotic-sphere invariants — and do NOT carry the Poincare/geometrization headline, which rests on the axiom declarations above and stays kernel-checked.",
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Metadata fix: stale axiomCount

`meta.meta.axiomCount` for poincare-conjecture read **34**, but the Lean source
`proofs/Proofs/PoincareConjecture.lean` contains exactly **32** literal `axiom`
declarations (`grep -c '^axiom '` → 32), and there are no assumption-carrying
structure/typeclass fields (no `structure`/`class` named `*Axiom*`; the only
"TQFTAxioms" hit is a section comment).

### Root cause
The file originally declared 34 axioms. PR #35770 ("Fix: leanFile.axiomCount to
literal declarations") corrected `leanFile.axiomCount` 34→32 after 2 axioms were
removed, but left the display-facing `meta.meta.axiomCount` at the stale 34.

### Evidence
- `leanFile.axiomCount`: 32 (already correct)
- `assumptions` prose: "**32 axioms**: ... 0 sorries"
- `grep -c '^axiom ' proofs/Proofs/PoincareConjecture.lean` → 32
- `Lean.ofReduceBool` (native_decide) is deliberately **not** counted here, per
  the disclose-only policy applied in #41407 (this entry was part of that batch,
  commit 52f71bc34c) — it is disclosed in the `assumptions` trust caveat.

### Change
```
-    "axiomCount": 34,
+    "axiomCount": 32,
```
Status (`axiomatized`) and badge (`axiom`) are unchanged and correct for a
Millennium Prize problem. One-line, JSON-validated diff.
