### PR TITLE
audit(erdos-409): fix phantom identifiers + reversed math in annotations

### DIFF
--- a/src/data/proofs/erdos-409/annotations.json
+++ b/src/data/proofs/erdos-409/annotations.json
@@ -30,12 +30,12 @@
       "endLine": 106
     },
     "title": "Totient Decrease and Iteration Termination Proofs",
-    "content": "The core proved results establishing that the iteration terminates. `totient_plus_one_lt_of_composite`: for composite $n > 1$, $\\varphi(n) + 1 < n$. Proof: $\\varphi(n) \\leq n - 2$ for composite $n$ because both 0 and $\\min\\text{Fac}(n)$ are not coprime to $n$, so at least 2 elements of $[0, n)$ are excluded from the totient count. Uses `Finset.card_lt_card` after showing the coprime filter misses at least $\\{0, \\min\\text{Fac}(n)\\}$. The `totientIterate_terminates` theorem then proves the iteration reaches a prime, using well-founded recursion on $\\mathbb{N}$.",
+    "content": "The core proved results establishing that the iteration terminates. `iterate_decreasing`: for composite $n > 1$, $\\varphi(n) + 1 < n$. Proof: $\\varphi(n) \\leq n - 2$ for composite $n$ because both 0 and $\\min\\text{Fac}(n)$ are not coprime to $n$, so at least 2 elements of $[0, n)$ are excluded from the totient count. Uses `Finset.card_le_card` after showing the coprime filter misses at least $\\{0, \\min\\text{Fac}(n)\\}$. The `iteration_terminates` theorem then proves the iteration reaches a prime, using well-founded recursion on $\\mathbb{N}$.",
     "mathContext": "$\\varphi(n) = |\\{k \\in [0,n) : \\gcd(k,n) = 1\\}|$. For composite $n$: $0$ and $\\min\\text{Fac}(n)$ are not coprime to $n$, so $\\varphi(n) \\leq n - 2$, hence $\\varphi(n) + 1 \\leq n - 1 < n$.",
     "significance": "key",
     "relatedConcepts": [
       "totient bound",
-      "Finset.card_lt_card",
+      "Finset.card_le_card",
       "well-founded recursion"
     ],
     "prerequisites": [
@@ -53,7 +53,7 @@
       "endLine": 137
     },
     "title": "Iteration Count and Basic Properties",
-    "content": "Defines `iterationsToReachPrime` counting how many steps to reach a prime, and proves basic properties. For primes, $F(p) = 0$ (already prime). For composite $n$, $F(n) = F(\\varphi(n)+1) + 1$ (one more step than the successor). Uses `Nat.strongRecOn` for the well-founded definition and `sSup` for the supremum characterization.",
+    "content": "Defines `iterationsToFirst` counting how many steps to reach a prime, and proves basic properties. For primes, $F(p) = 0$ (already prime). For composite $n$, $F(n) = F(\\varphi(n)+1) + 1$ (one more step than the successor). Uses `Nat.strongRecOn` for the well-founded definition and `sSup` for the supremum characterization.",
     "mathContext": "$F(p) = 0$ for prime $p$. $F(n) = 1 + F(\\varphi(n)+1)$ for composite $n > 1$. The function is well-defined by the decreasing chain $n > \\varphi(n) + 1 > \\cdots$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -63,7 +63,7 @@
     ],
     "prerequisites": [
       "Nat.strongRecOn",
-      "totient_plus_one_lt_of_composite"
+      "iterate_decreasing"
     ]
   },
   {
@@ -75,8 +75,8 @@
       "endLine": 271
     },
     "title": "Sigma Variant and Open Conjectures",
-    "content": "The closing section explores the variant using the sum-of-divisors function $\\sigma(n)$ instead of $\\varphi(n)$. Defines `sigmaPlusOne` and the analogous iteration. States the open conjectures about density of $n$ reaching specific primes, finiteness of the iteration for all $n$, and the relationship between the $\\varphi$ and $\\sigma$ variants.",
-    "mathContext": "Variant: $g(n) = \\sigma(n) - 1$ (sum of proper divisors). The iteration $n \\mapsto \\sigma(n) - 1$ also decreases for most $n$ but has different termination properties. Open: characterize which primes are reachable.",
+    "content": "The closing section explores the variant using the sum-of-divisors function $\\sigma(n)$ instead of $\\varphi(n)$. Proves `sigma_growing`, `sigma_prime_fixed`, and `sigma_composite_growth`: this iteration is non-decreasing at composites ($\\sigma(n) - 1 \\geq n$, in fact $\\geq n + 1$) and fixed at primes ($\\sigma(p) - 1 = p$), a fundamentally different dynamical system from the $\\varphi$-iteration. States the open conjectures about density of $n$ reaching specific primes, finiteness of the iteration for all $n$, and the relationship between the $\\varphi$ and $\\sigma$ variants.",
+    "mathContext": "Variant: $g(n) = \\sigma(n) - 1$ (sum of divisors minus one). Unlike the $\\varphi$-iteration, $g$ is non-decreasing for composites ($\\sigma(n) - 1 \\geq n$) and fixed at primes, so termination at a prime is not guaranteed. Open: characterize which primes are reachable.",
     "significance": "supporting",
     "relatedConcepts": [
       "sum of divisors",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-409 (Totient Iteration to Primes)

Routine audit re-serve. `meta.json`/Lean source (`Erdos409Problem.lean`) are clean
(423 lines, 18 theorems, 3 defs, 0 sorries, 0 `axiom` decls, 3 disclosed `native_decide`
uses matching `assumptions` prose) — no change needed there.

`annotations.json` had drifted from an earlier version of the file and referenced
identifiers that no longer exist:

- `totient_plus_one_lt_of_composite` → actual name is `iterate_decreasing`
- `totientIterate_terminates` → actual name is `iteration_terminates`
- `iterationsToReachPrime` → actual name is `iterationsToFirst`
- Claimed the file "defines `sigmaPlusOne` and the analogous iteration" — no such
  definition exists; the file only proves three standalone facts
  (`sigma_growing`, `sigma_prime_fixed`, `sigma_composite_growth`) about
  `n.divisors.sum id - 1`, no iterated function.

Also fixed a reversed math claim: the sigma-variant `mathContext` said the
σ-iteration "decreases for most n", but the file's own comment (lines 231-235)
and proved theorem `sigma_growing` show it is **non-decreasing** for composites
(`σ(n) - 1 ≥ n`) — the opposite of the φ-iteration's strict descent, and the
whole point of including this variant as a contrast.

## Recommended Fix

Applied directly: corrected the three phantom identifier names, fixed the
`Finset.card_lt_card` → `Finset.card_le_card` related-concept tag to match the
actual lemma used, and rewrote the sigma-variant content/mathContext to
describe the non-decreasing behavior the file actually proves.

---
Discovered during gallery integrity audit (reserve-mode re-serve of erdos-409).