### PR TITLE
Enrich cassini-identity-oq-01-oq-02: cover duplication/d'Ocagne sections, add adjugate keyInsight (98->100)

### DIFF
--- a/src/data/proofs/cassini-identity-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cassini-identity-oq-01-oq-02/annotations.json
@@ -57,5 +57,29 @@
     "significance": "key",
     "prerequisites": ["Matrix.det_pow", "Matrix.det_fin_two_of"],
     "relatedConcepts": ["Cassini's identity", "Determinant multiplicativity", "Alternating sign"]
+  },
+  {
+    "id": "ann-duplication",
+    "proofId": "cassini-identity-oq-01-oq-02",
+    "range": { "startLine": 132, "endLine": 156 },
+    "type": "theorem",
+    "title": "Duplication Formulas: the m = n Diagonal",
+    "content": "Setting $m = n$ in the two addition formulas — i.e. reading the entries of the *square* $Q^{n+1}\\cdot Q^{n+1} = Q^{2n+2}$ — collapses them to the classical Fibonacci duplication identities, with no new induction. `fib_two_mul_add_one` is the $(2,2)$ entry at $m=n$: $F_{2n+1} = F_{n+1}^2 + F_n^2$, the classical fact that an odd-index Fibonacci number is a sum of two consecutive squares. `fib_two_mul_add_two` is the $(1,2)$ entry at $m=n$: $F_{2n+2} = F_{n+2}F_{n+1} + F_{n+1}F_n$. Both proofs are one line: rewrite $2n{+}1$ (resp. $2n{+}2$) as $n+n+1$ (resp. $n+n+2$) by `ring`, then substitute the already-proved addition formula at $m=n$.",
+    "mathContext": "$F_{2n+1} = F_{n+1}^2 + F_n^2$ and $F_{2n+2} = F_{n+2}F_{n+1} + F_{n+1}F_n$ — the diagonal $m=n$ specialization of the addition formulas, needing no separate proof.",
+    "significance": "supporting",
+    "prerequisites": ["fib_add_matrix", "fib_add_offdiag"],
+    "relatedConcepts": ["Fibonacci duplication identities", "diagonal specialization", "fast-doubling algorithm"]
+  },
+  {
+    "id": "ann-docagne-adjugate",
+    "proofId": "cassini-identity-oq-01-oq-02",
+    "range": { "startLine": 158, "endLine": 221 },
+    "type": "insight",
+    "title": "Subtraction Identities Without an Inverse: the Adjugate Factorisation",
+    "content": "The addition formulas read entries of the *product* $Q^a\\cdot Q^b = Q^{a+b}$; classical *subtraction*-type identities (d'Ocagne, Catalan, Vajda) instead need a difference index $F_{a-b}$, i.e. an *inverse* power $Q^{a-b} = Q^a(Q^b)^{-1}$. This file avoids ever forming $(Q^b)^{-1}$ — and the associated $F_{-1}$ convention — by using the **adjugate** instead: since $A\\cdot\\operatorname{adj}(A) = (\\det A)\\bullet 1$ (`Matrix.mul_adjugate`) and $\\det(Q^{n+1}) = (-1)^{n+1}$, the factorisation $Q^{m+n+1}\\cdot\\operatorname{adj}(Q^{n+1}) = (-1)^{n+1}\\bullet Q^m$ (`Q_adj_factor`) lands on a genuine, non-negative power $Q^m$ rather than a negative one. `Q_pow_entry_10` extends the $(2,1)$-entry-is-$F_m$ fact to every $m$ including $m=0$ (needed because the adjugate factorisation can produce $Q^0$). Reading the $(2,1)$ entry of the adjugate factorisation gives `fib_dOcagne`: $F_{m+n+1}F_n - F_{m+n}F_{n+1} = (-1)^{n+1}F_m$ — the standard identity $F_aF_{b+1}-F_{a+1}F_b=(-1)^bF_{a-b}$ at $a=m+n,\\,b=n$, with the difference $a-b=m$ materialised as the bare exponent of $Q^m$. Mathlib has no Fibonacci companion matrix and none of d'Ocagne, Catalan, or Vajda's identities, so both the adjugate technique and its corollary are new.",
+    "mathContext": "$Q^{m+n+1}\\cdot\\operatorname{adj}(Q^{n+1}) = (-1)^{n+1}\\bullet Q^m$; its $(2,1)$ entry is $F_{m+n+1}F_n - F_{m+n}F_{n+1} = (-1)^{n+1}F_m$ (d'Ocagne), with the subtraction index $m$ realised as a non-negative exponent instead of $F_{-1}$.",
+    "significance": "key",
+    "prerequisites": ["Matrix.mul_adjugate", "Matrix.adjugate_fin_two_of", "Q_pow_succ_det", "pow_add"],
+    "relatedConcepts": ["d'Ocagne's identity", "matrix adjugate", "avoiding negative exponents/inverses", "Catalan's identity", "Vajda's identity"]
   }
 ]

--- a/src/data/proofs/cassini-identity-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cassini-identity-oq-01-oq-02/meta.json
@@ -143,7 +143,8 @@
       "**Associativity is the addition formula.** $Q^{m+n} = Q^m Q^n$ holds for the trivial reason that exponents add; reading off the $(1,2)$ entry turns this triviality into the Fibonacci addition law.",
       "**One factorisation, many identities.** The same equation $Q^{(m+1)+(n+1)} = Q^{m+1}Q^{n+1}$ yields the $(2,2)$ identity (= Mathlib's `Nat.fib_add`), the $(1,2)$ addition formula, and — via the determinant — Cassini. No per-identity induction is needed.",
       "**The closed power is the only induction.** All the combinatorial content is concentrated in $Q^{n+1} = !![F_{n+2},F_{n+1};F_{n+1},F_n]$; everything afterward is entry-reading and casting.",
-      "**Stay in ℤ.** Working with $(F_k : \\mathbb{Z})$ entries keeps matrix multiplication, the determinant, and the subtraction in Cassini genuine, with `ring` handling the entrywise algebra."
+      "**Stay in ℤ.** Working with $(F_k : \\mathbb{Z})$ entries keeps matrix multiplication, the determinant, and the subtraction in Cassini genuine, with `ring` handling the entrywise algebra.",
+      "**The adjugate replaces the inverse.** Subtraction-type identities like d'Ocagne's need a difference index $F_{a-b}$, which naively calls for $Q^{a-b} = Q^a(Q^b)^{-1}$. Since $A\\cdot\\operatorname{adj}(A) = (\\det A)\\bullet 1$ needs no inverse, substituting the adjugate for $(Q^{n+1})^{-1}$ in the factorisation keeps every exponent non-negative and sidesteps the $F_{-1}$ convention entirely — extending the 'one factorisation, many identities' pattern from products to differences."
     ],
     "prerequisites": [
       "Matrix multiplication, powers, and the determinant",


### PR DESCRIPTION
## Summary
- Genuine annotation-coverage gap: the file's second half — lines 132-221, covering the duplication formulas AND the d'Ocagne/adjugate technique that the entry's own description calls its most novel contribution ("Mathlib records no Fibonacci companion matrix and none of d'Ocagne/Catalan/Vajda") — had zero annotations, despite 3 meta.json `sections` covering that exact range.
- Added two new annotations matching those sections: `ann-duplication` (132-156, the m=n diagonal specialization) and `ann-docagne-adjugate` (158-221, the adjugate-instead-of-inverse technique and its d'Ocagne corollary), bringing annotation count 5 -> 7.
- Also added a 5th `keyInsight` about the adjugate trick (A·adj(A) = det(A)•1 avoids ever forming a matrix inverse or negative Fibonacci index) — genuinely novel content from the file's second half that wasn't reflected in any of the 4 existing keyInsights (all of which only covered the addition-formula/Cassini half).
- Quality score: 98 -> 100 (verified locally against the same formula `scripts/enricher/find-targets.ts` uses).

## Test plan
- [x] `python3 -c "import json; json.load(...)"` — both meta.json and annotations.json are valid JSON
- [x] Recomputed the quality-score breakdown locally: 100/100
- [x] `pnpm build` ran the data-manifest/gallery build step cleanly earlier in this session (only fails later at the known missing-`tsc` environment gap, unrelated to this change)