### PR TITLE
Enrich euler-identity-oq-01-oq-02: cover header docstring (lines 1-29)

### DIFF
--- a/src/data/proofs/euler-identity-oq-01-oq-02/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-02/meta.json
@@ -88,6 +88,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module header: the open question and the chain it answers",
+      "startLine": 1,
+      "endLine": 29,
+      "summary": "States OQ-01-OQ-02 — derive cos_eq_tsum (the power series of cos) from Mathlib's definition cos z = (e^{iz}+e^{-iz})/2 — and lists the five results the file packages: the exponential definitions, the complex and real power series, Euler's formula, and Euler's identity, exhibiting the chain definition → series → identity.",
+      "mathContext": "$\\cos z = \\tfrac{1}{2}(e^{iz}+e^{-iz})$ is Mathlib's *definition*; the file derives $\\cos z = \\sum_n (-1)^n z^{2n}/(2n)!$ from it, then $e^{ix} = \\cos x + i\\sin x$ and $e^{i\\pi} = -1$."
+    },
+    {
       "id": "exp-form",
       "title": "Section I: The Exponential Definitions",
       "startLine": 30,


### PR DESCRIPTION
## Summary
- `euler-identity-oq-01-oq-02` had `sections[0].startLine == 30`, leaving the module header (lines 1-29: states OQ-01-OQ-02 — derive cos_eq_tsum from Mathlib's exponential definition of cos — and lists the five packaged results) uncovered by `sections`.
- Added a header section (lines 1-29) summarizing only what the docstring states — no invented content.
- `sections` bucket 6/10→8/10 (3→4 sections); file stays well under all size caps.

Part of the ongoing header-docstring enrichment vein (first shipped as PR #41568).

## Test plan
- [x] `jq empty meta.json` — valid JSON
- [x] `npx tsx scripts/enricher/find-targets.ts --json --all` — sections bucket improved
- [x] Verified header content against `proofs/Proofs/EulerIdentityOQ01OQ02.lean` lines 1-29