### PR TITLE
audit(erdos-75): fix stale 'axiomatizes' prose for concrete structures/theorems

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16103,9 +16103,9 @@
     },
     "erdos-75": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:40Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T00:17:54Z",
+      "result": "issues-fixed"
     },
     "erdos-750": {
       "agentId": "auditor-agent-rebump-after-16267",

--- a/src/data/proofs/erdos-75/annotations.json
+++ b/src/data/proofs/erdos-75/annotations.json
@@ -5,12 +5,12 @@
     "type": "concept",
     "title": "Basic Mathlib Imports",
     "content": "Imports Nat.Basic, Finset, Rat.Basic, and tactics from Mathlib.",
-    "mathContext": "The formalization uses `ℚ` (rational numbers) for the density parameter $\\varepsilon$ and the linear constant $c$, avoiding the complications of working with real-valued exponents. The `Finset` import supports finite vertex counting. Notably, this file does NOT import Mathlib's `SimpleGraph` type—instead it axiomatizes an abstract `Graph` type to handle infinite graphs with uncountable chromatic number, which are beyond SimpleGraph's scope.",
+    "mathContext": "The formalization uses `ℚ` (rational numbers) for the density parameter $\\varepsilon$ and the linear constant $c$, avoiding the complications of working with real-valued exponents. The `Finset` import supports finite vertex counting. Notably, this file does NOT import Mathlib's `SimpleGraph` type—instead it defines an abstract `Graph` structure (no axioms) to handle infinite graphs with uncountable chromatic number, which are beyond SimpleGraph's scope.",
     "significance": "supporting",
     "relatedConcepts": [
       "ℚ",
       "Finset",
-      "abstract axiomatization"
+      "abstract graph structure"
     ],
     "prerequisites": [
       "Mathlib.Data.Nat.Basic",
@@ -26,18 +26,18 @@
     "proofId": "erdos-75",
     "type": "concept",
     "title": "Abstract Graph Type and Chromatic Number",
-    "content": "Axiomatizes Graph as an abstract type with chromaticNum G n meaning G requires ≥ n colours, and monotonicity of this predicate.",
-    "mathContext": "The abstract `Graph` type is necessary because Problem 75 concerns graphs with **uncountable chromatic number** ($\\chi(G) \\geq \\aleph_1$), which cannot be modeled by Mathlib's `SimpleGraph V` with finite `V`. The chromatic number is represented as a predicate `chromaticNum G n` ('$G$ requires at least $n$ colours') rather than a cardinal-valued function, with monotonicity axiom: if $G$ requires $n$ colours and $m \\leq n$, then $G$ requires $m$ colours. This representation sidesteps cardinal arithmetic while capturing the essential property.",
+    "content": "Defines Graph as an abstract structure (no axioms) with chromaticNum G n meaning G requires ≥ n colours, and proves monotonicity of this predicate.",
+    "mathContext": "The abstract `Graph` type is necessary because Problem 75 concerns graphs with **uncountable chromatic number** ($\\chi(G) \\geq \\aleph_1$), which cannot be modeled by Mathlib's `SimpleGraph V` with finite `V`. The chromatic number is represented as a predicate `chromaticNum G n` ('$G$ requires at least $n$ colours') rather than a cardinal-valued function, with a proved monotonicity theorem: if $G$ requires $n$ colours and $m \\leq n$, then $G$ requires $m$ colours. This representation sidesteps cardinal arithmetic while capturing the essential property.",
     "significance": "key",
     "relatedConcepts": [
       "chromatic number",
       "infinite graphs",
       "cardinal numbers",
-      "axiomatization"
+      "structure-based formalization"
     ],
     "prerequisites": [
       "Chromatic Number",
-      "Abstract Axiomatization",
+      "Abstract Graph Structure",
       "Predicate Monotonicity"
     ],
     "range": {
@@ -71,8 +71,8 @@
     "proofId": "erdos-75",
     "type": "concept",
     "title": "Finite Subgraphs and Independence Number",
-    "content": "Axiomatizes FiniteSubgraph G n (a subgraph on n vertices), indepNumber (its independence number), and the bound α(H) ≤ n.",
-    "mathContext": "The axiomatization of `FiniteSubgraph G n` as a type (rather than a predicate on vertex subsets) cleanly handles the passage from the infinite graph $G$ to its finite induced subgraphs. The **independence number** $\\alpha(H)$ is the size of the largest independent set in $H$, axiomatized with the trivial upper bound $\\alpha(H) \\leq n$ (at most all vertices are independent). The problem asks for *lower bounds* on $\\alpha(H)$ that are nearly linear in $n$.",
+    "content": "Defines FiniteSubgraph G n (a subgraph on n vertices) and indepNumber (its independence number), and proves the bound α(H) ≤ n.",
+    "mathContext": "The definition of `FiniteSubgraph G n` as a type (rather than a predicate on vertex subsets) cleanly handles the passage from the infinite graph $G$ to its finite induced subgraphs. The **independence number** $\\alpha(H)$ is the size of the largest independent set in $H$, with the trivial upper bound $\\alpha(H) \\leq n$ (at most all vertices are independent) proved as a theorem. The problem asks for *lower bounds* on $\\alpha(H)$ that are nearly linear in $n$.",
     "significance": "key",
     "relatedConcepts": [
       "independence number",

--- a/src/data/proofs/erdos-75/meta.json
+++ b/src/data/proofs/erdos-75/meta.json
@@ -90,7 +90,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem 75 is one of the most celebrated open problems in infinite graph theory, carrying a $1000 Erdős prize. It asks whether uncountable chromatic number is compatible with near-linear independence in every finite subgraph—a striking tension between global colouring complexity and local sparsity. The formalization captures both the basic (n^{1-ε}) and strong (linear) forms using an abstract axiomatization that goes beyond Mathlib's finite graph framework.",
+    "summary": "Erdős Problem 75 is one of the most celebrated open problems in infinite graph theory, carrying a $1000 Erdős prize. It asks whether uncountable chromatic number is compatible with near-linear independence in every finite subgraph—a striking tension between global colouring complexity and local sparsity. The formalization builds from-scratch graph, finite-subgraph, and independence-number infrastructure (concrete Lean 4 structures and proved theorems, no axioms) going beyond Mathlib's finite-graph framework, and defines both the basic (n^{1-ε}) and strong (linear) forms of the property as Lean propositions; the central existence conjecture itself is not formalized as a Lean statement and remains open.",
     "implications": "A positive answer would demonstrate a surprising separation between global and local graph properties, with implications for infinite Ramsey theory, the Erdős-Hajnal conjecture, and the set-theoretic foundations of combinatorics. A negative answer would establish a fundamental limitation on the independence structure of graphs with uncountable chromatic number.",
     "openQuestions": [
       "Does there exist a graph with χ ≥ ℵ₁ and the near-linear independence property?",


### PR DESCRIPTION
## Gallery Integrity Re-audit: erdos-75

**Proof**: erdos-75 (Uncountable Chromatic Number and Large Independent Sets)

Counts all match the Lean source: `axiomCount: 0`, `sorries: 0`, `theoremCount: 7`,
`definitionCount: 10` — no True stubs, no `native_decide`, no Mathlib-wrapper
mislabeling.

**Problem**: `conclusion.summary` and 3 annotations (`ann-e75-imports`,
`ann-e75-graphAxioms`, `ann-e75-finiteSubgraph`) still describe the `Graph`/
`FiniteSubgraph` structures and proved theorems (`chromaticNum_mono`,
`indepNumber_le`) as "axiomatized" / "axiomatizes" — stale wording from an
earlier version. The Lean file's own comment confirms the upgrade: "Previous
version used 7 abstract axioms for graph types and properties. These are now
concrete Lean 4 structures with proved theorems." `meta.assumptions` already
says "0 axioms, 0 sorries", so the stale phrasing directly contradicts the
file's own honest field.

This is understatement-direction (makes the proof look more assumption-laden
than it is, not less), so not a public overclaim risk, but confusing/
self-contradictory — cleaned up in place rather than filing a separate issue.

## Changes

- `meta.json`: `conclusion.summary` reworded to describe concrete structures/
  proved theorems instead of "an abstract axiomatization"
- `annotations.json`: 3 annotations reworded from "axiomatizes"/"axiomatized"
  to "defines"/"proves" for structures and theorems that carry no axioms
- `audit-tracker.json`: records this audit cycle (issues-fixed)

## Test plan

- [x] Verified JSON validity of both edited files
- [x] Diffed prose against `proofs/Proofs/Erdos75Problem.lean` — confirmed 0
      `axiom` declarations, all cited items are `structure`/`def`/`theorem`
- [x] Confirmed counts (axioms/sorries/theorems/defs) match meta.json

Discovered during gallery integrity audit.