### PR TITLE
Enrich three-place-identity-oq-01: add missing header section (uncovered lines 1-51)

### DIFF
--- a/src/data/proofs/three-place-identity-oq-01/meta.json
+++ b/src/data/proofs/three-place-identity-oq-01/meta.json
@@ -59,6 +59,14 @@
   },
   "sections": [
     {
+      "id": "tpi-oq01-header",
+      "title": "Module Header: The Question and the Sharp Answer",
+      "startLine": 1,
+      "endLine": 51,
+      "mathContext": "$D(\\mathrm{mem})\\,y\\,x \\leftrightarrow \\neg(\\mathrm{mem}\\,y\\,x \\leftrightarrow \\mathrm{mem}\\,x\\,x)$, from which sufficiency, necessity, inversion, and self-regularization all follow.",
+      "summary": "Imports the parent ThreePlaceIdentity file and states the module docstring: poses OQ-01 (is Foundation necessary or merely sufficient for the Round-Trip Theorem, and what happens when it fails?), previews the sharp answer D(mem) y x ↔ ¬(mem y x ↔ mem x x) and its four consequences (sufficiency, necessity, inversion, self-regularization), and lists the two references (Etter 2006, the sibling ThreePlaceIdentityOQ02 file). Opens the ThreePlaceIdentity.OQ01 namespace, opens ThreePlaceIdentity, and fixes the ambient type variable {U : Type}."
+    },
+    {
       "id": "tpi-oq01-sharp",
       "title": "Part I: The Sharp Round-Trip Identity",
       "startLine": 52,


### PR DESCRIPTION
## Summary

`three-place-identity-oq-01` was already at the enrichment quality target — 5 substantive `keyInsights`, a `mainTheorems` block, 2 `references`, a `crossReferences` entry to the parent, and a complete `conclusion` with 3 `openQuestions`. Per the size-guardrail/SKIP rule, no filler was added there.

The genuine gap: `meta.sections` started at line 52, leaving the module docstring (lines 1-51) uncovered — which poses OQ-01's question (is Foundation necessary or merely sufficient for the parent's Round-Trip Theorem?) and previews the sharp answer this file proves. Added a header section spanning lines 1-51.

## Test plan

- [x] `python3 -c "import json; json.load(...)"` — meta.json parses
- [x] `pnpm gallery:check-size` — all 4811 entries within the 60 KB cap
- [x] Verified lines 1-51 of `Proofs/ThreePlaceIdentityOQ01.lean` against the new section summary