### PR TITLE
Audit erdos-575: fix phantom "axiomatized as True" narrative

### DIFF
--- a/src/data/proofs/erdos-575/annotations.json
+++ b/src/data/proofs/erdos-575/annotations.json
@@ -99,7 +99,7 @@
     },
     "type": "insight",
     "title": "Erdős–Simonovits Conjecture (Problem #575)",
-    "content": "The main conjecture: for any finite family F containing a bipartite graph, some bipartite G ∈ F has ex(n; G) = O(ex(n; F)). Axiomatized as True because the full formal statement requires graph homomorphism machinery not yet available in Mathlib. The conjecture is open in general, though verified for special families (e.g., when F consists of complete bipartite graphs).",
+    "content": "The main conjecture: for any finite family F containing a bipartite graph, some bipartite G ∈ F has ex(n; G) = O(ex(n; F)). Stated only as a documentation comment in the Lean file, not as an axiom, definition, or theorem — the full formal statement requires graph homomorphism machinery not yet available in Mathlib. The conjecture is open in general, though verified for special families (e.g., when F consists of complete bipartite graphs).",
     "mathContext": "The conjecture asserts $\\exists G \\in \\mathcal{F},\\; G$ bipartite, such that $\\mathrm{ex}(n; G) = O(\\mathrm{ex}(n; \\mathcal{F}))$. Equivalently, the bipartite members of $\\mathcal{F}$ determine the order of magnitude of $\\mathrm{ex}(n; \\mathcal{F})$, and moreover a single one suffices.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-575/meta.json
+++ b/src/data/proofs/erdos-575/meta.json
@@ -65,7 +65,7 @@
       "title": "Main Conjecture",
       "startLine": 53,
       "endLine": 67,
-      "summary": "States the Erdős–Simonovits conjecture (Problem #575): for any finite family F containing a bipartite graph, some bipartite member G ∈ F satisfies ex(n; G) = O(ex(n; F)). Axiomatized as True due to the complexity of formalizing graph homomorphisms."
+      "summary": "States the Erdős–Simonovits conjecture (Problem #575): for any finite family F containing a bipartite graph, some bipartite member G ∈ F satisfies ex(n; G) = O(ex(n; F)). Stated only as a documentation comment, not as a Lean axiom, definition, or theorem — the conjecture is not formalized and remains open."
     },
     {
       "id": "context",


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-575 (Bipartite Turán Numbers Dominate)

**Problem**: The `conjecture` section summary in `meta.json` and the matching
annotation in `annotations.json` claimed the Erdős–Simonovits conjecture was
"axiomatized as True due to the complexity of formalizing graph homomorphisms."
The actual Lean file (`Proofs/Erdos575Problem.lean`) contains no such
axiom/def/theorem for the conjecture at all — it is stated purely as a
docstring comment (lines ~55-64), never as a Lean declaration.

## Evidence

- `grep -n "axiom\|sorry" proofs/Proofs/Erdos575Problem.lean` → no matches.
- Top-level fields are already honest: `status: "axiomatized"`, `badge: "wip"`,
  `axiomCount: 0`, `sorries: 0`, and `assumptions` correctly states "Previously
  cited axiom names have been removed from the Lean source."
- Only the nested section/annotation prose retained the stale "axiomatized as
  True" narrative from before that removal.

## Fix

Reworded both the `meta.json` section summary and the `annotations.json`
insight to state the conjecture is documented only as a comment, not declared
as a Lean axiom/def/theorem, and remains unformalized/open. No change to
status, badge, or counts — those were already correct.

---
Discovered during gallery integrity reserve re-audit (queue fully drained,
round-robin re-serve of oldest entries).