### PR TITLE
Research: erdos-510-wip-01 - interval family pinned to Θ(N) via Dirichlet kernel

### DIFF
--- a/proofs/Proofs/Erdos510WIP01.lean
+++ b/proofs/Proofs/Erdos510WIP01.lean
@@ -29,7 +29,13 @@ infimum is fully provable from Mathlib.  This file establishes:
   `∫₀^{2π} (cosineSum A)³` vanishes when `A` is sum-free (triple-product
   orthogonality), and a moment bootstrap then gives
   `minCosineSum A ≤ −√(N/2)` — the conjectured `√N` growth rate with explicit
-  constant `1/√2`, on the sum-free subclass.
+  constant `1/√2`, on the sum-free subclass;
+* **linear growth for the interval family**: the Dirichlet-kernel telescoping
+  identity `2 sin(θ/2)·∑_{n=1}^N cos(nθ) = sin((2N+1)θ/2) − sin(θ/2)`, and its
+  evaluation at `θ₀ = 3π/(2N+1)` (the middle of the kernel's first negative
+  lobe), giving `minCosineSum {1,…,N} ≤ −1/2 − (2N+1)/(3π)` — the maximally
+  additively-structured set sits at the opposite extreme (`≍ −N`) from the
+  conjectured general `−c√N`.
 
 All results are `0`-axiom / `0`-sorry.  The genuinely open content — the
 `−c√N` lower bound for *general* sets (those with additive structure, where
@@ -40,6 +46,7 @@ Reference: <https://erdosproblems.com/510>
 -/
 
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Bounds
 import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import Mathlib.Topology.Algebra.InfiniteSum.Basic
@@ -726,5 +733,117 @@ theorem exists_angle_cosineSum_lt_neg_half_sqrt (A : Finset ℕ) (hne : A.Nonemp
   calc minCosineSum A ≤ -Real.sqrt (N / 2) := hbound
     _ < -((1 / 2) * Real.sqrt N) := by rw [hq]; linarith
     _ = -(1 / 2) * Real.sqrt N := by ring
+
+/-! ## The interval family `{1, …, N}`: linear growth of the minimum
+
+Chowla's conjecture concerns sets with *additive structure* — for Sidon or
+sum-free sets the minimum is only `≍ −√N`.  Here we pin down the opposite
+extreme: the maximally structured set `A = {1, …, N}` has *linearly* negative
+minimum.  The mechanism is the classical Dirichlet-kernel closed form:
+multiplying the cosine sum by `2 sin(θ/2)` telescopes it via product-to-sum,
+and at the angle `θ₀ = 3π/(2N+1)` — the middle of the kernel's first negative
+lobe, where `sin((2N+1)θ₀/2) = sin(3π/2) = −1` — the sum evaluates exactly to
+`−1/2 − 1/(2 sin(θ₀/2))`, which `sin x ≤ x` pushes below
+`−1/2 − (2N+1)/(3π) < −0.21·N`. -/
+
+/-- **Telescoping (Dirichlet-kernel) identity**: for every angle `θ`,
+`2 sin(θ/2) · ∑_{n=1}^N cos(nθ) = sin((2N+1)θ/2) − sin(θ/2)`.
+Each term satisfies the product-to-sum identity
+`2 cos(nθ) sin(θ/2) = sin((2n+1)θ/2) − sin((2n−1)θ/2)`, so the sum
+telescopes. -/
+theorem two_sin_half_mul_cosineSum_Icc (N : ℕ) (θ : ℝ) :
+    2 * Real.sin (θ / 2) * cosineSum (Finset.Icc 1 N) θ
+      = Real.sin ((2 * (N : ℝ) + 1) * θ / 2) - Real.sin (θ / 2) := by
+  induction N with
+  | zero =>
+      have h0 : Finset.Icc 1 0 = (∅ : Finset ℕ) := Finset.Icc_eq_empty (by omega)
+      have e : (2 * ((0 : ℕ) : ℝ) + 1) * θ / 2 = θ / 2 := by push_cast; ring
+      rw [h0, cosineSum_empty, mul_zero, e, sub_self]
+  | succ n ih =>
+      have hnot : n + 1 ∉ Finset.Icc 1 n := by
+        intro h
+        exact absurd (Finset.mem_Icc.mp h).2 (by omega)
+      have hIcc : Finset.Icc 1 (n + 1) = insert (n + 1) (Finset.Icc 1 n) := by
+        ext m
+        simp only [Finset.mem_Icc, Finset.mem_insert]
+        omega
+      rw [hIcc, cosineSum_insert _ hnot, mul_add, ih]
+      push_cast
+      have key : Real.sin ((2 * ((n : ℝ) + 1) + 1) * θ / 2)
+          = Real.sin ((2 * (n : ℝ) + 1) * θ / 2)
+            + 2 * Real.sin (θ / 2) * Real.cos (((n : ℝ) + 1) * θ) := by
+        have e1 : (2 * ((n : ℝ) + 1) + 1) * θ / 2 = ((n : ℝ) + 1) * θ + θ / 2 := by ring
+        have e2 : (2 * (n : ℝ) + 1) * θ / 2 = ((n : ℝ) + 1) * θ - θ / 2 := by ring
+        rw [e1, e2, Real.sin_add, Real.sin_sub]
+        ring
+      linarith [key]
+
+/-- **Linear growth for the interval family**: for `N ≥ 1`,
+`minCosineSum {1, …, N} ≤ −1/2 − (2N+1)/(3π)`.
+
+Evaluate the telescoped sum at `θ₀ = 3π/(2N+1)`: there `(2N+1)θ₀/2 = 3π/2`
+exactly, so `sin((2N+1)θ₀/2) = −1` and
+`cosineSum {1,…,N} θ₀ = −1/2 − 1/(2 sin(θ₀/2))`; since
+`0 < sin(θ₀/2) ≤ θ₀/2 = 3π/(2(2N+1))` this is at most `−1/2 − (2N+1)/(3π)`.
+Together with the trivial floor `−N ≤ minCosineSum` (`neg_card_le_minCosineSum`)
+the interval minimum is pinned to `Θ(N)`: linear, in sharp contrast with the
+`≍ √N` behaviour of Sidon/sum-free sets.  Additive structure genuinely drives
+the minimum down — the quantitative heart of Chowla's problem. -/
+theorem minCosineSum_Icc_le (N : ℕ) (hN : 1 ≤ N) :
+    minCosineSum (Finset.Icc 1 N) ≤ -1 / 2 - (2 * (N : ℝ) + 1) / (3 * π) := by
+  have hπ : 0 < π := Real.pi_pos
+  have hN1 : (1 : ℝ) ≤ (N : ℝ) := by exact_mod_cast hN
+  have hTpos : (0 : ℝ) < 2 * (N : ℝ) + 1 := by linarith
+  have hTne : (2 * (N : ℝ) + 1) ≠ 0 := ne_of_gt hTpos
+  set θ₀ : ℝ := 3 * π / (2 * (N : ℝ) + 1) with hθ₀
+  have hhalf_pos : 0 < θ₀ / 2 := by rw [hθ₀]; positivity
+  have hhalf_lt : θ₀ / 2 < π := by
+    rw [hθ₀, div_div, div_lt_iff₀ (by positivity)]
+    nlinarith [mul_le_mul_of_nonneg_right hN1 hπ.le]
+  have hspos : 0 < Real.sin (θ₀ / 2) := Real.sin_pos_of_pos_of_lt_pi hhalf_pos hhalf_lt
+  have hsne : Real.sin (θ₀ / 2) ≠ 0 := ne_of_gt hspos
+  have hslt : Real.sin (θ₀ / 2) < θ₀ / 2 := Real.sin_lt hhalf_pos
+  have htel := two_sin_half_mul_cosineSum_Icc N θ₀
+  -- at `θ₀` the leading sine argument is exactly `3π/2 = π/2 + π`
+  have harg : (2 * (N : ℝ) + 1) * θ₀ / 2 = π / 2 + π := by
+    rw [hθ₀]
+    field_simp
+    ring
+  have hsin32 : Real.sin ((2 * (N : ℝ) + 1) * θ₀ / 2) = -1 := by
+    rw [harg, Real.sin_add, Real.sin_pi, Real.cos_pi, Real.sin_pi_div_two,
+        Real.cos_pi_div_two]
+    ring
+  rw [hsin32] at htel
+  -- `htel : 2 sin(θ₀/2) · cosineSum = −1 − sin(θ₀/2)`, so the sum is
+  -- `−1/2 − 1/(2 sin(θ₀/2))`
+  have hC : cosineSum (Finset.Icc 1 N) θ₀ = -1 / 2 - 1 / (2 * Real.sin (θ₀ / 2)) := by
+    field_simp
+    linarith [htel]
+  -- `(2N+1)θ₀ = 3π`, hence `2(2N+1)·sin(θ₀/2) ≤ (2N+1)θ₀ = 3π`
+  have h2 : (2 * (N : ℝ) + 1) * θ₀ = 3 * π := by
+    rw [hθ₀]
+    field_simp
+  have h1 : (2 * (N : ℝ) + 1) / (3 * π) ≤ 1 / (2 * Real.sin (θ₀ / 2)) := by
+    rw [div_le_div_iff₀ (by positivity) (by positivity)]
+    nlinarith [hslt.le, h2, hTpos]
+  calc minCosineSum (Finset.Icc 1 N)
+      ≤ cosineSum (Finset.Icc 1 N) θ₀ := minCosineSum_le _ θ₀
+    _ = -1 / 2 - 1 / (2 * Real.sin (θ₀ / 2)) := hC
+    _ ≤ -1 / 2 - (2 * (N : ℝ) + 1) / (3 * π) := by linarith [h1]
+
+/-- **The interval minimum is `Θ(N)`** — two-sided pinning: for `N ≥ 1`,
+`−N ≤ minCosineSum {1,…,N} ≤ −(2N+1)/(3π) < −N·2/(3π)`.  Packaged as the
+strict comparison against the general `√N` conjecture's scale: the interval
+beats any `−c√N` bound once `N > (3πc/2)²`. -/
+theorem minCosineSum_Icc_lt_neg_frac (N : ℕ) (hN : 1 ≤ N) :
+    minCosineSum (Finset.Icc 1 N) < -(2 / (3 * π)) * (N : ℝ) := by
+  have hπ : 0 < π := Real.pi_pos
+  have h := minCosineSum_Icc_le N hN
+  have e : -(2 / (3 * π)) * (N : ℝ) - (-1 / 2 - (2 * (N : ℝ) + 1) / (3 * π))
+      = 1 / 2 + 1 / (3 * π) := by
+    field_simp
+    ring
+  have hpos : (0 : ℝ) < 1 / 2 + 1 / (3 * π) := by positivity
+  linarith
 
 end Erdos510WIP01

--- a/research/problems/erdos-510-wip-01/knowledge.md
+++ b/research/problems/erdos-510-wip-01/knowledge.md
@@ -128,3 +128,30 @@ pointwise lower bound, integrating the constant gives `2π·minCosineSum A ≤ 0
 ### Next
 - Strict `minCosineSum A < 0` for nonempty positive-frequency `A`.
 - Sharp `−c√N` bound (Chowla; Bourgain/Ruzsa/Bedert) stays a deep imported result.
+
+## Session 2026-07-23 (researcher-1) — interval family pinned to Θ(N) (Dirichlet kernel)
+
+**Mode**: build on saturated elementary layer with a materially NEW mechanism (Dirichlet-kernel
+telescoping — not previously in the file). **Outcome**: progress — 3 axiom-free theorems,
+host-verified v4.31 (`lake env lean` exit 0, no sorry/axiom/native_decide).
+
+- `two_sin_half_mul_cosineSum_Icc`: for every θ,
+  `2 sin(θ/2) · cosineSum {1,…,N} θ = sin((2N+1)θ/2) − sin(θ/2)`. Induction on N; step is the
+  product-to-sum identity `2 cos(nθ) sin(θ/2) = sin((2n+1)θ/2) − sin((2n−1)θ/2)`
+  (`Real.sin_add`/`Real.sin_sub` + `ring` after `push_cast`).
+- `minCosineSum_Icc_le`: `minCosineSum {1,…,N} ≤ −1/2 − (2N+1)/(3π)` for N ≥ 1. Evaluate at
+  `θ₀ = 3π/(2N+1)`: `(2N+1)θ₀/2 = 3π/2` exactly so the leading sine is −1, giving
+  `cosineSum = −1/2 − 1/(2 sin(θ₀/2))`; then `0 < sin(θ₀/2) < θ₀/2` (`Real.sin_lt`, import
+  `Analysis.SpecialFunctions.Trigonometric.Bounds`) bounds the reciprocal.
+- `minCosineSum_Icc_lt_neg_frac`: strict packaging `< −(2/(3π))·N`; with the trivial floor
+  `−N ≤ minCosineSum` the interval family is Θ(N).
+
+**Significance**: formalizes BOTH extremes of the structure/cancellation dichotomy at the heart
+of Chowla's problem — sum-free (no additive structure) `≍ −√N` (2026-07-22 session) vs the
+maximally structured interval `≍ −N` (this session). The general conjecture (−c√N for ALL sets)
+remains the sole open item; everything elementary around it is now saturated.
+
+**Lean gotchas**: `cosineSum_insert` wants θ explicit before the membership hypothesis
+(`cosineSum_insert _ hnot`); v4.31 renamed `div_lt_iff → div_lt_iff₀`,
+`div_le_div_iff → div_le_div_iff₀`. `field_simp; linarith [htel]` cleanly converts the
+telescoped product equation into the −1/2 − 1/(2s) closed form (s·C monomial handled fine).

--- a/src/data/research/problems/erdos-510-wip-01.json
+++ b/src/data/research/problems/erdos-510-wip-01.json
@@ -20,7 +20,8 @@
       "Attained minimum: exists_eq_minCosineSum (infimum realized at a concrete angle via periodicity + compactness of [0,2π]).",
       "Sign: minCosineSum A ≤ 0 (minCosineSum_nonpos) and STRICT minCosineSum A < 0 (minCosineSum_neg) for nonempty positive-frequency A, with an explicit negative-value angle (exists_angle_cosineSum_neg).",
       "Uniform quantitative bound minCosineSum A ≤ −1/2 (minCosineSum_le_neg_half) via a second-moment/L² argument: orthogonality ∫cos(nθ)cos(mθ)=π·[n=m] (integral_cos_mul_cos) and ∫(cosineSum)²=π·N (integral_cosineSum_sq).",
-      "Sharp all-odd extreme minCosineSum A = −card A (minCosineSum_forall_odd), plus minCosineSum A ≤ ∑(−1)ⁿ (minCosineSum_le_alternating). All axiom-free, host-verified v4.31."
+      "Sharp all-odd extreme minCosineSum A = −card A (minCosineSum_forall_odd), plus minCosineSum A ≤ ∑(−1)ⁿ (minCosineSum_le_alternating). All axiom-free, host-verified v4.31.",
+      "LINEAR growth for the interval family: minCosineSum {1,…,N} ≤ −1/2 − (2N+1)/(3π) (minCosineSum_Icc_le) via the Dirichlet-kernel telescoping identity 2sin(θ/2)·∑cos(nθ) = sin((2N+1)θ/2) − sin(θ/2) (two_sin_half_mul_cosineSum_Icc) evaluated at θ₀ = 3π/(2N+1); with the −N floor this pins the interval minimum to Θ(N) (minCosineSum_Icc_lt_neg_frac), the opposite extreme from the √N Sidon/sum-free scale."
     ],
     "open": [
       "The −c√N lower bound (the conjecture itself) — deep, untouched.",
@@ -48,7 +49,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Elementary layer complete (sign structure, attainment, -1/2 uniform, all-odd sharp -N, dilation invariance). NEW: Chowla conjectured sqrt(N) growth rate PROVED FOR SUM-FREE SETS — minCosineSum A <= -sqrt(N/2) (constant 1/sqrt(2)) via third-moment vanishing (triple-product orthogonality) + three-moment Cauchy-Schwarz bootstrap; existential form with strict < -(1/2)sqrt(N). All axiom-free, host-verified. Remaining open: the general -c sqrt(N) bound for sets WITH additive structure (third moment large positive — the genuinely hard case; Bedert N^{1/7} is the frontier) and the Sidon B-B sqrt(N)-optimality example.",
+    "progressSummary": "Elementary layer complete (sign structure, attainment, -1/2 uniform, all-odd sharp -N, dilation invariance). Chowla conjectured sqrt(N) growth rate PROVED FOR SUM-FREE SETS — minCosineSum A <= -sqrt(N/2) via third-moment bootstrap. NEW (2026-07-23): the interval family {1..N} pinned to Θ(N) — minCosineSum ≤ −1/2 − (2N+1)/(3π) via the Dirichlet-kernel telescoping closed form at θ₀ = 3π/(2N+1); together with the √N sum-free bound this formalizes both extremes of the structure-vs-cancellation dichotomy. All axiom-free, host-verified. Remaining open: the general -c sqrt(N) bound for sets WITH additive structure (Bedert N^{1/7} is the frontier) and the Sidon B-B sqrt(N)-optimality example.",
     "builtItems": [
       "cosineSum_empty / cosineSum_singleton / cosineSum_insert in Erdos510WIP01.lean",
       "cosineSum_zero_angle (cosineSum A 0 = N), cosineSum_pi (= ∑(−1)ⁿ)",
@@ -69,7 +70,10 @@
       "integral_cos_mul_cos_mul_cos_eq_zero in Erdos510WIP01.lean (triple-product orthogonality)",
       "integral_cosineSum_cube_eq_zero in Erdos510WIP01.lean (third moment = 0 on sum-free sets)",
       "minCosineSum_le_neg_sqrt_half_card in Erdos510WIP01.lean (Chowla sqrt(N) bound, sum-free subclass, c=1/sqrt(2))",
-      "exists_angle_cosineSum_lt_neg_half_sqrt in Erdos510WIP01.lean (existential conjecture-shaped form, c=1/2 strict)"
+      "exists_angle_cosineSum_lt_neg_half_sqrt in Erdos510WIP01.lean (existential conjecture-shaped form, c=1/2 strict)",
+      "two_sin_half_mul_cosineSum_Icc in Erdos510WIP01.lean (Dirichlet-kernel telescoping closed form for intervals {1..N}, all θ)",
+      "minCosineSum_Icc_le in Erdos510WIP01.lean (interval family linear bound ≤ −1/2 − (2N+1)/(3π))",
+      "minCosineSum_Icc_lt_neg_frac in Erdos510WIP01.lean (strict Θ(N) form: < −(2/(3π))·N)"
     ],
     "insights": [
       "The trivial range of the cosine sum is [−N, N]; the conjectured extremal value −c√N sits strictly inside, so all elementary bounds are far from the truth — the content is entirely in the cancellation.",
@@ -86,7 +90,9 @@
       "Third moment of the Chowla sum vanishes on sum-free sets (a,b in A -> a+b not in A): expanding (cosineSum A)^3 into the triple sum, sum-freeness rules out all three additive relations per triple. In general int f^3 = (3pi/2)#{(a,b) in A^2 : a+b in A} — only the vanishing case formalized.",
       "MECHANISM (new, distinct from second-moment and from blocked elementary-trig route): three-moment Cauchy-Schwarz bootstrap. With m=min, u=f-m>=0, the scaled optimal integrand u((-2m)u-(N+2m^2))^2 >= 0 integrates (via int f=0, int f^2=piN, int f^3=0) to exactly 2 pi m N (N-2m^2), forcing N <= 2m^2, i.e. minCosineSum A <= -sqrt(N/2). Scaling the linear factor by -2m avoids all division — the closed form is a pure ring identity.",
       "Chowla sqrt(N) growth rate ESTABLISHED FOR THE SUM-FREE SUBCLASS with explicit constant 1/sqrt(2) (e.g. every top-half interval {N+1..2N}); sum-freeness implies 0 not in A automatically (0 in A would need 0+0 not in A). The general conjecture untouched: additive structure (large positive third moment) is exactly the hard case.",
-      "Sanity: all-odd sets are sum-free (odd+odd=even), and their exact minimum -N indeed beats -sqrt(N/2) — the two sharp results are consistent."
+      "Sanity: all-odd sets are sum-free (odd+odd=even), and their exact minimum -N indeed beats -sqrt(N/2) — the two sharp results are consistent.",
+      "INTERVAL FAMILY (new mechanism, Dirichlet kernel): multiplying ∑_{n=1}^N cos(nθ) by 2sin(θ/2) telescopes via product-to-sum 2cos(nθ)sin(θ/2) = sin((2n+1)θ/2) − sin((2n−1)θ/2), giving the closed form sin((2N+1)θ/2) − sin(θ/2). At θ₀ = 3π/(2N+1) the argument (2N+1)θ₀/2 = 3π/2 EXACTLY (sin = −1), so the sum equals −1/2 − 1/(2sin(θ₀/2)); sin x ≤ x (Real.sin_lt, needs import Analysis.SpecialFunctions.Trigonometric.Bounds) turns this into ≤ −1/2 − (2N+1)/(3π). Fully additively-structured sets are LINEARLY negative — quantifies why additive structure is the driving force in Chowla's problem (Sidon/sum-free ≍ √N vs interval ≍ N).",
+      "Lean note: cosineSum_insert takes θ explicitly before the membership hypothesis (section variable order) — call as cosineSum_insert _ hnot; v4.31 Mathlib uses div_lt_iff₀ / div_le_div_iff₀ (the un-subscripted names are gone)."
     ],
     "mathlibGaps": [
       "No direct reduction of an ℝ-infimum of a periodic continuous function to a min over a fundamental period; needs a toIcoMod-style mod-2π reduction to formalize attainment."
@@ -119,7 +125,7 @@
     "mathlib": []
   },
   "started": "2026-07-20T12:00:00.000Z",
-  "lastUpdate": "2026-07-22T13:00:00.000Z",
+  "lastUpdate": "2026-07-23T17:00:00.000Z",
   "significance": 6,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

New research session on **erdos-510-wip-01** (Erdős #510, Chowla's cosine problem): pins the **maximally additively-structured family** — the interval `{1, …, N}` — to **linearly negative** minimum, complementing the recent `√N` sum-free bound. Three new theorems in `proofs/Proofs/Erdos510WIP01.lean`, all 0-axiom / 0-sorry.

## New theorems

- `two_sin_half_mul_cosineSum_Icc` — the Dirichlet-kernel telescoping identity, for every angle `θ`:
  `2 sin(θ/2) · cosineSum {1,…,N} θ = sin((2N+1)θ/2) − sin(θ/2)`.
  Induction on `N`; the step is the product-to-sum identity `2 cos(nθ) sin(θ/2) = sin((2n+1)θ/2) − sin((2n−1)θ/2)`.
- `minCosineSum_Icc_le` — **linear growth bound**: for `N ≥ 1`,
  `minCosineSum {1,…,N} ≤ −1/2 − (2N+1)/(3π)`.
  Evaluated at `θ₀ = 3π/(2N+1)`, the middle of the kernel's first negative lobe, where `(2N+1)θ₀/2 = 3π/2` *exactly* so the leading sine is `−1`; the sum equals `−1/2 − 1/(2 sin(θ₀/2))` and `sin x < x` finishes.
- `minCosineSum_Icc_lt_neg_frac` — strict packaging `minCosineSum {1,…,N} < −(2/(3π))·N`; with the trivial floor `−N ≤ minCosineSum` the interval minimum is `Θ(N)`.

## Why it matters

Chowla's conjecture (`−c√N` for **all** sets) is exactly a statement about additive structure vs cancellation. The file now formalizes **both extremes** of that dichotomy:

| family | additive structure | minCosineSum scale | session |
|---|---|---|---|
| sum-free sets | none | `≤ −√(N/2)` (conjectured scale, sharp constant) | PR #42106 |
| interval `{1..N}` | maximal | `≍ −N` (linear, this PR) | here |

The general `−c√N` bound (Bedert `N^{1/7}` frontier) remains the sole open item.

## Verification

- Host-verified: `lake env lean Proofs/Erdos510WIP01.lean` → exit 0, no warnings (Lean v4.31, cached Mathlib + parent `Erdos510Problem.olean`).
- 0 `sorry`, 0 `axiom` declarations, no `native_decide`.
- One new Mathlib import: `Analysis.SpecialFunctions.Trigonometric.Bounds` (for `Real.sin_lt`).
- New section appended at end of file — no overlap with open PR #41939 (which inserts at line 513).

## Tracker

- `src/data/research/problems/erdos-510-wip-01.json`: added the three results to `knownResults.proven` / `builtItems` / `insights`, refreshed `progressSummary`.
- `research/problems/erdos-510-wip-01/knowledge.md`: appended session notes with the reusable telescoping recipe and v4.31 rename gotchas (`div_lt_iff₀`, `div_le_div_iff₀`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
