### PR TITLE
Enrich erdos-286: fix section boundary stranding the closing Summary block

### DIFF
--- a/src/data/proofs/erdos-286/meta.json
+++ b/src/data/proofs/erdos-286/meta.json
@@ -138,9 +138,9 @@
       "id": "egyptian",
       "title": "Egyptian Fractions and Greedy Algorithm",
       "startLine": 198,
-      "endLine": 236,
-      "summary": "Defines `IsEgyptianFraction` (definitionally equal to `IsUnitFractionSum`). The Fibonacci–Sylvester greedy algorithm result is referenced in a docstring (lines 208–209) — not declared as an axiom. Summary section recapping the result and references.",
-      "mathContext": "Greedy: take $n = \\lceil 1/q \\rceil$, recurse on $q - 1/n$. Terminates since $q - 1/n < 1/(n(n-1))$."
+      "endLine": 263,
+      "summary": "Defines `IsEgyptianFraction` (definitionally equal to `IsUnitFractionSum`) and proves `egyptian_eq_unit_fraction`. The Fibonacci–Sylvester greedy algorithm result is referenced in a docstring (lines 235–236) — not declared as an axiom. Closes with a `## Summary` comment recapping the problem status (SOLVED for k ≥ 3, k = 2 impossible), Croot's (e-1+ε)k bound, the k=3/k=4 examples, and references (Erdős–Graham 1980, Croot 2001).",
+      "mathContext": "Greedy: take $n = \\lceil 1/q \\rceil$, recurse on $q - 1/n$. Terminates since $q - 1/n < 1/(n(n-1))$. `IsEgyptianFraction S q \\iff IsUnitFractionSum S q$ (`Iff.rfl` — same underlying predicate, different name for the classical framing)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

The `egyptian` section (198-236) in `erdos-286`'s `meta.json` already claimed,
in its own `summary` text, to include "a summary section recapping the result
and references" — but its `endLine` (236) stopped one line before the actual
`/- ## Summary ... -/` comment block even starts (237-261 in
`Proofs/Erdos286Problem.lean`). The boundary was stale, silently excluding
the exact content the section's own description promised to cover.

Change:
- Extend `endLine` 236 → 263 (end of file) and expand the `summary`/
  `mathContext` to actually describe the Summary block's content: problem
  status (SOLVED for k ≥ 3, k = 2 impossible), Croot's (e-1+ε)k interval-width
  bound, the k=3/k=4 worked examples, and the two references (Erdős–Graham
  1980, Croot 2001).

No change to `badge`/`sorries`/`axiomCount`. File stays well under size caps
(meta.json 18.1 KB, « 60 KB).

## Test plan
- [x] `python3 -m json.tool` validates `meta.json`
- [x] `pnpm build`'s JSON-touching pipeline steps (gallery build,
  `check-search-index`, `build-loading-facts`, `build-redirects`) all passed;
  `tsc`/`vite build` are unavailable in this worktree (missing `node_modules`,
  a pre-existing environment gap, not caused by this change)
- [x] Diff scoped to only `src/data/proofs/erdos-286/meta.json` (build-noise
  files reverted before commit)