### PR TITLE
Enrich nakayama-lemma-oq-01: split local-forms into 5 real section boundaries

### DIFF
--- a/src/data/proofs/nakayama-lemma-oq-01/meta.json
+++ b/src/data/proofs/nakayama-lemma-oq-01/meta.json
@@ -92,12 +92,20 @@
       "mathContext": "General Jacobson-radical Nakayama for an arbitrary commutative ring."
     },
     {
-      "id": "local-forms",
-      "title": "The Local-Ring Forms",
+      "id": "local-vanishing",
+      "title": "nakayama_local: the Textbook Statement",
       "startLine": 72,
+      "endLine": 79,
+      "summary": "Under [IsLocalRing R]: nakayama_local specializes the Jacobson baseline to I = 𝔪, discharging I ≤ jacobson ⊥ by maximalIdeal_le_jacobson ⊥. This one line — N ≤ 𝔪·N ⟹ N = ⊥ — is the single most-cited form of Nakayama's lemma.",
+      "mathContext": "$N \\text{ f.g.},\\ N \\le \\mathfrak{m}\\cdot N \\implies N = \\bot$, via $\\mathfrak{m} \\le \\mathrm{jacobson}(\\bot)$."
+    },
+    {
+      "id": "subsingleton-bridge",
+      "title": "From ⊤ = ⊥ to Subsingleton M",
+      "startLine": 81,
       "endLine": 97,
-      "summary": "Under [IsLocalRing R]: nakayama_local (N ≤ 𝔪·N ⟹ N = ⊥, via 𝔪 ≤ jacobson ⊥); nakayama_local_top (finite M with M ≤ 𝔪·M is Subsingleton, translating ⊤ = ⊥ to a type-level triviality); nakayama_local_top_ne (the contrapositive: nonzero finite M has 𝔪·M ≠ M).",
-      "mathContext": "Textbook local Nakayama: 𝔪M = M ⟹ M = 0, and M/𝔪M ≠ 0 for M ≠ 0 finitely generated."
+      "summary": "nakayama_local_top upgrades the submodule equation to the type level: a finite M with M ≤ 𝔪·M is Subsingleton, since ⊤ = ⊥ forces every element into ⊥. nakayama_local_top_ne is the contrapositive — a nonzero finite M has 𝔪·M ≠ M — closed via not_subsingleton.",
+      "mathContext": "$\\mathfrak{m}\\cdot M = M \\implies \\mathrm{Subsingleton}(M);\\quad M \\ne 0 \\implies \\mathfrak{m}\\cdot M \\ne M$."
     },
     {
       "id": "generators",


### PR DESCRIPTION
Enrichment pass for nakayama-lemma-oq-01.

The entry already met quality targets (5 annotations with mathContext/significance/relatedConcepts, historicalContext, 4 keyInsights, conclusion with implications + 2 openQuestions), but had only 4 sections, with the third (`local-forms`, lines 72-97) bundling two conceptually distinct steps: the direct Jacobson-to-local specialization (`nakayama_local`) and a separate type-level Subsingleton translation (`nakayama_local_top`/`nakayama_local_top_ne`).

Split that section at the real theorem boundary between lines 79 and 81, giving `sections.length` 4 → 5:
- `local-vanishing` (72-79): `nakayama_local` itself
- `subsingleton-bridge` (81-97): the ⊤ = ⊥ → Subsingleton M translation and its contrapositive

No other content changed; file stays well under the 60 KB size cap (~13 KB).