### PR TITLE
Enrich spectral-trace-det-eigenvalues-oq-02: cross-reference matrix-similarity-invariants-oq-01

### DIFF
--- a/src/data/proofs/matrix-similarity-invariants-oq-01/meta.json
+++ b/src/data/proofs/matrix-similarity-invariants-oq-01/meta.json
@@ -197,6 +197,11 @@
       "targetId": "matrix-similarity-invariants-oq-01-oq-02",
       "relationship": "extends",
       "description": "Follow-up entry that develops this one: “The Minimal Polynomial Is a Similarity Invariant”. Extends the classical similarity invariants (determinant, trace, characteristic polynomial) with the minimal polynomial: similar matrices B = P·A·P⁻¹ have equal minimal polynomials over any commutative ring."
+    },
+    {
+      "targetId": "spectral-trace-det-eigenvalues-oq-02",
+      "relationship": "related",
+      "description": "Reaches the eigenvalue-multiset invariance of Similar.charpoly_roots_eq by a different route: cyclic invariance of the trace (tr(AB) = tr(BA)) is used to prove similarity invariance of the trace in the determinant-hypothesis form tr(P⁻¹AP) = tr(A) under IsUnit P.det (rather than P a bundled unit), and to derive the vanishing trace of a commutator, before bridging to the same charpoly-conjugation fact used here."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-02/meta.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-02/meta.json
@@ -117,6 +117,11 @@
       "targetId": "spectral-trace-det-eigenvalues-oq-01",
       "relationship": "related",
       "description": "Companion entry establishing trace = Σλ and det = Πλ as the sum and product of the eigenvalues. This entry supplies the cyclic-invariance side: it shows conjugation preserves the entire eigenvalue multiset, so the oq-01 identities make trace and determinant similarity invariants."
+    },
+    {
+      "targetId": "matrix-similarity-invariants-oq-01",
+      "relationship": "related",
+      "description": "Packages determinant, trace, characteristic polynomial, and (over an integral domain) the eigenvalue multiset into one unified similarity-invariants theorem, with similarity proved to be an equivalence relation. This entry reaches the same eigenvalue-multiset invariance (eigenvalues_units_conj) via a different route — as the bridge from cyclic-invariance-of-the-trace to the spectral picture of oq-01 — and adds the determinant-hypothesis (IsUnit P.det) form of similarity invariance that matrix-similarity-invariants-oq-01 does not state."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

`spectral-trace-det-eigenvalues-oq-02` was already at the enrichment quality target — 5 annotations with full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`, complete `historicalContext`, 4 substantive `keyInsights`, a full `conclusion` with `implications` and 2 `openQuestions`, and `sections` covering the whole Lean file. Per the size-guardrail/SKIP rule, no filler was added there.

The one genuine gap: `matrix-similarity-invariants-oq-01` independently proves the same eigenvalue-multiset invariance under conjugation (via `Matrix.charpoly_units_conj`) but the two entries weren't cross-linked, even though they cover closely overlapping territory (determinant/trace/characteristic-polynomial similarity invariants) from different angles — one via a unified `Similar` relation, the other via cyclic-invariance-of-the-trace as a bridge to the eigenvalue picture of its own companion entry (oq-01).

- Added a `crossReferences` entry from `spectral-trace-det-eigenvalues-oq-02` to `matrix-similarity-invariants-oq-01`
- Added the reciprocal `crossReferences` entry from `matrix-similarity-invariants-oq-01` back to `spectral-trace-det-eigenvalues-oq-02`

Both descriptions are accurate to what each file actually proves — verified against the Lean source (`SpectralTraceDetEigenvaluesOQ02.lean`, `MatrixSimilarityInvariantsOQ01.lean`) before writing.

## Test plan

- [x] `python3 -c "import json; json.load(...)"` — both meta.json files parse
- [x] `pnpm gallery:check-size` — all 4811 entries within the 60 KB cap (both files ~15-16 KB, well under)
- [x] Manually verified theorem/definition counts and content claims against the Lean source for both entries