### PR TITLE
audit: update tracker for law-of-cosines-oq-03 (issues-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21974,10 +21974,10 @@
       "result": "clean"
     },
     "law-of-cosines-oq-03": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:43Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T01:24:52Z",
+      "result": "issues-fixed"
     },
     "law-of-cosines-oq-03-oq-01": {
       "auditCount": 1,


### PR DESCRIPTION
Records audit completion for law-of-cosines-oq-03. Fixed stale "0 axioms" docstring in the Lean source (#42821); gallery meta.json was already accurate (axiomCount:3, badge:axiom, status:axiomatized, all disclosed correctly).