### PR TITLE
audit: re-serve erdos-1022 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8998,9 +8998,9 @@
       "issues": []
     },
     "erdos-1022": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:26Z",
+      "lastAudited": "2026-07-22T22:24:19Z",
       "result": "clean"
     },
     "erdos-1022-oq-01": {


### PR DESCRIPTION
## Summary
- Reserve-mode re-audit of erdos-1022 (Property B / sparse set families, axiomatized/axiom, OPEN problem).
- Verified exact count match against source: 1 axiom, 0 sorries, 28 theorems, 7 defs.
- No True stubs, no native_decide. Sole axiom `erdos_1022_conjecture` correctly encodes the open conjecture (proper `c_t → ∞` quantification), not a junk/vacuous instantiation.
- File documents an honest self-correction: a previously-false `lovász_theorem` axiom was removed, with a K₃ counterexample recorded in a comment.
- Every declaration name referenced in `sections[]`/`proofStrategy` verified to exist in the actual Lean source (no phantom decls).
- Result: **clean**. Tracker updated (`auditCount` 4→5, `lastAudited` refreshed).

## Test plan
- [x] `grep`-verified axiom/theorem/def counts against `proofs/Proofs/Erdos1022Problem.lean`
- [x] Confirmed no sorries, no True stubs, no native_decide
- [x] Cross-checked every named declaration in gallery prose against source