### PR TITLE
audit(erdos-1076): fix stale prose after 2026-03-27 dead-axiom elimination

### DIFF
--- a/src/data/proofs/erdos-1076/annotations.json
+++ b/src/data/proofs/erdos-1076/annotations.json
@@ -27,8 +27,8 @@
     "id": "ann-1076-hypergraph3",
     "proofId": "erdos-1076",
     "range": {
-      "startLine": 40,
-      "endLine": 54
+      "startLine": 34,
+      "endLine": 50
     },
     "type": "definition",
     "title": "3-Uniform Hypergraph Structure",
@@ -51,8 +51,8 @@
     "id": "ann-1076-familyf",
     "proofId": "erdos-1076",
     "range": {
-      "startLine": 56,
-      "endLine": 78
+      "startLine": 52,
+      "endLine": 74
     },
     "type": "definition",
     "title": "The Family F_k",
@@ -74,8 +74,8 @@
     "id": "ann-1076-containment",
     "proofId": "erdos-1076",
     "range": {
-      "startLine": 80,
-      "endLine": 94
+      "startLine": 76,
+      "endLine": 90
     },
     "type": "definition",
     "title": "Subgraph Containment and F_k-Freeness",
@@ -97,13 +97,13 @@
     "id": "ann-1076-ex3",
     "proofId": "erdos-1076",
     "range": {
-      "startLine": 96,
-      "endLine": 109
+      "startLine": 92,
+      "endLine": 97
     },
     "type": "concept",
     "title": "Extremal Number ex₃(n, F_k)",
-    "content": "The extremal number ex3(n, k) is axiomatized as a natural number together with two characterizing axioms: ex3_achieved states that some F_k-free hypergraph achieves this many edges; ex3_is_max states that no F_k-free hypergraph has more. This axiomatization avoids the need for decidability proofs that a constructive definition would require.",
-    "mathContext": "axiom ex3 (n k : ℕ) : ℕ. axiom ex3_achieved: ∃ H, IsFkFree k H ∧ numEdges H = ex3 n k. axiom ex3_is_max: ∀ H, IsFkFree k H → numEdges H ≤ ex3 n k.",
+    "content": "The extremal number ex3(n, k) is axiomatized as a bare natural-number-valued axiom, with no achieved/maximality guarantee. The characterizing axioms ex3_achieved (some F_k-free hypergraph achieves this many edges) and ex3_is_max (no F_k-free hypergraph has more) that once accompanied it were removed as dead (unreferenced) axioms in a 2026-03-27 cleanup (commit b22da88e49).",
+    "mathContext": "axiom ex3 (n k : ℕ) : ℕ. No further axioms constrain it in this file.",
     "significance": "key",
     "relatedConcepts": [
       "extremal function",
@@ -120,37 +120,35 @@
     "id": "ann-1076-bes",
     "proofId": "erdos-1076",
     "range": {
-      "startLine": 111,
-      "endLine": 120
+      "startLine": 99,
+      "endLine": 100
     },
     "type": "concept",
-    "title": "Brown-Erdős-Sós (1973)",
-    "content": "Two foundational results from the 1973 paper. brown_erdos_sos_k4: for k=4, ex₃(n, F_4) ~ n²/6 (the asymptotic is exact). brown_erdos_sos_general: for all k ≥ 4, ex₃(n, F_k) = Θ_k(n²) — quadratic growth with constants depending on k. The k=4 case was the base case; the conjecture that the coefficient is always 1/6 for k ≥ 5 took 46 years to resolve.",
-    "mathContext": "brown_erdos_sos_k4: Tendsto (fun n => ex3 n 4 / n²) atTop (nhds (1/6)). brown_erdos_sos_general: ∃ c₁ c₂ > 0, c₁·n² ≤ ex3(n,k) ≤ c₂·n² for n ≥ k.",
-    "significance": "key",
+    "title": "Brown-Erdős-Sós (1973) — removed as dead code",
+    "content": "This section header is now empty. It once held two axioms from the 1973 paper: brown_erdos_sos_k4 (for k=4, ex₃(n, F_4) ~ n²/6) and brown_erdos_sos_general (for k ≥ 4, ex₃(n, F_k) = Θ_k(n²)). Both were removed as dead (unreferenced) axioms in a 2026-03-27 batch cleanup (commit b22da88e49). The 1973 Brown-Erdős-Sós results are not formalized in this file — only the historical narrative in the header comment and overview mentions them.",
+    "mathContext": "No declarations remain in this range; see git history at commit b22da88e49 for the removed axiom statements.",
+    "significance": "minor",
     "relatedConcepts": [
       "k=4 base case",
       "Θ_k(n²)",
-      "quadratic growth",
-      "extremal bounds"
+      "dead code elimination"
     ],
     "prerequisites": [
       "Asymptotic growth (Θ notation)",
-      "Quadratic edge density",
-      "Convergence to a limit"
+      "Quadratic edge density"
     ]
   },
   {
     "id": "ann-1076-erdos1974",
     "proofId": "erdos-1076",
     "range": {
-      "startLine": 122,
-      "endLine": 137
+      "startLine": 101,
+      "endLine": 110
     },
     "type": "concept",
-    "title": "Erdős's Supporting Theorem (1974)",
-    "content": "Erdős proved that any 3-uniform hypergraph on n vertices with more than (1/3)C(n,2) = n(n-1)/6 edges must contain a member of F_5 or F_6. The threshold n(n-1)/6 = n²/6 - n/6 is asymptotically n²/6, explaining why 1/6 is the right constant. The theorem threshold_asymptotic verifies this algebraically: (1/3)·n(n-1)/2 = n²/6 - n/6.",
-    "mathContext": "erdos_1974_supporting: numEdges H > (1/3)·n(n-1)/2 → F_5 or F_6 subgraph exists. threshold_asymptotic: (1/3)·n(n-1)/2 = n²/6 - n/6, proved by ring.",
+    "title": "Erdős's Supporting Theorem (1974) — threshold identity only",
+    "content": "Erdős proved that any 3-uniform hypergraph on n vertices with more than (1/3)C(n,2) = n(n-1)/6 edges must contain a member of F_5 or F_6 — this theorem itself is NOT formalized here; the erdos_1974_supporting axiom that once stated it was removed as dead (unreferenced) code in a 2026-03-27 cleanup (commit b22da88e49). What remains is only the numeric identity thresholdEdges n = n²/6 - n/6, proved by threshold_asymptotic via `ring`, showing the threshold n(n-1)/6 is asymptotically n²/6.",
+    "mathContext": "thresholdEdges n := (1/3)·n·(n-1)/2. threshold_asymptotic: thresholdEdges n = n²/6 - n/6, proved by ring. No forced-subgraph conclusion is formalized.",
     "significance": "key",
     "relatedConcepts": [
       "density threshold",
@@ -168,8 +166,8 @@
     "id": "ann-1076-conjecture",
     "proofId": "erdos-1076",
     "range": {
-      "startLine": 139,
-      "endLine": 148
+      "startLine": 112,
+      "endLine": 121
     },
     "type": "definition",
     "title": "Brown-Erdős-Sós Conjecture",
@@ -192,13 +190,13 @@
     "id": "ann-1076-solution",
     "proofId": "erdos-1076",
     "range": {
-      "startLine": 150,
-      "endLine": 164
+      "startLine": 123,
+      "endLine": 133
     },
     "type": "concept",
-    "title": "The Solution (2019-2020)",
-    "content": "Two independent proofs resolve the conjecture. Bohman-Warnke (2019) used probabilistic constructions of large girth approximate Steiner triple systems. Glock-Kühn-Lo-Osthus (2020) used different combinatorial methods. Both are axiomatized as stating BrownErdosSosConjecture. The theorem ex3_asymptotic extracts the convergence for any specific k ≥ 5.",
-    "mathContext": "bohman_warnke_theorem: BrownErdosSosConjecture. glock_kuhn_lo_osthus_theorem: BrownErdosSosConjecture. ex3_asymptotic k hk := bohman_warnke_theorem k hk.",
+    "title": "The Solution — Bohman-Warnke only",
+    "content": "Two independent proofs resolve the conjecture in the mathematical literature: Bohman-Warnke (2019) via probabilistic constructions of large girth approximate Steiner triple systems, and Glock-Kühn-Lo-Osthus (2020) via different combinatorial methods. Only Bohman-Warnke's proof is axiomatized here as bohman_warnke_theorem. The glock_kuhn_lo_osthus_theorem axiom that once separately axiomatized the GKLO proof was removed as dead (unreferenced) code in a 2026-03-27 cleanup (commit b22da88e49) — GKLO's proof is not formalized in this file. The theorem ex3_asymptotic extracts the convergence for any specific k ≥ 5 directly from bohman_warnke_theorem.",
+    "mathContext": "bohman_warnke_theorem: BrownErdosSosConjecture. ex3_asymptotic k hk := bohman_warnke_theorem k hk.",
     "significance": "key",
     "relatedConcepts": [
       "Bohman-Warnke",

--- a/src/data/proofs/erdos-1076/meta.json
+++ b/src/data/proofs/erdos-1076/meta.json
@@ -43,15 +43,13 @@
     ],
     "originalContributions": [
       "Hypergraph3: 3-uniform hypergraph structure with ordered triples",
-      "FamilyF, IsInFamilyF: the family F_k definition with k vertices and k-2 edges",
+      "FamilyF, IsInFamilyF, family_F4/F5/F6_description: the family F_k definition with k vertices and k-2 edges",
       "ContainsSubgraph, IsFkFree: subgraph containment with all 6 permutations",
-      "ex3 axiom: extremal number with ex3_achieved and ex3_is_max",
-      "brown_erdos_sos_k4 and brown_erdos_sos_general: 1973 foundational results",
-      "erdos_1974_supporting: Erdős's threshold theorem for F_5/F_6",
-      "BrownErdosSosConjecture: formal statement via Filter.Tendsto",
-      "bohman_warnke_theorem and glock_kuhn_lo_osthus_theorem: solution axioms",
-      "IsSteinerTripleSystem and sts_num_edges: STS connection",
-      "extremal_sts_connection: near-STS density of extremal hypergraphs",
+      "ex3 axiom: bare extremal number (achieved/is-max characterizations removed as dead code in a 2026-03-27 cleanup)",
+      "thresholdEdges, threshold_asymptotic: numeric threshold n²/6 - n/6 only (Erdős's 1974 supporting theorem itself is not formalized)",
+      "BrownErdosSosConjecture, BrownErdosSosConjecture': formal statement via Filter.Tendsto",
+      "bohman_warnke_theorem: solution axiom for Bohman-Warnke's proof only (Glock-Kühn-Lo-Osthus's independent proof is not separately axiomatized)",
+      "IsSteinerTripleSystem: STS definition (sts_num_edges, extremal_sts_connection removed as dead code)",
       "erdos_1076 and erdos_1076_solved: main result theorems"
     ],
     "axiomCount": 2,
@@ -64,7 +62,7 @@
     "historicalContext": "Brown, Erdős, and Sós (1973) studied extremal problems for r-graphs (hypergraphs). They defined F_k as the family of 3-uniform hypergraphs with k vertices and k-2 edges, and conjectured that ex₃(n, F_k) ~ n²/6 for all k ≥ 5. They proved the k=4 case and showed ex₃(n, F_k) = Θ_k(n²) for all k ≥ 4.\n\nErdős (1974) provided supporting evidence: any 3-uniform hypergraph on n vertices with more than (1/3)C(n,2) edges must contain a member of F_5 or F_6. He also noted that the conjecture 'may easily turn out to be nonsense', highlighting the difficulty of the problem.\n\nThe conjecture was independently proved by Bohman and Warnke (2019) using large girth approximate Steiner triple system constructions, and by Glock, Kühn, Lo, and Osthus (2020). The key insight is that the extremal density n²/6 matches Steiner triple system density — extremal F_k-free hypergraphs resemble approximate Steiner systems with large girth, avoiding short cycles that would create F_k subgraphs.",
     "problemStatement": "**Problem Statement (Solved)**\n\nLet k ≥ 5 and let $\\mathcal{F}_k$ be the family of all 3-uniform hypergraphs with k vertices and k-2 edges.\n\n**Question:** Is $\\text{ex}_3(n, \\mathcal{F}_k) \\sim n^2/6$?\n\n**Answer: YES**\n\n- Brown-Erdős-Sós (1973): Proved for k=4, showed $\\Theta_k(n^2)$ bounds\n- Bohman-Warnke (2019): Proved asymptotic for all k ≥ 5\n- Glock-Kühn-Lo-Osthus (2020): Independent proof\n\nThe extremal number is asymptotically $n^2/6$, matching Steiner triple system density.",
     "text": "For k ≥ 5, let F_k be all 3-uniform hypergraphs with k vertices and k-2 edges. Is ex₃(n, F_k) ~ n²/6? SOLVED: YES (Bohman-Warnke 2019, Glock-Kühn-Lo-Osthus 2020).",
-    "proofStrategy": "The formalization defines 3-uniform hypergraphs via ordered triples, the family F_k, subgraph containment (with all 6 permutations of a triple), and the extremal number ex₃(n, F_k) as an axiom with achieved/maximum properties. Historical results from Brown-Erdős-Sós and Erdős are stated as axioms. The main conjecture is formalized using Filter.Tendsto for asymptotic convergence. Bohman-Warnke and Glock-Kühn-Lo-Osthus theorems resolve it. The connection to Steiner triple systems explains why n²/6 is the right constant.",
+    "proofStrategy": "The formalization defines 3-uniform hypergraphs via ordered triples, the family F_k, subgraph containment (with all 6 permutations of a triple), and the extremal number ex₃(n, F_k) as a bare axiom. Its achieved/maximum characterizing axioms, the Brown-Erdős-Sós 1973 axioms, Erdős's 1974 supporting-theorem axiom, the explicit upper/lower-bound axioms, and the Steiner-triple-system density axioms were all removed as dead (unreferenced) code in a 2026-03-27 batch cleanup (commit b22da88e49) — only the numeric threshold identity thresholdEdges n = n²/6 - n/6 (proved by `ring`) and the IsSteinerTripleSystem definition remain from those parts. The main conjecture is formalized using Filter.Tendsto for asymptotic convergence. Only Bohman-Warnke's proof is axiomatized (bohman_warnke_theorem); Glock-Kühn-Lo-Osthus's independent proof is not separately formalized.",
     "keyInsights": [
       "**F_k Family**: 3-uniform hypergraphs with k vertices and k-2 edges — the forbidden configurations whose avoidance gives the extremal number.",
       "**Asymptotic n²/6**: Matches Steiner triple system edge density n(n-1)/6 ~ n²/6, connecting extremal combinatorics to design theory.",
@@ -85,73 +83,89 @@
       "id": "hypergraph-basics",
       "title": "Part I: 3-Uniform Hypergraphs",
       "summary": "Hypergraph3 structure, numEdges, numVertices, IsInFamilyF definitions.",
-      "startLine": 38,
-      "endLine": 55,
+      "startLine": 34,
+      "endLine": 50,
       "mathContext": "3-uniform hypergraph: every edge has exactly 3 vertices. $|E|$ = numEdges, $|V|$ = numVertices."
     },
     {
       "id": "family-fk",
       "title": "Part II: The Family F_k",
-      "summary": "FamilyF definition, descriptions for k=4,5,6.",
-      "startLine": 56,
-      "endLine": 79,
+      "summary": "FamilyF definition plus family_F4/F5/F6_description theorems characterizing membership for k=4,5,6.",
+      "startLine": 52,
+      "endLine": 74,
       "mathContext": "Family $\\\\mathcal{F}_k$: all 3-uniform hypergraphs on $k$ vertices with exactly $k-2$ edges. For $k=4$: $\\\\binom{4}{3} - 2 = 2$ edges (missing 2 of 4 triangles)."
     },
     {
       "id": "subgraph-containment",
       "title": "Part III: Subgraph Containment",
       "summary": "ContainsSubgraph with 6 permutations, IsFkFree predicate.",
-      "startLine": 80,
-      "endLine": 95,
+      "startLine": 76,
+      "endLine": 90,
       "mathContext": "ContainsSubgraph: $H \\\\subseteq G$ as a subhypergraph (up to vertex permutation). $\\\\mathcal{F}_k$-free: no member of $\\\\mathcal{F}_k$ is a subgraph."
     },
     {
       "id": "extremal-numbers",
       "title": "Part IV: Extremal Numbers",
-      "summary": "ex3 axiom, ex3_achieved and ex3_is_max characterization.",
-      "startLine": 96,
-      "endLine": 110,
-      "mathContext": "$\\\\text{ex}_3(n, \\\\mathcal{F}_k) = \\\\max |E|$ over $\\\\mathcal{F}_k$-free 3-uniform hypergraphs on $n$ vertices. The Turan-type extremal number."
+      "summary": "ex3 axiomatized as a bare extremal number; the ex3_achieved and ex3_is_max characterizing axioms that once stood here were removed as dead (unreferenced) code on 2026-03-27.",
+      "startLine": 92,
+      "endLine": 97,
+      "mathContext": "$\\\\text{ex}_3(n, \\\\mathcal{F}_k)$ is an uninterpreted axiom; no achieved/maximality guarantee is formalized."
     },
     {
       "id": "bes-1973",
       "title": "Part V: Brown-Erdős-Sós Results (1973)",
-      "summary": "brown_erdos_sos_k4 (k=4 case) and brown_erdos_sos_general (Θ_k(n²)).",
-      "startLine": 111,
-      "endLine": 121,
-      "mathContext": "Brown-Erdos-Sos (1973): $\\\\text{ex}_3(n, \\\\mathcal{F}_4) = \\\\Theta(n^2)$. For $k \\\\geq 5$: $\\\\text{ex}_3(n, \\\\mathcal{F}_k) = \\\\Theta_k(n^2)$ with constants depending on $k$."
+      "summary": "Header only. The brown_erdos_sos_k4 and brown_erdos_sos_general axioms that once stood here were removed as dead (unreferenced) code on 2026-03-27; the 1973 results are not formalized in this file.",
+      "startLine": 99,
+      "endLine": 100,
+      "mathContext": "No declarations remain in this range; see commit b22da88e49 for the removed axiom statements."
     },
     {
       "id": "erdos-1974",
       "title": "Part VI: Erdős's Supporting Theorem (1974)",
-      "summary": "erdos_1974_supporting, thresholdEdges, threshold_asymptotic.",
-      "startLine": 122,
-      "endLine": 138,
-      "mathContext": "Erdos (1974): supporting evidence for the $n^2/6$ conjecture. The threshold $n^2/6$ arises from Steiner triple system density."
+      "summary": "thresholdEdges definition and threshold_asymptotic theorem (proved by ring). The erdos_1974_supporting axiom that once stood here was removed as dead code on 2026-03-27 — Erdős's 1974 theorem itself is not formalized.",
+      "startLine": 101,
+      "endLine": 110,
+      "mathContext": "thresholdEdges n := (1/3)*n*(n-1)/2. threshold_asymptotic: thresholdEdges n = n^2/6 - n/6, proved by `ring`."
     },
     {
       "id": "main-conjecture",
       "title": "Part VII: The Main Conjecture",
       "summary": "BrownErdosSosConjecture and BrownErdosSosConjecture' definitions.",
-      "startLine": 139,
-      "endLine": 149,
+      "startLine": 112,
+      "endLine": 121,
       "mathContext": "Brown-Erdos-Sos Conjecture: $\\\\text{ex}_3(n, \\\\mathcal{F}_k) \\\\sim n^2/6$ for all $k \\\\geq 5$. The extremal density is $1/6$ regardless of $k$."
     },
     {
       "id": "solution",
       "title": "Part VIII: The Solution",
-      "summary": "bohman_warnke_theorem, glock_kuhn_lo_osthus_theorem, ex3_asymptotic.",
-      "startLine": 150,
-      "endLine": 165,
-      "mathContext": "SOLVED: Bohman-Warnke (2021) and Glock-Kuhn-Lo-Osthus (2022) proved $\\\\text{ex}_3(n, \\\\mathcal{F}_k) = (1+o(1))n^2/6$ for $k \\\\geq 5$."
+      "summary": "bohman_warnke_theorem axiom and ex3_asymptotic theorem. Only Bohman-Warnke's proof is axiomatized; the glock_kuhn_lo_osthus_theorem axiom for the independent GKLO proof was removed as dead code on 2026-03-27.",
+      "startLine": 123,
+      "endLine": 133,
+      "mathContext": "bohman_warnke_theorem : BrownErdosSosConjecture. ex3_asymptotic k hk := bohman_warnke_theorem k hk."
     },
     {
       "id": "bounds",
       "title": "Part IX: Upper and Lower Bounds",
-      "summary": "ex3_upper_bound and ex3_lower_bound axioms.",
-      "startLine": 166,
-      "endLine": 173,
-      "mathContext": "Upper: $\\\\text{ex}_3(n, \\\\mathcal{F}_k) \\\\leq (1+o(1))n^2/6$. Lower: Steiner triple system constructions achieve $\\\\sim n^2/6$ edges."
+      "summary": "Header only. The ex3_upper_bound and ex3_lower_bound axioms that once stood here were removed as dead (unreferenced) code on 2026-03-27.",
+      "startLine": 135,
+      "endLine": 139,
+      "mathContext": "No declarations remain in this range; see commit b22da88e49 for the removed axiom statements."
+    },
+    {
+      "id": "steiner-connection",
+      "title": "Part X: Connection to Steiner Triple Systems",
+      "summary": "IsSteinerTripleSystem definition only. The sts_num_edges and extremal_sts_connection axioms that once related STS density to the extremal number were removed as dead code on 2026-03-27.",
+      "startLine": 141,
+      "endLine": 147,
+      "mathContext": "IsSteinerTripleSystem H := every pair of vertices lies in exactly one edge. No density relationship to ex3 is formalized."
+    },
+    {
+      "id": "summary",
+      "title": "Part XII: Summary",
+      "summary": "erdos_1076 and erdos_1076_solved theorems restating the resolved conjecture directly via bohman_warnke_theorem.",
+      "startLine": 151,
+      "endLine": 167,
+      "mathContext": "erdos_1076 : BrownErdosSosConjecture := bohman_warnke_theorem. erdos_1076_solved specializes it to a given k >= 5."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-1076

**Problem**: `meta.json` (`originalContributions`, `proofStrategy`, `sections`) and `annotations.json` still described 10 axioms as present in the Lean file — `ex3_achieved`, `ex3_is_max`, `brown_erdos_sos_k4`, `brown_erdos_sos_general`, `erdos_1974_supporting`, `glock_kuhn_lo_osthus_theorem`, `ex3_upper_bound`, `ex3_lower_bound`, `sts_num_edges`, `extremal_sts_connection` — but all were removed as dead (unreferenced) code by commit `b22da88e49` ("Research: batch dead axiom elimination — 650+ axioms removed across 47 problems", 2026-03-27) and never existed again afterward. That commit touched only the `.lean` file, so `meta.json`/`annotations.json` were never updated. Section/annotation line ranges were also drifted 6-27 lines from the now-shrunk (169-line) file.

`axiomCount` (2), `theoremCount` (7), `definitionCount` (11), and `sorries` (0) were already correct — this is purely stale/phantom prose, not a count mismatch.

## Evidence

- `git show b22da88e49 -- proofs/Proofs/Erdos1076Problem.lean` shows exactly those 10 axioms deleted as dead code.
- Current file only contains `axiom ex3` and `axiom bohman_warnke_theorem` — no `glock_kuhn_lo_osthus_theorem`, no BES-1973 axioms, no Erdős-1974 axiom, no upper/lower-bound axioms, no STS-density axioms.

## Fix

Rewrote `originalContributions`, `proofStrategy`, `sections` (meta.json) and all affected annotation blocks (annotations.json) to accurately reflect what remains: `ex3` as a bare axiom, only Bohman-Warnke's proof axiomatized (Glock-Kühn-Lo-Osthus's independent proof is not separately formalized), only the numeric threshold identity `thresholdEdges n = n²/6 - n/6` surviving from Erdős's 1974 theorem, and `IsSteinerTripleSystem` as a definition with no density axioms attached. Re-anchored all section/annotation line ranges to the current file. Where a section header is now empty (Part V, Part IX), the summary explicitly notes the removal rather than fabricating content.

---
Discovered during gallery integrity audit (round-robin re-serve).