### PR TITLE
Enrich erdos-359: cover the summary/packaging theorem (lines 175-207)

### DIFF
--- a/src/data/proofs/erdos-359/annotations.json
+++ b/src/data/proofs/erdos-359/annotations.json
@@ -295,5 +295,27 @@
       "conjectured superlinear growth for general n",
       "generalization beyond the n = 1 case"
     ]
+  },
+  {
+    "id": "ann-e359-summary-theorem",
+    "proofId": "erdos-359",
+    "range": {
+      "startLine": 175,
+      "endLine": 207
+    },
+    "type": "theorem",
+    "title": "Summary and Packaging Theorem",
+    "content": "A closing docstring restates the problem status (the three open questions, the known initial terms, and Porubsky's/Andrews' results), and erdos_359_summary packages the file's four proved structural facts -- A 0 = 1, StrictMono A, macmahonValues 0 = 1, macmahonValues 7 = 15 -- into a single conjunction. It adds no new mathematical content beyond macmahon_first_term and macmahon_strictMono (proved earlier) and the concrete values already verified in the known-values section; its role is purely to give a reader one citable statement for everything this file actually establishes, distinct from the open conjectures recorded only as comments.",
+    "mathContext": "erdos_359_summary : (forall A, IsMacMahonSeq A -> A 0 = 1) and (forall A, IsMacMahonSeq A -> StrictMono A) and macmahonValues 0 = 1 and macmahonValues 7 = 15.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "summary theorem",
+      "proof packaging",
+      "macmahon_first_term",
+      "macmahon_strictMono"
+    ],
+    "prerequisites": [
+      "the four component facts proved earlier in the file"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-359/meta.json
+++ b/src/data/proofs/erdos-359/meta.json
@@ -112,6 +112,13 @@
       "startLine": 168,
       "endLine": 174,
       "summary": "Comment noting the conjectured extension to sequences starting with n != 1."
+    },
+    {
+      "id": "summary-theorem",
+      "title": "Summary and Packaging Theorem",
+      "startLine": 175,
+      "endLine": 207,
+      "summary": "A closing docstring restates the problem (open questions, known values, Porubsky's/Andrews' results) and erdos_359_summary packages the four proved structural facts (A 0 = 1, StrictMono A, macmahonValues 0 = 1, macmahonValues 7 = 15) into a single conjunction, giving one theorem a reader can cite for everything this file actually establishes versus what remains conjectural."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- `sections`/annotations previously stopped at line 174 (the "General Starting Value" comment); the Lean file's closing docstring and the `erdos_359_summary` theorem (lines 175-207, which packages the file's four proved structural facts into one citable statement) had no section or annotation coverage.
- This entry already scores quality 100 from the automated scorer (`find-targets.ts`), because section *count* is scored, not line-range coverage — so this gap is invisible to the queue and had to be found by comparing `sections[].endLine` against the actual Lean file line count.
- Adds a `summary-theorem` section and a matching annotation covering lines 175-207, giving the meta.json full 1-207 coverage of `Proofs/Erdos359Problem.lean`.

No math claims changed — `theoremCount`/`definitionCount`/`axiomCount`/`sorries` were already accurate.

## Test plan
- [x] `python3 -m json.tool` validates both `meta.json` and `annotations.json`
- [x] `pnpm build` gallery-data steps (search index, loading-facts, redirects) pass; only the unrelated pre-existing `tsc: command not found` step fails (missing `node_modules` in this worktree, a known gap)
- [x] Verified no open PR already covers this gap (`gh pr list --search erdos-359`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)