### PR TITLE
Enrich basel-problem-oq-09-oq-01: add second open question (odd-exponent lambda)

### DIFF
--- a/src/data/proofs/basel-problem-oq-09-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-09-oq-01/meta.json
@@ -173,6 +173,11 @@
         "id": "basel-problem-oq-09-oq-01-oq-01",
         "question": "Prove the Dirichlet eta companion η(s) = (1 − 2^{1−s})ζ(s) as a sibling of hasSum_odd_pow by splitting the alternating zeta into its even and odd parts, recovering η(2) = π²/12 and η(4) = 7π⁴/720.",
         "significance": "medium"
+      },
+      {
+        "id": "basel-problem-oq-09-oq-01-oq-02",
+        "question": "hasSum_odd_pow is stated for arbitrary s : ℕ, not just even s — instantiate it at an odd exponent such as s = 3. No closed form for ζ(3) (Apéry's constant) is known, but the lemma still yields the unconditional identity λ(3) = ∑ 1/(2k+1)³ = (7/8)·ζ(3), pinning the odd-index sum to the same fixed fraction of ζ(3) regardless of whether ζ(3) itself has a closed form.",
+        "significance": "low"
       }
     ]
   },
@@ -208,6 +213,11 @@
       "id": "basel-problem-oq-09-oq-01-oq-01",
       "question": "Prove the Dirichlet eta companion η(s) = (1 − 2^{1−s})ζ(s) by an analogous even/odd split of the alternating zeta, recovering η(2) = π²/12 and η(4) = 7π⁴/720.",
       "significance": "medium"
+    },
+    {
+      "id": "basel-problem-oq-09-oq-01-oq-02",
+      "question": "hasSum_odd_pow is stated for arbitrary s : ℕ, not just even s — instantiate it at an odd exponent such as s = 3. No closed form for ζ(3) (Apéry's constant) is known, but the lemma still yields the unconditional identity λ(3) = ∑ 1/(2k+1)³ = (7/8)·ζ(3), pinning the odd-index sum to the same fixed fraction of ζ(3) regardless of whether ζ(3) itself has a closed form.",
+      "significance": "low"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary
- `conclusion.openQuestions` (and mirrored top-level `openQuestions`) had only 1 item; the enrichment quality target requires 2+.
- Adds a genuine second open question: `hasSum_odd_pow` in `BaselProblemOQ09OQ01.lean` is proved for arbitrary `s : ℕ` (no parity restriction), but the file only instantiates it at even exponents (s=2, s=4, general s=2m). The new question notes it also pins odd-exponent Dirichlet lambda values — e.g. λ(3) = (7/8)·ζ(3) — to a fixed fraction of ζ(3), even though ζ(3) (Apéry's constant) has no known closed form.
- No content deleted; all existing fields (5 annotations with mathContext/significance/relatedConcepts, 6-section coverage, 5 keyInsights, historicalContext, crossReferences) were already at target and left untouched. File size 14.6 KB, well under the 60 KB cap.

## Test plan
- [x] `python3 -m json.tool` validates the edited `meta.json`
- [x] `pnpm build` ran clean over the edited file (regenerated ~2100 unrelated files across the repo from stale caches; those were reverted, only the target file is included in this PR)