### PR TITLE
Enrich combinations-formula-oq-02-oq-01: cover header section/annotation

### DIFF
--- a/src/data/proofs/combinations-formula-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-02-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-cfoq0201-header",
+    "proofId": "combinations-formula-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "context",
+    "title": "Why the Closed Form Needs Restating: No Square Root on Q[[X]]",
+    "content": "The module docstring frames the open question — prove the Catalan generating function C(x) = (1 - sqrt(1-4x))/(2x) — and explains why it cannot be stated verbatim over a formal power series ring: sqrt(1-4x) presupposes an analytic square-root operation that a general power series ring does not have. The file instead formalizes the two algebraic identities that carry the closed form's exact content: the functional equation C = 1 + X*C^2 (the power-series shadow of the Segner convolution recurrence catalan_succ') and the square-root form (2XC-1)^2 = 1-4X (the quadratic the closed form solves). It notes that Mathlib records the convolution recurrence but not the generating-function identity, so this packaging is original.",
+    "mathContext": "$\\sqrt{1-4x}$ is not an operation on $\\mathbb{Q}\\llbracket X\\rrbracket$, so the closed form $C(x)=\\frac{1-\\sqrt{1-4x}}{2x}$ is replaced by $C = 1+XC^2$ and $(2XC-1)^2 = 1-4X$.",
+    "significance": "context",
+    "relatedConcepts": ["formal power series ring", "square-root branch point", "Segner/Catalan convolution", "generating function"],
+    "prerequisites": ["formal power series ring", "Catalan numbers"]
+  },
+  {
     "id": "ann-cfoq0201-def-C",
     "proofId": "combinations-formula-oq-02-oq-01",
     "range": { "startLine": 39, "endLine": 41 },

--- a/src/data/proofs/combinations-formula-oq-02-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-02-oq-01/meta.json
@@ -45,6 +45,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header: From the Closed Form to Two Ring Identities",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "States the open question (the Catalan generating function C(x) = (1 - sqrt(1-4x))/(2x)) and explains why the literal closed form cannot be written verbatim over a formal power series ring: square root is not an operation on Q[[X]]. Frames the two algebraic identities that carry its exact ring-theoretic content — the functional equation C = 1 + X*C^2 and the square-root form (2XC-1)^2 = 1-4X — and notes that Mathlib records the Catalan convolution recurrence (catalan_succ') but not this generating-function identity, making the power-series packaging here original.",
+      "mathContext": "$\\sqrt{1-4x}$ has no formal-power-series analogue, so the closed form $C(x)=\\frac{1-\\sqrt{1-4x}}{2x}$ is replaced by the ring identities $C = 1 + XC^2$ and $(2XC-1)^2 = 1-4X$ over $\\mathbb{Q}\\llbracket X\\rrbracket$."
+    },
+    {
       "id": "definition",
       "title": "The Ordinary Generating Function C(X)",
       "startLine": 39,


### PR DESCRIPTION
## Summary
- The gallery entry's `sections` and `annotations` both started at line 39, leaving the module docstring (lines 1-38) with zero coverage.
- That docstring is real content, not boilerplate: it states the open question (the Catalan GF closed form $C(x)=(1-\sqrt{1-4x})/(2x)$), explains why the literal closed form can't be written verbatim over a formal power series ring, and frames the two ring identities (`catalan_ogf_functional`, `catalan_ogf_sq`) the file proves instead.
- Adds a `header` section (lines 1-38) and a matching `context`-type annotation covering the same range, using only the file's own docstring content (no invented history).

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — both JSON files parse
- [x] File sizes well under the ~60KB cap (13.7KB / 7.2KB)
- [x] Verified against the Lean source (`Proofs/CombinationsFormulaOQ02OQ01.lean`) — 0 sorries, 0 axioms, matches existing meta claims