### PR TITLE
Enrich summation-by-parts-oq-01: split sections to 5

### DIFF
--- a/src/data/proofs/summation-by-parts-oq-01/meta.json
+++ b/src/data/proofs/summation-by-parts-oq-01/meta.json
@@ -59,19 +59,35 @@
   },
   "sections": [
     {
-      "id": "header",
-      "title": "Module Header and Algebraic Setup",
+      "id": "context",
+      "title": "Module Docstring: the Gap and the Method",
       "startLine": 1,
-      "endLine": 49,
-      "summary": "Docstring stating the finite arithmetico-geometric identity ∑_{k<n} k·rᵏ = (r − n·rⁿ + (n−1)·rⁿ⁺¹)/(r−1)² for r ≠ 1, explaining that it is the discrete analogue of differentiating the geometric series and the finite partial sum behind the classical infinite value r/(1−r)². Notes the gap it fills — Mathlib has geom_sum_eq but no weighted ∑ k·rᵏ, and the gallery's GeometricSeriesOQ06 is the distinct infinite/normed object. Then the imports (BigOperators.Module, Tactic), the namespace, open Finset, and the ambient variable {K : Type*} [Field K] establishing that only a field and r ≠ 1 are assumed.",
+      "endLine": 42,
+      "summary": "Docstring stating the finite arithmetico-geometric identity ∑_{k<n} k·rᵏ = (r − n·rⁿ + (n−1)·rⁿ⁺¹)/(r−1)² for r ≠ 1, explaining that it is the discrete analogue of differentiating the geometric series and the finite partial sum behind the classical infinite value r/(1−r)². Notes the gap it fills — Mathlib has geom_sum_eq but no weighted ∑ k·rᵏ, and the gallery's GeometricSeriesOQ06 is the distinct infinite/normed object — and previews the induction and Abel-summation-by-parts methods.",
       "mathContext": "$\\sum_{k=0}^{n-1} k\\,r^{k} = \\frac{r - n r^{n} + (n-1) r^{n+1}}{(r-1)^{2}},\\qquad r \\neq 1.$"
     },
     {
-      "id": "closed-form",
-      "title": "The Closed Form by Induction",
+      "id": "setup",
+      "title": "Namespace and Field Setup",
+      "startLine": 44,
+      "endLine": 49,
+      "summary": "namespace SummationByPartsOQ01, open Finset, and the ambient variable {K : Type*} [Field K] — the whole development lives over an arbitrary field, with r ≠ 1 the only hypothesis introduced per-theorem.",
+      "mathContext": "No normed structure is assumed; the identity is purely algebraic over $K$."
+    },
+    {
+      "id": "closed-form-statement",
+      "title": "The Closed Form: Statement",
       "startLine": 50,
+      "endLine": 55,
+      "summary": "sum_range_mul_geom states ∑_{k<n} k·rᵏ = (r − n·rⁿ + (n−1)·rⁿ⁺¹)/(r−1)² for r ≠ 1 in an arbitrary field K.",
+      "mathContext": "$\\sum_{k<n} k\\,r^k = \\dfrac{r - n r^n + (n-1) r^{n+1}}{(r-1)^2}$."
+    },
+    {
+      "id": "closed-form-proof",
+      "title": "The Closed Form: Proof by Induction",
+      "startLine": 56,
       "endLine": 64,
-      "summary": "sum_range_mul_geom: ∑_{k<n} k·rᵏ = (r − n·rⁿ + (n−1)·rⁿ⁺¹)/(r−1)² for r ≠ 1, proved by induction with field_simp + ring on the step.",
+      "summary": "Induction on n: the base case is the empty sum; the step uses Finset.sum_range_succ to add the term m·rᵐ, then field_simp clears the (r−1)² denominator (legal since r−1 ≠ 0) and ring closes the resulting polynomial identity.",
       "mathContext": "The inductive step absorbs the new term m·rᵐ by the polynomial identity n·rⁿ(r−1)² = n·rⁿ⁺² − 2n·rⁿ⁺¹ + n·rⁿ."
     },
     {


### PR DESCRIPTION
## Summary
- `sections.length` was 3, below the 5-section target for a quality-96 entry, with the module docstring lumped together with the namespace/open/variable setup (lines 1-49), and the `sum_range_mul_geom` theorem's statement lumped with its induction proof (lines 50-64).
- `annotations.json` already treats the docstring separately from the field setup (`ann-sbp-oq01-context` vs `ann-sbp-oq01-setup`), so `sections` is split at that real boundary plus the theorem statement/proof boundary (line 55/56) rather than adding filler.
- Result: 5 sections (`context`, `setup`, `closed-form-statement`, `closed-form-proof`, `by-parts`), still fully covering lines 1-83 of the 83-line Lean file, well under the size caps (13.7 KB meta.json).

## Test plan
- [x] Validated JSON structure (`python3 -c "import json; json.load(...)"`)
- [x] `pnpm build` produced zero errors for this entry
- [x] Verified all lemma/theorem names cited in meta.json/annotations.json match the Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)