### PR TITLE
Enrich factorial-telescoping-sum-oq-01-oq-01: add missing header section (4->5)

### DIFF
--- a/src/data/proofs/factorial-telescoping-sum-oq-01-oq-01/meta.json
+++ b/src/data/proofs/factorial-telescoping-sum-oq-01-oq-01/meta.json
@@ -23,6 +23,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Docstring, Imports, and Namespace",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "Module docstring stating the four theorems (term_telescope, sum_Icc, sum_lt_one, tendsto_one) and the key telescoping insight; imports (Mathlib.Data.Nat.Factorial.Basic, Mathlib.Algebra.BigOperators.Intervals, Mathlib.Analysis.SpecificLimits.Basic, Mathlib.Tactic), open Finset Nat Filter Topology, and the FactorialTelescopingConverges namespace.",
+      "mathContext": "Because (k+1)! = (k+1)·k!, the term k/(k+1)! = 1/k! − 1/(k+1)!, so the sum telescopes to 1 − 1/(n+1)! → 1."
+    },
+    {
       "id": "term-telescope",
       "title": "Section I: Telescoping of Reciprocals",
       "startLine": 35,


### PR DESCRIPTION
## Summary
- `sections` covered only lines 35-83 (the four theorems); lines 1-33 (module docstring, imports, `open`, namespace) had no section at all. Adds a `header` section covering that range — 4 sections -> 5, and the file is now fully covered.

No changes to Lean source; JSON-only enrichment pass. `meta.json` (11.6 KB) remains well under the size guardrails.

## Test plan
- [x] `jq empty` validates the JSON
- [x] Manually cross-checked the new section's line range against the Lean source
- [x] `pnpm build`'s enrichment/data-manifest/search-index/loading-facts steps ran clean over the changed file (no new "No Lean construct found" errors for this slug; `tsc` step fails host-wide due to a pre-existing `node v26.5.0` / `better-sqlite3` native-build issue, not this change)