### PR TITLE
Enrich bernoulli-inequality-oq-01-oq-02: link child discharging its degree-k open question

### DIFF
--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-02/meta.json
@@ -145,8 +145,8 @@
     "summary": "For a ≥ 0 the quadratic truncation of the binomial expansion is a valid Bernoulli-type lower bound, (1+a)ⁿ ≥ 1 + n·a + (n(n−1)/2)·a², with equality iff a = 0 ∨ n ≤ 2 and strictness iff a ≠ 0 ∧ n ≥ 3. This refines the first-order equality case (a = 0 ∨ n ≤ 1) by one step, the increment reflecting that the quadratic truncation is exact through degree two. The hypothesis a ≥ 0 is sharp. Verified: 0 sorries, 0 axioms.",
     "implications": "Mathlib carries only the first-order integer-power Bernoulli inequality (on −2 ≤ a) and rpow forms; the second-order truncation and its equality case were absent. This entry supplies them and exposes the general pattern: the degree-k binomial truncation is a lower bound for a ≥ 0 whose equality threshold is n ≤ k, generalizing the classical n ≤ 1 case.",
     "openQuestions": [
-      "Does the degree-k binomial truncation 1 + Σ_{j≤k} C(n,j)a^j ≤ (1+a)ⁿ hold for all a ≥ 0 with equality iff a = 0 ∨ n ≤ k, by the same Pascal induction?",
-      "On −1 < a < 0 the even and odd truncations bracket (1+a)ⁿ from opposite sides; can the second-order truncation be replaced by a sharp two-sided enclosure there?"
+      "Now discharged by bernoulli-inequality-oq-01-oq-02-oq-01, which proves the degree-k binomial truncation ∑_{i≤k} C(n,i)aⁱ ≤ (1+a)ⁿ for all a ≥ 0 with its sharp equality case, by the same Pascal induction.",
+      "On −1 < a < 0 the even and odd truncations bracket (1+a)ⁿ from opposite sides; can the second-order truncation be replaced by a sharp two-sided enclosure there? (Still open: bernoulli-inequality-oq-01-oq-02-oq-01 restates this at general k without resolving it.)"
     ],
     "crossReferences": []
   },
@@ -165,6 +165,11 @@
       "targetId": "binomial-theorem-oq-05",
       "relationship": "related",
       "description": "binomial-theorem-oq-05 proves the first-order strict Bernoulli inequality for a > 0; the second-order truncation here is the next term of the same expansion"
+    },
+    {
+      "targetId": "bernoulli-inequality-oq-01-oq-02-oq-01",
+      "relationship": "answered-by",
+      "description": "Answers this entry's first open question: proves the degree-k binomial truncation ∑_{i≤k} C(n,i)aⁱ ≤ (1+a)ⁿ for all a ≥ 0 and every k, with a uniform sharp equality case, generalizing this entry's k = 2 case."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `bernoulli-inequality-oq-01-oq-02` (second-order Bernoulli inequality). No open PR against this exact target as of claim time.

`bernoulli-inequality-oq-01-oq-02-oq-01` ("Degree-k Binomial Truncation Bound") explicitly answers this entry's first open question — its own crossReference says "The parent proves the second-order truncation and explicitly asks whether the degree-k truncation holds ...; this entry answers that question in full generality" — but the parent had no link back.

- Added an `answered-by` crossReference to the child.
- Rewrote openQuestion 1 to record the discharge.
- Left openQuestion 2 (the −1 < a < 0 two-sided enclosure) open but noted that the child only *restates* it at general k without resolving it — it's a genuinely distinct, still-open question.

No other content changed. `meta.json` stays at 17.0 KB, well under the 60 KB cap.
