### PR TITLE
audit(erdos-418): mark clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13460,8 +13460,8 @@
     },
     "erdos-418": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:39Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-23T23:48:20Z",
       "result": "clean"
     },
     "erdos-419": {


### PR DESCRIPTION
## Summary
- Re-audited `erdos-418` (Non-Cototients) as part of round-robin re-serve (queue fully drained: 4811/4811 audited).
- Verified `proofs/Proofs/Erdos418Problem.lean`: 0 real `axiom` declarations (the "we state as axiom" language is prose in a comment, never a Lean `axiom`), 0 `sorry`, 10 theorems / 11 defs match meta exactly.
- `native_decide` used in several named theorems (`cototient_two`, `two_is_cototient`, `three_is_cototient`, `four_is_cototient`, `small_odd_cototients`, `erdos_418_summary`) plus 3 anonymous examples — covered by the meta `assumptions` field's hedged, non-exhaustive disclosure.
- `status: axiomatized` + `badge: wip` remains appropriately conservative since the core Browkin-Schinzel infinitude claim is never formalized as an axiom or theorem in the file, only described in comments.
- No integrity issues found. Bumps `auditCount` 4→5 and refreshes `lastAudited`.

## Test plan
- [x] Manually diffed `audit-tracker.json` — only erdos-418's `auditCount`/`lastAudited` fields changed.
- [x] Confirmed no unrelated working-tree changes were staged.