### PR TITLE
Enrich abundant-number-oq-03-oq-01-oq-03: add header section, quality 98->100

### DIFF
--- a/src/data/proofs/abundant-number-oq-03-oq-01-oq-03/meta.json
+++ b/src/data/proofs/abundant-number-oq-03-oq-01-oq-03/meta.json
@@ -56,6 +56,14 @@
  },
  "sections": [
   {
+   "id": "header",
+   "title": "File Docstring: The Two-Seed Sharpening",
+   "startLine": 1,
+   "endLine": 59,
+   "summary": "Docstring explaining the improvement: a single seed (945) cannot beat spacing 1890, so a second odd abundant seed 1575 is added; the union of the two odd-multiple families occupies 7 residues per length-9450 window (5 + 3 − 1 after removing the lcm-4725 overlap), giving density ≥ 7/9450 = 1/1350. Imports the parent AbundantOddDensityOQ0301 and the seed/closure lemmas from AbundantNumberOQ02 and AbundantMultiplesOQ01; opens the namespace and sets Classical.propDecidable as a local instance to match the parent's Finset.filter decidability.",
+   "mathContext": "7/9450 = 1/1350 > 1/1890, from 5 odd multiples of 945 plus 3 of 1575 minus 1 shared odd multiple of lcm(945,1575) = 4725, per window of length 9450 = 2·lcm."
+  },
+  {
    "id": "second-seed",
    "title": "The Second Odd Abundant Seed",
    "startLine": 60,


### PR DESCRIPTION
## Summary
- Adds a `header` section (lines 1-59) covering the previously-uncovered file docstring, imports, namespace, and local `Classical.propDecidable` setup — the entry had only 4 sections spanning lines 60-187.
- Splits nothing else; existing 4 sections and all annotations are untouched.
- `find-targets.ts` quality score: 98 -> 100 (sections sub-score 8/10 -> 10/10).

## Test plan
- [x] `python3 -c "import json; json.load(...)"` — meta.json is valid JSON
- [x] `npx tsx scripts/enricher/find-targets.ts --json --all` confirms quality 100 for this entry
- [x] Verified no existing open PR targets this entry before creating

🤖 Generated with [Claude Code](https://claude.com/claude-code)