### PR TITLE
Enrich circumference-via-differentiation: cover header docstring

### DIFF
--- a/src/data/proofs/circumference-via-differentiation/meta.json
+++ b/src/data/proofs/circumference-via-differentiation/meta.json
@@ -38,6 +38,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Header: Circumference Formula via Differentiation of Area",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Derives the circumference C(r) = 2πr of a circle by differentiating its area A(r) = πr², formalizing the geometric fact that an infinitesimal growth dr of a disk adds an annular strip of area C(r)·dr, generalizing to the surface-area/volume relation for n-balls.",
+      "mathContext": "$A(r)=\\pi r^2 \\Rightarrow C(r) = dA/dr = 2\\pi r$, proved via Mathlib calculus (`Analysis.Calculus.Deriv.Polynomial`) and connected to the measure-theoretic disk volume via `ENNReal.toReal`."
+    },
+    {
       "id": "definitions",
       "title": "Area and Circumference Definitions",
       "startLine": 38,


### PR DESCRIPTION
Adds a `header` section (lines 1-37) covering the module docstring for "Circumference Formula via Differentiation of Area", which was previously uncovered by any section or annotation. Summary and mathContext are drawn directly from the file's own docstring — no invented content.