### PR TITLE
audit: refresh tracker for erdos-89 (clean, re-verified)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17146,8 +17146,8 @@
     },
     "erdos-89": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:44Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T02:17:09Z",
       "result": "clean"
     },
     "erdos-890": {


### PR DESCRIPTION
## Summary
- erdos-89's tracker entry had a stale `lastAudited` (2026-05-04), predating the phantom-axiom-narrative fix merged in #42877.
- `find-targets --next` resurfaced erdos-89 as a result. Re-verified `meta.json`/`annotations.json` still reflect the fix (0 axioms, phantom axiom names removed, honest "not formalized as a Lean axiom" disclosures).
- No content changes needed — just refreshing `auditCount`/`lastAudited` so the tracker stops resurfacing an already-fixed entry.

## Test plan
- [x] Confirmed meta.json/annotations.json content matches the merged fix from #42877
- [x] `claim-target.sh complete erdos-89 clean` updated the tracker locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)