### PR TITLE
Enrich erdos-823-oq-05: cover header docstring (lines 1-44)

### DIFF
--- a/src/data/proofs/erdos-823-oq-05/meta.json
+++ b/src/data/proofs/erdos-823-oq-05/meta.json
@@ -65,6 +65,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Why this file exists",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Module docstring: the registered Erdős #823 parent proves its concrete σ-values (σ(14)=σ(15)=24, etc.) via native_decide, which depends on Lean.ofReduceBool and so is not axiom-free under the project's axiom-integrity policy. This file reproves the same σ-values symbolically from Mathlib's arithmetic-function API — multiplicativity plus the value on primes and prime powers — so every result is kernel-checked with no native_decide and no axiom. It also flags a latent bug in the parent: its native_decide claim sigma_206_210 (σ(206)=σ(210)) is false.",
+      "mathContext": "$\\sigma(206)=\\sigma(2\\cdot103)=3\\cdot104=312 \\ne \\sigma(210)=\\sigma(2\\cdot3\\cdot5\\cdot7)=3\\cdot4\\cdot6\\cdot8=576$."
+    },
+    {
       "id": "sigma-on-primes",
       "title": "σ on a prime",
       "startLine": 45,


### PR DESCRIPTION
## Summary
- `sections[0]` started at line 45, leaving the module docstring (lines 1-44 of `Proofs/Erdos823SigmaValues.lean`) uncovered by any section or annotation
- The docstring is genuine content: it explains why the file exists (the parent's `native_decide` σ-value computations depend on `Lean.ofReduceBool` and aren't axiom-free; this file reproves them symbolically) and documents a latent bug in the parent — its `native_decide` claim `sigma_206_210` (σ(206)=σ(210)) is false
- Added one `header`-type section (`startLine: 1, endLine: 44`) summarizing only what the docstring says, no invented content

## Test plan
- [x] `jq empty meta.json` — valid JSON
- [x] `pnpm build` data-generation steps completed without error (final `tsc` step fails host-wide due to missing `node_modules` in this worktree, unrelated to this change)