### PR TITLE
Enrich stirling-formula-oq-03: add missing cross-references to its own answering children

### DIFF
--- a/src/data/proofs/stirling-formula-oq-03/meta.json
+++ b/src/data/proofs/stirling-formula-oq-03/meta.json
@@ -124,6 +124,16 @@
       "targetId": "stirling-formula-oq-02",
       "relationship": "sibling",
       "description": "Both extend the Stirling family; OQ-03 isolates the underlying Wallis product as an independent π-limit"
+    },
+    {
+      "targetId": "stirling-formula-oq-03-oq-01",
+      "relationship": "answered-by",
+      "description": "Directly answers this entry's first open question (rate of convergence): exhibits the explicit error bound π/2 − Wₙ ≤ π/(4(n+1)) for the partial Wallis products."
+    },
+    {
+      "targetId": "stirling-formula-oq-03-oq-02",
+      "relationship": "extended-by",
+      "description": "Uses this entry's Wallis limit to derive the central binomial asymptotic C(2n,n)·√(πn)/4ⁿ → 1, via the identity (4ⁿ/C(2n,n))² = Wₙ·(2n+1)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

`stirling-formula-oq-03` was already at the enrichment quality target — 4 substantive `keyInsights`, 5 annotations with full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`, `sections` covering the whole file, 2 `references`, and a complete `conclusion` with 2 `openQuestions`. Per the size-guardrail/SKIP rule, no filler was added there.

The genuine gap: both direct children already link back to this entry —
- `stirling-formula-oq-03-oq-01` answers this entry's first `openQuestions` item (rate of convergence) with an explicit bound π/2 − Wₙ ≤ π/(4(n+1))
- `stirling-formula-oq-03-oq-02` extends the Wallis limit to the central binomial asymptotic C(2n,n)·√(πn)/4ⁿ → 1

but the parent had no `crossReferences` pointing to either. Added both reciprocal links.

## Test plan

- [x] `python3 -c "import json; json.load(...)"` — meta.json parses
- [x] Verified both children's actual content/description before writing the cross-reference text (`pnpm gallery:check-size` unavailable — worktree was reaped mid-session and rebuilding `node_modules` wasn't warranted for a JSON-only change; file size ~5.9 KB, well under the 60 KB cap)