### PR TITLE
Audit: erdos-1007-oq-01 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8613,8 +8613,8 @@
     },
     "erdos-1007-oq-01": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:02:35Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-22T21:02:19Z",
       "result": "clean"
     },
     "erdos-1007-oq-01-oq-01": {


### PR DESCRIPTION
Reserve-mode re-audit. Verified theorem count (89), definition+structure count (14), 0 literal axioms, 0 sorries, and 15 native_decide uses all matching disclosed `assumptions` field. Spot-checked axiom-free claims (complete_graph_dim_exact chain) — genuinely native_decide-free, proved via linear independence argument. Clean.