### PR TITLE
Gallery integrity: erdos-1077 stale 'stated as axiom' Status line

### DIFF
--- a/proofs/Proofs/Erdos1077Problem.lean
+++ b/proofs/Proofs/Erdos1077Problem.lean
@@ -35,7 +35,7 @@ showing the correct answer is Θ(n^α) vertices.
 ## Status
 - [x] Problem statement formalized
 - [x] D-balanced property defined
-- [x] Correct answer stated as axiom
+- [x] Correct answer stated in documentation (no axiom — 0 axioms in this file)
 - [ ] Full constructive proof
 
 ## References

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9691,10 +9691,10 @@
       "result": "issues-fixed"
     },
     "erdos-1077": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:32Z",
-      "result": "clean"
+      "lastAudited": "2026-07-23T17:08:08Z",
+      "result": "issues-fixed"
     },
     "erdos-1078": {
       "agentId": "auditor-agent-2026-05-01",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-1077
**Problem**: The Lean source's own Status checklist claims "Correct answer stated as axiom" but the file has 0 axioms.

## Evidence

**Lean file (before)**: `- [x] Correct answer stated as axiom` (line 38 of the module docstring)
**Reality**: `grep -n axiom` finds only that one prose line — no `axiom` declarations exist. PR #30275 (2026-06-25) stripped the `**Axiom (Jiang-Longbrake 2025 - ...)**` doc-comment labels down to plain `/- ... -/` prose comments, but the Status checklist header wasn't updated to match.

`meta.json` was already accurate (`axiomCount: 0`, `assumptions: "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source..."`) — only the in-source docstring had drifted. All other counts verified exact: 4 defs, 6 theorems, 0 sorries, 0 axioms; no phantom declaration names in `originalContributions`/section prose.

## Fix

Updated the Status line to reflect reality: `- [x] Correct answer stated in documentation (no axiom — 0 axioms in this file)`.

---
Discovered during gallery integrity audit (reserve mode, queue drained).