### PR TITLE
Enrich sperner-mathlib4-oq-02: add missing cross-reference to follow-up oq-02-oq-04

### DIFF
--- a/src/data/proofs/sperner-mathlib4-oq-02/meta.json
+++ b/src/data/proofs/sperner-mathlib4-oq-02/meta.json
@@ -100,6 +100,10 @@
     {
       "targetId": "sperner-ndim",
       "relationship": "n-dimensional Sperner via the Freudenthal triangulation, the higher-dimensional door-counting setting."
+    },
+    {
+      "targetId": "sperner-mathlib4-oq-02-oq-04",
+      "relationship": "Follow-up entry: constructs the positive odd boundary seed this obstruction result showed could not come from any unsigned door count — the hemisphere sign-degree, an oriented ZMod-2 count read off the antipodal fundamental domain, proved odd for every hexagon labelling."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary

Claimed target `sperner-mathlib4-oq-02-oq-04` was already at the enrichment quality target — 4 substantive `keyInsights`, `sections` covering the whole 147-line file, 5 annotations with full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`, 4 `references`, 4 `crossReferences` to its own family, and a complete `conclusion` with 2 `openQuestions`. Per the size-guardrail/SKIP rule, no filler was added there.

The one genuine gap: `sperner-mathlib4-oq-02-oq-04` already cross-references `sperner-mathlib4-oq-02` as its `parent` (this follow-up constructs the positive odd boundary seed — the hemisphere sign-degree — that the parent's obstruction result showed could not come from any unsigned door count), but the link was one-directional. Added the reciprocal link on `sperner-mathlib4-oq-02`.

## Test plan

- [x] `python3 -c "import json; json.load(...)"` — meta.json parses
- [x] `pnpm gallery:check-size` — all 4811 entries within the 60 KB cap
- [x] Verified both entries' actual content/description before writing the cross-reference text