### PR TITLE
Enrich pythagorean-triples-oq-10: cover header docstring (lines 1-38)

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-10/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-10/meta.json
@@ -74,6 +74,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Docstring: Sharpening Oddness to a Mod-4 Residue",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "States the result — z ≡ 1 (mod 4), not merely odd — and explains why the sharper residue needs the actual parametrization z = m²+n² rather than z² ≡ 1 (mod 4) alone (both 1 and 3 square to 1 mod 4). Notes that 0 < z is essential to select the positive root, and previews the structural consequence that no integer ≡ 3 (mod 4) is ever a primitive hypotenuse.",
+      "mathContext": "$z^2 \\equiv 1 \\pmod 4$ is compatible with $z\\equiv 1$ or $z\\equiv 3$; the parametrization $z=m^2+n^2$, $m,n$ opposite parity, pins it to $z\\equiv 1\\pmod 4$."
+    },
+    {
       "id": "squares-mod-four",
       "title": "Squares modulo 4",
       "startLine": 39,


### PR DESCRIPTION
## Summary
- The module docstring (lines 1-38) was completely uncovered by both `sections` and `annotations.json` — it states the sharpened residue result (z ≡ 1 mod 4, not merely odd), explains why z² ≡ 1 (mod 4) alone is insufficient (both 1 and 3 square to 1 mod 4), and notes that positivity of z is load-bearing for selecting the correct root.
- Added a `header` section covering lines 1-38 summarizing only what the docstring itself states — no invented history or claims.

Part of the enricher header-docstring coverage vein (candidates where the first section skips the module docstring).

## Test plan
- [x] `meta.json` validated as well-formed JSON
- [x] `pnpm build` enrichment/gallery scripts processed the file without error