### PR TITLE
Enrich erdos-64: re-anchor drifted sections/annotations, cover new theorems

### DIFF
--- a/src/data/proofs/erdos-64/annotations.json
+++ b/src/data/proofs/erdos-64/annotations.json
@@ -235,8 +235,8 @@
     "id": "ann-e64-liu-mont",
     "proofId": "erdos-64",
     "range": {
-      "startLine": 102,
-      "endLine": 105
+      "startLine": 96,
+      "endLine": 101
     },
     "type": "concept",
     "title": "Liu-Montgomery Threshold Theorem (2020)",
@@ -259,8 +259,8 @@
     "id": "ann-e64-even-cycles",
     "proofId": "erdos-64",
     "range": {
-      "startLine": 116,
-      "endLine": 121
+      "startLine": 104,
+      "endLine": 110
     },
     "type": "concept",
     "title": "Liu-Montgomery Even Cycles Theorem",
@@ -283,8 +283,8 @@
     "id": "ann-e64-range-power",
     "proofId": "erdos-64",
     "range": {
-      "startLine": 124,
-      "endLine": 131
+      "startLine": 111,
+      "endLine": 119
     },
     "type": "concept",
     "title": "Range Contains Power of Two",
@@ -305,8 +305,8 @@
     "id": "ann-e64-infgraph",
     "proofId": "erdos-64",
     "range": {
-      "startLine": 136,
-      "endLine": 139
+      "startLine": 123,
+      "endLine": 127
     },
     "type": "definition",
     "title": "Infinite Graph Structure",
@@ -329,8 +329,8 @@
     "id": "ann-e64-tree",
     "proofId": "erdos-64",
     "range": {
-      "startLine": 159,
-      "endLine": 160
+      "startLine": 142,
+      "endLine": 146
     },
     "type": "concept",
     "title": "Infinite 3-Regular Tree Exists",
@@ -353,8 +353,8 @@
     "id": "ann-e64-degree3",
     "proofId": "erdos-64",
     "range": {
-      "startLine": 169,
-      "endLine": 172
+      "startLine": 149,
+      "endLine": 157
     },
     "type": "definition",
     "title": "Degree 3 Conjecture (Open)",
@@ -375,8 +375,8 @@
     "id": "ann-e64-dirac",
     "proofId": "erdos-64",
     "range": {
-      "startLine": 183,
-      "endLine": 185
+      "startLine": 690,
+      "endLine": 694
     },
     "type": "concept",
     "title": "Dirac's Theorem (1952)",
@@ -399,8 +399,8 @@
     "id": "ann-e64-bondy",
     "proofId": "erdos-64",
     "range": {
-      "startLine": 192,
-      "endLine": 197
+      "startLine": 695,
+      "endLine": 699
     },
     "type": "concept",
     "title": "Bondy's Pancyclicity Theorem (1971)",
@@ -417,6 +417,54 @@
       "edgeFinset.card",
       "bipartite definition",
       "ContainsCycleLength"
+    ]
+  },
+  {
+    "id": "ann-e64-even-cycle-mindeg3",
+    "proofId": "erdos-64",
+    "range": {
+      "startLine": 335,
+      "endLine": 359
+    },
+    "type": "insight",
+    "title": "Even Cycle from Minimum Degree 3 (machine-checked, axiom-free)",
+    "content": "Proves `hasMinDegree_three_exists_even_cycle`: every nonempty finite graph with $\\delta(G) \\ge 3$ contains a cycle of even length, with an explicit `SimpleGraph.Walk.IsCycle` witness. The classical longest-path argument: take a path $p$ of maximum length from $v_0$; maximality traps all $\\ge 3$ neighbours of $v_0$ at distinct positive indices along $p$. Taking the two largest such indices $a < b$, closing the prefix at $a$, at $b$, and around the segment $[a,b]$ yields three cycles of lengths $a+1$, $b+1$, $b-a+2$, summing to $2b+4$ (even) — so they cannot all be odd, and one is even.",
+    "mathContext": "$c_1 + c_2 + c_3 = (a+1) + (b+1) + (b-a+2) = 2b+4$, which is even, so an odd/odd/odd split is impossible by parity — at least one $c_i$ is even. Since every $2^k$ ($k \\ge 2$) is itself even, this proves the parity half of Problem 64's necessary condition (a $2^k$-cycle is in particular even), though not the power-of-two half, which remains open.",
+    "significance": "key",
+    "relatedConcepts": [
+      "longest-path method",
+      "parity argument",
+      "even cycle",
+      "Erdős-Gyárfás conjecture"
+    ],
+    "prerequisites": [
+      "hasMinDegree_two_exists_cycle",
+      "SimpleGraph.Walk.takeUntil",
+      "SimpleGraph.Walk.IsCycle"
+    ]
+  },
+  {
+    "id": "ann-e64-dirac-type-lower-bound",
+    "proofId": "erdos-64",
+    "range": {
+      "startLine": 563,
+      "endLine": 587
+    },
+    "type": "insight",
+    "title": "Dirac-Type Lower Bound on Cycle Length (machine-checked, axiom-free)",
+    "content": "Proves `hasMinDegree_exists_cycle_length_ge`, the quantitative companion to the parity result: minimum degree $d \\ge 2$ forces a cycle of length at least $d+1$. Reuses the same longest-path engine: the $\\ge d$ neighbours of the start vertex of a maximum-length path sit at distinct positive indices, so by pigeonhole the largest index $b$ satisfies $b \\ge d$ ($d$ distinct positive integers cannot all lie below $d$); closing the path prefix at that index yields an explicit cycle of length $b+1 \\ge d+1$.",
+    "mathContext": "The neighbour-index set $T \\subseteq \\{1, \\ldots, b\\}$ (via `Finset.Icc 1 b`) has $|T| \\ge d$, so $d \\le |\\mathrm{Icc}\\,1\\,b| = b$. For Problem 64 this shows minimum degree pushes the guaranteed cycle length up linearly, but a length merely $\\ge d+1$ is far weaker than a length exactly $2^k$, which remains the open core.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "pigeonhole principle",
+      "longest-path method",
+      "minimum degree",
+      "Dirac's theorem"
+    ],
+    "prerequisites": [
+      "hasMinDegree_three_exists_even_cycle",
+      "Finset.Icc",
+      "Finset.card_le_card"
     ]
   }
 ]

--- a/src/data/proofs/erdos-64/meta.json
+++ b/src/data/proofs/erdos-64/meta.json
@@ -88,25 +88,30 @@
       "degree_3_conjecture: explicit δ = 3 restatement",
       "dirac_theorem: axiomatized Hamiltonicity for δ ≥ n/2",
       "bondy_pancyclic: axiomatized pancyclicity for dense graphs",
-      "random_graph_cycles: axiomatized probabilistic evidence"
+      "random_graph_cycles: axiomatized probabilistic evidence",
+      "hasMinDegree_three_exists_even_cycle: proved (0-axiom) δ ≥ 3 forces an even-length cycle via longest-path parity argument",
+      "hasMinDegree_three_exists_even_containsCycleLength: proved (0-axiom) restatement in the ContainsCycleLength predicate, k ≥ 4",
+      "hasMinDegree_exists_cycle_length_ge: proved (0-axiom) Dirac-type rung, δ ≥ d forces a cycle of length ≥ d+1",
+      "hasMinDegree_containsCycleLength_ge: proved (0-axiom) restatement in the ContainsCycleLength predicate"
     ],
     "axiomCount": 0,
-    "lineCount": 205,
+    "lineCount": 732,
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
-    "theoremCount": 3,
-    "definitionCount": 12
+    "theoremCount": 14,
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "Erdős and Gyárfás posed this problem in the 1990s, conjecturing that the answer is NO: for every $r$, there should exist a graph with minimum degree $r$ avoiding all $2^k$-length cycles. This belief stemmed from the seeming rigidity of exponential cycle lengths compared to the flexibility available in dense graphs. The problem carries a $1000 Erdős prize, one of his highest bounties, reflecting its perceived difficulty. A breakthrough came from Hong Liu and Richard Montgomery (2020), who proved that for sufficiently large minimum degree $D$, every graph must contain a cycle of length $2^k$. Their proof, published as part of a broader result on even cycle lengths in graphs of large average degree, leverages the regularity method and a deep structural analysis showing that dense graphs contain cycles of every even length in a geometric range $[(\\log \\ell)^8, \\ell]$. Since this range contains a power of 2 whenever $\\ell \\ge 16$, the Erdős-Gyárfás conjecture is disproved for large $r$. However, the exact value of the threshold $D$ is not known, and the critical case $r = 3$ (minimum degree exactly 3) remains completely open. The problem connects to Dirac's theorem (1952), Bondy's pancyclicity theorem (1971), and the broader study of unavoidable cycle lengths in graph theory.",
     "problemStatement": "Does every finite graph with minimum degree at least $3$ contain a cycle of length $2^k$ for some $k \\ge 2$?",
     "text": "Does every finite graph with minimum degree ≥ 3 contain a cycle of length 2^k for some k ≥ 2? OPEN ($1000 prize).",
-    "proofStrategy": "The formalization defines cycle containment via injective vertex maps with cyclic adjacency (using `Fin.succMod`), minimum degree via `Finset.inf'` over neighbor counts, and the set $\\{2^k : k \\ge 2\\} = \\{4, 8, 16, \\ldots\\}$. The main conjecture and the disproved Erdős-Gyárfás conjecture are stated as Lean `Prop` definitions. Liu-Montgomery's threshold result and even-cycle theorem are axiomatized. An infinite counterexample (the infinite 3-regular tree) is formalized via a custom `InfGraph` structure, demonstrating that finiteness is essential. Supporting results include Dirac's theorem (Hamiltonicity from high degree), Bondy's pancyclicity theorem (dense graphs have all cycle lengths), and a probabilistic argument that random graphs contain power-of-two cycles.",
+    "proofStrategy": "The formalization defines cycle containment via injective vertex maps with cyclic adjacency (using `Fin.succMod`), minimum degree via `Finset.inf'` over neighbor counts, and the set $\\{2^k : k \\ge 2\\} = \\{4, 8, 16, \\ldots\\}$. The main conjecture and the disproved Erdős-Gyárfás conjecture are stated as Lean `Prop` definitions. Liu-Montgomery's threshold result and even-cycle theorem are axiomatized. An infinite counterexample (the infinite 3-regular tree) is formalized via a custom `InfGraph` structure, demonstrating that finiteness is essential. Supporting results include Dirac's theorem (Hamiltonicity from high degree), Bondy's pancyclicity theorem (dense graphs have all cycle lengths), and a probabilistic argument that random graphs contain power-of-two cycles. Two further machine-checked, axiom-free theorems apply the same longest-maximum-path technique used for plain cycle existence: `hasMinDegree_three_exists_even_cycle` shows δ ≥ 3 forces a cycle of even length (closing the parity half of the necessary condition), and `hasMinDegree_exists_cycle_length_ge` shows δ ≥ d forces a cycle of length at least d+1 (a Dirac-type quantitative rung, weaker than Dirac's theorem but requiring no density hypothesis).",
     "keyInsights": [
       "Liu-Montgomery breakthrough: ∃ D such that δ(G) ≥ D forces a C_{2^k} cycle. The proof shows dense graphs contain every even cycle length in a range [(log ℓ)^8, ℓ], which must include some 2^k",
       "Erdős-Gyárfás disproof: The conjecture that counterexamples exist for all r was disproved for large r, but r = 3 remains completely open",
       "Finiteness is essential: The infinite 3-regular tree has δ = 3 and no cycles at all",
       "Power-of-two special structure: {4, 8, 16, ...} is exponentially sparse (logarithmic density), making unavoidability a much stronger condition than for dense sets of cycle lengths",
-      "Probabilistic evidence: Random graphs G(n, c/n) almost surely satisfy the conjecture, so counterexamples must be highly structured"
+      "Probabilistic evidence: Random graphs G(n, c/n) almost surely satisfy the conjecture, so counterexamples must be highly structured",
+      "Longest-path engine proves two necessary conditions in full, axiom-free: δ ≥ 3 forces an even cycle (parity half of Problem 64), and δ ≥ d more generally forces a cycle of length ≥ d+1 (Dirac-type quantitative rung). Both reuse the same construction — the neighbours of a maximum-length path's start vertex sit at distinct positive indices, and closing the path there yields an explicit cycle — but neither touches the power-of-two half, which is the problem's entire remaining difficulty"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -196,27 +201,43 @@
       "mathContext": "Reconciles the two encodings of 'contains a cycle': the existence results hand back an explicit walk witnessing `Walk.IsCycle`, whereas the conjecture uses the length-indexed predicate `ContainsCycleLength G k`. `isCycle_containsCycleLength` turns an explicit cycle `c` into `ContainsCycleLength G c.length` by reindexing $i \\mapsto c.\\mathrm{getVert}\\, i$ and closing the wrap-around adjacency at the last vertex ($c.\\mathrm{getVert}\\, \\ell = v = c.\\mathrm{getVert}\\, 0$). `hasMinDegree_two_containsCycleLength` measures the cycle from `hasMinDegree_two_exists_cycle` to get a concrete $k \\geq 3$ (via `IsCycle.three_le_length`); `hasMinDegree_three_containsCycleLength` specializes to δ $\\geq$ 3 by $3 \\geq 2$. All axiom-free, and all prove only that *some* length $k \\geq 3$ occurs — not that $k = 2^{m}$, which is Problem 64's open core."
     },
     {
+      "id": "even-cycle-min-degree-3",
+      "title": "Even Cycle from Minimum Degree 3 (machine-checked, axiom-free)",
+      "summary": "Proves in full, without axioms, that every nonempty finite graph with δ(G) ≥ 3 contains a cycle of even length: `hasMinDegree_three_exists_even_cycle` and its `ContainsCycleLength`-restatement `hasMinDegree_three_exists_even_containsCycleLength`. The classical longest-path argument: take a path `p` of maximum length starting at `v₀`; maximality traps all ≥3 neighbours of `v₀` at distinct positive indices along `p`. Taking the two largest such indices `a < b`, closing the prefix at `a`, at `b`, and around the segment `[a,b]` produces three cycles of lengths `a+1`, `b+1`, `b-a+2`, which sum to `2b+4` — even — so they cannot all be odd, and one is even. Since every `2^k` (`k ≥ 2`) is itself even, this proves the parity half of Problem 64's necessary condition, though not the power-of-two half.",
+      "startLine": 335,
+      "endLine": 561,
+      "mathContext": "The three cycle lengths satisfy $c_1+c_2+c_3 = (a+1)+(b+1)+(b-a+2) = 2b+4$, even, so an all-odd split is impossible — at least one $c_i$ is even. Every $2^{k}$ ($k \\geq 2$) is even, so this discharges the parity-necessary-condition half of Problem 64 while leaving the power-of-two half open."
+    },
+    {
+      "id": "dirac-type-lower-bound",
+      "title": "Dirac-Type Lower Bound on Cycle Length (machine-checked, axiom-free)",
+      "summary": "Proves the quantitative companion to the parity result above: `hasMinDegree_exists_cycle_length_ge` shows minimum degree `d ≥ 2` forces a cycle of length at least `d+1`, with restatement `hasMinDegree_containsCycleLength_ge` in the `ContainsCycleLength` predicate. Reuses the same longest-path engine: the ≥d neighbours of the start vertex of a maximum-length path sit at distinct positive indices, so by pigeonhole the largest index `b` satisfies `b ≥ d` (d distinct positive integers cannot all lie below d); closing the path prefix at that index yields an explicit cycle of length `b+1 ≥ d+1`. For Problem 64 this shows minimum degree pushes the guaranteed cycle length up linearly, but a length merely `≥ d+1` is far weaker than a length exactly `2^k`, which remains the open core.",
+      "startLine": 563,
+      "endLine": 687,
+      "mathContext": "The neighbour-index set has $|T| \\geq d$ elements in $\\{1,\\ldots,b\\}$ (via `Finset.Icc 1 b`), so $d \\leq b$ by pigeonhole. Closing the maximum-length path's prefix at the largest index yields a cycle of length $b+1 \\geq d+1$ — a linear-in-$d$ guarantee, far short of the exponential target $2^{k}$."
+    },
+    {
       "id": "known-results",
       "title": "Known Cycle Results",
       "summary": "Documents in source comments the classical Dirac theorem (1952: δ ≥ n/2 → Hamiltonian) and Bondy theorem (1971: ≥ n²/4 edges → pancyclic or bipartite), neither carrying a Lean declaration. These classical results show high degree forces cycles but do not resolve specific lengths at δ = 3.",
-      "startLine": 335,
-      "endLine": 346,
+      "startLine": 688,
+      "endLine": 699,
       "mathContext": "Documents in source comments the classical Dirac theorem (1952: δ $\\geq$ n/2 → Hamiltonian) and Bondy theorem (1971: $\\geq$ n²/4 edges → pancyclic or bipartite), neither carrying a Lean declaration. These classical results show high degree forces cycles but do not resolve specific lengths at δ = 3."
     },
     {
       "id": "random-graphs",
       "title": "Probabilistic Bounds",
       "summary": "Documents in a source comment that random graphs G(n, c/n) almost surely have δ ≥ 3 and contain cycles of many lengths, offering heuristic evidence that any counterexample must be highly structured. Expository only — no axiom is declared.",
-      "startLine": 347,
-      "endLine": 354,
+      "startLine": 700,
+      "endLine": 707,
       "mathContext": "Documents in a source comment that random graphs G(n, c/n) almost surely have δ $\\geq$ 3 and contain cycles of many lengths, offering heuristic evidence that any counterexample must be highly structured. Expository only — no axiom is declared."
     },
     {
       "id": "summary-status",
       "title": "Summary and Problem Status",
       "summary": "Closing source-comment digest of Problem 64's status (OPEN, $1000 prize): the main question (δ ≥ 3 forces a 2^k-cycle), the key results (Liu-Montgomery 2020 for large degree, the resulting disproof of Erdős-Gyárfás, the still-open δ = 3 case, and the NO answer for infinite graphs), open questions on the Liu-Montgomery threshold and 'almost counterexamples', and references. Ends the `Erdos64` namespace.",
-      "startLine": 355,
-      "endLine": 379,
+      "startLine": 708,
+      "endLine": 732,
       "mathContext": "Closing source-comment digest of Problem 64's status (OPEN, \\$1000 prize): the main question (δ $\\geq$ 3 forces a $2^{k}$-cycle), the key results (Liu-Montgomery 2020 for large degree, the resulting disproof of Erdős-Gyárfás, the still-open δ = 3 case, and the NO answer for infinite graphs), open questions on the Liu-Montgomery threshold and 'almost counterexamples', and references. Ends the `Erdos64` namespace."
     }
   ],


### PR DESCRIPTION
## Summary

`erdos-64` (Erdős Problem #64, power-of-two cycles for min-degree-3 graphs) grew from ~205 → 379 → 732 lines across successive research passes that inserted two new machine-checked theorem blocks (an even-cycle parity result and a Dirac-type quantitative lower bound) in the middle of the file. `sections[]` and `annotations.json` were never fully re-anchored:

- 8 of 18 `annotations.json` entries pointed at stale line ranges left over from an even older (~197-line) version of the file — e.g. `ann-e64-dirac`/`ann-e64-bondy` (Dirac/Bondy theorem comments) pointed into the middle of an unrelated proof's tactic block.
- The tail 3 `sections[]` entries (`known-results`, `random-graphs`, `summary-status`) pointed to their pre-insertion line numbers (335-379), now inside the new theorem content instead of the doc comments they describe.
- ~350 lines (335-687) covering two new axiom-free theorems — `hasMinDegree_three_exists_even_cycle` (parity: δ≥3 ⇒ even cycle) and `hasMinDegree_exists_cycle_length_ge` (Dirac-type: δ≥d ⇒ cycle length ≥ d+1) — had zero section or annotation coverage.
- `meta.meta.lineCount`/`theoremCount`/`definitionCount` (205/3/12) were stale duplicates of the accurate `leanFile` block (732/14/11).

## Changes

- Re-anchored the 8 drifted annotations and 3 drifted sections to their correct current line ranges (content-matched, not guessed).
- Added 2 new sections + 2 new annotations covering the two new theorem blocks, giving full contiguous section coverage 25-732 (matching the actual file length).
- Fixed the stale `meta.meta` line/theorem/definition counts to match `leanFile`.
- Added the 4 new theorem names to `originalContributions`, one `keyInsights` entry, and a `proofStrategy` sentence summarizing the new results.
- No changes to `status`/`badge`/`axiomCount` — file is genuinely 0-axiom, 0-sorry; problem remains correctly `axiomatized`/OPEN.

## Test plan
- [x] `python3 -m json.tool` validates both JSON files
- [x] Verified section coverage is contiguous 25→732 with no gaps, matching `leanFile.lineCount`
- [x] `pnpm build` succeeds, bundle budget check passes