### PR TITLE
Enrich elementary-quadratic-reciprocity-oq004: full annotation coverage 1-211

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq004/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq004/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-eqr-oq01030101-overview",
+    "proofId": "elementary-quadratic-reciprocity-oq004",
+    "range": { "startLine": 1, "endLine": 73 },
+    "type": "context",
+    "title": "Strategy overview: closing the parent's squarefree follow-up",
+    "content": "The parent file (ZolotarevBaseCase) proved sign(ringMulPerm a on ℤ/p) = legendreSym p a for a single prime p, then combined it with the grandparent's CRT multiplicativity to handle a two-prime modulus p·q, explicitly leaving the general squarefree case as 'a routine induction over the prime factorization adding no new idea.' This file performs exactly that induction: strong induction on n via its smallest prime factor p = n.minFac, recursing on the cofactor m = n/p, landing on Mathlib's actual jacobiSym rather than a bespoke symbol. The honest-scope note is explicit that prime-power factors pᵉ (e ≥ 2) are NOT handled — CRT only separates coprime factors, and the sign on ℤ/(pᵉ) is a genuinely different computation left to a follow-up. Imports the parent file and opens its ringMulPerm API plus the NumberTheorySymbols scope for the J(· | ·) notation.",
+    "mathContext": "$\\mathrm{sgn}(x\\mapsto a x \\text{ on } \\mathbb{Z}/n) = J(a\\mid n)$ for all odd squarefree $n$, by strong induction on $n$ via $n.\\mathrm{minFac}$.",
+    "significance": "context",
+    "relatedConcepts": ["Zolotarev's lemma", "Frobenius 1914", "strong induction", "prime factorization"],
+    "prerequisites": ["the parent's prime base case", "the grandparent's CRT sign multiplicativity"]
+  },
+  {
     "id": "ann-eqr-oq01030101-bezout",
     "proofId": "elementary-quadratic-reciprocity-oq004",
     "range": { "startLine": 74, "endLine": 82 },
@@ -12,9 +24,21 @@
     "prerequisites": ["Bézout's identity", "units of ℤ/k"]
   },
   {
+    "id": "ann-eqr-oq01030101-mainstmt",
+    "proofId": "elementary-quadratic-reciprocity-oq004",
+    "range": { "startLine": 83, "endLine": 97 },
+    "type": "theorem",
+    "title": "The main induction — statement and setup",
+    "content": "main states the target for every odd squarefree n: given c coprime to n and a unit u representing c, sign(ringMulPerm u on ℤ/n) equals the Jacobi symbol J(c | n). The proof fixes n once and dispatches to Nat.strong_induction_on so the inductive hypothesis ih is available for any smaller m in the recursion, matching the peeling-off-the-smallest-prime-factor strategy described in the header.",
+    "mathContext": "$\\forall\\, n \\text{ odd squarefree},\\ c \\in \\mathbb{Z},\\ \\gcd(c,n)=1,\\ u \\in (\\mathbb{Z}/n)^\\times \\text{ repr. } c:\\quad \\mathrm{sgn}(\\pi_u) = J(c\\mid n)$",
+    "significance": "key",
+    "relatedConcepts": ["strong induction", "Jacobi symbol", "unit group of ZMod n"],
+    "prerequisites": ["Nat.strong_induction_on", "the statement being proved by induction on n"]
+  },
+  {
     "id": "ann-eqr-oq01030101-base1",
     "proofId": "elementary-quadratic-reciprocity-oq004",
-    "range": { "startLine": 98, "endLine": 104 },
+    "range": { "startLine": 98, "endLine": 106 },
     "type": "theorem",
     "title": "Recursion base: ℤ/1 is a subsingleton",
     "content": "When n = 1 the ring ℤ/1 has a single element, so ringMulPerm u is forced to be the identity permutation (Subsingleton.elim), its sign is 1, and jacobiSym.one_right gives J(c | 1) = 1. This anchors the strong induction.",
@@ -34,6 +58,18 @@
     "significance": "key",
     "relatedConcepts": ["squarefree integers", "minimal prime factor", "strong induction", "coprimality"],
     "prerequisites": ["squarefree ⟹ no repeated prime factors", "strong induction on n"]
+  },
+  {
+    "id": "ann-eqr-oq01030101-instances",
+    "proofId": "elementary-quadratic-reciprocity-oq004",
+    "range": { "startLine": 123, "endLine": 133 },
+    "type": "technique",
+    "title": "Local instances and the coprime split",
+    "content": "Before building the CRT units, the proof installs the Fact/NeZero instances p and m need to talk about ZMod p and ZMod m, derives that both factors are odd (Nat.odd_mul) and p ≠ 2 (odd primes aren't 2), inherits Squarefree m from Squarefree n along the divisibility m ∣ n, and confirms m < p·m. It then splits the coprimality IsCoprime c (p*m) into its two components IsCoprime c p and IsCoprime c m via of_mul_right_left/of_mul_right_right — exactly the two hypotheses intCast_isUnit_of_isCoprime needs at each factor.",
+    "mathContext": "$\\gcd(c, pm) = 1 \\;\\Longrightarrow\\; \\gcd(c,p) = 1 \\ \\wedge\\ \\gcd(c,m) = 1$",
+    "significance": "technical",
+    "relatedConcepts": ["IsCoprime.of_mul_right_left", "Nat.odd_mul", "Squarefree.squarefree_of_dvd"],
+    "prerequisites": ["coprimality splits over a product", "squarefreeness is inherited by divisors"]
   },
   {
     "id": "ann-eqr-oq01030101-crtmatch",
@@ -62,7 +98,7 @@
   {
     "id": "ann-eqr-oq01030101-main",
     "proofId": "elementary-quadratic-reciprocity-oq004",
-    "range": { "startLine": 169, "endLine": 174 },
+    "range": { "startLine": 168, "endLine": 174 },
     "type": "theorem",
     "title": "Frobenius/Zolotarev for squarefree odd n",
     "content": "sign_ringMulPerm_eq_jacobiSym: the clean-binder statement of the result — for n odd squarefree, c coprime to n, and the unit u representing c, sign(ringMulPerm u on ℤ/n) = J(c | n). This is the genuine Frobenius (1914) generalization of Zolotarev's lemma for squarefree odd moduli, landing on Mathlib's jacobiSym, with 0 sorries and 0 axioms.",
@@ -70,5 +106,17 @@
     "significance": "critical",
     "relatedConcepts": ["Zolotarev's lemma", "Frobenius 1914", "Jacobi symbol", "quadratic reciprocity"],
     "prerequisites": ["the inductive assembly over prime factors", "Mathlib's jacobiSym"]
+  },
+  {
+    "id": "ann-eqr-oq01030101-summary",
+    "proofId": "elementary-quadratic-reciprocity-oq004",
+    "range": { "startLine": 175, "endLine": 211 },
+    "type": "insight",
+    "title": "Summary: the recursive shadow of the Jacobi symbol",
+    "content": "The closing docstring restates the file's two results (the Bezout unit bridge and the main squarefree-odd Frobenius/Zolotarev theorem) and re-emphasizes the honest scope: prime-power factors pᵉ (e ≥ 2) are not covered, since CRT only separates coprime factors and the sign on ℤ/(pᵉ) needs a genuinely different argument. It then names the key insight driving the whole file: jacobiSym.mul_right (multiplicativity of the Jacobi symbol over its denominator) is the value-level shadow of sign_ringMulPerm_mul_of_odd (multiplicativity of the permutation sign under CRT) — the induction succeeds because the symbol's own recursive definition mirrors the CRT splitting. The trailing #check lines are a lightweight sanity confirmation that all three declarations elaborate under their stated names.",
+    "mathContext": "$J(c \\mid pm) = J(c\\mid p)\\,J(c\\mid m) \\;\\leftrightarrow\\; \\mathrm{sgn}(\\pi_{c,pm}) = \\mathrm{sgn}(\\pi_{c,p})\\,\\mathrm{sgn}(\\pi_{c,m})$",
+    "significance": "supporting",
+    "relatedConcepts": ["jacobiSym.mul_right", "CRT multiplicativity of sign", "honest scope / prime powers"],
+    "prerequisites": ["the full induction argument", "multiplicativity of the Jacobi symbol"]
   }
 ]

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq004/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq004/annotations.json
@@ -110,7 +110,7 @@
   {
     "id": "ann-eqr-oq01030101-summary",
     "proofId": "elementary-quadratic-reciprocity-oq004",
-    "range": { "startLine": 175, "endLine": 211 },
+    "range": { "startLine": 177, "endLine": 211 },
     "type": "insight",
     "title": "Summary: the recursive shadow of the Jacobi symbol",
     "content": "The closing docstring restates the file's two results (the Bezout unit bridge and the main squarefree-odd Frobenius/Zolotarev theorem) and re-emphasizes the honest scope: prime-power factors pᵉ (e ≥ 2) are not covered, since CRT only separates coprime factors and the sign on ℤ/(pᵉ) needs a genuinely different argument. It then names the key insight driving the whole file: jacobiSym.mul_right (multiplicativity of the Jacobi symbol over its denominator) is the value-level shadow of sign_ringMulPerm_mul_of_odd (multiplicativity of the permutation sign under CRT) — the induction succeeds because the symbol's own recursive definition mirrors the CRT splitting. The trailing #check lines are a lightweight sanity confirmation that all three declarations elaborate under their stated names.",


### PR DESCRIPTION
## Summary

`elementary-quadratic-reciprocity-oq004` (the squarefree-odd Frobenius/Jacobi
Zolotarev lemma) had only 6 annotations covering roughly 63% of the 211-line
Lean file (`ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01.lean`), leaving the
module's strategy overview, the main theorem's statement, a chunk of local
setup mid-proof, and the entire closing summary docstring unannotated.

- Added an annotation for the header/strategy-overview comment (1-73):
  explains what the parent left as a follow-up and how this file's induction
  closes it.
- Added an annotation for the main theorem's statement and induction setup
  (83-97).
- Added an annotation for the local instances + coprimality split step
  (123-133), between the existing "splitting off the smallest prime factor"
  and "CRT component units" annotations.
- Added an annotation for the closing Summary docstring (177-211): restates
  scope and names the key insight (`jacobiSym.mul_right` as the value-level
  shadow of the CRT sign multiplicativity).
- Extended two existing annotations' boundaries by a couple of lines each to
  close small tail gaps (base-case `rw` at line 106; Part II banner+docstring
  starting at 168).

Net: 6 → 10 annotations, full 1-211 line coverage (previously 74-174 with
internal gaps). No changes to `meta.json` — its `overview`/`conclusion`
fields were already at target (5 keyInsights, 726-char historicalContext, full
conclusion with 3 open questions).

Verified against `pnpm build`'s annotation-alignment checker (0 new errors for
this entry; global error count unchanged from baseline at 4994).

🤖 Generated with [Claude Code](https://claude.com/claude-code)