### PR TITLE
audit: re-serve erdos-1020 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8962,9 +8962,9 @@
       "result": "clean"
     },
     "erdos-1020": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:26Z",
+      "lastAudited": "2026-07-22T22:26:59Z",
       "result": "clean"
     },
     "erdos-1020-oq-02": {


### PR DESCRIPTION
## Summary
Reserve-mode re-audit of erdos-1020 (Erdős Matching Conjecture). Verified against `proofs/Proofs/Erdos1020Problem.lean`:

- 6 axioms, all named and attributed in `assumptions` (Erdős-Gallai r=2, Łuczak-Mieczkowska r=3, Huang-Loh-Sudakov large-n, Frankl upper bound, 2 construction lower bounds) — matches file exactly
- 0 sorries, 0 True-stubs, no `native_decide`
- 4 theorems, 12 definitions (11 `def` + 1 `structure`) — matches meta.json
- `status: "axiomatized"`, `badge: "axiom"` — correct per Tier C
- Open-for-r≥4 status stated honestly in conclusion/openQuestions; no overclaiming language found

No issues found — tracker updated to reflect re-audit.

## Test plan
- [x] Diffed axiom/theorem/def counts against source file
- [x] Checked meta.json prose for forbidden overclaiming phrases (none found)