### PR TITLE
Enrich fibonacci-identities-oq-01-oq-04: close section-coverage gap

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-01-oq-04/annotations.json
@@ -62,10 +62,10 @@
   {
     "id": "ann-examples",
     "proofId": "fibonacci-identities-oq-01-oq-04",
-    "range": { "startLine": 118, "endLine": 127 },
+    "range": { "startLine": 118, "endLine": 131 },
     "type": "example",
     "title": "Numeric sanity checks",
-    "content": "Two kernel-decidable instances confirm the identity: n=4 gives F₂·F₃·F₅·F₆ = 1·2·5·8 = 80 = 3⁴ − 1, and n=6 gives F₄·F₅·F₇·F₈ = 3·5·13·21 = 4095 = 8⁴ − 1. These use `decide` (kernel reduction), contributing no axioms beyond the foundational set.",
+    "content": "Two kernel-decidable instances confirm the identity: n=4 gives F₂·F₃·F₅·F₆ = 1·2·5·8 = 80 = 3⁴ − 1, and n=6 gives F₄·F₅·F₇·F₈ = 3·5·13·21 = 4095 = 8⁴ − 1. These use `decide` (kernel reduction), contributing no axioms beyond the foundational set. The file closes with a `#print axioms` audit on fib_gelin_cesaro_gap and fib_gelin_cesaro, which is the mechanical check that only propext / Classical.choice / Quot.sound appear — confirming the 0-axiom claim rather than merely asserting it.",
     "mathContext": "$F_4F_5F_7F_8=3\\cdot5\\cdot13\\cdot21=4095=8^4-1.$",
     "significance": "supporting",
     "relatedConcepts": ["decide", "numeric verification"]

--- a/src/data/proofs/fibonacci-identities-oq-01-oq-04/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-01-oq-04/meta.json
@@ -119,8 +119,8 @@
       "id": "examples",
       "title": "Numeric sanity checks",
       "startLine": 118,
-      "endLine": 127,
-      "summary": "Kernel-decidable checks at n=4 (F₂F₃F₅F₆ = 1·2·5·8 = 80 = 3⁴−1) and n=6 (F₄F₅F₇F₈ = 3·5·13·21 = 4095 = 8⁴−1).",
+      "endLine": 131,
+      "summary": "Kernel-decidable checks at n=4 (F₂F₃F₅F₆ = 1·2·5·8 = 80 = 3⁴−1) and n=6 (F₄F₅F₇F₈ = 3·5·13·21 = 4095 = 8⁴−1); the namespace close and the trailing #print axioms audit on fib_gelin_cesaro_gap / fib_gelin_cesaro, confirming only the foundational propext / Classical.choice / Quot.sound.",
       "mathContext": "$F_4F_5F_7F_8=3\\cdot5\\cdot13\\cdot21=4095=8^4-1.$"
     }
   ],


### PR DESCRIPTION
## Summary
- The `examples` section and its matching annotation ended at line 127, leaving the file's final 4 lines (the `end` namespace close and the trailing `#print axioms` audit) uncovered against the file's true `lineCount: 131`.
- Extended `sections[-1].endLine` and `ann-examples.range.endLine` from 127 to 131, and noted what those lines actually verify (the `#print axioms` calls mechanically confirm the 0-axiom claim rather than merely asserting it).

## Test plan
- [x] Validated meta.json / annotations.json parse and the section/annotation ranges now span the full 1-131 line file
- [x] `pnpm build` enrichment/data-validation steps passed (build fails later at an unrelated pre-existing `tsc: command not found` environment gap in this worktree, not touched by this change)