### PR TITLE
audit(erdos-1045): tracker entry — issues fixed (#42193)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9304,10 +9304,10 @@
       "result": "issues-fixed"
     },
     "erdos-1045": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:29Z",
-      "result": "clean"
+      "lastAudited": "2026-07-23T14:01:27Z",
+      "result": "issues-fixed"
     },
     "erdos-1046": {
       "auditCount": 4,


### PR DESCRIPTION
Tracker update for the erdos-1045 reserve-mode audit that found and fixed phantom axiom claims (sothanaphan_2025, cambie_dong_tang_6div) in meta.json prose. See #42192 and #42193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)