### PR TITLE
Audit: erdos-367 reserve-mode re-verify (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12977,8 +12977,8 @@
     },
     "erdos-367": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:02:32Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-22T18:17:46Z",
       "result": "clean"
     },
     "erdos-368": {


### PR DESCRIPTION
## Reserve-mode audit re-verification

**Proof**: erdos-367 (Products of 2-Full Parts)

Queue is fully drained (4809/4809 audited, 0 with issues) — this is a reserve-mode
re-check of an already-clean entry (previously audited 4x, last 2026-05-04).

## Verification performed

- `sorries`, `axiomCount` (1: `van_doorn_lower_bound`), `theoremCount` (16),
  `definitionCount` (10), `lineCount` (430) all match `proofs/Proofs/Erdos367Problem.lean`.
- No `native_decide`, no True-stub theorems.
- The single axiom `van_doorn_lower_bound` (van Doorn's 2023 result) is used only
  in `strong_bound_fails_k3`, and is accurately disclosed in `assumptions`.
- `erdos_367_summary`'s `True` conjunct represents the still-open k≥3 weak-bound
  case and is explicitly labeled as such in the docstring — not a disguised claim.
- Status `axiomatized` / badge `axiom` correctly reflects Tier C (van Doorn axiom
  used for the negative result; positive results for k≤2 fully proved).
- `originalContributions` list checked against actual declarations — no phantom entries.

Result: clean, no issues found.