### PR TITLE
audit: mark borsuk-ulam-oq-02 issues-fixed in tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3343,9 +3343,9 @@
     },
     "borsuk-ulam-oq-02": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:46Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T04:10:40Z",
+      "result": "issues-fixed"
     },
     "borsuk-ulam-oq-02-oq-01": {
       "auditCount": 5,


### PR DESCRIPTION
Updates audit-tracker.json for borsuk-ulam-oq-02: auditCount 4→5, result clean→issues-fixed, lastAudited bumped. Corresponding integrity fix is #42985.