### PR TITLE
Research: erdos-85-wip-01 - f(9) blocker overturned: elementary blueprint + pigeonhole C4 engine

### DIFF
--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -1374,4 +1374,70 @@ theorem minDegreeForC4_eight : minDegreeForC4 8 = 3 := by
   have hge : 3 ≤ minDegreeForC4 8 := three_le_minDegreeForC4 (by norm_num)
   omega
 
+/- ## Toward `f(9)`: the pigeonhole `C₄` engine
+
+The remaining open exact value below the Petersen threshold is `f(9)`.  The two
+lemmas below supply the *counting engine* for the planned elementary proof of
+`f(9) = 3` (no `ex(n; C₄)` extremal-table input), whose blueprint is:
+
+1. `δ ≥ 3`, `C₄`-free on `9` vertices bounds the cherry count
+   `Σᵥ C(d(v), 2) ≤ C(9,2) = 36`, and handshake parity forces the degree
+   sequence to be `(3⁸, 4)` or `(3⁶, 4³)` — a vertex of degree `≥ 6` gives
+   `15 + 24 > 36`, and degree `5` forces (parity) a second vertex of degree
+   `≥ 4`, giving `10 + 6 + 21 > 36`.
+2. **`(3⁶, 4³)` dies by pigeonhole**: the tight cherry count `36 = C(9,2)`
+   makes every pair have *exactly* one common neighbour, so counting paths of
+   length `2` out of any vertex `v` gives `Σ_{u ∈ N(v)} (d(u) − 1) = 8`; for a
+   degree-`4` vertex all four neighbour degrees are then forced to `3`, so the
+   three degree-`4` vertices are pairwise non-adjacent with neighbourhoods
+   inside the six degree-`3` vertices — and `4 + 4 = 6 + 2` triggers
+   `containsC4_of_degree_sum_subset` below.
+3. **`(3⁸, 4)` dies locally at the degree-`4` vertex `w`**: each of the four
+   remaining vertices (`R = V ∖ ({w} ∪ N(w))`) is adjacent to at most one
+   member of `N(w)` (two would be a second common neighbour with `w`), so `R`'s
+   internal edge count is at least `(12 − 4)/2 = 4`; a `C₄`-free graph on `4`
+   vertices has at most `4` edges, with the unique extremal graph the *paw*
+   (triangle plus pendant) — whose pendant then has total degree at most `2`,
+   contradicting `δ ≥ 3`.
+
+Steps 1–3 are recorded here as the working plan; only the engine is formalized
+in this file so far. -/
+
+/-- **Pigeonhole `C₄` engine (subset form).**  If two distinct vertices have
+their neighbourhoods inside a common vertex set `S` and their degrees sum to at
+least `|S| + 2`, the neighbourhoods share two distinct vertices — a `C₄`.  The
+`f(9)` programme applies this with `S` the six degree-`3` vertices of a
+hypothetical `(3⁶, 4³)` graph and `u, v` two of its degree-`4` vertices:
+`4 + 4 = 6 + 2`. -/
+theorem containsC4_of_degree_sum_subset {V : Type*} [Fintype V] [DecidableEq V]
+    {G : SimpleGraph V} [DecidableRel G.Adj] {u v : V} {S : Finset V}
+    (huv : u ≠ v) (hu : G.neighborFinset u ⊆ S) (hv : G.neighborFinset v ⊆ S)
+    (hsum : S.card + 2 ≤ G.degree u + G.degree v) :
+    containsC4 V G := by
+  have hunion : (G.neighborFinset u ∪ G.neighborFinset v).card ≤ S.card :=
+    Finset.card_le_card (Finset.union_subset hu hv)
+  have hcards := Finset.card_union_add_card_inter
+    (G.neighborFinset u) (G.neighborFinset v)
+  rw [G.card_neighborFinset_eq_degree, G.card_neighborFinset_eq_degree] at hcards
+  have hinter : 1 < (G.neighborFinset u ∩ G.neighborFinset v).card := by omega
+  obtain ⟨x, hx, y, hy, hxy⟩ := Finset.one_lt_card.mp hinter
+  rw [Finset.mem_inter] at hx hy
+  exact containsC4_of_two_common huv hxy
+    ((G.mem_neighborFinset u x).mp hx.1).symm
+    ((G.mem_neighborFinset v x).mp hx.2).symm
+    ((G.mem_neighborFinset u y).mp hy.1).symm
+    ((G.mem_neighborFinset v y).mp hy.2).symm
+
+/-- **Pigeonhole `C₄` engine (global form).**  Two distinct vertices whose
+degrees sum to at least `|V| + 2` force a `C₄`.  (Immediate from the subset
+form with `S = univ`.)  E.g. on `9` vertices any two vertices of degree `≥ 6`,
+or degrees `7 + 4`, already force a `C₄` — a cheap complement to the cherry
+count. -/
+theorem containsC4_of_card_add_two_le_degree_add_degree {V : Type*} [Fintype V]
+    [DecidableEq V] {G : SimpleGraph V} [DecidableRel G.Adj] {u v : V}
+    (huv : u ≠ v) (hsum : Fintype.card V + 2 ≤ G.degree u + G.degree v) :
+    containsC4 V G :=
+  containsC4_of_degree_sum_subset huv (Finset.subset_univ _) (Finset.subset_univ _)
+    (by rwa [Finset.card_univ])
+
 end Erdos85

--- a/research/problems/erdos-85-wip-01/knowledge.md
+++ b/research/problems/erdos-85-wip-01/knowledge.md
@@ -372,3 +372,58 @@ the degree sum 7·3 + 4 = 25 odd — handshake. So either a C₄ exists or G is 
   parity boost only yields one degree-4 vertex — not enough. Needs a C₄-free min-deg-3
   graph on 9 vertices (⟹ f(9) ≥ 4) or ex(9;C₄)-strength input.
 - f(10) = 4 (Petersen), dense C₄-free families, monotonicity core: unchanged, deep.
+
+## Session 2026-07-22c (researcher-1-9) — f(9) BLOCKER OVERTURNED: elementary route mapped + pigeonhole engine formalized
+
+**Mode**: attack the recorded f(9) blocker ("needs ex(9;C₄)-strength input").
+**Outcome**: the blocker is WRONG (third "needs extremal tables" note to fall) — a
+complete elementary route to **f(9) = 3** is mapped, and its counting engine is
+formalized (2 theorems, 0-axiom, host-verified `lake env lean` exit 0).
+
+### The f(9) = 3 blueprint (full, elementary, no ex(n;C₄) input)
+Suppose G on 9 vertices, δ ≥ 3, C₄-free.
+1. **Degree-sequence pinch**: cherry count Σᵥ C(d(v),2) ≤ C(9,2) = 36. Max degree
+   ≤ 5 (deg 6: 15+8·3 = 39 > 36); deg 5 impossible (parity: sum 29 odd forces a
+   second ≥4 vertex → 10+6+7·3 = 37 > 36). So degrees ∈ {3,4}; k = #(deg-4)
+   satisfies 27+k even (k odd) and 24+3k ≤ 36 (k ≤ 4): **k ∈ {1,3}**.
+2. **(3⁶,4³) dies by pigeonhole**: k=3 makes the cherry count EXACTLY 36 — every
+   pair has exactly one common neighbour. Path-count out of v:
+   Σ_{u∈N(v)}(d(u)−1) = 8 (each x ≠ v reached exactly once). For a deg-4 vertex:
+   four terms ≥2 summing to 8 → all four neighbours have degree 3. So the three
+   deg-4 vertices are pairwise non-adjacent with N ⊆ V₃ (|V₃| = 6), and
+   4 + 4 = 6 + 2 fires `containsC4_of_degree_sum_subset` → C₄. Contradiction.
+   (No friendship theorem needed — it's only in Mathlib's Archive, no olean.)
+3. **(3⁸,4) dies locally at the deg-4 vertex w**: each x ∈ R := V∖({w}∪N(w))
+   (|R| = 4) is adjacent to ≤ 1 member of N(w) (two ⇒ second common neighbour
+   with w ⇒ C₄ via the engine). R's degrees sum 12 = 2e(R) + e(R,N(w)) ≤
+   2e(R) + 4 → e(R) ≥ 4; C₄-free on 4 vertices → e(R) ≤ 4 (5 = K₄−e has C₄), so
+   e(R) = 4 and R is the paw (unique C₄-free 4-vertex 4-edge graph) — whose
+   pendant vertex has total degree ≤ 1 + 1 = 2 < 3. Contradiction.
+
+f(9) ≥ 3 is already known (three_le_minDegreeForC4). Hence f(9) = 3.
+
+### Formalized this session (Erdos85Problem.lean, end of file)
+- `containsC4_of_degree_sum_subset` — **pigeonhole C₄ engine (subset form)**:
+  u ≠ v, N(u) ⊆ S, N(v) ⊆ S, |S|+2 ≤ d(u)+d(v) → containsC4. Via
+  `Finset.card_union_add_card_inter` + `Finset.one_lt_card` +
+  `containsC4_of_two_common`.
+- `containsC4_of_card_add_two_le_degree_add_degree` — global form (S = univ):
+  |V|+2 ≤ d(u)+d(v) → C₄.
+
+### Remaining for f(9) = 3 (next session, all elementary)
+(a) The degree-sequence pinch (step 1) — cherry-sum bookkeeping in the style of
+    `containsC4_of_eight_min_degree_three`'s counting prelude.
+(b) The exact-path-count argument (step 2) — needs the tight-cherry ⇒
+    exactly-one-common-neighbour upgrade (double counting: injection
+    cherry→pair is bijective when counts match; Finset.card_le_card equality).
+(c) The paw analysis (step 3) — small finite case work; candidate for the
+    decide-engine style used in erdos-18 (4-vertex graphs).
+
+Estimated 300-450 lines total. Steps are independent; (c) may be easiest first.
+
+### Ops note
+The active worktree was reaped mid-session WITH dirty uncommitted changes
+(second reap today: researcher-1 at ~21:44Z, researcher-1-9-e116 at ~22:25Z) —
+work redone from agent context. Worktree janitor is deleting dirty worktrees,
+contrary to the "dirty/unpushed worktrees are always preserved" contract in
+the researcher role (COMMON.md Known-Gaps). Flagging for the operator.

--- a/src/data/research/problems/erdos-85-wip-01.json
+++ b/src/data/research/problems/erdos-85-wip-01.json
@@ -42,6 +42,11 @@
         "route": "the actual Erdos #85 monotonicity core (f(n+1) >= f(n) eventually)",
         "reopenCriterion": "materially new mechanism required; genuinely open in the literature.",
         "blockedAt": "2026-07-21"
+      },
+      {
+        "route": "PARTIALLY RESOLVED 2026-07-22 (was: f(9) needs ex(9;C4)-strength input): elementary f(9)=3 route found — degree pinch + pigeonhole engine (formalized) + path-count + paw analysis (blueprinted). Residual: formalize steps (a)-(c) per knowledge.md.",
+        "reopenCriterion": "open for formalization — mechanism identified, no new mathematics needed",
+        "blockedAt": "2026-07-22"
       }
     ],
     "nextAction": "STAND DOWN on elementary work. Reopen only per a blocker reopenCriterion: an ex(n;C4) edge bound (unlocks f(9)), a decide-free Petersen (f(10)=4), a dense C4-free family (KST lower bound), or the open monotonicity core. Note: the triangle-partition trick is 8-specific. At n=9 the cherry count is silent (9*C(3,2)=27 < 36=C(9,2)) so it cannot reduce min-deg 3 to a regular case; pinning f(9) in {3,4} needs either a C4-free min-deg-3 graph on 9 vertices (would give f(9)>=4) or an ex(9;C4)-strength edge bound.",
@@ -52,7 +57,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Exact-value table complete for 1<=n<=8 (f = 1,2,3,2,3,3,3,3). f(8)=3 proved 2026-07-22 via a LOCAL triangle-partition argument — the recorded blocker ('f(8)=3 iff ex(8;C4)=11 formalized') was WRONG. Reduction: a degree-5 vertex gives 31>28 cherries, two degree-4 vertices give 30>28, exactly one degree-4 vertex makes the degree sum 25 odd (handshake), so min-deg 3 on 8 vertices reduces to 3-regular; there a C4-free graph would have every vertex in a UNIQUE triangle (pairwise-disjoint punctured neighbourhoods pack 6 vertices into 4 slots otherwise; two triangles at v give a C4 or degree>=4), so triangles partition the 8 vertices into 3-sets — 3∤8. Earlier: f(7)=3 via handshake-parity boost; f(4m^2+2m+1)<=2m+1=sqrt(n)+1 upper-Beatty family. Remaining: f(9) (parity silent, needs ex(n;C4)-strength input), f(10)=4 (Petersen), odd-s Beatty, monotonicity core OPEN.",
+    "progressSummary": "PROGRESS (researcher-1-9, 2026-07-22, host-verified): f(9) blocker OVERTURNED — complete elementary blueprint for f(9)=3 recorded in knowledge.md (degree pinch to (3^8,4)/(3^6,4^3); pigeonhole + path-count kills k=3; paw analysis kills k=1) and the counting engine formalized 0-axiom (containsC4_of_degree_sum_subset + global form). Exact table 1..8 = 1,2,3,2,3,3,3,3 unchanged; f(9)=3 formalization is next (est. 300-450 lines, 3 independent steps). f(10)=4 (Petersen), dense families, monotonicity core: unchanged, deep.",
     "builtItems": [
       "C4_adj_zero_one/one_two/two_three/three_zero (four cycle edges) in Erdos85Problem.lean",
       "C4_not_adj_zero_two (diagonal non-edge) in Erdos85Problem.lean",
@@ -84,7 +89,9 @@
       "triangle_pair_unique (at degree 3 the triangle through a vertex is unique) in Erdos85Problem.lean",
       "containsC4_of_three_regular_eight (no 3-regular C4-free graph on 8 vertices: triangle partition, 3∤8) in Erdos85Problem.lean",
       "containsC4_of_eight_min_degree_three (min-deg 3 on Fin 8 forces C4: cherry-count + parity casework down to 3-regular) in Erdos85Problem.lean",
-      "minDegreeForC4_eight (f(8)=3, FIFTH exact value; table complete 1..8) in Erdos85Problem.lean — all 0-axiom, host-verified lake env lean exit 0"
+      "minDegreeForC4_eight (f(8)=3, FIFTH exact value; table complete 1..8) in Erdos85Problem.lean — all 0-axiom, host-verified lake env lean exit 0",
+      "containsC4_of_degree_sum_subset in Erdos85Problem.lean (pigeonhole C4 engine, subset form)",
+      "containsC4_of_card_add_two_le_degree_add_degree in Erdos85Problem.lean (global form)"
     ],
     "insights": [
       "Erdos85Problem.lean was a definitions-only stub (7 defs, 0 theorems). Asymptotics f(n)=(1+o(1))sqrt(n), f(4)=2, and the Ramsey reformulation need extremal graph theory beyond Mathlib; tractable axiom-free content is structural facts about C4, containsC4, and starGraph.",
@@ -109,7 +116,10 @@
       "Parity boost: odd |V| + odd k + min-deg >= k forces a vertex of degree >= k+1 (degree sum |V|*k odd contradicts handshake sum deg = 2|E|). This upgrades the KST cherry count exactly where it ties.",
       "At n = s^2+s+1 with s = 2m even, n-1 = k(k-1) EXACTLY for k = s+1, so the parity-refined count wins by the margin C(k+1,2)-C(k,2) = k; this is the unique j for which the parity argument works in the upper Beatty half (j >= 2 provably out of reach).",
       "The f(7) blocker 'needs ex(7;C4)' was refuted: 21 = C(7,2) < 24 = 6*C(3,2)+C(4,2). Plain count ties at 21=21; handshake parity breaks the tie.",
-      "omega rejects nonlinear atoms like card V * k: rewrite the Odd product away first (obtain <a, ha> := hodd.mul hk; rw [ha] at hhs) before calling omega."
+      "omega rejects nonlinear atoms like card V * k: rewrite the Odd product away first (obtain <a, ha> := hodd.mul hk; rw [ha] at hhs) before calling omega.",
+      "f(9) blocker overturned (third extremal-tables blocker to fall): complete elementary route to f(9)=3 mapped — cherry+parity pinch degrees to (3^8,4) or (3^6,4^3); pigeonhole kills (3^6,4^3) (deg-4 vertices have all-deg-3 neighbourhoods by exact path count, then 4+4=6+2); paw analysis kills (3^8,4) locally",
+      "Friendship theorem NOT needed for the tight-cherry case (and is unavailable anyway: Mathlib ships it only in Archive/Wiedijk100Theorems, no olean in the shared cache)",
+      "Pigeonhole C4 engine formalized: containsC4_of_degree_sum_subset (N(u),N(v) inside S with |S|+2 <= d(u)+d(v) forces C4) + global |V|+2 form — reusable for all future exact values"
     ],
     "mathlibGaps": [
       "Fin n has NO global CommRing instance (only scoped Fin.instCommRing via `open Fin.CommRing`, gated on NeZero n); needed for ring/linear_combination on cycleGraph differences"


### PR DESCRIPTION
## Summary
Research session for erdos-85-wip-01 (minimum degree forcing a C₄; exact values of f(n)).

## Progress
- 2 new axiom-free theorems in `proofs/Proofs/Erdos85Problem.lean` (+ blueprint section)
- Host-verified: `lake env lean` exit 0; `#print axioms` = `[propext, Classical.choice, Quot.sound]` on both; 0 sorry / 0 axiom
- Knowledge/tracker updated, including a structured update to the f(9) blocker

## Findings
The registered blocker claimed f(9) "needs ex(9;C₄)-strength input". That is wrong — the third "needs extremal tables" blocker on this problem to fall. A complete elementary route to **f(9) = 3** is now mapped:

1. **Degree pinch**: cherry count ≤ C(9,2) = 36 plus handshake parity forces the degree sequence of a hypothetical δ≥3 C₄-free graph on 9 vertices to be (3⁸,4) or (3⁶,4³).
2. **(3⁶,4³)**: the cherry count is then *exactly* 36, so every pair has exactly one common neighbour; a path-count out of each vertex forces the three degree-4 vertices to have all-degree-3 neighbourhoods, hence pairwise non-adjacent with neighbourhoods inside the six degree-3 vertices — and 4+4 = 6+2 fires the new pigeonhole engine → C₄.
3. **(3⁸,4)**: locally at the degree-4 vertex, the four outside vertices each see ≤ 1 of its neighbours, forcing their induced subgraph to be the paw (unique C₄-free 4-vertex graph with 4 edges), whose pendant has degree ≤ 2 < 3.

**Formalized this session** (the counting engine, reusable for all future exact values):
- `containsC4_of_degree_sum_subset` — if N(u), N(v) ⊆ S with |S| + 2 ≤ d(u) + d(v), then G contains a C₄
- `containsC4_of_card_add_two_le_degree_add_degree` — global form with S = univ

Note: the friendship theorem would also kill case 2 but is unavailable (Mathlib ships it only in `Archive/`, no olean); the route above avoids it.

Honest status: **f(9) = 3 is NOT yet formalized** — this session delivers the engine plus the complete blueprint (est. 300–450 lines across 3 independent steps, recorded in knowledge.md).

## Ops note
Two worktree reaps hit this agent today, the second deleting a *dirty* worktree mid-session (work redone from context). The janitor appears to violate the "dirty/unpushed worktrees are always preserved" contract — operator attention suggested.

## Status
**Outcome**: progress
**Next Steps**: formalize blueprint steps (a) degree pinch, (b) exact path-count, (c) paw analysis — independent, (c) likely easiest first.

🤖 Generated by researcher-1