### PR TITLE
Enrich sylow-theorem-oq-02-oq-01-oq-01: split sections to 5, add 5th keyInsight

### DIFF
--- a/src/data/proofs/sylow-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-02-oq-01-oq-01/meta.json
@@ -76,7 +76,8 @@
       "**Normal and characteristic coincide for Sylow subgroups.** The gap between invariance-under-inner-automorphisms and invariance-under-all-automorphisms vanishes precisely because a normal Sylow subgroup is unique, and automorphisms permute Sylow subgroups. This is sylow_characteristic_iff_normal — the entry's technical core.",
       "**Uniqueness upgrades invariance.** The same uniqueness that turns 'normal' into 'count one' (parent entry) also turns 'normal' into 'characteristic' here; both are facets of Sylow.unique_of_normal.",
       "**A new tier in the nilpotency chain.** nilpotent ⟺ all Sylow characteristic sits strictly above 'all Sylow normal' as a statement (characteristic is stronger than normal in general) yet is logically equivalent for Sylow subgroups — a clean example of an a-priori-stronger condition collapsing onto a weaker one under structural constraints.",
-      "**Explicit automorphism form.** Beyond the typeclass Characteristic, the entry states the concrete equality P.map φ.toMonoidHom = P for every φ : G ≃* G, the form most directly usable downstream."
+      "**Explicit automorphism form.** Beyond the typeclass Characteristic, the entry states the concrete equality P.map φ.toMonoidHom = P for every φ : G ≃* G, the form most directly usable downstream.",
+      "**TFAE via a common anchor.** nilpotent_tfae proves three biconditionals to a single anchor — `1 ↔ 2`, `1 ↔ 3`, `1 ↔ 4` — reusing nilpotent_iff_forall_sylow_normal, nilpotent_iff_forall_sylow_characteristic, and nilpotent_iff_forall_card_sylow_eq_one as already-proved edges, and lets `tfae_finish` assemble all six pairwise equivalences rather than re-deriving each one directly."
     ],
     "prerequisites": [
       "Sylow's theorems and the type Sylow p G (Mathlib.GroupTheory.Sylow)",
@@ -106,9 +107,17 @@
       "id": "coincidence",
       "title": "Characteristic ⟺ Normal for a Sylow Subgroup",
       "startLine": 86,
-      "endLine": 110,
-      "summary": "sylow_characteristic_iff_normal collapses the normal/characteristic gap via Sylow.characteristic_of_normal; sylow_characteristic_of_nilpotent and sylow_map_aut_eq_of_nilpotent give the nilpotent-case consequence and its explicit automorphism-invariance form.",
+      "endLine": 97,
+      "summary": "sylow_characteristic_iff_normal collapses the normal/characteristic gap: the forward direction is the generic characteristic ⇒ normal instance, the reverse is Sylow.characteristic_of_normal — a normal Sylow subgroup is unique, so it is invariant under every automorphism.",
       "mathContext": "The technical heart: uniqueness of a normal Sylow subgroup upgrades inner invariance to full invariance."
+    },
+    {
+      "id": "nilpotent-consequences",
+      "title": "Consequences for Nilpotent Groups",
+      "startLine": 98,
+      "endLine": 110,
+      "summary": "sylow_characteristic_of_nilpotent composes the headline nilpotent ⇒ normal with sylow_characteristic_iff_normal to get every Sylow subgroup characteristic; sylow_map_aut_eq_of_nilpotent unpacks that into the concrete equality P.map φ.toMonoidHom = P via Subgroup.characteristic_iff_map_eq.",
+      "mathContext": "$\\mathrm{Nilpotent}(G) \\Rightarrow \\forall \\varphi \\in \\mathrm{Aut}(G),\\ P.\\mathrm{map}\\,\\varphi = P.$"
     },
     {
       "id": "characterization",


### PR DESCRIPTION
Enrichment pass for sylow-theorem-oq-02-oq-01-oq-01 (quality 96→100 per `find-targets.ts`).

The recent #42748 fixed a section-boundary correctness bug but didn't close the count gap. This PR closes it:

- **sections (4→5):** split the "Characteristic ⟺ Normal for a Sylow Subgroup" section (lines 86-110) into two natural pieces: the coincidence lemma `sylow_characteristic_iff_normal` itself (86-97), and its two nilpotent-group consequences `sylow_characteristic_of_nilpotent` / `sylow_map_aut_eq_of_nilpotent` (98-110). Coverage remains contiguous and gap-free (1-149).
- **keyInsights (4→5):** added a genuinely distinct methodological insight on how `nilpotent_tfae` proves three biconditionals to a common anchor (`1↔2`, `1↔3`, `1↔4`) and lets `tfae_finish` assemble all six pairwise equivalences, rather than re-deriving each edge directly.

Verified: `find-targets.ts --json` now reports quality 100 (all 8 buckets maxed) for this entry, section line ranges are contiguous, and meta.json remains well under the 60KB size cap (~20KB).