### PR TITLE
Enrich erdos-415-oq-01: cover header docstring (lines 1-30)

### DIFF
--- a/src/data/proofs/erdos-415-oq-01/meta.json
+++ b/src/data/proofs/erdos-415-oq-01/meta.json
@@ -58,6 +58,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module header: F(n), the constructive goal, and the witness table",
+      "startLine": 1,
+      "endLine": 30,
+      "summary": "Defines F(n) (largest k such that every k! ordering of a window of k consecutive totients occurs in [1,n]) and states Erdős's asymptotic F(n) ≍ log log log n with an open constant. Announces the constructive lower bound F(n) ≥ 3 this file proves, tabulating the witness m and totient values for each of the 6 orderings of (φ(m), φ(m+1), φ(m+2)) — including the rare increasing run at m=105 and decreasing run at m=313.",
+      "mathContext": "$F(n) = \\max\\{k : \\text{every ordering of } (\\varphi(m{+}1),\\dots,\\varphi(m{+}k)) \\text{ occurs for some } m \\le n\\}$; here $F(n)\\ge 3$ for $n\\ge 315$, witnessed explicitly."
+    },
+    {
       "id": "k2",
       "title": "k = 2: Both Adjacent Orderings",
       "startLine": 33,


### PR DESCRIPTION
## Summary
- `erdos-415-oq-01` had `sections[0].startLine == 33`, leaving the module header (lines 1-30: defines F(n), states Erdős's asymptotic F(n) ≍ log log log n, and tabulates the 6 explicit witnesses this file proves) uncovered by `sections`.
- Added a header section (lines 1-30) summarizing only what the docstring states — no invented content.
- `sections` bucket 6/10→8/10 (3→4 sections); file stays well under all size caps.

Part of the ongoing header-docstring enrichment vein (first shipped as PR #41568).

## Test plan
- [x] `jq empty meta.json` — valid JSON
- [x] `npx tsx scripts/enricher/find-targets.ts --json --all` — sections bucket improved
- [x] Verified header content against `proofs/Proofs/Erdos415OQ01.lean` lines 1-30