### PR TITLE
Fix stirling-first-kind-oq-01: re-anchor annotation line ranges

### DIFF
--- a/src/data/proofs/stirling-first-kind-oq-01/annotations.json
+++ b/src/data/proofs/stirling-first-kind-oq-01/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "stirling-first-kind-oq-01",
     "range": {
       "startLine": 1,
-      "endLine": 60
+      "endLine": 51
     },
     "type": "concept",
     "title": "Stirling Numbers of the First Kind",
@@ -27,8 +27,8 @@
     "id": "ann-column-zero",
     "proofId": "stirling-first-kind-oq-01",
     "range": {
-      "startLine": 61,
-      "endLine": 73
+      "startLine": 52,
+      "endLine": 60
     },
     "type": "lemma",
     "title": "The Leftmost Column Collapse",
@@ -50,7 +50,7 @@
     "id": "ann-row-sum",
     "proofId": "stirling-first-kind-oq-01",
     "range": {
-      "startLine": 74,
+      "startLine": 61,
       "endLine": 101
     },
     "type": "theorem",

--- a/src/data/proofs/stirling-first-kind-oq-01/meta.json
+++ b/src/data/proofs/stirling-first-kind-oq-01/meta.json
@@ -80,30 +80,30 @@
       "id": "imports-docstring",
       "title": "Imports and Setup",
       "startLine": 1,
-      "endLine": 60,
+      "endLine": 51,
       "summary": "File-level docstring stating ∑ₖ c(n,k) = n!, its combinatorial meaning (cycle-count statistic on permutations), and the recurrence-to-factorial collapse used. Imports Mathlib and opens Nat and Finset.",
       "mathContext": "Nat.stirlingFirst n k counts permutations of an n-set with k cycles; Mathlib supplies the recurrence and edge values but not the row sum."
     },
     {
       "id": "column-zero",
       "title": "The Leftmost Column Collapse n·c(n,0) = 0",
-      "startLine": 61,
-      "endLine": 73,
+      "startLine": 52,
+      "endLine": 60,
       "summary": "stirlingFirst_mul_zero_left: by cases on n. For n = 0 the prefactor is 0; for n = m+1, c(n,0) = 0 by stirlingFirst_succ_zero. This is the fact that makes the row-sum recursion match the factorial recursion exactly.",
       "mathContext": "c(n,0) = 0 for n ≥ 1 (a nonempty permutation has at least one cycle) and the n = 0 term is annihilated by its prefactor."
     },
     {
       "id": "row-sum",
       "title": "The Row Sum ∑ₖ c(n,k) = n!",
-      "startLine": 74,
-      "endLine": 108,
+      "startLine": 61,
+      "endLine": 102,
       "summary": "stirlingFirst_row_sum: induction on n. Base by decide. Step peels k=0 (sum_range_succ'), applies the recurrence termwise, splits into n·A + R(n), uses the additive shift A + c(n,0) = R(n) and n·c(n,0) = 0 to get n·A = n·R(n), then folds (n+1)·R(n) = (n+1)! via Nat.factorial_succ.",
       "mathContext": "R(n+1) = n·R(n) + R(n) = (n+1)·R(n) with R(0) = 1, the factorial recursion."
     },
     {
       "id": "positivity",
       "title": "Positivity of the Row Sum",
-      "startLine": 109,
+      "startLine": 103,
       "endLine": 115,
       "summary": "stirlingFirst_row_sum_pos: rewrite by the row-sum identity and apply Nat.factorial_pos. Two concrete checks (row 4 sums to 24, c(4,2) = 11) close the file by decide.",
       "mathContext": "n! > 0, so there is always at least one permutation of an n-element set."

--- a/src/data/proofs/stirling-first-kind-oq-01/meta.json
+++ b/src/data/proofs/stirling-first-kind-oq-01/meta.json
@@ -80,30 +80,30 @@
       "id": "imports-docstring",
       "title": "Imports and Setup",
       "startLine": 1,
-      "endLine": 51,
+      "endLine": 60,
       "summary": "File-level docstring stating ∑ₖ c(n,k) = n!, its combinatorial meaning (cycle-count statistic on permutations), and the recurrence-to-factorial collapse used. Imports Mathlib and opens Nat and Finset.",
       "mathContext": "Nat.stirlingFirst n k counts permutations of an n-set with k cycles; Mathlib supplies the recurrence and edge values but not the row sum."
     },
     {
       "id": "column-zero",
       "title": "The Leftmost Column Collapse n·c(n,0) = 0",
-      "startLine": 52,
-      "endLine": 60,
+      "startLine": 61,
+      "endLine": 73,
       "summary": "stirlingFirst_mul_zero_left: by cases on n. For n = 0 the prefactor is 0; for n = m+1, c(n,0) = 0 by stirlingFirst_succ_zero. This is the fact that makes the row-sum recursion match the factorial recursion exactly.",
       "mathContext": "c(n,0) = 0 for n ≥ 1 (a nonempty permutation has at least one cycle) and the n = 0 term is annihilated by its prefactor."
     },
     {
       "id": "row-sum",
       "title": "The Row Sum ∑ₖ c(n,k) = n!",
-      "startLine": 61,
-      "endLine": 102,
+      "startLine": 74,
+      "endLine": 108,
       "summary": "stirlingFirst_row_sum: induction on n. Base by decide. Step peels k=0 (sum_range_succ'), applies the recurrence termwise, splits into n·A + R(n), uses the additive shift A + c(n,0) = R(n) and n·c(n,0) = 0 to get n·A = n·R(n), then folds (n+1)·R(n) = (n+1)! via Nat.factorial_succ.",
       "mathContext": "R(n+1) = n·R(n) + R(n) = (n+1)·R(n) with R(0) = 1, the factorial recursion."
     },
     {
       "id": "positivity",
       "title": "Positivity of the Row Sum",
-      "startLine": 103,
+      "startLine": 109,
       "endLine": 115,
       "summary": "stirlingFirst_row_sum_pos: rewrite by the row-sum identity and apply Nat.factorial_pos. Two concrete checks (row 4 sums to 24, c(4,2) = 11) close the file by decide.",
       "mathContext": "n! > 0, so there is always at least one permutation of an n-element set."


### PR DESCRIPTION
## Summary
- `annotations.json`'s `range` fields for `ann-imports-docstring`, `ann-column-zero`, and `ann-row-sum` pointed at the wrong lines in `proofs/Proofs/StirlingFirstKindOQ01.lean`: each was shifted forward relative to the theorem/doc-comment it claims to describe.
  - `ann-imports-docstring` (1–60) absorbed `stirlingFirst_mul_zero_left` (lines 52–60) without describing it.
  - `ann-column-zero` (61–73) pointed at the `stirlingFirst_row_sum` doc comment instead of `stirlingFirst_mul_zero_left`.
  - `ann-row-sum` started at line 74 — mid-proof, past its own doc comment (line 61) and theorem keyword (line 69).
- Re-anchored all three ranges to the actual construct boundaries (verified line-by-line against the `.lean` file). `ann-positivity` (103–107) and `ann-examples` (109–115) were already correct.
- `meta.json`'s `sections[]` had the identical issue but is already fixed by #42938 (open), so this PR is scoped to `annotations.json` only to avoid merge conflict/duplication.

## Test plan
- [x] `python3 -m json.tool` validates both JSON files
- [x] Manually cross-checked every new range against `grep -n` output of `proofs/Proofs/StirlingFirstKindOQ01.lean`