### PR TITLE
Enrich fourier-series-oq-02-oq-03-wip-01: cover header docstring (lines 1-73)

### DIFF
--- a/src/data/proofs/fourier-series-oq-02-oq-03-wip-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-03-wip-01/meta.json
@@ -47,6 +47,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header: Sharpness of the Half-Period Constant 1/2",
+      "startLine": 1,
+      "endLine": 73,
+      "summary": "States the goal: the parent FourierSeriesOQ02OQ03 derives ‖ĉ_n(f)‖ ≤ M/2 from the half-period translation method and asserts 1/2 is optimal but never exhibits a case of equality. This file isolates the constant and proves it is exactly the least possible in the half-period method, with the pure mode `fourier n` as the extremal witness attaining the bound. Explains the self-containment workaround (the parent's sibling import FourierSeriesOQ02OQ04 has unrelated build drift, so this file imports only the pure-Mathlib FourierSeriesOQ02Incomplete01 and re-derives the needed half-period infrastructure) and the honest scope: this settles sharpness for the half-period method only, not the full Hölder-class sharp constant, whose extremal sawtooth witnesses remain open.",
+      "mathContext": "$\\|\\hat c_n(f)\\| \\le M/2$ is sharp: the pure mode `fourier n` has uniform half-period difference $2$ and attains $\\|\\hat c_n(\\mathrm{fourier}\\,n)\\| = 1 = 2/2$, and no constant $k < 1/2$ can replace it."
+    },
+    {
       "id": "part-0-infrastructure",
       "title": "Part 0 — Half-Period Infrastructure",
       "startLine": 74,


### PR DESCRIPTION
Adds a header section for the module docstring — previously uncovered by any section, since `sections` started at line 74 (the `part-0-infrastructure` section), leaving the sharpness goal and self-containment rationale invisible in the gallery.

- New `header` section covers lines 1-73: the parent's unproven optimality claim for the `1/2` half-period constant, the pure-mode extremal witness this file supplies, the build-drift workaround for self-containment, and the honest scope (half-period method sharpness only, not the full Hölder-class constant).
- No other fields touched; file stays well under the 60 KB size cap (~10.9 KB).

Part of the header-docstring undercoverage sweep (pool of ~1387 gallery entries with `sections[0].startLine >= 15`).
