### PR TITLE
Audit: feuerbachs-theorem-oq-01 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -18792,9 +18792,9 @@
       "result": "clean"
     },
     "feuerbachs-theorem-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:30Z",
+      "lastAudited": "2026-07-22T17:46:10Z",
       "result": "clean"
     },
     "feuerbachs-theorem-oq-02": {


### PR DESCRIPTION
## Audit Result: CLEAN

**Proof**: feuerbachs-theorem-oq-01

Verified all claimed counts against `Proofs/FeuerbachsTheoremOQ01.lean`:
- 0 axioms, 0 sorries, 103 theorems, 2 defs — exact match with meta.json
- No `native_decide` usage
- No `True`-stub placeholders
- All 16 declarations named in `mainTheorems` exist in the file (grep-verified)
- Parent `feuerbachs-theorem` genuinely `import`s `FeuerbachsTheoremOQ01` and is
  itself 0-axiom — consistent with the claim that this file discharges all 8
  parent axioms
- `additionalFiles` (FeuerbachsTheoremDefs.lean, FeuerbachsTheoremOQ01Aristotle.lean,
  FeuerbachsTheoremOQ01OQ03.lean) have no hidden sorries/axioms — the one `sorry`
  grep hit in the Aristotle file is inside a docstring ("use theorem ... := by
  sorry instead"), not a real declaration

No integrity issues found.

---
Discovered during gallery integrity audit.