### PR TITLE
audit: re-serve erdos-1019 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8951,8 +8951,8 @@
     },
     "erdos-1019": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:03:26Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-22T22:33:29Z",
       "result": "clean"
     },
     "erdos-102": {


### PR DESCRIPTION
## Summary
- Reserve-mode re-audit (unaudited queue is drained, round-robin re-serving oldest).
- erdos-1019 (Saturated Planar Subgraphs, Simonovits dichotomy): meta.json claims verified exactly against `Proofs/Erdos1019Problem.lean` — 3 axioms, 0 sorries, 13 theorem/lemma decls (private included), 25 def/structure decls, 486 lines all match.
- The single `native_decide` use (in `K3_saturated_planar`) is traced through the call graph and confirmed unreachable from `erdos_1019_solved` — the assumptions text's disclosure and axiom footprint are accurate.
- Companion `Erdos1019Aristotle.lean` has sorries but is a non-primary scratch file not rendered as a public claim.

No issues found; audit-tracker.json updated (auditCount 4→5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)