### PR TITLE
Enrich algebraic-reals-meager-dense-gdelta: cover header docstring (lines 1-53)

### DIFF
--- a/src/data/proofs/algebraic-reals-meager-dense-gdelta/meta.json
+++ b/src/data/proofs/algebraic-reals-meager-dense-gdelta/meta.json
@@ -202,6 +202,13 @@
   ],
   "sections": [
     {
+      "id": "header",
+      "title": "Header: the explicit dense Gδ strengthening",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "Module docstring. States the parent's open question (exhibit the comeagre transcendentals as an explicit dense Gδ rather than an abstract residual-filter member), the set identity driving the proof — {x | ¬ IsAlgebraic ℚ x} = ⋂_{a algebraic} {a}ᶜ, a countable intersection of open sets since ℝ is T1 — and the dual corollary that the algebraic reals, being dense yet meagre, are not a Gδ (mirroring Mathlib's irrational/rational Gδ/Fσ contrast). Lists the five Main Results."
+    },
+    {
       "id": "abstract-lemmas",
       "title": "Abstract lemmas: complements of countable sets",
       "startLine": 54,


### PR DESCRIPTION
## Summary
- Adds the missing `header` section (lines 1-53) to `sections[]` for `algebraic-reals-meager-dense-gdelta`.
- The module docstring states the parent open question (exhibit the comeagre transcendentals as an explicit dense Gδ), the driving set identity `{x | ¬ IsAlgebraic ℚ x} = ⋂_{a algebraic} {a}ᶜ`, and the dual not-Gδ corollary for the algebraic reals — none of this was covered by any section or annotation.
- Entry was otherwise already at target (9 theorems, full overview/conclusion/crossRefs, rich `keyInsights`); no other fields touched.

## Test plan
- [x] `pnpm build` passes (validates JSON structure, search index, bundle budget)
- [x] Verified header content against `proofs/Proofs/AlgebraicRealsMeagerDenseGDelta.lean` lines 1-53