### PR TITLE
Enrich quadratic-gauss-sum-square-oq-04-oq-01: close two small section gaps

### DIFF
--- a/src/data/proofs/quadratic-gauss-sum-square-oq-04-oq-01/meta.json
+++ b/src/data/proofs/quadratic-gauss-sum-square-oq-04-oq-01/meta.json
@@ -23,8 +23,8 @@
       "id": "overview-header",
       "title": "Overview: p* is a fundamental discriminant",
       "startLine": 1,
-      "endLine": 44,
-      "summary": "Module docstring: extends the parent's field identity ℚ(g) = ℚ(√p*) by classifying p* arithmetically. The first supplement gives p* = ±p; the new point is p* ≡ 1 (mod 4) uniformly, which with squarefreeness (|p*| = p prime) makes p* a fundamental discriminant — the actual discriminant of ℚ(√p*)."
+      "endLine": 53,
+      "summary": "Module docstring: extends the parent's field identity ℚ(g) = ℚ(√p*) by classifying p* arithmetically. The first supplement gives p* = ±p; the new point is p* ≡ 1 (mod 4) uniformly, which with squarefreeness (|p*| = p prime) makes p* a fundamental discriminant — the actual discriminant of ℚ(√p*). Imports Mathlib, opens BigOperators/Polynomial, and fixes an odd prime p via [Fact p.Prime]."
     },
     {
       "id": "character-and-square",
@@ -44,7 +44,7 @@
       "id": "capstone",
       "title": "The Gauss sum squares to a fundamental discriminant",
       "startLine": 162,
-      "endLine": 171,
+      "endLine": 173,
       "summary": "gaussSum_sq_isFundamentalDiscriminant: ∃ D, g² = (D : ℂ) ∧ Squarefree D ∧ D ≡ 1 (mod 4) — g² is the fundamental discriminant p* = disc ℚ(g)."
     }
   ],


### PR DESCRIPTION
## Summary
- `sections` left two narrow gaps unaccounted for between adjacent sections: lines 45-53 (`import Mathlib`, `open` statements, `namespace`, `variable {p : ℕ} [Fact p.Prime]`) between the module docstring and the first `/-!` heading, and lines 172-173 (`end QuadraticGaussSumSquareOQ04OQ01`) after the capstone theorem.
- Extended `overview-header`'s `endLine` 44 -> 53 and `capstone`'s `endLine` 171 -> 173 to close both gaps.
- No new sections (still 4), same section count and boundaries otherwise — this is pure coverage completion, not a re-split.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — valid JSON
- [x] `npx tsx scripts/gallery/check-meta-size.ts quadratic-gauss-sum-square-oq-04-oq-01` — within all size caps
- [x] `npx tsx scripts/annotations/build.ts` — no warnings for this entry