### PR TITLE
audit(erdos-1058): fix axiom-masking annotations + stale axiomatized prose

### DIFF
--- a/src/data/proofs/erdos-1058/annotations.json
+++ b/src/data/proofs/erdos-1058/annotations.json
@@ -31,9 +31,9 @@
     },
     "type": "definition",
     "title": "Prime Sequence",
-    "content": "**prime_seq n:** The n-th prime number (p₁=2, p₂=3, p₃=5, ...).\n\nAxiomatized with basic properties: strictly increasing and each value is prime. The first five values are specified explicitly for verification.",
+    "content": "**prime_seq n:** The n-th prime number (p₁=2, p₂=3, p₃=5, ...), defined via `Nat.nth Nat.Prime`.\n\nNot an axiom: strictly increasing and primality are proved from Mathlib's `Nat.nth` API. The first five values are proved explicitly for verification.",
     "significance": "key",
-    "mathContext": "$p_n$ denotes the $n$-th prime: $p_1 = 2, p_2 = 3, p_3 = 5, p_4 = 7, p_5 = 11, \\ldots$ Axiomatized as a strictly increasing function with $\\text{Nat.Prime}(p_n)$ for all $n \\ge 1$.",
+    "mathContext": "$p_n$ denotes the $n$-th prime: $p_1 = 2, p_2 = 3, p_3 = 5, p_4 = 7, p_5 = 11, \\ldots$ Defined via `Nat.nth Nat.Prime` (not axiomatized); strict monotonicity and $\\text{Nat.Prime}(p_n)$ for all $n \\ge 1$ are proved.",
     "relatedConcepts": [
       "Prime enumeration",
       "Consecutive primes",
@@ -97,8 +97,8 @@
       "endLine": 102
     },
     "type": "concept",
-    "title": "Erdős-Stewart Conjecture (Proved)",
-    "content": "**erdos_stewart_conjecture:** There are only finitely many n satisfying the condition.\n\n**erdos_stewart_conjecture_true:** Luca proved this in 2001.\n\nAppears as Problem A2 in Guy's 'Unsolved Problems in Number Theory'.",
+    "title": "Erdős-Stewart Conjecture (Axiomatized)",
+    "content": "**erdos_stewart_conjecture:** There are only finitely many n satisfying the condition.\n\n**erdos_stewart_conjecture_true:** an `axiom` in this file, asserting Luca's 2001 result. Luca's own proof is not formalized in Lean; we assume the historically-published theorem rather than machine-verify it.\n\nAppears as Problem A2 in Guy's 'Unsolved Problems in Number Theory'.",
     "significance": "key",
     "mathContext": "$|\\{n : \\text{satisfiesCondition}(n)\\}| < \\infty$. Appeared as Problem A2 in Guy's 'Unsolved Problems in Number Theory'. Luca's resolution in Mathematics of Computation (2001) gave the complete answer.",
     "relatedConcepts": [
@@ -119,8 +119,8 @@
       "endLine": 113
     },
     "type": "concept",
-    "title": "Luca's Complete Classification",
-    "content": "**luca_theorem:** The only n satisfying the Erdős-Stewart condition are n = 1, 2, 3, 4, 5.\n\nThis completely classifies all solutions. Luca's proof uses factorial growth bounds and diophantine equation techniques to eliminate all n ≥ 6.",
+    "title": "Luca's Complete Classification (Axiomatized)",
+    "content": "**luca_theorem:** an `axiom` in this file, asserting the only n satisfying the Erdős-Stewart condition are n = 1, 2, 3, 4, 5.\n\nThis completely classifies all solutions, per Luca's published proof (factorial growth bounds and diophantine equation techniques to eliminate all n ≥ 6) — that proof itself is not formalized in Lean.",
     "mathContext": "Published in Mathematics of Computation (2001).",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-1058/meta.json
+++ b/src/data/proofs/erdos-1058/meta.json
@@ -85,8 +85,8 @@
       "title": "Prime Sequence Definitions",
       "startLine": 32,
       "endLine": 62,
-      "summary": "Axiomatizes the prime sequence and its properties",
-      "mathContext": "The prime-counting sequence $p_1 = 2, p_2 = 3, p_3 = 5, p_4 = 7, p_5 = 11, \\ldots$ is axiomatized as a strictly increasing function $\\text{prime\\_seq}: \\mathbb{N} \\to \\mathbb{N}$ with $\\text{Prime}(\\text{prime\\_seq}(n))$ for all $n$."
+      "summary": "Defines the prime sequence via `Nat.nth Nat.Prime` and proves its basic properties",
+      "mathContext": "The prime-counting sequence $p_1 = 2, p_2 = 3, p_3 = 5, p_4 = 7, p_5 = 11, \\ldots$ is defined as `Nat.nth Nat.Prime` (not axiomatized); strict monotonicity and $\\text{Prime}(\\text{prime\\_seq}(n))$ for all $n$ are proved from Mathlib's `Nat.nth` API."
     },
     {
       "id": "problem-statement",


### PR DESCRIPTION
## Gallery Integrity Audit: erdos-1058

**Proof**: erdos-1058 (Prime Divisors of n!+1 Between Consecutive Primes)

### Problem

`annotations.json` titles the two real `axiom` declarations in
`Erdos1058Problem.lean` in ways that mask that they're axioms:

- `ann-1058-conjecture` (covers `axiom erdos_stewart_conjecture_true`) is
  titled **"Erdős-Stewart Conjecture (Proved)"** and its content only says
  "Luca proved this in 2001" — no disclosure that this is an unproved
  `axiom` in the Lean file, not a Lean-verified theorem.
- `ann-1058-luca` (covers `axiom luca_theorem`) has no axiom disclosure at
  all.

Nowhere in `annotations.json` do these two axiom-covering entries mention
the word "axiom" — only `meta.json`'s top-level fields (`status`,
`badge`, `axiomCount`, `assumptions`) correctly disclose them. The
per-line annotations, which readers see hovering over the axiom
declarations directly, did not.

Separately, both `meta.json`'s `prime-seq` section and its matching
annotation still said "Axiomatized" for `prime_seq`, even though PR
#36501 grounded it on `Nat.nth Nat.Prime` and proved its properties
(strict monotonicity, primality, first five values) — stale,
safe-direction (understates rigor), fixed alongside since it's the same
file.

### Fix

- Retitled the two axiom-covering annotations to say "(Axiomatized)" and
  added explicit `axiom`/Luca's-proof-not-formalized disclosure.
- Updated the stale `prime-seq` prose (meta.json section + annotation) to
  reflect that it's now defined/proved, not axiomatized.

No changes to `axiomCount`, `status`, `badge`, or the Lean source — those
were already accurate.

---
Discovered during gallery integrity audit.