### PR TITLE
audit: update tracker for erdos-688 (issues-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15642,9 +15642,9 @@
     },
     "erdos-688": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:40Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T00:48:06Z",
+      "result": "issues-fixed"
     },
     "erdos-689": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Records the erdos-688 audit result in `src/data/proofs/audit-tracker.json` following #42790 (theorem/definition count fix).