### PR TITLE
Enrich erdos-10-wip-01-oq-03: cover header docstring (lines 1-70)

### DIFF
--- a/src/data/proofs/erdos-10-wip-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-10-wip-01-oq-03/meta.json
@@ -70,6 +70,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Docstring: The Offset Reduction and the Barrier at k ≥ 2",
+      "startLine": 1,
+      "endLine": 70,
+      "mathContext": "$\\neg\\mathrm{IsPrimePlusKPowers}\\,k\\,n \\iff \\forall w \\le n,\\ \\mathrm{popcount}(w) \\le k \\to \\neg(n-w).\\mathrm{Prime}$, the offset re-indexing of the parent's popcount characterization.",
+      "summary": "Docstring framing the entry against Erdős Problem #10: writing Sₖ = {n | IsPrimePlusKPowers k n}, it states the offset re-indexing not_isPrimePlusKPowers_iff (valid for every k), explains why the k = 1 case closes via the six-prime covering system and the parity clash 2^a odd ⟹ a = 0, and pins the barrier at k ≥ 2 — Crocker's (1971) two-power covering and the open k = 3 extension require simultaneously killing multi-bit offsets 2^a + 2^b + 2^c, beyond what the elementary single-power covering can reach. Lists the five results, the two references (Erdős 1950, Crocker 1971), and the erdosproblems.com link; imports the two parent thread files and opens their namespaces."
+    },
+    {
       "title": "The covering-method reduction (all k)",
       "startLine": 72,
       "endLine": 111,


### PR DESCRIPTION
## Summary
- Adds a `header` section (lines 1-70) covering the module docstring, previously uncovered by any section or annotation
- Docstring explains the offset re-indexing `not_isPrimePlusKPowers_iff`, why the k=1 case closes via the six-prime covering, and the barrier at k>=2 (Crocker 1971 / open k=3)
- Quality 96->98 (sections 6/10->8/10); file size 13.1KB->14.2KB, well under the 60KB cap
- No changes to axiomCount/status/badge — those already accurately reflect the 0-sorry, 0-axiom Lean file

Part of the recurring header-docstring undercoverage vein across the gallery.