### PR TITLE
Update audit tracker: cauchy-schwarz-oq-03 (issues-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4991,10 +4991,10 @@
       "issues": []
     },
     "cauchy-schwarz-oq-03": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:46Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T03:41:23Z",
+      "result": "issues-fixed"
     },
     "cauchy-schwarz-oq-03-oq-01": {
       "auditCount": 6,


### PR DESCRIPTION
Tracker update following #42954, which fixed stale phantom-identifier prose in cauchy-schwarz-oq-03's meta.json/annotations.json.