### PR TITLE
Enrich dissection-of-cubes-oq-04: header docstring + stale keyInsight fix

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-04/annotations.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/annotations.json
@@ -115,7 +115,7 @@
     },
     "type": "insight",
     "title": "Complete Platonic Solid Classification",
-    "content": "The theorem cube_isolated_dehn_invariant packages the complete 5-solid classification into a single conjunction. The cube (12 edges, π/2 dihedral) has D = 0; all other Platonic solids have D ≠ 0. The tetrahedron and octahedron results come from OQ02OQ02; the dodecahedron is new in this file; the icosahedron uses the axiomatized angle irrationality. The classification has an immediate geometric consequence: no scissors-congruence exists between the cube and any other Platonic solid.",
+    "content": "The theorem cube_isolated_dehn_invariant packages the complete 5-solid classification into a single conjunction. The cube (12 edges, π/2 dihedral) has D = 0; all other Platonic solids have D ≠ 0. The tetrahedron and octahedron results come from OQ02OQ02; the dodecahedron and icosahedron angle irrationalities are both new theorems proved in this file (the icosahedron case was formerly an axiom, now replaced by icoAngle_irrational). The classification has an immediate geometric consequence: no scissors-congruence exists between the cube and any other Platonic solid.",
     "mathContext": "Five Platonic solids (V-E+F = 2): Cube (8-12+6=2, π/2), Tetrahedron (4-6+4=2, arccos(1/3)), Octahedron (6-12+8=2, arccos(-1/3)), Dodecahedron (20-30+12=2, arccos(-1/√5)), Icosahedron (12-30+20=2, arccos(-√5/3)). All non-cube angles are irrational multiples of π, giving nonzero Dehn invariants. The cube's angle π/2 = (1/2)π is rational, giving D = 0.",
     "significance": "critical",
     "relatedConcepts": [

--- a/src/data/proofs/dissection-of-cubes-oq-04/annotations.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/annotations.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "ann-header",
+    "proofId": "dissection-of-cubes-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 59
+    },
+    "type": "context",
+    "title": "Cube Isolation Goal, Axiom Budget, and Classification Table",
+    "content": "The module docstring frames the file's goal (prove the cube is the unique Platonic solid with zero Dehn invariant), previews the new arccos(1/√5)/π irrationality result reusing the Chebyshev-sequence technique from OQ-02's Niven-style argument, and states the axiom budget as 0: both previously axiomatized results — the ℝ-over-ℤ flatness fact used in OQ02OQ02, and icoAngle_irrational proved in this file — are now proved theorems rather than assumptions. It closes with the classification table listing each Platonic solid's dihedral angle and whether its Dehn invariant vanishes (only the cube's does).",
+    "mathContext": "Classification: cube $\\pi/2 \\to D=0$; tetrahedron $\\arccos(1/3)$, octahedron $\\arccos(-1/3)$, dodecahedron $\\arccos(-1/\\sqrt5)$, icosahedron $\\arccos(-\\sqrt5/3) \\to D\\neq 0$.",
+    "significance": "context",
+    "relatedConcepts": ["Dehn invariant", "scissors congruence", "Hilbert's third problem", "Platonic solids"],
+    "prerequisites": ["Dehn invariant infrastructure from OQ-02/OQ-02-OQ-02"]
+  },
+  {
     "id": "ann-chebyshev-sequence-design",
     "proofId": "dissection-of-cubes-oq-04",
     "range": {

--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -78,7 +78,7 @@
       "The mod-5 divisibility argument works because the recurrence d_{n+2} = 6d_{n+1} - 25d_n reduces mod 5 to d_{n+2} \u2261 d_{n+1} (mod 5). Since d_0 = 2 \u2262 0 and d_1 = 6 \u2262 0 (mod 5), all d_n are coprime to 5.",
       "The half-angle identity 2\u00b7arccos(1/\u221a5) = arccos(-3/5) is proved rigorously by computing cos(2\u00b7arccos(1/\u221a5)) = -3/5 and using that arccos_cos identifies the unique value in [0,\u03c0] with that cosine. The range condition 2\u00b7arccos(1/\u221a5) \u2264 \u03c0 follows from arccos(1/\u221a5) \u2264 \u03c0/2 (which holds because 1/\u221a5 \u2265 0).",
       "The dodecahedron and tetrahedron/octahedron have provably different Dehn invariants (not just nonzero), but showing this directly would require comparing the angle classes [arccos(-1/\u221a5)] and [arccos(1/3)] in \u211d/\u03c0\u2124 \u2014 an additional algebraic independence question not addressed here.",
-      "The icosahedron axiom (icoAngle_irrational) is the only deferred result. It follows from a Chebyshev argument in \u2124[\u221a5]: for cos \u03b8 = -\u221a5/3, define a sequence with recurrence involving \u2124[\u221a5] coefficients. The structure is the same as the dodecahedron case but the arithmetic is in a quadratic number field."
+      "The icosahedron result icoAngle_irrational (arccos(-\u221a5/3)/\u03c0 \u2209 \u211a) was formerly an axiom but is now a proved theorem, via the same Niven-style Chebyshev machinery reused a third time: icoSeq (d_0=2, d_1=2, d_{n+2}=2d_{n+1}-81d_n) tracks 9^n\u00b72cos(n\u00b7arccos(1/9)), 3 \u2224 d_n by mod-3 induction, and arccos(1/9) = 2\u03c0 - 2\u00b7icoAngle links this back to icoAngle itself \u2014 no quadratic-field arithmetic in \u2124[\u221a5] is needed."
     ],
     "prerequisites": [
       "DissectionOfCubesOQ02OQ02.lean: Dehn invariant group \u211d \u2297_\u2124 (\u211d/\u03c0\u2124), cube/tetrahedron/octahedron results",
@@ -88,6 +88,14 @@
     ]
   },
   "sections": [
+    {
+      "id": "sec-header",
+      "title": "Header: Cube Isolation, New Result, and Axiom Budget",
+      "startLine": 1,
+      "endLine": 59,
+      "description": "Module docstring: states the goal (only the cube has zero Dehn invariant among the five Platonic solids), previews the new arccos(1/√5)/π irrationality result via the same Chebyshev-sequence technique used for arccos(1/3)/π in OQ-02, records the axiom budget as 0 (both formerly-axiomatized results — the ℝ-flatness fact from OQ02OQ02 and icoAngle_irrational here — are now proved theorems), and gives the classification table of dihedral angles and D=0 status for all five Platonic solids.",
+      "theorems": []
+    },
     {
       "id": "sec-chebyshev-sequence",
       "title": "Part I: Chebyshev Sequence for arccos(3/5)",


### PR DESCRIPTION
Two fixes for this entry:

1. Adds a header section (lines 1-59) and matching context annotation for the module docstring (goal statement, axiom budget, classification table), previously uncovered by any section or annotation.
2. Fixes a stale `keyInsights` item that called `icoAngle_irrational` "the only deferred result" (i.e. an axiom) proved via arithmetic in ℤ[√5]. The Lean file (`theorem icoAngle_irrational` at line 403, plus the axiom-audit comments at lines 528/540) confirms this is now a proved theorem via the mod-3 Chebyshev argument for `arccos(1/9)`, matching what `meta.originalContributions` and `meta.assumptions` already correctly state — only this one keyInsight was out of sync.

No content invented; the header addition restates only what the docstring says, and the keyInsight fix restates only what the Lean source and the rest of meta.json already say.