### PR TITLE
audit(erdos-1050): re-audit CLEAN — tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9370,9 +9370,9 @@
       "result": "clean"
     },
     "erdos-1050": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:28Z",
+      "lastAudited": "2026-07-23T00:07:59Z",
       "result": "clean"
     },
     "erdos-1051": {


### PR DESCRIPTION
## Summary
- Re-audited erdos-1050 (Irrationality of ∑ 1/(2^n - 3)), 5th audit pass.
- Verified against `proofs/Proofs/Erdos1050Problem.lean`: axiomCount 2 (both disclosed: `borwein_irrationality`, `S_approx`), theoremCount 27, definitionCount 9, sorries 0. No True stubs, no native_decide, no phantom declarations in prose/originalContributions.
- Status `axiomatized` / badge `axiom` accurately reflects the file; no changes needed beyond the tracker timestamp bump.

🤖 Generated with lean auditor agent