### PR TITLE
Enrich compactness-finite-subcover-oq-02-oq-01: cover header/setup (lines 1-55)

### DIFF
--- a/src/data/proofs/compactness-finite-subcover-oq-02-oq-01/meta.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-02-oq-01/meta.json
@@ -89,6 +89,14 @@
   },
   "sections": [
     {
+      "id": "header-and-setup",
+      "title": "Header: The Lebesgue-Number Route, and Ambient Setup",
+      "startLine": 1,
+      "endLine": 55,
+      "mathContext": "$X$ compact metric, $Y$ metric, $f:X\\to Y$ continuous; route via the preimage cover $U_z=f^{-1}(B(fz,\\varepsilon/2))$.",
+      "summary": "The module docstring frames Heine–Cantor and deliberately routes the proof through the Lebesgue number lemma rather than Mathlib's packaged CompactSpace.uniformContinuous_of_continuous: cover X by preimages of ε/2-balls, extract a single Lebesgue number δ, and read it off directly as a uniform modulus. It lists the four results proved (the ε–δ engine, the packaged Heine–Cantor, the continuity/uniform-continuity equivalence on compacta, and Cauchy preservation) and notes the mathlib badge, since the one non-trivial ingredient and the headline theorem both already exist in Mathlib. The ambient setup then fixes the hypotheses: [MetricSpace X] [CompactSpace X] for the domain — compactness here is essential and cannot be dropped (e.g. x ↦ x² on ℝ fails to be uniformly continuous) — and only [MetricSpace Y] for the codomain, since distances there are controlled purely by ε/2-balls and the triangle inequality."
+    },
+    {
       "id": "epsilon-delta-engine",
       "title": "The ε–δ Engine from the Lebesgue Number",
       "startLine": 61,


### PR DESCRIPTION
## Summary
- `sections` started at line 61, leaving the module docstring + ambient typeclass setup (lines 1-55 — Heine–Cantor statement, the deliberate Lebesgue-number route vs. Mathlib's packaged lemma, the four results list, and why domain compactness/codomain-only-metric is the right hypothesis split) with no section coverage, even though annotations already cover this range.
- Adds a `header-and-setup` section (lines 1-55) summarizing that content.
- No other fields touched; file stays well under the 60 KB size cap (~13.4 KB).

## Test plan
- [x] `jq empty meta.json` — valid JSON
- [x] `pnpm build` succeeds (gallery build + bundle budget checks pass)