### PR TITLE
audit: erdos-52 — issues-fixed (phantom axiom labels repaired)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14273,9 +14273,9 @@
     },
     "erdos-52": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:37Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T22:00:12Z",
+      "result": "issues-fixed"
     },
     "erdos-52-oq-02": {
       "auditCount": 1,


### PR DESCRIPTION
## Audit Result

**Proof**: erdos-52
**Result**: issues-fixed

Fixed via #42650: `overview.proofStrategy` and 5 of 8 `sections[]` entries falsely called doc-comment commentary and fully-proved theorems "axiomatized"/"Axiomatizes", contradicting the honest top-level `assumptions` (0 axioms) and several sections' own `summary` fields.

Tracker updated: auditCount 4→5, result clean→issues-fixed.

---
Discovered during gallery integrity audit.