### PR TITLE
Enrich sperner-mathlib4-oq-02-oq-04: quality 96 -> 100

### DIFF
--- a/src/data/proofs/sperner-mathlib4-oq-02-oq-04/meta.json
+++ b/src/data/proofs/sperner-mathlib4-oq-02-oq-04/meta.json
@@ -42,7 +42,8 @@
       "The oriented boundary seed the whole n ≥ 2 program was missing is the hemisphere SIGN-degree: push the {±1,±2} labelling through the magnitude-collapsing sign map sgn : Fin 4 → ZMod 2 and count sign flips along an antipodal-boundary arc. This is the first POSITIVE odd boundary seed on the hexagon — every prior boundary result (even ring, non-invariant half-ring) was negative.",
       "The sign map is the ZMod 2 reduction of the antipodal action (sgn (negL x) = sgn x + 1), so a hemisphere arc v₀ → ⋯ → v₃ = −v₀ has sign-distinct endpoints — exactly the boundary condition of the verified one-dimensional Tucker lemma. The odd hemisphere sign-degree is therefore n = 1 Tucker applied to the sign-reduced labelling, connecting the n = 2 boundary directly to the already-verified base case.",
       "The seed lives on the antipodal fundamental domain, not the whole circle: the full-ring sign-change count is EVEN (the loop returns to its starting sign), so the oddness is read off half the loop — the discrete analogue of reading a degree off a fundamental domain. This is why the sibling entries' full-ring and symmetric counts had to be even.",
-      "A sign flip is a genuinely weaker event than a complementary edge: a boundary edge can have opposite signs (e.g. +2 then −1) yet not be complementary (λ(v_{i+1}) ≠ −λ(v_i)). The complementary-edge count misses exactly these edges, which is precisely why it is even / non-parity-invariant while the sign-degree is odd. Bridging the odd sign flips to an interior complementary simplex is the remaining 2-D path-following."
+      "A sign flip is a genuinely weaker event than a complementary edge: a boundary edge can have opposite signs (e.g. +2 then −1) yet not be complementary (λ(v_{i+1}) ≠ −λ(v_i)). The complementary-edge count misses exactly these edges, which is precisely why it is even / non-parity-invariant while the sign-degree is odd. Bridging the odd sign flips to an interior complementary simplex is the remaining 2-D path-following.",
+      "Every certificate here is discharged by plain `decide`, not `native_decide` — the free-labelling space is exactly 4³ = 64 (the centre label c is boundary-irrelevant, and negL is determined by the free vertex), small enough for kernel whnf reduction. This keeps the result genuinely 0-axiom (only `propext` / `Classical.choice` / `Quot.sound`, no `Lean.ofReduceBool`), unlike sibling door-counting entries whose larger case spaces force `native_decide` and its attendant axiom disclosure."
     ]
   },
   "sections": [
@@ -63,10 +64,17 @@
     },
     {
       "id": "hemisphere-sign-degree-odd",
-      "title": "The Hemisphere Sign-Degree is Odd, the Full Ring Even",
+      "title": "The Hemisphere Sign-Degree is Odd",
       "startLine": 103,
+      "endLine": 118,
+      "summary": "arcSignChanges counts the edges of the fundamental-domain arc v₀ → v₁ → v₂ → v₃ across which the sign bit flips, and arc_sign_changes_odd proves this hemisphere sign-degree is ODD for every antipodal labelling (all 4³ = 64 cases by decide) — the positive odd boundary seed, obtained as n = 1 Tucker of the sign-reduced labelling whose arc endpoints sgn v₀ and sgn v₃ = sgn v₀ + 1 differ."
+    },
+    {
+      "id": "full-ring-even",
+      "title": "The Full Ring is Even — Oddness is a Fundamental-Domain Phenomenon",
+      "startLine": 119,
       "endLine": 128,
-      "summary": "arcSignChanges counts the edges of the fundamental-domain arc v₀ → v₁ → v₂ → v₃ across which the sign bit flips, and arc_sign_changes_odd proves this hemisphere sign-degree is ODD for every antipodal labelling (all 4³ = 64 cases by decide) — the positive odd boundary seed, obtained as n = 1 Tucker of the sign-reduced labelling whose arc endpoints sgn v₀ and sgn v₃ = sgn v₀ + 1 differ. fullSignChanges counts sign flips around the whole ring, and full_sign_changes_even proves it is always EVEN: the odd seed lives on the antipodal fundamental domain, not the whole circle."
+      "summary": "fullSignChanges counts sign flips around the whole boundary ring v₀ → v₁ → ⋯ → v₅ → v₀ (all six edges), and full_sign_changes_even proves this count is always EVEN, again by decide. The loop returns to its starting sign, so its telescoping sum is 0 mod 2; the odd hemisphere count is invisible on the full circle and appears only when restricting to the antipodal fundamental domain — the discrete analogue of reading a topological degree off half the loop."
     },
     {
       "id": "sign-vs-complementary",


### PR DESCRIPTION
Enrichment pass for `sperner-mathlib4-oq-02-oq-04` (quality: 96 -> 100).

The entry was already at target (5 annotations with mathContext/significance/relatedConcepts, ~700-char historicalContext, 4 keyInsights, full conclusion). The remaining 4 quality points mapped to two genuine gaps rather than filler:

- **keyInsights (4 -> 5)**: added a methodology insight explaining why every certificate here is discharged by plain `decide` rather than `native_decide` (the free-labelling space is exactly 4^3 = 64, small enough for kernel whnf reduction), keeping the result genuinely 0-axiom — directly relevant given the project's axiom-integrity conventions around `native_decide`/`Lean.ofReduceBool`.
- **sections (4 -> 5)**: split the combined "hemisphere sign-degree odd / full ring even" section (lines 103-128) into two sections along the existing annotation boundary (103-118 / 119-128), matching the two conceptually distinct theorems (`arc_sign_changes_odd`, `full_sign_changes_even`) that already had separate annotations.

No content was invented; both additions restate/derive facts already established by the file and its existing annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)