### PR TITLE
Enrich spectral-trace-det-eigenvalues-oq-02: update stale openQuestions after child discharges it

### DIFF
--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-02/meta.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-02/meta.json
@@ -131,11 +131,6 @@
       "targetId": "matrix-similarity-invariants-oq-01",
       "relationship": "related",
       "description": "Packages determinant, trace, characteristic polynomial, and (over an integral domain) the eigenvalue multiset into one unified similarity-invariants theorem, with similarity proved to be an equivalence relation. This entry reaches the same eigenvalue-multiset invariance (eigenvalues_units_conj) via a different route — as the bridge from cyclic-invariance-of-the-trace to the spectral picture of oq-01 — and adds the determinant-hypothesis (IsUnit P.det) form of similarity invariance that matrix-similarity-invariants-oq-01 does not state."
-    },
-    {
-      "targetId": "spectral-trace-det-eigenvalues-oq-02-oq-01",
-      "relationship": "extended-by",
-      "description": "Answers the first half of this entry's open question: proves the trace form tr(Aᵀ·B) = Σ Aᵢⱼ Bᵢⱼ is a genuine inner product, packaged as InnerProductSpace.Core ℝ (Matrix m n ℝ), with the induced norm identified as the Frobenius norm. The singular-value relation ‖A‖_F² = Σ σᵢ² is deliberately left out of scope there."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-02/meta.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-02/meta.json
@@ -131,13 +131,18 @@
       "targetId": "matrix-similarity-invariants-oq-01",
       "relationship": "related",
       "description": "Packages determinant, trace, characteristic polynomial, and (over an integral domain) the eigenvalue multiset into one unified similarity-invariants theorem, with similarity proved to be an equivalence relation. This entry reaches the same eigenvalue-multiset invariance (eigenvalues_units_conj) via a different route — as the bridge from cyclic-invariance-of-the-trace to the spectral picture of oq-01 — and adds the determinant-hypothesis (IsUnit P.det) form of similarity invariance that matrix-similarity-invariants-oq-01 does not state."
+    },
+    {
+      "targetId": "spectral-trace-det-eigenvalues-oq-02-oq-01",
+      "relationship": "extended-by",
+      "description": "Answers the first half of this entry's open question: proves the trace form tr(Aᵀ·B) = Σ Aᵢⱼ Bᵢⱼ is a genuine inner product, packaged as InnerProductSpace.Core ℝ (Matrix m n ℝ), with the induced norm identified as the Frobenius norm. The singular-value relation ‖A‖_F² = Σ σᵢ² is deliberately left out of scope there."
     }
   ],
   "conclusion": {
     "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization of cyclic invariance of the trace tr(A·B) = tr(B·A) (including the rectangular case), the vanishing of the trace of a commutator written with an explicit subtraction, similarity invariance of the trace in the practically-checkable determinant form, and the bridge to oq-01: similar matrices share their entire eigenvalue multiset over any field, with the trace and determinant invariance recovered as its sum/product shadows.",
     "implications": "Packages Mathlib's cyclic-trace identities with the commutator and conjugacy-class statements that matrix calculations actually use, and upgrades 'similar matrices have equal trace and determinant' to the strictly stronger 'similar matrices have equal eigenvalue multisets', tying the present entry to the spectral viewpoint of oq-01.",
     "openQuestions": [
-      "Prove the trace form tr(A·Bᵀ) = Σ Aᵢⱼ Bᵢⱼ is a genuine inner product (the Frobenius/Hilbert–Schmidt inner product) and relate its induced norm to the singular values.",
+      "Partially discharged by spectral-trace-det-eigenvalues-oq-02-oq-01: the trace form tr(Aᵀ·B) = Σ Aᵢⱼ Bᵢⱼ is proved a genuine inner product (packaged as InnerProductSpace.Core ℝ (Matrix m n ℝ)), but relating the induced norm to the singular values (‖A‖_F² = Σ σᵢ²) is explicitly left out of scope there and remains open.",
       "Formalize that the characteristic polynomial — not just the trace and determinant — is a complete set of similarity invariants exactly for diagonalisable matrices with distinct eigenvalues, sharpening eigenvalues_units_conj to a classification."
     ]
   },


### PR DESCRIPTION
## Summary
- `spectral-trace-det-eigenvalues-oq-02-oq-01` already proves the trace form is a genuine Frobenius/Hilbert–Schmidt inner product, but this parent's first `openQuestions` entry still described the question as fully open.
- Reworded to note the partial discharge: the inner-product axioms are proved (packaged as `InnerProductSpace.Core ℝ (Matrix m n ℝ)`), but the singular-value relation `‖A‖_F² = Σ σᵢ²` is explicitly left out of scope in the child and remains open.
- Scoped to avoid overlap with #42660 (open), which adds the corresponding `crossReferences` entry to the same file — this PR only touches `conclusion.openQuestions`.

## Test plan
- [x] `python3 -m json.tool` validates the edited `meta.json`
- [x] Verified against child entry's `meta.json` (`spectral-trace-det-eigenvalues-oq-02-oq-01`) that the inner-product axioms are proved and the singular-value relation is explicitly flagged out of scope
