### PR TITLE
audit(erdos-159): fix phantom axiom prose + reanchor sections after #8409

### DIFF
--- a/proofs/Proofs/Erdos159Problem.lean
+++ b/proofs/Proofs/Erdos159Problem.lean
@@ -9,8 +9,9 @@ Known bounds:
 - Lower: `R(C₄, Kₙ) ≫ n^{3/2} / (log n)^{3/2}` (Spencer)
 
 The Ramsey function R(C₄, Kₙ) is defined (not axiomatized) via `Nat.find`,
-using the finite Ramsey theorem to establish existence. The only axioms are
-the known upper and lower bounds (deep results not in Mathlib).
+using the finite Ramsey theorem to establish existence. The known upper and
+lower bounds (deep results not in Mathlib) are noted in comments only; the
+file has 0 axioms.
 
 *Reference:* [erdosproblems.com/159](https://www.erdosproblems.com/159)
 -/

--- a/src/data/proofs/erdos-159/meta.json
+++ b/src/data/proofs/erdos-159/meta.json
@@ -68,7 +68,7 @@
     "historicalContext": "**Erdős Problem #159 (Power Saving in $R(C_4, K_n)$)**\n\n**The Off-Diagonal Ramsey Problem:**\nThe Ramsey number $R(C_4, K_n)$ is the smallest $N$ such that every graph on $N$ vertices either contains a 4-cycle $C_4$ or has an independent set of size $n$. Equivalently, it is the maximum number of vertices in a $C_4$-free graph with independence number $< n$, plus one. Erdős asked whether this number admits a genuine power saving over the trivial $n^2$ bound.\n\n**Known Bounds:**\n- **Szemerédi** (via the regularity lemma): $R(C_4, K_n) \\leq C \\cdot n^2/(\\log n)^2$. The regularity lemma shows that $C_4$-free graphs have sparse regular pairs, forcing large independent sets. This is the best known upper bound but only improves on $n^2$ by a $( \\log n)^2$ factor.\n- **Spencer** (probabilistic method): $R(C_4, K_n) \\geq c \\cdot n^{3/2}/(\\log n)^{3/2}$. This combines random $C_4$-free graph constructions with the Kővári-Sós-Turán theorem, which bounds the maximum edges in a $C_4$-free graph to $O(n^{3/2})$.\n\n**The Exponent Gap:**\nThe exponent lies between $3/2$ and $2$ (up to logarithmic factors). Erdős's question asks whether the true exponent is strictly less than 2 — whether there exists $c > 0$ with $R(C_4, K_n) \\leq C \\cdot n^{2-c}$. This would be a polynomial improvement, fundamentally stronger than any logarithmic savings.\n\n**Connection to Finite Geometry:**\nAlgebraic constructions from finite geometry — notably incidence graphs of generalized quadrangles and polarity graphs of projective planes — provide explicit $C_4$-free graphs on $q^2 + q + 1$ vertices with $\\Theta(q^{3/2})$ edges and independence number $\\Theta(q)$. These constructions suggest the lower bound $n^{3/2}$ may be closer to the truth, but they have not been improved to yield $n^{2-c}$ upper bounds.\n\n**Current Status:** OPEN. Neither a power saving nor a proof that no power saving exists is known.",
     "problemStatement": "**Problem Statement (Open)**\n\nDoes there exist $c > 0$ such that $R(C_4, K_n) \\leq C \\cdot n^{2-c}$ for some constant $C$ and all sufficiently large $n$?\n\n**Known Bounds:**\n- Upper: $R(C_4, K_n) \\leq C \\cdot n^2/(\\log n)^2$ (Szemerédi, regularity lemma)\n- Lower: $R(C_4, K_n) \\geq c \\cdot n^{3/2}/(\\log n)^{3/2}$ (Spencer, probabilistic)\n\n**Exponent gap:** $3/2 \\leq \\text{exponent} \\leq 2$ (modulo logarithmic factors)",
     "text": "Does there exist c > 0 such that R(C₄, Kₙ) ≪ n^{2-c}? Known bounds: n^{3/2}/(log n)^{3/2} ≪ R(C₄, Kₙ) ≪ n²/(log n)².",
-    "proofStrategy": "**Formalization Approach**\n\nThe 293-line formalization defines the Ramsey number from first principles:\n\n1. **Graph Predicates:** `HasC4 G` via four distinct vertices with cycle adjacency; `HasClique G n` via pairwise-adjacent Finset.\n\n2. **Ramsey Number:** `ramseyC4Kn : ℕ → ℕ` DEFINED via `Nat.find` using the finite Ramsey theorem (not axiomatized). Key bridge: `HasClique_four_hasC4` (K₄ ⊇ C₄). Full threshold specification `ramseyC4Kn_spec` proved from `Nat.find`.\n\n3. **Known Bounds:** Szemerédi upper $O(n^2/(\\log n)^2)$ and Spencer lower $\\Omega(n^{3/2}/(\\log n)^{3/2})$ axiomatized (deep results).\n\n4. **Main Conjecture:** `ErdosProblem159` as $\\exists c > 0, C > 0, n_0$: $R(C_4, K_n) \\leq C \\cdot n^{2-c}$.\n\n5. **Properties and Values:** Monotonicity, lower bound $R \\geq n$, computed $R(C_4, K_1) = 1$ and $R(C_4, K_2) = 4$.",
+    "proofStrategy": "**Formalization Approach**\n\nThe 280-line formalization defines the Ramsey number from first principles:\n\n1. **Graph Predicates:** `HasC4 G` via four distinct vertices with cycle adjacency; `HasClique G n` via pairwise-adjacent Finset.\n\n2. **Ramsey Number:** `ramseyC4Kn : ℕ → ℕ` DEFINED via `Nat.find` using the finite Ramsey theorem (not axiomatized). Key bridge: `HasClique_four_hasC4` (K₄ ⊇ C₄). Full threshold specification `ramseyC4Kn_spec` proved from `Nat.find`.\n\n3. **Known Bounds:** Szemerédi upper $O(n^2/(\\log n)^2)$ and Spencer lower $\\Omega(n^{3/2}/(\\log n)^{3/2})$ noted in doc comments only — not axiomatized or otherwise formalized, and not used by any theorem in the file.\n\n4. **Main Conjecture:** `ErdosProblem159` as $\\exists c > 0, C > 0, n_0$: $R(C_4, K_n) \\leq C \\cdot n^{2-c}$.\n\n5. **Properties and Values:** Monotonicity, lower bound $R \\geq n$, computed $R(C_4, K_1) = 1$ and $R(C_4, K_2) = 4$.",
     "keyInsights": [
       "**Logarithmic vs. polynomial gap:** Szemerédi's bound $n^2/(\\log n)^2$ is a logarithmic improvement over $n^2$, while the conjecture asks for a polynomial one ($n^{2-c}$). The difference is fundamental: logarithmic savings follow from regularity-type arguments, but power savings require deeper structural understanding of $C_4$-free graphs.",
       "**Kővári-Sós-Turán as obstruction:** The Kővári-Sós-Turán theorem shows $C_4$-free graphs have $O(n^{3/2})$ edges, giving $R(C_4, K_n) \\geq \\Omega(n^{3/2})$ via the probabilistic method. This theorem is the key lower-bound ingredient and connects to the Zarankiewicz problem $z(n; 2, 2)$.",
@@ -109,41 +109,41 @@
     {
       "id": "ramsey-number",
       "title": "Ramsey Number R(C₄, Kₙ) — Defined from Ramsey's Theorem",
-      "startLine": 64,
-      "endLine": 165,
+      "startLine": 61,
+      "endLine": 162,
       "summary": "DEFINED (not axiomatized) via Nat.find: HasClique_four_hasC4 (K₄ ⊇ C₄), ramsey_C4_Kn_exists (existence from Ramsey theorem via edge coloring), ramseyC4Kn (Nat.find definition), ramseyC4Kn_spec (threshold specification proved from Nat.find properties)"
     },
     {
       "id": "known-bounds",
       "title": "Known Bounds",
-      "startLine": 167,
-      "endLine": 181,
-      "summary": "Two axioms: szemeredi_upper (R ≤ C·n²/(log n)²) and spencer_lower (R ≥ c·n^{3/2}/(log n)^{3/2}). Deep literature results not in Mathlib."
+      "startLine": 164,
+      "endLine": 169,
+      "summary": "No axioms — doc comments only, describing Szemerédi's upper bound (R ≤ C·n²/(log n)²) and Spencer's lower bound (R ≥ c·n^{3/2}/(log n)^{3/2}) as known literature results. Neither is declared as a Lean axiom or otherwise formalized; the szemeredi_upper/spencer_lower identifiers do not exist in this file."
     },
     {
       "id": "main-conjecture",
       "title": "Main Conjecture: Power Saving",
-      "startLine": 183,
-      "endLine": 194,
+      "startLine": 170,
+      "endLine": 181,
       "summary": "ErdosProblem159: ∃ c > 0, C > 0, n₀ such that R(C₄, Kₙ) ≤ C·n^{2-c} for n ≥ n₀"
     },
     {
       "id": "proved-properties",
       "title": "Proved Properties",
-      "startLine": 196,
-      "endLine": 224,
+      "startLine": 183,
+      "endLine": 211,
       "summary": "ramseyC4Kn_mono (monotonicity for 1 ≤ m ≤ n) and ramseyC4Kn_ge (trivial lower bound R ≥ n), both proved from the specification"
     },
     {
       "id": "computed-values",
       "title": "Computed Ramsey Values",
-      "startLine": 226,
-      "endLine": 282,
+      "startLine": 213,
+      "endLine": 280,
       "summary": "Exact Ramsey values computed and proved: ramseyC4Kn_one (R(C₄,K₁) = 1) and ramseyC4Kn_two (R(C₄,K₂) = 4), using Nat.find_eq_iff with explicit constructions and counterexamples"
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #159 asks whether the off-diagonal Ramsey number $R(C_4, K_n)$ admits a power saving: $R(C_4, K_n) \\leq C \\cdot n^{2-c}$ for some $c > 0$. The known bounds $\\Omega(n^{3/2}/(\\log n)^{3/2}) \\leq R(C_4, K_n) \\leq O(n^2/(\\log n)^2)$ leave an exponent gap from $3/2$ to $2$. The formalization defines the Ramsey number via Nat.find from the finite Ramsey theorem, computes R(C₄,K₁)=1 and R(C₄,K₂)=4, and axiomatizes only the deep asymptotic bounds.",
+    "summary": "Erdős Problem #159 asks whether the off-diagonal Ramsey number $R(C_4, K_n)$ admits a power saving: $R(C_4, K_n) \\leq C \\cdot n^{2-c}$ for some $c > 0$. The known bounds $\\Omega(n^{3/2}/(\\log n)^{3/2}) \\leq R(C_4, K_n) \\leq O(n^2/(\\log n)^2)$ leave an exponent gap from $3/2$ to $2$. The formalization defines the Ramsey number via Nat.find from the finite Ramsey theorem and computes R(C₄,K₁)=1 and R(C₄,K₂)=4; the deep asymptotic bounds are noted in comments only (0 axioms in the file) and are not used by the main conjecture statement.",
     "implications": "**Theoretical Significance**: **Connections**\n\n1. **Zarankiewicz Problem:** $R(C_4, K_n)$ is closely tied to $z(n; 2, 2)$, the maximum edges in a $C_4$-free bipartite graph. The Kővári-Sós-Turán bound $z(n; 2, 2) = O(n^{3/2})$ is the key ingredient in Spencer's lower bound.\n\n**2. Finite Geometry:** Algebraic $C_4$-free constructions from projective planes and generalized quadrangles achieve extremal edge counts, suggesting deep connections between Ramsey theory and algebraic combinatorics.\n\n3. **Regularity Lemma Limitations:** Szemerédi's upper bound relies on the regularity lemma, whose quantitative inefficiency may be the primary obstacle to a power saving. Bypassing regularity for structured forbidden-subgraph problems is a major theme in modern combinatorics.\n\n4. **Off-Diagonal Ramsey Theory:** The problem is a prototype for understanding $R(H, K_n)$ for sparse graphs $H$, where the interaction between graph structure and independence number creates rich combinatorial phenomena.",
     "openQuestions": [
       "Does R(C₄, Kₙ) ≤ C·n^{2-c} for some c > 0? (The main conjecture)",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-159 (Ramsey Numbers for C₄ and Complete Graphs)
**Problem**: `meta.json` describes two axioms (`szemeredi_upper`, `spencer_lower`) that no longer exist in the Lean file; section line-anchors also drifted stale.

## Evidence

PR #8409 ("Research: remove 2,256 unused axioms across 585 Erdős files") removed the `szemeredi_upper`/`spencer_lower` axiom declarations from `proofs/Proofs/Erdos159Problem.lean`, converting them to plain doc comments (per its own commit message: "mathematical content preserved in surrounding comments and docstrings"). It never touched `src/data/proofs/erdos-159/meta.json`.

**meta.json claims** (before this PR):
- `overview.proofStrategy` point 3: "Known Bounds: Szemerédi upper ... and Spencer lower ... **axiomatized** (deep results)."
- `overview.conclusion.summary`: "...and **axiomatizes only the deep asymptotic bounds**."
- `sections[]` "known-bounds" entry: "**Two axioms**: szemeredi_upper (...) and spencer_lower (...). Deep literature results not in Mathlib." with `startLine:167, endLine:181`.

**Lean file shows**:
- `grep -n "^axiom" Proofs/Erdos159Problem.lean` → no matches.
- `grep -n "szemeredi_upper\|spencer_lower" Proofs/Erdos159Problem.lean` → no matches anywhere (not even as identifiers in comments).
- `meta.axiomCount: 0` / `leanFile.axiomCount: 0` were already correct — only the prose was stale.
- The "Known Bounds" region is now two plain `/- ... -/` comment blocks (lines 164–169), unconnected to any theorem; `ErdosProblem159` (the open conjecture) references only `ramseyC4Kn`, not these bounds.
- Section line ranges had drifted from the 10-line removal: `computed-values.endLine: 282` pointed past the file's actual 280 lines.
- The file's own module docstring also claimed "The only axioms are the known upper and lower bounds", which is now false.

## Fix

- `overview.proofStrategy` / `overview.conclusion.summary`: rewritten to state the bounds are noted in comments only, not axiomatized, and unused by the main conjecture.
- `sections[]`: `known-bounds` summary corrected to "No axioms — doc comments only ... identifiers do not exist in this file"; `ramsey-number`/`known-bounds`/`main-conjecture`/`proved-properties`/`computed-values` line ranges reanchored to actual current line numbers.
- `proofs/Proofs/Erdos159Problem.lean` module docstring: corrected to "noted in comments only; the file has 0 axioms."
- No functional Lean changes — `axiomCount`/`sorries`/`theoremCount`/`definitionCount`/`lineCount` were already accurate and are unchanged.

---
Discovered during gallery integrity audit.