### PR TITLE
Audit: erdos-1006 fix false Walk.IsCycle claim + stale line count

### DIFF
--- a/src/data/proofs/erdos-1006/meta.json
+++ b/src/data/proofs/erdos-1006/meta.json
@@ -33,11 +33,6 @@
         "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
       },
       {
-        "theorem": "SimpleGraph.Walk.IsCycle",
-        "description": "Cycle predicate for graph walks, used for girth definition",
-        "module": "Mathlib.Combinatorics.SimpleGraph.Walk"
-      },
-      {
         "theorem": "Fintype",
         "description": "Finite type class for vertex sets of finite graphs",
         "module": "Mathlib.Data.Fintype.Basic"
@@ -45,7 +40,7 @@
     ],
     "originalContributions": [
       "Formal framework for graph orientations (Orientation structure with covers, exclusive, respects properties)",
-      "Girth definitions (hasGirthAtLeast, hasGirth) via SimpleGraph.Walk.IsCycle",
+      "Girth definitions (hasGirthAtLeast, hasGirth) via a custom List.Chain'-based cycle predicate (isCycleIn)",
       "Robust acyclicity predicate (isRobustlyAcyclic) for orientation stability",
       "Main theorem ores_conjecture_false: derives contradiction from Nešetřil-Rödl at g=5"
     ],
@@ -55,7 +50,7 @@
   "overview": {
     "historicalContext": "This problem, credited to Ore by Erdős (1971), explores whether high-girth graphs have particularly stable acyclic orientations. Every graph admits an acyclic orientation (just order the vertices and direct edges from lower to higher), but some orientations are 'fragile' — reversing a single edge creates a directed cycle. Ore asked whether avoiding short cycles (girth > 4) guarantees the existence of a 'robust' orientation that stays acyclic after any single edge reversal.\n\nEarly counterexamples at small girth were known: Ore found a girth-4 graph without this property, and Gallai observed the Grötzsch graph (11 vertices, girth 4, chromatic number 4) also fails. These examples relied on high chromatic number relative to girth, suggesting that chromatic structure, not just cycle length, governs robust orientability.\n\nNešetřil and Rödl (1978) settled the question completely by proving counterexamples exist for ALL girths g ≥ 3. Their proof uses the probabilistic method: by the Erdős theorem on graphs with high girth and high chromatic number, such graphs exist, and their high chromatic number forces every acyclic orientation to contain a 'fragile' edge whose reversal creates a directed cycle. The formalization axiomatizes the Nešetřil-Rödl theorem and derives the falsity of Ore's conjecture as a corollary.",
     "problemStatement": "Let G be a graph with girth > 4 (no cycles of length 3 or 4). Can the edges of G always be directed such that (1) there is no directed cycle, and (2) reversing any single edge also creates no directed cycle?",
-    "text": "A 141-line formalization of Erdős Problem #1006 (Ore's conjecture) with 3 axioms and 0 sorries. The file defines graph girth (`hasGirthAtLeast`, `hasGirth`) via `SimpleGraph.Walk.IsCycle`, the `Orientation` structure (covers + exclusive + respects), acyclicity of orientations, and robust acyclicity (acyclic after any single edge reversal). Three axioms capture the key mathematical content: `Orientation.reverseEdge` (edge reversal operation), `grotzsch_counterexample` (the Grötzsch graph at girth 4 has no robust orientation), and `nesetril_rodl_1978` (for every $g \\geq 3$, there exists a graph with girth $\\geq g$ admitting no robust acyclic orientation). The main theorem `ores_conjecture_false` instantiates Nešetřil-Rödl at $g = 5$ and derives a contradiction with the conjecture by `intro h_conj` / `obtain` / `exact`. The disproof reveals that chromatic number, not girth, governs robust orientability — high chromatic number forces 'critical' edges in every acyclic orientation.",
+    "text": "A 153-line formalization of Erdős Problem #1006 (Ore's conjecture) with 3 axioms and 0 sorries. The file defines graph girth (`hasGirthAtLeast`, `hasGirth`) via a custom `List.Chain'`-based cycle predicate (`isCycleIn`), the `Orientation` structure (covers + exclusive + respects), acyclicity of orientations, and robust acyclicity (acyclic after any single edge reversal). Three axioms capture the key mathematical content: `Orientation.reverseEdge` (edge reversal operation), `grotzsch_counterexample` (the Grötzsch graph at girth 4 has no robust orientation), and `nesetril_rodl_1978` (for every $g \\geq 3$, there exists a graph with girth $\\geq g$ admitting no robust acyclic orientation). The main theorem `ores_conjecture_false` instantiates Nešetřil-Rödl at $g = 5$ and derives a contradiction with the conjecture by `intro h_conj` / `obtain` / `exact`. The disproof reveals that chromatic number, not girth, governs robust orientability — high chromatic number forces 'critical' edges in every acyclic orientation.",
     "proofStrategy": "Nešetřil and Rödl (1978) used the probabilistic method to construct counterexamples. They showed that random graphs with high girth and high chromatic number have the property that EVERY acyclic orientation contains an edge whose reversal creates a directed cycle. This gives counterexamples for all girths g ≥ 3.",
     "keyInsights": [
       "Acyclic orientations correspond to linear orderings: direct u→v iff u comes before v",


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-1006

**Problem**: `meta.json` (mathlibDependencies, originalContributions, and overview.text) claimed the girth definitions (`hasGirthAtLeast`, `hasGirth`) are built "via `SimpleGraph.Walk.IsCycle`". The Lean source (`proofs/Proofs/Erdos1006Problem.lean`) never references `Walk` or `IsCycle` anywhere — it defines its own `isCycleIn` predicate directly via `List.Chain'` and `G.Adj`. Also fixed a stale "141-line" claim in overview.text; the actual/meta line count is 153.

## Evidence

**meta.json claimed**: dependency on `Mathlib.Combinatorics.SimpleGraph.Walk`'s `SimpleGraph.Walk.IsCycle`, repeated in 3 places; "141-line formalization"
**Lean file shows**: `grep -n "Walk\|IsCycle"` → no matches; custom `isCycleIn` (line 62) via `List.Chain'`; `wc -l` → 153 lines

## Fix

- Removed the phantom `SimpleGraph.Walk.IsCycle` entry from `mathlibDependencies`
- Corrected `originalContributions` and `overview.text` to describe the actual custom `List.Chain'`-based predicate
- Fixed stale "141-line" → "153-line"

## Verified clean (no other issues)

- 3 axioms (`Orientation.reverseEdge`, `grotzsch_counterexample`, `nesetril_rodl_1978`) match meta.axiomCount
- 1 theorem (`ores_conjecture_false`), 0 sorries — matches meta
- No native_decide, no True stubs
- status:"axiomatized" / badge:"axiom" is correctly Tier C; no overclaiming language

---
Discovered during gallery integrity audit (round-robin re-serve, queue drained).