### PR TITLE
Audit: erdos-961 fix stale sorry-count prose (issues-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17676,9 +17676,9 @@
     },
     "erdos-961": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:02:34Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-22T19:54:47Z",
+      "result": "issues-fixed"
     },
     "erdos-962": {
       "agentId": "auditor-agent-20260709",

--- a/src/data/proofs/erdos-961/meta.json
+++ b/src/data/proofs/erdos-961/meta.json
@@ -171,7 +171,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #961 on the distribution of smooth numbers in consecutive intervals. It includes proved equivalences between custom smooth number definitions and Mathlib's Nat.smoothNumbers, the proved Sylvester–Schur bound f(k) ≤ k, axiomatized stronger bounds (Erdős 1955, Jutila–Ramachandra–Shorey), the open polylogarithmic conjecture, and the connection to Problem #683. 3 sorries remain (f_sublinear, polylog_conjecture_open, f_le_smooth_gap_succ).",
+    "summary": "This formalization captures Erdős Problem #961 on the distribution of smooth numbers in consecutive intervals. It includes proved equivalences between custom smooth number definitions and Mathlib's Nat.smoothNumbers, the proved Sylvester–Schur bound f(k) ≤ k, axiomatized stronger bounds (Erdős 1955, Jutila–Ramachandra–Shorey), the open polylogarithmic conjecture, and the connection to Problem #683. 2 sorries remain (f_sublinear, f_le_smooth_gap_succ).",
     "implications": "1. **Analytic Number Theory**: Resolving the polylogarithmic conjecture would require fundamentally new understanding of smooth number distribution in short intervals\n\n**2. Cryptographic Applications**: Smooth number distribution directly affects the runtime analysis of factoring algorithms (quadratic sieve, number field sieve)\n\n3. **Sieve Theory**: The known bounds use sieve methods; the conjecture likely requires techniques beyond current sieve technology\n\n4. **Connection to #683**: Progress on smooth number gaps (Problem #683) would directly improve bounds on f(k).",
     "openQuestions": [
       "Is f(k) ≪ (log k)^C for some constant C?",


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-961

**Proof**: erdos-961 (Smooth Numbers in Consecutive Intervals)

**Problem**: `conclusion.summary` claimed "3 sorries remain (f_sublinear, polylog_conjecture_open, f_le_smooth_gap_succ)" but the Lean file (`Proofs/Erdos961Problem.lean`) has only 2 `sorry`s (`f_sublinear`, `f_le_smooth_gap_succ`). `polylog_conjecture_open` is not a declaration in the file at all — `polylog_conjecture` is a bare `Prop` def with no accompanying theorem (correctly left unaxiomatized per the file's own docstring, since its truth value is unknown).

## Evidence

- **meta.json claimed**: "3 sorries remain (f_sublinear, polylog_conjecture_open, f_le_smooth_gap_succ)"
- **Lean file shows**: exactly 2 sorries — `f_sublinear` (line 148) and `f_le_smooth_gap_succ` (line 207). `polylog_conjecture_open` does not exist anywhere in the file.
- The rest of meta.json is accurate: `sorries: 2` (top-level, `meta`, and `leanFile` blocks all agree), `axiomCount: 3` matches the 3 real axioms (`sylvester_schur`, `erdos_1955_bound`, `jutila_ramachandra_shorey_bound`), all 11 `originalContributions` map to real declarations, badge `axiom`/status `axiomatized` correctly reflect Tier C classification. No True-stubs, no native_decide.

## Fix

Corrected `conclusion.summary` to say "2 sorries remain (f_sublinear, f_le_smooth_gap_succ)", removing the phantom `polylog_conjecture_open` reference. Tracker updated to reflect `issues-fixed`.

---
Discovered during gallery integrity audit (reserve-mode re-verification).