### PR TITLE
Enrich sperner-mathlib4-oq-03: cover header docstring (lines 1-46)

### DIFF
--- a/src/data/proofs/sperner-mathlib4-oq-03/meta.json
+++ b/src/data/proofs/sperner-mathlib4-oq-03/meta.json
@@ -47,6 +47,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Scope: the combinatorial index layer of Sperner→Brouwer",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring naming the five results (fpIndex_eq_boundaryIndex, exists_panchromatic_of_boundaryIndex_ne_zero, boundaryIndex_eq_zero_of_no_panchromatic, the parity dichotomy, the boundaryless corollary) and stating the honesty boundary: this file is only the combinatorial fixed-point-index computation on an abstract CellComplex, not the geometric realization (subdivision, boundary index = 1, compactness) that full topological Brouwer needs.",
+      "mathContext": "Packages Sperner's parity theorem as an index identity $\\mathrm{fpIndex} = \\mathrm{boundaryIndex} \\in \\mathbb{Z}/2$, 0-axiom."
+    },
+    {
       "id": "counts",
       "title": "Panchromatic and Boundary-Door Counts",
       "startLine": 57,


### PR DESCRIPTION
Adds a `header` section covering the module docstring (lines 1-46), which
was previously uncovered by any section or annotation. The docstring names
all five main results and states the honesty boundary (combinatorial index
layer only, not the geometric realization needed for full Brouwer) — real
framing content, not boilerplate.