### PR TITLE
Enrich sylvester-sequence-oq-01-oq-01: add missing cross-reference to answering follow-up oq-01-oq-02

### DIFF
--- a/src/data/proofs/sylvester-sequence-oq-01-oq-01/meta.json
+++ b/src/data/proofs/sylvester-sequence-oq-01-oq-01/meta.json
@@ -167,6 +167,11 @@
       "proofId": "basel-problem",
       "relationship": "Another exact reciprocal-series evaluation",
       "description": "Both establish an exact closed value for a series of reciprocals as a genuine limit; here the value is the Egyptian-fraction unit 1 rather than the Basel value π²/6."
+    },
+    {
+      "proofId": "sylvester-sequence-oq-01-oq-02",
+      "relationship": "Answers this entry's first open question with the requested quantitative bound",
+      "description": "Proves the doubly-exponential lower bound aₙ ≥ 2^(2^(n-1)) and combines it with this entry's exact error term 1/(a_{n+1}-1) to certify the explicit convergence rate 1 - ∑_{k≤n} 1/aₖ ≤ 1/2^(2ⁿ) — exactly the quantitative bound this entry's open question asks for."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Claimed target `sylvester-sequence-oq-01-oq-02` was already at the enrichment quality target — 4 substantive `keyInsights`, a `mainTheorems` block, `sections` covering the whole file, 2 `references`, and a complete `conclusion` with 2 `openQuestions`. Per the size-guardrail/SKIP rule, no filler was added there.

The one genuine gap: `sylvester-sequence-oq-01-oq-02` already cross-references `sylvester-sequence-oq-01-oq-01` and states explicitly that it "discharges exactly" that entry's first open question (a doubly-exponential lower bound combined with a quantitative error bound — verified against `oq-01-oq-01`'s literal `openQuestions[0]`, which matches word-for-word). The link was one-directional: `oq-01-oq-01` had no `crossReferences` entry pointing to `oq-01-oq-02`. Added the reciprocal link.

## Test plan

- [x] `python3 -c "import json; json.load(...)"` — meta.json parses
- [x] `pnpm gallery:check-size` — all 4811 entries within the 60 KB cap
- [x] Verified `oq-01-oq-01`'s literal `openQuestions[0]` text matches what `oq-01-oq-02` claims to answer before writing the cross-reference