### PR TITLE
Enrich composition-card-2pow-oq-01: cover header docstring (lines 1-60)

### DIFF
--- a/src/data/proofs/composition-card-2pow-oq-01/meta.json
+++ b/src/data/proofs/composition-card-2pow-oq-01/meta.json
@@ -69,6 +69,14 @@
   },
   "sections": [
     {
+      "id": "header-overview",
+      "title": "Module Header: Statement, Scope, and Status",
+      "startLine": 1,
+      "endLine": 60,
+      "mathContext": "$\\mathrm{Fintype.card}\\,(\\mathrm{Composition}\\ n) = 2^{n-1}$, via the bijection with subsets of the $n-1$ internal gaps of $n$ unit boxes.",
+      "summary": "The module docstring states the headline count Fintype.card (Composition n) = 2^(n−1) and the 'bar or no bar' bijective model behind it, then draws the line between what Mathlib already supplies (the count itself, as composition_card, re-exported below as card_composition_eq) and what this file derives beyond that: the doubling recurrence, positivity, the explicit bijection to CompositionAsSet n, and worked small-n instances. It also flags upfront that the doubling recurrence genuinely needs n ≥ 1 — the 0→1 step fails because ℕ-subtraction truncates card (Composition 0) to 2^0 = 1 — which is why the recurrence below is phrased with n+2. A status checklist closes the header: 0 sorries, 0 axiom declarations, re-export plus original corollaries, plus pedagogical examples."
+    },
+    {
       "id": "headline-count",
       "title": "The Headline Count (re-exported from Mathlib)",
       "startLine": 61,


### PR DESCRIPTION
## Summary
- The gallery entry's `sections` array started at line 61 (`headline-count`), leaving the module docstring (lines 1-60 — problem statement, Mathlib-vs-original scope, status checklist) with no section coverage even though it's genuine content, not filler.
- Adds a `header-overview` section (lines 1-60) summarizing the docstring: the headline count statement, the bar/no-bar bijective model, what Mathlib supplies vs. what this file derives, and the n ≥ 1 edge-case caveat for the doubling recurrence.
- No other fields touched; file stays well under the 60 KB size cap (~14.8 KB).

## Test plan
- [x] `jq empty meta.json` — valid JSON
- [x] `pnpm build` succeeds (gallery build + bundle budget checks pass)