### PR TITLE
audit: mark erdos-601 clean (reserve re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14947,8 +14947,8 @@
     },
     "erdos-601": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:02:34Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-22T20:02:23Z",
       "result": "clean"
     },
     "erdos-602": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-601 (Erdős-Hajnal-Milner ordinal graph dichotomy, Tier C axiomatized). Verified: 9 sorries / 4 axioms in `Erdos601Problem.lean` match `meta.json` exactly, all 12 `originalContributions` grep-confirmed as real declarations, no True stubs, no native_decide. Companion `Erdos601Aristotle.lean` is a self-contained lemma bank with no gallery meta directory (orphan, makes no independent claim).

Tracker-only update; no content changes needed.

🤖 Generated with Claude Code