### PR TITLE
Audit: erdos-719 clean (reserve re-verification)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15860,11 +15860,11 @@
       "result": "clean"
     },
     "erdos-719": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [
         "PR #6447: sorries 2→1, lineCount 175→196"
       ],
-      "lastAudited": "2026-05-04T04:02:32Z",
+      "lastAudited": "2026-07-22T18:14:33Z",
       "result": "clean"
     },
     "erdos-72": {


### PR DESCRIPTION
## Summary
Reserve-mode re-audit of erdos-719 (Erdős Problem #719, Hypergraph Decomposition into Cliques). Queue is fully drained (4809/4809 audited, 0 open issues), so this re-verifies an oldest-audited entry per the auditor's round-robin cadence.

## Verification
- 1 axiom (`erdos_sauer_conjecture`) — matches `axiomCount: 1`; faithfully states the actual OPEN Erdős–Sauer conjecture (no junk/trivial instantiation risk), clearly documented as OPEN in both docstring and prose.
- 0 sorries — matches meta.
- 20/20 theorems and 10/10 definitions in the Lean source match the `originalContributions` and section summaries; no phantom declarations.
- No `native_decide`, no `True`-stub placeholders.
- `turan_graph` is a genuine proved theorem (not axiom) discharging the former graph-case axiom; `graph_case_bound` is honestly presented as a conditional reduction, and prose correctly states the graph case (r=2) remains open.

Result: **clean**, no changes needed beyond tracker update.

## Test plan
- [x] Diffed tracker to confirm only the erdos-719 entry changed (auditCount 5→6, lastAudited timestamp)