### PR TITLE
Enrich euler-totient-oq-01-oq-01-oq-02: split Part I into theorem/minimality (4->5 sections)

### DIFF
--- a/src/data/proofs/euler-totient-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-01-oq-02/meta.json
@@ -119,10 +119,19 @@
     },
     {
       "id": "part1-carmichael-theorem",
-      "title": "Part I: Carmichael's Theorem and Minimality",
+      "title": "Part I: Carmichael's Theorem",
       "startLine": 44,
+      "endLine": 50,
+      "summary": "unit_pow_carmichael gives a^λ(n)=1 for every unit, specialising Monoid.pow_exponent_eq_one to the unit group — the universal-exponent statement that names Carmichael's function.",
+      "mathContext": "$a^{\\lambda(n)} \\equiv 1 \\pmod n$ for every $a$ coprime to $n$, where $\\lambda(n) = \\exp\\big((\\mathbb{Z}/n\\mathbb{Z})^\\times\\big)$."
+    },
+    {
+      "id": "part1b-minimality",
+      "title": "Part I(b): Minimality of λ(n)",
+      "startLine": 52,
       "endLine": 58,
-      "summary": "unit_pow_carmichael gives a^λ(n)=1 for every unit (specialising Monoid.pow_exponent_eq_one); carmichael_dvd_of_forall_pow_eq_one shows any common exponent of the unit group is a multiple of λ(n), so λ(n) is the least positive universal exponent."
+      "summary": "carmichael_dvd_of_forall_pow_eq_one shows any common exponent of the unit group is a multiple of λ(n) (the (⇐) direction of Monoid.exponent_dvd_iff_forall_pow_eq_one), so with Carmichael's theorem λ(n) is the least positive universal exponent.",
+      "mathContext": "$\\big(\\forall a,\\ a^k = 1\\big) \\implies \\lambda(n) \\mid k$."
     },
     {
       "id": "part2-sharpness",


### PR DESCRIPTION
## Summary
- `sections` grouped Carmichael's theorem (`unit_pow_carmichael`) and its minimality corollary (`carmichael_dvd_of_forall_pow_eq_one`) into one "Part I" section (44-58), while `annotations.json` already treats them as two distinct theorems (44-50 and 52-58). Splits `sections` to match — 4 sections -> 5, each mapping to a single theorem.
- Content (including `mathContext`) is drawn from the existing annotations, not invented.

No changes to Lean source; JSON-only enrichment pass. `meta.json` (15.7 KB) remains well under the size guardrails.

## Test plan
- [x] `jq empty` validates the JSON
- [x] `pnpm build`'s enrichment/data-manifest/search-index/loading-facts steps ran clean over the changed file (pre-existing unrelated warnings for other slugs only; `tsc` step fails host-wide due to a pre-existing `node v26.5.0` / `better-sqlite3` native-build issue, not this change)