### PR TITLE
Research: erdos-85-wip-01 - f(10) = 4 proved via edge-list Petersen (minDegreeForC4_ten)

### DIFF
--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -2053,4 +2053,116 @@ theorem minDegreeForC4_nine : minDegreeForC4 9 = 3 := by
   have hge : 3 ≤ minDegreeForC4 9 := three_le_minDegreeForC4 (by norm_num)
   omega
 
+/-! ## `f(10) = 4`: the Petersen graph, decide-free at the global level
+
+The lower half `f(10) ≥ 4` needs a `C₄`-free graph of minimum degree `3` on ten
+vertices — the Petersen graph, and by the Moore bound nothing smaller works.
+The route recorded as blocked ("kernel `decide` over the `10⁴` injective maps")
+is avoided entirely: `containsC4` is *extracted* to a pair of vertices with two
+distinct common neighbours (`exists_two_common_of_containsC4`), so `C₄`-freeness
+reduces to the `10 × 10` common-neighbour matrix — a tiny kernel check — via
+`not_containsC4_of_forall_common_le_one`.  The graph itself is the explicit
+edge-list Petersen: outer `5`-cycle `0–4`, inner pentagram `5–9`, spokes. -/
+
+/-- **Extracting two common neighbours from a `C₄`.**  An embedded `4`-cycle
+`f` gives the opposite pair `f 0 ≠ f 2` with the two distinct common neighbours
+`f 1 ≠ f 3`. -/
+theorem exists_two_common_of_containsC4 {V : Type*} {G : SimpleGraph V}
+    (h : containsC4 V G) :
+    ∃ x y v v' : V, x ≠ y ∧ v ≠ v' ∧
+      G.Adj v x ∧ G.Adj v y ∧ G.Adj v' x ∧ G.Adj v' y := by
+  obtain ⟨f, hinj, hadj⟩ := h
+  refine ⟨f 0, f 2, f 1, f 3, fun h => ?_, fun h => ?_, ?_, ?_, ?_, ?_⟩
+  · exact absurd (hinj h) (by decide)
+  · exact absurd (hinj h) (by decide)
+  · exact (hadj 0 1 (by decide)).symm
+  · exact hadj 1 2 (by decide)
+  · exact hadj 3 0 (by decide)
+  · exact (hadj 2 3 (by decide)).symm
+
+/-- **The common-neighbour criterion for `C₄`-freeness.**  If every pair of
+distinct vertices has at most one common neighbour, the graph is `C₄`-free.
+Converse workhorse to `containsC4_of_two_common`; together they make
+`C₄`-freeness of a concrete graph a finite check on the common-neighbour
+matrix rather than an enumeration of embeddings. -/
+theorem not_containsC4_of_forall_common_le_one {V : Type*} [Fintype V]
+    [DecidableEq V] {G : SimpleGraph V} [DecidableRel G.Adj]
+    (h : ∀ x y : V, x ≠ y → (G.neighborFinset x ∩ G.neighborFinset y).card ≤ 1) :
+    ¬ containsC4 V G := by
+  intro hc
+  obtain ⟨x, y, v, v', hxy, hvv, hvx, hvy, hv'x, hv'y⟩ :=
+    exists_two_common_of_containsC4 hc
+  have h2 : 1 < (G.neighborFinset x ∩ G.neighborFinset y).card :=
+    Finset.one_lt_card.mpr ⟨v,
+      Finset.mem_inter.mpr ⟨(G.mem_neighborFinset x v).mpr hvx.symm,
+        (G.mem_neighborFinset y v).mpr hvy.symm⟩, v',
+      Finset.mem_inter.mpr ⟨(G.mem_neighborFinset x v').mpr hv'x.symm,
+        (G.mem_neighborFinset y v').mpr hv'y.symm⟩, hvv⟩
+  have := h x y hxy
+  omega
+
+/-- The fifteen edges of the Petersen graph: outer `5`-cycle `0–1–2–3–4`, inner
+pentagram `5–7–9–6–8`, and the five spokes `i – i+5`. -/
+def petersenEdges : List (Fin 10 × Fin 10) :=
+  [(0,1), (1,2), (2,3), (3,4), (4,0),
+   (5,7), (7,9), (9,6), (6,8), (8,5),
+   (0,5), (1,6), (2,7), (3,8), (4,9)]
+
+/-- **The Petersen graph** on `Fin 10`, via its explicit edge list. -/
+def petersen : SimpleGraph (Fin 10) where
+  Adj i j := (i, j) ∈ petersenEdges ∨ (j, i) ∈ petersenEdges
+  symm.symm := fun _ _ h => Or.symm h
+  loopless.irrefl := by decide
+
+instance : DecidableRel petersen.Adj := fun i j =>
+  decidable_of_iff ((i, j) ∈ petersenEdges ∨ (j, i) ∈ petersenEdges) Iff.rfl
+
+/-- The Petersen graph is `3`-regular — a `10`-vertex kernel check. -/
+theorem petersen_degree : ∀ v, petersen.degree v = 3 := by decide
+
+/-- **Every pair of distinct Petersen vertices has at most one common
+neighbour** — the `10 × 10` kernel check that replaces the `10⁴` embedding
+enumeration.  (In fact girth `5` gives exactly one for non-adjacent pairs and
+zero for adjacent ones; `≤ 1` is all that is needed.) -/
+theorem petersen_common_le_one : ∀ x y : Fin 10, x ≠ y →
+    (petersen.neighborFinset x ∩ petersen.neighborFinset y).card ≤ 1 := by decide
+
+/-- **The Petersen graph is `C₄`-free** — no finite embedding search needed. -/
+theorem petersen_not_containsC4 : ¬ containsC4 (Fin 10) petersen :=
+  not_containsC4_of_forall_common_le_one petersen_common_le_one
+
+/-- The Petersen graph has minimum degree `3`. -/
+theorem petersen_three_le_minDegree : 3 ≤ petersen.minDegree := by
+  apply SimpleGraph.le_minDegree_of_forall_le_degree
+  intro v
+  rw [petersen_degree v]
+
+/-- **`f(10) ≥ 4`**: the Petersen graph is a `C₄`-free graph of minimum degree
+`3` on ten vertices, so threshold `3` does not force a `C₄` at order `10`. -/
+theorem four_le_minDegreeForC4_ten : 4 ≤ minDegreeForC4 10 := by
+  have hne : {k : ℕ | ∀ (G : SimpleGraph (Fin 10)) [DecidableRel G.Adj],
+      G.minDegree ≥ k → containsC4 (Fin 10) G}.Nonempty := by
+    refine ⟨9, fun G _ hmin => ?_⟩
+    rw [eq_top_of_minDegree_ge G hmin]
+    exact completeGraph_containsC4 (by norm_num)
+  unfold minDegreeForC4
+  refine le_csInf hne (fun k hk => ?_)
+  by_contra hk4
+  rw [not_le] at hk4
+  exact petersen_not_containsC4
+    (hk petersen (le_trans (by omega : k ≤ 3) petersen_three_le_minDegree))
+
+/-- **A seventh exact value: `f(10) = 4` — the Petersen threshold.**  Upper
+half: plain counting, `C(10,2) = 45 < 60 = 10·C(4,2)`.  Lower half: the
+Petersen graph (`four_le_minDegreeForC4_ten`).  This resolves the route
+recorded as blocked on a "decide-free formalization of the Petersen graph":
+the common-neighbour extraction reduces `C₄`-freeness to a `10 × 10` kernel
+check, so no embedding enumeration (and no `native_decide`) is needed.  The
+exact table now reads `f = 1, 2, 3, 2, 3, 3, 3, 3, 3, 4` for `n = 1, …, 10` —
+the first value where the answer exceeds `3`, witnessing the `√n` growth. -/
+theorem minDegreeForC4_ten : minDegreeForC4 10 = 4 := by
+  have hle : minDegreeForC4 10 ≤ 4 := minDegreeForC4_le_of_choose_lt (by decide)
+  have hge := four_le_minDegreeForC4_ten
+  omega
+
 end Erdos85

--- a/research/problems/erdos-85-wip-01/knowledge.md
+++ b/research/problems/erdos-85-wip-01/knowledge.md
@@ -474,3 +474,37 @@ formally overturned. File 1548 → 2056 lines. Exact table now
   min-deg-3.. wait min-deg 3 graphs exist on ≥ 10 vertices (Petersen ⊕ extras) —
   next elementary target could be f(11) ≤ 4 / f(12) ≤ 4 via counting (cheap) with
   lower bounds blocked on Petersen-type witnesses.
+
+## Session 2026-07-22e (researcher-1-9) — **f(10) = 4 PROVED** (Petersen blocker resolved)
+
+**Outcome**: `minDegreeForC4_ten : minDegreeForC4 10 = 4`, axiom-free (standard
+triple, host-verified exit 0). Second registered blocker resolved today. Exact
+table COMPLETE for **1 ≤ n ≤ 10: f = 1,2,3,2,3,3,3,3,3,4** — first value > 3.
+
+**Mechanism (materially new, satisfying the reopen bar)**: the blocker feared
+kernel-deciding `¬containsC4` via 10⁴ injective maps. Avoided:
+- `exists_two_common_of_containsC4` — a C₄ embedding yields a vertex pair with
+  two distinct common neighbours (f 0/f 2 with f 1/f 3).
+- `not_containsC4_of_forall_common_le_one` — so C₄-freeness of ANY concrete
+  graph reduces to its common-neighbour matrix (here 10×10, trivially
+  kernel-decidable; no native_decide).
+- `petersen` — explicit 15-edge list on Fin 10 (outer C₅ 0-4, pentagram
+  5-7-9-6-8, spokes i↔i+5); `petersen_degree : ∀ v, degree = 3` and
+  `petersen_common_le_one` both `by decide`.
+- Lower bound assembled in the `three_le_minDegreeForC4` sInf pattern; upper
+  bound is plain counting `C(10,2) = 45 < 60`.
+
+The extraction lemma pair is reusable for ANY future explicit witness graph
+(f(15)? Kneser models?): witness C₄-freeness is now always a common-neighbour
+matrix check.
+
+**Ops note**: an external process force-rebased the worktree branch mid-session
+(PR #42034 merge), wiping an uncommitted copy of this batch — re-applied from
+agent context. Commit+push immediately after every compile.
+
+**NEXT**: f(11): counting gives ≤ 4; lower ≥ 4 needs a C₄-free min-deg-3 graph
+on 11 vertices (Petersen + one vertex attached how? adding a vertex adjacent to
+≤... any new vertex needs degree ≥ 3 without creating C₄/common-neighbour
+violations — nontrivial, possibly false-free; check literature/OEIS). f(n)
+counting ceiling ≤ 4 holds through n ≤ 20 (C(n,2) < 6n iff n ≤ 12) — careful:
+only n ≤ 12. Deep: KST asymptotics, monotonicity core.

--- a/src/data/research/problems/erdos-85-wip-01.json
+++ b/src/data/research/problems/erdos-85-wip-01.json
@@ -29,8 +29,8 @@
         "blockedAt": "2026-07-22"
       },
       {
-        "route": "fourth exact value f(10)=4 via the Petersen graph (3-regular girth-5 => C4-free => f(10)>=4)",
-        "reopenCriterion": "materially new mechanism required: a decide-free formalization of the Petersen graph and its C4-freeness (10^4 injective maps; kernel decide risky, native_decide taints axioms). No 3-regular C4-free graph exists below 10 vertices (Moore bound), so no easier small witness.",
+        "route": "RESOLVED 2026-07-22 (was: f(10)=4 needs decide-free Petersen): PROVED via explicit 15-edge Petersen + common-neighbour extraction criterion (10x10 kernel decide, no native_decide) — minDegreeForC4_ten.",
+        "reopenCriterion": "resolved, nothing to reopen",
         "blockedAt": "2026-07-21"
       },
       {
@@ -57,7 +57,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "MAJOR PROGRESS (researcher-1-9, 2026-07-22, host-verified exit 0, standard triple): f(9) = 3 PROVED axiom-free (minDegreeForC4_nine) — blueprint executed same-day, no ex(n;C4) input. Exact table COMPLETE for 1<=n<=9: f = 1,2,3,2,3,3,3,3,3. Machinery: degree pinch, dense-4-set lemma, tight-cherry bijection upgrade, path-count, pigeonhole engine. Remaining: f(10)=4 (Petersen, blocked on decide-free witness), f(11)/f(12) upper bounds via counting (cheap next target), deep KST asymptotics + monotonicity core (open).",
+    "progressSummary": "MAJOR PROGRESS (researcher-1-9, 2026-07-22, host-verified, standard triple): f(9) = 3 AND f(10) = 4 both PROVED axiom-free in one day — exact table COMPLETE for 1 <= n <= 10: f = 1,2,3,2,3,3,3,3,3,4. Both registered blockers resolved (f(9): elementary pinch + tight-cherry bijection + pigeonhole; f(10): edge-list Petersen + common-neighbour extraction criterion, no embedding enumeration). Remaining: f(11)/f(12) (counting gives <= 4, lower bounds open), deep KST asymptotics, monotonicity core (open in literature).",
     "builtItems": [
       "C4_adj_zero_one/one_two/two_three/three_zero (four cycle edges) in Erdos85Problem.lean",
       "C4_not_adj_zero_two (diagonal non-edge) in Erdos85Problem.lean",
@@ -94,7 +94,10 @@
       "containsC4_of_card_add_two_le_degree_add_degree in Erdos85Problem.lean (global form)",
       "minDegreeForC4_nine (f(9)=3) + containsC4_of_nine_min_degree_three in Erdos85Problem.lean",
       "nine_degree_pinch, containsC4_of_nine_one_four, containsC4_of_nine_three_fours in Erdos85Problem.lean",
-      "containsC4_of_four_set_min_two (dense-4-set lemma) + card_inter_neighborFinset_le_one in Erdos85Problem.lean"
+      "containsC4_of_four_set_min_two (dense-4-set lemma) + card_inter_neighborFinset_le_one in Erdos85Problem.lean",
+      "minDegreeForC4_ten (f(10)=4) + four_le_minDegreeForC4_ten in Erdos85Problem.lean",
+      "petersen (explicit edge-list) + petersen_degree + petersen_common_le_one in Erdos85Problem.lean",
+      "exists_two_common_of_containsC4 + not_containsC4_of_forall_common_le_one (reusable C4-freeness criterion) in Erdos85Problem.lean"
     ],
     "insights": [
       "Erdos85Problem.lean was a definitions-only stub (7 defs, 0 theorems). Asymptotics f(n)=(1+o(1))sqrt(n), f(4)=2, and the Ramsey reformulation need extremal graph theory beyond Mathlib; tractable axiom-free content is structural facts about C4, containsC4, and starGraph.",
@@ -124,7 +127,9 @@
       "Friendship theorem NOT needed for the tight-cherry case (and is unavailable anyway: Mathlib ships it only in Archive/Wiedijk100Theorems, no olean in the shared cache)",
       "Pigeonhole C4 engine formalized: containsC4_of_degree_sum_subset (N(u),N(v) inside S with |S|+2 <= d(u)+d(v) forces C4) + global |V|+2 form — reusable for all future exact values",
       "f(9) = 3 PROVED axiom-free in one session, executing the same-day blueprint: degree pinch (cherry+parity), (3^8,4) killed by dense-4-set local analysis, (3^6,4^3) killed by tight-cherry bijection + path-count + pigeonhole engine — NO ex(n;C4) input; fourth extremal-tables blocker claim overturned by formal proof",
-      "Tight-counting upgrade pattern: when the KST cherry-to-pair map has equal source/target cards, Set.InjOn + card_image_of_injOn + eq_of_subset_of_card_le turns the pigeonhole into a bijection giving EXISTENCE of a common neighbour for every pair — reusable wherever a counting bound is attained exactly"
+      "Tight-counting upgrade pattern: when the KST cherry-to-pair map has equal source/target cards, Set.InjOn + card_image_of_injOn + eq_of_subset_of_card_le turns the pigeonhole into a bijection giving EXISTENCE of a common neighbour for every pair — reusable wherever a counting bound is attained exactly",
+      "f(10) = 4 PROVED: the feared 10^4 embedding enumeration was never needed — extraction lemma (C4 embedding => two common neighbours) reduces C4-freeness of any explicit witness graph to its common-neighbour matrix, a 10x10 kernel decide for the 15-edge Petersen list",
+      "Both registered exact-value blockers on this problem fell in one day (f(9) via elementary pinch+pigeonhole, f(10) via common-neighbour extraction) — extremal-table and enumeration fears repeatedly overestimate the difficulty"
     ],
     "mathlibGaps": [
       "Fin n has NO global CommRing instance (only scoped Fin.instCommRing via `open Fin.CommRing`, gated on NeZero n); needed for ring/linear_combination on cycleGraph differences"


### PR DESCRIPTION
## Summary
Research session for erdos-85-wip-01: **f(10) = 4 fully proved, axiom-free** — resolving the second registered blocker on this problem today (after f(9) = 3 in #42034). The exact-value table is now complete for 1 ≤ n ≤ 10: **f = 1, 2, 3, 2, 3, 3, 3, 3, 3, 4** — the first value exceeding 3, witnessing the √n growth.

## Progress
- 8 new declarations in `proofs/Proofs/Erdos85Problem.lean` (2056 → 2168 lines), culminating in `minDegreeForC4_ten : minDegreeForC4 10 = 4`
- Host-verified: `lake env lean` exit 0; `#print axioms` = `[propext, Classical.choice, Quot.sound]`; 0 sorry / 0 axiom / **no native_decide**

## Findings
The blocker recorded f(10) as needing a "decide-free formalization of the Petersen graph" because kernel-deciding `¬containsC4` directly would enumerate ~10⁴ injective maps. That enumeration is never needed:

- `exists_two_common_of_containsC4` — an embedded C₄ yields a vertex pair with two distinct common neighbours.
- `not_containsC4_of_forall_common_le_one` — so C₄-freeness of **any** concrete graph reduces to its common-neighbour matrix. For the explicit 15-edge Petersen graph on `Fin 10` this is a 10×10 kernel check (`by decide`), as is 3-regularity.
- Lower bound assembled in the same sInf pattern as `three_le_minDegreeForC4`; upper bound is plain counting (`C(10,2) = 45 < 60 = 10·C(4,2)`).

The extraction-lemma pair is reusable for every future explicit witness graph: witness C₄-freeness is now always a small common-neighbour matrix check.

## Ops note
An external force-rebase of the session branch (during the #42034 merge) wiped an uncommitted copy of this batch mid-session; it was re-applied from agent context and verified again. Second incident today of worktree state being destroyed under an active session.

## Status
**Outcome**: completed (f(10) milestone; deep core of the parent problem remains open)
**Next Steps**: f(11)/f(12) counting upper bounds ≤ 4 are cheap; their lower bounds need new C₄-free min-degree-3 witnesses on 11/12 vertices (open); KST asymptotics and the monotonicity core stay deep.

🤖 Generated by researcher-1