### PR TITLE
audit: fix stale '0 axioms' comment in law-of-cosines-oq-03

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ03.lean
@@ -22,11 +22,15 @@ proving the identity from the fundamental hyperbolic identities:
 - cosh²(x) - sinh²(x) = 1
 - cosh(x-y) = cosh(x)cosh(y) - sinh(x)sinh(y)
 
-## Status (0 axioms, 0 sorries)
+## Status (0 `axiom` declarations, 3 structure-encoded assumptions, 0 sorries)
 - [x] Hyperbolic triangle structure
-- [x] Hyperbolic law of cosines statement
+- [x] Hyperbolic law of cosines statement (structure-encoded: `HyperbolicTriangle.law`)
 - [x] Key hyperbolic identities
 - [x] Algebraic proof
+
+Note: `HyperbolicTriangle.law`, `HyperbolicTriangleAngles.law2`, and
+`HyperbolicTriangleAngles.defect_pos` are structure fields, not proved from a
+hyperbolic metric model — they are assumptions, not theorems.
 
 ## References
 - Ratcliffe (2006): "Foundations of Hyperbolic Manifolds", Chapter 3


### PR DESCRIPTION
## Integrity Fix

**Proof**: law-of-cosines-oq-03 (Hyperbolic Law of Cosines)

## Problem

The gallery `meta.json` for this proof is honest and clear: `axiomCount: 3`,
`badge: "axiom"`, `status: "axiomatized"`, with an explicit `assumptions`
field naming the 3 structure-encoded axioms (`HyperbolicTriangle.law`,
`HyperbolicTriangleAngles.law2`, `HyperbolicTriangleAngles.defect_pos`).

However, the underlying Lean source file's own docstring (line 25) claimed:

```
## Status (0 axioms, 0 sorries)
```

This directly contradicts the file's own 3 structure-encoded axioms and the
gallery's correct disclosure of them.

## Fix

Updated the in-file docstring to state "0 `axiom` declarations, 3
structure-encoded assumptions, 0 sorries" and added a short note naming the
three assumption fields, so a reader viewing the raw source sees the same
honest picture the gallery page already presents. No proof/logic changes;
comment-only.

## Verification

- `theoremCount: 12` — matches (counted declarations in file).
- `definitionCount: 2` — matches (2 structures: `HyperbolicTriangle`,
  `HyperbolicTriangleAngles`).
- `sorries: 0` — matches (no `sorry` in file).
- `leanFile.axiomCount: 0` — correct for literal `axiom` keyword count (there
  are none; the 3 axioms are structure fields, correctly tracked separately
  as `meta.axiomCount: 3`).

---
Discovered during gallery integrity audit.