### PR TITLE
audit: erdos-1143 fix stale 'axiom' labels in alpha-regime section (LOW)

### DIFF
--- a/src/data/proofs/erdos-1143/meta.json
+++ b/src/data/proofs/erdos-1143/meta.json
@@ -106,8 +106,8 @@
       "title": "The $\\alpha > 2$ Regime",
       "startLine": 200,
       "endLine": 221,
-      "summary": "Two axioms for the parameter $\\alpha = k/p_u$: `erdos_selfridge_exact` ($2 < \\alpha < 3$, exact value of $F_k$ exists — paper not located), `alpha_gt_3_open` ($\\alpha > 3$, $F_k$ bounded between $k(d-1)$ and $kd + u$).",
-      "mathContext": "When $k = \\alpha p_u$ with $2 < \\alpha < 3$, the interval spans 2+ complete periods of $p_u$, enabling exact computation. For $\\alpha > 3$: only density bounds are known."
+      "summary": "Two theorems for the parameter $\\alpha = k/p_u$: `erdos_selfridge_exact` ($2 < \\alpha < 3$, a trivially-proved existence statement — the Erdős-Selfridge exact formula itself is not derived, paper not located), `alpha_gt_3_open` ($\\alpha > 3$, $F_k$ bounded between $k(d-1)$ and $kd + u$, proved from `covering_lower_bound` and the axiom `covering_upper_bound`).",
+      "mathContext": "When $k = \\alpha p_u$ with $2 < \\alpha < 3$, the interval spans 2+ complete periods of $p_u$, enabling exact computation (formula not formalized here). For $\\alpha > 3$: only density bounds are known, proved modulo the `covering_upper_bound` axiom."
     },
     {
       "id": "examples",


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-1143 (Covering Intervals with Multiples of Primes)
**Problem**: `sections[].alpha-regime.summary` and `.mathContext` labeled `erdos_selfridge_exact` and `alpha_gt_3_open` as axioms. Both are actually **proved theorems** in `Proofs/Erdos1143Problem.lean` — the file's real 2 axioms are `covering_asymptotic` and `covering_upper_bound`, which are already correctly disclosed in `meta.assumptions`/`meta.originalContributions`.

## Evidence

- `meta.axiomCount` / `leanFile.axiomCount`: 2 (correct — `covering_asymptotic`, `covering_upper_bound`)
- `erdos_selfridge_exact` (Erdos1143Problem.lean:208-214): `theorem ... := ⟨coveringFunction primes k, rfl⟩` — proved, docstring notes it's a trivial existence statement.
- `alpha_gt_3_open` (Erdos1143Problem.lean:236-245): `theorem ... := by intro _ _ k _; exact ⟨covering_lower_bound ..., covering_upper_bound ...⟩` — proved, combining a proved lemma with the `covering_upper_bound` axiom.
- The stale section summary said "Two axioms for the parameter α ... erdos_selfridge_exact ... alpha_gt_3_open", contradicting the file's own accurate axiom count/list elsewhere in the same meta.json.

This is a reverse-direction (understating) drift — no false claims about the axioms that actually exist, but it mislabels two proved theorems as unproved, which is confusing and inconsistent with the rest of the file (same pattern as #41527, #40009).

## Fix

Updated the `alpha-regime` section's `summary`/`mathContext` to describe both as proved theorems, noting `alpha_gt_3_open` still depends on the `covering_upper_bound` axiom.

---
Discovered during gallery integrity audit (reserve-mode re-audit, queue drained).