### PR TITLE
research(erdos30-wip01): h(16)=5 — span dichotomy fells the near-perfect ruler; exact table h(0..21) complete

### DIFF
--- a/proofs/Proofs/Erdos30WIP01.lean
+++ b/proofs/Proofs/Erdos30WIP01.lean
@@ -812,7 +812,8 @@ set in `{0,…,16}` has 15 distinct differences among `{1,…,16}`, *missing exa
 value* `d` — a near-perfect ruler, where the exhaustion arguments above lose traction.
 Parity forces `d` even; the mod-3 count forces `3 ∣ d` (with residue profile
 `(3,2,1)`); so `d ∈ {6, 12}`, but finishing requires a finer invariant or a structured
-search, left open here. -/
+search — supplied at the end of this file (`sidonNumber_sixteen`) by a span dichotomy
+plus a kernel-checked search over the four interior elements. -/
 
 private theorem isSidonSet_0_1_4_10_12_17 : IsSidonSet {0, 1, 4, 10, 12, 17} := by
   intro a b c d ha hb hc hd hab hcd heq
@@ -956,5 +957,149 @@ theorem sidonNumber_twentyone : sidonNumber 21 = 6 := by
       (fun A hsub hA => no_sidon_card_seven_range_twentytwo A hsub hA)
   · calc 6 = ({0, 1, 4, 10, 12, 17} : Finset ℕ).card := by decide
       _ ≤ sidonNumber 21 := sidonNumber_ge_card (by decide) isSidonSet_0_1_4_10_12_17
+
+/-! ### `h(16) = 5` — the near-perfect ruler, felled by a span dichotomy
+
+A 6-element Sidon set in `{0,…,16}` would be a 6-mark Golomb ruler of length at most
+`16` — but the optimal 6-mark ruler (`{0,1,4,10,12,17}`) has length `17`, so none
+exists and `h(16) = 5`.  The counting, parity, and mod-3 invariants all go slack here
+(the near-perfect ruler misses one difference `d ∈ {6,12}` and every residue count
+stays feasible), so this is the first entry of the table that genuinely needs a
+*search*.  We keep it small with a span dichotomy:
+
+* **Span ≤ 15.**  Sliding the set down by its minimum (`IsSidonSet` is
+  translation-invariant, and sliding preserves cardinality) lands it inside
+  `{0,…,15}` — impossible by the mod-3 obstruction `no_sidon_card_six_range_sixteen`
+  already proved for `h(15)`.
+* **Span = 16.**  The minimum slides to `0` and the maximum to `16`, so after the
+  slide the set is `{0, 16} ∪ B` with `B` one of the `C(15,4) = 1365` four-element
+  subsets of `{1,…,15}`.  A kernel-checked `decide` (`no_sidon_extension_zero_sixteen`)
+  rules out every one of them.  This stays well inside kernel range: `1365` subsets
+  with `6⁴ = 1296` quadruple checks each.
+
+The lower bound is the familiar 5-element witness `{0,1,4,9,11}`.  This closes the
+last missing value below `22`: the table `h(0),…,h(21)` is now complete. -/
+
+/-- Membership-bounded (hence decidable) form of the Sidon predicate, used for the
+finite search below.  `IsSidonSet` itself quantifies over all of `ℕ` and so has no
+`Decidable` instance; this form is equivalent (`sidonCheck_of_isSidonSet`). -/
+private def SidonCheck (A : Finset ℕ) : Prop :=
+  ∀ a ∈ A, ∀ b ∈ A, ∀ c ∈ A, ∀ d ∈ A,
+    a ≤ b → c ≤ d → a + b = c + d → a = c ∧ b = d
+
+private instance (A : Finset ℕ) : Decidable (SidonCheck A) :=
+  inferInstanceAs (Decidable (∀ a ∈ A, ∀ b ∈ A, ∀ c ∈ A, ∀ d ∈ A,
+    a ≤ b → c ≤ d → a + b = c + d → a = c ∧ b = d))
+
+private theorem sidonCheck_of_isSidonSet {A : Finset ℕ} (hA : IsSidonSet A) :
+    SidonCheck A :=
+  fun a ha b hb c hc d hd hab hcd heq => hA a b c d ha hb hc hd hab hcd heq
+
+set_option maxRecDepth 10000 in
+/-- **The exhaustive kernel search**: no four interior elements `B ⊆ {1,…,15}` extend
+the pinned endpoints `{0, 16}` to a 6-element Sidon set.  `1365` candidate subsets,
+each checked against the bounded Sidon predicate; `decide +kernel` hands the whole
+evaluation to the kernel's fast numeral arithmetic. -/
+private theorem no_sidon_extension_zero_sixteen :
+    ∀ B ∈ (Finset.Icc 1 15).powersetCard 4,
+      ¬ SidonCheck (insert 0 (insert 16 B)) := by
+  decide +kernel
+
+/-- **No 6-element Sidon set fits in `{0,…,16}`** — equivalently, every 6-mark Golomb
+ruler has length `≥ 17`.  Span dichotomy: after sliding the minimum to `0`, either the
+set lies in `{0,…,15}` (killed by the `h(15)` mod-3 obstruction) or its maximum is
+`16` and the four interior elements fall to the kernel search. -/
+theorem no_sidon_card_six_range_seventeen (A : Finset ℕ)
+    (hsub : A ⊆ Finset.range 17) (hA : IsSidonSet A) : A.card ≤ 5 := by
+  by_contra hcard
+  rw [not_le] at hcard
+  -- Counting caps the size at 6, so a violating set has exactly 6 elements.
+  have hup : A.card * A.card ≤ 32 + A.card := by
+    have := sidon_card_sq_le 16 hsub hA; omega
+  have hc6 : A.card = 6 := by
+    by_contra hne
+    have h7 : 7 ≤ A.card := by omega
+    have hmul : 7 * A.card ≤ A.card * A.card := Nat.mul_le_mul h7 (le_refl A.card)
+    omega
+  have hne : A.Nonempty := Finset.card_pos.mp (by omega)
+  set m := A.min' hne with hm
+  have hmle : ∀ x ∈ A, m ≤ x := fun x hx => A.min'_le x hx
+  have hbound : ∀ x ∈ A, x ≤ 16 := fun x hx => by
+    have := hsub hx; rw [Finset.mem_range] at this; omega
+  -- Slide the set down by its minimum.
+  set A' := A.image (fun x => x - m) with hA'
+  have hinj : Set.InjOn (fun x => x - m) ↑A := by
+    intro x hx y hy hxy
+    have hx' := hmle x (Finset.mem_coe.mp hx)
+    have hy' := hmle y (Finset.mem_coe.mp hy)
+    have hxy' : x - m = y - m := hxy
+    omega
+  have hA'card : A'.card = 6 := by
+    rw [hA', Finset.card_image_of_injOn hinj, hc6]
+  have hA'sidon : IsSidonSet A' := by
+    intro a b c d ha hb hc hd hab hcd heq
+    rw [hA'] at ha hb hc hd
+    simp only [Finset.mem_image] at ha hb hc hd
+    obtain ⟨a₀, ha₀, rfl⟩ := ha
+    obtain ⟨b₀, hb₀, rfl⟩ := hb
+    obtain ⟨c₀, hc₀, rfl⟩ := hc
+    obtain ⟨d₀, hd₀, rfl⟩ := hd
+    have hma := hmle a₀ ha₀; have hmb := hmle b₀ hb₀
+    have hmc := hmle c₀ hc₀; have hmd := hmle d₀ hd₀
+    obtain ⟨h1, h2⟩ := hA a₀ b₀ c₀ d₀ ha₀ hb₀ hc₀ hd₀ (by omega) (by omega) (by omega)
+    exact ⟨by omega, by omega⟩
+  have hzero : (0 : ℕ) ∈ A' := by
+    rw [hA']
+    exact Finset.mem_image.mpr ⟨m, A.min'_mem hne, Nat.sub_self m⟩
+  have hA'ne : A'.Nonempty := ⟨0, hzero⟩
+  have hA'bound : ∀ x ∈ A', x ≤ 16 := by
+    intro x hx
+    rw [hA'] at hx
+    obtain ⟨x₀, hx₀, hx₀eq⟩ := Finset.mem_image.mp hx
+    have hb := hbound x₀ hx₀
+    have hx₀eq' : x₀ - m = x := hx₀eq
+    omega
+  rcases Nat.lt_or_ge (A'.max' hA'ne) 16 with hM | hM
+  · -- Span ≤ 15: the slid set lives in {0,…,15}; the h(15) obstruction applies.
+    have hsub' : A' ⊆ Finset.range 16 := fun x hx => by
+      rw [Finset.mem_range]
+      exact lt_of_le_of_lt (A'.le_max' x hx) hM
+    have := no_sidon_card_six_range_sixteen A' hsub' hA'sidon
+    omega
+  · -- Span = 16: both endpoints pinned; the four interior elements fall to `decide`.
+    have h16 : (16 : ℕ) ∈ A' := by
+      have hMle : A'.max' hA'ne ≤ 16 := hA'bound _ (A'.max'_mem hA'ne)
+      have hMeq : A'.max' hA'ne = 16 := le_antisymm hMle hM
+      rw [← hMeq]
+      exact A'.max'_mem hA'ne
+    set B := (A'.erase 0).erase 16 with hB
+    have h16' : (16 : ℕ) ∈ A'.erase 0 := Finset.mem_erase.mpr ⟨by omega, h16⟩
+    have hrecon : insert 0 (insert 16 B) = A' := by
+      rw [hB, Finset.insert_erase h16', Finset.insert_erase hzero]
+    have hBcard : B.card = 4 := by
+      rw [hB, Finset.card_erase_of_mem h16', Finset.card_erase_of_mem hzero, hA'card]
+    have hBsub : B ⊆ Finset.Icc 1 15 := by
+      intro x hx
+      rw [hB] at hx
+      have hx16 := (Finset.mem_erase.mp hx).1
+      have hx' := Finset.mem_of_mem_erase hx
+      have hx0 := (Finset.mem_erase.mp hx').1
+      have hxA := Finset.mem_of_mem_erase hx'
+      have := hA'bound x hxA
+      rw [Finset.mem_Icc]
+      omega
+    exact no_sidon_extension_zero_sixteen B
+      (Finset.mem_powersetCard.mpr ⟨hBsub, hBcard⟩)
+      (by rw [hrecon]; exact sidonCheck_of_isSidonSet hA'sidon)
+
+/-- `h(16) = 5` — the last missing value below `22`, completing the exact table
+`h(0),…,h(21)`.  No 6-mark Golomb ruler has length `≤ 16`
+(`no_sidon_card_six_range_seventeen`); the 5-element witness `{0,1,4,9,11}` persists. -/
+theorem sidonNumber_sixteen : sidonNumber 16 = 5 := by
+  refine le_antisymm ?_ ?_
+  · exact sidonNumber_le_of_card
+      (fun A hsub hA => no_sidon_card_six_range_seventeen A hsub hA)
+  · calc 5 = ({0, 1, 4, 9, 11} : Finset ℕ).card := by decide
+      _ ≤ sidonNumber 16 := sidonNumber_ge_card (by decide) isSidonSet_0_1_4_9_11
 
 end Erdos30

--- a/src/data/research/problems/erdos-30-wip-01.json
+++ b/src/data/research/problems/erdos-30-wip-01.json
@@ -20,10 +20,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-09T17:33:20-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "iteration": 2,
+    "focus": "h(16)=5 SHIPPED (2026-07-23): the last missing table value below 22. sidonNumber_sixteen via no_sidon_card_six_range_seventeen — span dichotomy: slide the set down by its minimum (translation invariance, injective slide); span<=15 lands in {0..15} and dies on the h(15) mod-3 obstruction no_sidon_card_six_range_sixteen; span=16 pins both endpoints {0,16} and the four interior elements fall to a kernel-checked search (decide +kernel) over the C(15,4)=1365 subsets of {1..15} (SidonCheck = decidable membership-bounded Sidon predicate). Equivalently: every 6-mark Golomb ruler has length >= 17. Exact table h(0..21) now COMPLETE (stacked on PR #42270 h(15) mod-3 + PR #42285 h(17..21)).",
     "blockers": [],
-    "nextAction": "Exact table now extends past the counting wall to h(10)=4 (sidonNumber_ten), proved by the perfect-ruler parity obstruction (no 5-element Sidon set in {0,...,10}: its 10 distinct positive differences would exhaust {1,...,10}, sum 55 odd, but the sum of ordered positive differences is always even = 4*sum A). Reusable helpers added: sidonNumber_le_of_card, sum_offDiag_fst (offDiag first-coordinate sum = (|A|-1)*sum A). Counting bound alone caps at h(9); h(10) is the first value needing a genuinely new obstruction. NEXT (harder): h(11)=5 (needs the witness {0,1,4,9,11}) then h(12),h(13)... via case analysis, OR the polynomial sqrt(N)-order lower-bound construction (Singer/perfect difference sets) needing modular Sidon infrastructure absent from Mathlib. The open N^{1/4}-error Erdos-Turan conjecture ($1000) stays a Prop.",
+    "nextAction": "Table h(0..21) complete. Next walls: h(22..24) (counting blocks 7 while 42>2N, i.e. through N=20 only — at N=21 parity; N=22-24 need per-N analysis: 7-elt set first fits at span 25 {0,1,4,10,18,23,25}), or pivot to the DEEP targets: Singer/Bose difference-set lower bound h(N)>=(1-o(1))sqrt(N) (finite projective geometry, likely axiomatize), N^{1/4} constant refinement, and the $1000 N^eps conjecture (stays a Prop).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -46,7 +46,11 @@
       "Erdos30WIP01.lean: exact initial Sidon numbers sidonNumber_zero..six — h(0..6)=1,2,2,3,3,3,4. Sharp counting bound sidon_card_sq_le matched to optimal explicit Sidon sets {0},{0,1},{0,1,3},{0,1,4,6}. Reusable helpers sidonNumber_ge_card (lower from explicit set) + sidonNumber_le_of_sq (sharp upper via quadratic, tighter than floor-sqrt). 0-axiom docker-verified v4.31.",
       "sidonNumber_seven/eight/nine = 4 — exact values via counting upper + {0,1,4,6} witness (Erdos30WIP01.lean, 0-axiom)",
       "isSidonSet_0_1_4_9_11 in Erdos30WIP01.lean (5-element Sidon witness)",
-      "sidonNumber_eleven, sidonNumber_twelve, sidonNumber_thirteen, sidonNumber_fourteen in Erdos30WIP01.lean (h(11)..h(14)=5)"
+      "sidonNumber_eleven, sidonNumber_twelve, sidonNumber_thirteen, sidonNumber_fourteen in Erdos30WIP01.lean (h(11)..h(14)=5)",
+      "SidonCheck (decidable membership-bounded Sidon predicate) + sidonCheck_of_isSidonSet in Erdos30WIP01.lean",
+      "no_sidon_extension_zero_sixteen (kernel decide: no 4-subset of {1..15} extends {0,16} to a Sidon set) in Erdos30WIP01.lean",
+      "no_sidon_card_six_range_seventeen (no 6-elt Sidon set in {0..16} = no 6-mark Golomb ruler of length <=16; span dichotomy) in Erdos30WIP01.lean",
+      "sidonNumber_sixteen (h(16)=5, completing the exact table h(0..21)) in Erdos30WIP01.lean"
     ],
     "insights": [
       "Erdős–Turán upper bound is provable elementarily via difference-map injectivity: for a Sidon set A the map (a,b)↦a−b is injective on the off-diagonal (a−b=c−d ⇒ a+d=c+b ⇒ pair matches by the Sidon property), its image is nonzero integers in [−N,N] (2N of them), so |A.offDiag|=|A|²−|A| ≤ 2N.",
@@ -59,7 +63,8 @@
       "Exact table extended past the h(10) parity wall for free: at N=11 the 5-element witness {0,1,4,9,11} first fits, and the COUNTING bound is active again against 6-element sets (C(6,2)=15 distinct positive differences > N for all N<=14). One witness + sidonNumber_le_of_sq closes h(11)=h(12)=h(13)=h(14)=5.",
       "Next wall precisely characterized: at N=15 the counting bound goes slack (6*5=30=2*15) AND the parity argument is silent (perfect 6-mark ruler of length 15 has difference sum 120, even). h(15)=5 requires nonexistence of a perfect 6-mark ruler — a genuinely finer argument (next session target).",
       "5-way rcases witness pattern scales: 625 omega cases for isSidonSet_0_1_4_9_11 compile fast on host; the isSidonSet_0_1_4_6 template generalizes verbatim.",
-      "Shared-cache gotcha: Proofs.Erdos30Problem olean was missing — build parent explicitly with lake env lean -o .lake/build/lib/lean/Proofs/<X>.olean Proofs/<X>.lean, then the WIP file elaborates."
+      "Shared-cache gotcha: Proofs.Erdos30Problem olean was missing — build parent explicitly with lake env lean -o .lake/build/lib/lean/Proofs/<X>.olean Proofs/<X>.lean, then the WIP file elaborates.",
+      "When counting, parity, and mod-3 all go slack (the h(16) near-perfect ruler), a SPAN DICHOTOMY keeps the residual search kernel-sized: sliding by the minimum reduces span<=N-1 to the previous obstruction, and span=N pins both endpoints, cutting the search from C(17,6)=12376 to C(15,4)=1365 subsets — well inside decide +kernel range (elaborator-side decide times out at default heartbeats; +kernel hands evaluation to GMP-backed kernel numerals). set_option/omit must precede the docstring, not sit between docstring and theorem."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -87,7 +92,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.781Z",
-  "lastUpdate": "2026-07-22",
+  "lastUpdate": "2026-07-23",
   "significance": 8,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary

Proves **h(16) = 5** (`sidonNumber_sixteen`) — the last missing value in the exact Sidon table, which is now complete for all of `h(0), ..., h(21)`. Equivalently: **every 6-mark Golomb ruler has length >= 17**, so the classical optimal ruler `{0,1,4,10,12,17}` is length-optimal among initial segments.

This was the genuinely hard entry of the table: at N=16 the counting bound is slack (a 6-set is feasible by count), the h(10) parity argument is silent, and the h(15) mod-3 invariant admits a consistent residue profile — a hypothetical 6-element Sidon set in `{0,...,16}` would be a *near-perfect ruler* missing exactly one difference `d ∈ {6, 12}`, and no single invariant kills it.

## Approach: span dichotomy + kernel-sized search

`no_sidon_card_six_range_seventeen`: suppose a 6-element Sidon set `A ⊆ {0,...,16}`. Slide it down by its minimum (Sidon-ness is translation-invariant; the slide is injective, preserving cardinality):

- **Span <= 15**: the slid set lies in `{0,...,15}` — impossible by the already-merged h(15) mod-3 obstruction `no_sidon_card_six_range_sixteen`.
- **Span = 16**: both endpoints are pinned to `{0, 16}`, so the set is `insert 0 (insert 16 B)` with `B` one of the `C(15,4) = 1365` four-element subsets of `{1,...,15}`. A kernel-checked `decide +kernel` (`no_sidon_extension_zero_sixteen`) rules out every one.

The dichotomy cuts the naive `C(17,6) = 12376`-subset search down to 1365 subsets with 6^4 quadruple checks each — comfortably inside kernel range (whole file builds in 49s). `SidonCheck` is a new decidable membership-bounded form of the Sidon predicate with a bridge lemma `sidonCheck_of_isSidonSet`, reusable for any future finite Sidon searches.

Lower bound: the standing 5-element witness `{0,1,4,9,11}`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos30WIP01` — green (8577 jobs, file elaborates in 49s)
- 0 sorries, 0 axioms; `decide +kernel` is a kernel evaluation (no `Lean.ofReduceBool` / `native_decide`)

## Notes

- Stacks directly on merged #42285 (h(17)–h(21) + h(15) mod-3). Nothing else in flight touches this file.
- PR #42270 (h(15)) is now fully superseded: its entire content landed on main via #42285 (main's file is a strict extension of that branch). It can be closed — the close command is permission-gated for this agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
