### PR TITLE
audit: fix erdos-1024/1028 vacuous question existentials

### DIFF
--- a/proofs/Proofs/Erdos1024Problem.lean
+++ b/proofs/Proofs/Erdos1024Problem.lean
@@ -156,15 +156,15 @@ theorem phelps_rodl : ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ ∃ N : ℕ, ∀ n ≥ 
 The answer is f(n) ≍ (n log n)^(1/2).
 -/
 
-/-- The main question: estimate f(n). -/
+/-- The main question: estimate f(n). Fixed to `asymptoticBound`, not a free witness
+    function — a free `∃ g : ℕ → ℝ` here would make this trivially true for any f
+    (take g = f). -/
 def erdos_1024_question : Prop :=
-  ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ ∃ g : ℕ → ℝ, ∃ N : ℕ, ∀ n ≥ N,
-    c * g n ≤ f n ∧ (f n : ℝ) ≤ C * g n
+  ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ ∃ N : ℕ, ∀ n ≥ N,
+    c * asymptoticBound n ≤ f n ∧ (f n : ℝ) ≤ C * asymptoticBound n
 
 /-- The answer: f(n) ≍ (n log n)^(1/2). -/
-theorem erdos_1024_solved : erdos_1024_question := by
-  obtain ⟨c, C, hc, hC, N, hN⟩ := phelps_rodl
-  exact ⟨c, C, hc, hC, asymptoticBound, N, hN⟩
+theorem erdos_1024_solved : erdos_1024_question := phelps_rodl
 
 /-
 ## Steiner Triple Systems

--- a/proofs/Proofs/Erdos1028Problem.lean
+++ b/proofs/Proofs/Erdos1028Problem.lean
@@ -182,15 +182,14 @@ theorem H_asymptotic : ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ ∃ N : ℕ, ∀ n ≥
 The answer is H(n) = Θ(n^{3/2}).
 -/
 
-/-- The main question: estimate H(n). -/
+/-- The main question: estimate H(n). Fixed to n^(3/2), not a free witness function —
+    a free `∃ h : ℕ → ℝ` here would make this trivially true for any H (take h = H). -/
 def erdos_1028_question : Prop :=
-  ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ ∃ h : ℕ → ℝ, ∃ N : ℕ, ∀ n ≥ N,
-    c * h n ≤ H n ∧ (H n : ℝ) ≤ C * h n
+  ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ ∃ N : ℕ, ∀ n ≥ N,
+    c * (n : ℝ) ^ (3/2 : ℝ) ≤ H n ∧ (H n : ℝ) ≤ C * (n : ℝ) ^ (3/2 : ℝ)
 
 /-- The answer: H(n) = Θ(n^(3/2)). -/
-theorem erdos_1028_solved : erdos_1028_question := by
-  obtain ⟨c, C, hc, hC, N, hN⟩ := H_asymptotic
-  exact ⟨c, C, hc, hC, fun n => (n : ℝ) ^ (3/2 : ℝ), N, hN⟩
+theorem erdos_1028_solved : erdos_1028_question := H_asymptotic
 
 /-
 ## Symmetric Functions

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9068,10 +9068,10 @@
       "result": "clean"
     },
     "erdos-1024": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:26Z",
-      "result": "clean"
+      "lastAudited": "2026-07-22T22:10:07Z",
+      "result": "issues-fixed"
     },
     "erdos-1025": {
       "auditCount": 5,
@@ -9122,10 +9122,10 @@
       "result": "clean"
     },
     "erdos-1028": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:27Z",
-      "result": "clean"
+      "lastAudited": "2026-07-22T22:10:07Z",
+      "result": "issues-fixed"
     },
     "erdos-1029": {
       "auditCount": 6,

--- a/src/data/proofs/erdos-1028/meta.json
+++ b/src/data/proofs/erdos-1028/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "solved",
     "relatedProblems": [],
     "axiomCount": 2,
-    "lineCount": 309,
+    "lineCount": 308,
     "assumptions": "2 axioms: erdos_upper, erdos_spencer_lower. 0 sorries.",
     "mathlib_version": "4.31.0",
     "theoremCount": 8,
@@ -248,7 +248,7 @@
       "Finset"
     ],
     "namespace": "Erdos1028",
-    "lineCount": 309,
+    "lineCount": 308,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 11,


### PR DESCRIPTION
## Summary

Fixes #41899. Same defect just fixed in erdos-1025 (PR #41897): the
`erdos_NNNN_question` def quantified over a free `∃` witness function
(`g`/`h : ℕ → ℝ`) with no constraint tying it to the actual claimed
asymptotic. Because the witness is unconstrained, each `_question` def
was trivially true for **any** function on the LHS (take witness = LHS
function, c=C=1) — it did not encode the claimed asymptotic order.

- **erdos-1024**: `erdos_1024_question` now fixes the witness to
  `asymptoticBound n = (n log n)^(1/2)`; `erdos_1024_solved` reduces
  directly to the existing `phelps_rodl` theorem.
- **erdos-1028**: `erdos_1028_question` now fixes the witness to
  `n^(3/2)`; `erdos_1028_solved` reduces directly to `H_asymptotic`.
- Synced erdos-1028's stale `lineCount` (309→308, off by one after the
  edit removed a line net).

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.Erdos1024Problem` — builds successfully
- [x] `./proofs/scripts/docker-build.sh Proofs.Erdos1028Problem` — builds successfully (warnings are pre-existing, unrelated to this change)
- [x] Updated `audit-tracker.json` entries for both slugs (result: issues-fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)