### PR TITLE
Gallery integrity: erdos-1075 phantom axiom names in originalContributions

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9679,10 +9679,10 @@
       "result": "clean"
     },
     "erdos-1075": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:31Z",
-      "result": "clean"
+      "lastAudited": "2026-07-23T15:44:15Z",
+      "result": "issues-fixed"
     },
     "erdos-1076": {
       "auditCount": 4,

--- a/src/data/proofs/erdos-1075/meta.json
+++ b/src/data/proofs/erdos-1075/meta.json
@@ -71,8 +71,6 @@
       "erdos_1964_result axiom formalizing the known result with threshold εn^r",
       "threshold_decreasing axiom for monotonicity of r^{-r}",
       "ErdosConjecture1075 formal statement of the open problem with threshold (1+ε)(n/r)^r",
-      "threshold_comparison axiom relating the two edge thresholds",
-      "binomial_asymptotic axiom for C(m,r) ~ m^r/r!",
       "erdos_1075_summary theorem combining known result with monotonicity"
     ],
     "axiomCount": 2,


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-1075 (Dense Subgraphs in r-Uniform Hypergraphs)
**Problem**: `meta.originalContributions` listed `threshold_comparison` and
`binomial_asymptotic` as "axiom"s, but neither is a real Lean declaration —
they're only mentioned in source comments (`Proofs/Erdos1075Problem.lean`
lines 120-125, 131-134). 0 hits in the file, 0 hits in `git log -p --follow`
history — never formalized, not stripped after cleanup.

## Evidence

**meta.json claims** (before fix): `originalContributions` included
`"threshold_comparison axiom relating the two edge thresholds"` and
`"binomial_asymptotic axiom for C(m,r) ~ m^r/r!"`.

**Lean file shows**: only 2 real axioms exist —
`erdos_1964_result` (line 73) and `threshold_decreasing` (line 90).
`grep '^axiom'` confirms exactly 2, matching `axiomCount: 2` (which was
already correct). The `sections`/`mathContext` prose for the "conjecture" and
"asymptotics" sections already correctly disclose "no Lean declaration
exists" for both names — only `originalContributions` mischaracterized them.

## Fix

Removed the two phantom entries from `originalContributions`. No count
fields changed (`axiomCount`, `sorries`, `theoremCount`, `definitionCount`,
`lineCount` were all already correct against the source).

Audit tracker updated: `erdos-1075` → `issues-fixed`.

---
Discovered during gallery integrity audit.