### PR TITLE
Audit: erdos-89 phantom axiom narrative in meta.json + annotations.json

### DIFF
--- a/src/data/proofs/erdos-89/annotations.json
+++ b/src/data/proofs/erdos-89/annotations.json
@@ -124,18 +124,16 @@
     },
     "type": "concept",
     "title": "Guth-Katz Theorem (2015)",
-    "content": "**guthKatz** is the breakthrough result: g(n) ≥ c·n/log n for some c > 0.\n\nThis is weaker than the conjecture by a factor of √(log n), but was a major breakthrough after decades of work.\n\n**Why an axiom?** The proof uses sophisticated algebraic geometry techniques (polynomial partitioning).",
+    "content": "The **Guth-Katz Theorem** is the breakthrough result: g(n) ≥ c·n/log n for some c > 0.\n\nThis is weaker than the conjecture by a factor of √(log n), but was a major breakthrough after decades of work.\n\nThis result is described in a comment block, not formalized as a Lean axiom or theorem — the proof uses sophisticated algebraic geometry techniques (polynomial partitioning) outside the scope of this file.",
     "mathContext": "Guth and Katz proved this using a polynomial method, counting incidences between points and lines in 3D.",
     "significance": "key",
     "relatedConcepts": [
-      "axiom",
       "guth-katz",
       "polynomial-method"
     ],
     "prerequisites": [
       "Polynomial Partitioning",
-      "Incidence Geometry",
-      "Lean Axioms"
+      "Incidence Geometry"
     ]
   },
   {
@@ -147,11 +145,10 @@
     },
     "type": "concept",
     "title": "Grid Upper Bound",
-    "content": "**gridUpperBound** states: g(n) ≤ c·n/√(log n) for some c > 0.\n\nThe √n × √n integer grid achieves this bound, showing the conjecture is tight if true.\n\nThis uses number theory: the count of integers ≤ x representable as sums of two squares.",
+    "content": "The **grid upper bound** states: g(n) ≤ c·n/√(log n) for some c > 0.\n\nThe √n × √n integer grid achieves this bound, showing the conjecture is tight if true.\n\nThis is described in a comment block, not formalized as a Lean axiom or theorem — the argument uses number theory: the count of integers ≤ x representable as sums of two squares.",
     "mathContext": "The Landau-Ramanujan constant governs this: |{n ≤ x : n = a² + b²}| ~ Kx/√(log x).",
     "significance": "key",
     "relatedConcepts": [
-      "axiom",
       "upper-bound",
       "integer-grid",
       "sums-of-squares"
@@ -171,7 +168,7 @@
     },
     "type": "concept",
     "title": "Conjecture Implies Guth-Katz",
-    "content": "**conjecture_implies_guthKatz** shows the conjecture is strictly stronger than Guth-Katz.\n\nThe key: n/√(log n) > n/log n for large n, since √(log n) < log n.\n\nThis is a genuine Lean theorem (with one sorry for the inequality).",
+    "content": "**conjecture_implies_guthKatz** shows the conjecture is strictly stronger than Guth-Katz.\n\nThe key: n/√(log n) > n/log n for large n, since √(log n) < log n.\n\nThis is a genuine Lean theorem, fully proved (0 sorries).",
     "mathContext": "The proof uses `filter_upwards` to work with the eventually filter and `calc` for the chain of inequalities.",
     "significance": "key",
     "relatedConcepts": [
@@ -194,7 +191,7 @@
     },
     "type": "concept",
     "title": "Historical Development",
-    "content": "The problem saw steady progress over decades:\n\n- **1992**: Chung proves Ω(n^(4/5))\n- **2001**: Solymosi-Tóth prove Ω(n^(6/7))\n- **2004**: Tardos proves Ω(n^0.8641)\n- **2015**: Guth-Katz prove Ω(n/log n)\n\n**chung1992** and **tardos2004** are axioms for these historical bounds.",
+    "content": "The problem saw steady progress over decades:\n\n- **1992**: Chung proves Ω(n^(4/5))\n- **2001**: Solymosi-Tóth prove Ω(n^(6/7))\n- **2004**: Tardos proves Ω(n^0.8641)\n- **2015**: Guth-Katz prove Ω(n/log n)\n\nThese historical bounds are described in prose only; they are not formalized as Lean declarations (no `chung1992` or `tardos2004` axioms or theorems exist in this file).",
     "mathContext": "The exponent improved from 0.8 to 0.86 to... finally escaping polynomial bounds in 2015.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-89/meta.json
+++ b/src/data/proofs/erdos-89/meta.json
@@ -50,8 +50,8 @@
       "Definition of distinct distances for point sets",
       "Minimum distinct distances function g(n)",
       "Erdos89Conjecture as Ω(n/√(log n)) lower bound",
-      "Axiom for Guth-Katz Ω(n/log n) result",
-      "Axiom for grid upper bound O(n/√(log n))",
+      "Historical note (comment, not a Lean declaration) on Guth-Katz's Ω(n/log n) result",
+      "Historical note (comment, not a Lean declaration) on the grid upper bound O(n/√(log n))",
       "Theorem showing conjecture implies Guth-Katz",
       "Historical bounds from Chung and Tardos"
     ],
@@ -65,7 +65,7 @@
     "historicalContext": "The distinct distances problem is one of Erdős's most famous problems in combinatorial geometry, posed in 1946. Given n points in the plane, how many distinct pairwise distances must exist?\n\nThe √n × √n integer grid has only O(n/√(log n)) distinct distances, showing this bound would be tight if true. Erdős offered $500 for a proof.\n\nAfter decades of progress (Chung 1992, Solymosi-Tóth 2001, Tardos 2004), Guth and Katz made a breakthrough in 2015, proving Ω(n/log n) distinct distances using algebraic methods. This is tantalizingly close to Erdős's conjecture, differing only by a factor of √(log n).",
     "problemStatement": "**Erdős Problem #89 (OPEN)**\n\nDoes every set of $n$ distinct points in $\\mathbb{R}^2$ determine at least $\\Omega(n/\\sqrt{\\log n})$ distinct distances?\n\n**Known Results**:\n- Guth-Katz (2015): $\\Omega(n/\\log n)$ distinct distances\n- Grid construction: $O(n/\\sqrt{\\log n})$ is achievable\n\n**Prize**: $500",
     "text": "Does every set of n distinct points in ℝ² determine ≫ n/√(log n) many distinct distances?",
-    "proofStrategy": "We formalize the key concepts and partial results:\n\n1. **distinctDistances**: Set of pairwise distances for a point set\n\n2. **minDistinctDistances**: Minimum over all n-point sets\n\n3. **Erdos89Conjecture**: The Ω(n/√(log n)) lower bound\n\n4. **guthKatz** (axiom): The Ω(n/log n) partial result\n\n5. **gridUpperBound** (axiom): The O(n/√(log n)) construction\n\n6. **conjecture_implies_guthKatz**: Conjecture implies Guth-Katz",
+    "proofStrategy": "We formalize the key concepts and partial results:\n\n1. **distinctDistances**: Set of pairwise distances for a point set\n\n2. **minDistinctDistances**: Minimum over all n-point sets\n\n3. **Erdos89Conjecture**: The Ω(n/√(log n)) lower bound\n\n4. Guth-Katz's Ω(n/log n) partial result is described in a comment, not formalized as a Lean declaration\n\n5. The O(n/√(log n)) grid upper bound is described in a comment, not formalized as a Lean declaration\n\n6. **conjecture_implies_guthKatz**: Conjecture implies Guth-Katz",
     "keyInsights": [
       "**The grid construction**: A √n × √n integer grid achieves O(n/√(log n)) distinct distances, showing the conjecture would be tight.",
       "**Guth-Katz breakthrough**: Their 2015 proof used polynomial partitioning and incidence geometry, achieving Ω(n/log n).",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-89
**Problem**: meta.json and annotations.json describe named "axioms" (`guthKatz`, `gridUpperBound`, `chung1992`, `tardos2004`) that don't exist anywhere in the Lean source, plus one annotation falsely claims a fully-proved theorem "has one sorry".

## Evidence

**Lean file** (`proofs/Proofs/Erdos89Problem.lean`): verified via grep — 0 `axiom` declarations, 0 `sorry`. The Guth-Katz result and grid upper bound appear only as prose in `/- ... -/` comment blocks (lines 93-106), never as `axiom` or `theorem` decls.

**meta.json claimed**:
- `originalContributions`: "Axiom for Guth-Katz Ω(n/log n) result", "Axiom for grid upper bound O(n/√(log n))"
- `proofStrategy`: "**guthKatz** (axiom)...", "**gridUpperBound** (axiom)..."

**annotations.json claimed**:
- `ann-e89-guthkatz`: "**guthKatz** is the breakthrough result... Why an axiom?", tagged `"axiom"` in relatedConcepts / "Lean Axioms" in prerequisites
- `ann-e89-grid`: "**gridUpperBound** states...", tagged `"axiom"`
- `ann-e89-history`: "**chung1992** and **tardos2004** are axioms for these historical bounds"
- `ann-e89-implies`: "This is a genuine Lean theorem (with one sorry for the inequality)" — but `conjecture_implies_guthKatz` is fully proved with 0 sorries

## Fix (applied in this PR)

Reworded all five locations to state these historical results are prose/comments only, not Lean declarations (no axiom, no theorem), and corrected the sorry claim to reflect the theorem is fully proved. `meta.assumptions` already said "0 axioms, 0 sorries... Previously cited axiom names have been removed from the Lean source" — this PR extends that same cleanup to the `originalContributions`, `proofStrategy`, and `annotations.json` fields that a prior pass missed.

---
Discovered during gallery integrity audit (reserve re-audit, queue was fully drained: 0 unaudited, 0 with issues).