### PR TITLE
Enrich erdos-1042-oq-03: add 5th keyInsight (elementary vs potential-theoretic mechanism)

### DIFF
--- a/src/data/proofs/erdos-1042-oq-03/meta.json
+++ b/src/data/proofs/erdos-1042-oq-03/meta.json
@@ -46,7 +46,8 @@
       "The product formula gives an immediate two-sided geometric picture: f vanishes exactly at the roots (so they are interior to the lemniscate) while |f| is large far from all roots (so the lemniscate cannot escape their unit neighbourhood).",
       "Confinement to the union of degree-many unit balls is the geometric reason a lemniscate of a degree-n polynomial has at most n connected components: each bounded component must cluster near a root. The component count is thus a property of how the roots are arranged.",
       "This locates exactly why root geometry — not merely the transfinite diameter — matters: spreading the roots so their unit balls become disjoint separates the lemniscate into distinct clusters, whereas clustering the roots merges them.",
-      "Re-declaring the structures locally keeps the contribution axiom-free, in contrast to the parent entry whose Ghosh–Ramachandran results are axiomatized."
+      "Re-declaring the structures locally keeps the contribution axiom-free, in contrast to the parent entry whose Ghosh–Ramachandran results are axiomatized.",
+      "The confinement argument is purely elementary: it needs only continuity of finite products and the reverse triangle inequality bound ∏ᵢ|z - rootᵢ| ≥ 1 (from each factor ≥ 1), with no logarithmic potential, capacity, or transfinite-diameter machinery. The threshold '1' in the ball radius is inherited directly from the threshold '1' defining the lemniscate {|f| < 1} — the geometric skeleton the quantitative Ghosh–Ramachandran bounds build on top of, not a substitute for them."
     ],
     "prerequisites": [
       "Finite products over Finset (norm_prod, Finset.prod_eq_zero, Finset.prod_le_prod, Finset.prod_const_one)",


### PR DESCRIPTION
Enrichment pass for erdos-1042-oq-03. Quality gap was exactly keyInsights (4 items, 8/10 points) with every other dimension already at target (annotations 25, mathContext 10, significance 10, historicalContext 10, conclusion 15, sections 10, crossRefs 10) — quality 98/100.

Added a 5th keyInsight, verified against the Lean source (`Proofs/Erdos1042OQ03.lean`): the confinement argument is purely elementary (continuity of finite products + reverse triangle inequality, `norm_prod`/`Finset.prod_le_prod`), needing no logarithmic potential / capacity / transfinite-diameter machinery — contrasting it with the parent entry's axiomatized Ghosh–Ramachandran results, and noting the unit ball radius is directly inherited from the lemniscate's own threshold `|f| < 1`.

No other fields changed; sections/annotations/conclusion were already complete and accurate against the Lean file. Quality score: 98 -> 100.

Label: enrichment