### PR TITLE
Enrich erdos-1034-oq-02: cover header/open-question docstring (lines 1-42)

### DIFF
--- a/src/data/proofs/erdos-1034-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1034-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "erdos-1034-oq-02-header",
+    "proofId": "erdos-1034-oq-02",
+    "range": { "startLine": 1, "endLine": 42 },
+    "type": "context",
+    "title": "Erdős #1034 and Why the Book Lemma Matters",
+    "content": "The module docstring states Erdős #1034: a graph on n vertices with more than n²/4 edges was conjectured to always contain a triangle T with more than (1/2 - o(1))n vertices each adjacent to at least two of T's vertices. Ma–Tang disproved this with a construction achieving at most (2 - sqrt(5/2) + o(1))n ≈ 0.419n such good neighbours, leaving the threshold function h(n) sandwiched between (1/6 - o(1))n and that upper bound. The n/6 lower bound comes from the book lemma: a dense graph contains an edge lying in many common-neighbour triangles (a book), and every page of that book is automatically a good neighbour of any triangle built on the spine. OQ-02 asks whether n/6 can be improved beyond the book lemma — a genuinely open question this file does not resolve. Instead it formalizes the book-lemma mechanism exactly: book_le_goodNeighborCount proves the general structural bound, and book_goodNeighborCount_eq shows the pure book graph achieves it exactly, with a decide-verified witness on Fin 5.",
+    "mathContext": "$(1/6 - o(1))n \\le h(n) \\le (2 - \\sqrt{5/2} + o(1))n \\approx 0.419n$; a book with spine $\\{a,b\\}$ and page set $P$ gives the spine triangle $\\ge |P| - 1$ good neighbours.",
+    "significance": "context",
+    "relatedConcepts": ["Erdős #1034", "book lemma", "good neighbours", "Ma–Tang construction"],
+    "prerequisites": ["the parent open question", "common-neighbourhood books in dense graphs"]
+  },
+  {
     "id": "erdos-1034-oq-02-triangle-adjcount",
     "proofId": "erdos-1034-oq-02",
     "range": { "startLine": 44, "endLine": 71 },

--- a/src/data/proofs/erdos-1034-oq-02/meta.json
+++ b/src/data/proofs/erdos-1034-oq-02/meta.json
@@ -62,6 +62,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Overview: Erdős #1034 and the Book-Lemma Mechanism",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "States Erdős #1034 (disproved by Ma–Tang), the current bounds (1/6-o(1))n ≤ h(n) ≤ (2-√(5/2)+o(1))n on the good-neighbour threshold, and OQ-02's question of whether the book-lemma's n/6 lower bound can be improved. Previews that this file formalizes the book-lemma mechanism exactly (book_le_goodNeighborCount, book_goodNeighborCount_eq) without resolving the open question.",
+      "mathContext": "$(1/6 - o(1))n \\le h(n) \\le (2 - \\sqrt{5/2} + o(1))n$; a book of spine $\\{a,b\\}$ and $|P|$ pages gives a triangle with $\\ge |P|-1$ good neighbours."
+    },
+    {
       "id": "definitions",
       "title": "Triangles and Good Neighbours",
       "startLine": 43,


### PR DESCRIPTION
## Summary

`erdos-1034-oq-02` had no `sections` or `annotations` coverage for lines 1-42 — the module docstring stating Erdős #1034 itself (disproved by Ma–Tang), the current bounds on the good-neighbour threshold h(n), and OQ-02's specific open question (can the book lemma's n/6 lower bound be improved?), plus imports/namespace/variable declarations.

Added:
- A `header` section (`meta.json`, lines 1-42).
- A matching `context`-significance annotation (`annotations.json`) summarizing the open question and what the file does/doesn't resolve, with `mathContext`/`relatedConcepts`/`prerequisites`.

No existing content changed or removed. File sizes remain well under the ~60 KB cap (meta.json: 13.9 KB, annotations.json: 6.7 KB).

## Test plan
- [x] `jq empty` on both modified JSON files
- [x] `pnpm build` passes (validates gallery JSON structure)