### PR TITLE
Research: erdos-116-wip-01 — exact lemniscate areas (z^n extremal = π, degree-1 invariance)

### DIFF
--- a/proofs/Proofs/Erdos116WIP01.lean
+++ b/proofs/Proofs/Erdos116WIP01.lean
@@ -168,4 +168,130 @@ theorem sublevelMeasure_pos (P : UnitDiskPoly n) (hn : 0 < n) :
   exact ENNReal.toReal_pos (P.volume_realProd_sublevelSet_pos hn).ne'
     (P.volume_realProd_sublevelSet_lt_top).ne
 
+/-! ## Exact areas: the extremal configuration `p(z) = zⁿ` and degree one
+
+The Erdős–Herzog–Piranian extremal candidate puts all `n` roots at the origin,
+`p(z) = zⁿ`.  Its lemniscate is *exactly* the open unit disk — `‖zⁿ‖ = ‖z‖ⁿ < 1`
+iff `‖z‖ < 1` — so its area is exactly `π` (`Complex.volume_ball`).  At degree
+one every lemniscate is a unit disk `ball z₀ 1`, so the area is identically `π`
+wherever the root sits.  These are the first *exact* area values in this
+development: everything before only pinned `0 < area < ∞`.  In particular the
+value `π` of the conjectured maximizer is attained at every degree `n ≥ 1`
+(`exists_sublevelMeasure_eq_pi`), which is the "attainment" half of the sharp
+Pólya-type upper bound `sublevelMeasure P ≤ π` (the other half is the deep
+open content and stays out of this file). -/
+
+/-- The extremal candidate: all `n` roots at the origin, so `p(z) = zⁿ`. -/
+noncomputable def allRootsZero (n : ℕ) : UnitDiskPoly n :=
+  ⟨fun _ => (0 : ℂ), fun _ => by simp [Complex.abs]⟩
+
+/-- The extremal candidate evaluates to `p(z) = zⁿ`: a product of `n` copies of
+the single factor `z - 0 = z`. -/
+theorem eval_allRootsZero (n : ℕ) (z : ℂ) : (allRootsZero n).eval z = z ^ n := by
+  simp [UnitDiskPoly.eval, allRootsZero, Finset.prod_const]
+
+/-- **The extremal lemniscate is exactly the open unit disk.**  For `n ≠ 0`,
+`{z : ‖zⁿ‖ < 1} = ball 0 1`, since `‖zⁿ‖ = ‖z‖ⁿ` and, for a nonnegative base,
+`‖z‖ⁿ < 1 ↔ ‖z‖ < 1`. -/
+theorem sublevelSet_allRootsZero (hn : n ≠ 0) :
+    (allRootsZero n).sublevelSet = Metric.ball (0 : ℂ) 1 := by
+  ext z
+  constructor
+  · intro hz
+    have h1 : ‖(allRootsZero n).eval z‖ < 1 := hz
+    rw [eval_allRootsZero, norm_pow] at h1
+    rw [Metric.mem_ball, dist_zero_right]
+    exact (pow_lt_one_iff_of_nonneg (norm_nonneg z) hn).mp h1
+  · intro hz
+    rw [Metric.mem_ball, dist_zero_right] at hz
+    show ‖(allRootsZero n).eval z‖ < 1
+    rw [eval_allRootsZero, norm_pow]
+    exact (pow_lt_one_iff_of_nonneg (norm_nonneg z) hn).mpr hz
+
+/-- **`volume Sₚ = π` for the extremal candidate** (`ℂ`-side): the lemniscate is
+the unit ball, whose planar volume is `π` (`Complex.volume_ball`). -/
+theorem volume_sublevelSet_allRootsZero (hn : n ≠ 0) :
+    volume ((allRootsZero n).sublevelSet) = NNReal.pi := by
+  rw [sublevelSet_allRootsZero hn, Complex.volume_ball]
+  simp
+
+/-- The parent's `ℝ × ℝ` volume of the extremal lemniscate is `π`, transported
+across the volume-preserving equivalence `ℂ ≃ᵐ ℝ × ℝ` (same route as
+`volume_realProd_sublevelSet_lt_top`). -/
+theorem volume_realProd_sublevelSet_allRootsZero (hn : n ≠ 0) :
+    volume {p : ℝ × ℝ | Complex.abs ((allRootsZero n).eval ⟨p.1, p.2⟩) < 1}
+      = NNReal.pi := by
+  rw [(allRootsZero n).realProd_sublevelSet_eq_preimage]
+  have hmp := Complex.volume_preserving_equiv_real_prod.symm Complex.measurableEquivRealProd
+  rw [hmp.measure_preimage (allRootsZero n).measurableSet_sublevelSet.nullMeasurableSet]
+  exact volume_sublevelSet_allRootsZero hn
+
+/-- **The conjectured maximizer has lemniscate area exactly `π`.**  The parent's
+`sublevelMeasure` of `p(z) = zⁿ` is `π` on the nose for every `n ≠ 0` — the
+first exact value of `sublevelMeasure` in this development. -/
+theorem sublevelMeasure_allRootsZero (hn : n ≠ 0) :
+    sublevelMeasure (allRootsZero n) = Real.pi := by
+  rw [sublevelMeasure, volume_realProd_sublevelSet_allRootsZero hn]
+  simp [NNReal.coe_real_pi]
+
+/-- The degree-`1` polynomial `p(z) = z - z₀` with its single root `z₀` in the
+closed unit disk. -/
+noncomputable def singleRoot (z₀ : ℂ) (hz₀ : Complex.abs z₀ ≤ 1) : UnitDiskPoly 1 :=
+  ⟨fun _ => z₀, fun _ => hz₀⟩
+
+/-- The degree-`1` polynomial evaluates to `z - z₀`. -/
+theorem eval_singleRoot (z₀ : ℂ) (hz₀ : Complex.abs z₀ ≤ 1) (z : ℂ) :
+    (singleRoot z₀ hz₀).eval z = z - z₀ := by
+  simp [UnitDiskPoly.eval, singleRoot]
+
+/-- **Every degree-`1` lemniscate is a unit disk**: `{z : ‖z - z₀‖ < 1} = ball z₀ 1`. -/
+theorem sublevelSet_singleRoot (z₀ : ℂ) (hz₀ : Complex.abs z₀ ≤ 1) :
+    (singleRoot z₀ hz₀).sublevelSet = Metric.ball z₀ 1 := by
+  ext z
+  constructor
+  · intro hz
+    have h1 : ‖(singleRoot z₀ hz₀).eval z‖ < 1 := hz
+    rw [eval_singleRoot] at h1
+    rw [Metric.mem_ball, dist_eq_norm]
+    exact h1
+  · intro hz
+    rw [Metric.mem_ball, dist_eq_norm] at hz
+    show ‖(singleRoot z₀ hz₀).eval z‖ < 1
+    rw [eval_singleRoot]
+    exact hz
+
+/-- `volume Sₚ = π` at degree `1` (`ℂ`-side), independent of the root. -/
+theorem volume_sublevelSet_singleRoot (z₀ : ℂ) (hz₀ : Complex.abs z₀ ≤ 1) :
+    volume ((singleRoot z₀ hz₀).sublevelSet) = NNReal.pi := by
+  rw [sublevelSet_singleRoot, Complex.volume_ball]
+  simp
+
+/-- The parent's `ℝ × ℝ` volume at degree `1` is `π`, transported across
+`ℂ ≃ᵐ ℝ × ℝ` as above. -/
+theorem volume_realProd_sublevelSet_singleRoot (z₀ : ℂ) (hz₀ : Complex.abs z₀ ≤ 1) :
+    volume {p : ℝ × ℝ | Complex.abs ((singleRoot z₀ hz₀).eval ⟨p.1, p.2⟩) < 1}
+      = NNReal.pi := by
+  rw [(singleRoot z₀ hz₀).realProd_sublevelSet_eq_preimage]
+  have hmp := Complex.volume_preserving_equiv_real_prod.symm Complex.measurableEquivRealProd
+  rw [hmp.measure_preimage (singleRoot z₀ hz₀).measurableSet_sublevelSet.nullMeasurableSet]
+  exact volume_sublevelSet_singleRoot z₀ hz₀
+
+/-- **At degree `1` the lemniscate area is identically `π`**, wherever the root
+sits in the closed unit disk: `sublevelMeasure (z - z₀) = π` for all `‖z₀‖ ≤ 1`.
+So at degree one the area functional is *constant* — the extremal problem only
+becomes nontrivial from degree `2` on. -/
+theorem sublevelMeasure_singleRoot (z₀ : ℂ) (hz₀ : Complex.abs z₀ ≤ 1) :
+    sublevelMeasure (singleRoot z₀ hz₀) = Real.pi := by
+  rw [sublevelMeasure, volume_realProd_sublevelSet_singleRoot z₀ hz₀]
+  simp [NNReal.coe_real_pi]
+
+/-- **The conjectured extremal value `π` is attained at every degree `n ≥ 1`:**
+some `UnitDiskPoly n` has lemniscate area exactly `π` (namely `p(z) = zⁿ`).
+So the supremum of the area functional over `UnitDiskPoly n` is at least `π`,
+and if the deep sharp upper bound `sublevelMeasure P ≤ π` holds, that supremum
+equals `π` and is achieved. -/
+theorem exists_sublevelMeasure_eq_pi (hn : n ≠ 0) :
+    ∃ P : UnitDiskPoly n, sublevelMeasure P = Real.pi :=
+  ⟨allRootsZero n, sublevelMeasure_allRootsZero hn⟩
+
 end UnitDiskPoly

--- a/research/problems/erdos-116-wip-01/knowledge.md
+++ b/research/problems/erdos-116-wip-01/knowledge.md
@@ -155,3 +155,16 @@ truncates to `0`). This session discharges that finiteness:
 (open, measurable, bounded, finite planar measure). Remaining targets are the deep
 quantitative bounds — Pólya `π` upper bound and KLR `c/log n` lower bound — which rest on
 logarithmic-potential / area-of-lemniscate machinery absent from Mathlib.
+
+## Session 2026-07-22 (researcher-1): exact areas at the extremal configuration
+
+- `p(z) = zⁿ` (all roots 0) has lemniscate exactly the open unit disk: `‖zⁿ‖ = ‖z‖ⁿ < 1
+  ↔ ‖z‖ < 1` (`pow_lt_one_iff_of_nonneg`, needs `n ≠ 0`). Area = π on the nose via
+  `Complex.volume_ball` (`= .ofReal r ^ 2 * NNReal.pi`, simp closes at r = 1), then the
+  usual `ℂ ≃ᵐ ℝ × ℝ` volume-preserving transport to the parent's `sublevelMeasure`.
+- Degree 1: `{z : ‖z - z₀‖ < 1} = ball z₀ 1` (just `dist_eq_norm`), so the area
+  functional is constant π over the whole root disk at n = 1.
+- `exists_sublevelMeasure_eq_pi (hn : n ≠ 0) : ∃ P, sublevelMeasure P = Real.pi` —
+  formalizes that the conjectured maximizer attains π at every degree.
+- Lean idiom: membership in `sublevelSet` is defeq to `‖P.eval z‖ < 1` (the parent's
+  `Complex.abs` compat def unfolds by `rfl`); `show ‖_‖ < 1` converts cleanly.

--- a/research/problems/erdos-116-wip-01/state.md
+++ b/research/problems/erdos-116-wip-01/state.md
@@ -54,3 +54,20 @@ upgrading the gallery entry, not chased at the elementary layer. **STAND DOWN.**
 Lebesgue measure; bridge the parent's `ℝ×ℝ` sublevel set to `Sₚ ⊆ ℂ` via the
 `ℂ ≅ ℝ²` measure isomorphism, then `measure_lt_top`.~~ Done. See S4 above: elementary
 layer saturated; remaining work is deep potential theory (deep-blocked).
+
+## Status (S5, researcher-1, 2026-07-22) — exact areas: z^n extremal = π, degree-1 invariance
+
+New rung the saturated well-definedness layer did not cover: **exact values** of the
+area functional (everything before only pinned `0 < μ < ∞`). All 0-axiom,
+host-verified (`lake env lean` exit 0, fresh v4.31 olean chain):
+- `allRootsZero n` (all roots at 0, `p(z) = zⁿ`): `sublevelSet = ball 0 1` exactly
+  (`pow_lt_one_iff_of_nonneg`), `volume = π` (`Complex.volume_ball`), and
+  `sublevelMeasure (allRootsZero n) = Real.pi` — first exact area value in the vein.
+- `singleRoot z₀`: every degree-1 lemniscate is `ball z₀ 1`, so `sublevelMeasure ≡ π`
+  independent of the root — the extremal problem is degenerate at degree 1.
+- `exists_sublevelMeasure_eq_pi`: the conjectured extremal value π is attained at
+  every degree n ≥ 1 — the attainment half of the sharp Pólya-type upper bound.
+
+Remaining moves are still only the DEEP ones (KLR `c/log n` lower, Pólya `π` upper,
+the `1/log n` vs `1/log log n` gap — logarithmic potential theory absent from
+Mathlib). Elementary layer now saturated *including* exact-value computations.

--- a/src/data/research/problems/erdos-116-wip-01.json
+++ b/src/data/research/problems/erdos-116-wip-01.json
@@ -37,13 +37,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-1, 2026-07-20, host-verified lake env lean exit 0, #print axioms=[propext,Classical.choice,Quot.sound] on all 3): sublevelMeasure well-definedness discharged — volume Sₚ<⊤ (ℂ-side, compact closed ball) and, via the volume-preserving ℂ≃ᵐℝ² equiv, the parent ℝ×ℝ sublevel measure is finite, so sublevelMeasure=(volume).toReal is faithful. Key lemma 1 (open/measurable/bounded) done previously. Deep KLR c/log n lower and Pólya π upper bounds remain unformalized (potential theory not in Mathlib).",
+    "progressSummary": "PROGRESS (researcher-1, 2026-07-22, host-verified lake env lean exit 0): EXACT lemniscate areas added — extremal candidate z^n has sublevelSet = ball 0 1 and sublevelMeasure = pi on the nose (all n>=1); degree-1 lemniscates are unit disks so area is identically pi; exists_sublevelMeasure_eq_pi gives the attainment half of the sharp Polya-type bound. Well-definedness layer (open/measurable/bounded/finite/positive) was already complete. Remaining: deep KLR c/log n lower and Polya pi upper bounds (logarithmic potential theory, not in Mathlib).",
     "builtItems": [
       "UnitDiskPoly.eval_root_eq_zero / root_mem_sublevelSet / sublevelSet_nonempty / eval_of_degree_zero / sublevelSet_of_degree_zero / sublevelMeasure_nonneg in proofs/Proofs/Erdos116Problem.lean (6 axiom-free foundational theorems; host-verified v4.31, #print axioms = propext/Classical.choice/Quot.sound only)",
       "proofs/Proofs/Erdos116WIP01.lean — 6 axiom-free decls (continuous_eval, sublevelSet_eq_preimage, isOpen_sublevelSet, measurableSet_sublevelSet, sublevelSet_subset_closedBall, isBounded_sublevelSet)",
       "volume_sublevelSet_lt_top — volume Sₚ < ⊤: Sₚ⊆closedBall 0 2, compact in proper space ℂ, finite measure (Erdos116WIP01.lean)",
       "realProd_sublevelSet_eq_preimage — parent ℝ×ℝ sublevel set = measurableEquivRealProd.symm ⁻¹ Sₚ (Erdos116WIP01.lean)",
-      "volume_realProd_sublevelSet_lt_top — parent sublevelMeasure volume is finite, via volume-preserving ℂ≃ᵐℝ² (Erdos116WIP01.lean)"
+      "volume_realProd_sublevelSet_lt_top — parent sublevelMeasure volume is finite, via volume-preserving ℂ≃ᵐℝ² (Erdos116WIP01.lean)",
+      "allRootsZero/eval_allRootsZero/sublevelSet_allRootsZero/volume_sublevelSet_allRootsZero/volume_realProd_sublevelSet_allRootsZero/sublevelMeasure_allRootsZero in Erdos116WIP01.lean (z^n extremal config, area = pi)",
+      "singleRoot/eval_singleRoot/sublevelSet_singleRoot/volume_sublevelSet_singleRoot/volume_realProd_sublevelSet_singleRoot/sublevelMeasure_singleRoot (degree-1 area identically pi)",
+      "exists_sublevelMeasure_eq_pi (pi attained at every degree n >= 1)"
     ],
     "insights": [
       "Erdos116Problem.lean was a bare statement-stub: real definitions (UnitDiskPoly, eval, sublevelSet, sublevelMeasure) but ZERO theorems, while gallery meta prose falsely described four bounds \"stated as axioms\" and a main theorem ErdosProblem116 that did not exist in source.",
@@ -53,7 +56,10 @@
       "Sₚ ⊆ closedBall 0 2 (BOUNDED): if ‖z‖>2 then each factor ‖z-zᵢ‖ ≥ ‖z‖-‖zᵢ‖ ≥ ‖z‖-1 > 1 (roots in unit disk), so ‖p(z)‖=∏‖z-zᵢ‖ ≥ 1 and z∉Sₚ. Holds for all n incl. n=0 (Sₚ=∅).",
       "Lean gotcha: Finset.one_le_prod does NOT work on ℝ (needs MulLeftMono ℝ, false for a field with negatives). Use Finset.prod_le_prod against the constant-1 product: 1 = ∏ 1 ≤ ∏ f via Finset.prod_const_one. norm_prod rewrites ‖∏ f‖ = ∏ ‖f‖; norm_sub_norm_le for the reverse-triangle per-factor bound.",
       "sublevelMeasure well-definedness DISCHARGED: the parent defines sublevelMeasure = (volume {p:ℝ×ℝ|...}).toReal; proving that volume < ⊤ makes the .toReal faithful (not the ⊤↦0 truncation). Bridge: parent ℝ×ℝ set = Complex.measurableEquivRealProd.symm ⁻¹ Sₚ; Complex.volume_preserving_equiv_real_prod.symm + MeasurePreserving.measure_preimage transports volume to the ℂ side, bounded by volume(closedBall 0 2)<⊤ via IsCompact.measure_lt_top.",
-      "Key Mathlib names: isCompact_closedBall (ℂ ProperSpace) + IsCompact.measure_lt_top (volume IsFiniteMeasureOnCompacts); measure_lt_top_of_subset; Complex.measurableEquivRealProd{,_symm_apply}; measure_preimage needs NullMeasurableSet (use .measurableSet.nullMeasurableSet)."
+      "Key Mathlib names: isCompact_closedBall (ℂ ProperSpace) + IsCompact.measure_lt_top (volume IsFiniteMeasureOnCompacts); measure_lt_top_of_subset; Complex.measurableEquivRealProd{,_symm_apply}; measure_preimage needs NullMeasurableSet (use .measurableSet.nullMeasurableSet).",
+      "The extremal candidate p(z)=z^n has lemniscate EXACTLY ball 0 1 (pow_lt_one_iff_of_nonneg on ||z||^n), so its area is exactly pi via Complex.volume_ball — first exact value of sublevelMeasure in the vein",
+      "At degree 1 the area functional is CONSTANT: every lemniscate {|z-z0|<1} is ball z0 1 of area pi regardless of root position — the extremal problem only becomes nontrivial at degree >= 2",
+      "Attainment half of the sharp Polya-type upper bound is now formal: exists P : UnitDiskPoly n, sublevelMeasure P = pi for every n >= 1; only the inequality sublevelMeasure P <= pi remains (deep, potential theory)"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for erdos-116-wip-01 (Erdős–Herzog–Piranian lemniscate area, `proofs/Proofs/Erdos116WIP01.lean`).

## Progress
Adds the first **exact values** of the area functional to the vein — every prior session only pinned well-definedness (`0 < μ < ∞`). 13 new declarations, all 0-axiom / 0-sorry:

- `allRootsZero n` — the extremal candidate `p(z) = zⁿ` (all roots at the origin): its lemniscate is **exactly** `ball 0 1` (`pow_lt_one_iff_of_nonneg`), so `volume = π` (`Complex.volume_ball`) and `sublevelMeasure (allRootsZero n) = Real.pi` on the nose, for every `n ≠ 0`.
- `singleRoot z₀` — every degree-1 lemniscate `{z : ‖z - z₀‖ < 1}` is `ball z₀ 1`, so at degree 1 the area functional is **identically π**, wherever the root sits: the extremal problem is degenerate below degree 2.
- `exists_sublevelMeasure_eq_pi` — the conjectured extremal value π is **attained** at every degree `n ≥ 1`: the attainment half of the sharp Pólya-type upper bound (the inequality `sublevelMeasure P ≤ π` itself is the deep open content and stays out of the file).

## Verification
- Host-verified at v4.31.0: `lake env lean Proofs/Erdos116WIP01.lean` exit 0.
- `#print axioms` on `eval_allRootsZero`, `sublevelSet_allRootsZero`, `sublevelMeasure_allRootsZero`, `sublevelMeasure_singleRoot`, `exists_sublevelMeasure_eq_pi`: `[propext, Classical.choice, Quot.sound]` only.

## Files Modified
- `proofs/Proofs/Erdos116WIP01.lean` (+134 lines, 13 decls)
- `src/data/research/problems/erdos-116-wip-01.json`, `research/problems/erdos-116-wip-01/{state.md,knowledge.md}` (S5 session notes)

## Status
**Outcome**: progress
**Next Steps**: only DEEP targets remain (KLR c/log n lower bound, Pólya π upper bound — logarithmic potential theory absent from Mathlib). Elementary layer now saturated including exact-value computations.

🤖 Generated by researcher-1
