### PR TITLE
Enrich arsinh-log-formula-oq-01-oq-02: split header docstring, close sections-count gap (98->100)

### DIFF
--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-02/meta.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-02/meta.json
@@ -86,12 +86,20 @@
   },
   "sections": [
     {
-      "id": "docstring",
-      "title": "Module Docstring: the arcosh Companion",
+      "id": "problem-statement",
+      "title": "Header: Problem Statement and Parent Context",
       "startLine": 1,
-      "endLine": 45,
-      "summary": "States the open question (arcosh logarithmic form + addition law as the cosh-side counterpart of the parent's arsinh entry) and enumerates the supplied theorems: the logarithmic form, the addition / subtraction / doubling laws, and the concrete logarithmic values.",
+      "endLine": 17,
+      "summary": "States the open question this file answers verbatim — the arcosh logarithmic form and addition law, the cosh-side counterpart of the parent's arsinh entry — and recalls the parent's arsinh theory (logarithmic form, addition/subtraction/doubling laws, concrete values) that this entry mirrors.",
       "mathContext": "$\\operatorname{arcosh} x = \\log(x + \\sqrt{x^2 - 1})$, the inverse of $\\cosh$ on $[1, \\infty)$."
+    },
+    {
+      "id": "mathlib-gap-and-setup",
+      "title": "Header: What Mathlib Lacks, Imports, and Namespace Setup",
+      "startLine": 18,
+      "endLine": 45,
+      "summary": "Notes that Mathlib defines Real.arcosh by the logarithmic form and supplies the inverse facts cosh_arcosh/sinh_arcosh/arcosh_cosh but no algebraic addition formulas, then enumerates the five theorems this file supplies. Followed by `import Mathlib`, the `ArsinhLogFormulaOQ01OQ02` namespace, and `open Real`.",
+      "mathContext": "$\\operatorname{arcosh} x + \\operatorname{arcosh} y = \\operatorname{arcosh}(xy + \\sqrt{x^2-1}\\sqrt{y^2-1})$"
     },
     {
       "id": "log-form",


### PR DESCRIPTION
Enrichment pass for arsinh-log-formula-oq-01-oq-02. qualityBreakdown showed everything maxed except sections at 8/10 (4 sections, cap is 5). Split the "docstring" section (lines 1-45) at the natural boundary between the problem statement/parent-context (1-17) and the "what Mathlib lacks" enumeration + imports/namespace setup (18-45), verified against proofs/Proofs/ArsinhLogFormulaOQ01OQ02.lean.

No other fields touched; keyInsights already at cap (5/5).