### PR TITLE
Enrich stirling-first-kind-oq-01: add missing cross-references to answering follow-ups

### DIFF
--- a/src/data/proofs/stirling-first-kind-oq-01/meta.json
+++ b/src/data/proofs/stirling-first-kind-oq-01/meta.json
@@ -128,6 +128,16 @@
       "targetId": "stirling-second-kind-oq-01",
       "relationship": "related",
       "description": "Companion entry for the other Stirling triangle: the second-kind two-block column S(n,2) = 2^(n-1) − 1. Same author and recurrence style, distinct combinatorial object (set partitions vs. cycle structure of permutations)."
+    },
+    {
+      "targetId": "stirling-first-kind-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Direct follow-up answering this entry's second open question: the generating identity ∑ₖ c(n,k) xᵏ = ascPochhammer x n (the rising factorial), which reproves the row sum ∑ₖ c(n,k) = n! here as its x = 1 specialization."
+    },
+    {
+      "targetId": "stirling-first-kind-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Direct follow-up answering this entry's first open question: the signed alternating row identity, together with the falling-factorial generating identity for the signed numbers s(n,k) = (−1)^{n−k} c(n,k)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

`stirling-first-kind-oq-01` was already at the enrichment quality target — 5 annotations with full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`, complete `historicalContext`, 4 substantive `keyInsights`, a full `conclusion` with `implications` and 2 `openQuestions`, and `sections` covering the whole Lean file. Per the size-guardrail/SKIP rule, no filler was added there.

The genuine gap: this entry's two `conclusion.openQuestions` are already answered by direct follow-up entries in the gallery —
- `stirling-first-kind-oq-01-oq-01` (generating identity `∑ₖ c(n,k) xᵏ = ascPochhammer x n`, answering the second open question)
- `stirling-first-kind-oq-01-oq-02` (signed alternating row identity, answering the first open question)

Both follow-ups already `crossReference` back to this parent (`relationship: "extends"`), but the parent had only one `crossReferences` entry (to the sibling `stirling-second-kind-oq-01`) and didn't link forward to either child — the sibling `stirling-second-kind-oq-01` entry already follows the correct bidirectional pattern for its own answering follow-ups, so this brings `stirling-first-kind-oq-01` in line with that established convention.

## Test plan

- [x] `python3 -c "import json; json.load(...)"` — meta.json parses
- [x] `pnpm gallery:check-size` — all 4811 entries within the 60 KB cap (file is ~11 KB, well under)
- [x] Verified both target entries' descriptions/openQuestions match against their meta.json before writing the cross-reference text