### PR TITLE
Fix: buffons-needle-oq-01-oq-01 stale sorry-remaining comments

### DIFF
--- a/proofs/Proofs/BuffonsNeedleOQ01OQ01.lean
+++ b/proofs/Proofs/BuffonsNeedleOQ01OQ01.lean
@@ -309,28 +309,17 @@ theorem buffon_smooth_concrete
   -- (1/(π*d)) * (2 * ∫_a^b sqrt(..)) = 2 * (∫_a^b sqrt(..)) / (π*d)
   ring
 
-/-- **Closing the gap**: When `hFubini` is proved from `angular_average`,
-    the formula is automatic.
+/-- **Closing the gap**: `hFubini` is proved from `angular_average`,
+    making the formula automatic.
 
     The `hFubini` hypothesis above is EXACTLY the angular average theorem
     applied pointwise:
       ∫_0^π |γ'(t).1 sin θ + γ'(t).2 cos θ| dθ = 2√(γ'(t).1² + γ'(t).2²)
 
-    This IS `angular_average (deriv (Prod.fst ∘ γ) t) (deriv (Prod.snd ∘ γ) t)`.
-
-    So the full proof (once `angular_average` sorry is closed) is:
-
-    ```lean
-    theorem buffon_smooth_concrete_full ... :
-        concreteSmoothExpectedCrossings γ a b d = 2 * planarArcLength γ a b / (π * d) := by
-      apply buffon_smooth_concrete ... (fun t _ =>
-        angular_average (deriv (Prod.fst ∘ γ) t) (deriv (Prod.snd ∘ γ) t))
-    ```
-
-    The ONLY remaining sorry is the rotation identity in `angular_average`:
-      a sin θ + b cos θ = √(a²+b²) sin(θ + atan2(b,a))
-
-    This requires a careful Lean proof of the atan2 relationship. -/
+    This IS `angular_average (deriv (Prod.fst ∘ γ) t) (deriv (Prod.snd ∘ γ) t)`,
+    which is fully proved (0 sorries, via `Complex.arg`) in Part III above.
+    Combined with `buffon_smooth_concrete`, this gives `buffon_smooth_full`
+    below with no remaining gap in the angular average step. -/
 theorem hFubini_from_angular_average
     (γ : ℝ → ℝ × ℝ) (a b : ℝ) :
     ∀ t ∈ Set.uIcc a b,
@@ -357,24 +346,18 @@ These can be REPLACED by:
 1. `concreteSmoothExpectedCrossings` (concrete definition above)
 2. `buffon_smooth_concrete` (this file) + `angular_average` proof
 
-## Summary of the Proof Gap
+## Summary
 
-The ONLY remaining sorry is in `angular_average`, specifically the rotation identity:
-  a sin θ + b cos θ = √(a²+b²) sin(θ + arctan(b/a))
-
-This is provable in Lean using:
-- `Real.sin_add`: sin(x+y) = sin x cos y + cos x sin y
-- `Real.cos_arctan`: cos(arctan x) = 1/√(1+x²)
-- `Real.sin_arctan`: sin(arctan x) = x/√(1+x²)
-- Case split on a: when a > 0, a = 0, a < 0 (atan2 cases)
-- For each case, normalize (a/r, b/r) as (cos φ, sin φ)
-
-Estimated: 50-100 lines to close this sorry completely.
+`angular_average` is fully proved (0 sorries): the rotation identity
+  a sin θ + b cos θ = √(a²+b²) sin(θ + φ),  φ = Complex.arg (a + bi)
+is established uniformly for all (a, b), including a = 0, via `Complex.arg`,
+`Complex.cos_arg`, and `Complex.sin_arg` — avoiding a case split on the sign
+of a that an `arctan`-based approach would require.
 -/
 
-/-- **Full theorem via angular_average**: Once the rotation identity sorry
-    in `angular_average` is closed, this gives the complete theorem with
-    all hypotheses made explicit. -/
+/-- **Full theorem via angular_average**: combines `buffon_smooth_concrete`
+    with the rotation identity (`angular_average`, fully proved) to give the
+    complete theorem with all hypotheses made explicit. -/
 theorem buffon_smooth_full
     (γ : ℝ → ℝ × ℝ) (a b d : ℝ)
     (hd : 0 < d) (hab : a ≤ b)

--- a/src/data/proofs/buffons-needle-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01/annotations.json
@@ -168,8 +168,8 @@
     "id": "ann-buffon-oq01-full",
     "proofId": "buffons-needle-oq-01-oq-01",
     "range": {
-      "startLine": 377,
-      "endLine": 388
+      "startLine": 358,
+      "endLine": 372
     },
     "type": "concept",
     "title": "buffon_smooth_full: Complete Theorem Using angular_average as Fubini Witness",

--- a/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
@@ -71,7 +71,7 @@
     ],
     "dateAdded": "2026-02-25",
     "axiomCount": 0,
-    "lineCount": 391,
+    "lineCount": 374,
     "mathlib_version": "4.31.0",
     "theoremCount": 9,
     "definitionCount": 2
@@ -128,14 +128,14 @@
       "id": "main-theorem",
       "title": "Buffon-Barbier Smooth Curve Theorem",
       "startLine": 260,
-      "endLine": 340,
+      "endLine": 330,
       "summary": "buffon_smooth_concrete: main theorem given Fubini hypothesis. hFubini_from_angular_average: proves the Fubini hypothesis from angular_average. buffon_smooth_full: the complete theorem."
     },
     {
       "id": "connection",
       "title": "Connection to BuffonsNoodle.lean",
-      "startLine": 341,
-      "endLine": 390,
+      "startLine": 332,
+      "endLine": 374,
       "summary": "Documents how concreteSmoothExpectedCrossings replaces the axiomatic smoothExpectedCrossings from BuffonsNoodle.lean. The open question is fully resolved."
     }
   ],
@@ -197,7 +197,7 @@
       "MeasureTheory"
     ],
     "namespace": "BuffonsNeedleOQ01OQ01",
-    "lineCount": 391,
+    "lineCount": 374,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 2,


### PR DESCRIPTION
## Integrity Issue

**Proof**: buffons-needle-oq-01-oq-01
**Problem**: Stale docstrings claiming an unclosed sorry, publicly rendered as fully-proved code

## Evidence

`angular_average` (the rotation-identity theorem) is fully proved with 0 sorries, using `Complex.arg`/`Complex.cos_arg`/`Complex.sin_arg` to handle all cases (including a=0) uniformly — confirmed by `grep sorry` finding zero bare `sorry` tokens in the file, matching meta.json's accurate `sorries: 0` / `axiomCount: 0`.

However, the docstrings on `hFubini_from_angular_average` and `buffon_smooth_full`, plus a trailing "Summary of the Proof Gap" comment block, were written for a pre-upgrade version of the file and still said:

> "The ONLY remaining sorry is the rotation identity in `angular_average` ... Estimated: 50-100 lines to close this sorry completely."

and framed `buffon_smooth_full` as hypothetical future work ("Once the rotation identity sorry in `angular_average` is closed, this gives the complete theorem...") describing an `arctan`-based case-split approach that was never actually used (the real proof uses a uniform `Complex.arg` approach, as correctly described earlier in the same file at the `angular_average` docstring, lines 150-157 — the two docstrings directly contradicted each other).

This isn't a meta.json mismatch — `meta.json`'s overview/sections/conclusion text is accurate throughout. The issue is that the raw `.lean` source (comments included) is fetched and rendered verbatim to gallery visitors via `ProofViewer.tsx` (confirmed: `getProofAsync` fetches `source.lean`, splits and renders every line with block-comment-aware syntax highlighting — nothing is stripped or summarized). So a visitor reading the source would see a live contradiction: one theorem's docstring says the proof is complete, a later one says a sorry remains in that same theorem.

## Fix

- Rewrote the stale docstrings on `hFubini_from_angular_average` and `buffon_smooth_full`, and the "Summary of the Proof Gap" comment block, to state that `angular_average` is fully proved via `Complex.arg` (no case split needed), removing the "estimated 50-100 lines" / "ONLY remaining sorry" language and the phantom illustrative theorem name `buffon_smooth_concrete_full` (which doesn't exist in the file — the real one is `hFubini_from_angular_average`).
- The comment trim shortened the file 391 → 374 lines; updated `meta.json`'s two `lineCount` fields and the `main-theorem`/`connection` section `startLine`/`endLine` ranges, and `annotations.json`'s `ann-buffon-oq01-full` range, to match.
- No proof code was touched — only `/- ... -/` and `/-- ... -/` comment blocks.

---
Discovered during gallery integrity audit (reserve-mode re-serve).