### PR TITLE
Enrich algebraic-reals-meager-oq-02: split sections to 5 (sharp-boundary/resolution)

### DIFF
--- a/src/data/proofs/algebraic-reals-meager-oq-02/meta.json
+++ b/src/data/proofs/algebraic-reals-meager-oq-02/meta.json
@@ -138,9 +138,17 @@
       "id": "sharp-boundary",
       "title": "Comeagre does not imply conull",
       "startLine": 121,
-      "endLine": 175,
-      "summary": "The headline existential — a dense comeagre set of measure zero — and the abstract disjointness of the comeagre and a.e. filters, packaged with the measure side as the OQ-02 resolution.",
+      "endLine": 134,
+      "summary": "The headline existential exists_residual_dense_null — a dense comeagre set of measure zero — and the abstract disjointness residual_ae_disjoint of the comeagre and a.e. filters, the structural reason a set can be comeagre while its complement is conull.",
       "mathContext": "Disjoint (residual ℝ) (ae volume): topological and measure-theoretic largeness are independent."
+    },
+    {
+      "id": "oq02-resolution",
+      "title": "OQ-02 Resolution and Results Summary",
+      "startLine": 135,
+      "endLine": 177,
+      "summary": "oq02_resolution packages the measure-nullity of the algebraic reals with the comeagre-vs-conull sharp boundary into the single OQ-02 answer; closing #checks and the results table document all eight theorems as 0-sorry, 0-axiom.",
+      "mathContext": "$\\mathrm{volume}\\{x : \\mathrm{IsAlgebraic}\\,\\mathbb{Q}\\,x\\} = 0\\ \\wedge\\ \\exists S\\ \\text{dense comeagre},\\ \\mathrm{volume}\\,S = 0$."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `algebraic-reals-meager-oq-02`.

The `sections` array had only 4 entries; the final "sharp-boundary" section (lines 121-175) actually spanned two distinct syntactic parts of the Lean file, marked by explicit `-- === Part III ===` / `-- === Part IV ===` comment banners at lines 116 and 136:

- Part III (121-134): the headline `exists_residual_dense_null` existential and the abstract `residual_ae_disjoint` filter-disjointness fact.
- Part IV (135-177): the packaged `oq02_resolution` theorem, the closing `#check`s, and the results-summary table.

`annotations.json` already recognized this boundary (separate `ann-sharp-boundary` and `ann-resolution` annotations at 119-133 / 139-175), which is strong independent confirmation that the split tracks real content structure. Split the `sections` array to match, and extended final coverage to line 177 (the `end` line) for full-file coverage.

No other content changed.
