### PR TITLE
Enrich combinations-formula-oq-05-oq-01-oq-01: 5th keyInsight (98->100)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-05-oq-01-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-05-oq-01-oq-01/meta.json
@@ -50,7 +50,8 @@
       "Two classical one-step mechanisms compose exactly: absorption k C(n,k) = n C(n-1,k-1) turns the weighted row-n sum into n times an unweighted row-(n-1) sum, and the parent's telescoping then collapses that to a single binomial of row n-2.",
       "Stated with C(n+2,k) and cut-off j+1 the identity needs no natural-number subtraction and holds for all n, making the induction clean; the literal n (-1)^j C(n-2,j-1) form is a one-line specialisation for n ≥ 2.",
       "linear_combination is the right finisher for the inductive step: rather than rewriting under the (-1)^{j+2} factor (which fails on associativity), the absorption and Pascal equalities are supplied as linear hypotheses and ring handles the signed-power algebra.",
-      "The grandparent's full weighted-row vanishing is not assumed but derived: at j = n the coefficient C(n-2,n-1) = 0, so this entry is strictly stronger than the CombinationsFormulaOQ05 anchor."
+      "The grandparent's full weighted-row vanishing is not assumed but derived: at j = n the coefficient C(n-2,n-1) = 0, so this entry is strictly stronger than the CombinationsFormulaOQ05 anchor.",
+      "A generating-function view explains the n ≥ 2 hypothesis: differentiating ∑_k C(n,k)(-1)^k x^k = (1-x)^n gives ∑_k C(n,k)(-1)^k k x^{k-1} = -n(1-x)^{n-1}, so the full-row weighted sum (the j = n endpoint) is this derivative evaluated at x = 1 — it vanishes exactly when n ≥ 2, i.e. when (1-x)^{n-1} still has a root at x = 1, matching the hypothesis this entry (and its grandparent) carries."
     ]
   },
   "sections": [


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-05-oq-01-oq-01`.

**Gap identified:** `overview.keyInsights` had only 4 items, capping the keyInsights quality-scorer component at 8/10 (need 5 for the max 10/10). All other quality dimensions were already at max, giving a total of 98/100.

**Fix:** added a 5th key insight giving a generating-function explanation for the file's `n ≥ 2` hypothesis: differentiating ∑ C(n,k)(-1)^k x^k = (1-x)^n gives ∑ C(n,k)(-1)^k k x^{k-1} = -n(1-x)^{n-1}, so the full-row weighted sum (the j = n endpoint of this entry's identity, i.e. the grandparent's vanishing result) is this derivative at x = 1, which vanishes exactly when n ≥ 2. This connects the combinatorial telescoping proof already in the file to a calculus/generating-function viewpoint and explains why the hypothesis is exactly n ≥ 2.

Quality score: 98 -> 100 (verified via `npx tsx scripts/enricher/find-targets.ts --all`).