### PR TITLE
Enrich erdos-1129-oq-02: cover header docstring (lines 1-32)

### DIFF
--- a/src/data/proofs/erdos-1129-oq-02/meta.json
+++ b/src/data/proofs/erdos-1129-oq-02/meta.json
@@ -48,6 +48,14 @@
   },
   "sections": [
     {
+      "id": "sec-header-erdos-1129-oq-02",
+      "title": "Problem Statement and Background",
+      "summary": "States open question 2 of Erd\u0151s Problem #1129: since the Lebesgue constant is affine-invariant under transformations from $[-1,1]$ to $[a,b]$, optimal interpolation nodes for $[-1,1]$ transfer immediately to any interval, eliminating 2 axioms from the parent file down to 0.",
+      "startLine": 1,
+      "endLine": 32,
+      "mathContext": "The affine map $T(x)=(b-a)/2 \\cdot x + (a+b)/2$ satisfies $T(x)-T(y)=c(x-y)$, so the invariance factor $c^{n-1}$ cancels between numerator and denominator of the Lagrange basis, proving affine-invariance of the Lebesgue constant."
+    },
+    {
       "id": "affine-map",
       "title": "Affine Transformation Between Intervals",
       "startLine": 33,


### PR DESCRIPTION
Adds a header section covering the module docstring (lines 1-32), previously uncovered by any section or annotation. Enrichment pass, no other changes.