### PR TITLE
audit: refresh tracker for erdos-863 (issues-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16951,9 +16951,9 @@
     },
     "erdos-863": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:44Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T02:36:31Z",
+      "result": "issues-fixed"
     },
     "erdos-864": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Refreshes the audit tracker entry for erdos-863 after fixing phantom Filter.atTop/axiom
claims in its annotations.json (see #42894).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>