### PR TITLE
Research: erdos-64-wip-01 — even cycle from min degree 3 (longest-path parity, 0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos64Problem.lean
+++ b/proofs/Proofs/Erdos64Problem.lean
@@ -332,6 +332,234 @@ theorem hasMinDegree_three_containsCycleLength
     ∃ k : ℕ, k ≥ 3 ∧ ContainsCycleLength G k :=
   hasMinDegree_two_containsCycleLength G (fun v => le_trans (by norm_num) (hdeg v))
 
+/- ## Even cycle from minimum degree 3 (longest-path parity argument)
+
+Every power of two `2^k` (`k ≥ 2`) is even, so "the graph contains an **even** cycle"
+is a necessary — and classically nontrivial — precondition of Problem 64, sitting
+strictly between plain cycle existence (proved above from minimum degree `2`) and the
+open power-of-two-length core.
+
+The classical argument: take a path `p` of maximum length, starting at `v₀`.
+Maximality traps every neighbour of `v₀` on `p` (else `p` could be extended), so the
+at-least-three neighbours of `v₀` sit at distinct positive indices along `p`. If
+`a < b` are the two largest such indices (so `a ≥ 2`), closing `p` back to `v₀` from
+index `a`, from index `b`, and around the segment `[a, b]` produces three cycles of
+lengths `a + 1`, `b + 1`, and `b - a + 2`. These lengths sum to `2b + 4`, which is
+even — so they cannot all be odd, and one of the three cycles is even. -/
+
+/-- **Minimum degree `3` forces an even cycle.** Every nonempty finite graph with
+minimum degree at least `3` contains a cycle of even length (as an explicit
+`SimpleGraph.Walk.IsCycle` witness). This is the parity part of the necessary
+condition for Problem 64: a `2^k`-cycle is in particular even. The proof is the
+classical longest-path argument; see the section header above. -/
+theorem hasMinDegree_three_exists_even_cycle
+    {W : Type*} [Fintype W] [DecidableEq W] [Nonempty W]
+    (G : SimpleGraph W) [DecidableRel G.Adj]
+    (hdeg : HasMinDegree G 3) :
+    ∃ (v : W) (c : G.Walk v v), c.IsCycle ∧ Even c.length := by
+  classical
+  -- ### A path of maximum length exists
+  have hne : ({n : ℕ | ∃ (a : W) (b : W) (q : G.Walk a b), q.IsPath ∧ q.length = n}).Nonempty :=
+    ⟨0, Classical.arbitrary W, Classical.arbitrary W, Walk.nil, Walk.IsPath.nil, rfl⟩
+  have hbdd : BddAbove {n : ℕ | ∃ (a : W) (b : W) (q : G.Walk a b), q.IsPath ∧ q.length = n} := by
+    refine ⟨Fintype.card W, ?_⟩
+    rintro n ⟨a, b, q, hq, rfl⟩
+    exact hq.length_lt.le
+  obtain ⟨v₀, u, p, hp, hplen⟩ := Nat.sSup_mem hne hbdd
+  have hmax : ∀ (a b : W) (q : G.Walk a b), q.IsPath → q.length ≤ p.length := by
+    intro a b q hq
+    rw [hplen]
+    exact le_csSup hbdd ⟨a, b, q, hq, rfl⟩
+  -- ### Maximality traps every neighbour of the start vertex `v₀` on `p`
+  have hnbr : ∀ w : W, G.Adj v₀ w → w ∈ p.support := by
+    intro w hw
+    by_contra hws
+    have hcons : (Walk.cons hw.symm p).IsPath := (Walk.cons_isPath_iff _ _).mpr ⟨hp, hws⟩
+    have := hmax _ _ _ hcons
+    rw [Walk.length_cons] at this
+    omega
+  -- ### The neighbours of `v₀` sit at distinct positive indices along `p`
+  set idx : W → ℕ := fun w => if hw : w ∈ p.support then (p.takeUntil w hw).length else 0
+    with hidx
+  have hidx_get : ∀ w (hw : w ∈ p.support), p.getVert (idx w) = w := by
+    intro w hw
+    simp only [hidx, dif_pos hw]
+    exact Walk.getVert_length_takeUntil hw
+  -- the finset of neighbour indices
+  set T : Finset ℕ := (G.neighborFinset v₀).image idx with hT
+  have hTcard : 3 ≤ T.card := by
+    rw [hT, Finset.card_image_of_injOn]
+    · exact hdeg v₀
+    · intro w₁ hw₁ w₂ hw₂ hww
+      have h₁ : G.Adj v₀ w₁ := (G.mem_neighborFinset v₀ w₁).mp (Finset.mem_coe.mp hw₁)
+      have h₂ : G.Adj v₀ w₂ := (G.mem_neighborFinset v₀ w₂).mp (Finset.mem_coe.mp hw₂)
+      calc w₁ = p.getVert (idx w₁) := (hidx_get w₁ (hnbr _ h₁)).symm
+        _ = p.getVert (idx w₂) := by rw [hww]
+        _ = w₂ := hidx_get w₂ (hnbr _ h₂)
+  have hpos : ∀ n ∈ T, 1 ≤ n := by
+    intro n hn
+    rw [hT] at hn
+    obtain ⟨w, hw, rfl⟩ := Finset.mem_image.mp hn
+    have hadj : G.Adj v₀ w := (G.mem_neighborFinset v₀ w).mp hw
+    rcases Nat.eq_zero_or_pos (idx w) with h0 | h1
+    · exfalso
+      have hgw := hidx_get w (hnbr _ hadj)
+      rw [h0, Walk.getVert_zero] at hgw
+      exact hadj.ne hgw
+    · exact h1
+  -- ### Extract the two largest indices `a < b`, with `a ≥ 2`
+  have hTne : T.Nonempty := Finset.card_pos.mp (by omega)
+  have hbT : T.max' hTne ∈ T := T.max'_mem hTne
+  set b := T.max' hTne with hbdef
+  have hT'ne : (T.erase b).Nonempty := by
+    rw [← Finset.card_pos, Finset.card_erase_of_mem hbT]
+    omega
+  have haT' : (T.erase b).max' hT'ne ∈ T.erase b := (T.erase b).max'_mem hT'ne
+  set a := (T.erase b).max' hT'ne with hadef
+  have haT : a ∈ T := Finset.mem_of_mem_erase haT'
+  have hab : a < b := lt_of_le_of_ne (T.le_max' a haT) (Finset.ne_of_mem_erase haT')
+  have ha2 : 2 ≤ a := by
+    have hcne : ((T.erase b).erase a).Nonempty := by
+      rw [← Finset.card_pos, Finset.card_erase_of_mem haT', Finset.card_erase_of_mem hbT]
+      omega
+    obtain ⟨c, hc⟩ := hcne
+    have hcT' : c ∈ T.erase b := Finset.mem_of_mem_erase hc
+    have hca : c < a := lt_of_le_of_ne ((T.erase b).le_max' c hcT') (Finset.ne_of_mem_erase hc)
+    have := hpos c (Finset.mem_of_mem_erase hcT')
+    omega
+  -- ### The neighbours `x` (at index `a`) and `y` (at index `b`)
+  have hbT2 : b ∈ (G.neighborFinset v₀).image idx := by rw [← hT]; exact hbT
+  have haT2 : a ∈ (G.neighborFinset v₀).image idx := by rw [← hT]; exact haT
+  obtain ⟨y, hyN, hyb⟩ := Finset.mem_image.mp hbT2
+  obtain ⟨x, hxN, hxa⟩ := Finset.mem_image.mp haT2
+  have hax : G.Adj v₀ x := (G.mem_neighborFinset v₀ x).mp hxN
+  have hay : G.Adj v₀ y := (G.mem_neighborFinset v₀ y).mp hyN
+  have hxs : x ∈ p.support := hnbr x hax
+  have hys : y ∈ p.support := hnbr y hay
+  have hxa' : (p.takeUntil x hxs).length = a := by
+    rw [← hxa]; simp only [hidx, dif_pos hxs]
+  have hyb' : (p.takeUntil y hys).length = b := by
+    rw [← hyb]; simp only [hidx, dif_pos hys]
+  have hgx : p.getVert a = x := by rw [← hxa']; exact Walk.getVert_length_takeUntil hxs
+  have hgy : p.getVert b = y := by rw [← hyb']; exact Walk.getVert_length_takeUntil hys
+  have hblen : b ≤ p.length := by rw [← hyb']; exact p.length_takeUntil_le_length hys
+  have halen : a ≤ p.length := by omega
+  have hxy : x ≠ y := by
+    intro h
+    have hgg : p.getVert a = p.getVert b := by rw [hgx, hgy, h]
+    have := hp.getVert_injOn (by simp only [Set.mem_setOf_eq]; omega)
+      (by simp only [Set.mem_setOf_eq]; omega) hgg
+    omega
+  -- ### Closing a prefix `p.takeUntil w` through the edge `w — v₀` yields a cycle
+  have hclose : ∀ (w : W) (hw : w ∈ p.support) (hadj : G.Adj v₀ w),
+      2 ≤ (p.takeUntil w hw).length →
+      ∃ c : G.Walk v₀ v₀, c.IsCycle ∧ c.length = (p.takeUntil w hw).length + 1 := by
+    intro w hw hadj h2
+    set q := p.takeUntil w hw with hq
+    refine ⟨Walk.cons hadj q.reverse, ?_, ?_⟩
+    · rw [Walk.cons_isCycle_iff]
+      refine ⟨(hp.takeUntil hw).reverse, ?_⟩
+      intro hmem
+      rw [Walk.edges_reverse, List.mem_reverse] at hmem
+      -- an edge of a path through its start must be the first edge …
+      have hsnd : w = q.snd := (hp.takeUntil hw).eq_snd_of_mem_edges hmem
+      -- … but `w` is the endpoint of `q`, at index `q.length ≥ 2`
+      have h1 : q.getVert 1 = q.getVert q.length := by
+        rw [Walk.getVert_length]
+        exact hsnd.symm
+      have := (hp.takeUntil hw).getVert_injOn
+        (by simp only [Set.mem_setOf_eq]; omega)
+        (by simp only [Set.mem_setOf_eq]; omega) h1
+      omega
+    · rw [Walk.length_cons, Walk.length_reverse]
+  -- ### The middle segment from `x` to `y` along `p`
+  have hia : p.support.idxOf x = a := by
+    rw [← p.length_takeUntil hxs]; exact hxa'
+  have hdrop_gv : (p.dropUntil x hxs).getVert (b - a) = y := by
+    rw [Walk.dropUntil_eq_drop, Walk.getVert_copy, Walk.drop_getVert, hia,
+      show a + (b - a) = b by omega]
+    exact hgy
+  have hdrop_len : b - a ≤ (p.dropUntil x hxs).length := by
+    rw [Walk.length_dropUntil, hia]
+    omega
+  have hyd : y ∈ (p.dropUntil x hxs).support :=
+    Walk.mem_support_iff_exists_getVert.mpr ⟨b - a, hdrop_gv, hdrop_len⟩
+  set r := (p.dropUntil x hxs).takeUntil y hyd with hr
+  have hrpath : r.IsPath := (hp.dropUntil hxs).takeUntil hyd
+  have hrlen : r.length = b - a := by
+    have h₁ : (p.dropUntil x hxs).getVert r.length = y := Walk.getVert_length_takeUntil hyd
+    have hle : r.length ≤ (p.dropUntil x hxs).length :=
+      (p.dropUntil x hxs).length_takeUntil_le_length hyd
+    exact (hp.dropUntil hxs).getVert_injOn
+      (by simp only [Set.mem_setOf_eq]; omega)
+      (by simp only [Set.mem_setOf_eq]; omega)
+      (h₁.trans hdrop_gv.symm)
+  have hv₀r : v₀ ∉ r.support := by
+    intro hmem
+    have hmem' : v₀ ∈ (p.dropUntil x hxs).support :=
+      (p.dropUntil x hxs).support_takeUntil_subset_support hyd hmem
+    obtain ⟨n, hgv, hn⟩ := Walk.mem_support_iff_exists_getVert.mp hmem'
+    rw [Walk.dropUntil_eq_drop, Walk.getVert_copy, Walk.drop_getVert, hia] at hgv
+    have h0 : p.getVert (a + n) = p.getVert 0 := by rw [hgv, Walk.getVert_zero]
+    have hanle : a + n ≤ p.length := by
+      rw [Walk.length_dropUntil, hia] at hn
+      omega
+    have := hp.getVert_injOn (by simp only [Set.mem_setOf_eq]; omega)
+      (by simp only [Set.mem_setOf_eq]; omega) h0
+    omega
+  -- ### The third cycle: `v₀ — x — ⋯ — y — v₀` around the segment `[a, b]`
+  have hyv₀ : G.Adj y v₀ := hay.symm
+  have hc₃path : (r.concat hyv₀).IsPath := hrpath.concat hv₀r hyv₀
+  have hc₃edge : s(v₀, x) ∉ (r.concat hyv₀).edges := by
+    rw [Walk.edges_concat]
+    intro hmem
+    rw [List.concat_eq_append, List.mem_append, List.mem_singleton] at hmem
+    rcases hmem with hin | heq
+    · exact hv₀r (r.fst_mem_support_of_mem_edges hin)
+    · rcases Sym2.eq_iff.mp heq with ⟨h1, _⟩ | ⟨_, h2⟩
+      · exact hay.ne h1
+      · exact hxy h2
+  have hc₃ : (Walk.cons hax (r.concat hyv₀)).IsCycle :=
+    (Walk.cons_isCycle_iff _ _).mpr ⟨hc₃path, hc₃edge⟩
+  have hc₃len : (Walk.cons hax (r.concat hyv₀)).length = (b - a) + 2 := by
+    rw [Walk.length_cons, Walk.length_concat, hrlen]
+  -- ### Parity: the three cycle lengths `a+1`, `b+1`, `b-a+2` sum to `2b+4`
+  rcases Nat.even_or_odd a with hae | hao
+  · rcases Nat.even_or_odd b with hbe | hbo
+    · -- `a`, `b` both even: the segment cycle has even length `b - a + 2`
+      refine ⟨v₀, _, hc₃, ?_⟩
+      rw [hc₃len]
+      obtain ⟨i, hi⟩ := hae
+      obtain ⟨j, hj⟩ := hbe
+      exact ⟨j - i + 1, by omega⟩
+    · -- `b` odd: the cycle through index `b` has even length `b + 1`
+      obtain ⟨c, hcyc, hclen⟩ := hclose y hys hay (by rw [hyb']; omega)
+      refine ⟨v₀, c, hcyc, ?_⟩
+      rw [hclen, hyb']
+      obtain ⟨j, hj⟩ := hbo
+      exact ⟨j + 1, by omega⟩
+  · -- `a` odd: the cycle through index `a` has even length `a + 1`
+    obtain ⟨c, hcyc, hclen⟩ := hclose x hxs hax (by rw [hxa']; omega)
+    refine ⟨v₀, c, hcyc, ?_⟩
+    rw [hclen, hxa']
+    obtain ⟨i, hi⟩ := hao
+    exact ⟨i + 1, by omega⟩
+
+/-- Restatement in the `ContainsCycleLength` predicate: minimum degree `3` yields an
+**even** cycle length `k ≥ 4`. Every power of two `2^m` with `m ≥ 2` is even and `≥ 4`,
+so this proves exactly the parity-and-size part of the necessary condition of Problem 64;
+the open core is whether `k` can moreover be taken to be an exact power of two. -/
+theorem hasMinDegree_three_exists_even_containsCycleLength
+    {W : Type*} [Fintype W] [DecidableEq W] [Nonempty W]
+    (G : SimpleGraph W) [DecidableRel G.Adj]
+    (hdeg : HasMinDegree G 3) :
+    ∃ k : ℕ, 4 ≤ k ∧ Even k ∧ ContainsCycleLength G k := by
+  obtain ⟨v, c, hc, heven⟩ := hasMinDegree_three_exists_even_cycle G hdeg
+  refine ⟨c.length, ?_, heven, isCycle_containsCycleLength G c hc⟩
+  have h3 := hc.three_le_length
+  obtain ⟨m, hm⟩ := heven
+  omega
+
 /- ## Known Cycle Results -/
 
 /- 

--- a/proofs/Proofs/Erdos64Problem.lean
+++ b/proofs/Proofs/Erdos64Problem.lean
@@ -455,16 +455,16 @@ theorem hasMinDegree_three_exists_even_cycle
       2 ≤ (p.takeUntil w hw).length →
       ∃ c : G.Walk v₀ v₀, c.IsCycle ∧ c.length = (p.takeUntil w hw).length + 1 := by
     intro w hw hadj h2
-    set q := p.takeUntil w hw with hq
-    refine ⟨Walk.cons hadj q.reverse, ?_, ?_⟩
+    refine ⟨Walk.cons hadj (p.takeUntil w hw).reverse, ?_, ?_⟩
     · rw [Walk.cons_isCycle_iff]
       refine ⟨(hp.takeUntil hw).reverse, ?_⟩
       intro hmem
       rw [Walk.edges_reverse, List.mem_reverse] at hmem
       -- an edge of a path through its start must be the first edge …
-      have hsnd : w = q.snd := (hp.takeUntil hw).eq_snd_of_mem_edges hmem
-      -- … but `w` is the endpoint of `q`, at index `q.length ≥ 2`
-      have h1 : q.getVert 1 = q.getVert q.length := by
+      have hsnd : w = (p.takeUntil w hw).snd := (hp.takeUntil hw).eq_snd_of_mem_edges hmem
+      -- … but `w` is the endpoint of the prefix, at index `≥ 2`
+      have h1 : (p.takeUntil w hw).getVert 1 =
+          (p.takeUntil w hw).getVert (p.takeUntil w hw).length := by
         rw [Walk.getVert_length]
         exact hsnd.symm
       have := (hp.takeUntil hw).getVert_injOn

--- a/research/problems/erdos-64-wip-01/knowledge.md
+++ b/research/problems/erdos-64-wip-01/knowledge.md
@@ -113,3 +113,41 @@ File 316→379 lines.
   elementary path remains for the *length = power-of-two* refinement.
 - Optional: a girth/`egirth` restatement (`SimpleGraph.girth_le_length`) is now within reach
   but adds little beyond the existing `∃ k ≥ 3` bound.
+
+## Session 2026-07-22 (researcher-1): even-cycle parity layer
+
+### Result
+`hasMinDegree_three_exists_even_cycle` — every nonempty finite graph with min degree ≥ 3
+contains a cycle of **even** length (explicit `Walk.IsCycle`), plus
+`hasMinDegree_three_exists_even_containsCycleLength` (even `k ≥ 4` in the
+`ContainsCycleLength` predicate). Parity part of the necessary condition of Problem 64:
+a `2^k`-cycle is in particular even. Strictly between plain cycle existence (previous
+sessions) and the open power-of-two core.
+
+### Mechanism (classical longest-path parity argument)
+Take a maximum-length path `p` starting at `v₀`. Maximality traps every neighbour of `v₀`
+on `p.support` (else `Walk.cons` extends it). The ≥3 neighbours sit at distinct positive
+indices (`takeUntil` lengths); if `a < b` are the two largest (so `a ≥ 2`), the closings
+at index `a`, at index `b`, and around the segment `[a,b]` are three cycles of lengths
+`a+1`, `b+1`, `b−a+2`, summing to `2b+4` (even) — one must be even.
+
+### Lean idioms discovered
+- **Maximal path**: `Nat.sSup_mem` on `{n | ∃ a b (q : G.Walk a b), q.IsPath ∧ q.length = n}`
+  (nonempty via `Walk.nil`, `BddAbove` via `IsPath.length_lt`), maximality via `le_csSup`.
+  Mathlib has NO dedicated longest-path API.
+- **Neighbour → index**: `idx w := (p.takeUntil w hw).length` (dite-wrapped for totality);
+  injective on neighbours via `Walk.getVert_length_takeUntil`; image finset + `max'`/`erase`
+  extracts the two largest indices.
+- **Closing a prefix into a cycle**: `Walk.cons_isCycle_iff` + `IsPath.eq_snd_of_mem_edges`
+  (an edge of a path through its start must be the first edge; kills the `s(v₀,w) ∈ edges`
+  obstruction when the index is ≥ 2).
+- **Segment cycle**: `r := (p.dropUntil x _).takeUntil y _`; getVert bookkeeping via
+  `dropUntil_eq_drop` + `drop_getVert` + `getVert_copy`, `length_takeUntil` (= support.idxOf),
+  `IsPath.getVert_injOn` for exact length; close with `IsPath.concat` + `cons_isCycle_iff`.
+- **Gotcha**: do NOT `set q := p.takeUntil w hw` before applying `getVert_injOn` — freshly
+  elaborated membership goals use the unfolded spelling, so omega sees two different atoms
+  and fails. Use the explicit spelling (or fold nothing).
+
+### Next
+- Dirac-type rung: min degree d ⇒ cycle length ≥ d+1 — same maximal-path engine, now in-file.
+- The 2^k core stays blocked (Liu–Montgomery scale).

--- a/src/data/research/problems/erdos-64-wip-01.json
+++ b/src/data/research/problems/erdos-64-wip-01.json
@@ -37,30 +37,35 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (infrastructure): the cycle-existence layer is now connected to the length-indexed ContainsCycleLength predicate used by erdos_64_conjecture. isCycle_containsCycleLength converts any Walk.IsCycle into ContainsCycleLength G c.length; hasMinDegree_two/three_containsCycleLength then give that any min-degree>=2 (resp. degree-3, Problem 64 hypothesis) finite graph contains a cycle of some concrete length k>=3 in that predicate. All axiom-free ([propext, Classical.choice, Quot.sound], no sorryAx). Open power-of-two-length core untouched.",
+    "progressSummary": "PROGRESS: even-cycle parity layer proved (2026-07-22). hasMinDegree_three_exists_even_cycle + ContainsCycleLength restatement (even k>=4), axiom-free, via classical longest-path parity argument (three cycles a+1, b+1, b-a+2). This is the parity part of the necessary condition of Problem 64 (2^k-cycles are even), strictly between cycle existence (done) and the open power-of-two core (blocked, Liu-Montgomery scale). Maximal-path engine (Nat.sSup_mem + IsPath.length_lt) now available in-file.",
     "builtItems": [
       "connected_hasMinDegree_two_not_isAcyclic (Erdos64Problem.lean): nontrivial connected graph, HasMinDegree 2 => ¬IsAcyclic. Axiom-free.",
       "connected_hasMinDegree_two_exists_cycle (Erdos64Problem.lean): same hyp => ∃ v (c : Walk v v), c.IsCycle. Axiom-free.",
       "connected_hasMinDegree_three_exists_cycle (Erdos64Problem.lean): the Problem-64 degree-3 hypothesis (connected) forces a cycle. Axiom-free.",
       "hasMinDegree_two_exists_cycle in Erdos64Problem.lean: disconnected (general finite) min-degree>=2 => contains a cycle, 0 axioms (propext/Classical.choice/Quot.sound only), host-verified v4.31.0",
       "isCycle_containsCycleLength (Erdos64Problem.lean) — Walk.IsCycle c => ContainsCycleLength G c.length, axiom-free",
-      "hasMinDegree_two_containsCycleLength / hasMinDegree_three_containsCycleLength (Erdos64Problem.lean) — min-degree cycle-existence in the length-indexed predicate, axiom-free"
+      "hasMinDegree_two_containsCycleLength / hasMinDegree_three_containsCycleLength (Erdos64Problem.lean) — min-degree cycle-existence in the length-indexed predicate, axiom-free",
+      "hasMinDegree_three_exists_even_cycle in Erdos64Problem.lean: min-degree >=3 nonempty finite graph has an even-length Walk.IsCycle (0-axiom)",
+      "hasMinDegree_three_exists_even_containsCycleLength in Erdos64Problem.lean: even length k >= 4 in the ContainsCycleLength predicate"
     ],
     "insights": [
       "A finite nontrivial TREE has a leaf (degree-1 vertex): Mathlib SimpleGraph.IsTree.minDegree_eq_one_of_nontrivial. Hence a connected graph with min degree >= 2 cannot be a tree, so cannot be acyclic — the elementary base fact under Erdos #64.",
       "SimpleGraph.IsAcyclic unfolds to (forall closed walk, not IsCycle); its negation directly yields an explicit Walk.IsCycle, so ¬IsAcyclic is packaged as a concrete cycle.",
       "Connectivity can be dropped from the base cycle-existence fact: an arbitrary nonempty finite graph with min-degree >=2 contains a cycle. Proof passes to the connected component of any vertex and uses that neighbours stay inside their own component (ConnectedComponent.mem_supp_of_adj_mem_supp), so degrees are preserved on the induced subgraph (SimpleGraph.degree_induce_of_neighborSet_subset); if acyclic the component would be a nontrivial tree with a degree-1 vertex, contradicting min-degree >=2.",
       "Bridged the cycle-EXISTENCE layer to the length-indexed ContainsCycleLength predicate (in which erdos_64_conjecture is phrased): isCycle_containsCycleLength converts any Walk.IsCycle c into ContainsCycleLength G c.length. Mechanism = getVert enumeration: vs i = c.getVert i.val is injective on Fin c.length via IsCycle.getVert_injOn'; cyclic adjacency via adj_getVert_succ, wrap-around closing because c.getVert c.length = v = c.getVert 0.",
-      "hasMinDegree_two/three_containsCycleLength: min-degree>=2 (resp. 3) finite graph contains a cycle of some CONCRETE length k>=3 in the ContainsCycleLength encoding. This restates the elementary precondition of Problem 64 in the exact predicate the conjecture uses; the open content is that k can be chosen a power of two 2^m."
+      "hasMinDegree_two/three_containsCycleLength: min-degree>=2 (resp. 3) finite graph contains a cycle of some CONCRETE length k>=3 in the ContainsCycleLength encoding. This restates the elementary precondition of Problem 64 in the exact predicate the conjecture uses; the open content is that k can be chosen a power of two 2^m.",
+      "Parity middle layer between cycle-existence and the deep 2^k core: min-degree-3 forces an EVEN cycle, via the classical longest-path argument. Take a maximum-length path from v0; maximality traps all >=3 neighbours of v0 on the path at distinct positive indices; the two largest indices a<b (a>=2) give three cycles of lengths a+1, b+1, b-a+2 summing to 2b+4 (even), so one is even.",
+      "Lean mechanism for maximal paths: Nat.sSup_mem on {n | exists path of length n} (nonempty via Walk.nil, BddAbove via IsPath.length_lt), then le_csSup for maximality. No dedicated Mathlib longest-path API exists.",
+      "Key Mathlib toolkit for index arithmetic on paths: Walk.getVert_length_takeUntil (vertex at index = takeUntil length), Walk.length_takeUntil (= support.idxOf), Walk.dropUntil_eq_drop + Walk.drop_getVert + Walk.getVert_copy (getVert of suffix), IsPath.getVert_injOn (injectivity on indices <= length), IsPath.eq_snd_of_mem_edges (an edge of a path through its start is the first edge - closes the takeUntil prefix into a cycle)."
     ],
     "mathlibGaps": [
       "No general (disconnected/forest) leaf lemma: Mathlib only has IsTree.minDegree_eq_one_of_nontrivial (connected). A forest edge-count bound #edges <= n-1 is also absent (only IsTree.card_edgeFinset).",
       "No pre-existing minDegree => contains-cycle result in Mathlib SimpleGraph."
     ],
     "nextSteps": [
-      "General finite-graph case: pass to the connected component of any vertex (degrees preserved inside a component), apply the connected lemma there, lift the cycle to G via the induced-subgraph embedding (Walk.IsCycle transport through SimpleGraph.induce). Needs component-degree-preservation lemma.",
-      "Bridge the file's custom ContainsCycleLength (Fin.succMod encoding) to Mathlib Walk.IsCycle so cycle-LENGTH statements become expressible.",
-      "The open core (some cycle has length 2^k) requires Liu-Montgomery-scale machinery; out of reach elementarily."
+      "Refine parity toward the 2^k core: cycles of consecutive even lengths / length in dyadic ranges needs Liu-Montgomery-scale expansion machinery; out of reach elementarily.",
+      "Possible next elementary rung: min-degree d forces a cycle of length >= d+1 (Dirac-type longest-path bound) - same maximal-path engine now built in this file.",
+      "The open core (some cycle has length exactly 2^k) remains blocked per currentState.blockers."
     ],
     "markdown": "# Knowledge Base: erdos-64-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary
Research session for **erdos-64-wip-01** (Erdős Problem #64, OPEN, $1000: does every finite graph with min degree ≥ 3 contain a cycle of length 2^k?).

## Progress
- **`hasMinDegree_three_exists_even_cycle`**: every nonempty finite graph with minimum degree ≥ 3 contains a cycle of **even** length (explicit `Walk.IsCycle` witness). Classical longest-path parity argument: a maximum-length path from `v₀` traps all ≥ 3 neighbours of `v₀` at distinct positive indices; the two largest indices `a < b` (with `a ≥ 2`) yield three cycles of lengths `a+1`, `b+1`, `b−a+2`, which sum to `2b+4` — even — so one of them is even.
- **`hasMinDegree_three_exists_even_containsCycleLength`**: restatement giving an even length `k ≥ 4` in the file's `ContainsCycleLength` predicate.
- Files: `proofs/Proofs/Erdos64Problem.lean` (+228 lines), tracker JSON, knowledge.md.

## Findings
- This is the **parity part of the necessary condition** of Problem 64 (every `2^k`-cycle is even), sitting strictly between plain cycle existence (previous sessions, min degree 2) and the open power-of-two-length core (Liu–Montgomery scale, blocked). Not in Mathlib: no min-degree ⇒ even-cycle result exists upstream.
- Built a reusable **maximal-path engine**: `Nat.sSup_mem` over the set of path lengths (bounded via `IsPath.length_lt`) — Mathlib has no longest-path API. Enables Dirac-type rungs (min degree d ⇒ cycle ≥ d+1) as a future elementary step.
- Key closing lemma: `IsPath.eq_snd_of_mem_edges` (an edge of a path through its start must be the first edge) discharges the `cons_isCycle_iff` edge-freshness obligation.

## Verification
- Docker build clean (`Proofs.Erdos64Problem`, Lean v4.31.0, 0 errors/warnings).
- 0 sorries, 0 `axiom` declarations in the file; new theorems are axiom-free.

## Status
**Outcome**: progress (parity layer done; the 2^k core remains open/blocked per `currentState.blockers`)
**Next Steps**: optional Dirac-type bound (cycle length ≥ d+1) using the same maximal-path engine; the power-of-two core needs materially new machinery.

🤖 Generated by researcher-1
