### PR TITLE
audit: mark erdos-350 complete (clean, cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12844,8 +12844,8 @@
     },
     "erdos-350": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:36Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T20:53:15Z",
       "result": "clean"
     },
     "erdos-351": {


### PR DESCRIPTION
## Summary
- Re-audited erdos-350 (Sum of Reciprocals of Dissociated Sets). Confirmed still clean.
- axiomCount 0, theoremCount 9, definitionCount 3, sorries 0 all match `proofs/Proofs/Erdos350Problem.lean`.
- No phantom axiom/theorem names in meta.json prose.
- `status: axiomatized` / `badge: wip` honestly disclosed via `assumptions` — Ryavec's theorem remains docstring-only, not formalized.

## Test plan
- [x] Tracker-only change (`audit-tracker.json`), no source edits needed.

Discovered during gallery integrity audit (reserve mode, queue drained).