### PR TITLE
Enrich erdos-1113: fix mislabeled Fermat/summary annotations, close section gap

### DIFF
--- a/src/data/proofs/erdos-1113/annotations.json
+++ b/src/data/proofs/erdos-1113/annotations.json
@@ -157,14 +157,14 @@
     "id": "ann-e1113-fermat",
     "proofId": "erdos-1113",
     "range": {
-      "startLine": 159,
-      "endLine": 172
+      "startLine": 144,
+      "endLine": 151
     },
     "type": "definition",
-    "title": "Connection to Fermat Primes",
-    "content": "**Fermat numbers** $F_n = 2^{2^n} + 1$. Only 5 are known to be prime: $F_0 = 3, F_1 = 5, F_2 = 17, F_3 = 257, F_4 = 65537$. $F_5 = 4294967297 = 641 \\times 6700417$ is composite (axiomatized). The **Erdos-Graham observation** (axiomatized): if ALL Sierpinski numbers have covering sets, then infinitely many Fermat primes exist. Since this is considered highly unlikely, it provides strong indirect evidence that Problem #1113 has answer YES.",
-    "mathContext": "$F_n = 2^{2^n} + 1$, $\\text{AllSierpinskiHaveCoverings} \\Rightarrow \\forall\\, N$, $\\exists\\, n > N$, $F_n$ prime. The connection arises because if $m = 1$, then $2^k \\cdot 1 + 1 = 2^k + 1$, and the prime values are exactly the Fermat primes.",
-    "significance": "key",
+    "title": "Fermat Numbers and Fermat Primes",
+    "content": "**FermatNumber** $F_n = 2^{2^n} + 1$ and **IsFermatPrime** ($F_n$ prime). Only 5 Fermat numbers are known to be prime: $F_0 = 3, F_1 = 5, F_2 = 17, F_3 = 257, F_4 = 65537$; $F_5 = 4294967297 = 641 \\times 6700417$ is composite, and no further Fermat prime has ever been found despite extensive search. Neither $F_5$'s factorization nor the Erdos-Graham observation linking universal covering to Fermat-prime infinitude is stated as a Lean declaration in this file (both were among the axioms removed in a prior fix -- see `assumptions`); only the two definitions themselves are formalized here.",
+    "mathContext": "$F_n = 2^{2^n} + 1$, $\\text{IsFermatPrime}(n) \\Leftrightarrow \\text{Nat.Prime}(F_n)$. Setting $m = 1$ in the Sierpinski sequence gives $2^k \\cdot 1 + 1 = 2^k + 1$, whose prime values are exactly the Fermat primes -- the reason Problem #1113 connects to Fermat's conjecture at all.",
+    "significance": "supporting",
     "relatedConcepts": [
       "fermat-number",
       "fermat-prime",
@@ -174,6 +174,29 @@
       "sierpinski-number",
       "covering-set",
       "prime-numbers"
+    ]
+  },
+  {
+    "id": "ann-e1113-summary",
+    "proofId": "erdos-1113",
+    "range": {
+      "startLine": 154,
+      "endLine": 175
+    },
+    "type": "theorem",
+    "title": "Summary Theorem: Combining the Evidence",
+    "content": "**erdos_1113_summary** is the file's capstone result: a single verified conjunction of `izotov_is_sierpinski` (the axiom), `izotov_is_power`, and `ffk_consistent_with_izotov`, packaging every piece of evidence for Problem #1113 into one theorem. It does not resolve the open problem -- it certifies that all the assembled evidence (Izotov's candidate is Sierpinski *and* a perfect power, and this is consistent with FFK) is jointly consistent, which is the strongest statement this formalization can make about a genuinely open question.",
+    "mathContext": "$\\text{IsSierpinskiNumber}(m_{\\text{Izotov}}) \\wedge \\text{IsPerfectPower}(m_{\\text{Izotov}}) \\wedge (\\text{FFKConjecture} \\Rightarrow \\text{IsPerfectPower}(m_{\\text{Izotov}}) \\vee \\text{HasFiniteCoveringSet}(m_{\\text{Izotov}}))$, proved by the anonymous constructor $\\langle \\text{izotov\\_is\\_sierpinski}, \\text{izotov\\_is\\_power}, \\text{ffk\\_consistent\\_with\\_izotov} \\rangle$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "izotov-candidate",
+      "ffk-conjecture",
+      "conjunctive-summary"
+    ],
+    "prerequisites": [
+      "izotov-is-sierpinski axiom",
+      "izotov-is-power",
+      "ffk-consistent-with-izotov"
     ]
   }
 ]

--- a/src/data/proofs/erdos-1113/meta.json
+++ b/src/data/proofs/erdos-1113/meta.json
@@ -144,6 +144,14 @@
       "startLine": 144,
       "endLine": 151,
       "mathContext": "Defines `FermatNumber` ($F_n = 2^{2^n} + 1$) and `IsFermatPrime`. No specific Fermat-prime facts (e.g. $F_5$'s factorization $641 \\times 6700417$) or an Erdos-Graham connection are formalized as Lean declarations in this file; these were among the axioms removed in a prior fix (see `assumptions`)."
+    },
+    {
+      "id": "summary-theorem",
+      "title": "Summary Theorem (Parts IX-X)",
+      "summary": "Part IX is an empty section header (the FFK simultaneous-compositeness power result is not formalized). Part X proves `erdos_1113_summary`, the file's capstone: a single verified conjunction of `izotov_is_sierpinski`, `izotov_is_power`, and `ffk_consistent_with_izotov`, packaging all the assembled evidence for Problem #1113 into one result without resolving the open question.",
+      "startLine": 152,
+      "endLine": 175,
+      "mathContext": "$\\text{IsSierpinskiNumber}(m_{\\text{Izotov}}) \\wedge \\text{IsPerfectPower}(m_{\\text{Izotov}}) \\wedge (\\text{FFKConjecture} \\Rightarrow \\text{IsPerfectPower}(m_{\\text{Izotov}}) \\vee \\text{HasFiniteCoveringSet}(m_{\\text{Izotov}}))$, proved via the anonymous constructor combining the three prior results."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

`erdos-1113` (Sierpinski numbers without covering sets) had two real defects
rather than shallow filler gaps:

- **Mislabeled annotation ranges**: `ann-e1113-ffk` (range 135-154, titled "FFK
  Conjecture and Power Result") silently covered the `FermatNumber`/
  `IsFermatPrime` definitions (lines 144-151, Part VIII) without mentioning
  them. Meanwhile `ann-e1113-fermat` (titled "Connection to Fermat Primes")
  pointed at lines 159-172 — the `erdos_1113_summary` capstone theorem — not
  the Fermat definitions its content actually describes. Retargeted
  `ann-e1113-fermat` to the correct Fermat-definition lines (144-151).
- **Missing section for the capstone theorem**: the `sections` array ended at
  line 151, leaving Part IX (empty header) and Part X (the verified
  `erdos_1113_summary` theorem, lines 152-175) with no dedicated section. Added
  a `summary-theorem` section (152-175) and a matching `ann-e1113-summary`
  annotation describing what the theorem actually certifies (a consistency
  conjunction, not a resolution of the open problem).

Verified against the Lean source (`proofs/Proofs/Erdos1113Problem.lean`,
175 lines, 0 sorries, 1 axiom) line-by-line before making changes. `meta.json`
and `annotations.json` both stay well under the size caps (19.2 KB / 10.9 KB).
Quality score (`find-targets.ts`) moves 96 → 100.

## Test plan

- [x] `python3 -c "json.load(...)"` on both files — valid JSON
- [x] `npx tsx scripts/enricher/find-targets.ts --json` — erdos-1113 quality 100/100
- [x] Manually cross-checked every annotation/section line range against the Lean file

🤖 Generated with [Claude Code](https://claude.com/claude-code)