### PR TITLE
Research: erdos-18-wip-01 - hErdos 18/20/28 + record-setters (least practical m with index t is 2^t, t <= 5)

### DIFF
--- a/proofs/Proofs/Erdos18WIP01.lean
+++ b/proofs/Proofs/Erdos18WIP01.lean
@@ -2149,4 +2149,200 @@ theorem hErdos_thirty : hErdos 30 = 4 := by
   exact le_hErdos_of_card (k := 29) thirty_practical (by omega) (by omega)
     (by decide)
 
+/- ## The record-setter question: least practical `m` with `hErdos m = t`
+
+With the engines the exact-value table extends far enough to answer, for
+`t ≤ 4`, the natural "record-setter" question: what is the LEAST practical `m`
+with `hErdos m = t`?  The answer is `2^t` — the powers of two, exactly the
+family where the index formula `hErdos (2^k) = k` is available — because every
+practical number below `2^t` (there are only finitely many: `1, 2, 4, 6, 8, 12`
+below `16`) has index `≤ t − 1`.
+
+Three new engine values feed this:
+
+* **`hErdos 18 = 3`** — like `30`, the number `18 = 2·3²` has NO factorisation
+  into practical parts (`9`, `3` are odd), so `hErdos_mul_le` is silent and the
+  engine is the only route.  Hard target `k = 17` (two-divisor sums from
+  `{1,2,3,6,9}` reach only `15`).
+* **`hErdos 20 = 4`** — the target `k = 18` is the UNIQUE hard target
+  (`18 = 10+5+2+1` is forced: no three divisors of `20` sum to `18`).  Two
+  theory consequences: `20 < 24` yet `hErdos 20 = 4 > 3 = hErdos 24` — the
+  index is NOT monotone along practical numbers — and `d(20) = 6 < 8 = d(24)`
+  with the larger index on the smaller divisor count, sharpening the
+  structure-not-count moral of the `24`/`30` pair.
+* **`hErdos 28 = 4`** — hard target `k = 27` (`27 = 14+7+4+2` forced; the
+  three-divisor sums from `{1,2,4,7,14}` top out at `25`).
+
+The record-setter results themselves (`IsLeast` statements):
+`minimal_hErdos_two/three/four` — least practical `m` with index `2, 3, 4` is
+`4, 8, 16`.  Whether the pattern `2^t` persists for all `t` is genuinely open
+here: it would follow from the general upper bound `hErdos m ≤ log₂ m` for
+practical `m`, which fails to be greedy-provable (practical numbers can have
+consecutive-divisor ratio `> 2`, e.g. `6 → 13` in `78`), so it is recorded as
+a question, not a theorem. -/
+
+set_option maxRecDepth 20000 in
+/-- **`hErdos 18 = 3`** — engine-only, like `30`: `18 = 2·3²` has no
+factorisation into practical parts, so `hErdos_mul_le` gives nothing.  Hard
+target `k = 17`: the two-divisor sums of `{1,2,3,6,9}` reach only `9+6 = 15`. -/
+theorem hErdos_eighteen : hErdos 18 = 3 := by
+  refine le_antisymm (hErdos_le_of_witnesses (by decide)) ?_
+  exact le_hErdos_of_card (k := 17) eighteen_practical (by omega) (by omega)
+    (by decide)
+
+set_option maxRecDepth 20000 in
+/-- **`hErdos 20 = 4`** — unique hard target `k = 18` (`18 = 10+5+2+1` forced;
+no three divisors of `20` sum to `18`).  Note `20 < 24` with
+`hErdos 20 = 4 > 3 = hErdos 24`: the index is not monotone along practical
+numbers, and `d(20) = 6 < 8 = d(24)` puts the LARGER index on the SMALLER
+divisor count. -/
+theorem hErdos_twenty : hErdos 20 = 4 := by
+  refine le_antisymm (hErdos_le_of_witnesses (by decide)) ?_
+  exact le_hErdos_of_card (k := 18) twenty_practical (by omega) (by omega)
+    (by decide)
+
+set_option maxRecDepth 20000 in
+/-- **`hErdos 28 = 4`** — hard target `k = 27` (`27 = 14+7+4+2` forced; the
+three-divisor sums of `{1,2,4,7,14}` top out at `14+7+4 = 25`). -/
+theorem hErdos_twentyeight : hErdos 28 = 4 := by
+  refine le_antisymm (hErdos_le_of_witnesses (by decide)) ?_
+  exact le_hErdos_of_card (k := 27) twentyeight_practical (by omega) (by omega)
+    (by decide)
+
+/-- `hErdos 8 = 3` — the power-of-two formula at `k = 3`. -/
+theorem hErdos_eight : hErdos 8 = 3 := by
+  have h := hErdos_two_pow 3
+  norm_num at h
+  exact h
+
+/-- `hErdos 16 = 4` — the power-of-two formula at `k = 4`. -/
+theorem hErdos_sixteen : hErdos 16 = 4 := by
+  have h := hErdos_two_pow 4
+  norm_num at h
+  exact h
+
+/-- **Every practical number below `16` has index at most `3`.**  The practical
+numbers below `16` are exactly `1, 2, 4, 6, 8, 12` (each non-practical value is
+excluded by a kernel `decide`), and their indices `0, 1, 2, 2, 3, 3` are all
+known exactly. -/
+theorem hErdos_le_three_of_lt_sixteen {m : ℕ} (hm : IsPractical m)
+    (hlt : m < 16) : hErdos m ≤ 3 := by
+  interval_cases m
+  · exact absurd hm (by decide)
+  · simp [hErdos_one]
+  · simp [hErdos_two]
+  · exact absurd hm (by decide)
+  · simp [hErdos_four]
+  · exact absurd hm (by decide)
+  · simp [hErdos_six]
+  · exact absurd hm (by decide)
+  · simp [hErdos_eight]
+  · exact absurd hm (by decide)
+  · exact absurd hm (by decide)
+  · exact absurd hm (by decide)
+  · simp [hErdos_twelve]
+  · exact absurd hm (by decide)
+  · exact absurd hm (by decide)
+  · exact absurd hm (by decide)
+
+/-- **Record-setter at `t = 4`: the least practical number with index `4` is
+`16 = 2⁴`.**  Membership is the power-of-two formula; minimality is
+`hErdos_le_three_of_lt_sixteen`. -/
+theorem minimal_hErdos_four :
+    IsLeast { m : ℕ | IsPractical m ∧ hErdos m = 4 } 16 := by
+  constructor
+  · exact ⟨by decide, hErdos_sixteen⟩
+  · rintro m ⟨hpr, h4⟩
+    by_contra hlt
+    push Not at hlt
+    have := hErdos_le_three_of_lt_sixteen hpr hlt
+    omega
+
+/-- **Record-setter at `t = 3`: the least practical number with index `3` is
+`8 = 2³`.**  The practical numbers below `8` are `1, 2, 4, 6` with indices
+`0, 1, 2, 2`. -/
+theorem minimal_hErdos_three :
+    IsLeast { m : ℕ | IsPractical m ∧ hErdos m = 3 } 8 := by
+  constructor
+  · exact ⟨by decide, hErdos_eight⟩
+  · rintro m ⟨hpr, h3⟩
+    by_contra hlt
+    push Not at hlt
+    have h : hErdos m ≤ 2 := by
+      interval_cases m
+      · exact absurd hpr (by decide)
+      · simp [hErdos_one]
+      · simp [hErdos_two]
+      · exact absurd hpr (by decide)
+      · simp [hErdos_four]
+      · exact absurd hpr (by decide)
+      · simp [hErdos_six]
+      · exact absurd hpr (by decide)
+    omega
+
+/-- **Record-setter at `t = 2`: the least practical number with index `2` is
+`4 = 2²`.**  The practical numbers below `4` are `1, 2` with indices `0, 1`. -/
+theorem minimal_hErdos_two :
+    IsLeast { m : ℕ | IsPractical m ∧ hErdos m = 2 } 4 := by
+  constructor
+  · exact ⟨by decide, hErdos_four⟩
+  · rintro m ⟨hpr, h2⟩
+    by_contra hlt
+    push Not at hlt
+    have h : hErdos m ≤ 1 := by
+      interval_cases m
+      · exact absurd hpr (by decide)
+      · simp [hErdos_one]
+      · simp [hErdos_two]
+      · exact absurd hpr (by decide)
+    omega
+
+/-- `hErdos 32 = 5` — the power-of-two formula at `k = 5`. -/
+theorem hErdos_thirtytwo : hErdos 32 = 5 := by
+  have h := hErdos_two_pow 5
+  norm_num at h
+  exact h
+
+/-- **Every practical number below `32` has index at most `4`.**  The practical
+numbers in `[16, 32)` are `16, 18, 20, 24, 28, 30`, all pinned at index `≤ 4`
+by the engine values; below `16` the bound is
+`hErdos_le_three_of_lt_sixteen`. -/
+theorem hErdos_le_four_of_lt_thirtytwo {m : ℕ} (hm : IsPractical m)
+    (hlt : m < 32) : hErdos m ≤ 4 := by
+  by_cases h16 : m < 16
+  · exact (hErdos_le_three_of_lt_sixteen hm h16).trans (by omega)
+  · push Not at h16
+    interval_cases m
+    · simp [hErdos_sixteen]
+    · exact absurd hm (by decide)
+    · simp [hErdos_eighteen]
+    · exact absurd hm (by decide)
+    · simp [hErdos_twenty]
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · simp [hErdos_twentyfour]
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · simp [hErdos_twentyeight]
+    · exact absurd hm (by decide)
+    · simp [hErdos_thirty]
+    · exact absurd hm (by decide)
+
+/-- **Record-setter at `t = 5`: the least practical number with index `5` is
+`32 = 2⁵`.**  The record-setter sequence for `t = 1, …, 5` is
+`2, 4, 8, 16, 32` — so far exactly the powers of two, the family where the
+index formula `hErdos (2^k) = k` holds.  Whether this persists for all `t`
+is open (see the section comment). -/
+theorem minimal_hErdos_five :
+    IsLeast { m : ℕ | IsPractical m ∧ hErdos m = 5 } 32 := by
+  constructor
+  · exact ⟨by decide, hErdos_thirtytwo⟩
+  · rintro m ⟨hpr, h5⟩
+    by_contra hlt
+    push Not at hlt
+    have := hErdos_le_four_of_lt_thirtytwo hpr hlt
+    omega
+
 end Erdos18

--- a/research/problems/erdos-18-wip-01/knowledge.md
+++ b/research/problems/erdos-18-wip-01/knowledge.md
@@ -352,3 +352,53 @@ NEXT: minimal-m-with-hErdos=t sequence (2,6,12?,30? — needs hErdos 16,18,20,28
 confirm 30 is minimal for 4); hErdos of 2^a·3 family via engines; a lower-bound
 engine iterating the gap argument below m/2 (theory, not per-m decide); deep Vose
 hErdos(n!) < n^{o(1)} still blocked at elementary layer.
+
+## 2026-07-23 (researcher-1) — hErdos 18/20/28 + record-setters (least practical m with index t = 2^t, t ≤ 4)
+
+Engine session answering the prior NEXT (minimal-m sequence). Six new exact-value/
+record theorems + one helper, all 0-axiom (docker-verified):
+
+- `hErdos_eighteen = 3` — 18 = 2·3² joins 30 in the "no practical factorisation"
+  class (9, 3 odd ⟹ hErdos_mul_le silent); hard target k = 17 (pair sums from
+  {1,2,3,6,9} top out at 15).
+- `hErdos_twenty = 4` — the UNIQUE hard target k = 18 (18 = 10+5+2+1 forced; no
+  triple from {1,2,4,5,10} hits 18). **Non-monotonicity datum**: 20 < 24 but
+  hErdos 20 = 4 > 3 = hErdos 24; also d(20) = 6 < 8 = d(24) with LARGER index on
+  SMALLER divisor count — sharpens the structure-not-count moral of 24/30.
+- `hErdos_twentyeight = 4` — hard target k = 27 (14+7+4+2 forced; triples ≤ 25).
+- `hErdos_eight = 3`, `hErdos_sixteen = 4` — hErdos_two_pow specialisations
+  (same norm_num pattern as hErdos_four).
+- `hErdos_le_three_of_lt_sixteen` — interval_cases + per-value decide: practicals
+  below 16 are exactly 1,2,4,6,8,12 (indices 0,1,2,2,3,3).
+- `minimal_hErdos_two/three/four : IsLeast {m | IsPractical m ∧ hErdos m = t} 2^t`
+  — the record-setter sequence starts 2, 4, 8, 16 (t = 1 case is hErdos_eq_one_iff).
+
+### Table (all 0-axiom)
+hErdos: 1↦0, 2↦1, 4↦2, 6↦2, 8↦3, 12↦3, 16↦4, 18↦3, 20↦4, 24↦3, 28↦4, 30↦4, 2^k↦k.
+Hard targets: 12:11, 18:17, 20:18(unique), 24:23, 28:27, 30:29.
+
+### Open question crystallised (NOT a theorem)
+Is the record-setter 2^t for ALL t? Would follow from hErdos m ≤ log₂ m for
+practical m. The greedy halving proof FAILS: greedy needs the largest divisor
+d ≤ k to satisfy 2d > k, i.e. consecutive-divisor ratio ≤ 2, but practical
+numbers can violate this (78 = 2·3·13 is practical with divisor gap 6 → 13,
+ratio 2.17 — check: σ(6) = 12 ≥ 13−1). So the general upper bound needs a
+non-greedy argument (or a counterexample exists at larger t). Good future target.
+
+### Idioms
+- interval_cases + `exact absurd hpr (by decide)` for non-practical values +
+  `simp [hErdos_<val>]` for known values kills finite practical-enumeration goals.
+- IsLeast lower half: `rintro m ⟨hpr, ht⟩; by_contra hlt; push Not at hlt` then
+  the ≤-helper + omega (v4.31: push Not, not push_neg).
+
+UPDATE (same session): went ahead and closed t = 5 too — `hErdos_thirtytwo = 5`,
+`hErdos_le_four_of_lt_thirtytwo` (case split at 16 chains the ≤3 helper; sweep
+16..31), `minimal_hErdos_five : IsLeast ... 32`. Record-setter sequence proved
+2, 4, 8, 16, 32 for t = 1..5.
+
+NEXT: record-setter t = 6 (= 64?) needs engine values for the practicals in
+(32, 64): 36, 40, 42, 48, 54, 56, 60 (7 values; decides get slower — d(48) = 10
+⟹ 1024-subset powerset × 48 targets, likely needs bigger maxRecDepth or a
+smarter engine). General lower-bound engine iterating the gap argument below
+m/2. Non-monotonicity (20 vs 24) suggests studying WHERE the index drops.
+Deep Vose bound still blocked at the elementary layer.

--- a/research/problems/erdos-18-wip-01/state.md
+++ b/research/problems/erdos-18-wip-01/state.md
@@ -32,3 +32,31 @@ Phase ACT. Shipped decide-powered exact-value engines (`hErdos_le_of_witnesses`,
 and `hErdos 30 = 4` (first value with no practical factorisation — engines are the
 only route). All 0-axiom, host-verified. Deep Vose bound unchanged. See
 knowledge.md for the exact-value table and next candidates.
+
+## Status (researcher-1, 2026-07-23) — hErdos 18/20/28 + record-setters: least practical m with index t is 2^t (t ≤ 4)
+
+Phase ACT. Engine session extending the exact table and answering the
+minimal-m question the prior session posed (it asked for hErdos 16,18,20,28;
+hErdos 16 = 4 was already available via hErdos_two_pow):
+
+- `hErdos_eighteen : hErdos 18 = 3` — engine-only (18 = 2·3² has no practical
+  factorisation, like 30); hard target k = 17.
+- `hErdos_twenty : hErdos 20 = 4` — UNIQUE hard target k = 18 (10+5+2+1 forced).
+  Theory data: 20 < 24 with hErdos 20 = 4 > 3 = hErdos 24 — the index is NOT
+  monotone along practical numbers; and d(20) = 6 < 8 = d(24) with the larger
+  index on the smaller divisor count.
+- `hErdos_twentyeight : hErdos 28 = 4` — hard target k = 27 (14+7+4+2 forced).
+- `hErdos_eight`, `hErdos_sixteen` — power-of-two formula specialisations.
+- `hErdos_le_three_of_lt_sixteen` — every practical m < 16 has index ≤ 3
+  (practicals below 16 are 1,2,4,6,8,12 with indices 0,1,2,2,3,3).
+- `minimal_hErdos_two/three/four` — **IsLeast record-setters**: the least
+  practical m with hErdos m = t is 2^t for t = 2, 3, 4.
+
+Whether the record-setter is 2^t for ALL t is genuinely open here: it would
+follow from hErdos m ≤ log₂ m (practical m), which is NOT greedy-provable —
+practical numbers can have consecutive-divisor ratio > 2 (6 → 13 in 78), so the
+halving argument breaks. Recorded as a question. Deep Vose bound unchanged.
+
+Same-session addendum: t = 5 closed too — hErdos_thirtytwo = 5,
+hErdos_le_four_of_lt_thirtytwo, minimal_hErdos_five (IsLeast ... 32). The
+record-setter sequence is proved 2, 4, 8, 16, 32 for t = 1..5.

--- a/src/data/research/problems/erdos-18-wip-01.json
+++ b/src/data/research/problems/erdos-18-wip-01.json
@@ -20,10 +20,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-09T17:33:19-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "iteration": 2,
+    "focus": "2026-07-23: exact table extended + RECORD-SETTERS proved — hErdos 18 = 3 (engine-only, no practical factorisation), hErdos 20 = 4 (unique hard target 18; NON-MONOTONICITY: 20 < 24 but hErdos 20 = 4 > 3 = hErdos 24, and d(20) = 6 < 8 = d(24)), hErdos 28 = 4 (hard target 27), hErdos 8/16/32 via the power formula, and minimal_hErdos_two/three/four/five (IsLeast): the least practical m with hErdos m = t is 2^t for t = 2..5 — record-setter sequence 2, 4, 8, 16, 32. All 0-axiom, docker-verified. Open question crystallised: is the record-setter 2^t for ALL t? Would follow from hErdos m <= log2 m (practical m), but the greedy proof FAILS (practical 78 has divisor-gap ratio 13/6 > 2), so a non-greedy argument is needed.",
     "blockers": [],
-    "nextAction": "The correct Erdos #18 index is now formalized in Erdos18WIP01.lean: repLength m k (fewest divisors of m summing to k) and hErdos m = max_{k<m} repLength m k, with the axiom-free sandwich 1 <= hErdos m <= h m <= d(m) for practical m>=2 (hErdos_le_h confirms the parent's universal-set h over-counts) and the prize conjectures re-homed onto hErdos (conjecture_part1_erdos, conjecture_part2_weak_erdos). RESIDUAL mechanic follow-up: rename the parent Erdos18Problem.lean h -> hCover and repoint its conjecture_part1/part2_weak/part2_strong (and the Erdos18OQ01 subadditivity) at hErdos. DEEP/open: hErdos(n!) < n^{o(1)} (Vose 1985, ~sqrt log m i.o.) unformalized. Practicality-membership theory saturated.",
+    "nextAction": "Record-setter t = 6 (= 64?) needs engine values for practicals in (32,64): 36, 40, 42, 48, 54, 56, 60 (decides slower: d(48) = 10 => 1024-subset powerset x 48 targets). General lower-bound engine iterating the gap argument below m/2. Study where the index DROPS (20 vs 24 non-monotonicity). The log2 upper bound for practical m (would settle the record-setter question) needs a non-greedy argument. Deep Vose hErdos(n!) < n^{o(1)} still blocked at the elementary layer.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -56,7 +56,11 @@
       "le_repLength_of_card + le_hErdos_of_card in Erdos18WIP01.lean (decide-powered lower-bound engine)",
       "hErdos_twentyfour = 3, hErdos_four = 2, twentyfour_practical in Erdos18WIP01.lean",
       "hErdos_mul_lt_four_six in Erdos18WIP01.lean (first strict subadditivity instance)",
-      "hErdos_thirty = 4, thirty_practical in Erdos18WIP01.lean"
+      "hErdos_thirty = 4, thirty_practical in Erdos18WIP01.lean",
+      "hErdos_eighteen (= 3), hErdos_twenty (= 4), hErdos_twentyeight (= 4) — engine exact values in Erdos18WIP01.lean",
+      "hErdos_eight/hErdos_sixteen/hErdos_thirtytwo — power-formula specialisations in Erdos18WIP01.lean",
+      "hErdos_le_three_of_lt_sixteen + hErdos_le_four_of_lt_thirtytwo (finite practical-enumeration bounds) in Erdos18WIP01.lean",
+      "minimal_hErdos_two/three/four/five (IsLeast record-setters: least practical m with index t is 2^t, t = 2..5) in Erdos18WIP01.lean"
     ],
     "insights": [
       "Erdos18Problem.lean stub developed: representability (IsRepresentable) and practicality (IsPractical) are DECIDABLE via a finite powerset search over the divisor set — a single decision procedure subsuming all future example checks; all lemmas axiom-free (plain kernel decide, no native_decide/Lean.ofReduceBool).",
@@ -80,7 +84,10 @@
       "hErdos 12 = 3 shows subadditivity hErdos(a*b)<=hErdos a+hErdos b is TIGHT at 12=2*6; the counting bound lt_hErdos_of_pow_lt only gives hErdos 12 >= 2, so the combinatorial gap argument is strictly sharper at small scales",
       "Exact hErdos values reduce to two kernel decides via engines: upper (forall k < m exists small witness subset) + lower (one hard target where every summing subset is large); maxRecDepth 20000 needed for 8-divisor powersets",
       "Subadditivity hErdos(ab) <= hErdos a + hErdos b can be STRICT: hErdos(4*6) = 3 < 4 = hErdos 4 + hErdos 6, while 12 = 2*6 is tight — tightness depends on the factorisation",
-      "hErdos 30 = 4 is unreachable by subadditivity (30 = 2*3*5 has no practical factorisation) — the decide engine is strictly stronger than all prior bound tools; d(24) = d(30) = 8 but hErdos differs (3 vs 4), so the index sees divisor structure not divisor count"
+      "hErdos 30 = 4 is unreachable by subadditivity (30 = 2*3*5 has no practical factorisation) — the decide engine is strictly stronger than all prior bound tools; d(24) = d(30) = 8 but hErdos differs (3 vs 4), so the index sees divisor structure not divisor count",
+      "The index is NOT monotone along practical numbers: hErdos 20 = 4 > 3 = hErdos 24 with 20 < 24 and d(20) < d(24) — the larger index on the smaller divisor count",
+      "Record-setter sequence (least practical m with hErdos = t) is 2,4,8,16,32 for t = 1..5 — exactly the powers of two; 2^t for all t would follow from hErdos m <= log2 m (practical m), but greedy halving fails: practical numbers can have consecutive-divisor ratio > 2 (78 = 2*3*13, gap 6 -> 13)",
+      "Finite practical-enumeration goals: interval_cases + 'exact absurd hpr (by decide)' on non-practical values + 'simp [hErdos_<val>]' on pinned values; chain helpers with a by_cases at the previous threshold"
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -108,7 +115,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.780Z",
-  "lastUpdate": "2026-07-22T05:59:07Z",
+  "lastUpdate": "2026-07-23",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

Research session on **erdos-18-wip-01** (Erdős #18, fewest divisors representing every k < m — the `hErdos` index on practical numbers).

The prior session (#41892) shipped decide-powered exact-value engines and asked for hErdos 16, 18, 20, 28 to settle the "minimal m with index t" question. This session answers it through t = 5: the least practical m with `hErdos m = t` is exactly `2^t`.

### New exact values (engine-driven, kernel `decide` only — no native_decide)

- `hErdos_eighteen : hErdos 18 = 3` — engine-only, like 30: `18 = 2·3²` has no factorisation into practical parts, so `hErdos_mul_le` is silent. Hard target k = 17.
- `hErdos_twenty : hErdos 20 = 4` — the **unique** hard target is k = 18 (`18 = 10+5+2+1` forced). Two theory consequences: `20 < 24` yet `hErdos 20 = 4 > 3 = hErdos 24` — the index is **not monotone** along practical numbers — and `d(20) = 6 < 8 = d(24)` puts the larger index on the smaller divisor count.
- `hErdos_twentyeight : hErdos 28 = 4` — hard target k = 27 (`14+7+4+2` forced).
- `hErdos_eight = 3`, `hErdos_sixteen = 4`, `hErdos_thirtytwo = 5` — power-formula specialisations.

### Record-setters (`IsLeast` statements)

- `minimal_hErdos_two/three/four/five` — the least practical m with `hErdos m = t` is `4, 8, 16, 32` for t = 2..5 (t = 1 was already `hErdos_eq_one_iff`). Helpers `hErdos_le_three_of_lt_sixteen` and `hErdos_le_four_of_lt_thirtytwo` enumerate the finitely many practical numbers below each threshold.

The exact table now: hErdos 1,2,4,6,8,12,16,18,20,24,28,30,32 = 0,1,2,2,3,3,4,3,4,3,4,4,5 (+ `hErdos (2^k) = k`).

### Open question crystallised (recorded, not claimed)

Is the record-setter `2^t` for **all** t? It would follow from `hErdos m ≤ log₂ m` for practical m, but the greedy halving proof fails: practical numbers can have consecutive-divisor ratio > 2 (78 = 2·3·13 has the gap 6 → 13), so a non-greedy argument is needed. Deep Vose bound (`hErdos(n!)` polynomially small) unchanged.

### Honest accounting

- 0 sorries, 0 axioms; kernel `decide` under `set_option maxRecDepth 20000` (same pattern as the existing 24/30 values).
- Built via `./proofs/scripts/docker-build.sh Proofs.Erdos18WIP01` (8577 jobs, exit 0, twice — before and after the t = 5 batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
