### PR TITLE
Research: eqr-oq03-oq02-wip-01 — Gauss sum of χ₈ evaluated: τ = 2√2 = +√8 (sign included)

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01.lean
@@ -1,4 +1,5 @@
 import Proofs.ElementaryQuadraticReciprocityOQ03OQ02
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
 import Mathlib.Tactic
 
 /-
@@ -56,6 +57,22 @@ structural input the Gauss-sum route to generalized quadratic reciprocity rests 
 * `kronecker2_autocorr_spectrum`  — the full comb `C = (4,0,0,0,−4,0,0,0)`: `C(0)=4`,
                                    `C(1)=C(2)=C(3)=0`, `C(4)=−4`, completing the length-`8`
                                    autocorrelation whose DFT is the power spectrum `|τ(χ₈)|²=8`.
+
+## The Gauss sum of `χ₈` — explicit value and sign (Section G)
+
+* `zeta8` / `zeta8_eq_exp`        — the canonical primitive 8th root of unity
+                                    `ζ₈ = (1+i)/√2 = e^{2πi/8}`, with `ζ₈² = i`, `ζ₈⁴ = −1`,
+                                    `ζ₈⁸ = 1` and exact order `8` (`zeta8_orderOf`).
+* `gaussSumChi8_eq`               — **the Gauss sum evaluated**: `τ(χ₈) = ∑_{a=0}^{7} χ₈(a)ζ₈^a
+                                    = 2√2`, a *positive real* number.
+* `gaussSumChi8_eq_sqrt_conductor` — the sign of the Gauss sum (Gauss 1805, instance `D = 8`):
+                                    `τ(χ₈) = +√8`, the positive square root of the conductor.
+* `gaussSumChi8_sq`               — `τ(χ₈)² = 8 = χ₈(−1)·8`: the squared Gauss sum equals the
+                                    conductor, the identity that powers the Gauss-sum proof of
+                                    (generalized) quadratic reciprocity for the even character `χ₈`.
+* `gaussSumChi8_twisted`          — multiplicative covariance `∑_a χ₈(a)ζ₈^{ca} = χ₈(c)·τ(χ₈)`
+                                    for every unit `c ∈ {1,3,5,7}` mod `8` — the twisted Gauss
+                                    sums, the engine of the reciprocity argument.
 
 All results are fully machine-checked (0 axioms, 0 sorries).
 
@@ -431,5 +448,222 @@ theorem kronecker2_autocorr_spectrum :
     kronecker2_autocorr_two,
     kronecker2_autocorr_odd (Int.odd_iff.mpr (by decide)),
     kronecker2_autocorr_four⟩
+
+-- ============================================================
+-- Section G: The Gauss sum τ(χ₈) — explicit value and sign
+-- ============================================================
+
+/-- The canonical primitive eighth root of unity `ζ₈ = (1 + i)/√2`.  This is the
+    algebraic normal form of `e^{2πi/8}` (`zeta8_eq_exp` below); working with the
+    closed form keeps every Gauss-sum computation inside field arithmetic over
+    `ℚ(i, √2)` rather than transcendental-function manipulation. -/
+noncomputable def zeta8 : ℂ := (1 + Complex.I) / (Real.sqrt 2 : ℂ)
+
+/-- `(√2)² = 2` inside `ℂ` — the single algebraic relation through which every
+    occurrence of `√2` is eliminated in the Gauss-sum computations below. -/
+theorem sqrt_two_sq_complex : ((Real.sqrt 2 : ℂ)) ^ 2 = 2 := by
+  rw [← Complex.ofReal_pow, Real.sq_sqrt (by norm_num : (0:ℝ) ≤ 2)]
+  norm_num
+
+/-- `√2 ≠ 0` in `ℂ`, so division by `√2` in `zeta8` is honest field division. -/
+theorem sqrt_two_ne_zero_complex : ((Real.sqrt 2 : ℂ)) ≠ 0 :=
+  Complex.ofReal_ne_zero.mpr (Real.sqrt_ne_zero'.mpr (by norm_num))
+
+/-- `ζ₈² = i`: squaring the canonical eighth root of unity gives the canonical
+    fourth root of unity.  With `(√2)² = 2` this is pure ring algebra:
+    `((1+i)/√2)² = (1 + 2i + i²)/2 = i`. -/
+theorem zeta8_sq : zeta8 ^ 2 = Complex.I := by
+  unfold zeta8
+  rw [div_pow, sqrt_two_sq_complex]
+  linear_combination Complex.I_sq / 2
+
+/-- `ζ₈⁴ = −1`: the fourth power lands on the primitive square root of unity —
+    `ζ₈` is a square root of `i`, hence a fourth root of `−1`. -/
+theorem zeta8_pow_four : zeta8 ^ 4 = -1 := by
+  have h : zeta8 ^ 4 = (zeta8 ^ 2) ^ 2 := by ring
+  rw [h, zeta8_sq, Complex.I_sq]
+
+/-- `ζ₈⁸ = 1`: `ζ₈` is an eighth root of unity. -/
+theorem zeta8_pow_eight : zeta8 ^ 8 = 1 := by
+  have h : zeta8 ^ 8 = (zeta8 ^ 4) ^ 2 := by ring
+  rw [h, zeta8_pow_four]
+  norm_num
+
+/-- **`ζ₈` is a *primitive* eighth root of unity**: its multiplicative order is
+    exactly `8`.  Since `ζ₈⁸ = 1` the order divides `8 = 2³`; since `ζ₈⁴ = −1 ≠ 1`
+    it does not divide `4 = 2²`, which forces order `2³` exactly
+    (`orderOf_eq_prime_pow` with `p = 2`, `n = 2`). -/
+theorem zeta8_orderOf : orderOf zeta8 = 8 := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  have h := orderOf_eq_prime_pow (x := zeta8) (p := 2) (n := 2)
+    (by rw [show (2:ℕ) ^ 2 = 4 from rfl, zeta8_pow_four]; norm_num)
+    (by rw [show (2:ℕ) ^ (2 + 1) = 8 from rfl, zeta8_pow_eight])
+  simpa using h
+
+/-- **`ζ₈ = e^{2πi/8}`**: the closed form `(1+i)/√2` is exactly the canonical
+    exponential eighth root of unity.  Unfolds `e^{iπ/4} = cos(π/4) + i·sin(π/4)`
+    (Euler) and evaluates both trigonometric values to `√2/2`. -/
+theorem zeta8_eq_exp : zeta8 = Complex.exp (2 * (Real.pi : ℂ) * Complex.I / 8) := by
+  have harg : (2 * (Real.pi : ℂ) * Complex.I / 8) = ((Real.pi / 4 : ℝ) : ℂ) * Complex.I := by
+    push_cast
+    ring
+  rw [harg, Complex.exp_mul_I, ← Complex.ofReal_cos, ← Complex.ofReal_sin,
+    Real.cos_pi_div_four, Real.sin_pi_div_four]
+  unfold zeta8
+  rw [div_eq_iff sqrt_two_ne_zero_complex]
+  push_cast
+  linear_combination (-(1 + Complex.I) / 2) * sqrt_two_sq_complex
+
+/-- Powers of `ζ₈` reduce modulo `8` — the computational form of `ζ₈⁸ = 1`,
+    used to fold the exponents `ca` of the twisted Gauss sums back into `[0, 8)`. -/
+theorem zeta8_pow_mod (n : ℕ) : zeta8 ^ n = zeta8 ^ (n % 8) := by
+  conv_lhs => rw [← Nat.div_add_mod n 8]
+  rw [pow_add, pow_mul, zeta8_pow_eight, one_pow, one_mul]
+
+/-- **The Gauss sum of `χ₈ = (·/2)`**: `τ(χ₈) = ∑_{a=0}^{7} χ₈(a) ζ₈^a`, the
+    character sum against the canonical additive character of `ℤ/8ℤ`.  The
+    orthogonality data of Sections E–F pins its modulus (`|τ|² = 8`); the theorems
+    below compute the sum itself, sign included. -/
+noncomputable def gaussSumChi8 : ℂ :=
+  ∑ a ∈ Finset.range 8, (kronecker2 (a : ℤ) : ℂ) * zeta8 ^ a
+
+/-- **The Gauss sum evaluated: `τ(χ₈) = 2√2`.**  Only the odd residues
+    contribute, giving `τ = ζ₈ − ζ₈³ − ζ₈⁵ + ζ₈⁷ = 2ζ₈(1 − i) = 2√2` — a
+    *positive real* number.  This single identity subsumes the modulus computation
+    `|τ(χ₈)|² = 8` of the autocorrelation spectrum *and* determines the sign,
+    which no amount of `|τ|` bookkeeping can see. -/
+theorem gaussSumChi8_eq : gaussSumChi8 = 2 * (Real.sqrt 2 : ℂ) := by
+  have h3 : zeta8 ^ 3 = zeta8 * Complex.I := by
+    have h : zeta8 ^ 3 = zeta8 * zeta8 ^ 2 := by ring
+    rw [h, zeta8_sq]
+  have h5 : zeta8 ^ 5 = -zeta8 := by
+    have h : zeta8 ^ 5 = zeta8 * zeta8 ^ 4 := by ring
+    rw [h, zeta8_pow_four]
+    ring
+  have h7 : zeta8 ^ 7 = -(zeta8 * Complex.I) := by
+    have h : zeta8 ^ 7 = zeta8 ^ 3 * zeta8 ^ 4 := by ring
+    rw [h, h3, zeta8_pow_four]
+    ring
+  have key : zeta8 * (1 - Complex.I) = (Real.sqrt 2 : ℂ) := by
+    unfold zeta8
+    rw [div_mul_eq_mul_div, div_eq_iff sqrt_two_ne_zero_complex]
+    linear_combination (-1 : ℂ) * sqrt_two_sq_complex - Complex.I_sq
+  unfold gaussSumChi8
+  simp only [Finset.sum_range_succ, Finset.sum_range_zero, Nat.cast_zero, Nat.cast_one,
+    Nat.cast_ofNat]
+  rw [show kronecker2 0 = 0 from by decide, show kronecker2 1 = 1 from by decide,
+    show kronecker2 2 = 0 from by decide, show kronecker2 3 = -1 from by decide,
+    show kronecker2 4 = 0 from by decide, show kronecker2 5 = -1 from by decide,
+    show kronecker2 6 = 0 from by decide, show kronecker2 7 = 1 from by decide,
+    h3, h5, h7]
+  push_cast
+  linear_combination 2 * key
+
+/-- **`τ(χ₈)² = 8`: the squared Gauss sum is the conductor.**  This is the
+    `D = 8` instance of the fundamental identity `τ(χ_D)² = χ_D(−1)·D` for real
+    primitive characters — since `χ₈(−1) = 1` (`kronecker2` is even), the square
+    is `+8`.  It is exactly this identity that transports quadratic reciprocity
+    through the Gauss-sum argument. -/
+theorem gaussSumChi8_sq : gaussSumChi8 ^ 2 = 8 := by
+  rw [gaussSumChi8_eq]
+  linear_combination 4 * sqrt_two_sq_complex
+
+/-- `τ(χ₈)² = χ₈(−1)·8`, the even-character form of the conductor identity,
+    with the character value `χ₈(−1) = (−1/2) = 1` appearing explicitly. -/
+theorem gaussSumChi8_sq_eq_chi_neg_one_mul_conductor :
+    gaussSumChi8 ^ 2 = (kronecker2 (-1) : ℂ) * 8 := by
+  rw [show kronecker2 (-1) = 1 from by decide, gaussSumChi8_sq]
+  norm_num
+
+/-- `√8 = 2√2` — the conductor's square root in lowest surd form. -/
+theorem sqrt_eight_eq_two_mul_sqrt_two : Real.sqrt 8 = 2 * Real.sqrt 2 := by
+  rw [show (8:ℝ) = 4 * 2 by norm_num, Real.sqrt_mul (by norm_num : (0:ℝ) ≤ 4) 2,
+    show (4:ℝ) = 2 ^ 2 by norm_num, Real.sqrt_sq (by norm_num : (0:ℝ) ≤ 2)]
+
+/-- **The sign of the Gauss sum (Gauss 1805, instance `D = 8`)**:
+    `τ(χ₈) = +√8`, the *positive* square root of the conductor.  Determining this
+    sign for general `D` was famously hard — Gauss conjectured it in 1801 and
+    needed four more years for a proof.  For the even real primitive character of
+    conductor `8` the present file settles it by direct evaluation. -/
+theorem gaussSumChi8_eq_sqrt_conductor : gaussSumChi8 = (Real.sqrt 8 : ℂ) := by
+  rw [gaussSumChi8_eq, sqrt_eight_eq_two_mul_sqrt_two]
+  push_cast
+  ring
+
+/-- Twisted Gauss sum at `c = 3`: `∑_a χ₈(a) ζ₈^{3a} = χ₈(3)·τ(χ₈)`.
+    Folding the exponents `3a mod 8` permutes the odd residues `{1,3,5,7}` and the
+    permutation sign realized on the character values is exactly `χ₈(3) = −1`. -/
+theorem gaussSumChi8_twisted_three :
+    (∑ a ∈ Finset.range 8, (kronecker2 (a : ℤ) : ℂ) * zeta8 ^ (3 * a)) =
+      (kronecker2 3 : ℂ) * gaussSumChi8 := by
+  unfold gaussSumChi8
+  simp only [Finset.sum_range_succ, Finset.sum_range_zero, Nat.cast_zero, Nat.cast_one,
+    Nat.cast_ofNat, Nat.reduceMul]
+  rw [show kronecker2 0 = 0 from by decide, show kronecker2 1 = 1 from by decide,
+    show kronecker2 2 = 0 from by decide, show kronecker2 3 = -1 from by decide,
+    show kronecker2 4 = 0 from by decide, show kronecker2 5 = -1 from by decide,
+    show kronecker2 6 = 0 from by decide, show kronecker2 7 = 1 from by decide]
+  rw [show zeta8 ^ (9:ℕ) = zeta8 ^ (1:ℕ) from by rw [zeta8_pow_mod],
+    show zeta8 ^ (15:ℕ) = zeta8 ^ (7:ℕ) from by rw [zeta8_pow_mod],
+    show zeta8 ^ (21:ℕ) = zeta8 ^ (5:ℕ) from by rw [zeta8_pow_mod]]
+  push_cast
+  ring
+
+/-- Twisted Gauss sum at `c = 5`: `∑_a χ₈(a) ζ₈^{5a} = χ₈(5)·τ(χ₈)`. -/
+theorem gaussSumChi8_twisted_five :
+    (∑ a ∈ Finset.range 8, (kronecker2 (a : ℤ) : ℂ) * zeta8 ^ (5 * a)) =
+      (kronecker2 5 : ℂ) * gaussSumChi8 := by
+  unfold gaussSumChi8
+  simp only [Finset.sum_range_succ, Finset.sum_range_zero, Nat.cast_zero, Nat.cast_one,
+    Nat.cast_ofNat, Nat.reduceMul]
+  rw [show kronecker2 0 = 0 from by decide, show kronecker2 1 = 1 from by decide,
+    show kronecker2 2 = 0 from by decide, show kronecker2 3 = -1 from by decide,
+    show kronecker2 4 = 0 from by decide, show kronecker2 5 = -1 from by decide,
+    show kronecker2 6 = 0 from by decide, show kronecker2 7 = 1 from by decide]
+  rw [show zeta8 ^ (15:ℕ) = zeta8 ^ (7:ℕ) from by rw [zeta8_pow_mod],
+    show zeta8 ^ (25:ℕ) = zeta8 ^ (1:ℕ) from by rw [zeta8_pow_mod],
+    show zeta8 ^ (35:ℕ) = zeta8 ^ (3:ℕ) from by rw [zeta8_pow_mod]]
+  push_cast
+  ring
+
+/-- Twisted Gauss sum at `c = 7`: `∑_a χ₈(a) ζ₈^{7a} = χ₈(7)·τ(χ₈)`. -/
+theorem gaussSumChi8_twisted_seven :
+    (∑ a ∈ Finset.range 8, (kronecker2 (a : ℤ) : ℂ) * zeta8 ^ (7 * a)) =
+      (kronecker2 7 : ℂ) * gaussSumChi8 := by
+  unfold gaussSumChi8
+  simp only [Finset.sum_range_succ, Finset.sum_range_zero, Nat.cast_zero, Nat.cast_one,
+    Nat.cast_ofNat, Nat.reduceMul]
+  rw [show kronecker2 0 = 0 from by decide, show kronecker2 1 = 1 from by decide,
+    show kronecker2 2 = 0 from by decide, show kronecker2 3 = -1 from by decide,
+    show kronecker2 4 = 0 from by decide, show kronecker2 5 = -1 from by decide,
+    show kronecker2 6 = 0 from by decide, show kronecker2 7 = 1 from by decide]
+  rw [show zeta8 ^ (21:ℕ) = zeta8 ^ (5:ℕ) from by rw [zeta8_pow_mod],
+    show zeta8 ^ (35:ℕ) = zeta8 ^ (3:ℕ) from by rw [zeta8_pow_mod],
+    show zeta8 ^ (49:ℕ) = zeta8 ^ (1:ℕ) from by rw [zeta8_pow_mod]]
+  push_cast
+  ring
+
+/-- **Multiplicative covariance of the Gauss sum — the reciprocity engine.**
+    For every unit `c` of `ℤ/8ℤ`, twisting the additive character by `c` scales
+    the Gauss sum by the character value:
+
+        ∑_{a=0}^{7} χ₈(a) ζ₈^{ca} = χ₈(c) · τ(χ₈).
+
+    This covariance (substitute `a ↦ c⁻¹a` and use complete multiplicativity of
+    `χ₈`) is the identity through which the Gauss sum transports quadratic
+    reciprocity; here it is verified exhaustively over the unit group
+    `(ℤ/8ℤ)ˣ = {1, 3, 5, 7}`. -/
+theorem gaussSumChi8_twisted (c : ℕ) (hc : c = 1 ∨ c = 3 ∨ c = 5 ∨ c = 7) :
+    (∑ a ∈ Finset.range 8, (kronecker2 (a : ℤ) : ℂ) * zeta8 ^ (c * a)) =
+      (kronecker2 (c : ℤ) : ℂ) * gaussSumChi8 := by
+  rcases hc with rfl | rfl | rfl | rfl
+  · unfold gaussSumChi8
+    simp only [one_mul, Nat.cast_one]
+    rw [show kronecker2 1 = 1 from by decide]
+    push_cast
+    ring
+  · exact gaussSumChi8_twisted_three
+  · exact gaussSumChi8_twisted_five
+  · exact gaussSumChi8_twisted_seven
 
 end KroneckerSymbol

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/annotations.json
@@ -3,8 +3,8 @@
     "id": "ann-kron-wip01-congr-left",
     "proofId": "elementary-quadratic-reciprocity-oq-03-oq-02-wip-01",
     "range": {
-      "startLine": 62,
-      "endLine": 67
+      "startLine": 79,
+      "endLine": 84
     },
     "type": "concept",
     "title": "The Dirichlet-character periodicity of (a/n)",
@@ -25,8 +25,8 @@
     "id": "ann-kron-wip01-full-period",
     "proofId": "elementary-quadratic-reciprocity-oq-03-oq-02-wip-01",
     "range": {
-      "startLine": 68,
-      "endLine": 77
+      "startLine": 85,
+      "endLine": 94
     },
     "type": "technique",
     "title": "Full period n from a single residue identity",
@@ -48,8 +48,8 @@
     "id": "ann-kron-wip01-mod-eight-helper",
     "proofId": "elementary-quadratic-reciprocity-oq-03-oq-02-wip-01",
     "range": {
-      "startLine": 83,
-      "endLine": 95
+      "startLine": 100,
+      "endLine": 112
     },
     "type": "technique",
     "title": "Reducing kronecker2 to a function of a mod 8",
@@ -70,8 +70,8 @@
     "id": "ann-kron-wip01-kronecker2-period",
     "proofId": "elementary-quadratic-reciprocity-oq-03-oq-02-wip-01",
     "range": {
-      "startLine": 98,
-      "endLine": 106
+      "startLine": 115,
+      "endLine": 123
     },
     "type": "concept",
     "title": "Full period 8 for the (a/2) character",
@@ -92,8 +92,8 @@
     "id": "ann-kron-wip01-conductor-eight",
     "proofId": "elementary-quadratic-reciprocity-oq-03-oq-02-wip-01",
     "range": {
-      "startLine": 110,
-      "endLine": 140
+      "startLine": 127,
+      "endLine": 157
     },
     "type": "insight",
     "title": "8 is the exact conductor: (·/2) is primitive",

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/meta.json
@@ -2,7 +2,7 @@
   "id": "elementary-quadratic-reciprocity-oq-03-oq-02-wip-01",
   "title": "The Kronecker Symbol as a Periodic Character",
   "slug": "elementary-quadratic-reciprocity-oq-03-oq-02-wip-01",
-  "description": "Completes the parent Kronecker-symbol file with the Dirichlet-character periodicity that its Section 5 motivates but leaves unproved: the numerator character (a/n) at odd positive n depends only on a mod n and has full period n, and the (a/2) character kronecker2 has full period 8 (generalizing the parent's single-step kronecker2_periodic) and depends only on a mod 8; moreover 8 is the exact conductor — (·/2) is a primitive character mod 8, periodic with no proper divisor of 8 as a period (kronecker2_not_period_four, kronecker2_not_period_two, kronecker2_conductor_eight). All eight results are machine-verified, 0 axioms and 0 sorries, derived from the parent's public API. Section F completes the length-8 autocorrelation function C(t)=∑ (a/2)(a+t/2) of the conductor-8 character χ₈=(·/2) by supplying the off-peak values C(1)=C(2)=C(3)=0 (kronecker2_autocorr_odd via the pointwise parity obstruction kronecker2_mul_shift_odd, and kronecker2_autocorr_two), assembling the full sparse comb (4,0,0,0,-4,0,0,0) in kronecker2_autocorr_spectrum — the correlation datum whose DFT is the power spectrum |τ(χ₈)|²=8.",
+  "description": "Completes the parent Kronecker-symbol file with the Dirichlet-character periodicity that its Section 5 motivates but leaves unproved: the numerator character (a/n) at odd positive n depends only on a mod n and has full period n, and the (a/2) character kronecker2 has full period 8 (generalizing the parent's single-step kronecker2_periodic) and depends only on a mod 8; moreover 8 is the exact conductor — (·/2) is a primitive character mod 8, periodic with no proper divisor of 8 as a period (kronecker2_not_period_four, kronecker2_not_period_two, kronecker2_conductor_eight). All eight results are machine-verified, 0 axioms and 0 sorries, derived from the parent's public API. Section F completes the length-8 autocorrelation function C(t)=∑ (a/2)(a+t/2) of the conductor-8 character χ₈=(·/2) by supplying the off-peak values C(1)=C(2)=C(3)=0 (kronecker2_autocorr_odd via the pointwise parity obstruction kronecker2_mul_shift_odd, and kronecker2_autocorr_two), assembling the full sparse comb (4,0,0,0,-4,0,0,0) in kronecker2_autocorr_spectrum — the correlation datum whose DFT is the power spectrum |τ(χ₈)|²=8. Section G computes the Gauss sum itself: with the canonical primitive 8th root of unity ζ₈ = (1+i)/√2 = e^{2πi/8} (zeta8, zeta8_eq_exp, exact order 8 via zeta8_orderOf), the Gauss sum τ(χ₈) = ∑ χ₈(a)ζ₈^a is evaluated in closed form: τ(χ₈) = 2√2 = +√8 (gaussSumChi8_eq, gaussSumChi8_eq_sqrt_conductor) — the D=8 instance of Gauss's 1805 sign theorem, determining not just the modulus |τ|²=8 pinned by the Section E–F orthogonality data but the sign. The conductor identity τ² = 8 = χ₈(−1)·8 (gaussSumChi8_sq) and the twisted sums ∑ χ₈(a)ζ₈^{ca} = χ₈(c)τ for all units c mod 8 (gaussSumChi8_twisted) — the covariance identity powering the Gauss-sum route to generalized quadratic reciprocity — are verified exhaustively over (ℤ/8ℤ)ˣ = {1,3,5,7}.",
   "references": [
     {
       "authors": "Leopold Kronecker",
@@ -40,12 +40,12 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 26,
-    "defCount": 0,
-    "definitionCount": 0,
-    "lineCount": 435,
+    "theoremCount": 43,
+    "defCount": 2,
+    "definitionCount": 2,
+    "lineCount": 669,
     "dateAdded": "2026-07-11",
-    "assumptions": "0 axioms, 0 sorries — every result is machine-verified from the parent file's public API (propext, Classical.choice, Quot.sound only; the two kronecker2 results use only propext). Status is kept 'wip'/'axiomatized' to match the parent: the file proves genuine new lemmas (numerator periodicity of (a/n) for odd positive n via kronecker_congr_left / kronecker_add_mul_left / kronecker_periodic_left, and full period-8 periodicity of the (a/2) character via kronecker2_congr / kronecker2_add_mul_eight, plus the exact conductor 8 / primitivity of (·/2) via kronecker2_not_period_four / kronecker2_not_period_two / kronecker2_conductor_eight) but the broader open target — wiring kronecker2 into the definition at even moduli and generalized quadratic reciprocity for arbitrary fundamental discriminants — remains unformalized, exactly as documented in the parent's module note. Nothing new is assumed. Section E adds three further machine-verified results with no new assumptions: the anti-periodicity kronecker2_add_four ((a+4/2) = -(a/2), the sharp form of 'period 8 does not descend to 4'), the translation-invariant orthogonality kronecker2_sum_shifted_period (the mean of (·/2) over ANY full period vanishes, generalizing the parent-window kronecker2_sum_period), and the self-orthogonality kronecker2_sq_sum_period (∑ (a/2)² = φ(8) = 4 over a period) — all derived from the anti-periodicity and decidable residue arithmetic (propext, Classical.choice, Quot.sound only). Section F adds five further machine-verified results with no new assumptions: kronecker2_mul_shift_odd ((a/2)(a+t/2)=0 for odd t, pointwise via the parity obstruction), kronecker2_autocorr_odd and its translation-invariant _shifted form (C(t)=0 for odd t), kronecker2_autocorr_two (C(2)=0 by exact cancellation of the residue table, the one non-termwise off-peak), and the capstone kronecker2_autocorr_spectrum collecting C(0)=4, C(1)=C(2)=C(3)=0, C(4)=-4 into the full autocorrelation comb (4,0,0,0,-4,0,0,0) — all via decidable residue arithmetic and Finset.sum_eq_zero, kernel decide only (no native_decide, so no Lean.ofReduceBool; propext, Classical.choice, Quot.sound only).",
+    "assumptions": "0 axioms, 0 sorries — every result is machine-verified from the parent file's public API (propext, Classical.choice, Quot.sound only; the two kronecker2 results use only propext). Status is kept 'wip'/'axiomatized' to match the parent: the file proves genuine new lemmas (numerator periodicity of (a/n) for odd positive n via kronecker_congr_left / kronecker_add_mul_left / kronecker_periodic_left, and full period-8 periodicity of the (a/2) character via kronecker2_congr / kronecker2_add_mul_eight, plus the exact conductor 8 / primitivity of (·/2) via kronecker2_not_period_four / kronecker2_not_period_two / kronecker2_conductor_eight) but the broader open target — wiring kronecker2 into the definition at even moduli and generalized quadratic reciprocity for arbitrary fundamental discriminants — remains unformalized, exactly as documented in the parent's module note. Nothing new is assumed. Section E adds three further machine-verified results with no new assumptions: the anti-periodicity kronecker2_add_four ((a+4/2) = -(a/2), the sharp form of 'period 8 does not descend to 4'), the translation-invariant orthogonality kronecker2_sum_shifted_period (the mean of (·/2) over ANY full period vanishes, generalizing the parent-window kronecker2_sum_period), and the self-orthogonality kronecker2_sq_sum_period (∑ (a/2)² = φ(8) = 4 over a period) — all derived from the anti-periodicity and decidable residue arithmetic (propext, Classical.choice, Quot.sound only). Section F adds five further machine-verified results with no new assumptions: kronecker2_mul_shift_odd ((a/2)(a+t/2)=0 for odd t, pointwise via the parity obstruction), kronecker2_autocorr_odd and its translation-invariant _shifted form (C(t)=0 for odd t), kronecker2_autocorr_two (C(2)=0 by exact cancellation of the residue table, the one non-termwise off-peak), and the capstone kronecker2_autocorr_spectrum collecting C(0)=4, C(1)=C(2)=C(3)=0, C(4)=-4 into the full autocorrelation comb (4,0,0,0,-4,0,0,0) — all via decidable residue arithmetic and Finset.sum_eq_zero, kernel decide only (no native_decide, so no Lean.ofReduceBool; propext, Classical.choice, Quot.sound only). Section G adds seventeen further machine-verified results with no new assumptions: the primitive 8th root of unity zeta8 = (1+i)/√2 with zeta8_sq/zeta8_pow_four/zeta8_pow_eight/zeta8_orderOf (order exactly 8) and the exponential identification zeta8_eq_exp (ζ₈ = e^{2πi/8}, via Euler's formula and cos(π/4) = sin(π/4) = √2/2); the Gauss sum gaussSumChi8 = ∑ χ₈(a)ζ₈^a evaluated in closed form gaussSumChi8_eq (τ = 2√2), its sign form gaussSumChi8_eq_sqrt_conductor (τ = +√8), the conductor identity gaussSumChi8_sq (τ² = 8) with its even-character form, and the twisted Gauss sums gaussSumChi8_twisted_three/_five/_seven capped by gaussSumChi8_twisted (∑ χ₈(a)ζ₈^{ca} = χ₈(c)τ for every unit c mod 8). All proofs are field arithmetic over ℚ(i,√2) driven by linear_combination against the two relations i² = −1 and (√2)² = 2, plus kernel decide on the eight kronecker2 values (no native_decide; propext, Classical.choice, Quot.sound only).",
     "mathlibDependencies": [
       {
         "theorem": "jacobiSym.mod_left'",
@@ -88,65 +88,73 @@
       "id": "preamble",
       "title": "Preamble: the gap left by the parent",
       "startLine": 1,
-      "endLine": 46,
+      "endLine": 63,
       "summary": "Module docstring and imports. Records that the parent proves complete multiplicativity and motivates (·/n) as a primitive Dirichlet character (Section 5) but never formalizes numerator periodicity, and proves only single-step kronecker2_periodic; this file closes both gaps from the parent's public API with no new axioms. `open Int` brings the residue lemmas into scope.",
       "mathContext": "Goal: formalize the Dirichlet-character axiom $(a/n)=(b/n)$ when $a\\equiv b\\pmod n$, plus full period-8 periodicity of $(\\cdot/2)$."
     },
     {
       "id": "section-a",
       "title": "Section A: the Dirichlet-character property of (·/n)",
-      "startLine": 48,
-      "endLine": 88,
+      "startLine": 65,
+      "endLine": 105,
       "summary": "`kronecker_congr_left` (odd positive n: a ≡ b mod n ⟹ (a/n)=(b/n), via kronecker_eq_jacobi + jacobiSym.mod_left'), `kronecker_add_mul_left` (full period n: (a+n·k/n)=(a/n)), and `kronecker_periodic_left` (the k=1 textbook unit shift).",
       "mathContext": "For odd positive $n$: $(a/n)$ is a function of $a \\bmod n$, and $(a+nk\\,/\\,n)=(a/n)$ for all $k\\in\\mathbb{Z}$."
     },
     {
       "id": "section-b",
       "title": "Section B: full periodicity of the (·/2) character kronecker2",
-      "startLine": 89,
-      "endLine": 106,
+      "startLine": 106,
+      "endLine": 123,
       "summary": "Private helper `kronecker2_mod_eight` (kronecker2 x = kronecker2 (x % 8) via Int.emod_emod_of_dvd), then `kronecker2_congr` (a ≡ b mod 8 ⟹ equal) and `kronecker2_add_mul_eight` (full period 8, generalizing the parent's single-step kronecker2_periodic).",
       "mathContext": "$(\\cdot/2)$ is the even real Dirichlet character $\\chi_8$ modulo $8$: $\\mathrm{kronecker2}(a+8k)=\\mathrm{kronecker2}(a)$."
     },
     {
       "id": "section-c",
       "title": "Section C: 8 is the minimal period — (·/2) is primitive (conductor 8)",
-      "startLine": 107,
-      "endLine": 151,
+      "startLine": 124,
+      "endLine": 168,
       "summary": "`kronecker2_not_period_four` (period 4 fails, witnessed by kronecker2 5 = −1 ≠ 1 = kronecker2 1) and `kronecker2_not_period_two` (period 2 fails, witnessed by kronecker2 3 = −1 ≠ 1 = kronecker2 1), bundled with the full period-8 result in `kronecker2_conductor_eight`: 8 is the exact minimal period, so (·/2) = χ₈ is a *primitive* Dirichlet character mod 8, not induced from any smaller modulus. This upgrades the period-8 statement to the sharp conductor — the input the Gauss-sum route requires, since only primitive characters have nonvanishing Gauss sums.",
       "mathContext": "$\\chi_8=(\\cdot/2)$ has exact conductor $8$: periodic mod $8$ but not mod $4$ or mod $2$, hence primitive with nonvanishing Gauss sum $\\tau(\\chi_8)$."
     },
     {
       "id": "section-d",
       "title": "Section D: the residue-level character table and boundedness of χ₈",
-      "startLine": 152,
-      "endLine": 215,
+      "startLine": 169,
+      "endLine": 232,
       "summary": "The complete character table of (·/2): kronecker2_eq_zero_iff (0 on evens), kronecker2_ne_zero_iff (±1 on odds), kronecker2_eq_one_iff (+1 on {1,7} mod 8), kronecker2_eq_neg_one_iff (−1 on {3,5} mod 8), together with the pointwise bound kronecker2_abs_le_one and the mean-zero orthogonality kronecker2_sum_period over the base window [0,8).",
       "mathContext": "A non-principal Dirichlet character is pinned by its support and its two unit classes; the |χ|≤1 bound and ∑χ = 0 over a period are the elementary inputs the Gauss-sum / Pólya–Vinogradov estimates consume."
     },
     {
       "id": "section-e",
       "title": "Section E: anti-periodicity and the orthogonality normalization of χ₈",
-      "startLine": 216,
-      "endLine": 291,
+      "startLine": 233,
+      "endLine": 308,
       "summary": "Anti-periodicity kronecker2_add_four ((a+4/2) = -(a/2)); translation-invariant orthogonality kronecker2_sum_shifted_period (the mean over ANY full period vanishes, generalizing kronecker2_sum_period); and self-orthogonality kronecker2_sq_sum_period (∑ (a/2)² = φ(8) = 4). The anti-periodicity cancels the two halves of any window and normalizes the second moment.",
       "mathContext": "For the Gauss-sum route to generalized quadratic reciprocity: translation invariance of the character mean lets the Gauss sum ∑ χ₈(a) ζ^a be re-centered freely, and the diagonal norm ⟨χ₈,χ₈⟩ = φ(8) = 4 fixes |τ(χ₈)|² = 8. Anti-periodicity χ₈(a+4) = −χ₈(a) is the primitivity signature (conductor 8, not 4)."
     },
     {
       "id": "section-e-l2norm",
       "title": "Translation-Invariant L²-Norm and the Shift-4 Autocorrelation Peak",
-      "startLine": 292,
-      "endLine": 348,
+      "startLine": 309,
+      "endLine": 365,
       "summary": "Upgrades the base-window self-orthogonality to full translation invariance and reads off the second nonzero autocorrelation peak. kronecker2_sq_sum_shifted_period generalizes kronecker2_sq_sum_period to any length-8 window (∑ χ₈(c+a)² = 4 for every c, via the parity count of units among 8 consecutive integers). kronecker2_autocorr_four evaluates the shift-4 autocorrelation ∑ χ₈(a)χ₈(a+4) = −4, immediate from the anti-periodicity χ₈(a+4) = −χ₈(a); kronecker2_autocorr_four_shifted extends this to every window c. Together with the diagonal C(0) = 4 these are the two nonzero values of the length-8 autocorrelation function.",
       "mathContext": "$\\sum_{a=0}^{7}\\chi_8(c+a)^2 = 4$ for every $c$ (translation-invariant $L^2$-norm); $\\sum_{a=0}^{7}\\chi_8(a)\\chi_8(a+4) = -4$, the anti-diagonal peak of the autocorrelation $C(t)$, forced by $\\chi_8(a+4)=-\\chi_8(a)$."
     },
     {
       "id": "section-f",
       "title": "Section F: The Complete Autocorrelation Spectrum of χ₈ = (·/2)",
-      "startLine": 350,
-      "endLine": 435,
+      "startLine": 367,
+      "endLine": 452,
       "summary": "Determines the remaining off-peak values C(1) = C(2) = C(3) = 0 and assembles the full length-8 autocorrelation function. kronecker2_mul_shift_odd shows the pointwise product χ₈(a)·χ₈(a+t) vanishes termwise for every odd t (one of a, a+t is always even, and χ₈ vanishes on evens), giving kronecker2_autocorr_odd and its translation-invariant form (C(t) = 0 for all odd t, all windows) with no cancellation needed. kronecker2_autocorr_two handles the one non-termwise case, C(2) = 0, by exact cancellation of the residue table. kronecker2_autocorr_spectrum assembles all five values into the complete comb C(0,1,2,3,4) = (4,0,0,0,−4) — by the real-character symmetry C(t) = C(8−t) this determines all eight shifts as the sparse pattern (4,0,0,0,−4,0,0,0), the correlation data whose discrete Fourier transform is the power spectrum |τ(χ₈)|² = 8 in the Gauss-sum route to reciprocity.",
       "mathContext": "$C(t) := \\sum_{a=0}^{7}\\chi_8(a)\\chi_8(a+t)$. Odd $t$: termwise $0$ (parity obstruction). $C(2)=0$ by exact residue-table cancellation. Full spectrum: $(C(0),\\dots,C(7)) = (4,0,0,0,-4,0,0,0)$."
+    },
+    {
+      "id": "section-g",
+      "title": "Section G: The Gauss Sum τ(χ₈) — Explicit Value and Sign",
+      "startLine": 449,
+      "endLine": 668,
+      "summary": "Computes the Gauss sum of χ₈ in closed form. zeta8 defines the canonical primitive 8th root of unity ζ₈ = (1+i)/√2, identified with e^{2πi/8} (zeta8_eq_exp) and shown to have exact multiplicative order 8 (zeta8_sq: ζ₈² = i, zeta8_pow_four: ζ₈⁴ = −1, zeta8_pow_eight: ζ₈⁸ = 1, zeta8_orderOf). gaussSumChi8_eq evaluates the Gauss sum: τ(χ₈) = ∑ χ₈(a)ζ₈^a = ζ₈ − ζ₈³ − ζ₈⁵ + ζ₈⁷ = 2ζ₈(1−i) = 2√2 — a positive real, so gaussSumChi8_eq_sqrt_conductor records the sign theorem τ(χ₈) = +√8 (Gauss 1805, instance D = 8). gaussSumChi8_sq gives the conductor identity τ² = 8 = χ₈(−1)·8. The twisted sums gaussSumChi8_twisted_three/_five/_seven, capped by gaussSumChi8_twisted, verify the multiplicative covariance ∑ χ₈(a)ζ₈^{ca} = χ₈(c)·τ(χ₈) exhaustively over the unit group (ℤ/8ℤ)ˣ = {1,3,5,7} — the identity through which the Gauss sum transports quadratic reciprocity. All proofs are field arithmetic over ℚ(i,√2) via linear_combination against i² = −1 and (√2)² = 2, with exponents folded mod 8 by zeta8_pow_mod.",
+      "mathContext": "$\\tau(\\chi_8) = \\sum_{a=0}^{7}\\chi_8(a)\\zeta_8^a = 2\\sqrt{2} = +\\sqrt{8}$ with $\\zeta_8 = e^{2\\pi i/8}$: the modulus $|\\tau|^2 = 8$ AND the sign. Twisted covariance: $\\sum_a \\chi_8(a)\\zeta_8^{ca} = \\chi_8(c)\\,\\tau(\\chi_8)$ for $c \\in (\\mathbb{Z}/8\\mathbb{Z})^\\times$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Research increment on `elementary-quadratic-reciprocity-oq-03-oq-02-wip-01` (The Kronecker Symbol: Extending Jacobi to All Integers — WIP completion).

The prior Sections E–F established the full orthogonality/autocorrelation layer of the conductor-8 character `χ₈ = (·/2)`, pinning the *modulus* of its Gauss sum (`|τ(χ₈)|² = 8`) but leaving the Gauss sum itself — and in particular its **sign** — as the flagged open piece. **Section G (new) computes the Gauss sum in closed form.**

### New results (17 theorems, 2 defs — 0 axioms, 0 sorries)

- **`zeta8`** — the canonical primitive 8th root of unity `ζ₈ = (1+i)/√2`, with `ζ₈² = i`, `ζ₈⁴ = −1`, `ζ₈⁸ = 1`, exact multiplicative order 8 (`zeta8_orderOf`), and the exponential identification `ζ₈ = e^{2πi/8}` (`zeta8_eq_exp`, via Euler's formula and `cos(π/4) = sin(π/4) = √2/2`).
- **`gaussSumChi8_eq`** — the Gauss sum evaluated: `τ(χ₈) = Σ_{a=0}^{7} χ₈(a)ζ₈^a = ζ₈ − ζ₈³ − ζ₈⁵ + ζ₈⁷ = 2ζ₈(1−i) = 2√2`, a *positive real*.
- **`gaussSumChi8_eq_sqrt_conductor`** — the sign of the Gauss sum: `τ(χ₈) = +√8` (the `D = 8` instance of Gauss's 1805 sign theorem — the sign is invisible to any `|τ|` bookkeeping).
- **`gaussSumChi8_sq`** — the conductor identity `τ² = 8 = χ₈(−1)·8`, the identity through which the Gauss sum transports (generalized) quadratic reciprocity.
- **`gaussSumChi8_twisted`** — multiplicative covariance `Σ_a χ₈(a)ζ₈^{ca} = χ₈(c)·τ(χ₈)` verified exhaustively over the unit group `(ℤ/8ℤ)ˣ = {1,3,5,7}` — the engine of the Gauss-sum reciprocity argument.

All proofs are field arithmetic over `ℚ(i, √2)` driven by `linear_combination` against the two relations `i² = −1` and `(√2)² = 2`, with exponents folded mod 8 by `zeta8_pow_mod` and kernel `decide` on the eight `kronecker2` values (**no `native_decide`** — axiom profile stays `propext`/`Classical.choice`/`Quot.sound`).

### Gallery data

- `meta.json`: theoremCount 26 → 43, defCount 0 → 2, lineCount 435 → 669; description/assumptions extended; `sections[]` re-anchored (+17 header shift) and new Section G entry added.
- `annotations.json`: all five annotation ranges shifted +17 to match the grown file.

### Verification

`./proofs/scripts/docker-build.sh Proofs.ElementaryQuadraticReciprocityOQ03OQ02WIP01` — build succeeded (2970/2970 jobs), twice (including final file state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
