### PR TITLE
audit: erdos-496 — re-verified clean (audit round 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14089,8 +14089,8 @@
     },
     "erdos-496": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:38Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T22:57:35Z",
       "result": "clean"
     },
     "erdos-497": {


### PR DESCRIPTION
## Summary
- Round-robin re-audit of erdos-496 (Oppenheim conjecture) since the unaudited queue is drained.
- Verified 0 axioms, 0 sorries, no `native_decide` in `proofs/Proofs/Erdos496Problem.lean`.
- `theoremCount`/`definitionCount` match the file (2/3).
- `status: axiomatized` / `badge: wip` remain appropriate: Margulis's core theorem and the density result are prose-only commentary, not Lean declarations.
- Confirms the prior fix from #42698 (stale "axiomatized" proofStrategy prose) still holds.

## Test plan
- [x] Manual grep for `sorry`/`axiom`/`native_decide` in the Lean file — none found
- [x] Cross-checked meta.json counts against file contents