### PR TITLE
Enrich sum-of-kth-powers-oq-05-oq-01-oq-01: split sections to 5

### DIFF
--- a/src/data/proofs/sum-of-kth-powers-oq-05-oq-01-oq-01/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-05-oq-01-oq-01/meta.json
@@ -106,11 +106,19 @@
       "mathContext": "$\\sum_{i<m\\cdot n} i^k \\equiv n\\,\\sum_{i<m} i^k \\pmod m$."
     },
     {
-      "id": "crt",
-      "title": "Factor Readings and the CRT Characterization",
+      "id": "factor-readings",
+      "title": "Reading the Composite Sum Modulo Each Factor",
       "startLine": 70,
+      "endLine": 79,
+      "summary": "sum_pow_modEq_left / sum_pow_modEq_right: the composite sum ∑_{i<a·b} iᵏ read modulo each coprime factor, both instances of the replication congruence (at m=a,n=b and m=b,n=a via Nat.mul_comm).",
+      "mathContext": "$\\sum_{i<ab} i^k \\equiv b\\sum_{i<a} i^k \\pmod a, \\qquad \\sum_{i<ab} i^k \\equiv a\\sum_{i<b} i^k \\pmod b$."
+    },
+    {
+      "id": "crt-characterization",
+      "title": "The CRT Characterization",
+      "startLine": 81,
       "endLine": 114,
-      "summary": "sum_pow_modEq_left / sum_pow_modEq_right (the two factor readings) and sum_pow_crt (the complete CRT characterization for coprime a,b), plus sum_pow_crt_two_primes (the explicit distinct-primes formula via the parent dichotomy).",
+      "summary": "sum_pow_crt (the complete CRT characterization for coprime a,b, via Nat.modEq_and_modEq_iff_modEq_mul) and sum_pow_crt_two_primes (the explicit distinct-primes formula, composing the CRT characterization with the parent's prime dichotomy).",
       "mathContext": "$x \\equiv \\sum_{i<a b} i^k \\pmod{ab} \\iff x \\equiv b\\sum_{i<a} i^k \\pmod a \\wedge x \\equiv a\\sum_{i<b} i^k \\pmod b$."
     },
     {


### PR DESCRIPTION
## Summary
- `sections.length` was 4, below the 5-section target for a quality-96 entry, with four distinct theorems lumped into one `crt` section (lines 70-114): the two factor-reading lemmas (`sum_pow_modEq_left`/`sum_pow_modEq_right`) and the two CRT characterization theorems (`sum_pow_crt`, `sum_pow_crt_two_primes`).
- `annotations.json` already treats the factor readings (`ann-sokp-oq050101-factor-readings`, 70-79) separately from the CRT characterization (`ann-sokp-oq050101-crt` + `ann-sokp-oq050101-two-primes`, 81-114), so `sections` is split at the same real theorem boundary rather than adding filler.
- Result: 5 sections, still fully covering lines 1-133 of the 133-line Lean file, well under the size caps (14.5 KB meta.json).

## Test plan
- [x] Validated JSON structure (`python3 -c "import json; json.load(...)"`)
- [x] `pnpm build` produced zero errors for this entry
- [x] Verified all lemma/theorem names cited in meta.json/annotations.json match the Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)