### PR TITLE
audit(erdos-1062): fix stale/false axiomatized claims in annotations

### DIFF
--- a/src/data/proofs/erdos-1062/annotations.json
+++ b/src/data/proofs/erdos-1062/annotations.json
@@ -147,7 +147,7 @@
       "endLine": 76
     },
     "title": "Existence of Limiting Density",
-    "content": "Axiomatizes that $\\lim_{n \\to \\infty} f(n)/n$ exists and lies in $[0.6725, 0.6736]$. The existence follows from subadditivity-type arguments for the extremal function, analogous to how densities of other restricted sets are shown to exist via Fekete's lemma.",
+    "content": "Documents in a docstring (not formalized as an axiom or theorem) that $\\lim_{n \\to \\infty} f(n)/n$ exists and lies in $[0.6725, 0.6736]$. The existence follows from subadditivity-type arguments for the extremal function, analogous to how densities of other restricted sets are shown to exist via Fekete's lemma.",
     "mathContext": "$$\\exists\\, \\lambda \\in [0.6725, 0.6736] : \\lim_{n \\to \\infty} \\frac{f(n)}{n} = \\lambda$$\nThe limit exists by Fekete's lemma applied to a suitable superadditive reformulation of $f(n)$.",
     "significance": "key",
     "relatedConcepts": [
@@ -217,7 +217,7 @@
       "endLine": 97
     },
     "title": "Primitive Implies NDTO",
-    "content": "Proves that every primitive set is NDTO: if no element divides any other, then certainly no element divides two others. This is the only fully proved (non-axiomatized) result in the file, demonstrating the logical relationship between the two conditions via a direct proof by contradiction.",
+    "content": "Proves that every primitive set is NDTO: if no element divides any other, then certainly no element divides two others. This is one of nine fully proved theorems in the file (alongside the lower-bound construction, the strict-separation example, and several structural properties of NDTO), demonstrating the logical relationship between the two conditions via a direct proof by contradiction.",
     "mathContext": "$$\\text{IsPrimitive}(A) \\implies \\text{NDTO}(A)$$\nProof: if $a \\mid b$ and $a \\mid c$ with $a, b, c$ distinct, then $a \\mid b$ with $a \\neq b$ contradicts primitivity.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -239,7 +239,7 @@
       "endLine": 104
     },
     "title": "NDTO Is Strictly Weaker: The {2, 6, 9} Example",
-    "content": "Axiomatizes the separation: $\\{2, 6, 9\\}$ satisfies NDTO (2 divides only 6, not 9; 6 and 9 divide nothing else) but is not primitive (since $2 \\mid 6$). This concrete counterexample shows the implication Primitive $\\implies$ NDTO is strict, justifying why NDTO allows much larger sets.",
+    "content": "Proves the separation: $\\{2, 6, 9\\}$ satisfies NDTO (2 divides only 6, not 9; 6 and 9 divide nothing else) but is not primitive (since $2 \\mid 6$). This concrete counterexample shows the implication Primitive $\\implies$ NDTO is strict, justifying why NDTO allows much larger sets.",
     "mathContext": "In $\\{2, 6, 9\\}$: the divisibility graph has one edge $2 \\to 6$. Since $\\deg^+(2) = 1 \\leq 1$, NDTO holds. But $2 \\mid 6$ violates primitivity. Max degree $\\leq 1$ (NDTO) vs max degree $= 0$ (primitive) captures the difference.",
     "significance": "supporting",
     "relatedConcepts": [


### PR DESCRIPTION
## Integrity fix

**Proof**: erdos-1062 (Maximum "No Divides Two Others" Sets)

**Problem**: `annotations.json` (which is rendered publicly via `AnnotationPanel`)
contained stale prose from an earlier, smaller version of the file:

1. `erdos-1062-density-limit` said "**Axiomatizes** that lim f(n)/n exists..." —
   but this is only documented in a docstring comment, never an `axiom` or any
   declaration at all.
2. `erdos-1062-strictness` said "**Axiomatizes** the separation: {2, 6, 9}..." —
   but `ndto_strictly_weaker` is a fully proved `theorem` in the current file
   (`Proofs/Erdos1062Problem.lean:120-129`), not an axiom.
3. `erdos-1062-implication` said `primitive_implies_ndto` is "**the only fully
   proved (non-axiomatized) result in the file**" — false; the file has 9
   proved theorems (`lower_bound_construction`, `primitive_implies_ndto`,
   `ndto_strictly_weaker`, `ndto_subset`, `ndto_pair`, `maxNDTOSize_mono`,
   `ndto_singleton`, `maxNDTOSize_ge_one`, `maxNDTOSize_le`) plus one proved
   private lemma.

These claims directly contradict `meta.json`'s own accurate
`overview.proofStrategy` text ("A comparison with primitive sets is fully
proved... the file has 0 axioms") and the actual source, which has
`axiomCount: 0` / `sorries: 0` (verified by grep — no `axiom` or `sorry`
declarations exist).

## Evidence

**annotations.json claimed**: two proved results are "axiomatized"; one
proved theorem is "the only" proved result.

**Lean file shows**: 0 axioms, 0 sorries, 10 proved theorems/lemmas total
(`Proofs/Erdos1062Problem.lean`).

## Fix

Reworded the three annotation `content` fields to accurately describe what
is proved vs. merely documented in a docstring. No changes to `meta.json`
(already correct) or the Lean source.

---
Discovered during gallery integrity audit (reserve re-verify, queue drained —
all 4811 proofs currently audited).