### PR TITLE
Audit: erdos-1041 clean (reserve)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9268,9 +9268,9 @@
       "result": "clean"
     },
     "erdos-1041": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:27Z",
+      "lastAudited": "2026-07-22T23:06:27Z",
       "result": "clean"
     },
     "erdos-1042": {


### PR DESCRIPTION
## Audit result

Re-verified `erdos-1041` (Erdős Problem #1041: Paths in Polynomial Level Sets) in reserve mode (queue fully drained, 4810/4810 audited).

**Checked**: sorries (0, matches), axioms (0, matches), theoremCount (6, matches), definitionCount (5, matches — 4 defs + 1 structure per repo convention), no True stubs, no native_decide, no phantom axiom/theorem names in prose or annotations vs actual declarations, `status: "axiomatized"` + `axiomCount: 0` is the established repo convention for an honestly-disclosed open conjecture (not axiomatized as a bare Prop or unsound axiom). Main OPEN conjecture is correctly left undeclared (no axiom, no theorem) — only discussed in comments/prose, consistent with badge `wip`.

5th audit of this file, clean each time.

---
Discovered during gallery integrity audit (reserve mode).