### PR TITLE
Enrich abel-ruffini-oq-04-oq-01-oq-01: cover header docstring (lines 1-56)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-01/meta.json
@@ -44,6 +44,13 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Correcting the Parent's Open Question",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Module docstring lays out the correction in full: the parent's claim that x⁵ − x − 1 has 3 real roots is FALSE (it has exactly 1, so 2 complex-conjugate pairs), which breaks the parent's transposition argument; sketches the correct route (Dedekind mod 2 gives cycle type (2,3)) and lists precisely what is machine-checked below versus left open, before importing Mathlib and opening the namespace."
+    },
+    {
       "id": "witness-polynomial",
       "title": "The witness polynomial and its shape",
       "startLine": 57,


### PR DESCRIPTION
Adds a `header` section to `sections[]` covering lines 1-56 of `AbelRuffiniOQ04OQ01OQ01.lean` (the module docstring, which corrects a false claim in the parent entry about the number of real roots of x⁵ - x - 1 and lists what is/isn't machine-checked), which was previously uncovered by any section or annotation. No other fields touched; file stays well under size caps (~13 KB).