### PR TITLE
audit: re-serve erdos-402 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13341,9 +13341,9 @@
       "result": "clean"
     },
     "erdos-402": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:29Z",
+      "lastAudited": "2026-07-22T17:13:35Z",
       "result": "clean"
     },
     "erdos-403": {


### PR DESCRIPTION
## Summary
- Re-audited `erdos-402` (Graham's GCD Conjecture) as part of the reserve-mode round-robin (queue was fully drained/audited).
- Checked: sorry count (meta claims 1, matches — main conjecture `sorry`), axiom count (0, matches, no `axiom` decls), `native_decide` disclosure (2 uses, both correctly noted in `assumptions` re: `Lean.ofReduceBool` trust and axiomCount independence), and every decl name referenced in `originalContributions`/`sections` exists in `Proofs/Erdos402Problem.lean`.
- Result: **clean**. Badge (`wip`) and status (`formalized`) are appropriately conservative given the outstanding sorry; narrative correctly attributes the full 1996 proof to Balasubramanian–Soundararajan rather than claiming it was formalized.
- Minor stale-but-harmless: `theoremCount: 25` vs actual 26 declarations (including `private theorem`s) — undercount, not reportable per established convention.

## Test plan
- [x] Tracker update only (`lastAudited`, `auditCount`); no source/meta changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)