### PR TITLE
audit(erdos-383): fix stale annotations + mislabeled maxPrimeFac dependency

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13093,9 +13093,9 @@
     },
     "erdos-383": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:35Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T19:58:31Z",
+      "result": "issues-fixed"
     },
     "erdos-384": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-383/annotations.json
+++ b/src/data/proofs/erdos-383/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "erdos-383",
     "range": {
       "startLine": 1,
-      "endLine": 26
+      "endLine": 36
     },
     "type": "concept",
     "title": "Problem Overview",
@@ -32,8 +32,8 @@
     "id": "ann-383-primediv",
     "proofId": "erdos-383",
     "range": {
-      "startLine": 40,
-      "endLine": 47
+      "startLine": 44,
+      "endLine": 54
     },
     "type": "definition",
     "title": "Prime Divisors",
@@ -59,8 +59,8 @@
     "id": "ann-383-product",
     "proofId": "erdos-383",
     "range": {
-      "startLine": 59,
-      "endLine": 62
+      "startLine": 99,
+      "endLine": 105
     },
     "type": "concept",
     "title": "Consecutive Square Product",
@@ -86,8 +86,8 @@
     "id": "ann-383-special",
     "proofId": "erdos-383",
     "range": {
-      "startLine": 71,
-      "endLine": 81
+      "startLine": 114,
+      "endLine": 121
     },
     "type": "concept",
     "title": "Special Cases",
@@ -113,8 +113,8 @@
     "id": "ann-383-kgood",
     "proofId": "erdos-383",
     "range": {
-      "startLine": 88,
-      "endLine": 97
+      "startLine": 123,
+      "endLine": 129
     },
     "type": "concept",
     "title": "k-Good Primes",
@@ -140,12 +140,12 @@
     "id": "ann-383-kgoodset",
     "proofId": "erdos-383",
     "range": {
-      "startLine": 98,
-      "endLine": 104
+      "startLine": 135,
+      "endLine": 158
     },
     "type": "definition",
     "title": "Set of k-Good Primes",
-    "content": "kGoodPrimes(k) = {p | isKGood(p, k)}. zero_good_iff: every prime is 0-good.",
+    "content": "kGoodPrimes(k) = {p | isKGood(p, k)}. zero_good: every prime is 0-good (proved directly).",
     "mathContext": "The problem asks if kGoodPrimes(k) is infinite for all k.",
     "significance": "key",
     "relatedConcepts": [
@@ -167,12 +167,12 @@
     "id": "ann-383-conjecture",
     "proofId": "erdos-383",
     "range": {
-      "startLine": 111,
-      "endLine": 121
+      "startLine": 164,
+      "endLine": 168
     },
     "type": "concept",
     "title": "The Main Conjecture",
-    "content": "ErdosConjecture383 := ∀k, kGoodPrimes(k) is infinite. ErdosConjecture383' uses Nat.maxPrimeFac directly.",
+    "content": "ErdosConjecture383 := ∀k, kGoodPrimes(k) is infinite. ErdosConjecture383' uses this file's own `maxPrimeFac` helper directly (a local definition, not a Mathlib declaration).",
     "mathContext": "The conjecture asserts infinitely many k-good primes for each k.",
     "significance": "key",
     "relatedConcepts": [
@@ -188,20 +188,20 @@
     "prerequisites": [
       "universal quantification over all k",
       "infinitude of a set of primes",
-      "Nat.maxPrimeFac"
+      "the file's local maxPrimeFac helper"
     ]
   },
   {
     "id": "ann-383-partial",
     "proofId": "erdos-383",
     "range": {
-      "startLine": 128,
-      "endLine": 138
+      "startLine": 200,
+      "endLine": 205
     },
     "type": "concept",
     "title": "Partial Results",
-    "content": "all_primes_zero_good: every prime is 0-good. infinitely_many_zero_good: kGoodPrimes(0) is infinite. positive_density_smooth: smooth numbers have positive density.",
-    "mathContext": "The k=0 case is trivial. Smooth number density supports the general conjecture.",
+    "content": "all_primes_zero_good: every prime is 0-good. infinitely_many_zero_good: kGoodPrimes(0) is infinite. (The smooth-number density heuristic motivating the general conjecture is discussed only in this proof's gallery description, not as any Lean declaration.)",
+    "mathContext": "The k=0 case is trivial and fully proved. Smooth-number density is a heuristic motivation for the general conjecture, not formalized here.",
     "significance": "key",
     "relatedConcepts": [
       "partial",
@@ -223,8 +223,8 @@
     "id": "ann-383-problem382",
     "proofId": "erdos-383",
     "range": {
-      "startLine": 145,
-      "endLine": 151
+      "startLine": 212,
+      "endLine": 233
     },
     "type": "lemma",
     "title": "Relation to Problem #382",
@@ -250,8 +250,8 @@
     "id": "ann-383-smooth",
     "proofId": "erdos-383",
     "range": {
-      "startLine": 158,
-      "endLine": 161
+      "startLine": 239,
+      "endLine": 244
     },
     "type": "definition",
     "title": "Smooth Numbers",
@@ -277,13 +277,13 @@
     "id": "ann-383-dickman",
     "proofId": "erdos-383",
     "range": {
-      "startLine": 170,
-      "endLine": 175
+      "startLine": 17,
+      "endLine": 19
     },
     "type": "concept",
-    "title": "Dickman Function",
-    "content": "dickman_asymptotic: Ψ(x, x^{1/u}) ~ x·ρ(u) where ρ is the Dickman function. ρ(2) ≈ 0.307.",
-    "mathContext": "The Dickman function describes the density of smooth numbers. ρ(2) > 0 supports the conjecture.",
+    "title": "Dickman Function (Heuristic Only)",
+    "content": "The docstring's heuristic argument (lines 17-19) motivates the conjecture informally. No `dickman_asymptotic` or other Dickman-function identifier is declared anywhere in this Lean file — the asymptotic formula Ψ(x, x^{1/u}) ~ x·ρ(u) and the estimate ρ(2) ≈ 0.307 appear only in this proof's gallery description (meta.json), not in the Lean source.",
+    "mathContext": "The Dickman function describes the density of smooth numbers; it is cited only as motivation, not formalized in this file.",
     "significance": "key",
     "relatedConcepts": [
       "dickman",
@@ -304,12 +304,12 @@
     "id": "ann-383-heuristic",
     "proofId": "erdos-383",
     "range": {
-      "startLine": 182,
-      "endLine": 190
+      "startLine": 17,
+      "endLine": 19
     },
     "type": "concept",
     "title": "Heuristic Argument",
-    "content": "ρ(2) ≈ 0.307 means about 30.7% of numbers have no prime factor > √n. This suggests infinitely many k-good primes exist.",
+    "content": "The docstring argues informally that integers without prime divisors ≥ √n occur with positive density. The gallery description elaborates this as ρ(2) ≈ 0.307, i.e. about 30.7% of numbers have no prime factor > √n — this specific figure is not in the Lean docstring itself, only in the gallery prose.",
     "mathContext": "The probabilistic argument: smooth numbers are common enough.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -331,8 +331,8 @@
     "id": "ann-383-status",
     "proofId": "erdos-383",
     "range": {
-      "startLine": 197,
-      "endLine": 199
+      "startLine": 282,
+      "endLine": 286
     },
     "type": "concept",
     "title": "Problem Status",
@@ -358,12 +358,12 @@
     "id": "ann-383-formal",
     "proofId": "erdos-383",
     "range": {
-      "startLine": 206,
-      "endLine": 211
+      "startLine": 287,
+      "endLine": 291
     },
     "type": "concept",
     "title": "Formal Statement",
-    "content": "erdos_383_statement: The conjecture using Nat.maxPrimeFac and Finset.Icc.",
+    "content": "erdos_383_statement: The conjecture using this file's local maxPrimeFac helper and Finset.Icc.",
     "mathContext": "Precise formal statement adapted from formal-conjectures.",
     "significance": "key",
     "relatedConcepts": [
@@ -377,7 +377,7 @@
       "mathlib"
     ],
     "prerequisites": [
-      "Nat.maxPrimeFac",
+      "the file's local maxPrimeFac helper",
       "Finset.Icc interval",
       "formal Lean statement of a conjecture"
     ]

--- a/src/data/proofs/erdos-383/meta.json
+++ b/src/data/proofs/erdos-383/meta.json
@@ -34,14 +34,15 @@
         "module": "Mathlib.Algebra.BigOperators.Group.Finset"
       },
       {
-        "theorem": "Nat.maxPrimeFac",
-        "description": "Largest prime factor",
-        "module": "Mathlib.Data.Nat.Factorization.Basic"
+        "theorem": "Finset.max'",
+        "description": "Maximum element of a nonempty finite set",
+        "module": "Mathlib.Order.Finset.Lattice"
       }
     ],
     "originalContributions": [
       "primeDivisors definition: set of prime factors",
       "hasLargestPrimeFactor definition: p is max prime factor",
+      "maxPrimeFac definition: largest prime factor of n (0 if none); local helper, not a Mathlib declaration despite its Nat-style name",
       "consecutiveSquareProduct definition: ∏_{i=0}^k (p² + i)",
       "isKGood definition: p is k-good prime",
       "kGoodPrimes definition: set of k-good primes",
@@ -118,18 +119,18 @@
     {
       "id": "conjecture",
       "title": "The Erdős Conjecture",
-      "summary": "States the conjecture in two forms: `ErdosConjecture383` (∀ k, `kGoodPrimes k` is infinite) and `ErdosConjecture383'` using `maxPrimeFac` directly, and **proves** their equivalence (`conjecture_equiv`, a fully-proved theorem — not an axiom).",
+      "summary": "States the conjecture in two forms: `ErdosConjecture383` (∀ k, `kGoodPrimes k` is infinite) and `ErdosConjecture383'` using this file's local `maxPrimeFac` helper directly (not a Mathlib declaration), and **proves** their equivalence (`conjecture_equiv`, a fully-proved theorem — not an axiom).",
       "startLine": 161,
       "endLine": 196,
-      "mathContext": "States the conjecture in two forms: `ErdosConjecture383` (∀ k, `kGoodPrimes k` is infinite) and `ErdosConjecture383'` using `maxPrimeFac` directly, and **proves** their equivalence (`conjecture_equiv`, a fully-proved theorem — not an axiom)."
+      "mathContext": "States the conjecture in two forms: `ErdosConjecture383` (∀ k, `kGoodPrimes k` is infinite) and `ErdosConjecture383'` using this file's local `maxPrimeFac` helper directly (not a Mathlib declaration), and **proves** their equivalence (`conjecture_equiv`, a fully-proved theorem — not an axiom)."
     },
     {
       "id": "partial",
       "title": "Partial Results",
-      "summary": "Proves the k=0 case: `all_primes_zero_good` (trivial from `zero_good`) and `infinitely_many_zero_good` (from infinitude of primes). documents in source comments `positive_density_smooth` (no Lean declaration exists): √n-smooth numbers have positive asymptotic density.",
+      "summary": "Proves the k=0 case: `all_primes_zero_good` (trivial from `zero_good`) and `infinitely_many_zero_good` (from infinitude of primes). The smooth-number density heuristic motivating the general conjecture appears only in the gallery's descriptive prose (this meta.json), not as any Lean declaration or comment in this section.",
       "startLine": 197,
       "endLine": 207,
-      "mathContext": "Proves the k=0 case: `all_primes_zero_good` (trivial from `zero_good`) and `infinitely_many_zero_good` (from infinitude of primes). documents in source comments `positive_density_smooth` (no Lean declaration exists): √n-smooth numbers have positive asymptotic density."
+      "mathContext": "Proves the k=0 case: `all_primes_zero_good` (trivial from `zero_good`) and `infinitely_many_zero_good` (from infinitude of primes). The smooth-number density heuristic motivating the general conjecture appears only in the gallery's descriptive prose (this meta.json), not as any Lean declaration or comment in this section."
     },
     {
       "id": "problem382",
@@ -142,18 +143,18 @@
     {
       "id": "smooth",
       "title": "Smooth Numbers",
-      "summary": "Defines `isSmooth(n, y)` (all prime factors ≤ y), proves the key equivalence `kGood_iff_smooth` (p is k-good ↔ each p²+i is p-smooth for i ≤ k), and defines `countSmooth`. The Dickman heuristic (ρ(2) ≈ 0.307), which motivates a positive answer to the conjecture, is discussed in source comments only — no Dickman asymptotic is asserted as a Lean axiom.",
+      "summary": "Defines `isSmooth(n, y)` (all prime factors ≤ y), proves the key equivalence `kGood_iff_smooth` (p is k-good ↔ each p²+i is p-smooth for i ≤ k), and defines `countSmooth`. The Dickman heuristic (ρ(2) ≈ 0.307) discussed in this proof's gallery description does not appear anywhere in this file's Lean source or comments — no Dickman asymptotic is asserted as a Lean axiom or declaration here.",
       "startLine": 236,
       "endLine": 281,
-      "mathContext": "Defines `isSmooth(n, y)` (all prime factors ≤ y), proves the key equivalence `kGood_iff_smooth` (p is k-good ↔ each p²+i is p-smooth for i ≤ k), and defines `countSmooth`. The Dickman heuristic (ρ(2) ≈ 0.307), which motivates a positive answer to the conjecture, is discussed in source comments only — no Dickman asymptotic is asserted as a Lean axiom."
+      "mathContext": "Defines `isSmooth(n, y)` (all prime factors ≤ y), proves the key equivalence `kGood_iff_smooth` (p is k-good ↔ each p²+i is p-smooth for i ≤ k), and defines `countSmooth`. The Dickman heuristic (ρ(2) ≈ 0.307) discussed in this proof's gallery description does not appear anywhere in this file's Lean source or comments — no Dickman asymptotic is asserted as a Lean axiom or declaration here."
     },
     {
       "id": "summary",
       "title": "Summary and Formal Statement",
-      "summary": "Status string (OPEN) and `erdos_383_statement`: the formal conjecture using `Nat.maxPrimeFac` and `Finset.Icc`, proving equivalence with the `ErdosConjecture383'` formulation.",
+      "summary": "Status string (OPEN) and `erdos_383_statement`: the formal conjecture using this file's local `maxPrimeFac` helper and `Finset.Icc`, proving equivalence with the `ErdosConjecture383'` formulation.",
       "startLine": 282,
       "endLine": 292,
-      "mathContext": "Mathematical content: Status string (OPEN) and `erdos_383_statement`: the formal conjecture using `Nat.maxPrimeFac` and `Finset.Icc`, proving equivalence with the `ErdosConjecture383'` formulation."
+      "mathContext": "Mathematical content: Status string (OPEN) and `erdos_383_statement`: the formal conjecture using this file's local `maxPrimeFac` helper and `Finset.Icc`, proving equivalence with the `ErdosConjecture383'` formulation."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-383 (Prime Divisors of Consecutive Squares)
**Problem**: `annotations.json` had systematic line-range drift and phantom Lean identifiers; `meta.json` misattributed a local definition to Mathlib.

## Evidence

**annotations.json**: 12 of 14 entries' `range` fields pointed at unrelated code (drift accumulated after earlier file edits shifted line numbers). Four entries also named Lean declarations that do not exist anywhere in the file (confirmed via `grep`, 0 hits each):
- `zero_good_iff` (actual theorem is `zero_good`)
- `dickman_asymptotic` (no Dickman-function content is declared in the Lean source at all — only in this proof's gallery prose)
- `positive_density_smooth` (same — fabricated, not even present as a comment)
- `Nat.maxPrimeFac` (the file defines its own local `maxPrimeFac` in the `Erdos383` namespace; no such Mathlib declaration exists)

**meta.json**: `mathlibDependencies` listed `Nat.maxPrimeFac` from `Mathlib.Data.Nat.Factorization.Basic` as a dependency — this Mathlib declaration does not exist; the file's `maxPrimeFac` (line 73-74) is an original local helper built from `Finset.max'`. Two section summaries (`partial`, `smooth`) claimed the Dickman/smooth-density heuristic was "discussed in source comments" when it appears only in the gallery's own prose, not in the Lean file.

## Fix

- Re-anchored all 14 `annotations.json` `range` fields to their actual declarations (verified against current line numbers).
- Rewrote the 4 phantom-identifier entries to honestly state the content is prose/heuristic-only, not a Lean declaration.
- Corrected `mathlibDependencies` (`Nat.maxPrimeFac` → `Finset.max'`) and added `maxPrimeFac` to `originalContributions`.
- Corrected 2 section summaries' "discussed in source comments" claims.
- Counts (0 axioms, 0 sorries, 17 theorems, 13 definitions) were already accurate — unchanged. `status: axiomatized` / `badge: wip` unchanged (main conjecture is genuinely open).

## Verification

- `python3 -m json.tool` confirms both files remain valid JSON.
- Scripted check confirms every annotation `range` now overlaps the content its `content`/`title` describes.
- `grep` confirms none of the four phantom identifiers remain unqualified anywhere in `meta.json`/`annotations.json` (the one remaining hit for `dickman_asymptotic` is inside the corrected disclaimer text itself).

---
Discovered during gallery integrity audit (round-robin re-serve, queue fully drained: 4811/4811 audited, 0 open issues).