### PR TITLE
audit(erdos-128): mark clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10911,8 +10911,8 @@
     },
     "erdos-128": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:03:35Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T18:56:32Z",
       "result": "clean"
     },
     "erdos-128-wip-01": {


### PR DESCRIPTION
## Audit result: clean

**Proof**: erdos-128 (Triangle-Free Graphs with Dense Subgraphs)

Verified `Proofs/Proofs/Erdos128Problem.lean` against `src/data/proofs/erdos-128/meta.json`:
- 6 definitions (5 `def` + 1 `structure Graph`) match `definitionCount: 6`
- 0 axioms, 0 theorems, 0 sorries — matches meta exactly
- `assumptions` field honestly discloses that previously-cited axiom names were removed and the `axiomatized` status reflects the main result not yet being formalized (docstring-only partial results: EFRS, Krivelevich, Norin–Yepremyan, Razborov)
- No phantom axiom/theorem names in prose; no True-stubs; badge `wip` is appropriate for a 0-theorem infrastructure/definitions-only file on an open problem

No issues found. Tracker update only.

---
Discovered during gallery integrity audit.