### PR TITLE
audit(erdos-359): fix phantom axiom identifiers and stale annotation ranges

### DIFF
--- a/src/data/proofs/erdos-359/annotations.json
+++ b/src/data/proofs/erdos-359/annotations.json
@@ -164,8 +164,8 @@
     "id": "ann-e359-skip-examples",
     "proofId": "erdos-359",
     "range": {
-      "startLine": 117,
-      "endLine": 134
+      "startLine": 113,
+      "endLine": 131
     },
     "type": "concept",
     "title": "Why 3 and 6 are Skipped",
@@ -187,21 +187,20 @@
     "id": "ann-e359-growth-conjectures",
     "proofId": "erdos-359",
     "range": {
-      "startLine": 144,
-      "endLine": 162
+      "startLine": 133,
+      "endLine": 146
     },
     "type": "concept",
     "title": "Growth Rate Conjectures (OPEN)",
-    "content": "**Three open conjectures**: (1) a_k/k -> infinity (superlinear), (2) a_k/k^{1+c} -> 0 for c > 0 (subpolynomial), (3) Andrews' conjecture a_k ~ (k log k)/(log log k).",
-    "mathContext": "These capture the expected intermediate growth rate - faster than linear but slower than any polynomial > 1. All remain OPEN.",
+    "content": "**Three open conjectures**, recorded as prose comments (not Lean declarations): (1) a_k/k -> infinity (superlinear), (2) a_k/k^{1+c} -> 0 for c > 0 (subpolynomial), (3) Andrews' conjecture a_k ~ (k log k)/(log log k).",
+    "mathContext": "These capture the expected intermediate growth rate - faster than linear but slower than any polynomial > 1. All remain OPEN and are not formalized as Lean statements.",
     "significance": "key",
     "relatedConcepts": [
-      "tendsto",
       "asymptotic",
       "open-problem"
     ],
     "prerequisites": [
-      "superlinear and subpolynomial growth via Tendsto limits",
+      "superlinear and subpolynomial growth stated informally, not as Lean Tendsto statements",
       "Andrews' conjecture a_k ~ (k log k)/(log log k)",
       "intermediate asymptotic growth rate"
     ]
@@ -210,12 +209,12 @@
     "id": "ann-e359-porubsky-upper",
     "proofId": "erdos-359",
     "range": {
-      "startLine": 170,
-      "endLine": 176
+      "startLine": 154,
+      "endLine": 155
     },
     "type": "concept",
     "title": "Porubsky's Upper Bound (1977)",
-    "content": "**porubsky_upper** states: for any epsilon > 0, infinitely many k satisfy a_k < (log k)^epsilon * (k log k)/(log log k). This gives partial evidence for Andrews' conjecture.",
+    "content": "A comment records Porubsky's 1977 upper bound: for any epsilon > 0, infinitely many k satisfy a_k < (log k)^epsilon * (k log k)/(log log k). This is not a formalized Lean statement - no theorem or axiom captures it.",
     "mathContext": "The bound shows the sequence doesn't grow too much faster than the conjectured rate, at least infinitely often.",
     "significance": "key",
     "relatedConcepts": [
@@ -232,8 +231,8 @@
     "id": "ann-e359-counting",
     "proofId": "erdos-359",
     "range": {
-      "startLine": 177,
-      "endLine": 184
+      "startLine": 157,
+      "endLine": 163
     },
     "type": "definition",
     "title": "Counting Functions",
@@ -255,12 +254,12 @@
     "id": "ann-e359-porubsky-density",
     "proofId": "erdos-359",
     "range": {
-      "startLine": 186,
-      "endLine": 192
+      "startLine": 164,
+      "endLine": 166
     },
     "type": "concept",
     "title": "Porubsky's Density Bound",
-    "content": "**porubsky_density_bound** states limsup A(x)/pi(x) >= 1/log(2). MacMahon's sequence is denser than primes by at least this factor infinitely often.",
+    "content": "A comment records Porubsky's density bound: limsup A(x)/pi(x) >= 1/log(2). MacMahon's sequence is conjectured to be denser than primes by at least this factor infinitely often. This is not a formalized Lean statement - no theorem or axiom captures it.",
     "mathContext": "Since 1/log(2) ~ 1.44, the sequence has at least 44% more elements than primes (asymptotically, infinitely often).",
     "significance": "key",
     "relatedConcepts": [
@@ -278,12 +277,12 @@
     "id": "ann-e359-general-n",
     "proofId": "erdos-359",
     "range": {
-      "startLine": 199,
-      "endLine": 204
+      "startLine": 168,
+      "endLine": 174
     },
     "type": "concept",
     "title": "General Starting Value",
-    "content": "**general_n_superlinear** conjectures that sequences 'good for n' (starting with any n > 0) also have superlinear growth a_k/k -> infinity.",
+    "content": "A comment conjectures that sequences 'good for n' (starting with any n > 0) also have superlinear growth a_k/k -> infinity. This is not formalized - no Lean definition or theorem states it.",
     "mathContext": "The problem generalizes beyond n = 1. Different starting values create different sequences but with similar growth behavior.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-359/meta.json
+++ b/src/data/proofs/erdos-359/meta.json
@@ -25,11 +25,6 @@
     "mathlib_version": "4.31.0",
     "mathlibDependencies": [
       {
-        "theorem": "Filter.Tendsto",
-        "description": "Limits for growth rate statements",
-        "module": "Mathlib.Order.Filter.AtTopBot.Basic"
-      },
-      {
         "theorem": "Finset.Icc",
         "description": "Closed intervals for consecutive sums",
         "module": "Mathlib.Data.Finset.Basic"
@@ -49,12 +44,11 @@
       "Formal definition of consecutive sum achievability",
       "Definition of MacMahon sequence as 'good for 1'",
       "Verified examples of why 3 and 6 are skipped",
-      "Formalization of Andrews' asymptotic conjecture",
-      "Formalization of Porubsky's density bounds"
+      "Documented (not formalized) Andrews' asymptotic conjecture and Porubsky's density bounds as comments"
     ],
     "axiomCount": 0,
     "lineCount": 207,
-    "assumptions": "0 axioms, 0 sorries. Partial formalization of MacMahon's sequence problem: defines the sequence recursively and proves 6 basic structural properties. The main open conjectures about density and asymptotic growth (macmahon_initial_values, growth_faster_than_linear, etc.) are not formalized.",
+    "assumptions": "0 axioms, 0 sorries. Partial formalization of MacMahon's sequence problem: defines the sequence recursively and proves 6 basic structural properties. The main open conjectures (superlinear growth, subpolynomial growth, Andrews' asymptotic formula, Porubsky's density bound) are recorded only as prose comments, not as Lean axioms, definitions, or theorems.",
     "theoremCount": 6,
     "definitionCount": 7
   },
@@ -62,7 +56,7 @@
     "historicalContext": "Erdos Problem #359 concerns MacMahon's 'prime numbers of measurement' (OEIS A002048), a sequence defined by P.A. MacMahon in the early 20th century. The sequence starts with 1, and each subsequent term is the smallest positive integer that cannot be expressed as a sum of consecutive earlier terms.\n\nThe sequence begins: 1, 2, 4, 5, 8, 10, 14, 15, 21, 22, 26, 28, ...\n\nGeorge Andrews studied this sequence in 1975 and conjectured that a_k ~ (k log k) / (log log k). Stefan Porubsky proved partial results in 1977, establishing bounds comparing the sequence to the prime counting function.\n\nThe question of the exact growth rate remains OPEN. It is conjectured that a_k/k tends to infinity (superlinear growth) but a_k/k^{1+c} tends to 0 for any c > 0 (subpolynomial growth).",
     "problemStatement": "Let $a_1 < a_2 < \\cdots$ be an infinite sequence where $a_1 = n$ and $a_{i+1}$ is the smallest integer not expressible as a sum of consecutive earlier terms $a_j + a_{j+1} + \\cdots + a_k$.\n\n**Questions** (for $n = 1$):\n1. Prove $a_k / k \\to \\infty$\n2. Prove $a_k / k^{1+c} \\to 0$ for any $c > 0$\n\n**Conjecture** (Andrews): $a_k \\sim \\frac{k \\log k}{\\log \\log k}$\n\n**Status**: OPEN",
     "text": "What is the density of MacMahon's sequence where each term is the smallest integer not expressible as a sum of consecutive earlier terms? Conjectured: a_k ~ (k log k) / (log log k).",
-    "proofStrategy": "We formalize the problem by defining:\n\n1. **ConsecutiveSum**: The sum of terms A(a) + A(a+1) + ... + A(b)\n2. **AchievableSums**: All integers expressible as consecutive sums\n3. **IsGoodFor**: A sequence is 'good for n' if A(0) = n and each A(j+1) is the smallest integer greater than A(j) not in AchievableSums\n4. **IsMacMahonSeq**: The sequence 'good for 1'\n\nThe growth rate conjectures are stated as axioms since they remain open. We verify concrete examples (why 3 and 6 are skipped) and formalize Porubsky's density bounds.",
+    "proofStrategy": "We formalize the problem by defining:\n\n1. **ConsecutiveSum**: The sum of terms A(a) + A(a+1) + ... + A(b)\n2. **AchievableSums**: All integers expressible as consecutive sums\n3. **IsGoodFor**: A sequence is 'good for n' if A(0) = n and each A(j+1) is the smallest integer greater than A(j) not in AchievableSums\n4. **IsMacMahonSeq**: The sequence 'good for 1'\n\nThe growth rate conjectures remain open and are documented only as prose comments, not as Lean axioms or theorems, since stating them as axioms would misrepresent open conjectures as established facts. We verify concrete examples (why 3 and 6 are skipped) and define counting functions to compare the sequence's density with the primes, following Porubsky's approach.",
     "keyInsights": [
       "**Consecutive sums**: Unlike subset sums, we only consider sums of consecutive terms. This is more restrictive but creates interesting gaps.",
       "**OEIS A002048**: The MacMahon sequence 1, 2, 4, 5, 8, 10, 14, 15, ... is well-studied. Note 3 is missing because 3 = 1 + 2.",
@@ -95,29 +89,29 @@
       "id": "known-values",
       "title": "Known Values",
       "startLine": 94,
-      "endLine": 135,
+      "endLine": 131,
       "summary": "First 8 values: 1, 2, 4, 5, 8, 10, 14, 15. Why 3 and 6 are skipped."
     },
     {
       "id": "growth-conjectures",
       "title": "Growth Rate Conjectures",
-      "startLine": 136,
-      "endLine": 163,
-      "summary": "Open conjectures: superlinear but subpolynomial growth, Andrews' asymptotic."
+      "startLine": 133,
+      "endLine": 146,
+      "summary": "Open conjectures (comments only): superlinear but subpolynomial growth, Andrews' asymptotic."
     },
     {
       "id": "porubsky",
       "title": "Porubsky's Results",
-      "startLine": 164,
-      "endLine": 193,
-      "summary": "Porubsky's upper bound and density comparison with primes."
+      "startLine": 148,
+      "endLine": 166,
+      "summary": "Porubsky's upper bound (comment) and density comparison with primes via countingFunction/primeCounting."
     },
     {
       "id": "general-n",
       "title": "General Starting Value",
-      "startLine": 194,
-      "endLine": 207,
-      "summary": "Extension to sequences starting with n != 1."
+      "startLine": 168,
+      "endLine": 174,
+      "summary": "Comment noting the conjectured extension to sequences starting with n != 1."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-359 (MacMahon's Prime Numbers of Measurement)
**Problem**: Phantom axiom/theorem identifiers in prose plus stale annotation line ranges.

## Evidence

`annotations.json` presented three identifiers in bold as if they were real Lean
declarations — `porubsky_upper`, `porubsky_density_bound`, `general_n_superlinear`
— none of which exist anywhere in `Proofs/Erdos359Problem.lean` (confirmed via
grep). The open conjectures they refer to (Porubsky's upper bound, Porubsky's
density bound, growth for general starting value n) are recorded only as prose
comments in the Lean file, never as `axiom`, `def`, or `theorem`.

`meta.json` had the matching bug: `assumptions` named two more phantom
identifiers (`macmahon_initial_values`, `growth_faster_than_linear`) that also
don't exist in the file, and `originalContributions` claimed "Formalization of
Andrews' asymptotic conjecture" / "Formalization of Porubsky's density bounds" —
directly contradicted by the file's own `assumptions` text, since nothing was
formalized (0 axioms, comments only). `proofStrategy` also claimed "The growth
rate conjectures are stated as axioms since they remain open," which is false —
`axiomCount` is correctly 0; the conjectures are comments, not axioms.
`mathlibDependencies` listed `Filter.Tendsto` as used "for growth rate
statements," but `Tendsto` never appears in the file (grep confirms).

Several annotation/section line ranges had also drifted onto unrelated content
(e.g. `ann-e359-general-n` pointed at the `erdos_359_summary` theorem proof
instead of the actual "General Starting Value" comment block; `ann-e359-counting`
pointed at the Summary prose block instead of the `countingFunction`/
`primeCounting` definitions) — consistent with the file being edited (axioms
converted to comments) after the meta/annotations were generated, without a
re-anchor pass.

## Fix

- Removed phantom identifier names from `meta.json` `assumptions` and
  `annotations.json`; replaced with honest descriptions ("recorded as a comment,
  not formalized — no theorem or axiom captures it").
- Corrected `originalContributions` and `proofStrategy` to stop claiming these
  open conjectures were "formalized" or "stated as axioms."
- Removed the unused `Filter.Tendsto` mathlibDependency entry.
- Re-anchored `known-values`, `growth-conjectures`, `porubsky`, `general-n`
  section ranges in `meta.json`, and the corresponding annotation ranges in
  `annotations.json`, to the content they actually describe.

No change to `axiomCount` (0), `sorries` (0), `theoremCount` (6), or
`definitionCount` (7) — all were already accurate.

---
Discovered during gallery integrity audit.