### PR TITLE
audit: mark basel-problem-oq-02 clean (reserve re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2193,9 +2193,9 @@
       "result": "clean"
     },
     "basel-problem-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:47Z",
+      "lastAudited": "2026-07-24T05:06:05Z",
       "result": "clean"
     },
     "basel-problem-oq-03": {


### PR DESCRIPTION
## Summary
- Reserve re-audit (audit queue drained; round-robin re-serve of oldest entries).
- Verified `basel-problem-oq-02`: 5 axioms (all disclosed in `assumptions`/`mathlibDependencies`/prose: Lindemann, Apéry, Rivoal, Zudilin, Fischler-Sprang-Zudilin), 0 sorries, theoremCount 20 (19 public + 1 `private lemma`), definitionCount 6, no True stubs, no native_decide. `mainTheorems` names all resolve to real declarations. `status: "axiomatized"` / `badge: "axiom"` correctly reflects Tier C.
- No integrity issues found — result: clean.

## Test plan
- [x] `grep -n '^axiom'` on `proofs/Proofs/BaselProblemOQ02.lean` → 5, matches meta `axiomCount`
- [x] `grep -n sorry` → 0 hits, matches meta `sorries`
- [x] Companion file `BaselProblemOQ02Aristotle.lean` (disclosed in `additionalFiles`) is itself 0-axiom/0-sorry
- [x] `mainTheorems` entries (`zetaValue_two_transcendental`, `transcendental_pow_of_transcendental`, `even_odd_hierarchy`) all found in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)