### PR TITLE
Gallery integrity: erdos-555 stale sorry claim + phantom axiom labeling

### DIFF
--- a/src/data/proofs/erdos-555/meta.json
+++ b/src/data/proofs/erdos-555/meta.json
@@ -56,7 +56,7 @@
       "title": "Even Cycles and Colorings",
       "startLine": 24,
       "endLine": 35,
-      "summary": "Defines HasCycleOfLength (injective vertex sequence forming a cycle), EdgeColoring (k-coloring of K_m), and monochromaticGraph (subgraph of edges with color c, 1 sorry for symmetry)."
+      "summary": "Defines HasCycleOfLength (injective vertex sequence forming a cycle), EdgeColoring (k-coloring of K_m), and monochromaticGraph (subgraph of edges with color c); the symm/loopless obligations are fully discharged, no sorries."
     },
     {
       "id": "section-36",
@@ -70,14 +70,14 @@
       "title": "Ramsey Number Definition",
       "startLine": 48,
       "endLine": 57,
-      "summary": "Defines ramseyEvenCycle n k = R(C_{2n}; k) via Nat.find with a trivial existence witness."
+      "summary": "Defines ramseyEvenCycle n k = R(C_{2n}; k) as sInf of the set of thresholds forcing a monochromatic even cycle."
     },
     {
       "id": "erdos-bounds",
       "title": "Erdos General Bounds",
       "startLine": 58,
       "endLine": 71,
-      "summary": "Axioms: lower bound R(C_{2n}; k) ≥ c·k^{1+1/(2n)} and upper bound R(C_{2n}; k) ≤ C·k^{1+1/(n-1)} for n ≥ 2."
+      "summary": "Not formalized: comments only (no axiom declarations) noting the target lower bound R(C_{2n}; k) ≥ c·k^{1+1/(2n)} and upper bound R(C_{2n}; k) ≤ C·k^{1+1/(n-1)} for n ≥ 2."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-555
**Problem**: `sections[]` prose didn't match the current Lean source.

## Evidence

**meta.json claims** (before):
- "cycle-coloring": "...monochromaticGraph (subgraph of edges with color c, 1 sorry for symmetry)"
- "ramsey-def": "Defines ramseyEvenCycle n k = R(C_{2n}; k) via Nat.find with a trivial existence witness."
- "erdos-bounds": "Axioms: lower bound R(C_{2n}; k) ≥ c·k^{1+1/(2n)} and upper bound R(C_{2n}; k) ≤ C·k^{1+1/(n-1)} for n ≥ 2."

**Lean file shows** (`proofs/Proofs/Erdos555Problem.lean`): `symm`/`loopless` are fully discharged (no `sorry` anywhere, matching `sorries: 0`); `ramseyEvenCycle` is defined via `sInf`, not `Nat.find`; the Erdős/Chung-Graham bounds are plain `/- ... -/` comments, not `axiom` declarations (`axiomCount: 0`, consistent with the file's own `assumptions: "0 axioms..."` and honest `proofStrategy`/`conclusion` text elsewhere in the same meta.json).

## Fix

Reworded the three section summaries to match the actual source: no sorries, `sInf`-based definition, and comment-only (not axiomatized) bound targets.

---
Discovered during gallery integrity audit.