### PR TITLE
Enrich antitone-integral-sum-comparison-oq-01-oq-03: split Part IV, close sections-count gap (98->100)

### DIFF
--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-03/meta.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-03/meta.json
@@ -79,11 +79,19 @@
       "mathContext": "$\\sum_n f(n+1) < \\infty \\iff \\Big\\{\\int_1^{1+n} f\\Big\\}_n \\text{ is bounded above}.$"
     },
     {
-      "id": "harmonic-divergence",
-      "title": "Application: Divergence of the Harmonic Series (Part IV)",
+      "id": "harmonic-lemmas",
+      "title": "Instantiating at f = 1/x (Part IV, setup)",
       "startLine": 103,
+      "endLine": 118,
+      "summary": "oneDiv_antitone establishes that 1/x is antitone on [1,∞); log_integral evaluates the definite integral ∫₁^{1+n} 1/x dx = log(n+1) in closed form. These two facts are exactly the hypotheses integral_test needs to be applied to f = 1/x.",
+      "mathContext": "$x\\mapsto 1/x$ antitone on $[1,\\infty)$; $\\int_1^{1+n}\\tfrac1x\\,dx = \\log(n+1)$."
+    },
+    {
+      "id": "harmonic-divergence",
+      "title": "Application: Divergence of the Harmonic Series (Part IV, conclusion)",
+      "startLine": 120,
       "endLine": 141,
-      "summary": "Computes the logarithmic integral ∫₁^{1+n} 1/x dx = log(n+1), which is unbounded, so by the integral test not_summable_one_div_harmonic concludes the harmonic series ∑ 1/n diverges — the showcase application of the framework.",
+      "summary": "not_summable_one_div_harmonic feeds oneDiv_antitone and log_integral into integral_test: since log(n+1) → ∞ the integrals cannot be bounded above, so the harmonic series ∑ 1/(n+1) is not summable — the showcase application of the general dichotomy.",
       "mathContext": "$\\int_1^{1+n}\\tfrac1x\\,dx = \\log(n+1) \\to \\infty \\;\\Rightarrow\\; \\sum_n \\tfrac1n = \\infty.$"
     }
   ],


### PR DESCRIPTION
Enrichment pass for `antitone-integral-sum-comparison-oq-01-oq-03` (quality 98->100).

`overview.keyInsights` (5 items) and annotations (5) were already at target. The sole gap was `sections` count (4 items = 8/10 points, needs 5 for full 10).

Split the "Application: Divergence of the Harmonic Series (Part IV)" section (lines 103-141) at its real theorem boundary into:
- **Instantiating at f = 1/x (setup)** — `oneDiv_antitone` + `log_integral` (lines 103-118)
- **Application: Divergence of the Harmonic Series (conclusion)** — `not_summable_one_div_harmonic` (lines 120-141)

No Lean file changes. Verified with `find-targets.ts --all` (98->100) and `check-meta-size.ts`.