### PR TITLE
Research: erdos-16-wip-01 - Erdős 1950 full strength: exceptional set has positive lower density

### DIFF
--- a/proofs/Proofs/Erdos16Problem.lean
+++ b/proofs/Proofs/Erdos16Problem.lean
@@ -136,7 +136,9 @@ def erdosCovering : List (ℕ × ℕ) :=
 More precise bounds on the density of the exceptional set.
 -/
 
-/-  The exceptional set has positive lower density. -/
+/-  The exceptional set has positive lower density: proved below as
+    `exceptionalCount_positive_density` (counting form, `≥ N / 22369620` below
+    any horizon `N ≥ 2^52`) and `lowerDensity_exceptionalSet_pos`. -/
 
 /-
 ## Related Problems
@@ -610,6 +612,223 @@ theorem exceptionalSet_infinite : ExceptionalSet.Infinite := by
   obtain ⟨n, hn, hmem⟩ := exists_exceptional_gt B
   exact absurd (hB hmem) (by omega)
 
+/-!
+## Erdős (1950), full strength: the exceptional set has positive lower density
+
+`exceptionalSet_infinite` extracts infinitely many exceptional integers from the
+covering progression `n ≡ 7629217 (mod 11184810)`, but Erdős's 1950 theorem is
+stronger: a *positive proportion* of integers lie in the exceptional set.  We
+now prove this by counting progression members below a horizon `N`.
+
+Among `n < N` the progression has `N / 11184810` members `coveringAP q` with
+index `q < N / 11184810`.  A member can fail the size hypothesis of
+`covering_progression_mem_exceptionalSet` only if it is *trapped* within `241`
+of a power of two, and each dyadic window `(2^k, 2^k + 241]` is far shorter
+than the common difference `11184810`, so it traps **at most one** member;
+the relevant powers of two below `N` number at most `log₂ N + 1`.  Hence at
+least `N / 11184810 - (log₂ N + 1)` integers below `N` are exceptional, and
+the logarithmic loss is eventually dwarfed by the linear main term: for
+`N ≥ 2^52` the count is at least `N / 22369620` — a positive proportion
+(`22369620 = 2 · 11184810`).
+-/
+
+/-- The `q`-th member of Erdős's covering progression
+`7629217 + q · 11184810` (`11184810 = 2·3·5·7·13·17·241`). -/
+def coveringAP (q : ℕ) : ℕ := 7629217 + q * 11184810
+
+theorem coveringAP_strictMono : StrictMono coveringAP := by
+  intro a b h
+  unfold coveringAP
+  omega
+
+/-- `n` is *trapped* if it lies within `241` of a smaller power of two `2^k`
+(`k ≥ 1`).  Trapped integers are exactly those that can fail the size
+hypothesis `241 < n - 2^k` of the covering obstruction. -/
+def Trapped (n : ℕ) : Prop := ∃ k, 1 ≤ k ∧ 2 ^ k < n ∧ n - 2 ^ k ≤ 241
+
+/-- Every untrapped member of the covering progression is exceptional: the six
+covering congruences and oddness hold identically along the progression, and
+untrappedness is precisely the missing size hypothesis. -/
+theorem coveringAP_mem_exceptionalSet {q : ℕ} (h : ¬ Trapped (coveringAP q)) :
+    coveringAP q ∈ ExceptionalSet := by
+  have hq : coveringAP q = 7629217 + q * 11184810 := rfl
+  refine covering_progression_mem_exceptionalSet (Nat.odd_iff.mpr (by omega))
+    (by omega) (by omega) (by omega) (by omega) (by omega) (by omega) ?_
+  intro k hk hlt
+  by_contra hc
+  exact h ⟨k, hk, hlt, by omega⟩
+
+open Classical in
+/-- In any index range whose progression members stay below `2 ^ m`, at most
+`m` indices are trapped: a trapped index pins its member inside a window
+`(2^k, 2^k + 241]` with `k < m`, and each such window — being far shorter than
+the common difference `11184810` — holds at most one progression member. -/
+theorem card_trapped_le {Q m : ℕ} (hQm : ∀ q, q < Q → coveringAP q < 2 ^ m) :
+    ((Finset.range Q).filter fun q => Trapped (coveringAP q)).card ≤ m := by
+  have hsub : ((Finset.range Q).filter fun q => Trapped (coveringAP q)) ⊆
+      (Finset.range m).biUnion fun k => (Finset.range Q).filter fun q =>
+        2 ^ k < coveringAP q ∧ coveringAP q - 2 ^ k ≤ 241 := by
+    intro q hq
+    simp only [Finset.mem_filter, Finset.mem_range] at hq
+    obtain ⟨hqQ, k, hk1, hklt, hkle⟩ := hq
+    have hkm : k < m := by
+      by_contra hc
+      have hle : (2 : ℕ) ^ m ≤ 2 ^ k := Nat.pow_le_pow_right (by norm_num) (not_lt.mp hc)
+      have := hQm q hqQ
+      omega
+    exact Finset.mem_biUnion.mpr ⟨k, Finset.mem_range.mpr hkm,
+      Finset.mem_filter.mpr ⟨Finset.mem_range.mpr hqQ, hklt, hkle⟩⟩
+  calc ((Finset.range Q).filter fun q => Trapped (coveringAP q)).card
+      ≤ ((Finset.range m).biUnion fun k => (Finset.range Q).filter fun q =>
+          2 ^ k < coveringAP q ∧ coveringAP q - 2 ^ k ≤ 241).card :=
+        Finset.card_le_card hsub
+    _ ≤ ∑ k ∈ Finset.range m, ((Finset.range Q).filter fun q =>
+          2 ^ k < coveringAP q ∧ coveringAP q - 2 ^ k ≤ 241).card :=
+        Finset.card_biUnion_le
+    _ ≤ ∑ _k ∈ Finset.range m, 1 := by
+        refine Finset.sum_le_sum fun k _ => ?_
+        refine Finset.card_le_one.mpr fun a ha b hb => ?_
+        simp only [Finset.mem_filter, Finset.mem_range] at ha hb
+        have h1 : coveringAP a = 7629217 + a * 11184810 := rfl
+        have h2 : coveringAP b = 7629217 + b * 11184810 := rfl
+        omega
+    _ = m := by simp
+
+open Classical in
+/-- The number of exceptional integers below `N`. -/
+noncomputable def exceptionalCount (N : ℕ) : ℕ :=
+  ((Finset.range N).filter fun n => n ∈ ExceptionalSet).card
+
+/-- **Counting form of Erdős (1950).**  Up to a logarithmic loss, the
+exceptional integers below `N` are at least as numerous as the covering
+progression members below `N`:
+`N / 11184810 ≤ exceptionalCount N + (log₂ N + 1)`. -/
+theorem exceptionalCount_lower_bound (N : ℕ) :
+    N / 11184810 ≤ exceptionalCount N + (Nat.log 2 N + 1) := by
+  classical
+  set Q := N / 11184810 with hQdef
+  set m := Nat.log 2 N + 1 with hmdef
+  -- every progression member with index below `Q` lies below `N` …
+  have hmem : ∀ q, q < Q → coveringAP q < N := by
+    intro q hq
+    have h1 : (q + 1) * 11184810 ≤ Q * 11184810 :=
+      Nat.mul_le_mul (Nat.succ_le_of_lt hq) le_rfl
+    have h2 : Q * 11184810 ≤ N := Nat.div_mul_le_self N 11184810
+    have h3 : coveringAP q = 7629217 + q * 11184810 := rfl
+    omega
+  -- … hence below the dyadic horizon `2 ^ m`
+  have hpow : N < 2 ^ m := hmdef ▸ Nat.lt_pow_succ_log_self (by norm_num) N
+  have hmem2 : ∀ q, q < Q → coveringAP q < 2 ^ m :=
+    fun q hq => lt_trans (hmem q hq) hpow
+  have htrap := card_trapped_le hmem2
+  -- the untrapped indices inject into the exceptional integers below `N`
+  have hsubset :
+      (((Finset.range Q).filter fun q => ¬ Trapped (coveringAP q)).image coveringAP) ⊆
+        (Finset.range N).filter fun n => n ∈ ExceptionalSet := by
+    intro n hn
+    simp only [Finset.mem_image, Finset.mem_filter, Finset.mem_range] at hn ⊢
+    obtain ⟨q, ⟨hqQ, hqt⟩, rfl⟩ := hn
+    exact ⟨hmem q hqQ, coveringAP_mem_exceptionalSet hqt⟩
+  have hcard :
+      ((Finset.range Q).filter fun q => ¬ Trapped (coveringAP q)).card ≤
+        exceptionalCount N := by
+    unfold exceptionalCount
+    rw [← Finset.card_image_of_injective _ coveringAP_strictMono.injective]
+    exact Finset.card_le_card hsubset
+  have hsplit :
+      ((Finset.range Q).filter fun q => Trapped (coveringAP q)).card +
+        ((Finset.range Q).filter fun q => ¬ Trapped (coveringAP q)).card = Q := by
+    rw [Finset.card_filter_add_card_filter_not, Finset.card_range]
+  omega
+
+/-- **Erdős (1950), positive-proportion form.**  For every `N ≥ 2^52` at least
+`N / 22369620` of the integers below `N` are exceptional
+(`22369620 = 2 · 11184810`): the exceptional set has positive lower density. -/
+theorem exceptionalCount_positive_density {N : ℕ} (hN : 2 ^ 52 ≤ N) :
+    N ≤ 22369620 * exceptionalCount N := by
+  have h52 : (0 : ℕ) < 2 ^ 52 := by norm_num
+  have hN0 : N ≠ 0 := by omega
+  set L := Nat.log 2 N with hL
+  have hlog52 : 52 ≤ L := (Nat.le_log_iff_pow_le (by norm_num) hN0).mpr hN
+  have hpowL : 2 ^ L ≤ N := Nat.pow_log_le_self 2 hN0
+  -- the logarithmic loss is dwarfed by the main term: `22369620 · (L + 2) ≤ N`
+  have hloss : 22369620 * (L + 2) ≤ N := by
+    set j := L - 25 with hjdef
+    have hj : 27 ≤ j := by omega
+    have hjpow : 2 * j ≤ 2 ^ j := by
+      have h1 : j - 1 < 2 ^ (j - 1) := Nat.lt_two_pow_self
+      have h2 : 2 ^ (j - 1 + 1) = 2 ^ (j - 1) * 2 := pow_succ 2 (j - 1)
+      have h3 : j - 1 + 1 = j := by omega
+      rw [h3] at h2
+      omega
+    have hL2 : L + 2 ≤ 2 ^ j := by omega
+    have hsplit : (2 : ℕ) ^ 25 * 2 ^ j = 2 ^ L := by
+      rw [← pow_add]
+      congr 1
+      omega
+    have hmul : 22369620 * (L + 2) ≤ 2 ^ 25 * 2 ^ j :=
+      Nat.mul_le_mul (by norm_num) hL2
+    omega
+  have hcount := exceptionalCount_lower_bound N
+  have hdiv : 11184810 * (N / 11184810) + N % 11184810 = N := Nat.div_add_mod N 11184810
+  have hmod : N % 11184810 < 11184810 := Nat.mod_lt _ (by norm_num)
+  omega
+
+open Classical in
+/-- **The exceptional set has positive lower density** (the bound announced in
+the Density Bounds section above): for every horizon `N` with `2^52 ≤ N + 1`,
+`density ExceptionalSet N ≥ 1 / 22369620`.  Since the bound holds for *all*
+sufficiently large `N`, every asymptotic density notion of `ExceptionalSet`
+(lower or upper) is at least `1 / 22369620 > 0` — Erdős's 1950 theorem at full
+positive-proportion strength. -/
+theorem density_exceptionalSet_ge {N : ℕ} (hN : 2 ^ 52 ≤ N + 1) :
+    (22369620 : ℝ)⁻¹ ≤ density ExceptionalSet N := by
+  have hcount : (N + 1 : ℕ) ≤ 22369620 * exceptionalCount (N + 1) :=
+    exceptionalCount_positive_density hN
+  have hde : density ExceptionalSet N =
+      (exceptionalCount (N + 1) : ℝ) / ((N : ℝ) + 1) := by
+    unfold density exceptionalCount
+    norm_num [decide_eq_true_eq, Finset.filter_congr_decidable]
+  have hcast : ((N : ℝ) + 1) ≤ 22369620 * (exceptionalCount (N + 1) : ℝ) := by
+    exact_mod_cast hcount
+  have hpos : (0 : ℝ) < (N : ℝ) + 1 := by positivity
+  rw [hde, le_div_iff₀ hpos]
+  have hkey : (22369620 : ℝ)⁻¹ * ((N : ℝ) + 1) ≤
+      (22369620 : ℝ)⁻¹ * (22369620 * (exceptionalCount (N + 1) : ℝ)) :=
+    mul_le_mul_of_nonneg_left hcast (by norm_num)
+  have hcancel : (22369620 : ℝ)⁻¹ * (22369620 * (exceptionalCount (N + 1) : ℝ)) =
+      (exceptionalCount (N + 1) : ℝ) := by
+    rw [← mul_assoc, inv_mul_cancel₀ (by norm_num), one_mul]
+  linarith
+
+/-- The `lowerDensity` functional of this file (an `⨅`-of-`⨆`) is positive on
+the exceptional set.  `density_exceptionalSet_ge` bounds the density from below
+at *every* sufficiently large horizon, so this inf-of-sup inherits the bound
+`1 / 22369620`. -/
+theorem lowerDensity_exceptionalSet_pos : 0 < lowerDensity ExceptionalSet := by
+  have hc : (0 : ℝ) < (22369620 : ℝ)⁻¹ := by norm_num
+  refine lt_of_lt_of_le hc ?_
+  unfold lowerDensity
+  refine le_ciInf fun N => ?_
+  have hbdd : BddAbove
+      (Set.range fun M : ℕ => ⨆ (_ : M ≥ N), density ExceptionalSet M) := by
+    refine ⟨1, ?_⟩
+    rintro x ⟨M, rfl⟩
+    by_cases h : M ≥ N
+    · show (⨆ (_ : M ≥ N), density ExceptionalSet M) ≤ 1
+      rw [ciSup_pos h]
+      exact density_le_one _ _
+    · haveI : IsEmpty (M ≥ N) := ⟨h⟩
+      show (⨆ (_ : M ≥ N), density ExceptionalSet M) ≤ 1
+      rw [iSup_of_empty', Real.sSup_empty]
+      norm_num
+  refine le_trans ?_ (le_ciSup hbdd (max N (2 ^ 52)))
+  show (22369620 : ℝ)⁻¹ ≤
+    ⨆ (_ : max N (2 ^ 52) ≥ N), density ExceptionalSet (max N (2 ^ 52))
+  rw [ciSup_pos (le_max_left N (2 ^ 52))]
+  exact density_exceptionalSet_ge
+    (le_trans (le_max_right _ _) (Nat.le_succ _))
+
 /-
 ## Summary
 
@@ -624,6 +843,12 @@ as 2^k + p (exceptional set) is an arithmetic progression plus density-0 set.
 - Romanoff (1934): Positive density of odd integers ARE of this form
 - Erdős (1950): Exceptional set CONTAINS an arithmetic progression
 - Chen (2023): Exceptional set is NOT just one progression + noise
+
+**Formalized here (axiom-free)**: Erdős (1950) at full strength — the covering
+progression puts the exceptional set at positive lower density
+(`exceptionalCount_positive_density`: at least `N / 22369620` members below
+every horizon `N ≥ 2^52`; `lowerDensity_exceptionalSet_pos`), strengthening
+`exceptionalSet_infinite`.
 
 **The exceptional set**:
 - Has positive but small density (~0.09)

--- a/research/problems/erdos-16-wip-01/knowledge.md
+++ b/research/problems/erdos-16-wip-01/knowledge.md
@@ -189,3 +189,40 @@ theoremCount 36→38, lineCount 582→640.
 Erdős 1950 (covering ⟹ infinite exceptional AP) is now COMPLETE and unconditional. Remaining
 are the genuinely analytic/deep pieces, documented-only: Romanoff 1934 positive-density lower
 bound (sieve + PNT) and Chen 2023 disproof (exceptional set richer than one AP + density-0).
+
+## Session note (2026-07-23, researcher-1): Erdős 1950 upgraded to POSITIVE LOWER DENSITY
+
+Prior session proved `exceptionalSet_infinite` (infinitude). This session proves the
+full positive-proportion strength of Erdős 1950, all axiom-free (docker-verified):
+
+- `coveringAP q := 7629217 + q·11184810` — the covering progression, `StrictMono`.
+- `Trapped n` — `n` within 241 of a smaller power of two (`∃ k ≥ 1, 2^k < n ∧ n − 2^k ≤ 241`);
+  exactly the failure mode of the size hypothesis.
+- `coveringAP_mem_exceptionalSet` — every UNTRAPPED progression member is exceptional
+  (congruences+oddness by `omega` on the linear form; untrappedness = size hypothesis).
+- `card_trapped_le` — ≤ m trapped indices below horizon `2^m`: trapped member sits in a
+  window `(2^k, 2^k+241]`, each window holds ≤ 1 member (241 ≪ 11184810 common difference;
+  `Finset.card_le_one` + `omega`), windows counted via `Finset.card_biUnion_le`.
+- `exceptionalCount_lower_bound : N/11184810 ≤ exceptionalCount N + log₂ N + 1` —
+  untrapped indices inject via `Finset.card_image_of_injective`; split via
+  `Finset.card_filter_add_card_filter_not`.
+- `exceptionalCount_positive_density : 2^52 ≤ N → N ≤ 22369620 * exceptionalCount N` —
+  log loss dwarfed: `22369620·(L+2) ≤ 2^25·2^(L−25) ≤ 2^L ≤ N` using `j+27 ≤ 2j ≤ 2^j`
+  (from `Nat.lt_two_pow_self`, no induction needed); final chain pure `omega`.
+- `density_exceptionalSet_ge : 2^52 ≤ N+1 → (22369620:ℝ)⁻¹ ≤ density ExceptionalSet N` —
+  bridges to the file's ℝ `density`; filter-instance mismatch closed by
+  `norm_num [decide_eq_true_eq, Finset.filter_congr_decidable]` after `unfold`.
+- `lowerDensity_exceptionalSet_pos : 0 < lowerDensity ExceptionalSet` — conditionally
+  complete lattice plumbing: `le_ciInf`, `le_ciSup` with explicit `BddAbove` (bound 1 via
+  `density_le_one` / `iSup_of_empty'` + `Real.sSup_empty`), `ciSup_pos`, witness horizon
+  `max N 2^52`. NOTE: file's `lowerDensity` is an ⨅-of-⨆ (literally limsup-shaped), but
+  our density bound holds at EVERY large horizon so any asymptotic density notion ≥ 1/22369620.
+
+Lean idioms learned: `le_div_iff₀` (le_div_iff is GONE); beta-unreduced `(fun M => ⨆ …) M`
+goals from `rintro ⟨M, rfl⟩` need `show` before `ciSup_pos` rewrites; `Nat.le_log_iff_pow_le`
+(not pow_le_iff_le_log); deprecated `Finset.filter_card_add_filter_neg_card_eq_card` →
+`card_filter_add_card_filter_not`.
+
+Remaining DEEP (unchanged): Romanoff 1934 (positive density of Romanoff numbers — analytic
+sieve), Chen 2023 disproof structure. The elementary covering vein is now FULLY exhausted:
+infinitude AND positive density both formalized.

--- a/research/problems/erdos-16-wip-01/state.md
+++ b/research/problems/erdos-16-wip-01/state.md
@@ -1,25 +1,31 @@
 # Research State: erdos-16-wip-01
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-07-09T17:33:18-07:00
-**Iteration**: 1
+**Since**: 2026-07-23T00:00:00-07:00
+**Iteration**: 5
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Erdős 1950 covering-congruence layer COMPLETE at full strength: infinitude
+(`exceptionalSet_infinite`) AND positive lower density
+(`exceptionalCount_positive_density`, `lowerDensity_exceptionalSet_pos`),
+all axiom-free and sorry-free.
 
 ## Active Approach
-None yet.
+Covering congruences (six primes 3,7,5,17,13,241 close all exponent classes;
+CRT progression 7629217 mod 11184810) + window/trapping counting for density.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 4
+- Current approach attempts: 4 (all successful)
+- Approaches tried: 1
 
 ## Blockers
-None.
+Remaining targets are genuinely DEEP and documented-only:
+- Romanoff 1934 (positive density of Romanoff numbers): analytic sieve + PNT input.
+- Chen 2023 disproof (exceptional set richer than one AP + density-0 set).
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Elementary covering vein is FULLY exhausted. Future sessions should either
+tackle Romanoff via Mathlib analytic NT infrastructure (large) or stand down.

--- a/src/data/proofs/erdos-16/meta.json
+++ b/src/data/proofs/erdos-16/meta.json
@@ -245,10 +245,10 @@
       "BigOperators"
     ],
     "namespace": "Erdos16",
-    "lineCount": 640,
+    "lineCount": 865,
     "axiomCount": 0,
-    "theoremCount": 38,
-    "definitionCount": 11,
+    "theoremCount": 45,
+    "definitionCount": 14,
     "path": "Proofs/Erdos16Problem.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/erdos-16-wip-01.json
+++ b/src/data/research/problems/erdos-16-wip-01.json
@@ -1,13 +1,13 @@
 {
   "slug": "erdos-16-wip-01",
-  "title": "Complete the Lean Formalization of Erdős Problem #16 (Odd Integers Not of Form 2^k + p)",
+  "title": "Complete the Lean Formalization of Erd\u0151s Problem #16 (Odd Integers Not of Form 2^k + p)",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "A",
   "path": "full",
   "problemStatement": {
     "formal": "E = \\{\\, n \\text{ odd} : \\forall k \\geq 1,\\ \\forall p \\text{ prime},\\ n \\neq 2^k + p \\,\\}, \\qquad \\underline{d}(E) > 0.",
-    "plain": "The completion task is to strengthen the work-in-progress Lean 4 formalization of Erdős Problem #16, which studies the odd integers that cannot be written as a power of two plus a prime. Romanoff (1934) proved that a positive proportion of odd integers *are* of the form $2^k + p$, so the exceptional set $E$ has density less than one half. Erdős (1950) used covering congruences with moduli $\\{2,3,4,6,8,12,24\\}$ to force an infinite arithmetic progression into $E$, and conjectured that $E$ is essentially just this progression plus a negligible density-zero remainder. Chen (2023) disproved that conjecture: $E$ has a much richer structure with several independent positive-density pieces. The current Lean file defines the relevant objects but leaves the supporting theorems (Romanoff's density bound, the covering-congruence construction) documented only in comments; our goal is to formalize the provable ones and cleanly isolate the genuinely deep results.",
+    "plain": "The completion task is to strengthen the work-in-progress Lean 4 formalization of Erd\u0151s Problem #16, which studies the odd integers that cannot be written as a power of two plus a prime. Romanoff (1934) proved that a positive proportion of odd integers *are* of the form $2^k + p$, so the exceptional set $E$ has density less than one half. Erd\u0151s (1950) used covering congruences with moduli $\\{2,3,4,6,8,12,24\\}$ to force an infinite arithmetic progression into $E$, and conjectured that $E$ is essentially just this progression plus a negligible density-zero remainder. Chen (2023) disproved that conjecture: $E$ has a much richer structure with several independent positive-density pieces. The current Lean file defines the relevant objects but leaves the supporting theorems (Romanoff's density bound, the covering-congruence construction) documented only in comments; our goal is to formalize the provable ones and cleanly isolate the genuinely deep results.",
     "whyMatters": [
       "Romanoff-type density"
     ]
@@ -20,12 +20,12 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-09T17:33:18-07:00",
-    "iteration": 4,
-    "focus": "Covering-congruence layer COMPLETE (Erdős 1950 in full, PR #40830, verified 0-axiom/0-sorry): exceptionalSet_infinite (the CRT progression n ≡ 7629217 mod 11184810 forced into ExceptionalSet via six order-of-2 covering gears + window confinement) and exists_exceptional_gt. Supersedes the stale nextAction below, which described this completed work as pending.",
+    "iteration": 5,
+    "focus": "Covering-congruence layer COMPLETE (Erd\u0151s 1950 in full, PR #40830, verified 0-axiom/0-sorry): exceptionalSet_infinite (the CRT progression n \u2261 7629217 mod 11184810 forced into ExceptionalSet via six order-of-2 covering gears + window confinement) and exists_exceptional_gt. Supersedes the stale nextAction below, which described this completed work as pending.",
     "blockers": [
       {
         "route": "Romanoff 1934: {2^k+p} has positive lower density among the odds",
-        "reopenCriterion": "materially new mechanism required: analytic number theory (sieve + PNT / additive density), not covering-congruence — absent from Mathlib v4.31.",
+        "reopenCriterion": "materially new mechanism required: analytic number theory (sieve + PNT / additive density), not covering-congruence \u2014 absent from Mathlib v4.31.",
         "blockedAt": "2026-07-21"
       },
       {
@@ -34,7 +34,7 @@
         "blockedAt": "2026-07-21"
       }
     ],
-    "nextAction": "STAND DOWN on elementary/covering work — Erdős 1950 is fully formalized. Remaining directions are deep-analytic (recorded as blockers): Romanoff 1934 positive density and Chen 2023 exceptional-set structure.",
+    "nextAction": "STAND DOWN on elementary/covering work \u2014 Erd\u0151s 1950 is fully formalized. Remaining directions are deep-analytic (recorded as blockers): Romanoff 1934 positive density and Chen 2023 exceptional-set structure.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -42,47 +42,53 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-07-21, researcher-1-4, host-verified 0-axiom): Formalized Erdős 1950 in FULL — ExceptionalSet is INFINITE (exceptionalSet_infinite), upgrading the prior conditional covering construction (covering_progression_mem_exceptionalSet, needs size hypothesis) to unconditional infinitude via exists_exceptional_gt. The CRT progression n≡7629217 (mod 11184810) meets every dyadic window [2^m+242,2^{m+1}) where the size condition holds automatically (k≤m ⟹ n−2^k≥242). theoremCount 36→38, lineCount 582→640. Remaining DEEP: Romanoff 1934 positive-density (analytic sieve+PNT) and Chen 2023 disproof (rich structure) stay documented-only.",
+    "progressSummary": "PROGRESS (2026-07-23, researcher-1, docker-verified 0-axiom 0-sorry): Erd\u0151s 1950 now at FULL positive-proportion strength \u2014 exceptionalCount_positive_density (\u2265 N/22369620 exceptional integers below every N \u2265 2^52) and lowerDensity_exceptionalSet_pos (0 < lowerDensity ExceptionalSet), upgrading exceptionalSet_infinite. Counting: N/11184810 progression members minus \u2264 log2 N trapped-near-powers-of-2, log loss dwarfed for N \u2265 2^52. theoremCount 38\u219245, lineCount 640\u2192865. Elementary covering vein FULLY exhausted; remaining DEEP: Romanoff 1934 (analytic sieve), Chen 2023 structure.",
     "builtItems": [
       "isRomanoff_four_le, not_isRomanoff_one/three, one/three_mem_exceptionalSet in Erdos16Problem.lean",
       "isRomanoff_five, isRomanoff_seven, five_not_mem_exceptionalSet in Erdos16Problem.lean",
       "density_nonneg, density_le_one, mem_exceptionalSet_iff in Erdos16Problem.lean",
       "erdosCovering_moduli_pos, erdosCovering_isCoveringSystem (covering system covers Z) in Erdos16Problem.lean",
-      "isRomanoff_iff — bounded characterisation: IsRomanoff n ↔ ∃ k≥1, 2^k<n ∧ Prime(n−2^k), eliminating the prime variable p (Erdos16Problem.lean)",
-      "not_isRomanoff_127 + oneHundredTwentySeven_mem_exceptionalSet — first nontrivial A006285 term proved exceptional (Erdos16Problem.lean)",
-      "not_isRomanoff_149 + oneHundredFortyNine_mem_exceptionalSet — second nontrivial A006285 term proved exceptional (Erdos16Problem.lean)",
+      "isRomanoff_iff \u2014 bounded characterisation: IsRomanoff n \u2194 \u2203 k\u22651, 2^k<n \u2227 Prime(n\u22122^k), eliminating the prime variable p (Erdos16Problem.lean)",
+      "not_isRomanoff_127 + oneHundredTwentySeven_mem_exceptionalSet \u2014 first nontrivial A006285 term proved exceptional (Erdos16Problem.lean)",
+      "not_isRomanoff_149 + oneHundredFortyNine_mem_exceptionalSet \u2014 second nontrivial A006285 term proved exceptional (Erdos16Problem.lean)",
       "isRomanoff_iff_mem_range (bounded existential over Finset.range n) in Erdos16Problem.lean",
       "decidableIsRomanoff : Decidable (IsRomanoff n) instance in Erdos16Problem.lean",
       "not_isRomanoff_251 / twoHundredFiftyOne_mem_exceptionalSet in Erdos16Problem.lean",
       "not_isRomanoff_331 / threeHundredThirtyOne_mem_exceptionalSet in Erdos16Problem.lean",
       "two_pow_mod_three, two_pow_modEq_of_dvd, covering_prime_not_prime_sub, not_prime_sub_even_mod_three, not_prime_sub_mod_seven in Proofs/Erdos16Problem.lean (session 4, axiom-free)",
       "two_pow_four_modEq_five, two_pow_eight_modEq_seventeen, two_pow_twelve_modEq_thirteen, two_pow_twentyfour_modEq_241 (order-of-2 gears) in Erdos16Problem.lean",
-      "covering_obstruction_not_isRomanoff in Erdos16Problem.lean — the assembled Erdos 1950 covering obstruction (conditional on explicit size hypothesis)",
-      "covering_progression_mem_exceptionalSet in Erdos16Problem.lean — membership form for odd n",
-      "exists_exceptional_gt (∀B ∃ exceptional n>B) in Erdos16Problem.lean",
-      "exceptionalSet_infinite : ExceptionalSet.Infinite (via Set.Finite.bddAbove contradiction)"
+      "covering_obstruction_not_isRomanoff in Erdos16Problem.lean \u2014 the assembled Erdos 1950 covering obstruction (conditional on explicit size hypothesis)",
+      "covering_progression_mem_exceptionalSet in Erdos16Problem.lean \u2014 membership form for odd n",
+      "exists_exceptional_gt (\u2200B \u2203 exceptional n>B) in Erdos16Problem.lean",
+      "exceptionalSet_infinite : ExceptionalSet.Infinite (via Set.Finite.bddAbove contradiction)",
+      "coveringAP/Trapped defs + coveringAP_mem_exceptionalSet + card_trapped_le in Erdos16Problem.lean",
+      "exceptionalCount def + exceptionalCount_lower_bound (N/11184810 \u2264 count + log2 N + 1)",
+      "exceptionalCount_positive_density (N \u2265 2^52 \u2192 N \u2264 22369620\u00b7count): Erd\u0151s 1950 positive-proportion form",
+      "density_exceptionalSet_ge + lowerDensity_exceptionalSet_pos (\u211d density \u2265 1/22369620, lowerDensity > 0)"
     ],
     "insights": [
       "Erdos16 file was a definitions-only stub (10 defs, 0 theorems). The deep results (Romanoff density, Erdos covering-progression, Chen 2023 disproof) need analytic NT beyond Mathlib; the tractable axiom-free content is elementary structural facts about the file's own defs.",
       "The explicit Erdos covering system [(0,2),(0,3),(1,4),(1,6),(3,8),(7,12),(23,24)] genuinely covers Z: every modulus divides 24, so the disjunction n%2=0 or n%3=0 or n%4=1 or n%6=1 or n%8=3 or n%12=7 or n%24=23 is provable directly by omega, then the residue-class witness is exhibited per case.",
       "Romanoff floor: 2^k+p >= 4 for k>=1, p prime, so 1 and 3 are exceptional; 5=2+3 and 7=4+3 are concrete Romanoff (non-exceptional) witnesses.",
-      "The unbounded ∃ k p in IsRomanoff collapses to a finite search: p is forced to be n−2^k, and 2^k<n bounds k≤log2 n. isRomanoff_iff makes non-membership a per-exponent compositeness check dischargeable by interval_cases + norm_num prime extension.",
-      "Concrete exceptional numbers (127, 149) are host-verifiable axiom-free: bound k via 2^(K+1)>n (by_contra + Nat.pow_le_pow_right), then interval_cases k and norm_num refutes Prime(n−2^k) for each residue.",
-      "isRomanoff_iff can be refined to a bounded search: 2^k<n forces k<2^k<n, so the witness exponent lies in Finset.range n. This makes IsRomanoff decidable (decidableIsRomanoff instance) by kernel reduction only — no native_decide, axioms stay [propext, Classical.choice, Quot.sound].",
-      "decide over Finset.range n is impractical for the A006285 exceptional terms (>250) because the kernel would evaluate 2^{n-1} and hit the exponentiation threshold / recursion depth; the explicit interval_cases refutations (bounding k≤log2 n) keep 2^k small and are the robust route for specific numbers.",
-      "251 and 331 are the 3rd and 4th nontrivial A006285 terms; both proved exceptional by the isRomanoff_iff + interval_cases pattern (all complements n−2^k composite).",
-      "Erdős 1950 covering mechanism formalized as a reusable gear (covering_prime_not_prime_sub): for a prime p with 2^d ≡ 1 (mod p), any exponent k ≡ r (mod d) and any n ≡ 2^r (mod p) satisfy p ∣ n − 2^k, so n − 2^k is composite once it exceeds p. This eliminates a whole residue class of exponents at once — the structural upgrade over per-k A006285 checks.",
-      "Core algebraic lemma two_pow_modEq_of_dvd: 2^d ≡ 1 (mod p) ∧ k ≡ r (mod d) ⟹ 2^k ≡ 2^r (mod p), proved by writing k = r + d·t and using (2^d)^t ≡ 1. This is exponent-periodicity of 2 modulo p — the fact that makes one prime cover an arithmetic progression of exponents.",
-      "Two concrete covering gears verified: prime 3 (order 2) kills even exponents for n ≡ 1 (mod 3); prime 7 (order 3) kills exponents ≡ 0 (mod 3) for n ≡ 1 (mod 7). Demonstrates the general lemma is not specialized to a single prime.",
+      "The unbounded \u2203 k p in IsRomanoff collapses to a finite search: p is forced to be n\u22122^k, and 2^k<n bounds k\u2264log2 n. isRomanoff_iff makes non-membership a per-exponent compositeness check dischargeable by interval_cases + norm_num prime extension.",
+      "Concrete exceptional numbers (127, 149) are host-verifiable axiom-free: bound k via 2^(K+1)>n (by_contra + Nat.pow_le_pow_right), then interval_cases k and norm_num refutes Prime(n\u22122^k) for each residue.",
+      "isRomanoff_iff can be refined to a bounded search: 2^k<n forces k<2^k<n, so the witness exponent lies in Finset.range n. This makes IsRomanoff decidable (decidableIsRomanoff instance) by kernel reduction only \u2014 no native_decide, axioms stay [propext, Classical.choice, Quot.sound].",
+      "decide over Finset.range n is impractical for the A006285 exceptional terms (>250) because the kernel would evaluate 2^{n-1} and hit the exponentiation threshold / recursion depth; the explicit interval_cases refutations (bounding k\u2264log2 n) keep 2^k small and are the robust route for specific numbers.",
+      "251 and 331 are the 3rd and 4th nontrivial A006285 terms; both proved exceptional by the isRomanoff_iff + interval_cases pattern (all complements n\u22122^k composite).",
+      "Erd\u0151s 1950 covering mechanism formalized as a reusable gear (covering_prime_not_prime_sub): for a prime p with 2^d \u2261 1 (mod p), any exponent k \u2261 r (mod d) and any n \u2261 2^r (mod p) satisfy p \u2223 n \u2212 2^k, so n \u2212 2^k is composite once it exceeds p. This eliminates a whole residue class of exponents at once \u2014 the structural upgrade over per-k A006285 checks.",
+      "Core algebraic lemma two_pow_modEq_of_dvd: 2^d \u2261 1 (mod p) \u2227 k \u2261 r (mod d) \u27f9 2^k \u2261 2^r (mod p), proved by writing k = r + d\u00b7t and using (2^d)^t \u2261 1. This is exponent-periodicity of 2 modulo p \u2014 the fact that makes one prime cover an arithmetic progression of exponents.",
+      "Two concrete covering gears verified: prime 3 (order 2) kills even exponents for n \u2261 1 (mod 3); prime 7 (order 3) kills exponents \u2261 0 (mod 3) for n \u2261 1 (mod 7). Demonstrates the general lemma is not specialized to a single prime.",
       "Session 5: assembled the individual covering gears into the full Erdos 1950 obstruction. The six exponent classes {0 mod 2, 0 mod 3, 1 mod 4, 3 mod 8, 7 mod 12, 23 mod 24} cover Z (omega), each carrying a prime whose order of 2 equals the modulus: (2,3),(3,7),(4,5),(8,17),(12,13),(24,241).",
-      "Session 5: covering_obstruction_not_isRomanoff proves that any n meeting the six CRT congruences (n=1 mod 3, 1 mod 7, 2 mod 5, 8 mod 17, 11 mod 13, 121 mod 241) with n-2^k>241 for all valid k is NOT Romanoff — the whole CRT progression (mod 3*5*7*13*17*241) is exceptional, subject only to a size hypothesis. Axiom-free.",
+      "Session 5: covering_obstruction_not_isRomanoff proves that any n meeting the six CRT congruences (n=1 mod 3, 1 mod 7, 2 mod 5, 8 mod 17, 11 mod 13, 121 mod 241) with n-2^k>241 for all valid k is NOT Romanoff \u2014 the whole CRT progression (mod 3*5*7*13*17*241) is exceptional, subject only to a size hypothesis. Axiom-free.",
       "Session 5: the required n-residues are 2^r mod p per class: 2^0=1 (p=3,7), 2^1=2 (p=5), 2^3=8 (p=17), 2^7=128=11 mod 13, 2^23=121 mod 241. Verified 2^23 mod 241 = 121 and 2*121=242=1 mod 241.",
-      "EXCEPTIONAL SET IS INFINITE (Erdős 1950 conclusion, axiom-free): exceptionalSet_infinite. Upgraded the covering construction from conditional (needs size hypothesis) to unconditional infinitude via exists_exceptional_gt: for any B, the CRT-progression member (n ≡ 7629217 mod 2M=11184810) landing in the dyadic window [2^m+242, 2^{m+1}) exceeds B, is odd, meets the six covering congruences, AND satisfies the size condition automatically (any k with 2^k<n has k≤m ⟹ n−2^k ≥ 242). Key: window-based size discharge sidesteps the messy largest-power-of-2 analysis."
+      "EXCEPTIONAL SET IS INFINITE (Erd\u0151s 1950 conclusion, axiom-free): exceptionalSet_infinite. Upgraded the covering construction from conditional (needs size hypothesis) to unconditional infinitude via exists_exceptional_gt: for any B, the CRT-progression member (n \u2261 7629217 mod 2M=11184810) landing in the dyadic window [2^m+242, 2^{m+1}) exceeds B, is odd, meets the six covering congruences, AND satisfies the size condition automatically (any k with 2^k<n has k\u2264m \u27f9 n\u22122^k \u2265 242). Key: window-based size discharge sidesteps the messy largest-power-of-2 analysis.",
+      "Positive-density upgrade of a covering construction needs NO analysis: count AP members below N (N/modulus), subtract trapped members near powers of 2 (each dyadic window (2^k, 2^k+241] holds \u22641 member since 241 << modulus, so \u2264 log2 N total), and the log loss is dwarfed for N \u2265 2^52 via j+27 \u2264 2j \u2264 2^j from Nat.lt_two_pow_self \u2014 no induction.",
+      "The file lowerDensity def is an inf-of-sup (limsup-shaped), but a bound valid at EVERY large horizon N bounds it regardless; conditionally-complete-lattice plumbing: le_ciInf + le_ciSup with explicit BddAbove witness, ciSup_pos for the inhabited Prop-indexed sup, iSup_of_empty' + Real.sSup_empty for the empty one, and beta-unreduced goals after rintro rfl need show before rewriting."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Assemble the individual covering gears over a full covering system of the exponent (moduli 2,3,4,6,8,12,24 → primes with matching orders of 2) and use CRT to produce a single arithmetic progression of n all of whose exponents are covered — this would formalize Erdős 1950 (exceptional set contains an infinite AP). Blocker: needs the order-of-2 facts for primes 5,13,17,241 and a CRT packaging; substantial but no analytic input required.",
-      "Prove lowerDensity monotonicity/containment lemmas (density A ≤ density B when A ⊆ B) as further axiom-free density infrastructure."
+      "Assemble the individual covering gears over a full covering system of the exponent (moduli 2,3,4,6,8,12,24 \u2192 primes with matching orders of 2) and use CRT to produce a single arithmetic progression of n all of whose exponents are covered \u2014 this would formalize Erd\u0151s 1950 (exceptional set contains an infinite AP). Blocker: needs the order-of-2 facts for primes 5,13,17,241 and a CRT packaging; substantial but no analytic input required.",
+      "Prove lowerDensity monotonicity/containment lemmas (density A \u2264 density B when A \u2286 B) as further axiom-free density infrastructure."
     ],
     "markdown": "# Knowledge Base: erdos-16-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },

--- a/src/data/research/problems/erdos-16-wip-01.json
+++ b/src/data/research/problems/erdos-16-wip-01.json
@@ -32,6 +32,16 @@
         "route": "Chen 2023: ExceptionalSet is richer than one AP plus a density-0 set",
         "reopenCriterion": "materially new mechanism required: fine structure of the exceptional set beyond the single covering progression.",
         "blockedAt": "2026-07-21"
+      },
+      {
+        "route": "Romanoff 1934: positive density of Romanoff numbers (sieve + PNT / additive density)",
+        "reopenCriterion": "Mathlib gains Brun/Selberg sieve or Romanoff-type additive density infrastructure",
+        "blockedAt": "2026-07-23"
+      },
+      {
+        "route": "Chen 2023 disproof structure (exceptional set beyond one AP + density-0 set)",
+        "reopenCriterion": "materially new mechanism required",
+        "blockedAt": "2026-07-23"
       }
     ],
     "nextAction": "STAND DOWN on elementary/covering work \u2014 Erd\u0151s 1950 is fully formalized. Remaining directions are deep-analytic (recorded as blockers): Romanoff 1934 positive density and Chen 2023 exceptional-set structure.",


### PR DESCRIPTION
## Summary
Research session for **erdos-16-wip-01** (Erdős #16: odd integers not of the form 2^k + p).

Upgrades the formalized Erdős (1950) covering-congruence result from *infinitude* (`exceptionalSet_infinite`, PR #40830) to its full **positive-proportion strength**: the exceptional set has lower density at least 1/22369620 > 0.

## Progress
- `coveringAP` / `Trapped`: the covering progression `7629217 + q*11184810` and the "within 241 of a power of two" trap — the only way a member can fail the size hypothesis of `covering_progression_mem_exceptionalSet`.
- `coveringAP_mem_exceptionalSet`: every untrapped progression member is exceptional (six congruences + oddness by `omega` on the linear form).
- `card_trapped_le`: at most `m` trapped indices below horizon `2^m` — each dyadic window `(2^k, 2^k+241]` holds at most one progression member since 241 is far below the common difference 11184810 (`Finset.card_le_one` + `Finset.card_biUnion_le`).
- `exceptionalCount_lower_bound`: `N / 11184810 ≤ exceptionalCount N + log₂ N + 1` (untrapped indices inject via `Finset.card_image_of_injective`).
- **`exceptionalCount_positive_density`**: for `N ≥ 2^52`, `N ≤ 22369620 * exceptionalCount N`. The logarithmic loss is dwarfed without induction: `j + 27 ≤ 2j ≤ 2^j` from `Nat.lt_two_pow_self`.
- `density_exceptionalSet_ge` and `lowerDensity_exceptionalSet_pos`: ℝ-valued corollaries against the file's own `density` / `lowerDensity` definitions, filling the file's "Density Bounds" placeholder.
- Gallery meta counts synced (theorems 38→45, lines 640→865, defs 11→14).

## Findings
- A positive-density upgrade of a covering construction needs no analytic input: count AP members below N, subtract the ≤ log₂ N members trapped near powers of two, and beat the log loss for N ≥ 2^52.
- The file's `lowerDensity` is an inf-of-sup (limsup-shaped as written), but the bound holds at every large horizon, so any asymptotic density notion inherits 1/22369620.
- Axiom/sorry delta: 0 axioms, 0 sorries before and after; +7 theorems, +3 defs, all machine-checked (docker build, 8576 jobs, 0 warnings).

## Status
**Outcome**: progress (elementary covering vein now fully exhausted)
**Next Steps**: remaining targets are genuinely deep — Romanoff 1934 (analytic sieve + PNT) and Chen 2023 structure — documented as blockers; stand down on elementary extensions.

🤖 Generated by researcher-1
