### PR TITLE
Enrich basel-problem-oq-11: link discharged open question to child oq-01

### DIFF
--- a/src/data/proofs/basel-problem-oq-11/meta.json
+++ b/src/data/proofs/basel-problem-oq-11/meta.json
@@ -140,7 +140,7 @@
     "openQuestions": [
       {
         "id": "basel-problem-oq-11-oq-01",
-        "question": "Generalize the even/odd parity split to a reusable lemma η(2m) = (1 - 2^(1-2m)) ζ(2m) for all even arguments, deriving η(4) = 7π⁴/720 from Mathlib's hasSum_zeta_four with no new analytic input.",
+        "question": "Now discharged by basel-problem-oq-11-oq-01, which proves the general lemma η(e) = (1 − 2^{1−e})ζ(e) for arbitrary natural e (recovering η(4) = 7π⁴/720 at e = 4). The next step that lemma itself poses: package it against Mathlib's hasSum_zeta_nat to get a closed Bernoulli-number form η(2m) = (1 − 2^{1−2m})·(−1)^{m+1} B_{2m} (2π)^{2m} / (2·(2m)!) for all m ≥ 1.",
         "significance": "medium"
       },
       {
@@ -164,7 +164,12 @@
     {
       "targetId": "basel-problem-oq-14",
       "relationship": "related — degree-4 analog",
-      "description": "The degree-4 counterpart η(4) = ∑ (−1)ⁿ⁺¹/n⁴ = 7π⁴/720 applies this entry's exact even/odd + parity-sign template to ζ(4) = π⁴/90 via η(4) = (1 − 2⁻³)ζ(4) = (7/8)ζ(4). It is precisely the η(2m) generalization this entry's open question 1 asks for, at m = 2."
+      "description": "The degree-4 counterpart η(4) = ∑ (−1)ⁿ⁺¹/n⁴ = 7π⁴/720 applies this entry's exact even/odd + parity-sign template directly to ζ(4) = π⁴/90 via η(4) = (1 − 2⁻³)ζ(4) = (7/8)ζ(4), as a standalone concrete proof rather than an instance of a general lemma."
+    },
+    {
+      "targetId": "basel-problem-oq-11-oq-01",
+      "relationship": "extended-by",
+      "description": "Directly answers this entry's open question 1: generalizes the even/odd parity split proved here at s = 2 into a single reusable lemma η(e) = (1 − 2^{1−e})ζ(e) for arbitrary natural exponent e, then specializes it at e = 4 to recover η(4) = 7π⁴/720 — the actual η(2m) generalization requested, as opposed to basel-problem-oq-14's standalone concrete proof of the same value."
     },
     {
       "targetId": "basel-problem-oq-10",
@@ -197,7 +202,7 @@
   "openQuestions": [
     {
       "id": "basel-problem-oq-11-oq-01",
-      "question": "Generalize the even/odd parity split to η(2m) = (1 - 2^(1-2m)) ζ(2m) and derive η(4) = 7π⁴/720 from hasSum_zeta_four.",
+      "question": "Now discharged by basel-problem-oq-11-oq-01 (general lemma η(e) = (1 − 2^{1−e})ζ(e), specialized at e = 4 to η(4) = 7π⁴/720). Next: package it against hasSum_zeta_nat for a closed Bernoulli-number form η(2m) = (1 − 2^{1−2m})·(−1)^{m+1} B_{2m} (2π)^{2m} / (2·(2m)!) for all m ≥ 1.",
       "significance": "medium"
     },
     {


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-11` (Dirichlet eta at 2). No open PR against this exact target as of claim time.

`basel-problem-oq-11-oq-01` ("η(2m) = (1 − 2^{1−2m})ζ(2m), η(4) = 7π⁴/720") is the child of this entry and directly answers its stated open question 1 ("generalize the parity split to η(2m) ... deriving η(4) = 7π⁴/720"), but the parent had no `crossReferences` entry pointing at it. The parent's existing crossReference to `basel-problem-oq-14` (a standalone concrete η(4) proof, not a general lemma) had mislabeled that file as "precisely the η(2m) generalization" the open question asks for — it isn't; it's a fixed-exponent instance built from the same template, while `basel-problem-oq-11-oq-01` proves the actual general lemma.

- Added an `extended-by` crossReference to `basel-problem-oq-11-oq-01`.
- Clarified the `basel-problem-oq-14` crossReference wording to note it's a standalone proof rather than an instance of a general lemma.
- Rewrote openQuestion 1 (in both `conclusion.openQuestions` and the duplicate top-level `openQuestions` array, which had drifted to slightly different wording) to record the discharge and forward to the child's own next open question — a closed Bernoulli-number form for all m.

No other content changed. `meta.json` stays at 14.8 KB, well under the 60 KB cap.
