### PR TITLE
Enrich euler-totient-oq-10: split fibre-count section into criterion/fibre-count (4->5)

### DIFF
--- a/src/data/proofs/euler-totient-oq-10/meta.json
+++ b/src/data/proofs/euler-totient-oq-10/meta.json
@@ -103,11 +103,18 @@
       "summary": "Proves gcd(v, n) = ∑_{d∣n} (if d∣v then φ(d) else 0). The divisors of gcd(v, n) are exactly the common divisors of v and n, so Gauss's identity ∑_{e∣g} φ(e) = g rewrites the gcd as a divisor-filtered totient sum."
     },
     {
-      "id": "fibre-count",
-      "title": "The Reduction-to-1 Criterion and the Fibre Count",
+      "id": "reduction-criterion",
+      "title": "The Reduction-to-1 Criterion",
       "startLine": 75,
+      "endLine": 84,
+      "summary": "dvd_val_sub_one_iff: d ∣ (a − 1).val ⟺ unitsMap(a) = 1, via the castHom ring map, identifying the counted residues with the kernel of the reduction homomorphism."
+    },
+    {
+      "id": "fibre-count",
+      "title": "The Fibre Count",
+      "startLine": 86,
       "endLine": 120,
-      "summary": "Shows d ∣ (a − 1).val ⟺ unitsMap(a) = 1 (via the castHom ring map), identifying the counted residues with the kernel of the reduction homomorphism. Surjectivity of unitsMap plus Lagrange and the first isomorphism theorem give φ(d)·#{fibre} = φ(n)."
+      "summary": "totient_mul_fiber_card: the fibre (kernel) has size φ(n)/φ(d), i.e. #{fibre}·φ(d) = φ(n), from surjectivity of unitsMap plus Lagrange's theorem and the first isomorphism theorem."
     },
     {
       "id": "menon",


### PR DESCRIPTION
## Summary
- `sections` grouped `dvd_val_sub_one_iff` (the reduction-to-1 criterion, lines 75-84) and `totient_mul_fiber_card` (the fibre count, lines 86-120) into one "fibre-count" section. Splits them into two sections at the real theorem boundary — 4 sections -> 5.
- Verified line ranges against `proofs/Proofs/EulerTotientOQ10.lean`.

No changes to Lean source; JSON-only enrichment pass. `meta.json` (14.7 KB) remains well under the size guardrails.

## Test plan
- [x] `jq empty` validates the JSON
- [x] Manually cross-checked all 5 section line ranges against the Lean source
- [x] `pnpm build`'s enrichment/data-manifest/search-index/loading-facts steps ran clean over the changed file (no new "No Lean construct found" errors for this slug; `tsc` step fails host-wide due to a pre-existing `node v26.5.0` / `better-sqlite3` native-build issue, not this change)