### PR TITLE
Enrich algebraic-numbers-countable-oq-02-oq-05: 5th keyInsight (98->100)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-05/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-05/meta.json
@@ -31,7 +31,8 @@
       "Countable syntax ⟹ countably many definitions — the single reason every layer of the nameability hierarchy (algebraic, computable, definable) is countable.",
       "Uniqueness makes the map injective: two reals defined by the same formula would each be its sole realiser, hence equal.",
       "Stated for an arbitrary countable language, the theorem subsumes 'algebraic reals are countable' (Tarski's quantifier elimination makes the ∅-definable reals of the ordered field ℝ exactly the real algebraic numbers).",
-      "The undefinable-uncountable corollary is the Skolem/Tarski punchline: a countable language names only ℵ₀ of the continuum-many reals."
+      "The undefinable-uncountable corollary is the Skolem/Tarski punchline: a countable language names only ℵ₀ of the continuum-many reals.",
+      "Robust to enrichment, not tied to a fixed signature: the theorem is stated for an arbitrary countable language L, so enriching L with extra function or relation symbols (exp, sin, an order relation, even an oracle predicate) leaves the conclusion untouched as long as the enlarged language stays countable — the countability bound depends only on the language being countable, never on which particular symbols it contains."
     ],
     "prerequisites": [
       "First-order model theory (FirstOrder.Language: terms, bounded formulas, the satisfaction relation Realize)",


### PR DESCRIPTION
Enrichment pass for `algebraic-numbers-countable-oq-02-oq-05` (quality 98 -> 100).

Adds a genuinely new key insight, distinct from the existing 4: the theorem's countability bound depends only on the language `L` being countable, not on its particular signature — so enriching `L` with extra function/relation symbols (`exp`, `sin`, an oracle predicate) preserves the conclusion as long as the enlarged language stays countable. Verified against the Lean file's polymorphic `[Countable (Sigma l, L.Functions l)] [Countable (Sigma l, L.Relations l)]` hypotheses (`AlgebraicNumbersCountableOQ02OQ05.lean:92`).

No content deleted; existing keyInsights, sections, annotations, and cross-references untouched. `meta.json` stays well under the 60 KB cap (~20 KB).