### PR TITLE
Gallery integrity: erdos-537 stale sorry claims in prose

### DIFF
--- a/src/data/proofs/erdos-537/annotations.json
+++ b/src/data/proofs/erdos-537/annotations.json
@@ -190,7 +190,7 @@
     },
     "type": "concept",
     "title": "Ratio Bound Theorem",
-    "content": "If a₂ > a₃ both lie in the interval (N/2, N], then a₂/a₃ ∈ (1, 2). This is the only fully proved theorem in the file (no sorry). The proof uses the interval containment: a₂ ≤ N and a₃ > N/2 give a₂/a₃ < N/(N/2) = 2. The bound a₂ > a₃ gives the lower bound > 1.",
+    "content": "If a₂ > a₃ both lie in the interval (N/2, N], then a₂/a₃ ∈ (1, 2). The proof uses the interval containment: a₂ ≤ N and a₃ > N/2 give a₂/a₃ < N/(N/2) = 2. The bound a₂ > a₃ gives the lower bound > 1.",
     "mathContext": "For $a_2, a_3 \\in (N/2, N]$ with $a_2 > a_3$: $1 < a_2/a_3 < N/(N/2) = 2$. The proof works in $\\mathbb{Q}$: `one_lt_div` gives $a_2/a_3 > 1$ from $a_2 > a_3 > 0$, and `div_lt_iff` with $a_2 \\leq N$ and $a_3 > N/2$ gives $a_2/a_3 < 2$ via `linarith`. This interval constraint is incompatible with the gap property $p_3/p_2 > 2$.",
     "significance": "key",
     "relatedConcepts": [
@@ -257,8 +257,8 @@
     },
     "type": "concept",
     "title": "Erdős #537 Disproved",
-    "content": "The main theorem: ¬Erdos537Conjecture. The proof assumes the conjecture and derives a contradiction: Ruzsa's set is dense enough to trigger the conjecture's conclusion but has no three equal prime products. Contains 1 sorry for the final bookkeeping step connecting the density of the Ruzsa set in (N/2, N] to the IsDenseSubset predicate.",
-    "mathContext": "$\\neg\\text{Erdos537Conjecture}$: the proof proceeds by contradiction. Assuming the conjecture, for $\\varepsilon$ from `ruzsa_set_positive_density` and $N = \\max(N_0, N_1) + 1$, the Ruzsa set restricted to $(N/2, N]$ is $\\varepsilon/2$-dense (by `ruzsa_set_large_intersection`) and thus must contain three equal prime products (by the conjecture). But `ruzsa_no_three_products` says it doesn't. The `sorry` is for the final technical step converting between the two density formulations.",
+    "content": "The main theorem: ¬Erdos537Conjecture. The proof assumes the conjecture and derives a contradiction: Ruzsa's set is dense enough to trigger the conjecture's conclusion but has no three equal prime products. Fully proved (no sorry), modulo the file's 3 axioms (`ruzsa_set_positive_density`, `ruzsa_set_large_intersection`, `ruzsa_contradiction`).",
+    "mathContext": "$\\neg\\text{Erdos537Conjecture}$: the proof proceeds by contradiction. Assuming the conjecture, for $\\varepsilon$ from `ruzsa_set_positive_density` and $N = \\max(N_0, N_1) + 1$, the Ruzsa set restricted to $(N/2, N]$ is $\\varepsilon/2$-dense (by `ruzsa_set_large_intersection`) and thus must contain three equal prime products (by the conjecture). But `ruzsa_no_three_products` says it doesn't.",
     "significance": "key",
     "relatedConcepts": [
       "proof by contradiction",

--- a/src/data/proofs/erdos-537/meta.json
+++ b/src/data/proofs/erdos-537/meta.json
@@ -129,10 +129,10 @@
     {
       "id": "disproof",
       "title": "The Disproof",
-      "summary": "Assembles $\\text{ruzsa\\_no\\_three\\_products}$ (proved) and $\\text{erdos\\_537\\_disproved}$ (1 sorry) to negate the conjecture by exhibiting the Ruzsa set counterexample",
+      "summary": "Assembles $\\text{ruzsa\\_no\\_three\\_products}$ (proved) and $\\text{erdos\\_537\\_disproved}$ (proved, modulo the 3 axioms above) to negate the conjecture by exhibiting the Ruzsa set counterexample",
       "startLine": 158,
       "endLine": 199,
-      "mathContext": "Mathematical content: Assembles $\\text{ruzsa\\_no\\_three\\_products}$ (proved) and $\\text{erdos\\_537\\_disproved}$ (1 sorry) to negate the conjecture by exhibiting the Ruzsa set counterexample"
+      "mathContext": "Mathematical content: Assembles $\\text{ruzsa\\_no\\_three\\_products}$ (proved) and $\\text{erdos\\_537\\_disproved}$ (proved, modulo the 3 axioms above) to negate the conjecture by exhibiting the Ruzsa set counterexample"
     },
     {
       "id": "understanding",
@@ -167,7 +167,7 @@
       "Can Ruzsa's construction be adapted to disprove analogous problems with k > 3 equal prime products?",
       "What is the status of the related Problem #536 (two equal prime products), now that the #537 pathway is blocked?",
       "Are there dense sets avoiding three equal prime products that do NOT use the lacunary squarefree construction?",
-      "Can the remaining sorry in erdos_537_disproved be resolved by formalizing the set-theoretic bookkeeping for the interval argument?"
+      "Can the 3 axioms (positive density of the Ruzsa set, its large intersection with (N/2, N), and the contradiction lemma) be discharged with a fully constructive proof?"
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-537
**Problem**: meta.json/annotations.json prose (section "disproof" summary, an openQuestions entry, and 2 annotations) claimed `erdos_537_disproved` "Contains 1 sorry" / "the remaining sorry" — stale from before the sorry was resolved.

## Evidence

**meta.json claims**: top-level counts (`sorries: 0`, `axiomCount: 3`) are correct and match the file, but section/openQuestion prose contradicts them by describing a sorry that no longer exists.
**Lean file shows**: `proofs/Proofs/Erdos537Problem.lean` has 0 `sorry` occurrences and exactly 3 `axiom` declarations (`ruzsa_set_positive_density`, `ruzsa_set_large_intersection`, `ruzsa_contradiction`). `erdos_537_disproved` is fully proved modulo those axioms.

## Fix

Updated the stale prose in `meta.json` (disproof section summary/mathContext, final openQuestions entry) and `annotations.json` (ann-537-8, ann-537-11) to accurately reflect that the file is sorry-free and proved modulo its 3 disclosed axioms.

---
Discovered during gallery integrity audit (reserve-mode re-verification of erdos-537).