### PR TITLE
audit(fourier-series): fix stale axiomatized prose + phantom mainTheorems names

### DIFF
--- a/src/data/proofs/fourier-series/annotations.json
+++ b/src/data/proofs/fourier-series/annotations.json
@@ -290,18 +290,18 @@
     },
     "type": "concept",
     "title": "Bessel's Inequality",
-    "content": "Proves **Bessel's inequality**: for any finite set $S \\subseteq \\mathbb{Z}$, $\\sum_{n \\in S} |c_n|^2 \\leq \\int |f|^2\\, d\\mu$. The proof rewrites the RHS using Parseval, then applies `sum_le_tsum` (finite sum $\\leq$ infinite sum for nonneg terms).",
-    "mathContext": "Proved: `bessel_fourier (f) (s : Finset ℤ) : ∑ n ∈ s, ‖fourierCoeff (⇑f) n‖ ^ 2 ≤ ∫ t, ‖(⇑f) t‖ ^ 2 ∂haarAddCircle`. The proof: (1) rewrite RHS via `parseval_fourier`, (2) apply `sum_le_tsum` with nonnegativity from `sq_nonneg`, (3) use `summable_sq_fourierCoeff` for summability. For complete systems, Bessel becomes Parseval equality.",
+    "content": "Proves **Bessel's inequality**: for any finite set $S \\subseteq \\mathbb{Z}$, $\\sum_{n \\in S} |c_n|^2 \\leq \\int |f|^2\\, d\\mu$. The proof applies `sum_le_hasSum` directly to the `HasSum` witness from `hasSum_sq_fourierCoeff` (finite sum $\\leq$ infinite sum for nonneg terms).",
+    "mathContext": "Proved: `bessel_fourier (f) (s : Finset ℤ) : ∑ n ∈ s, ‖fourierCoeff (⇑f) n‖ ^ 2 ≤ ∫ t, ‖(⇑f) t‖ ^ 2 ∂haarAddCircle`. The proof: `sum_le_hasSum s (fun _ _ => sq_nonneg _) (hasSum_sq_fourierCoeff f)`, using nonnegativity from `sq_nonneg` and the `HasSum` witness from Mathlib's `hasSum_sq_fourierCoeff`. For complete systems, Bessel becomes Parseval equality.",
     "significance": "key",
     "relatedConcepts": [
       "Bessel's inequality",
-      "sum_le_tsum",
+      "sum_le_hasSum",
       "sq_nonneg",
       "partial sums"
     ],
     "prerequisites": [
       "parseval_fourier",
-      "sum_le_tsum",
+      "sum_le_hasSum",
       "summable_sq_fourierCoeff"
     ]
   },

--- a/src/data/proofs/fourier-series/meta.json
+++ b/src/data/proofs/fourier-series/meta.json
@@ -190,8 +190,8 @@
       "title": "Bessel's Inequality",
       "startLine": 325,
       "endLine": 351,
-      "summary": "Proves Bessel's inequality: $\\sum_{n \\in S} |c_n|^2 \\leq \\int |f|^2$ for any finite set $S \\subseteq \\mathbb{Z}$. Uses Parseval and `sum_le_tsum` for nonneg terms. Summability of $|c_n|^2$ is axiomatized (`summable_sq_fourierCoeff`).",
-      "mathContext": "Bessel: $\\sum_{n \\in S} |c_n|^2 \\leq \\|f\\|_{L^2}^2$ for any finite $S \\subseteq \\mathbb{Z}$. This is weaker than Parseval (partial sum $\\leq$ total). With completeness (Hilbert basis), Bessel becomes Parseval in the limit $S \\to \\mathbb{Z}$. The axiom `summable_sq_fourierCoeff` states $\\sum |c_n|^2 < \\infty$."
+      "summary": "Proves Bessel's inequality: $\\sum_{n \\in S} |c_n|^2 \\leq \\int |f|^2$ for any finite set $S \\subseteq \\mathbb{Z}$. Uses Parseval and `sum_le_hasSum` for nonneg terms. Summability of $|c_n|^2$ is proved (`summable_sq_fourierCoeff`), not axiomatized.",
+      "mathContext": "Bessel: $\\sum_{n \\in S} |c_n|^2 \\leq \\|f\\|_{L^2}^2$ for any finite $S \\subseteq \\mathbb{Z}$. This is weaker than Parseval (partial sum $\\leq$ total). With completeness (Hilbert basis), Bessel becomes Parseval in the limit $S \\to \\mathbb{Z}$. `summable_sq_fourierCoeff` is a proved theorem (from Mathlib's `hasSum_sq_fourierCoeff`) stating $\\sum |c_n|^2 < \\infty$."
     },
     {
       "id": "uniform-convergence",
@@ -206,8 +206,8 @@
       "title": "Uniqueness and Riemann-Lebesgue",
       "startLine": 394,
       "endLine": 450,
-      "summary": "Proves uniqueness: same Fourier coefficients $\\Rightarrow$ same $L^2$ function (via `HasSum.unique`). States the Riemann-Lebesgue lemma: $c_n \\to 0$ as $|n| \\to \\infty$ (axiomatized).",
-      "mathContext": "Uniqueness: $c_n(f) = c_n(g)\\ \\forall n \\Rightarrow f = g$ in $L^2$. Proof: both have the same Fourier series, which converges to both in $L^2$, so $f = g$ by `HasSum.unique`. Riemann-Lebesgue (axiom): $c_n(f) \\to 0$ as $|n| \\to \\infty$ for all $f \\in L^2$. The classical proof uses density of $C^1$ functions."
+      "summary": "Proves uniqueness: same Fourier coefficients $\\Rightarrow$ same $L^2$ function (via `HasSum.unique`). Proves the Riemann-Lebesgue lemma: $c_n \\to 0$ as $|n| \\to \\infty$, derived from Parseval summability (not axiomatized).",
+      "mathContext": "Uniqueness: $c_n(f) = c_n(g)\\ \\forall n \\Rightarrow f = g$ in $L^2$. Proof: both have the same Fourier series, which converges to both in $L^2$, so $f = g$ by `HasSum.unique`. Riemann-Lebesgue: $c_n(f) \\to 0$ as $|n| \\to \\infty$ for all $f \\in L^2$, proved directly from $\\sum \\|c_n\\|^2 < \\infty$ (Parseval) via `tendsto_cofinite_zero`, with no axiom involved."
     },
     {
       "id": "verification",
@@ -283,16 +283,16 @@
   ],
   "mainTheorems": [
     {
-      "name": "fourier_convergence",
+      "name": "hasSum_fourier_series",
       "type": "core",
       "description": "L2 convergence of Fourier series for square-integrable functions",
-      "leanType": "f in L2 -> Tendsto (fun N => norm(f - S_N f)) atTop (nhds 0)"
+      "leanType": "(f : Lp ℂ 2 (haarAddCircle (T := T))) -> HasSum (fun n => fourierCoeff f n • fourierLp 2 n) f"
     },
     {
-      "name": "parseval_theorem",
+      "name": "parseval_fourier",
       "type": "key",
       "description": "Parseval's theorem: ||f||^2 = sum |c_n|^2",
-      "leanType": "integral |f|^2 = sum n, |fourierCoeff f n|^2"
+      "leanType": "(f : Lp ℂ 2 (haarAddCircle (T := T))) -> ∑' n, ‖fourierCoeff f n‖^2 = ∫ t, ‖f t‖^2 ∂haarAddCircle"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary
- `bessel` and `uniqueness-riemann-lebesgue` sections in meta.json described `summable_sq_fourierCoeff` and `fourierCoeff_tendsto_zero` as "axiomatized", but commit a962bd49 (2026-03-23, "Prove both axioms (0 axioms)") upgraded both to genuine proofs. `axiomCount`/`sorries` were already correctly 0 — only the descriptive prose was stale, understating what's actually proved.
- `mainTheorems` named `fourier_convergence` and `parseval_theorem`, neither of which exists as a declaration in `proofs/Proofs/FourierSeries.lean`. The real names are `hasSum_fourier_series` and `parseval_fourier`.
- `annotations.json`'s `ann-fs-bessel` entry still cited `sum_le_tsum`, which the same upstream commit renamed to `sum_le_hasSum` (Mathlib API change).

No changes to the Lean file — this is a gallery-integrity audit fixing stale/phantom prose in meta.json and annotations.json only.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` on both edited JSON files
- [x] Grepped `proofs/Proofs/FourierSeries.lean` to confirm `hasSum_fourier_series`, `parseval_fourier`, and `sum_le_hasSum` are the actual declaration/lemma names, and that `summable_sq_fourierCoeff`/`fourierCoeff_tendsto_zero` are `theorem`s (not `axiom`s)
- [x] `git log -p` confirms commit a962bd49 converted both axioms to proofs and renamed `sum_le_tsum` → `sum_le_hasSum`

🤖 Generated with [Claude Code](https://claude.com/claude-code)