### PR TITLE
audit(fourier-series-oq-01): fix phantom mainTheorems axiom name

### DIFF
--- a/src/data/proofs/fourier-series-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-01/meta.json
@@ -247,7 +247,7 @@
       "leanType": "f ∈ L² → ∀ᵐ x, Tendsto (fun N => S_N f x) atTop (𝓝 (f x))"
     },
     {
-      "name": "carleson_hunt_weak_type",
+      "name": "carleson_hunt_maximal",
       "type": "axiom",
       "description": "Carleson-Hunt weak-type (2,2) maximal inequality",
       "leanType": "μ({S*f > λ}) ≤ (C/λ)² · ‖f‖²_{L²}"


### PR DESCRIPTION
## Gallery integrity fix

**Proof**: fourier-series-oq-01 (Carleson's Theorem)

**Problem**: `mainTheorems` in meta.json listed an axiom named
`carleson_hunt_weak_type`, which does not exist anywhere in
`Proofs/FourierSeriesOQ01.lean`.

## Evidence

- meta.json `mainTheorems` claimed: `carleson_hunt_weak_type`
- Actual axiom in the Lean file (line 177): `carleson_hunt_maximal`
- `annotations.json` already correctly references `carleson_hunt_maximal`
  in its docstring annotation and identifiers list — only `mainTheorems`
  in meta.json had the stale/phantom name.
- All other counts checked and match: axiomCount=2 ✓, sorries=0 ✓,
  theoremCount=22 ✓ (17 top-level + 5 `private theorem`), definitionCount=6 ✓,
  lineCount=857 ✓. Status `axiomatized` / badge `axiom` is honestly disclosed
  and matches Tier C — no other issues found.

## Fix

Renamed the `mainTheorems` entry from `carleson_hunt_weak_type` to
`carleson_hunt_maximal` to match the real declaration name. No other
fields changed.

---
Discovered during gallery integrity audit.