### PR TITLE
Enrich pythagorean-triples-oq-04-oq-01: split header into docstring/setup (4->5)

### DIFF
--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -7132,6 +7132,11 @@
       "passes": 1,
       "lastEnriched": "2026-07-23T21:06:40Z",
       "quality": 98
+    },
+    "pythagorean-triples-oq-04-oq-01": {
+      "passes": 1,
+      "lastEnriched": "2026-07-23T21:17:34Z",
+      "quality": 100
     }
   }
 }

--- a/src/data/proofs/pythagorean-triples-oq-04-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-04-oq-01/meta.json
@@ -84,11 +84,18 @@
   ],
   "sections": [
     {
-      "id": "header",
-      "title": "Setup: lifting two-factor multiplicativity to arbitrarily many primes",
+      "id": "docstring",
+      "title": "Imports and Module Docstring",
       "startLine": 1,
+      "endLine": 42,
+      "summary": "Imports Mathlib.NumberTheory.SumTwoSquares and Mathlib.Tactic. The module docstring states the goal — the constructive sufficiency direction of the two-square theorem, obtained by strong induction on the least prime factor rather than by citing Mathlib's existence-only Nat.eq_sq_add_sq_iff — with a results table summarizing the three theorems."
+    },
+    {
+      "id": "namespace-setup",
+      "title": "Namespace and Open",
+      "startLine": 44,
       "endLine": 46,
-      "summary": "Module docstring stating the goal — the constructive sufficiency direction of the two-square theorem, obtained by strong induction on the least prime factor rather than by citing Mathlib's existence-only Nat.eq_sq_add_sq_iff — with a results table for the three theorems; imports SumTwoSquares, opens the namespace and Nat."
+      "summary": "Declares namespace PythagoreanTriplesOQ04OQ01 and opens Nat, so minFac, Prime, and the arithmetic lemmas used throughout can be referred to unqualified."
     },
     {
       "id": "constructive-sufficiency",


### PR DESCRIPTION
Enrichment pass for pythagorean-triples-oq-04-oq-01.

Split the `header` section (1-46, imports + module docstring bundled with namespace/open) into:
- `docstring` (1-42): imports and the module docstring with the results table
- `namespace-setup` (44-46): namespace declaration and `open Nat`

No content/annotation changes.