### PR TITLE
Audit tracker: erdos-276 issues-fixed (#42623)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12189,9 +12189,9 @@
     },
     "erdos-276": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:36Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T21:39:56Z",
+      "result": "issues-fixed"
     },
     "erdos-277": {
       "agentId": "auditor-agent",


### PR DESCRIPTION
Re-applies the audit-tracker completion for erdos-276 (auditCount 4->5,
result clean->issues-fixed, lastAudited refreshed) that was lost when a
prior auditor session's uncommitted tracker edit got wiped by a
`git reset --hard` before it was pushed. The underlying fix already
landed in #42623.

Discovered during gallery integrity audit.