### PR TITLE
Fix: central-limit-theorem-oq-01-oq-02 drop stale True-stub/open-question prose

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5587,10 +5587,10 @@
       "issues": []
     },
     "central-limit-theorem-oq-01-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:29Z",
-      "result": "clean"
+      "lastAudited": "2026-07-22T16:57:05Z",
+      "result": "issues-fixed"
     },
     "central-limit-theorem-oq-01-oq-02-oq-01": {
       "auditCount": 2,

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02/meta.json
@@ -140,12 +140,10 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization builds the complete algebraic framework for the Lévy-Khintchine representation: Lévy triplets as the canonical parameterization of infinitely divisible distributions, explicit Gaussian and Poisson instances as fundamental building blocks, componentwise triplet addition reflecting independent sums, the Lévy-Itô decomposition into continuous and jump parts, and classification theorems that reduce distribution identification to checking which triplet components vanish. With 19 theorems (19 fully proved, 1 True stub for stable infinite divisibility) and 0 axioms, it provides a near-complete type-theoretic foundation for Lévy process theory.",
+    "summary": "This formalization builds the complete algebraic framework for the Lévy-Khintchine representation: Lévy triplets as the canonical parameterization of infinitely divisible distributions, explicit Gaussian and Poisson instances as fundamental building blocks, componentwise triplet addition reflecting independent sums, the Lévy-Itô decomposition into continuous and jump parts, and classification theorems that reduce distribution identification to checking which triplet components vanish. With 19 theorems (all fully proved) and 0 axioms, it provides a near-complete type-theoretic foundation for Lévy process theory; stable_inf_divisible (α-stable infinite divisibility) was left as a comment rather than formalized, since it needs characteristic-function theory beyond current Mathlib.",
     "implications": "The framework opens several formalization directions: full Lévy-Khintchine existence and uniqueness (from triplet to distribution), Lévy process construction via the Lévy-Itô theorem, jump-diffusion models for mathematical finance, and the connection between stable distributions and generalized central limit theorems. The algebraic structure of triplet addition also suggests formalizing infinitely divisible distributions as a commutative monoid in Lean's algebraic hierarchy.",
     "openQuestions": [
-      "Can gaussianExponent_zero be closed with simp/ring lemmas for Complex.ofReal arithmetic?",
-      "Can the stable_scaling rpow identity be proved using Mathlib's Real.rpow_natCast lemmas?",
-      "Can gaussian_variance_from_exponent be proved using Mathlib's Asymptotics.isLittleO framework?",
+      "Can stable_inf_divisible (α-stable distributions are infinitely divisible) be formalized with current Mathlib's characteristic-function theory?",
       "Is a full Lévy-Khintchine existence proof (triplet → distribution) feasible with current Mathlib measure theory?"
     ]
   },


### PR DESCRIPTION
## Integrity Issue

**Proof**: central-limit-theorem-oq-01-oq-02
**Problem**: `conclusion.summary` and `overview.conclusion.openQuestions` are stale from before the file's last sorries were closed (#4938 "prove last sorry (0 sorries)", #8688 "remove True-stub theorems from 16 proof files").

## Evidence

**meta.json claimed**: conclusion.summary said "19 theorems (19 fully proved, **1 True stub** for stable infinite divisibility)". openQuestions asked whether `gaussianExponent_zero`, `stable_scaling`, and `gaussian_variance_from_exponent` "can be closed"/"proved".

**Lean file shows** (`proofs/Proofs/CentralLimitTheoremOQ01OQ02.lean`): 0 sorries, 0 axioms, no `True` stubs anywhere. All three theorems named in the stale openQuestions are already fully proved with real tactic proofs (lines 86-89, 199-204, 267-282). `stable_inf_divisible` isn't a declared stub at all — it was removed and left only as a block comment (lines 206-209), which the `meta.assumptions` field (fresher) already correctly describes: "stable_inf_divisible ... was converted to a block comment".

This is an *understating* inaccuracy (claims weaker state than reality), not an overclaim, but the auditor mandate is that public claims match the kernel exactly — no more, no less either direction.

## Fix

- `conclusion.summary`: replaced the phantom "1 True stub" mention with wording that matches `meta.assumptions` (block comment, not a stub).
- `overview.conclusion.openQuestions`: dropped the 3 already-resolved items, kept only the 2 genuinely open directions (formalizing `stable_inf_divisible`, and full Lévy-Khintchine existence/uniqueness).
- Tracker: `central-limit-theorem-oq-01-oq-02` marked audited (issues-fixed).

---
Discovered during gallery integrity audit.