### PR TITLE
Enrich hilbert-17-oq-02: cover header and final theorem

### DIFF
--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -7127,6 +7127,11 @@
       "passes": 1,
       "lastEnriched": "2026-07-20T12:34:04Z",
       "quality": 98
+    },
+    "hilbert-17-oq-02": {
+      "passes": 1,
+      "lastEnriched": "2026-07-23T21:06:40Z",
+      "quality": 98
     }
   }
 }

--- a/src/data/proofs/hilbert-17-oq-02/annotations.json
+++ b/src/data/proofs/hilbert-17-oq-02/annotations.json
@@ -219,5 +219,26 @@
       "multivariate polynomials",
       "PSD predicate"
     ]
+  },
+  {
+    "id": "h17g-poly-three-psd",
+    "proofId": "hilbert-17-oq-02",
+    "range": {
+      "startLine": 189,
+      "endLine": 193
+    },
+    "type": "theorem",
+    "title": "The Classical Choi–Lam Polynomial Is PSD",
+    "content": "The capstone corollary: `choiLamPoly 3`, the classical Choi–Lam form as a genuine element of MvPolynomial (Fin 3) ℝ, is PSD under IsPSDMv — a direct instantiation of choiLamPoly_psd_iff at c = 3 (using le_refl). This is the polynomial-object counterpart of choiLam_three_nonneg and closes the entry: the canonical homogeneous PSD/SOS gap member is now established, and quantified by its degree-2 denominator certificate, in both the real-function and MvPolynomial formulations.",
+    "mathContext": "$\\mathrm{IsPSDMv}(\\mathrm{choiLamPoly}\\ 3)$, obtained from $\\mathrm{choiLamPoly\\_psd\\_iff}\\ 3$ at the reflexive instance $3 \\le 3$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "choiLamPoly_psd_iff"
+    ],
+    "relatedConcepts": [
+      "Choi–Lam form",
+      "PSD/SOS gap",
+      "MvPolynomial"
+    ]
   }
 ]

--- a/src/data/proofs/hilbert-17-oq-02/meta.json
+++ b/src/data/proofs/hilbert-17-oq-02/meta.json
@@ -199,6 +199,13 @@
   ],
   "sections": [
     {
+      "id": "header",
+      "title": "Module Docstring, Imports, and Namespace",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "The module docstring frames the goal: quantify the PSD/SOS gap for the homogeneous Choi–Lam form, contrasting it with the gallery's existing AFFINE gap members (Motzkin, Robinson). It states the target identity — (x²+y²+z²)·CL as an explicit sum of six squares — up front, then imports all of Mathlib and opens the `Hilbert17OQ02` namespace with `open MvPolynomial` for the trivariate-polynomial repackaging later in the file."
+    },
+    {
       "id": "form-and-certificate",
       "title": "The Choi–Lam Form and the Degree-2 Multiplier Certificate",
       "startLine": 49,


### PR DESCRIPTION
Enrichment pass for hilbert-17-oq-02.

Genuine coverage gaps (quality 96, 0 prior passes):
- `sections` began at line 49, leaving the 48-line module docstring/imports/namespace header uncovered. Added a `header` section (lines 1-48).
- The capstone theorem `choiLamPoly_three_psd` (lines 189-193) had no annotation. Added one.

No filler additions — both files remain well under the size caps (meta.json ~20.8 KB, annotations.json ~11.9 KB, cap ~60 KB).