### PR TITLE
audit: mark binomial-theorem-oq-03 clean (reserve re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3071,9 +3071,9 @@
       "note": "native_decide confined to anonymous example sanity-checks; named theorems axiom-clean (verified global sweep 2026-06-24)"
     },
     "binomial-theorem-oq-03": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:47Z",
+      "lastAudited": "2026-07-24T04:58:01Z",
       "result": "clean"
     },
     "binomial-theorem-oq-03-oq-01": {


### PR DESCRIPTION
## Summary
Reserve-mode re-audit of `binomial-theorem-oq-03` (queue was fully drained: 4811/4811 audited, 0 with issues). Verified against `proofs/Proofs/BinomialTheoremOQ03.lean`:

- sorries: 0 (matches meta)
- axioms: 0, no `axiom` declarations (matches meta)
- theoremCount: 33, definitionCount: 2 (both match exactly)
- no `native_decide`, no `True`-stub theorems
- all 9 `originalContributions` entries correspond to real declarations in the file
- badge `mathlib` is appropriately conservative given the file's Mathlib dependencies (Nat.choose, Vandermonde, log derivative, etc.)

No integrity issues found. Result: clean.

## Test plan
- [x] `grep` verified sorry/axiom/native_decide/True-stub counts against source
- [x] Cross-checked `originalContributions` names against actual `theorem`/`def` declarations

🤖 Generated with [Claude Code](https://claude.com/claude-code)