### PR TITLE
Enrich jensen-inequality-oq-01-oq-01-oq-01: split sections to 5

### DIFF
--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01/annotations.json
@@ -2,10 +2,10 @@
   {
     "id": "youngn-oq010101-header",
     "proofId": "jensen-inequality-oq-01-oq-01-oq-01",
-    "range": { "startLine": 1, "endLine": 31 },
+    "range": { "startLine": 1, "endLine": 39 },
     "type": "concept",
     "title": "The n-variable Young product inequality",
-    "content": "The header generalizes the parent's two-term Young inequality to an arbitrary finite family of exponents. For pᵢ > 0 with ∑ 1/pᵢ = 1 (generalized Hölder conjugacy) and nonnegative data aᵢ, ∏ aᵢ ≤ ∑ aᵢ^{pᵢ}/pᵢ, with equality iff all aᵢ^{pᵢ} are equal. This stands to the parent exactly as the grandparent's general weighted AM–GM stands to its two-variable instance: take weights wᵢ = 1/pᵢ and data zᵢ = aᵢ^{pᵢ}, so the weighted geometric mean ∏(aᵢ^{pᵢ})^{1/pᵢ} collapses to ∏aᵢ and the weighted arithmetic mean is the Young sum. Mathlib has only the two-variable Young inequality and none of the equality cases; this file supplies the full n-variable form, answering the parent's listed open question.",
+    "content": "The header generalizes the parent's two-term Young inequality to an arbitrary finite family of exponents. For pᵢ > 0 with ∑ 1/pᵢ = 1 (generalized Hölder conjugacy) and nonnegative data aᵢ, ∏ aᵢ ≤ ∑ aᵢ^{pᵢ}/pᵢ, with equality iff all aᵢ^{pᵢ} are equal. This stands to the parent exactly as the grandparent's general weighted AM–GM stands to its two-variable instance: take weights wᵢ = 1/pᵢ and data zᵢ = aᵢ^{pᵢ}, so the weighted geometric mean ∏(aᵢ^{pᵢ})^{1/pᵢ} collapses to ∏aᵢ and the weighted arithmetic mean is the Young sum. Mathlib has only the two-variable Young inequality and none of the equality cases; this file supplies the full n-variable form, answering the parent's listed open question. Followed by the imports, open Finset Real, and the ambient {ι, s, p, a} variables shared by every theorem below.",
     "mathContext": "$\\prod_i a_i \\le \\sum_i \\frac{a_i^{p_i}}{p_i},\\quad \\sum_i \\frac{1}{p_i} = 1$",
     "significance": "supporting",
     "relatedConcepts": ["Young's inequality", "weighted AM–GM", "generalized Hölder", "equality case"],

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01/meta.json
@@ -62,25 +62,41 @@
       "id": "header",
       "title": "Module Header and Overview",
       "startLine": 1,
-      "endLine": 40,
-      "summary": "Frames the n-variable Young product inequality as the general weighted AM–GM, notes Mathlib has only the two-variable Young inequality and none of the equality cases, and lists the three main results.",
+      "endLine": 39,
+      "summary": "Frames the n-variable Young product inequality as the general weighted AM–GM, notes Mathlib has only the two-variable Young inequality and none of the equality cases, and lists the three main results. Followed by the imports (Mathlib, both parent files) and open Finset Real, and the ambient {ι, s, p, a} variables shared by every theorem below.",
       "mathContext": "For $p_i>0$ with $\\sum 1/p_i=1$ and $a_i\\ge0$: $\\prod_i a_i \\le \\sum_i a_i^{p_i}/p_i$, equality iff all $a_i^{p_i}$ equal. Weights $w_i=1/p_i$, data $z_i=a_i^{p_i}$; geometric mean $\\prod (a_i^{p_i})^{1/p_i}=\\prod a_i$."
     },
     {
       "id": "rpow-pow-inv",
       "title": "The telescoping identity (aᵖ)^{1/p} = a",
       "startLine": 41,
-      "endLine": 47,
+      "endLine": 45,
       "summary": "rpow_pow_inv: for a ≥ 0 and p ≠ 0, raising aᵖ to the reciprocal power recovers a, via Real.rpow_mul and p·p⁻¹ = 1. This collapses the weighted geometric mean of the aᵢ^{pᵢ} to the plain product.",
       "mathContext": "$(a^p)^{p^{-1}} = a^{p\\cdot p^{-1}} = a^1 = a$ for $a\\ge0$, $p\\neq0$."
     },
     {
-      "id": "young-prod",
-      "title": "The n-variable Young product inequality and its equality case",
-      "startLine": 48,
+      "id": "young-prod-le",
+      "title": "The n-Variable Young Product Inequality",
+      "startLine": 47,
+      "endLine": 67,
+      "summary": "young_prod_le: ∏ aᵢ ≤ ∑ aᵢ^{pᵢ}/pᵢ, by specializing the grandparent's weighted_amgm_le with weights wᵢ = 1/pᵢ and data zᵢ = aᵢ^{pᵢ}.",
+      "mathContext": "$\\prod_i a_i \\le \\sum_i a_i^{p_i}/p_i$. Apply weighted AM–GM with $w_i=p_i^{-1}$, $z_i=a_i^{p_i}$; rewrite $\\prod z_i^{w_i}=\\prod a_i$ and $\\sum w_i z_i=\\sum a_i^{p_i}/p_i$."
+    },
+    {
+      "id": "young-prod-eq-iff",
+      "title": "The Equality Case",
+      "startLine": 69,
+      "endLine": 86,
+      "summary": "young_prod_eq_iff: ∏ aᵢ = ∑ aᵢ^{pᵢ}/pᵢ iff all the aᵢ^{pᵢ} are equal, by the same weighted AM–GM specialization applied to weighted_amgm_eq_iff. Recovers the parent's two-variable young_eq_iff at n = 2.",
+      "mathContext": "$\\prod_i a_i = \\sum_i a_i^{p_i}/p_i \\iff \\forall j,k,\\ a_j^{p_j}=a_k^{p_k}$."
+    },
+    {
+      "id": "young-prod-lt-of-ne",
+      "title": "The Strict Form",
+      "startLine": 88,
       "endLine": 95,
-      "summary": "young_prod_le proves the inequality from the grandparent's weighted_amgm_le; young_prod_eq_iff proves equality ↔ all aᵢ^{pᵢ} equal from weighted_amgm_eq_iff; young_prod_lt_of_ne gives the strict form.",
-      "mathContext": "$\\prod_i a_i = \\sum_i a_i^{p_i}/p_i \\iff \\forall j,k,\\ a_j^{p_j}=a_k^{p_k}$. Apply weighted AM–GM with $w_i=p_i^{-1}$, $z_i=a_i^{p_i}$; rewrite $\\prod z_i^{w_i}=\\prod a_i$ and $\\sum w_i z_i=\\sum a_i^{p_i}/p_i$."
+      "summary": "young_prod_lt_of_ne: if two of the values aᵢ^{pᵢ} differ, the product is strictly less than the Young sum, via lt_of_le_of_ne against the equality case.",
+      "mathContext": "$\\exists j,k,\\ a_j^{p_j} \\ne a_k^{p_k} \\Rightarrow \\prod_i a_i < \\sum_i a_i^{p_i}/p_i$."
     }
   ],
   "references": [


### PR DESCRIPTION
## Summary
- Sections were at 3/5: the "young-prod" section (48-95) bundled three separate theorems (`young_prod_le`, `young_prod_eq_iff`, `young_prod_lt_of_ne`) into one.
- Split at the real theorem boundaries the existing `annotations.json` already used (its 5 annotations were already split this way): header (1-39), rpow-pow-inv (41-45), young-prod-le (47-67), young-prod-eq-iff (69-86), young-prod-lt-of-ne (88-95).
- Closed a small header gap (`endLine` 40→39, realigned to the real boundary right before the first theorem doc-comment at line 41) and synced the matching header annotation's `endLine` (31→39) to cover the imports/`open`/`variable` lines it was missing.
- No changes to the Lean source, `overview`, or `conclusion`.

## Test plan
- [x] `meta.json` and `annotations.json` validate as JSON
- [x] File size (~12.8 KB) well under the 60 KB cap
- [x] Gallery build passes on this entry (unrelated pre-existing errors elsewhere: erdos-763, stirling-formula-oq-02-oq-01)