### PR TITLE
audit(erdos-385): refresh tracker after confirming #42510 fix held

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13104,9 +13104,9 @@
       "result": "clean"
     },
     "erdos-385": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:35Z",
+      "lastAudited": "2026-07-23T20:06:13Z",
       "result": "clean"
     },
     "erdos-386": {


### PR DESCRIPTION
## Summary
- Re-audited erdos-385; tracker's `lastAudited` was stale (2026-05-04), predating the axiom-label fix merged in #42510.
- Verified `axiomCount`, `theoremCount`, `definitionCount`, and `originalContributions` all still match `proofs/Proofs/Erdos385Problem.lean` exactly (0 axioms, 0 sorries, 5 proved theorems, 7 defs).
- No new issues; refreshing the tracker so this entry stops resurfacing as the oldest unaudited target.

## Test plan
- [x] Diffed meta.json fields against `grep -nE '^\s*(axiom|theorem|def|lemma)\b|sorry'` on the Lean source — all counts match.