### PR TITLE
Enrich euler-totient-oq-01-oq-02-oq-01: cover header docstring (lines 1-43)

### DIFF
--- a/src/data/proofs/euler-totient-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-02-oq-01/meta.json
@@ -25,6 +25,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Header: The Carmichael Function on Odd Prime Powers",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Module docstring stating the closed form λ(pᵏ) = pᵏ⁻¹(p − 1) for odd primes p and its mechanism (cyclic ⟹ exponent = order), contrasted with the parent's non-cyclic λ(2ᵏ) = 2ᵏ⁻² case; imports of ArithmeticFunction.Carmichael and RingTheory.ZMod.UnitsCyclic, the EulerTotientOQ01OQ02OQ01 namespace, and open ArithmeticFunction Nat.",
+      "mathContext": "$\\lambda(p^k) = p^{k-1}(p-1)$ for odd prime $p$, because $(\\mathbb{Z}/p^k\\mathbb{Z})^\\times$ is cyclic so its exponent $\\lambda$ equals its order $\\varphi(p^k)$."
+    },
+    {
       "id": "mechanism",
       "title": "Section I: The Cyclic Mechanism",
       "startLine": 44,


### PR DESCRIPTION
## Summary

The `sections[]` array in `meta.json` started at line 44, leaving the module docstring, imports, the `EulerTotientOQ01OQ02OQ01` namespace, and `open ArithmeticFunction Nat` (lines 1-43 of `Proofs/EulerTotientOQ01OQ02OQ01.lean`) uncovered by any section (annotations.json already covered lines 5-38 via an existing annotation). Added a `header` section covering lines 1-43, summarizing the docstring's closed-form claim and mechanism.

Quality score (per `scripts/enricher/find-targets.ts`): 96 -> 98 (sections breakdown 6/10 -> 8/10, from 3 -> 4 sections).

No other content changed.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — valid JSON
- [x] `pnpm run gallery:check-size` — within 60KB cap
- [ ] Full `pnpm build` (tsc/vite) could not run in this worktree — `node_modules` is absent entirely (pre-existing environment gap, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)