### PR TITLE
Enrich leibniz-pi-oq-02: add basel-problem and dirichlets-theorem cross-references

### DIFF
--- a/src/data/proofs/leibniz-pi-oq-02/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-02/meta.json
@@ -169,6 +169,16 @@
       "targetId": "leibniz-pi",
       "relationship": "answers-question",
       "description": "Answers OQ-02: 'How do generalized Leibniz-type formulas extend to other constants?'"
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "related",
+      "description": "dirichlet_eta_two claims η(2) = π²/12 via η(s) = (1-2^{1-s})ζ(s) at s=2, so the value rests on the Basel-problem evaluation ζ(2) = π²/6 proved in that entry."
+    },
+    {
+      "targetId": "dirichlets-theorem",
+      "relationship": "related",
+      "description": "Both entries formalize structure around the mod-4 Dirichlet character χ₄; this file identifies β(s) = L(s, χ₄) while Dirichlet's theorem uses the non-vanishing of Dirichlet L-functions at s=1 to prove infinitely many primes in each coprime residue class mod q."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for leibniz-pi-oq-02 (Generalized Leibniz-Type Formulas).

The entry was already at quality target — 10 fully-fielded annotations covering the whole 439-line file, accurate sorry/axiom counts, thorough historicalContext/keyInsights/conclusion. The one genuine gap was thin cross-referencing (only 1 entry, `leibniz-pi`).

Added 2 accurate cross-references:
- `basel-problem`: `dirichlet_eta_two` claims η(2) = π²/12 via the eta-zeta identity at s=2, which rests on ζ(2) = π²/6 (the Basel problem).
- `dirichlets-theorem`: both entries formalize structure around the mod-4 Dirichlet character χ₄ and Dirichlet L-functions.

No other changes — all other fields were already accurate and at target (verified `meta.meta.sorries: 9` is correct aggregation of the main file's 4 sorries + the `LeibnizPiOQ02Aristotle.lean` companion's 5 sorries, not drift).