### PR TITLE
audit(erdos-400): record audit cycle (issues-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13331,9 +13331,9 @@
     },
     "erdos-400": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:39Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T00:03:18Z",
+      "result": "issues-fixed"
     },
     "erdos-401": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Records the erdos-400 audit cycle in the tracker. Issue found and fixed in #42753 (stale "(axiom)" labels in annotations.json for two items now proved as theorems, and three phantom axiom names with no Lean declaration at all).