### PR TITLE
Enrich descartes-rule-of-signs-oq-02-oq-03: add header section

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-03/meta.json
@@ -72,6 +72,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header and complexRoots Definition",
+      "startLine": 1,
+      "endLine": 32,
+      "summary": "States the parent's open question (OQ-03): the budan_parity axiom rests on complex roots of a real polynomial coming in conjugate pairs, which ultimately depends on the Fundamental Theorem of Algebra. Lists the four results the file derives (aeval_conj_eq_zero, complexRoots_conj_invariant, count_complexRoots_conj, even_card_nonreal_roots — the conjugate-pair structure fixing the real-root parity), then defines complexRoots p as the complex root multiset of p.map (algebraMap ℝ ℂ).",
+      "mathContext": "$\\mathrm{complexRoots}\\,p = (p.\\mathrm{map}(\\mathbb{R}\\hookrightarrow\\mathbb{C})).\\mathrm{roots}$; the file derives that non-real elements of this multiset split into conjugate pairs $\\{z,\\bar z\\}$."
+    },
+    {
       "id": "membership",
       "title": "Conjugate of a Root Is a Root",
       "startLine": 33,


### PR DESCRIPTION
## Summary
- The module header (lines 1-32: docstring stating OQ-03, listing the four derived results, and the `complexRoots` definition) had no `sections` entry — the first section started at line 33.
- The docstring prose was already narrated by an existing annotation (`ann-overview`, lines 3-25) and the definition by `ann-complexroots-def` (lines 31-32), so this PR adds only the missing `header` section, summarizing content already present in the file and existing annotations.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — meta.json parses
- [x] File size well under the ~60KB cap (13.3KB)