### PR TITLE
Enrich shannon-source-coding-wip-01: add missing cross-references to follow-ups oq-01/oq-02

### DIFF
--- a/src/data/proofs/shannon-source-coding-wip-01/meta.json
+++ b/src/data/proofs/shannon-source-coding-wip-01/meta.json
@@ -131,6 +131,16 @@
       "targetId": "shannon-entropy",
       "relationship": "complements",
       "description": "ShannonEntropy proves subadditivity H(X,Y) ≤ H(X)+H(Y); this file proves the equality case for independent (product) distributions"
+    },
+    {
+      "targetId": "shannon-source-coding-wip-01-oq-01",
+      "relationship": "extended-by",
+      "description": "Follow-up entry: iterates this file's pairwise additivity along the tuple recursion Fin.consEquiv to the n-fold i.i.d. product, proving H(p^⊗n) = n·H(p) — discharges this entry's first open question"
+    },
+    {
+      "targetId": "shannon-source-coding-wip-01-oq-02",
+      "relationship": "extended-by",
+      "description": "Follow-up entry: proves the converse — additivity H(pXY) = H(pX)+H(pY) forces pXY to be the product distribution pX ⊗ pY — discharges this entry's second open question"
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
## Summary
Claimed target `shannon-source-coding-wip-01-oq-01` was already at quality target (5 full-depth annotations covering the whole 124-line file, 4 keyInsights, complete conclusion with implications and 2 open questions, sections covering the whole file, crossReferences all verified against the gallery). No filler was warranted there.

The genuine gap found instead: both follow-up entries link back to their parent `shannon-source-coding-wip-01`:
- `shannon-source-coding-wip-01-oq-01` iterates the parent's pairwise additivity to the n-fold i.i.d. product (discharging the parent's first open question)
- `shannon-source-coding-wip-01-oq-02` proves the converse (discharging the parent's second open question)

...but the parent's own `crossReferences` only pointed outward (to `shannon-source-coding`, `shannon-entropy`) — the link to its own follow-ups was missing. This PR adds the two reciprocal `extended-by` cross-references on the parent.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — meta.json still valid JSON
- [x] Verified both target IDs (`shannon-source-coding-wip-01-oq-01`, `shannon-source-coding-wip-01-oq-02`) exist in the gallery and already link back to this parent
- [x] `pnpm build` gallery-data step ran clean over the change (unrelated `tsc: command not found` failure is a pre-existing worktree infra gap, not caused by this change)