### PR TITLE
audit: mark erdos-1099 complete (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9900,8 +9900,8 @@
     },
     "erdos-1099": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:03:32Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T16:47:33Z",
       "result": "clean"
     },
     "erdos-11": {


### PR DESCRIPTION
## Summary
5th audit cycle re-serve of erdos-1099 (Divisor Ratio Sum Boundedness). Verified:
- theoremCount 36, definitionCount 10 match actual declarations (including `private theorem`)
- No `sorry`, no bare `axiom` declarations, no True stubs
- Single `native_decide` use (divisorRatios_two) fully disclosed in `assumptions` field and annotations
- Section/annotation line ranges spot-checked against file — no drift
- meta.json already honestly discloses that `erdos_1099`/`vose_liminf_bounded` use a trivial constant witness (n=2), and the true liminf statement is captured as an unproved `Prop` (`erdos_1099_strong_liminf`) rather than a false claim

No issues found. Marking complete as clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)