### PR TITLE
audit(a054656-distinct-prime-partition): mark issues-fixed in tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31901,8 +31901,8 @@
       "issues": []
     },
     "a054656-distinct-prime-partition": {
-      "auditCount": 1,
-      "lastAudited": "2026-07-22T23:13:19Z",
+      "auditCount": 2,
+      "lastAudited": "2026-07-23T18:37:51Z",
       "result": "issues-fixed",
       "issues": []
     }


### PR DESCRIPTION
## Summary
- Tracker-only follow-up to #42434 (content fix already merged): marks `a054656-distinct-prime-partition` as `issues-fixed` in `audit-tracker.json` so it doesn't resurface as a reserve-mode target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)