### PR TITLE
Enrich prob-method-applications-wip-01: split colouring-count section at real boundary (4->5)

### DIFF
--- a/src/data/proofs/prob-method-applications-wip-01/meta.json
+++ b/src/data/proofs/prob-method-applications-wip-01/meta.json
@@ -21,12 +21,20 @@
       "mathContext": "$\\sum_i |A_i| < |\\Omega| \\implies \\exists\\,\\omega,\\ \\forall i,\\ \\omega \\notin A_i$"
     },
     {
-      "id": "counting-colourings",
-      "title": "Counting Two-Colourings of a Finite Edge Set",
+      "id": "colouring-model",
+      "title": "Modelling Colourings and Counting the All-True Case",
       "startLine": 65,
+      "endLine": 99,
+      "summary": "Models a 2-colouring as S : Finset E and a block K as monochromatic when K ⊆ S or Disjoint K S (the Mono predicate, @[reducible] so DecidablePred is found by instance search). card_supersets_le bounds the all-true-on-K colourings by 2^(|E|−|K|) via the injection S ↦ S \\ K into the powerset of univ \\ K, injective because (S\\K) ∪ K = S recovers S.",
+      "mathContext": "$|\\{S : K \\subseteq S\\}| \\le |\\mathcal{P}(E\\setminus K)| = 2^{|E|-|K|}$, via $S \\mapsto S \\setminus K$."
+    },
+    {
+      "id": "colouring-count",
+      "title": "Counting the All-False Case and Combining to the Total Bound",
+      "startLine": 101,
       "endLine": 140,
-      "summary": "Models a 2-colouring as S : Finset E and a block K as monochromatic when K ⊆ S or Disjoint K S (the Mono predicate). card_supersets_le and card_disjoint_le each bound their family by 2^(|E|−|K|) (via an injection and an inclusion respectively); card_mono_le unions them to 2^(|E|−|K|+1).",
-      "mathContext": "$|\\{S : \\mathrm{Mono}\\,K\\,S\\}| \\le 2^{|E|-|K|+1}$"
+      "summary": "card_disjoint_le bounds the all-false-on-K colourings by 2^(|E|−|K|) via the simpler inclusion S ⊆ Kᶜ. card_mono_le then unions the two symmetric bounds (filter_or + card_union_le + pow_succ) to the total monochromatic count 2^(|E|−|K|+1), the per-block quantity the Ramsey union bound consumes.",
+      "mathContext": "$|\\{S : \\mathrm{Mono}\\,K\\,S\\}| \\le 2^{|E|-|K|} + 2^{|E|-|K|} = 2^{|E|-|K|+1}$"
     },
     {
       "id": "ramsey-avoidance",


### PR DESCRIPTION
## Summary
- `sections` bundled four distinct declarations — the `Mono` predicate, `card_supersets_le`, `card_disjoint_le`, and `card_mono_le` — into one 65-140 "counting-colourings" section (4 sections total).
- Split at the real boundary the entry's own annotations already recognize (annotations.json separately covers `card_supersets_le` at 75-99 and `card_disjoint_le`/`card_mono_le` at 101-140): `colouring-model` (65-99, the all-true-on-K case via an injection) and `colouring-count` (101-140, the all-false case plus the union-bound combination to the total 2^(|E|-|K|+1) bound).
- The other three sections (`context-setup`, `first-moment`, `ramsey-avoidance`) already mapped to real content boundaries and are unchanged.
- No changes to annotations.json (already 6 annotations with mathContext/significance/relatedConcepts/prerequisites) or the Lean source.

## Test plan
- [x] `meta.json` validates as JSON, sections cover the full 179-line file (aside from two blank-line gaps at 64/141)
- [x] `scripts/gallery/check-meta-size.ts prob-method-applications-wip-01` passes (~13 KB, well under the 60 KB cap)