### PR TITLE
Enrich algebraic-reals-meager-dense-gdelta-oq-03: cover header docstring (lines 1-56)

### DIFF
--- a/src/data/proofs/algebraic-reals-meager-dense-gdelta-oq-03/meta.json
+++ b/src/data/proofs/algebraic-reals-meager-dense-gdelta-oq-03/meta.json
@@ -187,6 +187,14 @@
   ],
   "sections": [
     {
+      "id": "header",
+      "title": "Header: which transcendentals are topologically generic?",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Module docstring. States the parent's third open question — the transcendentals are comeagre but not homogeneous, so which are topologically generic? Answers via the classical Baire-category theorem for Liouville numbers: the Liouville numbers are themselves a dense Gδ inside the transcendentals, so the generic (Baire-comeagre) transcendental is Liouville, while the non-Liouville transcendentals are meagre. States the measure-theoretic counterpoint: the Liouville set has Lebesgue measure zero, so it is simultaneously comeagre and null — the comeagre transcendental is Liouville, the almost-every transcendental is non-Liouville, and the two genericity filters are disjoint. Lists the eight Main Results.",
+      "mathContext": "Comeagre (Baire-generic) and full-measure (Lebesgue-generic) are independent notions of 'almost all': the Liouville numbers are comeagre yet Lebesgue-null, so the Baire-typical transcendental is Liouville while the measure-typical transcendental is not — `Real.disjoint_residual_ae` makes this divergence precise."
+    },
+    {
       "id": "transcendence-bridge",
       "title": "The transcendence bridge: Liouville ⟹ transcendental over ℚ",
       "startLine": 57,


### PR DESCRIPTION
## Summary
- Adds the missing `header` section (lines 1-56) to `sections[]`.
- The module docstring states the parent's third open question (which transcendentals are topologically generic?) and the resolution via Liouville numbers — comeagre yet Lebesgue-null, so Baire-generic and measure-generic transcendentals diverge — none of this was covered by any section or annotation.
- Entry otherwise already at target; no other fields touched.

## Test plan
- [x] `pnpm build` passes
- [x] Verified header content against `proofs/Proofs/AlgebraicRealsMeagerDenseGDeltaOQ03.lean` lines 1-56