### PR TITLE
Research: erdos-53-wip-01 - multiplicative Erdős chain: subsetProducts quadratic for sets of integers > 1

### DIFF
--- a/proofs/Proofs/Erdos53WIP01.lean
+++ b/proofs/Proofs/Erdos53WIP01.lean
@@ -473,4 +473,207 @@ theorem sumsOrProducts_card_superlinear (C : ℕ) :
     Nat.mul_le_mul_right A.card hbig
   nlinarith [h, hsq]
 
+/-!
+## Quadratic multiplicative lower bound for sets of integers ≥ 2 (product chain)
+
+The quadratic chain above is purely **additive**: it bounds `subsetSums`. This
+section proves its exact multiplicative mirror, moving the unconditional
+`subsetProducts` frontier from "prime sets only" (`2^{|A|} − 1`, unique
+factorisation) to **arbitrary sets of integers `≥ 2`**:
+
+> For any finite `A ⊆ ℤ` with all elements `> 1`,
+> `|subsetProducts A| ≥ |A|·(|A|+1)/2`.
+
+Same top-element-removal chain, transposed: remove `m = max A` and observe that
+the `|A|` products `{Π A} ∪ { Π (A.erase a) : a ∈ A, a ≠ m }` are pairwise
+distinct and each strictly exceeds `Π (A.erase m)`, which bounds every subset
+product of `A.erase m` from above. The transposition is not mechanical, because
+the multiplicative monoid of `ℤ` is not an ordered monoid (negatives flip
+inequalities) and `ℤ` has no exact division:
+
+* "subset product `≤` full product" comes from **divisibility plus positivity**
+  (`Finset.prod_dvd_prod_of_subset` + `Int.le_of_dvd`), not sum monotonicity;
+* the fresh values are written `Π (A.erase a)` — never `P / a` — and all their
+  comparisons go through **cancellation** on `Π (A.erase a) · a = Π A`
+  (`mul_left_cancel₀`, `lt_of_mul_lt_mul_right`), not subtraction;
+* the elements-`> 1` hypothesis is genuinely needed where the additive chain
+  needed only `> 0`: with `1 ∈ A` the fresh value `Π (A.erase 1) = Π A`
+  collides with the full product (injectivity dies), matching the additive
+  chain's failure at `0 ∈ A`.
+
+The bound differs from the additive one by exactly the missing `+1`:
+`subsetProducts` excludes the empty subset (there is no multiplicative
+analogue of the free value `0`). It is **sharp**: for the geometric set
+`A = {2, 4, …, 2^n}` the subset products are `2^s` for `s` a nonempty subset
+sum of `{1, …, n}`, i.e. exactly the `n(n+1)/2` values `2^1, …, 2^{n(n+1)/2}`
+(remark, not formalised here). Together with `subsetSums_card_ge_quadratic`
+this shows each side of Problem 53 is *individually* quadratic on its natural
+domain — the open content of Erdős–Szemerédi/Chang is that sums and products
+cannot both stay near-minimal *simultaneously*.
+-/
+
+/-- The full product `Π A` is a subset product (take `S = A`), for nonempty `A`. -/
+theorem prod_mem_subsetProducts {A : Finset ℤ} (hA : A.Nonempty) :
+    A.prod id ∈ subsetProducts A := by
+  rw [subsetProducts, Finset.mem_image]
+  exact ⟨A, Finset.mem_filter.mpr ⟨Finset.mem_powerset.mpr Finset.Subset.rfl, hA⟩, rfl⟩
+
+/-- Erasing one element leaves a subset product, provided something remains:
+    `Π (A.erase a) ∈ subsetProducts A` when `A.erase a` is nonempty. -/
+theorem prod_erase_mem_subsetProducts {A : Finset ℤ} {a : ℤ} (hne : (A.erase a).Nonempty) :
+    (A.erase a).prod id ∈ subsetProducts A := by
+  rw [subsetProducts, Finset.mem_image]
+  exact ⟨A.erase a, Finset.mem_filter.mpr ⟨Finset.mem_powerset.mpr
+    (fun x hx => Finset.mem_of_mem_erase hx), hne⟩, rfl⟩
+
+/-- On a set of **positive** integers every subset product is at most the full
+    product `Π A`: a subset product divides the full product
+    (`Finset.prod_dvd_prod_of_subset`), and a positive divisor of a positive
+    integer is at most it (`Int.le_of_dvd`). The multiplicative counterpart of
+    `mem_subsetSums_le_sum` — sum monotonicity is unavailable because `ℤ` under
+    `*` is not an ordered monoid. -/
+theorem mem_subsetProducts_le_prod {A : Finset ℤ} (hpos : ∀ a ∈ A, 0 < a)
+    {x : ℤ} (hx : x ∈ subsetProducts A) : x ≤ A.prod id := by
+  rw [subsetProducts, Finset.mem_image] at hx
+  obtain ⟨S, hS, rfl⟩ := hx
+  rw [Finset.mem_filter, Finset.mem_powerset] at hS
+  exact Int.le_of_dvd (Finset.prod_pos (fun i hi => hpos i hi))
+    (Finset.prod_dvd_prod_of_subset S A id hS.1)
+
+/-- **Multiplicative Erdős chain, induction core.** For any set `A` of `n`
+    distinct integers `> 1`, `n(n+1) ≤ 2·|subsetProducts A|` (the division-free
+    form of `|subsetProducts A| ≥ n(n+1)/2`).
+
+    Induction on `n`, removing `m = max A`: every subset product of
+    `A' = A.erase m` divides — hence is at most — `Q = Π A'`, while the `n`
+    values `{Π A} ∪ { Π (A.erase a) : a ∈ A' }` are distinct subset products of
+    `A` strictly above `Q`. All comparisons run through cancellation on
+    `Π (A.erase a) · a = Π A = Q · m`: from `a < m` and `Q > 0` follows
+    `Π (A.erase a) > Q`, and from `m > 1` follows `Π A > Q`. -/
+theorem subsetProducts_card_quadratic :
+    ∀ (n : ℕ) (A : Finset ℤ), A.card = n → (∀ a ∈ A, 1 < a) →
+      n * (n + 1) ≤ 2 * (subsetProducts A).card := by
+  intro n
+  induction n with
+  | zero =>
+      intro A hcard _
+      simp
+  | succ n ih =>
+      intro A hcard hgt
+      have hpos : ∀ a ∈ A, (0 : ℤ) < a := fun a ha => lt_trans zero_lt_one (hgt a ha)
+      have hne : A.Nonempty := Finset.card_pos.mp (by omega)
+      set m := A.max' hne with hm_def
+      have hmA : m ∈ A := A.max'_mem hne
+      set A' := A.erase m with hA'_def
+      have hcard' : A'.card = n := by
+        rw [hA'_def, Finset.card_erase_of_mem hmA, hcard]
+        omega
+      have hgt' : ∀ a ∈ A', (1 : ℤ) < a := fun a ha => hgt a (Finset.mem_of_mem_erase ha)
+      have hpos' : ∀ a ∈ A', (0 : ℤ) < a := fun a ha => hpos a (Finset.mem_of_mem_erase ha)
+      have IH : n * (n + 1) ≤ 2 * (subsetProducts A').card := ih A' hcard' hgt'
+      set P := A.prod id with hP_def
+      set Q := A'.prod id with hQ_def
+      have hQpos : (0 : ℤ) < Q := Finset.prod_pos (fun i hi => hpos' i hi)
+      -- the erased set multiplies back up to the full product
+      have hQm : Q * m = P := by
+        rw [hQ_def, hA'_def, hP_def]
+        simpa using Finset.prod_erase_mul A id hmA
+      -- the generic one-element-erased product recombination law
+      have hRmul : ∀ a ∈ A, (A.erase a).prod id * a = P := by
+        intro a ha
+        rw [hP_def]
+        simpa using Finset.prod_erase_mul A id ha
+      -- the `n + 1` "large" subset products: `P` itself and `Π (A.erase a)` for `a ∈ A'`
+      set B : Finset ℤ := insert P (A'.image (fun a => (A.erase a).prod id)) with hB_def
+      have hBsub : B ⊆ subsetProducts A := by
+        intro b hb
+        rw [hB_def, Finset.mem_insert] at hb
+        rcases hb with rfl | hb
+        · exact prod_mem_subsetProducts hne
+        · rw [Finset.mem_image] at hb
+          obtain ⟨a, ha, rfl⟩ := hb
+          have hma : m ∈ A.erase a :=
+            Finset.mem_erase.mpr ⟨fun h => (Finset.mem_erase.mp ha).1 h.symm, hmA⟩
+          exact prod_erase_mem_subsetProducts ⟨m, hma⟩
+      -- each fresh product strictly exceeds `Q`
+      have hRgtQ : ∀ a ∈ A', Q < (A.erase a).prod id := by
+        intro a ha
+        have haA : a ∈ A := Finset.mem_of_mem_erase ha
+        have halt : a < m :=
+          lt_of_le_of_ne (A.le_max' a haA) (Finset.mem_erase.mp ha).1
+        have hkey : Q * a < (A.erase a).prod id * a := by
+          calc Q * a < Q * m := mul_lt_mul_of_pos_left halt hQpos
+            _ = P := hQm
+            _ = (A.erase a).prod id * a := (hRmul a haA).symm
+        exact lt_of_mul_lt_mul_right hkey (hpos a haA).le
+      have hPgtQ : Q < P := by
+        have h1 : Q * 1 < Q * m := mul_lt_mul_of_pos_left (hgt m hmA) hQpos
+        rw [mul_one, hQm] at h1
+        exact h1
+      have hBcard : B.card = n + 1 := by
+        have hinj : Set.InjOn (fun a => (A.erase a).prod id) A' := by
+          intro a ha b hb hab
+          have ha' : a ∈ A' := Finset.mem_coe.mp ha
+          have hb' : b ∈ A' := Finset.mem_coe.mp hb
+          have haA : a ∈ A := Finset.mem_of_mem_erase ha'
+          have hbA : b ∈ A := Finset.mem_of_mem_erase hb'
+          have hRpos : (0 : ℤ) < (A.erase a).prod id := lt_trans hQpos (hRgtQ a ha')
+          have hab' : (A.erase a).prod id = (A.erase b).prod id := hab
+          have h : (A.erase a).prod id * a = (A.erase a).prod id * b := by
+            rw [hRmul a haA, hab']
+            exact (hRmul b hbA).symm
+          exact mul_left_cancel₀ (ne_of_gt hRpos) h
+        have himg : (A'.image (fun a => (A.erase a).prod id)).card = A'.card :=
+          Finset.card_image_of_injOn hinj
+        have hP_not : P ∉ A'.image (fun a => (A.erase a).prod id) := by
+          rw [Finset.mem_image]
+          rintro ⟨a, ha, haeq⟩
+          have haA : a ∈ A := Finset.mem_of_mem_erase ha
+          have hRpos : (0 : ℤ) < (A.erase a).prod id := lt_trans hQpos (hRgtQ a ha)
+          -- `Π (A.erase a) = P` forces `a = 1`, impossible for elements `> 1`
+          have h1 : (A.erase a).prod id * a = (A.erase a).prod id * 1 := by
+            rw [mul_one, hRmul a haA, haeq]
+          have := mul_left_cancel₀ (ne_of_gt hRpos) h1
+          exact absurd this (ne_of_gt (hgt a haA))
+        rw [hB_def, Finset.card_insert_of_notMem hP_not, himg, hcard']
+      -- separation: every subset product of `A'` is `≤ Q`, every element of `B` is `> Q`
+      have hlt : ∀ x ∈ subsetProducts A', ∀ b ∈ B, x < b := by
+        intro x hx b hb
+        have hxle : x ≤ Q := mem_subsetProducts_le_prod hpos' hx
+        rw [hB_def, Finset.mem_insert] at hb
+        rcases hb with rfl | hb
+        · exact lt_of_le_of_lt hxle hPgtQ
+        · rw [Finset.mem_image] at hb
+          obtain ⟨a, ha, rfl⟩ := hb
+          exact lt_of_le_of_lt hxle (hRgtQ a ha)
+      have hdisj : Disjoint (subsetProducts A') B := by
+        rw [Finset.disjoint_left]
+        intro x hx hxB
+        exact absurd (hlt x hx x hxB) (lt_irrefl x)
+      have hunion : subsetProducts A' ∪ B ⊆ subsetProducts A :=
+        Finset.union_subset
+          (subsetProducts_mono (fun x hx => Finset.mem_of_mem_erase hx)) hBsub
+      have hcount : (subsetProducts A').card + (n + 1) ≤ (subsetProducts A).card := by
+        have h := Finset.card_le_card hunion
+        rwa [Finset.card_union_of_disjoint hdisj, hBcard] at h
+      nlinarith [IH, hcount]
+
+/-- **Multiplicative quadratic bound (doubled form).** For any set `A` of
+    distinct integers `> 1`, `|A|·(|A|+1) ≤ 2·|subsetProducts A|` — the
+    multiplicative side **alone** realises quadratically many values, with no
+    primality assumption. Mirror of `subsetSums_card_ge_quadratic`; the missing
+    `+2` is the excluded empty subset. -/
+theorem subsetProducts_card_ge_quadratic {A : Finset ℤ} (hgt : ∀ a ∈ A, 1 < a) :
+    A.card * (A.card + 1) ≤ 2 * (subsetProducts A).card :=
+  subsetProducts_card_quadratic A.card A rfl hgt
+
+/-- **Multiplicative quadratic bound (division form).**
+    `|A|·(|A|+1)/2 ≤ |subsetProducts A|` for distinct integers `> 1` — sharp for
+    the geometric progression `{2, 4, …, 2^n}`, whose subset products are exactly
+    `2^1, …, 2^{n(n+1)/2}`. -/
+theorem subsetProducts_card_ge_quadratic' {A : Finset ℤ} (hgt : ∀ a ∈ A, 1 < a) :
+    A.card * (A.card + 1) / 2 ≤ (subsetProducts A).card := by
+  have h := subsetProducts_card_ge_quadratic hgt
+  omega
+
 end Erdos53

--- a/research/problems/erdos-53-wip-01/knowledge.md
+++ b/research/problems/erdos-53-wip-01/knowledge.md
@@ -184,3 +184,34 @@ untouched (the chain needs positivity for the total-sum upper bound).
 ### Files modified
 - `proofs/Proofs/Erdos53WIP01.lean` (+182 lines, 8 theorems)
 - `src/data/research/problems/erdos-53-wip-01.json`
+
+## Session 2026-07-23 (researcher-1) — multiplicative Erdős chain (product-side quadratic)
+
+`subsetProducts_card_quadratic`: |subsetProducts A| ≥ n(n+1)/2 for ARBITRARY
+finite A ⊆ ℤ with all elements > 1. Mirror of the additive chain (same
+max-removal induction), transposed division-free:
+
+- Fresh values: {Π A} ∪ {Π(A.erase a) : a ∈ A.erase m} — never written P/a.
+- Recombination law `hRmul : Π(A.erase a) · a = Π A` (Finset.prod_erase_mul)
+  drives everything: injectivity via mul_left_cancel₀, strict separation
+  Q < Π(A.erase a) via Q·a < Q·m = Π(A.erase a)·a then lt_of_mul_lt_mul_right.
+- Subset-product ≤ full-product: prod_dvd_prod_of_subset + Int.le_of_dvd
+  (ℤ's multiplicative monoid is NOT ordered — Finset.prod_le_prod_of_subset_
+  of_one_le' does not apply to ℤ; divisibility+positivity is the correct route).
+- Hypothesis 1 < a essential (1 ∈ A ⟹ Π(A.erase 1) = Π A, injectivity dies);
+  0 excluded a fortiori. Additive chain needed only 0 < a.
+- No +1 in the bound: subsetProducts filters out the empty subset.
+- Sharp: {2,4,…,2^n} products = 2^s, s ∈ [1, n(n+1)/2] (remark, not formalised).
+
+Lean gotchas (new this session):
+- Set.InjOn intro gives SET-coe memberships; convert with Finset.mem_coe.mp
+  before feeding Finset lemmas (or `have ha' : a ∈ A' := ha` — defeq works).
+- InjOn's hab `(fun a => …) a = (fun a => …) b` is NOT beta-reduced for rw;
+  materialise `have hab' : Π(A.erase a) = Π(A.erase b) := hab` first.
+- rw-order trap: rewriting haeq (R = P) before hRmul (R·a = P) destroys the
+  R·a pattern — order [mul_one, hRmul, haeq] not [mul_one, haeq, hRmul].
+
+Elementary vein now fully SATURATED (both sides individually quadratic).
+Remaining: Chang |A|^k (deep); thin maybe-rung: negatives in the additive
+chain (subset sums collide across sign — likely needs |·| tricks, assess
+before attempting).

--- a/research/problems/erdos-53-wip-01/state.md
+++ b/research/problems/erdos-53-wip-01/state.md
@@ -22,3 +22,29 @@ None.
 
 ## Next Action
 Remaining deep crux: Chang (|A|^k for arbitrary large sets, k>=2) — needs Freiman/Plünnecke machinery, out of scope. Possible elementary rungs: extend the chain bound to sets allowing negative elements (positivity currently required for the total-sum upper bound), or product-side analogue |subsetProducts| for sets of integers > 1 via monotone chain on log.
+
+## Status (researcher-1, 2026-07-23) — product-side chain landed
+
+The "product-side analogue" rung from Next Action is DONE:
+`subsetProducts_card_quadratic` — |subsetProducts A| >= n(n+1)/2 for ARBITRARY
+sets of integers > 1 (no primality). Moves the subsetProducts frontier from
+"prime sets only" (2^n − 1) to all sets of elements >= 2. Same max-removal
+chain as the additive bound, transposed division-free: fresh values written as
+Π(A.erase a) (never P/a), comparisons via cancellation on Π(A.erase a)·a = ΠA
+(mul_left_cancel₀ / lt_of_mul_lt_mul_right), subset-product ≤ full-product via
+prod_dvd_prod_of_subset + Int.le_of_dvd (ℤ's multiplicative monoid is not
+ordered — sum monotonicity has no direct analogue). The >1 hypothesis is
+essential: 1 ∈ A collides Π(A.erase 1) with ΠA (mirror of 0 ∈ A additively).
+Sharp for {2, 4, ..., 2^n} (products = 2^[1..n(n+1)/2], remark only).
+Helpers: prod_mem_subsetProducts, prod_erase_mem_subsetProducts,
+mem_subsetProducts_le_prod. theoremCount 19->25, still 0 axioms.
+
+Both sides of Problem 53 are now individually quadratic on their natural
+domains; the remaining content is exactly Chang (sum-product tension), deep.
+
+## Next Action (updated)
+Chang |A|^k arbitrary sets (deep, Freiman/Plünnecke — out of elementary
+scope). Thin rung left: negative elements in the ADDITIVE chain (positivity
+only used for the total-sum upper bound; max-removal still works if 0 ∉ A?
+— needs care, subset sums can collide across sign). Elementary vein otherwise
+SATURATED.

--- a/src/data/research/problems/erdos-53-wip-01.json
+++ b/src/data/research/problems/erdos-53-wip-01.json
@@ -37,7 +37,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Unconditional frontier widened from prime sets to ALL positive sets. New quadratic additive bound |subsetSums A| >= n(n+1)/2+1 (Erdős max-removal chain, 0-axiom, host-verified), hence quadratic/superlinear growth of |sumsOrProducts A| with no primality. Prime family: 2^|A| bound, all-k eventual (done earlier). Remaining deep crux: Chang's |A|^k for arbitrary large sets (k>=2 over all sets untouched; n(n+1)/2+1 < n^2).",
+    "progressSummary": "PROGRESS: prime family all-k + parity separation + BOTH quadratic chains (additive |subsetSums| >= n(n+1)/2+1 all positive sets; multiplicative |subsetProducts| >= n(n+1)/2 all sets >1) done, 0 axioms; elementary vein saturated; remaining = Chang |A|^k arbitrary sets (deep)",
     "builtItems": [
       "zero_mem_subsetSums, mem_subsetSums_of_mem, mem_subsetProducts_of_mem in Erdos53Problem.lean",
       "subsetSums/Products_subset_sumsOrProducts, subsetSumCount/subsetProductCount_le_card in Erdos53Problem.lean",
@@ -53,7 +53,9 @@
       "sumsOrProducts_card_ge_odd_prime in Erdos53WIP01.lean: for a nonempty set of distinct odd positive primes, 2^|A| + |A| - 1 <= |sumsOrProducts A|, strictly stronger than the base 2^|A| bound; the even family {0} union {min A + q : q != min A} adds |A| fresh values disjoint from the odd products. Axiom-free.",
       "sum_mem_subsetSums / sum_sub_mem_subsetSums / mem_subsetSums_le_sum in Erdos53WIP01.lean (subset-sum membership + total-sum upper bound helpers)",
       "subsetSums_card_quadratic + subsetSums_card_ge_quadratic(') in Erdos53WIP01.lean: n(n+1)+2 <= 2|subsetSums A| (and /2+1 form) for all positive sets, 0-axiom",
-      "sumsOrProducts_card_ge_quadratic + sumsOrProducts_card_superlinear in Erdos53WIP01.lean: quadratic growth of the representable set over ALL positive sets; every linear rate C beaten past |A| >= 2C"
+      "sumsOrProducts_card_ge_quadratic + sumsOrProducts_card_superlinear in Erdos53WIP01.lean: quadratic growth of the representable set over ALL positive sets; every linear rate C beaten past |A| >= 2C",
+      "prod_mem_subsetProducts, prod_erase_mem_subsetProducts, mem_subsetProducts_le_prod in Erdos53WIP01.lean",
+      "subsetProducts_card_quadratic (induction core) + subsetProducts_card_ge_quadratic + division form in Erdos53WIP01.lean"
     ],
     "insights": [
       "Erdos53Problem.lean was a definitions-only stub (9 defs, 0 theorems). Chang 2003 (conjecture holds) and the Erdos-Szemeredi upper bound need deep additive combinatorics beyond Mathlib; tractable axiom-free content is elementary structural facts about subsetSums/subsetProducts/sumset/productset.",
@@ -61,7 +63,11 @@
       "k=1 slice of Problem 53 is elementary: A ⊆ subsetSums A ⊆ sumsOrProducts A gives |A| ≤ |sumsOrProducts A| (erdosProblem53_exponent_one, N₀=0). Distinct-prime richness |subsetProducts A|=2^|A|-1 requires 0<p (Prime over ℤ is closed under negation; positivity kills the p↔-p product collision). Proved axiom-free via Prime.dvd_finsetProd_iff + Prime.associated_of_dvd + Int.associated_iff_natAbs.",
       "Exponential-richness witness (researcher-1, 2026-07-20): the additive side contributes exactly one value the multiplicative side cannot — 0 (empty subset sum), which is never a product of positive primes. So for distinct positive primes |sumsOrProducts A| ≥ (2^|A|-1)+1 = 2^|A|, exhibiting sets where the Problem-53 count is exponential. This is the strongest witness on the EASY direction; it does NOT bear on Chang’s theorem, which is the uniform bound over ALL large sets (prime sets are never the obstruction).",
       "Parity separation: for a set of distinct ODD primes, every nonempty subset product is odd (product of odds), while 0 and every 2-element subset sum p+q of odds is even. So the multiplicative and additive sides are provably overlap-free on the even numbers -- a genuine structural fact about Problem 53 two operations.",
-      "Erdős max-removal chain gives the first non-prime-specific bound: for ANY set of n distinct POSITIVE integers, |subsetSums A| >= n(n+1)/2 + 1 (sharp for {1..n}). Mechanism: every subset sum of A' = A.erase(max) is <= T - m (T = total, m = max), while the n values {T} u {T - a : a in A', a != m} are distinct subset sums strictly above T - m, so the count grows by n per step. Independent of parity/primality separations; still short of Chang (n(n+1)/2+1 < n^2 for n>=3, so k=2 over all sets remains open)."
+      "Erdős max-removal chain gives the first non-prime-specific bound: for ANY set of n distinct POSITIVE integers, |subsetSums A| >= n(n+1)/2 + 1 (sharp for {1..n}). Mechanism: every subset sum of A' = A.erase(max) is <= T - m (T = total, m = max), while the n values {T} u {T - a : a in A', a != m} are distinct subset sums strictly above T - m, so the count grows by n per step. Independent of parity/primality separations; still short of Chang (n(n+1)/2+1 < n^2 for n>=3, so k=2 over all sets remains open).",
+      "Multiplicative mirror of the Erdős chain: |subsetProducts A| >= n(n+1)/2 for arbitrary sets of integers > 1 — frontier moved from prime-only (2^n-1) to all sets of elements >= 2",
+      "Transposition is not mechanical: ZZ multiplicative monoid is unordered, so subset-product <= full-product goes via prod_dvd_prod_of_subset + Int.le_of_dvd; fresh values written Pi(A.erase a) (never P/a); all comparisons via cancellation on Pi(A.erase a)*a = Pi A",
+      "Elements->1 hypothesis essential multiplicatively where >0 sufficed additively: 1 in A collides Pi(A.erase 1) with Pi A, exact mirror of the 0-element degeneracy",
+      "Bound sharp for geometric {2,4,...,2^n} (products realize exactly 2^[1..n(n+1)/2]); both Problem-53 sides now individually quadratic — remaining content is exactly the sum-product tension (Chang, deep)"
     ],
     "mathlibGaps": [],
     "nextSteps": [],


### PR DESCRIPTION
## Summary
Research session for erdos-53-wip-01 (Erdős Problem #53, sums and products of distinct elements). Lands the multiplicative mirror of the additive Erdős chain merged in #41717.

## Progress
- `subsetProducts_card_quadratic` — for ANY finite set A of integers > 1, `|subsetProducts A| >= |A|(|A|+1)/2` (division-free doubled form + division form). Moves the unconditional subsetProducts frontier from "prime sets only" (2^|A| − 1 via unique factorisation) to arbitrary sets of elements >= 2.
- Helpers: `prod_mem_subsetProducts`, `prod_erase_mem_subsetProducts`, `mem_subsetProducts_le_prod`.
- File: `proofs/Proofs/Erdos53WIP01.lean` (19 → 25 theorems, 0 axioms, 0 sorries); knowledge/state/tracker updated.

## Findings
- The transposition is not mechanical: ℤ's multiplicative monoid is unordered, so "subset product ≤ full product" goes through divisibility + positivity (`prod_dvd_prod_of_subset` + `Int.le_of_dvd`); fresh values are written `Π(A.erase a)` — never `P/a` — and all comparisons run through cancellation on `Π(A.erase a)·a = ΠA`.
- The elements-`> 1` hypothesis is essential exactly where the additive chain needed only `> 0`: with `1 ∈ A` the fresh value `Π(A.erase 1)` collides with `ΠA`.
- Bound is sharp for geometric progressions {2, 4, ..., 2^n} (remark, not formalised).
- Both sides of Problem 53 are now individually quadratic on their natural domains — the remaining content is exactly the sum-product tension (Chang 2003, deep, stays documented not axiomatized).

## Status
**Outcome**: progress (elementary vein now saturated on both sides)
**Next Steps**: Chang |A|^k for arbitrary sets is the deep crux (Freiman/Plünnecke, out of elementary scope). Thin possible rung: negative elements in the additive chain (assess collision behaviour first).

🤖 Generated by researcher-1
