### PR TITLE
Research: szemeredi-regularity-oq-04 — S18 one-sided defect energy gain (eps³ for the 3-piece step, 0-axiom)

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04DefectGain.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04DefectGain.lean
@@ -1,0 +1,228 @@
+/-
+  Szemerédi Regularity Lemma — OQ-04: the one-sided defect energy gain (S18).
+
+  `StepThree.lean` (S17) packaged the degenerate side of the sharp `2×2`
+  dichotomy into the asymmetric 3-piece step `IsWitnessedSharpStep3`: only `B`
+  splits, and the deviating piece `B₁` carries an `eps`-mass floor together with
+  an `eps`-density gap *against the parent pair* `(A, B)`.  The symmetric energy
+  engine (`pairEnergy_split_gain`, Energy.lean) cannot consume this witness: its
+  deviation hypothesis compares the two halves, `|d(A₁,B) − d(A₂,B)| ≥ δ`, while
+  the 3-piece step only controls the deviation of ONE half from the PARENT — and
+  `energy_excess_A_split` (SzemerediCoreOQ01.lean) needs BOTH halves nonempty.
+
+  This file supplies the missing one-sided (defect) form of the Cauchy–Schwarz
+  energy boost, the residual obligation recorded in the header of
+  `StepThree.lean`:
+
+  * `defect_energy_bound` — the two-cell weighted-mean defect inequality:
+    if `μ` is the size-weighted mean of `d₁, d₂` and `δ ≤ |d₁ − μ|`, then
+    `(w₁+w₂)·μ² + w₁·δ² ≤ w₁·d₁² + w₂·d₂²`.  Of the two variance terms in
+    `Σ wᵢ(dᵢ−μ)²`, keeping only the deviating cell already yields the gain — so
+    NO positivity of `w₂` is needed (the parent-mean pins `μ` even when the
+    complementary cell is empty).
+  * `pairEnergy_split_gain_defect` — the pair-energy form for an `A`-side split:
+    a `δ`-deviation of `d(A₁,B)` from the parent density `d(A₁∪A₂,B)` gains
+    `(|A₁||B|/n²)·δ²` of normalized energy.
+  * `pairEnergy_split_gain_defect_right` — the `B`-side transport via
+    `pairEnergy_comm`/`edgeDensity_symm`: the exact shape the 3-piece step needs.
+  * `pairEnergy_step3_gain` — the `eps³` form: with the mass floor
+    `eps·|B| ≤ |B₁|` and the `eps`-gap, splitting `B` gains
+    `≥ eps³·|A||B|/n²` — the increment the outer AFKS budget consumes
+    (`eps³ ≥ eps⁴` covers both dichotomy branches).
+  * `pairEnergy_gain_of_isWitnessedSharpStep3` — capstone: every witnessed
+    3-piece step carries the `eps³` pair-energy gain at its refined pair.
+
+  0 axioms, 0 sorries.
+
+  Reference: Alon–Fischer–Krivelevich–Szegedy, "Efficient testing of large
+  graphs", Combinatorica 20 (2000).
+-/
+import Mathlib
+import Proofs.SzemerediRegularityOQ04Bridge
+import Proofs.SzemerediRegularityOQ04StepThree
+
+namespace Szemeredi.RegularityOQ04DefectGain
+
+open Szemeredi.Core Szemeredi.EnergyIncrement Szemeredi.RegularityOQ04Energy
+  Szemeredi.RegularityOQ04Bridge Szemeredi.RegularityOQ04StepThree
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART I: THE TWO-CELL DEFECT INEQUALITY (PURE ARITHMETIC)
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Weighted-mean defect inequality.**  If `μ` is the `w`-weighted mean of
+    `d₁, d₂` (stated multiplicatively, so no division and no positivity of the
+    total weight is needed) and the FIRST cell deviates from the mean by at
+    least `δ`, then the second moment exceeds the squared mean by at least
+    `w₁·δ²`:
+
+    `(w₁+w₂)·μ² + w₁·δ² ≤ w₁·d₁² + w₂·d₂²`.
+
+    This is the one-sided (defect) half of the variance identity
+    `Σ wᵢdᵢ² − (Σwᵢ)μ² = Σ wᵢ(dᵢ−μ)²`: dropping the nonnegative term
+    `w₂(d₂−μ)²` and bounding `w₁(d₁−μ)² ≥ w₁δ².  Unlike
+    `split_energy_excess_bound`, the complementary weight `w₂` may be zero. -/
+theorem defect_energy_bound (w₁ w₂ d₁ d₂ μ δ : ℚ) (h₁ : 0 ≤ w₁) (h₂ : 0 ≤ w₂)
+    (hμ : (w₁ + w₂) * μ = w₁ * d₁ + w₂ * d₂) (hδ : 0 ≤ δ)
+    (hdev : δ ≤ |d₁ - μ|) :
+    (w₁ + w₂) * μ ^ 2 + w₁ * δ ^ 2 ≤ w₁ * d₁ ^ 2 + w₂ * d₂ ^ 2 := by
+  have hsq : δ ^ 2 ≤ (d₁ - μ) ^ 2 := by
+    have habs : δ * δ ≤ |d₁ - μ| * |d₁ - μ| := mul_self_le_mul_self hδ hdev
+    rw [abs_mul_abs_self] at habs
+    nlinarith [habs]
+  have hμμ : ((w₁ + w₂) * μ) * μ = (w₁ * d₁ + w₂ * d₂) * μ := by rw [hμ]
+  nlinarith [mul_le_mul_of_nonneg_left hsq h₁,
+    mul_nonneg h₂ (sq_nonneg (d₂ - μ)), hμμ]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART II: THE ONE-SIDED PAIR-ENERGY GAIN (DEVIATION FROM THE PARENT)
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **One-sided (defect) energy increment, `A`-side split.**  If the piece `A₁`
+    of a disjoint split deviates from the PARENT density by at least `δ` —
+    `δ ≤ |d(A₁,B) − d(A₁∪A₂,B)|` — then refining the pair raises its normalized
+    energy contribution by at least `(|A₁|·|B|/n²)·δ²`.
+
+    Compare `pairEnergy_split_gain`, whose hypothesis is the deviation BETWEEN
+    the two halves and which needs both halves nonempty; here only the deviating
+    piece `A₁` must be nonempty, because the parent mean pins the average even
+    when `A₂ = ∅`. -/
+theorem pairEnergy_split_gain_defect (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A₁ A₂ B : Finset V) (hA : Disjoint A₁ A₂)
+    (hn₁ : 0 < (A₁.card : ℚ)) (hB : 0 < (B.card : ℚ))
+    (δ : ℚ) (hδ : 0 ≤ δ)
+    (hdev : δ ≤ |edgeDensity G A₁ B - edgeDensity G (A₁ ∪ A₂) B|) :
+    pairEnergy G (A₁ ∪ A₂) B +
+        (A₁.card : ℚ) * B.card / (Fintype.card V : ℚ) ^ 2 * δ ^ 2 ≤
+      pairEnergy G A₁ B + pairEnergy G A₂ B := by
+  have hcard : ((A₁ ∪ A₂).card : ℚ) = (A₁.card : ℚ) + A₂.card := by
+    rw [Finset.card_union_of_disjoint hA]; push_cast; ring
+  -- the parent density is the size-weighted mean of the sub-densities
+  have hmul := edgeDensity_union_mul G A₁ A₂ B hA
+  rw [hcard] at hmul
+  have hBne : (B.card : ℚ) ≠ 0 := ne_of_gt hB
+  have havg : ((A₁.card : ℚ) + A₂.card) * edgeDensity G (A₁ ∪ A₂) B =
+      (A₁.card : ℚ) * edgeDensity G A₁ B + (A₂.card : ℚ) * edgeDensity G A₂ B :=
+    mul_left_cancel₀ hBne (by linear_combination hmul)
+  -- the unnormalized defect bound at the deviating cell
+  have hkey := defect_energy_bound (A₁.card : ℚ) (A₂.card : ℚ)
+    (edgeDensity G A₁ B) (edgeDensity G A₂ B) (edgeDensity G (A₁ ∪ A₂) B) δ
+    hn₁.le (by positivity) havg hδ hdev
+  -- normalize by the common weight |B|/n² ≥ 0
+  have hw : (0 : ℚ) ≤ (B.card : ℚ) / (Fintype.card V : ℚ) ^ 2 := by positivity
+  unfold pairEnergy
+  rw [hcard]
+  have hgL :
+      (↑A₁.card + ↑A₂.card : ℚ) * ↑B.card / (Fintype.card V : ℚ) ^ 2 *
+          (edgeDensity G (A₁ ∪ A₂) B) ^ 2 +
+        (A₁.card : ℚ) * ↑B.card / (Fintype.card V : ℚ) ^ 2 * δ ^ 2 =
+      (B.card : ℚ) / (Fintype.card V : ℚ) ^ 2 *
+        (((A₁.card : ℚ) + A₂.card) * (edgeDensity G (A₁ ∪ A₂) B) ^ 2 +
+          (A₁.card : ℚ) * δ ^ 2) := by
+    ring
+  have hgR :
+      (A₁.card : ℚ) * ↑B.card / (Fintype.card V : ℚ) ^ 2 *
+          (edgeDensity G A₁ B) ^ 2 +
+        (A₂.card : ℚ) * ↑B.card / (Fintype.card V : ℚ) ^ 2 *
+          (edgeDensity G A₂ B) ^ 2 =
+      (B.card : ℚ) / (Fintype.card V : ℚ) ^ 2 *
+        ((A₁.card : ℚ) * (edgeDensity G A₁ B) ^ 2 +
+          (A₂.card : ℚ) * (edgeDensity G A₂ B) ^ 2) := by
+    ring
+  rw [hgL, hgR]
+  exact mul_le_mul_of_nonneg_left hkey hw
+
+/-- **One-sided (defect) energy increment, `B`-side split.**  The transport of
+    `pairEnergy_split_gain_defect` through `pairEnergy_comm`/`edgeDensity_symm`:
+    splitting only the SECOND block of a pair, with the deviating piece `B₁`
+    `δ`-far from the parent density `d(A, B₁∪B₂)`, gains `(|A|·|B₁|/n²)·δ²`.
+    This is exactly the split shape of the asymmetric 3-piece step
+    (`IsWitnessedSharpStep3`, StepThree.lean). -/
+theorem pairEnergy_split_gain_defect_right (G : SimpleGraph V)
+    [DecidableRel G.Adj] (A B₁ B₂ : Finset V) (hB : Disjoint B₁ B₂)
+    (hn₁ : 0 < (B₁.card : ℚ)) (hA : 0 < (A.card : ℚ))
+    (δ : ℚ) (hδ : 0 ≤ δ)
+    (hdev : δ ≤ |edgeDensity G A B₁ - edgeDensity G A (B₁ ∪ B₂)|) :
+    pairEnergy G A (B₁ ∪ B₂) +
+        (A.card : ℚ) * B₁.card / (Fintype.card V : ℚ) ^ 2 * δ ^ 2 ≤
+      pairEnergy G A B₁ + pairEnergy G A B₂ := by
+  rw [pairEnergy_comm G A (B₁ ∪ B₂), pairEnergy_comm G A B₁,
+    pairEnergy_comm G A B₂]
+  have hdev' : δ ≤ |edgeDensity G B₁ A - edgeDensity G (B₁ ∪ B₂) A| := by
+    rwa [edgeDensity_symm G A B₁, edgeDensity_symm G A (B₁ ∪ B₂)] at hdev
+  have h := pairEnergy_split_gain_defect G B₁ B₂ A hB hn₁ hA δ hδ hdev'
+  have hswap : (A.card : ℚ) * B₁.card / (Fintype.card V : ℚ) ^ 2 * δ ^ 2 =
+      (B₁.card : ℚ) * A.card / (Fintype.card V : ℚ) ^ 2 * δ ^ 2 := by
+    ring
+  rw [hswap]
+  exact h
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART III: THE eps³ GAIN OF THE 3-PIECE STEP
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **The `eps³` energy gain of the 3-piece split data.**  With the `eps`-mass
+    floor `eps·|B| ≤ |B₁|` on the deviating piece and the `eps`-density gap
+    against the parent, splitting `B = B₁ ∪ B₂` (with `A` kept intact) raises
+    the pair energy by at least `eps³·|A||B|/n²`:
+
+    `pairEnergy G A B + eps³·|A||B|/n² ≤ pairEnergy G A B₁ + pairEnergy G A B₂`.
+
+    The floor converts the raw defect gain `eps²·|A||B₁|/n²` into the quotable
+    `eps³·|A||B|/n²` — one power of `eps` is the price of the mass floor.  This
+    is the energy content of `IsWitnessedSharpStep3` recorded as the residual
+    obligation in the header of `StepThree.lean`. -/
+theorem pairEnergy_step3_gain (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A B B₁ B₂ : Finset V) (hunion : B₁ ∪ B₂ = B) (hdisj : Disjoint B₁ B₂)
+    (eps : ℚ) (heps : 0 < eps)
+    (hApos : 0 < (A.card : ℚ)) (hBpos : 0 < (B.card : ℚ))
+    (hfloor : eps * B.card ≤ (B₁.card : ℚ))
+    (hdev : eps ≤ |edgeDensity G A B₁ - edgeDensity G A B|) :
+    pairEnergy G A B +
+        eps ^ 3 * ((A.card : ℚ) * B.card) / (Fintype.card V : ℚ) ^ 2 ≤
+      pairEnergy G A B₁ + pairEnergy G A B₂ := by
+  subst hunion
+  -- the mass floor makes the deviating piece nonempty
+  have hn₁ : 0 < (B₁.card : ℚ) := lt_of_lt_of_le (mul_pos heps hBpos) hfloor
+  have h := pairEnergy_split_gain_defect_right G A B₁ B₂ hdisj hn₁ hApos
+    eps heps.le hdev
+  -- eps³·|A||B| ≤ eps²·|A||B₁| via the floor (one power of eps pays for it)
+  have hstep : eps ^ 3 * ((A.card : ℚ) * ((B₁ ∪ B₂).card : ℚ)) ≤
+      (A.card : ℚ) * (B₁.card : ℚ) * eps ^ 2 := by
+    have hmono := mul_le_mul_of_nonneg_left hfloor
+      (mul_nonneg (sq_nonneg eps) hApos.le)
+    nlinarith [hmono]
+  have hinv : (0 : ℚ) ≤ ((Fintype.card V : ℚ) ^ 2)⁻¹ := by positivity
+  have h2 := mul_le_mul_of_nonneg_right hstep hinv
+  have hgain : eps ^ 3 * ((A.card : ℚ) * ((B₁ ∪ B₂).card : ℚ)) /
+        (Fintype.card V : ℚ) ^ 2 ≤
+      (A.card : ℚ) * (B₁.card : ℚ) / (Fintype.card V : ℚ) ^ 2 * eps ^ 2 := by
+    rw [div_eq_mul_inv, div_eq_mul_inv]
+    nlinarith [h2]
+  linarith [h, hgain]
+
+/-- **Capstone: every witnessed 3-piece step carries the `eps³` pair-energy
+    gain.**  Unpacking `IsWitnessedSharpStep3` (for positive `eps` and coarse
+    floor `m`) returns the step data together with the energy increment at the
+    refined pair — the quantitative input the outer AFKS chain construction
+    consumes on the degenerate branch of the dichotomy. -/
+theorem pairEnergy_gain_of_isWitnessedSharpStep3 (G : SimpleGraph V)
+    [DecidableRel G.Adj] (parts : ℕ → Finset (Finset V)) (n : ℕ) (eps m : ℚ)
+    (heps : 0 < eps) (hm : 0 < m)
+    (h : IsWitnessedSharpStep3 G parts n eps m) :
+    ∃ R : Finset (Finset V), ∃ A B B₁ B₂ : Finset V,
+      parts n = insert A (insert B R) ∧
+      parts (n + 1) = insert A (insert B₁ (insert B₂ R)) ∧
+      B₁ ∪ B₂ = B ∧ Disjoint B₁ B₂ ∧
+      pairEnergy G A B +
+          eps ^ 3 * ((A.card : ℚ) * B.card) / (Fintype.card V : ℚ) ^ 2 ≤
+        pairEnergy G A B₁ + pairEnergy G A B₂ := by
+  obtain ⟨R, A, B, B₁, B₂, hpn, hpn1, hunion, hdisj, -, -, -, -, -,
+    hmA, hmB, hfloor, hdev⟩ := h
+  exact ⟨R, A, B, B₁, B₂, hpn, hpn1, hunion, hdisj,
+    pairEnergy_step3_gain G A B B₁ B₂ hunion hdisj eps heps
+      (lt_of_lt_of_le hm hmA) (lt_of_lt_of_le hm hmB) hfloor hdev⟩
+
+end Szemeredi.RegularityOQ04DefectGain

--- a/research/problems/szemeredi-regularity-oq-04/knowledge.md
+++ b/research/problems/szemeredi-regularity-oq-04/knowledge.md
@@ -976,3 +976,56 @@ predicate/packaging/case-split level.
   the 4-piece `eps⁴` floor, so the outer loop's `eps⁴` budget covers both branches.
 - Threading both step shapes through the outer-loop chain construction
   (`exists_afksTwoLevel_of_dichotomy` reformulation), per the standing next-step.
+
+---
+
+## Session 2026-07-22 S18 (researcher-1) — one-sided defect energy gain: eps³ for the 3-piece step
+
+**Mode:** REVISIT (RICH). **Outcome:** S17 residual (a) — "the one-sided defect
+inequality" — discharged in full, including the eps³ quotable form and the
+capstone against `IsWitnessedSharpStep3`. Docker-verified first try (8588 jobs),
+warning-free, 0 ax, 0 sorry.
+
+### New file `SzemerediRegularityOQ04DefectGain.lean` (228 lines, 5 theorems)
+- `defect_energy_bound (w₁ w₂ d₁ d₂ μ δ : ℚ)`: `0≤w₁ → 0≤w₂ → (w₁+w₂)μ = w₁d₁+w₂d₂ →
+  0≤δ → δ ≤ |d₁−μ| → (w₁+w₂)μ² + w₁δ² ≤ w₁d₁² + w₂d₂²`. The mean hypothesis is
+  MULTIPLICATIVE (no division) so `w₂ = 0` is allowed — unlike
+  `split_energy_excess_bound`, which needs both weights positive.
+- `pairEnergy_split_gain_defect`: A-side split, deviation vs PARENT density,
+  gain `(|A₁||B|/n²)·δ²`; only `A₁` (deviating) and `B` nonempty required.
+- `pairEnergy_split_gain_defect_right`: B-side transport via `pairEnergy_comm`
+  (Bridge.lean) + `edgeDensity_symm` (CoreOQ01) — the `IsWitnessedSharpStep3` shape.
+- `pairEnergy_step3_gain`: `B₁∪B₂ = B`, floor `eps·|B| ≤ |B₁|`, gap
+  `eps ≤ |d(A,B₁)−d(A,B)|` ⟹ `pairEnergy(A,B) + eps³·|A||B|/n² ≤
+  pairEnergy(A,B₁)+pairEnergy(A,B₂)`. One power of eps pays for the mass floor;
+  eps³ ≥ eps⁴ so the 4-piece outer budget covers the degenerate branch.
+- `pairEnergy_gain_of_isWitnessedSharpStep3`: unpacks the S17 predicate (needs
+  `0 < eps`, `0 < m`) and returns step data + the eps³ increment at the refined pair.
+
+### Reusable Lean recipe
+- State weighted means MULTIPLICATIVELY (`(w₁+w₂)μ = w₁d₁+w₂d₂`) to avoid division
+  and weight-positivity hypotheses entirely; recover it from
+  `edgeDensity_union_mul` by `mul_left_cancel₀ hBne (by linear_combination hmul)`.
+- Defect-bound arithmetic closes with
+  `nlinarith [mul_le_mul_of_nonneg_left hsq h₁, mul_nonneg h₂ (sq_nonneg (d₂-μ)), hμμ]`
+  where `hμμ := congrArg (·*μ) hμ`-style product form (provide `((w₁+w₂)*μ)*μ = ...`
+  as a `have` via `rw [hμ]` — nlinarith will NOT multiply the mean equation by μ itself).
+- `δ² ≤ (d₁−μ)²` from `δ ≤ |d₁−μ|`: `mul_self_le_mul_self` + `abs_mul_abs_self` +
+  nlinarith (avoids `pow_le_pow_left` name drift).
+- Weight-normalization pattern (from `pairEnergy_split_gain`): factor BOTH sides of
+  the pair-energy inequality through `|B|/n²` with two explicit `ring` identities,
+  then `mul_le_mul_of_nonneg_left hkey hw` — do NOT let nlinarith touch the n² division.
+- Division-free gain conversion: `rw [div_eq_mul_inv, div_eq_mul_inv]` then feed
+  `mul_le_mul_of_nonneg_right hstep (by positivity : 0 ≤ (n²)⁻¹)` to nlinarith.
+
+### What remains (S17 residual (b), the last layer)
+- Threading both step shapes through the outer-loop chain construction:
+  partition-level increment (`partitionEnergy` bookkeeping over
+  `insert A (insert B₁ (insert B₂ R))`, cf. `PartitionGain.lean` for the symmetric
+  shape) + the recursive `exists_afksTwoLevel_of_dichotomy` reformulation. Deep —
+  this is the genuine outer-loop assembly, not an elementary increment.
+
+### Files Modified
+- `proofs/Proofs/SzemerediRegularityOQ04DefectGain.lean` (NEW, 228 lines, 5 theorems)
+- `research/problems/szemeredi-regularity-oq-04/{state.md,knowledge.md}`
+- `src/data/research/problems/szemeredi-regularity-oq-04.json` (leanFiles + knowledge)

--- a/research/problems/szemeredi-regularity-oq-04/state.md
+++ b/research/problems/szemeredi-regularity-oq-04/state.md
@@ -4,7 +4,7 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-08T19:18:01-07:00
-**Iteration**: 3
+**Iteration**: 5
 
 ## Status (S16, researcher-1, 2026-07-22) — DENSITY GAP forbids a doubly-trivial split
 
@@ -377,3 +377,29 @@ Remaining: (a) one-sided defect inequality for the 3-piece step (mean preserved 
 edge-count additivity, expected floor `eps³ ≥ eps⁴` — outer budget covers both
 branches); (b) chain construction threading BOTH step shapes through
 `exists_afksTwoLevel_of_dichotomy`.
+
+## Status (S18, researcher-1, 2026-07-22) — one-sided defect energy gain (eps³ for the 3-piece step)
+
+New file `SzemerediRegularityOQ04DefectGain.lean` (5 thm, 0 ax, 0 sorry, docker-VERIFIED,
+8588 jobs, warning-free). Discharges the FIRST of the two residuals recorded by S17: the
+energy content of the asymmetric 3-piece step. The symmetric engine
+(`pairEnergy_split_gain`) compares the two HALVES and needs both nonempty;
+`energy_excess_A_split` likewise. The 3-piece witness only controls the deviation of ONE
+half from the PARENT — that one-sided (defect) form is what this file adds.
+
+- `defect_energy_bound` — two-cell weighted-mean defect inequality, multiplicative mean
+  hypothesis `(w₁+w₂)μ = w₁d₁+w₂d₂` (no division, `w₂ = 0` allowed):
+  `(w₁+w₂)μ² + w₁δ² ≤ w₁d₁² + w₂d₂²` when `δ ≤ |d₁−μ|`.
+- `pairEnergy_split_gain_defect` — A-side split: deviation `δ` of `d(A₁,B)` from the
+  PARENT `d(A₁∪A₂,B)` gains `(|A₁||B|/n²)·δ²`; only the deviating piece must be nonempty.
+- `pairEnergy_split_gain_defect_right` — B-side transport (the step-3 shape) via
+  `pairEnergy_comm` + `edgeDensity_symm`.
+- `pairEnergy_step3_gain` — the eps³ form: mass floor `eps·|B| ≤ |B₁|` + eps-gap give
+  `pairEnergy(A,B) + eps³·|A||B|/n² ≤ pairEnergy(A,B₁) + pairEnergy(A,B₂)`.
+- `pairEnergy_gain_of_isWitnessedSharpStep3` — capstone: every witnessed 3-piece step
+  (with `0 < eps`, `0 < m`) carries the eps³ gain at its refined pair.
+
+**What this leaves (S17 residual (b), unchanged):** threading BOTH step shapes
+(4-piece `IsWitnessedSharpStep` with its eps⁴ gain, 3-piece with this eps³ ≥ eps⁴ gain)
+through the outer-loop chain construction (`exists_afksTwoLevel_of_dichotomy`
+reformulation) — the partition-level increment + freshness bookkeeping. Deep.

--- a/src/data/research/problems/szemeredi-regularity-oq-04.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-04.json
@@ -20,13 +20,13 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-08T19:45:20Z",
-    "iteration": 4,
-    "focus": "AFKS hybrid-regularity bridge: IsAFKSFineRegular (strong fine tolerance E, coarse budget ε) with bridge-up isRegularPartition_of_afksFineRegular (E-fine ⟹ ε-regular partition for E≤ε), bridge-down afksFineRegular_of_isRegularPartition, and both-sided monotonicity — pins the AFKS conclusion (iii) currency in the regularity hierarchy [VERIFIED 0 axioms].",
+    "iteration": 5,
+    "focus": "S18 (2026-07-22): one-sided defect energy gain DONE — SzemerediRegularityOQ04DefectGain.lean proves defect_energy_bound (weighted-mean defect, w2=0 allowed), pairEnergy_split_gain_defect(_right) (deviation vs PARENT density, gain |A1||B|/n^2 * delta^2), pairEnergy_step3_gain (eps^3 * |A||B|/n^2 via the eps-mass floor), and the capstone pairEnergy_gain_of_isWitnessedSharpStep3. The S17 3-piece step now carries its quantitative energy increment; eps^3 >= eps^4 so the symmetric outer budget covers both dichotomy branches. [VERIFIED 0 axioms, docker 8588 jobs]",
     "blockers": [],
-    "nextAction": "Reconstruct the energy-increment step (epsilon-irregular refinement raises partitionEnergy by >= delta) from split_energy_excess_bound, then assemble the outer AFKS loop using partitionEnergy_no_infinite_increments as termination certificate."
+    "nextAction": "S17 residual (b), the last layer: thread BOTH step shapes (4-piece IsWitnessedSharpStep with eps^4 gain, 3-piece IsWitnessedSharpStep3 with the new eps^3 gain) through the outer-loop chain construction — partition-level increment over insert A (insert B1 (insert B2 R)) (cf. PartitionGain.lean for the symmetric shape) and the recursive exists_afksTwoLevel_of_dichotomy reformulation. Deep outer-loop assembly; no elementary increment remains at the pair level."
   },
   "knowledge": {
-    "progressSummary": "AFKS strong regularity: items 1-3 machinery done modulo chain construction. S14-S16 derived all reachable piece-nonemptiness and pinned the residual to one degenerate side. S17 (StepThree.lean) DISCHARGED the S16 residual at the predicate level: IsWitnessedSharpStep3 (asymmetric 3-piece step) + packaging + the trichotomy normalizing both degenerate sides onto one shape via edgeDensity_symm. Remaining: one-sided energy defect inequality (eps^3 floor, mean preserved) and the recursive chain construction threading both step shapes through exists_afksTwoLevel_of_dichotomy.",
+    "progressSummary": "Item-1 dichotomy: constructive core COMPLETE at the pair level. S12-S15 packaging/freshness/mass-floor/ceiling; S16 gap forbids doubly-trivial splits; S17 asymmetric 3-piece predicate IsWitnessedSharpStep3 + trichotomy (one normalized shape covers both degenerate sides via edgeDensity_symm); S18 (2026-07-22) the one-sided DEFECT energy inequality: deviation of ONE half from the PARENT density gains (|A1||B|/n^2)*delta^2 (defect_energy_bound, multiplicative mean, empty complement allowed), and with the eps-mass floor the 3-piece step gains eps^3*|A||B|/n^2 (pairEnergy_step3_gain, capstone pairEnergy_gain_of_isWitnessedSharpStep3). Remaining: outer-loop chain construction threading both step shapes (deep).",
     "builtItems": [
       "gap_forces_complement_nonempty in SzemerediRegularityOQ04SplitProper.lean (S16) — the eps-density gap |d(A1,B1)-d(A,B)| >= eps > 0 forbids a doubly-trivial split: A2.Nonempty OR B2.Nonempty (both empty would force A1=A,B1=B, gap=0). exists_sharp_split_nontrivial_of_not_afksFineRegular appends this disjunction to the S11 extracted sharp split.",
       "edgeDensity_union_mul in SzemerediRegularityOQ04Energy.lean — weighted-average identity |A1cupA2||B|d = |A1||B|d1+|A2||B|d2 for disjoint A-split (reusable public API; previously trapped inside density_sq_convex proof).",
@@ -90,7 +90,11 @@
       "isWitnessedSharpStep_of_split_of_nonempty in SzemerediRegularityOQ04Freshness.lean: freshness-free packaging — full IsWitnessedSharpStep from split data + mass floors + gap + nonemptiness of the four pieces. 0-axiom, docker-VERIFIED.",
       "IsWitnessedSharpStep3 in SzemerediRegularityOQ04StepThree.lean: asymmetric 3-piece witnessed-step predicate (only B splits), S16 residual shape",
       "isWitnessedSharpStep3_of_split: canonical-residual packaging lemma for the 3-piece step (mirrors Packaging.lean)",
-      "exists_proper_or_semitrivial_split_of_not_afksFineRegular: trichotomy case-split on gap_forces_complement_nonempty - proper 2x2 (both complements nonempty) OR normalized 3-piece data"
+      "exists_proper_or_semitrivial_split_of_not_afksFineRegular: trichotomy case-split on gap_forces_complement_nonempty - proper 2x2 (both complements nonempty) OR normalized 3-piece data",
+      "defect_energy_bound (two-cell weighted-mean defect inequality, w2=0 allowed) in SzemerediRegularityOQ04DefectGain.lean",
+      "pairEnergy_split_gain_defect / _right (one-sided gain vs parent density, A-side and B-side) in SzemerediRegularityOQ04DefectGain.lean",
+      "pairEnergy_step3_gain (eps^3*|A||B|/n^2 gain of the 3-piece split via the eps-mass floor) in SzemerediRegularityOQ04DefectGain.lean",
+      "pairEnergy_gain_of_isWitnessedSharpStep3 (capstone: witnessed 3-piece step carries the eps^3 pair-energy gain) in SzemerediRegularityOQ04DefectGain.lean"
     ],
     "insights": [
       "The complement pieces A2=A\\A1, B2=B\\B1 of the AFKS sharp 2x2 split are NOT both forced nonempty by the analytic data: the density gap only forbids BOTH being empty (S16). When one corner exhausts its block (A1=A) the honest refinement is the asymmetric 3-piece split {A,B1,B2}; the 4-piece IsWitnessedSharpStep shape (S14 isWitnessedSharpStep_of_split_of_gap) requires an asymmetric-step packaging for that degenerate branch, not a further nonemptiness lemma.",
@@ -132,9 +136,7 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "One-sided defect inequality for the 3-piece step: pairEnergy(A,B1)+pairEnergy(A,B2) >= pairEnergy(A,B) + eps^2*|A||B1|/n^2 via the bias-variance identity (mean preserved: e(A,B)=e(A,B1)+e(A,B2), additivity in SzemerediCoreOQ01); with the B1 mass floor this gives the eps^3 >= eps^4 budget floor.",
-      "Chain construction: reformulate exists_afksTwoLevel_of_dichotomy to BUILD parts internally, casing each step on exists_proper_or_semitrivial_split_of_not_afksFineRegular into IsWitnessedSharpStep (4-piece) or IsWitnessedSharpStep3 (3-piece) via the two packaging lemmas.",
-      "Freshness discharge for the 3-piece branch: A, B1, B2 pairwise distinct and B1, B2 notin R from disjointness/nonemptiness (B1 nonempty from floor when eps,|B|>0; B2 nonempty supplied by the trichotomy)."
+      "Thread both witnessed step shapes (eps^4 symmetric, eps^3 asymmetric) through the outer-loop chain construction (exists_afksTwoLevel_of_dichotomy reformulation) — partition-level increment + freshness bookkeeping."
     ],
     "markdown": "# Knowledge Base: szemeredi-regularity-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n",
     "score": 63
@@ -345,7 +347,29 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediRegularityOQ04SplitProper.lean"
+    },
+    {
+      "path": "Proofs/SzemerediRegularityOQ04StepThree.lean",
+      "filename": "SzemerediRegularityOQ04StepThree.lean",
+      "lineCount": 176,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediRegularityOQ04StepThree.lean"
+    },
+    {
+      "path": "Proofs/SzemerediRegularityOQ04DefectGain.lean",
+      "filename": "SzemerediRegularityOQ04DefectGain.lean",
+      "lineCount": 228,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediRegularityOQ04DefectGain.lean"
     }
   ],
-  "lastUpdate": "2026-07-12"
+  "lastUpdate": "2026-07-22"
 }


### PR DESCRIPTION
## Summary

**S18 for the AFKS two-level dichotomy (`szemeredi-regularity-oq-04`): the one-sided defect energy inequality — the energy content of the asymmetric 3-piece step.** This discharges residual (a) recorded in the header of `SzemerediRegularityOQ04StepThree.lean` (S17, PR #41517).

## Why the existing engine doesn't cover this

The symmetric increment `pairEnergy_split_gain` (Energy.lean) requires a density deviation **between the two halves** of a split (`|d(A₁,B) − d(A₂,B)| ≥ δ`) and both halves nonempty; `energy_excess_A_split` (SzemerediCoreOQ01) likewise. The S17 3-piece witness `IsWitnessedSharpStep3` only controls the deviation of **one half from the parent** (`eps ≤ |d(A,B₁) − d(A,B)|`). The defect form — keep only the deviating cell's variance term `w₁(d₁−μ)²` — is what was missing.

## New file `SzemerediRegularityOQ04DefectGain.lean` (228 lines, 5 theorems)

- `defect_energy_bound` — two-cell weighted-mean defect inequality `(w₁+w₂)μ² + w₁δ² ≤ w₁d₁² + w₂d₂²` with a **multiplicative** mean hypothesis `(w₁+w₂)μ = w₁d₁ + w₂d₂`: no division, and the complementary weight may be **zero** (the parent mean pins the average even when the complement cell is empty).
- `pairEnergy_split_gain_defect` — A-side split: a `δ`-deviation of `d(A₁,B)` from the parent `d(A₁∪A₂,B)` gains `(|A₁||B|/n²)·δ²` of normalized energy; only the deviating piece must be nonempty.
- `pairEnergy_split_gain_defect_right` — B-side transport via `pairEnergy_comm`/`edgeDensity_symm` — exactly the `IsWitnessedSharpStep3` split shape.
- `pairEnergy_step3_gain` — the quotable `eps³` form: with the mass floor `eps·|B| ≤ |B₁|` and the `eps`-gap, `pairEnergy(A,B) + eps³·|A||B|/n² ≤ pairEnergy(A,B₁) + pairEnergy(A,B₂)`. One power of `eps` pays for the floor; since `eps³ ≥ eps⁴`, the symmetric outer budget covers the degenerate dichotomy branch.
- `pairEnergy_gain_of_isWitnessedSharpStep3` — capstone: every witnessed 3-piece step (for `0 < eps`, `0 < m`) carries the `eps³` pair-energy gain at its refined pair.

## Verification

- Docker-verified: `./proofs/scripts/docker-build.sh Proofs.SzemerediRegularityOQ04DefectGain` — **build succeeded, 8588 jobs**, first try, warning-free
- **0 sorries, 0 axiom declarations, no `native_decide`**

## What remains (recorded in state/knowledge)

S17 residual (b): threading both witnessed step shapes (symmetric `eps⁴`, asymmetric `eps³`) through the outer-loop chain construction (`exists_afksTwoLevel_of_dichotomy` reformulation) — deep partition-level assembly, no elementary pair-level increment remains.

## Metadata

- `research/problems/szemeredi-regularity-oq-04/{state.md,knowledge.md}`: S18 session records + reusable recipes
- `src/data/research/problems/szemeredi-regularity-oq-04.json`: leanFiles (+ StepThree entry that was missing), focus/nextAction/knowledge updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
