### PR TITLE
Enrich fourier-series-oq-04-wip-01: cover header docstring (lines 1-42)

### DIFF
--- a/src/data/proofs/fourier-series-oq-04-wip-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-04-wip-01/meta.json
@@ -95,6 +95,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Why this file exists",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "Module docstring: the parent FourierSeriesOQ04.lean models the n-torus as Fin n → ℝ and leaves the Fourier coefficient as a placeholder (fourierCoeff := 0). Its OQ-04 asks whether the placeholder can be implemented via Mathlib's integration and Haar measure on compact groups, suggesting Fin n → AddCircle (1 : ℝ) with the product Haar measure. This file follows that path exactly: it builds the n-dimensional character e_k(x) = ∏ᵢ eᵢ(xᵢ) from Mathlib's fourier : ℤ → C(AddCircle T, ℂ), defines the genuine coefficient f̂(k) = ∫ f(x)·conj(e_k(x)) dHaar, and proves the character is a unimodular group homomorphism ℤⁿ → ℂˣ plus linearity of the coefficient.",
+      "mathContext": "$\\hat f(k) = \\int_{T^n} f(x)\\,\\overline{e_k(x)}\\,d\\mathrm{Haar}$, replacing the parent's placeholder $\\text{fourierCoeff} := 0$."
+    },
+    {
       "id": "definitions",
       "title": "Section I: The Genuine Character and Coefficient",
       "startLine": 43,


### PR DESCRIPTION
## Summary
- `sections[0]` started at line 43, leaving the module docstring (lines 1-42 of `Proofs/FourierSeriesOQ04WIP01.lean`) uncovered by any section or annotation
- The docstring is genuine content: it states the OQ-04 open question (implement the parent's placeholder `fourierCoeff := 0` via Mathlib integration/Haar measure) and this file's resolution path (`Fin n → AddCircle (1:ℝ)`, product Haar measure, `torusChar`/`fourierCoeffND`)
- Added one `header`-type section (`startLine: 1, endLine: 42`) summarizing only what the docstring says, no invented content

## Test plan
- [x] `jq empty meta.json` — valid JSON
- [x] File stays well under the 60 KB size cap (14.4 KB)