### PR TITLE
Enrich amgm-inequality-oq-03-oq-01-oq-02: cover header docstring (lines 1-63)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-01-oq-02/meta.json
@@ -93,6 +93,7 @@
     ]
   },
   "sections": [
+    {"id": "header", "title": "Header: Generalized mean inequality for arbitrary real exponents", "startLine": 1, "endLine": 63, "summary": "States the explicit Mathlib `TODO` this file fills — generalized mean monotonicity $M_p\\le M_q$ for all real $p\\le q$, including negative and sign-crossing exponents, beyond Mathlib's existing $p=1$ special case. Outlines the three-case proof (both positive via Jensen, both negative via duality, sign-crossing via a geometric-mean sandwich) combined by trichotomy.", "mathContext": "$M_p(z,w)=(\\sum_i w_i z_i^p)^{1/p}$ satisfies $M_p\\le M_q$ for all real $p\\le q\\neq 0$, closing the `Mathlib.Analysis.MeanInequalitiesPow` TODO via Jensen (same sign) and a geometric-mean sandwich (sign-crossing)."},
     {
       "id": "infrastructure",
       "title": "Power-Mean Abbreviation, Inversion, and Positivity",


### PR DESCRIPTION
Adds a `header` section covering the module docstring (lines 1-63) of the Lean file, previously uncovered by any section or annotation. Summarizes only what the docstring itself states.