### PR TITLE
Enrich erdos-740-incomplete-01: cover header + split witnesses into 5 sections

### DIFF
--- a/src/data/proofs/erdos-740-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-740-incomplete-01/meta.json
@@ -97,6 +97,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Header, Context, and Setup",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Module docstring on Erdős #740, the r = ∞ bipartite limiting case, and why the placeholder chromaticNumber := Cardinal.mk V made the parent's no_infinite_bipartite sorry meaningless. Imports Mathlib's coloring/bipartite theory, opens SimpleGraph, and fixes the ambient variables V, G.",
+      "mathContext": "$r=\\infty$ means 'no odd cycle of any length', i.e. bipartite; a bipartite graph has $\\chi \\le 2$."
+    },
+    {
       "id": "monotonicity-and-bound",
       "title": "Section I: Induced Monotonicity and the Bipartite Bound",
       "startLine": 41,
@@ -109,16 +117,24 @@
       "title": "Section II: The Bipartite Case of #740 Fails",
       "startLine": 53,
       "endLine": 68,
-      "summary": "no_bipartite_induced_realizes_chromatic: if χ(G) > 2 then no induced bipartite subgraph has χ = χ(G), because such a subgraph would force χ(G) ≤ 2.",
+      "summary": "no_bipartite_induced_realizes_chromatic: if χ(G) > 2 then no induced bipartite subgraph has χ = χ(G), because such a subgraph would force χ(G) ≤ 2. bipartite_induced_chromaticNumber_le_two restates the structural obstruction directly (any bipartite induced subgraph has χ ≤ 2, regardless of the ambient graph).",
       "mathContext": "The honest, real-chromatic-number replacement for the placeholder file's open no_infinite_bipartite sorry."
     },
     {
-      "id": "witnesses",
-      "title": "Section III: Explicit Witnesses K₃ and Kₙ",
+      "id": "triangle-witness",
+      "title": "Section III: The Triangle K₃ as a Witness",
       "startLine": 74,
-      "endLine": 106,
-      "summary": "triangle_chromaticNumber (χ(K₃) = 3) and completeGraph_chromaticNumber (χ(Kₙ) = n) feed no_bipartite_induced_realizes_chromatic to give triangle_has_no_bipartite_realization and completeGraph_has_no_bipartite_realization (n ≥ 3).",
-      "mathContext": "Shows the failure is non-vacuous: concrete graphs of chromatic number > 2 have no bipartite subgraph realizing their chromatic number."
+      "endLine": 89,
+      "summary": "triangle_chromaticNumber (χ(K₃) = 3) feeds no_bipartite_induced_realizes_chromatic to give triangle_has_no_bipartite_realization — the first concrete, non-vacuous witness of the failure.",
+      "mathContext": "$\\chi(K_3) = 3 > 2$, so no bipartite induced subgraph of $K_3$ realizes $\\chi(K_3)$."
+    },
+    {
+      "id": "general-witness",
+      "title": "Section IV: Every Kₙ (n ≥ 3) as a Witness",
+      "startLine": 91,
+      "endLine": 108,
+      "summary": "completeGraph_chromaticNumber (χ(Kₙ) = n) generalizes the triangle case to completeGraph_has_no_bipartite_realization for every n ≥ 3, closing the namespace.",
+      "mathContext": "$\\chi(K_n) = n > 2$ for $n \\ge 3$, so the failure of the bipartite case is witnessed by an infinite family, not just K₃."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Adds a `header` section for the previously-uncovered lines 1-39 (module docstring, imports, namespace/variable setup).
- Documents the previously-unmentioned `bipartite_induced_chromaticNumber_le_two` lemma (lines 66-68) in the "failure" section's summary.
- Splits the witnesses section into a triangle-K₃ piece and a general-Kₙ piece.
- Raises `sections` 6/10 -> 10/10 (overall quality 96 -> 100 per `scripts/enricher/find-targets.ts`).
- No content deleted.

## Test plan
- [x] `python3 -c "import json; json.load(...)"` — meta.json is valid JSON
- [x] `npx tsx scripts/enricher/find-targets.ts --json` — confirms quality 96 -> 100 for this entry