### PR TITLE
Enrich hilbert-9-reciprocity-oq-04: reanchor sections to real code boundaries (3->5)

### DIFF
--- a/src/data/proofs/hilbert-9-reciprocity-oq-04/meta.json
+++ b/src/data/proofs/hilbert-9-reciprocity-oq-04/meta.json
@@ -94,28 +94,44 @@
   ],
   "sections": [
     {
+      "id": "docs-imports",
+      "title": "Documentation, Imports, and Shared Setup",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "File header explaining the Hilbert's Ninth Problem context and stating the constant reciprocity law (a/P) = χ_q(a)^{deg P}, followed by `import Mathlib`, `open Finset`, the `Hilbert9ConstantReciprocity` namespace, and the shared `variable` block fixing `F K : Type*` as finite fields with `[Algebra F K]` — the ambient hypotheses used by every theorem below.",
+      "mathContext": "$F, K$ finite fields with $F \\hookrightarrow K$ via `algebraMap`, i.e. $K$ a finite extension of $F$."
+    },
+    {
       "id": "characteristic-and-casts",
       "title": "Characteristic Transfer and {±1}-Cast Injectivity",
-      "startLine": 47,
-      "endLine": 67,
+      "startLine": 45,
+      "endLine": 63,
       "summary": "Two helper lemmas. cast_pm_inj: integers in {1,−1} that agree after casting into a field of characteristic ≠ 2 are equal. ringChar_extension_ne_two: the algebra map preserves characteristic, so odd characteristic of F passes to K (via charP_of_injective_algebraMap).",
       "mathContext": "$\\mathrm{ringChar}\\,K = \\mathrm{ringChar}\\,F \\neq 2.$"
     },
     {
       "id": "constant-reciprocity",
       "title": "The Constant Reciprocity Law",
-      "startLine": 68,
-      "endLine": 156,
+      "startLine": 65,
+      "endLine": 148,
       "summary": "quadraticChar_algebraMap_eq_pow. After the degenerate a = 0 case, Euler's criterion in F and K plus the Nat identity card K / 2 = (q/2)·S (from card K = q^d, (q−1)·S = q^d−1, and q odd) give A^{card K/2} = (A^{q/2})^S; then (A^{q/2})^2 = A^{q−1} = 1 and S ≡ d (mod 2) collapse the exponent to d, and the {±1}-cast injectivity descends the value equality to the integer identity.",
       "mathContext": "$\\chi_K(a) = \\chi_F(a)^{[K:F]},\\quad [K:F] = d.$"
     },
     {
       "id": "square-criterion",
-      "title": "Square Criterion and the Even-Degree Corollary",
-      "startLine": 157,
-      "endLine": 186,
-      "summary": "isSquare_algebraMap_iff reads the reciprocity law through quadraticChar_one_iff_isSquare: a nonsquare a (χ_F(a) = −1) has χ_K(a) = (−1)^d = 1 iff d is even. isSquare_algebraMap_of_even_finrank specializes to even degree, covering all constants (including 0) and in particular the quadratic extension.",
+      "title": "Square Criterion",
+      "startLine": 150,
+      "endLine": 176,
+      "summary": "isSquare_algebraMap_iff reads the reciprocity law through quadraticChar_one_iff_isSquare: a nonsquare a (χ_F(a) = −1) has χ_K(a) = (−1)^d = 1 iff d is even, so a nonzero constant is a square in K iff it is already a square in F or [K:F] is even.",
       "mathContext": "$\\text{nonsquare } a \\text{ becomes a square in } F_{q^d} \\iff 2 \\mid d.$"
+    },
+    {
+      "id": "even-degree-corollary",
+      "title": "Even-Degree Corollary",
+      "startLine": 178,
+      "endLine": 186,
+      "summary": "isSquare_algebraMap_of_even_finrank specializes the square criterion: when [K:F] is even, every constant a ∈ F (including 0) is a square in K — in particular all of F_q is a square in the quadratic extension F_{q^2}. The a = 0 case is immediate (IsSquare.zero); otherwise it invokes isSquare_algebraMap_iff with the even hypothesis.",
+      "mathContext": "$2 \\mid [K:F] \\implies \\mathrm{IsSquare}(\\mathrm{algebraMap}_{F}^{K}\\,a)$ for every $a \\in F$."
     }
   ],
   "references": [


### PR DESCRIPTION
## Summary

`meta.json`'s `sections` array had two defects:

1. **Uncovered header** — no section covered lines 1-44 (the file's docstring
   explaining Hilbert's Ninth Problem context, `import Mathlib`, `open Finset`,
   the namespace, and the shared `variable {F K : Type*} ... [Algebra F K]`
   block used by every theorem in the file).
2. **Mislabeled boundaries** — `characteristic-and-casts` was anchored at
   `47-67`, which starts mid-docstring (missing the `omit ... in` clause and
   docstring opening at lines 45-46) and ends 4 lines past the actual code
   (bleeding into the next theorem's docstring). `constant-reciprocity`
   started at 68 instead of 65 for the same reason. `square-criterion` bundled
   two structurally distinct theorems (`isSquare_algebraMap_iff` and
   `isSquare_algebraMap_of_even_finrank`) into one section whose start (157)
   cut off the first three lines of its own docstring.

## Changes

Reanchored all sections to real theorem/comment boundaries verified directly
against `proofs/Proofs/Hilbert9ConstantReciprocity.lean`, and split the tail
into two sections matching the file's actual two-theorem structure:

- `docs-imports` (1-44) — new
- `characteristic-and-casts` (45-63, was 47-67)
- `constant-reciprocity` (65-148, was 68-156)
- `square-criterion` (150-176, was 157-186, narrowed to just `isSquare_algebraMap_iff`)
- `even-degree-corollary` (178-186) — new, `isSquare_algebraMap_of_even_finrank`

No content was removed; `annotations.json`'s line ranges were already accurate
and are unchanged. `meta.json` stays well under the 60 KB size cap (~14.8 KB).

## Test plan

- [x] `pnpm build` gallery-data step enriches this entry without error (JSON
      validated); unrelated `tsc` failure is a pre-existing missing
      `node_modules/.bin/tsc` in this worktree, not caused by this change
- [x] Verified new line ranges by reading the `.lean` file directly
- [x] Confirmed no other open PR exists for this slug before opening this one