### PR TITLE
Enrich composition-parts-choose-oq-01-oq-01: cover header docstring (lines 1-60)

### DIFF
--- a/src/data/proofs/composition-parts-choose-oq-01-oq-01/meta.json
+++ b/src/data/proofs/composition-parts-choose-oq-01-oq-01/meta.json
@@ -75,6 +75,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Imports and Docstring: the First Moment of Part-Count",
+      "startLine": 1,
+      "endLine": 60,
+      "mathContext": "Goal: $\\sum_{c:\\mathrm{Composition}\\ n} c.\\mathrm{length} = (n+1)2^{n-2}$, hence mean part-count $= \\tfrac{n+1}{2}$.",
+      "summary": "Imports Composition and Tactic, then a docstring framing the entry against the grandparent (card (Composition n) = 2^(n−1)) and parent (C(n−1,k−1) compositions with exactly k parts): this file computes the first moment — the total and mean number of parts across all compositions of n. States the headline results total_parts and two_mul_total_parts/mean_parts, and previews the route (the bridge length = gaps.card + 1 transported along the gap bijection, reducing to the elementary subset-sum m·2^(m−1)) before opening the namespace and Finset."
+    },
+    {
       "id": "gap-bridge",
       "title": "The Gap Bijection and the Part-Count Bridge",
       "startLine": 61,


### PR DESCRIPTION
## Summary
- `sections` in meta.json covered lines 61-205 of the 207-line Lean file, leaving the file docstring/imports header (lines 1-60) uncovered — a genuine content gap, not filler (the header states the problem, headline results, and proof route).
- Added a `header` section (lines 1-60) summarizing the imports and docstring, matching the depth already present in the existing `ann-overview` annotation covering the same range.
- No other fields touched; meta.json stays well under the 60 KB size cap (16.4 KB).

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — JSON validates
- [x] `npx tsx scripts/gallery/check-meta-size.ts composition-parts-choose-oq-01-oq-01` — within caps