### PR TITLE
Research (szemeredi-oq-04 S21): recursive chain construction from a maintained oracle (0-axiom)

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04Chain.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Chain.lean
@@ -1,0 +1,310 @@
+/-
+  Szemerédi Regularity Lemma — OQ-04: the recursive chain construction (S21).
+
+  The outer AFKS loop (`exists_afksTwoLevel_of_dichotomy_both`, S19) consumes a
+  *chain* `parts : ℕ → Finset (Finset V)` given in advance, and the single-step
+  realization (`exists_witnessed_next_of_not_afksFineRegular`, S20) produces,
+  from one non-fine-regular partition, one successor.  What was still missing is
+  the recursion that turns the step into the chain — the `Classical.choose` +
+  iteration glue S20's docstring names as the outstanding brick.  This file
+  supplies that recursion, in a form that isolates the one hypothesis the
+  recursion genuinely still lacks (re-equitization):
+
+  * `exists_fine_of_potential_oracle` — the ABSTRACT chain construction: for any
+    invariant `Inv`, target `Fine`, and `[0,1]`-bounded potential `f` on
+    `Inv`-states, an oracle that carries every non-`Fine` `Inv`-state to an
+    `Inv`-state with `f`-gain `≥ δ > 0` forces the existence of an `Inv`-state
+    that IS `Fine`.  Proof: if not, `Subtype.val`-iterating the chosen successor
+    map from any start state gives a sequence along which `f` climbs by `δ`
+    every step, contradicting the `[0,1]`-potential termination engine
+    (`no_infinite_energy_increments`).  No graph theory at all.
+
+  * `partitionEnergy_gain_of_witnessed_both` — the per-step energy gain of the
+    two-shape witnessed step, factored OUT of the S19 iteration count
+    (`afks_sharp_energy_iteration_count_of_witness_both` inlined it): EITHER
+    witness shape at step `n` raises `partitionEnergy` by the sharp uniform
+    floor `eps⁴·m²/n²` (for `eps ≤ 1`).
+
+  * `exists_energy_next_of_not_afksFineRegular` — S20's realization restated in
+    ENERGY form: a non-fine-regular equitable partition with mass floor `m`
+    admits a successor that covers, is pairwise disjoint, refines whatever the
+    parent refines, and carries `partitionEnergy` gain `≥ E⁴·m²/n²`.  (The
+    successor is the bare split, so equitability and the mass floor are NOT
+    asserted for it — that is exactly the re-equitization gap.)
+
+  * `exists_afksFineRegular_of_maintained_oracle` — the concrete chain: from a
+    seed partition satisfying the loop invariant (covering, pairwise disjoint,
+    refining `Vparts`, equitable, mass floor `m`) and a MAINTAINED step oracle —
+    one that returns a successor satisfying the SAME invariant along with any
+    positive energy gain `δ` — some partition satisfying the invariant is
+    AFKS-fine-regular.
+
+  * `exists_afksTwoLevel_of_maintained_oracle` — the capstone: with an
+    `ε`-regular coarse partition `Vparts` and the maintained oracle at fine
+    tolerance `E (Vparts.card)`, the full two-level AFKS conclusion
+    `IsAFKSTwoLevel` holds for some fine partition.
+
+  Comparing the oracle the capstone needs with what
+  `exists_energy_next_of_not_afksFineRegular` already delivers, the WHOLE
+  remaining gap of the OQ-04 program is now one analytic statement: re-equitize
+  the bare split (restoring equitability and the mass floor, staying a
+  refinement) while keeping a positive fraction of its energy gain — the
+  classical AFKS re-equitization bookkeeping, nothing else.
+
+  0 axioms, 0 sorries.
+
+  Reference: Alon–Fischer–Krivelevich–Szegedy, "Efficient testing of large
+  graphs", Combinatorica 20 (2000).
+-/
+import Mathlib
+import Proofs.SzemerediRegularityOQ04OuterBoth
+import Proofs.SzemerediRegularityOQ04StepRealize
+
+namespace Szemeredi.RegularityOQ04Chain
+
+open Classical
+open Szemeredi.Core Szemeredi.Regularity Szemeredi.EnergyIncrement
+  Szemeredi.RegularityOQ04 Szemeredi.RegularityOQ04Energy
+  Szemeredi.RegularityOQ04Bridge Szemeredi.RegularityOQ04StepThree
+  Szemeredi.RegularityOQ04DefectGain Szemeredi.RegularityOQ04Outer
+  Szemeredi.RegularityOQ04TwoLevel Szemeredi.RegularityOQ04ToleranceBridge
+  Szemeredi.RegularityOQ04OuterBoth Szemeredi.RegularityOQ04StepRealize
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART I: THE ABSTRACT CHAIN CONSTRUCTION
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Abstract chain construction from an invariant-maintaining oracle.**  Let
+    `Inv` be an invariant, `Fine` a target predicate, and `f` a potential that
+    is `[0,1]`-bounded on `Inv`-states.  Suppose every `Inv`-state that is not
+    `Fine` can be carried to another `Inv`-state with potential gain at least
+    `δ > 0`.  Then from any starting `Inv`-state some `Inv`-state is `Fine`.
+
+    This is the `Classical.choose` + iteration glue of the AFKS outer loop,
+    stated with no graph theory at all: were no `Inv`-state `Fine`, the chosen
+    successor map would iterate from the seed into an infinite chain along
+    which `f` gains `δ` at every step — impossible for a `[0,1]`-valued
+    potential (`no_infinite_energy_increments`). -/
+theorem exists_fine_of_potential_oracle {α : Type*}
+    (Inv Fine : α → Prop) (f : α → ℚ) (δ : ℚ) (hδ : 0 < δ)
+    (h0 : ∀ q, Inv q → 0 ≤ f q) (h1 : ∀ q, Inv q → f q ≤ 1)
+    (q₀ : α) (hq₀ : Inv q₀)
+    (horacle : ∀ q, Inv q → ¬ Fine q → ∃ q', Inv q' ∧ f q + δ ≤ f q') :
+    ∃ q, Inv q ∧ Fine q := by
+  by_contra hcon
+  have hnf : ∀ q, Inv q → ¬ Fine q := fun q hq hf => hcon ⟨q, hq, hf⟩
+  -- The chosen successor map on the subtype of invariant states.
+  have hstep : ∀ q : {q : α // Inv q}, ∃ q' : {q : α // Inv q},
+      f q.val + δ ≤ f q'.val := by
+    rintro ⟨q, hq⟩
+    obtain ⟨q', hq', hgain⟩ := horacle q hq (hnf q hq)
+    exact ⟨⟨q', hq'⟩, hgain⟩
+  choose next hnext using hstep
+  -- Iterating from the seed gives an infinite `δ`-increment chain: impossible.
+  exact no_infinite_energy_increments
+    (fun n => f ((next^[n] (⟨q₀, hq₀⟩ : {q : α // Inv q})).val)) δ hδ
+    (fun n => h0 _ (next^[n] ⟨q₀, hq₀⟩).prop)
+    (fun n => h1 _ (next^[n] ⟨q₀, hq₀⟩).prop)
+    (fun n => by rw [Function.iterate_succ_apply']; exact hnext _)
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART II: THE PER-STEP ENERGY GAIN OF THE TWO-SHAPE WITNESSED STEP
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Energy gain of a witnessed step, either shape.**  A step of a chain
+    witnessed by the symmetric 4-piece shape (`IsWitnessedSharpStep`) or by
+    the asymmetric 3-piece shape (`IsWitnessedSharpStep3`) raises
+    `partitionEnergy` by at least the sharp uniform floor `eps⁴·m²/n²`
+    (for `eps ≤ 1`, the 3-piece `eps³` gain dominates the common `eps⁴`
+    budget).  This is the per-step content of
+    `afks_sharp_energy_iteration_count_of_witness_both` (S19), factored out
+    so a single step can feed the recursive chain construction. -/
+theorem partitionEnergy_gain_of_witnessed_both
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (parts : ℕ → Finset (Finset V)) (n : ℕ) (eps m : ℚ)
+    (hε : 0 < eps) (hε1 : eps ≤ 1) (hm : 0 < m)
+    (hwit : IsWitnessedSharpStep G parts n eps m ∨
+      IsWitnessedSharpStep3 G parts n eps m) :
+    partitionEnergy G (parts n) + eps ^ 4 * m ^ 2 / (Fintype.card V : ℚ) ^ 2 ≤
+      partitionEnergy G (parts (n + 1)) := by
+  rcases hwit with hstep | hstep
+  · -- Symmetric 4-piece step: the sharp `eps⁴` product gain.
+    obtain ⟨R, A, B, A₁, A₂, B₁, B₂, hpn, hpn1, hAu, hBu, hdA, hdB,
+      hAins, hBR, hA1, hA2, hB1, hB2, hmA, hmB, hcA, hcB, hdev⟩ := hstep
+    rw [hpn, hpn1]
+    have hgain := partitionEnergy_prod_gain_eps4 G R A B A₁ A₂ B₁ B₂
+      hAu hBu hdA hdB hAins hBR hA1 hA2 hB1 hB2 eps hε.le hcA hcB hdev
+    have hmass : m ^ 2 ≤ (A.card : ℚ) * B.card := by
+      nlinarith [hmA, hmB, hm.le]
+    have hfloor : eps ^ 4 * m ^ 2 / (Fintype.card V : ℚ) ^ 2 ≤
+        eps ^ 4 * ((A.card : ℚ) * B.card) / (Fintype.card V : ℚ) ^ 2 := by
+      gcongr
+    linarith [hgain, hfloor]
+  · -- Asymmetric 3-piece step: the `eps³` defect gain dominates `eps⁴`.
+    obtain ⟨R, A, B, B₁, B₂, hpn, hpn1, hBu, hdB, hAins, hBR, hAins',
+      hB₁ins, hB₂R, hmA, hmB, hfl, hdev⟩ := hstep
+    rw [hpn, hpn1]
+    have hApos : 0 < (A.card : ℚ) := lt_of_lt_of_le hm hmA
+    have hBpos : 0 < (B.card : ℚ) := lt_of_lt_of_le hm hmB
+    have hgain := partitionEnergy_step3_refinement_gain G R A B B₁ B₂
+      hBu hdB hAins hBR hAins' hB₁ins hB₂R eps hε hApos hBpos hfl hdev
+    have hmass : m ^ 2 ≤ (A.card : ℚ) * B.card := by
+      nlinarith [hmA, hmB, hm.le]
+    have heps3 : (0 : ℚ) ≤ eps ^ 3 := by positivity
+    have h43 : eps ^ 4 ≤ eps ^ 3 := by
+      nlinarith [mul_nonneg heps3 (sub_nonneg.mpr hε1)]
+    have hnum : eps ^ 4 * m ^ 2 ≤ eps ^ 3 * ((A.card : ℚ) * B.card) :=
+      mul_le_mul h43 hmass (sq_nonneg m) heps3
+    have hfloor : eps ^ 4 * m ^ 2 / (Fintype.card V : ℚ) ^ 2 ≤
+        eps ^ 3 * ((A.card : ℚ) * B.card) / (Fintype.card V : ℚ) ^ 2 := by
+      rw [div_eq_mul_inv, div_eq_mul_inv]
+      exact mul_le_mul_of_nonneg_right hnum (by positivity)
+    linarith [hgain, hfloor]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART III: THE SINGLE STEP IN ENERGY FORM
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **The single-step realization, in energy form.**  An equitable, pairwise
+    disjoint, covering partition with per-part mass floor `m` that is not
+    AFKS-fine-regular admits a successor partition that covers, is pairwise
+    disjoint, refines every coarse partition the parent refines, and carries
+    a `partitionEnergy` gain of at least the sharp uniform floor `E⁴·m²/n²`.
+
+    The successor is the bare split of `exists_witnessed_next_of_not_afksFineRegular`
+    (S20); its witnessed step is converted to the energy gain by
+    `partitionEnergy_gain_of_witnessed_both` through the two-term chain
+    `q, q', q', …`.  Equitability and the mass floor are NOT asserted for the
+    successor — a bare split genuinely loses them; restoring them at a bounded
+    energy cost is precisely the re-equitization gap this file isolates. -/
+theorem exists_energy_next_of_not_afksFineRegular
+    (G : SimpleGraph V) [DecidableRel G.Adj] (ε E m : ℚ)
+    (hε : 0 ≤ ε) (hE : 0 < E) (hE1 : E ≤ 1) (hm : 0 < m)
+    (q : Finset (Finset V))
+    (hcover : ∀ v : V, ∃ P ∈ q, v ∈ P)
+    (hdisj : ∀ P Q : Finset V, P ∈ q → Q ∈ q → P ≠ Q → Disjoint P Q)
+    (hequit : ∀ P Q : Finset V, P ∈ q → Q ∈ q → (P.card : ℤ) - Q.card ≤ 1)
+    (hmass : ∀ P ∈ q, m ≤ (P.card : ℚ))
+    (hnot : ¬ IsAFKSFineRegular G ε E q) :
+    ∃ q' : Finset (Finset V),
+      (∀ v : V, ∃ P ∈ q', v ∈ P) ∧
+      (∀ P Q : Finset V, P ∈ q' → Q ∈ q' → P ≠ Q → Disjoint P Q) ∧
+      (∀ Vparts : Finset (Finset V),
+        IsRefinement q Vparts → IsRefinement q' Vparts) ∧
+      partitionEnergy G q + E ^ 4 * m ^ 2 / (Fintype.card V : ℚ) ^ 2 ≤
+        partitionEnergy G q' := by
+  obtain ⟨q', hc, hd, hr, hwit⟩ :=
+    exists_witnessed_next_of_not_afksFineRegular G ε E m hε hE hm q
+      hcover hdisj hequit hmass hnot
+  refine ⟨q', hc, hd, hr, ?_⟩
+  -- Thread the witnessed step through the two-term chain `q, q', q', …`.
+  have h := partitionEnergy_gain_of_witnessed_both G
+    (fun i => if i = 0 then q else q') 0 E m hE hE1 hm
+    (hwit (fun i => if i = 0 then q else q') 0 (by simp) (by simp))
+  simpa using h
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART IV: THE CONCRETE CHAIN AND THE TWO-LEVEL CAPSTONE
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **AFKS fine-regularity from a maintained step oracle.**  Let `q₀` satisfy
+    the loop invariant — covering, pairwise disjoint, refining the coarse
+    partition `Vparts`, equitable, per-part mass floor `m` — and suppose the
+    step oracle: every partition satisfying the invariant that is not
+    AFKS-fine-regular at `(ε, Ek)` has a successor satisfying the SAME
+    invariant with `partitionEnergy` gain at least `δ > 0`.  Then some
+    partition satisfying the invariant is AFKS-fine-regular.
+
+    This is the recursive chain construction of the AFKS outer loop.  The
+    oracle differs from what `exists_energy_next_of_not_afksFineRegular`
+    provides only in the equitability and mass-floor clauses of the successor:
+    discharging that difference — re-equitizing the bare split at a bounded
+    energy cost — is the single remaining analytic gap of the OQ-04 program. -/
+theorem exists_afksFineRegular_of_maintained_oracle
+    (G : SimpleGraph V) [DecidableRel G.Adj] (ε Ek m δ : ℚ) (hδ : 0 < δ)
+    (Vparts q₀ : Finset (Finset V))
+    (hcover₀ : ∀ v : V, ∃ P ∈ q₀, v ∈ P)
+    (hdisj₀ : ∀ P Q : Finset V, P ∈ q₀ → Q ∈ q₀ → P ≠ Q → Disjoint P Q)
+    (href₀ : IsRefinement q₀ Vparts)
+    (hequit₀ : ∀ P Q : Finset V, P ∈ q₀ → Q ∈ q₀ → (P.card : ℤ) - Q.card ≤ 1)
+    (hmass₀ : ∀ P ∈ q₀, m ≤ (P.card : ℚ))
+    (horacle : ∀ q : Finset (Finset V),
+      (∀ v : V, ∃ P ∈ q, v ∈ P) →
+      (∀ P Q : Finset V, P ∈ q → Q ∈ q → P ≠ Q → Disjoint P Q) →
+      IsRefinement q Vparts →
+      (∀ P Q : Finset V, P ∈ q → Q ∈ q → (P.card : ℤ) - Q.card ≤ 1) →
+      (∀ P ∈ q, m ≤ (P.card : ℚ)) →
+      ¬ IsAFKSFineRegular G ε Ek q →
+      ∃ q' : Finset (Finset V),
+        (∀ v : V, ∃ P ∈ q', v ∈ P) ∧
+        (∀ P Q : Finset V, P ∈ q' → Q ∈ q' → P ≠ Q → Disjoint P Q) ∧
+        IsRefinement q' Vparts ∧
+        (∀ P Q : Finset V, P ∈ q' → Q ∈ q' → (P.card : ℤ) - Q.card ≤ 1) ∧
+        (∀ P ∈ q', m ≤ (P.card : ℚ)) ∧
+        partitionEnergy G q + δ ≤ partitionEnergy G q') :
+    ∃ q : Finset (Finset V),
+      IsRefinement q Vparts ∧ IsAFKSFineRegular G ε Ek q := by
+  -- Instantiate the abstract chain construction with the packaged invariant.
+  obtain ⟨q, hq, hfine⟩ := exists_fine_of_potential_oracle
+    (Inv := fun q : Finset (Finset V) =>
+      (∀ v : V, ∃ P ∈ q, v ∈ P) ∧
+      (∀ P Q : Finset V, P ∈ q → Q ∈ q → P ≠ Q → Disjoint P Q) ∧
+      IsRefinement q Vparts ∧
+      (∀ P Q : Finset V, P ∈ q → Q ∈ q → (P.card : ℤ) - Q.card ≤ 1) ∧
+      (∀ P ∈ q, m ≤ (P.card : ℚ)))
+    (Fine := fun q => IsAFKSFineRegular G ε Ek q)
+    (f := fun q => partitionEnergy G q) (δ := δ) hδ
+    (fun q _ => partitionEnergy_nonneg G q)
+    (fun q hq => partitionEnergy_le_one G q hq.1 hq.2.1)
+    q₀ ⟨hcover₀, hdisj₀, href₀, hequit₀, hmass₀⟩
+    (by
+      rintro q ⟨hc, hd, hr, he, hmq⟩ hnot
+      obtain ⟨q', hc', hd', hr', he', hm', hgain⟩ :=
+        horacle q hc hd hr he hmq hnot
+      exact ⟨q', ⟨hc', hd', hr', he', hm'⟩, hgain⟩)
+  exact ⟨q, hq.2.2.1, hfine⟩
+
+/-- **The two-level AFKS conclusion from a maintained step oracle.**  With an
+    `ε`-regular coarse partition `Vparts`, a seed fine partition satisfying the
+    loop invariant, and the maintained step oracle at the dependent fine
+    tolerance `E (Vparts.card)` (any positive per-step energy gain `δ`), the
+    full two-level conclusion holds: some fine partition refines `Vparts` and
+    is AFKS-fine-regular — `IsAFKSTwoLevel G ε E Vparts`.
+
+    Together with `exists_energy_next_of_not_afksFineRegular`, this reduces the
+    entire remaining OQ-04 program to the re-equitization statement: convert
+    the bare-split successor into an invariant-maintaining one while keeping a
+    positive fraction `δ` of its `E⁴·m²/n²` energy gain. -/
+theorem exists_afksTwoLevel_of_maintained_oracle
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (ε : ℚ) (E : ℕ → ℚ) (m δ : ℚ) (hδ : 0 < δ)
+    (Vparts q₀ : Finset (Finset V))
+    (hcoarse : IsRegularPartition G ε Vparts)
+    (hcover₀ : ∀ v : V, ∃ P ∈ q₀, v ∈ P)
+    (hdisj₀ : ∀ P Q : Finset V, P ∈ q₀ → Q ∈ q₀ → P ≠ Q → Disjoint P Q)
+    (href₀ : IsRefinement q₀ Vparts)
+    (hequit₀ : ∀ P Q : Finset V, P ∈ q₀ → Q ∈ q₀ → (P.card : ℤ) - Q.card ≤ 1)
+    (hmass₀ : ∀ P ∈ q₀, m ≤ (P.card : ℚ))
+    (horacle : ∀ q : Finset (Finset V),
+      (∀ v : V, ∃ P ∈ q, v ∈ P) →
+      (∀ P Q : Finset V, P ∈ q → Q ∈ q → P ≠ Q → Disjoint P Q) →
+      IsRefinement q Vparts →
+      (∀ P Q : Finset V, P ∈ q → Q ∈ q → (P.card : ℤ) - Q.card ≤ 1) →
+      (∀ P ∈ q, m ≤ (P.card : ℚ)) →
+      ¬ IsAFKSFineRegular G ε (E Vparts.card) q →
+      ∃ q' : Finset (Finset V),
+        (∀ v : V, ∃ P ∈ q', v ∈ P) ∧
+        (∀ P Q : Finset V, P ∈ q' → Q ∈ q' → P ≠ Q → Disjoint P Q) ∧
+        IsRefinement q' Vparts ∧
+        (∀ P Q : Finset V, P ∈ q' → Q ∈ q' → (P.card : ℤ) - Q.card ≤ 1) ∧
+        (∀ P ∈ q', m ≤ (P.card : ℚ)) ∧
+        partitionEnergy G q + δ ≤ partitionEnergy G q') :
+    ∃ Wparts : Finset (Finset V), IsAFKSTwoLevel G ε E Vparts Wparts := by
+  obtain ⟨q, href, hfine⟩ := exists_afksFineRegular_of_maintained_oracle
+    G ε (E Vparts.card) m δ hδ Vparts q₀
+    hcover₀ hdisj₀ href₀ hequit₀ hmass₀ horacle
+  exact ⟨q, { coarseRegular := hcoarse, refines := href, fineRegular := hfine }⟩
+
+end Szemeredi.RegularityOQ04Chain

--- a/research/problems/szemeredi-regularity-oq-04/knowledge.md
+++ b/research/problems/szemeredi-regularity-oq-04/knowledge.md
@@ -1029,3 +1029,67 @@ warning-free, 0 ax, 0 sorry.
 - `proofs/Proofs/SzemerediRegularityOQ04DefectGain.lean` (NEW, 228 lines, 5 theorems)
 - `research/problems/szemeredi-regularity-oq-04/{state.md,knowledge.md}`
 - `src/data/research/problems/szemeredi-regularity-oq-04.json` (leanFiles + knowledge)
+
+## Session 2026-07-23 S21 (researcher-1) — the recursive chain construction (oracle form)
+
+**Mode:** REVISIT (RICH). **Outcome:** the `Classical.choose` + iteration glue that
+S20 named as the outstanding brick is DONE, in a form that isolates re-equitization
+as the single remaining analytic hypothesis. Docker-verified first try (8598 jobs,
+new file warning-free), 0 ax, 0 sorry.
+
+### New file `SzemerediRegularityOQ04Chain.lean` (310 lines, 5 theorems)
+- `exists_fine_of_potential_oracle` — ABSTRACT chain construction, no graph theory:
+  `Inv Fine : α → Prop`, potential `f : α → ℚ` with `0 ≤ f ≤ 1` on `Inv`-states,
+  oracle `∀ q, Inv q → ¬Fine q → ∃ q', Inv q' ∧ f q + δ ≤ f q'` (`δ > 0`), seed
+  `Inv q₀` ⟹ `∃ q, Inv q ∧ Fine q`. Proof shape: `by_contra` (no push needed —
+  `fun q hq hf => hcon ⟨q, hq, hf⟩` inlines the negation), `choose next hnext` on the
+  subtype `{q // Inv q}`, then `no_infinite_energy_increments` applied to
+  `fun n => f ((next^[n] ⟨q₀, hq₀⟩).val)` with the step from
+  `Function.iterate_succ_apply'`.
+- `partitionEnergy_gain_of_witnessed_both` — per-step `eps⁴·m²/n²` gain of EITHER
+  witness shape (4-piece via `partitionEnergy_prod_gain_eps4`, 3-piece via
+  `partitionEnergy_step3_refinement_gain` with `eps³ ≥ eps⁴` for `eps ≤ 1`) —
+  factored out of the S19 mixed iteration count so ONE step feeds the recursion.
+- `exists_energy_next_of_not_afksFineRegular` — S20's single-step realization in
+  ENERGY form: successor covers, disjoint, refines-transport, and
+  `partitionEnergy G q + E⁴·m²/n² ≤ partitionEnergy G q'`. The witnessed step is
+  converted via the constant-after-zero chain `fun i => if i = 0 then q else q'`
+  (parts 0 = q, parts 1 = q' both by `simp`; `simpa` restates the gain).
+- `exists_afksFineRegular_of_maintained_oracle` — concrete chain: invariant =
+  5-conjunction (cover ∧ disjoint ∧ IsRefinement · Vparts ∧ equitable ∧ mass ≥ m);
+  potential = `partitionEnergy G` bounded by `partitionEnergy_nonneg` /
+  `partitionEnergy_le_one` (the latter consuming the first two conjuncts).
+- `exists_afksTwoLevel_of_maintained_oracle` — capstone: `ε`-regular coarse `Vparts`
+  + maintained oracle at `E (Vparts.card)` ⟹ `∃ Wparts, IsAFKSTwoLevel G ε E Vparts
+  Wparts`. NO horizon `N` appears anywhere — the abstract construction replaces the
+  step-counting formulation (`exists_afksTwoLevel_of_dichotomy_both` needed
+  `hN : n²/(E⁴m²) < N` and a chain given in advance).
+
+### Reusable Lean recipe
+- Chain recursion without dependent `Nat.rec` pain: put the invariant in a SUBTYPE
+  `{q // Inv q}`, `choose` the successor map there, and use `Function.iterate`;
+  `Function.iterate_succ_apply'` gives `next^[n+1] x = next (next^[n] x)` exactly
+  where the step lemma wants it. The `[0,1]`-potential engine
+  (`no_infinite_energy_increments`, RegularityOQ04.lean) then kills the by_contra
+  branch with zero arithmetic.
+- To turn a "∀ chain through (q,q') at (n,n+1)" witness into a statement about the
+  PAIR, instantiate the chain `fun i => if i = 0 then q else q'` at n = 0; both
+  side conditions discharge by `simp`.
+
+### What remains (THE isolated gap)
+- **Re-equitization**: upgrade the bare-split successor (cover/disjoint/refines +
+  `E⁴·m²/n²` gain, from `exists_energy_next_of_not_afksFineRegular`) to one that is
+  also equitable with mass floor `m`, keeping any positive fraction `δ` of the gain —
+  then `exists_afksTwoLevel_of_maintained_oracle` closes the two-level AFKS
+  conclusion outright. This is the classical averaging/re-partition argument
+  (Mathlib's `Finpartition.equitabilise` is the natural tool, but the OQ-04 engine
+  works with raw `Finset (Finset V)` families — a bridge or a bespoke equitabilise
+  would be needed). Deep but now SHARPLY specified.
+- Seed existence (an initial equitable mass-`m` refinement of `Vparts`) is standard
+  and could be a small follow-up.
+
+### Files Modified
+- `proofs/Proofs/SzemerediRegularityOQ04Chain.lean` (NEW, 310 lines, 5 theorems)
+- `research/problems/szemeredi-regularity-oq-04/{state.md,knowledge.md}`
+- `src/data/research/problems/szemeredi-regularity-oq-04.json` (leanFiles += OuterBoth,
+  StepRealize, Chain; currentState S21)

--- a/research/problems/szemeredi-regularity-oq-04/state.md
+++ b/research/problems/szemeredi-regularity-oq-04/state.md
@@ -445,3 +445,37 @@ destroys the equitability and mass-floor hypotheses the step theorem requires of
 so the recursion cannot yet re-invoke it — that is the classical re-equitization bookkeeping
 (the "nonempty-equipartition model" blocker recorded in `Assembly.lean`). With this file the
 set-theoretic and analytic content of a SINGLE step is fully discharged, both shapes.
+
+## Status (S21, researcher-1, 2026-07-23) — the recursive chain construction (oracle form)
+
+New file `SzemerediRegularityOQ04Chain.lean` (5 thm, 0 ax, 0 sorry, docker-VERIFIED).
+Supplies the `Classical.choose` + iteration glue S20 named as the outstanding brick,
+in a form that isolates re-equitization as the single remaining hypothesis:
+
+- `exists_fine_of_potential_oracle` — ABSTRACT chain construction (no graph theory):
+  invariant `Inv`, target `Fine`, `[0,1]`-bounded potential `f` on `Inv`-states, and an
+  oracle carrying every non-`Fine` `Inv`-state to an `Inv`-state with `f`-gain `≥ δ > 0`
+  force an `Inv`-state that IS `Fine`. Proof: `choose` a successor map on the subtype
+  `{q // Inv q}`, iterate from the seed, contradict `no_infinite_energy_increments`.
+- `partitionEnergy_gain_of_witnessed_both` — the per-step `eps⁴·m²/n²` energy gain of
+  EITHER witness shape, factored out of the S19 iteration count so a single step can
+  feed the recursion.
+- `exists_energy_next_of_not_afksFineRegular` — S20's realization in ENERGY form: the
+  bare-split successor covers, is disjoint, refines, and gains `≥ E⁴·m²/n²` (threaded
+  through the two-term chain `i ↦ if i = 0 then q else q'`). Equitability/mass floor
+  NOT asserted — the bare split genuinely loses them.
+- `exists_afksFineRegular_of_maintained_oracle` — the concrete chain: seed satisfying
+  the loop invariant (cover, disjoint, refines Vparts, equitable, mass ≥ m) + a
+  MAINTAINED oracle (successor satisfies the SAME invariant, any energy gain `δ > 0`)
+  ⟹ some invariant partition is AFKS-fine-regular.
+- `exists_afksTwoLevel_of_maintained_oracle` — capstone: ε-regular coarse `Vparts` +
+  maintained oracle at fine tolerance `E (Vparts.card)` ⟹ `∃ Wparts,
+  IsAFKSTwoLevel G ε E Vparts Wparts`. Note: NO horizon `N` appears — the abstract
+  construction replaces step counting entirely.
+
+**What this leaves (THE single remaining analytic gap):** re-equitization. The delta
+between what `exists_energy_next_of_not_afksFineRegular` delivers (bare split: cover,
+disjoint, refines, energy gain `E⁴·m²/n²`) and what the maintained oracle needs
+(additionally equitable + mass floor `m`, keeping any positive fraction `δ` of the
+gain) — the classical AFKS re-equitization bookkeeping. Nothing else remains between
+the current engine and the two-level conclusion from a seed partition.

--- a/src/data/research/problems/szemeredi-regularity-oq-04.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-04.json
@@ -20,10 +20,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-08T19:45:20Z",
-    "iteration": 6,
-    "focus": "S19 (2026-07-23): outer loop threaded with BOTH step shapes DONE — SzemerediRegularityOQ04OuterBoth.lean proves partitionEnergy_step3_refinement_gain (whole-partition eps^3 lift of the S18 defect gain over insert A (insert B1 (insert B2 R))), afks_sharp_energy_iteration_count_of_witness_both (mixed 4-piece/3-piece chains stay within the SAME sharp n^2/(eps^4 m^2) budget for eps<=1), afks_regular_step_within_bound_both (termination against the disjunctive witness), and exists_afksTwoLevel_of_dichotomy_both / _equipartition consuming the S17 two-shape dichotomy. [VERIFIED 0 axioms, docker 8592 jobs]",
+    "iteration": 8,
+    "focus": "S21 (2026-07-23): recursive chain construction DONE in oracle form — SzemerediRegularityOQ04Chain.lean proves exists_fine_of_potential_oracle (abstract invariant/potential chain: choose successor on the subtype {q // Inv q}, iterate, contradict no_infinite_energy_increments), partitionEnergy_gain_of_witnessed_both (per-step eps^4 m^2/n^2 gain of EITHER witness shape, factored from S19), exists_energy_next_of_not_afksFineRegular (S20 single step in energy form), and exists_afksFineRegular/exists_afksTwoLevel_of_maintained_oracle (the two-level AFKS conclusion from a seed + an invariant-MAINTAINING step oracle; no horizon N appears). [VERIFIED 0 axioms, docker 8598 jobs] The single remaining analytic gap is RE-EQUITIZATION: upgrade the bare-split successor (cover/disjoint/refines + gain) to one that is also equitable with mass floor m, keeping a positive fraction of the gain.",
     "blockers": [],
-    "nextAction": "The residual gap is between split DATA and WITNESSED STEPS: exists_proper_or_semitrivial_split_of_not_afksFineRegular (S17) yields the 4-piece/3-piece split data, while the _both dichotomy hypothesis needs the chain parts(n+1) to BE the refined partition with the freshness clauses (split pieces distinct from each other and from R) and coarse mass floors discharged. Constructing the recursive refinement chain that realizes the case split at every non-regular step — the 'nonempty-equipartition model' blocker recorded in Assembly.lean — is the genuine remaining outer-loop content. Deep construction; no elementary increment remains at the pair or partition level."
+    "nextAction": "The ONE remaining gap: re-equitization. Bridge the delta between exists_energy_next_of_not_afksFineRegular (bare split: cover, disjoint, refines, energy gain E^4 m^2/n^2) and the maintained oracle of exists_afksTwoLevel_of_maintained_oracle (additionally equitable + mass floor m, any positive retained gain delta). Classical averaging/re-partition bookkeeping; Mathlib's Finpartition.equitabilise is the natural tool but the engine works with raw Finset (Finset V) families, so a bridge or bespoke equitabilise is needed. Also small: seed existence (initial equitable mass-m refinement of Vparts). Deep but sharply specified."
   },
   "knowledge": {
     "progressSummary": "Item-1 dichotomy: constructive core COMPLETE at the pair level. S12-S15 packaging/freshness/mass-floor/ceiling; S16 gap forbids doubly-trivial splits; S17 asymmetric 3-piece predicate IsWitnessedSharpStep3 + trichotomy (one normalized shape covers both degenerate sides via edgeDensity_symm); S18 (2026-07-22) the one-sided DEFECT energy inequality: deviation of ONE half from the PARENT density gains (|A1||B|/n^2)*delta^2 (defect_energy_bound, multiplicative mean, empty complement allowed), and with the eps-mass floor the 3-piece step gains eps^3*|A||B|/n^2 (pairEnergy_step3_gain, capstone pairEnergy_gain_of_isWitnessedSharpStep3). Remaining: outer-loop chain construction threading both step shapes (deep).",
@@ -97,7 +97,11 @@
       "pairEnergy_gain_of_isWitnessedSharpStep3 (capstone: witnessed 3-piece step carries the eps^3 pair-energy gain) in SzemerediRegularityOQ04DefectGain.lean",
       "partitionEnergy_step3_refinement_gain (whole-partition eps^3 lift of the 3-piece defect gain) in SzemerediRegularityOQ04OuterBoth.lean",
       "afks_sharp_energy_iteration_count_of_witness_both + afks_regular_step_within_bound_both (mixed-chain sharp budget and termination) in SzemerediRegularityOQ04OuterBoth.lean",
-      "exists_afksTwoLevel_of_dichotomy_both / _both_equipartition (outer AFKS loop consuming the S17 two-shape dichotomy) in SzemerediRegularityOQ04OuterBoth.lean"
+      "exists_afksTwoLevel_of_dichotomy_both / _both_equipartition (outer AFKS loop consuming the S17 two-shape dichotomy) in SzemerediRegularityOQ04OuterBoth.lean",
+      "SzemerediRegularityOQ04StepRealize.lean (S20): split_freshness3 + isWitnessedSharpStep3_of_split_of_nonempty/_gap, refined4/refined3 cover/disjoint/refines invariants, exists_witnessed_next_of_not_afksFineRegular (single-step realization)",
+      "exists_fine_of_potential_oracle (abstract invariant/potential chain construction) in SzemerediRegularityOQ04Chain.lean",
+      "partitionEnergy_gain_of_witnessed_both + exists_energy_next_of_not_afksFineRegular (per-step energy form) in SzemerediRegularityOQ04Chain.lean",
+      "exists_afksFineRegular_of_maintained_oracle + exists_afksTwoLevel_of_maintained_oracle (two-level AFKS from a maintained step oracle) in SzemerediRegularityOQ04Chain.lean"
     ],
     "insights": [
       "The complement pieces A2=A\\A1, B2=B\\B1 of the AFKS sharp 2x2 split are NOT both forced nonempty by the analytic data: the density gap only forbids BOTH being empty (S16). When one corner exhausts its block (A1=A) the honest refinement is the asymmetric 3-piece split {A,B1,B2}; the 4-piece IsWitnessedSharpStep shape (S14 isWitnessedSharpStep_of_split_of_gap) requires an asymmetric-step packaging for that degenerate branch, not a further nonemptiness lemma.",
@@ -137,7 +141,10 @@
       "The two degenerate sides of the sharp 2x2 split fold onto ONE asymmetric 3-piece shape: when B2 = empty (B1 = B, only A splits), swapping the parents via edgeDensity_symm turns |d(A1,B) - d(A,B)| into |d(B,A1) - d(B,A)|, i.e. the same only-second-block-splits form. One predicate (IsWitnessedSharpStep3) therefore covers both.",
       "The 3-piece step will carry a STRONGER energy floor than the 4-piece one: splitting only B with deviation >= eps on mass >= eps*|B| gains >= eps^3*|A||B|/n^2 (mean preserved by edge-count additivity e(A,B)=e(A,B1)+e(A,B2), already in SzemerediCoreOQ01) versus the eps^4 sharp floor - so the outer-loop eps^4 budget covers both branches without change.",
       "The degenerate branch is CHEAPER for the outer budget: for eps <= 1 the 3-piece eps^3*m^2/n^2 floor dominates the 4-piece eps^4*m^2/n^2 one, so mixed chains terminate within the unchanged sharp bound n^2/(eps^4*m^2) — threading the disjunctive dichotomy costs only the extra hypothesis E(k) <= 1.",
-      "The whole-partition lift of the 3-piece gain needs no new analysis: the A-row/column and (A,A) cell are unchanged, the B-rows/columns, (B,A) cross and B^2 diagonal split by pairEnergy monotonicity, and only the (A,B) cross consumes pairEnergy_step3_gain — Assembly.lean's block-decomposition template transfers verbatim with five instead of eight block inequalities."
+      "The whole-partition lift of the 3-piece gain needs no new analysis: the A-row/column and (A,A) cell are unchanged, the B-rows/columns, (B,A) cross and B^2 diagonal split by pairEnergy monotonicity, and only the (A,B) cross consumes pairEnergy_step3_gain — Assembly.lean's block-decomposition template transfers verbatim with five instead of eight block inequalities.",
+      "Chain recursion without dependent Nat.rec pain: choose the successor map on the subtype {q // Inv q} and use Function.iterate; iterate_succ_apply' hands the step lemma exactly the form it wants, and the [0,1]-potential engine kills the by_contra branch",
+      "A '∀ chain through (q,q') at (n,n+1)' witness becomes a pair statement by instantiating the chain fun i => if i = 0 then q else q' at n = 0; both side conditions are simp",
+      "The oracle formulation removes the horizon N entirely: exists_afksTwoLevel_of_maintained_oracle has no step count, replacing the S19 dichotomy form that needed hN and a chain given in advance; re-equitization is now THE isolated residual"
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -374,7 +381,40 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediRegularityOQ04DefectGain.lean"
+    },
+    {
+      "path": "Proofs/SzemerediRegularityOQ04OuterBoth.lean",
+      "filename": "SzemerediRegularityOQ04OuterBoth.lean",
+      "lineCount": 326,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediRegularityOQ04OuterBoth.lean"
+    },
+    {
+      "path": "Proofs/SzemerediRegularityOQ04StepRealize.lean",
+      "filename": "SzemerediRegularityOQ04StepRealize.lean",
+      "lineCount": 447,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediRegularityOQ04StepRealize.lean"
+    },
+    {
+      "path": "Proofs/SzemerediRegularityOQ04Chain.lean",
+      "filename": "SzemerediRegularityOQ04Chain.lean",
+      "lineCount": 310,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediRegularityOQ04Chain.lean"
     }
   ],
-  "lastUpdate": "2026-07-22"
+  "lastUpdate": "2026-07-23"
 }


### PR DESCRIPTION
## Summary

Research session S21 on **szemeredi-regularity-oq-04** (strong AFKS regularity lemma).

S20 (#42308) closed the single-step realization and named the outstanding brick: "the recursive chain construction (`Classical.choose` + `Nat.rec`) must invoke this theorem at each non-regular step … what the recursion must still supply is the maintenance of the equitability and mass-floor hypotheses." This session supplies that recursion, in a form that isolates re-equitization as the **single** remaining hypothesis.

### New file `SzemerediRegularityOQ04Chain.lean` (310 lines, 5 theorems, 0 sorries, 0 axioms)

- `exists_fine_of_potential_oracle` — the **abstract chain construction**, no graph theory: an invariant `Inv`, a target `Fine`, a `[0,1]`-bounded potential on `Inv`-states, and an oracle carrying every non-`Fine` `Inv`-state to an `Inv`-state with potential gain `≥ δ > 0` force an `Inv`-state that is `Fine`. Proof: `choose` a successor map on the subtype `{q // Inv q}`, iterate from the seed with `Function.iterate`, and contradict the existing `[0,1]`-potential termination engine (`no_infinite_energy_increments`).
- `partitionEnergy_gain_of_witnessed_both` — the per-step `eps⁴·m²/n²` energy gain of either witness shape (4-piece or 3-piece), factored out of the S19 mixed iteration count so a single step can feed the recursion.
- `exists_energy_next_of_not_afksFineRegular` — S20's single-step realization restated in energy form: the bare-split successor covers, is pairwise disjoint, transports refinement, and gains `≥ E⁴·m²/n²`. Equitability and the mass floor are deliberately **not** asserted — a bare split genuinely loses them.
- `exists_afksFineRegular_of_maintained_oracle` — the concrete chain: a seed satisfying the loop invariant (cover, disjoint, refines `Vparts`, equitable, mass floor `m`) plus a **maintained** step oracle yields an AFKS-fine-regular partition satisfying the invariant.
- `exists_afksTwoLevel_of_maintained_oracle` — the capstone: with an ε-regular coarse `Vparts` and the maintained oracle at the dependent fine tolerance `E (Vparts.card)`, the full two-level AFKS conclusion `∃ Wparts, IsAFKSTwoLevel G ε E Vparts Wparts` holds. Notably **no horizon `N` appears** — the oracle formulation replaces the step-counting formulation (`exists_afksTwoLevel_of_dichotomy_both` needed `hN` and a chain given in advance).

### What this isolates

The delta between what `exists_energy_next_of_not_afksFineRegular` delivers and what the maintained oracle needs is exactly: **re-equitize the bare split** (restore equitability + mass floor, stay a refinement) while keeping a positive fraction of the energy gain — the classical AFKS re-equitization bookkeeping. Nothing else remains between the current engine and the two-level conclusion from a seed partition.

### Honest accounting

- 0 sorries, 0 axioms; new file compiles warning-free.
- Built via `./proofs/scripts/docker-build.sh Proofs.SzemerediRegularityOQ04Chain` (8598 jobs, exit 0).
- Tracker updates: `leanFiles` gains the S19/S20 files (OuterBoth, StepRealize) that earlier sessions had not registered, plus the new Chain file; `currentState` moves to S21 with re-equitization as the sharply-specified sole blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
