### PR TITLE
audit(tracker): cantor-diagonalization-oq-02 re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4100,9 +4100,9 @@
       "issues": []
     },
     "cantor-diagonalization-oq-02": {
-      "auditCount": 7,
+      "auditCount": 8,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:47Z",
+      "lastAudited": "2026-07-24T04:25:19Z",
       "result": "clean"
     },
     "cantor-diagonalization-oq-02-oq-01": {


### PR DESCRIPTION
## Summary
- Re-served audit of cantor-diagonalization-oq-02 (round-robin re-serve, queue was fully drained: 0 unaudited).
- Verified 0 sorries, 0 axioms, no True stubs, no native_decide, theorem/def counts match source (16 theorems + 2 defs), lineCount exact match, badge `mathlib` correctly reflects Mathlib-heavy diagonal argument, `assumptions` text accurately discloses dependencies.
- No issues found; tracker updated to reflect re-audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)