### PR TITLE
Formalize the Dinitz–Garg–Goemans unsplittable-flow separation (finite decide certificate)

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 38065
-# Branch: feature/issue-38065
+# Issue: 41675
+# Branch: feature/issue-41675
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/proofs/Proofs/DinitzGargGoemans.lean
+++ b/proofs/Proofs/DinitzGargGoemans.lean
@@ -124,8 +124,9 @@ def D : ℕ := 15
 
 /-- The fractional flow is **feasible**: conservation holds at every internal node
 `u, v, w`; each terminal receives exactly its demand; the source emits the total
-demand; and every arc respects its capacity `u_a = x_a` (`x_a ≤ x_a`, trivially). -/
-def FractionalFeasible : Prop :=
+demand; and every arc respects its capacity `u_a = x_a` (`x_a ≤ x_a`, trivially).
+Marked `@[reducible]` so `decide`'s instance synthesis sees the decidable body. -/
+@[reducible] def FractionalFeasible : Prop :=
   inflow .u = outflow .u ∧ inflow .v = outflow .v ∧ inflow .w = outflow .w ∧
   inflow .t1 = d1 ∧ inflow .t2 = d2 ∧ inflow .t3 = d3 ∧
   outflow .s = d1 + d2 + d3 ∧
@@ -162,8 +163,9 @@ def routingCost (r : Routing) : ℕ :=
   d1 * pathCost (path1 r.1) + d2 * pathCost (path2 r.2.1) + d3 * pathCost (path3 r.2.2)
 
 /-- A routing is **capacity-good** if every arc load stays within `x_a + D`
-(capacity violation at most the maximum demand `D`). -/
-def CapGood (r : Routing) : Prop := ∀ a ∈ allArcs, load a r ≤ xflow a + D
+(capacity violation at most the maximum demand `D`). Marked `@[reducible]` so
+`decide`'s instance synthesis sees the bounded quantifier over `allArcs`. -/
+@[reducible] def CapGood (r : Routing) : Prop := ∀ a ∈ allArcs, load a r ≤ xflow a + D
 
 /-! ## The three verified facts (plain kernel `decide`, 0 axioms) -/
 

--- a/proofs/Proofs/DinitzGargGoemans.lean
+++ b/proofs/Proofs/DinitzGargGoemans.lean
@@ -1,0 +1,203 @@
+/-
+  The Dinitz–Garg–Goemans (DGG) unsplittable-flow separation — a finite,
+  machine-verified certificate.
+
+  Sources:
+    * Dmitry Rybin (@DmitryRybin1), 2026 announcement (found with GPT-5.6 Pro):
+      https://x.com/DmitryRybin1/status/2079904005652893709
+    * Dinitz, Garg, Goemans, "On the single-source unsplittable flow problem",
+      Combinatorica 19 (1999).
+
+  ## What this file proves
+
+  For one explicit single-source instance (7 vertices, 9 arcs, 3 demands) we
+  encode, in pure integer arithmetic, three finite facts and discharge them by
+  plain kernel `decide` (NOT `native_decide`), so the file is **0-axiom** —
+  `#print axioms` lists only `propext` / `Quot.sound`, with no `Lean.ofReduceBool`
+  and no `sorryAx`:
+
+    1. `fractional_cost_eq` : the given fractional flow has cost `cᵀx = 58`.
+    2. `fractional_feasible` : that fractional flow satisfies flow conservation at
+       every internal node, delivers each demand at its terminal, and respects the
+       arc capacities `u_a = x_a`.
+    3. `every_capgood_routing_costly` : **every** unsplittable routing whose arc
+       loads stay within `x_a + D` (capacity violation ≤ `D = dmax = 15`) has cost
+       `≥ 60`; and `capgood_optimum_is_60` exhibits a capacity-good routing of cost
+       exactly `60`, so the unsplittable optimum under this rule is `60`.
+
+  Since `60 > 58`, the unsplittable optimum strictly exceeds the fractional cost
+  even when a capacity violation up to the maximum demand `D` is allowed. This is
+  the exact quantity the DGG "cost + congestion" guarantee (the exact-`D` reading)
+  would forbid, so the certificate *separates* that bound.
+
+  ## The instance
+
+  Vertices `s, u, v, w, t1, t2, t3`; source `s`. Demands `d1 = 15, d2 = 10,
+  d3 = 15`, so `D = dmax = 15`. Arcs `(x_a fractional load, c_a unit cost)`, with
+  capacities `u_a = x_a`:
+
+      s→t1 (10,2)  s→t2 (6,3)  s→u (24,0)  u→t3 (10,2)  u→v (14,0)
+      v→t1 (5,0)   v→w (9,0)   w→t2 (4,0)  w→t3 (5,0)
+
+  Each terminal `t_i` is reachable by exactly two `s`→`t_i` paths (the underlying
+  undirected graph is a subdivision of `K₄`, so there are no hidden splice paths):
+
+      E1 = s→t1              Z1 = s→u→v→t1
+      E2 = s→t2              Z2 = s→u→v→w→t2
+      E3 = s→u→t3            Z3 = s→u→v→w→t3
+
+  Each direct path `E_i` costs `d_i · c(E_i) = 30`; each long path `Z_i` costs `0`.
+  A routing chooses one path per terminal (`2³ = 8` routings). The capacity rule
+  `y_a ≤ x_a + D` allows **at most one** `Z_i` (any two overload a shared arc:
+  `Z2+Z3` overloads `v→w` at `25 > 24`; `Z1+Z3` overloads `u→v` at `30 > 29`;
+  `Z1+Z2` overloads `s→u` at `40 > 39`), so every capacity-good routing uses at
+  least two cost-`30` paths ⇒ cost `≥ 60`.
+
+  ## Audit caveat (IMPORTANT — read before citing)
+
+  This entry records a **recently-announced finite certificate** (Rybin 2026),
+  reproduced here as machine-checkable integer facts. The *finite facts below are
+  solid and independently re-derived*. However, the announcement itself notes that
+  the latest primary source (Jan 2026) still lists the DGG conjecture as **open**,
+  and that the counterexample "should be independently audited before being
+  announced as an established result." Accordingly this file proves only the
+  self-contained separation statement for this explicit instance; it does **not**
+  claim to settle the DGG conjecture. The interpretation "refutes DGG Conjecture
+  1.3" is deferred to independent audit against the exact conjecture statement.
+-/
+
+import Mathlib
+
+namespace DinitzGargGoemans
+
+/-! ## The instance: arcs, capacities, unit costs -/
+
+/-- The nine arcs of the instance. -/
+inductive Arc
+  | st1 | st2 | su | ut3 | uv | vt1 | vw | wt2 | wt3
+  deriving DecidableEq
+
+/-- All nine arcs, as a list (used for bounded quantification in `decide`). -/
+def allArcs : List Arc :=
+  [.st1, .st2, .su, .ut3, .uv, .vt1, .vw, .wt2, .wt3]
+
+/-- Fractional load `x_a` on each arc; the arc capacity is `u_a = x_a`. -/
+def xflow : Arc → ℕ
+  | .st1 => 10 | .st2 => 6 | .su => 24 | .ut3 => 10 | .uv => 14
+  | .vt1 => 5  | .vw => 9  | .wt2 => 4 | .wt3 => 5
+
+/-- Unit cost `c_a` on each arc. -/
+def ucost : Arc → ℕ
+  | .st1 => 2 | .st2 => 3 | .su => 0 | .ut3 => 2 | .uv => 0
+  | .vt1 => 0 | .vw => 0 | .wt2 => 0 | .wt3 => 0
+
+/-! ## Nodes and the fractional flow's conservation -/
+
+/-- The seven vertices. -/
+inductive Node
+  | s | u | v | w | t1 | t2 | t3
+  deriving DecidableEq
+
+/-- Tail (origin) of each arc. -/
+def tail : Arc → Node
+  | .st1 => .s | .st2 => .s | .su => .s | .ut3 => .u | .uv => .u
+  | .vt1 => .v | .vw => .v | .wt2 => .w | .wt3 => .w
+
+/-- Head (destination) of each arc. -/
+def head : Arc → Node
+  | .st1 => .t1 | .st2 => .t2 | .su => .u | .ut3 => .t3 | .uv => .v
+  | .vt1 => .t1 | .vw => .w | .wt2 => .t2 | .wt3 => .t3
+
+/-- Total fractional flow leaving a node. -/
+def outflow (n : Node) : ℕ :=
+  (allArcs.filter (fun a => tail a = n)).foldr (fun a s => xflow a + s) 0
+
+/-- Total fractional flow entering a node. -/
+def inflow (n : Node) : ℕ :=
+  (allArcs.filter (fun a => head a = n)).foldr (fun a s => xflow a + s) 0
+
+/-- Demands `d_i`; `D = dmax = 15`. -/
+def d1 : ℕ := 15
+def d2 : ℕ := 10
+def d3 : ℕ := 15
+def D : ℕ := 15
+
+/-- The fractional flow is **feasible**: conservation holds at every internal node
+`u, v, w`; each terminal receives exactly its demand; the source emits the total
+demand; and every arc respects its capacity `u_a = x_a` (`x_a ≤ x_a`, trivially). -/
+def FractionalFeasible : Prop :=
+  inflow .u = outflow .u ∧ inflow .v = outflow .v ∧ inflow .w = outflow .w ∧
+  inflow .t1 = d1 ∧ inflow .t2 = d2 ∧ inflow .t3 = d3 ∧
+  outflow .s = d1 + d2 + d3 ∧
+  (∀ a ∈ allArcs, xflow a ≤ xflow a)
+
+/-- The fractional cost `cᵀx = Σ_a c_a · x_a`. -/
+def fractionalCost : ℕ := (allArcs.map (fun a => ucost a * xflow a)).foldr (· + ·) 0
+
+/-! ## Unsplittable routings -/
+
+/-- A routing is one path choice per terminal, encoded as `(b1, b2, b3) : Bool³`
+where `b_i = true` selects the long path `Z_i` and `b_i = false` the direct `E_i`. -/
+abbrev Routing := Bool × Bool × Bool
+
+/-- Arcs used by the chosen `s`→`t1` path. -/
+def path1 (b : Bool) : List Arc := if b then [.su, .uv, .vt1] else [.st1]
+/-- Arcs used by the chosen `s`→`t2` path. -/
+def path2 (b : Bool) : List Arc := if b then [.su, .uv, .vw, .wt2] else [.st2]
+/-- Arcs used by the chosen `s`→`t3` path. -/
+def path3 (b : Bool) : List Arc := if b then [.su, .uv, .vw, .wt3] else [.su, .ut3]
+
+/-- Load on arc `a` under routing `r`: the sum of the demands of the terminals
+whose chosen path traverses `a`. -/
+def load (a : Arc) (r : Routing) : ℕ :=
+  (if a ∈ path1 r.1 then d1 else 0) +
+  (if a ∈ path2 r.2.1 then d2 else 0) +
+  (if a ∈ path3 r.2.2 then d3 else 0)
+
+/-- The unit cost of a path (sum of its arcs' unit costs). -/
+def pathCost (p : List Arc) : ℕ := (p.map ucost).foldr (· + ·) 0
+
+/-- Cost of a routing: `Σ_i d_i · c(chosen path_i)`. -/
+def routingCost (r : Routing) : ℕ :=
+  d1 * pathCost (path1 r.1) + d2 * pathCost (path2 r.2.1) + d3 * pathCost (path3 r.2.2)
+
+/-- A routing is **capacity-good** if every arc load stays within `x_a + D`
+(capacity violation at most the maximum demand `D`). -/
+def CapGood (r : Routing) : Prop := ∀ a ∈ allArcs, load a r ≤ xflow a + D
+
+/-! ## The three verified facts (plain kernel `decide`, 0 axioms) -/
+
+/-- **(1)** The fractional flow has cost `cᵀx = 58`. -/
+theorem fractional_cost_eq : fractionalCost = 58 := by decide
+
+/-- **(2)** The fractional flow is feasible (conservation, demands, capacities). -/
+theorem fractional_feasible : FractionalFeasible := by decide
+
+/-- **(3a)** Every capacity-good unsplittable routing costs at least `60`. -/
+theorem every_capgood_routing_costly : ∀ r : Routing, CapGood r → 60 ≤ routingCost r := by
+  decide
+
+/-- **(3b)** The bound is tight: the routing `(E, E, Z) = (false, false, true)` is
+capacity-good and has cost exactly `60`, so the unsplittable optimum is `60`. -/
+theorem capgood_optimum_is_60 :
+    ∃ r : Routing, CapGood r ∧ routingCost r = 60 :=
+  ⟨(false, false, true), by decide, by decide⟩
+
+/-- **The DGG separation.** For this explicit instance the fractional optimum is
+`58` while every capacity-good (violation ≤ `D`) unsplittable routing costs `≥ 60`,
+with `60` attained. Hence the unsplittable optimum `60` strictly exceeds the
+fractional cost `58` even allowing a capacity violation up to the maximum demand —
+separating the exact-`D` DGG cost guarantee. -/
+theorem dgg_separation :
+    fractionalCost = 58 ∧ FractionalFeasible ∧
+    (∀ r : Routing, CapGood r → 60 ≤ routingCost r) ∧
+    (∃ r : Routing, CapGood r ∧ routingCost r = 60) ∧
+    fractionalCost < 60 :=
+  ⟨fractional_cost_eq, fractional_feasible, every_capgood_routing_costly,
+    capgood_optimum_is_60, by decide⟩
+
+-- Axiom audit: plain `decide` (NOT `native_decide`) ⇒ foundational axioms only
+-- (propext / Quot.sound); no `Lean.ofReduceBool`, no `sorryAx`.
+#print axioms dgg_separation
+
+end DinitzGargGoemans

--- a/src/data/proofs/dinitz-garg-goemans-counterexample/annotations.json
+++ b/src/data/proofs/dinitz-garg-goemans-counterexample/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-dgg-docstring",
+    "proofId": "dinitz-garg-goemans-counterexample",
+    "range": { "startLine": 1, "endLine": 69 },
+    "type": "concept",
+    "title": "A finite certificate separating the exact-D DGG cost bound",
+    "content": "The Dinitz–Garg–Goemans (DGG) conjecture (1999) concerns single-source unsplittable flow: route each demand along ONE path, given a fractional flow, while (in the exact-D form) preserving cost with capacity violation ≤ D = dmax. This file encodes one explicit instance (7 vertices, 9 arcs, demands d1=15,d2=10,d3=15, D=15) in pure integer arithmetic and proves three finite facts by plain kernel `decide`: the fractional flow is feasible with cost cᵀx = 58; every unsplittable routing with arc loads ≤ x_a + D costs ≥ 60; and 60 is attained. So the capacity-good unsplittable optimum (60) strictly exceeds the fractional cost (58). AUDIT CAVEAT: the finite facts are solid and independently re-derived, but the primary source (Jan 2026) still lists DGG as OPEN and the counterexample awaits independent audit — so this entry proves only the self-contained separation and does NOT claim to settle DGG.",
+    "mathContext": "Rybin (2026, via GPT-5.6 Pro): fractional cost 58 vs capacity-good unsplittable optimum 60 for one explicit instance.",
+    "significance": "critical",
+    "relatedConcepts": ["unsplittable flow", "DGG conjecture", "fractional relaxation", "capacity violation"],
+    "prerequisites": ["network flow", "combinatorial optimization"]
+  },
+  {
+    "id": "ann-dgg-instance",
+    "proofId": "dinitz-garg-goemans-counterexample",
+    "range": { "startLine": 73, "endLine": 92 },
+    "type": "definition",
+    "title": "The instance: nine arcs with fractional loads and unit costs",
+    "content": "`Arc` is a `deriving DecidableEq` enum of the nine arcs; `allArcs` lists them for bounded quantification. `xflow` gives the fractional load x_a on each arc, which also serves as its capacity u_a = x_a. `ucost` gives the unit cost c_a. The nonzero costs are s→t1 (c=2), s→t2 (c=3), u→t3 (c=2); all other arcs have cost 0. Encoding arcs as a small enum with integer maps keeps everything directly kernel-reducible, so `decide` can evaluate loads, costs, and conservation without any external solver.",
+    "mathContext": "s→t1 (10,2), s→t2 (6,3), s→u (24,0), u→t3 (10,2), u→v (14,0), v→t1 (5,0), v→w (9,0), w→t2 (4,0), w→t3 (5,0).",
+    "significance": "key",
+    "relatedConcepts": ["directed graph", "arc capacity", "unit cost", "DecidableEq"],
+    "prerequisites": ["network flow", "enumerated types"]
+  },
+  {
+    "id": "ann-dgg-feasibility",
+    "proofId": "dinitz-garg-goemans-counterexample",
+    "range": { "startLine": 94, "endLine": 136 },
+    "type": "definition",
+    "title": "Nodes, conservation, and fractional feasibility",
+    "content": "`Node` enumerates the seven vertices; `tail`/`head` give each arc's endpoints; `inflow`/`outflow` sum the fractional flow entering/leaving a node. `FractionalFeasible` (marked @[reducible] so `decide` sees its decidable body) bundles: conservation at internal nodes u,v,w (inflow = outflow), delivery of each demand at its terminal (inflow t_i = d_i), emission of the total demand at the source (outflow s = d1+d2+d3), and the arc-capacity check x_a ≤ x_a (u_a = x_a, trivially met). `fractionalCost` = Σ_a c_a·x_a. Numerically: u 24=10+14, v 14=5+9, w 9=4+5, terminals receive 15/10/15, source emits 40, and cᵀx = 2·10+3·6+2·10 = 58.",
+    "mathContext": "A valid s-rooted flow of the three demands with total cost 58.",
+    "significance": "key",
+    "relatedConcepts": ["flow conservation", "feasibility", "reducibility", "bounded quantifier"],
+    "prerequisites": ["network flow", "decidable quantifiers"]
+  },
+  {
+    "id": "ann-dgg-routings",
+    "proofId": "dinitz-garg-goemans-counterexample",
+    "range": { "startLine": 138, "endLine": 168 },
+    "type": "definition",
+    "title": "Unsplittable routings, arc loads, and the capacity rule",
+    "content": "A `Routing` is `Bool × Bool × Bool`: bit i selects terminal i's path — false = direct E_i, true = long Z_i. `path1/2/3` list the arcs of each choice (E1=[s→t1], Z1=[s→u,u→v,v→t1], etc.). `load a r` sums the demands of the terminals whose chosen path traverses arc a. `routingCost r` = Σ_i d_i·c(path_i); each E_i costs d_i·c(E_i) = 30 and each Z_i costs 0. `CapGood r` (marked @[reducible]) requires every arc load ≤ x_a + D — a capacity violation of at most the maximum demand D = 15. The rule forbids any two long paths (Z2+Z3 overloads v→w 25>24; Z1+Z3 overloads u→v 30>29; Z1+Z2 overloads s→u 40>39).",
+    "mathContext": "8 routings; at most one Z_i is capacity-good, so ≥2 cost-30 direct paths are forced.",
+    "significance": "critical",
+    "relatedConcepts": ["unsplittable routing", "arc congestion", "capacity violation", "path selection"],
+    "prerequisites": ["network flow", "boolean encoding"]
+  },
+  {
+    "id": "ann-dgg-verified",
+    "proofId": "dinitz-garg-goemans-counterexample",
+    "range": { "startLine": 170, "endLine": 205 },
+    "type": "theorem",
+    "title": "The separation, verified by kernel `decide` (0 axioms)",
+    "content": "`fractional_cost_eq` proves cᵀx = 58; `fractional_feasible` proves the flow is feasible; `every_capgood_routing_costly` proves — exhaustively over all 8 routings — that every capacity-good routing costs ≥ 60; `capgood_optimum_is_60` exhibits (E,E,Z) attaining cost 60; and `dgg_separation` packages 58 < 60, the strict gap between the fractional optimum and the capacity-good unsplittable optimum. All are discharged by plain kernel `decide` (NOT native_decide), so `#print axioms dgg_separation` lists only propext / Classical.choice / Quot.sound — no Lean.ofReduceBool, no sorryAx. Per the Axiom Integrity Policy those foundational axioms don't count, so the entry is genuinely axiom-free / verified. (Separately: the *interpretation* that this refutes DGG is announced but pending independent audit — this file proves only the finite separation.)",
+    "mathContext": "Fractional optimum 58 < 60 = capacity-good unsplittable optimum ⟹ the exact-D DGG cost bound is separated for this instance.",
+    "significance": "critical",
+    "relatedConcepts": ["decide", "exhaustive kernel verification", "0-axiom proof", "cost separation"],
+    "prerequisites": ["decidable propositions", "Fintype quantifiers"]
+  }
+]

--- a/src/data/proofs/dinitz-garg-goemans-counterexample/meta.json
+++ b/src/data/proofs/dinitz-garg-goemans-counterexample/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "dinitz-garg-goemans-counterexample",
+  "title": "Dinitz–Garg–Goemans Separation: a Finite Unsplittable-Flow Certificate (machine-verified)",
+  "slug": "dinitz-garg-goemans-counterexample",
+  "description": "A recently-announced (Rybin 2026, found with GPT-5.6 Pro), machine-verified finite certificate that separates the exact-D cost bound for single-source unsplittable flow — the quantity at the heart of the ~30-year-old Dinitz–Garg–Goemans (DGG) conjecture. For one explicit instance (7 vertices, 9 arcs, 3 demands d1=15, d2=10, d3=15, so D=dmax=15) with fractional loads x_a and unit costs c_a, this file encodes everything in pure integer arithmetic and discharges three facts by plain kernel `decide` (NOT native_decide), so the entry is 0-axiom / verified: (1) the given fractional flow is feasible (conservation + capacities) with cost cᵀx = 58; (2) every unsplittable routing whose arc loads stay within x_a + D (capacity violation ≤ D) costs ≥ 60; (3) that bound is attained, so the unsplittable optimum is exactly 60 > 58. AUDIT CAVEAT: this documents the finite separation certificate, which is solid and independently re-derived; the primary source (Jan 2026) still lists the DGG conjecture as OPEN, and the counterexample awaits independent audit — so the 'refutes DGG Conjecture 1.3' interpretation is deliberately NOT claimed here.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://x.com/DmitryRybin1/status/2079904005652893709",
+    "date": "2026-07-22",
+    "status": "verified",
+    "tags": [
+      "combinatorial-optimization",
+      "unsplittable-flow",
+      "network-flow",
+      "counterexample",
+      "finite-verification",
+      "decide",
+      "ai-assisted",
+      "verified"
+    ],
+    "proofRepoPath": "Proofs/DinitzGargGoemans.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 205,
+    "dateAdded": "07/22/26",
+    "mathlibDependencies": [
+      {
+        "theorem": "Fintype.decidableForallFintype",
+        "description": "Decidability of the universally-quantified statement over all routings (Bool × Bool × Bool is a Fintype), enabling the exhaustive `decide` over the 8 routings.",
+        "module": "Mathlib.Data.Fintype.Basic"
+      },
+      {
+        "theorem": "List.decidableBAll",
+        "description": "Decidability of bounded ∀ over the list of nine arcs (`∀ a ∈ allArcs, …`), used for the capacity-good predicate and the feasibility capacity check.",
+        "module": "Mathlib.Data.List.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Arc / Node: the explicit instance encoded as two small `deriving DecidableEq` enums (9 arcs, 7 nodes) with `xflow` (fractional load x_a = capacity u_a), `ucost` (unit cost c_a), and `tail`/`head` endpoint maps — a fully integer, kernel-reducible model.",
+      "fractional_cost_eq: `decide` proof that the fractional flow has cost cᵀx = Σ c_a·x_a = 58.",
+      "fractional_feasible: `decide` proof that the fractional flow conserves at internal nodes u,v,w, delivers d1,d2,d3 at the terminals, emits d1+d2+d3 at the source, and respects capacities u_a = x_a.",
+      "every_capgood_routing_costly: `decide` proof (exhaustive over the 8 routings Bool³) that every routing with arc loads ≤ x_a + D costs ≥ 60.",
+      "capgood_optimum_is_60 + dgg_separation: the routing (E,E,Z) attains cost 60, packaging the strict separation 58 < 60 between the fractional optimum and the capacity-good unsplittable optimum."
+    ],
+    "assumptions": "None — 0 axioms. All three facts are discharged by plain kernel `decide`, NOT `native_decide`, so `#print axioms dgg_separation` lists only the foundational axioms `propext` / `Classical.choice` / `Quot.sound` — no `Lean.ofReduceBool`, no `sorryAx`, no literal `axiom` declarations. Per the project's Axiom Integrity Policy, those three foundational axioms do not count as assumptions (only `Lean.ofReduceBool` / `sorryAx` would), so the entry is genuinely axiom-free / `verified`. The enumeration is tiny (8 routings, 9 arcs, integers ≤ 40), so the trusted kernel evaluates it directly — the compiler-trust step of `native_decide` is unnecessary. SEPARATE from the axiom question: the *mathematical interpretation* that this refutes the DGG conjecture is announced but NOT independently audited (the Jan-2026 primary source still lists DGG as open); this file proves only the self-contained finite separation for this explicit instance and makes no claim to settle DGG.",
+    "theoremCount": 4,
+    "definitionCount": 13,
+    "lastUpdated": "2026-07-22"
+  },
+  "overview": {
+    "historicalContext": "In the single-source unsplittable flow problem, a source s must route each of several demands d_i to its terminal t_i along a *single* path (unsplittable), given that a fractional (splittable) flow of the same demands exists. Dinitz, Garg and Goemans (Combinatorica, 1999) studied how much congestion and cost an unsplittable routing must incur relative to the fractional optimum; a central conjecture (in the exact-D form) asserts the cost can be preserved while violating each arc capacity by at most the maximum demand D = dmax. That question stood open for roughly three decades. In 2026 Dmitry Rybin announced (with GPT-5.6 Pro assistance) a concrete finite instance whose capacity-good unsplittable optimum strictly exceeds its fractional cost, separating the exact-D cost bound. Because a counterexample is a *finite* object — one fixed graph, finitely many demands, finitely many routings — the core arithmetic claim is verifiable by finite computation, which is exactly what this entry does in Lean.",
+    "problemStatement": "For the explicit instance (vertices s,u,v,w,t1,t2,t3; demands d1=15,d2=10,d3=15, D=15; arcs with the given fractional loads x_a and unit costs c_a), show that the fractional flow is feasible with cost 58, yet every unsplittable routing keeping each arc load within x_a + D costs at least 60 — and that 60 is attained. Hence the capacity-good unsplittable optimum (60) strictly exceeds the fractional cost (58), separating the exact-D DGG cost guarantee for this instance.",
+    "proofStrategy": "Encode the nine arcs and seven nodes as `deriving DecidableEq` enums, with integer maps `xflow` (= capacity), `ucost`, `tail`, `head`. Feasibility is a decidable conjunction: `inflow = outflow` at internal nodes, `inflow = d_i` at terminals, `outflow s = Σ d_i`, and `x_a ≤ x_a` for capacities. A routing is a triple `(b1,b2,b3) : Bool³` selecting the direct path E_i (b=false) or long path Z_i (b=true) per terminal; `load a r` sums the demands of terminals whose chosen path uses arc a, and `CapGood r := ∀ a ∈ allArcs, load a r ≤ x_a + D`. Mark `FractionalFeasible` and `CapGood` `@[reducible]` so `decide`'s instance synthesis sees the bounded quantifiers, then discharge `fractionalCost = 58`, `FractionalFeasible`, and `∀ r, CapGood r → 60 ≤ routingCost r` by plain kernel `decide` — the last an exhaustive check over the 8 routings.",
+    "keyInsights": [
+      "**A counterexample is finite and decidable.** Unlike proving a conjecture, refuting one here reduces to a fixed finite object: 7 vertices, 9 arcs, 3 demands, 6 candidate paths, 8 routings, all integer. The whole separation becomes a small `decide`, kernel-checkable with no external solver and no compiler-trust axiom.",
+      "**At most one long path can be used.** The capacity rule y_a ≤ x_a + D forbids any two of Z1,Z2,Z3 simultaneously: Z2+Z3 overloads v→w (25>24), Z1+Z3 overloads u→v (30>29), Z1+Z2 overloads s→u (40>39, since terminal 3 always traverses s→u). So every capacity-good routing uses ≥2 of the cost-30 direct paths, forcing cost ≥ 60.",
+      "**The separation is 58 vs 60.** The fractional flow costs cᵀx = 2·10 + 3·6 + 2·10 = 58; the capacity-good unsplittable optimum is exactly 60 (attained e.g. by (E,E,Z)). The strict gap 58 < 60 is the certificate.",
+      "**Kernel `decide`, not `native_decide`.** The enumeration is tiny, so the trusted Lean kernel evaluates it directly, leaving only propext / Classical.choice / Quot.sound in `#print axioms` — a strictly stronger guarantee than a `native_decide` certificate (which would add the compiler-trust axiom `Lean.ofReduceBool`).",
+      "**Provable content vs interpretation.** The Lean statement — 'for this explicit instance the fractional cost is 58 and every capacity-good unsplittable routing costs ≥ 60' — is true and machine-checkable regardless of any external audit. The further reading 'this refutes DGG Conjecture 1.3' is announced but pending independent audit (the Jan-2026 primary source still lists DGG as open), so the entry deliberately proves only the finite separation and hedges the interpretation."
+    ],
+    "prerequisites": [
+      "Single-source unsplittable flow and the fractional relaxation",
+      "Flow conservation and arc capacities",
+      "Decidability of bounded quantifiers over Fintype / List (`decide`)",
+      "The DGG conjecture (Dinitz–Garg–Goemans 1999) in its exact-D cost form"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble: the instance, the claim, and the audit caveat",
+      "startLine": 1,
+      "endLine": 69,
+      "summary": "Docstring: the DGG single-source unsplittable-flow question, the explicit instance (arcs with x_a/c_a, demands, the six E/Z paths), the three facts proved (fractional cost 58, feasibility, every capacity-good routing ≥ 60), that all use plain kernel `decide` (0 axioms — no Lean.ofReduceBool), and the audit caveat: the finite facts are solid but the 'refutes DGG' interpretation is pending independent audit (primary source still lists DGG as open).",
+      "mathContext": "Rybin (2026, via GPT-5.6 Pro): a finite instance separating the exact-D DGG cost bound — fractional cost 58 vs capacity-good unsplittable optimum 60."
+    },
+    {
+      "id": "instance",
+      "title": "The instance: arcs, capacities, unit costs",
+      "startLine": 73,
+      "endLine": 92,
+      "summary": "The nine arcs as a `deriving DecidableEq` enum `Arc`, listed in `allArcs`; `xflow` gives the fractional load x_a (= capacity u_a) and `ucost` the unit cost c_a of each arc.",
+      "mathContext": "Arcs s→t1 (10,2), s→t2 (6,3), s→u (24,0), u→t3 (10,2), u→v (14,0), v→t1 (5,0), v→w (9,0), w→t2 (4,0), w→t3 (5,0)."
+    },
+    {
+      "id": "conservation",
+      "title": "Nodes and the fractional flow's feasibility",
+      "startLine": 94,
+      "endLine": 136,
+      "summary": "The seven vertices as an enum `Node`; `tail`/`head` endpoint maps; `inflow`/`outflow` per node; demands d1=15,d2=10,d3=15 and D=15; `FractionalFeasible` (reducible) asserting conservation at u,v,w, delivery of each demand at its terminal, emission of Σd_i at s, and the trivial capacity check x_a ≤ x_a; and `fractionalCost = Σ c_a·x_a`.",
+      "mathContext": "Conservation: u 24=10+14, v 14=5+9, w 9=4+5; terminals receive 15,10,15; source emits 40; cᵀx = 58."
+    },
+    {
+      "id": "routings",
+      "title": "Unsplittable routings, loads, and the capacity rule",
+      "startLine": 138,
+      "endLine": 168,
+      "summary": "A `Routing` is `Bool³` selecting E_i (direct) or Z_i (long) per terminal; `path1/2/3` give the arcs of each choice; `load a r` sums the demands of terminals whose chosen path uses arc a; `routingCost` = Σ d_i·c(path_i); `CapGood` (reducible) requires every arc load ≤ x_a + D.",
+      "mathContext": "E_i costs d_i·c(E_i) = 30 each, Z_i costs 0; capacity rule y_a ≤ x_a + D allows at most one Z_i."
+    },
+    {
+      "id": "verified",
+      "title": "The three verified facts and the separation (0 axioms)",
+      "startLine": 170,
+      "endLine": 205,
+      "summary": "`fractional_cost_eq` (=58), `fractional_feasible`, `every_capgood_routing_costly` (∀ capacity-good routing, cost ≥ 60, exhaustive over the 8 routings), `capgood_optimum_is_60` ((E,E,Z) attains 60), and `dgg_separation` packaging 58 < 60 — all by plain kernel `decide`. `#print axioms dgg_separation` confirms only propext / Classical.choice / Quot.sound (no Lean.ofReduceBool, no sorryAx).",
+      "mathContext": "Fractional optimum 58 < 60 = capacity-good unsplittable optimum, separating the exact-D DGG cost bound for this instance."
+    }
+  ],
+  "conclusion": {
+    "summary": "For one explicit single-source instance, a machine-verified finite certificate: the fractional flow is feasible with cost 58, yet every unsplittable routing keeping each arc load within x_a + D (capacity violation ≤ D = dmax = 15) costs at least 60, with 60 attained. The strict gap 58 < 60 separates the exact-D DGG cost guarantee. All facts are discharged by plain kernel `decide`, so the entry is 0-axiom / verified (no Lean.ofReduceBool, no sorry).",
+    "implications": "Provides a fully kernel-checkable reproduction of the finite arithmetic behind Rybin's 2026 announced counterexample to the exact-D form of the Dinitz–Garg–Goemans conjecture. The Lean content — the separation for this specific instance — is solid and independent of any external audit.",
+    "openQuestions": [
+      "Independent audit of the interpretation: does this instance formally refute DGG Conjecture 1.3 as stated in the primary source? The Jan-2026 source still lists DGG as open; the announcement itself asks for independent audit before treating the refutation as established. This entry deliberately does not claim to settle DGG.",
+      "Formalize the exact DGG conjecture statement (the cost-plus-congestion bound) and connect it to this instance, so the refutation — if the audit confirms it — becomes a single machine-checked implication rather than a separation of one derived quantity.",
+      "Minimality: is this the smallest instance separating the exact-D cost bound, and what is the true worst-case cost ratio for capacity-good unsplittable flow?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Rybin, D. (@DmitryRybin1)",
+      "title": "Announced finite counterexample separating the exact-D cost bound for single-source unsplittable flow (found with GPT-5.6 Pro)",
+      "year": "2026",
+      "venue": "X (Twitter) announcement + shared ChatGPT transcript",
+      "note": "Source of the explicit instance formalized here: https://x.com/DmitryRybin1/status/2079904005652893709 . The announcement notes the counterexample should be independently audited before being treated as an established refutation, and that the latest primary source (Jan 2026) still lists the DGG conjecture as open."
+    },
+    {
+      "authors": "Dinitz, Y.; Garg, N.; Goemans, M. X.",
+      "title": "On the single-source unsplittable flow problem",
+      "year": "1999",
+      "venue": "Combinatorica 19(1), 17–41",
+      "note": "The origin of the DGG conjecture on cost and congestion of unsplittable flow relative to the fractional optimum; the exact-D cost form is the guarantee this finite certificate separates."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib.Data.Fintype.Basic and Mathlib.Data.List.Basic (decidable quantifiers, `decide`)",
+      "year": "2024",
+      "note": "Provides the Fintype/List decidability instances that make feasibility, the capacity-good predicate, and the exhaustive routing check computable by plain `decide` over the finite instance, yielding a 0-axiom kernel verification."
+    }
+  ],
+  "crossReferences": [],
+  "mainTheorems": [
+    {
+      "name": "dgg_separation",
+      "statement": "fractionalCost = 58 ∧ FractionalFeasible ∧ (∀ r : Routing, CapGood r → 60 ≤ routingCost r) ∧ (∃ r : Routing, CapGood r ∧ routingCost r = 60) ∧ fractionalCost < 60",
+      "description": "The finite DGG separation for this instance: fractional optimum 58, every capacity-good unsplittable routing costs ≥ 60 (with 60 attained), so 58 < 60. Machine-verified by plain kernel `decide` (0 axioms)."
+    },
+    {
+      "name": "fractional_cost_eq",
+      "statement": "fractionalCost = 58",
+      "description": "The exhibited fractional flow has cost cᵀx = Σ c_a·x_a = 58 (decide)."
+    },
+    {
+      "name": "fractional_feasible",
+      "statement": "FractionalFeasible",
+      "description": "The fractional flow conserves at internal nodes, delivers each demand at its terminal, emits the total demand at the source, and respects the arc capacities u_a = x_a (decide)."
+    },
+    {
+      "name": "every_capgood_routing_costly",
+      "statement": "∀ r : Routing, CapGood r → 60 ≤ routingCost r",
+      "description": "Every unsplittable routing whose arc loads stay within x_a + D (capacity violation ≤ D) costs at least 60 — exhaustive over the 8 routings (decide)."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## What

Formalizes the recently-announced (Rybin 2026, found with GPT-5.6 Pro) finite counterexample separating the exact-`D` cost bound for single-source unsplittable flow — the quantity at the heart of the ~30-year-old Dinitz–Garg–Goemans (DGG) conjecture — as a machine-verified gallery entry.

Closes #41675

## The instance (encoded exactly as given in the issue)

7 vertices `s,u,v,w,t1,t2,t3`; demands `d1=15, d2=10, d3=15`, so `D=dmax=15`. Nine arcs with fractional loads `x_a`/unit costs `c_a` (capacities `u_a=x_a`); each terminal has exactly two `s→t_i` paths (direct `E_i`, long `Z_i`), so `2³=8` routings.

## Theorems proved (all `decide`)

- `fractional_cost_eq` — the fractional flow has cost `cᵀx = 58`.
- `fractional_feasible` — the fractional flow conserves at internal nodes `u,v,w`, delivers each demand at its terminal, emits `Σd_i` at the source, and respects capacities `u_a = x_a`.
- `every_capgood_routing_costly` — **every** unsplittable routing whose arc loads stay within `x_a + D` (capacity violation ≤ `D`) costs `≥ 60` (exhaustive over the 8 routings).
- `capgood_optimum_is_60` — the routing `(E,E,Z)` attains cost `60`, so the capacity-good unsplittable optimum is exactly `60`.
- `dgg_separation` — packages the strict separation `58 < 60`.

## decide vs native_decide / axiom status

Uses **plain kernel `decide`** throughout (NOT `native_decide`). The enumeration is tiny (8 routings, 9 arcs, integers ≤ 40), so the trusted kernel reduces it directly.

`#print axioms dgg_separation` → `[propext, Classical.choice, Quot.sound]` — the three foundational axioms only. **No `Lean.ofReduceBool`, no `sorryAx`.** Per the Axiom Integrity Policy those foundational axioms don't count, so the entry is genuinely **axiom-free / `verified`** (`axiomCount: 0`, badge `original`).

## Build verification

- `./proofs/scripts/docker-build.sh Proofs.DinitzGargGoemans` → **Built successfully**, 0 sorries.
- `pnpm build` → gallery integrates, bundle budget OK (regenerated ~2000 data files were discarded as noise; only the new proof + gallery entry are committed).

## Audit caveat (important — reflected in prose)

This documents a **recently-announced finite certificate pending independent audit**, NOT a settled theorem. The finite Lean facts (the separation for this explicit instance) are solid and independently re-derived. The primary source (Jan 2026) still lists the DGG conjecture as **open**, and the announcement itself asks for independent audit before treating it as an established refutation — so the entry proves only the self-contained separation and deliberately does **not** claim to refute DGG Conjecture 1.3. Source cited: the X announcement + that it was found via GPT-5.6 Pro (2026).

## Files

- `proofs/Proofs/DinitzGargGoemans.lean`
- `src/data/proofs/dinitz-garg-goemans-counterexample/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
