### PR TITLE
Enrich taylor-sincos-convergence-oq-03-incomplete-01: cover header docstring (lines 1-33)

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-04/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-04/meta.json
@@ -70,6 +70,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Docstring: The Topology of the Fixed-Point Set",
+      "startLine": 1,
+      "endLine": 30,
+      "summary": "Frames the entry as complementary to the base Schauder/Brouwer/Kakutani existence results: rather than proving a fixed point exists, it shows the fixed-point set of a continuous self-map of [a,b] is a nonempty compact set. Lists the four results (closed, compact intersection, 1D Brouwer via IVT, and the combined nonempty-compact statement) and stresses the whole file is 0-axiom and sorry-free, importing only Mathlib rather than the axiom-bearing base file.",
+      "mathContext": "$f:[a,b]\\to[a,b]$ continuous $\\Rightarrow \\{x\\mid f(x)=x\\}$ is nonempty and compact."
+    },
+    {
       "id": "closed-compact",
       "title": "The Fixed-Point Set is Closed and Compact",
       "startLine": 31,

--- a/src/data/proofs/schauder-fixed-point-oq-04/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-04/meta.json
@@ -70,14 +70,6 @@
   },
   "sections": [
     {
-      "id": "header",
-      "title": "Module Docstring: The Topology of the Fixed-Point Set",
-      "startLine": 1,
-      "endLine": 30,
-      "summary": "Frames the entry as complementary to the base Schauder/Brouwer/Kakutani existence results: rather than proving a fixed point exists, it shows the fixed-point set of a continuous self-map of [a,b] is a nonempty compact set. Lists the four results (closed, compact intersection, 1D Brouwer via IVT, and the combined nonempty-compact statement) and stresses the whole file is 0-axiom and sorry-free, importing only Mathlib rather than the axiom-bearing base file.",
-      "mathContext": "$f:[a,b]\\to[a,b]$ continuous $\\Rightarrow \\{x\\mid f(x)=x\\}$ is nonempty and compact."
-    },
-    {
       "id": "closed-compact",
       "title": "The Fixed-Point Set is Closed and Compact",
       "startLine": 31,

--- a/src/data/proofs/taylor-sincos-convergence-oq-03-incomplete-01/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-03-incomplete-01/meta.json
@@ -67,6 +67,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Docstring: Discharging the Parent's Three Sorries",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "States the goal — completing the parent entry's three sorries (alternating_tail_bound and the sin/cos remainder applications) self-contained and axiom-free, via Mathlib's alternating_series_error_bound and the tsum forms of sin/cos. Flags that |x| ≤ 1 is exactly the domain where the term sequence is monotone, the hypothesis the alternating estimation needs, so the term definitions are reproduced rather than imported from the still-sorry-carrying parent.",
+      "mathContext": "Leibniz tail bound $\\|\\sum'_k (-1)^{k+n}a(k+n)\\| \\le a_n$ for antitone summable $a$, applied to the sin/cos tsum tails on $|x|\\le 1$."
+    },
+    {
       "id": "leibniz",
       "title": "The Leibniz Estimation",
       "startLine": 34,


### PR DESCRIPTION
## Summary
- The module docstring (lines 1-27) plus import/namespace/open lines (28-33) were completely uncovered by both `sections` and `annotations.json`. The docstring states the file's purpose — discharging the parent entry's three `sorry`s (the Leibniz alternating-series estimation and its sin/cos applications) self-contained and axiom-free — and explains why `|x| ≤ 1` is the correct domain (term sequence monotone there).
- Added a `header` section covering lines 1-33 summarizing only what the docstring states.
- Verified this file itself is genuinely sorry-free/axiom-free (its docstring's "sorry" mentions refer to the *parent* entry, which is accurate — not a stale claim about this file).

Part of the enricher header-docstring coverage vein (candidates where the first section skips the module docstring).

## Test plan
- [x] `meta.json` validated as well-formed JSON
- [x] File size (14 KB) well under the 60 KB cap