### PR TITLE
Enrich abel-ruffini-oq-03: extend final section/annotation to cover full file

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-03/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-03/annotations.json
@@ -99,7 +99,7 @@
     "proofId": "abel-ruffini-oq-03",
     "range": {
       "startLine": 111,
-      "endLine": 131
+      "endLine": 146
     },
     "type": "concept",
     "title": "What is left to reach an arbitrary abelian group",

--- a/src/data/proofs/abel-ruffini-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-03/meta.json
@@ -102,8 +102,8 @@
       "id": "target",
       "title": "Section IV — the full Kronecker–Weber target (not verified)",
       "startLine": 111,
-      "endLine": 131,
-      "summary": "A docstring recording the full abelian realization target and the two classical inputs (Dirichlet's theorem; the Galois correspondence descent to a quotient) needed to upgrade the verified family (ZMod n)ˣ to an arbitrary finite abelian group. Not asserted."
+      "endLine": 146,
+      "summary": "A docstring recording the full abelian realization target and the two classical inputs (Dirichlet's theorem; the Galois correspondence descent to a quotient) needed to upgrade the verified family (ZMod n)ˣ to an arbitrary finite abelian group, closing with the literal (unasserted) statement of kroneckerWeber_realization_target. Not asserted — no theorem or axiom with this name exists in the file."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for abel-ruffini-oq-03 (quality 96, 0 prior passes).

The file is 148 lines, but the last `sections` entry and the last `annotations.json` entry both stopped at `endLine: 131`, leaving lines 132-146 — the docstring naming the two classical inputs (Dirichlet's theorem, the Galois-correspondence descent) and the literal statement of the unasserted `kroneckerWeber_realization_target` — with no coverage at all.

The annotation's *content* already accurately describes that material (it was written correctly, just under-ranged), so this is a pure range fix: both endpoints extended from 131 to 146, plus a one-line addition to the section summary clarifying that `kroneckerWeber_realization_target` is not an actual theorem/axiom in the file (it's a stated-for-reference target).

No changes to Lean source, axiom/sorry counts, or status/badge — file remains 0 axioms, 0 sorries, verified.