### PR TITLE
Enrich godel-first-incompleteness-oq01-oq-02: add Rosser sibling cross-reference

### DIFF
--- a/src/data/proofs/godel-first-incompleteness-oq01-oq-02/meta.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01-oq-02/meta.json
@@ -100,6 +100,11 @@
       "targetId": "godel-first-incompleteness-oq01-oq-04",
       "relationship": "related",
       "description": "Sibling formalizing the Diagonal Lemma / fixed-point theorem underlying the object-level self-reference used here."
+    },
+    {
+      "targetId": "godel-first-incompleteness-oq01-oq-01",
+      "relationship": "related",
+      "description": "Rosser's alternative repair: reaches undecidability from plain consistency alone (no ω-consistency clause), via a proof-length comparison sentence rather than this entry's object-level fixed point — the comparison this entry's openQuestions calls for."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary
- The entry's own `conclusion.openQuestions` calls for comparison with the Rosser-sentence sibling (`…OQ01OQ01`), but that sibling was missing from the structured `crossReferences` array. Added it.
- Otherwise the entry was already at quality target (5 annotations with `mathContext`/`significance`/`relatedConcepts`, full section coverage of all 167 lines, 5 genuine `keyInsights`, rich `conclusion`) — no filler added per the size-guardrail/diminishing-returns rule.

## Test plan
- [x] `python3 -c "import json; json.load(open('src/data/proofs/godel-first-incompleteness-oq01-oq-02/meta.json'))"` — valid JSON
- [x] `wc -c` meta.json = 14316 bytes, well under the 60KB cap