### PR TITLE
Audit: erdos-196 (reserve) — re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11548,8 +11548,8 @@
     },
     "erdos-196": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:03:33Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T17:43:58Z",
       "result": "clean"
     },
     "erdos-197": {


### PR DESCRIPTION
## Summary
Reserve-mode re-audit of erdos-196 (Erdős #196: monotone 4-term APs in permutations). Queue is fully drained (0 unaudited), so re-verifying an already-audited entry.

## Verification
- 0 axioms, 0 sorries, no True stubs, no native_decide in `Proofs/Erdos196Problem.lean`
- `theoremCount: 4`, `definitionCount: 10`, `lineCount: 155` all match the actual file (matches both `meta` and `leanFile` blocks, no drift)
- Main conjecture `ErdosProblem196` is correctly stated as an unproven `def` (genuinely OPEN per erdosproblems.com), not disguised as an axiom
- `status: "axiomatized"` / `badge: "wip"` correctly reflect Tier C scaffold status — assumptions text explicitly discloses "0 axioms, 0 sorries... main result is not yet fully formalized"
- Sections/prose reference only declarations that exist in the file; no phantom axiom/theorem names

No issues found — marking clean in the audit tracker.

## Test plan
- [x] Read meta.json and Lean source side by side
- [x] Confirmed counts via manual read of the 156-line file
- [x] Checked for open/conflicting PRs on erdos-196 (none found)