### PR TITLE
fix(wrapper): spread account selection across top-N available accounts (#41727)

### DIFF
--- a/scripts/agents/claude-wrapper.sh
+++ b/scripts/agents/claude-wrapper.sh
@@ -38,15 +38,25 @@ unset CLAUDECODE 2>/dev/null || true
 #
 # Account selection strategy (in priority order):
 #   0. If claude-monitor's ~/.claude-monitor/ranking.json exists and is fresh
-#      (<10 min by generated_at / mtime), pick the least-utilized `available`
-#      account (ordered by status, util_7d, util_5h), joining ranking emails to
-#      on-disk token files via loom's derive_token_filename convention. This is
-#      a SOFT dependency: absent/stale/unparseable export → fall through below.
-#      Mirrors loom 0.12.0 (rjwalters/loom#3697, #3699) + lean-genius #41033.
-#   1. If .loom/tokens/.ranking exists and is <10 min old, pick the first
-#      account that has remaining weekly capacity (sorted by soonest reset).
+#      (<10 min by generated_at / mtime), rank `available` accounts least-utilized
+#      first (ordered by status, util_7d, util_5h) and pick one at RANDOM among
+#      the top-N (env LEAN_ACCOUNT_SPREAD_TOP_N, default 3; #41727), joining
+#      ranking emails to on-disk token files via loom's derive_token_filename
+#      convention. This is a SOFT dependency: absent/stale/unparseable export →
+#      fall through below. Mirrors loom 0.12.0 (rjwalters/loom#3697, #3699) +
+#      lean-genius #41033.
+#   1. If .loom/tokens/.ranking exists and is <10 min old, pick at random among
+#      the top-N accounts (same LEAN_ACCOUNT_SPREAD_TOP_N band) that still have
+#      remaining weekly capacity (sorted by soonest reset).
 #   2. If .loom/tokens/.allowlist exists, random among allowed accounts.
 #   3. Otherwise, random among all .token files.
+#
+# LEAN_ACCOUNT_SPREAD_TOP_N spreads load across the freshest accounts so that
+# many concurrent workers (and a sibling Loom daemon reading the same ranking)
+# don't all collide on the single most-available account and drive it to its
+# session limit (#41727). N is clamped to the eligible count and never widens
+# into exhausted/blocked accounts; N=1 reproduces the old deterministic
+# least-utilized pick exactly (a safe rollback).
 #
 # The ranking file (strategy 1) is written by:
 #   scripts/agents/check-accounts.sh --ranking
@@ -305,6 +315,35 @@ if [[ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
             return 1
         }
 
+        # Top-N spread pick (#41727). Given the count of ELIGIBLE accounts
+        # (already filtered: available/present/allowlisted/not-bad, ordered
+        # best-first), echo a random 0-based index into the top band and record
+        # the clamped band size in _spread_top_n (for the log line).
+        #
+        # The band size is env LEAN_ACCOUNT_SPREAD_TOP_N (default 3), clamped to
+        # the eligible count so we NEVER widen the band into exhausted/blocked
+        # accounts just to fill it — if fewer than N are eligible, we pick among
+        # those. N=1 always yields index 0 (RANDOM % 1 == 0), reproducing today's
+        # exact deterministic least-utilized pick — a safe rollback.
+        #
+        # Rationale: many concurrent workers (enricher×N, researcher×N, …) plus a
+        # sibling Loom daemon read the SAME claude-monitor ranking and each
+        # greedily took account[0], piling ~9 sessions onto one account until it
+        # hit its session limit in ~90s while others sat idle. Spreading the pick
+        # over the top-N least-utilized *available* accounts makes both consumers
+        # statistically fan out across the freshest accounts instead of colliding.
+        # Echoes "<chosen 0-based index> <clamped band size>" so callers can
+        # read both in the PARENT shell (a bare global set here would be lost —
+        # callers invoke this via $()/command substitution, i.e. a subshell).
+        _spread_top_n=1
+        _spread_pick() {  # $1 = eligible count (>=1)
+            local _n="$1" _band="${LEAN_ACCOUNT_SPREAD_TOP_N:-3}"
+            [[ "$_band" =~ ^[0-9]+$ ]] || _band=3
+            [[ "$_band" -lt 1 ]] && _band=1
+            [[ "$_band" -gt "$_n" ]] && _band="$_n"
+            echo "$(( RANDOM % _band )) $_band"
+        }
+
         if command -v jq >/dev/null 2>&1 && [[ -f "$_monitor_json" ]]; then
             # Freshness gate: prefer generated_at, else file mtime; <600s window.
             _mon_schema=$(jq -r '.schema // empty' "$_monitor_json" 2>/dev/null)
@@ -339,6 +378,12 @@ if [[ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
                     done < "$_allowlist_file"
                 fi
 
+                # Collect ALL eligible stems in least-utilized-first order, then
+                # spread the pick over the top-N (#41727) instead of always
+                # taking account[0]. Only available/present/allowlisted/not-bad
+                # accounts enter the band, so the band is never widened into an
+                # ineligible account.
+                _mon_eligible=()
                 while IFS= read -r _memail || [[ -n "$_memail" ]]; do
                     [[ -z "$_memail" ]] && continue
                     _mstem=$(_derive_token_stem "$_memail") || continue
@@ -355,10 +400,18 @@ if [[ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
                         && grep -q " $_mstem " "$_bad_tokens_file" 2>/dev/null; then
                         continue
                     fi
-                    _selected="$_tokens_dir/${_mstem}.token"
-                    _mode="monitor"
-                    break
+                    _mon_eligible+=("$_mstem")
                 done <<< "$_mon_emails"
+                if [[ ${#_mon_eligible[@]} -gt 0 ]]; then
+                    read -r _mpick _spread_top_n <<< "$(_spread_pick "${#_mon_eligible[@]}")"
+                    _mstem="${_mon_eligible[$_mpick]}"
+                    _selected="$_tokens_dir/${_mstem}.token"
+                    if [[ "$_spread_top_n" -gt 1 ]]; then
+                        _mode="monitor-spread"
+                    else
+                        _mode="monitor"
+                    fi
+                fi
             fi
         fi
 
@@ -366,21 +419,33 @@ if [[ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
         if [[ -z "$_selected" && -f "$_ranking_file" ]]; then
             _ranking_age=$(( $(date +%s) - $(stat -f %m "$_ranking_file" 2>/dev/null || stat -c %Y "$_ranking_file" 2>/dev/null || echo 0) ))
             if [[ $_ranking_age -lt 600 ]]; then  # <10 min old
+                # Collect the top band of eligible ranking entries (soonest-reset
+                # order, skipping exhausted/blocked/bad/missing), then spread the
+                # pick over the top-N (#41727) instead of always taking the first.
+                # Exhausted/blocked entries are dropped, never counted toward N.
+                _rank_eligible=()
                 while IFS='|' read -r _rname _rstatus || [[ -n "$_rname" ]]; do
                     _rname=$(echo "$_rname" | tr -d '[:space:]')
                     _rstatus=$(echo "$_rstatus" | tr -d '[:space:]')
                     [[ -z "$_rname" || "$_rname" == \#* ]] && continue
                     [[ "$_rstatus" == "exhausted" || "$_rstatus" == "blocked" ]] && continue
-                    if [[ -f "$_tokens_dir/${_rname}.token" ]]; then
-                        # Skip bad tokens
-                        if [[ -f "$_bad_tokens_file" ]] && grep -q " $_rname " "$_bad_tokens_file" 2>/dev/null; then
-                            continue
-                        fi
-                        _selected="$_tokens_dir/${_rname}.token"
-                        _mode="ranked"
-                        break
+                    [[ -f "$_tokens_dir/${_rname}.token" ]] || continue
+                    # Skip bad tokens
+                    if [[ -f "$_bad_tokens_file" ]] && grep -q " $_rname " "$_bad_tokens_file" 2>/dev/null; then
+                        continue
                     fi
+                    _rank_eligible+=("$_rname")
                 done < "$_ranking_file"
+                if [[ ${#_rank_eligible[@]} -gt 0 ]]; then
+                    read -r _rpick _spread_top_n <<< "$(_spread_pick "${#_rank_eligible[@]}")"
+                    _rname="${_rank_eligible[$_rpick]}"
+                    _selected="$_tokens_dir/${_rname}.token"
+                    if [[ "$_spread_top_n" -gt 1 ]]; then
+                        _mode="ranked-spread"
+                    else
+                        _mode="ranked"
+                    fi
+                fi
             fi
         fi
 


### PR DESCRIPTION
Closes #41727

## Problem
`scripts/agents/claude-wrapper.sh` account selection deterministically picked the **single most-available** account: both the claude-monitor path (Strategy 0) and the cached-ranking path (Strategy 1) `break` on the FIRST eligible entry. With many concurrent workers — plus a sibling **Loom daemon** reading the same `~/.claude-monitor/ranking.json` — everyone piled onto `account[0]`, driving it to its session limit in ~90s while other accounts sat idle.

## Fix
Rank eligible accounts exactly as before, then pick ONE at **random among the top-N** instead of always `[0]`.

- **Strategy 0 (monitor)**: collect all `available`/present/allowlisted/not-bad stems in least-utilized-first order (unchanged `sort_by(util_7d, util_5h)`), then random-pick among the first N. Logs mode `monitor-spread` (N>1) / `monitor` (N=1).
- **Strategy 1 (cached `.ranking`)**: collect the top band of non-exhausted/blocked/bad/missing entries (soonest-reset order), random-pick among the first N. Logs mode `ranked-spread` / `ranked`.
- Shared `_spread_pick` helper.

## Configurable N
- Env var **`LEAN_ACCOUNT_SPREAD_TOP_N`, default 3**.
- N is **clamped to the eligible count**, so the band NEVER widens into exhausted/blocked accounts to fill it — if fewer than N are available, it picks among those.
- **`N=1` reproduces today's exact deterministic least-utilized pick** (a safe rollback). Malformed/`<1` values fall back safely (`0`/`abc` → clamp/default).

## Untouched
Bootstrap/materialization block, ranking.json consumer schema, freshness gates, allowlist/`.bad_tokens` handling, Strategy 2/3 random fallbacks.

## Testing
`bash -n` clean. Verified with a scratch harness (instrumented copy that exits right after selection) against **stub** token dirs and a stub `ranking.json` — the live `.loom/tokens` was not touched:

- (a) N=3, 5 available → picks spread across the top-3, never accounts 4/5, mode `*-spread`.
- (b) N=1 → always the single least-utilized, mode `monitor`/`ranked` (exact old behavior).
- (c) exhausted/blocked/rate_limited accounts never selected, even to fill the band.
- (d) N clamps when fewer accounts are available (e.g. 2 available → band of 2).
- (e) allowlist gating still respected (only allowlisted stems enter the band).
- Both Strategy 0 and Strategy 1 exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
