### PR TITLE
Research: issue-41831 (A054656) - COMPLETE: 25-year OEIS conjecture fully machine-checked, 0 sorries 0 axioms

### DIFF
--- a/proofs/Proofs/A054656DistinctPrimePartition.lean
+++ b/proofs/Proofs/A054656DistinctPrimePartition.lean
@@ -9,11 +9,12 @@ none equal to `p`; the only non-representable residuals are `m ∈ {1, 4, 6}`.
 
 Source: OEIS A054656 (created April 2000, still labeled conjectural). An
 AI-claimed elementary proof (GPT-5.6 Pro) is the subject of GitHub issue #41831.
-This file turns the elementary core into machine-checked Lean and scaffolds the
-harder engine (seed block + interval-extension + Bertrand/Ramanujan induction)
-behind clearly-marked `sorry`s.
+This file turns the whole statement into machine-checked Lean: the elementary
+core, the Richert interval engine (seed block + bounded fresh-prime extension +
+Bertrand induction), and — via `Proofs/A054656TwoPrimesInterval.lean` — the
+Ramanujan-type two-primes-in-`(x, 2x]` input. **0 sorries, 0 axioms.**
 
-## Status of this file (second iteration, 2026-07-23)
+## Status of this file (fourth iteration, 2026-07-23): COMPLETE — 0 sorries
 
 VERIFIED (kernel `decide` only — no `native_decide`):
   * `not_repr_one`, `not_repr_four`, `not_repr_six`
@@ -21,37 +22,36 @@ VERIFIED (kernel `decide` only — no `native_decide`):
   * `present_iff_residual_repr`
       — the reduction: `p` present in `n` ↔ `p` prime, `p ≤ n`, and `n − p`
         is a sum of distinct primes avoiding `p`.
-  * `residual_avoiding_imp_repr` — an avoiding representation is a representation.
-  * `seed_block` (NEW) — the window `[13, 90]` (`B − A = 77 ≥ 64`) is
-    representable avoiding any single prime, via the `canSum` kernel subset-sum
-    checker over the eleven primes `≤ 31` (soundness bridge `canSum_sound`).
-  * `reprAvoiding_add_prime` (NEW) — the top-down fresh-prime extension step,
-    REPLACING the first iteration's `interval_extension`, whose hypotheses
-    (`B < q` and `q ≤ B − A + 1`) were jointly unsatisfiable (they force
-    `A = 0`, and `1` is never representable) — that engine was vacuous.
+  * `seed_block_bdd` / `seed_block` — the window `[13, 90]` is representable
+    avoiding any single prime, with all witness primes `≤ 31`, via the
+    `canSum` kernel subset-sum checker (soundness bridge `canSum_sound`).
+  * `reprAvoidingBdd_add_fresh` — sound fresh-prime extension for *bounded*
+    representations (a prime above the bound is automatically fresh).
+  * **Richert interval induction (NEW, third iteration)**: `EngineInv` /
+    `engineInv_step` / `engineInv_reach` — the interval `[13, B]` with witness
+    bound `Q` and slack `2Q + 12 ≤ B` grows without bound, one Bertrand prime
+    at a time; hence `reprAvoiding_of_thirteen_le` (every `m ≥ 13` is a sum of
+    distinct primes avoiding `p`).
+  * `repr_of_ge_seven_ne` (NEW: PROVED) — every residual `m ≥ 2`,
+    `m ∉ {4, 6}`, with `23 ≤ m + p`, is representable avoiding `p`
+    (small `m ≤ 12` by explicit witnesses, `m ≥ 13` by the engine).
+  * `A054656_main` (NEW: ASSEMBLED) — the main theorem for `n ≥ 23`.
 
-SCAFFOLDED (`sorry`, deferred):
-  * `repr_of_ge_seven_ne` — every residual with `23 ≤ m + p` is representable
-    avoiding `p`.  Statement REPAIRED this iteration: without `23 ≤ m + p` it
-    was FALSE — counterexamples `(m, p)` = `(2,2), (3,3), (8,3), (9,2), (10,3),
-    (11,11), (12,7)`, all with `m + p < 23` (see docstring).
-  * `A054656_main` — the main theorem for `n ≥ 23`.
-
-## Mathlib gap (identified this iteration)
-
-Mathlib HAS Bertrand's postulate:
-  `Nat.exists_prime_lt_and_le_two_mul (n) (hn0 : n ≠ 0) :`
-  `  ∃ p, Nat.Prime p ∧ n < p ∧ p ≤ 2 * n`
-(`Mathlib/NumberTheory/Bertrand.lean`, alias `Nat.bertrand`).
-
-Mathlib does NOT have any Ramanujan-prime result. The proof sketch needs
-"`(q, 2q]` contains at least TWO primes" (second Ramanujan prime `R₂ = 11`), so
-that after deleting the single forbidden prime `p` an available prime `≤ 2q`
-still remains. That two-primes-in-`(q,2q]` lemma must be BUILT on top of
-`Nat.exists_prime_lt_and_le_two_mul` — it is the key missing ingredient.
+  * `exists_second_prime_in_Ioc` (FOURTH ITERATION: the former single `sorry`,
+    now PROVED) — "`(x, 2x]` containing a prime `p` contains a second prime
+    `q ≠ p`" (equivalently: at least TWO primes in `(x, 2x]` for `x ≥ 11`,
+    i.e. the second Ramanujan prime `R₂ = 11`). Mathlib has only Bertrand
+    (`Nat.exists_prime_lt_and_le_two_mul`, ONE prime in `(x, 2x]`); the
+    two-prime version is proved in `Proofs/A054656TwoPrimesInterval.lean`
+    (imported below) by re-running Mathlib's Bertrand central binomial
+    analysis with one permitted prime removed, plus a descending prime-pair
+    chain for `x < 512`. Kernel-only; no `axiom`, no `native_decide`.
+    It enters the engine only through `bertrand_avoiding`, and only in the
+    collision case `x < p ≤ 2x` (for `p ∉ (x, 2x]` plain Bertrand suffices).
 -/
 
 import Mathlib
+import Proofs.A054656TwoPrimesInterval
 
 namespace A054656
 
@@ -247,13 +247,72 @@ theorem checkWindow_sound {l : List ℕ} {A B m : ℕ} (h : checkWindow l A B = 
   have hall := List.all_eq_true.mp h _ hi
   simpa [Nat.add_sub_cancel' h1] using hall
 
-/-- Packaged seed case: a duplicate-free list of primes avoiding `p` whose
-`checkWindow` certificate covers `[13, 90]` yields the seed interval. -/
+/-- Bounded avoiding representation (third iteration): a distinct-prime
+representation of `m` avoiding `avoid` whose witness primes are all `≤ bound`.
+The bound is what makes the bottom-up Richert interval induction sound: a
+freshly added prime strictly above the bound can never collide with the
+witness, so no Ramanujan-style "second prime" is needed for *freshness* —
+only for the prime *supply* when the forbidden prime blocks the Bertrand
+window (see `exists_second_prime_in_Ioc`). -/
+def ReprAvoidingBdd (m avoid bound : ℕ) : Prop :=
+  ∃ S : Finset ℕ, (∀ q ∈ S, Nat.Prime q) ∧ avoid ∉ S ∧ (∀ q ∈ S, q ≤ bound) ∧
+    S.sum id = m
+
+/-- Forgetting the bound. -/
+theorem reprAvoiding_of_bdd {m p b : ℕ} (h : ReprAvoidingBdd m p b) :
+    ReprAvoiding m p := by
+  obtain ⟨S, h1, h2, _, h4⟩ := h
+  exact ⟨S, h1, h2, h4⟩
+
+/-- The bound is monotone. -/
+theorem reprAvoidingBdd_mono {m p b b' : ℕ} (hb : b ≤ b')
+    (h : ReprAvoidingBdd m p b) : ReprAvoidingBdd m p b' := by
+  obtain ⟨S, h1, h2, h3, h4⟩ := h
+  exact ⟨S, h1, h2, fun q hq => le_trans (h3 q hq) hb, h4⟩
+
+/-- Fresh-prime extension for bounded representations: a prime `q` strictly
+above the bound is automatically absent from the witness, so it can always be
+added. This is the sound replacement for interval-extension freshness. -/
+theorem reprAvoidingBdd_add_fresh {m p b q : ℕ} (hq : Nat.Prime q)
+    (hqp : q ≠ p) (hbq : b < q) (h : ReprAvoidingBdd m p b) :
+    ReprAvoidingBdd (m + q) p q := by
+  obtain ⟨S, h1, h2, h3, h4⟩ := h
+  have hqS : q ∉ S := fun hmem => absurd (h3 q hmem) (by omega)
+  refine ⟨insert q S, ?_, ?_, ?_, ?_⟩
+  · intro x hx
+    rcases Finset.mem_insert.mp hx with rfl | hx
+    · exact hq
+    · exact h1 x hx
+  · intro hmem
+    rcases Finset.mem_insert.mp hmem with h | h
+    · exact hqp h.symm
+    · exact h2 h
+  · intro x hx
+    rcases Finset.mem_insert.mp hx with rfl | hx
+    · exact le_rfl
+    · exact le_trans (h3 x hx) (le_of_lt hbq)
+  · rw [Finset.sum_insert hqS, h4]
+    simp only [id_eq]
+    omega
+
+/-- Lift a `canSum` certificate over a list of primes not containing `p`, all
+`≤ b`, to a bounded `ReprAvoidingBdd` witness. -/
+theorem reprAvoidingBdd_of_canSum {l : List ℕ} {m p b : ℕ} (hnd : l.Nodup)
+    (hprime : ∀ q ∈ l, Nat.Prime q) (hp : p ∉ l) (hb : ∀ q ∈ l, q ≤ b)
+    (h : canSum l m = true) : ReprAvoidingBdd m p b := by
+  obtain ⟨S, hSl, hsum⟩ := canSum_sound hnd h
+  exact ⟨S, fun q hq => hprime q (hSl q hq), fun hpS => hp (hSl p hpS),
+    fun q hq => hb q (hSl q hq), hsum⟩
+
+/-- Packaged seed case: a duplicate-free list of primes avoiding `p`, all
+`≤ 31`, whose `checkWindow` certificate covers `[13, 90]` yields the bounded
+seed interval. -/
 private theorem seed_case {p : ℕ} (l : List ℕ) (hnd : l.Nodup)
-    (hprime : ∀ q ∈ l, Nat.Prime q) (hp : p ∉ l)
+    (hprime : ∀ q ∈ l, Nat.Prime q) (hp : p ∉ l) (hb : ∀ q ∈ l, q ≤ 31)
     (hwin : checkWindow l 13 90 = true) :
-    ∀ m, 13 ≤ m → m ≤ 90 → ReprAvoiding m p :=
-  fun _ h1 h2 => reprAvoiding_of_canSum hnd hprime hp (checkWindow_sound hwin h1 h2)
+    ∀ m, 13 ≤ m → m ≤ 90 → ReprAvoidingBdd m p 31 :=
+  fun _ h1 h2 => reprAvoidingBdd_of_canSum hnd hprime hp hb
+    (checkWindow_sound hwin h1 h2)
 
 /-- **Seed block (PROVED, second iteration).** The single window `[13, 90]`
 (length `78`, so `B − A = 77 ≥ 64`) is representable avoiding any prime `p`:
@@ -261,36 +320,42 @@ if `p` is one of the eleven pool primes, the ten remaining pool primes suffice
 (checked by kernel `decide` through `canSum`); if `p` is outside the pool, the
 full pool works (its elements are `≤ 31`, so none equals `p` — `p ∉ seedPool`
 is exactly the case hypothesis).  Kernel `decide` only — no `native_decide`,
-no `Finset.powerset` blow-up. -/
-theorem seed_block (p : ℕ) (hp : Nat.Prime p) :
-    ∃ A B : ℕ, 64 ≤ B - A ∧ ∀ m, A ≤ m → m ≤ B → ReprAvoiding m p := by
-  refine ⟨13, 90, by norm_num, ?_⟩
+no `Finset.powerset` blow-up.  Third iteration: strengthened to the *bounded*
+form (all witness primes `≤ 31`), which the Richert interval induction
+requires; the original existential form survives as `seed_block` below. -/
+theorem seed_block_bdd (p : ℕ) :
+    ∀ m, 13 ≤ m → m ≤ 90 → ReprAvoidingBdd m p 31 := by
   by_cases hmem : p ∈ seedPool
   · simp only [seedPool, List.mem_cons, List.not_mem_nil, or_false] at hmem
     rcases hmem with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
     · exact seed_case [3, 5, 7, 11, 13, 17, 19, 23, 29, 31]
-        (by decide) (by decide) (by decide) (by decide)
+        (by decide) (by decide) (by decide) (by decide) (by decide)
     · exact seed_case [2, 5, 7, 11, 13, 17, 19, 23, 29, 31]
-        (by decide) (by decide) (by decide) (by decide)
+        (by decide) (by decide) (by decide) (by decide) (by decide)
     · exact seed_case [2, 3, 7, 11, 13, 17, 19, 23, 29, 31]
-        (by decide) (by decide) (by decide) (by decide)
+        (by decide) (by decide) (by decide) (by decide) (by decide)
     · exact seed_case [2, 3, 5, 11, 13, 17, 19, 23, 29, 31]
-        (by decide) (by decide) (by decide) (by decide)
+        (by decide) (by decide) (by decide) (by decide) (by decide)
     · exact seed_case [2, 3, 5, 7, 13, 17, 19, 23, 29, 31]
-        (by decide) (by decide) (by decide) (by decide)
+        (by decide) (by decide) (by decide) (by decide) (by decide)
     · exact seed_case [2, 3, 5, 7, 11, 17, 19, 23, 29, 31]
-        (by decide) (by decide) (by decide) (by decide)
+        (by decide) (by decide) (by decide) (by decide) (by decide)
     · exact seed_case [2, 3, 5, 7, 11, 13, 19, 23, 29, 31]
-        (by decide) (by decide) (by decide) (by decide)
+        (by decide) (by decide) (by decide) (by decide) (by decide)
     · exact seed_case [2, 3, 5, 7, 11, 13, 17, 23, 29, 31]
-        (by decide) (by decide) (by decide) (by decide)
+        (by decide) (by decide) (by decide) (by decide) (by decide)
     · exact seed_case [2, 3, 5, 7, 11, 13, 17, 19, 29, 31]
-        (by decide) (by decide) (by decide) (by decide)
+        (by decide) (by decide) (by decide) (by decide) (by decide)
     · exact seed_case [2, 3, 5, 7, 11, 13, 17, 19, 23, 31]
-        (by decide) (by decide) (by decide) (by decide)
+        (by decide) (by decide) (by decide) (by decide) (by decide)
     · exact seed_case [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
-        (by decide) (by decide) (by decide) (by decide)
-  · exact seed_case seedPool (by decide) (by decide) hmem (by decide)
+        (by decide) (by decide) (by decide) (by decide) (by decide)
+  · exact seed_case seedPool (by decide) (by decide) hmem (by decide) (by decide)
+
+theorem seed_block (p : ℕ) (_hp : Nat.Prime p) :
+    ∃ A B : ℕ, 64 ≤ B - A ∧ ∀ m, A ≤ m → m ≤ B → ReprAvoiding m p :=
+  ⟨13, 90, by norm_num,
+    fun m h1 h2 => reprAvoiding_of_bdd (seed_block_bdd p m h1 h2)⟩
 
 /-- **Fresh-prime extension step (REPAIRED + PROVED, second iteration).**
 Replaces the first iteration's `interval_extension`, whose hypotheses were
@@ -318,6 +383,92 @@ theorem reprAvoiding_add_prime {p r q : ℕ} (hq : Nat.Prime q) (hqp : q ≠ p)
     simp only [id_eq]
     omega
 
+/-! ## The Richert interval induction (third iteration)
+
+Bottom-up engine: maintain an interval `[13, B]` of residuals representable
+avoiding `p` with all witness primes `≤ Q`, plus the slack `2Q + 12 ≤ B`.
+Each step adds one fresh prime `q ∈ (Q, 2Q]` with `q ≠ p`, extending the
+interval to `[13, B + q]` (the new segment `(B, B + q]` decomposes as
+`(m − q) + q` with `m − q ∈ [13, B]`, and `q` is fresh because it exceeds the
+old bound `Q`). The slack self-maintains: `2q + 12 ≤ B + q ⇔ q + 12 ≤ B`,
+which follows from `q ≤ 2Q ≤ B − 12`.
+
+The prime supply `q ∈ (Q, 2Q]`, `q ≠ p` is Bertrand **except** when the
+forbidden prime `p` is itself the only Bertrand witness — i.e. when
+`Q < p ≤ 2Q`. Dodging it needs a *second* prime in `(Q, 2Q]`: the
+Ramanujan-type strengthening (second Ramanujan prime `R₂ = 11`) that Mathlib
+does not have. That single statement, in its sharpest needed form, is proved
+in `Proofs/A054656TwoPrimesInterval.lean` and imported here. -/
+
+/- **Second prime in `(x, 2x]` (Ramanujan-type; formerly this file's single
+remaining `sorry`).** Now PROVED in `Proofs/A054656TwoPrimesInterval.lean`
+(imported above), which supplies `A054656.exists_second_prime_in_Ioc` with
+exactly the signature the engine needs: when a prime `p` lies in `(x, 2x]`
+with `x ≥ 11`, the window contains another prime `q ≠ p`. The proof re-runs
+Mathlib's Bertrand central-binomial analysis with one permitted prime of
+factorization exponent ≤ 1 removed (threshold `512`), then descends through
+an explicit prime-pair chain `521,523 → 269,271 → … → 17,19` with small-case
+witnesses down to `x = 6`. Kernel-only: no `axiom`, no `native_decide`. -/
+
+/-- **Bertrand avoiding one prime.** For `x ≥ 11` there is a prime
+`q ∈ (x, 2x]` with `q ≠ p`. Proved from plain Bertrand except in the
+collision case `x < p ≤ 2x`, which is delegated to
+`exists_second_prime_in_Ioc`. -/
+theorem bertrand_avoiding (x p : ℕ) (hx : 11 ≤ x) :
+    ∃ q, Nat.Prime q ∧ q ≠ p ∧ x < q ∧ q ≤ 2 * x := by
+  obtain ⟨q, hq, hxq, hq2x⟩ :=
+    Nat.exists_prime_lt_and_le_two_mul x (by omega)
+  by_cases hqp : q = p
+  · subst hqp
+    exact exists_second_prime_in_Ioc x q hx hq hxq hq2x
+  · exact ⟨q, hq, hqp, hxq, hq2x⟩
+
+/-- Engine invariant: every `m ∈ [13, B]` has a `p`-avoiding representation
+by primes `≤ Q`, with slack `2Q + 12 ≤ B` (so the next Bertrand prime
+`q ≤ 2Q` satisfies `q ≤ B − 12` and the extended segment's residuals stay
+`≥ 13`), and `11 ≤ Q` (so Bertrand applies). -/
+def EngineInv (p Q B : ℕ) : Prop :=
+  11 ≤ Q ∧ 2 * Q + 12 ≤ B ∧
+    ∀ m, 13 ≤ m → m ≤ B → ReprAvoidingBdd m p Q
+
+/-- Base state: the kernel-verified seed `[13, 90]` with bound `31`
+(`2·31 + 12 = 74 ≤ 90`). -/
+theorem engineInv_base (p : ℕ) : EngineInv p 31 90 :=
+  ⟨by norm_num, by norm_num, fun m h1 h2 => seed_block_bdd p m h1 h2⟩
+
+/-- Engine step: one fresh prime extends the interval by at least 12. -/
+theorem engineInv_step {p Q B : ℕ} (h : EngineInv p Q B) :
+    ∃ Q' B', B + 12 ≤ B' ∧ EngineInv p Q' B' := by
+  obtain ⟨hQ11, hQB, hcov⟩ := h
+  obtain ⟨q, hqprime, hqp, hQq, hq2Q⟩ := bertrand_avoiding Q p hQ11
+  refine ⟨q, B + q, by omega, by omega, by omega, ?_⟩
+  intro m h13 hm
+  by_cases hmB : m ≤ B
+  · exact reprAvoidingBdd_mono (le_of_lt hQq) (hcov m h13 hmB)
+  · have hr : ReprAvoidingBdd (m - q) p Q :=
+      hcov (m - q) (by omega) (by omega)
+    have hext := reprAvoidingBdd_add_fresh hqprime hqp hQq hr
+    have hmq : m - q + q = m := by omega
+    rwa [hmq] at hext
+
+/-- Iterating the engine reaches arbitrarily large intervals. -/
+theorem engineInv_reach (p : ℕ) :
+    ∀ k : ℕ, ∃ Q B, 90 + 12 * k ≤ B ∧ EngineInv p Q B := by
+  intro k
+  induction k with
+  | zero => exact ⟨31, 90, by norm_num, engineInv_base p⟩
+  | succ n ih =>
+    obtain ⟨Q, B, hB, hinv⟩ := ih
+    obtain ⟨Q', B', hB', hinv'⟩ := engineInv_step hinv
+    exact ⟨Q', B', by omega, hinv'⟩
+
+/-- **Every `m ≥ 13` is a sum of distinct primes avoiding `p`** — the
+engine's headline, fully machine-checked. -/
+theorem reprAvoiding_of_thirteen_le (p m : ℕ) (h13 : 13 ≤ m) :
+    ReprAvoiding m p := by
+  obtain ⟨Q, B, hB, hinv⟩ := engineInv_reach p m
+  exact reprAvoiding_of_bdd (hinv.2.2 m h13 (by omega))
+
 /-- **Every large-enough residual is representable avoiding `p` (DEFERRED;
 statement REPAIRED, second iteration).**  The first iteration omitted the
 hypothesis `23 ≤ m + p`, making the statement FALSE: e.g. `¬ReprAvoiding 8 3`
@@ -327,26 +478,99 @@ partition), `¬ReprAvoiding 10 3` (`10 = 2+3+5 = 3+7`), `¬ReprAvoiding 11 11`
 (`11` itself is the only partition), `¬ReprAvoiding 12 7` (`12 = 5+7 = 2+3+7`),
 and the degenerate `(m, p) ∈ {(2,2), (3,3)}`.  All counterexamples have
 `m + p < 23`; in the application `m = n − p` with `n ≥ 23`, so `23 ≤ m + p`
-always holds.  Combines `seed_block`, `reprAvoiding_add_prime`, and the
-Bertrand/Ramanujan induction; the Ramanujan step ("`(q, 2q]` has ≥ 2 primes")
-is the piece not yet in Mathlib — it must be built on
-`Nat.exists_prime_lt_and_le_two_mul`. -/
+always holds.  PROVED (third iteration): `m ≥ 13` is the Richert engine
+(`reprAvoiding_of_thirteen_le`); `m ≤ 12` forces `p ≥ 11`, so the explicit
+small witnesses (`{2}, {3}, {5}, {7}, {3,5}, {2,7}, {3,7}, {11}, {5,7}`)
+avoid `p` outright.  Fully machine-checked (the Ramanujan-type input
+`exists_second_prime_in_Ioc` is proved in the imported file). -/
 theorem repr_of_ge_seven_ne (m p : ℕ) (hp : Nat.Prime p)
     (hm : 2 ≤ m) (hne : m ≠ 4 ∧ m ≠ 6) (hnp : 23 ≤ m + p) :
     ReprAvoiding m p := by
-  sorry
+  by_cases h13 : 13 ≤ m
+  · exact reprAvoiding_of_thirteen_le p m h13
+  · -- `m ≤ 12`, so `p ≥ 23 − m ≥ 11`; explicit small witnesses avoid `p`.
+    have h12 : m ≤ 12 := by omega
+    have hp2 : 2 ≤ p := hp.two_le
+    have hpne12 : p ≠ 12 := by rintro rfl; exact absurd hp (by decide)
+    obtain ⟨hne4, hne6⟩ := hne
+    interval_cases m
+    · -- m = 2, p ≥ 21
+      exact ⟨{2}, by decide, by simp only [Finset.mem_singleton]; omega,
+        by decide⟩
+    · -- m = 3, p ≥ 20
+      exact ⟨{3}, by decide, by simp only [Finset.mem_singleton]; omega,
+        by decide⟩
+    · exact absurd rfl hne4
+    · -- m = 5, p ≥ 18
+      exact ⟨{5}, by decide, by simp only [Finset.mem_singleton]; omega,
+        by decide⟩
+    · exact absurd rfl hne6
+    · -- m = 7, p ≥ 16
+      exact ⟨{7}, by decide, by simp only [Finset.mem_singleton]; omega,
+        by decide⟩
+    · -- m = 8 = 3 + 5, p ≥ 15
+      exact ⟨{3, 5}, by decide,
+        by simp only [Finset.mem_insert, Finset.mem_singleton]; omega,
+        by decide⟩
+    · -- m = 9 = 2 + 7, p ≥ 14
+      exact ⟨{2, 7}, by decide,
+        by simp only [Finset.mem_insert, Finset.mem_singleton]; omega,
+        by decide⟩
+    · -- m = 10 = 3 + 7, p ≥ 13
+      exact ⟨{3, 7}, by decide,
+        by simp only [Finset.mem_insert, Finset.mem_singleton]; omega,
+        by decide⟩
+    · -- m = 11, p ≥ 12 and p ≠ 12, so p ≥ 13
+      exact ⟨{11}, by decide, by simp only [Finset.mem_singleton]; omega,
+        by decide⟩
+    · -- m = 12 = 5 + 7, p ≥ 11
+      exact ⟨{5, 7}, by decide,
+        by simp only [Finset.mem_insert, Finset.mem_singleton]; omega,
+        by decide⟩
 
-/-! ## Main theorem (DEFERRED assembly) -/
+/-! ## Main theorem (ASSEMBLED, third iteration) -/
 
-/-- **A054656 main theorem (DEFERRED).** For `n ≥ 23`, the primes absent from
+/-- **A054656 main theorem.** For `n ≥ 23`, the primes absent from
 every distinct-prime partition of `n` are exactly `{n−1, n−4, n−6} ∩ P`.
 
-Once `repr_of_ge_seven_ne` is discharged this follows from the verified
-reduction `present_iff_residual_repr` together with the three verified
-non-representability facts: for a prime `p ≤ n`, `p` is absent iff the residual
-`n − p ∈ {1, 4, 6}`, i.e. `p ∈ {n−1, n−4, n−6}`. -/
+FULLY PROVED (fourth iteration; `#print axioms` = foundational only): for a
+prime `p ≤ n`, the reduction
+`present_iff_residual_repr` says `p` is absent iff the residual `n − p` has no
+`p`-avoiding representation; `repr_of_ge_seven_ne` shows this forces
+`n − p ∈ {1, 4, 6}` (the residual `0` is the empty representation), i.e.
+`p ∈ {n−1, n−4, n−6}`; conversely those residuals are never representable
+(`not_reprAvoiding_of_mem_exceptional`). -/
 theorem A054656_main (n : ℕ) (hn : 23 ≤ n) :
     D n = {p | Nat.Prime p ∧ (p = n - 1 ∨ p = n - 4 ∨ p = n - 6)} := by
-  sorry
+  ext p
+  simp only [D, Set.mem_setOf_eq]
+  constructor
+  · rintro ⟨hp, hpn, hnpres⟩
+    refine ⟨hp, ?_⟩
+    by_contra hcon
+    push Not at hcon
+    obtain ⟨h1, h4, h6⟩ := hcon
+    apply hnpres
+    rw [present_iff_residual_repr]
+    refine ⟨hp, hpn, ?_⟩
+    rcases Nat.eq_zero_or_pos (n - p) with hm0 | hmpos
+    · -- residual 0: the empty representation
+      exact ⟨∅, by simp, by simp, by simp [hm0]⟩
+    · -- residual ≥ 1 and ∉ {1, 4, 6}: the engine applies
+      have hm1 : n - p ≠ 1 := fun h => h1 (by omega)
+      have hm4 : n - p ≠ 4 := fun h => h4 (by omega)
+      have hm6 : n - p ≠ 6 := fun h => h6 (by omega)
+      exact repr_of_ge_seven_ne (n - p) p hp (by omega) ⟨hm4, hm6⟩ (by omega)
+  · rintro ⟨hp, hcase⟩
+    have hpn : p ≤ n := by rcases hcase with rfl | rfl | rfl <;> omega
+    refine ⟨hp, hpn, ?_⟩
+    intro hpres
+    rw [present_iff_residual_repr] at hpres
+    obtain ⟨-, -, hrepr⟩ := hpres
+    refine not_reprAvoiding_of_mem_exceptional ?_ hrepr
+    rcases hcase with rfl | rfl | rfl
+    · left; omega
+    · right; left; omega
+    · right; right; omega
 
 end A054656

--- a/src/data/proofs/a054656-distinct-prime-partition/annotations.json
+++ b/src/data/proofs/a054656-distinct-prime-partition/annotations.json
@@ -2,69 +2,115 @@
   {
     "id": "ann-a054656-overview",
     "proofId": "a054656-distinct-prime-partition",
-    "range": { "startLine": 1, "endLine": 45 },
+    "range": {
+      "startLine": 1,
+      "endLine": 51
+    },
     "type": "concept",
-    "title": "A054656 and what this first iteration machine-checks",
-    "content": "OEIS A054656 (created April 2000, still labeled conjectural) counts, for each n, the primes p ≤ n that occur in NO partition of n into distinct primes. The claimed theorem: for every n ≥ 23 that absent set is exactly {n−1, n−4, n−6} ∩ P. The pivot is that a prime p ≤ n occurs in some distinct-prime partition of n iff the residual m = n − p is itself a sum of distinct primes avoiding p, and the only non-representable residuals are m ∈ {1, 4, 6}. This file turns the elementary core of an AI-claimed proof (GPT-5.6 Pro, GitHub issue #41831) into machine-checked Lean and scaffolds the harder representability engine behind clearly-marked `sorry`s. Status is honestly `formalized` — the elementary core is verified, the full theorem is not.",
+    "title": "A054656 fully machine-checked (fourth iteration: 0 sorries, 0 axioms)",
+    "content": "OEIS A054656 (created April 2000, still labeled conjectural) counts, for each n, the primes p ≤ n that occur in NO partition of n into distinct primes. The claimed theorem: for every n ≥ 23 that absent set is exactly {n−1, n−4, n−6} ∩ P. The pivot is that a prime p ≤ n occurs in some distinct-prime partition of n iff the residual m = n − p is itself a sum of distinct primes avoiding p, and the only non-representable residuals are m ∈ {1, 4, 6}. This file, with the imported companion `A054656TwoPrimesInterval.lean`, turns the whole AI-claimed proof (GPT-5.6 Pro, GitHub issue #41831) into machine-checked Lean: elementary core, Richert interval engine, Ramanujan-type two-primes input, and the assembled main theorem. 0 sorries, 0 axioms — `#print axioms A054656_main` = [propext, Classical.choice, Quot.sound]; a closed form left conjectural on OEIS since 2000 is now verified.",
     "significance": "critical",
     "mathContext": "$D(n) = \\{p \\le n : p \\text{ prime}, \\lnot\\,\\mathrm{Present}(p,n)\\}$; the conjecture is $D(n) = \\{n-1,n-4,n-6\\}\\cap\\mathbb{P}$ for $n \\ge 23$, so $A054656(n) = |D(n)|$.",
-    "relatedConcepts": ["distinct-prime partitions", "additive number theory", "OEIS A054656"]
+    "relatedConcepts": [
+      "distinct-prime partitions",
+      "additive number theory",
+      "OEIS A054656"
+    ]
   },
   {
     "id": "ann-a054656-encoding",
     "proofId": "a054656-distinct-prime-partition",
-    "range": { "startLine": 53, "endLine": 69 },
+    "range": {
+      "startLine": 53,
+      "endLine": 74
+    },
     "type": "definition",
     "title": "Encoding distinct-prime sums as Finsets of primes",
     "content": "A distinct-prime representation of m is modelled as a `Finset` of primes summing to m: `Repr m` asserts such a set exists, and `ReprAvoiding m avoid` additionally forbids one prime. Using a `Finset` makes distinctness automatic — elements are unique by construction, so no side condition is needed. `Present p n` says p lies in some distinct-prime partition of n, and `D n = {p | p prime, p ≤ n, ¬ Present p n}` is precisely the set whose cardinality is A054656(n). These four definitions fix the vocabulary the whole development rests on.",
     "significance": "key",
     "mathContext": "Repr m := ∃ S : Finset ℕ, (∀ q ∈ S, Nat.Prime q) ∧ S.sum id = m",
-    "relatedConcepts": ["Finset", "sum of distinct primes"]
+    "relatedConcepts": [
+      "Finset",
+      "sum of distinct primes"
+    ]
   },
   {
     "id": "ann-a054656-basic-facts",
     "proofId": "a054656-distinct-prime-partition",
-    "range": { "startLine": 71, "endLine": 83 },
+    "range": {
+      "startLine": 76,
+      "endLine": 90
+    },
     "type": "lemma",
     "title": "Two small supporting facts: summands are bounded, avoiding implies representing",
     "content": "`le_of_mem_repr` says every prime in a representing Finset is at most the sum it represents — immediate from `Finset.single_le_sum` since all summands are nonnegative. `repr_of_reprAvoiding` forgets the avoided-prime side condition, turning a `ReprAvoiding m avoid` witness into a plain `Repr m` witness by discarding the second component of the existential. Neither lemma is deep, but both are load-bearing: `le_of_mem_repr` is exactly what bounds the candidate-prime search to a finite powerset in the three exceptional-residual proofs, and `repr_of_reprAvoiding` lets the reduction lemma freely move between the avoiding and non-avoiding notions of representability.",
     "significance": "supporting",
     "mathContext": "$S.\\mathrm{sum}\\ \\mathrm{id} = m \\land p \\in S \\implies p \\le m$, via $p = \\mathrm{id}\\,p \\le S.\\mathrm{sum}\\ \\mathrm{id} = m$",
-    "prerequisites": ["Finset.single_le_sum"],
-    "relatedConcepts": ["Repr", "ReprAvoiding", "finite bounding argument"]
+    "prerequisites": [
+      "Finset.single_le_sum"
+    ],
+    "relatedConcepts": [
+      "Repr",
+      "ReprAvoiding",
+      "finite bounding argument"
+    ]
   },
   {
     "id": "ann-a054656-exceptional-residuals",
     "proofId": "a054656-distinct-prime-partition",
-    "range": { "startLine": 85, "endLine": 136 },
+    "range": {
+      "startLine": 92,
+      "endLine": 143
+    },
     "type": "lemma",
     "title": "The three exceptional residuals 1, 4, 6 (fully verified, kernel `decide`)",
     "content": "These are the tractable, machine-checked wins: 1, 4 and 6 admit NO distinct-prime representation. The proof pattern is uniform — every summand p of a set summing to m satisfies p ≤ m (via `Finset.single_le_sum`, since all summands are nonnegative), so the representing set is a subset of the primes ≤ m; `fin_cases` over that finite powerset and kernel `decide` then close each case. Because only `decide` is used (never `native_decide`), these lemmas carry no `Lean.ofReduceBool` dependency and are genuinely axiom-free. `not_reprAvoiding_of_mem_exceptional` packages all three for use in the main assembly.",
     "significance": "critical",
     "mathContext": "1 is below the smallest prime; no subset of {2,3} sums to 4; no subset of {2,3,5} sums to 6.",
-    "prerequisites": ["Finset.single_le_sum", "fin_cases", "decide"]
+    "prerequisites": [
+      "Finset.single_le_sum",
+      "fin_cases",
+      "decide"
+    ]
   },
   {
     "id": "ann-a054656-reduction",
     "proofId": "a054656-distinct-prime-partition",
-    "range": { "startLine": 138, "endLine": 169 },
+    "range": {
+      "startLine": 145,
+      "endLine": 172
+    },
     "type": "theorem",
     "title": "The reduction lemma — the verified pivot the whole proof turns on",
     "content": "`present_iff_residual_repr`: p occurs in a distinct-prime partition of n ⇔ p is a prime ≤ n AND the residual n − p is a sum of distinct primes avoiding p. Forward direction removes p from a partition containing it (`Finset.add_sum_erase`, so the remaining primes sum to n − p and p is no longer among them); the reverse inserts p back (`Finset.sum_insert`, valid because p was avoided). This fully-elementary equivalence is what converts the whole question into 'which residuals are representable', reducing A054656 to the arithmetic of representable integers. Both directions are proven with zero sorries.",
     "significance": "critical",
     "mathContext": "$\\mathrm{Present}(p,n) \\iff p \\in \\mathbb{P} \\wedge p \\le n \\wedge \\mathrm{ReprAvoiding}(n-p,\\,p)$, via the identity $p + (S \\setminus \\{p\\}).\\mathrm{sum}\\,\\mathrm{id} = S.\\mathrm{sum}\\,\\mathrm{id} = n$.",
-    "prerequisites": ["Finset.add_sum_erase", "Finset.sum_insert"],
-    "relatedConcepts": ["reduction to residual representability"]
+    "prerequisites": [
+      "Finset.add_sum_erase",
+      "Finset.sum_insert"
+    ],
+    "relatedConcepts": [
+      "reduction to residual representability"
+    ]
   },
   {
     "id": "ann-a054656-engine-deferred",
     "proofId": "a054656-distinct-prime-partition",
-    "range": { "startLine": 171, "endLine": 226 },
-    "type": "warning",
-    "title": "The representability engine and the Mathlib gap (DEFERRED — 4 sorries)",
-    "content": "The heavy lifting is scaffolded but not yet proven: `seed_block` (a run of ≥ 64 consecutive representable residuals, an enumeration over the ≤ 2⁹ subsets of the nine primes ≤ 23), `interval_extension` (extend a covered interval by an unused prime q ≤ B−A+1), `repr_of_ge_seven_ne` (every non-exceptional residual is representable avoiding one forbidden prime), and `A054656_main` (the final theorem for n ≥ 23). The key missing ingredient is a Ramanujan-prime fact: '(q, 2q] contains at least TWO primes' (R₂ = 11), so that after deleting the single forbidden prime an available prime ≤ 2q still remains. Mathlib HAS Bertrand's postulate (`Nat.exists_prime_lt_and_le_two_mul`) but NOT this two-primes strengthening — it must be built on top of Bertrand. That is the concrete next lemma for continuing this entry.",
+    "range": {
+      "startLine": 178,
+      "endLine": 529
+    },
+    "type": "concept",
+    "title": "The representability engine: kernel seed, Richert interval induction, imported Ramanujan input",
+    "content": "Third iteration: the engine is now a machine-checked bottom-up Richert interval induction. The kernel `canSum` checker certifies the seed window [13, 90] avoiding any one prime with all witness primes <= 31 (`seed_block_bdd`); the bounded predicate `ReprAvoidingBdd` makes fresh-prime extension sound (`reprAvoidingBdd_add_fresh`: a prime above the witness bound is automatically new); and `EngineInv`/`engineInv_step`/`engineInv_reach` grow the interval one Bertrand prime at a time, with self-maintaining slack 2Q + 12 <= B, giving `reprAvoiding_of_thirteen_le`: every m >= 13 is a sum of distinct primes avoiding p. The last input, `exists_second_prime_in_Ioc` - a second prime in (x, 2x] when the forbidden prime p itself lies there (Ramanujan R2 = 11; Mathlib has only Bertrand's one-prime version) - is proved in the imported `A054656TwoPrimesInterval.lean` (fourth iteration), so the engine is sorry-free. It is invoked only through `bertrand_avoiding` in the collision case x < p <= 2x.",
     "significance": "key",
-    "prerequisites": ["Nat.exists_prime_lt_and_le_two_mul"],
-    "relatedConcepts": ["Bertrand's postulate", "Ramanujan primes", "interval-covering induction"]
+    "prerequisites": [
+      "Nat.exists_prime_lt_and_le_two_mul"
+    ],
+    "relatedConcepts": [
+      "Bertrand's postulate",
+      "Ramanujan primes",
+      "interval-covering induction"
+    ]
   }
 ]

--- a/src/data/proofs/a054656-distinct-prime-partition/meta.json
+++ b/src/data/proofs/a054656-distinct-prime-partition/meta.json
@@ -2,53 +2,55 @@
   "id": "a054656-distinct-prime-partition",
   "slug": "a054656-distinct-prime-partition",
   "title": "OEIS A054656: Primes Absent from Every Distinct-Prime Partition of n",
-  "status": "formalized",
-  "description": "For n ≥ 23, the primes p ≤ n absent from every partition of n into distinct primes are exactly {n−1, n−4, n−6} ∩ P. Iteration 1 machine-checked the elementary core (residuals 1, 4, 6 are not distinct-prime sums; the reduction 'p present in n ⟺ n−p is a distinct-prime sum avoiding p'). Iteration 2 proves the seed block (the window [13, 90] is representable avoiding any one prime, via a kernel subset-sum checker over the primes ≤ 31) and the fresh-prime extension step, and repairs two defective scaffold statements; only the Bertrand–Ramanujan induction and final assembly remain sorried.",
+  "status": "verified",
+  "description": "For n ≥ 23, the primes p ≤ n absent from every partition of n into distinct primes are exactly {n−1, n−4, n−6} ∩ P — the closed form OEIS A054656 left conjectural since April 2000, now FULLY machine-checked (0 sorries, 0 axioms; kernel decide only). Iteration 1 verified the elementary core (residuals 1, 4, 6 are not distinct-prime sums; the reduction 'p present in n ⟺ n−p is a distinct-prime sum avoiding p'). Iteration 2 proved the kernel-verified seed block [13, 90] and the fresh-prime extension. Iteration 3 proved the Bertrand-based Richert interval induction and assembled repr_of_ge_seven_ne and A054656_main. Iteration 4 proved the last input — the Ramanujan-type 'second prime in (x, 2x]' lemma (R₂ = 11, a genuine Mathlib gap) — in the companion file A054656TwoPrimesInterval.lean by re-running Mathlib's Bertrand central-binomial analysis with one permitted prime removed, and wired it in. #print axioms A054656_main = [propext, Classical.choice, Quot.sound].",
   "overview": {
     "historicalContext": "OEIS A054656 was created in April 2000 and, as of this entry, is still labeled conjectural — over two decades with no published proof. The sequence counts primes p ≤ n absent from every partition of n into distinct primes, and the conjectural closed form is remarkably simple: for n ≥ 23 the absent primes are exactly {n−1, n−4, n−6} intersected with the primes. GitHub issue #41831 tracks an AI-claimed elementary proof (GPT-5.6 Pro); this file is the first Lean iteration turning that claimed argument into machine-checked mathematics, separating what is genuinely elementary (and now verified) from what still needs a number-theoretic ingredient Mathlib does not yet have.",
     "problemStatement": "For every integer n ≥ 23, show that the primes p ≤ n occurring in NO partition of n into distinct primes are exactly the primes among {n−1, n−4, n−6}. Equivalently: a prime p ≤ n is present in some distinct-prime partition of n if and only if the residual m = n − p is itself a sum of distinct primes none equal to p, and the only residuals with no such representation are m ∈ {1, 4, 6}.",
-    "proofStrategy": "Encode a distinct-prime sum as `Repr m := ∃ S : Finset ℕ, (∀ q ∈ S, Nat.Prime q) ∧ S.sum id = m`, with `ReprAvoiding` adding a forbidden prime and `Present p n` asserting p occurs in some distinct-prime partition of n. The pivot is `present_iff_residual_repr`: p is present in n iff p is prime, p ≤ n, and n − p is representable avoiding p — proved by a `Finset.erase`/`insert` bookkeeping argument with no case analysis on primality. On the base-case side, `not_repr_one`, `not_repr_four`, `not_repr_six` rule out the three exceptional residuals by bounding the candidate primes (≤ 1, ≤ 4, ≤ 6) and exhausting the finitely many subsets with `decide`. What remains sorry is the representability engine for every OTHER residual: a `seed_block` of ≥64 consecutive representable integers built from the nine primes ≤ 23, an `interval_extension` step that grows a representable interval by one fresh prime, and a Bertrand/Ramanujan induction (`repr_of_ge_seven_ne`) that pushes this to infinity — which needs a '(q, 2q] contains ≥ 2 primes' lemma that Mathlib does not currently provide.",
+    "proofStrategy": "Encode a distinct-prime sum as `Repr m := ∃ S : Finset ℕ, (∀ q ∈ S, Nat.Prime q) ∧ S.sum id = m`, with `ReprAvoiding` adding a forbidden prime and `Present p n` asserting p occurs in some distinct-prime partition of n. The pivot is `present_iff_residual_repr`: p is present in n iff p is prime, p ≤ n, and n − p is representable avoiding p — proved by a `Finset.erase`/`insert` bookkeeping argument with no case analysis on primality. On the base-case side, `not_repr_one`, `not_repr_four`, `not_repr_six` rule out the three exceptional residuals by bounding the candidate primes (≤ 1, ≤ 4, ≤ 6) and exhausting the finitely many subsets with `decide`. The representability engine (third iteration) is a bottom-up Richert interval induction over the bounded predicate `ReprAvoidingBdd m p Q` (witness primes ≤ Q): the kernel-verified seed covers [13, 90] with bound 31; `engineInv_step` adds one prime q ∈ (Q, 2Q], q ≠ p per step (fresh because q exceeds the witness bound), with self-maintaining slack 2Q + 12 ≤ B; `engineInv_reach` iterates to cover every m ≥ 13, and explicit small witnesses cover 2 ≤ m ≤ 12 when 23 ≤ m + p. The final input — a second prime in (x, 2x] when the forbidden prime p itself lies there (the '(q, 2q] contains ≥ 2 primes' Ramanujan lemma, R₂ = 11, absent from Mathlib) — is proved in the companion file A054656TwoPrimesInterval.lean and imported, closing the proof with 0 sorries.",
     "keyInsights": [
       "**The reduction is the whole ballgame.** `present_iff_residual_repr` converts a statement about partitions containing p into a statement about representing the residual n − p while avoiding p — a clean `Finset.erase`/`Finset.insert` correspondence that needs no primality case analysis, only the arithmetic identity p + (S.erase p).sum id = n.",
       "**Exactly three residuals are unrepresentable.** 1 is below the smallest prime 2; {2,3} (the only primes ≤ 4) cannot sum to 4; {2,3,5} (the only primes ≤ 6) cannot sum to 6. Each is a finite, fully verified `decide` check over subsets — the base case of the whole conjecture is closed with zero sorries.",
       "**Every larger residual is expected representable, but that needs infrastructure, not just computation.** The claimed argument bootstraps a finite seed block of ≥64 consecutive representable residuals (from the nine primes ≤ 23) and then extends it indefinitely by injecting one fresh prime at a time — an induction, not a single decidable check.",
       "**A genuine Mathlib gap surfaces here.** Mathlib has Bertrand's postulate (`Nat.exists_prime_lt_and_le_two_mul`, one prime in (n, 2n]) but no Ramanujan-prime result. The induction step needs TWO primes in (q, 2q] so that after deleting the one forbidden prime p, an eligible fresh prime still remains — this must be built on top of Bertrand, not found off the shelf.",
       "**Kernel `decide` throughout, deliberately.** Every verified lemma uses plain `decide`, not `native_decide`, so the finished portion carries no `Lean.ofReduceBool` dependency, keeping the door open for the finished entry to be genuinely axiom-free rather than merely axiomatized.",
-      "**The status is reported honestly.** `formalized` with 2 remaining sorries (`repr_of_ge_seven_ne`, `A054656_main`) rather than a premature `verified` claim — `seed_block` and the fresh-prime extension step are now proved, but the sequence remains conjectural until the Ramanujan-prime gap is closed."
+      "**The status is reported honestly.** Earlier iterations were labeled `formalized` while sorries remained; only now — 0 sorries, 0 axioms, kernel `decide` only, `#print axioms A054656_main` = [propext, Classical.choice, Quot.sound] — is the entry upgraded to `verified`."
     ]
   },
   "conclusion": {
-    "summary": "The elementary core of OEIS A054656 is machine-checked with zero sorries: the pivot reduction `present_iff_residual_repr`, the non-representability of the three exceptional residuals 1, 4, 6, and (as of the second iteration) the seed block and fresh-prime extension step of the representability engine. Only the Bertrand/Ramanujan induction (`repr_of_ge_seven_ne`) and the final assembly (`A054656_main`) remain `sorry`, pending a Ramanujan-prime-style lemma not yet in Mathlib. Status is honestly reported as `formalized`, not `verified`.",
-    "implications": "This first iteration converts a 25-year-old conjectural OEIS sequence into a precisely scoped Lean scaffold: the parts that are genuinely elementary are now verified, and the single missing number-theoretic ingredient — at least two primes in (q, 2q] — is identified explicitly rather than left implicit in an informal AI-generated argument. That makes the remaining work a well-defined target for either a future research pass or an Aristotle submission once the Ramanujan-prime lemma is stated.",
+    "summary": "OEIS A054656 is machine-checked END-TO-END with zero sorries and zero axioms: the pivot reduction, the three exceptional residuals 1, 4, 6, the kernel-verified bounded seed block [13, 90], the Richert interval induction, the residual engine repr_of_ge_seven_ne, the Ramanujan-type second-prime lemma (companion file A054656TwoPrimesInterval.lean, proved by re-running Mathlib's Bertrand central-binomial bound with one permitted prime removed plus a descending prime-pair chain), and the assembled main theorem A054656_main. #print axioms = foundational only. A closed form left conjectural on OEIS for 25 years is now fully verified.",
+    "implications": "A 25-year-old conjectural OEIS closed form is now a fully machine-checked theorem. The formalization also isolated and filled a genuine Mathlib gap — 'at least two primes in (n, 2n]' (Ramanujan R₂) — proved kernel-only in a standalone companion file that is a natural upstream candidate for Mathlib.",
     "openQuestions": [
-      "Does the seed-block enumeration (≥64 consecutive representable residuals from the nine primes ≤ 23, for each excluded prime p) stay within reach of kernel `decide`, or does the 2⁹-subset search force `native_decide` (which would require disclosing `Lean.ofReduceBool` and downgrading the eventual badge to `axiom`)?",
-      "Can the needed '≥ 2 primes in (q, 2q]' lemma be derived by applying Bertrand's postulate twice with a case split, or does it require genuinely new number-theoretic input beyond `Nat.exists_prime_lt_and_le_two_mul`?",
-      "Is the conjectural closed form {n−1, n−4, n−6} ∩ P actually correct for all n ≥ 23, or does OEIS A054656 have exceptions the informal proof missed?"
+      "Can the companion two-primes-in-(n, 2n] theorem (Ramanujan R₂ = 11, sharp at n = 6) be upstreamed to Mathlib, and does the one-permitted-prime variant of the Bertrand central-binomial analysis generalize to k permitted primes (the k-th Ramanujan prime R_k) without raising the 512 threshold beyond kernel reach?",
+      "OEIS A054656 remains labeled conjectural upstream: with the closed form now machine-verified for all n ≥ 23 (and the small cases finite), what is the right channel for feeding a Lean-verified resolution back to OEIS?"
     ]
   },
   "leanFile": {
     "path": "Proofs/A054656DistinctPrimePartition.lean",
-    "sorries": 2,
+    "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 11,
-    "definitionCount": 4
+    "theoremCount": 25,
+    "definitionCount": 9,
+    "lineCount": 576
   },
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026-07-22",
     "dateAdded": "2026-07-22",
-    "status": "formalized",
-    "badge": "wip",
+    "status": "verified",
+    "badge": "original",
     "proofRepoPath": "Proofs/A054656DistinctPrimePartition.lean",
-    "sorries": 2,
+    "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "Main theorem A054656_main and the Bertrand/Ramanujan induction repr_of_ge_seven_ne are stated as `sorry`. No `axiom` declarations and no structure-encoded assumptions. All verified lemmas use kernel `decide` (no native_decide, so no Lean.ofReduceBool dependency).",
+    "assumptions": "None. 0 sorries, 0 axiom declarations, no structure-encoded assumptions, across both the main file and the companion A054656TwoPrimesInterval.lean. All decidable checks use kernel decide (no native_decide, so no Lean.ofReduceBool dependency). #print axioms A054656_main = [propext, Classical.choice, Quot.sound].",
     "verifiedContributions": [
       "not_repr_one / not_repr_four / not_repr_six — 1, 4, 6 are not sums of distinct primes (kernel decide, 0 sorries)",
       "present_iff_residual_repr — the reduction: p occurs in a distinct-prime partition of n ⟺ p prime ∧ p ≤ n ∧ n−p is a sum of distinct primes avoiding p",
       "le_of_mem_repr, repr_of_reprAvoiding, not_reprAvoiding_of_mem_exceptional — verified supporting lemmas",
       "seed_block — the window [13, 90] is representable avoiding any single prime, via a kernel canSum subset-sum checker (canSum_sound, reprAvoiding_of_canSum, checkWindow_sound, seed_case)",
-      "reprAvoiding_add_prime — the fresh-prime extension step, replacing and repairing the first iteration's vacuous interval_extension"
+      "reprAvoiding_add_prime — the fresh-prime extension step, replacing and repairing the first iteration's vacuous interval_extension",
+      "exists_two_primes_in_Ioc / exists_second_prime_in_Ioc (companion file) — at least two primes in (n, 2n] for n ≥ 6 (sharp), the Ramanujan R₂ = 11 strengthening of Bertrand absent from Mathlib",
+      "A054656_main — the full closed form for n ≥ 23, 0 sorries, foundational axioms only"
     ],
     "deferred": [
       "repr_of_ge_seven_ne — every non-exceptional residual is representable avoiding p, via the Bertrand/Ramanujan induction (statement repaired this iteration to require 23 ≤ m + p)",
@@ -70,13 +72,13 @@
       "id": "preamble",
       "title": "Preamble: the conjecture, the AI-claimed proof, and the Mathlib gap",
       "startLine": 1,
-      "endLine": 52,
-      "summary": "Docstring: OEIS A054656 (n ≥ 23, absent primes = {n−1,n−4,n−6} ∩ P), the source of the claimed elementary proof (GitHub issue #41831, GPT-5.6 Pro), a status ledger of what is verified vs. scaffolded as of the second iteration (seed_block and the fresh-prime extension step now proved; repr_of_ge_seven_ne and A054656_main deferred), and the identified Mathlib gap — Bertrand's postulate exists but the needed two-primes-in-(q,2q] Ramanujan-style strengthening does not."
+      "endLine": 51,
+      "summary": "Docstring: OEIS A054656 (n ≥ 23, absent primes = {n−1,n−4,n−6} ∩ P), the source of the claimed elementary proof (GitHub issue #41831, GPT-5.6 Pro), a status ledger of the fourth iteration (COMPLETE — 0 sorries: Richert engine, repr_of_ge_seven_ne, A054656_main, and the formerly-sorried exists_second_prime_in_Ioc, now proved in the imported companion A054656TwoPrimesInterval.lean), and the identified-and-filled Mathlib gap — Bertrand's postulate exists upstream but the two-primes-in-(q,2q] Ramanujan strengthening had to be proved here."
     },
     {
       "id": "definitions",
       "title": "Core definitions: Repr, ReprAvoiding, Present, D",
-      "startLine": 60,
+      "startLine": 53,
       "endLine": 76,
       "summary": "`Repr m` (m is a sum of distinct primes), `ReprAvoiding m avoid` (a representation excluding one prime), `Present p n` (p occurs in some distinct-prime partition of n), and `D n` (the primes ≤ n absent from every such partition — |D n| is the OEIS sequence)."
     },
@@ -105,22 +107,22 @@
       "id": "scaffolding",
       "title": "The representability engine: seed block and extension (PROVED), induction (DEFERRED)",
       "startLine": 178,
-      "endLine": 337,
-      "summary": "`seedPool`/`canSum`/`checkWindow` (a kernel-friendly subset-sum decision procedure and its soundness bridge `canSum_sound`/`reprAvoiding_of_canSum`/`checkWindow_sound`), `seed_block` (PROVED — the window [13, 90] is representable avoiding any single prime), and `reprAvoiding_add_prime` (PROVED — the repaired fresh-prime extension step, replacing the first iteration's vacuous `interval_extension`). `repr_of_ge_seven_ne` (every non-exceptional residual with 23 ≤ m + p is representable avoiding p, via seed block + extension + Bertrand/Ramanujan induction) remains `sorry`, with the missing Ramanujan-prime ingredient documented inline."
+      "endLine": 529,
+      "summary": "`seedPool`/`canSum`/`checkWindow` (a kernel-friendly subset-sum decision procedure and its soundness bridge `canSum_sound`/`reprAvoiding_of_canSum`/`checkWindow_sound`), `seed_block` (PROVED — the window [13, 90] is representable avoiding any single prime), and `reprAvoiding_add_prime` (PROVED — the repaired fresh-prime extension step, replacing the first iteration's vacuous `interval_extension`). `repr_of_ge_seven_ne` is now PROVED (third iteration): m ≥ 13 via the Richert interval induction (`ReprAvoidingBdd`, `EngineInv`, `engineInv_reach`, `reprAvoiding_of_thirteen_le`), small residuals 2 ≤ m ≤ 12 via explicit witnesses; the Ramanujan-type `exists_second_prime_in_Ioc` is proved in the imported companion `A054656TwoPrimesInterval.lean` (fourth iteration), so the engine is sorry-free."
     },
     {
       "id": "main-theorem",
-      "title": "Main theorem (DEFERRED assembly): A054656_main",
-      "startLine": 339,
-      "endLine": 352,
-      "summary": "The target statement for n ≥ 23: D n = {p | Nat.Prime p ∧ (p = n−1 ∨ p = n−4 ∨ p = n−6)}. Once `repr_of_ge_seven_ne` is discharged this follows immediately from the verified reduction and the three verified non-representability facts; currently `sorry`."
+      "title": "Main theorem (FULLY PROVED): A054656_main",
+      "startLine": 531,
+      "endLine": 576,
+      "summary": "The target statement for n ≥ 23: D n = {p | Nat.Prime p ∧ (p = n−1 ∨ p = n−4 ∨ p = n−6)}. FULLY PROVED (fourth iteration) from the verified reduction, `repr_of_ge_seven_ne`, and the three verified non-representability facts; `#print axioms` = foundational only."
     }
   ],
   "crossReferences": [
     {
       "proofId": "bertrands-postulate",
       "relationship": "Mathlib dependency and identified gap",
-      "description": "This proof's deferred representability engine needs a two-primes-in-(q,2q] Ramanujan-style strengthening built on top of Bertrand's postulate (`Nat.exists_prime_lt_and_le_two_mul`), which Mathlib has but does not extend to the two-prime version this argument requires."
+      "description": "This proof's single remaining sorry (exists_second_prime_in_Ioc) is a two-primes-in-(q,2q] Ramanujan-style strengthening built on top of Bertrand's postulate (`Nat.exists_prime_lt_and_le_two_mul`), which Mathlib has but does not extend to the two-prime version this argument requires."
     }
   ],
   "references": [
@@ -134,7 +136,10 @@
       "url": "https://github.com/rjwalters/lean-genius/issues/41831"
     },
     {
-      "text": "Mathlib.NumberTheory.Bertrand — Nat.exists_prime_lt_and_le_two_mul (Bertrand's postulate), the single-prime result the deferred Ramanujan-prime lemma must be built on top of"
+      "text": "Mathlib.NumberTheory.Bertrand — Nat.exists_prime_lt_and_le_two_mul (Bertrand's postulate), the single-prime result the remaining Ramanujan-prime sorry must be built on top of"
     }
+  ],
+  "additionalFiles": [
+    "Proofs/A054656TwoPrimesInterval.lean"
   ]
 }

--- a/src/data/research/problems/issue-41831-formalize-oeis-a054656-primes-absent-from-every-di.json
+++ b/src/data/research/problems/issue-41831-formalize-oeis-a054656-primes-absent-from-every-di.json
@@ -6,7 +6,7 @@
   "tier": "B",
   "tractability": 5,
   "started": "2026-07-22",
-  "lastUpdate": "2026-07-23",
+  "lastUpdate": "2026-07-23T00:00:00.000Z",
   "path": "proofs/Proofs/A054656DistinctPrimePartition.lean",
   "leanFiles": [
     "proofs/Proofs/A054656DistinctPrimePartition.lean"
@@ -14,21 +14,21 @@
   "problemStatement": "For every integer n ≥ 23, the set D(n) of primes p ≤ n that occur in NO partition of n into distinct primes equals {n−1, n−4, n−6} ∩ P. Equivalently, a prime p ≤ n occurs in some distinct-prime partition of n iff the residual m = n − p is a sum of distinct primes none equal to p; the only non-representable residuals are m ∈ {1,4,6}.",
   "significance": "OEIS A054656 (created April 2000) is still labeled conjectural. An AI-claimed elementary proof (GPT-5.6 Pro, issue #41831) is the subject; the value added is turning the unreviewed claim into machine-checked Lean.",
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-07-22T00:00:00Z",
-    "iteration": 1,
-    "focus": "Verified the elementary core (residuals 1,4,6 non-representable + the present↔residual reduction, all kernel decide / 0 sorries). Scaffolded seed-block, interval-extension, and main theorem as sorry. Identified the Mathlib gap (no Ramanujan prime; two-primes-in-(q,2q] must be built on Nat.exists_prime_lt_and_le_two_mul).",
+    "iteration": 3,
+    "focus": "COMPLETE: A054656_main fully proved, 0 sorries, 0 axioms (foundational only). Ramanujan R2 lemma from companion A054656TwoPrimesInterval.lean wired in (iteration 5).",
     "blockers": [
       {
-        "route": "Ramanujan-prime induction ((q,2q] contains ≥2 primes) to push representable interval to infinity",
-        "reopenCriterion": "build a two-primes-in-(q,2q] lemma on top of Nat.exists_prime_lt_and_le_two_mul (Mathlib has no Ramanujan-prime result)",
-        "blockedAt": "2026-07-22"
+        "route": "exists_second_prime_in_Ioc — two primes in (x,2x] (Ramanujan R2 = 11)",
+        "reopenCriterion": "adapt the Erdos/Chebyshev binomial analysis of Mathlib's Bertrand proof to the two-prime version, or find any route to 'nextprime(nextprime x) <= 2x for x >= 11'",
+        "blockedAt": "2026-07-23"
       }
     ],
-    "nextAction": "Two primes in (q,2q] lemma, then the Bertrand strong induction for repr_of_ge_seven_ne."
+    "nextAction": "None — problem complete. Optional follow-ups: upstream the two-primes-in-(n,2n] theorem to Mathlib; report the Lean verification to OEIS (A054656 is still labeled conjectural upstream)."
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (iteration 4, 2026-07-23): THE LAST MATHEMATICAL GAP IS PROVED. A054656TwoPrimesInterval.lean establishes the Ramanujan-type theorem (two distinct primes in (n,2n] for all n >= 6; equivalently R2 = 11) with 0 sorries / 0 axioms by adapting the Erdos central-binomial proof from Mathlib Bertrand.lean to tolerate one permitted prime (contributes <= 2n since its exponent is <= 1), same 512 threshold, prime-pair chain for small n. It includes exists_second_prime_in_Ioc with the EXACT signature of the single remaining sorry in A054656DistinctPrimePartition.lean (iteration-3 version, PR #42724). Remaining: once both PRs merge, replace that sorry with a one-line call (requires import of Proofs.A054656TwoPrimesInterval) — then A054656_main is fully machine-checked end to end.",
+    "progressSummary": "COMPLETE (iteration 5, wiring): A054656_main #print axioms = [propext, Classical.choice, Quot.sound]. Iterations: (1) elementary core; (2) kernel seed block [13,90] + fresh-prime extension; (3) Richert interval induction + assembly, single sorry = exists_second_prime_in_Ioc; (4) Ramanujan R2 proved standalone in A054656TwoPrimesInterval.lean (PR #42815); (5) superseding wire-up of the conflicting iteration-3 PR #42724 onto main + import + deletion of the sorried placeholder (the imported theorem has the identical name/signature inside namespace A054656). Entry upgraded to verified/original.",
     "insights": [
       "Encoding 'sum of DISTINCT primes' as `∃ S : Finset ℕ, (∀ q ∈ S, Nat.Prime q) ∧ S.sum id = m` makes distinctness automatic (Finset), and non-representability of a small m reduces to a bounded search: every summand p ≤ m (Finset.single_le_sum), so S ⊆ (primes ≤ m); fin_cases over the powerset + kernel decide closes 1,4,6.",
       "The whole conjecture pivots on one fully-elementary reduction: p occurs in a distinct-prime partition of n iff p is prime, p ≤ n, and n−p is a sum of distinct primes AVOIDING p. Proved both directions with Finset.add_sum_erase (forward: erase p) and Finset.sum_insert (reverse: insert p). This is verified and is the load-bearing lemma.",
@@ -37,8 +37,7 @@
       "eta/atom gotcha: `S.sum id` (Finset.sum S id) and `∑ x ∈ S, id x` (Finset.sum S (fun x => id x)) differ syntactically; `rw`/`omega` treat them as distinct atoms. Use a calc chain or `simpa` to bridge, and feed omega a single consistent atom.",
       "List-recursion Bool checkers (canSum) beat Finset.powerset decides by orders of magnitude in the kernel: 12 window-decides x 78 values x 2^10 leaves ran at DEFAULT heartbeats.",
       "Scaffolded sorry statements must be adversarially checked before proving: two of the four A054656 scaffolds were defective (one vacuous — contradictory hypotheses; one false — missing 23 <= m+p).",
-      "Ramanujan R2 (two primes in (n,2n]) IS provable by adapting Mathlib Bertrand: a unique permitted prime p0 in (n,2n] divides centralBinom n at most once (p0^2 > 2n), inflating the factorization bound by only a factor 2n; the concave-endpoint argument still closes at the SAME threshold x=512 since 2^339 <= 2^(1024/3) (Mathlib had slack 2^329)",
-      "Small cases 6 <= n < 512 via a descending chain of prime PAIRS (b <= p < q <= 2c descends covering obligation from b to c): (512)521,523 -> (269)269,271 -> (139)139,149 -> (75)79,83 -> (42)43,47 -> (24)29,31 -> (16)17,19 -> (12), plus explicit witnesses for n=6..11; sharp threshold n >= 6 ((5,10] has only 7)"
+      "Wiring pattern for standalone-lemma companions: if the companion declares the lemma with the SAME fully-qualified name and signature as the parent's sorried placeholder, the wire-up is pure deletion — remove the placeholder and its call sites resolve to the import with no renaming. Deleting rather than renaming avoids a duplicate-declaration error."
     ],
     "builtItems": [
       "proofs/Proofs/A054656DistinctPrimePartition.lean — new file, builds on Lean v4.31.0",
@@ -50,15 +49,16 @@
       "seedPool (11 primes <= 31), canSum (kernel subset-sum checker), canSum_sound, reprAvoiding_of_canSum, checkWindow(+_sound), seed_case",
       "seed_block PROVED: window [13,90] representable avoiding any prime (12 kernel decides, default heartbeats)",
       "reprAvoiding_add_prime PROVED: top-down fresh-prime extension (replaces vacuous interval_extension)",
-      "Proofs/A054656TwoPrimesInterval.lean — exists_two_primes_in_Ioc (all n >= 6, sharp) and exists_second_prime_in_Ioc (exact-signature drop-in for the parent file last sorry); 0 sorries, 0 axioms, kernel-checked (propext/Classical.choice/Quot.sound only)"
+      "Iteration 5: wired A054656TwoPrimesInterval into A054656DistinctPrimePartition (import + delete sorried placeholder — name/signature identical, so call sites resolve to the imported theorem unchanged). Meta upgraded to verified/original, additionalFiles lists the companion. 0 sorries, 0 axioms end-to-end."
     ],
     "mathlibGaps": [
       "No Ramanujan-prime result in Mathlib. The proof needs '(q,2q] contains at least TWO primes' (second Ramanujan prime R₂ = 11) so that after deleting the single forbidden prime p an available prime ≤ 2q remains. This must be BUILT on Nat.exists_prime_lt_and_le_two_mul (Bertrand, in Mathlib/NumberTheory/Bertrand.lean, alias Nat.bertrand: ∀ n≠0, ∃ p, Nat.Prime p ∧ n<p ∧ p≤2n). Bertrand gives only ONE prime in (n,2n]; the two-primes strengthening is the key missing ingredient.",
       "No packaged 'sum of distinct primes representability' API; the seed-block enumeration (≤2^9=512 subsets of the nine primes ≤23) and interval-extension engine must be built from Finset.powerset + decide."
     ],
     "nextSteps": [
-      "After PR #42724 (iteration 3) and the TwoPrimesInterval PR both merge: in A054656DistinctPrimePartition.lean add import Proofs.A054656TwoPrimesInterval and replace the exists_second_prime_in_Ioc sorry body with exact A054656.exists_second_prime_in_Ioc x p hx hp hpl hpu (namespace note: new theorem lives at A054656.exists_second_prime_in_Ioc in the new module; rename or qualify to avoid clash with the parent declaration)",
-      "Update gallery meta.json: sorries 1 -> 0 once wired; consider Mathlib upstream submission of the two-primes theorem (genuinely absent there)"
+      "Build two_primes_in_Ioc_double: for q >= 11(?), (q,2q] contains >= 2 primes — via Nat.exists_prime_lt_and_le_two_mul applied at q and at (q + p1)/2-ish midpoint, or finite decide + Bertrand chaining; this is the sole Mathlib gap.",
+      "repr_of_ge_seven_ne: strong induction on m — for m > 90 take Bertrand prime q in (m/2, m], r = m - q < q; if q = p or r in {1,4,6} take the SECOND prime in (m/2, m] (needs the two-primes lemma); base m in [13,90] = seed_block, m in [2,12] finite cases with 23 <= m+p forcing p large.",
+      "A054656_main assembly from present_iff_residual_repr + not_repr_{1,4,6} + repr_of_ge_seven_ne."
     ]
   },
   "references": [


### PR DESCRIPTION
## Summary
Research session for issue-41831 (OEIS A054656). **The formalization is complete: `A054656_main` is fully proved — 0 sorries, 0 axioms, `#print axioms` = [propext, Classical.choice, Quot.sound].** The closed form (for n ≥ 23, the primes absent from every distinct-prime partition of n are exactly {n−1, n−4, n−6} ∩ P) has been labeled conjectural on OEIS since April 2000.

## Progress
- Re-lands the iteration-3 Richert engine (supersedes the now-conflicting PR #42724) on top of merged #42815, resolving the conflicts against main.
- Wires in the Ramanujan two-primes lemma: `import Proofs.A054656TwoPrimesInterval` and deletion of the sorried `exists_second_prime_in_Ioc` placeholder — the companion declares the identical name and signature inside `namespace A054656`, so all call sites resolve to the imported proof unchanged.
- Gallery entry upgraded `formalized`/`wip` → `verified`/`original`; `additionalFiles` lists the companion; annotations and sections re-anchored to the current file and de-staled; research tracker set to COMPLETED.
- Host-verified on v4.31.0: both files `lake env lean` exit 0; `#print axioms` foundational-only for `A054656_main`, `exists_second_prime_in_Ioc`, `bertrand_avoiding`.

## Adversarial checklist (how this claim could be wrong)
- **Statement pinning**: `A054656_main` proves `D n = {p | Nat.Prime p ∧ (p = n−1 ∨ p = n−4 ∨ p = n−6)}` for `23 ≤ n`, where `D n = {p | Nat.Prime p ∧ p ≤ n ∧ ¬ Present p n}` and `Present p n = ∃ S : Finset ℕ, (∀ q ∈ S, Nat.Prime q) ∧ p ∈ S ∧ S.sum id = n` — i.e. partitions are Finsets of primes (distinctness structural), matching the OEIS definition.
- **Not a near-miss**: the theorem is an equality of sets, not one inclusion; both directions run through the verified `present_iff_residual_repr` pivot.
- **Boundary**: n ≥ 23 is the OEIS threshold; below it the closed form genuinely fails (e.g. small n have extra absent primes), which the statement does not claim.
- **No hidden strength**: no `axiom`, no structure-encoded assumptions, no `native_decide` (kernel `decide` only — no `Lean.ofReduceBool`); the two-primes input is proved, not assumed.

## Status
**Outcome**: completed — the problem's formalization goal is fully achieved.
**Next Steps**: optional follow-ups only: upstream the two-primes-in-(n, 2n] theorem to Mathlib; report the Lean verification to OEIS. Ancestor PR #42724 closed as superseded by this PR.

🤖 Generated by researcher-1
