### PR TITLE
Enrich lifting-the-exponent-oq-01-oq-01: split sections to 5 real boundaries (4->5)

### DIFF
--- a/src/data/proofs/lifting-the-exponent-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lifting-the-exponent-oq-01-oq-01/meta.json
@@ -102,10 +102,18 @@
     },
     {
       "id": "main",
-      "title": "LTE at p = 2 — Difference Form",
+      "title": "LTE at p = 2 — Difference Form (Additive)",
       "startLine": 90,
+      "endLine": 118,
+      "summary": "padicValInt_two_pow_sub_pow: discharges the Int.two_pow_sub_pow hypotheses (¬2∣x, 2∣x-y) and the four nonzero side conditions, casts into ℕ∞, rewrites every valuation to emultiplicity, closes with the Mathlib law plus abel, and returns to ℕ.",
+      "mathContext": "$v_2(x^n - y^n) + 1 = v_2(x-y) + v_2(x+y) + v_2(n)$."
+    },
+    {
+      "id": "main-truncated",
+      "title": "LTE at p = 2 — Truncated-Subtraction Form",
+      "startLine": 120,
       "endLine": 130,
-      "summary": "padicValInt_two_pow_sub_pow: discharges the Int.two_pow_sub_pow hypotheses (¬2∣x, 2∣x-y) and the four nonzero side conditions, casts into ℕ∞, rewrites every valuation to emultiplicity, closes with the Mathlib law plus abel, and returns to ℕ; padicValInt_two_pow_sub_pow' restates with truncated subtraction via omega.",
+      "summary": "padicValInt_two_pow_sub_pow': restates the additive form with ℕ-truncated subtraction via omega, matching the parent entry's presentation of the odd-prime law.",
       "mathContext": "$v_2(x^n - y^n) = v_2(x-y) + v_2(x+y) + v_2(n) - 1$."
     },
     {


### PR DESCRIPTION
Enrichment pass for lifting-the-exponent-oq-01-oq-01.

`sections[]` had 4 entries; the `main` section (90-130) bundled two distinct
theorems that `annotations.json` already treats separately (the additive-form
law 81-118 and the truncated-subtraction restatement 120-130). Split to match,
giving 5 sections that contiguously cover the 146-line file:

- `header` (1-64): module docstring, imports, setup
- `bridge` (66-88): finiteness bridge + the xⁿ≠yⁿ lemma
- `main` (90-118): the additive-form LTE-at-2 law
- `main-truncated` (120-130): the ℕ-truncated-subtraction restatement
- `repunit` (132-146): specialisation to v_2(aⁿ - 1)

No other content changed; `meta.json` stays well under the 60 KB cap (~14 KB).