### PR TITLE
Enrich spectral-trace-det-eigenvalues-oq-02-oq-01: split sections to 5 (header/definition)

### DIFF
--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-02-oq-01/meta.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-02-oq-01/meta.json
@@ -77,12 +77,20 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Why This Is Content, Not a Re-export",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Module docstring explaining why Mathlib provides no inner-product instance on Matrix m n ℝ: the Frobenius norm lives in scoped defs (Matrix.frobeniusNormedAddCommGroup) kept out of instance resolution to avoid a norm diamond against the sup-norm, so the inner-product structure and its InnerProductSpace.Core certificate must be built from scratch.",
+      "mathContext": "$\\langle A, B\\rangle = \\operatorname{tr}(A^{\\mathsf T} B) = \\sum_{i,j} A_{ij} B_{ij}$."
+    },
+    {
       "id": "definition",
       "title": "The Frobenius Inner Product and its Entrywise Formula",
-      "startLine": 1,
+      "startLine": 45,
       "endLine": 60,
-      "summary": "Module docstring explaining why Mathlib provides no inner-product instance on Matrix m n ℝ (scoped Frobenius norm, norm diamond); definition frobInner A B := (Aᵀ * B).trace; and frobInner_eq_sum, the entrywise formula ⟪A, B⟫ = Σᵢⱼ Aᵢⱼ Bᵢⱼ obtained by unfolding the trace and commuting the double sum.",
-      "mathContext": "$\\langle A, B\\rangle = \\operatorname{tr}(A^{\\mathsf T} B) = \\sum_{i,j} A_{ij} B_{ij}$."
+      "summary": "frobInner A B := (Aᵀ * B).trace, the coordinate-free definition, and frobInner_eq_sum, the entrywise formula ⟪A, B⟫ = Σᵢⱼ Aᵢⱼ Bᵢⱼ obtained by unfolding trace/diag_apply/mul_apply/transpose_apply and one Finset.sum_comm — the bridge every later property is proved through.",
+      "mathContext": "$\\operatorname{tr}(A^{\\mathsf T} B) = \\sum_i \\sum_j A_{ij} B_{ij}$."
     },
     {
       "id": "bilinearity",


### PR DESCRIPTION
## Summary
- `sections.length` was 4, below the 5-section target for a quality-96 entry, with the module docstring (lines 1-44) and the `frobInner` definition + entrywise-formula theorem (lines 45-60) lumped into one section.
- `annotations.json` already treats these as two distinct concepts (`ann-spectraloq0201-1` framing/header, `ann-spectraloq0201-2` the entrywise bridge lemma), so the split brings `sections` in line with the file's real declaration boundaries rather than adding filler.
- Result: 5 sections, still fully covering lines 1-163 of the 163-line Lean file, well under the size caps (16.3 KB meta.json).

## Test plan
- [x] Validated JSON structure (`python3 -c "import json; json.load(...)"`)
- [x] `pnpm build` produced zero errors for this entry
- [x] Verified all lemma/definition names cited in meta.json/annotations.json match the Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)