### PR TITLE
audit: mark basel-problem clean (reserve re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2133,9 +2133,9 @@
       "result": "clean"
     },
     "basel-problem": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:47Z",
+      "lastAudited": "2026-07-24T05:09:14Z",
       "result": "clean"
     },
     "basel-problem-oq-01": {


### PR DESCRIPTION
## Summary
- Reserve re-audit of `basel-problem` (queue was fully drained: 4811/4811 audited, 0 issues).
- Verified 9 theorems, 0 axioms, 0 sorries, no `native_decide`, no True stubs.
- `mathlib` badge and `originalContributions` correctly scoped: core `basel_hasSum` is a direct call to Mathlib's `hasSum_zeta_two`; original work is pedagogical wrappers, positivity lemmas, and extensions to ζ(4)/ζ(2k).
- Result: clean, no fix needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)