### PR TITLE
Fix: erdos-433 drop 2 phantom originalContributions entries

### DIFF
--- a/src/data/proofs/erdos-433/meta.json
+++ b/src/data/proofs/erdos-433/meta.json
@@ -47,9 +47,7 @@
       "g(k,n) definition: max Frobenius over k-subsets of {1,...,n}",
       "Sylvester-Frobenius formula axiom: G({a,b}) = ab - a - b",
       "Dixmier's lower and upper bound axioms",
-      "AsymptoticFormula definition: g(k,n) ~ n²/(k-1)",
-      "Extremal set structure theorem",
-      "Gap counting and symmetry properties"
+      "AsymptoticFormula definition: g(k,n) ~ n²/(k-1)"
     ],
     "axiomCount": 4,
     "lineCount": 398,


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-433
**Problem**: `originalContributions` lists "Extremal set structure theorem" and "Gap counting and symmetry properties" as contributions, but no such theorem/definition exists in `Proofs/Erdos433Problem.lean` — Parts VII and IX are pure prose comment blocks. The `sections[]` field already describes these honestly ("Documents the extremal sets...", "Documents the gap-counting..."), so this is a top-level/section-level inconsistency.

## Evidence

**meta.json claims** (before): `originalContributions` includes "Extremal set structure theorem" and "Gap counting and symmetry properties".

**Lean file shows**: `grep -nE '^\s*(theorem|def|axiom|lemma|private lemma)\s' Proofs/Erdos433Problem.lean` — no declaration relating to "extremal" or "gap" exists; those parts of the file are comment-only.

Everything else verified correct: 4 axioms (`sylvester_frobenius`, `dixmier_lower_bound`, `dixmier_upper_bound`, `erdos_433_solved`), 0 sorries, 8 theorems (6 public + 2 private), 5 definitions, lineCount 398 — all match meta.json. Companion file `Erdos433Aristotle.lean` is fully proved (no axioms/sorries) and every lemma it's called for (`pair_subset_range`, `pair_card`, `finset_gcd_pred_self`, `frobenius_ub_pair`, `dixmier_k2_arith`) genuinely exists and is proved there. No native_decide, no True stubs.

## Fix

Removed the 2 phantom entries from `originalContributions` in `src/data/proofs/erdos-433/meta.json`.

---
Discovered during gallery integrity audit.