### PR TITLE
Enrich inclusion-exclusion-oq-04-oq-01-oq-01: cover header docstring (lines 1-59)

### DIFF
--- a/src/data/proofs/inclusion-exclusion-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-04-oq-01-oq-01/meta.json
@@ -107,6 +107,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header: Surjections as a Second Sieve Instance",
+      "startLine": 1,
+      "endLine": 59,
+      "summary": "Module docstring answering the derangements entry's open question by instantiating the same dual sieve to derive the surjection count #(Fin n ↠ Fin k) = Σ_j (-1)^j C(k,j)(k-j)^n, taking the bad property j = 'value j is missed'. Explains why this is a genuinely new gallery/Mathlib result (the second sieve application after derangements, equivalently k!·S(n,k) with S the Stirling numbers of the second kind), states the crux count (functions missing a t-set of values number (k-|t|)^n, via an explicit equivalence with the complementary codomain), and lists the Mathlib/gallery dependencies. Imports Fintype.Pi/Card/BigOperators, Finset.Powerset, Mathlib.Tactic, and the parent InclusionExclusionSieve file.",
+      "mathContext": "$\\#(\\text{surjections } \\mathrm{Fin}\\,n \\to \\mathrm{Fin}\\,k) = \\sum_{j=0}^k (-1)^j \\binom{k}{j}(k-j)^n = k!\\,S(n,k)$, the sieve's avoid-count for the bad properties 'value $j$ is missed'."
+    },
+    {
       "id": "misssets-and-crux",
       "title": "Miss Sets and the Crux Count",
       "startLine": 60,


### PR DESCRIPTION
Adds a `header` section (lines 1-59) covering the module docstring, previously uncovered by any section or annotation. The docstring states the surjection-count sieve instantiation (second application of the dual sieve after derangements) and explains its relation to the Stirling numbers of the second kind.

Part of the header-docstring undercoverage sweep (see prior PRs #41568, #41667/68/70-73, #41679-83, #41703, #41705-08, #41710/11).