### PR TITLE
Enrich maschke-theorem-oq-01-oq-01-oq-01: cover header docstring (lines 1-52)

### DIFF
--- a/src/data/proofs/maschke-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/maschke-theorem-oq-01-oq-01-oq-01/meta.json
@@ -92,6 +92,13 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "The augmentation sequence does not split",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Identifies the nilpotent g-1 from the parent entry with a generator of the augmentation ideal I = ker(ε) and shows the short exact sequence 0 → I → F_p[Z/p] → F_p → 0 does not split as F_p[Z/p]-modules: any splitting would force a g-invariant element with augmentation both 1 and 0 (mod p), a contradiction driven by the cyclic-shift structure of the regular representation."
+    },
+    {
       "id": "setup",
       "title": "Setup: the Group Algebra, Generator, and Augmentation",
       "startLine": 53,


### PR DESCRIPTION
Adds a `header`-type section covering the module docstring (lines 1-52), which was previously uncovered by any section or annotation. Content summarized directly from the file's own `/-! ... -/` docstring.