### PR TITLE
Enrich szemeredi-regularity-oq-02-oq-02: split sections to 5 (3->5)

### DIFF
--- a/src/data/proofs/szemeredi-regularity-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/szemeredi-regularity-oq-02-oq-02/annotations.json
@@ -50,7 +50,7 @@
     "proofId": "szemeredi-regularity-oq-02-oq-02",
     "range": {
       "startLine": 92,
-      "endLine": 130
+      "endLine": 134
     },
     "type": "technique",
     "title": "Large case: normalising by |A||B| to invoke ε-regularity",
@@ -72,8 +72,8 @@
     "id": "szemeredifk-sharp-ann-smallcase",
     "proofId": "szemeredi-regularity-oq-02-oq-02",
     "range": {
-      "startLine": 131,
-      "endLine": 160
+      "startLine": 135,
+      "endLine": 164
     },
     "type": "insight",
     "title": "Small case: max beats sum — the factor-of-2 killer",
@@ -119,7 +119,7 @@
     "proofId": "szemeredi-regularity-oq-02-oq-02",
     "range": {
       "startLine": 226,
-      "endLine": 229
+      "endLine": 233
     },
     "type": "context",
     "title": "Axiom audit: foundational axioms only",

--- a/src/data/proofs/szemeredi-regularity-oq-02-oq-02/meta.json
+++ b/src/data/proofs/szemeredi-regularity-oq-02-oq-02/meta.json
@@ -84,18 +84,34 @@
     {
       "id": "sharp-pair-bound",
       "title": "Sharp Per-Pair Cut Error Bound",
-      "summary": "pair_cut_error_bound_sharp: for an ε-regular pair (P,Q) and A ⊆ P, B ⊆ Q, the cut error |e(A,B) − d(P,Q)|A||B|| ≤ ε|P||Q| — the tight constant, improving the parent's 2ε|P||Q|.",
+      "summary": "pair_cut_error_bound_sharp: for an ε-regular pair (P,Q) and A ⊆ P, B ⊆ Q, the cut error |e(A,B) − d(P,Q)|A||B|| ≤ ε|P||Q| — the tight constant, improving the parent's 2ε|P||Q|. Splits on whether A, B are 'large' (≥ ε fraction of their part): the large case invokes ε-regularity directly, the two symmetric small cases bound e and d|A||B| each by ε|P||Q| and close via |x−y| ≤ max(x,y).",
       "startLine": 71,
-      "endLine": 160,
+      "endLine": 164,
       "mathContext": "Large case: ε-regularity gives |d(A,B) − d(P,Q)| ≤ ε, so the error is ≤ ε|A||B| ≤ ε|P||Q|. Small case: both e and d|A||B| are ≤ |A||B| ≤ ε|P||Q|, and |x − y| ≤ max(x, y) for x, y ≥ 0 bounds the difference by ε|P||Q|."
     },
     {
       "id": "sharp-main",
-      "title": "Sharp Main Comparison and Corollary",
-      "summary": "szemeredi_implies_fk_sharp: every ε-regular partition is an ε-cut-approximation, summing the sharp per-pair bound over all |parts|² pairs. sharp_recovers_original: the ε result entails the parent's 2ε result. Closes with #check/#print axioms audits confirming reliance only on propext / Classical.choice / Quot.sound.",
-      "startLine": 162,
-      "endLine": 229,
-      "mathContext": "The partition decomposition e(A,B) = Σᵢⱼ e(A∩Pᵢ, B∩Pⱼ) and the parts-product identity Σᵢⱼ|Pᵢ||Pⱼ| = n² (both from the parent) convert per-pair ε|P||Q| into global ε·n²."
+      "title": "Sharp Main Comparison: szemeredi_implies_fk_sharp",
+      "summary": "szemeredi_implies_fk_sharp: every ε-regular partition is an ε-cut-approximation, summing the sharp per-pair bound over all |parts|² pairs via the partition decomposition and the parts-product identity Σᵢⱼ|Pᵢ||Pⱼ| = n².",
+      "startLine": 166,
+      "endLine": 206,
+      "mathContext": "|e(A,B) − Σᵢⱼ d(Pᵢ,Pⱼ)|A∩Pᵢ||B∩Pⱼ|| ≤ Σᵢⱼ ε|Pᵢ||Pⱼ| = ε·n², via edge_count_partition_sum and parts_product_sum_eq_card_sq."
+    },
+    {
+      "id": "sharp-recovers-original",
+      "title": "Corollary: sharp_recovers_original",
+      "summary": "sharp_recovers_original: since ε ≤ 2ε for ε ≥ 0, the sharp ε-cut-approximation entails the parent's 2ε-cut-approximation, so szemeredi_implies_fk_sharp strictly generalizes szemeredi_implies_fk.",
+      "startLine": 208,
+      "endLine": 223,
+      "mathContext": "eps · n² ≤ 2 · eps · n² for eps, n² ≥ 0, so an ε-cut-approximation is automatically a 2ε-cut-approximation."
+    },
+    {
+      "id": "closing-checks-and-axioms",
+      "title": "Closing Checks and Axiom Audit",
+      "summary": "#check confirms both main theorems typecheck; end of namespace; #print axioms on all three theorems (pair_cut_error_bound_sharp, szemeredi_implies_fk_sharp, sharp_recovers_original) substantiates the 0-axiom claim.",
+      "startLine": 225,
+      "endLine": 233,
+      "mathContext": "Dependency set = {propext, Classical.choice, Quot.sound} for all three theorems — no sorryAx, no axiom declarations, no native_decide."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for szemeredi-regularity-oq-02-oq-02 (quality 96 per find-targets.ts breakdown — the only gap was `sections` at 3 of the 5 needed for max score).

The original 3 sections bundled multiple declarations together:
- "Sharp Main Comparison and Corollary" (162-229) covered both `szemeredi_implies_fk_sharp` and `sharp_recovers_original` plus the closing checks/axiom audit.

Split into the 5 real declaration boundaries in the file:
1. header (1-70) — unchanged
2. sharp-pair-bound (71-164) — the `pair_cut_error_bound_sharp` theorem
3. sharp-main (166-206) — `szemeredi_implies_fk_sharp`
4. sharp-recovers-original (208-223) — the `sharp_recovers_original` corollary
5. closing-checks-and-axioms (225-233) — `#check`/`#print axioms` block

While re-anchoring against the Lean source, found and fixed two genuine coverage gaps (both pre-existing, not introduced by the split):
- Section 2 previously ended at line 160, but the theorem's proof (the "A small" case) actually continues through line 164 — the last 4 lines were unlabeled. Extended to 164.
- The old trailing section ended at line 229, but the file's closing `#print axioms` statements run through line 233. Extended to 233.
- Matching annotation fixes: `szemeredifk-sharp-ann-largecase` extended 130→134 and `szemeredifk-sharp-ann-smallcase` extended 131-160→135-164 (matching the corrected large/small case boundary at line 134/135), and `szemeredifk-sharp-ann-axioms` extended 229→233.

No filler: annotations (6, all with mathContext/significance/relatedConcepts), keyInsights (5), conclusion (summary+implications+2 openQuestions), crossReferences, and references were already at target and untouched.

Verified: both JSON files parse; `pnpm build`'s gallery-data step shows no new annotation-validator errors for this entry (one pre-existing warning at line 226 — a `#check` statement isn't a recognized construct anchor — is unchanged from before this PR).