### PR TITLE
Enrich prime-reciprocal-divergence-oq-01: split sections to 5, cover full file (4->5)

### DIFF
--- a/src/data/proofs/prime-reciprocal-divergence-oq-01/meta.json
+++ b/src/data/proofs/prime-reciprocal-divergence-oq-01/meta.json
@@ -73,12 +73,20 @@
       "mathContext": "The core theorem. The pointwise identity $1/p^s = p^{-s}$ turns the $1/p^s$ packaging into Mathlib's $p^{-s}$ dichotomy, whose threshold $r < -1$ becomes $s > 1$."
     },
     {
-      "id": "directions",
-      "title": "One-Directional Corollaries",
+      "id": "convergence-direction",
+      "title": "Convergence Corollary: s > 1",
       "startLine": 44,
+      "endLine": 47,
+      "summary": "`prime_zeta_summable`: `∑_p 1/p^s` is summable for `s > 1`, the `.mpr` direction of the iff.",
+      "mathContext": "Extracts the convergence half of `prime_zeta_summable_iff`."
+    },
+    {
+      "id": "divergence-direction",
+      "title": "Divergence Corollary: s ≤ 1",
+      "startLine": 49,
       "endLine": 54,
-      "summary": "`prime_zeta_summable` (convergence for `s > 1`) and `prime_zeta_not_summable` (divergence for `s ≤ 1`) extract the two implications of the iff.",
-      "mathContext": "Splits the biconditional into the usable convergence and divergence statements."
+      "summary": "`prime_zeta_not_summable`: `∑_p 1/p^s` diverges for `s ≤ 1`, obtained by contraposing the `.mp` direction of the iff and closing with `linarith`.",
+      "mathContext": "Extracts the divergence half of `prime_zeta_summable_iff`."
     },
     {
       "id": "boundary-instances",


### PR DESCRIPTION
Enrichment pass for prime-reciprocal-divergence-oq-01: splits the `sections` array from 4 to 5, anchored at real theorem boundaries in `Proofs/PrimeReciprocalDivergenceOQ01.lean`.

- `imports-documentation`, `dichotomy`, `boundary-instances` unchanged.
- `directions` (44-54, bundling two named corollaries) split into `convergence-direction` (44-47: `prime_zeta_summable`) and `divergence-direction` (49-54: `prime_zeta_not_summable`).

Sections now cover the full 68-line file with no gaps. No content deleted.