### PR TITLE
Enrich schroeder-bernstein-oq-02-oq-01: split sections to 5 (4->5)

### DIFF
--- a/src/data/proofs/schroeder-bernstein-oq-02-oq-01/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-02-oq-01/meta.json
@@ -93,12 +93,20 @@
       "mathContext": "The CBS operator on the complete lattice Set α, as in OQ-02."
     },
     {
-      "id": "any-fixed-point",
-      "title": "A Bijection from Any Fixed Point",
+      "id": "fixed-point-lemmas",
+      "title": "Structural Facts About Any Fixed Point",
       "startLine": 72,
+      "endLine": 117,
+      "summary": "For any S with cbsOp f g S = S, re-derived from the fixed-point equation alone: compl_range_subset_fp, mem_range_of_not_mem_fp, gf_image_subset_fp, gf_mem_fp, mem_fimage_of_gb_mem_fp, gb_not_mem_fp — the parent's lemmas, generalized off minimality.",
+      "mathContext": "Every fixed point of T shares the same structural facts — minimality is not used."
+    },
+    {
+      "id": "piecewise-bijection",
+      "title": "The Piecewise Bijection equivFP",
+      "startLine": 119,
       "endLine": 165,
-      "summary": "The crux generalization: for any S with cbsOp f g S = S, the parent's lemmas (compl_range_subset_fp, mem_range_of_not_mem_fp, gf_image_subset_fp, gf_mem_fp, mem_fimage_of_gb_mem_fp, gb_not_mem_fp) are re-derived from the fixed-point equation alone. The piecewise map bijFP is injective (needs only f injective) and surjective (needs only g injective), packaged as equivFP : α ≃ β.",
-      "mathContext": "Every fixed point of T yields a Schroeder–Bernstein bijection — minimality is not used."
+      "summary": "bijFP: a ↦ f a on S, a ↦ g⁻¹ a off S. bijFP_injective needs only f injective; bijFP_surjective needs only g injective. equivFP packages both as α ≃ β — every fixed point of T yields a Schroeder–Bernstein bijection.",
+      "mathContext": "The piecewise map built from any fixed point S is a bijection α ≃ β."
     },
     {
       "id": "lfp-gfp",


### PR DESCRIPTION
## Summary
- `sections` already fully covered the 266-line file (1-266) but bundled two distinct parts into one 94-line "any-fixed-point" section: the structural facts re-derived from the fixed-point equation alone, and the piecewise bijection construction built from those facts.
- Split at the boundary the section's own annotation prose already draws ("the parent's structural lemmas are re-derived... The piecewise map bijFP... giving equivFP"): `fixed-point-lemmas` (72-117) and `piecewise-bijection` (119-165).
- Result: 4 -> 5 sections, same full 1-266 coverage, no other fields changed.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — valid JSON
- [x] `npx tsx scripts/gallery/check-meta-size.ts schroeder-bernstein-oq-02-oq-01` — within all size caps
- [x] `npx tsx scripts/annotations/build.ts` — no new warnings (one pre-existing, unrelated annotation-type mismatch at line 173 predates this change)