### PR TITLE
feat(research): bridge research:queued GitHub issues into the seeker candidate pool (#41840)

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -78,6 +78,21 @@
   description: Issue is part of an epic phase (references parent epic)
   color: "8B5CF6"  # violet-500 - lighter variant for child issues
 
+# Research Pipeline Labels
+# Bridge GitHub-filed research problems into the researcher candidate pool.
+# See scripts/research/ingest-issue-problems.sh (run each Seeker cycle).
+- name: research
+  description: Research agent work (general topic tag)
+  color: "5319E7"  # deep violet
+
+- name: research:queued
+  description: Math problem to route into the researcher candidate pool (Seeker intake trigger)
+  color: "1D76DB"  # blue - queued for the fleet
+
+- name: research:pooled
+  description: Ingested into the candidate pool by the Seeker intake (idempotency marker)
+  color: "0E8A16"  # green - now claimable by Researchers
+
 # Tier Labels (Goal Alignment)
 - name: tier:goal-advancing
   description: Directly implements a milestone deliverable or unblocks goal work

--- a/.lean/roles/seeker.md
+++ b/.lean/roles/seeker.md
@@ -40,6 +40,14 @@ Launched by `scripts/research/launch-seeker.sh` (tmux + claude-wrapper daemon):
    # .lean/state/candidate-pool.json (see #26802). No copy step is needed.
    python3 research/db/sync_pool.py 2>/dev/null
    ```
+2b. **Ingest GitHub research issues** (issue #41840 — additional source):
+   ```bash
+   # Turns each open issue labeled `research:queued` into a claimable pool
+   # entry (DB insert + site JSON + pool regen), then marks it `research:pooled`.
+   # Idempotent and ingest-always (independent of pool depth) — these are
+   # explicit human requests. Runs AFTER the gallery refresh above.
+   ./scripts/research/ingest-issue-problems.sh
+   ```
 3. **Check pool depth**:
    ```bash
    jq '[.candidates[] | select(.status == "available")] | length' .lean/state/candidate-pool.json
@@ -50,7 +58,8 @@ Launched by `scripts/research/launch-seeker.sh` (tmux + claude-wrapper daemon):
 
 ## Problem Sources
 
-Problems are extracted from the proof gallery:
+Problems are extracted from the proof gallery, **plus** human-filed GitHub
+issues (issue #41840):
 
 | Source | Description | Location |
 |--------|-------------|----------|
@@ -58,6 +67,25 @@ Problems are extracted from the proof gallery:
 | **Incomplete** | Proofs with `sorry` statements | `sorries > 0` in meta.json |
 | **WIP** | Work-in-progress proofs | `badge: "wip"` |
 | **Conditional** | Proofs depending on unproven hypotheses | `status: "conditional"` |
+| **GitHub issues** | Human-filed problems tagged `research:queued` | `scripts/research/ingest-issue-problems.sh` |
+
+### GitHub-issue intake (`research:queued`)
+
+`scripts/research/ingest-issue-problems.sh` bridges GitHub issues into the pool.
+Tag an issue **`research:queued`** (a dedicated trigger label — NOT the broad
+`research` topic tag) to route it to the fleet. Each cycle the script:
+
+1. Lists open issues labeled `research:queued`.
+2. For each not-yet-ingested issue, synthesizes a candidate (slug
+   `issue-<number>-<title>`, `status: available`, `sourceIssue: <number>`, issue
+   URL in `references.urls`), inserts it into `research/db/knowledge.db`, writes
+   `src/data/research/problems/<slug>.json`, and regenerates the pool.
+3. Marks the issue `research:pooled` and leaves a comment linking the pool slug.
+
+Idempotency is enforced by the `research:pooled` marker, the `sourceIssue` field
+in the site JSON, and the DB slug — an issue is never ingested twice. This is
+**additive**: gallery-derived sourcing is unchanged. First test case: #41831
+(OEIS A054656).
 | **Millennium** | Millennium Prize Problems | `millenniumProblem` field |
 | **Hilbert** | Hilbert's 23 Problems | `hilbertNumber` field |
 

--- a/research/README.md
+++ b/research/README.md
@@ -79,8 +79,34 @@ Problems are automatically extracted from the proof gallery:
 | **Conditional** | ~4 | Proofs depending on unproven hypotheses |
 | **Millennium** | 7 | Millennium Prize Problems |
 | **Hilbert** | 21 | Hilbert's 23 Problems |
+| **GitHub issues** | on demand | Human-filed problems tagged `research:queued` (see below) |
 
 **Total**: 427+ extractable open problems
+
+### GitHub-issue intake (`research:queued`)
+
+Beyond gallery extraction, you can hand the fleet a problem by **filing a GitHub
+issue and tagging it `research:queued`** (a dedicated trigger label — not the
+broad `research` topic tag). Each Seeker cycle runs:
+
+```bash
+./scripts/research/ingest-issue-problems.sh          # ingest newly-labeled issues
+./scripts/research/ingest-issue-problems.sh --dry-run # preview; mutate nothing
+```
+
+The script lists open `research:queued` issues and, for each one not already
+ingested, synthesizes a candidate-pool entry (slug `issue-<number>-<title>`,
+`status: available`, `sourceIssue: <number>`, issue URL in `references.urls`),
+inserts it into `research/db/knowledge.db`, writes
+`src/data/research/problems/<slug>.json`, regenerates the pool, and marks the
+issue `research:pooled` with a comment linking the pool slug. A Researcher then
+claims it via `claim-problem.sh claim-random` like any other candidate.
+
+Ingestion is **idempotent** (dedup by the `research:pooled` marker, the
+`sourceIssue` field, and the DB slug) and **additive** — gallery-derived
+sourcing is unchanged. Issue-sourced candidates are explicit human requests, so
+they are ingested every cycle regardless of pool depth. First test case: issue
+#41831 (OEIS A054656).
 
 ### View Problems by Tractability
 

--- a/scripts/research/ingest-issue-problems.sh
+++ b/scripts/research/ingest-issue-problems.sh
@@ -1,0 +1,334 @@
+#!/bin/bash
+#
+# ingest-issue-problems.sh - Bridge GitHub research issues into the candidate pool
+#
+# Scans open GitHub issues carrying a dedicated trigger label
+# (default: research:queued) and turns each not-yet-ingested issue into a
+# candidate-pool entry that `claim-problem.sh claim-random` will serve like any
+# other problem. This is an ADDITIONAL problem source for the Seeker — it does
+# NOT replace the gallery-derived sourcing.
+#
+# The research SQLite database (research/db/knowledge.db) is the single source
+# of truth: sync_pool.py regenerates .lean/state/candidate-pool.json from it
+# every Seeker cycle. So we INSERT the synthesized problem into the DB (and
+# write the site JSON), then regenerate the pool — otherwise the next
+# sync_pool.py run would drop an issue-sourced candidate that lived only in the
+# pool JSON.
+#
+# Idempotency (never ingest the same issue twice) is enforced three ways:
+#   1. The scan can skip issues that already carry the "pooled" marker label.
+#   2. A problem whose site JSON already records `sourceIssue: <n>` is skipped.
+#   3. A slug that already exists in the DB is skipped.
+# On successful ingest the issue is marked with the pooled label + a one-line
+# comment linking the pool slug.
+#
+# Usage:
+#   ./ingest-issue-problems.sh                 Ingest all newly-labeled issues
+#   ./ingest-issue-problems.sh --dry-run       Preview only; mutate nothing
+#   ./ingest-issue-problems.sh --repo O/R      Override target repo
+#   ./ingest-issue-problems.sh --label NAME    Override trigger label
+#   ./ingest-issue-problems.sh --help          Show this help
+#
+# Environment:
+#   INGEST_REPO           Target repo (default: rjwalters/lean-genius)
+#   INGEST_TRIGGER_LABEL  Trigger label to scan for (default: research:queued)
+#   INGEST_POOLED_LABEL   Marker label applied on ingest (default: research:pooled)
+#
+# Exit status is 0 whenever the scan completes (including "nothing to do").
+
+set -euo pipefail
+
+# --- Configuration ----------------------------------------------------------
+
+REPO="${INGEST_REPO:-rjwalters/lean-genius}"
+TRIGGER_LABEL="${INGEST_TRIGGER_LABEL:-research:queued}"
+POOLED_LABEL="${INGEST_POOLED_LABEL:-research:pooled}"
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run|-n) DRY_RUN=true; shift ;;
+        --repo) REPO="$2"; shift 2 ;;
+        --label) TRIGGER_LABEL="$2"; shift 2 ;;
+        --help|-h)
+            sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+# --- Repo root resolution ---------------------------------------------------
+#
+# Claims, the DB, and the gitignored candidate pool are SHARED coordination
+# state. When this runs from a linked worktree, an upward ".git" search resolves
+# to the worktree (where .lean/state/candidate-pool.json does not exist), so we
+# must resolve to the MAIN worktree root via the common git dir — exactly as
+# claim-problem.sh does — so every agent shares one pool and one DB.
+find_repo_root() {
+    local common_dir
+    if common_dir="$(git rev-parse --git-common-dir 2>/dev/null)" \
+        && common_dir="$(cd "$common_dir" 2>/dev/null && pwd)"; then
+        dirname "$common_dir"
+        return 0
+    fi
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.git" ]] || [[ -f "$dir/.git" ]]; then
+            echo "$dir"; return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "Error: Not in a git repository" >&2
+    return 1
+}
+
+REPO_ROOT="$(find_repo_root)"
+DB_PATH="$REPO_ROOT/research/db/knowledge.db"
+PROBLEMS_JSON_DIR="$REPO_ROOT/src/data/research/problems"
+SYNC_POOL="$REPO_ROOT/research/db/sync_pool.py"
+
+# Colors
+RED='\033[0;31m'; GREEN='\033[0;32m'; BLUE='\033[0;34m'; YELLOW='\033[1;33m'; NC='\033[0m'
+info()  { echo -e "${BLUE}i $1${NC}"; }
+ok()    { echo -e "${GREEN}+ $1${NC}"; }
+warn()  { echo -e "${YELLOW}! $1${NC}"; }
+err()   { echo -e "${RED}x $1${NC}" >&2; }
+
+# --- Dependency check -------------------------------------------------------
+check_deps() {
+    local missing=()
+    command -v gh >/dev/null 2>&1 || missing+=("gh")
+    command -v jq >/dev/null 2>&1 || missing+=("jq")
+    command -v python3 >/dev/null 2>&1 || missing+=("python3")
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        err "Missing dependencies: ${missing[*]}"
+        exit 1
+    fi
+}
+
+# --- Helpers ----------------------------------------------------------------
+
+# slugify <number> <title> -> "issue-<n>-<sanitized-title>"
+# Embedding the issue number guarantees a unique, provenance-bearing slug.
+slugify() {
+    local number="$1" title="$2" base
+    base="$(printf '%s' "$title" \
+        | tr '[:upper:]' '[:lower:]' \
+        | tr -c 'a-z0-9' '-' \
+        | tr -s '-' \
+        | sed 's/^-//; s/-$//' \
+        | cut -c1-50 \
+        | sed 's/-$//')"
+    if [[ -z "$base" ]]; then
+        echo "issue-${number}"
+    else
+        echo "issue-${number}-${base}"
+    fi
+}
+
+# db_has_slug <slug>  -> exit 0 if the slug is already a row in the DB
+db_has_slug() {
+    local slug="$1"
+    [[ -f "$DB_PATH" ]] || return 1
+    python3 - "$DB_PATH" "$slug" 2>/dev/null <<'PY'
+import sqlite3, sys
+db, slug = sys.argv[1], sys.argv[2]
+try:
+    c = sqlite3.connect(db)
+    row = c.execute("SELECT 1 FROM problems WHERE slug = ?", (slug,)).fetchone()
+    c.close()
+    sys.exit(0 if row else 1)
+except Exception:
+    sys.exit(1)
+PY
+}
+
+# already_ingested <number> <slug>  -> 0 if we've seen this issue before
+already_ingested() {
+    local number="$1" slug="$2"
+    # (2) site JSON already records this sourceIssue
+    if grep -rlq "\"sourceIssue\": *${number}\b" "$PROBLEMS_JSON_DIR" 2>/dev/null; then
+        return 0
+    fi
+    # (3) slug already present in the DB
+    if db_has_slug "$slug"; then
+        return 0
+    fi
+    return 1
+}
+
+# db_insert <slug> <title> <statement_plain>
+db_insert() {
+    local slug="$1" title="$2" statement="$3"
+    python3 - "$DB_PATH" "$slug" "$title" "$statement" <<'PY'
+import sqlite3, sys, json, datetime
+db, slug, title, statement = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+tags = json.dumps(["issue-sourced"])
+c = sqlite3.connect(db)
+# Issue-sourced problems are explicit human requests: tier B, mid significance,
+# mid tractability, status available. ON CONFLICT DO NOTHING keeps this
+# idempotent even if the slug slipped past the earlier dedup checks.
+c.execute(
+    """
+    INSERT INTO problems
+        (slug, title, status, tier, significance, tractability,
+         statement_plain, tags, started_at, last_updated)
+    VALUES (?, ?, 'available', 'B', 5, 5, ?, ?, ?, ?)
+    ON CONFLICT(slug) DO NOTHING
+    """,
+    (slug, title, statement, tags, now, now),
+)
+c.commit()
+c.close()
+PY
+}
+
+# write_problem_json <slug> <number> <title> <url> <statement_plain>
+write_problem_json() {
+    local slug="$1" number="$2" title="$3" url="$4" statement="$5"
+    local now
+    now="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    local out="$PROBLEMS_JSON_DIR/${slug}.json"
+    mkdir -p "$PROBLEMS_JSON_DIR"
+    jq -n \
+        --arg slug "$slug" \
+        --arg title "$title" \
+        --arg statement "$statement" \
+        --arg url "$url" \
+        --arg now "$now" \
+        --argjson number "$number" \
+        '{
+            slug: $slug,
+            title: $title,
+            phase: "OBSERVE",
+            status: "available",
+            tier: "B",
+            path: "full",
+            sourceIssue: $number,
+            problemStatement: { formal: "", plain: $statement, whyMatters: [] },
+            knownResults: { proven: [], open: [], goal: "" },
+            currentState: {
+                phase: "OBSERVE",
+                since: $now,
+                iteration: 1,
+                focus: "Initial problem understanding. Read the source issue and gather context.",
+                blockers: [],
+                nextAction: "Read the source GitHub issue thoroughly and acquire full context.",
+                attemptCounts: { total: 0, currentApproach: 0, approachesTried: 0 }
+            },
+            knowledge: {
+                progressSummary: "",
+                builtItems: [],
+                insights: [],
+                mathlibGaps: [],
+                nextSteps: [],
+                markdown: ("# Knowledge Base: " + $slug + "\n\nSourced from GitHub issue #" + ($number|tostring) + " (" + $url + ").\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n")
+            },
+            tags: ["issue-sourced"],
+            relatedProofs: [],
+            references: { papers: [], urls: [$url], mathlib: [] },
+            started: $now,
+            lastUpdate: $now,
+            significance: 5,
+            tractability: 5
+        }' > "$out"
+    echo "$out"
+}
+
+# --- Ingest one issue -------------------------------------------------------
+ingest_one() {
+    local number="$1" title="$2" url="$3" body="$4" has_pooled="$5"
+    local slug statement
+    slug="$(slugify "$number" "$title")"
+
+    # (1) marker label already present -> definitely ingested.
+    if [[ "$has_pooled" == "true" ]]; then
+        info "#$number already carries '$POOLED_LABEL' — skipping ($slug)"
+        return 0
+    fi
+
+    if already_ingested "$number" "$slug"; then
+        info "#$number already ingested ($slug) — skipping"
+        return 0
+    fi
+
+    # Plain-language statement: prefer the issue body, fall back to the title.
+    # Trim to a reasonable length for the pool "notes" summary.
+    statement="$(printf '%s' "$body" | tr '\r' ' ' | tr '\n' ' ' | sed 's/  */ /g; s/^ //; s/ $//' | cut -c1-500)"
+    [[ -z "$statement" ]] && statement="$title"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        warn "[dry-run] would ingest #$number as '$slug'"
+        echo "           title: $title"
+        echo "           statement: ${statement:0:100}..."
+        echo "           would: DB insert, write $PROBLEMS_JSON_DIR/${slug}.json, sync pool, label '$POOLED_LABEL' + comment"
+        return 0
+    fi
+
+    if [[ ! -f "$DB_PATH" ]]; then
+        err "DB not found at $DB_PATH — run 'python3 research/db/migrate.py' first. Skipping #$number."
+        return 0
+    fi
+
+    db_insert "$slug" "$title" "$statement"
+    local json_path
+    json_path="$(write_problem_json "$slug" "$number" "$title" "$url" "$statement")"
+    ok "Ingested #$number -> $slug"
+    info "  DB row + $json_path"
+
+    # Regenerate the consumed pool from the DB (source of truth).
+    if python3 "$SYNC_POOL" >/dev/null 2>&1; then
+        info "  Regenerated candidate pool"
+    else
+        warn "  sync_pool.py failed — pool not refreshed (candidate is in the DB and will appear on the next Seeker refresh)"
+    fi
+
+    # Mark the issue so we never ingest it twice, and leave a breadcrumb.
+    if gh issue edit "$number" --repo "$REPO" --add-label "$POOLED_LABEL" >/dev/null 2>&1; then
+        info "  Labeled #$number '$POOLED_LABEL'"
+    else
+        warn "  Could not add '$POOLED_LABEL' to #$number (label missing? run: gh label sync)"
+    fi
+    if gh issue comment "$number" --repo "$REPO" \
+        --body "Ingested into the researcher candidate pool as \`$slug\` (status: available). A Researcher can now claim it via \`claim-problem.sh claim-random\`." \
+        >/dev/null 2>&1; then
+        info "  Commented on #$number"
+    else
+        warn "  Could not comment on #$number"
+    fi
+}
+
+# --- Main -------------------------------------------------------------------
+main() {
+    check_deps
+
+    info "Scanning $REPO for open issues labeled '$TRIGGER_LABEL'..."
+    local issues_json count
+    if ! issues_json="$(gh issue list --repo "$REPO" --state open --label "$TRIGGER_LABEL" \
+            --limit 200 --json number,title,body,url,labels 2>/dev/null)"; then
+        err "gh issue list failed (auth? label '$TRIGGER_LABEL' missing?)"
+        exit 0
+    fi
+    count="$(jq 'length' <<<"$issues_json")"
+    if [[ "$count" -eq 0 ]]; then
+        ok "No open issues labeled '$TRIGGER_LABEL' — nothing to ingest."
+        return 0
+    fi
+    info "Found $count issue(s) labeled '$TRIGGER_LABEL'."
+
+    local i number title url body has_pooled
+    for ((i = 0; i < count; i++)); do
+        number="$(jq -r ".[$i].number" <<<"$issues_json")"
+        title="$(jq -r ".[$i].title" <<<"$issues_json")"
+        url="$(jq -r ".[$i].url" <<<"$issues_json")"
+        body="$(jq -r ".[$i].body // \"\"" <<<"$issues_json")"
+        has_pooled="$(jq -r ".[$i].labels | map(.name) | index(\"$POOLED_LABEL\") != null" <<<"$issues_json")"
+        ingest_one "$number" "$title" "$url" "$body" "$has_pooled"
+    done
+
+    ok "Issue intake complete."
+}
+
+main

--- a/scripts/research/launch-seeker.sh
+++ b/scripts/research/launch-seeker.sh
@@ -207,6 +207,18 @@ You are the **seeker** agent. Your mission is to keep the research pipeline fed 
    python3 research/db/sync_pool.py 2>/dev/null
    \`\`\`
 
+2b. **Ingest GitHub research issues** (ADDITIONAL source — issue #41840)
+   Human-filed research problems tagged \`research:queued\` are explicit
+   requests, so they are ingested EVERY cycle regardless of pool depth (the
+   gallery-derived replenishment below stays threshold-gated). This inserts each
+   new such issue into the DB, writes its site JSON, regenerates the pool, and
+   marks the issue \`research:pooled\` so it is never ingested twice.
+   \`\`\`bash
+   # Idempotent: skips issues already carrying research:pooled or already in the
+   # DB. Re-runs sync_pool.py internally, so run it AFTER the refresh above.
+   ./scripts/research/ingest-issue-problems.sh 2>&1 | tee -a "$LOG_FILE"
+   \`\`\`
+
 3. **Check candidate pool depth**
    \`\`\`bash
    AVAILABLE=\$(jq '[.candidates[] | select(.status == "available")] | length' .lean/state/candidate-pool.json)


### PR DESCRIPTION
## Summary

Bridges GitHub-filed research problems into the researcher candidate pool so a manually-filed issue (e.g. #41831, "Formalize OEIS A054656") is picked up by the fleet instead of being orphaned.

Previously the Seeker only sourced candidates from enriched gallery proofs; there was no path from a GitHub issue to `claim-problem.sh claim-random`. This adds an **idempotent, additive** issue -> pool intake, run each Seeker cycle.

## What changed

- **`scripts/research/ingest-issue-problems.sh`** (new) — deterministic intake:
  - Lists open issues labeled **`research:queued`** (dedicated trigger label, not the broad `research` tag).
  - For each not-yet-ingested issue: synthesizes a candidate (slug `issue-<number>-<title>`, `status: available`, `sourceIssue: <number>`, issue URL in `references.urls`), inserts it into `research/db/knowledge.db` (the source of truth), writes the full-schema `src/data/research/problems/<slug>.json`, and regenerates the consumed pool via `sync_pool.py`.
  - Marks the issue **`research:pooled`** and comments the pool slug.
  - Resolves `REPO_ROOT` via `git-common-dir` (like `claim-problem.sh`) so it shares the main checkout's pool/DB when run from the seeker worktree.
  - Flags: `--dry-run`, `--repo`, `--label`.
- **`scripts/research/launch-seeker.sh`** + **`.lean/roles/seeker.md`** — run the intake every cycle, AFTER the gallery refresh. Additive (gallery sourcing untouched); ingest-always (independent of `SEEKER_THRESHOLD`) because these are explicit human requests.
- **`.github/labels.yml`** — add `research`, `research:queued` (trigger), `research:pooled` (marker). Run `gh label sync` to create them on the repo.
- **`research/README.md`** — documents the trigger label and intake flow.

## Idempotency

Three independent guards, so an issue is never ingested twice:
1. `research:pooled` marker label on the issue.
2. `sourceIssue: <number>` field in the site JSON (grep dedup).
3. The `issue-<number>-...` slug already present in the DB (`ON CONFLICT DO NOTHING`).

## Testing

- `bash -n` + `shellcheck` clean on the new script (and `bash -n` on the edited launcher).
- **Hermetic end-to-end** against a *copy* of the real `knowledge.db` (no live state mutated): ran the exact DB-insert primitive, then `sync_pool.py` — the synthesized candidate appears in the regenerated pool as `status: available` and passes the non-terminal filter `claim-random` uses (i.e. it is claimable).
- Verified `jq` problem-JSON generation is valid and safely handles titles/bodies containing quotes and LaTeX backslashes (`jq --arg` + parameterized `sqlite3`); confirmed `sourceIssue` + issue URL land in the output.
- Verified `slugify` (normal title, all-punctuation title -> `issue-<n>`, truncation) and the `sourceIssue` idempotency grep.
- **Read-only dry-run** against the live repo (`--dry-run`) completes cleanly.
- Did **not** mutate any real issue labels/comments or the live DB/pool during testing.

## Design note

#41831 (OEIS A054656) is the intended first real test case: once it carries `research:queued`, the next Seeker cycle ingests it as a claimable candidate. (Label creation via `gh label sync` is the one manual prerequisite; the script degrades gracefully with a warning if the labels are not yet synced.)

Closes #41840
