### PR TITLE
Enrich geometric-series-oq-01-oq-03-oq-01: cover module header in sections

### DIFF
--- a/src/data/proofs/geometric-series-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-03-oq-01/meta.json
@@ -17,6 +17,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module header: statement, approach, and honest scope",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "The docstring states Abel's theorem in the regular direction at full strength — every convergent series ∑ₙ aₙ is Abel summable to its ordinary sum, generalizing the parent's geometric-only case — and previews the four-step approach: on-disc summability, the Mathlib left-limit, synthesis into AbelSummableTo, and the geometric consistency check. An 'Honest Scope' note flags this as a packaging result around Mathlib's Abel limit theorem, not a rederivation of it. Imports Mathlib.Analysis.Complex.AbelLimit and the parent file, and opens the GeometricSeriesOQ01OQ03 namespace.",
+      "mathContext": "$\\sum_n a_n = L \\implies \\sum_n a_n x^n \\to L \\text{ as } x \\to 1^-$"
+    },
+    {
       "id": "summable-on-disc",
       "title": "On-disc summability of the power series",
       "startLine": 55,


### PR DESCRIPTION
## Summary
- `sections[]` previously started at line 55, leaving the module docstring (theorem statement, four-step approach outline, "Honest Scope" note) and the imports/namespace/open lines (1-54) uncovered.
- Adds a `header` section (lines 1-54) summarizing the docstring's statement of Abel's theorem in the regular direction, its four-step proof plan, and the honest-scope framing as a packaging result around Mathlib's Abel limit theorem.

No other fields changed; file stays well under the 60 KB size cap (~16.9 KB).

## Test plan
- [x] `meta.json` validated as well-formed JSON
- [x] `pnpm build` gallery-JSON validation pass produced no errors for this entry
