### PR TITLE
Enrich collatz-cycles-oq-02: link discharged open question to child oq-01

### DIFF
--- a/src/data/proofs/collatz-cycles-oq-02/meta.json
+++ b/src/data/proofs/collatz-cycles-oq-02/meta.json
@@ -92,7 +92,7 @@
     "summary": "A non-trivial Collatz cycle with J odd steps and M even steps has M > J·log₂3, M ≥ ⌈J·log₂3⌉₊, and total length L = M + J > J·log₂6 ≈ 2.585·J — a clean general bound that subsumes the specific minimal-halving ladder of CollatzCycles.lean.",
     "implications": "**1. From a finite ladder to a uniform bound.** CollatzCycles.lean bounded halvings only for J = 1..4; this entry covers all J with the exact asymptotic constant log₂3.\n\n**2. Linear growth in odd steps.** The length grows at least like log₂6 · J, the elementary growth rate behind Eliahou's analysis.\n\n**3. Honest scope.** This is NOT Eliahou's full numerical bound (length ≥ 17,087,915), which sharpens the constant via the continued-fraction expansion of log₂3. That Diophantine-approximation step is not formalized here.",
     "openQuestions": [
-      "Formalize the continued-fraction expansion of log₂3 to obtain Eliahou's sharp numerical constant.",
+      "Now discharged by collatz-cycles-oq-02-oq-01, which formalizes the continued-fraction convergents of log₂3 (1/1, 2/1, 3/2, 8/5, 19/12, 65/41, 84/53, 485/306) to sharpen this entry's bound to an explicit rational constant. The next step that entry itself poses: formalize the two-sided Diophantine gap 3^J < 2^M < 3^J·(1 + ε) from a cycle's minimal element and combine with the best-approximation denominators to reach Eliahou's full numerical constant.",
       "Combine with a lower bound on the number of odd steps J in any non-trivial cycle to obtain an absolute length bound.",
       "Connect to the 2-adic / Diophantine obstruction ruling out small cycles entirely."
     ]
@@ -107,6 +107,11 @@
       "targetId": "collatz-cycles-oq-04",
       "relationship": "depends-on",
       "description": "Uses the general halving constraint 3^J < 2^M established in collatz-cycles-oq-04 as the hypothesis of the logarithmic bound."
+    },
+    {
+      "targetId": "collatz-cycles-oq-02-oq-01",
+      "relationship": "extended-by",
+      "description": "Answers this entry's first open question: formalizes the continued-fraction convergents of log₂3 and uses them to sharpen the cycle-length bound to an explicit rational constant, elementarily and axiom-free."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `collatz-cycles-oq-02` (Eliahou's logarithmic cycle-length bound). No open PR against this exact target as of claim time.

`collatz-cycles-oq-02-oq-01` ("Continued-Fraction Convergents of log₂3 and Sharp Rational Cycle Bounds") directly answers the parent's first open question ("Formalize the continued-fraction expansion of log₂3 to obtain Eliahou's sharp numerical constant") — the child's own `crossReferences` entry says exactly this ("Answers the parent's explicit openQuestion...") — but the parent had no link back to the child at all.

- Added an `extended-by` crossReference to `collatz-cycles-oq-02-oq-01`.
- Rewrote openQuestion 1 to record the discharge and forward to the child's own next open question (the two-sided Diophantine gap toward Eliahou's full numerical constant, ≥ 17,087,915).

No other content changed. `meta.json` stays at 9.8 KB, well under the 60 KB cap.
