### PR TITLE
Audit: cantors-theorem-oq-02 (reserve) — re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4274,9 +4274,9 @@
       "issues": []
     },
     "cantors-theorem-oq-02": {
-      "auditCount": 4,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:29Z",
+      "lastAudited": "2026-07-22T17:35:47Z",
       "result": "clean"
     },
     "cantors-theorem-oq-02-oq-04": {


### PR DESCRIPTION
## Reserve-mode re-audit

Queue is fully drained (4809/4809 audited, 0 issues). Re-verified `cantors-theorem-oq-02` (Lawvere's Fixed-Point Theorem) against `proofs/Proofs/CantorsTheoremOQ02.lean`:

- 0 sorries, 0 axioms (matches meta)
- 15/15 theorems present, all names in `originalContributions`/`sections` correspond to real declarations (no phantoms)
- lineCount 281 exact match
- No True stubs, no `native_decide`
- `status: verified` / `badge: mathlib` consistent with content

No issues found.

---
Discovered during gallery integrity audit.