### PR TITLE
Fix: erdos-404 restate conjecture via BddAbove, correct false ℕ∞ prose

### DIFF
--- a/proofs/Proofs/Erdos404Problem.lean
+++ b/proofs/Proofs/Erdos404Problem.lean
@@ -52,8 +52,16 @@ def secondaryQuestion : Prop :=
   ∃ p : ℕ, p.Prime ∧ ∃ seq : ℕ → ℕ, StrictMono seq ∧
     Tendsto (fun k => padicValNat p (∑ i ∈ Finset.range (k+1), (seq i).factorial)) atTop atTop
 
+/-- The genuine Erdős #404 finiteness question: for every `a ≥ 1` and prime `p`,
+    is the set of achievable prime-power exponents `divisiblePowers a p` bounded
+    above?  Note `f a p := sSup (divisiblePowers a p)` is `ℕ`-valued, and
+    `Nat.sSup` returns the junk value `0` (not `∞`) when the set is unbounded
+    (`Nat.sSup_of_not_bddAbove`).  We therefore state the conjecture via
+    `BddAbove`, which captures the real open problem — the naive
+    `∃ B : ℕ, f a p ≤ B` is trivially true for every `ℕ`-valued `f` and so does
+    not encode any mathematical content. -/
 def erdos404Conjecture : Prop :=
-  ∀ a : ℕ, a ≥ 1 → ∀ p : ℕ, p.Prime → ∃ B : ℕ, f a p ≤ B
+  ∀ a : ℕ, a ≥ 1 → ∀ p : ℕ, p.Prime → BddAbove (divisiblePowers a p)
 
 /- ## Part III: Known Results -/
 

--- a/src/data/proofs/erdos-404/meta.json
+++ b/src/data/proofs/erdos-404/meta.json
@@ -45,9 +45,9 @@
       "StrictIncSeq: strictly increasing sequence starting at a",
       "factorialSum: sum of factorials over a sequence",
       "dividesByPrimePower, divisiblePowers: prime power divisibility",
-      "f(a, p): supremum of achievable powers via sSup over ℕ∞",
+      "f(a, p): supremum of achievable powers via sSup over ℕ (Nat.sSup returns junk value 0 when the set is unbounded, not ∞)",
       "secondaryQuestion: unbounded v_p of partial factorial sums",
-      "erdos404Conjecture: finiteness of f for all (a, p)",
+      "erdos404Conjecture: BddAbove (divisiblePowers a p) for all a ≥ 1 and primes p (the genuine boundedness question; the naive ∃ B, f a p ≤ B would be vacuously true for ℕ-valued f)",
       "lin_bound axiom: f(2, 2) ≤ 254",
       "lin_bound_meaning axiom: 2^255 never divides such sums",
       "legendreSum: Legendre's formula computation",
@@ -63,7 +63,7 @@
     "prerequisites": [
       "p-adic valuation (padicValNat) and basic properties",
       "Factorials and divisibility in number theory",
-      "Supremum in extended naturals (sSup, WithTop)",
+      "Supremum over ℕ (Nat.sSup; junk value 0 for unbounded sets, boundedness via BddAbove)",
       "Legendre's formula for v_p(n!)",
       "Filter.Tendsto and convergence in Lean/Mathlib"
     ],
@@ -78,7 +78,7 @@
     "text": "For which (a, p) is there a bound on k such that p^k divides some sum of factorials starting at a? Let f(a, p) be the supremum. Lin proved f(2, 2) ≤ 254. OPEN.",
     "proofStrategy": "The formalization defines StrictIncSeq, factorialSum, dividesByPrimePower, and f(a, p). The main conjecture and secondary question are stated. Lin's bound is axiomatized. p-adic tools (Legendre's formula, asymptotics) and structural lemmas are included. Two concrete examples are proved by native_decide. The summary theorem proves the conjunction of Lin's bounds.",
     "keyInsights": [
-      "**Supremum formulation:** $f(a,p) = \\sup\\{k : p^k \\mid \\sum a_i!\\}$ uses extended naturals, allowing $f(a,p) = \\infty$ when arbitrarily high powers are achievable — the conjecture asks if this never happens",
+      "**Supremum formulation:** $f(a,p) = \\sup\\{k : p^k \\mid \\sum a_i!\\}$ is formalized as `sSup` over ℕ, so `f a p : ℕ`. Mathlib's `Nat.sSup` returns the junk value $0$ (not $\\infty$) when the set is unbounded, so the genuine open question is whether $\\{k : p^k \\mid \\sum a_i!\\}$ is bounded above — the conjecture is stated via `BddAbove`, since the naive $\\exists B, f(a,p) \\le B$ is trivially true for any ℕ-valued $f$",
       "**Only known bound:** Lin proved $f(2,2) \\leq 254$, meaning $2^{255}$ never divides any sum of factorials starting at $2!$. The gap $3 \\leq f(2,2) \\leq 254$ remains enormous",
       "**Legendre's formula governs individual terms:** $v_p(n!) = \\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor \\approx n/(p-1)$, so individual factorials have linearly growing $p$-adic valuations. The challenge is understanding what happens when they are summed",
       "**Factorization is the key tool:** $a_1! + a_2! = a_1!(1 + a_2!/a_1!)$, so $v_p$ of the sum splits into $v_p(a_1!)$ (known) plus $v_p(1 + a_2!/a_1!)$ (the mysterious part). The ratio $a_2!/a_1! = (a_1+1)(a_1+2)\\cdots a_2$ is a product of consecutive integers",
@@ -89,7 +89,7 @@
     "prerequisites": [
       "p-adic valuation (padicValNat) and basic properties",
       "Factorials and divisibility in number theory",
-      "Supremum in extended naturals (sSup, WithTop)",
+      "Supremum over ℕ (Nat.sSup; junk value 0 for unbounded sets, boundedness via BddAbove)",
       "Legendre's formula for v_p(n!)",
       "Filter.Tendsto and convergence in Lean/Mathlib"
     ]
@@ -101,7 +101,7 @@
       "startLine": 27,
       "endLine": 46,
       "summary": "StrictIncSeq, factorialSum, dividesByPrimePower, f(a, p) = sSup",
-      "mathContext": "The function $f(a,p) = \\sup\\{k : p^k \\mid \\sum a_i!\\text{ for some }a = a_1 < \\cdots < a_n\\}$ is defined using sSup over ℕ, allowing $f(a,p) = \\infty$ if arbitrarily high powers are achievable."
+      "mathContext": "The function $f(a,p) = \\sup\\{k : p^k \\mid \\sum a_i!\\text{ for some }a = a_1 < \\cdots < a_n\\}$ is defined using sSup over ℕ, so it is ℕ-valued; `Nat.sSup` returns the junk value $0$ (not $\\infty$) when the set is unbounded above."
     },
     {
       "id": "main-questions",
@@ -109,7 +109,7 @@
       "startLine": 47,
       "endLine": 55,
       "summary": "secondaryQuestion and erdos404Conjecture (OPEN)",
-      "mathContext": "Two open questions: (1) Is $f(a,p) < \\infty$ for all $(a,p)$? (2) Does there exist a prime $p$ and strictly increasing sequence $\\{a_i\\}$ with $v_p(\\sum_{i \\leq k} a_i!) \\to \\infty$?"
+      "mathContext": "Two open questions: (1) Is $\\{k : p^k \\mid \\sum a_i!\\}$ bounded above (`BddAbove (divisiblePowers a p)`) for all $(a,p)$ — equivalently, is $f(a,p)$ a genuine finite supremum rather than the junk value $0$? (2) Does there exist a prime $p$ and strictly increasing sequence $\\{a_i\\}$ with $v_p(\\sum_{i \\leq k} a_i!) \\to \\infty$?"
     },
     {
       "id": "known-results",


### PR DESCRIPTION
## Integrity fix for #41659

**Problem:** `erdos404Conjecture` was formalized as `∀ a ≥ 1, ∀ p prime, ∃ B : ℕ, f a p ≤ B`. Since `f : ℕ → ℕ → ℕ` is plain-ℕ-valued (and `Nat.sSup` returns junk value `0`, not `∞`, for unbounded sets via `Nat.sSup_of_not_bddAbove`), `∃ B, f a p ≤ B` is trivially true for every `(a,p)` — the "conjecture" was vacuous and did not capture the open problem. Additionally, `meta.json` prose repeatedly and falsely claimed the formalization uses extended naturals (`ℕ∞`/`WithTop`) with `∞` semantics; no such construct appears in the Lean file.

## Changes

**`proofs/Proofs/Erdos404Problem.lean`**
- Restated `erdos404Conjecture` as `∀ a ≥ 1, ∀ p, p.Prime → BddAbove (divisiblePowers a p)` — the genuine boundedness question, which is **not** trivially true.
- Added a docstring explaining the `ℕ`-valued `sSup` junk-value-`0` subtlety and why `BddAbove` (not `∃ B, f a p ≤ B`) is used.

**`src/data/proofs/erdos-404/meta.json`** — corrected four prose locations claiming ℕ∞/extended-naturals/∞ Lean semantics:
- `originalContributions[3]` "via sSup over ℕ∞" → accurate ℕ + junk-value-0 description
- `originalContributions[5]` "finiteness of f" → accurate `BddAbove` description
- `prerequisites[2]` / `overview.prerequisites[2]` "Supremum in extended naturals (sSup, WithTop)" → "Supremum over ℕ (Nat.sSup; junk value 0…)"
- `overview.keyInsights[0]` and `sections` `core-definitions` / `main-questions` `mathContext` — removed false `f(a,p) = ∞` claims, described the real `BddAbove` question.

## Evidence

- `grep 'ℕ∞\|WithTop\|extended natural' meta.json` → 0 after fix.
- Docker build `./proofs/scripts/docker-build.sh Proofs.Erdos404Problem` → **succeeds** (only pre-existing `push_neg` deprecation / unused-var linter warnings, unrelated to this change).
- JSON validates.

Closes #41659

🤖 Generated with [Claude Code](https://claude.com/claude-code)
