### PR TITLE
audit: mark buffons-needle-oq-01-oq-01 issues-fixed (#41723)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3771,10 +3771,10 @@
       "result": "clean"
     },
     "buffons-needle-oq-01-oq-01": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:34Z",
-      "result": "clean"
+      "lastAudited": "2026-07-22T20:15:47Z",
+      "result": "issues-fixed"
     },
     "buffons-needle-oq-01-oq-01-oq-01": {
       "auditCount": 3,


### PR DESCRIPTION
Tracker update for the audit of `buffons-needle-oq-01-oq-01`, whose overclaim fix is in #41723.