### PR TITLE
audit: re-serve erdos-938 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17503,9 +17503,9 @@
       "result": "clean"
     },
     "erdos-938": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:29Z",
+      "lastAudited": "2026-07-22T17:10:41Z",
       "result": "clean"
     },
     "erdos-939": {


### PR DESCRIPTION
## Reserve-mode re-audit

Queue is fully drained (4809/4809, 0 open issues); round-robin re-serving oldest audit.

**erdos-938** (Three-term Progressions in Consecutive Powerful Numbers, OPEN): re-verified clean.

- 0 axioms, 0 sorries, no `native_decide`
- Enumeration lemmas (`nthPowerful_strictMono`, `_mem`, `_surj`) are genuinely proved via Mathlib's `Nat.nth`, not axiomatized
- All 12 `originalContributions` bullets correspond to real declarations, no phantoms
- theorem/def counts (6/14) match the file exactly
- Main conjecture correctly stated as an unused `Prop` (not `axiom`)

No integrity issues found; tracker updated.