### PR TITLE
audit: mark dinitz-garg-goemans-counterexample issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31892,6 +31892,12 @@
       "lastAudited": "2026-07-21T15:35:52Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "dinitz-garg-goemans-counterexample": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-22T20:19:43Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Summary
- Tracker update for the audit of `dinitz-garg-goemans-counterexample` (the sole unaudited gallery entry).
- Verified math, sorry/axiom/native_decide claims all correct against `proofs/Proofs/DinitzGargGoemans.lean`; fixed a theorem/definition count undercount in #41730.

## Test plan
- [x] `audit-tracker.json` entry added with result `issues-fixed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)