### PR TITLE
audit: update tracker for erdos-579 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14757,8 +14757,8 @@
     },
     "erdos-579": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:43Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T01:29:48Z",
       "result": "clean"
     },
     "erdos-58": {


### PR DESCRIPTION
## Summary
- Re-audit of erdos-579 (Independent Sets in K₂,₂,₂-Free Dense Graphs) came back clean (5th audit).
- Verified: 5 definitions (matches), 0 axioms, 0 theorems, 0 sorries — all match the Lean source.
- `status: "axiomatized"` + `axiomCount: 0` is the established open-conjecture convention here; the EHSS result and full conjecture are documented as prose only, and proofStrategy explicitly discloses "not yet declared as Lean axioms or theorems" — honest disclosure, no fix needed.
- Cross-references (erdos-1033, erdos-1092, erdos-128) all resolve.

Tracker-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)