### PR TITLE
Enrich spectral-trace-det-eigenvalues-oq-02: add missing cross-reference to follow-up oq-02-oq-01

### DIFF
--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-02/meta.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-02/meta.json
@@ -122,6 +122,11 @@
       "targetId": "matrix-similarity-invariants-oq-01",
       "relationship": "related",
       "description": "Packages determinant, trace, characteristic polynomial, and (over an integral domain) the eigenvalue multiset into one unified similarity-invariants theorem, with similarity proved to be an equivalence relation. This entry reaches the same eigenvalue-multiset invariance (eigenvalues_units_conj) via a different route — as the bridge from cyclic-invariance-of-the-trace to the spectral picture of oq-01 — and adds the determinant-hypothesis (IsUnit P.det) form of similarity invariance that matrix-similarity-invariants-oq-01 does not state."
+    },
+    {
+      "targetId": "spectral-trace-det-eigenvalues-oq-02-oq-01",
+      "relationship": "extended-by",
+      "description": "Follow-up entry: answers this file's first open question by building the Frobenius/Hilbert–Schmidt inner product frobInner A B = tr(Aᵀ·B) from scratch and proving it satisfies the full InnerProductSpace.Core axioms — the trace-pairing symmetry ⟪A,B⟫ = ⟪B,A⟫ is exactly this file's cyclic invariance tr(AB) = tr(BA) specialised to A ↦ Aᵀ."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
`spectral-trace-det-eigenvalues-oq-02-oq-01` already links to this entry as its `extends` parent — it answers this file's first open question by constructing the Frobenius/Hilbert–Schmidt inner product `frobInner A B = tr(Aᵀ·B)` and proving the full `InnerProductSpace.Core` axiom set — but the link was one-directional. This adds the reciprocal `extended-by` crossReference on the parent.

The parent's second open question (characteristic polynomial as a complete similarity invariant for diagonalisable matrices with distinct eigenvalues) has no follow-up entry yet, so there's nothing to link there.

(Note: this PR and #42659 both touch `spectral-trace-det-eigenvalues-oq-02/meta.json` but in disjoint sections — `sections`/`annotations` there vs. `crossReferences` here — so they should merge without conflict in either order.)

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — meta.json still valid JSON
- [x] Verified `spectral-trace-det-eigenvalues-oq-02-oq-01` exists and its own `crossReferences` already points back to this parent