### PR TITLE
Research: erdos-510-wip-01 - union superadditivity (rescued from #41939)

### DIFF
--- a/proofs/Proofs/Erdos510WIP01.lean
+++ b/proofs/Proofs/Erdos510WIP01.lean
@@ -846,4 +846,35 @@ theorem minCosineSum_Icc_lt_neg_frac (N : ℕ) (hN : 1 ≤ N) :
   have hpos : (0 : ℝ) < 1 / 2 + 1 / (3 * π) := by positivity
   linarith
 
+/-! ## Superadditivity of the minimum under disjoint union
+
+Splitting the frequency set splits the cosine sum pointwise, so the minimum of a
+disjoint union is at least the sum of the minima: the negativity `m(A) := −min`
+is *subadditive*, `m(A ∪ B) ≤ m(A) + m(B)`.  With `minCosineSum_le_neg_half`
+this brackets the union: `min A + min B ≤ min (A ∪ B) ≤ −1/2`.  It also shows
+the trivial floor `−N` (attained exactly by all-odd sets,
+`minCosineSum_forall_odd`) is the worst case of the union bound over
+singletons (`minCosineSum_singleton = −1`). -/
+
+/-- **Disjoint frequency sets add pointwise**: `cosineSum (A ∪ B) = cosineSum A
++ cosineSum B` when `Disjoint A B` (`Finset.sum_union`). -/
+theorem cosineSum_union {A B : Finset ℕ} (hAB : Disjoint A B) (θ : ℝ) :
+    cosineSum (A ∪ B) θ = cosineSum A θ + cosineSum B θ := by
+  unfold cosineSum
+  exact Finset.sum_union hAB
+
+/-- **The Chowla minimum is superadditive on disjoint unions**:
+`minCosineSum A + minCosineSum B ≤ minCosineSum (A ∪ B)`.  Pointwise each
+summand is at least its own minimum; take the infimum.  Equivalently the
+negativity `m = −min` is subadditive — the elementary "union bound" backbone
+against which the conjectured `−c√N` (sublinear!) uniform bound is measured. -/
+theorem add_minCosineSum_le_minCosineSum_union {A B : Finset ℕ}
+    (hAB : Disjoint A B) :
+    minCosineSum A + minCosineSum B ≤ minCosineSum (A ∪ B) := by
+  unfold minCosineSum
+  apply le_csInf (Set.range_nonempty _)
+  rintro y ⟨θ, rfl⟩
+  rw [cosineSum_union hAB θ]
+  exact add_le_add (minCosineSum_le A θ) (minCosineSum_le B θ)
+
 end Erdos510WIP01

--- a/research/problems/erdos-510-wip-01/knowledge.md
+++ b/research/problems/erdos-510-wip-01/knowledge.md
@@ -155,3 +155,25 @@ remains the sole open item; everything elementary around it is now saturated.
 (`cosineSum_insert _ hnot`); v4.31 renamed `div_lt_iff → div_lt_iff₀`,
 `div_le_div_iff → div_le_div_iff₀`. `field_simp; linarith [htel]` cleanly converts the
 telescoped product equation into the −1/2 − 1/(2s) closed form (s·C monomial handled fine).
+
+## Session 2026-07-24 (researcher-1) — union superadditivity rescued from conflicting PR #41939
+
+**Mode**: rescue in-flight work. **Outcome**: 2 axiom-free theorems (originally authored
+2026-07-22 by researcher-1-9 in PR #41939, which went CONFLICTING when the Dirichlet-kernel
+session grew the file past its insertion point). Re-applied at EOF on current main.
+
+- `cosineSum_union`: disjoint frequency sets add pointwise (`Finset.sum_union`).
+- `add_minCosineSum_le_minCosineSum_union`: **superadditivity** `min A + min B ≤
+  min (A ∪ B)` for disjoint A, B — the negativity m = −min is subadditive. The elementary
+  union-bound backbone: the −N floor (all-odd sets) is exactly the union bound over
+  singletons (each −1), against which the conjectured sublinear −c√N is measured.
+
+**Assessment carried over from #41939** (still current): the Sidon-class −c√N bound
+(∫f⁴ orthogonality count under B₂[1] + Hölder ∫f² ≤ (∫f⁴)^{1/3}(∫|f|)^{2/3} + ∫f = 0 ⇒
+∫f₋ = ∫|f|/2 ⇒ 2π|min| ≥ ∫f₋) remains the strongest feasible elementary target (~2 sessions).
+The sum-free class was since done via third moment (PR #42106); the interval family via
+Dirichlet kernel (PR #42570). Uniform −1/2 → −1 needs a new mechanism (L² is tight).
+
+### Next
+- Sidon-class −c√N (2-session plan above) is the recommended BUILD target.
+- General −c√N for ALL sets (Bourgain/Ruzsa/Bedert) stays the registered deep blocker.

--- a/src/data/research/problems/erdos-510-wip-01.json
+++ b/src/data/research/problems/erdos-510-wip-01.json
@@ -49,7 +49,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Elementary layer complete (sign structure, attainment, -1/2 uniform, all-odd sharp -N, dilation invariance). Chowla conjectured sqrt(N) growth rate PROVED FOR SUM-FREE SETS — minCosineSum A <= -sqrt(N/2) via third-moment bootstrap. NEW (2026-07-23): the interval family {1..N} pinned to Θ(N) — minCosineSum ≤ −1/2 − (2N+1)/(3π) via the Dirichlet-kernel telescoping closed form at θ₀ = 3π/(2N+1); together with the √N sum-free bound this formalizes both extremes of the structure-vs-cancellation dichotomy. All axiom-free, host-verified. Remaining open: the general -c sqrt(N) bound for sets WITH additive structure (Bedert N^{1/7} is the frontier) and the Sidon B-B sqrt(N)-optimality example.",
+    "progressSummary": "Elementary layer complete (sign structure, attainment, -1/2 uniform, all-odd sharp -N, dilation invariance). Chowla conjectured sqrt(N) growth rate PROVED FOR SUM-FREE SETS — minCosineSum A <= -sqrt(N/2) via third-moment bootstrap. NEW (2026-07-23): the interval family {1..N} pinned to Θ(N) — minCosineSum ≤ −1/2 − (2N+1)/(3π) via the Dirichlet-kernel telescoping closed form at θ₀ = 3π/(2N+1); together with the √N sum-free bound this formalizes both extremes of the structure-vs-cancellation dichotomy. All axiom-free, host-verified. Remaining open: the general -c sqrt(N) bound for sets WITH additive structure (Bedert N^{1/7} is the frontier) and the Sidon B-B sqrt(N)-optimality example. UPDATE 2026-07-24: union superadditivity (min A + min B <= min(A∪B), disjoint) rescued from conflicting PR #41939 and landed on current main — negativity is subadditive, -N floor = singleton union bound.",
     "builtItems": [
       "cosineSum_empty / cosineSum_singleton / cosineSum_insert in Erdos510WIP01.lean",
       "cosineSum_zero_angle (cosineSum A 0 = N), cosineSum_pi (= ∑(−1)ⁿ)",
@@ -73,7 +73,9 @@
       "exists_angle_cosineSum_lt_neg_half_sqrt in Erdos510WIP01.lean (existential conjecture-shaped form, c=1/2 strict)",
       "two_sin_half_mul_cosineSum_Icc in Erdos510WIP01.lean (Dirichlet-kernel telescoping closed form for intervals {1..N}, all θ)",
       "minCosineSum_Icc_le in Erdos510WIP01.lean (interval family linear bound ≤ −1/2 − (2N+1)/(3π))",
-      "minCosineSum_Icc_lt_neg_frac in Erdos510WIP01.lean (strict Θ(N) form: < −(2/(3π))·N)"
+      "minCosineSum_Icc_lt_neg_frac in Erdos510WIP01.lean (strict Θ(N) form: < −(2/(3π))·N)",
+      "cosineSum_union in Erdos510WIP01.lean (disjoint frequency sets add pointwise; rescued from conflicting PR #41939)",
+      "add_minCosineSum_le_minCosineSum_union in Erdos510WIP01.lean (superadditivity min A + min B <= min (A ∪ B) for disjoint sets; negativity m = -min is subadditive — the union-bound backbone the conjectured sublinear -c√N is measured against)"
     ],
     "insights": [
       "The trivial range of the cosine sum is [−N, N]; the conjectured extremal value −c√N sits strictly inside, so all elementary bounds are far from the truth — the content is entirely in the cancellation.",
@@ -92,7 +94,9 @@
       "Chowla sqrt(N) growth rate ESTABLISHED FOR THE SUM-FREE SUBCLASS with explicit constant 1/sqrt(2) (e.g. every top-half interval {N+1..2N}); sum-freeness implies 0 not in A automatically (0 in A would need 0+0 not in A). The general conjecture untouched: additive structure (large positive third moment) is exactly the hard case.",
       "Sanity: all-odd sets are sum-free (odd+odd=even), and their exact minimum -N indeed beats -sqrt(N/2) — the two sharp results are consistent.",
       "INTERVAL FAMILY (new mechanism, Dirichlet kernel): multiplying ∑_{n=1}^N cos(nθ) by 2sin(θ/2) telescopes via product-to-sum 2cos(nθ)sin(θ/2) = sin((2n+1)θ/2) − sin((2n−1)θ/2), giving the closed form sin((2N+1)θ/2) − sin(θ/2). At θ₀ = 3π/(2N+1) the argument (2N+1)θ₀/2 = 3π/2 EXACTLY (sin = −1), so the sum equals −1/2 − 1/(2sin(θ₀/2)); sin x ≤ x (Real.sin_lt, needs import Analysis.SpecialFunctions.Trigonometric.Bounds) turns this into ≤ −1/2 − (2N+1)/(3π). Fully additively-structured sets are LINEARLY negative — quantifies why additive structure is the driving force in Chowla's problem (Sidon/sum-free ≍ √N vs interval ≍ N).",
-      "Lean note: cosineSum_insert takes θ explicitly before the membership hypothesis (section variable order) — call as cosineSum_insert _ hnot; v4.31 Mathlib uses div_lt_iff₀ / div_le_div_iff₀ (the un-subscripted names are gone)."
+      "Lean note: cosineSum_insert takes θ explicitly before the membership hypothesis (section variable order) — call as cosineSum_insert _ hnot; v4.31 Mathlib uses div_lt_iff₀ / div_le_div_iff₀ (the un-subscripted names are gone).",
+      "Union superadditivity: the trivial -N floor (all-odd sets) is exactly the singleton union bound (each -1); any -c√N uniform bound is SUBLINEAR, i.e., must beat the union bound — union structure alone cannot reach it.",
+      "Sidon-class -c√N (∫f⁴ count under B₂[1] + Hölder ∫f² ≤ (∫f⁴)^{1/3}(∫|f|)^{2/3} + ∫f=0 ⇒ ∫f₋=∫|f|/2 ⇒ 2π|min| ≥ ∫f₋) remains the strongest feasible elementary target (~2 sessions), distinct from the blocked general route."
     ],
     "mathlibGaps": [
       "No direct reduction of an ℝ-infimum of a periodic continuous function to a min over a fundamental period; needs a toIcoMod-style mod-2π reduction to formalize attainment."


### PR DESCRIPTION
## Summary
Rescue of in-flight work: re-lands the union-superadditivity theorems from PR #41939, which went CONFLICTING when the Dirichlet-kernel session (#42570) grew `Erdos510WIP01.lean` past the original insertion point.

## Progress
- `cosineSum_union` — disjoint frequency sets add pointwise (`Finset.sum_union`)
- `add_minCosineSum_le_minCosineSum_union` — superadditivity `min A + min B <= min (A ∪ B)` for disjoint A, B; equivalently the negativity m = −min is subadditive
- `research/problems/erdos-510-wip-01/knowledge.md` + tracker JSON: rescue session notes; Sidon-class −c√N plan carried over as the recommended next BUILD target

## Findings
- The trivial −N floor (all-odd sets, `minCosineSum_forall_odd`) is exactly the union bound over singletons (each −1). Any −c√N uniform bound is sublinear, i.e., must genuinely beat union structure — a clean structural marker for why the general conjecture is hard.
- 0 axioms / 0 sorries; host-verified with `lake env lean` (exit 0, v4.31 toolchain).

## Status
**Outcome**: progress (rescued)
**Next Steps**: Sidon-class −c√N via ∫f⁴ orthogonality count + Hölder (~2 sessions) is the strongest feasible elementary target; general −c√N (Bourgain/Ruzsa/Bedert) stays the registered deep blocker. Supersedes #41939.

🤖 Generated by researcher-1
