### PR TITLE
Enrich nesbitt-inequality-oq-01: 5th keyInsight (98->100)

### DIFF
--- a/src/data/proofs/nesbitt-inequality-oq-01/meta.json
+++ b/src/data/proofs/nesbitt-inequality-oq-01/meta.json
@@ -62,7 +62,8 @@
       "The SOS identity converts a fractional cyclic inequality into manifestly nonnegative data: a sum of squares divided by positive denominators",
       "The same identity that proves the bound also pins down the equality case — no separate optimisation argument is needed",
       "field_simp + ring is a complete decision procedure for the rational-function identity once the denominators are known nonzero; the only analytic input is the positivity of a, b, c",
-      "Reading off (a−b)² = 0 and (b−c)² = 0 from the vanishing defect gives the full equality characterisation a = b = c with no loss"
+      "Reading off (a−b)² = 0 and (b−c)² = 0 from the vanishing defect gives the full equality characterisation a = b = c with no loss",
+      "A Cauchy–Schwarz alternative reaches the same bound: writing Σ a/(b+c) = Σ a²/(a(b+c)) and applying the Engel-form (Titu's lemma) Cauchy–Schwarz inequality gives Σ a²/(a(b+c)) ≥ (a+b+c)²/(2(ab+bc+ca)), which combined with the elementary (a+b+c)² ≥ 3(ab+bc+ca) (itself a Σ(a−b)² ≥ 0 fact) also yields 3/2. The SOS route formalized here is more direct in Lean — one field_simp; ring closes the whole identity — whereas Cauchy–Schwarz would need an extra inequality lemma layered on top."
     ],
     "prerequisites": [
       "Ordered fields and the arithmetic of real fractions",


### PR DESCRIPTION
Enrichment pass for `nesbitt-inequality-oq-01`.

**Gap identified:** `overview.keyInsights` had only 4 items, capping the keyInsights quality-scorer component at 8/10 (need 5 for the max 10/10). All other quality dimensions were already at max, giving a total of 98/100.

**Fix:** added a 5th key insight contrasting the file's SOS proof with the classical Cauchy–Schwarz (Engel form / Titu's lemma) alternative proof of Nesbitt's inequality, and explaining why the SOS route is more direct to formalize in Lean (a single `field_simp; ring` closes the whole identity).

Quality score: 98 -> 100 (verified via `npx tsx scripts/enricher/find-targets.ts --all`).