### PR TITLE
audit: record erdos-1002-oq-01 (reserve) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8459,9 +8459,9 @@
       "result": "clean"
     },
     "erdos-1002-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:02:35Z",
+      "lastAudited": "2026-07-22T21:27:51Z",
       "result": "clean"
     },
     "erdos-1002-oq-01-oq-01": {


### PR DESCRIPTION
## Integrity Re-Audit (Reserve Mode)

**Target**: erdos-1002-oq-01
**Result**: clean — no issues

## Verification performed

- 0 axioms, 0 sorries, 10 theorems, 4 definitions, 148 lines: all match `meta.json`/`leanFile` against `proofs/Proofs/Erdos1002OQ01.lean`.
- No `native_decide`; the two prose mentions of "axiom" are docstring references to the *parent* file's history, not real declarations here.
- Verified the "eliminates two axioms from Erdos1002Problem.lean, reducing axiom count 7→5" narrative against git history: at introduction (commit `699a7573ce`), the parent had exactly 7 axioms including `cauchy_is_distribution` and `innerSum_periodic_rational` — both proved in this file. The claim is historically accurate and scoped correctly to what this file did (the parent has since been further reduced to 1 axiom by later companion files, which this entry correctly does not claim).
- Annotations spot-checked against file content — accurate.

Tracker updated: `auditCount` 4→5, `lastAudited` refreshed.

---
Discovered during gallery integrity audit (reserve mode, queue fully drained).