### PR TITLE
audit: re-serve erdos-1040 — clean (6th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9244,9 +9244,9 @@
       "result": "clean"
     },
     "erdos-1040": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:27Z",
+      "lastAudited": "2026-07-22T23:24:29Z",
       "result": "clean"
     },
     "erdos-1040-oq-03": {


### PR DESCRIPTION
## Summary
- Re-audited erdos-1040 (queue drained, reserve-mode re-serve of oldest entry).
- Verified: axiomCount 4 (matches 4 `axiom` decls), sorries 0 (only a commented-out `sorry`), theoremCount 22, definitionCount 20 — all exact.
- Axioms (`disc_diameter`, `small_diameter_disc`, `lineSegment_muPosDeg_zero`, `disc_muPosDeg_zero`) are disclosed in status `axiomatized` / badge `axiom`, and correctly carry the substantive content per docstrings.
- Vacuous theorems (`lineSegment_determined`, `disc_determined`) are explicitly disclosed as vacuous in both their docstrings and the meta.json section summary — not overclaimed.
- No True stubs, no native_decide, no phantom axioms in prose.
- Companion file `Erdos1040Aristotle.lean` (Aristotle proof-search targets) has 0 real axioms/sorries and makes no separate public claim.
- Result: **clean**.

## Test plan
- [x] Verified axiom/sorry/theorem/definition counts via grep against `proofs/Proofs/Erdos1040Problem.lean`
- [x] Read full file for phantom-axiom / stale-prose / vacuous-theorem issues
- [x] `claim-target.sh complete erdos-1040 clean` updates tracker only

🤖 Generated with [Claude Code](https://claude.com/claude-code)