### PR TITLE
Gallery integrity: erdos-486 — comment-only text mislabeled as axiom

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14008,9 +14008,9 @@
     },
     "erdos-486": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:38Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T23:08:51Z",
+      "result": "issues-fixed"
     },
     "erdos-487": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-486/annotations.json
+++ b/src/data/proofs/erdos-486/annotations.json
@@ -127,19 +127,18 @@
     },
     "type": "concept",
     "title": "The Main Conjecture",
-    "content": "**Erdős Problem #486** (OPEN): For ANY choice of forbidden residue sets X_n, the modular avoidance set B has a logarithmic density.\n\nThis is stated as an `axiom` because it's unproven. Using axiom makes the open status explicit in the Lean formalization—we're asserting without proof.",
+    "content": "**Erdős Problem #486** (OPEN): For ANY choice of forbidden residue sets X_n, the modular avoidance set B has a logarithmic density.\n\nThis is documented as a comment (no `axiom` is declared) because it's unproven; the open status is left explicit without asserting anything to the kernel.",
     "mathContext": "$\\forall X : (n : \\mathbb{N}) \\to \\mathcal{P}(\\mathbb{Z}/n\\mathbb{Z}),\\; \\exists d \\in \\mathbb{R},\\; \\text{HasLogDensity}(\\text{avoidanceSet}(X), d)$. The conjecture quantifies over ALL possible choices of forbidden sets, making it vastly more general than the Davenport-Erdős special case.",
     "significance": "key",
     "relatedConcepts": [
       "open conjecture",
-      "axiom declaration",
+      "documentation comments",
       "universal quantification",
       "existential density"
     ],
     "prerequisites": [
       "logarithmic density",
-      "modular avoidance sets",
-      "Lean axiom semantics"
+      "modular avoidance sets"
     ]
   },
   {
@@ -176,7 +175,7 @@
     "type": "concept",
     "title": "Davenport-Erdős Theorem (1936)",
     "content": "**Davenport and Erdős proved** that zero-avoidance sets always have logarithmic density. This is the foundational result that Problem #486 seeks to generalize.\n\nThe theorem was proved in 1936 with an elementary re-proof in 1951. It establishes that avoiding divisibility by any set of integers yields a set with well-defined logarithmic density.",
-    "mathContext": "$\\forall A \\subseteq \\mathbb{N},\\; \\exists d \\in \\mathbb{R},\\; \\text{HasLogDensity}(\\text{zeroAvoidanceSet}(A), d)$. Stated as axiom pending Mathlib formalization of the 1936 proof.",
+    "mathContext": "$\\forall A \\subseteq \\mathbb{N},\\; \\exists d \\in \\mathbb{R},\\; \\text{HasLogDensity}(\\text{zeroAvoidanceSet}(A), d)$. Documented as a comment pending Mathlib formalization of the 1936 proof (no axiom is declared).",
     "significance": "key",
     "relatedConcepts": [
       "Davenport-Erdős theorem",

--- a/src/data/proofs/erdos-486/meta.json
+++ b/src/data/proofs/erdos-486/meta.json
@@ -63,7 +63,7 @@
     "historicalContext": "This problem was posed by Paul Erdős as a generalization of earlier work on sets of integers defined by divisibility conditions. The foundational result is the Davenport-Erdős theorem (1936), which proved that sets of integers avoiding divisibility by elements of any set A always have a logarithmic density. Davenport and Erdős published their original proof in Acta Arithmetica, and Erdős later gave a simplified elementary proof in the Journal of the London Mathematical Society (1951) that avoided analytic methods entirely.\n\nBesicovitch (1934) demonstrated that natural density is too strong a requirement—there exist sets with logarithmic density but no natural density. His construction uses a carefully chosen sequence of primes with rapidly growing gaps, ensuring the counting function oscillates without converging. This justified the focus on logarithmic density for such problems.\n\nProblem #486 asks whether the Davenport-Erdős result extends to the far more general setting where we forbid arbitrary residue classes modulo each n, not just the class 0 (divisibility). This places the problem squarely in the intersection of additive combinatorics, sieve theory, and analytic number theory. The difficulty lies in the fact that arbitrary forbidden residue classes can create intricate interference patterns between moduli, unlike the structured divisibility condition.\n\nThis problem is part of Erdős's broader research program on densities of integer sequences, which includes Problems #25 (single forbidden residue per modulus) and #1134 (density of sets closed under affine maps). The hierarchy of generalizations reveals how rapidly the difficulty increases as the forbidden sets become more complex.",
     "problemStatement": "For each $n \\in \\mathbb{N}$, choose some $X_n \\subseteq \\mathbb{Z}/n\\mathbb{Z}$. Define the **modular avoidance set**:\n$$B = \\{m \\in \\mathbb{N} : m \\not\\equiv x \\pmod{n} \\text{ for all } n \\in \\mathbb{N}, x \\in X_n\\}$$\n\n**Conjecture**: $B$ must have a **logarithmic density**, i.e.,\n$$\\lim_{x \\to \\infty} \\frac{1}{\\log x} \\sum_{\\substack{m \\in B \\\\ m < x}} \\frac{1}{m}$$\nexists.\n\n**Status**: OPEN",
     "text": "For any choice of forbidden residue classes modulo each n, must the set of integers avoiding all forbidden classes have a logarithmic density?",
-    "proofStrategy": "Since this is an open conjecture, we cannot provide a proof. Our formalization:\n\n1. **Defines logarithmic density** precisely using Mathlib's Filter.Tendsto for limits\n2. **Formalizes the avoidance set** B using ZMod for modular arithmetic\n3. **States the conjecture** as an axiom, making the open status explicit\n4. **Records partial results** (Davenport-Erdős theorem) and context (Besicovitch counterexample)\n\nThe key insight is that logarithmic density is weaker than natural density, and this problem asks whether the Davenport-Erdős result—that divisibility-based avoidance sets have logarithmic density—extends to the much broader class of modular avoidance sets.",
+    "proofStrategy": "Since this is an open conjecture, we cannot provide a proof. Our formalization:\n\n1. **Defines logarithmic density** precisely using Mathlib's Filter.Tendsto for limits\n2. **Formalizes the avoidance set** B using ZMod for modular arithmetic\n3. **Documents the conjecture** in a comment block, making the open status explicit (no axiom is declared)\n4. **Records partial results** (Davenport-Erdős theorem) and context (Besicovitch counterexample) as comments, not formal declarations\n\nThe key insight is that logarithmic density is weaker than natural density, and this problem asks whether the Davenport-Erdős result—that divisibility-based avoidance sets have logarithmic density—extends to the much broader class of modular avoidance sets.",
     "keyInsights": [
       "**Logarithmic vs Natural Density**: Logarithmic density weights smaller integers more heavily (by 1/n), making it more likely to exist. Besicovitch showed natural density can fail even in simple cases.",
       "**Modular Avoidance**: Forbidding residue classes {0} mod n is just divisibility avoidance. The general case allows forbidding any residues, a strictly more complex condition.",
@@ -109,7 +109,7 @@
       "title": "Erdős Conjecture #486",
       "startLine": 57,
       "endLine": 76,
-      "summary": "States the open conjecture as an axiom: for any choice of forbidden residue sets X_n, the modular avoidance set has a logarithmic density.",
+      "summary": "Documents the open conjecture in a comment block (no axiom is declared): for any choice of forbidden residue sets X_n, the modular avoidance set has a logarithmic density.",
       "mathContext": "$\\forall X : (n : \\mathbb{N}) \\to \\mathcal{P}(\\mathbb{Z}/n\\mathbb{Z}),\\; \\exists d \\in \\mathbb{R},\\; \\text{HasLogDensity}(\\text{avoidanceSet}(X), d)$."
     },
     {
@@ -117,7 +117,7 @@
       "title": "Davenport-Erdős Theorem (1936)",
       "startLine": 77,
       "endLine": 97,
-      "summary": "Defines the zero-avoidance set (non-divisibility set) and states the Davenport-Erdős theorem: zero-avoidance sets always have logarithmic density. This is the proven X_n = {0} special case of #486.",
+      "summary": "Defines the zero-avoidance set (non-divisibility set) and documents the Davenport-Erdős theorem in a comment block (not a formal declaration): zero-avoidance sets always have logarithmic density. This is the proven X_n = {0} special case of #486.",
       "mathContext": "$\\text{zeroAvoidanceSet}(A) = \\{m : \\forall n \\in A,\\; n \\nmid m\\}$. Davenport-Erdős (1936): $\\forall A \\subseteq \\mathbb{N},\\; \\exists d,\\; \\text{HasLogDensity}(\\text{zeroAvoidanceSet}(A), d)$."
     },
     {
@@ -125,12 +125,12 @@
       "title": "Besicovitch Counterexample and Natural Density",
       "startLine": 98,
       "endLine": 108,
-      "summary": "Defines natural (asymptotic) density and states the Besicovitch counterexample: there exists a set A whose zero-avoidance set has logarithmic density but NOT natural density. This justifies the use of logarithmic density in #486.",
+      "summary": "Defines natural (asymptotic) density and documents the Besicovitch counterexample in a comment block (not a formal declaration): there exists a set A whose zero-avoidance set has logarithmic density but NOT natural density. This justifies the use of logarithmic density in #486.",
       "mathContext": "$\\text{HasNaturalDensity}(A, d) \\iff \\lim_{n \\to \\infty} \\frac{|A \\cap [0,n]|}{n+1} = d$. Besicovitch (1934): $\\exists A$ s.t. $\\text{zeroAvoidanceSet}(A)$ has log density but not natural density, proving logarithmic density is strictly weaker."
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #486, an open conjecture in analytic number theory about the existence of logarithmic densities for modular avoidance sets. We define the key concepts precisely and state the conjecture as an axiom, documenting its relationship to the proven Davenport-Erdős theorem and the Besicovitch counterexample that motivates the use of logarithmic density.",
+    "summary": "This formalization captures Erdős Problem #486, an open conjecture in analytic number theory about the existence of logarithmic densities for modular avoidance sets. We define the key concepts precisely and document the conjecture in a comment block (no axiom is declared), noting its relationship to the proven Davenport-Erdős theorem and the Besicovitch counterexample that motivates the use of logarithmic density.",
     "implications": "A positive resolution would unify and extend the theory of integer density under modular constraints. A negative answer would reveal surprising pathological behavior in seemingly natural sets of integers.",
     "openQuestions": [
       "Does the conjecture hold when X_n is finite for all n?",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-486
**Problem**: `overview.proofStrategy`, three section summaries (`main-conjecture`, `special-case`, `related-results`), and two annotations described the open conjecture, the Davenport-Erdős theorem, and the Besicovitch counterexample as "stated as an axiom" / "an axiom declaration". `proofs/Proofs/Erdos486Problem.lean` has **zero** `axiom` or `theorem` declarations — all three are bare `/- ... -/` block comments only.

## Evidence

**meta.json claimed**: "States the conjecture as an axiom, making the open status explicit"; "States the open conjecture as an axiom: ..."; "...states the Davenport-Erdős theorem: ..."; "...states the Besicovitch counterexample: ...". annotations.json: "This is stated as an `axiom` because it's unproven."

**Lean file shows**: `Proofs/Erdos486Problem.lean` contains only 5 `def`s (`logSum`, `HasLogDensity`, `avoidanceSet`, `zeroAvoidanceSet`, `HasNaturalDensity`); the conjecture and both cited results are documentary block comments with no `axiom`/`theorem` keyword. This matches the file's own `axiomCount: 0` and `assumptions` field ("No formal axiom or theorem statements are declared").

## Fix

Reworded the overclaiming prose in `meta.json` and `annotations.json` to say these are documented in comment blocks (no axiom declared), consistent with the already-honest top-level counts. Same pattern previously fixed in erdos-496 (#42698) and erdos-49 (#42704).

## Audit tracker

`audit-tracker.json` updated: erdos-486 marked `issues-fixed`.

---
Discovered during gallery integrity audit (reserve/round-robin mode, queue fully drained: 4811/4811 audited).