### PR TITLE
Audit erdos-1073: fix stale 'axioms' prose for proven composite witnesses

### DIFF
--- a/src/data/proofs/erdos-1073/meta.json
+++ b/src/data/proofs/erdos-1073/meta.json
@@ -75,8 +75,8 @@
       "title": "Known Composites",
       "startLine": 54,
       "endLine": 65,
-      "summary": "Proves 25 | 4!+1. States 121, 169 as axioms.",
-      "mathContext": "Proves 25 | 4!+1. States 121, 169 as axioms."
+      "summary": "Proves 25 | 4!+1, 121 | 5!+1, 169 | 12!+1, and 437 | 18!+1, all discharged via native_decide.",
+      "mathContext": "Proves 25 | 4!+1, 121 | 5!+1, 169 | 12!+1, and 437 | 18!+1, all discharged via native_decide."
     },
     {
       "id": "basic",


### PR DESCRIPTION
## Summary
- The "Known Composites" section (`sections[3]`) `summary`/`mathContext` claimed "States 121, 169 as axioms" — stale from before those were upgraded to `native_decide`-proved theorems.
- Confirmed via `git show 297cfb263d:proofs/Proofs/Erdos1073Problem.lean`: at creation (#1180), `composite_121` and `composite_169` were literal `axiom` declarations. They're now `theorem ... := by native_decide`, matching `composite_25`/`composite_437`.
- `meta.assumptions` already correctly discloses all four as native_decide-discharged (1 `Lean.ofReduceBool` axiom, disclosed policy-compliant) — only the section prose lagged.

## Evidence

**meta.json claimed** (sections[3]): "Proves 25 | 4!+1. States 121, 169 as axioms."

**Lean file shows** (`proofs/Proofs/Erdos1073Problem.lean:70-83`): all four are `theorem`s discharged by `native_decide`, no `axiom` keyword anywhere in the file.

## Fix
Updated the section summary/mathContext to describe all four composite witnesses as native_decide-proved, consistent with `meta.assumptions`.

## Test plan
- [x] `python3 -m json.tool` validates the JSON
- [x] No other stale "axiom" references remain for this entry (`grep -n axiom src/data/proofs/erdos-1073/meta.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)