### PR TITLE
Enrich knights-tour-oblique-oq-03: split sections to 5, fix header/commute gap

### DIFF
--- a/src/data/proofs/knights-tour-oblique-oq-03/annotations.json
+++ b/src/data/proofs/knights-tour-oblique-oq-03/annotations.json
@@ -5,7 +5,7 @@
     "type": "concept",
     "range": {
       "startLine": 1,
-      "endLine": 56
+      "endLine": 55
     },
     "title": "Two commuting symmetries of closed knight's tours",
     "content": "The OQ-02 program studies the symmetries that act on the histogram of oblique counts of closed knight's tours on the 8×8 board (Knuth, 2025). Two symmetries are natural and conceptually independent: the dihedral board group D₄ (applyD4Tour) permutes the SQUARES of the board (an isometry of the plane), while time-reversal (reverseTour, built in the OQ-02 reversal companion) permutes the TRAVERSAL ORDER of a fixed tour. This file proves they commute, so closed tours carry an order-16 D₄ × ℤ/2 action, refining the orbit-divisibility picture of the histogram. The docstring's honesty note distinguishes this assumption-free file from the base lineage, which uses native_decide (Lean.ofReduceBool) and accepts the uniqueness theorem unique_four_oblique as an axiom (Knuth's enumeration of ~1.3×10¹³ tours).",
@@ -28,7 +28,7 @@
     "proofId": "knights-tour-oblique-oq-03",
     "type": "theorem",
     "range": {
-      "startLine": 64,
+      "startLine": 56,
       "endLine": 71
     },
     "title": "reverseTour_applyD4Tour: reversal commutes with D₄",

--- a/src/data/proofs/knights-tour-oblique-oq-03/meta.json
+++ b/src/data/proofs/knights-tour-oblique-oq-03/meta.json
@@ -139,25 +139,41 @@
       "id": "header",
       "title": "File Header and the Two Symmetries",
       "startLine": 1,
-      "endLine": 56,
-      "summary": "Module docstring explaining the OQ-02 symmetry program, the two actions on closed tours (the dihedral board group D₄ and time-reversal), the claim that they commute to give an order-16 D₄ × ℤ/2 action, and an honesty note distinguishing this assumption-free file from the native_decide / enumeration-axiom base lineage. Imports the reversal companion file.",
+      "endLine": 55,
+      "summary": "Module docstring explaining the OQ-02 symmetry program, the two actions on closed tours (the dihedral board group D₄ and time-reversal), the claim that they commute to give an order-16 D₄ × ℤ/2 action, and an honesty note distinguishing this assumption-free file from the native_decide / enumeration-axiom base lineage. Imports the reversal companion file and declares the namespace.",
       "mathContext": "$D_4$ permutes board squares; reversal permutes traversal order; the file shows they commute."
     },
     {
       "id": "commute",
       "title": "Reversal commutes with D₄",
-      "startLine": 58,
+      "startLine": 56,
       "endLine": 71,
       "summary": "reverseTour_applyD4Tour: via closedTour_eq_iff the goal reduces to (t.squares.map (applyD4 g)).reverse = (t.squares.reverse).map (applyD4 g), closed by List.map_reverse.",
       "mathContext": "$\\mathrm{reverse}(\\mathrm{map}\\,\\sigma_g\\,L) = \\mathrm{map}\\,\\sigma_g\\,(\\mathrm{reverse}\\,L)$."
     },
     {
-      "id": "inverse-injective",
-      "title": "Invertibility and faithfulness of the composite symmetries",
+      "id": "left-inverse",
+      "title": "The Composite Symmetry Has an Explicit Inverse",
       "startLine": 73,
+      "endLine": 78,
+      "summary": "d4_reverse_leftInverse builds the explicit inverse of t ↦ reverseTour (applyD4Tour g t): t ↦ reverseTour (applyD4Tour (d4Inv g) t), using the commutation lemma, reverseTour_involutive, and applyD4Tour_inv_left.",
+      "mathContext": "Composite symmetry $R \\circ \\sigma_g$ has left inverse $R \\circ \\sigma_{g^{-1}}$."
+    },
+    {
+      "id": "injective",
+      "title": "Faithfulness of the Composite Symmetry",
+      "startLine": 80,
+      "endLine": 87,
+      "summary": "d4_reverse_injective derives injectivity of t ↦ reverseTour (applyD4Tour g t) via Function.LeftInverse.injective, so reversal together with D₄ acts faithfully (order 16 = |D₄ × ℤ/2|).",
+      "mathContext": "A function with a left inverse is injective; here the action of $D_4 \\times \\mathbb{Z}/2$ on closed tours is faithful."
+    },
+    {
+      "id": "orbit",
+      "title": "Reversal Maps D₄-Orbits to D₄-Orbits",
+      "startLine": 89,
       "endLine": 96,
-      "summary": "d4_reverse_leftInverse builds the explicit inverse of t ↦ reverseTour (applyD4Tour g t) (commutation + reverseTour_involutive + applyD4Tour_inv_left); d4_reverse_injective derives injectivity via Function.LeftInverse.injective; reverseTour_applyD4Tour_orbit records the orbit-level commutation.",
-      "mathContext": "Composite symmetry $R \\circ \\sigma_g$ has inverse $R \\circ \\sigma_{g^{-1}}$, so the action of $D_4 \\times \\mathbb{Z}/2$ is faithful."
+      "summary": "reverseTour_applyD4Tour_orbit: reversal maps the D₄-orbit of t onto the D₄-orbit of reverseTour t, witnessed by the same group element g.",
+      "mathContext": "$\\exists h,\\ \\mathrm{reverseTour}(\\sigma_g(t)) = \\sigma_h(\\mathrm{reverseTour}(t))$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Sections were at 3/5: "inverse-injective" (73-96) bundled three separate theorems (`d4_reverse_leftInverse`, `d4_reverse_injective`, `reverseTour_applyD4Tour_orbit`) into one.
- Split at real theorem boundaries into `left-inverse` (73-78), `injective` (80-87), and `orbit` (89-96), bringing sections from 3 to 5.
- Also fixed a real coverage gap: the header section/annotation ended at line 56 while `commute` started at line 64, leaving the section-level doc comment (57-63, "## Time-reversal commutes with the D₄ board action") uncovered by either. Moved the boundary (header 1-55, commute 56-71) so `commute` now includes its own introductory comment.
- Synced the matching `annotations.json` ranges (`ann-ktoq03-header` 1-56→1-55, `ann-ktoq03-commute` 64-71→56-71).
- No changes to the Lean source, `overview`, or `conclusion`.

## Test plan
- [x] `meta.json` and `annotations.json` validate as JSON
- [x] File size (~17.3 KB) well under the 60 KB cap
- [x] Gallery build passes on this entry (unrelated pre-existing errors elsewhere: erdos-763, stirling-formula-oq-02-oq-01)