### PR TITLE
Audit tracker: erdos-116 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10519,8 +10519,8 @@
     },
     "erdos-116": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:34Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T19:38:31Z",
       "result": "clean"
     },
     "erdos-1160": {


### PR DESCRIPTION
## Summary
- Reserve-mode re-audit of erdos-116 (Erdős Problem #116: Measure of Polynomial Sublevel Sets).
- Verified 6 theorems / 0 axioms / 0 sorries match meta.json exactly (quickcheck's grep undercounts to 4 due to `@[simp]`-prefixed theorems, a known false positive).
- Deep quantitative bounds (Pommerenke c/n⁴, KLR c/log n & C/log log n, Pólya π) are correctly disclosed as unformalized header prose only; status `axiomatized` / badge `wip` is accurate.
- Result: clean, no action needed.

## Test plan
- [x] Manually read Lean source and cross-checked all counts against meta.json
- [x] Confirmed no True stubs, no native_decide, no undisclosed axioms

🤖 Generated by the lean-auditor agent