### PR TITLE
Research: erdos-76 - fix degenerate minMaxPackingSize def (sInf -> sSup)

### DIFF
--- a/proofs/Proofs/Erdos76Problem.lean
+++ b/proofs/Proofs/Erdos76Problem.lean
@@ -102,9 +102,9 @@ For a given coloring, the maximum number of edge-disjoint monochromatic triangle
 noncomputable def maxPackingSize (c : EdgeColoring V) : ℕ :=
   sSup { k | ∃ ts : Finset (Triangle V), ts.card = k ∧ monochromaticPacking c ts }
 
-/-- The minimum over all colorings of the maximum packing size — the extremal quantity. -/
+/-- Min over colorings of max packing size (`sSup` of guarantee set; `sInf` would be `0`). -/
 noncomputable def minMaxPackingSize (n : ℕ) : ℕ :=
-  sInf { k | ∀ c : EdgeColoring (Fin n), maxPackingSize c ≥ k }
+  sSup { k | ∀ c : EdgeColoring (Fin n), maxPackingSize c ≥ k }
 
 /-
 ## The Extremal Construction: Balanced Bipartition Coloring

--- a/src/data/proofs/erdos-76/meta.json
+++ b/src/data/proofs/erdos-76/meta.json
@@ -61,7 +61,7 @@
       "EdgeColoring V as function assigning colors to edges",
       "Triangle structure with Finset V vertices and card = 3 proof",
       "edgeDisjoint, isPacking, monochromaticPacking definitions",
-      "maxPackingSize via sSup and minMaxPackingSize via sInf",
+      "maxPackingSize via sSup and minMaxPackingSize via sSup of the guarantee set (sInf would be degenerately 0)",
       "balancedColoring n with proved same_half_blue and diff_half_red",
       "gruslys_letzter axiom: lower bound (1 - 1/n) · n²/12",
       "extremal_uniqueness axiom: balanced coloring is essentially unique",


### PR DESCRIPTION
## Summary
Companion to #42952: the same `sInf`-of-guarantee-set degeneracy found by pattern scan. `minMaxPackingSize n` was `sInf { k | ∀ c, maxPackingSize c ≥ k }` — `0` always belongs, so the def was identically `0` instead of the intended min-over-colorings extremal quantity.

## Fix
One-word `sInf → sSup` (the guarantee set is downward closed; its `sSup` is the min-max). Line-neutral edit — all annotation anchors below line 105 preserved. `meta.json` keyConstruction wording synced.

Unlike erdos-620, **no axiom or theorem references this def yet** (the Gruslys–Letzter axioms constrain `maxPackingSize`, which was already correct) — latent landmine, not an active inconsistency, so zero breakage risk.

## Verification
`lake env lean Proofs/Erdos76Problem.lean` EXIT=0 (v4.31); only the pre-existing `packing_upper_bound` sorry warns.

## Status
**Outcome**: progress (integrity repair)
**Next Steps**: gallery-wide `sInf`-guarantee-set scan found no further instances (erdos-620 + erdos-76 were the only two matching the ∀-guarantee shape).

🤖 Generated by researcher-1