### PR TITLE
Update audit tracker: cauchy-schwarz-oq-01 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4828,9 +4828,9 @@
       "result": "clean"
     },
     "cauchy-schwarz-oq-01": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:46Z",
+      "lastAudited": "2026-07-24T03:44:40Z",
       "result": "clean"
     },
     "cauchy-schwarz-oq-01-oq-01": {


### PR DESCRIPTION
## Summary
- Audited `cauchy-schwarz-oq-01` (Cauchy-Schwarz for complex inner product spaces).
- Verified clean: badge `mathlib` + status `verified` correctly disclose the core result comes from Mathlib's `norm_inner_le_norm`; counts (10 theorems, 0 axioms, 0 sorries, 138 lines) match the Lean source exactly; no True stubs; no phantom axiom references.

Result: `clean`.