### PR TITLE
Enrich legendre-factorial-formula-oq-01: split sections to 5 real boundaries (4->5)

### DIFF
--- a/src/data/proofs/legendre-factorial-formula-oq-01/meta.json
+++ b/src/data/proofs/legendre-factorial-formula-oq-01/meta.json
@@ -69,11 +69,18 @@
       "summary": "Docstring stating Legendre's formula in its two classical forms (floor-sum and digit-sum) and announcing the new solved form vₚ(n!) = (n − Sₚ(n))/(p−1). Imports the p-adic valuation basics, opens Nat / Finset, and fixes a prime p (via the Fact p.Prime convention on each theorem)."
     },
     {
-      "id": "sec-floor-digit",
-      "title": "Floor-Sum and Digit-Sum Forms",
+      "id": "sec-floor-sum",
+      "title": "Floor-Sum Form",
       "startLine": 32,
+      "endLine": 38,
+      "summary": "padicValNat_factorial_eq_sum wraps Mathlib's padicValNat_factorial: vₚ(n!) = ∑_{i∈[1,b)} ⌊n/pⁱ⌋ for any bound b above log_p n."
+    },
+    {
+      "id": "sec-digit-sum",
+      "title": "Digit-Sum Form",
+      "startLine": 40,
       "endLine": 45,
-      "summary": "padicValNat_factorial_eq_sum wraps Mathlib's padicValNat_factorial (vₚ(n!) = ∑_{i∈[1,b)} ⌊n/pⁱ⌋ for any bound b above log_p n) and sub_one_mul_padicValNat_factorial_eq wraps sub_one_mul_padicValNat_factorial ((p−1)·vₚ(n!) = n − Sₚ(n))."
+      "summary": "sub_one_mul_padicValNat_factorial_eq wraps sub_one_mul_padicValNat_factorial: (p−1)·vₚ(n!) = n − Sₚ(n), where Sₚ(n) is the base-p digit sum."
     },
     {
       "id": "sec-solved",


### PR DESCRIPTION
Enrichment pass for legendre-factorial-formula-oq-01.

`sections[]` had 4 entries; `annotations.json` already splits the classical
statements at finer granularity (floor-sum 32-38, digit-sum 40-45 as separate
annotations) while `sections` merged them into one 32-45 block. Split
`sec-floor-digit` to match, giving 5 sections that contiguously cover the
full 71-line file:

- `sec-header` (1-30): docstring, imports, setup
- `sec-floor-sum` (32-38): floor-sum form
- `sec-digit-sum` (40-45): digit-sum form
- `sec-solved` (47-56): the new solved form isolating vₚ(n!)
- `sec-bound-instance` (58-71): the bound + worked v₂(10!) = 8 instance

No other content changed; `meta.json` stays well under the 60 KB cap (~10 KB).