### PR TITLE
Audit: re-serve cantor-diagonalization-oq-02-oq-01 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4106,9 +4106,9 @@
       "result": "clean"
     },
     "cantor-diagonalization-oq-02-oq-01": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:32Z",
+      "lastAudited": "2026-07-22T18:40:03Z",
       "result": "clean"
     },
     "cantor-diagonalization-oq-02-oq-03": {


### PR DESCRIPTION
## Audit Result: Clean

**Proof**: cantor-diagonalization-oq-02-oq-01 (reserve-mode re-audit, queue fully drained 4809/4809)

Verified against `proofs/Proofs/CantorDiagonalizationOQ02OQ01.lean`:
- 15 theorems (matches meta `theoremCount`)
- 0 sorries, 0 axioms, 0 native_decide
- No True-stub placeholders
- lineCount (130) matches actual file
- Badge `mathlib` correct — core results (aleph hierarchy, regularity, cofinality) derive from `Cardinal.aleph_lt_aleph`, `isRegular_aleph_one`, `aleph_succ`, `card_ord`, `lt_ord`
- Prose properly hedged for Tier B: "bridge formalization organizing Mathlib's...", `originalContributions` scoped to the organizing/derived characterizations, not the underlying Mathlib theorems

No issues found. Updates only `audit-tracker.json`.

---
Discovered during gallery integrity audit (reserve mode).