### PR TITLE
audit: update tracker for erdos-64 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15254,8 +15254,8 @@
     },
     "erdos-64": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:41Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T01:05:20Z",
       "result": "clean"
     },
     "erdos-640": {


### PR DESCRIPTION
Gallery integrity re-audit (reserve mode, queue drained 4811/4811): erdos-64
(Power of Two Cycles in Min Degree 3 Graphs) verified clean.

Every comment-only claim (Liu-Montgomery threshold/even-cycle theorem,
Dirac, Bondy, random-graph heuristic, infinite 3-regular tree) is already
explicitly tagged "documented in a source comment only — not a named Lean
declaration or axiom" throughout originalContributions, proofStrategy, and
section summaries. Verified all cited axiom-free theorem names
(`connected_hasMinDegree_two_exists_cycle`, `hasMinDegree_three_exists_even_cycle`,
etc.) actually exist in `Proofs/Erdos64Problem.lean` (867 lines, 16
theorems, 0 axioms, 0 sorries). No fixes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)