### PR TITLE
Enrich pythagorean-triples-oq-09: add header section, cover full file (4->5)

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-09/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-09/meta.json
@@ -71,6 +71,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Setup: the inradius integrality claim",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "Module docstring stating the three ingredients (parity, positivity, area identity) behind the inradius r=(x+y−z)/2 of an integer right triangle; imports Mathlib, opens PythagoreanTriple, and fixes x y z : ℤ.",
+      "mathContext": "$r=\\tfrac{x+y-z}{2}$; ingredients: $2\\mid x+y-z$, $z\\le x+y$, $(x+y-z)(x+y+z)=2xy$."
+    },
+    {
       "id": "parity",
       "title": "Parity: 2 ∣ (x+y−z)",
       "startLine": 43,


### PR DESCRIPTION
## Summary
- `sections` covered only lines 43-132 of the 132-line file, leaving the 42-line module docstring (states the parity/positivity/area-identity strategy behind the inradius integrality result) uncovered by any section — despite already having full annotation coverage (`pythag-oq09-header`, range 1-33).
- Added a `header` section for lines 1-42.
- Result: 4 -> 5 sections, full 1-132 line coverage, no other fields changed.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — valid JSON
- [x] `npx tsx scripts/gallery/check-meta-size.ts pythagorean-triples-oq-09` — within all size caps
- [x] `npx tsx scripts/annotations/build.ts` — no warnings for this entry
- [x] `wc -c meta.json` — 9.1 KB, well under the 60 KB cap