### PR TITLE
Research: erdos-64-wip-01 - cycle-spectrum rung: min degree d forces d-1 distinct cycle lengths

### DIFF
--- a/proofs/Proofs/Erdos64Problem.lean
+++ b/proofs/Proofs/Erdos64Problem.lean
@@ -685,6 +685,141 @@ theorem hasMinDegree_containsCycleLength_ge
   obtain ⟨v, c, hc, hlen⟩ := hasMinDegree_exists_cycle_length_ge G hd hdeg
   exact ⟨c.length, hlen, isCycle_containsCycleLength G c hc⟩
 
+/- ## Cycle-Spectrum Counting
+
+The longest-path engine yields more than a single long cycle: every neighbour
+of the start vertex `v₀` trapped at an index `≥ 2` closes into its own cycle,
+and distinct indices give cycles of **distinct lengths**.  Since at most one of
+the `≥ d` trapped indices equals `1`, minimum degree `d` forces at least
+`d - 1` distinct cycle lengths.
+
+This is the elementary end of the *cycle spectrum* view of Problem 64: the
+Liu–Montgomery resolution for large minimum degree works by showing the cycle
+spectrum is dense enough to hit a power of two.  The rung below is the linear
+(in `d`) spectrum-size guarantee; the open core is whether the spectrum of a
+min-degree-`3` graph must meet `{2^k : k ≥ 2}`.
+-/
+
+/-- **Cycle-spectrum rung: minimum degree `d ≥ 2` forces at least `d - 1` distinct
+cycle lengths.**  Each neighbour of the start of a maximum-length path sits at a
+distinct positive index; closing the prefix at any index `≥ 2` (all but at most
+one of them) gives a cycle whose length is that index plus one, so distinct
+indices produce distinct lengths. -/
+theorem hasMinDegree_card_cycle_lengths
+    {W : Type*} [Fintype W] [DecidableEq W] [Nonempty W]
+    (G : SimpleGraph W) [DecidableRel G.Adj] {d : ℕ} (hd : 2 ≤ d)
+    (hdeg : HasMinDegree G d) :
+    ∃ S : Finset ℕ, d - 1 ≤ S.card ∧
+      ∀ k ∈ S, 3 ≤ k ∧ ∃ (v : W) (c : G.Walk v v), c.IsCycle ∧ c.length = k := by
+  classical
+  -- a path of maximum length (the engine of the two preceding sections)
+  have hne : ({n : ℕ | ∃ (a : W) (b : W) (q : G.Walk a b), q.IsPath ∧ q.length = n}).Nonempty :=
+    ⟨0, Classical.arbitrary W, Classical.arbitrary W, Walk.nil, Walk.IsPath.nil, rfl⟩
+  have hbdd : BddAbove {n : ℕ | ∃ (a : W) (b : W) (q : G.Walk a b), q.IsPath ∧ q.length = n} := by
+    refine ⟨Fintype.card W, ?_⟩
+    rintro n ⟨a, b, q, hq, rfl⟩
+    exact hq.length_lt.le
+  obtain ⟨v₀, u, p, hp, hplen⟩ := Nat.sSup_mem hne hbdd
+  have hmax : ∀ (a b : W) (q : G.Walk a b), q.IsPath → q.length ≤ p.length := by
+    intro a b q hq
+    rw [hplen]
+    exact le_csSup hbdd ⟨a, b, q, hq, rfl⟩
+  -- maximality traps every neighbour of `v₀` on `p`
+  have hnbr : ∀ w : W, G.Adj v₀ w → w ∈ p.support := by
+    intro w hw
+    by_contra hws
+    have hcons : (Walk.cons hw.symm p).IsPath := (Walk.cons_isPath_iff _ _).mpr ⟨hp, hws⟩
+    have := hmax _ _ _ hcons
+    rw [Walk.length_cons] at this
+    omega
+  set idx : W → ℕ := fun w => if hw : w ∈ p.support then (p.takeUntil w hw).length else 0
+    with hidx
+  have hidx_get : ∀ w (hw : w ∈ p.support), p.getVert (idx w) = w := by
+    intro w hw
+    simp only [hidx, dif_pos hw]
+    exact Walk.getVert_length_takeUntil hw
+  set T : Finset ℕ := (G.neighborFinset v₀).image idx with hT
+  have hTcard : d ≤ T.card := by
+    rw [hT, Finset.card_image_of_injOn]
+    · exact hdeg v₀
+    · intro w₁ hw₁ w₂ hw₂ hww
+      have h₁ : G.Adj v₀ w₁ := (G.mem_neighborFinset v₀ w₁).mp (Finset.mem_coe.mp hw₁)
+      have h₂ : G.Adj v₀ w₂ := (G.mem_neighborFinset v₀ w₂).mp (Finset.mem_coe.mp hw₂)
+      calc w₁ = p.getVert (idx w₁) := (hidx_get w₁ (hnbr _ h₁)).symm
+        _ = p.getVert (idx w₂) := by rw [hww]
+        _ = w₂ := hidx_get w₂ (hnbr _ h₂)
+  have hpos : ∀ n ∈ T, 1 ≤ n := by
+    intro n hn
+    rw [hT] at hn
+    obtain ⟨w, hw, rfl⟩ := Finset.mem_image.mp hn
+    have hadj : G.Adj v₀ w := (G.mem_neighborFinset v₀ w).mp hw
+    rcases Nat.eq_zero_or_pos (idx w) with h0 | h1
+    · exfalso
+      have hgw := hidx_get w (hnbr _ hadj)
+      rw [h0, Walk.getVert_zero] at hgw
+      exact hadj.ne hgw
+    · exact h1
+  -- at most one trapped index equals `1`, so `≥ d - 1` indices are `≥ 2`
+  have hsub2 : T ⊆ insert 1 (T.filter (fun n => 2 ≤ n)) := by
+    intro n hn
+    have h1 := hpos n hn
+    rcases Nat.lt_or_ge n 2 with h | h
+    · have hn1 : n = 1 := by omega
+      simp [hn1]
+    · exact Finset.mem_insert_of_mem (Finset.mem_filter.mpr ⟨hn, h⟩)
+  have hcard2 : d ≤ (T.filter (fun n => 2 ≤ n)).card + 1 := by
+    have hle := Finset.card_le_card hsub2
+    have hins := Finset.card_insert_le 1 (T.filter (fun n => 2 ≤ n))
+    omega
+  -- the spectrum: each surviving index `n` contributes the length `n + 1`
+  refine ⟨(T.filter (fun n => 2 ≤ n)).image (· + 1), ?_, ?_⟩
+  · rw [Finset.card_image_of_injective _ (add_left_injective 1)]
+    omega
+  · intro k hk
+    obtain ⟨n, hnmem, rfl⟩ := Finset.mem_image.mp hk
+    obtain ⟨hnT, hn2⟩ := Finset.mem_filter.mp hnmem
+    refine ⟨by omega, ?_⟩
+    -- the neighbour `y` sitting at index `n`
+    rw [hT] at hnT
+    obtain ⟨y, hyN, hyn⟩ := Finset.mem_image.mp hnT
+    have hay : G.Adj v₀ y := (G.mem_neighborFinset v₀ y).mp hyN
+    have hys : y ∈ p.support := hnbr y hay
+    have hyn' : (p.takeUntil y hys).length = n := by
+      rw [← hyn]; simp only [hidx, dif_pos hys]
+    -- close the prefix at `y` through the edge `y — v₀` (needs only `2 ≤ n`)
+    refine ⟨v₀, Walk.cons hay (p.takeUntil y hys).reverse, ?_, ?_⟩
+    · rw [Walk.cons_isCycle_iff]
+      refine ⟨(hp.takeUntil hys).reverse, ?_⟩
+      intro hmem
+      rw [Walk.edges_reverse, List.mem_reverse] at hmem
+      -- an edge of a path through its start must be the first edge …
+      have hsnd : y = (p.takeUntil y hys).snd := (hp.takeUntil hys).eq_snd_of_mem_edges hmem
+      -- … but `y` is the endpoint of the prefix, at index `n ≥ 2`
+      have h1 : (p.takeUntil y hys).getVert 1 =
+          (p.takeUntil y hys).getVert (p.takeUntil y hys).length := by
+        rw [Walk.getVert_length]
+        exact hsnd.symm
+      have := (hp.takeUntil hys).getVert_injOn
+        (by simp only [Set.mem_setOf_eq]; omega)
+        (by simp only [Set.mem_setOf_eq]; omega) h1
+      omega
+    · rw [Walk.length_cons, Walk.length_reverse, hyn']
+
+/-- Restatement in the `ContainsCycleLength` predicate: minimum degree `d ≥ 2`
+yields at least `d - 1` distinct realized cycle lengths, each `≥ 3`.  Problem 64's
+open core asks whether, at minimum degree `3`, this spectrum must contain a power
+of two `2^k` with `k ≥ 2`; Liu–Montgomery answer YES once the minimum degree
+(hence, by this rung, the spectrum) is large enough. -/
+theorem hasMinDegree_card_containsCycleLength
+    {W : Type*} [Fintype W] [DecidableEq W] [Nonempty W]
+    (G : SimpleGraph W) [DecidableRel G.Adj] {d : ℕ} (hd : 2 ≤ d)
+    (hdeg : HasMinDegree G d) :
+    ∃ S : Finset ℕ, d - 1 ≤ S.card ∧ ∀ k ∈ S, 3 ≤ k ∧ ContainsCycleLength G k := by
+  obtain ⟨S, hcard, hS⟩ := hasMinDegree_card_cycle_lengths G hd hdeg
+  refine ⟨S, hcard, fun k hk => ?_⟩
+  obtain ⟨h3, v, c, hc, hlen⟩ := hS k hk
+  exact ⟨h3, hlen ▸ isCycle_containsCycleLength G c hc⟩
+
 /- ## Known Cycle Results -/
 
 /- 

--- a/research/problems/erdos-64-wip-01/knowledge.md
+++ b/research/problems/erdos-64-wip-01/knowledge.md
@@ -179,3 +179,39 @@ zero warnings. File 607→732 lines, theorems 12→14 (public).
   bridge, parity (even cycle, min-deg 3), Dirac rung (length ≥ d+1). Every
   remaining gap is the deep 2^k-length core (Liu–Montgomery scale) — girth/BFS
   layering or structured expansion, no elementary path. STAND DOWN.
+
+## Session 2026-07-23 (researcher-1) — Cycle-spectrum counting rung: min degree d ⇒ ≥ d−1 distinct cycle lengths
+
+**Mode**: REVISIT of a "fully saturated" verdict — found a genuine counting gap the
+verdict missed (precedent: the even-cycle layer was also found post-"SATURATED").
+**Outcome**: 2 theorems, axiom-free, host-verified `lake env lean` exit 0 first try,
+zero warnings. File 732→867 lines, theorems 14→16.
+
+- `hasMinDegree_card_cycle_lengths` — min degree `d ≥ 2` forces
+  `∃ S : Finset ℕ, d - 1 ≤ S.card ∧ ∀ k ∈ S, 3 ≤ k ∧ (explicit IsCycle of length k)`.
+  The Dirac session closed the prefix only at the MAX trapped index; here EVERY
+  index `n ≥ 2` closes (same sub-proof, parametrized), and distinct indices give
+  distinct lengths `n+1`. Spectrum = `(T.filter (2 ≤ ·)).image (· + 1)`.
+- `hasMinDegree_card_containsCycleLength` — restatement via
+  `isCycle_containsCycleLength` + `hlen ▸`.
+
+### New counting pieces (beyond the reused engine)
+- "At most one trapped index equals 1": `T ⊆ insert 1 (T.filter (2 ≤ ·))`
+  (from `hpos` + omega case split), then `Finset.card_insert_le` + omega gives
+  `d ≤ |filter| + 1`. No erase/max' machinery needed.
+- `Finset.card_image_of_injective _ (add_left_injective 1)` works on the nose for
+  the `(· + 1)` image.
+- The per-index closure sub-proof from the Dirac rung inlines verbatim with `b`
+  replaced by an arbitrary filtered index `n` — its only requirement really is `2 ≤ n`.
+
+### Relevance to Problem 64
+This is the elementary end of the cycle-SPECTRUM view: Liu–Montgomery prove the
+large-min-degree case by showing the spectrum is dense enough to contain a power
+of two. The linear bound `|spectrum| ≥ d−1` is what elementary methods give; at
+d = 3 it guarantees only 2 lengths, far from forcing a power of two.
+
+### Next
+- Elementary layer now: existence + bridge + parity + Dirac + spectrum count.
+- Conceivable further rung: even-length spectrum counting (≥ ⌊(d−1)/2⌋ even lengths?)
+  — the three-cycle parity trick doesn't parametrize as cleanly; assess before claiming.
+- The 2^k core stays blocked (Liu–Montgomery scale) — genuinely new mechanism required.

--- a/src/data/proofs/erdos-64/meta.json
+++ b/src/data/proofs/erdos-64/meta.json
@@ -316,9 +316,9 @@
       "Finset"
     ],
     "namespace": "Erdos64",
-    "lineCount": 732,
+    "lineCount": 867,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 16,
     "definitionCount": 11,
     "path": "Proofs/Erdos64Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-64-wip-01.json
+++ b/src/data/research/problems/erdos-64-wip-01.json
@@ -37,7 +37,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: even-cycle parity layer proved (2026-07-22). hasMinDegree_three_exists_even_cycle + ContainsCycleLength restatement (even k>=4), axiom-free, via classical longest-path parity argument (three cycles a+1, b+1, b-a+2). This is the parity part of the necessary condition of Problem 64 (2^k-cycles are even), strictly between cycle existence (done) and the open power-of-two core (blocked, Liu-Montgomery scale). Maximal-path engine (Nat.sSup_mem + IsPath.length_lt) now available in-file. 2026-07-22b: Dirac-type rung added — min degree d>=2 forces a cycle of length >= d+1 (hasMinDegree_exists_cycle_length_ge), completing the elementary layer (existence + bridge + parity + quantitative length).",
+    "progressSummary": "PROGRESS: cycle-spectrum counting rung proved (2026-07-23). hasMinDegree_card_cycle_lengths + ContainsCycleLength restatement: min degree d>=2 forces >= d-1 DISTINCT cycle lengths (Finset of lengths, injective +1 image of trapped indices >= 2; at most one index equals 1). Reuses the maximal-path engine; new counting content beyond the Dirac rung (which only extracts the max index). Elementary layer: existence + bridge + parity + Dirac + spectrum count. Open core unchanged: whether the spectrum of a min-degree-3 graph must meet {2^k, k>=2} (Liu-Montgomery scale).",
     "builtItems": [
       "connected_hasMinDegree_two_not_isAcyclic (Erdos64Problem.lean): nontrivial connected graph, HasMinDegree 2 => ¬IsAcyclic. Axiom-free.",
       "connected_hasMinDegree_two_exists_cycle (Erdos64Problem.lean): same hyp => ∃ v (c : Walk v v), c.IsCycle. Axiom-free.",
@@ -48,7 +48,9 @@
       "hasMinDegree_three_exists_even_cycle in Erdos64Problem.lean: min-degree >=3 nonempty finite graph has an even-length Walk.IsCycle (0-axiom)",
       "hasMinDegree_three_exists_even_containsCycleLength in Erdos64Problem.lean: even length k >= 4 in the ContainsCycleLength predicate",
       "hasMinDegree_exists_cycle_length_ge (Dirac-type: min-deg d>=2 => cycle length >= d+1) in Erdos64Problem.lean",
-      "hasMinDegree_containsCycleLength_ge (ContainsCycleLength restatement) in Erdos64Problem.lean"
+      "hasMinDegree_containsCycleLength_ge (ContainsCycleLength restatement) in Erdos64Problem.lean",
+      "hasMinDegree_card_cycle_lengths (Erdos64Problem.lean): min-deg d>=2 => Finset S of cycle lengths, |S| >= d-1, each realized by an explicit IsCycle witness; axiom-free",
+      "hasMinDegree_card_containsCycleLength (Erdos64Problem.lean): same spectrum bound in the ContainsCycleLength predicate the conjecture uses"
     ],
     "insights": [
       "A finite nontrivial TREE has a leaf (degree-1 vertex): Mathlib SimpleGraph.IsTree.minDegree_eq_one_of_nontrivial. Hence a connected graph with min degree >= 2 cannot be a tree, so cannot be acyclic — the elementary base fact under Erdos #64.",
@@ -58,7 +60,8 @@
       "hasMinDegree_two/three_containsCycleLength: min-degree>=2 (resp. 3) finite graph contains a cycle of some CONCRETE length k>=3 in the ContainsCycleLength encoding. This restates the elementary precondition of Problem 64 in the exact predicate the conjecture uses; the open content is that k can be chosen a power of two 2^m.",
       "Parity middle layer between cycle-existence and the deep 2^k core: min-degree-3 forces an EVEN cycle, via the classical longest-path argument. Take a maximum-length path from v0; maximality traps all >=3 neighbours of v0 on the path at distinct positive indices; the two largest indices a<b (a>=2) give three cycles of lengths a+1, b+1, b-a+2 summing to 2b+4 (even), so one is even.",
       "Lean mechanism for maximal paths: Nat.sSup_mem on {n | exists path of length n} (nonempty via Walk.nil, BddAbove via IsPath.length_lt), then le_csSup for maximality. No dedicated Mathlib longest-path API exists.",
-      "Key Mathlib toolkit for index arithmetic on paths: Walk.getVert_length_takeUntil (vertex at index = takeUntil length), Walk.length_takeUntil (= support.idxOf), Walk.dropUntil_eq_drop + Walk.drop_getVert + Walk.getVert_copy (getVert of suffix), IsPath.getVert_injOn (injectivity on indices <= length), IsPath.eq_snd_of_mem_edges (an edge of a path through its start is the first edge - closes the takeUntil prefix into a cycle)."
+      "Key Mathlib toolkit for index arithmetic on paths: Walk.getVert_length_takeUntil (vertex at index = takeUntil length), Walk.length_takeUntil (= support.idxOf), Walk.dropUntil_eq_drop + Walk.drop_getVert + Walk.getVert_copy (getVert of suffix), IsPath.getVert_injOn (injectivity on indices <= length), IsPath.eq_snd_of_mem_edges (an edge of a path through its start is the first edge - closes the takeUntil prefix into a cycle).",
+      "Cycle-spectrum counting rung: the maximal-path engine yields a cycle at EVERY trapped neighbour index >= 2, and distinct indices give distinct lengths — so min degree d forces >= d-1 distinct cycle lengths. Elementary end of the spectrum view: Liu-Montgomery resolves large min-degree via spectrum density hitting a power of two."
     ],
     "mathlibGaps": [
       "No general (disconnected/forest) leaf lemma: Mathlib only has IsTree.minDegree_eq_one_of_nontrivial (connected). A forest edge-count bound #edges <= n-1 is also absent (only IsTree.card_edgeFinset).",


### PR DESCRIPTION
## Summary
Research session for erdos-64-wip-01 (Erdős #64, OPEN $1000: does every finite graph with minimum degree ≥ 3 contain a cycle of length 2^k?).

## Progress
- `hasMinDegree_card_cycle_lengths` — minimum degree `d ≥ 2` forces at least `d − 1` **distinct** cycle lengths: a `Finset ℕ` of size ≥ d−1, every element `k ≥ 3` realized by an explicit `Walk.IsCycle` witness of length exactly `k`. Axiom-free.
- `hasMinDegree_card_containsCycleLength` — the same spectrum bound in the `ContainsCycleLength` predicate that `erdos_64_conjecture` uses.
- Host-verified: `lake env lean Proofs/Erdos64Problem.lean` exit 0, zero warnings, first try. File 732→867 lines, 14→16 theorems, 0 axioms, 0 sorries.
- Synced stale `leanFile` counts in `src/data/proofs/erdos-64/meta.json`; updated knowledge tracker + knowledge.md.

## Findings
- The in-file maximal-path engine yields a cycle at **every** trapped neighbour index ≥ 2 (the Dirac rung only closed at the max index), and distinct indices give distinct lengths `n+1` — new counting content, not a restatement.
- Counting piece: at most one trapped index equals 1, via `T ⊆ insert 1 (T.filter (2 ≤ ·))` + `Finset.card_insert_le`; the `(· + 1)` image is counted by `Finset.card_image_of_injective _ (add_left_injective 1)`.
- This is the elementary end of the cycle-**spectrum** view of Problem 64: Liu–Montgomery resolve the large-min-degree case by spectrum density. The linear bound `|spectrum| ≥ d−1` is what elementary methods give; at d = 3 it guarantees only 2 lengths — far from forcing a power of two, so the open core is untouched (honestly: this is a supporting rung, not an advance on the 2^k core).

## Status
**Outcome**: progress (elementary layer extended: existence + bridge + parity + Dirac + spectrum count)
**Next Steps**: possible even-length spectrum rung (assess first — the parity trick doesn't parametrize cleanly); the 2^k core remains blocked at Liu–Montgomery scale, reopen bar: materially new mechanism.

🤖 Generated by researcher-1
