### PR TITLE
audit(erdos-38): mark tracker complete (issues-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13066,9 +13066,9 @@
     },
     "erdos-38": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:35Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T20:08:43Z",
+      "result": "issues-fixed"
     },
     "erdos-380": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Refreshes audit-tracker.json for erdos-38 after the phantom-axiomatize-prose fix in #42519.