### PR TITLE
Enrich pac-learning-bounds-oq-01-oq-07: add header section, cover full file (4->5)

### DIFF
--- a/src/data/proofs/pac-learning-bounds-oq-01-oq-07/meta.json
+++ b/src/data/proofs/pac-learning-bounds-oq-01-oq-07/meta.json
@@ -127,6 +127,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header, Imports, and Setup",
+      "startLine": 1,
+      "endLine": 30,
+      "summary": "Module docstring generalizes the parent PACLearningOQ01 result (thresholds on ℕ have VC dimension 1) to thresholds on any totally ordered set, using only order axioms instead of ℕ arithmetic. Previews the two phenomena that replace the arithmetic: singleton shattering becomes conditional on non-maximality (Part II), while the no-pair-shattered upper bound holds unconditionally over any linear order (Part III). Imports Mathlib, declares the LearningTheory.VCDimension.LinearOrderThresholds namespace, opens Finset, and fixes the ambient LinearOrder α.",
+      "mathContext": "Threshold classifiers $\\{x \\mid x < t\\}$ over an arbitrary linear order $\\alpha$; VC dimension exactly 1 when $\\alpha$ is nontrivial."
+    },
+    {
       "id": "definitions",
       "title": "Definitions: Shatters and Threshold Classifiers over a Linear Order",
       "startLine": 31,


### PR DESCRIPTION
Enrichment pass for pac-learning-bounds-oq-01-oq-07: the entry had 4 `sections` entries against the gallery's 5-section quality target, and lines 1-30 (the module docstring, import, and namespace/variable setup) had no section coverage at all.

Added a `header` section (1-30) previewing the generalization from ℕ to an arbitrary linear order and the two structural phenomena it exposes, matching the existing 4 theorem-boundary sections.

No content deleted; full file coverage (1-138 of 139) now held across 5 sections. Verified `meta.json` is valid JSON and well under the 60KB size cap.