### PR TITLE
Enrich pythagorean-triples-oq-04-oq-01: add header section, cover full file (3->4)

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-04-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-04-oq-01/meta.json
@@ -84,6 +84,13 @@
   ],
   "sections": [
     {
+      "id": "header",
+      "title": "Setup: lifting two-factor multiplicativity to arbitrarily many primes",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring stating the goal — the constructive sufficiency direction of the two-square theorem, obtained by strong induction on the least prime factor rather than by citing Mathlib's existence-only Nat.eq_sq_add_sq_iff — with a results table for the three theorems; imports SumTwoSquares, opens the namespace and Nat."
+    },
+    {
       "id": "constructive-sufficiency",
       "title": "Part I: Constructive sufficiency via strong induction",
       "startLine": 47,


### PR DESCRIPTION
## Summary
- `sections` covered only lines 47-128 of the 128-line file, leaving the 46-line module docstring (states the constructive-sufficiency goal, the strong-induction strategy, and a results table for the three theorems) uncovered by any section — despite already having full annotation coverage (`ann-overview`, range 4-42).
- Added a `header` section for lines 1-46.
- Result: 3 -> 4 sections, full 1-128 line coverage, no other fields changed.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — valid JSON
- [x] `npx tsx scripts/gallery/check-meta-size.ts pythagorean-triples-oq-04-oq-01` — within all size caps
- [x] `npx tsx scripts/annotations/build.ts` — no warnings for this entry