### PR TITLE
Fix erdos-542: remove phantom Lean identifiers from annotations/meta

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14463,9 +14463,9 @@
     },
     "erdos-542": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:37Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T21:50:30Z",
+      "result": "issues-fixed"
     },
     "erdos-543": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-542/annotations.json
+++ b/src/data/proofs/erdos-542/annotations.json
@@ -27,7 +27,7 @@
     "proofId": "erdos-542",
     "type": "definition",
     "range": {
-      "startLine": 27,
+      "startLine": 25,
       "endLine": 33
     },
     "title": "Pairwise LCM Condition and Reciprocal Sum",
@@ -53,11 +53,11 @@
     "proofId": "erdos-542",
     "type": "definition",
     "range": {
-      "startLine": 39,
-      "endLine": 49
+      "startLine": 37,
+      "endLine": 45
     },
     "title": "Schinzel-Szekeres Theorem and Optimal Example",
-    "content": "`ErdosProblem542`: $\\forall n, A,\\, \\text{PairwiseLCMExceeds}(A,n) \\implies \\sum 1/a \\le 31/30$. `bound_achieved_by_235`: $\\sum 1/a = 31/30$ for $A = \\{2,3,5\\}$. `example_235_valid`: $\\{2,3,5\\}$ satisfies the LCM condition for $n = 5$ (since $\\text{lcm}(2,3) = 6, \\text{lcm}(2,5) = 10, \\text{lcm}(3,5) = 15$, all $> 5$).",
+    "content": "`ErdosProblem542`: $\\forall n, A,\\, \\text{PairwiseLCMExceeds}(A,n) \\implies \\sum 1/a \\le 31/30$. Two facts are documented only as source comments, with no corresponding Lean declaration: that $\\sum 1/a = 31/30$ for $A = \\{2,3,5\\}$, and that $\\{2,3,5\\}$ satisfies the LCM condition for $n = 5$ (since $\\text{lcm}(2,3) = 6, \\text{lcm}(2,5) = 10, \\text{lcm}(3,5) = 15$, all $> 5$).",
     "significance": "key",
     "mathContext": "**Andrzej Schinzel** and **George Szekeres** proved the bound $31/30$ in their 1959 paper 'Sur un probleme de M. Paul Erdos.' The proof analyzes the prime factorization structure of elements in $A$: if $a, b \\in A$ share a prime factor $p$, then $p | \\gcd(a,b)$, so $\\text{lcm}(a,b) = ab/\\gcd(a,b) \\le ab/p \\le n^2/p$. For this to exceed $n$, we need $ab > np$. The constraint forces elements to have 'spread out' prime factors. The extremal set $\\{2,3,5\\}$ consists of the three smallest primes, and $1/2 + 1/3 + 1/5 = 15/30 + 10/30 + 6/30 = 31/30$ is exactly the bound.",
     "relatedConcepts": [
@@ -77,8 +77,8 @@
     "proofId": "erdos-542",
     "type": "definition",
     "range": {
-      "startLine": 54,
-      "endLine": 62
+      "startLine": 49,
+      "endLine": 61
     },
     "title": "Chen's Stronger Bound (1996)",
     "content": "`ChenBound`: for $n > 172509$, $\\sum 1/a < 1/3 + 1/4 + 1/5 + 1/7 + 1/11 = 4699/4620 \\approx 1.017$. `chen_bound_value` proves $1/3 + 1/4 + 1/5 + 1/7 + 1/11 = 4699/4620$ by `norm_num`.",
@@ -101,11 +101,11 @@
     "proofId": "erdos-542",
     "type": "definition",
     "range": {
-      "startLine": 68,
-      "endLine": 79
+      "startLine": 65,
+      "endLine": 74
     },
     "title": "Maximal Sets Conjecture",
-    "content": "`MaximalSetsConjecture`: if $\\text{PairwiseLCMExceeds}(A,n)$ and $\\sum 1/a > 1$, then $A = \\{2,3,5\\}$ or $A = \\{3,4,5,7,11\\}$. `example_34_5_7_11_sum` and `example_34_5_7_11_valid` establish that $\\{3,4,5,7,11\\}$ is a valid example with sum $> 1$ for $n = 11$.",
+    "content": "`MaximalSetsConjecture`: if $\\text{PairwiseLCMExceeds}(A,n)$ and $\\sum 1/a > 1$, then $A = \\{2,3,5\\}$ or $A = \\{3,4,5,7,11\\}$. That $\\{3,4,5,7,11\\}$ is a valid example with sum $> 1$ for $n = 11$ is documented only as source comments — no corresponding Lean declarations exist.",
     "significance": "key",
     "mathContext": "The Erdos-Schinzel-Szekeres conjecture asserts a remarkably precise classification: among all sets satisfying the pairwise LCM condition, exactly two achieve reciprocal sum exceeding $1$. The set $\\{3,4,5,7,11\\}$ works because all pairwise LCMs exceed $11$: $\\text{lcm}(3,4)=12$, $\\text{lcm}(3,5)=15$, $\\text{lcm}(3,7)=21$, $\\text{lcm}(3,11)=33$, $\\text{lcm}(4,5)=20$, $\\text{lcm}(4,7)=28$, $\\text{lcm}(4,11)=44$, $\\text{lcm}(5,7)=35$, $\\text{lcm}(5,11)=55$, $\\text{lcm}(7,11)=77$. Its reciprocal sum is $1/3 + 1/4 + 1/5 + 1/7 + 1/11 \\approx 1.043$. This conjecture remains open.",
     "relatedConcepts": [
@@ -125,11 +125,11 @@
     "proofId": "erdos-542",
     "type": "concept",
     "range": {
-      "startLine": 84,
-      "endLine": 87
+      "startLine": 78,
+      "endLine": 78
     },
     "title": "No-Divisibility Property",
-    "content": "`lcm_condition_no_divisibility`: if $a \\mid b$ and $a \\ne b$ and both are in $A$ satisfying the LCM condition, then $b > n$ (contradicting $b \\le n$). Axiomatized since $\\text{lcm}(a,b) = b$ when $a \\mid b$.",
+    "content": "A source comment (no Lean declaration) notes: if $a \\mid b$ and $a \\ne b$ and both are in $A$ satisfying the LCM condition, then $b > n$ (contradicting $b \\le n$), since $\\text{lcm}(a,b) = b$ when $a \\mid b$. This is documented only as prose, not proved.",
     "significance": "supporting",
     "mathContext": "When $a \\mid b$, $\\text{lcm}(a,b) = b$. The LCM condition requires $\\text{lcm}(a,b) > n$, so $b > n$. But $b \\in A \\subseteq \\{1,\\ldots,n\\}$ gives $b \\le n$, a contradiction. This shows the LCM condition implies $A$ is an **antichain** under divisibility — no element divides another. Antichains under divisibility are closely related to **Dilworth's theorem** and the theory of **primitive sets** studied by Erdos, Behrend, and others.",
     "relatedConcepts": [
@@ -149,8 +149,8 @@
     "proofId": "erdos-542",
     "type": "concept",
     "range": {
-      "startLine": 90,
-      "endLine": 97
+      "startLine": 80,
+      "endLine": 99
     },
     "title": "Singleton Validity and Reciprocal Sum",
     "content": "`singleton_satisfies_lcm`: any singleton $\\{a\\}$ with $a \\in \\{1,\\ldots,n\\}$ and $a > 0$ satisfies the LCM condition vacuously (no distinct pairs). Proved by `Finset.mem_singleton` + `subst` + `absurd`. `reciprocal_sum_singleton`: $\\sum_{x \\in \\{a\\}} 1/x = 1/a$, proved by `simp`.",

--- a/src/data/proofs/erdos-542/meta.json
+++ b/src/data/proofs/erdos-542/meta.json
@@ -69,8 +69,9 @@
       "Stated optimal example {2,3,5} achieving equality 1/2 + 1/3 + 1/5 = 31/30",
       "Stated Chen's 1996 stronger bound for n > 172509",
       "Stated maximal sets conjecture ({2,3,5} and {3,4,5,7,11} only)",
-      "Proved singleton validity and no-divisibility property",
-      "Proved reciprocal sum formula for explicit sets"
+      "Proved singleton validity property",
+      "Proved reciprocal sum formula for explicit sets",
+      "Documented (as source comments, not Lean proofs) the no-divisibility property and the tight/maximal example facts"
     ],
     "axiomCount": 0,
     "lineCount": 99,
@@ -82,7 +83,7 @@
     "historicalContext": "Erdos posed this extremal problem about sets with pairwise large least common multiples, likely in the 1950s as part of his extensive investigations into primitive sets and multiplicative number theory.\n\n**Andrzej Schinzel** (born 1937, one of Poland's most prolific number theorists) and **George Szekeres** (1911-2005, Hungarian-Australian mathematician famous for the Erdos-Szekeres theorem) solved the problem in their 1959 paper 'Sur un probleme de M. Paul Erdos.' They proved $\\sum 1/a \\le 31/30$ using elementary but careful analysis of prime factorization structures. The bound is tight: $\\{2, 3, 5\\}$ achieves equality with $1/2 + 1/3 + 1/5 = 31/30$ for $n \\ge 6$.\n\nThe problem connects to **primitive sets** — sets where no element divides another — studied by Behrend (1935) and Erdos himself. The LCM condition $\\text{lcm}(a,b) > n$ is strictly stronger than primitivity and forces a form of multiplicative independence.\n\n**Yong-Gao Chen** (1996) proved that for $n > 172509$, the bound drops below $31/30$ to $4699/4620 \\approx 1.017$, showing the extremal configuration $\\{2,3,5\\}$ only works for small $n$. The threshold arises because large $n$ prevents small elements (especially $2$) from participating in valid sets.\n\nThe remaining **Erdos-Schinzel-Szekeres conjecture** posits that exactly two sets achieve reciprocal sum $> 1$: $\\{2,3,5\\}$ and $\\{3,4,5,7,11\\}$. This classification problem remains open and connects to questions about **Mertens-type bounds** for primitive sets and the theory of **B-free numbers**.",
     "problemStatement": "If $A \\subseteq \\{1, \\ldots, n\\}$ satisfies $\\text{lcm}(a,b) > n$ for all distinct $a, b \\in A$, must $\\sum_{a \\in A} 1/a \\le 31/30$?",
     "text": "If A ⊆ {1,...,n} with lcm(a,b) > n for distinct a,b ∈ A, must ∑ 1/a ≤ 31/30? Solved by Schinzel-Szekeres (1959).",
-    "proofStrategy": "We formalize PairwiseLCMExceeds (the pairwise LCM condition) and reciprocalSum. The Schinzel-Szekeres theorem is stated as the main result, with {2,3,5} as the optimal example. Chen's stronger bound for large n and the maximal sets conjecture are stated as additional results. We prove structural properties: singleton sets always satisfy the LCM condition, the reciprocal sum formula for explicit sets, and the no-divisibility property (lcm(a,b) > n implies neither divides the other within {1,...,n}).",
+    "proofStrategy": "We formalize PairwiseLCMExceeds (the pairwise LCM condition) and reciprocalSum. The Schinzel-Szekeres theorem is stated as the main result, with {2,3,5} as the optimal example. Chen's stronger bound for large n and the maximal sets conjecture are stated as additional results. We prove structural properties: singleton sets always satisfy the LCM condition, and the reciprocal sum formula for explicit sets. The no-divisibility property (lcm(a,b) > n implies neither divides the other within {1,...,n}) is documented only as a source comment, not proved in Lean.",
     "keyInsights": [
       "**Tight Bound**: The set {2, 3, 5} achieves 1/2 + 1/3 + 1/5 = 31/30 exactly, making the Schinzel-Szekeres bound best possible",
       "**LCM as Independence**: The condition lcm(a,b) > n is a strong form of multiplicative independence — it prevents any divisibility relation between elements",
@@ -115,7 +116,7 @@
       "title": "Schinzel-Szekeres Theorem",
       "startLine": 37,
       "endLine": 46,
-      "summary": "States `ErdosProblem542`: $\\sum 1/a \\le 31/30$ under the LCM condition. Axiomatizes the tight example $\\{2,3,5\\}$ with $1/2 + 1/3 + 1/5 = 31/30$ and its validity for $n = 5$."
+      "summary": "States `ErdosProblem542`: $\\sum 1/a \\le 31/30$ under the LCM condition. Documents in source comments (no Lean declarations exist) the tight example $\\{2,3,5\\}$ with $1/2 + 1/3 + 1/5 = 31/30$ and its validity for $n = 5$."
     },
     {
       "id": "chen-bound",
@@ -129,14 +130,14 @@
       "title": "Maximal Sets Conjecture",
       "startLine": 63,
       "endLine": 75,
-      "summary": "States `MaximalSetsConjecture`: only $\\{2,3,5\\}$ and $\\{3,4,5,7,11\\}$ achieve $\\sum 1/a > 1$. Axiomatizes that $\\{3,4,5,7,11\\}$ has sum $> 1$ and satisfies the LCM condition for $n = 11$."
+      "summary": "States `MaximalSetsConjecture`: only $\\{2,3,5\\}$ and $\\{3,4,5,7,11\\}$ achieve $\\sum 1/a > 1$. Documents in source comments (no Lean declarations exist) that $\\{3,4,5,7,11\\}$ has sum $> 1$ and satisfies the LCM condition for $n = 11$."
     },
     {
       "id": "structural",
       "title": "Structural Properties and Final Theorem",
       "startLine": 76,
       "endLine": 97,
-      "summary": "documents in source comments `lcm_condition_no_divisibility` (no Lean declaration exists) ($a \\mid b \\implies b > n$, i.e., $A$ is an antichain). Proves `singleton_satisfies_lcm` (vacuous satisfaction) and `reciprocal_sum_singleton` ($\\sum_{\\{a\\}} 1/x = 1/a$). `schinzel_szekeres_solves_542` axiomatizes the full resolution."
+      "summary": "Documents in source comments (no Lean declarations exist) the no-divisibility property ($a \\mid b \\implies b > n$, i.e., $A$ is an antichain) and the closing remark that the Schinzel-Szekeres theorem solves Erdős Problem 542. Proves `singleton_satisfies_lcm` (vacuous satisfaction) and `reciprocal_sum_singleton` ($\\sum_{\\{a\\}} 1/x = 1/a$)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- `annotations.json` cited `bound_achieved_by_235`, `example_235_valid`, `example_34_5_7_11_sum`, `example_34_5_7_11_valid`, and `lcm_condition_no_divisibility` as if they were Lean declarations. None exist in `Proofs/Erdos542Problem.lean` (grep confirms 0 hits) — they are only prose in source comments.
- `meta.json`'s `sections[]` narrative compounded this, claiming these comments were "Axiomatized" even though the file has 0 axioms, and `originalContributions`/`proofStrategy` claimed the no-divisibility property was "proved" when it is only a comment.
- Snapped annotation line ranges to the current file layout while touching these entries.

## Test plan
- [x] Validated both JSON files parse (`python3 -c "import json; json.load(...)"`)
- [x] Grepped the Lean source to confirm the five phantom identifiers and `axiom` keyword do not appear anywhere in the file
- [x] Diffed `theoremCount`/`definitionCount`/`axiomCount`/`lineCount` in meta.json against the actual file (5 defs, 3 theorems, 0 axioms, 99 lines) — all already correct, untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)