### PR TITLE
Enrich lhopital-oq-02-incomplete-01: split sections to 5 real boundaries (4->5)

### DIFF
--- a/src/data/proofs/lhopital-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/lhopital-oq-02-incomplete-01/meta.json
@@ -57,11 +57,19 @@
   },
   "sections": [
     {
-      "id": "sec-header",
-      "title": "Module Header, Imports, and Setup",
+      "id": "sec-imports",
+      "title": "Imports: the Parent ∞/∞ Rule",
       "startLine": 1,
+      "endLine": 4,
+      "summary": "Imports Log.Deriv, Exp, Exponential, and the parent module Proofs.LHopitalOQ02 — the load-bearing dependency, since Mathlib's own 26 L'Hôpital variants only cover the 0/0 form.",
+      "mathContext": "The parent rule LHopitalInfty.lhopital_infty_atTop is what makes the three ∞/∞ corollaries below possible without reproving L'Hôpital from scratch."
+    },
+    {
+      "id": "sec-header",
+      "title": "Module Header and Setup",
+      "startLine": 6,
       "endLine": 55,
-      "summary": "Module docstring framing the leaf as worked corollaries of the parent ∞/∞ rule, a per-limit f/g/f'/g' table, and the status checklist. Imports Log.Deriv, Exp, Exponential, and the parent module Proofs.LHopitalOQ02; opens Set Filter Topology Real.",
+      "summary": "Module docstring framing the leaf as worked corollaries of the parent ∞/∞ rule, a per-limit f/g/f'/g' table, and the status checklist. Opens Set Filter Topology Real inside the namespace.",
       "mathContext": "Each limit is an ∞/∞ indeterminate form f/g with g → +∞. The parent rule LHopitalInfty.lhopital_infty_atTop reduces the limit of f/g to the easy limit of f'/g'."
     },
     {


### PR DESCRIPTION
Enrichment pass for lhopital-oq-02-incomplete-01.

`sections[]` had 4 entries; the header block (1-55) bundled the imports
(which annotations.json already treats as a distinct annotation, "the
load-bearing dependency" on the parent's ∞/∞ rule) together with the module
docstring/setup. Split into 5 sections that contiguously cover the full
123-line file:

- `sec-imports` (1-4): the parent ∞/∞ rule import
- `sec-header` (6-55): docstring, per-limit table, status checklist
- `log-over-id` (56-76): Corollary 1
- `id-over-exp` (77-98): Corollary 2
- `nonzero-limit` (99-123): Corollary 3 (nonzero-limit case)

No other content changed; `meta.json` stays well under the 60 KB cap (~10 KB).