### PR TITLE
audit(erdos-46): mark re-audit clean, no issues found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13804,8 +13804,8 @@
     },
     "erdos-46": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:39Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T23:29:59Z",
       "result": "clean"
     },
     "erdos-460": {


### PR DESCRIPTION
## Gallery Integrity Audit: erdos-46

**Result**: clean, no issues found (re-audit #5).

### Checks performed
- 0 sorries, 0 axioms, no `native_decide` — matches meta.
- All 38 `originalContributions` lemma/theorem names verified to resolve to real declarations in `proofs/Proofs/Erdos46Problem.lean`.
- `ErdosProblem46`, `ErdosProblem46_infinitely_many`, `ErdosGraham_rational` are honestly disclosed as unproved `Prop` statements (Croot's deep theorem via density Hales–Jewett is not formalized) — consistent with `status: axiomatized`, `badge: wip` (Tier C).
- `meta.meta` block (752 lines, 38 theorems, 7 defs) matches the actual file; the `leanFile` block (359 lines, 25 theorems) is a stale undercount, which is harmless per convention.
- Cross-reference targets (erdos-311, erdos-321) exist.
- annotations.json consistently discloses "no bridging axiom" language, no phantom axiom claims.

Tracker-only change (`audit-tracker.json`), bumping `auditCount` 4→5 and `lastAudited`.

Discovered during gallery integrity audit.