### PR TITLE
Gallery integrity: erdos-1002 fabricated assumptions field

### DIFF
--- a/src/data/proofs/erdos-1002/meta.json
+++ b/src/data/proofs/erdos-1002/meta.json
@@ -24,7 +24,7 @@
     "relatedProblems": [],
     "axiomCount": 1,
     "lineCount": 183,
-    "assumptions": "1 axiom: erdos_1002_conjecture (OPEN: Erdős #1002 main conjecture on Cauchy distribution sums). Supporting lemmas cauchy_is_distribution, kesten_theorem, f_bounded_for_irrational, innerSum_log_bound, weyl_equidistribution, innerSum_periodic_rational now proved.",
+    "assumptions": "1 axiom: erdos_1002_conjecture (OPEN: Erdős #1002 main conjecture on Cauchy distribution sums). Two lemmas formerly axiomatized in this file — cauchy_is_distribution and innerSum_periodic_rational — are now proved in the companion file Erdos1002OQ01.lean.",
     "theoremCount": 2,
     "definitionCount": 11
   },


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-1002
**Problem**: `meta.assumptions` claims six "supporting lemmas now proved" — most are phantom, unproved, or belong to unrelated problems.

## Evidence

**meta.json claimed**: "Supporting lemmas cauchy_is_distribution, kesten_theorem, f_bounded_for_irrational, innerSum_log_bound, weyl_equidistribution, innerSum_periodic_rational now proved."

**Reality** (checked against `proofs/Proofs/`):
- `cauchy_is_distribution` — real, proved theorem in `Erdos1002OQ01.lean` ✓
- `innerSum_periodic_rational` — real, proved theorem in `Erdos1002OQ01.lean` ✓
- `f_bounded_for_irrational` — does not exist anywhere in the repository (phantom name)
- `innerSum_log_bound` — still an **axiom** in `Erdos1002OQ01OQ01.lean`, whose own docstring says "The log bound requires continued fraction theory and is axiomatized." Not proved.
- `weyl_equidistribution` — an axiom, but only in unrelated files `Erdos335Problem.lean` (Erdos #335) and `DeMoivreOQ03OQ01.lean` (De Moivre's formula) — nothing to do with Erdos #1002.
- `kesten_theorem` — an axiom, but only in `Erdos998Problem.lean` (Erdos #998) — a different, unrelated problem.

Top-level status/badge (`axiomatized`/`axiom`/`open`) were already accurate; only the `assumptions` prose overstated progress by claiming unproved axioms (some belonging to entirely different problems) as "now proved."

## Fix

Rewrote `assumptions` to only credit the two lemmas that are genuinely proved and genuinely part of this problem's axiom-elimination history, per `Erdos1002OQ01.lean`'s own docstring ("Eliminates two axioms from Erdos1002Problem.lean").

---
Discovered during gallery integrity audit.