### PR TITLE
Gallery integrity: erdos-1084 phantom axiom entries in mainTheorems

### DIFF
--- a/src/data/proofs/erdos-1084/meta.json
+++ b/src/data/proofs/erdos-1084/meta.json
@@ -186,14 +186,9 @@
       "description": "The consecutive integer configuration {0, 1, ..., n-1} achieves exactly n-1 unit-distance pairs"
     },
     {
-      "name": "harborth_exact",
+      "name": "maxUnitDistPairs",
       "type": "axiom",
-      "description": "Harborth's formula: f_2(n) = floor(3n - sqrt(12n-3)) for separated points in R^2, optimal on triangular lattice"
-    },
-    {
-      "name": "erdos_1084_d3_conjecture",
-      "type": "axiom",
-      "description": "The d=3 conjecture: f_3(n) = 6n - Theta(n^{2/3}), with leading coefficient from the kissing number tau(3) = 12"
+      "description": "Uninterpreted function f_d(n) : N -> N -> N for the maximum number of unit-distance pairs; Harborth's formula (d=2) and the d=3 conjecture cited in the docstring are not separately formalized as axioms in this file"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-1084
**Problem**: `mainTheorems` in meta.json listed two axiom-typed entries — `harborth_exact` and `erdos_1084_d3_conjecture` — that do not exist anywhere in the Lean source.

## Evidence

**meta.json claims**: `mainTheorems` includes:
- `harborth_exact` (type: axiom) — "Harborth's formula: f_2(n) = floor(3n - sqrt(12n-3))..."
- `erdos_1084_d3_conjecture` (type: axiom) — "The d=3 conjecture: f_3(n) = 6n - Theta(n^{2/3})..."

**Lean file shows** (`proofs/Proofs/Erdos1084Problem.lean`): `grep -n 'harborth_exact\|erdos_1084_d3_conjecture'` returns nothing. The file declares exactly **one** axiom:

```
axiom maxUnitDistPairs (d n : ℕ) : ℕ
```

an uninterpreted function with no equation constraining its value. Harborth's formula and the d=3 conjecture are mentioned only in the module docstring as cited prior results (Harborth 1974, Bezdek–Reid 2013), never as Lean declarations. This is consistent with `meta.axiomCount: 1`, which was already correct — the phantom entries only existed in the `mainTheorems` array.

## Fix

Replaced the two phantom entries with a single accurate entry describing the real axiom `maxUnitDistPairs`, noting that the docstring-cited formulas aren't separately formalized in this file. Verified `meta.json` parses as valid JSON after the edit and that `annotations.json` doesn't reference the phantom names.

---
Discovered during gallery integrity audit (reserve re-audit of erdos-1084).