### PR TITLE
audit(erdos-351): fix phantom axiomatized narrative

### DIFF
--- a/src/data/proofs/erdos-351/meta.json
+++ b/src/data/proofs/erdos-351/meta.json
@@ -7,7 +7,7 @@
     "author": "Graham (1963), Alekseyev (2019)",
     "sourceUrl": "https://erdosproblems.com/351",
     "date": "1963",
-    "status": "axiomatized",
+    "status": "open",
     "proofRepoPath": "Proofs/Erdos351Problem.lean",
     "tags": [
       "erdos",
@@ -43,8 +43,8 @@
     "originalContributions": [
       "Formal definition of strong completeness in Lean 4",
       "Definition of polynomial-reciprocal image sets",
-      "Axiomatized Graham's theorem for p(x) = x",
-      "Axiomatized Graham-Alekseyev theorem for p(x) = x²",
+      "Documented Graham's theorem for p(x) = x as background (not formalized)",
+      "Documented Graham-Alekseyev theorem for p(x) = x² as background (not formalized)",
       "Verified bounds on n + 1/n"
     ],
     "axiomCount": 0,
@@ -57,7 +57,7 @@
     "historicalContext": "Erdős Problem #351 concerns the additive structure of sequences of the form {p(n) + 1/n : n ∈ ℕ} where p(x) is a polynomial. The notion of 'strong completeness' is a robust form of additive completeness that survives removal of any finite set of elements.\n\nGraham (1963) proved the foundational case p(x) = x, showing that {n + 1/n : n ∈ ℕ} is strongly complete. This was a significant result in additive number theory.\n\nThe case p(x) = x² was resolved much later by combining Graham's work with Alekseyev's 2019 results on partitions into squares. The general question—whether ALL polynomials with positive leading coefficient yield strongly complete sets—remains open.",
     "problemStatement": "**Problem (Erdős-Graham)**: Let $p(x) \\in \\mathbb{Q}[x]$ be a polynomial with positive leading coefficient. Is the set\n$$A = \\{p(n) + 1/n : n \\in \\mathbb{N}\\}$$\nstrongly complete?\n\n**Definition**: A set $A$ is *strongly complete* if for any finite $B$, the finite sums from $A \\setminus B$ contain all sufficiently large integers.\n\n**Status**:\n- General: OPEN\n- p(x) = x: PROVED (Graham 1963)\n- p(x) = x²: PROVED (Graham + Alekseyev)",
     "text": "Is {p(n) + 1/n : n in N} strongly complete for all polynomials p(x)? General case open; solved for p(x) = x and p(x) = x².",
-    "proofStrategy": "We formalize the problem by:\n\n1. **Define the image set**: For polynomial P, the set {P(n) + 1/n : n ∈ ℕ}\n2. **Define strong completeness**: For any finite forbidden set B, eventually all integers are representable as sums from A \\ B\n3. **State solved cases as axioms**: Graham's theorem (p=x) and Graham-Alekseyev (p=x²)\n4. **Verify basic properties**: Elements n + 1/n lie strictly between n and n+1 (for n ≥ 2)\n\nThe proofs of the solved cases require deep results from partition theory and are stated as axioms.",
+    "proofStrategy": "We formalize the problem by:\n\n1. **Define the image set**: For polynomial P, the set {P(n) + 1/n : n ∈ ℕ}\n2. **Define strong completeness**: For any finite forbidden set B, eventually all integers are representable as sums from A \\ B\n3. **Document solved cases as background**: Graham's theorem (p=x) and Graham-Alekseyev (p=x²) are recorded in doc comments — not stated as axioms, definitions, or theorems\n4. **Verify basic properties**: Elements n + 1/n lie strictly between n and n+1 (for n ≥ 2)\n\nThe proofs of the solved cases require deep results from partition theory and are documented in comments as background — not formalized.",
     "keyInsights": [
       "**Strong completeness**: Unlike ordinary completeness (all large integers are sums), strong completeness requires this even after removing any finite set. This is a much stronger property.",
       "**The 1/n perturbation**: Adding 1/n to p(n) creates irrational-like spacing that helps with representability. The terms n + 1/n are 'almost integers' but distinct.",
@@ -98,7 +98,7 @@
       "title": "Solved Cases",
       "startLine": 56,
       "endLine": 74,
-      "summary": "Axiomatize Graham's theorem (p=x) and Graham-Alekseyev theorem (p=x²)."
+      "summary": "Document Graham's theorem (p=x) and Graham-Alekseyev theorem (p=x²) as background in comments (not formalized)."
     },
     {
       "id": "properties",
@@ -109,7 +109,7 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #351, which asks whether {p(n) + 1/n} is strongly complete for all polynomials p(x). The general problem remains open, but we axiomatize the solved cases: Graham (1963) for p(x) = x and Graham-Alekseyev for p(x) = x². We prove basic properties of the image sets.",
+    "summary": "We formalize Erdős Problem #351, which asks whether {p(n) + 1/n} is strongly complete for all polynomials p(x). The general problem remains open; the solved cases (Graham 1963 for p(x) = x and Graham-Alekseyev for p(x) = x²) are documented as background in doc comments, not formalized as axioms or theorems. We prove basic properties of the image sets.",
     "implications": "This problem connects polynomial growth rates with additive structure. The partial results suggest strong completeness may hold generally, but proving it requires understanding how polynomial growth interacts with the 1/n perturbation.",
     "openQuestions": [
       "Does strong completeness hold for all polynomials with positive leading coefficient?",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-351 (Strong Completeness of Polynomial-Reciprocal Sequences)
**Problem**: `originalContributions`, `overview.proofStrategy`, the "solved-cases" section summary, and `conclusion.summary` all claimed Graham's theorem (p(x)=x) and the Graham-Alekseyev theorem (p(x)=x²) were "axiomatized" / "stated as axioms". This is false: `axiomCount` is 0 and `Proofs/Erdos351Problem.lean` has zero `axiom` declarations. Those two results live only inside plain `/- ... -/` doc comments (lines 54-66) — not even `def`s, let alone `axiom`s.

The `meta.assumptions` field already stated this correctly ("documented in comments but not stated as axioms or proved"), so the file was internally contradictory: one field honest, four others overclaiming.

## Evidence

**meta.json claimed** (before fix):
- `status`: `"axiomatized"`
- `originalContributions`: "Axiomatized Graham's theorem for p(x) = x", "Axiomatized Graham-Alekseyev theorem for p(x) = x²"
- `proofStrategy`: "State solved cases as axioms... are stated as axioms"
- section summary: "Axiomatize Graham's theorem (p=x) and Graham-Alekseyev theorem (p=x²)."
- `conclusion.summary`: "we axiomatize the solved cases..."

**Lean file shows**: `Proofs/Erdos351Problem.lean` has `axiomCount: 0`. Lines 54-66 are plain comment blocks describing Graham's/Graham-Alekseyev's theorems as background — no `axiom`, `def`, or `theorem` declares them. Only real content: 3 definitions (`imageSet`, `IsStronglyComplete`, `HasStronglyCompleteImage`) and 8 theorems, all proving basic bounds/examples on `n + 1/n`, `n² + 1/n`.

## Fix

Reworded all five phantom-axiom mentions to "documented as background in doc comments — not formalized", and changed `status` from `"axiomatized"` → `"open"` to match the already-correct `erdosProblemStatus: "open"`.

Same fabrication pattern as erdos-349 (#42571), erdos-361 (#42550), erdos-364 (#42535), and ~20 other prior instances of this recurring "phantom axiomatized narrative" bug.

---
Discovered during gallery integrity audit (reserve re-serve, queue fully drained at audit time).