### PR TITLE
Enrich prime-gap-bounds-oq-02: split sections to 5, cover full file (3->5)

### DIFF
--- a/src/data/proofs/prime-gap-bounds-oq-02/meta.json
+++ b/src/data/proofs/prime-gap-bounds-oq-02/meta.json
@@ -74,6 +74,22 @@
   },
   "sections": [
     {
+      "id": "sec-header",
+      "title": "Header: Goal, Argument Sketch, and Status",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Module docstring: states the Rosser–Schoenfeld inequalities and explains why only the UPPER bound is reachable from Mathlib's Chebyshev estimate θ(x) ≤ log4·x; sketches the elementary tail argument (primes in (√x, x] each contribute ≥ ½ log x to θ) and records the status (0 axioms, 0 sorries) plus references.",
+      "mathContext": "x/log x < π(x) < 1.25506·x/log x (Rosser–Schoenfeld); this file proves the axiom-free upper half π(⌊x⌋) ≤ √x + 1 + (log 16)·x/log x."
+    },
+    {
+      "id": "sec-setup",
+      "title": "Imports and Namespace",
+      "startLine": 52,
+      "endLine": 59,
+      "summary": "`import Mathlib`, `open Finset`, `open scoped Nat.Prime`, and `namespace BoundedPrimeGapsOQ02Chebyshev` — the syntactic setup before the θ↔π bridge theorem.",
+      "mathContext": "Standard Mathlib import and namespace opening for the Chebyshev/prime-counting development."
+    },
+    {
       "id": "sec-bridge",
       "title": "The θ↔π Bridge (Mathlib TODO)",
       "startLine": 60,


### PR DESCRIPTION
## Summary
- `sections.length` was 3 (quality-score cap 6/10); split the uncovered 59-line header (docstring + import/opens/namespace) into 2 real syntactic sections, bringing coverage to the full 194-line file.
- New boundaries: `sec-header` (1-51, module docstring: Rosser–Schoenfeld statement, argument sketch, status), `sec-setup` (52-59, `import`/`open`/`namespace`), plus the unchanged `sec-bridge` (60-94), `sec-trivial` (95-105), `sec-main` (106-194).
- No changes to Lean source, annotations, or other meta.json fields — sections-only enrichment pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
