### PR TITLE
Audit: erdos-1003 clean (reserve re-verification)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8497,9 +8497,9 @@
       ]
     },
     "erdos-1003": {
-      "auditCount": 4,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:35Z",
+      "lastAudited": "2026-07-22T21:22:33Z",
       "result": "clean"
     },
     "erdos-1003-oq-02": {


### PR DESCRIPTION
## Summary
- Reserve-mode re-audit of `erdos-1003` (queue fully drained: 4810/4810).
- Verified theoremCount=16, definitionCount=6, axiomCount=0, sorries=0, lineCount=314 all match `Proofs/Erdos1003Problem.lean` exactly.
- The two open conjectures (`erdos_1003_conjecture`, `erdos_1003_strong_conjecture`) are `Prop` defs, never claimed proved, never axiomatized.
- Prose correctly discloses "main conjectures remain open" and scopes the FLP lower bound as documented-in-comments, not proved.
- No true stubs, no native_decide, no docstring-only false-positive grep hits.

Result: **clean**, no action needed.

🤖 Generated with Claude Code