### PR TITLE
Enrich erdos-1151: cover header docstring (lines 1-38)

### DIFF
--- a/src/data/proofs/erdos-1151/meta.json
+++ b/src/data/proofs/erdos-1151/meta.json
@@ -76,6 +76,14 @@
   },
   "sections": [
     {
+      "id": "sec-header-erdos-1151",
+      "title": "Problem Statement and Background",
+      "summary": "States Erd\u0151s Problem #1151 on Lagrange interpolation at Chebyshev nodes: the open conjecture that for any closed $A \\subseteq [-1,1]$ there is a continuous $f$ whose interpolants' limit points at some $x$ equal $A$, building on Erd\u0151s's 1941/1943 partial results.",
+      "startLine": 1,
+      "endLine": 38,
+      "mathContext": "$\\mathcal{L}^n f(x) = \\sum_i f(a_i)\\ell_i(x)$ is the degree-$(n-1)$ Lagrange interpolant at the Chebyshev nodes $a_1,\\dots,a_n$; Erd\u0151s (1941) showed divergence to $\\infty$ at rational-cosine points, but the general closed-set claim (1943) was never proved."
+    },
+    {
       "id": "chebyshev-nodes",
       "title": "Part I: Chebyshev Nodes",
       "startLine": 39,


### PR DESCRIPTION
Adds a header section covering the module docstring (lines 1-38), previously uncovered by any section or annotation. Enrichment pass, no other changes.