### PR TITLE
audit(erdos-1066): remove phantom axiom names from gallery prose

### DIFF
--- a/src/data/proofs/erdos-1066/annotations.json
+++ b/src/data/proofs/erdos-1066/annotations.json
@@ -8,7 +8,7 @@
     },
     "type": "concept",
     "title": "Problem Overview",
-    "content": "**Erdős Problem #1066: Independence Number of Unit Distance Graphs**\n\nFor n points in ℝ² with minimum distance 1, connected by edges at distance exactly 1, what is g(n) = guaranteed independent set size?\n\n**Status:** OPEN\n\n**Current Bounds:** (8/31)n ≤ g(n) ≤ (5/16)n\n\n**Key Results:**\n- Lower: Pollack n/4 (1985), Csizmadia 9n/35 (1998), Swanepoel 8n/31 (2002, best)\n- Upper: Chung-Graham-Pach 6n/19, Pach-Tóth 5n/16 (1996, best)\n\nThe formalization proves the arithmetic comparisons between all bounds using norm_num, and axiomatizes the historical results.",
+    "content": "**Erdős Problem #1066: Independence Number of Unit Distance Graphs**\n\nFor n points in ℝ² with minimum distance 1, connected by edges at distance exactly 1, what is g(n) = guaranteed independent set size?\n\n**Status:** OPEN\n\n**Current Bounds (historical literature, cited but not encoded as Lean axioms):** (8/31)n ≤ g(n) ≤ (5/16)n\n\n**Key Results:**\n- Lower: Pollack n/4 (1985), Csizmadia 9n/35 (1998), Swanepoel 8n/31 (2002, best)\n- Upper: Chung-Graham-Pach 6n/19, Pach-Tóth 5n/16 (1996, best)\n\nThe formalization axiomatizes only g(n) itself (as an opaque function with no properties) and proves the arithmetic comparisons between the literal bound constants using norm_num; the historical results above are docstring context, not separately axiomatized or tied to g.",
     "mathContext": "Connects graph theory, planar graphs, the Four Colour Theorem, and discrete geometry. Unit distance graphs with minimum distance 1 are always planar.",
     "significance": "key",
     "relatedConcepts": [
@@ -81,7 +81,7 @@
     },
     "type": "concept",
     "title": "Lower Bounds",
-    "content": "**Three progressively stronger lower bounds:**\n\n1. **pollack_lower_bound**: g(n) ≥ n/4 (1985) — from planarity and the Four Colour Theorem\n2. **csizmadia_lower_bound**: g(n) ≥ (9/35)n ≈ 0.257n (1998) — geometric arguments\n3. **swanepoel_lower_bound**: g(n) ≥ (8/31)n ≈ 0.258n (2002) — current best\n\n**lower_bounds_comparison** (PROVED): 1/4 < 9/35 < 8/31, confirming the progression.\n\nAll bounds are axiomatized since the proofs involve geometric reasoning about planar unit distance graphs.",
+    "content": "**Three progressively stronger lower bounds (historical, not axiomatized in this file):**\n\n1. **Pollack (1985)**: g(n) ≥ n/4 — from planarity and the Four Colour Theorem\n2. **Csizmadia (1998)**: g(n) ≥ (9/35)n ≈ 0.257n — geometric arguments\n3. **Swanepoel (2002)**: g(n) ≥ (8/31)n ≈ 0.258n — current best\n\n**lower_bounds_comparison** (PROVED): 1/4 < 9/35 < 8/31, confirming the progression of the literal constants.\n\nNone of these bounds are axiomatized or connected to `g` in the Lean file — only `g` itself is axiomatized (as an opaque function with no properties), and the comparison above is between bare rational constants, independent of `g`.",
     "mathContext": "The baseline n/4 follows from the Four Colour Theorem: planar graphs are 4-colorable, so the largest color class is an independent set of size ≥ n/4. Improvements exploit specific structure of unit distance graphs.",
     "significance": "key",
     "relatedConcepts": [
@@ -105,7 +105,7 @@
     },
     "type": "concept",
     "title": "Upper Bounds",
-    "content": "**Two upper bounds disproving Erdős's n/3 conjecture:**\n\n1. **chung_graham_pach_upper_bound**: g(n) ≤ (6/19)n ≈ 0.316n — first disproof of n/3\n2. **pach_toth_upper_bound**: g(n) ≤ (5/16)n = 0.3125n (1996) — current best\n\n**upper_bounds_comparison** (PROVED): 5/16 < 6/19 < 1/3, confirming the improvement over Erdős's conjecture.\n\nThe upper bounds are proved by explicit constructions of point configurations where independent sets are small.",
+    "content": "**Two upper bounds disproving Erdős's n/3 conjecture (historical, not axiomatized in this file):**\n\n1. **Chung-Graham-Pach**: g(n) ≤ (6/19)n ≈ 0.316n — first disproof of n/3\n2. **Pach-Tóth (1996)**: g(n) ≤ (5/16)n = 0.3125n — current best\n\n**upper_bounds_comparison** (PROVED): 5/16 < 6/19 < 1/3, confirming the improvement over Erdős's conjecture in the literal constants.\n\nNeither upper bound, nor the explicit constructions establishing them, are formalized here — the Lean file only compares the bare rational constants, disconnected from g.",
     "mathContext": "Erdős initially conjectured g(n) = n/3 ≈ 0.333n. The Chung-Graham-Pach construction disproved this. Pach-Tóth further improved the upper bound to 5/16 = 0.3125.",
     "significance": "key",
     "relatedConcepts": [
@@ -129,7 +129,7 @@
     },
     "type": "concept",
     "title": "Current Best Bounds and Gap",
-    "content": "**current_best_bounds** (PROVED): (8/31) < (5/16) — the lower bound is strictly below the upper bound.\n\n**bound_gap** (PROVED): 5/16 - 8/31 = 27/496 ≈ 0.054 — the gap is about 5.4%.\n\n**current_knowledge** (axiom): Combines Swanepoel and Pach-Tóth: (8/31)n ≤ g(n) ≤ (5/16)n for all n ≥ 1.\n\nThe true value of lim g(n)/n lies somewhere in this interval of width 27/496.",
+    "content": "**current_best_bounds** (PROVED): (8/31) < (5/16) — the lower bound is strictly below the upper bound.\n\n**bound_gap** (PROVED): 5/16 - 8/31 = 27/496 ≈ 0.054 — the gap is about 5.4%.\n\nThere is no axiom in this file combining Swanepoel and Pach-Tóth into a bound on g(n) itself; (8/31)n ≤ g(n) ≤ (5/16)n is the historical result cited in the docstring, not a Lean declaration.\n\nThe true value of lim g(n)/n lies somewhere in this interval of width 27/496.",
     "mathContext": "The gap 27/496 represents the current state of ignorance. Closing it is the main open challenge of Problem #1066.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-1066/meta.json
+++ b/src/data/proofs/erdos-1066/meta.json
@@ -45,12 +45,10 @@
     "originalContributions": [
       "Point2D, dist, UnitDistancePointSet, unitDistanceEdge: geometric definitions",
       "IsIndependentSet, independenceNumber: independence definitions",
-      "g axiom: guaranteed independent set size function",
-      "pollack_lower_bound, csizmadia_lower_bound, swanepoel_lower_bound: lower bound axioms",
-      "chung_graham_pach_upper_bound, pach_toth_upper_bound: upper bound axioms",
-      "lower_bounds_comparison, upper_bounds_comparison: proved arithmetic comparisons",
+      "g axiom: guaranteed independent set size function (opaque, no properties)",
+      "lower_bounds_comparison, upper_bounds_comparison: proved arithmetic comparisons among the literal historical-bound constants (1/4 < 9/35 < 8/31, 5/16 < 6/19 < 1/3); the historical bounds themselves (Pollack, Csizmadia, Swanepoel, Chung-Graham-Pach, Pach-Toth) are cited in docstrings only, not axiomatized or tied to g",
       "current_best_bounds, bound_gap: proved bounds",
-      "g_d axiom, erdos_higher_dimension_question: higher-dimensional generalization",
+      "g_d axiom: higher-dimensional generalization (opaque, no properties)",
       "erdos_1066_summary: proved summary combining all arithmetic results"
     ],
     "axiomCount": 2,
@@ -63,7 +61,7 @@
     "historicalContext": "This problem concerns unit distance graphs in the plane, where n points at minimum pairwise distance 1 are connected by edges if exactly at distance 1. Such graphs are always planar (edges cannot cross without forcing points closer than 1). The key quantity g(n) measures the guaranteed independent set size.\n\nErdős initially conjectured g(n) = n/3, but this was disproved by Chung, Graham, and Pach who showed g(n) ≤ 6n/19 ≈ 0.316n. The baseline lower bound g(n) ≥ n/4 follows from planarity and the Four Colour Theorem (observed by Pollack in 1985). This was improved by Csizmadia (1998) to 9n/35 and then by Swanepoel (2002) to the current best 8n/31.\n\nThe current best upper bound is due to Pach and Tóth (1996): g(n) ≤ 5n/16 = 0.3125n. The gap between 8/31 ≈ 0.258 and 5/16 = 0.3125 remains to be closed. The problem also generalizes to higher dimensions, where g_d(n) ~ n/d is conjectured.",
     "problemStatement": "Let G be a graph given by n points in ℝ², where any two distinct points are at least distance 1 apart, and we draw an edge between two points if they are distance 1 apart. Let g(n) be maximal such that any such graph always has an independent set on at least g(n) vertices. Estimate g(n), or perhaps lim g(n)/n.\n\n**Current Best Bounds:** (8/31)n ≤ g(n) ≤ (5/16)n\n**Status: OPEN**",
     "text": "Let G be a graph given by n points in ℝ² where any two distinct points are at least distance 1 apart, and we draw an edge between two points if they are distance exactly 1 apart. Let g(n) be maximal such that any such graph always has an independent set on at least g(n) vertices. Estimate g(n), or perhaps lim g(n)/n.",
-    "proofStrategy": "The formalization defines unit distance point sets using EuclideanSpace ℝ (Fin 2) and axiomatizes g(n) since computing the infimum over all configurations is not feasible in Lean. The key historical bounds are axiomatized (Pollack, Csizmadia, Swanepoel for lower; Chung-Graham-Pach, Pach-Tóth for upper), while the arithmetic comparisons between bound constants are proved using norm_num. The summary theorem combines all verified arithmetic facts.",
+    "proofStrategy": "The formalization defines unit distance point sets using EuclideanSpace ℝ (Fin 2) and axiomatizes g(n) and its higher-dimensional analogue g_d(n) as opaque functions, since computing the infimum over all configurations is not feasible in Lean; no axiom asserts the historical bounds as properties of g. The historical bounds (Pollack, Csizmadia, Swanepoel for lower; Chung-Graham-Pach, Pach-Tóth for upper) are cited in docstrings only. What is proved is the arithmetic comparison between the literal rational constants (1/4 < 9/35 < 8/31 and 5/16 < 6/19 < 1/3), independent of g, using norm_num. The summary theorem combines these four verified arithmetic facts.",
     "keyInsights": [
       "**Planarity is key**: Unit distance graphs with minimum distance 1 are planar, giving the baseline g(n) ≥ n/4",
       "**Erdős's n/3 conjecture was wrong**: Constructions show g(n) < n/3",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-1066
**Problem**: `axiomCount: 2` is numerically correct (only `g` and `g_d` are real `axiom` declarations in `proofs/Proofs/Erdos1066Problem.lean`), but `meta.json`'s `originalContributions`/`proofStrategy` and three blocks in `annotations.json` named six axioms that were never declared in the Lean file: `pollack_lower_bound`, `csizmadia_lower_bound`, `swanepoel_lower_bound`, `chung_graham_pach_upper_bound`, `pach_toth_upper_bound`, `current_knowledge`, `erdos_higher_dimension_question`.

The prose went further than just naming phantom axioms — it claimed the historical bounds themselves are "axiomatized" and even that the upper bounds are "proved by explicit constructions." In reality the Lean file only axiomatizes `g` and `g_d` as fully opaque functions with zero properties, and separately proves arithmetic comparisons between bare rational literals (e.g. `1/4 < 9/35 < 8/31`) that are never connected to `g` at all.

## Evidence

**meta.json claims**: `originalContributions` lists "pollack_lower_bound, csizmadia_lower_bound, swanepoel_lower_bound: lower bound axioms" and "chung_graham_pach_upper_bound, pach_toth_upper_bound: upper bound axioms"; `proofStrategy` says "The key historical bounds are axiomatized (Pollack, Csizmadia, Swanepoel for lower; Chung-Graham-Pach, Pach-Tóth for upper)".

**Lean file shows**: `grep` for all seven phantom names across `proofs/Proofs/Erdos1066Problem.lean` and the whole `proofs/Proofs/` tree returns 0 hits. The only axioms are:
```
axiom g (n : ℕ) : ℕ
axiom g_d (d n : ℕ) : ℕ
```
The five theorems (`lower_bounds_comparison`, `upper_bounds_comparison`, `current_best_bounds`, `bound_gap`, `erdos_1066_summary`) only compare literal `ℚ` constants via `norm_num`, with no reference to `g` or `g_d`.

## Fix

Reworded `originalContributions`, `proofStrategy` (meta.json), and the `ann-e1066-header`/`ann-e1066-lowerbounds`/`ann-e1066-upperbounds`/`ann-e1066-gap` blocks (annotations.json) to describe reality: the historical bounds are docstring/narrative context only, not axiomatized or tied to `g`; only `g`/`g_d` are axiomatized (opaque, no properties); the theorems prove arithmetic facts about literal constants, disconnected from `g`.

---
Discovered during gallery integrity audit.