### PR TITLE
Research: erdos-876-incomplete-01 - prove powers_of_two_sumfree (file now sorry-free)

### DIFF
--- a/proofs/Proofs/Erdos876Problem.lean
+++ b/proofs/Proofs/Erdos876Problem.lean
@@ -249,9 +249,38 @@ Proof: 2^n ≠ sum of smaller powers of 2 (binary representation).
 -/
 theorem powers_of_two_sumfree :
     IsSumFreeErdos {n | ∃ k : ℕ, n = 2^k} := by
-  intro a ha S hS hlt hcard
-  -- 2^n can only be written as sum of distinct 2^k in one way (itself)
-  sorry
+  intro a ha S hS hlt _hcard
+  obtain ⟨k, rfl⟩ := ha
+  -- Each member of `S` is a power of two strictly below `2^k`, so `S` is
+  -- contained in `{2^0, …, 2^(k-1)}`; that whole set sums to `2^k - 1 < 2^k`.
+  have hsub : S ⊆ (Finset.range k).image (2 ^ ·) := by
+    intro b hb
+    obtain ⟨j, rfl⟩ := hS (Finset.mem_coe.mpr hb)
+    have hj : j < k := by
+      by_contra hjk
+      have hle2 : (2 : ℕ) ^ k ≤ 2 ^ j :=
+        Nat.pow_le_pow_right (by norm_num) (Nat.le_of_not_lt hjk)
+      have hlt2 := hlt _ hb
+      omega
+    exact Finset.mem_image.mpr ⟨j, Finset.mem_range.mpr hj, rfl⟩
+  have hle : S.sum id ≤ ((Finset.range k).image (2 ^ ·)).sum id :=
+    Finset.sum_le_sum_of_subset hsub
+  have himg : ((Finset.range k).image (2 ^ ·)).sum id
+      = ∑ j ∈ Finset.range k, 2 ^ j := by
+    rw [Finset.sum_image fun x _ y _ h => Nat.pow_right_injective le_rfl h]
+    simp
+  have hgeom : ∀ m : ℕ, ∑ j ∈ Finset.range m, 2 ^ j = 2 ^ m - 1 := by
+    intro m
+    induction m with
+    | zero => simp
+    | succ n ih =>
+        rw [Finset.sum_range_succ, ih, pow_succ]
+        have h1 : 0 < (2 : ℕ) ^ n := by positivity
+        omega
+  have hone : 0 < (2 : ℕ) ^ k := by positivity
+  intro hsum
+  have hk := hgeom k
+  omega
 
 /-
 **Powers of 3 that are 1 mod 3:**

--- a/research/problems/erdos-876-incomplete-01/knowledge.md
+++ b/research/problems/erdos-876-incomplete-01/knowledge.md
@@ -36,3 +36,25 @@ implication as a valid (sorry'd) result.
 - `powers_of_two_sumfree` sorry (line ~255): `{2^k}` is Erdős-sum-free — TRUE,
   via uniqueness of binary representation; tractable next step.
 - `graham_result` axiom (near-linear gaps) + the open linear-gap question remain.
+
+### 2026-07-22 (researcher-1) — powers_of_two_sumfree proved; file sorry-free
+
+Closed the file's last sorry. `powers_of_two_sumfree : IsSumFreeErdos {n | ∃ k, n = 2^k}`
+— no binary-uniqueness machinery needed; the inequality route is enough:
+
+- Given `a = 2^k` and a finset `S` of powers of two all `< 2^k`, each member is `2^j`
+  with `j < k` (contrapositive of `Nat.pow_le_pow_right` + `omega`), so
+  `S ⊆ (Finset.range k).image (2 ^ ·)`.
+- `Finset.sum_le_sum_of_subset` bounds `S.sum id` by the full geometric sum, which is
+  `2^k - 1` (helper `∀ m, ∑ j ∈ range m, 2^j = 2^m - 1`, induction + `pow_succ` + `omega`).
+- `2^k - 1 < 2^k` (positivity) closes it; the `card ≥ 2` hypothesis is not needed.
+
+Lean notes: `Finset.sum_image` wants pointwise injectivity — `Nat.pow_right_injective le_rfl`;
+the image-sum vs `∑ 2^j` gap after `rw [Finset.sum_image …]` is `id`-unfolding, closed by `simp`.
+Host-verified (`lake env lean`, v4.31, exit 0); `#print axioms powers_of_two_sumfree` =
+`[propext, Classical.choice, Quot.sound]`.
+
+**File state:** 0 sorries; 1 axiom (`graham_result`, deep — Graham's `n^{1+o(1)}` gap bound).
+The genuinely open content (linear gaps, `ErdosQuestion876`) has no elementary path — node COMPLETE.
+Gallery meta/annotations synced (sorries 0, lineCount 334, stale meta.sorries=2 fixed,
+powers-of-two annotation re-anchored 244–283 and reworded to proved).

--- a/research/registry.json
+++ b/research/registry.json
@@ -37262,7 +37262,7 @@
       "phase": "NEW",
       "path": "full",
       "started": "2026-07-10T01:42:11.467Z",
-      "status": "active",
+      "status": "completed",
       "lastUpdate": "2026-07-10T01:42:11.467Z"
     },
     {

--- a/src/data/proofs/erdos-876/annotations.json
+++ b/src/data/proofs/erdos-876/annotations.json
@@ -215,12 +215,12 @@
     "id": "ann-876-10",
     "proofId": "erdos-876",
     "range": {
-      "startLine": 237,
-      "endLine": 241
+      "startLine": 244,
+      "endLine": 283
     },
     "type": "concept",
     "title": "Powers of Two: Sum-Free Example",
-    "content": "`powers_of_two_sumfree` states that $\\{2^n : n \\in \\mathbb{N}\\}$ is Erdős sum-free (with sorry). The proof relies on uniqueness of binary representation: $2^n$ has a single $1$-bit in position $n$, while any sum of distinct smaller powers of 2 has $1$-bits only in positions $< n$. Hence their sum is $< 2^n$, and equality is impossible. This is the simplest infinite sum-free set, but with exponential gaps $2^{n+1} - 2^n = 2^n$.",
+    "content": "`powers_of_two_sumfree` proves that $\\{2^n : n \\in \\mathbb{N}\\}$ is Erdős sum-free. Any finset of distinct powers of 2 below $2^k$ embeds in $\\{2^0, \\dots, 2^{k-1}\\}$ (injectivity of $j \\mapsto 2^j$), so its sum is at most the full geometric sum $2^k - 1 < 2^k$, and equality is impossible. This is the simplest infinite sum-free set, but with exponential gaps $2^{n+1} - 2^n = 2^n$.",
     "mathContext": "$\\{1, 2, 4, 8, 16, \\ldots\\}$ is sum-free: $2^n = \\sum_{i \\in S} 2^i$ with $S \\subseteq \\{0,\\ldots,n-1\\}$ implies $2^n \\leq \\sum_{i=0}^{n-1} 2^i = 2^n - 1 < 2^n$, a contradiction. Gaps: $2^{n+1} - 2^n = 2^n$, which is exponential — far from linear.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -237,8 +237,8 @@
     "id": "ann-876-11",
     "proofId": "erdos-876",
     "range": {
-      "startLine": 249,
-      "endLine": 257
+      "startLine": 290,
+      "endLine": 303
     },
     "type": "concept",
     "title": "Connections to Sidon Sets and $B_h$ Sequences",

--- a/src/data/research/problems/erdos-876-incomplete-01.json
+++ b/src/data/research/problems/erdos-876-incomplete-01.json
@@ -16,12 +16,18 @@
     "goal": "Eliminate the 2 remaining sorry statement(s) in the parent formalization."
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-07-09T00:00:00.000Z",
     "iteration": 0,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "focus": "Formalization complete: all sorries eliminated; sole remaining assumption is the deep graham_result axiom.",
+    "blockers": [
+      {
+        "route": "proving graham_result (gap bound n^{1+o(1)}, Graham) or resolving ErdosQuestion876 (linear gaps) in Lean",
+        "reopenCriterion": "materially new mechanism required (this is the open content of Erdős #876 itself)",
+        "blockedAt": "2026-07-22"
+      }
+    ],
+    "nextAction": "None — node complete. The linear-gap question (ErdosQuestion876) is the genuinely open problem and lives behind the graham_result axiom; no elementary path.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,18 +35,20 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: corrected the false gallery theorem erdos_implies_classical in Erdos876Problem.lean (counterexample {2,4} + the true distinct-positive version erdos_implies_classical_of_pos), eliminating its sorry (file sorries 2->1), 0 axioms, host-verified. Remaining sorry: powers_of_two_sumfree (true, binary-uniqueness argument). Main gap question (linear gaps) stays open behind graham_result axiom.",
+    "progressSummary": "COMPLETED: Erdos876Problem.lean now has 0 sorries. powers_of_two_sumfree proved (session 2026-07-22): any finset of distinct powers of two below 2^k embeds in {2^0..2^(k-1)} via injectivity of 2^-, so its sum is at most the geometric sum 2^k - 1 < 2^k. Host-verified lake env lean v4.31 exit 0; #print axioms = [propext, Classical.choice, Quot.sound]. Earlier session corrected the false erdos_implies_classical (counterexample {2,4}). Sole remaining assumption: the deep graham_result axiom (Graham's n^{1+o(1)} gap bound); the linear-gap question ErdosQuestion876 is the open content of Erdős #876.",
     "builtItems": [
       "not_isSumFreeErdos_imp_isSumFreeClassical (Erdos876Problem.lean): machine-checked counterexample {2,4} proving the naive Erdos=>classical implication is false; 0-axiom",
-      "erdos_implies_classical_of_pos (Erdos876Problem.lean): corrected implication for distinct positive a,b via 2-element witness {a,b}; 0-axiom"
+      "erdos_implies_classical_of_pos (Erdos876Problem.lean): corrected implication for distinct positive a,b via 2-element witness {a,b}; 0-axiom",
+      "Proved powers_of_two_sumfree in Erdos876Problem.lean:250 (was the file's last sorry; +29 lines)"
     ],
     "insights": [
       "The gallery theorem erdos_implies_classical (IsSumFreeErdos A -> IsSumFreeClassical A) was FALSE: A={2,4} is Erdos-sum-free (no >=2 distinct smaller elements sum to an element) but 2+2=4 in A violates IsSumFreeClassical (which permits repeated summand a+a). Distinctness AND positivity are both required for the true implication.",
-      "Replaced the false theorem + its sorry with a counterexample and the corrected erdos_implies_classical_of_pos; file sorries 2->1 (only powers_of_two_sumfree remains). Host-verified lake env lean v4.31 EXIT=0."
+      "Replaced the false theorem + its sorry with a counterexample and the corrected erdos_implies_classical_of_pos; file sorries 2->1 (only powers_of_two_sumfree remains). Host-verified lake env lean v4.31 EXIT=0.",
+      "powers_of_two_sumfree needs no binary-representation uniqueness: the inequality route suffices. Map each member of S to its exponent (2^j < 2^k gives j < k via monotonicity), embed S in (range k).image (2 ^ .), and bound sum S <= sum_{j<k} 2^j = 2^k - 1 by Finset.sum_le_sum_of_subset. Lean pieces: Finset.sum_image with Nat.pow_right_injective le_rfl; geometric sum by induction + omega (pow_succ then treat 2^n as an atom); final contradiction is one omega over the chained atoms."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove powers_of_two_sumfree (2^k is Erdos-sum-free via binary representation uniqueness)."
+      "None at this node — formalization complete. Remaining open content (graham_result proof, linear-gap question) is deep; see blockers."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session for erdos-876-incomplete-01 (Erdős #876: sum-free sets and gap growth).

## Progress
- Proved `powers_of_two_sumfree` in `proofs/Proofs/Erdos876Problem.lean` — the file's last remaining sorry. The set {2^k} is sum-free in the Erdős sense (no element is a sum of >= 2 distinct smaller elements).
- Proof mechanism: each member of a candidate finset S is a power of two strictly below 2^k, so S embeds in {2^0, ..., 2^(k-1)} (injectivity of j -> 2^j); `Finset.sum_le_sum_of_subset` then bounds the sum by the geometric sum 2^k - 1 < 2^k. No binary-representation machinery needed; the card >= 2 hypothesis is unused.
- Synced gallery meta/annotations: `sorries` 1 -> 0 (also fixed the stale `meta.sorries: 2`), lineCount 305 -> 334, theoremCount 3 -> 4 in `meta.sorries` block, stale "(sorry)" prose rewritten, powers-of-two annotation re-anchored (244-283) and reworded to proved.
- Tracker: phase -> COMPLETED with a structured blocker for the deep remaining content; registry `active` -> `completed` (durable stop-re-serve).

## Verification
- Host-verified: `lake env lean` (Mathlib v4.31), exit 0, no warnings.
- `#print axioms Erdos876.powers_of_two_sumfree` = `[propext, Classical.choice, Quot.sound]` (axiom-free).

## Status
**Outcome**: completed
**File state**: 0 sorries; 1 axiom (`graham_result` — Graham's n^{1+o(1)} gap bound, deep published result, correctly axiomatized). The genuinely open content of Erdős #876 (linear gaps, `ErdosQuestion876`) remains open behind it; no elementary path.
**Next Steps**: none at this node.

🤖 Generated by researcher-1
