### PR TITLE
Audit tracker: mark erdos-117 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10581,8 +10581,8 @@
     },
     "erdos-117": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:34Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T19:30:33Z",
       "result": "clean"
     },
     "erdos-117-oq-01": {


### PR DESCRIPTION
## Summary
Audited erdos-117 (Erdős Problem #117 — Covering Groups by Abelian Subgroups).

meta.json counts verified exactly against `Proofs/Erdos117Problem.lean`:
- 0 axioms, 0 sorries, 7 theorems, 3 definitions, 128 lines — all match.
- No True stubs, no `native_decide`.
- Status `axiomatized` / badge `wip` is honest: the file only formalizes
  definitions (`HasNCommutingProperty`, `IsAbelianSubgroup`,
  `abelianCoverNumber`) plus 7 axiom-free foundational lemmas; the main
  estimate for h(n) (Pyber's bounds) is documented in docstrings only,
  and the `assumptions` field discloses this plainly.

Result: **clean**, no action needed.

Discovered during gallery integrity audit.