### PR TITLE
Enrich erdos-1012-oq-03-oq-02: cover header docstring (lines 1-54)

### DIFF
--- a/src/data/proofs/erdos-1012-oq-03-oq-02/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03-oq-02/meta.json
@@ -90,6 +90,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Header: The Directed Handshake Lemma and Tournament Score Sums",
+      "summary": "Module docstring: notes the companion file's Hamiltonicity theorems rest on degree-counting identities that were never stated there, and states this file's headline result — the directed handshake lemma ∑outDegree = arcCount = ∑inDegree — together with its tournament specializations (outDegree+inDegree=n−1, 2·arcCount=n(n−1), the Landau score-sum identity) and a pigeonhole averaging consequence used by Ghouila–Houri-style threshold arguments.",
+      "startLine": 1,
+      "endLine": 54,
+      "mathContext": "Directed handshake lemma: $\\sum_v \\mathrm{outDegree}(v) = \\mathrm{arcCount} = \\sum_v \\mathrm{inDegree}(v)$; for tournaments, $\\mathrm{outDegree}(v)+\\mathrm{inDegree}(v)=n-1$, $2\\cdot\\mathrm{arcCount}=n(n-1)$, and $2\\sum_v\\mathrm{outDegree}(v)=n(n-1)$ (Landau's identity)."
+    },
+    {
       "id": "definitions",
       "title": "§0: Digraph definitions",
       "startLine": 56,


### PR DESCRIPTION
## Summary
- Adds a `header`-type section covering lines 1-54 of `Erdos1012OQ03OQ02.lean`, previously uncovered.
- Docstring states the headline directed handshake lemma and its tournament specializations (score sums, Landau's identity).

## Test plan
- [x] `pnpm build` passes