### PR TITLE
Enrich erdos-10-wip-01: full annotation+section coverage 1-146

### DIFF
--- a/src/data/proofs/erdos-10-wip-01/annotations.json
+++ b/src/data/proofs/erdos-10-wip-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-header-context",
+    "proofId": "erdos-10-wip-01",
+    "range": { "startLine": 1, "endLine": 39 },
+    "type": "context",
+    "title": "Adding Additive Structure to the Erdős #10 Powers-of-Two Thread",
+    "content": "The parent Erdos10OQ02 thread built RepWithAtMost k n ('n is a sum of at most k powers of two') and its reduction to popcount via repWithAtMost_iff_bitIndices_length, but had no additive structure. This file supplies exactly that: repWithAtMost_add shows RepWithAtMost is subadditive by concatenating exponent multisets, and feeding the popcount-minimal representations through it gives — for free — the classical fact that binary popcount is subadditive. The file closes with isPrimePlusKPowers_iff_popcount, rewriting the Erdős #10 predicate ('n is a prime plus at most k powers of two') into an O(log)-checkable form via popcount(n − p), the form the concrete witness searches (e.g. Grechuk's 1117175146) rest on. Imports both parent files and opens Erdos10OQ02 for RepWithAtMost and its lemmas.",
+    "mathContext": "Goal: $\\mathrm{RepWithAtMost}$ is subadditive, so $\\mathrm{popcount}(a+b)\\le\\mathrm{popcount}(a)+\\mathrm{popcount}(b)$, and the Erdős #10 predicate rewrites via $\\mathrm{popcount}(n-p)$.",
+    "significance": "context",
+    "relatedConcepts": ["Erdős–Graham problem", "RepWithAtMost", "binary popcount", "additive combinatorics"],
+    "prerequisites": ["the parent RepWithAtMost/popcount characterization (Erdos10OQ02)", "powSum_add"]
+  },
+  {
     "id": "ann-popcount-def",
     "proofId": "erdos-10-wip-01",
     "range": {
@@ -73,5 +85,17 @@
     "significance": "key",
     "relatedConcepts": ["Erdős problem #10", "prime plus powers of two", "computational witness search", "Grechuk's counterexample"],
     "prerequisites": ["the IsPrimePlusKPowers predicate", "popcount_le_iff", "Nat subtraction (omega)"]
+  },
+  {
+    "id": "ann-closing-summary",
+    "proofId": "erdos-10-wip-01",
+    "range": { "startLine": 129, "endLine": 146 },
+    "type": "insight",
+    "title": "Summary: From Subadditive Representation to the O(log) Predicate",
+    "content": "The closing docstring restates the three results in one line each — repWithAtMost_add (subadditivity of representation), bitIndices_length_add_le / bitIndices_length_sum_le (binary popcount subadditivity, single and iterated), and isPrimePlusKPowers_iff_popcount (the O(log) prime-plus-popcount form) — and names their dependencies on the two parent files Erdos10OQ02 and Erdos10OQ02Popcount. It closes with the file's status line: 0 sorries, 0 axiom declarations, no native_decide.",
+    "mathContext": "$\\mathrm{popcount}(a+b)\\le\\mathrm{popcount}(a)+\\mathrm{popcount}(b)$ and $\\mathrm{IsPrimePlusKPowers}\\,k\\,n \\iff \\exists\\,p\\ \\text{prime} \\le n,\\ \\mathrm{popcount}(n-p)\\le k$.",
+    "significance": "supporting",
+    "relatedConcepts": ["subadditivity", "binary popcount", "Erdős problem #10", "O(log) predicate"],
+    "prerequisites": ["all three main results of this file"]
   }
 ]

--- a/src/data/proofs/erdos-10-wip-01/meta.json
+++ b/src/data/proofs/erdos-10-wip-01/meta.json
@@ -63,6 +63,14 @@
   },
   "sections": [
     {
+      "id": "header-context",
+      "title": "Header: Adding Additive Structure to the Powers-of-Two Thread",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Module docstring on why the parent Erdos10OQ02 thread needed subadditivity, imports of both parent files, namespace/open setup, and the popcount abbreviation (Nat.bitIndices n).length.",
+      "mathContext": "Sets up the goal: RepWithAtMost subadditive ⟹ popcount subadditive ⟹ O(log) prime-plus-popcount form."
+    },
+    {
       "id": "rep-subadd",
       "title": "Part I: Subadditivity of Representation",
       "startLine": 42,
@@ -85,6 +93,14 @@
       "endLine": 138,
       "summary": "isPrimePlusKPowers_iff_popcount: IsPrimePlusKPowers k n ↔ ∃ prime p ≤ n, popcount(n−p) ≤ k.",
       "mathContext": "The O(log)-checkable form of the Erdős #10 predicate behind the concrete witness searches."
+    },
+    {
+      "id": "closing-summary",
+      "title": "Closing Summary",
+      "startLine": 139,
+      "endLine": 146,
+      "summary": "Restates the three results and their dependence on the two parent files, and closes with the file's status: 0 sorries, 0 axiom declarations, no native_decide.",
+      "mathContext": "Recap of subadditivity of representation ⟹ subadditivity of popcount ⟹ the O(log) prime-plus-popcount predicate."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

`erdos-10-wip-01` (subadditivity of representation and binary popcount for
Erdős #10) had both `annotations.json` and `meta.json`'s `sections` skip the
same two spans of the 146-line Lean file:

- lines 1-39/1-41: the module header (imports of both parent files, the
  docstring explaining why this file exists, namespace/open setup, and the
  `popcount` abbreviation) — sections started at line 42, annotations at 40.
- lines 129-146/139-146: the closing "Summary" docstring restating the three
  results and the file's axiom/sorry status — entirely uncovered.

Added one annotation + one section for each span. No changes to
`meta.json`'s `overview`/`conclusion` — already at target (5 keyInsights,
full conclusion with 3 open questions).

Verified against `pnpm build`'s annotation-alignment checker (0 new errors
for this entry; global error count unchanged from baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)