### PR TITLE
Enrich stirling-first-kind-oq-01-oq-01: split sections to 5 (per-corollary)

### DIFF
--- a/src/data/proofs/stirling-first-kind-oq-01-oq-01/meta.json
+++ b/src/data/proofs/stirling-first-kind-oq-01-oq-01/meta.json
@@ -158,11 +158,19 @@
       "mathContext": "$\\left(\\sum_{k} c(n,k) X^k\\right).\\mathrm{coeff}\\,j = c(n,j)$ since $(X^k).\\mathrm{coeff}\\,j = [j=k]$."
     },
     {
-      "id": "corollaries",
-      "title": "Evaluation and Row-Sum Corollaries",
+      "id": "evaluation-form",
+      "title": "Evaluation Corollary",
       "startLine": 82,
+      "endLine": 87,
+      "summary": "eval_ascPochhammer_eq_sum pushes eval through the generating identity (eval_finset_sum and the per-term eval_mul/eval_C/eval_pow/eval_X) to give the value form x(x+1)⋯(x+n−1) = ∑ c(n,k) xᵏ, for x in any commutative semiring R.",
+      "mathContext": "$(\\mathrm{ascPochhammer}\\,R\\,n).\\mathrm{eval}\\,x = \\sum_{k=0}^{n} c(n,k)\\,x^k$."
+    },
+    {
+      "id": "row-sum",
+      "title": "Row-Sum Corollary",
+      "startLine": 89,
       "endLine": 97,
-      "summary": "eval_ascPochhammer_eq_sum pushes eval through the generating identity to give x(x+1)⋯(x+n−1) = ∑ c(n,k) xᵏ. sum_stirlingFirst_eq_factorial specialises to x = 1 over ℕ, using ascPochhammer_eval_one to obtain the row sum ∑ c(n,k) = n!.",
+      "summary": "sum_stirlingFirst_eq_factorial specialises the evaluation form to x = 1 over ℕ, using ascPochhammer_eval_one (= n!) to obtain the row sum ∑ c(n,k) = n! — a second, structural proof of the parent entry's combinatorial identity.",
       "mathContext": "At $x = 1$: $\\sum_k c(n,k) = (\\mathrm{ascPochhammer}\\,\\mathbb{N}\\,n).\\mathrm{eval}\\,1 = n!$."
     }
   ],


### PR DESCRIPTION
## Summary
- `sections.length` was 4, below the 5-section target for a quality-96 entry, with two distinct theorems — `eval_ascPochhammer_eq_sum` (lines 82-87) and `sum_stirlingFirst_eq_factorial` (lines 89-97) — lumped into one `corollaries` section.
- Split at that real declaration boundary into `evaluation-form` and `row-sum`, matching the file's actual structure (one section per theorem plus the header, 5 total).
- Result: 5 sections, still fully covering lines 1-97 of the 97-line Lean file, well under the size caps (15.5 KB meta.json).

## Test plan
- [x] Validated JSON structure (`python3 -c "import json; json.load(...)"`)
- [x] `pnpm build` produced zero errors for this entry
- [x] Verified all lemma/theorem names cited in meta.json/annotations.json match the Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)