### PR TITLE
audit: fix erdos-1024, erdos-1028 vacuous question existential

### DIFF
--- a/proofs/Proofs/Erdos1024Problem.lean
+++ b/proofs/Proofs/Erdos1024Problem.lean
@@ -156,15 +156,15 @@ theorem phelps_rodl : ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ ∃ N : ℕ, ∀ n ≥ 
 The answer is f(n) ≍ (n log n)^(1/2).
 -/
 
-/-- The main question: estimate f(n). -/
+/-- The main question: estimate f(n). Fixed to `asymptoticBound` (≍ (n log n)^(1/2)),
+    not a free witness function — a free `∃ g : ℕ → ℝ` here would make this trivially
+    true for any f (take g = f). -/
 def erdos_1024_question : Prop :=
-  ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ ∃ g : ℕ → ℝ, ∃ N : ℕ, ∀ n ≥ N,
-    c * g n ≤ f n ∧ (f n : ℝ) ≤ C * g n
+  ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ ∃ N : ℕ, ∀ n ≥ N,
+    c * asymptoticBound n ≤ f n ∧ (f n : ℝ) ≤ C * asymptoticBound n
 
 /-- The answer: f(n) ≍ (n log n)^(1/2). -/
-theorem erdos_1024_solved : erdos_1024_question := by
-  obtain ⟨c, C, hc, hC, N, hN⟩ := phelps_rodl
-  exact ⟨c, C, hc, hC, asymptoticBound, N, hN⟩
+theorem erdos_1024_solved : erdos_1024_question := phelps_rodl
 
 /-
 ## Steiner Triple Systems

--- a/proofs/Proofs/Erdos1028Problem.lean
+++ b/proofs/Proofs/Erdos1028Problem.lean
@@ -182,15 +182,14 @@ theorem H_asymptotic : ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ ∃ N : ℕ, ∀ n ≥
 The answer is H(n) = Θ(n^{3/2}).
 -/
 
-/-- The main question: estimate H(n). -/
+/-- The main question: estimate H(n). Fixed to n^(3/2), not a free witness function —
+    a free `∃ h : ℕ → ℝ` here would make this trivially true for any H (take h = H). -/
 def erdos_1028_question : Prop :=
-  ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ ∃ h : ℕ → ℝ, ∃ N : ℕ, ∀ n ≥ N,
-    c * h n ≤ H n ∧ (H n : ℝ) ≤ C * h n
+  ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ ∃ N : ℕ, ∀ n ≥ N,
+    c * (n : ℝ) ^ (3/2 : ℝ) ≤ H n ∧ (H n : ℝ) ≤ C * (n : ℝ) ^ (3/2 : ℝ)
 
 /-- The answer: H(n) = Θ(n^(3/2)). -/
-theorem erdos_1028_solved : erdos_1028_question := by
-  obtain ⟨c, C, hc, hC, N, hN⟩ := H_asymptotic
-  exact ⟨c, C, hc, hC, fun n => (n : ℝ) ^ (3/2 : ℝ), N, hN⟩
+theorem erdos_1028_solved : erdos_1028_question := H_asymptotic
 
 /-
 ## Symmetric Functions

--- a/src/data/proofs/erdos-1028/meta.json
+++ b/src/data/proofs/erdos-1028/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "solved",
     "relatedProblems": [],
     "axiomCount": 2,
-    "lineCount": 309,
+    "lineCount": 308,
     "assumptions": "2 axioms: erdos_upper, erdos_spencer_lower. 0 sorries.",
     "mathlib_version": "4.31.0",
     "theoremCount": 8,
@@ -248,7 +248,7 @@
       "Finset"
     ],
     "namespace": "Erdos1028",
-    "lineCount": 309,
+    "lineCount": 308,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 11,


### PR DESCRIPTION
## Integrity Issue

Closes #41899.

`erdos_1024_question` and `erdos_1028_question` shared the same vacuous-existential defect fixed in erdos-1025 (PR #41897): each quantified over a **free** witness function (`∃ g : ℕ → ℝ` / `∃ h : ℕ → ℝ`) with no constraint tying it to the claimed asymptotic. That makes the def trivially true for **any** LHS function (take witness = LHS, c=C=1), so `_solved` proved nothing about the actual order of magnitude.

## Fix (mirrors #41897)

Replace the free existential witness with the concrete bound expression:

- **erdos-1024**: use `asymptoticBound n` (≍ (n log n)^(1/2)); `erdos_1024_solved` reduces to `phelps_rodl` directly.
- **erdos-1028**: use `(n : ℝ) ^ (3/2 : ℝ)`; `erdos_1028_solved` reduces to `H_asymptotic` directly.

No `obtain`/`use` repackaging remains. The real content was already captured by the preceding named theorems.

### Before (erdos-1024)
```lean
def erdos_1024_question : Prop :=
  ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ ∃ g : ℕ → ℝ, ∃ N : ℕ, ∀ n ≥ N,
    c * g n ≤ f n ∧ (f n : ℝ) ≤ C * g n
theorem erdos_1024_solved : erdos_1024_question := by
  obtain ⟨c, C, hc, hC, N, hN⟩ := phelps_rodl
  exact ⟨c, C, hc, hC, asymptoticBound, N, hN⟩
```
### After
```lean
def erdos_1024_question : Prop :=
  ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ ∃ N : ℕ, ∀ n ≥ N,
    c * asymptoticBound n ≤ f n ∧ (f n : ℝ) ≤ C * asymptoticBound n
theorem erdos_1024_solved : erdos_1024_question := phelps_rodl
```

## Metadata

- erdos-1028 `meta.json` lineCount 309→308 (one line net removed).
- erdos-1024 net lineCount unchanged (231).

## Validation

Both files verified with `./proofs/scripts/docker-build.sh` — **Build succeeded** (only pre-existing unrelated linter warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
