### PR TITLE
Audit: desargues-theorem-oq-04 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7344,9 +7344,9 @@
       "result": "clean"
     },
     "desargues-theorem-oq-04": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:30Z",
+      "lastAudited": "2026-07-22T17:49:50Z",
       "result": "clean"
     },
     "descartes-circle-theorem-oq-01": {


### PR DESCRIPTION
## Audit Result: CLEAN

**Proof**: desargues-theorem-oq-04 (Self-Duality of Desargues's Theorem)

Verified against `Proofs/DesarguesTheoremOQ04.lean`:
- 0 axioms, 0 sorries, 23 theorems, 10 defs (9 `def` + 1 `structure`) —
  exact match with meta.json
- No `native_decide` usage
- Both headline `rfl` claims verified to actually be proved by `rfl`:
  `collinear_eq_concurrent` and `dual_perspFromPoint_eq_perspFromLine`
- All 10 named `originalContributions` declarations present and correctly
  described

No integrity issues found.

---
Discovered during gallery integrity audit.