### PR TITLE
Enrich abel-ruffini-galois-extensions-oq-04-oq-01: cover header docstring (lines 1-43)

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01/meta.json
@@ -76,6 +76,13 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Setup and Statement of the Bridge",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Module docstring states the target: prove IsMaxNorm H K ↔ IsSimpleGroup (K ⧸ H.subgroupOf K) in the K = ⊤ case, axiom-free, via the correspondence theorem; then imports Mathlib and opens the ambient group G."
+    },
+    {
       "id": "predicate",
       "title": "The Maximal-Normal Predicate",
       "startLine": 44,


### PR DESCRIPTION
Adds a `header` section to `sections[]` covering lines 1-43 of `AbelRuffiniGaloisExtensionsOQ04OQ01.lean` (the module docstring stating the IsMaxNorm ↔ IsSimpleGroup bridge this file proves, plus imports/namespace/variable setup), which was previously uncovered by any section or annotation. No other fields touched; file stays well under size caps (~10.8 KB).