### PR TITLE
Enrich cube-root-3-irrational-oq-01-oq-02: cover header docstring

### DIFF
--- a/src/data/proofs/cube-root-3-irrational-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-01-oq-02/meta.json
@@ -60,6 +60,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Header: The Explicit ℚ-Basis {1, ∛3, ∛9} of ℚ(∛3)",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Answers OQ-02 by exhibiting an explicit ordered ℚ-basis of ℚ(∛3), using Mathlib's adjoin.powerBasis together with the companion file's degree-3 result to upgrade the power basis 1, ∛3, (∛3)² into a basis with explicit coordinates, identifying (∛3)² = ∛9.",
+      "mathContext": "$[\\mathbb Q(\\sqrt[3]3):\\mathbb Q]=3$ gives the power basis $\\{1,\\sqrt[3]3,\\sqrt[3]{3}^2\\}$; every $x\\in\\mathbb Q(\\sqrt[3]3)$ is uniquely $a+b\\sqrt[3]3+c\\sqrt[3]9$ since $\\sqrt[3]{3}^2=3^{2/3}=9^{1/3}=\\sqrt[3]9$."
+    },
+    {
       "id": "sec-setup",
       "title": "Setup: ∛3, ∛9, Integrality, and Degree",
       "startLine": 38,


### PR DESCRIPTION
Adds a `header` section (lines 1-37) covering the module docstring for "The Explicit Q-Basis of Q(cbrt3)", which was previously uncovered by any section or annotation. Summary and mathContext are drawn directly from the file's own docstring — no invented content.