### PR TITLE
audit(erdos-1101): fix phantom axiom prose + reanchor sections/annotations

### DIFF
--- a/src/data/proofs/erdos-1101/annotations.json
+++ b/src/data/proofs/erdos-1101/annotations.json
@@ -143,11 +143,11 @@
     "proofId": "erdos-1101",
     "range": {
       "startLine": 85,
-      "endLine": 90
+      "endLine": 88
     },
     "type": "concept",
     "title": "Conjecture 1: No Polynomial Growth",
-    "content": "Erdős conjectured that **NO good sequence can have polynomial growth** uₙ = O(n^k).\n\nThe intuition is that polynomial-growth sequences don't have enough 'room' between their terms to satisfy the gap bound. This is axiomatized because it remains an **OPEN problem**.",
+    "content": "Erdős conjectured that **NO good sequence can have polynomial growth** uₙ = O(n^k).\n\nThe intuition is that polynomial-growth sequences don't have enough 'room' between their terms to satisfy the gap bound. This is stated here as a comment (not a Lean declaration) because it remains an **OPEN problem**.",
     "significance": "key",
     "relatedConcepts": [
       "polynomial growth",
@@ -165,8 +165,8 @@
     "id": "ann-e1101-yes-subexp",
     "proofId": "erdos-1101",
     "range": {
-      "startLine": 92,
-      "endLine": 98
+      "startLine": 89,
+      "endLine": 93
     },
     "type": "concept",
     "title": "Conjecture 2: Sub-exponential Growth Possible",
@@ -188,8 +188,8 @@
     "id": "ann-e1101-existence",
     "proofId": "erdos-1101",
     "range": {
-      "startLine": 107,
-      "endLine": 111
+      "startLine": 101,
+      "endLine": 104
     },
     "type": "concept",
     "title": "Erdős's Existence Theorem",
@@ -211,8 +211,8 @@
     "id": "ann-e1101-sieve-bound",
     "proofId": "erdos-1101",
     "range": {
-      "startLine": 113,
-      "endLine": 121
+      "startLine": 105,
+      "endLine": 107
     },
     "type": "concept",
     "title": "Sieve Theory Lower Bound",

--- a/src/data/proofs/erdos-1101/meta.json
+++ b/src/data/proofs/erdos-1101/meta.json
@@ -49,7 +49,7 @@
     "originalContributions": [
       "Formal statement of the OPEN Erdős problem in Lean 4",
       "Definition of 'good sequence' predicate with all four conditions",
-      "Axiomatization of both conjectures (no polynomial, yes subexponential)",
+      "Documentation of both conjectures (no polynomial, yes subexponential) as comments, not yet formalized as Lean declarations",
       "Statement of Erdős's existence theorem and sieve lower bound",
       "Connection to Problem #208 (prime squares conjecture)"
     ],
@@ -105,25 +105,25 @@
       "id": "conjectures",
       "title": "The Main Conjectures",
       "startLine": 77,
-      "endLine": 99,
-      "summary": "Axioms stating no polynomial good sequence exists but subexponential does.",
-      "mathContext": "Axioms stating no polynomial good sequence exists but subexponential does."
+      "endLine": 93,
+      "summary": "Comments stating the two open conjectures: no polynomial good sequence exists, but a subexponential one does. Not formalized as axioms or declarations.",
+      "mathContext": "Comments stating the two open conjectures: no polynomial good sequence exists, but a subexponential one does. Not formalized as axioms or declarations."
     },
     {
       "id": "known-results",
       "title": "Known Results",
-      "startLine": 100,
-      "endLine": 122,
-      "summary": "Erdős's existence theorem and the sieve theory lower bound.",
-      "mathContext": "Erdős's existence theorem and the sieve theory lower bound."
+      "startLine": 94,
+      "endLine": 107,
+      "summary": "Comments describing Erdős's existence theorem and the sieve theory lower bound; not formalized as declarations.",
+      "mathContext": "Comments describing Erdős's existence theorem and the sieve theory lower bound; not formalized as declarations."
     },
     {
       "id": "prime-squares",
       "title": "Related Problem: Prime Squares",
-      "startLine": 123,
+      "startLine": 108,
       "endLine": 123,
-      "summary": "Connection to Problem #208 about the sequence of prime squares.",
-      "mathContext": "Connection to Problem #208 about the sequence of prime squares."
+      "summary": "Defines primeSquares (squares of consecutive primes) and comments connecting it to Problem #208's strong form.",
+      "mathContext": "Defines primeSquares (squares of consecutive primes) and comments connecting it to Problem #208's strong form."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-1101 (Erdős Problem #1101: Good Sequences and Gaps in Sieved Integers)

**Problem**: The Lean source states its two open conjectures ("no polynomial good sequence exists", "a subexponential one does") as plain `/- ... -/` comments, not `axiom` declarations — `axiomCount` is correctly `0`. However:

- `meta.json` section `conjectures` summary/mathContext said "**Axioms** stating no polynomial good sequence exists but subexponential does."
- `originalContributions` listed "**Axiomatization** of both conjectures".
- `annotations.json` annotation `ann-e1101-no-polynomial` said the conjecture "**is axiomatized** because it remains an OPEN problem."

None of this is true — there is no axiom in the file, and the top-level `assumptions` field already correctly says "0 axioms, 0 sorries... Previously cited axiom names have been removed from the Lean source", but the sections/annotations were never updated to match.

Additionally, 3 of 6 sections and 4 of 10 annotations had line-range drift:
- `prime-squares` section pointed only at line 123 (`end Erdos1101`), missing its actual content (the `primeSquares` def and Problem #208 discussion at lines 108-121).
- `known-results` section (100-122) swallowed the `prime-squares` section's content.
- Annotation `ann-e1101-existence` ("Erdős's Existence Theorem") pointed at lines 107-111, which is actually the tail of the Sieve Lower Bound comment + the Related Problem header — the real Existence Theorem text is at 101-104.
- Annotation `ann-e1101-sieve-bound` ("Sieve Theory Lower Bound") pointed at lines 113-121, which is the `primeSquares` def and Problem #208 comment, not the sieve bound text (105-107).

## Evidence

`grep -n axiom proofs/Proofs/Erdos1101Problem.lean` → 0 hits. File has 5 `def`s, 0 `theorem`s, 0 `sorry`, matching `axiomCount:0`/`theoremCount:0`/`sorries:0` already in meta.json — only the prose and line ranges were stale.

## Fix

- Reworded section summaries/mathContext and `originalContributions` to describe the conjectures as comments/documentation, not axioms.
- Reworded the annotation content to drop "is axiomatized".
- Re-anchored `conjectures` (77-93), `known-results` (94-107), `prime-squares` (108-123) sections and the 4 drifted annotation ranges to their actual content.

No Lean source changes; `axiomCount`, `theoremCount`, `sorries`, `definitionCount` were already correct.

---
Discovered during gallery integrity audit (reserve-mode re-verification).