### PR TITLE
fix(daemon): stop misdetecting polling-agent sleeps as COMPLETED

### DIFF
--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -1080,6 +1080,20 @@ get_agent_status() {
     if [[ -z "$claude_pid" ]]; then
         # No claude process - check if shell is at prompt
         if [[ "$pane_cmd" == "zsh" || "$pane_cmd" == "bash" || "$pane_cmd" == "sh" ]]; then
+            # A non-interactive script never changes the pty's foreground process
+            # group per subcommand, so pane_cmd still reports the wrapper's own
+            # shell name (bash) while it's inside a `sleep` — e.g. CYCLE_MIN_SECONDS'
+            # enforce_cycle_floor, or the wrapper's own retry/backoff delay. That
+            # looks identical to "script truly exited to an idle shell prompt"
+            # unless we also check for a live child process.
+            if has_child_processes "$pane_pid"; then
+                if is_polling_agent "$session"; then
+                    echo "IDLE"
+                else
+                    echo "RUNNING"
+                fi
+                return
+            fi
             echo "COMPLETED"
             return
         fi


### PR DESCRIPTION
## Summary

`get_agent_status()` in `scripts/lean/launch.sh` declares a Claude-based
agent `COMPLETED` whenever no `claude` child process is found and the
pane's foreground command is a bare shell name (`bash`/`zsh`/`sh`). But a
non-interactive script never hands off the pty's foreground process group
per subcommand, so the pane still reports `bash` while the wrapper is
inside a `sleep` — e.g. `enforce_cycle_floor`'s `CYCLE_MIN_SECONDS`
cycle-floor sleep (#41507), or the wrapper's own retry/backoff delay.
That's indistinguishable from a truly-finished script under the old
check, so the daemon's health-check loop kills and respawns the agent.

This is why seeker's busy-loop ("Daemon cycle 1" resetting every 1-3
minutes instead of ~30) persisted in `.loom/logs/seeker.log` even after
#41507 merged and the daemon was restarted: the very sleep #41507 added
is what the health check misreads as completion.

Fix mirrors the existing `is_script_based_agent` branch, which already
guards against this with a `has_child_processes` check before declaring
`COMPLETED`. Applied the same guard to the Claude-based branch: if the
pane's shell still has a live child (the `sleep` itself), the agent is
busy, not idle-at-prompt — report `IDLE` for polling agents (seeker,
deployer, auditor, tester, herald, mechanic) or `RUNNING` otherwise.

## Test plan

- [x] `bash -n scripts/lean/launch.sh` — syntax check passes
- [x] Reproduced the exact false-positive locally: sourced the real
      `get_pane_pid`/`find_claude_child`/`get_pane_command`/
      `has_child_processes` helpers from this branch and ran them
      against a `while true; do sleep 30; done` wrapper (mirrors
      `enforce_cycle_floor`'s loop shape) — confirmed `has_child_processes`
      correctly reports a live `sleep` child, so the patched status logic
      now reports `IDLE` instead of the old false `COMPLETED`.
- [ ] Live confirmation: after merge + daemon restart, `seeker.log` cycle
      spacing should widen to ~30min instead of ~1-3min (can be checked
      in a follow-up cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)