### PR TITLE
audit: fix theorem/definition counts for dinitz-garg-goemans-counterexample

### DIFF
--- a/src/data/proofs/dinitz-garg-goemans-counterexample/meta.json
+++ b/src/data/proofs/dinitz-garg-goemans-counterexample/meta.json
@@ -44,8 +44,8 @@
       "capgood_optimum_is_60 + dgg_separation: the routing (E,E,Z) attains cost 60, packaging the strict separation 58 < 60 between the fractional optimum and the capacity-good unsplittable optimum."
     ],
     "assumptions": "None — 0 axioms. All three facts are discharged by plain kernel `decide`, NOT `native_decide`, so `#print axioms dgg_separation` lists only the foundational axioms `propext` / `Classical.choice` / `Quot.sound` — no `Lean.ofReduceBool`, no `sorryAx`, no literal `axiom` declarations. Per the project's Axiom Integrity Policy, those three foundational axioms do not count as assumptions (only `Lean.ofReduceBool` / `sorryAx` would), so the entry is genuinely axiom-free / `verified`. The enumeration is tiny (8 routings, 9 arcs, integers ≤ 40), so the trusted kernel evaluates it directly — the compiler-trust step of `native_decide` is unnecessary. SEPARATE from the axiom question: the *mathematical interpretation* that this refutes the DGG conjecture is announced but NOT independently audited (the Jan-2026 primary source still lists DGG as open); this file proves only the self-contained finite separation for this explicit instance and makes no claim to settle DGG.",
-    "theoremCount": 4,
-    "definitionCount": 13,
+    "theoremCount": 5,
+    "definitionCount": 20,
     "lastUpdated": "2026-07-22"
   },
   "overview": {
@@ -160,6 +160,11 @@
       "name": "every_capgood_routing_costly",
       "statement": "∀ r : Routing, CapGood r → 60 ≤ routingCost r",
       "description": "Every unsplittable routing whose arc loads stay within x_a + D (capacity violation ≤ D) costs at least 60 — exhaustive over the 8 routings (decide)."
+    },
+    {
+      "name": "capgood_optimum_is_60",
+      "statement": "∃ r : Routing, CapGood r ∧ routingCost r = 60",
+      "description": "The routing (E,E,Z) = (false, false, true) is capacity-good and costs exactly 60, so the bound in every_capgood_routing_costly is tight (decide)."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary
- Routine audit of the sole unaudited gallery entry (`dinitz-garg-goemans-counterexample`, added 2026-07-22).
- Verified the math by hand against `proofs/Proofs/DinitzGargGoemans.lean`: fractional cost 58, conservation at u/v/w, all 8 routing loads/capacities, and the 60-cost separation all check out exactly.
- Confirmed 0 sorries, 0 `axiom` declarations, and no `native_decide` (plain `decide` only) — the entry's careful "0-axiom"/hedged-interpretation prose is accurate.
- Fixed two metadata count mismatches: `theoremCount` was 4 but the file has 5 theorems (`mainTheorems` omitted `capgood_optimum_is_60`); `definitionCount` was 13 but the file has 20 `def`s. Both are undercounts, not overclaims, but should reflect reality.

## Test plan
- [x] `python3 -m json.tool` validates the edited `meta.json`
- [x] Manually recomputed all arithmetic/conservation/capacity claims against the Lean source
- [x] `grep` confirmed 0 sorry, 0 axiom, 0 native_decide usage (only mentioned in docstring/comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)