### PR TITLE
Audit erdos-1086: remove phantom formalization claims

### DIFF
--- a/src/data/proofs/erdos-1086/annotations.json
+++ b/src/data/proofs/erdos-1086/annotations.json
@@ -121,17 +121,15 @@
     "id": "ann-e1086-upper-bounds",
     "proofId": "erdos-1086",
     "range": {
-      "startLine": 101,
-      "endLine": 107
+      "startLine": 100,
+      "endLine": 105
     },
     "type": "concept",
-    "title": "Upper Bounds: n^{5/2} to n^{20/9}",
-    "content": "The upper bound improved from $g(n) \\ll n^{5/2}$ (Erdős-Purdy 1971) to $g(n) \\ll n^{20/9}$ (Raz-Sharir 2017). The exponent decreased: $5/2 = 2.5 \\to 20/9 \\approx 2.222$, approaching but not reaching the conjectured quadratic.",
-    "mathContext": "The upper bounds use the reduction to point-curve incidences. For area $\\alpha$ and base $(A,B)$, the third vertex $C$ lies on a line parallel to $AB$ at distance $2\\alpha/|AB|$. This gives $O(n^2)$ lines, and the Szemerédi-Trotter theorem bounds point-line incidences. The Raz-Sharir improvement uses a refined incidence bound for algebraic curves (not just lines).",
+    "title": "Upper Bound: n^{20/9} (Raz-Sharir 2017), axiom",
+    "content": "`upper_bound_raz_sharir_2017`: $\\exists C > 0$ such that $g(n) \\leq C \\cdot n^{20/9}$ for $n \\geq 2$ — the current best known upper bound, taken as an axiom (not re-derived). `bestUpperExponent` names the constant $20/9$. In the literature the bound improved from the original $n^{5/2}$ (Erdős-Purdy 1971) to $n^{20/9}$ (Raz-Sharir 2017) via a sequence of incidence-geometry arguments; only the final Raz-Sharir bound is formalized here.",
+    "mathContext": "The literature's upper bounds use a reduction to point-curve incidences (for area $\\alpha$ and base $(A,B)$, the third vertex $C$ lies on a line parallel to $AB$) together with the Szemerédi-Trotter incidence theorem and, for Raz-Sharir, polynomial partitioning. None of that incidence-geometry machinery is formalized in this file — the bound is taken directly as an axiom.",
     "relatedConcepts": [
-      "Real.rpow",
-      "incidence_reduction",
-      "szemeredi_trotter_bound"
+      "Real.rpow"
     ],
     "significance": "key",
     "prerequisites": [
@@ -141,45 +139,20 @@
     ]
   },
   {
-    "id": "ann-e1086-conjecture",
-    "proofId": "erdos-1086",
-    "range": {
-      "startLine": 112,
-      "endLine": 118
-    },
-    "type": "concept",
-    "title": "Erdős-Purdy Conjecture",
-    "content": "`erdos_purdy_conjecture` states $g(n) = \\Theta(n^2 (\\log n)^\\alpha)$ for some $\\alpha > 0$: the truth is believed to be quadratic with a polylogarithmic correction. This is formalized as the existence of $\\alpha > 0$ with matching upper and lower bounds.",
-    "mathContext": "The conjecture predicts that the lower bound $n^2 \\log \\log n$ is closer to the truth than the upper bound $n^{20/9}$. The polylogarithmic correction $(\\log n)^\\alpha$ generalizes the $\\log \\log n$ in the lower bound. If true, this would be analogous to the Erdős unit distance conjecture, where grid-like constructions are near-extremal.",
-    "relatedConcepts": [
-      "Real.log",
-      "Real.rpow",
-      "Theta notation",
-      "extremal combinatorics"
-    ],
-    "significance": "key",
-    "prerequisites": [
-      "Big-Theta Notation",
-      "Polylogarithmic Factors",
-      "Extremal Combinatorics"
-    ]
-  },
-  {
     "id": "ann-e1086-gdim",
     "proofId": "erdos-1086",
     "range": {
-      "startLine": 126,
-      "endLine": 135
+      "startLine": 112,
+      "endLine": 120
     },
     "type": "concept",
     "title": "Higher-Dimensional Generalization g_d^r(n)",
-    "content": "`g_dim d r n` is the maximum number of $r$-simplices of the same volume from $n$ points in $\\mathbb{R}^d$. Axiomatized since the definition involves a supremum over all point configurations. `g2_is_g` states $g_2^2(n) = g(n)$, connecting to the original problem.",
-    "mathContext": "The generalization to $r$-simplices in $\\mathbb{R}^d$ reveals dimension-dependent behavior. The critical case is $d = 2r$: the Oppenheim-Lenz construction achieves $g_{2r}^r(n) \\geq c \\cdot n^{r+1}$ using a product construction. For $d < 2r$, the bounds are suboptimal; for $d > 2r$, higher-dimensional freedom allows more equal-volume simplices.",
+    "content": "`g_dim d r n` is axiomatized as the maximum number of $r$-simplices of the same volume from $n$ points in $\\mathbb{R}^d$ (no defining equation, no connection back to `g`). `bound_g3_2_dst` then axiomatizes a single instance: $g_3^2(n) \\ll n^{2.4286}$ (Dumitrescu-Sharir-Tóth 2009). No other dimensions or the Oppenheim-Lenz construction are formalized in this file.",
+    "mathContext": "The generalization to $r$-simplices in $\\mathbb{R}^d$ reveals dimension-dependent behavior in the literature (e.g. the Oppenheim-Lenz construction at $d = 2r$), but this file only introduces the abstract `g_dim` axiom and one concrete bound for $(d,r) = (3,2)$.",
     "relatedConcepts": [
       "simplex",
       "volume",
-      "dimension",
-      "g2_is_g"
+      "dimension"
     ],
     "significance": "key",
     "prerequisites": [
@@ -189,27 +162,25 @@
     ]
   },
   {
-    "id": "ann-e1086-higherdim-bounds",
+    "id": "ann-e1086-summary-theorems",
     "proofId": "erdos-1086",
     "range": {
-      "startLine": 137,
+      "startLine": 131,
       "endLine": 150
     },
-    "type": "concept",
-    "title": "Higher-Dimensional Bounds",
-    "content": "Various dimension-specific results:\n- $g_3^2(n) \\ll n^{8/3}$ (Erdős-Purdy) improved to $n^{2.4286}$ (DST 2009)\n- $g_6^2(n) \\gg n^3$ (Erdős-Purdy)\n- $g_4^2(n) \\leq g_5^2(n) \\ll n^{3-c}$ (Purdy 1974)\n- Oppenheim-Lenz: $g_{2k+2}^k(n) \\geq c \\cdot n^{k+1}$\n- Conjecture: $g_{2k+2}^k(n) = \\Theta(n^{k+1})$",
-    "mathContext": "The Oppenheim-Lenz construction places $n$ points on $k+1$ curves in $\\mathbb{R}^{2k+2}$ arranged so that many $(k+1)$-tuples span simplices of the same volume. The conjecture that this is optimal would generalize the 2D Erdős-Purdy conjecture. The Purdy bound $g_5^2(n) \\ll n^{3-c}$ is significant because $3$ is the 'obvious' exponent for 5D.",
+    "type": "theorem",
+    "title": "Summary Theorems Combining the Axiomatized Bounds",
+    "content": "`erdos_1086_statement` packages the lower bound (`lower_bound_erdos_purdy`) and the Raz-Sharir upper bound (`upper_bound_raz_sharir_2017`) into one conjunction. `erdos_1086_summary` adds the higher-dimensional bound (`bound_g3_2_dst`) as a third conjunct. Both are genuine theorems, but their content is entirely a restatement of the three axioms — no additional mathematical content is proved.",
+    "mathContext": "Since the three constituent facts are axioms, these theorems establish nothing beyond what was assumed; they exist to give a single named statement matching the problem's public claim.",
     "relatedConcepts": [
-      "g_dim",
-      "oppenheim_lenz_construction",
-      "erdos_purdy_conjecture_high_dim",
-      "Real.rpow"
+      "lower_bound_erdos_purdy",
+      "upper_bound_raz_sharir_2017",
+      "bound_g3_2_dst"
     ],
     "significance": "key",
     "prerequisites": [
-      "Asymptotic Upper and Lower Bounds",
-      "Simplex Volume in R^d",
-      "Geometric Constructions"
+      "Existential Quantification",
+      "Conjunction"
     ]
   }
 ]

--- a/src/data/proofs/erdos-1086/meta.json
+++ b/src/data/proofs/erdos-1086/meta.json
@@ -50,17 +50,12 @@
       "Point2D, Triangle, triangleArea definitions using shoelace formula",
       "countTrianglesWithArea via Finset.powersetCard 3 filtering",
       "maxTrianglesWithSameArea and g(n) via sSup",
-      "lower_bound_erdos_purdy: n² log log n lower bound",
-      "upper_bound_erdos_purdy_1971: original n^{5/2} upper bound",
-      "upper_bound_raz_sharir_2017: current best n^{20/9} upper bound",
-      "erdos_purdy_conjecture: Θ(n² polylog(n)) typed statement",
+      "lower_bound_erdos_purdy: n² log log n lower bound (axiom)",
+      "upper_bound_raz_sharir_2017: current best n^{20/9} upper bound (axiom)",
+      "bestUpperExponent: named constant for the 20/9 exponent",
       "g_dim axiom for higher-dimensional simplex generalization",
-      "g2_is_g relating g_dim 2 2 to g",
-      "Higher-dimensional bounds: g_3^2, g_6^2, Purdy g_4^2/g_5^2",
-      "oppenheim_lenz_construction lower bound for g_{2k+2}^k",
-      "erdos_purdy_conjecture_high_dim: typed upper bound conjecture",
-      "incidence_reduction and szemeredi_trotter_bound typed axioms",
-      "erdos_1086_statement and erdos_1086_summary genuine theorems"
+      "bound_g3_2_dst: g_3^2(n) ≪ n^{2.4286} bound (Dumitrescu-Sharir-Tóth 2009, axiom)",
+      "erdos_1086_statement and erdos_1086_summary genuine theorems combining the axiomatized bounds"
     ],
     "axiomCount": 4,
     "lineCount": 152,
@@ -72,7 +67,7 @@
     "historicalContext": "**Erdős Problem #1086: Triangles of Equal Area**\n\nOriginally posed by Oppenheim, this problem asks: given n points in the plane, how many triangles with the same area can they determine? The function g(n) measures this maximum.\n\n**Historical Development:**\n- **Oppenheim:** Posed the original question about equal-area triangles\n- **Erdős-Purdy (1971):** Established the first bounds: n² log log n ≪ g(n) ≪ n^{5/2}\n- **Pach-Sharir (1992):** Improved the upper bound using point-curve incidence techniques\n- **Dumitrescu-Sharir-Tóth (2009):** Further improvements to the upper bound\n- **Apfelbaum-Sharir (2010):** Continued refinements\n- **Raz-Sharir (2017):** Current best upper bound g(n) ≪ n^{20/9}\n\n**Key Connection:** The problem reduces to counting point-curve incidences. For a fixed base edge (A,B), the locus of points C giving a triangle of area α is a pair of parallel lines. The Szemerédi-Trotter incidence theorem is the main tool for upper bounds.",
     "problemStatement": "**Problem Statement (OPEN)**\n\nLet $g(n)$ be the maximum number of triangles with the same area that can be formed from $n$ points in $\\mathbb{R}^2$.\n\n**Known Bounds:**\n- Lower: $n^2 \\log \\log n \\ll g(n)$ (Erdős-Purdy 1971)\n- Upper: $g(n) \\ll n^{20/9}$ (Raz-Sharir 2017)\n- Exponent gap: $2$ vs $20/9 \\approx 2.222$\n\n**Conjecture:** $g(n) = \\Theta(n^2 \\operatorname{polylog}(n))$\n\n**Higher Dimensions:** $g_d^r(n)$ counts $r$-simplices of the same volume from $n$ points in $\\mathbb{R}^d$. The Oppenheim-Lenz construction gives $g_{2k+2}^k(n) \\geq c \\cdot n^{k+1}$.",
     "text": "Let g(n) be the maximum number of triangles with the same area determined by n points in ℝ². Best bounds: n² log log n ≪ g(n) ≪ n^{20/9} (Erdős-Purdy 1971, Raz-Sharir 2017). The Erdős-Purdy conjecture predicts g(n) = Θ(n² polylog(n)). Higher-dimensional generalizations involve g_d^r(n) for r-simplices in ℝ^d. Status: OPEN.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Geometric Definitions (lines 38-69):**\n   - `Point2D`: points in ℝ² via `EuclideanSpace ℝ (Fin 2)`\n   - `triangleArea`: shoelace formula ½|x_A(y_B-y_C) + ...|\n   - `Triangle`: structure with distinctness proofs\n\n2. **Counting Function g(n) (lines 71-91):**\n   - `countTrianglesWithArea`: filter powersetCard 3 by area\n   - `maxTrianglesWithSameArea`: supremum over areas\n   - `g n`: supremum over all n-point configurations\n\n3. **Known Bounds (lines 93-118):**\n   - Lower: n² log log n (Erdős-Purdy)\n   - Upper: n^{5/2} (1971), n^{20/9} (2017)\n   - Conjecture: Θ(n² polylog(n))\n\n4. **Higher Dimensions (lines 120-161):**\n   - `g_dim d r n`: axiomatized generalization\n   - Bounds for d = 3, 4, 5, 6\n   - Oppenheim-Lenz construction\n\n5. **Incidence Geometry (lines 181-200):**\n   - `incidence_reduction`: triangle counting → point-line incidences\n   - `szemeredi_trotter_bound`: O(n^{2/3}m^{2/3} + n + m)\n\n6. **Summary (lines 202-233):**\n   - `erdos_1086_statement` and `erdos_1086_summary`: genuine theorems",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Geometric Definitions (lines 45-70):**\n   - `Point2D`: points in ℝ² via `EuclideanSpace ℝ (Fin 2)`\n   - `triangleArea`: shoelace formula ½|x_A(y_B-y_C) + ...|\n   - `Triangle`: structure with distinctness proofs\n\n2. **Counting Function g(n) (lines 77-91):**\n   - `countTrianglesWithArea`: filter powersetCard 3 by area\n   - `maxTrianglesWithSameArea`: supremum over areas\n   - `g n`: supremum over all n-point configurations\n\n3. **Known Bounds (lines 96-105), as axioms:**\n   - Lower: n² log log n (Erdős-Purdy), `lower_bound_erdos_purdy`\n   - Upper: n^{20/9} (Raz-Sharir 2017), `upper_bound_raz_sharir_2017`\n   - `bestUpperExponent`: named constant 20/9\n\n4. **Higher Dimensions (lines 112-120), as axioms:**\n   - `g_dim d r n`: axiomatized generalization\n   - `bound_g3_2_dst`: single bound for the d=3, r=2 case (Dumitrescu-Sharir-Tóth 2009)\n\n5. **Main Results (lines 131-150):**\n   - `erdos_1086_statement` and `erdos_1086_summary`: genuine theorems combining the axiomatized bounds above",
     "keyInsights": [
       "**Incidence Reduction:** For fixed base edge AB and area α, point C lies on two lines parallel to AB — reducing triangle counting to point-line incidences",
       "**Szemerédi-Trotter Tool:** The ST theorem bounding point-line incidences to O(n^{2/3}m^{2/3} + n + m) is the main technique for upper bounds",
@@ -114,22 +109,22 @@
     {
       "id": "bounds",
       "title": "Known Bounds",
-      "summary": "lower_bound_erdos_purdy, upper_bound_erdos_purdy_1971, upper_bound_raz_sharir_2017, erdos_purdy_conjecture",
+      "summary": "lower_bound_erdos_purdy, upper_bound_raz_sharir_2017, bestUpperExponent",
       "startLine": 93,
       "endLine": 119,
-      "mathContext": "lower_bound_erdos_purdy, upper_bound_erdos_purdy_1971, upper_bound_raz_sharir_2017, erdos_purdy_conjecture"
+      "mathContext": "lower_bound_erdos_purdy, upper_bound_raz_sharir_2017, bestUpperExponent"
     },
     {
       "id": "higher-dim",
       "title": "Higher-Dimensional Generalizations",
-      "summary": "g_dim, g2_is_g, bounds for d=3,4,5,6, oppenheim_lenz_construction, erdos_purdy_conjecture_high_dim",
+      "summary": "g_dim axiom, bound_g3_2_dst (d=3, r=2 case only), erdos_1086_statement/erdos_1086_summary theorems",
       "startLine": 120,
       "endLine": 150,
-      "mathContext": "g_dim, g2_is_g, bounds for d=3,4,5,6, oppenheim_lenz_construction, erdos_purdy_conjecture_high_dim"
+      "mathContext": "g_dim axiom, bound_g3_2_dst (d=3, r=2 case only), erdos_1086_statement/erdos_1086_summary theorems"
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #1086 asks to estimate g(n), the maximum number of equal-area triangles from n points in ℝ². The best bounds are n² log log n ≪ g(n) ≪ n^{20/9} (Erdős-Purdy 1971, Raz-Sharir 2017), with the Erdős-Purdy conjecture predicting Θ(n² polylog(n)). The problem connects to Szemerédi-Trotter incidence geometry and generalizes to higher-dimensional simplices. The formalization includes typed conjectures, incidence-based reductions, and genuine theorems combining the main bounds.",
+    "summary": "Erdős Problem #1086 asks to estimate g(n), the maximum number of equal-area triangles from n points in ℝ². The best bounds are n² log log n ≪ g(n) ≪ n^{20/9} (Erdős-Purdy 1971, Raz-Sharir 2017); both are proved in the literature via Szemerédi-Trotter incidence geometry but are axiomatized (not independently re-derived) here. The formalization also axiomatizes a single d=3 higher-dimensional bound and combines the axiomatized bounds into two genuine summary theorems.",
     "implications": "**Theoretical Significance**: **Connections to Combinatorial Geometry**\n\n1. **Incidence Geometry:** The problem is fundamentally about point-curve incidences — the Szemerédi-Trotter theorem and its generalizations are the main tools\n\n2. **Erdős Distinct Distances:** Related to the distinct distances problem (Erdős #184) — both concern extremal point configuration geometry\n\n**3. Algebraic Methods:** Recent upper bound improvements use polynomial partitioning (Guth-Katz framework) applied to the incidence formulation\n\n4. **Higher Dimensions:** The dimension 2k+2 threshold for k-simplices reveals a dimension-dependent phase transition in extremal geometry\n\n5. **Grid Extremality:** Integer lattice grids are conjectured to be near-extremal, as in many Erdős-type point configuration problems.",
     "openQuestions": [
       "Close the gap between exponents 2 and 20/9 for g(n)",
@@ -194,7 +189,7 @@
       "year": "1983",
       "volume": "3",
       "pages": "381–392",
-      "note": "Proves the O(n^{2/3}m^{2/3} + n + m) point-line incidence bound that underlies all upper bounds for g(n) via the incidence_reduction argument."
+      "note": "Proves the O(n^{2/3}m^{2/3} + n + m) point-line incidence bound that underlies the upper bounds for g(n) in the literature; not separately formalized in this file (upper_bound_raz_sharir_2017 is axiomatized directly)."
     },
     {
       "authors": [
@@ -231,7 +226,7 @@
       "year": "2009",
       "volume": "116",
       "pages": "1177–1198",
-      "note": "Provides further upper bound improvements and treats the three-dimensional case g_3^2(n), directly covering the higher-dimensional bounds formalized in this proof."
+      "note": "Provides further upper bound improvements and treats the three-dimensional case g_3^2(n), which is the single higher-dimensional bound (bound_g3_2_dst) axiomatized in this proof."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-1086 (Triangles of Equal Area)

## Problem

`meta.json`'s `originalContributions`, `proofStrategy`, `conclusion.summary`,
`sections[].mathContext`, and `references[].note`, plus most of
`annotations.json`, described declarations that never existed in
`proofs/Proofs/Erdos1086Problem.lean`:

- `upper_bound_erdos_purdy_1971`, `erdos_purdy_conjecture`, `g2_is_g`,
  `oppenheim_lenz_construction`, `erdos_purdy_conjecture_high_dim`,
  `incidence_reduction`, `szemeredi_trotter_bound` — zero grep hits in the
  source file.
- Higher-dimensional bounds claimed for d=3,4,5,6; only the d=3 case
  (`bound_g3_2_dst`) is actually axiomatized.
- `proofStrategy` cited an "Incidence Geometry (lines 181-200)" section and a
  "Summary (lines 202-233)" section in a file that is only 152 lines long.
- `annotations.json` compounded this: annotations for `erdos_purdy_conjecture`,
  `g2_is_g`, and the phantom higher-dim bounds pointed at line ranges that
  actually contain unrelated real content (e.g. the start of
  `erdos_1086_statement`).

The counts that matter for status (`axiomCount: 4`, `theoremCount: 2`,
`definitionCount: 10`, `sorries: 0`) were already accurate against the source
— this is purely a narrative/prose overclaim, not a badge/status error. Status
`axiomatized` / badge `axiom` remain correct.

## Fix

Rewrote `originalContributions`, `proofStrategy`, `conclusion.summary`,
`sections`, and `references[].note` in `meta.json`, and rewrote the four
affected entries in `annotations.json`, to describe only the 4 axioms
(`lower_bound_erdos_purdy`, `upper_bound_raz_sharir_2017`, `g_dim`,
`bound_g3_2_dst`) and 2 theorems (`erdos_1086_statement`,
`erdos_1086_summary`) that actually exist in the Lean source.

---
Discovered during gallery integrity audit (reserve-mode re-verify).