### PR TITLE
audit(erdos-736): tracker bump — clean (reserve re-verify)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16001,8 +16001,8 @@
     },
     "erdos-736": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:40Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-22T23:52:01Z",
       "result": "clean"
     },
     "erdos-737": {


### PR DESCRIPTION
## Audit result: clean

Reserve-mode re-verification of erdos-736 (Chromatic Numbers and Finite Subgraph Inheritance / Taylor's conjecture).

**Verified against `proofs/Proofs/Erdos736Problem.lean`:**
- theoremCount: 17 (exact match)
- definitionCount: 10 (exact match)
- axiomCount: 0 (exact match — no `axiom` declarations)
- sorries: 0 (exact match)
- lineCount: 437 (exact match)
- No `native_decide`, no True stubs.

**Tier classification:** badge `verified` is honestly scoped — the open conjecture (Taylor's conjecture, independent of ZFC per Komjáth–Shelah) is stated only as a `Prop` (`TaylorConjecture`/`GeneralizedTaylorConjecture`), never proved or assumed. All 17 theorems (de Bruijn–Erdős compactness, its contrapositive, the Cardinal↔Colorable bridge lemmas, and the discrete-IVT `finite_case`) are fully machine-checked. `conclusion.summary` correctly states the problem is OPEN.

**originalContributions cross-checked:** all 8 bullets name real declarations in the file (`chromaticNumber`, `TaylorConjecture`, `GeneralizedTaylorConjecture`, `deBruijn_erdos_coloring`, `exists_finite_subgraph_not_colorable`, the bridge lemmas, `exists_induce_chiN_eq`, `finite_case`) — no phantom decls.

**Annotations:** axiom/sorry mentions in `annotations.json` are all about the mathematical axiom of choice / ZFC, not Lean `axiom` declarations — no masking.

No issues found. Tracker bump only.