### PR TITLE
audit: re-serve erdos-1057 — clean (5th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9460,9 +9460,9 @@
       "issues": []
     },
     "erdos-1057": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:28Z",
+      "lastAudited": "2026-07-22T23:30:01Z",
       "result": "clean"
     },
     "erdos-1057-oq-04": {


### PR DESCRIPTION
## Summary
Reserve-mode re-audit of erdos-1057 (queue was fully drained, 4811/4811).

Verified all meta.json counts against `Proofs/Erdos1057Problem.lean`:
- axiomCount: 1 (matches `infinitely_many_carmichaels`)
- sorries: 0 (matches, no sorry hits)
- lineCount: 1164 (matches `wc -l`)
- theoremCount: 67 (matches — 66 public `theorem` + 1 `private theorem`)
- definitionCount: 14 (matches — includes 3 `noncomputable def` declarations)

`native_decide` usage is confined to finite witness checks (Carmichael
number verification for 561–15841) and correctly disclosed in
`assumptions` as not feeding the axiomatized infinitude claim.

Result: clean, no issues found.

## Test plan
- [x] Grep-verified axiom/sorry/def/theorem counts against source
- [x] Spot-checked originalContributions declaration names exist in source
- [x] Confirmed native_decide disclosure accuracy