### PR TITLE
Enrich chinese-remainder-constructive-oq-05-oq-02: add missing header section

### DIFF
--- a/src/data/proofs/chinese-remainder-constructive-oq-05-oq-02/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-05-oq-02/meta.json
@@ -58,6 +58,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Open Question, Imports & Statement",
+      "startLine": 1,
+      "endLine": 32,
+      "summary": "File docstring framing the open question: the sibling proves 2- and 3-modulus CRT uniqueness certificates (crt_pair_iff, crt_triple_iff); this file generalises to an arbitrary pairwise-coprime list, connecting to the oq-04 list thread. Lists the three original deliverables (prod_dvd_of_forall_dvd, crt_list_unique, crt_345_unique); then `import Mathlib`, the namespace, and `open Nat`.",
+      "mathContext": "Goal: generalise the sibling's 2-/3-modulus CRT uniqueness certificates to an arbitrary pairwise-coprime list."
+    },
+    {
       "id": "engine",
       "title": "The Combination Engine: Product Divides Common Multiples",
       "startLine": 33,
@@ -94,7 +102,8 @@
       "**Coprimality lifts to the product.** The head modulus being coprime to every tail modulus makes it coprime to the whole tail product (`coprime_list_prod_right_iff`), which is exactly what lets the products multiply into a single divisor.",
       "**Uniqueness is one divisibility plus a bound.** Once `ms.prod` divides the difference of two solutions and that difference is smaller than `ms.prod`, it must be zero — no explicit construction is needed for the uniqueness half.",
       "**The certificate is the practical content.** Knowing the solution below the product is unique means any candidate found (e.g. by search or by the pair/triple constructions) is *the* answer.",
-      "**Pairwise, not setwise.** The hypothesis is `List.Pairwise Nat.Coprime`; the induction consumes the head's pairwise relations exactly once per step."
+      "**Pairwise, not setwise.** The hypothesis is `List.Pairwise Nat.Coprime`; the induction consumes the head's pairwise relations exactly once per step.",
+      "**Existence reduces the n-modulus case to one 2-modulus CRT step per cons.** `crt_list_exists` combines the head modulus with `Nat.chineseRemainder` against a tail solution `y` (congruent mod `t.prod`), then downgrades `x ≡ y [MOD t.prod]` to each individual tail modulus `m` via `ModEq.of_dvd` (since `m ∣ t.prod`) and chains with `y`'s own congruence — so the n-ary construction is literally the binary `Nat.chineseRemainder` applied once per list element."
     ],
     "prerequisites": [
       "Modular arithmetic and Nat.ModEq",


### PR DESCRIPTION
## Summary
- Adds a `header` section (lines 1-32: file docstring, `import Mathlib`, namespace, `open Nat`) that was completely missing from `sections` despite being covered by `annotations.json` (`ann-header` 1-27, `ann-setup` 29-33) — this closes a genuine gap where `sections` did not cover the full Lean file.
- Adds a 5th `keyInsight` on how `crt_list_exists` reduces the n-modulus construction to one `Nat.chineseRemainder` call per cons step, downgrading the tail-product congruence to each individual tail modulus via `ModEq.of_dvd`.
- Quality score 96 -> 100 (`npx tsx scripts/enricher/find-targets.ts`), via sections (4->5) and keyInsights (4->5).

No content deleted; the new section fixes real undercoverage, and the insight is a genuine account of the actual induction step (verified against `Proofs/ChineseRemainderConstructiveOQ05OQ02.lean` lines 97-112).

## Test plan
- [x] `pnpm build` passes (annotations/research/search-index/redirects/tsc/vite/bundle-budget all green)
- [x] `python3 -m json.tool meta.json` validates
- [x] Re-ran `find-targets.ts` to confirm quality now reports 100