### PR TITLE
research(a054656): iteration 2 — seed_block proved via kernel canSum checker; two defective scaffolds repaired (4 → 2 sorries)

### DIFF
--- a/proofs/Proofs/A054656DistinctPrimePartition.lean
+++ b/proofs/Proofs/A054656DistinctPrimePartition.lean
@@ -13,21 +13,28 @@ This file turns the elementary core into machine-checked Lean and scaffolds the
 harder engine (seed block + interval-extension + Bertrand/Ramanujan induction)
 behind clearly-marked `sorry`s.
 
-## Status of this file (first iteration)
+## Status of this file (second iteration, 2026-07-23)
 
-VERIFIED (0 sorries, kernel `decide` only — no `native_decide`):
+VERIFIED (kernel `decide` only — no `native_decide`):
   * `not_repr_one`, `not_repr_four`, `not_repr_six`
       — 1, 4, 6 are NOT sums of distinct primes.
   * `present_iff_residual_repr`
       — the reduction: `p` present in `n` ↔ `p` prime, `p ≤ n`, and `n − p`
         is a sum of distinct primes avoiding `p`.
   * `residual_avoiding_imp_repr` — an avoiding representation is a representation.
+  * `seed_block` (NEW) — the window `[13, 90]` (`B − A = 77 ≥ 64`) is
+    representable avoiding any single prime, via the `canSum` kernel subset-sum
+    checker over the eleven primes `≤ 31` (soundness bridge `canSum_sound`).
+  * `reprAvoiding_add_prime` (NEW) — the top-down fresh-prime extension step,
+    REPLACING the first iteration's `interval_extension`, whose hypotheses
+    (`B < q` and `q ≤ B − A + 1`) were jointly unsatisfiable (they force
+    `A = 0`, and `1` is never representable) — that engine was vacuous.
 
-SCAFFOLDED (`sorry`, hard engine deferred — see comments):
-  * `seed_block` — a run of ≥ 64 consecutive representable residuals.
-  * `interval_extension` — extend a representable interval by an unused prime.
-  * `repr_of_ge_seven_ne` — every residual ≥ 7 (and the small representable ones)
-    is representable avoiding one forbidden prime.
+SCAFFOLDED (`sorry`, deferred):
+  * `repr_of_ge_seven_ne` — every residual with `23 ≤ m + p` is representable
+    avoiding `p`.  Statement REPAIRED this iteration: without `23 ≤ m + p` it
+    was FALSE — counterexamples `(m, p)` = `(2,2), (3,3), (8,3), (9,2), (10,3),
+    (11,11), (12,7)`, all with `m + p < 23` (see docstring).
   * `A054656_main` — the main theorem for `n ≥ 23`.
 
 ## Mathlib gap (identified this iteration)
@@ -168,47 +175,164 @@ theorem present_iff_residual_repr {p n : ℕ} :
       simp only [id] at hsum ⊢
       omega
 
-/-! ## Scaffolding for the representability engine (DEFERRED — `sorry`)
+/-! ## The representability engine
 
 The heavy lifting: every residual `m ≥ 2` other than `1, 4, 6` is a sum of
-distinct primes, and can even avoid one forbidden prime `p`. The claimed proof
-does this via (1) an enumerated seed block of ≥ 64 consecutive representable
-integers from the nine primes `≤ 23`, (2) an interval-extension engine, and
-(3) a Bertrand/Ramanujan induction to push the representable interval to
-infinity. Each is stated below; the proofs are deferred. -/
+distinct primes, and (for `m + p ≥ 23`) can even avoid one forbidden prime `p`.
+The engine is (1) an enumerated **seed block** of consecutive representable
+integers — PROVED below via a kernel subset-sum checker, (2) a **fresh-prime
+extension step** — PROVED below (the original bottom-up interval statement was
+vacuous, see `reprAvoiding_add_prime`), and (3) a Bertrand/Ramanujan induction
+to push representability to infinity — still DEFERRED (the "two primes in
+`(q, 2q]`" ingredient is not in Mathlib). -/
 
-/-- **Seed block (DEFERRED).** There is a block of at least 64 consecutive
-integers, all representable as sums of distinct primes drawn from
-`{2,3,5,7,11,13,17,19,23}` with the forbidden prime `p` removed.
+/-- The seed pool: the eleven primes up to `31`.
 
-Deferred: this is a `decide`/`Finset.powerset`-computational enumeration over
-≤ 2⁹ = 512 subsets for each excluded prime `p`. Keep it kernel-`decide` if
-feasible; if the 512-subset search needs `native_decide`, disclose
-`Lean.ofReduceBool` and mark the gallery entry `axiomatized`. -/
+(The second iteration extended the pool from the nine primes `≤ 23`: with that
+smaller pool the longest representable run avoiding `p = 23` is `[7, 70]`,
+i.e. `B − A = 63` — one short of the required `64`. With primes up to `31`
+the single window `[13, 90]` is representable avoiding *any one* pool prime.) -/
+def seedPool : List ℕ := [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31]
+
+/-- Kernel-friendly subset-sum decision procedure: `canSum l m = true` iff some
+subset of the list `l` sums to `m`.  A direct structural recursion (use the
+head or don't) — no `Finset.powerset`, so the kernel evaluates it cheaply. -/
+def canSum : List ℕ → ℕ → Bool
+  | [], m => m == 0
+  | q :: rest, m => canSum rest m || (decide (q ≤ m) && canSum rest (m - q))
+
+/-- Soundness of `canSum`: a successful check yields an actual `Finset` of
+elements of `l` summing to `m` (duplicate-freeness of `l` makes the chosen
+sublist a genuine set). -/
+theorem canSum_sound : ∀ {l : List ℕ} {m : ℕ}, l.Nodup → canSum l m = true →
+    ∃ S : Finset ℕ, (∀ x ∈ S, x ∈ l) ∧ S.sum id = m := by
+  intro l
+  induction l with
+  | nil =>
+    intro m _ h
+    simp only [canSum, beq_iff_eq] at h
+    exact ⟨∅, by simp, by simp [h]⟩
+  | cons q rest ih =>
+    intro m hnd h
+    simp only [canSum, Bool.or_eq_true, Bool.and_eq_true, decide_eq_true_eq] at h
+    rcases h with h | ⟨hqm, h⟩
+    · obtain ⟨S, hSl, hsum⟩ := ih (List.Nodup.of_cons hnd) h
+      exact ⟨S, fun x hx => List.mem_cons_of_mem q (hSl x hx), hsum⟩
+    · obtain ⟨S, hSl, hsum⟩ := ih (List.Nodup.of_cons hnd) h
+      have hqS : q ∉ S := fun hq => (List.nodup_cons.mp hnd).1 (hSl q hq)
+      refine ⟨insert q S, ?_, ?_⟩
+      · intro x hx
+        rcases Finset.mem_insert.mp hx with rfl | hx
+        · simp
+        · exact List.mem_cons_of_mem q (hSl x hx)
+      · rw [Finset.sum_insert hqS, hsum]
+        simp only [id_eq]
+        omega
+
+/-- Lift a `canSum` certificate over a list of primes not containing `p` to a
+`ReprAvoiding` witness. -/
+theorem reprAvoiding_of_canSum {l : List ℕ} {m p : ℕ} (hnd : l.Nodup)
+    (hprime : ∀ q ∈ l, Nat.Prime q) (hp : p ∉ l) (h : canSum l m = true) :
+    ReprAvoiding m p := by
+  obtain ⟨S, hSl, hsum⟩ := canSum_sound hnd h
+  exact ⟨S, fun q hq => hprime q (hSl q hq), fun hpS => hp (hSl p hpS), hsum⟩
+
+/-- Window check: every `m ∈ [A, B]` passes `canSum l`. -/
+def checkWindow (l : List ℕ) (A B : ℕ) : Bool :=
+  (List.range (B + 1 - A)).all fun i => canSum l (A + i)
+
+theorem checkWindow_sound {l : List ℕ} {A B m : ℕ} (h : checkWindow l A B = true)
+    (h1 : A ≤ m) (h2 : m ≤ B) : canSum l m = true := by
+  have hi : m - A ∈ List.range (B + 1 - A) := List.mem_range.mpr (by omega)
+  have hall := List.all_eq_true.mp h _ hi
+  simpa [Nat.add_sub_cancel' h1] using hall
+
+/-- Packaged seed case: a duplicate-free list of primes avoiding `p` whose
+`checkWindow` certificate covers `[13, 90]` yields the seed interval. -/
+private theorem seed_case {p : ℕ} (l : List ℕ) (hnd : l.Nodup)
+    (hprime : ∀ q ∈ l, Nat.Prime q) (hp : p ∉ l)
+    (hwin : checkWindow l 13 90 = true) :
+    ∀ m, 13 ≤ m → m ≤ 90 → ReprAvoiding m p :=
+  fun _ h1 h2 => reprAvoiding_of_canSum hnd hprime hp (checkWindow_sound hwin h1 h2)
+
+/-- **Seed block (PROVED, second iteration).** The single window `[13, 90]`
+(length `78`, so `B − A = 77 ≥ 64`) is representable avoiding any prime `p`:
+if `p` is one of the eleven pool primes, the ten remaining pool primes suffice
+(checked by kernel `decide` through `canSum`); if `p` is outside the pool, the
+full pool works (its elements are `≤ 31`, so none equals `p` — `p ∉ seedPool`
+is exactly the case hypothesis).  Kernel `decide` only — no `native_decide`,
+no `Finset.powerset` blow-up. -/
 theorem seed_block (p : ℕ) (hp : Nat.Prime p) :
     ∃ A B : ℕ, 64 ≤ B - A ∧ ∀ m, A ≤ m → m ≤ B → ReprAvoiding m p := by
-  sorry
+  refine ⟨13, 90, by norm_num, ?_⟩
+  by_cases hmem : p ∈ seedPool
+  · simp only [seedPool, List.mem_cons, List.not_mem_nil, or_false] at hmem
+    rcases hmem with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+    · exact seed_case [3, 5, 7, 11, 13, 17, 19, 23, 29, 31]
+        (by decide) (by decide) (by decide) (by decide)
+    · exact seed_case [2, 5, 7, 11, 13, 17, 19, 23, 29, 31]
+        (by decide) (by decide) (by decide) (by decide)
+    · exact seed_case [2, 3, 7, 11, 13, 17, 19, 23, 29, 31]
+        (by decide) (by decide) (by decide) (by decide)
+    · exact seed_case [2, 3, 5, 11, 13, 17, 19, 23, 29, 31]
+        (by decide) (by decide) (by decide) (by decide)
+    · exact seed_case [2, 3, 5, 7, 13, 17, 19, 23, 29, 31]
+        (by decide) (by decide) (by decide) (by decide)
+    · exact seed_case [2, 3, 5, 7, 11, 17, 19, 23, 29, 31]
+        (by decide) (by decide) (by decide) (by decide)
+    · exact seed_case [2, 3, 5, 7, 11, 13, 19, 23, 29, 31]
+        (by decide) (by decide) (by decide) (by decide)
+    · exact seed_case [2, 3, 5, 7, 11, 13, 17, 23, 29, 31]
+        (by decide) (by decide) (by decide) (by decide)
+    · exact seed_case [2, 3, 5, 7, 11, 13, 17, 19, 29, 31]
+        (by decide) (by decide) (by decide) (by decide)
+    · exact seed_case [2, 3, 5, 7, 11, 13, 17, 19, 23, 31]
+        (by decide) (by decide) (by decide) (by decide)
+    · exact seed_case [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
+        (by decide) (by decide) (by decide) (by decide)
+  · exact seed_case seedPool (by decide) (by decide) hmem (by decide)
 
-/-- **Interval-extension engine (DEFERRED).** If every integer in `[A, B]` is
-representable (avoiding `p`) and an unused prime `q ≤ B − A + 1` larger than `B`
-(so `q` is genuinely new and `q ≠ p`) is available, then adding `q` extends
-representability continuously up to `B + q`: each `m ∈ (B, B + q]` is
-`q + (m − q)` with `m − q ∈ [A, B]`, and `q` is not among the seed primes since
-`q > B`. Elementary once the arithmetic of shifting a covered interval by `q`
-is set up. -/
-theorem interval_extension {p A B q : ℕ}
-    (hq : Nat.Prime q) (hqB : B < q)
-    (hcover : ∀ m, A ≤ m → m ≤ B → ReprAvoiding m p)
-    (hgap : q ≤ B - A + 1) :
-    ∀ m, A ≤ m → m ≤ B + q → ReprAvoiding m p := by
-  sorry
+/-- **Fresh-prime extension step (REPAIRED + PROVED, second iteration).**
+Replaces the first iteration's `interval_extension`, whose hypotheses were
+jointly unsatisfiable: it required both `B < q` (freshness) and
+`q ≤ B − A + 1` (no gap), which force `A = 0` — and covering `[0, B]` is
+impossible since `1` is never representable.  The sound engine is *top-down*:
+if the residual `r` is representable avoiding `p` and `r < q` for a fresh prime
+`q ≠ p`, then `r + q` is representable avoiding `p` (every element of `r`'s
+witness is `≤ r < q`, so `q` is automatically new).  In the Bertrand induction
+one takes `q ∈ (m/2, m]`, so `r = m − q < q` holds by construction. -/
+theorem reprAvoiding_add_prime {p r q : ℕ} (hq : Nat.Prime q) (hqp : q ≠ p)
+    (hr : ReprAvoiding r p) (hrq : r < q) : ReprAvoiding (r + q) p := by
+  obtain ⟨S, hprime, hpS, hsum⟩ := hr
+  have hqS : q ∉ S := fun hmem => absurd (le_of_mem_repr hsum hmem) (by omega)
+  refine ⟨insert q S, ?_, ?_, ?_⟩
+  · intro x hx
+    rcases Finset.mem_insert.mp hx with rfl | hx
+    · exact hq
+    · exact hprime x hx
+  · intro hmem
+    rcases Finset.mem_insert.mp hmem with h | h
+    · exact hqp h.symm
+    · exact hpS h
+  · rw [Finset.sum_insert hqS, hsum]
+    simp only [id_eq]
+    omega
 
-/-- **Every non-exceptional residual is representable avoiding `p` (DEFERRED).**
-Combines `seed_block`, `interval_extension`, and the Bertrand/Ramanujan
-induction. The Ramanujan step ("`(q, 2q]` has ≥ 2 primes") is the piece not yet
-in Mathlib; it must be built on `Nat.exists_prime_lt_and_le_two_mul`. -/
+/-- **Every large-enough residual is representable avoiding `p` (DEFERRED;
+statement REPAIRED, second iteration).**  The first iteration omitted the
+hypothesis `23 ≤ m + p`, making the statement FALSE: e.g. `¬ReprAvoiding 8 3`
+(`8 = 3 + 5` is the only distinct-prime partition of `8`, and it contains `3`),
+`¬ReprAvoiding 9 2` (`9 = 2 + 7` is the only
+partition), `¬ReprAvoiding 10 3` (`10 = 2+3+5 = 3+7`), `¬ReprAvoiding 11 11`
+(`11` itself is the only partition), `¬ReprAvoiding 12 7` (`12 = 5+7 = 2+3+7`),
+and the degenerate `(m, p) ∈ {(2,2), (3,3)}`.  All counterexamples have
+`m + p < 23`; in the application `m = n − p` with `n ≥ 23`, so `23 ≤ m + p`
+always holds.  Combines `seed_block`, `reprAvoiding_add_prime`, and the
+Bertrand/Ramanujan induction; the Ramanujan step ("`(q, 2q]` has ≥ 2 primes")
+is the piece not yet in Mathlib — it must be built on
+`Nat.exists_prime_lt_and_le_two_mul`. -/
 theorem repr_of_ge_seven_ne (m p : ℕ) (hp : Nat.Prime p)
-    (hm : 2 ≤ m) (hne : m ≠ 4 ∧ m ≠ 6) :
+    (hm : 2 ≤ m) (hne : m ≠ 4 ∧ m ≠ 6) (hnp : 23 ≤ m + p) :
     ReprAvoiding m p := by
   sorry
 

--- a/src/data/proofs/a054656-distinct-prime-partition/meta.json
+++ b/src/data/proofs/a054656-distinct-prime-partition/meta.json
@@ -3,7 +3,7 @@
   "slug": "a054656-distinct-prime-partition",
   "title": "OEIS A054656: Primes Absent from Every Distinct-Prime Partition of n",
   "status": "formalized",
-  "description": "For n ≥ 23, the primes p ≤ n absent from every partition of n into distinct primes are exactly {n−1, n−4, n−6} ∩ P. This first iteration machine-checks the elementary core — the residuals 1, 4, 6 are not sums of distinct primes, and the reduction 'p present in n ⟺ n−p is a distinct-prime sum avoiding p' — and scaffolds the seed-block / interval-extension / Bertrand-Ramanujan engine.",
+  "description": "For n ≥ 23, the primes p ≤ n absent from every partition of n into distinct primes are exactly {n−1, n−4, n−6} ∩ P. Iteration 1 machine-checked the elementary core (residuals 1, 4, 6 are not distinct-prime sums; the reduction 'p present in n ⟺ n−p is a distinct-prime sum avoiding p'). Iteration 2 proves the seed block (the window [13, 90] is representable avoiding any one prime, via a kernel subset-sum checker over the primes ≤ 31) and the fresh-prime extension step, and repairs two defective scaffold statements; only the Bertrand–Ramanujan induction and final assembly remain sorried.",
   "overview": {
     "historicalContext": "OEIS A054656 was created in April 2000 and, as of this entry, is still labeled conjectural — over two decades with no published proof. The sequence counts primes p ≤ n absent from every partition of n into distinct primes, and the conjectural closed form is remarkably simple: for n ≥ 23 the absent primes are exactly {n−1, n−4, n−6} intersected with the primes. GitHub issue #41831 tracks an AI-claimed elementary proof (GPT-5.6 Pro); this file is the first Lean iteration turning that claimed argument into machine-checked mathematics, separating what is genuinely elementary (and now verified) from what still needs a number-theoretic ingredient Mathlib does not yet have.",
     "problemStatement": "For every integer n ≥ 23, show that the primes p ≤ n occurring in NO partition of n into distinct primes are exactly the primes among {n−1, n−4, n−6}. Equivalently: a prime p ≤ n is present in some distinct-prime partition of n if and only if the residual m = n − p is itself a sum of distinct primes none equal to p, and the only residuals with no such representation are m ∈ {1, 4, 6}.",
@@ -28,7 +28,7 @@
   },
   "leanFile": {
     "path": "Proofs/A054656DistinctPrimePartition.lean",
-    "sorries": 4,
+    "sorries": 2,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 4

--- a/src/data/research/problems/issue-41831-formalize-oeis-a054656-primes-absent-from-every-di.json
+++ b/src/data/research/problems/issue-41831-formalize-oeis-a054656-primes-absent-from-every-di.json
@@ -6,7 +6,7 @@
   "tier": "B",
   "tractability": 5,
   "started": "2026-07-22",
-  "lastUpdate": "2026-07-22",
+  "lastUpdate": "2026-07-23",
   "path": "proofs/Proofs/A054656DistinctPrimePartition.lean",
   "leanFiles": [
     "proofs/Proofs/A054656DistinctPrimePartition.lean"
@@ -24,16 +24,19 @@
         "reopenCriterion": "build a two-primes-in-(q,2q] lemma on top of Nat.exists_prime_lt_and_le_two_mul (Mathlib has no Ramanujan-prime result)",
         "blockedAt": "2026-07-22"
       }
-    ]
+    ],
+    "nextAction": "Two primes in (q,2q] lemma, then the Bertrand strong induction for repr_of_ge_seven_ne."
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (first iteration): machine-checked the elementary core of A054656 in proofs/Proofs/A054656DistinctPrimePartition.lean. VERIFIED with 0 sorries and kernel `decide` only (no native_decide, no ofReduceBool): not_repr_one/four/six (1,4,6 are not sums of distinct primes), le_of_mem_repr, repr_of_reprAvoiding, not_reprAvoiding_of_mem_exceptional, and the pivot reduction present_iff_residual_repr (p present in n ↔ p prime ∧ p ≤ n ∧ n−p is a distinct-prime sum avoiding p). DEFERRED (sorry): seed_block, interval_extension, repr_of_ge_seven_ne, A054656_main. Build passes via docker-build.sh on Lean v4.31.0 / current Mathlib.",
+    "progressSummary": "PROGRESS (iteration 2, 2026-07-23): seed_block PROVED kernel-only — the single window [13,90] (B-A = 77 >= 64) is representable avoiding ANY one prime, via a List-recursion subset-sum checker canSum (no Finset.powerset; default heartbeats!) + soundness bridge canSum_sound + checkWindow, over the 11 primes <= 31. Pool had to grow from primes <= 23: avoiding p=23 the longest run was [7,70], B-A = 63 — one short. TWO defective scaffold statements repaired: interval_extension's hypotheses (B < q AND q <= B-A+1) force A = 0 and are jointly unsatisfiable (vacuous engine) — REPLACED by the proved top-down step reprAvoiding_add_prime (r < q fresh prime => r+q representable); repr_of_ge_seven_ne was FALSE without 23 <= m+p (counterexamples (8,3),(9,2),(10,3),(11,11),(12,7),(2,2),(3,3), all m+p < 23) — hypothesis added, still sorried. Remaining: 2 sorries — the Bertrand/Ramanujan induction (needs 'two primes in (q,2q]', NOT in Mathlib, must be built on Nat.exists_prime_lt_and_le_two_mul) and final assembly A054656_main.",
     "insights": [
       "Encoding 'sum of DISTINCT primes' as `∃ S : Finset ℕ, (∀ q ∈ S, Nat.Prime q) ∧ S.sum id = m` makes distinctness automatic (Finset), and non-representability of a small m reduces to a bounded search: every summand p ≤ m (Finset.single_le_sum), so S ⊆ (primes ≤ m); fin_cases over the powerset + kernel decide closes 1,4,6.",
       "The whole conjecture pivots on one fully-elementary reduction: p occurs in a distinct-prime partition of n iff p is prime, p ≤ n, and n−p is a sum of distinct primes AVOIDING p. Proved both directions with Finset.add_sum_erase (forward: erase p) and Finset.sum_insert (reverse: insert p). This is verified and is the load-bearing lemma.",
       "Because ReprAvoiding m p ⇒ Repr m, the three non-representability facts for 1,4,6 immediately give ¬ReprAvoiding for every forbidden prime — the exceptional residuals need no per-p work.",
       "The exceptional set {1,4,6} maps to absent primes {n−1,n−4,n−6}: p absent ⟺ n−p ∈ {1,4,6} ⟺ p ∈ {n−1,n−4,n−6}, which is exactly the A054656 formula once every other residual is shown representable.",
-      "eta/atom gotcha: `S.sum id` (Finset.sum S id) and `∑ x ∈ S, id x` (Finset.sum S (fun x => id x)) differ syntactically; `rw`/`omega` treat them as distinct atoms. Use a calc chain or `simpa` to bridge, and feed omega a single consistent atom."
+      "eta/atom gotcha: `S.sum id` (Finset.sum S id) and `∑ x ∈ S, id x` (Finset.sum S (fun x => id x)) differ syntactically; `rw`/`omega` treat them as distinct atoms. Use a calc chain or `simpa` to bridge, and feed omega a single consistent atom.",
+      "List-recursion Bool checkers (canSum) beat Finset.powerset decides by orders of magnitude in the kernel: 12 window-decides x 78 values x 2^10 leaves ran at DEFAULT heartbeats.",
+      "Scaffolded sorry statements must be adversarially checked before proving: two of the four A054656 scaffolds were defective (one vacuous — contradictory hypotheses; one false — missing 23 <= m+p)."
     ],
     "builtItems": [
       "proofs/Proofs/A054656DistinctPrimePartition.lean — new file, builds on Lean v4.31.0",
@@ -41,18 +44,19 @@
       "le_of_mem_repr, repr_of_reprAvoiding, not_reprAvoiding_of_mem_exceptional — VERIFIED helpers",
       "present_iff_residual_repr — VERIFIED reduction lemma (the pivot of the whole proof)",
       "Repr / ReprAvoiding / Present / D — definitions matching the OEIS statement",
-      "seed_block, interval_extension, repr_of_ge_seven_ne, A054656_main — stated with sorry (engine + main assembly deferred)"
+      "seed_block, interval_extension, repr_of_ge_seven_ne, A054656_main — stated with sorry (engine + main assembly deferred)",
+      "seedPool (11 primes <= 31), canSum (kernel subset-sum checker), canSum_sound, reprAvoiding_of_canSum, checkWindow(+_sound), seed_case",
+      "seed_block PROVED: window [13,90] representable avoiding any prime (12 kernel decides, default heartbeats)",
+      "reprAvoiding_add_prime PROVED: top-down fresh-prime extension (replaces vacuous interval_extension)"
     ],
     "mathlibGaps": [
       "No Ramanujan-prime result in Mathlib. The proof needs '(q,2q] contains at least TWO primes' (second Ramanujan prime R₂ = 11) so that after deleting the single forbidden prime p an available prime ≤ 2q remains. This must be BUILT on Nat.exists_prime_lt_and_le_two_mul (Bertrand, in Mathlib/NumberTheory/Bertrand.lean, alias Nat.bertrand: ∀ n≠0, ∃ p, Nat.Prime p ∧ n<p ∧ p≤2n). Bertrand gives only ONE prime in (n,2n]; the two-primes strengthening is the key missing ingredient.",
       "No packaged 'sum of distinct primes representability' API; the seed-block enumeration (≤2^9=512 subsets of the nine primes ≤23) and interval-extension engine must be built from Finset.powerset + decide."
     ],
     "nextSteps": [
-      "Prove seed_block by kernel `decide` over the powerset of {2,3,5,7,11,13,17,19,23}\\{p}; measure whether kernel decide handles 512 subsets or whether native_decide (→ disclose Lean.ofReduceBool, mark axiomatized) is needed.",
-      "Prove interval_extension: for m ∈ (B, B+q] write m = q + (m−q) with m−q ∈ [A,B]; q ∉ the seed set because q > B; combine with the covering representation avoiding p.",
-      "Build the two-primes-in-(q,2q] lemma on Nat.exists_prime_lt_and_le_two_mul (apply Bertrand twice / to a shifted interval), then run the induction pushing the representable interval to infinity (repr_of_ge_seven_ne).",
-      "Assemble A054656_main from present_iff_residual_repr + the three non-representability facts + repr_of_ge_seven_ne; handle the n ≥ 23 boundary so the residuals n−1,n−4,n−6 are the only exceptions.",
-      "Cross-check the Lean statement against the proof packet's independent verification for 23 ≤ n ≤ 10,000 (6,554,726 incidences, 640 subset-sum certificates) cited in issue #41831."
+      "Build two_primes_in_Ioc_double: for q >= 11(?), (q,2q] contains >= 2 primes — via Nat.exists_prime_lt_and_le_two_mul applied at q and at (q + p1)/2-ish midpoint, or finite decide + Bertrand chaining; this is the sole Mathlib gap.",
+      "repr_of_ge_seven_ne: strong induction on m — for m > 90 take Bertrand prime q in (m/2, m], r = m - q < q; if q = p or r in {1,4,6} take the SECOND prime in (m/2, m] (needs the two-primes lemma); base m in [13,90] = seed_block, m in [2,12] finite cases with 23 <= m+p forcing p large.",
+      "A054656_main assembly from present_iff_residual_repr + not_repr_{1,4,6} + repr_of_ge_seven_ne."
     ]
   },
   "references": [
@@ -60,5 +64,14 @@
     "GitHub issue #41831 (rjwalters/lean-genius)",
     "Mathlib/NumberTheory/Bertrand.lean — Nat.exists_prime_lt_and_le_two_mul"
   ],
-  "tags": ["oeis", "additive-number-theory", "distinct-primes", "partitions", "bertrand", "ramanujan-prime", "issue-sourced", "research"]
+  "tags": [
+    "oeis",
+    "additive-number-theory",
+    "distinct-primes",
+    "partitions",
+    "bertrand",
+    "ramanujan-prime",
+    "issue-sourced",
+    "research"
+  ]
 }


### PR DESCRIPTION
## Summary

Second research iteration for **issue #41831** (OEIS A054656 — primes absent from every distinct-prime partition of n). Three deliverables in `proofs/Proofs/A054656DistinctPrimePartition.lean`:

1. **`seed_block` PROVED** (was sorried): the single window `[13, 90]` (`B − A = 77 ≥ 64`) is representable as sums of distinct primes avoiding *any* one prime `p`.
2. **Vacuous scaffold replaced**: `interval_extension`'s hypotheses were jointly unsatisfiable — replaced by the proved top-down step `reprAvoiding_add_prime`.
3. **False scaffold repaired**: `repr_of_ge_seven_ne` was false as stated — hypothesis `23 ≤ m + p` added (still sorried, as intended).

Sorries: 4 → 2 (only the Bertrand/Ramanujan induction and final assembly remain).

## The seed block engine

`ReprAvoiding` is an existential over all `Finset ℕ`, so it isn't decidable directly. The certificate route:

- `canSum : List ℕ → ℕ → Bool` — subset-sum by structural recursion (use the head or don't). No `Finset.powerset`, so the kernel evaluates it cheaply.
- `canSum_sound` — a successful check yields an actual `Finset` summing to `m` (induction on the list; `Nodup` makes the chosen sublist a set).
- `checkWindow l A B` — `canSum` over the whole window in one decidable `Bool`, so each case is **one** `decide`, not 78 `interval_cases` decides.
- `seed_block` — 12 kernel decides (11 pool-prime cases + the `p ∉ seedPool` case, where freshness is exactly the case hypothesis). Compiled at **default heartbeats**; `#print axioms` = `propext, Classical.choice, Quot.sound`.

**Pool correction found by computation**: with the first iteration's pool (primes ≤ 23), avoiding `p = 23` the longest representable run is `[7, 70]` — `B − A = 63`, one short of the required 64, so `seed_block` was unprovable with that pool. The pool now uses the eleven primes ≤ 31, and `[13, 90]` works uniformly for every case.

## The two defective scaffolds

- `interval_extension` required both `B < q` (freshness) and `q ≤ B − A + 1` (no coverage gap). Together these force `A = 0` — and covering `[0, B]` is impossible since `1` is never a distinct-prime sum. The hypotheses are jointly unsatisfiable, making the theorem vacuous. The sound engine is top-down: `reprAvoiding_add_prime` (`r < q`, `q ≠ p` fresh prime ⟹ `r + q` representable avoiding `p`) — proved; in the Bertrand induction one takes `q ∈ (m/2, m]` so `r = m − q < q` holds by construction.
- `repr_of_ge_seven_ne` claimed `ReprAvoiding m p` for every `m ≥ 2, m ∉ {4,6}` and every prime `p`. Counterexamples: `(m,p) = (8,3)` (`8 = 3+5` is the only partition), `(9,2)` (`9 = 2+7`), `(10,3)` (`10 = 2+3+5 = 3+7`), `(11,11)`, `(12,7)`, `(2,2)`, `(3,3)`. All have `m + p < 23`; in the application `m + p = n ≥ 23`, so the added hypothesis `23 ≤ m + p` is exactly right.

## Files Modified

- `proofs/Proofs/A054656DistinctPrimePartition.lean` — engine section rewritten; header status updated
- `src/data/proofs/a054656-distinct-prime-partition/meta.json` — `leanFile.sorries` 4 → 2; description updated (status stays `formalized`)
- `src/data/research/problems/issue-41831-….json` — progressSummary/builtItems/insights/nextSteps

## Verification

- Host-verified Lean v4.31.0: `lake env lean` exit 0, only the 2 expected `sorry` warnings.
- `#print axioms` on `seed_block`, `reprAvoiding_add_prime`, `canSum_sound`: foundational axioms only. No `native_decide`, no `maxHeartbeats` pins.
- Window coverage independently cross-checked in exact arithmetic (Python) for all 12 avoid-cases before formalization.

## Status

**Outcome**: progress — engine half-built and now on sound foundations; 4 sorries → 2.
**Next Steps**: the sole Mathlib gap is "two primes in `(q, 2q]`" (to be built on `Nat.exists_prime_lt_and_le_two_mul`); then strong induction on `m` closes `repr_of_ge_seven_ne` (base `[13, 90]` = `seed_block`, step = `reprAvoiding_add_prime` with a Bertrand prime, second prime when `q = p` or the residual is exceptional), and `A054656_main` assembles via the verified reduction.

🤖 Generated by researcher-1
