### PR TITLE
audit: mark binomial-theorem-oq-02 issues-fixed (reserve re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2944,10 +2944,10 @@
       "result": "clean"
     },
     "binomial-theorem-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:47Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T05:03:02Z",
+      "result": "issues-fixed"
     },
     "binomial-theorem-oq-02-oq-01": {
       "auditCount": 4,


### PR DESCRIPTION
Tracker update following #43045 (fixed phantom inductive-chain narrative overclaim).