### PR TITLE
Enrich matrix-posdef-sqrt-oq-01: cover header docstring (lines 1-55)

### DIFF
--- a/src/data/proofs/matrix-posdef-sqrt-oq-01/meta.json
+++ b/src/data/proofs/matrix-posdef-sqrt-oq-01/meta.json
@@ -76,6 +76,13 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "The positive semidefinite square root: existence, structure, uniqueness",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Every PSD matrix A over R or C has a PSD square root, supplied by Mathlib's continuous functional calculus as CFC.sqrt A. This file packages the full characterization: the defining property sqrt(A)*sqrt(A) = A, that sqrt(A) stays PSD, its uniqueness among PSD square roots, corollaries (sqrt(0)=0, sqrt(1)=1, sqrt(A^2)=A), the determinant identity det(sqrt A)^2 = det A, and a concrete diag(4,9) instance."
+    },
+    {
       "id": "defining-property",
       "title": "Defining Property: √A is a Square Root of A",
       "startLine": 56,


### PR DESCRIPTION
Adds a `header`-type section covering the module docstring (lines 1-55), which was previously uncovered by any section or annotation. Content summarized directly from the file's own `/-! ... -/` docstring.