### PR TITLE
audit: erdos-477 — refresh tracker timestamp

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13927,8 +13927,8 @@
     },
     "erdos-477": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:38Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T23:15:24Z",
       "result": "clean"
     },
     "erdos-478": {


### PR DESCRIPTION
## Integrity Audit

**Proof**: erdos-477

Content fix (comment-only text mislabeled as axiom/def) already merged in #42715, but that PR only touched `meta.json`, leaving `audit-tracker.json`'s `lastAudited` stamped 2026-05-04. Reserve-mode `find-targets.ts --next` kept re-selecting erdos-477 as the oldest target.

Verified current state is consistent before refreshing:
- `meta.json` proofStrategy/summary correctly describe the 3 open conjectures as block comments, not axioms
- `Erdos477Problem.lean`: 0 axioms, 2 defs (matching prose), 22 theorems, 0 sorries

Tracker-only change; no content modified.

---
Discovered during gallery integrity audit (queue drained, reserve mode).