### PR TITLE
Enrich erdos-1025-oq-04: cover header docstring (lines 1-35)

### DIFF
--- a/src/data/proofs/erdos-1025-oq-04/meta.json
+++ b/src/data/proofs/erdos-1025-oq-04/meta.json
@@ -75,6 +75,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Docstring: Relaxing the Validity Constraint",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "Docstring recalling the parent's valid pair function setup (f x y ≠ x, y) and the Θ(√n) guarantee of Erdős–Hajnal/Spencer/Conlon–Fox–Sudakov, then posing OQ-4: what if degenerate values f x y ∈ {x,y} are allowed, with bounded frequency? Previews the two answers proved below — unbounded degeneracy collapses the guarantee to exactly 1 (the fbad witness), while bounded degeneracy (≤ k pairs) recovers validity on ≥ n − 2k vertices. Imports Mathlib and opens Finset.",
+      "mathContext": "OQ-4: relax `Valid f` to allow `f x y ∈ {x,y}`; ask how the $\\Theta(\\sqrt n)$ independent-set guarantee degrades."
+    },
+    {
       "id": "definitions",
       "title": "Relaxed Pair Functions and Independence",
       "startLine": 36,


### PR DESCRIPTION
## Summary
- `sections` in meta.json covered lines 36-189 of the 189-line file, leaving the module docstring/imports header (lines 1-35) uncovered — genuine content (recalls the parent's Θ(√n) result and poses OQ-4), not filler. The existing annotation already covers most of the same range (1-30).
- Added a `header` section (lines 1-35).
- No other fields touched; meta.json stays well under the 60 KB size cap.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — JSON validates
- [x] `npx tsx scripts/gallery/check-meta-size.ts erdos-1025-oq-04` — within caps