### PR TITLE
Gallery integrity: erdos-593 comment-only content mislabeled as axiomatized

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14880,9 +14880,9 @@
     },
     "erdos-593": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:41Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T00:44:00Z",
+      "result": "issues-fixed"
     },
     "erdos-594": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-593/meta.json
+++ b/src/data/proofs/erdos-593/meta.json
@@ -31,7 +31,7 @@
     "historicalContext": "Erdős posed this problem in 1995 as part of his investigations into infinite combinatorics and hypergraph coloring, offering a $500 prize for its solution. The question asks which finite 3-uniform hypergraphs are 'unavoidable' — meaning they must appear in every 3-uniform hypergraph of uncountable chromatic number. The motivation comes from the completely solved graph case: for ordinary graphs, a finite graph is unavoidable if and only if it is bipartite. The key insight behind the graph case is that non-bipartite graphs (those containing odd cycles) can be avoided because there exist triangle-free graphs of arbitrarily large chromatic number, as Erdős showed using the probabilistic method in 1959 and Mycielski demonstrated with an explicit construction in 1955. Erdős, Galvin, and Hajnal (1975) established the general framework: for each uniformity r, characterize the unavoidable finite r-uniform hypergraphs. The case r = 2 is solved. The case r = 3 is the first open frontier and has resisted all attempts for nearly five decades. The natural analog of bipartiteness is 2-colorability (property B), and 2-colorable hypergraphs are known to be unavoidable. Whether the converse holds — whether every unavoidable 3-uniform hypergraph must be 2-colorable — is the central open question.",
     "problemStatement": "Characterize those finite 3-uniform hypergraphs $F$ which appear as subhypergraphs in every 3-uniform hypergraph $H$ with $\\chi(H) > \\aleph_0$.",
     "text": "Characterize finite 3-uniform hypergraphs appearing in every 3-uniform hypergraph of chromatic number > ℵ₀. For graphs, the answer is bipartite graphs. The 3-uniform case remains OPEN ($500 prize).",
-    "proofStrategy": "The formalization defines Hypergraph3 (3-uniform hypergraphs), proper coloring with cardinal-bounded color sets, subhypergraph embedding via injective vertex maps, and the IsUnavoidable predicate. It then axiomatizes the solved graph case (unavoidable iff bipartite), the known sufficient condition for 3-uniform hypergraphs (2-colorable implies unavoidable), and the Erdős–Galvin–Hajnal framework. K₄³ is identified as the key test case for going beyond 2-colorability.",
+    "proofStrategy": "The formalization defines Hypergraph3 (3-uniform hypergraphs), proper coloring with cardinal-bounded color sets, subhypergraph embedding via injective vertex maps, and the IsUnavoidable predicate. The solved graph case (unavoidable iff bipartite), the known sufficient condition for 3-uniform hypergraphs (2-colorable implies unavoidable), and the Erdős–Galvin–Hajnal framework are recorded as comments, not as axioms or theorems. K₄³ is identified as the key test case for going beyond 2-colorability.",
     "keyInsights": [
       "For graphs (2-uniform): unavoidable $\\iff$ bipartite — completely solved via Erdős's 1959 probabilistic construction of triangle-free graphs with large chromatic number",
       "For 3-uniform hypergraphs: 2-colorable $\\implies$ unavoidable (the analog of bipartiteness), but the converse is open",
@@ -80,14 +80,14 @@
       "title": "The Graph Case (Solved)",
       "startLine": 74,
       "endLine": 98,
-      "summary": "Defines SimpleGraph' and IsBipartite. Axiomatizes the solved 2-uniform case: a graph is unavoidable iff bipartite."
+      "summary": "Defines SimpleGraph' and IsBipartite. Notes in a comment (not an axiom) the solved 2-uniform case: a graph is unavoidable iff bipartite."
     },
     {
       "id": "known-constraints",
       "title": "Known Constraints for 3-Uniform Case",
       "startLine": 99,
       "endLine": 110,
-      "summary": "Defines Is2Colorable and axiomatizes that 2-colorable hypergraphs are unavoidable. Identifies K₄³ (chromatic number 3, not 2-colorable) as the key test case."
+      "summary": "Defines Is2Colorable and notes in comments (not axioms) that 2-colorable hypergraphs are unavoidable and that K₄³ (chromatic number 3, not 2-colorable) is conjectured unavoidable, identifying it as the key test case."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-593
**Problem**: `overview.proofStrategy` and two section summaries (`graph-case`, `known-constraints`) claimed the formalization "axiomatizes" the solved graph case and the 2-colorable sufficient condition. The Lean file (`Proofs/Erdos593Problem.lean`) has `axiomCount: 0` — these facts are recorded only as `/- ... -/` comments (lines 92-94, 104-107), not as `axiom` declarations. This is the recurring comment-only-mislabeled-axiomatized class (same failure mode as erdos-691/70/477/486/49/496).

## Evidence

**meta.json claimed**: "It then axiomatizes the solved graph case (unavoidable iff bipartite), the known sufficient condition for 3-uniform hypergraphs (2-colorable implies unavoidable)..." plus two section summaries saying "Axiomatizes the solved 2-uniform case" / "axiomatizes that 2-colorable hypergraphs are unavoidable."

**Lean file shows**: 0 `axiom` declarations anywhere in the file (confirmed via grep + full read). The graph-case and sufficient-condition claims are plain descriptive comments with no formal content.

## Fix

Reworded `proofStrategy` and the two section summaries to say these facts are "recorded as comments, not as axioms or theorems," matching the already-honest `assumptions` field ("0 axioms, 0 sorries... Previously cited axiom names have been removed from the Lean source").

Marked `issues-fixed` in the audit tracker.

---
Discovered during gallery integrity audit.

🤖 Generated with Claude Code