### PR TITLE
audit(erdos-1026): fix phantom '20 axiomatized results' openQuestions claim

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9086,10 +9086,10 @@
       "result": "clean"
     },
     "erdos-1026": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:26Z",
-      "result": "clean"
+      "lastAudited": "2026-07-22T22:15:51Z",
+      "result": "issues-fixed"
     },
     "erdos-1026-oq-02": {
       "auditCount": 2,

--- a/src/data/proofs/erdos-1026/meta.json
+++ b/src/data/proofs/erdos-1026/meta.json
@@ -168,7 +168,7 @@
       "What is the exact extremal construction for small n?",
       "Does the bound extend to approximate monotonicity?",
       "What are the best algorithmic approaches to find maximum-sum monotonic subsequences?",
-      "Complete proofs of the 20 axiomatized results",
+      "Complete a Lean proof of the 1 remaining axiom (weighted_erdos_szekeres, the Tidor-Wang-Yang theorem)",
       "Extend to k-monotonic decompositions (neither increasing nor decreasing)"
     ]
   },


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-1026 (Monotonic Subsequence Sum Optimization)
**Problem**: `conclusion.openQuestions` claims "Complete proofs of the 20 axiomatized results" — a phantom count. The file (`Proofs/Erdos1026Problem.lean`) has exactly **1** axiom (`weighted_erdos_szekeres`, the Tidor-Wang-Yang theorem), matching `meta.axiomCount: 1` and the `assumptions` field. There is no set of 20 axiomatized results anywhere in this file or its companions (`erdos-1026-oq-02`, `erdos-1026-oq-05`, both 0 axioms).

Everything else in this entry checked out clean: axiom count (1), sorry count (0), theoremCount (9), definitionCount (13), and lineCount (323) all match the actual Lean source. Badge (`axiom`) and status (`axiomatized`) correctly reflect the single disclosed axiom.

## Fix

Replaced the phantom "20 axiomatized results" line with an accurate description of the actual single remaining axiom.

Discovered during gallery integrity audit (reserve-mode re-verification, oldest-audited entry).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>