### PR TITLE
Enrich geometric-series-oq-01-oq-02: cover header, split Grandi section into 2 real boundaries

### DIFF
--- a/src/data/proofs/geometric-series-oq-01-oq-02/meta.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-02/meta.json
@@ -68,6 +68,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Docstring: Regularity and Strict Extension",
+      "startLine": 1,
+      "endLine": 58,
+      "summary": "States OQ-02 of the parent — regularity (convergence ⟹ Cesàro summability to the same value) and strict extension (a divergent series can still be Cesàro summable) — and previews M1/M2 and the closed form used for Grandi. Imports Mathlib and the parent GeometricSeriesOQ01, opens the namespace and Finset, Filter.",
+      "mathContext": "Regularity: convergence $\\Rightarrow$ $(C,1)$-summable to the same limit. Strictness: Grandi is $(C,1)$-summable to $1/2$ though divergent."
+    },
+    {
       "id": "definitions",
       "title": "Cesàro Mean and Summability",
       "startLine": 59,
@@ -84,11 +92,19 @@
       "mathContext": "Consistency of Cesàro summation with ordinary convergence, via Filter.Tendsto.cesaro."
     },
     {
-      "id": "grandi",
-      "title": "M2: Grandi — (C,1) Summable but Divergent",
+      "id": "grandi-closed-form",
+      "title": "Grandi's Partial Sums: Closed Form and Bound",
       "startLine": 92,
+      "endLine": 124,
+      "summary": "sum_grandiPartial: the closed form ∑_{k<n} Sₖ = (n − Sₙ)/2 by induction on the parent's grandi_double_sum. grandi_partial_abs_le_one: |Sₙ| ≤ 1. grandiCesaroMean_eq: the resulting closed form for the Cesàro mean σₙ = (n − Sₙ)/(2n).",
+      "mathContext": "$\\sum_{k<n} S_k = (n - S_n)/2$, $|S_n|\\le 1$, so $\\sigma_n = (n-S_n)/(2n)$."
+    },
+    {
+      "id": "grandi-convergence-divergence",
+      "title": "M2: Grandi — (C,1) Summable but Divergent",
+      "startLine": 126,
       "endLine": 187,
-      "summary": "sum_grandiPartial closed form; grandiCesaroMean_tendsto (σₙ → 1/2); grandi_partial_not_tendsto (divergent partial sums); cesaro_strictly_extends_convergence.",
+      "summary": "grandiCesaroMean_tendsto: σₙ → 1/2 via the ε–N bound |σₙ − 1/2| = |Sₙ|/(2n) ≤ 1/(2n). grandi_partial_not_tendsto: the partial sums themselves diverge (even subsequence → 0, odd → 1, contradicting uniqueness of limits). cesaro_strictly_extends_convergence packages both into the strict-extension statement.",
       "mathContext": "Grandi's series witnesses that (C,1) summability strictly extends convergence."
     }
   ],


### PR DESCRIPTION
## Summary
- Sole remaining quality gap (96/100): sections count, 3 sections leaving the module docstring (lines 1-58) uncovered and bundling 4 theorems (sum_grandiPartial, grandi_partial_abs_le_one, grandiCesaroMean_eq, grandiCesaroMean_tendsto, grandi_partial_not_tendsto, cesaro_strictly_extends_convergence) into one "grandi" section.
- Added a header section (1-58) for the module docstring/imports/namespace/open.
- Split the "grandi" section at a real boundary: closed-form/bound lemmas (92-124) vs. the convergence/divergence results (126-187).
- No content deleted; existing summaries preserved and redistributed.
- Quality score: 96 → 100 (sections 3→5; all other dimensions already at max).

Verified JSON validity with `python3 -m json.tool`.