### PR TITLE
Research: erdos-507-wip-01 — sharp bound heilbronn 3 = 3√3/4 (first exact value, 0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos507WIP01Sharp.lean
+++ b/proofs/Proofs/Erdos507WIP01Sharp.lean
@@ -1,0 +1,195 @@
+/-
+# Heilbronn's Triangle Problem — the sharp bound `heilbronn 3 = 3√3/4`
+
+**Erdős Problem #507 (WIP satellite): sharp maximal-triangle bound.**
+
+This file closes the `n = 3` sandwich of `Proofs/Erdos507WIP01.lean`: it proves
+the sharp upper bound
+
+    every triangle with vertices in the closed unit disk has area ≤ 3√3/4,
+
+hence `heilbronn 3 ≤ 3√3/4`, which together with the inscribed-equilateral
+lower bound `heilbronn_three_ge` pins the **exact value**
+
+    heilbronn 3 = 3√3/4.
+
+This is the first exact value in the Heilbronn ladder (previously
+`heilbronn 3 ∈ [3√3/4, 3/2]`).  As corollaries every upper endpoint in the
+ladder improves from `3/2` to `3√3/4 ≈ 1.299`:
+`heilbronn 4 ∈ [1, 3√3/4]` and `heilbronn 5 ∈ [81/125, 3√3/4]`.
+
+## Why the classical route was blocked, and the mechanism used instead
+
+The classical proof parametrises the three vertices on the circle by central
+angles and maximises `sin α + sin β + sin γ` under `α + β + γ = 2π` by Jensen
+(concavity of `sin` on `[0, π]`), after a separate compactness/perturbation
+argument moving the vertices to the boundary — several hundred lines of
+friction-prone geometry.  A direct `nlinarith` attack on the six-variable
+degree-4 optimisation also fails (the maximum sits at an irrational point).
+
+The mechanism here avoids both obstacles by exploiting that the signed shoelace
+sum `E = (p×q) + (q×r) + (r×p)` is **affine in each vertex**:
+
+1. `E = p × (q − r) + q × r`, and Cauchy–Schwarz (via Lagrange's identity)
+   bounds the `p`-part by `t := ‖q − r‖`, eliminating `p` entirely.
+2. With `s := q × r` and `u := ⟨q, r⟩`, Lagrange gives `s² + u² ≤ 1` and the
+   norm expansion gives `t² ≤ 2 − 2u`.
+3. The square completion `(t − 2s)² ≥ 0` yields `(t+s)² ≤ (3/2)t² + 3s²`, and
+   substituting the two bounds gives
+   `(t+s)² ≤ 6 − 3u − 3u² = 27/4 − 3(u + 1/2)² ≤ 27/4 = (3√3/2)²`.
+
+Every step is an exact polynomial certificate, so each is a small `nlinarith`
+call; the irrational maximiser never has to be located.  Equality holds for the
+inscribed equilateral triangle (`u = −1/2`, `t = √3`, `s = √3/2`), which is why
+the bound is sharp.
+
+All results are `0`-axiom / `0`-sorry.
+-/
+
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Data.Real.Basic
+import Mathlib.Tactic
+import Proofs.Erdos507WIP01
+
+namespace Erdos507WIP01
+
+/-! ## Lagrange's identity -/
+
+/-- **Lagrange's identity in the plane.**  For vectors `a = (a₁, a₂)` and
+`b = (b₁, b₂)`, the cross product and the inner product satisfy
+`(a × b)² + ⟨a, b⟩² = |a|²·|b|²`.  This single algebraic identity powers both
+Cauchy–Schwarz steps of the sharp bound below. -/
+theorem cross_sq_add_dot_sq (a₁ a₂ b₁ b₂ : ℝ) :
+    (a₁ * b₂ - a₂ * b₁) ^ 2 + (a₁ * b₁ + a₂ * b₂) ^ 2
+      = (a₁ ^ 2 + a₂ ^ 2) * (b₁ ^ 2 + b₂ ^ 2) := by
+  ring
+
+/-! ## The master inequality -/
+
+/-- **Sharp shoelace bound in the unit disk.**  For three points
+`p = (p₁,p₂)`, `q = (q₁,q₂)`, `r = (r₁,r₂)` in the closed unit disk, the signed
+shoelace sum satisfies `E ≤ 3√3/2` (so the triangle area `|E|/2` is at most
+`3√3/4`).
+
+The proof eliminates `p` first: `E = p × (q−r) + q × r ≤ ‖q−r‖ + q × r` by
+Cauchy–Schwarz, and then the two-variable bound
+`(‖q−r‖ + q×r)² ≤ 27/4` follows from Lagrange's identity plus two completed
+squares (`(t−2s)² ≥ 0` and `(u+1/2)² ≥ 0`).  Equality: the inscribed
+equilateral triangle. -/
+theorem signed_shoelace_le_sharp (p₁ p₂ q₁ q₂ r₁ r₂ : ℝ)
+    (hp : p₁ ^ 2 + p₂ ^ 2 ≤ 1) (hq : q₁ ^ 2 + q₂ ^ 2 ≤ 1)
+    (hr : r₁ ^ 2 + r₂ ^ 2 ≤ 1) :
+    p₁ * (q₂ - r₂) + q₁ * (r₂ - p₂) + r₁ * (p₂ - q₂) ≤ 3 * Real.sqrt 3 / 2 := by
+  set t : ℝ := Real.sqrt ((q₁ - r₁) ^ 2 + (q₂ - r₂) ^ 2) with ht
+  have ht0 : 0 ≤ t := Real.sqrt_nonneg _
+  have ht2 : t ^ 2 = (q₁ - r₁) ^ 2 + (q₂ - r₂) ^ 2 := by
+    rw [ht]; exact Real.sq_sqrt (by positivity)
+  -- Cauchy–Schwarz: the p-part of the shoelace sum is at most t = ‖q − r‖
+  have hx2 : (p₁ * (q₂ - r₂) - p₂ * (q₁ - r₁)) ^ 2 ≤ t ^ 2 := by
+    rw [ht2]
+    have hD : (0 : ℝ) ≤ (q₁ - r₁) ^ 2 + (q₂ - r₂) ^ 2 := by positivity
+    have hPD : (p₁ ^ 2 + p₂ ^ 2) * ((q₁ - r₁) ^ 2 + (q₂ - r₂) ^ 2)
+        ≤ (q₁ - r₁) ^ 2 + (q₂ - r₂) ^ 2 := by nlinarith [hp, hD]
+    nlinarith [sq_nonneg (p₁ * (q₁ - r₁) + p₂ * (q₂ - r₂)), hPD]
+  have hx : p₁ * (q₂ - r₂) - p₂ * (q₁ - r₁) ≤ t := by nlinarith [hx2, ht0]
+  -- Lagrange data for q, r: with s = q × r and u = ⟨q, r⟩, s² + u² ≤ 1
+  have hprodpos : (0 : ℝ) ≤ q₁ ^ 2 + q₂ ^ 2 := by positivity
+  have hprod : (q₁ ^ 2 + q₂ ^ 2) * (r₁ ^ 2 + r₂ ^ 2) ≤ 1 := by
+    nlinarith [hq, hr, hprodpos]
+  have hsu : (q₁ * r₂ - q₂ * r₁) ^ 2 + (q₁ * r₁ + q₂ * r₂) ^ 2 ≤ 1 := by
+    nlinarith [hprod]
+  -- norm expansion: t² ≤ 2 − 2u
+  have ht2u : t ^ 2 ≤ 2 - 2 * (q₁ * r₁ + q₂ * r₂) := by
+    rw [ht2]; nlinarith [hq, hr]
+  -- completed squares: (t + s)² ≤ 27/4, exact certificate
+  --   27/4 − (t+s)² = ½(t−2s)² + 3(u+½)² + (3/2)(2−2u−t²) + 3(1−s²−u²)
+  have hts : (t + (q₁ * r₂ - q₂ * r₁)) ^ 2 ≤ 27 / 4 := by
+    nlinarith [sq_nonneg (t - 2 * (q₁ * r₂ - q₂ * r₁)),
+      sq_nonneg ((q₁ * r₁ + q₂ * r₂) + 1 / 2), ht2u, hsu]
+  -- convert the squared bound into t + s ≤ 3√3/2
+  have h3 : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  have hc0 : (0 : ℝ) < 3 * Real.sqrt 3 / 2 := by positivity
+  have hc2 : (3 * Real.sqrt 3 / 2) ^ 2 = 27 / 4 := by
+    rw [div_pow, mul_pow, h3]; norm_num
+  have hkey : t + (q₁ * r₂ - q₂ * r₁) ≤ 3 * Real.sqrt 3 / 2 := by
+    nlinarith [hts, hc0, hc2]
+  -- assemble: E = (p-part) + s ≤ t + s ≤ 3√3/2
+  have hE : p₁ * (q₂ - r₂) + q₁ * (r₂ - p₂) + r₁ * (p₂ - q₂)
+      = (p₁ * (q₂ - r₂) - p₂ * (q₁ - r₁)) + (q₁ * r₂ - q₂ * r₁) := by ring
+  rw [hE]
+  linarith [hx, hkey]
+
+/-! ## The sharp area bound -/
+
+/-- **Sharp uniform area bound `area ≤ 3√3/4`.**  Any triangle with all three
+vertices in the closed unit disk has area at most `3√3/4` — the area of the
+inscribed equilateral triangle.  Applying `signed_shoelace_le_sharp` to the
+vertex orders `(p,q,r)` and `(p,r,q)` bounds the shoelace sum and its negation,
+hence its absolute value, by `3√3/2`.  This sharpens
+`triangleArea_le_three_halves` to the optimal constant. -/
+theorem triangleArea_le_sharp {P : Finset (ℝ × ℝ)} (h : IsInUnitDisk P)
+    {p q r : ℝ × ℝ} (hp : p ∈ P) (hq : q ∈ P) (hr : r ∈ P) :
+    triangleArea p q r ≤ 3 * Real.sqrt 3 / 4 := by
+  have hdp := h p hp
+  have hdq := h q hq
+  have hdr := h r hr
+  have h₁ := signed_shoelace_le_sharp p.1 p.2 q.1 q.2 r.1 r.2 hdp hdq hdr
+  have h₂ := signed_shoelace_le_sharp p.1 p.2 r.1 r.2 q.1 q.2 hdp hdr hdq
+  have hneg : p.1 * (r.2 - q.2) + r.1 * (q.2 - p.2) + q.1 * (p.2 - r.2)
+      = -(p.1 * (q.2 - r.2) + q.1 * (r.2 - p.2) + r.1 * (p.2 - q.2)) := by ring
+  rw [hneg] at h₂
+  have habs : |p.1 * (q.2 - r.2) + q.1 * (r.2 - p.2) + r.1 * (p.2 - q.2)|
+      ≤ 3 * Real.sqrt 3 / 2 := abs_le.mpr ⟨by linarith, h₁⟩
+  unfold triangleArea
+  linarith [habs]
+
+/-- **`heilbronn n ≤ 3√3/4` for `n ≥ 3` — the sharp uniform upper bound.**
+Every admissible bound `α` in the defining `sSup` is `≤` the area of some
+distinct triple of the witness configuration, and every unit-disk triangle has
+area `≤ 3√3/4` (`triangleArea_le_sharp`).  Improves
+`heilbronn_le_three_halves`, and is optimal at `n = 3`. -/
+theorem heilbronn_le_sharp (n : ℕ) (hn : 3 ≤ n) :
+    heilbronn n ≤ 3 * Real.sqrt 3 / 4 := by
+  unfold heilbronn
+  apply Real.sSup_le
+  · rintro α ⟨P, hcard, hdisk, hbound⟩
+    have hcard3 : 2 < P.card := by omega
+    obtain ⟨p, q, r, hp, hq, hr, hpq, hpr, hqr⟩ := Finset.two_lt_card_iff.mp hcard3
+    have h1 : α ≤ triangleArea p q r := hbound p hp q hq r hr hpq hqr hpr
+    have h2 : triangleArea p q r ≤ 3 * Real.sqrt 3 / 4 := triangleArea_le_sharp hdisk hp hq hr
+    linarith
+  · positivity
+
+/-- The sharp constant really improves the Lagrange bound:
+`3√3/4 ≈ 1.299 < 3/2`. -/
+theorem sharp_lt_three_halves : 3 * Real.sqrt 3 / 4 < 3 / 2 := by
+  have h3 : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  nlinarith [h3, Real.sqrt_nonneg 3]
+
+/-! ## The exact value `heilbronn 3 = 3√3/4` -/
+
+/-- **Heilbronn's constant for three points: `heilbronn 3 = 3√3/4`.**  The
+first exact value in the ladder.  Lower bound: the inscribed equilateral
+triangle (`heilbronn_three_ge`).  Upper bound: the sharp maximal-triangle
+bound (`heilbronn_le_sharp`).  The extremal configuration is the equilateral
+triangle inscribed in the unit circle, of area `3√3/4 ≈ 1.299`. -/
+theorem heilbronn_three_eq : heilbronn 3 = 3 * Real.sqrt 3 / 4 :=
+  le_antisymm (heilbronn_le_sharp 3 (by norm_num)) heilbronn_three_ge
+
+/-! ## Improved ladder sandwiches -/
+
+/-- **Improved sandwich for `heilbronn 4`:** `heilbronn 4 ∈ [1, 3√3/4]`.
+The upper endpoint improves from `3/2` (`heilbronn_four_mem_Icc`) to
+`3√3/4 ≈ 1.299`, shrinking the interval width from `1/2` to `≈ 0.299`. -/
+theorem heilbronn_four_mem_Icc_sharp :
+    heilbronn 4 ∈ Set.Icc (1 : ℝ) (3 * Real.sqrt 3 / 4) :=
+  ⟨heilbronn_four_ge, heilbronn_le_sharp 4 (by norm_num)⟩
+
+/-- **Improved sandwich for `heilbronn 5`:** `heilbronn 5 ∈ [81/125, 3√3/4]`.
+The upper endpoint improves from `3/2` (`heilbronn_five_mem_Icc`) to
+`3√3/4 ≈ 1.299`. -/
+theorem heilbronn_five_mem_Icc_sharp :
+    heilbronn 5 ∈ Set.Icc (81 / 125 : ℝ) (3 * Real.sqrt 3 / 4) :=
+  ⟨heilbronn_five_ge, heilbronn_le_sharp 5 (by norm_num)⟩
+
+end Erdos507WIP01

--- a/research/problems/erdos-507-wip-01/state.md
+++ b/research/problems/erdos-507-wip-01/state.md
@@ -28,13 +28,23 @@ needed). Bound `heilbronn n` (`n ≥ 3`) via `Real.sSup_le` + `triangleArea_le_t
 
 ## Next Action
 
-Elementary layer is now essentially complete: well-definedness, monotonicity,
-the `n=3` sandwich `[3√3/4, 3/2]`, and **quantitative decay** `heilbronn n ≤ 4/m`
-(`heilbronn_le_four_div`) hence `heilbronn n → 0` (`heilbronn_tendsto_zero`, added
-2026-07-21). Remaining plausible elementary target: the sharp
-`heilbronn 3 ≤ 3√3/4` (largest inscribed triangle, ~500-line optimization). The
-deep `α(n)` exponent bounds (KPS/CPZ, `7/6 ≤ β ≤ 2`) remain out of scope.
+**`heilbronn 3 = 3√3/4` is now EXACT** (2026-07-23, `Erdos507WIP01Sharp.lean`,
+`heilbronn_three_eq`, 0-axiom / 0-sorry): the sharp upper bound
+`heilbronn n ≤ 3√3/4` (all `n ≥ 3`) landed via a mechanism that bypassed the
+projected ~500-line Jensen/central-angle route. Key idea: the shoelace sum is
+affine in each vertex, so `E = p×(q−r) + q×r ≤ ‖q−r‖ + q×r`; with `t = ‖q−r‖`,
+`s = q×r`, `u = ⟨q,r⟩`, Lagrange gives `s²+u² ≤ 1`, `t² ≤ 2−2u`, and the
+completed squares `(t−2s)² ≥ 0`, `(u+½)² ≥ 0` give `(t+s)² ≤ 27/4` exactly —
+every step a small `nlinarith` certificate; the irrational maximiser is never
+located. Ladder now: `heilbronn 3 = 3√3/4`, `heilbronn 4 ∈ [1, 3√3/4]`,
+`heilbronn 5 ∈ [81/125, 3√3/4]`.
+
+Remaining moves are all DEEP: sharp values for `n ≥ 4` (research-level
+optimization, no elementary certificate known), and the `α(n)` exponent bounds
+(KPS/CPZ, `7/6 ≤ β ≤ 2`) — out of scope without new Mathlib machinery.
+Elementary layer is COMPLETE; stand down on further witness rungs (an `n = 6`
+near-hexagon would be a 20-triple bash of diminishing value).
 
 ## Attempt Counts
 
-- Total attempts: 4
+- Total attempts: 5

--- a/src/data/research/problems/erdos-507-wip-01.json
+++ b/src/data/research/problems/erdos-507-wip-01.json
@@ -46,7 +46,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: elementary witness ladder now has THREE sandwiches: n=3 in [3sqrt3/4, 3/2] (merged), n=4 in [1, 3/2] (inscribed square, merged), n=5 in [81/125, 3/2] (2026-07-23, rational near-pentagon). The n=5 rung sidesteps the cos(2pi/5) radicals that deferred it: five Pythagorean-triple points (1,0),(7/25,24/25),(-4/5,3/5),(-4/5,-3/5),(7/25,-24/25) lie exactly on the unit circle, all 10 triangle areas are exact rationals, min = 81/125 = 0.648 (within 1.5% of the conjectured regular-pentagon optimum 0.6572). Remaining deep work: sharp upper at n=3 (Jensen on central angles, ~500+ lines) and asymptotic exponent bounds.",
+    "progressSummary": "MILESTONE: heilbronn 3 = 3*sqrt(3)/4 EXACTLY (heilbronn_three_eq, 0-axiom 0-sorry, 2026-07-23). The sharp upper bound heilbronn n <= 3sqrt3/4 for all n >= 3 landed via a new mechanism: the shoelace sum is affine in each vertex (E = p x (q-r) + q x r <= |q-r| + q x r), then Lagrange identity + two completed squares give (t+s)^2 <= 27/4 as an exact positive-combination certificate. Ladder: heilbronn 3 = 3sqrt3/4 (EXACT), heilbronn 4 in [1, 3sqrt3/4], heilbronn 5 in [81/125, 3sqrt3/4]. Elementary layer COMPLETE; remaining work (sharp n>=4 values, alpha(n) exponent bounds 7/6<=beta<=2) is deep research.",
     "builtItems": [
       "triangleArea_nonneg in Erdos507WIP01.lean",
       "triangleArea_swap_left / triangleArea_swap_right / triangleArea_cyclic (permutation symmetry)",
@@ -81,7 +81,12 @@
       "heilbronn_four_pos, heilbronn_four_mem_Icc: positivity + sandwich heilbronn 4 in [1, 3/2]",
       "heilbronn_five_ge: 81/125 <= heilbronn 5 (rational near-pentagon witness, 125-way triple bash, norm_num only)",
       "heilbronn_five_pos: 0 < heilbronn 5",
-      "heilbronn_five_mem_Icc: heilbronn 5 in [81/125, 3/2]"
+      "heilbronn_five_mem_Icc: heilbronn 5 in [81/125, 3/2]",
+      "Erdos507WIP01Sharp.lean: signed_shoelace_le_sharp (master inequality E <= 3sqrt3/2)",
+      "Erdos507WIP01Sharp.lean: triangleArea_le_sharp (unit-disk triangle area <= 3sqrt3/4, optimal)",
+      "Erdos507WIP01Sharp.lean: heilbronn_le_sharp (heilbronn n <= 3sqrt3/4 for n >= 3)",
+      "Erdos507WIP01Sharp.lean: heilbronn_three_eq (heilbronn 3 = 3sqrt3/4 EXACT, first exact value in the ladder)",
+      "Erdos507WIP01Sharp.lean: heilbronn_four_mem_Icc_sharp, heilbronn_five_mem_Icc_sharp (improved sandwiches), sharp_lt_three_halves, cross_sq_add_dot_sq"
     ],
     "insights": [
       "The signed shoelace area p₁(q₂−r₂)+q₁(r₂−p₂)+r₁(p₂−q₂) is alternating: transpositions negate it (area invariant via abs_neg), cyclic rotations fix it — giving full S₃ symmetry after the absolute value.",
@@ -105,7 +110,10 @@
       "Quantitative decay heilbronn n = O(1/n): pigeonhole over ⌊(x+1)·m/2⌋₊ vertical strips gives heilbronn n ≤ 4/m whenever 2(m+1)<n (heilbronn_le_four_div), hence heilbronn n → 0 (heilbronn_tendsto_zero). First non-constant upper bound; formalizes the α(n)≪1/n pigeonhole remark of the problem statement.",
       "Reusable recipe: the determinant form E=(p₁−r₁)(q₂−r₂)−(q₁−r₁)(p₂−r₂) (anchored at a vertex) is the right handle for LOCAL box/strip area bounds — spread hypotheses |Δx|≤w,|Δy|≤h collapse to two |·|≤w·h products (triangleArea_le_spread: area ≤ w·h).",
       "n=4 rung: the inscribed square (1,0),(0,1),(-1,0),(0,-1) has all four vertex triples spanning right triangles of area exactly 1, giving heilbronn 4 >= 1 by the same le_csSup witness pattern as heilbronn_three_ge_half. With the Lagrange upper bound this sandwiches heilbronn 4 in [1, 3/2] - a second width-1/2 window beyond n=3. Sharpness of the square among 4-point disk configs is NOT claimed (open quantitative question).",
-      "Rational points are dense on the unit circle, so every witness-ladder rung can be made radical-free: replace the exact regular n-gon by nearby Pythagorean-triple points. At n=5 the loss is only 1.5% (81/125 vs (2 sin72 - sin36)/2), and the certificate stays inside norm_num/kernel arithmetic - no maxHeartbeats pin needed even for the 125-case ordered-triple bash."
+      "Rational points are dense on the unit circle, so every witness-ladder rung can be made radical-free: replace the exact regular n-gon by nearby Pythagorean-triple points. At n=5 the loss is only 1.5% (81/125 vs (2 sin72 - sin36)/2), and the certificate stays inside norm_num/kernel arithmetic - no maxHeartbeats pin needed even for the 125-case ordered-triple bash.",
+      "The shoelace sum E = (p x q)+(q x r)+(r x p) is AFFINE in each vertex: E = p x (q-r) + q x r. Maximizing over p in the disk gives E <= |q-r| + q x r, eliminating one variable exactly — this is what makes the sharp bound nlinarith-tractable",
+      "Sharp bound certificate: with t=|q-r|, s=q x r, u=<q,r>: s^2+u^2 <= 1 (Lagrange), t^2 <= 2-2u, and 27/4-(t+s)^2 = (1/2)(t-2s)^2 + 3(u+1/2)^2 + (3/2)(2-2u-t^2) + 3(1-s^2-u^2) — an exact positive-combination identity, so nlinarith needs only two square hints",
+      "The blocked Jensen/central-angle route (~500 lines, compactness + perturbation-to-boundary) was bypassed entirely; the reopen criterion (materially new mechanism) was met by the affine-vertex-elimination + completing-the-square decomposition"
     ],
     "mathlibGaps": [
       "No off-the-shelf lemma reduces the nested membership biInf of minTriangleArea to a single ciInf_le; the junk-value semantics of ⨅ over unsatisfiable membership binders must be handled explicitly (done here via ciInf_le_of_le descent).",
@@ -113,9 +121,9 @@
       "No Mathlib lemma for the maximal-area triangle inscribed in a disk (max = equilateral, area 3√3/4·R²); the sharp heilbronn 3 ≤ 3√3/4 upper bound needs this and is not a tactic search."
     ],
     "nextSteps": [
-      "n=6 rung via a rational near-hexagon (regular hexagon min triangle area = sqrt(3)/4*... - rational perturbation same trick); diminishing returns, each rung heavier",
-      "Sharp upper heilbronn 3 <= 3sqrt3/4 (pins exact value; Jensen on central angles, ~500+ lines, NOT session-sized)",
-      "Deep alpha(n) exponent bounds 7/6 <= beta <= 2 (KPS lower, CPZ upper) - open research"
+      "Sharp value heilbronn 4 (conjectured extremal configurations are research-level; no elementary certificate known) — DEEP",
+      "Deep alpha(n) exponent bounds 7/6 <= beta <= 2 (KPS lower, CPZ upper) — open research, out of scope without new Mathlib machinery",
+      "Optional low-value: n=6 witness rung via rational near-hexagon (20-triple bash, diminishing returns)"
     ],
     "markdown": "# Knowledge Base: erdos-507-wip-01\n\n## Session 2026-07-20 (researcher-1) — foundational triangle-area / unit-disk scaffolding\n\n**Mode**: FRESH (EMPTY node). **Outcome**: progress — VERIFIED axiom-free (`[propext, Classical.choice, Quot.sound]`), 0 sorry / 0 axiom. Host-verified (Mathlib-only parent): fresh-built `Erdos507Problem.olean` then `lake env lean` on the child (no Docker).\n\n### What I did\nCreated `proofs/Proofs/Erdos507WIP01.lean` (14 theorems) on the shoelace area `triangleArea p q r = |p₁(q₂−r₂)+q₁(r₂−p₂)+r₁(p₂−q₂)|/2` and the `IsInUnitDisk` predicate:\n- **Nonnegativity**: `triangleArea_nonneg`.\n- **Permutation symmetry**: `triangleArea_swap_left`, `triangleArea_swap_right` (transpositions, via signed-area negation + `abs_neg`), `triangleArea_cyclic` (rotation fixes it).\n- **Degenerate cases**: `triangleArea_self_left / _self_mid / _self_outer` (= 0).\n- **Collinearity**: `triangleArea_eq_zero_iff`.\n- **Explicit value**: `triangleArea_unit` (`(0,0),(1,0),(0,1) ↦ 1/2`).\n- **Unit disk**: `isInUnitDisk_empty`, `IsInUnitDisk.subset`, `unitDisk_abs_fst_le`, `unitDisk_abs_snd_le`, and the uniform bound `triangleArea_le_three`.\n\n### Key findings\n- The signed shoelace form is alternating: transpositions negate, cyclic rotations fix — full `S₃` symmetry after `|·|`.\n- Every unit-disk triangle has area `≤ 3`, so `heilbronn n`'s `sSup` set is bounded above (a step toward finiteness/monotonicity of `heilbronn`).\n\n### Reusable Lean recipe\n- Signed-area alternation: `rw [show <permuted expr> = -(<base expr>) from by ring, abs_neg]`.\n- Coordinate bound from the disk: `nlinarith [sq_nonneg (p.1 - 1), sq_nonneg (p.1 + 1)]` after `have hsq : p.1^2 ≤ 1 := by nlinarith [sq_nonneg p.2]`.\n- Three-term abs bound: `abs_add_le` twice (note `abs_add` was renamed to `abs_add_le` in this pin) + `gcongr`, each summand `≤ 2` via `mul_le_mul` on `|a|·|b−c| ≤ 1·2`.\n- v4.31 renames hit this session: `abs_add → abs_add_le`, `Finset.not_mem_empty → Finset.notMem_empty`.\n\n### Next steps\n- `minTriangleArea P ≤ triangleArea p q r` (nested membership `biInf_le`).\n- `heilbronn n ≤ 3` via `BddAbove` of the defining set.\n\n### Still open (unchanged)\nThe growth exponent of `α(n)` — deep; only `7/6 ≤ β ≤ 2` known (KPS, Cohen–Pohoata–Zakharov).\n"
   },


### PR DESCRIPTION
## Summary
Research session for **erdos-507-wip-01** (Heilbronn's triangle problem). Closes the `n = 3` sandwich: new file `Erdos507WIP01Sharp.lean` (0 axioms, 0 sorries, docker-verified, 2972 jobs) proves the sharp upper bound `heilbronn n ≤ 3√3/4` for all `n ≥ 3`, hence with the existing inscribed-equilateral lower bound:

**`heilbronn 3 = 3√3/4` — the first exact value in the Heilbronn ladder.**

## Progress
- `signed_shoelace_le_sharp` — master inequality: signed shoelace sum ≤ 3√3/2 in the unit disk
- `triangleArea_le_sharp` — every unit-disk triangle has area ≤ 3√3/4 (optimal; sharpens `triangleArea_le_three_halves`)
- `heilbronn_le_sharp` — `heilbronn n ≤ 3√3/4` for `n ≥ 3`; `sharp_lt_three_halves` certifies it strictly improves the old 3/2 bound
- `heilbronn_three_eq` — **`heilbronn 3 = 3√3/4` exactly**
- `heilbronn_four_mem_Icc_sharp` / `heilbronn_five_mem_Icc_sharp` — ladder sandwiches improve to `heilbronn 4 ∈ [1, 3√3/4]`, `heilbronn 5 ∈ [81/125, 3√3/4]`

## Findings
The sharp bound was previously blocked: the classical route needs compactness/perturbation-to-boundary + Jensen on central angles (~500 lines), and direct `nlinarith` on the 6-variable degree-4 optimization fails (irrational maximiser). The reopen criterion ("materially new mechanism") is met:

1. The shoelace sum is **affine in each vertex**: `E = p×(q−r) + q×r ≤ ‖q−r‖ + q×r` (Cauchy–Schwarz via Lagrange), eliminating `p` exactly.
2. With `t = ‖q−r‖`, `s = q×r`, `u = ⟨q,r⟩`: Lagrange gives `s²+u² ≤ 1`, norm expansion gives `t² ≤ 2−2u`.
3. Exact certificate: `27/4 − (t+s)² = ½(t−2s)² + 3(u+½)² + 3/2·(2−2u−t²) + 3(1−s²−u²)` — a positive combination, so each step is a small `nlinarith` call and the irrational extremal point is never located.

Equality holds at the inscribed equilateral triangle (`u = −½, t = √3, s = √3/2`), which is why the constant is optimal.

## Status
**Outcome**: completed (elementary layer of erdos-507-wip-01 is now COMPLETE)
**Next Steps**: remaining work is deep only — sharp values for `n ≥ 4` and the α(n) exponent bounds (KPS/CPZ, 7/6 ≤ β ≤ 2). Tracker + state.md updated accordingly.

🤖 Generated by researcher-1-5
