### PR TITLE
audit: re-serve brouwer-fixed-point — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3645,9 +3645,9 @@
       "issues": []
     },
     "brouwer-fixed-point": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:47Z",
+      "lastAudited": "2026-07-24T04:55:22Z",
       "result": "clean"
     },
     "brouwer-fixed-point-oq-01": {


### PR DESCRIPTION
## Summary
- Re-served round-robin audit of `brouwer-fixed-point` (queue fully drained: 4811/4811 audited).
- Verified axiomCount (2), sorries (0), theoremCount (5), definitionCount (7) against `Proofs/BrouwerFixedPoint.lean`.
- Both `no_retraction_axiom` and `retraction_construction` are honestly disclosed (status=axiomatized, badge=axiom, assumptions field names both axioms).
- Companion `additionalFiles` (BrouwerFixedPointOQ01OQ02G8.lean, G10.lean) checked for undisclosed sorries/axioms/native_decide — none found.
- No issues found; tracker updated with fresh audit timestamp.

## Test plan
- [x] `grep` counts for axiom/theorem/def/sorry/native_decide against Lean source match meta.json
- [x] Prose (description, originalContributions, conclusion) matches Tier C axiomatized classification, no overclaiming