### PR TITLE
Enrich de-moivre-oq-01-oq-03-oq-02: cover header docstring (lines 1-44)

### DIFF
--- a/src/data/proofs/de-moivre-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-03-oq-02/meta.json
@@ -144,6 +144,14 @@
   ],
   "sections": [
     {
+      "id": "header",
+      "title": "Header: Packaging the Chebyshev Semigroup Law as a Monoid Homomorphism",
+      "summary": "Module docstring: states the open question — package the parent's Chebyshev–De Moivre recurrence as the semigroup/nesting law C_mn(x) = C_m(C_n(x)) over 𝔽_p, expressed as a monoid homomorphism (ℤ,·) →* (End 𝔽_p, ∘) — and explains this builds on Mathlib's existing polynomial composition identity C_mul, with the new content being the evaluation-map packaging, the commuting family, and the power-map conjugacy via z ↦ z+z⁻¹.",
+      "startLine": 1,
+      "endLine": 44,
+      "mathContext": "$C_{mn}(x) = C_m(C_n(x))$ over $\\mathbb F_p$, from Mathlib's $C_{R}(m\\cdot n) = C_R(m)\\circ C_R(n)$; bundled as a monoid homomorphism $(\\mathbb Z,\\cdot) \\to^* \\mathrm{End}(\\mathbb F_p)$, with $C_n$ conjugate to $z\\mapsto z^n$ via $z\\mapsto z+z^{-1}$ on the unit circle $zw=1$."
+    },
+    {
       "id": "evaluation-law",
       "title": "Evaluation-Map Composition Law",
       "startLine": 45,


### PR DESCRIPTION
## Summary
- Adds a `header`-type section covering lines 1-44 of `DeMoivreOQ01OQ03OQ02.lean`, previously uncovered.
- Docstring states the open question (package the Chebyshev semigroup law C_mn = C_m ∘ C_n over 𝔽_p as a monoid homomorphism) and what's new vs. Mathlib's existing polynomial composition law.

## Test plan
- [x] `pnpm build` passes