### PR TITLE
Research: annotations for A054656 gallery entry (issue #41831)

### DIFF
--- a/src/data/proofs/a054656-distinct-prime-partition/annotations.json
+++ b/src/data/proofs/a054656-distinct-prime-partition/annotations.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "ann-a054656-overview",
+    "proofId": "a054656-distinct-prime-partition",
+    "range": { "startLine": 1, "endLine": 45 },
+    "type": "concept",
+    "title": "A054656 and what this first iteration machine-checks",
+    "content": "OEIS A054656 (created April 2000, still labeled conjectural) counts, for each n, the primes p ≤ n that occur in NO partition of n into distinct primes. The claimed theorem: for every n ≥ 23 that absent set is exactly {n−1, n−4, n−6} ∩ P. The pivot is that a prime p ≤ n occurs in some distinct-prime partition of n iff the residual m = n − p is itself a sum of distinct primes avoiding p, and the only non-representable residuals are m ∈ {1, 4, 6}. This file turns the elementary core of an AI-claimed proof (GPT-5.6 Pro, GitHub issue #41831) into machine-checked Lean and scaffolds the harder representability engine behind clearly-marked `sorry`s. Status is honestly `formalized` — the elementary core is verified, the full theorem is not.",
+    "significance": "critical",
+    "relatedConcepts": ["distinct-prime partitions", "additive number theory", "OEIS A054656"]
+  },
+  {
+    "id": "ann-a054656-encoding",
+    "proofId": "a054656-distinct-prime-partition",
+    "range": { "startLine": 53, "endLine": 69 },
+    "type": "definition",
+    "title": "Encoding distinct-prime sums as Finsets of primes",
+    "content": "A distinct-prime representation of m is modelled as a `Finset` of primes summing to m: `Repr m` asserts such a set exists, and `ReprAvoiding m avoid` additionally forbids one prime. Using a `Finset` makes distinctness automatic — elements are unique by construction, so no side condition is needed. `Present p n` says p lies in some distinct-prime partition of n, and `D n = {p | p prime, p ≤ n, ¬ Present p n}` is precisely the set whose cardinality is A054656(n). These four definitions fix the vocabulary the whole development rests on.",
+    "significance": "key",
+    "mathContext": "Repr m := ∃ S : Finset ℕ, (∀ q ∈ S, Nat.Prime q) ∧ S.sum id = m",
+    "relatedConcepts": ["Finset", "sum of distinct primes"]
+  },
+  {
+    "id": "ann-a054656-exceptional-residuals",
+    "proofId": "a054656-distinct-prime-partition",
+    "range": { "startLine": 85, "endLine": 136 },
+    "type": "lemma",
+    "title": "The three exceptional residuals 1, 4, 6 (fully verified, kernel `decide`)",
+    "content": "These are the tractable, machine-checked wins: 1, 4 and 6 admit NO distinct-prime representation. The proof pattern is uniform — every summand p of a set summing to m satisfies p ≤ m (via `Finset.single_le_sum`, since all summands are nonnegative), so the representing set is a subset of the primes ≤ m; `fin_cases` over that finite powerset and kernel `decide` then close each case. Because only `decide` is used (never `native_decide`), these lemmas carry no `Lean.ofReduceBool` dependency and are genuinely axiom-free. `not_reprAvoiding_of_mem_exceptional` packages all three for use in the main assembly.",
+    "significance": "critical",
+    "mathContext": "1 is below the smallest prime; no subset of {2,3} sums to 4; no subset of {2,3,5} sums to 6.",
+    "prerequisites": ["Finset.single_le_sum", "fin_cases", "decide"]
+  },
+  {
+    "id": "ann-a054656-reduction",
+    "proofId": "a054656-distinct-prime-partition",
+    "range": { "startLine": 138, "endLine": 169 },
+    "type": "theorem",
+    "title": "The reduction lemma — the verified pivot the whole proof turns on",
+    "content": "`present_iff_residual_repr`: p occurs in a distinct-prime partition of n ⇔ p is a prime ≤ n AND the residual n − p is a sum of distinct primes avoiding p. Forward direction removes p from a partition containing it (`Finset.add_sum_erase`, so the remaining primes sum to n − p and p is no longer among them); the reverse inserts p back (`Finset.sum_insert`, valid because p was avoided). This fully-elementary equivalence is what converts the whole question into 'which residuals are representable', reducing A054656 to the arithmetic of representable integers. Both directions are proven with zero sorries.",
+    "significance": "critical",
+    "prerequisites": ["Finset.add_sum_erase", "Finset.sum_insert"],
+    "relatedConcepts": ["reduction to residual representability"]
+  },
+  {
+    "id": "ann-a054656-engine-deferred",
+    "proofId": "a054656-distinct-prime-partition",
+    "range": { "startLine": 171, "endLine": 226 },
+    "type": "warning",
+    "title": "The representability engine and the Mathlib gap (DEFERRED — 4 sorries)",
+    "content": "The heavy lifting is scaffolded but not yet proven: `seed_block` (a run of ≥ 64 consecutive representable residuals, an enumeration over the ≤ 2⁹ subsets of the nine primes ≤ 23), `interval_extension` (extend a covered interval by an unused prime q ≤ B−A+1), `repr_of_ge_seven_ne` (every non-exceptional residual is representable avoiding one forbidden prime), and `A054656_main` (the final theorem for n ≥ 23). The key missing ingredient is a Ramanujan-prime fact: '(q, 2q] contains at least TWO primes' (R₂ = 11), so that after deleting the single forbidden prime an available prime ≤ 2q still remains. Mathlib HAS Bertrand's postulate (`Nat.exists_prime_lt_and_le_two_mul`) but NOT this two-primes strengthening — it must be built on top of Bertrand. That is the concrete next lemma for continuing this entry.",
+    "significance": "key",
+    "prerequisites": ["Nat.exists_prime_lt_and_le_two_mul"],
+    "relatedConcepts": ["Bertrand's postulate", "Ramanujan primes", "interval-covering induction"]
+  }
+]


### PR DESCRIPTION
## Complete the A054656 gallery entry with annotations

The A054656 entry (Lean proof + meta.json, merged in #42095) was the **only gallery entry of 4811 without `annotations.json`**, so it would render as a bare page with no proof walkthrough. This adds a 5-annotation walkthrough anchored to the real declarations in `proofs/Proofs/A054656DistinctPrimePartition.lean`:

1. **Overview** (lines 1–45) — the A054656 conjecture, and what this first iteration machine-checks vs. defers.
2. **Encoding** (lines 53–69) — distinct-prime sums as `Finset`s of primes (`Repr` / `ReprAvoiding` / `Present` / `D`).
3. **Exceptional residuals** (lines 85–136) — 1, 4, 6 are not sums of distinct primes; verified with kernel `decide` (axiom-free, no `native_decide`).
4. **Reduction pivot** (lines 138–169) — `present_iff_residual_repr`, both directions verified.
5. **Deferred engine + Mathlib gap** (lines 171–226) — the 4 `sorry`s and the precise missing ingredient: a Ramanujan "two primes in (q,2q]" lemma to be built on Mathlib's Bertrand (`Nat.exists_prime_lt_and_le_two_mul`).

**Data-only** — no Lean source change; the proof already builds (independently Docker-verified, 4 expected `sorry` warnings). Entry status stays `formalized` / badge `wip` (set by auditor #42104). Validated: valid JSON, all ranges within the 228-line file, correct `type`/`significance` enums, unique ids.

Part of #41831.
