### PR TITLE
Research: erdos-64-wip-01 — Dirac-type rung: min degree d forces cycle length ≥ d+1 (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos64Problem.lean
+++ b/proofs/Proofs/Erdos64Problem.lean
@@ -560,6 +560,131 @@ theorem hasMinDegree_three_exists_even_containsCycleLength
   obtain ⟨m, hm⟩ := heven
   omega
 
+/- ## Dirac-Type Lower Bound on Cycle Length
+
+The same longest-path engine gives the classical quantitative rung: minimum
+degree `d ≥ 2` forces a cycle of length at least `d + 1`.  All `≥ d` neighbours
+of the start vertex `v₀` of a maximum-length path are trapped at distinct
+POSITIVE indices along the path, so the largest such index is at least `d`
+(`d` distinct positive integers cannot all be smaller than `d`); closing the
+prefix at that index through the edge back to `v₀` is a cycle of length `≥ d+1`.
+
+For Problem 64 this is the quantitative companion to the parity layer above:
+it shows how minimum degree pushes the guaranteed cycle length up linearly —
+but "some length `≥ d + 1`" is far from "length exactly `2^k`", which is the
+open core.
+-/
+
+/-- **Dirac-type rung: minimum degree `d ≥ 2` forces a cycle of length `≥ d + 1`.**
+The classical longest-path argument: every neighbour of the start of a
+maximum-length path sits at a distinct positive index on the path, so the
+largest neighbour index is at least `d`; closing the prefix there through the
+edge back to the start yields a cycle of length at least `d + 1`. -/
+theorem hasMinDegree_exists_cycle_length_ge
+    {W : Type*} [Fintype W] [DecidableEq W] [Nonempty W]
+    (G : SimpleGraph W) [DecidableRel G.Adj] {d : ℕ} (hd : 2 ≤ d)
+    (hdeg : HasMinDegree G d) :
+    ∃ (v : W) (c : G.Walk v v), c.IsCycle ∧ d + 1 ≤ c.length := by
+  classical
+  -- a path of maximum length (as in `hasMinDegree_three_exists_even_cycle`)
+  have hne : ({n : ℕ | ∃ (a : W) (b : W) (q : G.Walk a b), q.IsPath ∧ q.length = n}).Nonempty :=
+    ⟨0, Classical.arbitrary W, Classical.arbitrary W, Walk.nil, Walk.IsPath.nil, rfl⟩
+  have hbdd : BddAbove {n : ℕ | ∃ (a : W) (b : W) (q : G.Walk a b), q.IsPath ∧ q.length = n} := by
+    refine ⟨Fintype.card W, ?_⟩
+    rintro n ⟨a, b, q, hq, rfl⟩
+    exact hq.length_lt.le
+  obtain ⟨v₀, u, p, hp, hplen⟩ := Nat.sSup_mem hne hbdd
+  have hmax : ∀ (a b : W) (q : G.Walk a b), q.IsPath → q.length ≤ p.length := by
+    intro a b q hq
+    rw [hplen]
+    exact le_csSup hbdd ⟨a, b, q, hq, rfl⟩
+  -- maximality traps every neighbour of `v₀` on `p`
+  have hnbr : ∀ w : W, G.Adj v₀ w → w ∈ p.support := by
+    intro w hw
+    by_contra hws
+    have hcons : (Walk.cons hw.symm p).IsPath := (Walk.cons_isPath_iff _ _).mpr ⟨hp, hws⟩
+    have := hmax _ _ _ hcons
+    rw [Walk.length_cons] at this
+    omega
+  set idx : W → ℕ := fun w => if hw : w ∈ p.support then (p.takeUntil w hw).length else 0
+    with hidx
+  have hidx_get : ∀ w (hw : w ∈ p.support), p.getVert (idx w) = w := by
+    intro w hw
+    simp only [hidx, dif_pos hw]
+    exact Walk.getVert_length_takeUntil hw
+  set T : Finset ℕ := (G.neighborFinset v₀).image idx with hT
+  have hTcard : d ≤ T.card := by
+    rw [hT, Finset.card_image_of_injOn]
+    · exact hdeg v₀
+    · intro w₁ hw₁ w₂ hw₂ hww
+      have h₁ : G.Adj v₀ w₁ := (G.mem_neighborFinset v₀ w₁).mp (Finset.mem_coe.mp hw₁)
+      have h₂ : G.Adj v₀ w₂ := (G.mem_neighborFinset v₀ w₂).mp (Finset.mem_coe.mp hw₂)
+      calc w₁ = p.getVert (idx w₁) := (hidx_get w₁ (hnbr _ h₁)).symm
+        _ = p.getVert (idx w₂) := by rw [hww]
+        _ = w₂ := hidx_get w₂ (hnbr _ h₂)
+  have hpos : ∀ n ∈ T, 1 ≤ n := by
+    intro n hn
+    rw [hT] at hn
+    obtain ⟨w, hw, rfl⟩ := Finset.mem_image.mp hn
+    have hadj : G.Adj v₀ w := (G.mem_neighborFinset v₀ w).mp hw
+    rcases Nat.eq_zero_or_pos (idx w) with h0 | h1
+    · exfalso
+      have hgw := hidx_get w (hnbr _ hadj)
+      rw [h0, Walk.getVert_zero] at hgw
+      exact hadj.ne hgw
+    · exact h1
+  -- the largest neighbour index `b` is at least `d`:
+  -- `T` packs `≥ d` distinct integers into `[1, b]`, so `d ≤ |Icc 1 b| = b`
+  have hTne : T.Nonempty := Finset.card_pos.mp (by omega)
+  set b := T.max' hTne with hbdef
+  have hbT : b ∈ T := T.max'_mem hTne
+  have hsub : T ⊆ Finset.Icc 1 b := by
+    intro n hn
+    exact Finset.mem_Icc.mpr ⟨hpos n hn, T.le_max' n hn⟩
+  have hdb : d ≤ b := by
+    have hcard := Finset.card_le_card hsub
+    rw [Nat.card_Icc] at hcard
+    omega
+  -- the neighbour `y` sitting at index `b`
+  have hbT2 : b ∈ (G.neighborFinset v₀).image idx := by rw [← hT]; exact hbT
+  obtain ⟨y, hyN, hyb⟩ := Finset.mem_image.mp hbT2
+  have hay : G.Adj v₀ y := (G.mem_neighborFinset v₀ y).mp hyN
+  have hys : y ∈ p.support := hnbr y hay
+  have hyb' : (p.takeUntil y hys).length = b := by
+    rw [← hyb]; simp only [hidx, dif_pos hys]
+  -- close the prefix at `y` through the edge `y — v₀`
+  refine ⟨v₀, Walk.cons hay (p.takeUntil y hys).reverse, ?_, ?_⟩
+  · rw [Walk.cons_isCycle_iff]
+    refine ⟨(hp.takeUntil hys).reverse, ?_⟩
+    intro hmem
+    rw [Walk.edges_reverse, List.mem_reverse] at hmem
+    -- an edge of a path through its start must be the first edge …
+    have hsnd : y = (p.takeUntil y hys).snd := (hp.takeUntil hys).eq_snd_of_mem_edges hmem
+    -- … but `y` is the endpoint of the prefix, at index `b ≥ 2`
+    have h1 : (p.takeUntil y hys).getVert 1 =
+        (p.takeUntil y hys).getVert (p.takeUntil y hys).length := by
+      rw [Walk.getVert_length]
+      exact hsnd.symm
+    have := (hp.takeUntil hys).getVert_injOn
+      (by simp only [Set.mem_setOf_eq]; omega)
+      (by simp only [Set.mem_setOf_eq]; omega) h1
+    omega
+  · rw [Walk.length_cons, Walk.length_reverse, hyb']
+    omega
+
+/-- Restatement in the `ContainsCycleLength` predicate: minimum degree `d ≥ 2`
+yields a cycle length `k ≥ d + 1`.  Combined with the parity layer, min-degree-`3`
+graphs have an even cycle of length `≥ 4` and some cycle of length `≥ 4`; the
+open core of Problem 64 is whether a length can be taken to be an exact power
+of two. -/
+theorem hasMinDegree_containsCycleLength_ge
+    {W : Type*} [Fintype W] [DecidableEq W] [Nonempty W]
+    (G : SimpleGraph W) [DecidableRel G.Adj] {d : ℕ} (hd : 2 ≤ d)
+    (hdeg : HasMinDegree G d) :
+    ∃ k : ℕ, d + 1 ≤ k ∧ ContainsCycleLength G k := by
+  obtain ⟨v, c, hc, hlen⟩ := hasMinDegree_exists_cycle_length_ge G hd hdeg
+  exact ⟨c.length, hlen, isCycle_containsCycleLength G c hc⟩
+
 /- ## Known Cycle Results -/
 
 /- 

--- a/research/problems/erdos-64-wip-01/knowledge.md
+++ b/research/problems/erdos-64-wip-01/knowledge.md
@@ -151,3 +151,31 @@ at index `a`, at index `b`, and around the segment `[a,b]` are three cycles of l
 ### Next
 - Dirac-type rung: min degree d ⇒ cycle length ≥ d+1 — same maximal-path engine, now in-file.
 - The 2^k core stays blocked (Liu–Montgomery scale).
+
+## Session 2026-07-22b (researcher-1) — Dirac-type rung: min degree d ⇒ cycle length ≥ d+1
+
+**Mode**: cash in the recorded "Next" item (same maximal-path engine, now in-file).
+**Outcome**: 2 theorems, axiom-free, host-verified `lake env lean` exit 0 first try,
+zero warnings. File 607→732 lines, theorems 12→14 (public).
+
+- `hasMinDegree_exists_cycle_length_ge` — min degree `d ≥ 2` forces
+  `∃ v (c : G.Walk v v), c.IsCycle ∧ d + 1 ≤ c.length`. Engine identical to the
+  even-cycle session: maximal path from `v₀`, all neighbours trapped at distinct
+  positive `takeUntil`-length indices. NEW piece: the largest index `b = T.max'`
+  satisfies `d ≤ b` because `T ⊆ Finset.Icc 1 b` (`hpos` + `le_max'`) and
+  `Finset.card_le_card` + `Nat.card_Icc` give `d ≤ |T| ≤ b`. Close the prefix at
+  index `b` (needs only `2 ≤ b`, from `d ≥ 2`) — cycle length `b + 1 ≥ d + 1`.
+- `hasMinDegree_containsCycleLength_ge` — `ContainsCycleLength` restatement via
+  `isCycle_containsCycleLength`.
+
+### Lean notes
+- The pigeonhole "d distinct positive integers have max ≥ d" is exactly
+  `T ⊆ Icc 1 max'` + `Nat.card_Icc` (`|Icc 1 b| = b`), then omega. No induction.
+- Single-index cycle closure needs NO segment machinery (no dropUntil) — the
+  `hclose` sub-proof of the even-cycle theorem inlines cleanly with `y` at `max'`.
+
+### Next
+- Elementary layer now FULLY saturated: existence (min-deg 2), length-predicate
+  bridge, parity (even cycle, min-deg 3), Dirac rung (length ≥ d+1). Every
+  remaining gap is the deep 2^k-length core (Liu–Montgomery scale) — girth/BFS
+  layering or structured expansion, no elementary path. STAND DOWN.

--- a/src/data/proofs/erdos-64/meta.json
+++ b/src/data/proofs/erdos-64/meta.json
@@ -294,10 +294,10 @@
       "Finset"
     ],
     "namespace": "Erdos64",
-    "lineCount": 268,
+    "lineCount": 732,
     "axiomCount": 0,
-    "theoremCount": 6,
-    "definitionCount": 12,
+    "theoremCount": 14,
+    "definitionCount": 11,
     "path": "Proofs/Erdos64Problem.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/erdos-64-wip-01.json
+++ b/src/data/research/problems/erdos-64-wip-01.json
@@ -20,8 +20,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-09T17:33:20-07:00",
-    "iteration": 2,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "iteration": 3,
+    "focus": "Dirac rung DONE (2026-07-22b): hasMinDegree_exists_cycle_length_ge — min degree d>=2 forces a cycle of length >= d+1 (longest-path engine; largest neighbour index >= d via T subset Icc 1 max + card_Icc pigeonhole). With existence, length-predicate bridge, even-cycle parity and this quantitative rung, the ELEMENTARY layer is fully saturated.",
     "blockers": [
       {
         "route": "power-of-two cycle LENGTH: every finite graph with min-degree ≥ 3 contains a cycle of length 2^k",
@@ -29,7 +29,7 @@
         "blockedAt": "2026-07-21"
       }
     ],
-    "nextAction": "Open power-of-2 cycle length remains the mission; base cycle-existence infrastructure is complete for all finite graphs.",
+    "nextAction": "STAND DOWN at the elementary layer. Only the deep 2^k-length core remains (Liu-Montgomery scale). Do not re-claim without a genuinely new mechanism for power-of-two cycle lengths.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -37,7 +37,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: even-cycle parity layer proved (2026-07-22). hasMinDegree_three_exists_even_cycle + ContainsCycleLength restatement (even k>=4), axiom-free, via classical longest-path parity argument (three cycles a+1, b+1, b-a+2). This is the parity part of the necessary condition of Problem 64 (2^k-cycles are even), strictly between cycle existence (done) and the open power-of-two core (blocked, Liu-Montgomery scale). Maximal-path engine (Nat.sSup_mem + IsPath.length_lt) now available in-file.",
+    "progressSummary": "PROGRESS: even-cycle parity layer proved (2026-07-22). hasMinDegree_three_exists_even_cycle + ContainsCycleLength restatement (even k>=4), axiom-free, via classical longest-path parity argument (three cycles a+1, b+1, b-a+2). This is the parity part of the necessary condition of Problem 64 (2^k-cycles are even), strictly between cycle existence (done) and the open power-of-two core (blocked, Liu-Montgomery scale). Maximal-path engine (Nat.sSup_mem + IsPath.length_lt) now available in-file. 2026-07-22b: Dirac-type rung added — min degree d>=2 forces a cycle of length >= d+1 (hasMinDegree_exists_cycle_length_ge), completing the elementary layer (existence + bridge + parity + quantitative length).",
     "builtItems": [
       "connected_hasMinDegree_two_not_isAcyclic (Erdos64Problem.lean): nontrivial connected graph, HasMinDegree 2 => ¬IsAcyclic. Axiom-free.",
       "connected_hasMinDegree_two_exists_cycle (Erdos64Problem.lean): same hyp => ∃ v (c : Walk v v), c.IsCycle. Axiom-free.",
@@ -46,7 +46,9 @@
       "isCycle_containsCycleLength (Erdos64Problem.lean) — Walk.IsCycle c => ContainsCycleLength G c.length, axiom-free",
       "hasMinDegree_two_containsCycleLength / hasMinDegree_three_containsCycleLength (Erdos64Problem.lean) — min-degree cycle-existence in the length-indexed predicate, axiom-free",
       "hasMinDegree_three_exists_even_cycle in Erdos64Problem.lean: min-degree >=3 nonempty finite graph has an even-length Walk.IsCycle (0-axiom)",
-      "hasMinDegree_three_exists_even_containsCycleLength in Erdos64Problem.lean: even length k >= 4 in the ContainsCycleLength predicate"
+      "hasMinDegree_three_exists_even_containsCycleLength in Erdos64Problem.lean: even length k >= 4 in the ContainsCycleLength predicate",
+      "hasMinDegree_exists_cycle_length_ge (Dirac-type: min-deg d>=2 => cycle length >= d+1) in Erdos64Problem.lean",
+      "hasMinDegree_containsCycleLength_ge (ContainsCycleLength restatement) in Erdos64Problem.lean"
     ],
     "insights": [
       "A finite nontrivial TREE has a leaf (degree-1 vertex): Mathlib SimpleGraph.IsTree.minDegree_eq_one_of_nontrivial. Hence a connected graph with min degree >= 2 cannot be a tree, so cannot be acyclic — the elementary base fact under Erdos #64.",
@@ -88,7 +90,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.782Z",
-  "lastUpdate": "2026-07-10T00:41:25.929Z",
+  "lastUpdate": "2026-07-22",
   "significance": 8,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

**The Dirac-type quantitative rung for Erdős #64 (`erdos-64-wip-01`): minimum degree `d ≥ 2` forces a cycle of length ≥ `d + 1`.** This cashes in the "Next" item recorded by the even-cycle session (PR #41609): the longest-path engine is already in-file, and the quantitative rung needs only one new pigeonhole ingredient.

## Mathematical content (2 new theorems, axiom-free)

- `hasMinDegree_exists_cycle_length_ge` — every nonempty finite graph with minimum degree `d ≥ 2` contains an explicit `Walk.IsCycle` witness of length ≥ `d + 1`. Classical longest-path argument: all ≥ d neighbours of the start of a maximum-length path are trapped at distinct **positive** `takeUntil`-length indices, so the largest index `b` satisfies `d ≤ b` — `d` distinct positive integers cannot all be smaller than `d` (formalized as `T ⊆ Finset.Icc 1 b` plus `Nat.card_Icc`, no induction). Closing the prefix at index `b` through the edge back to the start gives a cycle of length `b + 1 ≥ d + 1`.
- `hasMinDegree_containsCycleLength_ge` — restatement in the file's `ContainsCycleLength` predicate (the one `erdos_64_conjecture` uses).

For Problem 64 this is the quantitative companion to the parity layer: min-degree-3 graphs have an even cycle (PR #41609) and a cycle of length ≥ 4; the open core remains whether some length can be an exact power of two. The elementary layer (existence + length-predicate bridge + parity + Dirac rung) is now fully saturated — everything left is the deep Liu–Montgomery-scale 2^k core.

## Verification

- Host-verified: `lake env lean Proofs/Erdos64Problem.lean` exit 0, **first try, zero warnings** (v4.31.0)
- **0 sorries, 0 axiom declarations, no `native_decide`**
- File: 607 → 732 lines

## Metadata

- `research/problems/erdos-64-wip-01/knowledge.md`: session record + pigeonhole recipe
- `src/data/research/problems/erdos-64-wip-01.json`: focus/nextAction — elementary layer saturated, stand down
- `src/data/proofs/erdos-64/meta.json`: refreshed stale `leanFile` counts (6→14 theorems, 268→732 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
