### PR TITLE
Audit: erdos-1059 (reserve) - re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9478,9 +9478,9 @@
       "result": "issues-fixed"
     },
     "erdos-1059": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:27Z",
+      "lastAudited": "2026-07-22T22:52:44Z",
       "result": "clean"
     },
     "erdos-1059-oq-01": {


### PR DESCRIPTION
## Reserve-mode re-audit

**Proof**: erdos-1059
**Result**: clean (re-verified after prior fix)

Prior integrity issue (phantom axiom in `mainTheorems` + `native_decide`
mislabeled as trust-free in annotations.json) was fixed and merged via #42035.
This is a re-verification confirming the fix landed correctly on main:

- `mainTheorems[]` no longer contains the fabricated `erdos_alternative_approach`
  axiom entry; all 4 remaining entries (`example_101`, `example_211`,
  `counterexample_89`, `two_witnesses`) match real declarations in
  `Proofs/Erdos1059Problem.lean`.
- `leanFile.axiomCount` / `meta.axiomCount` both 0, matching 0 `axiom` grep
  hits in source.
- `annotations.json` now correctly discloses `native_decide` /
  `Lean.ofReduceBool` trust footprint for `prime_211` / `example_211`
  (previously falsely claimed "no trust assumptions").

Tracker-only update; no source/meta changes needed.

---
Discovered during gallery integrity audit (reserve mode).