### PR TITLE
Enrich newton-power-sum-identities-oq-01-oq-03: split sections to 5, cover full file (4->5)

### DIFF
--- a/src/data/proofs/newton-power-sum-identities-oq-01-oq-03/meta.json
+++ b/src/data/proofs/newton-power-sum-identities-oq-01-oq-03/meta.json
@@ -99,11 +99,19 @@
       "mathContext": "$p_1=e_1,\\; p_2=e_1^2-2e_2,\\; p_3=e_1^3-3e_1e_2+3e_3$."
     },
     {
-      "id": "determinants",
-      "title": "Girard–Waring forward determinants",
+      "id": "determinants-low",
+      "title": "Girard–Waring Forward Determinants: Degrees 1 and 2",
       "startLine": 90,
+      "endLine": 107,
+      "summary": "psum_one_det (p₁ = det[e₁]) and psum_two_det (p₂ = det[[e₁,1],[2e₂,e₁]]), proved by det_fin_one_of / det_fin_two_of and linear_combination against the scalar identities.",
+      "mathContext": "$p_2=\\det\\begin{pmatrix}e_1&1\\\\2e_2&e_1\\end{pmatrix}$."
+    },
+    {
+      "id": "determinants-degree3",
+      "title": "Girard–Waring Forward Determinant: Degree 3",
+      "startLine": 109,
       "endLine": 121,
-      "summary": "psum_one_det, psum_two_det, psum_three_det: each power sum expressed as the determinant of the lower-Hessenberg matrix in the eⱼ, proved by det_fin_one_of / det_fin_two_of / det_fin_three (with Matrix.of_apply in the 3×3 simp set) and linear_combination against the scalar identities.",
+      "summary": "psum_three_det: p₃ = det[[e₁,1,0],[2e₂,e₁,1],[3e₃,e₂,e₁]], proved by Matrix.det_fin_three with Matrix.of_apply in the simp set (needed before the cons/head lemmas fire) and linear_combination against psum_three_eq.",
       "mathContext": "$p_3=\\det\\begin{pmatrix} e_1&1&0\\\\ 2e_2&e_1&1\\\\ 3e_3&e_2&e_1\\end{pmatrix}$."
     },
     {


### PR DESCRIPTION
Enrichment pass for newton-power-sum-identities-oq-01-oq-03: splits the `sections` array from 4 to 5, anchored at real theorem boundaries in `Proofs/NewtonPowerSumIdentitiesOQ01OQ03.lean`.

- `header`, `scalar`, `example` unchanged.
- `determinants` (90-121, three theorems) split into `determinants-low` (90-107: `psum_one_det`, `psum_two_det`) and `determinants-degree3` (109-121: `psum_three_det`).

Sections now cover the full 136-line file with no gaps. No content deleted.