### PR TITLE
Enrich mathematical-induction-oq-01-oq-01: split sections to 5, cover full file (4->5)

### DIFF
--- a/src/data/proofs/mathematical-induction-oq-01-oq-01/meta.json
+++ b/src/data/proofs/mathematical-induction-oq-01-oq-01/meta.json
@@ -111,12 +111,20 @@
       "mathContext": "$o \\neq 0 \\ \\Rightarrow\\ o \\bmod \\omega^{\\log_\\omega o} < o.$"
     },
     {
-      "id": "structure-and-base-case",
-      "title": "Leading Exponent and Base Case",
+      "id": "leading-exponent",
+      "title": "The Leading Exponent Bound",
       "startLine": 78,
-      "endLine": 88,
-      "summary": "cnf_exponent_le_log: every exponent is <= log omega o, so the leading exponent = log omega o (the base-omega 'degree'); cantor_normal_form_zero: CNF omega 0 = [].",
-      "mathContext": "$p \\in \\mathrm{CNF}\\,\\omega\\,o \\Rightarrow p_1 \\le \\log_\\omega o;\\qquad \\mathrm{CNF}\\,\\omega\\,0 = [\\,].$"
+      "endLine": 83,
+      "summary": "cnf_exponent_le_log: every exponent appearing in the base-omega Cantor normal form of o is <= log omega o, so the leading exponent equals log omega o — the analogue of the 'degree' of o in base omega.",
+      "mathContext": "$p \\in \\mathrm{CNF}\\,\\omega\\,o \\Rightarrow p_1 \\le \\log_\\omega o.$"
+    },
+    {
+      "id": "base-case",
+      "title": "The Base Case",
+      "startLine": 85,
+      "endLine": 90,
+      "summary": "cantor_normal_form_zero: the Cantor normal form of the zero ordinal is the empty list, CNF omega 0 = [] — the base case anchoring the transfinite recursion.",
+      "mathContext": "$\\mathrm{CNF}\\,\\omega\\,0 = [\\,].$"
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for mathematical-induction-oq-01-oq-01: the entry had 4 `sections` entries against the gallery's 5-section quality target, and the last section stopped at line 88, one short of the file's 90 lines.

Split `structure-and-base-case` (78-88, covering two unrelated theorems) into two sections at the real theorem boundary, and extended the last section to close over the trailing `end TransfiniteInduction` line:

- `leading-exponent` (78-83): `cnf_exponent_le_log`.
- `base-case` (85-90): `cantor_normal_form_zero`, extended to line 90 (was 88) for full-file coverage.

No content deleted; full file coverage (1-90) now held across 5 sections. Verified `meta.json` is valid JSON and well under the 60KB size cap.