### PR TITLE
Enrich euler-totient-oq-06-oq-01: realign sections to real theorem boundaries (4->5)

### DIFF
--- a/src/data/proofs/euler-totient-oq-06-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-06-oq-01/meta.json
@@ -119,32 +119,39 @@
   },
   "sections": [
     {
-      "id": "header-overview",
-      "title": "Module Overview, Imports, and Namespace",
+      "id": "header",
+      "title": "Module Docstring, Imports, and Namespace",
       "startLine": 1,
-      "endLine": 52,
+      "endLine": 37,
       "summary": "Module docstring deriving the master formula from Euler's product formula and the additivity of the p-adic valuation, with imports (`Mathlib.Data.Nat.Totient`, `Mathlib.Data.Nat.Factorization.Basic`, `Mathlib.NumberTheory.Padics.PadicVal.Basic`) and the namespace `EulerTotientOQ06OQ01` opening `Nat` and `Finset`."
     },
     {
       "id": "prime-power-blocks",
       "title": "Prime-Power Building Blocks",
-      "startLine": 53,
-      "endLine": 86,
+      "startLine": 39,
+      "endLine": 67,
       "summary": "`v2_totient_two_pow` (v₂(φ(2^k)) = k−1, since φ(2^k) = 2^(k−1)) and `v2_totient_odd_prime_pow` (v₂(φ(p^k)) = v₂(p−1) for odd prime p, since the factor p^(k−1) is odd) — the two regimes that the general formula glues together."
     },
     {
       "id": "master-formula",
       "title": "Master Formula and padicValNat Restatement",
-      "startLine": 87,
-      "endLine": 127,
+      "startLine": 69,
+      "endLine": 104,
       "summary": "`v2_totient_eq_sum`: v₂(φ(n)) = ∑_{p∣n} (kₚ−1)·v₂(p) + v₂(p−1), proved by applying `Nat.factorization · 2` to Euler's product formula and splitting each factor with `factorization_prod`/`_mul`/`_pow`; and `padicValNat_two_totient_eq_sum`, its `padicValNat 2` restatement via `Nat.factorization_def`."
     },
     {
       "id": "clean-split",
       "title": "Clean Split Isolating the Prime 2",
-      "startLine": 128,
-      "endLine": 158,
-      "summary": "`summand_eq` (each summand is k₂−1 at p=2 and v₂(p−1) at odd primes), `v2_totient_split` (for even n, v₂(φ(n)) = (v₂(n)−1) + ∑_{p∣n, p odd} v₂(p−1), by isolating the singleton {2} from the prime factors), and `totient_even_of_two_lt` recovering the parent's parity result."
+      "startLine": 106,
+      "endLine": 148,
+      "summary": "`summand_eq` (each summand is k₂−1 at p=2 and v₂(p−1) at odd primes), `v2_totient_split` (for even n, v₂(φ(n)) = (v₂(n)−1) + ∑_{p∣n, p odd} v₂(p−1), by isolating the singleton {2} from the prime factors)."
+    },
+    {
+      "id": "consistency",
+      "title": "Consistency With the Parent Parity Result",
+      "startLine": 150,
+      "endLine": 156,
+      "summary": "`totient_even_of_two_lt` recovers the parent entry's parity result (φ(n) even for n > 2, i.e. v₂(φ(n)) ≥ 1) directly from Mathlib's `Nat.totient_even`, confirming consistency with `euler-totient-oq-06`."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary
- `sections` had drifted from the real Lean structure: the boundaries cut straight through `v2_totient_odd_prime_pow` (previously split across "header-overview" ending at line 52 and "prime-power-blocks" starting at line 53) and through `v2_totient_eq_sum` (split across "prime-power-blocks" ending at 86 and "master-formula" starting at 87).
- Verified against `proofs/Proofs/EulerTotientOQ06OQ01.lean` and the already-correct `annotations.json` line ranges, then realigned all 4 sections to real construct boundaries and split off a 5th section (`consistency`, the `totient_even_of_two_lt` corollary) that had been folded into the tail of "clean-split".
- No prose invented — summaries reuse existing annotation content; the new 5th section's summary is drawn from the existing `ann-totient-even-of-two-lt` annotation.

No changes to Lean source; JSON-only enrichment pass. `meta.json` (15.3 KB) remains well under the size guardrails.

## Test plan
- [x] `jq empty` validates the JSON
- [x] Manually cross-checked all 5 section line ranges against the Lean source and `annotations.json`
- [x] `pnpm build`'s enrichment/data-manifest/search-index/loading-facts steps ran clean over the changed file (pre-existing unrelated warnings for other slugs only; `tsc` step fails host-wide due to a pre-existing `node v26.5.0` / `better-sqlite3` native-build issue, not this change)