### PR TITLE
Enrich area-of-circle-oq010: 5th keyInsight (98->100)

### DIFF
--- a/src/data/proofs/area-of-circle-oq010/meta.json
+++ b/src/data/proofs/area-of-circle-oq010/meta.json
@@ -94,7 +94,8 @@
       "Arc length and signed area are reparametrization invariants — the proof makes this a change-of-variables theorem rather than an axiom",
       "The signed-area case needs no monotonicity of φ: the Jacobian factor φ' enters linearly, so it survives even for non-monotone reparametrizations",
       "The derivative of a periodic function is periodic, and this alone (via periodic_deriv) lets the period-shift lemma close both integrals",
-      "Discharging the full `exists_nice_reparam` axiom additionally requires (i) a regularity field on the curve structure so the arc-length map is invertible by the inverse function theorem, and (ii) restating the axiom so the witness is literally γ∘φ — these invariance lemmas are the reusable analytic core of that remaining program"
+      "Discharging the full `exists_nice_reparam` axiom additionally requires (i) a regularity field on the curve structure so the arc-length map is invertible by the inverse function theorem, and (ii) restating the axiom so the witness is literally γ∘φ — these invariance lemmas are the reusable analytic core of that remaining program",
+      "The regularity hypotheses are minimal for what the integrands actually use: both `speedFn` and `areaFn` involve only first derivatives of x, y, so `ContDiff ℝ 1` on the coordinates and on φ suffices — no second-derivative or curvature assumption is needed even though φ is reparametrizing the curve"
     ],
     "prerequisites": [
       "Real analysis: derivatives, the chain rule, interval integrals",


### PR DESCRIPTION
Enrichment pass for area-of-circle-oq010. qualityBreakdown showed everything maxed except keyInsights at 8/10 (4 items, cap is 5). Added a 5th genuine insight, verified against the Lean source (proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01.lean): both speedFn and areaFn integrands use only first derivatives, so the ContDiff ℝ 1 hypotheses on x, y, φ are exactly what's needed — no curvature/second-derivative regularity, even though φ reparametrizes the curve.

No other fields touched; sections already at cap (5/5), historicalContext/conclusion/crossRefs unchanged.