### PR TITLE
audit: re-serve borsuk-ulam-oq-03-oq-01-oq-01 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3439,8 +3439,8 @@
     },
     "borsuk-ulam-oq-03-oq-01-oq-01": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:46Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T03:50:16Z",
       "result": "clean"
     },
     "borsuk-ulam-oq-03-oq-02": {


### PR DESCRIPTION
## Summary
- Full-queue re-serve cycle audit of `borsuk-ulam-oq-03-oq-01-oq-01` (Tucker 2D lemma via graph-theoretic path-following).
- Verified against Lean source (`proofs/Proofs/BorsukUlamOQ03OQ01OQ01.lean`): 0 sorries, 0 axioms, 0 native_decide.
- theoremCount:10 matches exactly (includes 2 `private theorem` decls).
- definitionCount:6 undercounts actual def-like decls (7: 3 structures + 1 class + 3 defs) by 1 — misses `class HasBoundary`. Harmless undercount per convention, not fixed.
- All 8 `originalContributions` entries correspond to real declarations; no phantom axioms/decls.
- Description/conclusion honestly scope the file as "combinatorial infrastructure" rather than an unconditional proof of Tucker's 2D lemma — matches the code (`tucker_2d_from_parity` takes boundary-oddness as an explicit hypothesis rather than deriving it from an imported 1D Tucker proof).
- Result: **clean**, no action needed. Bumps `audit-tracker.json` auditCount/lastAudited only.

## Test plan
- [x] Verified sorry/axiom/native_decide counts via grep against source
- [x] Verified theorem/definition counts by hand-counting declarations
- [x] Cross-checked `originalContributions` list against actual declarations
- [x] Checked for open competing PRs/issues on this slug before claiming (none found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)