### PR TITLE
Enrich lebesgue-measure-oq-03: cover closing concentration/summary block

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-03/annotations.json
+++ b/src/data/proofs/lebesgue-measure-oq-03/annotations.json
@@ -119,5 +119,23 @@
       "isoperimetric inequalities",
       "Gaussian tail bounds"
     ]
+  },
+  {
+    "id": "ann-closing-summary",
+    "proofId": "lebesgue-measure-oq-03",
+    "range": {
+      "startLine": 113,
+      "endLine": 137
+    },
+    "type": "context",
+    "title": "File Summary and the Prose-Only '3 Axioms' Claim",
+    "content": "Closes with a second, near-duplicate paraphrase of the concentration-of-measure remark, then a 'Summary' comment listing four key results (impossibility of translation-invariant measure, Gaussian measures as replacement, Wiener measure for Brownian motion, vanishing unit-ball volume) and a status line. The status line says '3 axioms (impossibility, Gaussian existence, Wiener existence)', but this file declares no `axiom`s at all — those three results are documented only in prose comments (Part I-III above), never formalized as Lean `axiom` or `theorem` declarations. The gallery's meta.json correctly reports `axiomCount: 0` and `theoremCount: 2` (only `orthonormal_dist` and `orthonormal_balls_disjoint` are proved); the in-source comment's axiom count is aspirational, describing a future formalization pass rather than this file's actual content.",
+    "mathContext": "Only 2 declarations are proved in this file: `orthonormal_dist` and `orthonormal_balls_disjoint`. The impossibility theorem, Gaussian measure existence, and Wiener measure existence remain informal prose — 0 of the '3 axioms' mentioned in the closing comment are actually declared as `axiom` in the source.",
+    "significance": "context",
+    "relatedConcepts": [
+      "axiom disclosure accuracy",
+      "prose-only vs. formalized claims"
+    ],
+    "prerequisites": []
   }
 ]

--- a/src/data/proofs/lebesgue-measure-oq-03/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-03/meta.json
@@ -89,6 +89,14 @@
       "endLine": 112,
       "summary": "Framework section describing Wiener measure as the canonical Gaussian measure on path space.",
       "mathContext": "Wiener measure is the distribution of Brownian motion $W: [0,1] \\to \\mathbb{R}$ with $W(0) = 0$, independent increments, and $W(t) - W(s) \\sim \\mathcal{N}(0, t-s)$. The Wiener measure lives on $C([0,1], \\mathbb{R})$, which is the Banach completion of the Cameron-Martin Hilbert space $H = \\{f: [0,1] \\to \\mathbb{R} \\mid f(0)=0, f' \\in L^2\\}$ with inner product $\\langle f, g \\rangle = \\int_0^1 f'(t)g'(t)dt$."
+    },
+    {
+      "id": "closing-summary",
+      "title": "Concentration of Measure and File Summary",
+      "startLine": 113,
+      "endLine": 137,
+      "summary": "A second, slightly reworded restatement of the concentration-of-measure comment (a Lipschitz function on the sphere $S^{n-1}$ is approximately constant on most of the sphere in high dimensions), followed by the closing Summary comment: a 4-item results ledger (impossibility, Gaussian measures, Wiener measure, vanishing ball volume) and a status line. Note the status line's '3 axioms' claim is prose only — the file has zero `axiom` declarations; meta.json's axiomCount: 0 is the accurate figure, matching only the two proved theorems (orthonormal_dist, orthonormal_balls_disjoint) plus unformalized commentary.",
+      "mathContext": "Concentration of measure on $S^{n-1}$ is the quantitative form of the impossibility argument: as dimension grows, mass concentrates on thin shells rather than spreading translation-invariantly."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Adds section `closing-summary` and annotation `ann-closing-summary` covering lines 113-137, the file's closing block (a duplicate concentration-of-measure paraphrase + the "Summary" comment), which had zero section coverage and zero annotation coverage before.
- The annotation flags an accuracy note worth having on record: the closing comment's "3 axioms" claim doesn't correspond to any actual `axiom` declaration in the file (`grep -n axiom` finds only this comment line, not a declaration) — `meta.json`'s `axiomCount: 0` / `theoremCount: 2` is already the accurate figure, so no meta.json change was needed, just documenting the discrepancy in the new annotation for readers of the source.

## Test plan
- [x] Validated `meta.json` and `annotations.json` are well-formed JSON
- [x] Confirmed via `grep -n axiom` that the file has zero `axiom` declarations, consistent with the existing `axiomCount: 0`
- [x] Confirmed the new range (113-137) matches the actual source boundaries (file ends at line 137)