### PR TITLE
Enrich mean-value-theorem-oq-02-oq-01-oq-01: split sections to 5, cover full file (4->5)

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-02-oq-01-oq-01/meta.json
@@ -156,11 +156,19 @@
       "mathContext": "Goal: $\\sum_{k\\le n} \\frac{x^k}{k!} \\to e^x$ for all $x \\in \\mathbb{R}$, completing the parent's $x>0$ result."
     },
     {
-      "id": "part1-derivs",
-      "title": "Part I: Derivatives of the Reflected Exponential",
+      "id": "part1-first-derivative",
+      "title": "Part I: The First Derivative of the Reflection",
       "startLine": 49,
+      "endLine": 64,
+      "summary": "deriv_exp_neg: the derivative of t ↦ exp(-t) is t ↦ -exp(-t), via HasDerivAt.comp with the derivative of negation.",
+      "mathContext": "$\\frac{d}{dt} e^{-t} = -e^{-t}$."
+    },
+    {
+      "id": "part1-iterated-derivative",
+      "title": "Part I: Iterated Derivatives of the Reflection",
+      "startLine": 66,
       "endLine": 78,
-      "summary": "deriv_exp_neg (deriv of exp(-t) is -exp(-t), via HasDerivAt.comp with the derivative of negation) and iteratedDeriv_exp_neg (iteratedDeriv n of exp(-t) is (-1)ⁿ exp(-t), by induction using iteratedDeriv_succ, deriv_const_mul, and deriv_exp_neg, closed by ring on the sign).",
+      "summary": "iteratedDeriv_exp_neg: iteratedDeriv n of exp(-t) is (-1)ⁿ exp(-t), by induction using iteratedDeriv_succ, deriv_const_mul, and deriv_exp_neg, closed by ring on the sign. Supplies both the Taylor coefficients at 0 and the uniform derivative bound used in Part II.",
       "mathContext": "$\\frac{d^n}{dt^n} e^{-t} = (-1)^n e^{-t}$."
     },
     {


### PR DESCRIPTION
Enrichment pass for mean-value-theorem-oq-02-oq-01-oq-01: the entry had only 4 `sections` entries against the gallery's 5-section quality target. Split `part1-derivs` (49-78, bundling two theorems) at the real theorem boundary:

- `part1-first-derivative` (49-64): `deriv_exp_neg`.
- `part1-iterated-derivative` (66-78): `iteratedDeriv_exp_neg`.

No content deleted; full file coverage (1-149) preserved across the now 5 sections. Verified `meta.json` is valid JSON and well under the 60KB size cap.