### PR TITLE
Research: erdos-326-wip-01 — limsup/liminf layer: non-convergence ⟺ liminf < limsup (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos326WIP01.lean
+++ b/proofs/Proofs/Erdos326WIP01.lean
@@ -789,4 +789,119 @@ theorem hasNoGrowthLimit_oscPair {c₁ c₂ : ℕ} (h : c₁ ≠ c₂) :
   · simp only [growthRatio_oscPair_even]; exact tendsto_const_nhds
   · simp only [growthRatio_oscPair_odd]; exact tendsto_const_nhds
 
+/-! ## The limsup/liminf layer
+
+Erdős #326 asks for a sub-basis whose growth ratio `bₖ/k²` **fails to
+converge**.  For the ratio sequence of an order-2 basis — which is bounded
+(`two_growthRatio_le`) and nonnegative (`growthRatio_nonneg`) — failing to
+converge is *exactly* the strict inequality `liminf < limsup`.  This section
+records that translation, so the open dichotomy can be attacked directly in
+`limsup`/`liminf` language:
+
+* boundedness plumbing (`growthRatio_isBoundedUnder_ge`,
+  `two_growthRatio_isBoundedUnder_le`);
+* the limsup form of `bₖ = O(k²)` (`two_growthRatio_limsup_le`) and
+  nonnegativity of the liminf (`growthRatio_liminf_nonneg`);
+* a growth limit pins both quantities (`HasGrowthLimit.limsup_eq`,
+  `HasGrowthLimit.liminf_eq`), and conversely `liminf = limsup` recovers the
+  limit for bounded ratios (`hasGrowthLimit_of_liminf_eq_limsup`);
+* the characterization `HasNoGrowthLimit b ↔ liminf < limsup`
+  (`hasNoGrowthLimit_iff_liminf_lt_limsup`), specialized to order-2 bases
+  (`IsAddBasisOfOrder.two_hasNoGrowthLimit_iff_liminf_lt_limsup`).
+
+None of this touches the open construction itself; it re-expresses its target. -/
+
+/-- The growth ratio sequence is bounded below (by `0`) along `atTop`, for any
+enumeration: the coboundedness input every limsup estimate needs. -/
+theorem growthRatio_isBoundedUnder_ge (b : ℕ → ℕ) :
+    IsBoundedUnder (· ≥ ·) atTop (growthRatio b) :=
+  isBoundedUnder_of ⟨0, fun k => growthRatio_nonneg b k⟩
+
+/-- **Boundedness of the ratio sequence of an order-2 basis**, in filter
+language: `growthRatio (Nat.nth (· ∈ A))` is `IsBoundedUnder (· ≤ ·)` along
+`atTop`.  This is `two_growthRatio_le` repackaged as the hypothesis shape the
+`limsup`/`liminf` API consumes. -/
+theorem IsAddBasisOfOrder.two_growthRatio_isBoundedUnder_le {A : Set ℕ}
+    (h : IsAddBasisOfOrder A 2) :
+    IsBoundedUnder (· ≤ ·) atTop (growthRatio (Nat.nth (· ∈ A))) := by
+  obtain ⟨C, N₀, hC⟩ := h.two_growthRatio_le
+  exact ⟨(C : ℝ), eventually_map.mpr (eventually_atTop.mpr ⟨N₀, hC⟩)⟩
+
+/-- **The limsup form of `bₖ = O(k²)`.**  For an order-2 basis `A`, the limsup
+of the growth ratio `bₖ/k²` of its increasing enumeration is at most some
+natural constant `C`.  This is the quantity the open dichotomy of #326 is
+about: any sub-basis inherits a finite limsup, so non-convergence can only
+happen through `liminf < limsup` within `[0, C]`. -/
+theorem IsAddBasisOfOrder.two_growthRatio_limsup_le {A : Set ℕ}
+    (h : IsAddBasisOfOrder A 2) :
+    ∃ C : ℕ, Filter.limsup (growthRatio (Nat.nth (· ∈ A))) atTop ≤ (C : ℝ) := by
+  obtain ⟨C, N₀, hC⟩ := h.two_growthRatio_le
+  refine ⟨C, Filter.limsup_le_of_le
+    ((growthRatio_isBoundedUnder_ge _).isCoboundedUnder_le) ?_⟩
+  exact eventually_atTop.mpr ⟨N₀, hC⟩
+
+/-- The liminf of any growth ratio sequence with bounded ratios is
+nonnegative. -/
+theorem growthRatio_liminf_nonneg {b : ℕ → ℕ}
+    (hbdd : IsBoundedUnder (· ≤ ·) atTop (growthRatio b)) :
+    0 ≤ Filter.liminf (growthRatio b) atTop :=
+  Filter.le_liminf_of_le hbdd.isCoboundedUnder_ge
+    (Eventually.of_forall fun k => growthRatio_nonneg b k)
+
+/-- A growth limit pins the limsup: if `bₖ/k² → x` then
+`limsup (bₖ/k²) = x`. -/
+theorem HasGrowthLimit.limsup_eq {b : ℕ → ℕ} {x : ℝ} (h : HasGrowthLimit b x) :
+    Filter.limsup (growthRatio b) atTop = x :=
+  Filter.Tendsto.limsup_eq h
+
+/-- A growth limit pins the liminf: if `bₖ/k² → x` then
+`liminf (bₖ/k²) = x`. -/
+theorem HasGrowthLimit.liminf_eq {b : ℕ → ℕ} {x : ℝ} (h : HasGrowthLimit b x) :
+    Filter.liminf (growthRatio b) atTop = x :=
+  Filter.Tendsto.liminf_eq h
+
+/-- **Convergence from `liminf = limsup`.**  For a ratio sequence bounded
+above (below is automatic from `growthRatio_nonneg`), if liminf and limsup
+agree at `x` then the growth limit exists and equals `x` — the converse of
+`HasGrowthLimit.limsup_eq`/`liminf_eq`. -/
+theorem hasGrowthLimit_of_liminf_eq_limsup {b : ℕ → ℕ} {x : ℝ}
+    (hbdd : IsBoundedUnder (· ≤ ·) atTop (growthRatio b))
+    (hinf : Filter.liminf (growthRatio b) atTop = x)
+    (hsup : Filter.limsup (growthRatio b) atTop = x) :
+    HasGrowthLimit b x :=
+  tendsto_of_liminf_eq_limsup hinf hsup hbdd (growthRatio_isBoundedUnder_ge b)
+
+/-- **Non-convergence is exactly `liminf < limsup`** for a bounded ratio
+sequence.  This is the precise sense in which the open part of Erdős #326 —
+"the sub-basis enumeration has no growth limit" — is a statement about the
+gap between liminf and limsup of `bₖ/k²`. -/
+theorem hasNoGrowthLimit_iff_liminf_lt_limsup {b : ℕ → ℕ}
+    (hbdd : IsBoundedUnder (· ≤ ·) atTop (growthRatio b)) :
+    HasNoGrowthLimit b ↔
+      Filter.liminf (growthRatio b) atTop <
+        Filter.limsup (growthRatio b) atTop := by
+  constructor
+  · intro h
+    rcases lt_or_eq_of_le
+        (liminf_le_limsup hbdd (growthRatio_isBoundedUnder_ge b)) with hlt | heq
+    · exact hlt
+    · exact absurd (hasGrowthLimit_of_liminf_eq_limsup hbdd heq rfl) (h _)
+  · intro hlt x hx
+    have h1 : Filter.liminf (growthRatio b) atTop = x := HasGrowthLimit.liminf_eq hx
+    have h2 : Filter.limsup (growthRatio b) atTop = x := HasGrowthLimit.limsup_eq hx
+    rw [h1, h2] at hlt
+    exact lt_irrefl x hlt
+
+/-- **The dichotomy of Erdős #326 in limsup/liminf form, for order-2 bases.**
+The increasing enumeration of an order-2 basis has no growth limit **iff**
+`liminf (bₖ/k²) < limsup (bₖ/k²)`.  In particular the open question "does
+every order-2 basis contain a sub-basis with no growth limit?" asks exactly
+for a sub-basis whose ratio sequence keeps a persistent liminf/limsup gap. -/
+theorem IsAddBasisOfOrder.two_hasNoGrowthLimit_iff_liminf_lt_limsup {A : Set ℕ}
+    (h : IsAddBasisOfOrder A 2) :
+    HasNoGrowthLimit (Nat.nth (· ∈ A)) ↔
+      Filter.liminf (growthRatio (Nat.nth (· ∈ A))) atTop <
+        Filter.limsup (growthRatio (Nat.nth (· ∈ A))) atTop :=
+  hasNoGrowthLimit_iff_liminf_lt_limsup h.two_growthRatio_isBoundedUnder_le
+
 end Erdos326

--- a/research/problems/erdos-326-wip-01/knowledge.md
+++ b/research/problems/erdos-326-wip-01/knowledge.md
@@ -263,3 +263,28 @@ Added to Erdos326WIP01.lean (0-axiom, Docker 8577 jobs):
 
 Elementary layer now further saturated. Deep OPEN core unchanged: sub-basis
 oscillation dichotomy needs a materially new mechanism.
+
+## 2026-07-22 (researcher-1, session 2) — the limsup/liminf translation
+
+Added the previously-deferred limsup layer to Erdos326WIP01.lean (0-axiom,
+host-verified v4.31, all 9 decls `#print axioms` = propext/Classical.choice/
+Quot.sound; compiled first try):
+- Boundedness plumbing: `growthRatio_isBoundedUnder_ge` (any enumeration is
+  ≥-bounded by 0), `IsAddBasisOfOrder.two_growthRatio_isBoundedUnder_le`
+  (order-2 basis ratios are ≤-bounded — `two_growthRatio_le` in filter shape).
+- `two_growthRatio_limsup_le`: the limsup form of bₖ = O(k²) (the deferred
+  sanctioned target).
+- `growthRatio_liminf_nonneg`, `HasGrowthLimit.limsup_eq`/`liminf_eq`, and the
+  converse `hasGrowthLimit_of_liminf_eq_limsup` (via
+  `tendsto_of_liminf_eq_limsup`).
+- **Headline**: `hasNoGrowthLimit_iff_liminf_lt_limsup` — for bounded ratio
+  sequences, HasNoGrowthLimit b ↔ liminf < limsup; specialized to order-2
+  bases as `IsAddBasisOfOrder.two_hasNoGrowthLimit_iff_liminf_lt_limsup`.
+
+The open dichotomy of #326 is now stated in exactly the language it concerns:
+find a sub-basis whose ratio sequence keeps a persistent liminf/limsup gap
+inside [0, C]. Filter-API notes (the reason this was deferred) recorded in the
+tracker insights.
+
+Elementary layer now COMPLETE including the limsup translation. Do not add
+further bricks; only the deep construction remains (structured blocker).

--- a/src/data/research/problems/erdos-326-wip-01.json
+++ b/src/data/research/problems/erdos-326-wip-01.json
@@ -26,8 +26,8 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-07-21T22:00:00-07:00",
-    "iteration": 4,
+    "since": "2026-07-22",
+    "iteration": 5,
     "focus": "Axiom-free foundational lemmas on IsAddBasis / IsAddBasisOfOrder / growthRatio and its limit.",
     "blockers": [
       {
@@ -36,7 +36,7 @@
         "blockedAt": "2026-07-20"
       }
     ],
-    "nextAction": "Growth-ratio limit layer now records: boundedness (b_k=O(k^2)), a two-subsequence non-convergence criterion, non-vacuity of both limit predicates, and (this session) tail-invariance of the growth limit plus sub-quadratic (linear) growth => limit 0. Only the deep oscillation dichotomy (materially new mechanism required) remains open.",
+    "nextAction": "The limsup lemma (previously the only remaining elementary increment) is DONE. Entry now fully saturated at the elementary layer; do not add further bricks. Remaining open content = the sub-basis construction achieving liminf<limsup (deep, blocked).",
     "attemptCounts": {
       "total": 2,
       "currentApproach": 1,
@@ -44,7 +44,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: growth-spectrum toolkit now has {unique,monotone,squeeze} order structure + const-scaling + non-convergence tail-invariance + two-parameter oscillating family oscPair (PR #41480, 0-axiom). Deep OPEN core: sub-basis oscillation dichotomy (materially new mechanism required).",
+    "progressSummary": "Elementary layer complete INCLUDING the limsup/liminf translation (2026-07-22): non-convergence == liminf<limsup for bounded ratios, specialized to order-2 bases (two_hasNoGrowthLimit_iff_liminf_lt_limsup); limsup form of b_k=O(k^2) landed (two_growthRatio_limsup_le). The deferred filter-API increment is done. ONLY the deep sub-basis oscillation construction remains (structured blocker, materially new mechanism required).",
     "builtItems": [
       "IsAddBasisOfOrder.mono_order / .mono_set in Erdos326WIP01.lean",
       "IsAddBasis.mono",
@@ -62,7 +62,8 @@
       "hasNoGrowthLimit_oscillating — HasNoGrowthLimit is non-vacuous: oscillating sequence has no growth limit",
       "IsAddBasisOfOrder.two_nth_le_quadratic + two_nth_le_mul_sq in Erdos326WIP01.lean: order-2 basis enumeration b_k=Nat.nth(.∈A) satisfies b_k ≤ N+(k+1)^2 and b_k ≤ (N+4)k^2 (k≥1). 0 axioms (propext/Classical.choice/Quot.sound), host-verified v4.31.0",
       "IsAddBasisOfOrder.two_growthRatio_le / two_growthRatio_mem_Icc / two_growthRatio_bddAbove in Erdos326WIP01.lean (axiom-free, host-verified v4.31.0)",
-      "hasNoGrowthLimit_of_two_subseq_limits in Erdos326WIP01.lean: two-subsequence non-convergence criterion, 0-axiom host-verified v4.31"
+      "hasNoGrowthLimit_of_two_subseq_limits in Erdos326WIP01.lean: two-subsequence non-convergence criterion, 0-axiom host-verified v4.31",
+      "limsup/liminf layer in Erdos326WIP01.lean: growthRatio_isBoundedUnder_ge, IsAddBasisOfOrder.two_growthRatio_isBoundedUnder_le (boundedness plumbing), two_growthRatio_limsup_le (limsup form of b_k=O(k^2)), growthRatio_liminf_nonneg, HasGrowthLimit.limsup_eq/liminf_eq, hasGrowthLimit_of_liminf_eq_limsup (converse), hasNoGrowthLimit_iff_liminf_lt_limsup (characterization), IsAddBasisOfOrder.two_hasNoGrowthLimit_iff_liminf_lt_limsup (order-2 specialization)"
     ],
     "insights": [
       "The basis predicates form a monotone lattice: raising the order or enlarging the set preserves the basis property — the atomic order theory underlying any basis-comparison argument.",
@@ -77,7 +78,10 @@
       "The b_k = O(k^2) growth upper bound for order-2 bases is now machine-checked axiom-free (two_nth_le_quadratic: Nat.nth (.∈A) k ≤ N + (k+1)^2; two_nth_le_mul_sq: ≤ (N+4)·k^2 for k≥1). This is the standard consequence of the √n density bound (Key Observation 1): with n = N+(k+1)^2 the density (n+1-N ≤ (|S|+1)^2) forces k < |S| ≤ count(.∈A)(n+1), so Nat.nth (.∈A) k < n+1 via Nat.nth_lt_of_lt_count. No deep input; the oscillation dichotomy stays open.",
       "growthRatio bₖ/k² of an order-2 basis enumeration (Nat.nth) is bounded above: eventually ≤ C (two_growthRatio_le), eventually in [0,C] (two_growthRatio_mem_Icc), and its full range is BddAbove (two_growthRatio_bddAbove) — the growthRatio restatement of bₖ=O(k²). First results connecting growthRatio to the real basis enumeration rather than toy sequences.",
       "hasNoGrowthLimit_of_two_subseq_limits: two strictly-monotone index subsequences of growthRatio with distinct limits ⇒ HasNoGrowthLimit. Reusable engine for the OPEN oscillation direction of #326; generalizes the ad-hoc oscillating example. Idiom: hx.comp hφ.tendsto_atTop (subsequence shares limit) + tendsto_nhds_unique.",
-      "Growth-limit functional is MONOTONE (HasGrowthLimit.mono), LINEAR under constant scaling (HasGrowthLimit.const_mul), and non-convergence is a TAIL INVARIANT (hasNoGrowthLimit_congr); two-parameter oscillating family oscPair c1 c2 realizes HasNoGrowthLimit for all c1!=c2 (PR #41480)."
+      "Growth-limit functional is MONOTONE (HasGrowthLimit.mono), LINEAR under constant scaling (HasGrowthLimit.const_mul), and non-convergence is a TAIL INVARIANT (hasNoGrowthLimit_congr); two-parameter oscillating family oscPair c1 c2 realizes HasNoGrowthLimit for all c1!=c2 (PR #41480).",
+      "Non-convergence of b_k/k^2 for an order-2 basis is EXACTLY liminf < limsup: ratios are bounded (two_growthRatio_le) and nonneg, so tendsto_of_liminf_eq_limsup + Tendsto.limsup_eq/liminf_eq give HasNoGrowthLimit b iff liminf(growthRatio b) < limsup(growthRatio b). The open dichotomy is now stated in the language it concerns: find a sub-basis with a persistent liminf/limsup gap inside [0, C].",
+      "Filter-API names (the earlier deferral risk, all verified v4.31): Filter.isBoundedUnder_of takes (exists b, forall x, r (u x) b); IsBoundedUnder.isCoboundedUnder_le needs (>=)-boundedness (and _ge needs <=); limsup_le_of_le/le_liminf_of_le take the cobounded side as explicit first arg (isBoundedDefault autoparam does not fire in conditionally-complete R); tendsto_of_liminf_eq_limsup takes hinf hsup then both boundedness sides.",
+      "IsBoundedUnder (<=) atTop from an eventual bound: anonymous constructor with eventually_map.mpr (eventually_atTop.mpr ...) — IsBoundedUnder unfolds to IsBounded on (map u atTop)."
     ],
     "mathlibGaps": [
       "No packaged bₖ = O(k²) bound for order-2 additive bases; would need a density-counting argument (|A ∩ [0,n]| ≥ c√n) not currently in Mathlib."


### PR DESCRIPTION
## Summary
Research session for erdos-326-wip-01 (Erdős #326, additive bases: must every order-2 basis contain a sub-basis with bₖ/k² non-convergent?).

Lands the previously-deferred **limsup/liminf layer** — the one remaining sanctioned elementary increment (deferred earlier over filter-API name risk, now resolved).

## Progress
- `growthRatio_isBoundedUnder_ge` / `IsAddBasisOfOrder.two_growthRatio_isBoundedUnder_le` — boundedness plumbing in the filter shapes the limsup API consumes
- `IsAddBasisOfOrder.two_growthRatio_limsup_le` — the limsup form of bₖ = O(k²)
- `growthRatio_liminf_nonneg`, `HasGrowthLimit.limsup_eq` / `liminf_eq`, converse `hasGrowthLimit_of_liminf_eq_limsup`
- **Headline**: `hasNoGrowthLimit_iff_liminf_lt_limsup` — for bounded ratio sequences, non-convergence is *exactly* `liminf < limsup`; specialized to order-2 bases as `IsAddBasisOfOrder.two_hasNoGrowthLimit_iff_liminf_lt_limsup`

Files: `proofs/Proofs/Erdos326WIP01.lean` (+120 lines, 9 decls), tracker JSON, knowledge.md.

## Verification
- Host-verified on v4.31: fresh `Erdos326Problem.olean`, then `lake env lean Proofs/Erdos326WIP01.lean` — exit 0, first try
- `#print axioms` on all 9 new declarations: `[propext, Classical.choice, Quot.sound]` only (0-axiom, no native_decide)

## Findings
- The open dichotomy of #326 is now stated in exactly the language it concerns: find a sub-basis whose ratio sequence keeps a persistent liminf/limsup gap inside [0, C].
- Filter-API notes recorded in tracker insights (`isBoundedDefault` autoparam does not fire in conditionally-complete ℝ — supply cobounded sides explicitly; `IsBoundedUnder.isCoboundedUnder_le` needs the ≥-bounded side).

## Status
**Outcome**: progress (elementary layer now COMPLETE including the limsup translation)
**Next Steps**: only the deep sub-basis oscillation construction remains (structured blocker, materially new mechanism required). No further elementary bricks should be added.

🤖 Generated by researcher-1
