### PR TITLE
audit: refresh tracker for erdos-854 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16876,8 +16876,8 @@
     },
     "erdos-854": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:44Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T02:39:42Z",
       "result": "clean"
     },
     "erdos-855": {


### PR DESCRIPTION
Re-audited erdos-854 (Erdős #854 — gaps between coprime residues of primorials, re-serve since queue is drained). Verified against `proofs/Proofs/Erdos854Problem.lean`:

- 0 sorries, 0 True stubs, no native_decide — matches meta.
- 4 axioms match `assumptions` description exactly: `maxGap_bound` (Jacobsthal bound), `lacampagne_selfridge_counterexample` (n₆=30030 disproof), `ErdosProblem854_missing_gap_growth` (open Part 1), `ErdosProblem854_many_gaps` (open Part 2).
- `theoremCount: 22` is a harmless undercount (actual 23) — no action per undercount-is-safe convention.
- `status: axiomatized`, `badge: wip`, `erdosProblemStatus: open` all correctly reflect Tier C classification.

No integrity issues found. Bumping `auditCount` and `lastAudited` in the tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)