### PR TITLE
audit: re-serve erdos-1021 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8974,9 +8974,9 @@
       "issues": []
     },
     "erdos-1021": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:26Z",
+      "lastAudited": "2026-07-22T22:30:02Z",
       "result": "clean"
     },
     "erdos-1021-oq-01": {


### PR DESCRIPTION
## Reserve-mode re-audit

**Proof**: erdos-1021 (Extremal Numbers for Bipartite Pair Graphs)
**Result**: clean

Verified against `proofs/Proofs/Erdos1021Problem.lean` and its companion
`Erdos1021Aristotle.lean`:

- Sorries: meta claims 2, file has exactly 2 (`k3_case_solved`, `trivial_bound`) — match
- Axioms: meta claims 0, none found in main file or Aristotle companion — match
- theoremCount 5 / definitionCount 17 — match exact grep counts
- No True stubs, no native_decide
- Badge `wip` / status `formalized` (not `verified`) correctly reflects the 2 open sorries
- `strong_implies_weak` is a real, sorry-free proof using genuine lemmas from the Aristotle companion (no phantom-chain pattern)

No changes needed beyond the tracker timestamp.