### PR TITLE
audit(erdos-74): fix phantom axiom narrative for rodlLinear/uncountableFails

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16026,9 +16026,9 @@
     },
     "erdos-74": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:40Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T00:24:36Z",
+      "result": "issues-fixed"
     },
     "erdos-740": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-74/annotations.json
+++ b/src/data/proofs/erdos-74/annotations.json
@@ -171,11 +171,11 @@
     },
     "type": "concept",
     "title": "Rödl's Linear Case (1982)",
-    "content": "**rodlLinear** states: For any ε > 0, there exists a graph with infinite chromatic number where every n-vertex subgraph needs at most εn edge deletions to become bipartite.\n\nThis shows the conjecture is TRUE for linear f(n) = εn. Rödl's construction uses probabilistic methods.\n\n**Why an axiom?** The construction is complex and not yet formalized in Mathlib.",
+    "content": "This comment documents Rödl's linear-case result: for any ε > 0, there exists a graph with infinite chromatic number where every n-vertex subgraph needs at most εn edge deletions to become bipartite.\n\nThis shows the conjecture is TRUE for linear f(n) = εn. Rödl's construction uses probabilistic methods.\n\n**Not formalized**: this result is documented in a comment only — there is no corresponding Lean declaration (axiom or theorem) in this file.",
     "mathContext": "The bound ⌈εn⌉₊ is linear in n. The construction works for any positive ε, no matter how small.",
     "significance": "key",
     "relatedConcepts": [
-      "axiom",
+      "unformalized",
       "rodl",
       "probabilistic-method"
     ],
@@ -217,11 +217,11 @@
     },
     "type": "concept",
     "title": "Uncountable Chromatic Number Fails",
-    "content": "**uncountableFails** states: If we require chromatic number ≥ ℵ₁ (uncountable), then NO such graph exists for any unbounded f.\n\nThis is a surprising dichotomy:\n- χ = ℵ₀ (countable infinite): Open question\n- χ = ℵ₁ (uncountable): Impossible!\n\nThe set-theoretic distinction is crucial to the problem.",
+    "content": "This comment documents the uncountable case: if we require chromatic number ≥ ℵ₁ (uncountable), then NO such graph exists for any unbounded f.\n\nThis is a surprising dichotomy:\n- χ = ℵ₀ (countable infinite): Open question\n- χ = ℵ₁ (uncountable): Impossible!\n\nThe set-theoretic distinction is crucial to the problem.\n\n**Not formalized**: this claim is documented in a comment only — there is no corresponding Lean declaration (axiom or theorem) in this file.",
     "mathContext": "The proof uses that uncountably-chromatic graphs must contain certain unavoidable non-bipartite configurations.",
     "significance": "key",
     "relatedConcepts": [
-      "axiom",
+      "unformalized",
       "set-theory",
       "cardinality",
       "aleph"

--- a/src/data/proofs/erdos-74/meta.json
+++ b/src/data/proofs/erdos-74/meta.json
@@ -50,8 +50,8 @@
       "Formal definition of edge distance to bipartite",
       "Maximum edge distance over n-vertex subgraphs",
       "Statement of the main question as a Prop",
-      "Axiom for Rödl's linear case (f = εn)",
-      "Axiom for failure with uncountable chromatic number",
+      "Documentation (comment only, not a Lean declaration) of Rödl's linear-case result (f = εn)",
+      "Documentation (comment only, not a Lean declaration) of the uncountable-chromatic-number failure case",
       "Proof of edgeDistUpperBound (Co-authored-by: Aristotle)",
       "Discovery: edgeDistToBipartite equivalence fails for infinite graphs (Aristotle)"
     ],
@@ -65,7 +65,7 @@
     "historicalContext": "This problem explores the tension between global complexity (chromatic number) and local structure (almost-bipartiteness). A bipartite graph has chromatic number ≤ 2, so to have infinite chromatic number, a graph must have non-bipartite subgraphs.\n\nErdős, Hajnal, and Szemerédi asked: can we have infinite chromatic number while keeping subgraphs 'almost' bipartite—requiring only few edge deletions to become bipartite?\n\nRödl (1982) proved this is possible when f(n) = εn (linear in n), but the question remains open for slower-growing f like √n. Surprisingly, the problem FAILS if we require uncountable chromatic number (≥ ℵ₁), revealing set-theoretic subtleties.",
     "problemStatement": "**Erdős Problem #74 (OPEN)**\n\nLet $f(n) \\to \\infty$ (possibly very slowly). Does there exist a graph $G$ such that:\n1. $G$ has infinite chromatic number\n2. Every $n$-vertex subgraph can be made bipartite by deleting $\\leq f(n)$ edges\n\n**Known Results**:\n- TRUE for $f(n) = \\varepsilon n$ (Rödl 1982)\n- OPEN for $f(n) = \\sqrt{n}$\n- FALSE if chromatic number is $\\aleph_1$\n\n**Prize**: $500 for proof, $250 for counterexample",
     "text": "For f(n) → ∞, is there a graph with infinite chromatic number where every n-vertex subgraph can be made bipartite by deleting ≤ f(n) edges?",
-    "proofStrategy": "We formalize the key concepts and partial results:\n\n1. **edgeDistToBipartite**: Minimum edges to delete for bipartiteness\n\n2. **maxEdgeDistToBipartite**: Worst case over n-vertex subgraphs\n\n3. **Erdos74Question**: The main open question\n\n4. **rodlLinear** (axiom): Rödl's result for f(n) = εn\n\n5. **SqrtNQuestion**: The open √n case\n\n6. **uncountableFails** (axiom): Failure for uncountable chromatic number",
+    "proofStrategy": "We formalize the key concepts and partial results:\n\n1. **edgeDistToBipartite**: Minimum edges to delete for bipartiteness\n\n2. **maxEdgeDistToBipartite**: Worst case over n-vertex subgraphs\n\n3. **Erdos74Question**: The main open question\n\n4. Rödl's result for f(n) = εn — described in a comment, not formalized as a Lean declaration\n\n5. **SqrtNQuestion**: The open √n case\n\n6. Failure for uncountable chromatic number — described in a comment, not formalized as a Lean declaration",
     "keyInsights": [
       "**Bipartite = 2-colorable**: Bipartite graphs have chromatic number ≤ 2, so infinite chromatic number requires non-bipartite subgraphs.",
       "**Almost bipartite**: A graph is 'almost bipartite' if few edge deletions make it bipartite. This measures distance to the bipartite world.",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-74
**Problem**: Phantom axiom narrative — `meta.json` (`originalContributions`, `overview.proofStrategy`) and `annotations.json` describe `rodlLinear` and `uncountableFails` as formal Lean `axiom` declarations, but neither identifier exists in `Proofs/Erdos74Problem.lean`. They were removed in commit c34e89c (only comment-only documentation remains).

## Evidence

**meta.json claims**: `"Axiom for Rödl's linear case (f = εn)"`, `"Axiom for failure with uncountable chromatic number"`; `proofStrategy` bolds `**rodlLinear** (axiom)` and `**uncountableFails** (axiom)`.
**annotations.json claims**: `ann-e74-rodl` and `ann-e74-uncountable` present `**rodlLinear**`/`**uncountableFails**` as declared axioms with a "Why an axiom?" justification, tagged `relatedConcepts: ["axiom", ...]`.
**Lean file shows**: `grep -n axiom Erdos74Problem.lean` and `grep -n rodlLinear\|uncountableFails` both return zero hits. `axiomCount: 0` in meta.json is correct — but the prose contradicts it by describing two axioms that don't exist.

## Fix

Reworded the affected fields to describe both results as narrative/comment-only documentation (no corresponding Lean declaration), matching the recurring "phantom axiom narrative" class. `axiomCount`/`sorries`/`theoremCount`/`definitionCount` were already accurate — no count changes needed.

---
Discovered during gallery integrity audit (reserve mode, queue fully drained at 4811/4811).