### PR TITLE
audit(borsuk-ulam-oq-02-oq-01): fix phantom open-conjecture axiom claim

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3348,10 +3348,10 @@
       "result": "clean"
     },
     "borsuk-ulam-oq-02-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:46Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T04:04:11Z",
+      "result": "issues-fixed"
     },
     "borsuk-ulam-oq-02-oq-01-oq-01": {
       "auditCount": 3,

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01/meta.json
@@ -18,7 +18,7 @@
     "sorries": 0,
     "axiomCount": 4,
     "lineCount": 144,
-    "assumptions": "buDim function, classical BU (Z/2), Yang-Borsuk (Z/p prime), monotonicity, open conjecture for composite groups.",
+    "assumptions": "buDim function, classical BU (Z/2), Yang-Borsuk (Z/p prime), monotonicity (4 axioms total). The open conjecture for composite groups is discussed in prose comments only — not axiomatized or otherwise formalized.",
     "originalContributions": [
       "Abstract buDim framework for cyclic group BU dimensions",
       "Proved z4_lower_bound: buDim(4, n+1) ≥ n from Z/2 subgroup",
@@ -67,7 +67,7 @@
       "title": "The Open Question",
       "startLine": 123,
       "endLine": 144,
-      "summary": "States the central open question: does buDim(n, d) always equal the maximum over prime factor bounds? Formulates this as an axiom using Nat.primeFactors.",
+      "summary": "States the central open question in prose comments: does buDim(n, d) always equal the maximum over prime factor bounds? Not formalized as a Lean axiom, definition, or any other declaration — no Nat.primeFactors usage appears in the file.",
       "mathContext": "If true, composite group structure adds no extra topological obstruction beyond what prime subgroups provide. The resolution requires Fadell-Husseini index theory and representation-theoretic analysis."
     }
   ],
@@ -91,7 +91,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Abstract BU dimension framework for composite cyclic groups. 6 theorems proved, 6 axioms (5 known results + 1 open conjecture). Key result: all composite BU dimensions are bounded below by prime factor bounds.",
+    "summary": "Abstract BU dimension framework for composite cyclic groups. 6 theorems proved from 4 axioms (the buDim function plus 3 known results: classical BU, Yang-Borsuk, monotonicity). The open conjecture for composite groups is stated in prose comments only, not axiomatized. Key result: all composite BU dimensions are bounded below by prime factor bounds.",
     "implications": "The framework provides a clean algebraic setting for studying the equivariant BU problem without topological infrastructure. The open conjecture, if true, would show that composite group structure adds no extra topological obstruction.",
     "openQuestions": [
       "Is buDim(n, d) = max_{p|n} buDim(p, d) for all composite n?",


### PR DESCRIPTION
## Integrity Issue

**Proof**: borsuk-ulam-oq-02-oq-01
**Problem**: Prose overstates axiom content — claims the open conjecture is axiomatized when it is comment-only.

## Evidence

**meta.json claimed**:
- `conclusion.summary`: "6 theorems proved, 6 axioms (5 known results + 1 open conjecture)."
- `sections[open-question].summary`: "...Formulates this as an axiom using Nat.primeFactors."
- `meta.assumptions`: listed "open conjecture for composite groups" alongside real axioms.

**Lean file shows** (`proofs/Proofs/BorsukUlamOQ02OQ01.lean`):
- Exactly 4 `axiom` declarations: `buDim`, `buDim_two`, `buDim_prime`, `buDim_mono`.
- Part IV ("The Open Question", lines 122-142) is pure `/- ... -/` comment
  text — no axiom, no `Nat.primeFactors` usage anywhere in the file, no Lean
  declaration of any kind for the conjecture.
- The structured `axiomCount: 4` field (both `meta.axiomCount` and
  `leanFile.axiomCount`) was already correct — only the free-text narrative
  overclaimed the axiom count and fabricated a formalization of the open
  conjecture that doesn't exist.

## Fix

Corrected `conclusion.summary`, the `open-question` section summary, and
`meta.assumptions` to accurately state: 4 axioms total, and the open
conjecture is discussed in prose comments only, not formalized as an axiom
or any other Lean declaration.

---
Discovered during gallery integrity audit.