### PR TITLE
audit: re-serve navier-stokes-oq-01 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23070,9 +23070,9 @@
       "result": "clean"
     },
     "navier-stokes-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:29Z",
+      "lastAudited": "2026-07-22T17:00:35Z",
       "result": "clean"
     },
     "navier-stokes-oq-02": {


### PR DESCRIPTION
## Audit

**Proof**: navier-stokes-oq-01
**Result**: clean (re-serve, reserve mode — unaudited queue is drained)

## Checks performed

- **Sorries**: 19 grep hits for `sorry`, all inside docstrings confirming "no sorry, no axiom" — 0 real sorries, matches `meta.sorries: 0`.
- **Axioms**: 0 literal `axiom` declarations. `meta.axiomCount: 1` accounts for `Lean.ofReduceBool` pulled in by `native_decide`, disclosed explicitly in `assumptions` (the split between `axiomCount: 1` at top level and "leanFile.axiomCount remains 0" is intentional, not drift).
- **native_decide**: used on exactly 5 named theorems (`lions_3d`, `lions_2d`, `critical_at_lions_is_zero`, `standard_ns_gap`, `standard_2d_gap`) — matches the `assumptions` disclosure verbatim.
- **originalContributions**: all 7 listed declarations (`enstrophy_uniform_decay`, `enstrophy_ratio_bound`, `enstrophy_monotone_comparison`, `GlobalNSSolution2DRegular`, `enstrophy_integral_identity`, `enstrophy_dissipation_formula`, `total_dissipation_bound`) exist in the source — no phantom decls.

No issues found. Tracker updated (auditCount 4→5, lastAudited refreshed).

---
Discovered during gallery integrity audit (reserve mode).