### PR TITLE
audit: erdos-1139 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10330,9 +10330,9 @@
       "result": "clean"
     },
     "erdos-1139": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:31Z",
+      "lastAudited": "2026-07-22T18:11:38Z",
       "result": "clean"
     },
     "erdos-114": {


### PR DESCRIPTION
## Audit Result: Clean

**Proof**: erdos-1139 (Erdős #1139 — Gaps in the Almost-Prime Sequence)

Verified `Proofs/Erdos1139Problem.lean` against `meta.json`:
- 16 theorems, 2 axioms, 6 definitions, 0 sorries — all counts match exactly
- All 3 `native_decide` uses (four_isAlmostPrime, eight_not_almostPrime, and the
  `bigOmega 8 = 3` step inside cube_gap_obstruction) are disclosed in `assumptions`
- Section line ranges match file structure exactly; no phantom declarations
- Badge `axiom`/status `axiomatized` correctly scoped — main conjecture and
  Hardy-Ramanujan asymptotic remain axioms, prose never claims them proved

No issues found. Updating audit-tracker.json only.

---
Discovered during gallery integrity audit.