### PR TITLE
Fix erdos-1085: erdosProblemStatus overclaims "solved"

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9767,10 +9767,10 @@
       "result": "clean"
     },
     "erdos-1085": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:31Z",
-      "result": "clean"
+      "lastAudited": "2026-07-23T15:17:25Z",
+      "result": "issues-fixed"
     },
     "erdos-1086": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-1085/meta.json
+++ b/src/data/proofs/erdos-1085/meta.json
@@ -21,7 +21,7 @@
     "sorries": 0,
     "erdosNumber": 1085,
     "erdosUrl": "https://erdosproblems.com/1085",
-    "erdosProblemStatus": "solved",
+    "erdosProblemStatus": "partially-solved",
     "dateAdded": "2026-01-17",
     "mathlib_version": "4.31.0",
     "mathlibDependencies": [


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-1085 (Unit Distance Problem)

**Problem**: `meta.erdosProblemStatus` was `"solved"`, but the problem is not solved.

## Evidence

- **erdosproblems.com/1085** badges the problem **OPEN**: "The most difficult cases are d=2 and d=3." The classic d=2 gap between n^(1+o(1)) and n^(4/3) has been open since 1946; d=3 also has an open sub-question.
- The file's own docstring/conclusion agree: "d=2, d=3 remain open with stubborn gaps... the d=2 case being one of the most famous open problems in combinatorial geometry" and lists it as the "Main Open Question" — only d≥4 is resolved (Lenz construction + Erdős–Stone).
- The `tags` array already includes `"partially-open"`, contradicting `erdosProblemStatus: "solved"` in the same file.
- The gallery's own controlled vocabulary already has `"partially-solved"` (used by 20 other entries) for exactly this situation. The sibling entry `erdos-90`, which covers the same still-open d=2 conjecture and is cross-referenced from this file as sharing it, is correctly tagged `erdosProblemStatus: "open"`.

## Fix

Changed `erdosProblemStatus` from `"solved"` to `"partially-solved"` in `src/data/proofs/erdos-1085/meta.json`. No other fields needed changes — axiomCount (1), theoremCount (0), sorries (0), definitionCount (6), badge (`axiom`), and status (`axiomatized`) all verified accurate against `proofs/Proofs/Erdos1085Problem.lean` (126 lines, exact match).

Audit tracker updated: `erdos-1085` → `issues-fixed`.

---
Discovered during gallery integrity audit (reserve round-robin re-audit; queue was fully drained at 4811/4811).