### PR TITLE
Enrich triangle-angle-sum-oq-06: split sections to 5, close small coverage gaps

### DIFF
--- a/src/data/proofs/triangle-angle-sum-oq-06/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-06/meta.json
@@ -89,17 +89,25 @@
       "id": "sum-to-product",
       "title": "The Four Sum-to-Product (Prosthaphaeresis) Identities",
       "startLine": 46,
-      "endLine": 99,
+      "endLine": 100,
       "mathContext": "$\\cos x + \\cos y = 2\\cos\\tfrac{x+y}{2}\\cos\\tfrac{x-y}{2}$ and its three companions.",
       "summary": "cos_add_cos, cos_sub_cos, sin_add_sin and sin_sub_sin convert each sum or difference of two sinusoids into a product of two sinusoids, proved by a three-line calc: rewrite x and y through the mean (x+y)/2 and half-difference (x−y)/2, expand with Real.cos_add / Real.cos_sub (resp. Real.sin_add / Real.sin_sub), and close by ring. They coincide with Mathlib's Real.cos_add_cos etc., anchored here from the addition formulas as the building blocks for the triangle corollaries."
     },
     {
-      "id": "half-angle-products",
-      "title": "The Triangle Half-Angle Product Identities",
+      "id": "half-angle-identities",
+      "title": "The General Half-Angle Product Identities (a+b+c=π/2)",
       "startLine": 101,
-      "endLine": 161,
+      "endLine": 140,
+      "mathContext": "$\\sin 2a + \\sin 2b + \\sin 2c = 4\\cos a\\cos b\\cos c$ for $a+b+c=\\pi/2$.",
+      "summary": "half_angle_sin_sum and half_angle_cos_sum establish the general a+b+c=π/2 products sin(2a)+sin(2b)+sin(2c) = 4·cos a·cos b·cos c and cos(2a)+cos(2b)+cos(2c) = 1 + 4·sin a·sin b·sin c by eliminating c via the π-reflections (Real.sin_pi_sub, Real.cos_pi_div_two_sub and their cos/sin counterparts) and closing the residual Pythagorean polynomial identity with linear_combination against Real.sin_sq_add_cos_sq."
+    },
+    {
+      "id": "triangle-identities",
+      "title": "The Triangle Half-Angle Product Corollaries (A+B+C=π)",
+      "startLine": 141,
+      "endLine": 162,
       "mathContext": "$\\sin A + \\sin B + \\sin C = 4\\cos\\tfrac{A}{2}\\cos\\tfrac{B}{2}\\cos\\tfrac{C}{2}$ for $A+B+C=\\pi$.",
-      "summary": "half_angle_sin_sum and half_angle_cos_sum establish the general a+b+c=π/2 products sin(2a)+sin(2b)+sin(2c) = 4·cos a·cos b·cos c and cos(2a)+cos(2b)+cos(2c) = 1 + 4·sin a·sin b·sin c by eliminating c via the π-reflections and closing the residual Pythagorean polynomial identity with linear_combination. triangle_sin_sum and triangle_cos_sum specialise them to the angles of a triangle (a = A/2, etc.), giving the classical identities not recorded in Mathlib."
+      "summary": "triangle_sin_sum and triangle_cos_sum specialise the half-angle identities to the angles of a triangle by substituting a = A/2, b = B/2, c = C/2 (so a+b+c = (A+B+C)/2 = π/2) and rewriting 2·(A/2) = A, giving the classical identities sin A + sin B + sin C = 4·cos(A/2)·cos(B/2)·cos(C/2) and cos A + cos B + cos C = 1 + 4·sin(A/2)·sin(B/2)·sin(C/2), not recorded in Mathlib."
     },
     {
       "id": "worked-instance",


### PR DESCRIPTION
Enrichment pass for `triangle-angle-sum-oq-06` (quality 96, pass 0).

## Assessment
meta.json (20 KB) well under caps; annotations already substantial. Two gaps: **sections 4, need 5**, and lines 100 and 162 (blank divider lines before `/-! ### ... -/` doc-comments) were uncovered — `sum-to-product` ended at 99, `half-angle-products` ran 101-161, `worked-instance` started at 163.

## Change
Split the 61-line `half-angle-products` section, which bundled two conceptually distinct pairs of theorems, at the real declaration boundary between the general half-angle lemmas and their triangle-specific corollaries:
- **half-angle-identities** (101-140): `half_angle_sin_sum` / `half_angle_cos_sum`, the general a+b+c=π/2 products.
- **triangle-identities** (141-162): `triangle_sin_sum` / `triangle_cos_sum`, the A+B+C=π corollaries obtained by substituting a=A/2 etc.

Also extended `sum-to-product` to end at 100 (was 99) and `triangle-identities` to end at 162 (was 161), closing the two 1-line gaps.

Result: 5 sections, fully contiguous coverage of all 175 lines, no accretion elsewhere.

## Verification
- JSON validated (`json.load`); confirmed zero gaps between consecutive section boundaries.
- Content checked against `Proofs/TriangleAngleSumOQ06.lean` — `half_angle_sin_sum`/`half_angle_cos_sum` at 114/131, `triangle_sin_sum`/`triangle_cos_sum` at 144/155, matching the new boundaries.