### PR TITLE
audit(a054656): fix invalid badge "formalized" -> "wip"

### DIFF
--- a/src/data/proofs/a054656-distinct-prime-partition/meta.json
+++ b/src/data/proofs/a054656-distinct-prime-partition/meta.json
@@ -18,7 +18,7 @@
     "date": "2026-07-22",
     "dateAdded": "2026-07-22",
     "status": "formalized",
-    "badge": "formalized",
+    "badge": "wip",
     "proofRepoPath": "Proofs/A054656DistinctPrimePartition.lean",
     "sorries": 4,
     "axiomCount": 0,

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31898,6 +31898,12 @@
       "lastAudited": "2026-07-22T20:19:43Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "a054656-distinct-prime-partition": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-22T23:13:19Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Audit result

Audited `a054656-distinct-prime-partition` (brand-new entry from #42095/#41831). The file itself is exemplary — module doc clearly separates VERIFIED (0 sorries, kernel `decide` only) from SCAFFOLDED (4 disclosed sorries), and all meta counts match exactly:

- `leanFile`/`meta` counts (sorries:4, axiomCount:0, theoremCount:11, definitionCount:4) all match the actual `.lean` file.
- No native_decide, no True stubs, no phantom axiom/theorem names.
- `conclusion` is honest: "the full theorem is not yet verified. Status is honestly `formalized` (4 sorries remain)."

**One issue found and fixed**: `meta.badge` was `"formalized"`, which is not a member of the `ProofBadge` union (`src/types/proof.ts`), so the gallery rendered no category badge at all for this entry. Since the file has 4 sorries, the correct badge per taxonomy is `wip`. Fixed inline.

This is a one-off instance of a much larger systemic pattern — see #42103 for the other 449 entries using invalid `badge` values (`verified`/`synthesis`).

---
Discovered during gallery integrity audit.