### PR TITLE
Fix erdos-66: phantom axiom narrative (erdosSarkozy/horvath2007)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15426,9 +15426,9 @@
     },
     "erdos-66": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:41Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T00:55:10Z",
+      "result": "issues-fixed"
     },
     "erdos-660": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-66/annotations.json
+++ b/src/data/proofs/erdos-66/annotations.json
@@ -111,53 +111,53 @@
     "prerequisites": [
       "the representation function r(n)",
       "logical negation of convergence",
-      "Erd\u0151s's conjecture (no nice limit)"
+      "Erdős's conjecture (no nice limit)"
     ]
   },
   {
     "id": "ann-e66-erdos-sarkozy",
     "proofId": "erdos-66",
     "range": {
-      "startLine": 100,
-      "endLine": 114
+      "startLine": 102,
+      "endLine": 111
     },
     "type": "concept",
     "title": "Erdős-Sárközy Theorem",
-    "content": "**erdosSarkozy** states that for any A, the error |r_A(n) - log(n)| cannot shrink to o(√log n).\n\nIn other words: the representation function cannot approximate log(n) with error smaller than √log(n) eventually.\n\n**Why this matters**: Even if r_A(n) ~ log(n), the fluctuations must remain significant. You can't 'smooth out' the representation function to exactly match log(n).",
-    "mathContext": "The statement says there is NO set A with `|r_A(n) - log n| / √(log n) → 0`. This is a universal negative—a strong constraint on all possible sets.",
-    "significance": "key",
+    "content": "This block is a **module comment only** (not a Lean declaration): it documents, in prose, that for any A the error |r_A(n) - log(n)| cannot shrink to o(√log n).\n\nIn other words: the representation function cannot approximate log(n) with error smaller than √log(n) eventually.\n\n**Why this matters**: Even if r_A(n) ~ log(n), the fluctuations must remain significant. You can't 'smooth out' the representation function to exactly match log(n).\n\n**Not formalized**: no `axiom` or `theorem` states this claim in Lean; it is documentation only.",
+    "mathContext": "The comment describes a universal negative—no set A has `|r_A(n) - log n| / √(log n) → 0`—but this is not expressed as a Lean `Prop` or assumed via `axiom` anywhere in the file.",
+    "significance": "supporting",
     "relatedConcepts": [
-      "axiom",
+      "comment-only",
       "error-bound",
       "sqrt-log"
     ],
     "prerequisites": [
       "error terms for representation functions",
-      "\u221a(log n) error bounds",
-      "the Erd\u0151s\u2013S\u00e1rk\u00f6zy theorem (axiom)"
+      "√(log n) error bounds",
+      "the Erdős–Sárközy theorem (documented in prose, not formalized)"
     ]
   },
   {
     "id": "ann-e66-horvath",
     "proofId": "erdos-66",
     "range": {
-      "startLine": 117,
-      "endLine": 130
+      "startLine": 112,
+      "endLine": 120
     },
     "type": "concept",
     "title": "Horváth's Improvement (2007)",
-    "content": "**horvath2007** strengthens Erdős-Sárközy: the error exceeds (1-ε)√log(n) for infinitely many n.\n\nFor any ε > 0 and any set A, there are arbitrarily large n where |r_A(n) - log(n)| > (1-ε)√log(n).\n\n**The improvement**: This gives a quantitative lower bound on the limsup of the error, not just that it doesn't go to zero.",
-    "mathContext": "Using `∀ᶠ n in atTop` means 'for all sufficiently large n'. Combined with the universal quantifier over ε, this says the error cannot stay below √log(n) for long.",
-    "significance": "key",
+    "content": "This block is also a **module comment only** (not a Lean declaration): it documents that Horváth strengthened Erdős-Sárközy so the error exceeds (1-ε)√log(n) for infinitely many n.\n\nFor any ε > 0 and any set A, there are arbitrarily large n where |r_A(n) - log(n)| > (1-ε)√log(n).\n\n**Not formalized**: no `axiom` or `theorem` states this claim in Lean; it is documentation only, describing a quantitative lower bound on the limsup of the error without asserting it.",
+    "mathContext": "Informally 'for all sufficiently large n' with a universal quantifier over ε—but this remains prose, not a Lean `Prop`, `axiom`, or `theorem`.",
+    "significance": "supporting",
     "relatedConcepts": [
-      "axiom",
+      "comment-only",
       "quantitative-bound",
       "limsup"
     ],
     "prerequisites": [
-      "quantitative bounds on r(n)\u2212n",
+      "quantitative bounds on r(n)−n",
       "limsup estimates",
-      "Horv\u00e1th's 2007 improvement"
+      "Horváth's 2007 improvement (documented in prose, not formalized)"
     ]
   },
   {
@@ -203,7 +203,7 @@
     "prerequisites": [
       "limsup and liminf of r(n)",
       "a universal constant bound",
-      "Erd\u0151s's stronger conjecture"
+      "Erdős's stronger conjecture"
     ]
   },
   {

--- a/src/data/proofs/erdos-66/meta.json
+++ b/src/data/proofs/erdos-66/meta.json
@@ -49,8 +49,8 @@
     "originalContributions": [
       "Formal definition of the representation function in Lean 4",
       "Statement of Problem 66 as a Prop without asserting truth",
-      "Axiom for Erdős-Sárközy theorem on error bounds",
-      "Axiom for Horváth's 2007 improvement",
+      "Documentation (comments only, not formalized) of the Erdős-Sárközy error bound",
+      "Documentation (comments only, not formalized) of Horváth's 2007 improvement",
       "Proof that the stronger conjecture implies the original"
     ],
     "axiomCount": 0,
@@ -63,7 +63,7 @@
     "historicalContext": "The representation function r_A(n) counts how many ways we can write n as a sum of two elements from a set A. This is a fundamental object in additive combinatorics, connected to problems like Goldbach's conjecture (where A is the primes).\n\nFor many natural sets, r_A(n) grows roughly like log(n). Erdős asked whether this growth can be EXACTLY logarithmic—whether r_A(n)/log(n) can converge to a nonzero limit.\n\nRandom constructions suggest the answer might be yes: if you choose A with probability c/√n for each n, then E[r_A(n)] ~ c²log(n). However, these constructions always have an exceptional set of density zero where the limit fails.\n\nThe challenge is eliminating this exceptional set. Erdős believed it cannot be done, conjecturing the answer is NO. The problem carries a $500 prize.",
     "problemStatement": "**Erdős Problem #66 (OPEN)**\n\nIs there a set $A \\subseteq \\mathbb{N}$ such that\n$$\\lim_{n\\to\\infty} \\frac{r_A(n)}{\\log n} = c \\neq 0$$\nwhere $r_A(n) = |\\{(a,b) \\in A^2 : a + b = n\\}|$ is the representation function?\n\n**Erdős's Conjecture**: The answer is NO.\n\n**Prize**: $500",
     "text": "Is there a set A ⊆ ℕ such that the representation function r_A(n) = |{(a,b) ∈ A² : a+b=n}| satisfies lim r_A(n)/log(n) = c ≠ 0?",
-    "proofStrategy": "We formalize the problem and its partial results:\n\n1. **representationFunction**: Counts ordered pairs (a,b) ∈ A² with a+b=n\n\n2. **Erdos66Question**: The statement that such an A exists (open)\n\n3. **ErdosConjecture66**: The negation (Erdős's belief)\n\n4. **Partial results as axioms**:\n   - Erdős-Sárközy: Error cannot be o(√log n)\n   - Horváth (2007): Error exceeds (1-ε)√log n infinitely often\n\n5. **ErdosStrongerConjecture**: Limsup and liminf are universally separated",
+    "proofStrategy": "We formalize the problem statement and one implication; the partial results are documented in prose only:\n\n1. **representationFunction**: Counts ordered pairs (a,b) ∈ A² with a+b=n\n\n2. **Erdos66Question**: The statement that such an A exists (open)\n\n3. **ErdosConjecture66**: The negation (Erdős's belief)\n\n4. **Partial results documented as comments (not axioms or theorems)**:\n   - Erdős-Sárközy: Error cannot be o(√log n)\n   - Horváth (2007): Error exceeds (1-ε)√log n infinitely often\n\n5. **ErdosStrongerConjecture**: Limsup and liminf are universally separated",
     "keyInsights": [
       "**Representation function**: r_A(n) counts ordered pairs summing to n. For primes, r_P(n) > 0 for even n is Goldbach's conjecture.",
       "**Logarithmic scale**: Many natural sets have r_A(n) ~ c·log(n). The question is whether the ratio can have a definite limit.",


### PR DESCRIPTION
## Gallery integrity issue

**Proof**: erdos-66 (Erdős Problem #66 — Representation Function Asymptotics)

**Problem**: meta.json and annotations.json narrated two partial results as if
they were declared Lean identifiers/axioms:
- `originalContributions`: "Axiom for Erdős-Sárközy theorem on error bounds", "Axiom for Horváth's 2007 improvement"
- `proofStrategy`: "Partial results as axioms: ..."
- `annotations.json`: "**erdosSarkozy** states that..." / "**horvath2007** strengthens..." with `relatedConcepts: ["axiom", ...]`

## Evidence

`grep -n "axiom" proofs/Proofs/Erdos66Problem.lean` returns **zero** hits — the
word "axiom" does not appear anywhere in the file, not even in a comment. The
Erdős-Sárközy and Horváth results exist only as prose in `/- ... -/` module
comments (lines 102–111 and 112–120); there is no `erdosSarkozy` or
`horvath2007` identifier, `axiom`, or `theorem` anywhere in the file.

The file's own `assumptions` field already says "Previously cited axiom names
have been removed from the Lean source" — this PR brings `originalContributions`,
`proofStrategy`, and `annotations.json` in line with that same disclosure,
which a prior edit apparently missed.

## Fix

- Reworded `originalContributions`/`proofStrategy` in meta.json to say these
  are documented in comments only, not formalized as axioms.
- Rewrote the two annotation entries to stop referencing phantom identifiers,
  drop the `"axiom"` tag from `relatedConcepts`, and corrected their stale
  `range` line numbers to match the actual comment blocks in the Lean source.
- `axiomCount`/`sorries` were already correct (0/0); no change needed there.

---
Discovered during gallery integrity audit.