### PR TITLE
Enrich herons-formula-oq-06: cover header docstring, add sibling-comparison insight

### DIFF
--- a/src/data/proofs/herons-formula-oq-06/meta.json
+++ b/src/data/proofs/herons-formula-oq-06/meta.json
@@ -19,7 +19,8 @@
       "The whole geometric inequality collapses, after clearing denominators and applying Heron, to a single symmetric polynomial inequality on the positive Ravi variables.",
       "The product–AM–GM inequality (x+y)(y+z)(z+x) ≥ 8xyz has a one-line sum-of-squares certificate, which simultaneously proves the inequality and pins down the equality case.",
       "Working with Area² (not Area) keeps the proof free of square roots everywhere except the single definitional step Area² = s(s-a)(s-b)(s-c) (Real.sq_sqrt).",
-      "The equality case comes for free from the same certificate: since each summand x(y-z)², y(z-x)², z(x-y)² is nonnegative, the sum vanishes iff x = y = z, i.e. iff the triangle is equilateral — so one SOS identity proves both R ≥ 2r and its sharpness."
+      "The equality case comes for free from the same certificate: since each summand x(y-z)², y(z-x)², z(x-y)² is nonnegative, the sum vanishes iff x = y = z, i.e. iff the triangle is equilateral — so one SOS identity proves both R ≥ 2r and its sharpness.",
+      "The Ravi substitution x = s-a, y = s-b, z = s-c is the same change of variables the sibling herons-formula-oq-04 uses for the isoperimetric inequality, but the two entries need genuinely different AM-GM cores afterward — the pairwise-product form (y+z)(z+x)(x+y) ≥ 8xyz here, versus the three-term xyz ≤ ((x+y+z)/3)³ there — showing the substitution alone does not determine which inequality closes the proof."
     ],
     "prerequisites": [
       "Heron's formula Area² = s(s-a)(s-b)(s-c)",
@@ -55,6 +56,14 @@
     }
   ],
   "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Docstring deriving Euler's inequality R ≥ 2r algebraically from the radius formulas down to the Ravi-substituted AM-GM consequence (y+z)(z+x)(x+y) ≥ 8xyz, followed by the imports, namespace EulerInequalityHeronOQ06, and open Real.",
+      "mathContext": "The chain R ≥ 2r ⟺ abc·s ≥ 8·Area² ⟺ abc ≥ 8(s-a)(s-b)(s-c) ⟺ (y+z)(z+x)(x+y) ≥ 8xyz is laid out in full before any Lean code."
+    },
     {
       "id": "amgm-core",
       "title": "The Algebraic Core — an SOS form of AM-GM",


### PR DESCRIPTION
## Summary
- `sections` previously left lines 1-44 (module docstring + imports/namespace) uncovered — first section started at line 46. Added a `header` section for 1-44.
- Added a 5th `keyInsight` comparing this entry's AM-GM core to the sibling `herons-formula-oq-04`: both use the same Ravi substitution, but need genuinely *different* AM-GM inequalities afterward (pairwise-product form here vs. three-term form there). Verified the sibling's actual lemma names (`amgm_three_nonneg`/`amgm_three_eq_iff`) before writing this to avoid overclaiming an "identical lemma" relationship that isn't true.
- Brings quality score 96 → 100 (was capped by `sections.length == 4` and `keyInsights.length == 4`).

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — valid JSON
- [x] `npx tsx scripts/enricher/find-targets.ts --json --all` confirms quality 96 → 100
- [x] `wc -c` meta.json = 12841 bytes, well under the 60KB cap