### PR TITLE
Enrich derangements-oq-03-oq-02: cover header docstring

### DIFF
--- a/src/data/proofs/derangements-oq-03-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-03-oq-02/meta.json
@@ -60,6 +60,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Header: Poisson(1) Approximation in Total Variation",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Proves the number of fixed points of a uniformly random permutation converges in total variation distance to the Poisson(1) distribution, bounding the pointwise error via the derangement alternating-series bound and summing a binomial-coefficient tail that vanishes as 2^(n+1)/(n+1)! → 0.",
+      "mathContext": "$X_n=\\#\\{i:\\sigma(i)=i\\}$ for uniform $\\sigma\\in S_n$ satisfies $P(X_n=k)=D(n-k)/((n-k)!k!)$; $\\sum_k |P(X_n=k)-e^{-1}/k!|\\to 0$."
+    },
+    {
       "id": "alt-series-bound",
       "title": "Section I: Alternating Series Bound for Derangements",
       "startLine": 40,


### PR DESCRIPTION
Adds a `header` section (lines 1-39) covering the module docstring for "Poisson(1) Approximation in Total Variation", which was previously uncovered by any section or annotation. Summary and mathContext are drawn directly from the file's own docstring — no invented content.