### PR TITLE
audit(erdos-346): fix phantom "axiomatised" Graham prose, status axiomatized->open

### DIFF
--- a/src/data/proofs/erdos-346/meta.json
+++ b/src/data/proofs/erdos-346/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/346",
-    "status": "axiomatized",
+    "status": "open",
     "proofRepoPath": "Proofs/Erdos346Problem.lean",
     "tags": [
       "erdos",
@@ -29,7 +29,7 @@
       "Zeckendorf representation"
     ],
     "lineCount": 80,
-    "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
+    "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The main conjecture (ErdosProblem346) remains open and is not yet formalized as a proved theorem in Lean.",
     "mathlib_version": "4.31.0",
     "theoremCount": 0,
     "definitionCount": 8
@@ -38,7 +38,7 @@
     "historicalContext": "A sequence of positive integers is complete if every sufficiently large integer can be represented as a sum of distinct terms. Zeckendorf's theorem (1972) shows the Fibonacci sequence is complete: every positive integer has a unique Fibonacci representation. The question of how robust completeness is — what happens when terms are removed — connects to deep properties of the golden ratio.\n\nGraham (1964) showed that the sequence Fₙ − (−1)^n (= 1, 3, 4, 8, 12, 21, ...) is both strongly complete (removing finitely many terms preserves completeness) and fragile (removing infinitely many terms can destroy it). Erdős and Graham (1980) studied this phenomenon systematically.\n\nThe golden ratio φ = (1+√5)/2 ≈ 1.618 appears as a sharp threshold: if aₙ₊₁/aₙ > φ, fragility is automatic.",
     "problemStatement": "If A is lacunary, strongly complete, and fragile, must lim a_{n+1}/a_n = φ?",
     "text": "If a lacunary sequence is strongly complete but fragile (removing any infinite subset destroys completeness), must a_{n+1}/a_n → φ?",
-    "proofStrategy": "The formalization defines subset sums, completeness, strong completeness, and fragility. Graham's example is axiomatised. The golden ratio threshold and the main conjecture are stated, along with the existence of irregular (non-lacunary) counterexamples.",
+    "proofStrategy": "The formalization defines subset sums, completeness, strong completeness, and fragility. Graham's example (grahamSeq) is defined, but its strong-completeness and fragility properties are documented only in doc comments — not formalized (no axiom, definition, or theorem states them). The golden ratio threshold and the main conjecture are stated as a Prop, along with the existence of irregular (non-lacunary) counterexamples noted in a comment.",
     "keyInsights": [
       "Strong completeness: finitely many removals preserve completeness",
       "Fragility: infinitely many removals destroy completeness",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-346
**Problem**: `overview.proofStrategy` and `meta.assumptions` claimed Graham's
example was "axiomatised" / that an "'axiomatized' status" was warranted, but
`Proofs/Erdos346Problem.lean` has 0 axioms (axiomCount: 0). Graham's
strong-completeness/fragility properties for `grahamSeq` live only in plain
`/- ... -/` doc comments (lines 61-62), not as `axiom` declarations — `grep
'^axiom'` has zero hits. `meta.status` was "axiomatized" while
`erdosProblemStatus` was already "open", so the status field contradicted
itself.

Same fabrication pattern as erdos-349 (#42571) and erdos-351 (#42581).

## Evidence

**meta.json claims (before)**:
- `status: "axiomatized"`
- `proofStrategy`: "...Graham's example is axiomatised..."
- `assumptions`: "...The 'axiomatized' status reflects that the main result is not yet fully formalized..."

**Lean file shows**: 8 `def`s (subsetSums, IsCompleteSet, IsStronglyComplete,
IsFragile, IsLacunary, goldenRatio, grahamSeq, ErdosProblem346), 0 `theorem`s,
0 `axiom`s, 0 `sorry`s. Graham's properties and the irregular-counterexample
claim are unattached prose comments (lines 61-62, 65, 79-80), not
declarations of any kind.

## Fix

- `status`: `"axiomatized"` -> `"open"` (matches `erdosProblemStatus: "open"`)
- `proofStrategy` reworded: Graham's properties are "documented only in doc
  comments — not formalized (no axiom, definition, or theorem states them)"
- `assumptions` reworded to drop the self-referential "'axiomatized' status" line

No count fields changed (axiomCount/theoremCount/sorries/definitionCount/lineCount
were all already accurate).

---
Discovered during gallery integrity audit (reserve-mode re-serve, queue fully drained 4811/4811).