### PR TITLE
Enrich bell-numbers-oq-01-oq-03: split inductive-step section (98->100)

### DIFF
--- a/src/data/proofs/bell-numbers-oq-01-oq-03/meta.json
+++ b/src/data/proofs/bell-numbers-oq-01-oq-03/meta.json
@@ -92,8 +92,16 @@
       "id": "row-sum",
       "title": "The Row-Sum Identity Σ c(n,k) = n!",
       "startLine": 49,
+      "endLine": 56,
+      "summary": "stirlingFirst_row_sum: Σ_{k∈range(n+1)} c(n, k) = n!, by induction on n. Statement and base case (n = 0, closed by simp); the inductive step is the content of the next section.",
+      "mathContext": "$\\sum_{k=0}^{n} c(n, k) = n!$: summing the number of $n$-permutations with exactly $k$ cycles over all $k$ recovers the total $n!$."
+    },
+    {
+      "id": "row-sum-inductive-step",
+      "title": "The Inductive Step: Peel, Re-index, Collapse",
+      "startLine": 57,
       "endLine": 79,
-      "summary": "stirlingFirst_row_sum: Σ_{k∈range(n+1)} c(n, k) = n!, by induction on n. The (n+1)-st row is split by sum_range_succ' (k=0 term c(n+1,0)=0) and each c(n+1,i+1) expanded by the recurrence, giving n·(Σ_i c(n,i+1)) + (Σ_i c(n,i)). The second sum is the IH; the first is handled by the re-index identity hsplit plus mul_stirlingFirst_zero, yielding n·n!. Then (n+1)·n! = (n+1)! by ring and Nat.factorial_succ.",
+      "summary": "The succ case of stirlingFirst_row_sum. The (n+1)-st row is split by sum_range_succ' (k=0 term c(n+1,0)=0) and each c(n+1,i+1) expanded by the recurrence, giving n·(Σ_i c(n,i+1)) + (Σ_i c(n,i)). The second sum is the IH; the first is handled by the re-index identity hsplit plus mul_stirlingFirst_zero, yielding n·n!. Then (n+1)·n! = (n+1)! by ring and Nat.factorial_succ.",
       "mathContext": "The recurrence collapse: $\\sum_k c(n{+}1, k) = n\\left(\\sum_k c(n,k)\\right) + \\sum_k c(n,k) = (n+1)\\, n! = (n+1)!$, once the shifted sum is reconciled with the full $n$-th row via the vanishing $k=0$ term."
     },
     {


### PR DESCRIPTION
## Summary
- `sections` had 4 entries; the quality scorer caps this sub-score at 2 points/section up to 5 (98/100 overall, missing the last 2 points).
- The "row-sum" section (lines 49-79) merged the theorem statement/base-case with the entire inductive step into one block, while the annotations.json already split this same range into two annotations (`ann-sf1-3` at 49-56, `ann-sf1-3-step` at 57-79) at the real `induction n with | zero => ... | succ n ih => ...` case boundary in `proofs/Proofs/BellNumbersOQ01OQ03.lean`.
- Split the section the same way: "row-sum" now covers the statement + base case (49-56), and a new "row-sum-inductive-step" covers the succ-case mechanics (57-79) — no content invented, just re-anchored to match the existing annotation boundary and the actual Lean case split.
- Quality score: 98 -> 100 (verified locally against the same formula `scripts/enricher/find-targets.ts` uses).

## Test plan
- [x] `python3 -c "import json; json.load(...)"` — meta.json is valid JSON
- [x] Recomputed the quality-score breakdown locally: 100/100
- [x] `pnpm build` ran the data-manifest/gallery build step cleanly (only fails later at the known missing-`tsc` environment gap, unrelated to this change)