### PR TITLE
Enrich inclusion-exclusion-oq-05: cover header docstring (lines 1-33)

### DIFF
--- a/src/data/proofs/inclusion-exclusion-oq-05/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-05/meta.json
@@ -59,6 +59,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header: Resolving Mathlib's Bonferroni TODO",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "Module docstring stating the Bonferroni inequalities (truncating inclusion-exclusion at an odd number of terms overestimates the union's cardinality, at an even number underestimates it) and identifying this as the standing TODO in Mathlib's InclusionExclusion.lean. Sketches the strategy: a partial alternating binomial identity ∑_{k=0}^m (-1)^k C(n+1,k) = (-1)^m C(n,m), not yet in Mathlib (which only has the full-sum version), applied pointwise at an element lying in exactly N of the sets and then summed via Finset.card_powersetCard. Imports Mathlib and opens Finset.",
+      "mathContext": "$\\sum_{k=1}^m (-1)^{k+1}\\binom{N}{k} = 1-(-1)^m\\binom{N-1}{m} \\gtrless 1$ for $m$ odd/even — the pointwise seed for the set-level Bonferroni bounds."
+    },
+    {
       "id": "part-1-partial-binomial",
       "title": "Part I: The Partial Alternating Binomial Identity",
       "startLine": 34,


### PR DESCRIPTION
Adds a `header` section (lines 1-33) covering the module docstring, previously uncovered by any section or annotation. The docstring states the Bonferroni inequalities result and notes it resolves a standing TODO in Mathlib's InclusionExclusion.lean.

Part of the header-docstring undercoverage sweep (see prior PRs #41568, #41667/68/70-73, #41679-83, #41703, #41705-08, #41710/11/13).