### PR TITLE
Enrich stirling-first-kind-oq-02: split sections to 5 (statement/proof)

### DIFF
--- a/src/data/proofs/stirling-first-kind-oq-02/meta.json
+++ b/src/data/proofs/stirling-first-kind-oq-02/meta.json
@@ -98,11 +98,19 @@
       "mathContext": "X(X+1)⋯(X+n−1) = ∑ₖ c(n,k) Xᵏ; the rising factorial is Mathlib's ascPochhammer ℤ n."
     },
     {
-      "id": "generating-identity",
-      "title": "The Generating Identity c(n,k) = [Xᵏ] ascPochhammer ℤ n",
+      "id": "generating-identity-statement",
+      "title": "The Generating Identity, Statement",
       "startLine": 48,
+      "endLine": 59,
+      "summary": "stirlingFirst_eq_ascPochhammer_coeff states the structural identity: c(n,k) equals the coefficient of Xᵏ in the rising factorial X(X+1)⋯(X+n−1) = ascPochhammer ℤ n, turning the combinatorial cycle-count into an algebraic polynomial coefficient.",
+      "mathContext": "$c(n,k) = [X^k]\\,\\mathrm{ascPochhammer}\\ \\mathbb{Z}\\ n$."
+    },
+    {
+      "id": "generating-identity-proof",
+      "title": "The Generating Identity, Proof",
+      "startLine": 60,
       "endLine": 81,
-      "summary": "stirlingFirst_eq_ascPochhammer_coeff: induction on n (generalizing k). Rewriting ascPochhammer ℤ (n+1) = ascPochhammer ℤ n · (X + C n) and taking the Xᵏ-coefficient (coeff_mul_X, coeff_mul_C) reproduces the Stirling recurrence c(n+1,k+1) = n·c(n,k+1) + c(n,k); the k=0 case gives c(n+1,0)=0.",
+      "summary": "Induction on n (generalizing k). Rewriting ascPochhammer ℤ (n+1) = ascPochhammer ℤ n · (X + C n) and taking the Xᵏ-coefficient (coeff_mul_X, coeff_mul_C) reproduces the Stirling recurrence c(n+1,k+1) = n·c(n,k+1) + c(n,k); the k=0 case gives c(n+1,0)=0.",
       "mathContext": "Coefficient extraction from the factor (X+n) is exactly the Pascal recurrence for the first-kind numbers."
     },
     {


### PR DESCRIPTION
## Summary
- `sections.length` was 4, below the 5-section target for a quality-96 entry, with the `stirlingFirst_eq_ascPochhammer_coeff` theorem's statement (lines 48-59) and its proof body (lines 60-81) lumped into one `generating-identity` section.
- `annotations.json` already treats these as two distinct concepts (`ann-generating-identity` for the statement, `ann-generating-proof` for the induction), so the split brings `sections` in line with the file's real statement/proof boundary rather than adding filler.
- Result: 5 sections, still fully covering lines 1-107 of the 107-line Lean file, well under the size caps (13.9 KB meta.json).

## Test plan
- [x] Validated JSON structure (`python3 -c "import json; json.load(...)"`)
- [x] `pnpm build` produced zero errors for this entry
- [x] Verified all lemma/theorem names cited in meta.json/annotations.json match the Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)