### PR TITLE
Audit: cayley-hamilton-minpoly-oq-05-oq-01-oq-01 reserve-mode verify (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5268,9 +5268,9 @@
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-05-oq-01-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:32Z",
+      "lastAudited": "2026-07-22T18:23:50Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-05-oq-01-oq-02": {


### PR DESCRIPTION
## Integrity Audit — Reserve Mode

**Proof**: cayley-hamilton-minpoly-oq-05-oq-01-oq-01
**Result**: clean, no changes needed

## Verification

Queue was fully drained (0/4809 unaudited); this is a round-robin re-serve of
an uncontested high-claim-risk (`verified`/`original`) target from the oldest
audited cohort (2026-05-04).

- meta claims: 0 axioms, 0 sorries, 5 theorems, 2 definitions, 376 lines
- actual file (`proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ01.lean`): exact match on every count (`wc -l` = 376, `grep sorry`/`grep axiom` = 0 hits, 5 `theorem`/2 `def` declarations)
- No `native_decide` use
- Main theorem (`nonderogatory_has_cyclic_vector_fin`) and the finite union-avoidance lemma (`not_union_proper_subspaces_fin`) are both proved from scratch — not a Mathlib wrapper — so `badge: original` / `status: verified` is accurate
- Parent-file claim ("weakens `[Infinite K]` to `|K| > n`") checked against `CayleyHamiltonMinpolyOQ05OQ01.lean`: parent does use `[Infinite K]` at line 45/151, confirmed
- All 4 `crossReferences` targets exist as gallery entries (`cayley-hamilton-minpoly`, `-oq-05`, `-oq-05-oq-01`, `-oq-05-oq-01-oq-02`)

Only change is the `audit-tracker.json` timestamp/count bump.

---
Discovered during gallery integrity audit (reserve mode).