### PR TITLE
Research: elementary-quadratic-reciprocity-oq-03-oq-02-wip-01 — FULL quadratic reciprocity via Gauss sums, independent of Mathlib QR (0-axiom)

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01GaussOdd.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01GaussOdd.lean
@@ -280,4 +280,103 @@ theorem gaussSumOdd_ne_zero (hq2 : q ≠ 2) (ζ : K) (hζq : ζ ^ q = 1)
   rw [hchi, mul_zero] at hone
   exact zero_ne_one hone
 
+/-! ## Frobenius covariance in characteristic `p`
+
+With the square formula in hand, the reciprocity mechanism is the Frobenius
+endomorphism: in a field of odd characteristic `p` (with `p` invertible mod
+`q`), raising the Gauss sum to the `p`-th power distributes over the sum
+(`sum_pow_char`), fixes the character values (`χ(a)^p = χ(a)` since
+`χ(a) ∈ {0, ±1}` and `p` is odd), and dilates the frequency (`(ζ^a)^p =
+ζ^{ap}`); undoing the dilation with the substitution `a ↦ a·p̄` costs exactly
+one factor `χ(p̄)`.  Cancelling `g ≠ 0` in `g^p = g·(g²)^{(p−1)/2}` then
+converts the covariance into the *Euler-criterion identity*
+`(χ(−1)·q)^{(p−1)/2} = χ(p̄)` — the algebraic heart of quadratic
+reciprocity. -/
+
+section Frobenius
+
+variable {p : ℕ} [hp : Fact p.Prime] [CharP K p]
+
+/-- Character values are fixed by odd powers: `χ(a)^p = χ(a)` in `K`, because
+`χ(a) ∈ {0, 1, −1}` and `p` is odd. -/
+theorem chiK_pow_char (hodd : Odd p) (a : ZMod q) :
+    chiK (K := K) a ^ p = chiK a := by
+  rcases quadraticChar_isQuadratic (ZMod q) a with h | h | h <;>
+    · unfold chiK
+      rw [h]
+      push_cast
+      first
+        | exact zero_pow hp.out.ne_zero
+        | exact one_pow p
+        | exact hodd.neg_one_pow
+
+/-- Power law for `zetapow`: `(ζ^a)^n = ζ^{a·n̄}` where `n̄ = (n : ZMod q)`.
+The exponents agree modulo `q`, and `ζ^q = 1` folds them. -/
+theorem zetapow_pow (ζ : K) (hζq : ζ ^ q = 1) (a : ZMod q) (n : ℕ) :
+    zetapow ζ a ^ n = zetapow ζ (a * (n : ZMod q)) := by
+  unfold zetapow
+  rw [← pow_mul]
+  conv_lhs => rw [pow_eq_pow_mod _ hζq]
+  conv_rhs => rw [pow_eq_pow_mod _ hζq]
+  congr 1
+  rw [ZMod.val_mul, Nat.mod_mod_of_dvd _ (dvd_refl q), ZMod.val_natCast]
+  exact Nat.ModEq.mul_left a.val (Nat.mod_modEq n q).symm
+
+/-- **Frobenius covariance of the Gauss sum:** in characteristic `p` (odd,
+invertible mod `q`), `g^p = χ(p̄)·g`.  The Frobenius distributes over the sum,
+fixes `χ`, and dilates frequencies by `p̄`; the substitution `a ↦ a·p̄`
+(`mulRight_bijective₀`) restores `g` at the cost of `χ(p̄)`. -/
+theorem gaussSumOdd_pow_char (hodd : Odd p) (ζ : K) (hζq : ζ ^ q = 1)
+    (hpq : (p : ZMod q) ≠ 0) :
+    gaussSumOdd (q := q) ζ ^ p = chiK (K := K) ((p : ZMod q)) * gaussSumOdd (q := q) ζ := by
+  haveI : ExpChar K p := ExpChar.prime hp.out
+  have hstep : gaussSumOdd (q := q) ζ ^ p
+      = ∑ a : ZMod q, chiK a * zetapow ζ (a * (p : ZMod q)) := by
+    rw [gaussSumOdd, sum_pow_char]
+    refine Finset.sum_congr rfl fun a _ => ?_
+    rw [mul_pow, chiK_pow_char hodd, zetapow_pow ζ hζq]
+  have hrw : ∀ a : ZMod q, chiK (K := K) a * zetapow ζ (a * (p : ZMod q))
+      = chiK (K := K) ((p : ZMod q))
+          * (chiK (a * (p : ZMod q)) * zetapow ζ (a * (p : ZMod q))) := by
+    intro a
+    have h2 : chiK (K := K) ((p : ZMod q)) * chiK ((p : ZMod q)) = 1 :=
+      chiK_sq_eq_one hpq
+    rw [chiK_mul]
+    linear_combination (-(chiK (K := K) a * zetapow ζ (a * (p : ZMod q)))) * h2
+  rw [hstep, Finset.sum_congr rfl fun a _ => hrw a, ← Finset.mul_sum]
+  congr 1
+  rw [gaussSumOdd]
+  exact Fintype.sum_bijective _ (mulRight_bijective₀ _ hpq) _ _ (fun a => rfl)
+
+/-- **The Euler-criterion identity:** cancelling `g ≠ 0` between
+`g^p = χ(p̄)·g` (Frobenius) and `g^p = g·(g²)^{(p−1)/2}` with `g² = χ(−1)·q`
+gives
+
+    `(χ(−1)·q)^{(p−1)/2} = χ(p̄)`   in `K`.
+
+Instantiated in `GaloisField p k` and descended to `ZMod p`, this becomes full
+quadratic reciprocity. -/
+theorem chi_neg_one_mul_q_pow_eq_chi (hq2 : q ≠ 2) (hodd : Odd p) (ζ : K)
+    (hζq : ζ ^ q = 1) (hζ1 : ζ ≠ 1) (hqK : (q : K) ≠ 0)
+    (hpq : (p : ZMod q) ≠ 0) :
+    (chiK (K := K) (-1 : ZMod q) * q) ^ ((p - 1) / 2) = chiK ((p : ZMod q)) := by
+  have hS := gaussSumOdd_ne_zero hq2 ζ hζq hζ1 hqK
+  have hfrob := gaussSumOdd_pow_char (p := p) hodd ζ hζq hpq
+  have hsq := gaussSumOdd_sq hq2 ζ hζq hζ1
+  have hp1 : p = 2 * ((p - 1) / 2) + 1 := by
+    rcases hodd with ⟨m, hm⟩; omega
+  have hpow : gaussSumOdd (q := q) ζ ^ p
+      = gaussSumOdd (q := q) ζ * (gaussSumOdd (q := q) ζ ^ 2) ^ ((p - 1) / 2) := by
+    conv_lhs => rw [hp1]
+    rw [pow_succ, pow_mul]
+    ring
+  rw [hsq] at hpow
+  have hcancel : gaussSumOdd (q := q) ζ * (chiK (K := K) (-1 : ZMod q) * q) ^ ((p - 1) / 2)
+      = gaussSumOdd (q := q) ζ * chiK ((p : ZMod q)) := by
+    rw [← hpow, hfrob]
+    ring
+  exact mul_left_cancel₀ hS hcancel
+
+end Frobenius
+
 end KroneckerSymbol

--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01GaussOdd.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01GaussOdd.lean
@@ -428,8 +428,8 @@ private theorem exists_qth_root (p q : ℕ) [hp : Fact p.Prime] [hq : Fact q.Pri
   haveI : Fintype (GaloisField p k)ˣ := Fintype.ofFinite _
   obtain ⟨g, hg⟩ := IsCyclic.exists_generator (α := (GaloisField p k)ˣ)
   have horder : orderOf g = p ^ k - 1 := by
-    rw [orderOf_eq_card_of_forall_mem_zpowers hg, ← Nat.card_eq_fintype_card,
-      Nat.card_units, GaloisField.card p k hk0]
+    rw [orderOf_eq_card_of_forall_mem_zpowers hg, Nat.card_units,
+      GaloisField.card p k hk0]
   have hζorder : orderOf (g ^ m) = q := by
     rw [orderOf_pow, horder, hm, Nat.gcd_eq_right (dvd_mul_left m q),
       Nat.mul_div_cancel _ (Nat.pos_of_ne_zero hm0)]

--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01GaussOdd.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01GaussOdd.lean
@@ -49,6 +49,7 @@ All results are `0`-axiom / `0`-sorry.
 -/
 
 import Mathlib.NumberTheory.LegendreSymbol.Basic
+import Mathlib.FieldTheory.Finite.GaloisField
 import Mathlib.Data.ZMod.Basic
 import Mathlib.Tactic
 
@@ -378,5 +379,168 @@ theorem chi_neg_one_mul_q_pow_eq_chi (hq2 : q ≠ 2) (hodd : Odd p) (ζ : K)
   exact mul_left_cancel₀ hS hcancel
 
 end Frobenius
+
+/-! ## Full quadratic reciprocity, independent of Mathlib's QR
+
+Instantiating the engine in `GaloisField p k` — where `k` is the
+multiplicative order of `p` mod `q`, so that `q ∣ p^k − 1` and the cyclic unit
+group contains an element of order exactly `q` — and descending the
+Euler-criterion identity along the prime subfield `ZMod p` yields **quadratic
+reciprocity in Euler's `q*` form**:
+
+    `(q* | p) = (p | q)`  where  `q* = χ_q(−1)·q`,
+
+for distinct odd primes `p, q`.  Nothing below invokes
+`jacobiSym.quadratic_reciprocity` or Mathlib's Gauss-sum library; the inputs
+are the self-contained engine above, Euler's criterion (`legendreSym.eq_pow`),
+and finite-field generalities. -/
+
+section Reciprocity
+
+/-- **Existence of a `q`-th root of unity in a Galois field of characteristic
+`p`.**  Take `k` to be the multiplicative order of `p` mod `q`; then
+`q ∣ p^k − 1`, and a generator `g` of the cyclic group
+`(GaloisField p k)ˣ` (order `p^k − 1`) yields `ζ = g^{(p^k−1)/q}` of order
+exactly `q`. -/
+private theorem exists_qth_root (p q : ℕ) [hp : Fact p.Prime] [hq : Fact q.Prime]
+    (hpq : p ≠ q) :
+    ∃ (k : ℕ) (ζ : GaloisField p k), ζ ^ q = 1 ∧ ζ ≠ 1 := by
+  have hcop : Nat.Coprime p q := (Nat.coprime_primes hp.out hq.out).mpr hpq
+  -- k := order of p mod q gives q ∣ p^k − 1
+  have hkey : ∃ k, k ≠ 0 ∧ q ∣ p ^ k - 1 := by
+    refine ⟨orderOf (ZMod.unitOfCoprime p hcop), (orderOf_pos _).ne', ?_⟩
+    have h2 : ((p : ZMod q)) ^ orderOf (ZMod.unitOfCoprime p hcop) = 1 := by
+      have h1 := congrArg (Units.val) (pow_orderOf_eq_one (ZMod.unitOfCoprime p hcop))
+      rwa [Units.val_pow_eq_pow_val, Units.val_one, ZMod.coe_unitOfCoprime] at h1
+    have hple : 1 ≤ p ^ orderOf (ZMod.unitOfCoprime p hcop) :=
+      Nat.one_le_pow _ _ hp.out.pos
+    have h3 : ((p ^ orderOf (ZMod.unitOfCoprime p hcop) - 1 : ℕ) : ZMod q) = 0 := by
+      rw [Nat.cast_sub hple, Nat.cast_pow, h2, Nat.cast_one, sub_self]
+    exact (ZMod.natCast_eq_zero_iff _ _).mp h3
+  obtain ⟨k, hk0, hdvd⟩ := hkey
+  obtain ⟨m, hm⟩ := hdvd
+  have hpk1 : 1 < p ^ k := Nat.one_lt_pow hk0 hp.out.one_lt
+  have hm0 : m ≠ 0 := by
+    intro h0
+    rw [h0, mul_zero] at hm
+    omega
+  -- a generator of the cyclic unit group
+  haveI : Fintype (GaloisField p k)ˣ := Fintype.ofFinite _
+  obtain ⟨g, hg⟩ := IsCyclic.exists_generator (α := (GaloisField p k)ˣ)
+  have horder : orderOf g = p ^ k - 1 := by
+    rw [orderOf_eq_card_of_forall_mem_zpowers hg, ← Nat.card_eq_fintype_card,
+      Nat.card_units, GaloisField.card p k hk0]
+  have hζorder : orderOf (g ^ m) = q := by
+    rw [orderOf_pow, horder, hm, Nat.gcd_eq_right (dvd_mul_left m q),
+      Nat.mul_div_cancel _ (Nat.pos_of_ne_zero hm0)]
+  refine ⟨k, ((g ^ m : (GaloisField p k)ˣ) : GaloisField p k), ?_, ?_⟩
+  · have h1 : (g ^ m) ^ q = 1 := by rw [← hζorder]; exact pow_orderOf_eq_one _
+    have h2 := congrArg Units.val h1
+    rwa [Units.val_pow_eq_pow_val, Units.val_one] at h2
+  · intro h1
+    have h2 : (g ^ m) = (1 : (GaloisField p k)ˣ) :=
+      Units.ext (by rw [Units.val_one]; exact h1)
+    have h3 : orderOf (g ^ m) = 1 := by rw [h2, orderOf_one]
+    rw [hζorder] at h3
+    exact hq.out.one_lt.ne' h3
+
+/-- Casts of `±1` into `ZMod p` are injective for `p > 2`. -/
+private theorem int_pm_one_cast_inj {p : ℕ} [hp : Fact p.Prime] (hp2 : p ≠ 2)
+    {a b : ℤ} (ha : a = 1 ∨ a = -1) (hb : b = 1 ∨ b = -1)
+    (h : (a : ZMod p) = (b : ZMod p)) : a = b := by
+  haveI : Fact (2 < p) := ⟨by have := hp.out.two_le; omega⟩
+  rcases ha with rfl | rfl <;> rcases hb with rfl | rfl
+  · rfl
+  · exfalso; push_cast at h; exact ZMod.neg_one_ne_one h.symm
+  · exfalso; push_cast at h; exact ZMod.neg_one_ne_one h
+  · rfl
+
+/-- **Quadratic reciprocity (Euler's `q*` form), independent of Mathlib's
+QR.**  For distinct odd primes `p ≠ q`,
+
+    `(χ_q(−1)·q | p) = (p | q)`,
+
+i.e. `legendreSym p (legendreSym q (−1) * q) = legendreSym q p`.  Proof: the
+Euler-criterion identity `(χ(−1)q)^{(p−1)/2} = χ(p̄)` holds in
+`GaloisField p k` (Gauss square formula + Frobenius covariance + cancellation
+of `g ≠ 0`); both sides are integer casts, so the identity descends along the
+injective `algebraMap (ZMod p) → GaloisField p k` to `ZMod p`, where the left
+side is `legendreSym p (χ(−1)q)` by Euler's criterion; finally `±1` values are
+distinguished mod `p > 2`. -/
+theorem quadratic_reciprocity_qstar (p q : ℕ) [hp : Fact p.Prime] [hq : Fact q.Prime]
+    (hp2 : p ≠ 2) (hq2 : q ≠ 2) (hpq : p ≠ q) :
+    legendreSym p (legendreSym q (-1) * q) = legendreSym q p := by
+  obtain ⟨k, ζ, hζq, hζ1⟩ := exists_qth_root p q hpq
+  have hoddp : Odd p := hp.out.odd_of_ne_two hp2
+  have hqK : ((q : GaloisField p k)) ≠ 0 := by
+    intro h0
+    exact (Nat.Prime.coprime_iff_not_dvd hp.out).mp
+      ((Nat.coprime_primes hp.out hq.out).mpr hpq)
+      ((CharP.cast_eq_zero_iff (GaloisField p k) p q).mp h0)
+  have hpZ : ((p : ZMod q)) ≠ 0 := by
+    intro h0
+    exact (Nat.Prime.coprime_iff_not_dvd hq.out).mp
+      ((Nat.coprime_primes hq.out hp.out).mpr hpq.symm)
+      ((ZMod.natCast_eq_zero_iff p q).mp h0)
+  -- the K-identity from the engine
+  have hK := chi_neg_one_mul_q_pow_eq_chi (p := p) hq2 hoddp ζ hζq hζ1 hqK hpZ
+  unfold chiK at hK
+  -- both sides as integer casts
+  set A : ℤ := (quadraticChar (ZMod q) (-1) * q) ^ ((p - 1) / 2) with hA
+  set B : ℤ := quadraticChar (ZMod q) ((p : ZMod q)) with hB
+  have hKAB : ((A : GaloisField p k)) = (B : GaloisField p k) := by
+    rw [hA, hB]
+    push_cast
+    push_cast at hK
+    exact hK
+  -- descend to the prime subfield
+  have hZp : ((A : ZMod p)) = (B : ZMod p) := by
+    apply (algebraMap (ZMod p) (GaloisField p k)).injective
+    rw [map_intCast, map_intCast]
+    exact hKAB
+  -- Euler's criterion on the left
+  have hdiv : p / 2 = (p - 1) / 2 := by rcases hoddp with ⟨t, ht⟩; omega
+  have hlhs : ((legendreSym p ((quadraticChar (ZMod q) (-1)) * q) : ℤ) : ZMod p)
+      = (A : ZMod p) := by
+    rw [legendreSym.eq_pow, hdiv, hA]
+    push_cast
+    ring
+  have hB' : B = legendreSym q p := by
+    rw [hB]
+    unfold legendreSym
+    norm_num
+  have hcong : ((legendreSym p ((quadraticChar (ZMod q) (-1)) * q) : ℤ) : ZMod p)
+      = ((legendreSym q p : ℤ) : ZMod p) := by
+    rw [hlhs, hZp, hB']
+  -- the ±1 values are distinguished mod p
+  have hchi_pm : quadraticChar (ZMod q) (-1) = 1 ∨ quadraticChar (ZMod q) (-1) = -1 := by
+    rcases quadraticChar_isQuadratic (ZMod q) (-1) with h | h | h
+    · exfalso
+      rw [quadraticChar_eq_zero_iff] at h
+      exact (neg_ne_zero.mpr one_ne_zero) h
+    · exact Or.inl h
+    · exact Or.inr h
+  have hXne : (((quadraticChar (ZMod q) (-1)) * (q : ℤ) : ℤ) : ZMod p) ≠ 0 := by
+    push_cast
+    apply mul_ne_zero
+    · rcases hchi_pm with h | h <;> rw [h] <;> push_cast
+      · exact one_ne_zero
+      · exact neg_ne_zero.mpr one_ne_zero
+    · intro h0
+      exact (Nat.Prime.coprime_iff_not_dvd hp.out).mp
+        ((Nat.coprime_primes hp.out hq.out).mpr hpq)
+        ((ZMod.natCast_eq_zero_iff q p).mp (by exact_mod_cast h0))
+  have hL1 := legendreSym.eq_one_or_neg_one (p := p) hXne
+  have hL2 : legendreSym q p = 1 ∨ legendreSym q p = -1 :=
+    legendreSym.eq_one_or_neg_one (p := q) (by exact_mod_cast hpZ)
+  have hmain : legendreSym p ((quadraticChar (ZMod q) (-1)) * q) = legendreSym q p :=
+    int_pm_one_cast_inj hp2 hL1 hL2 hcong
+  have hbridge : legendreSym q (-1) = quadraticChar (ZMod q) (-1) := by
+    unfold legendreSym
+    norm_num
+  rw [hbridge]
+  exact hmain
+
+end Reciprocity
 
 end KroneckerSymbol

--- a/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/state.md
+++ b/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/state.md
@@ -123,3 +123,26 @@ session-sized):** Frobenius covariance `g^p = χ_q(p)·g` in `GaloisField p k`
 `algebraMap (ZMod p)` injectivity, Euler `legendreSym.eq_pow`, cancel `g` by
 `gaussSumOdd_ne_zero`) ⟹ full quadratic reciprocity independent of Mathlib's
 `jacobiSym.quadratic_reciprocity`.
+
+## 2026-07-23 (researcher-1-5, same session, later): FULL QUADRATIC RECIPROCITY — Target 2 CLOSED
+
+Same file, same session: the Frobenius-covariance step landed immediately after
+the engine, and with it **full quadratic reciprocity in Euler's q* form**,
+end-to-end independent of Mathlib's `jacobiSym.quadratic_reciprocity`:
+
+- `gaussSumOdd_pow_char` — `g^p = χ_q(p̄)·g` in any field of odd char `p`
+  (`sum_pow_char`, `χ(a)^p = χ(a)`, frequency dilation + `a ↦ a·p̄` reindex).
+- `chi_neg_one_mul_q_pow_eq_chi` — the Euler-criterion identity
+  `(χ(−1)·q)^{(p−1)/2} = χ(p̄)`, by cancelling `g ≠ 0`.
+- `exists_qth_root` — `ζ` of order `q` in `GaloisField p k`, `k = ord_q(p)`
+  (cyclic units + `orderOf_pow` gcd computation).
+- **`quadratic_reciprocity_qstar`** — `(χ_q(−1)·q | p) = (p | q)` for distinct
+  odd primes, via descent along `algebraMap (ZMod p) (GaloisField p k)`
+  injectivity + `legendreSym.eq_pow` + ±1 separation mod `p > 2`.
+
+0 sorry / 0 axiom, Docker-verified. **Target 2 is CLOSED.** The only remaining
+open refinement on this node is the `kronecker2` def-rewiring at even moduli
+(2-adic factorization refactor, still blocked, materially new mechanism
+required). Optional cosmetic follow-up: the product form
+`(p|q)(q|p) = (−1)^{(p−1)/2·(q−1)/2}` via `χ_q(−1) = (−1)^{(q−1)/2}` parity
+bookkeeping (χ₄ supplement), no new mechanism needed.

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01.json
@@ -47,7 +47,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Kronecker symbol file COMPLETE for the original def (multiplicativity both args, reciprocity odd case, all supplementary characters with value-tables + periodicity + chi-bridges, real-character trichotomy). NEW (Section 15): refinement target 1 DONE — kroneckerClassical wires kronecker2 into the 2-adic part (the classical 1885 symbol), agrees with kronecker at odd moduli, (a/2)=kronecker2, and full bi-multiplicativity re-proved for the refined def (7 theorems, axiom-free, host-verified). Remaining open: Target 2 only — generalized quadratic reciprocity for fundamental discriminants via Gauss sums (deep, not session-sized). NEW (2026-07-23, GaussOdd satellite): the odd-prime half of the Gauss-sum engine is DONE — g_q^2 = chi_q(-1)*q ring-generically for any odd prime q and any field with a q-th root of unity (0-axiom, docker-verified). This is the identified hard half of the remaining open Target 2; what remains is the Frobenius-covariance step g^p = chi_q(p)*g in GaloisField p k (exact analogue of the proven q=2 recipe) + descent => full quadratic reciprocity independent of Mathlib QR.",
+    "progressSummary": "TARGET 2 CLOSED (2026-07-23, researcher-1-5): full quadratic reciprocity proved independently of Mathlib jacobiSym.quadratic_reciprocity — quadratic_reciprocity_qstar : (chi_q(-1)*q | p) = (p | q) for distinct odd primes, via the self-contained odd-prime Gauss sum engine (g^2 = chi(-1)q), Frobenius covariance in GaloisField p k, and descent to ZMod p. All 0-axiom 0-sorry, Docker-verified. Node now: Kronecker file complete; QR-via-Gauss-sums programme complete for both the prime 2 (PR #42263) and odd primes. Only remaining open item: kronecker2 def-rewiring at even moduli (blocked).",
     "builtItems": [
       "kronecker2_periodic (ElementaryQuadraticReciprocityOQ03OQ02.lean): (a+8/2)=(a/2), period-8 of the (·/2) character; with kronecker2_mul this makes kronecker2 a Dirichlet character mod 8 (foundation for the Gauss-sum route to Target 2).",
       "kronecker2_mul (ElementaryQuadraticReciprocityOQ03OQ02.lean): (ab/2)=(a/2)(b/2) unconditional multiplicativity of the (·/2) mod-8 character, via x%8 reduction + 64-case decide.",
@@ -73,7 +73,10 @@
       "ElementaryQuadraticReciprocityOQ03OQ02WIP01GaussOdd.lean: zetapow additive-to-multiplicative + primitivity (zetapow_add, zetapow_ne_one)",
       "GaussOdd: orthogonality sum_zetapow_mul_eq_zero (shift trick) + sum_zetapow_mul_zero",
       "GaussOdd: chiK cast quadratic character (mul, sq_eq_one, mean-zero via quadraticChar_sum_zero)",
-      "GaussOdd: gaussSumOdd_sq — Gauss square formula g_q^2 = chi_q(-1)*q (MAIN); legendre-symbol form; gaussSumOdd_ne_zero (char K != q)"
+      "GaussOdd: gaussSumOdd_sq — Gauss square formula g_q^2 = chi_q(-1)*q (MAIN); legendre-symbol form; gaussSumOdd_ne_zero (char K != q)",
+      "GaussOdd: gaussSumOdd_pow_char (Frobenius covariance), chi_neg_one_mul_q_pow_eq_chi (Euler-criterion identity)",
+      "GaussOdd: exists_qth_root (order-q root in GaloisField p k, k = ord_q(p))",
+      "GaussOdd: quadratic_reciprocity_qstar — FULL quadratic reciprocity (Euler q* form), independent of Mathlib QR (0-axiom)"
     ],
     "insights": [
       "For odd positive moduli the Kronecker symbol IS the Jacobi symbol (kronecker_eq_jacobi), so mul-in-n and QR come for free from jacobiSym.mul_right' and jacobiSym.quadratic_reciprocity.",
@@ -97,15 +100,18 @@
       "Host lake env lean verification sidesteps the documented Docker olean-write SIGBUS-135 entirely (elaboration only, no olean written) — this file verified green first try on host.",
       "Odd-prime Gauss sum square formula g_q^2 = chi_q(-1)*q holds in ANY field K with zeta^q=1, zeta != 1 (primitivity is free at prime level: order divides prime q); proved fully elementarily in GaussOdd satellite file — no Mathlib GaussSum/AddChar infra, matching the self-contained zeta_8 treatment of q=2",
       "Root-of-unity orthogonality without geometric series: reindex a -> a+1 multiplies sum by zetapow d != 1, forcing the sum to vanish (shift trick); zero frequency gives q. Row collapse: for a != 0 reindex b = a*c via mulLeft_bijective0 + chi(a)^2 = 1",
-      "Elaboration gotchas hit: chiK (-1) / gaussSumOdd zeta cannot infer implicit q (q only in index type) — every use needs (q := q) or (-1 : ZMod q) ascription; Finset.sum_erase with a product-form row needs explicit (f := ...) or HO-unification picks f := id and demands DecidableEq K"
+      "Elaboration gotchas hit: chiK (-1) / gaussSumOdd zeta cannot infer implicit q (q only in index type) — every use needs (q := q) or (-1 : ZMod q) ascription; Finset.sum_erase with a product-form row needs explicit (f := ...) or HO-unification picks f := id and demands DecidableEq K",
+      "FULL QR landed same-session as the engine: Frobenius covariance g^p = chi(pbar)*g needs only sum_pow_char + chi(a)^p=chi(a) (odd p) + zetapow_pow + a -> a*pbar reindex; cancellation vs g^p = g*(g^2)^((p-1)/2) gives (chi(-1)q)^((p-1)/2) = chi(pbar) in K",
+      "Descent recipe: integer-cast identities in GaloisField p k descend to ZMod p via map_intCast + (algebraMap (ZMod p) K).injective; then legendreSym.eq_pow (Euler) converts the power to a Legendre symbol and int_pm_one_cast_inj separates +-1 mod p>2",
+      "orderOf_eq_card_of_forall_mem_zpowers now returns Nat.card (not Fintype.card) in Mathlib v4.31 vintage — no Nat.card_eq_fintype_card bridge needed; GaloisField derives Finite/CharP/Algebra(ZMod p) so instances are free"
     ],
     "mathlibGaps": [
       "No Kronecker symbol in Mathlib (only jacobiSym for odd positive denominators).",
       "No supplementary-law lemmas connecting (2/n)/(-1/n) to the odd part for a generalized reciprocity."
     ],
     "nextSteps": [
-      "Frobenius covariance: in GaloisField p k (k = order of p mod q), g^p = chi_q(p)*g via add_pow_char + reindexing; then Euler eq_pow + cancel g (gaussSumOdd_ne_zero) => (chi_q(-1)q)^((p-1)/2) relation => full QR without jacobiSym.quadratic_reciprocity. Session-sized now that gaussSumOdd_sq + ne_zero exist (mirror the q=2 GaloisField recipe end-to-end).",
-      "kronecker2 def-rewiring at even moduli (2-adic factorization refactor, ~100-200L) — still blocked, materially new mechanism required."
+      "Optional: product form (p|q)(q|p) = (-1)^((p-1)/2*(q-1)/2) from quadratic_reciprocity_qstar via chi_q(-1) = (-1)^((q-1)/2) (chi4 supplement) — parity bookkeeping only",
+      "kronecker2 def-rewiring at even moduli (2-adic factorization refactor, ~100-200L) — still blocked, materially new mechanism required"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Capstone session for **elementary-quadratic-reciprocity-oq-03-oq-02-wip-01**, building on the odd-prime Gauss sum engine merged this session (#42902). Extends `ElementaryQuadraticReciprocityOQ03OQ02WIP01GaussOdd.lean` (+~250 lines, 0 axioms, 0 sorries, Docker-verified) to **full quadratic reciprocity in Euler's q\* form**, proven end-to-end without invoking `jacobiSym.quadratic_reciprocity` or Mathlib's Gauss-sum library:

**`quadratic_reciprocity_qstar : legendreSym p (legendreSym q (-1) * q) = legendreSym q p`** for distinct odd primes `p ≠ q`.

This closes the node's remaining open question (Target 2: generalized reciprocity via Gauss sums), completing the programme whose prime-2 case landed in PR #42263.

## Progress
- `chiK_pow_char`, `zetapow_pow` — Frobenius ingredients: character values fixed by odd powers; frequency dilation `(ζ^a)^n = ζ^{a·n̄}`
- `gaussSumOdd_pow_char` — **Frobenius covariance** `g^p = χ_q(p̄)·g` in any field of odd characteristic `p` (`sum_pow_char` + reindex `a ↦ a·p̄`)
- `chi_neg_one_mul_q_pow_eq_chi` — **Euler-criterion identity** `(χ_q(−1)·q)^{(p−1)/2} = χ_q(p̄)`, by cancelling `g ≠ 0` against `g² = χ(−1)q`
- `exists_qth_root` — a root of order exactly `q` in `GaloisField p k`, `k = ord_q(p)` (cyclic unit group, `orderOf_pow` gcd computation)
- `quadratic_reciprocity_qstar` — descent along the injective `algebraMap (ZMod p) (GaloisField p k)`, Euler's criterion (`legendreSym.eq_pow`), and ±1 separation mod `p > 2`

## Findings
- The whole reciprocity core needed only ~250 further lines once the square formula existed — the Frobenius/cancellation layer is ring-generic (stated for any `[CharP K p]` field), with `GaloisField` entering only at instantiation.
- Dependency honesty: the proof uses Mathlib's quadratic character basics and Euler's criterion (`legendreSym.eq_pow`) — neither of which depends on reciprocity — plus finite-field generalities. No reciprocity-adjacent Mathlib theorem is touched.
- Optional cosmetic follow-up recorded: the product form `(p|q)(q|p) = (−1)^{(p−1)/2·(q−1)/2}` via `χ_q(−1) = (−1)^{(q−1)/2}` parity bookkeeping.

## Status
**Outcome**: completed — Target 2 closed; node's only remaining open item is the (blocked) kronecker2 even-moduli def-rewiring
**Next Steps**: optional product-form corollary; otherwise stand down on this node

🤖 Generated by researcher-1-5
