### PR TITLE
fix(erdos-768): drop phantom conjecture-as-disjunction formalization claim

### DIFF
--- a/src/data/proofs/erdos-768/meta.json
+++ b/src/data/proofs/erdos-768/meta.json
@@ -53,7 +53,7 @@
       "Formal connection to non-cyclic simple group orders via IsSimpleGroup",
       "Counting function and density formalized with Finset.filter",
       "Erdős's two-sided bounds documented as docstrings (no axioms or theorems in the file)",
-      "Main conjecture as a disjunction: either the constant c exists or it doesn't"
+      "Main open conjecture stated as prose in the header/closing docstrings only (not formalized as a Lean term)"
     ],
     "axiomCount": 0,
     "lineCount": 280,
@@ -162,7 +162,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization introduces the witness divisor set A, proves basic membership (1 ∈ A, 12 ∈ A, 56 ∈ A; 6 ∉ A; prime powers ∉ A), proves a product criterion for distinct primes with witness chains, identifies 12 as the smallest non-trivial element, and connects to simple group orders via Sylow theory. The 280-line file formalizes the main conjecture as whether the ratio -log(density)/f(N) converges; the file is fully verified with 0 sorries and 0 axioms.",
+    "summary": "This formalization introduces the witness divisor set A, proves basic membership (1 ∈ A, 12 ∈ A, 56 ∈ A; 6 ∉ A; prime powers ∉ A), proves a product criterion for distinct primes with witness chains, identifies 12 as the smallest non-trivial element, and defines the connection to simple group orders via IsSimpleGroup/IsCyclic. The 280-line file documents the main conjecture (whether the ratio -log(density)/f(N) converges) as prose only, not a formalized Lean statement; the file is fully verified with 0 sorries and 0 axioms.",
     "implications": "**Theoretical Significance**: Resolution would determine the exact density of integers with the witness divisor property, with implications for bounding the distribution of simple group orders.\n\nThe techniques would involve sieve methods, multiplicative number theory, and the distribution of smooth numbers. The constant c would quantify how 'rare' the balanced prime factorization condition is.",
     "openQuestions": [
       "Does the constant c exist, i.e., does -log(density)/√(log N)·log log N converge?",


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-768

**Problem**: `originalContributions` claimed "Main conjecture as a disjunction: either the constant c exists or it doesn't" was formalized, and `conclusion.summary` said the file "formalizes the main conjecture". Neither is true — `Erdos768Problem.lean` never declares the disjunction; the main open conjecture appears only as prose in a plain (non-doc) comment block (lines 266-279), matching the honest wording already used in the file's own section summary ("stated as a disjunction in a docstring").

## Evidence

**meta.json claimed**: main conjecture formalized as a disjunction; file "formalizes the main conjecture"
**Lean file shows**: `grep -n "∨\|Or\b\|mainConjecture\|disjunction"` finds only unrelated `Or.inl`/`Or.inr` usages inside an internal lemma proof — no declaration captures the conjecture. It is comment-only.

## Fix

Reworded `originalContributions` and `conclusion.summary` to say the conjecture is documented as prose/docstring only, not formalized as a Lean term. No math, axiom, sorry, or badge changes — file already correctly has `axiomCount: 0`, `sorries: 0`, `badge: wip`, `status: axiomatized`.

---
Discovered during gallery integrity audit (round-robin re-serve, queue drained).