### PR TITLE
audit(erdos-14): mark issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11084,9 +11084,9 @@
     },
     "erdos-14": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:03:34Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T18:29:48Z",
+      "result": "issues-fixed"
     },
     "erdos-14-unique-sums": {
       "auditCount": 3,


### PR DESCRIPTION
Tracker update for #42428 (erdos-14: fixed a mathematically false universal
`erdos_freud_finite` axiom, converted to the correct existential statement).