### PR TITLE
Enrich erdos-1002-oq-02: cover header docstring (lines 1-54)

### DIFF
--- a/src/data/proofs/erdos-1002-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1002-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-header",
+    "proofId": "erdos-1002-oq-02",
+    "range": { "startLine": 1, "endLine": 54 },
+    "type": "context",
+    "title": "Background: Kesten's Cauchy Limit and the Sibling's CDF-Only Gap",
+    "content": "Erdős #1002 asks whether the weighted fractional sum f(α,n) = (1/log n)·Σ_{k≤n}(1/2−{αk}) has an asymptotic distribution function; Kesten (1960) proved the two-parameter variant converges to a Cauchy law, while the one-parameter case remains open. The sibling entry Erdos1002OQ01 records the Cauchy law only through its CDF cauchyDistribution ρ c = (1/π)·arctan(ρc)+1/2. This file supplies the missing connection to the Cauchy probability density cauchyDensity ρ x = ρ/(π(1+(ρx)²)) via three results: the CDF differentiates to the density (cauchyDistribution_hasDerivAt), the CDF is the running integral of the density (integral_cauchyDensity, the FTC form), and the density integrates to 1 over all of ℝ for ρ > 0 (integral_cauchyDensity_univ, the normalization that certifies it as a genuine probability density), together with supporting positivity, symmetry, and continuity facts.",
+    "mathContext": "Kesten's limit law is Cauchy with CDF $g_\\rho(c)=\\tfrac1\\pi\\arctan(\\rho c)+\\tfrac12$ and density $f_\\rho$; this file proves $g_\\rho'=f_\\rho$ and $\\int_{\\mathbb R} f_\\rho = 1$.",
+    "significance": "context",
+    "relatedConcepts": ["Erdős #1002", "Cauchy distribution", "Kesten's theorem", "probability density"],
+    "prerequisites": ["cumulative distribution functions", "probability densities"]
+  },
+  {
     "id": "ann-definitions",
     "proofId": "erdos-1002-oq-02",
     "range": { "startLine": 55, "endLine": 61 },

--- a/src/data/proofs/erdos-1002-oq-02/meta.json
+++ b/src/data/proofs/erdos-1002-oq-02/meta.json
@@ -56,6 +56,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Docstring: The Cauchy Distribution Connection",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "States the background (Erdős #1002 asks whether S(α,n) has an asymptotic distribution; Kesten 1960 proved the two-parameter variant converges to a Cauchy law) and the gap this file fills: the sibling Erdos1002OQ01 only records the Cauchy law's CDF, while the object in Kesten's theorem is the density. Lists the three connecting results — cauchyDistribution_hasDerivAt (CDF differentiates to density), integral_cauchyDensity (FTC form), integral_cauchyDensity_univ (total mass one) — plus supporting positivity/symmetry/continuity lemmas, self-contained and axiom-free.",
+      "mathContext": "Kesten's two-parameter limit is Cauchy with CDF $g_\\rho(c)=\\tfrac1\\pi\\arctan(\\rho c)+\\tfrac12$ and density $f_\\rho(x)=\\rho/(\\pi(1+(\\rho x)^2))$; this file proves $g_\\rho' = f_\\rho$ and $\\int_{\\mathbb R} f_\\rho = 1$."
+    },
+    {
       "id": "definitions",
       "title": "Definitions: Cauchy CDF and Density",
       "summary": "Two definitions at an arbitrary scale ρ: cauchyDistribution ρ c = (1/π)·arctan(ρc) + 1/2 (the Cauchy CDF, mirroring the sibling Erdos1002OQ01), and cauchyDensity ρ x = ρ/(π(1+(ρx)²)) (the Cauchy probability density).",


### PR DESCRIPTION
Both `sections` and `annotations.json` skipped the module docstring (lines 1-54), which gives the Kesten/Erdős #1002 background and states the gap this file fills relative to the sibling CDF-only entry. Adds one `header` section + one `context` annotation summarizing only what the docstring says; no invented history. File sizes remain well under caps (~15KB meta, ~8KB annotations).

Part of the header-docstring enrichment vein (~78 entries where `sections[0].startLine >= 15`).