### PR TITLE
Fix angle-trisection-oq-05-oq-03: realign section/annotation boundaries

### DIFF
--- a/src/data/proofs/angle-trisection-oq-05-oq-03/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-05-oq-03/annotations.json
@@ -130,7 +130,7 @@
     "proofId": "angle-trisection-oq-05-oq-03",
     "range": {
       "startLine": 100,
-      "endLine": 156
+      "endLine": 183
     },
     "type": "insight",
     "title": "minFoldLevel for Small Primes: 1, 2, 3, 5, 7, 11",
@@ -155,8 +155,8 @@
     "id": "multiplicative-property",
     "proofId": "angle-trisection-oq-05-oq-03",
     "range": {
-      "startLine": 160,
-      "endLine": 175
+      "startLine": 184,
+      "endLine": 201
     },
     "type": "insight",
     "title": "minFoldLevel_mul: The Dominant Prime Controls",
@@ -180,8 +180,8 @@
     "id": "concrete-computations",
     "proofId": "angle-trisection-oq-05-oq-03",
     "range": {
-      "startLine": 177,
-      "endLine": 237
+      "startLine": 202,
+      "endLine": 262
     },
     "type": "insight",
     "title": "Concrete Fold Levels: 6, 10, 14, 15, 42",
@@ -207,8 +207,8 @@
     "id": "unboundedness",
     "proofId": "angle-trisection-oq-05-oq-03",
     "range": {
-      "startLine": 240,
-      "endLine": 248
+      "startLine": 264,
+      "endLine": 275
     },
     "type": "insight",
     "title": "minFoldLevel_unbounded: Arbitrarily Many Folds Required",
@@ -226,6 +226,27 @@
       "minFoldLevel_nth_prime j hj: minFoldLevel (foldPrimeBound j) = j",
       "nth_prime_not_constructible_below: foldPrimeBound (j+1) is NOT j-fold constructible",
       "Nat.infinite_setOf_prime: used to ensure Nat.nth prime k exists for all k"
+    ]
+  },
+  {
+    "id": "summary-block",
+    "proofId": "angle-trisection-oq-05-oq-03",
+    "range": {
+      "startLine": 276,
+      "endLine": 298
+    },
+    "type": "context",
+    "title": "Closing Summary: The Dominant-Prime Answer",
+    "content": "The file's closing docstring restates the answer to open question OQ-05-OQ-03 in one line — minFoldLevel(d) = max{ j ≥ 1 : p_j divides d }, the prime-sequence index of d's largest prime factor — then catalogs all 8 results proved earlier (generalized monotonicity, multiplicativity, the `Nat.find`-based definition and its ≤-characterization, exact prime fold levels, the max-multiplicative property, the five concrete computations, and unboundedness) as a numbered ledger. It records the file's status (0 axioms, 0 sorries) and its dependency on the two prior files in the series, `AngleTrisectionOQ05OQ01` and `AngleTrisectionOQ05OQ02`.",
+    "mathContext": "$\\mathrm{minFoldLevel}(d) = \\max\\{j \\ge 1 : p_j \\mid d\\}$ — the dominant prime factor's index in the odd-prime sequence determines the fold count exactly.",
+    "significance": "context",
+    "relatedConcepts": [
+      "minFoldLevel",
+      "AngleTrisectionOQ05OQ01",
+      "AngleTrisectionOQ05OQ02"
+    ],
+    "prerequisites": [
+      "all theorems proved earlier in this file"
     ]
   }
 ]

--- a/src/data/proofs/angle-trisection-oq-05-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-05-oq-03/meta.json
@@ -109,31 +109,31 @@
       "id": "prime-fold-levels",
       "title": "Exact Fold Level for Primes and Concrete Values",
       "startLine": 100,
-      "endLine": 157,
+      "endLine": 183,
       "summary": "Proves minFoldLevel(foldPrimeBound j) = j for j ≥ 1. Computes concrete values: minFoldLevel 1 = 1, minFoldLevel 2 = 1, minFoldLevel 3 = 1, minFoldLevel 5 = 2, minFoldLevel 7 = 3, minFoldLevel 11 = 4.",
       "mathContext": "The $j$-th prime $p_j$ requires exactly $j$ simultaneous folds: it is $j$-fold constructible (since $p_j = p_j$) but not $(j-1)$-fold (since $p_j > p_{j-1}$)."
     },
     {
       "id": "multiplicative-property",
       "title": "Multiplicative Property and Product Computations",
-      "startLine": 158,
-      "endLine": 237,
+      "startLine": 184,
+      "endLine": 262,
       "summary": "Proves minFoldLevel(m*n) = max(minFoldLevel m, minFoldLevel n). Computes: minFoldLevel 6 = 1, minFoldLevel 10 = 2, minFoldLevel 15 = 2, minFoldLevel 14 = 3, minFoldLevel 42 = 3.",
       "mathContext": "The minimum fold level of a product is the max of the individual levels: $\\mathrm{minFoldLevel}(2 \\cdot 3 \\cdot 7) = \\max(1, 1, 3) = 3$."
     },
     {
       "id": "unboundedness",
       "title": "Unboundedness of minFoldLevel",
-      "startLine": 238,
-      "endLine": 249,
+      "startLine": 264,
+      "endLine": 275,
       "summary": "Proves minFoldLevel is unbounded: for any K, there exists d with minFoldLevel(d) > K. The witness is foldPrimeBound(K+1) = p_{K+1}.",
       "mathContext": "No fixed fold count suffices for all degrees: for each $K$, the $(K+1)$-th prime $p_{K+1}$ requires exactly $K+1$ folds. The set of fold levels is $\\{1, 2, 3, \\ldots\\}$, achieved by successive primes."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 250,
-      "endLine": 272,
+      "startLine": 276,
+      "endLine": 298,
       "summary": "Closing summary docstring restating the answer (minFoldLevel(d) = max{ j ≥ 1 : p_j ∣ d }) and listing the eight key results: generalized monotonicity, multiplicativity, the Nat.find definition, the ≤-characterization, exact prime fold levels, the max-multiplicative property, concrete computations (e.g. minFoldLevel 42 = 3), and unboundedness. Records status: 0 axioms, 0 sorries.",
       "mathContext": "The dominant-prime-factor description: minFoldLevel(d) is determined by the largest prime dividing d (e.g. $42 = 2\\cdot3\\cdot7$ has dominant prime $7 = p_3$, so minFoldLevel $= 3$)."
     }


### PR DESCRIPTION
## Summary
A systematic ~26-line drift had crept into every section/annotation boundary after `prime-fold-levels`, apparently from content (the `minFoldLevel_five`/`_seven`/`_eleven` theorems, lines 158-183) that was added without updating downstream boundaries. This mislabeled, not just under-covered: the `multiplicative-property` annotation (previously lines 160-175) pointed at parts of `minFoldLevel_five`/`_seven`, while its content described `minFoldLevel_mul` (actually at lines 184-201).

Fixes, verified line-by-line against the source (`grep -n "^theorem\|^/-! ##"`):
- `prime-fold-levels`: extended 100-157 → 100-183 (now includes `minFoldLevel_five/_seven/_eleven`, previously uncovered)
- `multiplicative-property`: corrected 158-237 (meta) / 160-175 (annotation) → 184-201/262 to actually point at `minFoldLevel_mul` and the concrete-computation theorems
- `concrete-computations` (annotation only): corrected 177-237 → 202-262
- `unboundedness`: corrected 238-249 → 264-275
- `summary` (meta section): corrected 250-272 → 276-298
- Added a new `summary-block` annotation (276-298) — the closing docstring had zero annotation coverage under any boundary

## Test plan
- [x] Validated `meta.json` and `annotations.json` are well-formed JSON
- [x] Verified every corrected boundary against `grep -n "^theorem\|^/-! ##"` output from the actual Lean source