### PR TITLE
audit(erdos-424): mark clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13505,8 +13505,8 @@
     },
     "erdos-424": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:39Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T23:44:54Z",
       "result": "clean"
     },
     "erdos-425": {


### PR DESCRIPTION
## Audit Result: clean

**Proof**: erdos-424 (Sequence Generated by a_i · a_j − 1)

Re-audited as part of round-robin re-serve (unaudited queue drained). Verified against `proofs/Proofs/Erdos424Problem.lean`:

- `axiomCount`: 0 (confirmed, no `axiom` declarations — grep hits are stale comment text only, e.g. "(Previously axiom.)" / "(Kept as axiom due to the Finset counting complexity.)", not real axioms)
- `sorries`: 0 (confirmed)
- `theoremCount`: 8 (confirmed: 5 `theorem` + 3 `private lemma`)
- `definitionCount`: 4 (confirmed: `nextGeneration`, `sequenceSet`, `generatedSet`, `generatedCount`)
- `lineCount`: 149 (confirmed via `wc -l`)
- No True-stub placeholders, no `native_decide`
- Status `axiomatized` / badge `wip` is honestly disclosed — `assumptions` field and the file's own "Status: OPEN" comment both correctly state the main density conjecture is prose-only/unformalized

No action needed. Bumping `auditCount` 4→5 and `lastAudited`.

---
Discovered during gallery integrity audit.