### PR TITLE
audit: re-serve cauchy-schwarz-integral-oq-01-oq-01 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4663,9 +4663,9 @@
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-01-oq-01": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:31Z",
+      "lastAudited": "2026-07-22T18:01:34Z",
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-01-oq-01-oq-01": {


### PR DESCRIPTION
## Audit Result: CLEAN

**Proof**: cauchy-schwarz-integral-oq-01-oq-01 (Hölder's Inequality in eLpNorm Form)
**Badge**: mathlib | **Status**: verified

## Verification

- Counts match exactly: 10 theorems, 0 axioms, 0 sorries, 0 definitions, 153 lines — confirmed by direct grep/wc against `proofs/Proofs/CauchySchwarzIntegralOQ01OQ01.lean`.
- No `native_decide` / `Lean.ofReduceBool` usage.
- No True-stub placeholders.
- `originalContributions` (cauchy_schwarz_lintegral, minkowski_eLpNorm, l2_cauchy_schwarz, minkowski_l2_from_cs, young_two) all resolve to real declarations in the file — no phantom decls.
- `mathlibDependencies` (ENNReal.lintegral_mul_le_Lp_mul_Lq, eLpNorm_add_le, abs_real_inner_le_norm, NNReal.young_inequality) all match actual lemma calls in the source.
- Prose is properly scoped for a Tier B Mathlib-wrapper: description leads with "Formalizes ... using Mathlib 4.26+ eLpNorm API", no "first formalization"/"independent proof" language, `minkowski_l2_from_cs` is a genuine derivation (norm-squared identity + nlinarith), not just a relabeled Mathlib call.

No changes needed — tracker re-persisted only (auditCount 5→6).

---
Discovered during gallery integrity audit (reserve mode, queue drained 0/4809 unaudited).