### PR TITLE
Enrich shannon-source-coding-wip-01-oq-01: add missing cross-reference to sibling oq-02

### DIFF
--- a/src/data/proofs/shannon-source-coding-wip-01-oq-01/meta.json
+++ b/src/data/proofs/shannon-source-coding-wip-01-oq-01/meta.json
@@ -138,6 +138,11 @@
       "targetId": "shannon-entropy",
       "relationship": "complements",
       "description": "ShannonEntropy proves subadditivity H(X,Y) ≤ H(X)+H(Y); this file gives the exact additivity for n independent copies of a single source"
+    },
+    {
+      "targetId": "shannon-source-coding-wip-01-oq-02",
+      "relationship": "complements",
+      "description": "Sibling entry proves the converse to the parent's additivity — H(pX ⊗ pY) = H(pX) + H(pY) holds only when p is a product distribution. This file iterates the parent's forward direction to the n-fold i.i.d. product; that one characterises exactly when additivity holds at all."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
## Summary

`shannon-source-coding-wip-01-oq-01` was already at the enrichment quality target — 5 annotations with full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`, a `mainTheorems` block, 4 substantive `keyInsights`, a full `conclusion`, `sections` covering the whole Lean file, 3 `crossReferences`, and 4 `references`. Per the size-guardrail/SKIP rule, no filler was added there.

The genuine gap: `shannon-source-coding-wip-01-oq-02` (the converse to the shared parent's additivity result — additivity holds only for product distributions) already cross-references this entry as a `complements` sibling, but the link was one-directional: this entry had no `crossReferences` entry pointing to `oq-02`. Added the reciprocal link.

## Test plan

- [x] `python3 -c "import json; json.load(...)"` — meta.json parses
- [x] `pnpm gallery:check-size` — all 4811 entries within the 60 KB cap (file is ~13 KB, well under)
- [x] Verified `shannon-source-coding-wip-01-oq-02`'s actual content/description before writing the cross-reference text