### PR TITLE
Enrich erdos-396-oq-04-oq-01-oq-01: cover header docstring (lines 1-46)

### DIFF
--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01/meta.json
@@ -48,6 +48,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Header: The Catalan Ratio Deficit is Harmonic",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring: recalls the parent's Catalan ratio r n = (4n+2)/(n+2) = 4 − 6/(n+2) and its convergence r n → 4, then examines the deficit δ n = 4 − r n = 6/(n+2), proving individual deficits tend to 0 but their cumulative sum (a harmonic partial sum) diverges — the precise discrete reason the Catalan asymptotic carries a polynomial correction below 4^n.",
+      "mathContext": "$\\delta_n = 4-r_n = \\dfrac{6}{n+2} \\to 0$, yet $\\sum_{k<n}\\delta_k = 6(H_{n+1}-1) \\to \\infty$ where $H_m=\\sum_{i<m}\\tfrac1{i+1}$; individually vanishing deficits with a divergent cumulative sum."
+    },
+    {
       "id": "definitions",
       "title": "Definitions: the deficit and the harmonic number",
       "startLine": 47,


### PR DESCRIPTION
Adds a `header`-type section to `meta.json` covering the module docstring (lines 1-46), previously uncovered by any section or annotation. The docstring recalls the parent's Catalan ratio r n → 4, examines the deficit δ n = 4 − r n = 6/(n+2), and states the dichotomy: individual deficits vanish but their cumulative (harmonic) sum diverges.

Part of the ongoing header-docstring enrichment vein.