### PR TITLE
Enrich poincare-conjecture: annotate lines 890-17683 (5%→100% coverage)

### DIFF
--- a/src/data/proofs/poincare-conjecture/annotations.json
+++ b/src/data/proofs/poincare-conjecture/annotations.json
@@ -515,5 +515,1442 @@
       "Axiom Versus Theorem",
       "Formal Verification"
     ]
+  },
+  {
+    "id": "ann-pc-quaternion-lie-group-s3",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 891,
+      "endLine": 1146
+    },
+    "type": "definition",
+    "title": "Concrete Quaternion Group Structure Realizing S³ as a Lie Group",
+    "content": "After introducing the Hopf fibration S¹ ↪ S³ → S² in comments, this block replaces a former existential 'S³ is a Lie group' axiom with a fully explicit construction: quaternion multiplication `quatMulE`, conjugation `quatConjE`, and identity `quatOneE` on ℝ⁴, proved to preserve the unit sphere, be continuous, and satisfy left-identity and right-inverse laws. These are packaged into `sphere3_is_lie_group`, an existential statement asserting a continuous multiplication/inverse with identity and inverse laws on S³.",
+    "mathContext": "Identifying $\\mathbb{R}^4$ with the quaternions $\\mathbb{H}$, the Hamilton product $(a_0,a_1,a_2,a_3)(b_0,b_1,b_2,b_3)$ satisfies the Euler four-square identity $\\|xy\\|^2 = \\|x\\|^2\\|y\\|^2$, which is exactly what is needed to show the unit sphere $S^3 = \\{x \\in \\mathbb{H} : \\|x\\|=1\\}$ is closed under multiplication. Together with conjugation as inverse and $(1,0,0,0)$ as identity, this realizes $S^3 \\cong SU(2)$ as a (compact, non-abelian) Lie group. The file proves only left-identity and right-inverse explicitly (sufficient for a group given associativity, which is verified separately as a raw polynomial identity later in the file), plus continuity of all the structure maps via their polynomial coordinate formulas.",
+    "significance": "key",
+    "relatedConcepts": [
+      "quaternions",
+      "Lie group",
+      "SU(2)",
+      "Hopf fibration",
+      "Euler four-square identity"
+    ],
+    "prerequisites": [
+      "EuclideanSpace and Metric.sphere",
+      "continuity of polynomial maps"
+    ]
+  },
+  {
+    "id": "ann-pc-hopf-map-surjective-essential",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 1147,
+      "endLine": 1375
+    },
+    "type": "concept",
+    "title": "Explicit Hopf Map S³ → S², Its Surjectivity, and a Weak 'Essential' Fact",
+    "content": "Defines the classical Hopf map `hopfMapE(a,b,c,d) = (a²+b²-c²-d², 2(ac+bd), 2(bc-ad))`, proves it sends the unit sphere to the unit sphere, is continuous, and is surjective via an explicit two-case preimage formula (south pole vs. general point, using a square root of (1+p₀)/2). `hopf_map_exists` packages this as a continuous surjection S³ → S². The following `hopf_map_essential` theorem, despite its name, only proves the much weaker fact that a continuous surjection onto a ≥2-point space cannot be literally constant — the code's own docstring flags that the genuine homotopy-theoretic essentialness (non-null-homotopy via Hopf invariant) is not established here. An axiom asserts S³ is not contractible.",
+    "mathContext": "The Hopf map $\\pi: S^3 \\to S^2$, $\\pi(a,b,c,d) = (a^2+b^2-c^2-d^2,\\, 2(ac+bd),\\, 2(bc-ad))$, arises from viewing $S^3 \\subset \\mathbb{C}^2$ via $z_1=a+bi,\\ z_2=c+di$ and mapping to $(|z_1|^2-|z_2|^2,\\ 2\\mathrm{Re}(z_1\\bar z_2),\\ 2\\mathrm{Im}(z_1\\bar z_2)) \\in S^2$. Its fibers are great circles, and it generates $\\pi_3(S^2) \\cong \\mathbb{Z}$ — a genuinely deep fact requiring the Hopf invariant, not captured by the elementary non-constancy argument given here (any continuous surjection onto a space with two distinct points is trivially non-constant).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Hopf fibration",
+      "Hopf invariant",
+      "homotopy groups of spheres",
+      "surjectivity"
+    ],
+    "prerequisites": [
+      "quaternion/complex coordinates on S³",
+      "continuous surjections"
+    ]
+  },
+  {
+    "id": "ann-pc-antipodal-map-invariants",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 1376,
+      "endLine": 1541
+    },
+    "type": "concept",
+    "title": "Antipodal Map on Spheres and Basic Topological Invariants",
+    "content": "Defines the antipodal map A(x) = -x on Euclidean space, proves it is continuous, an involution, norm-preserving, restricts to a fixed-point-free self-homeomorphism of S^n, and that antipodal points realize the sphere's diameter (distance 2). It then defines the Euler characteristic (as a bare integer wrapper) and Betti numbers of S^n by the closed formulas χ(S^n) = 1+(-1)^n and b_k ∈ {0,1}, verifying these for S⁰ through S⁴ and confirming the alternating-sum consistency for S³.",
+    "mathContext": "The antipodal map generates the deck-transformation group of the double cover $S^n \\to \\mathbb{RP}^n$; its fixed-point-freeness is exactly the condition needed for that quotient to be a manifold. The Euler characteristic formula $\\chi(S^n) = 1+(-1)^n$ and Betti numbers $b_0 = b_n = 1$ (others 0) follow from the minimal CW structure of $S^n$ (one 0-cell and one $n$-cell); here they are taken as definitions/formulas rather than derived from an actual CW/homology computation, so the 'proofs' are simple arithmetic checks of the formula rather than homological computations.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "antipodal map",
+      "real projective space",
+      "Euler characteristic",
+      "Betti numbers",
+      "CW complex"
+    ],
+    "prerequisites": [
+      "Metric.sphere",
+      "homeomorphism"
+    ]
+  },
+  {
+    "id": "ann-pc-lens-spaces-transfer-corollaries",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 1543,
+      "endLine": 1832
+    },
+    "type": "concept",
+    "title": "Lens Spaces, Transfer of Topological Properties, and Poincaré Corollaries",
+    "content": "Defines `LensSpaceParams` (p, q with gcd(p,q)=1) and instantiates concrete lens spaces L(1,0)≅S³, L(2,1)≅RP³, L(3,1), L(5,1), L(5,2), each with coprimality discharged by `native_decide`. `lens_homeomorphism_necessary` states a four-way disjunction meant to reflect the Reidemeister classification, but as proved it is logically trivial: the proof term is just `Or.inr (Or.inr (Or.inr (Or.inr hsamep)))`, i.e. it only ever uses the last disjunct (same p), not any actual modular-arithmetic Reidemeister condition — the code's own comment calls this a 'weakened' form. The remaining code proves that compactness, connectedness, path-connectedness, and nonemptiness transfer across `AreHomeomorphic`, and derives corollaries of the (assumed) Poincaré conjecture such as uniqueness of the simply-connected closed 3-manifold up to homeomorphism.",
+    "mathContext": "Lens spaces $L(p,q) = S^3/\\mathbb{Z}_p$ (with $\\mathbb{Z}_p$ acting freely via $(z_1,z_2)\\mapsto(\\zeta z_1, \\zeta^q z_2)$ for a primitive $p$-th root of unity $\\zeta$) have $\\pi_1(L(p,q)) \\cong \\mathbb{Z}/p\\mathbb{Z}$, so only $L(1,q)\\cong S^3$ is simply connected — making lens spaces the standard counterexamples showing the simple-connectivity hypothesis in Poincaré's conjecture is necessary. Reidemeister's 1935 theorem gives the sharp classification $L(p,q)\\cong L(p,q')$ iff $q'\\equiv \\pm q$ or $qq'\\equiv \\pm1 \\pmod p$, established via Reidemeister torsion; the file states this shape but does not actually formalize or use torsion, instead proving a degenerate special case of the disjunction.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "lens spaces",
+      "Reidemeister torsion",
+      "fundamental group",
+      "homeomorphism transfer"
+    ],
+    "prerequisites": [
+      "quotient spaces",
+      "AreHomeomorphic",
+      "coprimality"
+    ]
+  },
+  {
+    "id": "ann-pc-nonexamples-thurston-classification",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 1833,
+      "endLine": 2098
+    },
+    "type": "context",
+    "title": "Non-Examples (Homology Sphere, Whitehead Manifold) and Thurston Geometry Classification",
+    "content": "Introduces two axiomatized non-examples showing the Poincaré conjecture's hypotheses are both necessary: the Poincaré homology sphere (closed 3-manifold, same homology as S³, but π₁ nontrivial — here modeled abstractly via axioms, with π₁ nontriviality witnessed concretely by the order-120 binary icosahedral group `Multiplicative (ZMod 120)`) shows simple connectivity is essential, and the axiomatized Whitehead manifold (contractible but non-compact) shows closedness is essential. The section then defines Boolean-valued classifiers on the 8 Thurston geometries (`hasCompactModel`, `isIsotropic`, `curvatureType`, `isometryGroupDim`) and proves by case analysis / `native_decide` that spherical geometry is the unique one with a compact model and that exactly 3 of the 8 are isotropic.",
+    "mathContext": "The Poincaré homology sphere $\\Sigma(2,3,5) = SU(2)/I^*$ (quotient of $S^3$ by the binary icosahedral group $I^*$, $|I^*|=120$) has the homology of $S^3$ but fundamental group $I^*$, historically Poincaré's own counterexample to his first (homology-based) conjecture, motivating the corrected simply-connected formulation. The Whitehead manifold is a contractible open 3-manifold not homeomorphic to $\\mathbb{R}^3$, showing compactness cannot be dropped. Thurston's geometrization assigns each of 8 model geometries (spherical $S^3$, Euclidean $\\mathbb{R}^3$, hyperbolic $\\mathbb{H}^3$, $S^2\\times\\mathbb{R}$, $\\mathbb{H}^2\\times\\mathbb{R}$, Nil, Sol, $\\widetilde{SL_2\\mathbb{R}}$); only the spherical geometry has a compact simply-connected model, which is the structural reason geometrization implies the Poincaré conjecture. `geometrization_implies_poincare` packages this as a direct explicit one-piece witness rather than deriving it from a real decomposition theorem.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Poincaré homology sphere",
+      "binary icosahedral group",
+      "Whitehead manifold",
+      "Thurston geometrization",
+      "geometric structures"
+    ],
+    "prerequisites": [
+      "ContractibleSpace",
+      "SimplyConnectedSpace",
+      "Closed3Manifold"
+    ]
+  },
+  {
+    "id": "ann-pc-heegaard-mcg-surgery-quaternion-identities",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 2099,
+      "endLine": 2563
+    },
+    "type": "definition",
+    "title": "Heegaard Splittings, Mapping Class Group, Dehn Surgery, and Raw Quaternion Identities",
+    "content": "Defines `Handlebody`/`HeegaardSplitting` and Heegaard genus, proves S³ has a genus-0 splitting and states Waldhausen's genus-0-implies-S³ theorem as an axiom, giving a triple characterization of S³ (simply connected ↔ genus 0 ↔ homeomorphic to S³). Several downstream 'theorems' here are largely placeholder packagings rather than substantive results: `lens_heegaard_genus1` claims a fact about lens spaces but its witness is a `HeegaardSplitting Unit` unconnected to the actual lens-space parameter `L`; `heegaard_genus_additive` returns `P := M` (the first manifold itself) rather than an actual connected sum; `genus1_classification` always returns `Or.inr lensRP3` regardless of the hypotheses; and `reidemeister_singer`/`mcg_torus_is_SL2Z` reduce to trivial arithmetic (`omega`/`decide`) rather than encoding the cited classical theorems. The Dehn-surgery subsection axiomatizes `DehnSurgeryResult` and states Lickorish–Wallace with an existential witnessed vacuously by zero knots. The closing `QuaternionStructure` section re-derives, in raw-coordinate form, the associativity, identity, inverse, and norm-multiplicativity laws for quaternion multiplication as pure polynomial identities (all closed by `ring`/`nlinarith`), independent of the `EuclideanSpace`-based construction earlier in the file.",
+    "mathContext": "Every closed orientable 3-manifold admits a Heegaard splitting $M = H_1 \\cup_\\Sigma H_2$ into two handlebodies glued along a genus-$g$ surface; Waldhausen (1968) showed $g(M)=0 \\iff M \\cong S^3$, and lens spaces are exactly the genus-1 manifolds, classified via $\\mathrm{MCG}(T^2) \\cong SL(2,\\mathbb{Z})$. The Reidemeister–Singer theorem says any two splittings become isotopic after finitely many stabilizations. Lickorish–Wallace states every closed orientable 3-manifold arises from $S^3$ by Dehn surgery on a link. None of these substantive classical statements is actually proved here — the code states type signatures resembling them and discharges the goals with degenerate or hypothesis-ignoring witnesses. The quaternion identities, by contrast, are genuine and complete: the Lagrange/Euler four-square identity $(\\sum a_i^2)(\\sum b_i^2) = \\sum c_i^2$ and associativity of the Hamilton product are verified as polynomial ring identities in 8–12 real variables.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "Heegaard splitting",
+      "mapping class group",
+      "Dehn surgery",
+      "Lickorish-Wallace theorem",
+      "quaternion algebra"
+    ],
+    "prerequisites": [
+      "handlebody",
+      "SurgerySlope / coprimality",
+      "polynomial ring identities"
+    ]
+  },
+  {
+    "id": "ann-pc-rp3-covering-space",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 2564,
+      "endLine": 3220
+    },
+    "type": "concept",
+    "title": "RP³ via Covering Spaces: A Genuine Non-Simply-Connected 3-Manifold",
+    "content": "Defines abstract `CoveringSpace`/`FiniteCoveringSpace` structures and an axiom that a connected cover of a simply-connected space must be injective, then builds real projective space RP³ = S³/{x ~ −x} as a quotient by the antipodal involution. Local Euclidean-ness of RP³ is proved directly (not axiomatized) via an explicit gnomonic-projection homeomorphism between an open hemisphere of S³ and ℝ³; the file's own comment notes this eliminates a formerly axiomatized fact. The section closes by assembling these pieces into proofs that RP³ is a closed 3-manifold, that S³ → RP³ is a genuine 2-fold covering, that π₁(RP³) is nontrivial, and that RP³ is therefore not homeomorphic to S³.",
+    "mathContext": "The antipodal map $x \\mapsto -x$ acts freely on $S^3 \\subset \\mathbb{R}^4$, and $\\mathbb{RP}^3 = S^3/\\{\\pm 1\\}$ inherits the quotient topology. For $p \\in S^3$, the gnomonic (central) projection $v \\mapsto \\langle p,v\\rangle^{-1} v - p$ sends the open hemisphere $H_p = \\{v : \\langle p,v\\rangle > 0\\}$ homeomorphically onto the hyperplane $p^{\\perp} \\cong \\mathbb{R}^3$, with inverse $u \\mapsto (p+u)/\\|p+u\\|$; since $H_p$ injects into the quotient, this gives local Euclidean charts on $\\mathbb{RP}^3$. Because the covering $S^3 \\to \\mathbb{RP}^3$ is 2-to-1 (each fiber is $\\{x,-x\\}$, $x \\ne -x$ since the antipodal map is fixed-point free), the classification of covering spaces of simply connected spaces (only the trivial one-sheeted cover) forces $\\pi_1(\\mathbb{RP}^3) \\ne 1$, in fact $\\cong \\mathbb{Z}/2\\mathbb{Z}$. This is the standard example showing the hypothesis 'simply connected' in the Poincaré conjecture is not vacuous.",
+    "significance": "key",
+    "relatedConcepts": [
+      "covering space",
+      "real projective space",
+      "antipodal map",
+      "gnomonic projection",
+      "quotient topology",
+      "fundamental group"
+    ],
+    "prerequisites": [
+      "quotient spaces",
+      "local homeomorphism / manifold charts",
+      "simply connected space"
+    ]
+  },
+  {
+    "id": "ann-pc-ball3-and-surgery",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 3221,
+      "endLine": 3476
+    },
+    "type": "concept",
+    "title": "The 3-Ball, Alexander/Schoenflies Framework, and Dehn Surgery Obstructions",
+    "content": "Defines the closed 3-ball B³ and proves directly (from convexity/star-convexity) that it is compact, contractible, simply connected, and not homeomorphic to S³ (S³ is non-contractible elsewhere in the file). Note: the classical Alexander theorem itself (every tame S² in S³ bounds a ball) and the 3D Jordan-Brouwer separation theorem are NOT proved here — they appear only as removed/commented-out stubs marked 'reinstatable when needed'; the `TameS2inS3` structure records the setup but the section's only substantive Alexander-flavored consequence, `alexander_implies_genus0`, is actually derived from an existing genus-0 Heegaard splitting result rather than from Alexander's theorem being formalized. The second half axiomatizes how the fundamental group behaves under connected sum and Dehn surgery: `pi1_connected_sum`/`poincare_connected_sum` derive M#N simply-connected ⟹ M,N ≅ S³ from a free-product axiom, while `pi1_surgery_nontrivial` and the Property P axiom (Kronheimer–Mrowka, cited but not proved) are used to show nontrivial surgery on a knot in S³ never returns S³. The `MilnorSwanConstraint` structure and `milnor_swan_condition` theorem are essentially vacuous — for any finite group, the witness period = 1 trivially divides 4, so no real classification content is encoded.",
+    "mathContext": "$B^3$ is convex, hence star-convex, hence contractible; contractible spaces are simply connected, and since $S^3$ is proved non-contractible elsewhere, $B^3 \\not\\cong S^3$. Alexander's theorem (1924) states every tamely embedded $S^2 \\subset S^3$ separates $S^3$ into two components each homeomorphic to $B^3$ — foundational for genus-0 Heegaard splittings of $S^3$, but here that link is only asserted via a pre-existing theorem, not proved from Alexander's theorem itself. For surgery: Dehn surgery on a knot $K$ with slope $p/q$ modifies $\\pi_1(S^3 \\setminus K)$ by adding the relation $\\mu^p \\lambda^q = 1$; Property P asserts no nontrivial surgery on a nontrivial knot yields $S^3$, proved originally via instanton Floer homology (Kronheimer–Mrowka 2004) and here simply postulated as an axiom.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Alexander's theorem",
+      "Schoenflies theorem",
+      "Heegaard splitting",
+      "Dehn surgery",
+      "Property P",
+      "connected sum",
+      "free product"
+    ],
+    "prerequisites": [
+      "contractibility",
+      "fundamental group",
+      "knot theory basics"
+    ]
+  },
+  {
+    "id": "ann-pc-milnor-prime-decomposition",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 3477,
+      "endLine": 3669
+    },
+    "type": "concept",
+    "title": "Milnor's Uniqueness Theorem and Prime Decomposition Structure",
+    "content": "Introduces `IsIrreducible3Manifold` as an opaque (undefined) predicate — deliberately abstract to avoid a previous unsoundness where a trivial definition made a downstream 'not irreducible' claim about S¹×S² provable by contradiction from a vacuous truth. Axiomatizes that irreducibility implies primality and that S³ is irreducible (an Alexander's-theorem consequence), constructs S¹×S² concretely as a product-topology closed 3-manifold with charts built from stereographic projections on S¹ and S², and axiomatizes Milnor's uniqueness theorem. Note the axiom `milnor_uniqueness` only concludes `m = n` (equal factor counts) for two prime decompositions of the same manifold — it does not assert the individual factor-by-factor homeomorphism $P_i \\cong Q_i$ that the classical theorem includes, so it is a weakened form of Milnor's result. The remaining theorems (trivial decomposition of simply-connected manifolds, S³ as the identity for connected sum, cancellation `connected_sum_to_S3`, and RP³ being prime) are proved from this axiom together with the Poincaré conjecture established elsewhere.",
+    "mathContext": "A closed 3-manifold is irreducible if every embedded $S^2$ bounds a ball; it is prime if it is not a nontrivial connected sum. Every irreducible manifold is prime, but $S^1\\times S^2$ is a standard counterexample to the converse — it is prime yet contains a non-separating $S^2$. Milnor's uniqueness theorem (1962) is the 3-manifold analogue of unique factorization: if $M \\cong P_1 \\# \\cdots \\# P_m \\cong Q_1 \\# \\cdots \\# Q_n$ with all $P_i, Q_j$ prime, then $m=n$ and, after reordering, $P_i \\cong Q_i$. Under connected sum, $S^3$ acts as the identity element ($M \\# S^3 \\cong M$), making prime 3-manifolds (up to homeomorphism) a free commutative monoid — the formalized `milnor_uniqueness` axiom captures only the cardinality part $m=n$ of this statement.",
+    "significance": "key",
+    "relatedConcepts": [
+      "prime decomposition",
+      "irreducible 3-manifold",
+      "connected sum",
+      "Kneser-Milnor theorem",
+      "unique factorization"
+    ],
+    "prerequisites": [
+      "connected sum",
+      "closed 3-manifold",
+      "Poincaré conjecture statement"
+    ]
+  },
+  {
+    "id": "ann-pc-ricci-flow-foundations",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 3671,
+      "endLine": 3877
+    },
+    "type": "concept",
+    "title": "Ricci Flow Foundations: Hamilton–Perelman Statement Scaffolding",
+    "content": "Introduces structures (`RicciFlowSolution`, `PerelmanWEntropyData`, `RicciFlowSingularity`, `RicciFlowWithSurgery`) that abstractly package Hamilton's evolution equation $\\partial g/\\partial t = -2\\,\\mathrm{Ric}(g)$ and Perelman's key tools (W-entropy monotonicity, no-local-collapsing, singularity classification, surgery, finite extinction). Read the proof terms carefully: nearly every 'theorem' here — `hamilton_short_time_existence`, `hamilton_sphere_theorem`, `perelman_no_local_collapsing`, `perelman_finite_extinction_detailed` — is discharged by supplying a trivial, hypothesis-independent witness (e.g. a constant zero-curvature solution, κ=r₀=1, a `RicciFlowWithSurgery` with zero surgeries and T=1) rather than any real PDE argument, so these only confirm the existential *shape* of the classical statements is inhabited, not their mathematical content. The theorems that conclude `AreHomeomorphic M Sphere3` (`positive_ricci_SC_is_S3`, `poincare_via_ricci_flow`, `three_proofs_agree`) do so by directly invoking `poincare_conjecture_holds`, which is established elsewhere in the file independently of any Ricci-flow-specific hypothesis supplied here — so this section is a statement-level scaffold for Hamilton/Perelman's program, not an independent formalized proof of Poincaré via Ricci flow.",
+    "mathContext": "Hamilton (1982) introduced Ricci flow $\\partial_t g = -2\\,\\mathrm{Ric}(g)$, showing short-time existence and, for manifolds with positive Ricci curvature, convergence to constant curvature (hence spherical space forms). Perelman's contributions (2002–03) were the $\\mathcal{W}$-entropy functional $\\mathcal{W}(g,f,\\tau) = \\int_M [\\tau(|\\nabla f|^2+R)+f-n](4\\pi\\tau)^{-n/2}e^{-f}\\,dV$, monotone along the flow coupled to a backward heat equation; the no-local-collapsing theorem ruling out thin/collapsed regions; a classification of singularity models (shrinking round $S^3$, shrinking $S^2\\times\\mathbb{R}$ necks, and quotients); and finite-time extinction of Ricci flow with surgery on simply connected manifolds, which together give an independent analytic proof of the Poincaré conjecture.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Ricci flow",
+      "Hamilton's theorem",
+      "Perelman W-entropy",
+      "no local collapsing",
+      "singularity classification",
+      "finite extinction"
+    ],
+    "prerequisites": [
+      "Riemannian metric",
+      "Ricci curvature",
+      "closed 3-manifold"
+    ]
+  },
+  {
+    "id": "ann-pc-betti-gromov-bounds",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 3879,
+      "endLine": 4122
+    },
+    "type": "concept",
+    "title": "Betti Numbers, Euler Characteristic, and Gromov Volume/Topology Bounds",
+    "content": "Defines `BettiNumbers3`, encoding $b_0=1$, $b_3=1$, and Poincaré duality $b_1=b_2$ directly as structure hypotheses (assumed, not derived from a homology computation), and proves the Euler characteristic $\\chi = b_0-b_1+b_2-b_3$ vanishes purely by this arithmetic. Concrete Betti data is instantiated for S³, S¹×S², T³, lens spaces, and the Poincaré homology sphere; `phs_same_betti_as_S3` makes explicit that the Poincaré homology sphere has identical Betti numbers to S³ (b=(1,0,0,1)) despite nontrivial π₁ — the reason the Poincaré conjecture is stated using the fundamental group and not just homology. The section closes with `SimplicialVolume3`/`CheegerGromovData` scaffolding and 'Gromov Betti bound ≤ 8' theorems, verified individually for the four listed concrete manifolds plus a general version that takes $b_1 \\le 3$ as a hypothesis standing in for (but not derived from) non-negative Ricci curvature.",
+    "mathContext": "For a closed orientable $n$-manifold Poincaré duality gives $b_k = b_{n-k}$; for $n=3$ this forces $\\chi(M) = b_0 - b_1 + b_2 - b_3 = 0$ once $b_0=b_3=1$ and $b_1=b_2$. The Poincaré homology sphere $\\Sigma(2,3,5)$ is the classical example of a homology sphere ($H_*(\\Sigma) \\cong H_*(S^3)$) with nontrivial fundamental group $\\cong$ the binary icosahedral group of order 120, illustrating why homology alone cannot characterize $S^3$. Gromov's theorem bounds the total Betti number of a closed manifold with non-negative Ricci curvature by $2^n$ (here $\\le 8$ for $n=3$), and the Gromov simplicial volume (Gromov norm) is positive exactly for hyperbolic pieces among Thurston's eight geometries, vanishing for all six non-hyperbolic geometries realized among $S^3$, $T^3$, lens spaces, etc.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Betti numbers",
+      "Poincaré duality",
+      "Euler characteristic",
+      "Poincaré homology sphere",
+      "Gromov simplicial volume",
+      "Thurston geometries"
+    ],
+    "prerequisites": [
+      "homology of manifolds",
+      "Poincaré duality",
+      "Ricci curvature"
+    ]
+  },
+  {
+    "id": "ann-pc-jsj-decomposition-graph-manifolds",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 4123,
+      "endLine": 4504
+    },
+    "type": "concept",
+    "title": "JSJ Decomposition and Graph Manifolds",
+    "content": "Formalizes the Jaco-Shalen-Johannson (JSJ) decomposition as the second stage of 3-manifold structure theory (after Kneser-Milnor prime decomposition, before geometrization): cutting an irreducible manifold along essential tori into Seifert-fibered or atoroidal pieces. `EssentialTorus`, `IsAtoroidal`, `SeifertFiberedSpace`, and `JSJPiece` are defined as structures, `IsJSJDecomposition` is left `opaque` to block trivial instantiation, and the existence/uniqueness theorems (`jsj_decomposition`, `jsj_uniqueness`) are stated as axioms. A run of corollaries (`SC_atoroidal`, `S3_trivial_jsj`, `rp3_jsj_single_seifert`, etc.) then derive consequences for simply connected and specific manifolds, largely by chaining these axioms with the previously proved `poincare_conjecture_holds`. The following `IsGraphManifold`/`thurstonNorm` section models graph manifolds (all-Seifert JSJ pieces) and defines `thurstonNorm` as the constant-zero function — a placeholder stub, not an actual computation of the norm — so downstream theorems like `thurston_norm_ball_polyhedron` are trivial `rfl`s about this stub rather than substantive statements about Thurston's norm.",
+    "mathContext": "The JSJ decomposition theorem (Jaco–Shalen, Johannson, 1979) says every closed orientable irreducible 3-manifold $M$ admits a canonical (up to isotopy) collection of disjoint essential tori $T_1,\\dots,T_k \\subset M$ cutting it into pieces that are each Seifert fibered or atoroidal; atoroidal pieces are exactly the ones that, by geometrization, admit a hyperbolic structure. An essential torus $T^2 \\hookrightarrow M$ injects $\\pi_1(T^2) \\cong \\mathbb{Z}^2$ into $\\pi_1(M)$, so its non-existence for simply connected $M$ (`not_simply_connected` field) makes atoroidality automatic. The Thurston norm on $H_2(M;\\mathbb{R})$ is $\\|\\alpha\\|_T = \\inf\\{-\\chi(S) : [S]=\\alpha,\\ \\chi(S)<0\\}$, whose unit ball is a convex polyhedron (Thurston 1986); here it is only modeled as identically $0$, which happens to be correct for $S^3$ and other manifolds with $H_2=0$ but is not a general definition.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "JSJ decomposition",
+      "essential torus",
+      "Seifert fibered space",
+      "Thurston norm",
+      "graph manifold"
+    ],
+    "prerequisites": [
+      "Kneser-Milnor prime decomposition",
+      "fundamental group",
+      "3-manifold topology"
+    ]
+  },
+  {
+    "id": "ann-pc-perelman-outline-geometries-post",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 4506,
+      "endLine": 4806
+    },
+    "type": "context",
+    "title": "Perelman's Ricci Flow Proof Outline, Thurston's Eight Geometries, and Post-Perelman Results",
+    "content": "A narrative/tabular sketch of Perelman's actual proof strategy rather than a formalization of it: `HamiltonRicciFlowDetails`, `KappaNoncollapsing`, `WEntropyFunctional`, `SingularityType`, `CanonicalNeighborhood`, `SurgeryProcedure`, and `RicciFlowWithSurgeryDetail` are all structures whose fields are bare `Prop`s (uninstantiated placeholders, not proved facts), documenting the shape of Hamilton/Perelman's argument in comments. The one substantive theorem, `finite_extinction_time`, just restates the already-proved `poincare_conjecture_holds` under a different name, and `perelman_proof_outline` proves only that the four `CanonicalNeighborhood` constructors are pairwise distinct — a trivial enum fact standing in for Perelman's actual classification theorem. The following sections encode Thurston's eight model geometries (`ThurstonGeometryDetailed`) with a `geometryData` lookup table of isometry-group dimension and quotient counts (the latter as free-text `String`s, not verified classifications), then close with `OpenProblem3Manifold` and the generalized-Poincaré timeline; theorems like `mostow_rigidity`, `agol_virtual_haken`, and `perelman_declined_prize` are `rfl`/`decide` facts about these hand-entered enum/table values, not independent derivations.",
+    "mathContext": "Perelman's actual proof (2002–2003) establishes short-time existence of Ricci flow $\\partial_t g = -2\\,\\mathrm{Ric}(g)$, $\\kappa$-noncollapsing via monotonicity of the $\\mathcal{W}$-entropy $\\mathcal{W}(g,f,\\tau)=\\int[\\tau(|\\nabla f|^2+R)+f-n](4\\pi\\tau)^{-n/2}e^{-f}\\,dV$, a canonical-neighborhood classification of high-curvature regions (necks, caps, round components), and surgery through singularities with finite extinction time for simply connected manifolds. Thurston's eight geometries $S^3, E^3, H^3, S^2\\times\\mathbb{R}, H^2\\times\\mathbb{R}, \\mathrm{Nil}, \\mathrm{Sol}, \\widetilde{SL_2\\mathbb{R}}$ classify the possible geometric structures on JSJ pieces, with $S^3$ (isometry group dimension 6, isotropic) being the unique geometry realized by a simply connected compact quotient. Mostow rigidity states hyperbolic structures on closed 3-manifolds are unique up to isometry, so $\\pi_1$ determines the geometry; Agol's 2012 virtual Haken/fibering theorem resolved two long-standing conjectures about hyperbolic 3-manifolds.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Ricci flow",
+      "W-entropy",
+      "canonical neighborhoods",
+      "Thurston's eight geometries",
+      "Mostow rigidity",
+      "virtual Haken conjecture"
+    ],
+    "prerequisites": [
+      "Ricci flow basics",
+      "sectional/Ricci curvature",
+      "geometric structures on manifolds"
+    ]
+  },
+  {
+    "id": "ann-pc-phs-higherdim-surgery-knots",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 4808,
+      "endLine": 5121
+    },
+    "type": "context",
+    "title": "Poincaré Homology Sphere, Higher-Dimensional Generalizations, Dehn Surgery, and Knots",
+    "content": "A tour of the classical counterexamples and generalizations surrounding the conjecture, mostly encoded as enums/structures with `Prop`-typed fields plus a handful of arithmetic facts. `PHSConstruction` lists the five equivalent descriptions of the Poincaré homology sphere $\\Sigma(2,3,5)$ (as $S^3/I^*$, a Brieskorn sphere, $+1$-surgery on the trefoil, dodecahedral space, and $E_8$-plumbing boundary), with `binary_icosahedral_order` proving only the numeric fact $120 = 2\\cdot 60$. `poincareResolution`/`exoticSphereCounts` are hand-built lookup tables recording the known status (topological/smooth, prover) of the generalized Poincaré conjecture and exotic-sphere counts by dimension, with theorems like `smale_h_cobordism`, `freedman_topological_4d`, and `exotic_4_open` simply reading off entries by `rfl`. `DehnSurgeryData`/`KirbyCalculus` model Dehn surgery and Kirby moves as `Prop`-field structures; `lickorish_wallace_general` and `gordon_luecke` only verify that specific `SurgerySlope` numerators/denominators equal the claimed constants, not the underlying surgery theorems. `knot_surgery_poincare` again just re-invokes `poincare_conjecture_holds`.",
+    "mathContext": "The Poincaré homology sphere $\\Sigma(2,3,5) = \\{z_1^2+z_2^3+z_3^5=0\\}\\cap S^5$ has $H_*(\\Sigma;\\mathbb{Z}) \\cong H_*(S^3;\\mathbb{Z})$ but $\\pi_1(\\Sigma) \\cong I^*$, the binary icosahedral group of order $120$ (double cover of $A_5$), showing homology alone cannot detect $S^3$ — motivating Poincaré's reformulation using $\\pi_1$. The generalized Poincaré conjecture is now fully resolved: trivial in dimensions $1,2$; Perelman (2003) in dimension 3; Freedman (1982) topologically in dimension 4 (smooth case open, tied to the existence of exotic $\\mathbb{R}^4$s); Smale's h-cobordism theorem (1961) for dimension $\\geq 5$. Lickorish–Wallace (1962) shows every closed orientable 3-manifold arises from Dehn surgery on a link in $S^3$; Gordon–Luecke (1989) shows knots are determined by their complements (except for lens-space-type surgeries); Kronheimer–Mrowka's Property P (2004) rules out 0-surgery on a nontrivial knot yielding a homotopy sphere.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Poincaré homology sphere",
+      "Brieskorn sphere",
+      "exotic spheres",
+      "Dehn surgery",
+      "Property P",
+      "Gordon-Luecke theorem"
+    ],
+    "prerequisites": [
+      "homology vs. homotopy",
+      "knot complements",
+      "surgery on 3-manifolds"
+    ]
+  },
+  {
+    "id": "ann-pc-cyclic-actions-lens-spaces",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 5123,
+      "endLine": 5322
+    },
+    "type": "technique",
+    "title": "Concrete Cyclic Group Actions on S³ and Lens Space Geometry",
+    "content": "Unlike the surrounding sections, this is a genuinely worked-out analytic construction: `cyclicRotation p q` explicitly writes the $\\mathbb{Z}/p$ action $\\zeta\\cdot(z_1,z_2)=(\\zeta z_1,\\zeta^q z_2)$ on $S^3\\subset\\mathbb{C}^2\\cong\\mathbb{R}^4$ as a pair of 2D rotation blocks on `EuclideanSpace ℝ (Fin 4)`. It proves the action preserves the squared norm (`cyclicRotation_norm_sq`, via the identity $(\\cos\\theta\\,a-\\sin\\theta\\,b)^2+(\\sin\\theta\\,a+\\cos\\theta\\,b)^2=a^2+b^2$), hence maps $S^3$ to itself (`cyclicRotation_preserves_sphere`) and is continuous (`cyclicRotation_continuous`), and that applying the rotation $p$ times returns the identity angle $2\\pi$ (`cyclicRotation_period_identity`). These facts back concrete instances `rp3CyclicAction`, `l31CyclicAction`, `l52CyclicAction` realizing $L(2,1)=\\mathbb{RP}^3$, $L(3,1)$, and $L(5,2)$ as literal quotient actions rather than abstract axioms.",
+    "mathContext": "Lens spaces $L(p,q) = S^3/(\\mathbb{Z}/p)$ are defined via the free action $\\zeta\\cdot(z_1,z_2)=(\\zeta z_1,\\zeta^q z_2)$ for $\\zeta=e^{2\\pi i/p}$ a primitive $p$-th root of unity, giving $\\pi_1(L(p,q))\\cong\\mathbb{Z}/p\\mathbb{Z}$ (deck group of the universal cover $S^3\\to L(p,q)$). Freeness of the action for $p\\geq 2$ follows because a fixed point would force $z_1=z_2=0$, contradicting $|z_1|^2+|z_2|^2=1$; the case $q=1,p=2$ recovers the antipodal map and $\\mathbb{RP}^3$. Writing the action in real coordinates as two independent $2\\times2$ rotation matrices with angles $\\alpha=2\\pi/p$ and $\\beta=2\\pi q/p$ makes norm-preservation an elementary consequence of $\\cos^2\\theta+\\sin^2\\theta=1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "lens space",
+      "cyclic group action",
+      "free group action",
+      "deck transformation"
+    ],
+    "prerequisites": [
+      "EuclideanSpace coordinates",
+      "rotation matrices",
+      "covering space theory"
+    ]
+  },
+  {
+    "id": "ann-pc-euler-char-covering-betti",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 5325,
+      "endLine": 5604
+    },
+    "type": "concept",
+    "title": "Euler Characteristic Invariants, Covering-Space Consequences, and Betti Classification",
+    "content": "Derives consequences of the earlier `sc_covering_injective` result: a covering of a simply connected space is bijective (`sc_covering_bijective`), so a connected non-injective covering rules out simple connectivity (`not_sc_of_nontrivial_covering`), and multi-sheeted coverings imply nontrivial $\\pi_1$ (`pi1_nontrivial_of_multisheeted_covering`). These are applied to concrete cases: $\\mathbb{RP}^3$'s 2-sheeted cover by $S^3$, lens spaces' $p$-sheeted covers, and $\\Sigma(2,3,5)$'s 120-sheeted cover, summarized in `covering_theory_summary`. The `HomologySphere3`/`ManifoldInvariantTable` machinery and theorems like `betti_not_complete_invariant` make explicit that $S^3$ and $\\Sigma(2,3,5)$ share identical Betti numbers $(1,0,0,1)$ and Euler characteristic $0$ yet are not homeomorphic, illustrating why the Poincaré conjecture is genuinely about $\\pi_1$ rather than homology.",
+    "mathContext": "For a connected covering $p: \\tilde X \\to X$ with $X$ simply connected, $p$ must be a homeomorphism, since $\\pi_1(X)$ acting trivially forces a single sheet; contrapositively, a non-injective connected covering witnesses $\\pi_1(X)\\neq 1$. Poincaré duality in dimension 3 gives $b_0=b_3$ and $b_1=b_2$ for closed orientable $M$, so a homology sphere ($b_1=0$) automatically has Euler characteristic $\\chi=b_0-b_1+b_2-b_3=0$ — but $\\chi=0$ and matching Betti numbers say nothing about $\\pi_1$, as the pair $(S^3, \\Sigma(2,3,5))$ demonstrates: both have Betti vector $(1,0,0,1)$ but $\\pi_1(\\Sigma(2,3,5))\\cong I^*$ has order 120.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "covering space",
+      "Betti numbers",
+      "Euler characteristic",
+      "Poincaré duality",
+      "homology sphere"
+    ],
+    "prerequisites": [
+      "fundamental group of covering spaces",
+      "singular homology",
+      "Poincaré duality"
+    ]
+  },
+  {
+    "id": "ann-pc-circle-doubling-map",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 5606,
+      "endLine": 5841
+    },
+    "type": "technique",
+    "title": "The Circle-Doubling Map as an Explicit Covering",
+    "content": "Constructs the map $z\\mapsto z^2$ on $S^1$ concretely in real coordinates as `circleSquareE (a,b) = (a²-b², 2ab)` on `EuclideanSpace ℝ (Fin 2)`, then proves from scratch that it preserves norm-squared up to the fourth power (`circleSquareE_norm_sq`: $\\|z^2\\|^2=\\|z\\|^4$), restricts to a continuous self-map `circleDouble` of $S^1$, is not injective (both $(1,0)$ and $(-1,0)$ map to $(1,0)$, via `circleDouble_north`/`circleDouble_south`), and is surjective (`circleDouble_surjective`, using an explicit half-angle-formula construction of a square root on the circle). Packaging this as `s1_double_cover : CoveringSpace (↥Sphere1)` and applying `not_sc_of_nontrivial_covering` yields `sphere1_not_simply_connected` as an actual proof rather than an axiom.",
+    "mathContext": "The squaring map $z\\mapsto z^2$ on the unit circle is the prototypical connected 2-sheeted covering $S^1 \\to S^1$, exhibiting $\\pi_1(S^1)\\cong\\mathbb{Z}$ concretely: its failure to be injective (antipodal points $z,-z$ share an image) witnesses a nontrivial deck transformation. In real coordinates this is $(a,b)\\mapsto(a^2-b^2,2ab)$, and norm-squared doubling follows from $(a^2-b^2)^2+(2ab)^2=(a^2+b^2)^2$; surjectivity is the elementary fact that every complex number of modulus 1 has a square root of modulus 1, constructed here via $a=\\sqrt{(1+c)/2}$, $b=\\pm\\sqrt{(1-c)/2}$ matching the sign of the target's imaginary part.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "covering space",
+      "circle doubling map",
+      "fundamental group of the circle",
+      "surjectivity via half-angle formula"
+    ],
+    "prerequisites": [
+      "EuclideanSpace ℝ (Fin 2)",
+      "continuity of polynomial maps",
+      "covering space criterion for simple connectivity"
+    ]
+  },
+  {
+    "id": "ann-pc-product-coverings-obstructions",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 5843,
+      "endLine": 5994
+    },
+    "type": "insight",
+    "title": "Product Coverings and Fundamental-Group Obstructions to S³",
+    "content": "Extends the circle-doubling covering to products: `s2xs1_cover` doubles the $S^1$ factor of $S^2\\times S^1$, and `torus3_cover` doubles the first $S^1$ factor of $T^3=S^1\\times S^1\\times S^1$; both are shown non-injective by exhibiting explicit pairs of points ((north,south) pole pairs) with equal images, giving `sphere2_cross_S1_not_simply_connected_proved` and `torus3_not_simply_connected_proved` as genuine theorems replacing what the file notes were formerly axioms. The final block chains these results through `simply_connected_of_homeomorphic` to conclude $S^3$ is not homeomorphic to $S^2\\times S^1$ (`hopf_bundle_nontrivial`, `S2_cross_S1_not_S3`), $T^3$ (`torus3_not_S3`), or $S^1\\times S^2$ (`S1_cross_S2_not_S3`) — i.e., these are genuinely distinct manifolds from the Poincaré sphere.",
+    "mathContext": "If $X = Y\\times S^1$, doubling only the $S^1$ factor, $(y,z)\\mapsto(y,z^2)$, gives a connected covering of $X$ that is non-injective whenever $Y$ is nonempty (any $y$ paired with antipodal $S^1$ points), so $\\pi_1(X)$ surjects onto $\\mathbb{Z}/2$ and in particular $X$ is not simply connected; applied to $Y=S^2$ and to $T^3=S^1\\times(S^1\\times S^1)$ this detects the $S^1$ factor's contribution to $\\pi_1$. Since simple connectivity is a homeomorphism invariant, and $S^3$ is simply connected while $S^2\\times S^1$, $S^1\\times S^2$, and $T^3$ are not, none of these can be homeomorphic to $S^3$ — a concrete instance of the general principle that $\\pi_1$ is what actually characterizes $S^3$ among closed 3-manifolds, not homology or Euler characteristic.",
+    "significance": "key",
+    "relatedConcepts": [
+      "product covering space",
+      "fundamental group of a product",
+      "Hopf bundle",
+      "homeomorphism invariance of π₁"
+    ],
+    "prerequisites": [
+      "circle doubling map covering",
+      "simple connectivity under homeomorphism"
+    ]
+  },
+  {
+    "id": "ann-pc-morse-theory-foundations",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 5996,
+      "endLine": 6214
+    },
+    "type": "concept",
+    "title": "Morse Theory and the Weak/Strong Morse Inequalities for 3-Manifolds",
+    "content": "Defines a purely combinatorial model `MorseData3` recording counts of index-0..3 critical points, proves the strong Morse equality c0-c1+c2-c3=0 (`morse_euler_eq_zero`) follows by `omega` once the Euler characteristic vanishes, and packages the weak Morse inequalities c_k ≥ b_k as a structure (`WeakMorseInequalities`). It instantiates 'perfect' Morse functions on S³ (2 critical points), S¹×S² (4), and T³ (8), and derives a Reeb-theorem consequence: two critical points forces b1 = 0.",
+    "mathContext": "For a closed manifold $M$ with Morse function $f:M\\to\\mathbb{R}$, Morse theory gives $c_k\\ge b_k$ (weak inequalities) and $\\sum_k(-1)^k c_k=\\chi(M)$ (Morse equality). Reeb's theorem: if $f$ has exactly two nondegenerate critical points, $M\\cong S^n$. Note that `MorseData3` is a bare record of natural-number counts satisfying arithmetic constraints, not an actual smooth function on a manifold — the Lean 'proofs' here are `omega`/`rfl` checks on these counts, so the genuine differential-topological content (existence of such an $f$, its relation to handle attachment) is asserted only in the surrounding prose comments.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Morse theory",
+      "critical points",
+      "Betti numbers",
+      "Reeb's theorem",
+      "Heegaard splitting"
+    ],
+    "prerequisites": [
+      "smooth manifolds",
+      "homology",
+      "Euler characteristic"
+    ]
+  },
+  {
+    "id": "ann-pc-handle-decomposition",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 6216,
+      "endLine": 6472
+    },
+    "type": "concept",
+    "title": "Handle Decomposition and the Morse-Heegaard Correspondence",
+    "content": "Translates Morse critical-point data into handle counts via `MorseData3.toHandles` (0-handle = ball, ..., 3-handle = cap), shows the correspondence preserves the Euler-characteristic computation, proves handle-cancellation lemmas (e.g. `cancel_12_reduces_total` removes a 1-2 handle pair, reducing the total by 2), and derives `handle_to_heegaard`: a 'standard' decomposition (h0=h3=1) with balanced h1=h2=g yields a genus-g Heegaard splitting witness.",
+    "mathContext": "Handle decompositions realize Morse theory geometrically: attaching a $k$-handle $B^k\\times B^{n-k}$ corresponds to crossing an index-$k$ critical value. For closed 3-manifolds with $h_0=h_3=1$, $\\chi=0$ forces $h_1=h_2=g$, giving a genus-$g$ Heegaard splitting $M=H_g\\cup_\\Sigma H_g$. As with the Morse section, `HandleDecomp3` is a bare numeric record; `handle_to_heegaard` constructs a `HeegaardSplitting` of matching genus by definitional unfolding of the structure fields rather than by an actual geometric handle-attachment argument.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "handle decomposition",
+      "Heegaard splitting",
+      "handle cancellation",
+      "Morse theory"
+    ],
+    "prerequisites": [
+      "Morse theory",
+      "Heegaard splittings"
+    ]
+  },
+  {
+    "id": "ann-pc-surgery-thurston-concrete-topology",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 6475,
+      "endLine": 6771
+    },
+    "type": "concept",
+    "title": "Dehn Filling / Surgery Triangle, Thurston Norm & Fibering, and Verified Topology of S¹×S² and RP³",
+    "content": "Defines `DehnFilling` slopes and records (via a structure field, not a derivation) that a cusped hyperbolic manifold has at most 10 exceptional non-hyperbolic fillings, matching the figure-8 knot complement's extremal case. Defines an abstract `ThurstonNorm`/`FiberedStructure` record and checks S¹×S² and T³ against it. It then gives genuine Mathlib-backed proofs that the concrete product space S¹×S² (as `↥Sphere1 × ↥Sphere2`) and quotient RP³ (as `S³/{±1}`) are compact, connected, nonempty, and path-connected, plus a swap homeomorphism S¹×S² ≃ₜ S²×S¹.",
+    "mathContext": "Dehn surgery on a knot/link glues a solid torus along slope $p\\mu+q\\lambda$; the surgery exact triangle relates $M_{1/0},M_{0/1},M_{1/1}$ by a long exact sequence (or an exact triangle in Heegaard Floer homology), and Thurston's hyperbolic Dehn surgery theorem says only finitely many fillings destroy hyperbolicity. The Thurston norm $x(\\alpha)=\\min\\chi_-(S)$ over embedded surfaces detects fibered classes in $H_2(M;\\mathbb{Z})$. Only the S¹×S²/RP³ point-set facts at the end of this range are proved from real Mathlib instances (compactness of spheres, connectedness/path-connectedness of products and quotients, `isPathConnected_sphere`); the surgery-triangle, exceptional-filling-bound, and Thurston-norm/fibering material is encoded as structures whose bounds and example values are simply postulated in the `def`s, not derived from the underlying 3-manifold topology.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Dehn surgery",
+      "hyperbolic Dehn surgery theorem",
+      "Thurston norm",
+      "fibered 3-manifolds",
+      "compactness",
+      "path-connectedness"
+    ],
+    "prerequisites": [
+      "Dehn surgery",
+      "homology",
+      "point-set topology"
+    ]
+  },
+  {
+    "id": "ann-pc-seifert-spherical-space-forms",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 6773,
+      "endLine": 7241
+    },
+    "type": "concept",
+    "title": "Seifert Fibered Spaces, Orbifold Classification, and Spherical Space Forms S³/Γ",
+    "content": "Defines `SeifertData` (base orbifold genus, exceptional fibers, rational Euler number) and an `orbifoldEulerChar` formula, then `classifySeifertGeometry`, which reads off one of six Seifert-supporting Thurston geometries from the sign of χ_orb and whether the Euler number vanishes, checked on S³, S¹×S², T³. Separately defines `SphericalGroupType` (cyclic, binary dihedral, binary tetrahedral/octahedral/icosahedral — the five families of finite groups acting freely on S³) and `SphericalSpaceForm` = S³/Γ, proving the fundamental-group order equals |Γ| and that S³ is the unique space form with trivial π₁.",
+    "mathContext": "A Seifert fibration decomposes $M$ into circles, with exceptional fiber neighborhoods twisted by rotation $2\\pi q/p$; the geometry is determined by $(\\mathrm{sign}(\\chi_{orb}), e\\stackrel{?}{=}0)$. A spherical space form is $S^3/\\Gamma$ for finite $\\Gamma$ acting freely by isometries; Milnor's criterion (every abelian subgroup cyclic, every order-2 element central) pins down exactly the five families used here (Hopf 1926, Vincent 1947, Wolf 1967). Note that `classifySeifertGeometry` and `SphericalGroupType`/`SphericalSpaceForm` are combinatorial encodings — the classification theorems themselves (that these are the only Seifert geometries, or the only groups acting freely on $S^3$) are recorded in comments and baked into the `inductive`/`structure` definitions rather than proved; Lean results such as `seifert_geometry_count : 6+2=8` or `classify_S3` are simple computations that unpack the encoding, not independent verifications of the geometric classification theorems.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Seifert fibered space",
+      "orbifold Euler characteristic",
+      "Thurston's eight geometries",
+      "spherical space form",
+      "free group action on S³"
+    ],
+    "prerequisites": [
+      "Thurston's eight geometries",
+      "fundamental group",
+      "orbifolds"
+    ]
+  },
+  {
+    "id": "ann-pc-hcobordism-kirby-calculus",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 7243,
+      "endLine": 7520
+    },
+    "type": "context",
+    "title": "h-Cobordism Theorem (Statement Removed) and Kirby Calculus for Framed Links",
+    "content": "Introduces `Cobordism'`/`HCobordism'`/`WhiteheadTorsion` structures and states, in comments only, Smale's h-cobordism theorem and the Barden-Mazur-Stallings s-cobordism theorem — the code comments explicitly note the theorem statements were 'removed - unused downstream'. What remains, `h_cobordism_proves_gen_poincare` and `gen_schoenflies`, are `rfl` lookups into a hardcoded `genPoincareStatus` table rather than proofs derived from h-cobordism. The section then defines `FramedLink` (components, framings, symmetric linking matrix) and states the Lickorish-Wallace and Kirby completeness theorems in comments, but `lickorish_wallace_kirby` only exhibits a trivial witness (the empty link) and `kirby_theorem` only unpacks a structure field — neither proves the actual surgery-presentation completeness results.",
+    "mathContext": "The h-cobordism theorem (Smale 1962): a simply connected h-cobordism $W^n$ ($n\\ge5$) between $M,N$ satisfies $W\\cong M\\times[0,1]$, via the Whitney trick for cancelling algebraically-cancelling handle pairs — this is exactly what fails in dimension 3 (two 2-disks generically intersect), motivating Perelman's Ricci-flow approach instead. Kirby calculus represents every closed orientable 3-manifold as $\\partial$ of a 4-manifold built from 2-handles on a framed link in $S^3$ (Lickorish-Wallace 1962), with two diagrams representing the same manifold iff related by handle slides and $\\pm1$-blowups/blowdowns (Kirby 1978). None of these deep theorems are actually proved by the surrounding Lean code; this stretch is best read as a structured commentary/scaffold layer with a handful of small definitional lemmas about `FramedLink`, not a formalization of h-cobordism or Kirby's completeness theorem.",
+    "significance": "context",
+    "relatedConcepts": [
+      "h-cobordism theorem",
+      "Whitney trick",
+      "Whitehead torsion",
+      "Kirby calculus",
+      "Lickorish-Wallace theorem",
+      "framed links"
+    ],
+    "prerequisites": [
+      "handle decomposition",
+      "surgery theory",
+      "simply connected manifolds"
+    ]
+  },
+  {
+    "id": "ann-pc-borel-conjecture-surgery-presentations",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 7522,
+      "endLine": 7887
+    },
+    "type": "concept",
+    "title": "Borel Conjecture (Mislabeled as Simple Connectivity) and Concrete Linking-Matrix Surgery Presentations",
+    "content": "Defines `AsphericalManifold'` and a proposition `BorelConjecture'`, plus a summary table comparing it to Poincaré; separately records exotic-sphere counts (28 exotic 7-spheres, 992 in dimension 11) and notes the smooth 4D Poincaré conjecture is open. It closes with genuinely computed `FramedLink` surgery presentations: the empty link (S³), unknot with framing 0 (S¹×S²), framing ±1 (S³ again), the Hopf link with determinant pq−1, the Borromean rings (identity linking matrix), and the E8 plumbing (rank-8 linking matrix from the E8 Dynkin diagram), with concrete `rfl`/`norm_num` computations of their framings and matrix entries.",
+    "mathContext": "The actual Borel conjecture (1953) asserts closed *aspherical* manifolds are topologically rigid (homotopy equivalence implies homeomorphism) — the opposite end of the $\\pi_1$-complexity spectrum from Poincaré's trivial-$\\pi_1$ case, as the file's own commentary states. However `BorelConjecture'` as literally defined here — `∀ M, Closed3Manifold M → SimplyConnectedSpace M → AreHomeomorphic M Sphere3` — quantifies over *simply connected*, not aspherical, manifolds, so as written it restates the Poincaré conjecture rather than the Borel conjecture; `farrell_jones_conjecture`, defined to equal `BorelConjecture'`, inherits the same mismatch. The surgery-presentation computations are on firmer ground: the E8 plumbing's linking matrix is the (negative-definite, unimodular, rank-8) Cartan-type matrix of the $E_8$ root system, whose boundary is classically the Poincaré homology sphere $\\Sigma(2,3,5)$ — though that geometric fact is stated only in a comment, not proved; the Lean theorems merely compute entries of the abstract linking-matrix data type (e.g. `hopf_link_det`, `borromean_diagonal`, `e8_diagonal`).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Borel conjecture",
+      "aspherical manifold",
+      "exotic spheres",
+      "Kirby calculus",
+      "E8 lattice",
+      "Poincaré homology sphere"
+    ],
+    "prerequisites": [
+      "topological rigidity",
+      "framed links",
+      "linking numbers"
+    ]
+  },
+  {
+    "id": "ann-pc-quantum-invariants-perelman-entropy",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 7889,
+      "endLine": 8153
+    },
+    "type": "definition",
+    "title": "Quantum invariants and Perelman's F/W entropy functionals as data",
+    "content": "Defines `QuantumInvariant3` and `QuantumValues` structures holding named/level data for Turaev-Viro invariants, but the actual numeric fields (e.g. `turaev_viro_3/4/5`, `quantum_S3`, `quantum_PHS`) are hand-picked placeholder reals (all `1`, or a comment-flagged 'Approximate values' list for Σ(2,3,5)), not values computed from any 6j-symbol state sum. `theorem quantum_distinguishes_PHS_from_S3` only proves two literal hardcoded lists are unequal via `List.cons.inj`/`norm_num`, which is list-inequality bookkeeping rather than a computation showing the invariants differ. The following `PerelmanEntropy` section similarly wraps Perelman's F- and W-functionals in structures (`FunctionalF`, `WEntropy`) with free real-number fields and non-negativity hypotheses; `perelman_F_monotonicity` and `volume_lower_bound_dim3` are proved by `linarith`/`positivity` directly from those hypotheses, not from any PDE argument, and `perelman_program_chain`/`perelman_papers_summary` merely restate `genPoincareStatus 3 = .proved` by `rfl`.",
+    "mathContext": "The Turaev-Viro invariant $TV_r(M)$ is a state sum over admissible colorings of a triangulation of $M$ by quantum $6j$-symbols at a level-$r$ root of unity; it can distinguish manifolds (e.g. the Poincaré homology sphere $\\Sigma(2,3,5)$) that have identical Betti numbers and Euler characteristic to $S^3$. Perelman's entropy functionals are $F(g,f)=\\int_M (R+|\\nabla f|^2)e^{-f}\\,dV$ and $W(g,f,\\tau)=\\int_M\\big[\\tau(R+|\\nabla f|^2)+f-n\\big](4\\pi\\tau)^{-n/2}e^{-f}\\,dV$, satisfying the monotonicity formula $dF/dt = 2\\int_M |{\\rm Ric}+\\nabla^2 f|^2 e^{-f}\\,dV \\ge 0$ under the coupled flow $\\partial_t g=-2{\\rm Ric}(g)$, $\\partial_t f=-\\Delta f+|\\nabla f|^2-R$; this monotonicity underlies Perelman's no-local-collapsing theorem.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Turaev-Viro invariant",
+      "Perelman entropy functional",
+      "no-local-collapsing",
+      "quantum topology"
+    ],
+    "prerequisites": [
+      "Ricci flow basics",
+      "3-manifold homology invariants"
+    ]
+  },
+  {
+    "id": "ann-pc-hamilton-ricci-flow-program",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 8154,
+      "endLine": 8409
+    },
+    "type": "context",
+    "title": "Hamilton's pre-Perelman Ricci flow program (1982-1999)",
+    "content": "Documents Hamilton's chain of Ricci flow results (positive-Ricci convergence 1982, surface uniformization 1986, Harnack inequality 1993, compactness theorem 1995, Hamilton-Ivey pinching, singularity classification) largely as prose in doc-comments, with the accompanying Lean theorems (`einstein_pinching_dim3`, `hamilton_ode_coefficient_dim3`, `pinching_improvement_rate`, `hamilton_surface_chi`, `harnack_ancient_consequence`, `hamilton_compactness_conditions`, `hamilton_ivey_constant`, `singularity_blowup_models_dim3`, `hamilton_years_of_work`, `part_lxxi_hamilton_program_size`) proving only trivial numeric identities such as `4 * Nat.succ 1 = 8`, `(3:ℕ)-1=2`, `2002-1982=20`, and `(0:ℕ)≤0`, via `rfl`/`omega`/`le_refl`. None of these theorems formalize the differential-geometric content (pinching improvement, Harnack inequality, compactness) described in the comments — they are numeric stand-ins tagging the associated year/dimension/constant.",
+    "mathContext": "Hamilton's 1982 theorem shows a closed 3-manifold with ${\\rm Ric}>0$ converges under normalized Ricci flow $\\partial_t g=-2{\\rm Ric}(g)$ to a round metric, giving $M\\cong S^3/\\Gamma$; the curvature pinching ratio approaches the Einstein value $1/n=1/3$ in dimension 3. Hamilton-Ivey pinching bounds the most negative curvature eigenvalue $\\nu$ by $R\\ge(-\\nu)(\\log(-\\nu)+\\log(1+t)-3)$, a dimension-3-specific estimate that forces curvature operators to become asymptotically non-negative near singularities, and underlies Hamilton's partial singularity classification into Type I/II/III blow-up rates.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Hamilton-Ivey pinching",
+      "Harnack inequality",
+      "compactness theorem",
+      "Ricci flow singularities"
+    ],
+    "prerequisites": [
+      "Ricci flow equation",
+      "curvature pinching"
+    ]
+  },
+  {
+    "id": "ann-pc-exotic-spheres-smooth-poincare",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 8410,
+      "endLine": 8690
+    },
+    "type": "context",
+    "title": "Exotic spheres, Kervaire-Milnor, and the smooth Poincaré conjecture",
+    "content": "Records facts about exotic differentiable structures on spheres (`exotic_spheres_dim7`, `exotic_spheres_dim3`, `exotic_spheres_dim11`, `kervaire_milnor_dim7_check`, `j_homomorphism_dim3`), the status table of the smooth Poincaré conjecture by dimension (`smooth_poincare_dim4_status`, dimension 4 flagged OPEN), Moisé's TOP=DIFF theorem in dimension 3 (`moise_dimension`), and exotic $\\mathbb{R}^4$ (`exotic_r4_uniqueness`). As elsewhere, the Lean theorems only certify small arithmetic facts (e.g. `28=28`, `2^{2}=4`, `2^3-1=7`, `4*7=28`) rather than the underlying algebraic-topology arguments; `part_lxxii_exotic_sphere_facts` closes with `native_decide` on `28 = 4*7 ∧ 24 = Nat.factorial 4`, which — per this project's axiom-integrity policy — depends on `Lean.ofReduceBool` even though the statement itself is elementary.",
+    "mathContext": "Milnor (1956) showed $S^7$ admits $28$ pairwise non-diffeomorphic smooth structures, detected by the $\\mu$-invariant $\\mu(\\Sigma)=\\mathrm{sig}(W)-p_1^2/45 \\bmod 7$ for a bounding $8$-manifold $W$. Kervaire-Milnor (1963) fit the group of exotic $n$-spheres $\\Theta_n$ into an exact sequence $0\\to bP_{n+1}\\to\\Theta_n\\to \\mathrm{coker}(J_n)$ with $|bP_{4k}|$ expressible via Bernoulli numbers, e.g. $|bP_8| = 2^{2\\cdot2-2}(2^{2\\cdot2-1}-1)=4\\cdot 7=28$. Dimension 4 remains the only open case of the smooth Poincaré conjecture; Moisé's theorem gives TOP $=$ DIFF for $n\\le 3$, so Perelman's topological result implies the smooth statement in dimension 3.",
+    "significance": "context",
+    "relatedConcepts": [
+      "exotic spheres",
+      "Kervaire-Milnor sequence",
+      "Moisé's theorem",
+      "J-homomorphism"
+    ],
+    "prerequisites": [
+      "smooth structures on manifolds",
+      "stable homotopy groups of spheres"
+    ]
+  },
+  {
+    "id": "ann-pc-kappa-solutions-classification",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 8691,
+      "endLine": 8974
+    },
+    "type": "concept",
+    "title": "κ-solutions: a genuine 5-way inductive classification",
+    "content": "Introduces `KappaSolution` (ancient, κ-noncollapsed, bounded-nonneg-curvature flow) and the 5-constructor inductive `KappaSolutionType3D` (`roundS3`, `roundQuotient`, `cylinder`, `quotientCylinder`, `bryantSoliton`), grouped into 3 families by `kappaSolutionFamily`. Unlike the surrounding numeric-identity theorems, `compact_types_count`/`cylindrical_types_count`/`cap_types_count` genuinely compute `List.filter` lengths over the 5 constructors by `rfl`, and `round_S3_unique_compact_rotsym`/`all_kappa_solutions_are_solitons` are real case-exhaustive proofs (`cases t <;> simp_all`/`rfl`) over the finite type — though the properties fed into `kappaSolutionProps` (compact/positive-curvature/soliton/rotationally-symmetric flags) are manually asserted booleans, not derived from a geometric model. `BryantSoliton` and `CanonicalNeighborhoodThm` remain unproved structural placeholders, and Brendle's 2018 refinement to 3 types is stated only as `(3:ℕ)=3`.",
+    "mathContext": "A $\\kappa$-solution is an ancient Ricci flow, $\\kappa$-noncollapsed at all scales, with bounded non-negative curvature operator; Perelman showed every high-curvature point of a 3-dimensional Ricci flow has a canonical neighborhood modeled by such a solution. In dimension 3 every $\\kappa$-solution is a round shrinking $S^3$ or $S^3/\\Gamma$, a round shrinking cylinder $S^2\\times\\mathbb{R}$ (or its $\\mathbb{Z}_2$ quotient), or the Bryant steady soliton ${\\rm Ric}(g)=\\nabla^2 f$ with curvature decaying like $C/s$. Since the Weyl tensor vanishes identically in dimension 3, the Ricci tensor determines the full curvature tensor, which is what makes Hamilton-Ivey pinching and this classification possible; Brendle (2018) later refined the positively-curved ancient solutions to exactly 3 types (shrinking sphere, Bryant soliton, ancient oval).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Bryant soliton",
+      "canonical neighborhood theorem",
+      "Weyl tensor vanishing in dim 3",
+      "Brendle classification"
+    ],
+    "prerequisites": [
+      "ancient Ricci flow",
+      "curvature operator",
+      "κ-noncollapsing"
+    ]
+  },
+  {
+    "id": "ann-pc-standard-solution-surgery-algorithm",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 8975,
+      "endLine": 9313
+    },
+    "type": "technique",
+    "title": "Standard solution, 7-step surgery, and finite extinction as opaque pipelines",
+    "content": "Formalizes the standard solution (`StandardSolution`), surgery parameters (`SurgeryParameters`), horn regions (`Horn`), and the 7-step surgery pipeline as a `SurgeryAlgorithm` structure whose 7 fields are typed `Prop` with no supplied proofs or definitions connecting them — it names the steps (run flow, detect singularity, classify neighborhoods, find horns, cut, cap, resume) without formalizing what any step actually does. `surgery_algorithm_steps` merely proves `7=7`. `surgery_preserves_sc`'s extensive comment invokes van Kampen and Grushko's theorem, but the Lean proof obligation is just `0+0=0` by `omega` — the group-theoretic argument is not formalized. `sc_prime_decomposition_trivial` and `proof_chain_complete` close by citing the external `genPoincareStatus 3 = .proved` via `rfl`, i.e. they assert the conjecture is proved rather than deriving it from the surgery/extinction machinery described above.",
+    "mathContext": "Perelman's surgery replaces high-curvature necks (regions modeled on $S^2\\times\\mathbb{R}$) with copies of a rotationally symmetric standard solution that becomes extinct at time $T=1$, controlled by accuracy $\\delta$ and curvature threshold $\\Omega$; finiteness of the surgery times follows because each surgery removes volume $\\ge c\\delta^3$ while total volume is bounded. Finite extinction for simply connected manifolds uses the sweepout width $W(t)=\\min_{\\rm sweepout}\\max_s {\\rm Area}(\\Sigma_s)$ satisfying $dW/dt \\le -4\\pi + C\\sqrt{W(t)}$ (Perelman 2003; simplified by Colding-Minicozzi 2005 via min-max theory), which forces $W\\to 0$ in finite time and hence extinction of all simply-connected components, completing the chain from $W$-entropy monotonicity to the Poincaré conjecture.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "standard solution",
+      "neck surgery",
+      "finite extinction time",
+      "Colding-Minicozzi width"
+    ],
+    "prerequisites": [
+      "canonical neighborhood theorem",
+      "Ricci flow with surgery"
+    ]
+  },
+  {
+    "id": "ann-pc-3sphere-recognition-normal-surfaces",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 9314,
+      "endLine": 9650
+    },
+    "type": "concept",
+    "title": "Normal surface theory and decidability of 3-sphere recognition",
+    "content": "Formalizes Haken's normal surface machinery (`NormalDiskType` with 4 triangle + 3 quad types per tetrahedron, `NormalSurfaceCoords`, `VertexNormalSurface`), Rubinstein's almost-normal surfaces (`AlmostNormalPiece`: octagon/tube), the `RecognitionAlgorithm` and `CrushingAlgorithm` structures, and complexity-class claims for 3-sphere recognition, 3-manifold homeomorphism, and knot genus. As in the two preceding sections, every proved theorem here (`normal_disk_types_per_tet`, `quad_constraint_choices`, `sphere_euler_char`, `recognition_complexity_class`, `almost_normal_one_exceptional`, `three_manifold_homeomorphism_decidable`, `jaco_oertel_essential_sphere`, `complexity_landscape`, `haken_reduction_to_ILP`, `part_lxxv_normal_surface_facts`) is a small arithmetic identity (`4+3=7`, `3+1=4`, `2-2*0=2`, `2=2`, `1=1`, `4=4`, `7*1=7`, `3*2=6`) proved by `rfl`/`omega`, standing in for — but not formalizing — the cited theorems of Haken, Rubinstein-Thompson, Jaco-Oertel, Schleimer, and Kuperberg.",
+    "mathContext": "A normal surface meets each tetrahedron of a triangulation in triangles (cutting off a vertex) and quadrilaterals (separating opposite edge pairs), giving $7t$-dimensional integer coordinates subject to matching equations and an at-most-one-quad-type-per-tetrahedron constraint; this reduces 3-manifold topology to integer linear programming (Haken 1961). Rubinstein (1992/1995) and Thompson (1994) used almost-normal surfaces — normal except for one octagon or tube — to give a decision algorithm for $M\\cong S^3$, later shown to lie in ${\\rm NP}\\cap{\\rm co\\text{-}NP}$ (Schleimer 2004/2011, the co-NP certificate coming from Perelman's geometrization via hyperbolic structures); Kuperberg (2014) extended this to full decidability of the 3-manifold homeomorphism problem, in sharp contrast to the undecidability of the analogous problem in dimension $\\ge 4$ (Markov 1958, via the word problem for groups).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "normal surface theory",
+      "almost normal surfaces",
+      "3-sphere recognition",
+      "crushing algorithm"
+    ],
+    "prerequisites": [
+      "triangulated 3-manifolds",
+      "Euler characteristic of surfaces"
+    ]
+  },
+  {
+    "id": "ann-pc-taut-foliations-novikov",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 9651,
+      "endLine": 9973
+    },
+    "type": "concept",
+    "title": "Taut Foliations, Reeb Components, and Novikov's Theorem",
+    "content": "Defines `Foliation3`, `ReebComponent`, and `TautFoliation3` structures to model codimension-1 foliations of 3-manifolds and states Novikov's 1965 compact-leaf theorem, deriving that S³ admits no taut foliation. The code's own comment admits `novikov_compact_leaf` (line 9756) is 'proved' only because `ReebComponent`'s fields are all `Prop`, so `Nonempty ReebComponent` is trivially inhabited by `⟨True, True, True⟩` — it encodes none of the real geometric content of Novikov's theorem. The rest of the section (Reeb foliation of S³, Gabai genus detection, Eliashberg-Thurston, the L-space obstruction) is likewise a collection of `Prop`-valued placeholder structures and `rfl`/`native_decide` facts about hand-entered classification tables, not derivations from an actual formalized theory of foliations.",
+    "mathContext": "A codimension-1 foliation decomposes a 3-manifold into 2-dimensional leaves; a Reeb component foliates a solid torus $D^2\\times S^1$ with the boundary torus as the sole compact leaf and all interior leaves non-compact planes spiraling toward it. Novikov's theorem (1965) states every $C^2$ foliation of $S^3$ contains such a Reeb component, so $S^3$ admits no taut foliation — one of the earliest results (predating Perelman by decades) showing $S^3$ is topologically rigid. The Eliashberg–Thurston theorem (1998) later related taut foliations to tight contact structures, and Kronheimer–Mrowka–Ozsváth–Szabó (2007) showed taut foliation existence is obstructed by $S^3$ being an L-space, giving independent confirmations of the same rigidity phenomenon.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Reeb component",
+      "taut foliation",
+      "contact structure",
+      "L-space",
+      "Thurston norm"
+    ],
+    "prerequisites": [
+      "3-manifold topology",
+      "fundamental group",
+      "foliation theory basics"
+    ]
+  },
+  {
+    "id": "ann-pc-casson-invariant",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 9974,
+      "endLine": 10248
+    },
+    "type": "concept",
+    "title": "Casson Invariant of Integer Homology Spheres",
+    "content": "Introduces `CassonInvariant` (line 10006), a structure whose `lambda : ℤ` field is simply asserted, not computed from any representation-variety construction. Instances `cassonS3` (λ=0) and `cassonPHS` (λ=1) hand-enter the textbook values for S³ and the Poincaré homology sphere, and the surrounding theorems (surgery formula example, additivity, the Rokhlin-invariant congruence, Property P) are `rfl`/`decide`/`omega` checks on these asserted integers plus small arithmetic identities (e.g. `casson_trefoil_surgery` just checks `0 + 1*2/2 = 1`). This is best read as a formalized fact-table of known Casson invariant values and their known algebraic relations, not a derivation of the invariant from its SU(2) representation-counting definition.",
+    "mathContext": "The Casson invariant $\\lambda(M)\\in\\mathbb{Z}$ of an integer homology 3-sphere counts, with sign, conjugacy classes of irreducible representations $\\pi_1(M)\\to SU(2)$; it satisfies a Dehn-surgery formula $\\lambda(M_{K,1/n}) = \\lambda(M) + n\\,\\Delta_K''(1)/2$ in terms of the Alexander polynomial, is additive under connected sum, and reduces mod 2 to the Rokhlin invariant $\\mu(M)$. Since $\\pi_1(S^3)$ is trivial it has no irreducible SU(2) representations, giving $\\lambda(S^3)=0$, while the binary icosahedral group $\\pi_1(\\Sigma(2,3,5))$ has exactly one, giving $\\lambda(\\Sigma(2,3,5))=1$ — so $\\lambda$ distinguishes the Poincaré homology sphere from $S^3$ and (via $\\lambda\\ne 0\\Rightarrow$ surgery result $\\ne S^3$) gives a partial, non-gauge-theoretic proof of Property P for knots like the trefoil whose Alexander polynomial has $\\Delta''(1)\\ne 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Rokhlin invariant",
+      "Alexander polynomial",
+      "Property P",
+      "Dehn surgery",
+      "Vassiliev invariants"
+    ],
+    "prerequisites": [
+      "integer homology sphere",
+      "SU(2) representation theory",
+      "knot polynomials"
+    ]
+  },
+  {
+    "id": "ann-pc-heegaard-floer-homology",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 10249,
+      "endLine": 10736
+    },
+    "type": "concept",
+    "title": "Heegaard Floer Homology, L-Spaces, and Knot Floer Invariants",
+    "content": "Models Heegaard Floer homology data via `HFHatData` (line 10301), `LSpaceDef`, `DInvariant`, `SurgeryExactTriangle`, `KnotFloerData`, and `TauInvariant` structures whose numeric fields (rank, d-invariant, genus, τ) are hand-entered per example (`hfS3`, `hfPHS`, `hfkTrefoil`, `tauTrefoil`, etc.) rather than computed from an actual chain-complex construction of $\\widehat{HF}$. The associated theorems (`lspace_examples_verified`, `unknot_detection`, `trefoil_not_slice`, `part_lxxviii_hf_facts`) are `rfl`/`decide`/`native_decide` checks that these asserted values satisfy known numeric relations (e.g. rank of an L-space equals $|H_1|$, or $\\tau(\\text{trefoil})\\ne 0$ certifying it is not slice) — a lookup table of textbook facts about HF, not a formalization of the theory itself.",
+    "mathContext": "Heegaard Floer homology $\\widehat{HF}(Y,\\mathfrak s)$ (Ozsváth–Szabó, 2001) assigns finitely-generated abelian groups to a closed oriented 3-manifold with spin-c structure; an L-space is a rational homology sphere where $\\mathrm{rk}\\,\\widehat{HF}(Y)=|H_1(Y;\\mathbb Z)|$ is as small as possible ($S^3$, lens spaces, and $\\Sigma(2,3,5)$ all qualify). Knot Floer homology $\\widehat{HFK}(S^3,K)$ detects the Seifert genus $g(K)=\\max\\{s:\\widehat{HFK}(S^3,K,s)\\ne 0\\}$ and fiberedness, and the concordance invariant $\\tau(K)$ bounds the 4-ball genus, $|\\tau(K)|\\le g_4(K)$, giving a Floer-theoretic obstruction to sliceness. The chain $\\chi(\\widehat{HF}(Y))=\\pm\\lambda(Y)$ ties this back to the Casson invariant, and unknot detection via $\\widehat{HFK}$ combined with Property P gives an alternative, gauge-theoretic route to the Poincaré conjecture distinct from Perelman's Ricci flow.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "L-space",
+      "knot Floer homology",
+      "d-invariant",
+      "surgery exact triangle",
+      "Casson invariant"
+    ],
+    "prerequisites": [
+      "spin-c structures",
+      "Heegaard splittings",
+      "Alexander/Seifert genus"
+    ]
+  },
+  {
+    "id": "ann-pc-l-space-conjecture",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 10737,
+      "endLine": 10956
+    },
+    "type": "context",
+    "title": "The L-Space Conjecture (Boyer-Gordon-Watson)",
+    "content": "Models the (open) L-space conjecture via `LeftOrderability` and `LSpaceConjectureData` (line 10789), whose three Boolean/inductive fields (`isLSpace`, `pi1LO`, `hasTautFoliation`) are hand-entered per manifold (`bgwS3`, `bgwPHS`, `bgwT3`, `bgwBrieskorn237`, etc.) to match known facts. `bgwConsistent` is an iff-statement checked by `simp`/`decide` on data that was constructed to already satisfy it, so the 'proofs' (`bgw_S3_consistent`, etc.) verify internal consistency of hand-picked examples, not the conjecture itself, which remains open in general (only the graph-manifold case, cited as `graph_manifold_bgw_proved`, is a genuine theorem in the literature, represented here by the vacuous fact `(2:ℕ)=2`).",
+    "mathContext": "The L-space conjecture (Boyer–Gordon–Watson, 2013) proposes that for an irreducible rational homology sphere $Y$, three properties are equivalent: (A) $Y$ is not an L-space, (B) $\\pi_1(Y)$ is left-orderable, (C) $Y$ admits a co-orientable taut foliation. The implications (C)$\\Rightarrow$(A) (Ozsváth–Szabó, via the contact invariant) and (C)$\\Rightarrow$(B) (Calegari–Dunfield, for many cases) are known, while (A)$\\Rightarrow$(C) remains the hardest open direction; the conjecture is fully proved for graph manifolds (Boyer–Clay 2017). For the Poincaré conjecture itself, $S^3$ sits on the 'rigid' side of all three properties simultaneously — trivial (hence non-left-orderable) $\\pi_1$, an L-space, and no taut foliation — three mutually consistent signatures of its topological simplicity.",
+    "significance": "context",
+    "relatedConcepts": [
+      "left-orderable group",
+      "taut foliation",
+      "L-space",
+      "graph manifold"
+    ],
+    "prerequisites": [
+      "Heegaard Floer homology",
+      "foliation theory",
+      "orderable groups"
+    ]
+  },
+  {
+    "id": "ann-pc-contact-structures-tight-overtwisted",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 10957,
+      "endLine": 11322
+    },
+    "type": "concept",
+    "title": "Contact Structures and the Tight/Overtwisted Dichotomy",
+    "content": "Models contact topology via `ContactType`, `ContactData` (line 11012), `OvertwistedDisk`, `LegKnotData`, and `FillabilityLevel`/`fillabilityOrder` (line 11204). As in the preceding sections, per-manifold facts (`contactS3.tightCount := 1`, `contactL31.tightCount := 2`, `legTrefoilMax.tb := -1`, etc.) are hand-entered from the literature rather than derived, and the theorems checking them (`s3_unique_tight`, `bennequin_trefoil_bound`, `fillability_strict_order`) are `rfl`/`decide`/`simp` verifications that the asserted numbers satisfy known inequalities — e.g. `fillability_strict_order` reduces to checking the literal integers `4 > 3 > 2 > 1 > 0` assigned by `fillabilityOrder`. The section closes the loop back to Parts on foliations and Heegaard Floer homology via `foliation_to_contact_to_hf`, again a placeholder `rfl` on `(3:ℕ)=3` rather than a formalized chain of implications.",
+    "mathContext": "A contact structure $\\xi=\\ker\\alpha$ on a 3-manifold is a maximally non-integrable 2-plane field, and Eliashberg's 1989 dichotomy splits all such structures into overtwisted (containing an embedded overtwisted disk, classified purely by homotopy of 2-plane fields) versus tight (rigid, detected via the Heegaard Floer contact invariant $c(\\xi)\\in HF^+$). Eliashberg (1992) proved the standard contact structure on $S^3$ is the unique tight one, and Bennequin's theorem bounds Legendrian invariants by $tb(L)+|rot(L)|\\le 2g(K)-1$. The fillability hierarchy Stein $\\subset$ strongly $\\subset$ weakly fillable $\\subset$ tight organizes which contact structures bound symplectic 4-manifolds, and the Eliashberg–Thurston correspondence (taut foliation $\\to$ tight contact structure $\\to$ nonzero HF contact invariant) links this section back to the foliation-theoretic and Heegaard-Floer obstructions to $S^3$ admitting exotic structure.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "tight contact structure",
+      "overtwisted disk",
+      "Legendrian knot",
+      "Bennequin inequality",
+      "Stein fillability",
+      "Giroux correspondence"
+    ],
+    "prerequisites": [
+      "contact geometry basics",
+      "Heegaard Floer contact invariant",
+      "taut foliations"
+    ]
+  },
+  {
+    "id": "ann-pc-virtual-haken-wise",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 11323,
+      "endLine": 11671
+    },
+    "type": "concept",
+    "title": "Virtual Haken Conjecture and Wise's Cube-Complex Program",
+    "content": "Defines `VirtuallyHakenData`, `VirtualFiberingData`, `CubeComplexData`, and `GroupSeparabilityData` structures recording whether standard 3-manifolds (S³, T³, figure-eight complement, Weeks manifold, RP³, S¹×S², a Poincaré homology sphere) are virtually Haken, virtually fibered, LERF, and have surface subgroups. All theorems here (e.g. `agol_virtual_haken_verified`, `kahn_markovic_surface_subgroup`) are `native_decide`/`rfl`/`simp_all` case checks over this fixed 7-item list of hand-entered boolean flags, not derivations of Agol's or Kahn-Markovic's actual theorems from first principles.",
+    "mathContext": "Thurston's Virtual Haken Conjecture (1982) asked whether every closed hyperbolic 3-manifold has a finite cover containing an incompressible surface. Agol proved this in 2012 via a proof chain: Kahn–Markovic (surface subgroups exist in $\\pi_1(M)$) $\\to$ Bergeron–Wise ($\\pi_1(M)$ acts on a CAT(0) cube complex) $\\to$ Agol (the action is virtually special) $\\to$ special $\\Rightarrow$ LERF $\\Rightarrow$ virtual Haken and virtual fibering. The code encodes these implications as boolean fields on a small table of named examples and checks the table is internally consistent; it does not formalize cube complexes, special-ness, or LERF as mathematical objects.",
+    "significance": "context",
+    "relatedConcepts": [
+      "LERF",
+      "CAT(0) cube complex",
+      "surface subgroup",
+      "virtual fibering",
+      "special cube complex"
+    ],
+    "prerequisites": [
+      "hyperbolic 3-manifold",
+      "finite covering space",
+      "incompressible surface"
+    ]
+  },
+  {
+    "id": "ann-pc-gordon-luecke-knots",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 11672,
+      "endLine": 11951
+    },
+    "type": "concept",
+    "title": "Gordon-Luecke Theorem and Knot Complement Invariants",
+    "content": "Defines `KnotComplementData` and `AlexanderPolyData` structures with hand-entered invariants (crossing number, genus, fiberedness, hyperbolic volume, Alexander polynomial degree/values, bridge number) for six standard knots: the unknot, trefoil, figure-eight, cinquefoil, three-twist, and stevedore's knot. `gordon_luecke_verified` proves only that among these six fixed data records, matching genus/crossing-number/volume implies matching name — a finite case check on hand-picked labels, not a proof that a knot's complement topologically determines the knot as Gordon-Luecke's 1989 theorem actually states.",
+    "mathContext": "The Gordon–Luecke theorem asserts that knots $K_1, K_2 \\subset S^3$ with homeomorphic complements $S^3 \\setminus K_1 \\cong S^3 \\setminus K_2$ are ambient isotopic — knots are determined by their complements. The Alexander polynomial $\\Delta_K(t)$ satisfies $\\Delta_K(1) = \\pm 1$ and $\\Delta_K(-1) = \\det(K)$; for fibered knots the Seifert genus equals half the polynomial degree, $g(K) = \\deg(\\Delta_K)/2$. The file records these classical facts as literal numeric fields on six named knots and checks the numbers are mutually consistent (e.g. `fibered_genus_alexander`, `volume_ordering` using Cao–Meyerhoff volume data), rather than deriving them from a formal definition of the Alexander polynomial or Seifert surfaces.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Alexander polynomial",
+      "knot determinant",
+      "Seifert genus",
+      "hyperbolic volume",
+      "bridge number"
+    ],
+    "prerequisites": [
+      "knot complement",
+      "fibered knot",
+      "torus knot"
+    ]
+  },
+  {
+    "id": "ann-pc-character-varieties-apolynomial",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 11953,
+      "endLine": 12272
+    },
+    "type": "concept",
+    "title": "SL(2,C) Character Varieties, the A-Polynomial, and the Volume Conjecture",
+    "content": "Defines `CharacterVarietyData` (dimension, component count, A-polynomial M/L-degrees, boundary slope count, reciprocal symmetry) for the same six standard knots, plus `VolumeConjectureData` tracking hyperbolic volume and whether colored-Jones exponential growth has been analytically proved for each. Every theorem (`torus_knot_A_poly_degree`, `hyperbolic_A_poly_higher_degree`, `ccgls_verified`, `figure_eight_volume_conjecture`, etc.) is a `rfl`/`decide`/case-split check against these literal hand-entered numbers, not a construction of the character variety or A-polynomial from a presentation of $\\pi_1$.",
+    "mathContext": "The $SL(2,\\mathbb{C})$ character variety $X(M) = \\mathrm{Hom}(\\pi_1(M), SL(2,\\mathbb{C}))/\\!/SL(2,\\mathbb{C})$ encodes representations of a knot group; the discrete faithful representation gives the hyperbolic structure by Mostow rigidity. The A-polynomial $A(M,L)$ defines the image of the non-abelian part of $X(K)$ under $(\\mathrm{tr}\\,\\rho(\\mu), \\mathrm{tr}\\,\\rho(\\lambda)) \\mapsto (M,L)$, and its Newton polygon detects boundary slopes of essential surfaces (Culler–Shalen theory). The Volume Conjecture (Kashaev; Murakami–Murakami) states $\\lim_{N\\to\\infty} (2\\pi/N)\\log|J_N(K;e^{2\\pi i/N})| = \\mathrm{vol}(S^3\\setminus K)$, proved analytically only for the figure-eight knot and a few torus-knot-like cases; the code marks this via a boolean `isVerified` flag rather than proving the limit.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "A-polynomial",
+      "character variety",
+      "Culler-Shalen theory",
+      "Volume Conjecture",
+      "colored Jones polynomial",
+      "Mostow rigidity"
+    ],
+    "prerequisites": [
+      "knot group representations",
+      "boundary slopes",
+      "hyperbolic volume"
+    ]
+  },
+  {
+    "id": "ann-pc-hempel-distance-mcg",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 12274,
+      "endLine": 12662
+    },
+    "type": "concept",
+    "title": "Hempel Distance, Mapping Class Group Generators, and Curve Complex Hyperbolicity",
+    "content": "Defines `HempelDistanceData` (Heegaard splitting distance and reducibility flags for S³, L(5,2), T³, the figure-eight and Weeks manifolds, S¹×S²), `MCGComplexityData` (Lickorish's $3g-1$ and Humphries' $2g+1$ Dehn-twist generator counts for genus 0-3), `CurveComplexData` (dimension and Gromov-hyperbolicity flag), and `SubsurfaceProjectionData`/the Behrstock inequality, all as literal per-example numeric/boolean records checked by `rfl`, `decide`, or finite case splits (e.g. `hempel_distance_0_iff_reducible`, `lickorish_generator_bound`, `behrstock_inequality_data`). The final lines are a cumulative plain-text summary comment for Parts I-LXXXIV of the file (with several duplicated/inconsistent part-count banners, a known copy-paste artifact).",
+    "mathContext": "Hempel distance $d(V,W)$ is the minimal path length in the curve complex $\\mathcal{C}(\\Sigma_g)$ between the disk sets of a Heegaard splitting's two handlebodies: distance 0 means reducible, distance $\\geq 2$ means strongly irreducible (hence the manifold is irreducible), and distance $\\geq 3$ implies hyperbolicity (Scharlemann–Tomova). $\\mathcal{C}(\\Sigma_g)$ is Gromov $\\delta$-hyperbolic (Masur–Minsky 1999), with dimension $3g-4$, and the mapping class group $\\mathrm{Mod}(\\Sigma_g)$ is generated by $3g-1$ Dehn twists (Lickorish 1964) or $2g+1$ (Humphries 1979, optimal for $g\\geq 2$). The Masur–Minsky distance formula relates curve-complex distance to subsurface projections, controlled by the Behrstock inequality. The code records these classical theorem statements as data rather than proving them.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Heegaard splitting",
+      "curve complex",
+      "Dehn twist",
+      "mapping class group",
+      "Gromov hyperbolicity",
+      "subsurface projection"
+    ],
+    "prerequisites": [
+      "Heegaard genus",
+      "essential simple closed curve",
+      "handlebody"
+    ]
+  },
+  {
+    "id": "ann-pc-dehn-surgery-coefficients",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 12663,
+      "endLine": 12909
+    },
+    "type": "concept",
+    "title": "Dehn Surgery Coefficients and Exceptional Surgeries",
+    "content": "Defines a `SurgeryCoeff` structure (coprime p/q slopes) and a `surgeryDistance` function |p1 q2 - p2 q1|, then catalogs named constants (max exceptional distance 8, max 10 exceptional surgeries, Thurston hyperbolic threshold 6) and hardcoded example lists of surgeries on the trefoil, figure-eight knot, and a Heegaard-Floer surgery-exact-triangle example. Most of the named theorems (e.g. `trefoil_0_surgery_reducible`, `trefoil_plus1_poincare_hs`) only check the length of the hardcoded example list rather than deriving the stated topological fact; the real surgery-theoretic content (which slope gives which manifold) is asserted as literal list data, not proved from surgery theory.",
+    "mathContext": "Dehn surgery removes a tubular neighborhood of a knot $K \\subset S^3$ and reglues a solid torus along a slope $p/q \\in \\mathbb{Q} \\cup \\{\\infty\\}$ with $\\gcd(p,q)=1$. The surgery distance $\\Delta(r_1,r_2) = |p_1 q_2 - p_2 q_1|$ measures how far apart two slopes are. Thurston's hyperbolic Dehn surgery theorem says all but finitely many slopes on a hyperbolic knot yield hyperbolic manifolds; the Lackenby–Meyerhoff bound caps the number of exceptional (non-hyperbolic) slopes at 10. On the trefoil $+1$-surgery yields the Poincaré homology sphere $\\Sigma(2,3,5)$, a key historical example of a homology sphere that is not simply connected, relevant context for why Poincaré's conjecture needed the $\\pi_1$ hypothesis rather than a homological one.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Dehn surgery",
+      "exceptional surgery",
+      "Lickorish-Wallace theorem",
+      "Poincaré homology sphere",
+      "hyperbolic Dehn surgery"
+    ],
+    "prerequisites": [
+      "knot complements",
+      "solid torus gluing",
+      "hyperbolic 3-manifolds"
+    ]
+  },
+  {
+    "id": "ann-pc-reidemeister-torsion-lens-spaces",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 12911,
+      "endLine": 13192
+    },
+    "type": "definition",
+    "title": "Reidemeister Torsion and the Franz-Milnor Lens Space Classification",
+    "content": "Defines `RTLensParams` (lens space parameters p,q with gcd=1) together with `rtLensHomeo` and `rtLensHomotopy`, two explicit modular-arithmetic predicates encoding the classical homeomorphism and homotopy-equivalence criteria for lens spaces L(p,q). It then proves by `decide`/`simp` that L(7,1) and L(7,2) are homotopy equivalent (`rtL7_homotopy_equiv`) but not homeomorphic (`rtL7_not_homeomorphic`) — a genuine computation on the stated formulas, not just hardcoded booleans. The remainder of the section (Cheeger-Müller data, Whitehead-group table, Alexander-polynomial table, S³-detection invariants) again consists mostly of hardcoded literature facts packaged as lists, with the accompanying theorems checking list lengths/membership rather than proving the underlying torsion computations.",
+    "mathContext": "Reidemeister torsion $\\tau(L(p,q))$ was the first invariant (1935) able to distinguish homotopy-equivalent but non-homeomorphic spaces, resolving the classification of lens spaces: $L(p,q_1) \\cong L(p,q_2)$ iff $q_1 \\equiv \\pm q_2 \\pmod p$ or $q_1 q_2 \\equiv \\pm 1 \\pmod p$, while $L(p,q_1) \\simeq L(p,q_2)$ (homotopy equivalent) iff $q_1 q_2 \\equiv n^2 \\pmod p$ for some $n$. Since $1 \\cdot 2 = 2 \\equiv 3^2 \\pmod 7$ but $2 \\not\\equiv \\pm1 \\pmod 7$, $L(7,1)$ and $L(7,2)$ give the standard textbook example separating the two equivalence relations. Cheeger–Müller's theorem later identified $\\tau$ with the analytic (Ray–Singer) torsion built from the Laplacian spectrum.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Reidemeister torsion",
+      "lens space classification",
+      "Franz-Milnor theorem",
+      "Whitehead torsion",
+      "Alexander polynomial"
+    ],
+    "prerequisites": [
+      "lens spaces",
+      "modular arithmetic",
+      "Ray-Singer analytic torsion"
+    ]
+  },
+  {
+    "id": "ann-pc-seifert-hypvolume-sol-geometry",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 13194,
+      "endLine": 13837
+    },
+    "type": "concept",
+    "title": "Seifert Fibered Spaces, Hyperbolic Volume, and Sol Geometry",
+    "content": "Covers three of the eight Thurston geometries via hardcoded example data. `SeifertInvariant` bundles a base genus, a list of exceptional fibers, and a manually pre-computed sign field `chi_orb_sign`; the function `seifertGeometry` classifies the geometry type purely from that pre-set sign and the Euler number, so per-example theorems like `phs_is_spherical` just unfold the stored (not derived) sign field for `seifertPHS`, `seifertBrieskorn237`, etc. `noncomputable def v3` genuinely defines the regular-ideal-tetrahedron volume via `Real.sqrt`/`Real.log`/`Real.pi`, but the volumes in `hypVolExamples` (Weeks manifold, figure-eight complement, etc.) are separate hardcoded float literals, not derived from `v3`. `classifyMonodromy` is a real (if simple) decision procedure on `|tr(A)|` for Sol torus-bundle classification. Across all three subsections the surrounding theorems mostly check counts/filters of the literal example lists.",
+    "mathContext": "A Seifert fibered space fibers over a 2-orbifold with exceptional fibers $(p_i,q_i)$; its geometry is determined by the sign of the orbifold Euler characteristic $\\chi_{orb} = 2-2g-\\sum(1-1/p_i)$ and the Euler number $e_0 \\in \\mathbb{Q}$ of the circle bundle, together covering 6 of Thurston's 8 model geometries ($S^3, E^3, S^2\\times\\mathbb{R}, \\mathbb{H}^2\\times\\mathbb{R}, \\mathrm{Nil}, \\widetilde{SL_2}$). Hyperbolic volume is a topological invariant by Mostow rigidity, built from the ideal-tetrahedron volume $v_3 = \\tfrac{3\\sqrt3}{4}\\log(2+\\sqrt3) - \\tfrac{\\pi}{4} \\approx 1.01494$; the Weeks manifold (vol $\\approx 0.9427$) is the smallest closed hyperbolic 3-manifold and the figure-eight complement (vol $\\approx 2.0299$) the smallest 1-cusped one, with the Thurston–Jørgensen theorem giving the volume set order type $\\omega^\\omega$. Sol, the eighth geometry $\\mathbb{R}^2 \\rtimes \\mathbb{R}$, arises exactly on torus bundles over $S^1$ with Anosov monodromy $A \\in SL_2(\\mathbb{Z})$, $|\\mathrm{tr}(A)|>2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Thurston geometrization",
+      "Seifert fibered spaces",
+      "hyperbolic volume",
+      "Mostow rigidity",
+      "Sol geometry",
+      "Anosov monodromy"
+    ],
+    "prerequisites": [
+      "orbifolds",
+      "circle bundles",
+      "hyperbolic 3-manifolds",
+      "SL(2,Z) matrices"
+    ]
+  },
+  {
+    "id": "ann-pc-property-p-lspace-conjecture",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 13839,
+      "endLine": 14041
+    },
+    "type": "context",
+    "title": "Property P, Property R, and the L-Space Conjecture",
+    "content": "Catalogs Property P (Kronheimer-Mrowka 2004: no nontrivial surgery on a nontrivial knot yields S³), Property R (Gabai 1987: no surgery yields S¹×S²), and the L-space conjecture (Boyer-Gordon-Watson) as hardcoded example lists (`propertyPExamples`, `propertyRExamples`, `lspaceExamples`) with boolean fields for each of the three conjecturally-equivalent conditions (is-L-space, has-taut-foliation, has-left-orderable-π₁). The theorems (e.g. `lspace_conjecture_verified`, `non_lspace_has_properties`) check that the hand-entered boolean triples are mutually consistent on these 4-7 examples by case splitting; this confirms the data was entered consistently, not that the L-space conjecture (still open in general) holds.",
+    "mathContext": "Property P, proved via Seiberg-Witten/instanton gauge theory, was historically important because it eliminates surgery on knots as a source of counterexamples to the Poincaré conjecture. The L-space conjecture proposes that for an irreducible rational homology sphere $M$, the following are equivalent: (1) $M$ is not a Heegaard Floer L-space (i.e. $\\mathrm{rk}\\,\\widehat{HF}(M) > |H_1(M;\\mathbb{Z})|$), (2) $M$ admits a taut foliation, (3) $\\pi_1(M)$ is left-orderable. $S^3$ itself is an L-space with no taut foliation (Novikov) and trivial (hence non-left-orderable) $\\pi_1$, consistent with — but not a proof of — the conjecture.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Property P",
+      "Property R",
+      "L-space conjecture",
+      "taut foliations",
+      "left-orderable groups",
+      "Heegaard Floer homology"
+    ],
+    "prerequisites": [
+      "Dehn surgery",
+      "Heegaard Floer homology",
+      "foliations"
+    ]
+  },
+  {
+    "id": "ann-pc-duplicate-numbered-trivial-arithmetic",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 14042,
+      "endLine": 14293
+    },
+    "type": "context",
+    "title": "Duplicate-Numbered \"Chern-Simons / Smooth 4-Manifolds / Geometrization\" Block — Trivial Arithmetic Restatements",
+    "content": "This block re-uses part numbers already used earlier in the file (banner comments duplicate roman-numeral labels already assigned to the Reidemeister Torsion and Seifert Fibered Spaces sections seen earlier — a pure historical copy-paste artifact, not a semantic re-derivation) and covers Chern-Simons theory/quantum invariants, Freedman's 4-manifold classification and exotic spheres, and a second pass on Thurston's eight geometries. In every one of its eleven named theorems (`cs_level_parameter`, `jones_polynomial_properties`, `rt_invariant_kirby`, `part_lxxxiii_summary`, `generalized_poincare_status`, `freedman_classification`, `exotic_spheres_theta_7`, `part_lxxxiv_summary`, `thurston_geometry_dimensions`, `hyperbolic_volume_ordering`, `part_lxxxv_summary`) the actual Lean-checked proposition is a trivial closed-form arithmetic identity on small naturals — e.g. `(3:ℕ)+1=4 := by omega`, `(8:ℕ)=8 := rfl` (\"rank of E₈ lattice\"), `(28:ℕ)=4*7 := by omega` (|Θ₇|), `(3:ℕ)+4+1=8 := by omega` (isometry-dimension tally), `(1:ℕ)+2=3 := by omega`, and bare restatements like `(3:ℕ)=3 := rfl` / `(2:ℕ)=2 := rfl`. All of the substantive mathematics — the Chern-Simons level/representation count, the Jones polynomial and volume conjecture, Freedman's intersection-form classification, the open status of the smooth 4D Poincaré conjecture, and the Thurston geometry isometry-dimension table — is written only as prose in `--` comments inside each theorem body; none of it is encoded in, or established by, the actual formal statement. These theorems should be read as documentation blocks with a placeholder arithmetic check attached, not as formalizations of the named results.",
+    "mathContext": "The commented-out mathematics is real and correctly stated: Chern-Simons theory at level $k$ for $SU(2)$ has $k+1$ admissible representations and partition function $Z(S^3) = \\sqrt{2/(k+2)}\\sin(\\pi/(k+2))$; the Jones polynomial $V(K,t)$ is recovered from Wilson-loop expectation values and its detection of the unknot is open; Freedman's theorem classifies simply-connected closed topological 4-manifolds by intersection form and Kirby-Siebenmann invariant, while the *smooth* 4-dimensional Poincaré conjecture remains the one open case among all dimensions; $\\Theta_7 \\cong \\mathbb{Z}_{28}$ (Milnor's exotic 7-spheres) via Milnor-Kervaire; and the isometry groups of Thurston's 8 model geometries have dimension 6 (three isotropic geometries $S^3,E^3,\\mathbb{H}^3$), 4 (four geometries), or 3 (Sol alone). None of this, however, is what the Lean kernel actually verifies here — the kernel only checks the trivial numerical identity written after the comment block. This range overlaps content covered by prior sections in the file (Reidemeister torsion, Seifert fibered spaces), so its `sections[]` label 'Duplicate-Numbered Content' reflects real duplication in the source, not an artifact of this annotation.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Chern-Simons theory",
+      "Jones polynomial",
+      "Freedman's classification",
+      "exotic spheres",
+      "smooth 4D Poincaré conjecture",
+      "Thurston's eight geometries"
+    ],
+    "prerequisites": [
+      "quantum invariants",
+      "intersection forms",
+      "exotic smooth structures"
+    ]
+  },
+  {
+    "id": "ann-pc-heegaard-floer-lspace-perelman-entropy",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 14295,
+      "endLine": 14416
+    },
+    "type": "context",
+    "title": "Heegaard Floer Homology, the L-Space Conjecture, and Perelman's Entropy Functionals (Recap)",
+    "content": "The three theorems here (hf_euler_characteristic, l_space_conjecture_status, perelman_entropy_chain) are trivial numeric equalities like `(4:ℕ)=4 := rfl`; the real content is entirely in the attached doc-comments, which describe Heegaard Floer flavors and the d-invariant, the L-space conjecture's three conjecturally-equivalent conditions, and Perelman's F/W/reduced-volume functionals. No Heegaard Floer group, taut foliation, or entropy functional is actually formalized.",
+    "mathContext": "Heegaard Floer homology assigns groups $HF^-(Y), HF^+(Y), HF^\\infty(Y), \\widehat{HF}(Y)$ to a 3-manifold $Y$, with $\\chi(\\widehat{HF})=\\pm\\lambda(Y)$ recovering the Casson invariant. The L-space conjecture asserts that for irreducible rational homology spheres, $Y$ failing to be an L-space, $\\pi_1(Y)$ being left-orderable, and $Y$ admitting a co-oriented taut foliation are all equivalent. Perelman's proof rests on the $\\mathcal{F}$-functional $\\int_M(R+|\\nabla f|^2)e^{-f}d\\mu$, the scale-invariant $\\mathcal{W}$-functional, and the reduced volume $\\tilde V(\\tau)=\\int_M(4\\pi\\tau)^{-n/2}e^{-\\ell}dq$, whose monotonicity under Ricci flow drives $\\kappa$-non-collapsing and the canonical neighborhood theorem.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Heegaard Floer homology",
+      "L-space conjecture",
+      "Perelman entropy functional",
+      "Ricci flow monotonicity"
+    ],
+    "prerequisites": [
+      "3-manifold invariants",
+      "taut foliations",
+      "left-orderable groups"
+    ]
+  },
+  {
+    "id": "ann-pc-thurston-hyperbolic-dehn-surgery",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 14417,
+      "endLine": 14619
+    },
+    "type": "definition",
+    "title": "Thurston's Hyperbolic Dehn Surgery Theorem: Cusped Manifolds and Volume Bounds",
+    "content": "Defines a `CuspedHyperbolicManifold` structure and three concrete instances (figure-eight complement, Whitehead link, Borromean rings) carrying hardcoded volume constants (2.0299, 3.6638, 7.3277). The proved facts — volume ordering via `norm_num`, positivity of the `2π` threshold, `figEight_is_minimum` — record known numerical values from the literature (Cao–Meyerhoff minimum volume, the 2π-theorem, Gordon's bound of at most 10 exceptional surgeries) rather than deriving them from hyperbolic geometry.",
+    "mathContext": "For a cusped hyperbolic 3-manifold $M$, all but finitely many Dehn fillings $M(p/q)$ are hyperbolic, with $\\mathrm{vol}(M(p/q)) < \\mathrm{vol}(M)$ (Neumann–Zagier) and $\\mathrm{vol}(M(p/q)) \\to \\mathrm{vol}(M)$ as $|p|+|q|\\to\\infty$. The figure-eight knot complement realizes the minimum volume $v_{\\min}\\approx 2.0299$ (Cao–Meyerhoff). The $2\\pi$-theorem (Gromov–Thurston) guarantees hyperbolicity when the filling slope has length $>2\\pi$ in the cusp metric, and Mostow rigidity makes volume a topological invariant of hyperbolic 3-manifolds.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Dehn filling",
+      "hyperbolic volume",
+      "Mostow rigidity",
+      "2π-theorem"
+    ],
+    "prerequisites": [
+      "hyperbolic 3-manifolds",
+      "cusps",
+      "Dehn surgery"
+    ]
+  },
+  {
+    "id": "ann-pc-rokhlin-theorem-mu-invariant",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 14620,
+      "endLine": 14743
+    },
+    "type": "definition",
+    "title": "Rokhlin's Theorem and the μ-Invariant of Homology 3-Spheres",
+    "content": "Introduces `RokhlinInvariantData` and `BrieskornSphereData` structures holding hand-entered μ and Casson-invariant values for six example manifolds (S³, Σ(2,3,5), Σ(2,3,7), etc.) and six Brieskorn spheres. `casson_rokhlin_consistency` and `brieskorn_casson_rokhlin` prove the congruence λ≡μ (mod 2) by exhaustive case-check (`rcases ... <;> rfl/decide`) over these fixed lists, so they verify internal consistency of the inserted numbers rather than deriving μ or λ from the topological definitions.",
+    "mathContext": "Rokhlin's theorem states $\\sigma(W)\\equiv 0 \\pmod{16}$ for any closed spin 4-manifold $W$. This yields the Rokhlin invariant $\\mu(M)=\\sigma(W)/8 \\bmod 2 \\in \\mathbb{Z}/2$ for an integral homology 3-sphere $M$ bounding a spin 4-manifold $W$, satisfying $\\mu(S^3)=0$ but $\\mu(\\Sigma(2,3,5))=1$, and the Casson–Rokhlin relation $\\lambda(M)\\equiv\\mu(M)\\pmod 2$. Brieskorn spheres $\\Sigma(a,b,c)$, the links of $x^a+y^b+z^c=0$, supply a systematic testing family. Since $8\\nmid 16$, Rokhlin's theorem also shows the $E_8$-manifold ($\\sigma=8$) admits no smooth structure.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Rokhlin invariant",
+      "Casson invariant",
+      "Brieskorn sphere",
+      "spin 4-manifold"
+    ],
+    "prerequisites": [
+      "intersection form",
+      "signature of a 4-manifold"
+    ]
+  },
+  {
+    "id": "ann-pc-intersection-forms-4manifolds",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 14744,
+      "endLine": 15045
+    },
+    "type": "concept",
+    "title": "Intersection Forms of Simply Connected 4-Manifolds: Freedman vs Donaldson",
+    "content": "Builds an `IntersectionFormData` catalogue of eight examples (S⁴, CP², S²×S², K3, the E₈ manifold, connected sums) with rank/signature/parity/smoothability fields. The following theorems — `even_form_signature_mod8`, `donaldson_diagonalization`, `freedman_all_realized`, `eleven_eighths_violation_E8E8` — are all proved by `rcases ... <;> simp/decide` over these eight hardcoded entries, so they establish consistency of the example table (e.g. that `formE8.isSmoothable = false` was set correctly) rather than proving the general Donaldson or Freedman theorems for arbitrary 4-manifolds.",
+    "mathContext": "A simply connected closed 4-manifold's intersection form is a unimodular symmetric bilinear form on $H_2(M;\\mathbb{Z})$. Freedman's theorem (1982) shows every such form is realized by a closed topological 4-manifold, unique for odd forms and exactly two (distinguished by the Kirby–Siebenmann invariant $\\mathrm{ks}\\in H^4(M;\\mathbb{Z}/2)$) for even forms. Donaldson's theorem (1983), via Yang–Mills instantons, shows smooth definite forms must be diagonalizable, ruling out a smooth $E_8$-manifold even though it exists topologically. The $11/8$ conjecture (Matsumoto/Furuta) bounds rank $\\geq \\tfrac{11}{8}|\\sigma|$ for spin 4-manifolds, with K3 extremal and $E_8\\#E_8$ violating it.",
+    "significance": "key",
+    "relatedConcepts": [
+      "intersection form",
+      "Donaldson's theorem",
+      "Freedman's classification",
+      "Kirby-Siebenmann invariant",
+      "exotic ℝ⁴"
+    ],
+    "prerequisites": [
+      "signature of a 4-manifold",
+      "spin structures",
+      "Rokhlin's theorem"
+    ]
+  },
+  {
+    "id": "ann-pc-moise-theorem-top-pl-diff",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 15046,
+      "endLine": 15315
+    },
+    "type": "concept",
+    "title": "Moise's Theorem: TOP = PL = DIFF in Dimension 3",
+    "content": "Encodes Moise's theorem as a hand-written lookup function `categoryRelationByDim` (`.equal` for n≤3, `.allDiffer` for n=4, `.plEqDiff` otherwise). Theorems like `moise_dim3`, `dim4_anomalous`, and `dim3_all_poincare_equivalent` simply unfold and evaluate this hardcoded function by `decide`, rather than proving the underlying triangulability/uniqueness/smoothing results. A parallel `poincareCategoryStatus` and `hauptvermutungByDim` list records known status-by-dimension facts and is checked the same way, by case-splitting over the fixed list.",
+    "mathContext": "Moise (1952) proved $\\mathrm{TOP}_3 = \\mathrm{PL}_3 = \\mathrm{DIFF}_3$: every topological 3-manifold triangulates uniquely up to PL homeomorphism and every PL 3-manifold has a unique smooth structure, via Bing's shrinking technique. Consequently a proof of the Poincaré conjecture in any one category (Perelman worked smoothly, via Ricci flow) automatically yields all three. This contrasts with dimension 4, where $\\mathrm{TOP}\\neq\\mathrm{DIFF}$ (Freedman vs. Donaldson), and with $n\\geq 5$, where $\\mathrm{PL}=\\mathrm{DIFF}$ (Munkres–Hirsch) but $\\mathrm{TOP}$ can differ via the Kirby–Siebenmann obstruction in $H^4(M;\\mathbb{Z}/2)$, which vanishes automatically for 3-manifolds.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Moise's theorem",
+      "Hauptvermutung",
+      "Kirby-Siebenmann invariant",
+      "Bing shrinking"
+    ],
+    "prerequisites": [
+      "PL manifold",
+      "triangulation",
+      "smoothing theory"
+    ]
+  },
+  {
+    "id": "ann-pc-contact-foliation-examples",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 15316,
+      "endLine": 15472
+    },
+    "type": "context",
+    "title": "Weinstein Conjecture, BGW L-Space Data, Giroux Open Books, and the Thurston Norm",
+    "content": "A sequence of small example tables (`ReebDynamicsData`, `BGWConjectureData2`, `OpenBookData`, `ThurstonNormBallData`, `McMullenNormData`) record hardcoded orbit counts, L-space/taut-foliation/left-orderable flags, open-book invariants, and Thurston-norm values for named 3-manifolds and knots. The accompanying theorems (`weinstein_verified`, `bgw2_lspace_no_taut`, `planar_open_books`, `norm_two_genus_minus_one`) only check consistency properties across these fixed lists by `decide`/`native_decide`/case-split, not general results about Reeb dynamics, the L-space conjecture, or the Thurston norm.",
+    "mathContext": "The Weinstein conjecture asserts every Reeb vector field on a closed contact manifold has a closed orbit (proved for 3-manifolds by Taubes via Seiberg–Witten theory). The L-space conjecture links L-spaces, taut foliations, and left-orderability. Giroux's correspondence identifies contact structures up to isotopy with open book decompositions up to stabilization; the support genus measures the minimal page genus. McMullen's Alexander-norm bound relates the Thurston norm of a fibered knot complement to $2\\,\\mathrm{genus}(K)-1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Weinstein conjecture",
+      "L-space conjecture",
+      "open book decomposition",
+      "Thurston norm"
+    ],
+    "prerequisites": [
+      "contact structures",
+      "taut foliations",
+      "fibered knots"
+    ]
+  },
+  {
+    "id": "ann-pc-hcobordism-whitney-trick-block",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 15474,
+      "endLine": 15616
+    },
+    "type": "technique",
+    "title": "h-Cobordism Theorem and the Dimension-5 Threshold for the Whitney Trick",
+    "content": "A documentation-heavy block explaining why Smale's h-cobordism theorem needs ambient dimension ≥ 5: the Whitney trick requires an embedded 2-disk of codimension ≥ 3. The only Lean content is trivial arithmetic (`omega` proofs like `5-2=3 ∧ 4-2=2 ∧ 3-2=1`, and `2003-1961=42`) attached to prose narrating the handle-cancellation argument and the historical chronology of the generalized Poincaré conjecture (dim ≥5 in 1961, dim 4 in 1982, dim 3 in 2003); no handle decomposition, transversality argument, or embedding is actually formalized.",
+    "mathContext": "If $W$ is an h-cobordism between simply connected closed $n$-manifolds $M,N$ with $n\\geq 5$, then $W\\cong M\\times[0,1]$ (Smale, 1961), proved by cancelling handles in pairs using the Whitney trick: two transverse intersection points of opposite sign on complementary submanifolds are removed via an ambient isotopy guided by an embedded Whitney disk. Embedding this 2-disk needs codimension $n-2\\geq 3$, i.e. $n\\geq 5$; it fails in dimension 4, where Freedman's Casson-handle construction (1982) gives only the topological h-cobordism theorem, and fails completely in dimension 3, which is why Perelman needed Ricci flow with surgery instead.",
+    "significance": "key",
+    "relatedConcepts": [
+      "h-cobordism theorem",
+      "Whitney trick",
+      "handle decomposition",
+      "Casson handles"
+    ],
+    "prerequisites": [
+      "Morse theory",
+      "handle attachment",
+      "transversality"
+    ]
+  },
+  {
+    "id": "ann-pc-tqft-tower-smith-conjecture",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 15617,
+      "endLine": 16113
+    },
+    "type": "concept",
+    "title": "TQFT Axioms, the Papakyriakopoulos Tower, and the Smith Conjecture",
+    "content": "Defines a `TQFT3d` structure (genus-indexed state spaces, an empty-surface axiom, a partition function) and a `chernSimonsTQFT` instance whose state dimension is a hand-coded Verlinde-formula stub; `tqft_multiplicativity` and `verlinde_genus1` are genuine, if elementary, computations unfolding this definition, but most surrounding theorems (`cobordism_hypothesis`, `tqft_characterization_of_s3`) reduce to trivial numeric facts like `(4:ℕ)=4` attached to prose. The Papakyriakopoulos Tower and Smith Conjecture sections that follow are almost entirely documentation: theorems such as `smith_conjecture` and `orbifold_group_unknot` literally restate a hypothesis as their own conclusion (`a.p ≥ 2 := a.hp`), and `dehn_lemma_consequence`/`branched_cover_constraint` reduce to date-arithmetic (`1957-1910=47`, `1979-1939=40`) rather than formalizing Dehn's Lemma, the Loop/Sphere Theorems, or the actual proof of the Smith conjecture.",
+    "mathContext": "Atiyah's TQFT axioms make a $(2{+}1)$-TQFT a symmetric monoidal functor $n\\mathrm{Cob}\\to\\mathrm{Vect}$; for Chern–Simons theory at level $k$, the Verlinde formula gives $\\dim Z(T^2)=\\lfloor k/2\\rfloor+1$, and $Z(S^3)$ normalizes the WRT and Turaev–Viro invariants. Papakyriakopoulos's tower construction (1957) proves Dehn's Lemma, the Loop Theorem, and the Sphere Theorem — foundational embedding results underlying prime and JSJ decomposition. The Smith conjecture (1979) states that a smooth $\\mathbb{Z}/p$-action on $S^3$ with 1-dimensional fixed set must fix an unknotted circle, proved by combining Thurston's orbifold geometrization, equivariant minimal surface theory (Meeks–Yau), Culler–Shalen character varieties, and Bass–Serre theory.",
+    "significance": "key",
+    "relatedConcepts": [
+      "topological quantum field theory",
+      "Verlinde formula",
+      "Dehn's lemma",
+      "Loop theorem",
+      "Sphere theorem",
+      "Smith conjecture",
+      "orbifold geometrization"
+    ],
+    "prerequisites": [
+      "cobordism category",
+      "branched covering",
+      "incompressible surface"
+    ]
+  },
+  {
+    "id": "ann-pc-hcobordism-dimension-3-vs-5",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 16114,
+      "endLine": 16313
+    },
+    "type": "context",
+    "title": "h-Cobordism Theorem and Why Dimension 3 Fails",
+    "content": "This section is expository commentary (in doc comments) on Smale's h-cobordism theorem and why it fails in dimension 3, paired with 'theorems' that are mostly trivial numeric restatements (e.g. `whitney_trick_dimension'` just checks `n+2+2 ≥ n+1` via `omega`, and `poincare_by_dimension` checks `7-1=6`) rather than formalizations of the actual geometric arguments (Whitney trick, Casson handles, Whitehead torsion). It records, as prose plus arithmetic placeholders, why Smale's approach needs dimension ≥ 5 and why Perelman had to use Ricci flow instead.",
+    "mathContext": "Smale's h-cobordism theorem says a simply-connected compact h-cobordism $W$ between closed simply-connected manifolds $M,N$ of dimension $\\ge 5$ is a product $M\\times[0,1]$, via handle cancellation using the Whitney trick to remove excess intersections of embedded 2-disks — a move that needs codimension $\\ge 3$ to work. In dimension 4 Freedman gave a topological (not smooth) analogue using infinite Casson handles; in dimension 3 the Whitney trick has no room at all, forcing Perelman's Ricci-flow approach. Kervaire–Milnor's finite group $\\Theta_n$ of exotic smooth structures on $S^n$ (e.g. $|\\Theta_7|=28$) is also tabulated, with $|\\Theta_3|=1$ standing in for the fact (established via Perelman + Moise) that $S^3$ has no exotic smooth structure.",
+    "significance": "context",
+    "relatedConcepts": [
+      "h-cobordism theorem",
+      "Whitney trick",
+      "Casson handles",
+      "exotic spheres",
+      "Whitehead torsion"
+    ],
+    "prerequisites": [
+      "handle decomposition",
+      "simply connected manifold",
+      "smooth vs topological category"
+    ]
+  },
+  {
+    "id": "ann-pc-sphere-theorems-classical-differentiable",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 16314,
+      "endLine": 16547
+    },
+    "type": "context",
+    "title": "Sphere Theorems: 1/4-Pinching, Hamilton 1982, and Perelman as the Strongest Case",
+    "content": "Documents the classical Berger–Klingenberg sphere theorem (1/4 < K ≤ 1 implies homeomorphic to S^n), its sharpness via CP² (which is exactly 1/4-pinched but not a sphere), the Brendle–Schoen differentiable sphere theorem, and Hamilton's 1982 result that positive Ricci curvature on a closed 3-manifold forces convergence under Ricci flow to a spherical space form S³/Γ. As before, the 'theorems' (`sphere_theorem_dimension_constraints`, `hamilton_1982_positive_ricci`, `brendle_schoen_dimensions`) are trivial numeric facts (`omega`/`norm_num` on integers) standing in for the cited results; only `classicalPinching_pos`, `cp2_curvature_range`, `groveShiohama_bound_pos`, and `cheng_diameter_is_pi` are genuine (if easy) real-number lemmas about the defined constants.",
+    "mathContext": "For a complete simply-connected Riemannian $M^n$ with sectional curvature $\\delta \\le K \\le 1$, the classical sphere theorem needs $\\delta > 1/4$ to conclude $M \\cong_{\\text{top}} S^n$; $\\mathbb{CP}^2$ shows $\\delta=1/4$ is sharp since its holomorphic/anti-holomorphic curvatures are exactly $1$ and $1/4$. Brendle–Schoen (2009) upgraded the conclusion to diffeomorphism using Ricci flow with a pointwise-pinching condition. Hamilton's theorem $\\mathrm{Ric}>0 \\Rightarrow M^3 \\cong_{\\text{diff}} S^3/\\Gamma$ was the first Ricci-flow convergence result and the direct ancestor of Perelman's program; the section frames Perelman's $\\pi_1=1 \\Rightarrow S^3$ as the weakest-hypothesis (purely topological, no curvature assumption) member of this hierarchy of sphere theorems.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "1/4-pinching",
+      "Brendle-Schoen theorem",
+      "Hamilton's 1982 theorem",
+      "Ricci flow convergence",
+      "Grove-Shiohama diameter theorem"
+    ],
+    "prerequisites": [
+      "sectional curvature",
+      "Ricci curvature",
+      "space form"
+    ]
+  },
+  {
+    "id": "ann-pc-kneser-milnor-prime-decomposition",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 16548,
+      "endLine": 16762
+    },
+    "type": "definition",
+    "title": "Kneser-Milnor Prime Decomposition Reduces Poincaré to the Irreducible Case",
+    "content": "Defines a `PrimeType` inductive (S³, irreducible, S²×S¹) and a `connectedSumPieces` length function, then walks through — mostly via commentary and trivial `rfl`/`omega` placeholder proofs — the logical chain by which Kneser's existence and Milnor's uniqueness theorems for prime decomposition, combined with van Kampen's free-product formula for π₁ of a connected sum, reduce the Poincaré conjecture for a general simply-connected M³ down to the case where M³ is itself prime and irreducible. `free_product_trivial` and `s2xs1_fundamental_group` encode why S²×S¹ (π₁ = ℤ) can never appear as a summand of a simply-connected manifold.",
+    "mathContext": "Kneser (1929) proved every closed orientable 3-manifold decomposes as a finite connected sum $M \\cong P_1 \\# \\cdots \\# P_k \\#(S^2\\times S^1)^{\\#m}$ of prime pieces, and Milnor (1962) proved this decomposition is unique up to reordering — an analogue of unique prime factorization of integers. Van Kampen gives $\\pi_1(M\\#N)\\cong \\pi_1(M)*\\pi_1(N)$ (free product), and a free product is trivial iff both factors are, so if $M$ is simply connected every summand $P_i$ is simply connected; since $\\pi_1(S^2\\times S^1)=\\mathbb{Z}\\ne 1$, every summand must be irreducible with trivial $\\pi_1$, which by Perelman's theorem forces $P_i \\cong S^3$, hence $M \\cong S^3$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "prime decomposition",
+      "connected sum",
+      "van Kampen theorem",
+      "free product",
+      "irreducible 3-manifold"
+    ],
+    "prerequisites": [
+      "fundamental group",
+      "connected sum of manifolds"
+    ]
+  },
+  {
+    "id": "ann-pc-finite-extinction-time",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 16763,
+      "endLine": 17013
+    },
+    "type": "technique",
+    "title": "Finite Extinction Time via the Width Functional",
+    "content": "Formalizes small real-valued models of quantities from Perelman's third paper: `widthFunctional`, `widthDerivativeBound` (the bound dW/dt ≤ -4π + (3/4)R_min·W), `scalarCurvatureBlowup`, `maxSurgeries`, and the exact extinction time `s3ExtinctionTime r = r²/4` for a round S³ of radius r under Ricci flow. Unlike the surrounding sections, several lemmas here are genuine (if elementary) inequalities about these real functions — e.g. `blowup_faster_with_more_curvature` and `s3_larger_takes_longer` are proved with real `div_lt_div_of_pos_*` lemmas, not just `rfl`/`omega` placeholders — though they model the PDE behavior rather than proving it from the Ricci flow equation itself. Page-count 'theorems' (`perelman_page_count`, `verification_ratio`) are just trivia arithmetic.",
+    "mathContext": "Perelman's finite-extinction argument tracks a min-max width $W(t)=\\inf_{\\text{sweepouts}}\\max_s \\mathrm{Area}(\\Sigma_s)$ satisfying $dW/dt \\le -4\\pi + \\tfrac34 R_{\\min}(t)W$, while the maximum principle gives $R_{\\min}(t)\\ge R_{\\min}(0)/(1-\\tfrac23 R_{\\min}(0)t)$, which blows up in finite time when $R_{\\min}(0)>0$; combined, $W\\to 0$ in finite time, so a simply-connected $M^3$ under Ricci flow with surgery becomes extinct, and since it never fissions (simple connectivity), the terminal geometry must be the round $S^3$. The exact model computation $g(t) = (r^2-4t)g_0$ on the round $S^3(r)$, extinct at $t=r^2/4$, illustrates the rate at which volume $V(t)=2\\pi^2(r^2-4t)^{3/2}\\to 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "finite extinction time",
+      "width functional",
+      "min-max theory",
+      "scalar curvature blowup",
+      "Ricci flow with surgery"
+    ],
+    "prerequisites": [
+      "Ricci flow",
+      "maximum principle for PDEs",
+      "sweepout of a manifold"
+    ]
+  },
+  {
+    "id": "ann-pc-contractibility-hopf-galois-covering",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 17014,
+      "endLine": 17512
+    },
+    "type": "technique",
+    "title": "Contractibility Obstructions, the Hopf Map's Antipodal Descent, and the Covering-Space Galois Correspondence",
+    "content": "Three related pieces on the covering-space structure of S³/RP³. First, genuine (non-trivial) proofs that RP³ is not contractible (`rp3_not_contractible`, by contradiction from `rp3_pi1_nontrivial`) and that the antipodal map on S³ is fixed-point-free, framed as partial obstructions to a not-yet-proved `¬ContractibleSpace S³`. Second, a real computation that the Hopf map π: S³→S² is antipodal-invariant (`hopf_antipodal_invariant`, proved by unfolding the quadratic formula and case-splitting on coordinates) and hence descends via `Quotient.lift` to a genuine map `hopfMapRP3 : RP3 → S²`. Third, a large 'Galois correspondence' catalog (`CoveringSpaceData3`, `GaloisCorrespondence`, `UniversalCoverType`) encoding covering-space/subgroup facts for the 8 Thurston geometries and 3-manifold groups (residual finiteness, virtual Haken/fibered/special, profinite completions) as literal `List` data with only shallow `simp`/`native_decide` checks over those lists — descriptive tables, not formalizations of the cited theorems (Agol, Wise, Wilton–Zalesskii, Hempel).",
+    "mathContext": "The Galois correspondence for covering spaces says connected coverings of $X$ correspond bijectively to conjugacy classes of subgroups of $\\pi_1(X)$, with degree equal to subgroup index and normal coverings corresponding to normal subgroups; for spherical space forms $S^3/\\Gamma$ the universal cover is always $S^3$ with $\\Gamma=\\pi_1$. The Hopf map $\\pi(a,b,c,d)=(a^2+b^2-c^2-d^2,\\,2(ac+bd),\\,2(bc-ad))$ is quadratic in each coordinate, hence invariant under $x\\mapsto -x$, so it factors through $\\mathbb{RP}^3 = S^3/\\{\\pm1\\}$, linking the Hopf fibration $S^3\\to S^2$ to the double cover $S^3\\to \\mathbb{RP}^3$. Hempel's residual finiteness and Agol–Wise's virtual Haken/fibered/special theorems (used here only as data, not proved) describe how finite covers detect structure in all compact 3-manifold groups.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "covering space",
+      "Hopf fibration",
+      "Galois correspondence",
+      "residual finiteness",
+      "virtually Haken conjecture"
+    ],
+    "prerequisites": [
+      "fundamental group",
+      "quotient topology",
+      "Thurston geometries"
+    ]
+  },
+  {
+    "id": "ann-pc-sphere-theorem-panorama",
+    "proofId": "poincare-conjecture",
+    "range": {
+      "startLine": 17513,
+      "endLine": 17683
+    },
+    "type": "context",
+    "title": "Closing Panorama: Sphere Theorems and the Generalized Poincaré Conjecture by Dimension",
+    "content": "The file's final section, closing the PoincareConjecture namespace. It tabulates seven sphere theorems (Rauch through Perelman) as a `sphereTheoremHierarchy : List SphereTheoremData`, tabulates the generalized Poincaré conjecture's solved status per dimension 1 through 7 (`genPoincareDimStatus`), and records that ℂP², ℍP², CaP² are the three simply-connected 1/4-pinched spaces at the sharp boundary that are not spheres. As elsewhere, the 'theorems' mostly just check lengths/filters of these hard-coded lists (several via `native_decide`) rather than proving the underlying geometric facts; `smooth_poincare_open_only_dim4` correctly reflects that smooth Poincaré in dimension 4 remains open as of this writing.",
+    "mathContext": "The sphere-theorem hierarchy runs from Rauch's $\\delta\\approx 0.74$ pinching (1951) through Berger–Klingenberg's $\\delta>1/4$ (1961), Grove–Shiohama's diameter condition (1977), Hamilton's Ricci-curvature result (1982), Micallef–Moore and Brendle–Schoen's pointwise pinching (1988, 2009), down to Perelman's purely topological $\\pi_1=1$ hypothesis (2003) — each successive theorem strictly weakening its hypothesis while still concluding a diffeomorphism to (a quotient of) $S^n$. The generalized Poincaré conjecture (a homotopy $n$-sphere is homeomorphic to $S^n$) is solved topologically in every dimension $n\\ge 1$ (Zeeman/Stallings/Smale for $n\\ge5$ via h-cobordism, Freedman for $n=4$, Perelman for $n=3$, classically for $n\\le2$), but the *smooth* generalized Poincaré conjecture remains open specifically in dimension 4 (whether exotic smooth 4-spheres exist).",
+    "significance": "context",
+    "relatedConcepts": [
+      "generalized Poincaré conjecture",
+      "sphere theorem hierarchy",
+      "smooth 4-dimensional Poincaré conjecture",
+      "1/4-pinching sharpness"
+    ],
+    "prerequisites": [
+      "homotopy sphere",
+      "sectional curvature pinching",
+      "h-cobordism theorem"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

`annotations.json` for `poincare-conjecture` was severely stale relative to the file's actual size: only 23 annotations covering lines 1-889 out of the 17683-line `PoincareConjecture.lean` (~5%). The `sections[]` scaffolding in `meta.json` was already fixed to full 1-17683 coverage by #41547 (merged), but annotations were never caught up — a known independent-drift pattern between these two files (see prior enrichment PRs #41508/#41513/#41518/#41531/#41541 on other monster-scale entries).

Added 58 new annotations (81 total) tiling lines 890-17683, one per `sections[]` entry (splitting a couple of multi-topic sections), each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. The original 23 annotations (lines 1-889) are untouched.

Every named theorem/def referenced was grep-verified against `proofs/Proofs/PoincareConjecture.lean` before writing content, and annotation prose is deliberately matter-of-fact about proof substance rather than descriptive-summary-only — e.g. it notes where results are combinatorial bookkeeping on bare numeric records (`MorseData3`, `HandleDecomp3`) rather than derivations from actual differential-topological arguments, and where large literature-fact blocks (roughly 9314-14294 and scattered elsewhere: Hempel distance, Casson invariant, Heegaard Floer, L-space conjecture, Reidemeister torsion, TQFT/Smith conjecture, etc.) are hand-entered tables checked by `rfl`/`decide`/`native_decide` rather than proved from first principles.

## Accuracy findings (informational, not fixed here — out of enricher scope)

While reading the source, confirmed a few known-suspect spots at their **actual** line numbers (which differ from earlier guesses):
- `thurstonNorm := fun _ => 0` — placeholder, line 4451
- `novikov_compact_leaf` — trivially-true `Prop`-valued witness, line 9756
- `lickorish_wallace` — vacuous zero-knot existential, line 2343
- The lines 14042-14294 block (Chern-Simons/Freedman/geometrization) — all 11 named theorems there reduce to trivial arithmetic identities (e.g. `28 = 4*7`) behind docstrings describing much deeper results

These match/refine the overclaiming lead already flagged in #41547's description for a future mechanic/auditor pass — annotation content here just describes them honestly rather than re-flagging separately.

Not touched: `meta.json` (sections already correct on main), the Lean source itself.

## Test plan

- [x] `python3 -m json.tool` validates the JSON
- [x] `pnpm build` runs clean (unrelated `tsc: command not found` is a pre-existing environment gap, not caused by this change; all ~2180 build-regenerated noise files reverted with `git checkout -- .`, leaving only the intended `annotations.json` diff)
- [x] Every referenced theorem/def name grep-verified against the Lean source