### PR TITLE
Enrich dirichlets-theorem-oq-03-oq-01-oq-01: 5th key insight + split sections 4->5

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03-oq-01-oq-01/meta.json
@@ -48,7 +48,8 @@
       "The lower bound L* ≥ 1 is NOT analytic: it rests entirely on the trivial inequality q ≤ p for primes p ≡ 1 (mod q), not on Linnik's theorem, zero-free regions, or Bertrand's postulate. The parent's comment invoking a 'Bertrand variant' overstates what is needed.",
       "The argument is a clean instance of a general principle: a growth function dominating an unbounded base of size ≥ 1 cannot have a sub-linear (exponent < 1) power-law upper bound. Stated abstractly (admissible_ge_one), it is independent of number theory.",
       "The contradiction is localized to a single index i where the base exceeds the explicit threshold c^(1/(1-L)); the threshold identity (c^(1/(1-L)))^(1-L) = c is the only rpow computation required.",
-      "Keeping the growth function abstract and taking nonemptiness of the admissible set as a hypothesis makes the whole file axiom-free: the deep Dirichlet/Linnik existence input survives only as the explicit selector hypothesis hP and the nonemptiness hypothesis hne."
+      "Keeping the growth function abstract and taking nonemptiness of the admissible set as a hypothesis makes the whole file axiom-free: the deep Dirichlet/Linnik existence input survives only as the explicit selector hypothesis hP and the nonemptiness hypothesis hne.",
+      "The existence input is confined to exactly one place: admissible_ge_one proves 1 ≤ L for every admissible L using only domination and unboundedness, with no existence assumption; only criticalExponent_ge_one, which takes an infimum, additionally needs the admissible set to be nonempty (hne). This isolates precisely where a genuine existence theorem — Linnik's, or in the a = 1 case Dirichlet's — is load-bearing"
     ],
     "prerequisites": [
       "Real.rpow: rpow_sub, rpow_mul, rpow_lt_rpow, rpow_pos_of_pos",
@@ -116,11 +117,20 @@
       "mathContext": "The Linnik constant is the critical exponent $L$ with $p(a,q) \\le c\\, q^L$; this file proves $L \\ge 1$ from elementary domination."
     },
     {
-      "id": "abstract-critical-exponent",
-      "title": "The Abstract Critical Exponent and its Lower Bound",
+      "id": "admissible-lower-bound",
+      "title": "Definitions and the Core Contradiction Argument",
       "startLine": 41,
+      "endLine": 86,
+      "summary": "Definitions of `admissible f b` and `criticalExponent f b`, then `admissible_ge_one`: every admissible exponent ≥ 1 when f dominates an unbounded base ≥ 1, proved by contradiction via an explicit rpow threshold.",
+      "mathContext": "$L < 1 \\Rightarrow b_i^{1-L} \\le c$ for all $i$; choosing $i$ with $b_i$ above the threshold $c^{1/(1-L)}$ contradicts this, so every admissible $L$ satisfies $L \\ge 1$."
+    },
+    {
+      "id": "critical-exponent-corollary",
+      "title": "Lifting to the Infimum",
+      "startLine": 88,
       "endLine": 101,
-      "summary": "Definitions of `admissible f b` and `criticalExponent f b`, then `admissible_ge_one` (every admissible exponent ≥ 1 when f dominates an unbounded base ≥ 1) and `criticalExponent_ge_one`."
+      "summary": "`criticalExponent_ge_one`: under the same domination hypotheses plus nonemptiness of the admissible set, the infimum itself is ≥ 1, via `le_csInf` applied pointwise to `admissible_ge_one`.",
+      "mathContext": "$\\mathrm{admissible}\\,f\\,b \\ne \\emptyset \\wedge (\\forall L \\in \\mathrm{admissible}\\,f\\,b,\\ 1 \\le L) \\Rightarrow 1 \\le \\sInf(\\mathrm{admissible}\\,f\\,b)$."
     },
     {
       "id": "prime-domination",


### PR DESCRIPTION
Enrichment pass for dirichlets-theorem-oq-03-oq-01-oq-01 (quality 96, 0 passes).

- Split the `sections` array from 4 to 5, aligning boundaries with actual
  theorem declarations: separates `admissible_ge_one` (the core contradiction
  argument, lines 41-86) from `criticalExponent_ge_one` (the short le_csInf
  corollary that lifts it to the infimum, lines 88-95), which the previous
  4-section layout had merged into one span.
- Added a 5th `overview.keyInsights` item observing that the existence-theorem
  dependency (Linnik's, or Dirichlet's in the a = 1 case) is isolated to
  exactly one hypothesis — `hne` in `criticalExponent_ge_one` — while
  `admissible_ge_one` itself needs no existence input at all.

No content deleted; file stays well under the 60 KB size cap (~16.6 KB).