### PR TITLE
Enrich erdos-621: cover header docstring (lines 1-19)

### DIFF
--- a/src/data/proofs/erdos-621/annotations.json
+++ b/src/data/proofs/erdos-621/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "ann-621-header",
+    "proofId": "erdos-621",
+    "range": {
+      "startLine": 1,
+      "endLine": 19
+    },
+    "type": "concept",
+    "title": "Problem Statement and Resolution",
+    "content": "States the Erdős-Gallai-Tuza conjecture (1996): for a graph $G$ on $n$ vertices, is $\\alpha_1(G) + \\tau_1(G) \\le n^2/4$, where $\\alpha_1$ is the maximum triangle-sparse edge set and $\\tau_1$ the minimum triangle edge cover? Records that Norin-Sun (2016) resolved it by proving the stronger bound $\\alpha_1(G) + \\tau_B(G) \\le n^2/4$ with $\\tau_B$ the bipartite edge-deletion number, and that $\\tau_1 \\le \\tau_B$ makes the original conjecture immediate.",
+    "mathContext": "Fixes the two invariants used throughout the file: $\\alpha_1(G)$ generalizes the matching-style independence notion to triangles (edges hitting at most one edge per triangle), while $\\tau_1(G)$ generalizes vertex/edge covers to triangle transversals. The $n^2/4$ bound echoes Mantel's theorem, later formalized as the triangle-free special case.",
+    "significance": "key",
+    "relatedConcepts": [
+      "triangle edge cover",
+      "Norin-Sun theorem",
+      "bipartite edge deletion",
+      "Mantel's theorem"
+    ],
+    "prerequisites": [
+      "graph theory basics",
+      "extremal combinatorics"
+    ]
+  },
+  {
     "id": "ann-621-imports",
     "proofId": "erdos-621",
     "range": {

--- a/src/data/proofs/erdos-621/meta.json
+++ b/src/data/proofs/erdos-621/meta.json
@@ -47,6 +47,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Header and Background",
+      "summary": "Docstring header: states the Erdős-Gallai-Tuza conjecture $\\alpha_1(G) + \\tau_1(G) \\le n^2/4$, notes the 2016 Norin-Sun resolution via the stronger bipartite-removal bound, and records the 1996 Erdős-Gallai-Tuza remark that the problem 'is probably quite difficult.'",
+      "startLine": 1,
+      "endLine": 19,
+      "mathContext": "Introduces $\\alpha_1(G)$ (maximum triangle-sparse edge set) and $\\tau_1(G)$ (minimum triangle edge cover) — the invariants formalized and related throughout the rest of the file."
+    },
+    {
       "id": "imports",
       "title": "Imports and Setup",
       "summary": "Imports Mathlib's `SimpleGraph`, `Clique`, `Fintype`, and tactic libraries. Opens the `SimpleGraph`, `Finset`, and `Classical` namespaces and enables classical decidability for propositions.",


### PR DESCRIPTION
## Summary
- Adds a `header` section and `ann-621-header` annotation covering lines 1-19 of `Proofs/Erdos621Problem.lean` — the docstring stating the Erdős-Gallai-Tuza triangle edge cover conjecture and its 2016 Norin-Sun resolution — which had zero prior section/annotation coverage.
- No other content changed; file remains well under the 60 KB cap (~16.3 KB meta.json / ~25.1 KB annotations.json).

## Test plan
- [x] `pnpm build` passes
- [x] Verified via `git show origin/main:src/data/proofs/erdos-621/{meta,annotations}.json` that lines 1-19 had no prior coverage (min section/annotation startLine was 22)