### PR TITLE
Enrich abel-ruffini-oq-11: split single-equations section (4->5)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-11/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-11/meta.json
@@ -65,11 +65,20 @@
       "mathContext": "Galois' criterion: an equation is solvable by radicals iff its Galois group is a solvable group."
     },
     {
-      "id": "single-equations",
-      "title": "Single Pure Equations",
+      "id": "pure-power-equation",
+      "title": "A Single Pure Equation is Solvable",
       "startLine": 42,
+      "endLine": 46,
+      "summary": "gal_pow_sub_C_isSolvable re-exposes Mathlib's gal_X_pow_sub_C_isSolvable: Xⁿ = a has solvable Galois group for every n and every a — extracting one radical never destroys solvability. This is the base case the finite-product closure inducts on.",
+      "mathContext": "$\\mathrm{IsSolvable}\\,(X^n - C\\,a).\\mathrm{Gal}$ for every $n : \\mathbb{N}$, $a \\in F$."
+    },
+    {
+      "id": "roots-of-unity",
+      "title": "Roots of Unity are Solvable",
+      "startLine": 47,
       "endLine": 56,
-      "summary": "gal_pow_sub_C_isSolvable: Xⁿ = a has solvable Galois group (one root extraction never destroys solvability). gal_pow_sub_one_isSolvable: the n-th roots of unity Xⁿ = 1 likewise (abelian, hence solvable)."
+      "summary": "gal_pow_sub_one_isSolvable re-exposes Mathlib's gal_X_pow_sub_one_isSolvable: the n-th roots of unity Xⁿ = 1 have solvable (indeed abelian) Galois group — the other single-equation building block, distinct from the general Xⁿ = a case above since the splitting field here is abelian over F.",
+      "mathContext": "$\\mathrm{IsSolvable}\\,(X^n - 1).\\mathrm{Gal}$; the Galois group of the cyclotomic-type extension is abelian, hence solvable."
     },
     {
       "id": "finite-product-closure",


### PR DESCRIPTION
Quality 98->100 (sections bucket 8/10 -> 10/10).

Splits the "single-equations" section (lines 42-56) into its two natural theorem boundaries:
- `gal_pow_sub_C_isSolvable` — the general pure power equation Xn = a
- `gal_pow_sub_one_isSolvable` — roots of unity Xn = 1 (abelian splitting field)

These were bundled into one section despite being genuinely distinct results (general vs. abelian Galois group). No content deleted; existing keyInsights/crossReferences/conclusion untouched.