### PR TITLE
Enrich chebyshev-pnt-bridge-oq-06-oq-02: split checks section, add Rosser's-theorem insight

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-02/meta.json
@@ -83,7 +83,8 @@
       "The identity π(Nat.nth Prime n) = n + 1 is the precise bridge that lets a bound on the counting function π be re-read as a bound on the n-th prime — π' counts primes strictly below, so the +1 comes from pₙ being prime itself",
       "A bound π(m) ≤ C·m/log m on the counting function inverts to a lower bound pₙ ≳ (1/C)·n·log n on the n-th prime; the upper density constant 2 log 4 of Chebyshev becomes the denominator 4 log 4 of the prime growth",
       "The √pₙ tail in the OQ-06 bound, a nuisance for the density reading, is harmless here: log(√pₙ) ≤ √pₙ and log 4 ≥ 1 give √pₙ·log(√pₙ) ≤ pₙ·log 4, so the tail merely doubles the leading term",
-      "The result is genuinely sharper than Mathlib's Nat.add_two_le_nth_prime (pₙ ≥ n + 2): it supplies the extra log(n+2) factor, recovering the correct n·log n order of magnitude rather than mere linear growth"
+      "The result is genuinely sharper than Mathlib's Nat.add_two_le_nth_prime (pₙ ≥ n + 2): it supplies the extra log(n+2) factor, recovering the correct n·log n order of magnitude rather than mere linear growth",
+      "The constant 1/(4 log 4) ≈ 0.18 recovered here is far from the classical sharp result: Rosser's theorem (1939) shows pₙ > n·ln n for every n ≥ 1 by a more careful elementary argument, and the Prime Number Theorem gives the exact asymptotic pₙ/(n log n) → 1 — this entry's contribution is the correct n·log n order via the shortest possible route from the Chebyshev density already on hand, not the sharpest constant"
     ],
     "prerequisites": [
       "the prime-counting function π, π', and the n-th prime Nat.nth Nat.Prime",
@@ -117,8 +118,15 @@
       "id": "nth-prime-bound",
       "title": "The n·log n lower bound on the n-th prime",
       "startLine": 86,
+      "endLine": 153,
+      "summary": "nth_prime_lower_bound: read OQ-06 at m = pₙ, absorb the √pₙ correction, substitute the log bracket and pₙ ≥ n+2, yielding pₙ ≥ (n+1)·(½·log(n+2) − log 2)/(2·log 4)."
+    },
+    {
+      "id": "checks",
+      "title": "Verification and closing",
+      "startLine": 155,
       "endLine": 158,
-      "summary": "nth_prime_lower_bound: read OQ-06 at m = pₙ, absorb the √pₙ correction, substitute the log bracket and pₙ ≥ n+2, yielding pₙ ≥ (n+1)·(½·log(n+2) − log 2)/(2·log 4); closes with the #check sanity lines and the namespace end."
+      "summary": "#check sanity lines recording the two exported signatures (primeCounting_nth_prime and nth_prime_lower_bound), and the namespace end."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Targeted enrichment pass on `chebyshev-pnt-bridge-oq-06-oq-02` (quality score 96/100, never previously enriched). Same pattern as the sibling `chebyshev-pnt-bridge-oq-06-oq-01` (#41596): the entry was already substantively complete — 0 axioms, 0 sorries, full annotation coverage — so this closes the two remaining genuine gaps rather than adding filler.

- **Split the trailing `nth-prime-bound` section** (86–158) into `nth-prime-bound` (86–153, the theorem itself) and `checks` (155–158, the `#check` sanity lines + namespace end), matching the section boundary the `annotations.json` already uses (`ann-nth-prime-bound` 86–153, `ann-checks` 155–157) — `sections` in `meta.json` had fallen a step behind the finer-grained annotation split.
- **Added a 5th `keyInsight`** contextualizing the recovered constant `1/(4 log 4) ≈ 0.18` against the classical sharp result: Rosser's theorem (1939) proves `pₙ > n·ln n` for every `n ≥ 1` by a more careful elementary argument, and the Prime Number Theorem gives the exact asymptotic `pₙ/(n log n) → 1`. Clarifies that this entry's contribution is the correct order of growth via the shortest route from the Chebyshev density already on hand, not the sharpest constant.

No changes to axiom/sorry/status fields — those were already accurate. `meta.json` stays well under the 60 KB cap (15.3 KB).

## Test plan
- [x] Verified against `proofs/Proofs/ChebyshevPNTBridgeOQ06OQ02.lean` line-by-line (theorem names, line ranges, imports all match)
- [x] `pnpm build` passes (gallery data validation + bundle budget check)
- [x] JSON structure validated (`python3 -c "json.load(...)"`)
