### PR TITLE
Enrich stars-and-bars-weak-compositions-oq-03: add missing header section (uncovered lines 1-48)

### DIFF
--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-03/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-03/meta.json
@@ -77,6 +77,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header: The Weak/Positive Duality and the ±1 Bijection",
+      "startLine": 1,
+      "endLine": 48,
+      "mathContext": "$g\\,i = f\\,i + 1$: adding $1$ to each of the $k$ parts of a weak composition of $m$ gives a positive composition of $m+k$; the count of positive compositions of $n$ into $k$ parts is $\\binom{n-1}{k-1}$.",
+      "summary": "Imports the parent StarsAndBarsWeakCompositions file and states the module docstring: defines weak and positive compositions, states the classical ±1 shift duality between them, previews the explicit bijection positiveCompositionEquivWeak and the resulting count C(n−1,k−1) for 0 < k ≤ n, and notes what this adds over the parent (which counts only weak compositions) — both the positive-composition tuple count and this explicit shift equivalence are absent from Mathlib. Opens Finset, enters the StarsAndBars namespace, and fixes the ambient variables {k n : ℕ}."
+    },
+    {
       "id": "the-shift-arithmetic",
       "title": "The Arithmetic of the Per-Part Shift",
       "startLine": 49,


### PR DESCRIPTION
## Summary

`stars-and-bars-weak-compositions-oq-03` was already at the enrichment quality target — 4 substantive `keyInsights`, 2 `crossReferences`, and a complete `conclusion` with 2 `openQuestions`. Per the size-guardrail/SKIP rule, no filler was added there.

The genuine gap: `meta.sections` started at line 49, leaving the module docstring (lines 1-48) uncovered — which defines weak vs. positive compositions, states the classical ±1 shift duality, and previews the explicit bijection this file constructs. Added a header section spanning lines 1-48.

## Test plan

- [x] `python3 -c "import json; json.load(...)"` — meta.json parses
- [x] `pnpm gallery:check-size` — all 4811 entries within the 60 KB cap
- [x] Verified lines 1-48 of `Proofs/StarsAndBarsWeakCompositionsOQ03.lean` against the new section summary