### PR TITLE
audit: fix stale axiomCount in erdos-1155-oq-01(-oq-01)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10468,10 +10468,10 @@
       "result": "clean"
     },
     "erdos-1155-oq-01-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:35Z",
-      "result": "clean"
+      "lastAudited": "2026-07-23T20:38:08Z",
+      "result": "issues-fixed"
     },
     "erdos-1155-oq-01-oq-06": {
       "auditCount": 3,

--- a/src/data/proofs/erdos-1155-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01-oq-01/meta.json
@@ -22,11 +22,10 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 6,
+    "axiomCount": 5,
     "assumptions": [
       "triangleRemovalEdges: axiomatized function representing expected remaining edges after the triangle removal process on K_n (inherited)",
       "triangleRemovalEdges_nonneg: remaining edge count is non-negative (inherited)",
-      "triangleRemovalEdges_le_complete: remaining edges bounded by C(n,2) (inherited)",
       "bfl_upper_bound: BFL 2015 upper bound f(n) ≤ n^{3/2+ε} (inherited)",
       "bfl_lower_bound: BFL 2015 lower bound f(n) ≥ n^{3/2-ε} (inherited)",
       "triangleRemoval_mantel_bound: Mantel theorem upper bound (inherited)"

--- a/src/data/proofs/erdos-1155-oq-01/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01/meta.json
@@ -67,8 +67,8 @@
       "Conjecture-to-BFL hierarchy (strict weakening chain)",
       "Ratio tightness and bounded ratio characterization"
     ],
-    "axiomCount": 6,
-    "assumptions": "6 axioms inherited from Erdos1155Problem.lean: triangleRemovalEdges (triangle removal edge function), triangleRemovalEdges_nonneg (non-negativity), triangleRemovalEdges_le_complete (bounded by complete graph), bfl_upper_bound (BFL 2015 upper bound), bfl_lower_bound (BFL 2015 lower bound), triangleRemoval_mantel_bound (Mantel-type bound). 0 own axioms. 0 sorries.",
+    "axiomCount": 5,
+    "assumptions": "5 axioms inherited from Erdos1155Problem.lean: triangleRemovalEdges (triangle removal edge function), triangleRemovalEdges_nonneg (non-negativity), bfl_upper_bound (BFL 2015 upper bound), bfl_lower_bound (BFL 2015 lower bound), triangleRemoval_mantel_bound (Mantel-type bound). Note: triangleRemovalEdges_le_complete was converted from axiom to a proved theorem and is no longer an assumption. 0 own axioms. 0 sorries.",
     "relatedProblems": [
       {
         "id": "erdos-1155",


### PR DESCRIPTION
## Integrity Issue

**Proofs**: erdos-1155-oq-01-oq-01, erdos-1155-oq-01
**Problem**: Both meta.json files list `axiomCount: 6` and include `triangleRemovalEdges_le_complete` as an "inherited" axiom. That declaration was converted from `axiom` to a proved `theorem` in `proofs/Proofs/Erdos1155Problem.lean` on 2026-05-01 (commit `70e4a0f`). The correct inherited count is 5.

## Evidence

**meta.json claims**: 6 axioms inherited, including `triangleRemovalEdges_le_complete`.
**Lean file shows**: `Erdos1155Problem.lean` declares `theorem triangleRemovalEdges_le_complete` (not `axiom`); only 5 `axiom` declarations remain (`triangleRemovalEdges`, `triangleRemovalEdges_nonneg`, `triangleRemoval_mantel_bound`, `bfl_upper_bound`, `bfl_lower_bound`).
**Cross-check**: the parent `erdos-1155` meta.json already shows the corrected `axiomCount: 5`, and sibling `erdos-1155-oq-02` explicitly notes "triangleRemovalEdges_le_complete is now a theorem... not an axiom" — these two files were simply never updated when the fix landed.

## Fix

Updated `axiomCount` 6 → 5 and removed/reworded the stale assumption entry in both meta.json files. Severity: LOW (overcount — this understates what's proved rather than overclaiming, per the auditor's honesty standards, but the count should still be accurate).

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)