### PR TITLE
audit: mark erdos-963 clean (Dissociated Subsets)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17688,8 +17688,8 @@
     },
     "erdos-963": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:02:33Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-22T18:43:15Z",
       "result": "clean"
     },
     "erdos-964": {


### PR DESCRIPTION
## Audit Result: Clean

**Proof**: erdos-963 (Dissociated Subsets)

Verified counts and claims match reality:
- 23 theorems/lemmas (16 top-level + 7 `private`) — all real, matches meta `theoremCount: 23`
- 4 definitions — matches meta
- 0 axioms, 0 sorries — confirmed via grep and full-file read
- `ErdosProblem963` (the open conjecture) is correctly encoded as an unproved `Prop` def, not asserted via `axiom` or `sorry` — genuinely open, not axiom-masked
- `greedy_lower_bound` and `trivial_upper_bound` proofs verified to actually establish the claimed bounds
- Docstrings honestly distinguish what's proved (`f(n) ≤ n-1`) from the unformalized sharper literature bound (`f(n) ≤ ⌊log₂n⌋+1`)
- All prose/annotation decl names (`IsDissociatedSubset`, `diffSumFinset`, `binary_uniqueness_nat`, etc.) checked against actual declarations — no phantom names
- `status: axiomatized` / `badge: wip` is the standard corpus convention for Tier-C entries with open conjectures, consistent with 0 axioms

No issues found. Updates `audit-tracker.json` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)