### PR TITLE
Enrich napoleons-theorem-oq-04: cover header docstring, split to 5 sections

### DIFF
--- a/src/data/proofs/napoleons-theorem-oq-04/meta.json
+++ b/src/data/proofs/napoleons-theorem-oq-04/meta.json
@@ -54,6 +54,15 @@
   },
   "sections": [
     {
+      "title": "Header: Two Corrections to the Sketch",
+      "startLine": 1,
+      "endLine": 39,
+      "description": "Module docstring stating the area identity and explaining the two corrections needed to make the problem's original sketch true: the Napoleon triangle uses the centroid offset √3/6 (not the apex offset √3/2), and with a fixed signed-area convention the correct relation is an addition (outer + inner = original), because the inner triangle is oppositely oriented.",
+      "summary": "States the corrected identity and why the naive sketch is false",
+      "id": "header",
+      "mathContext": "The sketch's literal claim used the apex offset $\\sqrt3/2$ and a subtraction; substituting the true centroid offset $\\sqrt3/6$ and accounting for the inner triangle's reversed orientation turns it into $\\operatorname{triArea}(\\text{outer})+\\operatorname{triArea}(\\text{inner})=\\operatorname{triArea}(\\text{original})$, equivalent to the classical unsigned $|\\text{outer}|-|\\text{inner}|=|\\text{original}|$."
+    },
+    {
       "title": "Signed Area and its Real Expansion",
       "startLine": 40,
       "endLine": 50,


### PR DESCRIPTION
Enrichment pass for napoleons-theorem-oq-04.

The entry already met quality targets (5 annotations with mathContext/significance/relatedConcepts, 4 keyInsights, conclusion with implications + openQuestions, cross-references), but `sections[]` only covered lines 40-119 — the module docstring (lines 1-38), which states the corrected area identity and explains the two corrections to the original problem sketch (centroid offset √3/6 not apex √3/2; signed addition not subtraction), was uncovered.

Added a 5th section (`header`, lines 1-39) summarizing that corrected statement, bringing `sections.length` from 4 to 5. No other fields changed; file remains well under the 60 KB size cap (~14 KB).