### PR TITLE
Audit: erdos-249 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11992,9 +11992,9 @@
       "note": "2026-07-09 audit CLEAN: 9 native_decide all on trivial small-number facts (omega(6)=2, omega(1+k)<=2k); substantive erdos_248 is an axiom, so no ofReduceBool disclosure required."
     },
     "erdos-249": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:30Z",
+      "lastAudited": "2026-07-22T17:48:42Z",
       "result": "clean"
     },
     "erdos-249-oq-01": {


### PR DESCRIPTION
## Audit Result: CLEAN

**Proof**: erdos-249 (Irrationality of Totient Power Sum, OPEN)

Verified against `Proofs/Erdos249Problem.lean`:
- 0 axioms, 0 sorries, 13 theorems, 4 defs — exact match with meta.json
- No `native_decide` usage
- `erdos_249 : Prop := Irrational totientPowerSum` is a stated, unproved
  definition — genuinely open, not assumed as an axiom
- Convergence, positivity, and upper-bound lemmas are all fully proved from
  Mathlib (comparison test + `hasSum_coe_mul_geometric_of_norm_lt_one`)
- Prose (status: axiomatized/badge: wip/assumptions) consistently discloses
  the open status; no overclaiming

No integrity issues found.

---
Discovered during gallery integrity audit.