### PR TITLE
Record erdos-954 audit completion in tracker (issues-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17626,9 +17626,9 @@
     },
     "erdos-954": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:44Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T02:01:53Z",
+      "result": "issues-fixed"
     },
     "erdos-955": {
       "agentId": "mechanic-tracker-sync",


### PR DESCRIPTION
Audit result for erdos-954 (Rosen's Greedy Additive Sequence): issues-fixed.

Found and fixed a self-contradictory `meta.axiomCount` (PR #41306 flipped
it 0→1 while its own disclosure prose said "leanFile.axiomCount remains
0"). Fix merged in #42859.