### PR TITLE
Enrich angle-trisection-oq-02-oq-03-ext-oq-01: add missing header section (98->100)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-03-ext-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03-ext-oq-01/meta.json
@@ -57,6 +57,14 @@
   },
   "sections": [
     {
+      "id": "header-definition",
+      "title": "Header, Imports, and the TotientIsPow2 Definition",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring framing the file as the missing prime-2 case of the parent's coprime multiplicativity, stating the doubling and 2-power invariances and previewing the 7-gon/15-gon consequences. Imports Mathlib, opens the AngleTrisectionOQ02OQ03ExtOQ01 namespace, and re-declares TotientIsPow2 n := ∃ k, φ(n) = 2^k (matching the parent file's predicate).",
+      "mathContext": "TotientIsPow2 n is the Gauss–Wantzel constructibility predicate; this file determines its behavior under multiplication by the prime 2."
+    },
+    {
       "id": "single-step",
       "title": "Section I: The two single-step totient identities for p = 2",
       "startLine": 47,


### PR DESCRIPTION
Enrichment pass for `angle-trisection-oq-02-oq-03-ext-oq-01` (quality 98 -> 100).

Lines 1-46 (module docstring, imports, namespace, and the `TotientIsPow2` definition) had no section coverage at all -- the existing 4 sections started at line 47. Adds a 5th section closing this genuine gap.

No content deleted; existing keyInsights (already 5), annotations, and cross-references untouched. `meta.json` stays well under the 60 KB cap (~15.3 KB).