### PR TITLE
Fix sum-of-kth-powers-oq-05-oq-01: sections cut two theorem declarations; split to 5

### DIFF
--- a/src/data/proofs/sum-of-kth-powers-oq-05-oq-01/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-05-oq-01/meta.json
@@ -94,30 +94,38 @@
       "id": "header",
       "title": "Module Header and Setup",
       "startLine": 1,
-      "endLine": 39,
-      "summary": "Module docstring explaining the cast from the field-valued parent result to a Nat.ModEq statement, the imports (Mathlib and the parent file), and the namespace.",
+      "endLine": 34,
+      "summary": "Module docstring explaining the cast from the field-valued parent result to a Nat.ModEq statement, the imports (Mathlib and the parent file), the namespace, and the opens.",
       "mathContext": "$\\sum_{i<p} i^k \\pmod p$ obtained from $\\sum_{x:\\mathbb{Z}/p} x^k$."
     },
     {
       "id": "reindex",
       "title": "Residue-Cast Reindexing",
-      "startLine": 40,
-      "endLine": 55,
+      "startLine": 36,
+      "endLine": 46,
       "summary": "sum_range_cast_pow: the bijection i ↦ (i:ZMod p) on range p (inverse ZMod.val) identifies ∑_{i<p} (↑i)ᵏ with ∑_{x:ZMod p} xᵏ, via Finset.sum_nbij'.",
       "mathContext": "$\\sum_{i<p} (\\bar{i})^k = \\sum_{x:\\mathbb{Z}/p} x^k$."
     },
     {
       "id": "main",
-      "title": "Nat-Congruence Dichotomy and Corollaries",
-      "startLine": 56,
-      "endLine": 110,
-      "summary": "sum_pow_modEq (the main congruence), sum_pow_modEq_pred / sum_pow_modEq_zero (the two branches), and p_dvd_sum_pow_iff (the divisibility criterion).",
+      "title": "The Nat-Congruence Dichotomy",
+      "startLine": 48,
+      "endLine": 65,
+      "summary": "sum_pow_modEq: ∑_{i<p} iᵏ ≡ (if k≠0 ∧ (p−1)∣k then p−1 else 0) (mod p), by rewriting as an equality of ZMod p casts, pushing the cast through the sum, applying the reindexing lemma and the parent's sum_pow_zmod, and matching the −1/p−1 correspondence via Nat.cast_pred + ZMod.natCast_self.",
       "mathContext": "$\\sum_{i<p} i^k \\equiv \\begin{cases} p-1 & k \\neq 0,\\ (p-1)\\mid k \\\\ 0 & \\text{otherwise} \\end{cases} \\pmod p$"
+    },
+    {
+      "id": "corollaries",
+      "title": "Branch Corollaries and the Divisibility Criterion",
+      "startLine": 67,
+      "endLine": 99,
+      "summary": "sum_pow_modEq_pred / sum_pow_modEq_zero extract the two branches of the dichotomy; p_dvd_sum_pow_iff turns it into the divisibility criterion p ∣ ∑_{i<p} iᵏ ⟺ ¬(k≠0 ∧ (p−1)∣k), proved by contradiction (p ∣ p−1 would otherwise follow, impossible for a prime).",
+      "mathContext": "$p \\mid \\textstyle\\sum_{i<p} i^k \\iff \\neg\\big(k\\ne 0 \\wedge (p-1)\\mid k\\big)$."
     },
     {
       "id": "residues",
       "title": "Sum of Residues and Instances",
-      "startLine": 111,
+      "startLine": 101,
       "endLine": 125,
       "summary": "sum_residues_modEq (∑_{i<p} i ≡ 0 for odd primes, the k=1 case) and concrete decide-verified Nat.ModEq instances mod 5 and mod 7.",
       "mathContext": "$\\sum_{i<p} i \\equiv 0 \\pmod p$ for odd $p$; e.g. $\\sum_{i<5} i^4 = 354 \\equiv 4 \\pmod 5$."


### PR DESCRIPTION
## Summary
This is a correctness fix, not just a count gap.
- `header` (lines 1-39) ended mid-declaration of `sum_range_cast_pow`: its `theorem ... :` signature (line 39) was separated from its own `:=` body (line 40, which fell into `reindex`).
- `reindex` (lines 40-55) then ended mid-type-signature of `sum_pow_modEq`: the `[MOD p] := by` continuation of its statement was orphaned into `main` (56-110).

Rebuilt all section boundaries to match real theorem starts/ends — cross-checked against `annotations.json`, whose independently-derived ranges already get every one of these boundaries right:
- `header` (1-34), `reindex` (36-46, full `sum_range_cast_pow`), `main` (48-65, full `sum_pow_modEq`), `corollaries` (67-99, `sum_pow_modEq_pred` + `sum_pow_modEq_zero` + `p_dvd_sum_pow_iff`), `residues` (101-125, `sum_residues_modEq` + the four `decide`-verified instances).

Result: 5 sections (up from 4, meeting the quality-96 target), no overlaps, gaps, or mid-declaration cuts, still covering the full 125-line file, well under the size caps (13.5 KB meta.json).

## Test plan
- [x] Validated JSON structure (`python3 -c "import json; json.load(...)"`)
- [x] `pnpm build` produced zero errors for this entry
- [x] Manually re-read the Lean source line-by-line and cross-checked every new boundary against annotations.json's independently-derived ranges, which agree exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)