### PR TITLE
Enrich abel-ruffini-galois-extensions-oq-04-oq-01-oq-01: cover header docstring

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01-oq-01/meta.json
@@ -121,6 +121,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header: Closing the Deferred General Relative Case",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "States what is being settled: the parent branch (oq-04) defined the relative predicate IsMaxNorm H K and its child (oq-04-oq-01) proved the IsMaxNorm ⇔ IsSimpleGroup bridge only for K = ⊤, explicitly deferring 'the fully general K/subgroupOf version — working inside the subtype group ↥K' because of quotient typeclass issues. This file closes that gap axiom-free, identifies the added mathematical content as the lattice transfer between Subgroup ↥K and the ambient interval [H, K] of Subgroup G (via Subgroup.map K.subtype / Subgroup.subgroupOf K round trips), lists the four main results, and notes the K = ⊤ correspondence is reproved inline so the file depends only on import Mathlib.",
+      "mathContext": "Goal: for $H \\le K$ with $H.\\mathrm{subgroupOf}\\,K \\trianglelefteq \\uparrow K$, show $\\uparrow K / (H.\\mathrm{subgroupOf}\\,K)$ simple $\\iff \\mathrm{IsMaxNorm}\\,H\\,K$, via the lattice transfer between $\\mathrm{Subgroup}\\,\\uparrow K$ and $[H,K] \\subseteq \\mathrm{Subgroup}\\,G$."
+    },
+    {
       "id": "absolute",
       "title": "The Absolute Correspondence (K = ⊤, reproved inline)",
       "startLine": 48,


### PR DESCRIPTION
## Summary
- The module header docstring (lines 1-46 of `AbelRuffiniGaloisExtensionsOQ04OQ01OQ01.lean`) was previously uncovered by any `sections[]` entry or `annotations.json` range — the first section started at line 48.
- The header states the deferred general-relative case being settled, the four main results, and why the file depends only on `import Mathlib`; this is genuine framing content, not boilerplate.
- Added a single `header` section to `meta.json` (`sections[0]`, startLine 1 / endLine 46) summarizing exactly what the docstring says, with matching `mathContext`. No other fields touched.

## Test plan
- [x] `jq .` validates the JSON
- [x] `pnpm gallery:check-size` — all 4809 entries within caps (file well under the 60 KB ceiling, 17.5 KB → 18.6 KB)
- [x] Verified against the actual `.lean` file that lines 1-46 are undocumented docstring + imports/namespace, and that no existing annotation covers the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)
