### PR TITLE
Enrich picks-theorem-oq-02: cover header docstring (lines 1-39)

### DIFF
--- a/src/data/proofs/picks-theorem-oq-02/meta.json
+++ b/src/data/proofs/picks-theorem-oq-02/meta.json
@@ -55,6 +55,13 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "GCD boundary formula for lattice points on a segment",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Answers the parent entry's open question on constructive boundary counting for Pick's theorem: the number of integer lattice points on the segment from (0,0) to (a,b), including endpoints, is exactly gcd(a,b)+1, realized as the points (k·a/g, k·b/g) for k = 0,...,g. This gives the boundary term B = sum of gcd(|Δx|,|Δy|) over edges in Pick's formula A = I + B/2 - 1."
+    },
+    {
       "id": "definitions",
       "title": "Definitions",
       "startLine": 40,


### PR DESCRIPTION
Adds a `header`-type section covering the module docstring (lines 1-39), which was previously uncovered by any section or annotation. Content summarized directly from the file's own `/-! ... -/` docstring.