### PR TITLE
Audit erdos-1088: remove phantom formalization claims (open conjecture, 3 known results)

### DIFF
--- a/src/data/proofs/erdos-1088/meta.json
+++ b/src/data/proofs/erdos-1088/meta.json
@@ -38,10 +38,7 @@
     "originalContributions": [
       "AllDistancesDistinct predicate: all C(n,2) pairwise distances distinct via squared distance",
       "Axiomatization of f_d(n) as extremal function over point configurations",
-      "One-dimensional tight bounds: f_1(n) ≍ n²",
-      "Exact value f_2(3) = 7 (Erdős) and asymptotic f_d(3) = d²/2 + O(d)",
-      "Erdős-Straus exponential upper bound: f_d(n) ≤ c_n^d",
-      "ε-formalization of the subexponential conjecture f_d(n) = 2^{o(d)}"
+      "Erdős-Straus exponential upper bound axiomatized: f_d(n) ≤ c_n^d"
     ],
     "relatedProblems": [
       {
@@ -60,7 +57,7 @@
     "historicalContext": "**The Distinct Distance Subset Problem**\n\nErdős posed Problem #1088 in 1975, asking a Ramsey-type question in discrete geometry: how many points in $\\mathbb{R}^d$ guarantee the existence of an $n$-point subset where all $\\binom{n}{2}$ pairwise distances are distinct? This is fundamentally different from Problem #1083 (which asks for the minimum number of distinct distances in the entire point set): here we seek a *subset* with a *complete* set of distinct distances.\n\nThe problem has a rich history of partial results:\n\n**Exact values:**\n- **Erdős** proved $f_2(3) = 7$: the regular hexagon (6 vertices, only 2 distinct distances) shows $f_2(3) > 6$, and any 7 planar points contain a scalene triangle.\n- **Croft (1962)** proved $f_3(3) = 9$: the cube (8 vertices, only 3 distinct distances: edge, face diagonal, space diagonal) shows $f_3(3) > 8$.\n\n**Asymptotic results:**\n- **One dimension:** $f_1(n) \\asymp n^2$, related to Sidon sets and $B_2$ sequences.\n- **Three-point case:** $f_d(3) = d^2/2 + O(d)$, showing quadratic growth in dimension.\n- **Erdős-Straus:** $f_d(n) \\leq c_n^d$ for a constant $c_n$ depending on $n$, giving an exponential upper bound.\n\nThe central open question is whether the exponential dependence on $d$ is necessary: can $c_n$ be taken arbitrarily close to 1 (i.e., is $f_d(n) = 2^{o(d)}$)?",
     "problemStatement": "Let $f_d(n)$ be the minimal $m$ such that any set of $m$ points in $\\mathbb{R}^d$ contains a subset of $n$ points where all $\\binom{n}{2}$ pairwise distances are distinct.\n\n**Main Conjecture (OPEN):** For fixed $n \\geq 3$, is $f_d(n) = 2^{o(d)}$?\n\n**Known Bounds:**\n- $f_1(n) \\asymp n^2$\n- $f_2(3) = 7$, $f_3(3) = 9$\n- $f_d(3) = d^2/2 + O(d)$\n- $f_d(n) \\leq c_n^d$ (Erdős-Straus)",
     "text": "Let f_d(n) be the minimal m such that any m points in ℝ^d contain n points with all pairwise distances distinct. Is f_d(n) = 2^{o(d)} for fixed n ≥ 3? OPEN.",
-    "proofStrategy": "**Formalization Approach:**\n\nThe Lean formalization defines the problem cleanly and axiomatizes all known results:\n\n1. **Constructive definition of `AllDistancesDistinct`:** Uses squared Euclidean distance (avoiding square roots) to define when all $\\binom{n}{2}$ pairwise distances in a finite set are distinct. Points are represented as $\\text{Fin}\\, d \\to \\mathbb{R}$.\n\n2. **Axiomatized $f_d(n)$:** The extremal function is an axiom since defining the minimum over all point configurations requires second-order quantification.\n\n3. **Known results as axioms:** The one-dimensional bound, exact values, three-point asymptotics, and Erdős-Straus bound are separate axioms, cleanly organizing the state of knowledge.\n\n4. **Open conjecture:** Formalized as $\\forall \\varepsilon > 0, \\exists D, \\forall d \\geq D: f_d(n) \\leq 2^{\\varepsilon d}$, the standard $\\varepsilon$-characterization of $2^{o(d)}$.\n\n5. **Main theorem:** States the established Erdős-Straus bound, proved by direct invocation.",
+    "proofStrategy": "**Formalization Approach:**\n\nThe Lean formalization defines the problem and axiomatizes the one known result it uses:\n\n1. **Constructive definition of `AllDistancesDistinct`:** Uses squared Euclidean distance (avoiding square roots) to define when all $\\binom{n}{2}$ pairwise distances in a finite set are distinct. Points are represented as $\\text{Fin}\\, d \\to \\mathbb{R}$.\n\n2. **Axiomatized $f_d(n)$:** The extremal function is an axiom since defining the minimum over all point configurations requires second-order quantification.\n\n3. **Erdős-Straus bound as an axiom:** Only the exponential upper bound $f_d(n) \\leq c_n^d$ is axiomatized. The one-dimensional bound, exact values, and three-point asymptotics are documented in header comments for context but are not formalized as separate Lean declarations.\n\n4. **Open conjecture — not formalized:** The $2^{o(d)}$ subexponential question is stated only in prose comments; no Lean statement (axiom, definition, or theorem) encodes it.\n\n5. **Main theorem:** Restates the axiomatized Erdős-Straus bound (the known exponential upper bound), proved by direct invocation. It does not address the open subexponential conjecture.",
     "keyInsights": [
       "**Ramsey-theoretic structure:** The problem asks for a guaranteed substructure (distinct-distance subset) within any large enough point set, paralleling classical Ramsey problems about monochromatic cliques in colored graphs",
       "**Dimension-distance duality:** In $\\mathbb{R}^d$, the squared distance $\\sum (p_i - q_i)^2$ takes values in a set whose size grows with $d$, but the number of pairs $\\binom{n}{2}$ is fixed for fixed $n$ — this tension drives the problem",
@@ -94,18 +91,18 @@
     {
       "id": "known-results",
       "title": "Part II: Known Results",
-      "summary": "One-dimensional bound f_1(n) ≍ n², exact value f_2(3) = 7, three-point asymptotics f_d(3) = d²/2 + O(d), Erdős-Straus upper bound f_d(n) ≤ c_n^d",
+      "summary": "One-dimensional bound f_1(n) ≍ n², exact value f_2(3) = 7, and three-point asymptotics f_d(3) = d²/2 + O(d) are noted in comments only; the Erdős-Straus upper bound f_d(n) ≤ c_n^d is the sole result axiomatized here",
       "startLine": 50,
       "endLine": 70,
-      "mathContext": "One-dimensional bound f_1(n) ≍ n², exact value f_2(3) = 7, three-point asymptotics f_d(3) = d²/2 + O(d), Erdős-Straus upper bound f_d(n) ≤ c_n^d"
+      "mathContext": "One-dimensional bound f_1(n) ≍ n², exact value f_2(3) = 7, and three-point asymptotics f_d(3) = d²/2 + O(d) are documentation comments (not formalized); Erdős-Straus upper bound f_d(n) ≤ c_n^d is axiomatized"
     },
     {
       "id": "main-conjecture",
       "title": "Part III: The Main Question",
-      "summary": "The open conjecture: for fixed n ≥ 3, is f_d(n) = 2^{o(d)}? Formalized via ε-characterization of subexponential growth",
+      "summary": "The open conjecture: for fixed n ≥ 3, is f_d(n) = 2^{o(d)}? Stated in prose comments only — not formalized as a Lean declaration",
       "startLine": 71,
       "endLine": 85,
-      "mathContext": "The open conjecture: for fixed n ≥ 3, is f_d(n) = 2^{o(d)}? Formalized via ε-characterization of subexponential growth"
+      "mathContext": "The open conjecture: for fixed n ≥ 3, is f_d(n) = 2^{o(d)}? Stated in prose comments only — not formalized as a Lean declaration"
     },
     {
       "id": "main-theorem",
@@ -117,7 +114,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #1088 on guaranteed distinct-distance subsets in high dimensions. The constructive `AllDistancesDistinct` predicate using squared Euclidean distance provides a clean definition, while the known results ($f_1(n) \\asymp n^2$, $f_2(3) = 7$, $f_3(3) = 9$, $f_d(3) = d^2/2 + O(d)$, $f_d(n) \\leq c_n^d$) and the open conjecture ($f_d(n) = 2^{o(d)}$) are axiomatized as separate statements.",
+    "summary": "This formalization captures Erdős Problem #1088 on guaranteed distinct-distance subsets in high dimensions. The constructive `AllDistancesDistinct` predicate using squared Euclidean distance provides a clean definition, and $f_d(n)$ is axiomatized as an extremal function. Of the known results, only the Erdős-Straus exponential bound ($f_d(n) \\leq c_n^d$) is axiomatized; $f_1(n) \\asymp n^2$, $f_2(3) = 7$, $f_3(3) = 9$, and $f_d(3) = d^2/2 + O(d)$ are documented in comments for context but not formalized. The open conjecture ($f_d(n) = 2^{o(d)}$) is likewise stated only in prose — no Lean declaration formalizes it, and the main theorem merely restates the known Erdős-Straus bound.",
     "implications": "**Theoretical Significance**: Resolving the subexponential conjecture would have implications for high-dimensional discrete geometry and Ramsey theory.\n\nA positive answer ($f_d(n) = 2^{o(d)}$) would mean high-dimensional space provides a structural advantage for finding distinct-distance subsets beyond what counting arguments predict. A negative answer would establish a fundamental exponential barrier in the relationship between dimension and combinatorial complexity.",
     "openQuestions": [
       "Is $f_d(n) = 2^{o(d)}$ for fixed $n \\geq 3$? This is the main conjecture.",


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-1088 (Erdős Problem #1088: Distinct Distance Subsets in High Dimensions)

**Problem**: `meta.json` claimed formalization work that does not exist in `Proofs/Erdos1088Problem.lean`.

## Evidence

`Proofs/Erdos1088Problem.lean` has exactly 4 declarations: `def AllDistancesDistinct`, `axiom f`, `axiom erdos_straus_upper_bound`, `theorem erdos_1088` (which just restates `erdos_straus_upper_bound`). `axiomCount: 2` in meta.json was already correct.

But the narrative fields overclaimed:

- `overview.proofStrategy` point 4: *"**Open conjecture:** Formalized as ∀ε>0,∃D,∀d≥D: f_d(n)≤2^{εd}..."* — no such Lean statement exists anywhere in the file; the open conjecture appears only in a prose comment (lines 64-69).
- `sections[main-conjecture].summary`: *"Formalized via ε-characterization of subexponential growth"* — same false claim.
- `conclusion.summary`: *"...the known results (...) and the open conjecture (...) are axiomatized as separate statements"* — false; only the Erdős-Straus bound is axiomatized. The 1D bound (f₁(n)≍n²), f₂(3)=7, f₃(3)=9, and f_d(3)=d²/2+O(d) are documentation comments only, never declared in Lean.
- `originalContributions` listed "One-dimensional tight bounds: f_1(n) ≍ n²", "Exact value f_2(3) = 7 ... and asymptotic f_d(3) = d²/2 + O(d)", and "ε-formalization of the subexponential conjecture f_d(n) = 2^{o(d)}" as contributions — none of these three correspond to any Lean declaration.

## Fix

Rewrote `proofStrategy`, the `known-results`/`main-conjecture` section summaries, `conclusion.summary`, and `originalContributions` to state plainly that only the Erdős-Straus exponential bound is axiomatized, the other three known results are comment-only context, and the open $2^{o(d)}$ conjecture is not formalized at all — the main theorem restates the known (inferior) exponential bound rather than addressing the open question. `status: axiomatized`, `badge: axiom`, `axiomCount: 2`, and `sorries: 0` were already accurate and are unchanged.

---
Discovered during gallery integrity audit.