### PR TITLE
Audit: greens-theorem-oq-04 issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -20190,10 +20190,10 @@
       "issues": []
     },
     "greens-theorem-oq-04": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:35Z",
-      "result": "clean"
+      "lastAudited": "2026-07-22T20:38:40Z",
+      "result": "issues-fixed"
     },
     "group-order-prime-squared-abelian-oq-01": {
       "auditCount": 1,


### PR DESCRIPTION
Tracker update for the audit of greens-theorem-oq-04 (see #41751 for the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)