### PR TITLE
Fix erdos-566: honest sizeRamsey placeholder, drop phantom axiom comment

### DIFF
--- a/proofs/Proofs/Erdos566Problem.lean
+++ b/proofs/Proofs/Erdos566Problem.lean
@@ -46,11 +46,19 @@ def IsSparse {n : ℕ} (G : Graph n) : Prop :=
 def NoIsolated {n : ℕ} (H : Graph n) : Prop :=
   ∀ v : Fin n, ∃ u : Fin n, H.adj v u
 
-/-- The size Ramsey number r̂(G, H): the minimum number of edges
-    in a graph F such that every 2-coloring of E(F) contains a
-    monochromatic copy of G in color 1 or H in color 2. -/
-noncomputable def sizeRamsey {p q : ℕ} (G : Graph p) (H : Graph q) : ℕ :=
-  Nat.find (⟨p * q + 1, Nat.le_add_left 1 (p * q)⟩ : ∃ m : ℕ, m ≥ 1)  -- axiomatized below
+/-- Placeholder for the size Ramsey number r̂(G, H) — the minimum
+    number of edges in a graph F such that every 2-coloring of E(F)
+    contains a monochromatic copy of G in color 1 or H in color 2.
+
+    This is **not implemented**: the 2-coloring construction is not
+    formalized. The body is a constant stub returning `1`, independent
+    of `G`, `H`, `p`, and `q`. It exists only so the definitions
+    section type-checks; no result in this file depends on its value.
+    See the module docstring and the gallery entry, which record that
+    Problem #566 is OPEN and only the surrounding definitions are
+    formalized. -/
+noncomputable def sizeRamsey {p q : ℕ} (_G : Graph p) (_H : Graph q) : ℕ :=
+  1
 
 /- ## Main Question -/
 


### PR DESCRIPTION
## Problem

`Proofs/Erdos566Problem.lean`'s `sizeRamsey` def contradicted its own docstring: the docstring described the size Ramsey number r̂(G,H) via a 2-coloring construction, but the body was `Nat.find (⟨p*q+1, …⟩ : ∃ m, m ≥ 1)`, which resolves against the trivial predicate `m ≥ 1` and so **always returns the constant 1**, independent of `G`, `H`, `p`, `q`. The trailing `-- axiomatized below` comment was also phantom — no axiom follows in the file.

The gallery-facing prose (`meta.json`, `annotations.json`) was already corrected to disclose the placeholder in #42839. This PR fixes the **code** itself, per the "at minimum" recommendation in the issue.

## Fix

Minimal, honest repair (recommended option 3):

- Rewrote the `sizeRamsey` docstring to state plainly that it is an **unimplemented placeholder** returning `1`, on which no result in the file depends.
- Replaced the confusing `Nat.find` body with an explicit constant `1` and renamed the now-unused args to `_G`/`_H`.
- Dropped the stale `-- axiomatized below` comment.

No change to `axiomCount` (still 0) or status — this is a documentation/clarity fix that keeps the code semantically identical (still `= 1`) while removing the misleading `Nat.find` construction.

## Evidence

Before:
```lean
/-- The size Ramsey number r̂(G, H): the minimum number of edges … -/
noncomputable def sizeRamsey {p q : ℕ} (G : Graph p) (H : Graph q) : ℕ :=
  Nat.find (⟨p * q + 1, Nat.le_add_left 1 (p * q)⟩ : ∃ m : ℕ, m ≥ 1)  -- axiomatized below
```

After: honest placeholder docstring + `:= 1`, no phantom comment.

Build: `./proofs/scripts/docker-build.sh Proofs.Erdos566Problem` → `Build succeeded` (2969 jobs).

Closes #42840

🤖 Generated with [Claude Code](https://claude.com/claude-code)
