### PR TITLE
audit: erdos-49 — mark issues-fixed (5th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14038,9 +14038,9 @@
     },
     "erdos-49": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:38Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T23:04:52Z",
+      "result": "issues-fixed"
     },
     "erdos-490": {
       "agentId": "lean-auditor-reaudit",


### PR DESCRIPTION
## Audit

Reserve-mode re-verification of erdos-49 following PR #42704, which fixed
stale proofStrategy/section prose falsely claiming the totient lower bound
and Tao's (2023) upper bound were "axiomatized"/"stated" when both are only
docstring comments (no Lean `axiom` or `theorem` declaration).

**Verified**: `proofs/Proofs/Erdos49Problem.lean` has 0 `axiom` declarations,
0 sorries; meta.json prose now correctly describes both bounds as
comment-only, not formalized. Top-level `status: axiomatized` / `badge: wip`
remain honest per the repo's convention for 0-axiom-but-incomplete results.

Marks the tracker entry `issues-fixed` (auditCount 4→5) since the tracker
wasn't updated by the fix PR itself.

Discovered during gallery integrity audit (reserve mode, queue drained).