### PR TITLE
Fix erdos-53: remove phantom "Axiom:" labels from sections[]

### DIFF
--- a/src/data/proofs/erdos-53/meta.json
+++ b/src/data/proofs/erdos-53/meta.json
@@ -78,14 +78,14 @@
       "title": "Chang's Theorem (2003)",
       "startLine": 59,
       "endLine": 67,
-      "summary": "Axiom: ErdosProblem53 holds — Chang proved the polynomial lower bound for all k."
+      "summary": "Doc comment only (not an axiom or theorem): Chang (2003) proved ErdosProblem53 holds — the polynomial lower bound for all k."
     },
     {
       "id": "upper-bound",
       "title": "Erdős-Szemerédi Upper Bound",
       "startLine": 68,
       "endLine": 82,
-      "summary": "Axiom: arbitrarily large sets exist with representable count at most exp(c(log|A|)² log log|A|), formalized as |A|^(c·(log₂|A|+1))."
+      "summary": "Doc comment only (not an axiom or theorem): arbitrarily large sets exist with representable count at most exp(c(log|A|)² log log|A|)."
     },
     {
       "id": "sum-product-connection",
@@ -99,7 +99,7 @@
       "title": "Counting Functions",
       "startLine": 108,
       "endLine": 116,
-      "summary": "Defines subsetSumCount and subsetProductCount, with axioms that the union count dominates each individual count."
+      "summary": "Defines subsetSumCount and subsetProductCount as the cardinalities of subsetSums/subsetProducts. The theorems that the union count dominates each individual count (subsetSumCount_le_card, subsetProductCount_le_card) are proved later, in Section 7."
     },
     {
       "id": "foundational-lemmas",


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-53 (Erdős Problem #53: Sums and Products of Distinct Elements)

**Problem**: Three `sections[]` summaries in `meta.json` described doc-comment-only
content as `"Axiom: ..."`, contradicting the file's true 0-axiom state (confirmed
by `leanFile.axiomCount: 0`, `meta.axiomCount: 0`, and `grep '^axiom' → no hits`).

## Evidence

- `sections[chang-theorem]` said `"Axiom: ErdosProblem53 holds..."` — lines 59-67
  of the Lean file are a `/- ... -/` doc comment, not an `axiom` declaration.
- `sections[upper-bound]` said `"Axiom: arbitrarily large sets exist..."` and
  fabricated a formalized-bound detail (`|A|^(c·(log₂|A|+1))`) that appears
  nowhere in the file — lines 68-82 are doc comments only, and there is no
  Lean encoding of the upper bound at all (no `log`/`UpperBound` identifiers
  outside the comments).
- `sections[counting-functions]` said `"axioms that the union count dominates
  each individual count"` — `subsetSumCount_le_card` / `subsetProductCount_le_card`
  are actual proven `theorem`s (lines 166-175), not axioms, and they aren't even
  in this section's line range (108-116).

The top-level `meta.assumptions` and `overview.proofStrategy` fields already
correctly state "0 axioms... Chang's theorem and the Erdos-Szemeredi upper
bound... remain described in doc-comments only, NOT formalized" — this PR just
brings the `sections[]` array into agreement with that honest framing.

## Fix

Reworded the three summaries to say "doc comment only (not an axiom or
theorem)" and to correctly attribute the counting-function theorems to
Section 7 where they're actually proved.

---
Discovered during gallery integrity audit (erdos-53, oldest-tier re-serve).