### PR TITLE
Audit tracker: erdos-1071 clean (reserve re-verify)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9654,9 +9654,9 @@
       "issues": []
     },
     "erdos-1071": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:31Z",
+      "lastAudited": "2026-07-23T15:35:52Z",
       "result": "clean"
     },
     "erdos-1072": {


### PR DESCRIPTION
## Reserve re-verification

**Proof**: erdos-1071 (Maximal Packings of Unit Segments in the Unit Square)

Full independent re-check against `proofs/Proofs/Erdos1071Problem.lean`:

| Field | meta.json | Actual | Match |
|---|---|---|---|
| axiomCount | 1 | 1 (`danzer_finite_maximal_packing`) | ✓ |
| theoremCount | 23 | 23 | ✓ |
| definitionCount | 16 | 16 | ✓ |
| lineCount | 323 | 323 | ✓ |
| sorries | 0 | 0 | ✓ |
| True stubs | — | none | ✓ |
| native_decide | — | none | ✓ |

All 13 `originalContributions` entries and all 12 `sections[]` line-ranges
verified to correspond to real, correctly-anchored declarations — no phantom
names, no drift. Badge `axiom` / status `axiomatized` correctly scoped: part
(a) solved via the disclosed Danzer axiom, part (b) left as an honest
open-problem comment rather than an axiom. Clean.

---
Discovered during gallery integrity audit (reserve mode, queue fully drained).