### PR TITLE
Enrich erdos-1042-oq-03: cover header docstring (lines 1-33)

### DIFF
--- a/src/data/proofs/erdos-1042-oq-03/meta.json
+++ b/src/data/proofs/erdos-1042-oq-03/meta.json
@@ -56,6 +56,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header: The Geometric Mechanism Behind oq-03",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "States oq-03 (what geometric properties of the root set affect the lemniscate's component count) and the answer this file isolates: a monic f(z) = ∏ᵢ(z - rootᵢ) has its lemniscate {|f| < 1} confined to the union of open unit balls about the roots, since any z at distance ≥1 from every root forces |f(z)| ≥ 1. This confinement is what makes every bounded component trap a root, forcing the classical 'at most n components' bound. All results are re-declared self-contained and axiom-free, independent of the parent's Ghosh–Ramachandran axioms.",
+      "mathContext": "$z \\notin \\bigcup_i B(r_i,1) \\Rightarrow |f(z)| = \\prod_i |z-r_i| \\geq 1 \\Rightarrow z \\notin \\{|f|<1\\}$."
+    },
+    {
       "id": "setup",
       "title": "§I: Monic Polynomials and Their Lemniscates",
       "startLine": 34,


### PR DESCRIPTION
## Summary
- `erdos-1042-oq-03` (lemniscate confinement companion to Erdős #1042 oq-03) had `sections[0].startLine == 34`, leaving the module header docstring (lines 1-33: states the open question and the confinement result the file proves) uncovered by `sections` even though it was already covered by the `ann-overview`-style annotation (lines 1-28).
- Added a `header` section (lines 1-33) mirroring the existing annotation content — states oq-03 and summarizes the confinement mechanism, no invented content.
- Quality (find-targets.ts) moves 96→98... sections bucket 8/10→10/10; file stays well under all size caps (+~1KB).

Part of the ongoing header-docstring enrichment vein (first shipped as PR #41568).

## Test plan
- [x] `jq empty meta.json` — valid JSON
- [x] `npx tsx scripts/enricher/find-targets.ts --json --all` — sections bucket now 10/10
- [x] Verified header content against `proofs/Proofs/Erdos1042OQ03.lean` (lines 1-24 docstring, 26-33 imports/namespace) — no invented history/claims