### PR TITLE
Enrich sylow-theorems-oq-01-oq-02-oq-01: split sections to 5, cover header

### DIFF
--- a/src/data/proofs/sylow-theorems-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/sylow-theorems-oq-01-oq-02-oq-01/meta.json
@@ -51,24 +51,38 @@
   },
   "sections": [
     {
-      "id": "sylow-count",
-      "title": "Sylow count is one for every prime",
-      "summary": "card_sylow_eq_one_of_card_pq: the arithmetic core. Case split on whether r divides |G|; modular/divisibility reasoning for r ∈ {p,q}, structural triviality otherwise.",
+      "id": "header",
+      "title": "Header, method summary, and honest scope",
+      "summary": "Module docstring: the biprimal isomorphism-class problem, the q ∤ (p−1) direction this file settles, the Z-group/nilpotency method outline, and the disclosed honest scope (the q ∣ (p−1) case is left open). Opens the SylowOrderPQ namespace with classical logic and fixes an arbitrary group G.",
+      "startLine": 1,
+      "endLine": 48
+    },
+    {
+      "id": "sylow-count-divisors",
+      "title": "Sylow count, divisor case: r = p or r = q",
+      "summary": "card_sylow_eq_one_of_card_pq, first half: for r dividing |G| = p·q, coprimality collapses n_r ∣ p·q to n_r ∣ q (r=p) or n_r ∣ p (r=q); the nontrivial divisor is ruled out by the modular congruence, using q < p for r=p and the hypothesis q ∤ (p−1) for r=q.",
       "startLine": 49,
-      "endLine": 114
+      "endLine": 101
+    },
+    {
+      "id": "sylow-count-trivial",
+      "title": "Sylow count, non-divisor case: r ∤ |G|",
+      "summary": "Closes card_sylow_eq_one_of_card_pq: for a prime r not dividing |G|, every Sylow r-subgroup is forced trivial (order r^k ∣ p·q with r ∤ p·q forces k = 0), so Sylow r G is a Subsingleton and n_r = 1 — needed since the nilpotency criterion quantifies over every prime, not just those dividing |G|.",
+      "startLine": 102,
+      "endLine": 113
     },
     {
       "id": "cyclic",
       "title": "Cyclic case",
       "summary": "isCyclic_of_card_pq: squarefree ⇒ Z-group; all Sylows normal ⇒ nilpotent; finite nilpotent Z-group ⇒ cyclic.",
-      "startLine": 116,
-      "endLine": 140
+      "startLine": 114,
+      "endLine": 137
     },
     {
       "id": "uniqueness",
       "title": "Uniqueness of the isomorphism class",
-      "summary": "unique_isoclass_of_card_pq: any two such groups are isomorphic.",
-      "startLine": 142,
+      "summary": "unique_isoclass_of_card_pq: any two such groups are isomorphic (both cyclic of the same order, so ≅ via mulEquivOfCyclicCardEq).",
+      "startLine": 139,
       "endLine": 151
     }
   ],


### PR DESCRIPTION
## Summary

`sections` in `meta.json` previously covered only lines 49-151 (three sections:
`sylow-count`, `cyclic`, `uniqueness`), leaving the module docstring, method
summary, honest-scope disclosure, and namespace/variable setup (lines 1-48)
entirely uncovered by any section.

Split into 5 sections at real theorem boundaries (matching the granularity
already present in `annotations.json`), now covering the full 1-151 range:

1. `header` (1-48) — docstring, method outline, honest scope, namespace setup
2. `sylow-count-divisors` (49-101) — the `r = p` / `r = q` divisor case
3. `sylow-count-trivial` (102-113) — the `r ∤ |G|` trivial-Sylow case
4. `cyclic` (114-137) — unchanged content, boundary re-anchored
5. `uniqueness` (139-151) — unchanged content, boundary re-anchored

No prose was rewritten beyond section summaries; `keyInsights`,
`historicalContext`, `crossReferences`, and `annotations.json` were already at
target and are untouched.

## Test plan

- [x] `meta.json` validated as well-formed JSON
- [x] `pnpm build` passes (gallery build + bundle-budget checks)