### PR TITLE
Audit tracker: erdos-1084 issues-fixed (reserve re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9756,9 +9756,9 @@
     },
     "erdos-1084": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:03:31Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T15:12:43Z",
+      "result": "issues-fixed"
     },
     "erdos-1084-oq-01": {
       "auditCount": 4,


### PR DESCRIPTION
Reserve-mode re-audit of erdos-1084 found phantom axiom entries in `mainTheorems` (see PR #42276). Tracker updated to reflect result.