### PR TITLE
Enrich spherical-law-of-sines: cover header docstring (lines 1-32)

### DIFF
--- a/src/data/proofs/spherical-law-of-sines/meta.json
+++ b/src/data/proofs/spherical-law-of-sines/meta.json
@@ -68,6 +68,14 @@
   },
   "sections": [
     {
+      "id": "sec-header-spherical-law-of-sines",
+      "title": "Module Overview: Spherical Law of Sines",
+      "startLine": 1,
+      "endLine": 32,
+      "summary": "States the spherical law of sines: for a spherical triangle with unit-vector vertices A,B,C and arc-length sides a,b,c opposite dihedral angles α,β,γ, sin(a)/sin(α) = sin(b)/sin(β) = sin(c)/sin(γ). Outlines the proof: the key cross-product identity projPerp(B,A)×projPerp(C,A) = det[A,B,C]·A (valid since both projections are ⊥ to unit vector A) yields sin²(α) = det²/(sin²b sin²c), symmetric in a,b,c, giving the law of sines.",
+      "mathContext": "$\\dfrac{\\sin a}{\\sin\\alpha} = \\dfrac{\\sin b}{\\sin\\beta} = \\dfrac{\\sin c}{\\sin\\gamma}$ via $\\text{proj}_\\perp(B,A)\\times\\text{proj}_\\perp(C,A) = \\det[A,B,C]\\cdot A$."
+    },
+    {
       "id": "setup",
       "title": "Part I: Setup and Basic Lemmas",
       "startLine": 33,


### PR DESCRIPTION
Enrichment pass for spherical-law-of-sines: the module's opening docstring (lines 1-32) stated real framing content (problem statement, approach, key results) that was completely uncovered by any `sections[]` entry or annotation. Adds a single `header`-type section summarizing only what the docstring itself says.