### PR TITLE
Fix: erdos-404 stale lineCount 323→331

### DIFF
--- a/src/data/proofs/erdos-404/meta.json
+++ b/src/data/proofs/erdos-404/meta.json
@@ -67,7 +67,7 @@
       "Legendre's formula for v_p(n!)",
       "Filter.Tendsto and convergence in Lean/Mathlib"
     ],
-    "lineCount": 323,
+    "lineCount": 331,
     "assumptions": "1 axiom: lin_bound_meaning (2^255 never divides such sums). lin_bound was derived from lin_bound_meaning. 0 sorries.",
     "theoremCount": 10,
     "definitionCount": 9
@@ -213,7 +213,7 @@
       "Filter"
     ],
     "namespace": "Erdos404",
-    "lineCount": 323,
+    "lineCount": 331,
     "axiomCount": 1,
     "theoremCount": 10,
     "definitionCount": 9,


### PR DESCRIPTION
## Problem

The auditor flagged `erdos-404` (audit-tracker `result: issues-found`, cycle-20 batch). Independent verification against source found one genuine discrepancy: `meta.json` records `lineCount: 323` in two places (`meta.meta.lineCount` and `leanFile.lineCount`), but `proofs/Proofs/Erdos404Problem.lean` is actually **331 lines**.

The drift was introduced by PR #41662 (today), which restated the conjecture via `BddAbove` and corrected prose, growing the file without updating the line counts.

## Evidence

```
$ wc -l proofs/Proofs/Erdos404Problem.lean
331
```

Before: `"lineCount": 323` (×2)  →  After: `"lineCount": 331` (×2)

All other counts verified accurate against comment-stripped source and left unchanged:
- theoremCount 10 ✓ (8 public + 2 private)
- definitionCount 9 ✓
- axiomCount 1 ✓ (`lin_bound_meaning`)
- sorries 0 ✓
- status `axiomatized` / badge `axiom` ✓ (native_decide only in illustrative `example` blocks; not a verified substantive result)

## Scope

Metadata-only, one-field fix. Section `endLine` ranges for the last three sections also drifted ~8 lines from the same growth, but section re-anchoring is enricher territory and out of scope for this minimal integrity repair.