### PR TITLE
audit: mark erdos-957 clean (reserve re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17646,8 +17646,8 @@
     },
     "erdos-957": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:02:34Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-22T19:57:48Z",
       "result": "clean"
     },
     "erdos-958": {


### PR DESCRIPTION
## Audit result: clean

**Proof**: erdos-957 (Product of Extreme Distance Frequencies)

Reserve re-audit (unaudited/issues queue was fully drained). Verified:
- axiomCount 6, sorries 2, theoremCount 6, definitionCount 10 — all match `Proofs/Erdos957Problem.lean` exactly
- All `originalContributions` entries correspond to real declarations (no phantom decls)
- `status: axiomatized` / `badge: axiom` correctly disclosed given 6 axioms + 2 sorries
- No native_decide, no True-stubs

No changes needed beyond updating the tracker's audit timestamp/count.

---
Discovered during gallery integrity audit.