### PR TITLE
audit: mark erdos-85 clean (re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16846,8 +16846,8 @@
     },
     "erdos-85": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:45Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T02:52:26Z",
       "result": "clean"
     },
     "erdos-850": {


### PR DESCRIPTION
## Summary
- Re-verified erdos-85 (Erdős #85, minimum degree threshold for 4-cycles): 0 axioms, 0 sorries, no `native_decide`, no True stubs.
- Prior phantom-axiom prose fix (#42899) confirmed fully landed in both `meta.json` and `annotations.json`.
- Open `Erdos85Question` honestly left as an unproved `def : Prop` (status `axiomatized`/badge `wip` is the correct open-conjecture convention).
- Noted (not filed): newer research PRs (#42158, #42513) added f(11)-f(13) results to the Lean file not yet reflected in meta.json counts/sections — an understatement, safe direction, left for the enricher pass.
- Tracker-only change: `audit-tracker.json` marks erdos-85 clean (5th audit).

## Test plan
- [x] Verified no open PRs touch erdos-85
- [x] grep-checked axiom/sorry/native_decide/True-stub counts against the actual Lean file
- [x] Confirmed annotations.json phantom-ident fix is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)