### PR TITLE
Enrich russell-1-plus-1-oq-02: cover header docstring (lines 1-51)

### DIFF
--- a/src/data/proofs/russell-1-plus-1-oq-02/meta.json
+++ b/src/data/proofs/russell-1-plus-1-oq-02/meta.json
@@ -56,6 +56,14 @@
   },
   "sections": [
     {
+      "id": "sec-header-russell-1-plus-1-oq-02",
+      "title": "Module Overview: Peano ℕ as a Commutative Semiring",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Completes the arithmetic story left open by the parent entry (which builds Peano + and proves it commutative/associative but never defines *): defines multiplication by primitive recursion, proves every commutative-semiring law relating + and *, and bundles them into a single machine-checked CommSemiring witness. Entirely Mathlib-free, matching the parent's from-scratch style.",
+      "mathContext": "Peano recursion $n \\cdot 0 = 0,\\ n\\cdot(\\text{succ } m) = n\\cdot m + n$; proves the full commutative-semiring axiom set for $(\\mathbb{N},+,\\cdot)$."
+    },
+    {
       "id": "peano-recap",
       "title": "Peano naturals and addition (recap)",
       "startLine": 52,


### PR DESCRIPTION
Enrichment pass for russell-1-plus-1-oq-02: the module's opening docstring (lines 1-51) stated real framing content (problem statement, approach, key results) that was completely uncovered by any `sections[]` entry or annotation. Adds a single `header`-type section summarizing only what the docstring itself says.