### PR TITLE
Enrich erdos-1009-oq-03: cover header docstring (lines 1-56)

### DIFF
--- a/src/data/proofs/erdos-1009-oq-03/annotations.json
+++ b/src/data/proofs/erdos-1009-oq-03/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ek4gap-overview",
+    "proofId": "erdos-1009-oq-03",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "context",
+    "title": "The Integrality-Gap Question and the K₄ Witness",
+    "content": "The docstring frames OQ-03 against the parent Erdős #1009 result (Györi 1988): once large edge-disjoint triangle packings are known to exist, the algorithmic question is how hard they are to compute. Maximum edge-disjoint triangle packing is NP-hard, while its linear-programming relaxation is polynomial; whenever the fractional optimum ν* strictly exceeds the integer optimum ν, the LP value cannot recover the integer answer. This file certifies that separation on the smallest possible witness, K₄: only one triangle fits in an integer packing (any two of K₄'s four triangles share an edge), yet the uniform ½-weighting on all four triangles is a feasible fractional packing of value 2, since each of the six edges lies in exactly two triangles. The file is self-contained, adapting the parent's Triangle/edgeDisjoint idea to a concrete decidable Fin 4 model rather than the parent's non-computable sSup-based maximum.",
+    "mathContext": "$\\nu(K_4) = 1$ (integer optimum) vs. $\\nu^*(K_4) \\ge 2$ (fractional optimum via uniform weight $\\tfrac12$): a factor-2 integrality gap on the canonical smallest witness.",
+    "significance": "key",
+    "relatedConcepts": ["integrality gap", "LP relaxation", "NP-hardness", "fractional packing", "K₄"],
+    "prerequisites": ["linear programming duality", "edge-disjoint triangle packing", "decidable finite models"]
+  },
+  {
     "id": "ek4gap-model",
     "proofId": "erdos-1009-oq-03",
     "range": { "startLine": 57, "endLine": 74 },

--- a/src/data/proofs/erdos-1009-oq-03/meta.json
+++ b/src/data/proofs/erdos-1009-oq-03/meta.json
@@ -93,6 +93,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Docstring: the Integrality-Gap Certificate on K₄",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Docstring framing OQ-03's complexity question against the parent's Györi 1988 existence theorem, stating the two headline numbers ν(K₄) = 1 and ν*(K₄) ≥ 2, and previewing why K₄ works: its four triangles pairwise share an edge (integer bound 1), while each of its six edges lies in exactly two triangles so uniform ½-weights are feasible with value 2. Notes the file is self-contained, reuses the parent's Triangle/edgeDisjoint idea on a concrete decidable Fin 4 model, and is 0-sorry/0-axiom with only kernel-checked decide.",
+      "mathContext": "Certifies $\\nu(K_4)=1 < \\nu^*(K_4) \\ge 2$: the LP relaxation of maximum edge-disjoint triangle packing is not tight, already on the smallest witness."
+    },
+    {
       "id": "model",
       "title": "Decidable Model of K₄",
       "startLine": 57,


### PR DESCRIPTION
## Summary
- Both `sections` and `annotations.json` skipped the module docstring (lines 1-56 of the 191-line file) — a genuine gap, not filler: the docstring states OQ-03's complexity question, the two headline numbers ν(K₄)=1 and ν*(K₄)≥2, and the informal reason K₄ works.
- Added a `header` section and a matching `ek4gap-overview` annotation covering lines 1-56.
- No other fields touched; meta.json stays well under the 60 KB size cap.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` on both files — JSON validates
- [x] `npx tsx scripts/gallery/check-meta-size.ts erdos-1009-oq-03` — within caps