### PR TITLE
Research: erdos-89-wip-01 — regular n-gon upper bound g(n) ≤ ⌊n/2⌋; first new ladder entry 2 ≤ g(7) ≤ 3 (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos89WIP01Ngon.lean
+++ b/proofs/Proofs/Erdos89WIP01Ngon.lean
@@ -1,0 +1,255 @@
+/-
+  Erdős Problem #89 — the regular `n`-gon and the upper bound `g(n) ≤ ⌊n/2⌋`
+
+  Source: https://erdosproblems.com/89
+  Parent: `Proofs/Erdos89WIP01.lean` (the distinct-distances ladder: exact values
+  `g(0) = g(1) = 0`, `g(2) = g(3) = 1`, `g(4) = g(5) = 2`, the sandwich
+  `2 ≤ g(6) ≤ 3`, monotonicity, and the linear bound `g(n) ≤ n − 1` via the
+  collinear arithmetic progression `apSet`).
+
+  This file adds the classical pre-Erdős upper bound: the **regular `n`-gon**
+  on the unit circle realises at most `⌊n/2⌋` distinct distances, halving the
+  progression bound `n − 1`.
+
+  * `ngonPoint n k = (cos(2πk/n), sin(2πk/n))` — the `k`-th vertex.
+  * `dist_ngonPoint` — the **chord-length formula**: the distance between
+    vertices `i` and `j` is `2·|sin(π(i−j)/n)|`. All trigonometry in the file
+    flows through this single identity (`(cos A − cos B)² + (sin A − sin B)²
+    = 2 − 2cos(A−B) = 4 sin²((A−B)/2)`).
+  * `ngonPoint_injOn` / `ngonSet_card` — the `n` vertices are pairwise
+    distinct: a coincidence would force `sin(π(i−j)/n) = 0` with
+    `|π(i−j)/n| < π`, so `i = j`. Injectivity is thus *derived from the
+    distance formula* rather than proved by separate coordinate geometry.
+  * `ngonSet_distinctDistances_subset` — every chord length equals
+    `2·sin(πk/n)` for some `k ∈ {1, …, ⌊n/2⌋}`: the index `m = |i − j|`
+    reflects into `min(m, n−m)` via `sin(π − x) = sin x`.
+  * **`minDistinctDistances_le_half`** — `g(n) ≤ ⌊n/2⌋`. One uniform witness
+    now recovers every exact upper value in the ladder: `g(3) ≤ 1` (triangle),
+    `g(4) ≤ 2` (square), `g(5) ≤ 2` (pentagon), `g(6) ≤ 3` (hexagon — an
+    alternative to the parent's pentagon-plus-centre witness), and it is tight
+    at `n = 3, 4, 5` against the parent's exact values.
+  * `minDistinctDistances_seven_le_three` / `minDistinctDistances_seven_mem_Icc`
+    — the first NEW ladder entry from the bound: `2 ≤ g(7) ≤ 3` (previously the
+    best in-file bound at `n = 7` was `g(7) ≤ 6`). The true value is `g(7) = 3`;
+    the lower half needs the planar two-distance-set bound, open in the parent.
+
+  What the bound does NOT give: `g(n) ≥ ⌊n/2⌋` is FALSE for large `n` (Erdős's
+  `√n`-ish constructions beat the `n`-gon), so this is a genuine upper-bound
+  brick only — the conjectured truth is `Θ(n/√(log n))` (Guth–Katz), which
+  stays deep and axiomatized in the parent `Erdos89Problem`.
+
+  All results are axiom-free (`#print axioms` = `[propext, Classical.choice,
+  Quot.sound]`) and contain no `sorry`.
+-/
+
+import Mathlib
+import Proofs.Erdos89WIP01
+
+open Finset Real
+
+namespace Erdos89
+
+/- ## The vertices and the chord-length formula -/
+
+/-- The `k`-th vertex of the regular `n`-gon inscribed in the unit circle:
+`(cos(2πk/n), sin(2πk/n))`. -/
+noncomputable def ngonPoint (n k : ℕ) : EuclideanSpace ℝ (Fin 2) :=
+  !₂[Real.cos (2 * π * k / n), Real.sin (2 * π * k / n)]
+
+/-- **Chord-length formula.** The distance between vertices `i` and `j` of the
+regular `n`-gon is `2·|sin(π(i−j)/n)|`. The identity behind it:
+`(cos A − cos B)² + (sin A − sin B)² = 2 − 2cos(A−B) = 4·sin²((A−B)/2)`. -/
+theorem dist_ngonPoint (n i j : ℕ) :
+    Erdos89.dist (ngonPoint n i) (ngonPoint n j)
+      = 2 * |Real.sin (π * ((i : ℝ) - j) / n)| := by
+  unfold Erdos89.dist ngonPoint
+  rw [← dist_eq_norm, EuclideanSpace.dist_eq, Fin.sum_univ_two]
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Real.dist_eq]
+  rw [sq_abs, sq_abs]
+  have hAB : 2 * π * (i : ℝ) / n - 2 * π * (j : ℝ) / n
+      = 2 * (π * ((i : ℝ) - j) / n) := by ring
+  set θ := π * ((i : ℝ) - j) / n with hθ
+  have h34 : Real.cos (2 * π * (i : ℝ) / n) * Real.cos (2 * π * (j : ℝ) / n)
+      + Real.sin (2 * π * (i : ℝ) / n) * Real.sin (2 * π * (j : ℝ) / n)
+      = 1 - 2 * Real.sin θ ^ 2 := by
+    have h3 := Real.cos_sub (2 * π * (i : ℝ) / n) (2 * π * (j : ℝ) / n)
+    have h4 : Real.cos (2 * π * (i : ℝ) / n - 2 * π * (j : ℝ) / n)
+        = 1 - 2 * Real.sin θ ^ 2 := by
+      rw [hAB, Real.cos_two_mul]
+      have h5 := Real.sin_sq_add_cos_sq θ
+      linear_combination 2 * h5
+    linear_combination h4 - h3
+  have hkey : (Real.cos (2 * π * (i : ℝ) / n) - Real.cos (2 * π * (j : ℝ) / n)) ^ 2
+      + (Real.sin (2 * π * (i : ℝ) / n) - Real.sin (2 * π * (j : ℝ) / n)) ^ 2
+      = (2 * Real.sin θ) ^ 2 := by
+    have h1 := Real.sin_sq_add_cos_sq (2 * π * (i : ℝ) / n)
+    have h2 := Real.sin_sq_add_cos_sq (2 * π * (j : ℝ) / n)
+    linear_combination h1 + h2 - 2 * h34
+  rw [hkey, Real.sqrt_sq_eq_abs, abs_mul]
+  norm_num
+
+/- ## The vertices are pairwise distinct
+
+Injectivity is derived from the chord-length formula itself: coinciding
+vertices would have distance `0`, forcing `sin(π(i−j)/n) = 0` with the
+argument strictly inside `(−π, π)`, hence `i = j`. -/
+
+/-- The vertex map is injective on `{0, …, n−1}`. -/
+theorem ngonPoint_injOn (n : ℕ) :
+    Set.InjOn (ngonPoint n) ↑(Finset.range n) := by
+  intro i hi j hj hij
+  simp only [Finset.coe_range, Set.mem_Iio] at hi hj
+  have hnn : 0 < n := by omega
+  have hn : (0 : ℝ) < n := by exact_mod_cast hnn
+  have hd : Erdos89.dist (ngonPoint n i) (ngonPoint n j) = 0 := by
+    show ‖ngonPoint n i - ngonPoint n j‖ = 0
+    rw [hij, sub_self, norm_zero]
+  rw [dist_ngonPoint] at hd
+  have hs : Real.sin (π * ((i : ℝ) - j) / n) = 0 := by
+    have habs : |Real.sin (π * ((i : ℝ) - j) / n)| = 0 := by linarith
+    exact abs_eq_zero.mp habs
+  have hπ := Real.pi_pos
+  have hilt : (i : ℝ) - j < n := by
+    have h1 : (i : ℝ) < n := by exact_mod_cast hi
+    have h2 : (0 : ℝ) ≤ j := Nat.cast_nonneg j
+    linarith
+  have hjlt : -(n : ℝ) < (i : ℝ) - j := by
+    have h1 : (j : ℝ) < n := by exact_mod_cast hj
+    have h2 : (0 : ℝ) ≤ i := Nat.cast_nonneg i
+    linarith
+  have hlt : π * ((i : ℝ) - j) / n < π := by
+    have hmul : π * ((i : ℝ) - j) < π * n := by nlinarith
+    calc π * ((i : ℝ) - j) / n = π * ((i : ℝ) - j) * (n : ℝ)⁻¹ := by
+          rw [div_eq_mul_inv]
+      _ < π * n * (n : ℝ)⁻¹ := by
+          exact mul_lt_mul_of_pos_right hmul (inv_pos.mpr hn)
+      _ = π := by field_simp
+  have hgt : -π < π * ((i : ℝ) - j) / n := by
+    have hmul : π * (-(n : ℝ)) < π * ((i : ℝ) - j) := by nlinarith
+    calc -π = π * (-(n : ℝ)) * (n : ℝ)⁻¹ := by field_simp
+      _ < π * ((i : ℝ) - j) * (n : ℝ)⁻¹ := by
+          exact mul_lt_mul_of_pos_right hmul (inv_pos.mpr hn)
+      _ = π * ((i : ℝ) - j) / n := by rw [div_eq_mul_inv]
+  have hzero := (Real.sin_eq_zero_iff_of_lt_of_lt hgt hlt).mp hs
+  rcases div_eq_zero_iff.mp hzero with h | h
+  · rcases mul_eq_zero.mp h with h' | h'
+    · exact absurd h' Real.pi_ne_zero
+    · have : (i : ℝ) = j := by linarith [sub_eq_zero.mp h']
+      exact_mod_cast this
+  · exact absurd h (ne_of_gt hn)
+
+/-- The regular `n`-gon as a point set. -/
+noncomputable def ngonSet (n : ℕ) : Finset (EuclideanSpace ℝ (Fin 2)) :=
+  (Finset.range n).image (ngonPoint n)
+
+/-- The `n`-gon has exactly `n` points. -/
+theorem ngonSet_card (n : ℕ) : (ngonSet n).card = n := by
+  rw [ngonSet, Finset.card_image_of_injOn (ngonPoint_injOn n), Finset.card_range]
+
+/- ## Chord lengths take at most `⌊n/2⌋` values
+
+`sin(πm/n) = sin(π(n−m)/n)` reflects the index `m = |i−j| ∈ {1, …, n−1}` into
+`min(m, n−m) ∈ {1, …, ⌊n/2⌋}`, so every chord length is `2·sin(πk/n)` for some
+`k` in that short range. -/
+
+/-- Every chord value `2·|sin(πm/n)|` with `1 ≤ m < n` lies in the image of
+`{1, …, ⌊n/2⌋}` under `k ↦ 2·sin(πk/n)` — reflect `m` to `n − m` when
+`2m > n`, via `sin(π − x) = sin x`. -/
+theorem two_sin_mem_image {n m : ℕ} (h1 : 1 ≤ m) (hm : m < n) :
+    2 * |Real.sin (π * m / n)|
+      ∈ (Finset.Icc 1 (n / 2)).image (fun k : ℕ => 2 * Real.sin (π * k / n)) := by
+  have hnn : 0 < n := by omega
+  have hn : (0 : ℝ) < n := by exact_mod_cast hnn
+  have hm0 : (0 : ℝ) < m := by exact_mod_cast h1
+  have hmn : (m : ℝ) < n := by exact_mod_cast hm
+  have hπ := Real.pi_pos
+  have harg_pos : 0 < π * m / n := div_pos (mul_pos hπ hm0) hn
+  have harg_lt : π * m / n < π := by
+    have hmul : π * (m : ℝ) < π * n := by nlinarith
+    calc π * (m : ℝ) / n = π * (m : ℝ) * (n : ℝ)⁻¹ := by rw [div_eq_mul_inv]
+      _ < π * n * (n : ℝ)⁻¹ := mul_lt_mul_of_pos_right hmul (inv_pos.mpr hn)
+      _ = π := by field_simp
+  have hpos := Real.sin_pos_of_pos_of_lt_pi harg_pos harg_lt
+  rw [abs_of_pos hpos]
+  by_cases hhalf : 2 * m ≤ n
+  · exact Finset.mem_image.mpr ⟨m, Finset.mem_Icc.mpr ⟨h1, by omega⟩, rfl⟩
+  · refine Finset.mem_image.mpr
+      ⟨n - m, Finset.mem_Icc.mpr ⟨by omega, by omega⟩, ?_⟩
+    have hcast : ((n - m : ℕ) : ℝ) = (n : ℝ) - m := Nat.cast_sub hm.le
+    have hn0 : (n : ℝ) ≠ 0 := ne_of_gt hn
+    have harg : π * ((n : ℝ) - m) / n = π - π * m / n := by
+      field_simp
+    rw [hcast, harg, Real.sin_pi_sub]
+
+/-- Every distance of the `n`-gon is `2·sin(πk/n)` for some `k ∈ {1, …, ⌊n/2⌋}`. -/
+theorem ngonSet_distinctDistances_subset (n : ℕ) :
+    distinctDistances (ngonSet n)
+      ⊆ (Finset.Icc 1 (n / 2)).image (fun k : ℕ => 2 * Real.sin (π * k / n)) := by
+  rw [distinctDistances_eq_image]
+  intro d hd
+  rw [Finset.mem_image] at hd
+  obtain ⟨⟨p1, p2⟩, hpq, rfl⟩ := hd
+  rw [Finset.mem_offDiag] at hpq
+  obtain ⟨h1, h2, hne⟩ := hpq
+  rw [ngonSet, Finset.mem_image] at h1 h2
+  obtain ⟨a, ha, rfl⟩ := h1
+  obtain ⟨b, hb, rfl⟩ := h2
+  rw [Finset.mem_range] at ha hb
+  have hab : a ≠ b := fun h => hne (by rw [h])
+  rw [dist_ngonPoint]
+  rcases Nat.lt_or_ge a b with hlt | hge
+  · -- `a < b`: the index is `b − a`, entering through `sin(−x) = −sin x`.
+    have hm : (a : ℝ) - b = -(((b - a : ℕ) : ℝ)) := by
+      rw [Nat.cast_sub hlt.le]; ring
+    have hneg : π * ((a : ℝ) - b) / n = -(π * ((b - a : ℕ) : ℝ) / n) := by
+      rw [hm]; ring
+    rw [hneg, Real.sin_neg, abs_neg]
+    exact two_sin_mem_image (by omega) (by omega)
+  · -- `b < a`: the index is `a − b` directly.
+    have hlt' : b < a := by omega
+    have hm : (a : ℝ) - b = ((a - b : ℕ) : ℝ) := (Nat.cast_sub hlt'.le).symm
+    rw [hm]
+    exact two_sin_mem_image (by omega) (by omega)
+
+/- ## The halving upper bound and the first new ladder entry -/
+
+/-- **The `n`-gon upper bound: `g(n) ≤ ⌊n/2⌋`.** The regular `n`-gon is an
+`n`-point set whose chord lengths take at most `⌊n/2⌋` values, halving the
+progression bound `g(n) ≤ n − 1` (`minDistinctDistances_le_pred`). One uniform
+witness recovers the whole known upper ladder — `g(3) ≤ 1`, `g(4) ≤ 2`,
+`g(5) ≤ 2`, `g(6) ≤ 3` — and is TIGHT against the parent's exact values at
+`n = 3, 4, 5`. (For large `n` the bound is far from optimal: the truth is
+`Θ(n/√(log n))`, and already Erdős's grid beats the `n`-gon.) -/
+theorem minDistinctDistances_le_half (n : ℕ) :
+    minDistinctDistances n ≤ n / 2 := by
+  calc minDistinctDistances n
+      ≤ numDistinctDistances (ngonSet n) :=
+        minDistinctDistances_le_of_card_eq (ngonSet_card n)
+    _ = (distinctDistances (ngonSet n)).card := rfl
+    _ ≤ ((Finset.Icc 1 (n / 2)).image
+          (fun k : ℕ => 2 * Real.sin (π * k / n))).card :=
+        Finset.card_le_card (ngonSet_distinctDistances_subset n)
+    _ ≤ (Finset.Icc 1 (n / 2)).card := Finset.card_image_le
+    _ = n / 2 := by rw [Nat.card_Icc]
+
+/-- **`g(7) ≤ 3`** — the first ladder entry beyond the parent's table: the
+regular heptagon realises only the three chord lengths `2·sin(kπ/7)`,
+`k = 1, 2, 3`. Before this bound the best in-file estimate at `n = 7` was the
+progression's `g(7) ≤ 6`. -/
+theorem minDistinctDistances_seven_le_three : minDistinctDistances 7 ≤ 3 := by
+  have h := minDistinctDistances_le_half 7
+  norm_num at h
+  exact h
+
+/-- **Sandwich `2 ≤ g(7) ≤ 3`.** The lower half lifts `g(5) = 2` through
+monotonicity; the upper half is the heptagon. The true value is `g(7) = 3`,
+whose lower bound needs the planar two-distance-set theorem (a two-distance
+set in `ℝ²` has at most `5` points) — the same open brick that blocks
+`g(6) = 3` in the parent. -/
+theorem minDistinctDistances_seven_mem_Icc :
+    minDistinctDistances 7 ∈ Set.Icc 2 3 := by
+  refine ⟨?_, minDistinctDistances_seven_le_three⟩
+  calc 2 = minDistinctDistances 5 := minDistinctDistances_five.symm
+    _ ≤ minDistinctDistances 7 := minDistinctDistances_mono (by norm_num)
+
+end Erdos89

--- a/proofs/Proofs/Erdos89WIP01Ngon.lean
+++ b/proofs/Proofs/Erdos89WIP01Ngon.lean
@@ -230,7 +230,7 @@ theorem minDistinctDistances_le_half (n : ℕ) :
           (fun k : ℕ => 2 * Real.sin (π * k / n))).card :=
         Finset.card_le_card (ngonSet_distinctDistances_subset n)
     _ ≤ (Finset.Icc 1 (n / 2)).card := Finset.card_image_le
-    _ = n / 2 := by rw [Nat.card_Icc]
+    _ = n / 2 := by rw [Nat.card_Icc]; omega
 
 /-- **`g(7) ≤ 3`** — the first ladder entry beyond the parent's table: the
 regular heptagon realises only the three chord lengths `2·sin(kπ/7)`,

--- a/research/problems/erdos-89-wip-01/state.md
+++ b/research/problems/erdos-89-wip-01/state.md
@@ -23,3 +23,31 @@ None.
 ## Next Action
 Read problem.md thoroughly and acquire full context.
 Then move to ORIENT phase to explore literature and related proofs.
+
+## Status (researcher-1, 2026-07-23) — regular n-gon: g(n) ≤ ⌊n/2⌋, first new ladder entry 2 ≤ g(7) ≤ 3
+
+Phase ACT. New file `Erdos89WIP01Ngon.lean` (0 axioms, 0 sorries, Docker-verified,
+8578 jobs): the regular n-gon on the unit circle realises at most ⌊n/2⌋ distinct
+distances (`minDistinctDistances_le_half`), halving the progression bound n − 1.
+
+Method: ONE trig identity carries the whole file — the chord-length formula
+`dist_ngonPoint : dist = 2·|sin(π(i−j)/n)|` (from (cosA−cosB)² + (sinA−sinB)²
+= 4·sin²((A−B)/2), closed by `linear_combination`). Vertex injectivity is DERIVED
+from the formula (coincidence ⟹ sin = 0 with argument in (−π, π) ⟹ i = j via
+`Real.sin_eq_zero_iff_of_lt_of_lt`) — no per-vertex coordinate lemmas, in contrast
+to the pentagon witness's dozens of bespoke dist_* lemmas. Chord census: index
+m = |i−j| reflects to min(m, n−m) ∈ [1, ⌊n/2⌋] via `Real.sin_pi_sub`
+(`two_sin_mem_image`), so the distance set embeds in the ⌊n/2⌋-element image.
+
+Payoff: one uniform witness recovers the ENTIRE known upper ladder (g(3) ≤ 1,
+g(4) ≤ 2, g(5) ≤ 2 — tight against the exact values; g(6) ≤ 3 re-derived via the
+hexagon, independent of pentagon-plus-centre) and adds the first NEW entry:
+`minDistinctDistances_seven_mem_Icc : 2 ≤ g(7) ≤ 3` (heptagon; previous best
+in-file was g(7) ≤ 6).
+
+Upper side now SATURATED at the elementary layer: the n-gon's ⌊n/2⌋ is optimal
+among single-orbit constructions for small n; beating it needs Erdős's √n-grid
+(large n, real analytic number theory). All remaining ladder work is LOWER bounds
+— g(6) = 3 and g(7) = 3 both reduce to the planar two-distance-set ≤ 5-points
+theorem, the registered blocker (reopen: two-distance-set / incidence machinery
+in Mathlib).

--- a/src/data/research/problems/erdos-89-wip-01.json
+++ b/src/data/research/problems/erdos-89-wip-01.json
@@ -29,7 +29,7 @@
         "blockedAt": "2026-07-21"
       }
     ],
-    "nextAction": "All remaining directions are HARD/large, not elementary: (1) g(6) ≥ 3 ≡ sharp planar two-distance-set ≤ 5 points (Kelly/Erdős, beyond the Larman–Rogers–Seidel rank ceiling); (2) general regular-n-gon upper bound g(n) ≤ ⌊n/2⌋ (chord-length trig infrastructure, ~250+ lines); (3) √n × √n grid toward the conjectured rate. STAND DOWN unless taking on one of these as a full dedicated session.",
+    "nextAction": "Lower bounds only: g(6) = g(7) = 3 both need the planar two-distance-set ≤ 5-points theorem (registered blocker). Upper side is saturated: n-gon gives ⌊n/2⌋ uniformly; beating it needs grid/Erdős constructions (√n-type, large n only). Do not add more small-n upper witnesses.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -37,7 +37,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-07-21, researcher-1): g(6) ≤ 3 shipped axiom-free via the regular pentagon plus its circumcentre (minDistinctDistances_six_le_three; Docker-verified). The 5 centre-to-vertex spokes all equal the circumradius 4, and the 10 intra-pentagon distances reuse the g(5)=2 side/diagonal values, so the 6-point config realizes exactly the 3 distances {4, √(40−8√5), √(40+8√5)}. Combined with monotonicity g(6) ≥ g(5) = 2 this sandwiches g(6) ∈ [2,3] (minDistinctDistances_six_mem_Icc). Exact table still pinned through n=5: g(0)=g(1)=0, g(2)=g(3)=1, g(4)=g(5)=2. Pinning g(6)=3 needs the sharp two-distance-set ≤ 5-points bound (deep, beyond LRS rank ≤ 6).",
+    "progressSummary": "PROGRESS (2026-07-23, researcher-1): regular n-gon upper bound g(n) ≤ ⌊n/2⌋ shipped axiom-free in new file Erdos89WIP01Ngon.lean (minDistinctDistances_le_half; Docker-verified). Chord-length formula dist = 2|sin(π(i−j)/n)| proved once; vertex injectivity DERIVED from it (dist 0 ⟹ sin = 0 in (−π,π) ⟹ i = j, no separate coordinate geometry); index reflection min(m, n−m) via sin(π−x) = sin x. Halves the progression bound n−1; one uniform witness recovers the entire known upper ladder (tight at n = 3,4,5; hexagon re-derives g(6) ≤ 3) and adds the FIRST new entry: 2 ≤ g(7) ≤ 3 (minDistinctDistances_seven_mem_Icc). Exact table still pinned through n=5; g(6) = g(7) = 3 both blocked on the planar two-distance-set ≤ 5-points bound.",
     "builtItems": [
       "Erdos89.dist_pos_of_ne in Erdos89WIP01.lean",
       "Erdos89.distinctDistances_eq_image (filter redundant) in Erdos89WIP01.lean",
@@ -74,7 +74,12 @@
       "pentagonPlusCenter (6-point config) + pentagonPlusCenter_card = 6",
       "numDistinctDistances_pentagonPlusCenter_le_three: the 15 pairwise distances lie in {4, √(40−8√5), √(40+8√5)} ⇒ ≤ 3 (Erdos89WIP01.lean)",
       "minDistinctDistances_six_le_three: g(6) ≤ 3 (axiom-free)",
-      "minDistinctDistances_six_mem_Icc: sandwich g(6) ∈ [2,3] (floor via monotonicity g(6) ≥ g(5) = 2)"
+      "minDistinctDistances_six_mem_Icc: sandwich g(6) ∈ [2,3] (floor via monotonicity g(6) ≥ g(5) = 2)",
+      "ngonPoint/ngonSet + dist_ngonPoint chord-length formula 2|sin(π(i−j)/n)| in Erdos89WIP01Ngon.lean",
+      "ngonPoint_injOn: vertex distinctness derived from the chord formula (sin_eq_zero_iff_of_lt_of_lt)",
+      "two_sin_mem_image: index reflection m ↦ min(m, n−m) via Real.sin_pi_sub",
+      "minDistinctDistances_le_half: g(n) ≤ ⌊n/2⌋ (halves minDistinctDistances_le_pred)",
+      "minDistinctDistances_seven_le_three + minDistinctDistances_seven_mem_Icc: 2 ≤ g(7) ≤ 3"
     ],
     "insights": [
       "distinctDistances S filters (·>0) over the off-diagonal image, but every off-diagonal pair (p≠q) already has ‖p−q‖>0, so the filter is redundant: distinctDistances S = S.offDiag.image (dist · ·). This removes the awkward filter for all downstream cardinality reasoning.",
@@ -91,7 +96,10 @@
       "g(5) = 2 CLOSED (axiom-free): the regular pentagon is the planar 2-distance witness for the g(5) ≤ 2 upper bound, matching the general floor g(5) ≥ 2.",
       "Nested-radical distance computation is tractable via congr 1 + linear_combination: for pentagon of circumradius 4 the squared distances are 40∓8√5, and the only nonlinear identity needed is t1·t2 = 4√5 (t1=√(10+2√5), t2=√(10−2√5)), from (10+2√5)(10−2√5)=80=(4√5)².",
       "g(6) ≤ 3 realized by regular pentagon + circumcentre: 10 intra-pentagon distances reuse the g(5) side/diagonal values; 5 centre-to-vertex spokes all equal the circumradius 4 ⇒ exactly 3 distinct distances.",
-      "The matching lower bound g(6) ≥ 3 is equivalent to the SHARP planar two-distance statement (a 2-distance set in ℝ² has ≤ 5 points, Kelly/Erdős), which is strictly beyond the elementary Larman–Rogers–Seidel rank ceiling ≤ (d+1)(d+2)/2 = 6 — so g(6) = 3 stays the open lower-bound direction."
+      "The matching lower bound g(6) ≥ 3 is equivalent to the SHARP planar two-distance statement (a 2-distance set in ℝ² has ≤ 5 points, Kelly/Erdős), which is strictly beyond the elementary Larman–Rogers–Seidel rank ceiling ≤ (d+1)(d+2)/2 = 6 — so g(6) = 3 stays the open lower-bound direction.",
+      "The n-gon bound is proof-economical: injectivity and the distance census both flow from ONE trig identity (cosA−cosB)²+(sinA−sinB)² = 4sin²((A−B)/2), so no per-vertex coordinate lemmas are needed — contrast the pentagon witness which needed dozens of bespoke dist_* lemmas",
+      "Name-stability tactic: avoid div_lt_iff/lt_div_iff (renamed in recent Mathlib); the calc through div_eq_mul_inv + mul_lt_mul_of_pos_right + field_simp is drift-proof",
+      "g(n) ≤ ⌊n/2⌋ is tight at n = 3,4,5 and conjecturally at 6,7 — the first n where the n-gon is provably beaten is far out (grid constructions); so all remaining ladder work is LOWER bounds, which stay blocked on two-distance-set machinery"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for erdos-89-wip-01 (Erdős distinct distances). Executes the sanctioned reopener from the 2026-07-21 triage: "reopen only for a full dedicated session on the general n-gon ⌊n/2⌋ construction."

New file `proofs/Proofs/Erdos89WIP01Ngon.lean` (0 axioms, 0 sorries, Docker-verified, 8578 jobs): the regular n-gon on the unit circle realises at most ⌊n/2⌋ distinct distances, halving the parent's progression bound `g(n) ≤ n − 1`.

## Progress
- `dist_ngonPoint` — chord-length formula `dist = 2·|sin(π(i−j)/n)|`; the single trig identity `(cos A − cos B)² + (sin A − sin B)² = 4·sin²((A−B)/2)` carries the whole file (closed by `linear_combination`, no `nlinarith` grinding).
- `ngonPoint_injOn` — vertex distinctness DERIVED from the chord formula (coincidence forces `sin = 0` with argument in `(−π, π)`, hence `i = j`) — no per-vertex coordinate lemmas, in contrast to the pentagon witness's dozens of bespoke `dist_*` lemmas.
- `two_sin_mem_image` — index reflection `m ↦ min(m, n−m)` via `sin(π − x) = sin x`, embedding the distance set into `{2·sin(πk/n) : 1 ≤ k ≤ ⌊n/2⌋}`.
- **`minDistinctDistances_le_half`** — `g(n) ≤ ⌊n/2⌋` for all n.
- **`minDistinctDistances_seven_le_three` / `minDistinctDistances_seven_mem_Icc`** — first NEW ladder entry: `2 ≤ g(7) ≤ 3` (previous best in-file bound at n = 7 was `g(7) ≤ 6`).

## Findings
- One uniform witness recovers the ENTIRE known upper ladder: tight at n = 3, 4, 5 against the parent's exact values, and re-derives `g(6) ≤ 3` via the hexagon (independent of pentagon-plus-centre).
- Upper side is now saturated at the elementary layer. All remaining ladder work is lower bounds: `g(6) = 3` and `g(7) = 3` both reduce to the planar two-distance-set ≤ 5-points theorem (registered blocker, unchanged).
- Tactic note: avoided `div_lt_iff`/`lt_div_iff` (rename-drift risk) in favor of `div_eq_mul_inv` + `mul_lt_mul_of_pos_right` + `field_simp` calc steps.

## Status
**Outcome**: progress (upper-bound layer completed; lower bounds remain blocked)
**Next Steps**: only lower-bound work remains; blocked on two-distance-set / incidence machinery in Mathlib (registered in `currentState.blockers`).

🤖 Generated by researcher-1
