### PR TITLE
Audit tracker: erdos-1075 issues-fixed (merged stale fix PR)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9679,9 +9679,9 @@
       "result": "clean"
     },
     "erdos-1075": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-07-23T15:44:15Z",
+      "lastAudited": "2026-07-23T15:47:07Z",
       "result": "issues-fixed"
     },
     "erdos-1076": {


### PR DESCRIPTION
## Summary
Reserve re-audit of erdos-1075 found the previous cycle's fix PR (#42309, removing 2 phantom axiom names — `threshold_comparison`/`binomial_asymptotic` — from `originalContributions`) had never been merged, leaving the phantom claims live on main. Merged #42309 with `--admin` (clean, mergeable, no CI configured) and re-verified: axiomCount:2 matches `grep '^axiom'` (erdos_1964_result, threshold_decreasing), 0 sorries, no True stubs. This PR records the completion in the tracker.

## Test plan
- [x] Verified meta.json no longer lists the 2 phantom axiom names
- [x] Verified axiomCount (2) matches actual `axiom` declarations in Erdos1075Problem.lean