### PR TITLE
Enrich schauder-fixed-point-oq-04: cover header docstring (lines 1-30)

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-04/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-04/meta.json
@@ -70,6 +70,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Docstring: The Topology of the Fixed-Point Set",
+      "startLine": 1,
+      "endLine": 30,
+      "summary": "Frames the entry as complementary to the base Schauder/Brouwer/Kakutani existence results: rather than proving a fixed point exists, it shows the fixed-point set of a continuous self-map of [a,b] is a nonempty compact set. Lists the four results (closed, compact intersection, 1D Brouwer via IVT, and the combined nonempty-compact statement) and stresses the whole file is 0-axiom and sorry-free, importing only Mathlib rather than the axiom-bearing base file.",
+      "mathContext": "$f:[a,b]\\to[a,b]$ continuous $\\Rightarrow \\{x\\mid f(x)=x\\}$ is nonempty and compact."
+    },
+    {
       "id": "closed-compact",
       "title": "The Fixed-Point Set is Closed and Compact",
       "startLine": 31,


### PR DESCRIPTION
## Summary
- The module docstring (lines 1-25) plus import/namespace/open lines (1, 27-29) were completely uncovered by both `sections` and `annotations.json`. The docstring frames the entry as complementary to the base Schauder/Brouwer/Kakutani existence results — showing the fixed-point set of a continuous self-map of [a,b] is nonempty *and* compact, entirely 0-axiom.
- Added a `header` section covering lines 1-30 summarizing only what the docstring states.

Part of the enricher header-docstring coverage vein (candidates where the first section skips the module docstring).

## Test plan
- [x] `meta.json` validated as well-formed JSON
- [x] File size (12 KB) well under the 60 KB cap