### PR TITLE
Enrich pythagorean-triples-oq-07: cover header docstring (lines 1-29)

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-07/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-07/meta.json
@@ -76,6 +76,13 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Parity dichotomy: exactly one leg is even",
+      "startLine": 1,
+      "endLine": 29,
+      "summary": "In a primitive Pythagorean triple x^2+y^2=z^2 with coprime legs, exactly one leg is even and the other odd. Both-odd is impossible for any Pythagorean triple at all (an odd square is 1 mod 4, so a sum of two is 2 mod 4, never a perfect square), while both-even is excluded by coprimality; together they give the dichotomy Mathlib packages as PythagoreanTriple.even_odd_of_coprime, with the standalone both-odd obstruction surfaced as the genuine new content here."
+    },
+    {
       "id": "obstruction",
       "title": "The mod-4 Obstruction",
       "startLine": 30,


### PR DESCRIPTION
Adds a `header`-type section covering the module docstring (lines 1-29), which was previously uncovered by any section or annotation. Content summarized directly from the file's own `/-! ... -/` docstring.