### PR TITLE
Enrich amgm-inequality-oq-04-oq-04: add missing reciprocal cross-references

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
@@ -75,6 +75,11 @@
       "targetId": "leibniz-pi",
       "relationship": "contrast",
       "description": "Leibniz's series π/4 = 1 - 1/3 + 1/5 - ⋯ converges polynomially. The Brent-Salamin algorithm converges quadratically — each iteration doubles the digits. This makes it among the fastest known algorithms for computing π."
+    },
+    {
+      "targetId": "amgm-inequality-oq-04-oq-04",
+      "relationship": "related",
+      "description": "Proves with 0 axioms the per-step quadratic contraction $(a+b)/2-\\sqrt{ab} \\le (a-b)^2/(8b)$ and the abstract lemma turning any recursion $g_{n+1}\\le g_n^2/C$ into the doubly exponential bound $g_n\\le C(g_0/C)^{2^n}$ — precisely the ingredient this entry's `bs_summable` axiom (summability of $\\sum 2^n(a_n^2-b_n^2)$, this file's first open question) needs; assembling it into the explicit $|a_n-b_n|=O(r^{2^n})$ rate at $a_0=1,b_0=1/\\sqrt2$ is not yet done."
     }
   ],
   "sections": [

--- a/src/data/proofs/amgm-inequality-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04/meta.json
@@ -96,6 +96,11 @@
       "targetId": "pi-transcendental",
       "relationship": "related",
       "description": "The AGM limit $M(1, 1/\\sqrt{2})$ is related to $\\pi$ via the Brent-Salamin formula and Gauss's identity with complete elliptic integrals. The transcendence of $\\pi$ (Lindemann-Weierstrass, 1882) then implies that the AGM limit $M(1, 1/\\sqrt{2})$ is transcendental — a consequence of the axiomatized elliptic integral connection in this entry's `agm_elliptic_integral` axiom."
+    },
+    {
+      "targetId": "amgm-inequality-oq-04-oq-04",
+      "relationship": "related",
+      "description": "Child answering this entry's OQ-04 on quadratic convergence: proves with 0 axioms that one AGM step squares the gap, $(a+b)/2 - \\sqrt{ab} = (a-b)^2/(2(\\sqrt a+\\sqrt b)^2) \\le (a-b)^2/(8b)$, and the abstract lemma that a recursion $g_{n+1}\\le g_n^2/C$ unwinds to the doubly exponential bound $g_n \\le C(g_0/C)^{2^n}$. Assembling these into the explicit $O(M(a,b)(b/a)^{2^n})$ rate at the concrete AGM sequence remains open."
     }
   ],
   "sections": [


### PR DESCRIPTION
## Summary
- Parent `amgm-inequality-oq-04` poses an open question ("Prove the quadratic convergence rate: aₙ − bₙ = O(M(a,b)·(b/a)^{2ⁿ})...") that is exactly what `amgm-inequality-oq-04-oq-04` proves (the per-step gap-squaring identity + abstract quadratic-recursion-to-rate lemma, 0 axioms), but the parent never linked to the answering child.
- Sibling `amgm-inequality-oq-04-oq-05` (Brent-Salamin) has an open question about proving its `bs_summable` axiom via "the quadratic AGM convergence rate ... not yet in Mathlib" — again exactly the ingredient `amgm-inequality-oq-04-oq-04` supplies — but had no cross-reference to it either.
- Added one reciprocal `crossReferences` entry to each of the two files, honestly noting that assembling the per-step bound into the explicit rate at the concrete AGM sequence remains open (not claiming the open questions are fully closed).

Both files remain well under the 60 KB / 20-crossReference size caps (23.0 KB / 8 refs and 15.6 KB / 4 refs respectively).

## Test plan
- [x] `pnpm build` succeeds (validates JSON structure and gallery data manifest)
- [x] Both meta.json files parse as valid JSON