### PR TITLE
Fix: make erdos-1087 f(n) opaque to remove kernel inconsistency

### DIFF
--- a/proofs/Proofs/Erdos1087Problem.lean
+++ b/proofs/Proofs/Erdos1087Problem.lean
@@ -136,11 +136,16 @@ noncomputable def countDegenerateQuadruples (S : Finset Point) : ℕ :=
 /--
 **Maximum Degenerate Quadruples:**
 The maximum number of degenerate quadruples over all n-point sets.
+
+Declared `opaque` rather than as a concrete `def`. Computing this supremum is
+intractable, and — crucially — an ordinary `def := 0` placeholder would make
+`maxDegenerateQuadruples n` reduce to `0` by `rfl`, contradicting the
+`erdos_purdy_lower_bound` axiom (which asserts a strictly positive lower bound)
+and rendering the axiom set kernel-inconsistent. `opaque` hides the witness so no
+`rfl` reduction is available, leaving the Erdős–Purdy bounds as genuine,
+consistent unproven assumptions.
 -/
-noncomputable def maxDegenerateQuadruples (n : ℕ) : ℕ :=
-  -- This is the supremum over all n-point configurations
-  -- Formalized as an axiom since computing this is intractable
-  0  -- placeholder
+opaque maxDegenerateQuadruples (n : ℕ) : ℕ := 0
 
 /--
 **The Function f(n):**
@@ -261,8 +266,11 @@ f(n) ≤ C(n,4) ≤ n⁴/24, since at most all quadruples could be degenerate.
 -/
 theorem trivial_upper_bound (n : ℕ) (hn : n ≥ 4) :
     (f n : ℝ) ≤ (n : ℝ)^4 / 24 := by
-  simp only [f, maxDegenerateQuadruples, Nat.cast_zero]
-  positivity
+  -- Genuinely f(n) ≤ C(n,4) = n(n-1)(n-2)(n-3)/24 ≤ n⁴/24, since at most every
+  -- 4-subset is degenerate. With `maxDegenerateQuadruples` now `opaque` (no `rfl`
+  -- reduction to a junk value), this bound is no longer discharged by
+  -- computation and awaits a real proof of `f n ≤ n.choose 4`.
+  sorry
 
 /- 
 **Non-trivial Lower Bound Exists:**

--- a/src/data/proofs/erdos-1087/meta.json
+++ b/src/data/proofs/erdos-1087/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 2,
     "erdosNumber": 1087,
     "erdosUrl": "https://erdosproblems.com/1087",
     "erdosProblemStatus": "open",
@@ -65,8 +65,8 @@
       "erdos_1087 theorem: combining known bounds"
     ],
     "axiomCount": 2,
-    "lineCount": 321,
-    "assumptions": "2 axioms: erdos_purdy_lower_bound, erdos_purdy_upper_bound. 1 sorry.",
+    "lineCount": 329,
+    "assumptions": "2 axioms: erdos_purdy_lower_bound, erdos_purdy_upper_bound. 2 sorries. The extremal function f(n) is declared `opaque` (not a concrete def) so it does not reduce to a junk value by rfl; this keeps the two bound axioms consistent (an ordinary `def := 0` placeholder made f 4 = 0 provable, contradicting the positive lower bound and rendering the axiom set kernel-inconsistent).",
     "theoremCount": 6,
     "definitionCount": 14
   },
@@ -282,12 +282,12 @@
       "Finset"
     ],
     "namespace": "Erdos1087",
-    "lineCount": 321,
+    "lineCount": 329,
     "axiomCount": 2,
     "theoremCount": 6,
     "definitionCount": 14,
     "path": "Proofs/Erdos1087Problem.lean",
-    "sorries": 1
+    "sorries": 2
   },
-  "sorries": 1
+  "sorries": 2
 }


### PR DESCRIPTION
## Problem

Auditor issue #42264: the axiom set in `proofs/Proofs/Erdos1087Problem.lean` is **kernel-inconsistent** (`False` is provable).

`maxDegenerateQuadruples` was a concrete placeholder:

```lean
noncomputable def maxDegenerateQuadruples (n : ℕ) : ℕ := 0  -- placeholder
noncomputable def f (n : ℕ) : ℕ := maxDegenerateQuadruples n
```

so `f n` reduces to `0` by `rfl`, while

```lean
axiom erdos_purdy_lower_bound :
    ∃ c : ℝ, c > 0 ∧ ∀ n : ℕ, n ≥ 4 → (f n : ℝ) ≥ c * (n:ℝ)^3 * Real.log n
```

asserts a strictly positive lower bound. For `n = 4` this gives `0 ≥ (positive)`, so `False` follows. Same class as erdos-1054/459/606/… (junk value stand-in + unconditional axiom about the "real" quantity).

## Fix

Declare `maxDegenerateQuadruples` **`opaque`** instead of `def := 0`. The witness is hidden, so `f n = 0` is no longer provable by `rfl`, and the two Erdős–Purdy bound axioms become genuine, consistent unproven assumptions.

- `opaque` is **not** an axiom declaration and does not appear in `#print axioms`, so `axiomCount` stays **2**.
- `trivial_upper_bound` (whose proof was `simp [f, maxDegenerateQuadruples]; positivity`, i.e. relied on `f n = 0`) can no longer be discharged by computation; it becomes an honest `sorry` documenting that `f n ≤ n.choose 4 ≤ n⁴/24` still needs a real proof. **sorries 1 → 2.**

## Evidence

**Before:** the auditor's `theorem … : False` compiles cleanly.

**After:** `./proofs/scripts/docker-build.sh Proofs.Erdos1087Problem` →

```
⚠ [2339/2339] Built Proofs.Erdos1087Problem
warning: Erdos1087Problem.lean:267:8: declaration uses `sorry`  (trivial_upper_bound)
warning: Erdos1087Problem.lean:323:8: declaration uses `sorry`  (erdos_1087_summary, pre-existing)
Build completed successfully.
```

The `f 4 = 0 := rfl` step the inconsistency proof depended on no longer typechecks.

## meta.json

- `sorries` 1 → 2 (top-level, `meta`, `leanFile`)
- `lineCount` 321 → 329
- `assumptions` now discloses that `f` is `opaque` specifically to avoid the junk-value/`rfl` inconsistency.

`axiomCount` unchanged (2). `pnpm`-side JSON validated.

Closes #42264
