### PR TITLE
Research: erdos-1039-oq-05 - blockers rerouted: Hadamard inequality suffices for sharp d = 1

### DIFF
--- a/research/problems/erdos-1039-oq-05/knowledge.md
+++ b/research/problems/erdos-1039-oq-05/knowledge.md
@@ -360,3 +360,40 @@ extremal **upper** bound — DEEP. Parent Erdős #1039 remains OPEN.
 
 ### Files modified
 - `proofs/Proofs/Erdos1039TransfiniteDiameter.lean` (+~215 lines, roots-of-unity section)
+
+## Session 2026-07-22 (researcher-1-9) — ROUTE DISCOVERY: sharp d = 1 needs only Hadamard's inequality, not Fekete–Szegő
+
+**Mode**: assessment of the two blocked routes. **Outcome**: the "DEEP
+Fekete–Szegő / potential theory" assessment for the sharp value d = 1 is
+OVERESTIMATED for the disc. Both blockers reduce to **Hadamard's determinant
+inequality** — elementary linear algebra:
+
+For n points z₁,…,zₙ in the closed unit disc, the Vandermonde matrix V (rows
+(1, zᵢ, …, zᵢⁿ⁻¹)) satisfies
+- |det V| = spreadProduct(z) (Mathlib `Matrix.det_vandermonde` ✓ exists), and
+- Hadamard: |det V|² ≤ ∏ᵢ (row-norm²) = ∏ᵢ Σₖ |zᵢ|²ᵏ ≤ nⁿ (each |zᵢ| ≤ 1).
+
+Hence **spreadProduct ≤ n^{n/2}**, i.e. dₙ ≤ n^{1/(n-1)} — matching the
+formalized roots-of-unity lower bound `transfiniteDiameterN_rootsOfUnity_ge`
+EXACTLY. Consequences: **dₙ = n^{1/(n-1)} exactly** (blocker 2 falls) and,
+since n^{1/(n-1)} → 1 with `one_le_transfiniteDiameter` already proved,
+**d = 1 on the nose** (blocker 1 falls). No potential theory, no Fekete–Szegő.
+
+**Missing ingredient**: Hadamard's inequality is NOT in Mathlib (checked: only
+Hadamard product/matrices; no `det ≤ ∏ row norms`, no PosSemidef
+`det ≤ ∏ diag`). Formalization plan (2 sessions):
+1. **Hadamard via Gram**: for A : Matrix (Fin n) (Fin n) ℂ,
+   |det A|² = det (A * Aᴴ) and PSD G := A * Aᴴ has det G ≤ ∏ diag G.
+   The PSD lemma by induction via Schur complement, or directly via
+   Gram–Schmidt: det A = det of orthogonalized rows × unit triangular, and
+   ‖orthogonalized rowᵢ‖ ≤ ‖rowᵢ‖ (Mathlib has `gramSchmidt` +
+   `gramSchmidt_orthogonal` in Analysis.InnerProductSpace.GramSchmidtOrtho —
+   the determinant link needs building). Mathlib-general, upstream-worthy.
+2. **Apply**: row norm² = Σ_{k<n} |zᵢ|²ᵏ ≤ n; chain with det_vandermonde and
+   the existing rpow algebra (`discreteDiameter_rootConfig` pattern) to get
+   dₙ = n^{1/(n-1)} and d = 1.
+
+This mirrors today's pattern on erdos-85 (f(9), f(10)): "deep" blockers
+repeatedly turn out to have elementary mechanisms. Blocker reopen criteria are
+hereby met (materially new mechanism identified: Hadamard/Gram, not
+potential theory).

--- a/src/data/research/problems/erdos-1039-oq-05.json
+++ b/src/data/research/problems/erdos-1039-oq-05.json
@@ -35,13 +35,13 @@
     "focus": "Iteration 5: elementary lower-bound program COMPLETE. General bound dₙ ≥ n^{1/(n-1)} (roots of unity, #40737) + transformation laws (#40759) + d ∈ [1,2] (transfiniteDiameter_mem_Icc_one_two) all merged, 0-axiom. This session added tendsto_rootsOfUnity_lowerBound_one: (m+2)^{1/(m+1)} → 1, certifying the elementary root-of-unity lower bound is asymptotically sharp (saturates exactly at log-capacity 1). Erdos1039TransfiniteDiameter.lean now ~1150 lines, 0 axioms/sorries.",
     "blockers": [
       {
-        "route": "sharp value d = 1 (log-capacity of unit disc) via Fekete–Szegő / potential theory",
-        "reopenCriterion": "materially new Mathlib potential-theory API required",
+        "route": "sharp value d = 1 — REROUTED 2026-07-22: needs only Hadamard determinant inequality (missing from Mathlib), NOT Fekete-Szego; 2-session formalization plan in knowledge.md",
+        "reopenCriterion": "open for formalization — elementary mechanism identified (Hadamard via Gram/Gram-Schmidt)",
         "blockedAt": "2026-07-20"
       },
       {
-        "route": "exact dₙ = n^{1/(n-1)} for n ≥ 3 via the extremal (upper) bound that n-th roots of unity maximise the spread product",
-        "reopenCriterion": "materially new Mathlib potential-theory / Fekete–Szegő extremality API required",
+        "route": "exact d_n = n^{1/(n-1)} — REROUTED 2026-07-22: same Hadamard route as d = 1 (upper bound spreadProduct <= n^{n/2}); falls with it",
+        "reopenCriterion": "open for formalization — elementary mechanism identified",
         "blockedAt": "2026-07-21"
       }
     ],
@@ -53,7 +53,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Elementary transfinite-diameter (Fekete-points) program for the unit-disc capacity is COMPLETE and 0-axiom: discrete spread product, Fekete monotonicity + monotone-limit structure, exact d2=2, lower bounds d3>=sqrt3 / d4>=4^(1/3) / general dn>=n^(1/(n-1)) via roots of unity, d in [1,2], and asymptotic sharpness ->1. Only the DEEP sharp value d=1 (Fekete-Szego / logarithmic capacity) and the parent conjecture rho(f)>>1/n remain, both out of the elementary scope.",
+    "progressSummary": "Elementary transfinite-diameter (Fekete-points) program for the unit-disc capacity is COMPLETE and 0-axiom: discrete spread product, Fekete monotonicity + monotone-limit structure, exact d2=2, lower bounds d3>=sqrt3 / d4>=4^(1/3) / general dn>=n^(1/(n-1)) via roots of unity, d in [1,2], and asymptotic sharpness ->1. Only the DEEP sharp value d=1 (Fekete-Szego / logarithmic capacity) and the parent conjecture rho(f)>>1/n remain, both out of the elementary scope. UPDATE 2026-07-22 (researcher-1-9): both blockers REROUTED — Hadamard determinant inequality (elementary, missing from Mathlib) suffices for spreadProduct <= n^{n/2}, hence exact d_n = n^{1/(n-1)} AND sharp d = 1; Fekete-Szego never needed for the disc. 2-session formalization plan recorded.",
     "builtItems": [
       "Erdos1039TransfiniteDiameter.spreadProduct: the Vandermonde spread ∏_{i<j}‖zᵢ-zⱼ‖ (finite-n numerator of the transfinite diameter).",
       "Erdos1039TransfiniteDiameter.discreteDiameter: the n-point diameter dₙ(Z) = spreadProduct^{2/(n(n-1))}, the finite-n truncation of the transfinite diameter.",
@@ -104,7 +104,9 @@
       "GENERAL lower bound d_n >= n^(1/(n-1)) now PROVED (0-axiom) via the n-th roots of unity, generalising the exact terms d2=2, d3>=sqrt3, d4>=4^(1/3): transfiniteDiameterN_rootsOfUnity_ge (m) : (m+2)^(1/(m+1)) <= transfiniteDiameterN (m+2).",
       "Consequence one_le_transfiniteDiameter : 1 <= transfiniteDiameter (each d_{n+2} >= (n+2)^(1/(n+1)) >= 1, so the infimum is >= 1); with d<=2 this pins d in [1,2] (transfiniteDiameter_mem_Icc_one_two). Sharp d=1 (log capacity of the disc) still needs Fekete-Szego upper bound.",
       "Vandermonde-discriminant identity spreadProduct(roots of unity)^2 = n^n proved via: (a) per-index prod_{j!=i} ||zeta^i - zeta^j|| = n by translating j->j-i and pulling out the unit zeta^i, reducing to prod_{k=1}^{n-1}||1-zeta^k|| = |prod (1-zeta^k)| = |n| = n (IsPrimitiveRoot.prod_one_sub_pow_eq_order); (b) multiplying over n indices gives the ORDERED off-diagonal product n^n = (spreadProduct)^2 (lower/upper triangles equal by norm_sub_rev + Finset.prod_comm).",
-      "The discrete diameter transforms like a length: scaling covariance dₙ(cZ)=‖c‖·dₙ(Z) and translation invariance dₙ(Z+c)=dₙ(Z), general over all n and all configurations, 0-axiom — the finite-n shadows of cap(cK+a)=‖c‖·cap(K), explaining why the transfinite diameter of a disc of radius R (centred anywhere) is R."
+      "The discrete diameter transforms like a length: scaling covariance dₙ(cZ)=‖c‖·dₙ(Z) and translation invariance dₙ(Z+c)=dₙ(Z), general over all n and all configurations, 0-axiom — the finite-n shadows of cap(cK+a)=‖c‖·cap(K), explaining why the transfinite diameter of a disc of radius R (centred anywhere) is R.",
+      "Sharp d = 1 for the disc does NOT need Fekete-Szego/potential theory: Hadamard determinant inequality on the Vandermonde matrix gives spreadProduct <= n^{n/2}, matching the proved roots-of-unity lower bound exactly — d_n = n^{1/(n-1)} and d = 1 both follow; only missing Mathlib piece is Hadamard itself (2-session plan recorded)",
+      "Mathlib gap: no Hadamard inequality, no PosSemidef det <= prod diag (checked 2026-07-22); Matrix.det_vandermonde and gramSchmidt exist as building blocks"
     ],
     "mathlibGaps": [
       "Mathlib has no transfinite-diameter / logarithmic-capacity API; the n-point spread and its diameter had to be defined from scratch (done here). The limit d(Z)=limₙ dₙ and Fekete monotonicity are still absent.",


### PR DESCRIPTION
## Summary
Research session for erdos-1039-oq-05 (transfinite diameter of the unit disc). Route discovery: **both registered blockers reduce to Hadamard's determinant inequality** — the "deep Fekete–Szegő / potential theory" assessment for the sharp value d = 1 is overestimated for the disc.

## Findings
- Hadamard applied to the Vandermonde matrix of n points in the closed disc gives |det V|² ≤ ∏ᵢ Σₖ|zᵢ|²ᵏ ≤ nⁿ, i.e. **spreadProduct ≤ n^{n/2}** — matching the already-formalized roots-of-unity lower bound (`transfiniteDiameterN_rootsOfUnity_ge`) exactly. Hence dₙ = n^{1/(n−1)} exactly, and with the proved `one_le_transfiniteDiameter` and n^{1/(n−1)} → 1, **d = 1 on the nose**. No potential theory needed.
- The missing ingredient is Hadamard's inequality itself: checked absent from Mathlib (only the Hadamard *product* exists; no `det ≤ ∏ row norms`, no PosSemidef `det ≤ ∏ diag`). `Matrix.det_vandermonde` and `gramSchmidt` exist as building blocks.
- A concrete 2-session formalization plan is recorded in knowledge.md (Hadamard via Gram/Gram–Schmidt — Mathlib-general and upstream-worthy; then the application chain).

This mirrors today's pattern on erdos-85 (f(9), f(10)): "deep" blockers repeatedly turn out to have elementary mechanisms.

## Progress
- Knowledge + tracker updated; both blocker entries rerouted with reopen criteria met (materially new mechanism identified). No Lean changes this session.

## Status
**Outcome**: surveyed (route discovery)
**Next Steps**: session 1 — formalize Hadamard's inequality; session 2 — apply to Vandermonde, close dₙ = n^{1/(n−1)} and d = 1.

🤖 Generated by researcher-1