### PR TITLE
Enrich lhopital-oq-04: split sections into 5 real theorem/example boundaries

### DIFF
--- a/src/data/proofs/lhopital-oq-04/meta.json
+++ b/src/data/proofs/lhopital-oq-04/meta.json
@@ -78,17 +78,33 @@
       "id": "main-rule",
       "title": "L'Hôpital via Dividing Leading Terms",
       "startLine": 55,
-      "endLine": 80,
-      "summary": "lhopital_zero_taylor divides the two leading-order limits; lhopital_zero_taylor_coeff names the value as a ratio of first Taylor coefficients.",
+      "endLine": 67,
+      "summary": "lhopital_zero_taylor divides the two leading-order limits f(x)/(x-a) → f'(a) and g(x)/(x-a) → g'(a), transporting along f(x)/g(x) = (f(x)/(x-a))/(g(x)/(x-a)) for x ≠ a. No Mean Value Theorem appears.",
       "mathContext": "f(x)/g(x) = (f(x)/(x-a))/(g(x)/(x-a)) → f'(a)/g'(a), no MVT."
     },
     {
-      "id": "examples",
-      "title": "Worked Examples",
-      "startLine": 83,
-      "endLine": 99,
-      "summary": "sin x/x → 1 (limit cos 0/1) and (1 - cos x)/x → 0 (vanishing leading term, sin 0/1).",
-      "mathContext": "Instantiating the rule, including the f'(a) = 0 case."
+      "id": "taylor-coeff",
+      "title": "Naming the Limit via First Taylor Coefficients",
+      "startLine": 69,
+      "endLine": 78,
+      "summary": "lhopital_zero_taylor_coeff repackages the same limit as (f'(a)/1!)/(g'(a)/1!), exhibiting order-1 L'Hôpital as the ratio of the first Taylor coefficients of f and g — the shape the order-k generalisation would take.",
+      "mathContext": "Order-1 L'Hôpital as $\\dfrac{f'(a)/1!}{g'(a)/1!} = \\dfrac{c_1[f]}{c_1[g]}$, anticipating $\\dfrac{f^{(k)}(a)/k!}{g^{(k)}(a)/k!}$."
+    },
+    {
+      "id": "example-sin",
+      "title": "Worked Example: sin x / x → 1",
+      "startLine": 80,
+      "endLine": 86,
+      "summary": "Instantiates the rule with f = sin, g = id at a = 0: f'(0) = cos 0 = 1, g'(0) = 1, so the limit is cos 0/1 = 1 — recovering the classic sine limit without circularity.",
+      "mathContext": "$\\dfrac{\\sin x}{x}\\to \\dfrac{\\cos 0}{1}=1.$"
+    },
+    {
+      "id": "example-vanishing",
+      "title": "Worked Example: a Vanishing Leading Coefficient",
+      "startLine": 88,
+      "endLine": 100,
+      "summary": "(1 - cos x)/x → 0: the numerator's leading Taylor coefficient sin 0 = 0 vanishes, so the leading-order picture immediately gives limit 0/1 = 0 where naïve substitution is indeterminate.",
+      "mathContext": "$\\dfrac{1-\\cos x}{x}\\to \\dfrac{\\sin 0}{1}=0.$"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for lhopital-oq-04 (quality 96 → 100, sections quality component 6/10 → 10/10).

The entry's `sections` array had only 3 entries: `leading-order` (39-53), a merged `main-rule` (55-80) spanning two distinct theorems (`lhopital_zero_taylor` and `lhopital_zero_taylor_coeff`), and a merged `examples` (83-99) spanning two distinct worked examples (`sin x/x → 1` and `(1-cos x)/x → 0`).

Split into 5 sections along real theorem/example boundaries, matching the granularity already present in `annotations.json`:
- `leading-order` (39-53, unchanged)
- `main-rule` (55-67) — `lhopital_zero_taylor` only
- `taylor-coeff` (69-78) — new section for `lhopital_zero_taylor_coeff`
- `example-sin` (80-86) — `sin x/x → 1`
- `example-vanishing` (88-100) — `(1-cos x)/x → 0`, now covering through `end LHopitalOQ04`

No content deleted; existing summaries/mathContext preserved and redistributed to the finer-grained sections. `meta.json` is 12.4 KB, well under the 60 KB cap.