### PR TITLE
audit(tracker): area-of-circle-oq-03 re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1354,9 +1354,9 @@
       "result": "clean"
     },
     "area-of-circle-oq-03": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:46Z",
+      "lastAudited": "2026-07-24T04:20:41Z",
       "result": "clean"
     },
     "area-of-circle-oq-03-oq-01": {


### PR DESCRIPTION
## Integrity Audit

**Proof**: area-of-circle-oq-03 (Archimedes' Method of Exhaustion: Area of a Circle)

Re-serve audit of a previously-audited, currently uncontested target. Full verification against `proofs/Proofs/ArchimedesMethodOfExhaustion.lean`:

- theoremCount: 17 claimed, 17 found (matches `meta` and `leanFile` blocks)
- definitionCount: 2 claimed, 2 found (`inscribedArea`, `circumscribedArea`)
- axiomCount: 0 claimed, 0 found (only comment mentions "0 axioms")
- sorries: 0 claimed, 0 found
- lineCount: 369 claimed, 369 found
- No True-stub theorems, no `native_decide`
- All 5 `crossReferences` target ids resolve to existing gallery entries
- Proofs are substantive (derivative-based limit arguments, sandwich inequality, uniqueness), not vacuous

Status `verified` / badge `original` are justified — Mathlib is used only for standard building blocks (`HasDerivAt` for sin/tan), not the core theorem itself.

Result: **clean**. Only the tracker (`audit-tracker.json`) is updated.