### PR TITLE
Enrich amgm-inequality-oq-03-oq-03-oq-02: split sections to 5 (98->100)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-03-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-03-oq-02/meta.json
@@ -43,11 +43,20 @@
   },
   "sections": [
     {
-      "id": "preamble",
-      "title": "Module Header and Power Mean Definition",
+      "id": "header",
+      "title": "Module Header: Scoping the Finite-Monotonicity Gap",
       "startLine": 1,
+      "endLine": 28,
+      "summary": "Docstring framing the entry as the finite-monotonicity gap between the parent's endpoint identities (M₁ = AM, M₋₁ = HM) and the sibling's r → ±∞ limits, and outlining the three-part proof plan.",
+      "mathContext": "The chain M₋₁(a,b) ≤ M₀(a,b) ≤ M₁(a,b), i.e. HM ≤ GM ≤ AM, as the n=2 instance of power-mean monotonicity."
+    },
+    {
+      "id": "powermean-def",
+      "title": "The Power Mean Definition",
+      "startLine": 30,
       "endLine": 43,
-      "summary": "Docstring framing the entry as the finite-monotonicity gap between the parent's endpoint identities and the sibling's r → ±∞ limits. Re-declares `powerMean` (same definition as the parent) with the r = 0 geometric-mean branch."
+      "summary": "Re-declares `powerMean` (identical to the parent entry's definition): the r-th power mean of a finite indexed family of positive reals, with the r = 0 case set by convention to the geometric mean ∏xᵢ^(1/card).",
+      "mathContext": "powerMean x r = (∏ᵢ xᵢ)^(1/card) if r = 0, else ((∑ᵢ xᵢʳ)/card)^(1/r)."
     },
     {
       "id": "endpoint-evaluations",


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-03-oq-03-oq-02` (quality 98 -> 100).

This entry's keyInsights were already at the 5-item cap; the deficient bucket was `sections` (4 items, 8/10). Splits the "Module Header and Power Mean Definition" section (lines 1-43) into two: the module docstring (1-28) and the `powerMean` re-declaration (30-43) as its own section -- a natural boundary already implicit in the code's blank-line separation between the comment block and the def.

No content deleted; existing keyInsights, annotations, and cross-references untouched. `meta.json` stays well under the 60 KB cap (~12 KB).