### PR TITLE
fix(meta): erdos-1151 disclose companion file's undisclosed sorry

### DIFF
--- a/src/data/proofs/erdos-1151/meta.json
+++ b/src/data/proofs/erdos-1151/meta.json
@@ -17,7 +17,7 @@
       "interpolation"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 1151,
     "erdosUrl": "https://erdosproblems.com/1151",
     "erdosProblemStatus": "open",
@@ -39,10 +39,11 @@
       "Proof that Chebyshev nodes lie in [-1,1]",
       "Lagrange interpolation operator using basis polynomials",
       "Definition of limit point sets for sequences",
-      "Formal statement of the full conjecture with special cases derived"
+      "Formal statement of the full conjecture with special cases derived",
+      "Companion file Erdos1151OQ04.lean: partial proof of erdos_1941_divergence via the Lebesgue-function approach, reducing it to a single remaining sorry (lacunary-series construction in divergence_from_lebesgue_growth)"
     ],
     "axiomCount": 2,
-    "assumptions": "2 axioms: erdos_1941_divergence (Erdős 1941 result on divergence at rational cosines), erdos_1151_conjecture (the open problem).",
+    "assumptions": "2 axioms: erdos_1941_divergence (Erdős 1941 result on divergence at rational cosines), erdos_1151_conjecture (the open problem). The companion file Erdos1151OQ04.lean (listed under additionalFiles) works toward proving erdos_1941_divergence and contains 1 remaining sorry (divergence_from_lebesgue_growth); all its other lemmas are fully proved, no further axioms.",
     "lineCount": 222,
     "prerequisites": [
       "Polynomial interpolation (Lagrange basis)",
@@ -177,5 +178,5 @@
       "Proofs/Erdos1151OQ04.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 1
 }


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-1151 (Erdős Problem #1151 — Limit Points of Lagrange Interpolation at Chebyshev Nodes)
**Problem**: `meta.json` claimed `sorries: 0` (top-level and `meta.sorries`), but the companion file `Proofs/Erdos1151OQ04.lean` — listed in `additionalFiles`/`leanFile.additionalFiles` and imported by `Erdos1151OQ04Aristotle.lean` (which is itself imported/compiled as part of `proofs/`) — contains 1 real `sorry` in `divergence_from_lebesgue_growth` (line 2697), part of an in-progress Lebesgue-function proof attempt at the `erdos_1941_divergence` axiom.

The primary file `Erdos1151Problem.lean` is genuinely clean (0 sorries, 2 axioms, 7 theorems, 8 definitions — all match `leanFile.*` counts). The companion file's own docstring is also stale: it says the main reduction theorem is "FULLY PROVED... assuming two sorry lemmas," but one of those two (`trig_sum_harmonic_lb`) was fully proved in a later session — only 1 sorry actually remains.

## Evidence

**meta.json claimed**: `sorries: 0` everywhere
**Lean file shows**: `proofs/Proofs/Erdos1151OQ04.lean:2697` — `theorem divergence_from_lebesgue_growth ... := by sorry`

## Fix

- `meta.sorries` and top-level `sorries`: `0` → `1` (aggregate across primary + companion file, consistent with the erdos-873 precedent where `leanFile.sorries` stays scoped to the primary file only — left at `0`).
- `originalContributions`: added disclosure of the companion file's partial proof progress.
- `assumptions`: added disclosure of the companion file's 1 remaining sorry.

Badge (`axiom`) and status (`axiomatized`) were already appropriately conservative and don't need to change — this is purely a numeric/prose disclosure fix. `annotations.json` was checked and contains no mislabeling (only discusses the two disclosed axioms).

---
Discovered during gallery integrity audit (round-robin re-serve, queue was fully drained: 4811/4811 audited).