### PR TITLE
Research: erdos-18-wip-01 - t=8 record-setter 256; sub-family engine; local uniqueness returns at t=7

### DIFF
--- a/proofs/Proofs/Erdos18WIP01.lean
+++ b/proofs/Proofs/Erdos18WIP01.lean
@@ -3024,9 +3024,12 @@ theorem hErdos_twotwenty_le : hErdos 220 ≤ 6 := by
   refine hErdos_le_of_witnesses_from {1, 2, 4, 5, 10, 11, 20, 44, 55, 110} ?_ ?_ <;> decide
 
 set_option maxRecDepth 40000 in
+set_option maxHeartbeats 800000 in
 /-- `hErdos 224 ≤ 5` — sub-family engine: the split 224 = 2*112 only gives <= 1+6 = 7; the engine recovers the tight 5.
 The kernel finds `≤ 5`-divisor representations of every `k < 224` inside the
-11-element coin chain below (`2^11 = 2048` subsets searched). -/
+11-element coin chain below (`2^11 = 2048` subsets searched — the heaviest
+decide in the octave, hence the raised heartbeat budget; no 10-element
+sub-family of the 11 proper divisors covers every target). -/
 theorem hErdos_twotwentyfour_le : hErdos 224 ≤ 5 := by
   refine hErdos_le_of_witnesses_from {1, 2, 4, 7, 8, 14, 16, 28, 32, 56, 112} ?_ ?_ <;> decide
 

--- a/proofs/Proofs/Erdos18WIP01.lean
+++ b/proofs/Proofs/Erdos18WIP01.lean
@@ -2830,4 +2830,419 @@ theorem record_index_six_not_locally_unique :
     ∃ m, IsPractical m ∧ 64 < m ∧ m < 128 ∧ hErdos m = 6 :=
   ⟨78, seventyeight_practical, by norm_num, by norm_num, hErdos_seventyeight⟩
 
+/-! ### The record-setter at `t = 8`: the sub-family upper engine and the octave `[128, 256)`
+
+The octave `[128, 256)` contains 25 practical numbers.  Fifteen admit a
+practical split `m = 2 * (m/2)` whose subadditive bound already lands at
+`<= 7`; the other ten (`140, 150, 162, 196, 198, 204, 210, 220, 228, 234`)
+are practically-unsplittable, and two of them (`210` with `d = 16`, and the
+split-but-loose `240` with `d = 20`) have divisor counts that make the full
+powerset search of `hErdos_le_of_witnesses` infeasible.  The *sub-family*
+engine below restricts the kernel search to a hand-picked coin chain
+`S ⊆ divisors m`, cutting the search space from `2^d(m)` to `2^|S|` subsets.
+Each sub-family was chosen so the kernel certifies the *tight* upper bound
+(the Python-computed true index), not merely `<= 7` — this is what makes the
+local-uniqueness theorem at the end of the section possible. -/
+
+/-- **Sub-family upper-bound engine**: like `hErdos_le_of_witnesses`, but the
+kernel searches only a chosen `S ⊆ divisors m` instead of the full divisor
+set.  For `m` with many divisors (`d(240) = 20`, `d(210) = 16`) the full
+powerset has up to `2^20` subsets and the plain engine's `decide` is
+infeasible; a well-chosen coin chain of 9-11 divisors certifies the same
+bound at `2^9`-`2^11` subsets. -/
+theorem hErdos_le_of_witnesses_from (S : Finset ℕ) {m t : ℕ}
+    (hS : S ⊆ divisors m)
+    (h : ∀ k ∈ Finset.range m, ∃ T ∈ S.powerset, T.card ≤ t ∧ T.sum id = k) :
+    hErdos m ≤ t := by
+  unfold hErdos
+  apply Finset.sup_le
+  intro k hk
+  obtain ⟨T, hTpow, hTcard, hTsum⟩ := h k hk
+  exact (repLength_le_of_witness ((Finset.mem_powerset.mp hTpow).trans hS)
+    hTsum).trans hTcard
+
+/-- `hErdos 132 ≤ 6` — subadditivity at the practical split `132 = 2 · 66`. -/
+theorem hErdos_onethirtytwo_le : hErdos 132 ≤ 6 := by
+  have h : hErdos (2 * 66) ≤ hErdos 2 + hErdos 66 :=
+    hErdos_mul_le two_practical sixtysix_practical
+  rw [hErdos_two, hErdos_sixtysix] at h
+  calc hErdos 132 = hErdos (2 * 66) := by norm_num
+    _ ≤ 1 + 5 := h
+    _ ≤ 6 := by norm_num
+
+/-- `hErdos 144 ≤ 6` — subadditivity at the practical split `144 = 2 · 72`. -/
+theorem hErdos_onefortyfour_le : hErdos 144 ≤ 6 := by
+  have h72p : IsPractical 72 := by
+    simpa using two_mul_practical thirtysix_practical
+  have h : hErdos (2 * 72) ≤ hErdos 2 + hErdos 72 :=
+    hErdos_mul_le two_practical h72p
+  have hhalf := hErdos_seventytwo_le
+  rw [hErdos_two] at h
+  have hm : hErdos 144 = hErdos (2 * 72) := by norm_num
+  omega
+
+/-- `hErdos 168 ≤ 6` — subadditivity at the practical split `168 = 2 · 84`. -/
+theorem hErdos_onesixtyeight_le : hErdos 168 ≤ 6 := by
+  have h84p : IsPractical 84 := by
+    simpa using two_mul_practical fortytwo_practical
+  have h : hErdos (2 * 84) ≤ hErdos 2 + hErdos 84 :=
+    hErdos_mul_le two_practical h84p
+  have hhalf := hErdos_eightyfour_le
+  rw [hErdos_two] at h
+  have hm : hErdos 168 = hErdos (2 * 84) := by norm_num
+  omega
+
+/-- `hErdos 180 ≤ 5` — subadditivity at the practical split `180 = 2 · 90`. -/
+theorem hErdos_oneeighty_le : hErdos 180 ≤ 5 := by
+  have h : hErdos (2 * 90) ≤ hErdos 2 + hErdos 90 :=
+    hErdos_mul_le two_practical ninety_practical
+  rw [hErdos_two, hErdos_ninety] at h
+  calc hErdos 180 = hErdos (2 * 90) := by norm_num
+    _ ≤ 1 + 4 := h
+    _ ≤ 5 := by norm_num
+
+/-- `hErdos 192 ≤ 6` — subadditivity at the practical split `192 = 2 · 96`. -/
+theorem hErdos_oneninetytwo_le : hErdos 192 ≤ 6 := by
+  have h96p : IsPractical 96 := by
+    simpa using two_mul_practical fortyeight_practical
+  have h : hErdos (2 * 96) ≤ hErdos 2 + hErdos 96 :=
+    hErdos_mul_le two_practical h96p
+  have hhalf := hErdos_ninetysix_le
+  rw [hErdos_two] at h
+  have hm : hErdos 192 = hErdos (2 * 96) := by norm_num
+  omega
+
+/-- `hErdos 216 ≤ 6` — subadditivity at the practical split `216 = 2 · 108`. -/
+theorem hErdos_twosixteen_le : hErdos 216 ≤ 6 := by
+  have h108p : IsPractical 108 := by
+    simpa using two_mul_practical fiftyfour_practical
+  have h : hErdos (2 * 108) ≤ hErdos 2 + hErdos 108 :=
+    hErdos_mul_le two_practical h108p
+  have hhalf := hErdos_onehundredeight_le
+  rw [hErdos_two] at h
+  have hm : hErdos 216 = hErdos (2 * 108) := by norm_num
+  omega
+
+/-- `hErdos 252 ≤ 5` — subadditivity at the practical split `252 = 2 · 126`. -/
+theorem hErdos_twofiftytwo_le : hErdos 252 ≤ 5 := by
+  have h : hErdos (2 * 126) ≤ hErdos 2 + hErdos 126 :=
+    hErdos_mul_le two_practical onetwentysix_practical
+  rw [hErdos_two, hErdos_onetwentysix] at h
+  calc hErdos 252 = hErdos (2 * 126) := by norm_num
+    _ ≤ 1 + 4 := h
+    _ ≤ 5 := by norm_num
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 140 ≤ 5` — sub-family engine: 140 = 2^2*5*7 has no practical split (70, 35, 28, 20, 10, 14 fail: 70 and 28 are not practical, the rest are odd or non-practical).
+The kernel finds `≤ 5`-divisor representations of every `k < 140` inside the
+9-element coin chain below (`2^9 = 512` subsets searched). -/
+theorem hErdos_oneforty_le : hErdos 140 ≤ 5 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 4, 5, 7, 20, 28, 35, 70} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 150 ≤ 5` — sub-family engine: 150 = 2*3*5^2 has no practical split (75, 50, 30-cofactor 5, 25, 15 all odd or non-practical).
+The kernel finds `≤ 5`-divisor representations of every `k < 150` inside the
+9-element coin chain below (`2^9 = 512` subsets searched). -/
+theorem hErdos_onefifty_le : hErdos 150 ≤ 5 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 3, 5, 6, 15, 25, 50, 75} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 156 ≤ 6` — sub-family engine: the split 156 = 2*78 only gives <= 1+6 = 7; the engine recovers the tight 6.
+The kernel finds `≤ 6`-divisor representations of every `k < 156` inside the
+9-element coin chain below (`2^9 = 512` subsets searched). -/
+theorem hErdos_onefiftysix_le : hErdos 156 ≤ 6 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 3, 4, 6, 12, 26, 39, 78} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 160 ≤ 5` — sub-family engine: the split 160 = 2*80 only gives <= 1+6 = 7; the engine recovers the tight 5.
+The kernel finds `≤ 5`-divisor representations of every `k < 160` inside the
+10-element coin chain below (`2^10 = 1024` subsets searched). -/
+theorem hErdos_onesixty_le : hErdos 160 ≤ 5 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 4, 5, 8, 10, 16, 32, 40, 80} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 162 ≤ 5` — sub-family engine: 162 = 2*3^4 has no practical split (81, 54, 27, 18-cofactor 9, all odd cofactors).
+The kernel finds `≤ 5`-divisor representations of every `k < 162` inside the
+9-element coin chain below (`2^9 = 512` subsets searched). -/
+theorem hErdos_onesixtytwo_le : hErdos 162 ≤ 5 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 3, 6, 9, 18, 27, 54, 81} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 176 ≤ 6` — sub-family engine: the split 176 = 2*88 only gives <= 1+6 = 7; the engine recovers the tight 6.
+The kernel finds `≤ 6`-divisor representations of every `k < 176` inside the
+9-element coin chain below (`2^9 = 512` subsets searched). -/
+theorem hErdos_oneseventysix_le : hErdos 176 ≤ 6 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 4, 8, 11, 16, 22, 44, 88} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 196 ≤ 6` — sub-family engine: 196 = 2^2*7^2 has no practical split (98, 49, 28, 14 are not practical or odd).
+The kernel finds `≤ 6`-divisor representations of every `k < 196` inside the
+8-element coin chain below (`2^8 = 256` subsets searched). -/
+theorem hErdos_oneninetysix_le : hErdos 196 ≤ 6 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 4, 7, 14, 28, 49, 98} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 198 ≤ 5` — sub-family engine: 198 = 2*3^2*11 has no practical split (99, 66-cofactor 3, 33, 22-cofactor 9, 18-cofactor 11 all involve an odd or non-practical part).
+The kernel finds `≤ 5`-divisor representations of every `k < 198` inside the
+10-element coin chain below (`2^10 = 1024` subsets searched). -/
+theorem hErdos_oneninetyeight_le : hErdos 198 ≤ 5 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 3, 6, 9, 11, 18, 33, 66, 99} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 200 ≤ 5` — sub-family engine: the split 200 = 2*100 only gives <= 1+6 = 7; the engine recovers the tight 5.
+The kernel finds `≤ 5`-divisor representations of every `k < 200` inside the
+10-element coin chain below (`2^10 = 1024` subsets searched). -/
+theorem hErdos_twohundred_le : hErdos 200 ≤ 5 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 4, 5, 8, 10, 25, 40, 50, 100} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 204 ≤ 6` — sub-family engine: 204 = 2^2*3*17 has no practical split (102, 51, 34, 17 are not practical or odd).
+The kernel finds `≤ 6`-divisor representations of every `k < 204` inside the
+9-element coin chain below (`2^9 = 512` subsets searched). -/
+theorem hErdos_twohundredfour_le : hErdos 204 ≤ 6 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 3, 6, 12, 17, 34, 51, 102} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 208 ≤ 6` — sub-family engine: the split 208 = 2*104 only gives <= 1+6 = 7; the engine recovers the tight 6.
+The kernel finds `≤ 6`-divisor representations of every `k < 208` inside the
+9-element coin chain below (`2^9 = 512` subsets searched). -/
+theorem hErdos_twohundredeight_le : hErdos 208 ≤ 6 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 4, 8, 13, 16, 26, 52, 104} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 210 ≤ 5` — sub-family engine: 210 = 2*3*5*7 has no practical split (every cofactor pair contains an odd number); d(210) = 16 makes the full powerset infeasible -- the first genuine use of the sub-family engine.
+The kernel finds `≤ 5`-divisor representations of every `k < 210` inside the
+10-element coin chain below (`2^10 = 1024` subsets searched). -/
+theorem hErdos_twohundredten_le : hErdos 210 ≤ 5 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 3, 7, 10, 15, 21, 42, 70, 105} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 220 ≤ 6` — sub-family engine: 220 = 2^2*5*11 has no practical split (110, 55, 44, 22, 20-cofactor 11 fail).
+The kernel finds `≤ 6`-divisor representations of every `k < 220` inside the
+10-element coin chain below (`2^10 = 1024` subsets searched). -/
+theorem hErdos_twotwenty_le : hErdos 220 ≤ 6 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 4, 5, 10, 11, 20, 44, 55, 110} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 224 ≤ 5` — sub-family engine: the split 224 = 2*112 only gives <= 1+6 = 7; the engine recovers the tight 5.
+The kernel finds `≤ 5`-divisor representations of every `k < 224` inside the
+11-element coin chain below (`2^11 = 2048` subsets searched). -/
+theorem hErdos_twotwentyfour_le : hErdos 224 ≤ 5 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 4, 7, 8, 14, 16, 28, 32, 56, 112} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 228 ≤ 6` — sub-family engine: 228 = 2^2*3*19 has no practical split (114, 57, 38, 19 are not practical or odd).
+The kernel finds `≤ 6`-divisor representations of every `k < 228` inside the
+9-element coin chain below (`2^9 = 512` subsets searched). -/
+theorem hErdos_twotwentyeight_le : hErdos 228 ≤ 6 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 3, 6, 12, 19, 38, 57, 114} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 234 ≤ 5` — sub-family engine: 234 = 2*3^2*13 has no practical split (117, 78-cofactor 3, 39, 26-cofactor 9, 18-cofactor 13 all involve an odd or non-practical part).
+The kernel finds `≤ 5`-divisor representations of every `k < 234` inside the
+10-element coin chain below (`2^10 = 1024` subsets searched). -/
+theorem hErdos_twothirtyfour_le : hErdos 234 ≤ 5 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 3, 6, 9, 13, 26, 39, 78, 117} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 240 ≤ 5` — sub-family engine: the split 240 = 2*120 only gives <= 1+6 = 7; the engine recovers the tight 5 (d(240) = 20 rules out the full powerset).
+The kernel finds `≤ 5`-divisor representations of every `k < 240` inside the
+10-element coin chain below (`2^10 = 1024` subsets searched). -/
+theorem hErdos_twoforty_le : hErdos 240 ≤ 5 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 4, 8, 16, 30, 40, 60, 80, 120} ?_ ?_ <;> decide
+
+set_option maxRecDepth 200000 in
+/-- **Every practical number below `256` other than `128` has index at most
+`6`.**  Below `128` this is `hErdos_le_six_of_lt_onetwentyeight`; in the
+octave `[128, 256)` the 24 practical numbers other than `128` are bounded by
+the tight engine values and subadditive splits above (each non-practical
+value excluded by a kernel `decide`).  This is strictly sharper than the
+threshold `≤ 7` needed for the record-setter: it says `128` is the ONLY
+index-`7` practical number in its octave — local uniqueness returns after
+failing at `t = 6` (`record_index_six_not_locally_unique`). -/
+theorem hErdos_le_six_of_lt_twofiftysix_of_ne {m : ℕ} (hm : IsPractical m)
+    (hlt : m < 256) (hne : m ≠ 128) : hErdos m ≤ 6 := by
+  by_cases h128 : m < 128
+  · exact hErdos_le_six_of_lt_onetwentyeight hm h128
+  · push Not at h128
+    interval_cases m
+    · exact absurd rfl hne
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_onethirtytwo_le
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_oneforty_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_onefortyfour_le
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_onefifty_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_onefiftysix_le
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_onesixty_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact hErdos_onesixtytwo_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_onesixtyeight_le
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_oneseventysix_le
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_oneeighty_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_oneninetytwo_le
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_oneninetysix_le
+    · exact absurd hm (by decide)
+    · exact hErdos_oneninetyeight_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact hErdos_twohundred_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_twohundredfour_le
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_twohundredeight_le
+    · exact absurd hm (by decide)
+    · exact hErdos_twohundredten_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_twosixteen_le
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_twotwenty_le
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_twotwentyfour_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_twotwentyeight_le
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_twothirtyfour_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_twoforty_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_twofiftytwo_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+
+/-- **Every practical number below `256` has index at most `7`.**  The octave
+threshold feeding the `t = 8` record-setter. -/
+theorem hErdos_le_seven_of_lt_twofiftysix {m : ℕ} (hm : IsPractical m)
+    (hlt : m < 256) : hErdos m ≤ 7 := by
+  by_cases h : m = 128
+  · subst h
+    simp [hErdos_onetwentyeight]
+  · exact (hErdos_le_six_of_lt_twofiftysix_of_ne hm hlt h).trans (by omega)
+
+/-- `256` is practical — the power-of-two family at `n = 8`. -/
+theorem twofiftysix_practical : IsPractical 256 := by
+  simpa using two_pow_practical 8
+
+/-- `hErdos 256 = 8` — the power-of-two formula at `k = 8`. -/
+theorem hErdos_twofiftysix : hErdos 256 = 8 := by
+  have h := hErdos_two_pow 8
+  norm_num at h
+  exact h
+
+/-- **Record-setter at `t = 8`: the least practical number with index `8` is
+`256 = 2⁸`.**  The record-setter sequence for `t = 1, …, 8` is
+`2, 4, 8, 16, 32, 64, 128, 256` — exactly the powers of two, now through five
+doublings past the last octave (`[32, 64)`) where the record was locally
+unique. -/
+theorem minimal_hErdos_eight :
+    IsLeast { m : ℕ | IsPractical m ∧ hErdos m = 8 } 256 := by
+  constructor
+  · exact ⟨twofiftysix_practical, hErdos_twofiftysix⟩
+  · rintro m ⟨hpr, h8⟩
+    by_contra hlt
+    push Not at hlt
+    have := hErdos_le_seven_of_lt_twofiftysix hpr hlt
+    omega
+
+/-- **Local uniqueness of the record RETURNS at `t = 7`**: `128` is the only
+practical number below `256` with index `7`.  Contrast with `t = 6`, where
+the record `64` shares its index with `78, 88, 100, 104`
+(`record_index_six_not_locally_unique`).  The four index-`6` ties of the
+previous octave all double into `[128, 256)` — `156, 176, 200, 208` — but
+each doubling DROPS the index bound below the crude subadditive `1 + 6`: the
+engine certifies `hErdos 156 ≤ 6`, `176 ≤ 6`, `200 ≤ 5`, `208 ≤ 6`, so none
+of them reaches `7`.  Uniqueness is local: nothing here rules out an
+index-`7` practical number above `256`. -/
+theorem record_index_seven_locally_unique :
+    ∀ m, IsPractical m → m < 256 → hErdos m = 7 → m = 128 := by
+  intro m hm hlt h7
+  by_contra hne
+  have := hErdos_le_six_of_lt_twofiftysix_of_ne hm hlt hne
+  omega
+
 end Erdos18

--- a/research/problems/erdos-18-wip-01/knowledge.md
+++ b/research/problems/erdos-18-wip-01/knowledge.md
@@ -526,3 +526,9 @@ targets are cheap standalones only for d ≤ 12 (le_hErdos_of_card is a FULL
 powerset decide — d(210)=16, d(240)=20 lower bounds need a restricted lower
 engine, which does NOT exist and is NOT a witness check: a lower bound must
 search all of divisors m). Deep Vose bound unchanged.
+
+Kernel-cost calibration (build-verified): sub-family engine decides fit the
+default 200000-heartbeat elaboration budget up to 2^10 subsets x ~230 targets;
+the single 2^11 run (224, 11 proper divisors, no 10-coin sub-family covers)
+needs `set_option maxHeartbeats 800000`. Budget scales with 2^|S| x m — plan
+t = 9 coin chains at |S| <= 10 where possible, or expect heartbeat bumps.

--- a/research/problems/erdos-18-wip-01/knowledge.md
+++ b/research/problems/erdos-18-wip-01/knowledge.md
@@ -481,3 +481,48 @@ engine uppers for 80, 112 (cheap, d = 10) and 120 (d(120) = 16 → 2¹⁵ subset
 instead: pass an explicit List of per-target witness subsets and decide a
 linear check, O(m) not O(m·2^d)). Exact 40/56/60 still cheap standalones.
 Deep Vose bound unchanged.
+
+## Session 2026-07-24 (researcher-1, fourth session) — t = 8 closed: minimal_hErdos_eight = 256; local uniqueness RETURNS at t = 7
+
+`minimal_hErdos_eight : IsLeast {m | IsPractical m ∧ hErdos m = 8} 256` —
+record-setter sequence now 2, 4, 8, 16, 32, 64, 128, 256 for t = 1..8, all
+0-axiom. Membership is free (two_pow_practical 8, hErdos_two_pow 8); the work
+is the octave threshold.
+
+Structural finding (reversal of the t = 6 anomaly): local uniqueness of the
+record RETURNS at t = 7 — `record_index_seven_locally_unique`: 128 is the ONLY
+practical m < 256 with index 7. The four index-6 ties of [64,128) double into
+156, 176, 200, 208, but every doubling drops strictly below the subadditive
+1 + 6 bound (engine: 156 ≤ 6, 176 ≤ 6, 200 ≤ 5, 208 ≤ 6). Proved via the
+strengthened threshold `hErdos_le_six_of_lt_twofiftysix_of_ne` (practical
+m < 256, m ≠ 128 ⟹ index ≤ 6), from which both the plain threshold
+`hErdos_le_seven_of_lt_twofiftysix` and uniqueness are one-liners.
+
+New engine: `hErdos_le_of_witnesses_from` (sub-family upper engine) — restricts
+the kernel witness search to a chosen S ⊆ divisors m, cutting 2^d(m) to 2^|S|.
+This unblocked d(210) = 16 and d(240) = 20, exactly as predicted last session.
+Sub-families were greedy-pruned by Python (min-card DP mirroring the decide
+semantics, random restarts for the heavy ones); all 17 engine runs certify the
+TIGHT Python index, |S| = 8..11, worst kernel cost 2^11 × 224.
+
+Octave census [128, 256): 25 practicals. 15 fall to the 2·m′ split (132, 144,
+168, 180, 192, 216, 252 land at ≤ 6 or ≤ 5 directly; 128 is the record); 10
+are practically-unsplittable (140, 150, 162, 196, 198, 204, 210, 220, 228,
+234 — engine). 7 splittable ones (156, 160, 176, 200, 208, 224, 240) needed
+the engine anyway because the crude split lands at 7. Upper bounds only this
+session (no exact values / lower bounds in [128,256) yet): 140:5 150:5 156:6
+160:5 162:5 196:6 198:5 200:5 204:6 208:6 210:5 220:6 224:5 228:6 234:5 240:5.
+
+Threshold sweep [128, 256) needs maxRecDepth 200000 (depth scales with m:
+40000 for (32,64), 80000 for (64,128)).
+
+NEXT: t = 9 sweeps [256, 512) — ~40+ practicals, splits should handle most
+(every m = 2m′ with m′ practical in [128,256) inherits ≤ 1+6 = 7 ≤ 8), but
+the unsplittable census must be counted first; d grows (d(360) = 24, d(420) =
+24) so the sub-family engine is now mandatory, and the octave may become the
+first where a NON-power-of-two ties the record (candidates: none known —
+check 2·gap-type numbers). Exact values/lower bounds for [128,256) hard
+targets are cheap standalones only for d ≤ 12 (le_hErdos_of_card is a FULL
+powerset decide — d(210)=16, d(240)=20 lower bounds need a restricted lower
+engine, which does NOT exist and is NOT a witness check: a lower bound must
+search all of divisors m). Deep Vose bound unchanged.

--- a/research/problems/erdos-18-wip-01/state.md
+++ b/research/problems/erdos-18-wip-01/state.md
@@ -95,3 +95,24 @@ Method: split-vs-engine dichotomy at scale — 7 splits (72, 80, 84, 96, 108,
 = 4). Threshold `hErdos_le_six_of_lt_onetwentyeight` needs maxRecDepth 80000.
 All 0-axiom. Next: t = 8 ([128, 256)); index-6 octave census (needs a
 witness-list engine for d(120) = 16); exact 40/56/60. Deep Vose unchanged.
+
+## Status (researcher-1, 2026-07-24, fourth session) — t = 8 closed: minimal_hErdos_eight = 256; local uniqueness returns at t = 7
+
+Phase ACT. `minimal_hErdos_eight : IsLeast {m | IsPractical m ∧ hErdos m = 8} 256`
+— record-setter sequence proved 2^t for t = 1..8, 0-axiom throughout.
+
+Structural finding: local uniqueness of the record RETURNS at t = 7
+(`record_index_seven_locally_unique`: 128 is the only practical m < 256 with
+index 7) after failing at t = 6. The t = 6 ties double into 156/176/200/208
+but the sub-family engine certifies ≤ 6, ≤ 6, ≤ 5, ≤ 6 — each doubling beats
+the subadditive bound strictly.
+
+New: `hErdos_le_of_witnesses_from` — sub-family upper engine (search a chosen
+S ⊆ divisors m, 2^|S| ≪ 2^d(m)); unblocked d(210) = 16, d(240) = 20. 17
+tight engine bounds + 7 splits cover the octave; threshold
+`hErdos_le_six_of_lt_twofiftysix_of_ne` needs maxRecDepth 200000.
+
+Next: t = 9 ([256, 512), sub-family engine mandatory, count unsplittables
+first); exact values in [128,256) blocked for d > 12 (no restricted LOWER
+engine exists — lower bounds must search the full powerset). Deep Vose
+unchanged.

--- a/src/data/research/problems/erdos-18-wip-01.json
+++ b/src/data/research/problems/erdos-18-wip-01.json
@@ -35,7 +35,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: record-setter sequence 2^t proved for t=1..7 (minimal_hErdos_two..seven); exact-value table now covers all 7 practically-unsplittable numbers in [64,128); STRUCTURAL: record ties found at t=6 (78, 88, 100, 104 all index 6) - local uniqueness fails, gap-type vs dense-type dichotomy of unsplittables; open: 2^t for all t (non-greedy log2 bound), octave index-6 census (needs witness-list engine for d(120)=16), exact 40/56/60, deep Vose bound",
+    "progressSummary": "PROGRESS: record-setter sequence 2^t proved for t=1..8 (minimal_hErdos_two..eight, all 0-axiom); STRUCTURAL: local uniqueness of the record returns at t=7 (128 alone below 256) after failing at t=6; new sub-family upper engine hErdos_le_of_witnesses_from unblocks d(210)=16/d(240)=20; next rung t=9 needs [256,512) sweep with unsplittable census first",
     "builtItems": [
       "decidableIsRepresentable / decidableIsPractical instances (Erdos18Problem.lean)",
       "zero_isRepresentable, one_isRepresentable, isRepresentable_self, isRepresentable_le_sigma, mem_divisors_le (Erdos18Problem.lean)",
@@ -74,7 +74,12 @@
       "Split bounds: hErdos 72<=5, 80<=6, 84<=5, 96<=5, 108<=5, 112<=6, 120<=6 via hErdos_mul_le through 2*m'",
       "record_index_six_not_locally_unique: exists m practical, 64 < m < 128, hErdos m = 6 (witness 78)",
       "Practicality decides: 40, 42, 54, 56, 60, 66, 78, 88, 90, 104, 126",
-      "hErdos_onetwentyeight: hErdos 128 = 7 via hErdos_two_pow"
+      "hErdos_onetwentyeight: hErdos 128 = 7 via hErdos_two_pow",
+      "hErdos_le_of_witnesses_from in Erdos18WIP01.lean - sub-family upper-bound engine (restrict kernel search to chosen S subset of divisors m)",
+      "24 octave upper bounds hErdos_onethirtytwo_le .. hErdos_twofiftytwo_le (7 subadditive splits + 17 tight sub-family engine runs) in Erdos18WIP01.lean",
+      "hErdos_le_six_of_lt_twofiftysix_of_ne + hErdos_le_seven_of_lt_twofiftysix (octave thresholds, 128-case interval_cases sweep) in Erdos18WIP01.lean",
+      "minimal_hErdos_eight : IsLeast {m | IsPractical m and hErdos m = 8} 256 in Erdos18WIP01.lean",
+      "record_index_seven_locally_unique + twofiftysix_practical + hErdos_twofiftysix in Erdos18WIP01.lean"
     ],
     "insights": [
       "Erdos18Problem.lean stub developed: representability (IsRepresentable) and practicality (IsPractical) are DECIDABLE via a finite powerset search over the divisor set — a single decision procedure subsuming all future example checks; all lemmas axiom-free (plain kernel decide, no native_decide/Lean.ofReduceBool).",
@@ -111,7 +116,12 @@
       "Unsplittable does NOT imply high index: 90 = 2*3^2*5 and 126 = 2*3^2*7 have eleven proper divisors but index only 4 - index tracks divisor gaps, not divisor count. Unsplittables bifurcate: gap-type (index ties record) vs dense-type (index low).",
       "78 = 2*3*13, the counterexample that breaks greedy halving for hErdos m <= log2 m, is also a record-tier: the same divisor gap drives both phenomena. Ties probe but do not breach the log bound (6 <= log2 78).",
       "Host pre-validation: replicate divisors/IsPractical + Decidable instances in a Mathlib-only scratch file and time all new decides before touching the real file - 14 engine + 12 practicality decides validated in ~45s, zero wasted Docker cycles.",
-      "Non-practicality decides in the threshold interval_cases need maxRecDepth 80000 for m in (64,128) (40000 sufficed for (32,64)) - recursion depth scales with m."
+      "Non-practicality decides in the threshold interval_cases need maxRecDepth 80000 for m in (64,128) (40000 sufficed for (32,64)) - recursion depth scales with m.",
+      "Local uniqueness of the record RETURNS at t=7: 128 is the only practical m<256 with index 7 (record_index_seven_locally_unique). The four t=6 ties (78,88,100,104) double into 156,176,200,208 but each doubling drops strictly below the subadditive 1+6 bound (engine: 156<=6, 176<=6, 200<=5, 208<=6)",
+      "Octave [128,256) census: 25 practicals; 15 fall to the 2*m-prime split, 10 practically-unsplittable (140,150,162,196,198,204,210,220,228,234); 7 splittable ones still need the engine for tight bounds because the crude split lands at 7",
+      "Sub-family engine unblocks large divisor counts: d(210)=16 and d(240)=20 make the full-powerset witness decide infeasible, but greedy-pruned coin chains of 8-11 divisors certify the tight bound at 2^8..2^11 subsets; sub-families found by Python min-card DP with random-restart greedy pruning",
+      "No restricted LOWER engine is possible by the same trick: an upper bound needs one witness family, a lower bound must search ALL of divisors m, so exact values for d>12 numbers in [128,256) stay open",
+      "Threshold decide depth scales linearly with octave top: maxRecDepth 40000 for (32,64), 80000 for (64,128), 200000 for (128,256)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -140,7 +150,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.780Z",
-  "lastUpdate": "2026-07-23",
+  "lastUpdate": "2026-07-24",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Research: erdos-18-wip-01 — t = 8 record-setter closed (256); sub-family upper engine; local uniqueness returns at t = 7

Build-verified in Docker (8577 jobs, exit 0) on this exact branch head.

### Results (all 0-axiom, kernel `decide`)

- `minimal_hErdos_eight : IsLeast {m | IsPractical m ∧ hErdos m = 8} 256` — record-setter sequence is now 2, 4, 8, 16, 32, 64, 128, 256 for t = 1..8.
- `record_index_seven_locally_unique` — 128 is the ONLY practical m < 256 with index 7 (local uniqueness RETURNS after the t = 6 anomaly of four ties). Every doubling of the [64,128) index-6 ties (156, 176, 200, 208) drops strictly below the subadditive bound.
- Strengthened threshold `hErdos_le_six_of_lt_twofiftysix_of_ne` (practical m < 256, m != 128 => index <= 6); plain threshold and uniqueness are one-liners from it.
- New engine `hErdos_le_of_witnesses_from` — restricts the kernel witness search to a chosen sub-family S of divisors m, cutting 2^d(m) to 2^|S|; unblocked d(210) = 16 and d(240) = 20. All 17 engine runs certify the tight Python-side index (|S| = 8..11, worst kernel cost 2^11 x 224 targets, `maxHeartbeats 800000` on the single 2^11 run).
- Octave census [128, 256): 25 practicals — 15 fall to the 2m' split, 10 practically-unsplittable handled by the engine; upper bounds recorded for all hard cases.

### Files

- `proofs/Proofs/Erdos18WIP01.lean` (+418)
- `research/problems/erdos-18-wip-01/knowledge.md`, `state.md`, tracker JSON

Next: t = 9 sweeps [256, 512) — sub-family engine now mandatory (d(360) = d(420) = 24); lower bounds for d > 12 targets need a restricted lower engine that does not yet exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
