### PR TITLE
Enrich chebyshev-pnt-bridge-oq-02: cover header docstring

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-02/meta.json
@@ -69,6 +69,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Header: Explicit Real-Valued PNT Bounds from Chebyshev Power Bound",
+      "startLine": 1,
+      "endLine": 58,
+      "summary": "States the lower bound n·log(4) − log(2n+1) ≤ π(2n)·log(2n) derived from the Chebyshev integer power bound, together with the previously-established upper bound, giving explicit constants log(2) and 2·log(4) sandwiching π(x)·log(x)/x — Chebyshev's 1852 result establishing π(x) = Θ(x/log x).",
+      "mathContext": "$n\\log 4 - \\log(2n+1) \\le \\pi(2n)\\log(2n)$ combined with the upper bound $\\pi(N) \\le 2N\\log 4/\\log N + \\sqrt N + 1$ gives $\\log 2 \\le \\liminf \\pi(2n)\\log(2n)/n \\le \\limsup \\pi(n)\\log(n)/n \\le 2\\log 4$."
+    },
+    {
       "id": "lower-log",
       "title": "Lower Bound (Log Form)",
       "startLine": 59,


### PR DESCRIPTION
Adds a `header` section (lines 1-58) covering the module docstring for "Explicit Real-Valued PNT Bounds from Chebyshev Power Bound", which was previously uncovered by any section or annotation. Summary and mathContext are drawn directly from the file's own docstring — no invented content.