### PR TITLE
audit(erdos-1097): tracker entry — issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9858,9 +9858,9 @@
     },
     "erdos-1097": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:03:30Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T14:13:23Z",
+      "result": "issues-fixed"
     },
     "erdos-1097-oq-01": {
       "auditCount": 4,


### PR DESCRIPTION
Tracker entry for erdos-1097 audit: fixed prose overstating axiom count
(overview.text/section summary/annotations claimed 6/4 axioms; only 3 exist).
See #42223 for the fix.