### PR TITLE
Enrich quadratic-reciprocity-oq-04: add references (0->3)

### DIFF
--- a/src/data/proofs/quadratic-reciprocity-oq-04/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-04/meta.json
@@ -142,6 +142,26 @@
     "path": "Proofs/QuadraticReciprocityOQ04.lean",
     "sorries": 0
   },
+  "references": [
+    {
+      "title": "A Fast Monte-Carlo Test for Primality",
+      "author": "R. Solovay and V. Strassen",
+      "year": 1977,
+      "note": "SIAM J. Comput. 6(1), 84–85. Defines the primality test built on the J(a|n)=1 direction failing to certify squares; the a for which the test is fooled on composite n are the 'Euler liars' this entry's counterexample instantiates."
+    },
+    {
+      "title": "A Classical Introduction to Modern Number Theory, Chapter 5",
+      "author": "K. Ireland and M. Rosen",
+      "year": 1990,
+      "note": "Standard graduate reference developing the Jacobi symbol's multiplicativity and reciprocity, and the failure of residue-detection for composite moduli that this entry makes explicit."
+    },
+    {
+      "title": "Mathlib4: NumberTheory.LegendreSymbol.JacobiSymbol",
+      "author": "The Mathlib Community",
+      "year": 2024,
+      "note": "Provides `jacobiSym`, `jacobiSym.mul_right`, and `ZMod.nonsquare_of_jacobiSym_eq_neg_one`, and the reciprocity-based norm_num extension used to evaluate J(2 | 15)."
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "quadratic-reciprocity",


### PR DESCRIPTION
Enrichment pass for quadratic-reciprocity-oq-04.

The entry (Jacobi symbol residue-detection failure / Euler liars) had an empty `references` field despite the parent `quadratic-reciprocity` and sibling `quadratic-reciprocity-oq-03` entries both carrying literature citations. Adds 3 references directly tied to the content:

- Solovay & Strassen, *A Fast Monte-Carlo Test for Primality* (1977) — the primality test whose "Euler liars" this entry's J(2|15)=1 counterexample instantiates
- Ireland & Rosen, *A Classical Introduction to Modern Number Theory*, Ch. 5 (1990) — standard reference for Jacobi symbol multiplicativity/reciprocity
- Mathlib4: NumberTheory.LegendreSymbol.JacobiSymbol — the module supplying `jacobiSym`, `jacobiSym.mul_right`, `ZMod.nonsquare_of_jacobiSym_eq_neg_one`

Sections (5, contiguous full-file coverage of the 86-line file), keyInsights (4), annotations (5, all with mathContext/significance), and openQuestions (3) were already at target from a prior pass (#42609) — no filler added there.

Verified: JSON structure valid, `pnpm build` gallery-data step passes (build noise from unrelated regenerated files discarded before commit).