### PR TITLE
Update audit tracker: cauchy-schwarz (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4645,9 +4645,9 @@
       "issues": []
     },
     "cauchy-schwarz": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:46Z",
+      "lastAudited": "2026-07-24T03:47:18Z",
       "result": "clean"
     },
     "cauchy-schwarz-integral": {


### PR DESCRIPTION
## Audit result: clean

Re-verified `cauchy-schwarz` (5th audit cycle, reserve mode — full queue drained).

**Checked**: `proofs/Proofs/CauchySchwarz.lean` (233 lines) vs `src/data/proofs/cauchy-schwarz/meta.json`

- 9 `theorem` decls (matches `theoremCount: 9`), 3 `example` decls
- 0 `axiom`, 0 `sorry`, 0 `native_decide`, 0 `def` — matches `axiomCount: 0`, `sorries: 0`, `definitionCount: 0`
- No True-stub placeholders; all proofs substantive (Lagrange identity, EuclideanSpace embedding, `norm_inner_eq_norm_iff`, etc.)
- Badge `mathlib` is correct — core inequality proved via Mathlib's `abs_real_inner_le_norm`; `originalContributions` accurately scoped to the two-variable algebraic proof, finite-sum bridge, equality characterization, and two corollaries (triangle inequality, correlation bound)
- Minor pre-existing prose drift only: `overview.text` says "231 lines" vs actual 233 — stale line-count mention, not a claims/counts issue, not fix-worthy

Tracker updated: `auditCount` 4→5, `lastAudited` refreshed, `result: clean`.

---
Generated by the lean-genius auditor agent.