### PR TITLE
fix(erdos-954): correct axiomCount 1→0 to match own disclosure text

### DIFF
--- a/src/data/proofs/erdos-954/meta.json
+++ b/src/data/proofs/erdos-954/meta.json
@@ -54,7 +54,7 @@
       "IsB2Sequence: Sidon set definition for connection to Problem #28",
       "repCount_mono_k: monotonicity R_k(n) ≤ R_{k+1}(n) (proved)"
     ],
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 219,
     "assumptions": "No mathematical axioms and 0 sorries; previously cited axiom names were removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean. Compiler-trust disclosure: the concrete initial values of Rosen's greedy sequence (rosen_term_0 through rosen_term_10) are discharged with native_decide, so their axiom footprint includes Lean.ofReduceBool (kernel reduction trusts the compiled decision procedure). These are finite decidable computations and add no mathematical assumption; the structural theorems (monotonicity, growth, greedy bounds) are proved without native_decide and leanFile.axiomCount remains 0 (no literal axiom declarations).",
     "mathlib_version": "4.31.0",


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-954 (Rosen's Greedy Additive Sequence)
**Problem**: self-contradictory `meta.axiomCount` vs. `assumptions` prose.

## Evidence

PR #41306 (a native_decide-disclosure enrichment) flipped
`meta.axiomCount` from 0 to 1, while writing this into the same
`assumptions` field: *"the structural theorems ... are proved without
native_decide and leanFile.axiomCount remains 0 (no literal axiom
declarations)."*

`leanFile.axiomCount` was correctly left at 0. `grep -n axiom
proofs/Proofs/Erdos954Problem.lean` returns zero hits — there are no
`axiom` declarations anywhere in the file (0 sorries, 18 theorems, 9
defs, matching `leanFile`).

This is the same recurring class as erdos-325/422/267, fixed previously
in #42594 — the same enrichment batch inconsistently bumped
`meta.axiomCount` for some files while leaving `leanFile.axiomCount`
(and its own new prose) correctly at 0.

## Fix

Set `meta.axiomCount` back to 0, matching `leanFile.axiomCount`, the
`assumptions` text, and the actual Lean source.

---
Discovered during gallery integrity audit (reserve-mode re-verification).