### PR TITLE
Enrich chinese-remainder-constructive-oq-03: cover header docstring

### DIFF
--- a/src/data/proofs/chinese-remainder-constructive-oq-03/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-03/meta.json
@@ -38,6 +38,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Header: Efficient RNS Bases for Computer Arithmetic",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Poses the open question of the most efficient Residue Number System (RNS) bases under dynamic range, channel width, coprimality, and hardware-friendly moduli, and states that consecutive primes maximize the dynamic range M = ∏mᵢ for a fixed maximum modulus.",
+      "mathContext": "For pairwise coprime moduli $m_1,\\dots,m_k$, CRT gives a bijection $[0,M)\\cong\\prod \\mathbb Z/m_i$ where $M=\\prod m_i$; efficiency trades off dynamic range $M$ against channel width $\\max m_i$."
+    },
+    {
       "id": "rns-definitions",
       "title": "RNS Base Definitions and Bounds",
       "startLine": 38,


### PR DESCRIPTION
Adds a `header` section (lines 1-37) covering the module docstring for "Efficient RNS Bases for Computer Arithmetic", which was previously uncovered by any section or annotation. Summary and mathContext are drawn directly from the file's own docstring — no invented content.