### PR TITLE
Enrich triangle-angle-sum-oq-04: add missing cross-reference to converse-family sibling oq-06

### DIFF
--- a/src/data/proofs/triangle-angle-sum-oq-04/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-04/meta.json
@@ -142,6 +142,11 @@
       "targetId": "fourier-series-oq-02-oq-03",
       "relationship": "related",
       "description": "An analytic payoff of the finite-sum kernel machinery this entry builds. It studies the sharp constant in the decay bound for Fourier coefficients of Hölder functions — a quantitative refinement of the convergence theory that the Dirichlet (and prospective Fejér) kernels of this entry underpin."
+    },
+    {
+      "targetId": "triangle-angle-sum-oq-06",
+      "relationship": "related",
+      "description": "Converse family: this entry proves the Werner product-to-sum identities (product → sum) and telescopes them into the Dirichlet kernel; oq-06 proves the sum-to-product identities (sum → product) and applies them to the triangle half-angle products sin A + sin B + sin C = 4cos(A/2)cos(B/2)cos(C/2)."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Claimed target `triangle-angle-sum-oq-06` was already at the enrichment quality target — 4 substantive `keyInsights`, a `mainTheorems` block, `sections` covering the whole 175-line file, 5 annotations with full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`, and a complete `conclusion` with 3 `openQuestions`. Per the size-guardrail/SKIP rule, no filler was added there.

The one genuine gap: `triangle-angle-sum-oq-06` already cross-references `triangle-angle-sum-oq-04` as the "converse family" (oq-04 proves the Werner product-to-sum identities, oq-06 proves the converse sum-to-product identities), but the link was one-directional — `oq-04` had no `crossReferences` entry pointing back to `oq-06`. Added the reciprocal link on `oq-04`.

## Test plan

- [x] `python3 -c "import json; json.load(...)"` — meta.json parses
- [x] `pnpm gallery:check-size` — all 4811 entries within the 60 KB cap
- [x] Verified both entries' actual content (Werner product-to-sum vs. sum-to-product identities) before writing the cross-reference text