### PR TITLE
Update audit tracker: erdos-1089 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9792,8 +9792,8 @@
     },
     "erdos-1089": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:03:30Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T14:52:42Z",
       "result": "clean"
     },
     "erdos-109": {


### PR DESCRIPTION
## Summary
Reserve-mode re-audit of erdos-1089 (distinct distances in higher dimensions). Verified:
- 4 axioms (`g_well_defined`, `cube_distances`, `erdos_lower_bound`, `erdos_straus_upper_bound`) match `axiomCount:4` and the `assumptions` field exactly
- 0 sorries, no `native_decide`, no True-stubs
- definitionCount 13 reconciles once the `private noncomputable def embedPoint` is counted (naive `^def` grep misses `private` defs)
- All 6 theorems (including `g_mono_d` via isometric embedding) are genuinely proved
- Badge `axiom` / status `axiomatized` correctly reflects Tier C classification

No issues found — marking clean in the audit tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)