### PR TITLE
audit: mark borsuk-ulam issues-found in tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3336,10 +3336,10 @@
       "result": "clean"
     },
     "borsuk-ulam": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:46Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T04:17:28Z",
+      "result": "issues-found"
     },
     "borsuk-ulam-oq-02": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Marks `borsuk-ulam` as `issues-found` in the audit tracker after filing #42992 (kernel-inconsistent `tuckers_lemma` axiom in the `BorsukUlamOQ01.lean` companion file).

Discovered during routine gallery integrity audit.