### PR TITLE
Gallery integrity: fix phantom-axiom prose in erdos-85

### DIFF
--- a/src/data/proofs/erdos-85/annotations.json
+++ b/src/data/proofs/erdos-85/annotations.json
@@ -148,11 +148,10 @@
     },
     "type": "concept",
     "title": "Asymptotic Behavior",
-    "content": "**minDegreeForC4_asymptotic** states that f(n)/√n → 1 as n → ∞.\n\nThis means f(n) = (1 + o(1))√n: the threshold grows like the square root of the number of vertices.\n\n**Why an axiom?** This is a known result from extremal graph theory, but formalizing the proof requires substantial machinery.",
-    "mathContext": "Formally: `Tendsto (fun n => f(n)/√n) atTop (𝓝 1)` says the ratio converges to 1.",
+    "content": "A doc comment (not a Lean declaration) records that f(n)/√n → 1 as n → ∞.\n\nThis means f(n) = (1 + o(1))√n: the threshold grows like the square root of the number of vertices.\n\n**Why only a comment?** This is a known result from extremal graph theory, but formalizing the proof requires substantial machinery; there is no `minDegreeForC4_asymptotic` axiom or theorem in the Lean file.",
+    "mathContext": "Formally this would read: `Tendsto (fun n => f(n)/√n) atTop (𝓝 1)`, but no such statement is declared in Lean — the comment only describes the intended formalization.",
     "significance": "key",
     "relatedConcepts": [
-      "axiom",
       "tendsto",
       "asymptotic",
       "square-root"

--- a/src/data/proofs/erdos-85/meta.json
+++ b/src/data/proofs/erdos-85/meta.json
@@ -51,7 +51,7 @@
       "Definition of containsC4 predicate for graph embeddings",
       "Definition of minDegreeForC4 threshold function f(n)",
       "Erdos85Question as eventually monotone statement",
-      "Axioms for asymptotic behavior f(n) ~ √n",
+      "Asymptotic behavior f(n) ~ √n documented only in a comment (not a Lean axiom or theorem)",
       "Connection to Ramsey numbers R(C₄, K_{1,n})",
       "Kővári-Sós-Turán bound on C₄-free graphs",
       "one_le_starGraph_minDegree / two_le_minDegreeForC4: axiom-free lower bound f(n+1) ≥ 2 for n ≥ 3 (the C₄-free star has min-degree ≥ 1), pinning f(4) ≥ 2",
@@ -126,7 +126,7 @@
       "title": "Known Bounds",
       "startLine": 91,
       "endLine": 124,
-      "summary": "Axioms for asymptotic behavior and base case."
+      "summary": "Documents asymptotic behavior and base case only in comments, not as Lean axioms."
     },
     {
       "id": "ramsey",


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-85 (Minimum Degree for 4-Cycles)

**Problem**: Three prose spots claimed a real Lean axiom exists for the
f(n) ~ √n asymptotic result, but the file has `axiomCount: 0` and contains
no `axiom` keyword anywhere — the asymptotic is documented only in a plain
`/- ... -/` comment (lines 104-110 of `Proofs/Erdos85Problem.lean`).

1. `meta.originalContributions` listed "Axioms for asymptotic behavior f(n) ~ √n"
2. `sections[known-bounds].summary` said "Axioms for asymptotic behavior and base case"
3. `annotations.json` (`ann-e85-asymptotic`) named a nonexistent
   `minDegreeForC4_asymptotic` axiom and asked "Why an axiom?" — no such
   declaration exists anywhere in the Lean file.

This is the recurring "comment-only mislabeled axiomatized" class: prose
claims something is formally axiomatized in Lean when it's really just
described in a comment. (The file's `assumptions` field already had the
correct framing — "remain described in doc-comments only, NOT formalized" —
these three spots just hadn't caught up.)

## Evidence

**Claimed**: "Axioms for asymptotic behavior f(n) ~ √n" / "**minDegreeForC4_asymptotic** states..." / "Why an axiom?"

**Lean file shows**: `grep -n axiom proofs/Proofs/Erdos85Problem.lean` returns
no hits; lines 91-116 are `/- ... -/` doc comments, not declarations.

## Fix

Reworded all three spots to say the asymptotic is recorded only in a
comment, not formalized as a Lean axiom or theorem. No change to
`axiomCount` (already 0), `sorries` (already 0), `status`, or `badge` —
those were accurate.

---
Discovered during gallery integrity audit.