### PR TITLE
Enrich stirling-formula-oq-03-oq-02: split sections to 5 (squared/sqrt asymptotic)

### DIFF
--- a/src/data/proofs/stirling-formula-oq-03-oq-02/meta.json
+++ b/src/data/proofs/stirling-formula-oq-03-oq-02/meta.json
@@ -99,12 +99,20 @@
       "mathContext": "W n = 2^(4n)(n!)⁴/((2n)!²(2n+1)); substituting (2n)! = C·(n!)² collapses (n!)⁴ and leaves W n·(2n+1) = (2^(4n))/C² = (4ⁿ/C)²."
     },
     {
-      "id": "asymptotics",
-      "title": "The Three Asymptotic Forms",
+      "id": "squared-asymptotic",
+      "title": "Dividing by n: the Squared Limit Becomes π",
       "startLine": 80,
+      "endLine": 97,
+      "summary": "centralBinom_sq_div_tendsto: (4ⁿ/C)²/n → π. Dividing the exact identity by n turns the right side into W n·(2+1/n), which tends to (π/2)·2 = π since W n → π/2 and 1/n → 0.",
+      "mathContext": "$(4^n/C(2n,n))^2/n = W_n(2+1/n) \\to \\pi$."
+    },
+    {
+      "id": "sqrt-asymptotic",
+      "title": "Taking the Square Root: the Central Binomial Asymptotic",
+      "startLine": 99,
       "endLine": 128,
-      "summary": "centralBinom_sq_div_tendsto ((4ⁿ/C)²/n → π via W n·(2+1/n)), four_pow_div_centralBinom_sqrt_tendsto (4ⁿ/(C·√n) → √π via Tendsto.sqrt), and centralBinom_asymptotic (C·√(πn)/4ⁿ → 1 via the quotient √π/√π).",
-      "mathContext": "From W n → π/2: (4ⁿ/C)²/n = W n·(2+1/n) → π, hence 4ⁿ/(C·√n) → √π, hence C·√(πn)/4ⁿ → 1, i.e. C(2n,n) ~ 4ⁿ/√(πn)."
+      "summary": "four_pow_div_centralBinom_sqrt_tendsto (4ⁿ/(C·√n) → √π via Tendsto.sqrt) and centralBinom_asymptotic (C·√(πn)/4ⁿ → 1 via the quotient √π/√π) — the textbook central-binomial asymptotic C(2n,n) ~ 4ⁿ/√(πn).",
+      "mathContext": "$4^n/(C(2n,n)\\sqrt n) \\to \\sqrt\\pi \\;\\Rightarrow\\; C(2n,n)\\sqrt{\\pi n}/4^n \\to 1$."
     }
   ],
   "references": [


### PR DESCRIPTION
## Summary
- `sections.length` was 4, below the 5-section target for a quality-96 entry, with three theorems lumped into one `asymptotics` section (lines 80-128): `centralBinom_sq_div_tendsto`, and the two sqrt-stage results `four_pow_div_centralBinom_sqrt_tendsto` and `centralBinom_asymptotic`.
- `annotations.json` already splits the squared limit from the sqrt-stage results (`ann-sq-div` lines 80-97 vs `ann-sqrt-asymptotic` lines 99-127), so `sections` is split at the same real boundary rather than adding filler.
- Result: 5 sections, still fully covering lines 1-128 of the 128-line Lean file, well under the size caps (11.6 KB meta.json).

## Test plan
- [x] Validated JSON structure (`python3 -c "import json; json.load(...)"`)
- [x] `pnpm build` produced zero errors for this entry
- [x] Verified all lemma/theorem names cited in meta.json/annotations.json match the Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)