### PR TITLE
Enrich odd-squares-sum-oq-01: split header into docstring/setup (3->4 sections)

### DIFF
--- a/src/data/proofs/odd-squares-sum-oq-01/meta.json
+++ b/src/data/proofs/odd-squares-sum-oq-01/meta.json
@@ -59,15 +59,22 @@
   "sections": [
     {
       "id": "header",
-      "title": "Module Header and Statement",
+      "title": "Module Docstring",
       "startLine": 1,
-      "endLine": 45,
-      "summary": "Docstring stating the open question ∑_{k<n}(2k+1)² = n(2n−1)(2n+1)/3 (the sum of the squares of the first n odd numbers), positioning it as the odd-indexed companion of the square-pyramidal identity ∑_{k≤n}k² = n(n+1)(2n+1)/6 and noting Mathlib lacks this variant. Imports (BigOperators.Intervals, Tactic), the namespace, and open Finset, followed by the docstring of the division-free integer form three_mul_sum_odd_squares — deliberately additive (3·∑ + n = 4n³) so the inductive step avoids ℕ truncated subtraction and closes by ring."
+      "endLine": 35,
+      "summary": "Docstring stating the open question ∑_{k<n}(2k+1)² = n(2n−1)(2n+1)/3 (the sum of the squares of the first n odd numbers), positioning it as the odd-indexed companion of the square-pyramidal identity ∑_{k≤n}k² = n(n+1)(2n+1)/6 and noting Mathlib lacks this variant. States both results to follow: the division-free integer form three_mul_sum_odd_squares (3·∑ + n = 4n³) and the rational closed form sum_odd_squares_rat."
+    },
+    {
+      "id": "setup",
+      "title": "Namespace and Open",
+      "startLine": 36,
+      "endLine": 38,
+      "summary": "Imports (BigOperators.Intervals, Tactic) precede the docstring; here the file opens `namespace OddSquaresSum` and `open Finset` so range-sums can be written unqualified for both theorems that follow."
     },
     {
       "id": "integer-form",
       "title": "Division-free integer form (subtraction-free step)",
-      "startLine": 46,
+      "startLine": 39,
       "endLine": 59,
       "summary": "The exact ℕ identity 3·∑_{k<n} (2k+1)² + n = 4n³, proved by induction. Phrased additively it contains no truncated subtraction. The step peels the top odd square with sum_range_succ, reassociates so the inductive hypothesis 3·∑ + m = 4m³ appears verbatim, and a single `ring` closes the branch. The whole proof lives in ℕ — no casts to ℤ or ℚ."
     },
@@ -76,7 +83,7 @@
       "title": "Rational closed form n(2n−1)(2n+1)/3",
       "startLine": 60,
       "endLine": 74,
-      "summary": "The classical closed form ∑_{k<n} (2k+1)² = n(2n−1)(2n+1)/3 over ℚ. Base case is `simp` (empty sum). The inductive step peels the top term, rewrites by the hypothesis, and `push_cast; ring` discharges the polynomial identity — verifying (m(2m−1)(2m+1)/3) + (2m+1)² = (m+1)(2m+1)(2m+3)/3 in the field ℚ where division is genuine."
+      "summary": "The classical closed form ∑_{k<n} (2k+1)² = n(2n−1)(2n+1)/3 over ℚ. Base case is `simp` (empty sum). The inductive step peels the top term, rewrites by the hypothesis, and `push_cast; ring` discharges the polynomial identity — verifying (m(2m−1)(2m+1)/3) + (2m+1)² = (m+1)(2m+1)(2m+3)/3 in the field ℚ where division is genuine. Closes the OddSquaresSum namespace."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for odd-squares-sum-oq-01 (sum of squares of the first n odd numbers: ∑(2k+1)² = n(2n−1)(2n+1)/3).

This entry hits the common "sections < 5" quality gap, but the file is only 74 lines with exactly 2 theorems, so a genuine 5-way split (one section per real Lean construct — docstring, namespace/open, theorem, theorem) tops out at 4, not 5. Rather than force an artificial 5th boundary mid-proof, this splits the one real remaining boundary:

- `header` (1-35): module docstring only
- `setup` (36-38): `namespace OddSquaresSum`, `open Finset` (previously folded into header)
- `integer-form` (39-59): `three_mul_sum_odd_squares` (start corrected 46→39 to include its doc comment)
- `rational-closed-form` (60-74): `sum_odd_squares_rat`, closes the namespace

Sections remain contiguous and cover the full 74-line file. No content deleted; existing annotations/keyInsights/references untouched.