### PR TITLE
audit(tracker): area-of-circle-oq-03-oq-02 re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1366,9 +1366,9 @@
       "issues": []
     },
     "area-of-circle-oq-03-oq-02": {
-      "auditCount": 7,
+      "auditCount": 8,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:46Z",
+      "lastAudited": "2026-07-24T04:23:12Z",
       "result": "clean"
     },
     "area-of-circle-oq-03-oq-02-oq-01": {


### PR DESCRIPTION
## Audit result

Re-served (queue drained, round-robin) audit of `area-of-circle-oq-03-oq-02` (Archimedes π bounds 223/71 < π < 22/7).

- 0 axioms, 0 sorries, no True stubs
- 10/10 `mainTheorems`/theorem count match meta.json
- Core bounds derived from Mathlib's `Real.pi_gt_d4`/`Real.pi_lt_d4`; badge is `mathlib` and description/proofStrategy/conclusion all disclose the dependency
- No native_decide usage

Result: **clean**, no fix needed. Tracker updated only.