### PR TITLE
audit: update tracker for erdos-685 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15624,8 +15624,8 @@
     },
     "erdos-685": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:41Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T00:50:53Z",
       "result": "clean"
     },
     "erdos-686": {


### PR DESCRIPTION
Re-audited erdos-685 (round-robin re-serve, queue fully drained). Verified against Lean source: 96 lines, 0 axioms, 0 sorries, 6 theorems, 3 definitions — all match meta.json. Open conjecture ErdosProblem685 honestly left as unproved Prop (status:axiomatized/axiomCount:0 open-conjecture convention). Trivial lower bound correctly disclosed as prose-only. No overclaiming found. Result: clean.