### PR TITLE
Fix: erdos-326 meta.json overstates Cassels/open-problem as formalized (comment-only)

### DIFF
--- a/src/data/proofs/erdos-326/meta.json
+++ b/src/data/proofs/erdos-326/meta.json
@@ -43,7 +43,7 @@
     "originalContributions": [
       "Formal definition of additive bases and their orders in Lean 4",
       "Formalization of the growth rate concept for basis elements",
-      "Statement of both the open problem and Cassels' 1957 result",
+      "Comment documentation (not a Lean declaration) of both the open problem and Cassels' 1957 result",
       "Educational documentation connecting the concepts"
     ],
     "axiomCount": 0,
@@ -56,7 +56,7 @@
     "historicalContext": "Erdős Problem #326 concerns the asymptotic behavior of additive bases, a fundamental concept in additive number theory. An additive basis of order k is a set A of natural numbers such that every sufficiently large integer can be written as a sum of at most k elements from A. The classic example is Lagrange's four-square theorem: every natural number is a sum of four perfect squares.\n\nThe key quantity here is the growth rate: if we enumerate a basis as {b₁ < b₂ < ...}, how fast does bₖ grow compared to k²? For an order 2 basis, the elements can grow at most quadratically (otherwise there wouldn't be enough sums to cover all integers). Erdős asked whether, given any basis A, we can always find a sub-basis B whose growth ratio bₖ/k² fails to converge.\n\nErdős originally asked whether every basis A has non-convergent growth ratio (with A = B). This was disproved by Cassels in 1957, who constructed a basis where aₖ/k² does converge. The modified question about sub-bases remains open.",
     "problemStatement": "Let $A \\subset \\mathbb{N}$ be an additive basis of order 2 (every sufficiently large natural number is a sum of two elements of $A$). Must there exist a subset $B = \\{b_1 < b_2 < \\cdots\\} \\subseteq A$ which is also an additive basis such that\n$$\\lim_{k \\to \\infty} \\frac{b_k}{k^2}$$\ndoes not exist?\n\n**Status**: OPEN\n\n**Related result**: Cassels (1957) showed the original A=B version is false by constructing a convergent basis.",
     "text": "Let A be an additive basis of order 2. Must there exist a subset B which is also a basis such that the growth ratio of B has no limit?",
-    "proofStrategy": "Since this problem is open, we cannot prove the statement. Instead, we:\n\n1. **Define the concepts formally**: We introduce `IsAddBasisOfOrder` for order-k bases and `IsAddBasis` for general bases.\n\n2. **Define the growth question**: The `growthRatio` function computes bₖ/k², and `HasGrowthLimit` expresses convergence via Mathlib's filter-based limits.\n\n3. **State the open problem as a disjunction**: Either the statement holds for all order 2 bases, or it doesn't. This is trivially true but captures the mathematical question.\n\n4. **State Cassels' result**: We include the 1957 theorem showing a convergent basis exists, which resolved the original (weaker) formulation.\n\n5. **State the density bound**: Any order 2 basis has elements bounded by O(k²), a standard result from additive combinatorics.",
+    "proofStrategy": "Since this problem is open, we cannot prove the statement. Instead, we:\n\n1. **Define the concepts formally**: We introduce `IsAddBasisOfOrder` for order-k bases and `IsAddBasis` for general bases.\n\n2. **Define the growth question**: The `growthRatio` function computes bₖ/k², and `HasGrowthLimit` expresses convergence via Mathlib's filter-based limits.\n\n3. **Document the open problem in comments**: The file's module documentation describes the disjunction (either the statement holds for all order 2 bases, or it doesn't), but this is not encoded as a Lean declaration.\n\n4. **Document Cassels' result in comments**: The 1957 theorem showing a convergent basis exists is described in prose, not formalized as a Lean `theorem` or `axiom`.\n\n5. **Document the density bound in comments**: The standard O(k²) growth bound for order 2 bases is noted in prose only, not stated as a Lean declaration.",
     "keyInsights": [
       "**Additive basis**: A set A is an additive basis if every sufficiently large integer can be written as a sum of elements from A. Order k means we need at most k summands.",
       "**Growth rate bound**: For an order 2 basis with enumeration {b₁ < b₂ < ...}, we have bₖ = O(k²). This is because we need roughly n² pairs to cover all sums up to n.",
@@ -94,28 +94,28 @@
     },
     {
       "id": "main-theorem",
-      "title": "Main Theorem (Open)",
+      "title": "Main Theorem (Open, Documentation Only)",
       "startLine": 91,
       "endLine": 117,
-      "summary": "State Erdős Problem #326 as an open question: either every order 2 basis has a non-convergent sub-basis, or there's a counterexample."
+      "summary": "Comment documenting Erdős Problem #326 as an open question (either every order 2 basis has a non-convergent sub-basis, or there's a counterexample); no Lean declaration is stated in this range."
     },
     {
       "id": "cassels",
-      "title": "Cassels' Theorem (1957)",
+      "title": "Cassels' Theorem (1957, Documentation Only)",
       "startLine": 118,
       "endLine": 138,
-      "summary": "State Cassels' result showing there exists a basis with convergent growth ratio, disproving the original A=B formulation."
+      "summary": "Comment documenting Cassels' result (a basis with convergent growth ratio, disproving the original A=B formulation); not formalized as a Lean declaration."
     },
     {
       "id": "observations",
       "title": "Key Observations",
       "startLine": 139,
       "endLine": 139,
-      "summary": "State the standard upper bound that order 2 basis elements grow at most quadratically."
+      "summary": "Comment noting the standard upper bound that order 2 basis elements grow at most quadratically; not stated as a Lean declaration."
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #326, an open question about whether every additive basis of order 2 contains a sub-basis with non-convergent growth rate. The problem connects additive combinatorics with analysis through the study of sequence growth rates. We include Cassels' 1957 result which resolved the weaker original formulation.",
+    "summary": "We formalize the core definitions for Erdős Problem #326, an open question about whether every additive basis of order 2 contains a sub-basis with non-convergent growth rate. The problem connects additive combinatorics with analysis through the study of sequence growth rates. Cassels' 1957 result, which resolved the weaker original formulation, is documented in comments only and is not a Lean declaration.",
     "implications": "**Theoretical Significance**: This problem sits at the intersection of additive combinatorics and asymptotic analysis.\n\nA positive answer would show that 'nice' growth behavior cannot be inherited by all sub-bases. A negative answer (counterexample) would exhibit a special basis where every sub-basis has a definite growth rate.",
     "openQuestions": [
       "Is there an order 2 basis A such that every sub-basis B has convergent bₖ/k²?",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-326
**Problem**: `meta.json` narrative (proofStrategy, section summaries, originalContributions, conclusion.summary) claimed the open-problem disjunction and Cassels' 1957 theorem were "stated"/"included"/"formalized", but the Lean file only has comment blocks (`/- ... -/`) in those line ranges — no `def`/`theorem`/`axiom` declaration.

## Evidence

**meta.json claims** (before): proofStrategy step 3 "State the open problem as a disjunction"; step 4 "We include the 1957 theorem showing a convergent basis exists"; section "cassels" title "Cassels' Theorem (1957)"; conclusion "We include Cassels' 1957 result which resolved the weaker original formulation."

**Lean file shows**: `proofs/Proofs/Erdos326Problem.lean` has exactly 5 `def`s and 1 `theorem` (`IsAddBasis`, `IsAddBasisOfOrder`, `growthRatio`, `HasGrowthLimit`, `HasNoGrowthLimit`, `IsAddBasisOfOrder.isAddBasis`) — matching `theoremCount`/`definitionCount`/`axiomCount`/`sorries` in meta.json (all accurate). Lines 91-138 (the "Main Theorem" and "Cassels' Theorem" sections) are pure module-doc comments with zero declarations.

## Fix

Reworded proofStrategy, section titles/summaries, originalContributions, and conclusion.summary to describe these as comment-only documentation rather than formalized/stated Lean content. No changes to axiomCount/theoremCount/sorries/badge/status — those were already correct.

---
Discovered during gallery integrity audit.