### PR TITLE
Audit: erdos-574 clean (reserve re-verification)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14721,8 +14721,8 @@
     },
     "erdos-574": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:43Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T01:34:14Z",
       "result": "clean"
     },
     "erdos-575": {


### PR DESCRIPTION
## Audit result: clean

Reserve-mode re-verification of erdos-574 (queue is fully drained: 4811/4811 audited, 0 issues).

**Checked**: sorry count, axiom count, native_decide, True stubs, line/theorem/definition counts, prose-vs-Lean disclosure for the open conjecture.

**Result**: all counts match meta.json exactly (220 lines, 0 axioms, 0 sorries, 8 theorem/lemma decls, 6 def/structure decls). The Erdős–Simonovits conjecture is disclosed only as documentation comments, never as a formal declaration — consistent with `status: axiomatized` / `badge: wip`. No overclaiming language found.

Tracker-only diff (audit-tracker.json bump).