### PR TITLE
audit(erdos-673): fix section-summary overclaims on sorry'd theorems

### DIFF
--- a/src/data/proofs/erdos-673/meta.json
+++ b/src/data/proofs/erdos-673/meta.json
@@ -114,58 +114,58 @@
     {
       "id": "divisors",
       "title": "Divisor Definitions",
-      "summary": "Defines `sortedDivisors` (ordered divisor list via `Finset.sort`), `tau` ($\\tau(n) = |\\{d : d \\mid n\\}|$), and `divisorAt` (0-indexed access). Proves boundary properties: $d_0 = 1$ and $d_{\\tau(n)-1} = n$.",
+      "summary": "Defines `sortedDivisors` (ordered divisor list via `Finset.sort`), `tau` ($\\tau(n) = |\\{d : d \\mid n\\}|$), and `divisorAt` (0-indexed access). States boundary properties (sorry'd, not yet proved): $d_0 = 1$ and $d_{\\tau(n)-1} = n$.",
       "startLine": 33,
       "endLine": 55,
-      "mathContext": "Defines `sortedDivisors` (ordered divisor list via `Finset.sort`), `tau` ($\\tau(n) = |\\{d : d \\mid n\\}|$), and `divisorAt` (0-indexed access). Proves boundary properties: $d_0 = 1$ and $d_{\\tau(n)-1} = n$."
+      "mathContext": "Defines `sortedDivisors` (ordered divisor list via `Finset.sort`), `tau` ($\\tau(n) = |\\{d : d \\mid n\\}|$), and `divisorAt` (0-indexed access). States boundary properties (sorry'd, not yet proved): $d_0 = 1$ and $d_{\\tau(n)-1} = n$."
     },
     {
       "id": "g-function",
       "title": "The Function G(n)",
-      "summary": "Defines $G(n) = \\sum_i d_i/d_{i+1}$ as a sum over `Finset.range (tau n - 1)`. Computes $G(1) = 0$, $G(p) = 1/p$ for primes, and $G(p^2) = 2/p$.",
+      "summary": "Defines $G(n) = \\sum_i d_i/d_{i+1}$ as a sum over `Finset.range (tau n - 1)`. Proves $G(1) = 0$; states (sorry'd, not yet proved) $G(p) = 1/p$ for primes and $G(p^2) = 2/p$.",
       "startLine": 56,
       "endLine": 74,
-      "mathContext": "Defines $G(n) = \\sum_i d_i/d_{i+1}$ as a sum over `Finset.range (tau n - 1)`. Computes $G(1) = 0$, $G(p) = 1/p$ for primes, and $G($p^{2}$) = 2/p$."
+      "mathContext": "Defines $G(n) = \\sum_i d_i/d_{i+1}$ as a sum over `Finset.range (tau n - 1)`. Proves $G(1) = 0$; states (sorry'd, not yet proved) $G(p) = 1/p$ for primes and $G(p^2) = 2/p$."
     },
     {
       "id": "bounds",
       "title": "Bounds on G(n)",
-      "summary": "Establishes $G(n) \\le \\tau(n) - 1$ (trivial), Tao's $G(n) \\le \\tau(n)$, Tao's $G(n) \\ge \\tau(n/m)/m$ for $m \\mid n$, and the even-number corollary $G(n) \\ge \\tau(n)/4$.",
+      "summary": "States (sorry'd, not yet proved) $G(n) \\le \\tau(n) - 1$ (trivial), Tao's $G(n) \\le \\tau(n)$, Tao's $G(n) \\ge \\tau(n/m)/m$ for $m \\mid n$, and the even-number corollary $G(n) \\ge \\tau(n)/4$.",
       "startLine": 75,
       "endLine": 96,
-      "mathContext": "Mathematical content: Establishes $G(n) \\le \\tau(n) - 1$ (trivial), Tao's $G(n) \\le \\tau(n)$, Tao's $G(n) \\ge \\tau(n/m)/m$ for $m \\mid n$, and the even-number corollary $G(n) \\ge \\tau(n)/4$."
+      "mathContext": "Mathematical content (all sorry'd, not yet proved): $G(n) \\le \\tau(n) - 1$ (trivial), Tao's $G(n) \\le \\tau(n)$, Tao's $G(n) \\ge \\tau(n/m)/m$ for $m \\mid n$, and the even-number corollary $G(n) \\ge \\tau(n)/4$."
     },
     {
       "id": "asymptotic",
       "title": "Asymptotic Behavior",
-      "summary": "Proves average $(1/X) \\sum G(n) \\to \\infty$ and formalizes $G(n) \\to \\infty$ for density 1 of integers (`AlmostAllGToInfinity`), trivially answering Erdős's first question.",
+      "summary": "States (sorry'd, not yet proved) average $(1/X) \\sum G(n) \\to \\infty$ and formalizes $G(n) \\to \\infty$ for density 1 of integers (`AlmostAllGToInfinity`) as an unproved claim that would trivially answer Erdős's first question.",
       "startLine": 97,
       "endLine": 114,
-      "mathContext": "Verified: Proves average $(1/X) \\sum G(n) \\to \\infty$ and formalizes $G(n) \\to \\infty$ for density 1 of integers (`AlmostAllGToInfinity`), trivially answering Erdős's first question."
+      "mathContext": "Not yet proved (sorry'd): states average $(1/X) \\sum G(n) \\to \\infty$ and formalizes $G(n) \\to \\infty$ for density 1 of integers (`AlmostAllGToInfinity`), which would trivially answer Erdős's first question."
     },
     {
       "id": "distribution",
       "title": "Distribution of G(n)/τ(n)",
-      "summary": "Defines $\\text{GRatio}(n) = G(n)/\\tau(n)$, proves it is bounded in $[0,1]$, and formalizes the Erdős-Tenenbaum theorem: $G(n)/\\tau(n)$ has a continuous distribution function $F$.",
+      "summary": "Defines $\\text{GRatio}(n) = G(n)/\\tau(n)$, states (sorry'd, not yet proved) it is bounded in $[0,1]$, and formalizes the Erdős-Tenenbaum theorem as an unproved claim: $G(n)/\\tau(n)$ has a continuous distribution function $F$.",
       "startLine": 115,
       "endLine": 139,
-      "mathContext": "Formal definition: Defines $\\text{GRatio}(n) = G(n)/\\tau(n)$, proves it is bounded in $[0,1]$, and formalizes the Erdős-Tenenbaum theorem: $G(n)/\\tau(n)$ has a continuous distribution function $F$."
+      "mathContext": "Formal definition, with sorry'd claims: Defines $\\text{GRatio}(n) = G(n)/\\tau(n)$, states it is bounded in $[0,1]$, and formalizes the Erdős-Tenenbaum theorem: $G(n)/\\tau(n)$ has a continuous distribution function $F$ (not yet proved)."
     },
     {
       "id": "specific",
       "title": "Specific Values",
-      "summary": "Computes $G(6) = 1/2 + 2/3 + 1/2$ and $G(12) = 1/2 + 2/3 + 3/4 + 4/6 + 6/12$ from the divisor sequences. Shows highly composite numbers satisfy $G(n) \\ge \\tau(n)/4$.",
+      "summary": "States (sorry'd, not yet proved) $G(6) = 1/2 + 2/3 + 1/2$ and $G(12) = 1/2 + 2/3 + 3/4 + 4/6 + 6/12$ from the divisor sequences, and that highly composite numbers satisfy $G(n) \\ge \\tau(n)/4$.",
       "startLine": 140,
       "endLine": 156,
-      "mathContext": "Mathematical content: Computes $G(6) = 1/2 + 2/3 + 1/2$ and $G(12) = 1/2 + 2/3 + 3/4 + 4/6 + 6/12$ from the divisor sequences. Shows highly composite numbers satisfy $G(n) \\ge \\tau(n)/4$."
+      "mathContext": "Mathematical content (all sorry'd, not yet proved): $G(6) = 1/2 + 2/3 + 1/2$ and $G(12) = 1/2 + 2/3 + 3/4 + 4/6 + 6/12$ from the divisor sequences; highly composite numbers satisfy $G(n) \\ge \\tau(n)/4$."
     },
     {
       "id": "multiplicative",
       "title": "Multiplicative Properties",
-      "summary": "Proves $G$ is not multiplicative (exhibits coprime $a, b$ with $G(ab) \\neq G(a)G(b)$) but is superadditive: $G(mn) \\ge G(m) + G(n)$ for coprime $m, n$.",
+      "summary": "States (sorry'd, not yet proved) that $G$ is not multiplicative (exhibits coprime $a, b$ with $G(ab) \\neq G(a)G(b)$) and is superadditive: $G(mn) \\ge G(m) + G(n)$ for coprime $m, n$.",
       "startLine": 157,
       "endLine": 169,
-      "mathContext": "Verified: Proves $G$ is not multiplicative (exhibits coprime $a, b$ with $G(ab) \\neq G(a)G(b)$) but is superadditive: $G(mn) \\ge G(m) + G(n)$ for coprime $m, n$."
+      "mathContext": "Not yet proved (sorry'd): states $G$ is not multiplicative (exhibits coprime $a, b$ with $G(ab) \\neq G(a)G(b)$) and is superadditive: $G(mn) \\ge G(m) + G(n)$ for coprime $m, n$."
     },
     {
       "id": "formula",
@@ -178,10 +178,10 @@
     {
       "id": "tau-connection",
       "title": "Connection to τ(n)",
-      "summary": "Proves Dirichlet's $\\sum \\tau(n) \\sim X \\log X$ and the sandwich $c_1 \\sum \\tau(n) \\le \\sum G(n) \\le c_2 \\sum \\tau(n)$, confirming $G$ and $\\tau$ have comparable average order.",
+      "summary": "States (sorry'd, not yet proved) Dirichlet's $\\sum \\tau(n) \\sim X \\log X$ and the sandwich $c_1 \\sum \\tau(n) \\le \\sum G(n) \\le c_2 \\sum \\tau(n)$, an unproved claim that $G$ and $\\tau$ have comparable average order.",
       "startLine": 184,
       "endLine": 233,
-      "mathContext": "Verified: Proves Dirichlet's $\\sum \\tau(n) \\sim X \\log X$ and the sandwich $c_1 \\sum \\tau(n) \\le \\sum G(n) \\le c_2 \\sum \\tau(n)$, confirming $G$ and $\\tau$ have comparable average order."
+      "mathContext": "Not yet proved (sorry'd): states Dirichlet's $\\sum \\tau(n) \\sim X \\log X$ and the sandwich $c_1 \\sum \\tau(n) \\le \\sum G(n) \\le c_2 \\sum \\tau(n)$, which would confirm $G$ and $\\tau$ have comparable average order."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-673 (Sum of Consecutive Divisor Ratios)
**Problem**: Top-level metadata is honest (`badge: wip`, `status: formalized`, `sorries: 20`, `axiomCount: 0`), but 7 of the 9 `sections[]` entries use completion verbs ("Proves", "Establishes", "Computes", "Shows") describing theorems that are 100% `sorry`'d. These `summary` strings render publicly via `TableOfContents`, so readers see per-section claims of proof where none exists.

## Evidence

Every theorem in `Proofs/Erdos673Problem.lean` is `sorry`'d except `G_one` (line 62, proved via `simp`). Yet:

- `divisors` section: "**Proves** boundary properties: d₀=1 and d_{τ(n)-1}=n" — `first_divisor_eq_one`, `last_divisor_eq_n` are both `sorry`.
- `bounds` section: "**Establishes** ... Tao's G(n)≤τ(n) ... G(n)≥τ(n/m)/m ..." — `G_upper_bound`, `tao_upper_bound`, `tao_lower_bound`, `G_even_lower_bound` all `sorry`.
- `asymptotic` section (mathContext prefixed **"Verified:"**): "**Proves** average (1/X)ΣG(n)→∞ ..." — `average_G_tends_to_infinity`, `first_question_trivial` both `sorry`.
- `distribution` section: "... **proves** it is bounded in [0,1] ..." — `GRatio_bounded` is `sorry`.
- `specific` section: "**Computes** G(6)=... and G(12)=... **Shows** highly composite numbers satisfy ..." — `G_6`, `G_12`, `highly_composite_G_large` all `sorry`.
- `multiplicative` section (mathContext prefixed **"Verified:"**): "**Proves** G is not multiplicative ..." — `G_not_multiplicative`, `G_coprime_relation` both `sorry`.
- `tau-connection` section (mathContext prefixed **"Verified:"**): "**Proves** Dirichlet's Στ(n)~XlogX ..." — `tau_sum_asymptotic`, `G_tau_similar_average` both `sorry`.

The file's own `formula` section already uses the honest convention ("States ... (`AsymptoticFormula`)") for its sorry'd content — the other 7 sections just didn't follow it.

## Fix

Reworded all 7 section `summary`/`mathContext` fields to "States (sorry'd, not yet proved)" language, matching the file's own `formula` section and the disclosure convention used elsewhere in the gallery (e.g. erdos-753's "axiomatized as", "PROVED" distinctions). No change to `badge`, `status`, `sorries`, or `axiomCount` — those were already accurate.

---
Discovered during reserve-mode re-audit (tracker shows 4 prior "clean" audits, which checked sorry-count parity but not section-level prose).