### PR TITLE
Enrich matrix-similarity-invariants-oq-01-oq-01: cover header docstring

### DIFF
--- a/src/data/proofs/matrix-similarity-invariants-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/matrix-similarity-invariants-oq-01-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-header",
+    "proofId": "matrix-similarity-invariants-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 44 },
+    "type": "context",
+    "title": "Scalar Invariants vs. the Structural Layer",
+    "content": "The module docstring frames this entry against its companion [oq-01]: that entry collects the classical *scalar* similarity invariants (determinant, trace, characteristic polynomial); this one adds the *structural* layer — rank, nullity, and invertibility — which is exactly the data a change of basis cannot see about the underlying linear map. It previews the four results proved (rank_eq over any commutative ring; isUnit_iff / isUnit_det_iff; the matrix form of rank–nullity; nullity_eq and the trivial-kernel ⇔ full-rank bridge) and notes that Mathlib already has the ingredients (rank_mul_eq_left/right_of_isUnit_det, finrank_range_add_finrank_ker, isUnit_iff_isUnit_det) but packages neither a named Similar relation nor these invariance theorems.",
+    "mathContext": "Scalar invariants: $\\det A,\\ \\operatorname{tr} A,\\ \\chi_A(x)$. Structural invariants added here: $\\operatorname{rank} A,\\ \\operatorname{nullity} A,\\ \\operatorname{IsUnit} A$.",
+    "significance": "context",
+    "relatedConcepts": ["similarity invariants", "change of basis", "rank of a linear map", "kernel dimension"],
+    "prerequisites": ["matrices over a commutative ring", "the Similar relation from the companion entry"]
+  },
+  {
     "id": "ann-similar-def",
     "proofId": "matrix-similarity-invariants-oq-01-oq-01",
     "range": { "startLine": 45, "endLine": 48 },

--- a/src/data/proofs/matrix-similarity-invariants-oq-01-oq-01/meta.json
+++ b/src/data/proofs/matrix-similarity-invariants-oq-01-oq-01/meta.json
@@ -83,6 +83,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Rank, Nullity, and Invertibility as the Structural Layer",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Module docstring: the companion entry [oq-01] collects the classical *scalar* similarity invariants (determinant, trace, characteristic polynomial); this entry adds the *structural* layer — rank, nullity, and invertibility — the data a change of basis cannot see about a linear map. Lists the four results proved (rank_eq, isUnit_iff/isUnit_det_iff, rank_add_nullity, nullity_eq, nullity_eq_zero_iff_rank_eq_card) and notes Mathlib has the ingredients but no packaged similarity-invariance theorems.",
+      "mathContext": "$B = PAP^{-1} \\Rightarrow \\operatorname{rank} B = \\operatorname{rank} A,\\ \\operatorname{nullity} B = \\operatorname{nullity} A,\\ (\\operatorname{IsUnit} B \\iff \\operatorname{IsUnit} A)$."
+    },
+    {
       "id": "relation",
       "title": "The Similarity Relation",
       "startLine": 45,


### PR DESCRIPTION
Adds a header section (lines 1-44) and matching context annotation for the module docstring, which frames this entry against its companion [oq-01] and was previously uncovered by any section or annotation. No content invented — restates only what the docstring already says.