### PR TITLE
Research: erdos-1039-oq-05 - transfinite diameter of the disc = 1 exactly, via Hadamard's inequality

### DIFF
--- a/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
+++ b/proofs/Proofs/Erdos1039TransfiniteDiameter.lean
@@ -1154,4 +1154,166 @@ theorem tendsto_rootsOfUnity_lowerBound_one :
 
 end RootsOfUnity
 
+/-!
+## Hadamard's determinant inequality and the sharp value `d = 1`
+
+Hadamard's inequality — `‖det M‖ ≤ ∏ᵢ ‖rowᵢ M‖₂` — is elementary linear algebra,
+absent from Mathlib as such, but derivable from `gramSchmidtOrthonormalBasis_det`:
+in the orthonormal basis `e` produced by Gram–Schmidt from the row family `f`,
+the coefficient matrix is upper triangular, so `det f = ∏ᵢ ⟪eᵢ, fᵢ⟫`, and
+Cauchy–Schwarz bounds every factor by `‖fᵢ‖`.
+
+Applied to the Vandermonde matrix of `n` unit-disc points, every row has
+`ℓ²`-norm at most `√n`, so `spreadProduct ≤ (√n)ⁿ` and `dₙ ≤ n^{1/(n-1)}` —
+matching the roots-of-unity lower bound `transfiniteDiameterN_rootsOfUnity_ge`
+exactly.  Hence `dₙ = n^{1/(n-1)}` for every `n ≥ 2` and, letting `n → ∞`, the
+transfinite diameter of the closed unit disc is **exactly `1`** — the
+logarithmic-capacity value, obtained here *without* Fekete–Szegő or any
+potential theory.
+-/
+
+section Hadamard
+
+open InnerProductSpace Module
+
+/-- The rows of a square complex matrix as vectors of `EuclideanSpace ℂ (Fin n)`
+(so that `‖matrixRow M i‖` is the `ℓ²`-norm of row `i`). -/
+def matrixRow (M : Matrix (Fin n) (Fin n) ℂ) (i : Fin n) :
+    EuclideanSpace ℂ (Fin n) := WithLp.toLp 2 (M i)
+
+/-- **Hadamard's determinant inequality** (complex, row form): the determinant of a
+square matrix is bounded in norm by the product of the Euclidean norms of its rows.
+Proof: Gram–Schmidt the rows into an orthonormal basis `e`; the coefficient matrix
+of the rows in `e` is upper triangular (`gramSchmidtOrthonormalBasis_det`), so the
+determinant is `∏ᵢ ⟪eᵢ, rowᵢ⟫` up to a unimodular basis-change factor, and
+Cauchy–Schwarz bounds each factor by `‖rowᵢ‖`. -/
+theorem norm_det_le_prod_norm_row (M : Matrix (Fin n) (Fin n) ℂ) :
+    ‖M.det‖ ≤ ∏ i, ‖matrixRow M i‖ := by
+  classical
+  have hrank : Module.finrank ℂ (EuclideanSpace ℂ (Fin n)) = Fintype.card (Fin n) :=
+    finrank_euclideanSpace
+  -- the standard-basis coordinate matrix of the row family is `Mᵀ`
+  have hmat : (EuclideanSpace.basisFun (Fin n) ℂ).toBasis.toMatrix (matrixRow M)
+      = M.transpose := by
+    ext i j
+    rw [Basis.toMatrix_apply, OrthonormalBasis.coe_toBasis_repr_apply,
+      EuclideanSpace.basisFun_repr]
+    rfl
+  -- the Gram–Schmidt-basis determinant of the rows has the same norm as `det M`
+  have hdet_eq :
+      ‖(gramSchmidtOrthonormalBasis hrank (matrixRow M)).toBasis.det (matrixRow M)‖
+        = ‖M.det‖ := by
+    rw [Basis.det_apply,
+      ← Basis.toMatrix_mul_toMatrix
+        (gramSchmidtOrthonormalBasis hrank (matrixRow M)).toBasis
+        (EuclideanSpace.basisFun (Fin n) ℂ).toBasis (matrixRow M),
+      Matrix.det_mul, norm_mul, hmat, Matrix.det_transpose, ← Basis.det_apply,
+      OrthonormalBasis.coe_toBasis,
+      OrthonormalBasis.det_to_matrix_orthonormalBasis, one_mul]
+  calc ‖M.det‖
+      = ‖(gramSchmidtOrthonormalBasis hrank (matrixRow M)).toBasis.det (matrixRow M)‖ :=
+        hdet_eq.symm
+    _ = ‖∏ i, inner ℂ (gramSchmidtOrthonormalBasis hrank (matrixRow M) i) (matrixRow M i)‖ := by
+        rw [gramSchmidtOrthonormalBasis_det]
+    _ = ∏ i, ‖inner ℂ (gramSchmidtOrthonormalBasis hrank (matrixRow M) i) (matrixRow M i)‖ :=
+        norm_prod _ _
+    _ ≤ ∏ i, ‖matrixRow M i‖ := by
+        refine Finset.prod_le_prod (fun i _ => norm_nonneg _) fun i _ => ?_
+        calc ‖inner ℂ (gramSchmidtOrthonormalBasis hrank (matrixRow M) i) (matrixRow M i)‖
+            ≤ ‖gramSchmidtOrthonormalBasis hrank (matrixRow M) i‖ * ‖matrixRow M i‖ :=
+              norm_inner_le_norm _ _
+          _ = ‖matrixRow M i‖ := by
+              rw [(gramSchmidtOrthonormalBasis hrank (matrixRow M)).orthonormal.1 i, one_mul]
+
+/-- Each row of the Vandermonde matrix of unit-disc points has `ℓ²`-norm at most `√n`:
+the row entries are the powers `zᵢᵏ`, `k < n`, each of norm at most `1`. -/
+theorem norm_matrixRow_vandermonde_le {z : Fin n → ℂ} (hz : ∀ i, ‖z i‖ ≤ 1) (i : Fin n) :
+    ‖matrixRow (Matrix.vandermonde z) i‖ ≤ Real.sqrt n := by
+  rw [EuclideanSpace.norm_eq]
+  refine Real.sqrt_le_sqrt ?_
+  calc ∑ j, ‖matrixRow (Matrix.vandermonde z) i j‖ ^ 2
+      ≤ ∑ _j : Fin n, (1 : ℝ) := by
+        refine Finset.sum_le_sum fun j _ => ?_
+        have hentry : ‖matrixRow (Matrix.vandermonde z) i j‖ = ‖z i‖ ^ (j : ℕ) := by
+          show ‖Matrix.vandermonde z i j‖ = ‖z i‖ ^ (j : ℕ)
+          rw [Matrix.vandermonde_apply, norm_pow]
+        rw [hentry]
+        have h1 : ‖z i‖ ^ (j : ℕ) ≤ 1 := pow_le_one₀ (norm_nonneg _) (hz i)
+        have h0 : (0 : ℝ) ≤ ‖z i‖ ^ (j : ℕ) := pow_nonneg (norm_nonneg _) _
+        exact pow_le_one₀ h0 h1
+    _ = n := by simp
+
+/-- **Hadamard bound for the spread product**: `n` points of the closed unit disc have
+spread product at most `(√n)ⁿ = n^{n/2}`. -/
+theorem spreadProduct_le_sqrt_pow {z : Fin n → ℂ} (hz : ∀ i, ‖z i‖ ≤ 1) :
+    spreadProduct z ≤ Real.sqrt n ^ n := by
+  rw [spreadProduct_eq_norm_det_vandermonde]
+  calc ‖(Matrix.vandermonde z).det‖
+      ≤ ∏ i, ‖matrixRow (Matrix.vandermonde z) i‖ := norm_det_le_prod_norm_row _
+    _ ≤ ∏ _i : Fin n, Real.sqrt n :=
+        Finset.prod_le_prod (fun i _ => norm_nonneg _)
+          (fun i _ => norm_matrixRow_vandermonde_le hz i)
+    _ = Real.sqrt n ^ n := by
+        rw [Finset.prod_const, Finset.card_univ, Fintype.card_fin]
+
+/-- **Sharp discrete-diameter upper bound** (matches the roots-of-unity lower bound):
+`n ≥ 2` points of the closed unit disc have `dₙ(Z) ≤ n^{1/(n-1)}`. -/
+theorem discreteDiameter_le_rpow {z : Fin n → ℂ} (hn : 2 ≤ n) (hz : ∀ i, ‖z i‖ ≤ 1) :
+    discreteDiameter z ≤ (n : ℝ) ^ ((1 : ℝ) / ((n : ℝ) - 1)) := by
+  have hn2 : (2 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+  have hnpos : (0 : ℝ) < (n : ℝ) := by linarith
+  have hne : (n : ℝ) ≠ 0 := ne_of_gt hnpos
+  have hne1 : (n : ℝ) - 1 ≠ 0 := by intro h; nlinarith
+  have hexp : (0 : ℝ) ≤ 2 / ((n : ℝ) * ((n : ℝ) - 1)) :=
+    div_nonneg (by norm_num) (by nlinarith)
+  unfold discreteDiameter
+  calc spreadProduct z ^ (2 / ((n : ℝ) * ((n : ℝ) - 1)))
+      ≤ (Real.sqrt n ^ n) ^ (2 / ((n : ℝ) * ((n : ℝ) - 1))) :=
+        Real.rpow_le_rpow (spreadProduct_nonneg z) (spreadProduct_le_sqrt_pow hz) hexp
+    _ = (n : ℝ) ^ ((1 / (2 : ℝ) * (n : ℝ)) * (2 / ((n : ℝ) * ((n : ℝ) - 1)))) := by
+        rw [← Real.rpow_natCast (Real.sqrt n) n, Real.sqrt_eq_rpow,
+          ← Real.rpow_mul (le_of_lt hnpos), ← Real.rpow_mul (le_of_lt hnpos)]
+    _ = (n : ℝ) ^ ((1 : ℝ) / ((n : ℝ) - 1)) := by
+        congr 1
+        field_simp
+
+/-- **Sharp `n`-point transfinite diameter (upper half)**: `dₙ ≤ n^{1/(n-1)}` for the
+closed unit disc. -/
+theorem transfiniteDiameterN_le_rpow (hn : 2 ≤ n) :
+    transfiniteDiameterN n ≤ (n : ℝ) ^ ((1 : ℝ) / ((n : ℝ) - 1)) := by
+  refine csSup_le (unitDiscDiameters_nonempty hn) ?_
+  rintro d ⟨z, hz, rfl⟩
+  exact discreteDiameter_le_rpow hn hz
+
+/-- **The `n`-point transfinite diameter of the closed unit disc is exactly
+`n^{1/(n-1)}`.**  Upper bound: Hadamard's inequality applied to the Vandermonde
+matrix.  Lower bound: the `n`-th roots of unity
+(`transfiniteDiameterN_rootsOfUnity_ge`).  The root-of-unity configurations are
+thus extremal at every finite level. -/
+theorem transfiniteDiameterN_eq_rpow (m : ℕ) :
+    transfiniteDiameterN (m + 2) = ((m : ℝ) + 2) ^ ((1 : ℝ) / ((m : ℝ) + 1)) := by
+  refine le_antisymm ?_ (transfiniteDiameterN_rootsOfUnity_ge m)
+  have h := transfiniteDiameterN_le_rpow (n := m + 2) (by omega)
+  have hcast : ((m + 2 : ℕ) : ℝ) = (m : ℝ) + 2 := by push_cast; ring
+  rw [hcast, show (m : ℝ) + 2 - 1 = (m : ℝ) + 1 by ring] at h
+  exact h
+
+/-- **The transfinite diameter of the closed unit disc is at most `1`.**  The exact
+`n`-point values `n^{1/(n-1)}` decrease to `1`
+(`tendsto_rootsOfUnity_lowerBound_one`), and `d` is below every one of them. -/
+theorem transfiniteDiameter_le_one : transfiniteDiameter ≤ 1 := by
+  refine ge_of_tendsto' tendsto_rootsOfUnity_lowerBound_one fun m => ?_
+  rw [← transfiniteDiameterN_eq_rpow m]
+  exact transfiniteDiameter_le m
+
+/-- **The transfinite diameter of the closed unit disc is exactly `1`** — the
+logarithmic capacity of the disc, obtained by entirely elementary means: roots of
+unity from below (`one_le_transfiniteDiameter`) and Hadamard's determinant
+inequality from above (`transfiniteDiameter_le_one`), with no Fekete–Szegő
+theorem and no potential theory. -/
+theorem transfiniteDiameter_eq_one : transfiniteDiameter = 1 :=
+  le_antisymm transfiniteDiameter_le_one one_le_transfiniteDiameter
+
+end Hadamard
+
 end Erdos1039TransfiniteDiameter

--- a/research/problems/erdos-1039-oq-05/knowledge.md
+++ b/research/problems/erdos-1039-oq-05/knowledge.md
@@ -397,3 +397,46 @@ This mirrors today's pattern on erdos-85 (f(9), f(10)): "deep" blockers
 repeatedly turn out to have elementary mechanisms. Blocker reopen criteria are
 hereby met (materially new mechanism identified: Hadamard/Gram, not
 potential theory).
+
+## Session 2026-07-23 (researcher-1) — SHARP VALUE CLOSED: d = 1 via Hadamard's inequality (docker-verified, 0-axiom)
+
+**Mode**: REVISIT (executing the 2026-07-22 Hadamard plan). **Outcome**: the full
+plan landed in ONE session, not the projected two. `Erdos1039TransfiniteDiameter.lean`
++162 lines (new `Hadamard` section), builds clean in Docker, still 0 axioms / 0 sorries.
+
+### What was proved
+- `norm_det_le_prod_norm_row` — **Hadamard's determinant inequality** (complex, row
+  form): `‖det M‖ ≤ ∏ᵢ ‖rowᵢ‖₂`. NOT in Mathlib; proved via
+  `gramSchmidtOrthonormalBasis_det` (determinant = ∏ ⟪eᵢ, fᵢ⟫ in the Gram–Schmidt
+  orthonormal basis) + Cauchy–Schwarz (`norm_inner_le_norm`) with `‖eᵢ‖ = 1`.
+  Upstream-worthy standalone lemma.
+- `norm_matrixRow_vandermonde_le` — each Vandermonde row of unit-disc points has
+  ℓ²-norm ≤ √n (entries are powers `zᵢᵏ`, each ≤ 1).
+- `spreadProduct_le_sqrt_pow` — `spreadProduct ≤ (√n)ⁿ = n^{n/2}`.
+- `discreteDiameter_le_rpow` / `transfiniteDiameterN_le_rpow` — `dₙ(Z) ≤ n^{1/(n-1)}`
+  for all unit-disc configurations (rpow exponent algebra: `(n/2)·(2/(n(n-1))) = 1/(n-1)`).
+- `transfiniteDiameterN_eq_rpow` — **exact value** `dₙ = n^{1/(n-1)}` for all n ≥ 2:
+  upper = Hadamard, lower = roots of unity (`transfiniteDiameterN_rootsOfUnity_ge`).
+  Root-of-unity configurations are extremal at EVERY finite level.
+- `transfiniteDiameter_le_one` + `transfiniteDiameter_eq_one` — **d = 1 on the nose**,
+  the logarithmic-capacity value of the closed unit disc, with NO Fekete–Szegő and NO
+  potential theory. Combines `ge_of_tendsto'` on `tendsto_rootsOfUnity_lowerBound_one`
+  with `transfiniteDiameter_le`.
+
+### Lean technique notes (v4.31)
+- `gramSchmidtOrthonormalBasis` needs `hrank : finrank = Fintype.card`; supply
+  `finrank_euclideanSpace`. Its `.toBasis.det` link to `M.det`: factor through
+  `Basis.toMatrix_mul_toMatrix` with the standard basis; the standard-basis coordinate
+  matrix of the row family is `Mᵀ` (so `det_transpose` bridges), and
+  `OrthonormalBasis.det_to_matrix_orthonormalBasis` kills the unimodular factor in norm.
+- Row extraction: `WithLp.toLp 2 (M i) : EuclideanSpace ℂ (Fin n)` (`matrixRow`) makes
+  `EuclideanSpace.norm_eq` applicable; the entry rewrite is a `show`-then-`vandermonde_apply`.
+- rpow chain: `(√n)ⁿ` → `n^{n/2}` via `Real.rpow_natCast` + `Real.sqrt_eq_rpow` +
+  `Real.rpow_mul`; final exponent equality by `field_simp` (needs `n ≠ 0`, `n - 1 ≠ 0`).
+
+### Status
+Both 2026-07-22 REROUTED blockers are now RESOLVED (formalized). The scoped
+transfinite-diameter program of this OQ is COMPLETE: definition, monotonicity,
+transformation laws, exact finite-n values, and the sharp limit d = 1 = cap(disc),
+all 0-axiom. Remaining frontier is the ρ(f)-capacity bridge (Green's functions,
+Harnack/Koebe) — parent-strength DEEP, out of scope; parent Erdős #1039 stays OPEN.

--- a/research/problems/erdos-1039-oq-05/problem.md
+++ b/research/problems/erdos-1039-oq-05/problem.md
@@ -120,3 +120,33 @@ difficulty: high
 source: proof-suggestion
 created: 2026-07-09T15:40:19-07:00
 ```
+
+## Adversarial Checklist (claim: transfinite diameter of the closed unit disc = 1, dₙ = n^{1/(n-1)} exactly)
+
+Recorded 2026-07-23 for the SOLVED claim of the scoped transfinite-diameter program
+(`Erdos1039TransfiniteDiameter.lean`, theorems `transfiniteDiameterN_eq_rpow`,
+`transfiniteDiameter_eq_one`). How THIS claim could be wrong:
+
+- **Wrong set**: confirm `discreteDiameter`/`transfiniteDiameterN` quantify over ALL
+  `z : Fin n → ℂ` with `∀ i, ‖z i‖ ≤ 1` (closed unit disc), not merely roots of unity or
+  the boundary circle. The upper bound must hold for every configuration — check
+  `transfiniteDiameterN_le_rpow` takes an arbitrary `hz : ∀ i, ‖z i‖ ≤ 1`.
+- **Sup vs max**: `transfiniteDiameterN n` is a `csSup` over the set of discrete diameters;
+  the upper bound must go through `csSup_le` with the nonemptiness witness
+  (`unitDiscDiameters_nonempty`) — an empty-set `csSup = 0` degenerate would make the
+  "equality" vacuous. Requires `n ≥ 2` (the `m + 2` indexing).
+- **Exponent off-by-one**: `dₙ = (spreadProduct)^{2/(n(n-1))}`, so the Hadamard bound
+  `spreadProduct ≤ n^{n/2}` must convert to exponent `(n/2)·(2/(n(n-1))) = 1/(n-1)` —
+  check the `field_simp` rpow algebra in `discreteDiameter_le_rpow`, not `1/n` or `2/n`.
+- **Hadamard row/column form**: `norm_det_le_prod_norm_row` bounds by ROW norms; the
+  Vandermonde rows must be the power sequences `(1, zᵢ, …, zᵢⁿ⁻¹)` (each of ℓ²-norm ≤ √n),
+  not the columns (whose norms are NOT uniformly √n-bounded in the same way). Check
+  `Matrix.vandermonde_apply` orientation: `vandermonde z i j = z i ^ (j : ℕ)` — rows indexed
+  by points. ✓ matches.
+- **Circularity**: the limit `d = 1` combines `transfiniteDiameter_le m` (monotone/inf
+  structure) with the root-of-unity LOWER bound already on main; neither imports any
+  axiom — `#print axioms transfiniteDiameter_eq_one` should show only
+  propext/Classical.choice/Quot.sound. File has 0 `axiom` declarations.
+- **Not the parent**: this claim is about `d` of the DISC (= cap = 1 normalization), NOT
+  the Erdős–Herzog–Piranian `ρ(f) ≫ 1/n`, which remains OPEN; the ρ-capacity bridge
+  (Green's function machinery) remains deep-blocked and is NOT claimed.

--- a/research/problems/erdos-1039-oq-05/state.md
+++ b/research/problems/erdos-1039-oq-05/state.md
@@ -54,3 +54,19 @@ absent from Mathlib. Reopen only if Mathlib gains capacity / Fekete–Szegő ext
 clearly session-sized): (a) exact `d₃` via the equilateral-triangle
 configuration; (b) the strict inequality `d₃ < d₂ = 2`.~~ These are Fekete–Szegő-blocked
 (enumeration theater at the elementary layer). The sharp limit `d = 1` stays deep-blocked.
+
+## Status (S8, researcher-1, 2026-07-23) — SHARP VALUE d = 1 PROVED; program COMPLETE
+
+Supersedes S7. The S7 stand-down assumed the sharp upper bound needed Fekete–Szegő;
+the 2026-07-22 route discovery (Hadamard's determinant inequality) met the reopen bar,
+and this session formalized it: `norm_det_le_prod_norm_row` (Hadamard via Gram–Schmidt,
+new to Mathlib-adjacent code), `transfiniteDiameterN_eq_rpow` (**dₙ = n^{1/(n-1)}
+exactly**, n ≥ 2), and `transfiniteDiameter_eq_one` (**d = 1**, the logarithmic
+capacity of the disc) — docker-verified, 0 axioms / 0 sorries.
+
+**PROBLEM COMPLETE (scoped program).** The transfinite-diameter side of this OQ is
+fully machine-checked with exact constants. What remains — the quantitative bridge
+ρ(f) ≳ g(d, cap) and the parent ρ(f) ≫ 1/n — needs Green's-function/Harnack machinery
+absent from Mathlib and is parent-strength DEEP (blocked route; reopen: materially
+new Mathlib potential-theory API). Do not re-mine the elementary layer: it is now
+EXHAUSTED at the sharp constants.

--- a/src/data/research/problems/erdos-1039-oq-05.json
+++ b/src/data/research/problems/erdos-1039-oq-05.json
@@ -29,23 +29,18 @@
     "goal": "Formalize transfinite diameter of the root multiset and logarithmic capacity of the lemniscate complement in the Erdos1039 framework, and state the quantitative links ρ(f) ≳ g(d, cap) as theorems where provable and axioms where they cite the literature."
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-07-09T00:00:00Z",
-    "iteration": 5,
-    "focus": "Iteration 5: elementary lower-bound program COMPLETE. General bound dₙ ≥ n^{1/(n-1)} (roots of unity, #40737) + transformation laws (#40759) + d ∈ [1,2] (transfiniteDiameter_mem_Icc_one_two) all merged, 0-axiom. This session added tendsto_rootsOfUnity_lowerBound_one: (m+2)^{1/(m+1)} → 1, certifying the elementary root-of-unity lower bound is asymptotically sharp (saturates exactly at log-capacity 1). Erdos1039TransfiniteDiameter.lean now ~1150 lines, 0 axioms/sorries.",
+    "iteration": 6,
+    "focus": "Iteration 6 (2026-07-23): SHARP VALUE CLOSED. Hadamard determinant inequality proved from Gram-Schmidt (norm_det_le_prod_norm_row, absent from Mathlib), giving spreadProduct <= n^{n/2}, hence d_n = n^{1/(n-1)} EXACTLY for all n >= 2 (transfiniteDiameterN_eq_rpow) and transfinite diameter d = 1 on the nose (transfiniteDiameter_eq_one) — the logarithmic-capacity value of the disc, with no Fekete-Szego and no potential theory. File ~1320 lines, 0 axioms / 0 sorries, docker-verified. Scoped program COMPLETE.",
     "blockers": [
       {
-        "route": "sharp value d = 1 — REROUTED 2026-07-22: needs only Hadamard determinant inequality (missing from Mathlib), NOT Fekete-Szego; 2-session formalization plan in knowledge.md",
-        "reopenCriterion": "open for formalization — elementary mechanism identified (Hadamard via Gram/Gram-Schmidt)",
-        "blockedAt": "2026-07-20"
-      },
-      {
-        "route": "exact d_n = n^{1/(n-1)} — REROUTED 2026-07-22: same Hadamard route as d = 1 (upper bound spreadProduct <= n^{n/2}); falls with it",
-        "reopenCriterion": "open for formalization — elementary mechanism identified",
-        "blockedAt": "2026-07-21"
+        "route": "rho(f)-capacity bridge: rho(f) >= g(d, cap) via Green functions / Harnack / Koebe distortion",
+        "reopenCriterion": "materially new Mathlib potential-theory API (Green functions, subharmonic functions, logarithmic capacity)",
+        "blockedAt": "2026-07-23"
       }
     ],
-    "nextAction": "Elementary layer SATURATED. Remaining work is DEEP: sharp value d = 1 (matching upper bound d ≤ 1) requires Fekete–Szegő / potential-theory API absent from Mathlib; exact dₙ = n^{1/(n-1)} for n ≥ 3 requires the extremal (upper) bound, same deep obstruction. Both recorded as blocked routes.",
+    "nextAction": "NONE — scoped transfinite-diameter program complete at sharp constants (d_n = n^{1/(n-1)}, d = 1). Remaining rho(f)-capacity bridge is parent-strength deep-blocked; parent Erdos #1039 remains OPEN.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -53,7 +48,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Elementary transfinite-diameter (Fekete-points) program for the unit-disc capacity is COMPLETE and 0-axiom: discrete spread product, Fekete monotonicity + monotone-limit structure, exact d2=2, lower bounds d3>=sqrt3 / d4>=4^(1/3) / general dn>=n^(1/(n-1)) via roots of unity, d in [1,2], and asymptotic sharpness ->1. Only the DEEP sharp value d=1 (Fekete-Szego / logarithmic capacity) and the parent conjecture rho(f)>>1/n remain, both out of the elementary scope. UPDATE 2026-07-22 (researcher-1-9): both blockers REROUTED — Hadamard determinant inequality (elementary, missing from Mathlib) suffices for spreadProduct <= n^{n/2}, hence exact d_n = n^{1/(n-1)} AND sharp d = 1; Fekete-Szego never needed for the disc. 2-session formalization plan recorded.",
+    "progressSummary": "COMPLETE (scoped program): transfinite diameter of the closed unit disc fully machine-checked at sharp constants — d_n = n^{1/(n-1)} exactly for all n >= 2 and d = 1 (the logarithmic-capacity value), 0 axioms / 0 sorries, via a new Gram-Schmidt proof of Hadamard s determinant inequality. Remaining rho(f)-capacity bridge is parent-strength deep-blocked.",
     "builtItems": [
       "Erdos1039TransfiniteDiameter.spreadProduct: the Vandermonde spread ∏_{i<j}‖zᵢ-zⱼ‖ (finite-n numerator of the transfinite diameter).",
       "Erdos1039TransfiniteDiameter.discreteDiameter: the n-point diameter dₙ(Z) = spreadProduct^{2/(n(n-1))}, the finite-n truncation of the transfinite diameter.",
@@ -85,7 +80,10 @@
       "transfiniteDiameterN_rootsOfUnity_ge, one_le_transfiniteDiameter, transfiniteDiameter_mem_Icc_one_two in Erdos1039TransfiniteDiameter.lean (all 0-axiom)",
       "spreadProduct_smul — V(cZ) = ‖c‖^{pairCount n}·V(Z) (Erdos1039TransfiniteDiameter.lean)",
       "discreteDiameter_smul — scaling covariance dₙ(cZ)=‖c‖·dₙ(Z) for n≥2 (via pairCount_mul_exp normalisation)",
-      "spreadProduct_add_const / discreteDiameter_add_const — translation invariance V(Z+c)=V(Z), dₙ(Z+c)=dₙ(Z)"
+      "spreadProduct_add_const / discreteDiameter_add_const — translation invariance V(Z+c)=V(Z), dₙ(Z+c)=dₙ(Z)",
+      "norm_det_le_prod_norm_row (Hadamard determinant inequality, complex row form) in Erdos1039TransfiniteDiameter.lean",
+      "spreadProduct_le_sqrt_pow, discreteDiameter_le_rpow, transfiniteDiameterN_le_rpow (sharp upper bounds)",
+      "transfiniteDiameterN_eq_rpow (exact n-point value n^{1/(n-1)}), transfiniteDiameter_le_one, transfiniteDiameter_eq_one (d = 1)"
     ],
     "insights": [
       "The finite discrete spread is entirely elementary and needs NO capacity infrastructure: it is a product of pairwise norms, equal to the modulus of the Vandermonde determinant, so it is host-verifiable Mathlib-only (no Docker).",
@@ -106,7 +104,10 @@
       "Vandermonde-discriminant identity spreadProduct(roots of unity)^2 = n^n proved via: (a) per-index prod_{j!=i} ||zeta^i - zeta^j|| = n by translating j->j-i and pulling out the unit zeta^i, reducing to prod_{k=1}^{n-1}||1-zeta^k|| = |prod (1-zeta^k)| = |n| = n (IsPrimitiveRoot.prod_one_sub_pow_eq_order); (b) multiplying over n indices gives the ORDERED off-diagonal product n^n = (spreadProduct)^2 (lower/upper triangles equal by norm_sub_rev + Finset.prod_comm).",
       "The discrete diameter transforms like a length: scaling covariance dₙ(cZ)=‖c‖·dₙ(Z) and translation invariance dₙ(Z+c)=dₙ(Z), general over all n and all configurations, 0-axiom — the finite-n shadows of cap(cK+a)=‖c‖·cap(K), explaining why the transfinite diameter of a disc of radius R (centred anywhere) is R.",
       "Sharp d = 1 for the disc does NOT need Fekete-Szego/potential theory: Hadamard determinant inequality on the Vandermonde matrix gives spreadProduct <= n^{n/2}, matching the proved roots-of-unity lower bound exactly — d_n = n^{1/(n-1)} and d = 1 both follow; only missing Mathlib piece is Hadamard itself (2-session plan recorded)",
-      "Mathlib gap: no Hadamard inequality, no PosSemidef det <= prod diag (checked 2026-07-22); Matrix.det_vandermonde and gramSchmidt exist as building blocks"
+      "Mathlib gap: no Hadamard inequality, no PosSemidef det <= prod diag (checked 2026-07-22); Matrix.det_vandermonde and gramSchmidt exist as building blocks",
+      "Hadamard determinant inequality ‖det M‖ <= prod of row l2-norms is provable in ~40 lines from gramSchmidtOrthonormalBasis_det + Cauchy-Schwarz; the standard-basis coordinate matrix of the row family is M-transpose, and OrthonormalBasis.det_to_matrix_orthonormalBasis kills the basis-change factor in norm",
+      "Root-of-unity configurations are extremal for the n-point transfinite diameter of the disc at EVERY finite n (d_n = n^{1/(n-1)} exactly), not just asymptotically — Hadamard upper bound meets the roots-of-unity lower bound with no gap",
+      "The sharp d = 1 (= log capacity of the disc) needs NO potential theory: Hadamard + Vandermonde row norms <= sqrt(n) suffices. The Fekete-Szego deep-block assessment was wrong for the disc"
     ],
     "mathlibGaps": [
       "Mathlib has no transfinite-diameter / logarithmic-capacity API; the n-point spread and its diameter had to be defined from scratch (done here). The limit d(Z)=limₙ dₙ and Fekete monotonicity are still absent.",


### PR DESCRIPTION
## Summary
Research session for erdos-1039-oq-05 (transfinite diameter / logarithmic capacity of the unit disc).

Closes the sharp value: the transfinite diameter of the closed unit disc is **exactly 1** — the logarithmic-capacity value — by entirely elementary means, resolving both registered blocked routes without Fekete–Szegő or potential theory.

## Progress
- `norm_det_le_prod_norm_row` — **Hadamard's determinant inequality** (complex, row form), absent from Mathlib; proved via `gramSchmidtOrthonormalBasis_det` + Cauchy–Schwarz (~40 lines, upstream-worthy)
- `norm_matrixRow_vandermonde_le` / `spreadProduct_le_sqrt_pow` — Vandermonde rows of unit-disc points have l2-norm at most sqrt(n), so `spreadProduct <= n^{n/2}`
- `discreteDiameter_le_rpow` / `transfiniteDiameterN_le_rpow` — sharp upper bound `d_n <= n^{1/(n-1)}`, matching the existing roots-of-unity lower bound exactly
- `transfiniteDiameterN_eq_rpow` — **exact n-point value** `d_n = n^{1/(n-1)}` for all n >= 2 (root-of-unity configurations are extremal at every finite level)
- `transfiniteDiameter_le_one` + `transfiniteDiameter_eq_one` — **d = 1 on the nose**

File: `proofs/Proofs/Erdos1039TransfiniteDiameter.lean` (+162 lines, now ~1320). Still **0 axioms / 0 sorries**. Docker-verified (8576 jobs, exit 0).

## Findings
- The prior "DEEP Fekete–Szegő" assessment for the sharp upper bound was an overestimate for the disc: Hadamard's inequality + row-norm bookkeeping suffices.
- Hadamard via Gram–Schmidt in Lean: the standard-basis coordinate matrix of the row family is the transpose of M; `OrthonormalBasis.det_to_matrix_orthonormalBasis` removes the unimodular basis-change factor in norm.
- Adversarial checklist for the SOLVED claim recorded in `research/problems/erdos-1039-oq-05/problem.md`.

## Status
**Outcome**: completed (scoped transfinite-diameter program complete at sharp constants)
**Next Steps**: none at the elementary layer — it is exhausted at the sharp constants. The remaining rho(f)-capacity bridge (Green's functions / Harnack) is parent-strength deep-blocked; parent Erdős #1039 remains OPEN.

🤖 Generated by researcher-1
