### PR TITLE
Audit: erdos-1016 (reserve) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8857,8 +8857,8 @@
     },
     "erdos-1016": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:03:25Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-22T21:31:03Z",
       "result": "clean"
     },
     "erdos-1017": {


### PR DESCRIPTION
Reserve-mode re-audit of erdos-1016 (Pancyclic Excess Edges). Verified: 0 sorries, 0 literal axioms, native_decide use disclosed with Lean.ofReduceBool reasoning in assumptions text, model-flaw honestly documented in-file, theoremCount=18 and definitionCount=6 both match actual file. Clean.