### PR TITLE
Research: erdos-85-wip-01 - abstract surgery engine + f(13) >= 4 (f(13) in {4,5})

### DIFF
--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -2321,4 +2321,328 @@ theorem minDegreeForC4_twelve : minDegreeForC4 12 = 4 := by
   have hge := four_le_minDegreeForC4_twelve
   omega
 
+/-! ## The abstract vertex-adding surgery: `C₄`-free min-degree-3 witnesses grow
+
+The `f(11)` and `f(12)` witnesses were built by hand-picked surgeries on the
+Petersen graph, each verified by a fixed-size kernel `decide`.  This section
+formalizes the surgery **abstractly**, so that every future lower-bound rung
+`f(n+1) ≥ 4` reduces to exhibiting a small *configuration* in the current
+`n`-vertex witness instead of re-verifying an entire graph:
+
+given a `C₄`-free graph `G` (via the common-neighbour criterion) and vertices
+`a, b, c` with `a ~ b`, `b ~ c`, `a ≁ c`, where the edges `ab` and `bc` each
+lie in **no triangle**, the surgery
+
+    delete the edge `a–b`, add a new vertex `v` adjacent to `a`, `b`, `c`
+
+produces a graph on one more vertex that again has min-degree `≥ 3` (if `G`
+did) and all pairwise common neighbourhoods of size `≤ 1`.  The triangle-free
+hypotheses are exactly what the general step needs (they were automatic in the
+girth-5 Petersen but fail for arbitrary `C₄`-free graphs — `G` may have
+triangles elsewhere; only the two surgered edges must avoid them).  Note
+`common(a,c) = {b}` is automatic: `b` is a common neighbour and `C₄`-freeness
+caps the count at one.
+
+Applied to `petersen12` with the configuration `a = 4, b = 9, c = 7` (both
+edges triangle-free by a kernel check), this yields **`f(13) ≥ 4`** — beyond
+the counting range, where the upper bound `f(13) ≤ 4` is genuinely blocked —
+so `f(13) ∈ {4, 5}`. -/
+
+section Surgery
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- The adjacency relation of the surgered graph: old edges minus `a–b`
+(`some`-`some`), plus a new vertex `none` adjacent to exactly `a`, `b`, `c`. -/
+def surgeryAdj (G : SimpleGraph V) (a b c : V) : Option V → Option V → Prop
+  | some x, some y => G.Adj x y ∧ ¬(x = a ∧ y = b) ∧ ¬(x = b ∧ y = a)
+  | some x, none => x = a ∨ x = b ∨ x = c
+  | none, some y => y = a ∨ y = b ∨ y = c
+  | none, none => False
+
+/-- **The vertex-adding surgery**: delete the edge `a–b` of `G`, add a new
+vertex (`none`) adjacent to `a`, `b`, and `c`. -/
+def surgery (G : SimpleGraph V) (a b c : V) : SimpleGraph (Option V) where
+  Adj := surgeryAdj G a b c
+  symm.symm := by
+    intro p q h
+    match p, q with
+    | some x, some y =>
+        exact ⟨h.1.symm, fun hc => h.2.2 ⟨hc.2, hc.1⟩, fun hc => h.2.1 ⟨hc.2, hc.1⟩⟩
+    | some x, none => exact h
+    | none, some y => exact h
+    | none, none => exact h.elim
+  loopless.irrefl := by
+    intro p h
+    match p with
+    | some x => exact G.loopless.irrefl x h.1
+    | none => exact h
+
+instance surgeryDecidableRel (G : SimpleGraph V) [DecidableRel G.Adj] (a b c : V) :
+    DecidableRel (surgery G a b c).Adj := fun p q =>
+  match p, q with
+  | some x, some y =>
+      inferInstanceAs (Decidable (G.Adj x y ∧ ¬(x = a ∧ y = b) ∧ ¬(x = b ∧ y = a)))
+  | some x, none => inferInstanceAs (Decidable (x = a ∨ x = b ∨ x = c))
+  | none, some y => inferInstanceAs (Decidable (y = a ∨ y = b ∨ y = c))
+  | none, none => inferInstanceAs (Decidable False)
+
+@[simp] theorem surgery_adj_some_some {G : SimpleGraph V} {a b c x y : V} :
+    (surgery G a b c).Adj (some x) (some y) ↔
+      G.Adj x y ∧ ¬(x = a ∧ y = b) ∧ ¬(x = b ∧ y = a) := Iff.rfl
+
+@[simp] theorem surgery_adj_some_none {G : SimpleGraph V} {a b c x : V} :
+    (surgery G a b c).Adj (some x) none ↔ (x = a ∨ x = b ∨ x = c) := Iff.rfl
+
+@[simp] theorem surgery_adj_none_some {G : SimpleGraph V} {a b c y : V} :
+    (surgery G a b c).Adj none (some y) ↔ (y = a ∨ y = b ∨ y = c) := Iff.rfl
+
+@[simp] theorem surgery_adj_none_none {G : SimpleGraph V} {a b c : V} :
+    ¬ (surgery G a b c).Adj none none := fun h => h
+
+/-- **Old vertices keep their degree (at least)**: the map sending the deleted
+neighbour `b` of `a` (resp. `a` of `b`) to the new vertex and every other
+neighbour to itself injects the old neighbourhood of `x` into the new one. -/
+theorem surgery_degree_some {G : SimpleGraph V} [DecidableRel G.Adj] {a b c : V}
+    (hne : a ≠ b) (x : V) :
+    G.degree x ≤ (surgery G a b c).degree (some x) := by
+  rw [← SimpleGraph.card_neighborFinset_eq_degree,
+      ← SimpleGraph.card_neighborFinset_eq_degree]
+  apply Finset.card_le_card_of_injOn
+    (fun y => if (x = a ∧ y = b) ∨ (x = b ∧ y = a) then none else some y)
+  · intro y hy
+    simp only [Finset.mem_coe, SimpleGraph.mem_neighborFinset] at hy ⊢
+    by_cases hcase : (x = a ∧ y = b) ∨ (x = b ∧ y = a)
+    · rw [if_pos hcase]
+      rcases hcase with ⟨hxa, _⟩ | ⟨hxb, _⟩
+      · rw [surgery_adj_some_none]; exact Or.inl hxa
+      · rw [surgery_adj_some_none]; exact Or.inr (Or.inl hxb)
+    · rw [if_neg hcase]
+      rw [surgery_adj_some_some]
+      exact ⟨hy, fun h => hcase (Or.inl h), fun h => hcase (Or.inr h)⟩
+  · intro y₁ h₁ y₂ h₂ heq
+    simp only [] at heq
+    by_cases hc₁ : (x = a ∧ y₁ = b) ∨ (x = b ∧ y₁ = a) <;>
+      by_cases hc₂ : (x = a ∧ y₂ = b) ∨ (x = b ∧ y₂ = a)
+    · rcases hc₁ with ⟨hxa, hy₁⟩ | ⟨hxb, hy₁⟩ <;>
+        rcases hc₂ with ⟨hxa₂, hy₂⟩ | ⟨hxb₂, hy₂⟩
+      · rw [hy₁, hy₂]
+      · exact absurd (hxa ▸ hxb₂ : a = b) hne
+      · exact absurd (hxa₂ ▸ hxb : a = b) hne
+      · rw [hy₁, hy₂]
+    · rw [if_pos hc₁, if_neg hc₂] at heq
+      exact absurd heq (by simp)
+    · rw [if_neg hc₁, if_pos hc₂] at heq
+      exact absurd heq (by simp)
+    · rw [if_neg hc₁, if_neg hc₂] at heq
+      exact Option.some.inj heq
+
+/-- **The new vertex has degree at least `3`**: `a`, `b`, `c` are three
+distinct neighbours. -/
+theorem surgery_degree_none {G : SimpleGraph V} [DecidableRel G.Adj] {a b c : V}
+    (hab : a ≠ b) (hac : a ≠ c) (hbc : b ≠ c) :
+    3 ≤ (surgery G a b c).degree none := by
+  rw [← SimpleGraph.card_neighborFinset_eq_degree]
+  have hsub : ({some a, some b, some c} : Finset (Option V)) ⊆
+      (surgery G a b c).neighborFinset none := by
+    intro w hw
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hw
+    rw [SimpleGraph.mem_neighborFinset]
+    rcases hw with rfl | rfl | rfl
+    · rw [surgery_adj_none_some]; exact Or.inl rfl
+    · rw [surgery_adj_none_some]; exact Or.inr (Or.inl rfl)
+    · rw [surgery_adj_none_some]; exact Or.inr (Or.inr rfl)
+  calc 3 = ({some a, some b, some c} : Finset (Option V)).card := by
+        rw [Finset.card_insert_of_notMem (by simp [hab, hac]),
+            Finset.card_insert_of_notMem (by simp [hbc]), Finset.card_singleton]
+    _ ≤ _ := Finset.card_le_card hsub
+
+/-- **The surgery preserves the common-neighbour bound.**  If in `G` every pair
+of distinct vertices has at most one common neighbour, the edges `ab` and `bc`
+lie in no triangle, and `a ≁ c`, then every pair of distinct vertices of the
+surgered graph again has at most one common neighbour — so the result stays
+`C₄`-free. -/
+theorem surgery_common_le_one {G : SimpleGraph V} [DecidableRel G.Adj] {a b c : V}
+    (hab : G.Adj a b) (hbc : G.Adj b c) (hac : ¬ G.Adj a c) (hane : a ≠ c)
+    (htriab : ∀ z, G.Adj a z → G.Adj b z → False)
+    (htribc : ∀ z, G.Adj b z → G.Adj c z → False)
+    (hcom : ∀ x y : V, x ≠ y →
+      (G.neighborFinset x ∩ G.neighborFinset y).card ≤ 1) :
+    ∀ p q : Option V, p ≠ q →
+      ((surgery G a b c).neighborFinset p ∩ (surgery G a b c).neighborFinset q).card ≤ 1 := by
+  -- the common-neighbour bound of `G`, in element form
+  have hcom' : ∀ x y z₁ z₂ : V, x ≠ y → G.Adj x z₁ → G.Adj y z₁ →
+      G.Adj x z₂ → G.Adj y z₂ → z₁ = z₂ := by
+    intro x y z₁ z₂ hxy h1 h2 h3 h4
+    refine Finset.card_le_one.mp (hcom x y hxy) z₁ ?_ z₂ ?_
+    · rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset,
+        SimpleGraph.mem_neighborFinset]
+      exact ⟨h1, h2⟩
+    · rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset,
+        SimpleGraph.mem_neighborFinset]
+      exact ⟨h3, h4⟩
+  -- `b` is the unique common neighbour of the non-adjacent pair `(a, c)`
+  have huniq : ∀ z, G.Adj a z → G.Adj c z → z = b := fun z h1 h2 =>
+    hcom' a c z b hane h1 h2 hab hbc.symm
+  -- a common neighbour of a `some`-`some` pair inside `{a, b, c}` is impossible
+  have hkey : ∀ x y z : V, (x = a ∨ x = b ∨ x = c) → (y = a ∨ y = b ∨ y = c) →
+      x ≠ y → (surgery G a b c).Adj (some x) (some z) →
+      (surgery G a b c).Adj (some y) (some z) → False := by
+    intro x y z hx hy hxy hxz hyz
+    rw [surgery_adj_some_some] at hxz hyz
+    rcases hx with rfl | rfl | rfl <;> rcases hy with rfl | rfl | rfl
+    · exact hxy rfl
+    · exact htriab z hxz.1 hyz.1
+    · -- x = a, y = c: z is a common neighbour of (a, c), so z = b; but the
+      -- surgered adjacency `some a ~ some z` forbids z = b (deleted edge)
+      exact hxz.2.1 ⟨rfl, huniq z hxz.1 hyz.1⟩
+    · exact htriab z hyz.1 hxz.1
+    · exact hxy rfl
+    · exact htribc z hxz.1 hyz.1
+    · exact hyz.2.1 ⟨rfl, huniq z hyz.1 hxz.1⟩
+    · exact htribc z hyz.1 hxz.1
+    · exact hxy rfl
+  intro p q hpq
+  rw [Finset.card_le_one]
+  intro w₁ hw₁ w₂ hw₂
+  rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset,
+    SimpleGraph.mem_neighborFinset] at hw₁ hw₂
+  obtain ⟨hw₁p, hw₁q⟩ := hw₁
+  obtain ⟨hw₂p, hw₂q⟩ := hw₂
+  rcases p with _ | x <;> rcases q with _ | y
+  · exact absurd rfl hpq
+  · -- p = none, q = some y: all common neighbours are `some z` with
+    -- z ∈ {a, b, c} and z ~ y; two distinct such z collide via `hkey`
+    rcases w₁ with _ | z₁
+    · exact (surgery_adj_none_none hw₁p).elim
+    rcases w₂ with _ | z₂
+    · exact (surgery_adj_none_none hw₂p).elim
+    by_contra hne12
+    have hz₁ : z₁ = a ∨ z₁ = b ∨ z₁ = c := by rwa [surgery_adj_none_some] at hw₁p
+    have hz₂ : z₂ = a ∨ z₂ = b ∨ z₂ = c := by rwa [surgery_adj_none_some] at hw₂p
+    exact hkey z₁ z₂ y hz₁ hz₂ (fun h => hne12 (congrArg some h))
+      hw₁q.symm hw₂q.symm
+  · -- p = some x, q = none: mirror of the previous case
+    rcases w₁ with _ | z₁
+    · exact (surgery_adj_none_none hw₁q).elim
+    rcases w₂ with _ | z₂
+    · exact (surgery_adj_none_none hw₂q).elim
+    by_contra hne12
+    have hz₁ : z₁ = a ∨ z₁ = b ∨ z₁ = c := by rwa [surgery_adj_none_some] at hw₁q
+    have hz₂ : z₂ = a ∨ z₂ = b ∨ z₂ = c := by rwa [surgery_adj_none_some] at hw₂q
+    exact hkey z₁ z₂ x hz₁ hz₂ (fun h => hne12 (congrArg some h))
+      hw₁p.symm hw₂p.symm
+  · -- p = some x, q = some y
+    have hxy : x ≠ y := fun h => hpq (by rw [h])
+    rcases w₁ with _ | z₁ <;> rcases w₂ with _ | z₂
+    · rfl
+    · -- w₁ = none: x, y ∈ {a, b, c}, and z₂ is a `some` common neighbour
+      have hx : x = a ∨ x = b ∨ x = c := by rwa [surgery_adj_some_none] at hw₁p
+      have hy : y = a ∨ y = b ∨ y = c := by rwa [surgery_adj_some_none] at hw₁q
+      exact (hkey x y z₂ hx hy hxy hw₂p hw₂q).elim
+    · have hx : x = a ∨ x = b ∨ x = c := by rwa [surgery_adj_some_none] at hw₂p
+      have hy : y = a ∨ y = b ∨ y = c := by rwa [surgery_adj_some_none] at hw₂q
+      exact (hkey x y z₁ hx hy hxy hw₁p hw₁q).elim
+    · rw [surgery_adj_some_some] at hw₁p hw₁q hw₂p hw₂q
+      exact congrArg some (hcom' x y z₁ z₂ hxy hw₁p.1 hw₁q.1 hw₂p.1 hw₂q.1)
+
+end Surgery
+
+/-! ## Reusable lower-bound assembly, transport to `Fin (n+1)`, and `f(13) ≥ 4` -/
+
+/-- **Generic witness-to-lower-bound assembly**: a `C₄`-free graph of minimum
+degree `≥ 3` on `Fin n` (with `n ≥ 4`) forces `f(n) ≥ 4`.  Extracts the
+`sInf` argument used verbatim for `f(10)`, `f(11)`, `f(12)`. -/
+theorem four_le_minDegreeForC4_of_witness {n : ℕ} (hn : 4 ≤ n)
+    (G : SimpleGraph (Fin n)) [DecidableRel G.Adj]
+    (hdeg : 3 ≤ G.minDegree) (hC4 : ¬ containsC4 (Fin n) G) :
+    4 ≤ minDegreeForC4 n := by
+  have hne : {k : ℕ | ∀ (H : SimpleGraph (Fin n)) [DecidableRel H.Adj],
+      H.minDegree ≥ k → containsC4 (Fin n) H}.Nonempty := by
+    refine ⟨n - 1, fun H _ hmin => ?_⟩
+    rw [eq_top_of_minDegree_ge H hmin]
+    exact completeGraph_containsC4 hn
+  unfold minDegreeForC4
+  refine le_csInf hne (fun k hk => ?_)
+  by_contra hk4
+  rw [not_le] at hk4
+  exact hC4 (hk G (le_trans (by omega : k ≤ 3) hdeg))
+
+/-- The surgered graph, transported from `Option (Fin n)` to `Fin (n + 1)`
+along `finSuccEquiv`. -/
+def surgeryFin {n : ℕ} (G : SimpleGraph (Fin n)) (a b c : Fin n) :
+    SimpleGraph (Fin (n + 1)) :=
+  SimpleGraph.comap (⇑(finSuccEquiv n)) (surgery G a b c)
+
+instance surgeryFinDecidableRel {n : ℕ} (G : SimpleGraph (Fin n))
+    [DecidableRel G.Adj] (a b c : Fin n) :
+    DecidableRel (surgeryFin G a b c).Adj := fun u v =>
+  inferInstanceAs
+    (Decidable ((surgery G a b c).Adj (finSuccEquiv n u) (finSuccEquiv n v)))
+
+/-- Degrees only grow under the `finSuccEquiv` transport (they are in fact
+equal; the inequality is all that is needed). -/
+theorem surgeryFin_degree_ge {n : ℕ} (G : SimpleGraph (Fin n))
+    [DecidableRel G.Adj] (a b c : Fin n) (u : Fin (n + 1)) :
+    (surgery G a b c).degree (finSuccEquiv n u) ≤ (surgeryFin G a b c).degree u := by
+  rw [← SimpleGraph.card_neighborFinset_eq_degree,
+      ← SimpleGraph.card_neighborFinset_eq_degree]
+  apply Finset.card_le_card_of_injOn (fun w => (finSuccEquiv n).symm w)
+  · intro w hw
+    simp only [Finset.mem_coe, SimpleGraph.mem_neighborFinset] at hw ⊢
+    show (surgery G a b c).Adj (finSuccEquiv n u)
+      (finSuccEquiv n ((finSuccEquiv n).symm w))
+    rw [Equiv.apply_symm_apply]
+    exact hw
+  · intro w₁ _ w₂ _ h
+    exact (finSuccEquiv n).symm.injective h
+
+/-- `C₄`-freeness transports along the `finSuccEquiv` pullback. -/
+theorem surgeryFin_not_containsC4 {n : ℕ} (G : SimpleGraph (Fin n))
+    (a b c : Fin n) (h : ¬ containsC4 (Option (Fin n)) (surgery G a b c)) :
+    ¬ containsC4 (Fin (n + 1)) (surgeryFin G a b c) := by
+  rintro ⟨f, hinj, hadj⟩
+  exact h ⟨fun i => finSuccEquiv n (f i), (finSuccEquiv n).injective.comp hinj,
+    fun i j hij => hadj i j hij⟩
+
+/-- **`f(13) ≥ 4`** — the first rung beyond the counting range, via the
+abstract surgery applied to `petersen12` with the configuration
+`a = 4, b = 9, c = 7`: the edges `4–9` (spoke) and `9–7` (inner) are
+triangle-free, `4 ≁ 7`, and all remaining hypotheses are `12`-vertex kernel
+checks.  No `13`-vertex graph is ever `decide`d — the surgery lemmas carry
+the verification. -/
+theorem four_le_minDegreeForC4_thirteen : 4 ≤ minDegreeForC4 13 := by
+  have hab : petersen12.Adj 4 9 := by decide
+  have hbc : petersen12.Adj 9 7 := by decide
+  have hac : ¬ petersen12.Adj 4 7 := by decide
+  have hane : (4 : Fin 12) ≠ 7 := by decide
+  have htriab : ∀ z, petersen12.Adj 4 z → petersen12.Adj 9 z → False := by decide
+  have htribc : ∀ z, petersen12.Adj 9 z → petersen12.Adj 7 z → False := by decide
+  have hcommon := surgery_common_le_one hab hbc hac hane htriab htribc
+    petersen12_common_le_one
+  have hC4 : ¬ containsC4 (Fin 13) (surgeryFin petersen12 4 9 7) :=
+    surgeryFin_not_containsC4 petersen12 4 9 7
+      (not_containsC4_of_forall_common_le_one hcommon)
+  have hdeg : 3 ≤ (surgeryFin petersen12 4 9 7).minDegree := by
+    apply SimpleGraph.le_minDegree_of_forall_le_degree
+    intro u
+    refine le_trans ?_ (surgeryFin_degree_ge petersen12 4 9 7 u)
+    rcases h : finSuccEquiv 12 u with _ | x
+    · exact surgery_degree_none (by decide) (by decide) (by decide)
+    · exact le_trans (petersen12_degree x)
+        (surgery_degree_some (by decide) x)
+  exact four_le_minDegreeForC4_of_witness (by norm_num)
+    (surgeryFin petersen12 4 9 7) hdeg hC4
+
+/-- **`f(13) ∈ {4, 5}`**: the lower bound is the surgery witness; the upper
+bound is the counting bound at `k = 5` (`13 ≤ 5·4`).  Pinning `f(13) = 4`
+needs an upper-bound mechanism beyond the cherry count (the true value is `4`
+in the literature) — the honest remaining gap. -/
+theorem minDegreeForC4_thirteen_mem :
+    minDegreeForC4 13 = 4 ∨ minDegreeForC4 13 = 5 := by
+  have hle : minDegreeForC4 13 ≤ 5 :=
+    minDegreeForC4_le_of_le_mul_pred (by norm_num) (by norm_num)
+  have hge := four_le_minDegreeForC4_thirteen
+  omega
+
 end Erdos85

--- a/research/problems/erdos-85-wip-01/knowledge.md
+++ b/research/problems/erdos-85-wip-01/knowledge.md
@@ -558,3 +558,47 @@ common-neighbour-matrix kernel check via `not_containsC4_of_forall_common_le_one
   candidate general lemma; formalizing the general induction is real work
   (the decide route only does fixed n).
 - Deep: KST asymptotics, monotonicity core f(n+1) ≥ f(n) (the actual #85).
+
+## Session 2026-07-23 (researcher-1) — ABSTRACT SURGERY LEMMA + f(13) ≥ 4 (draft, verify below)
+
+**Target**: the "general induction is real work" item — formalize the vertex-adding
+surgery ABSTRACTLY so future rungs need only a small config check, not a fresh
+whole-graph decide. Applied to petersen12 (config a=4, b=9, c=7) for f(13) ≥ 4 —
+the first rung beyond the counting range (C(13,2) = 78 = 13·6 kills the cherry
+bound at k=4), so f(13) ∈ {4,5} is the honest endpoint (upper f(13) ≤ 4 blocked).
+
+**Key mathematical discovery (correcting the recorded surgery note)**: the
+2026-07-22f session's surgery justification implicitly used girth 5 ("(a,b),(b,c)
+were adjacent (0 common nbrs, girth 5)"). For general C₄-free G (which may have
+triangles!) the correct hypothesis set is:
+  a~b, b~c, a≁c, a≠c, AND edges ab, bc each in NO triangle
+  (common(a,b) = common(b,c) = ∅ in element form: ∀z, ¬(z~a ∧ z~b) etc.)
+common(a,c) = {b} is then AUTOMATIC (b is common; C₄-free caps at 1). The
+preservation proof: common nbrs of a some-some pair inside {a,b,c} are impossible
+(pairs (a,b),(b,c): triangle-freeness; pair (a,c): unique common = b, but the
+DELETED edge a–b means b is no longer adjacent to a — the ¬(x=a∧y=b) conjunct);
+new-vertex pairs reduce to the same key lemma.
+
+### Architecture (in Erdos85Problem.lean, section Surgery)
+- `surgery G a b c : SimpleGraph (Option V)` — some-some = G minus edge ab;
+  none ~ {a,b,c}. Match-defined Adj + Iff.rfl simp lemmas + DecidableRel.
+- Degree lower bounds WITHOUT Finset algebra: uniform injection
+  y ↦ if (x=a∧y=b)∨(x=b∧y=a) then none else some y from old nbhd(x) into new
+  nbhd(some x) (`card_le_card_of_injOn`); new vertex: {some a, some b, some c} ⊆ nbhd.
+- `surgery_common_le_one` — via `Finset.card_le_one` element form; single `hkey`
+  lemma dispatches all 9 {a,b,c}×{a,b,c} cases; both none-involving pair shapes
+  reduce to hkey.
+- `four_le_minDegreeForC4_of_witness` — generic sInf assembly extracted (was
+  inlined 3×), n−1 nonemptiness element.
+- `surgeryFin` = comap along `finSuccEquiv n` (Fin (n+1) ≃ Option (Fin n));
+  degree via symm-injection, containsC4 pullback by composing the embedding.
+- f(13) facts all 12-vertex decides (adjacencies, ≠, two ∀z triangle-freeness
+  checks) — NO 13-vertex decide anywhere.
+
+### Remaining
+- General ∀ n ≥ 10 induction needs CONFIG EXISTENCE in the iterated witnesses
+  (an edge pair ab, bc both triangle-free with a≁c) — not automatic in arbitrary
+  C₄-free min-deg-3 graphs (friendship-type obstructions); route: maintain an
+  invariant or use disjoint unions (base cases 10..19 + G ⊕ Petersen step).
+- Upper halves beyond n = 12 (f(13) ≤ 4) need real ex(n;C₄) input — blocked.
+- Deep: KST asymptotics, monotonicity core (the actual #85) OPEN.

--- a/research/problems/erdos-85-wip-01/state.md
+++ b/research/problems/erdos-85-wip-01/state.md
@@ -23,3 +23,26 @@ None.
 ## Next Action
 Read problem.md thoroughly and acquire full context.
 Then move to ORIENT phase to explore literature and related proofs.
+
+## Status (researcher-1, 2026-07-23) — abstract surgery engine + f(13) ≥ 4
+
+(The template header above predates the real work — see knowledge.md for the full
+session history; the exact table f(1..12) is complete on main.)
+
+This session: the vertex-adding surgery is now an ABSTRACT lemma set in
+`Erdos85Problem.lean` (section Surgery): `surgery G a b c : SimpleGraph (Option V)`
+with degree preservation, common-neighbour ≤ 1 preservation (hypotheses: a~b, b~c,
+a≁c, a≠c, edges ab/bc triangle-free), generic `four_le_minDegreeForC4_of_witness`,
+and `finSuccEquiv` transport. Applied to petersen12 (a=4, b=9, c=7):
+**f(13) ≥ 4**, hence f(13) ∈ {4,5} (`minDegreeForC4_thirteen_mem`) — first rung
+beyond the counting range, no 13-vertex decide.
+
+## Blockers
+- Upper bound f(13) ≤ 4 (and beyond n=12 generally): needs real ex(n;C₄)
+  edge-extremal input; cherry count provably stuck. Reopen: formalize a
+  Reiman-type bound.
+- General ∀ n ≥ 10 f(n) ≥ 4: needs config EXISTENCE (edge pair ab, bc both
+  triangle-free, a≁c) in iterated witnesses — not automatic in arbitrary
+  C₄-free min-deg-3 graphs. Reopen: invariant-maintaining induction or
+  disjoint-union route (needs base cases 13..19 + graph-sum infrastructure).
+- Deep: KST asymptotics; monotonicity core (the actual Erdős #85) OPEN.

--- a/src/data/research/problems/erdos-85-wip-01.json
+++ b/src/data/research/problems/erdos-85-wip-01.json
@@ -18,10 +18,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ORIENT",
+    "phase": "ACT",
     "since": "2026-07-09T17:33:20-07:00",
-    "iteration": 6,
-    "focus": "f(8)=3 PROVED (2026-07-22, local triangle-partition argument) — the recorded 'f(8) needs ex(8;C4)=11' blocker was WRONG: min-deg-3 on 8 vertices reduces to the 3-regular case (cherry count + handshake parity kill any degree-4+ vertex), and a 3-regular C4-free graph on 8 vertices is impossible purely locally (every vertex lies in a unique triangle => triangles partition 8 vertices into 3-sets, 3∤8). Exact table complete 1<=n<=8: f = 1,2,3,2,3,3,3,3. Remaining routes (f(9), f(10)=4 Petersen, odd-s Beatty, monotonicity core) are deep; blockers updated.",
+    "iteration": 7,
+    "focus": "2026-07-23: ABSTRACT vertex-adding surgery formalized (section Surgery in Erdos85Problem.lean) — general lemma set replacing per-n whole-graph decides: surgery G a b c on Option V, degree preservation via uniform injection, common-neighbour <= 1 preservation (hypotheses: a~b, b~c, a-not-c, edges ab/bc triangle-free — corrects the girth-5-implicit note), generic four_le_minDegreeForC4_of_witness, finSuccEquiv comap transport. Applied to petersen12 (a=4,b=9,c=7): f(13) >= 4, so f(13) in {4,5} — first rung beyond the counting range. No 13-vertex decide anywhere.",
     "blockers": [
       {
         "route": "RESOLVED 2026-07-22 (was: f(7)=3, then f(8)=3): handshake-parity boost proved f(7)=3; a LOCAL triangle-partition argument (no ex(n;C4) input) proved f(8)=3. Residual blocked part: upper-Beatty points beyond j=1 (n = s^2+s+j, j>=2), odd-s points, and f(9) still need ex(n;C4)-strength input.",
@@ -49,7 +49,7 @@
         "blockedAt": "2026-07-22"
       }
     ],
-    "nextAction": "STAND DOWN on elementary work. Reopen only per a blocker reopenCriterion: an ex(n;C4) edge bound (unlocks f(9)), a decide-free Petersen (f(10)=4), a dense C4-free family (KST lower bound), or the open monotonicity core. Note: the triangle-partition trick is 8-specific. At n=9 the cherry count is silent (9*C(3,2)=27 < 36=C(9,2)) so it cannot reduce min-deg 3 to a regular case; pinning f(9) in {3,4} needs either a C4-free min-deg-3 graph on 9 vertices (would give f(9)>=4) or an ex(9;C4)-strength edge bound.",
+    "nextAction": "Optional: chain surgery for f(14..19) lower rungs (config per step, cheap decides); general all-n>=10 theorem needs config-EXISTENCE argument (blocked route: not automatic in arbitrary C4-free graphs). Upper halves beyond n=12 need real ex(n;C4) input (blocked). Deep: KST asymptotics, monotonicity core.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -57,7 +57,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "MAJOR PROGRESS (researcher-1, 2026-07-22f, host-verified, standard triple): f(11) = 4 AND f(12) = 4 PROVED axiom-free via vertex-adding surgery on the Petersen graph (delete edge a-b, add v ~ {a,b,c}) — exact table COMPLETE for 1 <= n <= 12: f = 1,2,3,2,3,3,3,3,3,4,4,4, the full range the elementary cherry count reaches (12 = 4*3 is the boundary case). Remaining: f(13) upper bound needs new mechanism (counting gives only <= 5); general f(n) >= 4 for n >= 10 via iterated surgery; deep KST asymptotics, monotonicity core.",
+    "progressSummary": "PROGRESS: exact table 1..12 complete (f = 1,2,3,2,3,3,3,3,3,4,4,4) + f(13) in {4,5} via the NEW abstract surgery engine (2026-07-23): the vertex-adding surgery is now a general lemma (delete edge ab, add v~{a,b,c}; needs ab, bc triangle-free, a-not-c) with degree and common-neighbour preservation proved abstractly, plus generic witness assembly and finSuccEquiv transport. Future lower rungs reduce to config checks. Blocked: upper bounds beyond n=12 (need ex(n;C4)), general all-n config existence. Deep: KST asymptotics, monotonicity (the actual #85).",
     "builtItems": [
       "C4_adj_zero_one/one_two/two_three/three_zero (four cycle edges) in Erdos85Problem.lean",
       "C4_not_adj_zero_two (diagonal non-edge) in Erdos85Problem.lean",
@@ -99,7 +99,11 @@
       "petersen (explicit edge-list) + petersen_degree + petersen_common_le_one in Erdos85Problem.lean",
       "exists_two_common_of_containsC4 + not_containsC4_of_forall_common_le_one (reusable C4-freeness criterion) in Erdos85Problem.lean",
       "petersen11/petersen11Edges + degree/common-neighbour kernel checks + four_le_minDegreeForC4_eleven + minDegreeForC4_eleven (f(11)=4) in Erdos85Problem.lean",
-      "petersen12/petersen12Edges + degree/common-neighbour kernel checks + four_le_minDegreeForC4_twelve + minDegreeForC4_twelve (f(12)=4) in Erdos85Problem.lean"
+      "petersen12/petersen12Edges + degree/common-neighbour kernel checks + four_le_minDegreeForC4_twelve + minDegreeForC4_twelve (f(12)=4) in Erdos85Problem.lean",
+      "surgery/surgeryAdj + simp lemmas + DecidableRel (Erdos85Problem.lean section Surgery)",
+      "surgery_degree_some, surgery_degree_none, surgery_common_le_one (the abstract engine)",
+      "four_le_minDegreeForC4_of_witness (generic sInf assembly), surgeryFin + degree/C4 transport along finSuccEquiv",
+      "four_le_minDegreeForC4_thirteen, minDegreeForC4_thirteen_mem (f(13) in {4,5})"
     ],
     "insights": [
       "Erdos85Problem.lean was a definitions-only stub (7 defs, 0 theorems). Asymptotics f(n)=(1+o(1))sqrt(n), f(4)=2, and the Ramsey reformulation need extremal graph theory beyond Mathlib; tractable axiom-free content is structural facts about C4, containsC4, and starGraph.",
@@ -134,7 +138,11 @@
       "Both registered exact-value blockers on this problem fell in one day (f(9) via elementary pinch+pigeonhole, f(10) via common-neighbour extraction) — extremal-table and enumeration fears repeatedly overestimate the difficulty",
       "Vertex-adding surgery preserves C4-freeness + min degree 3: DELETE edge a-b, ADD vertex v ~ {a,b,c} with c a neighbour of b. The unique (a,c) common neighbour was exactly b (deleted as v arrives); outside vertices adjacent to two of {a,b,c} would have been a second common neighbour beforehand. Beats the parity obstruction (no 3-regular girth-5 graph at odd order).",
       "Counting range boundary: n <= k(k-1) with k=4 holds iff n <= 12; C(13,2) = 78 = 13*6 fails strictly, so f(13) <= 4 needs genuinely new upper-bound input (edge-extremal ex(n;C4) bound).",
-      "Surgery iterates: every n >= 10 admits a min-deg-3 C4-free graph, so f(n) >= 4 for all n >= 10 is a candidate general lemma (induction is real work; decide route only covers fixed n)."
+      "Surgery iterates: every n >= 10 admits a min-deg-3 C4-free graph, so f(n) >= 4 for all n >= 10 is a candidate general lemma (induction is real work; decide route only covers fixed n).",
+      "The correct abstract surgery hypotheses are NOT girth-5: a~b, b~c, a-not-adjacent-c, a != c, plus edges ab and bc each in no triangle. common(a,c) = {b} is automatic (C4-freeness caps at 1). The deleted a-b edge is what kills the second common neighbour of (a,c) in the surgered graph",
+      "Degree preservation without Finset algebra: the uniform map y -> if (x=a and y=b) or (x=b and y=a) then none else some y injects old neighbourhoods into new ones — one lemma covers a, b, and untouched vertices simultaneously",
+      "Set.MapsTo goals from Finset.card_le_card_of_injOn carry Set-coerced Finset membership: simp only [Finset.mem_coe, SimpleGraph.mem_neighborFinset] before adjacency reasoning",
+      "f(13) is the first n where the lower bound comes from a transported abstract construction rather than a fixed-n kernel decide — the surgery engine makes every future rung a small config check"
     ],
     "mathlibGaps": [
       "Fin n has NO global CommRing instance (only scoped Fin.instCommRing via `open Fin.CommRing`, gated on NeZero n); needed for ring/linear_combination on cycleGraph differences"


### PR DESCRIPTION
## Summary

Research session on **erdos-85-wip-01** (Erdős #85, minimum degree forcing C₄).

The vertex-adding surgery used for f(11)/f(12) (PR #42158) is now an **abstract lemma set** (`section Surgery` in `Erdos85Problem.lean`), replacing per-n whole-graph kernel decides. Applied to `petersen12` it gives **f(13) ≥ 4**, hence **f(13) ∈ {4, 5}** — the first rung beyond the counting range (C(13,2) = 78 = 13·6 kills the cherry bound at k = 4).

### The abstract engine (new, all axiom-free / sorry-free)

- `surgery G a b c : SimpleGraph (Option V)` — delete edge `a–b`, add a new vertex adjacent to `{a, b, c}`; match-defined `Adj` + simp lemmas + `DecidableRel`.
- `surgery_degree_some` / `surgery_degree_none` — degree preservation via a single uniform injection (no Finset algebra case split per vertex).
- `surgery_common_le_one` — the common-neighbour ≤ 1 bound is preserved. **Corrects the girth-5-implicit note** from the f(11)/f(12) session: the right hypotheses for general C₄-free G (which may contain triangles) are `a~b`, `b~c`, `a≁c`, `a≠c`, and edges `ab`, `bc` each triangle-free; `common(a,c) = {b}` is then automatic.
- `four_le_minDegreeForC4_of_witness` — generic witness-to-sInf assembly (was inlined 3×).
- `surgeryFin` + degree/C₄ transport along `finSuccEquiv n : Fin (n+1) ≃ Option (Fin n)`.

### The new rung

- `four_le_minDegreeForC4_thirteen : 4 ≤ minDegreeForC4 13` — config `a=4, b=9, c=7` on `petersen12`; all decides are 12-vertex (adjacency, `≠`, two `∀ z` triangle-freeness checks). **No 13-vertex decide anywhere.**
- `minDegreeForC4_thirteen_mem : minDegreeForC4 13 = 4 ∨ minDegreeForC4 13 = 5` — upper half is the counting bound at k = 5; pinning f(13) = 4 needs an ex(n;C₄)-strength edge bound (disclosed as the honest remaining gap).

Exact table now: f(1..12) = 1,2,3,2,3,3,3,3,3,4,4,4 (complete, on main) + f(13) ∈ {4,5}.

### Honest accounting

- 0 sorries, 0 axioms, 0 native_decide in the new code (kernel `decide` on 12-vertex facts only).
- Built via `./proofs/scripts/docker-build.sh Proofs.Erdos85Problem`.
- Remaining blockers recorded in state.md/knowledge.md: upper bounds beyond n = 12 need real ex(n;C₄) input; general ∀ n ≥ 10 lower bound needs a config-existence argument (not automatic in arbitrary C₄-free min-deg-3 graphs); deep KST asymptotics and the monotonicity core (the actual #85) remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
