### PR TITLE
Fix erdos-971: drop phantom axiom claims for unformalized Erdős 1949 results

### DIFF
--- a/src/data/proofs/erdos-971/annotations.json
+++ b/src/data/proofs/erdos-971/annotations.json
@@ -84,7 +84,7 @@
     },
     "type": "concept",
     "title": "Partial Result: Infinitely Many d",
-    "content": "**Erdős's first partial result** from 1949 establishes that the phenomenon in the main question DOES occur for infinitely many moduli d, even though we don't know if it occurs for ALL large d.\n\nThis is stated as an axiom because the proof uses Brun's sieve methods, which are not yet formalized in Mathlib. The key difference from the main question is `{...}.Infinite` instead of `∀ᶠ d in atTop`.\n\n**Why this matters**: Proving something for infinitely many values is often much easier than proving it for all sufficiently large values. This partial result shows the phenomenon is not impossible—it definitely happens—but leaves open whether it happens universally.",
+    "content": "**Erdős's first partial result** from 1949 establishes that the phenomenon in the main question DOES occur for infinitely many moduli d, even though we don't know if it occurs for ALL large d.\n\nThis result is **not formalized** in this file — it appears only as a prose comment, since the proof uses Brun's sieve methods, which are not yet formalized in Mathlib. No axiom, definition, or theorem in the Lean source states it.\n\n**Why this matters**: Proving something for infinitely many values is often much easier than proving it for all sufficiently large values. This partial result shows the phenomenon is not impossible—it definitely happens—but leaves open whether it happens universally.",
     "mathContext": "Brun's sieve is a combinatorial technique for counting primes satisfying multiple conditions. Erdős applied it to carefully constructed sequences of moduli with special multiplicative structure.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-971/meta.json
+++ b/src/data/proofs/erdos-971/meta.json
@@ -48,13 +48,13 @@
     "originalContributions": [
       "Defines leastCongruentPrime as the infimum of primes in an arithmetic progression",
       "States the open problem precisely using Mathlib filters for asymptotic behavior",
-      "Formalizes both of Erdős's 1949 partial results as axioms with documentation",
+      "Documents both of Erdős's 1949 partial results in prose comments (not formalized as Lean declarations, since their proofs use Brun's sieve methods not yet in Mathlib)",
       "Provides educational context connecting to Linnik's and Dirichlet's theorems",
       "Includes verified computational examples for small moduli"
     ],
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 143,
-    "assumptions": "No mathematical axioms and 0 sorries. Open problem — the conjectured bound on p(a,d) is not yet formalized. The status 'axiomatized' reflects the open mathematical question, not Lean axiom declarations. Compiler-trust disclosure: the concrete witnesses (example_p_3_10, example_p_1_10) are discharged with native_decide, so their axiom footprint includes Lean.ofReduceBool (kernel reduction trusts the compiled decision procedure); these are finite decidable computations and add no mathematical assumption, and leanFile.axiomCount remains 0 (no literal axiom declarations).",
+    "assumptions": "No mathematical axioms and 0 sorries. Open problem — the conjectured bound on p(a,d) is not yet formalized. Erdős's 1949 partial results are likewise not formalized as Lean declarations (no axiom, def, or theorem states them); they appear only as prose comments in the source, since their proofs use Brun's sieve methods not yet in Mathlib. The status 'axiomatized' reflects the open mathematical question, not Lean axiom declarations. Compiler-trust disclosure: the concrete witnesses (example_p_3_10, example_p_1_10) are discharged with native_decide, so their axiom footprint includes Lean.ofReduceBool (kernel reduction trusts the compiled decision procedure); these are finite decidable computations and add no mathematical assumption, and leanFile.axiomCount remains 0 (no literal axiom declarations).",
     "theoremCount": 2,
     "definitionCount": 2
   },
@@ -68,7 +68,7 @@
       "**Linnik's theorem**: Provides an upper bound p(a,d) ≤ c·d^L for some 'Linnik constant' L, currently known to satisfy L ≤ 5. This problem asks about the complementary lower bound behavior.",
       "**Expected size**: On average over residue classes, one expects p(a,d) ≈ φ(d)·log d by the prime number theorem for arithmetic progressions.",
       "**Brun's sieve**: The key tool in Erdős's 1949 partial results, allowing counting arguments for primes satisfying multiple congruence conditions.",
-      "**Open vs. solved variants**: The full statement (for ALL large d) remains open, but the statement for INFINITELY MANY d is proved."
+      "**Open vs. solved variants**: The full statement (for ALL large d) remains open; Erdős (1949) proved the statement for INFINITELY MANY d, but that proof is not formalized here — it is recorded only as a prose comment."
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -102,7 +102,7 @@
       "title": "Erdős's Partial Results (1949)",
       "startLine": 66,
       "endLine": 110,
-      "summary": "Formalizes both of Erdős's 1949 partial results: the statement for infinitely many d, and the complementary small prime bound."
+      "summary": "Documents (in prose comments, not as Lean declarations) both of Erdős's 1949 partial results: the statement for infinitely many d, and the complementary small prime bound."
     },
     {
       "id": "context",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-971
**Problem**: Erdős's two 1949 partial results are not formalized anywhere in
`Erdos971Problem.lean` — the two blocks at lines 79-98 are floating prose
comments with no attached `axiom`, `def`, or `theorem` (confirmed via
`grep -n axiom` returning zero hits in the whole file). Despite this,
`meta.json` and `annotations.json` describe them as formalized axioms in four
places, and `meta.axiomCount` was inflated to 1 against the file's correct
`leanFile.axiomCount: 0`.

## Evidence

**meta.json claims**:
- `originalContributions`: "Formalizes both of Erdős's 1949 partial results as axioms with documentation"
- `meta.axiomCount: 1`
- `sections[partial-results].summary`: "Formalizes both of Erdős's 1949 partial results..."
- `keyInsights`: "...the statement for INFINITELY MANY d is proved."

**annotations.json claims**:
- `ann-e971-infiniteseq.content`: "This is stated as an axiom because the proof uses Brun's sieve methods..."

**Lean file shows**: `grep -n axiom proofs/Proofs/Erdos971Problem.lean` → no matches. Lines 79-98 are bare `/- ... -/` comment blocks, not attached to any declaration. `leanFile.axiomCount: 0` (already correct).

## Fix

- `originalContributions` and the `partial-results` section summary now say the results are documented in prose comments, not formalized as Lean declarations.
- `meta.axiomCount` corrected 1 → 0 to match `leanFile.axiomCount` and the real file.
- `keyInsights` clarified that the "infinitely many d" proof is Erdős's (1949), not something formalized here.
- `annotations.json`'s "stated as an axiom" claim replaced with an explicit "not formalized" disclosure.

---
Discovered during gallery integrity audit (round-robin re-serve, last audited 2026-05-04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)