### PR TITLE
Research: erdos-507-wip-01 — heilbronn 4 sandwiched in [1, 3/2] (inscribed square, 0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos507WIP01.lean
+++ b/proofs/Proofs/Erdos507WIP01.lean
@@ -617,9 +617,9 @@ theorem heilbronn_four_ge : (1 : ℝ) ≤ heilbronn 4 := by
   refine le_csSup (heilbronn_defining_bddAbove 4 (by norm_num)) ?_
   refine ⟨{((1 : ℝ), (0 : ℝ)), (0, 1), (-1, 0), (0, -1)}, ?_, ?_, ?_⟩
   · -- the four vertices are distinct, so the configuration has cardinality `4`
-    rw [Finset.card_insert_of_not_mem (by norm_num [Prod.ext_iff]),
-      Finset.card_insert_of_not_mem (by norm_num [Prod.ext_iff]),
-      Finset.card_insert_of_not_mem (by norm_num [Prod.ext_iff]),
+    rw [Finset.card_insert_of_notMem (by norm_num [Prod.ext_iff]),
+      Finset.card_insert_of_notMem (by norm_num [Prod.ext_iff]),
+      Finset.card_insert_of_notMem (by norm_num [Prod.ext_iff]),
       Finset.card_singleton]
   · -- each vertex lies on the boundary of the closed unit disk
     intro p hp

--- a/proofs/Proofs/Erdos507WIP01.lean
+++ b/proofs/Proofs/Erdos507WIP01.lean
@@ -595,6 +595,59 @@ theorem heilbronn_three_mem_Icc :
     heilbronn 3 ∈ Set.Icc (3 * Real.sqrt 3 / 4) (3 / 2) :=
   ⟨heilbronn_three_ge, heilbronn_le_three_halves 3 (by norm_num)⟩
 
+/-! ## A concrete lower bound at `n = 4`: the inscribed square
+
+The `n = 3` ladder above pins `heilbronn 3` inside `[3√3/4, 3/2]`.  The next rung
+is a genuine *four-point* witness: the square inscribed in the unit circle.  Its
+four vertices `(1,0), (0,1), (−1,0), (0,−1)` produce exactly four unordered
+triples, and each spans a right triangle of area exactly `1` (each triple omits
+one vertex; the remaining three form half of the inscribed square, which has
+area `2`).  Hence `1` is admissible for the `sSup` defining `heilbronn 4`, giving
+the first nontrivial lower bound beyond `n = 3` — and, with the Lagrange upper
+bound `heilbronn n ≤ 3/2`, a second sandwich `heilbronn 4 ∈ [1, 3/2]` of width
+`1/2`. -/
+
+/-- **`heilbronn 4 ≥ 1`.**  The square inscribed in the unit circle,
+`(1,0), (0,1), (−1,0), (0,−1)`, is a four-point unit-disk configuration in which
+every ordering of every distinct vertex triple has `triangleArea` exactly `1`,
+so `1` lies in the defining `sSup` set of `heilbronn 4` (`le_csSup`, using
+`heilbronn_defining_bddAbove` for boundedness). -/
+theorem heilbronn_four_ge : (1 : ℝ) ≤ heilbronn 4 := by
+  unfold heilbronn
+  refine le_csSup (heilbronn_defining_bddAbove 4 (by norm_num)) ?_
+  refine ⟨{((1 : ℝ), (0 : ℝ)), (0, 1), (-1, 0), (0, -1)}, ?_, ?_, ?_⟩
+  · -- the four vertices are distinct, so the configuration has cardinality `4`
+    rw [Finset.card_insert_of_not_mem (by norm_num [Prod.ext_iff]),
+      Finset.card_insert_of_not_mem (by norm_num [Prod.ext_iff]),
+      Finset.card_insert_of_not_mem (by norm_num [Prod.ext_iff]),
+      Finset.card_singleton]
+  · -- each vertex lies on the boundary of the closed unit disk
+    intro p hp
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hp
+    rcases hp with rfl | rfl | rfl | rfl <;> norm_num
+  · -- every ordered distinct triple has area exactly `1 ≥ 1`
+    intro p hp q hq r hr hpq hqr hpr
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hp hq hr
+    rcases hp with rfl | rfl | rfl | rfl <;> rcases hq with rfl | rfl | rfl | rfl <;>
+        rcases hr with rfl | rfl | rfl | rfl <;>
+      first
+        | exact absurd rfl hpq
+        | exact absurd rfl hqr
+        | exact absurd rfl hpr
+        | (show (1 : ℝ) ≤ triangleArea _ _ _; unfold triangleArea; norm_num)
+
+/-- **`heilbronn 4` is strictly positive** — immediate from `heilbronn_four_ge`. -/
+theorem heilbronn_four_pos : 0 < heilbronn 4 :=
+  lt_of_lt_of_le (by norm_num) heilbronn_four_ge
+
+/-- **Sandwich at `n = 4`:** `heilbronn 4 ∈ [1, 3/2]`.  Lower bound from the
+inscribed square (`heilbronn_four_ge`); upper bound from the Lagrange bound
+`heilbronn n ≤ 3/2` (`heilbronn_le_three_halves`).  Note the lower bound is *not*
+claimed sharp: whether the inscribed square is the optimal four-point
+configuration in the disk is part of the open quantitative problem. -/
+theorem heilbronn_four_mem_Icc : heilbronn 4 ∈ Set.Icc (1 : ℝ) (3 / 2) :=
+  ⟨heilbronn_four_ge, heilbronn_le_three_halves 4 (by norm_num)⟩
+
 /-! ## Quantitative decay: `heilbronn n = O(1/n)`
 
 All the upper bounds above (`heilbronn n ≤ 3`, `≤ 3/2`) are *constant* in `n` —

--- a/research/problems/erdos-507-wip-01/knowledge.md
+++ b/research/problems/erdos-507-wip-01/knowledge.md
@@ -280,3 +280,14 @@ bound `heilbronn 3 ≥ 1/2`.
   obviously session-sized; the sharp bound follows from the inscribed-equilateral being the
   area-maximizer, which needs a real argument.
 - Deep `α(n)` exponent bounds (KPS lower, CPZ upper) remain open (literature: `7/6 ≤ β ≤ 2`).
+
+## Session 2026-07-22 (researcher-1): heilbronn 4 sandwich
+
+`heilbronn_four_ge` (≥ 1, inscribed square (1,0),(0,1),(−1,0),(0,−1) — each triple
+is half the inscribed square, area exactly 1), `heilbronn_four_pos`,
+`heilbronn_four_mem_Icc` (∈ [1, 3/2] with the Lagrange upper bound). Mirrors the
+`heilbronn_three_ge_half` witness pattern: `le_csSup` + `heilbronn_defining_bddAbove`,
+card via `Finset.card_insert_of_not_mem` chain (`norm_num [Prod.ext_iff]`), 64-way
+`rcases <;> first | absurd | norm_num [triangleArea]` triple bash. Sharpness of the
+square NOT claimed. Next elementary rung would be n=5 (regular pentagon — irrational
+cos(2π/5) areas, messier norm_num; feasible but heavier).

--- a/src/data/research/problems/erdos-507-wip-01.json
+++ b/src/data/research/problems/erdos-507-wip-01.json
@@ -46,7 +46,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Foundational Heilbronn toolkit + quantitative decay. n=3 SANDWICHED 3√3/4 ≤ heilbronn 3 ≤ 3/2. NEW (2026-07-21): heilbronn n ≤ 4/m for 2(m+1)<n (pigeonhole over vertical strips, heilbronn_le_four_div) ⇒ heilbronn n → 0 (heilbronn_tendsto_zero) — first bound showing genuine DECAY (all prior bounds constant in n); formalizes the elementary α(n)≪1/n remark. Open: sharp heilbronn 3 ≤ 3√3/4, and the deep α(n) exponent bounds (KPS/CPZ, 7/6≤β≤2).",
+    "progressSummary": "PROGRESS: n=3 sandwiched [3sqrt3/4, 3/2] (merged) and n=4 now sandwiched [1, 3/2] (2026-07-22, inscribed square). Elementary witness-ladder pattern (explicit config + le_csSup + case-bash on triples) works rung by rung; remaining deep work: sharp upper at n=3 (Jensen on central angles, ~500+ lines) and asymptotic exponent bounds.",
     "builtItems": [
       "triangleArea_nonneg in Erdos507WIP01.lean",
       "triangleArea_swap_left / triangleArea_swap_right / triangleArea_cyclic (permutation symmetry)",
@@ -76,7 +76,9 @@
       "triangleArea_le_spread in Erdos507WIP01.lean: three points within a w×h box span area ≤ w·h (determinant identity + abs_mul bounds), 0-axiom",
       "strip_spread (private) in Erdos507WIP01.lean: equal strip index ⌊(x+1)·m/2⌋₊ ⇒ |Δx|·m ≤ 2, 0-axiom",
       "heilbronn_le_four_div in Erdos507WIP01.lean: heilbronn n ≤ 4/m for 1≤m, 2(m+1)<n (Finset pigeonhole), 0-axiom",
-      "heilbronn_tendsto_zero in Erdos507WIP01.lean: Tendsto heilbronn atTop (𝓝 0), 0-axiom"
+      "heilbronn_tendsto_zero in Erdos507WIP01.lean: Tendsto heilbronn atTop (𝓝 0), 0-axiom",
+      "heilbronn_four_ge in Erdos507WIP01.lean: heilbronn 4 >= 1 (inscribed square, 0-axiom)",
+      "heilbronn_four_pos, heilbronn_four_mem_Icc: positivity + sandwich heilbronn 4 in [1, 3/2]"
     ],
     "insights": [
       "The signed shoelace area p₁(q₂−r₂)+q₁(r₂−p₂)+r₁(p₂−q₂) is alternating: transpositions negate it (area invariant via abs_neg), cyclic rotations fix it — giving full S₃ symmetry after the absolute value.",
@@ -98,7 +100,8 @@
       "|a×b| ≤ 1 for unit-disk a,b via Lagrange: (a×b)² = |a|²|b|² − ⟨a,b⟩² ≤ |a|²|b|² ≤ 1; nlinarith needs sq_nonneg ⟨a,b⟩ plus the product bound |a|²|b|²≤1. This gives |E| ≤ 3 (abs_add_le twice + gcongr), hence area ≤ 3/2 — strictly better than the summand-wise ≤3.",
       "The upper bound 3/2 is NOT sharp (true max |E|=3√3/2≈2.598, area 3√3/4≈1.299): the three determinants cannot be simultaneously maximal. Closing to the sharp 3√3/4 needs the central-angle constraint (angles subtended at O sum to 2π when O is interior) + Jensen on sin over [0,π] + an O-exterior case split — the genuine open optimization.",
       "Quantitative decay heilbronn n = O(1/n): pigeonhole over ⌊(x+1)·m/2⌋₊ vertical strips gives heilbronn n ≤ 4/m whenever 2(m+1)<n (heilbronn_le_four_div), hence heilbronn n → 0 (heilbronn_tendsto_zero). First non-constant upper bound; formalizes the α(n)≪1/n pigeonhole remark of the problem statement.",
-      "Reusable recipe: the determinant form E=(p₁−r₁)(q₂−r₂)−(q₁−r₁)(p₂−r₂) (anchored at a vertex) is the right handle for LOCAL box/strip area bounds — spread hypotheses |Δx|≤w,|Δy|≤h collapse to two |·|≤w·h products (triangleArea_le_spread: area ≤ w·h)."
+      "Reusable recipe: the determinant form E=(p₁−r₁)(q₂−r₂)−(q₁−r₁)(p₂−r₂) (anchored at a vertex) is the right handle for LOCAL box/strip area bounds — spread hypotheses |Δx|≤w,|Δy|≤h collapse to two |·|≤w·h products (triangleArea_le_spread: area ≤ w·h).",
+      "n=4 rung: the inscribed square (1,0),(0,1),(-1,0),(0,-1) has all four vertex triples spanning right triangles of area exactly 1, giving heilbronn 4 >= 1 by the same le_csSup witness pattern as heilbronn_three_ge_half. With the Lagrange upper bound this sandwiches heilbronn 4 in [1, 3/2] - a second width-1/2 window beyond n=3. Sharpness of the square among 4-point disk configs is NOT claimed (open quantitative question)."
     ],
     "mathlibGaps": [
       "No off-the-shelf lemma reduces the nested membership biInf of minTriangleArea to a single ciInf_le; the junk-value semantics of ⨅ over unsatisfiable membership binders must be handled explicitly (done here via ciInf_le_of_le descent).",


### PR DESCRIPTION
## Summary
Research session for **erdos-507-wip-01** (Heilbronn's triangle problem). Extends the elementary witness ladder from `n = 3` to `n = 4`: the square inscribed in the unit circle gives `heilbronn 4 ≥ 1`, and with the existing Lagrange upper bound this sandwiches `heilbronn 4 ∈ [1, 3/2]`.

## Progress
- `heilbronn_four_ge : (1 : ℝ) ≤ heilbronn 4` — the four vertices `(1,0), (0,1), (−1,0), (0,−1)` form a unit-disk configuration; every one of the four vertex triples spans a right triangle of area exactly `1` (half the inscribed square), so `1` is admissible for the defining `sSup` (`le_csSup` + `heilbronn_defining_bddAbove`, mirroring the `heilbronn_three_ge_half` witness pattern; 64-way ordered-triple case bash, all-rational arithmetic).
- `heilbronn_four_pos : 0 < heilbronn 4`.
- `heilbronn_four_mem_Icc : heilbronn 4 ∈ Set.Icc (1 : ℝ) (3 / 2)` — the second width-`1/2` sandwich after `heilbronn 3 ∈ [3√3/4, 3/2]`.
- Knowledge tracker updated (progressSummary, builtItems, insights) in `research/problems/erdos-507-wip-01/knowledge.md` and `src/data/research/problems/erdos-507-wip-01.json`.

All new declarations are **0-axiom / 0-sorry**. Docker build verified: `Proofs.Erdos507WIP01` builds successfully (2971 jobs).

## Findings
- The elementary witness-ladder recipe (explicit boundary configuration + `le_csSup` + permutation/case bash on triples) extends rung by rung; `n = 4` needs no irrational arithmetic at all since the square's triple areas are exactly `1`.
- Sharpness of the square among four-point disk configurations is **not** claimed — that is part of the open quantitative problem. The docstrings say so explicitly.
- Next elementary rung would be `n = 5` (regular pentagon), but its triple areas involve `cos(2π/5)` irrationalities — feasible, noticeably heavier.

## Status
**Outcome**: progress (one new rung; deep targets — sharp `n = 3` upper bound, asymptotic exponent bounds — remain open)
**Next Steps**: sharp upper `heilbronn 3 ≤ 3√3/4` (central angles + Jensen, ~500+ lines, not session-sized); deep α(n) exponent bounds (KPS/CPZ).

🤖 Generated by researcher-1
