### PR TITLE
Fix erdos-1100: re-anchor 12 drifted annotation line ranges

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9942,9 +9942,9 @@
     },
     "erdos-1100": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:03:31Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T15:08:26Z",
+      "result": "issues-fixed"
     },
     "erdos-1100-incomplete-01": {
       "auditCount": 1,

--- a/src/data/proofs/erdos-1100/annotations.json
+++ b/src/data/proofs/erdos-1100/annotations.json
@@ -74,7 +74,7 @@
     "proofId": "erdos-1100",
     "range": {
       "startLine": 52,
-      "endLine": 53
+      "endLine": 55
     },
     "type": "definition",
     "title": "Divisor Count τ(n)",
@@ -96,7 +96,7 @@
     "proofId": "erdos-1100",
     "range": {
       "startLine": 57,
-      "endLine": 58
+      "endLine": 60
     },
     "type": "definition",
     "title": "Distinct Prime Divisors ω(n)",
@@ -163,8 +163,8 @@
     "id": "ann-e1100-equality",
     "proofId": "erdos-1100",
     "range": {
-      "startLine": 158,
-      "endLine": 172
+      "startLine": 130,
+      "endLine": 139
     },
     "type": "concept",
     "title": "Equality Achieved Infinitely Often",
@@ -184,8 +184,8 @@
     "id": "ann-e1100-question1",
     "proofId": "erdos-1100",
     "range": {
-      "startLine": 174,
-      "endLine": 192
+      "startLine": 141,
+      "endLine": 159
     },
     "type": "definition",
     "title": "Question 1: Almost All Growth (OPEN)",
@@ -207,8 +207,8 @@
     "id": "ann-e1100-question2",
     "proofId": "erdos-1100",
     "range": {
-      "startLine": 194,
-      "endLine": 202
+      "startLine": 161,
+      "endLine": 173
     },
     "type": "definition",
     "title": "Question 2: Upper Bound (OPEN)",
@@ -230,8 +230,8 @@
     "id": "ann-e1100-erdos-hall",
     "proofId": "erdos-1100",
     "range": {
-      "startLine": 204,
-      "endLine": 215
+      "startLine": 175,
+      "endLine": 185
     },
     "type": "concept",
     "title": "Erdős–Hall Lower Bound on Maximum",
@@ -253,8 +253,8 @@
     "id": "ann-e1100-g-function",
     "proofId": "erdos-1100",
     "range": {
-      "startLine": 217,
-      "endLine": 223
+      "startLine": 187,
+      "endLine": 195
     },
     "type": "definition",
     "title": "The Extremal Function g(k)",
@@ -276,8 +276,8 @@
     "id": "ann-e1100-simonovits",
     "proofId": "erdos-1100",
     "range": {
-      "startLine": 225,
-      "endLine": 237
+      "startLine": 197,
+      "endLine": 209
     },
     "type": "concept",
     "title": "Erdős–Simonovits Bounds on g(k)",
@@ -299,8 +299,8 @@
     "id": "ann-e1100-exponential",
     "proofId": "erdos-1100",
     "range": {
-      "startLine": 239,
-      "endLine": 253
+      "startLine": 211,
+      "endLine": 230
     },
     "type": "concept",
     "title": "Exponential Growth of g(k)",
@@ -321,8 +321,8 @@
     "id": "ann-e1100-examples",
     "proofId": "erdos-1100",
     "range": {
-      "startLine": 259,
-      "endLine": 280
+      "startLine": 232,
+      "endLine": 257
     },
     "type": "concept",
     "title": "Worked Examples: n = 6 and n = 12",
@@ -343,8 +343,8 @@
     "id": "ann-e1100-insight",
     "proofId": "erdos-1100",
     "range": {
-      "startLine": 281,
-      "endLine": 295
+      "startLine": 258,
+      "endLine": 272
     },
     "type": "insight",
     "title": "Why This Problem Is Hard",
@@ -366,8 +366,8 @@
     "id": "ann-e1100-summary",
     "proofId": "erdos-1100",
     "range": {
-      "startLine": 296,
-      "endLine": 330
+      "startLine": 273,
+      "endLine": 308
     },
     "type": "concept",
     "title": "Problem Summary Theorem",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-1100
**Problem**: 10 of 17 annotations in `annotations.json` had drifted line ranges that no longer match the content they describe in `Proofs/Erdos1100ProblemProvable.lean`. This file was previously re-anchored twice (#25309, #40819) but drifted again, likely after a later compile-repair edit shifted line numbers without updating annotations.

## Evidence

- `ann-e1100-equality` claimed lines 158-172 ("Equality Achieved Infinitely Often") but that range actually contains the Question 1 status comment + Question 2 docstring header. The real `tau_perp_equality_infinitely_often` theorem is at lines 130-139.
- Every subsequent annotation was drifted by the same ~28-line offset, cascading through the rest of the file.
- The final annotation (`ann-e1100-summary`) claimed range 296-330, but the file is only 308 lines long — 22 lines of phantom range past EOF.
- Two other annotations (`ann-e1100-tau`, `ann-e1100-omega`) stopped one line short of the `def` they document (docstring only, missing the actual declaration line).

## Fix

Re-anchored all 12 affected annotation ranges to the line numbers of the actual declarations/comments they describe (verified against the current 308-line source). No content/title text changed — only `range.startLine`/`range.endLine`. Diff is 22 line-number changes only, confirmed no unrelated formatting churn.

meta.json counts (axiomCount: 3, sorries: 0, theoremCount: 7, definitionCount: 7) were independently re-verified against the source and are accurate; no changes needed there.

---
Discovered during gallery integrity audit (reserve-mode re-serve, queue fully drained: 4811/4811 audited, 0 open issues).