### PR TITLE
Enrich nicomachus-sum-of-cubes-oq-02: fix uncovered header/setup sections

### DIFF
--- a/src/data/proofs/nicomachus-sum-of-cubes-oq-02/meta.json
+++ b/src/data/proofs/nicomachus-sum-of-cubes-oq-02/meta.json
@@ -43,23 +43,37 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Header docstring",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Imports (`Mathlib.Algebra.BigOperators.Intervals`, `Mathlib.Tactic`) and the module docstring: states the open question (the p=4 Faulhaber closed form), the clear-denominator-and-subtraction strategy, and the novelty claim that Mathlib has the Gauss and cube-sum identities but not this one. 0 sorries, 0 axioms."
+    },
+    {
+      "id": "setup",
+      "title": "Namespace and open",
+      "startLine": 47,
+      "endLine": 49,
+      "summary": "Opens `namespace NicomachusFourthPowers` and `open Finset`, so `range` and `∑` below refer to `Finset.range` and `Finset.sum` unqualified."
+    },
+    {
       "id": "subtraction-free",
       "title": "Subtraction-free, division-free core",
-      "startLine": 59,
+      "startLine": 51,
       "endLine": 69,
       "summary": "The core lemma 30·(∑_{k≤n} k⁴) + n = 6n⁵ + 15n⁴ + 10n³, proved by induction. The base case is `simp`. The step peels the top fourth power with sum_range_succ, then a single subtraction-free `ring` identity 6m⁵ + 15m⁴ + 10m³ + 30(m+1)⁴ + 1 = 6(m+1)⁵ + 15(m+1)⁴ + 10(m+1)³ is combined with the inductive hypothesis by `omega` (which atomizes the power terms). No truncated ℕ subtraction and no division ever appears."
     },
     {
       "id": "factored-int",
       "title": "Factored form over ℤ",
-      "startLine": 77,
+      "startLine": 71,
       "endLine": 87,
       "summary": "30·(∑_{k≤n} k⁴) = n(n+1)(2n+1)(3n²+3n−1). Casting the ℕ identity to ℤ with push_cast lets the factor 3n²+3n−1 use honest subtraction; `linarith` isolates 30·∑ = 6n⁵+15n⁴+10n³ − n and a final `ring` recognizes that the product equals 6n⁵+15n⁴+10n³ − n."
     },
     {
       "id": "headline-rat",
       "title": "Headline closed form over ℚ",
-      "startLine": 93,
+      "startLine": 89,
       "endLine": 103,
       "summary": "∑_{k≤n} k⁴ = n(n+1)(2n+1)(3n²+3n−1)/30, the classical divided form. The same ℕ core is cast to ℚ, `linarith` isolates the sum as (6n⁵+15n⁴+10n³ − n)/30, and `ring` clears the product against the /30."
     },


### PR DESCRIPTION
Enrichment pass for `nicomachus-sum-of-cubes-oq-02` (Faulhaber's fourth-power sum).

The `sections[]` array skipped lines 1-58 of the Lean file (the header docstring,
the `namespace`/`open` block, and each theorem's own doc-comment), starting
instead at the `theorem` keyword of the first result. Sibling entries in the
same family (`nicomachus-sum-of-cubes-oq-01`, `nicomachus-sum-of-cubes-oq-03`)
follow the convention of a `header` section for the module docstring, a `setup`
section for the namespace/open lines, and section boundaries anchored at each
theorem's doc-comment rather than its `theorem` keyword.

Changes:
- Added `header` section (lines 1-45): imports + module docstring
- Added `setup` section (lines 47-49): `namespace`/`open Finset`
- Re-anchored `subtraction-free`, `factored-int`, `headline-rat` section
  `startLine`s to include each theorem's preceding doc-comment (51/71/89
  instead of 59/77/93), matching sibling convention

No content was removed; `annotations.json` was already complete (6 annotations,
all with `mathContext`/`significance`/`relatedConcepts`) and untouched. File
size 12.7 KB, well under the 60 KB cap.

Note: full `pnpm build` (vite/tsc stage) could not be run in this worktree due
to the known host-wide `better-sqlite3`/node v26 native-module build failure;
validated instead via `python3 -m json.load` and the gallery data-generation
stages of `pnpm build` (enrichment linking, search-index check, loading-facts,
redirects), all of which parsed and used this file without error.