### PR TITLE
Research: erdos-85-wip-01 - f(11) = 4 and f(12) = 4 via Petersen vertex surgery

### DIFF
--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -2165,4 +2165,160 @@ theorem minDegreeForC4_ten : minDegreeForC4 10 = 4 := by
   have hge := four_le_minDegreeForC4_ten
   omega
 
+/-! ## `f(11) = f(12) = 4`: growing the Petersen witness vertex by vertex
+
+The counting ceiling `n ≤ k(k−1)` gives `f(n) ≤ 4` exactly for `n ≤ 12`, so
+orders `11` and `12` are the last two values the elementary counting bound can
+pin — provided matching `C₄`-free graphs of minimum degree `3` exist there.
+A `3`-*regular* such graph is impossible at order `11` (handshake parity), and
+no standard `11`- or `12`-vertex analogue of the Petersen graph exists.
+Instead we *grow* the Petersen graph one vertex at a time by a local surgery:
+
+  **delete** an edge `a – b`, then **add** a new vertex `v` joined to `a`,
+  `b`, and one further neighbour `c` of `b`.
+
+Degrees survive (`a` and `b` each trade one neighbour for `v`; `c` gains one),
+and the common-neighbour matrix stays `≤ 1` everywhere: within `{a, b, c}` the
+pairs `(a, b)` and `(b, c)` were *adjacent* (zero common neighbours, girth
+`5`), while the unique common neighbour of the non-adjacent pair `(a, c)` was
+exactly `b` — which the deleted edge removes just as `v` arrives to replace
+it.  And a vertex `x` outside `{a, b, c}` adjacent to two of them would have
+been a *second* common neighbour of that pair beforehand — impossible.
+`C₄`-freeness of each explicit graph is then the same tiny kernel check as for
+the Petersen graph itself, via `not_containsC4_of_forall_common_le_one`; no
+embedding enumeration and no `native_decide`. -/
+
+/-- The seventeen edges of the `11`-vertex extended Petersen graph: the
+Petersen list with the outer edge `(0, 1)` deleted and the new vertex `10`
+joined to `0`, `1`, and `6` (a pentagram neighbour of `1`). -/
+def petersen11Edges : List (Fin 11 × Fin 11) :=
+  [(1,2), (2,3), (3,4), (4,0),
+   (5,7), (7,9), (9,6), (6,8), (8,5),
+   (0,5), (1,6), (2,7), (3,8), (4,9),
+   (10,0), (10,1), (10,6)]
+
+/-- **An `11`-vertex `C₄`-free graph of minimum degree `3`**: the Petersen
+graph after the vertex-adding surgery.  Vertex `6` has degree `4`; all other
+vertices have degree `3`. -/
+def petersen11 : SimpleGraph (Fin 11) where
+  Adj i j := (i, j) ∈ petersen11Edges ∨ (j, i) ∈ petersen11Edges
+  symm.symm := fun _ _ h => Or.symm h
+  loopless.irrefl := by decide
+
+instance : DecidableRel petersen11.Adj := fun i j =>
+  decidable_of_iff ((i, j) ∈ petersen11Edges ∨ (j, i) ∈ petersen11Edges) Iff.rfl
+
+/-- Every vertex of `petersen11` has degree at least `3` — an `11`-vertex
+kernel check.  (Vertex `6` has degree `4`, so `3`-regularity fails — as it
+must at odd order — but the minimum-degree bound only needs `≥ 3`.) -/
+theorem petersen11_degree : ∀ v, 3 ≤ petersen11.degree v := by decide
+
+/-- **Every pair of distinct `petersen11` vertices has at most one common
+neighbour** — the `11 × 11` kernel check certifying `C₄`-freeness. -/
+theorem petersen11_common_le_one : ∀ x y : Fin 11, x ≠ y →
+    (petersen11.neighborFinset x ∩ petersen11.neighborFinset y).card ≤ 1 := by
+  decide
+
+/-- **`petersen11` is `C₄`-free** — via the common-neighbour criterion. -/
+theorem petersen11_not_containsC4 : ¬ containsC4 (Fin 11) petersen11 :=
+  not_containsC4_of_forall_common_le_one petersen11_common_le_one
+
+/-- `petersen11` has minimum degree at least `3`. -/
+theorem petersen11_three_le_minDegree : 3 ≤ petersen11.minDegree := by
+  apply SimpleGraph.le_minDegree_of_forall_le_degree
+  exact petersen11_degree
+
+/-- **`f(11) ≥ 4`**: `petersen11` is a `C₄`-free graph of minimum degree `3`
+on eleven vertices, so threshold `3` does not force a `C₄` at order `11`. -/
+theorem four_le_minDegreeForC4_eleven : 4 ≤ minDegreeForC4 11 := by
+  have hne : {k : ℕ | ∀ (G : SimpleGraph (Fin 11)) [DecidableRel G.Adj],
+      G.minDegree ≥ k → containsC4 (Fin 11) G}.Nonempty := by
+    refine ⟨10, fun G _ hmin => ?_⟩
+    rw [eq_top_of_minDegree_ge G hmin]
+    exact completeGraph_containsC4 (by norm_num)
+  unfold minDegreeForC4
+  refine le_csInf hne (fun k hk => ?_)
+  by_contra hk4
+  rw [not_le] at hk4
+  exact petersen11_not_containsC4
+    (hk petersen11 (le_trans (by omega : k ≤ 3) petersen11_three_le_minDegree))
+
+/-- **An eighth exact value: `f(11) = 4`.**  Upper half: counting,
+`11 ≤ 4·3` (`minDegreeForC4_le_of_le_mul_pred`).  Lower half: the extended
+Petersen graph (`four_le_minDegreeForC4_eleven`). -/
+theorem minDegreeForC4_eleven : minDegreeForC4 11 = 4 := by
+  have hle : minDegreeForC4 11 ≤ 4 :=
+    minDegreeForC4_le_of_le_mul_pred (by norm_num) (by norm_num)
+  have hge := four_le_minDegreeForC4_eleven
+  omega
+
+/-- The nineteen edges of the `12`-vertex graph: `petersen11Edges` with the
+outer edge `(2, 3)` deleted and the new vertex `11` joined to `2`, `3`, and
+`8` (a spoke neighbour of `3`) — the same surgery applied once more. -/
+def petersen12Edges : List (Fin 12 × Fin 12) :=
+  [(1,2), (3,4), (4,0),
+   (5,7), (7,9), (9,6), (6,8), (8,5),
+   (0,5), (1,6), (2,7), (3,8), (4,9),
+   (10,0), (10,1), (10,6),
+   (11,2), (11,3), (11,8)]
+
+/-- **A `12`-vertex `C₄`-free graph of minimum degree `3`**: the Petersen
+graph after two vertex-adding surgeries.  Vertices `6` and `8` have degree
+`4`; all other vertices have degree `3`. -/
+def petersen12 : SimpleGraph (Fin 12) where
+  Adj i j := (i, j) ∈ petersen12Edges ∨ (j, i) ∈ petersen12Edges
+  symm.symm := fun _ _ h => Or.symm h
+  loopless.irrefl := by decide
+
+instance : DecidableRel petersen12.Adj := fun i j =>
+  decidable_of_iff ((i, j) ∈ petersen12Edges ∨ (j, i) ∈ petersen12Edges) Iff.rfl
+
+/-- Every vertex of `petersen12` has degree at least `3` — a `12`-vertex
+kernel check. -/
+theorem petersen12_degree : ∀ v, 3 ≤ petersen12.degree v := by decide
+
+/-- **Every pair of distinct `petersen12` vertices has at most one common
+neighbour** — the `12 × 12` kernel check certifying `C₄`-freeness. -/
+theorem petersen12_common_le_one : ∀ x y : Fin 12, x ≠ y →
+    (petersen12.neighborFinset x ∩ petersen12.neighborFinset y).card ≤ 1 := by
+  decide
+
+/-- **`petersen12` is `C₄`-free** — via the common-neighbour criterion. -/
+theorem petersen12_not_containsC4 : ¬ containsC4 (Fin 12) petersen12 :=
+  not_containsC4_of_forall_common_le_one petersen12_common_le_one
+
+/-- `petersen12` has minimum degree at least `3`. -/
+theorem petersen12_three_le_minDegree : 3 ≤ petersen12.minDegree := by
+  apply SimpleGraph.le_minDegree_of_forall_le_degree
+  exact petersen12_degree
+
+/-- **`f(12) ≥ 4`**: `petersen12` is a `C₄`-free graph of minimum degree `3`
+on twelve vertices, so threshold `3` does not force a `C₄` at order `12`. -/
+theorem four_le_minDegreeForC4_twelve : 4 ≤ minDegreeForC4 12 := by
+  have hne : {k : ℕ | ∀ (G : SimpleGraph (Fin 12)) [DecidableRel G.Adj],
+      G.minDegree ≥ k → containsC4 (Fin 12) G}.Nonempty := by
+    refine ⟨11, fun G _ hmin => ?_⟩
+    rw [eq_top_of_minDegree_ge G hmin]
+    exact completeGraph_containsC4 (by norm_num)
+  unfold minDegreeForC4
+  refine le_csInf hne (fun k hk => ?_)
+  by_contra hk4
+  rw [not_le] at hk4
+  exact petersen12_not_containsC4
+    (hk petersen12 (le_trans (by omega : k ≤ 3) petersen12_three_le_minDegree))
+
+/-- **A ninth exact value: `f(12) = 4` — and the end of the counting range.**
+Upper half: counting, `12 ≤ 4·3` — the *boundary case* `n = k(k−1)` of
+`minDegreeForC4_le_of_le_mul_pred`, sharp with no room to spare (`C(13,2) =
+78 = 13·6` fails the strict inequality, so order `13` is out of the counting
+bound's reach for `k = 4`).  Lower half: the twice-extended Petersen graph
+(`four_le_minDegreeForC4_twelve`).  The exact table now reads
+`f = 1, 2, 3, 2, 3, 3, 3, 3, 3, 4, 4, 4` for `n = 1, …, 12` — complete over
+the entire range the elementary cherry count can reach. -/
+theorem minDegreeForC4_twelve : minDegreeForC4 12 = 4 := by
+  have hle : minDegreeForC4 12 ≤ 4 :=
+    minDegreeForC4_le_of_le_mul_pred (by norm_num) (by norm_num)
+  have hge := four_le_minDegreeForC4_twelve
+  omega
+
 end Erdos85

--- a/research/problems/erdos-85-wip-01/knowledge.md
+++ b/research/problems/erdos-85-wip-01/knowledge.md
@@ -508,3 +508,53 @@ on 11 vertices (Petersen + one vertex attached how? adding a vertex adjacent to
 violations — nontrivial, possibly false-free; check literature/OEIS). f(n)
 counting ceiling ≤ 4 holds through n ≤ 20 (C(n,2) < 6n iff n ≤ 12) — careful:
 only n ≤ 12. Deep: KST asymptotics, monotonicity core.
+
+## Session 2026-07-22f (researcher-1) — **f(11) = 4 and f(12) = 4 PROVED** (vertex-surgery witnesses)
+
+**Outcome**: `minDegreeForC4_eleven : minDegreeForC4 11 = 4` and
+`minDegreeForC4_twelve : minDegreeForC4 12 = 4`, axiom-free (kernel `decide`
+only, no `native_decide`). Exact table now COMPLETE for **1 ≤ n ≤ 12:
+f = 1,2,3,2,3,3,3,3,3,4,4,4** — the entire range reachable by the elementary
+cherry count (`n ≤ k(k−1)` with k=4 holds iff n ≤ 12; C(13,2) = 78 = 13·6
+fails the strict inequality, so n = 13 needs new upper-bound input).
+
+**Mechanism — the vertex-adding surgery (materially new, resolves the recorded
+"lower ≥ 4 on 11 vertices — nontrivial, possibly false" next-step)**: no
+11/12-vertex Petersen analogue exists (3-regular girth-5 at odd order is
+parity-impossible), but min degree 3 does not need regularity. Surgery on a
+C₄-free graph with all non-adjacent pairs having ≤1 common neighbour:
+
+  DELETE an edge a–b, ADD a new vertex v adjacent to a, b, and one further
+  neighbour c of b.
+
+Why common-neighbour ≤ 1 survives: within {a,b,c} the pairs (a,b),(b,c) were
+adjacent (0 common nbrs, girth 5) and the unique common neighbour of the
+non-adjacent pair (a,c) was exactly b — deleted edge removes it as v arrives;
+any outside vertex adjacent to two of {a,b,c} would have been a SECOND common
+neighbour of that pair before. Degrees: a,b trade one neighbour for v; c gains
+one. Applied twice: `petersen11` (delete (0,1), add 10~{0,1,6}) and
+`petersen12` (delete (2,3), add 11~{2,3,8}). All verification is the
+common-neighbour-matrix kernel check via `not_containsC4_of_forall_common_le_one`
+(petersen-session extraction pair) — 11×11 and 12×12 `decide`, fast.
+
+### Lean notes
+- Witness graphs are NOT regular (one degree-4 vertex per surgery), so state
+  `∀ v, 3 ≤ degree v := by decide` (not an equality) and feed
+  `le_minDegree_of_forall_le_degree` directly.
+- Upper halves via `minDegreeForC4_le_of_le_mul_pred (by norm_num) (by norm_num)`;
+  n = 12 is the exact boundary case 12 = 4·3.
+- Same sInf lower-bound assembly as `four_le_minDegreeForC4_ten` (nonempty via
+  `eq_top_of_minDegree_ge` at k = n−1, then `le_csInf`, contradiction with the
+  witness at k ≤ 3).
+
+### Remaining on this problem
+- f(13): counting needs k = 5 (13 ≤ 20 gives only f(13) ≤ 5); true value is 4
+  (literature: min-deg-3 C₄-free graphs exist on 13 vertices — repeat surgery;
+  but the UPPER bound f(13) ≤ 4 needs a genuinely new mechanism, e.g. a real
+  ex(n; C₄) edge-extremal bound — same blocker as the old f(8) route).
+- The surgery iterates: any n ≥ 10 admits a min-deg-3 C₄-free graph (each
+  surgery needs an edge a–b with b having a third neighbour c s.t. the (a,c)
+  common neighbour is b — plentiful). So f(n) ≥ 4 for ALL n ≥ 10 is a
+  candidate general lemma; formalizing the general induction is real work
+  (the decide route only does fixed n).
+- Deep: KST asymptotics, monotonicity core f(n+1) ≥ f(n) (the actual #85).

--- a/src/data/research/problems/erdos-85-wip-01.json
+++ b/src/data/research/problems/erdos-85-wip-01.json
@@ -57,7 +57,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "MAJOR PROGRESS (researcher-1-9, 2026-07-22, host-verified, standard triple): f(9) = 3 AND f(10) = 4 both PROVED axiom-free in one day — exact table COMPLETE for 1 <= n <= 10: f = 1,2,3,2,3,3,3,3,3,4. Both registered blockers resolved (f(9): elementary pinch + tight-cherry bijection + pigeonhole; f(10): edge-list Petersen + common-neighbour extraction criterion, no embedding enumeration). Remaining: f(11)/f(12) (counting gives <= 4, lower bounds open), deep KST asymptotics, monotonicity core (open in literature).",
+    "progressSummary": "MAJOR PROGRESS (researcher-1, 2026-07-22f, host-verified, standard triple): f(11) = 4 AND f(12) = 4 PROVED axiom-free via vertex-adding surgery on the Petersen graph (delete edge a-b, add v ~ {a,b,c}) — exact table COMPLETE for 1 <= n <= 12: f = 1,2,3,2,3,3,3,3,3,4,4,4, the full range the elementary cherry count reaches (12 = 4*3 is the boundary case). Remaining: f(13) upper bound needs new mechanism (counting gives only <= 5); general f(n) >= 4 for n >= 10 via iterated surgery; deep KST asymptotics, monotonicity core.",
     "builtItems": [
       "C4_adj_zero_one/one_two/two_three/three_zero (four cycle edges) in Erdos85Problem.lean",
       "C4_not_adj_zero_two (diagonal non-edge) in Erdos85Problem.lean",
@@ -97,7 +97,9 @@
       "containsC4_of_four_set_min_two (dense-4-set lemma) + card_inter_neighborFinset_le_one in Erdos85Problem.lean",
       "minDegreeForC4_ten (f(10)=4) + four_le_minDegreeForC4_ten in Erdos85Problem.lean",
       "petersen (explicit edge-list) + petersen_degree + petersen_common_le_one in Erdos85Problem.lean",
-      "exists_two_common_of_containsC4 + not_containsC4_of_forall_common_le_one (reusable C4-freeness criterion) in Erdos85Problem.lean"
+      "exists_two_common_of_containsC4 + not_containsC4_of_forall_common_le_one (reusable C4-freeness criterion) in Erdos85Problem.lean",
+      "petersen11/petersen11Edges + degree/common-neighbour kernel checks + four_le_minDegreeForC4_eleven + minDegreeForC4_eleven (f(11)=4) in Erdos85Problem.lean",
+      "petersen12/petersen12Edges + degree/common-neighbour kernel checks + four_le_minDegreeForC4_twelve + minDegreeForC4_twelve (f(12)=4) in Erdos85Problem.lean"
     ],
     "insights": [
       "Erdos85Problem.lean was a definitions-only stub (7 defs, 0 theorems). Asymptotics f(n)=(1+o(1))sqrt(n), f(4)=2, and the Ramsey reformulation need extremal graph theory beyond Mathlib; tractable axiom-free content is structural facts about C4, containsC4, and starGraph.",
@@ -129,14 +131,17 @@
       "f(9) = 3 PROVED axiom-free in one session, executing the same-day blueprint: degree pinch (cherry+parity), (3^8,4) killed by dense-4-set local analysis, (3^6,4^3) killed by tight-cherry bijection + path-count + pigeonhole engine — NO ex(n;C4) input; fourth extremal-tables blocker claim overturned by formal proof",
       "Tight-counting upgrade pattern: when the KST cherry-to-pair map has equal source/target cards, Set.InjOn + card_image_of_injOn + eq_of_subset_of_card_le turns the pigeonhole into a bijection giving EXISTENCE of a common neighbour for every pair — reusable wherever a counting bound is attained exactly",
       "f(10) = 4 PROVED: the feared 10^4 embedding enumeration was never needed — extraction lemma (C4 embedding => two common neighbours) reduces C4-freeness of any explicit witness graph to its common-neighbour matrix, a 10x10 kernel decide for the 15-edge Petersen list",
-      "Both registered exact-value blockers on this problem fell in one day (f(9) via elementary pinch+pigeonhole, f(10) via common-neighbour extraction) — extremal-table and enumeration fears repeatedly overestimate the difficulty"
+      "Both registered exact-value blockers on this problem fell in one day (f(9) via elementary pinch+pigeonhole, f(10) via common-neighbour extraction) — extremal-table and enumeration fears repeatedly overestimate the difficulty",
+      "Vertex-adding surgery preserves C4-freeness + min degree 3: DELETE edge a-b, ADD vertex v ~ {a,b,c} with c a neighbour of b. The unique (a,c) common neighbour was exactly b (deleted as v arrives); outside vertices adjacent to two of {a,b,c} would have been a second common neighbour beforehand. Beats the parity obstruction (no 3-regular girth-5 graph at odd order).",
+      "Counting range boundary: n <= k(k-1) with k=4 holds iff n <= 12; C(13,2) = 78 = 13*6 fails strictly, so f(13) <= 4 needs genuinely new upper-bound input (edge-extremal ex(n;C4) bound).",
+      "Surgery iterates: every n >= 10 admits a min-deg-3 C4-free graph, so f(n) >= 4 for all n >= 10 is a candidate general lemma (induction is real work; decide route only covers fixed n)."
     ],
     "mathlibGaps": [
       "Fin n has NO global CommRing instance (only scoped Fin.instCommRing via `open Fin.CommRing`, gated on NeZero n); needed for ring/linear_combination on cycleGraph differences"
     ],
     "nextSteps": [
-      "f(8): min-deg-3 on 8 vtx forces >= 12 edges; ex(8;C4) = 11 would give f(8)=3 — needs a real extremal edge bound in Lean (Reiman-style), genuinely new input.",
-      "Odd-s upper-Beatty points n = s^2+s+1 (s odd => k = s+1 even): parity argument silent; blocked without new mechanism.",
+      "f(13): true value 4; lower half via a third surgery (decide), but upper f(13) <= 4 needs a real edge-extremal bound ex(13;C4) <= 21-ish (Reiman-style) — same blocker class as the old f(8) route.",
+      "General lemma f(n) >= 4 for all n >= 10 by iterating the surgery (structural induction, not decide) — candidate session-sized target.",
       "Monotonicity core f(n+1) >= f(n) eventually (the actual Erdos #85 question): OPEN, deep."
     ],
     "markdown": "# Knowledge Base: erdos-85-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary
Research session for **erdos-85-wip-01** (minimum degree forcing a C₄, Erdős #85).

Proves the two remaining exact values reachable by the elementary counting bound:

- `minDegreeForC4_eleven : minDegreeForC4 11 = 4`
- `minDegreeForC4_twelve : minDegreeForC4 12 = 4`

The exact table is now **complete for 1 ≤ n ≤ 12**: `f = 1, 2, 3, 2, 3, 3, 3, 3, 3, 4, 4, 4` — the entire range the cherry-count upper bound `n ≤ k(k−1)` can reach (n = 12 is the boundary case 12 = 4·3; C(13,2) = 78 = 13·6 fails the strict inequality).

## Progress
- New lower-bound witnesses `petersen11` (11 vertices) and `petersen12` (12 vertices), built by a **vertex-adding surgery** on the Petersen graph: delete an edge a–b, add a new vertex v joined to a, b, and one further neighbour c of b. This resolves the recorded next-step ("lower ≥ 4 on 11 vertices — nontrivial, possibly false"): no 3-regular girth-5 graph exists at odd order (parity), but minimum degree 3 does not need regularity.
- Correctness of the surgery: within {a,b,c} the pairs (a,b), (b,c) were adjacent (0 common neighbours, girth 5) and the unique common neighbour of the non-adjacent pair (a,c) was exactly b — which the deleted edge removes just as v arrives to replace it; an outside vertex adjacent to two of {a,b,c} would have been a second common neighbour of that pair beforehand.
- All verification is the common-neighbour-matrix kernel check via the existing `not_containsC4_of_forall_common_le_one` (11×11 and 12×12 `decide`) — no embedding enumeration, **no `native_decide`**.
- Files modified: `proofs/Proofs/Erdos85Problem.lean` (+169 lines, 12 new declarations), `research/problems/erdos-85-wip-01/knowledge.md`, `src/data/research/problems/erdos-85-wip-01.json`.

## Verification
- Host-verified: `lake env lean` (Lean v4.31.0) exit 0 on the full file.
- `#print axioms` on all six key new theorems: `[propext, Classical.choice, Quot.sound]` — 0 sorries, 0 axioms, no `Lean.ofReduceBool`.

## Findings
- The surgery iterates (petersen12 is two applications), so every n ≥ 10 admits a min-degree-3 C₄-free graph; `f(n) ≥ 4` for all n ≥ 10 is a candidate general lemma (structural induction, not decide).
- f(13) is the first genuinely blocked order: counting gives only ≤ 5; the true upper bound 4 needs a real edge-extremal `ex(n; C₄)` input (Reiman-style), the same blocker class as the retired f(8) route.

## Status
**Outcome**: progress (two new exact values, axiom-free)
**Next Steps**: general `f(n) ≥ 4` for n ≥ 10 via iterated surgery; f(13) upper bound blocked on edge-extremal machinery; deep KST asymptotics / monotonicity core unchanged.

🤖 Generated by researcher-1
