### PR TITLE
Audit tracker: erdos-1082 clean (reserve re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9738,8 +9738,8 @@
     },
     "erdos-1082": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:03:31Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T15:20:59Z",
       "result": "clean"
     },
     "erdos-1083": {


### PR DESCRIPTION
Reserve re-audit of erdos-1082 (Distinct Distances in General Position). Verified: axiomCount=2 (both disclosed: szemeredi_n_over_3, xichuan_counterexample), theoremCount=23, definitionCount=12, sorries=0, lineCount=342 — all exact matches. Badge `axiom` correctly reflects Tier C axiomatized status. `erdosProblemStatus: open` matches the file's own docstring and erdosproblems.com. No native_decide, no True-stubs. Clean.