### PR TITLE
Enrich erdos-1002-oq-01-oq-01-incomplete-01: split sum-bound/normalized-bound + 5th key insight

### DIFF
--- a/src/data/proofs/erdos-1002-oq-01-oq-01-incomplete-01/annotations.json
+++ b/src/data/proofs/erdos-1002-oq-01-oq-01-incomplete-01/annotations.json
@@ -36,16 +36,28 @@
     "prerequisites": ["fractional part bounds", "linarith"]
   },
   {
-    "id": "ann-erdos1002-apriori",
+    "id": "ann-erdos1002-sum-bound",
     "proofId": "erdos-1002-oq-01-oq-01-incomplete-01",
-    "range": { "startLine": 100, "endLine": 126 },
+    "range": { "startLine": 100, "endLine": 113 },
     "type": "theorem",
-    "title": "A Priori Control of the Weighted Sum",
-    "content": "abs_innerSum_le bounds the inner sum |S(α,n)| ≤ n/2 by the triangle inequality (Finset.abs_sum_le_sum_abs) over the pointwise envelope, summing n copies of 1/2. abs_f_le divides by log n > 0 (Real.log_pos, valid for n ≥ 2) to get |f(α,n)| ≤ (n/2)/log n, with gcongr propagating the inner bound through the division. This is the crude control certifying f is finite and well-defined — the open problem asks for the far finer O(1)-distributed behaviour, but even this trivial envelope confirms the question is about distribution, not size.",
-    "mathContext": "$|S(\\alpha,n)| \\le \\sum_{k=1}^n |\\mathrm{deviation}| \\le n\\cdot\\tfrac12 = \\tfrac n2$; $|f(\\alpha,n)| \\le \\frac{n/2}{\\log n}$ for $n \\ge 2$.",
+    "title": "A Priori Bound on the Inner Sum",
+    "content": "abs_innerSum_le bounds the inner sum |S(α,n)| ≤ n/2 by the triangle inequality (Finset.abs_sum_le_sum_abs) over the pointwise envelope, summing n copies of the bound 1/2 (Finset.sum_le_sum) and collapsing the constant sum via Finset.sum_const / Finset.card_range.",
+    "mathContext": "$|S(\\alpha,n)| \\le \\sum_{k=1}^n |\\mathrm{deviation}| \\le n\\cdot\\tfrac12 = \\tfrac n2$.",
     "significance": "key",
-    "relatedConcepts": ["Finset.abs_sum_le_sum_abs", "Finset.sum_le_sum", "Real.log_pos", "gcongr", "triangle inequality"],
-    "prerequisites": ["finite sums", "logarithm positivity"]
+    "relatedConcepts": ["Finset.abs_sum_le_sum_abs", "Finset.sum_le_sum", "Finset.sum_const", "triangle inequality"],
+    "prerequisites": ["finite sums"]
+  },
+  {
+    "id": "ann-erdos1002-normalized-bound",
+    "proofId": "erdos-1002-oq-01-oq-01-incomplete-01",
+    "range": { "startLine": 115, "endLine": 126 },
+    "type": "theorem",
+    "title": "A Priori Bound on the Normalized Sum",
+    "content": "abs_f_le divides the sum bound by log n > 0 (Real.log_pos, valid for n ≥ 2) to get |f(α,n)| ≤ (n/2)/log n, with gcongr propagating abs_innerSum_le through the division. This is the crude control certifying f is finite and well-defined — the open problem asks for the far finer O(1)-distributed behaviour, but even this trivial envelope confirms the question is about distribution, not size. The n ≥ 2 hypothesis is load-bearing, not cosmetic: it is exactly what keeps log n away from the zero value at n = 1 (and the n ≤ 1 guard in f's definition covers the remaining case).",
+    "mathContext": "$|f(\\alpha,n)| \\le \\frac{n/2}{\\log n}$ for $n \\ge 2$, since $\\log n > 0$ there.",
+    "significance": "key",
+    "relatedConcepts": ["Real.log_pos", "gcongr", "abs_div"],
+    "prerequisites": ["logarithm positivity", "abs_innerSum_le"]
   },
   {
     "id": "ann-erdos1002-zero-mean",

--- a/src/data/proofs/erdos-1002-oq-01-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1002-oq-01-oq-01-incomplete-01/meta.json
@@ -56,7 +56,8 @@
       "The deviation has a sharp, elementary pointwise envelope |deviation x| <= 1/2 with the upper value attained at integers — no equidistribution input needed.",
       "That envelope alone controls the whole weighted sum a priori: |S(alpha,n)| <= n/2 and |f(alpha,n)| <= (n/2)/log n, so f is finite and the open question is purely about its finer distribution.",
       "The deviation has zero mean over a period: integral over [0,1] of deviation = 0. This is the exact value every Weyl/Cesaro average of deviation converges to in the irrational case, and it needs no approximation theory.",
-      "The a.e. congruence trick (drop the single point x = 1) lets the fractional-part integral be computed as the ordinary integral of the identity, avoiding any special fractional-part integration lemma."
+      "The a.e. congruence trick (drop the single point x = 1) lets the fractional-part integral be computed as the ordinary integral of the identity, avoiding any special fractional-part integration lemma.",
+      "The n >= 2 hypothesis in abs_f_le is not a technical nicety but the same edge case handled twice: log n is only strictly positive for n >= 2 (log 1 = 0, and log 0 = 0 by Mathlib convention), so the guard 'if n <= 1 then 0' in the definition of f keeps f total, and the hypothesis n >= 2 in the bound keeps that same division meaningful."
     ]
   },
   "sections": [
@@ -77,12 +78,20 @@
       "mathContext": "deviation x = 1/2 - {x} with {x} in [0,1) gives the sharp two-sided envelope."
     },
     {
-      "id": "a-priori-control",
-      "title": "A Priori Control of the Weighted Sum",
-      "summary": "abs_innerSum_le (|S| <= n/2) and abs_f_le (|f| <= (n/2)/log n for n >= 2), certifying the weighted sum and its normalization are finite and bounded.",
+      "id": "sum-bound",
+      "title": "A Priori Bound on the Inner Sum",
+      "summary": "abs_innerSum_le: |S(alpha,n)| <= n/2, by the triangle inequality (Finset.abs_sum_le_sum_abs) summing n copies of the pointwise envelope 1/2.",
       "startLine": 100,
-      "endLine": 127,
-      "mathContext": "Triangle inequality over the |deviation| <= 1/2 envelope; division by log n > 0 (Real.log_pos) for n >= 2."
+      "endLine": 113,
+      "mathContext": "Triangle inequality over the |deviation| <= 1/2 envelope: |sum deviation| <= sum |deviation| <= n * (1/2)."
+    },
+    {
+      "id": "normalized-bound",
+      "title": "A Priori Bound on the Normalized Sum",
+      "summary": "abs_f_le: |f(alpha,n)| <= (n/2)/log n for n >= 2, dividing the sum bound by log n > 0 (Real.log_pos); certifies f is finite and well-defined, with the open question about the far finer true scale.",
+      "startLine": 115,
+      "endLine": 126,
+      "mathContext": "Division by log n > 0 (Real.log_pos, needs n >= 2) propagated through the sum bound via gcongr."
     },
     {
       "id": "zero-mean",


### PR DESCRIPTION
## Summary
- Splits the `a-priori-control` section (100-127) into two sections at the real theorem boundary: `sum-bound` (abs_innerSum_le, 100-113) and `normalized-bound` (abs_f_le, 115-126) — brings sections from 4 to 5, each mapping to a genuine Lean construct.
- Splits the matching annotation the same way, and adds a new insight to the `normalized-bound` annotation: the `n >= 2` hypothesis in `abs_f_le` is the same edge case as the `n <= 1` guard in the definition of `f` (both exist because `log n` is only positive for `n >= 2`).
- Adds a 5th `keyInsight` to `overview.keyInsights` making this load-bearing-guard observation explicit at the entry level too.

No changes to Lean source; JSON-only enrichment pass. `meta.json` (11.8 KB) and `annotations.json` (7.1 KB) remain well under the size guardrails.

## Test plan
- [x] `jq empty` validates both JSON files
- [x] `pnpm build`'s enrichment/data-manifest/search-index/loading-facts steps ran clean over the changed files (only unrelated `tsc` step failed, due to a pre-existing host-wide `node v26.5.0` / `better-sqlite3` native-build issue, not this change)