### PR TITLE
Audit: erdos-1004 tracker bump — issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8519,10 +8519,10 @@
       ]
     },
     "erdos-1004": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:35Z",
-      "result": "clean"
+      "lastAudited": "2026-07-22T21:15:07Z",
+      "result": "issues-fixed"
     },
     "erdos-1004-oq-02": {
       "auditCount": 1,


### PR DESCRIPTION
## Summary
- Marks erdos-1004 as audited (result: issues-fixed) in the audit tracker, following #41800 which corrected stale/fabricated annotation prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)