### PR TITLE
Enrich simson-line-theorem-oq-01-oq-01: add missing header section (98->100)

### DIFF
--- a/src/data/proofs/simson-line-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/simson-line-theorem-oq-01-oq-01/meta.json
@@ -67,6 +67,15 @@
   ],
   "sections": [
     {
+      "title": "Module Header: the Angle-Doubling Theorem",
+      "startLine": 1,
+      "endLine": 57,
+      "description": "Imports the parent SimsonLineTheorem. Module docstring: states the sharp generalisation — as P traverses the circumcircle its Simson line rotates at half P's angular speed, with the parent's antipodal-perpendicularity fact as the Q = -P special case (half-arc 90°). Explains why squaring the direction D p = (c-a)(p-b)/(2p) is the right invariant (it lifts the angle from ℝ/πℤ to ℝ/2πℤ and cancels the triangle-dependent factor), previews the exact closed-form master identity, and records the axiom status (0 axioms, 0 sorries). Opens the SimsonLineTheoremOQ01OQ01 namespace, Complex/ComplexConjugate, and imports foot/foot_diff from the parent.",
+      "summary": "Module Header: the Angle-Doubling Theorem",
+      "id": "header",
+      "mathContext": "Simson line direction $D_p = (c-a)(p-b)/(2p)$ on the unit circumcircle; squaring lifts the angle from $\\mathbb{R}/\\pi\\mathbb{Z}$ to $\\mathbb{R}/2\\pi\\mathbb{Z}$, cancelling the triangle-dependent factor and exposing the half-angle rotation."
+    },
+    {
       "title": "Unit-Circle Algebra",
       "startLine": 59,
       "endLine": 83,


### PR DESCRIPTION
Enrichment pass for `simson-line-theorem-oq-01-oq-01`.

**Gap identified:** `sections` covered only lines 59-193 — the entire module header/docstring (lines 1-57, the statement of the angle-doubling theorem and the squaring-invariant motivation) was uncovered, and the section count (4) capped the sections-count quality-scorer component at 8/10.

**Fix:** added a `header` section covering lines 1-57 (imports, module docstring stating the sharp generalisation, the squaring-invariant explanation, and the axiom status), inserted before the existing `unit-circle-algebra` section. No existing content was changed.

Quality score: 98 -> 100 (verified via `npx tsx scripts/enricher/find-targets.ts --all`).