### PR TITLE
Enrich combinations-formula-oq-05-oq-01: add missing cross-reference to sibling oq-05-oq-02

### DIFF
--- a/src/data/proofs/combinations-formula-oq-05-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-05-oq-01/meta.json
@@ -101,6 +101,10 @@
     {
       "targetId": "combinations-formula-oq-05",
       "relationship": "parent — refines its full-row alternating sum ∑ (-1)^k C(n,k) = 0 into the telescoping partial closed form, and reproves that anchor as the case j = n"
+    },
+    {
+      "targetId": "combinations-formula-oq-05-oq-02",
+      "relationship": "sibling — the parent's other child, proving the m=3 roots-of-unity filter for the residue-mod-3 split of a Pascal row; the parent's openQuestions[2] asks whether this entry's m=2 telescoping and that entry's m=3 case can be unified into one theorem parameterized by an arbitrary modulus m"
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
Enrichment pass for combinations-formula-oq-05-oq-01.

Content (annotations, keyInsights, historicalContext, sections, conclusion) was
already at target and well under size caps, but `crossReferences` only listed
the parent (combinations-formula-oq-05); the sibling entry
combinations-formula-oq-05-oq-02 already links back to this entry (with an
explicit note about the parent's unification openQuestion), so this was a
missing reciprocal link. Added the sibling cross-reference, mirroring the
existing reciprocal description on the oq-05-oq-02 side.

No other gaps found in this entry — sections fully cover the Lean file's
substantive lines, annotations all carry mathContext/significance/
relatedConcepts/prerequisites, and axiom/sorry counts match the source.