### PR TITLE
Gallery integrity: erdos-54 phantom axiom names in originalContributions

### DIFF
--- a/src/data/proofs/erdos-54/meta.json
+++ b/src/data/proofs/erdos-54/meta.json
@@ -51,10 +51,9 @@
       "Colouring2 and monoSubsetSums definitions",
       "IsRamsey2Complete formalization",
       "countingFn via Finset.Icc filtering",
-      "burr_erdos_lower axiom (c(log N)² lower bound)",
-      "conlon_fox_pham axiom (O((log N)²) upper bound)",
-      "ErdosProblem54 conjunction capturing Θ((log N)²)",
-      "burr_erdos_upper axiom ((2 log₂ N)³ historical bound)"
+      "ErdosProblem54 Prop conjunction capturing Θ((log N)²)",
+      "Four axiom-free foundational lemmas: zero_mem_monoSubsetSums, mem_monoSubsetSums_of_mem, countingFn_le, countingFn_mono",
+      "Burr–Erdős lower bound, Burr–Erdős historical (2 log₂ N)³ upper bound, and Conlon–Fox–Pham optimal upper bound are documented in header prose only — not formalized as axioms or theorems"
     ],
     "axiomCount": 0,
     "lineCount": 119,


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-54
**Problem**: `meta.originalContributions` named three phantom axioms that don't exist in the Lean source.

## Evidence

**meta.json claims** (before): `originalContributions` included "burr_erdos_lower axiom (c(log N)² lower bound)", "conlon_fox_pham axiom (O((log N)²) upper bound)", "burr_erdos_upper axiom ((2 log₂ N)³ historical bound)".

**Lean file shows** (`proofs/Proofs/Erdos54Problem.lean`): `grep -n 'burr_erdos_lower\|conlon_fox_pham\|burr_erdos_upper\|axiom'` finds none of these identifiers and no `axiom` keyword at all — `axiomCount: 0` is correct. The Burr–Erdős/Conlon–Fox–Pham bounds are plain header-comment prose. The file's own `overview.proofStrategy`, `sections[]`, and `conclusion` already correctly describe these as "documented in the header prose only... NOT formalized" — only `originalContributions` had drifted into phantom-axiom framing.

## Fix

Reworded `originalContributions` to match the rest of the file: lists the real definitions/theorems, and notes the three bounds are prose-only, not formalized as axioms or theorems.

---
Discovered during gallery integrity audit.