### PR TITLE
audit: mark basel-problem-oq-01 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2139,9 +2139,9 @@
       "result": "clean"
     },
     "basel-problem-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:47Z",
+      "lastAudited": "2026-07-24T05:12:05Z",
       "result": "clean"
     },
     "basel-problem-oq-01-oq-01": {


### PR DESCRIPTION
## Summary
- Re-served (round-robin) audit of `basel-problem-oq-01` (ζ(5) irrationality open question).
- Verified all meta.json counts against `Proofs/ZetaFiveIrrationality.lean`: 3 axioms, 1 sorry, 15 theorems, 1 definition — all exact matches.
- `status: axiomatized` / `badge: axiom` correctly reflects that this is a genuinely open problem (ζ(5) irrationality unresolved) with partial results (Apéry, Rivoal, Zudilin) axiomatized and disclosed.
- Cross-references all resolve to existing gallery entries.
- No open PR touches this exact slug; no issues found.

## Test plan
- [x] `grep` counts in Lean source match meta.json exactly
- [x] Prose reviewed for overclaiming — none found
- [x] Cross-reference targets verified to exist