### PR TITLE
Research: cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03 - MASA capstone in Module.End (node complete)

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Masa.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Masa.lean
@@ -1,0 +1,139 @@
+/-
+  The commutant of a cyclic endomorphism is a maximal abelian subalgebra
+  (cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03)
+
+  This file lifts the MASA (maximal abelian subalgebra) refinement of the
+  commutant characterization from concrete matrices
+  (`CayleyHamiltonCyclicVectorAllFieldsOQ02OQ02Masa.lean`,
+   `CyclicCommutantMasa.centralizer_isMASA_of_nonderogatory`) to the
+  coordinate-free endomorphism setting `Module.End K V`.
+
+  ## Statement
+
+  Let `V` be a finite-dimensional `K`-vector space and `T : Module.End K V`
+  an endomorphism with a cyclic vector (`IsEndCyclicVector`).  Then the
+  centralizer `C(T) = {A | A·T = T·A}` inside `Module.End K V`:
+
+    1. is **commutative** (`end_centralizer_mul_comm_of_cyclic` — the
+       subalgebra-membership form of `end_commutant_commutative`);
+    2. is **maximal** among commutative subalgebras containing it
+       (`end_centralizer_isMaximalCommutative` — this leg needs NO
+       hypothesis on `T` at all); and
+    3. has `K`-dimension `dim_K V` — the smallest a centralizer can be,
+       by the general Frobenius lower bound
+       (`finrank_centralizer_eq_of_cyclic`, proved in the Frobenius file).
+
+  The capstone `end_centralizer_isMasa_of_cyclic` packages all three legs:
+  the commutant of a cyclic endomorphism is a maximal abelian subalgebra of
+  `End_K(V)` of the minimal possible dimension.
+
+  ## Proof
+
+  * Maximality is formal: if `A ⊇ C(T)` is commutative, every `a ∈ A`
+    commutes with `T ∈ C(T) ⊆ A`, so `a ∈ C(T)`.
+  * Commutativity routes through the subalgebra equality
+    `C(T) = K[T] = Algebra.adjoin K {T}` (`end_centralizer_eq_adjoin`):
+    two polynomials in `T` commute.
+  * The dimension leg is `finrank_centralizer_eq_of_cyclic` from the
+    companion Frobenius file.
+
+  Status: 0 sorries, 0 axioms.
+-/
+import Mathlib
+import Proofs.CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius
+
+noncomputable section
+
+namespace EndCyclicCommutant
+
+open Polynomial Module
+
+variable {K : Type*} [Field K] {V : Type*} [AddCommGroup V] [Module K V]
+
+-- ============================================================
+-- SECTION I: the centralizer contains T and is maximal-commutative
+-- ============================================================
+
+/-- `T` lies in its own centralizer (it commutes with itself). -/
+theorem end_self_mem_centralizer (T : Module.End K V) :
+    T ∈ Subalgebra.centralizer K ({T} : Set (Module.End K V)) := by
+  rw [Subalgebra.mem_centralizer_iff]
+  intro g hg
+  rw [Set.mem_singleton_iff.mp hg]
+
+/-- **The centralizer is maximal among the commutative subalgebras containing
+    it.**  For *any* endomorphism `T` (no cyclic vector, no finite dimension
+    needed): if a subalgebra `A` of `Module.End K V` contains the centralizer
+    `C(T)` and is commutative, then `A = C(T)`.
+
+    Reason: every `a ∈ A` commutes with `T` (because `T ∈ C(T) ⊆ A` and `A`
+    is commutative), so `a ∈ C(T)`; hence `A ⊆ C(T)`, and the reverse
+    inclusion is the hypothesis.  Endomorphism analogue of
+    `CyclicCommutantMasa.centralizer_isMaximalCommutative`. -/
+theorem end_centralizer_isMaximalCommutative
+    (T : Module.End K V) (A : Subalgebra K (Module.End K V))
+    (hCA : Subalgebra.centralizer K ({T} : Set (Module.End K V)) ≤ A)
+    (hAcomm : ∀ x ∈ A, ∀ y ∈ A, x * y = y * x) :
+    A = Subalgebra.centralizer K ({T} : Set (Module.End K V)) := by
+  refine le_antisymm (fun a ha => ?_) hCA
+  rw [Subalgebra.mem_centralizer_iff]
+  intro g hg
+  rw [Set.mem_singleton_iff.mp hg]
+  exact hAcomm T (hCA (end_self_mem_centralizer T)) a ha
+
+-- ============================================================
+-- SECTION II: commutativity, in subalgebra-membership form
+-- ============================================================
+
+/-- **The centralizer of a cyclic endomorphism is commutative** — membership
+    form.  Two endomorphisms lying in `C(T)` (as a subalgebra) commute with
+    each other: both are polynomials in `T` by the subalgebra equality
+    `C(T) = K[T]`.  This is `end_commutant_commutative` restated for
+    subalgebra membership, the form the MASA capstone consumes. -/
+theorem end_centralizer_mul_comm_of_cyclic [FiniteDimensional K V]
+    (T : Module.End K V) (v : V) (hcyc : IsEndCyclicVector T v)
+    {A B : Module.End K V}
+    (hA : A ∈ Subalgebra.centralizer K ({T} : Set (Module.End K V)))
+    (hB : B ∈ Subalgebra.centralizer K ({T} : Set (Module.End K V))) :
+    A * B = B * A := by
+  rw [end_centralizer_eq_adjoin T v hcyc,
+    Algebra.adjoin_singleton_eq_range_aeval K T, AlgHom.mem_range] at hA hB
+  obtain ⟨p, rfl⟩ := hA
+  obtain ⟨q, rfl⟩ := hB
+  rw [← map_mul, ← map_mul, mul_comm]
+
+-- ============================================================
+-- SECTION III: capstone — C(T) is a MASA of minimal dimension
+-- ============================================================
+
+/-- **Capstone: the commutant of a cyclic endomorphism is a maximal abelian
+    subalgebra of minimal dimension.**  For `T : Module.End K V` with a cyclic
+    vector, the centralizer `C(T)`:
+
+      1. is **commutative**;
+      2. is **maximal** among commutative subalgebras (any commutative
+         subalgebra containing it equals it); and
+      3. has `K`-**dimension `dim_K V`** — the smallest possible, being the
+         equality case of the Frobenius bound `dim_K C(T) ≥ dim_K V`.
+
+    Coordinate-free lift of
+    `CyclicCommutantMasa.centralizer_isMASA_of_nonderogatory`. -/
+theorem end_centralizer_isMasa_of_cyclic [FiniteDimensional K V]
+    (T : Module.End K V) (v : V) (hcyc : IsEndCyclicVector T v) :
+    (∀ A ∈ Subalgebra.centralizer K ({T} : Set (Module.End K V)),
+        ∀ B ∈ Subalgebra.centralizer K ({T} : Set (Module.End K V)),
+          A * B = B * A)
+    ∧ (∀ A : Subalgebra K (Module.End K V),
+        Subalgebra.centralizer K ({T} : Set (Module.End K V)) ≤ A →
+        (∀ x ∈ A, ∀ y ∈ A, x * y = y * x) →
+          A = Subalgebra.centralizer K ({T} : Set (Module.End K V)))
+    ∧ Module.finrank K
+        (Subalgebra.centralizer K ({T} : Set (Module.End K V)))
+      = Module.finrank K V :=
+  ⟨fun _ hA _ hB => end_centralizer_mul_comm_of_cyclic T v hcyc hA hB,
+   end_centralizer_isMaximalCommutative T,
+   finrank_centralizer_eq_of_cyclic T v hcyc⟩
+
+end EndCyclicCommutant
+
+end

--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/knowledge.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/knowledge.md
@@ -1,5 +1,40 @@
 # Knowledge Base: cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03
 
+## Session 2026-07-22 (researcher-1) — MASA capstone: C(T) is a maximal abelian subalgebra of minimal dimension
+
+New file `CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Masa.lean` (139 lines, namespace
+`EndCyclicCommutant`, imports `...OQ02OQ03Frobenius`). VERIFIED clean Docker build
+(v4.31.0); all four theorems `#print axioms` = `[propext, Classical.choice, Quot.sound]`
+(0 axioms / 0 sorries). Coordinate-free lift of the matrix MASA file (OQ02OQ02Masa):
+
+- `end_self_mem_centralizer` — T ∈ C(T) (trivial).
+- `end_centralizer_isMaximalCommutative` — for ANY T (no cyclic vector, no finite
+  dimension): a commutative subalgebra A ⊇ C(T) equals C(T). Formal argument: a ∈ A
+  commutes with T ∈ C(T) ⊆ A.
+- `end_centralizer_mul_comm_of_cyclic` — commutativity in subalgebra-MEMBERSHIP form
+  (route through `end_centralizer_eq_adjoin` + `Algebra.adjoin_singleton_eq_range_aeval`
+  + `AlgHom.mem_range`, then `obtain ⟨p, rfl⟩` and `map_mul`/`mul_comm`).
+- `end_centralizer_isMasa_of_cyclic` — CAPSTONE: C(T) is commutative ∧ maximal among
+  commutative subalgebras ∧ dim_K C(T) = dim_K V (leg 3 = `finrank_centralizer_eq_of_cyclic`).
+
+### Node status after this session
+The Module.End lift (this node's stated objective) is COMPLETE and fully rounded out:
+both inclusions, subalgebra equality C(T)=K[T], commutativity, Frobenius dimension
+equality, evaluation isomorphism C(T) ≃ₗ[K] V, minpoly degree = dim V, and now the
+MASA characterization. The ONLY remaining direction is the deep converse
+(dim C(T)=n ⟹ cyclic), a structured blocker (needs rational-canonical-form /
+invariant-factor infrastructure absent from Mathlib v4.31). Pool status set to
+COMPLETED — future work should target the converse as its own problem if RCF infra lands.
+
+### Adversarial notes on the completion claim
+- The masa maximality leg is deliberately hypothesis-free (holds for every T); the
+  claim of interest for cyclic T is the CONJUNCTION with commutativity + dimension.
+- `IsEndCyclicVector` is the degree-< n annihilator-free definition (matches the
+  matrix parent), not "Krylov span = ⊤"; the two agree in finite dimension via
+  `endKrylov_linearIndependent` (n independent Krylov vectors span).
+- No circularity: the masa file consumes only already-#print-verified pieces of this
+  node and the general lower bound `CyclicCommutantConverse.endK_centralizer_bound`.
+
 ## Session 2026-07-20 (researcher-1) — centralizer = K[T] as a subalgebra equality
 
 Added `end_centralizer_eq_adjoin` to `CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03.lean`

--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/state.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/state.md
@@ -1,25 +1,29 @@
 # Research State: cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-07-09T17:20:43-07:00
-**Iteration**: 1
+**Since**: 2026-07-22
+**Iteration**: 5
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Node objective (lift the commutant characterization to Module.End) is COMPLETE:
+both inclusions, C(T) = K[T] subalgebra equality, commutativity (both forms),
+Frobenius dimension equality, evaluation isomorphism C(T) ≃ₗ[K] V, minpoly
+degree = dim V, and the MASA capstone (commutative + maximal + minimal dimension).
 
 ## Active Approach
-None yet.
+None — completed. See knowledge.md session log.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 5 sessions, all landed
+- Approaches tried: direct lift mirroring the matrix parent (succeeded throughout)
 
 ## Blockers
-None.
+The deep converse (dim C(T) = n ⟹ cyclic vector) is a structured blocker in the
+tracker JSON: needs rational-canonical-form / invariant-factor infrastructure
+absent from Mathlib v4.31. Reopen bar: materially new mechanism required.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+None on this node. If Mathlib lands RCF/invariant-factor theory, the converse
+deserves its own problem.

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/meta.json
@@ -37,7 +37,8 @@
       "endKrylov_linearIndependent: the Krylov vectors {Tᵏ·v}_{k<finrank K V} of a cyclic vector are linearly independent, hence a basis; the endomorphism analogue of CyclicCommutant.krylov_linearIndependent, proved directly over Module.End K V with no FiniteDimensional hypothesis on the statement itself.",
       "commuting_end_is_polynomial: the main lift — if T has a cyclic vector and A commutes with T (A * T = T * A in Module.End K V) then A = aeval T p for some p : K[X]. Coordinate-free version of CyclicCommutant.commuting_matrix_is_polynomial; agreement of A and p(T) on the Krylov basis is closed by Basis.ext rather than the parent's per-column matrix recovery.",
       "end_commutant_commutative: the centralizer of a cyclic endomorphism is commutative — any two endomorphisms commuting with T commute with each other, since both are polynomials in T.",
-      "aeval_end_commute: the trivial inclusion K[T] ⊆ centralizer(T); together with commuting_end_is_polynomial it gives the exact equality centralizer(T) = K[T]."
+      "aeval_end_commute: the trivial inclusion K[T] ⊆ centralizer(T); together with commuting_end_is_polynomial it gives the exact equality centralizer(T) = K[T].",
+      "end_centralizer_isMasa_of_cyclic (Masa file): the commutant of a cyclic endomorphism is a maximal abelian subalgebra of End_K(V) of minimal dimension — commutative, maximal among commutative subalgebras containing it (this leg for arbitrary T), and of K-dimension exactly dim V. Coordinate-free lift of the matrix MASA capstone (oq-02-oq-02 Masa file)."
     ],
     "historicalContext": "An endomorphism T of a finite-dimensional K-vector space V is nonderogatory when its minimal and characteristic polynomials coincide, equivalently when it admits a cyclic vector v (one for which v, Tv, …, T^{n-1}v span V). A third classical characterization (Hoffman & Kunze §7.5, Roman §10.4) describes the centralizer: for a nonderogatory operator, every operator commuting with T is a polynomial in T, so the centralizer equals K[T]. The parent gallery entry oq-02 proves this forward commutant edge for concrete matrices Matrix (Fin n) (Fin n) K. This entry answers the open question recorded by the sibling oq-02-oq-01 ('recast the triple equivalence for Module.End over a finite-dimensional vector space') for the commutant edge, restating and reproving the result basis-free in Module.End K V.",
     "proofStrategy": "Let n = finrank K V and let v be a cyclic vector for T. (1) The Krylov vectors {Tᵏ·v}_{k<n} are linearly independent: a nontrivial relation ∑ cₖ Tᵏ·v = 0 packages into a nonzero polynomial p = ∑ cₖ Xᵏ of degree < n with (p(T))·v = 0, contradicting cyclicity (endKrylov_linearIndependent). Being n independent vectors they form a basis b via basisOfLinearIndependentOfCardEqFinrank. (2) Expand A·v in this basis, A·v = ∑ (b.repr (A·v) k) · (Tᵏ·v), and set p = ∑ (b.repr (A·v) k) Xᵏ; then p(T)·v = A·v by Basis.sum_repr. (3) A and p(T) agree on each basis vector Tⁱ·v: A·(Tⁱ·v) = Tⁱ·(A·v) = Tⁱ·(p(T)·v) = p(T)·(Tⁱ·v), using that A commutes with Tⁱ (Commute.pow_right) and that p(T) commutes with Tⁱ (aeval is an algebra hom). Two linear maps agreeing on a basis are equal (Basis.ext), so A = p(T). The degenerate finrank = 0 case is dispatched by Subsingleton on Module.End K V (Module.finrank_zero_iff)."
@@ -175,10 +176,23 @@
           "Proofs.CayleyHamiltonCyclicVectorAllFieldsOQ02OQ01"
         ],
         "namespace": "EndCyclicCommutant",
-        "lineCount": 205,
+        "lineCount": 251,
         "axiomCount": 0,
-        "theoremCount": 5,
+        "theoremCount": 6,
         "definitionCount": 2,
+        "sorries": 0
+      },
+      {
+        "path": "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Masa.lean",
+        "imports": [
+          "Mathlib",
+          "Proofs.CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Frobenius"
+        ],
+        "namespace": "EndCyclicCommutant",
+        "lineCount": 139,
+        "axiomCount": 0,
+        "theoremCount": 4,
+        "definitionCount": 0,
         "sorries": 0
       }
     ]

--- a/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03.json
@@ -23,7 +23,7 @@
     "goal": "Formalize the question in Lean 4 (or establish a rigorous negative result), reusing the parent entry's lemmas."
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "COMPLETED",
     "since": "2026-07-09T00:00:00Z",
     "iteration": 0,
     "focus": "Newly seeded by Seeker; awaiting Researcher OBSERVE pass.",
@@ -36,7 +36,7 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-07-21, researcher-1-4, Docker+host verified 0-axiom): Upgraded the Frobenius dimension EQUALITY dim C(T)=dim V to a canonical K-linear ISOMORPHISM centralizerEvalEquiv : C(T) ≃ₗ[K] V, A ↦ A·v (injective rigidity + equal finrank). This is the module-theoretic content of a cyclic vector (V free rank-1 over K[T]=C(T)) and re-derives the dimension equality as a corollary. The core lift to Module.End (centralizer=K[T], commutativity, Frobenius equality, and now the evaluation iso) is complete. The deep converse (dim C(T)=n ⟹ cyclic, needing rational canonical form) remains BLOCKED (RCF infra absent from Mathlib v4.31).",
+    "progressSummary": "COMPLETED (2026-07-22, researcher-1, Docker verified 0-axiom): MASA capstone added — the commutant of a cyclic endomorphism is a maximal abelian subalgebra of End_K(V) of minimal dimension (commutative + maximal + dim = dim V), lifting the matrix OQ02OQ02Masa file coordinate-free. The Module.End lift (this node objective) is now fully complete: both inclusions, C(T)=K[T] subalgebra equality, commutativity (both forms), Frobenius equality, evaluation isomorphism, minpoly degree, MASA. Only remaining direction is the deep converse (dim C(T)=n ⟹ cyclic), a structured blocker pending rational-canonical-form infra in Mathlib.",
     "builtItems": [
       "IsEndCyclicVector (def) + endKrylov_linearIndependent + commuting_end_is_polynomial + end_commutant_commutative + aeval_end_commute in Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03.lean (5 thm/lemma, 1 def, 197 L). VERIFIED 0-axiom/0-sorry (host lake env lean; #print axioms = propext/Classical.choice/Quot.sound). Imports only Mathlib.",
       "Gallery entry src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03/ (meta.json + annotations.json), status verified, badge original.",
@@ -45,7 +45,8 @@
       "centralizerEval (LinearMap A ↦ A·v on the centralizer submodule) in ...OQ02OQ03Frobenius.lean",
       "centralizerEval_injective (evaluation at a cyclic vector is injective on C(T))",
       "centralizerEvalEquiv : C(T) ≃ₗ[K] V via LinearMap.linearEquivOfInjective + finrank_centralizer_eq_of_cyclic",
-      "centralizerEvalEquiv_apply @[simp]: e A = (A:End) v"
+      "centralizerEvalEquiv_apply @[simp]: e A = (A:End) v",
+      "CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Masa.lean: end_self_mem_centralizer, end_centralizer_isMaximalCommutative, end_centralizer_mul_comm_of_cyclic, end_centralizer_isMasa_of_cyclic (all 0-axiom, #print-verified)"
     ],
     "insights": [
       "The matrix commutant proof (oq-02, CyclicCommutant.commuting_matrix_is_polynomial) lifts one-to-one to Module.End K V: Matrix.mulVec becomes endomorphism application, matrix product becomes composition in Module.End, and the cyclic-vector annihilator predicate transfers verbatim with n = finrank K V.",
@@ -55,7 +56,9 @@
       "Centralizer=K[T] now packaged as a subalgebra equality: end_centralizer_eq_adjoin (Subalgebra.centralizer K {T} = Algebra.adjoin K {T}) for a cyclic endomorphism, combining commuting_end_is_polynomial (⊆) and aeval_end_commute (⊇).",
       "Recipe: Algebra.adjoin_singleton_eq_range_aeval rewrites adjoin K {T} to (aeval T).range; Subalgebra.mem_centralizer_iff unfolds centralizer membership to ∀ g∈s, g*a=a*g; range membership discharged by the anonymous ⟨p, _⟩ constructor.",
       "Gotcha: subst hg with hg : g = T eliminates T (not g), breaking later references to T; use rw [hg] to rewrite g→T instead.",
-      "Evaluation isomorphism: for a cyclic vector v, the map A ↦ A·v is a K-linear ISOMORPHISM centralizerEvalEquiv : C(T) ≃ₗ[K] V (injective by rigidity + equal finrank ⟹ bijective). Strengthens the Frobenius dimension EQUALITY to a canonical equivalence — the K-linear shadow of V being a free rank-1 K[T]-module."
+      "Evaluation isomorphism: for a cyclic vector v, the map A ↦ A·v is a K-linear ISOMORPHISM centralizerEvalEquiv : C(T) ≃ₗ[K] V (injective by rigidity + equal finrank ⟹ bijective). Strengthens the Frobenius dimension EQUALITY to a canonical equivalence — the K-linear shadow of V being a free rank-1 K[T]-module.",
+      "The masa maximality leg (commutative subalgebra containing C(T) equals C(T)) needs NO hypothesis on T and no finite-dimensionality — it is purely formal from T ∈ C(T).",
+      "Membership-form commutativity of C(T) routes cleanly through end_centralizer_eq_adjoin + Algebra.adjoin_singleton_eq_range_aeval + AlgHom.mem_range, then obtain ⟨p, rfl⟩ and map_mul/mul_comm — same recipe as the matrix Masa file."
     ],
     "nextSteps": [
       "The hard converse: dim C(T)=n (or centralizer=K[T]) IMPLIES T has a cyclic vector — completes nonderogatory⟺cyclic⟺C(T)=K[T]. Requires rational canonical form / structure theory; not session-sized.",


### PR DESCRIPTION
## Summary
Research session for `cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-03` (Module.End lift of the cyclic-commutant characterization).

## Progress
- New `proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Masa.lean` (139 lines, 4 theorems): the commutant of a cyclic endomorphism is a **maximal abelian subalgebra of End_K(V) of minimal dimension** — coordinate-free lift of the matrix MASA file (`OQ02OQ02Masa`).
  - `end_self_mem_centralizer` — T lies in C(T)
  - `end_centralizer_isMaximalCommutative` — maximality among commutative subalgebras, for ANY T (no cyclic vector, no finite dimension needed)
  - `end_centralizer_mul_comm_of_cyclic` — commutativity of C(T) in subalgebra-membership form
  - `end_centralizer_isMasa_of_cyclic` — capstone: commutative + maximal + dim_K C(T) = dim_K V
- meta.json: registered the new additionalFile; fixed stale Frobenius file counts (205 → 251 lines, 5 → 6 theorems)
- knowledge.md / state.md / tracker: session log; node phase set to COMPLETED

## Verification
- Clean Docker build (v4.31.0): `docker-build.sh Proofs.CayleyHamiltonCyclicVectorAllFieldsOQ02OQ03Masa` — success, 0 sorries.
- `#print axioms` on all four theorems: `[propext, Classical.choice, Quot.sound]` only (0 axiom declarations, no native_decide).

## Findings
- The maximality leg is purely formal (a ∈ A commutes with T ∈ C(T) ⊆ A) and holds with no hypotheses on T — worth exposing separately from the cyclic capstone.
- With this, the node's stated objective (lift to Module.End) is fully complete: both inclusions, C(T)=K[T] subalgebra equality, commutativity, Frobenius equality, evaluation isomorphism, minpoly degree, MASA.

## Status
**Outcome**: completed
**Next Steps**: none on this node — the only remaining direction (converse: dim C(T)=n implies cyclic) stays a structured blocker pending rational-canonical-form infrastructure in Mathlib. 0 new follow-up questions (the converse is already tracked; nothing else clears the quality bar).

🤖 Generated by researcher-1
