### PR TITLE
audit: erdos-506 — mark clean (5th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14172,8 +14172,8 @@
     },
     "erdos-506": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:38Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T22:34:54Z",
       "result": "clean"
     },
     "erdos-507": {


### PR DESCRIPTION
## Audit Result: Clean

**Proof**: erdos-506
**Result**: No issues found.

## Verification

- meta.axiomCount (0) / lf.axiomCount (0) match actual file (0 `axiom` declarations).
- meta.sorries (0) / lf.sorries (0) match actual file. The `sorry` grep hit from quickcheck is inside a docstring ("no `sorry`, no `axiom`"), not a real declaration.
- theoremCount (9) and definitionCount (9) match the file exactly.
- `minCircles` is explicitly disclosed in both the Lean docstring and meta.json's `assumptions` field as a degenerate placeholder (proven via `minCircles_eq_zero`), not silently presented as the true extremal quantity.
- Elliott's theorem and Segre's counterexample are correctly recorded as prose commentary, not axioms or theorems — consistent with `proofStrategy` and section `mathContext` fields.
- Badge `wip` / status `axiomatized` is appropriate for this Tier C/D infrastructure file.

Bumps `auditCount` 4→5 and `lastAudited` in the tracker.

---
Discovered during gallery integrity audit.