### PR TITLE
Enrich sum-of-divisors-oq-04: add missing cross-reference to answering follow-up

### DIFF
--- a/src/data/proofs/sum-of-divisors-oq-04/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-04/meta.json
@@ -167,6 +167,11 @@
       "description": "Generalizes the base entry's specific-prime checks (σ(p) = p+1 for six primes) and numerical perfect/abundant/amicable classifications to the universally quantified structural laws of σ"
     },
     {
+      "targetId": "sum-of-divisors-oq-04-oq-01",
+      "relationship": "related",
+      "description": "Direct follow-up that turns this entry's closed geometric identity σ(pⁱ)·(p−1) = pⁱ⁺¹−1 into the qualitative deficiency/abundancy classification of every prime power: σ(pᵏ) < 2·pᵏ always, with powers of two almost-perfect (σ(2ᵏ) = 2ᵏ⁺¹−1)."
+    },
+    {
       "targetId": "abundant-number-oq-03",
       "relationship": "related",
       "description": "The σ-form of perfection (σ(n) = 2n) sits beside the abundance condition (σ(n) > 2n) in the same divisor-sum classification of integers"


### PR DESCRIPTION
## Summary

`sum-of-divisors-oq-04` was already at the enrichment quality target — 6 annotations with full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`, a `mainTheorems` block, 5 substantive `keyInsights`, a full `conclusion`, `sections` covering the whole Lean file, and 4 `crossReferences` (to `sum-of-divisors`, `abundant-number-oq-03`, `perfect-numbers`, `euler-totient`). Per the size-guardrail/SKIP rule, no filler was added there.

The genuine gap: `sum-of-divisors-oq-04-oq-01` is a direct follow-up that already cross-references back to this entry (`relationship: "extends"` — it turns this entry's closed geometric identity σ(pⁱ)·(p−1) = pⁱ⁺¹−1 into the qualitative deficiency/abundancy classification of every prime power), but the link was one-directional: this entry had no `crossReferences` entry pointing forward to its own child. Added the reciprocal link.

## Test plan

- [x] `python3 -c "import json; json.load(...)"` — meta.json parses
- [x] `pnpm gallery:check-size` — all 4811 entries within the 60 KB cap (file is ~15 KB, well under)
- [x] Verified `sum-of-divisors-oq-04-oq-01`'s actual content/description before writing the cross-reference text