### PR TITLE
Enrich markov-equation-oq-04: split sections to 5 real boundaries (4->5)

### DIFF
--- a/src/data/proofs/markov-equation-oq-04/meta.json
+++ b/src/data/proofs/markov-equation-oq-04/meta.json
@@ -76,10 +76,19 @@
     },
     {
       "id": "sec-headline",
-      "title": "Headline Statements and Consequences",
+      "title": "Headline: All Three Pairs Are Coprime",
       "startLine": 108,
+      "endLine": 135,
+      "summary": "markov_coprime + the three projections markov_coprime_12/23/13, and markov_gcd_eq_one restating pairwise coprimality in Int.gcd form.",
+      "mathContext": "$\\gcd(x,y)=\\gcd(y,z)=\\gcd(x,z)=1$ for every positive Markov triple."
+    },
+    {
+      "id": "sec-parity",
+      "title": "The Parity Corollary: At Most One Even Coordinate",
+      "startLine": 137,
       "endLine": 165,
-      "summary": "markov_coprime + the three projections, markov_gcd_eq_one (Int.gcd form), not_two_dvd_both (a coprime pair cannot share the non-unit factor 2), markov_at_most_one_even / markov_not_both_even (no two coordinates simultaneously even), and sanity checks on small triples like (2,5,29)."
+      "summary": "not_two_dvd_both (a coprime pair cannot share the non-unit factor 2), markov_at_most_one_even / markov_not_both_even (no two coordinates are simultaneously even), and sanity checks on small triples like (2,5,29).",
+      "mathContext": "Coprimality forbids a common factor of 2 in any pair, so at most one of $x,y,z$ is even."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for markov-equation-oq-04.

`sections[]` had 4 entries; `sec-headline` (108-165) bundled two distinct
groups of theorems that `annotations.json` already treats separately (the
pairwise-coprimality headline 108-135, and the parity corollary 137-165).
Split to match, giving 5 sections that contiguously cover the 165-line file:

- `sec-header` (1-50): overview, Coprime3 predicate
- `sec-vieta` (52-67): Vieta jump preserves coprimality
- `sec-invariant` (69-106): coprimality as a tree invariant
- `sec-headline` (108-135): all three pairs are coprime (+ gcd form)
- `sec-parity` (137-165): the parity corollary (at most one even coordinate)

No other content changed; `meta.json` stays well under the 60 KB cap (~10 KB).