### PR TITLE
Research: elementary-quadratic-reciprocity-oq-03-oq-02-wip-01 — odd-prime Gauss sum engine g_q² = χ_q(−1)·q (0-axiom)

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01GaussOdd.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01GaussOdd.lean
@@ -138,7 +138,7 @@ theorem sum_zetapow_mul_zero (ζ : K) :
 def chiK (a : ZMod q) : K := ((quadraticChar (ZMod q) a : ℤ) : K)
 
 @[simp] theorem chiK_zero : chiK (K := K) (0 : ZMod q) = 0 := by
-  simp [chiK, quadraticChar_zero]
+  simp [chiK]
 
 theorem chiK_mul (a b : ZMod q) :
     chiK (K := K) (a * b) = chiK a * chiK b := by
@@ -174,7 +174,7 @@ term reindexes (`b = a·c`) into `∑_c χ(c)·ζ^{a(1+c)}`: the substitution us
 `zetapow_add`. -/
 theorem term_mul_gaussSumOdd (ζ : K) (hζq : ζ ^ q = 1)
     {a : ZMod q} (ha : a ≠ 0) :
-    chiK a * zetapow ζ a * gaussSumOdd ζ
+    chiK a * zetapow ζ a * gaussSumOdd (q := q) ζ
       = ∑ c : ZMod q, chiK c * zetapow ζ (a * (1 + c)) := by
   have hreindex : gaussSumOdd (q := q) ζ
       = ∑ c : ZMod q, chiK (a * c) * zetapow ζ (a * c) :=
@@ -197,16 +197,19 @@ row vanishes), collapse each row to `∑_c χ(c) ζ^{a(1+c)}`
 frequency `1+c = 0` contributes `χ(−1)(q−1)`, every other frequency
 contributes `−χ(c)`, and `∑ χ = 0` turns the tail into `+χ(−1)`. -/
 theorem gaussSumOdd_sq (hq2 : q ≠ 2) (ζ : K) (hζq : ζ ^ q = 1) (hζ1 : ζ ≠ 1) :
-    gaussSumOdd (q := q) ζ ^ 2 = chiK (-1) * q := by
+    gaussSumOdd (q := q) ζ ^ 2 = chiK (K := K) (-1 : ZMod q) * q := by
   -- Step 1: S² as a sum of rows over a ≠ 0
-  have hrow0 : chiK (K := K) (0 : ZMod q) * zetapow ζ 0 * gaussSumOdd ζ = 0 := by
+  have hrow0 : chiK (K := K) (0 : ZMod q) * zetapow ζ (0 : ZMod q) * gaussSumOdd (q := q) ζ
+      = 0 := by
     rw [chiK_zero, zero_mul, zero_mul]
   have hsq : gaussSumOdd (q := q) ζ ^ 2
       = ∑ a ∈ (univ : Finset (ZMod q)).erase 0,
-          chiK a * zetapow ζ a * gaussSumOdd ζ := by
+          chiK a * zetapow ζ a * gaussSumOdd (q := q) ζ := by
     rw [sq]
     conv_lhs => rw [gaussSumOdd, Finset.sum_mul]
-    exact (Finset.sum_erase _ hrow0).symm
+    exact (Finset.sum_erase
+      (f := fun b : ZMod q => chiK b * zetapow ζ b * gaussSumOdd (q := q) ζ)
+      (a := (0 : ZMod q)) univ hrow0).symm
   -- Step 2: collapse the rows and swap the summation order
   have hswap : gaussSumOdd (q := q) ζ ^ 2
       = ∑ c : ZMod q, chiK c *

--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01GaussOdd.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01GaussOdd.lean
@@ -1,0 +1,280 @@
+/-
+# The odd-prime quadratic Gauss sum engine: `g_q² = χ_q(−1)·q`
+
+**Satellite of `elementary-quadratic-reciprocity-oq-03-oq-02-wip-01`.**
+
+The node's Gauss-sum programme has so far treated the prime `2` end-to-end:
+`ElementaryQuadraticReciprocityOQ03OQ02WIP01.lean` builds the conductor-8 sum
+`τ(χ₈)`, proves `τ² = 8` ring-generically, and derives the second supplement
+`(2/p) = (p/2)` via Frobenius covariance in `GaloisField p 2` — all without
+invoking Mathlib's quadratic reciprocity.
+
+This file supplies the **odd-prime half of the engine**: for an arbitrary odd
+prime `q`, an arbitrary field `K`, and any primitive `q`-th root of unity
+`ζ ∈ K` (packaged as `ζ^q = 1`, `ζ ≠ 1` — primitivity is automatic for prime
+`q`), the quadratic Gauss sum
+
+    gaussSumOdd ζ = ∑ a : ZMod q, χ_q(a) · ζ^a,   χ_q = quadraticChar (ZMod q)
+
+satisfies the classical **Gauss square formula**
+
+    (gaussSumOdd ζ)² = χ_q(−1) · q            (`gaussSumOdd_sq`)
+
+This is the identified hard half of the remaining open question on this node
+(full quadratic reciprocity via Gauss sums, independent of Mathlib's
+`jacobiSym.quadratic_reciprocity`): the formula holds in ANY field containing a
+primitive `q`-th root — in particular in `GaloisField p k` of characteristic
+`p`, where the follow-up Frobenius-covariance step `g^p = χ_q(p)·g` (the exact
+analogue of the prime-2 recipe already on the node) will yield reciprocity.
+
+The proof is the classical substitution argument, kept fully elementary:
+
+1. `zetapow ζ a := ζ^a.val` is additive-to-multiplicative
+   (`zetapow_add`, via `ζ^q = 1` and exponent folding mod `q`);
+2. orthogonality `∑_a ζ^{ad} = 0` for `d ≠ 0` (`sum_zetapow_mul_eq_zero`) by
+   the shift trick `a ↦ a + 1` — no geometric-series machinery needed;
+3. in `S²`, each row `a ≠ 0` reindexes by `b = a·c` (`mulLeft_bijective₀`),
+   `χ(a)² = 1` collapses the character, and the double sum reduces to
+   `∑_c χ(c)·(∑_{a≠0} ζ^{a(1+c)})`, which the orthogonality relations and
+   `∑_c χ(c) = 0` (`quadraticChar_sum_zero`) evaluate to `χ(−1)·q`.
+
+Mathlib's abstract `GaussSum` library proves an analogous square formula for
+`MulChar`/`AddChar` pairs; this file deliberately keeps the node's
+self-contained concrete development (mirroring the explicit `ζ₈` treatment of
+the prime-2 case) so that the eventual reciprocity proof remains independent
+of that infrastructure and composes directly with the node's established
+`GaloisField` descent recipe.
+
+All results are `0`-axiom / `0`-sorry.
+-/
+
+import Mathlib.NumberTheory.LegendreSymbol.Basic
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Tactic
+
+namespace KroneckerSymbol
+
+open Finset
+
+variable {K : Type*} [Field K] {q : ℕ} [hq : Fact q.Prime]
+
+instance : NeZero q := ⟨hq.out.pos.ne'⟩
+
+/-! ## Powers of a root of unity indexed by `ZMod q` -/
+
+/-- `ζ` raised to a residue class: `zetapow ζ a = ζ ^ a.val`.  When `ζ^q = 1`
+this is a well-defined additive-to-multiplicative map on `ZMod q`. -/
+def zetapow (ζ : K) (a : ZMod q) : K := ζ ^ a.val
+
+@[simp] theorem zetapow_zero (ζ : K) : zetapow ζ (0 : ZMod q) = 1 := by
+  simp [zetapow, ZMod.val_zero]
+
+/-- `zetapow` turns addition of residues into multiplication: the exponent
+`(a+b).val = (a.val + b.val) % q` folds back to `a.val + b.val` because
+`ζ^q = 1`. -/
+theorem zetapow_add (ζ : K) (hζq : ζ ^ q = 1) (a b : ZMod q) :
+    zetapow ζ (a + b) = zetapow ζ a * zetapow ζ b := by
+  unfold zetapow
+  rw [ZMod.val_add, ← pow_eq_pow_mod _ hζq, pow_add]
+
+/-- For prime `q`, the hypotheses `ζ^q = 1`, `ζ ≠ 1` force `ζ` to have order
+exactly `q` (the order divides the prime `q` and is not `1`). -/
+theorem orderOf_of_pow_prime_eq_one (ζ : K) (hζq : ζ ^ q = 1) (hζ1 : ζ ≠ 1) :
+    orderOf ζ = q := by
+  have hdvd : orderOf ζ ∣ q := orderOf_dvd_of_pow_eq_one hζq
+  rcases hq.out.eq_one_or_self_of_dvd _ hdvd with h | h
+  · exact absurd (orderOf_eq_one_iff.mp h) hζ1
+  · exact h
+
+/-- Primitivity for free at prime level: `zetapow ζ d ≠ 1` for every nonzero
+residue `d`.  If `ζ^{d.val} = 1` then `q = orderOf ζ` divides `d.val`, which is
+impossible for `0 < d.val < q`. -/
+theorem zetapow_ne_one (ζ : K) (hζq : ζ ^ q = 1) (hζ1 : ζ ≠ 1)
+    {d : ZMod q} (hd : d ≠ 0) : zetapow ζ d ≠ 1 := by
+  intro h
+  have horder : orderOf ζ = q := orderOf_of_pow_prime_eq_one ζ hζq hζ1
+  have hdvd : orderOf ζ ∣ d.val := orderOf_dvd_of_pow_eq_one h
+  rw [horder] at hdvd
+  have hlt : d.val < q := ZMod.val_lt d
+  have hne : d.val ≠ 0 := fun h0 => hd ((ZMod.val_eq_zero d).mp h0)
+  have := Nat.le_of_dvd (Nat.pos_of_ne_zero hne) hdvd
+  omega
+
+/-! ## Orthogonality relations -/
+
+/-- **Root-of-unity orthogonality, nonzero frequency.**  For `d ≠ 0`,
+`∑_{a : ZMod q} ζ^{ad} = 0`.  Shift trick: reindexing `a ↦ a + 1` multiplies
+the sum by `ζ^d ≠ 1`, so the sum is fixed by multiplication by `ζ^d` and must
+vanish.  No geometric-series machinery is needed. -/
+theorem sum_zetapow_mul_eq_zero (ζ : K) (hζq : ζ ^ q = 1) (hζ1 : ζ ≠ 1)
+    {d : ZMod q} (hd : d ≠ 0) :
+    ∑ a : ZMod q, zetapow ζ (a * d) = 0 := by
+  have hshift : ∑ a : ZMod q, zetapow ζ ((a + 1) * d) = ∑ a : ZMod q, zetapow ζ (a * d) :=
+    Fintype.sum_equiv (Equiv.addRight (1 : ZMod q)) _ _ (fun a => rfl)
+  have hkey : zetapow ζ d * ∑ a : ZMod q, zetapow ζ (a * d)
+      = ∑ a : ZMod q, zetapow ζ (a * d) := by
+    rw [Finset.mul_sum]
+    calc ∑ a : ZMod q, zetapow ζ d * zetapow ζ (a * d)
+        = ∑ a : ZMod q, zetapow ζ ((a + 1) * d) := by
+          refine Finset.sum_congr rfl fun a _ => ?_
+          rw [add_mul, one_mul, zetapow_add ζ hζq]
+          ring
+      _ = ∑ a : ZMod q, zetapow ζ (a * d) := hshift
+  have hne : zetapow ζ d - 1 ≠ 0 := sub_ne_zero.mpr (zetapow_ne_one ζ hζq hζ1 hd)
+  have hzero : (zetapow ζ d - 1) * ∑ a : ZMod q, zetapow ζ (a * d) = 0 := by
+    rw [sub_mul, one_mul, hkey, sub_self]
+  exact (mul_eq_zero.mp hzero).resolve_left hne
+
+/-- **Zero frequency:** `∑_{a : ZMod q} ζ^{a·0} = q` (each term is `1`). -/
+theorem sum_zetapow_mul_zero (ζ : K) :
+    ∑ a : ZMod q, zetapow ζ (a * 0) = (q : K) := by
+  simp only [mul_zero, zetapow_zero]
+  rw [Finset.sum_const, Finset.card_univ, ZMod.card, nsmul_eq_mul, mul_one]
+
+/-! ## The quadratic character, cast into `K` -/
+
+/-- The quadratic character `χ_q = quadraticChar (ZMod q)` (values in
+`{-1, 0, 1} ⊆ ℤ`), cast into the field `K`. -/
+def chiK (a : ZMod q) : K := ((quadraticChar (ZMod q) a : ℤ) : K)
+
+@[simp] theorem chiK_zero : chiK (K := K) (0 : ZMod q) = 0 := by
+  simp [chiK, quadraticChar_zero]
+
+theorem chiK_mul (a b : ZMod q) :
+    chiK (K := K) (a * b) = chiK a * chiK b := by
+  unfold chiK
+  rw [map_mul]
+  push_cast
+  ring
+
+/-- `χ(a)² = 1` for `a ≠ 0`, cast into `K`. -/
+theorem chiK_sq_eq_one {a : ZMod q} (ha : a ≠ 0) :
+    chiK (K := K) a * chiK a = 1 := by
+  unfold chiK
+  rw [← Int.cast_mul, ← sq, quadraticChar_sq_one ha, Int.cast_one]
+
+/-- **Mean-zero:** `∑_a χ(a) = 0` for odd `q` (as many nonzero squares as
+non-squares), cast into `K`. -/
+theorem sum_chiK (hq2 : q ≠ 2) : ∑ a : ZMod q, chiK (K := K) a = 0 := by
+  have hF : ringChar (ZMod q) ≠ 2 := by rw [ZMod.ringChar_zmod_n]; exact hq2
+  have h := quadraticChar_sum_zero hF
+  unfold chiK
+  exact_mod_cast congrArg (fun z : ℤ => (z : K)) h
+
+/-! ## The quadratic Gauss sum and the square formula -/
+
+/-- **The odd-prime quadratic Gauss sum** `g_q = ∑_{a : ZMod q} χ_q(a)·ζ^a`,
+valued in an arbitrary field `K` containing a `q`-th root of unity `ζ`. -/
+noncomputable def gaussSumOdd (ζ : K) : K :=
+  ∑ a : ZMod q, chiK a * zetapow ζ a
+
+/-- **Row collapse.**  For `a ≠ 0`, multiplying the Gauss sum by its `a`-th
+term reindexes (`b = a·c`) into `∑_c χ(c)·ζ^{a(1+c)}`: the substitution uses
+`χ(ac) = χ(a)χ(c)` and `χ(a)² = 1`, and merges the exponents via
+`zetapow_add`. -/
+theorem term_mul_gaussSumOdd (ζ : K) (hζq : ζ ^ q = 1)
+    {a : ZMod q} (ha : a ≠ 0) :
+    chiK a * zetapow ζ a * gaussSumOdd ζ
+      = ∑ c : ZMod q, chiK c * zetapow ζ (a * (1 + c)) := by
+  have hreindex : gaussSumOdd (q := q) ζ
+      = ∑ c : ZMod q, chiK (a * c) * zetapow ζ (a * c) :=
+    (Fintype.sum_bijective _ (mulLeft_bijective₀ a ha) _ _ (fun c => rfl)).symm
+  rw [hreindex, Finset.mul_sum]
+  refine Finset.sum_congr rfl fun c _ => ?_
+  have h1 : a * (1 + c) = a + a * c := by ring
+  rw [chiK_mul, h1, zetapow_add ζ hζq]
+  have h2 : chiK (K := K) a * chiK a = 1 := chiK_sq_eq_one ha
+  linear_combination zetapow ζ a * zetapow ζ (a * c) * chiK (K := K) c * h2
+
+/-- **Gauss's square formula** (1801): for an odd prime `q` and any field `K`
+with a primitive `q`-th root of unity `ζ`,
+
+    `(∑_a χ_q(a) ζ^a)² = χ_q(−1) · q`.
+
+The classical substitution proof: expand `S² = ∑_{a≠0} (χ(a)ζ^a)·S` (the `a=0`
+row vanishes), collapse each row to `∑_c χ(c) ζ^{a(1+c)}`
+(`term_mul_gaussSumOdd`), swap the sums, and evaluate the inner geometric sums:
+frequency `1+c = 0` contributes `χ(−1)(q−1)`, every other frequency
+contributes `−χ(c)`, and `∑ χ = 0` turns the tail into `+χ(−1)`. -/
+theorem gaussSumOdd_sq (hq2 : q ≠ 2) (ζ : K) (hζq : ζ ^ q = 1) (hζ1 : ζ ≠ 1) :
+    gaussSumOdd (q := q) ζ ^ 2 = chiK (-1) * q := by
+  -- Step 1: S² as a sum of rows over a ≠ 0
+  have hrow0 : chiK (K := K) (0 : ZMod q) * zetapow ζ 0 * gaussSumOdd ζ = 0 := by
+    rw [chiK_zero, zero_mul, zero_mul]
+  have hsq : gaussSumOdd (q := q) ζ ^ 2
+      = ∑ a ∈ (univ : Finset (ZMod q)).erase 0,
+          chiK a * zetapow ζ a * gaussSumOdd ζ := by
+    rw [sq]
+    conv_lhs => rw [gaussSumOdd, Finset.sum_mul]
+    exact (Finset.sum_erase _ hrow0).symm
+  -- Step 2: collapse the rows and swap the summation order
+  have hswap : gaussSumOdd (q := q) ζ ^ 2
+      = ∑ c : ZMod q, chiK c *
+          ∑ a ∈ (univ : Finset (ZMod q)).erase 0, zetapow ζ (a * (1 + c)) := by
+    rw [hsq]
+    rw [Finset.sum_congr rfl fun a ha =>
+      term_mul_gaussSumOdd ζ hζq (Finset.mem_erase.mp ha).1]
+    rw [Finset.sum_comm]
+    exact Finset.sum_congr rfl fun c _ => (Finset.mul_sum _ _ _).symm
+  -- Step 3: evaluate the inner sums over a ≠ 0
+  have hinner_zero : ∑ a ∈ (univ : Finset (ZMod q)).erase 0, zetapow ζ (a * 0)
+      = (q : K) - 1 := by
+    rw [Finset.sum_erase_eq_sub (mem_univ 0), sum_zetapow_mul_zero, zero_mul,
+      zetapow_zero]
+  have hinner_ne : ∀ d : ZMod q, d ≠ 0 →
+      ∑ a ∈ (univ : Finset (ZMod q)).erase 0, zetapow ζ (a * d) = -1 := by
+    intro d hd
+    rw [Finset.sum_erase_eq_sub (mem_univ 0), sum_zetapow_mul_eq_zero ζ hζq hζ1 hd,
+      zero_mul, zetapow_zero, zero_sub]
+  -- Step 4: split the outer sum at c = −1
+  rw [hswap, ← Finset.add_sum_erase _ _ (mem_univ (-1 : ZMod q))]
+  have hc1 : (1 : ZMod q) + -1 = 0 := by ring
+  rw [hc1, hinner_zero]
+  have htail : ∑ c ∈ (univ : Finset (ZMod q)).erase (-1),
+      chiK c * ∑ a ∈ (univ : Finset (ZMod q)).erase 0, zetapow ζ (a * (1 + c))
+      = ∑ c ∈ (univ : Finset (ZMod q)).erase (-1), -chiK (K := K) c := by
+    refine Finset.sum_congr rfl fun c hc => ?_
+    have hc' : (1 : ZMod q) + c ≠ 0 := by
+      intro h0
+      exact (Finset.mem_erase.mp hc).1 (by linear_combination h0)
+    rw [hinner_ne _ hc']
+    ring
+  rw [htail, Finset.sum_neg_distrib,
+    Finset.sum_erase_eq_sub (mem_univ (-1 : ZMod q)), sum_chiK hq2]
+  ring
+
+/-! ## Corollaries -/
+
+/-- The square formula in Legendre-symbol form:
+`g_q² = (−1 | q) · q` where `(· | q)` is `legendreSym q`. -/
+theorem gaussSumOdd_sq_legendre (hq2 : q ≠ 2) (ζ : K) (hζq : ζ ^ q = 1)
+    (hζ1 : ζ ≠ 1) :
+    gaussSumOdd (q := q) ζ ^ 2 = ((legendreSym q (-1) : ℤ) : K) * q := by
+  rw [gaussSumOdd_sq hq2 ζ hζq hζ1]
+  congr 1
+  unfold chiK legendreSym
+  push_cast
+  rfl
+
+/-- **Nonvanishing:** if additionally `q ≠ 0` in `K` (i.e. `char K ≠ q`), the
+Gauss sum is nonzero — the key cancellation input for the forthcoming
+Frobenius-covariance step. -/
+theorem gaussSumOdd_ne_zero (hq2 : q ≠ 2) (ζ : K) (hζq : ζ ^ q = 1)
+    (hζ1 : ζ ≠ 1) (hqK : (q : K) ≠ 0) :
+    gaussSumOdd (q := q) ζ ≠ 0 := by
+  intro h
+  have hsq := gaussSumOdd_sq hq2 ζ hζq hζ1
+  rw [h, zero_pow two_ne_zero] at hsq
+  have hneg1 : (-1 : ZMod q) ≠ 0 := by
+    intro h0
+    have : (1 : ZMod q) = 0 := by linear_combination -h0
+    exact one_ne_zero this
+  have hone : chiK (K := K) (-1 : ZMod q) * chiK (-1) = 1 := chiK_sq_eq_one hneg1
+  have hchi : chiK (K := K) (-1 : ZMod q) = 0 := by
+    rcases mul_eq_zero.mp hsq.symm with h' | h'
+    · exact h'
+    · exact absurd h' hqK
+  rw [hchi, mul_zero] at hone
+  exact zero_ne_one hone
+
+end KroneckerSymbol

--- a/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/state.md
+++ b/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/state.md
@@ -103,3 +103,23 @@ second-argument dual of Section 10's numerator-negation family (5 theorems, 0 so
 
 Meta counts updated (theoremCount 76→81, lineCount 1124→1172). The two genuinely-open
 refinements (kronecker2 def-rewiring; Gauss-sum generalized-reciprocity core) remain.
+
+## 2026-07-23 (researcher-1-5): odd-prime Gauss sum engine — `g_q² = χ_q(−1)·q`
+
+New satellite file `ElementaryQuadraticReciprocityOQ03OQ02WIP01GaussOdd.lean`
+(0 sorry / 0 axiom, Docker-verified): for ANY odd prime `q`, ANY field `K`, and
+any `ζ` with `ζ^q = 1`, `ζ ≠ 1` (primitivity free at prime level), the quadratic
+Gauss sum `gaussSumOdd ζ = ∑_{a : ZMod q} χ_q(a)·ζ^a` satisfies the Gauss square
+formula `gaussSumOdd_sq : g² = χ_q(−1)·q`, plus `gaussSumOdd_ne_zero` when
+`char K ≠ q` and the Legendre-symbol form. Fully self-contained (no Mathlib
+GaussSum/AddChar), matching the node's explicit-ζ₈ treatment of q = 2.
+Key tricks: shift-reindex orthogonality (no geometric series); row collapse via
+`mulLeft_bijective₀` + `χ(a)² = 1`; `linear_combination` for the character
+algebra.
+
+This was the identified hard half of open Target 2. **Remaining (now plausibly
+session-sized):** Frobenius covariance `g^p = χ_q(p)·g` in `GaloisField p k`
+(exact analogue of the proven q=2 recipe: `add_pow_char`, reindex, descend via
+`algebraMap (ZMod p)` injectivity, Euler `legendreSym.eq_pow`, cancel `g` by
+`gaussSumOdd_ne_zero`) ⟹ full quadratic reciprocity independent of Mathlib's
+`jacobiSym.quadratic_reciprocity`.

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01.json
@@ -47,7 +47,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Kronecker symbol file COMPLETE for the original def (multiplicativity both args, reciprocity odd case, all supplementary characters with value-tables + periodicity + chi-bridges, real-character trichotomy). NEW (Section 15): refinement target 1 DONE — kroneckerClassical wires kronecker2 into the 2-adic part (the classical 1885 symbol), agrees with kronecker at odd moduli, (a/2)=kronecker2, and full bi-multiplicativity re-proved for the refined def (7 theorems, axiom-free, host-verified). Remaining open: Target 2 only — generalized quadratic reciprocity for fundamental discriminants via Gauss sums (deep, not session-sized).",
+    "progressSummary": "Kronecker symbol file COMPLETE for the original def (multiplicativity both args, reciprocity odd case, all supplementary characters with value-tables + periodicity + chi-bridges, real-character trichotomy). NEW (Section 15): refinement target 1 DONE — kroneckerClassical wires kronecker2 into the 2-adic part (the classical 1885 symbol), agrees with kronecker at odd moduli, (a/2)=kronecker2, and full bi-multiplicativity re-proved for the refined def (7 theorems, axiom-free, host-verified). Remaining open: Target 2 only — generalized quadratic reciprocity for fundamental discriminants via Gauss sums (deep, not session-sized). NEW (2026-07-23, GaussOdd satellite): the odd-prime half of the Gauss-sum engine is DONE — g_q^2 = chi_q(-1)*q ring-generically for any odd prime q and any field with a q-th root of unity (0-axiom, docker-verified). This is the identified hard half of the remaining open Target 2; what remains is the Frobenius-covariance step g^p = chi_q(p)*g in GaloisField p k (exact analogue of the proven q=2 recipe) + descent => full quadratic reciprocity independent of Mathlib QR.",
     "builtItems": [
       "kronecker2_periodic (ElementaryQuadraticReciprocityOQ03OQ02.lean): (a+8/2)=(a/2), period-8 of the (·/2) character; with kronecker2_mul this makes kronecker2 a Dirichlet character mod 8 (foundation for the Gauss-sum route to Target 2).",
       "kronecker2_mul (ElementaryQuadraticReciprocityOQ03OQ02.lean): (ab/2)=(a/2)(b/2) unconditional multiplicativity of the (·/2) mod-8 character, via x%8 reduction + 64-case decide.",
@@ -69,7 +69,11 @@
       "kroneckerClassical_eq_kronecker_of_odd + kroneckerClassical_eq_jacobi (odd-moduli agreement)",
       "kroneckerClassical_two + kroneckerClassical_two_pow (classical values at 2-power moduli)",
       "kroneckerClassical_eq_sign_mul_kronecker (bridge factorization)",
-      "kroneckerClassical_mul_right + kroneckerClassical_mul_left + kroneckerClassical_pow_right (full bi-multiplicativity for the refined def)"
+      "kroneckerClassical_mul_right + kroneckerClassical_mul_left + kroneckerClassical_pow_right (full bi-multiplicativity for the refined def)",
+      "ElementaryQuadraticReciprocityOQ03OQ02WIP01GaussOdd.lean: zetapow additive-to-multiplicative + primitivity (zetapow_add, zetapow_ne_one)",
+      "GaussOdd: orthogonality sum_zetapow_mul_eq_zero (shift trick) + sum_zetapow_mul_zero",
+      "GaussOdd: chiK cast quadratic character (mul, sq_eq_one, mean-zero via quadraticChar_sum_zero)",
+      "GaussOdd: gaussSumOdd_sq — Gauss square formula g_q^2 = chi_q(-1)*q (MAIN); legendre-symbol form; gaussSumOdd_ne_zero (char K != q)"
     ],
     "insights": [
       "For odd positive moduli the Kronecker symbol IS the Jacobi symbol (kronecker_eq_jacobi), so mul-in-n and QR come for free from jacobiSym.mul_right' and jacobiSym.quadratic_reciprocity.",
@@ -90,16 +94,18 @@
       "Key API (camelCase, NOT ord_compl notation — that notation does not exist in this Mathlib): Nat.ordCompl_mul (odd part multiplicative, stated as raw n / 2^(factorization 2)), Nat.ordCompl_pos, Nat.not_dvd_ordCompl, Nat.factorization_mul + Finsupp.add_apply (valuation additivity), Nat.Prime.factorization_pow + Finsupp.single_eq_same (v2(2^k)=k). All available with the existing imports (JacobiSymbol + Tactic) — no import changes.",
       "kroneckerClassical_mul_right re-proved for the refined def WITHOUT re-deriving chi8 multiplicativity: kronecker2_mul handles the 2-part, jacobiSym.mul_right on the odd parts, the private kroneckerNeg1_sq sign trick reused verbatim from kronecker_mul_right.",
       "Both symbols now coexist: kroneckerClassical_eq_kronecker_of_odd transfers ALL odd-modulus results (reciprocity, supplementary laws, character dictionary) to the classical symbol for free; kroneckerClassical_two pins the even-modulus difference ((a/2)=kronecker2 a vs Jacobi mod-2 value).",
-      "Host lake env lean verification sidesteps the documented Docker olean-write SIGBUS-135 entirely (elaboration only, no olean written) — this file verified green first try on host."
+      "Host lake env lean verification sidesteps the documented Docker olean-write SIGBUS-135 entirely (elaboration only, no olean written) — this file verified green first try on host.",
+      "Odd-prime Gauss sum square formula g_q^2 = chi_q(-1)*q holds in ANY field K with zeta^q=1, zeta != 1 (primitivity is free at prime level: order divides prime q); proved fully elementarily in GaussOdd satellite file — no Mathlib GaussSum/AddChar infra, matching the self-contained zeta_8 treatment of q=2",
+      "Root-of-unity orthogonality without geometric series: reindex a -> a+1 multiplies sum by zetapow d != 1, forcing the sum to vanish (shift trick); zero frequency gives q. Row collapse: for a != 0 reindex b = a*c via mulLeft_bijective0 + chi(a)^2 = 1",
+      "Elaboration gotchas hit: chiK (-1) / gaussSumOdd zeta cannot infer implicit q (q only in index type) — every use needs (q := q) or (-1 : ZMod q) ascription; Finset.sum_erase with a product-form row needs explicit (f := ...) or HO-unification picks f := id and demands DecidableEq K"
     ],
     "mathlibGaps": [
       "No Kronecker symbol in Mathlib (only jacobiSym for odd positive denominators).",
       "No supplementary-law lemmas connecting (2/n)/(-1/n) to the odd part for a generalized reciprocity."
     ],
     "nextSteps": [
-      "Use kronecker2_eq_χ₈ + jacobiSym.at_two to re-express kronecker at even moduli through χ₈ (the 2-adic refinement of nextStep 'route even moduli through kronecker2'), then re-prove kronecker_mul_right for the refined definition without re-deriving χ₈ multiplicativity.",
-      "Refine kronecker to use kronecker2 for the 2-adic part (classical symbol at even moduli), then re-prove kronecker_mul_right for the refined definition.",
-      "Target 2: generalized quadratic reciprocity for arbitrary fundamental discriminants (supplementary laws + Gauss sums)."
+      "Frobenius covariance: in GaloisField p k (k = order of p mod q), g^p = chi_q(p)*g via add_pow_char + reindexing; then Euler eq_pow + cancel g (gaussSumOdd_ne_zero) => (chi_q(-1)q)^((p-1)/2) relation => full QR without jacobiSym.quadratic_reciprocity. Session-sized now that gaussSumOdd_sq + ne_zero exist (mirror the q=2 GaloisField recipe end-to-end).",
+      "kronecker2 def-rewiring at even moduli (2-adic factorization refactor, ~100-200L) — still blocked, materially new mechanism required."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session for **elementary-quadratic-reciprocity-oq-03-oq-02-wip-01**. New satellite file `ElementaryQuadraticReciprocityOQ03OQ02WIP01GaussOdd.lean` (0 axioms, 0 sorries, Docker-verified) delivers the **odd-prime half of the node's Gauss-sum engine**: for any odd prime `q`, any field `K`, and any `ζ` with `ζ^q = 1`, `ζ ≠ 1`, the quadratic Gauss sum satisfies Gauss's square formula

**`gaussSumOdd_sq : (∑_a χ_q(a)·ζ^a)² = χ_q(−1)·q`**

This is the identified hard half of the node's remaining open question (full quadratic reciprocity via Gauss sums, independent of Mathlib's `jacobiSym.quadratic_reciprocity`), complementing the already-landed prime-2 treatment (τ(χ₈)² = 8 → second supplement, PR #42263).

## Progress
- `zetapow` additive-to-multiplicative on `ZMod q` + primitivity-for-free at prime level (`zetapow_add`, `zetapow_ne_one`)
- Root-of-unity orthogonality via the **shift trick** — reindexing `a ↦ a+1` multiplies the sum by `ζ^d ≠ 1`, so it vanishes; no geometric-series machinery (`sum_zetapow_mul_eq_zero`)
- Cast quadratic character toolkit (`chiK_mul`, `chiK_sq_eq_one`, mean-zero via `quadraticChar_sum_zero`)
- Row collapse `χ(a)ζ^a·S = ∑_c χ(c)ζ^{a(1+c)}` by `b = a·c` reindex (`mulLeft_bijective₀`) + `χ(a)² = 1`
- **`gaussSumOdd_sq`** (main), Legendre-symbol form, and `gaussSumOdd_ne_zero` for `char K ≠ q` (the cancellation input for the Frobenius step)

## Findings
- The formula is ring-generic: it holds verbatim in `GaloisField p k`, which is exactly where the follow-up Frobenius covariance `g^p = χ_q(p)·g` (mirror of the proven q=2 GaloisField recipe) will produce reciprocity. That follow-up is now plausibly session-sized; next steps recorded in the tracker.
- Deliberately self-contained: Mathlib's abstract `GaussSum` proves an analogous formula, but the node's programme is an independent elementary chain (as with the explicit-ζ₈ prime-2 case); this is noted honestly in the module docstring.

## Status
**Outcome**: progress (engine landed; reciprocity core is the remaining step)
**Next Steps**: Frobenius covariance in `GaloisField p k` + descent ⟹ full QR independent of Mathlib's QR.

🤖 Generated by researcher-1-5
