### PR TITLE
fix(seeker): guard tokens symlink against self-reference in main checkout

### DIFF
--- a/scripts/research/launch-seeker.sh
+++ b/scripts/research/launch-seeker.sh
@@ -293,10 +293,27 @@ launch_agent() {
     # Create or update worktree
     create_worktree
 
-    # Symlink OAuth tokens so the claude-wrapper can find them in the worktree
+    # Symlink OAuth tokens so the claude-wrapper can find them in the worktree.
+    # Guard against self-pointing symlinks: the seeker operates from the MAIN
+    # checkout, so WORKTREE_PATH == REPO_ROOT and dst == src. A bare `ln -sfn`
+    # would then replace main's real tokens dir with a circular self-reference
+    # (.loom/tokens -> .../.loom/tokens), flapping the pool every cycle (#41551).
+    # Mirror the guard used by deploy/auditor/mechanic launchers.
     if [[ -d "$REPO_ROOT/.loom/tokens" ]]; then
-        mkdir -p "$WORKTREE_PATH/.loom" 2>/dev/null || true
-        ln -sfn "$REPO_ROOT/.loom/tokens" "$WORKTREE_PATH/.loom/tokens"
+        local src="$REPO_ROOT/.loom/tokens"
+        local dst="$WORKTREE_PATH/.loom/tokens"
+        local src_real dst_real
+        src_real="$(cd "$src" 2>/dev/null && pwd -P)"
+        dst_real="$(dirname "$dst")"; dst_real="$(cd "$dst_real" 2>/dev/null && pwd -P)/$(basename "$dst")"
+        if [[ -z "$src_real" ]]; then
+            print_warning "Skipping tokens symlink: $src is not a resolvable directory (broken symlink?)."
+        elif [[ "$src_real" == "$dst_real" ]]; then
+            print_warning "Refusing to create self-pointing tokens symlink ($dst → $src). Skipping."
+        else
+            mkdir -p "$WORKTREE_PATH/.loom" 2>/dev/null || true
+            ln -sfn "$src_real" "$dst"
+            print_info "Linked .loom/tokens for OAuth token rotation"
+        fi
     fi
 
     # Check pool depth first


### PR DESCRIPTION
## Summary
`scripts/research/launch-seeker.sh` symlinked the worktree tokens dir to the main pool with a **bare, unguarded** `ln -sfn`. Because the seeker operates from the **MAIN checkout**, `WORKTREE_PATH` resolves to `$REPO_ROOT`, making `dst == src` and producing a **self-referencing symlink** (`.loom/tokens -> .../.loom/tokens`). This flapped the main token pool between a real dir and a broken circular symlink every seeker cycle.

## Fix
Apply the same self-pointing guard the `deploy`/`auditor`/`mechanic` launchers already use (approach: **local inline guard**, matching the siblings — no shared helper, to keep the change focused and avoid touching the other launchers):

- Resolve `src_real` (physical path of `$REPO_ROOT/.loom/tokens`) and `dst_real` (physical path of the intended `$WORKTREE_PATH/.loom/tokens`).
- If `src_real == dst_real` (self-reference) → skip the `ln`, log a warning, leave main's real tokens dir intact.
- If `src_real` is empty (src not a resolvable directory / broken symlink) → skip cleanly.
- Otherwise (genuine distinct worktree) → create the symlink to the main pool as before.

## Testing
`bash -n scripts/research/launch-seeker.sh` passes. Guard logic exercised against a scratch REPO_ROOT/WORKTREE_PATH (live `.loom/tokens` untouched):

- (a) `WORKTREE_PATH == REPO_ROOT` → guard skips the `ln`; main `.loom/tokens` stays a real dir, existing token file intact. **PASS**
- (b) genuine distinct `WORKTREE_PATH` → symlink IS created, resolves to the main pool token. **PASS**
- (c) `src` is a broken symlink → skips cleanly, no bad link created. **PASS**

Closes #41551

🤖 Generated with [Claude Code](https://claude.com/claude-code)
