### PR TITLE
audit: mark erdos-896 clean (Unique Product Representations)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17202,8 +17202,8 @@
     },
     "erdos-896": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:02:33Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-22T18:46:41Z",
       "result": "clean"
     },
     "erdos-897": {


### PR DESCRIPTION
## Audit Result: Clean

**Proof**: erdos-896 (Unique Product Representations)

Verified counts and claims match reality:
- 1 axiom (`van_doorn_bounds`, Van Doorn's asymptotic bounds) — matches meta `axiomCount: 1`
- 0 sorries, 24 theorems, 8 definitions, 408 lines — all match meta exactly
- No `native_decide`, no True stubs, no phantom decls in `originalContributions`
- Badge `axiom` / status `axiomatized` (Tier C) is honest: the file proves the
  trivial/quadratic bounds and symmetry properties without axioms, and correctly
  discloses only Van Doorn's deep asymptotic result as axiomatized
- Two annotations (`ann-896-4`, `ann-896-7`) mislabel proved theorems
  (`maxUniqueProducts_achieved`, `uniqueProductCount_comm`) as "axioms" —
  understatement-direction (makes the file look weaker than it is), not an
  overclaim, so not filed as a separate integrity issue

---
Discovered during gallery integrity audit (reserve-mode re-serve, oldest audit).