### PR TITLE
fix(claude-wrapper): classify 5h session-cap message as TOKEN_EXHAUSTED

### DIFF
--- a/scripts/agents/claude-wrapper.sh
+++ b/scripts/agents/claude-wrapper.sh
@@ -631,8 +631,9 @@ classify_error() {
     #   - "hit your limit"                              (legacy short form)
     #   - "You've hit your org's monthly usage limit"   (org cap; multi-word gap defeats `hit.your.limit`)
     #   - "You've hit your weekly limit · resets …"     (weekly cap; same multi-word gap)
+    #   - "You've hit your session limit · resets …"    (5h session cap; same multi-word gap — the word "session" defeats `hit your limit`)
     #   - "You're out of extra usage · resets …"        (session/extra-usage cap)
-    if echo "$output" | grep -qi "hit your limit\|monthly usage limit\|weekly limit\|out of extra usage"; then
+    if echo "$output" | grep -qi "hit your limit\|hit your session limit\|session limit\|monthly usage limit\|weekly limit\|out of extra usage"; then
         echo "TOKEN_EXHAUSTED"
         return
     fi


### PR DESCRIPTION
## Problem

The exhaustion classifier in `scripts/agents/claude-wrapper.sh` `classify_error` (~line 635) missed the 5-hour rolling **session cap** message:

> `You've hit your session limit · resets 4pm (America/Los_Angeles)`

(note the `·` middot). The old pattern was:

```bash
grep -qi "hit your limit\|monthly usage limit\|weekly limit\|out of extra usage"
```

`hit your limit` does **not** match `hit your `**`session`**` limit` — the word "session" sits in the multi-word gap, the exact failure mode the comment above already documents for the org "monthly usage limit" / "weekly limit" phrasings. It's also not weekly/monthly-usage/out-of-extra-usage.

**Impact:** `classify_error` never returned `TOKEN_EXHAUSTED` for the session cap → `mark_token_bad()` + `rotate_to_working_token()` never fired → the agent pinned to the exhausted account and burned 300s ticks (or died) instead of rotating to a healthy account. The 5-hour session window is the most common cap in normal operation, so the miss defeated the rotation feature precisely when it's needed most.

## Fix

Add `hit your session limit` and the broader `session limit` alternatives to the `grep -qi` alternation, and document the session-cap phrasing in the comment block:

```bash
grep -qi "hit your limit\|hit your session limit\|session limit\|monthly usage limit\|weekly limit\|out of extra usage"
```

## Testing

- `bash -n scripts/agents/claude-wrapper.sh` passes (bash 3.2, macOS).
- Scratch harness against the exact regex:
  - `You've hit your session limit · resets 4pm (America/Los_Angeles)` → **TOKEN_EXHAUSTED** (the bug)
  - existing matches (`hit your limit`, weekly, org monthly usage, out of extra usage) still classify as **TOKEN_EXHAUSTED**
  - `session limit reached` variant → **TOKEN_EXHAUSTED**
  - benign non-exhaustion strings (success message, 401 auth, 429 rate limit) → **NOT** matched
- No live fleet disturbed (isolated scratch harness).

## Merge safety

Change is confined to the `classify_error` exhaustion regex + its comment. It does **not** touch the account-selection strategies (~lines 322-384, Strategy 0/1) being edited concurrently by #41727 in a different worktree — the two PRs are on disjoint regions and merge cleanly.

Closes #41737
