### PR TITLE
Enrich fibonacci-identities-oq-02-oq-02: add missing header section (4->5)

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-02-oq-02/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-02/meta.json
@@ -79,6 +79,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Docstring, Import, and Namespace",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Module docstring stating the open question (does divisibility extend to general Uₙ(P,Q)?), the forward-divisibility answer for all P,Q, the index-addition law it rests on, and the honesty note that the converse is out of scope. Imports Mathlib and opens the FibonacciIdentitiesOQ02OQ02 namespace.",
+      "mathContext": "$U_0=0,\\ U_1=1,\\ U_{n+2}=P\\,U_{n+1}-Q\\,U_n$; the goal is $m\\mid n \\Rightarrow U_m\\mid U_n$ for every $P,Q\\in\\mathbb{Z}$."
+    },
+    {
       "id": "definition",
       "title": "The First-Kind Lucas Sequence",
       "startLine": 52,


### PR DESCRIPTION
## Summary
- `sections` covered only lines 52-167 (the definition and three theorems); lines 1-47 (module docstring, import, namespace) had no section. Adds a `header` section covering that range — 4 sections -> 5, and the file is now fully covered.
- Verified against `proofs/Proofs/FibonacciIdentitiesOQ02OQ02.lean`.

No changes to Lean source; JSON-only enrichment pass. `meta.json` (11.4 KB) remains well under the size guardrails.

## Test plan
- [x] `jq empty` validates the JSON
- [x] Manually cross-checked the new section's line range against the Lean source
- [x] `pnpm build`'s enrichment/data-manifest/search-index/loading-facts steps ran clean over the changed file (no new "No Lean construct found" errors for this slug; `tsc` step fails host-wide due to a pre-existing `node v26.5.0` / `better-sqlite3` native-build issue, not this change)