### PR TITLE
Enrich urysohns-lemma-oq-01: add missing header section (uncovered lines 1-39)

### DIFF
--- a/src/data/proofs/urysohns-lemma-oq-01/meta.json
+++ b/src/data/proofs/urysohns-lemma-oq-01/meta.json
@@ -33,6 +33,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header: Urysohn's Lemma and the Explicit Metric Witness",
+      "startLine": 1,
+      "endLine": 39,
+      "mathContext": "Mathlib's abstract Urysohn separation `exists_continuous_zero_one_of_isClosed`, contrasted with the explicit metric witness $f(x)=\\dfrac{d(x,s)}{d(x,s)+d(x,t)}$ built purely from `Metric.infDist`.",
+      "summary": "Imports Mathlib and states the module docstring: frames Urysohn's lemma (Urysohn 1925) as the cornerstone separation theorem of point-set topology, cites Mathlib's abstract statements exists_continuous_zero_one_of_isClosed and the locally-compact-Hausdorff variant exists_continuous_zero_one_of_isCompact (source of the mathlib badge), and previews the genuine content added: the explicit metric Urysohn function f(x) = d(x,s)/(d(x,s)+d(x,t)), proved continuous, 0 on s, 1 on t, and [0,1]-valued with no appeal to the abstract machinery. Opens the UrysohnsLemmaOQ01 namespace and opens Set/Metric."
+    },
+    {
       "id": "abstract-lemma",
       "title": "Part (a): The Abstract Lemma in a Normal Space",
       "startLine": 40,


### PR DESCRIPTION
## Summary

`urysohns-lemma-oq-01` was already at the enrichment quality target — 5 substantive `keyInsights`, full `mathlibDependencies`/`originalContributions`, `crossReferences` to both children answering its `openQuestions`, and a complete `conclusion`. Per the size-guardrail/SKIP rule, no filler was added to those fields.

The genuine gap: `meta.sections` started at line 40, leaving the module docstring, import, namespace, and opens (lines 1-39) uncovered. That header explains the whole contrast this entry is built around — Mathlib's abstract Urysohn separation vs. the explicit metric witness `f(x) = d(x,s)/(d(x,s)+d(x,t))` built purely from `Metric.infDist` — so it's substantive content, not boilerplate. Added a `header` section spanning lines 1-39.

## Test plan

- [x] `python3 -c "import json; json.load(...)"` — meta.json parses
- [x] `pnpm gallery:check-size` — all 4811 entries within the 60 KB cap (file is ~16.6 KB, well under)
- [x] Verified lines 1-39 of `Proofs/UrysohnsLemmaOQ01.lean` against the new section summary