### PR TITLE
Enrich compactness-finite-subcover-oq-01-oq-02-oq-01: cover theorem statement gap

### DIFF
--- a/src/data/proofs/compactness-finite-subcover-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-01-oq-02-oq-01/annotations.json
@@ -12,6 +12,18 @@
     "prerequisites": ["real analysis", "suprema/infima", "limits"]
   },
   {
+    "id": "ann-theorem-statement",
+    "proofId": "compactness-finite-subcover-oq-01-oq-02-oq-01",
+    "range": { "startLine": 29, "endLine": 45 },
+    "type": "definition",
+    "title": "Formalizing 'Nested, Shrinking, Complete' as Lean Hypotheses",
+    "content": "The docstring's prose is turned into exactly four hypotheses: `Monotone a` and `Antitone b` encode 'nested' (each interval contains the next), `∀ n, a n ≤ b n` rules out an interval being empty, and `Tendsto (fun n => b n - a n) atTop (𝓝 0)` encodes 'shrinking'. No compactness or completeness hypothesis is stated explicitly — it is silently supplied by `ℝ` itself, since the proof only ever needs a conditional supremum to exist, which every `BddAbove` set of reals has. The conclusion packages both existence and uniqueness into one equation, `⋂ n, Icc (a n) (b n) = {⨆ n, a n}`, rather than the more common two-step 'is nonempty, and is a singleton'.",
+    "mathContext": "Hypotheses: $a\\nearrow$, $b\\searrow$, $a_n\\le b_n\\ \\forall n$, $b_n-a_n\\to 0$. Conclusion: $\\bigcap_n [a_n,b_n]=\\{\\sup_n a_n\\}$ in one equation.",
+    "significance": "technical",
+    "relatedConcepts": ["Monotone", "Antitone", "Tendsto", "conditional completeness of ℝ", "iInter as Icc"],
+    "prerequisites": ["order relations on sequences", "filters and limits"]
+  },
+  {
     "id": "ann-cross-bound",
     "proofId": "compactness-finite-subcover-oq-01-oq-02-oq-01",
     "range": { "startLine": 46, "endLine": 58 },


### PR DESCRIPTION
Adds an annotation for lines 29-45 of `CompactnessFiniteSubcoverOq01Oq02Oq01.lean` — the `open`/`namespace` lines and the main theorem's docstring — which were previously uncovered by any annotation (existing annotations jumped from line 28 straight to line 46, the start of the proof body). All other quality targets for this entry were already met (5 annotations w/ mathContext, historicalContext, keyInsights, conclusion, sections all within size caps).