### PR TITLE
Enrich stirling-first-kind-oq-01: 5th keyInsight + split sections

### DIFF
--- a/src/data/proofs/stirling-first-kind-oq-01/meta.json
+++ b/src/data/proofs/stirling-first-kind-oq-01/meta.json
@@ -67,7 +67,8 @@
       "**A statistic identity for free**: every permutation of an n-set has a well-defined number of cycles, so the cycle-count statistic c(n,·) is a partition of the n! permutations; summing it over all k must return n!.",
       "**The recurrence collapses to the factorial recursion**: c(n+1,k+1) = n·c(n,k+1) + c(n,k) turns the row sum into R(n+1) = n·A + R(n), and the single index-shift fact A + c(n,0) = R(n) — together with n·c(n,0) = 0 — reduces it to R(n+1) = (n+1)·R(n).",
       "**Subtraction-free over ℕ**: phrasing the shift as the *additive* identity A + c(n,0) = R(n) (rather than A = R(n) − c(n,0)) keeps the whole argument in ℕ with no truncated-subtraction side conditions.",
-      "**Filling a real Mathlib gap**: Mathlib's Stirling file proves the recurrence and the edge values c(n,n)=1, c(n+1,1)=n!, c(n+1,n)=C(n+1,2), but not the row sum; this is the first aggregate identity for the first-kind triangle."
+      "**Filling a real Mathlib gap**: Mathlib's Stirling file proves the recurrence and the edge values c(n,n)=1, c(n+1,1)=n!, c(n+1,n)=C(n+1,2), but not the row sum; this is the first aggregate identity for the first-kind triangle.",
+      "**Sign flips the asymptotics entirely**: the unsigned row sum ∑ₖ c(n,k) = n! grows factorially, but the *signed* row sum ∑ₖ (−1)^{n−k} c(n,k) — the falling factorial x^{(n)} evaluated at x = 1 — collapses to 0 for every n ≥ 2, since x^{(n)} carries a factor (x−1). The same recurrence yields radically different closed forms depending on whether cycles are counted with or without sign."
     ],
     "prerequisites": [
       "Unsigned Stirling numbers of the first kind and the cycle decomposition of permutations",
@@ -80,33 +81,41 @@
       "id": "imports-docstring",
       "title": "Imports and Setup",
       "startLine": 1,
-      "endLine": 60,
+      "endLine": 50,
       "summary": "File-level docstring stating ∑ₖ c(n,k) = n!, its combinatorial meaning (cycle-count statistic on permutations), and the recurrence-to-factorial collapse used. Imports Mathlib and opens Nat and Finset.",
       "mathContext": "Nat.stirlingFirst n k counts permutations of an n-set with k cycles; Mathlib supplies the recurrence and edge values but not the row sum."
     },
     {
       "id": "column-zero",
       "title": "The Leftmost Column Collapse n·c(n,0) = 0",
-      "startLine": 61,
-      "endLine": 73,
+      "startLine": 52,
+      "endLine": 59,
       "summary": "stirlingFirst_mul_zero_left: by cases on n. For n = 0 the prefactor is 0; for n = m+1, c(n,0) = 0 by stirlingFirst_succ_zero. This is the fact that makes the row-sum recursion match the factorial recursion exactly.",
       "mathContext": "c(n,0) = 0 for n ≥ 1 (a nonempty permutation has at least one cycle) and the n = 0 term is annihilated by its prefactor."
     },
     {
       "id": "row-sum",
       "title": "The Row Sum ∑ₖ c(n,k) = n!",
-      "startLine": 74,
-      "endLine": 108,
+      "startLine": 61,
+      "endLine": 101,
       "summary": "stirlingFirst_row_sum: induction on n. Base by decide. Step peels k=0 (sum_range_succ'), applies the recurrence termwise, splits into n·A + R(n), uses the additive shift A + c(n,0) = R(n) and n·c(n,0) = 0 to get n·A = n·R(n), then folds (n+1)·R(n) = (n+1)! via Nat.factorial_succ.",
       "mathContext": "R(n+1) = n·R(n) + R(n) = (n+1)·R(n) with R(0) = 1, the factorial recursion."
     },
     {
       "id": "positivity",
       "title": "Positivity of the Row Sum",
+      "startLine": 103,
+      "endLine": 107,
+      "summary": "stirlingFirst_row_sum_pos: rewrite by the row-sum identity and apply Nat.factorial_pos, an immediate corollary isolated for downstream use.",
+      "mathContext": "n! > 0, so there is always at least one permutation of an n-element set."
+    },
+    {
+      "id": "examples",
+      "title": "Concrete Numerical Checks",
       "startLine": 109,
       "endLine": 115,
-      "summary": "stirlingFirst_row_sum_pos: rewrite by the row-sum identity and apply Nat.factorial_pos. Two concrete checks (row 4 sums to 24, c(4,2) = 11) close the file by decide.",
-      "mathContext": "n! > 0, so there is always at least one permutation of an n-element set."
+      "summary": "Two concrete checks close the file by kernel decide: the fourth row sums to 24 = 4!, and c(4,2) = 11, the number of permutations of a 4-set with exactly two cycles.",
+      "mathContext": "∑ₖ c(4,k) = 24 = 4! and c(4,2) = 11, both verified by axiom-free kernel decide."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for stirling-first-kind-oq-01 (quality 96 -> 100):

- Added a 5th `keyInsight`: the sign-flip contrast between the unsigned row sum (grows factorially, = n!) and the signed row sum (collapses to 0 for n >= 2, the falling factorial x^(n) at x=1), tying into the entry's existing open question about formalizing the signed identity.
- Split `sections` from 4 to 5 at the Lean file's natural theorem/proof boundaries (imports/docstring, column-zero lemma, row-sum theorem, positivity corollary, concrete examples), aligning startLine/endLine with the actual declarations and giving the previously-merged positivity+examples section its own entry.

No content deleted; existing annotations, references, and cross-references untouched. meta.json stays well under the 60 KB cap (~11.8 KB).