### PR TITLE
Fix erdos-598: phantom axiom prose (no axiom declarations exist)

### DIFF
--- a/src/data/proofs/erdos-598/annotations.json
+++ b/src/data/proofs/erdos-598/annotations.json
@@ -31,7 +31,7 @@
     },
     "type": "definition",
     "title": "The Cardinal κ = (2^ℵ₀)⁺",
-    "content": "Defines κ as Order.succ (2 ^ ℵ₀), the successor of the continuum cardinal. Under CH, κ = ℵ₂; without CH, κ can be much larger. The axiom kappa_gt_aleph0 records that κ exceeds ℵ₀. This cardinal serves a dual role: as the number of colors and as the minimum subset size that must realize all colors.",
+    "content": "Defines κ as Order.succ (2 ^ ℵ₀), the successor of the continuum cardinal. Under CH, κ = ℵ₂; without CH, κ can be much larger. A source comment notes that κ exceeds ℵ₀, but this is not formalized as any axiom or lemma. This cardinal serves a dual role: as the number of colors and as the minimum subset size that must realize all colors.",
     "mathContext": "$\\kappa = (2^{\\aleph_0})^+ = \\mathfrak{c}^+$. Under CH ($\\mathfrak{c} = \\aleph_1$), $\\kappa = \\aleph_2$. Under $\\mathfrak{c} = \\aleph_{\\omega}$, $\\kappa = \\aleph_{\\omega+1}$. The successor operation ensures $\\kappa$ is a regular cardinal (Hausdorff's theorem).",
     "significance": "key",
     "relatedConcepts": [
@@ -170,7 +170,7 @@
     },
     "type": "concept",
     "title": "Monotonicity in Ground Set Size",
-    "content": "If a chromatically complete coloring exists for a ground set of cardinality m', it also exists for any m ≤ m'. The coloring can be restricted to the smaller set. This means the problem is hardest for the minimal case m = κ, and solving that case would settle all larger cases. The axiom formalizes this with an existential witness for the restricted coloring.",
+    "content": "If a chromatically complete coloring exists for a ground set of cardinality m', it also exists for any m ≤ m'. The coloring can be restricted to the smaller set. This means the problem is hardest for the minimal case m = κ, and solving that case would settle all larger cases. This is stated only as a source comment; no axiom or lemma formalizes it.",
     "mathContext": "If $m \\le m'$ and $c: [m']^{\\le\\omega} \\to \\kappa$ is chromatically complete, then the restriction $c|_{[m]^{\\le\\omega}}$ is chromatically complete for $m$. This follows from $[X]^{\\le\\omega} \\cap [m]^{\\le\\omega} \\ne \\emptyset$ for $X \\subseteq m$ with $|X| = \\kappa$.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-598/meta.json
+++ b/src/data/proofs/erdos-598/meta.json
@@ -30,7 +30,7 @@
     "historicalContext": "Erdős posed this problem in 1987 in his paper on combinatorial problems in set theory. The question lies at the intersection of partition calculus, cardinal arithmetic, and the combinatorics of countable subsets. The classical Erdős–Rado partition relation ℵ₁ → (ℵ₁)²_{ℵ₀} (1956) established foundational results about coloring pairs, but coloring countable subsets introduces an entirely different combinatorial landscape. The successor of the continuum κ = (2^ℵ₀)⁺ appears as the natural threshold because it is the smallest cardinal exceeding the number of reals, and questions about partition properties at this level are known to be sensitive to set-theoretic axioms. Under CH, κ = ℵ₂ and the problem connects to classical partition properties of ℵ₂ studied by Todorcevic, Shelah, and others. The problem asks whether κ colors suffice for a 'chromatic completeness' property: every κ-sized subset must realize all colors among its countable subsets. This is a strong Ramsey-type requirement that goes beyond standard partition relations by quantifying over all large subsets simultaneously.",
     "problemStatement": "Let $m$ be an infinite cardinal and $\\kappa = (2^{\\aleph_0})^+$. Can one color the countable subsets of $m$ with $\\kappa$ colors so that every $X \\subseteq m$ with $|X| = \\kappa$ contains subsets of every color?",
     "text": "Can one color countable subsets of an infinite set m with κ = (2^ℵ₀)⁺ colors so that every κ-sized subset contains all colors? OPEN.",
-    "proofStrategy": "The formalization defines κ = (2^ℵ₀)⁺ using Lean's Cardinal and Order.succ, CountableSubset as countable subsets of a type, and ChromaticCompleteness as the requirement that every κ-sized subset realizes all colors. ErdosProblem598 states the universal version for all ground sets of size ≥ κ. Special cases include the minimal case m = κ and the CH scenario. Monotonicity in the ground set size is axiomatized.",
+    "proofStrategy": "The formalization defines κ = (2^ℵ₀)⁺ using Lean's Cardinal and Order.succ, CountableSubset as countable subsets of a type, and ChromaticCompleteness as the requirement that every κ-sized subset realizes all colors. ErdosProblem598 states the universal version for all ground sets of size ≥ κ. Special cases include the minimal case m = κ and the CH scenario. Monotonicity in the ground set size is noted only in a source comment, not formalized as any Lean declaration.",
     "keyInsights": [
       "The cardinal $\\kappa = (2^{\\aleph_0})^+$ serves a dual role: both the number of colors and the minimum subset size that must realize all colors, creating a delicate balance",
       "Chromatic completeness is a strong Ramsey-type property: every κ-sized subset must contain countable subsets of every single color, with no exceptions",
@@ -58,7 +58,7 @@
       "title": "Cardinal Setup",
       "startLine": 22,
       "endLine": 31,
-      "summary": "Defines κ = (2^ℵ₀)⁺ as Order.succ (2 ^ ℵ₀) and axiomatizes κ > ℵ₀."
+      "summary": "Defines κ = (2^ℵ₀)⁺ as Order.succ (2 ^ ℵ₀); a comment notes κ > ℵ₀ but this is not formalized as any declaration."
     },
     {
       "id": "countable-subsets",
@@ -93,7 +93,7 @@
       "title": "Monotonicity",
       "startLine": 84,
       "endLine": 84,
-      "summary": "Axiomatizes that coloring existence is monotone in the ground set size: larger sets inherit chromatically complete colorings from smaller ones via restriction."
+      "summary": "A source comment states (informally, not as any Lean declaration) that coloring existence is monotone in the ground set size: larger sets would inherit chromatically complete colorings from smaller ones via restriction."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-598
**Problem**: meta.json and annotations.json claim things are "axiomatized" that are actually just informal Lean source comments — no `axiom` declaration exists anywhere in `Proofs/Erdos598Problem.lean` (verified via `grep axiom`, zero hits; `axiomCount: 0` is correct). Worst case: `annotations.json` names a specific nonexistent axiom, `kappa_gt_aleph0`, that was never declared.

## Evidence

**meta.json claims**:
- `overview.proofStrategy`: "Monotonicity in the ground set size is axiomatized."
- `sections[cardinal-setup].summary`: "...axiomatizes κ > ℵ₀."
- `sections[monotonicity].summary`: "Axiomatizes that coloring existence is monotone..."

**annotations.json claims**:
- `erdos-598-ann-kappa`: "The axiom kappa_gt_aleph0 records that κ exceeds ℵ₀."
- `erdos-598-ann-monotone`: "The axiom formalizes this with an existential witness for the restricted coloring."

**Lean file shows**: Both claims correspond only to plain `/- ... -/` comments (lines 32 and 86-87), not `axiom` declarations. The file has 6 `def`s, 0 `theorem`s, 0 `axiom`s, 0 `sorry`s — matching `meta.json`'s own `axiomCount: 0`, so the prose contradicts the file's own metadata.

## Fix

Reworded the five prose locations above to state these are informal source comments, not formalized declarations, and removed the phantom `kappa_gt_aleph0` axiom name.

---
Discovered during gallery integrity audit (erdos-598).