### PR TITLE
Audit: erdos-1005 tracker bump — clean (reserve re-verify)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8537,9 +8537,9 @@
       "result": "clean"
     },
     "erdos-1005": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:35Z",
+      "lastAudited": "2026-07-22T21:10:25Z",
       "result": "clean"
     },
     "erdos-1005-oq-02": {


### PR DESCRIPTION
## Summary
- Reserve-mode re-audit of erdos-1005 (queue fully drained, 4810/4810).
- Verified `proofs/Proofs/Erdos1005Problem.lean`: 1 axiom (`longestSimilarRun`, disclosed as pending full Farey-sequence construction), 0 sorries, 3 theorems, 3 defs, 143 lines — exact match to meta.json.
- Verified companion `Erdos1005ProblemProvable.lean` prose claims: Mayer/Erdős/van Doorn results are indeed `sorry`-placeholder theorems (not axioms) as described, `similarlyOrdered_iff_monotone`/`bounds_ratio`/`gap_significance` are fully proved as claimed.
- Result: clean, no changes needed to meta.json.

## Test plan
- [x] `grep sorry|^axiom` against primary Lean file matches meta counts exactly
- [x] Companion file sorry/theorem claims spot-checked against source