### PR TITLE
Enrich chinese-remainder-non-coprime-oq-04: cover header docstring

### DIFF
--- a/src/data/proofs/chinese-remainder-non-coprime-oq-04/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-04/meta.json
@@ -87,6 +87,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Header: Dirichlet's Approximation Theorem and CRT Lattice Connections",
+      "startLine": 1,
+      "endLine": 26,
+      "summary": "Answers the open question on implications for simultaneous Diophantine approximation by formalizing Dirichlet's 1842 approximation theorem via pigeonhole, plus the Stern–Brocot mediant theorem, a lattice-point covering lemma, golden-ratio identities, and non-coprime CRT solvability examples connecting to lattice geometry.",
+      "mathContext": "Dirichlet's theorem: $\\forall \\alpha\\in\\mathbb R, N\\ge 1,\\ \\exists\\, p,q$ with $1\\le q\\le N$ and $|q\\alpha-p|<1/N$, proved by pigeonholing $N+1$ fractional parts $\\{q\\alpha\\}$ into $N$ intervals of width $1/N$."
+    },
+    {
       "id": "pigeonhole-setup",
       "title": "Pigeonhole Setup for Fractional Part Binning",
       "startLine": 27,


### PR DESCRIPTION
Adds a `header` section (lines 1-26) covering the module docstring for "Dirichlet's Approximation Theorem and CRT Lattice Connections", which was previously uncovered by any section or annotation. Summary and mathContext are drawn directly from the file's own docstring — no invented content.