### PR TITLE
Update audit tracker: cauchy-schwarz-oq-04 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5022,9 +5022,9 @@
       "agentId": "auditor-reaudit-20260708"
     },
     "cauchy-schwarz-oq-04": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:45Z",
+      "lastAudited": "2026-07-24T03:33:48Z",
       "result": "clean"
     },
     "cauchy-schwarz-oq-04-oq-01": {


### PR DESCRIPTION
Gallery integrity audit re-serve. Verified cauchy-schwarz-oq-04 against Proofs/CauchySchwarzOQ04.lean:
- 0 sorries, 0 axioms, 0 native_decide, no True stubs
- theoremCount 17 / definitionCount 2 match actual declarations
- All 8 crossReferences resolve to existing gallery entries
- Badge `original` appropriate (core results proved independently using Mathlib inner-product primitives, not a single wrapped Mathlib theorem)

Result: clean, no changes needed to meta.json.

Discovered during gallery integrity audit.