### PR TITLE
research(erdos507-wip01): heilbronn 5 ∈ [81/125, 3/2] — rational near-pentagon fells the deferred n=5 rung

### DIFF
--- a/proofs/Proofs/Erdos507WIP01.lean
+++ b/proofs/Proofs/Erdos507WIP01.lean
@@ -800,4 +800,82 @@ theorem heilbronn_tendsto_zero :
   rw [Real.dist_eq, sub_zero, abs_of_nonneg hpos]
   linarith [hbound, h4m]
 
+/-! ## A concrete lower bound at `n = 5`: a rational near-pentagon
+
+The natural five-point witness is the regular pentagon inscribed in the unit
+circle, whose minimum triangle area is `(2 sin 72° − sin 36°)/2 ≈ 0.6572`.  Its
+coordinates, however, involve the nested radicals of `cos(2π/5)` — every one of
+the ten triangle areas would be an expression in `√5` and `√(10 ± 2√5)`, far
+outside `norm_num`'s reach (this is exactly why the `n = 5` rung was deferred
+when the `n = 4` square was formalized).
+
+Rational points are dense on the unit circle, so we instead perturb each
+pentagon vertex to a nearby *Pythagorean-triple* point:
+
+    A = (1, 0)              (angle    0°)
+    B = (7/25,  24/25)      (angle  73.7°, near  72°)
+    C = (−4/5,  3/5)        (angle 143.1°, near 144°)
+    D = (−4/5, −3/5)        (angle 216.9°, near 216°)
+    E = (7/25, −24/25)      (angle 286.3°, near 288°)
+
+All five points lie *exactly* on the unit circle (`3² + 4² = 5²`,
+`7² + 24² = 25²`), and every one of the ten triangle areas is an exact rational:
+
+    ABC = ADE = BCD = CDE = 81/125,   ABE = 432/625,
+    BCE = BDE = 648/625,              ABD = ACD = ACE = 27/25.
+
+The minimum is `81/125 = 0.648` — within `1.5%` of the conjectured optimum
+`≈ 0.6572` — and the whole certificate is a kernel-friendly `norm_num`
+computation.  This yields the third sandwich of the elementary ladder:
+`heilbronn 5 ∈ [81/125, 3/2]`. -/
+
+/-- **`heilbronn 5 ≥ 81/125`.**  The rational near-pentagon
+`(1,0), (7/25, 24/25), (−4/5, 3/5), (−4/5, −3/5), (7/25, −24/25)` — five
+Pythagorean-triple points lying exactly on the unit circle near the vertices of
+the regular pentagon — has minimum triangle area exactly `81/125`, so `81/125`
+lies in the defining `sSup` set of `heilbronn 5` (`le_csSup`, using
+`heilbronn_defining_bddAbove` for boundedness).  All ten triple areas are
+rational (`81/125`, `432/625`, `648/625`, `27/25`), so every ordering of every
+distinct triple is discharged by `norm_num` — no radicals appear anywhere,
+unlike for the exact regular pentagon. -/
+theorem heilbronn_five_ge : (81 / 125 : ℝ) ≤ heilbronn 5 := by
+  unfold heilbronn
+  refine le_csSup (heilbronn_defining_bddAbove 5 (by norm_num)) ?_
+  refine ⟨{((1 : ℝ), (0 : ℝ)), (7 / 25, 24 / 25), (-(4 / 5), 3 / 5),
+    (-(4 / 5), -(3 / 5)), (7 / 25, -(24 / 25))}, ?_, ?_, ?_⟩
+  · -- the five vertices are distinct, so the configuration has cardinality `5`
+    rw [Finset.card_insert_of_notMem (by norm_num [Prod.ext_iff]),
+      Finset.card_insert_of_notMem (by norm_num [Prod.ext_iff]),
+      Finset.card_insert_of_notMem (by norm_num [Prod.ext_iff]),
+      Finset.card_insert_of_notMem (by norm_num [Prod.ext_iff]),
+      Finset.card_singleton]
+  · -- each vertex lies exactly on the boundary of the closed unit disk
+    intro p hp
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hp
+    rcases hp with rfl | rfl | rfl | rfl | rfl <;> norm_num
+  · -- every ordered distinct triple has area `≥ 81/125`
+    intro p hp q hq r hr hpq hqr hpr
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hp hq hr
+    rcases hp with rfl | rfl | rfl | rfl | rfl <;>
+        rcases hq with rfl | rfl | rfl | rfl | rfl <;>
+        rcases hr with rfl | rfl | rfl | rfl | rfl <;>
+      first
+        | exact absurd rfl hpq
+        | exact absurd rfl hqr
+        | exact absurd rfl hpr
+        | (show (81 / 125 : ℝ) ≤ triangleArea _ _ _; unfold triangleArea; norm_num)
+
+/-- **`heilbronn 5` is strictly positive** — immediate from `heilbronn_five_ge`. -/
+theorem heilbronn_five_pos : 0 < heilbronn 5 :=
+  lt_of_lt_of_le (by norm_num) heilbronn_five_ge
+
+/-- **Sandwich at `n = 5`:** `heilbronn 5 ∈ [81/125, 3/2]`.  Lower bound from the
+rational near-pentagon (`heilbronn_five_ge`); upper bound from the Lagrange bound
+`heilbronn n ≤ 3/2` (`heilbronn_le_three_halves`).  The lower bound is *not*
+claimed sharp — the true five-point optimum is conjecturally the regular
+pentagon's `(2 sin 72° − sin 36°)/2 ≈ 0.6572`, and `81/125 = 0.648` sits within
+`1.5%` of it. -/
+theorem heilbronn_five_mem_Icc : heilbronn 5 ∈ Set.Icc (81 / 125 : ℝ) (3 / 2) :=
+  ⟨heilbronn_five_ge, heilbronn_le_three_halves 5 (by norm_num)⟩
+
 end Erdos507WIP01

--- a/research/problems/erdos-507-wip-01/knowledge.md
+++ b/research/problems/erdos-507-wip-01/knowledge.md
@@ -291,3 +291,29 @@ card via `Finset.card_insert_of_not_mem` chain (`norm_num [Prod.ext_iff]`), 64-w
 `rcases <;> first | absurd | norm_num [triangleArea]` triple bash. Sharpness of the
 square NOT claimed. Next elementary rung would be n=5 (regular pentagon — irrational
 cos(2π/5) areas, messier norm_num; feasible but heavier).
+
+## Session 2026-07-23 (researcher-1): heilbronn 5 sandwich via rational near-pentagon
+
+`heilbronn_five_ge` (≥ 81/125), `heilbronn_five_pos`, `heilbronn_five_mem_Icc`
+(∈ [81/125, 3/2]). The trick that unblocked the deferred n=5 rung: instead of the
+regular pentagon (whose cos(2π/5) coordinates put every triangle area in nested
+√5 radicals, outside norm_num), perturb each vertex to a nearby Pythagorean-triple
+point on the unit circle — (1,0), (7/25,24/25), (−4/5,3/5), (−4/5,−3/5),
+(7/25,−24/25). All 10 triangle areas are exact rationals (81/125 ×4, 432/625,
+648/625 ×2, 27/25 ×3); min = 81/125 = 0.648, within 1.5% of the conjectured
+pentagon optimum (2sin72°−sin36°)/2 ≈ 0.6572. Same skeleton as the n=4 square
+(le_csSup + card_insert chain + 125-way rcases <;> first | absurd | norm_num);
+compiled first try at DEFAULT heartbeats (no pin needed), #print axioms =
+propext/Classical.choice/Quot.sound on all three decls. Host-verified
+`lake env lean` v4.31 exit 0 (parent olean fresh).
+
+### Idiom (reusable for any witness-ladder rung)
+Rational points are dense on S¹, so every regular-n-gon witness can be made
+radical-free at a few-percent loss in the bound. Pythagorean triples used:
+(3,4,5) at ±143.13°, (7,24,25) at ±73.74°.
+
+### Remaining (unchanged in kind)
+- n=6 near-hexagon possible, heavier, diminishing returns — elementary ladder
+  now effectively saturated through n=5.
+- DEEP: sharp n=3 upper (Jensen on central angles, ~500+ lines, NOT
+  session-sized); α(n) exponent bounds 7/6 ≤ β ≤ 2.

--- a/src/data/research/problems/erdos-507-wip-01.json
+++ b/src/data/research/problems/erdos-507-wip-01.json
@@ -28,9 +28,9 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-07-20T15:20:00-07:00",
-    "iteration": 3,
-    "focus": "Axiom-free structural facts on minTriangleArea (the nested triple-infimum) and heilbronn (its sSup), built on the verified triangleArea geometry.",
+    "since": "2026-07-23T17:50:00Z",
+    "iteration": 4,
+    "focus": "Elementary witness ladder: explicit rational configurations + le_csSup + ordered-triple case bash, rung by rung (n=3,4,5 done).",
     "blockers": [
       {
         "route": "the α(n) growth exponent via elementary planar geometry",
@@ -38,15 +38,15 @@
         "blockedAt": "2026-07-20"
       }
     ],
-    "nextAction": "Sharpen the n=3 lower bound toward the exact heilbronn 3 = 3√3/4 (largest inscribed triangle) — upper half needs a max-inscribed-triangle bound, likely not session-sized. Otherwise the deep α(n) exponent bounds (KPS/CPZ) remain out of scope.",
+    "nextAction": "Elementary ladder saturated through n=5; each further rung is heavier with diminishing returns. Remaining substance is deep: sharp n=3 upper bound (Jensen, not session-sized) and alpha(n) exponent bounds (open).",
     "attemptCounts": {
-      "total": 3,
+      "total": 4,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: n=3 sandwiched [3sqrt3/4, 3/2] (merged) and n=4 now sandwiched [1, 3/2] (2026-07-22, inscribed square). Elementary witness-ladder pattern (explicit config + le_csSup + case-bash on triples) works rung by rung; remaining deep work: sharp upper at n=3 (Jensen on central angles, ~500+ lines) and asymptotic exponent bounds.",
+    "progressSummary": "PROGRESS: elementary witness ladder now has THREE sandwiches: n=3 in [3sqrt3/4, 3/2] (merged), n=4 in [1, 3/2] (inscribed square, merged), n=5 in [81/125, 3/2] (2026-07-23, rational near-pentagon). The n=5 rung sidesteps the cos(2pi/5) radicals that deferred it: five Pythagorean-triple points (1,0),(7/25,24/25),(-4/5,3/5),(-4/5,-3/5),(7/25,-24/25) lie exactly on the unit circle, all 10 triangle areas are exact rationals, min = 81/125 = 0.648 (within 1.5% of the conjectured regular-pentagon optimum 0.6572). Remaining deep work: sharp upper at n=3 (Jensen on central angles, ~500+ lines) and asymptotic exponent bounds.",
     "builtItems": [
       "triangleArea_nonneg in Erdos507WIP01.lean",
       "triangleArea_swap_left / triangleArea_swap_right / triangleArea_cyclic (permutation symmetry)",
@@ -78,7 +78,10 @@
       "heilbronn_le_four_div in Erdos507WIP01.lean: heilbronn n ≤ 4/m for 1≤m, 2(m+1)<n (Finset pigeonhole), 0-axiom",
       "heilbronn_tendsto_zero in Erdos507WIP01.lean: Tendsto heilbronn atTop (𝓝 0), 0-axiom",
       "heilbronn_four_ge in Erdos507WIP01.lean: heilbronn 4 >= 1 (inscribed square, 0-axiom)",
-      "heilbronn_four_pos, heilbronn_four_mem_Icc: positivity + sandwich heilbronn 4 in [1, 3/2]"
+      "heilbronn_four_pos, heilbronn_four_mem_Icc: positivity + sandwich heilbronn 4 in [1, 3/2]",
+      "heilbronn_five_ge: 81/125 <= heilbronn 5 (rational near-pentagon witness, 125-way triple bash, norm_num only)",
+      "heilbronn_five_pos: 0 < heilbronn 5",
+      "heilbronn_five_mem_Icc: heilbronn 5 in [81/125, 3/2]"
     ],
     "insights": [
       "The signed shoelace area p₁(q₂−r₂)+q₁(r₂−p₂)+r₁(p₂−q₂) is alternating: transpositions negate it (area invariant via abs_neg), cyclic rotations fix it — giving full S₃ symmetry after the absolute value.",
@@ -101,7 +104,8 @@
       "The upper bound 3/2 is NOT sharp (true max |E|=3√3/2≈2.598, area 3√3/4≈1.299): the three determinants cannot be simultaneously maximal. Closing to the sharp 3√3/4 needs the central-angle constraint (angles subtended at O sum to 2π when O is interior) + Jensen on sin over [0,π] + an O-exterior case split — the genuine open optimization.",
       "Quantitative decay heilbronn n = O(1/n): pigeonhole over ⌊(x+1)·m/2⌋₊ vertical strips gives heilbronn n ≤ 4/m whenever 2(m+1)<n (heilbronn_le_four_div), hence heilbronn n → 0 (heilbronn_tendsto_zero). First non-constant upper bound; formalizes the α(n)≪1/n pigeonhole remark of the problem statement.",
       "Reusable recipe: the determinant form E=(p₁−r₁)(q₂−r₂)−(q₁−r₁)(p₂−r₂) (anchored at a vertex) is the right handle for LOCAL box/strip area bounds — spread hypotheses |Δx|≤w,|Δy|≤h collapse to two |·|≤w·h products (triangleArea_le_spread: area ≤ w·h).",
-      "n=4 rung: the inscribed square (1,0),(0,1),(-1,0),(0,-1) has all four vertex triples spanning right triangles of area exactly 1, giving heilbronn 4 >= 1 by the same le_csSup witness pattern as heilbronn_three_ge_half. With the Lagrange upper bound this sandwiches heilbronn 4 in [1, 3/2] - a second width-1/2 window beyond n=3. Sharpness of the square among 4-point disk configs is NOT claimed (open quantitative question)."
+      "n=4 rung: the inscribed square (1,0),(0,1),(-1,0),(0,-1) has all four vertex triples spanning right triangles of area exactly 1, giving heilbronn 4 >= 1 by the same le_csSup witness pattern as heilbronn_three_ge_half. With the Lagrange upper bound this sandwiches heilbronn 4 in [1, 3/2] - a second width-1/2 window beyond n=3. Sharpness of the square among 4-point disk configs is NOT claimed (open quantitative question).",
+      "Rational points are dense on the unit circle, so every witness-ladder rung can be made radical-free: replace the exact regular n-gon by nearby Pythagorean-triple points. At n=5 the loss is only 1.5% (81/125 vs (2 sin72 - sin36)/2), and the certificate stays inside norm_num/kernel arithmetic - no maxHeartbeats pin needed even for the 125-case ordered-triple bash."
     ],
     "mathlibGaps": [
       "No off-the-shelf lemma reduces the nested membership biInf of minTriangleArea to a single ciInf_le; the junk-value semantics of ⨅ over unsatisfiable membership binders must be handled explicitly (done here via ciInf_le_of_le descent).",
@@ -109,8 +113,9 @@
       "No Mathlib lemma for the maximal-area triangle inscribed in a disk (max = equilateral, area 3√3/4·R²); the sharp heilbronn 3 ≤ 3√3/4 upper bound needs this and is not a tactic search."
     ],
     "nextSteps": [
-      "SHARP upper bound heilbronn 3 ≤ 3√3/4 (would pin heilbronn 3 = 3√3/4 exactly via heilbronn_three_ge). Statement to prove: for p,q,r with |p|,|q|,|r|≤1, triangleArea p q r ≤ 3√3/4. Approach: E = Σ|a||b|sin θ over central angles θ_ab+θ_bc+θ_ca=2π (O interior) → 3·sin(2π/3)=3√3/2 by Jensen (sin concave on [0,π]); plus O-exterior case. Large (~500+ lines); not yet session-sized.",
-      "The deep α(n) growth exponent bounds (KPS lower, CPZ upper) — 7/6 ≤ β ≤ 2, genuine open research, not session-sized."
+      "n=6 rung via a rational near-hexagon (regular hexagon min triangle area = sqrt(3)/4*... - rational perturbation same trick); diminishing returns, each rung heavier",
+      "Sharp upper heilbronn 3 <= 3sqrt3/4 (pins exact value; Jensen on central angles, ~500+ lines, NOT session-sized)",
+      "Deep alpha(n) exponent bounds 7/6 <= beta <= 2 (KPS lower, CPZ upper) - open research"
     ],
     "markdown": "# Knowledge Base: erdos-507-wip-01\n\n## Session 2026-07-20 (researcher-1) — foundational triangle-area / unit-disk scaffolding\n\n**Mode**: FRESH (EMPTY node). **Outcome**: progress — VERIFIED axiom-free (`[propext, Classical.choice, Quot.sound]`), 0 sorry / 0 axiom. Host-verified (Mathlib-only parent): fresh-built `Erdos507Problem.olean` then `lake env lean` on the child (no Docker).\n\n### What I did\nCreated `proofs/Proofs/Erdos507WIP01.lean` (14 theorems) on the shoelace area `triangleArea p q r = |p₁(q₂−r₂)+q₁(r₂−p₂)+r₁(p₂−q₂)|/2` and the `IsInUnitDisk` predicate:\n- **Nonnegativity**: `triangleArea_nonneg`.\n- **Permutation symmetry**: `triangleArea_swap_left`, `triangleArea_swap_right` (transpositions, via signed-area negation + `abs_neg`), `triangleArea_cyclic` (rotation fixes it).\n- **Degenerate cases**: `triangleArea_self_left / _self_mid / _self_outer` (= 0).\n- **Collinearity**: `triangleArea_eq_zero_iff`.\n- **Explicit value**: `triangleArea_unit` (`(0,0),(1,0),(0,1) ↦ 1/2`).\n- **Unit disk**: `isInUnitDisk_empty`, `IsInUnitDisk.subset`, `unitDisk_abs_fst_le`, `unitDisk_abs_snd_le`, and the uniform bound `triangleArea_le_three`.\n\n### Key findings\n- The signed shoelace form is alternating: transpositions negate, cyclic rotations fix — full `S₃` symmetry after `|·|`.\n- Every unit-disk triangle has area `≤ 3`, so `heilbronn n`'s `sSup` set is bounded above (a step toward finiteness/monotonicity of `heilbronn`).\n\n### Reusable Lean recipe\n- Signed-area alternation: `rw [show <permuted expr> = -(<base expr>) from by ring, abs_neg]`.\n- Coordinate bound from the disk: `nlinarith [sq_nonneg (p.1 - 1), sq_nonneg (p.1 + 1)]` after `have hsq : p.1^2 ≤ 1 := by nlinarith [sq_nonneg p.2]`.\n- Three-term abs bound: `abs_add_le` twice (note `abs_add` was renamed to `abs_add_le` in this pin) + `gcongr`, each summand `≤ 2` via `mul_le_mul` on `|a|·|b−c| ≤ 1·2`.\n- v4.31 renames hit this session: `abs_add → abs_add_le`, `Finset.not_mem_empty → Finset.notMem_empty`.\n\n### Next steps\n- `minTriangleArea P ≤ triangleArea p q r` (nested membership `biInf_le`).\n- `heilbronn n ≤ 3` via `BddAbove` of the defining set.\n\n### Still open (unchanged)\nThe growth exponent of `α(n)` — deep; only `7/6 ≤ β ≤ 2` known (KPS, Cohen–Pohoata–Zakharov).\n"
   },
@@ -134,7 +139,7 @@
     "mathlib": []
   },
   "started": "2026-07-20T12:30:00.000Z",
-  "lastUpdate": "2026-07-21",
+  "lastUpdate": "2026-07-23",
   "significance": 6,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

Research session for **erdos-507-wip-01** (Heilbronn's triangle problem, Erdős #507). Extends the elementary witness ladder to its third sandwich:

**`heilbronn 5 ∈ [81/125, 3/2]`** — new theorems `heilbronn_five_ge`, `heilbronn_five_pos`, `heilbronn_five_mem_Icc` in `proofs/Proofs/Erdos507WIP01.lean` (appended at end of file; no existing lines shifted).

## The idea: a rational near-pentagon

The n=5 rung was explicitly deferred when the n=4 square landed (#41700): the regular pentagon's coordinates involve `cos(2π/5)` nested radicals, putting all ten triangle areas outside `norm_num`'s reach.

The unblocking observation is that **rational points are dense on the unit circle**, so the pentagon can be perturbed vertex-by-vertex to Pythagorean-triple points lying *exactly* on the circle:

| vertex | point | angle (target) |
|---|---|---|
| A | (1, 0) | 0° (0°) |
| B | (7/25, 24/25) | 73.7° (72°) |
| C | (−4/5, 3/5) | 143.1° (144°) |
| D | (−4/5, −3/5) | 216.9° (216°) |
| E | (7/25, −24/25) | 286.3° (288°) |

All ten triangle areas are exact rationals — `81/125` (×4), `432/625`, `648/625` (×2), `27/25` (×3) — with minimum `81/125 = 0.648`, within **1.5%** of the conjectured regular-pentagon optimum `(2·sin 72° − sin 36°)/2 ≈ 0.6572`. The proof mirrors the n=4 skeleton (`le_csSup` + `card_insert` chain + 125-way `rcases <;> first | absurd | norm_num` ordered-triple bash) and compiled **first try at default heartbeats** — no `maxHeartbeats` pin needed.

The idiom is reusable: every regular-n-gon witness on the ladder can be made radical-free at a few-percent loss in the bound.

## Files Modified

- `proofs/Proofs/Erdos507WIP01.lean` — +3 theorems, +1 section (append-only)
- `research/problems/erdos-507-wip-01/knowledge.md` — session note
- `src/data/research/problems/erdos-507-wip-01.json` — progressSummary/builtItems/insights/nextSteps

## Verification

- Host-verified: `lake env lean Proofs/Erdos507WIP01.lean` on Lean v4.31.0, exit 0 (parent `Erdos507Problem.olean` fresh, built 07-20 against a parent file unchanged since 07-17).
- `#print axioms` on all three new declarations: `propext, Classical.choice, Quot.sound` only.
- 0 sorries, 0 axioms, no `native_decide`, no `maxHeartbeats` pins.
- Witness areas independently cross-checked with exact rational arithmetic (Python `fractions`) before formalization.

## Status

**Outcome**: progress — elementary ladder now sandwiches n=3 `[3√3/4, 3/2]`, n=4 `[1, 3/2]`, n=5 `[81/125, 3/2]`.
**Next Steps**: elementary ladder effectively saturated through n=5 (n=6 near-hexagon possible but heavier, diminishing returns). Remaining substance is DEEP: sharp n=3 upper bound `heilbronn 3 ≤ 3√3/4` (Jensen on central angles, not session-sized) and the α(n) exponent bounds `7/6 ≤ β ≤ 2` (KPS/CPZ, open).

🤖 Generated by researcher-1
