### PR TITLE
Enrich erdos-876: cover Part VIII-IX tail (259-305)

### DIFF
--- a/src/data/proofs/erdos-876/annotations.json
+++ b/src/data/proofs/erdos-876/annotations.json
@@ -255,5 +255,29 @@
       "sum-free definition",
       "Sidon set definition"
     ]
+  },
+  {
+    "id": "ann-876-12",
+    "proofId": "erdos-876",
+    "range": {
+      "startLine": 259,
+      "endLine": 305
+    },
+    "type": "theorem",
+    "title": "Part VIII–IX: Sidon/B_h remarks and the summary theorem",
+    "content": "Part VIII (prose comments, not formalized) elaborates the Sidon-set connection begun in the previous block and introduces $B_h$ sequences (generalizing Sidon to no repeated $h$-fold sum) as the natural hierarchy sum-free sets sit atop. Part IX restates Problem #876's status as PARTIALLY SOLVED, listing the three open questions (linear gaps, exact reciprocal-sum supremum, gap-vs-density tightness) and four known results as a prose ledger, then proves `erdos_876_summary`. That theorem is not new mathematics: it destructures `graham_result ε hε` and forwards the sum-free and gap-bound components directly, restating Graham's axiom as the file's closing corollary rather than adding independent content.",
+    "mathContext": "`erdos_876_summary : \\forall \\varepsilon > 0, \\exists a : \\mathbb{N} \\to \\mathbb{N}, \\text{IsSumFreeErdos}(\\text{range } a) \\land \\exists N, \\forall n \\ge N, (a_{n+1}-a_n) < n^{1+\\varepsilon}$ — proved by `obtain \\langle a, hincr, hsum, N, hgap\\rangle := graham_result \\varepsilon h\\varepsilon; exact \\langle a, hsum, N, hgap\\rangle`, discarding only the `hincr` (increasing enumeration) witness.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Sidon sets",
+      "B_h sequences",
+      "Graham's result",
+      "proof by destructuring an axiom"
+    ],
+    "prerequisites": [
+      "graham_result",
+      "IsSumFreeErdos",
+      "gap"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-876/meta.json
+++ b/src/data/proofs/erdos-876/meta.json
@@ -17,7 +17,7 @@
       "partially-solved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 876,
     "erdosUrl": "https://erdosproblems.com/876",
     "erdosProblemStatus": "open",
@@ -46,8 +46,8 @@
       "Density-zero, Łuczak-Schoen, DEM, and Sullivan results appear only as prose comments — they are NOT formalized as axioms or theorems"
     ],
     "axiomCount": 1,
-    "lineCount": 259,
-    "assumptions": "1 axiom: graham_result. 2 sorries.",
+    "lineCount": 305,
+    "assumptions": "1 axiom: graham_result. 1 sorry (powers_of_two_sumfree).",
     "theoremCount": 3,
     "definitionCount": 9,
     "additionalFiles": [
@@ -58,7 +58,7 @@
     "historicalContext": "**Erdős Problem #876: Sum-Free Sets and Gap Growth**\n\nA **sum-free set** in Erdős's sense is an infinite set $A = \\{a_1 < a_2 < \\cdots\\} \\subset \\mathbb{N}$ where no element equals a sum of distinct smaller elements from $A$. This is strictly stronger than the classical sum-free condition (no $a + b = c$), as it forbids all subset sums, not just pairs.\n\nPaul Erdős proved in 1962 that such sets must have asymptotic density zero, establishing a fundamental sparsity constraint. The natural follow-up question — how sparse must they be? — was pursued through several key developments:\n\n- **Erdős (1962):** Proved density zero and the crude reciprocal sum bound $\\sum_{a \\in A} 1/a < 100$.\n- **Ronald Graham (c. 1998):** Showed that for any $\\varepsilon > 0$, there exists a sum-free set with gaps $a_{n+1} - a_n < n^{1+\\varepsilon}$ for large $n$. This is the best positive result toward the linear gap question.\n- **Jean-Marc Deshouillers, Erdős, and Giuseppe Melfi (1999):** Constructed a sum-free set with $a_n \\sim n^{3+o(1)}$, establishing the cubic growth rate as achievable.\n- **Tomasz Łuczak and Tomasz Schoen (2000):** Proved tight bounds on the counting function: $|A \\cap [1,N]| = O(\\sqrt{N \\log N})$ for any sum-free $A$, and there exists $B$ with $|B \\cap [1,N]| \\gg \\sqrt{N/(\\log N)^{1/2+o(1)}}$.\n- **Steven Sullivan:** Improved Erdős's reciprocal sum bound to $\\sum 1/a < 4$ and conjectured the supremum is slightly above 2.\n\nThe central open question remains: **can the gaps be made linear**, i.e., is $a_{n+1} - a_n < n$ achievable? Graham's result shows we can get arbitrarily close to linear ($n^{1+\\varepsilon}$), suggesting the answer might be yes, but the problem has resisted resolution for over two decades.",
     "problemStatement": "**Problem Statement (Partially Solved)**\n\nLet $A = \\{a_1 < a_2 < \\cdots\\} \\subset \\mathbb{N}$ be an infinite sum-free set, meaning no $a \\in A$ equals $b_1 + b_2 + \\cdots + b_r$ for distinct $b_i \\in A$ with $b_i < a$.\n\n**Questions:**\n1. How small can the gaps $a_{n+1} - a_n$ be?\n2. Is it possible that $a_{n+1} - a_n < n$?\n\n**Known:**\n- Graham: Gaps can be $< n^{1+o(1)}$\n- Main question (linear gaps) is OPEN\n\n**Additional Question:**\nWhat is $\\max \\sum_{a \\in A} 1/a$? Sullivan shows $< 4$, conjectures $\\approx 2$.",
     "text": "For an infinite sum-free set A = {a₁ < a₂ < ⋯}, how small can gaps aₙ₊₁ - aₙ be? Graham showed n^{1+o(1)} is achievable; whether gaps < n is possible remains OPEN.",
-    "proofStrategy": "**Formalization Approach**\n\nThe formalization distinguishes two sum-free notions and builds toward the open question:\n\n1. **Two Definitions (Lines 49–76):** `IsSumFreeErdos` forbids any subset sum of distinct predecessors equaling an element; `IsSumFreeClassical` only forbids $a + b = c$. The naive implication `IsSumFreeErdos → IsSumFreeClassical` is **false** (`not_isSumFreeErdos_imp_isSumFreeClassical`: $\\{2,4\\}$ is Erdős-sum-free but $2+2=4\\in A$); the correct `erdos_implies_classical_of_pos` holds only for distinct positive summands. Both are axiom- and sorry-free.\n\n2. **Gap Machinery (Lines 84–109):** Defines `gap a n = a(n+1) - a(n)`, `HasGapBound`, and the critical `HasLinearGapBound` condition $a_{n+1} - a_n < n$.\n\n3. **The Open Question (Lines 117–136):** `ErdosQuestion876` existentially asserts a sum-free set with linear gaps. Graham's axiom shows near-linear ($n^{1+\\varepsilon}$) gaps are achievable.\n\n4. **Density and Growth (Lines 140–169):** Erdős's density-zero result, Łuczak-Schoen's counting bounds $\\Theta(\\sqrt{N \\log N})$, and DEM's cubic growth construction are recorded in prose comments only — none are formalized as axioms or theorems. The only declaration is `def cubicGrowthExponent := 3`.\n\n5. **Reciprocal Sums (Lines 175–193):** Defines `reciprocalSum` via `tsum`; Erdős's bound, Sullivan's improvement, and Sullivan's conjecture are described in comments, not axiomatized.\n\n6. **Examples and Summary (Lines 198–257):** Powers of 2 as a basic sum-free set (sorry in proof), connections to Sidon sets, and the summary theorem.",
+    "proofStrategy": "**Formalization Approach**\n\nThe formalization distinguishes two sum-free notions and builds toward the open question:\n\n1. **Two Definitions (Lines 49–76):** `IsSumFreeErdos` forbids any subset sum of distinct predecessors equaling an element; `IsSumFreeClassical` only forbids $a + b = c$. The naive implication `IsSumFreeErdos → IsSumFreeClassical` is **false** (`not_isSumFreeErdos_imp_isSumFreeClassical`: $\\{2,4\\}$ is Erdős-sum-free but $2+2=4\\in A$); the correct `erdos_implies_classical_of_pos` holds only for distinct positive summands. Both are axiom- and sorry-free.\n\n2. **Gap Machinery (Lines 84–109):** Defines `gap a n = a(n+1) - a(n)`, `HasGapBound`, and the critical `HasLinearGapBound` condition $a_{n+1} - a_n < n$.\n\n3. **The Open Question (Lines 117–136):** `ErdosQuestion876` existentially asserts a sum-free set with linear gaps. Graham's axiom shows near-linear ($n^{1+\\varepsilon}$) gaps are achievable.\n\n4. **Density and Growth (Lines 140–169):** Erdős's density-zero result, Łuczak-Schoen's counting bounds $\\Theta(\\sqrt{N \\log N})$, and DEM's cubic growth construction are recorded in prose comments only — none are formalized as axioms or theorems. The only declaration is `def cubicGrowthExponent := 3`.\n\n5. **Reciprocal Sums (Lines 175–193):** Defines `reciprocalSum` via `tsum`; Erdős's bound, Sullivan's improvement, and Sullivan's conjecture are described in comments, not axiomatized.\n\n6. **Examples and Summary (Lines 198–305):** Powers of 2 as a basic sum-free set (sorry in proof), connections to Sidon sets and $B_h$ sequences, and the closing `erdos_876_summary` theorem, which restates Graham's axiom rather than adding new content.",
     "keyInsights": [
       "**Erdős vs Classical Sum-Free:** The Erdős condition ($\\nexists$ subset sum of predecessors $= a$) is strictly stronger than classical ($a + b \\neq c$). The set $\\{1, 5, 6\\}$ is classically sum-free ($1+5=6$ violates classical!) but illustrates the distinction — Erdős sum-free sets avoid ALL subset sums, making them much sparser.",
       "**Density-Growth Duality:** The Łuczak-Schoen counting bound $|A \\cap [1,N]| = O(\\sqrt{N \\log N})$ and the DEM growth rate $a_n \\sim n^{3+o(1)}$ are dual perspectives: if $|A \\cap [1,N]| \\sim \\sqrt{N}$, inverting gives $a_n \\sim n^2$. The $\\log N$ correction explains the cubic (rather than quadratic) growth.",
@@ -135,6 +135,14 @@
       "startLine": 227,
       "endLine": 257,
       "mathContext": "States `powers_of_two_sumfree`: $\\{$2^{n}$ : n \\in \\mathbb{N}\\}$ is sum-free (sorry — the proof uses binary uniqueness). Notes connections to Sidon sets and $B_h$ sequences."
+    },
+    {
+      "id": "sidon-and-summary",
+      "title": "Sidon Set Connection and Summary Theorem",
+      "summary": "Part VIII notes in prose (not formalized) that sum-free sets relate to but differ from Sidon sets (distinct pairwise sums) and $B_h$ sequences. Part IX restates the problem's status as PARTIALLY SOLVED and proves `erdos_876_summary`: for every $\\varepsilon > 0$ there is a sum-free set with eventually-linear-plus-$\\varepsilon$ gaps — a direct corollary of the `graham_result` axiom, not new content.",
+      "startLine": 259,
+      "endLine": 305,
+      "mathContext": "`erdos_876_summary : \\forall \\varepsilon > 0, \\exists a, \\text{IsSumFreeErdos}(\\text{range } a) \\land \\exists N, \\forall n \\ge N, \\text{gap}(a,n) < n^{1+\\varepsilon}$ — obtained by destructuring `graham_result ε hε` and discarding the increasing-enumeration component."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Adds section `sidon-and-summary` (lines 259-305) and annotation `ann-876-12` covering the file's tail: Part VIII (Sidon/B_h prose remarks) and Part IX (status ledger + the `erdos_876_summary` theorem, which just restates the `graham_result` axiom). This range had zero section/annotation coverage — the file grew from 259 to 305 lines across prior passes but coverage wasn't extended.
- Fixes stale `meta.meta.sorries` (2 → 1) and `meta.meta.lineCount` (259 → 305), which had drifted out of sync with `leanFile.sorries`/`leanFile.lineCount` (both already correct at 1 / 305) and the actual source (`grep -n sorry` shows exactly one, at line 254).
- Minor accuracy fix to `overview.proofStrategy` point 6, which still cited the pre-growth line range (198-257).

## Test plan
- [x] Validated `meta.json` and `annotations.json` are well-formed JSON
- [x] Confirmed via `grep -n sorry`/`grep -n "^axiom "` that the file has exactly 1 sorry and 1 axiom, matching the corrected counts
- [x] Confirmed new section/annotation line range (259-305) matches actual source boundaries (Part VIII starts at line 262, file ends at line 305)