### PR TITLE
Enrich bounded-prime-gaps-oq-04: cover LargeSieveHolds and Summary block

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-04/annotations.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04/annotations.json
@@ -151,5 +151,30 @@
       "Finset.Icc",
       "Complex.norm bounds"
     ]
+  },
+  {
+    "id": "ann-bpg-large-sieve",
+    "proofId": "bounded-prime-gaps-oq-04",
+    "range": {
+      "startLine": 327,
+      "endLine": 336
+    },
+    "type": "definition",
+    "title": "The Large Sieve: Layer 3's Averaging Tool",
+    "content": "`LargeSieveHolds` records the large sieve inequality in simplified form: the total 'energy' of a sequence (aₙ), averaged over exponential sums e(na/q) at reduced residues a mod q and summed over moduli q ≤ Q with weight φ(q)⁻¹, is bounded by (N + Q² − 1)·Σ|aₙ|². Unlike the other definitions in this file, the body is left as `True` — the docstring notes the precise formulation needs exponential sums e(na/q), which are not yet wired up here — so this is a placeholder marking where Layer 3 of the roadmap (the large sieve) enters, not a working statement. Its role in the BV proof is to bound bilinear sums on average across moduli, which is what lets the Type I/II sum decomposition in Vaughan's identity be assembled into the full BV bound.",
+    "mathContext": "Large sieve inequality: $\\sum_{q \\le Q} \\varphi(q)^{-1} \\sum_{\\substack{a=1 \\\\ \\gcd(a,q)=1}}^{q} \\left|\\sum_{n \\le N} a_n\\, e(na/q)\\right|^2 \\le (N + Q^2 - 1) \\sum_n |a_n|^2$.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "large sieve",
+      "exponential sums",
+      "Vaughan's identity",
+      "Type I/II sums",
+      "bilinear forms"
+    ],
+    "prerequisites": [
+      "Pólya-Vinogradov inequality",
+      "Dirichlet characters",
+      "exponential sums e(na/q)"
+    ]
   }
 ]

--- a/src/data/proofs/bounded-prime-gaps-oq-04/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04/meta.json
@@ -121,11 +121,19 @@
     },
     {
       "id": "polya-vinogradov",
-      "title": "Pólya-Vinogradov Inequality",
-      "summary": "Statement of the key missing Mathlib lemma and its role in the BV proof",
+      "title": "Pólya-Vinogradov Inequality and the Large Sieve",
+      "summary": "Statement of the key missing Mathlib lemma (Pólya-Vinogradov, Layer 1) and, immediately after it, a placeholder statement of the large sieve inequality (Layer 3's averaging tool)",
       "startLine": 300,
       "endLine": 337,
-      "mathContext": "Pólya-Vinogradov (1918): $|\\sum_{n=M+1}^{M+N} \\chi(n)| \\leq \\sqrt{q} \\log q$ for non-principal $\\chi \\pmod{q}$, any $M, N$. The $\\sqrt{q}\\log q$ bound is independent of the interval length."
+      "mathContext": "Pólya-Vinogradov (1918): $|\\sum_{n=M+1}^{M+N} \\chi(n)| \\leq \\sqrt{q} \\log q$ for non-principal $\\chi \\pmod{q}$, any $M, N$. Large sieve: $\\sum_{q\\leq Q}\\varphi(q)^{-1}\\sum_{\\gcd(a,q)=1}|\\sum_{n\\leq N}a_n e(na/q)|^2 \\leq (N+Q^2-1)\\sum|a_n|^2$."
+    },
+    {
+      "id": "summary",
+      "title": "Summary: What Is Formalized and What Remains",
+      "summary": "Closing comment block inventorying the 8 formalized definitions/theorems, restating the ~12000-line/4-layer effort estimate with Pólya-Vinogradov as the highest-leverage next step, and tying BV back to the `maynard_tao_sieve` axiom it would let BoundedPrimeGaps.lean discharge.",
+      "startLine": 338,
+      "endLine": 365,
+      "mathContext": "BV formalized as 1 axiom of 3 in the bounded-gaps chain; discharging it (via the 4-layer roadmap) would leave `maynard_tao_sieve` resting only on Selberg sieve combinatorics."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- `LargeSieveHolds` (lines 327-336) fell inside the `polya-vinogradov` annotation's line range but was never actually described in its content — adds a dedicated `definition`-type annotation explaining the large sieve placeholder and its role (Layer 3 averaging tool for Vaughan's identity).
- The closing `## Summary` comment block (lines 338-365, 27 lines) had zero section or annotation coverage — adds a `summary` section.

Both additions stay well under the meta.json size caps (12.6 KB / 60 KB) and annotation count guidance.

## Test plan
- [x] `python3 -c "import json; json.load(...)"` on both edited files — valid JSON
- [x] `pnpm build` JSON-validation stages (gallery:check-size, annotations:build, research:build, check-search-index) pass; `tsc -b` fails only due to the known missing-`node_modules` environment gap, unrelated to this change