### PR TITLE
audit(erdos-873): disclose 2 undisclosed sorries in companion file

### DIFF
--- a/src/data/proofs/erdos-873/annotations.json
+++ b/src/data/proofs/erdos-873/annotations.json
@@ -147,11 +147,11 @@
     },
     "type": "concept",
     "title": "Erdős-Szemerédi Upper Bound",
-    "content": "**Known result**: For k = 3 and any sequence A, we have F(A,X,3) ≪ X^(1/3) log X.\n\nThis shows the exponent 1/3 is achievable for 3-term windows. Stated as an axiom since the proof requires deep number-theoretic analysis.",
+    "content": "**Known result**: For k = 3 and any sequence A, we have F(A,X,3) ≪ X^(1/3) log X.\n\nThis shows the exponent 1/3 is achievable for 3-term windows. This file documents it only as source commentary (no Lean declaration here); the companion file `Erdos873ProblemProvable.lean` states it as a `sorry`-terminated theorem, not an axiom.",
     "mathContext": "The X^(1/3) factor comes from counting solutions to a*b*c being 'smooth' (having small prime factors). The log X factor accounts for multiplicity.",
     "significance": "key",
     "relatedConcepts": [
-      "axiom",
+      "sorry",
       "upper-bound",
       "k-equals-3"
     ],
@@ -174,7 +174,7 @@
     "mathContext": "The construction of extremal sequences uses number-theoretic techniques to maximize the count of small-LCM triples.",
     "significance": "supporting",
     "relatedConcepts": [
-      "axiom",
+      "sorry",
       "lower-bound",
       "tightness"
     ],

--- a/src/data/proofs/erdos-873/meta.json
+++ b/src/data/proofs/erdos-873/meta.json
@@ -42,14 +42,14 @@
     "originalContributions": [
       "Definition of consecutive LCM counting function F(A,X,k)",
       "Formal statement of the open conjecture as a `Prop` (`lcmConjecture`)",
-      "Documentation of the Erdős-Szemerédi bounds on F(A,X,3) (recorded in source comments; not formalized as axioms or theorems)",
+      "Formal statement of the Erdős-Szemerédi bounds on F(A,X,3) as `sorry`-terminated theorems in the companion file `Erdos873ProblemProvable.lean` (statements are formalized; proofs are not supplied)",
       "Verified examples for natural and exponential sequences"
     ],
     "axiomCount": 1,
     "lineCount": 148,
     "assumptions": [
       "Lean.ofReduceBool — the named theorem `consecutiveLcm_powers_of_two` is discharged with `native_decide` in its base cases, which trusts the Lean compiler's kernel evaluation rather than producing a checked proof term. This compiler-trust footprint is the only assumption the formalization introduces (there are no `axiom` declarations in the source).",
-      "The Erdős-Szemerédi (1992) bounds for k=3 (upper F(A,X,3) ≪ X^{1/3} log X for all strictly increasing A; matching lower bound ≫ X^{1/3} log X infinitely often) are documented in the source as background context — they are NOT formalized as Lean axioms or theorems."
+      "The companion file `Erdos873ProblemProvable.lean` (listed under `leanFile.additionalFiles`) states the Erdős-Szemerédi (1992) k=3 bounds as two `theorem`s (`erdos_szemeredi_upper_bound`, `erdos_szemeredi_lower_bound`) but both are discharged with `sorry` — they are formalized statements without proofs, not proved theorems and not axioms."
     ],
     "dateAdded": "2025-12-22",
     "prerequisites": [
@@ -59,7 +59,8 @@
       "Prime factorization and multiplicative functions"
     ],
     "theoremCount": 4,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "sorries": 2
   },
   "overview": {
     "historicalContext": "This problem was posed by Erdős and Szemerédi in their work on multiplicative properties of sequences. It asks about the fundamental question: how many consecutive terms of a sequence can have 'small' LCM?\n\nThe LCM of consecutive terms measures their multiplicative dependence. If terms share many prime factors, their LCM is relatively small. The question is whether, for any sequence, we can always find a window size k such that few k-tuples have LCM below any threshold X^ε.\n\nErdős and Szemerédi proved tight bounds for k=3: F(A,X,3) grows like X^(1/3) log X in the worst case. The general conjecture asks whether the exponent can be made arbitrarily small by increasing k.",
@@ -183,5 +184,5 @@
       "description": "Related Erdős problem sharing themes: number-theory, sequences"
     }
   ],
-  "sorries": 0
+  "sorries": 2
 }


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-873 (Erdős-Szemerédi LCM Conjecture)
**Problem**: `meta.json` claimed `sorries: 0` (top-level, `meta.sorries`, and `leanFile.sorries`), but the companion file `Proofs/Erdos873ProblemProvable.lean` — explicitly listed in `leanFile.additionalFiles` and compiled as part of the `proofs/` package — contains two `sorry`-terminated theorems (`erdos_szemeredi_upper_bound`, `erdos_szemeredi_lower_bound`) formalizing the Erdős-Szemerédi k=3 bounds.

`originalContributions` and `assumptions` also claimed these bounds were "documented in source comments... not formalized as axioms or theorems." That's only true of the *primary* file (`Erdos873Problem.lean`, which has bare comments, no declaration). The companion file does formalize them — as unproved (`sorry`) theorem statements.

Two `annotations.json` entries (`ann-e873-upper-bound`, `ann-e873-lower-bound`) separately mislabeled the same bounds as "stated as an axiom" — no `axiom` is declared anywhere for these; the companion file uses `sorry`, not `axiom`.

## Evidence

**meta.json claimed**: `sorries: 0` everywhere; bounds "not formalized as axioms or theorems"
**Lean file shows**: `proofs/Proofs/Erdos873ProblemProvable.lean:111` and `:119` — both `theorem ... := by sorry`

## Fix

- `meta.sorries` and top-level `sorries`: `0` → `2` (aggregate across primary + companion file, consistent with how `meta.axiomCount` already diverges from `leanFile.axiomCount` for the disclosed `native_decide` axiom). `leanFile.sorries` left at `0` since it's scoped to the primary file only.
- `originalContributions`: corrected to say the bounds are formalized as `sorry`-terminated theorems in the companion file, not merely documented in comments.
- `assumptions`: added disclosure of the companion file's two sorries.
- `annotations.json`: reworded the two entries that called the sorry'd bounds "an axiom".

Badge (`wip`) and status (`axiomatized`) were already appropriately conservative and don't need to change — this is purely a numeric/prose disclosure fix.

---
Discovered during gallery integrity audit (round-robin re-serve, queue was fully drained: 4811/4811 audited).