### PR TITLE
Enrich erdos-220-incomplete-01-oq-01: cover header docstring (lines 1-55)

### DIFF
--- a/src/data/proofs/erdos-220-incomplete-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-220-incomplete-01-oq-01/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "ann-header-overview",
+    "proofId": "erdos-220-incomplete-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 42
+    },
+    "type": "context",
+    "title": "Module Header: Generalizing the Companion's Single p = 7 Check",
+    "content": "The docstring states this entry's exact purpose: the companion erdos-220-incomplete-01 verifies ∑(a_{k+1}−a_k)² = p − 2 only for p = 7 (by decide on a fixed list), while the sibling erdos-220-oq-01 proves the general Cauchy–Schwarz lower bound (n−2)² ≤ (φ(n)−1)·∑gaps² for every modulus n. This file closes that gap by proving the prime identity for EVERY prime p, over the sibling's real strictly-increasing enumeration E rather than a hard-coded list, and identifies it as the equality case of the Cauchy–Schwarz bound: primes are exactly where the gap sequence is constant. The three-step argument previewed here — gaps ≥ 1 by monotonicity, telescoping to p − 2, zero-sum-of-nonnegatives forcing every gap to be 1 — is proved with 0 axioms, 0 sorries, and no native_decide.",
+    "mathContext": "$\\sum_k (a_{k+1}-a_k)^2 = p - 2\\ \\forall\\, p \\text{ prime}$, the equality case of $(n-2)^2 \\le (\\varphi(n)-1)\\sum(a_{k+1}-a_k)^2$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Erdős #220",
+      "Montgomery–Vaughan bound",
+      "Cauchy–Schwarz equality case",
+      "reduced residues"
+    ],
+    "prerequisites": [
+      "erdos-220-oq-01 (Cauchy–Schwarz lower bound, telescoping sum_gaps)",
+      "erdos-220-incomplete-01 (p = 7 numeric check)"
+    ]
+  },
+  {
     "id": "ann-one-le-gap",
     "proofId": "erdos-220-incomplete-01-oq-01",
     "range": {

--- a/src/data/proofs/erdos-220-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-220-incomplete-01-oq-01/meta.json
@@ -69,6 +69,14 @@
   },
   "sections": [
     {
+      "id": "header-overview",
+      "title": "Module Header: Closing the p = 7-Only Gap of the Companion",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "The module docstring states the open question this entry closes: the companion erdos-220-incomplete-01 only checks ∑gaps² = p−2 for the single modulus p = 7, while the sibling erdos-220-oq-01 proves the general Cauchy–Schwarz lower bound (n−2)² ≤ (φ(n)−1)·∑gaps². It sketches the three-step argument — every gap is ≥ 1 by monotonicity, the φ(p)−1 = p−2 gaps telescope to p−2, so a sum of nonnegatives equal to their count forces every gap to be exactly 1 — and notes the file is 0 axioms, 0 sorries, no native_decide, importing Mathlib and Proofs.Erdos220OQ01.",
+      "mathContext": "$\\sum_k (a_{k+1}-a_k)^2 = p - 2$ for every prime $p$, identified as the Cauchy–Schwarz equality case of the sibling's bound $(n-2)^2 \\le (\\varphi(n)-1)\\sum(a_{k+1}-a_k)^2$."
+    },
+    {
       "id": "gap-lower-bound",
       "title": "Every Gap is at Least 1",
       "startLine": 56,


### PR DESCRIPTION
Enrichment pass for erdos-220-incomplete-01-oq-01.

The module docstring (lines 1-55 of `Proofs/Erdos220Incomplete01OQ01.lean`) explains exactly why this entry exists — the companion `erdos-220-incomplete-01` only checks the squared-gap identity for p = 7, while this file proves it for every prime and identifies the result as the Cauchy–Schwarz equality case — but was entirely uncovered by `sections`/`annotations` (first section started at line 56). Added:

- A `header-overview` section (lines 1-55) summarizing the docstring's stated purpose and argument sketch.
- A matching `context`-significance annotation with the same content plus `mathContext`/`relatedConcepts`/`prerequisites`.

No other content changed. File size 14.8 KB → 15.4 KB, well under the 60 KB cap; annotations 5 → 6, sections 3 → 4, both under caps.