### PR TITLE
Enrich euler-totient-oq-07-oq-04: split parity-engine section (4->5) + fix 2 annotation startLine bugs

### DIFF
--- a/src/data/proofs/euler-totient-oq-07-oq-04/annotations.json
+++ b/src/data/proofs/euler-totient-oq-07-oq-04/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "ann-two-dvd-totient-of-ne-one-two",
     "proofId": "euler-totient-oq-07-oq-04",
-    "range": { "startLine": 51, "endLine": 63 },
+    "range": { "startLine": 53, "endLine": 63 },
     "type": "theorem",
     "title": "The Parity Engine: a ∉ {1,2} ⟹ 2 ∣ φ a",
     "content": "Packages the totient's parity into a single divisibility usable element-by-element. The proof cases on `a`: if `a = 0` then `φ 0 = 0` is divisible by 2 (`simp`); otherwise `a` is positive and, being ≠ 1 and ≠ 2, satisfies `2 < a` (by `omega`), so `Nat.totient_even` makes `φ a` even and `Even.two_dvd` extracts the factor. The naturals with an odd totient are exactly {1, 2}.",
@@ -62,7 +62,7 @@
   {
     "id": "ann-worked-examples",
     "proofId": "euler-totient-oq-07-oq-04",
-    "range": { "startLine": 121, "endLine": 133 },
+    "range": { "startLine": 123, "endLine": 133 },
     "type": "concept",
     "title": "Worked Fin 3 Families",
     "content": "Three concrete witnesses over Fin 3: the family ![100, 2, 999] is setwise coprime because a₁ = 2 gives φ = 1; the family ![3, 4, 9] is not setwise coprime (all arguments ≥ 3) via `gcd_totient_family_ne_one_of_forall`; and its setwise gcd is exactly gcd(φ3, φ4, φ9) = gcd(2, 2, 6) = 2 by kernel `decide`.",

--- a/src/data/proofs/euler-totient-oq-07-oq-04/meta.json
+++ b/src/data/proofs/euler-totient-oq-07-oq-04/meta.json
@@ -112,21 +112,28 @@
       "id": "header-overview",
       "title": "Module Overview, Imports, and Namespace",
       "startLine": 1,
-      "endLine": 54,
+      "endLine": 51,
       "summary": "Module docstring framing the goal — lift the pairwise totient-coprimality criterion to a finite family — with imports (`Mathlib.Data.Nat.Totient`, `Mathlib.Algebra.GCDMonoid.Finset`, `Mathlib.Tactic`), the contents list, the `EulerTotientOQ07OQ04` namespace, `open Nat` (so `φ` is `Nat.totient`), and the `{ι : Type*}` index variable."
     },
     {
       "id": "parity-engine",
-      "title": "The Parity Engine and the Shared Family Factor",
-      "startLine": 55,
-      "endLine": 78,
-      "summary": "`two_dvd_totient_of_ne_one_two` (a ∉ {1,2} ⟹ 2 ∣ φ a, by casing a = 0 vs a ≥ 3 and `Nat.totient_even`) and `two_dvd_gcd_totient_family` (every argument outside {1,2} ⟹ 2 ∣ s.gcd of the totients, via `Finset.dvd_gcd`)."
+      "title": "The Parity Engine",
+      "startLine": 53,
+      "endLine": 60,
+      "summary": "`two_dvd_totient_of_ne_one_two`: a ∉ {1,2} ⟹ 2 ∣ φ a, by casing a = 0 (φ 0 = 0 is even) vs a ≥ 3 (`Nat.totient_even`)."
+    },
+    {
+      "id": "family-shared-factor",
+      "title": "The Shared Factor of a Totient Family",
+      "startLine": 62,
+      "endLine": 71,
+      "summary": "`two_dvd_gcd_totient_family`: if every argument avoids {1,2}, the totients all share the factor 2, so 2 divides their setwise gcd, via `Finset.dvd_gcd` lifting the pointwise divisibility."
     },
     {
       "id": "headline-criterion",
       "title": "The Finite-Family Coprimality Criterion",
-      "startLine": 79,
-      "endLine": 105,
+      "startLine": 73,
+      "endLine": 104,
       "summary": "`gcd_totient_family_eq_one_iff` — the headline biconditional s.gcd (fun i ↦ φ (a i)) = 1 ↔ ∃ i ∈ s, a i = 1 ∨ a i = 2 (forward: contrapositive via the shared factor 2; reverse: `Finset.gcd_dvd` plus `Nat.dvd_one`) — and `gcd_totient_family_ne_one_of_forall`, its contrapositive stated directly."
     },
     {


### PR DESCRIPTION
## Summary
- `sections` grouped `two_dvd_totient_of_ne_one_two` and `two_dvd_gcd_totient_family` into one "parity-engine" section; splits them into two sections at the real theorem boundary — 4 sections -> 5.
- While in the file, also fixed two pre-existing `annotations.json` `startLine` bugs the build flagged as "No Lean construct found": `ann-two-dvd-totient-of-ne-one-two` pointed at the `variable` line (51) instead of the theorem's docstring (53), and `ann-worked-examples` pointed at a comment line (121) instead of the first `example` (123).

No changes to Lean source; JSON-only enrichment pass. `meta.json` (13.7 KB) remains well under the size guardrails.

## Test plan
- [x] `jq empty` validates both JSON files
- [x] `pnpm build` no longer reports "No Lean construct found" errors for this slug (2 pre-existing errors resolved); enrichment/data-manifest/search-index/loading-facts steps ran clean otherwise (pre-existing unrelated warnings for other slugs only; `tsc` step fails host-wide due to a pre-existing `node v26.5.0` / `better-sqlite3` native-build issue, not this change)