### PR TITLE
Enrich hilbert-10-oq-04-oq-03-oq-02: split single-row/worked-example sections

### DIFF
--- a/src/data/proofs/hilbert-10-oq-04-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/hilbert-10-oq-04-oq-03-oq-02/annotations.json
@@ -50,7 +50,7 @@
   {
     "id": "h10oq040302-ann-04",
     "proofId": "hilbert-10-oq-04-oq-03-oq-02",
-    "range": { "startLine": 82, "endLine": 92 },
+    "range": { "startLine": 82, "endLine": 94 },
     "type": "definition",
     "title": "A Worked 2×2 System",
     "content": "An explicit example certifies the system statement is non-vacuous: the 2×2 system x + 2y = 5, 3x + 4y = 11 is solvable with witness (x, y) = (1, 2), since 1 + 2·2 = 5 and 3·1 + 4·2 = 11. The proof supplies the witness ![1, 2], reduces the vector equality pointwise with funext, and discharges each coordinate by fin_cases i <;> simp using Fin.sum_univ_two to expand the matrix–vector product. Concretely this exhibits a lattice point: b = (5, 11)ᵀ is the column combination 1·(1,3)ᵀ + 2·(2,4)ᵀ, an instance of the column-span membership the bridge characterizes abstractly.",


### PR DESCRIPTION
## Summary
- Sections were at 4/5: the "single-row" section spanned lines 62-92, bundling the single-row consistency theorem (`solvable_single_row_iff_sum`, 62-80) with the worked 2x2 example (82-92) into one entry, even though `annotations.json` already treated them as two distinct annotations.
- Split into 5 sections at the real theorem boundary: header (1-44, extended to cover the previously-uncovered import/open/namespace/variable lines 38-44), range-membership (45-51), colspan-bridge (53-60), single-row theorem (62-80), worked 2×2 example (82-94, extended to the file's closing `end`).
- Extended the matching `worked-example` annotation's `endLine` from 92 to 94 for consistency.
- No changes to the Lean source, `overview`, `conclusion`, or the other 4 annotations (already well-covered with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`).

## Test plan
- [x] `meta.json` and `annotations.json` validate as JSON
- [x] File size (~14.6 KB) well under the 60 KB cap
- [x] Gallery build (enrichment/search-index/loading-facts/redirects stages) passes on this entry