### PR TITLE
Fix: erdos-939 annotations drop stale native_decide claim

### DIFF
--- a/src/data/proofs/erdos-939/annotations.json
+++ b/src/data/proofs/erdos-939/annotations.json
@@ -280,17 +280,17 @@
     },
     "type": "concept",
     "title": "Lander-Parkin Counterexample",
-    "content": "**Lander and Parkin (1967)** disproved Euler's conjecture by finding:\n\n27⁵ + 84⁵ + 110⁵ + 133⁵ = 144⁵\n\nThis was discovered by computer search—one of the first major mathematical results found by computer.\n\nThe proof uses `native_decide` for direct computation.",
+    "content": "**Lander and Parkin (1967)** disproved Euler's conjecture by finding:\n\n27⁵ + 84⁵ + 110⁵ + 133⁵ = 144⁵\n\nThis was discovered by computer search—one of the first major mathematical results found by computer.\n\nThe proof verifies the identity by kernel computation with `decide` and `norm_num`.",
     "mathContext": "27^5 + 84^5 + 110^5 + 133^5 = 14348907 + 4182119424 + 16105100000 + 40725541933 = 61917364224 = 144^5.",
     "significance": "key",
     "relatedConcepts": [
       "lander-parkin",
       "counterexample",
-      "native-decide"
+      "kernel-computation"
     ],
     "prerequisites": [
       "Counterexamples by computer search",
-      "`native_decide`",
+      "`decide` / `norm_num`",
       "Sums of fifth powers"
     ]
   },


### PR DESCRIPTION
## Problem

`src/data/proofs/erdos-939/annotations.json` still claimed the Lander–Parkin counterexample proof "uses `native_decide` for direct computation", but that is no longer true on `main`.

Merged PR #41462 replaced `native_decide` in `proofs/Proofs/Erdos939Problem.lean` with kernel-checked tactics:

```
· decide
use 144
rw [Finset.sum_insert (by decide), Finset.sum_insert (by decide),
  Finset.sum_insert (by decide), Finset.sum_singleton]
norm_num
...
theorem lander_parkin_identity : 27^5 + 84^5 + 110^5 + 133^5 = 144^5 := by norm_num
```

`grep native_decide proofs/Proofs/Erdos939Problem.lean` → no matches. The annotation prose was stale.

## Fix (annotations.json only, minimal)

- `content`: "The proof uses `native_decide` for direct computation." → "The proof verifies the identity by kernel computation with `decide` and `norm_num`."
- `relatedConcepts`: `native-decide` → `kernel-computation`
- `prerequisites`: `` `native_decide` `` → `` `decide` / `norm_num` ``

## Evidence

- `grep -rn native_decide src/data/proofs/erdos-939/` → no matches after fix
- JSON re-validated with `json.load`
- The genuine `axiom cambie_r5_example` (line 147) is untouched; `status: axiomatized`, `axiomCount: 1` remain correct.
