### PR TITLE
Enrich spectral-trace-det-eigenvalues-oq-02: cover the file's uncovered tail

### DIFF
--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-02/annotations.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-02/annotations.json
@@ -102,11 +102,11 @@
     "proofId": "spectral-trace-det-eigenvalues-oq-02",
     "range": {
       "startLine": 150,
-      "endLine": 196
+      "endLine": 208
     },
     "type": "concept",
     "title": "Concrete ℤ Witnesses",
-    "content": "Worked integer examples making the phenomena tangible. trace_mul_comm_cross_dim(_value): a 1×2 and a 2×1 matrix whose products A·B (1×1) and B·A (2×2) have different SIZES yet both trace 11 — the rectangular case in action. trace_mul_comm_noncomm_example with mul_comm_noncomm_example_ne and _value: a non-commuting pair (A·B ≠ B·A as matrices) whose two products nonetheless share trace 3 — equal traces do not imply equal products. trace_commutator_example: that pair's commutator A·B − B·A has trace 0, the general vanishing made concrete.",
+    "content": "Worked integer examples making the phenomena tangible. trace_mul_comm_cross_dim(_value): a 1×2 and a 2×1 matrix whose products A·B (1×1) and B·A (2×2) have different SIZES yet both trace 11 — the rectangular case in action. trace_mul_comm_noncomm_example with mul_comm_noncomm_example_ne and _value: a non-commuting pair (A·B ≠ B·A as matrices) whose two products nonetheless share trace 3 — equal traces do not imply equal products. trace_commutator_example: that pair's commutator A·B − B·A has trace 0, applying trace_commutator_eq_zero directly to close the file's proof content. After the namespace closes, six `#print axioms` commands check the five headline theorems plus the cross-dimension witness, machine-verifying the docstring's claim of no `sorry` and no axioms beyond `propext`/`Classical.choice`/`Quot.sound`.",
     "mathContext": "Cross-dim: $\\operatorname{tr}(AB)=\\operatorname{tr}(BA)=11$ with $AB\\in M_1,\\ BA\\in M_2$. Non-commuting: $AB\\neq BA$ but both trace $3$; $\\operatorname{tr}(AB-BA)=0$.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-02/meta.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-02/meta.json
@@ -107,8 +107,8 @@
       "id": "examples",
       "title": "Concrete Illustrations over ℤ",
       "startLine": 150,
-      "endLine": 196,
-      "summary": "trace_mul_comm_cross_dim(_value): a 1×2 / 2×1 pair with products of different sizes both of trace 11; trace_mul_comm_noncomm_example(_ne/_value): a non-commuting pair with A·B ≠ B·A but equal product-traces 3; trace_commutator_example: that pair's commutator has trace 0.",
+      "endLine": 208,
+      "summary": "trace_mul_comm_cross_dim(_value): a 1×2 / 2×1 pair with products of different sizes both of trace 11; trace_mul_comm_noncomm_example(_ne/_value): a non-commuting pair with A·B ≠ B·A but equal product-traces 3; trace_commutator_example: that pair's commutator has trace 0, applying trace_commutator_eq_zero directly. Closes the namespace, then six #print axioms commands on the five original theorems plus the cross-dimension witness confirm the file's opening claim — no sorry, no extra axioms beyond propext/Classical.choice/Quot.sound.",
       "mathContext": "$\\operatorname{tr}([1\\,2][3;4]) = \\operatorname{tr}([3;4][1\\,2]) = 11$."
     }
   ],


### PR DESCRIPTION
## Summary
The `examples` section/annotation stopped at line 196, cutting off the file's last theorem (`trace_commutator_example`, lines 194-199) mid-proof and leaving the closing `#print axioms` verification block (lines 200-208) completely uncovered by both `sections` and `annotations.json`.

Extended both the `sections` entry and the matching `annotations.json` entry to `endLine: 208`, and named the `#print axioms` block explicitly in the summary/content — it machine-checks the module docstring's own claim of "no sorry, no extra axioms," which was previously invisible to a reader working section-by-section.

No other gaps found: all 5 annotations already have `mathContext`/`significance`/`relatedConcepts`, `keyInsights` (4)/`conclusion`/`crossReferences` (2) were already at target, and the file is well under the size caps (~16.9 KB meta.json). No filler added.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` on both `meta.json` and `annotations.json`
- [x] Manually diffed the extended ranges (150→208) against the actual `.lean` file to confirm the tail content (`trace_commutator_example` proof + 6 `#print axioms` lines) is what's now covered
- [x] `pnpm build` gallery-data step ran clean over this entry (unrelated pre-existing errors on other entries, not caused by this change)