### PR TITLE
Gallery integrity: erdos-477 — comment-only conjectures mislabeled as axiom/def

### DIFF
--- a/src/data/proofs/erdos-477/meta.json
+++ b/src/data/proofs/erdos-477/meta.json
@@ -31,13 +31,13 @@
     "historicalContext": "Erdős and Graham posed this problem in their 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory*, asking whether any polynomial of degree $\\geq 2$ can 'perfectly tile' the integers by translation. The question asks: given $f : \\mathbb{Z} \\to \\mathbb{Z}$ of degree $\\geq 2$, does there exist $A \\subseteq \\mathbb{Z}$ such that $\\mathbb{Z} = A \\oplus f(\\mathbb{Z})$? Sekanina (1959) had already shown this is impossible for $f(x) = x^2$ by analyzing the gap structure between consecutive squares. The problem connects to several deep areas: factorization of abelian groups (Hajós's theorem), the Coven-Meyerowitz conjecture on tiling $\\mathbb{Z}$ by finite sets, and additive combinatorics more broadly. The key difficulty is that polynomial images are sparse ($|f(\\mathbb{Z}) \\cap [-N,N]| = O(N^{1/d})$ for degree $d$), so any complement $A$ must have density approaching 1, yet must avoid double-covering any integer. The formalization is notable for containing many proved theorems (not just axioms), establishing structural properties of perfect complements.",
     "problemStatement": "Is there a polynomial $f : \\mathbb{Z} \\to \\mathbb{Z}$ of degree $\\geq 2$ and a set $A \\subseteq \\mathbb{Z}$ such that $\\mathbb{Z} = A \\oplus f(\\mathbb{Z})$, i.e., every integer has a unique representation $z = a + f(n)$ with $a \\in A$, $n \\in \\mathbb{Z}$?",
     "text": "Is there a polynomial f: ℤ → ℤ of degree ≥ 2 and a set A ⊆ ℤ such that every integer has a unique representation a + f(n)? Sekanina (1959) showed no for f(x) = x². Erdős–Graham conjecture: no for all such f. Open.",
-    "proofStrategy": "The formalization builds a theory of perfect complements from scratch, proving structural properties (non-emptiness, commutativity, shift invariance, difference set constraints, finiteness obstructions), then specializing to the squares case with gap analysis. The main conjectures are axiomatized: no degree $\\geq 2$ polynomial, no monomial $x^k$ ($k \\geq 2$), and the combined Erdős-Graham conjecture. The linear case $f(x) = x$ is proved trivial, motivating the degree $\\geq 2$ restriction.",
+    "proofStrategy": "The formalization builds a theory of perfect complements from scratch, proving structural properties (non-emptiness, commutativity, shift invariance, difference set constraints, finiteness obstructions), then specializing to the squares case with gap analysis. The main conjectures (no degree $\\geq 2$ polynomial, no monomial $x^k$ with $k \\geq 2$, and the combined Erdős-Graham conjecture) are documented as block comments only, not formal `axiom` or `def` declarations — the file contains zero axioms. The linear case $f(x) = x$ is proved trivial, motivating the degree $\\geq 2$ restriction.",
     "keyInsights": [
       "The difference set constraint $(A - A) \\cap (B - B) = \\{0\\}$ is the key algebraic obstruction: it forces $A$ and $f(\\mathbb{Z})$ to have 'incompatible' additive structure",
       "Sekanina's argument for squares uses the growing gap $(n+1)^2 - n^2 = 2n+1$ between consecutive squares: $A$ must fill these widening gaps while maintaining unique representation",
       "The linear case $f(x) = x$ is trivially solvable ($A = \\{0\\}$), showing the degree $\\geq 2$ condition is essential, not an artifact",
       "For degree $d \\geq 2$, the complement $A$ must have density $\\to 1$ since $|f(\\mathbb{Z}) \\cap [-N,N]| = O(N^{1/d})$, yet $A$ must avoid all difference-set conflicts with $f(\\mathbb{Z})$",
-      "The file proves 12 theorems from scratch (not axioms), making it one of the most complete formalizations in the gallery"
+      "The file proves 22 theorems from scratch (not axioms), making it one of the most complete formalizations in the gallery"
     ],
     "prerequisites": [
       "Analysis (approximation theory, interpolation)",
@@ -108,12 +108,12 @@
       "title": "Main Conjectures (Open)",
       "startLine": 242,
       "endLine": 261,
-      "summary": "Axioms: Erdős-Graham conjecture (no degree $\\geq 2$ polynomial tiles $\\mathbb{Z}$), monomial conjecture, and main statement.",
-      "mathContext": "Axiomatized: Axioms: Erdős-Graham conjecture (no degree $\\geq 2$ polynomial tiles $\\mathbb{Z}$), monomial conjecture, and main statement."
+      "summary": "Block comments (not formal declarations): Erdős-Graham conjecture (no degree $\\geq 2$ polynomial tiles $\\mathbb{Z}$), monomial conjecture, and main statement.",
+      "mathContext": "Documented only as prose comments (no `axiom` or `def` declaration): Erdős-Graham conjecture (no degree $\\geq 2$ polynomial tiles $\\mathbb{Z}$), monomial conjecture, and main statement."
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem 477 with a rich development of perfect complement theory: 12 proved theorems establishing structural properties (difference sets, symmetries, finiteness, gap analysis) alongside 3 open conjectures stated as `def : Prop` (not formal `axiom` declarations; leanFile.axiomCount = 0). This is one of the most substantially proved entries in the gallery.",
+    "summary": "The formalization captures Erdős Problem 477 with a rich development of perfect complement theory: 22 proved theorems establishing structural properties (difference sets, symmetries, finiteness, gap analysis) alongside 3 open conjectures documented only as block comments (not formal `def` or `axiom` declarations; leanFile.axiomCount = 0). This is one of the most substantially proved entries in the gallery.",
     "implications": "**Theoretical Significance**: Resolution of this conjecture would deepen our understanding of which subsets of $\\mathbb{Z}$ can tile by translation.\n\nIt connects to the Coven-Meyerowitz conjecture (which characterizes finite sets tiling $\\mathbb{Z}$), Hajós's theorem on factorizations of abelian groups, and the broader theory of sumsets in additive combinatorics. A positive answer (some polynomial tiles) would be remarkable; the expected negative answer would confirm a fundamental rigidity of polynomial images.",
     "openQuestions": [
       "Does the Erdős-Graham conjecture hold: is it true that no polynomial $f$ of degree $\\geq 2$ admits $A$ with $A \\oplus f(\\mathbb{Z}) = \\mathbb{Z}$?",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-477 (Polynomial Complements of Integer Sets)
**Problem**: `proofStrategy`, the `main-conjectures` section (summary + mathContext), and `conclusion.summary` describe the 3 open conjectures (Erdős-Graham, monomial case, combined main statement) as "axiomatized" or "stated as `def : Prop`". In reality, lines 245-261 of the Lean file are pure `/- ... -/` block comments — there is no `axiom` declaration anywhere in the file, and the only 2 `def`s (`polyImage`, `IsPerfectComplement`) are unrelated infrastructure, not the conjectures themselves.

Same class as #42712 (erdos-486), #42698 (erdos-496), and the earlier erdos-49 occurrence: comment-only prose mislabeled as a formal declaration.

Also fixed a stale "12 proved theorems" prose count (in `keyInsights` and `conclusion.summary`) to the actual 22, matching the existing `theoremCount: 22` field already in the same meta.json.

## Evidence

**meta.json claimed**: "The main conjectures are axiomatized: ..." / section mathContext "Axiomatized: Axioms: ..." / conclusion "3 open conjectures stated as `def : Prop` (not formal `axiom` declarations; leanFile.axiomCount = 0)"

**Lean file shows**: `grep -n axiom proofs/Proofs/Erdos477Problem.lean` returns nothing; `grep -n "^def" ...` returns only `polyImage` and `IsPerfectComplement` (lines 27, 33). Lines 243-261 ("The Main Conjectures" section) are entirely `/- ... -/` block comments with no declarations.

## Fix

Reworded `proofStrategy`, the `main-conjectures` section summary/mathContext, and `conclusion.summary` to say the conjectures are documented as block comments only (not formal `axiom` or `def` declarations), and corrected the stale theorem count.

Top-level `status: "axiomatized"` left unchanged — that's a category convention for axiomatized-style open problems in this gallery, independent of whether a literal `axiom` keyword exists. `axiomCount: 0` was already correct.

---
Discovered during gallery integrity audit (queue drained 4811/4811, round-robin reserve mode).