### PR TITLE
Fix dirichlets-theorem-oq-03-oq-01: sections mislabel 3 theorems' content

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03-oq-01/meta.json
@@ -127,20 +127,20 @@
       "id": "critical-exponent",
       "title": "The Critical Exponent",
       "startLine": 62,
-      "endLine": 77,
+      "endLine": 70,
       "summary": "`criticalExponent` as sInf; lower-bound and non-negativity lemmas from the conditional-infimum API."
     },
     {
       "id": "ray-and-sandwich",
       "title": "Ray Property and Sandwich",
-      "startLine": 79,
-      "endLine": 106,
+      "startLine": 72,
+      "endLine": 99,
       "summary": "Every exponent above the critical one is admissible; the sandwich Ioi(c) ⊆ admissible ⊆ Ici(c)."
     },
     {
       "id": "monotonicity",
       "title": "Monotonicity under Domination",
-      "startLine": 107,
+      "startLine": 101,
       "endLine": 115,
       "summary": "Pointwise domination shrinks the admissible set and lowers the critical exponent."
     },


### PR DESCRIPTION
Fix dirichlets-theorem-oq-03-oq-01: sections mislabel 3 theorems' content

The `critical-exponent`, `ray-and-sandwich`, and `monotonicity` section
boundaries didn't line up with the actual theorem declarations:
- `critical-exponent` (endLine 77) ran 7 lines past
  criticalExponent_nonneg's proof (which ends at 70), swallowing the
  docstring and signature of the next theorem, mem_admissible_of_gt.
- `ray-and-sandwich` (startLine 79) then picked up mid-signature at line 79,
  leaving line 78 uncovered by any section, and its endLine 106 ran all the
  way through admissible_mono (101-106) -- a monotonicity/comparison lemma,
  not a ray/sandwich one.
- `monotonicity` (startLine 107) started after admissible_mono had already
  been consumed by the previous section, so it covered only
  criticalExponent_mono, contradicting its own summary ("pointwise
  domination shrinks the admissible set...") which describes admissible_mono
  too.

Realigned to critical-exponent: 62-70, ray-and-sandwich: 72-99,
monotonicity: 101-115, verified line-by-line against
proofs/Proofs/DirichletsTheoremOQ03OQ01.lean. annotations.json already had
the correct boundaries for these same theorems and needed no change.
