### PR TITLE
Research (szemeredi-oq-04 S19): thread both step shapes through the AFKS outer loop

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04OuterBoth.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04OuterBoth.lean
@@ -1,0 +1,326 @@
+/-
+  Szemerédi Regularity Lemma — OQ-04: the outer loop threaded with BOTH step
+  shapes (S17 residual (b), the last layer).
+
+  The item-1 dichotomy of the strong (AFKS) regularity lemma resolves a
+  non-fine-regular partition into one of TWO honest refinement shapes
+  (`StepThree.lean`, S16–S17):
+
+  * the symmetric 4-piece step `IsWitnessedSharpStep` (`Outer.lean`) — both
+    parents split, sharp `2×2` grid, `eps⁴` partition-energy gain
+    (`partitionEnergy_prod_gain_eps4`, Assembly.lean); and
+  * the asymmetric 3-piece step `IsWitnessedSharpStep3` (`StepThree.lean`) —
+    only `B` splits, defect deviation against the parent, `eps³` PAIR-energy
+    gain (`pairEnergy_gain_of_isWitnessedSharpStep3`, DefectGain.lean, S18).
+
+  The outer-loop assembly `exists_afksTwoLevel_of_dichotomy` (`Outer.lean`)
+  consumed only the 4-piece shape, so the degenerate branch of the dichotomy
+  could not yet drive the loop.  This file closes that gap:
+
+  * `partitionEnergy_step3_refinement_gain` — the S18 pair-level `eps³` gain
+    lifted to the WHOLE partition: replacing `{A, B}` by `{A, B₁, B₂}` over the
+    untouched residual `R` raises `partitionEnergy` by `eps³·|A||B|/n²`.  The
+    block decomposition mirrors `partitionEnergy_prod_refinement_gain`
+    (Assembly.lean): the `R×R` block and every `A`-row/column are unchanged,
+    the `B`-rows/columns against `R`, the `(B,A)` cross and the `B²` diagonal
+    split by pure `pairEnergy` monotonicity, and the single `(A,B)` cross
+    carries the defect gain (`pairEnergy_step3_gain`).
+  * `afks_sharp_energy_iteration_count_of_witness_both` — the mixed-chain
+    iteration count: a chain in which EVERY step is witnessed by EITHER shape
+    still gains `≥ eps⁴·m²/n²` per step (for `eps ≤ 1` the 3-piece `eps³` floor
+    dominates the 4-piece `eps⁴` one), so `N ≤ n²/(eps⁴·m²)` — the SAME sharp
+    budget as the pure 4-piece chain: the degenerate branch is not merely
+    tolerated, it is cheaper.
+  * `afks_regular_step_within_bound_both` — termination: past the sharp budget
+    some step carries NEITHER witness shape.
+  * `exists_afksTwoLevel_of_dichotomy_both` — **the reformulated outer loop**:
+    the dichotomy hypothesis now concludes `IsWitnessedSharpStep ∨
+    IsWitnessedSharpStep3`, exactly the disjunction
+    `exists_proper_or_semitrivial_split_of_not_afksFineRegular` (S17) produces.
+    A step below the horizon with neither witness must be AFKS-fine-regular,
+    and packages with the coarse partition into `IsAFKSTwoLevel`.
+  * `exists_afksTwoLevel_of_dichotomy_both_equipartition` — the tower-free
+    `k²/E(k)⁴` horizon form of the same conclusion.
+
+  Everything is a chaining of verified primitives: 0 axioms, 0 sorries.
+
+  Reference: Alon–Fischer–Krivelevich–Szegedy, "Efficient testing of large
+  graphs", Combinatorica 20 (2000).
+-/
+import Mathlib
+import Proofs.SzemerediRegularityOQ04Outer
+import Proofs.SzemerediRegularityOQ04DefectGain
+
+namespace Szemeredi.RegularityOQ04OuterBoth
+
+open Classical
+open Szemeredi.Core Szemeredi.EnergyIncrement Szemeredi.RegularityOQ04Energy
+  Szemeredi.RegularityOQ04Bridge Szemeredi.RegularityOQ04StepThree
+  Szemeredi.RegularityOQ04DefectGain Szemeredi.RegularityOQ04Outer
+  Szemeredi.RegularityOQ04TwoLevel Szemeredi.RegularityOQ04ToleranceBridge
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- The bridge in nested-double-sum form (local re-derivation of the Bridge
+    file's `private` helper), convenient for block decompositions. -/
+private theorem partitionEnergy_eq_double_sum (G : SimpleGraph V)
+    [DecidableRel G.Adj] (parts : Finset (Finset V)) :
+    partitionEnergy G parts =
+      parts.sum (fun P => parts.sum (fun Q => pairEnergy G P Q)) := by
+  rw [partitionEnergy_eq_sum_pairEnergy,
+    show parts.product parts = parts ×ˢ parts from rfl, Finset.sum_product]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART I: THE 3-PIECE STEP GAIN, LIFTED TO THE WHOLE PARTITION
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Whole-partition `eps³` gain of the asymmetric 3-piece refinement.**  Let
+    `R` be the remaining parts and `A, B` two further distinct parts; split only
+    `B = B₁ ∪ B₂` disjointly, with the deviating piece `B₁` carrying the
+    `eps`-mass floor and the `eps`-defect deviation against the parent density
+    `d(A,B)`.  Then replacing `{A, B}` by `{A, B₁, B₂}` raises
+    `partitionEnergy` by at least `eps³·|A||B|/n²`:
+
+    `partitionEnergy G (insert A (insert B R)) + eps³·|A||B|/n²
+        ≤ partitionEnergy G (insert A (insert B₁ (insert B₂ R)))`.
+
+    The ordered-pair double sum decomposes as in
+    `partitionEnergy_prod_refinement_gain`: the `R×R` block, the `(A,A)` cell
+    and the `A`-rows/columns against `R` coincide on both sides; the
+    `B`-rows/columns against `R`, the `(B,A)` cross and the `B²` diagonal split
+    by pure `pairEnergy` monotonicity; and the single `(A,B)` cross carries the
+    one-sided defect gain `pairEnergy_step3_gain` (S18). -/
+theorem partitionEnergy_step3_refinement_gain (G : SimpleGraph V)
+    [DecidableRel G.Adj] (R : Finset (Finset V)) (A B B₁ B₂ : Finset V)
+    (hBunion : B₁ ∪ B₂ = B) (hdisjB : Disjoint B₁ B₂)
+    -- coarse-side freshness
+    (hAins : A ∉ insert B R) (hBR : B ∉ R)
+    -- fine-side freshness
+    (hAins' : A ∉ insert B₁ (insert B₂ R))
+    (hB₁ins : B₁ ∉ insert B₂ R) (hB₂R : B₂ ∉ R)
+    (eps : ℚ) (heps : 0 < eps)
+    (hApos : 0 < (A.card : ℚ)) (hBpos : 0 < (B.card : ℚ))
+    (hfloor : eps * B.card ≤ (B₁.card : ℚ))
+    (hdev : eps ≤ |edgeDensity G A B₁ - edgeDensity G A B|) :
+    partitionEnergy G (insert A (insert B R)) +
+        eps ^ 3 * ((A.card : ℚ) * B.card) / (Fintype.card V : ℚ) ^ 2 ≤
+      partitionEnergy G (insert A (insert B₁ (insert B₂ R))) := by
+  -- `(A,B)` cross block: carries the S18 defect gain.
+  have hAB : pairEnergy G A B +
+        eps ^ 3 * ((A.card : ℚ) * B.card) / (Fintype.card V : ℚ) ^ 2 ≤
+      pairEnergy G A B₁ + pairEnergy G A B₂ :=
+    pairEnergy_step3_gain G A B B₁ B₂ hBunion hdisjB eps heps hApos hBpos
+      hfloor hdev
+  -- `(B,A)` cross block (pure monotonicity).
+  have hBA : pairEnergy G B A ≤ pairEnergy G B₁ A + pairEnergy G B₂ A := by
+    have h := pairEnergy_split_mono G B₁ B₂ A hdisjB
+    rwa [hBunion] at h
+  -- diagonal `B²` block (pure monotonicity, both coordinates).
+  have hBB : pairEnergy G B B ≤
+      pairEnergy G B₁ B₁ + pairEnergy G B₁ B₂ +
+        pairEnergy G B₂ B₁ + pairEnergy G B₂ B₂ := by
+    have a := pairEnergy_split_mono G B₁ B₂ (B₁ ∪ B₂) hdisjB
+    have b := pairEnergy_split_mono_right G B₁ B₁ B₂ hdisjB
+    have c := pairEnergy_split_mono_right G B₂ B₁ B₂ hdisjB
+    rw [hBunion] at a b c; linarith
+  -- `B`-column against `R` splits.
+  have hcolB : R.sum (fun Q => pairEnergy G B Q) ≤
+      R.sum (fun Q => pairEnergy G B₁ Q) +
+        R.sum (fun Q => pairEnergy G B₂ Q) := by
+    rw [← Finset.sum_add_distrib]
+    refine Finset.sum_le_sum fun Q _ => ?_
+    have h := pairEnergy_split_mono G B₁ B₂ Q hdisjB
+    rwa [hBunion] at h
+  -- `B`-row against `R` splits.
+  have hrowB : R.sum (fun P => pairEnergy G P B) ≤
+      R.sum (fun P => pairEnergy G P B₁) +
+        R.sum (fun P => pairEnergy G P B₂) := by
+    rw [← Finset.sum_add_distrib]
+    refine Finset.sum_le_sum fun P _ => ?_
+    have h := pairEnergy_split_mono_right G P B₁ B₂ hdisjB
+    rwa [hBunion] at h
+  -- Expand both partition energies to their block decompositions.
+  rw [partitionEnergy_eq_double_sum, partitionEnergy_eq_double_sum]
+  simp only [Finset.sum_insert hAins, Finset.sum_insert hBR,
+    Finset.sum_insert hAins', Finset.sum_insert hB₁ins,
+    Finset.sum_insert hB₂R, Finset.sum_add_distrib]
+  linarith [hAB, hBA, hBB, hcolB, hrowB]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART II: THE MIXED-CHAIN ITERATION COUNT (BOTH STEP SHAPES)
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Sharp iteration count for a mixed chain of witnessed steps.**  If every
+    step `n < N` of a refinement chain is witnessed by EITHER shape — the
+    symmetric 4-piece `IsWitnessedSharpStep` or the asymmetric 3-piece
+    `IsWitnessedSharpStep3`, both at tolerance `eps ≤ 1` and mass floor `m` —
+    then each step raises `partitionEnergy` by at least the uniform floor
+    `eps⁴·m²/n²` (the 4-piece step by `partitionEnergy_prod_gain_eps4`, the
+    3-piece step by the stronger `eps³ ≥ eps⁴` defect gain of Part I), so the
+    `[0,1]`-potential engine caps the chain length at the SAME sharp budget as
+    the pure 4-piece chain:
+
+    `N ≤ n² / (eps⁴·m²)`.
+
+    The degenerate branch of the S17 dichotomy therefore costs the outer loop
+    nothing: its per-step gain is `eps³·m²/n² ≥ eps⁴·m²/n²`. -/
+theorem afks_sharp_energy_iteration_count_of_witness_both
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (parts : ℕ → Finset (Finset V)) (N : ℕ) (eps m : ℚ)
+    (hε : 0 < eps) (hε1 : eps ≤ 1) (hm : 0 < m)
+    (hcard : 0 < (Fintype.card V : ℚ))
+    (hcover : ∀ n, ∀ v : V, ∃ P ∈ parts n, v ∈ P)
+    (hdisjoint : ∀ n, ∀ P Q : Finset V, P ∈ parts n → Q ∈ parts n → P ≠ Q →
+      Disjoint P Q)
+    (hwit : ∀ n, n < N → IsWitnessedSharpStep G parts n eps m ∨
+      IsWitnessedSharpStep3 G parts n eps m) :
+    (N : ℚ) ≤ (Fintype.card V : ℚ) ^ 2 / (eps ^ 4 * m ^ 2) := by
+  refine afks_sharp_energy_iteration_count G parts N eps (m ^ 2) hε
+    (by positivity) hcard hcover hdisjoint ?_
+  intro n hn
+  rcases hwit n hn with hstep | hstep
+  · -- symmetric 4-piece step: the sharp `eps⁴` product gain.
+    obtain ⟨R, A, B, A₁, A₂, B₁, B₂, hpn, hpn1, hAu, hBu, hdA, hdB,
+      hAins, hBR, hA1, hA2, hB1, hB2, hmA, hmB, hcA, hcB, hdev⟩ := hstep
+    rw [hpn, hpn1]
+    have hgain := partitionEnergy_prod_gain_eps4 G R A B A₁ A₂ B₁ B₂
+      hAu hBu hdA hdB hAins hBR hA1 hA2 hB1 hB2 eps hε.le hcA hcB hdev
+    have hmass : m ^ 2 ≤ (A.card : ℚ) * B.card := by
+      nlinarith [hmA, hmB, hm.le]
+    have hfloor : eps ^ 4 * m ^ 2 / (Fintype.card V : ℚ) ^ 2 ≤
+        eps ^ 4 * ((A.card : ℚ) * B.card) / (Fintype.card V : ℚ) ^ 2 := by
+      gcongr
+    linarith [hgain, hfloor]
+  · -- asymmetric 3-piece step: the `eps³` defect gain dominates `eps⁴`.
+    obtain ⟨R, A, B, B₁, B₂, hpn, hpn1, hBu, hdB, hAins, hBR, hAins',
+      hB₁ins, hB₂R, hmA, hmB, hfl, hdev⟩ := hstep
+    rw [hpn, hpn1]
+    have hApos : 0 < (A.card : ℚ) := lt_of_lt_of_le hm hmA
+    have hBpos : 0 < (B.card : ℚ) := lt_of_lt_of_le hm hmB
+    have hgain := partitionEnergy_step3_refinement_gain G R A B B₁ B₂
+      hBu hdB hAins hBR hAins' hB₁ins hB₂R eps hε hApos hBpos hfl hdev
+    -- `eps⁴·m² ≤ eps³·m² ≤ eps³·|A||B|` (one power of `eps ≤ 1` is dropped).
+    have hmass : m ^ 2 ≤ (A.card : ℚ) * B.card := by
+      nlinarith [hmA, hmB, hm.le]
+    have heps3 : (0 : ℚ) ≤ eps ^ 3 := by positivity
+    have h43 : eps ^ 4 ≤ eps ^ 3 := by
+      nlinarith [mul_nonneg heps3 (sub_nonneg.mpr hε1)]
+    have hnum : eps ^ 4 * m ^ 2 ≤ eps ^ 3 * ((A.card : ℚ) * B.card) :=
+      mul_le_mul h43 hmass (sq_nonneg m) heps3
+    have hfloor : eps ^ 4 * m ^ 2 / (Fintype.card V : ℚ) ^ 2 ≤
+        eps ^ 3 * ((A.card : ℚ) * B.card) / (Fintype.card V : ℚ) ^ 2 := by
+      rw [div_eq_mul_inv, div_eq_mul_inv]
+      exact mul_le_mul_of_nonneg_right hnum (by positivity)
+    linarith [hgain, hfloor]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART III: TERMINATION AGAINST BOTH SHAPES
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Termination for the two-shape loop.**  Past the sharp budget
+    `n²/(eps⁴·m²)`, some step `n < N` carries NEITHER witness shape: it is not
+    a symmetric 4-piece sharp step and not an asymmetric 3-piece defect step.
+    This is the contrapositive of the mixed-chain iteration count, and the
+    exact hook the two-shape dichotomy needs — at that step the S17 case split
+    can produce no refinement, so the partition must already be fine-regular. -/
+theorem afks_regular_step_within_bound_both
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (parts : ℕ → Finset (Finset V)) (N : ℕ) (eps m : ℚ)
+    (hε : 0 < eps) (hε1 : eps ≤ 1) (hm : 0 < m)
+    (hcard : 0 < (Fintype.card V : ℚ))
+    (hcover : ∀ n, ∀ v : V, ∃ P ∈ parts n, v ∈ P)
+    (hdisjoint : ∀ n, ∀ P Q : Finset V, P ∈ parts n → Q ∈ parts n → P ≠ Q →
+      Disjoint P Q)
+    (hN : (Fintype.card V : ℚ) ^ 2 / (eps ^ 4 * m ^ 2) < N) :
+    ∃ n < N, ¬ (IsWitnessedSharpStep G parts n eps m ∨
+      IsWitnessedSharpStep3 G parts n eps m) := by
+  by_contra hcon
+  push_neg at hcon
+  have hle := afks_sharp_energy_iteration_count_of_witness_both
+    G parts N eps m hε hε1 hm hcard hcover hdisjoint hcon
+  exact absurd hle (not_le.mpr hN)
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART IV: THE OUTER LOOP, RE-THREADED WITH BOTH STEP SHAPES
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **The outer AFKS loop with the two-shape dichotomy (S17 residual (b)).**
+    Identical wiring to `exists_afksTwoLevel_of_dichotomy` (Outer.lean), but
+    the regular-or-refine dichotomy hypothesis now concludes the DISJUNCTION of
+    step shapes — a witnessed symmetric 4-piece sharp step OR a witnessed
+    asymmetric 3-piece defect step — which is exactly what the S17 case split
+    `exists_proper_or_semitrivial_split_of_not_afksFineRegular` yields for a
+    non-fine-regular partition.
+
+    Past the sharp budget the mixed-chain termination finds a step with
+    NEITHER witness; by the dichotomy's contrapositive that partition is
+    AFKS-fine-regular, and it packages with the coarse `ε`-regular `Vparts`
+    into the two-level conclusion.  The extra hypothesis over the one-shape
+    version is only `E(k) ≤ 1` (needed so the 3-piece `eps³` gain dominates the
+    common `eps⁴` budget); every tolerance of interest satisfies it. -/
+theorem exists_afksTwoLevel_of_dichotomy_both
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (ε : ℚ) (E : ℕ → ℚ) (Vparts : Finset (Finset V))
+    (parts : ℕ → Finset (Finset V)) (N : ℕ) (m : ℚ)
+    (hEpos : 0 < E Vparts.card) (hE1 : E Vparts.card ≤ 1) (hm : 0 < m)
+    (hcard : 0 < (Fintype.card V : ℚ))
+    (hcover : ∀ n, ∀ v : V, ∃ P ∈ parts n, v ∈ P)
+    (hdisjoint : ∀ n, ∀ P Q : Finset V, P ∈ parts n → Q ∈ parts n → P ≠ Q →
+      Disjoint P Q)
+    (hN : (Fintype.card V : ℚ) ^ 2 / (E Vparts.card ^ 4 * m ^ 2) < N)
+    (hcoarse : IsRegularPartition G ε Vparts)
+    (href : ∀ n, IsRefinement (parts n) Vparts)
+    (hdich : ∀ n, n < N → ¬ IsAFKSFineRegular G ε (E Vparts.card) (parts n) →
+      IsWitnessedSharpStep G parts n (E Vparts.card) m ∨
+      IsWitnessedSharpStep3 G parts n (E Vparts.card) m) :
+    ∃ n < N, IsAFKSTwoLevel G ε E Vparts (parts n) := by
+  obtain ⟨n, hn, hno⟩ := afks_regular_step_within_bound_both
+    G parts N (E Vparts.card) m hEpos hE1 hm hcard hcover hdisjoint hN
+  refine ⟨n, hn, ?_⟩
+  have hfine : IsAFKSFineRegular G ε (E Vparts.card) (parts n) := by
+    by_contra hcon
+    exact hno (hdich n hn hcon)
+  exact
+    { coarseRegular := hcoarse
+      refines := href n
+      fineRegular := hfine }
+
+/-- **Vertex-count-free (tower-free) horizon form of the two-shape loop.**
+    Identical conclusion to `exists_afksTwoLevel_of_dichotomy_both`, with the
+    horizon stated in the dimension-free `k²/E(k)⁴` shape via the
+    equipartition mass floor `m = n/k`, exactly as in
+    `exists_afksTwoLevel_of_dichotomy_equipartition`. -/
+theorem exists_afksTwoLevel_of_dichotomy_both_equipartition
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (ε : ℚ) (E : ℕ → ℚ) (Vparts : Finset (Finset V))
+    (parts : ℕ → Finset (Finset V)) (N : ℕ)
+    (hEpos : 0 < E Vparts.card) (hE1 : E Vparts.card ≤ 1)
+    (hkpos : 0 < Vparts.card) (hcard : 0 < (Fintype.card V : ℚ))
+    (hcover : ∀ n, ∀ v : V, ∃ P ∈ parts n, v ∈ P)
+    (hdisjoint : ∀ n, ∀ P Q : Finset V, P ∈ parts n → Q ∈ parts n → P ≠ Q →
+      Disjoint P Q)
+    (hN : (Vparts.card : ℚ) ^ 2 / E Vparts.card ^ 4 < N)
+    (hcoarse : IsRegularPartition G ε Vparts)
+    (href : ∀ n, IsRefinement (parts n) Vparts)
+    (hdich : ∀ n, n < N → ¬ IsAFKSFineRegular G ε (E Vparts.card) (parts n) →
+      IsWitnessedSharpStep G parts n (E Vparts.card)
+        ((Fintype.card V : ℚ) / Vparts.card) ∨
+      IsWitnessedSharpStep3 G parts n (E Vparts.card)
+        ((Fintype.card V : ℚ) / Vparts.card)) :
+    ∃ n < N, IsAFKSTwoLevel G ε E Vparts (parts n) := by
+  set k : ℚ := (Vparts.card : ℚ) with hk
+  set n : ℚ := (Fintype.card V : ℚ) with hnc
+  have hkq : (0 : ℚ) < k := by rw [hk]; exact_mod_cast hkpos
+  have hmpos : (0 : ℚ) < n / k := div_pos hcard hkq
+  have hEne : E Vparts.card ≠ 0 := hEpos.ne'
+  have hkne : k ≠ 0 := hkq.ne'
+  have hnne : n ≠ 0 := hcard.ne'
+  -- `n² / (E(k)⁴ · (n/k)²) = k² / E(k)⁴`.
+  have heq : n ^ 2 / (E Vparts.card ^ 4 * (n / k) ^ 2) =
+      k ^ 2 / E Vparts.card ^ 4 := by
+    field_simp
+  refine exists_afksTwoLevel_of_dichotomy_both G ε E Vparts parts N (n / k)
+    hEpos hE1 hmpos hcard hcover hdisjoint ?_ hcoarse href hdich
+  rw [heq]; exact hN
+
+end Szemeredi.RegularityOQ04OuterBoth

--- a/src/data/research/problems/szemeredi-regularity-oq-04.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-04.json
@@ -20,10 +20,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-08T19:45:20Z",
-    "iteration": 5,
-    "focus": "S18 (2026-07-22): one-sided defect energy gain DONE — SzemerediRegularityOQ04DefectGain.lean proves defect_energy_bound (weighted-mean defect, w2=0 allowed), pairEnergy_split_gain_defect(_right) (deviation vs PARENT density, gain |A1||B|/n^2 * delta^2), pairEnergy_step3_gain (eps^3 * |A||B|/n^2 via the eps-mass floor), and the capstone pairEnergy_gain_of_isWitnessedSharpStep3. The S17 3-piece step now carries its quantitative energy increment; eps^3 >= eps^4 so the symmetric outer budget covers both dichotomy branches. [VERIFIED 0 axioms, docker 8588 jobs]",
+    "iteration": 6,
+    "focus": "S19 (2026-07-23): outer loop threaded with BOTH step shapes DONE — SzemerediRegularityOQ04OuterBoth.lean proves partitionEnergy_step3_refinement_gain (whole-partition eps^3 lift of the S18 defect gain over insert A (insert B1 (insert B2 R))), afks_sharp_energy_iteration_count_of_witness_both (mixed 4-piece/3-piece chains stay within the SAME sharp n^2/(eps^4 m^2) budget for eps<=1), afks_regular_step_within_bound_both (termination against the disjunctive witness), and exists_afksTwoLevel_of_dichotomy_both / _equipartition consuming the S17 two-shape dichotomy. [VERIFIED 0 axioms, docker 8592 jobs]",
     "blockers": [],
-    "nextAction": "S17 residual (b), the last layer: thread BOTH step shapes (4-piece IsWitnessedSharpStep with eps^4 gain, 3-piece IsWitnessedSharpStep3 with the new eps^3 gain) through the outer-loop chain construction — partition-level increment over insert A (insert B1 (insert B2 R)) (cf. PartitionGain.lean for the symmetric shape) and the recursive exists_afksTwoLevel_of_dichotomy reformulation. Deep outer-loop assembly; no elementary increment remains at the pair level."
+    "nextAction": "The residual gap is between split DATA and WITNESSED STEPS: exists_proper_or_semitrivial_split_of_not_afksFineRegular (S17) yields the 4-piece/3-piece split data, while the _both dichotomy hypothesis needs the chain parts(n+1) to BE the refined partition with the freshness clauses (split pieces distinct from each other and from R) and coarse mass floors discharged. Constructing the recursive refinement chain that realizes the case split at every non-regular step — the 'nonempty-equipartition model' blocker recorded in Assembly.lean — is the genuine remaining outer-loop content. Deep construction; no elementary increment remains at the pair or partition level."
   },
   "knowledge": {
     "progressSummary": "Item-1 dichotomy: constructive core COMPLETE at the pair level. S12-S15 packaging/freshness/mass-floor/ceiling; S16 gap forbids doubly-trivial splits; S17 asymmetric 3-piece predicate IsWitnessedSharpStep3 + trichotomy (one normalized shape covers both degenerate sides via edgeDensity_symm); S18 (2026-07-22) the one-sided DEFECT energy inequality: deviation of ONE half from the PARENT density gains (|A1||B|/n^2)*delta^2 (defect_energy_bound, multiplicative mean, empty complement allowed), and with the eps-mass floor the 3-piece step gains eps^3*|A||B|/n^2 (pairEnergy_step3_gain, capstone pairEnergy_gain_of_isWitnessedSharpStep3). Remaining: outer-loop chain construction threading both step shapes (deep).",
@@ -94,7 +94,10 @@
       "defect_energy_bound (two-cell weighted-mean defect inequality, w2=0 allowed) in SzemerediRegularityOQ04DefectGain.lean",
       "pairEnergy_split_gain_defect / _right (one-sided gain vs parent density, A-side and B-side) in SzemerediRegularityOQ04DefectGain.lean",
       "pairEnergy_step3_gain (eps^3*|A||B|/n^2 gain of the 3-piece split via the eps-mass floor) in SzemerediRegularityOQ04DefectGain.lean",
-      "pairEnergy_gain_of_isWitnessedSharpStep3 (capstone: witnessed 3-piece step carries the eps^3 pair-energy gain) in SzemerediRegularityOQ04DefectGain.lean"
+      "pairEnergy_gain_of_isWitnessedSharpStep3 (capstone: witnessed 3-piece step carries the eps^3 pair-energy gain) in SzemerediRegularityOQ04DefectGain.lean",
+      "partitionEnergy_step3_refinement_gain (whole-partition eps^3 lift of the 3-piece defect gain) in SzemerediRegularityOQ04OuterBoth.lean",
+      "afks_sharp_energy_iteration_count_of_witness_both + afks_regular_step_within_bound_both (mixed-chain sharp budget and termination) in SzemerediRegularityOQ04OuterBoth.lean",
+      "exists_afksTwoLevel_of_dichotomy_both / _both_equipartition (outer AFKS loop consuming the S17 two-shape dichotomy) in SzemerediRegularityOQ04OuterBoth.lean"
     ],
     "insights": [
       "The complement pieces A2=A\\A1, B2=B\\B1 of the AFKS sharp 2x2 split are NOT both forced nonempty by the analytic data: the density gap only forbids BOTH being empty (S16). When one corner exhausts its block (A1=A) the honest refinement is the asymmetric 3-piece split {A,B1,B2}; the 4-piece IsWitnessedSharpStep shape (S14 isWitnessedSharpStep_of_split_of_gap) requires an asymmetric-step packaging for that degenerate branch, not a further nonemptiness lemma.",
@@ -132,11 +135,13 @@
       "S13: split freshness (the 6 pairwise ≠ + 4 ∉R the S12 packaging took as hypotheses) is fully derivable from partition pairwise-disjointness + nonemptiness of the four 2×2 split pieces. Reduces the item-1 dichotomy obligation to purely: build the chain with parts(n+1) of insert-shape and NONEMPTY split pieces.",
       "Reusable Finset idiom: disjoint + subset ⇒ empty via Finset.inter_eq_left.mpr (X⊆C ⇒ X∩C=X) composed with Finset.disjoint_iff_inter_eq_empty.mp; underlies both cross-block distinctness and ∉R freshness.",
       "The two degenerate sides of the sharp 2x2 split fold onto ONE asymmetric 3-piece shape: when B2 = empty (B1 = B, only A splits), swapping the parents via edgeDensity_symm turns |d(A1,B) - d(A,B)| into |d(B,A1) - d(B,A)|, i.e. the same only-second-block-splits form. One predicate (IsWitnessedSharpStep3) therefore covers both.",
-      "The 3-piece step will carry a STRONGER energy floor than the 4-piece one: splitting only B with deviation >= eps on mass >= eps*|B| gains >= eps^3*|A||B|/n^2 (mean preserved by edge-count additivity e(A,B)=e(A,B1)+e(A,B2), already in SzemerediCoreOQ01) versus the eps^4 sharp floor - so the outer-loop eps^4 budget covers both branches without change."
+      "The 3-piece step will carry a STRONGER energy floor than the 4-piece one: splitting only B with deviation >= eps on mass >= eps*|B| gains >= eps^3*|A||B|/n^2 (mean preserved by edge-count additivity e(A,B)=e(A,B1)+e(A,B2), already in SzemerediCoreOQ01) versus the eps^4 sharp floor - so the outer-loop eps^4 budget covers both branches without change.",
+      "The degenerate branch is CHEAPER for the outer budget: for eps <= 1 the 3-piece eps^3*m^2/n^2 floor dominates the 4-piece eps^4*m^2/n^2 one, so mixed chains terminate within the unchanged sharp bound n^2/(eps^4*m^2) — threading the disjunctive dichotomy costs only the extra hypothesis E(k) <= 1.",
+      "The whole-partition lift of the 3-piece gain needs no new analysis: the A-row/column and (A,A) cell are unchanged, the B-rows/columns, (B,A) cross and B^2 diagonal split by pairEnergy monotonicity, and only the (A,B) cross consumes pairEnergy_step3_gain — Assembly.lean's block-decomposition template transfers verbatim with five instead of eight block inequalities."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Thread both witnessed step shapes (eps^4 symmetric, eps^3 asymmetric) through the outer-loop chain construction (exists_afksTwoLevel_of_dichotomy reformulation) — partition-level increment + freshness bookkeeping."
+      "Construct the recursive refinement chain realizing the S17 case split as witnessed steps (freshness + equitable mass floors discharged) — the remaining input to exists_afksTwoLevel_of_dichotomy_both."
     ],
     "markdown": "# Knowledge Base: szemeredi-regularity-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n",
     "score": 63


### PR DESCRIPTION
## Summary

`szemeredi-regularity-oq-04` S19 — discharges the tracker's last recorded layer, **S17 residual (b): thread BOTH step shapes through the outer-loop chain construction**.

New file `proofs/Proofs/SzemerediRegularityOQ04OuterBoth.lean` (0 axioms, 0 sorries, docker-verified 8592 jobs, built first try):

- `partitionEnergy_step3_refinement_gain` — the S18 pair-level `eps^3` defect gain lifted to the **whole partition** over `insert A (insert B1 (insert B2 R))`, mirroring `Assembly.lean`'s block decomposition (five block inequalities instead of eight: the `(A,B)` cross carries `pairEnergy_step3_gain`, everything else is `pairEnergy` monotonicity or unchanged).
- `afks_sharp_energy_iteration_count_of_witness_both` — mixed chains in which every step is witnessed by **either** the symmetric 4-piece `IsWitnessedSharpStep` or the asymmetric 3-piece `IsWitnessedSharpStep3` stay within the **same** sharp budget `N <= n^2/(eps^4 m^2)`: for `eps <= 1` the 3-piece `eps^3` floor dominates the common `eps^4` one, so the degenerate branch costs the loop nothing.
- `afks_regular_step_within_bound_both` — termination: past the sharp budget some step carries neither witness shape.
- `exists_afksTwoLevel_of_dichotomy_both` (+ `_equipartition` tower-free `k^2/E(k)^4` form) — the reformulated outer AFKS assembly whose dichotomy hypothesis is now the **disjunction** of step shapes, exactly what the S17 case split `exists_proper_or_semitrivial_split_of_not_afksFineRegular` produces. The only new hypothesis over the one-shape `exists_afksTwoLevel_of_dichotomy` is `E(k) <= 1`.

## Remaining open content (recorded in tracker)

The gap between S17's split **data** and the dichotomy's witnessed **steps**: constructing the recursive refinement chain that realizes the case split at every non-regular step, with freshness clauses and equitable mass floors discharged (the "nonempty-equipartition model" blocker noted in `Assembly.lean`). Deep construction; no elementary increment remains at the pair or partition level.

## Verification

```
./proofs/scripts/docker-build.sh Proofs.SzemerediRegularityOQ04OuterBoth
Build completed successfully (8592 jobs).
```

Only warning: the repo-wide `push_neg` deprecation shared by the existing OQ04 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
