### PR TITLE
fix(erdos-1042): remove phantom axiom names from gallery narrative

### DIFF
--- a/src/data/proofs/erdos-1042/annotations.json
+++ b/src/data/proofs/erdos-1042/annotations.json
@@ -31,7 +31,7 @@
     },
     "type": "definition",
     "title": "Transfinite Diameter",
-    "content": "**transfiniteDiameter F** is axiomatized as a real-valued function on sets F ⊆ ℂ, equal to the logarithmic capacity.\n\nKey properties:\n- `transfiniteDiameter_nonneg`: always ≥ 0\n- `disc_transfinite_diameter`: disc of radius r has diameter r\n- `interval_transfinite_diameter`: [-1,1] has diameter 1/2\n\nThe formal definition is ρ(F) = lim_{n→∞} sup_{z₁,...,zₙ∈F} (∏_{i<j} |zᵢ-zⱼ|)^{1/C(n,2)}, but this requires Chebyshev constant machinery not available in Mathlib.",
+    "content": "**transfiniteDiameter F** is axiomatized as a real-valued function on sets F ⊆ ℂ, equal to the logarithmic capacity.\n\nKey properties discussed only in comments, not formalized as declarations:\n- nonnegativity: always ≥ 0\n- disc of radius r has diameter r\n- [-1,1] has diameter 1/2\n\nThe formal definition is ρ(F) = lim_{n→∞} sup_{z₁,...,zₙ∈F} (∏_{i<j} |zᵢ-zⱼ|)^{1/C(n,2)}, but this requires Chebyshev constant machinery not available in Mathlib.",
     "mathContext": "The transfinite diameter equals the Chebyshev constant and the logarithmic capacity — three equivalent formulations of the 'size' of a compact set in ℂ. This equivalence is a deep theorem of Fekete and Szegő.",
     "significance": "key",
     "relatedConcepts": [
@@ -55,7 +55,7 @@
     },
     "type": "definition",
     "title": "Lemniscates and Component Counting",
-    "content": "**PolynomialWithRoots F** is a structure with degree, roots (a function Fin n → ℂ), and a proof that all roots lie in F.\n\n**lemniscate f** = {z : |f(z)| < 1}, the sublevel set of a polynomial.\n\n**numComponents S** and **maxComponents F n** are axiomatized: numComponents counts connected components of a set, maxComponents gives the maximum achievable by degree-n polynomials with roots in F.",
+    "content": "**PolynomialWithRoots F** is a structure with degree, roots (a function Fin n → ℂ), and a proof that all roots lie in F.\n\n**lemniscate f** = {z : |f(z)| < 1}, the sublevel set of a polynomial.\n\n**numComponents S** and **maxComponents F n** are ordinary definitions (via Nat.card / sSup), not axioms: numComponents counts connected components of a set, maxComponents gives the maximum achievable by degree-n polynomials with roots in F.",
     "mathContext": "The connected components of a lemniscate are bounded open regions around clusters of roots. When roots are well-separated, each root contributes roughly one component.",
     "significance": "key",
     "relatedConcepts": [
@@ -101,7 +101,7 @@
     },
     "type": "concept",
     "title": "Erdős-Herzog-Piranian (1958)",
-    "content": "**ehp_disc_result**: The unit disc achieves n components for all n > 0. This is the classical positive result.\n\n**roots_of_unity_example**: The specific polynomial f(z) = zⁿ + 1 achieves this. Its roots are the nth roots of -1, evenly spaced on the unit circle. Each root generates one small component of the lemniscate.\n\nThis shows the maximum n components IS achievable when F is the unit disc (transfinite diameter 1).",
+    "content": "Discussed only in comments, not formalized as declarations:\n\n**Disc result**: The unit disc achieves n components for all n > 0. This is the classical positive result.\n\n**Roots-of-unity example**: The specific polynomial f(z) = zⁿ + 1 achieves this. Its roots are the nth roots of -1, evenly spaced on the unit circle. Each root generates one small component of the lemniscate.\n\nThis shows the maximum n components IS achievable when F is the unit disc (transfinite diameter 1) — but this claim is not backed by an axiom or theorem in this file, only prose.",
     "mathContext": "The roots of zⁿ + 1 are e^{iπ(2k+1)/n} for k = 0,...,n-1. When |z - zₖ| is small, |f(z)| ≈ |z - zₖ| · ∏_{j≠k} |zₖ - zⱼ|, which is < 1 in a small disc around zₖ.",
     "significance": "key",
     "relatedConcepts": [
@@ -124,7 +124,7 @@
     },
     "type": "concept",
     "title": "Ghosh-Ramachandran Solution (2024)",
-    "content": "Three axioms capturing the complete 2024 solution:\n\n**ghosh_ramachandran_small_diameter**: If 0 < d < 1, at most (1-c)n components for some c > 0. This confirms Question 2.\n\n**ghosh_ramachandran_small_connected**: If d ≤ 1/4 and F is connected, only 1 component. A dramatic strengthening for connected sets.\n\n**ghosh_ramachandran_diameter_one_examples**: For d = 1, there exist F with n components for infinitely many n. This partially answers Question 1.\n\nThe 1/4 threshold in the connected case is sharp — related to the capacity of the Mandelbrot set.",
+    "content": "Two axioms plus one comment-only claim toward the complete 2024 solution:\n\n**ghosh_ramachandran_small_diameter** (axiom): If 0 < d < 1, at most (1-c)n components for some c > 0. This confirms Question 2.\n\n**Small-connected result** (comment only, not formalized): If d ≤ 1/4 and F is connected, only 1 component. A dramatic strengthening for connected sets — no axiom or theorem backs this claim in the file.\n\n**ghosh_ramachandran_diameter_one_examples** (axiom): For d = 1, there exist F with n components for infinitely many n. This partially answers Question 1.\n\nThe 1/4 threshold in the connected case is sharp — related to the capacity of the Mandelbrot set.",
     "mathContext": "The solution uses tools from potential theory (Green's function, equilibrium measure), the argument principle for component counting, and careful estimates of polynomial norms.",
     "significance": "key",
     "relatedConcepts": [
@@ -148,7 +148,7 @@
     },
     "type": "concept",
     "title": "Geometry vs Diameter Counterexample",
-    "content": "**diameter_not_sufficient**: The crucial insight that the answer cannot depend on transfinite diameter alone.\n\nF₁ = disc of radius 1/2: transfinite diameter = 1/2, always gives 1 component\nF₂ = interval [-1,1]: transfinite diameter = 1/2, can give ≥ 0.01n components\n\nSame diameter, completely different behavior! The disc is 'round' (all directions equal), while the interval is 'thin' (extends in one direction), allowing Chebyshev-like polynomials to create many components.",
+    "content": "Discussed only in a comment, not formalized as a declaration: the crucial insight that the answer cannot depend on transfinite diameter alone.\n\nF₁ = disc of radius 1/2: transfinite diameter = 1/2, always gives 1 component\nF₂ = interval [-1,1]: transfinite diameter = 1/2, can give ≥ 0.01n components\n\nSame diameter, completely different behavior! The disc is 'round' (all directions equal), while the interval is 'thin' (extends in one direction), allowing Chebyshev-like polynomials to create many components.",
     "mathContext": "The interval [-1,1] supports Chebyshev polynomials Tₙ(x), whose lemniscates have n components corresponding to the n intervals where |Tₙ(x)| < 1. The disc has rotational symmetry that prevents this.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-1042/meta.json
+++ b/src/data/proofs/erdos-1042/meta.json
@@ -37,15 +37,14 @@
       }
     ],
     "originalContributions": [
-      "transfiniteDiameter axiom with nonnegativity",
-      "disc_transfinite_diameter and interval_transfinite_diameter axioms",
+      "transfiniteDiameter axiom (nonnegativity, disc, and interval values discussed only in comments, not formalized)",
       "PolynomialWithRoots structure, lemniscate definition",
-      "numComponents and maxComponents axioms",
+      "numComponents and maxComponents definitions (Nat.card / sSup, not axioms)",
       "mainQuestion1 and mainQuestion2 definitions",
-      "ehp_disc_result and roots_of_unity_example axioms (1958)",
       "ghosh_ramachandran_small_diameter axiom: d < 1 → (1-c)n bound",
       "ghosh_ramachandran_diameter_one_examples axiom: d = 1 → n components",
-      "erdos_1042_summary theorem combining key results"
+      "erdos_1042_summary theorem combining key results",
+      "note: the EHP 1958 disc/roots-of-unity example and the GR d ≤ 1/4 single-component result are discussed only in comments, not formalized as declarations"
     ],
     "axiomCount": 3,
     "lineCount": 129,
@@ -57,7 +56,7 @@
     "historicalContext": "Erdős, Herzog, and Piranian posed this problem in their 1958 paper on metric properties of polynomials. A polynomial lemniscate is the sublevel set {z : |f(z)| < 1} of a polynomial f, and the question concerns how many connected components it can have when the roots are constrained to lie in a closed set F ⊆ ℂ. The transfinite diameter (logarithmic capacity) of F controls the answer.\n\nThe 1958 paper showed that for the unit disc (transfinite diameter 1), the lemniscate of f(z) = zⁿ + 1 has exactly n connected components — one small disc around each nth root of -1. This left open whether sets with smaller transfinite diameter must have fewer components, and whether the answer depends on diameter alone.\n\nThe problem remained open for over 65 years until Ghosh and Ramachandran (2024) gave a complete solution. They proved that for transfinite diameter d < 1, components are bounded by (1-c)n for some c > 0 depending on F. For d ≤ 1/4 with F connected, only one component is possible. Crucially, they showed the answer cannot depend on transfinite diameter alone: the disc of radius 1/2 and the interval [-1,1] both have transfinite diameter 1/2, but behave completely differently.",
     "problemStatement": "Let F ⊆ ℂ be closed with transfinite diameter d. For f(z) = ∏ᵢ(z - zᵢ) with roots zᵢ ∈ F, the lemniscate is L = {z : |f(z)| < 1}.\n\n**Q1:** If d = 1 and F is not contained in any disc of radius 1, can L have n components?\n**Q2:** If d < 1, must L have at most (1-c)n components for some c > 0?\n\n**Status:** SOLVED (Ghosh-Ramachandran 2024).",
     "text": "For polynomials with roots in a closed set F ⊆ ℂ, how many connected components can the lemniscate {z : |f(z)| < 1} have? Depends on transfinite diameter and geometry. SOLVED by Ghosh-Ramachandran (2024).",
-    "proofStrategy": "The formalization axiomatizes transfiniteDiameter, numComponents, and maxComponents to avoid requiring full potential theory and topological component machinery. The key Ghosh-Ramachandran theorems (small diameter, small connected, diameter-one examples) are stated as axioms. The summary theorem combines the two main results via exact.",
+    "proofStrategy": "The formalization axiomatizes transfiniteDiameter (logarithmic capacity) to avoid requiring full potential theory machinery; numComponents and maxComponents are ordinary definitions (Nat.card / sSup), not axioms. Two of the three key Ghosh-Ramachandran results (small diameter bound, diameter-one examples) are stated as axioms; the third (d ≤ 1/4 and F connected ⇒ single component) appears only in a comment and is not formalized as a declaration. The summary theorem combines the two axiomatized GR results via exact.",
     "keyInsights": [
       "**Transfinite diameter** (logarithmic capacity) controls lemniscate component counts",
       "**EHP 1958:** f(z) = zⁿ + 1 gives n components for the unit disc",
@@ -74,7 +73,7 @@
     {
       "id": "transfinite-diameter",
       "title": "Transfinite Diameter",
-      "summary": "transfiniteDiameter axiom, nonnegativity, disc and interval examples",
+      "summary": "transfiniteDiameter axiom; nonnegativity, disc, and interval values are comments only, not formalized",
       "startLine": 31,
       "endLine": 50,
       "mathContext": "The transfinite diameter (logarithmic capacity) $d(F) = \\lim_{n \\to \\infty} \\max_{z_1,\\ldots,z_n \\in F} \\left(\\prod_{i<j} |z_i - z_j|\\right)^{2/(n(n-1))}$. Examples: $d(\\overline{\\mathbb{D}}) = 1$ (unit disc), $d([-1,1]) = 1/2$ (interval). Axiomatized with $d(F) \\ge 0$."
@@ -98,7 +97,7 @@
     {
       "id": "ehp-result",
       "title": "Erdős-Herzog-Piranian Result (1958)",
-      "summary": "ehp_disc_result and roots_of_unity_example axioms",
+      "summary": "EHP 1958 disc/roots-of-unity example, discussed only in comments — not formalized as an axiom or theorem",
       "startLine": 88,
       "endLine": 102,
       "mathContext": "Erdős-Herzog-Piranian (1958): for $F = \\overline{\\mathbb{D}}$ (unit disc), $\\text{maxComponents}(F, n) = n$. Witness: $f(z) = z^n + 1$, whose lemniscate has $n$ small discs around the $n$th roots of $-1$: $\\{z : |z^n + 1| < 1\\}$ has one component near each $e^{i\\pi(2k+1)/n}$."
@@ -106,10 +105,10 @@
     {
       "id": "gr-solution",
       "title": "Ghosh-Ramachandran Solution (2024)",
-      "summary": "Three main GR theorems: small diameter, small connected, diameter-1",
+      "summary": "Two GR theorems formalized as axioms: small diameter bound, diameter-1 examples; the small-connected (d ≤ 1/4) result is comment-only",
       "startLine": 103,
       "endLine": 125,
-      "mathContext": "Ghosh-Ramachandran (2024): (1) $d(F) < 1 \\Rightarrow \\text{maxComponents}(F, n) \\le (1-c)n$ for some $c = c(F) > 0$; (2) $d(F) \\le 1/4$ and $F$ connected $\\Rightarrow \\text{maxComponents}(F, n) = 1$; (3) $d(F) = 1$ and $F$ not in a unit disc $\\Rightarrow \\text{maxComponents}(F, n) = n$."
+      "mathContext": "Ghosh-Ramachandran (2024): (1) $d(F) < 1 \\Rightarrow \\text{maxComponents}(F, n) \\le (1-c)n$ for some $c = c(F) > 0$ — formalized as axiom `ghosh_ramachandran_small_diameter`; (2) $d(F) \\le 1/4$ and $F$ connected $\\Rightarrow \\text{maxComponents}(F, n) = 1$ — discussed only in a comment, not formalized; (3) $d(F) = 1$ and $F$ not in a unit disc $\\Rightarrow \\text{maxComponents}(F, n) = n$ — formalized as axiom `ghosh_ramachandran_diameter_one_examples`."
     },
     {
       "id": "counterexample",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-1042
**Problem**: `meta.json` (`originalContributions`, `sections`, `proofStrategy`) and `annotations.json` name several axioms that do not exist anywhere in `proofs/Proofs/Erdos1042Problem.lean`: `disc_transfinite_diameter`, `interval_transfinite_diameter`, `ehp_disc_result`, `roots_of_unity_example`, `transfiniteDiameter_nonneg`, `ghosh_ramachandran_small_connected`. In the source these are all plain (non-declaration) comments — the corresponding named axioms were never written. `proofStrategy` also claimed `numComponents`/`maxComponents` are axiomatized (they are ordinary `def`s via `Nat.card`/`sSup`) and that all three GR theorems are stated as axioms (only two are; the d ≤ 1/4 single-component result is comment-only).

## Evidence

**meta.json claims**: `originalContributions` listed "disc_transfinite_diameter and interval_transfinite_diameter axioms" and "ehp_disc_result and roots_of_unity_example axioms (1958)"; `sections[gr-solution].summary` said "Three main GR theorems"; `annotations.json` `ann-e1042-gr-solution` said "Three axioms capturing the complete 2024 solution" including `ghosh_ramachandran_small_connected`.

**Lean file shows**: only 3 real `axiom` declarations exist — `transfiniteDiameter`, `ghosh_ramachandran_small_diameter`, `ghosh_ramachandran_diameter_one_examples` (matches top-level `axiomCount: 3`, which was already correct). None of the phantom names above appear anywhere in `proofs/Proofs/` (repo-wide grep, zero hits). The disc/interval/EHP/small-connected content exists only as stripped `/-  ... -/` comments with no attached identifier.

## Fix Applied

Rewrote the affected `originalContributions`, `sections[].summary`/`mathContext`, `proofStrategy` fields in `meta.json`, and the `content` fields in `annotations.json`, to state plainly which results are formalized as axioms/definitions versus discussed only in comments. Top-level `axiomCount`/`sorries`/`theoremCount`/`definitionCount` were already accurate — no change needed there.

---
Discovered during gallery integrity audit (reserve-mode re-verification; 4 prior audits of this entry were marked clean but only checked top-level counts, missing the phantom names buried in narrative fields).