### PR TITLE
Fix eisenstein-criterion-oq-01-oq-02: close annotation coverage gaps

### DIFF
--- a/src/data/proofs/eisenstein-criterion-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/eisenstein-criterion-oq-01-oq-02/annotations.json
@@ -29,7 +29,7 @@
     "type": "tactic",
     "range": {
       "startLine": 32,
-      "endLine": 54
+      "endLine": 51
     },
     "title": "Irreducibility over ℚ via Gauss's Lemma",
     "content": "The single new algebraic input. Since $X^n - p$ is monic it is **primitive**, and primitive-polynomial Gauss's lemma (`IsPrimitive.Int.irreducible_iff_irreducible_map_cast`) says it is irreducible over $\\mathbb{Z}$ iff its image in $\\mathbb{Q}[X]$ is. The image of $X^n - C\\,p$ under $\\mathbb{Z} \\to \\mathbb{Q}$ is again $X^n - C\\,p$ (closed by `simp`), so the parent's $\\mathbb{Z}$-irreducibility transfers to $\\mathbb{Q}$ for **every** exponent $n$, not just prime $n$.",
@@ -50,7 +50,7 @@
     "proofId": "eisenstein-criterion-oq-01-oq-02",
     "type": "tactic",
     "range": {
-      "startLine": 56,
+      "startLine": 55,
       "endLine": 78
     },
     "title": "Identifying the Minimal Polynomial",
@@ -72,8 +72,8 @@
     "proofId": "eisenstein-criterion-oq-01-oq-02",
     "type": "theorem",
     "range": {
-      "startLine": 83,
-      "endLine": 98
+      "startLine": 79,
+      "endLine": 96
     },
     "title": "The Extension Degree Equals the Exponent",
     "content": "For $\\alpha$ integral over $K$, $\\dim_K K\\langle\\alpha\\rangle = \\deg(\\operatorname{minpoly}_K\\alpha)$ (`IntermediateField.adjoin.finrank`). Substituting the identified minimal polynomial and $\\operatorname{natDegree}(X^n - p) = n$ gives $[\\mathbb{Q}(\\alpha) : \\mathbb{Q}] = n$. Taking $\\alpha = p^{1/n}$ (via `Real.rpow_inv_natCast_pow`) shows **Eisenstein furnishes a real algebraic number of every prescribed degree** $n \\ge 1$.",


### PR DESCRIPTION
Fix eisenstein-criterion-oq-01-oq-02: close annotation coverage gaps

Adjacent annotation ranges were each off by a few lines, leaving two spans
of the Lean file completely uncovered by any annotation:
- Line 55 (the opening line of aeval_root's docstring) was excluded from
  both the preceding "irreducible-rat" annotation (which stopped at 54,
  three lines past its own theorem's end at 51, wrongly absorbing the next
  section's `/-! ### The minimal polynomial...` title comment) and the
  "minpoly" annotation (which started at 56, one line late).
- Lines 79-82 -- the "### The degree of the radical extension" section
  title comment and the entirety of finrank_adjoin_eq's docstring -- were
  excluded from both "minpoly" (ending at 78) and "degree" (starting at 83,
  four lines late).

Realigned irreducible-rat to 32-51, minpoly to 55-78, and degree to 79-96,
verified against proofs/Proofs/EisensteinCriterionOQ01OQ02.lean line by
line. This file's meta.json `sections[]` were already correctly aligned and
needed no change.
