### PR TITLE
audit: fix erdos-830 axiomCount flip (1->0) + phantom axiom annotation

### DIFF
--- a/src/data/proofs/erdos-830/annotations.json
+++ b/src/data/proofs/erdos-830/annotations.json
@@ -137,13 +137,13 @@
     },
     "type": "concept",
     "title": "Open Conjecture: Infinitely Many Pairs",
-    "content": "**Are there infinitely many amicable pairs?** This is perhaps the central question.\n\nOver 1.2 billion amicable pairs have been found by computer search, but this doesn't prove infinitude. The pattern could theoretically stop at some astronomically large number.\n\nStated as an `axiom` because it remains unproven.",
+    "content": "**Are there infinitely many amicable pairs?** This is perhaps the central question.\n\nOver 1.2 billion amicable pairs have been found by computer search, but this doesn't prove infinitude. The pattern could theoretically stop at some astronomically large number.\n\nDocumented here as source commentary only — it is not stated as a Lean `axiom` and does not appear as a declaration in the file.",
     "mathContext": "The set {(a,b) | IsAmicable a b} is conjectured to be infinite. No proof or disproof exists.",
     "significance": "key",
     "relatedConcepts": [
       "infinity",
       "conjecture",
-      "axiom"
+      "open-problem"
     ],
     "prerequisites": [
       "Set.Infinite",

--- a/src/data/proofs/erdos-830/meta.json
+++ b/src/data/proofs/erdos-830/meta.json
@@ -45,7 +45,7 @@
       "Documentation of the Erdős and Pomerance upper bounds (recorded in source comments; not yet formalized as Lean statements)",
       "Counting function A(x) formalization"
     ],
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 142,
     "dateAdded": "2025-12-22",
     "prerequisites": [


### PR DESCRIPTION
## Integrity fix

**Proof**: erdos-830 (Amicable Pairs)

**Problem 1**: `meta.meta.axiomCount` = 1, but `leanFile.axiomCount` = 0 and the
actual source (`proofs/Proofs/Erdos830Problem.lean`) has zero `axiom`
declarations. The `assumptions` field already correctly disclosed "there are
no `axiom` declarations in the source" — only the top-level count field was
stale/flipped.

**Problem 2**: `annotations.json`'s `ann-e830-infinite` entry said the open
infinitude conjecture is "Stated as an `axiom` because it remains unproven."
The referenced lines (82-89) are a plain doc comment (`/- ... -/`), not a Lean
`axiom` declaration — nothing in the file axiomatizes the conjecture.

## Fix

- `meta.json`: `axiomCount` 1 → 0 (now consistent with `leanFile.axiomCount`
  and the source).
- `annotations.json`: reworded the annotation to say the conjecture is
  documented as commentary only, not a Lean axiom; dropped the misleading
  `"axiom"` tag from `relatedConcepts`.

No other fields needed correction — theoremCount (9), definitionCount (3),
sorries (0), and the `native_decide`/`Lean.ofReduceBool` disclosure were all
already accurate.

---
Discovered during gallery integrity audit.