### PR TITLE
audit: mark erdos-299 clean (reserve re-serve)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12383,8 +12383,8 @@
     },
     "erdos-299": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:02:33Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-22T19:25:50Z",
       "result": "clean"
     },
     "erdos-3": {


### PR DESCRIPTION
## Integrity Audit — Reserve Re-serve

**Proof**: erdos-299 (Bounded Gap Sequences and Unit Fractions, Bloom 2021)

Queue is fully drained (4809/4809 audited); this is a round-robin re-serve of
the oldest audit entry (lastAudited 2026-05-04). Re-verified against
`proofs/Proofs/Erdos299Problem.lean` — no drift since prior audit:

- axiomCount: 1 (`bloom_theorem`, externally-attributed Bloom 2021 density
  theorem — not masking an internal gap)
- sorries: 0 (confirmed via case-sensitive grep; the `harmonicSorry177575`
  string is Aristotle-cruft comment text, not a real decl)
- theoremCount: 10, definitionCount: 7, lineCount: 384 — all match file exactly
- `native_decide` used in 2 concrete Egyptian-fraction example theorems
  (`egyptian_236`, `egyptian_2_4_6_12`), correctly disclosed in
  `meta.assumptions` with the `Lean.ofReduceBool` compiler-trust caveat
- All 5 `originalContributions` bullets map to real decls, no phantoms

No action needed. Bumps `audit-tracker.json` auditCount 4→5,
lastAudited 2026-05-04→2026-07-22.

---
Discovered during gallery integrity audit.