### PR TITLE
Gallery integrity: erdos-377 phantom axiomatized EGRS75 narrative

### DIFF
--- a/src/data/proofs/erdos-377/annotations.json
+++ b/src/data/proofs/erdos-377/annotations.json
@@ -146,7 +146,7 @@
     },
     "type": "concept",
     "title": "EGRS First Moment",
-    "content": "**egrs_first_moment**: (1/x)∑_{n≤x} f(n) → γ₀ as x → ∞. The Cesàro mean of f(n) converges to γ₀.",
+    "content": "This comment (not a Lean declaration) records EGRS75's first-moment result: (1/x)∑_{n≤x} f(n) → γ₀ as x → ∞. The Cesàro mean of f(n) converges to γ₀.",
     "mathContext": "This shows f(n) is 'typically' about γ₀ ≈ 0.794. But average convergence doesn't bound the maximum.",
     "significance": "key",
     "relatedConcepts": [
@@ -169,7 +169,7 @@
     },
     "type": "concept",
     "title": "EGRS Second Moment",
-    "content": "**egrs_second_moment**: (1/x)∑_{n≤x} f(n)² → γ₀² as x → ∞. The Cesàro mean of f(n)² equals the square of the first moment limit.",
+    "content": "This comment (not a Lean declaration) records EGRS75's second-moment result: (1/x)∑_{n≤x} f(n)² → γ₀² as x → ∞. The Cesàro mean of f(n)² equals the square of the first moment limit.",
     "mathContext": "Combined with the first moment, this implies Var(f) = E[f²] - E[f]² → γ₀² - γ₀² = 0. So f(n) concentrates around γ₀.",
     "significance": "key",
     "relatedConcepts": [
@@ -192,7 +192,7 @@
     },
     "type": "concept",
     "title": "Almost Everywhere Result",
-    "content": "**egrs_almost_everywhere**: For almost all n, f(n) = γ₀ + o(1). The function approaches γ₀ for 'most' integers.",
+    "content": "This comment (not a Lean declaration) records EGRS75's almost-everywhere result: for almost all n, f(n) = γ₀ + o(1). The function approaches γ₀ for 'most' integers.",
     "mathContext": "This follows from the variance → 0 argument. The cofinite filter captures 'all but finitely many' integers.",
     "significance": "key",
     "relatedConcepts": [
@@ -215,7 +215,7 @@
     },
     "type": "concept",
     "title": "EGRS Upper Bound",
-    "content": "**egrs_upper_bound**: f(n) ≤ c·log(log(n)) for some c < 1 and all large n. This improves the trivial Mertens bound.",
+    "content": "This comment (not a Lean declaration) records EGRS75's upper-bound result: f(n) ≤ c·log(log(n)) for some c < 1 and all large n. This improves the trivial Mertens bound.",
     "mathContext": "Mertens' theorem gives ∑_{p≤n} 1/p ~ log(log n), so f(n) ≤ log(log n) trivially. EGRS improved the constant to c < 1.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-377/meta.json
+++ b/src/data/proofs/erdos-377/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Graham, Ruzsa, & Straus (1975)",
     "sourceUrl": "https://erdosproblems.com/377",
     "date": "1975",
-    "status": "axiomatized",
+    "status": "open",
     "proofRepoPath": "Proofs/Erdos377Problem.lean",
     "tags": [
       "erdos",
@@ -48,12 +48,12 @@
     "originalContributions": [
       "Formal definition of the prime-sum function f(n)",
       "Statement of the open boundedness conjecture",
-      "Four EGRS75 results: first moment, second moment, almost everywhere, upper bound",
-      "Definition of the constant γ₀"
+      "Definition of the constant γ₀",
+      "Proof that the two prime sums partition the total reciprocal-prime sum (complementary_sums)"
     ],
     "axiomCount": 0,
     "lineCount": 134,
-    "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives.",
+    "assumptions": "0 axioms, 0 sorries. EGRS75's four statistical results (first/second moment, almost-everywhere, upper bound) are documented as reference comments only — not formalized as axioms, definitions, or theorems. Only sumInvPrimesNotDivCentralBinom, BoundedConjectureHolds, gamma0, sumInvPrimesDividingCentralBinom, and the theorems erdos_377/complementary_sums are actual Lean declarations.",
     "theoremCount": 2,
     "definitionCount": 4
   },
@@ -61,7 +61,7 @@
     "historicalContext": "This problem arose from studying the prime factorization of central binomial coefficients C(2n, n). The 1975 paper by Erdős, Graham, Ruzsa, and Straus (EGRS75) made significant progress on understanding the 'statistical' behavior of the prime divisibility pattern.\n\nThe central binomial C(2n, n) is highly composite — most primes p ≤ n divide it. By Kummer's theorem, p | C(2n,n) iff there's a carry when adding n + n in base p. The question asks whether the primes that 'miss' have bounded reciprocal sum.\n\nEGRS proved remarkable results about the average behavior but left the main conjecture (uniform boundedness) open. This is mentioned in Guy's 'Unsolved Problems in Number Theory' (Problem B33).",
     "problemStatement": "**Definition**: Let $f(n) = \\sum_{p \\leq n, p \\nmid \\binom{2n}{n}} \\frac{1}{p}$\n\n**Conjecture (Open)**: Is there an absolute constant $C > 0$ such that $f(n) \\leq C$ for all $n$?\n\n**Known Results (EGRS 1975)**:\n1. $\\lim_{x\\to\\infty} \\frac{1}{x}\\sum_{n\\leq x} f(n) = \\gamma_0$ where $\\gamma_0 = \\sum_{k=2}^{\\infty} \\frac{\\log k}{2^k} \\approx 0.794$\n2. $\\lim_{x\\to\\infty} \\frac{1}{x}\\sum_{n\\leq x} f(n)^2 = \\gamma_0^2$\n3. For almost all $n$: $f(n) = \\gamma_0 + o(1)$\n4. For large $n$: $f(n) \\leq c \\log\\log n$ for some $c < 1$",
     "text": "Is there an absolute constant C such that ∑_{p≤n, p∤C(2n,n)} 1/p ≤ C for all n? The main conjecture is OPEN, but EGRS75 proved f(n) averages to γ₀ = ∑log(k)/2^k and is ≤ c·log(log(n)) for c < 1.",
-    "proofStrategy": "We formalize:\n\n1. **The function f(n)**: Sum of 1/p over primes p ≤ n not dividing C(2n, n)\n\n2. **The open conjecture**: Whether f(n) is uniformly bounded\n\n3. **EGRS results as axioms**: Four theorems about average behavior:\n   - First moment: Cesàro mean → γ₀\n   - Second moment: Cesàro mean of squares → γ₀²\n   - Almost everywhere: f(n) ≈ γ₀ for almost all n\n   - Upper bound: f(n) ≤ c log(log n) for c < 1\n\n4. **The constant γ₀**: Defined as the infinite series ∑log(k)/2^k",
+    "proofStrategy": "We formalize:\n\n1. **The function f(n)**: Sum of 1/p over primes p ≤ n not dividing C(2n, n)\n\n2. **The open conjecture**: Whether f(n) is uniformly bounded\n\n3. **EGRS results as reference commentary**: Four results about average behavior are documented in doc comments only (no axiom, definition, or theorem declares them):\n   - First moment: Cesàro mean → γ₀\n   - Second moment: Cesàro mean of squares → γ₀²\n   - Almost everywhere: f(n) ≈ γ₀ for almost all n\n   - Upper bound: f(n) ≤ c log(log n) for c < 1\n\n4. **The constant γ₀**: Defined as the infinite series ∑log(k)/2^k\n\n5. **complementary_sums**: A proved theorem that the two prime sums partition ∑_{p≤n} 1/p",
     "keyInsights": [
       "**Kummer's theorem connection**: p | C(2n,n) iff adding n+n in base p produces a carry. Primes NOT dividing are those where all base-p digits of n are 'small' (< p/2).",
       "**Average vs pointwise**: EGRS showed f(n) is 'typically' about γ₀ ≈ 0.794, but the maximum could potentially be unbounded.",
@@ -101,7 +101,7 @@
       "title": "EGRS 1975 Results",
       "startLine": 63,
       "endLine": 111,
-      "summary": "Four axioms capturing the known results: first moment, second moment, almost everywhere, upper bound."
+      "summary": "Four EGRS75 results (first moment, second moment, almost everywhere, upper bound) documented as reference comments — not declared as axioms, definitions, or theorems."
     },
     {
       "id": "understanding",
@@ -112,7 +112,7 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #377 about primes not dividing central binomial coefficients. While the main boundedness conjecture remains open, EGRS75 proved remarkable statistical results: f(n) averages to γ₀ ≈ 0.794, concentrates around this value, and is bounded by c·log(log n) for c < 1.",
+    "summary": "We formalize Erdős Problem #377 about primes not dividing central binomial coefficients. While the main boundedness conjecture remains open, the literature (EGRS75, cited in comments only) reports remarkable statistical results: f(n) averages to γ₀ ≈ 0.794, concentrates around this value, and is bounded by c·log(log n) for c < 1.",
     "implications": "Understanding which primes divide C(2n,n) connects to digit patterns (Kummer's theorem), asymptotic analysis (Mertens estimates), and the rich structure of central binomials. A positive answer would confirm that 'almost all' of the prime reciprocal sum comes from dividing primes.",
     "openQuestions": [
       "Is f(n) uniformly bounded? (The main open conjecture)",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-377 (Erdős Problem #377: Primes Not Dividing Central Binomial)
**Problem**: `meta.json` narrative fields and `annotations.json` described EGRS75's
four statistical results as "axioms" / gave them fabricated Lean identifier
names, but none of them are declared anywhere in the file.

## Evidence

**meta.json claims**:
- `proofStrategy` point 3: "EGRS results as axioms: Four theorems about average behavior"
- `sections[egrs-results].summary`: "Four axioms capturing the known results: first moment, second moment, almost everywhere, upper bound"
- `originalContributions`: listed "Four EGRS75 results: first moment, second moment, almost everywhere, upper bound" as a contribution
- `status: "axiomatized"`

**annotations.json claims**: four annotations (`ann-e377-first-moment`,
`ann-e377-second-moment`, `ann-e377-ae`, `ann-e377-upper-bound`) bolded
fabricated identifier names `egrs_first_moment`, `egrs_second_moment`,
`egrs_almost_everywhere`, `egrs_upper_bound` as if they were real declarations.

**Lean file shows** (`proofs/Proofs/Erdos377Problem.lean` lines 71-95):
these four results are pure `/- ... -/` doc comments with **no** accompanying
`axiom`, `def`, or `theorem` — `grep -n "axiom"` and the identifier names all
return zero hits. `meta.axiomCount`/`leanFile.axiomCount` were already
honestly `0`, but the surrounding prose fabricated formal content around
that honest count.

## Fix

- Reworded `proofStrategy`, the `egrs-results` section summary, and
  `originalContributions` to state these results are documented as reference
  comments only, not axiomatized/formalized.
- Reworded the 4 annotation `content` fields to drop the fabricated bold
  identifier names.
- Changed `status` from `axiomatized` → `open` (matches `erdosProblemStatus`;
  nothing in the file is actually axiomatized) — same convention applied to
  erdos-50.
- Clarified `assumptions` to spell out exactly which 6 declarations are real.

No change to `axiomCount`/`theoremCount`/`definitionCount`/`sorries` — those
were already accurate.

---
Discovered during gallery integrity audit (round-robin re-serve of an
already-audited entry).