### PR TITLE
Gallery integrity: erdos-388 fixes stale axiomatized prose after axiom removal

### DIFF
--- a/src/data/proofs/erdos-388/annotations.json
+++ b/src/data/proofs/erdos-388/annotations.json
@@ -96,7 +96,7 @@
       "endLine": 69
     },
     "title": "Finiteness Conjecture (Problem #388)",
-    "content": "The main open conjecture: there are only finitely many solutions to the equal-products equation with $k_1, k_2 > 3$ and disjoint blocks. Formalized as $\\exists N, \\forall \\text{sol}, m_2 \\leq N$. This is a strong Diophantine finiteness statement — the $k > 3$ threshold is believed to be sharp.",
+    "content": "The main open conjecture: there are only finitely many solutions to the equal-products equation with $k_1, k_2 > 3$ and disjoint blocks, i.e. $\\exists N, \\forall \\text{sol}, m_2 \\leq N$. This is stated in a comment only — not declared as a Lean axiom or theorem; it existed as `axiom erdos_388_conjecture` in an earlier version of the file, stripped to a plain comment by a later migration commit and never restored. This is a strong Diophantine finiteness statement — the $k > 3$ threshold is believed to be sharp.",
     "mathContext": "**Conjecture (Erdős)**: $|\\{(m_1, m_2, k_1, k_2) : k_i > 3, m_1+k_1 \\leq m_2, \\prod_{i=1}^{k_1}(m_1+i) = \\prod_{j=1}^{k_2}(m_2+j)\\}| < \\infty$. Even the question of whether any non-trivial solutions exist (with $k_1 \\neq k_2$ or $m_1 \\neq m_2$) remains open for $k_i > 3$.",
     "significance": "key",
     "relatedConcepts": [
@@ -140,7 +140,7 @@
       "endLine": 90
     },
     "title": "Generalized Finiteness Conjecture",
-    "content": "For any fixed nonzero $a, b$, the proportional-products equation should have only finitely many solutions with $k_1 > 2$. This is strictly stronger than the main conjecture (which is the case $a = b = 1, k_i > 3$).",
+    "content": "For any fixed nonzero $a, b$, the proportional-products equation should have only finitely many solutions with $k_1 > 2$. This is stated in a comment only — not declared as a Lean axiom or theorem; it existed as `axiom erdos_388_generalized` in an earlier version of the file, stripped to a plain comment by a later migration commit and never restored. This is strictly stronger than the main conjecture (which is the case $a = b = 1, k_i > 3$).",
     "mathContext": "**Generalized conjecture**: $\\forall a, b > 0, \\; |\\{\\text{solutions to } a \\cdot \\prod(m_1+i) = b \\cdot \\prod(m_2+j), k_1 > 2\\}| < \\infty$. The $k_1 > 2$ threshold (instead of $> 3$) is possible because the proportional factor $a/b$ absorbs some small-case families.",
     "significance": "key",
     "relatedConcepts": [
@@ -160,7 +160,7 @@
       "endLine": 99
     },
     "title": "Erdős–Selfridge Theorem (1975)",
-    "content": "A product of two or more consecutive positive integers is never a perfect power: $(m+1)(m+2) \\cdots (m+k) \\neq n^r$ for $k \\geq 2, r \\geq 2, m > 0$. This landmark result of Paul Erdős and John Selfridge settled a long-standing conjecture using the Bertrand postulate and $p$-adic valuations. It implies that consecutive products have 'rich' prime factorizations that prevent perfect-power structure.",
+    "content": "A product of two or more consecutive positive integers is never a perfect power: $(m+1)(m+2) \\cdots (m+k) \\neq n^r$ for $k \\geq 2, r \\geq 2, m > 0$. This landmark result of Paul Erdős and John Selfridge settled a long-standing conjecture using the Bertrand postulate and $p$-adic valuations. It is stated in a comment only — not declared as a Lean axiom or theorem; it existed as `axiom erdos_selfridge` in an earlier version of the file, stripped to a plain comment by a later migration commit and never restored.",
     "mathContext": "**Erdős–Selfridge (1975)**: $\\prod_{i=1}^k (m+i) \\neq n^r$ for $k \\geq 2, r \\geq 2, m \\geq 1$. The proof analyzes the $p$-adic valuation $v_p(\\prod(m+i))$: by Bertrand's postulate, there exists a prime $p$ with $m+1 \\leq p \\leq m+k$ that divides exactly one factor, making $v_p(\\text{product})$ odd — contradicting the $r$-th power condition.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-388/meta.json
+++ b/src/data/proofs/erdos-388/meta.json
@@ -32,7 +32,7 @@
     "historicalContext": "Paul Erdős posed this problem in the 1970s–1980s as part of his systematic investigation of Diophantine equations involving products of consecutive integers. The foundational result in this area is the Erdős–Selfridge theorem (1975, Illinois J. Math.), which proved that a product of two or more consecutive positive integers is never a perfect power — settling a conjecture that had been open since the 19th century (partial results by Obláth, 1956). Problem #388 asks the next natural question: when can two *disjoint* blocks of consecutive integers have the same product? The connection to factorials $(m+1) \\cdots (m+k) = (m+k)!/m!$ means this is equivalent to asking when two factorial ratios can be equal. The threshold $k > 3$ is essential because for small $k$, parametric families of solutions exist. The problem also connects to the Brocard–Ramanujan problem ($n! + 1 = m^2$) and to Erdős Problems #363 and #931 on related product identities.",
     "problemStatement": "Are there only finitely many solutions to $\\prod_{i=1}^{k_1}(m_1+i) = \\prod_{j=1}^{k_2}(m_2+j)$ with $k_1, k_2 > 3$ and $m_1 + k_1 \\leq m_2$ (disjoint blocks)?",
     "text": "Can one classify all solutions of ∏(m₁+i) = ∏(m₂+j) where k₁, k₂ > 3 and the blocks are disjoint? Erdős conjectured only finitely many solutions exist. Generalizes to proportional products a·∏(m₁+i) = b·∏(m₂+j).",
-    "proofStrategy": "We formalize the consecutive product $\\prod_{i=1}^k (m+i)$ via `Finset.Icc`, encode solutions as proof-carrying structures (with $k > 3$, disjointness, and product equality baked in), state the finiteness conjecture, generalize to proportional products $a \\cdot \\prod = b \\cdot \\prod$, and connect to the Erdős–Selfridge theorem and factorial identities.",
+    "proofStrategy": "We formalize the consecutive product $\\prod_{i=1}^k (m+i)$ via `Finset.Icc` and encode solutions as proof-carrying structures (with $k > 3$, disjointness, and product equality baked in). The finiteness conjecture, its proportional generalization, and the Erdős–Selfridge theorem are documented in comments only — none is declared as a Lean axiom or theorem in the current file; each existed as an `axiom` in an earlier version but was stripped to a plain comment by a later migration commit and never restored.",
     "keyInsights": [
       "**Factorial ratio reformulation**: The equal-products equation $\\prod(m_1+i) = \\prod(m_2+j)$ is equivalent to $(m_1+k_1)!/m_1! = (m_2+k_2)!/m_2!$, transforming a combinatorial question into one about factorial ratios",
       "**Erdős–Selfridge as motivation**: The 1975 proof that $\\prod_{i=1}^k (m+i) \\neq n^r$ uses $p$-adic valuations and Bertrand's postulate — similar techniques constrain equal-product solutions by showing that consecutive products have 'irregular' prime factorizations",
@@ -65,21 +65,21 @@
       "title": "Main Conjecture",
       "startLine": 62,
       "endLine": 70,
-      "summary": "The finiteness conjecture: $\\exists N, \\forall \\text{sol}, m_2 \\leq N$, axiomatized as `erdos_388_conjecture`. This is the main open problem."
+      "summary": "The finiteness conjecture $\\exists N, \\forall \\text{sol}, m_2 \\leq N$ is stated in a comment only — not declared as a Lean axiom or theorem. An earlier version of the file declared this as `axiom erdos_388_conjecture`, but a later migration commit stripped it to a plain comment and it was never restored."
     },
     {
       "id": "generalized-version",
       "title": "Generalized Proportional Version",
       "startLine": 71,
       "endLine": 91,
-      "summary": "Defines `ProportionalProductSolution` for $a \\cdot \\prod(m_1+i) = b \\cdot \\prod(m_2+j)$ with $k_1 > 2$, and axiomatizes the generalized finiteness conjecture for fixed nonzero $a, b$."
+      "summary": "Defines `ProportionalProductSolution` for $a \\cdot \\prod(m_1+i) = b \\cdot \\prod(m_2+j)$ with $k_1 > 2$. The generalized finiteness conjecture for fixed nonzero $a, b$ is stated in a comment only — not declared as a Lean axiom or theorem; it existed as `axiom erdos_388_generalized` in an earlier version, stripped to a comment by a later migration commit and never restored."
     },
     {
       "id": "erdos-selfridge",
       "title": "Erdős–Selfridge Theorem",
       "startLine": 92,
       "endLine": 100,
-      "summary": "Axiomatizes the 1975 result: $\\prod_{i=1}^k (m+i) \\neq n^r$ for $k \\geq 2, r \\geq 2, m \\geq 1$. No product of consecutive positive integers is a perfect power."
+      "summary": "States the 1975 result in a comment only — not declared as a Lean axiom or theorem: $\\prod_{i=1}^k (m+i) \\neq n^r$ for $k \\geq 2, r \\geq 2, m \\geq 1$ (no product of consecutive positive integers is a perfect power). It existed as `axiom erdos_selfridge` in an earlier version, stripped to a comment by a later migration commit and never restored."
     },
     {
       "id": "factorial-and-trivial",
@@ -90,7 +90,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures the full structure of Erdős Problem #388: the equal-products equation for disjoint blocks of consecutive integers, the finiteness conjecture with the $k > 3$ threshold, the proportional generalization, and connections to the Erdős–Selfridge theorem (1975) and factorial arithmetic. The proof-carrying structure design ensures all constraints are verified at the type level.",
+    "summary": "This file formalizes the equal-products equation for disjoint blocks of consecutive integers as a proof-carrying `EqualProductSolution` structure (with $k > 3$ and disjointness verified at the type level), its proportional generalization, and the factorial-ratio identity (proved as a theorem). The finiteness conjecture itself, its proportional generalization, and the Erdős–Selfridge theorem (1975) are documented in comments only — none is declared as a Lean axiom or theorem in the current file.",
     "implications": "Resolving the finiteness conjecture would advance understanding of Diophantine equations involving factorial-type products. It connects to the broader question of when multiplicative coincidences among integers force structural constraints, with implications for the abc conjecture and Diophantine approximation.",
     "openQuestions": [
       "Are there any non-trivial solutions with $k_1, k_2 > 3$ and disjoint blocks?",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-388 (Products of Consecutive Integers)
**Problem**: meta.json/annotations.json prose claims the finiteness conjecture, its proportional generalization, and the Erdős–Selfridge theorem are "axiomatized"/"Formalized as" specific identifiers (`erdos_388_conjecture`, `erdos_388_generalized`, `erdos_selfridge`), but none of these exist in the current Lean file — 0 grep hits.

## Evidence

**meta.json claims** (3 section summaries + proofStrategy + conclusion): "axiomatized as `erdos_388_conjecture`", "axiomatizes the generalized finiteness conjecture", "Axiomatizes the 1975 result", "captures the full structure ... connections to the Erdős–Selfridge theorem".

**Lean file shows**: `axiomCount: 0` (correctly reflected in meta), and `grep -n "erdos_388_conjecture\|axiom" proofs/Proofs/Erdos388Problem.lean` returns nothing. Commit `c34e89c683` ("Research: 3D Feuerbach analogue..." — an unrelated-titled squashed batch commit, part of a 2,256-axiom bulk removal sweep) demoted the 3 `axiom` declarations (`erdos_388_conjecture`, `erdos_388_generalized`, `erdos_selfridge`) to plain `/- ... -/` doc comments. `axiomCount`/`theoremCount` were already correct (0/2), but the prose narrating these as axiomatized/formalized was never updated to match — same class of drift previously found and fixed in erdos-124/erdos-1038/erdos-236 from the same commit's blast radius.

## Fix

Rewrote the 3 affected `sections[]` summaries, `overview.proofStrategy`, `conclusion.summary`, and 3 `annotations.json` entries to state plainly that these three statements are documented in comments only, not declared as Lean axioms or theorems, and to note the earlier-axiom → stripped-to-comment history for context. Left `status: axiomatized` / `badge: wip` unchanged, following the erdos-124/erdos-1038 precedent that this codebase uses "axiomatized" loosely for "documented but not machine-checked" — the `assumptions` field already disclosed 0 axioms honestly.

## Verification

- `python3 -m json.tool` confirms both files remain valid JSON.
- `theoremCount: 2`, `definitionCount: 4`, `axiomCount: 0`, `sorries: 0` in meta.json all match the actual Lean source (`consecutiveProduct_eq_factorial_ratio`, `trivial_equal_product` theorems; `consecutiveProduct`, `EqualProductSolution`, `equalProductSolutions`, `ProportionalProductSolution` definitions/structures).

---
Discovered during gallery integrity audit (round-robin re-serve, queue fully drained: 4811/4811 audited, 0 open issues).