### PR TITLE
Enrich cube-root-3-irrational-oq-03: cover header docstring (lines 1-43)

### DIFF
--- a/src/data/proofs/cube-root-3-irrational-oq-03/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-03/meta.json
@@ -94,6 +94,14 @@
   ],
   "sections": [
     {
+      "id": "header",
+      "title": "Header: The Field Degree [ℚ(∛3) : ℚ] = 3",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "States the open question — extend irrationality of ∛3 to the full statement that ∛3 has degree 3 over ℚ (equivalently, {1, ∛3, (∛3)²} is linearly independent over ℚ), going further than a sibling entry that only rules out a quadratic relation. This file connects to Mathlib's field-theory layer: from the single arithmetic fact that 3 has no rational cube root, it proves X³ − 3 is irreducible over ℚ (via the degree-≤3 no-root criterion), hence is the minimal polynomial of ∛3, hence [ℚ(∛3) : ℚ] = 3, recording the linear-independence content both elementarily and via Mathlib's LinearIndependent predicate.",
+      "mathContext": "From $q^3=3$ having no rational solution: $X^3-3$ is irreducible over $\\mathbb{Q}$, so $\\mathrm{minpoly}\\,\\mathbb{Q}\\,\\sqrt[3]{3} = X^3-3$ and $[\\mathbb{Q}(\\sqrt[3]{3}):\\mathbb{Q}]=3$."
+    },
+    {
       "id": "inherited-and-arithmetic-input",
       "title": "Inherited Facts and the Single Arithmetic Input",
       "startLine": 44,


### PR DESCRIPTION
Adds a header section covering the module docstring (lines 1-43), previously uncovered by any section or annotation. Summarizes the open question and the file's answer, following the header-docstring enrichment vein.