### PR TITLE
Enrich erdos-1065-incomplete-01: cover header docstring (lines 1-52)

### DIFF
--- a/src/data/proofs/erdos-1065-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1065-incomplete-01/meta.json
@@ -165,43 +165,28 @@
         "content": "IsFormA, oddPart, twoVal, sub_one_eq, oddPart_eq.",
         "startLine": 53,
         "endLine": 82,
-        "theorems": [
-          "sub_one_eq",
-          "oddPart_eq"
-        ]
+        "theorems": ["sub_one_eq", "oddPart_eq"]
       },
       {
         "title": "Sufficiency",
         "content": "isFormA_of_oddPart_prime, isFormA_of_oddPart_one, isFormA_of_oddPart.",
         "startLine": 85,
         "endLine": 118,
-        "theorems": [
-          "isFormA_of_oddPart_prime",
-          "isFormA_of_oddPart_one",
-          "isFormA_of_oddPart"
-        ]
+        "theorems": ["isFormA_of_oddPart_prime", "isFormA_of_oddPart_one", "isFormA_of_oddPart"]
       },
       {
         "title": "Necessity",
         "content": "oddPart_of_isFormA (q=2 / q-odd split).",
         "startLine": 124,
         "endLine": 145,
-        "theorems": [
-          "oddPart_of_isFormA"
-        ]
+        "theorems": ["oddPart_of_isFormA"]
       },
       {
         "title": "Characterization and Examples",
         "content": "isFormA_iff_oddPart and the 37/41/17/71 reproofs.",
         "startLine": 149,
         "endLine": 181,
-        "theorems": [
-          "isFormA_iff_oddPart",
-          "not_isFormA_37",
-          "isFormA_41",
-          "isFormA_17",
-          "not_isFormA_71"
-        ]
+        "theorems": ["isFormA_iff_oddPart", "not_isFormA_37", "isFormA_41", "isFormA_17", "not_isFormA_71"]
       }
     ],
     "mathContext": {

--- a/src/data/proofs/erdos-1065-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1065-incomplete-01/meta.json
@@ -67,6 +67,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Header: A Structural Characterization of Form A Primes",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "States the research problem — Erdős #1065 asks whether infinitely many primes p = 2^k·q+1 with q prime (\"Form A\" primes) exist; the parent axiomatizes infinitude and checks examples by hand. This file supplies the missing structural criterion those checks were probing: writing p−1 = 2^a·m with m odd, an odd prime p is Form A iff m = 1 (p is Fermat-type, q = 2) or m is prime (q = m); m odd composite means p is not Form A. Fully elementary, 0 axioms and 0 sorries, with a locally redefined Form A predicate so it stays independent of the parent's conjecture axiom.",
+      "mathContext": "Writing $p-1=2^a m$ with $m$ odd: $p$ is Form A $\\iff m=1 \\text{ or } m \\text{ prime}$."
+    },
+    {
       "id": "core",
       "title": "Definitions and the Odd-Part Computation",
       "startLine": 53,
@@ -157,28 +165,43 @@
         "content": "IsFormA, oddPart, twoVal, sub_one_eq, oddPart_eq.",
         "startLine": 53,
         "endLine": 82,
-        "theorems": ["sub_one_eq", "oddPart_eq"]
+        "theorems": [
+          "sub_one_eq",
+          "oddPart_eq"
+        ]
       },
       {
         "title": "Sufficiency",
         "content": "isFormA_of_oddPart_prime, isFormA_of_oddPart_one, isFormA_of_oddPart.",
         "startLine": 85,
         "endLine": 118,
-        "theorems": ["isFormA_of_oddPart_prime", "isFormA_of_oddPart_one", "isFormA_of_oddPart"]
+        "theorems": [
+          "isFormA_of_oddPart_prime",
+          "isFormA_of_oddPart_one",
+          "isFormA_of_oddPart"
+        ]
       },
       {
         "title": "Necessity",
         "content": "oddPart_of_isFormA (q=2 / q-odd split).",
         "startLine": 124,
         "endLine": 145,
-        "theorems": ["oddPart_of_isFormA"]
+        "theorems": [
+          "oddPart_of_isFormA"
+        ]
       },
       {
         "title": "Characterization and Examples",
         "content": "isFormA_iff_oddPart and the 37/41/17/71 reproofs.",
         "startLine": 149,
         "endLine": 181,
-        "theorems": ["isFormA_iff_oddPart", "not_isFormA_37", "isFormA_41", "isFormA_17", "not_isFormA_71"]
+        "theorems": [
+          "isFormA_iff_oddPart",
+          "not_isFormA_37",
+          "isFormA_41",
+          "isFormA_17",
+          "not_isFormA_71"
+        ]
       }
     ],
     "mathContext": {


### PR DESCRIPTION
Adds a header section covering the module docstring (lines 1-52), previously uncovered by any section or annotation. Summarizes the open question and the file's answer, following the header-docstring enrichment vein.