### PR TITLE
audit(erdos-258): fix phantom axiom prose for unformalized solved variants

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12060,9 +12060,9 @@
     },
     "erdos-258": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:03:33Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T17:14:02Z",
+      "result": "issues-fixed"
     },
     "erdos-259": {
       "agentId": "auditor-2026-05-02-erdos-259",

--- a/src/data/proofs/erdos-258/meta.json
+++ b/src/data/proofs/erdos-258/meta.json
@@ -41,12 +41,12 @@
       }
     ],
     "originalContributions": [
-      "Formal statement of both solved variants of Erdős Problem #258",
+      "Documentation (in comments, not Lean declarations) of both solved variants of Erdős Problem #258",
       "Definition of divisor function τ(n) and product prefixes",
       "Statement of the open general case as a Prop",
       "Verified computations of τ for small values"
     ],
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 108,
     "assumptions": "No mathematical axioms and 0 sorries; previously cited axiom names were removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean. Compiler-trust disclosure: the concrete divisor-count facts (tau_one, tau_two, tau_six, tau_twelve, tau_prime_five, tau_prime_seven, and the tau_pos_* positivity witnesses) are discharged with native_decide, so their axiom footprint includes Lean.ofReduceBool (kernel reduction trusts the compiled decision procedure). These are finite decidable computations and add no mathematical assumption; leanFile.axiomCount remains 0 (no literal axiom declarations).",
     "theoremCount": 9,
@@ -56,7 +56,7 @@
     "historicalContext": "Erdős Problem #258 asks about the irrationality of certain infinite series involving the divisor function τ(n). The problem has a rich history spanning several decades of number theory research.\n\nThe general question (arbitrary sequences with aₙ → ∞) remains OPEN. However, two important special cases have been solved:\n\n1. **Monotone sequences** (Erdős-Straus, 1971): If the sequence (aₙ) is monotone increasing, then the sum is always irrational.\n\n2. **Constant/power case** (Erdős, 1948): The series Σ τ(n)/tⁿ is irrational for any integer t ≥ 2. This connects to Lambert series, which have applications throughout analytic number theory.\n\nThe problem was formalized in Lean as part of Google DeepMind's Formal Conjectures project.",
     "problemStatement": "Let $a_1, a_2, \\ldots$ be a sequence of positive integers with $a_n \\to \\infty$. Is the sum\n$$\\sum_{n=1}^{\\infty} \\frac{\\tau(n)}{a_1 \\cdot a_2 \\cdots a_n}$$\nirrational, where $\\tau(n)$ denotes the number of positive divisors of $n$?\n\n**Status**: The general case is OPEN. Solved for monotone sequences (Erdős-Straus 1971) and for $\\sum \\tau(n)/t^n$ with $t \\geq 2$ (Erdős 1948).",
     "text": "Is the sum of τ(n)/(a₁·...·aₙ) irrational for sequences with aₙ → ∞? Solved for monotone sequences by Erdős-Straus (1971).",
-    "proofStrategy": "We formalize the problem statement and both solved variants:\n\n1. **Define the divisor function** τ(n) = |{d : d divides n}|, using Mathlib's `Nat.divisors.card`.\n\n2. **Define product prefixes** a₁ · a₂ · ... · aₙ using Finset.prod.\n\n3. **State the monotone variant** as an axiom: if (aₙ) is monotone and tends to infinity, the sum is irrational.\n\n4. **State the power variant** as an axiom: Σ τ(n)/tⁿ is irrational for t ≥ 2.\n\n5. **Define the open conjecture** as a Prop for the general case.\n\nWe also verify τ(n) for small values using `native_decide`.",
+    "proofStrategy": "We formalize the problem statement and the open conjecture, and document the two solved variants in comments (not as Lean declarations):\n\n1. **Define the divisor function** τ(n) = |{d : d divides n}|, using Mathlib's `Nat.divisors.card`.\n\n2. **Define product prefixes** a₁ · a₂ · ... · aₙ using Finset.prod.\n\n3. **Document the monotone variant** in a comment: if (aₙ) is monotone and tends to infinity, the sum is irrational. Not formalized as an axiom or theorem.\n\n4. **Document the power variant** in a comment: Σ τ(n)/tⁿ is irrational for t ≥ 2. Not formalized as an axiom or theorem.\n\n5. **Define the open conjecture** as a Prop for the general case.\n\nWe also verify τ(n) for small values using `native_decide`.",
     "keyInsights": [
       "**Divisor function τ(n)**: Counts divisors of n. For example: τ(1)=1, τ(6)=4, τ(p)=2 for prime p. It's multiplicative: τ(mn) = τ(m)τ(n) when gcd(m,n) = 1.",
       "**Why monotonicity matters**: The Erdős-Straus proof for monotone sequences uses that the denominators grow predictably. Without monotonicity, the denominators can fluctuate wildly, making the analysis much harder.",
@@ -96,7 +96,7 @@
       "title": "Main Results",
       "startLine": 60,
       "endLine": 94,
-      "summary": "The two solved variants: monotone (Erdős-Straus) and power case (Erdős), stated as axioms."
+      "summary": "The two solved variants: monotone (Erdős-Straus) and power case (Erdős), documented in comments only — not stated as axioms or theorems."
     },
     {
       "id": "open-problem",


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-258

**Problem**: `meta.json` claimed the two solved variants of Erdős Problem #258 (Erdős-Straus monotone case, 1971; Erdős power case, 1948) were "stated as axioms" / had a "formal statement" in the Lean source. In reality `Proofs/Erdos258Problem.lean` never declares them as `axiom` or `theorem` — they exist only as prose inside comment blocks (lines 61-82). `grep -n '^axiom' Proofs/Erdos258Problem.lean` returns 0 hits.

## Evidence

**meta.json claimed**:
- `originalContributions[0]`: "Formal statement of both solved variants of Erdős Problem #258"
- `proofStrategy`: "State the monotone variant as an axiom..." / "State the power variant as an axiom..."
- `sections[main-results].summary`: "...stated as axioms"
- `meta.axiomCount`: 1 (conflicting with `leanFile.axiomCount: 0`)

**Lean file shows**: no `axiom` keyword anywhere in the file; the monotone/power variants exist only as prose in `/- ... -/` comment blocks with no corresponding declaration. `leanFile.axiomCount: 0` and the file's own `assumptions` text already correctly note "No mathematical axioms and 0 sorries" — the top-level `meta.axiomCount: 1` and the contribution/strategy prose just hadn't been updated to match.

## Fix

- `meta.axiomCount`: 1 → 0 (matches `leanFile.axiomCount` and actual source)
- `originalContributions[0]`, `proofStrategy` (steps 3-4), and the `main-results` section summary reworded to say the two variants are documented in comments only, not formalized as axioms/theorems.

Badge (`wip`) and status (`axiomatized`) were already appropriately conservative and are unchanged.

---
Discovered during gallery integrity audit (reserve-mode re-verification, queue fully drained at 4811/4811).