### PR TITLE
Enrich product-of-segments-of-chords-oq-05-oq-01: split sections to 5 (4->5)

### DIFF
--- a/src/data/proofs/product-of-segments-of-chords-oq-05-oq-01/meta.json
+++ b/src/data/proofs/product-of-segments-of-chords-oq-05-oq-01/meta.json
@@ -74,11 +74,18 @@
       "summary": "chord_segment_product_eq_abs_power: dist(P,A)·dist(P,B) = |power O r P|, from |t₁|·|t₂| = |t₁·t₂| and the parent's t₁·t₂ = power. chord_segment_product_direction_independent: two directions give the same product of lengths."
     },
     {
-      "id": "branches",
-      "title": "Exterior Secant–Secant and Interior Intersecting-Chords",
+      "id": "exterior",
+      "title": "Exterior Secant–Secant Case (Euclid III.36)",
       "startLine": 96,
+      "endLine": 108,
+      "summary": "secant_secant_exterior: for P strictly outside the sphere (r < ‖P−O‖), dist(P,A)·dist(P,B) = ‖P−O‖²−r², with no absolute value — strict positivity of the power via nlinarith, then abs_of_pos."
+    },
+    {
+      "id": "interior",
+      "title": "Interior Intersecting-Chords Case (Euclid III.35)",
+      "startLine": 109,
       "endLine": 122,
-      "summary": "secant_secant_exterior: for P strictly outside, dist·dist = ‖P−O‖²−r² (abs_of_pos). intersecting_chords_interior: for P strictly inside, dist·dist = r²−‖P−O‖² (abs_of_neg), the classical Euclid III.35 form."
+      "summary": "intersecting_chords_interior: for P strictly inside the sphere (‖P−O‖ < r), dist(P,A)·dist(P,B) = r²−‖P−O‖² — the classical intersecting-chords theorem, via a negative power and abs_of_neg."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- `sections` already fully covered the 122-line file (1-122) but bundled two distinct classical results into one "branches" section: `secant_secant_exterior` (Euclid III.36) and `intersecting_chords_interior` (Euclid III.35).
- Split into two sections at the real theorem boundary (line 109), matching the per-theorem annotation ranges already present (`ann-posc0501-exterior` 96-108, `ann-posc0501-interior` 109-121).
- Result: 4 -> 5 sections, same full 1-122 coverage, no other fields changed.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — valid JSON
- [x] `npx tsx scripts/gallery/check-meta-size.ts product-of-segments-of-chords-oq-05-oq-01` — within all size caps
- [x] `npx tsx scripts/annotations/build.ts` — no warnings for this entry
- [x] `wc -c meta.json` — 10.7 KB, well under the 60 KB cap