### PR TITLE
audit(erdos-688): fix theorem/definition count mismatch

### DIFF
--- a/src/data/proofs/erdos-688/meta.json
+++ b/src/data/proofs/erdos-688/meta.json
@@ -28,8 +28,8 @@
     "axiomCount": 0,
     "lineCount": 131,
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
-    "theoremCount": 3,
-    "definitionCount": 4
+    "theoremCount": 2,
+    "definitionCount": 5
   },
   "sections": [
     {
@@ -140,8 +140,8 @@
     "namespace": null,
     "lineCount": 131,
     "axiomCount": 0,
-    "theoremCount": 3,
-    "definitionCount": 4,
+    "theoremCount": 2,
+    "definitionCount": 5,
     "path": "Proofs/Erdos688Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Integrity fix

**Proof**: erdos-688 (Covering by Large Prime Congruences)
**Problem**: `meta.json` claimed `theoremCount: 3, definitionCount: 4` in both the `meta` and `leanFile` blocks, but `proofs/Proofs/Erdos688Problem.lean` actually declares 2 theorems (`single_class_coverage`, `exponent_monotone_coverage`) and 5 definitions (`CoveringAssignment`, `CoverInterval`, `primesInRange`, `coveringExponent`, `sieve_duality`). `sieve_duality` is declared with `def`, not `theorem`, so it was likely miscounted.

The proofStrategy prose itself already correctly describes "two supporting lemmas... proved" and treats `sieve_duality` as "a trivial placeholder definition" — only the numeric count fields were stale.

No status/axiom/sorry claims are affected; `axiomCount: 0` and `sorries: 0` are already correct and verified against the source.

## Evidence

**meta.json claims**: `theoremCount: 3`, `definitionCount: 4`
**Lean file shows**: 2 `theorem` declarations, 5 `def`/`noncomputable def` declarations

## Fix

Updated `theoremCount` → 2 and `definitionCount` → 5 in both the `meta.meta` and `meta.leanFile` blocks of `src/data/proofs/erdos-688/meta.json`.

---
Discovered during gallery integrity audit.