### PR TITLE
audit(erdos-42): record audit cycle 5 (issues-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13471,10 +13471,10 @@
       "result": "clean"
     },
     "erdos-42": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:39Z",
-      "result": "clean"
+      "lastAudited": "2026-07-23T23:52:27Z",
+      "result": "issues-fixed"
     },
     "erdos-420": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Tracker update for the erdos-42 audit cycle. Fixed a phantom axiom claim
in `proofStrategy` (merged in #42745): the prose said "the remaining
axioms record Sedov's M=2,3 results and the open general conjecture" but
the file has 0 axiom declarations — those results are documented only as
plain comments, consistent with axiomCount:0 and the rest of the file's
own section summaries.