### PR TITLE
research(erdos548-incomplete01): fill all 8 Aristotle-companion sorries — companions now sorry-free

### DIFF
--- a/proofs/Proofs/Erdos548Aristotle.lean
+++ b/proofs/Proofs/Erdos548Aristotle.lean
@@ -8,7 +8,7 @@
   Aristotle skips that. This companion focuses on concrete graph constructions
   (pathGraph, starGraph) and the handshaking lemma.
 
-  Included targets (5):
+  All 5 targets PROVED directly (2026-07-23, researcher-1) — no sorries remain:
   - pathGraph_adj_symm: adjacency in the path graph is symmetric (by definition)
   - starGraph_center_adj: center vertex is adjacent to every leaf
   - starGraph_adj_symm: adjacency in the star graph is symmetric (by definition)
@@ -27,27 +27,27 @@ variable {V : Type*} [Fintype V] [DecidableEq V]
 
 /-- Adjacency in the path graph is symmetric: if i→j then j→i. -/
 theorem pathGraph_adj_symm (n : ℕ) (i j : Fin n) :
-    (Erdos548.pathGraph n).Adj i j ↔ (Erdos548.pathGraph n).Adj j i := by
-  sorry
+    (Erdos548.pathGraph n).Adj i j ↔ (Erdos548.pathGraph n).Adj j i :=
+  ⟨fun h => h.symm, fun h => h.symm⟩
 
 /-- The center vertex (index 0) is adjacent to every leaf in the star graph. -/
 theorem starGraph_center_adj (k : ℕ) (hk : k ≥ 1) (j : Fin (k + 1))
-    (hj : j.val ≠ 0) : (Erdos548.starGraph k).Adj ⟨0, Nat.zero_lt_succ k⟩ j := by
-  sorry
+    (hj : j.val ≠ 0) : (Erdos548.starGraph k).Adj ⟨0, Nat.zero_lt_succ k⟩ j :=
+  Or.inl ⟨rfl, hj⟩
 
 /-- Adjacency in the star graph is symmetric. -/
 theorem starGraph_adj_symm (k : ℕ) (i j : Fin (k + 1)) :
-    (Erdos548.starGraph k).Adj i j ↔ (Erdos548.starGraph k).Adj j i := by
-  sorry
+    (Erdos548.starGraph k).Adj i j ↔ (Erdos548.starGraph k).Adj j i :=
+  ⟨fun h => h.symm, fun h => h.symm⟩
 
 /-- The handshaking lemma: sum of degrees equals twice the edge count.
     Uses Mathlib's SimpleGraph.sum_degrees_eq_twice_card_edges. -/
 theorem sum_degrees_twice_edges_ari (G : SimpleGraph V) [DecidableRel G.Adj] :
-    (Finset.univ.sum fun v => G.degree v) = 2 * G.edgeFinset.card := by
-  sorry
+    (Finset.univ.sum fun v => G.degree v) = 2 * G.edgeFinset.card :=
+  G.sum_degrees_eq_twice_card_edges
 
 /-- Every graph contains itself as a subgraph (identity injection). -/
-theorem containsSubgraph_refl (G : SimpleGraph V) : ContainsSubgraph G G := by
-  sorry
+theorem containsSubgraph_refl (G : SimpleGraph V) : ContainsSubgraph G G :=
+  ⟨id, Function.injective_id, fun _ _ h => h⟩
 
 end Erdos548Aristotle

--- a/proofs/Proofs/Erdos548ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos548ProblemAristotle.lean
@@ -2,6 +2,7 @@
   Aristotle targets for Erdős Problem #548 (Erdős-Sós Conjecture)
   Routine supporting lemmas for automated proof search.
   See Erdos548Problem.lean for the main formalization.
+  All 3 targets PROVED directly (2026-07-23, researcher-1) — no sorries remain.
 
   Criteria for inclusion:
   - sum_degrees_eq_twice_edges: handshaking lemma (standard graph theory)
@@ -42,17 +43,34 @@ def starGraph (k : ℕ) : SimpleGraph (Fin (k + 1)) where
 -- This is a standard result: SimpleGraph.sum_degrees_eq_twice_card_edges.
 theorem sum_degrees_eq_twice_edges (G : SimpleGraph V) [DecidableRel G.Adj] :
     (Finset.univ.sum fun v => G.degree v) = 2 * edgeCount G := by
-  sorry
+  have h := G.sum_degrees_eq_twice_card_edges
+  unfold edgeCount
+  convert h using 2
+  congr!
 
 -- Routine: The star graph K_{1,k} is connected for k ≥ 1.
 -- Every leaf is adjacent to the center (vertex 0), and 0 reaches all vertices.
 theorem starGraph_connected (k : ℕ) (hk : k ≥ 1) : (starGraph k).Connected := by
-  sorry
+  rw [SimpleGraph.connected_iff]
+  refine ⟨fun i j => ?_, ⟨0⟩⟩
+  have h0 : ∀ a : Fin (k + 1), a.val ≠ 0 → (starGraph k).Adj 0 a :=
+    fun a ha => Or.inl ⟨by simp, ha⟩
+  by_cases hij : i = j
+  · exact hij ▸ SimpleGraph.Reachable.refl i
+  · by_cases hi : i.val = 0
+    · by_cases hj : j.val = 0
+      · exact absurd (Fin.ext (hi.trans hj.symm)) hij
+      · have hi0 : i = (0 : Fin (k + 1)) := Fin.ext (by simpa using hi)
+        exact hi0 ▸ (h0 j hj).reachable
+    · by_cases hj : j.val = 0
+      · have hj0 : j = (0 : Fin (k + 1)) := Fin.ext (by simpa using hj)
+        exact hj0 ▸ ((h0 i hi).symm).reachable
+      · exact ((h0 i hi).symm.reachable).trans (h0 j hj).reachable
 
 -- Routine: Each edge of the star K_{1,k} contributes to reachability.
 -- Adjacent vertices in the star are reachable (trivially: direct adjacency).
 theorem starGraph_adj_reachable (k : ℕ) (i j : Fin (k + 1))
-    (h : (starGraph k).Adj i j) : (starGraph k).Reachable i j := by
-  sorry
+    (h : (starGraph k).Adj i j) : (starGraph k).Reachable i j :=
+  h.reachable
 
 end Erdos548Aristotle

--- a/research/problems/erdos-548-incomplete-01/knowledge.md
+++ b/research/problems/erdos-548-incomplete-01/knowledge.md
@@ -1,0 +1,46 @@
+# Knowledge: erdos-548-incomplete-01 (Erdős–Sós Conjecture)
+
+## Session 2026-07-23 (researcher-1): all 8 companion sorries filled
+
+The problem.md target ("complete the 6 sorries") is DONE — both Aristotle
+companion files are now sorry-free (8 sorries total at session start):
+
+- `Erdos548Aristotle.lean` (5): pathGraph_adj_symm / starGraph_adj_symm
+  (`⟨fun h => h.symm, fun h => h.symm⟩` — SimpleGraph.Adj.symm on both iff
+  directions), starGraph_center_adj (`Or.inl ⟨rfl, hj⟩` — the Adj of a
+  structure-literal graph unfolds definitionally), sum_degrees_twice_edges_ari
+  (`G.sum_degrees_eq_twice_card_edges` verbatim), containsSubgraph_refl
+  (`⟨id, Function.injective_id, fun _ _ h => h⟩`).
+- `Erdos548ProblemAristotle.lean` (3): sum_degrees_eq_twice_edges (copy of the
+  main file's proof: convert + congr!), starGraph_connected (verbatim copy of
+  the main file's proof — identical local starGraph def), starGraph_adj_reachable
+  (`h.reachable`).
+
+Host-verified v4.31: parent `Erdos548Problem.lean` elaborated with
+`lake env lean -o .lake/build/lib/lean/Proofs/Erdos548Problem.olean` (exit 0,
+warnings only), then both companions `lake env lean` exit 0. All fills are
+term-mode or copied tactic proofs — no new axioms, no native_decide.
+
+## File inventory
+
+- `Erdos548Problem.lean` (513 lines): 0 sorries, **8 axioms** — 7 are
+  literature-named DEEP results (brandt_dobson, sacle_wozniak, wang_li_liu,
+  path_extremal, komlos_sos_large_k, erdos_gallai_matching, turan_path_formula)
+  plus `trivial_tree_bound` (generic-named, provable in principle, see below).
+- Both companions: 0 sorries.
+- Gallery meta (src/data/proofs/erdos-548/meta.json) tracks only the main file
+  (additionalFiles: null); its `sorries = 0` was already accurate for the main
+  file and is now accurate for the whole family.
+
+## Next steps
+
+1. **`trivial_tree_bound`** (n(k−1)+1 edges ⟹ contains every tree with k
+   edges) is the one Mathlib-provable axiom (the incomplete-01 generic-named
+   vein). Standard proof: (a) any G with e(G) > (k−1)n has a subgraph H with
+   δ(H) ≥ k (delete low-degree vertices, ≤ (k−1)n edges removed); (b) δ(H) ≥ k
+   ⟹ H ⊇ every k-edge tree (greedy leaf-order embedding — needs tree leaf
+   induction). Substantial: needs min-degree subgraph extraction + tree
+   induction; NOT obviously session-sized in SimpleGraph API. Check whether
+   Mathlib has `SimpleGraph.exists_subgraph_minDegree` analogues first.
+2. The other 7 axioms are genuine literature results — leave as axioms.
+3. The conjecture itself (ErdosSosConjecture) is OPEN — never a target.


### PR DESCRIPTION
## Summary

Research session for **erdos-548-incomplete-01** (Erdős–Sós conjecture, Erdős #548). The problem's stated target — "complete the 6 sorries" — is done: **all 8 sorries** (the count had grown since problem creation) across the two Aristotle companion files are now proved directly. Both companions are sorry-free.

## Fills

`proofs/Proofs/Erdos548Aristotle.lean` (5):
- `pathGraph_adj_symm`, `starGraph_adj_symm` — `⟨fun h => h.symm, fun h => h.symm⟩` (`SimpleGraph.Adj.symm` both ways)
- `starGraph_center_adj` — `Or.inl ⟨rfl, hj⟩` (structure-literal `Adj` unfolds definitionally)
- `sum_degrees_twice_edges_ari` — Mathlib's `G.sum_degrees_eq_twice_card_edges` verbatim
- `containsSubgraph_refl` — `⟨id, Function.injective_id, fun _ _ h => h⟩`

`proofs/Proofs/Erdos548ProblemAristotle.lean` (3):
- `sum_degrees_eq_twice_edges` — mirror of the main file's proved version (`convert` + `congr!`)
- `starGraph_connected` — verbatim copy of the main file's proof (identical local `starGraph` definition)
- `starGraph_adj_reachable` — `h.reachable`

No statement was changed; every fill is term-mode or a copied tactic proof. No new axioms, no `native_decide`.

## Files Modified

- `proofs/Proofs/Erdos548Aristotle.lean` — 5 sorries → 0
- `proofs/Proofs/Erdos548ProblemAristotle.lean` — 3 sorries → 0
- `research/problems/erdos-548-incomplete-01/knowledge.md` — new (session record + next-step analysis)

## Verification

- Host-verified on Lean v4.31.0: parent `Erdos548Problem.lean` elaborated first (`lake env lean -o … .olean`, exit 0, warnings only), then both companions `lake env lean` exit 0 (warnings only — pre-existing unused-variable lints).
- Gallery meta (`src/data/proofs/erdos-548/meta.json`) tracks only the main file (`additionalFiles: null`) and already reads `sorries = 0`; that figure was accurate for the main file and is now accurate for the whole family — no meta change needed.

## Status

**Outcome**: progress — the incomplete-01 completion target is fulfilled; companion files sorry-free.
**Next Steps**: the main file's 8 axioms remain: 7 are literature-named deep results (Brandt–Dobson, Saclé–Woźniak, Wang–Li–Liu, Komlós–Sós, Erdős–Gallai, …) and stay axioms; `trivial_tree_bound` (n(k−1)+1 edges ⟹ every k-edge tree embeds) is the one Mathlib-provable candidate — needs min-degree-subgraph extraction + greedy leaf-order tree embedding, likely not session-sized (analysis in knowledge.md).

🤖 Generated by researcher-1
