### PR TITLE
Research: erdos-620-incomplete-01 - fix degenerate erdosRogers (inconsistent Shearer axiom) + certification lemmas

### DIFF
--- a/proofs/Proofs/Erdos620Problem.lean
+++ b/proofs/Proofs/Erdos620Problem.lean
@@ -94,7 +94,7 @@ noncomputable def maxTriangleFreeInduced (G : SimpleGraph V) : ℕ :=
            the maximum triangle-free induced subgraph size.
 -/
 noncomputable def erdosRogers (n : ℕ) : ℕ :=
-  sInf {k : ℕ | ∀ (G : SimpleGraph (Fin n)), K4Free G → maxTriangleFreeInduced G ≥ k}
+  sSup {k : ℕ | ∀ (G : SimpleGraph (Fin n)), K4Free G → maxTriangleFreeInduced G ≥ k}
 
 /-- Alternative characterization: f(n) is the largest k such that
     every K₄-free graph on n vertices has a triangle-free induced subgraph
@@ -222,7 +222,7 @@ theorem erdos_rogers_ramsey_connection (n k : ℕ) (hn : n ≥ ramsey3k k) :
 /-- The generalized Erdős-Rogers function f_{s,t}(n):
     minimum K_t-free induced subgraph size in K_s-free graphs on n vertices. -/
 noncomputable def generalizedErdosRogers (s t n : ℕ) : ℕ :=
-  sInf {k : ℕ | ∀ (G : SimpleGraph (Fin n)),
+  sSup {k : ℕ | ∀ (G : SimpleGraph (Fin n)),
     G.CliqueFree s → ∃ H : Finset (Fin n), H.card ≥ k ∧
       (inducedSubgraph G H).CliqueFree t}
 
@@ -282,3 +282,102 @@ structure of extremal K₄-free graphs.
 - What is the structure of extremal graphs?
 - Can probabilistic constructions be derandomized?
 -/
+
+namespace Erdos620
+
+/- ## Part XII: Well-Definedness of the Corrected f(n)
+
+REPAIR NOTE (2026-07-24).  `erdosRogers` and `generalizedErdosRogers` were
+originally defined as `sInf` of their guarantee sets `{k | ∀ G, … → … ≥ k}`.
+Every such set contains `k = 0`, so both functions were identically `0`; in
+particular the axiom `shearer_lower_bound` then asserted
+`0 ≥ c·√n·√(log n)/log(log n)` with a strictly positive right-hand side at
+`n = 16` — a false statement, making the file's axiom set inconsistent.
+The guarantee set is downward closed, so the intended value — the LARGEST
+uniformly guaranteed `k` — is its `sSup`.  Both definitions now use `sSup`;
+the lemmas below certify that the corrected `erdosRogers` has the min-max
+behaviour the prose describes, and that the axioms constrain a genuinely
+nonzero quantity. -/
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+omit [Fintype V] [DecidableEq V] in
+/-- The empty vertex set induces a triangle-free subgraph. -/
+theorem inducedTriangleFree_empty (G : SimpleGraph V) :
+    InducedTriangleFree G (∅ : Finset V) := by
+  rintro ⟨⟨x, hx⟩, -, -, -⟩
+  exact absurd hx (Finset.notMem_empty x)
+
+omit [DecidableEq V] in
+/-- The size set defining `maxTriangleFreeInduced` is bounded by `|V|`. -/
+theorem bddAbove_triangleFreeInduced_sizes (G : SimpleGraph V) :
+    BddAbove {k : ℕ | ∃ S : Finset V, S.card = k ∧ InducedTriangleFree G S} := by
+  refine ⟨Fintype.card V, ?_⟩
+  rintro k ⟨S, hcard, -⟩
+  rw [← hcard, ← Finset.card_univ]
+  exact S.card_le_univ
+
+omit [DecidableEq V] in
+/-- Any triangle-free induced vertex set is a lower witness for
+`maxTriangleFreeInduced`. -/
+theorem le_maxTriangleFreeInduced {G : SimpleGraph V} {S : Finset V}
+    (hS : InducedTriangleFree G S) : S.card ≤ maxTriangleFreeInduced G := by
+  apply le_csSup (bddAbove_triangleFreeInduced_sizes G)
+  exact show ∃ T : Finset V, T.card = S.card ∧ InducedTriangleFree G T from ⟨S, rfl, hS⟩
+
+omit [DecidableEq V] in
+/-- `maxTriangleFreeInduced` never exceeds the number of vertices. -/
+theorem maxTriangleFreeInduced_le_card (G : SimpleGraph V) :
+    maxTriangleFreeInduced G ≤ Fintype.card V := by
+  apply csSup_le
+  · exact ⟨0, ∅, Finset.card_empty, inducedTriangleFree_empty G⟩
+  · rintro k ⟨S, hcard, -⟩
+    rw [← hcard, ← Finset.card_univ]
+    exact S.card_le_univ
+
+/-- The empty graph is K₄-free. -/
+theorem k4Free_bot (n : ℕ) : K4Free (⊥ : SimpleGraph (Fin n)) := by
+  rintro ⟨a, b, c, d, -, -, -, -, -, -, hab, -⟩
+  exact hab
+
+/-- **Min-over-graphs behaviour**: the corrected `erdosRogers n` is at most the
+maximum triangle-free induced size of ANY single K₄-free graph — exactly the
+property the degenerate `sInf` form failed to have (it was identically `0`,
+which satisfied this vacuously but broke the lower-bound axiom). -/
+theorem erdosRogers_le {n : ℕ} {G : SimpleGraph (Fin n)} (hG : K4Free G) :
+    erdosRogers n ≤ maxTriangleFreeInduced G := by
+  apply csSup_le
+  · exact ⟨0, fun H _ => Nat.zero_le _⟩
+  · exact fun k hk => hk G hG
+
+/-- **Guarantee behaviour**: any uniform guarantee over all K₄-free graphs
+lower-bounds `erdosRogers n`. -/
+theorem le_erdosRogers {n k : ℕ}
+    (h : ∀ G : SimpleGraph (Fin n), K4Free G → maxTriangleFreeInduced G ≥ k) :
+    k ≤ erdosRogers n := by
+  refine le_csSup ⟨n, ?_⟩ h
+  rintro m hm
+  calc m ≤ maxTriangleFreeInduced (⊥ : SimpleGraph (Fin n)) := hm ⊥ (k4Free_bot n)
+    _ ≤ Fintype.card (Fin n) := maxTriangleFreeInduced_le_card _
+    _ = n := Fintype.card_fin n
+
+/-- Sanity: `f(n) ≤ n`. -/
+theorem erdosRogers_le_card (n : ℕ) : erdosRogers n ≤ n :=
+  ((erdosRogers_le (k4Free_bot n)).trans
+    (maxTriangleFreeInduced_le_card _)).trans_eq (Fintype.card_fin n)
+
+/-- Nontriviality at the other end: every K₄-free graph on `n ≥ 1` vertices
+contains a nonempty triangle-free induced subgraph (a single vertex), so the
+corrected `f(n) ≥ 1` — in particular `erdosRogers` is NOT identically zero,
+as the degenerate `sInf` version was. -/
+theorem one_le_erdosRogers {n : ℕ} (hn : 1 ≤ n) : 1 ≤ erdosRogers n := by
+  apply le_erdosRogers
+  intro G _
+  have hsingle : InducedTriangleFree G ({⟨0, hn⟩} : Finset (Fin n)) := by
+    rintro ⟨⟨x, hx⟩, ⟨y, hy⟩, ⟨z, hz⟩, hxy, hyz, hxz, -⟩
+    simp only [Finset.mem_singleton] at hx hy hz
+    exact hxy (by simp [hx, hy])
+  calc 1 = ({⟨0, hn⟩} : Finset (Fin n)).card := (Finset.card_singleton _).symm
+    _ ≤ maxTriangleFreeInduced G := le_maxTriangleFreeInduced hsingle
+
+end Erdos620

--- a/src/data/proofs/erdos-620/meta.json
+++ b/src/data/proofs/erdos-620/meta.json
@@ -187,6 +187,12 @@
       "endLine": 281,
       "summary": "Formalizes the problem's openness as non-existence of a pure power-law $f(n) \\asymp n^\\alpha$. The theorem `erdos_620_unsolved` (sorry'd) encodes that no single exponent captures the logarithmic correction.",
       "mathContext": "Formalizes the problem's openness as non-existence of a pure power-law $f(n) \\asymp n^\\alpha$. The theorem `erdos_620_unsolved` (sorry'd) encodes that no single exponent captures the logarithmic correction."
+    },
+    {
+      "title": "Repair: Well-Definedness of f(n)",
+      "startLine": 284,
+      "endLine": 383,
+      "summary": "Repair note and certification lemmas for the corrected sSup definitions of erdosRogers and generalizedErdosRogers. The original sInf guarantee-set definitions were identically 0 (0 always belongs to the set), which made the shearer_lower_bound axiom a false statement. Lemmas certify min-over-graphs behaviour (erdosRogers_le), the guarantee direction (le_erdosRogers), the trivial bounds 1 <= f(n) <= n, and boundedness of maxTriangleFreeInduced."
     }
   ],
   "conclusion": {
@@ -241,9 +247,9 @@
       "Finset"
     ],
     "namespace": "Erdos620",
-    "lineCount": 284,
+    "lineCount": 383,
     "axiomCount": 2,
-    "theoremCount": 8,
+    "theoremCount": 17,
     "definitionCount": 15,
     "path": "Proofs/Erdos620Problem.lean",
     "sorries": 4,

--- a/src/data/research/problems/erdos-620-incomplete-01.json
+++ b/src/data/research/problems/erdos-620-incomplete-01.json
@@ -16,22 +16,29 @@
     "goal": "Eliminate the 4 remaining sorry statement(s) in the parent formalization."
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-07-09T00:00:00.000Z",
-    "iteration": 0,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 1,
+    "focus": "Repaired degenerate erdosRogers/generalizedErdosRogers definitions (sInf -> sSup) that made the shearer_lower_bound axiom false; certified corrected defs with 9 axiom-free lemmas.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Remaining sorries: sparse_case (TRUE, needs Caro-Wei-style n/3 independent-set induction, ~1 session, delicate edge accounting); original_is_f43 (def-bridge via K4Free <-> CliqueFree 4 and TriangleFree <-> CliqueFree 3, now meaningful after sSup fix); erdos_rogers_ramsey_connection (check ramsey3k def shape first); erdos_620_unsolved asserts the problem is open as a theorem - UNPROVABLE placeholder, should be removed or reframed as a def, not proved.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "AVAILABLE: parent formalization has 4 open sorry statement(s) to complete.",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "INTEGRITY REPAIR (2026-07-24, researcher-1): erdosRogers and generalizedErdosRogers were sInf of guarantee sets {k | forall G, ... >= k}; 0 always belongs, so both were identically 0, making axiom shearer_lower_bound FALSE (0 >= positive at n=16) and the axiom set inconsistent. Fixed to sSup (guarantee set is downward closed; sSup = largest guaranteed k). Added 9 axiom-free certification lemmas (Part XII): erdosRogers_le (min-over-graphs), le_erdosRogers (guarantee direction), 1 <= f(n) <= n, maxTriangleFreeInduced bounds. Host-verified lake env lean EXIT=0; companion Erdos620ProblemAristotle unaffected.",
+    "builtItems": [
+      "Part XII in Erdos620Problem.lean: inducedTriangleFree_empty, bddAbove_triangleFreeInduced_sizes, le_maxTriangleFreeInduced, maxTriangleFreeInduced_le_card, k4Free_bot, erdosRogers_le, le_erdosRogers, erdosRogers_le_card, one_le_erdosRogers",
+      "Fixed defs: erdosRogers (sInf->sSup), generalizedErdosRogers (sInf->sSup)"
+    ],
+    "insights": [
+      "The sInf-of-guarantee-set idiom is a degeneracy trap: {k | forall G, P G -> f G >= k} always contains 0, so sInf = 0. The intended min-max value is sSup of that (downward-closed) set. Scan other Problem files for this pattern.",
+      "erdos_620_unsolved (sorry) asserts openness of the problem as a Lean theorem - a category error; it is not provable and should be converted to a def or removed.",
+      "sparse_case (edges <= n implies independent set >= n/3) is TRUE (Caro-Wei / min-degree <= 2 greedy) but the discrete induction edge-accounting is delicate; est. 1 dedicated session."
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },


### PR DESCRIPTION
## Summary
Integrity repair for `Erdos620Problem.lean` (Erdős–Rogers problem): the `erdosRogers` definition was degenerate in a way that made the `shearer_lower_bound` **axiom false**, i.e. the file's axiom set was inconsistent.

## The bug
`erdosRogers n` (and `generalizedErdosRogers s t n`) were defined as `sInf {k | ∀ G, K4Free G → maxTriangleFreeInduced G ≥ k}`. Since `k = 0` always belongs to that set, `sInf` = 0 — both functions were identically zero. The axiom `shearer_lower_bound` then asserted `(0 : ℝ) ≥ c·√n·√(log n)/log(log n)` with a strictly positive right-hand side at `n = 16` (`c > 0`, `√16 = 4`, `log 16 > 1` so `log(log 16) > 0`) — a false statement, from which `False` is derivable inside Lean.

## The fix
- `sInf → sSup` in both definitions (the guarantee set is downward closed, so its `sSup` is the intended "largest uniformly guaranteed k" — matching the file's own prose and the existing `ann-620-function` gallery annotation).
- Part XII appended at EOF (annotation-safe, zero existing-line shifts): 9 axiom-free certification lemmas — `erdosRogers_le` (min-over-graphs behaviour), `le_erdosRogers` (guarantee direction), `one_le_erdosRogers` / `erdosRogers_le_card` (`1 ≤ f(n) ≤ n`, so the corrected f is provably NOT identically 0/degenerate), plus `maxTriangleFreeInduced` witness & upper bounds.
- meta.json: lineCount 284→383, theoremCount 8→17, one new section entry. sorries (4) and axiomCount (2) unchanged.

## Verification
- `lake env lean Proofs/Erdos620Problem.lean` EXIT=0 (v4.31), no new warnings from added code.
- Companion `Erdos620ProblemAristotle.lean` re-checked against the rebuilt olean — unaffected (it only proves `turan_is_K4Free`).

## Status
**Outcome**: progress (integrity repair + 9 lemmas)
**Next Steps**: `sparse_case` sorry is TRUE and provable (Caro–Wei-style n/3 induction, ~1 session); `original_is_f43` is now a meaningful def-bridge; `erdos_620_unsolved` asserts openness as a theorem — unprovable placeholder that should be reframed. Also worth scanning other Problem files for the same `sInf`-of-guarantee-set degeneracy pattern.

🤖 Generated by researcher-1
