### PR TITLE
audit(erdos-112): fix phantom axiom prose and drifted section/annotation ranges

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10150,10 +10150,10 @@
       "notes": "Issue #14777 — phantom axioms in narrative + section line drift; meta.axiomCount=3 (correct)"
     },
     "erdos-112": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:32Z",
-      "result": "clean"
+      "lastAudited": "2026-07-23T16:26:37Z",
+      "result": "issues-fixed"
     },
     "erdos-1120": {
       "auditCount": 4,

--- a/src/data/proofs/erdos-112/annotations.json
+++ b/src/data/proofs/erdos-112/annotations.json
@@ -121,13 +121,13 @@
     "id": "well-defined",
     "proofId": "erdos-112",
     "range": {
-      "startLine": 55,
-      "endLine": 61
+      "startLine": 53,
+      "endLine": 59
     },
     "type": "concept",
-    "title": "Well-Definedness of k(n,m)",
-    "content": "The core axiom states that k(n,m) achieves its Ramsey-type guarantee: for all n, m ≥ 1, every directed graph on k ≥ k(n,m) vertices contains either an independent set of size n or a transitive tournament of size m. This is the directed analogue of the classical Ramsey theorem.",
-    "mathContext": "For all $n, m \\geq 1$ and every directed graph $G$ on $k \\geq k(n,m)$ vertices: $\\alpha(G) \\geq n \\;\\lor\\; \\text{tt}(G) \\geq m$, where $\\alpha(G)$ is the independence number and $\\text{tt}(G)$ is the maximum transitive tournament size.",
+    "title": "Main Question and Ramsey Lower Bound (Documentation Comment, Not a Lean Axiom)",
+    "content": "A plain prose comment (not a Lean declaration) states the problem and the Ramsey-type guarantee informally: k(n,m) should be the minimum size guaranteeing an independent set of size n or a transitive tournament of size m, with k(n,m) ≥ R(n,m) via the ordinary Ramsey number. No identifier for this exists in the file — it is documentation only, not a formalized axiom or theorem.",
+    "mathContext": "Informal comment recording that $k(n,m)$ is the threshold Ramsey-type function, with $R(n,m) \\leq k(n,m)$ since orienting an undirected clique yields a (not necessarily transitive) tournament. Nothing here is machine-checked.",
     "significance": "key",
     "relatedConcepts": [
       "Ramsey theorem",
@@ -145,13 +145,13 @@
     "id": "ramsey-lower",
     "proofId": "erdos-112",
     "range": {
-      "startLine": 67,
-      "endLine": 69
+      "startLine": 64,
+      "endLine": 65
     },
     "type": "concept",
-    "title": "Ramsey Lower Bound k(n,m) ≥ R(n,m)",
-    "content": "The ordinary Ramsey number R(n,m) provides a lower bound on k(n,m). Any undirected graph can be oriented to create a directed graph, and a clique in the undirected graph becomes a tournament (not necessarily transitive) in the directed version. Since transitive tournaments are more restrictive than cliques, more vertices may be needed.",
-    "mathContext": "Since every clique of size $m$ in an undirected graph contains a transitive tournament of size $m$ when oriented, we have $R(n,m) \\leq k(n,m)$. The axiom states the weaker $k(n,m) \\geq 1$ as a placeholder for the full Ramsey bound.",
+    "title": "Larson–Mitchell Quadratic Bound (Documentation Comment, Not a Lean Axiom)",
+    "content": "A plain prose comment records the Larson–Mitchell (1997) result k(n,3) ≤ n² for transitive triples. This is a literature citation, not a formalized Lean axiom or theorem — no identifier for it exists in the file.",
+    "mathContext": "Comment-only record of the best known bound for $m=3$: $k(n,3) \\leq n^2$ (Larson–Mitchell, 1997).",
     "significance": "key",
     "relatedConcepts": [
       "Ramsey number R(n,m)",
@@ -168,13 +168,13 @@
     "id": "hunter-upper",
     "proofId": "erdos-112",
     "range": {
-      "startLine": 73,
-      "endLine": 76
+      "startLine": 61,
+      "endLine": 62
     },
     "type": "concept",
-    "title": "Hunter's 3-Color Ramsey Upper Bound",
-    "content": "Hunter's bound k(n,m) ≤ C · 3^(n+2m) arises from a 3-coloring reduction. Given a directed graph, color each pair of distinct vertices with one of three colors: 'forward edge,' 'backward edge,' or 'no edge.' A monochromatic set of color 'no edge' gives an independent set; monochromatic 'forward' or 'backward' gives a tournament, which yields the bound via the 3-color Ramsey number R(n,m,m).",
-    "mathContext": "The 3-coloring argument yields $k(n,m) \\leq R_3(n,m,m)$ where $R_3$ is the 3-color Ramsey number. Using the standard bound $R_3(n,m,m) \\leq C \\cdot 3^{n+2m}$, this gives an exponential upper bound in both $n$ and $m$.",
+    "title": "Hunter's 3-Color Ramsey Upper Bound (Documentation Comment, Not a Lean Axiom)",
+    "content": "A plain prose comment records Hunter's bound k(n,m) ≤ C · 3^(n+2m), arising from a 3-coloring reduction: coloring each vertex pair 'forward edge,' 'backward edge,' or 'no edge' reduces the problem to the 3-color Ramsey number R(n,m,m). This is documentation only — no axiom or theorem in the file formalizes it.",
+    "mathContext": "Comment-only record that the 3-coloring argument yields $k(n,m) \\leq R_3(n,m,m) \\leq C \\cdot 3^{n+2m}$, an exponential upper bound in both $n$ and $m$.",
     "significance": "key",
     "relatedConcepts": [
       "multicolor Ramsey number",

--- a/src/data/proofs/erdos-112/meta.json
+++ b/src/data/proofs/erdos-112/meta.json
@@ -68,34 +68,34 @@
     },
     {
       "id": "main-question",
-      "title": "Main Question: Well-Definedness of k(n,m)",
-      "startLine": 53,
+      "title": "Main Question and Known Bounds (Documentation Comments, Not Lean Axioms)",
+      "startLine": 51,
       "endLine": 62,
-      "summary": "States the core axiom $\\texttt{erdos\\_112\\_well\\_defined}$: for all $n,m \\geq 1$, every directed graph on $k \\geq k(n,m)$ vertices contains either an independent set of size $n$ or a transitive tournament of size $m$. This is the Ramsey-type guarantee that $k(n,m)$ is well-defined.",
-      "mathContext": "States the core axiom $\\texttt{erdos\\_112\\_well\\_defined}$: for all $n,m \\geq 1$, every directed graph on $k \\geq k(n,m)$ vertices contains either an independent set of size $n$ or a transitive tournament of size $m$. This is the Ramsey-type guarantee that $k(n,m)$ is well-defined."
+      "summary": "Documents Erdős Problem #112 as plain prose comments (`/- ... -/`), not Lean declarations: the problem statement, the Ramsey lower bound $k(n,m) \\geq R(n,m)$, and Hunter's 3-color upper bound $k(n,m) \\leq R(n,m,m) \\leq C \\cdot 3^{n+2m}$. No identifier such as `erdos_112_well_defined` or `ramsey_lower` exists in the file — these are informal documentation, not formalized axioms or theorems.",
+      "mathContext": "The comments record, without formalizing: the open problem of determining $k(n,m)$; the lower bound $R(n,m) \\leq k(n,m)$ from orienting undirected graphs; and Hunter's upper bound $k(n,m) \\leq R(n,m,m)$ via a 3-coloring reduction. None of this is machine-checked."
     },
     {
       "id": "ramsey-lower-bound",
-      "title": "Ramsey Lower Bound",
-      "startLine": 65,
-      "endLine": 69,
-      "summary": "Axiomatizes the lower bound $k(n,m) \\geq R(n,m)$, where $R(n,m)$ is the ordinary (undirected) Ramsey number. This holds because any undirected graph can be oriented, so the directed problem is at least as hard as the undirected one.",
-      "mathContext": "Axiomatizes the lower bound $k(n,m) \\geq R(n,m)$, where $R(n,m)$ is the ordinary (undirected) Ramsey number."
+      "title": "Larson–Mitchell and Erdős–Rado Bounds (Documentation Comments, Not Lean Axioms)",
+      "startLine": 64,
+      "endLine": 68,
+      "summary": "Documents, as plain comments rather than Lean declarations, the Larson–Mitchell quadratic bound $k(n,3) \\leq n^2$ (1997) and the original Erdős–Rado upper bound $k(n,m) \\leq \\frac{2^{m-1}(n-1)^m + n - 2}{2n-3}$ (1967). Neither is formalized as an axiom or theorem in this file.",
+      "mathContext": "Records the Larson–Mitchell bound for $m=3$ and the general Erdős–Rado bound as literature citations in comments, with no corresponding Lean statement."
     },
     {
       "id": "hunter-upper-bound",
-      "title": "Hunter's 3-Color Ramsey Upper Bound",
-      "startLine": 71,
-      "endLine": 76,
-      "summary": "States Hunter's upper bound $k(n,m) \\leq C \\cdot 3^{n+2m}$ for some constant $C > 0$. This arises from a 3-coloring argument: edges between vertices are colored by direction (forward, backward, or no edge), reducing to the 3-color Ramsey number $R(n,m,m)$.",
-      "mathContext": "States Hunter's upper bound $k(n,m) \\leq C \\cdot 3^{n+2m}$ for some constant $C > 0$. This arises from a 3-coloring argument: edges between vertices are colored by direction (forward, backward, or no edge), reducing to the 3-color Ramsey number $R(n,m,m)$."
+      "title": "Observations: Path Variant and Ramsey Connection (Documentation Comments, Not Lean Axioms)",
+      "startLine": 70,
+      "endLine": 77,
+      "summary": "Documents two further observations as plain comments: the directed-path variant of the problem has the exact solution $(n-1)(m-1)+1$, and $k(n,m) \\leq R(n,m)$ follows since an undirected independent set is also directed-independent. Neither is a formalized Lean statement.",
+      "mathContext": "Comment-only observations connecting the directed-path variant and the classical Ramsey number to $k(n,m)$; not represented as Lean declarations."
     }
   ],
   "overview": {
     "historicalContext": "Erdős and Rado posed this problem in their landmark 1967 paper on partition relations, extending classical Ramsey theory into the directed setting. The question arose naturally from studying tournaments — complete directed graphs where every pair of vertices has exactly one directed edge — which had been studied extensively since the 1930s by König, Rédei, and others. Rédei's 1934 theorem that every tournament contains a Hamiltonian path hinted at rich structural properties in directed graphs. The function $k(n,m)$ generalizes the undirected Ramsey number $R(n,m)$ by replacing 'clique' with 'transitive tournament,' introducing the asymmetry of edge directions. Larson and Mitchell's 1997 quadratic bound $k(n,3) \\leq n^2$ for transitive triples was a breakthrough for the special case $m=3$. The problem connects to Dilworth's theorem (1950) on antichains in partial orders, since a transitive tournament on $m$ vertices corresponds to a chain of length $m$ in the partial order induced by the edges. Despite decades of work, the exact growth rate of $k(n,m)$ for general $n$ and $m$ remains open, making this one of the enduring questions in directed Ramsey theory.",
     "problemStatement": "Determine $k(n,m)$, the minimum $k$ such that every directed graph on $k$ vertices contains an independent set of size $n$ or a transitive tournament of size $m$. Known bounds: $R(n,m) \\leq k(n,m) \\leq R(n,m,m)$.",
     "text": "Determine k(n,m): the minimum vertices guaranteeing an independent set of size n or a transitive tournament of size m in any directed graph. Known: R(n,m) ≤ k(n,m) ≤ R(n,m,m). Open.",
-    "proofStrategy": "The formalization axiomatizes the directed Ramsey function $k(n,m)$ and states its defining property: every sufficiently large directed graph contains either an independent set of size $n$ or a transitive tournament of size $m$. Rather than attempting to compute $k(n,m)$ (which is open), the Lean file captures the known structural results as axioms — the Ramsey lower bound, Hunter's 3-color upper bound via $R(n,m,m)$, the Larson–Mitchell quadratic bound for $m=3$, and the original Erdős–Rado estimate. Each axiom faithfully represents a theorem from the literature, using Lean's type system to enforce the correct quantifier structure and hypothesis conditions.",
+    "proofStrategy": "The formalization defines the directed Ramsey function $k(n,m)$ as a stub (`directedRamsey := fun _ _ => 0`) since its exact value is open, together with the supporting definitions `IsDirectedGraph`, `IsIndependentSet`, and `IsTransitiveTournament`. Rather than attempting to compute $k(n,m)$, the Lean file records the known structural results — the Ramsey lower bound, Hunter's 3-color upper bound via $R(n,m,m)$, the Larson–Mitchell quadratic bound for $m=3$, and the original Erdős–Rado estimate — as plain prose comments citing the literature. These are documentation only: no axiom or theorem declaration formalizes any of these bounds.",
     "keyInsights": [
       "**Ramsey number sandwich**: The bounds $R(n,m) \\leq k(n,m) \\leq R(n,m,m)$ place the directed Ramsey number between the 2-color and 3-color undirected Ramsey numbers, reflecting how edge orientation adds exactly one 'color' of complexity",
       "**Transitive tournaments as linear orders**: A transitive tournament on $m$ vertices is equivalent to a total order, connecting this combinatorial problem to order theory and Dilworth's theorem on chain decompositions",
@@ -110,7 +110,7 @@
     ]
   },
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #112 — the directed Ramsey problem for independent sets versus transitive tournaments — by axiomatizing the function $k(n,m)$ and its known bounds in Lean 4. The formalization faithfully represents the Ramsey lower bound, Hunter's 3-color upper bound, the Larson–Mitchell quadratic estimate for $m=3$, and the original 1967 Erdős–Rado bound, providing a formal foundation for one of the central open problems in directed Ramsey theory.",
+    "summary": "This formalization sets up Erdős Problem #112 — the directed Ramsey problem for independent sets versus transitive tournaments — by defining the relevant directed-graph structures and a stub function $k(n,m)$ in Lean 4. The Ramsey lower bound, Hunter's 3-color upper bound, the Larson–Mitchell quadratic estimate for $m=3$, and the original 1967 Erdős–Rado bound are recorded as documentation comments citing the literature, not as formalized axioms or theorems, providing groundwork rather than a formal result for this open problem in directed Ramsey theory.",
     "implications": "Resolving the exact growth rate of $k(n,m)$ would bridge the gap between 2-color and 3-color Ramsey theory, with potential implications for tournament decomposition, partial order theory, and the Hales–Jewett theorem in higher dimensions. Progress on this problem could also advance understanding of the Erdős–Hajnal conjecture, which posits that tournaments avoiding a fixed subtournament have polynomial-size transitive subtournaments.",
     "openQuestions": [
       "Is $k(n,m)$ polynomial in $n$ for every fixed $m \\geq 4$, extending the Larson–Mitchell quadratic bound beyond $m=3$?",


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-112 (Directed Ramsey: Independent Sets vs Transitive Tournaments)

## Problem

`Erdos112Problem.lean` contains **zero** axiom declarations — `directedRamsey`
is a plain stub `def` and the known bounds (Ramsey lower bound, Hunter's
upper bound, Larson–Mitchell, Erdős–Rado) are recorded only as prose
comments (`/- ... -/`). `meta.axiomCount: 0` correctly reflects this, and
`meta.assumptions` already says so explicitly.

However, 3 `sections[]` entries and 3 `annotations.json` entries described
this content with formal-axiom language — "States the core axiom
`erdos_112_well_defined`", "Axiomatizes the lower bound", "the axiom states
the weaker k(n,m) ≥ 1 as a placeholder" — inventing Lean identifier names
(`erdos_112_well_defined`, `ramsey_lower`, `hunter_upper`) that never
existed in the file, and contradicting the file's own `assumptions`
disclosure. These sections/annotations also pointed at the wrong line
ranges (e.g. the "hunter-upper-bound" section spanned lines 71-76, which is
actually the "Observations" / path-variant comment, not Hunter's bound at
lines 61-62).

This survived 4 prior "clean" audits (tracker: `auditCount: 4`) because
`axiomCount` itself was correct — the drift was only in the narrative
prose and annotation ranges.

## Fix

- Re-anchored `main-question`, `ramsey-lower-bound`, and `hunter-upper-bound`
  sections in `meta.json` to their correct line ranges and rewrote their
  summaries/mathContext to describe the content as documentation comments,
  not formalized axioms.
- Rewrote `overview.proofStrategy` and `conclusion.summary` similarly.
- Re-anchored and rewrote the corresponding `well-defined`, `ramsey-lower`,
  and `hunter-upper` entries in `annotations.json`.
- No change to `axiomCount`, `sorries`, `theoremCount`, or `badge` — those
  were already correct.

## Test plan

- [x] `python3 -c "import json; json.load(open(...))"` on both files — valid JSON
- [x] Confirmed via `grep` that no `erdos_112_well_defined` / `ramsey_lower`
      / `hunter_upper` identifiers exist anywhere in
      `proofs/Proofs/Erdos112Problem.lean`
- [x] Manually re-verified new line ranges against the actual file content

---
Discovered during gallery integrity audit.