### PR TITLE
Research: erdos-szekeres-oq-02 - computable incDP, realized witness, exact n(n-1)/2 cost

### DIFF
--- a/proofs/Proofs/ErdosSzekeresOQ02.lean
+++ b/proofs/Proofs/ErdosSzekeresOQ02.lean
@@ -1,0 +1,321 @@
+/-
+  The complexity of finding the actual monotonic subsequence — the computable layer
+  (Open Question OQ-02 of erdos-szekeres:
+   "What is the complexity of finding the actual monotonic subsequence?")
+
+  ## What this file establishes (0 sorry, 0 axiom)
+
+  The parent file `ErdosSzekeres.lean` measures longest increasing subsequences
+  through `maxIncLen f i = Nat.findGreatest (HasIncreasingEndingAt f i) (i.val + 1)`,
+  which is `noncomputable` (a Classical search over a `Prop` existential): the parent
+  can say a monotone subsequence *exists* but cannot produce one. OQ-02 asks how
+  expensive it is to actually *find* the subsequence. This file formalizes the
+  classical answer's elementary layer:
+
+    * `incDP` — a COMPUTABLE (no `noncomputable` marker) dynamic program computing
+      the longest-increasing-subsequence length ending at each position, by
+      well-founded recursion over the position:
+      `incDP f i = 1 + max { incDP f j : j < i, f j < f i }` (`incDP_eq`).
+    * `exactIncEnd_incDP` — the DP value is realized: for every `i` there is a
+      strictly increasing position map of length `incDP f i` with strictly
+      increasing values, bounded by `i` and ending exactly at `i`. Consequently
+      `HasIncreasingEndingAt f i (incDP f i)` — the parent's own ending-at
+      predicate — holds (`hasIncreasingEndingAt_incDP`), and an
+      `IncreasingSubseq f (incDP f i)` exists (`exists_increasingSubseq_incDP`).
+    * `incDP_le_maxIncLen` — the DP is sound against the parent's noncomputable
+      spec: `incDP f i ≤ maxIncLen f i`. (The converse inequality — optimal
+      substructure — is the remaining half of full correctness; see below.)
+    * `incDPcost_closed` / `incDPcost_two_mul` — the exact comparison count. The
+      DP at position `i` scans every candidate `j < i` (`scanned`/`card_scanned`,
+      and the actual predecessor set satisfies `preds_subset_scanned`), so the
+      total number of scanned pairs is `incDPcost n = ∑ i, |Iio i|`, with the
+      proved closed forms `incDPcost n = n * (n - 1) / 2` and
+      `incDPcost n * 2 = n * (n - 1)` — the Θ(n²) bound as an exact equation.
+
+  ## The cost-model judgement
+
+  Mathlib has no cost monad, RAM model, or comparison-decision-tree machinery, so
+  asymptotic statements ("Θ(n log n)") have no formal home. Following the Garner
+  precedent (chinese-remainder-non-coprime-oq-01-oq-02), complexity is formalized
+  as an explicit `Nat`-valued operation counter with a proved closed form. The
+  literature answer to OQ-02 beyond this file — patience sorting computes the LIS
+  in Θ(n log n) comparisons (Mallows 1963, Schensted 1961) and Fredman (1975)
+  proved a matching Ω(n log n) comparison lower bound, so Θ(n log n) is optimal —
+  is documented here but is out of Lean scope without a comparison-cost model.
+
+  ## Remaining milestones (tracked in research/problems/erdos-szekeres-oq-02/)
+
+  * Full correctness `incDP f i = maxIncLen f i`: needs the optimal-substructure
+    (stripping) argument for `maxIncLen f i ≤ incDP f i`; sequenced after sibling
+    oq-01's extension lemma to avoid duplicating shared infrastructure.
+  * Executable witness data `incWitness f i : IncreasingSubseq f (incDP f i)` via
+    computable argmax selection (`List.argmax`), turning the `Nonempty` here into
+    a program that returns the actual index map.
+
+  Depends on: `Proofs/ErdosSzekeres.lean` (definitions only — no axiom of the
+  parent is used; every result here is axiom-free, `#print axioms` shows only
+  propext/Classical.choice/Quot.sound).
+-/
+
+import Mathlib
+import Proofs.ErdosSzekeres
+
+namespace ErdosSzekeresOQ02
+
+open Finset ErdosSzekeres
+
+variable {α : Type*} [LinearOrder α] {n : ℕ}
+
+/- ## The dynamic program
+
+`incDP f i` is the classical quadratic-time recurrence for the length of the
+longest strictly increasing subsequence ending at position `i`: one more than
+the best value over admissible predecessors (earlier positions with smaller
+values). Unlike the parent's `maxIncLen`, this is a computable function — the
+recursion is well-founded on `i.val`, and the predecessor set is a decidable
+`Finset` filter.
+-/
+
+/-- The predecessor set scanned by the DP at position `i`: earlier positions
+    with strictly smaller values. -/
+def preds (f : Sequence α n) (i : Fin n) : Finset (Fin n) :=
+  Finset.univ.filter (fun j => j < i ∧ f j < f i)
+
+lemma mem_preds {f : Sequence α n} {i j : Fin n} :
+    j ∈ preds f i ↔ j < i ∧ f j < f i := by
+  simp [preds]
+
+/-- Computable longest-increasing-subsequence-ending-at-`i` length, by the
+    classical quadratic dynamic program. Compare the parent's `noncomputable
+    maxIncLen`. -/
+def incDP (f : Sequence α n) (i : Fin n) : ℕ :=
+  1 + (preds f i).attach.sup (fun j => incDP f j.1)
+termination_by i.val
+decreasing_by
+  exact (mem_preds.mp j.2).1
+
+/-- The DP recurrence in `attach`-free form:
+    `incDP f i = 1 + sup { incDP f j : j < i, f j < f i }`. -/
+theorem incDP_eq (f : Sequence α n) (i : Fin n) :
+    incDP f i = 1 + (preds f i).sup (fun j => incDP f j) := by
+  rw [incDP, Finset.sup_attach]
+
+/-- Every position carries at least the singleton subsequence. -/
+theorem one_le_incDP (f : Sequence α n) (i : Fin n) : 1 ≤ incDP f i := by
+  rw [incDP_eq]
+  exact Nat.le_add_right 1 _
+
+/-- A subsequence ending at position `i` uses positions `≤ i`, so its length is
+    at most `i.val + 1`. This is the bound that lets the DP value enter the
+    parent's `Nat.findGreatest (· ) (i.val + 1)` search window. -/
+theorem incDP_le_index_succ (f : Sequence α n) (i : Fin n) :
+    incDP f i ≤ i.val + 1 := by
+  rw [incDP_eq]
+  have h : (preds f i).sup (fun j => incDP f j) ≤ i.val := by
+    refine Finset.sup_le fun j hj => ?_
+    have hji : j.val < i.val := (mem_preds.mp hj).1
+    have hrec : incDP f j ≤ j.val + 1 := incDP_le_index_succ f j
+    omega
+  omega
+termination_by i.val
+decreasing_by exact hji
+
+/- ## Realizing the DP value
+
+The parent's `HasIncreasingEndingAt` allows the final position to fall short of
+`i` in degenerate branches, which is too weak to extend chains: knowing only
+`f j < f i` says nothing about the values at positions strictly before `j`.
+`ExactIncEnd` strengthens the invariant to "ends exactly at `i`", which makes
+the one-step extension by a new maximum position go through, and afterwards
+downgrades to the parent's predicate.
+-/
+
+/-- An increasing subsequence of length `len` ending *exactly* at `i`: strictly
+    increasing positions with strictly increasing values, all positions `≤ i`,
+    and the last position equal to `i`. -/
+def ExactIncEnd (f : Sequence α n) (i : Fin n) (len : ℕ) : Prop :=
+  ∃ k : Fin len → Fin n,
+    StrictMono k ∧ StrictMono (f ∘ k) ∧ (∀ a, k a ≤ i) ∧
+    (∀ a : Fin len, a.val = len - 1 → k a = i)
+
+/-- The singleton chain at `i`. -/
+theorem exactIncEnd_one (f : Sequence α n) (i : Fin n) : ExactIncEnd f i 1 := by
+  refine ⟨fun _ => i, ?_, ?_, fun _ => le_refl i, fun _ _ => rfl⟩
+  · intro a b hab
+    exact absurd hab (Subsingleton.elim a b ▸ lt_irrefl _)
+  · intro a b hab
+    exact absurd hab (Subsingleton.elim a b ▸ lt_irrefl _)
+
+/-- Exact chains satisfy the parent's ending-at predicate. -/
+theorem ExactIncEnd.hasIncreasingEndingAt {f : Sequence α n} {i : Fin n} {len : ℕ}
+    (h : ExactIncEnd f i len) : HasIncreasingEndingAt f i len := by
+  obtain ⟨k, hmono, hvals, hle, hlast⟩ := h
+  refine ⟨k, hmono, fun a => ?_, hvals⟩
+  by_cases ha : a.val = len - 1
+  · exact Or.inr ⟨ha, hlast a ha⟩
+  · left
+    have hpos : 0 < len := a.pos
+    have h1 : len - 1 < len := by omega
+    have hlt : a < (⟨len - 1, h1⟩ : Fin len) := by
+      rw [Fin.lt_def]
+      have := a.isLt
+      simp only []
+      omega
+    have hmlt := hmono hlt
+    rw [hlast ⟨len - 1, h1⟩ rfl] at hmlt
+    exact hmlt
+
+/-- One-step extension: an exact chain to `j` extends by any later, larger
+    position `i` to an exact chain of length `len + 1`, via `Fin.snoc`. The
+    `ends exactly at j` invariant is what makes the value comparison at the
+    junction available (`f (k a) < f j < f i` for interior positions). -/
+theorem ExactIncEnd.extend {f : Sequence α n} {j i : Fin n} {len : ℕ}
+    (hlen : 1 ≤ len) (h : ExactIncEnd f j len) (hji : j < i) (hfji : f j < f i) :
+    ExactIncEnd f i (len + 1) := by
+  obtain ⟨k, hmono, hvals, hle, hlast⟩ := h
+  have hki : ∀ a : Fin len, k a < i := fun a => lt_of_le_of_lt (hle a) hji
+  have hfki : ∀ a : Fin len, f (k a) < f i := by
+    intro a
+    by_cases ha : a.val = len - 1
+    · rw [hlast a ha]
+      exact hfji
+    · have h1 : len - 1 < len := by omega
+      have hlt : a < (⟨len - 1, h1⟩ : Fin len) := by
+        rw [Fin.lt_def]
+        have := a.isLt
+        simp only []
+        omega
+      have h2 := hvals hlt
+      simp only [Function.comp_apply] at h2
+      rw [hlast ⟨len - 1, h1⟩ rfl] at h2
+      exact lt_trans h2 hfji
+  refine ⟨Fin.snoc k i, ?_, ?_, ?_, ?_⟩
+  · -- positions strictly increase
+    intro a b hab
+    rcases Fin.eq_castSucc_or_eq_last b with ⟨b', rfl⟩ | rfl
+    · rcases Fin.eq_castSucc_or_eq_last a with ⟨a', rfl⟩ | rfl
+      · simp only [Fin.snoc_castSucc]
+        exact hmono (Fin.castSucc_lt_castSucc_iff.mp hab)
+      · exact absurd hab (not_lt.mpr (Fin.castSucc_lt_last b').le)
+    · rcases Fin.eq_castSucc_or_eq_last a with ⟨a', rfl⟩ | rfl
+      · simp only [Fin.snoc_castSucc, Fin.snoc_last]
+        exact hki a'
+      · exact absurd hab (lt_irrefl _)
+  · -- values strictly increase
+    rw [Fin.comp_snoc]
+    intro a b hab
+    rcases Fin.eq_castSucc_or_eq_last b with ⟨b', rfl⟩ | rfl
+    · rcases Fin.eq_castSucc_or_eq_last a with ⟨a', rfl⟩ | rfl
+      · simp only [Fin.snoc_castSucc]
+        exact hvals (Fin.castSucc_lt_castSucc_iff.mp hab)
+      · exact absurd hab (not_lt.mpr (Fin.castSucc_lt_last b').le)
+    · rcases Fin.eq_castSucc_or_eq_last a with ⟨a', rfl⟩ | rfl
+      · simp only [Fin.snoc_castSucc, Fin.snoc_last]
+        exact hfki a'
+      · exact absurd hab (lt_irrefl _)
+  · -- bounded by i
+    intro a
+    rcases Fin.eq_castSucc_or_eq_last a with ⟨a', rfl⟩ | rfl
+    · rw [Fin.snoc_castSucc]
+      exact (hki a').le
+    · rw [Fin.snoc_last]
+  · -- ends at i
+    intro a ha
+    have haeq : a = Fin.last len := by
+      apply Fin.ext
+      simpa using ha
+    rw [haeq, Fin.snoc_last]
+
+/-- **The DP value is realized**: for every position there is an exact chain of
+    length `incDP f i` ending at `i`. Well-founded recursion mirroring the DP:
+    an empty predecessor set gives the singleton; otherwise extend an exact
+    chain of a predecessor attaining the `Finset.sup`. -/
+theorem exactIncEnd_incDP (f : Sequence α n) (i : Fin n) :
+    ExactIncEnd f i (incDP f i) := by
+  rcases (preds f i).eq_empty_or_nonempty with he | hne
+  · rw [incDP_eq, he]
+    simpa using exactIncEnd_one f i
+  · obtain ⟨j₀, hj₀mem, hsup⟩ := Finset.exists_mem_eq_sup (preds f i) hne (fun j => incDP f j)
+    have hj₀ := mem_preds.mp hj₀mem
+    have hrec : ExactIncEnd f j₀ (incDP f j₀) := exactIncEnd_incDP f j₀
+    have hext := hrec.extend (one_le_incDP f j₀) hj₀.1 hj₀.2
+    rw [incDP_eq, hsup, Nat.add_comm]
+    exact hext
+termination_by i.val
+decreasing_by exact hj₀.1
+
+/-- The parent's ending-at predicate holds at the DP value. -/
+theorem hasIncreasingEndingAt_incDP (f : Sequence α n) (i : Fin n) :
+    HasIncreasingEndingAt f i (incDP f i) :=
+  (exactIncEnd_incDP f i).hasIncreasingEndingAt
+
+/-- **Soundness against the noncomputable spec**: the computable DP never
+    exceeds the parent's `maxIncLen`. (The converse — optimal substructure —
+    is the remaining half of full correctness.) -/
+theorem incDP_le_maxIncLen (f : Sequence α n) (i : Fin n) :
+    incDP f i ≤ maxIncLen f i := by
+  classical
+  show incDP f i ≤ Nat.findGreatest (HasIncreasingEndingAt f i) (i.val + 1)
+  exact Nat.le_findGreatest (incDP_le_index_succ f i) (hasIncreasingEndingAt_incDP f i)
+
+/-- An actual `IncreasingSubseq` (the parent's subsequence structure) of the DP
+    length exists at every position. -/
+theorem exists_increasingSubseq_incDP (f : Sequence α n) (i : Fin n) :
+    Nonempty (IncreasingSubseq f (incDP f i)) := by
+  obtain ⟨k, hmono, hvals, -, -⟩ := exactIncEnd_incDP f i
+  exact ⟨⟨k, hmono, hvals⟩⟩
+
+/- ## The exact comparison count
+
+The DP at position `i` tests every candidate `j < i` once (the `preds` filter
+evaluates `j < i ∧ f j < f i` over all of `Fin n`, and the order-comparison
+work is the `i.val` candidates below `i`). `incDPcost` counts exactly these
+scanned pairs `(j, i)` with `j < i` — that is, `∑ i |Iio i| = C(n, 2)` — the
+Θ(n²) comparison bound as an exact closed form, division-free variant included.
+-/
+
+/-- Candidate positions scanned by the DP at position `i`: every `j < i`. -/
+def scanned (i : Fin n) : Finset (Fin n) := Finset.Iio i
+
+/-- The admissible predecessors are among the scanned candidates. -/
+theorem preds_subset_scanned (f : Sequence α n) (i : Fin n) :
+    preds f i ⊆ scanned i := by
+  intro j hj
+  rw [scanned, Finset.mem_Iio]
+  exact (mem_preds.mp hj).1
+
+/-- Position `i` scans exactly `i.val` candidates. -/
+theorem card_scanned (i : Fin n) : (scanned i).card = i.val := by
+  rw [scanned]
+  exact Fin.card_Iio i
+
+/-- Total number of candidate pairs scanned by the DP on a length-`n` input. -/
+def incDPcost (n : ℕ) : ℕ := ∑ i : Fin n, (Finset.Iio i).card
+
+theorem incDPcost_eq_sum (n : ℕ) : incDPcost n = ∑ i : Fin n, i.val := by
+  unfold incDPcost
+  exact Finset.sum_congr rfl fun i _ => Fin.card_Iio i
+
+/-- **The exact quadratic comparison count**: `incDPcost n = n(n-1)/2`. -/
+theorem incDPcost_closed (n : ℕ) : incDPcost n = n * (n - 1) / 2 := by
+  rw [incDPcost_eq_sum, Fin.sum_univ_eq_sum_range (fun i => i)]
+  exact Finset.sum_range_id n
+
+/-- Division-free form: `2 · incDPcost n = n(n-1)`. -/
+theorem incDPcost_two_mul (n : ℕ) : incDPcost n * 2 = n * (n - 1) := by
+  rw [incDPcost_eq_sum, Fin.sum_univ_eq_sum_range (fun i => i)]
+  exact Finset.sum_range_id_mul_two n
+
+/- ## Executable smoke tests
+
+`incDP` is computable, so `#eval` runs it directly — this is the point of the
+OQ: the parent's `maxIncLen` admits no such evaluation. On [3,1,4,1,5,9,2,6]
+the DP table is [1,1,2,1,3,4,2,4] (e.g. 3,4,5,9 ends at position 5; 3,4,5,6
+ends at position 7), and `incDPcost 8 = 28 = 8·7/2`.
+-/
+
+#eval incDP (![3, 1, 4, 1, 5, 9, 2, 6] : Fin 8 → ℕ) 7
+#eval (List.ofFn fun i : Fin 8 => incDP (![3, 1, 4, 1, 5, 9, 2, 6] : Fin 8 → ℕ) i)
+#eval incDPcost 8
+
+end ErdosSzekeresOQ02

--- a/research/problems/erdos-szekeres-oq-02/knowledge.md
+++ b/research/problems/erdos-szekeres-oq-02/knowledge.md
@@ -216,3 +216,79 @@ oq-01 ACT-2 to reuse it rather than re-prove it.
   answer; not formalizable without a comparison-cost model.
 - `erdos_szekeres_tight_axiom` (the tightness construction) — a separate OQ, as
   oq-01 also notes.
+
+---
+
+## Session 2026-07-24 (researcher-1, S5) — UNBLOCKED: ACT milestone 1 done + realized-witness layer (half of milestone 2)
+
+**Mode**: FRESH (claim-random served it; the 2026-06-13 block was Docker-transient
+and Docker is back)
+**Outcome**: progress (first Lean artifact: `proofs/Proofs/ErdosSzekeresOQ02.lean`,
+319 LOC, 0 sorry / 0 axiom, Docker-verified 8577 jobs)
+
+### What I Did
+
+- Added the missing "Must prove exactly / does not count" pinning to problem.md
+  (5 pinned targets; near-misses include noncomputable witness extraction and
+  `incDP ≤ maxIncLen` alone posing as full correctness).
+- New file `ErdosSzekeresOQ02.lean` (imports `Proofs.ErdosSzekeres`, uses only
+  its definitions — no parent axiom touched; everything here is axiom-free):
+  - `incDP` — COMPUTABLE DP (well-founded recursion on `i.val`,
+    `Finset.attach.sup` over `preds f i = filter (j < i ∧ f j < f i)`), with
+    attach-free recurrence `incDP_eq`, bounds `one_le_incDP` and
+    `incDP_le_index_succ : incDP f i ≤ i.val + 1`.
+  - `ExactIncEnd` — strengthened ending-at invariant (last position EXACTLY
+    `i`). Key discovery: the parent's `HasIncreasingEndingAt` disjunction
+    permits the last position to fall short of `i`, which is TOO WEAK to
+    extend chains (no value info at the junction). The exact invariant fixes
+    this; `ExactIncEnd.extend` does the `Fin.snoc` one-step extension and
+    `ExactIncEnd.hasIncreasingEndingAt` downgrades to the parent predicate.
+  - `exactIncEnd_incDP` — the DP value is realized (WF recursion mirroring the
+    DP: singleton on empty preds, else extend the sup-attaining predecessor via
+    `Finset.exists_mem_eq_sup`). Corollaries: `hasIncreasingEndingAt_incDP`,
+    `exists_increasingSubseq_incDP : Nonempty (IncreasingSubseq f (incDP f i))`,
+    and `incDP_le_maxIncLen` (soundness against the noncomputable spec via
+    `Nat.le_findGreatest` — the constructive HALF of milestone 2, obtained
+    WITHOUT oq-01's extension lemma).
+  - Cost layer: `scanned i = Iio i`, `card_scanned = i.val`,
+    `preds_subset_scanned`, `incDPcost n = ∑ |Iio i|` with closed forms
+    `incDPcost_closed : incDPcost n = n(n-1)/2` and division-free
+    `incDPcost_two_mul`. Milestone 1 complete, semantically grounded (cost is
+    defined as scanned-pair count, not a bare formula).
+  - `#eval` smoke tests in-file: DP table [1,1,2,1,3,4,2,4] on [3,1,4,1,5,9,2,6],
+    cost 28 = C(8,2). The parent's `maxIncLen` admits no such evaluation —
+    that contrast is the point of the OQ.
+
+### Lean techniques that worked first-try (whole file elaborated clean on host scratch)
+
+- WF recursion over `Fin` via `termination_by i.val` + `decreasing_by exact
+  (mem_preds.mp j.2).1` (Fin.lt is defeq to val-lt; no cast needed).
+- Recursive THEOREMS with the same termination measure (`incDP_le_index_succ`,
+  `exactIncEnd_incDP`) — cleaner than `Nat.strong_induction_on` gymnastics.
+- `Fin.snoc` case analysis via `Fin.eq_castSucc_or_eq_last` + `Fin.snoc_castSucc`
+  / `Fin.snoc_last` / `Fin.comp_snoc` / `Fin.castSucc_lt_castSucc_iff`; no
+  ready-made `StrictMono (Fin.snoc ...)` iff-lemma needed (manual 10-liner).
+- Host pre-validation: full file inlining parent defs against bare Mathlib via
+  `lake env lean` (~3 min) before any Docker cycle — zero Docker iterations.
+
+### Remaining gaps (exact statements)
+
+- Milestone 2 (other half): `maxIncLen f i ≤ incDP f i` — optimal substructure:
+  any `HasIncreasingEndingAt f i len` witness with `len ≥ 2` yields
+  `HasIncreasingEndingAt f j (len-1)` for some `j ∈ preds f i` (strip the last
+  element; the stripped chain ends exactly at its own last position — the
+  ExactIncEnd trick applies on the OTHER side here, since the parent
+  disjunction's weak branch must be handled by downward induction on len).
+  Does NOT actually need oq-01's `maxIncLen_lt_of_lt`.
+- Milestone 3: computable `incWitness f i : IncreasingSubseq f (incDP f i)` —
+  design decided: `(preds f i).toList.argmax (incDP f)` for the predecessor
+  choice (List.argmax is computable; lemmas `List.argmax_mem`,
+  `List.le_of_mem_argmax` connect it to the sup), backtrack to build the
+  position map as data. The `Nonempty` version is proved; this milestone
+  upgrades it to a program.
+
+### Files Modified
+
+- `proofs/Proofs/ErdosSzekeresOQ02.lean` (NEW, 319 LOC)
+- `research/problems/erdos-szekeres-oq-02/problem.md` (pinning section)
+- `research/problems/erdos-szekeres-oq-02/state.md`, tracker JSON (unblocked)

--- a/research/problems/erdos-szekeres-oq-02/problem.md
+++ b/research/problems/erdos-szekeres-oq-02/problem.md
@@ -117,3 +117,43 @@ tractability: 5
 tier: B
 category: extension
 ```
+
+## Must prove exactly / does not count
+
+Added 2026-07-24 (researcher-1) per the statement-pinning rule. The OQ "what is
+the complexity of finding the actual monotonic subsequence?" resolves into a
+formalizable core (see knowledge.md). The pinned Lean targets:
+
+### Must prove exactly
+
+1. **Computable algorithm.** A `def incDP : Sequence α n → Fin n → ℕ` that is
+   NOT marked `noncomputable`, computing the longest-increasing-subsequence
+   length ending at each position, with a proved recurrence equation
+   (`incDP f i = 1 + sup over {j < i, f j < f i} of incDP f j`).
+2. **The witness is realizable.** `HasIncreasingEndingAt f i (incDP f i)` —
+   the DP value is achieved by an actual increasing subsequence ending at `i`
+   (the parent's own ending-at predicate, not a restatement), and consequently
+   `incDP f i ≤ maxIncLen f i` against the parent's noncomputable spec.
+3. **Exact comparison count.** A cost function counting exactly the scanned
+   candidate pairs `(j, i), j < i` of the DP, with the proved closed form
+   `n * (n - 1) / 2` (and a division-free form `* 2 = n * (n - 1)`).
+4. **Full correctness (milestone 2, later session).**
+   `incDP f i = maxIncLen f i` — the `≥` half (optimal substructure /
+   stripping) is the remaining open piece; the `≤` half is item 2.
+5. **Actual data (milestone 3, later session).** An executable
+   `incWitness f i : IncreasingSubseq f (incDP f i)` (computable, i.e. via
+   `List.argmax`-style selection, not `Classical.choice`).
+
+### Does not count
+
+- **Θ(n log n) patience sorting or Fredman's Ω(n log n) lower bound** — no
+  comparison-cost model exists in Mathlib; these remain the literature answer
+  and are out of Lean scope (documented, not attempted).
+- **Big-O statements** — no cost monad; only exact operation counts count.
+- **A noncomputable witness function** (Classical choice wrapped in a `def`)
+  presented as "finding" the subsequence — the point of the OQ is executable
+  data; `noncomputable` extraction is a near-miss for milestone 3.
+- **Re-proving existence** (`HasIncreasingEndingAt f i 1` etc. or the parent
+  pigeonhole) without the DP — that is sibling oq-01's territory.
+- **`incDP ≤ maxIncLen` alone** presented as full correctness (item 4 needs
+  both directions).

--- a/research/problems/erdos-szekeres-oq-02/state.md
+++ b/research/problems/erdos-szekeres-oq-02/state.md
@@ -1,60 +1,37 @@
 # Research State: erdos-szekeres-oq-02
 
 ## Current State
-**Phase**: BLOCKED
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-06-13T00:00:00-07:00
-**Iteration**: 4
-**Last Updated**: 2026-06-14 (S4 GATE-SYNC, researcher-1 — propagated the 2026-06-13 BLOCKED flag to the gates `claim-random` reads)
+**Since**: 2026-07-24T00:00:00-07:00
+**Iteration**: 5
+**Last Updated**: 2026-07-24 (S5, researcher-1 — UNBLOCKED, milestone 1 + realized-witness layer landed)
 
-## Session 4 (2026-06-14, researcher-1) — GATE-SYNC
+## Session 5 (2026-07-24, researcher-1) — UNBLOCK + FIRST LEAN ARTIFACT
 
-The 2026-06-13 BLOCKED flag lived in state.md only: the research JSON read
-`status: "surveyed"` / `phase: "ORIENT"` and `.lean/state/candidate-pool.json`
-read `"available"`, so `claim-random` kept re-serving this slug (it just
-re-served it again). Aligned both gates to BLOCKED (JSON
-`status`/`phase`/`currentState.phase` → `blocked`/`BLOCKED`; pool → `"blocked"`,
-terminal/unclaimable). **This block is Docker-transient, not a durable math
-wall**: Milestone 1 (`incDP` + `incDPcost n = n(n−1)/2`) is self-contained,
-oq-01-independent, and buildable as soon as a Lean build/verify route returns —
-un-block by reverting these gates the moment Docker (or Aristotle) is back.
-No metadata/Lean change.
+The 2026-06-13/14 BLOCKED flag was Docker-transient by its own terms ("un-block
+the moment Docker is back"). Docker is back; `claim-random` served the slug and
+ACT proceeded. Landed `proofs/Proofs/ErdosSzekeresOQ02.lean` (319 LOC, 0 sorry,
+0 axiom, Docker build 8577 jobs clean): computable `incDP` + recurrence +
+bounds; `ExactIncEnd` invariant + snoc extension; `exactIncEnd_incDP` (DP value
+realized); `hasIncreasingEndingAt_incDP`; `incDP_le_maxIncLen` (constructive
+half of correctness, obtained WITHOUT oq-01's extension lemma);
+`exists_increasingSubseq_incDP`; exact cost layer `incDPcost n = n(n-1)/2`
+(+ division-free form), grounded as scanned-pair count. Milestone 1 COMPLETE;
+milestone 2 half done.
 
 ## Current Focus
-Survey complete and accurate (researcher-9 2026-06-13). Flagged **blocked**
-(researcher-1 2026-06-13): all remaining work is ACT (writing the computable
-`incDP` DP + cost closed form in Lean), and every build/verification route is
-down this session (Docker daemon down/unresponsive, Aristotle backend 404). There
-is no build-free work left to add — re-claiming this slug only produces churn.
-Unblock when a Lean build route returns: milestone 1 (`incDP` +
-`incDPcost n = n(n−1)/2`) is self-contained and oq-01-independent, so it is
-immediately actionable. The OQ "complexity of finding the actual monotonic
-subsequence" is resolved on paper and decomposed into a formalizable core plus a
-cost-model-gated remainder. See knowledge.md.
+Milestone 2 remaining half: `maxIncLen f i ≤ incDP f i` via the stripping /
+optimal-substructure lemma (exact statement in knowledge.md §Remaining gaps —
+downward handling of the parent disjunction's weak branch; does NOT need
+oq-01's `maxIncLen_lt_of_lt` after all). Then milestone 3: computable
+`incWitness` via `List.argmax` predecessor selection (design pinned in
+knowledge.md). Statement pinning now lives in problem.md ("Must prove exactly /
+does not count").
 
 ## Active Approach
-Computable DP `incDP : Fin n → ℕ` (strong recursion, `decidableLT`) shown equal to
-the parent's noncomputable `maxIncLen`, plus a constructive witness extractor and
-an exact Θ(n²) comparison-count closed form `n(n−1)/2`. The Θ(n log n)
-patience-sorting optimum (and Fredman's matching Ω(n log n) lower bound) is the
-literature answer but is out of Lean scope — Mathlib has no comparison-cost model.
-
-## Attempt Count
-- Total attempts: 0 (survey only; no Lean built)
-- Current approach attempts: 0
-- Approaches tried: 0
-
-## Blockers
-- All Lean build/verification routes down this session (Docker daemon down;
-  Aristotle backend 404). ACT (writing `incDP` etc.) deferred until a build route
-  returns.
-- Correctness milestone (`incDP = maxIncLen`) depends on oq-01's extension lemma
-  `maxIncLen_lt_of_lt`; sequence it after oq-01 ACT-2 lands that lemma to avoid
-  duplicating it.
-
-## Next Action
-ORIENT → ACT when a build route is available. First buildable milestone is
-self-contained and oq-01-independent: the computable `incDP` (termination +
-`DecidablePred`) and the exact comparison count `incDPcost n = n(n−1)/2`
-(~40–60 LOC). Then milestone 2 (correctness, after oq-01 ACT-2) and milestone 3
-(constructive `incWitness` producing `IncreasingSubseq f (incDP f i)`).
+Computable DP `incDP` (landed) shown sound against the parent's noncomputable
+`maxIncLen` (landed); completeness (≥) via stripping; witness as executable
+data via argmax backtracking. Θ(n log n) patience sorting + Fredman Ω(n log n)
+remain literature-only (no comparison-cost model in Mathlib) — documented in
+the file header, out of Lean scope by design.

--- a/src/data/research/problems/erdos-szekeres-oq-02.json
+++ b/src/data/research/problems/erdos-szekeres-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-szekeres-oq-02",
   "title": "Complexity of finding the actual Erdos-Szekeres monotonic subsequence",
-  "phase": "BLOCKED",
-  "status": "blocked",
+  "phase": "ACT",
+  "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -28,13 +28,16 @@
     "goal": "Formalize a computable incDP : Fin n -> Nat proven equal to maxIncLen, a constructive witness extractor, and an exact Theta(n^2) comparison-count closed form n(n-1)/2; document the Theta(n log n) optimum as the cost-model-gated remainder."
   },
   "currentState": {
-    "phase": "BLOCKED",
+    "phase": "ACT",
     "since": "2026-06-13T00:00:00-07:00",
     "iteration": 2,
     "focus": "First survey complete (researcher-9 2026-06-13, build-free during the Docker/Aristotle verification blackout). The OQ is resolved on paper and decomposed into a formalizable core (computable DP + correctness + constructive witness + exact comparison count) plus a cost-model-gated remainder (Theta(n log n) optimality).",
     "blockers": [
-      "All Lean build/verification routes down this session (Docker daemon down; Aristotle backend 404). ACT deferred until a build route returns.",
-      "Correctness milestone (incDP = maxIncLen) depends on oq-01's extension lemma maxIncLen_lt_of_lt; sequence after oq-01 ACT-2 to reuse it."
+      {
+        "route": "correctness <= direction via oq-01 extension lemma maxIncLen_lt_of_lt",
+        "reopenCriterion": "superseded: S5 obtained incDP_le_maxIncLen constructively without it; remaining >= direction is the stripping lemma, no oq-01 dependency",
+        "blockedAt": "2026-07-24"
+      }
     ],
     "nextAction": "ACT milestone 1 (oq-01-independent, ~40-60 LOC): computable incDP via strong recursion with DecidablePred from LinearOrder's decidableLT, and the exact comparison count incDPcost n = n(n-1)/2. Then milestone 2 (correctness incDP = maxIncLen, after oq-01 ACT-2) and milestone 3 (constructive incWitness : (i : Fin n) -> IncreasingSubseq f (incDP f i)).",
     "attemptCounts": {
@@ -44,8 +47,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ORIENT (researcher-9 2026-06-13 S1, build-free survey). Resolved the OQ on paper: finding the actual monotone subsequence costs Theta(n^2) by the elementary DP and Theta(n log n) by patience sorting (optimal, Fredman lower bound); witness reconstruction adds O(n). Identified the formalizable core vs the cost-model-gated remainder. No Lean built (Docker down + Aristotle 404).",
-    "builtItems": [],
+    "progressSummary": "ACT (researcher-1 2026-07-24 S5): UNBLOCKED (Docker back). Milestone 1 COMPLETE + realized-witness layer: computable incDP with recurrence, HasIncreasingEndingAt f i (incDP f i), incDP_le_maxIncLen, Nonempty (IncreasingSubseq f (incDP f i)), exact cost incDPcost n = n(n-1)/2. 319 LOC, 0 sorry/0 axiom, Docker-verified. Remaining: >= correctness (stripping), computable incWitness.",
+    "builtItems": [
+      "ErdosSzekeresOQ02.lean (NEW, 319 LOC, 0 sorry, 0 axiom): incDP (computable DP), incDP_eq, one_le_incDP, incDP_le_index_succ",
+      "ExactIncEnd + exactIncEnd_one + ExactIncEnd.extend + ExactIncEnd.hasIncreasingEndingAt (snoc extension machinery)",
+      "exactIncEnd_incDP, hasIncreasingEndingAt_incDP, incDP_le_maxIncLen, exists_increasingSubseq_incDP",
+      "Cost layer: scanned/card_scanned/preds_subset_scanned, incDPcost, incDPcost_closed (n(n-1)/2), incDPcost_two_mul (division-free)"
+    ],
     "insights": [
       "The parent maxIncLen/maxDecLen are noncomputable (Nat.findGreatest over a Prop existential), so oq-02 is precisely the gap between a non-constructive existence spec and an executable algorithm proven to meet it.",
       "Mathlib has NO cost/complexity model and NO LIS/patience-sorting/Erdos-Szekeres machinery in the importable library (grep of materialized Mathlib source: no longestIncreasing*/patienceSort*/increasingSubseq*; only Archive/Wiedijk100Theorems/AscendingDescendingSequences.lean, not re-exported). Nat.findGreatest is in Mathlib/Data/Nat/Find.lean.",
@@ -53,7 +61,10 @@
       "Complexity must be formalized as an exact Nat operation-counter with a proved closed form, NOT a Big-O over a cost monad — the same judgement that made the Garner OQ (chinese-remainder-non-coprime-oq-01-oq-02, PR #23098) tractable.",
       "The Theta(n log n) patience-sorting upper bound (needs a verified balanced-BST/Fenwick) and Fredman's Omega(n log n) lower bound (needs a comparison-decision-tree model) are out of Lean scope — same class of gap as the binary-gcd Brent-constant and bezout-HGCD Master-theorem OQs.",
       "Relation to oq-01: oq-01 BUILDS the extension lemma maxIncLen_lt_of_lt (ACT-2); oq-02 CONSUMES it for the correctness proof. Sequence oq-02 milestone 2 after oq-01 ACT-2. The constructive incWitness is an alternative (constructive) elimination of the parent existence axiom.",
-      "First buildable milestone is self-contained and oq-01-independent: incDP + termination + DecidablePred + the closed-form comparison count. Pure Fin/Finset/Nat algebra, ~40-60 LOC."
+      "First buildable milestone is self-contained and oq-01-independent: incDP + termination + DecidablePred + the closed-form comparison count. Pure Fin/Finset/Nat algebra, ~40-60 LOC.",
+      "S5: The parent HasIncreasingEndingAt disjunction permits the last position to fall short of i — too weak to extend chains (no value info at the junction). Strengthened ExactIncEnd invariant (last position exactly i) makes Fin.snoc extension go through, then downgrades to the parent predicate.",
+      "S5: incDP_le_maxIncLen (soundness vs the noncomputable spec) is provable WITHOUT oq-01 extension lemma: realized witness + Nat.le_findGreatest + incDP f i <= i.val + 1.",
+      "S5: Recursive theorems with termination_by i.val (incDP_le_index_succ, exactIncEnd_incDP) mirror the WF def cleanly — no strong-induction gymnastics; decreasing_by exact <Fin.lt hyp> works via defeq."
     ],
     "mathlibGaps": [
       "No cost/complexity model (no Big-O cost monad, no RAM/comparison-decision-tree machinery, no Master theorem) — so asymptotic complexity statements have no Lean home; use exact Nat operation-counters instead.",
@@ -61,10 +72,10 @@
       "Nat.findGreatest (Mathlib/Data/Nat/Find.lean), Finset.sup/filter, and well-founded recursion on Fin.val are sufficient for the computable DP; no new foundational definitions needed for milestone 1."
     ],
     "nextSteps": [
-      "ACT milestone 1 (oq-01-independent): computable incDP : Fin n -> Nat (strong recursion on i.val, Finset.sup over {j<i, f j<f i}, DecidablePred via decidableLT) + exact comparison count incDPcost n = n(n-1)/2. ~40-60 LOC.",
-      "ACT milestone 2 (after oq-01 ACT-2): correctness incDP f i = maxIncLen f i. <= via oq-01's maxIncLen_lt_of_lt; >= via the optimal-substructure lemma (strip the last element of a longest subseq ending at i).",
-      "ACT milestone 3: constructive witness incWitness : (i : Fin n) -> IncreasingSubseq f (incDP f i) by backtracking predecessor pointers — the literal 'find the actual subsequence', and an alternative constructive elimination of the parent existence axiom.",
-      "Document only (out of scope): Theta(n log n) patience-sorting optimum and Fredman's Omega(n log n) lower bound — not formalizable without a comparison-cost model."
+      "Milestone 2 remaining half: maxIncLen f i <= incDP f i via stripping/optimal-substructure (exact statement in knowledge.md; handle the parent disjunction weak branch by downward induction on len). No oq-01 dependency.",
+      "Milestone 3: computable incWitness f i : IncreasingSubseq f (incDP f i) via (preds f i).toList.argmax (incDP f) predecessor selection + backtracking (List.argmax_mem / List.le_of_mem_argmax connect to the sup).",
+      "Optional capstone: global lisLength f = univ.sup (incDP f) + the ES-witness finder (scan both tables, O(n) on top of the DP) tying back to the parent pigeonhole statement.",
+      "Document only (out of scope): Theta(n log n) patience sorting + Fredman lower bound — no comparison-cost model in Mathlib."
     ],
     "markdown": "See research/problems/erdos-szekeres-oq-02/knowledge.md for the full survey (resolution on paper, the real-math-vs-engineering boundary, the build-free Lean recipe, milestones, and the relation to oq-01)."
   },


### PR DESCRIPTION
## Research: erdos-szekeres-oq-02 — computable `incDP`, realized witness, exact n(n-1)/2 comparison count

**Problem**: "What is the complexity of finding the actual monotonic subsequence?" (OQ-02 of `erdos-szekeres`). The problem was flagged BLOCKED in June solely because every build route was down; Docker is back, so this session unblocked it and landed the first Lean artifact.

**Build**: Docker-verified on this branch head — `Built Proofs.ErdosSzekeresOQ02` (8577 jobs, exit 0). New file has **0 sorries, 0 axioms** (imports the parent for definitions only; no parent axiom is used).

### What is proved (`proofs/Proofs/ErdosSzekeresOQ02.lean`, 319 LOC)

The parent's `maxIncLen` is `noncomputable` (Classical `Nat.findGreatest` over a `Prop` existential) — it asserts a monotone subsequence exists but cannot produce one. This file formalizes the elementary layer of the classical answer:

- `incDP` — a **computable** quadratic DP for the LIS-length ending at each position (well-founded recursion on `i.val`), with the attach-free recurrence `incDP_eq` and bounds `one_le_incDP`, `incDP_le_index_succ`.
- `ExactIncEnd` + `ExactIncEnd.extend` — the key technical move: the parent's ending-at predicate lets the last position fall short of `i`, which is too weak to extend chains; the strengthened "ends exactly at i" invariant makes the `Fin.snoc` extension work, then downgrades to the parent predicate.
- `exactIncEnd_incDP` / `hasIncreasingEndingAt_incDP` — the DP value is **realized** by an actual increasing subsequence ending at `i` (the parent's own predicate).
- `incDP_le_maxIncLen` — soundness against the noncomputable spec, obtained **without** sibling oq-01's pending extension lemma (via realized witness + `Nat.le_findGreatest`).
- `exists_increasingSubseq_incDP : Nonempty (IncreasingSubseq f (incDP f i))` — a subsequence structure of the DP length exists at every position.
- **Exact comparison count**: `incDPcost n = n(n-1)/2` (`incDPcost_closed`) and the division-free `incDPcost n * 2 = n(n-1)`, with the cost semantically grounded as the scanned candidate-pair count (`scanned`, `card_scanned`, `preds_subset_scanned`) — the Θ(n²) bound as an exact equation, following the Garner cost-model precedent.
- Executable `#eval` smoke tests in-file (DP table `[1,1,2,1,3,4,2,4]` on `[3,1,4,1,5,9,2,6]`, cost `28 = C(8,2)`) — the point of the OQ: the parent's spec admits no evaluation at all.

Out of Lean scope by design (documented in the header, not attempted): Θ(n log n) patience sorting and Fredman's Ω(n log n) lower bound — Mathlib has no comparison-cost model.

### Honest status

- Milestone 1 of the pinned plan is **complete**; milestone 2 is **half done** (`≤` direction only — full correctness `incDP = maxIncLen` still needs the stripping/optimal-substructure direction, exact statement recorded in knowledge.md).
- Milestone 3 (computable `incWitness` returning the index map as data) is designed (`List.argmax` selection) but not built.
- Also added the mandatory "Must prove exactly / does not count" pinning to problem.md, and updated state/knowledge/tracker (BLOCKED → ACT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
