### PR TITLE
Update audit tracker: borsuk-ulam-oq-03 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3426,9 +3426,9 @@
       "result": "clean"
     },
     "borsuk-ulam-oq-03": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:46Z",
+      "lastAudited": "2026-07-24T04:00:42Z",
       "result": "clean"
     },
     "borsuk-ulam-oq-03-oq-01": {


### PR DESCRIPTION
## Audit result: clean

Re-served re-audit of `borsuk-ulam-oq-03`. Verified against the Lean source:

- `axiomCount: 1` matches — exactly one `axiom` declaration (`borsuk_ulam_general`, line 295); all other prose/comments narrating "4 axioms declared" are historical/reduction-chain commentary, correctly clarified inline as "(1 independent)" with the other 3 now proved as theorems.
- `sorries: 0` matches — no `sorry` in the file.
- `native_decide` usage (`tverberg_6_fails`, line 5061) is already disclosed in `assumptions` ("uses native_decide (Lean.ofReduceBool)... not the headline result").
- All 18 `mainTheorems` entries verified against actual declarations — `borsuk_ulam_general` correctly typed `axiom`; the other 17 all confirmed as `theorem` declarations at their stated names.
- `status: "axiomatized"` / `badge: "axiom"` correctly reflect Tier C classification.
- No True-stub theorems found.
- `annotations.json` axiom-reduction narrative is consistent with current file state.

No integrity issues found.