### PR TITLE
fix(claude-wrapper): drop bare 'session limit' from exhaustion regex (#41737 follow-up — stranded by merge race)

### DIFF
--- a/scripts/agents/claude-wrapper.sh
+++ b/scripts/agents/claude-wrapper.sh
@@ -696,9 +696,13 @@ classify_error() {
     #   - "hit your limit"                              (legacy short form)
     #   - "You've hit your org's monthly usage limit"   (org cap; multi-word gap defeats `hit.your.limit`)
     #   - "You've hit your weekly limit · resets …"     (weekly cap; same multi-word gap)
-    #   - "You've hit your session limit · resets …"    (5h session cap; same multi-word gap — the word "session" defeats `hit your limit`)
+    #   - "You've hit your session limit · resets …"    (5h session cap; the word "session" defeats `hit your limit`, so match `hit your session limit`)
     #   - "You're out of extra usage · resets …"        (session/extra-usage cap)
-    if echo "$output" | grep -qi "hit your limit\|hit your session limit\|session limit\|monthly usage limit\|weekly limit\|out of extra usage"; then
+    # NOTE: match `hit your session limit`, not a bare `session limit` — this
+    # branch runs on exit-0 output too (classify_error has no non-zero-exit
+    # guard here), so a successful turn merely mentioning "session limit" in
+    # prose must not be misclassified as TOKEN_EXHAUSTED.
+    if echo "$output" | grep -qi "hit your limit\|hit your session limit\|monthly usage limit\|weekly limit\|out of extra usage"; then
         echo "TOKEN_EXHAUSTED"
         return
     fi


### PR DESCRIPTION
## Context
Follow-up to #41737 / PR #41742. The Doctor's fix (`3ae71890c5`) that dropped the too-broad bare `session limit` alternative was **stranded by a deployer fast-merge race**: PR #41742 auto-merged with the stale pre-fix head `6cc23684` (13:31:43) *before* the fix commit (13:30:58) was picked up, so `main` still carries the false-positive hazard the Judge flagged.

This PR cherry-picks the exact Judge-approved fix (`3ae71890c5`) onto current `main` (which already has #41727/#41744's spread changes — the cherry-pick auto-merged cleanly, disjoint regions).

## The fix
`scripts/agents/claude-wrapper.sh` `classify_error` exhaustion regex:
```
- grep -qi "hit your limit\|hit your session limit\|session limit\|monthly usage limit\|weekly limit\|out of extra usage"
+ grep -qi "hit your limit\|hit your session limit\|monthly usage limit\|weekly limit\|out of extra usage"
```
Removes the bare `session limit`. The exhaustion branch has **no exit-0 guard** (unlike the adjacent 429 branch), so a successful exit-0 turn merely mentioning "session limit" in prose (a live topic across this fleet — #41033/#41727/#41737) would otherwise misclassify as `TOKEN_EXHAUSTED` → spurious rotation + `consecutive_failures++`. The specific `hit your session limit` already matches the real live message, so the bare form was redundant.

## Verified
- Cherry-pick applied cleanly onto main; coexists with #41727's spread logic (both present).
- `bash -n` clean.
- Classify behavior: `You've hit your session limit · resets 4pm …` → MATCH (TOKEN_EXHAUSTED); benign exit-0 prose mentioning "session limit" → no match; the four pre-existing phrasings (hit your limit / weekly / monthly usage / out of extra usage) → MATCH.
- Content is byte-identical to the Judge-approved fix on the #41742 branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)