### PR TITLE
audit: erdos-524 tracker update (clean, 5th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14316,8 +14316,8 @@
     },
     "erdos-524": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:37Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T22:16:03Z",
       "result": "clean"
     },
     "erdos-525": {


### PR DESCRIPTION
Re-audited erdos-524 (round-robin re-serve, queue was fully drained: 4811/4811 audited, 0 issues).

Verified meta.json against Lean source:
- 22 theorems, 4 definitions, 1 axiom (`erdos_524_main`), 0 sorries, 322 lines — all match.
- The sole axiom `erdos_524_order_of_magnitude` packages the open Salem–Zygmund order-of-magnitude conjecture as `∃ f, (∀n, 0<f n) ∧ ∀ᵐ t, ∃ c₁ c₂ N₀, ∀ n≥N₀, c₁*f n ≤ M_n(t) ≤ c₂*f n`. Traced the existential scope: `f` is chosen independent of `t`, so a trivial witness like `f(n)=n` fails — Chung's i.o. upper bound `M_n ≤ C√(n/loglogn)` rules out `c₁·n ≤ M_n` holding for all large `n` a.e. Confirms this is a genuine non-vacuous open-conjecture packaging (contrast with erdos-523's `∧ True` vacuity, fixed in #42657/58).

Result: clean, no changes to meta.json needed. Only the audit-tracker.json bump is included here.