### PR TITLE
audit: re-serve cayley-hamilton-minpoly-oq-05-oq-01-oq-03 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5280,9 +5280,9 @@
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-05-oq-01-oq-03": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:33Z",
+      "lastAudited": "2026-07-22T19:40:49Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-05-oq-01-oq-04": {


### PR DESCRIPTION
## Audit summary

Reserve-mode re-verification (queue drained). Independently re-checked prose
against source, not just counts (per prior-audit gotchas about phantom
declarations slipping past count-only re-serves).

- All 19 `theoremCount` declarations and 6 `def`s named in
  `meta.originalContributions` exist verbatim in
  `proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ03.lean` — no phantom decls.
- All 9 section summaries accurately describe the corresponding code block,
  including an honest self-correction note in Section IX
  (`minpoly_minimal_degree`) acknowledging it doesn't fully characterize
  "nonderogatory" — a genuinely disclosed limitation, not overclaimed.
- 0 axioms, 0 sorries, no `native_decide`; lineCount (350) matches exactly.
- `matrix_nonderogatory_implies_module` correctly calls into
  `NonderogatoryComplete.nonderogatory_has_cyclic_vector` from the imported
  parent file `CayleyHamiltonMinpolyOQ05OQ01.lean`, confirmed to exist.

No issues found. Tracker updated to reflect the re-audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)