### PR TITLE
fix(erdos-325): correct stale axiom prose + axiomCount contradiction

### DIFF
--- a/src/data/proofs/erdos-325/meta.json
+++ b/src/data/proofs/erdos-325/meta.json
@@ -25,16 +25,6 @@
     "mathlib_version": "4.31.0",
     "mathlibDependencies": [
       {
-        "theorem": "Asymptotics.IsBigO",
-        "description": "Big-O asymptotic notation",
-        "module": "Mathlib.Analysis.Asymptotics.Asymptotics"
-      },
-      {
-        "theorem": "Filter.atTop",
-        "description": "Filter for limits as x → ∞",
-        "module": "Mathlib.Order.Filter.AtTopBot"
-      },
-      {
         "theorem": "Set.ncard",
         "description": "Cardinality of finite sets",
         "module": "Mathlib.Data.Set.Card"
@@ -47,7 +37,7 @@
       "Statement of Wooley's partial result for k=3",
       "Context: Mahler-Erdős theorem for two-term sums"
     ],
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 126,
     "assumptions": "No mathematical axioms and 0 sorries; previously cited axiom names were removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean. Compiler-trust disclosure: the concrete sum-of-three-powers witnesses (three_isSumThreePower_two, three_isSumThreePower_three, twentynine_isSumThreePower_three) are discharged with native_decide, so their axiom footprint includes Lean.ofReduceBool (kernel reduction trusts the compiled decision procedure). These are finite decidable computations and add no mathematical assumption; leanFile.axiomCount remains 0 (no literal axiom declarations).",
     "theoremCount": 4,
@@ -57,13 +47,13 @@
     "historicalContext": "Erdős Problem #325 concerns the density of integers that can be written as sums of three k-th powers. This is a natural extension of the classical Waring problem, which asks how many k-th powers are needed to represent ALL integers.\n\nFor sums of TWO k-th powers, Mahler and Erdős proved in 1938 that the count f_{k,2}(x) of such integers up to x satisfies f_{k,2}(x) ≫ x^{2/k}. The expected density for j terms is x^{j/k} (heuristically, there are about x^{1/k} k-th powers up to x, so about x^{j/k} ways to sum j of them).\n\nFor THREE k-th powers, the conjecture f_{k,3}(x) ≫ x^{3/k} remains open. The best known result for k=3 (cubes) is due to Wooley (2015): f_{3,3}(x) ≫ x^{0.917}, which falls short of the conjectured x^1.",
     "problemStatement": "Let $k \\geq 3$ and let $f_{k,3}(x)$ denote the number of integers $\\leq x$ which can be written as sums of three nonnegative $k$-th powers. Is it true that\n$$f_{k,3}(x) \\gg x^{3/k}?$$\n\n**Status**: OPEN — The main conjecture is unresolved.\n\n**Best Known**: For $k=3$, Wooley proved $f_{3,3}(x) \\gg x^{0.917}$ (2015).",
     "text": "Let f_{k,3}(x) count integers ≤ x that are sums of three k-th powers. Is it true that f_{k,3}(x) ≫ x^{3/k} for k ≥ 3?",
-    "proofStrategy": "We formalize the problem using Mathlib's asymptotic notation:\n\n1. **Core Definitions**: Define `IsSumThreePower k n` as the predicate for n being a sum of three k-th powers, and `cardIsSumThreePowerBelow k x` as the counting function f_{k,3}(x).\n\n2. **Examples**: Verify concrete cases like 0 = 0^k + 0^k + 0^k and 3 = 1^3 + 1^3 + 1^3.\n\n3. **Main Conjecture**: State as an axiom that x^{3/k} = O(f_{k,3}(x)) in the `atTop` filter.\n\n4. **Partial Results**: Include Wooley's theorem for k=3 and the Mahler-Erdős theorem for two terms as context.",
+    "proofStrategy": "We formalize the concrete parts of the problem in Lean and document the rest in comments:\n\n1. **Core Definitions**: Define `IsSumThreePower k n` as the predicate for n being a sum of three k-th powers, and `cardIsSumThreePowerBelow k x` as the counting function f_{k,3}(x).\n\n2. **Examples**: Verify concrete cases like 0 = 0^k + 0^k + 0^k and 3 = 1^3 + 1^3 + 1^3.\n\n3. **Main Conjecture**: Document (in comments, not as a Lean axiom or theorem) that the conjecture asks whether x^{3/k} = O(f_{k,3}(x)) in the `atTop` filter.\n\n4. **Partial Results**: Note Wooley's theorem for k=3 and the Mahler-Erdős theorem for two terms as context; also documented in comments, not formalized.",
     "keyInsights": [
       "**Waring's problem connection**: Every sufficiently large integer is a sum of at most g(k) k-th powers. Problem #325 asks about the density of those representable by exactly 3.",
       "**The 3/k exponent**: Heuristically, there are ~x^{1/k} k-th powers up to x, so ~x^{3/k} potential sums of three. The conjecture says this heuristic is correct up to a constant.",
       "**Wooley's gap**: For cubes (k=3), the conjecture predicts x^1 but Wooley only achieved x^{0.917}. Closing this gap is a major open problem.",
       "**Two vs three terms**: The two-term case f_{k,2}(x) ≫ x^{2/k} was proved in 1938. Three terms is significantly harder.",
-      "**Asymptotic notation**: We use Mathlib's `IsBigO` to express f ≫ g as 'g = O(f)', meaning f grows at least as fast as g."
+      "**Asymptotic notation**: Mathlib's `IsBigO` would express f ≫ g as 'g = O(f)', but the conjecture itself is only documented in comments here, not formalized as a Lean declaration."
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -98,7 +88,7 @@
       "title": "The Main Conjecture",
       "startLine": 74,
       "endLine": 92,
-      "summary": "Statement of Erdős Problem #325 as an axiom using asymptotic notation."
+      "summary": "Documents Erdős Problem #325 in comments using asymptotic-notation language; not a Lean axiom or declaration."
     },
     {
       "id": "variants",
@@ -116,7 +106,7 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #325 on the density of sums of three k-th powers. The conjecture f_{k,3}(x) ≫ x^{3/k} remains OPEN. We define the counting function, verify concrete examples, state the main conjecture and its variants as axioms, and provide context via the solved two-term analogue.",
+    "summary": "We formalize Erdős Problem #325 on the density of sums of three k-th powers. The conjecture f_{k,3}(x) ≫ x^{3/k} remains OPEN. We define the counting function, verify concrete examples, document the main conjecture and its variants in comments (not as Lean axioms), and provide context via the solved two-term analogue.",
     "implications": "**Theoretical Significance**: This problem lies at the intersection of additive number theory and analytic methods.\n\nA proof would establish that sums of three powers have the 'expected' density, with implications for understanding the structure of power sums. Progress here often involves the Hardy-Littlewood circle method and mean value estimates.",
     "openQuestions": [
       "Can Wooley's x^{0.917} bound for three cubes be improved toward x^1?",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-325

**Problem**: After the main-conjecture axioms were stripped from the Lean
source down to plain doc comments (`/- ... -/`), several `meta.json` prose
fields still described the conjecture as "stated as an axiom using
asymptotic notation." No such Lean declaration exists anymore — the file
has 0 axioms (`leanFile.axiomCount: 0`), and `Asymptotics.IsBigO`/
`Filter.atTop` are unused (only `Set.ncard` is actually referenced).

Separately, PR #41299 bumped `meta.axiomCount` 0→1 in the same edit that
added disclosure text saying "No mathematical axioms" and "leanFile.axiomCount
remains 0 (no literal axiom declarations)" — a direct self-contradiction
within the same field.

## Evidence

**meta.json claimed**: `axiomCount: 1`; `proofStrategy` said "State as an
axiom that x^{3/k} = O(f_{k,3}(x))"; section `main-conjecture` summary said
"Statement of Erdős Problem #325 as an axiom using asymptotic notation";
`conclusion.summary` said "state the main conjecture and its variants as
axioms"; `mathlibDependencies` listed `Asymptotics.IsBigO` and `Filter.atTop`.

**Lean file shows** (`proofs/Proofs/Erdos325Problem.lean`): the main
conjecture, its epsilon variant, Wooley's theorem, and the Mahler-Erdős
theorem are all plain `/- ... -/` comments — no `axiom`, `theorem`, or `def`
captures them. `IsBigO`/`atTop` never appear as Lean identifiers anywhere in
the file. Only 4 theorems + 4 defs exist (matches `theoremCount`/
`definitionCount`), all correctly counted already.

## Fix

- `axiomCount`: 1 → 0 (matches `leanFile.axiomCount` and the `assumptions`
  disclosure text, which was already accurate).
- Removed unused `Asymptotics.IsBigO` / `Filter.atTop` from
  `mathlibDependencies`.
- Reworded `proofStrategy`, the last `keyInsights` bullet, the
  `main-conjecture` section summary, and `conclusion.summary` to say the
  conjecture is documented in comments, not formalized as a Lean axiom.

No Lean source changes — this is a metadata-only correction matching the
recurring "stale axiomatized prose after axiom strip" pattern (same class
as PRs #42466, #42413).

---
Discovered during gallery integrity audit.