### PR TITLE
fix(erdos-1108): remove phantom axiom names, correct drifted line ranges

### DIFF
--- a/src/data/proofs/erdos-1108/annotations.json
+++ b/src/data/proofs/erdos-1108/annotations.json
@@ -26,8 +26,8 @@
     "id": "ann-e1108-factorial-sums",
     "proofId": "erdos-1108",
     "range": {
-      "startLine": 43,
-      "endLine": 46
+      "startLine": 39,
+      "endLine": 42
     },
     "type": "definition",
     "title": "Factorial Sums Set",
@@ -49,8 +49,8 @@
     "id": "ann-e1108-factorial-examples",
     "proofId": "erdos-1108",
     "range": {
-      "startLine": 50,
-      "endLine": 68
+      "startLine": 46,
+      "endLine": 64
     },
     "type": "concept",
     "title": "Factorial Sum Examples",
@@ -72,8 +72,8 @@
     "id": "ann-e1108-powerful-def",
     "proofId": "erdos-1108",
     "range": {
-      "startLine": 76,
-      "endLine": 79
+      "startLine": 72,
+      "endLine": 75
     },
     "type": "definition",
     "title": "Powerful Numbers",
@@ -95,8 +95,8 @@
     "id": "ann-e1108-one-powerful",
     "proofId": "erdos-1108",
     "range": {
-      "startLine": 83,
-      "endLine": 86
+      "startLine": 79,
+      "endLine": 82
     },
     "type": "concept",
     "title": "1 is Powerful",
@@ -119,7 +119,7 @@
     "proofId": "erdos-1108",
     "range": {
       "startLine": 96,
-      "endLine": 102
+      "endLine": 104
     },
     "type": "definition",
     "title": "Main Question Sets",
@@ -142,11 +142,11 @@
     "proofId": "erdos-1108",
     "range": {
       "startLine": 106,
-      "endLine": 113
+      "endLine": 111
     },
     "type": "concept",
     "title": "Question 1 (OPEN)",
-    "content": "**erdos_1108_kth_powers_open**: For each k >= 2, does FactorialSums contain only finitely many k-th powers? This is axiomatized as a Prop since the answer is unknown.",
+    "content": "**Question 1**: For each k >= 2, does FactorialSums contain only finitely many k-th powers? This is recorded only as a documentation comment in the source — it is not formalized as a Lean axiom, definition, or theorem.",
     "mathContext": "Even the case k=2 (squares) is open. It's not known if there are infinitely many squares expressible as sums of distinct factorials.",
     "significance": "key",
     "relatedConcepts": [
@@ -156,7 +156,6 @@
     ],
     "prerequisites": [
       "number theory",
-      "Lean 4 axiom declarations",
       "Diophantine analysis"
     ]
   },
@@ -164,12 +163,12 @@
     "id": "ann-e1108-question2",
     "proofId": "erdos-1108",
     "range": {
-      "startLine": 115,
-      "endLine": 121
+      "startLine": 106,
+      "endLine": 111
     },
     "type": "concept",
     "title": "Question 2 (OPEN)",
-    "content": "**erdos_1108_powerful_open**: Does FactorialSums contain only finitely many powerful numbers? Also axiomatized as an unknown Prop.",
+    "content": "**Question 2**: Does FactorialSums contain only finitely many powerful numbers? Also recorded only as a documentation comment — not formalized as a Lean declaration.",
     "mathContext": "Powerful numbers are rarer than perfect powers, so this might be easier, but it's still open.",
     "significance": "key",
     "relatedConcepts": [
@@ -179,7 +178,6 @@
     ],
     "prerequisites": [
       "number theory",
-      "Lean 4 axiom declarations",
       "multiplicative number theory"
     ]
   },
@@ -187,12 +185,12 @@
     "id": "ann-e1108-brindza-erdos",
     "proofId": "erdos-1108",
     "range": {
-      "startLine": 125,
-      "endLine": 133
+      "startLine": 113,
+      "endLine": 117
     },
     "type": "concept",
     "title": "Brindza-Erdős Bound (1991)",
-    "content": "**brindza_erdos_bound**: For fixed r terms, if n1! + ... + nr! is powerful, then n1 <= C(r). The largest index is bounded.",
+    "content": "**Brindza-Erdős bound**: For fixed r terms, if n1! + ... + nr! is powerful, then n1 <= C(r). The largest index is bounded. This is documented as a comment describing the known result — it is not formalized as a Lean theorem or axiom in this file.",
     "mathContext": "This is a partial result: for any fixed r, only finitely many r-term factorial sums can be powerful. But r is unbounded in the main question.",
     "significance": "key",
     "relatedConcepts": [
@@ -210,8 +208,8 @@
     "id": "ann-e1108-mahler",
     "proofId": "erdos-1108",
     "range": {
-      "startLine": 140,
-      "endLine": 158
+      "startLine": 119,
+      "endLine": 136
     },
     "type": "concept",
     "title": "Mahler's Related Problem",

--- a/src/data/proofs/erdos-1108/meta.json
+++ b/src/data/proofs/erdos-1108/meta.json
@@ -58,7 +58,7 @@
     "historicalContext": "This problem was asked by Erdős at Oberwolfach in 1988, motivated by discussions with Mahler shortly before Mahler's death that same year. Mahler had posed a related question about finite sums of powers of a base k: for k >= 5, does A_k contain only finitely many squares?\n\nMahler showed that for k <= 4, there are infinitely many squares in A_k. For k >= 5, he found only one square: 1 + 7 + 7² + 7³ = 400 = 20².\n\nBrindza and Erdős (1991) proved a partial result: for any fixed number r of terms, if n₁! + ... + nᵣ! is powerful, then the largest term n₁ is bounded by a constant depending only on r. This doesn't resolve the main question because the number of terms is unbounded.",
     "problemStatement": "**Erdős Problem #1108**: Let $A = \\left\\{ \\sum_{n \\in S} n! : S \\subset \\mathbb{N} \\text{ finite} \\right\\}$ be the set of all finite sums of distinct factorials.\n\n**Question 1 (OPEN)**: For each $k \\geq 2$, does $A$ contain only finitely many $k$-th powers?\n\n**Question 2 (OPEN)**: Does $A$ contain only finitely many powerful numbers?\n\n**Status**: OPEN\n\n**Known Result** (Brindza-Erdős 1991): For any fixed $r$, if $n_1! + \\cdots + n_r!$ is powerful with $n_1 \\geq \\cdots \\geq n_r$, then $n_1 \\leq C(r)$ for some constant depending only on $r$.",
     "text": "Does the set of finite sums of distinct factorials contain only finitely many k-th powers (for k >= 2)? Does it contain only finitely many powerful numbers?",
-    "proofStrategy": "We formalize this open problem and its known partial results:\n\n1. **Define FactorialSums**: The set A of all finite sums of distinct factorials.\n\n2. **Define IsPowerful**: A number is powerful if every prime factor appears with exponent >= 2.\n\n3. **Axiomatize the open questions**: Since the answers are unknown, we axiomatize the questions as Props.\n\n4. **State Brindza-Erdős bound**: For fixed number of terms, the largest factorial index is bounded.\n\n5. **State Mahler's related results**: For bases k <= 4, infinitely many squares; for k >= 5, only one known square.\n\n6. **Prove small examples**: We verify that 1 is both a square factorial sum and powerful.",
+    "proofStrategy": "We formalize this open problem and its known partial results:\n\n1. **Define FactorialSums**: The set A of all finite sums of distinct factorials.\n\n2. **Define IsPowerful**: A number is powerful if every prime factor appears with exponent >= 2.\n\n3. **Document the open questions**: Since the answers are unknown, both questions are recorded as prose comments — they are not formalized as Lean axioms, definitions, or theorems.\n\n4. **State Brindza-Erdős bound**: For fixed number of terms, the largest factorial index is bounded (documented in a comment, not formalized).\n\n5. **State Mahler's related results**: For bases k <= 4, infinitely many squares; for k >= 5, only one known square.\n\n6. **Prove small examples**: We verify that 1 is both a square factorial sum and powerful.",
     "keyInsights": [
       "**Factorial sums**: The set A = {0, 1, 2, 3, 6, 7, 8, 9, 24, 25, ...} consists of all numbers expressible as sums of distinct factorials. This is analogous to binary representation but with factorials.",
       "**Powerful numbers**: Numbers like 1, 4, 8, 9, 16, 25, 27, 36 where every prime factor has exponent >= 2. They are products of squares and cubes.",
@@ -83,56 +83,56 @@
     {
       "id": "factorial-sums",
       "title": "Factorial Sums Definition",
-      "startLine": 37,
-      "endLine": 69,
+      "startLine": 33,
+      "endLine": 64,
       "summary": "Definition of FactorialSums set and membership examples.",
       "mathContext": "Formal definition: Definition of FactorialSums set and membership examples."
     },
     {
       "id": "powerful",
       "title": "Powerful Numbers",
-      "startLine": 70,
-      "endLine": 93,
+      "startLine": 66,
+      "endLine": 94,
       "summary": "Definition and examples of powerful numbers.",
       "mathContext": "Formal definition: Definition and examples of powerful numbers."
     },
     {
       "id": "main-sets",
       "title": "Main Question Sets",
-      "startLine": 94,
-      "endLine": 103,
+      "startLine": 96,
+      "endLine": 104,
       "summary": "Definitions of k-th powers and powerful numbers in factorial sums.",
       "mathContext": "Formal definition: Definitions of k-th powers and powerful numbers in factorial sums."
     },
     {
       "id": "open-questions",
       "title": "The Open Questions",
-      "startLine": 104,
-      "endLine": 122,
-      "summary": "Axiomatization of both open questions.",
-      "mathContext": "Axiomatized: Axiomatization of both open questions."
+      "startLine": 106,
+      "endLine": 111,
+      "summary": "Statement of both open questions as documentation comments (not formalized as axioms or Lean declarations).",
+      "mathContext": "Documented, not axiomatized: both open questions are recorded in prose; no axiom or Prop encodes either one."
     },
     {
       "id": "partial-results",
       "title": "Known Partial Results",
-      "startLine": 123,
-      "endLine": 139,
-      "summary": "Brindza-Erdős bound and related open problem #398.",
-      "mathContext": "Bound: Brindza-Erdős bound and related open problem #398."
+      "startLine": 113,
+      "endLine": 117,
+      "summary": "Brindza-Erdős bound and related open problem #398 (documented in a comment, not formalized as a Lean declaration).",
+      "mathContext": "Documented, not formalized: Brindza-Erdős bound and related open problem #398."
     },
     {
       "id": "mahler",
       "title": "Mahler's Related Problem",
-      "startLine": 140,
-      "endLine": 159,
+      "startLine": 119,
+      "endLine": 136,
       "summary": "Mahler's problem on power sums and his example.",
       "mathContext": "Mathematical content: Mahler's problem on power sums and his example."
     },
     {
       "id": "small-cases",
       "title": "Small Cases",
-      "startLine": 160,
-      "endLine": 171,
+      "startLine": 138,
+      "endLine": 150,
       "summary": "Proofs that sets are nonempty (1 is in both).",
       "mathContext": "Verified: Proofs that sets are nonempty (1 is in both)."
     }


### PR DESCRIPTION
## Gallery integrity fix — erdos-1108

**Proof**: erdos-1108 (Factorial Sums and Perfect Powers)

### Problem

`meta.json`/`annotations.json` invented three Lean declarations that never
exist in `Proofs/Erdos1108Problem.lean` — `erdos_1108_kth_powers_open`,
`erdos_1108_powerful_open`, `brindza_erdos_bound` — and claimed both OPEN
questions were "axiomatized as a Prop". In reality these are plain prose
comments (`/- ... -/`) with no accompanying `axiom`/`def`/`theorem`.
`axiomCount: 0` was already correct; only the narrative overclaimed a
formalization step that never happened (same pattern as #42251/#42253 for
erdos-1088).

Additionally, sections/annotations from "open-questions" onward had drifted
onto the wrong code:
- `partial-results` (labeled "Brindza-Erdős bound") pointed at Mahler's
  `PowerSums` definition and example theorems.
- `mahler` (labeled "Mahler's Related Problem") pointed at the Small-Cases
  and Summary theorems instead.
- `small-cases` pointed past EOF into the Summary theorem.
- Several annotation ranges (factorial-sums, powerful-def, one-powerful,
  question1/2, brindza-erdos, mahler) were off by several lines, including
  one (`ann-e1108-one-powerful`) that pointed at `four_is_powerful` instead
  of `one_is_powerful`.

### Fix

- Rewrote `proofStrategy` step 3 and the `open-questions`/`partial-results`
  section prose to say the questions/bound are documented in comments, not
  axiomatized.
- Removed the three phantom declaration names from `annotations.json`
  content fields.
- Re-anchored every drifted `sections[]`/annotation `range` to the actual
  line numbers in the Lean source (verified by direct read + grep).

No change to `axiomCount`, `sorries`, `theoremCount`, or `definitionCount` —
all four were already correct (13 theorems, 5 defs, 0 axioms, 0 sorries).

## Test plan
- [x] `node -e "JSON.parse(...)"` on both files — valid JSON
- [x] `grep -n "erdos_1108_kth_powers_open\|erdos_1108_powerful_open\|brindza_erdos_bound\|^axiom"` on the Lean file — 0 hits, confirming these were phantom
- [x] Manually cross-checked every section/annotation range against the actual file line numbers

Discovered during gallery integrity audit (reserve mode, round-robin re-serve).