### PR TITLE
audit(erdos-1054): flag inconsistent tao_disproves_part_i axiom, tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9394,10 +9394,10 @@
       "result": "clean"
     },
     "erdos-1054": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:28Z",
-      "result": "clean"
+      "lastAudited": "2026-07-23T00:01:59Z",
+      "result": "issues-found"
     },
     "erdos-1054-construction-d": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary
- Reserve-mode re-audit of erdos-1054 found a CRITICAL inconsistency: axiom `tao_disproves_part_i` asserts the negation of a provable statement (see #42129 for full analysis + compiled proof of `False`).
- Tracker bump only — no source changes in this PR; fix tracked in #42129 for lean-mechanic.

Fixes tracker entry per audit run; see #42129.