### PR TITLE
Enrich sylow-theorem-oq-02-oq-01: split header section to 5 (docstring/imports)

### DIFF
--- a/src/data/proofs/sylow-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-02-oq-01/meta.json
@@ -85,12 +85,20 @@
   },
   "sections": [
     {
-      "id": "setup",
-      "title": "Setup: Local-to-Global Framing",
+      "id": "docstring",
+      "title": "Overview: Local-to-Global Framing",
       "startLine": 1,
-      "endLine": 49,
-      "summary": "Module docstring framing the lift from the parent's per-prime n_p = [G : N_G(P)] criterion to a global nilpotency characterization, imports (Nilpotent, Sylow, Subgroup.Basic, Tactic), namespace SylowNilpotent, and the standing context variable {G : Type*} [Group G] [Finite G].",
+      "endLine": 37,
+      "summary": "Module docstring framing the lift from the parent's per-prime n_p = [G : N_G(P)] criterion to a global nilpotency characterization: nilpotent ⟺ all Sylow normal ⟺ every Sylow count n_p = 1. States the four main results and notes that fusing Mathlib's TFAE headline with Sylow uniqueness supplies the counting form.",
       "mathContext": "Finiteness is essential: nilpotent ⟺ all-Sylow-normal is special to finite groups."
+    },
+    {
+      "id": "imports-setup",
+      "title": "Imports and Standing Context",
+      "startLine": 38,
+      "endLine": 49,
+      "summary": "Imports Mathlib.GroupTheory.Nilpotent, Mathlib.GroupTheory.Sylow, Mathlib.Algebra.Group.Subgroup.Basic, and Mathlib.Tactic. Namespace SylowNilpotent, and the standing context variable {G : Type*} [Group G] [Finite G] shared by all four theorems.",
+      "mathContext": "All results below are stated for an arbitrary finite group G."
     },
     {
       "id": "headline",


### PR DESCRIPTION
Enrichment pass for `sylow-theorem-oq-02-oq-01` (quality 96, pass 0).

## Assessment
meta.json (14 KB) well under caps; annotations already at 5. Gap: **sections 4, need 5** — `setup` (1-49) bundled the module docstring with the imports/namespace/variable declaration, two distinct units.

## Change
Split `setup` at the real declaration boundary (no accretion elsewhere):
- **docstring** (1-37): the module docstring — local-to-global framing and the four main results.
- **imports-setup** (38-49): the four imports, `namespace SylowNilpotent`, and the standing `variable {G : Type*} [Group G] [Finite G]`.

The other three sections (`headline`, `normalizer`, `counting`) are unchanged.

## Verification
- JSON validated (`json.load`).
- Content checked against `Proofs/SylowTheoremOQ02OQ01Nilpotent.lean` — docstring ends at line 37, imports at 39-42, namespace at 44, variable at 46, matching the new boundaries.