### PR TITLE
Enrich erdos-249-oq-01: cover header docstring (lines 1-26)

### DIFF
--- a/src/data/proofs/erdos-249-oq-01/meta.json
+++ b/src/data/proofs/erdos-249-oq-01/meta.json
@@ -68,6 +68,14 @@
   },
   "sections": [
     {
+      "id": "sec-header-erdos-249-oq-01",
+      "title": "Problem Statement and Background",
+      "summary": "Extends Erd\u0151s Problem #249 (is $\\sum \\varphi(n)/2^n$ irrational?) with tighter numeric bounds $87/64 < \\text{totientPowerSum} < 351/256$ (interval width $\\approx 0.012$), and rules out the sum equaling several specific rationals including $4/3$.",
+      "startLine": 1,
+      "endLine": 26,
+      "mathContext": "All bounds are proved from Mathlib with 0 axioms and 0 sorries by direct term computation for $n=3,\\dots,10$ combined with a tail comparison against $\\sum n/2^n$."
+    },
+    {
       "id": "term-computations-1",
       "title": "Part I: Term Computations (n = 3, 4, 5)",
       "summary": "Computes φ(n)/2^n for n = 3 (prime: 1/4), n = 4 (= 2², native_decide: 1/8), n = 5 (prime: 1/8).",


### PR DESCRIPTION
Adds a header section covering the module docstring (lines 1-26), previously uncovered by any section or annotation. Enrichment pass, no other changes.