### PR TITLE
Fix: remove kernel-inconsistent axiom tuckers_lemma in borsuk-ulam

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ01.lean
+++ b/proofs/Proofs/BorsukUlamOQ01.lean
@@ -128,21 +128,25 @@ def SignedLabeling (V : Type*) (n : ℕ) := V → Fin n × Bool
 def IsComplementaryEdge {V : Type*} {n : ℕ} (L : SignedLabeling V n) (u v : V) : Prop :=
   ∃ k : Fin n, (L u = (k, true) ∧ L v = (k, false)) ∨ (L u = (k, false) ∧ L v = (k, true))
 
-/-- Tucker's lemma: any antipodal labeling of a triangulated ball has a
-    complementary edge. This is the combinatorial foundation of the
-    PPAD-completeness result.
+/- **Tucker's lemma (not axiomatized here).** Tucker's lemma states that any
+   antipodal labeling of a triangulated ball has a complementary edge — the
+   combinatorial foundation of the PPAD-completeness result.
 
-    We state this for a finite simplicial complex with an antipodal
-    labeling on the boundary. -/
-axiom tuckers_lemma (n : ℕ) (hn : n ≥ 1)
-    (V : Type) [Fintype V] [DecidableEq V]
-    (edges : Set (V × V))
-    (boundary : Set V)
-    (antipodal_map : V → V)
-    (L : SignedLabeling V n)
-    -- Antipodal condition on boundary
-    (h_antipodal : ∀ v ∈ boundary, L (antipodal_map v) = (⟨(L v).1, !(L v).2⟩)) :
-    ∃ u v, (u, v) ∈ edges ∧ IsComplementaryEdge L u v
+   We deliberately do NOT axiomatize the general statement. A naive axiom of
+   the form "for any finite `V`, edge set, boundary and antipodal map, an
+   antipodal boundary labeling forces a complementary edge" is *false*, hence
+   kernel-inconsistent: instantiating with `V := Empty`, `edges := ∅`,
+   `boundary := ∅` makes the antipodal hypothesis vacuously true while the
+   conclusion `∃ u v, ...` is unsatisfiable, so `False` becomes derivable. The
+   real hypothesis — that `(V, edges)` is the 1-skeleton of an antipodally
+   symmetric triangulation of a ball, with `antipodal_map` an involution and a
+   genuine boundary condition — requires simplicial-complex infrastructure not
+   yet available in Mathlib.
+
+   The bare lemma is not invoked by any theorem in this file (only
+   `borsuk_ulam_exact` is used, to derive the approximate version), so no result
+   here depends on it; we record the statement here as documentation rather than
+   as an unsound axiom. -/
 
 -- ============================================================
 -- PART 6: PPAD Complexity Class
@@ -321,7 +325,7 @@ The PPAD-completeness means:
 2. But no polynomial-time algorithm exists (unless PPAD ⊆ P)
 3. The problem sits strictly between P and NP-hard
 
-Axioms: 3 (borsuk_ulam_exact, tuckers_lemma, ppad_solution_exists)
+Axioms: 1 (borsuk_ulam_exact)
 Sorries: 0
 -/
 

--- a/src/data/proofs/borsuk-ulam/meta.json
+++ b/src/data/proofs/borsuk-ulam/meta.json
@@ -41,7 +41,7 @@
     ],
     "dateAdded": "2025-12-22",
     "lineCount": 267,
-    "axiomCount": 3,
+    "axiomCount": 2,
     "additionalFiles": [
       "Proofs/BorsukUlamOQ01.lean"
     ],
@@ -54,8 +54,7 @@
     ],
     "assumptions": [
       "no_continuous_odd_nonzero_on_sphere (BorsukUlam.lean): For n ≥ 1, there is no continuous odd function h: ℝ^(n+1) → ℝ^n that is nonzero on the n-sphere. This requires covering space theory and fundamental groups beyond Mathlib's current algebraic topology coverage.",
-      "borsuk_ulam_exact (BorsukUlamOQ01.lean): The original existence statement of an antipodal point f(x) = f(-x) for any continuous f: Sⁿ → ℝⁿ — axiomatized to bridge to OQ01 sharpness questions.",
-      "tuckers_lemma (BorsukUlamOQ01.lean): Tucker's combinatorial lemma on antipodally-labelled triangulations, used in OQ01 to study sharpness of antipodal collapse maps."
+      "borsuk_ulam_exact (BorsukUlamOQ01.lean): The original existence statement of an antipodal point f(x) = f(-x) for any continuous f: Sⁿ → ℝⁿ — axiomatized to bridge to OQ01 sharpness questions."
     ],
     "relatedProblems": [
       {
@@ -288,9 +287,9 @@
         "lineCount": 328,
         "theorems": 17,
         "definitions": 10,
-        "axioms": 2,
+        "axioms": 1,
         "sorries": 0,
-        "description": "OQ-01: Approximate Borsuk-Ulam and PPAD complexity. Formalizes the approximate antipodal pair problem, Tucker's lemma (axiomatized: tuckers_lemma), the structural reduction from Tucker's lemma to approximate Borsuk-Ulam, and proves exact Borsuk-Ulam (axiomatized: borsuk_ulam_exact) implies the approximate version. Companion to BorsukUlam.lean addressing the computational-complexity open question (Papadimitriou 1994, PPAD-completeness)."
+        "description": "OQ-01: Approximate Borsuk-Ulam and PPAD complexity. Formalizes the approximate antipodal pair problem, Tucker's lemma (stated as documentation, not axiomatized — the general unconstrained-graph form is false, see file), the structural reduction from Tucker's lemma to approximate Borsuk-Ulam, and proves exact Borsuk-Ulam (axiomatized: borsuk_ulam_exact) implies the approximate version. Companion to BorsukUlam.lean addressing the computational-complexity open question (Papadimitriou 1994, PPAD-completeness)."
       }
     ]
   },


### PR DESCRIPTION
## Problem

Auditor issue #42992: the axiom `tuckers_lemma` (line 137 of `Proofs/BorsukUlamOQ01.lean`) was stated over a completely unconstrained finite type `V` with no non-degeneracy hypotheses, making it **kernel-inconsistent** — it can be used to derive `False`.

Instantiating with `V := Empty`, `edges := ∅`, `boundary := ∅` makes `h_antipodal` vacuously true while the conclusion `∃ u v, (u,v) ∈ edges ∧ ...` is unsatisfiable (no term of type `Empty` exists). The auditor verified this compiles to a proof of `False`.

## Fix

Following the sibling fix #42972 (`tucker_2d` in `borsuk-ulam-oq-03-oq-01`), and the auditor's recommended option (b):

- **Removed** the false `axiom tuckers_lemma` (it was unused — `grep` confirms it is never invoked as a premise by any theorem; only `borsuk_ulam_exact` is used, to derive the approximate version), replacing it with a documentation block explaining why the general unconstrained-graph statement is deliberately not axiomatized.
- **Fixed** the stale closing docstring `Axioms: 3 (borsuk_ulam_exact, tuckers_lemma, ppad_solution_exists)` → `Axioms: 1 (borsuk_ulam_exact)`. `ppad_solution_exists` was a phantom name never declared.
- **meta.json**: top-level `axiomCount` 3 → 2; `additionalFiles[0].axioms` 2 → 1; removed the `tuckers_lemma` `assumptions` entry; reworded the companion-file description.

`status` stays `axiomatized` / badge `axiom` — `borsuk_ulam_exact` and `no_continuous_odd_nonzero_on_sphere` remain legitimate stated axioms.

## Evidence

```
✔ [3034/3034] Built Proofs.BorsukUlamOQ01 (1.3s)
Build completed successfully (3034 jobs).
=== Build succeeded ===
```

The file is now free of the inconsistent axiom and still compiles.

Closes #42992
