### PR TITLE
audit(erdos-361): fix phantom asymptotic-growth identifiers in section prose

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12923,9 +12923,9 @@
     },
     "erdos-361": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:35Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T20:26:47Z",
+      "result": "issues-fixed"
     },
     "erdos-362": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-361/meta.json
+++ b/src/data/proofs/erdos-361/meta.json
@@ -104,8 +104,8 @@
       "title": "Asymptotic Growth",
       "startLine": 52,
       "endLine": 64,
-      "summary": "documents in source comments `maxNonRepr_bigO_bound` (no Lean declaration exists) (existence of a big-O bound) and the plausible $\\Theta(\\sqrt{n})$ growth rate `maxNonRepr_plausible_theta` using Mathlib's `Asymptotics.IsTheta` and `Asymptotics.IsBigO` with `Filter.atTop`.",
-      "mathContext": "Axioms: $\\text{maxNonReprSize}(c, n) = O(f(n))$ for some $f$; conjecture: $\\text{maxNonReprSize}(c, n) = \\Theta(\\sqrt{n})$, formalized via Mathlib's $\\texttt{IsTheta}$."
+      "summary": "Records two open asymptotic questions as prose comments only — no Lean declaration exists for either: whether `maxNonReprSize c n` admits a big-$O$ upper bound, and the plausible $\\Theta(\\sqrt{n})$ growth rate. `Asymptotics.IsBigO`/`IsTheta` are imported but never invoked in the file.",
+      "mathContext": "Open questions (prose only, not formalized as axiom, definition, or theorem): does $\\text{maxNonReprSize}(c, n) = O(f(n))$ for some $f$? Is $\\text{maxNonReprSize}(c, n) = \\Theta(\\sqrt{n})$? No Mathlib $\\texttt{IsBigO}$/$\\texttt{IsTheta}$ declaration is made."
     },
     {
       "id": "basic-properties",


### PR DESCRIPTION
## Integrity Issue (fixed directly)

**Proof**: erdos-361 (Largest Non-Representing Subsets)
**Problem**: The `sections[].asymptotics` block invented two Lean identifiers
that don't exist in the source (`maxNonRepr_bigO_bound`,
`maxNonRepr_plausible_theta`) and its `mathContext` labeled the file's
prose-only open questions as formal `Axioms:`, claiming they are
"formalized via Mathlib's IsTheta". `Asymptotics.IsBigO`/`IsTheta` are
imported in the Lean file but never actually invoked anywhere.

This contradicted the file's own honest `overview.proofStrategy` and
top-level `conclusion.summary`, which correctly state "no asymptotic
axiom or IsBigO/IsTheta declaration is present."

## Evidence

- `grep -n "maxNonRepr_bigO_bound\|maxNonRepr_plausible_theta\|IsTheta\|IsBigO" proofs/Proofs/Erdos361Problem.lean` → no matches.
- `axiomCount: 0`, 0 sorries confirmed (`grep -n "sorry\|^axiom"` → no matches); `theoremCount: 6` / `definitionCount: 5` match the source; `lineCount: 140` matches `wc -l`.
- `status: "axiomatized"` + `axiomCount: 0` is this repo's normal convention for an open conjecture stated as an unproved `Prop`/`def` (`ErdosProblem361`, `MaxNonReprUnbounded`), not a mismatch.

## Fix

Reworded the `asymptotics` section's `summary`/`mathContext` to describe
the two open asymptotic questions as unformalized prose comments only,
matching the rest of the file's honest disclosure. No badge/status change.

---
Discovered during gallery integrity audit (round-robin re-serve, oldest
audit in queue — erdos-361, previously clean x4).