### PR TITLE
audit(erdos-1138): fix stale axiom prose, phantom decls, drifted sections/annotations

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10318,10 +10318,10 @@
       "result": "clean"
     },
     "erdos-1138": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:32Z",
-      "result": "clean"
+      "lastAudited": "2026-07-23T16:20:03Z",
+      "result": "issues-fixed"
     },
     "erdos-1138-oq-03": {
       "auditCount": 5,

--- a/src/data/proofs/erdos-1138/annotations.json
+++ b/src/data/proofs/erdos-1138/annotations.json
@@ -210,13 +210,13 @@
     "id": "ann-e1138-maxPrimeGap_le",
     "proofId": "erdos-1138",
     "range": {
-      "startLine": 82,
-      "endLine": 88
+      "startLine": 84,
+      "endLine": 93
     },
     "type": "concept",
     "title": "Trivial Bound on Maximal Prime Gap",
-    "content": "Attempts to prove $d(x) \\le x$: the maximal gap between consecutive primes below $x$ cannot exceed $x$ itself. The proof handles the empty case (no gaps when there are fewer than 2 primes below $x$) but leaves the non-empty case as sorry, requiring a `BddAbove` proof for the gap set and a bound on its `sSup`.",
-    "mathContext": "$d(x) = \\sup\\{q - p : p, q \\text{ consecutive primes}, q \\le x\\} \\le x$ because each gap satisfies $q - p < q \\le x$. The sorry arises from the need to show the set is bounded above (for `sSup` to be meaningful in $\\mathbb{N}$) and then that the supremum respects the pointwise bound.",
+    "content": "Proves $d(x) \\le x$: the maximal gap between consecutive primes below $x$ cannot exceed $x$ itself. The proof case-splits on whether the gap set is empty (`csSup_empty` gives `bot_le`) or nonempty (`csSup_le` reduces to the pointwise bound $q - p \\le q \\le x$). Fully proved — no sorry.",
+    "mathContext": "$d(x) = \\sup\\{q - p : p, q \\text{ consecutive primes}, q \\le x\\} \\le x$ because each gap satisfies $q - p \\le q \\le x$.",
     "significance": "key",
     "relatedConcepts": [
       "sSup and BddAbove",
@@ -233,13 +233,13 @@
     "id": "ann-e1138-erdos_1138",
     "proofId": "erdos-1138",
     "range": {
-      "startLine": 90,
-      "endLine": 117
+      "startLine": 195,
+      "endLine": 214
     },
     "type": "concept",
     "title": "Erdős Problem 1138 (Main Conjecture)",
-    "content": "The central conjecture, stated as an axiom: for any constant $C > 1$ and tolerance $\\varepsilon > 0$, there exists $N$ such that for all $x \\ge N$ and all $y$ with $x/2 < y < x$, the number of primes in $(y, y + \\lfloor Cd \\rfloor]$ satisfies $(1 - \\varepsilon) \\cdot Cd/\\log y \\le \\pi(y + \\lfloor Cd \\rfloor) - \\pi(y) \\le (1 + \\varepsilon) \\cdot Cd/\\log y$. The extensive docstring documents the problem's status (OPEN) and why it is out of reach: even under RH, short-interval PNT needs $h > x^{1/2+\\varepsilon}$, while $Cd \\sim C(\\log x)^2$ is far shorter.",
-    "mathContext": "The $\\varepsilon$-sandwich formulation avoids division: $f(x) \\sim g(x)$ is equivalent to $(1-\\varepsilon)g(x) \\le f(x) \\le (1+\\varepsilon)g(x)$ for all $\\varepsilon > 0$ eventually. The use of `Nat.floor (C * d)` converts the real-valued interval length to a natural number endpoint. The universality over $y \\in (x/2, x)$ is the strongest form, implying both average and worst-case control.",
+    "content": "The central conjecture, recorded as a documentation comment — not a Lean axiom or theorem: for any constant $C > 1$, if $d$ is the maximal prime gap below $x$, is $\\pi(y + Cd) - \\pi(y) \\sim Cd / \\log y$ for $x/2 < y < x$ as $x \\to \\infty$? The comment documents the problem's status (OPEN) and why it is out of reach: even under RH, short-interval PNT needs $h > x^{1/2+\\varepsilon}$, while $Cd \\sim C(\\log x)^2$ is far shorter. Because it is only a comment, the file makes no formal claim about this statement.",
+    "mathContext": "An $\\varepsilon$-sandwich formalization would read $(1-\\varepsilon)g(x) \\le f(x) \\le (1+\\varepsilon)g(x)$ for all $\\varepsilon > 0$ eventually, but no such statement is declared in Lean here — this section is prose only.",
     "significance": "key",
     "relatedConcepts": [
       "short interval prime number theorem",
@@ -251,22 +251,20 @@
     "prerequisites": [
       "primesInInterval",
       "maxPrimeGap",
-      "Real.log",
-      "Nat.floor",
-      "filter-based limits"
+      "Real.log"
     ]
   },
   {
     "id": "ann-e1138-bertrand",
     "proofId": "erdos-1138",
     "range": {
-      "startLine": 121,
-      "endLine": 124
+      "startLine": 217,
+      "endLine": 222
     },
     "type": "concept",
     "title": "Bertrand's Postulate",
-    "content": "States Bertrand's postulate as an axiom: for every $n \\ge 1$, there exists a prime $p$ with $n < p \\le 2n$. This was conjectured by Bertrand in 1845 and proved by Chebyshev in 1852. Erdős gave an elegant elementary proof in 1932 at age 19 — his first published paper. The result implies that $d(n) < n$ for all $n$, but this is vastly weaker than Cramér's conjecture $d(x) \\sim (\\log x)^2$.",
-    "mathContext": "$\\forall n \\ge 1, \\, \\exists p \\text{ prime}: n < p \\le 2n$. Equivalently, the prime gap after any prime $p$ is at most $p$: $p_{n+1} - p_n < p_n$. Bertrand's postulate is available in Mathlib as `Nat.bertrand`, but is stated here as an axiom for self-containedness.",
+    "content": "Proves Bertrand's postulate as a genuine theorem (`bertrand_postulate`), not an axiom: for every $n \\ge 1$, there exists a prime $p$ with $n < p \\le 2n$. The proof is a direct call to Mathlib's `Nat.bertrand`. Bertrand's postulate was conjectured in 1845 and proved by Chebyshev in 1852; Erdős gave an elegant elementary proof in 1932 at age 19 — his first published paper. The result implies $d(n) < n$ for all $n$, but this is vastly weaker than Cramér's conjecture $d(x) \\sim (\\log x)^2$.",
+    "mathContext": "$\\forall n \\ge 1, \\, \\exists p \\text{ prime}: n < p \\le 2n$, obtained here via Mathlib's `Nat.bertrand n (by omega)`.",
     "significance": "key",
     "relatedConcepts": [
       "Chebyshev's theorem",
@@ -276,20 +274,20 @@
     ],
     "prerequisites": [
       "Nat.Prime",
-      "basic arithmetic inequalities"
+      "Mathlib's Nat.bertrand"
     ]
   },
   {
     "id": "ann-e1138-cramer",
     "proofId": "erdos-1138",
     "range": {
-      "startLine": 126,
-      "endLine": 132
+      "startLine": 224,
+      "endLine": 227
     },
     "type": "concept",
     "title": "Cramér's Conjecture",
-    "content": "States Cramér's conjecture as an axiom: for every $\\varepsilon > 0$, eventually $d(x) \\le (1 + \\varepsilon)(\\log x)^2$. Harald Cramér proposed this in 1936 based on his probabilistic model of primes, where each integer $n$ is independently 'prime' with probability $1/\\log n$. Under this model, the maximal gap below $x$ is $(\\log x)^2$ with probability 1. The conjecture is OPEN and far stronger than any proven result. If true, Erdős's conjecture would ask for the PNT in intervals of length $\\sim C(\\log x)^2$.",
-    "mathContext": "$\\forall \\varepsilon > 0, \\, \\exists N, \\, \\forall x \\ge N: d(x) \\le (1 + \\varepsilon)(\\log x)^2$. The best unconditional bound is $d(x) \\ll x^{0.525}$ (Baker–Harman–Pintz, 2001). Under RH, one gets $d(x) \\ll \\sqrt{x} \\log x$ (Cramér, 1920). Granville (1995) suggested the constant may be $2e^{-\\gamma} \\approx 1.1229$ rather than 1.",
+    "content": "Records Cramér's conjecture on maximal prime gaps ($\\limsup d(x)/(\\log x)^2 = 1$) as a trailing documentation comment only — it is not declared as an axiom or theorem in Lean. Harald Cramér proposed this in 1936 based on his probabilistic model of primes, where each integer $n$ is independently 'prime' with probability $1/\\log n$. The conjecture is OPEN and far stronger than any proven result.",
+    "mathContext": "Informally, $\\forall \\varepsilon > 0, \\, \\exists N, \\, \\forall x \\ge N: d(x) \\le (1 + \\varepsilon)(\\log x)^2$ — recorded as prose, not a Lean statement. The best unconditional bound is $d(x) \\ll x^{0.525}$ (Baker–Harman–Pintz, 2001). Under RH, one gets $d(x) \\ll \\sqrt{x} \\log x$ (Cramér, 1920).",
     "significance": "key",
     "relatedConcepts": [
       "Cramér's probabilistic model",

--- a/src/data/proofs/erdos-1138/meta.json
+++ b/src/data/proofs/erdos-1138/meta.json
@@ -65,9 +65,7 @@
       "primeCounting_two",
       "primeCounting_le",
       "maxPrimeGap_le",
-      "erdos_1138",
-      "bertrand_postulate",
-      "cramer_conjecture"
+      "bertrand_postulate"
     ],
     "axiomCount": 0,
     "lineCount": 227,
@@ -79,7 +77,7 @@
     "historicalContext": "Erdős Problem #1138 sits at the intersection of two of the deepest themes in analytic number theory: the distribution of primes in short intervals and the structure of maximal prime gaps. The prime number theorem, proved independently by Hadamard and de la Vallée Poussin in 1896, establishes that $\\pi(x) \\sim x/\\log x$, but understanding $\\pi(x+h) - \\pi(x)$ for short intervals $h = o(x)$ is far harder. Huxley (1972) showed unconditionally that the asymptotic $\\pi(x+h) - \\pi(x) \\sim h/\\log x$ holds for $h > x^{7/12}$, while under the Riemann Hypothesis one can take $h > x^{1/2+\\varepsilon}$.\n\nMeanwhile, the maximal prime gap $d(x) = \\max_{p_n < x}(p_{n+1} - p_n)$ is conjectured by Cramér (1936) to satisfy $d(x) \\sim (\\log x)^2$, based on a probabilistic model of the primes. The best unconditional result, due to Baker–Harman–Pintz (2001), gives a prime in every interval $[x, x + x^{0.525}]$, but this is enormously larger than $(\\log x)^2$. Erdős's question asks whether the prime counting function still behaves asymptotically correctly in intervals of length $Cd(x)$ — intervals potentially as short as $C(\\log x)^2$ — centered around arbitrary points $y \\in (x/2, x)$. This would require a dramatic strengthening of all known short-interval results.\n\nThe problem reflects Erdős's characteristic approach of posing questions that connect disparate areas: here, the combinatorial structure of prime gaps meets the analytic machinery of the prime number theorem.",
     "problemStatement": "For $x/2 < y < x$ and $C > 1$, if $d = \\max_{p_n < x}(p_{n+1} - p_n)$ is the maximal prime gap below $x$, is it true that $\\pi(y + Cd) - \\pi(y) \\sim Cd / \\log y$ as $x \\to \\infty$?",
     "text": "For x/2 < y < x and C > 1, if d is the maximal prime gap below x, is π(y + Cd) - π(y) ~ Cd / log y?",
-    "proofStrategy": "The formalization builds the necessary infrastructure in stages. First, the prime counting function $\\pi(n)$ is defined using `Finset.filter` over `Finset.range`, giving a computable definition. Interval counting $\\pi(b) - \\pi(a)$ and the maximal prime gap $d(x) = \\sup\\{q - p : p, q \\text{ consecutive primes}, q \\le x\\}$ are then defined. Basic properties of $\\pi$ (monotonicity, values at 0, 1, 2, and trivial upper bounds) are proved. The conjecture itself is stated as an axiom using the $\\varepsilon$-formulation: for every $\\varepsilon > 0$, the ratio of the actual prime count to the expected count lies in $[1-\\varepsilon, 1+\\varepsilon]$ for sufficiently large $x$. Related results — Bertrand's postulate and Cramér's conjecture — are included as axioms to contextualize the problem.",
+    "proofStrategy": "The formalization builds the necessary infrastructure in stages. First, the prime counting function $\\pi(n)$ is defined using `Finset.filter` over `Finset.range`, giving a computable definition. Interval counting $\\pi(b) - \\pi(a)$ and the maximal prime gap $d(x) = \\sup\\{q - p : p, q \\text{ consecutive primes}, q \\le x\\}$ are then defined. Basic properties of $\\pi$ (monotonicity, values at 0, 1, 2, and trivial upper bounds) are proved, along with `BddAbove`/`Set.Nonempty` lemmas for the prime-gap set and a computable `primesUpTo` infrastructure. The Erdős conjecture itself is stated only as a documentation comment — not a Lean declaration — using the $\\varepsilon$-formulation: for every $\\varepsilon > 0$, the ratio of the actual prime count to the expected count lies in $[1-\\varepsilon, 1+\\varepsilon]$ for sufficiently large $x$; it remains unformalized since the problem is open. Bertrand's postulate is proved as a genuine theorem via Mathlib's `Nat.bertrand`; Cramér's conjecture on maximal prime gaps appears only as descriptive commentary to contextualize the problem, not as an axiom.",
     "keyInsights": [
       "**Gap between conjecture and provability**: Cramér's conjecture predicts $d(x) \\sim (\\log x)^2$, but even under the Riemann Hypothesis, short interval PNT requires $h > x^{1/2+\\varepsilon}$. The gap between $(\\log x)^2$ and $x^{1/2+\\varepsilon}$ is astronomical, making this problem completely out of reach of current methods.",
       "**Uniformity over the interval $(x/2, x)$**: The conjecture asks for the asymptotic to hold for *all* $y$ in the second half $(x/2, x)$, not just a typical $y$. This uniformity requirement is much stronger than an average-case statement and rules out approaches based on mean-value theorems alone.",
@@ -121,22 +119,43 @@
       "id": "basic-properties",
       "title": "Basic Properties of $\\pi$",
       "startLine": 53,
-      "endLine": 89,
-      "summary": "Proves fundamental properties: monotonicity ($a \\le b \\Rightarrow \\pi(a) \\le \\pi(b)$) via `Finset.card_le_card`, exact values $\\pi(0) = 0$, $\\pi(1) = 0$, $\\pi(2) = 1$ by `decide`, the trivial bound $\\pi(n) \\le n + 1$ via `Finset.card_filter_le`, and $d(x) \\le x$ (`maxPrimeGap_le`), with the `BddAbove` argument (`primeGapBelow_bddAbove`) fully proved via `csSup_le` — no sorries remain in this section."
+      "endLine": 94,
+      "summary": "Proves fundamental properties: monotonicity ($a \\le b \\Rightarrow \\pi(a) \\le \\pi(b)$) via `Finset.card_le_card`, exact values $\\pi(0) = 0$, $\\pi(1) = 0$, $\\pi(2) = 1$ by `decide`, the trivial bound $\\pi(n) \\le n + 1$ via `Finset.card_filter_le`, and $d(x) \\le x$ (`maxPrimeGap_le`) via `csSup_le` on the (possibly empty) prime-gap set."
+    },
+    {
+      "id": "prime-gap-set-properties",
+      "title": "Prime Gap Set Properties",
+      "startLine": 95,
+      "endLine": 131,
+      "summary": "Establishes `BddAbove` and `Set.Nonempty` for the prime gap set below $x$ — prerequisites for `sSup` to behave correctly. Proves `primeGapBelow_bddAbove`, `primeGap_mem_le`, witnesses the gap $3-2=1$ via `one_mem_primeGapBelow` (for $x \\ge 3$), derives `primeGapBelow_nonempty`, the definitional `maxPrimeGap_eq_sSup` (`rfl`), and `maxPrimeGap_pos` ($x \\ge 3 \\Rightarrow 1 \\le maxPrimeGap(x)$)."
+    },
+    {
+      "id": "computable-prime-infrastructure",
+      "title": "Computable Prime Infrastructure",
+      "startLine": 132,
+      "endLine": 170,
+      "summary": "Defines a computable Finset `primesUpTo n` and shows `primeCounting` equals its cardinality (`rfl`). Proves 2 and 3 belong to `primesUpTo n` for $n \\ge 2$/$3$ respectively, giving `primeCounting_pos` ($\\pi(n) \\ge 1$ for $n \\ge 2$) and `primeCounting_ge_two` ($\\pi(n) \\ge 2$ for $n \\ge 3$)."
+    },
+    {
+      "id": "interval-counting-properties",
+      "title": "Interval Counting Properties",
+      "startLine": 171,
+      "endLine": 194,
+      "summary": "Proves monotonicity of `primesInInterval` in its right endpoint, that `primesInInterval a a = 0`, and that `primesInInterval a (a+1) \\le 1` by case-splitting on whether $a+1$ is prime via `Finset.filter_insert`."
     },
     {
       "id": "erdos-conjecture",
       "title": "The Erdős Conjecture (Problem 1138)",
-      "startLine": 90,
-      "endLine": 118,
-      "summary": "States the main conjecture: for $C > 1$ and $\\varepsilon > 0$, there exists $N$ such that for all $x \\ge N$ and $y \\in (x/2, x)$, the prime count $\\pi(y + \\lfloor Cd \\rfloor) - \\pi(y)$ lies within $(1 \\pm \\varepsilon) \\cdot Cd / \\log y$. Declared as an axiom since this is an open problem."
+      "startLine": 195,
+      "endLine": 214,
+      "summary": "States Erdős Problem #1138 as an informal comment — not a Lean axiom or declaration: for $C > 1$ and $x/2 < y < x$, whether $\\pi(y + Cd) - \\pi(y) \\sim Cd / \\log y$ as $x \\to \\infty$, where $d$ is the maximal prime gap below $x$. Marked OPEN; the file records known context (unconditional short-interval PNT needs $h > x^{7/12}$, RH gives $h > x^{1/2+\\varepsilon}$, Cramér's conjectured gap $\\sim (\\log x)^2$) but does not formalize the statement."
     },
     {
       "id": "related-results",
       "title": "Related Known Results",
-      "startLine": 119,
+      "startLine": 216,
       "endLine": 227,
-      "summary": "States Bertrand's postulate (for $n \\ge 1$, there exists a prime in $(n, 2n]$) and Cramér's conjecture ($d(x) \\le (1+\\varepsilon)(\\log x)^2$ eventually) as axioms, providing context for the strength of Erdős's conjecture relative to known and conjectured bounds on prime gaps."
+      "summary": "Proves Bertrand's postulate (`bertrand_postulate`: for $n \\ge 1$, $\\exists$ a prime in $(n, 2n]$) as a genuine theorem via Mathlib's `Nat.bertrand` — not an axiom. Cramér's conjecture on maximal prime gaps ($\\limsup d(x)/(\\log x)^2 = 1$) appears only in a trailing comment as OPEN context; it is not declared in Lean."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-1138
**Problem**: Prior axiom-removal cleanup (commit 515ea3d34c) converted the Erdős conjecture, Bertrand's postulate, and Cramér's conjecture from `axiom` declarations into a proved theorem (`bertrand_postulate`, via Mathlib's `Nat.bertrand`) and doc comments (the conjecture and Cramér's conjecture are no longer declared in Lean at all — pure prose). The gallery metadata was never updated to match:

1. `meta.originalContributions` still listed phantom names `erdos_1138` and `cramer_conjecture` — 0 grep hits anywhere in `proofs/Proofs/Erdos1138Problem.lean`.
2. `overview.proofStrategy` still said the conjecture and Bertrand/Cramér "are included as axioms".
3. `sections[]` "erdos-conjecture" (startLine 90–118) and "related-results" (startLine 119–227) were badly mis-anchored — the real Erdős-conjecture comment is now at lines 195–214, and both summaries still describe axiom declarations that don't exist.
4. `annotations.json` had the same "stated as an axiom" claims for the conjecture, Bertrand, and Cramér, at line ranges up to ~95 lines stale.
5. `annotations.json`'s `ann-e1138-maxPrimeGap_le` claimed the theorem "leaves the non-empty case as sorry" — false; `maxPrimeGap_le` is fully proved (`csSup_empty`/`csSup_le` case split), matching `sorries: 0`.

axiomCount (0), sorries (0), theoremCount (21), and definitionCount (5) were already accurate — this is a descriptive-metadata-only drift, not a count/status error.

## Evidence

**meta.json claims** (before): `originalContributions` includes `"erdos_1138"`, `"cramer_conjecture"`; `proofStrategy`: "The conjecture itself is stated as an axiom... Related results — Bertrand's postulate and Cramér's conjecture — are included as axioms".

**Lean file shows**: `grep -n "erdos_1138\|cramer_conjecture" proofs/Proofs/Erdos1138Problem.lean` → no hits. The Erdős-conjecture text (lines 195–214) and Cramér's-conjecture text (lines 224–227) are `/- ... -/` doc comments with no accompanying `axiom`/`theorem`. `bertrand_postulate` (lines 217–222) is a `theorem`, proved by `Nat.bertrand n (by omega)`.

## Fix

- Removed phantom `erdos_1138`/`cramer_conjecture` from `originalContributions`.
- Rewrote `proofStrategy` to describe the conjecture/Cramér's conjecture as comment-only (unformalized, open) and Bertrand's postulate as a proved theorem via Mathlib.
- Re-anchored and rewrote 6 `sections[]` entries to match actual line ranges/content (added 3 previously-missing intermediate sections: prime-gap-set-properties, computable-prime-infrastructure, interval-counting-properties).
- Re-anchored and rewrote the 4 affected `annotations.json` entries, dropping the stale "as sorry" and "as an axiom" claims.

---
Discovered during gallery integrity audit (reserve-mode re-verification; queue fully drained at 4811/4811, 0 open issues).