### PR TITLE
Research: erdos-53-wip-01 - signed extension of quadratic subset-sums bound refuted (node closed)

### DIFF
--- a/proofs/Proofs/Erdos53WIP01.lean
+++ b/proofs/Proofs/Erdos53WIP01.lean
@@ -676,4 +676,105 @@ theorem subsetProducts_card_ge_quadratic' {A : Finset ℤ} (hgt : ∀ a ∈ A, 1
   have h := subsetProducts_card_ge_quadratic hgt
   omega
 
+/-
+## Sharpness: positivity cannot be weakened to nonzero (negative-elements route refuted)
+
+The Erdős quadratic chain (`subsetSums_card_ge_quadratic'`) assumes every element
+positive.  The natural weakening — allow negative elements, requiring only `a ≠ 0`
+(the additive mirror of the multiplicative chain excluding `1`) — is FALSE, and not
+by an accident of small cases: for EVERY `n ≥ 2` the witness `{-1, 1, 2, …, n-1}`
+has all its subset sums inside `[-1, (n-1)n/2]`, hence at most `(n-1)n/2 + 2` of
+them, short of the triangular bound `n(n+1)/2 + 1` by a margin growing linearly in
+`n`.  Mixed signs permit genuine additive cancellation, and the max-removal chain's
+"fresh values above the old total" mechanism is irreparably sign-dependent.  This
+closes the last elementary rung recorded for this node: any signed extension needs a
+materially different, cancellation-aware mechanism.
+-/
+
+/-- Gauss summation, `Icc` form: `2·(1 + 2 + ⋯ + m) = m(m+1)`. -/
+theorem two_mul_sum_Icc_id (m : ℕ) : 2 * (Finset.Icc 1 m).sum id = m * (m + 1) := by
+  induction m with
+  | zero => simp
+  | succ k ih =>
+      rw [Finset.sum_Icc_succ_top (Nat.le_add_left 1 k), mul_add, ih, id_eq]
+      ring
+
+/-- **Positivity is essential in the additive quadratic chain.**  For every `n ≥ 2`
+    there is a set of `n` distinct *nonzero* integers — the single negative element
+    `-1` together with `1, 2, …, n-1` — whose subset-sum count violates the
+    triangular bound of `subsetSums_card_ge_quadratic'` (stated here in the file's
+    doubled form; the failure margin is `2(n-1)`).  So the hypothesis `0 < a`
+    cannot be weakened to `a ≠ 0`: one negative element already breaks the bound at
+    every size. -/
+theorem subsetSums_quadratic_fails_of_negative (n : ℕ) (hn : 2 ≤ n) :
+    ∃ A : Finset ℤ, A.card = n ∧ (∀ a ∈ A, a ≠ 0) ∧
+      2 * (subsetSums A).card < n * (n + 1) + 2 := by
+  classical
+  -- The positive part `P = {1, …, n-1}` and the witness `A = insert (-1) P`.
+  set P : Finset ℤ := (Finset.Icc 1 (n - 1)).image (fun i : ℕ => (i : ℤ)) with hP
+  have hPpos : ∀ a ∈ P, (0 : ℤ) < a := by
+    intro a ha
+    rw [hP, Finset.mem_image] at ha
+    obtain ⟨i, hi, rfl⟩ := ha
+    exact_mod_cast (Finset.mem_Icc.mp hi).1
+  have hneg : (-1 : ℤ) ∉ P := fun h => absurd (hPpos _ h) (by norm_num)
+  refine ⟨insert (-1 : ℤ) P, ?_, ?_, ?_⟩
+  · -- `|A| = n`: the `n-1` positives plus the fresh element `-1`.
+    rw [Finset.card_insert_of_notMem hneg, hP,
+        Finset.card_image_of_injective _ Nat.cast_injective, Nat.card_Icc]
+    omega
+  · intro a ha
+    rcases Finset.mem_insert.mp ha with rfl | h
+    · norm_num
+    · exact ne_of_gt (hPpos a h)
+  · -- Every subset sum lies in `[-1, T]` with `T = ∑ P`: the `-1` can lower a sum
+    -- by at most `1`, and the positive part contributes at most the full total.
+    set T : ℤ := P.sum id with hT
+    have hsub : subsetSums (insert (-1 : ℤ) P) ⊆ Finset.Icc (-1 : ℤ) T := by
+      intro x hx
+      rw [subsetSums, Finset.mem_image] at hx
+      obtain ⟨S, hS, rfl⟩ := hx
+      rw [Finset.mem_powerset] at hS
+      have hS' : S.erase (-1) ⊆ P := by
+        intro a ha
+        rcases Finset.mem_insert.mp (hS (Finset.mem_of_mem_erase ha)) with h | h
+        · exact absurd h (Finset.ne_of_mem_erase ha)
+        · exact h
+      have h0 : (0 : ℤ) ≤ (S.erase (-1)).sum id :=
+        Finset.sum_nonneg fun a ha => le_of_lt (hPpos a (hS' ha))
+      have hle : (S.erase (-1)).sum id ≤ T :=
+        Finset.sum_le_sum_of_subset_of_nonneg hS'
+          (fun a ha _ => le_of_lt (hPpos a ha))
+      rw [Finset.mem_Icc]
+      by_cases hm : (-1 : ℤ) ∈ S
+      · rw [← Finset.insert_erase hm, Finset.sum_insert (Finset.notMem_erase _ _)]
+        simp only [id_eq] at h0 hle ⊢
+        omega
+      · rw [Finset.erase_eq_self.mpr hm] at h0 hle
+        exact ⟨le_trans (by norm_num) h0, hle⟩
+    -- Count: `|Icc (-1) T| = Tn + 2` where `Tn = 1 + 2 + ⋯ + (n-1)`.
+    have hTn : T = (((Finset.Icc 1 (n - 1)).sum id : ℕ) : ℤ) := by
+      rw [hT, hP, Finset.sum_image (fun a _ b _ h => Nat.cast_injective h)]
+      push_cast
+      simp only [id_eq]
+    have hIcc : (Finset.Icc (-1 : ℤ) T).card = (Finset.Icc 1 (n - 1)).sum id + 2 := by
+      rw [Int.card_Icc, hTn]
+      omega
+    have hcard : (subsetSums (insert (-1 : ℤ) P)).card ≤ (Finset.Icc 1 (n - 1)).sum id + 2 := by
+      rw [← hIcc]
+      exact Finset.card_le_card hsub
+    -- Gauss + arithmetic: `2·Tn + 4 = (n-1)n + 4 < n(n+1) + 2` for `n ≥ 2`.
+    obtain ⟨m, rfl⟩ : ∃ m, n = m + 2 := ⟨n - 2, by omega⟩
+    have hgauss : 2 * (Finset.Icc 1 (m + 2 - 1)).sum id = (m + 1) * (m + 2) := by
+      have h := two_mul_sum_Icc_id (m + 1)
+      have hred : m + 2 - 1 = m + 1 := rfl
+      rw [hred]
+      linarith [h]
+    nlinarith [hcard, hgauss]
+
+/-- Concrete illustration at the smallest size: `{1, -1}` realises only the three
+    subset sums `{0, 1, -1}` — one short of the four demanded of two-element
+    positive sets by `subsetSums_card_ge_quadratic'`. -/
+theorem subsetSums_pair_neg_card : (subsetSums {(1 : ℤ), -1}).card = 3 := by decide
+
 end Erdos53

--- a/research/problems/erdos-53-wip-01/knowledge.md
+++ b/research/problems/erdos-53-wip-01/knowledge.md
@@ -215,3 +215,25 @@ Elementary vein now fully SATURATED (both sides individually quadratic).
 Remaining: Chang |A|^k (deep); thin maybe-rung: negatives in the additive
 chain (subset sums collide across sign — likely needs |·| tricks, assess
 before attempting).
+
+## Session 2026-07-23 (researcher-1, iteration 2): signed extension refuted, node closed
+
+`subsetSums_quadratic_fails_of_negative` (Erdos53WIP01.lean): for every n >= 2,
+A = {-1} ∪ {1..n-1} has 2|subsetSums A| < n(n+1)+2, so the positivity
+hypothesis of the quadratic chain cannot be weakened to a ≠ 0. Proof shape:
+subsetSums A ⊆ Icc (-1) T with T = Σ(positive part); card via Int.card_Icc;
+Gauss via bespoke `two_mul_sum_Icc_id` (induction + Finset.sum_Icc_succ_top);
+final arithmetic nlinarith after `obtain ⟨m, rfl⟩ : ∃ m, n = m + 2`.
+
+Lean gotchas this session:
+- omega sees `Finset.sum s id` and `∑ x ∈ s, id x` as DIFFERENT atoms after
+  `rw [Finset.sum_insert]`; normalize with `simp only [id_eq] at h0 hle ⊢`
+  before omega.
+- `Finset.erase_eq_self.mpr` is the robust spelling for erase-of-nonmember
+  (avoids erase_eq_of_notMem name drift).
+- `m + 2 - 1 = m + 1` is rfl (Nat.succ_sub_one) — usable directly in rw.
+- decide handles `(subsetSums {1,-1}).card = 3` fine (small Int Finsets).
+
+Route ledger: "negative elements in additive max-removal chain" is now a
+REFUTED route (counterexample family formalized), recorded in tracker
+blockers. Only Chang (deep) remains; node marked completed in pool.

--- a/research/problems/erdos-53-wip-01/state.md
+++ b/research/problems/erdos-53-wip-01/state.md
@@ -48,3 +48,31 @@ scope). Thin rung left: negative elements in the ADDITIVE chain (positivity
 only used for the total-sum upper bound; max-removal still works if 0 ∉ A?
 — needs care, subset sums can collide across sign). Elementary vein otherwise
 SATURATED.
+
+## Status (researcher-1, 2026-07-23, iteration 2) — negative-elements rung REFUTED; node closed
+
+The last thin rung ("negative elements in the additive chain") is now CLOSED
+with a machine-checked refutation, not a note:
+
+- `subsetSums_quadratic_fails_of_negative`: for EVERY n >= 2 the witness
+  {-1, 1, 2, ..., n-1} (n distinct nonzero integers) has
+  2*|subsetSums A| < n(n+1) + 2 — the quadratic bound FAILS. All subset sums
+  lie in [-1, (n-1)n/2] (the -1 lowers by at most 1; the positive part is
+  capped by its total), so at most (n-1)n/2 + 2 values vs the triangular
+  demand n(n+1)/2 + 1: a margin growing linearly (n-1). So positivity cannot
+  be weakened to nonzero — the failure is structural (additive cancellation),
+  not a small-case accident.
+- Helpers: `two_mul_sum_Icc_id` (Gauss, Icc form);
+  `subsetSums_pair_neg_card` ({1,-1} has exactly 3 subset sums, by decide).
+- All #print axioms = [propext, Classical.choice, Quot.sound]. theoremCount
+  25 -> 28, still 0 axioms/sorries.
+
+## Final state
+
+Elementary vein FULLY SATURATED and now definitively fenced:
+- additive side quadratic for positive sets (sharp), multiplicative side
+  quadratic for sets > 1 (sharp), prime family exponential for all k,
+  parity refinement, and the signed extension REFUTED.
+- Remaining content is exactly Chang 2003 (|A|^k for arbitrary large sets,
+  Freiman/Plünnecke + multiplicative energy) — deep, documented, out of
+  elementary scope. Node complete.

--- a/src/data/research/problems/erdos-53-wip-01.json
+++ b/src/data/research/problems/erdos-53-wip-01.json
@@ -18,18 +18,23 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-07-09T17:33:19-07:00",
     "iteration": 4,
-    "focus": "Session 2026-07-22: quadratic additive lower bound for arbitrary positive sets. subsetSums_card_quadratic (induction on max-removal): n(n+1)+2 <= 2|subsetSums A|; corollaries sumsOrProducts_card_ge_quadratic and sumsOrProducts_card_superlinear. 8 new theorems (11->19), 0-axiom, host-verified v4.31.",
+    "focus": "Elementary vein saturated and fenced: signed extension refuted (subsetSums_quadratic_fails_of_negative); only Chang (deep) remains.",
     "blockers": [
       {
         "route": "lower-order refinement of the easy-direction lower bound (parity/prefix-sum even-value counting) past 2^|A| + |A| - 1",
         "reopenCriterion": "materially new mechanism required (pushing beyond the linear +|A| term = counting subset-sum vs subset-product collisions on the even numbers, which is essentially the deep sum-product problem itself)",
         "blockedAt": "2026-07-21"
+      },
+      {
+        "route": "negative-elements extension of additive max-removal chain (weaken 0 < a to a ≠ 0)",
+        "reopenCriterion": "REFUTED — statement false for every n ≥ 2 (witness {-1,1,...,n-1}, formalized as subsetSums_quadratic_fails_of_negative); do not reopen; any signed bound needs a cancellation-aware restatement",
+        "blockedAt": "2026-07-23"
       }
     ],
-    "nextAction": "Chang's theorem (|A|^k for arbitrary large A, not just primes) remains documented not axiomatized — needs Freiman/Plünnecke additive-combinatorics machinery absent from the file. Prime family fully handled for all k.",
+    "nextAction": "None — node complete. Remaining content is exactly Chang 2003 (deep, documented axiom-free as prose in parent).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -37,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: prime family all-k + parity separation + BOTH quadratic chains (additive |subsetSums| >= n(n+1)/2+1 all positive sets; multiplicative |subsetProducts| >= n(n+1)/2 all sets >1) done, 0 axioms; elementary vein saturated; remaining = Chang |A|^k arbitrary sets (deep)",
+    "progressSummary": "COMPLETE: both sides individually quadratic on natural domains (positive / >1), prime family exponential for all k, parity refinement, and the signed extension REFUTED (machine-checked counterexample family). Remaining content is exactly Chang 2003 — deep, out of elementary scope. Node closed.",
     "builtItems": [
       "zero_mem_subsetSums, mem_subsetSums_of_mem, mem_subsetProducts_of_mem in Erdos53Problem.lean",
       "subsetSums/Products_subset_sumsOrProducts, subsetSumCount/subsetProductCount_le_card in Erdos53Problem.lean",
@@ -55,7 +60,8 @@
       "subsetSums_card_quadratic + subsetSums_card_ge_quadratic(') in Erdos53WIP01.lean: n(n+1)+2 <= 2|subsetSums A| (and /2+1 form) for all positive sets, 0-axiom",
       "sumsOrProducts_card_ge_quadratic + sumsOrProducts_card_superlinear in Erdos53WIP01.lean: quadratic growth of the representable set over ALL positive sets; every linear rate C beaten past |A| >= 2C",
       "prod_mem_subsetProducts, prod_erase_mem_subsetProducts, mem_subsetProducts_le_prod in Erdos53WIP01.lean",
-      "subsetProducts_card_quadratic (induction core) + subsetProducts_card_ge_quadratic + division form in Erdos53WIP01.lean"
+      "subsetProducts_card_quadratic (induction core) + subsetProducts_card_ge_quadratic + division form in Erdos53WIP01.lean",
+      "Erdos53WIP01.lean: subsetSums_quadratic_fails_of_negative (∀ n ≥ 2 refutation of signed quadratic bound), two_mul_sum_Icc_id (Gauss Icc form), subsetSums_pair_neg_card (decide). theoremCount 25→28, 0 axioms."
     ],
     "insights": [
       "Erdos53Problem.lean was a definitions-only stub (9 defs, 0 theorems). Chang 2003 (conjecture holds) and the Erdos-Szemeredi upper bound need deep additive combinatorics beyond Mathlib; tractable axiom-free content is elementary structural facts about subsetSums/subsetProducts/sumset/productset.",
@@ -67,7 +73,8 @@
       "Multiplicative mirror of the Erdős chain: |subsetProducts A| >= n(n+1)/2 for arbitrary sets of integers > 1 — frontier moved from prime-only (2^n-1) to all sets of elements >= 2",
       "Transposition is not mechanical: ZZ multiplicative monoid is unordered, so subset-product <= full-product goes via prod_dvd_prod_of_subset + Int.le_of_dvd; fresh values written Pi(A.erase a) (never P/a); all comparisons via cancellation on Pi(A.erase a)*a = Pi A",
       "Elements->1 hypothesis essential multiplicatively where >0 sufficed additively: 1 in A collides Pi(A.erase 1) with Pi A, exact mirror of the 0-element degeneracy",
-      "Bound sharp for geometric {2,4,...,2^n} (products realize exactly 2^[1..n(n+1)/2]); both Problem-53 sides now individually quadratic — remaining content is exactly the sum-product tension (Chang, deep)"
+      "Bound sharp for geometric {2,4,...,2^n} (products realize exactly 2^[1..n(n+1)/2]); both Problem-53 sides now individually quadratic — remaining content is exactly the sum-product tension (Chang, deep)",
+      "The quadratic subset-sums bound is FALSE with any negative element allowed: {-1,1,...,n-1} keeps all subset sums in [-1,(n-1)n/2], giving ≤ (n-1)n/2+2 values vs the triangular demand n(n+1)/2+1 — a linearly growing deficit. Positivity (not merely nonzeroness) is the correct hypothesis; formalized for all n ≥ 2."
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -91,7 +98,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.781Z",
-  "lastUpdate": "2026-07-21",
+  "lastUpdate": "2026-07-23T00:00:00.000Z",
   "significance": 7,
   "tractability": 6,
   "nextAction": "Optional extensions: (a) general polynomial-vs-exponential domination ∀k ∃N ∀n≥N, n^k ≤ 2^n (needs induction/analysis) to lift the prime-set connection to every k; (b) an additive richness lower bound for prime sets on the SUM side (subset sums of primes are not generally injective — quantify collisions). Chang’s theorem for arbitrary large sets remains the deep open crux and should stay axiom-documented, not axiomatized."


### PR DESCRIPTION
## Summary
Research session for erdos-53-wip-01 (Erdős Problem #53, sums and products of distinct elements). Closes the last recorded elementary rung with a machine-checked refutation.

## Progress
- `subsetSums_quadratic_fails_of_negative`: for **every** n ≥ 2 the witness {−1, 1, 2, …, n−1} (n distinct nonzero integers) satisfies 2·|subsetSums A| < n(n+1) + 2 — the Erdős quadratic bound fails the moment one negative element is allowed. The positivity hypothesis of `subsetSums_card_ge_quadratic'` cannot be weakened to a ≠ 0.
- Helpers: `two_mul_sum_Icc_id` (Gauss summation, Icc form), `subsetSums_pair_neg_card` (smallest case, by decide).
- Files: `proofs/Proofs/Erdos53WIP01.lean` (theoremCount 25 → 28, 0 sorries, 0 axioms; all new theorems `#print axioms` = propext/Classical.choice/Quot.sound), plus tracker/state/knowledge updates.
- Host-verified on v4.31.0: `lake env lean Proofs/Erdos53WIP01.lean` exit 0.

## Findings
- All subset sums of {−1} ∪ {1..n−1} lie in [−1, (n−1)n/2], so at most (n−1)n/2 + 2 values against the triangular demand n(n+1)/2 + 1 — a deficit growing linearly in n. Mixed signs enable genuine additive cancellation; the max-removal "fresh values above the old total" mechanism is irreparably sign-dependent.
- The "negative elements" route is recorded as a REFUTED blocked route in the tracker (counterexample family formalized).

## Status
**Outcome**: completed — elementary vein fully saturated and now fenced (additive quadratic sharp for positive sets, multiplicative quadratic sharp for sets > 1, prime family exponential for all k, parity refinement, signed extension refuted). Remaining content is exactly Chang 2003 (deep, stays documented).
**Next Steps**: none at the elementary level; node marked completed in the pool.

🤖 Generated by researcher-1
