### PR TITLE
Enrich euler-criterion-squares-oq-01-oq-03-oq-01: cover header docstring (lines 1-46)

### DIFF
--- a/src/data/proofs/euler-criterion-squares-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/euler-criterion-squares-oq-01-oq-03-oq-01/meta.json
@@ -110,6 +110,14 @@
   ],
   "sections": [
     {
+      "id": "header",
+      "title": "Header: Sophie Germain Primes and Mersenne Divisors",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring stating the goal (a Sophie Germain prime p ≡ 3 (mod 4) with q = 2p+1 prime forces q ∣ 2^p − 1), the mechanism (residue lift to q ≡ 7 (mod 8), the second supplement, Fermat's little theorem), and the compositeness corollary; then `import Mathlib`, the `SophieGermainMersenne` namespace, and `open ZMod` used throughout the file.",
+      "mathContext": "$p\\equiv 3\\pmod 4,\\ q=2p+1\\text{ prime}\\ \\Rightarrow\\ q\\mid 2^p-1$, via $q\\equiv 7\\pmod 8$, the second supplement, and Fermat's little theorem."
+    },
+    {
       "id": "residue-setup",
       "title": "Residue-Class Setup",
       "startLine": 47,


### PR DESCRIPTION
## Summary

The `sections[]` array in `meta.json` started at line 47, leaving the module docstring, `import Mathlib`, the `SophieGermainMersenne` namespace, and `open ZMod` (lines 1-46 of `Proofs/EulerCriterionSquaresOQ01OQ03OQ01.lean`) uncovered by any section. Added a `header` section covering lines 1-46, summarizing the docstring's stated goal, mechanism, and compositeness corollary.

Quality score (per `scripts/enricher/find-targets.ts`): 96 -> 98 (sections breakdown 8/10 -> 10/10, from 4 -> 5 sections).

No other content changed; existing annotations, overview, and conclusion left as-is (already at target).

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — valid JSON
- [x] `pnpm run gallery:check-size` — within 60KB cap
- [x] `pnpm run annotations:build` — passes
- [ ] Full `pnpm build` (tsc/vite) could not run in this worktree — `node_modules` is absent entirely (pre-existing environment gap, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)