### PR TITLE
Enrich ramsey-r4k-extensions-oq-03-oq-01: fix mid-theorem section split, split to 5 (4->5)

### DIFF
--- a/src/data/proofs/ramsey-r4k-extensions-oq-03-oq-01/meta.json
+++ b/src/data/proofs/ramsey-r4k-extensions-oq-03-oq-01/meta.json
@@ -97,22 +97,29 @@
       "id": "counting-core",
       "title": "The abstract counting core: exactly two constant colourings",
       "startLine": 47,
-      "endLine": 76,
-      "summary": "card_constant_colorings proves that among all Bool-colourings of a nonempty finite type α, exactly two are constant. The predicate `∀ x y, c x = c y` is shown to cut out the injective image of `Bool` under `b ↦ (fun _ => b)`, whose cardinality is Fintype.card Bool = 2."
+      "endLine": 77,
+      "summary": "card_constant_colorings proves that among all Bool-colourings of a nonempty finite type α, exactly two are constant. The predicate `∀ x y, c x = c y` is shown to cut out the injective image of `Bool` under `b ↦ (fun _ => b)`, whose cardinality is Fintype.card Bool = 2. Followed by the 'Instantiation for the edges of a k-clique' marker and the ambient `{V : Type*} [Fintype V] [DecidableEq V]` variable used by the rest of the file."
     },
     {
       "id": "clique-edges",
-      "title": "Edges and colourings of a k-clique",
+      "title": "Edges and Colourings of a k-Clique",
       "startLine": 78,
-      "endLine": 101,
+      "endLine": 98,
       "summary": "cliqueEdges S is the 2-subsets of S; cliqueEdges_card shows a k-clique has C(k,2) edges. EdgeColoring S is the type of 2-colourings of those edges, and card_edgeColorings computes the total 2^C(k,2) via Fintype.card_fun and Fintype.card_coe."
     },
     {
+      "id": "monochromatic-count",
+      "title": "Monochromatic-Colouring Count (Main Combinatorial Result)",
+      "startLine": 99,
+      "endLine": 112,
+      "summary": "card_monochromatic_edgeColorings instantiates the abstract counting core at the k-clique's edge type (nonempty for k ≥ 2, since a k-clique with k ≥ 2 has an edge) to get exactly two monochromatic edge-colourings — the numerator of the bad-event probability p."
+    },
+    {
       "id": "bad-event-probability",
-      "title": "The bad-event probability p = 2^(1−C(k,2))",
-      "startLine": 103,
+      "title": "The Bad-Event Probability p = 2^(1−C(k,2))",
+      "startLine": 113,
       "endLine": 140,
-      "summary": "card_monochromatic_edgeColorings instantiates the counting core at the edge type (nonempty for k ≥ 2) to get exactly two monochromatic colourings. clique_monochromatic_probability divides by the total and simplifies to the closed form 2^(1−C(k,2)); triangle_monochromatic_count is the k=3 check giving 2 of 8."
+      "summary": "clique_monochromatic_probability divides the monochromatic count by the total and simplifies to the closed form 2^(1−C(k,2)) via zpow lemmas; triangle_monochromatic_count is the k=3 sanity check giving 2 of 8 (= 2^(1-3) = 1/4)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- The old "clique-edges" section (78-101) and "bad-event-probability" section (103-140) split `card_monochromatic_edgeColorings`'s docstring+theorem (lines 99-111) across the section boundary — lines 99-101 landed in one section, 102-140 in the next, cutting the declaration mid-docstring.
- Split into 5 sections at real declaration boundaries: preamble (1-46, unchanged), counting-core (47-77, extended to include the `/-! Instantiation -/` marker and `variable` decl that precede the next section), clique-edges (78-98: `cliqueEdges`/`cliqueEdges_card`/`EdgeColoring`/`card_edgeColorings`), monochromatic-count (99-112: `card_monochromatic_edgeColorings`, now whole), bad-event-probability (113-140: `clique_monochromatic_probability` + `triangle_monochromatic_count` + `end`).
- Coverage remains contiguous 1-140. No changes to annotations.json or the Lean source.

## Test plan
- [x] `meta.json` validates as JSON
- [x] File size (~18 KB) well under the 60 KB cap
- [x] Section boundaries verified against `proofs/Proofs/RamseyR4kExtensionsOQ03OQ01.lean` declaration lines — no section now cuts a theorem/docstring