### PR TITLE
Enrich product-of-segments-of-chords-oq-04: split radical-center section, close sections-count gap (98->100)

### DIFF
--- a/src/data/proofs/product-of-segments-of-chords-oq-04/meta.json
+++ b/src/data/proofs/product-of-segments-of-chords-oq-04/meta.json
@@ -74,11 +74,18 @@
       "summary": "Vec2 = EuclideanSpace ℝ (Fin 2). normSq_coord and power_coord give the coordinate expansion of the power function; equal_power_linear is the coordinate form of the radical-axis equation, proved by linear_combination."
     },
     {
-      "id": "radical-center",
-      "title": "Part 2b: Existence and Uniqueness of the Radical Center",
+      "id": "radical-center-uniqueness",
+      "title": "Part 2b: Uniqueness of the Radical Center",
       "startLine": 139,
+      "endLine": 178,
+      "summary": "radical_center_unique: two points of equal power to three circles with non-collinear centers coincide, via determinant elimination (linear_combination) against the nonzero centre determinant."
+    },
+    {
+      "id": "radical-center-existence",
+      "title": "Part 2c: Existence and Packaged Uniqueness of the Radical Center",
+      "startLine": 179,
       "endLine": 218,
-      "summary": "radical_center_unique: two points of equal power to three circles with non-collinear centers coincide, via determinant elimination (linear_combination) against the nonzero centre determinant. radical_center_exists: explicit Cramer-rule construction of the radical center using the !₂[...] constructor, verified by clearing denominators with div_eq_iff and ring. radical_center_existsUnique packages both into ∃!."
+      "summary": "radical_center_exists: explicit Cramer-rule construction of the radical center using the !₂[...] constructor, verified by clearing denominators with div_eq_iff and ring. radical_center_existsUnique packages existence and uniqueness into a single ∃!."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `product-of-segments-of-chords-oq-04`.

**Gap identified:** `sections` had only 4 entries, capping the sections-count quality-scorer component at 8/10 (need ≥5 for the max 10/10). All other quality dimensions were already at max, giving a total of 98/100.

**Fix:** split the `radical-center` section (lines 139-218, 80 lines) into two sections at the real Lean-construct boundary (line 179, the docstring of `radical_center_exists`):
- `radical-center-uniqueness` (139-178): `radical_center_unique`
- `radical-center-existence` (179-218): `radical_center_exists` and `radical_center_existsUnique`

No content was removed; the other three sections (`header`, `power-quadratic`, `coordinate-form`) are unchanged.

Quality score: 98 -> 100 (verified via `npx tsx scripts/enricher/find-targets.ts --all`).