### PR TITLE
Enrich descartes-circle-theorem-oq-01-oq-02-oq-01: add missing header section

### DIFF
--- a/src/data/proofs/descartes-circle-theorem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/descartes-circle-theorem-oq-01-oq-02-oq-01/meta.json
@@ -87,6 +87,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Overview: How Many Curvatures Are Odd?",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "Poses the follow-up question to the sibling integrality leaf: among the four integer curvatures of a Descartes quadruple, how many are odd? Answer: always 0 or 2, and exactly 2 in the primitive (not-all-even) case. Previews the elementary mod-4 argument used throughout.",
+      "mathContext": "$(a+b+c+d)^2 = 2(a^2+b^2+c^2+d^2)$; oddCount $\\in \\{0,2\\}$, and $=2$ when not all of $a,b,c,d$ are even."
+    },
+    {
       "id": "definitions",
       "title": "The Integer Descartes Relation and Odd-Count",
       "startLine": 43,


### PR DESCRIPTION
## Summary

`descartes-circle-theorem-oq-01-oq-02-oq-01` already has a `context`-significance annotation (`descparity-overview`, lines 3-39) covering the module docstring, but the `sections` array skipped it entirely — the first section (`definitions`) starts at line 43, leaving the file's framing (the parity question, the four results proved, and the mod-4 proof sketch) with no `sections` entry.

Added a `header` section (lines 1-42) summarizing the same content the existing annotation already covers, so `sections` now spans the full file.

No existing content changed or removed. File size remains well under the ~60 KB cap (13.8 KB).

## Test plan
- [x] `jq empty` on the modified JSON file
- [x] `pnpm build` passes (validates gallery JSON structure)