### PR TITLE
Enrich niven-theorem-oq-01-oq-03: split sections to 5 (4->5)

### DIFF
--- a/src/data/proofs/niven-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/niven-theorem-oq-01-oq-03/meta.json
@@ -115,12 +115,19 @@
       "mathContext": "sin(2π/3) = √3/2 ∉ ℚ."
     },
     {
-      "id": "classification",
-      "title": "The Classification sin(2π/n) ⟺ n ∈ {1,2,4,12}",
+      "id": "classification-forward",
+      "title": "The Classification: Forward Direction",
       "startLine": 134,
+      "endLine": 195,
+      "summary": "sin_two_pi_div_rational_iff, forward direction: rationality of sin(2π/n) forces n ∈ {1,2,4,12}. Splits n < 4 (interval_cases, with n = 3 discharged by the irrationality lemma) and n ≥ 4 (the angle 2π/n lies in (0, π/2]; Niven's theorem plus positivity of sin restrict it to {1/2, 1}; strictMonoOn_sin.injOn then pins 2π/n = π/6, so n = 12, or 2π/n = π/2, so n = 4).",
+      "mathContext": "$\\sin(2\\pi/n) \\in \\mathbb{Q} \\Rightarrow n \\in \\{1,2,4,12\\}$."
+    },
+    {
+      "id": "classification-reverse",
+      "title": "The Classification: Reverse Direction",
+      "startLine": 196,
       "endLine": 210,
-      "summary": "sin_two_pi_div_rational_iff: forward direction splits n < 4 (interval_cases, with n = 3 discharged by the irrationality lemma) and n ≥ 4 (angle in (0, π/2]; Niven + positivity ⇒ sin ∈ {1/2, 1}; strictMonoOn_sin.injOn pins 2π/n = π/6 ⇒ n = 12 or = π/2 ⇒ n = 4). Reverse direction evaluates the five special angles.",
-      "mathContext": "n ≥ 1 ⇒ (sin(2π/n) ∈ ℚ ⟺ n ∈ {1,2,4,12})."
+      "summary": "sin_two_pi_div_rational_iff, reverse direction: five explicit special-angle evaluations confirm sin(2π/n) ∈ ℚ for each n ∈ {1,2,4,12} (sin(2π) = 0, sin(π) = 0, sin(π/2) = 1, sin(π/6) = 1/2)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for niven-theorem-oq-01-oq-03: the entry had only 4 `sections` entries against the gallery's 5-section quality target. Split `classification` (134-210, bundling the forward and reverse directions of a single iff theorem) at the real proof-structure boundary:

- `classification-forward` (134-195): rationality of sin(2π/n) forces n ∈ {1,2,4,12}.
- `classification-reverse` (196-210): the five explicit special-angle evaluations confirming the converse.

No content deleted; full file coverage (1-210) preserved across the now 5 sections. Verified `meta.json` is valid JSON and well under the 60KB size cap.