### PR TITLE
audit: record erdos-1060 audit completion (issues-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9539,10 +9539,10 @@
       "result": "clean"
     },
     "erdos-1060": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:27Z",
-      "result": "clean"
+      "lastAudited": "2026-07-22T22:39:11Z",
+      "result": "issues-fixed"
     },
     "erdos-1061": {
       "auditCount": 4,


### PR DESCRIPTION
Tracker update for erdos-1060 audit (reserve-mode re-serve). Result: issues-fixed — stale meta.axiomCount corrected 1→0 in #41996.

🤖 Generated with [Claude Code](https://claude.com/claude-code)