### PR TITLE
Research: erdos-531-incomplete-01 - prove F 2 = 8 (kernel decide, file now sorry-free)

### DIFF
--- a/proofs/Proofs/Erdos531Incomplete01.lean
+++ b/proofs/Proofs/Erdos531Incomplete01.lean
@@ -9,9 +9,10 @@ import Proofs.Erdos531Problem
 
 **Erdős Problem #531** (OPEN growth rate). `F(k)` is the least `N` such that every
 2-colouring of `{1,…,N}` admits a `k`-element set whose non-empty subset sums are
-monochromatic. `Erdos531Problem.lean` proves `F 1 = 1` but leaves `F 2 = 8` as a
-`sorry`, noting it needs the reduction of the infinite colouring quantifier
-`∀ c : ℕ → Bool` to a finite search — deferred there as out of scope.
+monochromatic. `Erdos531Problem.lean` proves `F 1 = 1` and (as of 2026-07-22)
+`F 2 = 8` in full: the infinite colouring quantifier `∀ c : ℕ → Bool` is reduced
+to a kernel-`decide` check `forcedCheck_all` over the 256 restrictions to
+`{1,…,8}`, plus the explicit `N = 7` witness colouring.
 
 This companion supplies the reusable **`k = 2` subset-sum machinery** that
 reduction rests on: for a genuine two-element set `{a, b}` (`a ≠ b`) the

--- a/proofs/Proofs/Erdos531Problem.lean
+++ b/proofs/Proofs/Erdos531Problem.lean
@@ -135,6 +135,201 @@ theorem F_1 : F 1 = 1 := by
   have hge : 1 ≤ F 1 := validN_one_ge_one (Nat.sInf_mem ⟨1, hmem⟩)
   exact le_antisymm hle hge
 
+/-- For a distinct pair `{a, b}`, monochromaticity of all subset sums is exactly
+    `c b = c a ∧ c (a + b) = c a`: the non-empty subsets of a pair are `{a}`,
+    `{b}`, `{a, b}`, with sums `a`, `b`, `a + b`. -/
+theorem monochromaticSubsetSums_pair_iff (c : Coloring) {a b : ℕ} (hab : a ≠ b) :
+    MonochromaticSubsetSums c {a, b} ↔ c b = c a ∧ c (a + b) = c a := by
+  constructor
+  · rintro ⟨col, hcol⟩
+    have hmem_a : a ∈ SubsetSums {a, b} := by
+      rw [SubsetSums, Finset.mem_image]
+      refine ⟨{a}, ?_, by simp⟩
+      rw [Finset.mem_filter, Finset.mem_powerset]
+      exact ⟨Finset.singleton_subset_iff.mpr (Finset.mem_insert_self a {b}),
+        Finset.singleton_ne_empty a⟩
+    have hmem_b : b ∈ SubsetSums {a, b} := by
+      rw [SubsetSums, Finset.mem_image]
+      refine ⟨{b}, ?_, by simp⟩
+      rw [Finset.mem_filter, Finset.mem_powerset]
+      exact ⟨Finset.singleton_subset_iff.mpr
+        (Finset.mem_insert_of_mem (Finset.mem_singleton_self b)),
+        Finset.singleton_ne_empty b⟩
+    have hmem_ab : a + b ∈ SubsetSums {a, b} := by
+      rw [SubsetSums, Finset.mem_image]
+      refine ⟨{a, b}, ?_, by simp [Finset.sum_pair hab]⟩
+      rw [Finset.mem_filter, Finset.mem_powerset]
+      exact ⟨Finset.Subset.refl _, Finset.insert_ne_empty a {b}⟩
+    rw [hcol a hmem_a, hcol b hmem_b, hcol (a + b) hmem_ab]
+    exact ⟨rfl, rfl⟩
+  · rintro ⟨hba, hsum⟩
+    refine ⟨c a, ?_⟩
+    intro s hs
+    rw [SubsetSums, Finset.mem_image] at hs
+    obtain ⟨t, htf, hts⟩ := hs
+    rw [Finset.mem_filter, Finset.mem_powerset] at htf
+    obtain ⟨hsub, hne⟩ := htf
+    by_cases ha' : a ∈ t <;> by_cases hb' : b ∈ t
+    · have ht : t = {a, b} := by
+        apply Finset.Subset.antisymm hsub
+        intro x hx
+        rcases Finset.mem_insert.mp hx with rfl | hx'
+        · exact ha'
+        · rw [Finset.mem_singleton] at hx'; subst hx'; exact hb'
+      subst ht
+      rw [Finset.sum_pair hab] at hts
+      simp only [id_eq] at hts
+      rw [← hts]; exact hsum
+    · have ht : t = {a} := by
+        apply Finset.Subset.antisymm
+        · intro x hx
+          rcases Finset.mem_insert.mp (hsub hx) with rfl | hx'
+          · exact Finset.mem_singleton_self _
+          · rw [Finset.mem_singleton] at hx'; subst hx'; exact absurd hx hb'
+        · exact Finset.singleton_subset_iff.mpr ha'
+      subst ht
+      simp only [Finset.sum_singleton, id_eq] at hts
+      rw [← hts]
+    · have ht : t = {b} := by
+        apply Finset.Subset.antisymm
+        · intro x hx
+          rcases Finset.mem_insert.mp (hsub hx) with rfl | hx'
+          · exact absurd hx ha'
+          · rw [Finset.mem_singleton] at hx'; subst hx'
+            exact Finset.mem_singleton_self _
+        · exact Finset.singleton_subset_iff.mpr hb'
+      subst ht
+      simp only [Finset.sum_singleton, id_eq] at hts
+      rw [← hts]; exact hba
+    · obtain ⟨x, hx⟩ := Finset.nonempty_iff_ne_empty.mpr hne
+      rcases Finset.mem_insert.mp (hsub hx) with rfl | hx'
+      · exact absurd hx ha'
+      · rw [Finset.mem_singleton] at hx'; subst hx'; exact absurd hx hb'
+
+/-- Bool-level check: some distinct pair `{i+1, j+1} ⊆ {1,…,8}` of colour `col`
+    (under `v : Fin 8 → Bool`, `v i` = colour of `i+1`) has element sum `s`. -/
+def monoPairSumCheck (v : Fin 8 → Bool) (s : ℕ) (col : Bool) : Bool :=
+  (List.finRange 8).any fun i =>
+    (List.finRange 8).any fun j =>
+      decide (i.val < j.val) && decide (i.val + j.val + 2 = s) &&
+        (v i == col) && (v j == col)
+
+/-- Bool-level check that a colouring of `{1,…,8}` is *forced*: either some
+    distinct pair with sum ≤ 8 is already monochromatic, or some sum
+    `s ∈ {9,…,16}` carries both a `true`-monochromatic and a
+    `false`-monochromatic pair — so no colour of `s` avoids a pair. -/
+def forcedCheck (v : Fin 8 → Bool) : Bool :=
+  ((List.finRange 8).any fun i =>
+    (List.finRange 8).any fun j =>
+      decide (i.val < j.val) &&
+        (if h : i.val + j.val + 2 ≤ 8 then
+          (v i == v j) && (v ⟨i.val + j.val + 1, by omega⟩ == v i)
+        else false))
+  ||
+  ((List.range 8).any fun k =>
+    monoPairSumCheck v (k + 9) true && monoPairSumCheck v (k + 9) false)
+
+/-- Exhaustive kernel check over all `2^8 = 256` colourings of `{1,…,8}`:
+    every one is forced. Pure `decide` — no `native_decide`, no new axioms. -/
+set_option maxRecDepth 8192 in
+theorem forcedCheck_all : ∀ v : Fin 8 → Bool, forcedCheck v = true := by decide
+
+/-- `8 ∈ ValidN 2`: every 2-colouring of `ℕ` admits a distinct pair
+    `{a, b} ⊆ {1,…,8}` whose subset sums `a`, `b`, `a + b` are monochromatic. -/
+theorem eight_mem_validN_two : (8 : ℕ) ∈ ValidN 2 := by
+  intro c
+  have hb := forcedCheck_all (fun i : Fin 8 => c (i.val + 1))
+  simp only [forcedCheck, Bool.or_eq_true] at hb
+  rcases hb with h | h
+  · -- a direct pair with sum ≤ 8
+    obtain ⟨i, -, hi⟩ := List.any_eq_true.mp h
+    obtain ⟨j, -, hj⟩ := List.any_eq_true.mp hi
+    rw [Bool.and_eq_true] at hj
+    obtain ⟨hij', hd⟩ := hj
+    have hij : i.val < j.val := of_decide_eq_true hij'
+    have hi8 := i.isLt
+    have hj8 := j.isLt
+    by_cases hs : i.val + j.val + 2 ≤ 8
+    · rw [dif_pos hs, Bool.and_eq_true] at hd
+      obtain ⟨hvv, hvs⟩ := hd
+      have h1 : c (j.val + 1) = c (i.val + 1) := (beq_iff_eq.mp hvv).symm
+      have h2 : c (i.val + j.val + 1 + 1) = c (i.val + 1) := beq_iff_eq.mp hvs
+      refine ⟨{i.val + 1, j.val + 1}, Finset.card_pair (by omega), ?_, ?_⟩
+      · intro x hx
+        rcases Finset.mem_insert.mp hx with rfl | hx'
+        · exact ⟨by omega, by omega⟩
+        · rw [Finset.mem_singleton] at hx'; subst hx'
+          exact ⟨by omega, by omega⟩
+      · refine (monochromaticSubsetSums_pair_iff c (by omega)).mpr ⟨h1, ?_⟩
+        have hrw : i.val + 1 + (j.val + 1) = i.val + j.val + 1 + 1 := by omega
+        rw [hrw]
+        exact h2
+    · rw [dif_neg hs] at hd
+      exact absurd hd (by simp)
+  · -- a conflict sum s = k + 9: both colours of s are excluded, so whichever
+    -- colour `c (k+9)` takes completes one of the two recorded pairs
+    obtain ⟨k, -, hk⟩ := List.any_eq_true.mp h
+    rw [Bool.and_eq_true] at hk
+    obtain ⟨ht, hf⟩ := hk
+    simp only [monoPairSumCheck] at ht hf
+    obtain ⟨i₁, -, hi₁⟩ := List.any_eq_true.mp ht
+    obtain ⟨j₁, -, hj₁⟩ := List.any_eq_true.mp hi₁
+    obtain ⟨i₂, -, hi₂⟩ := List.any_eq_true.mp hf
+    obtain ⟨j₂, -, hj₂⟩ := List.any_eq_true.mp hi₂
+    simp only [Bool.and_eq_true, beq_iff_eq, decide_eq_true_eq] at hj₁ hj₂
+    obtain ⟨⟨⟨hij₁, hsum₁⟩, hci₁⟩, hcj₁⟩ := hj₁
+    obtain ⟨⟨⟨hij₂, hsum₂⟩, hci₂⟩, hcj₂⟩ := hj₂
+    have hb₁ := i₁.isLt; have hb₂ := j₁.isLt
+    have hb₃ := i₂.isLt; have hb₄ := j₂.isLt
+    cases hcs : c (k + 9)
+    · -- c (k+9) = false: the false-coloured pair completes
+      refine ⟨{i₂.val + 1, j₂.val + 1}, Finset.card_pair (by omega), ?_, ?_⟩
+      · intro x hx
+        rcases Finset.mem_insert.mp hx with rfl | hx'
+        · exact ⟨by omega, by omega⟩
+        · rw [Finset.mem_singleton] at hx'; subst hx'
+          exact ⟨by omega, by omega⟩
+      · refine (monochromaticSubsetSums_pair_iff c (by omega)).mpr ⟨?_, ?_⟩
+        · rw [hci₂, hcj₂]
+        · have hrw : i₂.val + 1 + (j₂.val + 1) = k + 9 := by omega
+          rw [hrw, hcs, hci₂]
+    · -- c (k+9) = true: the true-coloured pair completes
+      refine ⟨{i₁.val + 1, j₁.val + 1}, Finset.card_pair (by omega), ?_, ?_⟩
+      · intro x hx
+        rcases Finset.mem_insert.mp hx with rfl | hx'
+        · exact ⟨by omega, by omega⟩
+        · rw [Finset.mem_singleton] at hx'; subst hx'
+          exact ⟨by omega, by omega⟩
+      · refine (monochromaticSubsetSums_pair_iff c (by omega)).mpr ⟨?_, ?_⟩
+        · rw [hci₁, hcj₁]
+        · have hrw : i₁.val + 1 + (j₁.val + 1) = k + 9 := by omega
+          rw [hrw, hcs, hci₁]
+
+/-- The explicit colouring defeating `N = 7`: colour `3, 5, 6, 7` red (`true`)
+    and everything else — in particular `1, 2, 4` and all sums `≥ 8` — blue
+    (`false`). Red pair sums land in `{8,…,13}` (blue), blue pair sums land in
+    `{3, 5, 6}` (red). -/
+def witnessColoring : Coloring := fun n =>
+  decide (n = 3 ∨ n = 5 ∨ n = 6 ∨ n = 7)
+
+/-- `7 ∉ ValidN 2`: the witness colouring leaves every distinct pair in
+    `{1,…,7}` non-monochromatic. -/
+theorem seven_not_mem_validN_two : (7 : ℕ) ∉ ValidN 2 := by
+  intro h
+  obtain ⟨A, hcard, hbound, hmono⟩ := h witnessColoring
+  obtain ⟨a, b, hab, rfl⟩ := Finset.card_eq_two.mp hcard
+  obtain ⟨h1, h2⟩ := (monochromaticSubsetSums_pair_iff witnessColoring hab).mp hmono
+  obtain ⟨ha1, ha7⟩ := hbound a (Finset.mem_insert_self a {b})
+  obtain ⟨hb1, hb7⟩ := hbound b (Finset.mem_insert_of_mem (Finset.mem_singleton_self b))
+  interval_cases a <;> interval_cases b <;> revert hab h1 h2 <;> decide
+
+/-- `ValidN k` is upward closed: a witness set for `N` also lies in `{1,…,M}`
+    for any `M ≥ N`. -/
+theorem validN_mono {k N M : ℕ} (hNM : N ≤ M) (hN : N ∈ ValidN k) : M ∈ ValidN k := by
+  intro c
+  obtain ⟨A, hcard, hbound, hmono⟩ := hN c
+  exact ⟨A, hcard, fun a ha => ⟨(hbound a ha).1, (hbound a ha).2.trans hNM⟩, hmono⟩
+
 /-- F(2) = 8. **Correction (2026-07-10):** an earlier draft claimed `F 2 = 3`.
     That value is FALSE for the distinct-pair Folkman number defined here (a set
     `A` of `k = 2` *distinct* elements `{a, b}` with `a, b, a+b` monochromatic).
@@ -149,11 +344,18 @@ theorem F_1 : F 1 = 1 := by
     (In particular `3 ∉ ValidN 2`: the colouring `3 ↦ R`, everything else `B`
     defeats all three pairs of `{1,2,3}`, namely `{1,2}`, `{1,3}`, `{2,3}`.)
 
-    The exact-value proof requires reducing the infinite coloring quantifier
-    `∀ c : ℕ → Bool` to a finite search over `{1,…,15}`; that finite-reduction is
-    left for a follow-up session (out of scope here). -/
+    The finite-coloring reduction is carried out below: `forcedCheck_all` kernel-
+    checks all 256 restrictions of a colouring to `{1,…,8}`, certifying that each
+    either contains a direct monochromatic pair (sum ≤ 8) or pins a sum
+    `s ∈ {9,…,16}` on which two opposite-coloured pairs collide — so either
+    colour of `s` completes a pair. -/
 theorem F_2 : F 2 = 8 := by
-  sorry -- Verified by exhaustive computation; needs finite-coloring reduction to formalize.
+  have h8 : (8 : ℕ) ∈ ValidN 2 := eight_mem_validN_two
+  have h7 : (7 : ℕ) ∉ ValidN 2 := seven_not_mem_validN_two
+  have hne : (ValidN 2).Nonempty := ⟨8, h8⟩
+  rcases Nat.lt_or_ge (F 2) 8 with hlt | hge
+  · exact absurd (validN_mono (by omega) (Nat.sInf_mem hne)) h7
+  · exact le_antisymm (Nat.sInf_le h8) hge
 
 /-  F(3) ≥ 11: Lower bound for 3-element sets. -/
 /-

--- a/proofs/Proofs/Erdos531Problem.lean
+++ b/proofs/Proofs/Erdos531Problem.lean
@@ -229,9 +229,9 @@ def forcedCheck (v : Fin 8 → Bool) : Bool :=
   ((List.range 8).any fun k =>
     monoPairSumCheck v (k + 9) true && monoPairSumCheck v (k + 9) false)
 
+set_option maxRecDepth 8192 in
 /-- Exhaustive kernel check over all `2^8 = 256` colourings of `{1,…,8}`:
     every one is forced. Pure `decide` — no `native_decide`, no new axioms. -/
-set_option maxRecDepth 8192 in
 theorem forcedCheck_all : ∀ v : Fin 8 → Bool, forcedCheck v = true := by decide
 
 /-- `8 ∈ ValidN 2`: every 2-colouring of `ℕ` admits a distinct pair
@@ -354,7 +354,8 @@ theorem F_2 : F 2 = 8 := by
   have h7 : (7 : ℕ) ∉ ValidN 2 := seven_not_mem_validN_two
   have hne : (ValidN 2).Nonempty := ⟨8, h8⟩
   rcases Nat.lt_or_ge (F 2) 8 with hlt | hge
-  · exact absurd (validN_mono (by omega) (Nat.sInf_mem hne)) h7
+  · have hmem : F 2 ∈ ValidN 2 := Nat.sInf_mem hne
+    exact absurd (validN_mono (by omega) hmem) h7
   · exact le_antisymm (Nat.sInf_le h8) hge
 
 /-  F(3) ≥ 11: Lower bound for 3-element sets. -/

--- a/research/problems/erdos-531-incomplete-01/knowledge.md
+++ b/research/problems/erdos-531-incomplete-01/knowledge.md
@@ -22,3 +22,31 @@ host-verified, `#print axioms` = `[propext, Classical.choice, Quot.sound]` on al
 ### Next Steps
 - Prove `subsetSums_pair_subset : SubsetSums {a,b} ⊆ {a,b,a+b}` (subset enumeration
   of `{a,b}`), upgrading forward to the full iff and enabling step 2.
+
+### 2026-07-22 (researcher-1) — F 2 = 8 PROVED; parent file sorry-free
+
+Executed the deferred finite-coloring reduction directly in `Erdos531Problem.lean`
+(the companion's pair machinery pointed the way; the parent needed its own iff):
+
+- **Upper (`eight_mem_validN_two`)**: `forcedCheck_all` — kernel `decide` over all
+  `v : Fin 8 → Bool` (256 colourings of {1..8}, ~3.5s, NO native_decide): each is
+  either directly forced (mono distinct pair with sum ≤ 8) or pins a conflict sum
+  `s ∈ {9..16}` carrying both a true-mono and false-mono pair, so either colour of
+  `c s` completes a pair. KEY DESIGN: per-sum conflict check avoids enumerating the
+  2^16 extensions; the bridge to arbitrary `c : ℕ → Bool` is DEFINITIONAL — apply
+  the decided lemma at `fun i : Fin 8 => c (i.val + 1)`, no bit-encoding/testBit.
+- **Lower (`seven_not_mem_validN_two`)**: witness colouring 3,5,6,7 ↦ true, else
+  false (red pair sums land ≥ 8 = blue, blue pair sums are 3,5,6 = red);
+  `interval_cases a <;> interval_cases b <;> revert hab h1 h2 <;> decide`.
+- **Assembly**: `validN_mono` upward closure + `Nat.sInf_le`/`Nat.sInf_mem`.
+  GOTCHA: type-ascribe `Nat.sInf_mem hne : F 2 ∈ ValidN 2` or omega treats
+  `F 2` and `sInf (ValidN 2)` as distinct atoms. GOTCHA: doc-comment must follow
+  `set_option ... in`, not precede it.
+- `monochromaticSubsetSums_pair_iff`: pair {a,b} mono ↔ `c b = c a ∧ c (a+b) = c a`
+  (subsets of a pair = {a},{b},{a,b} — by_cases on a∈t/b∈t).
+
+Host-verified `lake env lean` v4.31 exit 0; `#print axioms F_2` =
+`[propext, Classical.choice, Quot.sound]`. File: 0 sorries, 14 theorems, 423 lines;
+2 deep axioms unchanged (folkman_theorem, balogh_2017). Gallery meta/annotations
+synced incl. the FALSE "F(2) = 3" claim still sitting in the small-cases annotation.
+Node COMPLETE. F(3) exact (2^33-scale) and F(k) growth remain the open content.

--- a/research/registry.json
+++ b/research/registry.json
@@ -37190,7 +37190,7 @@
       "phase": "NEW",
       "path": "full",
       "started": "2026-07-10T01:42:11.462Z",
-      "status": "active",
+      "status": "completed",
       "lastUpdate": "2026-07-10T01:42:11.462Z"
     },
     {

--- a/src/data/proofs/erdos-531/annotations.json
+++ b/src/data/proofs/erdos-531/annotations.json
@@ -181,11 +181,11 @@
     "proofId": "erdos-531",
     "range": {
       "startLine": 104,
-      "endLine": 113
+      "endLine": 361
     },
     "type": "concept",
     "title": "Small Cases",
-    "content": "**Explicit Values:**\n\n- **F(1) = 1:** Any single element has exactly one subset sum (itself), trivially monochromatic\n- **F(2) = 3:** In {1,2,3}, any 2-coloring forces {a,b,a+b} monochromatic\n- **F(3) ≥ 11:** The 3-element case requires at least 11 elements\n\nEven F(3) is only known as a lower bound - exact computation is very hard.",
+    "content": "**Explicit Values:**\n\n- **F(1) = 1:** Any single element has exactly one subset sum (itself), trivially monochromatic — proven as `F_1`.\n- **F(2) = 8:** For the distinct-pair Folkman number defined here, $N = 7$ still admits a defeating coloring ($3,5,6,7$ red, everything else blue), while every 2-coloring of $\\{1,\\ldots,8\\}$ forces a monochromatic pair $\\{a, b, a+b\\}$ — proven as `F_2` via a kernel-`decide` check (`forcedCheck_all`) over all 256 restrictions. An earlier draft's F(2) = 3 was false.\n- **F(3) ≥ 11:** Documented in a source comment only (no Lean declaration).\n\nEven F(3) is only known as a lower bound - exact computation is very hard.",
     "significance": "supporting",
     "relatedConcepts": [
       "Base cases",

--- a/src/data/proofs/erdos-531/meta.json
+++ b/src/data/proofs/erdos-531/meta.json
@@ -18,7 +18,7 @@
       "combinatorics"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 531,
     "erdosUrl": "https://erdosproblems.com/531",
     "erdosProblemStatus": "open",
@@ -50,14 +50,14 @@
       "folkman_theorem axiom: existence of F(k)",
       "balogh_2017 axiom: F(k) ≥ 2^{2^{k-1}/k}",
       "F_1 theorem (F(1) = 1): fully proven via one_mem_validN_one and validN_one_ge_one (no sorry)",
-      "F_2 theorem (F(2) = 8): value corrected from an earlier false F(2) = 3; proof sorry'd pending finite-coloring reduction. F(3) ≥ 11 documented in source comment only (no Lean declaration)",
+      "F_2 theorem (F(2) = 8): value corrected from an earlier false F(2) = 3; fully proven via a kernel-decide finite-coloring reduction (forcedCheck_all over all 256 restrictions to {1,...,8}, plus the explicit N = 7 witness coloring). F(3) ≥ 11 documented in source comment only (no Lean declaration)",
       "erdos_531 theorem: main result"
     ],
     "axiomCount": 2,
-    "lineCount": 220,
-    "assumptions": "2 axioms: folkman_theorem, balogh_2017. 1 sorry (F_2, the exact value F(2) = 8).",
-    "theoremCount": 9,
-    "definitionCount": 6,
+    "lineCount": 423,
+    "assumptions": "2 axioms: folkman_theorem, balogh_2017 (deep published results). 0 sorries.",
+    "theoremCount": 14,
+    "definitionCount": 9,
     "additionalFiles": [
       "Proofs/Erdos531Aristotle.lean"
     ]
@@ -66,7 +66,7 @@
     "historicalContext": "**Erdős Problem #531: Folkman's Theorem**\n\nThis problem asks about the quantitative aspects of Folkman's theorem, a fundamental result in Ramsey theory.\n\n**Key History:**\n- Sanders and Folkman (1960s): Proved the existence of F(k)\n- Rado's theorem (1933): Provides an alternative proof via partition regularity\n- Erdős-Spencer (1989): First non-trivial lower bound F(k) ≥ 2^{ck²/log k}\n- Balogh et al. (2017): Improved to F(k) ≥ 2^{2^{k-1}/k}\n\n**Mathematical Setting:**\nThe function F(k) is the Folkman number: the minimum N such that any 2-coloring of {1,...,N} contains a k-element subset where all 2^k - 1 non-empty subset sums are monochromatic.",
     "problemStatement": "**Problem Statement (Bounds Established, Exact Growth Open)**\n\nLet F(k) be the minimal N such that if we two-colour {1,...,N}, there is a set A of size k such that all subset sums (for non-empty subsets) are monochromatic. Estimate F(k).\n\n**Known Results:**\n$$F(k) \\geq 2^{2^{k-1}/k}$$\n\nBalogh-Eberhard-Narayanan-Treglown-Wagner (2017) proved this doubly-exponential lower bound, improving on Erdős-Spencer (1989).\n\nThe upper bound (from Folkman's existence proof) is much larger, leaving a huge gap.",
     "text": "Estimate F(k), the minimal N such that any 2-coloring of {1,...,N} has a k-element set with monochromatic subset sums. Lower bound: F(k) ≥ 2^{2^{k-1}/k}.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Core Definitions:**\n   - Coloring: ℕ → Bool\n   - SubsetSums: all non-empty subset sums of a finite set\n   - MonochromaticSubsetSums: all sums have same color\n   - F(k): minimum N using sInf\n\n2. **Main Theorems as Axioms:**\n   - folkman_theorem: F(k) exists (finite for all k ≥ 1)\n   - balogh_2017: F(k) ≥ 2^{2^{k-1}/k}\n   - erdos_spencer_1989 (documented in source comment only; no Lean declaration exists)\n\n3. **Small Cases:** F_1 (F(1) = 1) is fully proven; F_2 (F(2) = 8) is sorry-stubbed pending a finite-coloring reduction (an earlier draft's F(2) = 3 was false for the distinct-pair Folkman number defined here). F(3) ≥ 11 is documented in a source comment only (no Lean declaration)\n\n4. **Connections:** Link to Rado's theorem on partition regularity",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Core Definitions:**\n   - Coloring: ℕ → Bool\n   - SubsetSums: all non-empty subset sums of a finite set\n   - MonochromaticSubsetSums: all sums have same color\n   - F(k): minimum N using sInf\n\n2. **Main Theorems as Axioms:**\n   - folkman_theorem: F(k) exists (finite for all k ≥ 1)\n   - balogh_2017: F(k) ≥ 2^{2^{k-1}/k}\n   - erdos_spencer_1989 (documented in source comment only; no Lean declaration exists)\n\n3. **Small Cases:** F_1 (F(1) = 1) is fully proven; F_2 (F(2) = 8) is fully proven: a kernel-decide check over all 256 colorings of {1,...,8} shows each forces a direct pair or a conflict sum, and the explicit N = 7 witness coloring gives the lower bound (an earlier draft's F(2) = 3 was false for the distinct-pair Folkman number defined here). F(3) ≥ 11 is documented in a source comment only (no Lean declaration)\n\n4. **Connections:** Link to Rado's theorem on partition regularity",
     "keyInsights": [
       "A $k$-element set $A$ has $2^k - 1$ non-empty subsets, each producing a sum. Monochromaticity requires ALL these sums to get the same color — an exponentially growing constraint that explains why $F(k)$ grows so fast",
       "The lower bound $F(k) \\geq 2^{2^{k-1}/k}$ is doubly exponential: even the exponent $2^{k-1}/k$ grows exponentially in $k$. This means $F(5) \\geq 2^{16/5} \\approx 10$, but $F(20) \\geq 2^{2^{19}/20} \\approx 2^{26000}$ — enormous growth",
@@ -124,34 +124,34 @@
     {
       "id": "small-cases",
       "title": "Small Cases",
-      "summary": "Proves `F_1` ($F(1) = 1$) in full. Declares `F_2` ($F(2) = 8$) as a sorry-stubbed theorem pending a finite-coloring reduction; an earlier draft's $F(2) = 3$ was false for the distinct-pair Folkman number defined here. $F(3) \\geq 11$ is documented in a source comment only (no Lean declaration exists).",
+      "summary": "Proves `F_1` ($F(1) = 1$) and `F_2` ($F(2) = 8$) in full. The finite-coloring reduction is a kernel `decide` (`forcedCheck_all`) over all $256$ restrictions to $\\{1,\\ldots,8\\}$; an earlier draft's $F(2) = 3$ was false for the distinct-pair Folkman number defined here. $F(3) \\geq 11$ is documented in a source comment only (no Lean declaration exists).",
       "startLine": 96,
-      "endLine": 159,
-      "mathContext": "$F(1) = 1$: any single element has its (unique) subset sum trivially monochromatic (fully proven). $F(2) = 8$: for the distinct-pair number defined here ($\\{a,b\\}$ with $a,b,a+b$ mono), $N = 7$ admits a defeating 2-coloring while every 2-coloring of $\\{1,\\ldots,8\\}$ forces such a pair — so $F(2) = 8$, not $3$ (established by exhaustive check; the Lean proof needs a finite-coloring reduction). $F(3) \\geq 11$: verified by exhaustive search."
+      "endLine": 361,
+      "mathContext": "$F(1) = 1$: any single element has its (unique) subset sum trivially monochromatic (fully proven). $F(2) = 8$: for the distinct-pair number defined here ($\\{a,b\\}$ with $a,b,a+b$ mono), $N = 7$ admits a defeating 2-coloring while every 2-coloring of $\\{1,\\ldots,8\\}$ forces such a pair — so $F(2) = 8$, not $3$ (fully machine-checked: kernel `decide` over the $256$ restrictions plus the explicit $N = 7$ witness coloring). $F(3) \\geq 11$: verified by exhaustive search."
     },
     {
       "id": "upper-bounds",
       "title": "Upper Bounds",
       "summary": "Documents the tower-type upper bound from Folkman's original existence proof and the Hales-Jewett/Rado approach, which gives $F(k) \\leq \\text{tower}(k)$ for an iterated exponential.",
-      "startLine": 160,
-      "endLine": 167,
+      "startLine": 362,
+      "endLine": 369,
       "mathContext": "Upper bounds come from the Rado/Hales-Jewett proof, giving $F(k) \\leq \\text{tower}(O(k))$ (iterated exponential). The gap between lower ($2^{2^{k-1}/k}$) and upper ($\\text{tower}(O(k))$) is enormous — closing it is the core of Problem #531."
     },
     {
       "id": "rado-connection",
       "title": "Connection to Rado's Theorem",
       "summary": "documents in source comments `folkman_from_rado` (no Lean declaration exists): Folkman's theorem follows from Rado's theorem on partition regularity. The subset sum equations form a partition-regular system because the coefficient matrix satisfies Rado's columns condition.",
-      "startLine": 168,
-      "endLine": 181,
+      "startLine": 370,
+      "endLine": 383,
       "mathContext": "Rado's theorem (1933): a system $Ax = 0$ over $\\mathbb{Z}$ is partition regular iff $A$ satisfies the columns condition. For Folkman: the variables are $x_1, \\ldots, x_k$ and $y_S$ for each $\\emptyset \\neq S \\subseteq [k]$, with equations $\\sum_{i \\in S} x_i = y_S$. The coefficient matrix satisfies Rado's condition."
     },
     {
       "id": "main-results",
       "title": "Main Results",
       "summary": "Combines all results into `erdos_531`: Folkman's theorem holds, $F(k) \\geq 2^{2^{k-1}/k}$, and exact values for $k \\leq 2$. Asserts the exact growth rate remains open.",
-      "startLine": 182,
-      "endLine": 220,
-      "mathContext": "Summary: $F(k) < \\infty$ (Folkman), $F(k) \\geq 2^{2^{k-1}/k}$ (Balogh et al.), $F(1) = 1$ (proven), $F(2) = 8$ (value corrected from a false $F(2) = 3$; Lean proof sorry'd). The exact growth rate of $F(k)$ — somewhere between doubly exponential and tower-type — remains open."
+      "startLine": 384,
+      "endLine": 423,
+      "mathContext": "Summary: $F(k) < \\infty$ (Folkman), $F(k) \\geq 2^{2^{k-1}/k}$ (Balogh et al.), $F(1) = 1$ (proven), $F(2) = 8$ (value corrected from a false $F(2) = 3$; fully proven). The exact growth rate of $F(k)$ — somewhere between doubly exponential and tower-type — remains open."
     }
   ],
   "conclusion": {
@@ -176,12 +176,12 @@
     ],
     "opens": [],
     "namespace": "Erdos531",
-    "lineCount": 220,
+    "lineCount": 423,
     "axiomCount": 2,
-    "theoremCount": 9,
-    "definitionCount": 6,
+    "theoremCount": 14,
+    "definitionCount": 9,
     "path": "Proofs/Erdos531Problem.lean",
-    "sorries": 1,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos531Aristotle.lean"
     ]
@@ -203,5 +203,5 @@
       "description": "Erdős #843 concerns subset sums in combinatorial settings — directly related to the subset sum monochromaticity condition that defines $F(k)$"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }

--- a/src/data/research/problems/erdos-531-incomplete-01.json
+++ b/src/data/research/problems/erdos-531-incomplete-01.json
@@ -16,12 +16,18 @@
     "goal": "Eliminate the 2 remaining sorry statement(s) in the parent formalization."
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "COMPLETED",
     "since": "2026-07-09T00:00:00.000Z",
     "iteration": 0,
     "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "blockers": [
+      {
+        "route": "exact values / growth rate beyond F(2): F(3) (search space 2^33 colourings per candidate N) and the open doubly-exponential-vs-tower growth of F(k)",
+        "reopenCriterion": "materially new mechanism required (symmetry reduction or SAT-style certificate import for F(3); the growth rate is the open content of Erdős #531)",
+        "blockedAt": "2026-07-22"
+      }
+    ],
+    "nextAction": "None — F 2 = 8 fully proved in Erdos531Problem.lean (kernel decide, axiom-free); node complete.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,18 +35,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Created Erdos531Incomplete01.lean — axiom-free k=2 subset-sum machinery toward the deferred F 2 = 8 finite-coloring reduction. Establishes SubsetSums {a,b} membership of a,b,a+b and the forward monochromatic characterization (c a = c b = c(a+b)).",
+    "progressSummary": "COMPLETED: F 2 = 8 fully proved in Erdos531Problem.lean (2026-07-22), eliminating the file's only sorry. Mechanism: (upper) kernel-decide forcedCheck_all over all 256 colourings of {1..8} — each either contains a direct monochromatic distinct pair with sum <= 8, or pins a conflict sum s in {9..16} carrying both a true- and a false-monochromatic pair, so either colour of s completes a pair; bridged to arbitrary c : Nat -> Bool definitionally via v := fun i : Fin 8 => c (i+1). (lower) explicit witness colouring (3,5,6,7 red, else blue) defeats N = 7, checked by interval_cases + decide. sInf assembly via upward closure validN_mono. Host-verified lake env lean v4.31 exit 0; #print axioms F_2 = [propext, Classical.choice, Quot.sound] — no native_decide. File: 0 sorries, 2 deep axioms (folkman_theorem, balogh_2017).",
     "builtItems": [
       "Erdos531.mem_subsetSums_pair_left / _right / _add in Erdos531Incomplete01.lean",
-      "Erdos531.monochromaticSubsetSums_pair_forward in Erdos531Incomplete01.lean"
+      "Erdos531.monochromaticSubsetSums_pair_forward in Erdos531Incomplete01.lean",
+      "Erdos531Problem.lean: monochromaticSubsetSums_pair_iff, monoPairSumCheck, forcedCheck, forcedCheck_all (kernel decide, 256 cases), eight_mem_validN_two, witnessColoring, seven_not_mem_validN_two, validN_mono, F_2 proof (+29 lines companion docstring sync)"
     ],
     "insights": [
       "For a distinct pair {a,b} the non-empty subset sums are exactly a, b, a+b (witnessed by {a},{b},{a,b}; the a+b witness needs a≠b via Finset.sum_pair). This is the concrete SubsetSums the abstract F_2 reduction must range over.",
       "monochromaticSubsetSums_pair_forward gives the necessary condition c a = c b = c(a+b): the forward direction the F 2 ≥ 8 counterexample checks pair-by-pair against the witness colouring 1,2,4↦B / 3,5,6,7↦R. The backward direction (constructing a mono set) additionally needs SubsetSums {a,b} ⊆ {a,b,a+b}, left for follow-up.",
-      "The F 2 = 8 sorry in the parent needs (a) reduce ∀ c:ℕ→Bool to c|[1,15] finite search, (b) 8∈ValidN 2 via backward char, (c) ∀ m<8, m∉ValidN 2 via the explicit witness colouring + forward char. This session supplies the pair machinery for steps (b)/(c)."
+      "The F 2 = 8 sorry in the parent needs (a) reduce ∀ c:ℕ→Bool to c|[1,15] finite search, (b) 8∈ValidN 2 via backward char, (c) ∀ m<8, m∉ValidN 2 via the explicit witness colouring + forward char. This session supplies the pair machinery for steps (b)/(c).",
+      "Finite-coloring reduction pattern for adversary-coloured sums: quantify the decided statement over v : Fin 8 -> Bool (Fintype decide enumerates all 256 in ~3s kernel time) and phrase out-of-window sums as a per-sum CONFLICT check (both colours banned) rather than enumerating extensions (2^16 would be needed). The bridge to c : Nat -> Bool is definitional (apply the decided lemma at fun i => c (i+1)) — no bit-encoding or testBit lemmas needed. Doc-comment must come AFTER `set_option ... in`, and pin Nat.sInf_mem's type to `F 2 ∈ ...` so omega sees one atom."
     ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "None at this node. F(3) exact value would need symmetry reduction or certificate import (2^33-scale search); the F(k) growth rate is the open content of Erdős #531."
+    ]
   },
   "tags": [
     "seeker-selected",


### PR DESCRIPTION
## Summary
Research session for erdos-531-incomplete-01 (Erdős #531: Folkman numbers, monochromatic subset sums). Proves the exact value `F 2 = 8`, eliminating the only sorry in `Erdos531Problem.lean` — the finite-coloring reduction that earlier sessions deferred as out of scope.

## Progress
- **`F_2 : F 2 = 8`** fully proved (was: sorry "Verified by exhaustive computation; needs finite-coloring reduction to formalize").
- **Upper bound** (`eight_mem_validN_two`): `forcedCheck_all` kernel-`decide`s all 256 colorings of {1..8} (~3.5s, no `native_decide`): each either contains a direct monochromatic distinct pair with sum <= 8, or pins a conflict sum s in {9..16} carrying both a true- and a false-monochromatic pair — so either color of `c s` completes a pair. The bridge to arbitrary `c : Nat -> Bool` is definitional (apply the decided lemma at `fun i : Fin 8 => c (i.val + 1)`); the per-sum conflict analysis avoids enumerating the 2^16 extensions.
- **Lower bound** (`seven_not_mem_validN_two`): the explicit coloring 3,5,6,7 red / everything else blue defeats N = 7 (red pair sums land in {8..13} = blue; blue pair sums are 3,5,6 = red).
- **Assembly**: `monochromaticSubsetSums_pair_iff` (pair mono iff `c b = c a` and `c (a+b) = c a`), `validN_mono` upward closure, `Nat.sInf` sandwich.
- Companion `Erdos531Incomplete01.lean` docstring synced (no API change); gallery meta/annotations synced (sorries 1 -> 0, lineCount 423, theoremCount 14) including correcting a FALSE "F(2) = 3" claim still present in the small-cases annotation; tracker COMPLETED + structured blocker; registry active -> completed.

## Verification
- Host-verified `lake env lean` (Mathlib v4.31): whole file exit 0, no warnings.
- `#print axioms Erdos531.F_2` = `[propext, Classical.choice, Quot.sound]` — the new material is axiom-free; the file's 2 declared axioms (folkman_theorem, balogh_2017) are deep published results not used by F_2.
- Value independently cross-checked by Python brute force under the file's exact semantics (N=7 admits a defeating coloring; N=8 forces).

## Status
**Outcome**: completed
**Next Steps**: none at this node. F(3) exact value needs a 2^33-scale search (symmetry reduction or certificate import); the F(k) growth rate is the open content of Erdős #531.

🤖 Generated by researcher-1
