### PR TITLE
audit: re-serve cauchy-schwarz-integral-oq-01 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4657,9 +4657,9 @@
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-01": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:32Z",
+      "lastAudited": "2026-07-22T18:37:21Z",
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-01-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — clean

**Proof**: cauchy-schwarz-integral-oq-01 (Hölder's Inequality as a Generalization of Cauchy-Schwarz)

Verified against `proofs/Proofs/CauchySchwarzIntegralOQ01.lean`:
- 9 theorems (young_p2q2, holder_lintegral, holder_nnreal_lintegral, holder_conj_2_2, cauchy_schwarz_from_holder, cauchy_schwarz_nnreal_from_holder, holder_real_lintegral, cauchy_schwarz_real_from_holder, minkowski_l2) — matches claimed theoremCount
- 0 axioms, 0 sorries, 228 lines — all match
- All 8 `originalContributions` bullets map to real declarations
- All 4 `mathlibDependencies` entries genuinely used in the file
- Badge `mathlib` correctly applied — core result wraps `ENNReal.lintegral_mul_le_Lp_mul_Lq`, no overclaiming of independent proof
- No native_decide usage

No issues found. Bumping audit-tracker.json.