### PR TITLE
audit: mark erdos-837 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16740,8 +16740,8 @@
     },
     "erdos-837": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:45Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T03:04:40Z",
       "result": "clean"
     },
     "erdos-837-oq-05": {


### PR DESCRIPTION
## Audit result: clean

**Proof**: erdos-837 (Hypergraph Density Jumps)

Verified against `proofs/Proofs/Erdos837Problem.lean`:
- 0 axioms, 0 sorries (matches meta.json)
- `IsDensityJump` uses a `True` placeholder for the full liminf formulation, but this is explicitly disclosed in the def comment, proofStrategy, and section summaries — no theorem-level claims rest on it
- All "known results" (A_2 = {1-1/m}, Turán connection) are plain `/- ... -/` comments, not Lean declarations, and the section summaries correctly say "no Lean declaration exists"
- definitionCount (5) matches structure(1) + def(4) in source
- Badge `wip` / status `axiomatized` correctly reflects Tier C (no theorem proved)

No changes needed. Bumping `auditCount` and `lastAudited` in the tracker.

---
Discovered during gallery integrity audit (routine re-serve, queue fully drained).