### PR TITLE
Enrich erdos-335: re-anchor schnirelmann-bridge section to cover tail theorems

### DIFF
--- a/src/data/proofs/erdos-335/annotations.json
+++ b/src/data/proofs/erdos-335/annotations.json
@@ -527,7 +527,7 @@
     "proofId": "erdos-335",
     "range": {
       "startLine": 500,
-      "endLine": 523
+      "endLine": 547
     },
     "type": "theorem",
     "title": "Schnirelmann ≤ Asymptotic Density Bridge",

--- a/src/data/proofs/erdos-335/meta.json
+++ b/src/data/proofs/erdos-335/meta.json
@@ -92,10 +92,10 @@
       "schnirelmann_le_complement: PROVED — in a density-additive pair, schnirelmannDensity A ≤ 1 − asympDensity B"
     ],
     "axiomCount": 3,
-    "lineCount": 523,
+    "lineCount": 547,
     "assumptions": "3 axioms: weyl_equidistribution, fractional_part_density_additive, erdos_335_conjecture (OPEN). See Lean source for complete statements.",
-    "theoremCount": 46,
-    "definitionCount": 8
+    "theoremCount": 43,
+    "definitionCount": 5
   },
   "sections": [
     {
@@ -198,7 +198,7 @@
       "id": "schnirelmann-bridge",
       "title": "Bridge to Mathlib's Schnirelmann Density",
       "startLine": 461,
-      "endLine": 523,
+      "endLine": 547,
       "summary": "Connects this file's asympDensity to Mathlib's schnirelmannDensity. Proves countingFn_eq_filter_card (the two counting functions agree since Set.Ioc 0 N = Set.Icc 1 N on ℕ), then the bridge schnirelmann_le_asymp (infimum ≤ limit), and corollaries hasPositiveDensity_of_schnirelmann_pos and schnirelmann_le_complement.",
       "mathContext": "The Schnirelmann density $\\sigma(A)=\\inf_{n>0}|A\\cap[1,n]|/n$ is a lower bound for the asymptotic density $d(A)=\\lim_{n\\to\\infty}|A\\cap[1,n]|/n$ whenever the latter exists, since an infimum of a sequence never exceeds its limit. This makes Mathlib's Schnirelmann API available for the asymptotic-density theory of #335."
     }
@@ -223,7 +223,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Erdős Problem #335 asks for a characterization of all pairs $A, B \\subseteq \\mathbb{N}$ with positive density and $d(A+B) = d(A) + d(B)$. The known examples come from fractional part sets via Weyl equidistribution; the open conjecture is that *all* examples have this group-theoretic origin. The 123-line Lean file formalizes density, sumsets, the fractional part construction, the main conjecture, basic properties, and one proved theorem (`additive_implies_tight`). It has 0 sorries.",
+    "summary": "Erdős Problem #335 asks for a characterization of all pairs $A, B \\subseteq \\mathbb{N}$ with positive density and $d(A+B) = d(A) + d(B)$. The known examples come from fractional part sets via Weyl equidistribution; the open conjecture is that *all* examples have this group-theoretic origin. The 547-line Lean file formalizes density, sumsets, the fractional part construction, and the main conjecture (3 axioms, including the open conjecture itself), then proves 43 theorems — from `additive_implies_tight` and the core sumset/density algebra through a concrete positive-density witness to a bridge into Mathlib's Schnirelmann density API. It has 0 sorries.",
     "implications": "**Theoretical Significance**: **Connections and Implications**\n\n1. **Inverse Sumset Theory:** A positive resolution would be a major inverse theorem in additive combinatorics: a purely density-theoretic condition (exact additivity) implies algebraic structure (group rotation origin). This parallels Freiman's theorem, which deduces structure from small doubling.\n\n2. **Ergodic Theory Connection:** The fractional part construction connects to irrational rotations on $\\mathbb{R}/\\mathbb{Z}$. A full characterization might involve higher-dimensional tori or more general compact abelian groups, linking combinatorial number theory to ergodic theory.\n\n**3. Plünnecke–Ruzsa Tightness:** The proved theorem shows that density additivity is equivalent to Plünnecke–Ruzsa being tight. Understanding when the fundamental inequality is tight is a central question in additive combinatorics.\n\n4. **Additive Combinatorics Cluster:** This problem belongs to Erdős and Graham's family of sumset problems (#322, #335–337, #343) exploring the extremal behavior of additive structures. Together these problems map out the boundary between generic and structured behavior of sumsets.\n\n5. **Measure-Theoretic Translation:** Weyl equidistribution transforms the discrete density question into a continuous measure question on the circle. A characterization would clarify exactly when this translation is the only mechanism producing exact additivity.",
     "openQuestions": [
       "**Do all density-additive pairs arise from group rotations?** This is the core open question. No exotic examples are known, but no proof of characterization exists.",
@@ -268,10 +268,10 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 523,
+    "lineCount": 547,
     "axiomCount": 3,
-    "theoremCount": 46,
-    "definitionCount": 8,
+    "theoremCount": 43,
+    "definitionCount": 5,
     "path": "Proofs/Erdos335Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
Enrichment pass for erdos-335 (Density Additivity Characterization).

The Lean file (`Proofs/Erdos335Problem.lean`) is 547 lines, but `meta.json` and `annotations.json` documented coverage only through line 523 (`lineCount: 523`). The three trailing theorems — `schnirelmann_le_asymp`, `hasPositiveDensity_of_schnirelmann_pos`, `schnirelmann_le_complement` — start at line 524 and fell entirely outside the last section's (`schnirelmann-bridge`, 461-523) and last annotation's (`ann-e335-schnirelmann-bridge`, 500-523) documented ranges, even though both already *describe* those three theorems in their summary/content text (and `meta.meta.originalContributions` lists them as "PROVED"). This is the stale-section-boundary pattern: the prose already assumed coverage the line range didn't actually reach.

Fixes:
- Extend `sections[schnirelmann-bridge].endLine` and `annotations[ann-e335-schnirelmann-bridge].range.endLine` from 523 to 547 (EOF) — no new claims, the existing summary/content already accurately describes these three theorems.
- Fix stale `lineCount` (523 -> 547, both `meta.meta` and `leanFile`), `theoremCount` (46 -> 43) and `definitionCount` (8 -> 5) to match the actual file (verified via `grep -cE '^\s*(theorem|def) '`).
- Fix `conclusion.summary`, which still said "The 123-line Lean file ... basic properties, and one proved theorem" — badly stale versus the actual 547-line, 43-theorem file. Corrected to reflect the real scope.

No new mathematical claims were added; all changes bring metadata in line with what the Lean source already contains and what the existing prose already described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)