### PR TITLE
audit: fix stale open question for erdos-453

### DIFF
--- a/src/data/proofs/erdos-453/meta.json
+++ b/src/data/proofs/erdos-453/meta.json
@@ -211,8 +211,7 @@
     "implications": "**Theoretical Significance**: The prime number graph provides geometric insight into prime distribution.\n\nConvex hull analysis is a powerful tool for studying multiplicative properties of primes. The technique of converting arithmetic questions into geometric ones via logarithms is broadly applicable.",
     "openQuestions": [
       "What is the natural density of $\\{n \\mid \\forall\\, 0 < i < n : p_n^2 > p_{n+i}p_{n-i}\\}$ in $\\mathbb{N}$? Pomerance proved infinitude but not a density estimate.",
-      "Can `convexity_implies_product_bound` be proved in Lean without `sorry`? It requires `Real.log_mul` and `Real.exp_lt_exp` — straightforward but not yet formalized.",
-      "Is there an explicit constructive sequence of counterexamples (not just an existence proof)? The Lean axiom `pomerance_1979` is non-constructive.",
+      "Is there an explicit constructive sequence of counterexamples (not just an existence proof)? The theorem `pomerance_1979` is proved from the non-constructive axiom `pomerance_convex_hull_lemma`.",
       "Can the full argument be formalized in Lean without any `axiom` or `sorry`, using only Mathlib's PNT and real analysis lemmas?"
     ]
   },


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-453

**Problem**: `conclusion.openQuestions` in meta.json claimed
`convexity_implies_product_bound` was "straightforward but not yet
formalized" without `sorry`. It's actually already fully proved
(Proofs/Erdos453Problem.lean:206-211), via the fully-proved
`log_to_product` (lines 174-200). The `sections[]` entry for this part
of the file already correctly describes it as "fully proved via
`log_to_product`" — only the `conclusion.openQuestions` list had gone
stale.

Also fixed a mislabeling: the open question referred to "the Lean axiom
`pomerance_1979`", but `pomerance_1979` is a proved `theorem`, not an
`axiom` — it's derived from the actual axiom
`pomerance_convex_hull_lemma`.

## Evidence

- `grep -n "sorry\|axiom "` on the Lean file shows only 2 axiom
  declarations (`logPrime_ratio_tendsto_zero`,
  `pomerance_convex_hull_lemma`) and 0 sorries — matches
  `meta.axiomCount: 2` / `meta.sorries: 0`, which are correct.
- `convexity_implies_product_bound` (lines 206-211) has a complete
  proof body (`log_to_product n i hn ⟨hi_pos, hi_lt⟩ (hv i hi_pos
  hi_lt)`), no sorry.

## Fix

Removed the stale openQuestion and corrected the axiom/theorem
mislabeling in the remaining constructive-counterexample question.
No change to status/badge/sorries/axiomCount — those were already
accurate.

---
Discovered during gallery integrity audit (reserve-mode re-verification, queue fully drained at 4810/4810).