### PR TITLE
Enrich compactness-finite-subcover-oq-02: add header section

### DIFF
--- a/src/data/proofs/compactness-finite-subcover-oq-02/meta.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-02/meta.json
@@ -88,6 +88,13 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header: Subordinate Finite ε-Nets",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "States the headline result exists_subordinate_finite_ball_cover — a metric-space refinement of the finite-subcover characterization of compactness, producing a single Lebesgue radius δ and a finite set of centers whose δ-balls cover the space and are each subordinate to (contained in) some member of the cover. Names the two Mathlib ingredients assembled (lebesgue_number_lemma_of_metric, exists_finite_cover_balls_of_isCompact_closure) and the two structural corollaries (a constructive Heine–Borel finite subcover, and a fineness refinement bounding diameters by 2δ), explaining why no single Mathlib lemma packages this combination."
+    },
+    {
       "id": "subordinate-net",
       "title": "The Subordinate Finite ε-Net",
       "startLine": 56,


### PR DESCRIPTION
## Summary
- The module header (lines 1-55: the docstring stating the headline result, the two Mathlib ingredients it combines, and the two structural corollaries) had no `sections` entry — the first section started at line 56.
- The header content was already narrated by an existing annotation (`csfs02-ann-overview`, lines 3-48), so this PR adds only the missing `header` section entry, summarizing content already stated in the file's own docstring.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — meta.json parses
- [x] File size well under the ~60KB cap (14.1KB)