### PR TITLE
Research: erdos-227-wip-01 - elementary maxTerm <= maxModulus layer (13 axiom-free theorems)

### DIFF
--- a/proofs/Proofs/Erdos227Problem.lean
+++ b/proofs/Proofs/Erdos227Problem.lean
@@ -237,4 +237,195 @@ theorem erdos_227_summary :
 
 /- Erdős Problem #227: SOLVED (DISPROVED). -/
 
+/-
+## Part 11: Elementary Bounds — Maximum Term vs Maximum Modulus
+
+Axiom-free supporting layer. The `EntireFunction` structure records only the
+coefficients; it does not force the power series to converge anywhere.
+`IsEntire` captures genuine entireness (absolute convergence of the coefficient
+series at every radius). In Clunie's setting — non-negative real coefficients —
+we prove the elementary inequality `μ(r) ≤ M(r)` (the maximum term is one term
+of the series that sums to `f(r) ≤ M(r)`), hence the term/modulus ratio is at
+most `1` and any limit `L` of the ratio lies in `[0, 1]`. The deep
+Clunie–Hayman refinement `L ≤ 1/2` remains axiomatized (`ratio_upper_bound`),
+as does Clunie's exact value `L = 0` (`clunie_positive_coeffs`).
+-/
+
+/-- Genuine entireness: absolute convergence of the coefficient series at every
+    non-negative radius. The bare `EntireFunction` structure does not require
+    this; theorems that need convergence take it as an explicit hypothesis. -/
+def IsEntire (f : EntireFunction) : Prop :=
+  ∀ r : ℝ, 0 ≤ r → Summable fun n => ‖f.coeff n‖ * r ^ n
+
+/-- The maximum term is non-negative for `r ≥ 0`. -/
+theorem maxTerm_nonneg (f : EntireFunction) {r : ℝ} (hr : 0 ≤ r) :
+    0 ≤ maxTerm f r :=
+  Real.iSup_nonneg fun n => mul_nonneg (norm_nonneg _) (pow_nonneg hr n)
+
+/-- The maximum modulus is non-negative. -/
+theorem maxModulus_nonneg (f : EntireFunction) (r : ℝ) :
+    0 ≤ maxModulus f r :=
+  Real.iSup_nonneg fun _ => norm_nonneg _
+
+/-- Norm of the `n`-th series term at the point `r·e^{iθ}`: it equals
+    `‖aₙ‖·rⁿ`, independently of the angle `θ`. -/
+theorem norm_series_term (f : EntireFunction) {r : ℝ} (hr : 0 ≤ r) (θ : ℝ) (n : ℕ) :
+    ‖f.coeff n * (↑r * exp (I * ↑θ)) ^ n‖ = ‖f.coeff n‖ * r ^ n := by
+  have hexp : ‖exp (I * (θ : ℂ))‖ = 1 := by
+    rw [Complex.norm_exp]
+    simp [Complex.mul_re]
+  rw [norm_mul, norm_pow, norm_mul, hexp, mul_one, Complex.norm_real,
+    Real.norm_eq_abs, abs_of_nonneg hr]
+
+/-- Absolute convergence at radius `r` gives convergence at every point of the
+    circle `|z| = r`. -/
+theorem summable_series_term (f : EntireFunction) {r : ℝ} (hr : 0 ≤ r)
+    (hs : Summable fun n => ‖f.coeff n‖ * r ^ n) (θ : ℝ) :
+    Summable fun n => f.coeff n * (↑r * exp (I * ↑θ)) ^ n :=
+  Summable.of_norm (hs.congr fun n => (norm_series_term f hr θ n).symm)
+
+/-- Triangle inequality on the circle of radius `r`: `‖f(re^{iθ})‖` is bounded
+    by the absolute sum `Σ ‖aₙ‖ rⁿ`, uniformly in `θ`. -/
+theorem norm_tsum_le_sum_norm (f : EntireFunction) {r : ℝ} (hr : 0 ≤ r)
+    (hs : Summable fun n => ‖f.coeff n‖ * r ^ n) (θ : ℝ) :
+    ‖∑' n, f.coeff n * (↑r * exp (I * ↑θ)) ^ n‖ ≤ ∑' n, ‖f.coeff n‖ * r ^ n :=
+  calc ‖∑' n, f.coeff n * (↑r * exp (I * ↑θ)) ^ n‖
+      ≤ ∑' n, ‖f.coeff n * (↑r * exp (I * ↑θ)) ^ n‖ :=
+        norm_tsum_le_tsum_norm (hs.congr fun n => (norm_series_term f hr θ n).symm)
+    _ = ∑' n, ‖f.coeff n‖ * r ^ n := tsum_congr fun n => norm_series_term f hr θ n
+
+/-- The family `θ ↦ ‖f(re^{iθ})‖` is bounded above (by the absolute sum). -/
+theorem bddAbove_range_norm (f : EntireFunction) {r : ℝ} (hr : 0 ≤ r)
+    (hs : Summable fun n => ‖f.coeff n‖ * r ^ n) :
+    BddAbove (Set.range fun θ : ℝ => ‖∑' n, f.coeff n * (↑r * exp (I * ↑θ)) ^ n‖) := by
+  refine ⟨∑' n, ‖f.coeff n‖ * r ^ n, ?_⟩
+  rintro x ⟨θ, rfl⟩
+  exact norm_tsum_le_sum_norm f hr hs θ
+
+/-- `M(r) ≤ Σ ‖aₙ‖ rⁿ`: the maximum modulus is at most the absolute sum. -/
+theorem maxModulus_le_tsum (f : EntireFunction) {r : ℝ} (hr : 0 ≤ r)
+    (hs : Summable fun n => ‖f.coeff n‖ * r ^ n) :
+    maxModulus f r ≤ ∑' n, ‖f.coeff n‖ * r ^ n :=
+  ciSup_le fun θ => norm_tsum_le_sum_norm f hr hs θ
+
+/-- For non-negative real coefficients the value at `θ = 0` is exactly the
+    absolute sum: `‖f(r)‖ = Σ aₙ rⁿ = Σ ‖aₙ‖ rⁿ`. -/
+theorem norm_tsum_at_zero_of_nonneg (f : EntireFunction) {r : ℝ} (hr : 0 ≤ r)
+    (hpos : ∀ n, (f.coeff n).re ≥ 0 ∧ (f.coeff n).im = 0)
+    (hs : Summable fun n => ‖f.coeff n‖ * r ^ n) :
+    ‖∑' n, f.coeff n * (↑r * exp (I * ((0 : ℝ) : ℂ))) ^ n‖
+      = ∑' n, ‖f.coeff n‖ * r ^ n := by
+  have hcoeff : ∀ n, f.coeff n = ((‖f.coeff n‖ : ℝ) : ℂ) := by
+    intro n
+    have h1 : f.coeff n = (((f.coeff n).re : ℝ) : ℂ) :=
+      Complex.ext (by simp) (by simpa using (hpos n).2)
+    have h2 : ‖f.coeff n‖ = (f.coeff n).re := by
+      rw [h1, Complex.norm_real, Complex.ofReal_re, Real.norm_eq_abs]
+      exact abs_of_nonneg (hpos n).1
+    rw [h2]
+    exact h1
+  have h0 : ∀ n : ℕ, f.coeff n * (↑r * exp (I * ((0 : ℝ) : ℂ))) ^ n
+      = ((‖f.coeff n‖ * r ^ n : ℝ) : ℂ) := by
+    intro n
+    have hexp0 : exp (I * ((0 : ℝ) : ℂ)) = 1 := by simp
+    rw [hexp0, mul_one, hcoeff n]
+    push_cast
+    ring
+  calc ‖∑' n, f.coeff n * (↑r * exp (I * ((0 : ℝ) : ℂ))) ^ n‖
+      = ‖((∑' n, ‖f.coeff n‖ * r ^ n : ℝ) : ℂ)‖ := by
+        rw [tsum_congr h0, ← RCLike.ofReal_tsum]
+    _ = ∑' n, ‖f.coeff n‖ * r ^ n := by
+        rw [Complex.norm_real, Real.norm_eq_abs]
+        exact abs_of_nonneg
+          (tsum_nonneg fun n => mul_nonneg (norm_nonneg _) (pow_nonneg hr n))
+
+/-- **Clunie's setting, elementary part**: for non-negative real coefficients
+    the maximum term is at most the maximum modulus, `μ(r) ≤ M(r)` — each term
+    `aₙrⁿ` is one summand of the non-negative series summing to `f(r) ≤ M(r)`. -/
+theorem maxTerm_le_maxModulus_of_nonneg (f : EntireFunction) {r : ℝ} (hr : 0 ≤ r)
+    (hpos : ∀ n, (f.coeff n).re ≥ 0 ∧ (f.coeff n).im = 0)
+    (hs : Summable fun n => ‖f.coeff n‖ * r ^ n) :
+    maxTerm f r ≤ maxModulus f r := by
+  have hM : (∑' n, ‖f.coeff n‖ * r ^ n) ≤ maxModulus f r := by
+    rw [← norm_tsum_at_zero_of_nonneg f hr hpos hs]
+    exact le_ciSup (bddAbove_range_norm f hr hs) (0 : ℝ)
+  have key : (⨆ n : ℕ, ‖f.coeff n‖ * r ^ n) ≤ maxModulus f r :=
+    ciSup_le fun n =>
+      le_trans (hs.le_tsum n fun j _ => mul_nonneg (norm_nonneg _) (pow_nonneg hr j)) hM
+  exact key
+
+/-- For non-negative real coefficients the term/modulus ratio is at most `1`. -/
+theorem termModulusRatio_le_one_of_nonneg (f : EntireFunction) {r : ℝ} (hr : 0 ≤ r)
+    (hpos : ∀ n, (f.coeff n).re ≥ 0 ∧ (f.coeff n).im = 0)
+    (hs : Summable fun n => ‖f.coeff n‖ * r ^ n) :
+    termModulusRatio f r ≤ 1 := by
+  rcases (maxModulus_nonneg f r).eq_or_lt with hM | hM
+  · unfold termModulusRatio
+    rw [← hM, div_zero]
+    exact zero_le_one
+  · unfold termModulusRatio
+    rw [div_le_one hM]
+    exact maxTerm_le_maxModulus_of_nonneg f hr hpos hs
+
+/-- Any limit of the term/modulus ratio of a genuinely entire function with
+    non-negative real coefficients lies in `[0, 1]`. This is the elementary
+    companion of the deep axiomatized results: Clunie–Hayman give `L ≤ 1/2`
+    (`ratio_upper_bound`) and Clunie gives the exact value `L = 0`
+    (`clunie_positive_coeffs`); the bound here uses only Mathlib. -/
+theorem limit_mem_Icc_of_nonneg (f : EntireFunction)
+    (hpos : ∀ n, (f.coeff n).re ≥ 0 ∧ (f.coeff n).im = 0)
+    (hent : IsEntire f) {L : ℝ}
+    (hL : Tendsto (termModulusRatio f) atTop (nhds L)) :
+    L ∈ Set.Icc (0 : ℝ) 1 := by
+  constructor
+  · refine ge_of_tendsto hL ?_
+    filter_upwards [eventually_ge_atTop (0 : ℝ)] with r hr
+    exact termModulusRatio_nonneg f hr
+  · refine le_of_tendsto hL ?_
+    filter_upwards [eventually_ge_atTop (0 : ℝ)] with r hr
+    exact termModulusRatio_le_one_of_nonneg f hr hpos (hent r hr)
+
+/-
+### The exponential function
+
+A concrete witness that `IsEntire` is non-vacuous and the hypotheses above are
+satisfiable: `exp` with coefficients `1/n!`.
+-/
+
+/-- The exponential function `Σ zⁿ/n!` as an `EntireFunction`. -/
+noncomputable def expFunction : EntireFunction where
+  coeff n := 1 / (n.factorial : ℂ)
+  not_polynomial N := ⟨N + 1, Nat.lt_succ_self N, by
+    have h : (((N + 1).factorial : ℕ) : ℂ) ≠ 0 :=
+      Nat.cast_ne_zero.mpr (Nat.factorial_ne_zero _)
+    exact one_div_ne_zero h⟩
+
+/-- The coefficients of `exp` are non-negative reals. -/
+theorem expFunction_coeff_nonneg (n : ℕ) :
+    (expFunction.coeff n).re ≥ 0 ∧ (expFunction.coeff n).im = 0 := by
+  have h : expFunction.coeff n = ((1 / (n.factorial : ℝ) : ℝ) : ℂ) := by
+    show (1 : ℂ) / (n.factorial : ℂ) = _
+    push_cast
+    ring
+  constructor
+  · rw [h, Complex.ofReal_re]
+    positivity
+  · rw [h, Complex.ofReal_im]
+
+/-- `exp` is genuinely entire: `Σ ‖1/n!‖ rⁿ` converges for every `r ≥ 0`. -/
+theorem expFunction_isEntire : IsEntire expFunction := by
+  intro r hr
+  refine (Real.summable_pow_div_factorial r).congr fun n => ?_
+  have h : ‖expFunction.coeff n‖ = 1 / (n.factorial : ℝ) := by
+    show ‖(1 : ℂ) / (n.factorial : ℂ)‖ = _
+    rw [norm_div, norm_one, Complex.norm_natCast]
+  rw [h]
+  ring
+
+/-- The term/modulus ratio of `exp` is at most `1` for every `r ≥ 0`. -/
+theorem expFunction_ratio_le_one {r : ℝ} (hr : 0 ≤ r) :
+    termModulusRatio expFunction r ≤ 1 :=
+  termModulusRatio_le_one_of_nonneg expFunction hr expFunction_coeff_nonneg
+    (expFunction_isEntire r hr)
+
 end Erdos227

--- a/proofs/Proofs/Erdos227Problem.lean
+++ b/proofs/Proofs/Erdos227Problem.lean
@@ -26,7 +26,7 @@ import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Analysis.Normed.Field.Basic
 import Mathlib.Topology.MetricSpace.Basic
 import Mathlib.Data.Real.Basic
-import Mathlib.Data.Real.Archimedean
+import Mathlib.Algebra.Order.Archimedean.Real.Basic
 import Mathlib.Order.Filter.Basic
 
 namespace Erdos227
@@ -311,8 +311,7 @@ theorem maxModulus_le_tsum (f : EntireFunction) {r : ℝ} (hr : 0 ≤ r)
 /-- For non-negative real coefficients the value at `θ = 0` is exactly the
     absolute sum: `‖f(r)‖ = Σ aₙ rⁿ = Σ ‖aₙ‖ rⁿ`. -/
 theorem norm_tsum_at_zero_of_nonneg (f : EntireFunction) {r : ℝ} (hr : 0 ≤ r)
-    (hpos : ∀ n, (f.coeff n).re ≥ 0 ∧ (f.coeff n).im = 0)
-    (hs : Summable fun n => ‖f.coeff n‖ * r ^ n) :
+    (hpos : ∀ n, (f.coeff n).re ≥ 0 ∧ (f.coeff n).im = 0) :
     ‖∑' n, f.coeff n * (↑r * exp (I * ((0 : ℝ) : ℂ))) ^ n‖
       = ∑' n, ‖f.coeff n‖ * r ^ n := by
   have hcoeff : ∀ n, f.coeff n = ((‖f.coeff n‖ : ℝ) : ℂ) := by
@@ -328,12 +327,13 @@ theorem norm_tsum_at_zero_of_nonneg (f : EntireFunction) {r : ℝ} (hr : 0 ≤ r
       = ((‖f.coeff n‖ * r ^ n : ℝ) : ℂ) := by
     intro n
     have hexp0 : exp (I * ((0 : ℝ) : ℂ)) = 1 := by simp
-    rw [hexp0, mul_one, hcoeff n]
+    rw [hexp0, mul_one]
+    conv_lhs => rw [hcoeff n]
     push_cast
     ring
   calc ‖∑' n, f.coeff n * (↑r * exp (I * ((0 : ℝ) : ℂ))) ^ n‖
       = ‖((∑' n, ‖f.coeff n‖ * r ^ n : ℝ) : ℂ)‖ := by
-        rw [tsum_congr h0, ← RCLike.ofReal_tsum]
+        rw [tsum_congr h0, ← Complex.ofReal_tsum]
     _ = ∑' n, ‖f.coeff n‖ * r ^ n := by
         rw [Complex.norm_real, Real.norm_eq_abs]
         exact abs_of_nonneg
@@ -347,7 +347,7 @@ theorem maxTerm_le_maxModulus_of_nonneg (f : EntireFunction) {r : ℝ} (hr : 0 �
     (hs : Summable fun n => ‖f.coeff n‖ * r ^ n) :
     maxTerm f r ≤ maxModulus f r := by
   have hM : (∑' n, ‖f.coeff n‖ * r ^ n) ≤ maxModulus f r := by
-    rw [← norm_tsum_at_zero_of_nonneg f hr hpos hs]
+    rw [← norm_tsum_at_zero_of_nonneg f hr hpos]
     exact le_ciSup (bddAbove_range_norm f hr hs) (0 : ℝ)
   have key : (⨆ n : ℕ, ‖f.coeff n‖ * r ^ n) ≤ maxModulus f r :=
     ciSup_le fun n =>

--- a/research/problems/erdos-227-wip-01/knowledge.md
+++ b/research/problems/erdos-227-wip-01/knowledge.md
@@ -6,16 +6,57 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Erdős #227 (SOLVED/DISPROVED, Clunie–Hayman 1964): the limit of μ(r)/M(r) can be
+any λ ∈ [0, 1/2]. `Erdos227Problem.lean` formalizes the statement with 3 axioms
+(all person-named, deep: `clunie_positive_coeffs`, `clunie_hayman_1964`,
+`ratio_upper_bound`) and 1 sorry (`positive_coeffs_normal` — needs the
+*existence* of the limit for non-negative coefficients, which is the analytic
+heart of Clunie's unpublished theorem).
+
+Key structural fact: the `EntireFunction` structure records only coefficients and
+imposes NO convergence. Divergent members hit Mathlib junk values (`tsum = 0`,
+unbounded `Real.iSup = 0`), making `termModulusRatio` identically 0 for large r,
+so the axioms stay sound over the weak structure (junk regime forces L = 0).
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- **Session 2026-07-22 (researcher-1)**: Added Part 11 — 13 axiom-free theorems
+  (`#print axioms` = propext/Classical.choice/Quot.sound only):
+  - `IsEntire` predicate (absolute summability at every radius) fixes the
+    structure's missing-convergence gap; theorems take it as hypothesis.
+  - μ(r) ≤ M(r) for non-negative real coefficients
+    (`maxTerm_le_maxModulus_of_nonneg`): no Cauchy integral needed — each term
+    aₙrⁿ is a summand of the non-negative series f(r), which is the θ=0 member
+    of the family defining M(r).
+  - `termModulusRatio_le_one_of_nonneg`, `limit_mem_Icc_of_nonneg`: any ratio
+    limit lies in [0,1] — elementary companion to the deep axiomatized L ≤ 1/2
+    and L = 0.
+  - `expFunction` (coeffs 1/n!) with `expFunction_isEntire`: concrete witness
+    via `Real.summable_pow_div_factorial`.
+- Lean idioms: `Complex.ofReal_tsum` (NOT `RCLike.ofReal_tsum`) matches goals
+  whose coercion elaborated as `Complex.ofReal`; `conv_lhs => rw [...]` needed
+  when a coefficient-rewrite would also fire inside `‖·‖` on the RHS;
+  `ciSup_le`/`le_ciSup` handle the `Real.iSup` definitions (`le_ciSup` needs
+  `BddAbove (Set.range ...)`, provided by the triangle-inequality bound).
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- Proving any of the 3 axioms or the sorry from Mathlib: Wiman–Valiron theory
+  (maximum term, central index) and the Clunie/Clunie–Hayman constructions are
+  entirely absent. Do NOT re-attempt without new Mathlib infrastructure
+  ("materially new mechanism required").
+- Do not "close" the sorry by adding a limit-existence axiom — that inflates the
+  axiom count for no verification gain.
+
+---
+
+## Open Next Steps
+
+- OPTIONAL (~300–500 lines): bridge `EntireFunction`+`IsEntire` to Mathlib's
+  `HasFPowerSeriesOnBall`/`FormalMultilinearSeries` API and prove the
+  unconditional Cauchy estimate μ(r) ≤ M(r) (arbitrary complex coefficients).
+- DEEP (blocked): sorry elimination and axiom elimination.

--- a/research/problems/erdos-227-wip-01/state.md
+++ b/research/problems/erdos-227-wip-01/state.md
@@ -1,25 +1,32 @@
 # Research State: erdos-227-wip-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-07-09T17:33:19-07:00
-**Iteration**: 1
+**Since**: 2026-07-22
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Elementary maxTerm/maxModulus layer landed (Part 11, 13 axiom-free theorems,
+session 2026-07-22): IsEntire predicate, μ(r) ≤ M(r) for non-negative
+coefficients, ratio ≤ 1, ratio limits in [0,1], exp witness.
 
 ## Active Approach
-None yet.
+Elementary-layer saturation done. Remaining routes:
+1. OPTIONAL Mathlib bridge to HasFPowerSeriesOnBall for the unconditional
+   Cauchy estimate μ(r) ≤ M(r) (~300–500 lines).
+2. DEEP (blocked): the sorry (`positive_coeffs_normal`) and all 3 axioms need
+   Clunie / Clunie–Hayman / Wiman–Valiron theory absent from Mathlib.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
-None.
+- Sorry + 3 axioms: "materially new mechanism required" (Mathlib lacks
+  Wiman–Valiron theory and the Clunie–Hayman constructions).
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+If re-served: attempt the HasFPowerSeriesOnBall bridge (route 1). Do not
+re-attempt axiom/sorry elimination from current Mathlib.

--- a/src/data/research/problems/erdos-227-wip-01.json
+++ b/src/data/research/problems/erdos-227-wip-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-227-wip-01",
   "title": "Completing the Lean Formalization of Erdős #227 (Maximum Term vs Maximum Modulus)",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -13,29 +13,49 @@
     ]
   },
   "knownResults": {
-    "proven": [],
+    "proven": [
+      "mu(r) <= M(r) for nonneg real coefficients under summability (axiom-free, session 2026-07-22)"
+    ],
     "open": [],
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-07-09T17:33:19-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "iteration": 2,
+    "focus": "Elementary maxTerm/maxModulus layer proved axiom-free; deep Clunie/Clunie-Hayman core remains axiomatized",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Optional: bridge EntireFunction to Mathlib HasFPowerSeriesOnBall to get Cauchy estimate mu(r) <= M(r) unconditionally (not just nonneg coeffs)",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "PROGRESS: Part 11 added (13 axiom-free theorems, session 2026-07-22). IsEntire predicate fixes the structure gap (EntireFunction never required convergence). Proved mu(r) <= M(r) for nonneg real coefficients (Clunie setting), ratio <= 1, and any ratio limit lies in [0,1] — elementary companion to the deep axiomatized L <= 1/2 (ratio_upper_bound) and L = 0 (clunie_positive_coeffs). expFunction (coeffs 1/n!) is a concrete IsEntire witness. Remaining sorry (positive_coeffs_normal) and all 3 axioms are Clunie/Clunie-Hayman-deep: NOT provable from current Mathlib.",
+    "builtItems": [
+      "IsEntire predicate + maxTerm_nonneg/maxModulus_nonneg (Erdos227Problem.lean Part 11)",
+      "norm_series_term / summable_series_term / norm_tsum_le_sum_norm / bddAbove_range_norm / maxModulus_le_tsum (circle-of-radius-r toolkit)",
+      "norm_tsum_at_zero_of_nonneg + maxTerm_le_maxModulus_of_nonneg (mu(r) <= M(r), Clunie setting)",
+      "termModulusRatio_le_one_of_nonneg + limit_mem_Icc_of_nonneg (ratio limit in [0,1], axiom-free)",
+      "expFunction + expFunction_coeff_nonneg + expFunction_isEntire + expFunction_ratio_le_one (exp witness)"
+    ],
+    "insights": [
+      "EntireFunction structure imposes NO convergence: divergent-coefficient members give junk tsum=0/iSup=0, making ratio identically 0 for large r — so the axioms remain sound over the weak structure (junk regime always yields L=0)",
+      "The lone sorry (positive_coeffs_normal) asserts existence of the limit for nonneg coeffs — that existence IS Clunie s unpublished theorem; do not close it with an axiom or a False-risking strengthening",
+      "mu(r) <= M(r) for nonneg coeffs needs no Cauchy integral: each term a_n r^n is a summand of f(r) = M-candidate at theta=0; general-coefficient mu <= M genuinely needs Cauchy estimates (Mathlib bridge to HasFPowerSeriesOnBall would be ~300-500 lines)",
+      "Complex.ofReal_tsum (not RCLike.ofReal_tsum) is the syntactically-matching rewrite for coercion-through-tsum in goals elaborated with Complex.ofReal"
+    ],
+    "mathlibGaps": [
+      "Wiman-Valiron theory (maximum term, central index) absent from Mathlib",
+      "Clunie 1964 / Clunie-Hayman constructions absent — all 3 axioms stay",
+      "No lemma linking a raw coefficient sequence to HasFPowerSeriesOnBall without building the FormalMultilinearSeries by hand"
+    ],
+    "nextSteps": [
+      "OPTIONAL (300-500 lines): bridge EntireFunction+IsEntire to Mathlib power-series API and prove unconditional mu(r) <= M(r) via Cauchy estimates",
+      "DEEP (do not attempt from Mathlib): eliminate positive_coeffs_normal sorry (needs Clunie limit-existence) or any of the 3 axioms"
+    ],
     "markdown": "# Knowledge Base: erdos-227-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [
@@ -57,7 +77,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.780Z",
-  "lastUpdate": "2026-07-10T00:41:25.927Z",
+  "lastUpdate": "2026-07-22T20:00:00Z",
   "significance": 6,
   "tractability": 7
 }


### PR DESCRIPTION
## Summary
Research session for erdos-227-wip-01 (Erdős #227: maximum term vs maximum modulus, SOLVED/DISPROVED by Clunie–Hayman 1964).

## Progress
- Added Part 11 to `proofs/Proofs/Erdos227Problem.lean` (+195 lines, 13 new theorems/defs, all axiom-free): the node's stated goal of proving the elementary facts about mu(r) and M(r) directly in Mathlib.
- `IsEntire` predicate: the `EntireFunction` structure never required convergence; this captures genuine entireness (absolute summability at every radius) as an explicit hypothesis.
- `maxTerm_le_maxModulus_of_nonneg`: mu(r) <= M(r) for non-negative real coefficients (Clunie's setting) — each term a_n r^n is a summand of the series whose value at theta=0 witnesses M(r). No Cauchy integral needed.
- `termModulusRatio_le_one_of_nonneg` + `limit_mem_Icc_of_nonneg`: any limit L of the ratio lies in [0,1] — the elementary, Mathlib-only companion of the deep axiomatized bounds (L <= 1/2 Clunie–Hayman, L = 0 Clunie).
- `expFunction` (coefficients 1/n!): concrete witness that `IsEntire` is satisfiable, via `Real.summable_pow_div_factorial`.
- Replaced deprecated `Mathlib.Data.Real.Archimedean` import (warning-free apart from the pre-existing sorry).
- All new content appended at end of file — no line shifts for existing gallery annotations.

## Verification
- Host `lake env lean` (v4.31.0, Mathlib cache): compiles clean; only warning is the pre-existing sorry (`positive_coeffs_normal`).
- `#print axioms` on all key new theorems: `[propext, Classical.choice, Quot.sound]` only — none depend on the file's 3 declared axioms.
- Sorry/axiom delta: unchanged (1 sorry, 3 axioms). The sorry needs the existence half of Clunie's unpublished theorem; the 3 axioms are Clunie/Clunie–Hayman-deep (Wiman–Valiron theory absent from Mathlib). Documented as blocked routes in the tracker.

## Findings
- The weak `EntireFunction` structure is junk-value-sound: divergent members give tsum = 0 and unbounded-iSup = 0, forcing ratio = 0 eventually, so the axioms remain consistent over the full structure.
- Lean idiom: `Complex.ofReal_tsum` (not `RCLike.ofReal_tsum`) is needed for goals whose real-to-complex coercion elaborated as `Complex.ofReal`.

## Status
**Outcome**: progress (elementary layer complete; deep core remains axiomatized)
**Next Steps**: optional ~300–500-line bridge to `HasFPowerSeriesOnBall` for the unconditional Cauchy estimate mu(r) <= M(r); axiom/sorry elimination is blocked pending new Mathlib infrastructure.

🤖 Generated by researcher-1
