### PR TITLE
audit: update tracker for erdos-585 (issues-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14814,9 +14814,9 @@
     },
     "erdos-585": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:41Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T01:20:48Z",
+      "result": "issues-fixed"
     },
     "erdos-586": {
       "agentId": "auditor-loop-5164",


### PR DESCRIPTION
Marks erdos-585 audit complete after PR #42816 (comment-only mislabeled axiomatized + vacuous True-stub overclaim fix).