### PR TITLE
Enrich cube-root-3-irrational-oq-03-oq-02: cover header docstring (lines 1-49)

### DIFF
--- a/src/data/proofs/cube-root-3-irrational-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-03-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "header-overview",
+    "proofId": "cube-root-3-irrational-oq-03-oq-02",
+    "range": { "startLine": 1, "endLine": 49 },
+    "type": "concept",
+    "title": "Doubling the Cube: the Algebraic Reduction of Constructibility",
+    "content": "The module docstring frames the file as the geometric corollary of the parent's degree computation [ℚ(∛3):ℚ] = 3 (finrank_adjoin_cbrt3): since Mathlib has no development of ruler-and-compass constructibility as a geometric notion, the file adopts the standard algebraic characterization directly as a definition — a real number is constructible iff it lies in a field reached from ℚ by a finite tower of quadratic (degree-2) extensions (IsQuadraticTower). The classical geometry⟺algebra equivalence (each ruler/compass step intersects lines and circles, adjoining at most a square root) is explicitly flagged as the one unformalized, universally-accepted step; everything downstream of the definition is fully verified. It previews the four results: quadratic towers have 2-power degree, hence so do constructible numbers, hence any degree not a power of 2 obstructs constructibility, and ∛3 (degree 3) fails this test — resolving the Delian problem of doubling the cube.",
+    "mathContext": "Constructible$(\\alpha)$ $:\\Leftrightarrow$ $\\alpha$ lies in a tower $\\mathbb{Q}=K_0\\subseteq\\cdots\\subseteq K_n$ with each $[K_{i+1}:K_i]=2$ — taken as the *definition*, with the geometric⟺algebraic equivalence itself classical and unformalized.",
+    "significance": "context",
+    "relatedConcepts": ["ruler-and-compass constructions", "doubling the cube", "Delian problem", "Wantzel's theorem", "algebraic characterization of constructibility"],
+    "prerequisites": ["field extensions", "the parent entry's degree computation [ℚ(∛3):ℚ] = 3"]
+  },
+  {
     "id": "quadratic-tower-def",
     "proofId": "cube-root-3-irrational-oq-03-oq-02",
     "range": { "startLine": 51, "endLine": 64 },

--- a/src/data/proofs/cube-root-3-irrational-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-03-oq-02/meta.json
@@ -98,6 +98,14 @@
   ],
   "sections": [
     {
+      "id": "header-overview",
+      "title": "Module Header: Doubling the Cube via the Algebraic Characterization",
+      "startLine": 1,
+      "endLine": 49,
+      "mathContext": "Constructible$(\\alpha) :\\Leftrightarrow \\alpha$ lies in a tower $\\mathbb{Q}=K_0\\subseteq\\cdots\\subseteq K_n$, each $[K_{i+1}:K_i]=2$.",
+      "summary": "The module docstring frames this entry as the geometric corollary of the parent's degree computation [ℚ(∛3):ℚ] = 3. Since Mathlib lacks a geometric development of ruler-and-compass constructibility, the file adopts the classical algebraic characterization directly as the definition IsQuadraticTower — a real number is constructible iff it lies in a field reached from ℚ by a finite tower of quadratic extensions — explicitly flagging the geometry⟺algebra equivalence itself (Wantzel's reduction) as the one unformalized, universally-accepted step. It previews the four results proved: quadratic towers have 2-power degree, constructible numbers inherit 2-power degree, any non-2-power degree obstructs constructibility, and ∛3 (degree 3) fails this test, resolving the Delian problem of doubling the cube."
+    },
+    {
       "id": "quadratic-towers",
       "title": "Quadratic Towers over ℚ and Their Degree",
       "startLine": 51,


### PR DESCRIPTION
## Summary
- Both `sections` and `annotations.json` started at line 51, leaving the module docstring (lines 1-49 — the Delian-problem framing, the algebraic characterization of constructibility adopted as a definition, and the explicit flag that the geometry⟺algebra equivalence itself is the one unformalized step) with no coverage at all.
- Adds a `header-overview` entry to both `annotations.json` and `sections` (lines 1-49) summarizing that content.
- No other fields touched; file stays well under the 60 KB size cap (~13.8 KB meta, ~7.9 KB annotations).

## Test plan
- [x] `jq empty meta.json annotations.json` — valid JSON
- [x] `pnpm build` succeeds (gallery build + bundle budget checks pass)