### PR TITLE
Enrich erdos-46: cover 202-line greedy-overshoot/bracket growth tail

### DIFF
--- a/src/data/proofs/erdos-46/annotations.json
+++ b/src/data/proofs/erdos-46/annotations.json
@@ -169,8 +169,8 @@
       "endLine": 66
     },
     "title": "Erdős–Graham Rational Generalization",
-    "content": "**ErdosGraham_rational**: $\\forall q \\in \\mathbb{Q}_{>0},\\, \\forall r,\\, \\forall c: \\exists S: \\text{IsRatFractionRepr}(S, q) \\wedge \\text{IsMonochromatic}(c, S)$. The axiom **rational_from_infinite** asserts this follows from the infinitely-many version.",
-    "mathContext": "The reduction uses that any $q > 0$ can be written as a finite sum of values $1/n$ with $n \\ge 2$. Given infinitely many disjoint monochromatic representations of $1$, one selects enough of them and adjusts to represent $q$. The axiom bridges the gap without formalizing this combinatorial argument.",
+    "content": "**ErdosGraham_rational**: $\\forall q \\in \\mathbb{Q}_{>0},\\, \\forall r,\\, \\forall c: \\exists S: \\text{IsRatFractionRepr}(S, q) \\wedge \\text{IsMonochromatic}(c, S)$. Stated only as a `Prop`, with a source comment recording that it follows from the infinitely-many-disjoint-solutions version — no bridging axiom is declared (the file is 0-axiom).",
+    "mathContext": "The reduction uses that any $q > 0$ can be written as a finite sum of values $1/n$ with $n \\ge 2$. Given infinitely many disjoint monochromatic representations of $1$, one selects enough of them and adjusts to represent $q$. This combinatorial argument is documented but not formalized; no axiom asserts it.",
     "significance": "key",
     "relatedConcepts": [
       "Erdős–Graham conjecture",
@@ -212,7 +212,7 @@
       "endLine": 76
     },
     "title": "Singleton Not a Representation",
-    "content": "**not_unitFractionRepr_singleton**: $\\neg\\text{IsUnitFractionRepr}(\\{n\\})$ for any $n$. Axiomatized — since $n \\ge 2$ implies $1/n \\le 1/2 < 1$.",
+    "content": "**not_isUnitFractionRepr_singleton**: $\\neg\\text{IsUnitFractionRepr}(\\{n\\})$ for any $n$. Proved (0 axioms) — since $n \\ge 2$ implies $1/n \\le 1/2 < 1$.",
     "mathContext": "For $n \\ge 2$, $1/n \\le 1/2 < 1$, so no singleton gives sum $1$. The minimum representation has 3 terms (e.g., $1/2 + 1/3 + 1/6 = 1$).",
     "significance": "supporting",
     "relatedConcepts": [
@@ -232,7 +232,7 @@
       "endLine": 84
     },
     "title": "Monochromaticity Properties and Cardinality Bound",
-    "content": "**mono_one_colour**: any set is monochromatic under a 1-colouring ($r = 1$). **mono_subset**: subsets of monochromatic sets are monochromatic. **unitFractionRepr_card_ge_two**: representations have $|S| \\ge 2$ (axiomatized).",
+    "content": "**mono_one_colour**: any set is monochromatic under a 1-colouring ($r = 1$). **mono_subset**: subsets of monochromatic sets are monochromatic. **two_le_card_of_isUnitFractionRepr**: representations have $|S| \\ge 2$ (proved, 0 axioms).",
     "mathContext": "The 1-colouring case is trivial since `Fin 1` has only one element (`0`). The subset lemma is standard Ramsey theory: colour is inherited. The cardinality bound $|S| \\ge 2$ follows from the empty and singleton exclusions. Together these lemmas establish the basic framework for the partition regularity statement.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -244,6 +244,94 @@
       "IsMonochromatic",
       "FiniteColouring",
       "IsUnitFractionRepr"
+    ]
+  },
+  {
+    "id": "erdos-46-greedy-overshoot",
+    "proofId": "erdos-46",
+    "type": "technique",
+    "range": {
+      "startLine": 570,
+      "endLine": 621
+    },
+    "title": "Half-Block Bound and Greedy Overshoot",
+    "content": "**sum_Ico_inv_ge_half**: for $N \\ge 1$, $\\sum_{k=N+1}^{2N} 1/k \\ge 1/2$, since each of the $N$ terms is $\\ge 1/(2N)$. **sum_Ico_inv_ge_one**: concatenating this bound at $N$ and at $2N$ shows the block $[N{+}1, 4N]$ sums to $\\ge 1$. **exists_isRatFractionRepr_ge_one_min_gt** packages the block $[N{+}1,4N]$ as an `IsRatFractionRepr` witness with $q \\ge 1$ and every denominator $> N$.",
+    "mathContext": "Half-block: $\\sum_{k=N+1}^{2N} 1/k \\ge N \\cdot \\frac{1}{2N} = \\frac12$ via `Finset.card_nsmul_le_sum`. Doubling: applying the half-block bound at $N$ (covering $[N{+}1,2N]$) and at $2N$ (covering $[2N{+}1,4N]$) and splitting the sum via `Finset.sum_Ico_consecutive` gives $\\sum_{[N+1,4N]} 1/k \\ge \\frac12+\\frac12=1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "block-doubling bound",
+      "Finset.card_nsmul_le_sum",
+      "Finset.sum_Ico_consecutive",
+      "greedy harmonic sum"
+    ],
+    "prerequisites": [
+      "IsRatFractionRepr",
+      "Finset.Ico"
+    ]
+  },
+  {
+    "id": "erdos-46-controlled-overshoot",
+    "proofId": "erdos-46",
+    "type": "technique",
+    "range": {
+      "startLine": 626,
+      "endLine": 676
+    },
+    "title": "Controlled Greedy Overshoot",
+    "content": "**exists_isRatFractionRepr_controlled_overshoot**: for $N \\ge 1$ there is a consecutive block $[N{+}1, M)$ (with $M \\le 4N{+}1$) whose reciprocals sum to $q$ with $1 \\le q < 1 + 1/(N{+}1)$, every denominator $> N$. Uses `Nat.find` to take the *minimal* $M = b_0$ for which the block first reaches sum $\\ge 1$: the block one term shorter falls short of $1$ by minimality, and the single extra term $1/(b_0{-}1) \\le 1/(N{+}1)$ bounds the overshoot.",
+    "mathContext": "Let $b_0 = \\min\\{b : \\sum_{[N+1,b)} 1/k \\ge 1\\}$ (exists by `sum_Ico_inv_ge_one`, via `Nat.find`). Minimality gives $\\sum_{[N+1,b_0-1)} 1/k < 1$, and splitting off the top term via `Finset.sum_Ico_succ_top`, $\\sum_{[N+1,b_0)} 1/k = \\sum_{[N+1,b_0-1)} 1/k + 1/(b_0{-}1)$, so the overshoot $q - 1 < 1/(b_0{-}1) \\le 1/(N{+}1)$ since $b_0 - 1 \\ge N+1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.find (minimality)",
+      "controlled overshoot",
+      "Finset.sum_Ico_succ_top"
+    ],
+    "prerequisites": [
+      "sum_Ico_inv_ge_one",
+      "Nat.find"
+    ]
+  },
+  {
+    "id": "erdos-46-controlled-undershoot",
+    "proofId": "erdos-46",
+    "type": "technique",
+    "range": {
+      "startLine": 677,
+      "endLine": 729
+    },
+    "title": "Controlled Greedy Undershoot",
+    "content": "**exists_isRatFractionRepr_controlled_undershoot**: the below-1 companion of the controlled overshoot. Using the same minimal $b_0$, the one-term-shorter block $[N{+}1, b_0{-}1)$ sums to $q$ with $1 - 1/(N{+}1) \\le q < 1$, every denominator $> N$ — since it falls short of $1$ by minimality, yet differs from the reaching block only by the single top term $1/(b_0{-}1) \\le 1/(N{+}1)$.",
+    "mathContext": "With $b_0$ minimal such that $\\sum_{[N+1,b_0)} 1/k \\ge 1$: set $c = b_0 - 1$, so $\\sum_{[N+1,c)} 1/k < 1$ (minimality) and $\\sum_{[N+1,c)} 1/k + 1/c \\ge 1$ (from $\\sum_{[N+1,b_0)}$ via `Finset.sum_Ico_succ_top`), giving $\\sum_{[N+1,c)} 1/k \\ge 1 - 1/c \\ge 1 - 1/(N{+}1)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "controlled undershoot",
+      "Nat.find (minimality)",
+      "Finset.sum_Ico_succ_top"
+    ],
+    "prerequisites": [
+      "exists_isRatFractionRepr_controlled_overshoot"
+    ]
+  },
+  {
+    "id": "erdos-46-bracket-one",
+    "proofId": "erdos-46",
+    "type": "insight",
+    "range": {
+      "startLine": 731,
+      "endLine": 752
+    },
+    "title": "Two-Sided Bracket of 1, Vanishing Width",
+    "content": "**exists_isRatFractionRepr_bracket_one**: combines the controlled overshoot and undershoot into representations $q_- < 1 \\le q_+$, both with every denominator $> N$, and gap $q_+ - q_- < 2/(N{+}1)$. As $N \\to \\infty$ the bracket collapses onto $1$: an elementary, colouring-free approximation of $1$ from both sides by large-denominator Egyptian sums. Exactly landing on $1$ (closing the residual gap collision-free) is left open, tracked as the file's remaining bounded-rational Diophantine step.",
+    "mathContext": "$q_+ - q_- < \\left(1+\\frac1{N+1}\\right) - \\left(1-\\frac1{N+1}\\right) = \\frac{2}{N+1}$, proved by combining `exists_isRatFractionRepr_controlled_overshoot` and `exists_isRatFractionRepr_controlled_undershoot` with `linarith`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "two-sided approximation",
+      "vanishing gap",
+      "Diophantine subset-sum"
+    ],
+    "prerequisites": [
+      "exists_isRatFractionRepr_controlled_overshoot",
+      "exists_isRatFractionRepr_controlled_undershoot"
     ]
   }
 ]

--- a/src/data/proofs/erdos-46/meta.json
+++ b/src/data/proofs/erdos-46/meta.json
@@ -57,12 +57,16 @@
       "Verified basic properties (empty/singleton exclusion, monotone, |S| ≥ 2 cardinality lower bound)",
       "Fibonacci–Sylvester splitting engine: inv_mul_succ, split_unit_fraction, isUnitFractionRepr_replace, and exists_isUnitFractionRepr_card_ge (arbitrarily long representations)",
       "infinite_isUnitFractionRepr: axiom-free proof that infinitely many distinct unit-fraction representations of 1 exist",
-      "Multiplicative scaling engine: isRatFractionRepr_smul and exists_isRatFractionRepr_inv_min_ge (representations of 1/t with all denominators ≥ 2t)"
+      "Multiplicative scaling engine: isRatFractionRepr_smul and exists_isRatFractionRepr_inv_min_ge (representations of 1/t with all denominators ≥ 2t)",
+      "Telescoping engine: sum_Ico_inv_mul_succ, injective_mul_succ, isRatFractionRepr_telescope, and exists_isRatFractionRepr_min_gt (builds representations of a positive rational from pronic-number denominators, all exceeding a given bound)",
+      "Divisor-sum bridge: isUnitFractionRepr_of_divisorSum and divisorSum_min_gt, reducing the min-denominator->N crux to a pseudoperfect/practical-number decomposition",
+      "Greedy harmonic overshoot: sum_Ico_inv_ge_half, sum_Ico_inv_ge_one, exists_isRatFractionRepr_ge_one_min_gt, and exists_isRatFractionRepr_controlled_overshoot (a consecutive-block representation of q in [1, 1+1/(N+1)) with every denominator > N)",
+      "Two-sided bracket of 1: exists_isRatFractionRepr_controlled_undershoot and exists_isRatFractionRepr_bracket_one (representations of q₋ < 1 ≤ q₊ with q₊ - q₋ < 2/(N+1), all denominators > N)"
     ],
     "axiomCount": 0,
-    "lineCount": 359,
+    "lineCount": 752,
     "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives.",
-    "theoremCount": 25,
+    "theoremCount": 38,
     "definitionCount": 7
   },
   "overview": {
@@ -77,7 +81,9 @@
       "**Non-constructive proof**: Croot's argument gives no explicit bounds on the size of the denominators or number of colours needed",
       "**Minimum representation**: $|S| \\ge 2$ for any unit fraction representation (e.g., $1/2 + 1/3 + 1/6 = 1$ is minimal with 3 terms)",
       "**Formalized elementary core (0 axioms)**: what is machine-checked here is the *colouring-free* skeleton — representations of $1$ exist ($\\{2,3,6\\}$), have $\\ge 2$ terms, and are infinitely many — proved by iterating the Fibonacci–Sylvester splitting $1/n = 1/(n{+}1) + 1/(n(n{+}1))$ on the largest denominator. Croot's deep monochromatic theorem is stated as a `Prop`, not formalized",
-      "**Two assembly engines**: representations combine *additively* over disjoint denominator sets (`isRatFractionRepr_union`, $q + p$) and *multiplicatively* by scaling every denominator by $t$ (`isRatFractionRepr_smul`, $q \\mapsto q/t$ with all denominators $\\ge 2t$) — the multiplicative engine forces large denominators, the prerequisite for the pairwise-disjoint chaining behind the infinitely-many variant"
+      "**Two assembly engines**: representations combine *additively* over disjoint denominator sets (`isRatFractionRepr_union`, $q + p$) and *multiplicatively* by scaling every denominator by $t$ (`isRatFractionRepr_smul`, $q \\mapsto q/t$ with all denominators $\\ge 2t$) — the multiplicative engine forces large denominators, the prerequisite for the pairwise-disjoint chaining behind the infinitely-many variant",
+      "**Greedy harmonic bracket (axiom-free)**: the block-doubling bound $\\sum_{k=N+1}^{2N} 1/k \\ge 1/2$, concatenated at $N$ and $2N$, gives $\\sum_{k=N+1}^{4N} 1/k \\ge 1$ — a consecutive-block Egyptian representation of some $q \\ge 1$ with every denominator $> N$. Taking the minimal such block sharpens this to a *controlled* overshoot $q \\in [1, 1 + 1/(N+1))$, and the one-term-shorter block gives a matching undershoot $q \\in [1 - 1/(N+1), 1)$",
+      "**Two-sided bracket, still open at the last step**: the controlled overshoot and undershoot sandwich $1$ between two large-denominator representations with gap $< 2/(N+1) \\to 0$ as $N \\to \\infty$ — an elementary, colouring-free approach to representing *exactly* $1$ with arbitrarily large minimum denominator, but closing the residual gap collision-free remains a bounded-rational Diophantine step that this file leaves open"
     ],
     "prerequisites": [
       "Unit fractions and Egyptian fractions",
@@ -166,6 +172,22 @@
       "endLine": 550,
       "summary": "A structurally different attack surface that translates the open crux into multiplicative number theory. `isUnitFractionRepr_of_divisorSum`: if $T$ is a set of distinct divisors of $M$ with $\\sum_{d \\in T} d = M$ (so $M$ is *pseudoperfect via $T$*) and each $2d \\le M$, then the cofactor set $\\{M/d : d \\in T\\}$ is a unit-fraction representation of $1$, since $\\sum 1/(M/d) = (\\sum d)/M = 1$. `divisorSum_min_gt`: if additionally every chosen divisor satisfies $N \\cdot d < M$ (i.e. $d < M/N$), every cofactor denominator $M/d$ exceeds $N$. Together they reduce \"represent $1$ with min denominator $> N$\" to \"write $M$ as a sum of distinct divisors of $M$, each $< M/N$\". The reduction is an **equivalence** (from any Egyptian representation $S$ of $1$, take $M = \\operatorname{lcm} S$ and $d_s = M/s$), so under the equivalent-strength rule it earns no decomposition credit; it is recorded as infrastructure exposing the divisor / practical-number route.",
       "mathContext": "Divisor-sum bridge: dividing a pseudoperfect decomposition $\\sum_{d \\in T} d = M$ through by $M$ turns each divisor $d$ into a reciprocal $1/(M/d) = d/M$, and the cofactor map $d \\mapsto M/d$ is injective on divisors of $M$ (left inverse $q \\mapsto M/q$). The minimum denominator is $M / \\max T$, which exceeds $N$ exactly when every $d < M/N$. This phrases the crux entirely in terms of $\\texttt{Nat.divisors}$: the genuine open content becomes a **practical-number completeness** fact — producing an $M$ with enough *small* divisors summing exactly to $M$."
+    },
+    {
+      "id": "greedy-overshoot",
+      "title": "Greedy Harmonic Overshoot",
+      "startLine": 552,
+      "endLine": 676,
+      "summary": "A fourth engine, complementary to the additive/multiplicative/telescoping ones (which all stay strictly below $1$): the **greedy harmonic block**. `sum_Ico_inv_ge_half`: the $N$-term block $[N{+}1, 2N]$ sums to $\\ge 1/2$ (each term $\\ge 1/(2N)$). `sum_Ico_inv_ge_one`: concatenating this bound at $N$ and at $2N$ shows $[N{+}1, 4N]$ sums to $\\ge 1$, with every denominator $> N$. `exists_isRatFractionRepr_ge_one_min_gt` packages this as a representation of some $q \\ge 1$. `exists_isRatFractionRepr_controlled_overshoot` sharpens it: taking the *minimal* block reaching sum $\\ge 1$ (via `Nat.find`) bounds the overshoot to $q < 1 + 1/(N{+}1)$, since the one-term-shorter block still falls short and the single extra term is $\\le 1/(N{+}1)$.",
+      "mathContext": "Half-block bound: $\\sum_{k=N+1}^{2N} 1/k \\ge N \\cdot 1/(2N) = 1/2$. Doubling: $\\sum_{k=N+1}^{4N} 1/k = \\sum_{k=N+1}^{2N} 1/k + \\sum_{k=2N+1}^{4N} 1/k \\ge 1/2 + 1/2 = 1$. Minimality (`Nat.find`) on $b \\mapsto \\sum_{k=N+1}^{b-1} 1/k \\ge 1$ gives the least $b_0$ with $\\sum_{[N+1,b_0)} 1/k \\ge 1$; the block one shorter, $[N{+}1, b_0{-}1)$, sums to $< 1$, and the two blocks differ by the single term $1/(b_0{-}1) \\le 1/(N{+}1)$, forcing $q < 1 + 1/(N{+}1)$."
+    },
+    {
+      "id": "two-sided-bracket",
+      "title": "Two-Sided Bracket of 1 with Vanishing Width",
+      "startLine": 677,
+      "endLine": 752,
+      "summary": "The below-$1$ companion and its combination with the overshoot. `exists_isRatFractionRepr_controlled_undershoot`: the same minimal block $b_0$ from the overshoot construction, taken one term short ($[N{+}1, b_0{-}1)$), sums to some $q < 1$ with $q \\ge 1 - 1/(N{+}1)$ by the same single-term difference bound. `exists_isRatFractionRepr_bracket_one` combines both: representations $q_- < 1 \\le q_+$ exist with every denominator $> N$ and gap $q_+ - q_- < 2/(N{+}1)$, so the bracket collapses onto $1$ as $N \\to \\infty$. This is the file's closest elementary approach to the open crux (an *exact* representation of $1$ with min denominator $> N$) — the residual $[q_-, q_+]$ gap must still be closed collision-free, which is not done here.",
+      "mathContext": "Undershoot: with $b_0$ minimal such that $\\sum_{[N+1,b_0)} 1/k \\ge 1$, the shorter block $[N{+}1, b_0{-}1)$ sums to $q_- < 1$ with $q_- \\ge 1 - 1/(b_0{-}1) \\ge 1 - 1/(N{+}1)$ (since $b_0 - 1 \\ge N+1$). Bracket: $q_+ - q_- < (1 + 1/(N{+}1)) - (1 - 1/(N{+}1)) = 2/(N{+}1) \\to 0$. Both $q_-, q_+$ use only denominators $> N$; exactly landing on $1$ (a bounded-rational Diophantine subset-sum) remains open."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

`erdos-46`'s `meta.json` sections stopped at line 550, but `Proofs/Erdos46Problem.lean`
has grown to 752 lines via merged research PRs adding two new axiom-free engines:
a **greedy harmonic overshoot** (`sum_Ico_inv_ge_half`/`_ge_one`, a controlled-overshoot
representation of some `q ∈ [1, 1+1/(N+1))` with every denominator `> N`) and its
**two-sided bracket-of-1 companion** (a matching undershoot, then
`exists_isRatFractionRepr_bracket_one` sandwiching `1` with vanishing gap `< 2/(N+1)`).
202 lines of genuine new mathematics — well-documented in the Lean source's own
docstrings — were completely uncovered by sections or annotations.

While reading the surrounding annotations to match this entry's existing (very high)
documentation quality, I found 3 older annotations referencing identifiers that no
longer exist under those names (`not_unitFractionRepr_singleton` →
`not_isUnitFractionRepr_singleton`, `unitFractionRepr_card_ge_two` →
`two_le_card_of_isUnitFractionRepr`, and a false "axiom `rational_from_infinite`"
claim for `ErdosGraham_rational`, which the file states only as a `Prop` with an
expository comment) — the file has `axiomCount: 0` and these were never axioms in
the current source. Fixed those three in passing since they were adjacent and easy
to verify; did not attempt a full annotation audit of the whole file (out of scope
for this pass).

Changes:
- Add two sections (`greedy-overshoot` 552-676, `two-sided-bracket` 677-752) — full
  section coverage 21-752, no gaps.
- Add 4 new annotations for the previously-uncovered theorems.
- Fix stale `meta.lineCount` (359→752) and `meta.theoremCount` (25→38), matching the
  actual file (`grep -c` verified: 38 theorems, 0 axioms, 0 sorries).
- Add 4 `originalContributions` entries: two for engines that already had sections
  but were missing from this summary list (telescoping, divisor-sum bridge), two for
  the new engines (greedy overshoot, two-sided bracket).
- Add 2 `keyInsights` describing the new results.
- Fix the 3 stale/renamed annotations described above.

Note: PR #39457 ("discharge singleton-exclusion + \|S\|≥2 structural lemmas") is open
against this same file but is based on a stale ~84-line snapshot from before the
research PRs that grew the file to 752 lines merged; its target lemmas already exist
under slightly different names in current `main`, and its line range (69-106) doesn't
overlap this PR's changes (552-752). Flagging for a mechanic/doctor pass to close as
superseded, not fixing it here (out of scope).

File stays well under size caps (meta.json 23.2 KB, annotations.json 15.9 KB, both « 60 KB).

## Test plan
- [x] `python3 -m json.tool` validates both `meta.json` and `annotations.json`
- [x] `pnpm build`'s JSON-touching pipeline steps (gallery build, `check-search-index`,
  `build-loading-facts`, `build-redirects`) all passed; `tsc`/`vite build` are
  unavailable in this worktree (missing `node_modules`, a pre-existing environment
  gap, not caused by this change)
- [x] Diff scoped to only `src/data/proofs/erdos-46/` (build-noise files reverted
  before commit)
- [x] Verified via `grep` that the 3 corrected identifiers exist under their new
  names and that no axiom declarations exist for the facts whose wording was fixed