### PR TITLE
Enrich erdos-601: cover trailing Summary comment

### DIFF
--- a/src/data/proofs/erdos-601/meta.json
+++ b/src/data/proofs/erdos-601/meta.json
@@ -165,6 +165,14 @@
       "startLine": 198,
       "endLine": 247,
       "mathContext": "States `GeneralConjecture`: $P(\\alpha)$ holds for all limit ordinals $\\alpha$. Proves the partial result (limit ordinals below $\\omega_1^{\\omega+2}$) and the knowledge gap between known and conjectured."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 249,
+      "endLine": 273,
+      "summary": "Closing comment (after `end Erdos601`) recapping the problem status (OPEN, $500 prize), the question (which limit ordinals α force an infinite path or an order-type-α independent set in every graph on α), the two known results (Erdős–Hajnal–Milner 1970 below ω₁^{ω+2}; Larson 1990 below 2^ℵ₀ under Martin's Axiom), and the two open prizes (the ω₁^{ω+2} boundary, $250; the general conjecture, $500). Lists 4 of the file's key sorry/axiom sites as illustrative examples, not an exhaustive count — the file has 9 `sorry`s and 4 `axiom`s in total (see `meta.assumptions`).",
+      "mathContext": "Ordinal Ramsey-type statement: $\\forall$ graph $G$ on $\\alpha$ (limit ordinal), $G$ has an infinite path or an independent set of order type $\\alpha$. Proved for $\\alpha < \\omega_1^{\\omega+2}$ (unconditional) and $\\alpha < 2^{\\aleph_0}$ (under Martin's Axiom); open in general and at the $\\omega_1^{\\omega+2}$ boundary specifically."
     }
   ],
   "overview": {


### PR DESCRIPTION
## Summary

`erdos-601`'s sections stopped at line 247 (`end Erdos601`), leaving the
closing `## Summary` comment block (249-273) uncovered: the problem status
(OPEN, \$500 prize), the ordinal-Ramsey question (which limit ordinals α
force an infinite path or an order-type-α independent set in every graph on
α), the two known results (Erdős–Hajnal–Milner 1970 for α < ω₁^{ω+2}; Larson
1990 for α < 2^ℵ₀ under Martin's Axiom), and the two open prizes.

Change:
- Add one section (`summary`, 249-273) closing the gap.

Verified via `grep` that the file has 9 `sorry`s and 4 `axiom`s (matching
`meta.sorries`/`meta.axiomCount` already in the file) — noted in the new
section's summary that the comment's own "Key sorries" list is illustrative,
not an exhaustive count, so readers aren't misled by the partial list in the
source comment itself.

No change to `badge`/`sorries`/`axiomCount` — those already correctly reflect
the Lean source. File stays well under size caps (meta.json 17.3 KB, « 60 KB).

## Test plan
- [x] `python3 -m json.tool` validates `meta.json`
- [x] `pnpm build`'s JSON-touching pipeline steps (gallery build,
  `check-search-index`, `build-loading-facts`, `build-redirects`) all passed;
  `tsc`/`vite build` are unavailable in this worktree (missing `node_modules`,
  a pre-existing environment gap, not caused by this change)
- [x] Diff scoped to only `src/data/proofs/erdos-601/meta.json` (build-noise
  files reverted before commit)