### PR TITLE
audit: re-serve erdos-241 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11928,8 +11928,8 @@
     },
     "erdos-241": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:03:33Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T17:34:43Z",
       "result": "clean"
     },
     "erdos-242": {


### PR DESCRIPTION
## Audit Result: clean

**Proof**: erdos-241 (Maximum Size of B₃ Sets)

Re-verified in reserve-mode round-robin. Grepped `proofs/Proofs/Erdos241Problem.lean` directly:

- theorems: 13 (matches `theoremCount: 13`)
- axioms: 0 (matches `axiomCount: 0`)
- sorries: 0 real declarations (the single `sorry` grep hit at line 129 is a docstring mention — "no `sorry` and no `axiom`" — not an actual term)
- native_decide: 0
- lineCount: 228 (exact match)

`originalContributions`/`assumptions` honestly disclose that the Bose-Chowla lower bound and Green's upper bound (the f(N) ~ N^(1/3) asymptotics) are documented as prose only, not axiomatized — consistent with `status: axiomatized`, `badge: wip`, `erdosProblemStatus: open`.

This confirms the axiom-masking fix from issue cluster #483 (merged via #40009/#40003) is holding — no regression.

Only tracker metadata changes (`audit-tracker.json`); no source or meta.json edits needed.

---
Discovered during gallery integrity audit (reserve-mode re-serve, queue fully drained 4811/4811 audited, 0 issues).