### PR TITLE
research(erdos30-wip01): h(22)–h(28) — chained span dichotomy, optimal 7-mark ruler, mod-4 double count; table complete h(0..28)

### DIFF
--- a/proofs/Proofs/Erdos30WIP01.lean
+++ b/proofs/Proofs/Erdos30WIP01.lean
@@ -1129,6 +1129,7 @@ private theorem isSidonSet_of_sidonCheck {A : Finset ℕ} (hA : SidonCheck A) :
   fun a b c d ha hb hc hd hab hcd heq => hA a ha b hb c hc d hd hab hcd heq
 
 set_option maxRecDepth 100000 in
+set_option maxHeartbeats 4000000 in
 /-- Kernel search for `h(22)`: no five interior elements `B ⊆ {1,…,21}` extend the
 pinned endpoints `{0, 22}` to a 7-element Sidon set (`C(21,5) = 20349` candidates). -/
 private theorem no_sidon_extension_zero_twentytwo :
@@ -1233,6 +1234,7 @@ theorem sidonNumber_twentytwo : sidonNumber 22 = 6 := by
       _ ≤ sidonNumber 22 := sidonNumber_ge_card (by decide) isSidonSet_0_1_4_10_12_17
 
 set_option maxRecDepth 100000 in
+set_option maxHeartbeats 4000000 in
 /-- Kernel search for `h(23)`: no five interior elements `B ⊆ {1,…,22}` extend the
 pinned endpoints `{0, 23}` to a 7-element Sidon set (`C(22,5) = 26334` candidates). -/
 private theorem no_sidon_extension_zero_twentythree :
@@ -1332,6 +1334,7 @@ theorem sidonNumber_twentythree : sidonNumber 23 = 6 := by
       _ ≤ sidonNumber 23 := sidonNumber_ge_card (by decide) isSidonSet_0_1_4_10_12_17
 
 set_option maxRecDepth 100000 in
+set_option maxHeartbeats 4000000 in
 /-- Kernel search for `h(24)`: no five interior elements `B ⊆ {1,…,23}` extend the
 pinned endpoints `{0, 24}` to a 7-element Sidon set (`C(23,5) = 33649` candidates). -/
 private theorem no_sidon_extension_zero_twentyfour :
@@ -1469,5 +1472,198 @@ theorem sidonNumber_twentyseven : sidonNumber 27 = 7 := by
     nlinarith [hm, h8]
   · calc 7 = ({0, 1, 4, 10, 18, 23, 25} : Finset ℕ).card := by decide
       _ ≤ sidonNumber 27 := sidonNumber_ge_card (by decide) isSidonSet_0_1_4_10_18_23_25
+
+/-! ### `h(28) = 7` — the third wall falls to a mod-4 class double count
+
+At `N = 28` the counting bound goes slack against an 8-element set for the first
+time (`8·7 = 56 = 2·28`), the `h(10)`/`h(21)` parity trick is silent (a perfect
+8-mark ruler of span `28` has difference sum `1 + ⋯ + 28 = 406`, *even*), and the
+`h(15)` mod-3 count is inconclusive (class sizes `{4,3,1}` satisfy it).  The
+`h(16)`/`h(22..24)` span dichotomy would need a `C(27,6) ≈ 296k`-candidate kernel
+search.  None of that is necessary: counting differences **mod 4** kills the
+configuration outright, with no search at all.
+
+An 8-element Sidon set in `{0,…,28}` has `C(8,2) = 28` distinct positive
+differences inside `{1,…,28}`, hence *exhausting* it — a perfect 8-mark ruler is
+forced automatically (no span dichotomy needed).  Among the `56` signed nonzero
+differences `{±1,…,±28}` exactly `14` are `≡ 0 (mod 4)` and exactly `14` are
+`≡ 2 (mod 4)`.  Writing `c₀,c₁,c₂,c₃` for the sizes of the residue classes of `A`
+mod `4`:
+
+* ordered pairs with `a − b ≡ 0 (mod 4)` are the same-class pairs:
+  `∑ᵣ cᵣ(cᵣ − 1) = 14`, i.e. `∑ᵣ cᵣ² = 22`;
+* ordered pairs with `a − b ≡ 2 (mod 4)` pair class `r` with class `r + 2`:
+  `∑ᵣ cᵣ·c_{r+2 mod 4} = 2(c₀c₂ + c₁c₃) = 14`.
+
+With `c₀ + c₁ + c₂ + c₃ = 8` the first constraint forces the multiset of class
+sizes to be `{4,2,1,1}` or `{3,3,2,0}`, and for every arrangement of either,
+`c₀c₂ + c₁c₃ ∈ {6, 9}` — never `7`.  Contradiction, so `h(28) = 7`. -/
+
+/-- **No 8-element Sidon set fits in `{0,…,28}`** — the perfect-ruler mod-4 double
+count.  Such a set would have `56` signed differences exhausting `{±1,…,±28}`,
+hence exactly `14` ordered pairs with `a − b ≡ 0 (mod 4)` and exactly `14` with
+`a − b ≡ 2 (mod 4)`; but with `c₀ + c₁ + c₂ + c₃ = 8` the class-size counts
+`∑ cᵣ(cᵣ − 1) = 14` and `∑ cᵣ·c_{r+2 mod 4} = 14` are jointly unsatisfiable. -/
+set_option maxHeartbeats 4000000 in
+theorem no_sidon_card_eight_range_twentynine (A : Finset ℕ)
+    (hsub : A ⊆ Finset.range 29) (hA : IsSidonSet A) : A.card ≤ 7 := by
+  by_contra hcard
+  rw [not_le] at hcard
+  -- Counting caps the size at 8, so a violating set has exactly 8 elements.
+  have hup : A.card * A.card ≤ 56 + A.card := by
+    have := sidon_card_sq_le 28 hsub hA; omega
+  have hc8 : A.card = 8 := by
+    have h8 : 8 ≤ A.card := hcard
+    by_contra hne
+    have h9 : 9 ≤ A.card := by omega
+    have hmul : 9 * A.card ≤ A.card * A.card := Nat.mul_le_mul h9 (le_refl A.card)
+    omega
+  have hfull : Set.InjOn diffMap ↑A.offDiag := diffMap_injOn hA
+  have hoffcard : A.offDiag.card = 56 := by rw [Finset.offDiag_card, hc8]
+  -- `diffMap` sends the off-diagonal onto the 56 nonzero integers of `[-28, 28]`.
+  have hmapsFull : ∀ p ∈ A.offDiag, diffMap p ∈ (Finset.Icc (-28 : ℤ) 28).erase 0 := by
+    intro p hp
+    rw [Finset.mem_offDiag] at hp
+    obtain ⟨hp1, hp2, hpne⟩ := hp
+    have hb1 := hsub hp1; have hb2 := hsub hp2
+    rw [Finset.mem_range] at hb1 hb2
+    rw [Finset.mem_erase, Finset.mem_Icc]
+    simp only [diffMap]
+    exact ⟨fun h => hpne (by omega), by omega, by omega⟩
+  have hcardErase : ((Finset.Icc (-28 : ℤ) 28).erase 0).card = 56 := by
+    rw [Finset.card_erase_of_mem (by decide), Int.card_Icc]; decide
+  have himageFull : A.offDiag.image diffMap = (Finset.Icc (-28 : ℤ) 28).erase 0 := by
+    refine Finset.eq_of_subset_of_card_le (fun d hd => ?_) ?_
+    · rw [Finset.mem_image] at hd
+      obtain ⟨p, hp, rfl⟩ := hd
+      exact hmapsFull p hp
+    · rw [Finset.card_image_of_injOn hfull, hoffcard]
+      exact le_of_eq hcardErase
+  -- `T0` = the off-diagonal pairs whose difference is divisible by `4`.
+  set T0 := A.offDiag.filter (fun p => diffMap p % 4 = 0) with hT0
+  have hT0sub : T0 ⊆ A.offDiag := Finset.filter_subset _ _
+  have hinjT0 : Set.InjOn diffMap ↑T0 := hfull.mono (Finset.coe_subset.mpr hT0sub)
+  -- Its image is the 14 nonzero multiples of 4 in `[-28, 28]`, so `|T0| = 14`.
+  have hT0img : T0.image diffMap
+      = ((Finset.Icc (-28 : ℤ) 28).erase 0).filter (fun d => d % 4 = 0) := by
+    rw [hT0, ← Finset.filter_image (p := fun d : ℤ => d % 4 = 0), himageFull]
+  have hT0card : T0.card = 14 := by
+    rw [← Finset.card_image_of_injOn hinjT0, hT0img]
+    decide
+  -- `T2` = the off-diagonal pairs whose difference is `≡ 2 (mod 4)`.
+  set T2 := A.offDiag.filter (fun p => diffMap p % 4 = 2) with hT2
+  have hT2sub : T2 ⊆ A.offDiag := Finset.filter_subset _ _
+  have hinjT2 : Set.InjOn diffMap ↑T2 := hfull.mono (Finset.coe_subset.mpr hT2sub)
+  -- Its image is the 14 values `≡ 2 (mod 4)` in `[-28, 28]`, so `|T2| = 14`.
+  have hT2img : T2.image diffMap
+      = ((Finset.Icc (-28 : ℤ) 28).erase 0).filter (fun d => d % 4 = 2) := by
+    rw [hT2, ← Finset.filter_image (p := fun d : ℤ => d % 4 = 2), himageFull]
+  have hT2card : T2.card = 14 := by
+    rw [← Finset.card_image_of_injOn hinjT2, hT2img]
+    decide
+  -- Structurally, `T0` is the set of same-residue pairs, fibered by the class.
+  have hT0eq : T0 = A.offDiag.filter (fun p => p.1 % 4 = p.2 % 4) := by
+    rw [hT0]
+    refine Finset.filter_congr (fun p hp => ?_)
+    simp only [diffMap]
+    omega
+  have hfiber0 : ∀ r : ℕ, T0.filter (fun p => p.1 % 4 = r)
+      = (A.filter (fun a => a % 4 = r)).offDiag := by
+    intro r
+    ext p
+    rw [hT0eq]
+    simp only [Finset.mem_filter, Finset.mem_offDiag]
+    constructor
+    · rintro ⟨⟨⟨h1, h2, hne⟩, heqr⟩, h1r⟩
+      exact ⟨⟨h1, h1r⟩, ⟨h2, by omega⟩, hne⟩
+    · rintro ⟨⟨h1, h1r⟩, ⟨h2, h2r⟩, hne⟩
+      exact ⟨⟨⟨h1, h2, hne⟩, by omega⟩, h1r⟩
+  -- `T2` fibers into full class products: first coordinate in class `r`, second
+  -- in class `(r + 2) % 4` (distinct classes, so off-diagonality is automatic).
+  have hfiber2 : ∀ r s : ℕ, s = (r + 2) % 4 → T2.filter (fun p => p.1 % 4 = r)
+      = (A.filter (fun a => a % 4 = r)) ×ˢ (A.filter (fun a => a % 4 = s)) := by
+    intro r s hs
+    ext p
+    rw [hT2]
+    simp only [Finset.mem_filter, Finset.mem_offDiag, Finset.mem_product]
+    constructor
+    · rintro ⟨⟨⟨h1, h2, hne⟩, hd2⟩, h1r⟩
+      refine ⟨⟨h1, h1r⟩, h2, ?_⟩
+      simp only [diffMap] at hd2
+      omega
+    · rintro ⟨⟨h1, h1r⟩, h2, h2s⟩
+      refine ⟨⟨⟨h1, h2, ?_⟩, ?_⟩, h1r⟩
+      · omega
+      · simp only [diffMap]
+        omega
+  -- Fiberwise counts: `|A| = ∑ cᵣ`, `|T0| = ∑ cᵣ(cᵣ − 1)`, `|T2| = ∑ cᵣ·c_{r+2 mod 4}`.
+  have hfib : A.card = ∑ r ∈ Finset.range 4, (A.filter (fun a => a % 4 = r)).card :=
+    Finset.card_eq_sum_card_fiberwise
+      (fun a _ => Finset.mem_range.mpr (Nat.mod_lt _ (by norm_num)))
+  have hT0fib : T0.card = ∑ r ∈ Finset.range 4, (T0.filter (fun p => p.1 % 4 = r)).card :=
+    Finset.card_eq_sum_card_fiberwise
+      (fun p _ => Finset.mem_range.mpr (Nat.mod_lt _ (by norm_num)))
+  have hT2fib : T2.card = ∑ r ∈ Finset.range 4, (T2.filter (fun p => p.1 % 4 = r)).card :=
+    Finset.card_eq_sum_card_fiberwise
+      (fun p _ => Finset.mem_range.mpr (Nat.mod_lt _ (by norm_num)))
+  have hcount0 : (14 : ℕ) = ∑ r ∈ Finset.range 4,
+      ((A.filter (fun a => a % 4 = r)).card * (A.filter (fun a => a % 4 = r)).card
+        - (A.filter (fun a => a % 4 = r)).card) := by
+    rw [← hT0card, hT0fib]
+    refine Finset.sum_congr rfl (fun r _ => ?_)
+    rw [hfiber0 r, Finset.offDiag_card]
+  have hcount2 : (14 : ℕ) = ∑ r ∈ Finset.range 4,
+      ((A.filter (fun a => a % 4 = r)).card
+        * (A.filter (fun a => a % 4 = (r + 2) % 4)).card) := by
+    rw [← hT2card, hT2fib]
+    refine Finset.sum_congr rfl (fun r _ => ?_)
+    rw [hfiber2 r ((r + 2) % 4) rfl, Finset.card_product]
+  -- Extract the three Diophantine constraints and refute them by finite case analysis.
+  have hsum8 : (A.filter (fun a => a % 4 = 0)).card + (A.filter (fun a => a % 4 = 1)).card
+      + (A.filter (fun a => a % 4 = 2)).card + (A.filter (fun a => a % 4 = 3)).card = 8 := by
+    have h := hfib
+    rw [hc8] at h
+    simp only [Finset.sum_range_succ, Finset.sum_range_zero, zero_add] at h
+    omega
+  have hsame : ((A.filter (fun a => a % 4 = 0)).card * (A.filter (fun a => a % 4 = 0)).card
+        - (A.filter (fun a => a % 4 = 0)).card)
+      + ((A.filter (fun a => a % 4 = 1)).card * (A.filter (fun a => a % 4 = 1)).card
+        - (A.filter (fun a => a % 4 = 1)).card)
+      + ((A.filter (fun a => a % 4 = 2)).card * (A.filter (fun a => a % 4 = 2)).card
+        - (A.filter (fun a => a % 4 = 2)).card)
+      + ((A.filter (fun a => a % 4 = 3)).card * (A.filter (fun a => a % 4 = 3)).card
+        - (A.filter (fun a => a % 4 = 3)).card) = 14 := by
+    have h := hcount0
+    simp only [Finset.sum_range_succ, Finset.sum_range_zero, zero_add] at h
+    exact h.symm
+  have hcross : (A.filter (fun a => a % 4 = 0)).card * (A.filter (fun a => a % 4 = 2)).card
+      + (A.filter (fun a => a % 4 = 1)).card * (A.filter (fun a => a % 4 = 3)).card
+      + (A.filter (fun a => a % 4 = 2)).card * (A.filter (fun a => a % 4 = 0)).card
+      + (A.filter (fun a => a % 4 = 3)).card * (A.filter (fun a => a % 4 = 1)).card = 14 := by
+    have h := hcount2
+    simp only [Finset.sum_range_succ, Finset.sum_range_zero, zero_add,
+      Nat.reduceAdd, Nat.reduceMod] at h
+    exact h.symm
+  generalize hg0 : (A.filter (fun a => a % 4 = 0)).card = c0 at hsum8 hsame hcross
+  generalize hg1 : (A.filter (fun a => a % 4 = 1)).card = c1 at hsum8 hsame hcross
+  generalize hg2 : (A.filter (fun a => a % 4 = 2)).card = c2 at hsum8 hsame hcross
+  generalize hg3 : (A.filter (fun a => a % 4 = 3)).card = c3 at hsum8 hsame hcross
+  have hb0 : c0 ≤ 8 := by omega
+  have hb1 : c1 ≤ 8 := by omega
+  have hb2 : c2 ≤ 8 := by omega
+  have hb3 : c3 ≤ 8 := by omega
+  interval_cases c0 <;> interval_cases c1 <;> interval_cases c2 <;>
+    interval_cases c3 <;> omega
+
+/-- `h(28) = 7` — the third wall.  Counting is slack (`56 = 2·28`), parity is silent
+(`1 + ⋯ + 28 = 406` even), and mod-3 is inconclusive; the mod-4 class double count
+(`no_sidon_card_eight_range_twentynine`) rules out the forced perfect 8-mark ruler,
+and the span-25 optimal 7-mark Golomb ruler still attains `7`. -/
+theorem sidonNumber_twentyeight : sidonNumber 28 = 7 := by
+  refine le_antisymm ?_ ?_
+  · exact sidonNumber_le_of_card
+      (fun A hsub hA => no_sidon_card_eight_range_twentynine A hsub hA)
+  · calc 7 = ({0, 1, 4, 10, 18, 23, 25} : Finset ℕ).card := by decide
+      _ ≤ sidonNumber 28 := sidonNumber_ge_card (by decide) isSidonSet_0_1_4_10_18_23_25
 
 end Erdos30

--- a/proofs/Proofs/Erdos30WIP01.lean
+++ b/proofs/Proofs/Erdos30WIP01.lean
@@ -1102,4 +1102,372 @@ theorem sidonNumber_sixteen : sidonNumber 16 = 5 := by
   · calc 5 = ({0, 1, 4, 9, 11} : Finset ℕ).card := by decide
       _ ≤ sidonNumber 16 := sidonNumber_ge_card (by decide) isSidonSet_0_1_4_9_11
 
+/-! ### `h(22) = h(23) = h(24) = 6` and `h(25) = h(26) = h(27) = 7` — the table to 27
+
+Past `h(21)` the parity wall is again silent (a 7-element Sidon set in `{0,…,N}` for
+`N ∈ {22, 23, 24}` misses `N − 21` differences, and no small congruence pins them
+down), but the span dichotomy of `h(16)` *scales*: sliding a hypothetical 7-element
+Sidon set down by its minimum either reduces the span below the previous obstruction
+or pins both endpoints `{0, N}`, leaving a kernel search over the
+`C(N−1, 5)` five-element interior subsets — `20349`, `26334`, `33649` candidates for
+`N = 22, 23, 24`.  The three searches chain: each span-reduction case appeals to the
+obstruction proved just before it, with the merged `h(21)` parity theorem
+(`no_sidon_card_seven_range_twentytwo`) anchoring the chain.
+
+At `N = 25` the **optimal 7-mark Golomb ruler** `{0, 1, 4, 10, 18, 23, 25}` (span 25,
+differences `{1,…,25} \ {11, 12, 16, 20}`) finally fits, and the counting bound blocks
+an 8-element set throughout `25 ≤ N ≤ 27` (`8² = 64 > 2N + 8`), so
+`h(25) = h(26) = h(27) = 7`.  The table `h(0), …, h(27)` is now complete; the next
+wall is `N = 28`, where counting goes slack for eight (`64 = 2·28 + 8`) and the
+8-mark ruler `{0, 1, 4, 9, 15, 22, 32, 34}` is still far away (span 34). -/
+
+/-- Converse bridge to `sidonCheck_of_isSidonSet`: the bounded predicate implies the
+unbounded one (any violating quadruple lies in `A` anyway), so explicit witnesses can
+be certified by `decide` instead of an `|A|⁴`-case `rcases`/`omega` sweep. -/
+private theorem isSidonSet_of_sidonCheck {A : Finset ℕ} (hA : SidonCheck A) :
+    IsSidonSet A :=
+  fun a b c d ha hb hc hd hab hcd heq => hA a ha b hb c hc d hd hab hcd heq
+
+set_option maxRecDepth 100000 in
+/-- Kernel search for `h(22)`: no five interior elements `B ⊆ {1,…,21}` extend the
+pinned endpoints `{0, 22}` to a 7-element Sidon set (`C(21,5) = 20349` candidates). -/
+private theorem no_sidon_extension_zero_twentytwo :
+    ∀ B ∈ (Finset.Icc 1 21).powersetCard 5,
+      ¬ SidonCheck (insert 0 (insert 22 B)) := by
+  decide +kernel
+
+/-- **No 7-element Sidon set fits in `{0,…,22}`.**  Span dichotomy: after sliding the
+minimum to `0`, either the set lies in `{0,…,21}` (killed by the `h(21)` parity
+obstruction) or its span is exactly `22` and the five interior elements fall to the
+kernel search. -/
+theorem no_sidon_card_seven_range_twentythree (A : Finset ℕ)
+    (hsub : A ⊆ Finset.range 23) (hA : IsSidonSet A) : A.card ≤ 6 := by
+  by_contra hcard
+  rw [not_le] at hcard
+  -- Counting caps the size at 7, so a violating set has exactly 7 elements.
+  have hup : A.card * A.card ≤ 44 + A.card := by
+    have := sidon_card_sq_le 22 hsub hA; omega
+  have hc7 : A.card = 7 := by
+    by_contra hne
+    have h8 : 8 ≤ A.card := by omega
+    have hmul : 8 * A.card ≤ A.card * A.card := Nat.mul_le_mul h8 (le_refl A.card)
+    omega
+  have hne : A.Nonempty := Finset.card_pos.mp (by omega)
+  set m := A.min' hne with hm
+  have hmle : ∀ x ∈ A, m ≤ x := fun x hx => A.min'_le x hx
+  have hbound : ∀ x ∈ A, x ≤ 22 := fun x hx => by
+    have := hsub hx; rw [Finset.mem_range] at this; omega
+  -- Slide the set down by its minimum.
+  set A' := A.image (fun x => x - m) with hA'
+  have hinj : Set.InjOn (fun x => x - m) ↑A := by
+    intro x hx y hy hxy
+    have hx' := hmle x (Finset.mem_coe.mp hx)
+    have hy' := hmle y (Finset.mem_coe.mp hy)
+    have hxy' : x - m = y - m := hxy
+    omega
+  have hA'card : A'.card = 7 := by
+    rw [hA', Finset.card_image_of_injOn hinj, hc7]
+  have hA'sidon : IsSidonSet A' := by
+    intro a b c d ha hb hc hd hab hcd heq
+    rw [hA'] at ha hb hc hd
+    simp only [Finset.mem_image] at ha hb hc hd
+    obtain ⟨a₀, ha₀, rfl⟩ := ha
+    obtain ⟨b₀, hb₀, rfl⟩ := hb
+    obtain ⟨c₀, hc₀, rfl⟩ := hc
+    obtain ⟨d₀, hd₀, rfl⟩ := hd
+    have hma := hmle a₀ ha₀; have hmb := hmle b₀ hb₀
+    have hmc := hmle c₀ hc₀; have hmd := hmle d₀ hd₀
+    obtain ⟨h1, h2⟩ := hA a₀ b₀ c₀ d₀ ha₀ hb₀ hc₀ hd₀ (by omega) (by omega) (by omega)
+    exact ⟨by omega, by omega⟩
+  have hzero : (0 : ℕ) ∈ A' := by
+    rw [hA']
+    exact Finset.mem_image.mpr ⟨m, A.min'_mem hne, Nat.sub_self m⟩
+  have hA'ne : A'.Nonempty := ⟨0, hzero⟩
+  have hA'bound : ∀ x ∈ A', x ≤ 22 := by
+    intro x hx
+    rw [hA'] at hx
+    obtain ⟨x₀, hx₀, hx₀eq⟩ := Finset.mem_image.mp hx
+    have hb := hbound x₀ hx₀
+    have hx₀eq' : x₀ - m = x := hx₀eq
+    omega
+  rcases Nat.lt_or_ge (A'.max' hA'ne) 22 with hM | hM
+  · -- Span ≤ 21: the slid set lives in {0,…,21}; the h(21) parity obstruction applies.
+    have hsub' : A' ⊆ Finset.range 22 := fun x hx => by
+      rw [Finset.mem_range]
+      exact lt_of_le_of_lt (A'.le_max' x hx) hM
+    have := no_sidon_card_seven_range_twentytwo A' hsub' hA'sidon
+    omega
+  · -- Span = 22: both endpoints pinned; the five interior elements fall to `decide`.
+    have h22 : (22 : ℕ) ∈ A' := by
+      have hMle : A'.max' hA'ne ≤ 22 := hA'bound _ (A'.max'_mem hA'ne)
+      have hMeq : A'.max' hA'ne = 22 := le_antisymm hMle hM
+      rw [← hMeq]
+      exact A'.max'_mem hA'ne
+    set B := (A'.erase 0).erase 22 with hB
+    have h22' : (22 : ℕ) ∈ A'.erase 0 := Finset.mem_erase.mpr ⟨by omega, h22⟩
+    have hrecon : insert 0 (insert 22 B) = A' := by
+      rw [hB, Finset.insert_erase h22', Finset.insert_erase hzero]
+    have hBcard : B.card = 5 := by
+      rw [hB, Finset.card_erase_of_mem h22', Finset.card_erase_of_mem hzero, hA'card]
+    have hBsub : B ⊆ Finset.Icc 1 21 := by
+      intro x hx
+      rw [hB] at hx
+      have hx22 := (Finset.mem_erase.mp hx).1
+      have hx' := Finset.mem_of_mem_erase hx
+      have hx0 := (Finset.mem_erase.mp hx').1
+      have hxA := Finset.mem_of_mem_erase hx'
+      have := hA'bound x hxA
+      rw [Finset.mem_Icc]
+      omega
+    exact no_sidon_extension_zero_twentytwo B
+      (Finset.mem_powersetCard.mpr ⟨hBsub, hBcard⟩)
+      (by rw [hrecon]; exact sidonCheck_of_isSidonSet hA'sidon)
+
+/-- `h(22) = 6`: the span dichotomy scales past the parity wall, and the span-17
+ruler `{0,1,4,10,12,17}` still gives the lower bound. -/
+theorem sidonNumber_twentytwo : sidonNumber 22 = 6 := by
+  refine le_antisymm ?_ ?_
+  · exact sidonNumber_le_of_card
+      (fun A hsub hA => no_sidon_card_seven_range_twentythree A hsub hA)
+  · calc 6 = ({0, 1, 4, 10, 12, 17} : Finset ℕ).card := by decide
+      _ ≤ sidonNumber 22 := sidonNumber_ge_card (by decide) isSidonSet_0_1_4_10_12_17
+
+set_option maxRecDepth 100000 in
+/-- Kernel search for `h(23)`: no five interior elements `B ⊆ {1,…,22}` extend the
+pinned endpoints `{0, 23}` to a 7-element Sidon set (`C(22,5) = 26334` candidates). -/
+private theorem no_sidon_extension_zero_twentythree :
+    ∀ B ∈ (Finset.Icc 1 22).powersetCard 5,
+      ¬ SidonCheck (insert 0 (insert 23 B)) := by
+  decide +kernel
+
+/-- **No 7-element Sidon set fits in `{0,…,23}`.**  Same dichotomy, chained onto the
+`h(22)` obstruction. -/
+theorem no_sidon_card_seven_range_twentyfour (A : Finset ℕ)
+    (hsub : A ⊆ Finset.range 24) (hA : IsSidonSet A) : A.card ≤ 6 := by
+  by_contra hcard
+  rw [not_le] at hcard
+  have hup : A.card * A.card ≤ 46 + A.card := by
+    have := sidon_card_sq_le 23 hsub hA; omega
+  have hc7 : A.card = 7 := by
+    by_contra hne
+    have h8 : 8 ≤ A.card := by omega
+    have hmul : 8 * A.card ≤ A.card * A.card := Nat.mul_le_mul h8 (le_refl A.card)
+    omega
+  have hne : A.Nonempty := Finset.card_pos.mp (by omega)
+  set m := A.min' hne with hm
+  have hmle : ∀ x ∈ A, m ≤ x := fun x hx => A.min'_le x hx
+  have hbound : ∀ x ∈ A, x ≤ 23 := fun x hx => by
+    have := hsub hx; rw [Finset.mem_range] at this; omega
+  set A' := A.image (fun x => x - m) with hA'
+  have hinj : Set.InjOn (fun x => x - m) ↑A := by
+    intro x hx y hy hxy
+    have hx' := hmle x (Finset.mem_coe.mp hx)
+    have hy' := hmle y (Finset.mem_coe.mp hy)
+    have hxy' : x - m = y - m := hxy
+    omega
+  have hA'card : A'.card = 7 := by
+    rw [hA', Finset.card_image_of_injOn hinj, hc7]
+  have hA'sidon : IsSidonSet A' := by
+    intro a b c d ha hb hc hd hab hcd heq
+    rw [hA'] at ha hb hc hd
+    simp only [Finset.mem_image] at ha hb hc hd
+    obtain ⟨a₀, ha₀, rfl⟩ := ha
+    obtain ⟨b₀, hb₀, rfl⟩ := hb
+    obtain ⟨c₀, hc₀, rfl⟩ := hc
+    obtain ⟨d₀, hd₀, rfl⟩ := hd
+    have hma := hmle a₀ ha₀; have hmb := hmle b₀ hb₀
+    have hmc := hmle c₀ hc₀; have hmd := hmle d₀ hd₀
+    obtain ⟨h1, h2⟩ := hA a₀ b₀ c₀ d₀ ha₀ hb₀ hc₀ hd₀ (by omega) (by omega) (by omega)
+    exact ⟨by omega, by omega⟩
+  have hzero : (0 : ℕ) ∈ A' := by
+    rw [hA']
+    exact Finset.mem_image.mpr ⟨m, A.min'_mem hne, Nat.sub_self m⟩
+  have hA'ne : A'.Nonempty := ⟨0, hzero⟩
+  have hA'bound : ∀ x ∈ A', x ≤ 23 := by
+    intro x hx
+    rw [hA'] at hx
+    obtain ⟨x₀, hx₀, hx₀eq⟩ := Finset.mem_image.mp hx
+    have hb := hbound x₀ hx₀
+    have hx₀eq' : x₀ - m = x := hx₀eq
+    omega
+  rcases Nat.lt_or_ge (A'.max' hA'ne) 23 with hM | hM
+  · -- Span ≤ 22: the slid set lives in {0,…,22}; the h(22) obstruction applies.
+    have hsub' : A' ⊆ Finset.range 23 := fun x hx => by
+      rw [Finset.mem_range]
+      exact lt_of_le_of_lt (A'.le_max' x hx) hM
+    have := no_sidon_card_seven_range_twentythree A' hsub' hA'sidon
+    omega
+  · -- Span = 23: both endpoints pinned; the five interior elements fall to `decide`.
+    have h23 : (23 : ℕ) ∈ A' := by
+      have hMle : A'.max' hA'ne ≤ 23 := hA'bound _ (A'.max'_mem hA'ne)
+      have hMeq : A'.max' hA'ne = 23 := le_antisymm hMle hM
+      rw [← hMeq]
+      exact A'.max'_mem hA'ne
+    set B := (A'.erase 0).erase 23 with hB
+    have h23' : (23 : ℕ) ∈ A'.erase 0 := Finset.mem_erase.mpr ⟨by omega, h23⟩
+    have hrecon : insert 0 (insert 23 B) = A' := by
+      rw [hB, Finset.insert_erase h23', Finset.insert_erase hzero]
+    have hBcard : B.card = 5 := by
+      rw [hB, Finset.card_erase_of_mem h23', Finset.card_erase_of_mem hzero, hA'card]
+    have hBsub : B ⊆ Finset.Icc 1 22 := by
+      intro x hx
+      rw [hB] at hx
+      have hx23 := (Finset.mem_erase.mp hx).1
+      have hx' := Finset.mem_of_mem_erase hx
+      have hx0 := (Finset.mem_erase.mp hx').1
+      have hxA := Finset.mem_of_mem_erase hx'
+      have := hA'bound x hxA
+      rw [Finset.mem_Icc]
+      omega
+    exact no_sidon_extension_zero_twentythree B
+      (Finset.mem_powersetCard.mpr ⟨hBsub, hBcard⟩)
+      (by rw [hrecon]; exact sidonCheck_of_isSidonSet hA'sidon)
+
+/-- `h(23) = 6`. -/
+theorem sidonNumber_twentythree : sidonNumber 23 = 6 := by
+  refine le_antisymm ?_ ?_
+  · exact sidonNumber_le_of_card
+      (fun A hsub hA => no_sidon_card_seven_range_twentyfour A hsub hA)
+  · calc 6 = ({0, 1, 4, 10, 12, 17} : Finset ℕ).card := by decide
+      _ ≤ sidonNumber 23 := sidonNumber_ge_card (by decide) isSidonSet_0_1_4_10_12_17
+
+set_option maxRecDepth 100000 in
+/-- Kernel search for `h(24)`: no five interior elements `B ⊆ {1,…,23}` extend the
+pinned endpoints `{0, 24}` to a 7-element Sidon set (`C(23,5) = 33649` candidates). -/
+private theorem no_sidon_extension_zero_twentyfour :
+    ∀ B ∈ (Finset.Icc 1 23).powersetCard 5,
+      ¬ SidonCheck (insert 0 (insert 24 B)) := by
+  decide +kernel
+
+/-- **No 7-element Sidon set fits in `{0,…,24}`.**  Same dichotomy, chained onto the
+`h(23)` obstruction.  This is sharp: the 7-mark ruler `{0,1,4,10,18,23,25}` fits at
+`N = 25`. -/
+theorem no_sidon_card_seven_range_twentyfive (A : Finset ℕ)
+    (hsub : A ⊆ Finset.range 25) (hA : IsSidonSet A) : A.card ≤ 6 := by
+  by_contra hcard
+  rw [not_le] at hcard
+  have hup : A.card * A.card ≤ 48 + A.card := by
+    have := sidon_card_sq_le 24 hsub hA; omega
+  have hc7 : A.card = 7 := by
+    by_contra hne
+    have h8 : 8 ≤ A.card := by omega
+    have hmul : 8 * A.card ≤ A.card * A.card := Nat.mul_le_mul h8 (le_refl A.card)
+    omega
+  have hne : A.Nonempty := Finset.card_pos.mp (by omega)
+  set m := A.min' hne with hm
+  have hmle : ∀ x ∈ A, m ≤ x := fun x hx => A.min'_le x hx
+  have hbound : ∀ x ∈ A, x ≤ 24 := fun x hx => by
+    have := hsub hx; rw [Finset.mem_range] at this; omega
+  set A' := A.image (fun x => x - m) with hA'
+  have hinj : Set.InjOn (fun x => x - m) ↑A := by
+    intro x hx y hy hxy
+    have hx' := hmle x (Finset.mem_coe.mp hx)
+    have hy' := hmle y (Finset.mem_coe.mp hy)
+    have hxy' : x - m = y - m := hxy
+    omega
+  have hA'card : A'.card = 7 := by
+    rw [hA', Finset.card_image_of_injOn hinj, hc7]
+  have hA'sidon : IsSidonSet A' := by
+    intro a b c d ha hb hc hd hab hcd heq
+    rw [hA'] at ha hb hc hd
+    simp only [Finset.mem_image] at ha hb hc hd
+    obtain ⟨a₀, ha₀, rfl⟩ := ha
+    obtain ⟨b₀, hb₀, rfl⟩ := hb
+    obtain ⟨c₀, hc₀, rfl⟩ := hc
+    obtain ⟨d₀, hd₀, rfl⟩ := hd
+    have hma := hmle a₀ ha₀; have hmb := hmle b₀ hb₀
+    have hmc := hmle c₀ hc₀; have hmd := hmle d₀ hd₀
+    obtain ⟨h1, h2⟩ := hA a₀ b₀ c₀ d₀ ha₀ hb₀ hc₀ hd₀ (by omega) (by omega) (by omega)
+    exact ⟨by omega, by omega⟩
+  have hzero : (0 : ℕ) ∈ A' := by
+    rw [hA']
+    exact Finset.mem_image.mpr ⟨m, A.min'_mem hne, Nat.sub_self m⟩
+  have hA'ne : A'.Nonempty := ⟨0, hzero⟩
+  have hA'bound : ∀ x ∈ A', x ≤ 24 := by
+    intro x hx
+    rw [hA'] at hx
+    obtain ⟨x₀, hx₀, hx₀eq⟩ := Finset.mem_image.mp hx
+    have hb := hbound x₀ hx₀
+    have hx₀eq' : x₀ - m = x := hx₀eq
+    omega
+  rcases Nat.lt_or_ge (A'.max' hA'ne) 24 with hM | hM
+  · -- Span ≤ 23: the slid set lives in {0,…,23}; the h(23) obstruction applies.
+    have hsub' : A' ⊆ Finset.range 24 := fun x hx => by
+      rw [Finset.mem_range]
+      exact lt_of_le_of_lt (A'.le_max' x hx) hM
+    have := no_sidon_card_seven_range_twentyfour A' hsub' hA'sidon
+    omega
+  · -- Span = 24: both endpoints pinned; the five interior elements fall to `decide`.
+    have h24 : (24 : ℕ) ∈ A' := by
+      have hMle : A'.max' hA'ne ≤ 24 := hA'bound _ (A'.max'_mem hA'ne)
+      have hMeq : A'.max' hA'ne = 24 := le_antisymm hMle hM
+      rw [← hMeq]
+      exact A'.max'_mem hA'ne
+    set B := (A'.erase 0).erase 24 with hB
+    have h24' : (24 : ℕ) ∈ A'.erase 0 := Finset.mem_erase.mpr ⟨by omega, h24⟩
+    have hrecon : insert 0 (insert 24 B) = A' := by
+      rw [hB, Finset.insert_erase h24', Finset.insert_erase hzero]
+    have hBcard : B.card = 5 := by
+      rw [hB, Finset.card_erase_of_mem h24', Finset.card_erase_of_mem hzero, hA'card]
+    have hBsub : B ⊆ Finset.Icc 1 23 := by
+      intro x hx
+      rw [hB] at hx
+      have hx24 := (Finset.mem_erase.mp hx).1
+      have hx' := Finset.mem_of_mem_erase hx
+      have hx0 := (Finset.mem_erase.mp hx').1
+      have hxA := Finset.mem_of_mem_erase hx'
+      have := hA'bound x hxA
+      rw [Finset.mem_Icc]
+      omega
+    exact no_sidon_extension_zero_twentyfour B
+      (Finset.mem_powersetCard.mpr ⟨hBsub, hBcard⟩)
+      (by rw [hrecon]; exact sidonCheck_of_isSidonSet hA'sidon)
+
+/-- `h(24) = 6`. -/
+theorem sidonNumber_twentyfour : sidonNumber 24 = 6 := by
+  refine le_antisymm ?_ ?_
+  · exact sidonNumber_le_of_card
+      (fun A hsub hA => no_sidon_card_seven_range_twentyfive A hsub hA)
+  · calc 6 = ({0, 1, 4, 10, 12, 17} : Finset ℕ).card := by decide
+      _ ≤ sidonNumber 24 := sidonNumber_ge_card (by decide) isSidonSet_0_1_4_10_12_17
+
+/-- The **optimal 7-mark Golomb ruler** `{0,1,4,10,18,23,25}` is a Sidon set — the
+first 7-element Sidon set to fit in an initial segment (span `25`, sharp by
+`no_sidon_card_seven_range_twentyfive`).  Certified through the `SidonCheck` bridge:
+one `decide` replaces the `7⁴ = 2401`-case `rcases`/`omega` sweep the 6-element
+witnesses needed. -/
+private theorem isSidonSet_0_1_4_10_18_23_25 :
+    IsSidonSet {0, 1, 4, 10, 18, 23, 25} :=
+  isSidonSet_of_sidonCheck (by decide)
+
+/-- `h(25) = 7`: the optimal 7-mark Golomb ruler fits exactly, and
+`8² = 64 > 58 = 2·25 + 8` blocks an 8-element Sidon set. -/
+theorem sidonNumber_twentyfive : sidonNumber 25 = 7 := by
+  refine le_antisymm (sidonNumber_le_of_sq fun m hm => ?_) ?_
+  · by_contra hc; rw [not_le] at hc
+    have h8 : 8 ≤ m := hc
+    nlinarith [hm, h8]
+  · calc 7 = ({0, 1, 4, 10, 18, 23, 25} : Finset ℕ).card := by decide
+      _ ≤ sidonNumber 25 := sidonNumber_ge_card (by decide) isSidonSet_0_1_4_10_18_23_25
+
+/-- `h(26) = 7`: `64 > 60 = 2·26 + 8` blocks eight, and the span-25 ruler still fits. -/
+theorem sidonNumber_twentysix : sidonNumber 26 = 7 := by
+  refine le_antisymm (sidonNumber_le_of_sq fun m hm => ?_) ?_
+  · by_contra hc; rw [not_le] at hc
+    have h8 : 8 ≤ m := hc
+    nlinarith [hm, h8]
+  · calc 7 = ({0, 1, 4, 10, 18, 23, 25} : Finset ℕ).card := by decide
+      _ ≤ sidonNumber 26 := sidonNumber_ge_card (by decide) isSidonSet_0_1_4_10_18_23_25
+
+/-- `h(27) = 7`: `64 > 62 = 2·27 + 8` blocks eight, and the span-25 ruler still fits.
+This closes the counting stretch: at `N = 28` the bound goes slack (`64 = 2·28 + 8`),
+opening the next wall. -/
+theorem sidonNumber_twentyseven : sidonNumber 27 = 7 := by
+  refine le_antisymm (sidonNumber_le_of_sq fun m hm => ?_) ?_
+  · by_contra hc; rw [not_le] at hc
+    have h8 : 8 ≤ m := hc
+    nlinarith [hm, h8]
+  · calc 7 = ({0, 1, 4, 10, 18, 23, 25} : Finset ℕ).card := by decide
+      _ ≤ sidonNumber 27 := sidonNumber_ge_card (by decide) isSidonSet_0_1_4_10_18_23_25
+
 end Erdos30

--- a/research/problems/erdos-30-wip-01/knowledge.md
+++ b/research/problems/erdos-30-wip-01/knowledge.md
@@ -158,3 +158,41 @@ the optimal 8-mark ruler `{0,1,4,9,15,22,32,34}` has span 34 — six values need
 per-N nonexistence of an 8-element set; the dichotomy would need `C(N−1,6)`-scale kernel
 searches (~296k at N = 28, growing). DEEP targets unchanged (Singer √N lower bound,
 N^{1/4} refinement, $1000 N^ε conjecture).
+
+## Session 2026-07-23b (researcher-1) — h(28)=7 via mod-4 class double count (NO kernel search)
+
+Added 2 declarations to `Erdos30WIP01.lean` (0 sorries, 0 axioms):
+- `no_sidon_card_eight_range_twentynine`: no 8-element Sidon set in {0,…,28}.
+- `sidonNumber_twentyeight : sidonNumber 28 = 7`. Table now COMPLETE h(0..28).
+
+**Mechanism — the feared ~296k-candidate kernel search was unnecessary.** At N = 28
+an 8-element Sidon set has C(8,2) = 28 distinct positive differences in {1,…,28},
+so the perfect ruler is FORCED (no span dichotomy: 56 signed differences must
+exhaust {±1,…,±28}, the `himageFull` cardinality step from the h(10) template).
+Then a **mod-4 double count**: among {±1,…,±28} exactly 14 values are ≡ 0 (mod 4)
+and 14 are ≡ 2 (mod 4). With c₀..c₃ the mod-4 class sizes of A:
+- same-class ordered pairs: Σ cᵣ(cᵣ−1) = 14 (fiber `T0.filter (p.1%4=r)` =
+  `(A.filter (·%4=r)).offDiag`, exactly the h(15) mod-3 fibration);
+- cross-class ordered pairs (r vs r+2): Σ cᵣ·c_{(r+2)%4} = 14 (NEW fibration:
+  `T2.filter (p.1%4=r) = A_r ×ˢ A_{(r+2)%4}` — off-diagonality is automatic since
+  the classes differ; card via `Finset.card_product`).
+With Σ cᵣ = 8: first constraint forces multiset {4,2,1,1} or {3,3,2,0}; for every
+arrangement c₀c₂+c₁c₃ ∈ {6,9}, never 7. `interval_cases`×4 + omega closes
+(hsum8 linearly prunes the nesting to ~165 leaves).
+
+**Lean notes**: general fibration lemma stated as
+`∀ r s, s = (r+2)%4 → T2.filter … = A_r ×ˢ A_s` and instantiated with `rfl` inside
+the `sum_congr` — avoids `(r+2)%4` literal-normalization headaches; the extraction
+step then needs `Nat.reduceAdd, Nat.reduceMod` simprocs to fold `(0+2)%4 → 2`
+inside the filter lambdas before `generalize` can abstract the class cards.
+Mod-obstruction ladder so far: h(10) parity (sum odd), h(15) mod-3 same-class,
+h(21) parity again, h(28) mod-4 same+cross class. Each perfect-ruler wall
+N = k(k−1)/2 falls to a residue count so far.
+
+**Next wall (h(29..33)):** perfect ruler NO LONGER forced (28 diffs in {1,…,29}
+miss one value); span dichotomy returns: span ≤ 28 slides to the h(28) theorem,
+span = N pins {0,N}. Mod-4 alone is INSUFFICIENT at N = 29 (checked: missing
+value ≡ 2 (mod 4) with class multiset {4,2,1,1} arranged c₀c₂+c₁c₃ = 6 survives
+the double count) — needs either a mod-4+mod-3 combination, endpoint-pinned
+sum-collision pruning (a+b = 29 forbidden pairs), or the C(28,6) ≈ 376k kernel
+search. DEEP targets unchanged.

--- a/research/problems/erdos-30-wip-01/knowledge.md
+++ b/research/problems/erdos-30-wip-01/knowledge.md
@@ -133,3 +133,28 @@ split), a genuinely new session-sized target.
 Build note: parent olean `Proofs.Erdos30Problem` was missing from the shared cache —
 build it explicitly first: `lake env lean -o .lake/build/lib/lean/Proofs/Erdos30Problem.olean
 Proofs/Erdos30Problem.lean`, then the WIP file elaborates normally.
+
+## Session 2026-07-23 (researcher-1) — table extended: h(22..24)=6, h(25..27)=7
+
+Added 12 declarations to `Erdos30WIP01.lean` (0 sorries, 0 axioms; kernel `decide +kernel`
+for the searches):
+- `isSidonSet_of_sidonCheck` (private): converse `SidonCheck` bridge — explicit witnesses
+  now certify by one `decide` instead of an `|A|⁴`-case `rcases`/`omega` sweep.
+- `no_sidon_extension_zero_twentytwo/-three/-four` (private): kernel searches — no
+  5-subset of `{1,…,N−1}` extends the pinned endpoints `{0,N}` to a 7-element Sidon set
+  (`C(N−1,5)` = 20349 / 26334 / 33649 candidates for N = 22, 23, 24).
+- `no_sidon_card_seven_range_twentythree/-four/-five`: no 7-element Sidon set in
+  `{0,…,N}` for N = 22, 23, 24 — the h(16) span dichotomy CHAINED: slide down by the
+  minimum; reduced span appeals to the obstruction proved just before (anchor: the
+  merged h(21) parity theorem `no_sidon_card_seven_range_twentytwo`), span = N pins both
+  endpoints and falls to the kernel search.
+- `isSidonSet_0_1_4_10_18_23_25` (private): the optimal 7-mark Golomb ruler (span 25,
+  differences `{1,…,25} \ {11,12,16,20}`), certified via the bridge.
+- `sidonNumber_twentytwo … twentyseven`: h(22)=h(23)=h(24)=6, h(25)=h(26)=h(27)=7.
+  Exact table now COMPLETE h(0..27).
+
+**Next wall (h(28..33)):** counting goes slack for eight at N = 28 (8·7 = 56 = 2·28) and
+the optimal 8-mark ruler `{0,1,4,9,15,22,32,34}` has span 34 — six values needing
+per-N nonexistence of an 8-element set; the dichotomy would need `C(N−1,6)`-scale kernel
+searches (~296k at N = 28, growing). DEEP targets unchanged (Singer √N lower bound,
+N^{1/4} refinement, $1000 N^ε conjecture).

--- a/research/problems/erdos-30-wip-01/state.md
+++ b/research/problems/erdos-30-wip-01/state.md
@@ -1,25 +1,34 @@
 # Research State: erdos-30-wip-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-07-09T17:33:20-07:00
-**Iteration**: 1
+**Since**: 2026-07-23T09:19:00-07:00
+**Iteration**: 6
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Exact Sidon table h(N) = sidonNumber N. COMPLETE for h(0..27) as of the
+2026-07-23 session (h(22..24)=6 via chained span dichotomy + kernel searches,
+h(25..27)=7 via the optimal 7-mark Golomb ruler {0,1,4,10,18,23,25}).
 
 ## Active Approach
-None yet.
+Span dichotomy (slide-down by minimum + pinned-endpoint kernel search),
+chained across consecutive N. `SidonCheck` converse bridge certifies
+witnesses with a single `decide`.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 6 sessions
+- Current approach attempts: 3 (h(16), h(17..21), h(22..27) — all landed)
+- Approaches tried: parity wall, mod-3 class count, span dichotomy
 
 ## Blockers
-None.
+h(28..33) wall: counting goes slack for card-8 at N=28 (8·7 = 56 = 2·28);
+optimal 8-mark ruler {0,1,4,9,15,22,32,34} has span 34 → six values each
+needing per-N nonexistence of an 8-element Sidon set, with C(N−1,6)-scale
+kernel searches (~296k candidates at N=28, growing). Elementary layer is
+near-saturated.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Either attack h(28) with a smarter pruned search (backtracking encoded as a
+decidable predicate rather than raw subset enumeration), or switch to DEEP
+targets: Singer √N lower bound, N^{1/4} refinement, $1000 N^ε conjecture.

--- a/research/problems/erdos-30-wip-01/state.md
+++ b/research/problems/erdos-30-wip-01/state.md
@@ -3,32 +3,35 @@
 ## Current State
 **Phase**: ACT
 **Path**: full
-**Since**: 2026-07-23T09:19:00-07:00
-**Iteration**: 6
+**Since**: 2026-07-23T10:45:00-07:00
+**Iteration**: 7
 
 ## Current Focus
-Exact Sidon table h(N) = sidonNumber N. COMPLETE for h(0..27) as of the
-2026-07-23 session (h(22..24)=6 via chained span dichotomy + kernel searches,
-h(25..27)=7 via the optimal 7-mark Golomb ruler {0,1,4,10,18,23,25}).
+Exact Sidon table h(N) = sidonNumber N. COMPLETE for h(0..28) as of the
+2026-07-23b session (h(28)=7 via a mod-4 class double count — the perfect
+8-mark ruler is forced at N=28 and the residue-class counts
+Σcᵣ(cᵣ−1)=14, Σcᵣ·c_{r+2}=14, Σcᵣ=8 are jointly unsatisfiable; no kernel
+search needed).
 
 ## Active Approach
-Span dichotomy (slide-down by minimum + pinned-endpoint kernel search),
-chained across consecutive N. `SidonCheck` converse bridge certifies
-witnesses with a single `decide`.
+Residue-class double counting against forced perfect rulers at the wall
+values N = k(k−1)/2 (h(10) parity, h(15) mod-3, h(21) parity, h(28) mod-4);
+chained span dichotomy + pinned-endpoint kernel search for the in-between
+values. `SidonCheck` converse bridge certifies witnesses with one `decide`.
 
 ## Attempt Count
-- Total attempts: 6 sessions
-- Current approach attempts: 3 (h(16), h(17..21), h(22..27) — all landed)
-- Approaches tried: parity wall, mod-3 class count, span dichotomy
+- Total attempts: 7 sessions
+- Current approach attempts: 4 (h(16), h(17..21), h(22..27), h(28) — all landed)
+- Approaches tried: parity wall, mod-3 class count, span dichotomy, mod-4 double count
 
 ## Blockers
-h(28..33) wall: counting goes slack for card-8 at N=28 (8·7 = 56 = 2·28);
-optimal 8-mark ruler {0,1,4,9,15,22,32,34} has span 34 → six values each
-needing per-N nonexistence of an 8-element Sidon set, with C(N−1,6)-scale
-kernel searches (~296k candidates at N=28, growing). Elementary layer is
-near-saturated.
+h(29..33) wall: perfect ruler no longer forced (28 diffs in {1,…,N} miss
+N−28 values); span dichotomy returns but the span-N branch needs per-N
+nonexistence with C(N−1,6)-scale kernel searches (~376k at N=29). Mod-4
+alone checked INSUFFICIENT at N=29 (a {4,2,1,1} arrangement with the missing
+value ≡ 2 mod 4 survives). Elementary layer near-saturated.
 
 ## Next Action
-Either attack h(28) with a smarter pruned search (backtracking encoded as a
-decidable predicate rather than raw subset enumeration), or switch to DEEP
+Either combine mod-3 × mod-4 (or endpoint sum-collision pruning: pairs
+summing to N are forbidden when {0,N} ⊆ A) to fell h(29), or switch to DEEP
 targets: Singer √N lower bound, N^{1/4} refinement, $1000 N^ε conjecture.

--- a/src/data/research/problems/erdos-30-wip-01.json
+++ b/src/data/research/problems/erdos-30-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Exact sidonNumber table now COMPLETE through h(27): h(0..2)=1,2,2; h(3..5)=3; h(6..10)=4; h(11..16)=5; h(17..24)=6 (witness {0,1,4,10,12,17} through 21, then chained span dichotomy + kernel searches for 22..24); h(25..27)=7 (optimal 7-mark Golomb ruler {0,1,4,10,18,23,25} + counting vs eight). Two-sided elementary bounds stand. NEXT wall: h(28..33) (counting slack for eight at N=28; optimal 8-mark ruler span 34). DEEP unchanged: Singer sqrt(N) lower construction, N^{1/4} refinement, $1000 conjecture.",
+    "progressSummary": "Exact sidonNumber table COMPLETE through h(28): h(0..2)=1,2,2; h(3..5)=3; h(6..10)=4; h(11..16)=5; h(17..24)=6; h(25..28)=7 (h(28) via mod-4 class double count against the forced perfect 8-mark ruler — no kernel search). Two-sided elementary bounds stand. NEXT wall: h(29..33) (perfect ruler no longer forced; mod-4 alone insufficient at N=29). DEEP unchanged: Singer sqrt(N) lower construction, N^{1/4} refinement, $1000 conjecture.",
     "builtItems": [
       "Erdos30WIP01.lean: diffMap_injOn (Set.InjOn of difference map on Sidon off-diagonal)",
       "Erdos30WIP01.lean: sidon_offDiag_card_le (|A.offDiag| ≤ 2N for Sidon A ⊆ {0..N})",
@@ -55,7 +55,9 @@
       "no_sidon_extension_zero_twentytwo/-three/-four (kernel searches: no 5-subset of {1..N-1} extends {0,N} to a Sidon set, N=22,23,24) in Erdos30WIP01.lean",
       "no_sidon_card_seven_range_twentythree/-four/-five (no 7-element Sidon set in {0..N}, N=22,23,24 — chained span dichotomy) in Erdos30WIP01.lean",
       "isSidonSet_0_1_4_10_18_23_25 (optimal 7-mark Golomb ruler witness, decide-certified) in Erdos30WIP01.lean",
-      "sidonNumber_twentytwo..twentyseven (h(22..24)=6, h(25..27)=7 — exact table now h(0..27)) in Erdos30WIP01.lean"
+      "sidonNumber_twentytwo..twentyseven (h(22..24)=6, h(25..27)=7 — exact table now h(0..27)) in Erdos30WIP01.lean",
+      "no_sidon_card_eight_range_twentynine in Erdos30WIP01.lean — no 8-element Sidon set in {0..28}, via forced perfect ruler + mod-4 class double count (cross-class fibration T2.filter(p.1%4=r) = A_r ×ˢ A_{(r+2)%4})",
+      "sidonNumber_twentyeight in Erdos30WIP01.lean — h(28)=7; exact table complete h(0..28)"
     ],
     "insights": [
       "Erdős–Turán upper bound is provable elementarily via difference-map injectivity: for a Sidon set A the map (a,b)↦a−b is injective on the off-diagonal (a−b=c−d ⇒ a+d=c+b ⇒ pair matches by the Sidon property), its image is nonzero integers in [−N,N] (2N of them), so |A.offDiag|=|A|²−|A| ≤ 2N.",
@@ -72,7 +74,10 @@
       "When counting, parity, and mod-3 all go slack (the h(16) near-perfect ruler), a SPAN DICHOTOMY keeps the residual search kernel-sized: sliding by the minimum reduces span<=N-1 to the previous obstruction, and span=N pins both endpoints, cutting the search from C(17,6)=12376 to C(15,4)=1365 subsets — well inside decide +kernel range (elaborator-side decide times out at default heartbeats; +kernel hands evaluation to GMP-backed kernel numerals). set_option/omit must precede the docstring, not sit between docstring and theorem.",
       "The span dichotomy SCALES and CHAINS: for consecutive slack values N=22,23,24 each proof's reduced-span branch cites the obstruction proved just before it (anchor: h(21) parity), so one anchor + k kernel searches settle k consecutive table values. Kernel decide handles C(23,5)=33649 candidate 5-subsets (each a 7-element SidonCheck) in a single build — an order of magnitude past the h(16) search (1365) with no special handling.",
       "Converse bridge isSidonSet_of_sidonCheck makes explicit-witness certification O(1) author effort: SidonCheck's bounded quantifiers are decidable, so `isSidonSet_of_sidonCheck (by decide)` replaces the 7^4=2401-case rcases/omega sweep. Retro-applicable to all earlier witnesses (they used manual rcases).",
-      "h(25)=h(26)=h(27)=7 come free once the ruler {0,1,4,10,18,23,25} is certified: 8²=64 > 2N+8 through N=27. The table now ends exactly where counting goes slack for eight: 64 = 2*28+8 at N=28, and the optimal 8-mark ruler has span 34, so h(28..33) is a six-value wall needing C(N-1,6)-scale searches (~296k at N=28)."
+      "h(25)=h(26)=h(27)=7 come free once the ruler {0,1,4,10,18,23,25} is certified: 8²=64 > 2N+8 through N=27. The table now ends exactly where counting goes slack for eight: 64 = 2*28+8 at N=28, and the optimal 8-mark ruler has span 34, so h(28..33) is a six-value wall needing C(N-1,6)-scale searches (~296k at N=28).",
+      "h(28)=7 needs NO kernel search: at N=28 the perfect 8-mark ruler is FORCED (C(8,2)=28 distinct positive differences must exhaust {1..28}), and a mod-4 class double count refutes it — same-class Σc_r(c_r−1)=14 with cross-class Σc_r·c_{(r+2)%4}=14 and Σc_r=8 is unsatisfiable (class multiset must be {4,2,1,1} or {3,3,2,0}, giving c0c2+c1c3 ∈ {6,9}, never 7)",
+      "Mod-obstruction ladder at the perfect-ruler walls N=k(k−1)/2: h(10) parity (odd sum), h(15) mod-3 same-class, h(21) parity, h(28) mod-4 same+cross-class — every wall so far falls to a residue count, no exhaustive search",
+      "Mod-4 checked INSUFFICIENT at N=29: 28 diffs in {1..29} miss one value; missing ≡2 (mod 4) with class multiset {4,2,1,1} arranged c0c2+c1c3=6 survives the double count — h(29) needs mod-3×mod-4 combination, endpoint sum-collision pruning, or a C(28,6)≈376k kernel search"
     ],
     "mathlibGaps": [],
     "nextSteps": [

--- a/src/data/research/problems/erdos-30-wip-01.json
+++ b/src/data/research/problems/erdos-30-wip-01.json
@@ -20,10 +20,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-09T17:33:20-07:00",
-    "iteration": 2,
-    "focus": "h(16)=5 SHIPPED (2026-07-23): the last missing table value below 22. sidonNumber_sixteen via no_sidon_card_six_range_seventeen — span dichotomy: slide the set down by its minimum (translation invariance, injective slide); span<=15 lands in {0..15} and dies on the h(15) mod-3 obstruction no_sidon_card_six_range_sixteen; span=16 pins both endpoints {0,16} and the four interior elements fall to a kernel-checked search (decide +kernel) over the C(15,4)=1365 subsets of {1..15} (SidonCheck = decidable membership-bounded Sidon predicate). Equivalently: every 6-mark Golomb ruler has length >= 17. Exact table h(0..21) now COMPLETE (stacked on PR #42270 h(15) mod-3 + PR #42285 h(17..21)).",
+    "iteration": 3,
+    "focus": "h(22)..h(27) SHIPPED (2026-07-23): table extended to h(0..27). h(22)=h(23)=h(24)=6 via the SCALED span dichotomy chained across three N values: slide down by the minimum; reduced span appeals to the previous N's obstruction (anchored at the merged h(21) parity theorem no_sidon_card_seven_range_twentytwo), span=N pins endpoints {0,N} and the FIVE interior elements fall to decide +kernel over C(N-1,5) subsets (20349 / 26334 / 33649 candidates for N=22,23,24). h(25)=h(26)=h(27)=7: the optimal 7-mark Golomb ruler {0,1,4,10,18,23,25} (span 25, sharp by no_sidon_card_seven_range_twentyfive) gives the witness, certified via the new converse bridge isSidonSet_of_sidonCheck (decide replaces the 7^4=2401-case rcases sweep); counting blocks eight (64 > 2N+8 through N=27).",
     "blockers": [],
-    "nextAction": "Table h(0..21) complete. Next walls: h(22..24) (counting blocks 7 while 42>2N, i.e. through N=20 only — at N=21 parity; N=22-24 need per-N analysis: 7-elt set first fits at span 25 {0,1,4,10,18,23,25}), or pivot to the DEEP targets: Singer/Bose difference-set lower bound h(N)>=(1-o(1))sqrt(N) (finite projective geometry, likely axiomatize), N^{1/4} constant refinement, and the $1000 N^eps conjecture (stays a Prop).",
+    "nextAction": "Table h(0..27) complete. Next wall is N=28: counting goes slack for eight (64 = 2*28+8) and the optimal 8-mark ruler {0,1,4,9,15,22,32,34} has span 34, so h(28..33) need per-N nonexistence of an 8-element Sidon set — span dichotomy would need C(N-1,6) kernel searches (~296k at N=28, likely still feasible but growing). Or pivot to the DEEP targets: Singer/Bose difference-set lower bound h(N)>=(1-o(1))sqrt(N) (finite projective geometry, likely axiomatize), N^{1/4} constant refinement, and the $1000 N^eps conjecture (stays a Prop).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Exact sidonNumber table now COMPLETE through h(14): h(0..2)=1,2,2; h(3..5)=3; h(6..10)=4 (h(10) via perfect-ruler parity); h(11..14)=5 (witness {0,1,4,9,11} + counting bound active again vs 6-element sets). Two-sided elementary bounds stand. NEXT: h(15)=5 needs perfect 6-mark ruler nonexistence (counting slack at 30=2*15, parity silent since 120 even). DEEP unchanged: Singer sqrt(N) lower construction, N^{1/4} refinement, $1000 conjecture.",
+    "progressSummary": "Exact sidonNumber table now COMPLETE through h(27): h(0..2)=1,2,2; h(3..5)=3; h(6..10)=4; h(11..16)=5; h(17..24)=6 (witness {0,1,4,10,12,17} through 21, then chained span dichotomy + kernel searches for 22..24); h(25..27)=7 (optimal 7-mark Golomb ruler {0,1,4,10,18,23,25} + counting vs eight). Two-sided elementary bounds stand. NEXT wall: h(28..33) (counting slack for eight at N=28; optimal 8-mark ruler span 34). DEEP unchanged: Singer sqrt(N) lower construction, N^{1/4} refinement, $1000 conjecture.",
     "builtItems": [
       "Erdos30WIP01.lean: diffMap_injOn (Set.InjOn of difference map on Sidon off-diagonal)",
       "Erdos30WIP01.lean: sidon_offDiag_card_le (|A.offDiag| ≤ 2N for Sidon A ⊆ {0..N})",
@@ -50,7 +50,12 @@
       "SidonCheck (decidable membership-bounded Sidon predicate) + sidonCheck_of_isSidonSet in Erdos30WIP01.lean",
       "no_sidon_extension_zero_sixteen (kernel decide: no 4-subset of {1..15} extends {0,16} to a Sidon set) in Erdos30WIP01.lean",
       "no_sidon_card_six_range_seventeen (no 6-elt Sidon set in {0..16} = no 6-mark Golomb ruler of length <=16; span dichotomy) in Erdos30WIP01.lean",
-      "sidonNumber_sixteen (h(16)=5, completing the exact table h(0..21)) in Erdos30WIP01.lean"
+      "sidonNumber_sixteen (h(16)=5, completing the exact table h(0..21)) in Erdos30WIP01.lean",
+      "isSidonSet_of_sidonCheck (converse SidonCheck bridge: decidable witness certification) in Erdos30WIP01.lean",
+      "no_sidon_extension_zero_twentytwo/-three/-four (kernel searches: no 5-subset of {1..N-1} extends {0,N} to a Sidon set, N=22,23,24) in Erdos30WIP01.lean",
+      "no_sidon_card_seven_range_twentythree/-four/-five (no 7-element Sidon set in {0..N}, N=22,23,24 — chained span dichotomy) in Erdos30WIP01.lean",
+      "isSidonSet_0_1_4_10_18_23_25 (optimal 7-mark Golomb ruler witness, decide-certified) in Erdos30WIP01.lean",
+      "sidonNumber_twentytwo..twentyseven (h(22..24)=6, h(25..27)=7 — exact table now h(0..27)) in Erdos30WIP01.lean"
     ],
     "insights": [
       "Erdős–Turán upper bound is provable elementarily via difference-map injectivity: for a Sidon set A the map (a,b)↦a−b is injective on the off-diagonal (a−b=c−d ⇒ a+d=c+b ⇒ pair matches by the Sidon property), its image is nonzero integers in [−N,N] (2N of them), so |A.offDiag|=|A|²−|A| ≤ 2N.",
@@ -64,7 +69,10 @@
       "Next wall precisely characterized: at N=15 the counting bound goes slack (6*5=30=2*15) AND the parity argument is silent (perfect 6-mark ruler of length 15 has difference sum 120, even). h(15)=5 requires nonexistence of a perfect 6-mark ruler — a genuinely finer argument (next session target).",
       "5-way rcases witness pattern scales: 625 omega cases for isSidonSet_0_1_4_9_11 compile fast on host; the isSidonSet_0_1_4_6 template generalizes verbatim.",
       "Shared-cache gotcha: Proofs.Erdos30Problem olean was missing — build parent explicitly with lake env lean -o .lake/build/lib/lean/Proofs/<X>.olean Proofs/<X>.lean, then the WIP file elaborates.",
-      "When counting, parity, and mod-3 all go slack (the h(16) near-perfect ruler), a SPAN DICHOTOMY keeps the residual search kernel-sized: sliding by the minimum reduces span<=N-1 to the previous obstruction, and span=N pins both endpoints, cutting the search from C(17,6)=12376 to C(15,4)=1365 subsets — well inside decide +kernel range (elaborator-side decide times out at default heartbeats; +kernel hands evaluation to GMP-backed kernel numerals). set_option/omit must precede the docstring, not sit between docstring and theorem."
+      "When counting, parity, and mod-3 all go slack (the h(16) near-perfect ruler), a SPAN DICHOTOMY keeps the residual search kernel-sized: sliding by the minimum reduces span<=N-1 to the previous obstruction, and span=N pins both endpoints, cutting the search from C(17,6)=12376 to C(15,4)=1365 subsets — well inside decide +kernel range (elaborator-side decide times out at default heartbeats; +kernel hands evaluation to GMP-backed kernel numerals). set_option/omit must precede the docstring, not sit between docstring and theorem.",
+      "The span dichotomy SCALES and CHAINS: for consecutive slack values N=22,23,24 each proof's reduced-span branch cites the obstruction proved just before it (anchor: h(21) parity), so one anchor + k kernel searches settle k consecutive table values. Kernel decide handles C(23,5)=33649 candidate 5-subsets (each a 7-element SidonCheck) in a single build — an order of magnitude past the h(16) search (1365) with no special handling.",
+      "Converse bridge isSidonSet_of_sidonCheck makes explicit-witness certification O(1) author effort: SidonCheck's bounded quantifiers are decidable, so `isSidonSet_of_sidonCheck (by decide)` replaces the 7^4=2401-case rcases/omega sweep. Retro-applicable to all earlier witnesses (they used manual rcases).",
+      "h(25)=h(26)=h(27)=7 come free once the ruler {0,1,4,10,18,23,25} is certified: 8²=64 > 2N+8 through N=27. The table now ends exactly where counting goes slack for eight: 64 = 2*28+8 at N=28, and the optimal 8-mark ruler has span 34, so h(28..33) is a six-value wall needing C(N-1,6)-scale searches (~296k at N=28)."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary

Research sessions for **erdos-30-wip-01** (Sidon sets, Erdős #30). Two units of work on this branch:

1. **h(22..27)** (previous session, previously unpushed): chained span dichotomy + pinned-endpoint kernel searches give h(22)=h(23)=h(24)=6; the optimal 7-mark Golomb ruler {0,1,4,10,18,23,25} (certified through a new `SidonCheck` converse bridge — one `decide` instead of a 7⁴-case `rcases` sweep) gives h(25)=h(26)=h(27)=7.
2. **h(28)** (this session): `sidonNumber 28 = 7` via a **mod-4 residue-class double count** — no kernel search.

The exact Sidon table is now **complete for h(0..28)**, all axiom-free (0 sorries, 0 axioms, no `native_decide`; kernel `decide` only).

## The h(28) argument

N = 28 is the third "wall": the counting bound goes slack (8·7 = 56 = 2·28), the h(10)/h(21) parity trick is silent (1+⋯+28 = 406 is even), the h(15) mod-3 count is inconclusive, and the span-dichotomy route would have needed a C(27,6) ≈ 296k-candidate kernel search. Instead:

- An 8-element Sidon set in {0,…,28} has C(8,2) = 28 distinct positive differences inside {1,…,28}, so the **perfect 8-mark ruler is forced** (the 56 signed differences exhaust {±1,…,±28}).
- Exactly 14 of those signed values are ≡ 0 (mod 4) and exactly 14 are ≡ 2 (mod 4). With c₀..c₃ the mod-4 class sizes of A: same-class pairs give Σcᵣ(cᵣ−1) = 14, cross-class pairs give Σcᵣ·c₍ᵣ₊₂₎ = 2(c₀c₂+c₁c₃) = 14.
- With Σcᵣ = 8 the first constraint forces class multiset {4,2,1,1} or {3,3,2,0}; every arrangement gives c₀c₂+c₁c₃ ∈ {6,9}, never 7. Contradiction.

New reusable piece: the cross-class fibration `T2.filter (p.1 % 4 = r) = A_r ×ˢ A_(r+2 mod 4)` (off-diagonality is automatic across distinct classes), complementing the h(15) same-class `offDiag` fibration.

## Files Modified

- `proofs/Proofs/Erdos30WIP01.lean` — +14 declarations across the two sessions (h(22..27): 12, h(28): 2)
- `research/problems/erdos-30-wip-01/{state.md,knowledge.md}` — session notes
- `src/data/research/problems/erdos-30-wip-01.json` — insights/builtItems/progressSummary

## Verification

- Host-verified with a standalone `lake env lean Proofs/Erdos30WIP01.lean` on Lean v4.31.0 (exit 0), parent `Proofs.Erdos30Problem` olean built first.
- The three h(22..24) `decide +kernel` searches and the h(28) `interval_cases⁴ <;> omega` sweep exceed the default 200000-heartbeat elaboration limit, so this PR pins `set_option maxHeartbeats 4000000 in` at those four declarations — without the pins the file does not build standalone.
- No sorry / axiom / native_decide in the file; kernel `decide` only.

## Status

**Outcome**: progress — exact table extended h(0..27) → h(0..28); mod-obstruction ladder now: parity (h10), mod-3 (h15), parity (h21), mod-4 double count (h28).
**Next Steps**: h(29..33) — perfect ruler no longer forced; mod-4 alone checked insufficient at N=29 (a {4,2,1,1} arrangement with the missing value ≡ 2 mod 4 survives). Needs mod-3×mod-4 combination, endpoint sum-collision pruning, or a ≈376k kernel search. DEEP targets unchanged (Singer √N lower bound, N^{1/4} refinement, $1000 N^ε conjecture).

Note: open PR #42270 (h(15) mod-3, branch `research/erdos30-wip01-h15-mod3`) is fully superseded — its content landed on main via #42319. It should be closed (close attempt from this agent was permission-blocked).

🤖 Generated by researcher-1
