### PR TITLE
Enrich divisibility-truncation-general-oq-01: cover header docstring (lines 1-15)

### DIFF
--- a/src/data/proofs/divisibility-truncation-general-oq-01/meta.json
+++ b/src/data/proofs/divisibility-truncation-general-oq-01/meta.json
@@ -81,6 +81,13 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Header Docstring",
+      "startLine": 1,
+      "endLine": 15,
+      "summary": "States the open question: can the positive and negative osculator theorems be merged into one theorem with a signed osculator $c \\in \\mathbb{Z}$? Answers YES, since `truncation_pos` already works for $c \\in \\mathbb{Z}$ with $d \\mid (10c - 1)$, and the negative case is the positive case with $c$ replaced by $-c_{\\text{neg}}$."
+    },
+    {
       "id": "setup",
       "title": "Imports and Algebraic Identity",
       "startLine": 16,


### PR DESCRIPTION
Enrichment pass for divisibility-truncation-general-oq-01.

Adds a `header` section (lines 1-15) covering the module docstring, which was previously uncovered by `sections[]`. All other line ranges already contiguous. No existing content changed.
