### PR TITLE
audit(erdos-945): fix annotation phantom-axiom claim on open conjecture

### DIFF
--- a/src/data/proofs/erdos-945/annotations.json
+++ b/src/data/proofs/erdos-945/annotations.json
@@ -123,18 +123,18 @@
     },
     "type": "concept",
     "title": "The Main Conjecture",
-    "content": "**Is F(x) ≤ (log x)^{O(1)}?**\n\nThis asks whether the longest run of consecutive integers with distinct divisor counts is bounded by a polynomial in log x. After 70+ years, this remains open.\n\nStated as an axiom since no proof exists.",
+    "content": "**Is F(x) ≤ (log x)^{O(1)}?**\n\nThis asks whether the longest run of consecutive integers with distinct divisor counts is bounded by a polynomial in log x. After 70+ years, this remains open.\n\nStated as a `Prop` definition (not proved, and not an axiom) since no proof exists.",
     "mathContext": "Erdos945Prop: ∃C>0, F(x) ≤ (log x)^C eventually. The O(1) means some constant exponent.",
     "significance": "key",
     "relatedConcepts": [
       "conjecture",
-      "axiom",
+      "open-problem",
       "polylogarithmic"
     ],
     "prerequisites": [
       "polylogarithmic growth ((log x)^C)",
       "the function F(x)",
-      "axioms for open (unproven) conjectures"
+      "unproven statements formalized as Prop definitions (not axioms)"
     ]
   },
   {


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-945 (Erdős Problem #945: Consecutive Integers with Distinct Divisor Counts)

**Problem**: `annotations.json`'s `ann-e945-conjecture` block claimed the open
conjecture is "Stated as an axiom since no proof exists," and listed "axiom"
as a related concept / prerequisite. The Lean source has zero `axiom`
declarations — `Erdos945Prop` is a `def Erdos945Prop : Prop := ...`, i.e. an
unproved proposition, not an axiom.

## Evidence

**annotations.json claimed**: "Stated as an axiom since no proof exists."
(`relatedConcepts` included `"axiom"`; `prerequisites` included `"axioms for
open (unproven) conjectures"`)

**Lean file shows** (`proofs/Proofs/Erdos945Problem.lean:85-86`):
```
def Erdos945Prop : Prop :=
  ∃ C : ℝ, C > 0 ∧ ∀ᶠ x in atTop, (F x : ℝ) ≤ x.log ^ C
```
`grep -n "^axiom" proofs/Proofs/Erdos945Problem.lean` → no matches.

## Fix

Reworded the annotation to describe `Erdos945Prop` as an unproved `Prop`
definition rather than an axiom, and swapped the "axiom" related-concept /
prerequisite for accurate wording.

Note: `meta.axiomCount: 1` vs `leanFile.axiomCount: 0` was checked and is
**not** a bug — it's the intentional `native_decide` / `Lean.ofReduceBool`
compiler-trust disclosure added in #41293 for the `tau_1`/`tau_2`/`tau_6`/
`tau_12` witnesses. Left untouched.

---
Discovered during gallery integrity audit (recurring phantom-axiom-narrative
class — annotation/comment text describing a conjecture as "axiomatized"
with no corresponding `axiom` declaration in the source).