### PR TITLE
fix(meta): erdos-399 — stale axiomatized narrative over fully proved file

### DIFF
--- a/proofs/Proofs/Erdos399Problem.lean
+++ b/proofs/Proofs/Erdos399Problem.lean
@@ -60,7 +60,7 @@ theorem erdos_399_disproved :
 /-- Alternative form: 10! = 48^4 - 36^4 -/
 theorem erdos_399_alt : (10! : ℤ) = (48 : ℤ)^4 - (36 : ℤ)^4 := by native_decide
 
-/- ## Historical Results (Axiomatized) -/
+/- ## Historical Results (documented for context, not formalized) -/
 
 /- 
 **Erdős-Obláth Theorem (1937)**: There are no solutions to n! = x^k ± y^k

--- a/src/data/proofs/erdos-399/meta.json
+++ b/src/data/proofs/erdos-399/meta.json
@@ -7,7 +7,7 @@
     "author": "Jonas Barfield",
     "sourceUrl": "https://erdosproblems.com/399",
     "date": "2020s",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos399Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "diophantine-equations",
       "factorials"
     ],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "erdosNumber": 399,
     "erdosUrl": "https://erdosproblems.com/399",
@@ -42,13 +42,13 @@
     "originalContributions": [
       "Formal verification of Barfield's counterexample 10! = 48^4 - 36^4",
       "Existential witness proving the conjecture is false",
-      "Axiomatized Erdős-Obláth, Pollack-Shapiro, and Cambie theorems",
+      "Documented (not formalized) the Erdős-Obláth, Pollack-Shapiro, and Cambie historical results as context",
       "Verification that gcd(48,36) = 12 (not coprime)",
       "Algebraic factorization 48^4 - 36^4 = 12^4 * 175"
     ],
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 123,
-    "assumptions": "No mathematical axioms and 0 sorries; previously cited axiom names were removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean. Compiler-trust disclosure: the concrete Barfield-counterexample facts (factorial_10, pow_48_4, pow_36_4, barfield_counterexample = 10! + 36^4 = 48^4, erdos_399_alt, and the barfield_gcd/barfield_factored/diff_4_3_pow4 witnesses) are discharged with native_decide, so their axiom footprint includes Lean.ofReduceBool (kernel reduction trusts the compiled decision procedure). These are finite decidable computations and add no mathematical assumption; leanFile.axiomCount remains 0 (no literal axiom declarations).",
+    "assumptions": "No mathematical axioms and 0 sorries; the main result (erdos_399_disproved) is fully proved via an explicit existential witness. The historical results (Erdős-Obláth, Pollack-Shapiro, Cambie) are documented as comments only — they were never declared as Lean axioms and are not formalized. Compiler-trust disclosure: the concrete Barfield-counterexample facts (factorial_10, pow_48_4, pow_36_4, barfield_counterexample = 10! + 36^4 = 48^4, erdos_399_alt, and the barfield_gcd/barfield_factored/diff_4_3_pow4 witnesses) are discharged with native_decide, so their axiom footprint includes Lean.ofReduceBool (kernel reduction trusts the compiled decision procedure). These are finite decidable computations and add no mathematical assumption; leanFile.axiomCount remains 0 (no literal axiom declarations).",
     "theoremCount": 16,
     "definitionCount": 0
   },
@@ -56,7 +56,7 @@
     "historicalContext": "Erdős Problem #399 concerns the equation n! = x^k ± y^k, asking whether there are any solutions with xy > 1 and k > 2. This is a classic Diophantine problem connecting factorials with perfect powers.\n\n**Historical Progress**:\n- Erdős-Obláth (1937): Proved no solutions exist when gcd(x,y) = 1 and k ≠ 4\n- Pollack-Shapiro (1973): Proved no solutions to n! = x^4 - 1 (called 'the next to last case')\n- Cambie: Showed no solutions to n! = x^4 + y^4 with gcd(x,y) = 1\n\nThe known methods all relied on the coprimality condition gcd(x,y) = 1. When x and y share a common factor, the analysis becomes more complex.\n\n**The Counterexample**: Jonas Barfield discovered that 10! = 48^4 - 36^4, which satisfies all the conditions (xy > 1, k > 2) but violates gcd(x,y) = 1 (since gcd(48,36) = 12). This disproves the conjecture.",
     "problemStatement": "**Conjecture (Erdős)**: Are there no solutions to\n$$n! = x^k \\pm y^k$$\nwith $x, y, n \\in \\mathbb{N}$, $xy > 1$, and $k > 2$?\n\n**Answer**: NO — Disproved by Barfield.\n\n**Counterexample**: $10! = 48^4 - 36^4$\n\nVerification:\n- 10! = 3,628,800\n- 48^4 = 5,308,416\n- 36^4 = 1,679,616\n- 48^4 - 36^4 = 5,308,416 - 1,679,616 = 3,628,800 = 10!",
     "text": "Is it true that there are no solutions to n! = x^k ± y^k with xy > 1 and k > 2? Disproved by Barfield: 10! = 48^4 - 36^4.",
-    "proofStrategy": "We formalize the disproof by:\n\n1. **Verify the counterexample**: Use native_decide to confirm 10! + 36^4 = 48^4\n2. **Check the conditions**: 48 * 36 = 1728 > 1 and 4 > 2\n3. **Construct the existential witness**: (n,x,y,k) = (10,48,36,4) satisfies all conditions\n4. **Axiomatize historical results**: Erdős-Obláth, Pollack-Shapiro, Cambie theorems\n5. **Analyze the counterexample**: gcd(48,36) = 12, and 48^4 - 36^4 = 12^4 * 175\n\nThe key insight is that 48 = 12 * 4 and 36 = 12 * 3, so the factorization 48^4 - 36^4 = 12^4 * (4^4 - 3^4) = 12^4 * 175 reveals the algebraic structure.",
+    "proofStrategy": "We formalize the disproof by:\n\n1. **Verify the counterexample**: Use native_decide to confirm 10! + 36^4 = 48^4\n2. **Check the conditions**: 48 * 36 = 1728 > 1 and 4 > 2\n3. **Construct the existential witness**: (n,x,y,k) = (10,48,36,4) satisfies all conditions\n4. **Document historical results** (as comments, not formalized): Erdős-Obláth, Pollack-Shapiro, Cambie theorems\n5. **Analyze the counterexample**: gcd(48,36) = 12, and 48^4 - 36^4 = 12^4 * 175\n\nThe key insight is that 48 = 12 * 4 and 36 = 12 * 3, so the factorization 48^4 - 36^4 = 12^4 * (4^4 - 3^4) = 12^4 * 175 reveals the algebraic structure.",
     "keyInsights": [
       "**The coprimality gap**: All prior methods assumed gcd(x,y) = 1. Barfield's example has gcd(48,36) = 12, exploiting this gap.",
       "**Why k = 4**: The case k = 4 was special because Erdős-Obláth's methods don't apply. Barfield's example uses exactly this exponent.",
@@ -89,7 +89,7 @@
       "title": "Historical Results",
       "startLine": 63,
       "endLine": 92,
-      "summary": "Axiomatize Erdős-Obláth (1937), Pollack-Shapiro (1973), and Cambie's theorems on coprime cases."
+      "summary": "Document (as comments, not formalized) Erdős-Obláth (1937), Pollack-Shapiro (1973), and Cambie's theorems on coprime cases."
     },
     {
       "id": "sum-squares",


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-399 (Factorial Diophantine Equations)

**Problem**: `meta.status: "axiomatized"`, `badge: "wip"`, and `meta.axiomCount: 1` claimed the file rests on axioms, and `originalContributions`/`proofStrategy`/`sections[]` said the historical results (Erdős-Obláth, Pollack-Shapiro, Cambie) were "axiomatized". None of this is true: the file has **0 `axiom` declarations and 0 sorries** (`leanFile.axiomCount` already correctly said 0), the main disprove theorem `erdos_399_disproved` is fully proved via an explicit existential witness, and the historical results exist only as plain `/- ... -/` comments with no corresponding Lean declaration at all — never axiomatized, just documented for context.

## Evidence

- `grep -n "axiom\|sorry" proofs/Proofs/Erdos399Problem.lean` → no matches.
- `erdos_399_disproved` (line 56-58) is a complete proof: `⟨10, 48, 36, 4, by decide⟩`.
- Line 63's own section heading said `## Historical Results (Axiomatized)` despite no axiom decl following it.
- Convention check: comparable 0-axiom/0-sorry native_decide-disclosed entries in the gallery use `status: verified`, `badge: original` (not `axiomatized`/`wip`).

## Fix

- `status`: `axiomatized` → `verified`
- `badge`: `wip` → `original`
- `axiomCount`: `1` → `0`
- Corrected `originalContributions`, `assumptions`, `proofStrategy` step 4, and the `historical` section summary to say the historical results are documented (not formalized), not axiomatized.
- Corrected the misleading `## Historical Results (Axiomatized)` heading in the Lean source itself.

No functional Lean changes — comment-only edit in the `.lean` file; `meta.json` narrative/status only.

---
Discovered during gallery integrity audit.