### PR TITLE
Enrich cube-root-3-irrational-oq-03-oq-01: 5th key insight + split degree-obstruction section

### DIFF
--- a/src/data/proofs/cube-root-3-irrational-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-03-oq-01/meta.json
@@ -88,7 +88,8 @@
       "**Constructibility is a degree constraint, and 3 fails it.** Wantzel's criterion turns the geometric impossibility into a divisibility: constructible ⟹ degree a power of 2. The parent already pinned the degree of ∛3 at 3; this entry only needs 3 ∤ 2^k to finish.",
       "**The tower law is the whole mechanism.** finrank ℚ ℚ⟮∛3⟯ ∣ finrank ℚ E holds for any E containing ∛3, purely because degrees multiply along ℚ ⊆ ℚ(∛3) ⊆ E. No properties of E beyond its dimension are used.",
       "**Phrased at the right level of generality.** Rather than formalizing a full ruler-and-compass predicate, the impossibility is stated for all 2-power-degree subfields — the exact algebraic content of constructibility — keeping the proof short and fully verified.",
-      "**Quadratic case is the crux.** cbrt3_notMem_of_finrank_two isolates k = 1: ∛3 is unreachable already by a single square-root construction, which is where the tower of a compass-and-straightedge process would have to begin."
+      "**Quadratic case is the crux.** cbrt3_notMem_of_finrank_two isolates k = 1: ∛3 is unreachable already by a single square-root construction, which is where the tower of a compass-and-straightedge process would have to begin.",
+      "**The obstruction is about the *degree* 3, not the radicand.** three_not_pow_two only needs that 3 is prime and unequal to 2 — the same one-line argument (p ∤ 2^k) blocks any element whose minimal polynomial has prime degree p ≠ 2 from every 2-power-degree field. ∛3's specific value never enters the arithmetic step; only [ℚ(∛3):ℚ] = 3, supplied by the parent, does."
     ],
     "prerequisites": [
       "Field extensions, degree [E:F], and the tower law",
@@ -109,22 +110,30 @@
       "id": "arithmetic",
       "title": "The Arithmetic Obstruction",
       "startLine": 36,
-      "endLine": 44,
+      "endLine": 43,
       "summary": "three_not_pow_two: 3 is not a power of 2, since 3 ∣ 2^k would force 3 ∣ 2.",
       "mathContext": "$3 \\neq 2^k$ for all $k$; the prime $3$ cannot divide a power of $2$."
     },
     {
-      "id": "degree-obstruction",
-      "title": "∛3 Lies in No 2-Power-Degree Field",
-      "startLine": 46,
-      "endLine": 61,
-      "summary": "cbrt3_notMem_of_finrank_pow_two: if [E:ℚ] = 2^k then ∛3 ∉ E, since ℚ(∛3) ⊆ E would make 3 divide 2^k via the tower law.",
-      "mathContext": "$\\sqrt[3]{3} \\in E \\Rightarrow 3 = [\\mathbb{Q}(\\sqrt[3]{3}):\\mathbb{Q}] \\mid [E:\\mathbb{Q}] = 2^k$, impossible."
+      "id": "degree-obstruction-statement",
+      "title": "Statement: ∛3 Lies in No 2-Power-Degree Field",
+      "startLine": 44,
+      "endLine": 51,
+      "summary": "cbrt3_notMem_of_finrank_pow_two's statement: for E ⊆ ℝ an intermediate field with [E:ℚ] = 2^k, ∛3 ∉ E. This is exactly the obstruction that makes ∛3 non-constructible, since every ruler-and-compass constructible real lies in such a 2-power-degree field.",
+      "mathContext": "$[E:\\mathbb{Q}] = 2^k \\Rightarrow \\sqrt[3]{3} \\notin E$."
+    },
+    {
+      "id": "degree-obstruction-proof",
+      "title": "Proof: the Tower Law Forces 3 ∣ 2^k",
+      "startLine": 52,
+      "endLine": 59,
+      "summary": "Assume ∛3 ∈ E. Then ℚ⟮∛3⟯ ≤ E by adjoin_simple_le_iff, so finrank ℚ ℚ⟮∛3⟯ ∣ finrank ℚ E via the tower law finrank_bot_mul_relfinrank. Rewriting by the parent's finrank_adjoin_cbrt3 = 3 and the hypothesis finrank ℚ E = 2^k gives 3 ∣ 2^k, hence 3 ∣ 2 (dvd_of_dvd_pow) and a contradiction by omega.",
+      "mathContext": "$\\sqrt[3]{3} \\in E \\Rightarrow 3 = [\\mathbb{Q}(\\sqrt[3]{3}):\\mathbb{Q}] \\mid [E:\\mathbb{Q}] = 2^k \\Rightarrow 3 \\mid 2$, impossible."
     },
     {
       "id": "quadratic",
       "title": "The Quadratic Case",
-      "startLine": 62,
+      "startLine": 60,
       "endLine": 68,
       "summary": "cbrt3_notMem_of_finrank_two: the k = 1 instance — ∛3 is in no quadratic extension of ℚ, the first obstruction to any construction.",
       "mathContext": "$\\sqrt[3]{3} \\notin E$ whenever $[E:\\mathbb{Q}] = 2$."


### PR DESCRIPTION
Enrichment pass for cube-root-3-irrational-oq-03-oq-01.

The entry sat at quality 96/100: annotations, mathContext, significance, historicalContext, conclusion, and crossRefs buckets were at cap, but `keyInsights` scored 8/10 (4 items) and `sections` scored 8/10 (4 sections).

**keyInsights (4 -> 5):** added a genuinely new insight — `three_not_pow_two` only needs that 3 is prime and ≠ 2, so the identical one-line argument obstructs any element of prime degree p ≠ 2 from every 2-power-degree field. The specific value of ∛3 never enters the arithmetic step, only the degree 3 (supplied by the parent) does.

**sections (4 -> 5, and fixes a real coverage gap):** the old `degree-obstruction` section (46-61) actually left line 45 of the theorem's doc comment uncovered, while overlapping the next theorem's doc comment (60-61) claimed by `quadratic` (62-68). Split it into `degree-obstruction-statement` (44-51) and `degree-obstruction-proof` (52-59), and tightened `arithmetic` (36-43) / `quadratic` (60-68) so the 68-line file is covered with no gaps or overlaps.

Verified with `find-targets.ts --json`: quality 96 -> 100 (keyInsights 8/10 -> 10/10, sections 8/10 -> 10/10, all other buckets unchanged at cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)