### PR TITLE
Enrich handshake-lemma: cover header docstring (lines 1-42)

### DIFF
--- a/src/data/proofs/handshake-lemma/meta.json
+++ b/src/data/proofs/handshake-lemma/meta.json
@@ -69,6 +69,13 @@
   },
   "sections": [
     {
+      "title": "Module header: statement and honest scope note",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "States the handshake identity ∑ deg(v) = 2·|E(G)| and its parity corollary, notes Mathlib already has the two headline facts (sum_degrees_eq_twice_card_edges, even_card_odd_degree_vertices), and lists the four original contributions this file adds on top: even_sum_degrees, even_card_of_all_odd_degree, even_card_of_oddRegular, and the K₃ sharpness witness.",
+      "mathContext": "$\\sum_v \\deg(v) = 2|E(G)|$; honest-scope note: only the four listed corollaries are new content, the rest re-exports Mathlib."
+    },
+    {
       "title": "The handshake lemma and its parity forms",
       "startLine": 46,
       "endLine": 62,


### PR DESCRIPTION
## Summary
- `handshake-lemma` had `sections[0].startLine == 46`, leaving the module header (lines 1-42: the handshake identity statement + an "honest scope note" listing the four original contributions beyond Mathlib's two re-exported facts) uncovered by `sections`.
- Added a header section (lines 1-42) summarizing only what the docstring itself states — no invented history.
- `sections` bucket 6/10→8/10 (3→4 sections); file stays well under all size caps.

Part of the ongoing header-docstring enrichment vein (first shipped as PR #41568).

## Test plan
- [x] `jq empty meta.json` — valid JSON
- [x] `npx tsx scripts/enricher/find-targets.ts --json --all` — sections bucket improved
- [x] Verified header content against `proofs/Proofs/HandshakeLemma.lean` lines 1-42