### PR TITLE
Audit erdos-1096 (reserve): re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9852,8 +9852,8 @@
     },
     "erdos-1096": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:03:30Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T14:31:43Z",
       "result": "clean"
     },
     "erdos-1097": {


### PR DESCRIPTION
## Summary
- Reserve-mode re-audit of erdos-1096 (Erdős #1096, gap convergence in q-expansions).
- Verified: 5 axioms (qSequence, pisot_no_gap_property, gap_universal_bound, qSequenceM, bugeaud_characterization) match meta.axiomCount and assumptions text exactly.
- 0 sorries, no native_decide, no True-stubs.
- definitionCount 9 matches (excludes the known v4.31 `Complex.abs` compat shim).
- theoremCount in meta (14) undercounts the actual 15 (13 `theorem` + 2 `private lemma`) — harmless per convention (undercounts are stale-but-safe, not reportable).
- Status "axiomatized" / badge "axiom" honestly reflect the axioms present; overview/conclusion don't overclaim.
- No open/contested PRs found for this slug before claiming.

Result: clean. Updates `audit-tracker.json` lastAudited/auditCount only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)