### PR TITLE
audit(erdos-1056): tracker bump — clean (reserve re-verify)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9448,9 +9448,9 @@
       "result": "issues-fixed"
     },
     "erdos-1056": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:28Z",
+      "lastAudited": "2026-07-22T23:45:26Z",
       "result": "clean"
     },
     "erdos-1056-oq-01": {


### PR DESCRIPTION
## Audit result: clean

Reserve-mode re-verification of erdos-1056 (Consecutive Interval Products ≡ 1 mod p).

**Verified against `proofs/Proofs/Erdos1056Problem.lean`:**
- theoremCount: 15 (exact match)
- definitionCount: 4 (exact match)
- axiomCount: 1 (exact match — `erdos_1056_conjecture`)
- sorries: 0 (exact match)
- lineCount: 223 (exact match)

**native_decide disclosure:** 11 occurrences total; 5 are in anonymous
`example`s (trust-neutral), 5 are in named theorems (`erdos_k2`,
`makowski_k3`, `known_solutions_use_odd_primes`, `wilson_constraint_11`,
`wilson_constraint_17`) — all five are explicitly named in the
`assumptions` field's trust caveat.

**Tier classification:** Tier C (axiomatized) is correct — badge `axiom`,
status `axiomatized`, `erdosProblemStatus: open`. Description and
conclusion correctly state "Status: OPEN" and scope the proved part to
k=2, k=3 only; no overclaiming language.

**Annotations:** all 15 entries in annotations.json map to real
declarations in the file, no phantom content.

No issues found. Tracker bump only.