### PR TITLE
Enrich geometric-series-oq002: cover header docstring (lines 1-46)

### DIFF
--- a/src/data/proofs/geometric-series-oq002/meta.json
+++ b/src/data/proofs/geometric-series-oq002/meta.json
@@ -89,6 +89,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Why this file exists",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring: the parent geometric-series-oq-07-oq-01-oq-01 (Frobenius' identity) proves the geometric-moment numerator Nₘ(X) = ∑ₖ S(m,k)·k!·Xᵏ·(1−X)^{m−k} equals the Eulerian polynomial Eₘ, defined by the recurrence E₀=1, E_{m+1}=X(1−X)E'ₘ+(m+1)XEₘ, but left open (oq-01) identifying Eₘ's coefficients with the classical combinatorial Eulerian numbers ⟨m,k⟩ (the descent statistic on permutations, triangle recurrence ⟨m,k⟩=(k+1)⟨m−1,k⟩+(m−k)⟨m−1,k−1⟩, ⟨m,0⟩=1). This file builds ⟨m,k⟩ from scratch (Mathlib has only Eulerian graphs, not Eulerian numbers) and proves eulerPoly_eq_eulerianNumbers: E_{m+1}(X) = ∑ⱼ ⟨m+1,j⟩·X^{j+1}, by induction on m matching the differential recurrence coefficient-by-coefficient against the Eulerian triangle recurrence. Everything is 0-axiom and sorry-free.",
+      "mathContext": "$E_{m+1}(X) = \\sum_{j=0}^{m} \\langle m+1,j\\rangle X^{j+1}$, settling the open coefficient-identification question of the parent entry."
+    },
+    {
       "id": "eulerian-numbers",
       "title": "The Combinatorial Eulerian Numbers",
       "startLine": 47,


### PR DESCRIPTION
## Summary
- `sections[0]` started at line 47, leaving the module docstring (lines 1-46 of `Proofs/GeometricSeriesOQ07OQ01OQ01OQ01.lean`) uncovered by any section or annotation
- The docstring is genuine content: it states the open question this file settles (identifying the Eulerian polynomial's coefficients with the classical combinatorial Eulerian numbers, an open item left by the parent `geometric-series-oq-07-oq-01-oq-01`) and the proof method
- Added one `header`-type section (`startLine: 1, endLine: 46`) summarizing only what the docstring says, no invented content

## Test plan
- [x] `jq empty meta.json` — valid JSON
- [x] File stays well under the 60 KB size cap (17.5 KB)