### PR TITLE
Enrich triangular-reciprocals-oq-02-oq-04: add missing header section (uncovered lines 1-49)

### DIFF
--- a/src/data/proofs/triangular-reciprocals-oq-02-oq-04/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-02-oq-04/meta.json
@@ -81,6 +81,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header: The Rate-of-Convergence Question and Its Answer",
+      "startLine": 1,
+      "endLine": 49,
+      "mathContext": "$\\left|\\sum_{n=1}^{\\infty}\\tfrac{1}{n(n+k)} - S_N(k)\\right| = \\tfrac{1}{k}(H_{N+k}-H_N) \\le \\tfrac{1}{N+1}$, uniformly in $k$.",
+      "summary": "Module docstring: states the parent's closed form ∑ 1/(n(n+k)) = H_k/k and its partial-sum form, quotes the parent's fourth open question on the rate of convergence verbatim, explains the mathematical content (the error is exactly (1/k)(H_{N+k}-H_N), and the new ingredient is the uniform tail bound H_{N+k}-H_N ≤ k/(N+1) whose k cancels against the 1/k prefactor), and lists all 8 results. Imports Mathlib and the parent TriangularReciprocalsOQ02 file, opens Finset/BigOperators/Filter/Topology/Real and the parent's TriangularReciprocalsHarmonic namespace, and enters the TriangularReciprocalsOQ02OQ04 namespace."
+    },
+    {
       "id": "harmonic-diff",
       "title": "Harmonic Tail Difference: Nonnegativity and the k/(N+1) Bound",
       "startLine": 50,


### PR DESCRIPTION
## Summary

`triangular-reciprocals-oq-02-oq-04` was already at the enrichment quality target — 5 substantive `keyInsights`, 3 `crossReferences` (all already reciprocated by the related entries), and a complete `conclusion` with 2 `openQuestions`. Per the size-guardrail/SKIP rule, no filler was added there.

The genuine gap: `meta.sections` started at line 50, leaving the module docstring (lines 1-49) uncovered — which quotes the parent's fourth open question verbatim and explains the uniform-in-k tail bound this file proves. Added a header section spanning lines 1-49.

## Test plan

- [x] `python3 -c "import json; json.load(...)"` — meta.json parses
- [x] `pnpm gallery:check-size` — all 4811 entries within the 60 KB cap
- [x] Verified lines 1-49 of `Proofs/TriangularReciprocalsOQ02OQ04.lean` against the new section summary