### PR TITLE
Enrich composition-card-2pow-oq-01-oq-01: cover header docstring (lines 1-50)

### DIFF
--- a/src/data/proofs/composition-card-2pow-oq-01-oq-01/meta.json
+++ b/src/data/proofs/composition-card-2pow-oq-01-oq-01/meta.json
@@ -73,6 +73,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Imports and Docstring: the By-Length Refinement",
+      "startLine": 1,
+      "endLine": 50,
+      "mathContext": "Goal: $\\#\\{c:\\mathrm{Composition}\\ n \\mid c.\\mathrm{length}=k\\} = \\binom{n-1}{k-1}$, summing to $2^{n-1}$.",
+      "summary": "Imports Composition, Fintype.Powerset, Nat.Choose.Sum, and Tactic, then a docstring stating the by-length refinement of the parent's total count: compositions of n into exactly k parts number C(n−1, k−1), recovering the parent's 2^(n−1) by summing over k. Previews the route — Mathlib's compositionEquiv/compositionAsSetEquiv bijection to gap subsets, the length↔cardinality dictionary equiv_card_add_one, and Fintype.card_finset_len for counting fixed-cardinality subsets — before opening Finset and the namespace."
+    },
+    {
       "id": "length-cardinality-dictionary",
       "title": "The Length ↔ Subset-Cardinality Dictionary",
       "startLine": 51,


### PR DESCRIPTION
## Summary
- `sections` in meta.json covered lines 51-189 of the 189-line Lean file, leaving the module docstring/imports header (lines 1-50) uncovered — genuine content (problem statement, proof route preview), not filler.
- Added a `header` section (lines 1-50) summarizing the imports and docstring, matching the depth of the existing annotation covering the same range.
- No other fields touched; meta.json stays well under the 60 KB size cap.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — JSON validates
- [x] `npx tsx scripts/gallery/check-meta-size.ts composition-card-2pow-oq-01-oq-01` — within caps