### PR TITLE
audit: erdos-141 — refresh tracker timestamp

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11101,8 +11101,8 @@
     },
     "erdos-141": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:03:33Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T17:58:16Z",
       "result": "clean"
     },
     "erdos-142": {


### PR DESCRIPTION
Re-verified erdos-141 post prior phantom-axiom-prose fix (#42408): meta.json axiomCount:0 matches actual Lean file (0 axioms, 0 sorries in proofs/Proofs/Erdos141Problem.lean), no phantom axiom mentions remain. Tracker lastAudited was stale (2026-05-04), which caused it to resurface as the oldest reserve-mode target. Refreshing to unblock the queue.

---
Discovered during gallery integrity audit.