### PR TITLE
Audit: erdos-493 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14068,9 +14068,9 @@
       "result": "clean"
     },
     "erdos-493": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:30Z",
+      "lastAudited": "2026-07-22T17:47:40Z",
       "result": "clean"
     },
     "erdos-494": {


### PR DESCRIPTION
## Audit Result: CLEAN

**Proof**: erdos-493 (Product Minus Sum Representation)

Verified all claimed counts against `Proofs/Erdos493Problem.lean`:
- 0 axioms, 0 sorries, 4 theorems, 2 defs — exact match with meta.json
- No `native_decide` usage
- `erdos_493` has the correct existential-threshold shape
  `∃ k, ∃ N₀, ∀ n ≥ N₀, HasProdMinusSumK n k` — not a false unconditional
  `∀ n` bound
- All `originalContributions` decls (HasProdMinusSum2, HasProdMinusSumK,
  prod_minus_sum_identity, erdos_493_nonneg, erdos_493_sufficiently_large,
  erdos_493, three examples) verified present

No integrity issues found.

---
Discovered during gallery integrity audit.