### PR TITLE
Enrich erdos-866-wip-01: split threshold section into witness/guarantees + proof (4->5 sections)

### DIFF
--- a/src/data/proofs/erdos-866-wip-01/meta.json
+++ b/src/data/proofs/erdos-866-wip-01/meta.json
@@ -157,11 +157,19 @@
       "mathContext": "Among any three integers two share parity, so one pairwise sum is even, hence not in the odd numbers."
     },
     {
-      "id": "threshold",
-      "title": "Threshold reformulation g_k(N) ≥ 1",
+      "id": "witness-guarantees",
+      "title": "The Size-N Witness and the Guarantees Predicate",
       "startLine": 81,
+      "endLine": 97,
+      "summary": "exists_large_set_without_config bundles the odd numbers as a size-N witness with no k-configuration. Guarantees N k g then formalizes the threshold semantics: every A of size ≥ N+g contains all pairwise sums of some k-family.",
+      "mathContext": "$\\mathrm{Guarantees}(N,k,g)$: every $A$ with $|A| \\ge N+g$ contains all pairwise sums of some $k$-family; $g_k(N)$ is the least such $g$."
+    },
+    {
+      "id": "threshold-proof",
+      "title": "The Threshold Bound g_k(N) ≥ 1",
+      "startLine": 99,
       "endLine": 113,
-      "summary": "exists_large_set_without_config bundles the size-N odd witness; Guarantees N k g formalizes the threshold semantics; not_guarantees_zero refutes a threshold of 0; g_k_ge_one concludes that every valid threshold is at least 1.",
+      "summary": "not_guarantees_zero refutes a threshold of 0 using the odd-numbers witness; g_k_ge_one concludes that any g satisfying Guarantees N k g must be at least 1 — the elementary lower bound g_k(N) ≥ 1 for all k ≥ 3.",
       "mathContext": "$g = 0$ does not guarantee a configuration, so $g_k(N) \\ge 1$ for all $k \\ge 3$."
     }
   ],


### PR DESCRIPTION
## Summary
- `sections` collapsed the whole threshold-reformulation block (lines 81-113) into one section, while `annotations.json` already treats the witness/`Guarantees`-definition (85-97) and the threshold proof (`not_guarantees_zero`/`g_k_ge_one`, 99-111) as two distinct pieces. Splits `sections` to match — 4 sections -> 5, each still mapping to real Lean constructs.
- Prose is drawn from the existing annotation content, not invented.

No changes to Lean source; JSON-only enrichment pass. `meta.json` (14.3 KB) remains well under the size guardrails.

## Test plan
- [x] `jq empty` validates the JSON
- [x] `pnpm build`'s enrichment/data-manifest/search-index/loading-facts steps ran clean over the changed file (pre-existing unrelated warnings for other slugs only; `tsc` step fails host-wide due to a pre-existing `node v26.5.0` / `better-sqlite3` native-build issue, not this change)