### PR TITLE
audit: fix erdos-1025 vacuous question existential

### DIFF
--- a/proofs/Proofs/Erdos1025Problem.lean
+++ b/proofs/Proofs/Erdos1025Problem.lean
@@ -153,15 +153,14 @@ theorem g_asymptotic : ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ ∃ N : ℕ, ∀ n ≥
 The answer is g(n) = Θ(n^(1/2)).
 -/
 
-/-- The main question: estimate g(n). -/
+/-- The main question: estimate g(n). Fixed to n^(1/2), not a free witness function —
+    a free `∃ h : ℕ → ℝ` here would make this trivially true for any g (take h = g). -/
 def erdos_1025_question : Prop :=
-  ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ ∃ h : ℕ → ℝ, ∃ N : ℕ, ∀ n ≥ N,
-    c * h n ≤ g n ∧ (g n : ℝ) ≤ C * h n
+  ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ ∃ N : ℕ, ∀ n ≥ N,
+    c * (n : ℝ) ^ (1/2 : ℝ) ≤ g n ∧ (g n : ℝ) ≤ C * (n : ℝ) ^ (1/2 : ℝ)
 
 /-- The answer: g(n) = Θ(n^(1/2)). -/
-theorem erdos_1025_solved : erdos_1025_question := by
-  obtain ⟨c, C, hc, hC, N, hN⟩ := g_asymptotic
-  use c, C, hc, hC, fun n => (n : ℝ) ^ (1/2 : ℝ), N
+theorem erdos_1025_solved : erdos_1025_question := g_asymptotic
 
 /-
 ## Related: Set Mappings

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9074,10 +9074,10 @@
       "result": "clean"
     },
     "erdos-1025": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:26Z",
-      "result": "clean"
+      "lastAudited": "2026-07-22T22:04:29Z",
+      "result": "issues-fixed"
     },
     "erdos-1025-oq-04": {
       "auditCount": 1,

--- a/src/data/proofs/erdos-1025/meta.json
+++ b/src/data/proofs/erdos-1025/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "solved",
     "relatedProblems": [],
     "axiomCount": 4,
-    "lineCount": 241,
+    "lineCount": 240,
     "assumptions": "4 axioms: erdos_hajnal_lower, erdos_hajnal_upper, spencer_lower, cfs_upper. 0 sorries.",
     "mathlib_version": "4.31.0",
     "theoremCount": 6,
@@ -230,7 +230,7 @@
       "Finset"
     ],
     "namespace": "Erdos1025",
-    "lineCount": 241,
+    "lineCount": 240,
     "axiomCount": 4,
     "theoremCount": 6,
     "definitionCount": 13,


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-1025

**Problem**: `erdos_1025_question` quantified over a free `∃ h : ℕ → ℝ`:

```lean
def erdos_1025_question : Prop :=
  ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ ∃ h : ℕ → ℝ, ∃ N : ℕ, ∀ n ≥ N,
    c * h n ≤ g n ∧ (g n : ℝ) ≤ C * h n
```

Since `h` is unconstrained, this is trivially true for **any** `g : ℕ → ℕ`
(take `h n := (g n : ℝ)`, `c = C = 1`) — it carries zero information about
the actual Θ(n^{1/2}) asymptotic that the file's docstring and gallery
prose claim as "the answer". The genuinely substantive result (tying the
bound to n^(1/2)) was already correctly proved by `g_asymptotic`; the
headline "Main Question Answered" theorem just repackaged it into a
vacuous wrapper.

Same template also appears in `erdos-1024` and `erdos-1028` (not fixed
here — out of scope of this claim, filing a separate issue).

## Fix

Fixed `erdos_1025_question` to state the bound directly against
`n^(1/2)` instead of a free witness function, matching `g_asymptotic`
exactly:

```lean
def erdos_1025_question : Prop :=
  ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ ∃ N : ℕ, ∀ n ≥ N,
    c * (n : ℝ) ^ (1/2 : ℝ) ≤ g n ∧ (g n : ℝ) ≤ C * (n : ℝ) ^ (1/2 : ℝ)

theorem erdos_1025_solved : erdos_1025_question := g_asymptotic
```

Verified `lake env lean` compiles clean (only a pre-existing unrelated
unused-variable warning). Also corrected `lineCount` 241→240 in
`meta.json` (stale undercount... now overcount, fixed).

Axiom/theorem/def/sorry counts unchanged (4/6/13/0) — this is a
statement-faithfulness fix, not a counting fix.

---
Discovered during gallery integrity audit.