### PR TITLE
Research: erdos-64-wip-01 - even-length cycle spectrum rung, sharp for K_{d+1} (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos64Problem.lean
+++ b/proofs/Proofs/Erdos64Problem.lean
@@ -820,6 +820,235 @@ theorem hasMinDegree_card_containsCycleLength
   obtain ⟨h3, v, c, hc, hlen⟩ := hS k hk
   exact ⟨h3, hlen ▸ isCycle_containsCycleLength G c hc⟩
 
+/- ## Even-length cycle spectrum (parity-class difference cycles)
+
+A `2^k`-cycle (`k ≥ 2`) is even, so the part of the cycle spectrum relevant to
+Problem 64 is the EVEN sub-spectrum.  The longest-path engine refines once more:
+among the `≥ d` trapped neighbour indices, some parity class carries at least
+`⌈d/2⌉` of them, and for two trapped indices `a < b` of EQUAL parity the segment
+cycle `v₀ — v_a — ⋯ — v_b — v₀` has even length `b - a + 2`.  Fixing `a` to be
+the smallest index of the majority class and letting `b` range over the rest
+yields `⌈d/2⌉ - 1 = ⌊(d-1)/2⌋` distinct even cycle lengths.  (Unlike the prefix
+cycles of the two preceding rungs, segment cycles need no `index ≥ 2` proviso —
+any `1 ≤ a < b` closes.)
+
+The count is SHARP: the complete graph `K_{d+1}` has minimum degree `d` and its
+cycle lengths are exactly `3, 4, …, d + 1`, of which exactly `⌊(d-1)/2⌋` are
+even.  So at minimum degree `3` no counting refinement of this kind can beat
+"one even cycle length", and upgrading that single even length to a power of two
+is precisely the open Liu–Montgomery-scale core of Problem 64.
+-/
+
+/-- **Even-spectrum rung: minimum degree `d` forces at least `⌊(d-1)/2⌋` distinct
+EVEN cycle lengths**, each realized by an explicit cycle witness.  Sharp for the
+complete graph `K_{d+1}`.  Mechanism: the majority parity class of the trapped
+neighbour indices, closed pairwise through same-parity segment cycles of length
+`b - a + 2`. -/
+theorem hasMinDegree_card_even_cycle_lengths
+    {W : Type*} [Fintype W] [DecidableEq W] [Nonempty W]
+    (G : SimpleGraph W) [DecidableRel G.Adj] {d : ℕ}
+    (hdeg : HasMinDegree G d) :
+    ∃ L : Finset ℕ, (d - 1) / 2 ≤ L.card ∧
+      ∀ k ∈ L, Even k ∧ ∃ (v : W) (c : G.Walk v v), c.IsCycle ∧ c.length = k := by
+  classical
+  -- a path of maximum length (the engine of the preceding sections)
+  have hne : ({n : ℕ | ∃ (a : W) (b : W) (q : G.Walk a b), q.IsPath ∧ q.length = n}).Nonempty :=
+    ⟨0, Classical.arbitrary W, Classical.arbitrary W, Walk.nil, Walk.IsPath.nil, rfl⟩
+  have hbdd : BddAbove {n : ℕ | ∃ (a : W) (b : W) (q : G.Walk a b), q.IsPath ∧ q.length = n} := by
+    refine ⟨Fintype.card W, ?_⟩
+    rintro n ⟨a, b, q, hq, rfl⟩
+    exact hq.length_lt.le
+  obtain ⟨v₀, u, p, hp, hplen⟩ := Nat.sSup_mem hne hbdd
+  have hmax : ∀ (a b : W) (q : G.Walk a b), q.IsPath → q.length ≤ p.length := by
+    intro a b q hq
+    rw [hplen]
+    exact le_csSup hbdd ⟨a, b, q, hq, rfl⟩
+  -- maximality traps every neighbour of `v₀` on `p`
+  have hnbr : ∀ w : W, G.Adj v₀ w → w ∈ p.support := by
+    intro w hw
+    by_contra hws
+    have hcons : (Walk.cons hw.symm p).IsPath := (Walk.cons_isPath_iff _ _).mpr ⟨hp, hws⟩
+    have := hmax _ _ _ hcons
+    rw [Walk.length_cons] at this
+    omega
+  set idx : W → ℕ := fun w => if hw : w ∈ p.support then (p.takeUntil w hw).length else 0
+    with hidx
+  have hidx_get : ∀ w (hw : w ∈ p.support), p.getVert (idx w) = w := by
+    intro w hw
+    simp only [hidx, dif_pos hw]
+    exact Walk.getVert_length_takeUntil hw
+  set T : Finset ℕ := (G.neighborFinset v₀).image idx with hT
+  have hTcard : d ≤ T.card := by
+    rw [hT, Finset.card_image_of_injOn]
+    · exact hdeg v₀
+    · intro w₁ hw₁ w₂ hw₂ hww
+      have h₁ : G.Adj v₀ w₁ := (G.mem_neighborFinset v₀ w₁).mp (Finset.mem_coe.mp hw₁)
+      have h₂ : G.Adj v₀ w₂ := (G.mem_neighborFinset v₀ w₂).mp (Finset.mem_coe.mp hw₂)
+      calc w₁ = p.getVert (idx w₁) := (hidx_get w₁ (hnbr _ h₁)).symm
+        _ = p.getVert (idx w₂) := by rw [hww]
+        _ = w₂ := hidx_get w₂ (hnbr _ h₂)
+  have hpos : ∀ n ∈ T, 1 ≤ n := by
+    intro n hn
+    rw [hT] at hn
+    obtain ⟨w, hw, rfl⟩ := Finset.mem_image.mp hn
+    have hadj : G.Adj v₀ w := (G.mem_neighborFinset v₀ w).mp hw
+    rcases Nat.eq_zero_or_pos (idx w) with h0 | h1
+    · exfalso
+      have hgw := hidx_get w (hnbr _ hadj)
+      rw [h0, Walk.getVert_zero] at hgw
+      exact hadj.ne hgw
+    · exact h1
+  -- segment cycles: any two trapped indices `a < b` close into a cycle of
+  -- length `b - a + 2` (the `[a, b]` stretch of `p` plus the edges back to `v₀`)
+  have hseg : ∀ a b : ℕ, a ∈ T → b ∈ T → a < b →
+      ∃ c : G.Walk v₀ v₀, c.IsCycle ∧ c.length = b - a + 2 := by
+    intro a b haT hbT hab
+    have ha1 : 1 ≤ a := hpos a haT
+    rw [hT] at haT hbT
+    obtain ⟨y, hyN, hyb⟩ := Finset.mem_image.mp hbT
+    obtain ⟨x, hxN, hxa⟩ := Finset.mem_image.mp haT
+    have hax : G.Adj v₀ x := (G.mem_neighborFinset v₀ x).mp hxN
+    have hay : G.Adj v₀ y := (G.mem_neighborFinset v₀ y).mp hyN
+    have hxs : x ∈ p.support := hnbr x hax
+    have hys : y ∈ p.support := hnbr y hay
+    have hxa' : (p.takeUntil x hxs).length = a := by
+      rw [← hxa]; simp only [hidx, dif_pos hxs]
+    have hyb' : (p.takeUntil y hys).length = b := by
+      rw [← hyb]; simp only [hidx, dif_pos hys]
+    have hgx : p.getVert a = x := by rw [← hxa']; exact Walk.getVert_length_takeUntil hxs
+    have hgy : p.getVert b = y := by rw [← hyb']; exact Walk.getVert_length_takeUntil hys
+    have hblen : b ≤ p.length := by rw [← hyb']; exact p.length_takeUntil_le_length hys
+    have halen : a ≤ p.length := by omega
+    have hxy : x ≠ y := by
+      intro h
+      have hgg : p.getVert a = p.getVert b := by rw [hgx, hgy, h]
+      have := hp.getVert_injOn (by simp only [Set.mem_setOf_eq]; omega)
+        (by simp only [Set.mem_setOf_eq]; omega) hgg
+      omega
+    -- the middle segment of `p` from `x` (index `a`) to `y` (index `b`)
+    have hia : p.support.idxOf x = a := by
+      rw [← p.length_takeUntil hxs]; exact hxa'
+    have hdrop_gv : (p.dropUntil x hxs).getVert (b - a) = y := by
+      rw [Walk.dropUntil_eq_drop, Walk.getVert_copy, Walk.drop_getVert, hia,
+        show a + (b - a) = b by omega]
+      exact hgy
+    have hdrop_len : b - a ≤ (p.dropUntil x hxs).length := by
+      rw [Walk.length_dropUntil, hia]
+      omega
+    have hyd : y ∈ (p.dropUntil x hxs).support :=
+      Walk.mem_support_iff_exists_getVert.mpr ⟨b - a, hdrop_gv, hdrop_len⟩
+    set r := (p.dropUntil x hxs).takeUntil y hyd with hr
+    have hrpath : r.IsPath := (hp.dropUntil hxs).takeUntil hyd
+    have hrlen : r.length = b - a := by
+      have h₁ : (p.dropUntil x hxs).getVert r.length = y := Walk.getVert_length_takeUntil hyd
+      have hle : r.length ≤ (p.dropUntil x hxs).length :=
+        (p.dropUntil x hxs).length_takeUntil_le_length hyd
+      exact (hp.dropUntil hxs).getVert_injOn
+        (by simp only [Set.mem_setOf_eq]; omega)
+        (by simp only [Set.mem_setOf_eq]; omega)
+        (h₁.trans hdrop_gv.symm)
+    have hv₀r : v₀ ∉ r.support := by
+      intro hmem
+      have hmem' : v₀ ∈ (p.dropUntil x hxs).support :=
+        (p.dropUntil x hxs).support_takeUntil_subset_support hyd hmem
+      obtain ⟨n, hgv, hn⟩ := Walk.mem_support_iff_exists_getVert.mp hmem'
+      rw [Walk.dropUntil_eq_drop, Walk.getVert_copy, Walk.drop_getVert, hia] at hgv
+      have h0 : p.getVert (a + n) = p.getVert 0 := by rw [hgv, Walk.getVert_zero]
+      have hanle : a + n ≤ p.length := by
+        rw [Walk.length_dropUntil, hia] at hn
+        omega
+      have := hp.getVert_injOn (by simp only [Set.mem_setOf_eq]; omega)
+        (by simp only [Set.mem_setOf_eq]; omega) h0
+      omega
+    -- close the segment: `v₀ — x — ⋯ — y — v₀`
+    have hyv₀ : G.Adj y v₀ := hay.symm
+    have hcpath : (r.concat hyv₀).IsPath := hrpath.concat hv₀r hyv₀
+    have hcedge : s(v₀, x) ∉ (r.concat hyv₀).edges := by
+      rw [Walk.edges_concat]
+      intro hmem
+      rw [List.concat_eq_append, List.mem_append, List.mem_singleton] at hmem
+      rcases hmem with hin | heq
+      · exact hv₀r (r.fst_mem_support_of_mem_edges hin)
+      · rcases Sym2.eq_iff.mp heq with ⟨h1, _⟩ | ⟨_, h2⟩
+        · exact hay.ne h1
+        · exact hxy h2
+    refine ⟨Walk.cons hax (r.concat hyv₀),
+      (Walk.cons_isCycle_iff _ _).mpr ⟨hcpath, hcedge⟩, ?_⟩
+    rw [Walk.length_cons, Walk.length_concat, hrlen]
+  -- a same-parity subclass `S` of the trapped indices yields `|S| - 1` distinct
+  -- even lengths: fix the smallest index and close against every other one
+  have key : ∀ S : Finset ℕ, S ⊆ T → (∀ i ∈ S, ∀ j ∈ S, i % 2 = j % 2) →
+      ∃ L : Finset ℕ, S.card - 1 ≤ L.card ∧
+        ∀ k ∈ L, Even k ∧ ∃ c : G.Walk v₀ v₀, c.IsCycle ∧ c.length = k := by
+    intro S hST hpar
+    rcases S.eq_empty_or_nonempty with rfl | hSne
+    · exact ⟨∅, by simp, by simp⟩
+    have hmS : S.min' hSne ∈ S := S.min'_mem hSne
+    refine ⟨(S.erase (S.min' hSne)).image (fun k => k - S.min' hSne + 2), ?_, ?_⟩
+    · have hinj : Set.InjOn (fun k => k - S.min' hSne + 2) (S.erase (S.min' hSne)) := by
+        intro k₁ h₁ k₂ h₂ heq
+        have h₁' : k₁ ∈ S.erase (S.min' hSne) := h₁
+        have h₂' : k₂ ∈ S.erase (S.min' hSne) := h₂
+        have hk₁ : S.min' hSne ≤ k₁ := S.min'_le k₁ (Finset.mem_of_mem_erase h₁')
+        have hk₂ : S.min' hSne ≤ k₂ := S.min'_le k₂ (Finset.mem_of_mem_erase h₂')
+        have heq' : k₁ - S.min' hSne + 2 = k₂ - S.min' hSne + 2 := heq
+        omega
+      rw [Finset.card_image_of_injOn hinj, Finset.card_erase_of_mem hmS]
+    · intro k hk
+      obtain ⟨b, hb, rfl⟩ := Finset.mem_image.mp hk
+      have hbS : b ∈ S := Finset.mem_of_mem_erase hb
+      have hmb : S.min' hSne < b :=
+        lt_of_le_of_ne (S.min'_le b hbS) (Ne.symm (Finset.ne_of_mem_erase hb))
+      obtain ⟨c, hc, hclen⟩ := hseg (S.min' hSne) b (hST hmS) (hST hbS) hmb
+      refine ⟨?_, c, hc, hclen⟩
+      have hpar' := hpar b hbS (S.min' hSne) hmS
+      rw [Nat.even_iff]
+      omega
+  -- the majority parity class carries at least `⌈d/2⌉` trapped indices
+  have hsplit : (T.filter (fun n => n % 2 = 0)).card
+      + (T.filter (fun n => ¬ n % 2 = 0)).card = T.card :=
+    Finset.card_filter_add_card_filter_not _
+  obtain ⟨S, hSsub, hSpar, hScard⟩ :
+      ∃ S : Finset ℕ, S ⊆ T ∧ (∀ i ∈ S, ∀ j ∈ S, i % 2 = j % 2) ∧ d ≤ 2 * S.card := by
+    rcases Nat.lt_or_ge (T.filter (fun n => n % 2 = 0)).card
+        (T.filter (fun n => ¬ n % 2 = 0)).card with hcmp | hcmp
+    · refine ⟨T.filter (fun n => ¬ n % 2 = 0), Finset.filter_subset _ _, ?_, by omega⟩
+      intro i hi j hj
+      have hi' := (Finset.mem_filter.mp hi).2
+      have hj' := (Finset.mem_filter.mp hj).2
+      omega
+    · refine ⟨T.filter (fun n => n % 2 = 0), Finset.filter_subset _ _, ?_, by omega⟩
+      intro i hi j hj
+      have hi' := (Finset.mem_filter.mp hi).2
+      have hj' := (Finset.mem_filter.mp hj).2
+      omega
+  obtain ⟨L, hLcard, hL⟩ := key S hSsub hSpar
+  refine ⟨L, by omega, fun k hk => ?_⟩
+  obtain ⟨hke, c, hc, hclen⟩ := hL k hk
+  exact ⟨hke, v₀, c, hc, hclen⟩
+
+/-- Restatement in the `ContainsCycleLength` predicate: minimum degree `d` yields
+at least `⌊(d-1)/2⌋` distinct EVEN realized cycle lengths, each `≥ 4` (an even
+cycle length is automatically `≥ 4`).  Problem 64's target family
+`{2^k : k ≥ 2}` lies inside "even and `≥ 4`", so this rung counts exactly the
+sub-spectrum the open core must hit; at `d = 3` it guarantees one even length —
+sharp, by `K₄` — and the open question is whether that even sub-spectrum must
+meet the powers of two. -/
+theorem hasMinDegree_card_even_containsCycleLength
+    {W : Type*} [Fintype W] [DecidableEq W] [Nonempty W]
+    (G : SimpleGraph W) [DecidableRel G.Adj] {d : ℕ}
+    (hdeg : HasMinDegree G d) :
+    ∃ L : Finset ℕ, (d - 1) / 2 ≤ L.card ∧
+      ∀ k ∈ L, Even k ∧ 4 ≤ k ∧ ContainsCycleLength G k := by
+  obtain ⟨L, hcard, hL⟩ := hasMinDegree_card_even_cycle_lengths G hdeg
+  refine ⟨L, hcard, fun k hk => ?_⟩
+  obtain ⟨hke, v, c, hc, hlen⟩ := hL k hk
+  have h3 : 3 ≤ k := hlen ▸ hc.three_le_length
+  have h4 : 4 ≤ k := by
+    rw [Nat.even_iff] at hke
+    omega
+  exact ⟨hke, h4, hlen ▸ isCycle_containsCycleLength G c hc⟩
+
 /- ## Known Cycle Results -/
 
 /- 

--- a/research/problems/erdos-64-wip-01/knowledge.md
+++ b/research/problems/erdos-64-wip-01/knowledge.md
@@ -215,3 +215,27 @@ d = 3 it guarantees only 2 lengths, far from forcing a power of two.
 - Conceivable further rung: even-length spectrum counting (≥ ⌊(d−1)/2⌋ even lengths?)
   — the three-cycle parity trick doesn't parametrize as cleanly; assess before claiming.
 - The 2^k core stays blocked (Liu–Montgomery scale) — genuinely new mechanism required.
+
+## Session 2026-07-23b (researcher-1): even-spectrum rung (the flagged residual) DONE
+
+`hasMinDegree_card_even_cycle_lengths` + `_even_containsCycleLength`: min degree
+d forces >= floor((d-1)/2) DISTINCT even cycle lengths (each with IsCycle
+witness; bridge adds 4 <= k). SHARP for K_{d+1} (lengths 3..d+1). Simpler than
+the feared parity case analysis: majority parity class + same-parity segment
+cycles only.
+
+Mechanism notes:
+- `hseg` (extracted from the even-cycle proof's inline segment construction):
+  ANY trapped indices a < b give a v0-cycle of length b-a+2; needs only
+  1 <= a (hpos), NOT a >= 2 — the a >= 2 proviso is specific to prefix cycles.
+- Majority class: Finset.card_filter_add_card_filter_not (v4.31 name;
+  filter_card_add_filter_neg_card_eq_card is DEPRECATED); le_or_lt is GONE —
+  use Nat.lt_or_ge.
+- Counting: base = class min', image under (. - min + 2), InjOn via min'_le +
+  omega (materialize Set-coe memberships and non-beta-reduced heq as typed
+  `have`s first — same gotcha as erdos-53).
+- Evenness/4 <= k: Nat.even_iff + omega throughout.
+- No `2 <= d` hypothesis needed: (d-1)/2 <= 2*S.card arithmetic degenerates
+  gracefully (omega handles /2 by literal).
+
+Elementary layer now saturated INCLUDING the flagged residual. STAND DOWN.

--- a/research/problems/erdos-64-wip-01/state.md
+++ b/research/problems/erdos-64-wip-01/state.md
@@ -40,3 +40,34 @@ elementary component/tree arguments.
 ## Next Action
 The elementary cycle-existence layer is saturated. Only the deep power-of-2
 length question remains open.
+
+## Status (researcher-1, 2026-07-23b) — EVEN-spectrum rung landed (the flagged residual)
+
+The adversarial assessment of the "even-length spectrum count" rung came out
+POSITIVE, with a simpler mechanism than feared: no parity case analysis on
+pairs — the majority parity class of trapped neighbour indices alone suffices.
+For a < b of EQUAL parity the segment cycle has even length b - a + 2, so
+fixing a = min(class) and ranging b over the rest yields |class| - 1 >=
+ceil(d/2) - 1 = floor((d-1)/2) distinct even lengths.
+
+- `hasMinDegree_card_even_cycle_lengths`: min degree d ==> >= floor((d-1)/2)
+  distinct EVEN cycle lengths with explicit IsCycle witnesses. No d >= 2
+  hypothesis needed (bound degenerates gracefully).
+- `hasMinDegree_card_even_containsCycleLength`: bridge form, each length even,
+  >= 4, ContainsCycleLength. The target family {2^k : k >= 2} sits inside
+  "even and >= 4", so this counts exactly the sub-spectrum the open core must hit.
+- SHARP: K_{d+1} realizes cycle lengths 3..d+1, exactly floor((d-1)/2) even —
+  so at d = 3 no counting refinement beats "one even length"; the open content
+  is entirely in hitting a power of two.
+- Key extraction: `hseg` — ANY two trapped indices a < b close into a
+  b-a+2 cycle (needs only 1 <= a, unlike prefix cycles which need index >= 2).
+- File 867 -> 1096 lines, 16 -> 18 theorems, 0 axioms/sorries; both new
+  theorems #print axioms = foundational only. meta.json leanFile synced.
+
+## Final assessment
+
+The elementary layer is now saturated INCLUDING the flagged residual rung:
+existence + length bridge + parity + Dirac rung + full spectrum count + EVEN
+spectrum count (sharp). Every remaining direction requires the deep
+power-of-two-length core (Liu-Montgomery scale). Node should not be re-served
+for elementary work.

--- a/src/data/proofs/erdos-64/meta.json
+++ b/src/data/proofs/erdos-64/meta.json
@@ -316,9 +316,9 @@
       "Finset"
     ],
     "namespace": "Erdos64",
-    "lineCount": 867,
+    "lineCount": 1096,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 18,
     "definitionCount": 11,
     "path": "Proofs/Erdos64Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-64-wip-01.json
+++ b/src/data/research/problems/erdos-64-wip-01.json
@@ -21,15 +21,20 @@
     "phase": "ACT",
     "since": "2026-07-09T17:33:20-07:00",
     "iteration": 3,
-    "focus": "Dirac rung DONE (2026-07-22b): hasMinDegree_exists_cycle_length_ge — min degree d>=2 forces a cycle of length >= d+1 (longest-path engine; largest neighbour index >= d via T subset Icc 1 max + card_Icc pigeonhole). With existence, length-predicate bridge, even-cycle parity and this quantitative rung, the ELEMENTARY layer is fully saturated.",
+    "focus": "Even-spectrum rung landed (floor((d-1)/2) distinct even cycle lengths, sharp for K_{d+1}); elementary layer fully saturated including the flagged residual.",
     "blockers": [
       {
         "route": "power-of-two cycle LENGTH: every finite graph with min-degree ≥ 3 contains a cycle of length 2^k",
         "reopenCriterion": "materially new mechanism required: Liu–Montgomery-scale extremal/expansion machinery. Elementary cycle-EXISTENCE (a cycle exists at all, for every finite min-degree-≥2 graph) is COMPLETE (PRs #40522/#40874/#40917); the 2^k-length core is the open $1000 problem.",
         "blockedAt": "2026-07-21"
+      },
+      {
+        "route": "counting refinements of the longest-path engine (spectrum/parity)",
+        "reopenCriterion": "materially new mechanism required — even-spectrum count floor((d-1)/2) is sharp for K_{d+1}, so no further counting rung can constrain the d=3 case",
+        "blockedAt": "2026-07-23"
       }
     ],
-    "nextAction": "STAND DOWN at the elementary layer. Only the deep 2^k-length core remains (Liu-Montgomery scale). Do not re-claim without a genuinely new mechanism for power-of-two cycle lengths.",
+    "nextAction": "None elementary. Only the deep power-of-two-length core (Liu-Montgomery scale) remains; requires a materially new mechanism.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -37,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: cycle-spectrum counting rung proved (2026-07-23). hasMinDegree_card_cycle_lengths + ContainsCycleLength restatement: min degree d>=2 forces >= d-1 DISTINCT cycle lengths (Finset of lengths, injective +1 image of trapped indices >= 2; at most one index equals 1). Reuses the maximal-path engine; new counting content beyond the Dirac rung (which only extracts the max index). Elementary layer: existence + bridge + parity + Dirac + spectrum count. Open core unchanged: whether the spectrum of a min-degree-3 graph must meet {2^k, k>=2} (Liu-Montgomery scale).",
+    "progressSummary": "Elementary layer FULLY saturated incl. flagged residual: cycle existence (connected/general), length-predicate bridge, even cycle, Dirac rung (length >= d+1), spectrum count (>= d-1 lengths), EVEN spectrum count (>= floor((d-1)/2), sharp). Only the deep 2^k-length core (Liu-Montgomery) remains.",
     "builtItems": [
       "connected_hasMinDegree_two_not_isAcyclic (Erdos64Problem.lean): nontrivial connected graph, HasMinDegree 2 => ¬IsAcyclic. Axiom-free.",
       "connected_hasMinDegree_two_exists_cycle (Erdos64Problem.lean): same hyp => ∃ v (c : Walk v v), c.IsCycle. Axiom-free.",
@@ -50,7 +55,8 @@
       "hasMinDegree_exists_cycle_length_ge (Dirac-type: min-deg d>=2 => cycle length >= d+1) in Erdos64Problem.lean",
       "hasMinDegree_containsCycleLength_ge (ContainsCycleLength restatement) in Erdos64Problem.lean",
       "hasMinDegree_card_cycle_lengths (Erdos64Problem.lean): min-deg d>=2 => Finset S of cycle lengths, |S| >= d-1, each realized by an explicit IsCycle witness; axiom-free",
-      "hasMinDegree_card_containsCycleLength (Erdos64Problem.lean): same spectrum bound in the ContainsCycleLength predicate the conjecture uses"
+      "hasMinDegree_card_containsCycleLength (Erdos64Problem.lean): same spectrum bound in the ContainsCycleLength predicate the conjecture uses",
+      "Erdos64Problem.lean: hasMinDegree_card_even_cycle_lengths + hasMinDegree_card_even_containsCycleLength (even sub-spectrum count, sharp), hseg segment-cycle extraction. 16->18 theorems, 867->1096 lines, 0 axioms."
     ],
     "insights": [
       "A finite nontrivial TREE has a leaf (degree-1 vertex): Mathlib SimpleGraph.IsTree.minDegree_eq_one_of_nontrivial. Hence a connected graph with min degree >= 2 cannot be a tree, so cannot be acyclic — the elementary base fact under Erdos #64.",
@@ -61,7 +67,8 @@
       "Parity middle layer between cycle-existence and the deep 2^k core: min-degree-3 forces an EVEN cycle, via the classical longest-path argument. Take a maximum-length path from v0; maximality traps all >=3 neighbours of v0 on the path at distinct positive indices; the two largest indices a<b (a>=2) give three cycles of lengths a+1, b+1, b-a+2 summing to 2b+4 (even), so one is even.",
       "Lean mechanism for maximal paths: Nat.sSup_mem on {n | exists path of length n} (nonempty via Walk.nil, BddAbove via IsPath.length_lt), then le_csSup for maximality. No dedicated Mathlib longest-path API exists.",
       "Key Mathlib toolkit for index arithmetic on paths: Walk.getVert_length_takeUntil (vertex at index = takeUntil length), Walk.length_takeUntil (= support.idxOf), Walk.dropUntil_eq_drop + Walk.drop_getVert + Walk.getVert_copy (getVert of suffix), IsPath.getVert_injOn (injectivity on indices <= length), IsPath.eq_snd_of_mem_edges (an edge of a path through its start is the first edge - closes the takeUntil prefix into a cycle).",
-      "Cycle-spectrum counting rung: the maximal-path engine yields a cycle at EVERY trapped neighbour index >= 2, and distinct indices give distinct lengths — so min degree d forces >= d-1 distinct cycle lengths. Elementary end of the spectrum view: Liu-Montgomery resolves large min-degree via spectrum density hitting a power of two."
+      "Cycle-spectrum counting rung: the maximal-path engine yields a cycle at EVERY trapped neighbour index >= 2, and distinct indices give distinct lengths — so min degree d forces >= d-1 distinct cycle lengths. Elementary end of the spectrum view: Liu-Montgomery resolves large min-degree via spectrum density hitting a power of two.",
+      "Even-spectrum count: majority parity class of trapped neighbour indices + same-parity segment cycles (length b-a+2) give floor((d-1)/2) distinct even cycle lengths from min degree d — SHARP for K_{d+1} (cycle lengths 3..d+1). Segment cycles need only 1 <= a < b, unlike prefix cycles (index >= 2). At d=3 this means exactly one guaranteed even length; the entire open content is pinning it to a power of two."
     ],
     "mathlibGaps": [
       "No general (disconnected/forest) leaf lemma: Mathlib only has IsTree.minDegree_eq_one_of_nontrivial (connected). A forest edge-count bound #edges <= n-1 is also absent (only IsTree.card_edgeFinset).",
@@ -93,7 +100,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.782Z",
-  "lastUpdate": "2026-07-22",
+  "lastUpdate": "2026-07-23T00:00:00.000Z",
   "significance": 8,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary
Research session for erdos-64-wip-01 (Erdős Problem #64, $1000: does min degree 3 force a 2^k-cycle?). Lands the one flagged residual elementary rung: the **even-length cycle spectrum count**.

## Progress
- `hasMinDegree_card_even_cycle_lengths`: minimum degree d forces at least ⌊(d−1)/2⌋ **distinct even cycle lengths**, each realized by an explicit `Walk.IsCycle` witness.
- `hasMinDegree_card_even_containsCycleLength`: bridge form — each length is even, ≥ 4, and realized in the `ContainsCycleLength` predicate the conjecture uses. The target family {2^k : k ≥ 2} lies inside "even and ≥ 4", so this counts exactly the sub-spectrum the open core must hit.
- Mechanism: majority parity class of the trapped neighbour indices (longest-path engine), closed pairwise by same-parity **segment cycles** of length b−a+2 (extracted as a parametrized `hseg`; unlike prefix cycles it needs only 1 ≤ a < b, no index ≥ 2 proviso).
- Files: `proofs/Proofs/Erdos64Problem.lean` (867 → 1096 lines, 16 → 18 theorems, 0 axioms, 0 sorries; both new theorems `#print axioms` = propext/Classical.choice/Quot.sound), gallery meta leanFile synced, tracker/state/knowledge updated.
- Host-verified on v4.31.0: `lake env lean Proofs/Erdos64Problem.lean` exit 0, no warnings.

## Findings
- The bound is **sharp**: K_{d+1} has minimum degree d and cycle lengths exactly 3…d+1, hence exactly ⌊(d−1)/2⌋ even ones. At d = 3 this means no counting refinement of the longest-path engine can guarantee more than one even cycle length — the open content is entirely in pinning an even length to a power of two (Liu–Montgomery scale). Recorded as a blocked route ("counting refinements of the longest-path engine", reopen bar: materially new mechanism).
- The adversarially flagged fear (parity trick doesn't parametrize) dissolved: no pairwise parity case analysis is needed, only the majority class.

## Status
**Outcome**: progress — elementary layer now saturated *including* the flagged residual rung; node should not be re-served for elementary work.
**Next Steps**: none elementary; only the deep power-of-two-length core remains.

🤖 Generated by researcher-1
