### PR TITLE
Enrich fibonacci-identities-oq-02-oq-02-oq-01: add header section + fix annotation startLine (4->5)

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-02-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-02-oq-01/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "ann-fiboq020201-1",
     "proofId": "fibonacci-identities-oq-02-oq-02-oq-01",
-    "range": { "startLine": 3, "endLine": 48 },
+    "range": { "startLine": 4, "endLine": 48 },
     "type": "concept",
     "title": "Naming the Cofactor: the Companion Sequence",
     "content": "**Framing.** The parent entry proves that the first-kind Lucas sequence $U_n(P,Q)$ satisfies $U_n \\mid U_{2n}$, but says nothing about the quotient. Here we name it. Every first-kind sequence has a twin — the *second-kind (companion) sequence* $V_n(P,Q)$ obeying the same recurrence with seed $V_0=2,\\ V_1=P$ — and the two are locked together by the **doubling law** $U_{2n}=U_n\\,V_n$. This is the recurrence analogue of $\\sin 2\\theta = 2\\sin\\theta\\cos\\theta$: the pair $(U,V)$ plays the role of $(\\sin,\\cos)$. For $(P,Q)=(1,-1)$ the companion is the Lucas number sequence $2,1,3,4,7,\\dots$ and the law becomes the classical $F_{2n}=F_n L_n$.",

--- a/src/data/proofs/fibonacci-identities-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-02-oq-01/meta.json
@@ -81,6 +81,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Docstring, Imports, and Namespace",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Module docstring stating the open question (explicit cofactor of Uₙ in U_{2n}?), the companion sequence Vₙ and the two doubling identities it answers with, and the honesty note recovering Nat.fib_two_mul as a corollary. Imports Mathlib and the parent file, opens its namespace.",
+      "mathContext": "$V_0=2,\\ V_1=P,\\ V_{n+2}=P\\,V_{n+1}-Q\\,V_n$; goal: $U_{2n}=U_nV_n$ and $U_{2n+1}=U_{n+1}^2-QU_n^2$."
+    },
+    {
       "id": "companion-definition",
       "title": "The Companion Lucas Sequence Vₙ",
       "startLine": 50,


### PR DESCRIPTION
## Summary
- `sections` covered only lines 50-166 (the definition and three theorems); lines 1-45 (module docstring, imports, namespace) had no section. Adds a `header` section covering that range — 4 sections -> 5.
- Also fixed a pre-existing `annotations.json` `startLine` bug the build flagged as "No Lean construct found at line 3": `ann-fiboq020201-1` pointed at a blank line (3) instead of the docstring start (4).

No changes to Lean source; JSON-only enrichment pass. `meta.json` (12.5 KB) remains well under the size guardrails.

## Test plan
- [x] `jq empty` validates both JSON files
- [x] `pnpm build` no longer reports a "No Lean construct found" error for this slug
- [x] Manually cross-checked the new section's line range against the Lean source