### PR TITLE
Enrich lucas-sequence-degree2-identities-oq-01: split sections into 5 real boundaries

### DIFF
--- a/src/data/proofs/lucas-sequence-degree2-identities-oq-01/meta.json
+++ b/src/data/proofs/lucas-sequence-degree2-identities-oq-01/meta.json
@@ -28,9 +28,17 @@
       "id": "fast-doubling-pair",
       "title": "Section I: The Fast-Doubling Pair (U_double_pair)",
       "startLine": 42,
+      "endLine": 73,
+      "summary": "U_double_pair: U₂ₙ = Uₙ·Vₙ and U₂ₙ₊₁ = Uₙ₊₁² − Q·Uₙ² by one simultaneous induction on n; the successor step expands the recurrence at the doubled index, feeds in the inductive pair, eliminates Vₖ by V_eq, and closes by ring.",
+      "mathContext": "$U_{2n}=U_n V_n,\\ U_{2n+1}=U_{n+1}^2-Q U_n^2$, by simultaneous induction pairing the two doubled indices."
+    },
+    {
+      "id": "fundamental-doubling",
+      "title": "Extracting U_two_mul and U_two_mul_add_one",
+      "startLine": 74,
       "endLine": 82,
-      "summary": "U_double_pair: U₂ₙ = Uₙ·Vₙ and U₂ₙ₊₁ = Uₙ₊₁² − Q·Uₙ² by one simultaneous induction on n; the successor step expands the recurrence at the doubled index, feeds in the inductive pair, eliminates Vₖ by V_eq, and closes by ring. U_two_mul and U_two_mul_add_one extract the two components.",
-      "mathContext": "$U_{2n}=U_n V_n,\\ U_{2n+1}=U_{n+1}^2-Q U_n^2$; e.g. Fibonacci $F_6=8=F_3 L_3=2\\cdot4$."
+      "summary": "U_two_mul and U_two_mul_add_one extract the two components of U_double_pair as standalone named theorems — U₂ₙ = Uₙ·Vₙ is the OQ-01 first target.",
+      "mathContext": "$U_{2n}=U_n V_n$; e.g. Fibonacci $F_6=8=F_3 L_3=2\\cdot4$."
     },
     {
       "id": "companion-doubling",
@@ -42,11 +50,19 @@
     },
     {
       "id": "specializations",
-      "title": "Section III: Named Specializations and Numeric Checks",
+      "title": "Section III: Named Specializations",
       "startLine": 111,
-      "endLine": 133,
-      "summary": "fib_doubling F₂ₙ = Fₙ·Lₙ and lucas_doubling L₂ₙ = Lₙ² − 2·(−1)ⁿ at (1,−1), pell_doubling U₂ₙ = Uₙ·Vₙ at (2,−1), plus kernel-decide numeric sanity checks (F₆=8, L₆=18).",
+      "endLine": 125,
+      "summary": "fib_doubling F₂ₙ = Fₙ·Lₙ and lucas_doubling L₂ₙ = Lₙ² − 2·(−1)ⁿ at (P,Q)=(1,−1), pell_doubling U₂ₙ = Uₙ·Vₙ at (2,−1) — the general doubling laws instantiated at the classical parameter pairs.",
       "mathContext": "The (P,Q)=(1,−1) and (2,−1) instances of the general doubling laws."
+    },
+    {
+      "id": "numeric-check",
+      "title": "Kernel-Decide Numeric Sanity Check",
+      "startLine": 126,
+      "endLine": 133,
+      "summary": "Verifies F₆ = 8, L₆ = 18, F₆ = F₃·L₃, and L₆ = L₃² − 2·(−1)³ by kernel `decide` at (P,Q) = (1,−1), n = 3 — a concrete check of both doubling formulas at once.",
+      "mathContext": "$F_6=8=F_3L_3=2\\cdot4,\\ L_6=18=L_3^2-2(-1)^3=16+2$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for lucas-sequence-degree2-identities-oq-01 (quality 96 → 100, sections quality component 6/10 → 10/10).

The entry's `sections` array had only 3 entries, two of which merged multiple theorems: `fast-doubling-pair` (42-82) combined the induction `U_double_pair` with its two named extractions `U_two_mul`/`U_two_mul_add_one`, and `specializations` (111-133) combined the three named instances (Fibonacci/Lucas/Pell) with the separate numeric sanity-check example. Split into 5 sections along real boundaries, matching the granularity already present in `annotations.json`:

- `fast-doubling-pair` (42-73) — `U_double_pair` (the induction) only
- `fundamental-doubling` (74-82) — new, extraction of `U_two_mul`/`U_two_mul_add_one`
- `companion-doubling` (83-110, unchanged) — `V_two_mul`/`V_two_mul_add_one`
- `specializations` (111-125) — the three named instances only
- `numeric-check` (126-133) — new, the kernel-`decide` sanity check

No content deleted; summaries redistributed to the finer-grained sections. `meta.json` is 13.6 KB, well under the 60 KB cap.