### PR TITLE
Enrich shannon-source-coding-wip-01-oq-01: split entropy section, add 5th keyInsight

### DIFF
--- a/src/data/proofs/shannon-source-coding-wip-01-oq-01/meta.json
+++ b/src/data/proofs/shannon-source-coding-wip-01-oq-01/meta.json
@@ -62,7 +62,8 @@
       "**The tuple recursion is the induction engine.** Fin.consEquiv : α × (Fin n → α) ≃ (Fin (n+1) → α) splits off one symbol at a time, converting the n-fold product into an atomic product distribution that the parent's pairwise additivity already handles — no new analytic content, just clean reindexing.",
       "**Normalisation must be tracked alongside entropy.** The additivity step consumes ∑ p^⊗n = 1, so the proof proves ∑ₓ ∏ᵢ p(xᵢ) = (∑ₐ p a)^n as a companion induction; the two inductions run along the identical Fin.consEquiv recursion.",
       "**Entropy-rate backbone.** H(p^⊗n) = n·H(p) is the exact finite-block form of Shannon's entropy rate: n i.i.d. symbols carry n·H(p) bits, the quantity typical-set coding compresses to and the AEP concentrates around.",
-      "**Axiom-free and hypothesis-minimal.** The only assumption is ∑ₐ p a = 1, the defining property of a probability distribution; #print axioms confirms reliance only on propext, Classical.choice, Quot.sound."
+      "**Axiom-free and hypothesis-minimal.** The only assumption is ∑ₐ p a = 1, the defining property of a probability distribution; #print axioms confirms reliance only on propext, Classical.choice, Quot.sound.",
+      "**A purely combinatorial extension, not a new analytic result.** All the analytic content — the negMulLog linearization negMulLog(x·y) = y·negMulLog x + x·negMulLog y — lives in the parent's entropy_prod, reproved here unchanged. This file's entire contribution is the induction scaffold (Fin.consEquiv, Fin.prod_univ_succ) that lifts the binary identity to n-ary; a realistic illustration of how much of formalizing a 'generalization' is bookkeeping rather than new mathematics."
     ]
   },
   "sections": [
@@ -75,12 +76,20 @@
       "mathContext": "$H(p^{\\otimes n}) = n \\cdot H(p)$ for $\\sum_a p(a) = 1$; iterated from pairwise $H(p_X \\otimes p_Y) = H(p_X) + H(p_Y)$ along $\\mathrm{Fin.consEquiv}$."
     },
     {
-      "id": "entropy-and-additivity",
-      "title": "Entropy in negMulLog form and pairwise additivity",
+      "id": "entropy-def",
+      "title": "Entropy in negMulLog form",
       "startLine": 47,
+      "endLine": 49,
+      "summary": "entropy p := ∑ₓ negMulLog(p x), matching the parent's definition and agreeing with the standard −∑ₓ p x · log(p x); negMulLog builds in the 0·log 0 = 0 convention so no case split on zeros is needed downstream.",
+      "mathContext": "$H(p) = \\sum_x \\mathrm{negMulLog}(p_x)$"
+    },
+    {
+      "id": "entropy-prod",
+      "title": "Pairwise additivity (reproved locally)",
+      "startLine": 51,
       "endLine": 71,
-      "summary": "entropy p := ∑ₓ negMulLog(p x). entropy_prod: H(pX ⊗ pY) = H(pX) + H(pY) for ∑ pX = ∑ pY = 1 (the parent result, reproved locally so the file is self-contained; the atomic step iterated below).",
-      "mathContext": "$H(p) = \\sum_x \\mathrm{negMulLog}(p_x), \\qquad H(p_X \\otimes p_Y) = H(p_X) + H(p_Y).$"
+      "summary": "entropy_prod: H(pX ⊗ pY) = H(pX) + H(pY) for ∑ pX = ∑ pY = 1 — the parent result, reproved locally so this file is self-contained; the atomic step iterated by entropy_pow below.",
+      "mathContext": "$H(p_X \\otimes p_Y) = H(p_X) + H(p_Y).$"
     },
     {
       "id": "normalisation",


### PR DESCRIPTION
Enrichment pass for shannon-source-coding-wip-01-oq-01 (quality 96/100, 0 passes).

The entry was already close to the quality target; the two remaining gaps were:
- `sections` (4 sections, capped score at 8/10): the `entropy-and-additivity`
  section bundled the `entropy` definition (lines 47-49) with the `entropy_prod`
  theorem (lines 51-71) into one block. Split into two sections at the real
  Lean declaration boundary so each section maps to one construct.
- `overview.keyInsights` (4 items, capped score at 8/10): added a 5th insight
  that honestly frames the file's contribution — the analytic content
  (negMulLog linearization) is entirely the parent's `entropy_prod`, reproved
  unchanged; this file's own work is purely the `Fin.consEquiv` induction
  scaffold that lifts binary additivity to n-ary.

No content deleted, no invented history/citations. Verified against the Lean
source (`proofs/Proofs/ShannonSourceCodingWIP01OQ01.lean`, 124 lines,
3 theorems, 2 definitions, 0 sorries, 0 axioms) — section/annotation line
ranges match real declarations (`npx tsx scripts/annotations/build.ts` reports
no "No Lean construct found" warnings for this entry). `meta.json` is 13.1 KB,
well under the 60 KB cap.