### PR TITLE
audit: erdos-261 — mark issues-fixed (5th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12091,9 +12091,9 @@
     },
     "erdos-261": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:37Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T22:31:38Z",
+      "result": "issues-fixed"
     },
     "erdos-262": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Tracker update for the erdos-261 audit (see #42675 for the actual meta.json fix).

Continuum-representation (Part 3) prose in meta.json overclaimed the
honestly-flagged placeholder theorems (`ErdosProblem261_continuum`,
`ErdosProblem261_two_reps`); fixed there. This PR just records the audit
result.