### PR TITLE
Enrich mersenne-prime-exponent: add header section, cover full file (4->5)

### DIFF
--- a/src/data/proofs/mersenne-prime-exponent/meta.json
+++ b/src/data/proofs/mersenne-prime-exponent/meta.json
@@ -56,6 +56,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header, Imports, and the Open Question",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Module docstring states the classical necessary condition on Mersenne primes — if 2^n − 1 is prime then n is prime — and previews the contrapositive proof: n ≥ 2, a composite n has a proper divisor d lifting to a proper Mersenne divisor 2^d − 1, contradicting primality via the two escape hatches closed by injectivity of d ↦ 2^d. Notes the converse is false (2¹¹ − 1 = 2047 = 23·89). Imports GeomSum and Nat.Prime.Basic, opens the MersennePrimeExponent namespace.",
+      "mathContext": "$\\mathrm{Prime}(2^n-1) \\Rightarrow \\mathrm{Prime}(n)$; necessary but not sufficient (the converse fails at $n=11$)."
+    },
+    {
       "id": "exponent-at-least-two",
       "title": "A prime Mersenne number forces n ≥ 2",
       "startLine": 55,


### PR DESCRIPTION
Enrichment pass for mersenne-prime-exponent: the entry had 4 `sections` entries against the gallery's 5-section quality target, and lines 1-54 (the module docstring, imports, and namespace) had no section coverage at all.

Added a `header` section (1-54) previewing the classical result and the contrapositive proof sketch, matching the existing 4 theorem-boundary sections.

No content deleted; full file coverage (1-89 of 91) now held across 5 sections. Verified `meta.json` is valid JSON and well under the 60KB size cap.