### PR TITLE
Rebalance fleet defaults: 1 enricher / 3 researchers (#43008)

### DIFF
--- a/.claude/commands/lean.md
+++ b/.claude/commands/lean.md
@@ -21,14 +21,20 @@ Parse `$ARGUMENTS` and route:
 # Start in tmux via the keeper (recommended — runs autonomously AND auto-restarts
 # the daemon if it crashes; the daemon runs under `set -euo pipefail` and can die
 # on any unguarded non-zero in its loop, which leaves agents orphaned).
-tmux new-session -d -s lean-daemon './scripts/lean/daemon-keeper.sh --enricher 2 --researcher 1 --deployer 1'
+tmux new-session -d -s lean-daemon './scripts/lean/daemon-keeper.sh --enricher 1 --researcher 3 --deployer 1'
 
 # Or with custom pool
-tmux new-session -d -s lean-daemon './scripts/lean/daemon-keeper.sh --enricher 2 --researcher 3 --aristotle 1 --seeker 1 --deployer 1 --auditor 1 --mechanic 1'
+tmux new-session -d -s lean-daemon './scripts/lean/daemon-keeper.sh --enricher 1 --researcher 3 --aristotle 1 --seeker 1 --deployer 1 --auditor 1 --mechanic 1'
 
 # Adopt an already-running fleet without tearing it down (keeper + monitor-only):
-tmux new-session -d -s lean-daemon './scripts/lean/daemon-keeper.sh --monitor-only --interval 60 --enricher 2 --researcher 5 --aristotle 1 --auditor 1 --seeker 1 --deployer 1 --tester 1 --herald 1 --mechanic 1'
+tmux new-session -d -s lean-daemon './scripts/lean/daemon-keeper.sh --monitor-only --interval 60 --enricher 1 --researcher 3 --aristotle 1 --auditor 1 --seeker 1 --deployer 1 --tester 1 --herald 1 --mechanic 1'
 ```
+
+> **Pool ratio (issue #43008):** default is 1 enricher / 3 researchers. The
+> enrichment queue sits at its quality floor — when `launch.sh status` shows
+> "Proofs needing enrichment: 0" (or find-targets serves only 96+-quality
+> score-ceiling noise), extra enricher capacity is wasted; keep enrichers at 1
+> and spend the slots on researchers instead.
 
 > The keeper supervises the supervisor: it restarts `launch.sh daemon` on any
 > non-clean exit, with crash-loop backoff, and logs lifecycle events to

--- a/scripts/lean/daemon-keeper.sh
+++ b/scripts/lean/daemon-keeper.sh
@@ -21,7 +21,7 @@
 # Typically launched in tmux so it survives the controlling terminal:
 #   tmux new-session -d -s lean-daemon \
 #     './scripts/lean/daemon-keeper.sh --monitor-only --interval 60 \
-#        --researcher 5 --enricher 2 --aristotle 1 --auditor 1 \
+#        --researcher 3 --enricher 1 --aristotle 1 --auditor 1 \
 #        --seeker 1 --deployer 1 --tester 1 --herald 1 --mechanic 1'
 #
 # Clean shutdown (keeper + daemon both exit, agents stopped by the daemon):

--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -83,11 +83,12 @@ RESPAWN_COOLDOWN_SECONDS=300  # 5 minutes between respawns of same agent
 MISSING_SESSION_ALERT_CYCLES=3
 
 # Default pool sizes
-# Balanced team: 5 researchers (continuous), 8 support agents (sleeping between cycles)
-# ~72 active min/hr across 9 accounts = ~8 min/hr per account
+# Rebalanced (issue #43008): 1 enricher, 3 researchers. The enrichment queue has
+# been at its quality floor (find-targets serving only 96+-quality noise), so
+# capacity moves back to research. Support agents sleep between cycles.
 DEFAULT_ENRICHER=1
 DEFAULT_ARISTOTLE=1
-DEFAULT_RESEARCHER=5
+DEFAULT_RESEARCHER=3
 DEFAULT_SEEKER=1
 DEFAULT_DEPLOYER=1
 DEFAULT_AUDITOR=1
@@ -163,7 +164,7 @@ Agent Types:
 Examples:
   $0 start                              # Start with defaults
   $0 start --researcher 3               # Custom pool sizes
-  $0 start --enricher 2 --researcher 1  # Include Enrichers
+  $0 start --enricher 1 --researcher 3  # Include Enrichers
   $0 spawn researcher                   # Add one Researcher
   $0 spawn seeker                       # Add seeker agent
   $0 scale researcher 4                 # Scale to 4 Researchers

--- a/scripts/lean/status.sh
+++ b/scripts/lean/status.sh
@@ -391,6 +391,14 @@ EOF
         # Work Queue
         echo -e "  ${CYAN}Work Queue:${NC}"
         echo "    Proofs needing enrichment: $enrichment_count"
+        # Enrichment-saturation signal (issue #43008): when the queue is empty,
+        # any running enrichers are idle or reduced to score-ceiling noise
+        # (find-targets serving only 96+-quality entries). Flag it so operators
+        # know enricher slots are better spent on researchers.
+        if [[ "$enrichment_count" == "0" ]]; then
+            echo -e "      ${YELLOW}Enrichment queue saturated — enricher capacity may be idle;${NC}"
+            echo -e "      ${YELLOW}consider './scripts/lean/launch.sh scale enricher 1' and adding researchers.${NC}"
+        fi
         echo "    Aristotle jobs pending: $aristotle_jobs"
         echo "    Aristotle candidates: $aristotle_candidates"
         echo "    Research problems available: $research_problems"


### PR DESCRIPTION
Closes #43008 (Epic #43004, Phase 1)

## Why

Fleet capacity is ~90% self-maintenance. Over the last 7 days, of 3,445 commits merged to main: 1,694 enrichment (49%), 1,032 audit/tracker bookkeeping (30%), 327 fixes (9.5%), 315 research (9%). The enrichment queue has been at its quality floor for days — enricher output is score-ceiling gaming ("add 5th keyInsight (98→100)") with zero mathematical content. This PR moves the default ratio from 2 enrichers / 1 researcher (the live daemon-keeper launch line) to 1 enricher / 3 researchers.

## Changes

**Defaults**
- `scripts/lean/launch.sh`: `DEFAULT_RESEARCHER` 5 → 3 (`DEFAULT_ENRICHER` was already 1 — the live 2/1 ratio came from explicit flags in the documented launch line, not script defaults). Usage example `start --enricher 2 --researcher 1` → `--enricher 1 --researcher 3`.
- `scripts/lean/daemon-keeper.sh`: header example invocation `--researcher 5 --enricher 2` → `--researcher 3 --enricher 1`.

**Docs**
- `.claude/commands/lean.md`: all three documented `daemon-keeper.sh` launch lines now use `--enricher 1 --researcher 3`; added a pool-ratio note explaining the enrichment-saturation signal.

**Saturation signal (task 3)**
- `scripts/lean/status.sh`: when "Proofs needing enrichment" is 0, `launch.sh status` now prints a yellow warning that enricher capacity may be idle and suggests scaling enrichers down / researchers up.

**Researcher worktree bootstrap (task 4) — verified, no change needed**
- The daemon spawn path (`launch.sh spawn/scale` → `scripts/research/parallel-research.sh --slot N` → `create_worktree`) provisions `researcher-N` worktrees automatically, with the #38398 health check and mass-deletion tripwire.
- The historical "fresh worktree lacks `.lean/research` / `.lean/state` / `research/db`" gotcha is already fixed at the root: `scripts/research/claim-problem.sh` resolves `REPO_ROOT` via `git rev-parse --git-common-dir` (lines 20–49), so all researchers share the MAIN checkout's pool/claims/db regardless of worktree freshness. researcher-2/-3 will be provisioned by the daemon on scale-up.

## Operator actions post-merge (live fleet)

`research/lean-daemon-state.json` is runtime state written by the daemon; this PR does not touch it. To apply the new ratio to the running fleet:

```
./scripts/lean/launch.sh scale enricher 1
./scripts/lean/launch.sh scale researcher 3
```

(or restart the daemon — the tmux launch line in `.claude/commands/lean.md` now encodes the new ratio, and script defaults preserve it).

## Verification

- `bash -n` clean on `launch.sh`, `status.sh`, `daemon-keeper.sh`
- No occurrences of the old pool flags remain: `grep -rn -- "--enricher 2" .claude/ CLAUDE.md scripts/lean/` is empty
- Diff limited to defaults, docs, and the additive saturation note — no restructuring

🤖 Generated with [Claude Code](https://claude.com/claude-code)
