### PR TITLE
Audit: erdos-1070 clean (reserve re-verify)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9642,9 +9642,9 @@
       "issues": []
     },
     "erdos-1070": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:29Z",
+      "lastAudited": "2026-07-23T00:28:40Z",
       "result": "clean"
     },
     "erdos-1070-oq-05": {


### PR DESCRIPTION
## Integrity Audit — erdos-1070

Reserve-mode re-verification (audit queue drained, round-robin re-serve of oldest audit).

**Result**: clean — all meta.json counts match the Lean source exactly.

- Axioms: 10/10 (f, m1, larman_rogers_theorem, croft_lower_bound, moser_spindle_upper_bound, acmvz_upper_bound, chromaticNumberPlane, de_grey_lower_bound, chromatic_upper_bound, independence_chromatic_relation) — all present as real `axiom` declarations, no phantoms
- Sorries: 0/0
- Theorems: 6/6 (5 `theorem` + 1 `lemma`)
- Definitions: 7/7 (incl. `UnitDistanceGraph` structure)
- Lines: 237/237
- No `native_decide`
- Status `axiomatized` / badge `axiom` (Tier C) is honest — prose correctly distinguishes axiomatized inputs from proved consequences (`f_lower_bound`, `density_insufficient_for_quarter`, `f_from_chromatic`, `erdos_1070_summary`), no overclaiming language
- All 6 cross-references resolve to existing gallery entries

No fix needed; tracker updated (auditCount 5→6).

🤖 Generated with the lean-genius auditor agent