### PR TITLE
Research: erdos-116-wip-01 - first quantitative two-sided bounds π/9ⁿ ≤ μ(Sₚ) ≤ 4π

### DIFF
--- a/proofs/Proofs/Erdos116WIP01.lean
+++ b/proofs/Proofs/Erdos116WIP01.lean
@@ -294,4 +294,131 @@ theorem exists_sublevelMeasure_eq_pi (hn : n ≠ 0) :
     ∃ P : UnitDiskPoly n, sublevelMeasure P = Real.pi :=
   ⟨allRootsZero n, sublevelMeasure_allRootsZero hn⟩
 
+/-! ## First quantitative bounds: `π / 9 ^ n ≤ sublevelMeasure P ≤ 4 · π`
+
+Everything above pins `0 < sublevelMeasure P < ∞` and computes exact values at
+special configurations, but gives no quantitative control for an *arbitrary*
+`P : UnitDiskPoly n`.  This section proves the first two-sided quantitative
+bounds — the same shape as the deep targets, with elementary constants:
+
+* **Upper bound `4π`** (weak Pólya): `Sₚ ⊆ closedBall 0 2`
+  (`sublevelSet_subset_closedBall`), and the disk of radius `2` has area `4π`.
+  Pólya's sharp constant `π` needs potential theory and stays open here.
+* **Lower bound `π/9ⁿ`** (weak Pommerenke): the ball of radius `3⁻ⁿ` around any
+  root lies inside the lemniscate — for `z` in that ball the distinguished
+  factor is `< 3⁻ⁿ`, while each of the `n - 1` other factors satisfies
+  `‖z - zⱼ‖ ≤ ‖z - zᵢ‖ + ‖zᵢ - zⱼ‖ < 3⁻ⁿ + 2 ≤ 3`, so
+  `‖p(z)‖ < 3⁻ⁿ · 3^(n-1) = 1/3 < 1`.  Hence `μ(Sₚ) ≥ π · 9⁻ⁿ`.
+
+Pommerenke's `c/n⁴` and KLR's sharp `c/log n` require logarithmic potential
+theory; `π/9ⁿ` is what the bare triangle inequality yields, and it is the first
+positive quantitative lower bound in this development. -/
+
+/-- **`sublevelMeasure` is the `toReal` of the `ℂ`-side lemniscate volume.**  The
+parent's `ℝ × ℝ` sublevel set is the volume-preserving image of `Sₚ` under
+`ℂ ≃ᵐ ℝ × ℝ`, so its measure agrees with `volume Sₚ`.  Deduplicates the transport
+used in the exact-area computations above and lets the quantitative bounds below
+work entirely on the `ℂ` side. -/
+theorem sublevelMeasure_eq_toReal_volume (P : UnitDiskPoly n) :
+    sublevelMeasure P = (volume P.sublevelSet).toReal := by
+  rw [sublevelMeasure, P.realProd_sublevelSet_eq_preimage]
+  have hmp := Complex.volume_preserving_equiv_real_prod.symm Complex.measurableEquivRealProd
+  rw [hmp.measure_preimage P.measurableSet_sublevelSet.nullMeasurableSet]
+
+/-- **Weak Pólya upper bound: `sublevelMeasure P ≤ 4π`.**  The lemniscate sits
+inside `closedBall 0 2` (`sublevelSet_subset_closedBall`), whose area is `4π`.
+This is the first quantitative upper bound valid for every `P`; Pólya's sharp
+constant `π` (attained by `zⁿ`, see `sublevelMeasure_allRootsZero`) is the deep
+open content. -/
+theorem sublevelMeasure_le_four_pi (P : UnitDiskPoly n) :
+    sublevelMeasure P ≤ 4 * Real.pi := by
+  rw [P.sublevelMeasure_eq_toReal_volume]
+  have hfin : volume (Metric.closedBall (0 : ℂ) 2) ≠ ⊤ :=
+    (isCompact_closedBall (0 : ℂ) 2).measure_lt_top.ne
+  have hmono : volume P.sublevelSet ≤ volume (Metric.closedBall (0 : ℂ) 2) :=
+    measure_mono P.sublevelSet_subset_closedBall
+  calc (volume P.sublevelSet).toReal
+      ≤ (volume (Metric.closedBall (0 : ℂ) 2)).toReal := ENNReal.toReal_mono hfin hmono
+    _ = 4 * Real.pi := by
+        rw [Complex.volume_closedBall, ENNReal.toReal_mul, ENNReal.toReal_pow,
+          ENNReal.toReal_ofReal (by norm_num : (0:ℝ) ≤ 2), ENNReal.coe_toReal,
+          NNReal.coe_real_pi]
+        ring
+
+/-- **A ball of radius `3⁻ⁿ` around any root lies inside the lemniscate.**  For
+`z ∈ ball zᵢ 3⁻ⁿ`, split off the distinguished factor `‖z - zᵢ‖ < 3⁻ⁿ`; each of
+the `n - 1` remaining factors satisfies
+`‖z - zⱼ‖ ≤ ‖z - zᵢ‖ + ‖zᵢ - zⱼ‖ < 3⁻ⁿ + 2 ≤ 3`, so
+`‖p(z)‖ < 3⁻ⁿ · 3^(n-1) = 1/3 < 1`.  (The argument `i : Fin n` forces `n ≥ 1`.) -/
+theorem ball_subset_sublevelSet (P : UnitDiskPoly n) (i : Fin n) :
+    Metric.ball (P.roots i) (1 / 3 ^ n) ⊆ P.sublevelSet := by
+  intro z hz
+  rw [Metric.mem_ball, dist_eq_norm] at hz
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 := ⟨n - 1, (Nat.succ_pred_eq_of_pos i.pos).symm⟩
+  show ‖P.eval z‖ < 1
+  rw [UnitDiskPoly.eval, norm_prod,
+    ← Finset.mul_prod_erase Finset.univ _ (Finset.mem_univ i)]
+  have hrpos : (0:ℝ) < 3 ^ (m + 1) := by positivity
+  have hr1 : (1:ℝ) / 3 ^ (m + 1) ≤ 1 := by
+    rw [div_le_one hrpos]
+    exact one_le_pow₀ (by norm_num)
+  have hrest : ∏ j ∈ Finset.univ.erase i, ‖z - P.roots j‖ ≤ 3 ^ m := by
+    have hcard : (Finset.univ.erase i).card = m := by
+      simp [Finset.card_erase_of_mem]
+    calc ∏ j ∈ Finset.univ.erase i, ‖z - P.roots j‖
+        ≤ ∏ _j ∈ Finset.univ.erase i, (3:ℝ) := by
+          refine Finset.prod_le_prod (fun j _ => norm_nonneg _) (fun j _ => ?_)
+          have hij : ‖P.roots i - P.roots j‖ ≤ 2 := by
+            have h1 : ‖P.roots i‖ ≤ 1 := P.roots_in_disk i
+            have h2 : ‖P.roots j‖ ≤ 1 := P.roots_in_disk j
+            calc ‖P.roots i - P.roots j‖
+                ≤ ‖P.roots i‖ + ‖P.roots j‖ := norm_sub_le _ _
+              _ ≤ 2 := by linarith
+          calc ‖z - P.roots j‖
+              = ‖(z - P.roots i) + (P.roots i - P.roots j)‖ := by
+                rw [sub_add_sub_cancel]
+            _ ≤ ‖z - P.roots i‖ + ‖P.roots i - P.roots j‖ := norm_add_le _ _
+            _ ≤ 3 := by linarith
+      _ = 3 ^ m := by rw [Finset.prod_const, hcard]
+  have h3m : (0:ℝ) < 3 ^ m := by positivity
+  calc ‖z - P.roots i‖ * ∏ j ∈ Finset.univ.erase i, ‖z - P.roots j‖
+      ≤ ‖z - P.roots i‖ * 3 ^ m := mul_le_mul_of_nonneg_left hrest (norm_nonneg _)
+    _ < 1 / 3 ^ (m + 1) * 3 ^ m := mul_lt_mul_of_pos_right hz h3m
+    _ = 1 / 3 := by
+        have h3m' : (3:ℝ) ^ m ≠ 0 := ne_of_gt h3m
+        rw [pow_succ]
+        field_simp
+    _ < 1 := by norm_num
+
+/-- **Weak Pommerenke lower bound: `π / 9 ^ n ≤ sublevelMeasure P`.**  The
+lemniscate contains a ball of radius `3⁻ⁿ` around each root
+(`ball_subset_sublevelSet`), and that ball has area `π · 9⁻ⁿ`.  This is the
+first positive quantitative lower bound valid for every `P` — exponentially
+weaker than Pommerenke's `c/n⁴` and KLR's sharp `c/log n` (both requiring
+potential theory), but fully machine-checked. -/
+theorem pi_div_pow_le_sublevelMeasure (P : UnitDiskPoly n) (hn : 0 < n) :
+    Real.pi / 9 ^ n ≤ sublevelMeasure P := by
+  rw [P.sublevelMeasure_eq_toReal_volume]
+  have hmono : volume (Metric.ball (P.roots ⟨0, hn⟩) (1 / 3 ^ n)) ≤ volume P.sublevelSet :=
+    measure_mono (P.ball_subset_sublevelSet ⟨0, hn⟩)
+  have hfin : volume P.sublevelSet ≠ ⊤ := P.volume_sublevelSet_lt_top.ne
+  have hle := ENNReal.toReal_mono hfin hmono
+  rw [Complex.volume_ball, ENNReal.toReal_mul, ENNReal.toReal_pow,
+    ENNReal.toReal_ofReal (by positivity : (0:ℝ) ≤ 1 / 3 ^ n), ENNReal.coe_toReal,
+    NNReal.coe_real_pi] at hle
+  refine le_trans (le_of_eq ?_) hle
+  have h32 : ((3:ℝ) ^ n) ^ 2 = 9 ^ n := by
+    rw [← pow_mul, Nat.mul_comm n 2, pow_mul]
+    norm_num
+  rw [div_pow, one_pow, h32]
+  ring
+
+/-- **First two-sided quantitative control of the lemniscate area:**
+`π / 9ⁿ ≤ sublevelMeasure P ≤ 4π` for every degree-`n ≥ 1` polynomial with
+roots in the closed unit disk.  The deep content of Erdős #116 is narrowing
+this window to `[c / log n, π]` (KLR lower bound + Pólya upper bound). -/
+theorem sublevelMeasure_mem_Icc (P : UnitDiskPoly n) (hn : 0 < n) :
+    sublevelMeasure P ∈ Set.Icc (Real.pi / 9 ^ n) (4 * Real.pi) :=
+  ⟨P.pi_div_pow_le_sublevelMeasure hn, P.sublevelMeasure_le_four_pi⟩
+
 end UnitDiskPoly

--- a/proofs/Proofs/Erdos116WIP01.lean
+++ b/proofs/Proofs/Erdos116WIP01.lean
@@ -421,4 +421,76 @@ theorem sublevelMeasure_mem_Icc (P : UnitDiskPoly n) (hn : 0 < n) :
     sublevelMeasure P ∈ Set.Icc (Real.pi / 9 ^ n) (4 * Real.pi) :=
   ⟨P.pi_div_pow_le_sublevelMeasure hn, P.sublevelMeasure_le_four_pi⟩
 
+/-! ## The full Pólya equality family: all roots at any point `a`
+
+`allRootsZero` treated the extremal candidate `zⁿ`.  Pólya's (deep, unproved
+here) equality statement says the area bound `π` is attained **exactly** when
+all roots coincide — at *any* point `a` of the closed disk, not just `0`.  This
+section formalizes the attainment half in full generality: for every `‖a‖ ≤ 1`
+and `n ≥ 1`, the polynomial `(z − a)ⁿ` has lemniscate exactly `ball a 1` and
+area exactly `π`.  So the area functional is constant (`= π`) on the whole
+conjectured extremal family, and `exists_sublevelMeasure_eq_pi` holds with the
+witness placed anywhere in the disk. -/
+
+/-- All `n` roots at a common point `a` of the closed unit disk. -/
+noncomputable def allRootsAt (n : ℕ) (a : ℂ) (ha : Complex.abs a ≤ 1) :
+    UnitDiskPoly n :=
+  ⟨fun _ => a, fun _ => ha⟩
+
+/-- The repeated-root polynomial evaluates to `(z − a)ⁿ`. -/
+theorem eval_allRootsAt (n : ℕ) (a : ℂ) (ha : Complex.abs a ≤ 1) (z : ℂ) :
+    (allRootsAt n a ha).eval z = (z - a) ^ n := by
+  simp [UnitDiskPoly.eval, allRootsAt, Finset.prod_const]
+
+/-- **The repeated-root lemniscate is exactly the unit ball at `a`.**  For
+`n ≠ 0`, `{z : ‖(z − a)ⁿ‖ < 1} = ball a 1`. -/
+theorem sublevelSet_allRootsAt {n : ℕ} (hn : n ≠ 0) (a : ℂ)
+    (ha : Complex.abs a ≤ 1) :
+    (allRootsAt n a ha).sublevelSet = Metric.ball a 1 := by
+  ext z
+  constructor
+  · intro hz
+    have h1 : ‖(allRootsAt n a ha).eval z‖ < 1 := hz
+    rw [eval_allRootsAt, norm_pow] at h1
+    rw [Metric.mem_ball, dist_eq_norm]
+    exact (pow_lt_one_iff_of_nonneg (norm_nonneg _) hn).mp h1
+  · intro hz
+    rw [Metric.mem_ball, dist_eq_norm] at hz
+    show ‖(allRootsAt n a ha).eval z‖ < 1
+    rw [eval_allRootsAt, norm_pow]
+    exact (pow_lt_one_iff_of_nonneg (norm_nonneg _) hn).mpr hz
+
+/-- `volume` of the repeated-root lemniscate is `π` (`ℂ`-side), wherever the
+root sits. -/
+theorem volume_sublevelSet_allRootsAt {n : ℕ} (hn : n ≠ 0) (a : ℂ)
+    (ha : Complex.abs a ≤ 1) :
+    volume ((allRootsAt n a ha).sublevelSet) = NNReal.pi := by
+  rw [sublevelSet_allRootsAt hn a ha, Complex.volume_ball]
+  simp
+
+/-- The parent's `ℝ × ℝ` volume of the repeated-root lemniscate is `π`,
+transported across `ℂ ≃ᵐ ℝ × ℝ` as usual. -/
+theorem volume_realProd_sublevelSet_allRootsAt {n : ℕ} (hn : n ≠ 0) (a : ℂ)
+    (ha : Complex.abs a ≤ 1) :
+    volume {p : ℝ × ℝ | Complex.abs ((allRootsAt n a ha).eval ⟨p.1, p.2⟩) < 1}
+      = NNReal.pi := by
+  rw [(allRootsAt n a ha).realProd_sublevelSet_eq_preimage]
+  have hmp := Complex.volume_preserving_equiv_real_prod.symm
+    Complex.measurableEquivRealProd
+  rw [hmp.measure_preimage
+    (allRootsAt n a ha).measurableSet_sublevelSet.nullMeasurableSet]
+  exact volume_sublevelSet_allRootsAt hn a ha
+
+/-- **The area functional is identically `π` on the whole Pólya equality
+family**: every repeated-root polynomial `(z − a)ⁿ` (`‖a‖ ≤ 1`, `n ≥ 1`) has
+`sublevelMeasure = π` exactly.  Generalizes `sublevelMeasure_allRootsZero`
+(`a = 0`) and `sublevelMeasure_singleRoot` (`n = 1`); the deep converse — that
+these are the *only* maximizers — is Pólya's equality case and stays open
+here. -/
+theorem sublevelMeasure_allRootsAt {n : ℕ} (hn : n ≠ 0) (a : ℂ)
+    (ha : Complex.abs a ≤ 1) :
+    sublevelMeasure (allRootsAt n a ha) = Real.pi := by
+  rw [sublevelMeasure, volume_realProd_sublevelSet_allRootsAt hn a ha]
+  simp [NNReal.coe_real_pi]
+
 end UnitDiskPoly

--- a/research/problems/erdos-116-wip-01/knowledge.md
+++ b/research/problems/erdos-116-wip-01/knowledge.md
@@ -168,3 +168,45 @@ logarithmic-potential / area-of-lemniscate machinery absent from Mathlib.
   formalizes that the conjectured maximizer attains π at every degree.
 - Lean idiom: membership in `sublevelSet` is defeq to `‖P.eval z‖ < 1` (the parent's
   `Complex.abs` compat def unfolds by `rfl`); `show ‖_‖ < 1` converts cleanly.
+
+## Session 2026-07-22 (researcher-1, iter 3 ACT): first quantitative two-sided bounds
+
+**Outcome**: progress — 5 new axiom-free theorems in `Erdos116WIP01.lean`
+(host-verified `lake env lean` exit 0, `#print axioms` =
+`[propext, Classical.choice, Quot.sound]` on all five). First *quantitative*
+control for arbitrary `P`: **`π/9ⁿ ≤ sublevelMeasure P ≤ 4π`** — same shape as
+the target `[c/log n, π]`, elementary constants.
+
+### What was added (namespace `UnitDiskPoly`)
+- `sublevelMeasure_eq_toReal_volume` — `sublevelMeasure P = (volume Sₚ).toReal`;
+  dedupes the ℂ ≅ ℝ×ℝ transport (all later bounds work purely on the ℂ side).
+- `sublevelMeasure_le_four_pi` — weak Pólya: `Sₚ ⊆ closedBall 0 2` +
+  `Complex.volume_closedBall` (area `4π`), `ENNReal.toReal_mono` with the
+  compact-ball finiteness.
+- `ball_subset_sublevelSet (i : Fin n)` — `ball zᵢ 3⁻ⁿ ⊆ Sₚ`: split the
+  distinguished factor off via `Finset.mul_prod_erase`; the other `n-1` factors
+  are `≤ 3` by `‖z-zⱼ‖ ≤ ‖z-zᵢ‖ + ‖zᵢ-zⱼ‖ < 3⁻ⁿ + 2`; product
+  `< 3⁻ⁿ·3ⁿ⁻¹ = 1/3 < 1`.
+- `pi_div_pow_le_sublevelMeasure` — weak Pommerenke: `π/9ⁿ ≤ sublevelMeasure P`
+  via `Complex.volume_ball` at radius `3⁻ⁿ`.
+- `sublevelMeasure_mem_Icc` — headline: `sublevelMeasure P ∈ Icc (π/9ⁿ) (4π)`.
+
+### Reusable Lean recipes
+- Split one factor from a `Finset.univ` product: `rw [← Finset.mul_prod_erase
+  Finset.univ _ (Finset.mem_univ i)]`; `(univ.erase i).card = m` for `Fin (m+1)`
+  closes with `simp [Finset.card_erase_of_mem]`.
+- `n = m + 1` from `i : Fin n`: `obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 :=
+  ⟨n - 1, (Nat.succ_pred_eq_of_pos i.pos).symm⟩`.
+- `(ENNReal.ofReal r ^ 2 * NNReal.pi).toReal` unpacks with `ENNReal.toReal_mul`,
+  `ENNReal.toReal_pow`, `ENNReal.toReal_ofReal`, `ENNReal.coe_toReal`,
+  `NNReal.coe_real_pi`.
+- `((3:ℝ)^n)^2 = 9^n`: `rw [← pow_mul, Nat.mul_comm n 2, pow_mul]; norm_num`.
+
+### Remaining open (unchanged)
+Narrowing `[π/9ⁿ, 4π]` to `[c/log n, π]` is the deep content: Pólya's sharp `π`
+and KLR's `c/log n` both need logarithmic-potential machinery absent from
+Mathlib. Next elementary increments could be: polynomial-in-`n` lower bound via
+covering by root clusters (probably still exponential without potential theory),
+or the `n = 1` sharpness statement `sublevelMeasure P = π` for all degree-1 `P`
+(already done) extended to a monotonicity/continuity statement of the area
+functional in the roots.

--- a/research/problems/erdos-116-wip-01/knowledge.md
+++ b/research/problems/erdos-116-wip-01/knowledge.md
@@ -210,3 +210,15 @@ covering by root clusters (probably still exponential without potential theory),
 or the `n = 1` sharpness statement `sublevelMeasure P = π` for all degree-1 `P`
 (already done) extended to a monotonicity/continuity statement of the area
 functional in the roots.
+
+## Session 2026-07-22b (researcher-1-9): full Pólya equality family
+
+Added to the same PR branch (#41875, now carries both sessions): `allRootsAt` —
+**every** repeated-root polynomial `(z−a)ⁿ` (`‖a‖ ≤ 1`, `n ≥ 1`) has lemniscate
+exactly `ball a 1` and `sublevelMeasure = π` on the nose
+(`sublevelMeasure_allRootsAt`, axiom-free, host-verified). The area functional
+is constant `π` on the whole conjectured Pólya extremal family — generalizes
+`allRootsZero` (a = 0) and `singleRoot` (n = 1). Deep converse (uniqueness of
+maximizers) remains open with the other quantitative blockers. Same proof
+skeleton as allRootsZero: `Complex.volume_ball` works at any center, so no
+translation machinery was needed.

--- a/research/problems/erdos-116-wip-01/state.md
+++ b/research/problems/erdos-116-wip-01/state.md
@@ -4,7 +4,7 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-20
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
 Axiom-free topology of the polynomial lemniscate `Sₚ = {z : |p(z)| < 1}` for
@@ -71,3 +71,13 @@ host-verified (`lake env lean` exit 0, fresh v4.31 olean chain):
 Remaining moves are still only the DEEP ones (KLR `c/log n` lower, Pólya `π` upper,
 the `1/log n` vs `1/log log n` gap — logarithmic potential theory absent from
 Mathlib). Elementary layer now saturated *including* exact-value computations.
+
+## Status (S6, researcher-1, 2026-07-22) — first quantitative two-sided bounds
+
+5 new axiom-free theorems (host-verified, `[propext, Classical.choice, Quot.sound]`):
+**`π/9ⁿ ≤ sublevelMeasure P ≤ 4π`** for every `P : UnitDiskPoly n`, `n ≥ 1`
+(`sublevelMeasure_mem_Icc`). Upper: `Sₚ ⊆ closedBall 0 2` + `Complex.volume_closedBall`.
+Lower: `ball zᵢ 3⁻ⁿ ⊆ Sₚ` (`ball_subset_sublevelSet`, factor-splitting triangle
+inequality) + `Complex.volume_ball`. Also `sublevelMeasure_eq_toReal_volume` dedupes
+the `ℂ ≅ ℝ²` transport. First quantitative control for arbitrary `P` — same shape as
+the target `[c/log n, π]`, elementary constants. Deep blockers unchanged.

--- a/src/data/research/problems/erdos-116-wip-01.json
+++ b/src/data/research/problems/erdos-116-wip-01.json
@@ -37,7 +37,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-1, 2026-07-22, host-verified lake env lean exit 0, all new theorems [propext, Classical.choice, Quot.sound]): first QUANTITATIVE two-sided bounds for arbitrary P — pi/9^n <= sublevelMeasure P <= 4pi (sublevelMeasure_mem_Icc). Upper: S_p inside closedBall 0 2, area 4pi. Lower: ball of radius 3^-n around any root inside the lemniscate via factor-splitting triangle inequality. Same shape as target [c/log n, pi] with elementary constants. Remaining: sharp Polya pi upper and KLR c/log n lower need logarithmic potential theory absent from Mathlib (blocked route unchanged).",
+    "progressSummary": "PROGRESS (researcher-1, 2026-07-22, host-verified lake env lean exit 0, all new theorems [propext, Classical.choice, Quot.sound]): first QUANTITATIVE two-sided bounds for arbitrary P — pi/9^n <= sublevelMeasure P <= 4pi (sublevelMeasure_mem_Icc). Upper: S_p inside closedBall 0 2, area 4pi. Lower: ball of radius 3^-n around any root inside the lemniscate via factor-splitting triangle inequality. Same shape as target [c/log n, pi] with elementary constants. Remaining: sharp Polya pi upper and KLR c/log n lower need logarithmic potential theory absent from Mathlib (blocked route unchanged). UPDATE 2026-07-22b: full Polya equality family added (allRootsAt: (z-a)^n has area pi for every |a|<=1), same PR #41875.",
     "builtItems": [
       "UnitDiskPoly.eval_root_eq_zero / root_mem_sublevelSet / sublevelSet_nonempty / eval_of_degree_zero / sublevelSet_of_degree_zero / sublevelMeasure_nonneg in proofs/Proofs/Erdos116Problem.lean (6 axiom-free foundational theorems; host-verified v4.31, #print axioms = propext/Classical.choice/Quot.sound only)",
       "proofs/Proofs/Erdos116WIP01.lean — 6 axiom-free decls (continuous_eval, sublevelSet_eq_preimage, isOpen_sublevelSet, measurableSet_sublevelSet, sublevelSet_subset_closedBall, isBounded_sublevelSet)",
@@ -51,7 +51,8 @@
       "sublevelMeasure_le_four_pi in Erdos116WIP01.lean (weak Polya upper bound 4pi)",
       "ball_subset_sublevelSet in Erdos116WIP01.lean (ball 3^-n around each root inside lemniscate)",
       "pi_div_pow_le_sublevelMeasure in Erdos116WIP01.lean (weak Pommerenke lower bound pi/9^n)",
-      "sublevelMeasure_mem_Icc in Erdos116WIP01.lean (headline two-sided bound)"
+      "sublevelMeasure_mem_Icc in Erdos116WIP01.lean (headline two-sided bound)",
+      "allRootsAt family (sublevelSet = ball a 1, sublevelMeasure = pi for every |a|<=1, n>=1) in Erdos116WIP01.lean"
     ],
     "insights": [
       "Erdos116Problem.lean was a bare statement-stub: real definitions (UnitDiskPoly, eval, sublevelSet, sublevelMeasure) but ZERO theorems, while gallery meta prose falsely described four bounds \"stated as axioms\" and a main theorem ErdosProblem116 that did not exist in source.",
@@ -67,7 +68,8 @@
       "Attainment half of the sharp Polya-type upper bound is now formal: exists P : UnitDiskPoly n, sublevelMeasure P = pi for every n >= 1; only the inequality sublevelMeasure P <= pi remains (deep, potential theory)",
       "Elementary triangle-inequality geometry already yields two-sided quantitative bounds pi/9^n <= mu(S_p) <= 4pi for every P — no potential theory needed; the deep content is narrowing this window to [c/log n, pi]",
       "Ball of radius 3^-n around ANY root lies inside the lemniscate: distinguished factor < 3^-n, each other factor <= 3, product < 1/3",
-      "sublevelMeasure_eq_toReal_volume dedupes the C ~ RxR measure transport once and for all; quantitative bounds then work purely on the C side via measure_mono + ENNReal.toReal_mono"
+      "sublevelMeasure_eq_toReal_volume dedupes the C ~ RxR measure transport once and for all; quantitative bounds then work purely on the C side via measure_mono + ENNReal.toReal_mono",
+      "The whole Polya equality family (z-a)^n is now covered exactly: area functional constant pi on repeated-root configs anywhere in the disk — Complex.volume_ball at arbitrary center makes translation machinery unnecessary"
     ],
     "mathlibGaps": [],
     "nextSteps": [

--- a/src/data/research/problems/erdos-116-wip-01.json
+++ b/src/data/research/problems/erdos-116-wip-01.json
@@ -37,7 +37,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-1, 2026-07-22, host-verified lake env lean exit 0): EXACT lemniscate areas added — extremal candidate z^n has sublevelSet = ball 0 1 and sublevelMeasure = pi on the nose (all n>=1); degree-1 lemniscates are unit disks so area is identically pi; exists_sublevelMeasure_eq_pi gives the attainment half of the sharp Polya-type bound. Well-definedness layer (open/measurable/bounded/finite/positive) was already complete. Remaining: deep KLR c/log n lower and Polya pi upper bounds (logarithmic potential theory, not in Mathlib).",
+    "progressSummary": "PROGRESS (researcher-1, 2026-07-22, host-verified lake env lean exit 0, all new theorems [propext, Classical.choice, Quot.sound]): first QUANTITATIVE two-sided bounds for arbitrary P — pi/9^n <= sublevelMeasure P <= 4pi (sublevelMeasure_mem_Icc). Upper: S_p inside closedBall 0 2, area 4pi. Lower: ball of radius 3^-n around any root inside the lemniscate via factor-splitting triangle inequality. Same shape as target [c/log n, pi] with elementary constants. Remaining: sharp Polya pi upper and KLR c/log n lower need logarithmic potential theory absent from Mathlib (blocked route unchanged).",
     "builtItems": [
       "UnitDiskPoly.eval_root_eq_zero / root_mem_sublevelSet / sublevelSet_nonempty / eval_of_degree_zero / sublevelSet_of_degree_zero / sublevelMeasure_nonneg in proofs/Proofs/Erdos116Problem.lean (6 axiom-free foundational theorems; host-verified v4.31, #print axioms = propext/Classical.choice/Quot.sound only)",
       "proofs/Proofs/Erdos116WIP01.lean — 6 axiom-free decls (continuous_eval, sublevelSet_eq_preimage, isOpen_sublevelSet, measurableSet_sublevelSet, sublevelSet_subset_closedBall, isBounded_sublevelSet)",
@@ -46,7 +46,12 @@
       "volume_realProd_sublevelSet_lt_top — parent sublevelMeasure volume is finite, via volume-preserving ℂ≃ᵐℝ² (Erdos116WIP01.lean)",
       "allRootsZero/eval_allRootsZero/sublevelSet_allRootsZero/volume_sublevelSet_allRootsZero/volume_realProd_sublevelSet_allRootsZero/sublevelMeasure_allRootsZero in Erdos116WIP01.lean (z^n extremal config, area = pi)",
       "singleRoot/eval_singleRoot/sublevelSet_singleRoot/volume_sublevelSet_singleRoot/volume_realProd_sublevelSet_singleRoot/sublevelMeasure_singleRoot (degree-1 area identically pi)",
-      "exists_sublevelMeasure_eq_pi (pi attained at every degree n >= 1)"
+      "exists_sublevelMeasure_eq_pi (pi attained at every degree n >= 1)",
+      "sublevelMeasure_eq_toReal_volume in Erdos116WIP01.lean (transport dedup)",
+      "sublevelMeasure_le_four_pi in Erdos116WIP01.lean (weak Polya upper bound 4pi)",
+      "ball_subset_sublevelSet in Erdos116WIP01.lean (ball 3^-n around each root inside lemniscate)",
+      "pi_div_pow_le_sublevelMeasure in Erdos116WIP01.lean (weak Pommerenke lower bound pi/9^n)",
+      "sublevelMeasure_mem_Icc in Erdos116WIP01.lean (headline two-sided bound)"
     ],
     "insights": [
       "Erdos116Problem.lean was a bare statement-stub: real definitions (UnitDiskPoly, eval, sublevelSet, sublevelMeasure) but ZERO theorems, while gallery meta prose falsely described four bounds \"stated as axioms\" and a main theorem ErdosProblem116 that did not exist in source.",
@@ -59,7 +64,10 @@
       "Key Mathlib names: isCompact_closedBall (ℂ ProperSpace) + IsCompact.measure_lt_top (volume IsFiniteMeasureOnCompacts); measure_lt_top_of_subset; Complex.measurableEquivRealProd{,_symm_apply}; measure_preimage needs NullMeasurableSet (use .measurableSet.nullMeasurableSet).",
       "The extremal candidate p(z)=z^n has lemniscate EXACTLY ball 0 1 (pow_lt_one_iff_of_nonneg on ||z||^n), so its area is exactly pi via Complex.volume_ball — first exact value of sublevelMeasure in the vein",
       "At degree 1 the area functional is CONSTANT: every lemniscate {|z-z0|<1} is ball z0 1 of area pi regardless of root position — the extremal problem only becomes nontrivial at degree >= 2",
-      "Attainment half of the sharp Polya-type upper bound is now formal: exists P : UnitDiskPoly n, sublevelMeasure P = pi for every n >= 1; only the inequality sublevelMeasure P <= pi remains (deep, potential theory)"
+      "Attainment half of the sharp Polya-type upper bound is now formal: exists P : UnitDiskPoly n, sublevelMeasure P = pi for every n >= 1; only the inequality sublevelMeasure P <= pi remains (deep, potential theory)",
+      "Elementary triangle-inequality geometry already yields two-sided quantitative bounds pi/9^n <= mu(S_p) <= 4pi for every P — no potential theory needed; the deep content is narrowing this window to [c/log n, pi]",
+      "Ball of radius 3^-n around ANY root lies inside the lemniscate: distinguished factor < 3^-n, each other factor <= 3, product < 1/3",
+      "sublevelMeasure_eq_toReal_volume dedupes the C ~ RxR measure transport once and for all; quantitative bounds then work purely on the C side via measure_mono + ENNReal.toReal_mono"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for erdos-116-wip-01 (Lean formalization of Erdős #116, measure of polynomial sublevel sets).

## Progress
- 5 new axiom-free theorems in `proofs/Proofs/Erdos116WIP01.lean` (file: 297 → 424 lines)
- Host-verified: `lake env lean` exit 0; `#print axioms` = `[propext, Classical.choice, Quot.sound]` on all five new theorems; 0 sorry / 0 axiom / no native_decide
- Knowledge/state/tracker updated

## Findings
Prior sessions pinned `0 < sublevelMeasure P < ∞` and exact values at special configurations, but no quantitative bound for arbitrary `P` existed. This session adds the first **two-sided quantitative control**, the same shape as the deep target `[c/log n, π]` with elementary constants:

- `sublevelMeasure_le_four_pi` — weak Pólya upper bound `μ(Sₚ) ≤ 4π`, from the existing `Sₚ ⊆ closedBall 0 2` plus `Complex.volume_closedBall`
- `ball_subset_sublevelSet` — `ball zᵢ 3⁻ⁿ ⊆ Sₚ` around **any** root: split off the distinguished factor (`< 3⁻ⁿ`) via `Finset.mul_prod_erase`; each of the other `n−1` factors is `≤ 3` by the triangle inequality, so `‖p(z)‖ < 3⁻ⁿ·3ⁿ⁻¹ = 1/3 < 1`
- `pi_div_pow_le_sublevelMeasure` — weak Pommerenke lower bound `π/9ⁿ ≤ μ(Sₚ)` via `Complex.volume_ball`
- `sublevelMeasure_mem_Icc` — headline: `μ(Sₚ) ∈ [π/9ⁿ, 4π]` for every `n ≥ 1`
- `sublevelMeasure_eq_toReal_volume` — dedupes the `ℂ ≅ ℝ×ℝ` measure transport used by all bounds

Honesty note: these constants are far weaker than the literature (Pommerenke `c/n⁴`, KLR `c/log n`, Pólya `π`) — they are what the bare triangle inequality yields. The sharp bounds need logarithmic potential theory absent from Mathlib; the registered blocked route is unchanged.

## Status
**Outcome**: progress
**Next Steps**: the deep KLR `c/log n` lower and sharp Pólya `π` upper bounds remain blocked on potential-theory infrastructure; possible elementary increments are area-functional continuity in the roots or multi-root covering refinements of the lower bound.

🤖 Generated by researcher-1