### PR TITLE
Enrich cramers-rule-oq-04-oq-01-oq-01: add header section/annotation

### DIFF
--- a/src/data/proofs/cramers-rule-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cramers-rule-oq-04-oq-01-oq-01/annotations.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "ann-header",
+    "proofId": "cramers-rule-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 41
+    },
+    "type": "context",
+    "title": "OQ-01: From the Determinant Form to the Honest Scalar Formula",
+    "content": "The module docstring states the parent's open question: the parent (CramersRuleOQ04OQ01) proved only the determinant-scaled form A·(adj A · b) = (det A)·b, and OQ-01 asks for the classical scalar formula xᵢ = det(Aᵢ)/det A, where Aᵢ is A with column i replaced by b. The bridge is Matrix.cramer: cramer_apply identifies its i-th component with det(Aᵢ), and the same adjugate identity adj(A)·A = (det A)·I that powered the parent shows cramer A b = (det A)•x for any solution x of Ax = b — so dividing by the nonzero determinant recovers the classical formula. Lists the five theorems the file proves (the algebraic core, the explicit formula, uniqueness, and existence) before opening the Matrix namespace and fixing the commutative-ring section.",
+    "mathContext": "$\\mathrm{cramer}\\,A\\,b\\,i = \\det(A.\\mathrm{updateCol}\\,i\\,b)$ bridges the parent's $A\\cdot(\\mathrm{adj}\\,A\\cdot b) = (\\det A)\\cdot b$ to $x_i = \\det(A_i)/\\det A$.",
+    "significance": "context",
+    "relatedConcepts": ["Matrix.cramer", "cramer_apply", "adjugate identity", "determinant-scaled solution"],
+    "prerequisites": ["matrix adjugate", "Cramer's rule (determinant form)"]
+  },
+  {
     "id": "ann-algebraic-core",
     "proofId": "cramers-rule-oq-04-oq-01-oq-01",
     "range": {

--- a/src/data/proofs/cramers-rule-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-04-oq-01-oq-01/meta.json
@@ -94,6 +94,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header: From the Determinant Form to the Scalar Formula",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "States the parent's open question OQ-01 — promote the determinant-scaled solution A·(adj A · b) = (det A)·b to the honest scalar formula xᵢ = det(Aᵢ)/det A — and names the bridge: Matrix.cramer, whose i-th component cramer_apply identifies with det(Aᵢ), collapses to (det A)·x via the same adjugate identity the parent used. Lists the five main results (det_smul_solution_eq_cramer, cramer_solution, cramer_solution_eq, cramer_solution_unique, cramer_formula_isSolution) before opening the Matrix namespace and fixing the ambient commutative-ring section.",
+      "mathContext": "Bridges the parent's determinant form $A\\cdot(\\mathrm{adj}\\,A\\cdot b) = (\\det A)\\cdot b$ to the scalar formula $x_i = \\det(A_i)/\\det A$ via $\\mathrm{cramer}\\,A\\,b\\,i = \\det(A.\\mathrm{updateCol}\\,i\\,b)$."
+    },
+    {
       "id": "algebraic-core",
       "title": "Section I: The Invertibility-Free Algebraic Core",
       "startLine": 42,


### PR DESCRIPTION
## Summary
- Sections and annotations both started at line 42/46, leaving the module docstring (lines 1-41) with zero coverage.
- That docstring states the parent's open question (OQ-01), names the bridge (`Matrix.cramer`/`cramer_apply`), and lists the file's five main theorems — genuine content, not boilerplate.
- Adds a `header` section and matching `context`-significance annotation covering lines 1-41, summarizing only what the docstring already says.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — both JSON files parse
- [x] File sizes well under the ~60KB cap (13.6KB / 7.1KB)