### PR TITLE
audit: fix erdos-1060 stale meta.axiomCount (1→0)

### DIFF
--- a/src/data/proofs/erdos-1060/meta.json
+++ b/src/data/proofs/erdos-1060/meta.json
@@ -61,7 +61,7 @@
       "solution_le_sqrt theorem: solutions satisfy k ≤ √n",
       "f_le_sqrt theorem: f(n) ≤ √n — proved upper bound"
     ],
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 387,
     "assumptions": "No mathematical axioms and 0 sorries. σ function properties, g(k)=k·σ(k) infrastructure, and f(n) ≤ √n bound fully proved. Open conjectures not formalized as axioms; badge updated from 'axiom' to 'wip'. Compiler-trust disclosure: the concrete computations (sigma_one, f_of_one, mem_A327153_iff) are discharged with native_decide, so their axiom footprint includes Lean.ofReduceBool (kernel reduction trusts the compiled decision procedure); these are finite decidable computations and add no mathematical assumption, and leanFile.axiomCount remains 0 (no literal axiom declarations).",
     "theoremCount": 19,


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-1060 (Counting Solutions to k·σ(k) = n)
**Problem**: `meta.axiomCount` claimed 1 axiom while `leanFile.axiomCount` claimed 0, and the actual Lean source has zero `axiom` declarations.

## Evidence

**meta.json claims**: `meta.axiomCount: 1` (top-level block)
**leanFile block claims**: `leanFile.axiomCount: 0` — matches actual file
**Lean file shows**: no `axiom` keyword anywhere in `proofs/Proofs/Erdos1060Problem.lean`; the two open conjectures (weak/strong bounds) are plain block comments, not axiomatized
**No Stubs/ companion**: unlike erdos-611's legitimate chain-sum pattern, there's no `Stubs/Erdos1060Problem.lean` to explain a 5+5-style double count
**Self-contradicting**: the entry's own `assumptions` prose already states "No mathematical axioms" and "leanFile.axiomCount remains 0 (no literal axiom declarations)"

## Fix

Changed `meta.axiomCount` from `1` to `0` to match reality and the entry's own disclosure text.

## Audit Summary

Rest of the entry verified clean: theoremCount 19 = exact grep count, definitionCount 6 = exact grep count, sorries 0 = confirmed, native_decide usage (sigma_one, f_of_one, 5 examples) properly disclosed in assumptions, status `axiomatized`/badge `wip` is the established convention for honestly-documented open problems with 0 real axioms (cf. erdos-358 and 194 similar entries), no phantom decls in originalContributions, no overclaiming language — description explicitly states "This problem remains OPEN."

---
Discovered during gallery integrity audit (reserve-mode re-serve).
🤖 Generated with [Claude Code](https://claude.com/claude-code)