### PR TITLE
Update audit tracker: erdos-1087 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9780,9 +9780,9 @@
     },
     "erdos-1087": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-05-04T04:03:30Z",
-      "result": "clean"
+      "auditCount": 6,
+      "lastAudited": "2026-07-23T14:57:50Z",
+      "result": "issues-found"
     },
     "erdos-1088": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Marks erdos-1087 audited with `issues-found`. See #42264 for the discovered
issue: the `erdos_purdy_lower_bound` axiom is kernel-inconsistent with the
`maxDegenerateQuadruples := 0` placeholder def in `Proofs/Erdos1087Problem.lean`.