### PR TITLE
Enrich collatz-cycles-oq-04: link discharged open question to child oq-02

### DIFF
--- a/src/data/proofs/collatz-cycles-oq-04/meta.json
+++ b/src/data/proofs/collatz-cycles-oq-04/meta.json
@@ -128,7 +128,7 @@
     "summary": "All 13 theorems are fully proved with 0 sorries and 0 axioms. The proof generalizes the specific j=1,2,3,4 halving constraints from CollatzCycles.lean to all j ≥ 1 via the product equation ∏(3nᵢ+1) = 2^M·∏nᵢ and the inductive bound ∏(3nᵢ+1) > 3^j·∏nᵢ.",
     "implications": "The general halving constraint M ≥ j+1 (with the sharper bound M ≥ ⌈j·log₂(3)⌉ being beyond what this proof gives directly) implies that any non-trivial Collatz cycle grows quickly in length. The product equation 2^M·∏nᵢ = ∏(3nᵢ+1) is the fundamental algebraic identity of Collatz cycle theory.",
     "openQuestions": [
-      "Can the sharp bound M ≥ ⌈j·log₂(3)⌉ be formalized from the product equation using Diophantine approximation techniques?",
+      "Now discharged by collatz-cycles-oq-02, which takes the halving constraint 3^j < 2^M proved here and, via base-2 logarithms (not Diophantine approximation as originally envisioned here), formalizes exactly the sharp bound M ≥ ⌈j·log₂3⌉ — and the finer Diophantine-approximation route is itself carried out one level deeper in collatz-cycles-oq-02-oq-01.",
       "Can Eliahou's bound (any non-trivial cycle has M > 17 billion) be derived from the product equation with additional number-theoretic input?"
     ]
   },
@@ -142,6 +142,11 @@
       "targetId": "collatz-structured-oq-02",
       "relationship": "related",
       "description": "CollatzStructured OQ-02 proves similar cycle constraints using interval_cases; this file uses algebraic product methods instead"
+    },
+    {
+      "targetId": "collatz-cycles-oq-02",
+      "relationship": "extended-by",
+      "description": "Answers this entry's open question: takes the halving constraint 3^j < 2^M proved here and derives the sharp bound M ≥ ⌈j·log₂3⌉ via base-2 logarithms."
     }
   ],
   "references": [


### PR DESCRIPTION
## Summary
- `collatz-cycles-oq-04`'s conclusion posed the open question "Can the sharp bound M ≥ ⌈j·log₂(3)⌉ be formalized from the product equation?" — this is exactly what its own child `collatz-cycles-oq-02` formalizes (`halvings_ge_ceil`), taking the halving constraint `3^j < 2^M` proved in oq-04 and deriving `M ≥ ⌈j·log₂3⌉` via base-2 logarithms.
- Added a reciprocal `extended-by` crossReference from oq-04 to oq-02 (oq-02 already lists oq-04 as `depends-on`).
- Updated the discharged openQuestion text to point to oq-02, and note that the finer Diophantine-approximation route (as originally envisioned in the question) is carried out one level deeper in `collatz-cycles-oq-02-oq-01`.

No Lean source changes; JSON validated, no other files touched.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — valid JSON
- [x] Verified crossReference target `collatz-cycles-oq-02` exists in the gallery
- [x] Confirmed via source read that oq-02's `halvings_ge_ceil` theorem matches the claimed discharge