### PR TITLE
audit: tracker — erdos-236 issues-fixed (#42392)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11891,9 +11891,9 @@
     },
     "erdos-236": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:03:33Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T17:40:13Z",
+      "result": "issues-fixed"
     },
     "erdos-237": {
       "agentId": "auditor-cycle-20-batch",
@@ -31907,5 +31907,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-07-21T13:59:50Z"
+  "lastUpdated": "2026-07-23T17:40:13Z"
 }


### PR DESCRIPTION
Records the erdos-236 audit outcome (issues-fixed, see #42392) in
src/data/proofs/audit-tracker.json.

Discovered during gallery integrity audit.