### PR TITLE
Enrich law-of-cosines-oq-07-oq-01: split sections to 5 real boundaries (4->5)

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-07-oq-01/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-07-oq-01/meta.json
@@ -51,6 +51,14 @@
   },
   "sections": [
     {
+      "id": "setup",
+      "title": "Setup: From Necessity to a Full Characterisation",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Module docstring: the parent law-of-cosines-oq-07 proved the parallelogram law necessary via Apollonius; this entry adds the converse (Jordan–von Neumann 1935) to get a two-sided characterisation, over an arbitrary RCLike field 𝕜.",
+      "mathContext": "States the three headline results — parallelogram_of_innerProductSpace, innerProductSpaceOfParallelogram, nonempty_innerProductSpace_iff_parallelogram — and distinguishes this entry's functional-analytic focus from sibling oq-02's metric/affine one."
+    },
+    {
       "id": "part1-necessity",
       "title": "Part I: Necessity (Forward Direction)",
       "startLine": 56,
@@ -75,7 +83,7 @@
       "id": "part4-instantiation",
       "title": "Part IV: Euclidean Plane Instantiation",
       "startLine": 97,
-      "endLine": 103,
+      "endLine": 104,
       "summary": "Confirms the characterisation recognises the standard model EuclideanSpace ℝ (Fin 2)."
     }
   ],


### PR DESCRIPTION
Enrichment pass for law-of-cosines-oq-07-oq-01.

`sections[]` had 4 entries (lines 56-103) and left the module docstring
(lines 1-55 — problem statement, the Jordan–von Neumann background, and the
distinction from sibling oq-02) uncovered, even though `annotations.json`
already has a header annotation spanning lines 1-54. Split into 5 sections
that cover the full 104-line file, matching existing Lean declaration
boundaries:

- `setup` (1-55): module docstring motivating the characterisation
- `part1-necessity` (56-63): forward direction
- `part2-sufficiency` (65-73): converse (Jordan–von Neumann)
- `part3-characterisation` (75-95): the two-sided biconditional
- `part4-instantiation` (97-104): Euclidean-plane confirmation, extended to EOF

No other content changed; `meta.json` stays well under the 60 KB cap (~11 KB).