### PR TITLE
Enrich newton-power-sum-identities-oq-01-oq-02: split sections to 5, cover full file (4->5)

### DIFF
--- a/src/data/proofs/newton-power-sum-identities-oq-01-oq-02/meta.json
+++ b/src/data/proofs/newton-power-sum-identities-oq-01-oq-02/meta.json
@@ -109,9 +109,17 @@
       "id": "determinant",
       "title": "Toeplitz-determinant closed form",
       "startLine": 134,
-      "endLine": 164,
-      "summary": "esymm_one_det, two_esymm_two_det, six_esymm_three_det: k!·eₖ as the determinant of the lower-Hessenberg Toeplitz matrix in the power sums, expanded via det_fin_one_of/det_fin_two_of/det_fin_three and matched to the scalar reverse identities; plus a Fin 2 / ℤ worked example.",
+      "endLine": 149,
+      "summary": "esymm_one_det, two_esymm_two_det, six_esymm_three_det: k!·eₖ as the determinant of the lower-Hessenberg Toeplitz matrix in the power sums, expanded via det_fin_one_of/det_fin_two_of/det_fin_three and matched to the scalar reverse identities.",
       "mathContext": "$3!\\,e_3=\\det\\begin{pmatrix}p_1&1&0\\\\p_2&p_1&2\\\\p_3&p_2&p_1\\end{pmatrix}$."
+    },
+    {
+      "id": "worked-example",
+      "title": "Worked Example: Fin 2 over ℤ",
+      "startLine": 151,
+      "endLine": 164,
+      "summary": "Specialises the degree-2 determinant identity to two variables over ℤ (σ = Fin 2, R = ℤ), where p₁ = X₀ + X₁, p₂ = X₀² + X₁², and 2·e₂ = 2·X₀X₁ = p₁² − p₂, confirming the abstract closed form against the familiar symmetric-function formulas.",
+      "mathContext": "$2\\,e_2(X_0,X_1) = 2X_0X_1 = p_1^2 - p_2$ at $\\sigma = \\mathrm{Fin}\\,2,\\ R = \\mathbb{Z}$."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for newton-power-sum-identities-oq-01-oq-02: splits the `sections` array from 4 to 5, anchored at real boundaries in `Proofs/NewtonPowerSumIdentitiesOQ01OQ02.lean`.

- `header`, `forward`, `reverse` unchanged.
- `determinant` narrowed from 134-164 to 134-149 (just the three determinant theorems).
- New `worked-example` section (151-164): the Fin 2 / ℤ sanity-check example, previously bundled into `determinant` without its own boundary.

Sections now cover the full 164-line file with no gaps. No content deleted.