### PR TITLE
Enrich cube-root-2-irrational-oq-05: split specializations by parameter slice (96→98)

### DIFF
--- a/src/data/proofs/cube-root-2-irrational-oq-05/meta.json
+++ b/src/data/proofs/cube-root-2-irrational-oq-05/meta.json
@@ -100,12 +100,20 @@
       "mathContext": "$\\left(p^{1/n}\\right)^n = p$ and $n \\nmid v_p(p) = 1$."
     },
     {
-      "id": "specializations",
-      "title": "Cube Roots and Roots of Two",
+      "id": "cube-root-specializations",
+      "title": "Cube Roots: the n = 3 Slice",
       "startLine": 55,
+      "endLine": 70,
+      "summary": "irrational_cbrt_prime (∛p for all primes) fixes n = 3 and varies p; irrational_cbrt_two recovers the base gallery entry ∛2 and irrational_cbrt_three gives ∛3, both by simpa from irrational_cbrt_prime.",
+      "mathContext": "$\\sqrt[3]{p}, \\sqrt[3]{2}, \\sqrt[3]{3} \\notin \\mathbb{Q}$."
+    },
+    {
+      "id": "roots-of-two-specialization",
+      "title": "Roots of Two: the p = 2 Slice",
+      "startLine": 72,
       "endLine": 78,
-      "summary": "irrational_cbrt_prime (∛p for all primes), irrational_cbrt_two and irrational_cbrt_three (∛2, ∛3), and irrational_rpow_inv_two (every n-th root of 2).",
-      "mathContext": "$\\sqrt[3]{p}, \\sqrt[3]{2}, \\sqrt[3]{3}, \\sqrt[n]{2} \\notin \\mathbb{Q}$."
+      "summary": "irrational_rpow_inv_two fixes p = 2 and varies n ≥ 2, giving every n-th root of 2 as irrational — the orthogonal specialization direction to the cube-root slice above.",
+      "mathContext": "$\\sqrt[n]{2} \\notin \\mathbb{Q}$ for every $n \\geq 2$."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for cube-root-2-irrational-oq-05 (quality 96→98).

The `specializations` section (lines 55-78) bundled two genuinely distinct
specialization directions the module docstring itself calls out separately
("Specializing n = 3 ... Specializing p = 2 ..."):

- `cube-root-specializations` (55-70): fixes n = 3, varies p
  (`irrational_cbrt_prime`, `irrational_cbrt_two`, `irrational_cbrt_three`).
- `roots-of-two-specialization` (72-78): fixes p = 2, varies n
  (`irrational_rpow_inv_two`).

Split into two sections along that existing conceptual boundary. No content
deleted; existing annotations already align with the new boundaries. File
stays well under the 60KB size cap (~13KB).