### PR TITLE
Research: erdos-548 — eliminate all 6 sorries in Erdos548Problem (star embedding, handshake, extremal sup)

### DIFF
--- a/proofs/Proofs/Erdos548Problem.lean
+++ b/proofs/Proofs/Erdos548Problem.lean
@@ -95,9 +95,70 @@ def starGraph (k : ℕ) : SimpleGraph (Fin (k + 1)) where
     | inl h => exact h.2 h.1
     | inr h => exact h.2 h.1
 
-/-- Stars are trees. -/
+/-- The star's edge set: one edge from the centre `0` to each other vertex. -/
+theorem starGraph_edgeFinset (k : ℕ) :
+    (starGraph k).edgeFinset =
+      (Finset.univ.erase (0 : Fin (k + 1))).image
+        (fun j => s((0 : Fin (k + 1)), j)) := by
+  ext e
+  refine Sym2.inductionOn e fun i j => ?_
+  simp only [SimpleGraph.mem_edgeFinset, SimpleGraph.mem_edgeSet, Finset.mem_image,
+    Finset.mem_erase, Finset.mem_univ, and_true]
+  constructor
+  · rintro (⟨hi, hj⟩ | ⟨hj, hi⟩)
+    · have hi0 : i = (0 : Fin (k + 1)) := Fin.ext (by simpa using hi)
+      refine ⟨j, fun h0 => hj (by simp [h0]), by rw [hi0]⟩
+    · have hj0 : j = (0 : Fin (k + 1)) := Fin.ext (by simpa using hj)
+      refine ⟨i, fun h0 => hi (by simp [h0]), ?_⟩
+      rw [hj0, Sym2.eq_swap]
+  · rintro ⟨a, ha0, hae⟩
+    rw [Sym2.eq_iff] at hae
+    rcases hae with ⟨h0i, haj⟩ | ⟨h0j, hai⟩
+    · exact Or.inl ⟨by simp [← h0i], fun h => ha0 (Fin.ext (by simp [haj, h]))⟩
+    · exact Or.inr ⟨by simp [← h0j], fun h => ha0 (Fin.ext (by simp [hai, h]))⟩
+
+/-- The star on `k+1` vertices has exactly `k` edges. -/
+theorem starGraph_edgeFinset_card (k : ℕ) : (starGraph k).edgeFinset.card = k := by
+  rw [starGraph_edgeFinset]
+  have hinj : Set.InjOn (fun j => s((0 : Fin (k + 1)), j))
+      (Finset.univ.erase (0 : Fin (k + 1))) := by
+    intro a _ b _ hab
+    rw [Sym2.eq_iff] at hab
+    rcases hab with ⟨-, h⟩ | ⟨h0b, ha0⟩
+    · exact h
+    · rw [ha0, h0b]
+  rw [Finset.card_image_of_injOn hinj, Finset.card_erase_of_mem (Finset.mem_univ _),
+    Finset.card_univ, Fintype.card_fin]
+  omega
+
+/-- The star graph is connected: every vertex is adjacent to the centre `0`. -/
+theorem starGraph_connected (k : ℕ) : (starGraph k).Connected := by
+  rw [SimpleGraph.connected_iff]
+  refine ⟨fun i j => ?_, ⟨0⟩⟩
+  have h0 : ∀ a : Fin (k + 1), a.val ≠ 0 → (starGraph k).Adj 0 a :=
+    fun a ha => Or.inl ⟨by simp, ha⟩
+  by_cases hij : i = j
+  · exact hij ▸ SimpleGraph.Reachable.refl i
+  · by_cases hi : i.val = 0
+    · by_cases hj : j.val = 0
+      · exact absurd (Fin.ext (hi.trans hj.symm)) hij
+      · have hi0 : i = (0 : Fin (k + 1)) := Fin.ext (by simpa using hi)
+        exact hi0 ▸ (h0 j hj).reachable
+    · by_cases hj : j.val = 0
+      · have hj0 : j = (0 : Fin (k + 1)) := Fin.ext (by simpa using hj)
+        exact hj0 ▸ ((h0 i hi).symm).reachable
+      · exact ((h0 i hi).symm.reachable).trans (h0 j hj).reachable
+
+/-- Stars are trees.  (Formerly a sorry; proved via
+    `SimpleGraph.isTree_iff_connected_and_card`: the star is connected with
+    exactly `k` edges on `k+1` vertices.  True for every `k`; the original
+    `k ≥ 1` hypothesis is kept for signature stability.) -/
 theorem star_is_tree (k : ℕ) (hk : k ≥ 1) : IsTree (starGraph k) := by
-  sorry
+  show (starGraph k).IsTree
+  rw [SimpleGraph.isTree_iff_connected_and_card]
+  refine ⟨starGraph_connected k, ?_⟩
+  rw [Nat.card_eq_fintype_card, ← SimpleGraph.edgeFinset_card,
+    starGraph_edgeFinset_card, Nat.card_eq_fintype_card, Fintype.card_fin]
 
 /- ## Part II: Subgraph Containment -/
 
@@ -117,17 +178,52 @@ noncomputable def edgeCount (G : SimpleGraph V) : ℕ := G.edgeFinset.card
 /-- Sum of degrees equals twice the number of edges. -/
 theorem sum_degrees_eq_twice_edges (G : SimpleGraph V) [DecidableRel G.Adj] :
     (Finset.univ.sum fun v => G.degree v) = 2 * edgeCount G := by
-  sorry
+  have h := G.sum_degrees_eq_twice_card_edges
+  unfold edgeCount
+  convert h using 2
+  congr!
 
 /-- Average degree of a graph. -/
 noncomputable def avgDegree (G : SimpleGraph V) : ℚ :=
   if h : Fintype.card V = 0 then 0
   else (2 * edgeCount G : ℚ) / Fintype.card V
 
-/-- A graph has average degree > k-1 iff it has > (k-1)n/2 edges. -/
-theorem avg_degree_iff_edges (G : SimpleGraph V) [DecidableRel G.Adj] (k : ℕ) :
+/-- A graph has average degree > k-1 iff it has > (k-1)n/2 edges.
+
+    (Statement repair: the original sorried statement omitted `k ≥ 1` and was
+    false at `k = 0` — there the ℚ-side threshold `↑k - 1 = -1` is trivially
+    beaten while the ℕ-side threshold `(k-1) * n / 2` truncates to `0`.) -/
+theorem avg_degree_iff_edges (G : SimpleGraph V) [DecidableRel G.Adj] (k : ℕ) (hk : 1 ≤ k) :
     avgDegree G > k - 1 ↔ edgeCount G > (k - 1) * Fintype.card V / 2 := by
-  sorry
+  have hcast : ((k : ℚ) - 1) = ((k - 1 : ℕ) : ℚ) := by
+    rw [Nat.cast_sub hk, Nat.cast_one]
+  by_cases hn : Fintype.card V = 0
+  · -- no vertices: both sides are false
+    have hV : IsEmpty V := Fintype.card_eq_zero_iff.mp hn
+    have hE : edgeCount G = 0 := by
+      rw [edgeCount, Finset.card_eq_zero, Finset.eq_empty_iff_forall_notMem]
+      intro e
+      induction e using Sym2.inductionOn with
+      | hf a b => exact fun _ => hV.elim a
+    rw [avgDegree, dif_pos hn]
+    constructor
+    · intro h
+      exfalso
+      have h1 : (1 : ℚ) ≤ (k : ℚ) := by exact_mod_cast hk
+      rw [gt_iff_lt, hcast] at h
+      have : (0 : ℚ) ≤ ((k - 1 : ℕ) : ℚ) := Nat.cast_nonneg _
+      linarith
+    · intro h
+      rw [hn, Nat.mul_zero, Nat.zero_div, hE] at h
+      exact absurd h (lt_irrefl 0)
+  · have hn' : (0 : ℚ) < (Fintype.card V : ℚ) := by
+      exact_mod_cast Nat.pos_of_ne_zero hn
+    have key : avgDegree G > (k : ℚ) - 1 ↔
+        (k - 1) * Fintype.card V < 2 * edgeCount G := by
+      rw [avgDegree, dif_neg hn, gt_iff_lt, hcast, lt_div_iff₀ hn']
+      exact_mod_cast Iff.rfl
+    rw [key]
+    omega
 
 /- ## Part IV: The Erdős-Sós Conjecture -/
 
@@ -232,11 +328,24 @@ noncomputable def extremalNumber (n : ℕ) {W : Type*} [Fintype W] (T : SimpleGr
   sSup {m : ℕ | ∃ (G : SimpleGraph (Fin n)) (_ : DecidableRel G.Adj),
     TreeFree G T ∧ edgeCount G = m}
 
-/-- The Erdős-Sós conjecture implies ex(n, T) ≤ (k-1)n/2 for trees T on k+1 vertices. -/
-theorem erdos_sos_implies_extremal {W : Type*} [Fintype W] [DecidableEq W]
+/-- The Erdős-Sós conjecture implies ex(n, T) ≤ (k-1)n/2 for trees T on k+1 vertices.
+
+    (Statement repair: `W` must live in `Type` — `ErdosSosConjecture`
+    quantifies its tree type over `Type`, so the universe-polymorphic
+    `Type*` version is not derivable from it.) -/
+theorem erdos_sos_implies_extremal {W : Type} [Fintype W] [DecidableEq W]
     (T : SimpleGraph W) (hT : IsTree T) (hk : Fintype.card W = k + 1) (n : ℕ) (hn : n ≥ k + 1) :
     ErdosSosConjecture → extremalNumber n T ≤ (k - 1) * n / 2 := by
-  sorry
+  intro hesc
+  refine csSup_le' ?_
+  rintro m ⟨G, instG, hfree, hcount⟩
+  by_contra hm
+  push_neg at hm
+  refine hfree ?_
+  refine hesc k (Fin n) G W T hT hk ?_ ?_
+  · simpa using hn
+  · rw [Fintype.card_fin]
+    omega
 
 /- ## Part VII: Special Trees -/
 
@@ -249,7 +358,75 @@ theorem star_easier (n k : ℕ) (hn : n ≥ k + 1)
     (G : SimpleGraph (Fin n)) [DecidableRel G.Adj]
     (hG : edgeCount G ≥ k * n / 2) :
     ContainsSubgraph G (starGraph k) := by
-  sorry
+  -- Step 1: some vertex has degree ≥ k (pigeonhole on the degree sum).
+  have hne : Nonempty (Fin n) := ⟨⟨0, by omega⟩⟩
+  obtain ⟨v, hv⟩ : ∃ v : Fin n, k ≤ G.degree v := by
+    by_contra hall
+    push_neg at hall
+    -- every degree ≤ k - 1, and k ≥ 1 (a degree is < k), so sum ≤ (k-1) n
+    obtain ⟨w⟩ := hne
+    have hk1 : 1 ≤ k := by have := hall w; omega
+    have hsum : (Finset.univ.sum fun u => G.degree u) ≤ (k - 1) * n := by
+      calc (Finset.univ.sum fun u => G.degree u)
+          ≤ Finset.univ.card • (k - 1) :=
+            Finset.sum_le_card_nsmul _ _ _ (fun u _ => by have := hall u; omega)
+        _ = (k - 1) * n := by
+            rw [Finset.card_univ, Fintype.card_fin, smul_eq_mul, Nat.mul_comm]
+    rw [sum_degrees_eq_twice_edges, Nat.sub_mul, one_mul] at hsum
+    -- omega needs the (nonlinear) fact n ≤ k*n spelled out
+    have hkn : n ≤ k * n := Nat.le_mul_of_pos_left n hk1
+    -- 2 * edgeCount ≥ 2 * (k*n/2) ≥ k*n - 1 and ≤ k*n - n with n ≥ 2
+    omega
+  -- Step 2: pick k distinct neighbours of v and map the star onto them.
+  obtain ⟨S, hS, hScard⟩ :=
+    Finset.exists_subset_card_eq (n := k) (s := G.neighborFinset v) (by rwa [G.card_neighborFinset_eq_degree])
+  let e := S.orderIsoOfFin hScard
+  refine ⟨Fin.cases v (fun i => (e i : Fin n)), ?_, ?_⟩
+  · -- injectivity: v is not its own neighbour, and e is injective
+    have hveS : ∀ i : Fin k, (e i : Fin n) ≠ v := by
+      intro i hvi
+      have : (e i : Fin n) ∈ G.neighborFinset v := hS (e i).2
+      rw [hvi, SimpleGraph.mem_neighborFinset] at this
+      exact G.irrefl this
+    intro a b hab
+    induction a using Fin.cases with
+    | zero =>
+      induction b using Fin.cases with
+      | zero => rfl
+      | succ j =>
+        simp only [Fin.cases_zero, Fin.cases_succ] at hab
+        exact absurd hab.symm (hveS j)
+    | succ i =>
+      induction b using Fin.cases with
+      | zero =>
+        simp only [Fin.cases_zero, Fin.cases_succ] at hab
+        exact absurd hab (hveS i)
+      | succ j =>
+        simp only [Fin.cases_succ] at hab
+        have : e i = e j := Subtype.ext hab
+        rw [e.injective this]
+  · -- adjacency: a star edge joins the centre to a leaf
+    intro a b hab
+    rcases hab with ⟨ha, hb⟩ | ⟨hb, ha⟩
+    · -- a is the centre, b = succ j is a leaf
+      have ha0 : a = 0 := Fin.ext (by simpa using ha)
+      induction b using Fin.cases with
+      | zero => exact absurd (by simp) hb
+      | succ j =>
+        subst ha0
+        simp only [Fin.cases_zero, Fin.cases_succ]
+        have : (e j : Fin n) ∈ G.neighborFinset v := hS (e j).2
+        rwa [SimpleGraph.mem_neighborFinset] at this
+    · -- b is the centre, a = succ i is a leaf
+      have hb0 : b = 0 := Fin.ext (by simpa using hb)
+      induction a using Fin.cases with
+      | zero => exact absurd (by simp) ha
+      | succ i =>
+        subst hb0
+        simp only [Fin.cases_zero, Fin.cases_succ]
+        have : (e i : Fin n) ∈ G.neighborFinset v := hS (e i).2
+        rw [SimpleGraph.mem_neighborFinset] at this
+        exact this.symm
 
 /- ## Part VIII: The Komlós-Sós Bound -/
 
@@ -297,8 +474,8 @@ axiom turan_path_formula (n k : ℕ) (hn : n ≥ k - 1) (hk : k ≥ 2) :
 -/
 def erdos_548_open : Prop := ErdosSosConjecture ∨ ¬ErdosSosConjecture
 
-theorem erdos_548_status : erdos_548_open := by
-  exact Or.inl (by sorry) -- Open problem
+theorem erdos_548_status : erdos_548_open :=
+  Classical.em ErdosSosConjecture
 
 end Erdos548
 

--- a/src/data/proofs/erdos-548/meta.json
+++ b/src/data/proofs/erdos-548/meta.json
@@ -17,15 +17,15 @@
       "erdos"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 0,
     "erdosNumber": 548,
     "erdosUrl": "https://erdosproblems.com/548",
     "erdosProblemStatus": "open",
     "axiomCount": 17,
-    "lineCount": 319,
-    "assumptions": "17 axiom(s) and 6 sorries(s) aggregated across files. In the primary Erdos548Problem.lean: 8 axioms (deep extremal-graph-theory literature results: trivial_tree_bound, brandt_dobson, sacle_wozniak, wang_li_liu, path_extremal, komlos_sos_large_k, erdos_gallai_matching, turan_path_formula) and 6 sorries. The former tree_edge_count axiom is now a proved theorem, and the IsTree definition was corrected to Mathlib's genuine SimpleGraph.IsTree (it had been degenerate — equivalent to Connected).",
+    "lineCount": 513,
+    "assumptions": "17 axiom(s) aggregated across files (8 in the primary Erdos548Problem.lean — deep extremal-graph-theory literature results: trivial_tree_bound, brandt_dobson, sacle_wozniak, wang_li_liu, path_extremal, komlos_sos_large_k, erdos_gallai_matching, turan_path_formula — plus 9 in the legacy stub Proofs/Stubs/Erdos548Problem.lean). The primary file now has 0 sorries: all six were proved in July 2026 (star_is_tree, sum_degrees_eq_twice_edges, avg_degree_iff_edges, erdos_sos_implies_extremal, star_easier, erdos_548_status). Two statements required repair to be provable: avg_degree_iff_edges gained the missing k ≥ 1 hypothesis (false at k = 0 as stated), and erdos_sos_implies_extremal restricts its tree vertex type from Type* to Type (ErdosSosConjecture quantifies over Type). erdos_548_status is now Classical.em rather than a sorry that would have asserted the conjecture itself. The former tree_edge_count axiom is a proved theorem, and IsTree delegates to Mathlib genuine SimpleGraph.IsTree. Aristotle companion files retain their own sorry stubs pending proof search.",
     "mathlib_version": "4.31.0",
-    "theoremCount": 7,
+    "theoremCount": 10,
     "definitionCount": 16,
     "additionalFiles": [
       "Proofs/Erdos548Aristotle.lean",
@@ -159,12 +159,12 @@
       "Finset"
     ],
     "namespace": "Erdos548",
-    "lineCount": 319,
+    "lineCount": 513,
     "axiomCount": 8,
-    "theoremCount": 7,
+    "theoremCount": 10,
     "definitionCount": 16,
     "path": "Proofs/Erdos548Problem.lean",
-    "sorries": 6,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos548Aristotle.lean",
       "Proofs/Erdos548ProblemAristotle.lean",
@@ -189,5 +189,5 @@
       "description": "Related Erdős problem sharing themes: extremal-graph-theory, graph-theory"
     }
   ],
-  "sorries": 6
+  "sorries": 0
 }

--- a/src/data/research/problems/erdos-548-incomplete-01.json
+++ b/src/data/research/problems/erdos-548-incomplete-01.json
@@ -16,12 +16,12 @@
     "goal": "Eliminate the 6 remaining sorry statement(s) in the parent formalization."
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "COMPLETE",
     "since": "2026-07-09T00:00:00.000Z",
     "iteration": 0,
-    "focus": "Initial exploration of the problem.",
+    "focus": "All 6 sorries eliminated; file sorry-free with 8 literature axioms. PR #42136.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None - node complete. Remaining depth is proving the 8 literature axioms (deep extremal graph theory).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,12 +29,18 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AXIOM ELIMINATION + DEF FIX (researcher-1, 2026-07-20): corrected the degenerate local IsTree definition to Mathlib SimpleGraph.IsTree and proved the former tree_edge_count axiom from IsTree.card_edgeFinset, reducing primary-file axioms 9→8. The remaining 8 axioms are deep extremal-graph-theory literature results (Brandt-Dobson, Sacle-Wozniak, Wang-Li-Liu, Komlos-Sos, Turan path formula, Erdos-Gallai matching, path_extremal, trivial_tree_bound). 6 sorries remain (sum_degrees_eq_twice_edges, avg_degree_iff_edges, star_is_tree, etc.).",
+    "progressSummary": "All 6 sorries in Proofs/Erdos548Problem.lean eliminated and Docker-build verified (3001 jobs). Proved: star_is_tree (via new starGraph_edgeFinset_card), sum_degrees_eq_twice_edges (Mathlib handshake), avg_degree_iff_edges (statement repaired with missing 1 <= k hypothesis - false at k=0 as stated), erdos_sos_implies_extremal (Type* -> Type restriction to match ErdosSosConjecture, csSup_le'), star_easier (pigeonhole degree >= k + orderIsoOfFin star embedding), erdos_548_status (Classical.em replacing Or.inl (by sorry) which had sorried the open conjecture itself). The 8 literature axioms are unchanged. PR #42136.",
     "builtItems": [
-      "Erdos548Problem.lean: IsTree now delegates to Mathlib SimpleGraph.IsTree; tree_edge_count proved via IsTree.card_edgeFinset (axiom 9→8). Host-verified v4.31.0 EXIT=0."
+      "Erdos548Problem.lean: IsTree now delegates to Mathlib SimpleGraph.IsTree; tree_edge_count proved via IsTree.card_edgeFinset (axiom 9→8). Host-verified v4.31.0 EXIT=0.",
+      "starGraph_edgeFinset_card: (starGraph k).edgeFinset.card = k via image-of-erase counting with card_image_of_injOn",
+      "star_easier: full proof that average degree > k-1 embeds the star K_{1,k} (easy case of Erdos-Sos)",
+      "erdos_sos_implies_extremal: extremalNumber bound from the conjecture via csSup_le'"
     ],
     "insights": [
-      "The local IsTree def (Connected ∧ ∀ v w, Adj v w → Reachable v w) was degenerate: the second conjunct holds for every graph, so IsTree meant Connected, making tree_edge_count false. Redefining IsTree := G.IsTree (Mathlib SimpleGraph.IsTree) both fixes the conjecture statements and makes tree_edge_count provable."
+      "The local IsTree def (Connected ∧ ∀ v w, Adj v w → Reachable v w) was degenerate: the second conjunct holds for every graph, so IsTree meant Connected, making tree_edge_count false. Redefining IsTree := G.IsTree (Mathlib SimpleGraph.IsTree) both fixes the conjecture statements and makes tree_edge_count provable.",
+      "avg_degree_iff_edges was FALSE at k=0 as originally stated (avgDegree > k-1 over Q is vacuous at k=0 while the edge bound is not); the missing 1 <= k hypothesis is required for provability.",
+      "erdos_548_status previously read Or.inl (by sorry) - i.e. the file sorried the OPEN conjecture itself. Replaced with Classical.em, which is the honest formal content of an open-status disjunction.",
+      "Star embedding recipe: pigeonhole on the degree sum (sum_degrees_eq_twice_edges + Finset.sum_le_card_nsmul) yields a vertex of degree >= k; Finset.orderIsoOfFin on the neighbour set then gives the injective Fin (k+1) embedding, with Fin.cases splitting centre/leaf adjacency."
     ],
     "mathlibGaps": [],
     "nextSteps": []


### PR DESCRIPTION
## Summary

Eliminates **all 6 sorries** in `proofs/Proofs/Erdos548Problem.lean` (Erdős Problem #548, the Erdős–Sós Conjecture). The file is now sorry-free with its 8 literature axioms unchanged.

## Proofs added

- **`star_is_tree`** — stars are trees, via a new `starGraph_edgeFinset_card` (edge count = k, image-of-erase counting argument) plus connectivity through the centre, feeding Mathlib's `IsTree` characterization.
- **`sum_degrees_eq_twice_edges`** — handshaking lemma delegated to Mathlib's `sum_degrees_eq_twice_card_edges`.
- **`avg_degree_iff_edges`** — statement repaired: as written it was **false at k = 0** (avg degree > -1 is vacuous while the edge bound is not); gained the missing `1 ≤ k` hypothesis, then proved over ℚ.
- **`erdos_sos_implies_extremal`** — tree vertex type restricted `Type*` → `Type` (matching `ErdosSosConjecture`, which quantifies over `Type`), proved via `csSup_le'`.
- **`star_easier`** — the easy star case of the conjecture: average degree > k-1 forces a vertex of degree ≥ k (pigeonhole via degree-sum), then `orderIsoOfFin` embeds the star `K_{1,k}` onto k distinct neighbours.
- **`erdos_548_status`** — now `Classical.em`; the previous `Or.inl (by sorry)` had effectively sorried the open conjecture itself.

## Statement repairs (disclosed in meta.json assumptions)

Two of the six statements were unprovable as stated and required repair: the `k ≥ 1` hypothesis on `avg_degree_iff_edges`, and the `Type` restriction on `erdos_sos_implies_extremal`.

## Verification

- Docker build: `Proofs.Erdos548Problem` — **success, 3001 jobs**, warnings only (lint).
- Sorries: 6 → **0** (only remaining "sorry" match is a docstring).
- Axioms: 8, unchanged (deep literature results: trivial_tree_bound, brandt_dobson, sacle_wozniak, wang_li_liu, path_extremal, komlos_sos_large_k, erdos_gallai_matching, turan_path_formula).
- meta.json synced: sorries 6→0, theoremCount 7→10, lineCount 319→513, assumptions prose updated.

Problem node: `erdos-548-incomplete-01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
