### PR TITLE
Enrich rh-consequences-oq-03: cover Auxiliary Monotonicity section

### DIFF
--- a/src/data/proofs/rh-consequences-oq-03/annotations.json
+++ b/src/data/proofs/rh-consequences-oq-03/annotations.json
@@ -48,6 +48,18 @@
     "prerequisites": ["Dirichlet series", "analytic continuation", "Riemann Hypothesis"]
   },
   {
+    "id": "ann-rhoq03-exponent-mono",
+    "proofId": "rh-consequences-oq-03",
+    "range": { "startLine": 108, "endLine": 128 },
+    "type": "insight",
+    "title": "Auxiliary Monotonicity of the Exponent",
+    "content": "mertens_bound_exponent_mono records that the Littlewood condition only gets weaker as the exponent grows: if |M(n)| ≤ C·n^{1/2+ε} holds for all n ≥ 1, the same inequality with the same constant C holds at any larger exponent ε' ≥ ε, since n^{1/2+ε} ≤ n^{1/2+ε'} whenever n ≥ 1 (Real.rpow_le_rpow_of_exponent_le). This is a bookkeeping lemma rather than analytic content — it makes precise that 'for every ε > 0' in LittlewoodBound is really an infimum-type condition: proving the bound for one ε suffices to get it for free at every larger ε.",
+    "mathContext": "$n \\ge 1,\\ \\varepsilon \\le \\varepsilon' \\Rightarrow n^{1/2+\\varepsilon} \\le n^{1/2+\\varepsilon'}$, so $|M(n)| \\le C n^{1/2+\\varepsilon} \\Rightarrow |M(n)| \\le C n^{1/2+\\varepsilon'}$ with the same constant $C$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.rpow_le_rpow_of_exponent_le", "monotonicity in the exponent", "LittlewoodBound"],
+    "prerequisites": ["real power monotonicity", "LittlewoodBound"]
+  },
+  {
     "id": "ann-rhoq03-forward",
     "proofId": "rh-consequences-oq-03",
     "range": { "startLine": 129, "endLine": 154 },


### PR DESCRIPTION
## Summary
- `rh-consequences-oq-03`'s `meta.json` has 6 `sections` covering the full 184-line file, but `annotations.json` only had 6 annotations — the "Auxiliary monotonicity" section (lines 108-128, `mertens_bound_exponent_mono`) had zero annotation coverage.
- Adds one annotation matching the existing (correct) section boundary, so annotation ranges now fully tile the Lean file.
- No changes to meta.json — the section already correctly described the theorem; only annotations.json lagged.

## Test plan
- [x] `pnpm build` passes (JSON validation, search index, redirects, bundle budget all green)
- [x] Verified annotation range against `proofs/Proofs/RiemannHypothesisConsequencesOQ03.lean` line-by-line