### PR TITLE
audit(tracker): cantor-diagonalization-oq-01 re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4050,8 +4050,8 @@
     },
     "cantor-diagonalization-oq-01": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:47Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T04:42:17Z",
       "result": "clean"
     },
     "cantor-diagonalization-oq-01-oq-01": {


### PR DESCRIPTION
## Summary
- Re-serve audit (unaudited queue is drained; round-robin oldest-first) of `cantor-diagonalization-oq-01`.
- Verified meta.json counts against `proofs/Proofs/CantorDiagonalizationOQ01.lean`: 2 axioms, 28 theorems, 5 defs, 0 sorries, 442 lines — all match.
- Both axioms (`konig_cofinality_bound`, `aleph_omega_cofinality_is_aleph_zero`) are honestly disclosed in prose, annotations.json, and assumptions field, with "Why an axiom?" justification comments in the Lean source. No phantom axiom names.
- No `native_decide`/`decide` tactic usage found (only prose mentions of "decide").
- Status `axiomatized` / badge `axiom` (Tier C) is appropriate — no overclaiming.
- Updates `audit-tracker.json` only.

## Test plan
- [x] Diffed meta.json counts against Lean source via grep
- [x] Confirmed axiom identifiers match Lean declarations exactly
- [x] Confirmed annotations.json axiom disclosure matches