### PR TITLE
Enrich area-of-circle-oq-05-oq-03-oq-03: 5th keyInsight (98->100)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-03-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-03-oq-03/meta.json
@@ -35,7 +35,8 @@
       "Translation in space ↦ modulation in frequency: sliding the Gaussian by a multiplies its transform by the pure phase e^{ita}, leaving the magnitude untouched.",
       "Modulation in space ↦ translation in frequency: twisting the Gaussian by e^{iax} simply shifts its transform t ↦ t+a. These are the two halves of the Fourier shift theorem, dual under the inverse transform.",
       "No new analysis is needed beyond the parent: translation is handled by Lebesgue translation-invariance (integral_sub_right_eq_self) after pulling out the constant phase, and modulation by merging exponentials and re-using the parent at a shifted frequency.",
-      "The cast subtlety (x:ℂ)-a vs ↑(x-a) must be bridged with integral_congr_ae before the translation-invariance lemma will fire — a recurring practical point when combining ℝ→ℂ coercions with measure-theoretic rewrites."
+      "The cast subtlety (x:ℂ)-a vs ↑(x-a) must be bridged with integral_congr_ae before the translation-invariance lemma will fire — a recurring practical point when combining ℝ→ℂ coercions with measure-theoretic rewrites.",
+      "Translation and modulation are the Fourier-theoretic shadow of Pontryagin duality for ℝ: the characters of the additive group ℝ are exactly the phases x ↦ e^{iax}, and the shift theorem says the group ℝ acts on itself in physical space (translation) and, dually, on its own character group in frequency space (modulation) — the Fourier transform literally interchanges these two actions. The dilation sibling (area-of-circle-oq-05-oq-03-oq-01) supplies the orthogonal, magnitude-changing symmetry (width inversion, no phase); together the two describe the full symmetry group acting on the Gaussian under the transform."
     ],
     "prerequisites": [
       "area-of-circle-oq-05-oq-03 — the Gaussian Fourier self-duality ∫ e^{itx} e^{-x²/2} = e^{-t²/2}√(2π) (reproved here)",
@@ -99,6 +100,11 @@
       "targetId": "area-of-circle-oq-05-oq-03",
       "relationship": "extends",
       "description": "Parent: the Gaussian is its own Fourier transform. This entry adds the translation/modulation behaviour and recovers the parent as the a=0 case."
+    },
+    {
+      "targetId": "area-of-circle-oq-05-oq-03-oq-01",
+      "relationship": "related",
+      "description": "Sibling: proves the dilation/width-inversion symmetry of the Gaussian Fourier transform (magnitude-changing, phase-free). Together with this entry's phase symmetry (translation/modulation, magnitude-preserving) the two describe the full affine symmetry group acting on the Gaussian under the transform."
     },
     {
       "targetId": "central-limit-theorem",


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-05-oq-03-oq-03` (quality 98->100).

`sections` (5 items) and annotations were already at target. The sole gap was `overview.keyInsights` at 4 items (needs 5 for full points). Added a genuine 5th insight, not filler:

Translation/modulation duality is the Fourier-theoretic shadow of Pontryagin duality for `ℝ`: the characters of the additive group `ℝ` are exactly the phases `x ↦ e^{iax}`, and the shift theorem says translating in physical space and modulating in frequency space are dual actions of `ℝ` on itself. Also added a cross-reference to the dilation sibling `area-of-circle-oq-05-oq-03-oq-01`, noting it supplies the orthogonal, phase-free scale symmetry — together the two describe the full affine symmetry group acting on the Gaussian under the transform.

No Lean file changes. Verified with `find-targets.ts --all` (98->100) and `check-meta-size.ts`.