### PR TITLE
Enrich summation-by-parts-oq-01-oq-01: split header section to 5 (statement/method)

### DIFF
--- a/src/data/proofs/summation-by-parts-oq-01-oq-01/meta.json
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-01/meta.json
@@ -58,12 +58,20 @@
   },
   "sections": [
     {
-      "id": "header",
-      "title": "Overview, motivation, and imports",
+      "id": "header-statement",
+      "title": "Overview: What This Proves",
       "startLine": 1,
+      "endLine": 19,
+      "summary": "Imports Mathlib.Algebra.BigOperators.Module and Mathlib.Tactic. States the target identity ∑_{k<n} k²·rᵏ = (n²·rⁿ − (2n²−2n−1)·rⁿ⁺¹ + (n−1)²·rⁿ⁺² − r² − r)/(r−1)³ for r ≠ 1 in a field K — the second-order arithmetico-geometric sum, one step beyond the parent's first-order ∑ k·rᵏ, and the finite hypothesis-free analogue of the twice-differentiated geometric series.",
+      "mathContext": "$\\sum_{k=0}^{n-1} k^2 r^k = \\dfrac{n^2 r^n - (2n^2-2n-1)r^{n+1} + (n-1)^2 r^{n+2} - r^2 - r}{(r-1)^3}$ for $r\\neq 1$."
+    },
+    {
+      "id": "header-method",
+      "title": "Novelty and Method",
+      "startLine": 20,
       "endLine": 53,
-      "summary": "Docstring stating the second-order identity ∑_{k<n} k²·rᵏ, explaining why it is absent from Mathlib and the gallery (only the geometric and first-order sums exist), and outlining the three approaches (induction, Abel summation by parts, r=2 specialization). Imports Mathlib.Algebra.BigOperators.Module and Mathlib.Tactic, opens Finset, and fixes an arbitrary field K.",
-      "mathContext": "The identity is exact over any field for r ≠ 1; the classical ∑ k²·rᵏ = r(1+r)/(1−r)³ is only its |r|<1 limit."
+      "summary": "Explains the novelty: Mathlib has only the geometric closed form and the gallery only the first-order ∑ k·rᵏ; this is the exact finite sum over any field, not an |r|<1 analytic limit. Previews the three results: the induction proof, Abel summation by parts (whose non-constant differences 2k+1 drop the sum to first order), and the r=2 specialization. Enters namespace SummationByPartsOQ01OQ01, opens Finset, and fixes an arbitrary field K.",
+      "mathContext": "Finite algebraic identity under $r \\neq 1$, not an $\\lVert r\\rVert<1$ analytic limit; $\\Delta(k^2) = 2k+1$ drives the by-parts degree reduction."
     },
     {
       "id": "closed-form",


### PR DESCRIPTION
Enrichment pass for `summation-by-parts-oq-01-oq-01` (quality 96, pass 0).

## Assessment
meta.json (12.6 KB) well under caps; annotations already at 5 (from #33899). Gap: **sections 4, need 5** — the 53-line `header` section spans two distinct docstring parts (target-identity statement, and novelty/method), while the annotations array already splits this same range into two annotations.

## Change
Split the `header` section to mirror the existing annotation boundaries (no accretion elsewhere):
- **header-statement** (1–19): imports and the target identity Σ_{k<n} k²·rᵏ = (n²·rⁿ − (2n²−2n−1)·rⁿ⁺¹ + (n−1)²·rⁿ⁺² − r² − r)/(r−1)³ for r ≠ 1.
- **header-method** (20–53): why it's new (finite field identity vs. the gallery's analytic |r|<1 limits) and the three-result preview (induction, Abel summation by parts, r=2 specialization), plus namespace/open/variable declarations.

Result: 5 sections, coverage aligned to the docstring's own section breaks and to the existing annotation ranges.

## Verification
- JSON validated (`json.load`).
- Content checked against `Proofs/SummationByPartsOQ01OQ01.lean` — line ranges match the docstring's `## What This Proves` / `## Why It Is Not Already in the Gallery / Mathlib` / `## Method` sections and the namespace/open/variable declarations at lines 49–53.