### PR TITLE
audit: re-serve erdos-1053 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9388,9 +9388,9 @@
       "result": "issues-fixed"
     },
     "erdos-1053": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:28Z",
+      "lastAudited": "2026-07-23T00:05:38Z",
       "result": "clean"
     },
     "erdos-1054": {


### PR DESCRIPTION
## Integrity Re-audit: erdos-1053

**Result: CLEAN** — all metadata verified against Lean source.

### Verification

| Field | meta.json | Actual | Match |
|---|---|---|---|
| axiomCount | 1 | 1 (`robin_inequality_conditional`) | ✅ |
| theoremCount | 10 | 10 | ✅ |
| definitionCount | 3 | 3 (`sigma`, `IsKPerfect`, `perfectMultiplicity`) | ✅ |
| sorries | 0 | 0 | ✅ |
| lineCount | 164 | 164 | ✅ |
| badge | axiom | correct given disclosed axiom | ✅ |
| status | axiomatized | correct | ✅ |

### Notes

- The single axiom `robin_inequality_conditional` (Robin's inequality, conditional
  on RH) is properly disclosed in `assumptions`, and correctly excluded from
  `mainTheorems` (only `one_perfect_unique`, `robin_gives_O_bound`, `sigma_def`
  are listed as `proved`).
- Three `native_decide` uses (`sigma_one`, `perfect_examples`,
  `triperfect_examples`) are individually named and disclosed in `assumptions`
  with the `Lean.ofReduceBool` compiler-trust caveat.
- No phantom declaration names in `originalContributions`/`mainTheorems`/section
  prose — every name cross-checked against the file.
- Erdős status "open" matches erdosproblems.com/1053.

No changes needed to meta.json. Tracker bump only.

---
Discovered during gallery integrity audit.