### PR TITLE
Enrich three-subgroups-lemma-oq-01: add missing header section (uncovered lines 1-56)

### DIFF
--- a/src/data/proofs/three-subgroups-lemma-oq-01/meta.json
+++ b/src/data/proofs/three-subgroups-lemma-oq-01/meta.json
@@ -66,6 +66,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header and the Normal-Subgroup Statement",
+      "startLine": 1,
+      "endLine": 56,
+      "mathContext": "$\\lbrack\\lbrack H,K\\rbrack,L\\rbrack \\le N \\wedge \\lbrack\\lbrack K,L\\rbrack,H\\rbrack \\le N \\Rightarrow \\lbrack\\lbrack L,H\\rbrack,K\\rbrack \\le N$ for $N \\trianglelefteq G$, recovering Mathlib's $=\\bot$ case as $N=\\bot$.",
+      "summary": "Imports (Commutator.Basic, QuotientGroup.Defs, Tactic) and the module docstring: states the classical ≤ N three subgroups lemma, contrasts it with Mathlib's = ⊥ special case (Subgroup.commutator_commutator_eq_bot_of_rotate, from the Hall–Witt identity), and previews the quotient-transport proof (X ≤ N ⟺ X.map (mk' N) = ⊥, map distributing over the bracket via Subgroup.map_commutator). Opens the ThreeSubgroupsLemmaOQ01 namespace, opens Subgroup, and fixes the ambient group G."
+    },
+    {
       "id": "normal-form",
       "title": "The Normal-Subgroup Three Subgroups Lemma",
       "startLine": 57,


### PR DESCRIPTION
## Summary

`three-subgroups-lemma-oq-01` was already well developed — 5 annotations with full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`, 4 substantive `keyInsights`, a full `conclusion` with 3 `openQuestions`, 4 `references`, and a `crossReferences` entry to its child. Per the size-guardrail/SKIP rule, no filler was added to those fields.

The genuine gap: `meta.sections` started at line 57, leaving the module docstring, imports, and namespace/variable setup (lines 1-56) — which explain the whole relative-form vs. Mathlib's `= ⊥` case contrast and the quotient-transport proof strategy — completely uncovered by `sections`. This content is already present in `annotations.json` (`ann-tsl01-overview` covers lines 5-41), so this was a `sections`-array gap, not a missing-content gap. Added a `header` section spanning lines 1-56.

## Test plan

- [x] `python3 -c "import json; json.load(...)"` — meta.json parses
- [x] `pnpm gallery:check-size` — all 4811 entries within the 60 KB cap (file is ~16 KB, well under)
- [x] Verified lines 1-56 of `Proofs/ThreeSubgroupsLemmaOQ01.lean` against the new section summary