### PR TITLE
Enrich dirichlet-approximation-theorem-oq-05-oq-02: 5th key insight + split header section

### DIFF
--- a/src/data/proofs/dirichlet-approximation-theorem-oq-05-oq-02/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-05-oq-02/meta.json
@@ -64,7 +64,8 @@
       "**The conjugate of √d is just −√d**: the parent's norm form needed the golden-ratio Vieta relations, but for a bare square root the two roots of X² − d are x and −x, so the norm form q²(p/q − x)(p/q + x) = p² − d·q² has no middle term and no special API — the argument is *simpler* than the golden-ratio case, not harder",
       "**Irrationality is the only nonelementary input, and it is fully decoupled**: the analytic core (identity + non-vanishing + case analysis) is stated over an abstract irrational x with x² = d, so every concrete surd √2, √3, √5, √6, … is a one-line instantiation differing only in which Mathlib irrationality lemma is cited",
       "**A nonzero integer is ≥ 1**: exactly as in the parent, the entire lower bound reduces to the triviality that |p² − d·q²| ≥ 1 once it is known to be nonzero — badly-approximability of quadratic surds is, at bottom, this integrality fact plus a triangle inequality",
-      "**Explicit but non-optimal constant**: c = 1/(1+2x) is fully explicit (e.g. 1/(1+2√2) for √2) and requires no continued fractions; the sharp constant 1/(2√d) needs the periodic CF convergents, but badly-approximability only asks for some positive c"
+      "**Explicit but non-optimal constant**: c = 1/(1+2x) is fully explicit (e.g. 1/(1+2√2) for √2) and requires no continued fractions; the sharp constant 1/(2√d) needs the periodic CF convergents, but badly-approximability only asks for some positive c",
+      "**The proof needs no case split on the sign of p/q − x beyond the size dichotomy**: the argument only ever asks whether A = |p/q − x| is ≥ 1 or < 1, never whether p/q lies above or below x — the absolute values and the triangle inequality |B| ≤ A + 2x absorb that sign information automatically, which is why one theorem covers every rational approximation p/q at once"
     ],
     "prerequisites": [
       "The identity that √d and −√d are the two roots of X² − d, giving the norm form p² − d·q² = q²(p/q − √d)(p/q + √d)",
@@ -75,17 +76,25 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 51,
+      "mathContext": "$x^2 = d$, $x$ irrational, conjugate $-x$; goal: $c/q^2 \\le |x - p/q|$ with $c = 1/(1+2x)$ explicit.",
+      "summary": "Module docstring contrasting the golden-ratio parent's Vieta-relation argument with the uniform statement proved here for any square root x of d, the Mathlib import, the DirichletApproximationOQ05OQ02 namespace, and the abstract section General with variables {d : ℕ} {x : ℝ} that the whole analytic core is proved over."
+    },
+    {
       "id": "norm-form-identity",
       "title": "The Norm-Form Identity p² − d·q² over ℤ[√d]",
-      "startLine": 1,
-      "endLine": 66,
+      "startLine": 53,
+      "endLine": 64,
       "mathContext": "$q^2\\left(\\tfrac pq - x\\right)\\left(\\tfrac pq + x\\right) = p^2 - d\\,q^2 \\in \\mathbb{Z}$, where $x^2 = d$ so the roots of $X^2 - d$ are $x$ and $-x$.",
-      "summary": "After a docstring contrasting the golden-ratio parent with the uniform statement proved here, norm_form_identity establishes the core algebraic fact for an abstract square root x of d: because the conjugate of x is −x, the product (p/q − x)(p/q + x) collapses to (p/q)² − x² = (p/q)² − d, which equals (p² − d·q²)/q². The proof expands the product with ring, substitutes the hypothesis x² = d, and clears denominators with field_simp. No golden-ratio-specific API is used — only the single equation x² = d."
+      "summary": "norm_form_identity establishes the core algebraic fact for an abstract square root x of d: because the conjugate of x is −x, the product (p/q − x)(p/q + x) collapses to (p/q)² − x² = (p/q)² − d, which equals (p² − d·q²)/q². The proof expands the product with ring, substitutes the hypothesis x² = d, and clears denominators with field_simp. No golden-ratio-specific API is used — only the single equation x² = d."
     },
     {
       "id": "non-vanishing",
       "title": "Non-Vanishing of the Norm Form via Irrationality",
-      "startLine": 68,
+      "startLine": 66,
       "endLine": 92,
       "mathContext": "$p^2 - d\\,q^2 \\ne 0$ for $q > 0$, since otherwise $p/q \\in \\{x, -x\\}$ would be rational.",
       "summary": "norm_form_ne_zero shows the integer p² − d·q² never vanishes for q > 0. If it were zero, the norm-form identity forces (p/q − x)(p/q + x) = 0, so p/q = x or p/q = −x. The first gives x = p/q; the second gives x = (−p)/q; both express x as a ratio of integers, contradicting Irrational.ne_rational. This is the only place irrationality enters, and it is precisely what makes the norm a nonzero integer — hence ≥ 1 in absolute value."


### PR DESCRIPTION
Enrichment pass for dirichlet-approximation-theorem-oq-05-oq-02 (quality 96 -> 100 per find-targets.ts scoring):

- Added a 5th `overview.keyInsights` entry noting that the proof's only
  case split is on the size of A = |p/q - x| (>= 1 vs < 1), never on the
  sign of p/q - x — the absolute values and the triangle inequality
  |B| <= A + 2x absorb the sign automatically, which is why the single
  theorem covers every rational approximation p/q uniformly.
- Split the `sections` array from 4 to 5 entries at a real boundary: the
  former "norm-form-identity" section (lines 1-66) bundled the module
  docstring/imports/namespace/section-variable setup together with the
  `norm_form_identity` theorem itself. Pulled the prose+setup out into
  its own "header" section (1-51), leaving "norm-form-identity" (53-64)
  to cover just the theorem, and adjusted "non-vanishing"'s start (66)
  to match.

No content was removed; the Lean file itself is unchanged (0 sorries,
0 axioms, all 6 theorems proved).