### PR TITLE
Enrich fatou-lemma-oq-01-oq-02-oq-01: split into 5 sections + cover namespace setup

### DIFF
--- a/src/data/proofs/fatou-lemma-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fatou-lemma-oq-01-oq-02-oq-01/meta.json
@@ -158,11 +158,27 @@
       "mathContext": "$|f_n| \\le g$ integrable, $f_n \\to F$ pointwise $\\Rightarrow \\int f_n \\to \\int F$, via Fatou on $g \\pm f_n$."
     },
     {
-      "id": "dct-add-bracket",
-      "title": "DCT via the Upper Bracket g + fₙ",
+      "id": "namespace-setup",
+      "title": "Namespace, Opens, and Shared Variables",
+      "startLine": 59,
+      "endLine": 65,
+      "summary": "Opens the MeasureTheory/Filter/Set/Topology namespaces and scoped ENNReal notation, declares the FatouLemmaOQ01OQ02OQ01 namespace, and fixes the ambient measurable space α with measure μ shared by both theorems.",
+      "mathContext": "`variable {α : Type*} [MeasurableSpace α] {μ : Measure α}` — the common ambient space for both `dct_of_dominated` and `dct_of_dominated_sub`."
+    },
+    {
+      "id": "dct-add-setup",
+      "title": "Measurability and Integrability Setup",
       "startLine": 66,
+      "endLine": 100,
+      "summary": "Opens dct_of_dominated: derives measurability and the bound |F| ≤ g for the pointwise limit F from |fₙ| ≤ g and fₙ → F, then integrability of each fₙ and of F via Integrable.mono', and pointwise nonnegativity of the shifts g + fₙ and g + F.",
+      "mathContext": "From $|f_n|\\le g$, $g$ integrable, and $f_n\\to F$: $F$ measurable, $|F|\\le g$, so $f_n,F$ integrable and $g+f_n\\ge0$, $g+F\\ge0$."
+    },
+    {
+      "id": "dct-add-fatou",
+      "title": "DCT via the Upper Bracket g + fₙ",
+      "startLine": 101,
       "endLine": 139,
-      "summary": "dct_of_dominated derives the signed dominated convergence theorem from Fatou applied to g + fₙ. After establishing measurability and integrability of F and fₙ from |fₙ| ≤ g, the nonnegative g + fₙ (dominated by 2g, converging to g + F) is fed to the nonnegative Fatou bracket; ofReal_integral_eq_lintegral_ofReal and ENNReal.toReal transfer the convergence to ∫ (g + fₙ) → ∫ (g + F), and integral_add cancellation of ∫ g gives ∫ fₙ → ∫ F.",
+      "summary": "Feeds the nonnegative g + fₙ (dominated by 2g, converging to g + F) to the nonnegative Fatou bracket tendsto_lintegral_of_dominated_convergence; ofReal_integral_eq_lintegral_ofReal and ENNReal.toReal transfer the convergence to ∫ (g + fₙ) → ∫ (g + F), and integral_add cancellation of ∫ g gives ∫ fₙ → ∫ F.",
       "mathContext": "$g + f_n \\ge 0$, $g + f_n \\le 2g$, $g + f_n \\to g + F$; $\\int(g+f_n)\\to\\int(g+F)$, cancel $\\int g$."
     },
     {


### PR DESCRIPTION
## Summary
- Splits the combined "DCT via the Upper Bracket g + fₙ" section (66-139, spanning the whole first theorem) into a setup half (66-100: measurability/integrability/nonnegativity) and the Fatou-bracket half (101-139: the actual dominated-convergence application and integral transfer).
- Adds a new "Namespace, Opens, and Shared Variables" section (59-65) that covers a previously-uncovered gap (opens, namespace, shared `variable` declaration), bringing `sections.length` from 3 to 5.
- No prose/insight changes needed — keyInsights (5) and all other buckets were already at target.

## Test plan
- [x] `jq . meta.json` validates
- [x] `npx tsx scripts/enricher/find-targets.ts --all --json` confirms quality 96 → 100 (sections 6→10, all other buckets already maxed)