### PR TITLE
audit: mark solution-of-cubic-oq-03-oq-02 clean (re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24988,9 +24988,9 @@
       "result": "clean"
     },
     "solution-of-cubic-oq-03-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:45Z",
+      "lastAudited": "2026-07-24T02:47:59Z",
       "result": "clean"
     },
     "solution-of-cubic-oq-03-oq-03": {


### PR DESCRIPTION
Re-audited solution-of-cubic-oq-03-oq-02 as part of the round-robin re-serve
(unaudited queue is drained: 4811/4811). Verified PR #42898's phantom-axiom
prose fix is still intact:

- 0 axioms, 0 sorries in `Proofs/SolutionOfCubicOQ03OQ02.lean` (matches meta.json)
- `status: "axiomatized"`, `badge: "wip"` — appropriate for Tier C
- `assumptions` field honestly states axiom names were removed from source
- `overview.historicalContext` has no "axiom" mentions
- `section-trig-roots` summary correctly says Wantzel's theorem appears "only
  in comments, not as Lean axioms or theorems" (not "axiomatized")

Tracker update only — bumps auditCount and lastAudited for this entry.