### PR TITLE
audit(erdos-1094): fix stale axiomCount and exception-count prose

### DIFF
--- a/src/data/proofs/erdos-1094/annotations.json
+++ b/src/data/proofs/erdos-1094/annotations.json
@@ -77,7 +77,7 @@
       "endLine": 79
     },
     "title": "Computationally Verified Exceptions",
-    "content": "Twelve of the 14 known exceptions are verified computationally using native_decide, which reduces the check to kernel evaluation. Each exception (n,k) satisfies k > 0, n ≥ 2k, and minFac(C(n,k)) > max(n/k, k). Notable cases include C(7,3) = 35 (the smallest exception, shared with Problem 384), C(62,6) (Selfridge's famous exception), and C(95,10) (the largest computationally verified).",
+    "content": "All 14 known exceptions are verified computationally using native_decide, which reduces the check to kernel evaluation. Each exception (n,k) satisfies k > 0, n ≥ 2k, and minFac(C(n,k)) > max(n/k, k). Notable cases include C(7,3) = 35 (the smallest exception, shared with Problem 384), C(62,6) (Selfridge's famous exception), and C(284,28) ≈ 2.4×10³⁸ (the largest, previously an axiom).",
     "mathContext": "Verified: $\\operatorname{lpf}\\binom{7}{3} = \\operatorname{lpf}(35) = 5 > 3 = \\max(2,3)$, $\\operatorname{lpf}\\binom{62}{6} = 11 > 10 = \\max(10,6)$, and 10 others by kernel computation.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-1094/meta.json
+++ b/src/data/proofs/erdos-1094/meta.json
@@ -19,7 +19,7 @@
     "erdosNumber": 1094,
     "erdosUrl": "https://erdosproblems.com/1094",
     "erdosProblemStatus": "open",
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 248,
     "assumptions": "No mathematical axioms. Previously had 1 axiom (main_implies_384) which was eliminated by proving the naive formulation of Problem 384 is false. Open conjecture; supporting lemmas fully verified. Compiler-trust disclosure: the 14 known exception witnesses (exception_7_3 … exception_284_28, the largest checking C(284,28)≈2.4×10³⁸), the non-exception witnesses (non_exception_4_2 … non_exception_100_2), the bound_* simplifications, erdos384_naive_false, and the choose_gt_one_* facts are discharged with native_decide, so their axiom footprint includes Lean.ofReduceBool (kernel reduction trusts the compiled decision procedure). These are finite decidable computations and add no mathematical assumption; leanFile.axiomCount remains 0 (no literal axiom declarations).",
     "mathlib_version": "4.31.0",


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-1094 (Least Prime Factor of Binomial Coefficients)
**Problem**: `meta.axiomCount` (top-level) said `1`, contradicting `leanFile.axiomCount: 0`, the actual Lean source (0 `axiom` declarations), and the `assumptions` prose in the same JSON block ("No mathematical axioms... previously had 1 axiom... which was eliminated"). Stale from before `main_implies_384` was removed.

Also fixed a stale annotation claiming "twelve of the 14" exceptions were verified — all 14 are proved via `native_decide` (the two largest, `exception_241_16` and `exception_284_28`, were formerly axioms and are now proved).

## Evidence

- `src/data/proofs/erdos-1094/meta.json` top-level `meta.axiomCount`: 1 → 0
- `leanFile.axiomCount`: already 0 (unchanged)
- `grep '^axiom' proofs/Proofs/Erdos1094Problem.lean`: 0 hits
- theoremCount (38), definitionCount (8), sorries (0) all verified exact against the file — no other mismatches found.

## Fix

Two one-line JSON edits; no Lean source changes.

---
Discovered during gallery integrity audit (severity: LOW per axiom-count-off-by-1 rubric; fixed inline).