### PR TITLE
Enrich erdos-131-oq003: cover header docstring (lines 1-47)

### DIFF
--- a/src/data/proofs/erdos-131-oq003/annotations.json
+++ b/src/data/proofs/erdos-131-oq003/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "davenport-header",
+    "proofId": "erdos-131-oq003",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "context",
+    "title": "Goal and Companions: D(G₁ ⊕ G₂) ≥ D(G₁) + D(G₂) − 1",
+    "content": "The docstring states the goal for arbitrary additive groups G₁, G₂: D(G₁ ⊕ G₂) ≥ D(G₁) + D(G₂) − 1. Two companions are named: `Erdos131DavenportRank2` proves the rank-2 CYCLIC case D(ℤ/aℤ ⊕ ℤ/bℤ) ≥ a + b − 1 via one explicit extremal sequence, and `Erdos131DavenportConstant` gives the exact cyclic value D(ℤ/nℤ) = n. This file instead proves the underlying structural principle — the concatenation of zero-sum-free sequences — for arbitrary group summands, and is deliberately self-contained (imports only Mathlib, not the companions) so it verifies independently. The matching upper bound D(ℤ/aℤ ⊕ ℤ/bℤ) = a + b − 1 for a ∣ b is Olson's theorem, a substantial result not formalized here.",
+    "mathContext": "$D(G_1 \\oplus G_2) \\ge D(G_1) + D(G_2) - 1$ for arbitrary additive groups $G_1, G_2$; specializes to the rank-2 cyclic bound $a+b-1$.",
+    "significance": "context",
+    "relatedConcepts": ["Davenport constant", "direct sum of groups", "Olson's theorem", "Erdős #131"],
+    "prerequisites": ["finite abelian groups", "Davenport constant"]
+  },
+  {
     "id": "davenport-defs",
     "proofId": "erdos-131-oq003",
     "range": { "startLine": 48, "endLine": 57 },

--- a/src/data/proofs/erdos-131-oq003/meta.json
+++ b/src/data/proofs/erdos-131-oq003/meta.json
@@ -32,6 +32,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Docstring: The General Direct-Sum Bound",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "States the goal D(G₁ ⊕ G₂) ≥ D(G₁) + D(G₂) − 1 for arbitrary additive groups, names the two companion files (the rank-2 cyclic bound with an explicit extremal witness, and the exact cyclic value D(ℤ/nℤ) = n), and explains that this file proves the underlying structural concatenation principle in full generality instead of relying on one concrete sequence. Notes the file is deliberately self-contained (imports only Mathlib, not the companions) and that the matching upper bound for a ∣ b is Olson's theorem, not formalized here.",
+      "mathContext": "$D(G_1 \\oplus G_2) \\ge D(G_1) + D(G_2) - 1$, proved via the concatenation principle for zero-sum-free sequences; unconditional, axiom-free."
+    },
+    {
       "id": "davenport-framework",
       "title": "Davenport Set Framework",
       "startLine": 48,


### PR DESCRIPTION
Both `sections` and `annotations.json` skipped the module docstring (lines 1-47), which states the general direct-sum goal D(G₁⊕G₂) ≥ D(G₁)+D(G₂)−1, names the two companion files, and notes the file is deliberately self-contained plus the Olson's-theorem caveat for the matching upper bound. Adds one `header` section + one `context` annotation summarizing only what the docstring says; no invented history. File sizes remain well under caps (~19KB meta, ~9KB annotations).

Part of the header-docstring enrichment vein (~78 entries where `sections[0].startLine >= 15`).