### PR TITLE
Fix dissection-of-cubes-oq-01-oq-01-oq-01: sections attribute SECTION-comment markers to the wrong region

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-01-oq-01/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "dissect-oq010101-ann-header",
     "proofId": "dissection-of-cubes-oq-01-oq-01-oq-01",
-    "range": { "startLine": 1, "endLine": 70 },
+    "range": { "startLine": 1, "endLine": 65 },
     "type": "concept",
     "title": "Does the minimal-collision witness survive real coverage?",
     "content": "The gallery result minimal_collision_achievable (OQ-01-01) builds a CubeDissection with exactly 2 colliding cubes, but its covers_unit_cube field is the placeholder True — the cubes do not actually fill the unit cube. This entry replaces that placeholder with a genuine volumetric coverage predicate ∑ c.side³ = 1 and asks whether the witness survives. It does not: the published example occupies under 7% of the unit cube. The predicate is shown satisfiable (the unit cube, 0 collisions), the known witness is shown to fail it, and a new cardinality bound proves any genuine minimal-collision dissection needs ≥ 3 cubes.",
@@ -14,7 +14,7 @@
   {
     "id": "dissect-oq010101-ann-structure",
     "proofId": "dissection-of-cubes-oq-01-oq-01-oq-01",
-    "range": { "startLine": 71, "endLine": 97 },
+    "range": { "startLine": 66, "endLine": 97 },
     "type": "definition",
     "title": "GeoCubeDissection with volumetric coverage",
     "content": "GeoCubeDissection keeps the combinatorial constraints of CubeDissection (all cubes contained in the unit cube, pairwise interior-disjoint) but replaces the True placeholder with the real coverage field volume_fills : ∑ c.size³ = 1. For pairwise interior-disjoint cubes inside [0,1]³ this is exactly the necessary condition for filling the unit cube, and is measure-sufficient. The forgetful map toCubeDissection discharges covers_unit_cube by trivial, letting the existing collidingCubes and HasMinimalCollision machinery be reused unchanged.",

--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-01-oq-01/meta.json
@@ -105,34 +105,34 @@
       "id": "header",
       "title": "Module Header",
       "startLine": 1,
-      "endLine": 70,
+      "endLine": 65,
       "summary": "Docstring stating the question (does the witness survive genuine coverage?) and the answer (no), plus imports and opens."
     },
     {
       "id": "geo-structure",
       "title": "Genuine (Volumetric) Cube Dissection",
-      "startLine": 71,
-      "endLine": 100,
+      "startLine": 66,
+      "endLine": 97,
       "summary": "GeoCubeDissection with `volume_fills : ∑ c.side³ = 1` and the forgetful map to CubeDissection."
     },
     {
       "id": "satisfiable",
       "title": "The Predicate is Satisfiable — the Unit Cube",
-      "startLine": 101,
-      "endLine": 150,
+      "startLine": 98,
+      "endLine": 145,
       "summary": "unitCube, unitGeoDissection (a genuine dissection), unitGeo_no_collision (0 colliding cubes), unitGeo_not_minimal."
     },
     {
       "id": "witness-fails",
       "title": "The Minimal-Collision Example Fails Genuine Coverage",
-      "startLine": 151,
-      "endLine": 180,
+      "startLine": 146,
+      "endLine": 175,
       "summary": "exampleCubes_volume_ne_one (volume 59/864 ≠ 1) and no_geo_with_exampleCubes (the headline obstruction)."
     },
     {
       "id": "open-question",
       "title": "The Open Question, Restated",
-      "startLine": 181,
+      "startLine": 176,
       "endLine": 203,
       "summary": "Restates the open geometric question and transports the ≥2 lower bound to GeoCubeDissection."
     },


### PR DESCRIPTION
Fix dissection-of-cubes-oq-01-oq-01-oq-01: sections attribute SECTION-comment markers to the wrong region

The file marks its five logical parts with inline `-- SECTION N: ...` banner
comments (at lines 66, 98, 146, 176, 205). meta.json's `sections[]` attributed
every one of the first four banners to the section they *close* instead of
the section they *introduce*:
- header ran to line 70, five lines into the SECTION 1 banner (66-68) plus
  the first line of GeoCubeDissection's docstring.
- geo-structure (71-100) then picked up mid-docstring and, at its far end,
  absorbed the SECTION 2 banner that actually introduces "satisfiable".
- The same off-by-several-lines pattern repeated at the satisfiable/
  witness-fails and witness-fails/open-question boundaries.
- The open-question/cardinality-bound boundary (176 vs 205, matching
  SECTION 4 and SECTION 5) was already correct, confirming the fix pattern.

Realigned to header:1-65, geo-structure:66-97, satisfiable:98-145,
witness-fails:146-175, open-question:176-203 (unchanged), verified against
proofs/Proofs/DissectionOfCubesOQ01OQ01OQ01.lean. annotations.json had the
identical bug only at the header/geo-structure boundary (70/71 -> 65/66);
every other annotation range was already correctly aligned and needed no
change.
