### PR TITLE
Enrich dirichlet-approximation-theorem-oq-03-oq-03: cover header and tail sections

### DIFF
--- a/src/data/proofs/dirichlet-approximation-theorem-oq-03-oq-03/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-03-oq-03/meta.json
@@ -93,6 +93,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Docstring: Packaging the Determinant–Shear Volume Technique",
+      "startLine": 1,
+      "endLine": 54,
+      "mathContext": "Goal: $\\operatorname{vol}(M\\cdot[a,b]) = |\\det M|\\prod_i(b_i-a_i)$, closing the parent's open $\\operatorname{vol}(K(\\alpha,N))=4$ step.",
+      "summary": "Docstring framing the entry against the parent's single open volume step (volume(body α N) = 4) and packaging the general-dimension 'volume = |det| · box volume' lemma its third open question requested. Previews the five results (the reusable core, unit-cube volume, concrete parallelepiped volume, the 2-D shoelace specialisation, and the Dirichlet-body closure) and notes the relation to Mathlib's abstract addHaar_image_linearMap / addHaar_parallelepiped. import Mathlib only; opens the namespace."
+    },
+    {
       "id": "reusable-core",
       "title": "The Reusable Core: volume of a box-image = |det| · box volume",
       "startLine": 55,
@@ -112,7 +120,7 @@
       "id": "plane-and-dirichlet",
       "title": "The Plane Specialisation and the Dirichlet Body Volume",
       "startLine": 106,
-      "endLine": 123,
+      "endLine": 130,
       "mathContext": "Area of the $(a,b),(c,d)$ parallelogram $= |ad - bc|$; $\\operatorname{vol}(\\text{shear}\\cdot[-N,N]\\times[-1/N,1/N]) = 4$.",
       "summary": "volume_parallelogram_2d evaluates Matrix.det_fin_two on the 2×2 coordinate matrix to recover the shoelace area |a·d − b·c|. volume_dirichlet_body instantiates the core lemma at the shear !![1,0; α,−1] (determinant −1 by Matrix.det_fin_two_of) and the box [−N,N]×[−1/N,1/N]: |det| = 1 and the sides (2N)(2/N) = 4 (ENNReal.ofReal_mul, N > 0), closing the parent entry's open volume(K) = 4 step."
     }


### PR DESCRIPTION
## Summary
- `sections` in meta.json covered lines 55-123 of the 130-line Lean file. Two genuine gaps:
  - The module docstring/import header (lines 1-54) was uncovered, though the existing annotation already covers roughly the same range.
  - The last section (`plane-and-dirichlet`) ended at line 123, five lines short of the theorem's actual proof end (line 130) — extended to 130 so the closing `volume_dirichlet_body` proof lines aren't orphaned.
- Added a `header` section (lines 1-54) and extended the tail section's `endLine` to 130.
- No other fields touched; meta.json stays well under the 60 KB size cap.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — JSON validates
- [x] `npx tsx scripts/gallery/check-meta-size.ts dirichlet-approximation-theorem-oq-03-oq-03` — within caps