### PR TITLE
audit: re-serve erdos-1027 — clean (5th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9104,9 +9104,9 @@
       "issues": []
     },
     "erdos-1027": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:27Z",
+      "lastAudited": "2026-07-22T23:21:58Z",
       "result": "clean"
     },
     "erdos-1027-oq-01": {


### PR DESCRIPTION
Re-verified erdos-1027 (Property B abundance / Koishi Chan) against `Proofs/Erdos1027Problem.lean`. Genuinely clean, matches prior 4 audits.

Counts (all exact match to meta.json):
- axioms: 1 (`erdos_1027_solution`)
- sorries: 0
- theorems+lemmas: 10
- definitions: 14
- lineCount: 353

The single axiom `Erdos1027Statement` has the correct `∀c>0, ∃δ>0, ∃N, ∀n≥N, ...` threshold-guarded structure (not the no-threshold-∀ pattern that produces inconsistent axioms).

Cross-checked every declaration name referenced in `proofStrategy`, section summaries, and `annotations.json` against the actual file — all 24 named decls exist at the claimed line ranges, no phantom declarations. No undisclosed `native_decide`/`ofReduceBool`. Auxiliary `Proofs/Erdos1027Aristotle.lean` (disclosed in `additionalFiles`) is a standalone exploratory lemma, correctly not counted in main-file totals.

Tracker-only change (`audit-tracker.json` bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)