### PR TITLE
research(#43007): triage 91 blocked pool problems; unblock sig-8/9 entries shelved by template placeholders

### DIFF
--- a/research/notes/blocked-pool-triage-2026-07-23.md
+++ b/research/notes/blocked-pool-triage-2026-07-23.md
@@ -1,0 +1,156 @@
+# Blocked-pool triage — 2026-07-23 (issue #43007, epic #43004)
+
+Triage of all 91 `status='blocked'` rows in `research/db/knowledge.db` (pool source of truth,
+regenerated into `.lean/state/candidate-pool.json` by `research/db/sync_pool.py` every Seeker cycle).
+Applied by `scripts/research/triage-blocked-pool.py` (idempotent; DB backed up to
+`knowledge.db.pre-triage-issue43007`).
+
+Root causes found:
+
+- **2026-06-13/14 verification blackout** (Docker daemon hung + Aristotle backend 404): ~40 rows
+  were blocked solely because no build/verification route existed. Docker has been healthy for
+  weeks (`docker info` exit 0 on 2026-07-23); nothing ever unblocked them.
+- **Template placeholders**: 6 rows carried the literal unfilled template
+  `[Explain what we're trying to prove in accessible terms]` as `statement_plain` — the string the
+  pool surfaces as the BLOCKED reason. Real statements restored from each `problem.md`.
+- **No reason at all**: ~20 rows had empty `current_blockers`; several have `state.md` explicitly
+  saying "Blockers: None".
+- **Stale build-regression claims**: szemeredi-full-oq-01 / roth-theorem-k3-oq-03-incomplete-01 /
+  sperner-ndim-mathlib-oq-02 cited v4.26-era parent build errors that predate the v4.31 toolchain
+  migration (#39062; RothTheoremOQ03 also repaired in #37676). Returned to pool with a
+  verify-parent-build-first next action.
+- **Registry-terminal drift**: 5 rows are `graduated` in the tracked registry but were stuck
+  `blocked` in the DB (the reconciler only touches servable rows); 1 row is a duplicate of
+  completed siblings (-> skipped).
+
+Counts: **54 -> available**, **31 kept blocked** (all with concrete reasons), **5 -> graduated**, **1 -> skipped**; 10 statements de-templated; 37 registry.json entries flipped blocked->active (required so `sync-db-status-from-registry.py` does not re-block the unblocked rows each Seeker cycle).
+
+
+## Returned to available (54)
+
+- **amgm-inequality-oq-04-oq-03** (sig 9)
+- **szemeredi-full-oq-01** (sig 9) — Verify parent build first: the recorded 28-error regression in Proofs.FurstenbergCorrespondenceOQ01 predates the v4.26->v4.31 toolchain migration (#39062) which touched the file; run ./proofs/scripts/docker-build.sh Proofs.FurstenbergCorrespondenceOQ01 and resume the S13 roadmap if green (triage #43007, 2026-07-23)
+- **ballot-problem-oq-03-oq-01-oq-02-incomplete-01** (sig 8)
+- **bertrands-postulate-oq-02** (sig 8)
+- **euler-polyhedral-formula-oq-02-oq-01-wip-01** (sig 8)
+- **fundamental-theorem-calculus-oq-02-incomplete-01** (sig 8)
+- **ballot-problem-oq-02-oq-05** (sig 7)
+- **basel-problem-oq-01-oq-01-oq-02-oq-02** (sig 7)
+- **birthday-problem-oq-03-oq-01-oq-02-oq-01** (sig 7)
+- **cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-01-oq-01** (sig 7)
+- **erdos-1151-oq-04** (sig 7)
+- **erdos-1210** (sig 7)
+- **erdos-szekeres-oq-03** (sig 7)
+- **konigsberg-oq-03-wip-01** (sig 7)
+- **minkowski-fundamental-theorem-oq-06** (sig 7)
+- **prob-method-lovasz-local-oq-01** (sig 7)
+- **roth-theorem-k3-oq-03-incomplete-01** (sig 7) — Verify parent build first: the recorded v4.26 API-drift errors in Proofs.RothTheoremOQ03 predate the #37676 drift repair and the v4.31 migration (#39062); run ./proofs/scripts/docker-build.sh Proofs.RothTheoremOQ03, then resume the companion roadmap (triage #43007, 2026-07-23)
+- **roth-theorem-oq-02** (sig 7)
+- **sperner-ndim-mathlib-oq-02** (sig 7) — Verify parent build first: the recorded 100+ v4.26-drift errors in SpernerFreudenthalSimplex.lean predate the v4.31 migration (#39062) which touched the file; run ./proofs/scripts/docker-build.sh Proofs.SpernerFreudenthalSimplex and resume the rebase queue if green (triage #43007, 2026-07-23)
+- **sum-of-divisors-oq-02** (sig 7)
+- **abel-ruffini-galois-extensions-oq-05** (sig 6)
+- **abel-ruffini-oq-08** (sig 6)
+- **binomial-theorem-oq-02-oq-01-oq-01-oq-03** (sig 6)
+- **bounded-prime-gaps-oq-03-oq-02** (sig 6)
+- **cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01** (sig 6)
+- **cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01** (sig 6)
+- **central-limit-theorem-oq-01-oq-01-oq-04-oq-01** (sig 6)
+- **erdos-1006-oq-01-oq-02** (sig 6)
+- **erdos-659-oq-01-oq-02** (sig 6)
+- **erdos-735-oq-04** (sig 6)
+- **fermat-defect-one-oq-02** (sig 6)
+- **fodor-pressing-down-oq-04** (sig 6)
+- **gauss-wilson-non-cyclic-oq-02** (sig 6)
+- **gauss-wilson-non-cyclic-oq-03** (sig 6)
+- **general-quartic-oq-02** (sig 6)
+- **godel-second-incompleteness-oq02-oq-02** (sig 6)
+- **greens-theorem-oq-01-oq-01-oq-02-oq-01** (sig 6)
+- **greens-theorem-oq-01-oq-01-oq-02-oq-02** (sig 6)
+- **hilbert-14-oq-04** (sig 6)
+- **inverse-galois-d4-oq-03** (sig 6)
+- **pell-equation-oq-05** (sig 6)
+- **product-of-segments-of-chords-oq-03** (sig 6)
+- **shannon-channel-coding-oq-02-oq-01-oq-01** (sig 6)
+- **shapley-folkman-oq-01** (sig 6)
+- **sperner-simplicial-instance-oq-01** (sig 6)
+- **sqrt2-minpoly-oq-03** (sig 6)
+- **triangle-inequality-oq-04-oq-01** (sig 6)
+- **ballot-problem-oq-01-oq-02-oq-01-oq-02-oq-01** (sig 5)
+- **chinese-remainder-non-coprime-oq-01-oq-02** (sig 5)
+- **desargues-theorem-oq-02-oq-02** (sig 5)
+- **erdos-szekeres-oq-02** (sig 5)
+- **halting-problem-oq-03** (sig —)
+- **motivic-flag-maps-oq-03** (sig —)
+- **weak-goldbach-oq-03** (sig —)
+
+## Kept blocked, concrete reasons (31)
+
+- **euler-polyhedral-formula-oq-02-oq-01-oq-01** (sig 9): Mathlib gap: no Gaussian curvature, geodesic curvature, Riemannian area form, manifold integration, or Stokes for manifolds-with-boundary; re-survey when these land in Mathlib (triage #43007, 2026-07-23)
+- **algebraic-numbers-countable-oq-03** (sig 8): Gelfond-Schneider transcendence requires machinery absent from Mathlib (even Hermite-Lindemann is gated on upstream Mathlib PR #28013, cf. nth-root-irrational-oq-03); also no problem.md grounding under research/problems/ (triage #43007, 2026-07-23)
+- **sperner-ndim-oq-05** (sig 8): Human-only step: refresh rjwalters/mathlib4:sperner-abstract-parity with current SpernerMathlib4.lean and submit the upstream Mathlib PR (ref mathlib4#25231); no research-agent action possible until then (triage #43007, 2026-07-23)
+- **bertrands-postulate-oq-01** (sig 7): Cramer's conjecture is open mathematics (1936; provable under RH only) — removing axiom cramer_conjecture is infeasible for any agent; Mathlib also lacks PNT-strength analytic number theory (triage #43007, 2026-07-23)
+- **cevas-theorem-oq-01-oq-02** (sig 7): Ungrounded stub: no research/problems/cevas-theorem-oq-01-oq-02/ directory (no problem.md or state.md); needs seeker re-grounding before serving (triage #43007, 2026-07-23)
+- **erdos-1168-oq-04** (sig 7): Ungrounded seeker stub: no research/problems/erdos-1168-oq-04/problem.md; demoted by seeker 2026-06-16; needs re-grounding (triage #43007, 2026-07-23)
+- **erdos-166-oq-04** (sig 7): Ungrounded seeker stub: no research/problems/erdos-166-oq-04/problem.md; demoted by seeker 2026-06-16; needs re-grounding (triage #43007, 2026-07-23)
+- **erdos-476-oq-05-incomplete-01** (sig 7): Ungrounded seeker stub: no research/problems/erdos-476-oq-05-incomplete-01/problem.md; demoted by seeker 2026-06-16; needs re-grounding (triage #43007, 2026-07-23)
+- **erdos-604-incomplete-01** (sig 7): Mathlib gap: Landau-Ramanujan density theorem absent; workable fallback per state.md is axiomatizing it as a named hypothesis (status: axiomatized, blocker disclosed) (triage #43007, 2026-07-23)
+- **erdos-998-oq-02** (sig 7): Ungrounded seeker stub: no research/problems/erdos-998-oq-02/problem.md; demoted by seeker 2026-06-16; needs re-grounding (triage #43007, 2026-07-23)
+- **four-square-distribution-oq-01** (sig 7): Mathlib gap: no q-expansion/Fourier-coefficient machinery for jacobiTheta and no Eisenstein-coefficient identification (theta^4 vs E2(tau) - 4*E2(4tau)) (triage #43007, 2026-07-23)
+- **hilbert-11-oq-02** (sig 7): Mathlib gap: Hasse-Weil bound for genus-1 curves over F_p absent — the unconditional Case-B universal theorem is multi-session Mathlib-scale work (triage #43007, 2026-07-23)
+- **hurwitz-theorem-wip-01** (sig 7): Mathlib gap: no classical Frobenius theorem for real division algebras (finite-dim associative division algebra over R has finrank in {1,2,4}); verified absent 2026-05-08 (triage #43007, 2026-07-23)
+- **inclusion-exclusion-oq-01-oq-02** (sig 7): Ungrounded: no research/problems/inclusion-exclusion-oq-01-oq-02/ directory and corrupted statement metadata; needs seeker re-grounding (triage #43007, 2026-07-23)
+- **nth-root-irrational-oq-03** (sig 7): Hermite-Lindemann discharge gated on upstream Mathlib PR #28013; remaining S5d path needs continued-fraction API absent from the pinned Mathlib (triage #43007, 2026-07-23)
+- **algebraic-numbers-countable-oq-02-oq-01** (sig 6): Ungrounded: no research/problems/algebraic-numbers-countable-oq-02-oq-01/ state; blocked in registry with no recorded reason; needs re-triage/grounding (triage #43007, 2026-07-23)
+- **cantor-diagonalization-oq-01-oq-01-oq-02-oq-01** (sig 6): At axiom floor: 4 genuine Easton-1970 realizability axioms require class-forcing infrastructure absent from Mathlib (multi-year); no session-sized discharge exists (triage #43007, 2026-07-23)
+- **ehrhart-cube-proven-oq-05** (sig 6): Soundness blocker: the S5 target picks_theorem_derived is FALSE as stated (S4 OBSERVE, PR #23003 constant-curve/placement counterexample); the proposition must be restated before any ACT (triage #43007, 2026-07-23)
+- **erdos-1036-oq-01-oq-01** (sig 6): Ungrounded: no research/problems/erdos-1036-oq-01-oq-01/ state and no recorded blocker; blocked status inherited without reason — needs seeker re-grounding (triage #43007, 2026-07-23)
+- **erdos-1039-oq-04** (sig 6): Ungrounded: no research/problems/erdos-1039-oq-04/ state and no recorded blocker; blocked status inherited without reason — needs seeker re-grounding (triage #43007, 2026-07-23)
+- **erdos-258-oq-01** (sig 6): General non-monotone case is open mathematics (Erdős problem 258); no state grounding recorded under research/problems/ (triage #43007, 2026-07-23)
+- **erdos-460-incomplete-01** (sig 6): Ungrounded: no research/problems/erdos-460-incomplete-01/ state and no recorded blocker; blocked status inherited without reason — needs seeker re-grounding (triage #43007, 2026-07-23)
+- **erdos-818-incomplete-01** (sig 6): Elementary provable layer mined out across prior sessions; remaining axioms are deep (vein saturated — see prior researcher session records) (triage #43007, 2026-07-23)
+- **erdos-895-incomplete-01** (sig 6): barber_theorem positive direction needs a >1000-line SAT/case proof (graph space 2^(n choose 2), not decide-able, not session-sized; Aristotle not a fit); counterexample direction fully shipped; mined out across 7 sessions (triage #43007, 2026-07-23)
+- **godel-second-incompleteness-oq02-oq-01** (sig 6): init-gap phantom: no research/problems/godel-second-incompleteness-oq02-oq-01/problem.md; demoted by seeker 2026-07-07; needs re-grounding (triage #43007, 2026-07-23)
+- **infinitude-primes-4k1-oq-03** (sig 6): Mathlib gap: the natural-density form requires an Ikehara/Tauberian transfer absent from Mathlib (triage #43007, 2026-07-23)
+- **kepler-conjecture-oq-03** (sig 6): init-gap phantom: no research/problems/kepler-conjecture-oq-03/problem.md; demoted by seeker 2026-07-07; needs re-grounding (triage #43007, 2026-07-23)
+- **prime-number-theorem-oq-01** (sig 6): Target is the Riemann Hypothesis itself — open mathematics; no formal proof path exists (triage #43007, 2026-07-23)
+- **erdos-1002-oq-01-wip-01** (sig 5): Ungrounded: no research/problems/erdos-1002-oq-01-wip-01/ state and no recorded blocker; blocked status inherited without reason — needs seeker re-grounding (triage #43007, 2026-07-23)
+- **erdos-1064-oq-03** (sig 4): Ungrounded: no research/problems/erdos-1064-oq-03/ state and no recorded blocker; blocked status inherited without reason — needs seeker re-grounding (triage #43007, 2026-07-23)
+- **erdos-1093-oq-02** (sig 4): state.md is Phase BLOCKED without a recorded blocker; needs per-problem re-triage before serving (triage #43007, 2026-07-23)
+
+## Reconciled to graduated per registry (5)
+
+- **cevas-theorem-oq-01-oq-01** (sig 7)
+- **greens-theorem-oq-02-oq-02** (sig 7)
+- **tietze-extension-theorem-oq-01-oq-02** (sig 6)
+- **wilson-theorem-oq-01** (sig 6)
+- **spherical-law-of-sines-oq-03** (sig 5)
+
+## Skipped as duplicate (1)
+
+- **dilworth-theorem-oq-01-oq-03** (sig 6): Duplicate of completed work under sibling slugs dilworth-theorem-oq-01 and dilworth-theorem-oq-01-oq-01-oq-02 (state.md: SURVEYED, do not build) (triage #43007, 2026-07-23)
+
+## Post-triage pool state
+
+- 261 available (was 207), 31 blocked (was 91), 145 graduated, 17 skipped, 102 in-progress, 3631 completed
+- Available at sig>=8: szemeredi-full-oq-01 (9), amgm-inequality-oq-04-oq-03 (9),
+  bertrands-postulate-oq-02 (8), fundamental-theorem-calculus-oq-02-incomplete-01 (8),
+  euler-polyhedral-formula-oq-02-oq-01-wip-01 (8), ballot-problem-oq-03-oq-01-oq-02-incomplete-01 (8)
+- Blocked at sig>=8 (all with specific reasons): euler-polyhedral-formula-oq-02-oq-01-oq-01 (9,
+  Mathlib Riemannian-geometry gap), sperner-ndim-oq-05 (8, human-only upstream Mathlib PR),
+  algebraic-numbers-countable-oq-03 (8, Gelfond–Schneider transcendence gap)
+- 0 blocked entries with template-placeholder reasons
+
+## Persistence
+
+Verified by simulating a full Seeker cycle (`sync-db-status-from-registry.py` +`sync_pool.py`)
+against the triaged DB and the patched registry: the reconciler makes 0 changes and the
+regenerated pool preserves every disposition.
+
+**Pre-merge caveat**: until the registry.json flip in this PR lands on main (and reaches the
+main checkout the Seeker runs from), the live reconciler will re-block the 37 unblocked rows
+whose registry status was still `blocked`. The triage script is idempotent — after merge, run
+once from the repo root to heal any re-blocked rows:
+
+```bash
+python3 scripts/research/triage-blocked-pool.py --apply && python3 research/db/sync_pool.py
+```

--- a/research/registry.json
+++ b/research/registry.json
@@ -69,7 +69,7 @@
       "phase": "NEW",
       "path": "full",
       "started": "2026-04-26T10:54:44.961Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-24T23:25:31.254Z"
     },
     {
@@ -872,7 +872,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-04-04T09:42:47.007Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-04-04T09:42:47.024Z"
     },
     {
@@ -2358,7 +2358,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.882Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T12:52:51.882Z"
     },
     {
@@ -2731,7 +2731,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-04-22T13:25:38.489Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T00:00:00.000Z"
     },
     {
@@ -3890,7 +3890,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-04-14T17:49:44.227Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-02T00:00:00Z"
     },
     {
@@ -4280,7 +4280,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.887Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T12:52:52.117Z"
     },
     {
@@ -6366,7 +6366,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.912Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T12:52:52.129Z"
     },
     {
@@ -6991,7 +6991,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:52.056Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T14:53:03.185Z"
     },
     {
@@ -8054,7 +8054,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:52.056Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T14:53:03.185Z"
     },
     {
@@ -9475,7 +9475,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-04-26T14:51:07.083Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-05-16T22:05:00.000Z"
     },
     {
@@ -11666,7 +11666,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-04-13T22:43:37.485Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T00:00:00.000Z"
     },
     {
@@ -14931,7 +14931,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.938Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T12:52:52.134Z"
     },
     {
@@ -15388,7 +15388,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-05-12T15:34:56-07:00",
-      "status": "blocked"
+      "status": "active"
     },
     {
       "slug": "erdos-736",
@@ -16506,7 +16506,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.899Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T12:52:52.124Z"
     },
     {
@@ -16719,7 +16719,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-04-04T09:42:47.007Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T00:00:00.000Z"
     },
     {
@@ -17806,7 +17806,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-04-03T10:50:50.309Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-04-03T10:50:50.324Z"
     },
     {
@@ -17913,7 +17913,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:52.056Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T14:53:03.186Z"
     },
     {
@@ -17921,7 +17921,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.933Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T12:52:52.132Z"
     },
     {
@@ -18261,7 +18261,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.900Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T12:52:52.126Z"
     },
     {
@@ -18350,7 +18350,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.956Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T12:52:52.138Z"
     },
     {
@@ -18358,7 +18358,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.918Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T12:52:52.129Z"
     },
     {
@@ -18483,7 +18483,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.952Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T12:52:52.137Z"
     },
     {
@@ -18775,7 +18775,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.935Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T12:52:52.133Z"
     },
     {
@@ -19405,7 +19405,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.929Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T12:52:51.929Z"
     },
     {
@@ -21273,7 +21273,7 @@
       "phase": "BLOCKED",
       "path": "fast",
       "started": "2026-05-12T13:53:32-07:00",
-      "status": "blocked"
+      "status": "active"
     },
     {
       "slug": "napoleons-theorem-oq-01",
@@ -22265,7 +22265,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.948Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T12:52:52.136Z"
     },
     {
@@ -22885,7 +22885,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-04-03T10:50:50.309Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-04-03T10:50:50.324Z"
     },
     {
@@ -22920,7 +22920,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.899Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T12:52:52.124Z"
     },
     {
@@ -23133,7 +23133,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.889Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T12:52:52.121Z"
     },
     {
@@ -23383,7 +23383,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-05-12T15:34:56-07:00",
-      "status": "blocked"
+      "status": "active"
     },
     {
       "slug": "shapley-folkman-oq-02",
@@ -23622,7 +23622,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.827Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T12:52:52.111Z"
     },
     {
@@ -23888,7 +23888,7 @@
       "phase": "ACT",
       "path": "full",
       "started": "2026-06-13T12:52:51.950Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T00:00:00.000Z"
     },
     {
@@ -24130,7 +24130,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.946Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T12:52:52.135Z"
     },
     {
@@ -24826,7 +24826,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.946Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T12:52:52.135Z"
     },
     {
@@ -25058,7 +25058,7 @@
       "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.899Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-06-13T12:52:52.125Z"
     },
     {
@@ -26015,7 +26015,7 @@
       "phase": "OBSERVE",
       "path": "full",
       "started": "2026-06-23T09:12:19.106Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-07-10T00:01:19.626Z"
     },
     {
@@ -34229,7 +34229,7 @@
       "phase": "NEW",
       "path": "full",
       "started": "2026-07-02T05:53:08.469Z",
-      "status": "blocked",
+      "status": "active",
       "lastUpdate": "2026-07-02T05:53:08.469Z"
     },
     {

--- a/scripts/research/triage-blocked-pool.py
+++ b/scripts/research/triage-blocked-pool.py
@@ -49,15 +49,21 @@ Usage:
 """
 
 import json
+import os
 import shutil
 import sqlite3
 import sys
 from pathlib import Path
 
+# The live knowledge.db exists ONLY in the main checkout (gitignored runtime
+# state), while a triage PR is developed in a worktree. Env overrides let the
+# worktree copy of this script operate on the live DB / a specific registry.
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
-DB_PATH = REPO_ROOT / "research" / "db" / "knowledge.db"
-REGISTRY_PATH = REPO_ROOT / "research" / "registry.json"
-BACKUP_PATH = REPO_ROOT / "research" / "db" / "knowledge.db.pre-triage-issue43007"
+DB_PATH = Path(os.environ.get(
+    "LEAN_TRIAGE_DB", REPO_ROOT / "research" / "db" / "knowledge.db"))
+REGISTRY_PATH = Path(os.environ.get(
+    "LEAN_TRIAGE_REGISTRY", REPO_ROOT / "research" / "registry.json"))
+BACKUP_PATH = DB_PATH.with_name(DB_PATH.name + ".pre-triage-issue43007")
 
 TRIAGE_TAG = "(triage #43007, 2026-07-23)"
 

--- a/scripts/research/triage-blocked-pool.py
+++ b/scripts/research/triage-blocked-pool.py
@@ -1,0 +1,636 @@
+#!/usr/bin/env python3
+"""
+Triage of the 91 blocked candidate-pool problems (issue #43007, epic #43004).
+
+The candidate pool served to Researchers (.lean/state/candidate-pool.json) is
+regenerated every Seeker cycle by research/db/sync_pool.py from
+research/db/knowledge.db (gitignored runtime state, the source of truth for
+pool status). A 2026-06-13/14 host verification blackout (Docker daemon hung +
+Aristotle backend 404) caused dozens of problems to be flagged `blocked`; the
+blackout ended weeks ago but nothing ever unblocked them. Several other rows
+were blocked with a literal unfilled template ("[Explain what we're trying to
+prove in accessible terms]") as their pool-visible reason, or with no reason
+at all.
+
+This script applies a reviewed, per-slug disposition table (see issue #43007
+and research/notes/blocked-pool-triage-2026-07-23.md for the rationale):
+
+  * available  — the recorded blocker is gone (Docker is back, .lake symlink
+                 loop fixed, parent files repaired/migrated in #37676/#39062)
+                 or none ever existed. Row returns to the servable pool.
+  * blocked    — a genuine blocker exists (Mathlib gap, open mathematics,
+                 human-only step, ungrounded stub). current_blockers is
+                 rewritten to a concrete, specific reason.
+  * graduated  — the git-tracked registry already records the problem as
+                 graduated; the DB row is reconciled to the terminal status
+                 (sync-db-status-from-registry.py only reconciles *servable*
+                 rows, so blocked->graduated needs this one-time fix).
+  * skipped    — duplicate of completed sibling slugs; never serve.
+
+Placeholder / corrupted statement_plain values are replaced with real
+statements sourced from each problem's research/problems/<slug>/problem.md.
+
+The script also flips registry.json entries from `blocked` to `active` for
+rows returned to `available`: launch-seeker.sh runs
+scripts/research/sync-db-status-from-registry.py before every pool regen,
+which would otherwise copy the stale registry `blocked` right back onto the
+freshly unblocked (servable) DB row.
+
+Idempotent and safe to re-run: status changes only apply to rows still in the
+source status ('blocked'), statement replacements only fire while the current
+statement is empty/placeholder/corrupted, and the DB is backed up alongside
+itself once (knowledge.db.pre-triage-issue43007).
+
+Usage:
+    python3 scripts/research/triage-blocked-pool.py --dry-run   # report only
+    python3 scripts/research/triage-blocked-pool.py --apply     # write DB + registry
+    # then regenerate the pool:
+    python3 research/db/sync_pool.py
+"""
+
+import json
+import shutil
+import sqlite3
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DB_PATH = REPO_ROOT / "research" / "db" / "knowledge.db"
+REGISTRY_PATH = REPO_ROOT / "research" / "registry.json"
+BACKUP_PATH = REPO_ROOT / "research" / "db" / "knowledge.db.pre-triage-issue43007"
+
+TRIAGE_TAG = "(triage #43007, 2026-07-23)"
+
+# Statement placeholders that may be overwritten by a real statement.
+PLACEHOLDER_STATEMENTS = {
+    "",
+    "[Explain what we're trying to prove in accessible terms]",
+    "AVAILABLE",
+    "BLOCKED: BLOCKED: AVAILABLE: AVAILABLE",
+}
+
+# ---------------------------------------------------------------------------
+# Disposition table. Keys: every slug with status='blocked' in knowledge.db at
+# triage time (91 rows, 2026-07-23). Values:
+#   action:    'available' | 'blocked' | 'graduated' | 'skipped'
+#   reasons:   list[str] — new current_blockers (only for action='blocked'/'skipped')
+#   statement: replacement statement_plain (applied only over placeholders)
+#   next:      next_action to set
+# ---------------------------------------------------------------------------
+D = {
+    # ------------------------------------------------------------------ sig 9
+    "amgm-inequality-oq-04-oq-03": {
+        "action": "available",
+        "statement": (
+            "Prove Gauss's AGM theorem M(a,b) = a*pi/(2K(k')) with "
+            "k' = sqrt(1-k^2), k = b/a, via the hypergeometric identity "
+            "K(k) = (pi/2) * 2F1(1/2,1/2;1;k^2)."
+        ),
+        # Blocked 2026-06-13 solely by the Docker/Aristotle verification
+        # blackout; every discharge leg was build-gated. Docker is back.
+    },
+    "szemeredi-full-oq-01": {
+        "action": "available",
+        "next": (
+            "Verify parent build first: the recorded 28-error regression in "
+            "Proofs.FurstenbergCorrespondenceOQ01 predates the v4.26->v4.31 "
+            "toolchain migration (#39062) which touched the file; run "
+            "./proofs/scripts/docker-build.sh Proofs.FurstenbergCorrespondenceOQ01 "
+            "and resume the S13 roadmap if green " + TRIAGE_TAG
+        ),
+    },
+    "euler-polyhedral-formula-oq-02-oq-01-oq-01": {
+        "action": "blocked",
+        "statement": (
+            "Full smooth Gauss-Bonnet from first principles: for a compact "
+            "Riemannian 2-manifold M with boundary, "
+            "integral_M K dA + integral_dM k_g ds = 2*pi*chi(M)."
+        ),
+        "reasons": [
+            "Mathlib gap: no Gaussian curvature, geodesic curvature, Riemannian "
+            "area form, manifold integration, or Stokes for "
+            "manifolds-with-boundary; re-survey when these land in Mathlib "
+            + TRIAGE_TAG
+        ],
+    },
+    # ------------------------------------------------------------------ sig 8
+    "algebraic-numbers-countable-oq-03": {
+        "action": "blocked",
+        "reasons": [
+            "Gelfond-Schneider transcendence requires machinery absent from "
+            "Mathlib (even Hermite-Lindemann is gated on upstream Mathlib PR "
+            "#28013, cf. nth-root-irrational-oq-03); also no problem.md "
+            "grounding under research/problems/ " + TRIAGE_TAG
+        ],
+    },
+    "ballot-problem-oq-03-oq-01-oq-02-incomplete-01": {
+        "action": "available",
+        "next": (
+            "Discharge the multi-corner GNW-exchange sorry (~150-200 LOC): "
+            "prove the cross-product identity "
+            "F(mu,c1)*F(mu\\c1,c2) = F(mu,c2)*F(mu\\c2,c1) by induction on "
+            "|mu| (GNW 1979), then alpha determination; verify PR #15599 "
+            "single-corner build first " + TRIAGE_TAG
+        ),
+    },
+    "bertrands-postulate-oq-02": {"action": "available"},
+    "euler-polyhedral-formula-oq-02-oq-01-wip-01": {
+        "action": "available",
+        "statement": (
+            "WIP completion of the smooth Gauss-Bonnet gallery proof "
+            "(euler-polyhedral-formula-oq-02-oq-01): derive "
+            "gauss_bonnet_polygon from gauss_bonnet_boundary via a "
+            "GeodesicPolygon.toBoundary coercion (~10 LOC S4 ACT)."
+        ),
+    },
+    "fundamental-theorem-calculus-oq-02-incomplete-01": {
+        "action": "available",
+        "statement": (
+            "Generalized Stokes theorem companion (fundamental-theorem-calculus"
+            "-oq-02): create IteratedFDerivSymmetric.lean supporting lemmas "
+            "toward the exterior-derivative machinery."
+        ),
+    },
+    "sperner-ndim-oq-05": {
+        "action": "blocked",
+        "reasons": [
+            "Human-only step: refresh rjwalters/mathlib4:sperner-abstract-parity "
+            "with current SpernerMathlib4.lean and submit the upstream Mathlib "
+            "PR (ref mathlib4#25231); no research-agent action possible until "
+            "then " + TRIAGE_TAG
+        ],
+    },
+    # ------------------------------------------------------------------ sig 7
+    "ballot-problem-oq-02-oq-05": {"action": "available"},
+    "basel-problem-oq-01-oq-01-oq-02-oq-02": {"action": "available"},
+    "bertrands-postulate-oq-01": {
+        "action": "blocked",
+        "reasons": [
+            "Cramer's conjecture is open mathematics (1936; provable under RH "
+            "only) — removing axiom cramer_conjecture is infeasible for any "
+            "agent; Mathlib also lacks PNT-strength analytic number theory "
+            + TRIAGE_TAG
+        ],
+    },
+    "birthday-problem-oq-03-oq-01-oq-02-oq-01": {"action": "available"},
+    "cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-01-oq-01": {
+        "action": "available",
+        "next": "Begin problem exploration (state.md: phase NEW, no blockers) "
+        + TRIAGE_TAG,
+    },
+    "cevas-theorem-oq-01-oq-01": {"action": "graduated"},
+    "cevas-theorem-oq-01-oq-02": {
+        "action": "blocked",
+        "reasons": [
+            "Ungrounded stub: no research/problems/cevas-theorem-oq-01-oq-02/ "
+            "directory (no problem.md or state.md); needs seeker re-grounding "
+            "before serving " + TRIAGE_TAG
+        ],
+    },
+    "erdos-1151-oq-04": {"action": "available"},
+    "erdos-1168-oq-04": {
+        "action": "blocked",
+        "statement": "",
+        "reasons": [
+            "Ungrounded seeker stub: no research/problems/erdos-1168-oq-04/"
+            "problem.md; demoted by seeker 2026-06-16; needs re-grounding "
+            + TRIAGE_TAG
+        ],
+    },
+    "erdos-1210": {"action": "available"},
+    "erdos-166-oq-04": {
+        "action": "blocked",
+        "statement": "",
+        "reasons": [
+            "Ungrounded seeker stub: no research/problems/erdos-166-oq-04/"
+            "problem.md; demoted by seeker 2026-06-16; needs re-grounding "
+            + TRIAGE_TAG
+        ],
+    },
+    "erdos-476-oq-05-incomplete-01": {
+        "action": "blocked",
+        "reasons": [
+            "Ungrounded seeker stub: no research/problems/erdos-476-oq-05-"
+            "incomplete-01/problem.md; demoted by seeker 2026-06-16; needs "
+            "re-grounding " + TRIAGE_TAG
+        ],
+    },
+    "erdos-604-incomplete-01": {
+        "action": "blocked",
+        "reasons": [
+            "Mathlib gap: Landau-Ramanujan density theorem absent; workable "
+            "fallback per state.md is axiomatizing it as a named hypothesis "
+            "(status: axiomatized, blocker disclosed) " + TRIAGE_TAG
+        ],
+    },
+    "erdos-998-oq-02": {
+        "action": "blocked",
+        "statement": "",
+        "reasons": [
+            "Ungrounded seeker stub: no research/problems/erdos-998-oq-02/"
+            "problem.md; demoted by seeker 2026-06-16; needs re-grounding "
+            + TRIAGE_TAG
+        ],
+    },
+    "erdos-szekeres-oq-03": {"action": "available"},
+    "four-square-distribution-oq-01": {
+        "action": "blocked",
+        "reasons": [
+            "Mathlib gap: no q-expansion/Fourier-coefficient machinery for "
+            "jacobiTheta and no Eisenstein-coefficient identification "
+            "(theta^4 vs E2(tau) - 4*E2(4tau)) " + TRIAGE_TAG
+        ],
+    },
+    "greens-theorem-oq-02-oq-02": {"action": "graduated"},
+    "hilbert-11-oq-02": {
+        "action": "blocked",
+        "reasons": [
+            "Mathlib gap: Hasse-Weil bound for genus-1 curves over F_p absent — "
+            "the unconditional Case-B universal theorem is multi-session "
+            "Mathlib-scale work " + TRIAGE_TAG
+        ],
+    },
+    "hurwitz-theorem-wip-01": {
+        "action": "blocked",
+        "reasons": [
+            "Mathlib gap: no classical Frobenius theorem for real division "
+            "algebras (finite-dim associative division algebra over R has "
+            "finrank in {1,2,4}); verified absent 2026-05-08 " + TRIAGE_TAG
+        ],
+    },
+    "inclusion-exclusion-oq-01-oq-02": {
+        "action": "blocked",
+        "statement": "",
+        "reasons": [
+            "Ungrounded: no research/problems/inclusion-exclusion-oq-01-oq-02/ "
+            "directory and corrupted statement metadata; needs seeker "
+            "re-grounding " + TRIAGE_TAG
+        ],
+    },
+    "konigsberg-oq-03-wip-01": {
+        "action": "available",
+        "statement": (
+            "Complete the WIP proof 'Eulerian Paths in Hypergraphs and Infinite "
+            "Graphs' (konigsberg-oq-03): file is 0-sorry/0-axiom; pursue the S8 "
+            "candidate-menu extensions."
+        ),
+    },
+    "minkowski-fundamental-theorem-oq-06": {"action": "available"},
+    "nth-root-irrational-oq-03": {
+        "action": "blocked",
+        "reasons": [
+            "Hermite-Lindemann discharge gated on upstream Mathlib PR #28013; "
+            "remaining S5d path needs continued-fraction API absent from the "
+            "pinned Mathlib " + TRIAGE_TAG
+        ],
+    },
+    "prob-method-lovasz-local-oq-01": {"action": "available"},
+    "roth-theorem-k3-oq-03-incomplete-01": {
+        "action": "available",
+        "statement": (
+            "Density increment via Gowers norms: companion to "
+            "Proofs.RothTheoremOQ03 (roth-theorem-k3-oq-03)."
+        ),
+        "next": (
+            "Verify parent build first: the recorded v4.26 API-drift errors in "
+            "Proofs.RothTheoremOQ03 predate the #37676 drift repair and the "
+            "v4.31 migration (#39062); run ./proofs/scripts/docker-build.sh "
+            "Proofs.RothTheoremOQ03, then resume the companion roadmap "
+            + TRIAGE_TAG
+        ),
+    },
+    "roth-theorem-oq-02": {"action": "available"},
+    "sperner-ndim-mathlib-oq-02": {
+        "action": "available",
+        "next": (
+            "Verify parent build first: the recorded 100+ v4.26-drift errors in "
+            "SpernerFreudenthalSimplex.lean predate the v4.31 migration "
+            "(#39062) which touched the file; run ./proofs/scripts/"
+            "docker-build.sh Proofs.SpernerFreudenthalSimplex and resume the "
+            "rebase queue if green " + TRIAGE_TAG
+        ),
+    },
+    "sum-of-divisors-oq-02": {"action": "available"},
+    # -------------------------------------------------------- sig NULL (deep OQ)
+    "halting-problem-oq-03": {"action": "available"},
+    "motivic-flag-maps-oq-03": {"action": "available"},
+    "weak-goldbach-oq-03": {"action": "available"},
+    # ------------------------------------------------------------------ sig 6
+    "abel-ruffini-galois-extensions-oq-05": {
+        "action": "available",
+        "next": "Begin problem exploration (state.md: phase NEW, blockers: none) "
+        + TRIAGE_TAG,
+    },
+    "abel-ruffini-oq-08": {
+        "action": "available",
+        "next": "Resume OBSERVE (state.md: blockers none) " + TRIAGE_TAG,
+    },
+    "algebraic-numbers-countable-oq-02-oq-01": {
+        "action": "blocked",
+        "reasons": [
+            "Ungrounded: no research/problems/algebraic-numbers-countable-oq-02-"
+            "oq-01/ state; blocked in registry with no recorded reason; needs "
+            "re-triage/grounding " + TRIAGE_TAG
+        ],
+    },
+    "binomial-theorem-oq-02-oq-01-oq-01-oq-03": {"action": "available"},
+    "bounded-prime-gaps-oq-03-oq-02": {"action": "available"},
+    "cantor-diagonalization-oq-01-oq-01-oq-02-oq-01": {
+        "action": "blocked",
+        "reasons": [
+            "At axiom floor: 4 genuine Easton-1970 realizability axioms require "
+            "class-forcing infrastructure absent from Mathlib (multi-year); "
+            "no session-sized discharge exists " + TRIAGE_TAG
+        ],
+    },
+    "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01-oq-01": {
+        "action": "available"
+    },
+    "cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01": {
+        "action": "available",
+        "next": (
+            "Discharge skolemNoether_module_iso (Wedderburn-Artin + isotypic "
+            "module isomorphism, ~200-300 LOC — research-hard but no external "
+            "blocker now that Docker is back) " + TRIAGE_TAG
+        ),
+    },
+    "central-limit-theorem-oq-01-oq-01-oq-04-oq-01": {"action": "available"},
+    "dilworth-theorem-oq-01-oq-03": {
+        "action": "skipped",
+        "reasons": [
+            "Duplicate of completed work under sibling slugs dilworth-theorem-"
+            "oq-01 and dilworth-theorem-oq-01-oq-01-oq-02 (state.md: SURVEYED, "
+            "do not build) " + TRIAGE_TAG
+        ],
+    },
+    "ehrhart-cube-proven-oq-05": {
+        "action": "blocked",
+        "reasons": [
+            "Soundness blocker: the S5 target picks_theorem_derived is FALSE as "
+            "stated (S4 OBSERVE, PR #23003 constant-curve/placement "
+            "counterexample); the proposition must be restated before any ACT "
+            + TRIAGE_TAG
+        ],
+    },
+    "erdos-1006-oq-01-oq-02": {"action": "available"},
+    "erdos-1036-oq-01-oq-01": {
+        "action": "blocked",
+        "reasons": [
+            "Ungrounded: no research/problems/erdos-1036-oq-01-oq-01/ state and "
+            "no recorded blocker; blocked status inherited without reason — "
+            "needs seeker re-grounding " + TRIAGE_TAG
+        ],
+    },
+    "erdos-1039-oq-04": {
+        "action": "blocked",
+        "reasons": [
+            "Ungrounded: no research/problems/erdos-1039-oq-04/ state and no "
+            "recorded blocker; blocked status inherited without reason — needs "
+            "seeker re-grounding " + TRIAGE_TAG
+        ],
+    },
+    "erdos-258-oq-01": {
+        "action": "blocked",
+        "reasons": [
+            "General non-monotone case is open mathematics (Erdős problem 258); "
+            "no state grounding recorded under research/problems/ " + TRIAGE_TAG
+        ],
+    },
+    "erdos-460-incomplete-01": {
+        "action": "blocked",
+        "reasons": [
+            "Ungrounded: no research/problems/erdos-460-incomplete-01/ state "
+            "and no recorded blocker; blocked status inherited without reason — "
+            "needs seeker re-grounding " + TRIAGE_TAG
+        ],
+    },
+    "erdos-659-oq-01-oq-02": {
+        "action": "available",
+        "next": (
+            "Resume S9 PREP ((5,7) axis-vs-plane mixed-modulus recipe); note "
+            "the lower-bound side must be axiomatised (no Mathlib Solymosi-Vu) "
+            + TRIAGE_TAG
+        ),
+    },
+    "erdos-735-oq-04": {"action": "available"},
+    "erdos-818-incomplete-01": {
+        "action": "blocked",
+        "reasons": [
+            "Elementary provable layer mined out across prior sessions; "
+            "remaining axioms are deep (vein saturated — see prior researcher "
+            "session records) " + TRIAGE_TAG
+        ],
+    },
+    "erdos-895-incomplete-01": {
+        "action": "blocked",
+        "reasons": [
+            "barber_theorem positive direction needs a >1000-line SAT/case "
+            "proof (graph space 2^(n choose 2), not decide-able, not "
+            "session-sized; Aristotle not a fit); counterexample direction "
+            "fully shipped; mined out across 7 sessions " + TRIAGE_TAG
+        ],
+    },
+    "erdos-szekeres-oq-02": {"action": "available"},
+    "fermat-defect-one-oq-02": {
+        "action": "available",
+        "next": (
+            "Resume ACT on the n=3 result (state.md: no blockers for n=3; the "
+            "n>=4 direction is abc/Pillai-hard and out of scope — do NOT "
+            "submit the headline sorry to Aristotle) " + TRIAGE_TAG
+        ),
+    },
+    "fodor-pressing-down-oq-04": {"action": "available"},
+    "gauss-wilson-non-cyclic-oq-02": {"action": "available"},
+    "gauss-wilson-non-cyclic-oq-03": {"action": "available"},
+    "general-quartic-oq-02": {"action": "available"},
+    "godel-second-incompleteness-oq02-oq-01": {
+        "action": "blocked",
+        "reasons": [
+            "init-gap phantom: no research/problems/godel-second-incompleteness-"
+            "oq02-oq-01/problem.md; demoted by seeker 2026-07-07; needs "
+            "re-grounding " + TRIAGE_TAG
+        ],
+    },
+    "godel-second-incompleteness-oq02-oq-02": {"action": "available"},
+    "greens-theorem-oq-01-oq-01-oq-02-oq-01": {"action": "available"},
+    "greens-theorem-oq-01-oq-01-oq-02-oq-02": {"action": "available"},
+    "hilbert-14-oq-04": {"action": "available"},
+    "infinitude-primes-4k1-oq-03": {
+        "action": "blocked",
+        "reasons": [
+            "Mathlib gap: the natural-density form requires an Ikehara/"
+            "Tauberian transfer absent from Mathlib " + TRIAGE_TAG
+        ],
+    },
+    "inverse-galois-d4-oq-03": {"action": "available"},
+    "kepler-conjecture-oq-03": {
+        "action": "blocked",
+        "reasons": [
+            "init-gap phantom: no research/problems/kepler-conjecture-oq-03/"
+            "problem.md; demoted by seeker 2026-07-07; needs re-grounding "
+            + TRIAGE_TAG
+        ],
+    },
+    "pell-equation-oq-05": {"action": "available"},
+    "prime-number-theorem-oq-01": {
+        "action": "blocked",
+        "reasons": [
+            "Target is the Riemann Hypothesis itself — open mathematics; no "
+            "formal proof path exists " + TRIAGE_TAG
+        ],
+    },
+    "product-of-segments-of-chords-oq-03": {"action": "available"},
+    "shannon-channel-coding-oq-02-oq-01-oq-01": {"action": "available"},
+    "shapley-folkman-oq-01": {"action": "available"},
+    "sperner-simplicial-instance-oq-01": {"action": "available"},
+    "sqrt2-minpoly-oq-03": {"action": "available"},
+    "tietze-extension-theorem-oq-01-oq-02": {"action": "graduated"},
+    "triangle-inequality-oq-04-oq-01": {"action": "available"},
+    "wilson-theorem-oq-01": {"action": "graduated"},
+    # ------------------------------------------------------------------ sig 5
+    "ballot-problem-oq-01-oq-02-oq-01-oq-02-oq-01": {"action": "available"},
+    "chinese-remainder-non-coprime-oq-01-oq-02": {"action": "available"},
+    "desargues-theorem-oq-02-oq-02": {"action": "available"},
+    "erdos-1002-oq-01-wip-01": {
+        "action": "blocked",
+        "reasons": [
+            "Ungrounded: no research/problems/erdos-1002-oq-01-wip-01/ state "
+            "and no recorded blocker; blocked status inherited without reason — "
+            "needs seeker re-grounding " + TRIAGE_TAG
+        ],
+    },
+    "spherical-law-of-sines-oq-03": {"action": "graduated"},
+    # ------------------------------------------------------------------ sig 4
+    "erdos-1064-oq-03": {
+        "action": "blocked",
+        "reasons": [
+            "Ungrounded: no research/problems/erdos-1064-oq-03/ state and no "
+            "recorded blocker; blocked status inherited without reason — needs "
+            "seeker re-grounding " + TRIAGE_TAG
+        ],
+    },
+    "erdos-1093-oq-02": {
+        "action": "blocked",
+        "reasons": [
+            "state.md is Phase BLOCKED without a recorded blocker; needs "
+            "per-problem re-triage before serving " + TRIAGE_TAG
+        ],
+    },
+}
+
+
+def main() -> None:
+    apply = "--apply" in sys.argv
+    dry_run = "--dry-run" in sys.argv or not apply
+
+    if not DB_PATH.exists():
+        print(f"Error: database not found at {DB_PATH}")
+        print("(knowledge.db is gitignored runtime state; run from the main "
+              "checkout where the live DB resides.)")
+        sys.exit(1)
+
+    if apply and not BACKUP_PATH.exists():
+        shutil.copy2(DB_PATH, BACKUP_PATH)
+        print(f"Backed up DB to {BACKUP_PATH}")
+
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+
+    cur.execute(
+        "SELECT slug, status, statement_plain, current_blockers, next_action "
+        "FROM problems WHERE status = 'blocked'"
+    )
+    blocked_rows = {r["slug"]: r for r in cur.fetchall()}
+
+    missing = sorted(set(blocked_rows) - set(D))
+    if missing:
+        print(f"WARNING: {len(missing)} blocked rows have NO disposition "
+              "(left untouched):")
+        for s in missing:
+            print(f"  {s}")
+
+    stats = {"available": 0, "blocked": 0, "graduated": 0, "skipped": 0,
+             "already-done": 0, "stmt-fixed": 0}
+    changes = []
+
+    for slug, d in sorted(D.items()):
+        row = blocked_rows.get(slug)
+        if row is None:
+            # Row no longer blocked (already applied, or claimed since).
+            stats["already-done"] += 1
+            continue
+
+        action = d["action"]
+        sets, args = [], []
+
+        if action != "blocked":
+            sets.append("status = ?")
+            args.append(action)
+        if action in ("blocked", "skipped") and d.get("reasons"):
+            sets.append("current_blockers = ?")
+            args.append(json.dumps(d["reasons"], ensure_ascii=False))
+        if action == "available":
+            # Clear stale blackout/blocker text on rows returning to the pool.
+            sets.append("current_blockers = ?")
+            args.append("[]")
+
+        stmt = d.get("statement")
+        if stmt is not None and (row["statement_plain"] or "").strip() in \
+                PLACEHOLDER_STATEMENTS:
+            sets.append("statement_plain = ?")
+            args.append(stmt)
+            stats["stmt-fixed"] += 1
+
+        nxt = d.get("next")
+        if nxt:
+            sets.append("next_action = ?")
+            args.append(nxt)
+
+        sets.append("last_updated = CURRENT_TIMESTAMP")
+        stats[action] += 1
+        changes.append((slug, action))
+        if apply:
+            cur.execute(
+                f"UPDATE problems SET {', '.join(sets)} WHERE slug = ? "
+                "AND status = 'blocked'",
+                (*args, slug),
+            )
+
+    # ---- registry.json: blocked -> active for rows returned to the pool ----
+    registry_flips = []
+    if REGISTRY_PATH.exists():
+        with open(REGISTRY_PATH) as f:
+            registry = json.load(f)
+        avail_slugs = {s for s, d in D.items() if d["action"] == "available"}
+        for p in registry.get("problems", []):
+            if p.get("slug") in avail_slugs and p.get("status") == "blocked":
+                registry_flips.append(p["slug"])
+                if apply:
+                    p["status"] = "active"
+        if apply and registry_flips:
+            with open(REGISTRY_PATH, "w") as f:
+                json.dump(registry, f, indent=2, ensure_ascii=False)
+                f.write("\n")
+
+    mode = "APPLY" if apply else "DRY-RUN"
+    print(f"[{mode}] triage-blocked-pool (issue #43007)")
+    print(f"  dispositions:      {len(D)}")
+    print(f"  currently blocked: {len(blocked_rows)}")
+    print(f"  -> available:      {stats['available']}")
+    print(f"  -> kept blocked:   {stats['blocked']} (reasons rewritten)")
+    print(f"  -> graduated:      {stats['graduated']}")
+    print(f"  -> skipped:        {stats['skipped']}")
+    print(f"  statements fixed:  {stats['stmt-fixed']}")
+    print(f"  already applied:   {stats['already-done']}")
+    print(f"  registry blocked->active flips: {len(registry_flips)}")
+
+    if apply:
+        conn.commit()
+        print("  DB committed.")
+        print("  Now regenerate the pool: python3 research/db/sync_pool.py")
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #43007 (Epic #43004, Phase 1)

## What this does

Triage of all 91 `status='blocked'` rows in the research candidate pool. The pool consumed by Researchers (`.lean/state/candidate-pool.json`) is regenerated every Seeker cycle by `research/db/sync_pool.py` from `research/db/knowledge.db` (gitignored runtime state) — so the fix is applied at that source, via a tracked, idempotent, reviewable script.

## Root causes found

1. **2026-06-13/14 verification blackout** (Docker daemon hung + Aristotle 404): ~40 rows blocked solely because no build route existed. Docker has been healthy for weeks; nothing ever unblocked them.
2. **Template placeholders**: 6 rows carried the literal `[Explain what we're trying to prove in accessible terms]` as `statement_plain` (the string the pool surfaces as the BLOCKED reason). Real statements restored from each `problem.md`.
3. **No reason at all**: ~20 rows had empty `current_blockers`; several had `state.md` explicitly saying "Blockers: None".
4. **Stale build-regression claims**: szemeredi-full-oq-01 / roth-theorem-k3-oq-03-incomplete-01 / sperner-ndim-mathlib-oq-02 cited v4.26-era parent errors predating the v4.31 migration (#39062; RothTheoremOQ03 also repaired in #37676). Returned with verify-parent-build-first next actions.
5. **Registry-terminal drift**: 5 rows graduated in the registry but stuck blocked in the DB; 1 duplicate row.

## Changes

- `scripts/research/triage-blocked-pool.py` (new, tracked): per-slug disposition table + apply logic. Idempotent; backs up the DB once (`knowledge.db.pre-triage-issue43007`); env overrides for worktree use; refuses nothing silently (warns on uncovered blocked rows).
- `research/registry.json`: 37 entries flipped `blocked` -> `active`. Required: `launch-seeker.sh` runs `sync-db-status-from-registry.py` before every pool regen, which copies registry `blocked` back onto servable DB rows — without this flip the unblocks revert within one Seeker cycle.
- `research/notes/blocked-pool-triage-2026-07-23.md`: full per-slug triage record.

Note: `research/candidate-pool.json` and `research/db/` are gitignored (#38387), so no generated JSON can be committed; the live DB and pool were updated operationally and the script is the durable artifact.

## Results (applied live, verified in regenerated pool)

- blocked 91 -> 31, available 207 -> 261, graduated +5, skipped +1
- **0 blocked entries with template-placeholder reasons**
- Available at sig>=8 (was 0): szemeredi-full-oq-01 (9), amgm-inequality-oq-04-oq-03 (9), bertrands-postulate-oq-02 (8), fundamental-theorem-calculus-oq-02-incomplete-01 (8), euler-polyhedral-formula-oq-02-oq-01-wip-01 (8), ballot-problem-oq-03-oq-01-oq-02-incomplete-01 (8)
- Kept blocked at sig>=8, each with a specific reason: euler-polyhedral-formula-oq-02-oq-01-oq-01 (9, Mathlib lacks Gaussian/geodesic curvature, area form, Stokes on manifolds-with-boundary), sperner-ndim-oq-05 (8, human-only upstream Mathlib PR submission), algebraic-numbers-countable-oq-03 (8, Gelfond-Schneider transcendence machinery absent; ungrounded)

## Persistence verification

Simulated a full Seeker cycle (`sync-db-status-from-registry.py` + `sync_pool.py`) against the triaged DB with the patched registry: reconciler makes **0 changes**, regenerated pool preserves every disposition.

**Pre-merge caveat**: until this registry flip reaches the main checkout, the live reconciler re-blocks the 37 unblocked rows whose registry status was still `blocked` (confirmed by dry-run). The script is idempotent — after merge, run once from the repo root:

```
python3 scripts/research/triage-blocked-pool.py --apply && python3 research/db/sync_pool.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
