### PR TITLE
audit: fix buffons-needle-oq-01-oq-01 overclaim and inverted cross-reference

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "buffons-needle-oq-01-oq-01",
   "title": "Buffon-Barbier: Angular Average and the Smooth Curve Formula",
   "slug": "buffons-needle-oq-01-oq-01",
-  "description": "Proves the Buffon-Barbier smooth curve theorem (E[crossings] = 2L/(πd)) from first principles using the angular average identity ∫_0^π |a sin θ + b cos θ| dθ = 2√(a²+b²). This resolves the open question in buffons-needle-oq-01 by replacing the axiomatic smooth case with a concrete verified proof.",
+  "description": "Proves the Buffon-Barbier smooth curve theorem (E[crossings] = 2L/(πd)) from first principles using the angular average identity ∫_0^π |a sin θ + b cos θ| dθ = 2√(a²+b²), conditional on an explicit interval-integrability hypothesis (hInnerInt). This makes progress on the open question posed by the axioms in buffons-noodle by giving a concrete, proved definition and formula in place of the axiomatized smoothExpectedCrossings — the remaining hInnerInt gap is closed for C¹ curves in buffons-needle-oq-01, and the buffons-noodle axioms themselves are not modified by this file.",
   "meta": {
     "author": "Barbier (1860); Lean formalization 2026",
     "sourceUrl": "https://en.wikipedia.org/wiki/Buffon%27s_noodle",
@@ -18,7 +18,7 @@
       "angular-average",
       "integral-geometry",
       "cauchy-crofton",
-      "open-question-resolved"
+      "conditional-on-integrability"
     ],
     "badge": "original",
     "sorries": 0,
@@ -77,9 +77,9 @@
     "definitionCount": 2
   },
   "overview": {
-    "historicalContext": "In buffons-needle-oq-01 (Buffon's Noodle), the smooth curve case of the Buffon-Barbier theorem was left as an open question, formalized as an axiom. The question was: can the axiom `buffon_noodle_smooth_eq` be derived from Mathlib's arc length theory?\n\nThis file answers YES. The key insight is the **angular average identity**:\n  ∫_0^π |a sin θ + b cos θ| dθ = 2√(a² + b²)\n\nThis is the fundamental reason why the crossing probability depends only on arc length and not on the shape of the curve. For any direction (a, b) representing the tangent vector γ'(t), the integral of |crossings contribution| over all angles θ gives exactly 2‖γ'(t)‖. Integrating over t gives 2L/(πd).\n\nThe proof uses Complex.arg to find the rotation angle φ such that a sin θ + b cos θ = √(a²+b²) · sin(θ + φ), then applies the rotation-invariant identity ∫_0^π |sin(θ + c)| dθ = 2.",
-    "problemStatement": "**Open Question from buffons-needle-oq-01**: Can the smooth curve axiom\n  `buffon_noodle_smooth_eq : smoothExpectedCrossings γ a b d = 2 * arcLength(γ) / (π * d)`\nbe proved from Mathlib's arc length theory?\n\n**Theorem (Buffon-Barbier, 1860)**: For any smooth planar curve γ : [a,b] → ℝ² with arc length L, when dropped randomly on a floor with parallel lines (spacing d), the expected number of crossings is:\n  E[crossings] = 2L / (πd)\n\n**Answer**: YES — proved here using the angular average theorem and Fubini's theorem.",
-    "text": "Proves the Buffon-Barbier smooth curve theorem (E[crossings] = 2L/(πd)) from first principles using the angular average identity ∫_0^π |a sin θ + b cos θ| dθ = 2√(a²+b²). This resolves the open question in buffons-needle-oq-01 by replacing the axiomatic smooth case with a concrete verified proof.",
+    "historicalContext": "In buffons-noodle (BuffonsNoodle.lean), the smooth curve case of the Buffon-Barbier theorem was left as an open question, formalized as an axiom. The question was: can the axiom `buffon_noodle_smooth_eq` be derived from Mathlib's arc length theory?\n\nThis file answers YES. The key insight is the **angular average identity**:\n  ∫_0^π |a sin θ + b cos θ| dθ = 2√(a² + b²)\n\nThis is the fundamental reason why the crossing probability depends only on arc length and not on the shape of the curve. For any direction (a, b) representing the tangent vector γ'(t), the integral of |crossings contribution| over all angles θ gives exactly 2‖γ'(t)‖. Integrating over t gives 2L/(πd).\n\nThe proof uses Complex.arg to find the rotation angle φ such that a sin θ + b cos θ = √(a²+b²) · sin(θ + φ), then applies the rotation-invariant identity ∫_0^π |sin(θ + c)| dθ = 2.",
+    "problemStatement": "**Open Question from buffons-noodle**: Can the smooth curve axiom\n  `buffon_noodle_smooth_eq : smoothExpectedCrossings γ a b d = 2 * arcLength(γ) / (π * d)`\nbe proved from Mathlib's arc length theory?\n\n**Theorem (Buffon-Barbier, 1860)**: For any smooth planar curve γ : [a,b] → ℝ² with arc length L, when dropped randomly on a floor with parallel lines (spacing d), the expected number of crossings is:\n  E[crossings] = 2L / (πd)\n\n**Answer (partial)**: proved here for a concrete `concreteSmoothExpectedCrossings` definition, conditional on an explicit interval-integrability hypothesis (`hInnerInt`) plus the angular average theorem; `hInnerInt` is discharged for C¹ curves in buffons-needle-oq-01.",
+    "text": "Proves the Buffon-Barbier smooth curve theorem (E[crossings] = 2L/(πd)) from first principles using the angular average identity ∫_0^π |a sin θ + b cos θ| dθ = 2√(a²+b²), conditional on an explicit interval-integrability hypothesis (hInnerInt). This makes progress on the open question posed by buffons-noodle's axioms by giving a concrete, proved formula in place of the axiomatized smoothExpectedCrossings.",
     "proofStrategy": "**Key Identity**: ∫_0^π |a sin θ + b cos θ| dθ = 2√(a² + b²)\n\n**Why this works**:\n- The vector (a sin θ + b cos θ) measures how much the tangent direction (a, b) contributes to crossings for angle θ\n- Averaging over all angles θ ∈ [0, π] gives exactly 2‖(a,b)‖ = 2 times the speed\n- The formula 2L/(πd) follows by integrating over the curve and normalizing by πd\n\n**Proof of angular average** (the heart of the proof):\n1. For (a, b) = (0, 0): both sides = 0 ✓\n2. For (a, b) ≠ (0, 0): Let r = √(a²+b²) and φ = arg(a + bi)\n   - Then cos φ = a/r and sin φ = b/r\n   - So a sin θ + b cos θ = r(sin θ cos φ + cos θ sin φ) = r sin(θ + φ)\n   - Therefore: ∫_0^π |a sin θ + b cos θ| dθ = r ∫_0^π |sin(θ + φ)| dθ = r · 2 = 2r ✓\n\n**Rotation invariance**: ∫_0^π |sin(θ + c)| dθ = 2\n- Change variables u = θ + c: ∫_c^{c+π} |sin u| du\n- Split and use |sin(u+π)| = |sin u| to show ∫_c^{c+π} = ∫_0^π\n- Equals 2 by the basic integral ✓",
     "keyInsights": [
       "The angular average ∫_0^π |a sin θ + b cos θ| dθ = 2√(a²+b²) is the KEY INSIGHT explaining why shape doesn't matter in Buffon's noodle",
@@ -136,12 +136,12 @@
       "title": "Connection to BuffonsNoodle.lean",
       "startLine": 332,
       "endLine": 374,
-      "summary": "Documents how concreteSmoothExpectedCrossings replaces the axiomatic smoothExpectedCrossings from BuffonsNoodle.lean. The open question is fully resolved."
+      "summary": "Documents how concreteSmoothExpectedCrossings could replace the axiomatic smoothExpectedCrossings from BuffonsNoodle.lean. The axioms in BuffonsNoodle.lean are not modified by this file; the remaining hInnerInt gap is closed for C¹ curves in buffons-needle-oq-01."
     }
   ],
   "conclusion": {
-    "summary": "The Buffon-Barbier smooth curve theorem is proved from first principles using the angular average identity. The open question from BuffonsNoodle.lean is resolved: the axiomatic smooth case is not needed. The proof requires only Fubini's theorem (as an explicit hypothesis), not the full co-area formula.",
-    "implications": "**Mathematical Significance**:\n\n**1. Angular Average as the Central Identity**\nThe formula ∫_0^π |a sin θ + b cos θ| dθ = 2√(a²+b²) is the heart of integral geometry. It explains WHY the crossing probability depends only on length: every arc element contributes proportionally to its length, independent of direction.\n\n**2. The Cauchy-Crofton Connection**\nThis proof is a special case of the Cauchy-Crofton formula:\n   measure(lines meeting curve C) = 2 · length(C)\nOur proof gives an elementary verification using only Fubini and the angular average.\n\n**3. Eliminating Axioms**\nThe axiomatic treatment in BuffonsNoodle.lean used:\n  `noncomputable axiom smoothExpectedCrossings`\n  `axiom buffon_noodle_smooth_eq`\nThis file replaces both with proved theorems, improving the formalization.\n\n**4. Technique: Complex.arg for Rotation**\nUsing Complex.arg to find the rotation angle φ = arg(a+bi) is an elegant approach that handles all cases (a=0, a<0, a>0) uniformly through Mathlib's existing arg theory.",
+    "summary": "The Buffon-Barbier smooth curve formula is proved for a concrete `concreteSmoothExpectedCrossings` definition, from first principles using the angular average identity. Fubini's contribution (`hFubini`) is fully discharged internally via `angular_average`; the one remaining explicit hypothesis on the headline theorem `buffon_smooth_full` is interval-integrability (`hInnerInt`), which is not proved in this file — it is discharged for C¹ curves in buffons-needle-oq-01. The axioms in BuffonsNoodle.lean (`smoothExpectedCrossings`, `buffon_noodle_smooth_eq`) are unaffected by this file.",
+    "implications": "**Mathematical Significance**:\n\n**1. Angular Average as the Central Identity**\nThe formula ∫_0^π |a sin θ + b cos θ| dθ = 2√(a²+b²) is the heart of integral geometry. It explains WHY the crossing probability depends only on length: every arc element contributes proportionally to its length, independent of direction.\n\n**2. The Cauchy-Crofton Connection**\nThis proof is a special case of the Cauchy-Crofton formula:\n   measure(lines meeting curve C) = 2 · length(C)\nOur proof gives an elementary verification using only Fubini and the angular average.\n\n**3. Toward Eliminating Axioms**\nThe axiomatic treatment in BuffonsNoodle.lean uses:\n  `noncomputable axiom smoothExpectedCrossings`\n  `axiom buffon_noodle_smooth_eq`\nThis file does not remove those axioms (they remain in BuffonsNoodle.lean); it instead proves an alternative, concrete formula (`concreteSmoothExpectedCrossings = 2L/(πd)`) conditional on `hInnerInt`, providing the building block a future integration could use to retire the axioms.\n\n**4. Technique: Complex.arg for Rotation**\nUsing Complex.arg to find the rotation angle φ = arg(a+bi) is an elegant approach that handles all cases (a=0, a<0, a>0) uniformly through Mathlib's existing arg theory.",
     "openQuestions": [
       "Fully integrate with BuffonsNoodle.lean by removing the axioms and using concreteSmoothExpectedCrossings",
       "Prove the integrability hypothesis (hInnerInt) from smoothness of γ",
@@ -154,12 +154,12 @@
     {
       "targetId": "buffons-needle",
       "relationship": "extends",
-      "description": "Extends the original Buffon's needle formalization by resolving the open question about the smooth curve case"
+      "description": "Extends the original Buffon's needle formalization toward the smooth curve case (via buffons-noodle's axioms)"
     },
     {
       "targetId": "buffons-needle-oq-01",
-      "relationship": "extends",
-      "description": "Directly resolves the open question from buffons-needle-oq-01 by proving the axiomatic smooth case with a concrete verified proof"
+      "relationship": "extended-by",
+      "description": "buffons-needle-oq-01 imports this file (`import Proofs.BuffonsNeedleOQ01OQ01`) and closes this file's remaining hInnerInt gap by proving integrability follows automatically from ContDiff ℝ 1 γ"
     },
     {
       "targetId": "area-of-circle",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `buffons-needle-oq-01-oq-01`

**Problem**: Prose claimed the open question posed by `BuffonsNoodle.lean`'s
axioms (`smoothExpectedCrossings`, `buffon_noodle_smooth_eq`) was fully
"resolved" and "the axiomatic smooth case is not needed" — but:

1. This directly contradicts the file's own `openQuestions[0]`: "Fully
   integrate with BuffonsNoodle.lean by removing the axioms and using
   concreteSmoothExpectedCrossings" — still listed as open in the same
   meta.json.
2. `BuffonsNoodle.lean` still has both axioms untouched; the gallery entry
   for that file (`buffons-noodle`) is correctly badged `axiomatized`/`axiom`
   with `axiomCount: 2` and does not cross-reference this fix.
3. The headline theorem `buffon_smooth_full` carries an unproved explicit
   `hInnerInt` (interval-integrability) hypothesis. `conclusion.summary`
   mislabeled the remaining gap as "Fubini's theorem" — but Fubini
   (`hFubini`) is actually fully discharged internally via
   `hFubini_from_angular_average`; `hInnerInt` is the real, undischarged
   hypothesis, and it isn't mentioned anywhere outside `openQuestions`.
4. The `crossReferences` entry for `buffons-needle-oq-01` claimed *this*
   file "directly resolves the open question from buffons-needle-oq-01" —
   backwards. `BuffonsNeedleOQ01.lean` literally does
   `import Proofs.BuffonsNeedleOQ01OQ01` and its own docstring says it
   "fills the final gap in `BuffonsNeedleOQ01OQ01.lean` by proving that the
   `hInnerInt` integrability condition is automatic" for C¹ curves — i.e.
   `buffons-needle-oq-01` builds on and completes *this* file, not the
   reverse.
5. `historicalContext`/`problemStatement` attributed the axiom-bearing file
   to "buffons-needle-oq-01", but the axioms actually live in the separate
   `buffons-noodle` gallery entry (`BuffonsNoodle.lean`).

## Evidence

- `grep -n axiom proofs/Proofs/BuffonsNoodle.lean` — both axioms present,
  unmodified.
- `head -20 proofs/Proofs/BuffonsNeedleOQ01.lean` — confirms
  `import Proofs.BuffonsNeedleOQ01OQ01` and the "fills the final gap ...
  hInnerInt" docstring.
- `buffon_smooth_full` signature in `BuffonsNeedleOQ01OQ01.lean` — takes
  `hInnerInt` as an explicit hypothesis; does not take `hFubini` (derived
  internally).

## Fix

Corrected `description`, `overview.historicalContext`,
`overview.problemStatement`, `overview.text`, the `connection` section
summary, `conclusion.summary`, `conclusion.implications`, and the
`crossReferences` entry for `buffons-needle-oq-01` to accurately describe
this as a conditional result (explicit `hInnerInt` hypothesis) that makes
progress toward — but does not eliminate — the `BuffonsNoodle.lean` axioms,
with the remaining gap closed downstream in `buffons-needle-oq-01`. Numeric
counts (0 axioms, 0 sorries, badge `original`, status `verified`) were
already accurate and are unchanged.

---
Discovered during gallery integrity audit.