### PR TITLE
Record erdos-575 audit completion in tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14727,9 +14727,9 @@
     },
     "erdos-575": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:43Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T01:40:16Z",
+      "result": "issues-fixed"
     },
     "erdos-576": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
PR #42833 fixed the phantom "axiomatized as True" narrative for erdos-575, but the `audit-tracker.json` completion record was left uncommitted in the shared checkout and would have been lost on the next `git reset --hard origin/main`. This restores the tracker entry (auditCount 4→5, result: issues-fixed) so `find-targets` doesn't re-serve it as stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)