### PR TITLE
Audit: erdos-1044 - fix definitionCount 2->3

### DIFF
--- a/src/data/proofs/erdos-1044/meta.json
+++ b/src/data/proofs/erdos-1044/meta.json
@@ -27,7 +27,7 @@
     "assumptions": "2 axioms: maxBoundaryLength, tang_infimum_eq_two. 0 sorries.",
     "mathlib_version": "4.31.0",
     "theoremCount": 3,
-    "definitionCount": 2
+    "definitionCount": 3
   },
   "overview": {
     "historicalContext": "**Polynomial Lemniscates and Metric Properties**\n\nThis problem originates from the 1958 paper of Erdős, Herzog, and Piranian, *Metric properties of polynomials*, which systematically studied how the geometry of polynomial level sets $\\{z : |f(z)| = c\\}$ (called **lemniscates**) relates to the distribution of roots.\n\nA **polynomial lemniscate** is the level curve $\\{z \\in \\mathbb{C} : |f(z)| = c\\}$ for a polynomial $f$ and constant $c > 0$. These curves generalize Bernoulli's lemniscate ($|z^2 - 1| = c$) and have been studied since the 18th century. The sublevel set $\\{z : |f(z)| < c\\}$ is an open set whose connected components are bounded by lemniscate arcs.\n\nFor a monic polynomial $f(z) = \\prod_{i=1}^n (z - z_i)$ with all roots in the closed unit disk $|z_i| \\le 1$, define $\\Lambda(f)$ as the maximum of the boundary lengths of the connected components of $\\{z : |f(z)| < 1\\}$. The problem asks: what is $\\inf_f \\Lambda(f)$?\n\n**Connection to Potential Theory**: The function $\\log|f(z)|$ is subharmonic in $\\mathbb{C}$ and harmonic away from the roots. It equals the sum of Green's functions $\\sum_i \\log|z - z_i|$. The sublevel set $\\{|f| < 1\\}$ is equivalently $\\{\\sum_i \\log|z - z_i| < 0\\}$, and its boundary is where the 'logarithmic potential' of the root configuration vanishes. The boundary length thus encodes metric information about the potential-theoretic landscape.\n\n**Tang's Resolution**: Quanyu Tang proved that $\\inf_f \\Lambda(f) = 2$. The key insights are:\n\n1. **Lower bound**: $\\Lambda(f) > 2$ for every polynomial. The argument uses the fact that the boundary of any component of $\\{|f| < 1\\}$ containing a root must surround that root, and the geometry of the level set near a root forces a minimum perimeter related to the diameter of the root's neighborhood.\n\n2. **Upper bound**: The roots-of-unity polynomials $f_n(z) = z^n - 1$ have $\\Lambda(f_n) \\to 2$ as $n \\to \\infty$. The sublevel set of $z^n - 1$ consists of $n$ small 'petals' near each $n$th root of unity. As $n$ grows, each petal becomes a narrow region whose boundary length approaches $2$ (the length of a degenerate 'slit').\n\n3. **Infimum not achieved**: No polynomial actually achieves $\\Lambda(f) = 2$. The limiting shape is a segment (diameter of length $2$), but a polynomial level set boundary is always a smooth closed curve, never a segment.\n\nThe problem connects to several deep areas: the **Smale–Shub conjecture** on critical points of polynomials, **Chebyshev polynomials** (which minimize $\\|f\\|_{\\infty}$ on intervals), and the **transfinite diameter** of compact sets in $\\mathbb{C}$.",
@@ -204,7 +204,7 @@
     "lineCount": 123,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 2,
+    "definitionCount": 3,
     "path": "Proofs/Erdos1044Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary
- Reserve-mode audit re-verification of erdos-1044 (Boundary Length of Polynomial Level Sets, Tang).
- Axioms (2: `maxBoundaryLength`, `tang_infimum_eq_two`) and their disclosure prose are honest and accurate — no phantom/vacuous/inconsistent axiom issues found.
- `definitionCount` in meta.json was 2 but the file declares 3 `def`s: the v4.31 migration compat shim `Complex.abs` (line 27), `HasRootsInDisk` (line 41), and `rootsOfUnity` (line 85). Sibling file erdos-1048 counts the same compat shim in its definitionCount, confirming the convention should include it here too.
- axiomCount (2), theoremCount (3), and sorries (0) were already correct; only definitionCount needed fixing.

## Test plan
- [x] Verified all axiom/theorem/def names in the Lean source against meta.json prose — no phantom declarations.
- [x] Cross-checked definitionCount convention against sibling erdos-1048Problem.lean, which counts the identical compat shim.