### PR TITLE
Enrich inclusion-exclusion-oq-03-oq-01: cover header docstring (lines 1-48)

### DIFF
--- a/src/data/proofs/inclusion-exclusion-oq-03-oq-01/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-03-oq-01/meta.json
@@ -79,6 +79,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header: Closing the Parent's Open Question",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Module docstring stating the goal: the parent entry proves the pointwise laws of the single-element SOS update step ζ_a but stops short of showing that folding it over every element reproduces the full zeta transform ζf(S) = ∑_{T⊆S} f(T). This file closes that gap — the correctness theorem of the O(n·2ⁿ) fast subset-sum DP (Yates' algorithm) underlying fast subset convolution and the Björklund–Husfeldt–Kaski–Koivisto 'Fourier meets Möbius' algorithm — and lists the four main results. Imports the parent file and Mathlib.Tactic; opens the IEOQ03 namespace with Finset.",
+      "mathContext": "Folding $\\zeta_a$ over every $a$ collapses the partial-sweep invariant to the full zeta transform $\\zeta f(S) = \\sum_{T \\subseteq S} f(T)$."
+    },
+    {
       "id": "fold-definitions",
       "title": "The fold of the single-element SOS step",
       "startLine": 49,


### PR DESCRIPTION
Adds a `header` section (lines 1-48) covering the module docstring, previously uncovered by any section or annotation. The docstring states the goal (closing the parent's open question by proving the folded SOS step reproduces the full zeta transform) and lists the four main results.

Part of the header-docstring undercoverage sweep (see prior PRs #41568, #41667/68/70-73, #41679-83, #41703, #41705).