### PR TITLE
Enrich picks-theorem-oq-03-ext-oq-02: split sections to 5, cover full file (3->5)

### DIFF
--- a/src/data/proofs/picks-theorem-oq-03-ext-oq-02/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03-ext-oq-02/meta.json
@@ -49,25 +49,41 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Docstring: Hibi's Palindromy Criterion",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "States the goal: abstract the parent entry's example-based h*-vector palindromy into the general algebraic characterization, Hibi's criterion (1991) — h*-vector palindromic iff h*-polynomial self-reciprocal — proved over an arbitrary commutative semiring with 0 sorries and 0 axioms. Imports Mathlib, opens Polynomial and Finset, fixes a semiring variable R.",
+      "mathContext": "Hibi's criterion: $h_i = h_{d-i}$ for all $i \\le d$ iff $\\mathrm{reflect}_d H = H$ where $H(X) = \\sum h_i X^i$."
+    },
+    {
       "id": "hstar-polynomial",
       "title": "Section I: The h*-Polynomial and Palindromy",
-      "startLine": 47,
-      "endLine": 62,
+      "startLine": 45,
+      "endLine": 59,
       "summary": "Defines hStarPoly d h = sum_{i in range (d+1)} C (h i) * X^i and Palindromic d h := for all i <= d, h i = h (d-i). Proves coeff_hStarPoly: the polynomial coefficients are exactly the entries of h up to d.",
       "mathContext": "The h*-polynomial $H(X) = \\sum_{i=0}^{d} h^*_i X^i$ packages the h*-vector; palindromy is $h^*_i = h^*_{d-i}$."
     },
     {
       "id": "hibi-criterion",
       "title": "Section II: Hibi's Criterion (Algebraic Core)",
-      "startLine": 64,
-      "endLine": 97,
-      "summary": "reflect_eq_iff_palindromic: reflect d (hStarPoly d h) = hStarPoly d h <-> Palindromic d h, over any semiring. reflexive_hStar_palindromic: self-reciprocity (reflexivity) implies palindromy. hStar_constant_eq_leading: palindromic implies h_0 = h_d.",
+      "startLine": 61,
+      "endLine": 78,
+      "summary": "reflect_eq_iff_palindromic: reflect d (hStarPoly d h) = hStarPoly d h <-> Palindromic d h, over any semiring — proved by Polynomial.ext together with coeff_reflect and the two branches of revAt.",
       "mathContext": "Self-reciprocity $\\mathrm{reflect}_d H = H$ means $\\mathrm{coeff}_i = \\mathrm{coeff}_{d-i}$; this is Hibi's reflexive iff palindromic, reduced to its algebraic skeleton."
     },
     {
+      "id": "reflexive-bridge",
+      "title": "Section III: The Reflexive-to-Palindromic Bridge and Normalization",
+      "startLine": 80,
+      "endLine": 96,
+      "summary": "reflexive_hStar_palindromic: self-reciprocity (the reflexivity/Ehrhart-Macdonald reciprocity content, taken as an explicit hypothesis) implies palindromy, by direct application of reflect_eq_iff_palindromic. hStar_constant_eq_leading: a palindromic h*-vector satisfies h_0 = h_d, the reflexive/Gorenstein normalization.",
+      "mathContext": "Given self-reciprocity as hypothesis, palindromy and the normalization $h_0 = h_d$ follow immediately from the algebraic equivalence."
+    },
+    {
       "id": "octahedron-corollary",
-      "title": "Section III: Octahedron Example as a Corollary",
-      "startLine": 99,
+      "title": "Section IV: Octahedron Example as a Corollary",
+      "startLine": 98,
       "endLine": 121,
       "summary": "octaH = (1,3,3,1); octaH_palindromic via interval_cases; octaH_self_reciprocal obtained from palindromy through the general equivalence; octaH_normalization confirms h_0 = h_3.",
       "mathContext": "The octahedron (3D cross-polytope) is reflexive; its h*-vector $(1,3,3,1)$ is palindromic, recovered here as an instance of the general theorem."


### PR DESCRIPTION
Enrichment pass for picks-theorem-oq-03-ext-oq-02: splits the `sections` array from 3 to 5, anchored at real theorem/definition boundaries in `Proofs/PicksTheoremOQ03ExtOQ02.lean`, and closes the header-docstring coverage gap (lines 1-44 were previously uncovered).

- New `header` section (1-44): module docstring stating Hibi's palindromy criterion goal.
- `hstar-polynomial` narrowed to the def block (45-59).
- `hibi-criterion` narrowed to just `reflect_eq_iff_palindromic` (61-78).
- New `reflexive-bridge` section (80-96): `reflexive_hStar_palindromic` + `hStar_constant_eq_leading`, previously bundled into the criterion section.
- `octahedron-corollary` unchanged in content, renumbered to Section IV (98-121).

Sections now cover the full 121-line file with no gaps. No content deleted; annotations.json untouched (already at 5 annotations meeting the quality target).