### PR TITLE
audit: refresh tracker for erdos-873 (issues-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17035,8 +17035,8 @@
     },
     "erdos-873": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-07-24T02:26:45Z",
+      "auditCount": 6,
+      "lastAudited": "2026-07-24T02:30:57Z",
       "result": "issues-fixed"
     },
     "erdos-874": {


### PR DESCRIPTION
Tracker refresh following #42890 (fixed missing meta.additionalFiles causing false sorry-mismatch flag).