### PR TITLE
audit(erdos-873): fix meta.additionalFiles location for auditor tooling

### DIFF
--- a/src/data/proofs/erdos-873/meta.json
+++ b/src/data/proofs/erdos-873/meta.json
@@ -60,7 +60,10 @@
     ],
     "theoremCount": 4,
     "definitionCount": 3,
-    "sorries": 2
+    "sorries": 2,
+    "additionalFiles": [
+      "Proofs/Erdos873ProblemProvable.lean"
+    ]
   },
   "overview": {
     "historicalContext": "This problem was posed by Erdős and Szemerédi in their work on multiplicative properties of sequences. It asks about the fundamental question: how many consecutive terms of a sequence can have 'small' LCM?\n\nThe LCM of consecutive terms measures their multiplicative dependence. If terms share many prime factors, their LCM is relatively small. The question is whether, for any sequence, we can always find a window size k such that few k-tuples have LCM below any threshold X^ε.\n\nErdős and Szemerédi proved tight bounds for k=3: F(A,X,3) grows like X^(1/3) log X in the worst case. The general conjecture asks whether the exponent can be made arbitrarily small by increasing k.",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-873
**Problem**: `find-targets.ts` flagged a false "sorry mismatch: claims 2, actual 0"

## Evidence

**meta.json claims**: `meta.sorries: 2` (correctly counting the 2 disclosed
sorries in the companion file `Erdos873ProblemProvable.lean`).

**Lean file shows**: main file `Erdos873Problem.lean` has 0 sorries; companion
file has exactly 2 (`erdos_szemeredi_upper_bound`, `erdos_szemeredi_lower_bound`),
matching the claim.

**Root cause**: `resolveAllLeanFiles()` in `scripts/auditor/find-targets.ts`
follows companion files via `meta.meta.additionalFiles`, but erdos-873's
`meta.json` only listed the companion file under `meta.leanFile.additionalFiles`
(added in #42888). Without it under `meta.meta`, the script never reads the
companion file, so it computed 0 total sorries and flagged a mismatch against
the (accurate) claim of 2.

## Fix

Added `"additionalFiles": ["Proofs/Erdos873ProblemProvable.lean"]` under
`meta.meta`, matching the convention used by every other entry with a
companion file (e.g. erdos-877, erdos-625, erdos-1091). No prose or count
changed — this only restores the auditor script's ability to see the
already-accurate disclosure.

Verified locally: `find-targets.ts --issues` goes from 1 flagged entry to 0
after this change.

---
Discovered during gallery integrity audit.