### PR TITLE
Enrich erdos-396-oq-04-oq-01: sanity-checks annotation + child cross-ref

### DIFF
--- a/src/data/proofs/erdos-396-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01/annotations.json
@@ -121,5 +121,27 @@
       "induction",
       "inequalities"
     ]
+  },
+  {
+    "id": "ann-e396oq04oq01-sanity",
+    "proofId": "erdos-396-oq-04-oq-01",
+    "range": {
+      "startLine": 176,
+      "endLine": 187
+    },
+    "type": "context",
+    "title": "Sanity checks",
+    "content": "Three closed-form numeric checks anchor the abstract results to concrete Catalan numbers: `catalanRatio 0 = 1` reflects `catalan 1 = catalan 0` (both equal 1); `catalanRatio 2 = 5/2` reflects `catalan 3 = (5/2)·catalan 2`, i.e. $5 = \\frac{5}{2}\\cdot 2$; and `catalan 3 < 4^3` (i.e. $5 < 64$) instantiates `catalan_lt_four_pow` at $n = 3$, showing the bound is far from tight for small $n$ even though the ratio itself is already close to its limiting value.",
+    "mathContext": "$r(0) = 1,\\ r(2) = \\tfrac52,\\ \\mathrm{catalan}\\,3 = 5 < 4^3 = 64$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Catalan numbers",
+      "numeric verification",
+      "catalanRatio",
+      "growth bound"
+    ],
+    "prerequisites": [
+      "arithmetic"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-396-oq-04-oq-01/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01/meta.json
@@ -114,6 +114,11 @@
       "targetId": "erdos-396",
       "relationship": "ancestor",
       "description": "Root problem: descending factorials dividing central binomial coefficients, whose base case rests on the Catalan numbers studied here."
+    },
+    {
+      "targetId": "erdos-396-oq-04-oq-01-oq-01",
+      "relationship": "child",
+      "description": "Child OQ: studies the deficit δ n = 4 − r n = 6/(n+2) itself, showing it is exactly the tail of a harmonic series — δ n → 0 termwise, yet the cumulative deficit ∑_{k<n} δ k diverges, the precise discrete reason Catalan growth carries a polynomial correction below 4^n."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary
- Add an annotation for lines 176-187 ("Sanity checks"), the only section in `sections[]` that had no corresponding entry in `annotations.json`
- Add the missing `child` crossReference to `erdos-396-oq-04-oq-01-oq-01` (the harmonic-deficit follow-up), which already links back here as `parent`

## Notes
Two other open PRs (#42356, #42329) touch `keyInsights`/`sections` on this same entry's meta.json — this PR only touches `crossReferences` in meta.json and adds a new item to annotations.json, so it should merge cleanly alongside either.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — both files valid JSON
- [x] File sizes well under the 60 KB cap (meta.json 10 KB, annotations.json 6.9 KB)
- [x] `pnpm build` gallery-data validation steps passed ("Search index checks passed", enrichment summary) before an unrelated `tsc: command not found` env failure