### PR TITLE
Enrich cauchy-schwarz-integral-oq007: add missing header annotation

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq007/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq007/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "wpme-ann-header",
+    "proofId": "cauchy-schwarz-integral-oq007",
+    "range": { "startLine": 1, "endLine": 51 },
+    "type": "context",
+    "title": "Module header: the equality-case open question",
+    "content": "The module docstring frames the file as answering open question #2 of the parent `CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ03.lean`, which proved the weighted power mean chain WHM ≤ WGM ≤ WAM ≤ WQM for positive a, b and weights w₁, w₂ > 0 with w₁ + w₂ = 1: does the equality case WHM = WGM = WAM = WQM ⇔ a = b extend to the weighted setting? It answers YES, previews the three individual link lemmas (wam_eq_wqm_iff, wgm_eq_wam_iff, whm_eq_wgm_iff) and the headline chain_eq_iff, and sketches the three techniques used below — the weighted-variance identity, Mathlib's weighted AM-GM equality condition, and reciprocal duality. The file then opens the `WeightedPowerMeanEquality` namespace, opens `Real` for unqualified `sqrt`/`rpow` notation, and fixes `a b w₁ w₂ : ℝ` as section variables shared by every declaration below.",
+    "mathContext": "Open question: does $\\mathrm{WHM}=\\mathrm{WGM}=\\mathrm{WAM}=\\mathrm{WQM} \\iff a=b$ extend the parent's non-strict chain $\\mathrm{WHM}\\le\\mathrm{WGM}\\le\\mathrm{WAM}\\le\\mathrm{WQM}$? Answered YES via three links and the headline `chain_eq_iff`.",
+    "significance": "context",
+    "relatedConcepts": ["equality case", "the parent power-mean chain", "research problem framing"],
+    "prerequisites": ["the parent file's non-strict chain WHM ≤ WGM ≤ WAM ≤ WQM"]
+  },
+  {
     "id": "wpme-ann-defs",
     "proofId": "cauchy-schwarz-integral-oq007",
     "range": { "startLine": 52, "endLine": 67 },


### PR DESCRIPTION
## Summary
- `annotations.json` had 6 annotations covering lines 52-306, but the module header — the docstring stating the research problem, previewing the three equality-case links and headline `chain_eq_iff`, plus the `namespace`/`open Real`/`variable` block — spans lines 1-51 and was uncovered.
- `sections[]` in meta.json already covers this range (the "header" section, lines 1-47), so this closes an annotation-coverage gap rather than a section gap.
- Added `wpme-ann-header` (type `context`, significance `context`) summarizing the open question this file answers and the three proof techniques it previews, with `mathContext`, `relatedConcepts`, and `prerequisites`.
- Result: annotations now cover lines 1-306 (full file). meta.json unchanged; annotations.json 8.0 KB, well under size caps.

## Test plan
- [x] Validated JSON structure (`python3 -c "import json; json.load(...)"`)
- [x] `pnpm build` gallery-data validators passed (`check-size`, `check-verified-companions`, `check-search-index`, `loading-facts`, `build-redirects`) before an unrelated `tsc`/`better-sqlite3` native-module failure (host-wide Node v26.5 issue, not touched by this change)
- [x] Verified all lemma names cited in the new annotation match the Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)