### PR TITLE
Research: erdos-548 greedy tree embedding — trivial_tree_bound axiom eliminated (8→7)

### DIFF
--- a/proofs/Proofs/Erdos548Problem.lean
+++ b/proofs/Proofs/Erdos548Problem.lean
@@ -253,16 +253,11 @@ def Erdos548Statement : Prop :=
 
 /- ## Part V: Known Results -/
 
-/-- **Trivial Bound**
-
-    n(k-1) + 1 edges suffice to contain any tree on k+1 vertices.
-    (Much weaker than the conjecture.)
--/
-axiom trivial_tree_bound (n k : ℕ) (hn : n ≥ k + 1)
-    (G : SimpleGraph (Fin n)) [DecidableRel G.Adj]
-    (hG : edgeCount G ≥ n * (k - 1) + 1)
-    (T : SimpleGraph (Fin (k + 1))) (hT : IsTree T) :
-    ContainsSubgraph G T
+/- **Trivial Bound** — n(k-1) + 1 edges suffice to contain any tree on k+1
+   vertices (much weaker than the conjecture).  Formerly an `axiom` declared
+   here; now proved as the theorem `trivial_tree_bound` in Part XII below,
+   combining the Part XI min-degree extraction with a greedy leaf-at-a-time
+   tree embedding. -/
 
 /-- **Girth of a graph**: length of shortest cycle, or ∞ if acyclic.
     (v4.31 migration: `G.Walk` is indexed by vertices, not the carrier type;
@@ -485,13 +480,12 @@ The classical proof of the trivial bound has two halves:
    neighbours *inside `s`* — iteratively delete any vertex with fewer than
    `k` internal neighbours; each deletion destroys at most `k − 1` edges, so
    the edge surplus survives to a nonempty core.
-2. **Greedy tree embedding** (remaining): a set of internal minimum degree
-   `≥ k` contains every tree on `k + 1` vertices — embed the tree one leaf at
-   a time; at most `k` vertices are used, so a fresh neighbour always exists.
-   This needs a leaf-removal induction for trees (Mathlib:
+2. **Greedy tree embedding** (PROVED in Part XII): a set of internal minimum
+   degree `≥ k` contains every tree on `k + 1` vertices — embed the tree one
+   leaf at a time; at most `k` vertices are used, so a fresh neighbour always
+   exists.  Uses the leaf-removal induction for trees (Mathlib:
    `IsTree.exists_vert_degree_one_of_nontrivial`,
-   `Connected.induce_compl_singleton_of_degree_eq_one`) and is left for a
-   future session.
+   `Connected.induce_compl_singleton_of_degree_eq_one`, `IsAcyclic.induce`).
 
 The extraction half is stated over `edgesInside` (edges with both endpoints
 in a `Finset`), mirroring the sound internal-degree formulation used for the
@@ -619,6 +613,149 @@ theorem exists_min_degree_subset_of_edgeCount (G : SimpleGraph V)
     rw [edgesInside_univ, Finset.card_univ, ← edgeCount_eq_card_edgeFinset G]
     exact h)
   exact ⟨s, hne, hdeg⟩
+
+/- ## Part XII: Greedy tree embedding — `trivial_tree_bound` is a theorem
+
+The second half of the classical proof of the trivial bound: a vertex set
+`s` in which every vertex has at least `k` neighbours inside `s` contains
+every tree on at most `k + 1` vertices.  Induction on the vertex count:
+remove a leaf `x` (`IsTree.exists_vert_degree_one_of_nontrivial`), embed the
+smaller tree (`Connected.induce_compl_singleton_of_degree_eq_one` +
+`IsAcyclic.induce` show the rest is still a tree), then attach `x` to a
+fresh internal neighbour of the image of its unique support vertex — the
+image so far occupies at most `k` vertices, one of which is the attachment
+point itself, so at most `k − 1` of its `k` internal neighbours are taken.
+
+Combined with the Part XI extraction this discharges the former
+`trivial_tree_bound` axiom (Part V). -/
+
+/-- **Greedy tree embedding (induction core).**  Every tree `T` on at most
+`k + 1` vertices embeds into a vertex set `s` of internal minimum degree
+`≥ k`, with the whole image inside `s`. -/
+theorem exists_tree_embedding_into_min_degree_set
+    (G : SimpleGraph V) [DecidableRel G.Adj] (k : ℕ) (s : Finset V)
+    (hne : s.Nonempty)
+    (hdeg : ∀ v ∈ s, k ≤ (s.filter (fun u => G.Adj v u)).card) :
+    ∀ (m : ℕ) (W : Type) [Fintype W] [DecidableEq W] (T : SimpleGraph W),
+      Fintype.card W = m → m ≤ k + 1 → T.IsTree →
+      ∃ f : W → V, Function.Injective f ∧ (∀ w, f w ∈ s) ∧
+        ∀ a b, T.Adj a b → G.Adj (f a) (f b) := by
+  intro m
+  induction m with
+  | zero =>
+    intro W _ _ T hcardW _ hT
+    -- a tree is connected, hence nonempty — impossible on 0 vertices
+    haveI hempty : IsEmpty W := Fintype.card_eq_zero_iff.mp hcardW
+    exact absurd hT.connected.nonempty (not_nonempty_iff.mpr hempty)
+  | succ m ih =>
+    intro W _ _ T hcardW hm hT
+    rcases Nat.eq_zero_or_pos m with rfl | hmpos
+    · -- one vertex: map it anywhere in `s`; a tree has no loops
+      obtain ⟨v0, hv0⟩ := hne
+      haveI : Subsingleton W :=
+        Fintype.card_le_one_iff_subsingleton.mp (by omega)
+      refine ⟨fun _ => v0, fun a b _ => Subsingleton.elim a b,
+        fun _ => hv0, fun a b hab => ?_⟩
+      exact absurd (Subsingleton.elim a b ▸ hab) T.irrefl
+    · -- at least two vertices: remove a leaf `x` and recurse
+      haveI : Nontrivial W := Fintype.one_lt_card_iff_nontrivial.mp (by omega)
+      obtain ⟨x, hx⟩ := hT.exists_vert_degree_one_of_nontrivial
+      obtain ⟨y, hxy, hy⟩ := SimpleGraph.degree_eq_one_iff_existsUnique_adj.mp hx
+      -- the tree minus its leaf is a tree on `m` vertices
+      have hT' : (T.induce ({x}ᶜ : Set W)).IsTree :=
+        ⟨hT.connected.induce_compl_singleton_of_degree_eq_one hx,
+          hT.isAcyclic.induce _⟩
+      have hcard' : Fintype.card ↑({x}ᶜ : Set W) = m := by
+        rw [Fintype.card_compl_set, Set.card_singleton, hcardW]
+        omega
+      obtain ⟨f', hinj', hmem', hadj'⟩ :=
+        ih ↑({x}ᶜ : Set W) (T.induce ({x}ᶜ : Set W)) hcard' (by omega) hT'
+      -- the unique neighbour `y` of the leaf survives in the complement
+      have hyx : y ≠ x := hxy.ne'
+      have hyc : y ∈ ({x}ᶜ : Set W) := by simp [hyx]
+      -- a fresh internal neighbour of `f' ⟨y, _⟩` exists:
+      -- the image occupies `m ≤ k` vertices, one of them the attachment point
+      have hfy : f' ⟨y, hyc⟩ ∈ s := hmem' _
+      have hNcard : k ≤ (s.filter (fun u => G.Adj (f' ⟨y, hyc⟩) u)).card :=
+        hdeg _ hfy
+      have hinter : Finset.univ.image f' ∩
+            s.filter (fun u => G.Adj (f' ⟨y, hyc⟩) u) ⊆
+          (Finset.univ.image f').erase (f' ⟨y, hyc⟩) := by
+        intro z hz
+        rw [Finset.mem_inter] at hz
+        refine Finset.mem_erase.mpr ⟨?_, hz.1⟩
+        have hadjz : G.Adj (f' ⟨y, hyc⟩) z := (Finset.mem_filter.mp hz.2).2
+        exact fun h => G.irrefl (h ▸ hadjz)
+      have himgcard : (Finset.univ.image f').card = m := by
+        rw [Finset.card_image_of_injective _ hinj', Finset.card_univ, hcard']
+      have hfresh :
+          0 < ((s.filter (fun u => G.Adj (f' ⟨y, hyc⟩) u)) \
+            Finset.univ.image f').card := by
+        have h1 := Finset.card_sdiff_add_card_inter
+          (s.filter (fun u => G.Adj (f' ⟨y, hyc⟩) u)) (Finset.univ.image f')
+        have h2 := Finset.card_le_card hinter
+        rw [Finset.card_erase_of_mem
+          (Finset.mem_image_of_mem f' (Finset.mem_univ ⟨y, hyc⟩)), himgcard]
+          at h2
+        rw [Finset.inter_comm] at h1
+        omega
+      obtain ⟨z, hz⟩ := Finset.card_pos.mp hfresh
+      rw [Finset.mem_sdiff, Finset.mem_filter] at hz
+      obtain ⟨⟨hzs, hzadj⟩, hzimg⟩ := hz
+      -- assemble: send the leaf to the fresh vertex, keep the rest
+      refine ⟨fun w => if h : w = x then z else f' ⟨w, by simp [h]⟩,
+        ?_, ?_, ?_⟩
+      · -- injectivity
+        intro a b hab
+        by_cases ha : a = x <;> by_cases hb : b = x
+        · rw [ha, hb]
+        · simp only [dif_pos ha, dif_neg hb] at hab
+          refine absurd ?_ hzimg
+          rw [hab]
+          exact Finset.mem_image_of_mem f' (Finset.mem_univ _)
+        · simp only [dif_neg ha, dif_pos hb] at hab
+          refine absurd ?_ hzimg
+          rw [← hab]
+          exact Finset.mem_image_of_mem f' (Finset.mem_univ _)
+        · simp only [dif_neg ha, dif_neg hb] at hab
+          exact Subtype.mk_eq_mk.mp (hinj' hab)
+      · -- the image stays inside `s`
+        intro w
+        by_cases h : w = x
+        · simp only [dif_pos h]; exact hzs
+        · simp only [dif_neg h]; exact hmem' _
+      · -- adjacency is preserved
+        intro a b hab
+        by_cases ha : a = x <;> by_cases hb : b = x
+        · exact absurd (ha ▸ hb ▸ hab) T.irrefl
+        · -- the leaf's only edge goes to `y`; subtype proofs are irrelevant
+          have hby : b = y := hy b (ha ▸ hab)
+          subst hby
+          simp only [dif_pos ha, dif_neg hb]
+          exact hzadj.symm
+        · have hay : a = y := hy a (hb ▸ hab).symm
+          subst hay
+          simp only [dif_neg ha, dif_pos hb]
+          exact hzadj
+        · simp only [dif_neg ha, dif_neg hb]
+          exact hadj' ⟨a, by simp [ha]⟩ ⟨b, by simp [hb]⟩ hab
+
+/-- **Trivial Bound (now a theorem).**  `n·(k−1) + 1` edges force containment
+of every tree on `k + 1` vertices.  Extraction (Part XI) produces a nonempty
+vertex set of internal minimum degree `≥ k`; the greedy embedding above puts
+any `(k+1)`-vertex tree inside it.  (Formerly an `axiom` in Part V.) -/
+theorem trivial_tree_bound (n k : ℕ) (hn : n ≥ k + 1)
+    (G : SimpleGraph (Fin n)) [DecidableRel G.Adj]
+    (hG : edgeCount G ≥ n * (k - 1) + 1)
+    (T : SimpleGraph (Fin (k + 1))) (hT : IsTree T) :
+    ContainsSubgraph G T := by
+  obtain ⟨s, hne, hdeg⟩ := exists_min_degree_subset_of_edgeCount G k (by
+    rw [Fintype.card_fin, Nat.mul_comm]
+    exact hG)
+  obtain ⟨f, hinj, _, hadj⟩ :=
+    exists_tree_embedding_into_min_degree_set G k s hne hdeg (k + 1)
+      (Fin (k + 1)) T (Fintype.card_fin _) (le_refl _) hT
+  exact ⟨f, hinj, hadj⟩
 
 end Erdos548
 

--- a/research/problems/erdos-548-incomplete-01/knowledge.md
+++ b/research/problems/erdos-548-incomplete-01/knowledge.md
@@ -81,3 +81,41 @@ the induced-subgraph inclusion.
 Other axioms (brandt_dobson, sacle_wozniak, wang_li_liu, komlos_sos_large_k,
 erdos_gallai_matching, path_extremal, turan_path_formula) are person/paper-named
 DEEP results — leave axiomatized.
+
+## 2026-07-23 (researcher-1) — greedy tree embedding PROVED; trivial_tree_bound is now a THEOREM (axioms 8 → 7)
+
+Part XII added to `Erdos548Problem.lean` (host `lake env lean` EXIT=0,
+`#print axioms` = propext/Classical.choice/Quot.sound for both new theorems):
+
+- `exists_tree_embedding_into_min_degree_set` — every tree `T` on ≤ k+1
+  vertices embeds into a Finset `s` of internal min degree ≥ k, image ⊆ s.
+  Ordinary (not strong) induction on `m = Fintype.card W` suffices: the
+  recursion only steps m+1 → m. Statement quantifies `W : Type` inside the
+  motive so the IH applies to the subtype `↑({x}ᶜ : Set W)`.
+  - Leaf removal: `IsTree.exists_vert_degree_one_of_nontrivial` +
+    `degree_eq_one_iff_existsUnique_adj` (unique neighbour y);
+    smaller tree = `⟨hT.connected.induce_compl_singleton_of_degree_eq_one hx,
+    hT.isAcyclic.induce _⟩`; card via `Fintype.card_compl_set` +
+    `Set.card_singleton` (leaves goal `m+1-1 = m`, close with omega).
+  - Fresh-vertex count: image (m elements) ∩ neighbourhood ⊆ image.erase
+    (attachment point) — attachment not its own neighbour (`G.irrefl`);
+    `Finset.card_sdiff_add_card_inter` + omega gives a fresh internal
+    neighbour z since m ≤ k.
+  - Assembly `fun w => if h : w = x then z else f' ⟨w, by simp [h]⟩`.
+  ★LEAN GOTCHAS: (1) `rw [dif_pos/dif_neg]` FAILS on the beta-unreduced
+  `(fun w => dite ...) a` goals refine produces — use `simp only [dif_pos ha,
+  dif_neg hb]` (simp beta-reduces first). (2) For the leaf-edge adjacency
+  goal `G.Adj z (f' ⟨y, pf⟩)` where pf is the dite-produced proof: `subst`
+  the b = y equation FIRST, then `exact hzadj.symm` — kernel defeq handles
+  proof irrelevance, no `rw [Subtype.ext ...]` needed (which fails on
+  syntactic proof-term mismatch).
+- `trivial_tree_bound` — now a theorem: Part XI extraction (mul_comm bridges
+  `n*(k-1)+1` vs `(k-1)*n+1`) + embedding at m = k+1 = card (Fin (k+1)).
+  The `axiom` declaration in Part V is deleted (comment points to Part XII).
+
+Axioms 8 → 7; remaining 7 all person/paper-named DEEP (leave axiomatized).
+Gallery meta updated: meta.axiomCount 17→16, leanFile.axiomCount 8→7,
+theoremCount 15→17, assumptions prose, section-4 + conclusion prose
+("axiomatizes four partial results" → trivial bound proved, three remain).
+★This node's elementary vein is now EXHAUSTED — every generic-math-named
+axiom is proved; do not re-claim except to attack the deep literature axioms.

--- a/src/data/proofs/erdos-548/meta.json
+++ b/src/data/proofs/erdos-548/meta.json
@@ -21,11 +21,11 @@
     "erdosNumber": 548,
     "erdosUrl": "https://erdosproblems.com/548",
     "erdosProblemStatus": "open",
-    "axiomCount": 17,
-    "lineCount": 513,
-    "assumptions": "17 axiom(s) aggregated across files (8 in the primary Erdos548Problem.lean — deep extremal-graph-theory literature results: trivial_tree_bound, brandt_dobson, sacle_wozniak, wang_li_liu, path_extremal, komlos_sos_large_k, erdos_gallai_matching, turan_path_formula — plus 9 in the legacy stub Proofs/Stubs/Erdos548Problem.lean). The primary file now has 0 sorries: all six were proved in July 2026 (star_is_tree, sum_degrees_eq_twice_edges, avg_degree_iff_edges, erdos_sos_implies_extremal, star_easier, erdos_548_status). Two statements required repair to be provable: avg_degree_iff_edges gained the missing k ≥ 1 hypothesis (false at k = 0 as stated), and erdos_sos_implies_extremal restricts its tree vertex type from Type* to Type (ErdosSosConjecture quantifies over Type). erdos_548_status is now Classical.em rather than a sorry that would have asserted the conjecture itself. The former tree_edge_count axiom is a proved theorem, and IsTree delegates to Mathlib genuine SimpleGraph.IsTree. Aristotle companion files retain their own sorry stubs pending proof search.",
+    "axiomCount": 16,
+    "lineCount": 793,
+    "assumptions": "16 axiom(s) aggregated across files (7 in the primary Erdos548Problem.lean — deep extremal-graph-theory literature results: brandt_dobson, sacle_wozniak, wang_li_liu, path_extremal, komlos_sos_large_k, erdos_gallai_matching, turan_path_formula — plus 9 in the legacy stub Proofs/Stubs/Erdos548Problem.lean). The former trivial_tree_bound axiom is now a proved theorem (July 2026): Part XI extracts a nonempty vertex set of internal minimum degree ≥ k from any graph with n(k−1)+1 edges, and Part XII embeds every (k+1)-vertex tree into such a set by a greedy leaf-at-a-time induction. The primary file has 0 sorries: all six were proved in July 2026 (star_is_tree, sum_degrees_eq_twice_edges, avg_degree_iff_edges, erdos_sos_implies_extremal, star_easier, erdos_548_status). Two statements required repair to be provable: avg_degree_iff_edges gained the missing k ≥ 1 hypothesis (false at k = 0 as stated), and erdos_sos_implies_extremal restricts its tree vertex type from Type* to Type (ErdosSosConjecture quantifies over Type). erdos_548_status is now Classical.em rather than a sorry that would have asserted the conjecture itself. The former tree_edge_count axiom is a proved theorem, and IsTree delegates to Mathlib genuine SimpleGraph.IsTree. Aristotle companion files retain their own sorry stubs pending proof search.",
     "mathlib_version": "4.31.0",
-    "theoremCount": 15,
+    "theoremCount": 17,
     "definitionCount": 16,
     "additionalFiles": [
       "Proofs/Erdos548Aristotle.lean",
@@ -90,8 +90,8 @@
       "title": "Part V: Known Partial Results",
       "startLine": 158,
       "endLine": 227,
-      "summary": "Axiomatizes four partial results: trivial bound ($n(k-1)+1$ edges), Brandt-Dobson (girth $\\ge 5$), Sacle-Wozniak ($C_4$-free), and Wang-Li-Liu (complement girth $\\ge 5$). Defines `girth`, `hasGirthAtLeast`, `C4Free`, and `complement` with inline proofs.",
-      "mathContext": "Axiomatizes four partial results: trivial bound ($n(k-1)+1$ edges), Brandt-Dobson (girth $\\ge 5$), Sacle-Wozniak ($C_4$-free), and Wang-Li-Liu (complement girth $\\ge 5$). Defines `girth`, `hasGirthAtLeast`, `C4Free`, and `complement` with inline proofs."
+      "summary": "States four partial results: the trivial bound ($n(k-1)+1$ edges) is a proved theorem (`trivial_tree_bound`, Part XII — min-degree extraction plus greedy leaf embedding); Brandt-Dobson (girth $\\ge 5$), Sacle-Wozniak ($C_4$-free), and Wang-Li-Liu (complement girth $\\ge 5$) remain axiomatized literature results. Defines `girth`, `hasGirthAtLeast`, `C4Free`, and `complement` with inline proofs.",
+      "mathContext": "States four partial results: the trivial bound ($n(k-1)+1$ edges) is a proved theorem (`trivial_tree_bound`, Part XII — min-degree extraction plus greedy leaf embedding); Brandt-Dobson (girth $\\ge 5$), Sacle-Wozniak ($C_4$-free), and Wang-Li-Liu (complement girth $\\ge 5$) remain axiomatized literature results. Defines `girth`, `hasGirthAtLeast`, `C4Free`, and `complement` with inline proofs."
     },
     {
       "id": "extremal-function",
@@ -135,7 +135,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdos Problem #548 is the famous Erdos-Sos conjecture: every graph with average degree $> k-1$ contains every tree on $k+1$ vertices. The formalization captures the conjecture in two equivalent forms, constructs path and star graphs, axiomatizes four partial results (trivial bound, girth $\\ge 5$, $C_4$-free, complement girth $\\ge 5$), defines the extremal function, and connects to the Komlos-Sos-Szemeredi asymptotic result and the Erdos-Gallai matching theorem. Despite 60+ years of effort and strong partial results, the general conjecture remains open.",
+    "summary": "Erdos Problem #548 is the famous Erdos-Sos conjecture: every graph with average degree $> k-1$ contains every tree on $k+1$ vertices. The formalization captures the conjecture in two equivalent forms, constructs path and star graphs, proves the trivial bound ($n(k-1)+1$ edges, via min-degree extraction and greedy tree embedding), axiomatizes three partial results (girth $\\ge 5$, $C_4$-free, complement girth $\\ge 5$), defines the extremal function, and connects to the Komlos-Sos-Szemeredi asymptotic result and the Erdos-Gallai matching theorem. Despite 60+ years of effort and strong partial results, the general conjecture remains open.",
     "implications": "1. **Tree Turan problem:** Would completely resolve $\\text{ex}(n, T)$ for all trees, giving the uniform bound $(k-1)n/2$ with paths achieving equality\n\n2. **Extremal graph theory:** Would establish trees as a natural threshold family -- the simplest connected graphs whose Turan numbers obey a single formula\n\n**3. Embedding theory:** The partial results reveal that graph structure (girth, complement density) governs tree embeddability, connecting to structural graph theory\n\n4. **Regularity method:** The Komlos-Sos-Szemeredi approach demonstrates the power (and limitations) of the regularity-blow-up method -- it works asymptotically but leaves finite cases open\n\n5. **Algorithmic implications:** A constructive proof would yield polynomial-time algorithms for finding tree embeddings in dense graphs.",
     "openQuestions": [
       "Is the Erdos-Sos conjecture true in full generality?",
@@ -159,9 +159,9 @@
       "Finset"
     ],
     "namespace": "Erdos548",
-    "lineCount": 656,
-    "axiomCount": 8,
-    "theoremCount": 15,
+    "lineCount": 793,
+    "axiomCount": 7,
+    "theoremCount": 17,
     "definitionCount": 17,
     "path": "Proofs/Erdos548Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Eliminates the `trivial_tree_bound` axiom from `Erdos548Problem.lean` (Erdős–Sós, #548): **8 → 7 axioms**. The remaining 7 are all person/paper-named deep literature results (Brandt–Dobson, Saclé–Wozniak, Wang–Li–Liu, Komlós–Sós, Erdős–Gallai, path extremal/Turán).

## What's proved (Part XII, new)

- `exists_tree_embedding_into_min_degree_set` — every tree on at most `k+1` vertices embeds into a vertex set `s` of internal minimum degree `>= k`, with image inside `s`. Induction on the vertex count: remove a leaf (`IsTree.exists_vert_degree_one_of_nontrivial`), the rest is still a tree (`Connected.induce_compl_singleton_of_degree_eq_one` + `IsAcyclic.induce`), and a fresh attachment vertex always exists because the image occupies at most `k` vertices, one of which is the attachment point itself.
- `trivial_tree_bound` — now a **theorem**: the Part XI min-degree extraction (merged in #42732) supplies the set `s` from `n(k-1)+1` edges; the greedy embedding places any `(k+1)`-vertex tree inside it. The `axiom` declaration in Part V is removed.

## Verification

- Host `lake env lean Proofs/Erdos548Problem.lean` EXIT=0 (unpiped), 0 errors
- `#print axioms` for both new theorems: `[propext, Classical.choice, Quot.sound]`
- `grep -c "^axiom "` = 7

## Gallery metadata

- `meta.axiomCount` 17 → 16, `leanFile.axiomCount` 8 → 7 (aggregation includes 9 legacy-stub axioms)
- `theoremCount` 15 → 17, `lineCount` refreshed
- `assumptions`, Part-V section summary, and conclusion prose updated (trivial bound no longer listed as axiomatized)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
