### PR TITLE
Enrich de-moivre-oq-03-oq-01-oq-01: cover header docstring (lines 1-36)

### DIFF
--- a/src/data/proofs/de-moivre-oq-03-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/de-moivre-oq-03-oq-01-oq-01/annotations.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "ann-header",
+    "proofId": "de-moivre-oq-03-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 36
+    },
+    "type": "context",
+    "title": "Why This File Exists: Replacing a True Stub",
+    "content": "The module docstring states the parent entry's (de-moivre-oq-03-oq-01) placeholder — `irrational_exponent_single_valued` proved only `True := trivial` — and quotes its first open question: can the real statement be proved from cpow_def_of_ne_zero and the single-valuedness of Complex.log? It previews the answer: the principal value (e^{iθ})^α = e^{iαθ} is single 'almost definitionally' (cpow is a function once the principal branch is fixed), but the substantive content is why there is no multi-valuedness for irrational α — the branch family k ↦ e^{2πiαk} is injective, because the orbit e^{2πiαn} never returns to 1 for n ≠ 0, unlike the rational p/q case which has exactly q distinct values.",
+    "mathContext": "Previews $(e^{i\\theta})^\\alpha = e^{i\\alpha\\theta}$ (single value) and the injectivity of $k \\mapsto e^{2\\pi i\\alpha k}$ for irrational $\\alpha$, contrasting with the $q$-fold ambiguity of rational exponents $p/q$.",
+    "significance": "context",
+    "relatedConcepts": ["True-stub replacement", "principal branch single-valuedness", "rational vs irrational branch structure"],
+    "prerequisites": ["the parent entry's open question", "complex power cpow"]
+  },
+  {
     "id": "ann-principal",
     "proofId": "de-moivre-oq-03-oq-01-oq-01",
     "range": {

--- a/src/data/proofs/de-moivre-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-03-oq-01-oq-01/meta.json
@@ -67,6 +67,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header: Replacing the True Stub",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "States the parent's first open question (prove irrational_exponent_single_valued from cpow_def_of_ne_zero and the single-valuedness of Complex.log) and previews why the irrational case differs from the rational p/q case: the branch family k ↦ e^{2πiαk} is injective, since the orbit never returns to 1, so no integer q creates a finite ambiguity.",
+      "mathContext": "Frames the single-valuedness question and previews the four theorems (principal_value, exp_two_pi_ne_one_of_irrational, branch_injective, irrational_exponent_single_valued)."
+    },
+    {
       "id": "principal",
       "title": "The Single Principal Value",
       "startLine": 37,


### PR DESCRIPTION
## Summary

`de-moivre-oq-03-oq-01-oq-01` had complete annotation/section coverage of the theorem body (lines 37-111) but no annotation or section covering the module docstring (lines 1-29) and imports/namespace boilerplate (30-36). The docstring is genuine content, not boilerplate: it states the parent entry's (`de-moivre-oq-03-oq-01`) first open question, quotes it verbatim, and previews the mathematical resolution (why irrational-exponent branch families are injective while rational ones cycle).

Added:
- A `header` section (`meta.json`, lines 1-36) summarizing the docstring's framing.
- A matching `context`-significance annotation (`annotations.json`) with `mathContext`/`relatedConcepts`/`prerequisites`.

No existing content changed or removed. File sizes remain far under the ~60 KB cap (meta.json: 14.1 KB, annotations.json: 8.1 KB).

## Test plan
- [x] `jq empty` on both modified JSON files
- [x] `pnpm build` passes (validates gallery JSON structure)