### PR TITLE
Enrich abel-ruffini-galois-extensions-oq-04-oq-02: cover header docstring (lines 1-39)

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-02/meta.json
@@ -120,6 +120,13 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Setup: the Module Instance of Jordan–Hölder",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Module docstring explains that Mathlib already supplies JordanHolderLattice (Submodule R M) — IsMaximal = the covering relation ⋖, Iso = a linear equivalence of successive quotients — so this file specializes CompositionSeries.jordan_holder to that instance; then imports Mathlib and opens the ambient ring/module variables and namespace."
+    },
+    {
       "id": "main-theorem",
       "title": "Jordan–Hölder for Modules",
       "startLine": 46,


### PR DESCRIPTION
Adds a `header` section to `sections[]` covering lines 1-39 of `AbelRuffiniGaloisExtensionsOQ04OQ02.lean` (the module docstring explaining that Mathlib already supplies `JordanHolderLattice (Submodule R M)`, plus imports/open/variable/namespace setup), which was previously uncovered by any section or annotation. No other fields touched; file stays well under size caps (~14 KB).