### PR TITLE
Enrich abel-ruffini-oq001: cover header section

### DIFF
--- a/src/data/proofs/abel-ruffini-oq001/meta.json
+++ b/src/data/proofs/abel-ruffini-oq001/meta.json
@@ -48,6 +48,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Header: the mod-2 route and its honest scope",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Module docstring: recaps the parent's failed parity argument (x⁵-x-1 has one real root, so conjugation is an even double transposition), states the Dedekind mod-2 fix — factor as (x²+x+1)(x³+x²+1) over 𝔽₂ to get Frobenius cycle type (2,3) — and lists exactly what is and is not machine-checked (Dedekind's theorem itself, mod-3, and ℚ-irreducibility are explicitly NOT formalized here).",
+      "mathContext": "$x^5-x-1 \\equiv (x^2{+}x{+}1)(x^3{+}x^2{+}1) \\pmod 2$"
+    },
+    {
       "id": "definitions",
       "title": "The Factors and Reduction over 𝔽₂",
       "startLine": 44,


### PR DESCRIPTION
## Summary

`sections` in `meta.json` started at line 44, leaving the module docstring
(lines 1-43) uncovered — the recap of the parent's failed parity argument,
the Dedekind mod-2 fix, and the explicit "not formalized here" scope
disclosure (Dedekind's theorem itself, mod-3, ℚ-irreducibility).

Added a `header` section (1-43) summarizing this content. Sections now cover
the full 1-116 range. No other content changed; `keyInsights` (5),
`historicalContext`, `conclusion` (with `honestStatement` and 3
`openQuestions`), and `crossReferences` were already at target.

## Test plan

- [x] `meta.json` validated as well-formed JSON
- [x] `pnpm build` passes (gallery build + bundle-budget checks)