### PR TITLE
Enrich erdos-430: cover header docstring (lines 1-15)

### DIFF
--- a/src/data/proofs/erdos-430/annotations.json
+++ b/src/data/proofs/erdos-430/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "erdos-430-ann-header",
+    "proofId": "erdos-430",
+    "range": {
+      "startLine": 1,
+      "endLine": 15
+    },
+    "type": "context",
+    "title": "Erdős #430: Composite Numbers in Greedy Large-Factor Sequences",
+    "content": "The file header states Erdős Problem #430 in full: starting from $a_1 = n-1$, repeatedly take the greatest integer below the previous term whose every prime factor exceeds the current gap to $n$. Selfridge's computations suggest the resulting sequence always eventually contains a composite for $n$ large enough, but no proof is known. The header also records Sarosh Adenwalla's observation that #430 is equivalent to the first part of Erdős Problem #385 — the file later proves this equivalence (`erdos_385_equivalence`) and axiomatizes only the genuinely open pieces (`erdos_430_conjecture`, `small_n_all_prime`).",
+    "mathContext": "Greedy sequence: $a_1 = n-1$, $a_{k+1} = \\max\\{m \\in [1,a_k) : \\forall p \\mid m,\\, p \\text{ prime} \\Rightarrow p > n-m\\}$, terminating at $0$. Open question: does $\\exists N_0,\\, \\forall n \\geq N_0$, some nonzero $a_k$ composite?",
+    "significance": "context",
+    "relatedConcepts": [
+      "Erdős Problem #430",
+      "Erdős Problem #385 equivalence",
+      "Selfridge computations",
+      "rough (prime-factor-bounded) numbers"
+    ],
+    "prerequisites": [
+      "prime factorization",
+      "greedy sequence construction"
+    ]
+  },
+  {
     "id": "erdos-430-ann-imports",
     "proofId": "erdos-430",
     "range": {


### PR DESCRIPTION
## Summary
- `erdos-430`'s Lean file header (lines 1-15) — the full problem statement, greedy-sequence definition, Selfridge computational context, and the Adenwalla #385-equivalence note — had zero annotation or section coverage; the first existing annotation/section started at line 18 (imports).
- Adds one `context`-type annotation covering lines 1-15 summarizing the problem statement and pointing to the equivalence proof (`erdos_385_equivalence`) and the two remaining axiomatized claims (`erdos_430_conjecture`, `small_n_all_prime`) that the rest of the file already documents.

## Test plan
- [x] Validated `annotations.json` is well-formed JSON
- [x] `pnpm build` data-generation steps (enrichment, search index, loading-facts, redirects) ran clean over this file; unrelated `tsc: command not found` failure is a pre-existing worktree environment gap, not caused by this change
- [x] Verified no drift vs `origin/main` for the Lean source before annotating