### PR TITLE
Research: erdos-510-wip-01 - union superadditivity + Sidon-route assessment

### DIFF
--- a/proofs/Proofs/Erdos510WIP01.lean
+++ b/proofs/Proofs/Erdos510WIP01.lean
@@ -513,4 +513,35 @@ theorem minCosineSum_dilate {d : ℕ} (hd : d ≠ 0) :
       = sInf (Set.range (cosineSum A))
   rw [hrange]
 
+/-! ## Superadditivity of the minimum under disjoint union
+
+Splitting the frequency set splits the cosine sum pointwise, so the minimum of a
+disjoint union is at least the sum of the minima: the negativity `m(A) := −min`
+is *subadditive*, `m(A ∪ B) ≤ m(A) + m(B)`.  With `minCosineSum_le_neg_half`
+this brackets the union: `min A + min B ≤ min (A ∪ B) ≤ −1/2`.  It also shows
+the trivial floor `−N` (attained exactly by all-odd sets,
+`minCosineSum_forall_odd`) is the worst case of the union bound over
+singletons (`minCosineSum_singleton = −1`). -/
+
+/-- **Disjoint frequency sets add pointwise**: `cosineSum (A ∪ B) = cosineSum A
++ cosineSum B` when `Disjoint A B` (`Finset.sum_union`). -/
+theorem cosineSum_union {A B : Finset ℕ} (hAB : Disjoint A B) (θ : ℝ) :
+    cosineSum (A ∪ B) θ = cosineSum A θ + cosineSum B θ := by
+  unfold cosineSum
+  exact Finset.sum_union hAB
+
+/-- **The Chowla minimum is superadditive on disjoint unions**:
+`minCosineSum A + minCosineSum B ≤ minCosineSum (A ∪ B)`.  Pointwise each
+summand is at least its own minimum; take the infimum.  Equivalently the
+negativity `m = −min` is subadditive — the elementary "union bound" backbone
+against which the conjectured `−c√N` (sublinear!) uniform bound is measured. -/
+theorem add_minCosineSum_le_minCosineSum_union {A B : Finset ℕ}
+    (hAB : Disjoint A B) :
+    minCosineSum A + minCosineSum B ≤ minCosineSum (A ∪ B) := by
+  unfold minCosineSum
+  apply le_csInf (Set.range_nonempty _)
+  rintro y ⟨θ, rfl⟩
+  rw [cosineSum_union hAB θ]
+  exact add_le_add (minCosineSum_le A θ) (minCosineSum_le B θ)
+
 end Erdos510WIP01

--- a/research/problems/erdos-510-wip-01/knowledge.md
+++ b/research/problems/erdos-510-wip-01/knowledge.md
@@ -94,3 +94,39 @@ pointwise lower bound, integrating the constant gives `2π·minCosineSum A ≤ 0
 ### Next
 - Strict `minCosineSum A < 0` for nonempty positive-frequency `A`.
 - Sharp `−c√N` bound (Chowla; Bourgain/Ruzsa/Bedert) stays a deep imported result.
+
+## Session 2026-07-22 (researcher-1-9) — union superadditivity + candidate-target assessment
+
+**Mode**: build on saturated elementary layer. **Outcome**: small progress — 2 axiom-free
+theorems (host-verified `lake env lean` exit 0, standard triple), plus a scoping
+assessment of the remaining elementary targets.
+
+### Added (Erdos510WIP01.lean)
+- `cosineSum_union` — disjoint frequency sets add pointwise (`Finset.sum_union`).
+- `add_minCosineSum_le_minCosineSum_union` — **superadditivity**: `min A + min B ≤
+  min (A ∪ B)` for disjoint A, B; i.e. the negativity m = −min is subadditive.
+  The elementary union-bound backbone: −N floor = union of singletons (each −1),
+  against which the conjectured sublinear −c√N is measured.
+
+### Candidate-target assessment (why nothing bigger this session)
+- **Interval family {1..N}**: computed min ~ −(2N+1)/(3π) − 1/2 (θ = 3π/(2N+1) via
+  the telescoped Dirichlet identity 2sin(θ/2)Σcos(nθ) = sin((N+½)θ) − sin(θ/2)).
+  Linear negativity — but SUBSUMED: all-odd sets already attain the exact floor −N
+  (`minCosineSum_forall_odd`), so an interval example adds no strength. REJECTED.
+- **Sidon √N-optimality** (min ≥ −C√N for Sidon A, showing conjectured floor tight):
+  needs ∫f⁴ = π·(count of ±a±b±c±d = 0 solutions) via 4-fold product-to-sum, then
+  Hölder ∫f² ≤ (∫f⁴)^{1/3}(∫|f|)^{2/3} → ∫|f| ≥ c√N → |min| ≥ c√N... WAIT that
+  direction gives min ≤ −c√N for Sidon (a LOWER bound on negativity for a special
+  class — the interesting direction!). Route: Sidon ⇒ ∫f⁴ ≤ CπN² ⇒ (πN)³ ≤
+  (∫f⁴)(∫|f|)² ⇒ ∫|f| ≥ c√N·π ⇒ ∫f_− = ∫|f|/2 (since ∫f = 0) ⇒
+  2π|min| ≥ ∫f_− ⇒ min ≤ −c√N. **This is the strongest feasible elementary
+  target**: proves the CONJECTURED −c√N bound for the Sidon class. Est. 2 sessions:
+  (1) 4-fold product-to-sum + ∫f⁴ orthogonality count under B₂[1]; (2) Hölder
+  (Mathlib `inner_mul_le_norm_mul_norm`/`MeasureTheory.integral` Hölder exists as
+  `MeasureTheory.integral_mul_le_Lp_mul_Lq`-style) + negative-part bookkeeping.
+  Distinct from the blocked route (which demanded −c√N for ALL A).
+- **Uniform −1/2 → −1**: L² method is tight at −1/2 (kept terms saturate); −1
+  would need a new mechanism; singleton shows −1 would be sharp. Not attempted.
+
+### Next
+Sidon-class −c√N (2-session plan above) is the recommended BUILD target.

--- a/src/data/research/problems/erdos-510-wip-01.json
+++ b/src/data/research/problems/erdos-510-wip-01.json
@@ -48,7 +48,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "minCosineSum A ≤ 0 (integral avg) and strict <0 for nonempty positive-frequency A were established; NOW upgraded to a UNIFORM QUANTITATIVE constant minCosineSum A ≤ −1/2 (minCosineSum_le_neg_half) via a second-moment/L² argument: first moment ∫cosineSum=0, second moment ∫(cosineSum)²=π·N (integral_cosineSum_sq, from orthogonality integral_cos_mul_cos), and the sandwich m≤f≤N. Axiom-free. This is a materially new mechanism distinct from the still-open/blocked −c√N growth route (which needs Bourgain/Ruzsa/Bedert). Remaining: the sharp −c√N lower bound and the Sidon √N-optimality example.",
+    "progressSummary": "PROGRESS (researcher-1-9, 2026-07-22, host-verified): union superadditivity added (min A + min B <= min(A cup B), disjoint) — negativity subadditive, -N floor = singleton union bound. Elementary layer otherwise saturated (<=-1/2 uniform via L2; all-odd -N sharp; dilation invariance). Assessment recorded: Sidon-class -c*sqrt(N) via int f^4 + Holder is the recommended next BUILD (2-session plan in knowledge.md); interval example subsumed; -1/2 -> -1 needs new mechanism. Deep all-A -c*sqrt(N) (Bourgain/Bedert) unchanged.",
     "builtItems": [
       "cosineSum_empty / cosineSum_singleton / cosineSum_insert in Erdos510WIP01.lean",
       "cosineSum_zero_angle (cosineSum A 0 = N), cosineSum_pi (= ∑(−1)ⁿ)",
@@ -65,7 +65,9 @@
       "integral_cos_mul_cos (Erdos510WIP01.lean): orthogonality ∫cos(nθ)cos(mθ)=π·[n=m]",
       "integral_cosineSum_sq (Erdos510WIP01.lean): second moment ∫(cosineSum A)²=π·|A|",
       "minCosineSum_le_neg_half (Erdos510WIP01.lean): minCosineSum A ≤ −1/2, all axiom-free",
-      "minCosineSum_le_alternating + minCosineSum_forall_odd in Erdos510WIP01.lean, 0-axiom host-verified v4.31"
+      "minCosineSum_le_alternating + minCosineSum_forall_odd in Erdos510WIP01.lean, 0-axiom host-verified v4.31",
+      "cosineSum_union in Erdos510WIP01.lean (disjoint pointwise additivity)",
+      "add_minCosineSum_le_minCosineSum_union in Erdos510WIP01.lean (superadditivity of the Chowla minimum)"
     ],
     "insights": [
       "The trivial range of the cosine sum is [−N, N]; the conjectured extremal value −c√N sits strictly inside, so all elementary bounds are far from the truth — the content is entirely in the cancellation.",
@@ -77,7 +79,10 @@
       "Second-moment/L² averaging gives a UNIFORM QUANTITATIVE bound minCosineSum A ≤ −1/2 for every nonempty positive-frequency A (minCosineSum_le_neg_half). Mechanism: first moment ∫₀^{2π}cosineSum=0 and second moment ∫₀^{2π}(cosineSum)²=π·N (integral_cosineSum_sq), plus the pointwise sandwich m≤f≤N, give ∫(f−m)(N−f)≥0 ⟹ −πN−2πmN≥0 ⟹ m≤−1/2. A fixed constant, materially DISTINCT from the still-open −c√N growth route.",
       "Orthogonality of cosine characters over a full period proved from scratch (integral_cos_mul_cos): ∫₀^{2π}cos(nθ)cos(mθ)=π·[n=m] for n,m≥1, via product-to-sum cos(nθ)cos(mθ)=½(cos((n+m)θ)+cos((n−m)θ)) and the ℤ-frequency period-integral vanishing integral_cos_int_mul_eq_zero.",
       "Lean gotchas hit: (1) integral_congr+integral_div on a big integrand triggers a whnf timeout — rewrite the integrand as a funext function-equality then split with integral_add/integral_const_mul instead; (2) applying integral_cos_int_mul_eq_zero _ with a metavar k plus sub_ne_zero.mpr loops isDefEq — pin k=(n:ℤ)−(m:ℤ) explicitly; (3) (((n:ℤ)−(m:ℤ)):ℝ) elaborates to ↑↑n−↑↑m (difference of casts) not ↑(↑n−↑m) — normalize with Int.cast_sub/Int.cast_natCast.",
-      "minCosineSum_forall_odd: all-odd frequency sets attain the extreme Chowla minimum minCosineSum A = −A.card (sharp; cos(nπ)=−1 for odd n meets neg_card lower bound). Plus minCosineSum_le_alternating: minCosineSum A ≤ ∑(−1)ⁿ = #even−#odd."
+      "minCosineSum_forall_odd: all-odd frequency sets attain the extreme Chowla minimum minCosineSum A = −A.card (sharp; cos(nπ)=−1 for odd n meets neg_card lower bound). Plus minCosineSum_le_alternating: minCosineSum A ≤ ∑(−1)ⁿ = #even−#odd.",
+      "Union superadditivity proved: min A + min B <= min(A cup B) for disjoint A,B — negativity is subadditive; the -N floor is exactly the union bound over singletons",
+      "Interval family rejected as example: its ~-0.2N negativity is subsumed by the sharp all-odd -N attainment already on file",
+      "Sidon-class -c*sqrt(N) is the strongest feasible elementary target (proves the conjectured bound for the Sidon class, distinct from the blocked all-A route): via int f^4 <= C*N^2 (4-fold product-to-sum orthogonality) + Holder (pi*N)^3 <= (int f^4)(int |f|)^2 + int f = 0 splitting; est. 2 sessions"
     ],
     "mathlibGaps": [
       "No direct reduction of an ℝ-infimum of a periodic continuous function to a min over a fundamental period; needs a toIcoMod-style mod-2π reduction to formalize attainment."


### PR DESCRIPTION
## Summary
Research session for erdos-510-wip-01 (Chowla cosine problem).

## Progress
- 2 new axiom-free theorems in `proofs/Proofs/Erdos510WIP01.lean` (516 → 553 lines); host-verified `lake env lean` exit 0, `#print axioms` = standard triple
- Scoping assessment of remaining elementary targets recorded in knowledge.md

## Findings
- `cosineSum_union` + `add_minCosineSum_le_minCosineSum_union`: the Chowla minimum is **superadditive** on disjoint unions (equivalently, the negativity m = −min is subadditive). This is the elementary union-bound backbone: the −N floor (attained sharply by all-odd sets, already on file) is exactly the union bound over singletons, and the conjectured −c√N says the truth is dramatically sublinear.
- **Assessment** (why nothing bigger this session): the interval family's ~−0.2N negativity is subsumed by the sharp all-odd −N result; sharpening the uniform −1/2 needs a new mechanism (the L² method is tight); the strongest feasible elementary target is **the Sidon-class −c√N bound** (proving the conjectured bound for Sidon sets, distinct from the blocked all-A route) via ∫f⁴ orthogonality counting + Hölder — a concrete 2-session plan is recorded in knowledge.md.

Honesty note: this session's formalized content is a small structural lemma; the main contribution is the vetted plan for the Sidon route.

## Status
**Outcome**: progress (minor) + surveyed
**Next Steps**: Sidon-class −c√N per the 2-session plan (4-fold product-to-sum + ∫f⁴ count, then Hölder + negative-part bookkeeping).

🤖 Generated by researcher-1