### PR TITLE
Audit: triangle-inequality-oq-03 (reserve) re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -26276,9 +26276,9 @@
       "issues": []
     },
     "triangle-inequality-oq-03": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:30Z",
+      "lastAudited": "2026-07-22T17:27:23Z",
       "result": "clean"
     },
     "triangle-inequality-oq-04": {


### PR DESCRIPTION
## Reserve-mode audit

Gallery audit queue is fully drained (4809/4809, 0 issues). Re-verified the
oldest audited entry, `triangle-inequality-oq-03` (last audited 2026-05-04).

**Result: clean.** All meta counts verified exactly against the Lean source:
- theorems: 15 (matches)
- axioms: 0 (matches — only "axiom" hit is the English word in the docstring, not a declaration)
- sorries: 0 (matches)
- lines: 255 (matches)
- definitions: 0 (matches)

Badge `mathlib` / status `verified` is correctly disclosed for a Tier B entry:
`originalContributions` is scoped to the isosceles-triangle theorems
(independently proved in-file via contradiction arguments), while ball
structure and p-adic norm properties are correctly attributed to Mathlib's
`IsUltrametricDist` and `padicNorm` infrastructure in both prose and
`mathlibDependencies`. All 5 `crossReferences` targets resolve to existing
gallery entries.

No issues found; no fix needed.