### PR TITLE
Research: erdos-117-wip-01 - h(3) = 3 exact + h(4) rung (ladder now 0,1,1,3,>=4)

### DIFF
--- a/proofs/Proofs/Erdos117WIP01Exact.lean
+++ b/proofs/Proofs/Erdos117WIP01Exact.lean
@@ -1,0 +1,404 @@
+/-
+  Erdős Problem #117 — Covering Groups by Abelian Subgroups: **h(3) = 3, exactly**.
+
+  Companion to `Erdos117Problem.lean` and the `Erdos117WIP01*` ladder.  Prior
+  companions pinned `h(0) = 0`, `h(1) = h(2) = 1`, and — conditionally on the
+  covering set being nonempty — `h(n) ≥ 3` for `n ≥ 3` (witness `Q₈`).  Every
+  `h(3)` statement so far carried the honest hypothesis
+  `∃ k, CoversWithAbelian k 3`, because well-definedness of `h(3)` (a UNIFORM
+  finite abelian-cover budget for *every* group with the 3-commuting property)
+  was assessed as "classification-strength, not attempted here"
+  (`Erdos117WIP01Three.lean` header).
+
+  This file removes that hypothesis: the uniform budget is `3`, by an entirely
+  elementary argument, and consequently
+
+      **h(3) = 3** — the first nontrivial exact value on the Erdős #117 ladder,
+      unconditional and axiom-free.
+
+  The two-step mechanism (no classification, no Pyber, no symplectic forms):
+
+  1. **Covering.**  If `a`, `b` do not commute, then `{a, b, ab}` is pairwise
+     non-commuting, so in a group with the 3-commuting property every `g` must
+     commute with one of `a`, `b`, `ab` — otherwise `{a, b, ab, g}` is a
+     4-subset with no commuting pair.  Hence `G = C(a) ∪ C(b) ∪ C(ab)`.
+
+  2. **Centralizers are abelian.**  If `u, v ∈ C(a)` fail to commute, a case
+     analysis on which of `u`, `v`, `uv` the element `b` commutes with produces
+     an explicit pairwise non-commuting 4-set in every case:
+
+       | `b~u` | `b~v` | `b~uv` | forbidden 4-set          |
+       |-------|-------|--------|--------------------------|
+       |  yes  |  yes  |  (yes) | `{au, av, b, a(uv)}`     |
+       |  yes  |  no   |   —    | `{au, b, v, uv}`         |
+       |  no   |  yes  |   —    | symmetric (swap `u,v`)   |
+       |  no   |  no   |  yes   | `{b, u, v, a(uv)}`       |
+       |  no   |  no   |  no    | `{b, u, v, uv}`          |
+
+     Distinctness of the four elements is automatic: non-commuting elements are
+     distinct, so `no_four_clique` needs only the six non-commutation edges.
+
+  Main results (all axiom-free — `#print axioms` = propext/Classical.choice/Quot.sound):
+
+  * `no_four_clique`                   : the 3-commuting property forbids four
+                                         pairwise non-commuting elements.
+  * `centralizer_abelian_of_three`     : in a group with the 3-commuting property,
+                                         the centralizer of either member of a
+                                         non-commuting pair is abelian.
+  * `exists_three_abelian_cover`       : **every** group (finite or not) with the
+                                         3-commuting property is covered by 3
+                                         abelian subgroups.
+  * `coversWithAbelian_three_three`    : `CoversWithAbelian 3 3` — the covering
+                                         set of `h(3)` is inhabited by `3`.
+  * `coversWithAbelian_three_nonempty` : `h(3)` is well-defined (discharges the
+                                         `hne` hypothesis of the `Three.lean`
+                                         lower-bound results).
+  * `abelianCoverNumber_le_three`      : `h(3) ≤ 3`.
+  * `abelianCoverNumber_three`         : **`h(3) = 3`** (unconditional).
+  * `abelianCoverNumber_two_lt_three_unconditional` : `h(2) < h(3)` — the
+                                         ladder's first strict jump past `1`,
+                                         now unconditional: `0, 1, 1, 3, …`.
+  * `abelianCoverNumber_le_three_of_le` : `h(n) ≤ 3` for all `n ≤ 3`.
+
+  Pyber's exponential bounds and the open exact growth base (Erdős #117 proper)
+  are untouched.
+
+  0 axioms, 0 sorries.
+-/
+
+import Mathlib
+import Proofs.Erdos117Problem
+import Proofs.Erdos117WIP01
+import Proofs.Erdos117WIP01Mono
+import Proofs.Erdos117WIP01Cover
+import Proofs.Erdos117WIP01Two
+import Proofs.Erdos117WIP01Three
+
+/- The universe of the ambient groups (see `Erdos117WIP01Mono.lean`):
+   `CoversWithAbelian`/`abelianCoverNumber` are universe-polymorphic, so every
+   occurrence below is pinned to the same `u`.  The group-theoretic lemmas of
+   sections 1–3 are universe-agnostic. -/
+universe u
+
+/- ## 1. Commutation kit
+
+Seven cancellation micro-lemmas.  Everything below is pure `mul_assoc` +
+`mul_left_cancel`/`mul_right_cancel` bookkeeping, packaged so each clique edge
+in section 3 is a one-liner. -/
+
+section CommKit
+
+variable {G : Type*} [Group G]
+
+/-- An element commuting with `x` and `y` commutes with `x * y`. -/
+theorem comm_mul_of_comm {b x y : G} (hbx : b * x = x * b) (hby : b * y = y * b) :
+    b * (x * y) = (x * y) * b := by
+  calc b * (x * y) = (b * x) * y := (mul_assoc b x y).symm
+    _ = (x * b) * y := by rw [hbx]
+    _ = x * (b * y) := mul_assoc x b y
+    _ = x * (y * b) := by rw [hby]
+    _ = (x * y) * b := (mul_assoc x y b).symm
+
+/-- If `b` commutes with `u`, and `a * u` commutes with `b`, then `a` commutes
+    with `b` (cancel `u` on the right). -/
+theorem comm_ab_of_comm_mul {a b u : G} (hbu : b * u = u * b)
+    (h : (a * u) * b = b * (a * u)) : a * b = b * a := by
+  have h1 : (a * b) * u = (b * a) * u := by
+    calc (a * b) * u = a * (b * u) := mul_assoc a b u
+      _ = a * (u * b) := by rw [hbu]
+      _ = (a * u) * b := (mul_assoc a u b).symm
+      _ = b * (a * u) := h
+      _ = (b * a) * u := (mul_assoc b a u).symm
+  exact mul_right_cancel h1
+
+/-- Left-multiplication by a common commuting element reflects commutation:
+    `(a*x)*(a*y) = a*(a*(x*y))` when `a` commutes with `x`. -/
+theorem mul_mul_eq_of_comm {a x : G} (hax : a * x = x * a) (y : G) :
+    (a * x) * (a * y) = a * (a * (x * y)) := by
+  calc (a * x) * (a * y) = a * (x * (a * y)) := mul_assoc a x (a * y)
+    _ = a * ((x * a) * y) := by rw [← mul_assoc x a y]
+    _ = a * ((a * x) * y) := by rw [← hax]
+    _ = a * (a * (x * y)) := by rw [mul_assoc a x y]
+
+/-- If `a` commutes with `x` and `y`, and `a*x` commutes with `a*y`, then `x`
+    commutes with `y` (cancel `a` twice on the left). -/
+theorem comm_of_mul_mul {a x y : G} (hax : a * x = x * a) (hay : a * y = y * a)
+    (h : (a * x) * (a * y) = (a * y) * (a * x)) : x * y = y * x := by
+  have h1 : a * (a * (x * y)) = a * (a * (y * x)) := by
+    rw [← mul_mul_eq_of_comm hax y, ← mul_mul_eq_of_comm hay x]
+    exact h
+  exact mul_left_cancel (mul_left_cancel h1)
+
+/-- `x` commutes with `x * y` only if `x` commutes with `y`. -/
+theorem comm_of_self_mul_left {x y : G} (h : x * (x * y) = (x * y) * x) :
+    x * y = y * x :=
+  mul_left_cancel (h.trans (mul_assoc x y x))
+
+/-- `y` commutes with `x * y` only if `x` commutes with `y`. -/
+theorem comm_of_self_mul_right {x y : G} (h : y * (x * y) = (x * y) * y) :
+    x * y = y * x :=
+  (mul_right_cancel ((mul_assoc y x y).trans h)).symm
+
+/-- If `a` commutes with `v`, and `a*u` commutes with `v`, then `u` commutes
+    with `v` (cancel `a` on the left). -/
+theorem comm_of_mul_left_right {a u v : G} (hav : a * v = v * a)
+    (h : (a * u) * v = v * (a * u)) : u * v = v * u := by
+  have h1 : a * (u * v) = a * (v * u) := by
+    calc a * (u * v) = (a * u) * v := (mul_assoc a u v).symm
+      _ = v * (a * u) := h
+      _ = (v * a) * u := (mul_assoc v a u).symm
+      _ = (a * v) * u := by rw [← hav]
+      _ = a * (v * u) := mul_assoc a v u
+  exact mul_left_cancel h1
+
+/-- If `a` commutes with `u`, and `u` commutes with `a*x`, then `u` commutes
+    with `x` (cancel `a` on the left). -/
+theorem comm_of_left_mul {a u x : G} (hau : a * u = u * a)
+    (h : u * (a * x) = (a * x) * u) : u * x = x * u := by
+  have h1 : a * (u * x) = a * (x * u) := by
+    calc a * (u * x) = (a * u) * x := (mul_assoc a u x).symm
+      _ = (u * a) * x := by rw [hau]
+      _ = u * (a * x) := mul_assoc u a x
+      _ = (a * x) * u := h
+      _ = a * (x * u) := mul_assoc a x u
+  exact mul_left_cancel h1
+
+/-- If `b` commutes with `u` and with `u * v`, then `b` commutes with `v`
+    (cancel `u` on the left). -/
+theorem comm_right_of_comm_mul {b u v : G} (hbu : b * u = u * b)
+    (h : b * (u * v) = (u * v) * b) : b * v = v * b := by
+  have h1 : u * (b * v) = u * (v * b) := by
+    calc u * (b * v) = (u * b) * v := (mul_assoc u b v).symm
+      _ = (b * u) * v := by rw [← hbu]
+      _ = b * (u * v) := mul_assoc b u v
+      _ = (u * v) * b := h
+      _ = u * (v * b) := mul_assoc u v b
+  exact mul_left_cancel h1
+
+end CommKit
+
+/- ## 2. The 3-commuting property forbids 4-cliques -/
+
+section NoFourClique
+
+variable {G : Type*} [Group G]
+
+/-- **No four pairwise non-commuting elements** exist in a group with the
+    3-commuting property.  Distinctness is automatic (an element commutes with
+    itself), so only the six non-commutation edges are required.  The 4-subset
+    `{w, x, y, z}` then violates the defining property. -/
+theorem no_four_clique (hprop : HasNCommutingProperty G 3) {w x y z : G}
+    (cwx : w * x ≠ x * w) (cwy : w * y ≠ y * w) (cwz : w * z ≠ z * w)
+    (cxy : x * y ≠ y * x) (cxz : x * z ≠ z * x) (cyz : y * z ≠ z * y) :
+    False := by
+  classical
+  have hwx : w ≠ x := fun h => cwx (by rw [h])
+  have hwy : w ≠ y := fun h => cwy (by rw [h])
+  have hwz : w ≠ z := fun h => cwz (by rw [h])
+  have hxy : x ≠ y := fun h => cxy (by rw [h])
+  have hxz : x ≠ z := fun h => cxz (by rw [h])
+  have hyz : y ≠ z := fun h => cyz (by rw [h])
+  have hcard : ({w, x, y, z} : Finset G).card = 4 := by
+    rw [Finset.card_insert_of_notMem (by simp [hwx, hwy, hwz]),
+        Finset.card_insert_of_notMem (by simp [hxy, hxz]),
+        Finset.card_insert_of_notMem (by simp [hyz]),
+        Finset.card_singleton]
+  obtain ⟨p, q, hp, hq, hpq, hcomm⟩ :=
+    hprop {w, x, y, z} (by rw [hcard]; norm_num)
+  simp only [Finset.mem_insert, Finset.mem_singleton] at hp hq
+  rcases hp with rfl | rfl | rfl | rfl <;> rcases hq with rfl | rfl | rfl | rfl <;>
+    first
+      | exact hpq rfl
+      | exact cwx hcomm | exact cwy hcomm | exact cwz hcomm
+      | exact cxy hcomm | exact cxz hcomm | exact cyz hcomm
+      | exact cwx hcomm.symm | exact cwy hcomm.symm | exact cwz hcomm.symm
+      | exact cxy hcomm.symm | exact cxz hcomm.symm | exact cyz hcomm.symm
+
+end NoFourClique
+
+/- ## 3. Centralizers of non-commuting elements are abelian -/
+
+section CentralizerAbelian
+
+variable {G : Type*} [Group G]
+
+/-- Case `b~u`, `b~v`: the 4-set `{a*u, a*v, b, a*(u*v)}` is pairwise
+    non-commuting. -/
+private theorem centralizer_case_both (hprop : HasNCommutingProperty G 3)
+    {a b u v : G} (hab : a * b ≠ b * a)
+    (hau : a * u = u * a) (hav : a * v = v * a) (huv : u * v ≠ v * u)
+    (hbu : b * u = u * b) (hbv : b * v = v * b) : False := by
+  have hauv : a * (u * v) = (u * v) * a := comm_mul_of_comm hau hav
+  have hbuv : b * (u * v) = (u * v) * b := comm_mul_of_comm hbu hbv
+  refine no_four_clique hprop
+    (w := a * u) (x := a * v) (y := b) (z := a * (u * v)) ?_ ?_ ?_ ?_ ?_ ?_
+  · exact fun h => huv (comm_of_mul_mul hau hav h)
+  · exact fun h => hab (comm_ab_of_comm_mul hbu h)
+  · exact fun h => huv (comm_of_self_mul_left (comm_of_mul_mul hau hauv h))
+  · exact fun h => hab (comm_ab_of_comm_mul hbv h)
+  · exact fun h => huv (comm_of_self_mul_right (comm_of_mul_mul hav hauv h))
+  · exact fun h => hab (comm_ab_of_comm_mul hbuv h.symm)
+
+/-- Case `b~u`, `¬ b~v`: the 4-set `{a*u, b, v, u*v}` is pairwise
+    non-commuting. -/
+private theorem centralizer_case_left (hprop : HasNCommutingProperty G 3)
+    {a b u v : G} (hab : a * b ≠ b * a)
+    (hau : a * u = u * a) (hav : a * v = v * a) (huv : u * v ≠ v * u)
+    (hbu : b * u = u * b) (hbv : b * v ≠ v * b) : False := by
+  have hauv : a * (u * v) = (u * v) * a := comm_mul_of_comm hau hav
+  refine no_four_clique hprop
+    (w := a * u) (x := b) (y := v) (z := u * v) ?_ ?_ ?_ ?_ ?_ ?_
+  · exact fun h => hab (comm_ab_of_comm_mul hbu h)
+  · exact fun h => huv (comm_of_mul_left_right hav h)
+  · exact fun h => huv (comm_of_self_mul_left (comm_of_mul_left_right hauv h))
+  · exact hbv
+  · exact fun h => hbv (comm_right_of_comm_mul hbu h)
+  · exact fun h => huv (comm_of_self_mul_right h)
+
+/-- Case `¬ b~u`, `¬ b~v`, `b~uv`: the 4-set `{b, u, v, a*(u*v)}` is pairwise
+    non-commuting. -/
+private theorem centralizer_case_product (hprop : HasNCommutingProperty G 3)
+    {a b u v : G} (hab : a * b ≠ b * a)
+    (hau : a * u = u * a) (hav : a * v = v * a) (huv : u * v ≠ v * u)
+    (hbu : b * u ≠ u * b) (hbv : b * v ≠ v * b)
+    (hbuv : b * (u * v) = (u * v) * b) : False := by
+  refine no_four_clique hprop
+    (w := b) (x := u) (y := v) (z := a * (u * v)) ?_ ?_ ?_ ?_ ?_ ?_
+  · exact hbu
+  · exact hbv
+  · exact fun h => hab (comm_ab_of_comm_mul hbuv h.symm)
+  · exact huv
+  · exact fun h => huv (comm_of_self_mul_left (comm_of_left_mul hau h))
+  · exact fun h => huv (comm_of_self_mul_right (comm_of_left_mul hav h))
+
+/-- Case `¬ b~u`, `¬ b~v`, `¬ b~uv`: the 4-set `{b, u, v, u*v}` is pairwise
+    non-commuting. -/
+private theorem centralizer_case_none (hprop : HasNCommutingProperty G 3)
+    {b u v : G} (huv : u * v ≠ v * u)
+    (hbu : b * u ≠ u * b) (hbv : b * v ≠ v * b)
+    (hbuv : b * (u * v) ≠ (u * v) * b) : False := by
+  refine no_four_clique hprop
+    (w := b) (x := u) (y := v) (z := u * v) ?_ ?_ ?_ ?_ ?_ ?_
+  · exact hbu
+  · exact hbv
+  · exact hbuv
+  · exact huv
+  · exact fun h => huv (comm_of_self_mul_left h)
+  · exact fun h => huv (comm_of_self_mul_right h)
+
+/-- **Centralizers of non-commuting elements are abelian** in a group with the
+    3-commuting property.  If `u, v ∈ C(a)` failed to commute, then splitting on
+    which of `u`, `v`, `u*v` the witness `b` (with `a*b ≠ b*a`) commutes with
+    yields four pairwise non-commuting elements in every case — impossible. -/
+theorem centralizer_abelian_of_three (hprop : HasNCommutingProperty G 3)
+    {a b : G} (hab : a * b ≠ b * a) :
+    IsAbelianSubgroup G (Subgroup.centralizer {a}) := by
+  intro u v hu hv
+  by_contra huv
+  have hau : a * u = u * a := (Subgroup.mem_centralizer_singleton_iff.mp hu).symm
+  have hav : a * v = v * a := (Subgroup.mem_centralizer_singleton_iff.mp hv).symm
+  by_cases hbu : b * u = u * b
+  · by_cases hbv : b * v = v * b
+    · exact centralizer_case_both hprop hab hau hav huv hbu hbv
+    · exact centralizer_case_left hprop hab hau hav huv hbu hbv
+  · by_cases hbv : b * v = v * b
+    · -- symmetric to `centralizer_case_left` with the roles of `u`, `v` swapped
+      exact centralizer_case_left hprop hab hav hau (fun h => huv h.symm) hbv hbu
+    · by_cases hbuv : b * (u * v) = (u * v) * b
+      · exact centralizer_case_product hprop hab hau hav huv hbu hbv hbuv
+      · exact centralizer_case_none hprop huv hbu hbv hbuv
+
+end CentralizerAbelian
+
+/- ## 4. Three abelian subgroups cover -/
+
+section Cover
+
+variable {G : Type*} [Group G]
+
+/-- **The uniform 3-cover.**  Every group with the 3-commuting property — finite
+    or not — is covered by three abelian subgroups.  Abelian case: `⊤` three
+    times.  Non-abelian case with `a*b ≠ b*a`: the centralizers
+    `C(a), C(b), C(a*b)` are abelian (`centralizer_abelian_of_three`), and they
+    cover because an element `g` commuting with none of `a`, `b`, `a*b` would
+    complete `{a, b, a*b}` to four pairwise non-commuting elements. -/
+theorem exists_three_abelian_cover (hprop : HasNCommutingProperty G 3) :
+    ∃ H : Fin 3 → Subgroup G,
+      (∀ i, IsAbelianSubgroup G (H i)) ∧ ∀ g : G, ∃ i, g ∈ H i := by
+  by_cases habel : ∀ x y : G, x * y = y * x
+  · exact ⟨fun _ => ⊤, fun _ x y _ _ => habel x y, fun g => ⟨0, trivial⟩⟩
+  · obtain ⟨a, ha⟩ := not_forall.mp habel
+    obtain ⟨b, hab⟩ := not_forall.mp ha
+    have hab' : b * a ≠ a * b := fun h => hab h.symm
+    have haab : a * (a * b) ≠ (a * b) * a := fun h => hab (comm_of_self_mul_left h)
+    have hbab : b * (a * b) ≠ (a * b) * b := fun h => hab (comm_of_self_mul_right h)
+    refine ⟨![Subgroup.centralizer {a}, Subgroup.centralizer {b},
+        Subgroup.centralizer {a * b}], ?_, ?_⟩
+    · intro i
+      fin_cases i
+      · exact centralizer_abelian_of_three hprop hab
+      · exact centralizer_abelian_of_three hprop hab'
+      · exact centralizer_abelian_of_three hprop (fun h => haab h.symm)
+    · intro g
+      by_cases hga : g * a = a * g
+      · exact ⟨0, show g ∈ Subgroup.centralizer {a} from
+          Subgroup.mem_centralizer_singleton_iff.mpr hga⟩
+      · by_cases hgb : g * b = b * g
+        · exact ⟨1, show g ∈ Subgroup.centralizer {b} from
+            Subgroup.mem_centralizer_singleton_iff.mpr hgb⟩
+        · by_cases hgab : g * (a * b) = (a * b) * g
+          · exact ⟨2, show g ∈ Subgroup.centralizer {a * b} from
+              Subgroup.mem_centralizer_singleton_iff.mpr hgab⟩
+          · exact (no_four_clique hprop hab haab (fun h => hga h.symm)
+              hbab (fun h => hgb h.symm) (fun h => hgab h.symm)).elim
+
+end Cover
+
+/- ## 5. h(3) = 3 -/
+
+/-- **`CoversWithAbelian 3 3`**: a budget of three abelian subgroups covers
+    every finite group with the 3-commuting property — in every universe. -/
+theorem coversWithAbelian_three_three : CoversWithAbelian.{u} 3 3 := by
+  intro G _ _ hprop
+  exact exists_three_abelian_cover hprop
+
+/-- **`h(3)` is well-defined**: the covering set is nonempty.  This discharges
+    the `hne` hypothesis carried by every `h(3)` lower-bound statement in
+    `Erdos117WIP01Three.lean` — previously assessed there as requiring
+    classification-strength input. -/
+theorem coversWithAbelian_three_nonempty : ∃ k, CoversWithAbelian.{u} k 3 :=
+  ⟨3, coversWithAbelian_three_three⟩
+
+/-- **`h(3) ≤ 3`**: the upper half of the exact value. -/
+theorem abelianCoverNumber_le_three : abelianCoverNumber.{u} 3 ≤ 3 := by
+  rw [abelianCoverNumber_eq_sInf]
+  exact Nat.sInf_le coversWithAbelian_three_three
+
+/-- **`h(3) = 3`** — the first nontrivial exact value on the Erdős #117 ladder,
+    unconditional.  Lower bound: `Q₈` (`three_le_abelianCoverNumber_three`, its
+    nonemptiness hypothesis now discharged).  Upper bound: the uniform 3-cover
+    by centralizers.  The known ladder is now exactly `0, 1, 1, 3, …`. -/
+theorem abelianCoverNumber_three : abelianCoverNumber.{u} 3 = 3 :=
+  le_antisymm abelianCoverNumber_le_three
+    (three_le_abelianCoverNumber_three coversWithAbelian_three_nonempty)
+
+/-- **`h(2) < h(3)`, unconditional** — the ladder's first strict jump past `1`,
+    with the well-definedness hypothesis of the previous conditional version
+    (`abelianCoverNumber_two_lt_three`) discharged. -/
+theorem abelianCoverNumber_two_lt_three_unconditional :
+    abelianCoverNumber.{u} 2 < abelianCoverNumber.{u} 3 := by
+  rw [abelianCoverNumber_two, abelianCoverNumber_three]
+  norm_num
+
+/-- **`h(n) ≤ 3` for all `n ≤ 3`** — monotonicity is now usable at `m = 3`
+    because well-definedness there is proved. -/
+theorem abelianCoverNumber_le_three_of_le {n : ℕ} (hn : n ≤ 3) :
+    abelianCoverNumber.{u} n ≤ 3 :=
+  (abelianCoverNumber_mono hn coversWithAbelian_three_nonempty).trans_eq
+    abelianCoverNumber_three
+
+/- ## Axiom audit -/
+
+#print axioms coversWithAbelian_three_three
+#print axioms abelianCoverNumber_three
+#print axioms abelianCoverNumber_two_lt_three_unconditional

--- a/proofs/Proofs/Erdos117WIP01Four.lean
+++ b/proofs/Proofs/Erdos117WIP01Four.lean
@@ -1,0 +1,211 @@
+/-
+  Erdős Problem #117 — Covering Groups by Abelian Subgroups: the `h(4)` rung.
+
+  Companion to `Erdos117Problem.lean` and the `Erdos117WIP01*` ladder.  With
+  `h(3) = 3` settled exactly (`Erdos117WIP01Exact.lean`), the next rung is the
+  budget-3 impossibility at threshold `4`.  The witness is the symmetric group
+  `S₃ = Equiv.Perm (Fin 3)`:
+
+  * **`S₃` has the 4-commuting property** — its non-commuting graph has clique
+    number exactly `4` (the three transpositions together with a 3-cycle are
+    pairwise non-commuting; any 5-subset of the 6 elements contains either the
+    identity or both 3-cycles).  Verified by a kernel-checked `decide` over all
+    `2⁶` subsets — no `Lean.ofReduceBool`.
+  * **No 3 abelian subgroups cover `S₃`** — an abelian subgroup contains at most
+    one of the three transpositions, and never both a transposition and a
+    3-cycle.  So a 3-cover assigns the 3-cycle to some member, all three
+    transpositions to the remaining two members, and pigeonhole puts two
+    non-commuting transpositions together.  Contradiction.
+
+  Consequences (mirroring `Erdos117WIP01Three.lean`, with `S₃` transported to
+  any universe by `ULift`):
+
+  * `not_coversWithAbelian_three` : for `n ≥ 4`, budget `3` never covers.
+  * `four_le_abelianCoverNumber`  : **`h(n) ≥ 4` for all `n ≥ 4`** whenever
+                                    `h(n)` is well-defined.
+  * `abelianCoverNumber_three_lt_four` : `h(3) < h(4)` (conditional on `h(4)`
+                                    well-definedness) — the ladder strictly
+                                    increases again: `0, 1, 1, 3, ≥4, …`.
+  * `abelianCoverNumber_four_eq_zero_or_four_le` : unconditionally, `h(4)` is
+                                    `0` (ill-defined fallback) or `≥ 4`.
+
+  Well-definedness of `h(4)` is genuinely open here: the centralizer-cover
+  trick of `Erdos117WIP01Exact.lean` is specific to clique number 3 (the 5-case
+  analysis showing centralizers abelian breaks at `ω = 4` — `S₃` itself has the
+  non-abelian centralizer `C(e) = S₃`... the correct obstruction is that a
+  maximal 4-clique's centralizers need not be abelian).  A uniform bound needs
+  a materially new mechanism (e.g. a Neumann-type `|G : Z(G)| ≤ f(n)` bound).
+
+  0 axioms, 0 sorries.  Kernel `decide` only (no `native_decide`).
+-/
+
+import Mathlib
+import Proofs.Erdos117Problem
+import Proofs.Erdos117WIP01
+import Proofs.Erdos117WIP01Mono
+import Proofs.Erdos117WIP01Cover
+import Proofs.Erdos117WIP01Three
+import Proofs.Erdos117WIP01Exact
+
+/- The universe of the ambient groups (see `Erdos117WIP01Mono.lean`): the finite
+   witness `S₃` lives in `Type 0` and is transported into `Type u` by `ULift`. -/
+universe u
+
+/- ## 1. The generic pigeonhole: a 4-clique defeats any 3-cover by abelian
+      subgroups -/
+
+section Pigeonhole
+
+variable {G : Type*} [Group G]
+
+/-- **Four pairwise non-commuting elements defeat every abelian 3-cover.**
+    Generic form (no finiteness, no concrete group): if `t₁, t₂, t₃, c` are
+    pairwise non-commuting and `H : Fin 3 → Subgroup G` is a family of abelian
+    subgroups covering `G`, we get a contradiction.  The member containing `c`
+    can contain no `tᵢ`; the remaining two members receive three transpositions,
+    so two non-commuting ones share an abelian subgroup. -/
+theorem not_abelian_three_cover_of_four_clique {t₁ t₂ t₃ c : G}
+    (h12 : t₁ * t₂ ≠ t₂ * t₁) (h13 : t₁ * t₃ ≠ t₃ * t₁) (h23 : t₂ * t₃ ≠ t₃ * t₂)
+    (h1c : t₁ * c ≠ c * t₁) (h2c : t₂ * c ≠ c * t₂) (h3c : t₃ * c ≠ c * t₃)
+    {H : Fin 3 → Subgroup G} (hAb : ∀ i, IsAbelianSubgroup G (H i))
+    (hCov : ∀ g : G, ∃ i, g ∈ H i) : False := by
+  obtain ⟨j, hcj⟩ := hCov c
+  obtain ⟨i1, hm1⟩ := hCov t₁
+  obtain ⟨i2, hm2⟩ := hCov t₂
+  obtain ⟨i3, hm3⟩ := hCov t₃
+  -- no `tᵢ` shares the abelian member containing `c`
+  have hi1 : i1 ≠ j := fun h => h1c (hAb j t₁ c (h ▸ hm1) hcj)
+  have hi2 : i2 ≠ j := fun h => h2c (hAb j t₂ c (h ▸ hm2) hcj)
+  have hi3 : i3 ≠ j := fun h => h3c (hAb j t₃ c (h ▸ hm3) hcj)
+  -- pigeonhole: three indices avoiding `j` inside `Fin 3` must collide
+  have hv1 : i1.val ≠ j.val := fun h => hi1 (Fin.ext h)
+  have hv2 : i2.val ≠ j.val := fun h => hi2 (Fin.ext h)
+  have hv3 : i3.val ≠ j.val := fun h => hi3 (Fin.ext h)
+  have hb1 := i1.isLt
+  have hb2 := i2.isLt
+  have hb3 := i3.isLt
+  have hbj := j.isLt
+  have hcol : i1.val = i2.val ∨ i1.val = i3.val ∨ i2.val = i3.val := by omega
+  rcases hcol with h | h | h
+  · exact h12 (hAb i1 t₁ t₂ hm1 (Fin.ext h ▸ hm2))
+  · exact h13 (hAb i1 t₁ t₃ hm1 (Fin.ext h ▸ hm3))
+  · exact h23 (hAb i2 t₂ t₃ hm2 (Fin.ext h ▸ hm3))
+
+end Pigeonhole
+
+/- ## 2. The witness: `S₃` has the 4-commuting property, sharply -/
+
+/-- Abbreviation for the symmetric group on three letters. -/
+local notation "S₃" => Equiv.Perm (Fin 3)
+
+set_option maxRecDepth 8192 in
+set_option maxHeartbeats 1600000 in
+/-- **`S₃` has the 4-commuting property**: every subset of size `> 4` contains
+    two distinct commuting elements.  Mathematically: a 5-subset of the six
+    elements either contains the identity or contains both 3-cycles — a
+    commuting pair either way; so the non-commuting graph of `S₃` has clique
+    number `4`.  Verified by a kernel-checked finite computation (`decide`)
+    over all `2⁶` subsets — no `Lean.ofReduceBool` involved. -/
+theorem s3_hasNCommutingProperty_four : HasNCommutingProperty S₃ 4 := by
+  unfold HasNCommutingProperty
+  decide
+
+set_option maxRecDepth 8192 in
+set_option maxHeartbeats 1600000 in
+/-- **The threshold is sharp**: `S₃` does *not* have the 3-commuting property —
+    the three transpositions together with a 3-cycle form a pairwise
+    non-commuting 4-subset.  So `S₃` enters the `h(n)` covering problem exactly
+    at `n = 4`. -/
+theorem s3_not_hasNCommutingProperty_three : ¬ HasNCommutingProperty S₃ 3 := by
+  unfold HasNCommutingProperty
+  decide
+
+/-- The three transpositions of `S₃` are pairwise non-commuting, and none of
+    them commutes with the 3-cycle `(swap 0 1) * (swap 0 2)`.  All six facts by
+    kernel `decide`. -/
+theorem s3_four_clique :
+    let t₁ : S₃ := Equiv.swap 0 1
+    let t₂ : S₃ := Equiv.swap 0 2
+    let t₃ : S₃ := Equiv.swap 1 2
+    let c : S₃ := Equiv.swap 0 1 * Equiv.swap 0 2
+    t₁ * t₂ ≠ t₂ * t₁ ∧ t₁ * t₃ ≠ t₃ * t₁ ∧ t₂ * t₃ ≠ t₃ * t₂ ∧
+      t₁ * c ≠ c * t₁ ∧ t₂ * c ≠ c * t₂ ∧ t₃ * c ≠ c * t₃ := by
+  decide
+
+/- ## 3. Budget `3` fails at every threshold `n ≥ 4` -/
+
+/-- **Budget `3` never covers at any threshold `n ≥ 4`.**  The witness is
+    `ULift S₃` (transported to universe `u`; the 4-commuting property transfers
+    along `MulEquiv.ulift` and up the threshold by monotonicity).  A 3-cover by
+    abelian subgroups is defeated by the transposition/3-cycle pigeonhole
+    (`not_abelian_three_cover_of_four_clique`), with the six non-commutation
+    facts descending to `S₃` along `ULift.down`. -/
+theorem not_coversWithAbelian_three {n : ℕ} (hn : 4 ≤ n) :
+    ¬ CoversWithAbelian.{u} 3 n := by
+  intro h
+  obtain ⟨H, hAb, hCov⟩ := h (ULift.{u} S₃)
+    (hasNCommutingProperty_mono hn
+      (hasNCommutingProperty_of_mulEquiv MulEquiv.ulift.symm
+        s3_hasNCommutingProperty_four))
+  obtain ⟨h12, h13, h23, h1c, h2c, h3c⟩ := s3_four_clique
+  exact not_abelian_three_cover_of_four_clique
+    (t₁ := ULift.up (Equiv.swap 0 1)) (t₂ := ULift.up (Equiv.swap 0 2))
+    (t₃ := ULift.up (Equiv.swap 1 2))
+    (c := ULift.up (Equiv.swap 0 1 * Equiv.swap 0 2))
+    (fun h => h12 (congrArg ULift.down h)) (fun h => h13 (congrArg ULift.down h))
+    (fun h => h23 (congrArg ULift.down h)) (fun h => h1c (congrArg ULift.down h))
+    (fun h => h2c (congrArg ULift.down h)) (fun h => h3c (congrArg ULift.down h))
+    hAb hCov
+
+/- ## 4. The lower bound `h(n) ≥ 4` for `n ≥ 4` -/
+
+/-- **`h(n) ≥ 4` for every `n ≥ 4`** — whenever `h(n)` is well-defined (the
+    covering set is nonempty rather than the `sInf ∅ = 0` fallback; for `n ≥ 4`
+    nonemptiness remains unformalized — see the header on why the `ω = 3`
+    mechanism does not extend).  Proof: `h(n)` is a member of the covering set
+    (`Nat.sInf_mem`), so `h(n) ≤ 3` would put `3` in the set by upward closure —
+    contradicting `not_coversWithAbelian_three`. -/
+theorem four_le_abelianCoverNumber {n : ℕ} (hn : 4 ≤ n)
+    (hne : ∃ k, CoversWithAbelian.{u} k n) :
+    4 ≤ abelianCoverNumber.{u} n := by
+  by_contra hlt
+  have hneSet : {k | CoversWithAbelian.{u} k n}.Nonempty := hne
+  have hmem : CoversWithAbelian.{u} (abelianCoverNumber.{u} n) n := Nat.sInf_mem hneSet
+  have hle : abelianCoverNumber.{u} n ≤ 3 := by omega
+  exact not_coversWithAbelian_three hn (coversWithAbelian_upward hle hmem)
+
+/-- **`h(4) ≥ 4`** — the threshold case `n = 4`. -/
+theorem four_le_abelianCoverNumber_four
+    (hne : ∃ k, CoversWithAbelian.{u} k 4) :
+    4 ≤ abelianCoverNumber.{u} 4 :=
+  four_le_abelianCoverNumber (le_refl 4) hne
+
+/-- **`h(3) < h(4)`** (conditional on `h(4)` being well-defined): with
+    `h(3) = 3` exact (`abelianCoverNumber_three`), the ladder strictly
+    increases again.  Known shape: `0, 1, 1, 3, ≥4, …`. -/
+theorem abelianCoverNumber_three_lt_four
+    (hne : ∃ k, CoversWithAbelian.{u} k 4) :
+    abelianCoverNumber.{u} 3 < abelianCoverNumber.{u} 4 := by
+  have h3 : abelianCoverNumber.{u} 3 = 3 := abelianCoverNumber_three
+  have h4 := four_le_abelianCoverNumber_four hne
+  omega
+
+/-- **Unconditional dichotomy for `h(4)`**: either the covering set is empty and
+    `h(4) = 0` (the `sInf ∅ = 0` fallback — ruled out mathematically by Pyber's
+    upper bound, which is not formalized), or `h(4) ≥ 4`.  In no case is
+    `h(4) ∈ {1, 2, 3}`. -/
+theorem abelianCoverNumber_four_eq_zero_or_four_le :
+    abelianCoverNumber.{u} 4 = 0 ∨ 4 ≤ abelianCoverNumber.{u} 4 := by
+  by_cases hne : ∃ k, CoversWithAbelian.{u} k 4
+  · exact Or.inr (four_le_abelianCoverNumber_four hne)
+  · left
+    rw [abelianCoverNumber_eq_sInf]
+    exact Nat.sInf_eq_zero.mpr
+      (Or.inr (Set.not_nonempty_iff_eq_empty.mp hne))
+
+/- ## Axiom audit -/
+
+#print axioms s3_hasNCommutingProperty_four
+#print axioms not_coversWithAbelian_three
+#print axioms four_le_abelianCoverNumber
+#print axioms abelianCoverNumber_three_lt_four

--- a/research/problems/erdos-117-wip-01/knowledge.md
+++ b/research/problems/erdos-117-wip-01/knowledge.md
@@ -89,3 +89,52 @@ universe-polymorphic so `PUnit : Type u` supplies the witness group in any `u`.
 (deep) and the OPEN exact base of the growth stay unformalized. `h(n)`
 well-definedness for general `n` (nonemptiness of the `sInf` argument) needs a
 uniform cover bound = the Pyber upper bound, so it is NOT elementary.
+
+## Session 2026-07-23 (researcher-1) — h(3) = 3 EXACT, unconditional (docker-VERIFIED, 8582 jobs; #print axioms = propext/Classical.choice/Quot.sound)
+
+**Mode**: REVISIT. **Outcome**: the "classification-strength" assessment of `h(3) ≤ 3`
+(in `Erdos117WIP01Three.lean`'s header) was an OVERESTIMATE — the uniform 3-cover is
+elementary. New file `Erdos117WIP01Exact.lean` proves **h(3) = 3**, the first
+nontrivial exact value on the Erdős #117 ladder, and discharges the well-definedness
+hypothesis (`∃ k, CoversWithAbelian k 3`) that every prior h(3) statement carried.
+
+### The mechanism (no classification, no Pyber, no symplectic forms)
+1. **Covering**: a ≁ b ⟹ {a, b, ab} pairwise non-commuting ⟹ every g commutes with
+   one of a, b, ab (else {a,b,ab,g} is a forbidden 4-set) ⟹ G = C(a) ∪ C(b) ∪ C(ab).
+2. **Centralizers abelian**: u,v ∈ C(a) non-commuting ⟹ case-split on which of
+   u, v, uv the witness b commutes with; each of the 5 cases yields an explicit
+   pairwise non-commuting 4-set:
+   (b~u,b~v) → {au, av, b, a(uv)}; (b~u,¬b~v) → {au, b, v, uv} (+ mirror);
+   (¬,¬,b~uv) → {b, u, v, a(uv)}; (¬,¬,¬) → {b, u, v, uv}.
+   Distinctness is FREE: non-commuting elements are automatically distinct, so
+   `no_four_clique` needs only the 6 edges — this collapsed what looked like a
+   distinctness-bookkeeping nightmare.
+3. Combined: `CoversWithAbelian 3 3` (works for ALL groups, finiteness unused) ⟹
+   `h(3) ≤ 3` via `Nat.sInf_le`; with Q₈'s `three_le_abelianCoverNumber_three`
+   (hypothesis now discharged) ⟹ **h(3) = 3**. Ladder exactly: 0, 1, 1, 3, …
+
+### Lean technique notes (v4.31)
+- Commutation kit: 7 cancellation micro-lemmas (`comm_mul_of_comm`,
+  `comm_ab_of_comm_mul`, `comm_of_mul_mul`, `comm_of_self_mul_left/right`,
+  `comm_of_mul_left_right`, `comm_of_left_mul`, `comm_right_of_comm_mul`) — all
+  pure `calc` + `mul_assoc` + `mul_left/right_cancel`; each clique edge becomes a
+  one-liner `fun h => hX (kit ... h)`.
+- `no_four_clique`: Finset `{w,x,y,z}` card-4 via chained
+  `Finset.card_insert_of_not_mem` (distinctness derived from non-commutation);
+  the 16-way `rcases ... <;> rcases ... <;> first | exact ...` dispatch handles
+  both orientations of the commuting pair via `hcomm`/`hcomm.symm`.
+- `Subgroup.mem_centralizer_singleton_iff : k ∈ centralizer {g} ↔ k * g = g * k`
+  (member on the LEFT) — orientation matters; `.symm` where needed.
+- Mirror case (¬b~u, b~v) = apply the (b~u, ¬b~v) lemma with u↔v swapped and
+  `fun h => huv h.symm` — no duplicate proof.
+- `![C₁, C₂, C₃] i` after `fin_cases i` / `⟨0, show g ∈ …⟩` reduces definitionally;
+  `show` makes the defeq explicit and robust.
+
+### Still open / out of scope
+- h(4): S₃ has the 4-commuting property (ω(S₃) = 4) and needs 4 abelian subgroups —
+  h(4) ≥ 4 is a plausible next rung (needs `not_coversWithAbelian_three` via S₃);
+  well-definedness of h(4) (uniform bound for ω ≤ 4 groups) is genuinely harder —
+  the centralizer-cover trick gives a cover by 4 CENTRALIZERS of a max clique, but
+  their abelianness FAILS in general at ω = 4 (S₃: C((12)) = {e,(12)} abelian ✓, but
+  the general argument breaks — the 5-case analysis is specific to ω = 3).
+- Pyber's exponential bounds c₁ⁿ < h(n) < c₂ⁿ: DEEP, untouched (the open problem).

--- a/research/problems/erdos-117-wip-01/knowledge.md
+++ b/research/problems/erdos-117-wip-01/knowledge.md
@@ -138,3 +138,29 @@ hypothesis (`∃ k, CoversWithAbelian k 3`) that every prior h(3) statement carr
   their abelianness FAILS in general at ω = 4 (S₃: C((12)) = {e,(12)} abelian ✓, but
   the general argument breaks — the 5-case analysis is specific to ω = 3).
 - Pyber's exponential bounds c₁ⁿ < h(n) < c₂ⁿ: DEEP, untouched (the open problem).
+
+## Session 2026-07-23 (researcher-1, session 2) — h(4) rung: budget 3 fails at n >= 4 (S₃ pigeonhole)
+
+**Mode**: REVISIT (executing the "next rung" identified this morning). New file
+`Erdos117WIP01Four.lean` (0 ax, 0 sorry, kernel decide only).
+
+- `not_abelian_three_cover_of_four_clique` — GENERIC pigeonhole: four pairwise
+  non-commuting elements t₁,t₂,t₃,c defeat any abelian 3-cover (the member holding
+  c excludes every tᵢ; three tᵢ into two remaining members collide). Works in any
+  group; Fin-3 index pigeonhole via `.val` + `omega` (convert `Fin` ≠ to `.val` ≠
+  with `Fin.ext`, feed `isLt` bounds).
+- `s3_hasNCommutingProperty_four` — S₃ has the 4-commuting property (`decide`,
+  2⁶ subsets, maxRecDepth 8192); `s3_not_hasNCommutingProperty_three` — SHARP:
+  the 4-clique {swap 0 1, swap 0 2, swap 1 2, 3-cycle} shows S₃ enters exactly
+  at threshold 4.
+- `not_coversWithAbelian_three` (n ≥ 4) — ULift transport exactly as Three.lean
+  (property along `MulEquiv.ulift.symm`, non-commutation descends via
+  `congrArg ULift.down`).
+- `four_le_abelianCoverNumber` / `_four` — h(n) ≥ 4 for n ≥ 4 (conditional on
+  well-definedness, honest hne hypothesis); `abelianCoverNumber_three_lt_four`
+  (h(3)=3 < h(4), conditional); `abelianCoverNumber_four_eq_zero_or_four_le`
+  (unconditional dichotomy).
+
+Ladder: **0, 1, 1, 3 (exact), ≥4, …** — strictly increasing again at n = 4.
+Well-definedness of h(4) does NOT follow from the ω=3 centralizer trick
+(blocked route; reopen = Neumann-type |G:Z| ≤ f(n) or materially new mechanism).

--- a/research/problems/erdos-117-wip-01/problem.md
+++ b/research/problems/erdos-117-wip-01/problem.md
@@ -123,3 +123,34 @@ created: 2026-07-09T17:33:20-07:00
 
 **Significance**: 6/10
 **Tractability**: 6/10
+
+## Adversarial Checklist (claim: h(3) = 3, exact and unconditional)
+
+Recorded 2026-07-23 for the SOLVED claim `abelianCoverNumber_three : abelianCoverNumber.{u} 3 = 3`
+in `Erdos117WIP01Exact.lean`. How THIS claim could be wrong:
+
+- **sInf ∅ = 0 degeneracy**: the equality is only meaningful if the covering set is
+  nonempty — confirm `coversWithAbelian_three_three : CoversWithAbelian 3 3` is a
+  genuine membership proof (a uniform 3-cover for EVERY finite group in the universe
+  with the property), not a vacuous or classical trick. `coversWithAbelian_three_nonempty`
+  must be derived from it, not assumed.
+- **Universe quantification**: `abelianCoverNumber.{u}` quantifies over `G : Type u`
+  only. Confirm the cover proof (`exists_three_abelian_cover`) is universe-agnostic
+  (`{G : Type*}`) so the membership holds at EVERY `u`, and the lower bound transports
+  `Q₈` via `ULift` (in `Three.lean`) — no universe mismatch making either bound vacuous.
+- **Wrong property orientation**: `HasNCommutingProperty G 3` = "every subset of card
+  > 3 (i.e. ≥ 4) contains two DISTINCT commuting elements" — confirm the clique
+  argument uses card-4 subsets (`no_four_clique` builds `{w,x,y,z}` with card = 4 > 3),
+  not card-3, and that distinctness is derived (non-commuting ⟹ distinct), not assumed.
+- **Cover but not abelian / abelian but not cover**: the three subgroups must satisfy
+  BOTH conjuncts: `centralizer_abelian_of_three` needs the 5-case analysis to be
+  exhaustive — cases (b~u,b~v), (b~u,¬b~v), (¬b~u,b~v), (¬b~u,¬b~v,b~uv),
+  (¬b~u,¬b~v,¬b~uv) cover all of {T,F}³ restricted to reachable combinations. Confirm
+  the mirror case really is `centralizer_case_left` with u,v swapped (huv symm'd).
+- **Lower-bound circularity**: `three_le_abelianCoverNumber_three` (Q₈, from
+  `Three.lean`) must not depend on any nonemptiness assumption other than the one now
+  proved; confirm `#print axioms abelianCoverNumber_three` = propext/Classical.choice/
+  Quot.sound only (verified in build log 2026-07-23, 8582 jobs).
+- **Not the parent problem**: h(3) = 3 is one exact ladder value; Erdős #117 proper
+  (the exponential growth base, Pyber's c₁ⁿ < h(n) < c₂ⁿ) remains OPEN and is NOT
+  claimed. h(n) for n ≥ 4 remains open (well-definedness included).

--- a/research/problems/erdos-117-wip-01/state.md
+++ b/research/problems/erdos-117-wip-01/state.md
@@ -136,3 +136,18 @@ Candidate next rung: h(4) ≥ 4 via S₃ (ω(S₃) = 4, minimal abelian cover 4 
 h(4) well-definedness (uniform bound at ω ≤ 4) does NOT follow from this session's
 trick — the centralizer-abelianness argument is specific to ω = 3; treat h(4) ≤ C
 as blocked pending a materially new mechanism. Pyber bounds remain DEEP/out of scope.
+
+## Status (researcher-1, 2026-07-23, session 2) — h(4) ≥ 4 rung (S₃), conditional
+
+`Erdos117WIP01Four.lean` (0 ax, 0 sorry, kernel decide only): budget 3 fails for
+every n ≥ 4 — S₃ has the 4-commuting property sharply (not the 3-property), and a
+generic transposition/3-cycle pigeonhole defeats any abelian 3-cover. Hence
+h(n) ≥ 4 for n ≥ 4 (conditional on well-definedness), h(3) < h(4) conditional,
+h(4) ∈ {0} ∪ [4,∞) unconditional. Ladder: 0, 1, 1, 3 (exact), ≥4, …
+
+Elementary rungs n ≤ 4 now EXHAUSTED except h(4) well-definedness/upper bound,
+which is a registered blocked route (the ω = 3 centralizer mechanism does not
+extend; reopen: Neumann-type |G:Z| ≤ f(n) formalized or materially new mechanism).
+Next elementary candidate if ever needed: h(5) lower rung would need a 5-clique
+witness group with abelian-cover analysis (e.g. D₅ or S₄ subsets) — NOT session-
+sized without new tooling; do not chase. Pyber bounds remain the open core.

--- a/research/problems/erdos-117-wip-01/state.md
+++ b/research/problems/erdos-117-wip-01/state.md
@@ -109,3 +109,30 @@ None.
 ## Next Action
 Read problem.md thoroughly and acquire full context.
 Then move to ORIENT phase to explore literature and related proofs.
+
+## Status (researcher-1, 2026-07-23) — h(3) = 3 EXACT, unconditional
+
+New file `Erdos117WIP01Exact.lean` (0 ax, 0 sorry, docker-VERIFIED). The Three.lean
+header's "classification-strength" assessment of `h(3) ≤ 3` was wrong — the uniform
+3-cover is elementary:
+- `no_four_clique` — the 3-commuting property forbids 4 pairwise non-commuting
+  elements (distinctness free: non-commuting ⟹ distinct).
+- `centralizer_abelian_of_three` — the crux: u,v ∈ C(a) non-commuting ⟹ 5-way case
+  split on b vs {u, v, uv} each yields an explicit forbidden 4-set
+  ({au,av,b,a(uv)} / {au,b,v,uv} / mirror / {b,u,v,a(uv)} / {b,u,v,uv}).
+- `exists_three_abelian_cover` — G = C(a) ∪ C(b) ∪ C(ab) with all three abelian
+  (finiteness unused; works for every group).
+- `coversWithAbelian_three_three`, `coversWithAbelian_three_nonempty` — h(3)
+  WELL-DEFINED (discharges every `hne` hypothesis in Three.lean).
+- **`abelianCoverNumber_three : h(3) = 3`** — first nontrivial exact ladder value;
+  `abelianCoverNumber_two_lt_three_unconditional`; `abelianCoverNumber_le_three_of_le`.
+
+Ladder now EXACTLY `0, 1, 1, 3, …` (all unconditional).
+
+## Next Action (updated 2026-07-23)
+Candidate next rung: h(4) ≥ 4 via S₃ (ω(S₃) = 4, minimal abelian cover 4 — needs
+`not_coversWithAbelian_three` by showing no 3 abelian subgroups cover S₃, likely
+`decide`-able on Equiv.Perm (Fin 3) subgroups or by the transposition argument).
+h(4) well-definedness (uniform bound at ω ≤ 4) does NOT follow from this session's
+trick — the centralizer-abelianness argument is specific to ω = 3; treat h(4) ≤ C
+as blocked pending a materially new mechanism. Pyber bounds remain DEEP/out of scope.

--- a/src/data/research/problems/erdos-117-wip-01.json
+++ b/src/data/research/problems/erdos-117-wip-01.json
@@ -20,10 +20,21 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-09T17:33:20-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
-    "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "iteration": 2,
+    "focus": "2026-07-23: h(3) = 3 EXACT and unconditional (Erdos117WIP01Exact.lean, 0 ax / 0 sorry). Elementary uniform 3-cover: G = C(a) u C(b) u C(ab) with all three centralizers abelian via a 5-case forbidden-4-clique analysis; discharges the well-definedness hypothesis of all prior h(3) statements. Ladder exactly 0, 1, 1, 3, ...",
+    "blockers": [
+      {
+        "route": "h(4) upper bound / well-definedness: centralizer-abelianness argument is specific to clique number 3",
+        "reopenCriterion": "materially new mechanism required (e.g. Neumann-type index bound |G:Z| <= f(n) formalized)",
+        "blockedAt": "2026-07-23"
+      },
+      {
+        "route": "Pyber exponential bounds c1^n < h(n) < c2^n (the open problem proper)",
+        "reopenCriterion": "materially new Mathlib group-theory API or literature-scale formalization effort",
+        "blockedAt": "2026-07-22"
+      }
+    ],
+    "nextAction": "Optional next rung: h(4) >= 4 lower bound via S3 (omega(S3)=4, minimal abelian cover 4). h(4) upper/well-definedness and Pyber bounds are blocked routes. The h(3) program is COMPLETE.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added Erdos117WIP01Three.lean (10 axiom-free theorems, kernel decide only - no ofReduceBool). First jump of the ladder: h(n) >= 3 for all n >= 3 (conditional on well-definedness = Pyber's unformalized upper bound). Crux 1: no group is a union of two proper subgroups => a 2-abelian-cover forces abelian (no counting/finiteness). Crux 2: Q8 = QuaternionGroup 2 is non-abelian with the 3-commuting property (decide over 2^8 subsets) => the n=2 collapse is sharp. Also h(2) < h(3) (first strict jump past 1) and the unconditional dichotomy h(3) = 0 or h(3) >= 3. Ladder shape now 0, 1, 1, >=3, ... Prior: h(0)=0, h(1)=h(2)=1 exact, monotonicity, closure. ELEMENTARY LAYER LIKELY SATURATED: h(3) <= 3 needs a uniform 3-cover for every 3-commuting group (classification-strength); deep = Pyber bounds.",
+    "progressSummary": "PROGRESS: h(3) = 3 EXACT and unconditional (Erdos117WIP01Exact.lean, 0 axioms / 0 sorries) — first nontrivial exact value on the Erdos #117 ladder. The classification-strength blocker for h(3) <= 3 fell to an elementary 5-case clique analysis: G = C(a) u C(b) u C(ab) with abelian centralizers. Well-definedness of h(3) proved (uniform budget 3, finiteness unused). Ladder exactly 0, 1, 1, 3, ... Prior: h(0)=0, h(1)=h(2)=1, monotonicity, Q8 lower bound. Remaining: h(4) rung (S3 lower bound plausible; upper bound blocked — mechanism specific to omega=3), Pyber exponential bounds DEEP.",
     "builtItems": [
       "three_le_abelianCoverNumber in Erdos117WIP01Three.lean - h(n) >= 3 for all n >= 3 whenever h(n) is well-defined; via eq_top_or_eq_top_of_cover (no group is a union of two proper subgroups) + comm_of_two_abelian_cover, and witness ULift Q8: quaternionGroup_hasNCommutingProperty_three (kernel decide, 2^8 subsets, no ofReduceBool) + quaternionGroup_not_comm. Corollaries: not_coversWithAbelian_one/_two, abelianCoverNumber_two_lt_three (h(2) < h(3)), abelianCoverNumber_three_eq_zero_or_three_le (unconditional dichotomy), hasNCommutingProperty_three_not_comm (n=2 collapse sharp). 0-axiom, docker 8581 jobs.",
       "abelianCoverNumber_mono in Erdos117WIP01Mono.lean — h(n) is monotone nondecreasing: n<=m and a finite m-cover exists (exists k, CoversWithAbelian k m) => h(n) <= h(m). Crux coversWithAbelian_of_le: an m-cover is an n-cover since the n-commuting property implies the m-property (hasNCommutingProperty_mono). Nonemptiness hypothesis is honest (Nat.sInf empty = 0 convention; well-definedness of h(m) is Pyber's unformalized upper bound). CoversWithAbelian names the defining-set condition; abelianCoverNumber_eq_sInf is rfl. 0-axiom, docker 8578 jobs.",
@@ -47,7 +58,10 @@
       "coversWithAbelian_upward — covering set upward-closed in k via bot-padding (Erdos117WIP01Cover.lean)",
       "not_coversWithAbelian_zero — for n>=1, 0 subgroups never cover (PUnit witness) (Erdos117WIP01Cover.lean)",
       "one_le_abelianCoverNumber — h(n)>=1 for n>=1 when covering set nonempty (Erdos117WIP01Cover.lean)",
-      "Erdos117WIP01Two.lean: exists_three_pairwise_noncommuting, hasNCommutingProperty_two_iff, hasNCommutingProperty_two_iff_one, abelianCoverNumber_two (h(2)=1), abelianCoverNumber_one_eq_two — 0 axioms, 0 sorries"
+      "Erdos117WIP01Two.lean: exists_three_pairwise_noncommuting, hasNCommutingProperty_two_iff, hasNCommutingProperty_two_iff_one, abelianCoverNumber_two (h(2)=1), abelianCoverNumber_one_eq_two — 0 axioms, 0 sorries",
+      "Erdos117WIP01Exact.lean: commutation kit (7 cancellation micro-lemmas), no_four_clique, centralizer_abelian_of_three, exists_three_abelian_cover",
+      "coversWithAbelian_three_three, coversWithAbelian_three_nonempty (h(3) well-defined)",
+      "abelianCoverNumber_three : h(3) = 3 (exact, unconditional), abelianCoverNumber_two_lt_three_unconditional, abelianCoverNumber_le_three_of_le"
     ],
     "insights": [
       "UNIVERSE gotcha (confirmed again): abelianCoverNumber and CoversWithAbelian are universe-polymorphic in the group universe (bodies quantify forall G:Type*), so the VALUE depends on u. Any monotonicity/set-algebra statement must pin one explicit `universe u` and annotate EVERY occurrence with .{u}; unannotated occurrences get independent universes => abelianCoverNumber.{u_1} vs .{u_3} and @h G application-type mismatch. A `universe` command takes a plain /- -/ comment, not a /-- -/ docstring.",
@@ -59,7 +73,11 @@
       "The covering set {k | CoversWithAbelian k n} is a terminal segment: upward-closed in k (pad a k-cover with copies of bot — coversWithAbelian_upward) and, for n>=1, never contains 0 (empty family cannot cover PUnit — not_coversWithAbelian_zero). With Nat.sInf_mem this pins it as [h(n),inf) when nonempty.",
       "General lower bound h(n)>=1 for n>=1 whenever h(n) is well-defined (covering set nonempty). Complements h(0)=0: the covering number leaves 0 exactly at the n=0->1 step. For n>=2 nonemptiness of the set is precisely Pyber unformalized upper bound. (one_le_abelianCoverNumber)",
       "COLLAPSE AT n=2: the 2-commuting property is exactly commutativity — in any non-abelian group a non-commuting pair a,b spawns the 3-element pairwise non-commuting set {a,b,ab} (a vs ab commute iff ab=ba by left cancellation; b vs ab iff ba=ab by right cancellation; distinctness forced since a=ab ⟹ b=1 central). So the n=2 threshold adds nothing over n=1, and h(2)=1 unconditionally.",
-      "Where the collapse stops: Q8 is non-abelian with the 3-commuting property (non-commuting graph clique number 3: a clique picks at most one of each {±i},{±j},{±k}), and no 2 abelian subgroups cover Q8 (abelian subgroups have order ≤4; 4+4−|shared ⊇ {±1}| ≤ 6 < 8). So h(3) ≥ 3 — first genuinely non-abelian rung, NOT yet formalized."
+      "Where the collapse stops: Q8 is non-abelian with the 3-commuting property (non-commuting graph clique number 3: a clique picks at most one of each {±i},{±j},{±k}), and no 2 abelian subgroups cover Q8 (abelian subgroups have order ≤4; 4+4−|shared ⊇ {±1}| ≤ 6 < 8). So h(3) ≥ 3 — first genuinely non-abelian rung, NOT yet formalized.",
+      "The h(3) <= 3 uniform cover assessed as classification-strength is elementary: a nonabelian group with the 3-commuting property is covered by C(a), C(b), C(ab) for any non-commuting a,b, and each centralizer is abelian by a 5-case forbidden-4-clique analysis (cases on which of u, v, uv the witness b commutes with)",
+      "Distinctness in 4-clique arguments is free: non-commuting elements are automatically distinct, so no_four_clique needs only the 6 non-commutation edges — this collapses the distinctness bookkeeping entirely",
+      "The 3-cover works for ALL groups (finiteness never used), so CoversWithAbelian 3 3 holds in every universe; h(3) is well-defined, discharging the hne hypotheses that Three.lean carried",
+      "Mathlib v4.31 rename: Finset.card_insert_of_not_mem -> Finset.card_insert_of_notMem"
     ],
     "mathlibGaps": [],
     "nextSteps": [

--- a/src/data/research/problems/erdos-117-wip-01.json
+++ b/src/data/research/problems/erdos-117-wip-01.json
@@ -20,8 +20,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-09T17:33:20-07:00",
-    "iteration": 2,
-    "focus": "2026-07-23: h(3) = 3 EXACT and unconditional (Erdos117WIP01Exact.lean, 0 ax / 0 sorry). Elementary uniform 3-cover: G = C(a) u C(b) u C(ab) with all three centralizers abelian via a 5-case forbidden-4-clique analysis; discharges the well-definedness hypothesis of all prior h(3) statements. Ladder exactly 0, 1, 1, 3, ...",
+    "iteration": 3,
+    "focus": "2026-07-23 (session 2): h(4) rung added (Erdos117WIP01Four.lean, 0 ax / 0 sorry, kernel decide). Budget 3 fails for all n >= 4: S3 has the 4-commuting property SHARPLY (not the 3-property) and a generic transposition/3-cycle pigeonhole defeats any abelian 3-cover. h(n) >= 4 for n >= 4 (conditional), h(3) < h(4) conditional, h(4) in {0} u [4,inf) unconditional. Ladder: 0, 1, 1, 3 (exact), >=4, ...",
     "blockers": [
       {
         "route": "h(4) upper bound / well-definedness: centralizer-abelianness argument is specific to clique number 3",
@@ -34,7 +34,7 @@
         "blockedAt": "2026-07-22"
       }
     ],
-    "nextAction": "Optional next rung: h(4) >= 4 lower bound via S3 (omega(S3)=4, minimal abelian cover 4). h(4) upper/well-definedness and Pyber bounds are blocked routes. The h(3) program is COMPLETE.",
+    "nextAction": "STAND DOWN on elementary rungs: n <= 4 exhausted except h(4) well-definedness/upper (blocked route). h(5)+ lower rungs not session-sized. Pyber bounds = the open core, DEEP.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -42,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: h(3) = 3 EXACT and unconditional (Erdos117WIP01Exact.lean, 0 axioms / 0 sorries) — first nontrivial exact value on the Erdos #117 ladder. The classification-strength blocker for h(3) <= 3 fell to an elementary 5-case clique analysis: G = C(a) u C(b) u C(ab) with abelian centralizers. Well-definedness of h(3) proved (uniform budget 3, finiteness unused). Ladder exactly 0, 1, 1, 3, ... Prior: h(0)=0, h(1)=h(2)=1, monotonicity, Q8 lower bound. Remaining: h(4) rung (S3 lower bound plausible; upper bound blocked — mechanism specific to omega=3), Pyber exponential bounds DEEP.",
+    "progressSummary": "PROGRESS: ladder now 0, 1, 1, 3 (EXACT, unconditional), >=4 (conditional). Session 1: h(3) = 3 exact via elementary uniform 3-cover (Erdos117WIP01Exact.lean). Session 2: h(4) rung — budget 3 fails for all n >= 4 via S3 transposition/3-cycle pigeonhole (Erdos117WIP01Four.lean). Both 0 axioms / 0 sorries, docker-verified. Blocked routes: h(4) well-definedness/upper (omega=3 mechanism does not extend; reopen = Neumann-type |G:Z| bound), Pyber exponential bounds (the open problem).",
     "builtItems": [
       "three_le_abelianCoverNumber in Erdos117WIP01Three.lean - h(n) >= 3 for all n >= 3 whenever h(n) is well-defined; via eq_top_or_eq_top_of_cover (no group is a union of two proper subgroups) + comm_of_two_abelian_cover, and witness ULift Q8: quaternionGroup_hasNCommutingProperty_three (kernel decide, 2^8 subsets, no ofReduceBool) + quaternionGroup_not_comm. Corollaries: not_coversWithAbelian_one/_two, abelianCoverNumber_two_lt_three (h(2) < h(3)), abelianCoverNumber_three_eq_zero_or_three_le (unconditional dichotomy), hasNCommutingProperty_three_not_comm (n=2 collapse sharp). 0-axiom, docker 8581 jobs.",
       "abelianCoverNumber_mono in Erdos117WIP01Mono.lean — h(n) is monotone nondecreasing: n<=m and a finite m-cover exists (exists k, CoversWithAbelian k m) => h(n) <= h(m). Crux coversWithAbelian_of_le: an m-cover is an n-cover since the n-commuting property implies the m-property (hasNCommutingProperty_mono). Nonemptiness hypothesis is honest (Nat.sInf empty = 0 convention; well-definedness of h(m) is Pyber's unformalized upper bound). CoversWithAbelian names the defining-set condition; abelianCoverNumber_eq_sInf is rfl. 0-axiom, docker 8578 jobs.",
@@ -61,7 +61,9 @@
       "Erdos117WIP01Two.lean: exists_three_pairwise_noncommuting, hasNCommutingProperty_two_iff, hasNCommutingProperty_two_iff_one, abelianCoverNumber_two (h(2)=1), abelianCoverNumber_one_eq_two — 0 axioms, 0 sorries",
       "Erdos117WIP01Exact.lean: commutation kit (7 cancellation micro-lemmas), no_four_clique, centralizer_abelian_of_three, exists_three_abelian_cover",
       "coversWithAbelian_three_three, coversWithAbelian_three_nonempty (h(3) well-defined)",
-      "abelianCoverNumber_three : h(3) = 3 (exact, unconditional), abelianCoverNumber_two_lt_three_unconditional, abelianCoverNumber_le_three_of_le"
+      "abelianCoverNumber_three : h(3) = 3 (exact, unconditional), abelianCoverNumber_two_lt_three_unconditional, abelianCoverNumber_le_three_of_le",
+      "Erdos117WIP01Four.lean: not_abelian_three_cover_of_four_clique (generic), s3_hasNCommutingProperty_four (+sharp negation), s3_four_clique",
+      "not_coversWithAbelian_three (n>=4), four_le_abelianCoverNumber(_four), abelianCoverNumber_three_lt_four, abelianCoverNumber_four_eq_zero_or_four_le"
     ],
     "insights": [
       "UNIVERSE gotcha (confirmed again): abelianCoverNumber and CoversWithAbelian are universe-polymorphic in the group universe (bodies quantify forall G:Type*), so the VALUE depends on u. Any monotonicity/set-algebra statement must pin one explicit `universe u` and annotate EVERY occurrence with .{u}; unannotated occurrences get independent universes => abelianCoverNumber.{u_1} vs .{u_3} and @h G application-type mismatch. A `universe` command takes a plain /- -/ comment, not a /-- -/ docstring.",
@@ -77,7 +79,10 @@
       "The h(3) <= 3 uniform cover assessed as classification-strength is elementary: a nonabelian group with the 3-commuting property is covered by C(a), C(b), C(ab) for any non-commuting a,b, and each centralizer is abelian by a 5-case forbidden-4-clique analysis (cases on which of u, v, uv the witness b commutes with)",
       "Distinctness in 4-clique arguments is free: non-commuting elements are automatically distinct, so no_four_clique needs only the 6 non-commutation edges — this collapses the distinctness bookkeeping entirely",
       "The 3-cover works for ALL groups (finiteness never used), so CoversWithAbelian 3 3 holds in every universe; h(3) is well-defined, discharging the hne hypotheses that Three.lean carried",
-      "Mathlib v4.31 rename: Finset.card_insert_of_not_mem -> Finset.card_insert_of_notMem"
+      "Mathlib v4.31 rename: Finset.card_insert_of_not_mem -> Finset.card_insert_of_notMem",
+      "Generic 4-clique pigeonhole (not_abelian_three_cover_of_four_clique): four pairwise non-commuting elements defeat any abelian 3-cover in ANY group — the c-member excludes all three t_i, and Fin-3 pigeonhole (via .val + omega with Fin.ext) collides two non-commuting t_i",
+      "S3 = Equiv.Perm (Fin 3) enters the covering ladder exactly at threshold 4: has the 4-commuting property but not the 3-property (kernel decide, 2^6 subsets, maxRecDepth 8192) — the clique {swap 0 1, swap 0 2, swap 1 2, 3-cycle}",
+      "ULift transport idiom for budget-impossibility reused verbatim from Three.lean: property along MulEquiv.ulift.symm, non-commutation facts descend via congrArg ULift.down"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Two research sessions for erdos-117-wip-01 (Erdős #117: covering groups by abelian subgroups, h(n) ladder), bundled on one branch.

**Session 1 — h(3) = 3, exact and unconditional** (`Erdos117WIP01Exact.lean`): the first nontrivial exact value on the Erdős #117 ladder. The uniform 3-cover that `Three.lean` assessed as "classification-strength" is elementary.

**Session 2 — the h(4) rung** (`Erdos117WIP01Four.lean`): budget 3 fails for every n ≥ 4, via S₃.

## Progress
`Erdos117WIP01Exact.lean` (~405 lines, 0 axioms / 0 sorries, docker-verified; `#print axioms` = propext/Classical.choice/Quot.sound):
- `no_four_clique` — the 3-commuting property forbids four pairwise non-commuting elements (distinctness free)
- `centralizer_abelian_of_three` — 5-case forbidden-4-clique analysis: centralizers of non-commuting elements are abelian
- `exists_three_abelian_cover` — `G = C(a) ∪ C(b) ∪ C(ab)` covers every group with the 3-commuting property (finiteness unused)
- `coversWithAbelian_three_three` / `coversWithAbelian_three_nonempty` — **h(3) is well-defined**, discharging the `hne` hypotheses carried by all prior h(3) statements
- `abelianCoverNumber_three` — **h(3) = 3**; plus unconditional `h(2) < h(3)` and `h(n) ≤ 3` for `n ≤ 3`

`Erdos117WIP01Four.lean` (0 axioms / 0 sorries, kernel decide only):
- `not_abelian_three_cover_of_four_clique` — generic pigeonhole: four pairwise non-commuting elements defeat any abelian 3-cover
- `s3_hasNCommutingProperty_four` + sharp negation at 3 — S₃ enters the ladder exactly at threshold 4 (`decide` over 2⁶ subsets, no `ofReduceBool`)
- `not_coversWithAbelian_three` (n ≥ 4, ULift transport), `four_le_abelianCoverNumber` — **h(n) ≥ 4 for n ≥ 4** (honest well-definedness hypothesis), `abelianCoverNumber_three_lt_four`, unconditional h(4) dichotomy

## Findings
- The known ladder is now exactly **0, 1, 1, 3, ≥4, …** — h(3) unconditional, the h(4) bound carrying an honest `hne` hypothesis.
- The "deep blockers turn out elementary" pattern: no classification, no Pyber, no symplectic forms — a 7-lemma commutation kit plus clique case analysis.
- h(4) well-definedness/upper bound is genuinely blocked: the ω = 3 centralizer mechanism does not extend (recorded as a structured blocked route; reopen = Neumann-type |G:Z| ≤ f(n)).
- Adversarial checklist for the h(3) = 3 claim recorded in `research/problems/erdos-117-wip-01/problem.md`.

## Status
**Outcome**: progress (major — first exact nontrivial ladder value + next rung)
**Next Steps**: elementary rungs n ≤ 4 exhausted; Pyber exponential bounds remain the open problem proper (deep-blocked).

🤖 Generated by researcher-1
