### PR TITLE
Research: erdos-53-wip-01 — quadratic subset-sums bound for arbitrary positive sets (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos53WIP01.lean
+++ b/proofs/Proofs/Erdos53WIP01.lean
@@ -291,4 +291,186 @@ theorem sumsOrProducts_card_ge_odd_prime {A : Finset ℤ}
   omega
 
 
+/-!
+## Quadratic additive lower bound for arbitrary positive sets (Erdős chain)
+
+Every bound above is specific to the **prime** family — the exponential richness
+comes from the multiplicative side (unique factorisation makes subset products
+injective). This section proves the first bound in this development that holds for
+**arbitrary** sets of distinct positive integers, with no primality whatsoever:
+
+> For any finite `A ⊆ ℤ` with all elements positive,
+> `|subsetSums A| ≥ |A|·(|A|+1)/2 + 1`.
+
+This is the classical Erdős subset-sums argument, by induction on `|A|`: remove
+the maximum `m = max A` and observe that the `|A|` sums
+`{T} ∪ { T - a : a ∈ A, a ≠ m }` (where `T = Σ A`) are pairwise distinct and each
+**strictly exceeds** `T - m = Σ (A \ {m})`, which bounds every subset sum of
+`A \ {m}` from above. So each induction step contributes `|A|` fresh values on top
+of the recursive count, and the triangular number accumulates.
+
+Consequences recorded below:
+
+* `subsetSums_card_ge_quadratic` — `n(n+1) + 2 ≤ 2·|subsetSums A|` (doubled form,
+  division-free), hence `n(n+1)/2 + 1 ≤ |subsetSums A|`.
+* `sumsOrProducts_card_ge_quadratic` — the same bound for the full representable
+  set, i.e. quadratic-in-`|A|` growth for **all** positive sets, the `k = 1` case
+  of Problem 53 with a full extra factor `~|A|/2` to spare.
+* `sumsOrProducts_card_superlinear` — for every linear rate `C` there is a
+  threshold beyond which every positive set satisfies
+  `C·|A| ≤ |sumsOrProducts A|`.
+
+The mechanism (monotone chain via top-element removal) is genuinely additive and
+independent of the parity/primality separations above. It still falls short of
+Chang's theorem — `n(n+1)/2 + 1 < n^2` for `n ≥ 3`, so even `k = 2` over all sets
+remains untouched — but it moves the unconditional frontier from "prime sets only"
+to "all positive sets".
+-/
+
+/-- The full sum `Σ A` is a subset sum (take `S = A` in the powerset). -/
+theorem sum_mem_subsetSums (A : Finset ℤ) : A.sum id ∈ subsetSums A := by
+  rw [subsetSums, Finset.mem_image]
+  exact ⟨A, Finset.mem_powerset.mpr Finset.Subset.rfl, rfl⟩
+
+/-- Dropping a single element from the full sum stays a subset sum:
+    `Σ A - a` is the sum over `A.erase a`. -/
+theorem sum_sub_mem_subsetSums {A : Finset ℤ} {a : ℤ} (ha : a ∈ A) :
+    A.sum id - a ∈ subsetSums A := by
+  rw [subsetSums, Finset.mem_image]
+  refine ⟨A.erase a, Finset.mem_powerset.mpr (fun x hx => Finset.mem_of_mem_erase hx), ?_⟩
+  rw [Finset.sum_erase_eq_sub ha, id_eq]
+
+/-- On a set of **nonnegative** integers, every subset sum is at most the full
+    sum `Σ A` (monotonicity of sums under subset inclusion). -/
+theorem mem_subsetSums_le_sum {A : Finset ℤ} (hnn : ∀ a ∈ A, 0 ≤ a)
+    {s : ℤ} (hs : s ∈ subsetSums A) : s ≤ A.sum id := by
+  rw [subsetSums, Finset.mem_image] at hs
+  obtain ⟨S, hS, rfl⟩ := hs
+  rw [Finset.mem_powerset] at hS
+  exact Finset.sum_le_sum_of_subset_of_nonneg hS (fun a ha _ => hnn a ha)
+
+/-- **Erdős quadratic bound, induction core.** For any set `A` of `n` distinct
+    positive integers, `n(n+1) + 2 ≤ 2·|subsetSums A|` (the division-free form of
+    `|subsetSums A| ≥ n(n+1)/2 + 1`).
+
+    Induction on `n`, removing `m = max A`: every subset sum of `A' = A.erase m`
+    is at most `T - m` (where `T = Σ A`), while the `n` values
+    `{T} ∪ { T - a : a ∈ A', a ≠ m }` are distinct subset sums of `A` strictly
+    above `T - m`. So the count grows by at least `n` at each step. -/
+theorem subsetSums_card_quadratic :
+    ∀ (n : ℕ) (A : Finset ℤ), A.card = n → (∀ a ∈ A, 0 < a) →
+      n * (n + 1) + 2 ≤ 2 * (subsetSums A).card := by
+  intro n
+  induction n with
+  | zero =>
+      intro A hcard _
+      rw [Finset.card_eq_zero] at hcard
+      subst hcard
+      rw [subsetSums_empty]
+      simp
+  | succ n ih =>
+      intro A hcard hpos
+      have hne : A.Nonempty := Finset.card_pos.mp (by omega)
+      set m := A.max' hne with hm_def
+      have hmA : m ∈ A := A.max'_mem hne
+      have hm_pos : 0 < m := hpos m hmA
+      set A' := A.erase m with hA'_def
+      have hcard' : A'.card = n := by
+        rw [hA'_def, Finset.card_erase_of_mem hmA, hcard]
+        omega
+      have hpos' : ∀ a ∈ A', 0 < a := fun a ha => hpos a (Finset.mem_of_mem_erase ha)
+      have IH : n * (n + 1) + 2 ≤ 2 * (subsetSums A').card := ih A' hcard' hpos'
+      set T := A.sum id with hT_def
+      -- the erased set sums to exactly `T - m`
+      have hT' : A'.sum id = T - m := by
+        rw [hA'_def, Finset.sum_erase_eq_sub hmA, id_eq]
+      -- the `n + 1` "large" subset sums: `T` itself and `T - a` for `a ∈ A'`
+      set B : Finset ℤ := insert T (A'.image (fun a => T - a)) with hB_def
+      have hBsub : B ⊆ subsetSums A := by
+        intro b hb
+        rw [hB_def, Finset.mem_insert] at hb
+        rcases hb with rfl | hb
+        · exact sum_mem_subsetSums A
+        · rw [Finset.mem_image] at hb
+          obtain ⟨a, ha, rfl⟩ := hb
+          exact sum_sub_mem_subsetSums (Finset.mem_of_mem_erase ha)
+      have hBcard : B.card = n + 1 := by
+        have himg : (A'.image (fun a => T - a)).card = A'.card :=
+          Finset.card_image_of_injective _ sub_right_injective
+        have hT_not : T ∉ A'.image (fun a => T - a) := by
+          rw [Finset.mem_image]
+          rintro ⟨a, ha, haeq⟩
+          have := hpos' a ha
+          omega
+        rw [hB_def, Finset.card_insert_of_notMem hT_not, himg, hcard']
+      -- separation: every subset sum of `A'` is `≤ T - m`, every element of `B`
+      -- is `> T - m` (for `T - a` because `a < m` by maximality; for `T` because
+      -- `m > 0`)
+      have hlt : ∀ x ∈ subsetSums A', ∀ b ∈ B, x < b := by
+        intro x hx b hb
+        have hxle : x ≤ T - m := by
+          have h1 := mem_subsetSums_le_sum (fun a ha => (hpos' a ha).le) hx
+          rwa [hT'] at h1
+        rw [hB_def, Finset.mem_insert] at hb
+        rcases hb with rfl | hb
+        · omega
+        · rw [Finset.mem_image] at hb
+          obtain ⟨a, ha, rfl⟩ := hb
+          have hane : a ≠ m := (Finset.mem_erase.mp ha).1
+          have halt : a < m :=
+            lt_of_le_of_ne (A.le_max' a (Finset.mem_of_mem_erase ha)) hane
+          omega
+      have hdisj : Disjoint (subsetSums A') B := by
+        rw [Finset.disjoint_left]
+        intro x hx hxB
+        exact absurd (hlt x hx x hxB) (lt_irrefl x)
+      have hunion : subsetSums A' ∪ B ⊆ subsetSums A :=
+        Finset.union_subset
+          (subsetSums_mono (fun x hx => Finset.mem_of_mem_erase hx)) hBsub
+      have hcount : (subsetSums A').card + (n + 1) ≤ (subsetSums A).card := by
+        have h := Finset.card_le_card hunion
+        rwa [Finset.card_union_of_disjoint hdisj, hBcard] at h
+      nlinarith [IH, hcount]
+
+/-- **Erdős quadratic bound (doubled form).** For any set `A` of distinct positive
+    integers, `|A|·(|A|+1) + 2 ≤ 2·|subsetSums A|` — the additive side **alone**
+    realises quadratically many values, with no primality assumption. -/
+theorem subsetSums_card_ge_quadratic {A : Finset ℤ} (hpos : ∀ a ∈ A, 0 < a) :
+    A.card * (A.card + 1) + 2 ≤ 2 * (subsetSums A).card :=
+  subsetSums_card_quadratic A.card A rfl hpos
+
+/-- **Erdős quadratic bound (division form).** `|A|·(|A|+1)/2 + 1 ≤ |subsetSums A|`
+    for distinct positive integers — the classical triangular-number statement.
+    Sharp for `A = {1, 2, …, n}`, whose subset sums are exactly `[0, n(n+1)/2]`. -/
+theorem subsetSums_card_ge_quadratic' {A : Finset ℤ} (hpos : ∀ a ∈ A, 0 < a) :
+    A.card * (A.card + 1) / 2 + 1 ≤ (subsetSums A).card := by
+  have h := subsetSums_card_ge_quadratic hpos
+  generalize A.card * (A.card + 1) = q at h ⊢
+  omega
+
+/-- **Quadratic growth of the representable set over ALL positive sets.** For any
+    finite set of distinct positive integers — no primality, no parity, no
+    superincreasing structure — `|A|·(|A|+1) + 2 ≤ 2·|sumsOrProducts A|`. The
+    first unconditional bound in this development whose scope matches Problem 53's
+    quantifier "for any large `A`" (restricted to positive elements): the easy
+    linear bound `card_le_sumsOrProducts` is beaten by a full factor `~|A|/2`. -/
+theorem sumsOrProducts_card_ge_quadratic {A : Finset ℤ} (hpos : ∀ a ∈ A, 0 < a) :
+    A.card * (A.card + 1) + 2 ≤ 2 * (sumsOrProducts A).card :=
+  le_trans (subsetSums_card_ge_quadratic hpos)
+    (Nat.mul_le_mul_left 2 (Finset.card_le_card (subsetSums_subset_sumsOrProducts A)))
+
+/-- **Superlinearity over all positive sets.** For every linear rate `C` there is
+    a threshold `N` (explicitly `N = 2C`) beyond which every set of distinct
+    positive integers satisfies `C·|A| ≤ |sumsOrProducts A|`. Strengthens the
+    `k = 1` case of Problem 53 on positive sets from "at least `|A|`" to "at least
+    any prescribed multiple of `|A|`". -/
+theorem sumsOrProducts_card_superlinear (C : ℕ) :
+    ∃ N, ∀ A : Finset ℤ, (∀ a ∈ A, 0 < a) → N ≤ A.card →
+      C * A.card ≤ (sumsOrProducts A).card := by
+  refine ⟨2 * C, fun A hpos hbig => ?_⟩
+  have h := sumsOrProducts_card_ge_quadratic hpos
+  have hsq : 2 * C * A.card ≤ A.card * A.card :=
+    Nat.mul_le_mul_right A.card hbig
+  nlinarith [h, hsq]
+
 end Erdos53

--- a/research/problems/erdos-53-wip-01/knowledge.md
+++ b/research/problems/erdos-53-wip-01/knowledge.md
@@ -142,3 +142,45 @@ unaffected (Mathlib oleans cached); no docker.
 Chang's theorem (the |A|^k bound for *arbitrary* large A, not just primes) stays documented,
 not axiomatized — it needs additive-combinatorics machinery (Freiman/Plünnecke) absent here.
 The prime family is now fully handled for all k.
+
+## Session 2026-07-22 (researcher-1) — quadratic additive bound for arbitrary positive sets
+
+Added 8 axiom-free theorems to `Erdos53WIP01.lean` (theoremCount 11→19, 294→476 lines;
+host-verified v4.31 via fresh-parent-olean path, exit 0; `#print axioms` on all four
+headline theorems = propext/Classical.choice/Quot.sound).
+
+**The point.** Every previous bound in the development is prime-family-specific (the
+exponential richness lives on the multiplicative side). This session proves the first
+bound whose scope matches Problem 53's "arbitrary large A" quantifier (restricted to
+positive elements): the classical Erdős subset-sums chain.
+
+- `subsetSums_card_quadratic` / `subsetSums_card_ge_quadratic('`)`: for ANY set of n
+  distinct positive integers, `n(n+1) + 2 ≤ 2·|subsetSums A|`, i.e.
+  `|subsetSums A| ≥ n(n+1)/2 + 1` (sharp for {1,…,n}). Induction on n removing
+  `m = max A`: every subset sum of `A' = A.erase m` is `≤ T − m` (`T = Σ A`,
+  `mem_subsetSums_le_sum` + `sum_erase_eq_sub`), while the n values
+  `{T} ∪ {T − a : a ∈ A'}` are distinct subset sums strictly above `T − m`
+  (distinct by `sub_right_injective`; above by `a < m` from `le_max'` + erase-ne).
+  Disjoint-union card count adds n per step; triangular number accumulates.
+- `sumsOrProducts_card_ge_quadratic`: same bound for the full representable set —
+  quadratic growth over ALL positive sets, beating the linear
+  `card_le_sumsOrProducts` by a factor ~|A|/2.
+- `sumsOrProducts_card_superlinear (C)`: explicit threshold `N = 2C` past which
+  `C·|A| ≤ |sumsOrProducts A|` — the k=1 case of Problem 53 with any prescribed
+  linear rate, on all positive sets.
+
+**Lean notes.** `Finset.sum_erase_eq_sub` needs a trailing `id_eq` rewrite (id a vs a
+not closed by rw's rfl). `Finset.card_erase_of_mem` leaves `n+1−1 = n` (ℕ sub) — close
+with omega. Avoided `Finset.erase_subset` signature drift by using
+`fun x hx => Finset.mem_of_mem_erase hx` inline. Final arithmetic (triangular-number
+step and superlinearity) via `nlinarith` with an explicit `Nat.mul_le_mul_right` hint.
+
+**Honesty.** `n(n+1)/2 + 1 < n²` for `n ≥ 3`: even the k=2 case of Problem 53 over
+arbitrary sets remains untouched. Chang's theorem stays documented, not axiomatized.
+This widens the unconditional frontier (primes → all positive sets) at polynomial
+degree ~2/2, it does not approach the uniform |A|^k crux. Negative elements also
+untouched (the chain needs positivity for the total-sum upper bound).
+
+### Files modified
+- `proofs/Proofs/Erdos53WIP01.lean` (+182 lines, 8 theorems)
+- `src/data/research/problems/erdos-53-wip-01.json`

--- a/research/problems/erdos-53-wip-01/state.md
+++ b/research/problems/erdos-53-wip-01/state.md
@@ -1,13 +1,13 @@
 # Research State: erdos-53-wip-01
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: ACT
 **Path**: full
 **Since**: 2026-07-09T17:33:19-07:00
-**Iteration**: 2
+**Iteration**: 4
 
 ## Current Focus
-Batch 2 of axiom-free lemmas landed (Section 8): k=1 base case, distinct-prime richness 2^|A|-1, trivial upper bracket. Theorem count 12 -> 24, still 0 axioms.
+Quadratic additive lower bound landed: |subsetSums A| >= n(n+1)/2+1 for ALL positive sets (Erdős max-removal chain), plus sumsOrProducts quadratic/superlinear corollaries. theoremCount 11->19 in Erdos53WIP01.lean, still 0 axioms.
 
 ## Active Approach
 Elementary structural formalization of subset-sum/product sets; Chang deep theorem stays documented.
@@ -21,4 +21,4 @@ Elementary structural formalization of subset-sum/product sets; Chang deep theor
 None.
 
 ## Next Action
-Optional: small decide computations of |sumsOrProducts A| for tiny explicit A (problem.md item iii). Chang/Erdős–Szemerédi upper bound out of Mathlib scope.
+Remaining deep crux: Chang (|A|^k for arbitrary large sets, k>=2) — needs Freiman/Plünnecke machinery, out of scope. Possible elementary rungs: extend the chain bound to sets allowing negative elements (positivity currently required for the total-sum upper bound), or product-side analogue |subsetProducts| for sets of integers > 1 via monotone chain on log.

--- a/src/data/research/problems/erdos-53-wip-01.json
+++ b/src/data/research/problems/erdos-53-wip-01.json
@@ -20,8 +20,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-09T17:33:19-07:00",
-    "iteration": 3,
-    "focus": "Session: general poly-vs-exp domination exists_pow_le_two_pow (∀k ∃N, n≥N→n^k≤2^n, via isLittleO_pow_const_const_pow_of_one_lt) generalising sq_le_two_pow(k=2); + erdosProblem53_prime_exponent_eventually (Problem-53 on primes for arbitrary exponent k). 2 axiom-free theorems, theoremCount 7→9, host-verified.",
+    "iteration": 4,
+    "focus": "Session 2026-07-22: quadratic additive lower bound for arbitrary positive sets. subsetSums_card_quadratic (induction on max-removal): n(n+1)+2 <= 2|subsetSums A|; corollaries sumsOrProducts_card_ge_quadratic and sumsOrProducts_card_superlinear. 8 new theorems (11->19), 0-axiom, host-verified v4.31.",
     "blockers": [
       {
         "route": "lower-order refinement of the easy-direction lower bound (parity/prefix-sum even-value counting) past 2^|A| + |A| - 1",
@@ -37,7 +37,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Easy direction sharpened via parity separation. Prime family already handled for all k (2^|A| lower bound, all-k eventual). New: for ODD primes, 2^|A|+|A|-1 lower bound via overlap-free even sums vs odd products. This is a lower-order refinement of the EASY direction; Chang for arbitrary large sets remains the deep open crux (documented, untouched).",
+    "progressSummary": "PROGRESS: Unconditional frontier widened from prime sets to ALL positive sets. New quadratic additive bound |subsetSums A| >= n(n+1)/2+1 (Erdős max-removal chain, 0-axiom, host-verified), hence quadratic/superlinear growth of |sumsOrProducts A| with no primality. Prime family: 2^|A| bound, all-k eventual (done earlier). Remaining deep crux: Chang's |A|^k for arbitrary large sets (k>=2 over all sets untouched; n(n+1)/2+1 < n^2).",
     "builtItems": [
       "zero_mem_subsetSums, mem_subsetSums_of_mem, mem_subsetProducts_of_mem in Erdos53Problem.lean",
       "subsetSums/Products_subset_sumsOrProducts, subsetSumCount/subsetProductCount_le_card in Erdos53Problem.lean",
@@ -50,14 +50,18 @@
       "erdosProblem53_prime_exponent_two: distinct positive primes with |A|≥4 realise ≥ |A|^2 representable integers (first superlinear instance on the prime family)",
       "sumsOrProducts_card_prime_pinned: prime sets pinned in [2^|A|, 2^{|A|+1}]",
       "subsetProducts_odd_of_odd in Erdos53WIP01.lean: every nonempty subset product of odd integers is odd (Finset.prod_induction over Odd).",
-      "sumsOrProducts_card_ge_odd_prime in Erdos53WIP01.lean: for a nonempty set of distinct odd positive primes, 2^|A| + |A| - 1 <= |sumsOrProducts A|, strictly stronger than the base 2^|A| bound; the even family {0} union {min A + q : q != min A} adds |A| fresh values disjoint from the odd products. Axiom-free."
+      "sumsOrProducts_card_ge_odd_prime in Erdos53WIP01.lean: for a nonempty set of distinct odd positive primes, 2^|A| + |A| - 1 <= |sumsOrProducts A|, strictly stronger than the base 2^|A| bound; the even family {0} union {min A + q : q != min A} adds |A| fresh values disjoint from the odd products. Axiom-free.",
+      "sum_mem_subsetSums / sum_sub_mem_subsetSums / mem_subsetSums_le_sum in Erdos53WIP01.lean (subset-sum membership + total-sum upper bound helpers)",
+      "subsetSums_card_quadratic + subsetSums_card_ge_quadratic(') in Erdos53WIP01.lean: n(n+1)+2 <= 2|subsetSums A| (and /2+1 form) for all positive sets, 0-axiom",
+      "sumsOrProducts_card_ge_quadratic + sumsOrProducts_card_superlinear in Erdos53WIP01.lean: quadratic growth of the representable set over ALL positive sets; every linear rate C beaten past |A| >= 2C"
     ],
     "insights": [
       "Erdos53Problem.lean was a definitions-only stub (9 defs, 0 theorems). Chang 2003 (conjecture holds) and the Erdos-Szemeredi upper bound need deep additive combinatorics beyond Mathlib; tractable axiom-free content is elementary structural facts about subsetSums/subsetProducts/sumset/productset.",
       "Clean generic Finset targets that generalize across these stubs: image-of-powerset card bound (card_image_le + card_powerset gives <= 2^|A|), image-of-product card bound (card_image_le + card_product gives <= |A|^2), monotonicity via powerset_mono + image_subset_image, membership via singleton subset.",
       "k=1 slice of Problem 53 is elementary: A ⊆ subsetSums A ⊆ sumsOrProducts A gives |A| ≤ |sumsOrProducts A| (erdosProblem53_exponent_one, N₀=0). Distinct-prime richness |subsetProducts A|=2^|A|-1 requires 0<p (Prime over ℤ is closed under negation; positivity kills the p↔-p product collision). Proved axiom-free via Prime.dvd_finsetProd_iff + Prime.associated_of_dvd + Int.associated_iff_natAbs.",
       "Exponential-richness witness (researcher-1, 2026-07-20): the additive side contributes exactly one value the multiplicative side cannot — 0 (empty subset sum), which is never a product of positive primes. So for distinct positive primes |sumsOrProducts A| ≥ (2^|A|-1)+1 = 2^|A|, exhibiting sets where the Problem-53 count is exponential. This is the strongest witness on the EASY direction; it does NOT bear on Chang’s theorem, which is the uniform bound over ALL large sets (prime sets are never the obstruction).",
-      "Parity separation: for a set of distinct ODD primes, every nonempty subset product is odd (product of odds), while 0 and every 2-element subset sum p+q of odds is even. So the multiplicative and additive sides are provably overlap-free on the even numbers -- a genuine structural fact about Problem 53 two operations."
+      "Parity separation: for a set of distinct ODD primes, every nonempty subset product is odd (product of odds), while 0 and every 2-element subset sum p+q of odds is even. So the multiplicative and additive sides are provably overlap-free on the even numbers -- a genuine structural fact about Problem 53 two operations.",
+      "Erdős max-removal chain gives the first non-prime-specific bound: for ANY set of n distinct POSITIVE integers, |subsetSums A| >= n(n+1)/2 + 1 (sharp for {1..n}). Mechanism: every subset sum of A' = A.erase(max) is <= T - m (T = total, m = max), while the n values {T} u {T - a : a in A', a != m} are distinct subset sums strictly above T - m, so the count grows by n per step. Independent of parity/primality separations; still short of Chang (n(n+1)/2+1 < n^2 for n>=3, so k=2 over all sets remains open)."
     ],
     "mathlibGaps": [],
     "nextSteps": [],


### PR DESCRIPTION
## Summary
Research session for erdos-53-wip-01 (Erdős Problem #53 — sums and products of distinct elements, resolved by Chang 2003; formalizing the tractable rungs, Chang stays documented).

## Progress
- New section in `proofs/Proofs/Erdos53WIP01.lean` (+182 lines, 8 theorems, 11→19): the classical Erdős quadratic subset-sums bound.
- `subsetSums_card_quadratic` / `subsetSums_card_ge_quadratic(')`: for ANY set of `n` distinct **positive** integers, `n(n+1) + 2 ≤ 2·|subsetSums A|`, i.e. `|subsetSums A| ≥ n(n+1)/2 + 1` (sharp for `{1,…,n}`). Induction removing `m = max A`: subset sums of `A.erase m` are `≤ T − m`, while the `n` values `{T} ∪ {T − a : a ∈ A.erase m}` are distinct subset sums strictly above `T − m`.
- `sumsOrProducts_card_ge_quadratic`: quadratic growth of the full representable set over **all** positive sets — the first bound in this development not specific to the prime family.
- `sumsOrProducts_card_superlinear (C)`: explicit threshold `N = 2C` past which `C·|A| ≤ |sumsOrProducts A|`.
- Tracker/knowledge/state updated.

## Findings
- The max-removal chain is a genuinely additive mechanism, independent of the parity/primality separations already in the file; it widens the unconditional frontier from "prime sets" to "all positive sets".
- Honesty: `n(n+1)/2 + 1 < n²` for `n ≥ 3` — even the `k = 2` case of Problem 53 over arbitrary sets remains untouched; Chang's `|A|^k` stays the documented open crux. Positivity is genuinely used (total-sum upper bound); negative elements untouched.

## Verification
- Host-verified at v4.31 via fresh-parent-olean path: `lake exe cache get`, `lake env lean -o …/Erdos53Problem.olean`, then `lake env lean Proofs/Erdos53WIP01.lean` → exit 0.
- `#print axioms` on all four headline theorems = `[propext, Classical.choice, Quot.sound]` (0 axioms, 0 sorries).

## Status
**Outcome**: progress
**Next Steps**: Chang (`|A|^k`, arbitrary sets, k≥2) needs Freiman/Plünnecke machinery — out of elementary scope. Possible rungs: chain bound allowing negative elements; product-side analogue for sets of integers > 1.

🤖 Generated by researcher-1
