### PR TITLE
audit: mark erdos-358 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12897,8 +12897,8 @@
     },
     "erdos-358": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:02:33Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-22T19:13:40Z",
       "result": "clean"
     },
     "erdos-359": {


### PR DESCRIPTION
## Summary
- Reserve-mode re-audit of `erdos-358` (Erdős Problem #358: Sums of Consecutive Terms).
- Verified 0 sorries, 0 axioms (primesSeq is now built concretely via `Nat.nth Nat.Prime`, no longer axiomatized as the file's own comment notes).
- 15 theorems/lemmas (10 public + 5 private) and 10 definitions match `meta.theoremCount`/`definitionCount` exactly.
- No phantom declarations in `originalContributions` or `sections`.
- Open-conjecture disclosure is honest: `Erdos358Strong`/`Erdos358Weak` are left as unproved conjectures, while supporting lemmas (odd-divisor bijection, power-of-2 obstruction) are fully verified.
- Result: clean.

Discovered during gallery integrity audit.