### PR TITLE
fix(daemon): run missing-agent detection during total-pool blackout (#41509)

### DIFF
--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -1493,6 +1493,67 @@ write_missing_agents() {
     fi
 }
 
+# Helper: Persistent-missing-session detection & alerting (#39652, #41509).
+# Tracks how many CONSECUTIVE cycles each CONFIGURED agent has stayed below
+# target; once the count crosses MISSING_SESSION_ALERT_CYCLES it escalates to a
+# WARN and persists a MISSING record (via write_missing_agents) that
+# /lean health & /lean status render as a red row instead of silently omitting
+# the agent. Live counts come from count_agent_sessions so this is a single
+# source of truth and can run in BOTH the normal daemon cycle AND the total-pool
+# blackout path where get_all_agent_sessions is empty (#41509 -- otherwise the
+# blackout early-continues before detection and /lean status stays empty).
+# Args, in order:
+#   enricher researcher aristotle auditor seeker deployer herald mechanic tester
+detect_and_persist_missing_agents() {
+    local enricher="$1" researcher="$2" aristotle="$3" auditor="$4" \
+          seeker="$5" deployer="$6" herald="$7" mechanic="$8" tester="$9"
+    local missing_json="[]"
+    local mtype mtarget mactive mcycles
+    for _pair in \
+        "enricher $enricher" \
+        "researcher $researcher" \
+        "aristotle $aristotle" \
+        "auditor $auditor" \
+        "seeker $seeker" \
+        "deployer $deployer" \
+        "herald $herald" \
+        "mechanic $mechanic" \
+        "tester $tester"; do
+        read -r mtype mtarget <<< "$_pair"
+
+        # Only configured agents (target >= 1) can be "missing".
+        if [[ "$mtarget" -lt 1 ]]; then
+            set_missing_cycles "$mtype" 0
+            continue
+        fi
+
+        # Aristotle scale-to-zero (issue #22471) is an intentional absence,
+        # not a failed launch -- don't false-alarm on it.
+        if [[ "$mtype" == "aristotle" ]] && [[ -f "$ARISTOTLE_SCALED_MARKER" ]]; then
+            set_missing_cycles "$mtype" 0
+            continue
+        fi
+
+        mactive=$(count_agent_sessions "$mtype")
+        if [[ "$mactive" -lt "$mtarget" ]]; then
+            mcycles=$(get_missing_cycles "$mtype")
+            mcycles=$((mcycles + 1))
+            set_missing_cycles "$mtype" "$mcycles"
+            if [[ "$mcycles" -ge "$MISSING_SESSION_ALERT_CYCLES" ]]; then
+                daemon_log "WARN" "Agent '$mtype' MISSING: configured=$mtarget running=$mactive for $mcycles consecutive cycles (respawn attempted, session still absent)"
+                missing_json=$(echo "$missing_json" | jq -c \
+                    --arg t "$mtype" --argjson cfg "$mtarget" \
+                    --argjson run "$mactive" --argjson cyc "$mcycles" \
+                    '. += [{type: $t, configured: $cfg, running: $run, missing_cycles: $cyc}]' \
+                    2>/dev/null || echo "$missing_json")
+            fi
+        else
+            set_missing_cycles "$mtype" 0
+        fi
+    done
+    write_missing_agents "$missing_json"
+}
+
 # Helper: Daemon log with timestamp
 daemon_log() {
     local level="$1"
@@ -2348,12 +2409,41 @@ cmd_daemon() {
             break
         fi
 
+        # Re-read target config from state file each cycle, then apply the
+        # time-based schedule. Done BEFORE the health check so both the normal
+        # path and the total-blackout early-continue (#41509) see the same
+        # scheduled targets -- otherwise a scheduled scale-to-zero during a
+        # blackout would false-alarm on stale config.
+        # (This ensures scale-down / stop commands are respected without a
+        # daemon restart.)
+        if [[ -f "$STATE_FILE" ]]; then
+            enricher=$(jq -r '.config.enricher // 0' "$STATE_FILE" 2>/dev/null || echo "$enricher")
+            aristotle=$(jq -r '.config.aristotle // 0' "$STATE_FILE" 2>/dev/null || echo "$aristotle")
+            researcher=$(jq -r '.config.researcher // 0' "$STATE_FILE" 2>/dev/null || echo "$researcher")
+            seeker=$(jq -r '.config.seeker // 0' "$STATE_FILE" 2>/dev/null || echo "$seeker")
+            auditor=$(jq -r '.config.auditor // 0' "$STATE_FILE" 2>/dev/null || echo "$auditor")
+            deployer=$(jq -r '.config.deployer // 0' "$STATE_FILE" 2>/dev/null || echo "$deployer")
+            herald=$(jq -r '.config.herald // 0' "$STATE_FILE" 2>/dev/null || echo "$herald")
+            mechanic=$(jq -r '.config.mechanic // 0' "$STATE_FILE" 2>/dev/null || echo "$mechanic")
+        fi
+
+        # Apply time-based schedule overrides
+        apply_schedule
+
         # 2. Health check all agent sessions
         local sessions
         sessions=$(get_all_agent_sessions)
 
         if [[ -z "$sessions" ]]; then
             daemon_log "WARN" "No agent sessions found, cycle $cycle_count"
+            # Total-pool blackout (#41509): the health-check / pool-gap / respawn
+            # logic below is intentionally skipped when there are zero sessions,
+            # but persistent-missing detection must still fire so .missing_agents
+            # is persisted and /lean status shows MISSING rows (not just the live
+            # /lean health view). Reuse the same helper as the normal path.
+            detect_and_persist_missing_agents \
+                "$enricher" "$researcher" "$aristotle" "$auditor" \
+                "$seeker" "$deployer" "$herald" "$mechanic" "$tester"
             update_daemon_state "$cycle_count" "$total_respawns"
             continue
         fi
@@ -2468,24 +2558,9 @@ cmd_daemon() {
 
         # 2b. Pool gap detection: spawn missing agents whose sessions vanished
         # (get_all_agent_sessions only returns existing sessions, so if a session
-        # exits entirely, the health check above never sees it)
-
-        # Re-read target config from state file each cycle.
-        # This ensures scale-down / stop commands are respected by the daemon
-        # without needing to restart it.
-        if [[ -f "$STATE_FILE" ]]; then
-            enricher=$(jq -r '.config.enricher // 0' "$STATE_FILE" 2>/dev/null || echo "$enricher")
-            aristotle=$(jq -r '.config.aristotle // 0' "$STATE_FILE" 2>/dev/null || echo "$aristotle")
-            researcher=$(jq -r '.config.researcher // 0' "$STATE_FILE" 2>/dev/null || echo "$researcher")
-            seeker=$(jq -r '.config.seeker // 0' "$STATE_FILE" 2>/dev/null || echo "$seeker")
-            auditor=$(jq -r '.config.auditor // 0' "$STATE_FILE" 2>/dev/null || echo "$auditor")
-            deployer=$(jq -r '.config.deployer // 0' "$STATE_FILE" 2>/dev/null || echo "$deployer")
-            herald=$(jq -r '.config.herald // 0' "$STATE_FILE" 2>/dev/null || echo "$herald")
-            mechanic=$(jq -r '.config.mechanic // 0' "$STATE_FILE" 2>/dev/null || echo "$mechanic")
-        fi
-
-        # Apply time-based schedule overrides
-        apply_schedule
+        # exits entirely, the health check above never sees it). Target config
+        # was already re-read from STATE_FILE + schedule-adjusted at the top of
+        # this cycle (before the blackout early-continue).
 
         local enricher_active=0 researcher_active=0 aristotle_active=0 auditor_active=0 seeker_active=0 deployer_active=0 herald_active=0 mechanic_active=0
         for i in $(seq 1 $MAX_ENRICHER); do
@@ -2599,56 +2674,14 @@ cmd_daemon() {
         # cycle, but when the launcher dies silently (#39649) a CONFIGURED
         # agent can stay session-less indefinitely with only routine INFO
         # "pool gap" noise -- exactly how the deployer went unnoticed for 7
-        # days. Track how many CONSECUTIVE cycles each configured agent has
-        # stayed below target; once it crosses the threshold, escalate to a
-        # WARN and persist a MISSING record that /lean health & /lean status
-        # render as a red row instead of silently omitting the agent.
-        local tester_active=0
-        tmux has-session -t "tester-agent" 2>/dev/null && tester_active=1
-        local missing_json="[]"
-        local mtype mactive mtarget mcycles
-        for _pair in \
-            "enricher $enricher_active $enricher" \
-            "researcher $researcher_active $researcher" \
-            "aristotle $aristotle_active $aristotle" \
-            "auditor $auditor_active $auditor" \
-            "seeker $seeker_active $seeker" \
-            "deployer $deployer_active $deployer" \
-            "herald $herald_active $herald" \
-            "mechanic $mechanic_active $mechanic" \
-            "tester $tester_active $tester"; do
-            read -r mtype mactive mtarget <<< "$_pair"
-
-            # Only configured agents (target >= 1) can be "missing".
-            if [[ "$mtarget" -lt 1 ]]; then
-                set_missing_cycles "$mtype" 0
-                continue
-            fi
-
-            # Aristotle scale-to-zero (issue #22471) is an intentional absence,
-            # not a failed launch -- don't false-alarm on it.
-            if [[ "$mtype" == "aristotle" ]] && [[ -f "$ARISTOTLE_SCALED_MARKER" ]]; then
-                set_missing_cycles "$mtype" 0
-                continue
-            fi
-
-            if [[ "$mactive" -lt "$mtarget" ]]; then
-                mcycles=$(get_missing_cycles "$mtype")
-                mcycles=$((mcycles + 1))
-                set_missing_cycles "$mtype" "$mcycles"
-                if [[ "$mcycles" -ge "$MISSING_SESSION_ALERT_CYCLES" ]]; then
-                    daemon_log "WARN" "Agent '$mtype' MISSING: configured=$mtarget running=$mactive for $mcycles consecutive cycles (respawn attempted, session still absent)"
-                    missing_json=$(echo "$missing_json" | jq -c \
-                        --arg t "$mtype" --argjson cfg "$mtarget" \
-                        --argjson run "$mactive" --argjson cyc "$mcycles" \
-                        '. += [{type: $t, configured: $cfg, running: $run, missing_cycles: $cyc}]' \
-                        2>/dev/null || echo "$missing_json")
-                fi
-            else
-                set_missing_cycles "$mtype" 0
-            fi
-        done
-        write_missing_agents "$missing_json"
+        # days. detect_and_persist_missing_agents tracks consecutive absent
+        # cycles per configured agent, escalates to a WARN past the threshold,
+        # and persists the MISSING set that /lean health & /lean status render
+        # as a red row. (The same helper also runs on the total-blackout
+        # early-continue path above -- #41509.)
+        detect_and_persist_missing_agents \
+            "$enricher" "$researcher" "$aristotle" "$auditor" \
+            "$seeker" "$deployer" "$herald" "$mechanic" "$tester"
 
         # 3. Work queue assessment (with timeout protection)
         local queue_stats

--- a/scripts/tests/daemon-missing-agent.test.sh
+++ b/scripts/tests/daemon-missing-agent.test.sh
@@ -170,6 +170,47 @@ simulate_cycle 1 1   # came back -> reset
 assert_eq "one absent cycle then recovery: no warn" "$warned" ""
 assert_eq "counter reset to 0 after recovery" "$(get_missing_cycles deployer)" "0"
 
+echo "== total-pool blackout persists .missing_agents for /lean status (#41509) =="
+# Regression for the edge case where the daemon early-continues on an empty pool
+# BEFORE running missing-agent detection, leaving .missing_agents (which
+# /lean status reads) empty even though a configured agent is absent. The shared
+# helper detect_and_persist_missing_agents now runs on the blackout path too.
+# Args order: enricher researcher aristotle auditor seeker deployer herald mechanic tester
+write_state 1 0                 # deployer configured=1, everything else 0
+FAKE_SESSIONS=""                # zero sessions -> total blackout
+set_missing_cycles deployer 0
+# Cycles 1 and 2: below threshold, nothing persisted yet.
+detect_and_persist_missing_agents 0 0 0 0 0 1 0 0 0 >> "$DAEMON_LOG_FILE"
+assert_eq "blackout cycle 1: no missing persisted yet" \
+    "$(jq -c '.missing_agents' "$STATE_FILE")" "[]"
+detect_and_persist_missing_agents 0 0 0 0 0 1 0 0 0 >> "$DAEMON_LOG_FILE"
+assert_eq "blackout cycle 2: still below threshold" \
+    "$(jq -c '.missing_agents' "$STATE_FILE")" "[]"
+# Cycle 3: threshold reached -> .missing_agents persisted for /lean status.
+detect_and_persist_missing_agents 0 0 0 0 0 1 0 0 0 >> "$DAEMON_LOG_FILE"
+assert_eq "blackout cycle 3: deployer persisted to .missing_agents" \
+    "$(jq -r '.missing_agents[0].type' "$STATE_FILE")" "deployer"
+assert_eq "blackout: persisted configured=1" \
+    "$(jq -r '.missing_agents[0].configured' "$STATE_FILE")" "1"
+assert_eq "blackout: persisted running=0" \
+    "$(jq -r '.missing_agents[0].running' "$STATE_FILE")" "0"
+# The same rows /lean status reads are what cmd_health renders from live state.
+status_out="$(cmd_health 2>/dev/null | strip_ansi)"
+assert_contains "blackout: MISSING surfaced (status/health share the record)" \
+    "$status_out" "MISSING"
+
+echo "== healthy pool in blackout helper: no false alarm, nothing persisted =="
+write_state 1 0
+FAKE_SESSIONS="deployer"         # deployer session live -> healthy
+set_missing_cycles deployer 0
+detect_and_persist_missing_agents 0 0 0 0 0 1 0 0 0 >/dev/null
+detect_and_persist_missing_agents 0 0 0 0 0 1 0 0 0 >/dev/null
+detect_and_persist_missing_agents 0 0 0 0 0 1 0 0 0 >/dev/null
+assert_eq "healthy pool: .missing_agents stays empty" \
+    "$(jq -c '.missing_agents' "$STATE_FILE")" "[]"
+assert_eq "healthy pool: deployer cycle counter stays 0" \
+    "$(get_missing_cycles deployer)" "0"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Follow-up to #39652 (PR #41506). The daemon's `cmd_daemon` loop early-`continue`d when `get_all_agent_sessions` returned empty (a **total blackout** — zero agent sessions) *before* reaching the step-2c missing-agent detection block. So in a whole-pool-dead scenario the per-agent `MISSING` WARN and the `.missing_agents` STATE_FILE persistence never fired, and `/lean status` (which reads `.missing_agents`) stayed empty. `/lean health` still showed the rows live and the pre-existing `WARN "No agent sessions found"` still logged — the gap was only the persisted record for `/lean status`.

## Changes

- Extract step 2c into a reusable `detect_and_persist_missing_agents` helper that recomputes live counts via the existing `count_agent_sessions` (single source of truth) and reuses `get_missing_cycles` / `set_missing_cycles` / `write_missing_agents` / `MISSING_SESSION_ALERT_CYCLES`.
- Call the helper on the total-blackout early-`continue` path too, so `.missing_agents` is persisted and `/lean status` shows MISSING rows in a blackout.
- Hoist the per-cycle STATE_FILE config re-read + `apply_schedule` ahead of the health check so both the normal and blackout paths see the same scheduled targets — a scheduled scale-to-zero during a blackout won't false-alarm on stale config.

The early-`continue` is otherwise preserved: the health-check / pool-gap / respawn / completions / state self-heal logic is unchanged, and a single-agent-missing-among-a-live-pool (the original #39652 case) behaves exactly as before.

## Testing

`bash -n scripts/lean/launch.sh` passes. Extended `scripts/tests/daemon-missing-agent.test.sh`:
- Total blackout (deployer configured=1, zero sessions): nothing persisted at cycles 1–2, `.missing_agents` persists deployer at cycle 3 (threshold), MISSING surfaced.
- Healthy pool through the same helper: `.missing_agents` stays `[]`, counter stays 0 (no false alarm).

All 28 assertions pass.

Closes #41509

🤖 Generated with [Claude Code](https://claude.com/claude-code)
