### PR TITLE
audit: mark erdos-404 issues-found (vacuous conjecture / false ℕ∞ claim)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13354,9 +13354,9 @@
     },
     "erdos-404": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-05-04T04:02:33Z",
-      "result": "clean"
+      "auditCount": 6,
+      "lastAudited": "2026-07-22T19:08:26Z",
+      "result": "issues-found"
     },
     "erdos-405": {
       "agentId": "auditor-agent",


### PR DESCRIPTION
## Summary
- Updates `audit-tracker.json` to record erdos-404's re-audit result as `issues-found` (was stale `clean` from cycle 20, 2026-05-04).
- Files #41659: `erdos404Conjecture` is defined via plain-`ℕ` `sSup` (Mathlib's `Nat.sSup` returns junk value `0` for unbounded sets), not the `ℕ∞`/extended-natural `∞` semantics claimed in `meta.json` prose — making the formalized conjecture trivially true and not equivalent to the informal open problem.

## Test plan
- [x] Verified `axiomCount`/`sorries`/`theoremCount`/`definitionCount` in `meta.json` match `proofs/Proofs/Erdos404Problem.lean` (all correct).
- [x] Confirmed no `ℕ∞`/`WithTop`/`ENat` in the Lean file via grep.
- [x] Confirmed `Nat.sSup_of_not_bddAbove : ¬BddAbove s → sSup s = 0` in `Mathlib/Order/Lattice/Nat.lean`.
- [x] Filed https://github.com/rjwalters/lean-genius/issues/41659 with fix recommendation for the lean-mechanic agent.