### PR TITLE
Enrich schroeder-bernstein-oq-05: cover header docstring, split to 5 sections (4->5)

### DIFF
--- a/src/data/proofs/schroeder-bernstein-oq-05/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-05/meta.json
@@ -80,6 +80,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Overview: Dual Schroeder-Bernstein",
+      "startLine": 1,
+      "endLine": 32,
+      "summary": "Module docstring stating the dual theorem (mutual surjections imply equinumerosity) and its relationship to the classical injective form, plus imports, namespace, the `Function` open, and the ambient `{A B : Type*}` variables.",
+      "mathContext": "Frames the AC-dependence: each surjection is split into an injective right inverse, then the classical (choice-free) Schroeder-Bernstein theorem is applied to the two injections."
+    },
+    {
       "id": "section",
       "title": "Splitting a Surjection into an Injective Section",
       "startLine": 33,


### PR DESCRIPTION
## Summary
- Lines 1-32 (module docstring stating the dual theorem and its AC-dependence, plus imports/namespace/open/variable) were uncovered by any section — sections started at line 33.
- Added a header section (1-32); the 4 existing sections (splitting-a-surjection, bijection-form, equiv-form, cardinal-form) are unchanged.
- Coverage is now contiguous 1-76. No changes to annotations.json (already covers 1-20 in its context annotation) or the Lean source.

## Test plan
- [x] `meta.json` validates as JSON
- [x] File size (~11 KB) well under the 60 KB cap