### PR TITLE
Research: erdos-18-wip-01 - decide engines + hErdos 24 = 3 (strict subadditivity), hErdos 30 = 4

### DIFF
--- a/proofs/Proofs/Erdos18WIP01.lean
+++ b/proofs/Proofs/Erdos18WIP01.lean
@@ -2042,5 +2042,111 @@ theorem hErdos_twelve : hErdos 12 = 3 := by
           unfold hErdos
           exact Finset.le_sup (Finset.mem_range.mpr (by omega))
 
-end Erdos18
+/- ## Decide-powered exact-value engines, and `hErdos 24 = 3`, `hErdos 30 = 4`
 
+The exact values so far (`hErdos 6 = 2`, `hErdos 12 = 3`) were computed by hand:
+one `repLength_le_of_witness` invocation per target `k` for the upper bound, and a
+bespoke kernel check for the lower bound. The two **engines** below reduce *any*
+concrete exact value to two `decide` calls:
+
+* `hErdos_le_of_witnesses` — upper bound: a kernel search finding, for every
+  `k < m`, some divisor subset of size `≤ t` summing to `k`;
+* `le_repLength_of_card` / `le_hErdos_of_card` — lower bound: a kernel check
+  that every divisor subset summing to one chosen hard target `k` has `≥ t`
+  elements.
+
+With them we pin two new exact values, each carrying theory-level information:
+
+* **`hErdos 24 = 3`** — the first *strict* instance of subadditivity:
+  `hErdos (4·6) = 3 < 2 + 2 = hErdos 4 + hErdos 6` (`hErdos_mul_lt_four_six`),
+  in contrast to `12 = 2·6` where the subadditive bound is attained.
+* **`hErdos 30 = 4`** — `30` has *no* factorisation into practical parts
+  (`15`, `10`, `5` are not practical), so `hErdos_mul_le` gives no upper bound at
+  all and the engine is the only available route. Moreover `24` and `30` both
+  have `d(m) = 8` divisors, yet their indices differ (`3` vs `4`): the index
+  depends on the divisor *structure*, not the divisor count. The counting bound
+  `lt_hErdos_of_pow_lt` gives only `≥ 2` for both, and the upper-half gap only
+  `≥ 2`; the hard target `k = 29` (`29 = 15+10+3+1` is forced, no three divisors
+  of `30` sum to `29`) needs the full kernel check. -/
+
+/-- **Upper-bound engine**: if a kernel search finds, for every `k < m`, a divisor
+subset of size `≤ t` summing to `k`, then `hErdos m ≤ t`. Reduces the upper half
+of any concrete exact-value computation to one `decide`. -/
+theorem hErdos_le_of_witnesses {m t : ℕ}
+    (h : ∀ k ∈ Finset.range m, ∃ T ∈ (divisors m).powerset, T.card ≤ t ∧ T.sum id = k) :
+    hErdos m ≤ t := by
+  unfold hErdos
+  apply Finset.sup_le
+  intro k hk
+  obtain ⟨T, hTpow, hTcard, hTsum⟩ := h k hk
+  exact (repLength_le_of_witness (Finset.mem_powerset.mp hTpow) hTsum).trans hTcard
+
+/-- **Lower-bound engine (per target)**: if every divisor subset summing to `k`
+has at least `t` elements (a finite kernel check over the powerset), then
+`t ≤ repLength m k`. Generalises the bespoke `three_le_repLength_twelve_eleven`. -/
+theorem le_repLength_of_card {m k t : ℕ} (hm : IsPractical m) (hk1 : 1 ≤ k)
+    (hkm : k < m)
+    (h : ∀ T ∈ (divisors m).powerset, T.sum id = k → t ≤ T.card) :
+    t ≤ repLength m k := by
+  unfold repLength
+  apply le_csInf
+  · obtain ⟨T, hTsub, hTsum⟩ := hm.2 k hk1 hkm
+    exact ⟨T.card, T, hTsub, rfl, hTsum⟩
+  · rintro s ⟨T, hTsub, rfl, hTsum⟩
+    exact h T (Finset.mem_powerset.mpr hTsub) hTsum
+
+/-- **Lower-bound engine (index)**: one hard target `k < m` needing `≥ t` divisors
+forces `t ≤ hErdos m`. -/
+theorem le_hErdos_of_card {m k t : ℕ} (hm : IsPractical m) (hk1 : 1 ≤ k)
+    (hkm : k < m)
+    (h : ∀ T ∈ (divisors m).powerset, T.sum id = k → t ≤ T.card) :
+    t ≤ hErdos m := by
+  refine (le_repLength_of_card hm hk1 hkm h).trans ?_
+  unfold hErdos
+  exact Finset.le_sup (Finset.mem_range.mpr hkm)
+
+/-- `24` is practical — decision procedure. -/
+theorem twentyfour_practical : IsPractical 24 := by decide
+
+set_option maxRecDepth 20000 in
+/-- **`hErdos 24 = 3`.** Upper: the engine finds `≤ 3`-divisor representations for
+all `k < 24` (the two-divisor sums from `{1,2,3,4,6,8,12}` reach up to `20`, and
+`12 + 8 + {1,2,3}` covers `21, 22, 23`). Lower: no two divisors of `24` sum to
+`23` (max two-divisor sum below `24` is `12 + 8 = 20`), so `k = 23` needs three. -/
+theorem hErdos_twentyfour : hErdos 24 = 3 := by
+  refine le_antisymm (hErdos_le_of_witnesses (by decide)) ?_
+  exact le_hErdos_of_card (k := 23) twentyfour_practical (by omega) (by omega)
+    (by decide)
+
+/-- `hErdos 4 = 2` — the power-of-two formula at `k = 2`. -/
+theorem hErdos_four : hErdos 4 = 2 := by
+  have h := hErdos_two_pow 2
+  norm_num at h
+  exact h
+
+/-- **Subadditivity can be strict**: `hErdos (4·6) = 3 < 2 + 2 = hErdos 4 + hErdos 6`.
+Contrast with `12 = 2·6`, where `hErdos 12 = 3 = 1 + 2` attains the subadditive
+bound (`hErdos_twelve`). So `hErdos_mul_le` is tight at some factorisations and
+strict at others — even for the same kind of split of highly practical numbers. -/
+theorem hErdos_mul_lt_four_six : hErdos (4 * 6) < hErdos 4 + hErdos 6 := by
+  have h24 : (4 * 6 : ℕ) = 24 := by norm_num
+  rw [h24, hErdos_twentyfour, hErdos_four, hErdos_six]
+  norm_num
+
+/-- `30` is practical — decision procedure. -/
+theorem thirty_practical : IsPractical 30 := by decide
+
+set_option maxRecDepth 20000 in
+/-- **`hErdos 30 = 4`** — the first exact value out of reach of *both* prior
+methods: `30 = 2·3·5` has no factorisation into practical parts, so
+`hErdos_mul_le` is inapplicable, and the upper-half gap gives only `≥ 2`. The
+hard target is `k = 29`: the only representation is `29 = 15 + 10 + 3 + 1`
+(no three divisors of `30` sum to `29`), so four divisors are needed. Note
+`d(24) = d(30) = 8` while `hErdos 24 = 3 ≠ 4 = hErdos 30`: the index sees the
+divisor structure, not the divisor count. -/
+theorem hErdos_thirty : hErdos 30 = 4 := by
+  refine le_antisymm (hErdos_le_of_witnesses (by decide)) ?_
+  exact le_hErdos_of_card (k := 29) thirty_practical (by omega) (by omega)
+    (by decide)
+
+end Erdos18

--- a/research/problems/erdos-18-wip-01/knowledge.md
+++ b/research/problems/erdos-18-wip-01/knowledge.md
@@ -312,3 +312,43 @@ Idioms: after `rcases c with _ | _ | c` state helper products as `d * (c + 1 + 1
 NEXT: exact hErdos on 2^a·3 family or hErdos 24/30; a general lower-bound engine
 (iterating the gap argument below m/2?); or the deep Vose hErdos(n!) < n^{o(1)}
 (still blocked at elementary layer).
+
+## 2026-07-22 (researcher-1-9) — DECIDE ENGINES + hErdos 24 = 3 (strict subadditivity), hErdos 30 = 4
+
+Shipped the general exact-value engines requested by the prior session's NEXT, plus
+two new exact values (0-axiom, host-verified `lake env lean` exit 0, `#print axioms`
+= propext/Classical.choice/Quot.sound on all six new public results):
+
+- `hErdos_le_of_witnesses` — **upper-bound engine**: `(∀ k ∈ range m, ∃ T ∈
+  (divisors m).powerset, T.card ≤ t ∧ T.sum id = k) → hErdos m ≤ t`; hypothesis
+  discharged by one kernel `decide`. Replaces per-k `interval_cases` +
+  `repLength_le_of_witness` case lists (24/30 cases would have been needed here).
+- `le_repLength_of_card` / `le_hErdos_of_card` — **lower-bound engine**: one hard
+  target `k` with "every divisor subset summing to `k` has ≥ t elements" (kernel
+  `decide` over the powerset) forces `t ≤ hErdos m`. Generalises the bespoke
+  `three_le_repLength_twelve_eleven`.
+- `hErdos_twentyfour : hErdos 24 = 3` (+ `twentyfour_practical`, `hErdos_four`).
+- `hErdos_mul_lt_four_six : hErdos (4·6) < hErdos 4 + hErdos 6` — **first strict
+  instance of subadditivity** (3 < 2+2), contrasting the tight split 12 = 2·6.
+- `hErdos_thirty : hErdos 30 = 4` (+ `thirty_practical`) — first exact value out of
+  reach of BOTH prior methods: 30 = 2·3·5 has no practical factorisation
+  (`hErdos_mul_le` inapplicable) and gap/counting bounds stop at ≥ 2. Hard target
+  k=29 (only rep 15+10+3+1). Also d(24) = d(30) = 8 but indices 3 ≠ 4: the index
+  sees divisor structure, not divisor count.
+
+### Idioms (v4.31)
+- The engine `decide`s (powerset of 8 divisors × ≤30 targets) exceed the default
+  elaborator recursion: put `set_option maxRecDepth 20000 in` BEFORE the docstring
+  (`/-- ... -/ set_option ... in theorem` is a parse error, "expected 'lemma'").
+- Exact-value skeleton is now 3 lines: `refine le_antisymm
+  (hErdos_le_of_witnesses (by decide)) ?_; exact le_hErdos_of_card (k := K)
+  <m>_practical (by omega) (by omega) (by decide)`.
+
+### Known exact values (all 0-axiom)
+hErdos 1=0, 2=1, 4=2, 6=2, 12=3, 24=3, 30=4, 2^k=k. Strictness data: 12=2·6 tight,
+24=4·6 strict.
+
+NEXT: minimal-m-with-hErdos=t sequence (2,6,12?,30? — needs hErdos 16,18,20,28 to
+confirm 30 is minimal for 4); hErdos of 2^a·3 family via engines; a lower-bound
+engine iterating the gap argument below m/2 (theory, not per-m decide); deep Vose
+hErdos(n!) < n^{o(1)} still blocked at elementary layer.

--- a/research/problems/erdos-18-wip-01/state.md
+++ b/research/problems/erdos-18-wip-01/state.md
@@ -23,3 +23,12 @@ None.
 ## Next Action
 Read problem.md thoroughly and acquire full context.
 Then move to ORIENT phase to explore literature and related proofs.
+
+## Status (researcher-1-9, 2026-07-22) — decide engines + hErdos 24 = 3, hErdos 30 = 4
+
+Phase ACT. Shipped decide-powered exact-value engines (`hErdos_le_of_witnesses`,
+`le_repLength_of_card`/`le_hErdos_of_card`) and exact values `hErdos 24 = 3`
+(first strict subadditivity: `hErdos(4·6) = 3 < 2+2`, `hErdos_mul_lt_four_six`)
+and `hErdos 30 = 4` (first value with no practical factorisation — engines are the
+only route). All 0-axiom, host-verified. Deep Vose bound unchanged. See
+knowledge.md for the exact-value table and next candidates.

--- a/src/data/research/problems/erdos-18-wip-01.json
+++ b/src/data/research/problems/erdos-18-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: hErdos index has exact values hErdos(2^k)=k, hErdos 6=2, hErdos 12=3 (subadditivity TIGHT at 2*6), characterization hErdos m=1 iff m=2 via upper-half divisor gap (no divisor in (m/2,m)), sandwich 1<=hErdos<=h<=d(m), subadditivity + m<=(d(m)+1)^hErdos counting lower bound (all 0-axiom). Deep/open: hErdos(n!)<n^{o(1)} (Vose); residual mechanic = rename parent h->hCover.",
+    "progressSummary": "PROGRESS (researcher-1-9, 2026-07-22, host-verified lake env lean exit 0, all new results [propext, Classical.choice, Quot.sound]): decide-powered exact-value ENGINES (upper: hErdos_le_of_witnesses; lower: le_hErdos_of_card) + two new exact values — hErdos 24 = 3 (first STRICT subadditivity: hErdos(4*6) = 3 < 2+2) and hErdos 30 = 4 (first value unreachable by subadditivity since 30 has no practical factorisation; d(24)=d(30)=8 yet indices differ). Known exact values: hErdos 1,2,4,6,12,24,30,2^k = 0,1,2,2,3,3,4,k. Deep/open: hErdos(n!) < n^{o(1)} (Vose); residual mechanic = rename parent h -> hCover.",
     "builtItems": [
       "decidableIsRepresentable / decidableIsPractical instances (Erdos18Problem.lean)",
       "zero_isRepresentable, one_isRepresentable, isRepresentable_self, isRepresentable_le_sigma, mem_divisors_le (Erdos18Problem.lean)",
@@ -51,7 +51,12 @@
       "repLength_mul_le, hErdos_mul_le, hErdos_pow_le (hErdos(m^k)<=k*hErdos m, tight at m=2), repLength_zero, repLength_spec in Erdos18WIP01.lean (0-axiom)",
       "repLength_le_of_witness, two_mul_le_of_dvd_of_lt, two_le_card_of_sum_upper_half, two_le_repLength_of_upper_half in Erdos18WIP01.lean (upper-half gap engine)",
       "two_le_hErdos (practical m>=3), hErdos_one, hErdos_two, hErdos_eq_one_iff in Erdos18WIP01.lean",
-      "hErdos_six (=2, first non-2-power exact value), twelve_practical, three_le_card_of_sum_eleven (kernel decide over 64 subsets), three_le_repLength_twelve_eleven, hErdos_twelve (=3, subadditivity tight) in Erdos18WIP01.lean"
+      "hErdos_six (=2, first non-2-power exact value), twelve_practical, three_le_card_of_sum_eleven (kernel decide over 64 subsets), three_le_repLength_twelve_eleven, hErdos_twelve (=3, subadditivity tight) in Erdos18WIP01.lean",
+      "hErdos_le_of_witnesses in Erdos18WIP01.lean (decide-powered upper-bound engine)",
+      "le_repLength_of_card + le_hErdos_of_card in Erdos18WIP01.lean (decide-powered lower-bound engine)",
+      "hErdos_twentyfour = 3, hErdos_four = 2, twentyfour_practical in Erdos18WIP01.lean",
+      "hErdos_mul_lt_four_six in Erdos18WIP01.lean (first strict subadditivity instance)",
+      "hErdos_thirty = 4, thirty_practical in Erdos18WIP01.lean"
     ],
     "insights": [
       "Erdos18Problem.lean stub developed: representability (IsRepresentable) and practicality (IsPractical) are DECIDABLE via a finite powerset search over the divisor set — a single decision procedure subsuming all future example checks; all lemmas axiom-free (plain kernel decide, no native_decide/Lean.ofReduceBool).",
@@ -72,7 +77,10 @@
       "hErdos is SUBADDITIVE over products: hErdos(a*b) <= hErdos a + hErdos b for practical a,b (PR #41475). Correct-index counterpart of the parent Erdos18OQ01 subadditivity, which held only for the over-counting universal-set h.",
       "Upper-half divisor gap: no divisor of m lies strictly in (m/2, m) (proper divisor has cofactor >= 2), so any k with m<2k<2m needs >= 2 divisors in every distinct-divisor representation",
       "hErdos m = 1 exactly at m = 2 (over practical m): m=1 gives 0, and k=m-1 forces hErdos >= 2 for practical m>=3",
-      "hErdos 12 = 3 shows subadditivity hErdos(a*b)<=hErdos a+hErdos b is TIGHT at 12=2*6; the counting bound lt_hErdos_of_pow_lt only gives hErdos 12 >= 2, so the combinatorial gap argument is strictly sharper at small scales"
+      "hErdos 12 = 3 shows subadditivity hErdos(a*b)<=hErdos a+hErdos b is TIGHT at 12=2*6; the counting bound lt_hErdos_of_pow_lt only gives hErdos 12 >= 2, so the combinatorial gap argument is strictly sharper at small scales",
+      "Exact hErdos values reduce to two kernel decides via engines: upper (forall k < m exists small witness subset) + lower (one hard target where every summing subset is large); maxRecDepth 20000 needed for 8-divisor powersets",
+      "Subadditivity hErdos(ab) <= hErdos a + hErdos b can be STRICT: hErdos(4*6) = 3 < 4 = hErdos 4 + hErdos 6, while 12 = 2*6 is tight — tightness depends on the factorisation",
+      "hErdos 30 = 4 is unreachable by subadditivity (30 = 2*3*5 has no practical factorisation) — the decide engine is strictly stronger than all prior bound tools; d(24) = d(30) = 8 but hErdos differs (3 vs 4), so the index sees divisor structure not divisor count"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for erdos-18-wip-01 (practical numbers / corrected Erdős #18 index `hErdos`).

## Progress
- 9 new axiom-free declarations in `proofs/Proofs/Erdos18WIP01.lean` (2046 → 2149 lines)
- Host-verified: `lake env lean` exit 0; `#print axioms` = `[propext, Classical.choice, Quot.sound]` on all new public results; 0 sorry / 0 axiom / no native_decide
- Knowledge/state/tracker updated

## Findings
The prior session's NEXT list asked for a general exact-value engine. This session ships it and uses it:

- **Engines**: `hErdos_le_of_witnesses` (upper: one kernel `decide` searches, for every `k < m`, a divisor subset of size ≤ t summing to k) and `le_repLength_of_card`/`le_hErdos_of_card` (lower: one hard target where every summing subset is large, kernel check over the powerset). Any concrete exact value is now a 3-line proof with two `decide`s — subsumes the per-k `interval_cases` witness lists used for `hErdos 6`/`hErdos 12`.
- **`hErdos 24 = 3` — subadditivity can be strict**: `hErdos(4·6) = 3 < 2 + 2 = hErdos 4 + hErdos 6` (`hErdos_mul_lt_four_six`), contrasting the tight split `12 = 2·6`. Tightness of `hErdos_mul_le` depends on the factorisation.
- **`hErdos 30 = 4` — first value beyond all prior tools**: `30 = 2·3·5` has no factorisation into practical parts, so `hErdos_mul_le` gives no bound; the gap and counting arguments stop at ≥ 2. The hard target is `k = 29` (only representation `15+10+3+1`). Also `d(24) = d(30) = 8` while the indices differ (3 vs 4): the index sees divisor *structure*, not divisor count.
- Known exact values now: `hErdos 1,2,4,6,12,24,30 = 0,1,2,2,3,3,4` and `hErdos(2^k) = k`.
- Idiom: the big `decide`s need `set_option maxRecDepth 20000 in` placed *before* the docstring.

Honesty note: these are elementary finite computations plus reusable engine lemmas; the deep prize conjecture `hErdos(n!) < n^{o(1)}` (Vose) is untouched and remains a stated conjecture `Prop`.

## Status
**Outcome**: progress
**Next Steps**: minimal-m-with-`hErdos = t` sequence (needs `hErdos 16,18,20,28` to confirm 30 is minimal for index 4 — now cheap via the engines); `2^a·3` family; deep Vose bound remains blocked at the elementary layer.

🤖 Generated by researcher-1