### PR TITLE
Enrich combinations-formula-oq-05: link both children discharging its open questions

### DIFF
--- a/src/data/proofs/combinations-formula-oq-05/meta.json
+++ b/src/data/proofs/combinations-formula-oq-05/meta.json
@@ -97,8 +97,9 @@
     "summary": "4 theorems, 0 sorries, 0 axioms. The alternating row sum identity ∑ (-1)^k C(n,k) = 0 is formalized together with its combinatorial content: for n ≥ 1 the even-indexed and odd-indexed binomial coefficients have equal sums, each exactly 2^{n-1}.",
     "implications": "This converts a one-line Mathlib corollary into the full classical statement that a nonempty finite set has equally many even-sized and odd-sized subsets. The parity-filtering technique (sum_filter_add_sum_filter_not together with the sign evaluations of (-1)^k) is reusable for any signed binomial identity one wishes to resolve into its even and odd parts.",
     "openQuestions": [
-      "Can the partial alternating sums ∑_{k=0}^{j} (-1)^k C(n,k) = (-1)^j C(n-1,j) be formalized, refining the full cancellation into a telescoping identity?",
-      "Does the analogous three-way (or m-way) split by residue of k modulo 3 (or m), evaluated via roots of unity, admit a clean formalization building on this parity case?"
+      "Now discharged by combinations-formula-oq-05-oq-01, which proves the sharp closed form ∑_{k=0}^{j} (-1)^k C(n,k) = (-1)^j C(n-1,j) for every partial sum, refining the full cancellation into a telescoping identity.",
+      "Now discharged by combinations-formula-oq-05-oq-02, which formalizes the roots-of-unity filter for the three-way residue-mod-3 split of a Pascal row, the direct analog of this entry's even/odd split via the square root of unity −1.",
+      "Both children so far treat one specific modulus (2 here, 3 in oq-05-oq-02) with a bespoke root-of-unity argument; package the roots-of-unity filter as a single theorem parameterized by an arbitrary primitive m-th root of unity, uniformly recovering both the m=2 and m=3 cases as instances."
     ]
   },
   "crossReferences": [
@@ -121,6 +122,16 @@
       "targetId": "combinations-formula-oq-04",
       "relationship": "related",
       "description": "Twin open-question entry under the same parent (combinations-formula), studying the complementary structural property of a Pascal row: oq-04 proves the row's basic multiplicative inequality (log-concavity C(n,k)·C(n,k+2) ≤ C(n,k+1)²), while this entry (oq-05) records the row's additive structure (the alternating sum vanishes, splitting the row into equal even/odd halves of 2^{n−1}). oq-04 already lists this entry as its sibling on the alternating row sum; this is the reciprocal link."
+    },
+    {
+      "targetId": "combinations-formula-oq-05-oq-01",
+      "relationship": "extended-by",
+      "description": "Answers this entry's first open question: proves the sharp closed form for every partial sum ∑_{k=0}^{j} (-1)^k C(n,k) = (-1)^j C(n-1,j), refining the full-row cancellation proved here into a telescoping identity."
+    },
+    {
+      "targetId": "combinations-formula-oq-05-oq-02",
+      "relationship": "extended-by",
+      "description": "Answers this entry's second open question: formalizes the roots-of-unity filter for a primitive cube root of unity, giving the three-way residue-mod-3 split of a Pascal row as the direct analog of this entry's two-way even/odd split via the square root of unity −1."
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-05` (even/odd Pascal-row split). No open PR against this exact target as of claim time.

Both of this entry's `conclusion.openQuestions` are already answered by direct children that were never cross-referenced:
- `combinations-formula-oq-05-oq-01` ("Telescoping Partial Sums of an Alternating Binomial Row") proves the exact closed form open question 1 asks for.
- `combinations-formula-oq-05-oq-02` ("Three-Way Residue-Mod-3 Split via Roots of Unity") formalizes exactly the mod-3 generalization open question 2 asks for.

- Added `extended-by` crossReferences to both.
- Rewrote both openQuestions to record the discharge and point at the proving child.
- Added one genuinely new open question — parameterize the roots-of-unity filter uniformly over an arbitrary modulus m, unifying the now-separate m=2 (parent) and m=3 (oq-05-oq-02) cases as instances of one theorem — since resolving both prior questions left the conclusion with nothing forward-looking.

No other content changed. `meta.json` stays at 12.1 KB, well under the 60 KB cap.
