### PR TITLE
Fix erdos-14: erdos_freud_finite axiom was mathematically false

### DIFF
--- a/proofs/Proofs/Erdos14Problem.lean
+++ b/proofs/Proofs/Erdos14Problem.lean
@@ -86,10 +86,12 @@ axiom ess_upper_lower_bound :
       ∃ᶠ N : ℕ in (atTop : Filter ℕ),
         C * (N : ℝ) ^ ((1 : ℝ) / 3 - ε) ≤ (nonUniqueSumCountInf A N : ℝ))
 
-/-- **Erdős–Freud**: For any finite A ⊆ ℕ, the non-unique sum count satisfies
-    |{1,...,N}\B| < 2^{3/2} · N^{1/2}. The constant 2^{3/2} may be optimal. -/
+/-- **Erdős–Freud**: For every N, there exists A ⊆ {1,...,N} whose non-unique sum
+    count satisfies |{1,...,N}\B| < 2^{3/2} · N^{1/2}. The constant 2^{3/2} may be
+    optimal. (Existential: an upper bound achieved by some choice of A, not a bound
+    satisfied by every A — e.g. A = {1,...,N} itself violates it.) -/
 axiom erdos_freud_finite :
-  ∀ (A : Finset ℕ) (N : ℕ),
+  ∀ N : ℕ, ∃ A : Finset ℕ, A ⊆ Icc 1 N ∧
     (nonUniqueSumCount A N : ℝ) < 2 ^ ((3 : ℝ) / 2) * (N : ℝ) ^ ((1 : ℝ) / 2)
 
 /- ## Structural Observations -/

--- a/src/data/proofs/erdos-14/meta.json
+++ b/src/data/proofs/erdos-14/meta.json
@@ -21,14 +21,14 @@
     "erdosUrl": "https://erdosproblems.com/14",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 109,
+    "lineCount": 111,
     "prerequisites": [
       "Additive combinatorics (sumsets and representation functions)",
       "Finite set theory",
       "Extremal combinatorics",
       "Probabilistic method"
     ],
-    "assumptions": "2 axioms: ess_upper_lower_bound (Erdős-Sárközy-Szemerédi combined upper+lower bound) and erdos_freud_finite (Erdős-Freud finite analogue). Open conjectures Erdos14a and Erdos14b are formalized as Prop definitions. 0 sorries.",
+    "assumptions": "2 axioms: ess_upper_lower_bound (Erdős-Sárközy-Szemerédi combined upper+lower bound) and erdos_freud_finite (Erdős-Freud finite analogue: ∃ A ⊆ {1,...,N} achieving the bound). Open conjectures Erdos14a and Erdos14b are formalized as Prop definitions. 0 sorries.",
     "mathlib_version": "4.31.0",
     "theoremCount": 1,
     "definitionCount": 6
@@ -105,21 +105,21 @@
       "id": "erdos-freud",
       "title": "Erdős-Freud Finite Analogue",
       "startLine": 89,
-      "endLine": 93,
+      "endLine": 95,
       "summary": "For $A \\subseteq \\{1,\\ldots,N\\}$, $\\exists A$ with $f_A(N) < 2^{3/2}\\sqrt{N}$. The constant $2\\sqrt{2}$ may be optimal.",
       "mathContext": "For $A \\subseteq \\{1,\\ldots,N\\}$, $\\exists A$ with $f_A(N) < $$2^{{3/2}$}$\\sqrt{N}$. The constant $2\\sqrt{2}$ may be optimal."
     },
     {
       "id": "structural-observations",
       "title": "Structural Observations",
-      "startLine": 94,
-      "endLine": 109,
+      "startLine": 97,
+      "endLine": 111,
       "summary": "`non_unique_monotone`: proves the non-unique sum count `nonUniqueSumCountInf A N` is monotonically non-decreasing in N (M ≤ N ⟹ count M ≤ count N), via `Set.ncard_le_ncard` on the nested difference sets. A preceding comment records the Sidon-set heuristic: a Sidon A has ≤ √N + O(N^{1/4}) elements up to N, so its sumset misses ~N integers.",
       "mathContext": "$M \\le N \\implies \\mathrm{nonUniqueSumCount}(A,M) \\le \\mathrm{nonUniqueSumCount}(A,N)$ — the count of non-uniquely-represented sums grows with the window, proved by monotonicity of `Set.ncard` on nested `Icc` differences."
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #14 in 110 lines of Lean 4, encoding the unique-sum representation problem with both finite and infinite versions, the two open conjectures, ESS bounds ($O(N^{1/2+\\varepsilon})$ eventually, $\\Omega(N^{1/3-\\varepsilon})$ frequently), the Erdős-Freud finite analogue, and structural observations about Sidon sets. Zero sorries; all deep results axiomatized.",
+    "summary": "This formalization captures Erdős Problem #14 in 111 lines of Lean 4, encoding the unique-sum representation problem with both finite and infinite versions, the two open conjectures, ESS bounds ($O(N^{1/2+\\varepsilon})$ eventually, $\\Omega(N^{1/3-\\varepsilon})$ frequently), the Erdős-Freud finite analogue, and structural observations about Sidon sets. Zero sorries; all deep results axiomatized.",
     "implications": "**Theoretical Significance**: Resolution would clarify the fundamental limits of unique representation in additive combinatorics.\n\nIf conjecture (a) holds, it establishes $\\sqrt{N}$ as a universal barrier — no set can achieve better than $\\sim \\sqrt{N}$ non-unique sums. This connects to the broader theory of additive bases, Sidon sets, and the probabilistic method in combinatorial number theory.",
     "openQuestions": [
       "Is $f_A(N) \\gg N^{1/2-\\varepsilon}$ for all $A$ and all large $N$? This is conjecture (a), the main open question.",
@@ -141,7 +141,7 @@
       "Asymptotics"
     ],
     "namespace": null,
-    "lineCount": 109,
+    "lineCount": 111,
     "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 6,


### PR DESCRIPTION
## Integrity Issue (CRITICAL — inconsistent axiom)

**Proof**: erdos-14
**Problem**: `erdos_freud_finite` axiomatized a FALSE mathematical statement, making the axiom set kernel-inconsistent.

## Evidence

The axiom claimed the Erdős–Freud bound holds for **every** finite `A ⊆ ℕ`:

```lean
axiom erdos_freud_finite :
  ∀ (A : Finset ℕ) (N : ℕ),
    (nonUniqueSumCount A N : ℝ) < 2 ^ ((3 : ℝ) / 2) * (N : ℝ) ^ ((1 : ℝ) / 2)
```

But the real Erdős–Freud theorem (correctly stated in erdos-14's own `meta.json` prose,
and correctly formalized as an existential in the sibling gallery entry
`erdos-14-unique-sums` / `Erdos14UniqueSums.lean`) says only that **some** `A ⊆ {1,...,N}`
achieves the bound — not every `A`.

Counterexample: for `A = Finset.Icc 1 20`, `N = 20`, `nonUniqueSumCount A N = 18`
(computed via `native_decide`), but the claimed universal bound is
`2^{3/2} * sqrt(20) ≈ 12.65`. `18 < 12.65` is false, so the axiom is false at this
instance. I confirmed this is kernel-derivable by writing a scratch file that proves
`False` from the old axiom + this concrete instance (compiled cleanly via
`docker-build.sh`, then deleted — never committed).

## Fix (applied in this PR)

Changed the axiom to the correct existential form, matching both the file's own prose
and the sibling entry's formalization:

```lean
axiom erdos_freud_finite :
  ∀ N : ℕ, ∃ A : Finset ℕ, A ⊆ Icc 1 N ∧
    (nonUniqueSumCount A N : ℝ) < 2 ^ ((3 : ℝ) / 2) * (N : ℝ) ^ ((1 : ℝ) / 2)
```

`Proofs/Erdos14Problem.lean` rebuilds cleanly (only pre-existing deprecation warnings).
Counts unchanged (2 axioms, 1 theorem, 6 definitions, 0 sorries); `meta.json` line/section
numbers updated for the 2-line docstring growth.

---
Discovered during gallery integrity audit (reserve mode).