### PR TITLE
audit: record erdos-1113 — issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10094,10 +10094,10 @@
       "notes": "Issue #14800 — phantom tang_yang_2021 axiom in sections; meta.axiomCount=5 is correct (5 actual axioms: erdos_graham_1980, twofold_eq_kfold, threefold_eq_kfold, bhj_r_lacunary, chen_r2_bound)"
     },
     "erdos-1113": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:29Z",
-      "result": "clean"
+      "lastAudited": "2026-07-22T17:20:24Z",
+      "result": "issues-fixed"
     },
     "erdos-1114": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Tracker update for the erdos-1113 audit resolved in #41563 (phantom axiom
claims removed from originalContributions/proofStrategy/keyInsights/sections).