### PR TITLE
Gallery integrity: erdos-691 comment-only content mislabeled as axiomatized

### DIFF
--- a/src/data/proofs/erdos-691/annotations.json
+++ b/src/data/proofs/erdos-691/annotations.json
@@ -253,7 +253,7 @@
     "type": "concept",
     "title": "Primes Are Behrend",
     "content": "The set of all primes is a Behrend sequence, since Σ 1/p = ∞ (Euler) and primes are pairwise coprime.",
-    "mathContext": "This is a direct corollary of `coprime_behrend_iff` applied to $A = \\{p : p \\text{ prime}\\}$. Primes are pairwise coprime by definition, and **Euler** proved $\\sum_p 1/p = \\infty$ in 1737, establishing that the harmonic sum over primes diverges. The density of $M_{\\text{primes}}$ being 1 means almost every positive integer has a prime divisor—which is trivially true since every $n \\geq 2$ has a prime factor. The non-trivial content is the density-theoretic framework that extends to more subtle sets.",
+    "mathContext": "This would follow from the coprime Behrend criterion (documented as a comment only, not a Lean declaration) applied to $A = \\{p : p \\text{ prime}\\}$. Primes are pairwise coprime by definition, and **Euler** proved $\\sum_p 1/p = \\infty$ in 1737, establishing that the harmonic sum over primes diverges. The density of $M_{\\text{primes}}$ being 1 means almost every positive integer has a prime divisor—which is trivially true since every $n \\geq 2$ has a prime factor. The non-trivial content is the density-theoretic framework that extends to more subtle sets.",
     "significance": "key",
     "relatedConcepts": [
       "Euler's theorem",
@@ -261,7 +261,6 @@
       "fundamental theorem of arithmetic"
     ],
     "prerequisites": [
-      "coprime_behrend_iff",
       "primes"
     ],
     "range": {

--- a/src/data/proofs/erdos-691/meta.json
+++ b/src/data/proofs/erdos-691/meta.json
@@ -32,7 +32,7 @@
     "historicalContext": "The study of sets of multiples dates to the 1930s with Davenport and Erdős, who proved that every set of multiples has a natural density (the Davenport-Erdős theorem). Felix Behrend investigated when this density equals 1, leading to the concept of 'Behrend sequences'. For pairwise coprime sets A (with all elements > 1), the classical result states that A is Behrend iff Σ 1/a = ∞. This follows from inclusion-exclusion: the density of integers not divisible by any of a₁,...,aₖ is exactly ∏(1 - 1/aᵢ) when the aᵢ are coprime, and this product vanishes iff the reciprocal sum diverges. Erdős asked for a general characterization without the coprimality assumption—a much harder problem since inclusion-exclusion becomes non-multiplicative when elements share common factors. Tenenbaum (1996) found a sharp threshold for lacunary block sequences: with block widths η_k = (k+1)^{-β} and geometrically growing positions, the sequence is Behrend iff β < log 2 ≈ 0.693. This unexpected threshold (not at β = 1 where Σ η_k diverges) reveals that the Behrend property depends on subtle interactions between block positions and widths. The general characterization remains one of the central open problems in multiplicative number theory.",
     "problemStatement": "Find a necessary and sufficient condition on A ⊆ ℕ for the set of multiples M_A = {n : a|n for some a ∈ A} to have asymptotic density 1.",
     "text": "Find a necessary and sufficient condition for a set A ⊆ ℕ to be a Behrend sequence (its multiples have density 1). Known for coprime sets: Σ 1/a = ∞. General criterion remains open.",
-    "proofStrategy": "The formalization builds a complete density infrastructure: countingFunction, upperDensity, lowerDensity, HasDensity, and HasDensityOne using Mathlib's Filter.atTop with limsup/liminf. The set of multiples and Behrend property are defined, followed by 9 fully proved structural lemmas establishing algebraic properties of M_A (monotonicity, union decomposition, closure under multiples, counting bounds). The coprime criterion, primes-are-Behrend, block sequence theory (lacunary sequences, convergent η obstruction, Tenenbaum's threshold), and the main open problem are axiomatized.",
+    "proofStrategy": "The formalization builds a complete density infrastructure: countingFunction, upperDensity, lowerDensity, HasDensity, and HasDensityOne using Mathlib's Filter.atTop with limsup/liminf. The set of multiples and Behrend property are defined, followed by 9 fully proved structural lemmas establishing algebraic properties of M_A (monotonicity, union decomposition, closure under multiples, counting bounds). The coprime criterion, primes-are-Behrend, block sequence theory (lacunary sequences, convergent η obstruction, Tenenbaum's threshold), and the main open problem are documented as block comments only, not formal `axiom` declarations — the file contains zero axioms.",
     "keyInsights": [
       "**Substantial proved content**: 9 fully proved lemmas/theorems establish the algebraic structure of M_A—monotonicity, union decomposition, closure under multiples, counting function bounds—all without sorry",
       "**Coprime vs general**: For coprime sets, Behrend ↔ Σ 1/a = ∞ via multiplicative inclusion-exclusion; without coprimality, the product formula breaks and a new approach is needed",
@@ -92,16 +92,16 @@
       "title": "Pairwise Coprime Characterization",
       "startLine": 123,
       "endLine": 143,
-      "summary": "Defines coprimality, divergent reciprocal sum, and axiomatizes the coprime Behrend criterion and primes-are-Behrend.",
-      "mathContext": "Formal definition: Defines coprimality, divergent reciprocal sum, and axiomatizes the coprime Behrend criterion and primes-are-Behrend."
+      "summary": "Defines coprimality and divergent reciprocal sum; documents the coprime Behrend criterion and primes-are-Behrend as block comments, not formal `axiom` declarations.",
+      "mathContext": "Formal definition: Defines coprimality and divergent reciprocal sum. The coprime Behrend criterion and primes-are-Behrend are prose comments only — no Lean declaration."
     },
     {
       "id": "block-sequences",
       "title": "Block Sequences and Tenenbaum's Theorem",
       "startLine": 144,
       "endLine": 173,
-      "summary": "Defines lacunary block sequences, axiomatizes the convergent η obstruction, and states Tenenbaum's log 2 threshold.",
-      "mathContext": "Formal definition: Defines lacunary block sequences, axiomatizes the convergent η obstruction, and states Tenenbaum's log 2 threshold."
+      "summary": "Defines lacunary block sequences; documents the convergent η obstruction and Tenenbaum's log 2 threshold as block comments, not formal `axiom` declarations.",
+      "mathContext": "Formal definition: Defines lacunary block sequences. The convergent η obstruction and Tenenbaum's log 2 threshold are prose comments only — no Lean declaration."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-691 (Behrend Sequences and Density of Multiples)
**Problem**: `proofStrategy` and the `coprime-characterization` / `block-sequences` section summaries+mathContext describe the coprime Behrend criterion, primes-are-Behrend, the convergent η obstruction, and Tenenbaum's log 2 threshold as "axiomatized". In reality these are pure `/- ... -/` block comments (lines 143-179 of the Lean file) -- there is no `axiom` declaration anywhere in the file (`axiomCount: 0`, confirmed by `grep -n axiom`).

Same class as #42778 (erdos-70), #42715 (erdos-477), #42712 (erdos-486), #42698 (erdos-496), and the erdos-49 occurrence: comment-only prose mislabeled as a formal declaration.

Additionally, `annotations.json`'s `ann-e691-primesBehrend` entry claimed "This is a direct corollary of `coprime_behrend_iff`" and listed `coprime_behrend_iff` as a prerequisite -- but no such identifier is declared anywhere in the Lean source.

## Evidence

**meta.json claimed**: proofStrategy "...are axiomatized." / coprime-characterization section "...axiomatizes the coprime Behrend criterion and primes-are-Behrend." / block-sequences section "...axiomatizes the convergent η obstruction, and states Tenenbaum's log 2 threshold."

**Lean file shows**: `grep -n axiom proofs/Proofs/Erdos691Problem.lean` returns nothing -- zero `axiom` declarations. Lines 143-179 are entirely `/- ... -/` block comments describing these results informally, with no declaration of any kind following them.

**annotations.json claimed**: `coprime_behrend_iff` as an existing identifier and prerequisite; it does not appear anywhere in the Lean source.

## Fix

Reworded `proofStrategy` and both section summaries/mathContexts to say these results are documented as block comments only (not formal `axiom` declarations). Reworded the `primesBehrend` annotation to describe the coprime criterion as comment-only rather than implying a real corollary derivation, and dropped the phantom `coprime_behrend_iff` prerequisite.

Top-level `status: "axiomatized"` and `badge: "wip"` left unchanged -- category convention for this open-problem entry. `axiomCount: 0` was already correct.

---
Discovered during gallery integrity audit (queue drained 4811/4811, round-robin reserve mode).