### PR TITLE
Enrich det-conjugate-transpose-oq-01: cover header docstring (lines 1-36)

### DIFF
--- a/src/data/proofs/det-conjugate-transpose-oq-01/meta.json
+++ b/src/data/proofs/det-conjugate-transpose-oq-01/meta.json
@@ -125,6 +125,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "File Docstring and Imports",
+      "startLine": 1,
+      "endLine": 36,
+      "mathContext": "$\\det(M^{\\mathsf H}) = \\overline{\\det M}$, with the Hermitian-reality and unitary-unit-circle corollaries previewed.",
+      "summary": "Module docstring stating the base identity det Mᴴ = star (det M) over a StarRing, noting it re-exports Mathlib's Matrix.det_conjTranspose (previously absent from the gallery), and previewing the two structural corollaries: Hermitian matrices have a self-adjoint (over ℂ, real) determinant, and unitary matrices have a determinant of modulus one. Imports Determinant.Basic, Hermitian, and the Complex circle API; opens Matrix and the namespace."
+    },
+    {
       "id": "base-identity",
       "title": "The Base Identity det Mᴴ = star (det M)",
       "startLine": 37,


### PR DESCRIPTION
## Summary
- `sections` in meta.json covered lines 37-112 of the 113-line Lean file, leaving the module docstring/imports header (lines 1-36) uncovered — genuine content (states the base identity and previews both corollaries), not filler.
- Added a `header` section (lines 1-36) summarizing the docstring, matching the depth of the existing annotation covering the same range.
- No other fields touched; meta.json stays well under the 60 KB size cap.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — JSON validates
- [x] `npx tsx scripts/gallery/check-meta-size.ts det-conjugate-transpose-oq-01` — within caps