### PR TITLE
Enrich solution-of-cubic-oq-04: cover header docstring (lines 1-44)

### DIFF
--- a/src/data/proofs/solution-of-cubic-oq-04/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-04/meta.json
@@ -122,6 +122,14 @@
   ],
   "sections": [
     {
+      "id": "header",
+      "title": "Header: closed-form vs. iterative cost for solving the cubic",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "States OQ-04 — compare the arithmetic-operation cost of Cardano's closed form against an iterative bisection root-finder for the depressed cubic x^3+px+q=0 to accuracy epsilon — and the answer this file proves: Cardano's cost is a fixed epsilon-independent constant, while bisection needs an unbounded number of steps growing like log(1/epsilon), giving a rigorous closed-form vs. iterative separation.",
+      "mathContext": "$T_{\\text{Cardano}}(\\varepsilon)=O(1)$ vs. $T_{\\text{iterative}}(\\varepsilon)=\\Theta(\\log(1/\\varepsilon))$, since bisection width $W/2^n$ reaching accuracy $\\varepsilon$ forces $n\\ge\\log_2(W/\\varepsilon)$."
+    },
+    {
       "id": "bisection-recurrence",
       "title": "Part 1: The Bisection Width Recurrence",
       "summary": "Defines bisectionWidth W n = W/2^n and proves the halving step and positivity.",


### PR DESCRIPTION
Adds a header section covering the uncovered module docstring (lines 1-44), which states OQ-04's closed-form-vs-iterative cost comparison and the file's answer (Cardano O(1) vs. bisection Theta(log(1/eps))). Part of the fleet's header-docstring enrichment vein.