### PR TITLE
Enrich algebraic-numbers-countable-oq-01-oq-01: cover header docstring (lines 1-47)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-01-oq-01/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-01-oq-01/meta.json
@@ -98,6 +98,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Scope: the algebraic numbers form an algebraically closed field",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Module docstring: previews the five results — promoting the parent's algebraicSubfield to an IntermediateField, identifying it with Mathlib's algebraicClosure K L, the transitivity-of-algebraicity crux (an element algebraic over the field of algebraic elements is already algebraic over K), the algebraic-closedness theorem when L is algebraically closed, and the specialization to ℚ ⊆ ℂ giving a countable algebraically closed field strictly inside the uncountable ℂ.",
+      "mathContext": "$\\overline{K}^{\\text{rel}}_L$ closed under roots when $L$ is algebraically closed; specializes to $\\overline{\\mathbb{Q}} \\subset \\mathbb{C}$ countable."
+    },
+    {
       "id": "upgrade",
       "title": "§1: From subfield to intermediate field",
       "startLine": 60,


### PR DESCRIPTION
Adds a `header` section covering the module docstring (lines 1-47), previously
uncovered. Previews the five results, from promoting the parent's subfield to
an IntermediateField through the algebraic-closedness theorem and the ℚ ⊆ ℂ
specialization.