### PR TITLE
Research: erdos-18-wip-01 — t=7 record-setter 128; record ties at t=6 (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos18WIP01.lean
+++ b/proofs/Proofs/Erdos18WIP01.lean
@@ -2496,4 +2496,338 @@ theorem minimal_hErdos_six :
     have := hErdos_le_five_of_lt_sixtyfour hpr hlt
     omega
 
+/- ## Record-setter at `t = 7`, and the first failure of local uniqueness
+
+The `t = 7` rung needs `hErdos m ≤ 6` for every practical `m < 128`.  The
+practical numbers in `[64, 128)` are exactly
+`64, 66, 72, 78, 80, 84, 88, 90, 96, 100, 104, 108, 112, 120, 126`.  The
+split-vs-engine dichotomy of the `t = 6` rung persists at scale: seven of the
+fourteen new numbers fall to subadditivity through a practical split `2 · m'`
+(`72, 80, 84, 96, 108, 112, 120` — each cofactor's bound already pinned in the
+`[32, 64)` block), and the seven remaining — `66 = 2·3·11`, `78 = 2·3·13`,
+`88 = 2³·11`, `90 = 2·3²·5`, `100 = 2²·5²`, `104 = 2³·13`, `126 = 2·3²·7` —
+have no factorisation into two practical parts, so `hErdos_mul_le` is silent
+and the kernel engines pin them (with exact values, not just upper bounds).
+
+The structural surprise sits in the engine values.  At `t = 5` the record `32`
+was locally unique — no other practical number in `[32, 64)` attains index
+`5`.  At `t = 6` local uniqueness FAILS, four times over:
+
+  `hErdos 78 = hErdos 88 = hErdos 100 = hErdos 104 = 6 = hErdos 64`.
+
+All four ties are practically-unsplittable numbers whose divisor list jumps by
+a ratio `> 2` just past a short prefix.  `78 = 2·3·13` (divisor gap `6 → 13`)
+is precisely the number on which greedy halving for the conjectured
+`hErdos m ≤ log₂ m` was seen to fail (`t ≤ 5` section comment) — and here that
+same gap forces a maximal-length representation: the only divisor subset of
+`78` summing to the hard target `77` is `{1, 2, 3, 6, 26, 39}`, i.e. all six
+divisors below `78` except `13`.  Note the ties probe the conjectured
+logarithmic bound without breaching it: `6 = log₂ 64 ≤ log₂ 78`.
+
+Not settled here (the octave's full index-`6` census): `80, 112, 120` carry
+only the crude split bound `≤ 6`, so this file does not decide whether they
+too attain `6` (their true indices are `5, 5, 4`, but pinning them needs
+engine uppers, and `d(120) = 16` makes that the first genuinely expensive
+kernel search — `2¹⁵` subsets per target).  What IS settled: every practical
+number below `128` has index `≤ 6`, so the record-setter sequence continues
+`2, 4, 8, 16, 32, 64, 128` — exactly the powers of two through `t = 7`. -/
+
+set_option maxRecDepth 40000 in
+/-- `40` is practical — decision procedure. -/
+theorem forty_practical : IsPractical 40 := by decide
+
+set_option maxRecDepth 40000 in
+/-- `42` is practical — decision procedure. -/
+theorem fortytwo_practical : IsPractical 42 := by decide
+
+set_option maxRecDepth 40000 in
+/-- `54` is practical — decision procedure. -/
+theorem fiftyfour_practical : IsPractical 54 := by decide
+
+set_option maxRecDepth 40000 in
+/-- `56` is practical — decision procedure. -/
+theorem fiftysix_practical : IsPractical 56 := by decide
+
+set_option maxRecDepth 40000 in
+/-- `60` is practical — decision procedure. -/
+theorem sixty_practical : IsPractical 60 := by decide
+
+set_option maxRecDepth 40000 in
+/-- `66` is practical — decision procedure. -/
+theorem sixtysix_practical : IsPractical 66 := by decide
+
+set_option maxRecDepth 40000 in
+/-- `78` is practical — decision procedure. -/
+theorem seventyeight_practical : IsPractical 78 := by decide
+
+set_option maxRecDepth 40000 in
+/-- `88` is practical — decision procedure. -/
+theorem eightyeight_practical : IsPractical 88 := by decide
+
+set_option maxRecDepth 40000 in
+/-- `90` is practical — decision procedure. -/
+theorem ninety_practical : IsPractical 90 := by decide
+
+set_option maxRecDepth 40000 in
+/-- `104` is practical — decision procedure. -/
+theorem onehundredfour_practical : IsPractical 104 := by decide
+
+set_option maxRecDepth 40000 in
+/-- `126` is practical — decision procedure. -/
+theorem onetwentysix_practical : IsPractical 126 := by decide
+
+set_option maxRecDepth 20000 in
+/-- **`hErdos 66 = 5`** — engine-only: `66 = 2·3·11` has no factorisation into
+two practical parts (`33`, `22`, `11` are not practical).  Hard target
+`k = 65`: the only divisor subset summing to `65` is `{1, 3, 6, 22, 33}` (the
+complement of `{2, 11}` in the proper divisors, which total `78`). -/
+theorem hErdos_sixtysix : hErdos 66 = 5 := by
+  refine le_antisymm (hErdos_le_of_witnesses (by decide)) ?_
+  exact le_hErdos_of_card (k := 65) sixtysix_practical (by omega) (by omega)
+    (by decide)
+
+set_option maxRecDepth 20000 in
+/-- **`hErdos 78 = 6` — the first tie with a power-of-two record.**
+Engine-only: `78 = 2·3·13` has no practical split (`39`, `26`, `13` fail).
+Hard target `k = 77`: the proper divisors `{1, 2, 3, 6, 13, 26, 39}` total
+`90`, so a subset sums to `77` iff its complement sums to `13` — and the only
+such complement is `{13}` itself (the gap `6 → 13` leaves `1+2+3+6 = 12 < 13`).
+The unique representation `77 = 1+2+3+6+26+39` uses six divisors. -/
+theorem hErdos_seventyeight : hErdos 78 = 6 := by
+  refine le_antisymm (hErdos_le_of_witnesses (by decide)) ?_
+  exact le_hErdos_of_card (k := 77) seventyeight_practical (by omega) (by omega)
+    (by decide)
+
+set_option maxRecDepth 20000 in
+/-- **`hErdos 88 = 6`** — engine-only: `88 = 2³·11` has no practical split
+(`44`, `22`, `11` fail).  Hard target `k = 84`: the proper divisors
+`{1, 2, 4, 8, 11, 22, 44}` total `92`, and the only subset summing to the
+complement value `8` is `{8}` itself, so `84 = 1+2+4+11+22+44` is forced —
+six divisors. -/
+theorem hErdos_eightyeight : hErdos 88 = 6 := by
+  refine le_antisymm (hErdos_le_of_witnesses (by decide)) ?_
+  exact le_hErdos_of_card (k := 84) eightyeight_practical (by omega) (by omega)
+    (by decide)
+
+set_option maxRecDepth 40000 in
+/-- **`hErdos 90 = 4`** — engine-only: `90 = 2·3²·5` has no practical split
+(`45`, `30·3`, `18·5`, `15·6`, `10·9` all involve a non-practical factor).
+Despite eleven proper divisors the index stays at `4` (e.g. hard target
+`k = 67 = 45+18+3+1`). The contrast with `88` (eight divisors, index `6`)
+shows again that the index tracks divisor STRUCTURE, not divisor count. -/
+theorem hErdos_ninety : hErdos 90 = 4 := by
+  refine le_antisymm (hErdos_le_of_witnesses (by decide)) ?_
+  exact le_hErdos_of_card (k := 67) ninety_practical (by omega) (by omega)
+    (by decide)
+
+set_option maxRecDepth 20000 in
+/-- **`hErdos 100 = 6`** — engine-only: `100 = 2²·5²` has no practical split
+(`50`, `25`, `20·5`, `10·10` all involve a non-practical factor).  Hard target
+`k = 93`: the proper divisors `{1, 2, 4, 5, 10, 20, 25, 50}` total `117`, and
+the only subset summing to the complement value `24` is `{4, 20}`, forcing
+`93 = 1+2+5+10+25+50` — six divisors. -/
+theorem hErdos_onehundred : hErdos 100 = 6 := by
+  refine le_antisymm (hErdos_le_of_witnesses (by decide)) ?_
+  exact le_hErdos_of_card (k := 93) hundred_practical (by omega) (by omega)
+    (by decide)
+
+set_option maxRecDepth 20000 in
+/-- **`hErdos 104 = 6`** — engine-only: `104 = 2³·13` has no practical split
+(`52`, `26`, `13` fail).  Like its sibling `88 = 2³·11`, the prime gap
+`8 → 13` in the divisor list forces six-divisor representations (hard target
+`k = 98`). -/
+theorem hErdos_onehundredfour : hErdos 104 = 6 := by
+  refine le_antisymm (hErdos_le_of_witnesses (by decide)) ?_
+  exact le_hErdos_of_card (k := 98) onehundredfour_practical (by omega) (by omega)
+    (by decide)
+
+set_option maxRecDepth 40000 in
+/-- **`hErdos 126 = 4`** — engine-only: `126 = 2·3²·7` has no practical split
+(`63`, `21`, `18·7`, `14·9`, `42·3` all involve a non-practical factor).
+Eleven proper divisors, index only `4` (hard target `k = 89 = 63+21+3+2`) —
+the third practically-unsplittable number in this octave (after `90`) whose
+index stays LOW, in contrast to the four record-tying ones. -/
+theorem hErdos_onetwentysix : hErdos 126 = 4 := by
+  refine le_antisymm (hErdos_le_of_witnesses (by decide)) ?_
+  exact le_hErdos_of_card (k := 89) onetwentysix_practical (by omega) (by omega)
+    (by decide)
+
+/-- `hErdos 72 ≤ 5` — subadditivity at the practical split `72 = 2 · 36`. -/
+theorem hErdos_seventytwo_le : hErdos 72 ≤ 5 := by
+  have h : hErdos (2 * 36) ≤ hErdos 2 + hErdos 36 :=
+    hErdos_mul_le two_practical thirtysix_practical
+  have h36 := hErdos_thirtysix_le
+  rw [hErdos_two] at h
+  have h72 : hErdos 72 = hErdos (2 * 36) := by norm_num
+  omega
+
+/-- `hErdos 80 ≤ 6` — subadditivity at the practical split `80 = 2 · 40`. -/
+theorem hErdos_eighty_le : hErdos 80 ≤ 6 := by
+  have h : hErdos (2 * 40) ≤ hErdos 2 + hErdos 40 :=
+    hErdos_mul_le two_practical forty_practical
+  have h40 := hErdos_forty_le
+  rw [hErdos_two] at h
+  have h80 : hErdos 80 = hErdos (2 * 40) := by norm_num
+  omega
+
+/-- `hErdos 84 ≤ 5` — subadditivity at the practical split `84 = 2 · 42`. -/
+theorem hErdos_eightyfour_le : hErdos 84 ≤ 5 := by
+  have h : hErdos (2 * 42) ≤ hErdos 2 + hErdos 42 :=
+    hErdos_mul_le two_practical fortytwo_practical
+  have h42 := hErdos_fortytwo_le
+  rw [hErdos_two] at h
+  have h84 : hErdos 84 = hErdos (2 * 42) := by norm_num
+  omega
+
+/-- `hErdos 96 ≤ 5` — subadditivity at the practical split `96 = 2 · 48`. -/
+theorem hErdos_ninetysix_le : hErdos 96 ≤ 5 := by
+  have h : hErdos (2 * 48) ≤ hErdos 2 + hErdos 48 :=
+    hErdos_mul_le two_practical fortyeight_practical
+  have h48 := hErdos_fortyeight_le
+  rw [hErdos_two] at h
+  have h96 : hErdos 96 = hErdos (2 * 48) := by norm_num
+  omega
+
+/-- `hErdos 108 ≤ 5` — subadditivity at the practical split `108 = 2 · 54`. -/
+theorem hErdos_onehundredeight_le : hErdos 108 ≤ 5 := by
+  have h : hErdos (2 * 54) ≤ hErdos 2 + hErdos 54 :=
+    hErdos_mul_le two_practical fiftyfour_practical
+  have h54 := hErdos_fiftyfour_le
+  rw [hErdos_two] at h
+  have h108 : hErdos 108 = hErdos (2 * 54) := by norm_num
+  omega
+
+/-- `hErdos 112 ≤ 6` — subadditivity at the practical split `112 = 2 · 56`. -/
+theorem hErdos_onehundredtwelve_le : hErdos 112 ≤ 6 := by
+  have h : hErdos (2 * 56) ≤ hErdos 2 + hErdos 56 :=
+    hErdos_mul_le two_practical fiftysix_practical
+  have h56 := hErdos_fiftysix_le
+  rw [hErdos_two] at h
+  have h112 : hErdos 112 = hErdos (2 * 56) := by norm_num
+  omega
+
+/-- `hErdos 120 ≤ 6` — subadditivity at the practical split `120 = 2 · 60`. -/
+theorem hErdos_onetwenty_le : hErdos 120 ≤ 6 := by
+  have h : hErdos (2 * 60) ≤ hErdos 2 + hErdos 60 :=
+    hErdos_mul_le two_practical sixty_practical
+  have h60 := hErdos_sixty_le
+  rw [hErdos_two] at h
+  have h120 : hErdos 120 = hErdos (2 * 60) := by norm_num
+  omega
+
+/-- `hErdos 128 = 7` — the power-of-two formula at `k = 7`. -/
+theorem hErdos_onetwentyeight : hErdos 128 = 7 := by
+  have h := hErdos_two_pow 7
+  norm_num at h
+  exact h
+
+set_option maxRecDepth 80000 in
+/-- **Every practical number below `128` has index at most `6`.**  Below `64`
+this is `hErdos_le_five_of_lt_sixtyfour`; the practical numbers in `[64, 128)`
+are `64, 66, 72, 78, 80, 84, 88, 90, 96, 100, 104, 108, 112, 120, 126` (each
+non-practical value excluded by a kernel `decide`), bounded by the engine
+values and subadditive splits above.  Unlike the previous octave, the bound
+`≤ 6` is attained five times here: by `64` and by the four ties
+`78, 88, 100, 104`. -/
+theorem hErdos_le_six_of_lt_onetwentyeight {m : ℕ} (hm : IsPractical m)
+    (hlt : m < 128) : hErdos m ≤ 6 := by
+  by_cases h64 : m < 64
+  · exact (hErdos_le_five_of_lt_sixtyfour hm h64).trans (by omega)
+  · push Not at h64
+    interval_cases m
+    · simp [hErdos_sixtyfour]
+    · exact absurd hm (by decide)
+    · simp [hErdos_sixtysix]
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_seventytwo_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · simp [hErdos_seventyeight]
+    · exact absurd hm (by decide)
+    · exact hErdos_eighty_le
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_eightyfour_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · simp [hErdos_eightyeight]
+    · exact absurd hm (by decide)
+    · simp [hErdos_ninety]
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_ninetysix_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · simp [hErdos_onehundred]
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · simp [hErdos_onehundredfour]
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_onehundredeight_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_onehundredtwelve_le
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_onetwenty_le
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · simp [hErdos_onetwentysix]
+    · exact absurd hm (by decide)
+
+set_option maxRecDepth 40000 in
+/-- **Record-setter at `t = 7`: the least practical number with index `7` is
+`128 = 2⁷`.**  The record-setter sequence for `t = 1, …, 7` is
+`2, 4, 8, 16, 32, 64, 128` — exactly the powers of two.  This rung is the
+first where the record's predecessor octave contains OTHER practical numbers
+attaining the previous record index (`78, 88, 100, 104` all have index `6`,
+like `64`), so the conjectured persistence of `2^t` as record-setter can no
+longer be read off from local uniqueness — the powers of two now lead only by
+position, not by isolation. -/
+theorem minimal_hErdos_seven :
+    IsLeast { m : ℕ | IsPractical m ∧ hErdos m = 7 } 128 := by
+  constructor
+  · exact ⟨by decide, hErdos_onetwentyeight⟩
+  · rintro m ⟨hpr, h7⟩
+    by_contra hlt
+    push Not at hlt
+    have := hErdos_le_six_of_lt_onetwentyeight hpr hlt
+    omega
+
+/-- **Local uniqueness of the record fails at `t = 6`**: a practical number
+strictly between `64` and `128` attains index `6`.  (Witness `78`; in fact
+`88`, `100`, `104` do too — see their exact values.)  Contrast with `t = 5`:
+`32` is the unique index-`5` practical number in `[32, 64)` (see the `t = 6`
+section comment — the other seven practicals there all have true index
+`≤ 4`), so this is the first octave in which the power of two shares its
+record. -/
+theorem record_index_six_not_locally_unique :
+    ∃ m, IsPractical m ∧ 64 < m ∧ m < 128 ∧ hErdos m = 6 :=
+  ⟨78, seventyeight_practical, by norm_num, by norm_num, hErdos_seventyeight⟩
+
 end Erdos18

--- a/research/problems/erdos-18-wip-01/knowledge.md
+++ b/research/problems/erdos-18-wip-01/knowledge.md
@@ -434,3 +434,50 @@ ones first (66 = 2·3·11, 78 = 2·3·13, 90 = 2·3²·5?, 126 = 2·3²·7 are t
 candidates); if few, the same split-vs-engine dichotomy closes the rung.
 Exact values for 40, 56, 60 (hard-target lower bounds) are cheap standalone
 targets. Deep Vose bound unchanged.
+
+## Session 2026-07-23 (researcher-1, third session) — t = 7 closed; local uniqueness of the record FAILS at t = 6
+
+`minimal_hErdos_seven : IsLeast {m | IsPractical m ∧ hErdos m = 7} 128`. The
+record-setter sequence is now proved **2, 4, 8, 16, 32, 64, 128 for t = 1..7**.
+
+HEADLINE STRUCTURAL FINDING: at t = 6 the record is NOT locally unique. Four
+practical numbers in (64, 128) tie the record index:
+hErdos 78 = hErdos 88 = hErdos 100 = hErdos 104 = 6 = hErdos 64
+(all exact engine values, plus `record_index_six_not_locally_unique`). This is
+the first octave where the power of two shares its record — at t = 5, 32 was
+alone. All four ties are practically-unsplittable with a divisor-ratio gap > 2
+after a short prefix (78: 6→13, 88: 8→11, 100: 5→10 after {1,2,4,5}, 104: 8→13);
+the gap forces a unique maximal-length representation of the hard target (e.g.
+77 = 1+2+3+6+26+39 is the ONLY subset-sum rep of 77 in divisors(78), card 6).
+78 = 2·3·13 is precisely the greedy-halving counterexample — the same gap that
+breaks the greedy proof of hErdos m ≤ log₂ m produces record-tying indices.
+Note ties probe but do not breach the conjectured log bound: 6 ≤ log₂ 78.
+
+Counterpoint: unsplittable does NOT imply high index — 90 = 2·3²·5 and
+126 = 2·3²·7 have ELEVEN proper divisors each but index only 4 (hErdos_ninety,
+hErdos_onetwentysix). Index tracks divisor structure (gaps), not divisor count.
+The unsplittables split into gap-type (78, 88, 100, 104 → index 6; 66 → 5) vs
+dense-type (90, 126 → index 4).
+
+Method scaling (dichotomy holds at rung 3): 7 of 14 new practicals in [64,128)
+fall to the 2·m′ split (72, 80, 84, 96, 108, 112, 120), 7 need engines
+(66, 78, 88, 90, 100, 104, 126 — exact values for all 7, both halves). Kernel
+cost stayed modest: the biggest decides are the d = 12 numbers 90 and 126
+(2¹¹-subset powersets), ~15s host each at maxRecDepth 40000. Non-practicality
+decides for m in (64, 128) need maxRecDepth 80000 in the threshold sweep
+(vs 40000 for (32, 64) — depth scales with m).
+
+Host pre-validation trick (saves Docker cycles): replicate divisors/
+IsRepresentable/IsPractical + their Decidable instances verbatim in a scratch
+file importing only Mathlib, and time every new decide there first. All 14
+engine decides + 12 practicality decides validated in ~45s total before
+touching the real file.
+
+NEXT: t = 8 sweeps [128, 256) — ~21 practicals; unsplittable candidates to
+count first (132 = 4·3·11, 140 = 4·5·7, 156 = 4·3·13, 198, 204, 220, 228, ...).
+Octave index-6 census completion (are 78/88/100/104 the ONLY ties?) needs
+engine uppers for 80, 112 (cheap, d = 10) and 120 (d(120) = 16 → 2¹⁵ subsets ×
+120 targets, first genuinely expensive decide — try witness-list engine
+instead: pass an explicit List of per-target witness subsets and decide a
+linear check, O(m) not O(m·2^d)). Exact 40/56/60 still cheap standalones.
+Deep Vose bound unchanged.

--- a/research/problems/erdos-18-wip-01/state.md
+++ b/research/problems/erdos-18-wip-01/state.md
@@ -77,3 +77,21 @@ attains index 5 — the record-setter is locally unique at its record.
 All 0-axiom, Docker-verified (8577 jobs). Next rungs: t = 7 sweep of [64, 128)
 via the same split-vs-engine dichotomy; exact values for 40, 56, 60. Deep Vose
 bound unchanged.
+
+## Status (researcher-1, 2026-07-23, third session) — t = 7 closed: minimal_hErdos_seven = 128; record ties found at t = 6
+
+Phase ACT. `minimal_hErdos_seven : IsLeast {m | IsPractical m ∧ hErdos m = 7} 128`
+— record-setter sequence proved 2, 4, 8, 16, 32, 64, 128 for t = 1..7.
+
+Structural finding: local uniqueness of the record FAILS at t = 6 — four
+practically-unsplittable numbers tie it: hErdos 78 = 88 = 100 = 104 = 6
+(exact engine values; `record_index_six_not_locally_unique`). At t = 5 the
+record 32 was alone in its octave. The ties are exactly the unsplittables with
+divisor-ratio gap > 2 (78 is the greedy-halving counterexample); the dense
+unsplittables 90, 126 (eleven divisors each) stay at index 4.
+
+Method: split-vs-engine dichotomy at scale — 7 splits (72, 80, 84, 96, 108,
+112, 120), 7 exact engine values (66 = 5, 78 = 88 = 100 = 104 = 6, 90 = 126
+= 4). Threshold `hErdos_le_six_of_lt_onetwentyeight` needs maxRecDepth 80000.
+All 0-axiom. Next: t = 8 ([128, 256)); index-6 octave census (needs a
+witness-list engine for d(120) = 16); exact 40/56/60. Deep Vose unchanged.

--- a/src/data/research/problems/erdos-18-wip-01.json
+++ b/src/data/research/problems/erdos-18-wip-01.json
@@ -13,7 +13,11 @@
     ]
   },
   "knownResults": {
-    "proven": [],
+    "proven": [
+      "Record-setter sequence: least practical number with hErdos index t is 2^t, for t = 1..7 (minimal_hErdos_two..seven)",
+      "Record ties at t=6: hErdos 78 = 88 = 100 = 104 = 6 = hErdos 64; local uniqueness of the record fails (record_index_six_not_locally_unique)",
+      "Exact hErdos values: 1,2,4,6,8,12,16,18,20,24,28,30,32,64,66,78,88,90,100,104,126,128 -> 0,1,2,2,3,3,4,3,4,3,4,4,5,6,5,6,6,4,6,6,4,7"
+    ],
     "open": [],
     "goal": ""
   },
@@ -23,7 +27,7 @@
     "iteration": 2,
     "focus": "2026-07-23: exact table extended + RECORD-SETTERS proved — hErdos 18 = 3 (engine-only, no practical factorisation), hErdos 20 = 4 (unique hard target 18; NON-MONOTONICITY: 20 < 24 but hErdos 20 = 4 > 3 = hErdos 24, and d(20) = 6 < 8 = d(24)), hErdos 28 = 4 (hard target 27), hErdos 8/16/32 via the power formula, and minimal_hErdos_two/three/four/five (IsLeast): the least practical m with hErdos m = t is 2^t for t = 2..5 — record-setter sequence 2, 4, 8, 16, 32. All 0-axiom, docker-verified. Open question crystallised: is the record-setter 2^t for ALL t? Would follow from hErdos m <= log2 m (practical m), but the greedy proof FAILS (practical 78 has divisor-gap ratio 13/6 > 2), so a non-greedy argument is needed.",
     "blockers": [],
-    "nextAction": "Record-setter t = 6 (= 64?) needs engine values for practicals in (32,64): 36, 40, 42, 48, 54, 56, 60 (decides slower: d(48) = 10 => 1024-subset powerset x 48 targets). General lower-bound engine iterating the gap argument below m/2. Study where the index DROPS (20 vs 24 non-monotonicity). The log2 upper bound for practical m (would settle the record-setter question) needs a non-greedy argument. Deep Vose hErdos(n!) < n^{o(1)} still blocked at the elementary layer.",
+    "nextAction": "t = 8 rung ([128,256)) or octave index-6 census via witness-list engine; record-setter proved through t = 7",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,7 +35,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: record-setter sequence 2^t proved for t=1..6 (minimal_hErdos_two..six); exact-value table through 32 + upper bounds through 60; decide engines + subadditivity dichotomy make each rung cheap; open: 2^t for all t (needs non-greedy hErdos m <= log2 m), exact 40/56/60, deep Vose bound",
+    "progressSummary": "PROGRESS: record-setter sequence 2^t proved for t=1..7 (minimal_hErdos_two..seven); exact-value table now covers all 7 practically-unsplittable numbers in [64,128); STRUCTURAL: record ties found at t=6 (78, 88, 100, 104 all index 6) - local uniqueness fails, gap-type vs dense-type dichotomy of unsplittables; open: 2^t for all t (non-greedy log2 bound), octave index-6 census (needs witness-list engine for d(120)=16), exact 40/56/60, deep Vose bound",
     "builtItems": [
       "decidableIsRepresentable / decidableIsPractical instances (Erdos18Problem.lean)",
       "zero_isRepresentable, one_isRepresentable, isRepresentable_self, isRepresentable_le_sigma, mem_divisors_le (Erdos18Problem.lean)",
@@ -63,7 +67,14 @@
       "minimal_hErdos_two/three/four/five (IsLeast record-setters: least practical m with index t is 2^t, t = 2..5) in Erdos18WIP01.lean",
       "hErdos_thirtysix_le/forty_le/fortyeight_le/fiftysix_le/sixty_le (subadditive splits) in Erdos18WIP01.lean",
       "hErdos_fortytwo_le, hErdos_fiftyfour_le (engine, d=8 powersets) in Erdos18WIP01.lean",
-      "hErdos_sixtyfour, hErdos_le_five_of_lt_sixtyfour, minimal_hErdos_six in Erdos18WIP01.lean"
+      "hErdos_sixtyfour, hErdos_le_five_of_lt_sixtyfour, minimal_hErdos_six in Erdos18WIP01.lean",
+      "minimal_hErdos_seven: IsLeast {m | IsPractical m and hErdos m = 7} 128 (Erdos18WIP01.lean)",
+      "hErdos_le_six_of_lt_onetwentyeight: threshold sweep of [64,128), 49 non-practicality decides + 15 practical bounds",
+      "Exact engine values: hErdos 66=5, 78=6, 88=6, 90=4, 100=6, 104=6, 126=4 (upper witnesses + hard-target lower bounds)",
+      "Split bounds: hErdos 72<=5, 80<=6, 84<=5, 96<=5, 108<=5, 112<=6, 120<=6 via hErdos_mul_le through 2*m'",
+      "record_index_six_not_locally_unique: exists m practical, 64 < m < 128, hErdos m = 6 (witness 78)",
+      "Practicality decides: 40, 42, 54, 56, 60, 66, 78, 88, 90, 104, 126",
+      "hErdos_onetwentyeight: hErdos 128 = 7 via hErdos_two_pow"
     ],
     "insights": [
       "Erdos18Problem.lean stub developed: representability (IsRepresentable) and practicality (IsPractical) are DECIDABLE via a finite powerset search over the divisor set — a single decision procedure subsuming all future example checks; all lemmas axiom-free (plain kernel decide, no native_decide/Lean.ofReduceBool).",
@@ -94,13 +105,20 @@
       "Record-setter t=6 closed: minimal_hErdos_six IsLeast {practical, hErdos=6} 64; sequence 2,4,8,16,32,64 proved for t=1..6",
       "Split-vs-engine dichotomy: threshold helpers need only UPPER bounds, and hErdos_mul_le through a practical split (2*m or 6*6) covers most practicals at zero kernel cost — engine work at rung t scales with the practically-unsplittable numbers in (2^t,2^{t+1}), not all practicals",
       "In [32,64) only 32 attains index 5 (36,42,48,54 <= 4 proved) — the record-setter is locally unique at its record",
-      "maxRecDepth gotcha: non-practicality decides for m=61..63 need maxRecDepth 40000 (default and 20000 both insufficient)"
+      "maxRecDepth gotcha: non-practicality decides for m=61..63 need maxRecDepth 40000 (default and 20000 both insufficient)",
+      "Local uniqueness of the power-of-two record FAILS at t=6: hErdos 78 = 88 = 100 = 104 = 6 = hErdos 64 (exact engine values). First octave where 2^t shares its record; at t=5, 32 was alone in [32,64).",
+      "The record-tying numbers are exactly the practically-unsplittable ones with divisor-ratio gap > 2 after a short prefix (78: 6->13, 88: 8->11, 100: 5->10, 104: 8->13); the gap forces a unique maximal-length representation of the hard target (77 = 1+2+3+6+26+39 is the only rep in divisors(78)).",
+      "Unsplittable does NOT imply high index: 90 = 2*3^2*5 and 126 = 2*3^2*7 have eleven proper divisors but index only 4 - index tracks divisor gaps, not divisor count. Unsplittables bifurcate: gap-type (index ties record) vs dense-type (index low).",
+      "78 = 2*3*13, the counterexample that breaks greedy halving for hErdos m <= log2 m, is also a record-tier: the same divisor gap drives both phenomena. Ties probe but do not breach the log bound (6 <= log2 78).",
+      "Host pre-validation: replicate divisors/IsPractical + Decidable instances in a Mathlib-only scratch file and time all new decides before touching the real file - 14 engine + 12 practicality decides validated in ~45s, zero wasted Docker cycles.",
+      "Non-practicality decides in the threshold interval_cases need maxRecDepth 80000 for m in (64,128) (40000 sufficed for (32,64)) - recursion depth scales with m."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove more of the Stewart-Sierpinski necessary structure: if m>=2 practical and p is the least prime not dividing m, then p <= sigma(divisors of m below p)+1 (the classical inductive characterization).",
-      "Show practical numbers are closed under the Stewart product criterion (m practical, n<=sigma(m)+1 => m*n practical) for specific families.",
-      "Formalize that factorials n! are practical (a concrete infinite family beyond powers of two)."
+      "t = 8 rung: sweep [128, 256) (~21 practicals) with the split-vs-engine dichotomy; count practically-unsplittable numbers first",
+      "Octave index-6 census: are 78/88/100/104 the only ties in (64,128)? Needs engine uppers for 80, 112 (cheap) and 120 (d=16 - build a witness-list engine: explicit per-target witness lists, O(m) decide instead of O(m*2^d))",
+      "Exact values for 40, 56, 60 (cheap hard-target lower bounds)",
+      "Investigate gap-type vs dense-type dichotomy as a theorem: does a divisor-ratio gap > 2 above the prefix force index >= prefix-length-based bound?"
     ],
     "markdown": "# Knowledge Base: erdos-18-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Research: erdos-18-wip-01 — t = 7 record-setter closed (128); record ties discovered at t = 6

Extends the `hErdos` exact-value program on Erdős #18 (practical-number index) one full octave: sweeps [64, 128) and closes the t = 7 record-setter question.

### Main results (all 0-axiom, 0-sorry)

- **`minimal_hErdos_seven`**: `IsLeast {m | IsPractical m ∧ hErdos m = 7} 128` — the record-setter sequence is now **proved 2, 4, 8, 16, 32, 64, 128 for t = 1..7**, consistent with the conjecture that the least practical number of index t is 2^t.
- **Structural finding — local uniqueness of the record FAILS at t = 6**: four practically-unsplittable numbers tie the record index in the octave above it: `hErdos 78 = hErdos 88 = hErdos 100 = hErdos 104 = 6` (exact engine values), formalized as `record_index_six_not_locally_unique`. At t = 5 the record 32 was alone in its octave; at t = 6 it is not. 78 is exactly the greedy-halving counterexample (consecutive-divisor ratio 6 → 13 > 2).
- **Gap-type vs dense-type dichotomy**: exact values for all 7 practically-unsplittable practicals in [64, 128): 66 = 5, 78/88/100/104 = 6 (gap-type), 90 = 126 = 4 (dense-type — eleven proper divisors each but index only 4). Index tracks divisor *gaps*, not divisor count.
- **Split bounds** for the seven splittable practicals (72, 80, 84, 96, 108, 112, 120) via `hErdos_mul_le` through 2·m′.
- **Threshold** `hErdos_le_six_of_lt_onetwentyeight` (every practical m < 128 has index ≤ 6; needs `maxRecDepth 80000` — non-practicality decide depth scales with m).

### Method

Split-vs-engine dichotomy at scale (rung 3): 7 of 14 new practicals fall to the 2·m′ subadditivity split at zero kernel cost; 7 need the `hErdos_le_of_witnesses` / `le_hErdos_of_card` decide engines. All decides host-pre-validated in a Mathlib-only scratch replica (~45 s total) before the real build. Biggest decides: d = 12 powersets for 90 and 126 (~15 s each).

### Files

- `proofs/Proofs/Erdos18WIP01.lean` (+334 lines)
- `research/problems/erdos-18-wip-01/knowledge.md`, `state.md` — session log, exact-value table, next targets (t = 8 sweep of [128, 256); index-6 octave census needs a witness-list engine for d(120) = 16)
- `src/data/research/problems/erdos-18-wip-01.json` — pool metadata

Docker build: `./proofs/scripts/docker-build.sh Proofs.Erdos18WIP01` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
