### PR TITLE
audit: fix phantom declarations in erdos-34 (Consecutive Sums)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12747,9 +12747,9 @@
     },
     "erdos-34": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:02:32Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-22T18:08:11Z",
+      "result": "issues-fixed"
     },
     "erdos-340": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-34/annotations.json
+++ b/src/data/proofs/erdos-34/annotations.json
@@ -94,11 +94,10 @@
     },
     "type": "concept",
     "title": "The Disproved Conjecture",
-    "content": "**ErdosConjecture** states: For all epsilon > 0, there exists N such that for all n > N and all pi in S_n, S(pi) < epsilon * n^2.\n\n**erdos_34_disproved** asserts this is FALSE.\n\nCounterexamples exist with S(pi) >= cn^2 for constant c > 0 (specifically c >= 1/4).",
+    "content": "**ErdosConjecture** states: For all epsilon > 0, there exists N such that for all n > N and all pi in S_n, S(pi) < epsilon * n^2.\n\nThis is FALSE, as documented in the file's comments: counterexamples exist with S(pi) >= cn^2 for constant c > 0 (specifically c >= 1/4). NOTE: the falsity of ErdosConjecture is not formalized as a Lean declaration in this file -- it is recorded only in prose comments.",
     "mathContext": "The little-o notation S(pi) = o(n^2) means S(pi)/n^2 -> 0 as n -> infinity.",
     "significance": "key",
     "relatedConcepts": [
-      "axiom",
       "counterexample",
       "asymptotic"
     ],
@@ -123,11 +122,10 @@
     },
     "type": "concept",
     "title": "Hegyvari's Counterexample (1986)",
-    "content": "**hegyvari_counterexample** states there exist permutations with S(pi) >= (1/18 + o(1))n^2.\n\nThis was the FIRST counterexample to Erdos's conjecture.\n\n1/18 ~ 0.056 shows the conjecture fails by a constant factor.",
+    "content": "A comment documents that there exist permutations with S(pi) >= (1/18 + o(1))n^2 (Hegyvari, 1986).\n\nThis was the FIRST counterexample to Erdos's conjecture.\n\n1/18 ~ 0.056 shows the conjecture fails by a constant factor. NOTE: this bound is not formalized as a Lean declaration -- it is documentation only.",
     "mathContext": "Hegyvari's construction is explicit but the 1/18 constant was later improved dramatically.",
     "significance": "key",
     "relatedConcepts": [
-      "axiom",
       "hegyvari",
       "first-counterexample"
     ],
@@ -151,11 +149,10 @@
     },
     "type": "concept",
     "title": "Konieczny's Quarter Bound (2015)",
-    "content": "**konieczny_quarter_bound** states there exist permutations with S(pi) >= n^2/4.\n\nThis shows the conjecture is 'extremely false' - not just failing by a small constant, but by a factor of 1/4.\n\nSince max possible is ~n^2/2 pairs, this is nearly half the theoretical maximum!",
+    "content": "A comment documents that there exist permutations with S(pi) >= n^2/4 (Konieczny, 2015).\n\nThis shows the conjecture is 'extremely false' - not just failing by a small constant, but by a factor of 1/4.\n\nSince max possible is ~n^2/2 pairs, this is nearly half the theoretical maximum! NOTE: this bound is not formalized as a Lean declaration -- it is documentation only.",
     "mathContext": "1/4 = 0.25, compared to Hegyvari's 1/18 ~ 0.056 - a 4.5x improvement.",
     "significance": "key",
     "relatedConcepts": [
-      "axiom",
       "konieczny",
       "optimal-bound"
     ],
@@ -180,7 +177,7 @@
     },
     "type": "concept",
     "title": "Bounds on Maximum f(n)",
-    "content": "**f_lower_bound**: f(n) >= 0.286 * n^2\n**f_upper_bound**: f(n) <= 0.446 * n^2\n\nwhere f(n) = max_{pi} S(pi).\n\nThe gap [0.286, 0.446] shows the exact maximum is not yet known.",
+    "content": "Comments document: f(n) >= 0.286 * n^2 and f(n) <= 0.446 * n^2, where f(n) = max_{pi} S(pi).\n\nThe gap [0.286, 0.446] shows the exact maximum is not yet known. NOTE: neither bound is formalized as a Lean declaration -- both are documentation only.",
     "mathContext": "These bounds from Konieczny (2015) leave room for improvement.",
     "significance": "key",
     "relatedConcepts": [
@@ -209,7 +206,7 @@
     },
     "type": "concept",
     "title": "Random Permutation Behavior",
-    "content": "**random_permutation_limit** states that for a random permutation,\n\nS(pi) ~ (1 + e^-2)/4 * n^2 ~ 0.2838 * n^2\n\nThis shows most permutations violate the conjecture by the same amount as worst-case constructions!",
+    "content": "A comment documents that for a random permutation,\n\nS(pi) ~ (1 + e^-2)/4 * n^2 ~ 0.2838 * n^2\n\nThis shows most permutations violate the conjecture by the same amount as worst-case constructions! NOTE: this asymptotic is not formalized as a Lean declaration -- it is documentation only.",
     "mathContext": "e^-2 ~ 0.135, so (1 + e^-2)/4 ~ 0.2838. Almost identical to the lower bound 0.286.",
     "significance": "key",
     "relatedConcepts": [
@@ -238,7 +235,7 @@
     },
     "type": "concept",
     "title": "The Identity Permutation is Special",
-    "content": "**identity_is_little_o** states S(iota) = o(n^2) for the identity permutation.\n\nFor iota(i) = i, consecutive sums are arithmetic progressions: sum_{i=u}^v i = (v-u+1)(u+v)/2.\n\nThe number of distinct such sums is O(n^1.5), not Theta(n^2).\n\nThis special case motivated Erdos's (false) conjecture.",
+    "content": "A comment documents that S(iota) = o(n^2) for the identity permutation.\n\nFor iota(i) = i, consecutive sums are arithmetic progressions: sum_{i=u}^v i = (v-u+1)(u+v)/2.\n\nThe number of distinct such sums is O(n^1.5), not Theta(n^2).\n\nThis special case motivated Erdos's (false) conjecture. NOTE: this o(n^2) property is not formalized as a Lean declaration -- it is documentation only (the file defines identityPerm but proves no theorem about its S-value).",
     "mathContext": "Identity has fewer distinct sums because arithmetic progression sums have algebraic structure.",
     "significance": "key",
     "relatedConcepts": [
@@ -267,7 +264,7 @@
     },
     "type": "concept",
     "title": "Minimum Bounds g(n)",
-    "content": "**g_lower_bound**: g(n) >= c * n^(3/2) for some c > 0.\n\n**MinimumConjecture**: Is g(n) >= n^(2-o(1))? (conjectured)\n\nwhere g(n) = min_{pi} S(pi).\n\nEven the minimum is superlinear - every permutation has many distinct consecutive sums.",
+    "content": "A comment documents that g(n) >= c * n^(3/2) for some c > 0 (not formalized as a Lean declaration).\n\n**MinimumConjecture** (a formal def in this file) asks: Is g(n) >= n^(2-o(1))? (conjectured, open)\n\nwhere g(n) = min_{pi} S(pi).\n\nEven the minimum is superlinear - every permutation has many distinct consecutive sums.",
     "mathContext": "The gap between n^1.5 (known) and n^(2-o(1)) (conjectured) is significant.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-34/meta.json
+++ b/src/data/proofs/erdos-34/meta.json
@@ -15,7 +15,7 @@
       "permutations",
       "disproved"
     ],
-    "badge": "original",
+    "badge": "infrastructure",
     "sorries": 0,
     "erdosNumber": 34,
     "erdosUrl": "https://erdosproblems.com/34",
@@ -40,12 +40,10 @@
       }
     ],
     "originalContributions": [
-      "Formal definition of consecutive sums S(pi)",
-      "Statement of the disproved conjecture",
-      "Hegyvari's first counterexample (1/18 bound)",
-      "Konieczny's n^2/4 bound",
-      "Bounds on max/min f(n), g(n)",
-      "Identity permutation satisfies o(n^2)"
+      "Formal definitions of consecutiveSum, S(pi), f(n), g(n)",
+      "Statement of ErdosConjecture and MinimumConjecture as formal Props",
+      "Proof that S(pi) <= n^2 (trivial cardinality bound)",
+      "Proof that every consecutive sum is positive"
     ],
     "axiomCount": 0,
     "prerequisites": [
@@ -56,7 +54,7 @@
       "Cardinality of finite sets"
     ],
     "lineCount": 209,
-    "assumptions": "0 axioms, 0 sorries. All stated theorems fully proved.",
+    "assumptions": "0 axioms, 0 sorries. The 2 stated theorems (a trivial S(pi) <= n^2 cardinality bound and consecutive-sum positivity) are fully proved. The historical disproof itself -- Hegyvari's (1986) and Konieczny's (2015) counterexample bounds, the random-permutation asymptotic, and the identity permutation's o(n^2) property -- is documented in comments for context only; none of it is formalized as a Lean axiom, theorem, or def.",
     "theoremCount": 2,
     "definitionCount": 9
   },
@@ -64,7 +62,7 @@
     "historicalContext": "For a permutation π of {1,...,n}, the consecutive sums ∑_{i=u}^{v} π(i) range over O(n²) possible values (there are n(n+1)/2 intervals [u,v]). The quantity S(π) — the number of distinct values among these sums — measures how 'spread out' the sums are.\n\nErdős observed that the identity permutation has S(id) = o(n²) because its consecutive sums form arithmetic progressions with many coincidences. He conjectured this holds for ALL permutations — one of his rare spectacularly wrong conjectures.\n\nHegyvári (1986) gave the first counterexample, constructing a permutation with S(π) ≥ n²/18. Konieczny (2015) showed the conjecture is 'extremely false': there exist permutations achieving S(π) ≥ n²/4, which is asymptotically optimal since S(π) ≤ n²/2 trivially. The maximum f(n) = max_π S(π) satisfies 0.286n² ≤ f(n) ≤ 0.446n², with the lower bound coming from random permutations: for a random π, S(π) ∼ (1 + e⁻²)/4 · n² ≈ 0.284n². The connection to random permutations suggests that most permutations are far from Erdős's conjecture.",
     "problemStatement": "**Erdos Problem #34 (DISPROVED)**\n\nFor a permutation $\\pi \\in S_n$, let $S(\\pi)$ count distinct consecutive sums $\\sum_{i=u}^v \\pi(i)$.\n\n**Erdos's Conjecture**: $S(\\pi) = o(n^2)$ for all $\\pi$.\n\n**Disproof**:\n- Hegyvari (1986): $S(\\pi) \\geq \\frac{1}{18}n^2$ exists\n- Konieczny (2015): $S(\\pi) \\geq \\frac{n^2}{4}$ exists\n\n**Bounds**: $0.286n^2 \\leq f(n) \\leq 0.446n^2$ where $f(n) = \\max_\\pi S(\\pi)$",
     "text": "Is S(pi) = o(n^2) for all permutations? DISPROVED - there exist permutations with S(pi) >= n^2/4.",
-    "proofStrategy": "We formalize:\n\n1. **consecutiveSum**: Sum from position u to v\n2. **S(pi)**: Count of distinct consecutive sums\n3. **ErdosConjecture**: The (false) statement S(pi) = o(n^2) for all pi\n4. **erdos_34_disproved**: Axiom stating the conjecture is false\n5. **Bounds**: Hegyvari, Konieczny, and random permutation results",
+    "proofStrategy": "We formalize the definitions (consecutiveSum, S, f, g, ErdosConjecture, MinimumConjecture, identityPerm) and prove two supporting facts: S(pi) <= n^2 (trivial cardinality bound) and every consecutive sum is positive. The historical disproof of Erdos's conjecture -- Hegyvari's (1986) 1/18 bound, Konieczny's (2015) n^2/4 bound, the random-permutation asymptotic, and the identity permutation's o(n^2) property -- is recorded in comments for context but is NOT formalized: no axiom, theorem, or def in this file encodes any of these bounds.",
     "keyInsights": [
       "**Identity is special**: S(iota) = o(n^2) because consecutive sums form arithmetic progressions with limited distinct values.",
       "**Most permutations are not special**: Random permutations have S(pi) ~ 0.284n^2, far from o(n^2).",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-34 (Erdos Problem #34: Consecutive Sums in Permutations)
**Problem**: `meta.json`'s `proofStrategy`/`originalContributions` and `annotations.json` reference fabricated Lean declarations that do not exist in `Proofs/Erdos34Problem.lean`.

## Evidence

**meta.json claimed**: `proofStrategy` item 4 said "**erdos_34_disproved**: Axiom stating the conjecture is false", and item 5 claimed "Bounds: Hegyvari, Konieczny, and random permutation results" were formalized. `originalContributions` listed "Hegyvari's first counterexample (1/18 bound)", "Konieczny's n^2/4 bound", "Bounds on max/min f(n), g(n)", and "Identity permutation satisfies o(n^2)" as contributions. `annotations.json` named 7 more phantom declarations (`hegyvari_counterexample`, `konieczny_quarter_bound`, `f_lower_bound`, `f_upper_bound`, `random_permutation_limit`, `identity_is_little_o`, `g_lower_bound`) and tagged several with `relatedConcepts: ["axiom", ...]`.

**Lean file shows**: `grep -n "^axiom"` returns nothing — the file has **0 axiom declarations**. None of the above 8 names appear anywhere in the file. The actual content is: definitions (`consecutiveSum`, `S`, `f`, `g`, `ErdosConjecture`, `identityPerm`, `MinimumConjecture`, `Perm`) plus exactly 2 proved theorems — `S_upper_bound` (trivial `S n π ≤ n * n` cardinality bound) and `consecutiveSum_pos` (positivity). The historical disproof itself (Hegyvári 1986, Konieczny 2015, the random-permutation asymptotic, the identity permutation's `o(n²)` property) exists **only as prose comments** (lines 104-129, 140-146, 152-162) — never as an axiom, theorem, or def.

## Fix Applied

- `meta.json`: rewrote `proofStrategy` to honestly describe what's formalized (definitions + 2 trivial lemmas) vs. what's documentation-only (the historical bounds); trimmed `originalContributions` to the 4 real items; clarified `assumptions`; downgraded `badge` from `original` to `infrastructure` (Tier D — definitions + minor supporting lemmas, not a theorem-level disproof).
- `annotations.json`: reworded the 7 annotations that named phantom declarations to describe them as documentation/comments rather than Lean declarations, and dropped the misleading `"axiom"` tag from `relatedConcepts`.

Discovered during gallery integrity audit.