### PR TITLE
fix(meta): erdos-49 — proofStrategy/sections overclaim axiomatized/stated

### DIFF
--- a/src/data/proofs/erdos-49/meta.json
+++ b/src/data/proofs/erdos-49/meta.json
@@ -31,7 +31,7 @@
     "historicalContext": "Erdős posed this problem in the 1930s, observing that the primes $\\{2, 3, 5, 7, 11, \\ldots\\}$ naturally form a set with strictly increasing totient values since $\\varphi(p) = p - 1$ for primes. He conjectured that primes are asymptotically optimal: no subset of $\\{1, \\ldots, N\\}$ with increasing totient values can be much larger than $\\pi(N)$. Pomerance (1979) obtained the first non-trivial bounds using sieve methods, showing $|A| \\leq c \\cdot \\pi(N)$ for some constant $c > 1$. Ford (1998) improved the constant using his work on the anatomy of integers and the distribution of $\\varphi$-values. The problem was fully resolved by Terence Tao in 2023, who proved $|A| \\leq (1 + O((\\log\\log x)^5 / \\log x)) \\pi(x)$, confirming Erdős's conjecture with an explicit error term. Tao's proof combines multiplicative number theory, the Selberg sieve, and a careful analysis of the distribution of totient values among smooth numbers. The result exemplifies the extremal role of primes in number-theoretic optimization problems.",
     "problemStatement": "Let A = {a₁ < ⋯ < aₜ} ⊆ {1,…,N} with φ(a₁) < ⋯ < φ(aₜ). Is |A| ≤ (1 + o(1))π(N)?",
     "text": "Let A ⊆ {1,…,N} with φ(a₁) < ⋯ < φ(aₜ). The primes form such a set. Tao (2023) proved |A| ≤ (1+o(1))π(N), confirming primes are asymptotically largest.",
-    "proofStrategy": "The formalization defines increasing totient sets, the maximum size function via powerset filtration, and the prime counting function. The primes-are-optimal lower bound $\\text{maxIncTotientSize}(N) \\geq \\pi(N)$ is stated, and Tao's asymptotic upper bound is axiomatized with the $(1+\\varepsilon)$ formulation. A density-zero corollary follows from the Prime Number Theorem.",
+    "proofStrategy": "The formalization defines increasing totient sets, the maximum size function via powerset filtration, and the prime counting function, plus two elementary totient facts (`totient_prime`, `totient_le`) as proved theorems. The primes-are-optimal lower bound and Tao's (2023) asymptotic upper bound are described only in docstring-style comments — no Lean declaration (axiom or theorem) states or proves either bound, so the core result is not formalized.",
     "keyInsights": [
       "**Primes as natural witnesses**: $\\varphi(p) = p - 1$ for primes, so primes ordered by size automatically have increasing totient values, giving $|A| \\geq \\pi(N)$",
       "**Asymptotic optimality**: Tao's theorem $|A| \\leq (1 + O((\\log\\log x)^5/\\log x))\\pi(x)$ shows primes are not just good — they are essentially the best possible, with only a vanishing multiplicative overhead",
@@ -74,16 +74,16 @@
       "title": "Primes as Increasing Totient Set",
       "startLine": 41,
       "endLine": 45,
-      "summary": "States that primes form an increasing totient set (since $\\varphi(p) = p-1$ is strictly increasing with $p$) and derives the lower bound $\\text{maxIncTotientSize}(N) \\geq \\pi(N)$.",
-      "mathContext": "States that primes form an increasing totient set (since $\\varphi(p) = p-1$ is strictly increasing with $p$) and derives the lower bound $\\text{maxIncTotientSize}(N) \\geq \\$\\pi$(N)$."
+      "summary": "Comment (not a Lean declaration) noting that primes form an increasing totient set, since $\\varphi(p) = p-1$ is strictly increasing with $p$, which would give the lower bound $\\text{maxIncTotientSize}(N) \\geq \\pi(N)$ — this bound is not itself stated or proved as a Lean declaration.",
+      "mathContext": "Comment (not a Lean declaration) noting that primes form an increasing totient set, since $\\varphi(p) = p-1$ is strictly increasing with $p$, which would give the lower bound $\\text{maxIncTotientSize}(N) \\geq \\pi(N)$ — this bound is not itself stated or proved as a Lean declaration."
     },
     {
       "id": "tao-theorem",
       "title": "Tao's Theorem (2023)",
       "startLine": 46,
       "endLine": 52,
-      "summary": "Tao's asymptotic upper bound: $\\forall \\varepsilon > 0,\\; \\exists N_0,\\; \\forall N \\geq N_0: \\text{maxIncTotientSize}(N) \\leq (1+\\varepsilon) \\pi(N)$. Axiomatized over $\\mathbb{Q}$ for computability.",
-      "mathContext": "Tao's asymptotic upper bound: $\\forall \\varepsilon > 0,\\; \\exists N_0,\\; \\forall N \\geq N_0: \\text{maxIncTotientSize}(N) \\leq (1+\\varepsilon) \\$\\pi$(N)$. Axiomatized over $\\mathbb{Q}$ for computability."
+      "summary": "Comment describing Tao's asymptotic upper bound $\\forall \\varepsilon > 0,\\; \\exists N_0,\\; \\forall N \\geq N_0: \\text{maxIncTotientSize}(N) \\leq (1+\\varepsilon) \\pi(N)$ — not present as an axiom or theorem in the Lean source, only as prose.",
+      "mathContext": "Comment describing Tao's asymptotic upper bound $\\forall \\varepsilon > 0,\\; \\exists N_0,\\; \\forall N \\geq N_0: \\text{maxIncTotientSize}(N) \\leq (1+\\varepsilon) \\pi(N)$ — not present as an axiom or theorem in the Lean source, only as prose."
     },
     {
       "id": "main-statement",
@@ -98,8 +98,8 @@
       "title": "Density Zero Corollary",
       "startLine": 62,
       "endLine": 65,
-      "summary": "The weaker result: $\\text{maxIncTotientSize}(N) = o(N)$. Follows from Tao's bound and the PNT ($\\pi(N) \\sim N/\\ln N = o(N)$).",
-      "mathContext": "The weaker result: $\\text{maxIncTotientSize}(N) = o(N)$. Follows from Tao's bound and the PNT ($\\$\\pi$(N) \\sim N/\\ln N = o(N)$)."
+      "summary": "Comment describing the weaker $o(N)$ density-zero claim, which would follow from Tao's bound and the PNT ($\\pi(N) \\sim N/\\ln N = o(N)$) — not formalized as a corollary in Lean.",
+      "mathContext": "Comment describing the weaker $o(N)$ density-zero claim, which would follow from Tao's bound and the PNT ($\\pi(N) \\sim N/\\ln N = o(N)$) — not formalized as a corollary in Lean."
     },
     {
       "id": "totient-properties",


### PR DESCRIPTION
## Gallery integrity fix

**Proof**: erdos-49 (Sets with Increasing Euler Totient Values)
**Problem**: `overview.proofStrategy` and three section summaries (`primes-optimal`, `tao-theorem`, `weaker-form`) described the primes-lower-bound as "stated" and Tao's (2023) upper bound as "axiomatized", but `proofs/Proofs/Erdos49Problem.lean` has **zero** `axiom` declarations — both claims exist only as `/- ... -/` block comments, with no Lean declaration (axiom or theorem) backing either. This contradicted the file's own `assumptions` field ("Previously cited axiom names have been removed from the Lean source") and `axiomCount: 0`.

Same pattern as the erdos-496 fix (#42698): comment-only content mislabeled "axiomatized" overstates the formalization level (an `axiom` is a real, kernel-tracked Lean construct; a comment carries zero formal commitment).

Top-level `status: "axiomatized"` / `badge: "wip"` were already honest — only the descriptive prose was stale/inconsistent.

## Evidence

**meta.json claimed**: "the primes-are-optimal lower bound ... is stated, and Tao's asymptotic upper bound is axiomatized"
**Lean file shows**: lines 41-52 are plain comments (`/- ... -/`), not `axiom`/`theorem`/`lemma` declarations; `grep axiom proofs/Proofs/Erdos49Problem.lean` returns nothing.

## Fix

Rewrote `proofStrategy` and the three affected section `summary`/`mathContext` fields to accurately describe the content as comment-only, not stated/axiomatized/derived. Also fixed a stray broken-LaTeX artifact (`$\$\pi$(N)$`) left over from a prior find/replace in two `mathContext` fields.

---
Discovered during gallery integrity audit (reserve-mode re-serve, queue drained: 4811/4811 audited, 0 with issues).