### PR TITLE
Enrich erdos-1017-oq-03-oq-01: full annotation+section coverage 1-146

### DIFF
--- a/src/data/proofs/erdos-1017-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1017-oq-03-oq-01/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "erdos1017oq03oq01-ann-header",
     "proofId": "erdos-1017-oq-03-oq-01",
-    "range": { "startLine": 3, "endLine": 42 },
+    "range": { "startLine": 1, "endLine": 42 },
     "type": "concept",
     "title": "The Quarter-Square ↔ Triangular-Number Bridge",
     "content": "Erdős Problem #1017 (Erdős–Goodman–Pósa, 1966) has extremal value T(n) = ⌊n²/4⌋ — the quarter-square sequence, both the worst-case number of complete subgraphs needed to edge-partition an n-vertex graph and the edge count of the balanced complete bipartite graph K_{⌊n/2⌋,⌈n/2⌉}. The sibling file Erdos1017OQ03.lean records T's closed forms, monotonicity, and two-sided envelope; this child entry records the exact additive link between the quarter-squares and the triangular numbers. The central identity T(n) + T(n+1) = C(n+1,2) = n(n+1)/2 says two consecutive quarter-squares sum to a triangular number, so the extremal bipartite edge counts on n and n+1 vertices together tile the complete graph K_{n+1}. turanBound n := n²/4 is re-declared, so the file is self-contained over Mathlib.",
@@ -18,6 +18,18 @@
       "extremal graph theory",
       "floor function over ℕ"
     ]
+  },
+  {
+    "id": "erdos1017oq03oq01-ann-def",
+    "proofId": "erdos-1017-oq-03-oq-01",
+    "range": { "startLine": 48, "endLine": 50 },
+    "type": "definition",
+    "title": "Re-declaring the Turán Bound",
+    "content": "turanBound n := n^2 / 4 is re-declared here rather than imported from the sibling Erdos1017OQ03.lean, so this file depends only on Mathlib and stays self-contained (0 sorries, 0 axioms, no native_decide). Every downstream identity in this file — the increments, the triangular-number bridge, the binomial bridge, and the accumulation formula — is proved directly from this one-line definition.",
+    "mathContext": "$T(n) := \\lfloor n^2/4 \\rfloor$",
+    "significance": "context",
+    "relatedConcepts": ["Turán bound", "natural-number division", "self-contained re-declaration"],
+    "prerequisites": ["floor division over ℕ"]
   },
   {
     "id": "erdos1017oq03oq01-ann-succ",
@@ -118,5 +130,17 @@
       "the additive increment",
       "finite sums over ranges"
     ]
+  },
+  {
+    "id": "erdos1017oq03oq01-ann-significance",
+    "proofId": "erdos-1017-oq-03-oq-01",
+    "range": { "startLine": 123, "endLine": 146 },
+    "type": "context",
+    "title": "Significance: the additive/telescoping structure of the quarter-squares",
+    "content": "The closing docstring ties the file's three results together: the central identity T(n) + T(n+1) = C(n+1,2) = n(n+1)/2 (two consecutive quarter-squares tile the edges of K_{n+1}); the exact, parity-blind two-step increment T(n+2) = T(n) + (n+1); and the accumulation formula T(n) = ∑_{k<n} ⌈k/2⌉ expressing T as the running sum of its own increments. Together these pin the additive/telescoping structure of the quarter-square sequence, complementing the sibling file's multiplicative identity T(m+n) − T(m−n) = m·n and its discrete convexity.",
+    "mathContext": "$T(n)+T(n+1)=\\binom{n+1}{2},\\quad T(n+2)=T(n)+(n+1),\\quad T(n)=\\textstyle\\sum_{k<n}\\lceil k/2\\rceil$",
+    "significance": "supporting",
+    "relatedConcepts": ["additive structure", "telescoping sum", "quarter-square identity", "discrete convexity"],
+    "prerequisites": ["the three main results of this file", "the sibling file's multiplicative identity"]
   }
 ]

--- a/src/data/proofs/erdos-1017-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-1017-oq-03-oq-01/meta.json
@@ -90,6 +90,14 @@
       "startLine": 105,
       "endLine": 121,
       "mathContext": "Nat.choose_two_right + congr/ring for the binomial bridge; a one-line induction (Finset.sum_range_succ + turanBound_succ) for the accumulation formula."
+    },
+    {
+      "id": "significance",
+      "title": "Significance and Closing Remarks",
+      "summary": "Closing docstring tying together the central identity, the exact two-step increment, and the accumulation formula as the additive/telescoping structure of the quarter-square sequence, complementing the sibling file's multiplicative identity and discrete convexity.",
+      "startLine": 122,
+      "endLine": 146,
+      "mathContext": "Restates T(n)+T(n+1) = C(n+1,2), T(n+2) = T(n)+(n+1), and T(n) = sum_{k<n} ceil(k/2) as the file's three pillars of additive structure."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
## Summary

`erdos-1017-oq-03-oq-01` (the quarter-square ↔ triangular-number bridge for
the Turán bound) had annotations covering only lines 3-121 of a 146-line file,
and `sections` stopping at line 121 too — leaving:

- the `def turanBound` re-declaration (lines 48-50) unannotated (fell in the
  gap between the header docstring annotation and the first theorem
  annotation), and
- the entire 24-line closing "Significance" docstring (122-146) with no
  annotation or section at all.

Changes:
- Extended the header annotation to start at line 1 (include the `import`
  line).
- Added an annotation for the `turanBound` re-declaration (48-50).
- Added an annotation and a matching `meta.json` section for the closing
  Significance docstring (123-146 / 122-146 respectively).

Net: full 1-146 annotation and section coverage (previously ~81%
annotation / 83% section coverage with an internal gap). No changes to
`meta.json` `overview`/`conclusion` — already at target (4 keyInsights,
full conclusion with 3 open questions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)