### PR TITLE
Audit erdos-1081: re-anchor drifted sections/annotations

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9732,9 +9732,9 @@
     },
     "erdos-1081": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:03:31Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T15:27:13Z",
+      "result": "issues-fixed"
     },
     "erdos-1082": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-1081/annotations.json
+++ b/src/data/proofs/erdos-1081/annotations.json
@@ -26,8 +26,8 @@
     "id": "ann-e1081-squarefull-def",
     "proofId": "erdos-1081",
     "range": {
-      "startLine": 43,
-      "endLine": 53
+      "startLine": 38,
+      "endLine": 48
     },
     "type": "definition",
     "title": "Squarefull Number Definition",
@@ -49,8 +49,8 @@
     "id": "ann-e1081-squarefull-alt",
     "proofId": "erdos-1081",
     "range": {
-      "startLine": 55,
-      "endLine": 66
+      "startLine": 50,
+      "endLine": 55
     },
     "type": "definition",
     "title": "Alternative Characterization",
@@ -71,8 +71,8 @@
     "id": "ann-e1081-examples",
     "proofId": "erdos-1081",
     "range": {
-      "startLine": 68,
-      "endLine": 107
+      "startLine": 60,
+      "endLine": 139
     },
     "type": "concept",
     "title": "Squarefull Examples",
@@ -93,8 +93,8 @@
     "id": "ann-e1081-sums-def",
     "proofId": "erdos-1081",
     "range": {
-      "startLine": 112,
-      "endLine": 117
+      "startLine": 145,
+      "endLine": 150
     },
     "type": "concept",
     "title": "Sums of Two Squarefull Numbers",
@@ -115,8 +115,8 @@
     "id": "ann-e1081-sum-examples",
     "proofId": "erdos-1081",
     "range": {
-      "startLine": 119,
-      "endLine": 131
+      "startLine": 152,
+      "endLine": 164
     },
     "type": "concept",
     "title": "Sum Examples",
@@ -137,8 +137,8 @@
     "id": "ann-e1081-counting",
     "proofId": "erdos-1081",
     "range": {
-      "startLine": 137,
-      "endLine": 158
+      "startLine": 166,
+      "endLine": 185
     },
     "type": "concept",
     "title": "The Counting Function A(x)",
@@ -160,8 +160,8 @@
     "id": "ann-e1081-conjecture",
     "proofId": "erdos-1081",
     "range": {
-      "startLine": 164,
-      "endLine": 179
+      "startLine": 190,
+      "endLine": 209
     },
     "type": "concept",
     "title": "Erdős's Conjecture (Disproved)",
@@ -182,8 +182,8 @@
     "id": "ann-e1081-odoni",
     "proofId": "erdos-1081",
     "range": {
-      "startLine": 185,
-      "endLine": 197
+      "startLine": 211,
+      "endLine": 221
     },
     "type": "concept",
     "title": "Odoni's Lower Bound",
@@ -205,8 +205,8 @@
     "id": "ann-e1081-alpha",
     "proofId": "erdos-1081",
     "range": {
-      "startLine": 203,
-      "endLine": 209
+      "startLine": 222,
+      "endLine": 232
     },
     "type": "definition",
     "title": "The Critical Exponent α",
@@ -228,8 +228,8 @@
     "id": "ann-e1081-blomer-granville",
     "proofId": "erdos-1081",
     "range": {
-      "startLine": 211,
-      "endLine": 223
+      "startLine": 234,
+      "endLine": 239
     },
     "type": "concept",
     "title": "Blomer-Granville Theorem (2006)",
@@ -251,8 +251,8 @@
     "id": "ann-e1081-comparison",
     "proofId": "erdos-1081",
     "range": {
-      "startLine": 225,
-      "endLine": 235
+      "startLine": 240,
+      "endLine": 261
     },
     "type": "concept",
     "title": "Exponent Comparison",
@@ -273,8 +273,8 @@
     "id": "ann-e1081-heuristic",
     "proofId": "erdos-1081",
     "range": {
-      "startLine": 241,
-      "endLine": 257
+      "startLine": 263,
+      "endLine": 284
     },
     "type": "concept",
     "title": "Why the Conjecture Failed",
@@ -296,8 +296,8 @@
     "id": "ann-e1081-summary",
     "proofId": "erdos-1081",
     "range": {
-      "startLine": 280,
-      "endLine": 309
+      "startLine": 304,
+      "endLine": 337
     },
     "type": "concept",
     "title": "Problem Summary",

--- a/src/data/proofs/erdos-1081/meta.json
+++ b/src/data/proofs/erdos-1081/meta.json
@@ -86,72 +86,72 @@
       "id": "squarefull",
       "title": "Squarefull Numbers",
       "summary": "Definition of squarefull (powerful) numbers and alternative characterization",
-      "startLine": 39,
-      "endLine": 79,
+      "startLine": 34,
+      "endLine": 55,
       "mathContext": "Formal definition: Definition of squarefull (powerful) numbers and alternative characterization"
     },
     {
       "id": "examples-squarefull",
       "title": "Squarefull Examples",
       "summary": "Proofs that 1, 4, 8, 9 are squarefull",
-      "startLine": 80,
-      "endLine": 107,
+      "startLine": 57,
+      "endLine": 139,
       "mathContext": "Verified: Proofs that 1, 4, 8, 9 are squarefull"
     },
     {
       "id": "sums",
       "title": "Sums of Two Squarefull",
       "summary": "Definition and examples: 5 = 1+4, 13 = 4+9",
-      "startLine": 108,
-      "endLine": 132,
+      "startLine": 141,
+      "endLine": 164,
       "mathContext": "Formal definition: Definition and examples: 5 = 1+4, 13 = 4+9"
     },
     {
       "id": "counting",
       "title": "The Counting Function A(x)",
       "summary": "A(x) definition and squarefull count asymptotic S(x) ~ c√x",
-      "startLine": 133,
-      "endLine": 159,
+      "startLine": 166,
+      "endLine": 189,
       "mathContext": "A(x) definition and squarefull count asymptotic S(x) ~ c$\\sqrt{x}$"
     },
     {
       "id": "conjecture",
       "title": "Erdős's Conjecture (Disproved)",
       "summary": "The false conjecture A(x) ~ cx/√(log x) and Odoni's disproof",
-      "startLine": 160,
-      "endLine": 180,
+      "startLine": 190,
+      "endLine": 209,
       "mathContext": "Verified: The false conjecture A(x) ~ cx/√(log x) and Odoni's disproof"
     },
     {
       "id": "odoni",
       "title": "Odoni's Lower Bound",
       "summary": "A(x) grows faster by a slowly growing factor",
-      "startLine": 181,
-      "endLine": 198,
+      "startLine": 211,
+      "endLine": 221,
       "mathContext": "Mathematical content: A(x) grows faster by a slowly growing factor"
     },
     {
       "id": "blomer-granville",
       "title": "Blomer-Granville Refinement",
       "summary": "The correct exponent α = 1 - 2^(-1/3) ≈ 0.206",
-      "startLine": 199,
-      "endLine": 236,
+      "startLine": 222,
+      "endLine": 261,
       "mathContext": "Mathematical content: The correct exponent α = 1 - 2^(-1/3) ≈ 0.206"
     },
     {
       "id": "explanation",
       "title": "Why the Conjecture Failed",
       "summary": "Heuristic explanation and connection to quadratic forms",
-      "startLine": 237,
-      "endLine": 275,
+      "startLine": 263,
+      "endLine": 302,
       "mathContext": "Mathematical content: Heuristic explanation and connection to quadratic forms"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Complete answer: NO, with correct exponent α ≈ 0.206",
-      "startLine": 276,
-      "endLine": 335,
+      "startLine": 304,
+      "endLine": 339,
       "mathContext": "Mathematical content: Complete answer: NO, with correct exponent α ≈ 0.206"
     }
   ],


### PR DESCRIPTION
## Gallery Integrity Audit: erdos-1081

**Proof**: erdos-1081 (Sums of Two Squarefull Numbers)

**Counts verified correct** (no change): axiomCount:1 (`odoni_disproof`, disclosed), theoremCount:9, definitionCount:7, sorries:0, lineCount:339, no True stubs, no native_decide. Badge `axiom` / status `axiomatized` are honest.

**Problem found**: `meta.json`'s `sections` array and `annotations.json` had line ranges systematically offset ~25-40 lines from the declarations/comments they claim to describe. All cited names are real (no phantom declarations) and all ranges are `<= 339`, so this wasn't caught by a phantom-name or out-of-range check — but every section/annotation rendered the wrong code snippet in the gallery UI.

Examples:
- `sections[3]` ("counting") claimed A(x)'s definition lives at lines 133-159; `A` is actually defined at line 174 (that range is really `nine_squarefull` + `IsSumOfTwoSquarefull`'s docstring).
- `sections[1]` ("examples-squarefull", "Proofs that 1, 4, 8, 9 are squarefull") pointed at lines 80-107, which is entirely inside the `prime_power_squarefull` proof — the actual `four_squarefull`/`eight_squarefull`/`nine_squarefull` theorems are at 117-139.
- `annotations.json`'s `ann-e1081-alpha` ("The Critical Exponent α") pointed at 203-209, which is `erdos_conjecture`'s tail + `odoni_disproof`'s docstring/axiom; the real `alpha` def is at line 232.

## Fix

Re-mapped every `sections[].startLine/endLine` and `annotations[].range` to the actual declaration/comment it describes, verified against the current line-numbered source (`proofs/Proofs/Erdos1081Problem.lean`). No math/status/badge/count changes — this is purely a re-anchor.

Tracker updated via `claim-target.sh complete erdos-1081 issues-fixed`.

---
Discovered during gallery integrity audit.