### PR TITLE
Enrich erdos-64: cover 353-line parity/Dirac-rung growth, fix mislabeled annotations

### DIFF
--- a/src/data/proofs/erdos-64/annotations.json
+++ b/src/data/proofs/erdos-64/annotations.json
@@ -235,12 +235,12 @@
     "id": "ann-e64-liu-mont",
     "proofId": "erdos-64",
     "range": {
-      "startLine": 102,
-      "endLine": 105
+      "startLine": 96,
+      "endLine": 101
     },
     "type": "concept",
     "title": "Liu-Montgomery Threshold Theorem (2020)",
-    "content": "Axiomatizes the Liu-Montgomery result: there exists a constant $D$ such that every graph with $\\delta(G) \\ge D$ contains a cycle of length $2^k$ for some $k \\ge 2$. This disproves the Erdős-Gyárfás conjecture for $r \\ge D$ but leaves $r < D$ (especially $r = 3$) open.",
+    "content": "Documents the Liu-Montgomery result in a source comment (expository only — no Lean axiom or declaration is given): there exists a constant $D$ such that every graph with $\\delta(G) \\ge D$ contains a cycle of length $2^k$ for some $k \\ge 2$. This disproves the Erdős-Gyárfás conjecture for $r \\ge D$ but leaves $r < D$ (especially $r = 3$) open.",
     "mathContext": "$\\exists D \\in \\mathbb{N}$ such that $\\delta(G) \\ge D \\implies \\exists k \\ge 2,\\, C_{2^k} \\subseteq G$. The exact value of $D$ is unknown; the proof gives a tower-type bound.",
     "significance": "key",
     "relatedConcepts": [
@@ -259,12 +259,12 @@
     "id": "ann-e64-even-cycles",
     "proofId": "erdos-64",
     "range": {
-      "startLine": 116,
-      "endLine": 121
+      "startLine": 104,
+      "endLine": 110
     },
     "type": "concept",
     "title": "Liu-Montgomery Even Cycles Theorem",
-    "content": "Axiomatizes the stronger result: graphs with $\\delta(G) \\ge D$ contain all even cycle lengths in $[4, L]$ for some $L \\ge 16$. This is much stronger than just finding one power-of-two cycle—it gives a full spectrum of even cycles.",
+    "content": "Documents the stronger result in a source comment (expository only — no Lean axiom or declaration is given): graphs with $\\delta(G) \\ge D$ contain all even cycle lengths in $[4, L]$ for some $L \\ge 16$. This is much stronger than just finding one power-of-two cycle—it gives a full spectrum of even cycles.",
     "mathContext": "$\\delta(G) \\ge D \\implies \\exists L \\ge 16$ such that $\\forall m \\in \\{4, 6, 8, \\ldots, L\\},\\, C_m \\subseteq G$. The range $[4, L]$ contains $2^k = 4$ whenever $L \\ge 4$.",
     "significance": "key",
     "relatedConcepts": [
@@ -329,12 +329,12 @@
     "id": "ann-e64-tree",
     "proofId": "erdos-64",
     "range": {
-      "startLine": 159,
-      "endLine": 160
+      "startLine": 142,
+      "endLine": 146
     },
     "type": "concept",
     "title": "Infinite 3-Regular Tree Exists",
-    "content": "Axiomatizes the existence of an infinite 3-regular tree: a connected acyclic graph where every vertex has exactly 3 neighbors. This shows finiteness is essential for the conjecture—without it, 3-regular acyclic graphs exist and trivially avoid all cycles.",
+    "content": "Documents the existence of an infinite 3-regular tree in a source comment (expository only — no Lean axiom or declaration is given): a connected acyclic graph where every vertex has exactly 3 neighbors. This shows finiteness is essential for the conjecture—without it, 3-regular acyclic graphs exist and trivially avoid all cycles.",
     "mathContext": "$\\exists$ infinite graph $T$ with $\\deg(v) = 3$ for all $v$ and no cycles. This is the infinite binary tree where each vertex connects to a parent and two children (the root has three children). $T$ has $\\delta = 3$ but $C_k \\not\\subseteq T$ for all $k \\ge 3$.",
     "significance": "key",
     "relatedConcepts": [
@@ -353,8 +353,8 @@
     "id": "ann-e64-degree3",
     "proofId": "erdos-64",
     "range": {
-      "startLine": 169,
-      "endLine": 172
+      "startLine": 154,
+      "endLine": 157
     },
     "type": "definition",
     "title": "Degree 3 Conjecture (Open)",
@@ -368,19 +368,19 @@
     ],
     "prerequisites": [
       "erdos_64_conjecture",
-      "liu_montgomery_threshold"
+      "Liu-Montgomery threshold (source-comment result, not a Lean declaration)"
     ]
   },
   {
     "id": "ann-e64-dirac",
     "proofId": "erdos-64",
     "range": {
-      "startLine": 183,
-      "endLine": 185
+      "startLine": 690,
+      "endLine": 694
     },
     "type": "concept",
     "title": "Dirac's Theorem (1952)",
-    "content": "Axiomatizes Dirac's theorem: if $n \\ge 3$ and $\\delta(G) \\ge n/2$, then $G$ is Hamiltonian (contains a cycle through all $n$ vertices). This shows that high minimum degree forces long cycles, but does not directly control which specific lengths appear.",
+    "content": "Documents Dirac's theorem in a source comment (expository only — no Lean axiom or declaration is given): if $n \\ge 3$ and $\\delta(G) \\ge n/2$, then $G$ is Hamiltonian (contains a cycle through all $n$ vertices). This shows that high minimum degree forces long cycles, but does not directly control which specific lengths appear.",
     "mathContext": "Dirac (1952): $|V(G)| = n \\ge 3$ and $\\delta(G) \\ge n/2 \\implies G$ contains $C_n$. This is the classical sufficient condition for Hamiltonicity. It does not directly help with Problem #64 (which needs specific lengths, not just long cycles).",
     "significance": "supporting",
     "relatedConcepts": [
@@ -399,12 +399,12 @@
     "id": "ann-e64-bondy",
     "proofId": "erdos-64",
     "range": {
-      "startLine": 192,
-      "endLine": 197
+      "startLine": 695,
+      "endLine": 699
     },
     "type": "concept",
     "title": "Bondy's Pancyclicity Theorem (1971)",
-    "content": "Axiomatizes Bondy's theorem: if $|E(G)| \\ge n^2/4$ and $n \\ge 3$, then either $G$ is bipartite or $G$ contains all cycle lengths $3, 4, \\ldots, n$. Dense non-bipartite graphs have all cycle lengths, so they trivially satisfy Problem #64.",
+    "content": "Documents Bondy's theorem in a source comment (expository only — no Lean axiom or declaration is given): if $|E(G)| \\ge n^2/4$ and $n \\ge 3$, then either $G$ is bipartite or $G$ contains all cycle lengths $3, 4, \\ldots, n$. Dense non-bipartite graphs have all cycle lengths, so they trivially satisfy Problem #64.",
     "mathContext": "Bondy (1971): $|E(G)| \\ge n^2/4$ and $G$ not bipartite $\\implies$ $G$ contains $C_k$ for all $3 \\le k \\le n$. Combined with Mantel's theorem ($n^2/4$ is the max for triangle-free), this characterizes dense graphs as pancyclic or bipartite.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -417,6 +417,98 @@
       "edgeFinset.card",
       "bipartite definition",
       "ContainsCycleLength"
+    ]
+  },
+  {
+    "id": "ann-e64-even-cycle-thm",
+    "proofId": "erdos-64",
+    "range": {
+      "startLine": 355,
+      "endLine": 546
+    },
+    "type": "technique",
+    "title": "Longest-Path Trapped-Neighbours Argument",
+    "content": "`hasMinDegree_three_exists_even_cycle` is machine-checked and axiom-free: it takes a path $p$ of maximum length in $G$, starting at $v_0$. Maximality traps every neighbour of $v_0$ at a distinct positive index along $p$ (otherwise $p$ could be extended). With $\\delta(G) \\ge 3$, at least three such indices exist; let $a < b$ be the two largest. Closing the prefix of $p$ at index $a$ back through the edge to $v_0$ gives a cycle of length $a+1$; closing at $b$ gives length $b+1$; and the segment of $p$ strictly between indices $a$ and $b$, closed through $v_0$ via both endpoint edges, gives a third cycle of length $b-a+2$. These three lengths sum to $2b+4$, which is even, so they cannot all be odd — one of the three cycles is even.",
+    "mathContext": "On a maximum-length path $p$ with start $v_0$, every neighbour $w$ of $v_0$ satisfies $w \\in p.\\mathrm{support}$ (else $\\mathrm{cons}\\,w\\,p$ is a longer path), so the set $T$ of neighbour indices $\\mathrm{idx}(w) = |p.\\mathrm{takeUntil}\\,w|$ has $|T| \\geq 3$ and every element $\\geq 1$. Taking $b = \\max T$ and $a = \\max(T \\setminus \\{b\\})$ gives $2 \\leq a < b$. Three explicit cycles of lengths $a+1$, $b+1$, $b-a+2$ then exist (via `Walk.cons` closures), and $(a+1)+(b+1)+(b-a+2) = 2b+4$ is even, forcing at least one summand even.",
+    "significance": "key",
+    "relatedConcepts": [
+      "longest path argument",
+      "parity argument",
+      "SimpleGraph.Walk.IsCycle",
+      "extremal path technique"
+    ],
+    "prerequisites": [
+      "hasMinDegree_two_exists_cycle",
+      "Walk.takeUntil / Walk.dropUntil",
+      "Nat.even_or_odd"
+    ]
+  },
+  {
+    "id": "ann-e64-even-cycle-bridge",
+    "proofId": "erdos-64",
+    "range": {
+      "startLine": 552,
+      "endLine": 561
+    },
+    "type": "concept",
+    "title": "Even Cycle, Restated via ContainsCycleLength",
+    "content": "`hasMinDegree_three_exists_even_containsCycleLength` reindexes the even-cycle witness from `hasMinDegree_three_exists_even_cycle` through `isCycle_containsCycleLength`, giving $\\exists k \\geq 4$, $\\mathrm{Even}\\,k$, with $\\mathrm{ContainsCycleLength}\\,G\\,k$ — the necessary parity-and-size part of Problem 64's hypothesis, phrased in the predicate the open conjecture itself uses. It is still a strict weakening: it does not pin $k$ down to a power of two.",
+    "mathContext": "Combines `hasMinDegree_three_exists_even_cycle` with `isCycle_containsCycleLength` and `IsCycle.three_le_length`: $\\delta(G) \\geq 3 \\Rightarrow \\exists k \\geq 4,\\ \\mathrm{Even}\\,k \\wedge \\mathrm{ContainsCycleLength}\\,G\\,k$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ContainsCycleLength",
+      "isCycle_containsCycleLength",
+      "even cycle"
+    ],
+    "prerequisites": [
+      "hasMinDegree_three_exists_even_cycle",
+      "isCycle_containsCycleLength"
+    ]
+  },
+  {
+    "id": "ann-e64-dirac-rung",
+    "proofId": "erdos-64",
+    "range": {
+      "startLine": 578,
+      "endLine": 673
+    },
+    "type": "technique",
+    "title": "Dirac-Type Rung: Cycle Length ≥ d + 1",
+    "content": "`hasMinDegree_exists_cycle_length_ge` is machine-checked and axiom-free: reusing the trapped-neighbour set-up from the even-cycle argument, if $\\delta(G) \\ge d$ (with $d \\ge 2$) then the $\\ge d$ neighbours of a maximum-length path's start vertex $v_0$ occupy $\\ge d$ distinct positive indices. Since $d$ distinct positive integers cannot all be less than $d$, the largest index $b$ satisfies $b \\geq d$; closing the path's prefix at $b$ back through the edge to $v_0$ yields an explicit cycle of length $b+1 \\geq d+1$. This is the classical quantitative rung underlying Dirac-type results, proved here directly rather than via Dirac's Hamiltonicity theorem (which needs $\\delta \\geq n/2$, far stronger than this hypothesis).",
+    "mathContext": "$d \\geq 2$, $\\delta(G) \\geq d$: the neighbour-index set $T$ (as in the parity argument) satisfies $|T| \\geq d$ and $T \\subseteq \\mathrm{Icc}\\,1\\,b$ where $b = \\max T$, so $d \\leq |\\mathrm{Icc}\\,1\\,b| = b$ (`Finset.card_le_card`). Closing $p$'s prefix of length $b$ through $v_0$'s edge to the neighbour at index $b$ gives a cycle of length $b + 1 \\geq d + 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "longest path argument",
+      "Dirac-type bound",
+      "quantitative extremal result",
+      "Finset.card_le_card"
+    ],
+    "prerequisites": [
+      "HasMinDegree",
+      "Walk.takeUntil",
+      "Finset.max'"
+    ]
+  },
+  {
+    "id": "ann-e64-dirac-rung-bridge",
+    "proofId": "erdos-64",
+    "range": {
+      "startLine": 675,
+      "endLine": 686
+    },
+    "type": "concept",
+    "title": "Dirac-Type Rung, Restated via ContainsCycleLength",
+    "content": "`hasMinDegree_containsCycleLength_ge` restates the Dirac-type rung in `ContainsCycleLength`: $\\delta(G) \\geq d$ (with $d \\geq 2$) gives $\\exists k \\geq d+1$ with $\\mathrm{ContainsCycleLength}\\,G\\,k$. Combined with the parity result, minimum-degree-3 graphs have both an even cycle and a cycle of length $\\geq 4$ — but Problem 64's open core, that some cycle length can be forced to be exactly a power of two, remains untouched by either.",
+    "mathContext": "Combines `hasMinDegree_exists_cycle_length_ge` with `isCycle_containsCycleLength`: $d \\geq 2$, $\\delta(G) \\geq d \\Rightarrow \\exists k \\geq d+1,\\ \\mathrm{ContainsCycleLength}\\,G\\,k$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ContainsCycleLength",
+      "isCycle_containsCycleLength",
+      "Dirac-type bound"
+    ],
+    "prerequisites": [
+      "hasMinDegree_exists_cycle_length_ge",
+      "isCycle_containsCycleLength"
     ]
   }
 ]

--- a/src/data/proofs/erdos-64/meta.json
+++ b/src/data/proofs/erdos-64/meta.json
@@ -80,33 +80,39 @@
       "power_two_even: proved 2^k is even for k ≥ 2",
       "erdos_64_conjecture: main open conjecture (δ ≥ 3 → ∃ C_{2^k})",
       "erdos_gyarfas_conjecture: disproved counter-conjecture",
-      "liu_montgomery_threshold: axiomatized ∃ D, δ ≥ D → ∃ C_{2^k}",
-      "liu_montgomery_even_cycles: axiomatized even cycle spectrum theorem",
+      "Liu-Montgomery threshold (∃ D, δ ≥ D → ∃ C_{2^k}): documented in a source comment only — not a named Lean declaration or axiom",
+      "Liu-Montgomery even-cycle spectrum theorem: documented in a source comment only — not a named Lean declaration or axiom",
       "range_contains_power_of_two: proved [4, L] contains 2^k for L ≥ 16",
       "InfGraph: infinite graph structure (for tree counterexample)",
-      "infinite_3_regular_tree_exists: axiomatized finiteness necessity",
+      "Infinite 3-regular tree existence: documented in a source comment only — not a named Lean declaration or axiom",
       "degree_3_conjecture: explicit δ = 3 restatement",
-      "dirac_theorem: axiomatized Hamiltonicity for δ ≥ n/2",
-      "bondy_pancyclic: axiomatized pancyclicity for dense graphs",
-      "random_graph_cycles: axiomatized probabilistic evidence"
+      "connected_hasMinDegree_two_exists_cycle / hasMinDegree_two_exists_cycle: axiom-free proof that δ ≥ 2 forces a cycle (tree-has-a-leaf argument), the latter dropping the connectivity hypothesis",
+      "isCycle_containsCycleLength, hasMinDegree_two/three_containsCycleLength: axiom-free bridge from an explicit `Walk.IsCycle` witness to the length-indexed `ContainsCycleLength` predicate",
+      "hasMinDegree_three_exists_even_cycle: axiom-free longest-path parity argument producing an even cycle from δ ≥ 3",
+      "hasMinDegree_exists_cycle_length_ge: axiom-free Dirac-type rung, a cycle of length ≥ d + 1 from δ ≥ d",
+      "Dirac's theorem (1952): documented in a source comment only — not a named Lean declaration or axiom",
+      "Bondy's pancyclicity theorem (1971): documented in a source comment only — not a named Lean declaration or axiom",
+      "Random-graph cycle heuristic: documented in a source comment only — not a named Lean declaration or axiom"
     ],
     "axiomCount": 0,
-    "lineCount": 205,
+    "lineCount": 732,
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
-    "theoremCount": 3,
+    "theoremCount": 14,
     "definitionCount": 12
   },
   "overview": {
     "historicalContext": "Erdős and Gyárfás posed this problem in the 1990s, conjecturing that the answer is NO: for every $r$, there should exist a graph with minimum degree $r$ avoiding all $2^k$-length cycles. This belief stemmed from the seeming rigidity of exponential cycle lengths compared to the flexibility available in dense graphs. The problem carries a $1000 Erdős prize, one of his highest bounties, reflecting its perceived difficulty. A breakthrough came from Hong Liu and Richard Montgomery (2020), who proved that for sufficiently large minimum degree $D$, every graph must contain a cycle of length $2^k$. Their proof, published as part of a broader result on even cycle lengths in graphs of large average degree, leverages the regularity method and a deep structural analysis showing that dense graphs contain cycles of every even length in a geometric range $[(\\log \\ell)^8, \\ell]$. Since this range contains a power of 2 whenever $\\ell \\ge 16$, the Erdős-Gyárfás conjecture is disproved for large $r$. However, the exact value of the threshold $D$ is not known, and the critical case $r = 3$ (minimum degree exactly 3) remains completely open. The problem connects to Dirac's theorem (1952), Bondy's pancyclicity theorem (1971), and the broader study of unavoidable cycle lengths in graph theory.",
     "problemStatement": "Does every finite graph with minimum degree at least $3$ contain a cycle of length $2^k$ for some $k \\ge 2$?",
     "text": "Does every finite graph with minimum degree ≥ 3 contain a cycle of length 2^k for some k ≥ 2? OPEN ($1000 prize).",
-    "proofStrategy": "The formalization defines cycle containment via injective vertex maps with cyclic adjacency (using `Fin.succMod`), minimum degree via `Finset.inf'` over neighbor counts, and the set $\\{2^k : k \\ge 2\\} = \\{4, 8, 16, \\ldots\\}$. The main conjecture and the disproved Erdős-Gyárfás conjecture are stated as Lean `Prop` definitions. Liu-Montgomery's threshold result and even-cycle theorem are axiomatized. An infinite counterexample (the infinite 3-regular tree) is formalized via a custom `InfGraph` structure, demonstrating that finiteness is essential. Supporting results include Dirac's theorem (Hamiltonicity from high degree), Bondy's pancyclicity theorem (dense graphs have all cycle lengths), and a probabilistic argument that random graphs contain power-of-two cycles.",
+    "proofStrategy": "The formalization defines cycle containment via injective vertex maps with cyclic adjacency (using `Fin.succMod`), minimum degree via `Finset.inf'` over neighbor counts, and the set $\\{2^k : k \\ge 2\\} = \\{4, 8, 16, \\ldots\\}$. The main conjecture and the disproved Erdős-Gyárfás conjecture are stated as Lean `Prop` definitions. Liu-Montgomery's threshold result and even-cycle theorem, Dirac's theorem, Bondy's pancyclicity theorem, and the random-graph heuristic are all documented only in source comments (expository, not Lean axioms or declarations). An infinite counterexample (the infinite 3-regular tree) is formalized via a custom `InfGraph` structure, demonstrating that finiteness is essential. Beyond this, four fully machine-checked, axiom-free results build a quantitative engine around the open conjecture: a longest-path argument shows δ ≥ 2 forces a cycle (dropping connectivity via a connected-component reduction), a bridge converts explicit `Walk.IsCycle` witnesses to the length-indexed `ContainsCycleLength` predicate the conjecture uses, a longest-path *parity* argument shows δ ≥ 3 forces an *even* cycle, and a Dirac-type rung shows δ ≥ d forces a cycle of length at least d + 1.",
     "keyInsights": [
       "Liu-Montgomery breakthrough: ∃ D such that δ(G) ≥ D forces a C_{2^k} cycle. The proof shows dense graphs contain every even cycle length in a range [(log ℓ)^8, ℓ], which must include some 2^k",
       "Erdős-Gyárfás disproof: The conjecture that counterexamples exist for all r was disproved for large r, but r = 3 remains completely open",
       "Finiteness is essential: The infinite 3-regular tree has δ = 3 and no cycles at all",
       "Power-of-two special structure: {4, 8, 16, ...} is exponentially sparse (logarithmic density), making unavoidability a much stronger condition than for dense sets of cycle lengths",
-      "Probabilistic evidence: Random graphs G(n, c/n) almost surely satisfy the conjecture, so counterexamples must be highly structured"
+      "Probabilistic evidence: Random graphs G(n, c/n) almost surely satisfy the conjecture, so counterexamples must be highly structured",
+      "Longest-path parity argument (axiom-free): a maximum-length path's start vertex v₀ traps all ≥3 of its neighbours at distinct positive indices along the path; the two largest indices a < b give three cycles of lengths a+1, b+1, b−a+2 summing to 2b+4 (even), so one of the three must itself be even — this proves δ ≥ 3 forces an even cycle without resolving which length",
+      "Dirac-type rung (axiom-free): the same trapped-neighbour argument shows the largest neighbour index is ≥ d when δ ≥ d, so closing the path at that index yields a cycle of length ≥ d+1 — a genuine quantitative lower bound, but far short of forcing length exactly 2^k"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -196,27 +202,43 @@
       "mathContext": "Reconciles the two encodings of 'contains a cycle': the existence results hand back an explicit walk witnessing `Walk.IsCycle`, whereas the conjecture uses the length-indexed predicate `ContainsCycleLength G k`. `isCycle_containsCycleLength` turns an explicit cycle `c` into `ContainsCycleLength G c.length` by reindexing $i \\mapsto c.\\mathrm{getVert}\\, i$ and closing the wrap-around adjacency at the last vertex ($c.\\mathrm{getVert}\\, \\ell = v = c.\\mathrm{getVert}\\, 0$). `hasMinDegree_two_containsCycleLength` measures the cycle from `hasMinDegree_two_exists_cycle` to get a concrete $k \\geq 3$ (via `IsCycle.three_le_length`); `hasMinDegree_three_containsCycleLength` specializes to δ $\\geq$ 3 by $3 \\geq 2$. All axiom-free, and all prove only that *some* length $k \\geq 3$ occurs — not that $k = 2^{m}$, which is Problem 64's open core."
     },
     {
+      "id": "even-cycle-parity",
+      "title": "Even Cycle from Minimum Degree 3 (Longest-Path Parity Argument)",
+      "summary": "Machine-checked, axiom-free: `hasMinDegree_three_exists_even_cycle` proves every nonempty finite graph with δ ≥ 3 contains a cycle of **even** length. Takes a path of maximum length starting at v₀; maximality traps all ≥3 neighbours of v₀ at distinct positive indices along the path. The two largest indices a < b give three cycles — closing at a, closing at b, and the segment between them — of lengths a+1, b+1, b−a+2, summing to 2b+4 (even), so at least one is even. `hasMinDegree_three_exists_even_containsCycleLength` restates this in the length-indexed `ContainsCycleLength` predicate. Every C_{2^k} is even, so this is a necessary precondition of Problem 64, strictly weaker than the open power-of-two-length core.",
+      "startLine": 335,
+      "endLine": 561,
+      "mathContext": "`hasMinDegree_three_exists_even_cycle`: δ(G) $\\geq$ 3 $\\Rightarrow$ $\\exists$ a cycle of even length. Proof: on a maximum-length path $p$ from $v_0$, every neighbour of $v_0$ sits at a distinct positive index (else $p$ extends); taking the two largest indices $a < b$, closing the prefixes at $a$ and at $b$, and closing the segment $[a,b]$ back through $v_0$ gives three cycles of lengths $a+1$, $b+1$, $b-a+2$, which sum to $2b+4$ — even — so parity forces one of the three to be even. `hasMinDegree_three_exists_even_containsCycleLength` reindexes this via `isCycle_containsCycleLength` into $\\exists k \\geq 4$, $\\mathrm{Even}\\,k$, $\\mathrm{ContainsCycleLength}\\,G\\,k$."
+    },
+    {
+      "id": "dirac-rung",
+      "title": "Dirac-Type Lower Bound on Cycle Length",
+      "summary": "Machine-checked, axiom-free: `hasMinDegree_exists_cycle_length_ge` reuses the same maximum-length-path engine to prove a quantitative rung — minimum degree d ≥ 2 forces a cycle of length ≥ d+1. The d ≥ 2 neighbours of the path's start vertex trap at distinct positive indices, so the largest index is at least d (d distinct positive integers cannot all be < d); closing the prefix there yields the bound. `hasMinDegree_containsCycleLength_ge` restates this in `ContainsCycleLength`. Shows how minimum degree pushes the guaranteed cycle length up linearly, though 'some length ≥ d+1' is far from 'length exactly 2^k'.",
+      "startLine": 563,
+      "endLine": 687,
+      "mathContext": "`hasMinDegree_exists_cycle_length_ge`: $d \\geq 2$, $\\delta(G) \\geq d$ $\\Rightarrow$ $\\exists$ a cycle of length $\\geq d+1$. The $\\geq d$ neighbours of a maximum path's start vertex occupy $d$ distinct positive indices, so $T \\subseteq [1,b]$ with $|T| \\geq d$ forces $b \\geq d$ (`Finset.card_le_card` on $T \\subseteq \\mathrm{Icc}\\,1\\,b$); closing the prefix of length $b$ back to the start gives a cycle of length $b+1 \\geq d+1$. `hasMinDegree_containsCycleLength_ge` reindexes via `isCycle_containsCycleLength`."
+    },
+    {
       "id": "known-results",
       "title": "Known Cycle Results",
       "summary": "Documents in source comments the classical Dirac theorem (1952: δ ≥ n/2 → Hamiltonian) and Bondy theorem (1971: ≥ n²/4 edges → pancyclic or bipartite), neither carrying a Lean declaration. These classical results show high degree forces cycles but do not resolve specific lengths at δ = 3.",
-      "startLine": 335,
-      "endLine": 346,
+      "startLine": 688,
+      "endLine": 699,
       "mathContext": "Documents in source comments the classical Dirac theorem (1952: δ $\\geq$ n/2 → Hamiltonian) and Bondy theorem (1971: $\\geq$ n²/4 edges → pancyclic or bipartite), neither carrying a Lean declaration. These classical results show high degree forces cycles but do not resolve specific lengths at δ = 3."
     },
     {
       "id": "random-graphs",
       "title": "Probabilistic Bounds",
       "summary": "Documents in a source comment that random graphs G(n, c/n) almost surely have δ ≥ 3 and contain cycles of many lengths, offering heuristic evidence that any counterexample must be highly structured. Expository only — no axiom is declared.",
-      "startLine": 347,
-      "endLine": 354,
+      "startLine": 700,
+      "endLine": 707,
       "mathContext": "Documents in a source comment that random graphs G(n, c/n) almost surely have δ $\\geq$ 3 and contain cycles of many lengths, offering heuristic evidence that any counterexample must be highly structured. Expository only — no axiom is declared."
     },
     {
       "id": "summary-status",
       "title": "Summary and Problem Status",
       "summary": "Closing source-comment digest of Problem 64's status (OPEN, $1000 prize): the main question (δ ≥ 3 forces a 2^k-cycle), the key results (Liu-Montgomery 2020 for large degree, the resulting disproof of Erdős-Gyárfás, the still-open δ = 3 case, and the NO answer for infinite graphs), open questions on the Liu-Montgomery threshold and 'almost counterexamples', and references. Ends the `Erdos64` namespace.",
-      "startLine": 355,
-      "endLine": 379,
+      "startLine": 708,
+      "endLine": 732,
       "mathContext": "Closing source-comment digest of Problem 64's status (OPEN, \\$1000 prize): the main question (δ $\\geq$ 3 forces a $2^{k}$-cycle), the key results (Liu-Montgomery 2020 for large degree, the resulting disproof of Erdős-Gyárfás, the still-open δ = 3 case, and the NO answer for infinite graphs), open questions on the Liu-Montgomery threshold and 'almost counterexamples', and references. Ends the `Erdos64` namespace."
     }
   ],


### PR DESCRIPTION
## Summary

`erdos-64`'s `meta.json` sections stopped at line 379, but the Lean file
(`Proofs/Erdos64Problem.lean`) has since grown to 732 lines via merged research
PRs (#40522, #40874, #40917, #41609, #41690) that added two axiom-free results:
a longest-path parity argument (minimum degree 3 forces an even cycle) and a
Dirac-type quantitative rung (minimum degree d forces a cycle of length ≥ d+1).
353 lines of genuine new mathematics were completely uncovered by sections or
annotations.

Digging further, six existing annotations (`ann-e64-liu-mont`, `ann-e64-even-cycles`,
`ann-e64-tree`, `ann-e64-degree3`, `ann-e64-dirac`, `ann-e64-bondy`) turned out to be
anchored to the *wrong* line ranges — they predate a prior cleanup that removed
literal `axiom` declarations for Liu-Montgomery/Dirac/Bondy/the infinite-tree
counterexample (converting them to prose-only comments, per `meta.assumptions`),
and were never re-anchored as the file grew around them. Their line ranges
currently point into unrelated theorem proofs, and their wording falsely claimed
these facts are "axiomatized" when the source only documents them in comments
with no Lean declaration at all (`grep` confirms none of `liu_montgomery_threshold`,
`dirac_theorem`, `bondy_pancyclic`, `infinite_3_regular_tree_exists` exist as
identifiers anywhere in the file).

Changes:
- Add two sections (`even-cycle-parity`, `dirac-rung`) covering lines 335-687,
  and move `known-results`/`random-graphs`/`summary-status` to their correct
  new positions (688-732) — full section coverage 25-732 with no gaps.
- Fix the 6 mislabeled annotations' `range` to their actual content, and reword
  from "axiomatizes X" to "documents X in a source comment (not a Lean
  declaration)" to match the honest `assumptions` field already in meta.json.
- Add 4 new annotations for the previously-uncovered theorems
  (`hasMinDegree_three_exists_even_cycle` and its `ContainsCycleLength`
  restatement, `hasMinDegree_exists_cycle_length_ge` and its restatement).
- Fix stale `meta.lineCount` (205→732) and `meta.theoremCount` (3→14, matches
  `leanFile.theoremCount`), and correct `originalContributions` entries that
  invented Lean identifier names for comment-only facts.
- Add 2 `keyInsights` describing the new axiom-free results and lightly expand
  `proofStrategy` to mention them.

No change to `badge`/`sorries`/`axiomCount` — those already correctly reflect
the Lean source (`axiomatized`/`wip`, 0 sorries, 0 axioms). File stays well
under size caps (meta.json 28.1 KB, annotations.json 22.4 KB, both « 60 KB).

## Test plan
- [x] `python3 -m json.tool` validates both `meta.json` and `annotations.json`
- [x] `pnpm build`'s JSON-touching pipeline steps (gallery build, `check-search-index`,
  `build-loading-facts`, `build-redirects`) all passed; `tsc`/`vite build` are
  unavailable in this worktree (missing `node_modules`, a pre-existing
  environment gap, not caused by this change)
- [x] Diff scoped to only `src/data/proofs/erdos-64/` (2135 build-noise files
  reverted before commit)
- [x] Verified via `grep` that no `axiom`/named declaration exists in the Lean
  source for any of the facts whose annotation wording was softened