### PR TITLE
Enrich cube-root-3-irrational-oq-02-oq-01: cover header docstring

### DIFF
--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-01/meta.json
@@ -89,6 +89,14 @@
   ],
   "sections": [
     {
+      "id": "header",
+      "title": "Header: [ℚ(∛3):ℚ] = 3 as Corollary of Eisenstein Approach",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Answers OQ-01 by deriving the degree-3 field extension [ℚ(∛3):ℚ] = 3 as a one-line specialization (n=3, m=3, p=3) of the general adjoin_nthRoot_finrank theorem, strengthening mere irrationality of ∛3 to the stronger fact that no quadratic rational relation holds.",
+      "mathContext": "Specializing $\\mathrm{Module.finrank}\\ \\mathbb Q\\ \\mathbb Q\\langle m^{1/n}\\rangle = n$ at $n=3,m=3,p=3$ (since $3\\mid 3$, $9\\nmid 3$) gives $[\\mathbb Q(\\sqrt[3]3):\\mathbb Q]=3$, hence $\\mathrm{minpoly}$ has degree 3."
+    },
+    {
       "id": "sec-setup",
       "title": "Setup: Imports and Namespace",
       "startLine": 40,


### PR DESCRIPTION
Adds a `header` section (lines 1-39) covering the module docstring for "[Q(cbrt3):Q] = 3 as Corollary of Eisenstein Approach", which was previously uncovered by any section or annotation. Summary and mathContext are drawn directly from the file's own docstring — no invented content.