### PR TITLE
Enrich erdos-11-wip-01: cover header docstring (lines 1-32)

### DIFF
--- a/src/data/proofs/erdos-11-wip-01/meta.json
+++ b/src/data/proofs/erdos-11-wip-01/meta.json
@@ -58,6 +58,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Docstring: Statement and Roadmap",
+      "startLine": 1,
+      "endLine": 32,
+      "summary": "States Erdős #11 (open): is every odd n > 1 the sum of a squarefree number and a power of two? Notes the parent Erdos11Problem bit-rotted against current Mathlib and lists this file's three tools — isSquarefreePlusPow2_iff (bounded characterization), squarefreePlusPow2_of_witness (easy direction), and the worked cases 3..17 — plus the honest caveat that a kernel decide over a range is unavailable since Squarefree routes through Nat.minSqFac.",
+      "mathContext": "Erdős #11: $\\forall$ odd $n>1,\\ n = s + 2^k$ with $s$ squarefree? 0 axioms, 0 sorries; Hercher (2024), Granville–Soundararajan (1998)."
+    },
+    {
       "id": "definitions",
       "title": "Self-Contained Predicates",
       "startLine": 33,


### PR DESCRIPTION
Sections skipped the module docstring (lines 1-32), which states the Erdős #11 open question, notes the bit-rotted parent, and lists this file's three tools (bounded characterization, easy direction, worked cases 3..17) plus the kernel-decide caveat. Adds one `header` section mirroring content already present in the existing overview annotation (range 1-25); no invented history.

Part of the header-docstring enrichment vein (~78 entries where `sections[0].startLine >= 15`).