### PR TITLE
Research: erdos-46-wip-01 — CRUX: exact unit-fraction repr of 1 with all denominators > N (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos46WIP01SmallDivisors.lean
+++ b/proofs/Proofs/Erdos46WIP01SmallDivisors.lean
@@ -1,0 +1,206 @@
+/-
+  Erdős Problem #46 — Small-divisor completeness: unit-fraction representations
+  of 1 with arbitrarily large minimum denominator.
+
+  Source: https://erdosproblems.com/46
+  Parents: `Proofs/Erdos46Problem.lean` (defines `IsUnitFractionRepr`, the
+  divisor-sum bridge `isUnitFractionRepr_of_divisorSum` / `divisorSum_min_gt`,
+  and the harmonic block bound `sum_Ico_inv_ge_one`) and
+  `Proofs/Erdos18WIP01.lean` (practical numbers: `factorial_practical`, the
+  divisor coin-chain `divisor_chain_of_practical`, and the subset-sum engine
+  `finset_chain_covers`).
+
+  This file resolves the vein's registered crux — **a representation of exactly
+  `1` by distinct unit fractions with every denominator `> N`** — via the
+  "practical-number completeness" route recorded as the open next step on the
+  divisor-sum bridge:
+
+  * Take `M = (4(N+1))!`.  `M` is practical (`factorial_practical`), so its full
+    divisor set is a subset-sum coin chain (`divisor_chain_of_practical`).
+  * Restrict to the *small* divisors `D = {d ∣ M : d ≤ M/(N+1)}`.  The chain
+    condition for each `d ∈ D` mentions only divisors `< d`, all of which stay
+    in `D` — a threshold restriction of a coin chain is again a coin chain
+    (`small_divisor_chain`).
+  * The cofactors `M/j` for `j` in the harmonic block `[N+2, 4(N+1)]` all lie in
+    `D`, and their sum is at least `M · ∑ 1/j ≥ M` (`sum_Ico_inv_ge_one`), so
+    `∑ D ≥ M` (`small_divisor_sum_ge`).
+  * Hence `finset_chain_covers` produces distinct divisors `T ⊆ D` with
+    `∑ T = M` exactly, and the divisor-sum bridge converts the cofactor family
+    `{M/d : d ∈ T}` into a unit-fraction representation of `1` whose
+    denominators all exceed `N` (`exists_isUnitFractionRepr_min_gt`).
+
+  Consequently every finite set of naturals can be avoided by a representation
+  of `1` (`exists_isUnitFractionRepr_disjoint`) — the collision-freeness
+  obstruction recorded in the problem knowledge is gone.
+
+  This does NOT touch the genuinely deep monochromatic statement
+  (`ErdosProblem46`, Croot 2003), which needs density/covering machinery.  The
+  construction here is the colour-free core previously identified as the
+  missing crux for disjoint chaining.
+
+  All results are axiom-free (`propext`, `Classical.choice`, `Quot.sound` only).
+-/
+
+import Mathlib
+import Proofs.Erdos46Problem
+import Proofs.Erdos18WIP01
+
+open Finset
+
+namespace Erdos46SmallDivisors
+
+open Erdos18 (finset_chain_covers divisor_chain_of_practical factorial_practical)
+
+/- ## The small-divisor pool
+
+Throughout, `M = (4(N+1))!` and the pool is `D = {d ∣ M : d ≤ M/(N+1)}`. -/
+
+/-- **Threshold restriction preserves the coin chain.**  For practical `M`, the
+divisors of `M` that are `≤ B` still satisfy the subset-sum chain condition:
+the chain inequality for `d` only involves divisors `< d ≤ B`, and all of those
+survive the threshold filter. -/
+theorem small_divisor_chain {M B : ℕ} (hM : Erdos18.IsPractical M) :
+    ∀ d ∈ M.divisors.filter (· ≤ B),
+      d ≤ 1 + ∑ t ∈ (M.divisors.filter (· ≤ B)).filter (· < d), t := by
+  intro d hd
+  rw [Finset.mem_filter] at hd
+  have hfull := divisor_chain_of_practical hM d hd.1
+  have hsetseq : (M.divisors.filter (· ≤ B)).filter (· < d)
+      = M.divisors.filter (· < d) := by
+    rw [Finset.filter_filter]
+    apply Finset.filter_congr
+    intro e _
+    constructor
+    · exact fun h => h.2
+    · exact fun h => ⟨by omega, h⟩
+  rw [hsetseq]
+  exact hfull
+
+/-- **The small divisors of `(4(N+1))!` sum to at least `M`.**  The cofactors
+`M/j` for `j` in the harmonic block `[N+2, 4(N+1)]` are distinct divisors of
+`M`, each `≤ M/(N+1)`, and their reciprocal-weighted total is at least
+`M · ∑_{j} 1/j ≥ M` by the block bound `sum_Ico_inv_ge_one`. -/
+theorem small_divisor_sum_ge (N : ℕ) (hN : 1 ≤ N) :
+    (4 * (N + 1)).factorial ≤
+      ∑ d ∈ (4 * (N + 1)).factorial.divisors.filter
+        (· ≤ (4 * (N + 1)).factorial / (N + 1)), d := by
+  set M : ℕ := (4 * (N + 1)).factorial with hM
+  have hMpos : 0 < M := Nat.factorial_pos _
+  have hMne : M ≠ 0 := hMpos.ne'
+  -- the harmonic index block, phrased exactly as in `sum_Ico_inv_ge_one (N+1)`
+  set J : Finset ℕ := Finset.Ico ((N + 1) + 1) (4 * (N + 1) + 1) with hJ
+  have hJdvd : ∀ j ∈ J, j ∣ M := by
+    intro j hj
+    rw [hJ, Finset.mem_Ico] at hj
+    exact Nat.dvd_factorial (by omega) (by omega)
+  have hJpos : ∀ j ∈ J, 0 < j := by
+    intro j hj
+    rw [hJ, Finset.mem_Ico] at hj
+    omega
+  -- the cofactor image lands inside the small-divisor pool
+  have himsub : J.image (fun j => M / j) ⊆ M.divisors.filter (· ≤ M / (N + 1)) := by
+    intro x hx
+    rw [Finset.mem_image] at hx
+    obtain ⟨j, hj, rfl⟩ := hx
+    have hjdvd := hJdvd j hj
+    have hjlo : N + 1 ≤ j := by
+      rw [hJ, Finset.mem_Ico] at hj
+      omega
+    rw [Finset.mem_filter]
+    refine ⟨Nat.mem_divisors.mpr ⟨Nat.div_dvd_of_dvd hjdvd, hMne⟩, ?_⟩
+    apply (Nat.le_div_iff_mul_le (by omega : 0 < N + 1)).mpr
+    calc M / j * (N + 1) ≤ M / j * j := Nat.mul_le_mul (le_refl _) hjlo
+      _ = M := Nat.div_mul_cancel hjdvd
+  -- the cofactor map is injective on the block
+  have hinjJ : ∀ x ∈ J, ∀ y ∈ J, M / x = M / y → x = y := by
+    intro x hx y hy h
+    have i₁ : M / (M / x) = x := Nat.div_div_self (hJdvd x hx) hMne
+    have i₂ : M / (M / y) = y := Nat.div_div_self (hJdvd y hy) hMne
+    rw [← i₁, ← i₂, h]
+  -- rational lower bound for the image sum
+  have hharm := sum_Ico_inv_ge_one (N + 1) (by omega)
+  have hcast : ∀ j ∈ J, ((M / j : ℕ) : ℚ) = (M : ℚ) * (1 / (j : ℚ)) := by
+    intro j hj
+    rw [Nat.cast_div (hJdvd j hj) (by exact_mod_cast (hJpos j hj).ne'), mul_one_div]
+  have hQ : (M : ℚ) ≤ ∑ d ∈ J.image (fun j => M / j), (d : ℚ) := by
+    rw [Finset.sum_image hinjJ, Finset.sum_congr rfl hcast, ← Finset.mul_sum]
+    calc (M : ℚ) = (M : ℚ) * 1 := by ring
+      _ ≤ (M : ℚ) * ∑ j ∈ J, 1 / (j : ℚ) :=
+          mul_le_mul_of_nonneg_left hharm (by positivity)
+  have hNat : M ≤ ∑ d ∈ J.image (fun j => M / j), d := by
+    have := hQ
+    rw [← Nat.cast_sum] at this
+    exact_mod_cast this
+  exact le_trans hNat (Finset.sum_le_sum_of_subset himsub)
+
+/- ## The crux: exact representations of 1 with large minimum denominator -/
+
+/-- **Unit-fraction representations of `1` with arbitrarily large minimum
+denominator.**  For every `N ≥ 1` there is a finite set `S` of distinct
+denominators, all `> N`, with `∑_{n ∈ S} 1/n = 1` exactly.
+
+Construction: `M = (4(N+1))!` is practical, its divisors `≤ M/(N+1)` form a
+subset-sum coin chain totalling `≥ M`, so some distinct family of them sums to
+`M` exactly; the cofactors of that family are the denominators. -/
+theorem exists_isUnitFractionRepr_min_gt (N : ℕ) (hN : 1 ≤ N) :
+    ∃ S : Finset ℕ, IsUnitFractionRepr S ∧ ∀ n ∈ S, N < n := by
+  set M : ℕ := (4 * (N + 1)).factorial with hM
+  have hMpos : 0 < M := Nat.factorial_pos _
+  have hMne : M ≠ 0 := hMpos.ne'
+  set D : Finset ℕ := M.divisors.filter (· ≤ M / (N + 1)) with hD
+  -- coin chain + total ≥ M ⟹ an exact subset-sum hitting M
+  have hchain := small_divisor_chain (B := M / (N + 1))
+    (factorial_practical (4 * (N + 1)))
+  have hDsum : M ≤ ∑ d ∈ D, d := small_divisor_sum_ge N hN
+  obtain ⟨T, hTsub, hTsum⟩ := finset_chain_covers D hchain M hDsum
+  -- unpack the pool membership facts for the chosen family
+  have hTdvd : ∀ d ∈ T, d ∣ M := by
+    intro d hd
+    have := hTsub hd
+    rw [hD, Finset.mem_filter] at this
+    exact (Nat.mem_divisors.mp this.1).1
+  have hTle : ∀ d ∈ T, d ≤ M / (N + 1) := by
+    intro d hd
+    have := hTsub hd
+    rw [hD, Finset.mem_filter] at this
+    exact this.2
+  have hTpos : ∀ d ∈ T, 0 < d := by
+    intro d hd
+    rcases Nat.eq_zero_or_pos d with rfl | hpos
+    · exact absurd (Nat.eq_zero_of_zero_dvd (hTdvd 0 hd)) hMne
+    · exact hpos
+  have hmul : ∀ d ∈ T, (N + 1) * d ≤ M := by
+    intro d hd
+    have h2 := (Nat.le_div_iff_mul_le (by omega : 0 < N + 1)).mp (hTle d hd)
+    rw [Nat.mul_comm]
+    exact h2
+  have h2d : ∀ d ∈ T, 2 * d ≤ M := by
+    intro d hd
+    calc 2 * d ≤ (N + 1) * d := Nat.mul_le_mul (by omega) (le_refl d)
+      _ ≤ M := hmul d hd
+  have hltN : ∀ d ∈ T, N * d < M := by
+    intro d hd
+    have h1 := hmul d hd
+    have hd1 := hTpos d hd
+    have hexp : (N + 1) * d = N * d + d := by ring
+    rw [hexp] at h1
+    omega
+  exact ⟨T.image (fun d => M / d),
+    isUnitFractionRepr_of_divisorSum (by omega) hTdvd h2d (by simpa using hTsum),
+    divisorSum_min_gt hTdvd hltN⟩
+
+/-- **Any finite set can be avoided**: for every finite `S₀ : Finset ℕ` there is
+a unit-fraction representation of `1` disjoint from `S₀`.  This removes the
+collision-freeness obstruction to disjoint chaining recorded in the problem
+knowledge: iterating yields arbitrarily many pairwise-disjoint representations
+of `1`. -/
+theorem exists_isUnitFractionRepr_disjoint (S₀ : Finset ℕ) :
+    ∃ S : Finset ℕ, IsUnitFractionRepr S ∧ Disjoint S₀ S := by
+  obtain ⟨S, hS, hmin⟩ := exists_isUnitFractionRepr_min_gt (S₀.sup id + 1) (by omega)
+  refine ⟨S, hS, Finset.disjoint_left.mpr ?_⟩
+  intro a ha hamem
+  have h1 : a ≤ S₀.sup id := Finset.le_sup (f := id) ha
+  have h2 := hmin a hamem
+  omega
+
+end Erdos46SmallDivisors

--- a/research/problems/erdos-46-wip-01/knowledge.md
+++ b/research/problems/erdos-46-wip-01/knowledge.md
@@ -139,3 +139,47 @@ open bounded-rational Diophantine step.
 - Extract the reaching-block sum split: `have h := hPb₀; simp only [hP] at h;
   rwa [hb₀eq, Finset.sum_Ico_succ_top (by omega : N+1 ≤ c)] at h` gives
   `1 ≤ (block c).sum + 1/c` directly usable by `linarith` with `h1c : 1/c ≤ 1/(N+1)`.
+
+## Session 2026-07-22 (researcher-1, session 2) — ★CRUX SOLVED: exact repr of 1 with min > N
+
+**The registered open nugget — a unit-fraction representation of EXACTLY 1 with every
+denominator > N — is now a THEOREM.** New companion file
+`Erdos46WIP01SmallDivisors.lean` (206 L, 0-axiom, host-verified v4.31 EXIT=0, zero
+warnings), via the practical-number completeness route the divisor-sum bridge left
+open (explicitly a nextStep, NOT a blocked route):
+
+- `exists_isUnitFractionRepr_min_gt (N) (hN : 1 ≤ N) : ∃ S, IsUnitFractionRepr S ∧
+  ∀ n ∈ S, N < n`. Construction: M = (4(N+1))! is practical
+  (`Erdos18.factorial_practical`), so its divisor set is a subset-sum coin chain
+  (`Erdos18.divisor_chain_of_practical`); the THRESHOLD RESTRICTION
+  D = {d ∣ M : d ≤ M/(N+1)} is still a coin chain (`small_divisor_chain` — the chain
+  condition for d only references divisors < d ≤ threshold, all of which survive the
+  filter); the cofactors M/j for j in the harmonic block [N+2, 4(N+1)] lie in D and
+  total ≥ M·Σ1/j ≥ M (`small_divisor_sum_ge`, reusing `sum_Ico_inv_ge_one (N+1)`);
+  `Erdos18.finset_chain_covers` then hits M exactly with distinct small divisors, and
+  the existing bridge `isUnitFractionRepr_of_divisorSum` + `divisorSum_min_gt`
+  converts the cofactor family into the required representation.
+- `exists_isUnitFractionRepr_disjoint (S₀) : ∃ S, IsUnitFractionRepr S ∧ Disjoint S₀ S`
+  — any finite set avoided (take N = S₀.sup id + 1). **The collision-freeness
+  obstruction to disjoint chaining is GONE**: iterating yields arbitrarily many
+  pairwise-disjoint representations of 1.
+
+Cross-file reuse: imports `Proofs.Erdos18WIP01` (practical-number engine built for
+Erdős #18) into the Erdős #46 vein — `Erdos18.divisors` is defeq `Nat.divisors`, so
+the bridge composes with zero glue. The two WIP veins were secretly the same
+mathematics: "denominators > N summing to 1" = "divisors < M/N summing to M".
+
+Idioms: threshold chain restriction = `Finset.filter_filter` + `Finset.filter_congr`
+(e < d ≤ B kills the extra conjunct); M/j ≤ M/(N+1) robustly via
+`(Nat.le_div_iff_mul_le (0<N+1)).mpr` + `Nat.mul_le_mul (le_refl _) hjlo` +
+`Nat.div_mul_cancel` (avoids div_le_div_left name churn); ℕ→ℚ sum bound via
+`Finset.sum_image hinj` + `Nat.cast_div` + `← Finset.mul_sum`, back by
+`rw [← Nat.cast_sum]; exact_mod_cast`; (N+1)*d = N*d + d by `ring` then `omega`
+(omega treats N*d as an atom — never leave both orderings).
+
+### Still open (UNCHANGED)
+The monochromatic statement `ErdosProblem46` (Croot 2003) — the colouring must now
+merely be combined with pigeonhole over the disjoint family? NO: pigeonhole gives ONE
+colour class hit infinitely often across disjoint reprs, but a repr need not be
+monochromatic. Croot's density machinery is still required. The colour-free
+infrastructure is complete.

--- a/src/data/research/problems/erdos-46-wip-01.json
+++ b/src/data/research/problems/erdos-46-wip-01.json
@@ -42,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-1-3, 2026-07-22): added Erdos46WIP01Cost.lean (2 axiom-free theorems) — the OBSTRUCTION/lower-bound side complementing the existing construction toolkit. card_ge_of_forall_gt: min denom >N forces >=N+1 terms (cost grows linearly in N). exists_le_card: smallest denom <= card. Neither is a construction, so neither is equivalent-strength to the open large-min-denom target. Exact landing on 1 with min>N (bounded Diophantine subset-sum) + deep Croot 2003 remain unformalized.",
+    "progressSummary": "MAJOR (researcher-1, 2026-07-22): THE REGISTERED CRUX IS SOLVED — exists_isUnitFractionRepr_min_gt (new companion Erdos46WIP01SmallDivisors.lean, 0-axiom, host-verified): for every N >= 1 a unit-fraction representation of EXACTLY 1 with all denominators > N. Route = practical-number completeness (the divisor-sum bridge's open nextStep): M = (4(N+1))! is practical (Erdos18 toolkit import), its divisors <= M/(N+1) remain a subset-sum coin chain under threshold restriction and total >= M via harmonic-block cofactors, so finset_chain_covers hits M exactly; the bridge converts cofactors into the repr. Corollary exists_isUnitFractionRepr_disjoint: any finite set avoided — the collision-freeness obstruction to disjoint chaining is GONE. Still open: the monochromatic ErdosProblem46 (Croot 2003 density machinery).",
     "builtItems": [
       "exists_isRatFractionRepr_bracket_one in Erdos46Problem.lean (0-axiom) — packages controlled overshoot+undershoot into a single two-sided bracket of 1: exists Slo,Shi,qlo,qhi with both reprs' denoms > N, qlo<1<=qhi, and explicit vanishing width qhi-qlo < 2/(N+1). Launching point for exact landing on 1.",
       "not_isUnitFractionRepr_singleton — no singleton represents 1 (Erdos46Problem.lean)",
@@ -60,7 +60,10 @@
       "exists_isUnitFractionRepr_card_eq in proofs/Proofs/Erdos46Problem.lean (|S|=k for all k≥3, 0-axiom, host-verified)",
       "Divisor-sum bridge (Erdos46Problem.lean): isUnitFractionRepr_of_divisorSum — distinct divisors T of M with 2d≤M and Σ_{d∈T}d=M yield IsUnitFractionRepr {M/d}; divisorSum_min_gt — N·d<M ∀d∈T forces every denominator M/d > N. Host-verified v4.31.0, #print axioms = [propext, Classical.choice, Quot.sound] (0 added axioms, 0 sorries).",
       "card_ge_of_forall_gt — min denom >N ==> card >= N+1 (Erdos46WIP01Cost.lean, 0-axiom)",
-      "exists_le_card — smallest denom <= card in any unit-fraction repr of 1 (Erdos46WIP01Cost.lean, 0-axiom)"
+      "exists_le_card — smallest denom <= card in any unit-fraction repr of 1 (Erdos46WIP01Cost.lean, 0-axiom)",
+      "Erdos46WIP01SmallDivisors.lean: exists_isUnitFractionRepr_min_gt — exact repr of 1, all denoms > N (THE CRUX) [0-axiom]",
+      "small_divisor_chain (threshold restriction of practical divisor coin chain), small_divisor_sum_ge (harmonic cofactor total >= M)",
+      "exists_isUnitFractionRepr_disjoint: repr of 1 avoiding any finite set (collision obstruction removed)"
     ],
     "insights": [
       "Erdos46Problem.lean stub developed: 13 axiom-free foundational lemmas on unit-fraction / rational representations and monochromatic sets (all [propext,Classical.choice,Quot.sound], no sorry/native_decide).",
@@ -74,7 +77,10 @@
       "EQUIVALENT-STRENGTH BLOCKER (min>N repr of exactly 1): every elementary bootstrap bottoms out at representing a fixed unit fraction 1/c with min>N. But scaling by t maps a min>M repr of 1 to a min>tM repr of 1/t, and two nested-scale disjoint 1/2-reprs union back to a min>N repr of 1 — so \"1/c with min>N\" and \"1 with min>N\" are equivalent strength. Hence the union-assembly and raise-min-by-one routes earn ZERO decomposition credit.",
       "Divisor-sum reformulation of the open crux: repr of 1 with min>N ⟺ some M is a sum of distinct divisors each < M/N (forward = isUnitFractionRepr_of_divisorSum; converse via M=lcm S, d_s=M/s). Being an iff, the reduction is EQUIVALENT-STRENGTH (no decomposition credit), but it re-expresses the crux in multiplicative NT where Nat.divisors is available. The residual open content is a practical-number completeness fact: exhibit M with enough SMALL divisors (all < M/N) summing exactly to M. This is a materially new mechanism distinct from the two blocked bootstrap routes (union/scaling, raise-min-by-one).",
       "COST LOWER BOUND (obstruction side, non-equivalent-strength): representing 1 by unit fractions all with denominator >N FORCES cardinality >= N+1 (each term <=1/(N+1), sum=1). So the large-min-denom target is genuinely expensive — cardinality grows at least linearly in N. This is a necessary constraint on any such repr, NOT a construction. (card_ge_of_forall_gt, Erdos46WIP01Cost.lean)",
-      "DUAL: in ANY unit-fraction repr of 1 the smallest denominator is <= number of terms (some n in S has n<=|S|); else all denoms >|S| would force |S|>=|S|+1. (exists_le_card)"
+      "DUAL: in ANY unit-fraction repr of 1 the smallest denominator is <= number of terms (some n in S has n<=|S|); else all denoms >|S| would force |S|>=|S|+1. (exists_le_card)",
+      "The erdos-18 practical-number engine and the erdos-46 crux are the same mathematics: denominators > N summing to 1 = distinct divisors < M/N summing to M; Erdos18.divisors is defeq Nat.divisors so the toolkits compose with zero glue",
+      "Threshold restriction preserves subset-sum coin chains: the chain condition for d references only divisors < d, all below the threshold — so practical numbers have COMPLETE small-divisor pools once the pool total passes M (harmonic block of cofactors)",
+      "The equivalent-strength blocked routes (bootstraps) are all obsolete: the target itself is now constructed; remaining open content is exclusively the monochromatic/Croot layer"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for **erdos-46-wip-01** (Erdős #46, monochromatic unit fractions). **The vein's registered crux is solved**: for every N there is a representation of *exactly* 1 by distinct unit fractions with every denominator > N. New 0-axiom companion `proofs/Proofs/Erdos46WIP01SmallDivisors.lean` (206 lines).

## The result
- `exists_isUnitFractionRepr_min_gt (N) (hN : 1 ≤ N) : ∃ S, IsUnitFractionRepr S ∧ ∀ n ∈ S, N < n` — the "exact landing on 1 with denominators > N" that the problem knowledge has tracked as the open bounded-Diophantine nugget across the last six sessions (overshoot/undershoot/bracket/cost bricks).
- `exists_isUnitFractionRepr_disjoint (S₀) : ∃ S, IsUnitFractionRepr S ∧ Disjoint S₀ S` — any finite set can be avoided, so the collision-freeness obstruction to disjoint chaining (documented in the knowledge file) is gone: iterating gives arbitrarily many pairwise-disjoint representations of 1.

## Construction (practical-number completeness)
Take M = (4(N+1))!. It is practical (`Erdos18.factorial_practical`), so its divisor set is a subset-sum coin chain (`Erdos18.divisor_chain_of_practical`). The key observations:
1. **Threshold restriction preserves the chain** (`small_divisor_chain`): the chain condition for a divisor d only references divisors < d, all of which survive the filter to D = {d ∣ M : d ≤ M/(N+1)}.
2. **The pool total passes M** (`small_divisor_sum_ge`): the cofactors M/j for j in the harmonic block [N+2, 4(N+1)] are distinct members of D summing to ≥ M·∑ 1/j ≥ M, by the existing block bound `sum_Ico_inv_ge_one`.
3. `Erdos18.finset_chain_covers` then produces distinct divisors T ⊆ D with ∑T = M **exactly**, and the existing divisor-sum bridge (`isUnitFractionRepr_of_divisorSum` + `divisorSum_min_gt`) converts the cofactor family {M/d : d ∈ T} into the required representation.

This is the route the divisor-sum bridge session left as the open next step ("practical-number completeness"), not one of the registered equivalent-strength blocked bootstraps — it constructs the target itself.

Cross-vein reuse: the file imports `Proofs.Erdos18WIP01` (the practical-number engine built for Erdős #18). `Erdos18.divisors` is definitionally `Nat.divisors`, so the two toolkits compose with zero glue — "denominators > N summing to 1" and "distinct divisors < M/N summing to M" are the same mathematics.

## Verification
Host-verified on v4.31.0: EXIT=0, zero warnings, 0 sorries. `#print axioms` on all four theorems: `[propext, Classical.choice, Quot.sound]` only.

## Status
**Outcome**: progress (registered crux resolved; colour-free infrastructure complete)
**Next Steps**: only the genuinely deep monochromatic statement `ErdosProblem46` (Croot 2003) remains — pigeonhole over the disjoint family does NOT suffice (a repr need not be monochromatic), so the density/covering machinery is still the frontier.

🤖 Generated by researcher-1
