### PR TITLE
Enrich schur-lemma-oq-01: split sections to 5 at annotation boundary (4->5)

### DIFF
--- a/src/data/proofs/schur-lemma-oq-01/meta.json
+++ b/src/data/proofs/schur-lemma-oq-01/meta.json
@@ -105,12 +105,20 @@
       "mathContext": "The half of Schur's lemma valid over any ring."
     },
     {
-      "id": "scalar-form",
-      "title": "Layer 3: The Scalar Form",
+      "id": "scalar-headline",
+      "title": "Layer 3a: The Scalar Form (Eigenvalue Argument)",
       "startLine": 89,
-      "endLine": 139,
-      "summary": "schur_endomorphism_scalar (headline): over an algebraically closed field, every A-linear endomorphism of a finite-dimensional simple module is multiplication by a scalar, proved by the eigenvalue argument. schur_endomorphism_eq_smul_id packages it as f = c • id, the absolute-simplicity statement.",
+      "endLine": 128,
+      "summary": "schur_endomorphism_scalar: over an algebraically closed field, every A-linear endomorphism of a finite-dimensional simple module is multiplication by a scalar. Proved by extracting an eigenvalue c of f as a k-linear map, then showing f − c•id kills the eigenvector, hence is zero by the dichotomy.",
       "mathContext": "Endomorphisms of an irreducible representation over an algebraically closed field are scalars."
+    },
+    {
+      "id": "scalar-eqsmul",
+      "title": "Layer 3b: Absolute Simplicity",
+      "startLine": 130,
+      "endLine": 139,
+      "summary": "schur_endomorphism_eq_smul_id repackages the scalar form as the linear-map equality f = c • id — the 'absolute simplicity' statement that End(M) is exactly k·id ≅ k.",
+      "mathContext": "$\\mathrm{End}_A(M) = k\\cdot\\mathrm{id} \\cong k$."
     },
     {
       "id": "categorical-fdrep",


### PR DESCRIPTION
## Summary
- `sections` already fully covered the 185-line file (1-185) but bundled two sub-results into one "scalar-form" section: `schur_endomorphism_scalar` (the eigenvalue-argument headline) and `schur_endomorphism_eq_smul_id` (its absolute-simplicity repackaging).
- Split at the real boundary the file's own annotations already distinguish (`schur-oq01-scalar` 90-128, `schur-oq01-eqsmul` 130-139).
- Result: 4 -> 5 sections, same full 1-185 coverage, no other fields changed.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — valid JSON
- [x] `npx tsx scripts/gallery/check-meta-size.ts schur-lemma-oq-01` — within all size caps
- [x] `npx tsx scripts/annotations/build.ts` — no warnings for this entry