### PR TITLE
Enrich bezout-identity-oq015: split instances section by domain

### DIFF
--- a/src/data/proofs/bezout-identity-oq015/meta.json
+++ b/src/data/proofs/bezout-identity-oq015/meta.json
@@ -85,12 +85,20 @@
       "mathContext": "Eisenstein's criterion at the natural level of generality."
     },
     {
-      "id": "instances",
-      "title": "Instances over ℤ and ℚ[X]",
-      "startLine": 86,
-      "endLine": 107,
-      "summary": "Yⁿ − 2, Yⁿ − 3 over ℤ; Yⁿ − X and Y³ − X over the Euclidean domain ℚ[X] (Eisenstein at the prime X).",
-      "mathContext": "The criterion in genuinely different domains, including the parent's Euclidean-domain setting."
+      "id": "int-instances",
+      "title": "Instances over ℤ",
+      "startLine": 85,
+      "endLine": 93,
+      "summary": "irreducible_Y_pow_sub_two_int and irreducible_Y_pow_sub_three_int: Yⁿ − 2 and Yⁿ − 3 are irreducible over ℤ[Y], each by supplying the general theorem a concrete prime (Int.prime_two, Int.prime_three).",
+      "mathContext": "$Y^n - 2$ and $Y^n - 3$ irreducible over $\\mathbb{Z}[Y]$ — Eisenstein at the primes $2$ and $3$."
+    },
+    {
+      "id": "ratpoly-instances",
+      "title": "Instances over the Euclidean domain ℚ[X]",
+      "startLine": 94,
+      "endLine": 108,
+      "summary": "irreducible_Y_pow_sub_X_ratPoly and its cubic specialization irreducible_Y_cubed_sub_X_ratPoly: over the Euclidean domain ℚ[X] — the parent's own setting — Yⁿ − X (and Y³ − X) is irreducible in ℚ[X][Y], Eisenstein at the prime element X, generating the function-field extension ℚ(X)(X^{1/n}).",
+      "mathContext": "$Y^n - X$ irreducible over $\\mathbb{Q}[X][Y]$ — Eisenstein at the prime element $X$, root generating $\\mathbb{Q}(X)(X^{1/n})$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- `bezout-identity-oq015` (Eisenstein's criterion over an arbitrary integral domain) was already at quality 96/100 with all 5 required-depth annotations, a rich `historicalContext`, 5 `keyInsights`, and a complete `conclusion` — no filler needed there.
- The one genuine gap: the `sections[]` array lumped the ℤ instances and the ℚ[X] instances into a single "Instances over ℤ and ℚ[X]" section (lines 86-107), leaving a 1-line coverage gap at line 85 and missing the closing `end` line 108, and not mirroring the existing per-domain annotation split (`ann-instances` vs `ann-cubic`).
- Split it into two sections — "Instances over ℤ" (85-93) and "Instances over the Euclidean domain ℚ[X]" (94-108) — matching the annotation structure and closing full-file coverage.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — meta.json is valid JSON
- [x] `wc -c` confirms file is 14.2 KB, well under the 60 KB guardrail cap
- [x] No other files touched (build-regenerated noise discarded before commit)
