### PR TITLE
Enrich lagrange-four-squares-waring-g2-oq-03-oq-08: split sections to 5 real boundaries (4->5)

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-08/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-08/meta.json
@@ -127,10 +127,19 @@
     },
     {
       "id": "g2-isleast",
-      "title": "g(2) = 4, sharp and axiom-free",
+      "title": "g(2) = 4, Sharp and Axiom-Free",
       "startLine": 73,
+      "endLine": 87,
+      "summary": "Sufficient k (def) and g2_isLeast: IsLeast {k | Sufficient k} 4. The lower half proceeds by contradiction — a hypothetical k ≤ 3 in the sufficient set would, via mono, make 7 representable by ≤ 3 squares, contradicting seven_not_three.",
+      "mathContext": "$g(2)=4$ as $\\mathrm{IsLeast}\\{k : \\mathrm{Sufficient}(k)\\}\\,4$: $4\\in\\{k\\}$ by Lagrange, and no $k\\le 3$ works since that would make $7$ a sum of $\\le 3$ squares."
+    },
+    {
+      "id": "waring-infimum",
+      "title": "Infimum Form and Human-Readable Restatements",
+      "startLine": 89,
       "endLine": 98,
-      "summary": "Sufficient k (def), g2_isLeast (IsLeast {k | Sufficient k} 4 — lower half by contradiction via mono + seven_not_three), waring_g2 (sInf = 4 via IsLeast.csInf_eq), and the human-readable four_squares_suffice / three_squares_insufficient."
+      "summary": "waring_g2 restates g2_isLeast as an infimum, sInf {k | Sufficient k} = 4, via IsLeast.csInf_eq. four_squares_suffice and three_squares_insufficient give the plain-language restatements of the two halves. Closes the namespace.",
+      "mathContext": "$\\operatorname{sInf}\\{k : \\mathrm{Sufficient}(k)\\} = 4$, the infimum form of the least-element statement."
     }
   ],
   "sorries": []


### PR DESCRIPTION
## Summary
- `sections` had only 4 entries (quality-96 gap: sections count is capped at 10 points, 2 per section up to 5). The full 98-line file was covered, but the last section bundled two distinct results.
- Split the final section of `Proofs/LagrangeFourSquaresWaringG2OQ03OQ08.lean` at a real theorem boundary:
  4. `g(2) = 4, Sharp and Axiom-Free` (73-87): `Sufficient` def + `g2_isLeast`
  5. `Infimum Form and Human-Readable Restatements` (89-98, new): `waring_g2` + the two plain-language restatements
- Added `mathContext` to both, matching the style of the other three (unchanged) sections.
- No content deleted; file remains well under the 60 KB cap.

## Test plan
- [x] `python3 -m json.tool` validates the JSON
- [x] Sections still cover the full Lean file (1-98) with no gaps or overlaps