### PR TITLE
Fix: erdos-1054 restate open questions over true unbounded f (remove inconsistent axiom)

### DIFF
--- a/proofs/Proofs/Erdos1054Problem.lean
+++ b/proofs/Proofs/Erdos1054Problem.lean
@@ -75,6 +75,22 @@ def computeF (n : ℕ) (bound : ℕ := 10000) : ℕ :=
   | [] => 0
   | m :: _ => m + 1
 
+open Classical in
+/--
+The true (unbounded) f(n): the least m ≥ 1 such that n is the sum of the k
+smallest divisors of m for some k ≥ 1, or 0 if no such m exists.
+
+Unlike `computeF` (which caps the search at a fixed `bound`, defaulting to
+10000, and is therefore bounded by that constant for every n), this searches all
+of ℕ, so it faithfully represents the function of Erdős #1054. It is
+`noncomputable` because the search has no a priori bound. The open questions
+below (and Tao's disproof of Part I) are stated in terms of this `f`; using the
+bounded `computeF` instead would make them trivially decidable and render the
+disproof axiom inconsistent.
+-/
+noncomputable def f (n : ℕ) : ℕ :=
+  if h : ∃ m : ℕ, m ≥ 1 ∧ n ∈ partialDivisorSums m then Nat.find h else 0
+
 /-
 ## Concrete Values of f(n)
 
@@ -447,7 +463,7 @@ theorem partial_sums_skip_5 (m : ℕ) (hm : m ≥ 1) :
 Terry Tao showed this is FALSE.
 -/
 def erdos_1054_part_i : Prop :=
-  ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, (computeF n : ℝ) < ε * n
+  ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, (f n : ℝ) < ε * n
 
 /--
 **Open Question II**: Is f(n) = o(n) for almost all n?
@@ -455,13 +471,13 @@ The set of exceptions should have natural density 0.
 -/
 def erdos_1054_part_ii : Prop :=
   ∀ ε > 0, ∀ δ > 0, ∃ N : ℕ, ∀ M ≥ N,
-    ((Finset.filter (fun n => decide ((computeF n : ℝ) ≥ ε * n)) (Finset.range M)).card : ℝ) < δ * M
+    ((Finset.filter (fun n => decide ((f n : ℝ) ≥ ε * n)) (Finset.range M)).card : ℝ) < δ * M
 
 /--
 **Open Question III**: Is limsup f(n)/n = ∞?
 -/
 def erdos_1054_part_iii : Prop :=
-  ∀ C : ℝ, ∃ n : ℕ, n ≥ 1 ∧ (computeF n : ℝ) ≥ C * n
+  ∀ C : ℝ, ∃ n : ℕ, n ≥ 1 ∧ (f n : ℝ) ≥ C * n
 
 /--
 Tao's result: Part I is FALSE.

--- a/src/data/proofs/erdos-1054/meta.json
+++ b/src/data/proofs/erdos-1054/meta.json
@@ -38,16 +38,16 @@
     ],
     "originalContributions": [
       "Formal statement of the OPEN Erdős problem in Lean 4",
-      "Axiomatization of the function f(n) and representability predicate",
-      "Statement of the three open questions (o(n), almost all, limsup)",
+      "Definition of the true (unbounded, noncomputable) function f(n) via Nat.find, alongside the representability predicate and the bounded computable approximation computeF",
+      "Statement of the three open questions (o(n), almost all, limsup) in terms of the unbounded f(n)",
       "Formalization of Tao's partial result disproving Part I",
       "Analysis of exceptional values n = 2 and n = 5"
     ],
     "axiomCount": 1,
-    "lineCount": 612,
-    "assumptions": "1 axiom: tao_disproves_part_i. See Lean source for the complete statement. Trust caveat: the concrete `computeF`/`f_*_eq` value computations (small n) are closed by `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom; these finite demonstrations do not feed the axiomatized result `tao_disproves_part_i`.",
+    "lineCount": 628,
+    "assumptions": "1 axiom: tao_disproves_part_i, which asserts Tao's disproof of Part I (¬(f(n) = o(n))) for the true, unbounded, noncomputable f(n) (defined via Nat.find). Stating the open questions in terms of this unbounded f — rather than the bounded computable approximation computeF (default search bound 10000) — is essential: a bounded function is trivially o(n), so an axiom about the bounded version would be inconsistent. See Lean source for the complete statement. Trust caveat: the concrete `computeF`/`f_*_eq` value computations (small n) are closed by `native_decide`, which adds the `Lean.ofReduceBool` compiler-trust axiom; these finite demonstrations do not feed the axiomatized result `tao_disproves_part_i`.",
     "theoremCount": 52,
-    "definitionCount": 8
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "This problem was posed by Erdős and appears as Problem B2 in Richard Guy's influential book 'Unsolved Problems in Number Theory' (2004). The function f(n) computes the minimal m such that n can be written as a sum of the k smallest divisors of m.\n\nThe function has a curious property: it is undefined for exactly two values, n = 2 and n = 5. These are the only positive integers that cannot be expressed as a partial sum of divisors. This follows from a careful analysis of divisor structure.\n\nTerry Tao made significant progress on this problem by showing that the strong conjecture f(n) = o(n) is FALSE. He proved that the density of {n : f(n) ≤ δn} is at most O(δ²), meaning there are many n where f(n) is at least a constant fraction of n.\n\nHowever, the weaker question—whether f(n) = o(n) for ALMOST ALL n—remains open, as does the question of whether limsup f(n)/n = ∞.",
@@ -206,10 +206,10 @@
       "Finset"
     ],
     "namespace": "Erdos1054",
-    "lineCount": 612,
+    "lineCount": 628,
     "axiomCount": 1,
     "theoremCount": 52,
-    "definitionCount": 8,
+    "definitionCount": 9,
     "path": "Proofs/Erdos1054Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Problem

`erdos-1054` (`Proofs/Erdos1054Problem.lean`) contained an **inconsistent axiom** (integrity issue #42129, filed by the auditor). `axiom tao_disproves_part_i : ¬erdos_1054_part_i` asserted the negation of a **provable** statement:

`erdos_1054_part_i` was stated over `computeF n`, whose default search bound (`bound := 10000`) makes it bounded by the constant 10000 for **every** n. Any bounded function is trivially `o(n)`, so `erdos_1054_part_i` was provably true — and its negation-axiom therefore let the kernel derive `False` (the auditor verified this with a scratch proof).

## Fix (auditor Option 1 — faithful restatement)

Introduce the **true, unbounded** function via `Nat.find`, and restate the three open questions in terms of it:

```lean
open Classical in
noncomputable def f (n : ℕ) : ℕ :=
  if h : ∃ m : ℕ, m ≥ 1 ∧ n ∈ partialDivisorSums m then Nat.find h else 0
```

- `erdos_1054_part_i/ii/iii` now quantify over `f n` (unbounded) instead of `computeF n` (bounded, default 10000).
- The bounded, computable `computeF` is kept for the concrete small-`n` value theorems (`f_1_eq_one`, … — all use explicit bounds, unaffected).
- `tao_disproves_part_i` now faithfully axiomatizes Tao's genuine result about the true `f`. Because `f` has no a priori bound, `erdos_1054_part_i` is no longer provable, so the axiom set is **consistent** again.

## Validation

- `./proofs/scripts/docker-build.sh Proofs.Erdos1054Problem` — **Build succeeded (955 jobs)**.
- The auditor's inconsistency route (`computeF_le_bound` ⇒ `erdos_1054_part_i` ⇒ `False`) no longer applies: it depended on the fixed bound, which `f` does not have.

## Metadata

Updated `meta.json`: `definitionCount` 8→9 (added `f`), `lineCount` 612→628, and corrected the "Axiomatization of the function f(n)" prose (f is now genuinely defined, not axiomatized) plus the `assumptions` note documenting why the unbounded `f` is required. Status stays `axiomatized` / badge `axiom` / `axiomCount: 1`.

Closes #42129
