### PR TITLE
audit: re-serve erdos-1047 — clean (5th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9316,9 +9316,9 @@
       "result": "clean"
     },
     "erdos-1047": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:28Z",
+      "lastAudited": "2026-07-22T23:34:55Z",
       "result": "clean"
     },
     "erdos-1047-oq-02": {


### PR DESCRIPTION
## Summary

Reserve-mode re-audit of `erdos-1047` (queue fully drained, 0 unaudited / 0 with issues). Oldest-cohort target, verified uncontested by open PRs before claiming.

## Verification

- **Sorries**: 0 claimed, 0 found (all `sorry` string hits across the 5-file chain are inside docstrings, none in tactic position).
- **Axioms**: 0 claimed, 0 found. The former `goodman_counterexample` axiom is fully discharged — `Erdos1047Problem.lean` has no `axiom` declarations; the docstring quotations of the old axiom in `OQ02.lean`/`Certificate.lean`/`Reduction.lean` are historical narrative, not live declarations.
- **theoremCount 37 / definitionCount 16** (meta block): matches the aggregate over `Erdos1047Main.lean` + the 4 `additionalFiles` (Problem, OQ02, OQ02Certificate, OQ02Reduction) — 53 theorems / 22 defs total across all 6 files in the directory, minus 16 theorems / 6 defs belonging to `Erdos1047OQ02ChordExit.lean`, which is **not** imported by any counted file and correctly excluded from `additionalFiles`. It's a superseded draft (`STATUS: build-pending` in its own docstring).
- **leanFile block** (4 theorems / 0 defs / 70 lines / 0 axioms / 0 sorries): matches `Erdos1047Main.lean` alone exactly.
- **native_decide**: none in any of the 5 counted files.
- Prose-referenced declaration names (`goodman_counterexample_proof`, `componentContaining_lemniscate_not_convex_of_chord_exits`) verified to exist with matching statements.

## Known, already-tracked issue (not duplicated)

`badge: "verified"` is an invalid `ProofBadge` enum value (silently renders no badge) — this is the pre-existing 449-entry regression from issue #42103, already fixed for this exact file by open PR #42108 (remaps to `mathlib`). Not re-filed here.

## Result

Clean. `audit-tracker.json` updated: `erdos-1047` auditCount 4→5, lastAudited refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)