### PR TITLE
Enrich erdos-286-oq-01: split sections 3->5 at real theorem boundaries

### DIFF
--- a/src/data/proofs/erdos-286-oq-01/meta.json
+++ b/src/data/proofs/erdos-286-oq-01/meta.json
@@ -103,25 +103,41 @@
       "id": "header",
       "title": "Module Docstring and Import",
       "startLine": 1,
-      "endLine": 38,
+      "endLine": 37,
       "summary": "Imports Mathlib; module docstring framing this child of Erdős #286 (unit fractions in short intervals) and stating the small-k picture it pins down denominator-free: k = 2 impossibility (no_two_distinct_unit_fractions), k = 3 existence (repr_236) and uniqueness ({2,3,6}, three_distinct_unit_fractions_eq_one), combined in three_distinct_iff — so 1 has no 2-term distinct Egyptian representation and a unique 3-term one. Namespace Erdos286OQ01, open Finset; notes all results are 0-axiom (no sorry/axiom/native_decide).",
       "mathContext": "1 = Σ 1/nᵢ with distinct nᵢ: no k = 2 solution, unique k = 3 solution {2,3,6}; k = 3 is the smallest term count admitting a representation."
     },
     {
       "id": "k2",
       "title": "k = 2: No Two Distinct Unit Fractions Sum to 1",
-      "startLine": 39,
+      "startLine": 38,
       "endLine": 62,
       "summary": "no_two_distinct_unit_fractions rules out 1/a + 1/b = 1 for distinct a < b: a = 1 forces a vanishing term, while a ≥ 2 forces b ≥ 3 and a sum ≤ 5/6 < 1.",
       "mathContext": "$\\tfrac1a + \\tfrac1b = 1$ with $a < b$ has no solution: $a=1 \\Rightarrow \\tfrac1b = 0$; $a \\ge 2 \\Rightarrow \\tfrac1a + \\tfrac1b \\le \\tfrac12 + \\tfrac13 = \\tfrac56 < 1$."
     },
     {
-      "id": "k3",
-      "title": "k = 3: Existence and Uniqueness of {2, 3, 6}",
-      "startLine": 64,
+      "id": "k3-existence",
+      "title": "k = 3, Existence: the Witness 1/2 + 1/3 + 1/6",
+      "startLine": 63,
+      "endLine": 69,
+      "summary": "Section-2 header comment, then repr_236: a one-line norm_num proof that 1/2 + 1/3 + 1/6 = 1, the existence half of the k = 3 threshold.",
+      "mathContext": "$\\tfrac12 + \\tfrac13 + \\tfrac16 = 1$, discharged by `norm_num` — the existence witness at the k = 3 threshold."
+    },
+    {
+      "id": "k3-uniqueness",
+      "title": "k = 3, Uniqueness: Squeezing a = 2, b = 3, c = 6",
+      "startLine": 70,
+      "endLine": 124,
+      "summary": "three_distinct_unit_fractions_eq_one, the heart of the entry: for a < b < c with 1/a + 1/b + 1/c = 1, an ordered squeeze forces a < 3 then a = 2 (by_contra + omega), then substitution and a second squeeze force b = 3, and finally linear_combination + inv_inj pin c = 6.",
+      "mathContext": "$1 < 3/a \\Rightarrow a<3,\\ a\\ne1 \\Rightarrow a=2$; then $\\tfrac1b+\\tfrac1c=\\tfrac12,\\ \\tfrac1c<\\tfrac1b \\Rightarrow b=3$; then $\\tfrac1c=\\tfrac16 \\Rightarrow c=6$."
+    },
+    {
+      "id": "k3-iff",
+      "title": "k = 3 Combined Characterisation and Namespace Close",
+      "startLine": 125,
       "endLine": 133,
-      "summary": "repr_236 gives existence; three_distinct_unit_fractions_eq_one gives uniqueness by squeezing a = 2, b = 3, then c = 6; three_distinct_iff packages both directions.",
-      "mathContext": "For $a < b < c$: $\\tfrac1a + \\tfrac1b + \\tfrac1c = 1 \\iff (a,b,c) = (2,3,6)$; and $\\tfrac12 + \\tfrac13 + \\tfrac16 = 1$."
+      "summary": "three_distinct_iff packages existence (repr_236) and uniqueness (three_distinct_unit_fractions_eq_one) into a single ↔: for a < b < c, 1/a + 1/b + 1/c = 1 exactly when (a,b,c) = (2,3,6); closes the Erdos286OQ01 namespace.",
+      "mathContext": "For $a < b < c$: $\\tfrac1a + \\tfrac1b + \\tfrac1c = 1 \\iff (a,b,c) = (2,3,6)$."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for erdos-286-oq-01 (small-k Egyptian representations of 1).

The entry was at quality 96/100 — the sole gap was `sections.length = 3`, capping the sections-coverage score at 6/10. Split the existing 3 sections (header, k=2, k=3-combined) into 5 conceptual sections that follow the actual theorem boundaries in `Erdos286OQ01.lean`:

1. header (imports/docstring/namespace)
2. k=2 impossibility
3. k=3 existence witness (`repr_236`)
4. k=3 uniqueness squeeze (`three_distinct_unit_fractions_eq_one`)
5. k=3 combined iff-characterisation (`three_distinct_iff`)

Line ranges are contiguous and grep-verified against the current Lean source (133 lines). No content was removed; only the section boundaries and per-section summaries/mathContext were added. Quality score verified via `find-targets.ts`: 96 → 100.