### PR TITLE
Research: erdos-548 min-degree extraction proved (half of trivial_tree_bound)

### DIFF
--- a/proofs/Proofs/Erdos548Problem.lean
+++ b/proofs/Proofs/Erdos548Problem.lean
@@ -532,7 +532,7 @@ theorem edgesInside_erase_bound (G : SimpleGraph V) [DecidableRel G.Adj]
       refine Finset.mem_image.mpr ⟨Sym2.Mem.other hv, ?_, hother⟩
       rw [Finset.mem_filter]
       constructor
-      · exact hin _ (by rw [← hother]; exact Sym2.mem_mk_right _ _)
+      · exact hin _ (Sym2.other_mem hv)
       · have hadj : s(v, Sym2.Mem.other hv) ∈ G.edgeSet := by
           rw [hother]
           exact SimpleGraph.mem_edgeFinset.mp heE
@@ -594,6 +594,16 @@ theorem exists_min_degree_subset (G : SimpleGraph V) [DecidableRel G.Adj]
         (by rw [hcard]; omega)
       exact ⟨s, hne, hsub.trans (Finset.erase_subset v t), hdegs⟩
 
+omit [DecidableEq V] in
+/-- `edgeCount` agrees with the edge-finset cardinality for any decidability
+instance (`edgeCount` was defined under `Classical`; the two edge finsets are
+extensionally equal). -/
+theorem edgeCount_eq_card_edgeFinset (G : SimpleGraph V)
+    [DecidableRel G.Adj] : edgeCount G = G.edgeFinset.card := by
+  unfold edgeCount
+  refine congrArg Finset.card (Finset.ext fun e => ?_)
+  simp [SimpleGraph.mem_edgeFinset]
+
 /-- **Min-degree extraction from the edge count.** A graph on `V` with at
 least `(k−1)·|V| + 1` edges contains a nonempty vertex set `s` in which every
 vertex has at least `k` neighbours inside `s` — the extraction half of the
@@ -606,8 +616,8 @@ theorem exists_min_degree_subset_of_edgeCount (G : SimpleGraph V)
     ∃ s : Finset V, s.Nonempty ∧
       ∀ v ∈ s, k ≤ (s.filter (fun u => G.Adj v u)).card := by
   obtain ⟨s, hne, _, hdeg⟩ := exists_min_degree_subset G k Finset.univ (by
-    rw [edgesInside_univ]
-    simpa [edgeCount, Finset.card_univ] using h)
+    rw [edgesInside_univ, Finset.card_univ, ← edgeCount_eq_card_edgeFinset G]
+    exact h)
   exact ⟨s, hne, hdeg⟩
 
 end Erdos548

--- a/proofs/Proofs/Erdos548Problem.lean
+++ b/proofs/Proofs/Erdos548Problem.lean
@@ -477,6 +477,139 @@ def erdos_548_open : Prop := ErdosSosConjecture ∨ ¬ErdosSosConjecture
 theorem erdos_548_status : erdos_548_open :=
   Classical.em ErdosSosConjecture
 
+/- ## Part XI: Toward eliminating `trivial_tree_bound` — min-degree extraction
+
+The classical proof of the trivial bound has two halves:
+1. **Extraction** (PROVED below): a graph with at least `(k−1)·n + 1` edges
+   contains a nonempty vertex set `s` in which every vertex has at least `k`
+   neighbours *inside `s`* — iteratively delete any vertex with fewer than
+   `k` internal neighbours; each deletion destroys at most `k − 1` edges, so
+   the edge surplus survives to a nonempty core.
+2. **Greedy tree embedding** (remaining): a set of internal minimum degree
+   `≥ k` contains every tree on `k + 1` vertices — embed the tree one leaf at
+   a time; at most `k` vertices are used, so a fresh neighbour always exists.
+   This needs a leaf-removal induction for trees (Mathlib:
+   `IsTree.exists_vert_degree_one_of_nontrivial`,
+   `Connected.induce_compl_singleton_of_degree_eq_one`) and is left for a
+   future session.
+
+The extraction half is stated over `edgesInside` (edges with both endpoints
+in a `Finset`), mirroring the sound internal-degree formulation used for the
+chromatic-degeneracy lemma of Erdős #751 — a global min-degree statement
+would be false (isolated vertices survive in any same-vertex-type subgraph). -/
+
+/-- The edges of `G` with both endpoints inside `t`. -/
+noncomputable def edgesInside (G : SimpleGraph V) [DecidableRel G.Adj]
+    (t : Finset V) : Finset (Sym2 V) :=
+  G.edgeFinset.filter (fun e => ∀ x ∈ e, x ∈ t)
+
+/-- On the full vertex set, `edgesInside` is the whole edge set. -/
+theorem edgesInside_univ (G : SimpleGraph V) [DecidableRel G.Adj] :
+    edgesInside G Finset.univ = G.edgeFinset := by
+  unfold edgesInside
+  exact Finset.filter_true_of_mem (fun e _ x _ => Finset.mem_univ x)
+
+/-- Removing a vertex `v` from `t` destroys at most `deg_t(v)` inside-edges:
+every inside-edge either avoids `v` (and survives in `t.erase v`) or joins
+`v` to one of its neighbours inside `t`. -/
+theorem edgesInside_erase_bound (G : SimpleGraph V) [DecidableRel G.Adj]
+    (t : Finset V) (v : V) :
+    (edgesInside G t).card ≤
+      (edgesInside G (t.erase v)).card +
+        (t.filter (fun u => G.Adj v u)).card := by
+  have hsub : edgesInside G t ⊆
+      edgesInside G (t.erase v) ∪
+        (t.filter (fun u => G.Adj v u)).image (fun u => s(v, u)) := by
+    intro e he
+    unfold edgesInside at he
+    rw [Finset.mem_filter] at he
+    obtain ⟨heE, hin⟩ := he
+    by_cases hv : v ∈ e
+    · -- `e = s(v, u)` for the other endpoint `u`
+      rw [Finset.mem_union]
+      right
+      have hother := Sym2.other_spec hv
+      refine Finset.mem_image.mpr ⟨Sym2.Mem.other hv, ?_, hother⟩
+      rw [Finset.mem_filter]
+      constructor
+      · exact hin _ (by rw [← hother]; exact Sym2.mem_mk_right _ _)
+      · have hadj : s(v, Sym2.Mem.other hv) ∈ G.edgeSet := by
+          rw [hother]
+          exact SimpleGraph.mem_edgeFinset.mp heE
+        exact hadj
+    · rw [Finset.mem_union]
+      left
+      unfold edgesInside
+      rw [Finset.mem_filter]
+      refine ⟨heE, fun x hx => Finset.mem_erase.mpr ⟨?_, hin x hx⟩⟩
+      rintro rfl
+      exact hv hx
+  calc (edgesInside G t).card
+      ≤ (edgesInside G (t.erase v) ∪
+          (t.filter (fun u => G.Adj v u)).image (fun u => s(v, u))).card :=
+        Finset.card_le_card hsub
+    _ ≤ (edgesInside G (t.erase v)).card
+        + ((t.filter (fun u => G.Adj v u)).image (fun u => s(v, u))).card :=
+        Finset.card_union_le _ _
+    _ ≤ _ := by
+        have himg := Finset.card_image_le
+          (s := t.filter (fun u => G.Adj v u)) (f := fun u => s(v, u))
+        omega
+
+/-- **Min-degree extraction (strong-induction core).** Any vertex set `t`
+carrying at least `(k−1)·|t| + 1` inside-edges contains a nonempty subset
+`s ⊆ t` in which every vertex has at least `k` neighbours inside `s`. -/
+theorem exists_min_degree_subset (G : SimpleGraph V) [DecidableRel G.Adj]
+    (k : ℕ) :
+    ∀ t : Finset V, (k - 1) * t.card + 1 ≤ (edgesInside G t).card →
+      ∃ s : Finset V, s.Nonempty ∧ s ⊆ t ∧
+        ∀ v ∈ s, k ≤ (s.filter (fun u => G.Adj v u)).card := by
+  intro t
+  induction t using Finset.strongInduction with
+  | _ t ih =>
+    intro hE
+    by_cases hall : ∀ v ∈ t, k ≤ (t.filter (fun u => G.Adj v u)).card
+    · refine ⟨t, ?_, Finset.Subset.refl t, hall⟩
+      rcases Finset.eq_empty_or_nonempty t with rfl | hne
+      · exfalso
+        have hempty : edgesInside G (∅ : Finset V) = ∅ := by
+          rw [Finset.eq_empty_iff_forall_notMem]
+          intro e he
+          unfold edgesInside at he
+          rw [Finset.mem_filter] at he
+          exact absurd (he.2 e.out.1 (Sym2.out_fst_mem e))
+            (Finset.notMem_empty _)
+        rw [hempty] at hE
+        simp at hE
+      · exact hne
+    · simp only [not_forall, not_le] at hall
+      obtain ⟨v, hvt, hdeg⟩ := hall
+      have hcard : (t.erase v).card = t.card - 1 := Finset.card_erase_of_mem hvt
+      have hpos : 1 ≤ t.card := Finset.card_pos.mpr ⟨v, hvt⟩
+      have hbound := edgesInside_erase_bound G t v
+      have hmul : (k - 1) * t.card = (k - 1) * (t.card - 1) + (k - 1) := by
+        conv_lhs => rw [← Nat.sub_add_cancel hpos]
+        ring
+      obtain ⟨s, hne, hsub, hdegs⟩ := ih (t.erase v) (Finset.erase_ssubset hvt)
+        (by rw [hcard]; omega)
+      exact ⟨s, hne, hsub.trans (Finset.erase_subset v t), hdegs⟩
+
+/-- **Min-degree extraction from the edge count.** A graph on `V` with at
+least `(k−1)·|V| + 1` edges contains a nonempty vertex set `s` in which every
+vertex has at least `k` neighbours inside `s` — the extraction half of the
+classical proof of `trivial_tree_bound` (the hypothesis matches its
+`edgeCount G ≥ n·(k−1) + 1` up to commutativity). The remaining half is the
+greedy embedding of an arbitrary `(k+1)`-vertex tree into such an `s`. -/
+theorem exists_min_degree_subset_of_edgeCount (G : SimpleGraph V)
+    [DecidableRel G.Adj] (k : ℕ)
+    (h : (k - 1) * Fintype.card V + 1 ≤ edgeCount G) :
+    ∃ s : Finset V, s.Nonempty ∧
+      ∀ v ∈ s, k ≤ (s.filter (fun u => G.Adj v u)).card := by
+  obtain ⟨s, hne, _, hdeg⟩ := exists_min_degree_subset G k Finset.univ (by
+    rw [edgesInside_univ]
+    simpa [edgeCount, Finset.card_univ] using h)
+  exact ⟨s, hne, hdeg⟩
+
 end Erdos548
 
 /-

--- a/research/problems/erdos-548-incomplete-01/knowledge.md
+++ b/research/problems/erdos-548-incomplete-01/knowledge.md
@@ -44,3 +44,40 @@ term-mode or copied tactic proofs — no new axioms, no native_decide.
    Mathlib has `SimpleGraph.exists_subgraph_minDegree` analogues first.
 2. The other 7 axioms are genuine literature results — leave as axioms.
 3. The conjecture itself (ErdosSosConjecture) is OPEN — never a target.
+
+## 2026-07-23 (researcher-1) — min-degree extraction PROVED (half of trivial_tree_bound)
+
+Part XI added to `Erdos548Problem.lean` (appended at end, 0 new axioms, host
+`lake env lean` EXIT=0, lint-clean, `#print axioms` foundational only):
+
+- `edgesInside G t` — edges with both endpoints in a `Finset t` (needed because
+  a global-minDegree statement is FALSE — same isolated-vertex trap as the
+  erdos-751 repair; internal-degree Finset form is the sound one).
+- `edgesInside_erase_bound` — deleting `v` destroys ≤ deg_t(v) inside-edges
+  (union-image counting; use `Sym2.other_spec`/`Sym2.other_mem`, NOT
+  `rw [← other_spec]` which fails motive-typecheck).
+- `exists_min_degree_subset` — strong induction: `(k−1)|t| + 1 ≤ e(t)` yields
+  nonempty `s ⊆ t` with internal degree ≥ k everywhere. Nonlinear arithmetic
+  handled by one `conv_lhs => rw [← Nat.sub_add_cancel]; ring` identity + omega.
+- `edgeCount_eq_card_edgeFinset` — instance bridge (edgeCount was defined under
+  `open scoped Classical`; ext + `mem_edgeFinset` closes the two-instance gap;
+  `simpa [edgeCount]` FAILS with instance mismatch).
+- `exists_min_degree_subset_of_edgeCount` — extraction from
+  `(k−1)·|V| + 1 ≤ edgeCount G` (matches trivial_tree_bound's hypothesis up to
+  `mul_comm`).
+
+**Remaining to eliminate `trivial_tree_bound` (next session):** greedy tree
+embedding — a Finset `s` with internal degree ≥ k contains every tree on k+1
+vertices. Route: induction on `Fintype.card W` (T on W); remove a leaf
+(`IsTree.exists_vert_degree_one_of_nontrivial` — needs Nontrivial;
+singleton tree base case), embed the smaller tree
+(`Connected.induce_compl_singleton_of_degree_eq_one` keeps it a tree — also
+need acyclicity of induce: `IsAcyclic.induce`), then extend: image has ≤ k
+vertices, the attachment vertex has ≥ k internal neighbours, so a fresh one
+exists. Injectivity bookkeeping like `star_easier`'s `Fin.cases` embedding.
+Then `trivial_tree_bound` = extraction + embedding + `ContainsSubgraph` via
+the induced-subgraph inclusion.
+
+Other axioms (brandt_dobson, sacle_wozniak, wang_li_liu, komlos_sos_large_k,
+erdos_gallai_matching, path_extremal, turan_path_formula) are person/paper-named
+DEEP results — leave axiomatized.

--- a/src/data/proofs/erdos-548/meta.json
+++ b/src/data/proofs/erdos-548/meta.json
@@ -25,7 +25,7 @@
     "lineCount": 513,
     "assumptions": "17 axiom(s) aggregated across files (8 in the primary Erdos548Problem.lean — deep extremal-graph-theory literature results: trivial_tree_bound, brandt_dobson, sacle_wozniak, wang_li_liu, path_extremal, komlos_sos_large_k, erdos_gallai_matching, turan_path_formula — plus 9 in the legacy stub Proofs/Stubs/Erdos548Problem.lean). The primary file now has 0 sorries: all six were proved in July 2026 (star_is_tree, sum_degrees_eq_twice_edges, avg_degree_iff_edges, erdos_sos_implies_extremal, star_easier, erdos_548_status). Two statements required repair to be provable: avg_degree_iff_edges gained the missing k ≥ 1 hypothesis (false at k = 0 as stated), and erdos_sos_implies_extremal restricts its tree vertex type from Type* to Type (ErdosSosConjecture quantifies over Type). erdos_548_status is now Classical.em rather than a sorry that would have asserted the conjecture itself. The former tree_edge_count axiom is a proved theorem, and IsTree delegates to Mathlib genuine SimpleGraph.IsTree. Aristotle companion files retain their own sorry stubs pending proof search.",
     "mathlib_version": "4.31.0",
-    "theoremCount": 10,
+    "theoremCount": 15,
     "definitionCount": 16,
     "additionalFiles": [
       "Proofs/Erdos548Aristotle.lean",
@@ -159,10 +159,10 @@
       "Finset"
     ],
     "namespace": "Erdos548",
-    "lineCount": 513,
+    "lineCount": 656,
     "axiomCount": 8,
-    "theoremCount": 10,
-    "definitionCount": 16,
+    "theoremCount": 15,
+    "definitionCount": 17,
     "path": "Proofs/Erdos548Problem.lean",
     "sorries": 0,
     "additionalFiles": [


### PR DESCRIPTION
## Research: erdos-548-incomplete-01 — min-degree extraction proved (first half of `trivial_tree_bound` elimination)

**Problem:** Erdős #548 (Erdős–Sós conjecture), `proofs/Proofs/Erdos548Problem.lean`. The file has 0 sorries and 8 axioms; all but one are person/paper-named deep results (Brandt–Dobson, Saclé–Wozniak, Wang–Li–Liu, Komlós–Sós, Erdős–Gallai, path extremal numbers) that should stay axiomatized. The exception is the generic-math-named **`trivial_tree_bound`** (n(k−1)+1 edges ⇒ contains every (k+1)-vertex tree), whose classical proof is elementary: (1) extract a subgraph of min degree ≥ k, (2) greedily embed the tree. This PR proves half (1) in full.

### New (Part XI, 5 theorems + 1 def, 0 new axioms)

- `edgesInside G t` — edges with both endpoints inside a `Finset t`. The internal-degree Finset formulation is the *sound* one — a global min-degree statement would be false (isolated vertices survive in every same-vertex-type subgraph), the same trap repaired in the Erdős #751 file.
- `edgesInside_erase_bound` — deleting a vertex destroys at most its internal degree many inside-edges (union/image counting over `Sym2`).
- `exists_min_degree_subset` — strong-induction core: `(k−1)·|t| + 1 ≤ e(t)` yields a nonempty `s ⊆ t` with every internal degree ≥ k.
- `edgeCount_eq_card_edgeFinset` — decidability-instance bridge (`edgeCount` was defined under `Classical`).
- `exists_min_degree_subset_of_edgeCount` — the extraction stated against `edgeCount G ≥ (k−1)·|V| + 1`, matching `trivial_tree_bound`'s hypothesis up to commutativity.

### Verification

- `lake env lean Proofs/Erdos548Problem.lean` → EXIT=0; no new warnings (one `omit` added; remaining warnings pre-exist on main).
- `#print axioms` for the new theorems: `[propext, Classical.choice, Quot.sound]` — no file axiom is involved.
- Section appended at end of file — existing annotation ranges unshifted. Gallery meta counts synced (15 theorems / 17 defs / 656 lines); status stays `axiomatized` (8 axioms unchanged, this PR adds none).

### Remaining (documented in knowledge + file comment)

Greedy tree embedding: a vertex set with internal degree ≥ k contains every tree on k+1 vertices (leaf-removal induction via `IsTree.exists_vert_degree_one_of_nontrivial` + `Connected.induce_compl_singleton_of_degree_eq_one`). With that, `trivial_tree_bound` becomes a theorem and the file drops 8 → 7 axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
