### PR TITLE
audit: erdos-267 — fix phantom axiom narrative

### DIFF
--- a/src/data/proofs/erdos-267/annotations.json
+++ b/src/data/proofs/erdos-267/annotations.json
@@ -103,7 +103,7 @@
     },
     "type": "concept",
     "title": "Series Convergence",
-    "content": "**axiom fibonacci_reciprocal_summable**:\n  Summable (n ↦ 1/F_n)\n\nThe series Σ 1/F_n converges because:\n- F_n ≈ φⁿ/√5 with φ > 1\n- 1/F_n ≈ √5/φⁿ\n- Σ 1/φⁿ is a convergent geometric series\n\nThe value is Σ 1/F_n ≈ 3.3598...",
+    "content": "Convergence of Σ 1/F_n is discussed in prose comments only — no axiom or theorem is declared in this file. The comments note that:\n- F_n ≈ φⁿ/√5 with φ > 1\n- 1/F_n ≈ √5/φⁿ\n- Σ 1/φⁿ is a convergent geometric series\n\nThe value is Σ 1/F_n ≈ 3.3598...",
     "mathContext": "Convergence follows from comparison with geometric series. The exact value involves complex formulas with q-series.",
     "significance": "key",
     "relatedConcepts": [
@@ -115,7 +115,7 @@
       "analysis",
       "convergence",
       "series",
-      "axiom"
+      "geometric-series"
     ]
   },
   {
@@ -127,7 +127,7 @@
     },
     "type": "concept",
     "title": "Solved Cases",
-    "content": "**axiom good_bicknell_hoggatt** (1974/1976):\n  Irrational (Σ 1/F_{2^n})\n\nThe first special case proved. Indices 2^n are very sparse.\n\n**axiom andre_jeannin** (1989):\n  Irrational (Σ 1/F_n)\n\nThe full reciprocal sum is irrational!\n\nUses transcendence theory and continued fractions.",
+    "content": "These historical results are cited in prose comments only — neither is formalized as an axiom or theorem in this file.\n\n**Good, Bicknell-Hoggatt** (1974/1976): Irrational (Σ 1/F_{2^n})\n\nThe first special case proved. Indices 2^n are very sparse.\n\n**André-Jeannin** (1989): Irrational (Σ 1/F_n)\n\nThe full reciprocal sum is irrational!\n\nUses transcendence theory and continued fractions.",
     "mathContext": "André-Jeannin's result is stronger than what Erdős asked. It shows even c = 1 (all indices) gives irrationality.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-267/meta.json
+++ b/src/data/proofs/erdos-267/meta.json
@@ -48,7 +48,7 @@
       "erdos_267_open by classical EM (decidability of open conjecture)",
       "pow_two_series_first_terms computation via native_decide"
     ],
-    "axiomCount": 1,
+    "axiomCount": 0,
     "prerequisites": [
       "Fibonacci sequence and recurrence relations",
       "Golden ratio and Binet's formula",
@@ -66,7 +66,7 @@
     "historicalContext": "This problem connects to a long tradition of irrationality questions in number theory going back to Euler's work on $e$ and Lambert's proof that $\\pi$ is irrational (1761). Erdős posed it as part of his broader program asking when 'natural' arithmetic series sum to irrational numbers.\n\nGood (1974) proved the first special case: $\\sum 1/F_{2^n}$ is irrational, using the rapid growth of $F_{2^n}$ and a clever continued fraction argument. Bicknell and Hoggatt (1976) extended this to related subsequences with indices $2^n k$.\n\nThe breakthrough came when André-Jeannin (1989) proved the full sum $\\sum 1/F_n$ is irrational using techniques from transcendence theory, specifically Padé approximation and the connection between Fibonacci numbers and the theory of $q$-series. Paradoxically, this proves the $c = 1$ case (all indices, weakest sparsity condition) while the general $c > 1$ case remains open — a situation where the strongest-looking result is proved but weaker-looking intermediate cases resist proof.\n\nThe problem is part of a cluster of Erdős irrationality conjectures including #250 ($\\sum \\sigma(n)/2^n$, solved by Nesterenko 1996) and #259 ($\\sum \\mu(n)^2 n / 2^n$, solved by Chen-Ruzsa).",
     "problemStatement": "Let F_n be the Fibonacci sequence (F₁ = F₂ = 1, F_{n+1} = F_n + F_{n-1}). If n₁ < n₂ < ... is an infinite sequence with n_{k+1}/n_k ≥ c > 1, must Σ 1/F_{n_k} be irrational? Erdős also asked if n_k/k → ∞ might suffice.",
     "text": "If n₁ < n₂ < ... is a sequence with n_{k+1}/n_k ≥ c > 1, must Σ 1/F_{n_k} be irrational? PARTIALLY SOLVED: Special cases proved, general conjecture OPEN.",
-    "proofStrategy": "The formalization defines Fibonacci growth, the golden ratio, and series convergence. Verified theorems include Fibonacci values and the golden ratio bound. The solved cases (2^n indices and full sum) are recorded as axioms. The main conjecture and weaker variant are formalized as open problems.",
+    "proofStrategy": "The formalization defines Fibonacci growth, the golden ratio, and series convergence. Verified theorems include Fibonacci values and the golden ratio bound. The solved cases (2^n indices and full sum) are described in prose comments only — they are not formalized as axioms or theorems in this file. The main conjecture and weaker variant are formalized as open Prop statements.",
     "keyInsights": [
       "Fibonacci values F₁ through F₁₂ verified by rfl",
       "goldenRatio_gt_one verified: φ = (1+√5)/2 > 1",
@@ -119,18 +119,18 @@
     {
       "id": "convergence",
       "title": "Series Convergence",
-      "summary": "fibonacci_reciprocal_summable axiom, comparison with geometric series",
+      "summary": "Convergence via comparison with geometric series, discussed in prose comments only — no axiom or theorem declared",
       "startLine": 96,
       "endLine": 107,
-      "mathContext": "Axiomatized: fibonacci_reciprocal_summable axiom, comparison with geometric series"
+      "mathContext": "Not formalized: convergence argument (comparison with geometric series) is prose only, with no corresponding declaration"
     },
     {
       "id": "solved-cases",
       "title": "Solved Cases",
-      "summary": "good_bicknell_hoggatt (2^n indices), andre_jeannin (full sum) axioms",
+      "summary": "Good/Bicknell-Hoggatt (2^n indices) and André-Jeannin (full sum) results are cited in prose comments; not formalized as declarations in this file",
       "startLine": 108,
       "endLine": 129,
-      "mathContext": "good_bicknell_hoggatt ($2^{n}$ indices), andre_jeannin (full sum) axioms"
+      "mathContext": "Not formalized: Good/Bicknell-Hoggatt ($2^{n}$ indices) and André-Jeannin (full sum) are cited in comments only, with no corresponding axiom or theorem"
     },
     {
       "id": "main-conjecture",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-267 (Erdős Problem #267 — Irrationality of Fibonacci Reciprocal Sums)

## Problem

`meta.json`'s `meta.axiomCount` was `1`, contradicting `leanFile.axiomCount` (`0`),
the actual source file (`Proofs/Erdos267Problem.lean` has zero `axiom`
declarations), and its own `assumptions` text ("No mathematical axioms and 0
sorries... leanFile.axiomCount remains 0").

Separately, `proofStrategy`, the `solved-cases`/`convergence` sections in
`meta.json`, and two entries in `annotations.json` presented the historical
Good/Bicknell-Hoggatt and André-Jeannin results as formalized axioms named
`good_bicknell_hoggatt`, `andre_jeannin`, and `fibonacci_reciprocal_summable`.
None of these identifiers exist anywhere in the Lean file — the corresponding
line ranges (96–129) are prose `/- ... -/` comments only, with no axiom or
theorem declaration.

## Evidence

```
$ grep -n "good_bicknell_hoggatt\|andre_jeannin\|fibonacci_reciprocal_summable\|^axiom" proofs/Proofs/Erdos267Problem.lean
(no matches)
```

`leanFile.axiomCount: 0` and `leanFile.sorries: 0` in meta.json are correct and
already matched the file; only the top-level `meta.axiomCount` and the
narrative fields were wrong.

## Fix

- `meta.axiomCount`: `1` → `0`
- `proofStrategy`: removed the false "recorded as axioms" claim; now discloses
  the solved cases are described in prose comments only
- `sections[id=convergence]` and `sections[id=solved-cases]`: removed phantom
  axiom names, reworded to state these results are not formalized
- `annotations.json`: rewrote the two annotations that rendered
  `**axiom good_bicknell_hoggatt**`, `**axiom andre_jeannin**`, and
  `**axiom fibonacci_reciprocal_summable**` as if they were real declarations

No changes to the Lean source, badge, or status — this is a documentation
accuracy fix only.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)