### PR TITLE
audit(erdos-1069): tracker entry — clean (re-verified)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9624,9 +9624,9 @@
       "result": "issues-fixed"
     },
     "erdos-1069": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:29Z",
+      "lastAudited": "2026-07-23T00:41:28Z",
       "result": "clean"
     },
     "erdos-107": {


### PR DESCRIPTION
## Audit summary

**Proof**: erdos-1069 (Szemérédi-Trotter Theorem on k-Rich Lines)
**Result**: clean (5th audit)

Verified against `proofs/Proofs/Erdos1069Problem.lean`:
- 1 axiom (`szemeredi_trotter`) — matches `axiomCount: 1`, badge `axiom`, status `axiomatized`
- 0 sorries
- 6 real theorem/lemma declarations (grep's 7th hit at line 15 is a docstring false-positive, not a declaration)
- 14 definitions — matches `definitionCount: 14`
- No `native_decide`
- All 15 `originalContributions` names correspond to real declarations
- File already carries an explicit "Honesty note" disclosing the existential constant in `kRich_bound` is per-(P,L,k) rather than uniform; `meta.json` assumptions field matches
- No open PRs referencing erdos-1069

Reserve-mode re-verification (queue fully drained: 4811/4811 audited, 0 issues).

---
Discovered during gallery integrity audit.