### PR TITLE
audit: fix erdos-1029 remaining false Filter.map_atTop_atTop mention

### DIFF
--- a/src/data/proofs/erdos-1029/annotations.json
+++ b/src/data/proofs/erdos-1029/annotations.json
@@ -81,7 +81,7 @@
     "type": "concept",
     "title": "The Main Conjecture and Equivalence",
     "content": "The conjecture is formalized as Tendsto ramseyRatio atTop atTop, where ramseyRatio k = R(k)/(k·2^{k/2}). An equivalent formulation using explicit ε-δ style (for every M, ratio eventually exceeds M) is proved equivalent via Filter.tendsto_atTop_atTop. This demonstrates how Mathlib's filter framework connects topological and quantifier-based formulations.",
-    "mathContext": "The equivalence proof unpacks Tendsto in terms of Filter.map_atTop_atTop, showing that divergence to infinity is equivalent to the ∀M ∃K ∀k≥K formulation. This is a clean application of Mathlib's filter API.",
+    "mathContext": "The equivalence proof unpacks Tendsto in terms of Filter.tendsto_atTop_atTop, showing that divergence to infinity is equivalent to the ∀M ∃K ∀k≥K formulation. This is a clean application of Mathlib's filter API.",
     "significance": "key",
     "relatedConcepts": [
       "Filter.Tendsto",


### PR DESCRIPTION
## Summary
- Follow-up to #41876, which fixed the false `Filter.map_atTop_atTop` lemma citation in the `ann-1029-conjecture` annotation's `content` field but missed the identical error in its `mathContext` field (the annotation duplicated the wrong claim in both fields; the source's `conjecture_equiv` proof actually uses `Filter.tendsto_atTop_atTop`, line 148).
- #41876 auto-merged before this second commit propagated to the PR, so the fix landed only partially on main.

## Test plan
- [x] `grep -n "map_atTop_atTop"` on `annotations.json`/`meta.json` now returns no hits.
- [x] `python3 -m json.tool` validated the edited file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)