### PR TITLE
Enrich quadratic-reciprocity-oq-04: fix drifted section boundaries, split to 5

### DIFF
--- a/src/data/proofs/quadratic-reciprocity-oq-04/annotations.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-04/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "ann-qr-oq04-overview",
     "proofId": "quadratic-reciprocity-oq-04",
-    "range": { "startLine": 1, "endLine": 48 },
+    "range": { "startLine": 1, "endLine": 49 },
     "type": "concept",
     "title": "What the Jacobi Symbol Keeps and Loses",
     "content": "The Jacobi symbol J(a | b) extends the Legendre symbol to odd b by multiplicativity over the prime factorization, and keeps the quadratic reciprocity law — so it stays efficiently computable without factoring b. But it loses residue-detection: for composite b, J(a | b) = 1 no longer implies that a is a square mod b. Mathlib has the residue equivalence only for prime moduli.",
@@ -14,7 +14,7 @@
   {
     "id": "ann-qr-oq04-evaluation",
     "proofId": "quadratic-reciprocity-oq-04",
-    "range": { "startLine": 49, "endLine": 64 },
+    "range": { "startLine": 50, "endLine": 61 },
     "type": "tactic",
     "title": "Computing J(2 | 15) and Its Factorization",
     "content": "jacobiSym_two_fifteen evaluates J(2 | 15) = 1 using Mathlib's reciprocity-based norm_num extension (axiom-clean, not native_decide). jacobiSym_two_fifteen_factor exhibits the multiplicative decomposition J(2 | 15) = J(2 | 3)·J(2 | 5) = (-1)(-1), the mechanism by which two Legendre non-residues produce a Jacobi value of +1.",
@@ -26,7 +26,7 @@
   {
     "id": "ann-qr-oq04-nonsquare",
     "proofId": "quadratic-reciprocity-oq-04",
-    "range": { "startLine": 65, "endLine": 68 },
+    "range": { "startLine": 62, "endLine": 64 },
     "type": "tactic",
     "title": "2 Is Not a Square mod 15",
     "content": "two_nonsquare_mod_fifteen is decided over the finite ring ℤ/15: the squares are {0,1,4,6,9,10}, and 2 is not among them. This uses kernel decide (no native_decide), so it adds no axioms.",
@@ -38,7 +38,7 @@
   {
     "id": "ann-qr-oq04-counterexample",
     "proofId": "quadratic-reciprocity-oq-04",
-    "range": { "startLine": 69, "endLine": 76 },
+    "range": { "startLine": 65, "endLine": 77 },
     "type": "theorem",
     "title": "The Converse Fails for Composite Moduli (an Euler Liar)",
     "content": "jacobi_one_not_isSquare_of_composite packages the witness a = 2, b = 15 into an existential: there is an odd composite b with J(a | b) = 1 yet a not a square mod b. The proof supplies ⟨2, 15, …⟩ and discharges the four conjuncts — ¬Prime 15 and Odd 15 by decide, J(2|15) = 1 by the earlier jacobiSym_two_fifteen, and ¬IsSquare via a push_cast bridge (2 : ℤ) : ZMod 15 = (2 : ZMod 15) into two_nonsquare_mod_fifteen. This proves Mathlib's prime-only isSquare_of_jacobiSym_eq_one is sharp: the primality hypothesis cannot be dropped. Such J=1 non-squares are exactly the Euler liars that make the Solovay–Strassen primality test probabilistic.",

--- a/src/data/proofs/quadratic-reciprocity-oq-04/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-04/meta.json
@@ -85,33 +85,41 @@
       "id": "header",
       "title": "Module Header and Imports",
       "startLine": 1,
-      "endLine": 48,
+      "endLine": 49,
       "summary": "Docstring framing the Jacobi generalization, what is retained (reciprocity, computability) and what is lost (residue-detection); imports Mathlib; namespace QuadraticReciprocityJacobi",
       "mathContext": "J(a | b) extends (a | p) multiplicatively; reciprocity holds for all odd b, but J(a|b)=1 ⇏ square for composite b."
     },
     {
       "id": "evaluation",
       "title": "Evaluating J(2 | 15) and Its Factorization",
-      "startLine": 49,
-      "endLine": 64,
+      "startLine": 50,
+      "endLine": 61,
       "summary": "jacobiSym_two_fifteen (= 1, via the norm_num extension) and jacobiSym_two_fifteen_factor (= J(2|3)·J(2|5)), exhibiting the (-1)(-1) = 1 mechanism",
       "mathContext": "$J(2|15) = 1 = J(2|3)\\,J(2|5) = (-1)(-1)$."
     },
     {
       "id": "nonsquare",
       "title": "2 Is Not a Square mod 15",
-      "startLine": 65,
-      "endLine": 68,
+      "startLine": 62,
+      "endLine": 64,
       "summary": "two_nonsquare_mod_fifteen by kernel decide (squares mod 15 are {0,1,4,6,9,10})",
       "mathContext": "$2 \\notin \\{x^2 : x \\in \\mathbb{Z}/15\\} = \\{0,1,4,6,9,10\\}$."
     },
     {
       "id": "counterexample",
-      "title": "Failure of the Converse and the Surviving Direction",
-      "startLine": 69,
+      "title": "Failure of the Converse (an Euler Liar)",
+      "startLine": 65,
+      "endLine": 77,
+      "summary": "jacobi_one_not_isSquare_of_composite: an odd composite b and an a with J(a | b) = 1 yet a not a square mod b, so the prime-only isSquare_of_jacobiSym_eq_one is sharp",
+      "mathContext": "$\\exists a,b:\\ \\neg\\,\\mathrm{Prime}\\,b \\wedge \\mathrm{Odd}\\,b \\wedge J(a|b)=1 \\wedge \\neg\\,\\mathrm{IsSquare}\\,(a:\\mathbb{Z}/b)$."
+    },
+    {
+      "id": "surviving-direction",
+      "title": "The Direction That Survives for All b",
+      "startLine": 78,
       "endLine": 86,
-      "summary": "jacobi_one_not_isSquare_of_composite (J = 1 but non-square for composite b) and jacobiSym_neg_one_imp_nonsquare (J = -1 ⟹ non-square, all b)",
-      "mathContext": "$\\exists a,b:\\ \\neg\\,\\mathrm{Prime}\\,b \\wedge \\mathrm{Odd}\\,b \\wedge J(a|b)=1 \\wedge \\neg\\,\\mathrm{IsSquare}\\,(a:\\mathbb{Z}/b)$; and $J(a|b)=-1 \\Rightarrow \\neg\\,\\mathrm{IsSquare}$."
+      "summary": "jacobiSym_neg_one_imp_nonsquare, re-exported from Mathlib: J(a | b) = -1 always certifies a non-square, even for composite b",
+      "mathContext": "$J(a|b)=-1 \\Rightarrow \\neg\\,\\mathrm{IsSquare}\\,(a:\\mathbb{Z}/b)$, valid for every $b$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `quadratic-reciprocity-oq-04`.

The 4 existing `sections` and their matching `annotations.json` ranges had
drifted from the actual theorem locations in `QuadraticReciprocityOQ04.lean`:

- `two_nonsquare_mod_fifteen` (the actual theorem at lines 62-63) was folded
  into the `evaluation` section (49-64), while the `nonsquare` section
  (65-68) actually pointed at the docstring of the *next* theorem
  (`jacobi_one_not_isSquare_of_composite`).
- The `counterexample` section (69-86) combined two distinct theorems
  (`jacobi_one_not_isSquare_of_composite` and `jacobiSym_neg_one_imp_nonsquare`)
  under one summary.

Re-anchored both `meta.json` sections and `annotations.json` ranges to the
real theorem boundaries (verified via `grep -n` against the Lean source),
and split the tail into two sections — `counterexample` and
`surviving-direction` — giving 5 sections that each map onto exactly one
theorem or the header, still covering the full file (lines 1-86).

No content was deleted; only line ranges were corrected and one section
summary was split into two.