### PR TITLE
Enrich sum-of-kth-powers-oq-04: add missing cross-reference to orthogonal sibling oq-05

### DIFF
--- a/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
@@ -124,6 +124,11 @@
       "targetId": "sum-of-kth-powers-oq-02",
       "relationship": "related",
       "description": "The Euler–Maclaurin machinery underlying this entry is the classical bridge from power sums to the Riemann zeta function; OQ-02 pushes the parent's power sums to non-integer exponents and analytic continuation, the regime where these same asymptotics govern the partial sums of ζ."
+    },
+    {
+      "targetId": "sum-of-kth-powers-oq-05",
+      "relationship": "related",
+      "description": "The orthogonal modular face of the same power-sum family: where this entry gives the n→∞ asymptotic ∑ iᵏ/n^{k+1} → 1/(k+1), OQ-05 gives the exact finite-field congruence ∑_{x∈𝔽_q} xᵏ = −1 iff (q−1)∣k — an integer/asymptotic closed form versus a Fermat-little-theorem congruence."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Claimed target `sum-of-kth-powers-oq-05` was already at the enrichment quality target — 4 substantive `keyInsights`, 7 annotations with full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`, `sections` covering the whole file, 2 `references`, and a complete `conclusion` with 2 `openQuestions`. Per the size-guardrail/SKIP rule, no filler was added there.

The one genuine gap: `sum-of-kth-powers-oq-05` already cross-references `sum-of-kth-powers-oq-04` as the "orthogonal" asymptotic counterpart in its own description (this entry gives the n→∞ asymptotic ∑ iᵏ/n^{k+1} → 1/(k+1); oq-05 gives the exact finite-field congruence ∑ xᵏ = −1 iff (q−1)∣k), but the link was one-directional. Added the reciprocal link on `oq-04`.

## Test plan

- [x] `python3 -c "import json; json.load(...)"` — meta.json parses
- [x] `pnpm gallery:check-size` — all 4811 entries within the 60 KB cap
- [x] Verified both entries' actual content/description before writing the cross-reference text