### PR TITLE
audit(erdos-1135): fix stale axiom-prose after 2026-03-30 cleanup

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10300,10 +10300,10 @@
       "result": "clean"
     },
     "erdos-1135": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:32Z",
-      "result": "clean"
+      "lastAudited": "2026-07-23T16:03:22Z",
+      "result": "issues-fixed"
     },
     "erdos-1136": {
       "auditCount": 4,

--- a/src/data/proofs/erdos-1135/meta.json
+++ b/src/data/proofs/erdos-1135/meta.json
@@ -55,18 +55,11 @@
       "summary": "Proves $f(1) = 2$ and $f(2) = 1$ by `decide`, establishing the unique known cycle $1 \\to 2 \\to 1$. Derives $\\texttt{ReachesOne}(1)$ trivially with witness $k = 0$."
     },
     {
-      "id": "partial-results",
-      "title": "Partial Results (Axiomatized)",
+      "id": "structural-properties",
+      "title": "Structural Properties",
       "startLine": 47,
-      "endLine": 62,
-      "summary": "Axiomatizes two landmark results: **Tao (2019)** — for any $g(n) \\to \\infty$, almost all orbits drop below $g(m)$; **Krasikov–Lagarias (2003)** — at least $x^{0.84}$ integers below $x$ reach 1. Both are beyond current Mathlib formalization."
-    },
-    {
-      "id": "conjecture",
-      "title": "The Full Conjecture",
-      "startLine": 64,
-      "endLine": 69,
-      "summary": "States the Collatz conjecture as an axiom: $\\forall m \\geq 1, \\texttt{ReachesOne}(m)$. Open since pre-1952, with $500 Erdős prize."
+      "endLine": 68,
+      "summary": "Proves four structural lemmas about the compressed Collatz map: `collatzIter_collatz` ($k$ iterations from $f(m)$ equal $k+1$ iterations from $m$, by induction), `collatz_pos` ($f$ preserves positivity), and the case-split identities `collatz_even_eq`/`collatz_odd_eq` ($f(m) = m/2$ for even $m$, $(3m+1)/2$ for odd $m$)."
     },
     {
       "id": "even-reduction",
@@ -85,11 +78,11 @@
       "mathContext": "The orbit lengths: $f(2) = 1$ (1 step). $3 \\to 5 \\to 8 \\to 4 \\to 2 \\to 1$ (5 steps). $7 \\to 11 \\to 17 \\to 26 \\to 13 \\to 20 \\to 10 \\to 5 \\to 8 \\to 4 \\to 2 \\to 1$ (11 steps). The orbit lengths grow irregularly — this unpredictability is the essence of the problem's difficulty."
     },
     {
-      "id": "deep-partial-results",
-      "title": "Deep Partial Results and Conjecture (Axioms)",
+      "id": "open-results-documented",
+      "title": "Open Results (Documented, Not Formalized)",
       "startLine": 88,
       "endLine": 97,
-      "summary": "Axiomatizes Tao (2019): for almost all $m$, the orbit drops below any function $g(m) \\to \\infty$. Axiomatizes Krasikov-Lagarias (2003): $|\\{m \\leq x : m \\text{ reaches 1}\\}| \\geq x^{0.84}$. States the full conjecture: $\\forall m \\geq 1, \\texttt{ReachesOne}(m)$.",
+      "summary": "Plain comments — not Lean `axiom` declarations — describing Tao (2019): for almost all $m$, the orbit drops below any function $g(m) \\to \\infty$; Krasikov-Lagarias (2003): $|\\{m \\leq x : m \\text{ reaches 1}\\}| \\geq x^{0.84}$; and the full conjecture $\\forall m \\geq 1, \\texttt{ReachesOne}(m)$. An earlier file version stated these as three `axiom` declarations (`tao_almost_all`, `krasikov_lagarias`, `erdos_1135_collatz_conjecture`); a 2026-03-30 repo-wide unused-axiom cleanup (#8409) removed them as unreferenced, leaving only the doc comments.",
       "mathContext": "Tao's result: $\\text{dens}(\\{m \\leq x : \\min_k f^k(m) \\leq g(m)\\}) \\to 1$ for any $g(n) \\to \\infty$. This means 'almost all' orbits get arbitrarily small, but does not prove they reach 1. Krasikov-Lagarias: at least $x^{0.84}$ integers below $x$ reach 1, improving earlier $x^{0.81}$ bounds."
     }
   ],
@@ -97,7 +90,7 @@
     "historicalContext": "The Collatz conjecture was formulated by Lothar Collatz around 1937, though it did not appear in print until the early 1950s. The problem has been independently rediscovered by many mathematicians, earning it a profusion of names: the 3n+1 problem, Syracuse problem, Kakutani's problem, Hasse's algorithm, and Ulam's conjecture. Erdős called it one of the problems for which 'mathematics may not be ready' and informally estimated a $500 prize for its resolution. Jeffrey Lagarias, who compiled the definitive survey 'The 3x+1 Problem and its Generalizations' (AMS, 2010), described it as 'an extraordinarily difficult problem, completely out of reach of present day mathematics.' In 2019, Terence Tao achieved the strongest theoretical advance: almost all orbits attain almost bounded values. Despite Tao's breakthrough and computational verification to $2^{68}$ by David Barina (2020), the full conjecture remains stubbornly open.",
     "problemStatement": "Does every positive integer $m$ eventually reach 1 under iteration of $f(n) = n/2$ (if $n$ is even) or $f(n) = (3n+1)/2$ (if $n$ is odd)?",
     "text": "Does every positive integer eventually reach 1 under f(n) = n/2 (even) or (3n+1)/2 (odd)? Verified up to 2^68. Tao: almost all orbits attain small values. Open. $500.",
-    "proofStrategy": "The formalization defines the compressed Collatz map and its iteration constructively in Lean 4, proves basic values ($f(1) = 2$, $f(2) = 1$) via the `decide` tactic, and axiomatizes the deep results of Tao and Krasikov–Lagarias that lie beyond current Mathlib capabilities. The full conjecture is stated as an axiom, reflecting its open status.",
+    "proofStrategy": "The formalization defines the compressed Collatz map and its iteration constructively in Lean 4, proves basic values ($f(1) = 2$, $f(2) = 1$) via the `decide` tactic, several structural lemmas (orbit transitivity, positivity, even/odd step identities), and verifies $\\texttt{ReachesOne}$ for $m = 2,\\dots,7$ via `native_decide`. Tao's and Krasikov–Lagarias's results, and the full conjecture itself, are documented in comments but are not stated as Lean axioms or theorems — an earlier file version axiomatized them, but a 2026-03-30 repo-wide unused-axiom cleanup removed the axioms as unreferenced.",
     "keyInsights": [
       "**Fully computable definitions**: `collatz` and `collatzIter` are defined without sorry or axioms, enabling Lean's kernel to evaluate Collatz orbits for any concrete input",
       "**Tao's entropy decrement (2019)**: Almost all orbits attain values below any function growing to infinity — the strongest theoretical result, using a novel connection between the Collatz map and entropy on cyclic groups",
@@ -111,7 +104,7 @@
     ]
   },
   "conclusion": {
-    "summary": "This formalization captures the Collatz conjecture (Erdős Problem #1135) in Lean 4 with fully computable definitions and axiomatized deep results. The constructive core — the Collatz map, its iteration, and the ReachesOne predicate — can be evaluated by Lean's kernel for any concrete input. The partial results of Tao and Krasikov–Lagarias are stated as axioms, honestly reflecting the formalization gap between published mathematics and current proof assistant libraries.",
+    "summary": "This formalization captures the Collatz conjecture (Erdős Problem #1135) in Lean 4 with fully computable definitions, structural lemmas, and concrete orbit verifications for $m = 1,\\dots,7$. The constructive core — the Collatz map, its iteration, and the ReachesOne predicate — can be evaluated by Lean's kernel for any concrete input. Tao's and Krasikov–Lagarias's partial results, and the full conjecture itself, are documented in comments only (not stated as Lean axioms), honestly reflecting that this file formalizes only the definitions and small-case computations, not the open mathematics.",
     "implications": "**Theoretical Significance**: A resolution of the Collatz conjecture would have profound implications across mathematics.\n\nIt would illuminate the interface between **computation and proof** (is every true $\\Pi_1^0$ statement provable?), advance **dynamical systems on integers** (understanding how piecewise-linear maps generate complex orbits), and potentially require new mathematical tools bridging ergodic theory, number theory, and logic. Conway's undecidability result for generalizations suggests that any proof must exploit specific structure of the 3n+1 map.",
     "openQuestions": [
       "Does every positive integer reach 1 under Collatz iteration, or do counterexamples (divergent orbits or nontrivial cycles) exist?",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-1135 (Collatz Conjecture)
**Problem**: meta.json's `sections`, `overview.proofStrategy`, and `conclusion.summary` describe the file as containing `axiom` declarations for Tao's (2019) almost-all result, the Krasikov–Lagarias (2003) density bound, and the full Collatz conjecture. None of these axioms exist in the current file.

## Evidence

**Lean file** (`proofs/Proofs/Erdos1135Problem.lean`, 97 lines): zero occurrences of the word `axiom` anywhere, including in comments (`grep -n -i axiom` → no hits). `leanFile.axiomCount: 0` in meta.json was already correct.

**meta.json claimed** (stale): section "Partial Results (Axiomatized)" — "Axiomatizes two landmark results: Tao (2019)... Krasikov–Lagarias (2003)..."; section "The Full Conjecture" — "States the Collatz conjecture as an axiom..."; section "Deep Partial Results and Conjecture (Axioms)" — "Axiomatizes Tao... Axiomatizes Krasikov-Lagarias... States the full conjecture...". Same claim repeated in `overview.proofStrategy` and `conclusion.summary`.

**Root cause**: the original file (655c8aa99b, 2026-01-26) did have three real `axiom` declarations (`tao_almost_all`, `krasikov_lagarias`, `erdos_1135_collatz_conjecture`). A repo-wide unused-axiom sweep (`c34e89c683`, PR #8409, 2026-03-30, "remove 2,256 unused axioms across 585 Erdős files") removed all three as unreferenced by any theorem, leaving only their doc comments — this was correct/intentional cleanup, but meta.json's prose was never updated to match. Separately, an earlier commit (`6ae2bf865e`) had inserted ~30 lines of new structural lemmas *before* the Partial-Results/Conjecture sections, so even the `startLine`/`endLine` ranges no longer matched their described content (they described what used to be at those line numbers).

## Fix

- Re-anchored `sections` to the current 97-line file: merged the stale "Partial Results (Axiomatized)" (47-62) and "The Full Conjecture" (64-69) sections — whose claimed content had shifted to lines 47-77 (now "Structural Properties" + the already-correct "Even Step Reduction" section) — into one accurate "Structural Properties" section (47-68).
- Rewrote the final section (88-97) from "Deep Partial Results and Conjecture (Axioms)" to "Open Results (Documented, Not Formalized)", stating plainly these are comments, not `axiom` declarations, and noting the 2026-03-30 removal for provenance.
- Rewrote `overview.proofStrategy` and `conclusion.summary` to drop the "axiomatizes"/"stated as an axiom" language.

No change to `status`, `badge`, or `axiomCount` — those were already accurate (0 literal axioms; `axiomCount: 1` reflects the disclosed `native_decide`/`Lean.ofReduceBool` compiler-trust footprint per the existing `assumptions` note, unrelated to this issue).

---
Discovered during gallery integrity audit.