### PR TITLE
Enrich odd-cubes-sum-oq-01: cover header docstring (lines 1-56)

### DIFF
--- a/src/data/proofs/odd-cubes-sum-oq-01/meta.json
+++ b/src/data/proofs/odd-cubes-sum-oq-01/meta.json
@@ -54,6 +54,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Header: Sum of cubes of the first n odd numbers",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Proves $\\sum_{k=1}^n (2k-1)^3 = n^2(2n^2-1)$, the odd-indexed companion to Nicomachus's $\\sum k^3=(\\sum k)^2$, via a subtraction-free core identity $\\big(\\sum(2k+1)^3\\big)+n^2=2n^4$ that keeps the induction entirely inside $\\mathbb N$.",
+      "mathContext": "$\\sum_{k=1}^n (2k-1)^3 = n^2(2n^2-1)$ (OEIS A002593)."
+    },
+    {
       "id": "definition",
       "title": "The Odd Cube and Its Reindexing",
       "startLine": 57,


### PR DESCRIPTION
Adds a `header` section covering the module docstring (lines 1-56), previously uncovered by any section or annotation. Proves the closed form for the sum of cubes of the first n odd numbers, the odd-indexed companion to Nicomachus's identity.