### PR TITLE
audit(erdos-409): record audit cycle 5 (issues-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13390,10 +13390,10 @@
       "result": "clean"
     },
     "erdos-409": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:39Z",
-      "result": "clean"
+      "lastAudited": "2026-07-23T23:57:45Z",
+      "result": "issues-fixed"
     },
     "erdos-41": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Records the tracker entry for the erdos-409 re-audit (cycle 5): annotations.json
had phantom identifiers and a reversed math claim, fixed in #42749.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>