### PR TITLE
Enrich algebraic-reals-meager-oq-02-oq-01: cover results-summary tail

### DIFF
--- a/src/data/proofs/algebraic-reals-meager-oq-02-oq-01/meta.json
+++ b/src/data/proofs/algebraic-reals-meager-oq-02-oq-01/meta.json
@@ -150,6 +150,14 @@
       "endLine": 149,
       "summary": "Proves real_symmetric_oxtoby: ℝ = L ⊔ Lᶜ (disjoint, union = univ) with L comeagre-and-null and Lᶜ meagre-and-conull, and oq01_resolution packaging the dual witness with the decomposition.",
       "mathContext": "A single partition of ℝ witnesses both failures of implication: comeagre ⇏ conull (on L) and meagre ⇏ null (on Lᶜ)."
+    },
+    {
+      "id": "results-summary",
+      "title": "Sanity Checks and Results Summary",
+      "startLine": 151,
+      "endLine": 175,
+      "summary": "Six `#check` sanity checks confirming every named theorem elaborates, followed by a closing `## Results Summary` comment: a table listing all 8 theorems (2 inherited from Mathlib: `liouville_residual`, `liouville_null`; 6 proved in this file) with their statements and status, and the final tally — 0 sorries, 0 declared axioms (the file's proofs rest only on the inherited Mathlib triple).",
+      "mathContext": "Confirms the complete dependency chain is sorry-free and axiom-free: `isMeagre_compl_of_mem_residual` (complement of residual is meagre) → `nonLiouville_meagre`/`nonLiouville_conull` (via Mathlib's `liouville_residual`/`liouville_null`) → `exists_meagre_conull` (dual Oxtoby witness) → `real_symmetric_oxtoby` (symmetric decomposition) → `oq01_resolution` (final packaging)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

`algebraic-reals-meager-oq-02-oq-01`'s sections stopped at line 149, leaving
the closing block (151-175) uncovered: six `#check` sanity checks confirming
every named theorem elaborates, and a `## Results Summary` comment with a
table listing all 8 theorems (2 inherited from Mathlib, 6 proved in this
file) and their status, ending with the 0-sorries/0-axioms tally.

Change:
- Add one section (`results-summary`, 151-175) closing the gap — full section
  coverage 1-175.

No change to `badge`/`status`/`sorries`/`axiomCount` — already correctly
`mathlib`/`verified`/`0`/`0`, matching the source (verified via `grep`).
File stays well under size caps (meta.json 16.3 KB, « 60 KB).

## Test plan
- [x] `python3 -m json.tool` validates `meta.json`
- [x] `pnpm build`'s JSON-touching pipeline steps (gallery build,
  `check-search-index`, `build-loading-facts`, `build-redirects`) all passed;
  `tsc`/`vite build` are unavailable in this worktree (missing `node_modules`,
  a pre-existing environment gap, not caused by this change)
- [x] Diff scoped to only
  `src/data/proofs/algebraic-reals-meager-oq-02-oq-01/meta.json` (build-noise
  files reverted before commit)