### PR TITLE
Enrich erdos-425: cover header docstring (lines 1-30)

### DIFF
--- a/src/data/proofs/erdos-425/annotations.json
+++ b/src/data/proofs/erdos-425/annotations.json
@@ -1,5 +1,27 @@
 [
   {
+    "id": "ann-425-header",
+    "proofId": "erdos-425",
+    "type": "concept",
+    "range": {
+      "startLine": 1,
+      "endLine": 30
+    },
+    "title": "Problem Statement and Background",
+    "content": "States Erdős Problem #425 (1968, partially solved): the maximum size $F(n)$ of a multiplicative Sidon subset of $\\{1,\\ldots,n\\}$. Poses two open questions (a single-constant refinement of the $n^{3/4}(\\log n)^{-3/2}$ secondary term, and the $r$-fold generalization) and summarizes Erdős's bounds and Alexander's disproof of the real-version conjecture.",
+    "significance": "key",
+    "mathContext": "The header fixes the extremal-function framing used by every later section: $F(n)$ counts subsets where all pairwise products $ab$ ($a<b$) are distinct. Erdős's 1968 bounds $\\pi(n) + c_1 n^{3/4}(\\log n)^{-3/2} \\le F(n) \\le \\pi(n) + c_2 n^{3/4}(\\log n)^{-3/2}$ are stated here as background before being formalized as the `erdos_bounds` axiom later in the file.",
+    "relatedConcepts": [
+      "multiplicative Sidon sets",
+      "prime counting function",
+      "asymptotic bounds"
+    ],
+    "prerequisites": [
+      "basic number theory",
+      "asymptotic notation"
+    ]
+  },
+  {
     "id": "ann-425-imports",
     "proofId": "erdos-425",
     "type": "concept",

--- a/src/data/proofs/erdos-425/meta.json
+++ b/src/data/proofs/erdos-425/meta.json
@@ -76,6 +76,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Header and Background",
+      "summary": "Docstring header: states the problem, the two open questions (single-constant asymptotics; $r$-fold generalization), Erdős's 1968 bounds, and the real-number version with Alexander's disproof of the $o(x)$ conjecture. Lists the three source references [Er68], [Er73], [ErGr80].",
+      "startLine": 1,
+      "endLine": 30,
+      "mathContext": "Sets up notation used throughout: $F(n)$ for the integer extremal function, the conjectured secondary term $n^{3/4}(\\log n)^{-3/2}$, and the real-valued analogue on $A \\subset [1,x]$ with $|ab-cd|\\ge 1$."
+    },
+    {
       "id": "imports",
       "title": "Imports and Namespace",
       "summary": "Imports `Nat.Prime`, `Finset`, `Primorial`, and `Real.Basic`. Opens `Erdos425` namespace for all definitions and theorems.",


### PR DESCRIPTION
## Summary
- Adds a `header` section and `ann-425-header` annotation covering lines 1-30 of `Proofs/Erdos425Problem.lean` — the docstring stating Erdős Problem #425 (multiplicative Sidon sets), its open questions, Erdős's 1968 bounds, and Alexander's disproof of the real-version conjecture — which had zero prior section/annotation coverage.
- No other content changed; file remains well under the 60 KB cap (~14.9 KB meta.json / ~13.1 KB annotations.json).

## Test plan
- [x] `pnpm build` passes
- [x] Verified via `git show origin/main:src/data/proofs/erdos-425/{meta,annotations}.json` that lines 1-30 had no prior coverage (min section/annotation startLine was 31)