### PR TITLE
Research: erdos-751 axiom-free cycle existence in 4-chromatic graphs

### DIFF
--- a/proofs/Proofs/Erdos751Problem.lean
+++ b/proofs/Proofs/Erdos751Problem.lean
@@ -462,4 +462,128 @@ theorem erdos_751_summary (G : SimpleGraph V) [DecidableRel G.Adj] :
   ⟨erdos_751_chromatic_4 G, min_degree_3_cycle_gap G,
     chromatic_4_implies_subgraph_min_deg_3 G⟩
 
+/-
+## Part VII: Cycle Existence (axiom-free)
+
+The Bondy–Vince axiom asserts *two* cycles with close lengths. This section
+proves, without any axiom, that the cycle spectrum is at least *nonempty*:
+a finite nonempty graph in which every vertex has degree at least 2 contains
+a cycle (each connected component of an acyclic graph is a tree, and a
+nontrivial finite tree has a vertex of degree 1). Chained through the proved
+chromatic–degeneracy lemma this yields `erdos_751_cycle_exists`: a 4-chromatic
+graph contains a cycle — previously even this weak form of the answer was only
+derivable through the Bondy–Vince axiom.
+-/
+
+/-- Every member of `cycleLengths` is at least 3: cycles in a simple graph
+have length at least 3. -/
+theorem three_le_of_mem_cycleLengths {G : SimpleGraph V} [DecidableRel G.Adj]
+    {n : ℕ} (hn : n ∈ cycleLengths G) : 3 ≤ n := by
+  obtain ⟨v, c, hc, rfl⟩ := hn
+  exact hc.three_le_length
+
+/-- The degree of a vertex inside its connected-component graph equals its
+degree in `G`: every `G`-neighbour of a vertex lies in the vertex's
+component. -/
+theorem degree_toSimpleGraph_eq (G : SimpleGraph V) [DecidableRel G.Adj]
+    (C : G.ConnectedComponent) [Fintype C] [DecidableRel C.toSimpleGraph.Adj]
+    (x : C) : C.toSimpleGraph.degree x = G.degree x.1 := by
+  show (C.toSimpleGraph.neighborFinset x).card = (G.neighborFinset x.1).card
+  apply Finset.card_bij (fun y _ => y.1)
+  · intro y hy
+    rw [SimpleGraph.mem_neighborFinset] at hy
+    rw [SimpleGraph.mem_neighborFinset]
+    exact hy
+  · intro y1 h1 y2 h2 heq
+    exact Subtype.ext heq
+  · intro u hu
+    rw [SimpleGraph.mem_neighborFinset] at hu
+    have hus : u ∈ C.supp := C.mem_supp_of_adj_mem_supp x.2 hu
+    exact ⟨⟨u, hus⟩, by rw [SimpleGraph.mem_neighborFinset]; exact hu, rfl⟩
+
+/-- **Minimum degree ≥ 2 forces a cycle** (contrapositive form): a finite
+nonempty graph in which every vertex has at least two neighbours is not
+acyclic. If it were, each connected component would be a tree
+(`IsAcyclic.isTree_connectedComponent`); the component of any vertex is
+nontrivial (the vertex has a neighbour, which lies in the same component), so
+the tree has a vertex of degree 1 (`IsTree.exists_vert_degree_one_of_nontrivial`),
+whose degree in `G` is the same — contradicting the degree bound. -/
+theorem not_isAcyclic_of_two_le_degree (G : SimpleGraph V) [DecidableRel G.Adj]
+    (h : ∀ v, 2 ≤ G.degree v) : ¬ G.IsAcyclic := by
+  intro hac
+  obtain ⟨v⟩ := ‹Nonempty V›
+  have hvdeg : 0 < G.degree v := lt_of_lt_of_le (by norm_num) (h v)
+  obtain ⟨w, hw⟩ := (G.degree_pos_iff_exists_adj v).mp hvdeg
+  let C : G.ConnectedComponent := G.connectedComponentMk v
+  have hvC : v ∈ C.supp := rfl
+  have hwC : w ∈ C.supp := C.mem_supp_of_adj_mem_supp hvC hw
+  haveI : Fintype C := Fintype.ofFinite C
+  haveI : DecidableRel C.toSimpleGraph.Adj := Classical.decRel _
+  haveI : Nontrivial C :=
+    ⟨⟨v, hvC⟩, ⟨w, hwC⟩, fun heq => hw.ne (congrArg Subtype.val heq)⟩
+  have htree : C.toSimpleGraph.IsTree := hac.isTree_connectedComponent C
+  obtain ⟨x, hx⟩ := htree.exists_vert_degree_one_of_nontrivial
+  have hxdeg : C.toSimpleGraph.degree x = G.degree x.1 :=
+    degree_toSimpleGraph_eq G C x
+  have h2 := h x.1
+  omega
+
+/-- A finite nonempty graph in which every vertex has degree at least 2 has a
+nonempty cycle spectrum. -/
+theorem cycleLengths_nonempty_of_two_le_degree (G : SimpleGraph V)
+    [DecidableRel G.Adj] (h : ∀ v, 2 ≤ G.degree v) :
+    (cycleLengths G).Nonempty := by
+  by_contra hempty
+  apply not_isAcyclic_of_two_le_degree G h
+  intro v c hc
+  exact hempty ⟨c.length, v, c, hc, rfl⟩
+
+/-- The file's `minDegree` is a lower bound for every vertex degree. -/
+theorem minDegree_le_degree' (G : SimpleGraph V) [DecidableRel G.Adj] (v : V) :
+    minDegree G ≤ G.degree v :=
+  Finset.min'_le _ _ (Finset.mem_image_of_mem _ (Finset.mem_univ v))
+
+/-- **Nonvacuity of the Bondy–Vince hypothesis** (axiom-free): minimum degree
+at least 2 — in particular the `minDegree G ≥ 3` hypothesis of
+`bondy_vince_theorem` — already forces the cycle spectrum to be nonempty. -/
+theorem cycleLengths_nonempty_of_two_le_minDegree (G : SimpleGraph V)
+    [DecidableRel G.Adj] (h : 2 ≤ minDegree G) : (cycleLengths G).Nonempty :=
+  cycleLengths_nonempty_of_two_le_degree G
+    (fun v => le_trans h (minDegree_le_degree' G v))
+
+/-- **Erdős #751, axiom-free component: a 4-chromatic graph contains a
+cycle.** The chromatic–degeneracy lemma extracts a vertex set on which the
+induced subgraph has all degrees ≥ 3 ≥ 2, the cycle-existence engine produces
+a cycle there, and cycles of induced subgraphs are cycles of `G`.
+`#print axioms erdos_751_cycle_exists` reports foundational axioms only — no
+`bondy_vince_theorem`. -/
+theorem erdos_751_cycle_exists (G : SimpleGraph V) [DecidableRel G.Adj]
+    (hchi : chromaticNumber G = 4) : (cycleLengths G).Nonempty := by
+  obtain ⟨s, hne, hdeg⟩ := four_chromatic_subgraph_minDeg G hchi
+  haveI : Nonempty ↥((↑s : Set V)) :=
+    ⟨⟨hne.choose, Finset.mem_coe.mpr hne.choose_spec⟩⟩
+  letI : DecidableRel (G.induce (↑s : Set V)).Adj :=
+    fun a b => decidable_of_iff (G.Adj a.1 b.1) induce_adj.symm
+  have h2 : ∀ x : ↥((↑s : Set V)), 2 ≤ (G.induce (↑s : Set V)).degree x := by
+    intro x
+    rw [degree_induce_eq_filter_card G s x]
+    have := hdeg x.1 (Finset.mem_coe.mp x.2)
+    omega
+  obtain ⟨n, hn⟩ := cycleLengths_nonempty_of_two_le_degree
+    (G.induce (↑s : Set V)) h2
+  exact ⟨n, cycleLengths_induce_subset G _ hn⟩
+
+/-- A 4-chromatic graph is not acyclic (axiom-free corollary of
+`erdos_751_cycle_exists`). -/
+theorem not_isAcyclic_of_four_chromatic (G : SimpleGraph V)
+    [DecidableRel G.Adj] (hchi : chromaticNumber G = 4) : ¬ G.IsAcyclic := by
+  obtain ⟨n, v, c, hc, _⟩ := erdos_751_cycle_exists G hchi
+  exact fun hac => hac c hc
+
+/-- A 4-chromatic graph has girth at least 3 (axiom-free): its cycle spectrum
+is nonempty, so Mathlib's `three_le_girth` applies. -/
+theorem three_le_girth_of_four_chromatic (G : SimpleGraph V)
+    [DecidableRel G.Adj] (hchi : chromaticNumber G = 4) : 3 ≤ girth G :=
+  SimpleGraph.three_le_girth (not_isAcyclic_of_four_chromatic G hchi)
+
 end Erdos751

--- a/proofs/Proofs/Erdos751Problem.lean
+++ b/proofs/Proofs/Erdos751Problem.lean
@@ -475,6 +475,7 @@ graph contains a cycle — previously even this weak form of the answer was only
 derivable through the Bondy–Vince axiom.
 -/
 
+omit [Fintype V] [DecidableEq V] [Nonempty V] in
 /-- Every member of `cycleLengths` is at least 3: cycles in a simple graph
 have length at least 3. -/
 theorem three_le_of_mem_cycleLengths {G : SimpleGraph V} [DecidableRel G.Adj]
@@ -482,6 +483,7 @@ theorem three_le_of_mem_cycleLengths {G : SimpleGraph V} [DecidableRel G.Adj]
   obtain ⟨v, c, hc, rfl⟩ := hn
   exact hc.three_le_length
 
+omit [DecidableEq V] [Nonempty V] in
 /-- The degree of a vertex inside its connected-component graph equals its
 degree in `G`: every `G`-neighbour of a vertex lies in the vertex's
 component. -/
@@ -501,6 +503,7 @@ theorem degree_toSimpleGraph_eq (G : SimpleGraph V) [DecidableRel G.Adj]
     have hus : u ∈ C.supp := C.mem_supp_of_adj_mem_supp x.2 hu
     exact ⟨⟨u, hus⟩, by rw [SimpleGraph.mem_neighborFinset]; exact hu, rfl⟩
 
+omit [DecidableEq V] in
 /-- **Minimum degree ≥ 2 forces a cycle** (contrapositive form): a finite
 nonempty graph in which every vertex has at least two neighbours is not
 acyclic. If it were, each connected component would be a tree
@@ -512,7 +515,7 @@ theorem not_isAcyclic_of_two_le_degree (G : SimpleGraph V) [DecidableRel G.Adj]
     (h : ∀ v, 2 ≤ G.degree v) : ¬ G.IsAcyclic := by
   intro hac
   obtain ⟨v⟩ := ‹Nonempty V›
-  have hvdeg : 0 < G.degree v := lt_of_lt_of_le (by norm_num) (h v)
+  have hvdeg : 0 < G.degree v := by have := h v; omega
   obtain ⟨w, hw⟩ := (G.degree_pos_iff_exists_adj v).mp hvdeg
   let C : G.ConnectedComponent := G.connectedComponentMk v
   have hvC : v ∈ C.supp := rfl
@@ -528,6 +531,7 @@ theorem not_isAcyclic_of_two_le_degree (G : SimpleGraph V) [DecidableRel G.Adj]
   have h2 := h x.1
   omega
 
+omit [DecidableEq V] in
 /-- A finite nonempty graph in which every vertex has degree at least 2 has a
 nonempty cycle spectrum. -/
 theorem cycleLengths_nonempty_of_two_le_degree (G : SimpleGraph V)
@@ -538,11 +542,13 @@ theorem cycleLengths_nonempty_of_two_le_degree (G : SimpleGraph V)
   intro v c hc
   exact hempty ⟨c.length, v, c, hc, rfl⟩
 
+omit [DecidableEq V] in
 /-- The file's `minDegree` is a lower bound for every vertex degree. -/
 theorem minDegree_le_degree' (G : SimpleGraph V) [DecidableRel G.Adj] (v : V) :
     minDegree G ≤ G.degree v :=
   Finset.min'_le _ _ (Finset.mem_image_of_mem _ (Finset.mem_univ v))
 
+omit [DecidableEq V] in
 /-- **Nonvacuity of the Bondy–Vince hypothesis** (axiom-free): minimum degree
 at least 2 — in particular the `minDegree G ≥ 3` hypothesis of
 `bondy_vince_theorem` — already forces the cycle spectrum to be nonempty. -/

--- a/research/problems/erdos-751-incomplete-01/knowledge.md
+++ b/research/problems/erdos-751-incomplete-01/knowledge.md
@@ -81,3 +81,36 @@ induce_adj.symm`.
 ## Open (blocked, unchanged)
 
 - `bondy_vince_theorem` — deep 1998 result, no Mathlib cycle-length-spectrum API.
+
+## 2026-07-23 (researcher-1, session 3) — axiom-free cycle existence (Part VII)
+
+New section appended at END of file (no annotation line shifts). 9 new theorems,
+host-verified `lake env lean` v4.31 EXIT=0, lint-clean (only the 7 pre-existing
+warnings remain), 0 new axioms:
+
+- **`erdos_751_cycle_exists`** (new headline): `χ(G) = 4 → (cycleLengths G).Nonempty`,
+  `#print axioms` = [propext, Classical.choice, Quot.sound] — previously even
+  cycle existence in a 4-chromatic graph was only derivable through the
+  Bondy–Vince axiom. Corollaries `not_isAcyclic_of_four_chromatic`,
+  `three_le_girth_of_four_chromatic` (uses Mathlib `three_le_girth`).
+- **Engine `not_isAcyclic_of_two_le_degree`** (min degree ≥ 2 ⇒ not acyclic —
+  NOT in Mathlib): if acyclic, the component of any vertex is a tree
+  (`IsAcyclic.isTree_connectedComponent`), nontrivial because a degree-2 vertex
+  has a neighbour in the same component (`mem_supp_of_adj_mem_supp`), so
+  `IsTree.exists_vert_degree_one_of_nontrivial` gives a degree-1 vertex whose
+  component-degree equals its G-degree (`degree_toSimpleGraph_eq`, card_bij as
+  in degree_induce_eq_filter_card) — contradiction. Plus
+  `cycleLengths_nonempty_of_two_le_degree`/`..._of_two_le_minDegree`
+  (Bondy–Vince hypothesis nonvacuity), `minDegree_le_degree'`,
+  `three_le_of_mem_cycleLengths`.
+
+**Idioms:** `C.toSimpleGraph = G.induce C.supp` on CoeSort (SetLike) subtype;
+noncomputable instances in ¬-proof via `haveI : Fintype C := Fintype.ofFinite C`
++ `Classical.decRel _`; `v ∈ (G.connectedComponentMk v).supp := rfl`;
+Nontrivial via `fun heq => hw.ne (congrArg Subtype.val heq)`; `omit [...] in`
+must precede the DOCSTRING, not sit between docstring and theorem; omitting an
+instance cascades unused-var warnings to callers — chase the chain.
+
+**Remaining (unchanged):** only deep `bondy_vince_theorem` axiom. Possible next
+rungs (hard): two cycles through a common vertex when δ≥3; Bondy–Vince itself
+needs DFS/ear machinery absent from Mathlib.

--- a/src/data/proofs/erdos-751/meta.json
+++ b/src/data/proofs/erdos-751/meta.json
@@ -56,7 +56,7 @@
     "axiomCount": 1,
     "lineCount": 465,
     "assumptions": "1 axiom: bondy_vince_theorem (Bondy–Vince 1998: minDegree ≥ 3 ⟹ two cycle lengths differ by ≤ 2) — a deep graph-theory result with no Mathlib cycle-length-spectrum API. The chromatic–degeneracy lemma four_chromatic_subgraph_minDeg (χ(G)=4 ⟹ a nonempty vertex set s in which every vertex has ≥ 3 neighbours inside s, i.e. the induced subgraph has minimum degree ≥ 3) is now PROVED from Mathlib via a critical-subgraph argument (take a vertex-minimal subset whose induced graph is not 3-colorable; greedy extension shows each of its vertices has ≥ 3 internal neighbours). A previous formulation quantified minDegree over the whole vertex type, which was false as stated (K₄ plus an isolated vertex); the proved statement bounds degrees inside the extracted set. The subgraph's close cycles lift to G via the verified cycleLengths_induce_subset lemma. 0 sorries.",
-    "theoremCount": 16,
+    "theoremCount": 25,
     "definitionCount": 6
   },
   "overview": {
@@ -146,10 +146,10 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos751",
-    "lineCount": 465,
+    "lineCount": 595,
     "axiomCount": 1,
-    "theoremCount": 16,
-    "definitionCount": 3,
+    "theoremCount": 25,
+    "definitionCount": 6,
     "path": "Proofs/Erdos751Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Research: erdos-751-incomplete-01 — axiom-free cycle existence (Part VII)

**Problem:** Erdős #751 (cycle-length gaps in 4-chromatic graphs), file `proofs/Proofs/Erdos751Problem.lean`.

Prior sessions eliminated both sorries and reduced the file to a single deep axiom (`bondy_vince_theorem`). This session adds a new Part VII proving, **without any axiom**, that the cycle spectrum of a 4-chromatic graph is nonempty — previously even this weak form of the answer routed through the Bondy–Vince axiom.

### New theorems (9, all 0-axiom)

- `erdos_751_cycle_exists` — **new headline**: `chromaticNumber G = 4 → (cycleLengths G).Nonempty`. Verified `#print axioms` = `[propext, Classical.choice, Quot.sound]`.
- `not_isAcyclic_of_two_le_degree` — the engine: a finite nonempty graph with all degrees ≥ 2 is not acyclic. This elementary fact is **absent from Mathlib**: each component of an acyclic graph is a tree (`IsAcyclic.isTree_connectedComponent`); the component of any vertex is nontrivial, so `IsTree.exists_vert_degree_one_of_nontrivial` yields a degree-1 vertex, whose component-degree equals its `G`-degree — contradiction.
- `degree_toSimpleGraph_eq` — degree bridge: degree inside `C.toSimpleGraph` equals degree in `G` (all neighbours stay in the component).
- `cycleLengths_nonempty_of_two_le_degree`, `cycleLengths_nonempty_of_two_le_minDegree` — Bondy–Vince hypothesis **nonvacuity**: `minDegree ≥ 2` (a fortiori the axiom's `≥ 3`) already forces a nonempty cycle spectrum, axiom-free.
- `minDegree_le_degree'`, `three_le_of_mem_cycleLengths` — small supporting lemmas.
- `not_isAcyclic_of_four_chromatic`, `three_le_girth_of_four_chromatic` — 4-chromatic graphs are not acyclic and have girth ≥ 3 (via Mathlib `three_le_girth`).

### Verification

- Host-verified: `lake exe cache get` + `lake env lean Proofs/Erdos751Problem.lean` → **EXIT=0** (Lean v4.31 toolchain, no Docker build needed — Mathlib-only imports).
- Axiom audit: new theorems depend on foundational axioms only; `erdos_751` (headline using Bondy–Vince) unchanged at 1 axiom.
- Lint: all new declarations warning-free (`omit` clauses added); only the 7 pre-existing warnings remain.
- New section appended at end of file — existing gallery annotation line ranges unshifted.
- Gallery meta synced: `theoremCount` 16→25, `lineCount` 465→595, `definitionCount` 3→6 (actual def count). Status/badge/axiomCount unchanged (`axiomatized`/`axiom`/1).

### Remaining

Only the deep `bondy_vince_theorem` (1998) axiom — needs cycle-length-spectrum / DFS machinery absent from Mathlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
