### PR TITLE
Enrich sum-of-divisors-oq-07: split sections to 5 (per-theorem)

### DIFF
--- a/src/data/proofs/sum-of-divisors-oq-07/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-07/meta.json
@@ -101,19 +101,35 @@
       "mathContext": "$\\sigma_k(p^i) = \\sum_{j\\le i} p^{jk} = \\tfrac{p^{k(i+1)}-1}{p^k-1}$."
     },
     {
-      "id": "prime-power",
-      "title": "Geometric Collapse and the Prime-Power Closed Form",
+      "id": "geom-collapse",
+      "title": "The Underlying Geometric Collapse",
       "startLine": 40,
+      "endLine": 51,
+      "summary": "geom_sigma_sum: (∑_{j<i+1} p^{jk})·(pᵏ−1) = p^{k(i+1)}−1 over ℤ, geom_sum_mul at base x = pᵏ re-indexed to the σₖ summand shape p^{jk} — the single collapse every later result reduces to.",
+      "mathContext": "$\\left(\\sum_{j<i+1} p^{jk}\\right)(p^k-1) = p^{k(i+1)}-1$."
+    },
+    {
+      "id": "prime-power",
+      "title": "Closed Form on a Prime Power, All k",
+      "startLine": 53,
       "endLine": 60,
-      "summary": "geom_sigma_sum (the geometric collapse (∑ p^{jk})·(pᵏ−1) = p^{k(i+1)}−1 over ℤ) and sigma_prime_pow_mul (the closed form σₖ(pⁱ)·(pᵏ−1) = p^{k(i+1)}−1 for every k).",
+      "summary": "sigma_prime_pow_mul: σₖ(pⁱ)·(pᵏ−1) = p^{k(i+1)}−1 for every exponent k, generalizing OQ-04's k = 1 case, by rewriting via sigma_apply_prime_pow and applying geom_sigma_sum.",
       "mathContext": "$(p^k-1)\\sigma_k(p^i) = p^{k(i+1)}-1$."
     },
     {
+      "id": "two-primes",
+      "title": "Closed Form on a Two-Prime Product pᵃqᵇ",
+      "startLine": 62,
+      "endLine": 78,
+      "summary": "sigma_two_primes_pow_mul: σₖ(pᵃqᵇ)·(pᵏ−1)(qᵏ−1) = (p^{k(a+1)}−1)(q^{k(b+1)}−1), splitting σₖ via multiplicativity on the coprime prime powers and assembling the two prime-power identities with linear_combination.",
+      "mathContext": "$\\sigma_k(p^aq^b)(p^k-1)(q^k-1) = (p^{k(a+1)}-1)(q^{k(b+1)}-1)$."
+    },
+    {
       "id": "factorization",
-      "title": "Two-Prime and General Factorization Forms",
-      "startLine": 61,
-      "endLine": 95,
-      "summary": "sigma_two_primes_pow_mul (the two-prime product law via multiplicativity) and sigma_mul_prod_primeFactors (the general closed geometric-product form over the full factorization).",
+      "title": "The General Closed Geometric-Product Form",
+      "startLine": 80,
+      "endLine": 93,
+      "summary": "sigma_mul_prod_primeFactors: the general closed geometric-product form σₖ(n)·∏_{p∣n}(pᵏ−1) = ∏_{p∣n}(p^{k(vₚ(n)+1)}−1) over the full factorization, collapsing Mathlib's product-of-sums into a product of closed quotients.",
       "mathContext": "$\\sigma_k(n)\\prod_{p\\mid n}(p^k-1) = \\prod_{p\\mid n}(p^{k(v_p(n)+1)}-1)$."
     }
   ],


### PR DESCRIPTION
Enrichment pass for sum-of-divisors-oq-07 (quality 96->100).

Split the 3-section structure (header, prime-power, factorization) into 5 sections at each theorem's real boundary: `header`, `geom-collapse` (geom_sigma_sum), `prime-power` (sigma_prime_pow_mul), `two-primes` (sigma_two_primes_pow_mul), `factorization` (sigma_mul_prod_primeFactors). This mirrors the file's existing 5-way annotations.json split exactly (same start/end lines), confirming the boundaries track real conceptual structure already recognized elsewhere in the file.

No other content changed; annotations, keyInsights (already 5), historicalContext, conclusion, and cross-references were already at target.