### PR TITLE
Enrich konigsberg-oq-01-oq-02-incomplete-01: cover header docstring (lines 1-63)

### DIFF
--- a/src/data/proofs/konigsberg-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/konigsberg-oq-01-oq-02-incomplete-01/meta.json
@@ -53,6 +53,7 @@
     ]
   },
   "sections": [
+      {"id": "sec-header-konigsberg-oq-01-oq-02-incomplete-01", "title": "Module Header: Circuit-Removal Balance — Correcting the Parent's Unconditional Claim", "startLine": 1, "endLine": 63, "summary": "States and fixes a false unconditional theorem in the parent file KonigsbergOQ01OQ02.lean: removing a circuit's edges from a directed graph preserves balance only if the graph was already balanced, not unconditionally. Outlines the four results: the Finset.sdiff degree-distributivity lemmas, the corrected balance-preservation theorem with the missing hypothesis restored, a witness that a genuine directed circuit is circuit-balanced, and a concrete Fin 4 counterexample refuting the parent's unconditional version. Fully self-contained, 0 axioms, 0 sorries.", "mathContext": "For $S \\subseteq E$ circuit-balanced (out-degree = in-degree on $S$ at every vertex) inside a balanced graph $E$, the difference graph $E \\setminus S$ is again balanced; the parent's unconditional version (balance of $E \\setminus S$ with no hypothesis on $E$) is false."},
     {
       "id": "sec-degrees",
       "title": "Degrees as filtered edge-set cardinalities",


### PR DESCRIPTION
Adds a header section covering the module docstring (previously uncovered by `sections[]`/`annotations.json`), per the enrichment header-docstring vein.