### PR TITLE
Enrich erdos-207: cover header docstring (lines 1-27)

### DIFF
--- a/src/data/proofs/erdos-207/meta.json
+++ b/src/data/proofs/erdos-207/meta.json
@@ -81,6 +81,14 @@
   },
   "sections": [
     {
+      "id": "sec-header-erdos-207",
+      "title": "Problem Statement and Background",
+      "summary": "States Erd\u0151s Problem #207 on high-girth Steiner triple systems, resolved by Kwan\u2013Sah\u2013Sawhney\u2013Simkin (2022): for any girth parameter $g$ and admissible order $n \\equiv 1,3 \\pmod 6$, there exists an STS on $n$ vertices where every $j \\le g$ edges span at least $j+3$ vertices.",
+      "startLine": 1,
+      "endLine": 27,
+      "mathContext": "A Steiner triple system is a 3-uniform hypergraph where every pair of vertices lies in exactly one triple; the girth condition rules out small tightly-overlapping configurations, strengthening mere existence (known since $n\\equiv1,3\\pmod6$ is necessary and sufficient) to structural sparseness."
+    },
+    {
       "id": "imports",
       "title": "Imports and Namespace",
       "summary": "Imports Mathlib modules for `Finset`, `Fintype.card`, `Finset.biUnion`, and natural number arithmetic. Opens `Finset` namespace within `Erdos207`.",


### PR DESCRIPTION
Adds a header section covering the module docstring (lines 1-27), previously uncovered by any section or annotation. Enrichment pass, no other changes.