### PR TITLE
Fix: remap 452 invalid badge values to valid ProofBadge tiers (#42103)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-01/meta.json
@@ -19,7 +19,7 @@
       "research",
       "extension"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 245,

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-04/meta.json
@@ -20,7 +20,7 @@
       "abel-ruffini"
     ],
     "proofRepoPath": "Proofs/AbelRuffiniOQ04OQ02OQ04.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 literal `axiom` declarations and 0 sorries. Every result depends only on the foundational axioms propext, Classical.choice, Quot.sound (not counted), as confirmed by `#print axioms` on isSolvable and S5_not_isSolvable_but_dihedral_is. No `native_decide` is used (the `decide` calls are kernel-evaluated on finite ZMod 2 / Fin 5 data), so `Lean.ofReduceBool` is NOT introduced. Built on Mathlib's `DihedralGroup`, `solvable_of_ker_le_range`, and `Equiv.Perm.fin_5_not_solvable`.",

--- a/src/data/proofs/abel-ruffini-oq-06-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-06-oq-01/meta.json
@@ -21,7 +21,7 @@
       "metabelian",
       "solvability-by-radicals"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 105,

--- a/src/data/proofs/abel-ruffini-oq-07-discriminant-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-07-discriminant-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
       "finset-product",
       "abel-ruffini"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "This file records structural properties of the difference product δ = diffProd r and the discriminant disc r = δ² over an arbitrary commutative ring R (the separability criterion additionally assumes R is an integral domain, and uses Matrix.det_vandermonde_ne_zero_iff). No further hypotheses are imposed: symmetry, antisymmetry under transposition, translation invariance, and the discriminant–derivative formula hold for every finite family r : Fin n → R. Every theorem is fully machine-checked with 0 sorries and 0 axioms (only propext, Classical.choice, Quot.sound; no native_decide, no Lean.ofReduceBool).",

--- a/src/data/proofs/abel-ruffini-oq-07-discriminant-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-07-discriminant-oq-01/meta.json
@@ -19,7 +19,7 @@
       "vandermonde",
       "abel-ruffini"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "This file formalizes the general discriminant criterion 'Gal ⊆ Aₙ ⟺ disc is a square in the base field' for a finite Galois extension E/F whose Galois group permutes a distinguished family r : Fin n → E of distinct elements (a genuine hypothesis hperm, satisfied by the roots of a separable polynomial split by E). The central theorem disc_isSquare_iff_gal_le_alternating takes as hypotheses: injectivity of r (distinct roots), 2 ≠ 0 in E (characteristic ≠ 2, needed so that δ = −δ forces δ = 0), and that the Galois group permutes r. These are structural setup, not axioms. The Galois-descent step invokes Mathlib's IsGalois.mem_range_algebraMap_iff_fixed (requires [FiniteDimensional F E] [IsGalois F E]). Every theorem is fully machine-checked with 0 sorries and 0 axioms (only propext, Classical.choice, Quot.sound; no native_decide, no Lean.ofReduceBool).",

--- a/src/data/proofs/abel-ruffini-oq-07-discriminant/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-07-discriminant/meta.json
@@ -20,7 +20,7 @@
       "jordan-theorem",
       "quintic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "This file proves the DISCRIMINANT-ROUTE group-theoretic reduction of Gal(X⁵−X−1) ≅ S₅. The assembler gal_eq_top_of_transitive_threeCycle_odd takes three hypotheses: (i) the Galois action is transitive on the 5 roots (from irreducibility, Selmer 1956); (ii) Gal contains a 3-cycle (from 3 ∣ |Gal|); (iii) Gal contains an odd permutation (from Δ = 2869 not being a square, formalized as disc_not_square). It concludes Gal = ⊤ = S₅ via Mathlib's Jordan theorem (alternatingGroup_le_of_isPreprimitive_of_isThreeCycle_mem) plus the index-2 maximality of the alternating group. All three inputs are explicit HYPOTHESES, not axioms: the bridges that produce them in full generality — the Dedekind–Frobenius cycle-type theorem and the discriminant criterion 'Gal ⊆ A_n ⟺ disc is a square' — are not present in Mathlib v4.26.0. Every theorem in this file is fully machine-checked with 0 sorries and 0 axioms (only propext, Classical.choice, Quot.sound; disc_not_square uses decide, NOT native_decide, so no Lean.ofReduceBool).",

--- a/src/data/proofs/abel-ruffini-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-07/meta.json
@@ -18,7 +18,7 @@
       "abel-ruffini",
       "frobenius"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "This file proves the group-theoretic REDUCTION of Gal(X⁵−X−1) ≅ S₅. The order-divisibility input 5 ∣ |Gal| is now fully discharged with NO assumptions: five_dvd_card_gal derives it for the genuine Galois group f.Gal from Irreducible f (via Polynomial.Gal.prime_degree_dvd_card), and f_irreducible supplies Irreducible f directly from Mathlib's Selmer theorem Polynomial.X_pow_sub_X_sub_one_irreducible_rat — so five_dvd_card_gal_unconditional : 5 ∣ Nat.card f.Gal holds unconditionally, axiom-free and sorry-free. The SOLE remaining hypothesis is the existence of a transposition in Gal (from the order-6 Frobenius at p=2), exposed as an explicit hypothesis of gal_eq_top_of_five_dvd_and_swap, NOT an axiom. Supplying it in Lean requires the Dedekind–Frobenius bridge (factor type mod an unramified prime ⟹ a Frobenius element of matching cycle type in f.Gal), which Mathlib v4.26.0 does not provide; it is the same open bridge InverseGaloisA5.lean axiomatises as three_dvd_gal_card. All theorems in this file are fully machine-checked with 0 sorries and 0 axioms.",

--- a/src/data/proofs/abel-ruffini-oq014/meta.json
+++ b/src/data/proofs/abel-ruffini-oq014/meta.json
@@ -22,7 +22,7 @@
       "abel-ruffini"
     ],
     "proofRepoPath": "Proofs/AbelRuffiniOQ04OQ02OQ04OQ03.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 literal `axiom` declarations and 0 sorries. `#print axioms` on derivedSeries_two_eq_bot_of_metabelian, isSolvable_of_metacyclic, and derivedSeries_two_eq_bot_of_metacyclic reports only the foundational axioms propext, Classical.choice, Quot.sound (not counted). No `native_decide` and no `decide`, so `Lean.ofReduceBool` is NOT introduced. Built on Mathlib's derived series API (map_derivedSeries_eq, commutator_eq_bot_iff_le_centralizer, QuotientGroup.ker_mk') and IsCyclic.commGroup.",

--- a/src/data/proofs/abundant-number-oq-01/meta.json
+++ b/src/data/proofs/abundant-number-oq-01/meta.json
@@ -9,7 +9,7 @@
     "date": "Antiquity (Nicomachus, ~100 CE); OEIS A005101",
     "status": "verified",
     "proofRepoPath": "Proofs/AbundantMultiplesOQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "tags": [
       "number-theory",
       "divisor-sum",

--- a/src/data/proofs/abundant-number-oq-02-oq-01/meta.json
+++ b/src/data/proofs/abundant-number-oq-02-oq-01/meta.json
@@ -9,7 +9,7 @@
     "date": "Classical; OEIS A005231 (odd abundant numbers), A047802 (least abundant coprime to first k primes)",
     "status": "verified",
     "proofRepoPath": "Proofs/AbundantNumberOQ02OQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "tags": [
       "number-theory",
       "divisor-sum",

--- a/src/data/proofs/abundant-number-oq-02/meta.json
+++ b/src/data/proofs/abundant-number-oq-02/meta.json
@@ -9,7 +9,7 @@
     "date": "Classical; OEIS A005231 (odd abundant numbers), smallest 945",
     "status": "verified",
     "proofRepoPath": "Proofs/AbundantNumberOQ02.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "tags": [
       "number-theory",
       "divisor-sum",

--- a/src/data/proofs/abundant-number-oq-03-oq-01-oq-03/meta.json
+++ b/src/data/proofs/abundant-number-oq-03-oq-01-oq-03/meta.json
@@ -9,7 +9,7 @@
   "date": "Classical; OEIS A005231 (odd abundant numbers)",
   "status": "verified",
   "proofRepoPath": "Proofs/AbundantOddDensityOQ030103.lean",
-  "badge": "verified",
+  "badge": "mathlib",
   "tags": [
    "number-theory",
    "divisor-sum",

--- a/src/data/proofs/abundant-number-oq-03-oq-01/meta.json
+++ b/src/data/proofs/abundant-number-oq-03-oq-01/meta.json
@@ -9,7 +9,7 @@
     "date": "Classical; OEIS A005231 (odd abundant numbers)",
     "status": "verified",
     "proofRepoPath": "Proofs/AbundantOddDensityOQ0301.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "tags": [
       "number-theory",
       "divisor-sum",

--- a/src/data/proofs/abundant-number-oq-03-oq-02/meta.json
+++ b/src/data/proofs/abundant-number-oq-03-oq-02/meta.json
@@ -9,7 +9,7 @@
     "date": "Classical; OEIS A005231 (odd abundant numbers)",
     "status": "verified",
     "proofRepoPath": "Proofs/AbundantOddCountingOQ0302.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "tags": [
       "number-theory",
       "divisor-sum",

--- a/src/data/proofs/abundant-number-oq-03/meta.json
+++ b/src/data/proofs/abundant-number-oq-03/meta.json
@@ -9,7 +9,7 @@
     "date": "Classical; OEIS A005231 (odd abundant numbers)",
     "status": "verified",
     "proofRepoPath": "Proofs/AbundantOddInfiniteOQ03.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "tags": [
       "number-theory",
       "divisor-sum",

--- a/src/data/proofs/abundant-number-oq-04/meta.json
+++ b/src/data/proofs/abundant-number-oq-04/meta.json
@@ -9,7 +9,7 @@
     "date": "Classical; OEIS A005100 (deficient numbers), A000396 (perfect numbers)",
     "status": "verified",
     "proofRepoPath": "Proofs/AbundantDeficientDvdOQ04.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "tags": [
       "number-theory",
       "divisor-sum",

--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
@@ -19,7 +19,7 @@
       "research",
       "seeker-selected"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 1080,

--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-05/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-05/meta.json
@@ -175,7 +175,7 @@
   ],
   "meta": {
     "status": "verified",
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 3,

--- a/src/data/proofs/alternating-series-boole-summation-oq-01/meta.json
+++ b/src/data/proofs/alternating-series-boole-summation-oq-01/meta.json
@@ -18,7 +18,7 @@
       "limits",
       "convergence"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 163,

--- a/src/data/proofs/alternating-series-boole-summation-oq-03-oq-01/meta.json
+++ b/src/data/proofs/alternating-series-boole-summation-oq-03-oq-01/meta.json
@@ -21,7 +21,7 @@
       "geometric-series",
       "closed-form"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 143,

--- a/src/data/proofs/alternating-series-boole-summation-oq-03/meta.json
+++ b/src/data/proofs/alternating-series-boole-summation-oq-03/meta.json
@@ -19,7 +19,7 @@
       "closed-form",
       "polynomial"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 105,

--- a/src/data/proofs/alternating-series-test-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/alternating-series-test-oq-01-oq-02-oq-01/meta.json
@@ -21,7 +21,7 @@
       "two-sided-bound",
       "leibniz-bracket"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-24",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/alternating-series-test-oq-01-oq-02/meta.json
+++ b/src/data/proofs/alternating-series-test-oq-01-oq-02/meta.json
@@ -19,7 +19,7 @@
       "bounded-variation",
       "total-variation"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-24",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-03/meta.json
@@ -21,7 +21,7 @@
       "characteristic-two",
       "mv-polynomial"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "mathlibDependencies": [
       {
         "theorem": "MvPolynomial.aeval_esymm_eq_multiset_esymm",

--- a/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
@@ -16,7 +16,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ03.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [],
     "originalContributions": [

--- a/src/data/proofs/amgm-inequality-oq-05-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-05-oq-01/meta.json
@@ -19,7 +19,7 @@
       "amgm",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 200,

--- a/src/data/proofs/amgm-inequality-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-05/meta.json
@@ -19,7 +19,7 @@
       "amgm",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 111,

--- a/src/data/proofs/amgm-inequality-oq009/meta.json
+++ b/src/data/proofs/amgm-inequality-oq009/meta.json
@@ -19,7 +19,7 @@
       "characteristic-two",
       "mv-polynomial"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "mathlibDependencies": [
       {
         "theorem": "MvPolynomial.psum_eq_mul_esymm_sub_sum",

--- a/src/data/proofs/amgm-inequality-oq010/meta.json
+++ b/src/data/proofs/amgm-inequality-oq010/meta.json
@@ -19,7 +19,7 @@
       "characteristic-two",
       "mv-polynomial"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "mathlibDependencies": [
       {
         "theorem": "MvPolynomial.psum_eq_mul_esymm_sub_sum",

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/meta.json
@@ -19,7 +19,7 @@
       "chebyshev",
       "general-formula"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 388,

--- a/src/data/proofs/angle-trisection-oq-02-oq-03-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03-oq-03/meta.json
@@ -18,7 +18,7 @@
       "primitive-roots",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/angle-trisection-oq-03-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-03/meta.json
@@ -17,7 +17,7 @@
       "number-theory",
       "decidability"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 194,

--- a/src/data/proofs/angle-trisection-oq-05-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-05-oq-04-incomplete-01/meta.json
@@ -19,7 +19,7 @@
       "extension"
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ05OQ04Incomplete01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-01",
     "axiomCount": 0,

--- a/src/data/proofs/angle-trisection-oq001/meta.json
+++ b/src/data/proofs/angle-trisection-oq001/meta.json
@@ -16,7 +16,7 @@
       "separability",
       "characteristic-p"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-05-04",
     "mathlibDependencies": [

--- a/src/data/proofs/angle-trisection-oq007/meta.json
+++ b/src/data/proofs/angle-trisection-oq007/meta.json
@@ -17,7 +17,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ01OQ02OQ02.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 16,

--- a/src/data/proofs/angle-trisection-oq008/meta.json
+++ b/src/data/proofs/angle-trisection-oq008/meta.json
@@ -17,7 +17,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ01OQ02OQ03.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 5,

--- a/src/data/proofs/area-of-circle-oq-03-oq-03-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-03-oq-01/meta.json
@@ -20,7 +20,7 @@
       "method-of-exhaustion",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/area-of-circle-oq-05-incomplete-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-incomplete-01-oq-01-oq-01/meta.json
@@ -44,7 +44,7 @@
     "lineCount": 225,
     "theoremCount": 18,
     "definitionCount": 1,
-    "badge": "verified",
+    "badge": "mathlib",
     "originalContributions": [
       "stdNormal_even_moment_doubleFactorial: ∫ x^{2k} ∂stdNormal = (2k-1)‼ — the general even-moment formula for the standard normal N(0,1), for every k. The grandparent AreaOfCircleOQ05Incomplete01OQ01 evaluated only E[X⁰], E[X¹], E[X²] and explicitly left the general formula open; this entry closes it. The probabilist normalization (E[X^{2k}] = (2k-1)‼, no √π factor) is distinct from the physicist Gaussian-weight sibling area-of-circle-oq-07-oq-05-oq-01 (∫ x^{2n} e^{-x²} = (2n-1)‼√π/2ⁿ), and the method differs entirely: MGF-derivative recursion rather than integration by parts.",
       "stdNormal_odd_moment: ∫ x^{2k+1} ∂stdNormal = 0 — the vanishing of every odd moment, obtained from the same recursion seeded by E[X] = 0 (the ODE gives g'(0) = 0·g(0) = 0). Both open strands — even and odd — fall out of one parity-preserving recursion.",

--- a/src/data/proofs/area-of-circle-oq-07-oq-02-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-02-oq-02/meta.json
@@ -42,7 +42,7 @@
     "lineCount": 164,
     "theoremCount": 8,
     "definitionCount": 0,
-    "badge": "verified",
+    "badge": "mathlib",
     "originalContributions": [
       "first_half_moment: ∫_{(0,∞)} x·e^{-b x²} dx = 1/(2b) for b > 0, evaluated via the explicit primitive -(2b)⁻¹·e^{-b x²} and integral_Ioi_of_hasDerivAt_of_tendsto' — a genuinely non-trivial value, unlike the full-line first moment which vanishes by odd symmetry",
       "second_half_moment: ∫_{(0,∞)} x²·e^{-b x²} dx = √(π/b)/(4b) for b > 0, obtained by a single integration by parts (primitive g(x) = -(2b)⁻¹·x·e^{-b x²}, vanishing at 0 and ∞) that reduces the second moment to (2b)⁻¹ times the parent's zeroth moment √(π/b)/2",

--- a/src/data/proofs/arithmetic-series-oq-04-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-04-oq-03/meta.json
@@ -17,7 +17,7 @@
       "analytic-continuation",
       "arithmetic-series"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 215,

--- a/src/data/proofs/arithmetic-series/meta.json
+++ b/src/data/proofs/arithmetic-series/meta.json
@@ -17,7 +17,7 @@
       "classic",
       "gauss"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/baire-category-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/baire-category-theorem-oq-01-oq-01-oq-01/meta.json
@@ -39,7 +39,7 @@
     "lineCount": 256,
     "theoremCount": 5,
     "definitionCount": 0,
-    "badge": "verified",
+    "badge": "mathlib",
     "originalContributions": [
       "isOpenMap: the Open Mapping Theorem — a surjective bounded linear map T : E →L[𝕜] F between Banach spaces is an open map. Derived from the gallery Baire category theorem (BaireCategoryTheoremOQ01.baire_nonempty_interior), completing the trio of Baire-powered cornerstones of functional analysis alongside the parent's Uniform Boundedness Principle.",
       "exists_approx_preimage_norm_le: the single Baire step of the whole development. The images of the unit balls cover F by a countable union of closed sets closure (T '' ball 0 n); the gallery category theorem hands back one with nonempty interior, and a rescaling shell estimate turns this into: every y is approximated within ‖y‖/2 by the image of an element of norm ≤ C‖y‖. This is the ONLY appeal to Baire — everything downstream is completeness bookkeeping.",

--- a/src/data/proofs/ballot-problem-oq-03-oq-02-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02-oq-03/meta.json
@@ -21,7 +21,7 @@
       "commutative-ring",
       "ballot-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-24",
     "axiomCount": 0,

--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -17,7 +17,7 @@
       "permutations",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axioms": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/ballot-problem-oq-04-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-04-oq-02-oq-01/meta.json
@@ -20,7 +20,7 @@
       "bijection",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. 0 sorries, 0 literal `axiom` declarations, 0 structure-encoded assumptions. The full theorem nonCrossingCount n = catalan n (nonCrossingCount_eq_catalan) is machine-checked and depends only on the foundational axioms propext / Classical.choice / Quot.sound (Classical.choice enters via Fintype.equivOfCardEq and .some on the first-return bijection's Nonempty). No native_decide and no Lean.ofReduceBool — the n ≤ 3 corollary uses kernel `decide`, not native_decide. Confirmed by `#print axioms nonCrossingCount_eq_catalan`. Status verified.",

--- a/src/data/proofs/banach-fixed-point-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/banach-fixed-point-oq-01-oq-01-oq-02/meta.json
@@ -19,7 +19,7 @@
       "fixed-point-iteration",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-01",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/banach-fixed-point-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/banach-fixed-point-oq-01-oq-02-oq-01/meta.json
@@ -19,7 +19,7 @@
       "normed-space",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-24",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/banach-fixed-point-oq-01-oq-02/meta.json
+++ b/src/data/proofs/banach-fixed-point-oq-01-oq-02/meta.json
@@ -19,7 +19,7 @@
       "normed-space",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-24",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/basel-problem-oq-04-oq-03-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-04-oq-03-oq-01/meta.json
@@ -19,7 +19,7 @@
       "dirichlet-series",
       "basel-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-26",
     "mathlibDependencies": [

--- a/src/data/proofs/basel-problem-oq-06-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-06-oq-01/meta.json
@@ -16,7 +16,7 @@
       "zeta-values",
       "basel-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/basel-problem-oq-10-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-10-oq-03/meta.json
@@ -53,7 +53,7 @@
     "lineCount": 156,
     "theoremCount": 5,
     "definitionCount": 0,
-    "badge": "verified",
+    "badge": "mathlib",
     "originalContributions": [
       "tendsto_alternating_harmonic_log_two: the ordered partial sums ∑_{i<n} (-1)^i/(i+1) converge to log 2. Because Mathlib has no value for this series (contrast the Leibniz case), this is proved from scratch via Abel's limit theorem applied to the power series of log(1+x) — the substantive analytic content.",
       "not_summable_alternating_harmonic: the family (-1)^n/(n+1) is NOT Summable — its absolute values are the divergent harmonic series 1/(n+1), so convergence is only conditional.",

--- a/src/data/proofs/bernoulli-inequality-oq-01/meta.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01/meta.json
@@ -18,7 +18,7 @@
       "induction",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/bertrands-postulate-oq-05-oq-02/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-05-oq-02/meta.json
@@ -20,7 +20,7 @@
       "divisibility",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/bertrands-postulate-oq-05/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-05/meta.json
@@ -19,7 +19,7 @@
       "perfect-square",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
       "well-founded-recursion",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-05-04",

--- a/src/data/proofs/bezout-identity-oq001/meta.json
+++ b/src/data/proofs/bezout-identity-oq001/meta.json
@@ -28,7 +28,7 @@
       "unimodular-matrices",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-07-02",

--- a/src/data/proofs/bezout-identity-oq012/meta.json
+++ b/src/data/proofs/bezout-identity-oq012/meta.json
@@ -16,7 +16,7 @@
       "UFD",
       "Zsqrtd"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "axiomCount": 0,

--- a/src/data/proofs/bezout-identity-oq013/meta.json
+++ b/src/data/proofs/bezout-identity-oq013/meta.json
@@ -17,7 +17,7 @@
       "norm",
       "Zsqrtd"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "axiomCount": 0,

--- a/src/data/proofs/bezout-identity-oq015/meta.json
+++ b/src/data/proofs/bezout-identity-oq015/meta.json
@@ -16,7 +16,7 @@
       "euclidean-domain",
       "ufd"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 108,

--- a/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-02/meta.json
@@ -16,7 +16,7 @@
       "binomial-series",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.31.0",
@@ -137,7 +137,7 @@
     }
   ],
   "status": "verified",
-  "badge": "verified",
+  "badge": "mathlib",
   "leanFile": {
     "imports": [
       "Mathlib",

--- a/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-03/meta.json
@@ -17,7 +17,7 @@
       "generating-functions",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-01",
     "mathlib_version": "4.31.0",
@@ -134,7 +134,7 @@
     }
   ],
   "status": "verified",
-  "badge": "verified",
+  "badge": "mathlib",
   "leanFile": {
     "imports": [
       "Mathlib",

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -15,7 +15,7 @@
       "mathlib-integration"
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,

--- a/src/data/proofs/binomial-theorem-oq-06-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-06-oq-02/meta.json
@@ -19,7 +19,7 @@
       "finset-sum",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-02",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/binomial-theorem-oq-06/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-06/meta.json
@@ -18,7 +18,7 @@
       "finset-sum",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-01",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/binomial-theorem-oq002/meta.json
+++ b/src/data/proofs/binomial-theorem-oq002/meta.json
@@ -16,7 +16,7 @@
       "combinatorics"
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ02.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-05-04",
     "axiomCount": 0,

--- a/src/data/proofs/binomial-theorem-oq005/meta.json
+++ b/src/data/proofs/binomial-theorem-oq005/meta.json
@@ -17,7 +17,7 @@
       "binomial-theorem"
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ04.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-21",
     "axiomCount": 0,

--- a/src/data/proofs/birch-swinnerton-dyer-oq-06-oq-01/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer-oq-06-oq-01/meta.json
@@ -18,7 +18,7 @@
       "millennium-prize",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-24",
     "axiomCount": 0,

--- a/src/data/proofs/birthday-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
       "descFactorial",
       "indicator"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "definitionCount": 2,

--- a/src/data/proofs/birthday-problem-oq008/meta.json
+++ b/src/data/proofs/birthday-problem-oq008/meta.json
@@ -16,7 +16,7 @@
       "closed-form",
       "enumeration"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-21",
     "axiomCount": 0,

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-02/meta.json
@@ -17,7 +17,7 @@
       "free-actions",
       "number-theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-21",
     "axiomCount": 0,

--- a/src/data/proofs/borsuk-ulam-oq-04-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-04-oq-03/meta.json
@@ -17,7 +17,7 @@
       "fundamental-group",
       "classifying-space"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 197,

--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-03/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-03/meta.json
@@ -19,7 +19,7 @@
       "mathlib",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 135,

--- a/src/data/proofs/brianchon-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/brianchon-theorem-oq-01-oq-01-oq-01/meta.json
@@ -17,7 +17,7 @@
       "incidence-theorem",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-27",
     "axiomCount": 0,

--- a/src/data/proofs/brianchon-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/brianchon-theorem-oq-01-oq-01/meta.json
@@ -17,7 +17,7 @@
       "incidence-theorem",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-03-oq-01/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-03-oq-01/meta.json
@@ -70,7 +70,7 @@
       "set-valued-analysis",
       "correspondences"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-01",
     "axiomCount": 0,

--- a/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01/meta.json
@@ -16,7 +16,7 @@
       "monotonicity",
       "high-dimensional"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "axiomCount": 0,

--- a/src/data/proofs/buffons-needle-oq002/meta.json
+++ b/src/data/proofs/buffons-needle-oq002/meta.json
@@ -18,7 +18,7 @@
       "trigonometric-integrals",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 198,

--- a/src/data/proofs/buffons-needle-oq003/meta.json
+++ b/src/data/proofs/buffons-needle-oq003/meta.json
@@ -19,7 +19,7 @@
       "fundamental-theorem-of-calculus",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 75,

--- a/src/data/proofs/buffons-needle-oq006/meta.json
+++ b/src/data/proofs/buffons-needle-oq006/meta.json
@@ -17,7 +17,7 @@
       "closed-form",
       "high-dimensional"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "axiomCount": 0,

--- a/src/data/proofs/buffons-needle-oq007/meta.json
+++ b/src/data/proofs/buffons-needle-oq007/meta.json
@@ -17,7 +17,7 @@
       "asymptotics",
       "high-dimensional"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "axiomCount": 0,

--- a/src/data/proofs/burnside-counting-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/burnside-counting-oq-04-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
       "native-decide-free",
       "oeis-a000029"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-24",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/burnside-counting-oq-04-oq-01-oq-02/meta.json
+++ b/src/data/proofs/burnside-counting-oq-04-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
       "native-decide-free",
       "oeis-a000029"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-02",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/burnside-counting-oq-04-oq-01/meta.json
+++ b/src/data/proofs/burnside-counting-oq-04-oq-01/meta.json
@@ -18,7 +18,7 @@
       "kernel-decide",
       "native-decide-free"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/burnside-counting-oq-04-oq-02/meta.json
+++ b/src/data/proofs/burnside-counting-oq-04-oq-02/meta.json
@@ -18,7 +18,7 @@
       "kernel-decide",
       "native-decide-free"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-03/meta.json
@@ -17,7 +17,7 @@
       "cofinality",
       "easton-theorem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-21",
     "axiomCount": 0,

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-wip-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-wip-01/meta.json
@@ -16,7 +16,7 @@
       "intermediate-cardinals",
       "cofinality"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-02",
     "axiomCount": 0,

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-02/meta.json
@@ -55,7 +55,7 @@
       "type-theory",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-02",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/cantors-theorem-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-01-oq-04/meta.json
@@ -17,7 +17,7 @@
       "continuum",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 102,

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Poincaré (separation), Schur–Horn (majorization direction); formalized for lean-genius",
     "status": "verified",
-    "badge": "verified",
+    "badge": "mathlib",
     "proofRepoPath": "Proofs/CauchyInterlacingMajorizationPositivity.lean",
     "axiomCount": 0,
     "sorries": 0,

--- a/src/data/proofs/cauchy-interlacing-theorem-oq003/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq003/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Issai Schur (1923); Hardy–Littlewood–Pólya / Karamata (majorization characterization); formalized for lean-genius",
     "status": "verified",
-    "badge": "verified",
+    "badge": "mathlib",
     "proofRepoPath": "Proofs/SchurHornMajorization.lean",
     "axiomCount": 0,
     "sorries": 0,

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json
@@ -13,7 +13,7 @@
       "holder-inequality",
       "hilbert-space"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 166,

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02-oq-01/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ01OQ02OQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-02-oq-01/meta.json
@@ -16,7 +16,7 @@
       "orthogonal-projection",
       "cauchy-schwarz"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 152,

--- a/src/data/proofs/cauchy-schwarz-oq002/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq002/meta.json
@@ -17,7 +17,7 @@
       "bessel",
       "gram-schmidt"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 192,

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02/meta.json
@@ -25,7 +25,7 @@
       "research",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 207,

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-03/meta.json
@@ -28,7 +28,7 @@
       "research",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 310,

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-02/meta.json
@@ -15,7 +15,7 @@
       "algebra-homomorphisms",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 173,

--- a/src/data/proofs/cayley-hamilton-oq-02-oq-01-analytic/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-02-oq-01-analytic/meta.json
@@ -9,7 +9,7 @@
     "date": "2026-07-04",
     "dateAdded": "2026-07-04",
     "status": "verified",
-    "badge": "verified",
+    "badge": "mathlib",
     "proofRepoPath": "Proofs/CayleyHamiltonOQ02OQ01Analytic.lean",
     "tags": [
       "linear-algebra",

--- a/src/data/proofs/cayley-hamilton-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-02-oq-01/meta.json
@@ -9,7 +9,7 @@
     "date": "2026-07-03",
     "dateAdded": "2026-07-02",
     "status": "verified",
-    "badge": "verified",
+    "badge": "mathlib",
     "proofRepoPath": "Proofs/CayleyHamiltonOQ02OQ01.lean",
     "tags": [
       "linear-algebra",

--- a/src/data/proofs/cayley-hamilton-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-02-oq-02-oq-01/meta.json
@@ -36,7 +36,7 @@
       "frobenius-covariants",
       "diagonalizable"
     ],
-    "badge": "formalized",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "axiomCount": 0,

--- a/src/data/proofs/cayley-hamilton-oq-04-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-04-oq-02/meta.json
@@ -16,7 +16,7 @@
       "differential-equations",
       "putzer"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-25",
     "axiomCount": 0,

--- a/src/data/proofs/cayley-hamilton-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-04/meta.json
@@ -16,7 +16,7 @@
       "matrix-inverse",
       "cramers-rule"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-24",
     "axiomCount": 0,

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "asymptotic-invariant",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-02",
     "axiomCount": 0,

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-03/meta.json
@@ -20,7 +20,7 @@
       "advanced",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-02-oq-01/meta.json
@@ -18,7 +18,7 @@
       "signed-ratios",
       "sin"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-05-03",
     "axiomCount": 0,

--- a/src/data/proofs/chebyshev-bounds-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-02-oq-01-oq-02/meta.json
@@ -17,7 +17,7 @@
       "asymptotics",
       "big-theta"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 148,

--- a/src/data/proofs/chebyshev-bounds-oq-02-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-02-oq-01/meta.json
@@ -17,7 +17,7 @@
       "central-binomial",
       "analytic-number-theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 201,

--- a/src/data/proofs/chebyshev-bounds-oq-02-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-02-oq-02/meta.json
@@ -16,7 +16,7 @@
       "prime-counting",
       "analytic-number-theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 146,

--- a/src/data/proofs/chebyshev-bounds-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-02/meta.json
@@ -16,7 +16,7 @@
       "prime-counting",
       "analytic-number-theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 135,

--- a/src/data/proofs/chebyshev-bounds-oq-06-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-06-oq-01/meta.json
@@ -19,7 +19,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/ChebyshevBoundsOQ0601.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/chebyshev-bounds-oq-06-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-06-oq-02/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/ChebyshevThetaFourPow.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/chebyshev-bounds-oq-06/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-06/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/ChebyshevBoundsOQ06.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-03-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-03-oq-01/meta.json
@@ -17,7 +17,7 @@
       "prime-number-theorem",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-05-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-05-oq-01/meta.json
@@ -17,7 +17,7 @@
       "prime-number-theorem",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-01/meta.json
@@ -17,7 +17,7 @@
       "prime-number-theorem",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-02/meta.json
@@ -18,7 +18,7 @@
       "prime-number-theorem",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/chinese-remainder-constructive-oq-04-oq-05/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04-oq-05/meta.json
@@ -16,7 +16,7 @@
       "computable",
       "canonical-form"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-19",

--- a/src/data/proofs/chinese-remainder-constructive-oq-05-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-05-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "existence-uniqueness",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 123,

--- a/src/data/proofs/chinese-remainder-constructive-oq-05-oq-01/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-05-oq-01/meta.json
@@ -17,7 +17,7 @@
       "coprime-moduli",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 110,

--- a/src/data/proofs/chinese-remainder-constructive-oq-05/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-05/meta.json
@@ -16,7 +16,7 @@
       "native-decide-removal",
       "coprime-moduli"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 110,

--- a/src/data/proofs/collatz-structured-oq-01/meta.json
+++ b/src/data/proofs/collatz-structured-oq-01/meta.json
@@ -16,7 +16,7 @@
       "invariance",
       "open-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 347,

--- a/src/data/proofs/combinations-formula-oq-01-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-01-oq-01/meta.json
@@ -15,7 +15,7 @@
       "pascal-triangle",
       "finite-sums"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-21",
     "axiomCount": 0,

--- a/src/data/proofs/cube-root-2-irrational-oq-05-oq-02/meta.json
+++ b/src/data/proofs/cube-root-2-irrational-oq-05-oq-02/meta.json
@@ -21,7 +21,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/CubeRoot2IrrationalOQ05OQ02.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/cube-root-3-irrational-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-01-oq-03/meta.json
@@ -17,7 +17,7 @@
       "algebraic-degree",
       "squarefree"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 143,

--- a/src/data/proofs/cube-root-3-irrational-oq-01/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-01/meta.json
@@ -16,7 +16,7 @@
       "gauss-lemma",
       "algebraic-degree"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 130,

--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-03/meta.json
@@ -18,7 +18,7 @@
       "sophie-germain",
       "eisenstein"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-04",
     "axiomCount": 0,

--- a/src/data/proofs/cyclotomic-polynomials-oq-01/meta.json
+++ b/src/data/proofs/cyclotomic-polynomials-oq-01/meta.json
@@ -19,7 +19,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/CyclotomicPolynomialsOQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/cyclotomic-polynomials-oq-02/meta.json
+++ b/src/data/proofs/cyclotomic-polynomials-oq-02/meta.json
@@ -19,7 +19,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/CyclotomicPolynomialsOQ02.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/de-moivre-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-02-oq-01/meta.json
@@ -20,7 +20,7 @@
       "finset-sum",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-15",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/de-moivre-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-03-oq-01-oq-01/meta.json
@@ -16,7 +16,7 @@
       "single-valued",
       "branch-cut"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 112,

--- a/src/data/proofs/denumerability-rationals-oq-04-oq-04/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-04-oq-04/meta.json
@@ -15,7 +15,7 @@
       "cardinality",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 102,

--- a/src/data/proofs/denumerability-rationals-oq-07/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-07/meta.json
@@ -16,7 +16,7 @@
       "aleph-null",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-20",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/desargues-theorem-oq-03/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-03/meta.json
@@ -18,7 +18,7 @@
       "determinant",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-03/meta.json
@@ -16,7 +16,7 @@
       "fundamental-theorem-of-algebra",
       "descartes"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 93,

--- a/src/data/proofs/dilworth-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dilworth-theorem-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "min-max"
     ],
     "proofRepoPath": "Proofs/DilworthMirskyHardOQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/dilworth-theorem-oq-01/meta.json
+++ b/src/data/proofs/dilworth-theorem-oq-01/meta.json
@@ -17,7 +17,7 @@
       "pigeonhole"
     ],
     "proofRepoPath": "Proofs/DilworthTheoremOQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-03/meta.json
@@ -250,6 +250,6 @@
   },
   "sorries": 0,
   "status": "verified",
-  "badge": "verified",
+  "badge": "original",
   "axiomCount": 0
 }

--- a/src/data/proofs/dissection-of-cubes-oq-03-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-03-oq-02/meta.json
@@ -17,7 +17,7 @@
       "wiedijk-82",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 209,

--- a/src/data/proofs/dissection-of-cubes-oq-04-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04-oq-02/meta.json
@@ -19,7 +19,7 @@
       "polytopes",
       "4-dimensional"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 187,

--- a/src/data/proofs/divisibility-by-three-oq-01-oq-03/meta.json
+++ b/src/data/proofs/divisibility-by-three-oq-01-oq-03/meta.json
@@ -17,7 +17,7 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/DivisibilityByThreeOQ01OQ03.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 sorries, 0 explicit axiom declarations, 0 structure-encoded assumptions. All four headline theorems (modEq_alternating_digits, dvd_iff_dvd_alternating_digits, dvd_succ_base_iff_alternating, alternating_digit_rules_summary) verified via `#print axioms` to depend only on the standard foundational axioms propext / Classical.choice / Quot.sound — NOT sorryAx and NOT Lean.ofReduceBool. Two illustrative `example` blocks in Part IV use `native_decide` to evaluate concrete alternating digit sums (Nat.digits is well-founded recursion and does not reduce under `decide`), but these examples are not the substantive results and do not appear in any theorem's axiom set.",

--- a/src/data/proofs/egorov-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/egorov-theorem-oq-01-oq-03/meta.json
@@ -43,7 +43,7 @@
     "lineCount": 212,
     "theoremCount": 7,
     "definitionCount": 1,
-    "badge": "verified",
+    "badge": "mathlib",
     "originalContributions": [
       "marching_not_tendstoUniformlyOn_of_volume_lt_top: the headline sharpness result — for ANY set s ⊆ ℝ of finite Lebesgue measure, the marching indicators fₙ = 𝟙_[n,n+1] do NOT converge uniformly to 0 on the complement sᶜ. This establishes that Egorov's finite-(total-)measure hypothesis is essential: on the infinite-measure space ℝ no finite-measure exceptional set can be removed to obtain uniform convergence. Mathlib has the abstract Egorov theorem but no counterexample witnessing the necessity of finiteness.",
       "marching_tendsto_zero: the marching indicators fₙ = 𝟙_[n,n+1] converge to 0 at EVERY point of ℝ (not merely a.e.) — for a fixed x, once n > x the bump [n,n+1] has marched past x, so fₙ(x) = 0 eventually. This is the everywhere-pointwise convergence that makes the failure of uniformity striking.",

--- a/src/data/proofs/ehrhart-cube-proven-oq-04/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-04/meta.json
@@ -23,7 +23,7 @@
       "research",
       "seeker-selected"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 775,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01/meta.json
@@ -95,7 +95,7 @@
       "cyclic-groups",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 344,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03/meta.json
@@ -94,7 +94,7 @@
       "group-homomorphisms",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 261,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq004/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq004/meta.json
@@ -86,7 +86,7 @@
       "induction",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 211,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq005/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq005/meta.json
@@ -86,7 +86,7 @@
       "units",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 202,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq006/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq006/meta.json
@@ -94,7 +94,7 @@
       "left-regular-representation",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 318,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq007/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq007/meta.json
@@ -94,7 +94,7 @@
       "odd-modulus",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 216,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq008/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq008/meta.json
@@ -94,7 +94,7 @@
       "odd-modulus",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 153,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq009/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq009/meta.json
@@ -92,7 +92,7 @@
       "perfect-shuffle",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 838,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq010/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq010/meta.json
@@ -95,7 +95,7 @@
       "odd-modulus",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 197,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq011/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq011/meta.json
@@ -93,7 +93,7 @@
       "odd-modulus",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 201,

--- a/src/data/proofs/erdos-1-oq-02/meta.json
+++ b/src/data/proofs/erdos-1-oq-02/meta.json
@@ -17,7 +17,7 @@
       "anticoncentration",
       "berry-esseen"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 935,

--- a/src/data/proofs/erdos-10-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-10-incomplete-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "multiset",
       "representation-functions"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 112,

--- a/src/data/proofs/erdos-10-incomplete-01-oq-02/meta.json
+++ b/src/data/proofs/erdos-10-incomplete-01-oq-02/meta.json
@@ -18,7 +18,7 @@
       "covering-congruences",
       "parity"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 155,

--- a/src/data/proofs/erdos-10-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-10-incomplete-01/meta.json
@@ -18,7 +18,7 @@
       "multiset",
       "representation-functions"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 150,

--- a/src/data/proofs/erdos-10-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-10-oq-01-incomplete-01/meta.json
@@ -18,7 +18,7 @@
       "covering-congruences",
       "chinese-remainder-theorem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 186,

--- a/src/data/proofs/erdos-10-wip-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-10-wip-01-oq-01/meta.json
@@ -19,7 +19,7 @@
       "additive-combinatorics",
       "erdos-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 196,

--- a/src/data/proofs/erdos-10-wip-01/meta.json
+++ b/src/data/proofs/erdos-10-wip-01/meta.json
@@ -17,7 +17,7 @@
       "additive-combinatorics",
       "erdos-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 146,

--- a/src/data/proofs/erdos-100-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-100-oq-01-incomplete-01/meta.json
@@ -31,7 +31,7 @@
       "integer-distances",
       "incidence-geometry"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "axiomCount": 0,

--- a/src/data/proofs/erdos-1002-oq-01-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1002-oq-01-oq-01-incomplete-01/meta.json
@@ -33,7 +33,7 @@
       "weyl",
       "measure-theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "axiomCount": 0,

--- a/src/data/proofs/erdos-1002-oq-01/meta.json
+++ b/src/data/proofs/erdos-1002-oq-01/meta.json
@@ -16,7 +16,7 @@
       "distribution-functions",
       "axiom-elimination"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1002,
     "erdosUrl": "https://erdosproblems.com/1002",

--- a/src/data/proofs/erdos-1002-oq-03/meta.json
+++ b/src/data/proofs/erdos-1002-oq-03/meta.json
@@ -18,7 +18,7 @@
       "continued-fractions",
       "complete-residue-system"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1002,
     "erdosUrl": "https://erdosproblems.com/1002",

--- a/src/data/proofs/erdos-1002-oq-04/meta.json
+++ b/src/data/proofs/erdos-1002-oq-04/meta.json
@@ -18,7 +18,7 @@
       "liouville-numbers",
       "rational-approximation"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1002,
     "erdosUrl": "https://erdosproblems.com/1002",

--- a/src/data/proofs/erdos-1003-oq-03/meta.json
+++ b/src/data/proofs/erdos-1003-oq-03/meta.json
@@ -17,7 +17,7 @@
       "open-question",
       "extension"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 304,

--- a/src/data/proofs/erdos-1007-oq-04/meta.json
+++ b/src/data/proofs/erdos-1007-oq-04/meta.json
@@ -17,7 +17,7 @@
       "euclidean-embedding",
       "extremal-graph-theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 314,

--- a/src/data/proofs/erdos-1007-oq-05-oq-01/meta.json
+++ b/src/data/proofs/erdos-1007-oq-05-oq-01/meta.json
@@ -16,7 +16,7 @@
       "erdos-problem",
       "euclidean-embedding"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 109,

--- a/src/data/proofs/erdos-1008-oq-02/meta.json
+++ b/src/data/proofs/erdos-1008-oq-02/meta.json
@@ -19,7 +19,7 @@
       "reiman",
       "c4-free"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1008,
     "erdosUrl": "https://erdosproblems.com/1008",

--- a/src/data/proofs/erdos-1009-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-1009-oq-03-oq-01/meta.json
@@ -20,7 +20,7 @@
       "fractional-cover",
       "complexity"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1009,
     "erdosUrl": "https://erdosproblems.com/1009",

--- a/src/data/proofs/erdos-1009-oq-03/meta.json
+++ b/src/data/proofs/erdos-1009-oq-03/meta.json
@@ -20,7 +20,7 @@
       "decidable",
       "extremal-combinatorics"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1009,
     "erdosUrl": "https://erdosproblems.com/1009",

--- a/src/data/proofs/erdos-1011-oq-03/meta.json
+++ b/src/data/proofs/erdos-1011-oq-03/meta.json
@@ -22,7 +22,7 @@
       "monotonicity",
       "open-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1011,
     "erdosUrl": "https://erdosproblems.com/1011",

--- a/src/data/proofs/erdos-1012-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-1012-oq-02-oq-01/meta.json
@@ -16,7 +16,7 @@
       "triangle-free",
       "extremal-graph-theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-27",
     "axiomCount": 0,

--- a/src/data/proofs/erdos-1017-oq-02/meta.json
+++ b/src/data/proofs/erdos-1017-oq-02/meta.json
@@ -29,7 +29,7 @@
       "clique-partition",
       "erdos-problems"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "axiomCount": 0,

--- a/src/data/proofs/erdos-1017-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-1017-oq-03-oq-01/meta.json
@@ -29,7 +29,7 @@
       "triangular-numbers",
       "erdos-problems"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-30",
     "axiomCount": 0,

--- a/src/data/proofs/erdos-1017-oq-03/meta.json
+++ b/src/data/proofs/erdos-1017-oq-03/meta.json
@@ -29,7 +29,7 @@
       "clique-partition",
       "erdos-problems"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "axiomCount": 0,

--- a/src/data/proofs/erdos-1017-oq-05/meta.json
+++ b/src/data/proofs/erdos-1017-oq-05/meta.json
@@ -31,7 +31,7 @@
       "clique-partition",
       "erdos-problems"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-04",
     "axiomCount": 0,

--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01-oq-01/meta.json
@@ -17,7 +17,7 @@
       "first-moment",
       "erdos"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 7,

--- a/src/data/proofs/erdos-1020-oq-02/meta.json
+++ b/src/data/proofs/erdos-1020-oq-02/meta.json
@@ -17,7 +17,7 @@
       "regime-transition",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 523,

--- a/src/data/proofs/erdos-1021-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1021-oq-01-incomplete-01/meta.json
@@ -17,7 +17,7 @@
       "limits",
       "zarankiewicz"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 165,

--- a/src/data/proofs/erdos-1021-wip-01/meta.json
+++ b/src/data/proofs/erdos-1021-wip-01/meta.json
@@ -17,7 +17,7 @@
       "regular-graphs",
       "handshake-lemma"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 219,

--- a/src/data/proofs/erdos-1021-wip-02/meta.json
+++ b/src/data/proofs/erdos-1021-wip-02/meta.json
@@ -17,7 +17,7 @@
       "c4-free",
       "kovari-sos-turan"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 218,

--- a/src/data/proofs/erdos-1022-oq-02/meta.json
+++ b/src/data/proofs/erdos-1022-oq-02/meta.json
@@ -261,6 +261,6 @@
   ],
   "sorries": 0,
   "status": "verified",
-  "badge": "verified",
+  "badge": "original",
   "axiomCount": 0
 }

--- a/src/data/proofs/erdos-1023-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1023-oq-01-oq-01/meta.json
@@ -17,7 +17,7 @@
       "extremal",
       "erdos"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 200,

--- a/src/data/proofs/erdos-1023-oq-02/meta.json
+++ b/src/data/proofs/erdos-1023-oq-02/meta.json
@@ -45,7 +45,7 @@
       "symmetric-difference",
       "erdos-problems"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "axiomCount": 0,

--- a/src/data/proofs/erdos-1023-oq-03/meta.json
+++ b/src/data/proofs/erdos-1023-oq-03/meta.json
@@ -32,7 +32,7 @@
       "binomial-coefficients",
       "erdos-problems"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "axiomCount": 0,

--- a/src/data/proofs/erdos-1023-oq-04/meta.json
+++ b/src/data/proofs/erdos-1023-oq-04/meta.json
@@ -34,7 +34,7 @@
       "binomial-coefficients",
       "erdos-problems"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "axiomCount": 0,

--- a/src/data/proofs/erdos-1023-oq-05/meta.json
+++ b/src/data/proofs/erdos-1023-oq-05/meta.json
@@ -47,7 +47,7 @@
     "dateAdded": "2026-07-02",
     "status": "verified",
     "proofRepoPath": "Proofs/Erdos1023OQ05.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 6,

--- a/src/data/proofs/erdos-1026-oq-02/meta.json
+++ b/src/data/proofs/erdos-1026-oq-02/meta.json
@@ -17,7 +17,7 @@
       "approximation",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 170,

--- a/src/data/proofs/erdos-1026-oq-05/meta.json
+++ b/src/data/proofs/erdos-1026-oq-05/meta.json
@@ -18,7 +18,7 @@
       "decomposition",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 377,

--- a/src/data/proofs/erdos-1034-oq-02/meta.json
+++ b/src/data/proofs/erdos-1034-oq-02/meta.json
@@ -18,7 +18,7 @@
       "good-neighbours",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 194,

--- a/src/data/proofs/erdos-1047/meta.json
+++ b/src/data/proofs/erdos-1047/meta.json
@@ -18,7 +18,7 @@
       "counterexample",
       "potential-theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1047,
     "erdosUrl": "https://erdosproblems.com/1047",

--- a/src/data/proofs/erdos-1058-oq-03/meta.json
+++ b/src/data/proofs/erdos-1058-oq-03/meta.json
@@ -17,7 +17,7 @@
       "wilson-theorem",
       "prime-power"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1058,
     "erdosUrl": "https://erdosproblems.com/1058",

--- a/src/data/proofs/erdos-107-oq-01/meta.json
+++ b/src/data/proofs/erdos-107-oq-01/meta.json
@@ -19,7 +19,7 @@
       "extension",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 311,

--- a/src/data/proofs/erdos-1070-oq-05/meta.json
+++ b/src/data/proofs/erdos-1070-oq-05/meta.json
@@ -19,7 +19,7 @@
       "independence-number",
       "higher-dimension"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1070,
     "erdosUrl": "https://erdosproblems.com/1070",

--- a/src/data/proofs/erdos-1090/meta.json
+++ b/src/data/proofs/erdos-1090/meta.json
@@ -17,7 +17,7 @@
       "collinear-points",
       "solved"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1090,
     "erdosUrl": "https://erdosproblems.com/1090",

--- a/src/data/proofs/erdos-1100-oq-02/meta.json
+++ b/src/data/proofs/erdos-1100-oq-02/meta.json
@@ -17,7 +17,7 @@
       "prime-power",
       "extremal"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 170,

--- a/src/data/proofs/erdos-1179-oq-01-oq-02/meta.json
+++ b/src/data/proofs/erdos-1179-oq-01-oq-02/meta.json
@@ -132,7 +132,7 @@
       "erdos-problem",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. Self-contained: imports only Mathlib and restates the three parent correction-term definitions verbatim. The main theorem loglog_implies_sublinear proves the hierarchy implication CorrectionIsLogLog ⟹ CorrectionIsSublinearInLog (Θ(log log N) ⟹ o(log₂ N)) that the parent erdos-1179-oq-01 left unformalized. Machine-checked: `lake env lean Proofs/Erdos1179OQ01OQ02.lean` elaborates the file against prebuilt Mathlib oleans with zero errors and zero sorries, and `#print axioms` reports only [propext, Classical.choice, Quot.sound] — the foundational axioms; no Lean.ofReduceBool (no native_decide) and no sorryAx. This entry proves ONLY the logical implication between candidate rates; it does NOT resolve the open second-order question (which rate actually holds).",

--- a/src/data/proofs/erdos-1179-oq-02-rigidity/meta.json
+++ b/src/data/proofs/erdos-1179-oq-02-rigidity/meta.json
@@ -18,7 +18,7 @@
       "erdos-problem",
       "rigidity"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. Depends only on Erdos1179.epsUniform_spanning (from the verified sibling Proofs/Erdos1179OQ02.lean) and Erdos1179.total_reprCount (from the parent Proofs/Erdos1179Problem.lean), plus the named Mathlib lemma Finset.sum_eq_sum_iff_of_le (the @[to_additive] image of Finset.prod_eq_prod_iff_of_le). This file formalizes the EQUALITY/rigidity case of the trivial lower bound only; the headline OQ-02 (the additive Oₑ(1) UPPER bound) remains open.",

--- a/src/data/proofs/erdos-1179-oq-02/meta.json
+++ b/src/data/proofs/erdos-1179-oq-02/meta.json
@@ -18,7 +18,7 @@
       "erdos-problem",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. Machine-checked: green docker-build of Proofs.Erdos1179OQ02 (7744 jobs, 2026-06-19) confirms the typecheck. Depends only on Erdos1179.total_reprCount and Erdos1179.expectedReprCount_pos from the parent Proofs/Erdos1179Problem.lean. This file formalizes only the LOWER-BOUND direction together with structural API for the ε-uniformity predicate (monotonicity in ε, the two-sided count sandwich, and the contrapositive too-small bound); the headline OQ-02 (the additive Oₑ(1) UPPER bound) remains open. The structural bounds and the exact small-N gap are additionally certified by research/problems/erdos-1179-oq-02/verify_uniform_subset_sums.py (all pass; the script notes it cannot decide the asymptotic Oₑ(1) question).",

--- a/src/data/proofs/erdos-12/meta.json
+++ b/src/data/proofs/erdos-12/meta.json
@@ -16,7 +16,7 @@
       "density",
       "additive-combinatorics"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos12ProblemAPNPartI.lean",

--- a/src/data/proofs/erdos-1207-oq-03/meta.json
+++ b/src/data/proofs/erdos-1207-oq-03/meta.json
@@ -20,7 +20,7 @@
       "lower-bound",
       "open"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1207,
     "erdosUrl": "https://erdosproblems.com/1207",

--- a/src/data/proofs/erdos-1207/meta.json
+++ b/src/data/proofs/erdos-1207/meta.json
@@ -17,7 +17,7 @@
       "arithmetic-progressions",
       "open"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1207,
     "erdosUrl": "https://erdosproblems.com/1207",

--- a/src/data/proofs/erdos-1210/meta.json
+++ b/src/data/proofs/erdos-1210/meta.json
@@ -16,7 +16,7 @@
       "harmonic-sums",
       "extremal-combinatorics"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1210,
     "erdosUrl": "https://erdosproblems.com/1210",

--- a/src/data/proofs/erdos-125/meta.json
+++ b/src/data/proofs/erdos-125/meta.json
@@ -20,7 +20,7 @@
       "additive-combinatorics",
       "alphaproof-nexus"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 125,
     "erdosUrl": "https://erdosproblems.com/125",

--- a/src/data/proofs/erdos-128-wip-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-128-wip-01-oq-01-oq-01-oq-01/meta.json
@@ -32,7 +32,7 @@
       "ramsey-turan",
       "erdos-problems"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "axiomCount": 0,

--- a/src/data/proofs/erdos-128-wip-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-128-wip-01-oq-01-oq-01/meta.json
@@ -31,7 +31,7 @@
       "ramsey-turan",
       "erdos-problems"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "axiomCount": 0,

--- a/src/data/proofs/erdos-128-wip-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-128-wip-01-oq-01/meta.json
@@ -72,7 +72,7 @@
       "ramsey-turan",
       "erdos-problems"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "axiomCount": 0,

--- a/src/data/proofs/erdos-128-wip-01/meta.json
+++ b/src/data/proofs/erdos-128-wip-01/meta.json
@@ -89,7 +89,7 @@
       "ramsey-turan",
       "erdos-problems"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "axiomCount": 0,

--- a/src/data/proofs/erdos-152/meta.json
+++ b/src/data/proofs/erdos-152/meta.json
@@ -15,7 +15,7 @@
       "sumsets",
       "alphaproof-nexus"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 152,
     "erdosUrl": "https://erdosproblems.com/152",

--- a/src/data/proofs/erdos-156/meta.json
+++ b/src/data/proofs/erdos-156/meta.json
@@ -18,7 +18,7 @@
       "additive-combinatorics",
       "extremal-combinatorics"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 156,
     "erdosUrl": "https://erdosproblems.com/156",

--- a/src/data/proofs/erdos-220-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-220-incomplete-01/meta.json
@@ -16,7 +16,7 @@
       "gap-distribution",
       "montgomery-vaughan"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 133,

--- a/src/data/proofs/erdos-309-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-309-incomplete-01/meta.json
@@ -17,7 +17,7 @@
       "harmonic-numbers",
       "asymptotic-analysis"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 309,
     "erdosUrl": "https://erdosproblems.com/309",

--- a/src/data/proofs/erdos-32-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-32-incomplete-01/meta.json
@@ -18,7 +18,7 @@
       "asymptotics",
       "open-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/erdos-340-greedy-sidon/meta.json
+++ b/src/data/proofs/erdos-340-greedy-sidon/meta.json
@@ -18,7 +18,7 @@
       "erdos",
       "infrastructure"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/erdos-357-oq-04/meta.json
+++ b/src/data/proofs/erdos-357-oq-04/meta.json
@@ -27,7 +27,7 @@
       "mathlib-api",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "divergence",
       "limits"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 396,
     "erdosUrl": "https://erdosproblems.com/396",

--- a/src/data/proofs/erdos-396-oq-04-oq-01/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01/meta.json
@@ -17,7 +17,7 @@
       "limits",
       "growth-bounds"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 396,
     "erdosUrl": "https://erdosproblems.com/396",

--- a/src/data/proofs/erdos-396-oq-04/meta.json
+++ b/src/data/proofs/erdos-396-oq-04/meta.json
@@ -16,7 +16,7 @@
       "divisibility",
       "recurrence"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 396,
     "erdosUrl": "https://erdosproblems.com/396",

--- a/src/data/proofs/erdos-396-oq001/meta.json
+++ b/src/data/proofs/erdos-396-oq001/meta.json
@@ -17,7 +17,7 @@
       "growth-bounds",
       "logarithm"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 396,
     "erdosUrl": "https://erdosproblems.com/396",

--- a/src/data/proofs/erdos-396-oq002/meta.json
+++ b/src/data/proofs/erdos-396-oq002/meta.json
@@ -17,7 +17,7 @@
       "stirling-formula",
       "growth-bounds"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 396,
     "erdosUrl": "https://erdosproblems.com/396",

--- a/src/data/proofs/erdos-396-oq003/meta.json
+++ b/src/data/proofs/erdos-396-oq003/meta.json
@@ -19,7 +19,7 @@
       "critical-exponent",
       "limits"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 396,
     "erdosUrl": "https://erdosproblems.com/396",

--- a/src/data/proofs/erdos-396-oq004/meta.json
+++ b/src/data/proofs/erdos-396-oq004/meta.json
@@ -19,7 +19,7 @@
       "radius-of-convergence",
       "limits"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 396,
     "erdosUrl": "https://erdosproblems.com/396",

--- a/src/data/proofs/erdos-396-oq005/meta.json
+++ b/src/data/proofs/erdos-396-oq005/meta.json
@@ -20,7 +20,7 @@
       "critical-exponent",
       "limits"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 396,
     "erdosUrl": "https://erdosproblems.com/396",

--- a/src/data/proofs/erdos-396-oq006/meta.json
+++ b/src/data/proofs/erdos-396-oq006/meta.json
@@ -19,7 +19,7 @@
       "monotonicity",
       "recurrence"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 396,
     "erdosUrl": "https://erdosproblems.com/396",

--- a/src/data/proofs/erdos-396-oq007/meta.json
+++ b/src/data/proofs/erdos-396-oq007/meta.json
@@ -19,7 +19,7 @@
       "telescoping-product",
       "analytic-combinatorics"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 396,
     "erdosUrl": "https://erdosproblems.com/396",

--- a/src/data/proofs/erdos-396-oq008/meta.json
+++ b/src/data/proofs/erdos-396-oq008/meta.json
@@ -36,7 +36,7 @@
       "pi-bounds",
       "induction"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 396,
     "erdosUrl": "https://erdosproblems.com/396",

--- a/src/data/proofs/erdos-396-oq009/meta.json
+++ b/src/data/proofs/erdos-396-oq009/meta.json
@@ -20,7 +20,7 @@
       "pi",
       "square-root"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 396,
     "erdosUrl": "https://erdosproblems.com/396",

--- a/src/data/proofs/erdos-396-oq010/meta.json
+++ b/src/data/proofs/erdos-396-oq010/meta.json
@@ -20,7 +20,7 @@
       "critical-exponent",
       "pi"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 396,
     "erdosUrl": "https://erdosproblems.com/396",

--- a/src/data/proofs/erdos-396-oq011/meta.json
+++ b/src/data/proofs/erdos-396-oq011/meta.json
@@ -19,7 +19,7 @@
       "monotonicity",
       "logarithm"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 396,
     "erdosUrl": "https://erdosproblems.com/396",

--- a/src/data/proofs/erdos-415-oq-01/meta.json
+++ b/src/data/proofs/erdos-415-oq-01/meta.json
@@ -16,7 +16,7 @@
       "constructive-bound",
       "permutation-patterns"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 98,

--- a/src/data/proofs/erdos-458-oq-05/meta.json
+++ b/src/data/proofs/erdos-458-oq-05/meta.json
@@ -17,7 +17,7 @@
       "nth-prime",
       "axiom-free"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 458,
     "erdosUrl": "https://erdosproblems.com/458",

--- a/src/data/proofs/erdos-493-oq-01/meta.json
+++ b/src/data/proofs/erdos-493-oq-01/meta.json
@@ -17,7 +17,7 @@
       "combinatorics",
       "bijective-proof"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 493,
     "erdosUrl": "https://erdosproblems.com/493",

--- a/src/data/proofs/erdos-57-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-57-incomplete-01/meta.json
@@ -18,7 +18,7 @@
       "connectivity",
       "combinatorics"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 57,
     "erdosUrl": "https://erdosproblems.com/57",

--- a/src/data/proofs/erdos-633/meta.json
+++ b/src/data/proofs/erdos-633/meta.json
@@ -17,7 +17,7 @@
       "open-problem",
       "tiling-theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 633,
     "erdosUrl": "https://erdosproblems.com/633",

--- a/src/data/proofs/erdos-653-oq-01/meta.json
+++ b/src/data/proofs/erdos-653-oq-01/meta.json
@@ -15,7 +15,7 @@
       "erdos-problems",
       "incidence-geometry"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-19",
     "axiomCount": 0,

--- a/src/data/proofs/erdos-736/meta.json
+++ b/src/data/proofs/erdos-736/meta.json
@@ -17,7 +17,7 @@
       "set-theory",
       "independence"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 736,
     "erdosUrl": "https://erdosproblems.com/736",

--- a/src/data/proofs/erdos-741/meta.json
+++ b/src/data/proofs/erdos-741/meta.json
@@ -17,7 +17,7 @@
       "open",
       "partition-regularity"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos741ProblemAPNPartI.lean",

--- a/src/data/proofs/erdos-771-construction/meta.json
+++ b/src/data/proofs/erdos-771-construction/meta.json
@@ -16,7 +16,7 @@
       "subset-sums",
       "primes"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 690,

--- a/src/data/proofs/erdos-793-oq-03/meta.json
+++ b/src/data/proofs/erdos-793-oq-03/meta.json
@@ -18,7 +18,7 @@
       "extremal-combinatorics",
       "open-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 793,
     "erdosUrl": "https://erdosproblems.com/793",

--- a/src/data/proofs/erdos-816-oq-01/meta.json
+++ b/src/data/proofs/erdos-816-oq-01/meta.json
@@ -17,7 +17,7 @@
       "pigeonhole",
       "extremal-graph-theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-21",
     "axiomCount": 0,

--- a/src/data/proofs/erdos-835-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-835-incomplete-01/meta.json
@@ -31,7 +31,7 @@
       "erdos-problems",
       "graph-coloring"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "axiomCount": 0,

--- a/src/data/proofs/erdos-846/meta.json
+++ b/src/data/proofs/erdos-846/meta.json
@@ -21,7 +21,7 @@
       "density-to-structure",
       "alphaproof-nexus"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 846,
     "erdosUrl": "https://erdosproblems.com/846",

--- a/src/data/proofs/erdos-866-oq-01/meta.json
+++ b/src/data/proofs/erdos-866-oq-01/meta.json
@@ -27,7 +27,7 @@
       "parity",
       "erdos-problems"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "axiomCount": 0,

--- a/src/data/proofs/erdos-895-counterexample-fin18/meta.json
+++ b/src/data/proofs/erdos-895-counterexample-fin18/meta.json
@@ -18,7 +18,7 @@
       "verified"
     ],
     "proofRepoPath": "Proofs/Erdos895CounterexampleFin18.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 120,

--- a/src/data/proofs/erdos-94-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-94-oq-02-incomplete-01/meta.json
@@ -20,7 +20,7 @@
       "reduction",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. All results depend only on Lean's foundational axioms (propext, Classical.choice, Quot.sound); there are no axiom declarations, no sorries, and no structure-encoded assumptions. The theorems are stated abstractly over an arbitrary real sequence with the relevant convergence/envelope facts as ordinary hypotheses (not axioms).",

--- a/src/data/proofs/erdos-978-oq-01/meta.json
+++ b/src/data/proofs/erdos-978-oq-01/meta.json
@@ -19,7 +19,7 @@
       "ZMod",
       "open-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 978,
     "erdosUrl": "https://erdosproblems.com/978",

--- a/src/data/proofs/erdos-998-oq-04/meta.json
+++ b/src/data/proofs/erdos-998-oq-04/meta.json
@@ -18,7 +18,7 @@
       "three-distance-theorem",
       "irrational-rotation"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 998,
     "erdosUrl": "https://erdosproblems.com/998",

--- a/src/data/proofs/erdos-ko-rado-oq-01/meta.json
+++ b/src/data/proofs/erdos-ko-rado-oq-01/meta.json
@@ -17,7 +17,7 @@
       "cyclic-intervals",
       "erdos-ko-rado"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 244,

--- a/src/data/proofs/erdos-ko-rado-oq-02/meta.json
+++ b/src/data/proofs/erdos-ko-rado-oq-02/meta.json
@@ -16,7 +16,7 @@
       "kruskal-katona",
       "erdos-ko-rado"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 171,

--- a/src/data/proofs/erdos-ko-rado-oq-03/meta.json
+++ b/src/data/proofs/erdos-ko-rado-oq-03/meta.json
@@ -17,7 +17,7 @@
       "erdos-ko-rado",
       "uniqueness"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-26",
     "axiomCount": 0,

--- a/src/data/proofs/euler-criterion-squares-oq-01-oq-02/meta.json
+++ b/src/data/proofs/euler-criterion-squares-oq-01-oq-02/meta.json
@@ -33,7 +33,7 @@
       "quadratic-reciprocity",
       "supplementary-laws"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/euler-identity-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01/meta.json
@@ -15,7 +15,7 @@
       "euler-formula",
       "alternative-proof"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 211,

--- a/src/data/proofs/euler-polyhedral-formula-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-01-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "euler-formula"
     ],
     "proofRepoPath": "Proofs/PlanarGraphDischarging.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/euler-totient-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-01-oq-02/meta.json
@@ -17,7 +17,7 @@
       "fermat-euler",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 82,

--- a/src/data/proofs/euler-totient-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-02-oq-02-oq-01/meta.json
@@ -15,7 +15,7 @@
       "primitive-root"
     ],
     "proofRepoPath": "Proofs/EulerTotientOQ02OQ02OQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 literal `axiom` declarations, 0 sorries, and no `native_decide`. The key theorems `carmichael_isLeast_universal`, `carmichael_dvd_iff`, `carmichael_eq_totient_iff_isCyclic`, and `carmichael_eight_lt_totient` were confirmed via `#print axioms` to depend only on the ordinary foundational axioms propext, Classical.choice, Quot.sound; there is no `sorryAx` and no `Lean.ofReduceBool`. The single concrete evaluation λ(8) = 2 is obtained from Mathlib's closed-form `carmichael_two_pow_of_ne_two` (not a decision procedure), and Mathlib's `ZMod.not_isCyclic_units_eight` uses only kernel `decide`, so no `Lean.ofReduceBool` enters.",

--- a/src/data/proofs/euler-totient-oq-02-oq-02/meta.json
+++ b/src/data/proofs/euler-totient-oq-02-oq-02/meta.json
@@ -13,7 +13,7 @@
       "lagrange-theorem"
     ],
     "proofRepoPath": "Proofs/EulerTotientOQ02OQ02.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 literal `axiom` declarations, 0 sorries, and no `native_decide`. All 8 theorems depend only on the ordinary foundational axioms propext, Classical.choice, Quot.sound (confirmed via `#print axioms`); there is no `sorryAx` and no `Lean.ofReduceBool`. This entry deliberately avoids the base file's `native_decide` numerical checks, replacing the non-coprime counterexamples with the general 0-axiom theorem `coprime_of_pow_modEq_one`.",

--- a/src/data/proofs/euler-totient-oq-03-oq-02/meta.json
+++ b/src/data/proofs/euler-totient-oq-03-oq-02/meta.json
@@ -20,7 +20,7 @@
       "prime-powers"
     ],
     "proofRepoPath": "Proofs/EulerTotientOQ03OQ02.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 literal `axiom` declarations and 0 sorries. Every theorem depends only on the foundational axioms propext, Classical.choice, Quot.sound (not counted), as confirmed by `#print axioms` on totient_sq_ge_self and sqrt_le_totient. No `native_decide` is used (the `decide`/`norm_num`/`nlinarith` calls are kernel-checked), so `Lean.ofReduceBool` is NOT introduced. Built against Mathlib's `Nat.totient` API (`totient_prime_pow`, `totient_mul`, `recOnPosPrimePosCoprime`, `exists_eq_two_pow_mul_odd`).",

--- a/src/data/proofs/euler-totient-oq-03-oq-03/meta.json
+++ b/src/data/proofs/euler-totient-oq-03-oq-03/meta.json
@@ -13,7 +13,7 @@
       "product-formula"
     ],
     "proofRepoPath": "Proofs/EulerTotientOQ03OQ03.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 literal `axiom` declarations and 0 sorries. All seven theorems depend only on the foundational axioms propext, Classical.choice, Quot.sound (not counted). The example sanity checks use kernel `decide`/`norm_num` only — no `native_decide`, so `Lean.ofReduceBool` is NOT introduced. Built against Mathlib's `Nat.totient` API; the central identity `Nat.totient_gcd_mul_totient_mul` is from Mathlib, and the consequences derived here (exact division form, coprime/divisibility collapses, general power formula) are proved from it.",

--- a/src/data/proofs/factor-remainder-theorem-oq-06-oq-01/meta.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-06-oq-01/meta.json
@@ -15,7 +15,7 @@
       "rational-root-theorem",
       "irrationality"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/factor-remainder-theorem-oq-06/meta.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-06/meta.json
@@ -16,7 +16,7 @@
       "irrationality",
       "factor-theorem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/fatou-lemma-oq-01-oq-02/meta.json
+++ b/src/data/proofs/fatou-lemma-oq-01-oq-02/meta.json
@@ -41,7 +41,7 @@
     "lineCount": 161,
     "theoremCount": 6,
     "definitionCount": 0,
-    "badge": "synthesis",
+    "badge": "mathlib",
     "originalContributions": [
       "escaping_no_integrable_majorant: the headline — the escaping-mass sequence escaping n = 𝟙_[n,n+1) admits NO integrable majorant. Every g : ℝ → ℝ≥0∞ with escaping n ≤ g for all n has ∫⁻ g = ∞. This formalizes the claim the parent entry asserted only informally, and is the precise quantitative reason the dominated convergence theorem cannot be applied to the escaping bumps. Mathlib records DCT and its integrable-majorant hypothesis but no witness that the hypothesis is genuinely necessary.",
       "ici_indicator_le_of_dominates: the supporting mechanism — any g dominating all bumps dominates the indicator of [0,∞). For x ≥ 0 the single bump escaping ⌊x⌋₊ already equals 1 at x (as x ∈ [⌊x⌋₊, ⌊x⌋₊+1)), so 𝟙_[0,∞) ≤ g pointwise; this is the pointwise supremum ⨆ₙ escaping n = 𝟙_[0,∞) in usable form. Integrating against volume (Set.Ici 0) = ∞ forces ∫⁻ g = ∞.",

--- a/src/data/proofs/fermat-two-squares-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-01-oq-03-oq-01/meta.json
@@ -140,7 +140,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/FermatTwoSquaresOQ01OQ03OQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/fermat-two-squares-oq-04-oq-01/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-04-oq-01/meta.json
@@ -19,7 +19,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/FermatTwoSquaresOQ04OQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/fermat-two-squares-oq-04/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-04/meta.json
@@ -19,7 +19,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/FermatTwoSquaresOQ04.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/fermat-two-squares-oq-05/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-05/meta.json
@@ -17,7 +17,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/FermatTwoSquaresOQ05.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/fermat-two-squares-oq-06-oq-02/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-06-oq-02/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/FermatTwoSquaresOQ06OQ02.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [],

--- a/src/data/proofs/fermat-two-squares-oq-06/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-06/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/FermatTwoSquaresOQ06.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/fermat-two-squares-oq-07/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-07/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/FermatTwoSquaresOQ07.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [],

--- a/src/data/proofs/fermat-two-squares-oq-09/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-09/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/FermatTwoSquaresOQ09.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/fibonacci-identities-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-02-oq-01/meta.json
@@ -32,7 +32,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/FibonacciIdentitiesOQ02OQ02OQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/fibonacci-identities-oq-02-oq-02/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-02/meta.json
@@ -31,7 +31,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/FibonacciIdentitiesOQ02OQ02.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-02/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-02/meta.json
@@ -18,7 +18,7 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/FibonacciIdentitiesOQ06OQ01OQ02.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. Every theorem's `#print axioms` lists only the standard foundational axioms propext / Classical.choice / Quot.sound; no native_decide, no Lean.ofReduceBool. Fully machine-checked.",

--- a/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-03/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-06-oq-01-oq-03/meta.json
@@ -18,7 +18,7 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/FibonacciIdentitiesOQ06OQ01OQ03.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. Every theorem's `#print axioms` lists only the standard foundational axioms propext / Classical.choice / Quot.sound; no native_decide, no Lean.ofReduceBool. Fully machine-checked.",

--- a/src/data/proofs/fibonacci-identities-oq-08-oq-01/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-08-oq-01/meta.json
@@ -10,7 +10,7 @@
     "status": "verified",
     "tags": ["number-theory", "fibonacci", "lucas-numbers", "telescoping-sum", "alternating-sum", "bisection", "induction", "research"],
     "proofRepoPath": "Proofs/FibonacciIdentitiesOQ08OQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/fibonacci-identities-oq-08/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-08/meta.json
@@ -10,7 +10,7 @@
     "status": "verified",
     "tags": ["number-theory", "fibonacci", "lucas-numbers", "telescoping-sum", "induction", "research"],
     "proofRepoPath": "Proofs/FibonacciIdentitiesOQ08.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/fodor-pressing-down-oq-03/meta.json
+++ b/src/data/proofs/fodor-pressing-down-oq-03/meta.json
@@ -9,7 +9,7 @@
     "date": "Classical set theory (Fodor 1956; reflection theory)",
     "status": "verified",
     "proofRepoPath": "Proofs/Reflection/Basic.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "tags": [
       "set-theory",
       "ordinals",

--- a/src/data/proofs/fourier-series-oq-02-oq-03-wip-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-03-wip-01/meta.json
@@ -16,7 +16,7 @@
       "extremal",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 9,

--- a/src/data/proofs/fourth-root-2-irrational-oq-01/meta.json
+++ b/src/data/proofs/fourth-root-2-irrational-oq-01/meta.json
@@ -18,7 +18,7 @@
       "tower-law",
       "dihedral-group"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 229,

--- a/src/data/proofs/fourth-root-2-irrational-oq-02/meta.json
+++ b/src/data/proofs/fourth-root-2-irrational-oq-02/meta.json
@@ -17,7 +17,7 @@
       "eisenstein-criterion",
       "intermediate-field"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 227,

--- a/src/data/proofs/fourth-root-2-irrational-oq-03/meta.json
+++ b/src/data/proofs/fourth-root-2-irrational-oq-03/meta.json
@@ -18,7 +18,7 @@
       "minimal-polynomial",
       "dihedral-group"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 147,

--- a/src/data/proofs/friendship-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/friendship-theorem-oq-01-oq-02/meta.json
@@ -37,7 +37,7 @@
       "trace",
       "combinatorics"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-01",
     "axiomCount": 0,

--- a/src/data/proofs/gamma-log-convexity-oq-01/meta.json
+++ b/src/data/proofs/gamma-log-convexity-oq-01/meta.json
@@ -15,7 +15,7 @@
       "inequalities",
       "gautschi"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-20",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/gcd-algorithm-oq-01-oq-04/meta.json
+++ b/src/data/proofs/gcd-algorithm-oq-01-oq-04/meta.json
@@ -19,7 +19,7 @@
       "intermediate"
     ],
     "proofRepoPath": "Proofs/GCDAlgorithmOQ01OQ04.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 178,

--- a/src/data/proofs/general-quartic/meta.json
+++ b/src/data/proofs/general-quartic/meta.json
@@ -16,7 +16,7 @@
       "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/GeneralQuartic.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/geometric-series-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-01-oq-02/meta.json
@@ -16,7 +16,7 @@
       "geometric-series",
       "dirichlet-eta"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 101,

--- a/src/data/proofs/geometric-series-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-01/meta.json
@@ -16,7 +16,7 @@
       "geometric-series",
       "divergent-series"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 79,

--- a/src/data/proofs/geometric-series-oq-01-oq-02/meta.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-02/meta.json
@@ -16,7 +16,7 @@
       "divergent-series",
       "geometric-series"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 198,

--- a/src/data/proofs/godel-first-incompleteness-oq01-oq-02/meta.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01-oq-02/meta.json
@@ -16,7 +16,7 @@
       "model-theory",
       "consistency"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 167,

--- a/src/data/proofs/godel-first-incompleteness-oq01-oq-03/meta.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01-oq-03/meta.json
@@ -16,7 +16,7 @@
       "model-theory",
       "soundness"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 143,

--- a/src/data/proofs/godel-incompleteness-oq-04/meta.json
+++ b/src/data/proofs/godel-incompleteness-oq-04/meta.json
@@ -18,7 +18,7 @@
       "cardinal-arithmetic",
       "advanced"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "greens-theorem",
       "axiom-elimination"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. 0 sorries, 0 axioms. The 2D and 3D cases are proved here directly; n-dimensional order independence (iteratedIntervalIntegral_order_independent) is proved as a real theorem in the subsidiary module Proofs.GreensTheoremOQ01OQ01OQ01OQ01 via Equiv.Perm.swap_induction_on plus the adjacent-swap Fubini lemma.",

--- a/src/data/proofs/greens-theorem-oq002/meta.json
+++ b/src/data/proofs/greens-theorem-oq002/meta.json
@@ -38,7 +38,7 @@
       "open-question",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 230,

--- a/src/data/proofs/halting-problem-oq-01/meta.json
+++ b/src/data/proofs/halting-problem-oq-01/meta.json
@@ -21,7 +21,7 @@
       "partial-recursive",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 255,

--- a/src/data/proofs/halting-problem-oq-02/meta.json
+++ b/src/data/proofs/halting-problem-oq-02/meta.json
@@ -17,7 +17,7 @@
       "partial-recursive",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 144,

--- a/src/data/proofs/hermite-legendre-factorial-oq-01/meta.json
+++ b/src/data/proofs/hermite-legendre-factorial-oq-01/meta.json
@@ -18,7 +18,7 @@
       "euclidean-division",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 130,

--- a/src/data/proofs/hermite-legendre-factorial-oq-02/meta.json
+++ b/src/data/proofs/hermite-legendre-factorial-oq-02/meta.json
@@ -18,7 +18,7 @@
       "induction",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 159,

--- a/src/data/proofs/hermite-legendre-factorial/meta.json
+++ b/src/data/proofs/hermite-legendre-factorial/meta.json
@@ -17,7 +17,7 @@
       "euclidean-division",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 82,

--- a/src/data/proofs/hermite-sawtooth-identity-oq-01-oq-03/meta.json
+++ b/src/data/proofs/hermite-sawtooth-identity-oq-01-oq-03/meta.json
@@ -17,7 +17,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/HermiteSawtoothIdentityOQ01OQ03.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. Fully machine-checked: 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. Depends only on the foundational axioms propext, Classical.choice, Quot.sound.",

--- a/src/data/proofs/hilbert-10-oq002/meta.json
+++ b/src/data/proofs/hilbert-10-oq002/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research",
     "date": "2026-06-19",
     "status": "verified",
-    "badge": "verified",
+    "badge": "mathlib",
     "proofRepoPath": "Proofs/Hilbert10OQ04OQ03OQ02OQ01.lean",
     "tags": [
       "hilbert-10",

--- a/src/data/proofs/hilbert-13-oq-02/meta.json
+++ b/src/data/proofs/hilbert-13-oq-02/meta.json
@@ -17,7 +17,7 @@
       "kolmogorov-arnold",
       "topological-invariant"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 174,

--- a/src/data/proofs/hilbert-22-oq-01-oq-03/meta.json
+++ b/src/data/proofs/hilbert-22-oq-01-oq-03/meta.json
@@ -16,7 +16,7 @@
       "hilbert-problems",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 263,

--- a/src/data/proofs/hilbert-23-oq-01/meta.json
+++ b/src/data/proofs/hilbert-23-oq-01/meta.json
@@ -17,7 +17,7 @@
       "hilbert-problems",
       "intermediate"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/hurwitz-theorem-oq-03-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-oq-01-incomplete-01/meta.json
@@ -55,7 +55,7 @@
       "mathlib-api",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-07-01",

--- a/src/data/proofs/intermediate-value-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-02-oq-01/meta.json
@@ -17,7 +17,7 @@
       "continuity",
       "convergence"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-21",
     "axiomCount": 0,

--- a/src/data/proofs/intermediate-value-theorem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-02-oq-02/meta.json
@@ -17,7 +17,7 @@
       "convergence-rate",
       "square-root"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "axiomCount": 0,

--- a/src/data/proofs/inverse-galois-d4-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq-02-oq-03-oq-01/meta.json
@@ -21,7 +21,7 @@
       "field-extensions",
       "polynomial"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 118,

--- a/src/data/proofs/inverse-galois-d4-oq-02-oq-03/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq-02-oq-03/meta.json
@@ -20,7 +20,7 @@
       "field-extensions",
       "polynomial"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 81,

--- a/src/data/proofs/inverse-galois-d4-oq-02/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq-02/meta.json
@@ -20,7 +20,7 @@
       "field-extensions",
       "polynomial"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 429,

--- a/src/data/proofs/inverse-galois-d4-oq-03-incomplete-01/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq-03-incomplete-01/meta.json
@@ -19,7 +19,7 @@
       "capelli-theorem",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 205,

--- a/src/data/proofs/inverse-galois-d4-oq-03/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq-03/meta.json
@@ -18,7 +18,7 @@
       "capelli-theorem",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 363,

--- a/src/data/proofs/inverse-galois-d4-oq001/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq001/meta.json
@@ -22,7 +22,7 @@
       "affine-group",
       "polynomial"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 75,

--- a/src/data/proofs/inverse-galois-d4-oq002/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq002/meta.json
@@ -22,7 +22,7 @@
       "symmetric-group",
       "polynomial"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 113,

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "equality-case",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-22",

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "equality-case",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-22",

--- a/src/data/proofs/jensen-inequality-oq-01/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01/meta.json
@@ -17,7 +17,7 @@
       "equality-case",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-22",

--- a/src/data/proofs/jensen-inequality-oq001/meta.json
+++ b/src/data/proofs/jensen-inequality-oq001/meta.json
@@ -18,7 +18,7 @@
       "inequalities",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-22",

--- a/src/data/proofs/jensen-inequality-oq002/meta.json
+++ b/src/data/proofs/jensen-inequality-oq002/meta.json
@@ -19,7 +19,7 @@
       "inequalities",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-22",

--- a/src/data/proofs/jensen-inequality-oq003/meta.json
+++ b/src/data/proofs/jensen-inequality-oq003/meta.json
@@ -20,7 +20,7 @@
       "inequalities",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-22",

--- a/src/data/proofs/jensen-inequality-oq005/meta.json
+++ b/src/data/proofs/jensen-inequality-oq005/meta.json
@@ -18,7 +18,7 @@
       "inequalities",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-22",

--- a/src/data/proofs/jensen-inequality-oq006/meta.json
+++ b/src/data/proofs/jensen-inequality-oq006/meta.json
@@ -18,7 +18,7 @@
       "inequalities",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-22",

--- a/src/data/proofs/jensen-inequality-oq007/meta.json
+++ b/src/data/proofs/jensen-inequality-oq007/meta.json
@@ -19,7 +19,7 @@
       "inequalities",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-22",

--- a/src/data/proofs/konigsberg-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/konigsberg-oq-01-oq-02-incomplete-01/meta.json
@@ -18,7 +18,7 @@
       "hierholzer",
       "refutation"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-25",
     "axiomCount": 0,

--- a/src/data/proofs/konigsberg-oq-05/meta.json
+++ b/src/data/proofs/konigsberg-oq-05/meta.json
@@ -15,7 +15,7 @@
       "parity",
       "vertex-degree"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-01",
     "axiomCount": 0,

--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-08/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-08/meta.json
@@ -16,7 +16,7 @@
       "three-squares",
       "least-element"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-21",
     "axiomCount": 0,

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-01/meta.json
@@ -24,7 +24,7 @@
       "cyclic-units",
       "ZMod"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-05-12",
     "axiomCount": 0,

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-02/meta.json
@@ -25,7 +25,7 @@
       "semidirect-product",
       "automorphism"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "axiomCount": 0,

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-01/meta.json
@@ -17,7 +17,7 @@
       "finite-groups",
       "pq-groups"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-05-05",
     "axiomCount": 0,

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-01/meta.json
@@ -18,7 +18,7 @@
       "subgroups",
       "quotient-groups"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-28",
     "axiomCount": 0,

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-02/meta.json
@@ -18,7 +18,7 @@
       "lagrange",
       "subgroups"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-28",
     "axiomCount": 0,

--- a/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-01-oq-03/meta.json
@@ -16,7 +16,7 @@
       "cross-product",
       "duality"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-05-06",
     "mathlibDependencies": [

--- a/src/data/proofs/law-of-cosines-oq-04-oq-01/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-04-oq-01/meta.json
@@ -31,7 +31,7 @@
       "law-of-cosines",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 178,

--- a/src/data/proofs/law-of-cosines-oq-08/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-08/meta.json
@@ -16,7 +16,7 @@
       "metric",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 149,

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-02/meta.json
@@ -30,7 +30,7 @@
       "real-analysis",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-27",
     "axiomCount": 0,

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-03/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-03/meta.json
@@ -18,7 +18,7 @@
       "borel-sets",
       "real-analysis"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 244,

--- a/src/data/proofs/lebesgue-measure-oq-03-wip-01/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-03-wip-01/meta.json
@@ -19,7 +19,7 @@
       "functional-analysis",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/lebesgue-measure-oq-04/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-04/meta.json
@@ -17,7 +17,7 @@
       "cardinality",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 139,

--- a/src/data/proofs/lebesgue-measure-oq003/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq003/meta.json
@@ -31,7 +31,7 @@
       "real-analysis",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-21",
     "axiomCount": 0,

--- a/src/data/proofs/legendre-factorial-formula-oq-01-oq-02/meta.json
+++ b/src/data/proofs/legendre-factorial-formula-oq-01-oq-02/meta.json
@@ -18,7 +18,7 @@
       "digit-sum",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 128,

--- a/src/data/proofs/lhopital-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lhopital-oq-01-oq-01/meta.json
@@ -17,7 +17,7 @@
       "monotonicity",
       "extension"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 127,

--- a/src/data/proofs/lhopital-oq-04-oq-01/meta.json
+++ b/src/data/proofs/lhopital-oq-04-oq-01/meta.json
@@ -17,7 +17,7 @@
       "derivatives",
       "iterated-derivative"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 201,

--- a/src/data/proofs/lhopital-oq-04/meta.json
+++ b/src/data/proofs/lhopital-oq-04/meta.json
@@ -16,7 +16,7 @@
       "limits",
       "derivatives"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 100,

--- a/src/data/proofs/lhopital-oq-05-oq-01/meta.json
+++ b/src/data/proofs/lhopital-oq-05-oq-01/meta.json
@@ -17,7 +17,7 @@
       "trigonometry",
       "squeeze-theorem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 87,

--- a/src/data/proofs/lhopital-oq-05-oq-02/meta.json
+++ b/src/data/proofs/lhopital-oq-05-oq-02/meta.json
@@ -17,7 +17,7 @@
       "trigonometry",
       "squeeze-theorem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 145,

--- a/src/data/proofs/lhopital-oq-05/meta.json
+++ b/src/data/proofs/lhopital-oq-05/meta.json
@@ -17,7 +17,7 @@
       "trigonometry",
       "squeeze-theorem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 83,

--- a/src/data/proofs/lovasz-local-lemma-oq-01-chain-rule/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-chain-rule/meta.json
@@ -17,7 +17,7 @@
       "conditional-probability",
       "chain-rule"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-02",
     "axiomCount": 0,

--- a/src/data/proofs/lovasz-local-lemma-oq-01-conditional-avoidance/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-conditional-avoidance/meta.json
@@ -16,7 +16,7 @@
       "probability",
       "conditional-probability"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-03",
     "axiomCount": 0,

--- a/src/data/proofs/lovasz-local-lemma-oq-01-denominator-recursion/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-denominator-recursion/meta.json
@@ -16,7 +16,7 @@
       "conditional-probability",
       "induction"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-03",
     "axiomCount": 0,

--- a/src/data/proofs/lovasz-local-lemma-oq-01-denominator-step/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-denominator-step/meta.json
@@ -15,7 +15,7 @@
       "measure-theory",
       "conditional-probability"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-03",
     "axiomCount": 0,

--- a/src/data/proofs/lovasz-local-lemma-oq-01-dependency-split/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-dependency-split/meta.json
@@ -16,7 +16,7 @@
       "conditional-probability",
       "independence"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-03",
     "axiomCount": 0,

--- a/src/data/proofs/lovasz-local-lemma-oq-01-euler-threshold/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-euler-threshold/meta.json
@@ -16,7 +16,7 @@
       "inequalities",
       "exponential-function"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-03",
     "axiomCount": 0,

--- a/src/data/proofs/lovasz-local-lemma-oq-01-inclusion-exclusion/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-inclusion-exclusion/meta.json
@@ -17,7 +17,7 @@
       "inclusion-exclusion",
       "bonferroni"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-03",
     "axiomCount": 0,

--- a/src/data/proofs/lovasz-local-lemma-oq-01-independence-bridge/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-independence-bridge/meta.json
@@ -16,7 +16,7 @@
       "probability",
       "independence"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-03",
     "axiomCount": 0,

--- a/src/data/proofs/lovasz-local-lemma-oq-01-induction-step/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-induction-step/meta.json
@@ -15,7 +15,7 @@
       "measure-theory",
       "conditional-probability"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-03",
     "axiomCount": 0,

--- a/src/data/proofs/lovasz-local-lemma-oq-01-quantitative/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-quantitative/meta.json
@@ -16,7 +16,7 @@
       "probability",
       "conditional-probability"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-03",
     "axiomCount": 0,

--- a/src/data/proofs/lovasz-local-lemma-oq-01-subset-history-pos/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-subset-history-pos/meta.json
@@ -16,7 +16,7 @@
       "probability",
       "conditional-probability"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-03",
     "axiomCount": 0,

--- a/src/data/proofs/lovasz-local-lemma-oq-01-symmetric-step/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-symmetric-step/meta.json
@@ -15,7 +15,7 @@
       "measure-theory",
       "conditional-probability"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-03",
     "axiomCount": 0,

--- a/src/data/proofs/lovasz-local-lemma-oq-01-union-bound/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-union-bound/meta.json
@@ -17,7 +17,7 @@
       "union-bound",
       "first-moment-method"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-02",
     "axiomCount": 0,

--- a/src/data/proofs/lovasz-local-lemma-oq-01/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01/meta.json
@@ -16,7 +16,7 @@
       "probability",
       "independence"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-02",
     "axiomCount": 0,

--- a/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
@@ -16,7 +16,7 @@
       "am-gm",
       "polynomial-inequalities"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-13",
     "axiomCount": 0,

--- a/src/data/proofs/lucas-sequence-degree2-identities-oq-02-oq-01/meta.json
+++ b/src/data/proofs/lucas-sequence-degree2-identities-oq-02-oq-01/meta.json
@@ -10,7 +10,7 @@
     "status": "verified",
     "tags": ["number-theory", "lucas-sequences", "divisibility", "coprimality", "gcd", "induction", "research"],
     "proofRepoPath": "Proofs/LucasSequenceDegree2IdentitiesOQ02OQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/markov-equation/meta.json
+++ b/src/data/proofs/markov-equation/meta.json
@@ -16,7 +16,7 @@
       "infinite-descent",
       "markov-tree"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-21",

--- a/src/data/proofs/minpoly-charpoly-oq-01-oq-01/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-01-oq-01/meta.json
@@ -20,7 +20,7 @@
       "non-derogatory",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 197,

--- a/src/data/proofs/minpoly-charpoly-oq-02/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-02/meta.json
@@ -19,7 +19,7 @@
       "eigenspace",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 456,

--- a/src/data/proofs/minpoly-charpoly-oq-03-oq-01/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-03-oq-01/meta.json
@@ -21,7 +21,7 @@
       "rational-canonical-form",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 258,

--- a/src/data/proofs/minpoly-charpoly-oq-03/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-03/meta.json
@@ -19,7 +19,7 @@
       "structure-theorem-pid",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 739,

--- a/src/data/proofs/navier-stokes-oq-01-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01-oq-01/meta.json
@@ -38,7 +38,7 @@
       "analysis",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-02",
     "relatedProblems": [

--- a/src/data/proofs/pascals-hexagon-incomplete-01/meta.json
+++ b/src/data/proofs/pascals-hexagon-incomplete-01/meta.json
@@ -16,7 +16,7 @@
       "linear-algebra",
       "sylvester"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 152,

--- a/src/data/proofs/pell-equation-oq-02/meta.json
+++ b/src/data/proofs/pell-equation-oq-02/meta.json
@@ -15,7 +15,7 @@
       "fundamental-solution",
       "quadratic-fields"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 105,

--- a/src/data/proofs/pell-equation-oq-03/meta.json
+++ b/src/data/proofs/pell-equation-oq-03/meta.json
@@ -20,7 +20,7 @@
       "exponential-growth",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-07-01",

--- a/src/data/proofs/pell-equation-oq-04-oq-01/meta.json
+++ b/src/data/proofs/pell-equation-oq-04-oq-01/meta.json
@@ -72,7 +72,7 @@
       "finiteness",
       "classification"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 276,

--- a/src/data/proofs/pell-equation-oq-04/meta.json
+++ b/src/data/proofs/pell-equation-oq-04/meta.json
@@ -66,7 +66,7 @@
       "brahmagupta-identity",
       "group-action"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 251,

--- a/src/data/proofs/pell-equation-oq-05/meta.json
+++ b/src/data/proofs/pell-equation-oq-05/meta.json
@@ -69,7 +69,7 @@
       "units",
       "dirichlet-unit-theorem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 421,

--- a/src/data/proofs/pell-equation-oq-06-oq-01-oq-02/meta.json
+++ b/src/data/proofs/pell-equation-oq-06-oq-01-oq-02/meta.json
@@ -17,7 +17,7 @@
       "group-theory",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-07-02",

--- a/src/data/proofs/pell-equation-oq-06-oq-01/meta.json
+++ b/src/data/proofs/pell-equation-oq-06-oq-01/meta.json
@@ -17,7 +17,7 @@
       "vieta-jumping",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-21",

--- a/src/data/proofs/pell-equation-oq-06-oq-02/meta.json
+++ b/src/data/proofs/pell-equation-oq-06-oq-02/meta.json
@@ -19,7 +19,7 @@
       "norm-multiplicativity",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-22",

--- a/src/data/proofs/pell-equation-oq-06-oq-03-oq-03/meta.json
+++ b/src/data/proofs/pell-equation-oq-06-oq-03-oq-03/meta.json
@@ -18,7 +18,7 @@
       "quadratic-integer-ring",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-07-04",

--- a/src/data/proofs/pell-equation-oq-06-oq-03/meta.json
+++ b/src/data/proofs/pell-equation-oq-06-oq-03/meta.json
@@ -17,7 +17,7 @@
       "cayley-hamilton",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-22",

--- a/src/data/proofs/pell-equation-oq-06-oq-04/meta.json
+++ b/src/data/proofs/pell-equation-oq-06-oq-04/meta.json
@@ -18,7 +18,7 @@
       "real-analysis",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-22",

--- a/src/data/proofs/pell-equation-oq-06-oq-05/meta.json
+++ b/src/data/proofs/pell-equation-oq-06-oq-05/meta.json
@@ -20,7 +20,7 @@
       "lattice",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-22",

--- a/src/data/proofs/pell-equation-oq-06-oq-06/meta.json
+++ b/src/data/proofs/pell-equation-oq-06-oq-06/meta.json
@@ -20,7 +20,7 @@
       "group-structure",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-22",

--- a/src/data/proofs/pell-equation-oq-06-oq-07/meta.json
+++ b/src/data/proofs/pell-equation-oq-06-oq-07/meta.json
@@ -20,7 +20,7 @@
       "coprimality",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-22",

--- a/src/data/proofs/pell-equation-oq-07-oq-01-oq-01/meta.json
+++ b/src/data/proofs/pell-equation-oq-07-oq-01-oq-01/meta.json
@@ -30,7 +30,7 @@
       "recurrence",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-07-01",

--- a/src/data/proofs/pell-equation-oq-07-oq-01-oq-02/meta.json
+++ b/src/data/proofs/pell-equation-oq-07-oq-01-oq-02/meta.json
@@ -30,7 +30,7 @@
       "abstraction",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-07-01",

--- a/src/data/proofs/pell-equation-oq-07-oq-01/meta.json
+++ b/src/data/proofs/pell-equation-oq-07-oq-01/meta.json
@@ -30,7 +30,7 @@
       "conjugation",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-23",

--- a/src/data/proofs/pell-equation-oq-07/meta.json
+++ b/src/data/proofs/pell-equation-oq-07/meta.json
@@ -28,7 +28,7 @@
       "characteristic-polynomial",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-22",

--- a/src/data/proofs/pell-equation-oq-08/meta.json
+++ b/src/data/proofs/pell-equation-oq-08/meta.json
@@ -28,7 +28,7 @@
       "zmod",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-07-01",

--- a/src/data/proofs/perfect-numbers-oq-02/meta.json
+++ b/src/data/proofs/perfect-numbers-oq-02/meta.json
@@ -16,7 +16,7 @@
       "sigma",
       "sum-of-divisors"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 108,

--- a/src/data/proofs/prime-gap-bounds-oq-02/meta.json
+++ b/src/data/proofs/prime-gap-bounds-oq-02/meta.json
@@ -17,7 +17,7 @@
       "explicit-bounds",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/prime-reciprocal-divergence-oq-01/meta.json
+++ b/src/data/proofs/prime-reciprocal-divergence-oq-01/meta.json
@@ -17,7 +17,7 @@
       "convergence",
       "series"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/primitive-roots-oq-04/meta.json
+++ b/src/data/proofs/primitive-roots-oq-04/meta.json
@@ -16,7 +16,7 @@
       "complex-analysis",
       "regular-polygon"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-20",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/prob-method-applications-wip-01-oq-01/meta.json
+++ b/src/data/proofs/prob-method-applications-wip-01-oq-01/meta.json
@@ -17,7 +17,7 @@
       "union-bound",
       "erdos"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/prob-method-applications-wip-01-oq-02/meta.json
+++ b/src/data/proofs/prob-method-applications-wip-01-oq-02/meta.json
@@ -18,7 +18,7 @@
       "union-bound",
       "erdos"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/prob-method-applications-wip-01-oq-03/meta.json
+++ b/src/data/proofs/prob-method-applications-wip-01-oq-03/meta.json
@@ -67,7 +67,7 @@
       "first-moment-method",
       "union-bound"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/prob-method-applications-wip-01/meta.json
+++ b/src/data/proofs/prob-method-applications-wip-01/meta.json
@@ -50,7 +50,7 @@
       "union-bound",
       "first-moment-method"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/prob-method-second-moment/meta.json
+++ b/src/data/proofs/prob-method-second-moment/meta.json
@@ -16,7 +16,7 @@
       "probability",
       "intermediate"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/ptolemys-theorem-oq-03/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-03/meta.json
@@ -37,7 +37,7 @@
       "intermediate"
     ],
     "proofRepoPath": "Proofs/PtolemysTheoremOQ03.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/ptolemys-theorem-oq-04/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-04/meta.json
@@ -37,7 +37,7 @@
       "intermediate"
     ],
     "proofRepoPath": "Proofs/PtolemysTheoremOQ04.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/ptolemys-theorem-oq-05/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-05/meta.json
@@ -60,7 +60,7 @@
     "date": "2026",
     "dateAdded": "2026-06-24",
     "status": "verified",
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "definitionCount": 0,
     "theoremCount": 3,

--- a/src/data/proofs/pythagorean-theorem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-03-oq-02/meta.json
@@ -16,7 +16,7 @@
       "hyperbolic-functions",
       "lorentz-factor"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 190,

--- a/src/data/proofs/pythagorean-triples-oq-08/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-08/meta.json
@@ -15,7 +15,7 @@
       "diophantine",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-19",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/pythagorean-triples-oq-10/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-10/meta.json
@@ -15,7 +15,7 @@
       "diophantine",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-24",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/quadratic-gauss-sum-square-oq-03/meta.json
+++ b/src/data/proofs/quadratic-gauss-sum-square-oq-03/meta.json
@@ -32,7 +32,7 @@
       "discriminant",
       "zmod"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 209,

--- a/src/data/proofs/ramanujan-sum-fallacy-oq-02/meta.json
+++ b/src/data/proofs/ramanujan-sum-fallacy-oq-02/meta.json
@@ -16,7 +16,7 @@
       "summability",
       "educational"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/ramsey-r4k-oq-02/meta.json
+++ b/src/data/proofs/ramsey-r4k-oq-02/meta.json
@@ -14,7 +14,7 @@
       "exact-ramsey-numbers",
       "lower-bounds"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 107,

--- a/src/data/proofs/ramseys-theorem-oq-04-oq-01/meta.json
+++ b/src/data/proofs/ramseys-theorem-oq-04-oq-01/meta.json
@@ -19,7 +19,7 @@
       "testBit",
       "number-theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/ramseys-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/ramseys-theorem-oq-04-oq-03/meta.json
@@ -17,7 +17,7 @@
       "exact-bounds",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-02",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "counting-operator",
       "ZMod"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
@@ -18,7 +18,7 @@
       "normalization",
       "ZMod"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-04",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/roth-theorem-k3-oq001/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq001/meta.json
@@ -18,7 +18,7 @@
       "counting-operator",
       "ZMod"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/roth-theorem-k3-oq002/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq002/meta.json
@@ -53,7 +53,7 @@
       "counting-operator",
       "ZMod"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/schroder-numbers-oq-01/meta.json
+++ b/src/data/proofs/schroder-numbers-oq-01/meta.json
@@ -15,7 +15,7 @@
       "growth-bound",
       "monotonicity"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-20",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/schroeder-bernstein-oq-03/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/meta.json
@@ -16,7 +16,7 @@
       "set-theory",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 3556,

--- a/src/data/proofs/schur-lemma-oq-02/meta.json
+++ b/src/data/proofs/schur-lemma-oq-02/meta.json
@@ -18,7 +18,7 @@
       "endomorphism-algebra",
       "absolute-simplicity"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 129,

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-03/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-03/meta.json
@@ -41,7 +41,7 @@
     "lineCount": 284,
     "theoremCount": 16,
     "definitionCount": 2,
-    "badge": "verified",
+    "badge": "mathlib",
     "originalContributions": [
       "shannonHartley_eq_awgn: the bridge identity C(B, P, N) = (2B / log 2)·awgnCapacity P N. This is the precise formal content of 'Nyquist sampling + change of logarithm base': the per-use AWGN capacity awgnCapacity P N = ½ log(1 + P/N) (nats per channel use, from the parent file) is multiplied by the Nyquist factor 2B (independent dimensions per second) and divided by log 2 (the nats→bits change of base), yielding the bits-per-second Shannon–Hartley value. It ties the bandlimited formula directly to the parent's verified per-use quantity rather than re-deriving it.",
       "shannonHartleyCapacity / shannonHartley_eq_two_B_bits_per_use: the definition C(B, P, N) = B·log₂(1 + P/N) and its 'Nyquist reading' C = 2B·(½ log₂(1 + P/N)), exposing the capacity as 2B copies of the per-use bit capacity ½ log₂(1 + P/N).",

--- a/src/data/proofs/shannon-entropy-oq-03/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03/meta.json
@@ -16,7 +16,7 @@
       "verified"
     ],
     "proofRepoPath": "Proofs/ShannonEntropySSA.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. The strong-subadditivity inequality H(X,Y,Z)+H(Y) ≤ H(X,Y)+H(Y,Z) is proved axiom-free (0 sorries) in the parent file Proofs/ShannonEntropy.lean as InformationTheory.strong_subadditivity (conditional-KL-divergence argument: each term p·log(p/q) ≥ p−q via the Gibbs inequality, block sum telescoping to 0). This file re-exports that theorem and derives its three three-variable corollaries (conditioning_reduces_entropy_general, conditioning_reduces_entropy_general′, conditional_mi_nonneg) by linear rearrangement. #print axioms reports only [propext, Classical.choice, Quot.sound].",

--- a/src/data/proofs/shannon-source-coding-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-04-incomplete-01/meta.json
@@ -17,7 +17,7 @@
       "source-coding",
       "entropy"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 180,

--- a/src/data/proofs/simson-line-theorem-oq-01/meta.json
+++ b/src/data/proofs/simson-line-theorem-oq-01/meta.json
@@ -49,7 +49,7 @@
       "complex-coordinates",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/solution-of-cubic-oq-01-oq-01/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
       "vieta",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [],
     "originalContributions": [
@@ -133,7 +133,7 @@
     ]
   },
   "status": "verified",
-  "badge": "verified",
+  "badge": "mathlib",
   "leanFile": {
     "imports": [
       "Proofs.SolutionOfCubicOQ01"

--- a/src/data/proofs/solution-of-cubic-oq-01-oq-02/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-02/meta.json
@@ -19,7 +19,7 @@
       "vieta",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [],
     "originalContributions": [
@@ -134,7 +134,7 @@
     ]
   },
   "status": "verified",
-  "badge": "verified",
+  "badge": "mathlib",
   "leanFile": {
     "imports": [
       "Proofs.SolutionOfCubicOQ01OQ01"

--- a/src/data/proofs/solution-of-cubic-oq-01-oq-03/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-03/meta.json
@@ -19,7 +19,7 @@
       "polynomial-arithmetic",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [],
     "originalContributions": [
@@ -134,7 +134,7 @@
     ]
   },
   "status": "verified",
-  "badge": "verified",
+  "badge": "mathlib",
   "leanFile": {
     "imports": [
       "Mathlib.Tactic"

--- a/src/data/proofs/solution-of-cubic-oq-01-oq-04/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-04/meta.json
@@ -19,7 +19,7 @@
       "depressed-cubic",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       "Polynomial.rootMultiplicity_eq_rootMultiplicity",
@@ -135,7 +135,7 @@
     ]
   },
   "status": "verified",
-  "badge": "verified",
+  "badge": "mathlib",
   "leanFile": {
     "imports": [
       "Proofs.SolutionOfCubicOQ01",

--- a/src/data/proofs/solution-of-cubic-oq-01/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-01/meta.json
@@ -18,7 +18,7 @@
       "depressed-cubic",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [],
     "originalContributions": [
@@ -124,7 +124,7 @@
     ]
   },
   "status": "verified",
-  "badge": "verified",
+  "badge": "mathlib",
   "leanFile": {
     "imports": [
       "Proofs.SolutionOfCubic"

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-05-oq-01/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-05-oq-01/meta.json
@@ -18,7 +18,7 @@
       "roots",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "axiomCount": 0,
@@ -70,7 +70,7 @@
     }
   ],
   "status": "verified",
-  "badge": "verified",
+  "badge": "mathlib",
   "leanFile": {
     "imports": [
       "Mathlib"

--- a/src/data/proofs/sperner-ndim-oq-06/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-06/meta.json
@@ -22,7 +22,7 @@
       "PPAD",
       "advanced"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "originalContributions": [
       "Abstract model of the Kuhn door-pivot rule as a partial successor `step`/`orbit` on `Option V` (none = terminate at a fully-coloured simplex)",

--- a/src/data/proofs/sperner-simplicial-bridge-oq-01/meta.json
+++ b/src/data/proofs/sperner-simplicial-bridge-oq-01/meta.json
@@ -10,7 +10,7 @@
     "dateAdded": "2026-05-13",
     "mathlib_version": "4.31.0",
     "status": "verified",
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "theoremCount": 13,
     "definitionCount": 3,

--- a/src/data/proofs/spherical-law-of-cosines-oq-04/meta.json
+++ b/src/data/proofs/spherical-law-of-cosines-oq-04/meta.json
@@ -18,7 +18,7 @@
       "cayley-klein",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 390,

--- a/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/meta.json
@@ -15,7 +15,7 @@
       "irreducibility",
       "square-roots"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-22",
     "axiomCount": 0,

--- a/src/data/proofs/stirling-first-kind-oq-01-oq-02/meta.json
+++ b/src/data/proofs/stirling-first-kind-oq-01-oq-02/meta.json
@@ -17,7 +17,7 @@
       "generating-identity",
       "enumerative"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-24",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/stirling-first-kind-oq-01/meta.json
+++ b/src/data/proofs/stirling-first-kind-oq-01/meta.json
@@ -16,7 +16,7 @@
       "factorial",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-20",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/stirling-first-kind-oq-02-oq-01/meta.json
+++ b/src/data/proofs/stirling-first-kind-oq-02-oq-01/meta.json
@@ -17,7 +17,7 @@
       "generating-identity",
       "enumerative"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-24",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/stirling-first-kind-oq-02/meta.json
+++ b/src/data/proofs/stirling-first-kind-oq-02/meta.json
@@ -18,7 +18,7 @@
       "ascPochhammer",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-20",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/stirling-formula-oq-01-oq-01/meta.json
+++ b/src/data/proofs/stirling-formula-oq-01-oq-01/meta.json
@@ -16,7 +16,7 @@
       "factorial",
       "special-functions"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 114,

--- a/src/data/proofs/stirling-formula-oq-02-oq-01/meta.json
+++ b/src/data/proofs/stirling-formula-oq-02-oq-01/meta.json
@@ -16,7 +16,7 @@
       "log-convexity",
       "bohr-mollerup"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-27",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/stirling-formula-oq-03-oq-01/meta.json
+++ b/src/data/proofs/stirling-formula-oq-03-oq-01/meta.json
@@ -16,7 +16,7 @@
       "error-bound",
       "limits"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-24",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/stirling-formula-oq-03/meta.json
+++ b/src/data/proofs/stirling-formula-oq-03/meta.json
@@ -15,7 +15,7 @@
       "limits",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-19",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/stirling-second-kind-oq-01/meta.json
+++ b/src/data/proofs/stirling-second-kind-oq-01/meta.json
@@ -15,7 +15,7 @@
       "closed-form",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-20",
     "mathlib_version": "4.31.0",

--- a/src/data/proofs/subset-count-oq-02-oq-02/meta.json
+++ b/src/data/proofs/subset-count-oq-02-oq-02/meta.json
@@ -13,7 +13,7 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/SubsetCountOQ02OQ02.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 literal `axiom` declarations, 0 sorries, and no `native_decide` (the lone numerical sanity check uses kernel `decide`, so no `Lean.ofReduceBool`). The only axioms appearing in `#print axioms` are the ordinary foundational ones (propext, Classical.choice, Quot.sound), which the project policy does not count. Key Mathlib inputs: Multiset.powersetCard_cons, Multiset.card_powersetCard, Finset.powersetCard_succ_insert, Finset.powerset_card_disjiUnion, Finset.card_powerset, Finset.card_image_of_injOn, Finset.card_union_of_disjoint.",

--- a/src/data/proofs/subset-count-oq-04/meta.json
+++ b/src/data/proofs/subset-count-oq-04/meta.json
@@ -18,7 +18,7 @@
       "research",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 11,

--- a/src/data/proofs/sum-of-divisors-oq-01-oq-01/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-01-oq-01/meta.json
@@ -20,7 +20,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/SumOfDivisorsOQ01OQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/sylvester-gallai-theorem-oq-01/meta.json
+++ b/src/data/proofs/sylvester-gallai-theorem-oq-01/meta.json
@@ -9,7 +9,7 @@
     "date": "Posed 1893 (Sylvester); proved 1940 (Melchior), 1944 (Gallai), 1948 (Kelly)",
     "status": "verified",
     "proofRepoPath": "Proofs/SylvesterGallaiOQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "tags": [
       "combinatorial-geometry",
       "incidence-geometry",

--- a/src/data/proofs/szemeredi-counting-oq-01-oq-01/meta.json
+++ b/src/data/proofs/szemeredi-counting-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
       "verified",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-07-02",

--- a/src/data/proofs/szemeredi-regularity-oq-02-oq-02/meta.json
+++ b/src/data/proofs/szemeredi-regularity-oq-02-oq-02/meta.json
@@ -44,7 +44,7 @@
       "sharp-constant",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-04",
     "axiomCount": 0,

--- a/src/data/proofs/taylor-sincos-convergence-oq-03-incomplete-01/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-03-incomplete-01/meta.json
@@ -16,7 +16,7 @@
       "trigonometric",
       "leibniz"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 140,

--- a/src/data/proofs/telescoping-product-oq-01/meta.json
+++ b/src/data/proofs/telescoping-product-oq-01/meta.json
@@ -39,7 +39,7 @@
     "author": "Lean Genius researcher-2",
     "status": "verified",
     "proofRepoPath": "Proofs/TelescopingProductOQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 98,

--- a/src/data/proofs/triangle-inequality-oq-06-oq-02/meta.json
+++ b/src/data/proofs/triangle-inequality-oq-06-oq-02/meta.json
@@ -17,7 +17,7 @@
       "sharpness"
     ],
     "proofRepoPath": "Proofs/TriangleInequalityOQ06OQ02.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "packagingNote": "Tier C follow-up that answers an open question posed verbatim in the parent triangle-inequality-oq-06 gallery entry. The core inequality is a two-step composition of the Mathlib lemmas abs_dist_sub_le (three-point reverse) and dist_le_range_sum_dist (polygon/path inequality), so the inequality itself is short. The genuinely new content is the sharpness layer: telescoping_reverse_triangle_sharp_mono proves that for every monotone real chain a₀ ≤ ⋯ ≤ aₙ ≤ w the telescoping bound is an equality (both sides equal aₙ − a₀, the right via Finset.sum_range_sub telescoping), certifying the inequality cannot be improved, plus an explicit numeric witness (0,1,2 chain, w = 10). Status is verified (0 sorries, 0 axioms — only propext/Classical.choice/Quot.sound).",
     "sorries": 0,
     "axiomCount": 0,

--- a/src/data/proofs/triangle-inequality-oq-06/meta.json
+++ b/src/data/proofs/triangle-inequality-oq-06/meta.json
@@ -18,7 +18,7 @@
       "sharpness"
     ],
     "proofRepoPath": "Proofs/TriangleInequalityOQ06.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "packagingNote": "Tier B bundle with an original sharpness layer. The atomic inequalities are one-line re-exports of named Mathlib lemmas (abs_dist_sub_le, dist_dist_dist_le, abs_norm_sub_norm_le, LipschitzWith.dist_right/left) plus the standard glue for the quadrilateral form (Real.dist_eq). The genuinely new content is the three sharpness theorems: reverse_triangle_eq_of_between (the reverse inequality is an equality for collinear reals a ≤ b ≤ c), quadrilateral_sharp (an explicit real configuration attaining the two-endpoint bound), and dist_lipschitz_optimal (the Lipschitz constant 1 is best possible). Status is verified (0 sorries, 0 axioms — only propext/Classical.choice/Quot.sound).",
     "sorries": 0,
     "axiomCount": 0,

--- a/src/data/proofs/triangle-inequality-oq-07/meta.json
+++ b/src/data/proofs/triangle-inequality-oq-07/meta.json
@@ -19,7 +19,7 @@
       "equivalence-relation"
     ],
     "proofRepoPath": "Proofs/TriangleInequalityOQ07.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "packagingNote": "Tier B bundle with an original structural layer. The atomic facts are re-exports of named Mathlib lemmas (IsUltrametricDist.dist_triangle_max, ball_eq_of_mem, ball_eq_or_disjoint, isClopen_ball) and the general Setoid/partition API (Setoid.classes, isPartition_classes, IsPartition.pairwiseDisjoint/sUnion_eq_univ). The genuinely new content — which Mathlib does NOT provide — is the equivalence-relation packaging: SameBall (the fixed-radius relation), ballSetoid (proof that it is an equivalence relation, with transitivity supplied by the strong triangle inequality), ballSetoid_class (each class equals a ball), balls_eq_classes (the classes are exactly the radius-r balls), and balls_isPartition (the radius-r balls partition the space). Status is verified (0 sorries, 0 axioms — only propext/Classical.choice/Quot.sound).",
     "sorries": 0,
     "axiomCount": 0,

--- a/src/data/proofs/triangular-reciprocals-oq-04/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-04/meta.json
@@ -16,7 +16,7 @@
       "intermediate"
     ],
     "proofRepoPath": "Proofs/TriangularReciprocalsOQ04.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. Fully machine-checked: 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions.",

--- a/src/data/proofs/unit-distance-independence-oq-01/meta.json
+++ b/src/data/proofs/unit-distance-independence-oq-01/meta.json
@@ -16,7 +16,7 @@
       "chromatic-number",
       "graph-coloring"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-25",
     "axiomCount": 0,

--- a/src/data/proofs/vietas-formulas-oq-04-oq-01/meta.json
+++ b/src/data/proofs/vietas-formulas-oq-04-oq-01/meta.json
@@ -18,7 +18,7 @@
       "symmetric-functions",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 7,

--- a/src/data/proofs/vietas-formulas-oq-04/meta.json
+++ b/src/data/proofs/vietas-formulas-oq-04/meta.json
@@ -18,7 +18,7 @@
       "research",
       "field-theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 6,

--- a/src/data/proofs/vietas-formulas-oq-05/meta.json
+++ b/src/data/proofs/vietas-formulas-oq-05/meta.json
@@ -18,7 +18,7 @@
       "research",
       "ring-theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 8,


### PR DESCRIPTION
## Summary

Fixes the invalid-badge-value integrity defect: **452** gallery entries set a `badge` value outside the `ProofBadge` union (`verified` ×458 lines, `synthesis` ×1, `formalized` ×1). `ProofBadge` (`src/components/ui/proof-badge.tsx:22-23`) looks up `BADGE_INFO[badge]`, gets `undefined`, and returns `null` — so these entries silently rendered **no category badge**.

`verified`/`formalized` are `status` values, not badges (per `proofs/BADGE_TAXONOMY.md` and `src/types/proof.ts:102-111`); they were conflated with the `badge` field. This is the same defect class fixed for `research` in #24758.

## Fix (per-file, content-driven — non-overclaiming)

Canonical badge = **nested `meta.badge` if already valid, else remap by actual Lean content**, then both the top-level `badge` and nested `meta.badge` are set to it:

| old → new | lines |
|-----------|-------|
| `verified` → `mathlib` | 456 |
| `verified` → `original` | 2 |
| `synthesis` → `mathlib` | 1 |
| `formalized` → `mathlib` | 1 |

- **All 449 verified/synthesis/formalized entries are 0-sorry, 0-axiom** after comment-stripping → `mathlib` (the conservative, non-overclaiming default; consistent with their existing `axiomCount:0` / `status:verified`). The audit script's 44 `verified→axiom` were **comment false-positives** — its `hasAxiom` regex does not strip comments.
- **2 files** (`dirichlets-theorem-oq-02-oq-03`, `erdos-1022-oq-02`) had a stale top-level `badge:verified` while the curated nested `meta.badge` was already `original` — these were missed by the issue's `.meta.badge` jq. Top-level is mirrored to the curated `original`.

## Evidence

- Before: 452 files with `badge ∉ ProofBadge` (0 rendered a category badge).
- After: `0` remaining invalid badges; `0` JSON parse failures; diff = **452 files, 460 ins / 460 del**, touching **only** badge value lines (verified via `git diff` grep).

Scope note: the audit's other ~526 proposed reclassifications (`wip↔mathlib`, `axiom↔mathlib`, `infrastructure→*`) are deliberately **not** touched — they are reclassifications between *valid* badges needing human review, as the issue requests.

Closes #42103
