### PR TITLE
Enrich abel-ruffini-oq-04-oq-01-oq-02: split header section, close two annotation gaps

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/annotations.json
@@ -51,7 +51,7 @@
     "id": "ann-transitive-subgroup",
     "proofId": "abel-ruffini-oq-04-oq-01-oq-02",
     "range": {
-      "startLine": 55,
+      "startLine": 47,
       "endLine": 69
     },
     "type": "theorem",
@@ -97,7 +97,7 @@
     "id": "ann-degree-divides-order",
     "proofId": "abel-ruffini-oq-04-oq-01-oq-02",
     "range": {
-      "startLine": 85,
+      "startLine": 76,
       "endLine": 105
     },
     "type": "theorem",

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/meta.json
@@ -87,11 +87,19 @@
   },
   "sections": [
     {
-      "id": "header-setup",
-      "title": "Framing and Setup",
+      "id": "docstring",
+      "title": "Module Docstring: Framing the Open Question",
       "startLine": 1,
+      "endLine": 38,
+      "summary": "Module docstring framing the open question — generalize the concrete quintic Gal(x⁵−4x+2) ≅ S₅ (parent AbelRuffiniOQ04OQ01) and the abstract sibling lemma to the Galois-theoretic fact that supplies the transitivity hypothesis: irreducible ⟹ Gal is a transitive subgroup of S_n, with n | |Gal| in every degree.",
+      "mathContext": "$p \\text{ irreducible} \\implies \\mathrm{Gal}\\,p$ is (isomorphic to) a transitive subgroup of $S_n$, $n = \\deg p$."
+    },
+    {
+      "id": "imports-setup",
+      "title": "Imports, Opens, and the Ambient Variables",
+      "startLine": 40,
       "endLine": 45,
-      "summary": "Module docstring framing the open question — generalize the concrete quintic Gal(x⁵−4x+2) ≅ S₅ (parent AbelRuffiniOQ04OQ01) and the abstract sibling lemma to the Galois-theoretic fact that supplies the transitivity hypothesis — then `import Mathlib`, `open Polynomial Polynomial.Gal MulAction` with scoped `IntermediateField` notation, `namespace AbelRuffiniOQ04OQ01OQ02`, and the `variable {F} [Field F] (p : F[X]) (E) [Field E] [Algebra F E]` setup. The central object throughout is Mathlib's permutation representation galActionHom p E.",
+      "summary": "`import Mathlib`, `open Polynomial Polynomial.Gal MulAction` with scoped `IntermediateField` notation, `namespace AbelRuffiniOQ04OQ01OQ02`, and the `variable {F} [Field F] (p : F[X]) (E) [Field E] [Algebra F E]` setup shared by all three theorems. The central object throughout is Mathlib's permutation representation galActionHom p E.",
       "mathContext": "$\\mathrm{galActionHom}\\,p\\,E : \\mathrm{Gal}\\,p \\to \\mathrm{Perm}(\\mathrm{rootSet}\\,p\\,E).$"
     },
     {


### PR DESCRIPTION
Enrichment pass for abel-ruffini-oq-04-oq-01-oq-02 (quality 96, 0 prior passes).

Two independent fixes:

1. **Sections (4 → 5).** `annotations.json` already splits the header into the module docstring (1-38) and the imports/opens/variable setup (40-45); `sections` had them merged into one "Framing and Setup" entry. Split to match.

2. **Two docstring annotation gaps.** The annotation for `galActionHom_range_isPretransitive` started at line 55, but the theorem's docstring actually starts at line 47 — 8 lines of substantive prose (explaining the theorem is "a transitive subgroup of Sₙ" in the precise sense meant here) were uncovered. Same issue for `natDegree_dvd_card`: its annotation started at line 85, but the docstring (explaining the generalization from Mathlib's prime-degree-only lemma) starts at line 76. Extended both annotation ranges backward to include the full docstrings.

No changes to Lean source, axiom/sorry counts, or status/badge — file remains 0 axioms, 0 sorries, verified.