### PR TITLE
Enrich abel-ruffini-galois-extensions-oq-02: split sections to 5

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-02/meta.json
@@ -146,12 +146,20 @@
       "mathContext": "The number of intermediate fields equals the number of subgroups; degrees of the two tower halves are the order and index of the corresponding subgroup."
     },
     {
-      "id": "normal-and-quintic",
-      "title": "Parts VI–VII: normal refinement and the X⁵ − 4X + 2 instantiation",
+      "id": "normal-refinement",
+      "title": "Part VI: the normal refinement",
       "startLine": 160,
+      "endLine": 173,
+      "summary": "`isGalois_fixedField_of_normal` (normal H ↦ fixedField H is Galois over F) and `normalQuotientEquiv` (Gal(E/F) ⧸ H ≃* Gal(fixedField H / F)) — the correspondence's finest refinement, linking normal subgroups to Galois subextensions with the quotient as their Galois group.",
+      "mathContext": "For normal $H \\trianglelefteq \\mathrm{Gal}(E/F)$: $\\mathrm{fixedField}\\,H / F$ is itself Galois, with $\\mathrm{Gal}(E/F)/H \\simeq \\mathrm{Gal}(\\mathrm{fixedField}\\,H/F)$."
+    },
+    {
+      "id": "quintic",
+      "title": "Part VII: the X⁵ − 4X + 2 instantiation",
+      "startLine": 174,
       "endLine": 201,
-      "summary": "`isGalois_fixedField_of_normal` and `normalQuotientEquiv` (normal H ↦ Galois subextension with quotient Galois group); then the Quintic section: `IsGalois ℚ (X⁵−4X+2).SplittingField` and `quintic_card_intermediateField_eq_card_subgroup`.",
-      "mathContext": "Normal subgroups correspond to Galois subextensions with quotient group as Galois group; instantiated on the concrete Abel–Ruffini witness whose group is S₅."
+      "summary": "Establishes `IsGalois ℚ (X⁵−4X+2).SplittingField` (separable ⟹ splitting field Galois) and instantiates the counting bijection as `quintic_card_intermediateField_eq_card_subgroup`, tying the abstract dictionary to OQ-01's concrete unsolvable quintic with Galois group S₅.",
+      "mathContext": "The splitting field of $X^5-4X+2$ over $\\mathbb{Q}$ is Galois with group $S_5$ (OQ-01); its intermediate fields biject with the subgroups of $S_5$."
     }
   ],
   "theorems": [


### PR DESCRIPTION
Enrichment pass for abel-ruffini-galois-extensions-oq-02 (quality 96, 0 prior passes).

`sections` had only 4 entries; the last one ("Parts VI–VII: normal refinement and the X⁵−4X+2 instantiation", lines 160-201) bundled two logically distinct parts of the file. `annotations.json` had already split this exact range into two annotations (160-173 and 174-201) matching the file's own `Part VI` / `Part VII` comment banners — `sections` just hadn't caught up.

Split into `normal-refinement` (160-173: `isGalois_fixedField_of_normal`, `normalQuotientEquiv`) and `quintic` (174-201: the concrete `IsGalois ℚ (X⁵−4X+2).SplittingField` instantiation), giving 4 → 5 sections that now match the annotation boundaries.

No changes to Lean source, axiom/sorry counts, or status/badge — file remains 0 axioms, 0 sorries, verified. `meta.json` ~27.3 KB, well under the 60 KB cap.