### PR TITLE
Enrich ptolemys-theorem-oq-05: split sections to 5, cover header (3->5)

### DIFF
--- a/src/data/proofs/ptolemys-theorem-oq-05/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-05/meta.json
@@ -24,6 +24,13 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Setup: the problem and the inversion strategy",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "Module docstring stating OQ-05: the gallery's PtolemysComplexProof.lean and Mathlib's cospherical equality case both fall short of the general metric statement. States the inversion-distance identity and the two downstream theorems it feeds (ptolemy_origin, ptolemy_dist), then fixes a real inner product space V and opens RealInnerProductSpace for the ⟪·,·⟫ notation."
+    },
+    {
       "id": "inversion-dist",
       "title": "The inversion-distance identity",
       "startLine": 54,
@@ -41,8 +48,15 @@
       "id": "ptolemy-dist",
       "title": "Ptolemy for four arbitrary points of an affine space",
       "startLine": 134,
-      "endLine": 152,
-      "summary": "dist(a,c)·dist(b,d) ≤ dist(a,b)·dist(c,d) + dist(b,c)·dist(a,d) in any NormedAddTorsor over a real inner product space, by translating the fourth point to the origin; instantiated concretely in EuclideanSpace ℝ (Fin 3)."
+      "endLine": 145,
+      "summary": "dist(a,c)·dist(b,d) ≤ dist(a,b)·dist(c,d) + dist(b,c)·dist(a,d) in any NormedAddTorsor over a real inner product space, by translating the fourth point d to the origin (x = a−ᵥd etc.) and applying ptolemy_origin."
+    },
+    {
+      "id": "ptolemy-3d-witness",
+      "title": "A three-dimensional witness",
+      "startLine": 147,
+      "endLine": 153,
+      "summary": "Concrete instantiation of ptolemy_dist in EuclideanSpace ℝ (Fin 3): a one-line application showing the dimension-free proof reaches a configuration the gallery's planar complex-number proof cannot address."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary
- `sections` covered only lines 54-152 of the 153-line file, leaving the 53-line module docstring/setup (imports, the OQ-05 problem statement, the inversion strategy, namespace/variable declarations) with no section — despite it already having full annotation coverage (`ann-ptoq05-header`, range 1-53).
- Added a `header` section for lines 1-53.
- Split the former `ptolemy-dist` section (134-152) into the four-point theorem itself (134-145) and its separate 3D witness `example` (147-153), matching the existing annotation boundaries (`ann-ptolemy-dist` / `ann-ptolemy-3d`).
- Result: 3 -> 5 sections, full 1-153 line coverage, no other fields changed.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — valid JSON
- [x] `npx tsx scripts/gallery/check-meta-size.ts ptolemys-theorem-oq-05` — within all size caps
- [x] `npx tsx scripts/annotations/build.ts` — no "No Lean construct found" warnings for this entry
- [x] `wc -c meta.json` — 11.4 KB, well under the 60 KB cap