### PR TITLE
Fix: erdos-321 originalContributions overclaims tautology as A={1,...,N} case

### DIFF
--- a/src/data/proofs/erdos-321/meta.json
+++ b/src/data/proofs/erdos-321/meta.json
@@ -40,7 +40,7 @@
       "Formal framework for distinct reciprocal subset sums: HasDistinctReciprocalSums over ℚ (exact arithmetic) and R(N) via Finset.sup",
       "Proved equivalence of two subset sum formulations (distinct subsets ↔ injective map)",
       "Proved hereditary property: subsets of sets with distinct reciprocal sums inherit distinctness",
-      "Proved conjecture holds trivially for A = {1,...,N} (erdos_321_asymptotics)",
+      "erdos_321_asymptotics: tautological existence statement ∃ f, R(N) = f(N), proved by rfl with f = maxDistinctReciprocal — not a partial result on the conjecture, which remains open (see axiomatized Bleicher–Erdős bounds)",
       "Connected Bleicher–Erdős bounds to Egyptian fraction theory and greedy algorithms",
       "maxDistinctReciprocal_ge_one: PROVED — R(N) ≥ 1 for N ≥ 1, witnessed by singleton {1} ∈ {1,...,N}"
     ],


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-321

**Problem**: `originalContributions` bullet 4 said `erdos_321_asymptotics` "Proved conjecture holds trivially for A = {1,...,N}". The theorem is actually a content-free tautology (`∃ f, R(N) = f(N)`, proved by taking `f = maxDistinctReciprocal`) with no mention of `A` anywhere in its statement. This contradicts the same file's own `mainTheorems` entry and `main-conjecture` section summary, which both correctly label it "tautological".

## Evidence

**meta.json claimed**: "Proved conjecture holds trivially for A = {1,...,N} (erdos_321_asymptotics)"

**Lean file shows** (`proofs/Proofs/Erdos321Problem.lean:185-188`):
```lean
theorem erdos_321_asymptotics :
    ∃ f : ℕ → ℝ, ∀ N : ℕ, N ≥ 2 →
      (maxDistinctReciprocal N : ℝ) = f N :=
  ⟨fun N => (maxDistinctReciprocal N : ℝ), fun _ _ => rfl⟩
```
No `A` in sight — it's a trivial existential satisfied by `f = maxDistinctReciprocal`.

## Fix

Reworded the bullet to match the accurate description already used elsewhere in the file.

---
Discovered during gallery integrity reserve-mode audit.