### PR TITLE
Enrich inclusion-exclusion-oq-04-oq-01: cover header docstring (lines 1-52)

### DIFF
--- a/src/data/proofs/inclusion-exclusion-oq-04-oq-01/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-04-oq-01/meta.json
@@ -113,6 +113,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header: Derangements as a Sieve Instance",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Module docstring answering the parent's first open question by instantiating the dual sieve to derive the derangement count D_n. States the sieve setup (universe Equiv.Perm (Fin n), bad property i = 'fixes point i'), the resulting closed sieve form D_n = Σ_k (-1)^k C(n,k)(n-k)! and its classical exponential form n!·Σ(-1)^k/k!, and explains why this is not redundant with Mathlib's/the gallery's recurrence-based derivations — it is the genuine textbook inclusion-exclusion argument. Names the crux count (permutations fixing a t-element set number (n-|t|)!, via Equiv.Perm.subtypeEquivSubtypePerm) and the Mathlib/gallery dependencies. Imports Combinatorics.Derangements.Finite, Data.Fintype.Perm, Data.Finset.Powerset, Mathlib.Tactic, and the parent InclusionExclusionSieve file.",
+      "mathContext": "$D_n = \\sum_{k=0}^n (-1)^k \\binom{n}{k}(n-k)! = n!\\sum_{k=0}^n \\frac{(-1)^k}{k!}$, derived as the sieve's avoid-count for the bad properties $\\{\\sigma(i)=i\\}$."
+    },
+    {
       "id": "fixsets-and-crux",
       "title": "Fixed-Point Sets and the Crux Count",
       "startLine": 53,


### PR DESCRIPTION
Adds a `header` section (lines 1-52) covering the module docstring, previously uncovered by any section or annotation. The docstring states the sieve instantiation deriving the derangement count and explains why this derivation is conceptually distinct from the existing recurrence-based proofs.

Part of the header-docstring undercoverage sweep (see prior PRs #41568, #41667/68/70-73, #41679-83, #41703, #41705-08, #41710).