### PR TITLE
audit: re-serve erdos-1031 — clean (7th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9164,9 +9164,9 @@
       "result": "issues-fixed"
     },
     "erdos-1031": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:27Z",
+      "lastAudited": "2026-07-22T23:27:23Z",
       "result": "clean"
     },
     "erdos-1032": {


### PR DESCRIPTION
## Summary
- Reserve-mode re-audit of erdos-1031 (queue fully drained: 4811/4811 audited, 0 open issues).
- Verified all meta.json counts against the Lean source exactly: 3 axioms (`ramsey_trivial_bound`, `promel_rodl`, `ramsey_upper_bound`), 1 sorry (`erdos_1031_solved`), 17 theorems, 18 definitions, 546 lines.
- Status `axiomatized` / badge `axiom` correctly reflects the disclosed gap; no True stubs, no native_decide, no phantom axiom names in prose.
- 7th consecutive clean audit for this entry.

## Test plan
- [x] Grepped axiom/sorry/theorem/def counts directly against `proofs/Proofs/Erdos1031Problem.lean`
- [x] Cross-checked overview/conclusion prose and annotations for phantom declaration names
- [x] Confirmed `meta.assumptions` discloses exact axiom names and sorry count