### PR TITLE
Research: erdos-46-wip-01 — colour-free Erdős–Graham rational layer (every q>0, denominators > N; 0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos46WIP01SmallDivisors.lean
+++ b/proofs/Proofs/Erdos46WIP01SmallDivisors.lean
@@ -203,4 +203,119 @@ theorem exists_isUnitFractionRepr_disjoint (S₀ : Finset ℕ) :
   have h2 := hmin a hamem
   omega
 
+/- ## From `1` to every positive rational
+
+With the crux `exists_isUnitFractionRepr_min_gt` in hand, the disjoint-union
+and scaling primitives of the parent file (`isRatFractionRepr_union`,
+`isRatFractionRepr_smul`) upgrade "exactly `1`, denominators `> N`" to
+"exactly `q`, denominators `> N`" for EVERY positive rational `q`.  This is the
+colour-free layer of the Erdős–Graham rational generalization
+(`ErdosGraham_rational` with the colouring stripped): the remaining distance
+from these results to `ErdosGraham_rational` / `ErdosProblem46` is purely the
+monochromatic (Croot 2003) input. -/
+
+/-- Combined avoidance: a representation of `1` whose denominators all exceed
+`N` AND which avoids any prescribed finite set `S₀`.  Runs the crux at
+threshold `max N (S₀.sup id)`. -/
+theorem exists_isUnitFractionRepr_min_gt_disjoint (N : ℕ) (hN : 1 ≤ N)
+    (S₀ : Finset ℕ) :
+    ∃ S : Finset ℕ, IsUnitFractionRepr S ∧ (∀ n ∈ S, N < n) ∧ Disjoint S₀ S := by
+  obtain ⟨S, hS, hmin⟩ :=
+    exists_isUnitFractionRepr_min_gt (max N (S₀.sup id)) (hN.trans (le_max_left _ _))
+  refine ⟨S, hS, fun n hn => lt_of_le_of_lt (le_max_left _ _) (hmin n hn), ?_⟩
+  refine Finset.disjoint_left.mpr fun a ha hamem => ?_
+  have h1 : a ≤ S₀.sup id := Finset.le_sup (f := id) ha
+  have h2 := hmin a hamem
+  have h3 := le_max_right N (S₀.sup id)
+  omega
+
+/-- Every positive natural `a` is a sum of distinct unit fractions with all
+denominators `> N`: chain `a` pairwise-disjoint representations of `1` via
+`isRatFractionRepr_union` and the avoidance lemma. -/
+theorem exists_isRatFractionRepr_natCast_min_gt (a N : ℕ) (ha : 1 ≤ a)
+    (hN : 1 ≤ N) :
+    ∃ S : Finset ℕ, IsRatFractionRepr S (a : ℚ) ∧ ∀ n ∈ S, N < n := by
+  induction a, ha using Nat.le_induction with
+  | base =>
+    obtain ⟨S, hS, hmin⟩ := exists_isUnitFractionRepr_min_gt N hN
+    refine ⟨S, ?_, hmin⟩
+    rw [Nat.cast_one]
+    exact hS
+  | succ a ha ih =>
+    obtain ⟨S, hS, hSmin⟩ := ih
+    obtain ⟨T, hT, hTmin, hdisj⟩ := exists_isUnitFractionRepr_min_gt_disjoint N hN S
+    refine ⟨S ∪ T, ?_, fun n hn => ?_⟩
+    · have hcast : ((a + 1 : ℕ) : ℚ) = (a : ℚ) + 1 := by push_cast; ring
+      rw [hcast]
+      exact isRatFractionRepr_union hdisj hS ((isRatFractionRepr_one_iff T).mpr hT)
+    · rcases Finset.mem_union.mp hn with h | h
+      · exact hSmin n h
+      · exact hTmin n h
+
+/-- **Colour-free Erdős–Graham layer.**  Every positive rational `q` has a
+representation by distinct unit fractions with all denominators `> N`: write
+`q = q.num / q.den`, represent the positive natural `q.num.toNat` with
+denominators `> N`, and scale every denominator by `q.den`
+(`isRatFractionRepr_smul`). -/
+theorem exists_isRatFractionRepr_pos_min_gt (q : ℚ) (hq : 0 < q) (N : ℕ)
+    (hN : 1 ≤ N) :
+    ∃ S : Finset ℕ, IsRatFractionRepr S q ∧ ∀ n ∈ S, N < n := by
+  have hnum : (0 : ℤ) < q.num := Rat.num_pos.mpr hq
+  have hapos : 1 ≤ q.num.toNat := by omega
+  have hbpos : 0 < q.den := Nat.pos_of_ne_zero q.den_nz
+  obtain ⟨S, hS, hmin⟩ :=
+    exists_isRatFractionRepr_natCast_min_gt q.num.toNat N hapos hN
+  refine ⟨S.image (fun n => q.den * n), ?_, fun m hm => ?_⟩
+  · have hsmul := isRatFractionRepr_smul hS hbpos
+    have hcast : ((q.num.toNat : ℕ) : ℚ) = (q.num : ℚ) := by
+      rw [← Int.cast_natCast, Int.toNat_of_nonneg hnum.le]
+    rw [hcast, Rat.num_div_den q] at hsmul
+    exact hsmul
+  · obtain ⟨n, hn, rfl⟩ := Finset.mem_image.mp hm
+    exact lt_of_lt_of_le (hmin n hn) (Nat.le_mul_of_pos_left n hbpos)
+
+/-- **Egyptian-fraction representability of every positive rational** — the
+qualitative Fibonacci–Sylvester theorem, obtained here from the
+practical-number engine rather than the greedy algorithm: every `q > 0` is a
+finite sum of distinct unit fractions (denominators `≥ 2`). -/
+theorem exists_isRatFractionRepr_of_pos (q : ℚ) (hq : 0 < q) :
+    ∃ S : Finset ℕ, IsRatFractionRepr S q :=
+  let ⟨S, hS, _⟩ := exists_isRatFractionRepr_pos_min_gt q hq 1 le_rfl
+  ⟨S, hS⟩
+
+/-- Arbitrarily many pairwise-disjoint representations of `1`: for every `k`
+there is a `Fin k`-indexed family of pairwise-disjoint unit-fraction
+representations of `1` — the colour-free skeleton of
+`ErdosProblem46_infinitely_many`. -/
+theorem exists_pairwise_disjoint_isUnitFractionRepr (k : ℕ) :
+    ∃ F : Fin k → Finset ℕ, (∀ i, IsUnitFractionRepr (F i)) ∧
+      ∀ i j, i ≠ j → Disjoint (F i) (F j) := by
+  induction k with
+  | zero => exact ⟨fun i => i.elim0, fun i => i.elim0, fun i => i.elim0⟩
+  | succ k ih =>
+    obtain ⟨F, hF, hdisj⟩ := ih
+    obtain ⟨T, hT, hTdisj⟩ :=
+      exists_isUnitFractionRepr_disjoint (Finset.univ.biUnion F)
+    have hsub : ∀ j : Fin k, F j ⊆ Finset.univ.biUnion F := fun j =>
+      Finset.subset_biUnion_of_mem F (Finset.mem_univ j)
+    refine ⟨Fin.cons T F, fun i => ?_, fun i j hij => ?_⟩
+    · induction i using Fin.cases with
+      | zero => rw [Fin.cons_zero]; exact hT
+      | succ i => rw [Fin.cons_succ]; exact hF i
+    · induction i using Fin.cases with
+      | zero =>
+        induction j using Fin.cases with
+        | zero => exact absurd rfl hij
+        | succ j =>
+          rw [Fin.cons_zero, Fin.cons_succ]
+          exact (Finset.disjoint_of_subset_left (hsub j) hTdisj).symm
+      | succ i =>
+        induction j using Fin.cases with
+        | zero =>
+          rw [Fin.cons_succ, Fin.cons_zero]
+          exact Finset.disjoint_of_subset_left (hsub i) hTdisj
+        | succ j =>
+          rw [Fin.cons_succ, Fin.cons_succ]
+          exact hdisj i j fun h => hij (congrArg Fin.succ h)
+
 end Erdos46SmallDivisors

--- a/research/problems/erdos-46-wip-01/knowledge.md
+++ b/research/problems/erdos-46-wip-01/knowledge.md
@@ -183,3 +183,44 @@ merely be combined with pigeonhole over the disjoint family? NO: pigeonhole give
 colour class hit infinitely often across disjoint reprs, but a repr need not be
 monochromatic. Croot's density machinery is still required. The colour-free
 infrastructure is complete.
+
+## Session 2026-07-22 (researcher-1, session 3) — colour-free Erdős–Graham rational layer
+
+With the crux (`exists_isUnitFractionRepr_min_gt`, PR #41555) in hand, the previously
+equivalent-strength-blocked directions become legitimate DOWNSTREAM derivations — the
+blocked routes were about reaching `1` FROM `1/c` pieces; consequences OF `1` are fair
+game. Five new theorems appended to `Erdos46WIP01SmallDivisors.lean` (all 0-axiom,
+host-verified v4.31 EXIT=0, `#print axioms` = [propext, Classical.choice, Quot.sound]):
+
+- `exists_isUnitFractionRepr_min_gt_disjoint (N) (hN) (S₀)`: repr of 1, denoms > N,
+  disjoint from S₀ — run the crux at threshold `max N (S₀.sup id)`.
+- `exists_isRatFractionRepr_natCast_min_gt (a N) (ha : 1 ≤ a)`: repr of (a : ℚ) with
+  denoms > N. `induction a, ha using Nat.le_induction`; step = union with a fresh repr
+  of 1 avoiding the accumulated S (via `isRatFractionRepr_union` + the avoidance lemma).
+- `exists_isRatFractionRepr_pos_min_gt (q) (hq : 0 < q) (N)`: **colour-free
+  Erdős–Graham layer** — every positive rational, denoms > N. Represent `q.num.toNat`,
+  scale by `q.den` (`isRatFractionRepr_smul`); scaling only grows denominators.
+- `exists_isRatFractionRepr_of_pos`: Egyptian-fraction representability of every
+  positive rational (qualitative Fibonacci–Sylvester) — the N = 1 instance, obtained
+  WITHOUT formalizing the greedy algorithm.
+- `exists_pairwise_disjoint_isUnitFractionRepr (k)`: Fin k pairwise-disjoint reprs of 1
+  (colour-free skeleton of `ErdosProblem46_infinitely_many`).
+
+### Lean idioms (v4.31, all first-try green)
+- `induction a, ha using Nat.le_induction with | base | succ a ha ih` for `∀ a ≥ 1`.
+- Rational num/den reassembly: `hnum : (0:ℤ) < q.num := Rat.num_pos.mpr hq`;
+  `1 ≤ q.num.toNat` by `omega` (omega handles Int.toNat); den positivity via
+  `Nat.pos_of_ne_zero q.den_nz`; cast bridge
+  `((q.num.toNat : ℕ) : ℚ) = (q.num : ℚ)` by `rw [← Int.cast_natCast,
+  Int.toNat_of_nonneg hnum.le]`; finish with `Rat.num_div_den q`.
+- Fin-family extension: `Fin.cons T F` + `induction i using Fin.cases with
+  | zero | succ i` (case names are zero/succ); Lean auto-generalizes the
+  i-dependent `hij : i ≠ j`; `Fin.cons_zero`/`Fin.cons_succ` rewrite; succ-succ
+  injectivity via `fun h => hij (congrArg Fin.succ h)`;
+  `Finset.subset_biUnion_of_mem F (mem_univ j)` feeds
+  `Finset.disjoint_of_subset_left`.
+
+### Still open (UNCHANGED, DEEP)
+Only the monochromatic layer remains: `ErdosProblem46` / `ErdosGraham_rational`
+(Croot 2003, density/covering machinery). The colour-free elementary programme is
+COMPLETE — stand down on further colour-free rungs.

--- a/research/problems/erdos-46-wip-01/state.md
+++ b/research/problems/erdos-46-wip-01/state.md
@@ -4,34 +4,43 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-09T17:33:18-07:00
-**Iteration**: 3
+**Iteration**: 5
 
-## Status (2026-07-22, researcher-1) — two-sided bracket of 1 (denoms > N, vanishing width)
+## Status (2026-07-22, researcher-1, session 3) — COLOUR-FREE LAYER COMPLETE
 
-The `Erdos46Problem.lean` parent already carries a rich 0-axiom elementary toolkit for
-unit-fraction representations (telescoping `sum_Ico_inv_mul_succ` / `isRatFractionRepr_telescope`,
-divisor-sum route `isUnitFractionRepr_of_divisorSum` + `divisorSum_min_gt`, the harmonic-tail
-bounds `sum_Ico_inv_ge_half/ge_one`, and the two controlled approximations
-`exists_isRatFractionRepr_controlled_overshoot` (`1 ≤ q < 1+1/(N+1)`, denoms > N) and
-`exists_isRatFractionRepr_controlled_undershoot` (`1-1/(N+1) ≤ q < 1`, denoms > N)).
+The registered crux — a unit-fraction representation of exactly `1` with every
+denominator `> N` — was solved earlier today (PR #41555,
+`Erdos46WIP01SmallDivisors.lean`, practical-number completeness route). This
+session derived the full colour-free consequence layer on top of it (all
+0-axiom, host-verified v4.31):
 
-This session added `exists_isRatFractionRepr_bracket_one (N) (hN : 1 ≤ N)` (0-axiom,
-docker-verified `[propext, Classical.choice, Quot.sound]`): a single packaged witness
-sandwiching `1` — `∃ Slo Shi qlo qhi`, both reprs with denoms > N, `qlo < 1 ≤ qhi`, and the
-**explicit vanishing width** `qhi - qlo < 2/(N+1)`. As `N → ∞` the bracket collapses onto `1`.
-This is the exact launching point an *exact* landing on `1` would refine.
+- `exists_isUnitFractionRepr_min_gt_disjoint` — repr of `1`, denoms `> N`,
+  avoiding any prescribed finite set (crux at threshold `max N (S₀.sup id)`).
+- `exists_isRatFractionRepr_natCast_min_gt` — every natural `a ≥ 1`
+  represented with denoms `> N` (`Nat.le_induction`, disjoint-union chaining).
+- `exists_isRatFractionRepr_pos_min_gt` — **colour-free Erdős–Graham layer**:
+  every positive rational `q` represented with denoms `> N` (scale the
+  `q.num.toNat` representation by `q.den` via `isRatFractionRepr_smul`).
+- `exists_isRatFractionRepr_of_pos` — Egyptian-fraction representability of
+  every positive rational (qualitative Fibonacci–Sylvester), free at `N = 1`.
+- `exists_pairwise_disjoint_isUnitFractionRepr` — `Fin k` pairwise-disjoint
+  families of representations of `1` (colour-free skeleton of
+  `ErdosProblem46_infinitely_many`).
+
+Note the old blocked routes (assembling exactly `1` FROM `1/c` pieces) are
+untouched: this session runs the derivations in the opposite, legitimate
+direction (consequences OF the solved crux).
 
 ## Active Approach
-Elementary unit-fraction toolkit + controlled overshoot/undershoot bracketing `1` with
-denominators > N. The exact-landing step is the genuine open crux (below).
+None — colour-free elementary programme is finished.
 
 ## Blockers
-- **Exact landing on `1` with denominators > N** (close the residual `[qlo, qhi]` gap
-  collision-free) = a bounded-rational Diophantine subset-sum. This is the hard nugget; the
-  two-sided bracket now pins it to a `< 2/(N+1)`-wide window but does not close it elementarily.
+- **Monochromatic layer** (`ErdosProblem46`, `ErdosGraham_rational`; Croot
+  2003): needs density/covering machinery (density Hales–Jewett-adjacent) far
+  beyond current Mathlib. DEEP — not session-sized.
 
 ## Next Action
-Attempt the exact-landing subset-sum inside the bracketed window (or the denominator-inflation
-route: repeatedly split the smallest term `1/m = 1/(m+1) + 1/(m(m+1))` to push all denoms > N,
-handling collisions). If neither is session-sized, STAND DOWN — the near-1 bracket layer is
-complete.
+STAND DOWN unless attacking the monochromatic Croot layer itself. All
+elementary colour-free content (representations, large-min, avoidance,
+rational generalization, disjoint families, cost bounds, brackets) is done —
+further colour-free additions are likely cosmetic.

--- a/src/data/research/problems/erdos-46-wip-01.json
+++ b/src/data/research/problems/erdos-46-wip-01.json
@@ -20,8 +20,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-09T17:33:18-07:00",
-    "iteration": 3,
-    "focus": "Session 2: splitting identity (Fibonacci–Sylvester 1/n=1/(n+1)+1/(n(n+1))), telescoping form, concrete witness {2,3,6}, existence, and the term-replacement lengthening step (isUnitFractionRepr_replace). 5 axiom-free theorems, theoremCount 16→21, host-verified.",
+    "iteration": 4,
+    "focus": "colour-free layer complete; only deep monochromatic (Croot) input remains",
     "blockers": [
       {
         "route": "union/scaling assembly of large-min 1/c pieces into exactly 1",
@@ -34,7 +34,7 @@
         "blockedAt": "2026-07-21"
       }
     ],
-    "nextAction": "Croot's theorem (existence of monochromatic representation) is deep/unformalized — needs density/covering machinery from the 2003 paper. Elementary splitting/lengthening toolkit now in place; a full lengthening-to-infinity chain would need denominator-freshness bookkeeping.",
+    "nextAction": "STAND DOWN unless attacking the monochromatic Croot layer itself (deep). All elementary colour-free content is done.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -42,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "MAJOR (researcher-1, 2026-07-22): THE REGISTERED CRUX IS SOLVED — exists_isUnitFractionRepr_min_gt (new companion Erdos46WIP01SmallDivisors.lean, 0-axiom, host-verified): for every N >= 1 a unit-fraction representation of EXACTLY 1 with all denominators > N. Route = practical-number completeness (the divisor-sum bridge's open nextStep): M = (4(N+1))! is practical (Erdos18 toolkit import), its divisors <= M/(N+1) remain a subset-sum coin chain under threshold restriction and total >= M via harmonic-block cofactors, so finset_chain_covers hits M exactly; the bridge converts cofactors into the repr. Corollary exists_isUnitFractionRepr_disjoint: any finite set avoided — the collision-freeness obstruction to disjoint chaining is GONE. Still open: the monochromatic ErdosProblem46 (Croot 2003 density machinery).",
+    "progressSummary": "COLOUR-FREE LAYER COMPLETE: crux (exact repr of 1, denoms > N, PR #41555) extended to every positive rational q with denoms > N, plus Egyptian-fraction representability of all q > 0 and Fin k pairwise-disjoint families of reprs of 1 (all 0-axiom, host-verified). The ONLY remaining content is the monochromatic layer (ErdosProblem46 / ErdosGraham_rational, Croot 2003), which needs density/covering machinery far beyond current Mathlib.",
     "builtItems": [
       "exists_isRatFractionRepr_bracket_one in Erdos46Problem.lean (0-axiom) — packages controlled overshoot+undershoot into a single two-sided bracket of 1: exists Slo,Shi,qlo,qhi with both reprs' denoms > N, qlo<1<=qhi, and explicit vanishing width qhi-qlo < 2/(N+1). Launching point for exact landing on 1.",
       "not_isUnitFractionRepr_singleton — no singleton represents 1 (Erdos46Problem.lean)",
@@ -63,7 +63,12 @@
       "exists_le_card — smallest denom <= card in any unit-fraction repr of 1 (Erdos46WIP01Cost.lean, 0-axiom)",
       "Erdos46WIP01SmallDivisors.lean: exists_isUnitFractionRepr_min_gt — exact repr of 1, all denoms > N (THE CRUX) [0-axiom]",
       "small_divisor_chain (threshold restriction of practical divisor coin chain), small_divisor_sum_ge (harmonic cofactor total >= M)",
-      "exists_isUnitFractionRepr_disjoint: repr of 1 avoiding any finite set (collision obstruction removed)"
+      "exists_isUnitFractionRepr_disjoint: repr of 1 avoiding any finite set (collision obstruction removed)",
+      "exists_isUnitFractionRepr_min_gt_disjoint in Erdos46WIP01SmallDivisors.lean (repr of 1, denoms > N, avoiding any finite S0)",
+      "exists_isRatFractionRepr_natCast_min_gt (every a >= 1 represented, denoms > N, via Nat.le_induction disjoint chaining)",
+      "exists_isRatFractionRepr_pos_min_gt (colour-free Erdos-Graham layer: every q > 0, denoms > N)",
+      "exists_isRatFractionRepr_of_pos (Egyptian fractions for every positive rational)",
+      "exists_pairwise_disjoint_isUnitFractionRepr (Fin k pairwise-disjoint reprs of 1)"
     ],
     "insights": [
       "Erdos46Problem.lean stub developed: 13 axiom-free foundational lemmas on unit-fraction / rational representations and monochromatic sets (all [propext,Classical.choice,Quot.sound], no sorry/native_decide).",
@@ -80,11 +85,14 @@
       "DUAL: in ANY unit-fraction repr of 1 the smallest denominator is <= number of terms (some n in S has n<=|S|); else all denoms >|S| would force |S|>=|S|+1. (exists_le_card)",
       "The erdos-18 practical-number engine and the erdos-46 crux are the same mathematics: denominators > N summing to 1 = distinct divisors < M/N summing to M; Erdos18.divisors is defeq Nat.divisors so the toolkits compose with zero glue",
       "Threshold restriction preserves subset-sum coin chains: the chain condition for d references only divisors < d, all below the threshold — so practical numbers have COMPLETE small-divisor pools once the pool total passes M (harmonic block of cofactors)",
-      "The equivalent-strength blocked routes (bootstraps) are all obsolete: the target itself is now constructed; remaining open content is exclusively the monochromatic/Croot layer"
+      "The equivalent-strength blocked routes (bootstraps) are all obsolete: the target itself is now constructed; remaining open content is exclusively the monochromatic/Croot layer",
+      "With the crux solved, the previously equivalent-strength directions become legitimate DOWNSTREAM derivations: 1 -> a (disjoint-union chaining) -> a/b (scaling by q.den) gives every positive rational with denominators > N. The blocked routes were only about reaching 1 FROM 1/c pieces, not about deriving consequences of 1.",
+      "Egyptian-fraction representability of every positive rational (qualitative Fibonacci-Sylvester) falls out of the practical-number engine without formalizing the greedy algorithm: it is the N=1 instance of the colour-free Erdos-Graham layer.",
+      "Fin.cons + induction using Fin.cases (case names zero/succ) is the clean pattern for extending a Fin k family of pairwise-disjoint sets by one avoiding element; Lean 4 induction auto-generalizes the i-dependent hypothesis hij."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Exact landing on 1 with denominators > N (close the [qlo,qhi] gap collision-free) = bounded-rational Diophantine subset-sum. HARD NUGGET; the bracket now pins it to a <2/(N+1) window. Alt route: denominator inflation by repeatedly splitting the smallest term 1/m=1/(m+1)+1/(m(m+1)), handling collisions."
+      "Monochromatic layer (Croot 2003): density/covering machinery not in Mathlib — DEEP, not session-sized. The colour-free infrastructure is complete; do not add further colour-free rungs without checking they are not cosmetic."
     ],
     "markdown": "# Knowledge Base: erdos-46-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary
Research session for **erdos-46-wip-01** (Erdős #46, monochromatic unit fractions). Builds the full colour-free consequence layer on top of today's solved crux (#41555: exact unit-fraction representation of 1 with all denominators > N).

## Progress
Five new theorems appended to `proofs/Proofs/Erdos46WIP01SmallDivisors.lean` (+115 lines), all 0-axiom (`#print axioms` = `[propext, Classical.choice, Quot.sound]`), host-verified on v4.31 (`lake env lean` EXIT=0, fresh parent oleans, zero warnings):

- `exists_isUnitFractionRepr_min_gt_disjoint` — representation of 1 with denominators > N **and** disjoint from any prescribed finite set (crux at threshold `max N (S₀.sup id)`).
- `exists_isRatFractionRepr_natCast_min_gt` — every natural `a ≥ 1` is a sum of distinct unit fractions with denominators > N (`Nat.le_induction`, chaining pairwise-disjoint representations of 1 via `isRatFractionRepr_union`).
- `exists_isRatFractionRepr_pos_min_gt` — **colour-free Erdős–Graham layer**: every positive rational q is a sum of distinct unit fractions with all denominators > N (represent `q.num.toNat`, scale by `q.den` via `isRatFractionRepr_smul`).
- `exists_isRatFractionRepr_of_pos` — Egyptian-fraction representability of every positive rational (qualitative Fibonacci–Sylvester statement), obtained from the practical-number engine without formalizing the greedy algorithm.
- `exists_pairwise_disjoint_isUnitFractionRepr` — for every k, a `Fin k`-indexed pairwise-disjoint family of representations of 1 (colour-free skeleton of `ErdosProblem46_infinitely_many`).

## Findings
- The blocked routes recorded on this problem (assembling exactly 1 *from* `1/c` pieces — equivalent-strength while the crux was open) do not block this work: these are derivations *of consequences* of the now-proved crux, in the opposite direction.
- With this session the colour-free elementary programme of the vein is **complete**: representations, large-minimum, avoidance, rational generalization, disjoint families, cost bounds, and brackets all exist as 0-axiom theorems. The only remaining content is the monochromatic layer (`ErdosProblem46` / `ErdosGraham_rational`, Croot 2003), which needs density/covering machinery far beyond current Mathlib.

## Files Modified
- `proofs/Proofs/Erdos46WIP01SmallDivisors.lean` (+115)
- `research/problems/erdos-46-wip-01/state.md`, `knowledge.md`
- `src/data/research/problems/erdos-46-wip-01.json`

## Status
**Outcome**: progress (colour-free layer complete; vein moving to blocked — only deep Croot input remains)
**Next Steps**: stand down on colour-free rungs; the monochromatic Croot layer is the sole remaining target and is not session-sized.

🤖 Generated by researcher-1 (researcher-1-6)
