### PR TITLE
research(erdos-179): complete F supersaturation def + prove AP_free_has_2APs (2 sorries, 0 axioms)

### DIFF
--- a/proofs/Proofs/Erdos179Problem.lean
+++ b/proofs/Proofs/Erdos179Problem.lean
@@ -68,9 +68,17 @@ noncomputable def F (k N ℓ : ℕ) : ℕ :=
   where
     supersaturation_exists (k N ℓ : ℕ) : ∃ M, ∀ A : Finset ℕ,
         A.card = N → countAPs A k ≥ M → ContainsAP A ℓ := by
-      use N^2 + 1  -- Trivial upper bound
+      -- Trivial existence: at most `2 ^ N` subsets of `A` exist, so a set of size
+      -- `N` can never contain `2 ^ N + 1` many k-APs; the hypothesis is vacuous.
+      refine ⟨2 ^ N + 1, ?_⟩
       intro A hN hcount
-      sorry
+      exfalso
+      have hle : countAPs A k ≤ 2 ^ N := by
+        have h1 : countAPs A k ≤ A.powerset.card := by
+          unfold countAPs
+          exact Finset.card_filter_le _ _
+        rwa [Finset.card_powerset, hN] at h1
+      omega
 
 /-- The property that F_k(N, ℓ) captures. -/
 def SupersaturationProperty (k N ℓ M : ℕ) : Prop :=
@@ -205,10 +213,50 @@ axiom behrend_construction :
       ∃ A : Finset (Fin N), ¬ContainsAP (A.map (Fin.valEmbedding)) 3 ∧
         (A.card : ℝ) ≥ N / Real.exp (c * Real.sqrt (Real.log N))
 
-/-- In a 3-AP-free set, every pair of distinct elements forms a 2-AP. -/
-theorem AP_free_has_2APs (A : Finset ℕ) (hA : ¬ContainsAP A 3) :
+/-- A 2-term AP is just the (unordered) pair of its two entries. -/
+theorem arithmeticProgression_two (a d : ℕ) :
+    arithmeticProgression a d 2 = {a, a + d} := by
+  ext x
+  simp only [arithmeticProgression, Finset.mem_image, Finset.mem_range,
+    Finset.mem_insert, Finset.mem_singleton]
+  constructor
+  · rintro ⟨i, hi, rfl⟩
+    interval_cases i
+    · left; ring
+    · right; ring
+  · rintro (rfl | rfl)
+    · exact ⟨0, by norm_num, by ring⟩
+    · exact ⟨1, by norm_num, by ring⟩
+
+/-- Every pair of distinct elements forms a 2-AP, so the number of 2-term APs in
+    any set is exactly `C(|A|, 2)`. (The 3-AP-free hypothesis is not needed: the
+    identity holds for every finite set.) -/
+theorem AP_free_has_2APs (A : Finset ℕ) (_hA : ¬ContainsAP A 3) :
     countAPs A 2 = A.card.choose 2 := by
-  sorry  -- Every pair {a, b} with a < b is a 2-AP with d = b - a
+  have key : (A.powerset.filter fun S => ∃ a d, d > 0 ∧ S = arithmeticProgression a d 2)
+      = A.powersetCard 2 := by
+    ext S
+    simp only [Finset.mem_filter, Finset.mem_powerset, Finset.mem_powersetCard]
+    constructor
+    · rintro ⟨hSA, a, d, hd, rfl⟩
+      exact ⟨hSA, by rw [arithmeticProgression_two, Finset.card_pair (by omega)]⟩
+    · rintro ⟨hSA, hcard⟩
+      refine ⟨hSA, ?_⟩
+      rw [Finset.card_eq_two] at hcard
+      obtain ⟨x, y, hxy, rfl⟩ := hcard
+      rcases lt_or_gt_of_ne hxy with hlt | hgt
+      · refine ⟨x, y - x, by omega, ?_⟩
+        rw [arithmeticProgression_two]
+        have : x + (y - x) = y := by omega
+        rw [this]
+      · refine ⟨y, x - y, by omega, ?_⟩
+        rw [arithmeticProgression_two]
+        have : y + (x - y) = x := by omega
+        rw [this, Finset.pair_comm]
+  have hcard : countAPs A 2 = (A.powersetCard 2).card := by
+    unfold countAPs
+    rw [key]
+  rw [hcard, Finset.card_powersetCard]
 
 /-
 ## Part IX: Special Cases and Asymptotics

--- a/src/data/proofs/erdos-179/meta.json
+++ b/src/data/proofs/erdos-179/meta.json
@@ -17,15 +17,15 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 8,
+    "sorries": 6,
     "erdosNumber": 179,
     "erdosUrl": "https://erdosproblems.com/179",
     "erdosProblemStatus": "solved",
     "axiomCount": 14,
-    "lineCount": 255,
-    "assumptions": "14 axiom(s) across the chain: 6 in Erdos179Problem.lean (F_lower_bound, fox_pohoata_theorem, leng_sah_sawhney, szemeredi_theorem, roth_theorem, behrend_construction) + 8 in Stubs/Erdos179Problem.lean (6 duplicates of the main-file axioms plus random_set_APs and dense_sets_many_3APs unique to the stub scaffold). 8 sorries in the main proof. See the Lean sources for details.",
+    "lineCount": 303,
+    "assumptions": "14 axiom(s) across the chain: 6 in Erdos179Problem.lean (F_lower_bound, fox_pohoata_theorem, leng_sah_sawhney, szemeredi_theorem, roth_theorem, behrend_construction) + 8 in Stubs/Erdos179Problem.lean (6 duplicates of the main-file axioms plus random_set_APs and dense_sets_many_3APs unique to the stub scaffold). 6 sorries remain in the main proof (the F supersaturation-threshold definition is now complete and arithmeticProgression_two / AP_free_has_2APs are proved). See the Lean sources for details.",
     "mathlib_version": "4.31.0",
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 9,
     "additionalFiles": [
       "Proofs/Erdos179ProblemAristotle.lean",
@@ -56,10 +56,10 @@
     {
       "id": "sec-header-erdos-179",
       "title": "Problem Statement and Background",
-      "summary": "States Erd\u0151s Problem #179 on arithmetic-progression supersaturation, resolved by Fox\u2013Pohoata (2020) and sharpened by Leng\u2013Sah\u2013Sawhney (2024): the threshold $F_k(N,\\ell)$ for forcing an $\\ell$-term AP from many $k$-term APs satisfies $F_k(N,\\ell) = N^{2-o(1)}$.",
+      "summary": "States Erdős Problem #179 on arithmetic-progression supersaturation, resolved by Fox–Pohoata (2020) and sharpened by Leng–Sah–Sawhney (2024): the threshold $F_k(N,\\ell)$ for forcing an $\\ell$-term AP from many $k$-term APs satisfies $F_k(N,\\ell) = N^{2-o(1)}$.",
       "startLine": 1,
       "endLine": 31,
-      "mathContext": "Builds on Szemer\u00e9di's theorem, Roth's theorem, and Behrend's construction; Fox\u2013Pohoata give $F_k(N,\\ell) \\le N^2/(\\log\\log N)^{C_\\ell}$, improved by Leng\u2013Sah\u2013Sawhney to a doubly-exponential saving."
+      "mathContext": "Builds on Szemerédi's theorem, Roth's theorem, and Behrend's construction; Fox–Pohoata give $F_k(N,\\ell) \\le N^2/(\\log\\log N)^{C_\\ell}$, improved by Leng–Sah–Sawhney to a doubly-exponential saving."
     },
     {
       "id": "imports",
@@ -170,12 +170,12 @@
       "Finset"
     ],
     "namespace": "Erdos179",
-    "lineCount": 255,
+    "lineCount": 303,
     "axiomCount": 6,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 9,
     "path": "Proofs/Erdos179Problem.lean",
-    "sorries": 8,
+    "sorries": 6,
     "additionalFiles": [
       "Proofs/Erdos179ProblemAristotle.lean",
       "Proofs/Erdos179Aristotle.lean",
@@ -208,5 +208,5 @@
       "description": "Related Erdős problem sharing themes: additive-combinatorics, arithmetic-progressions, ramsey-theory"
     }
   ],
-  "sorries": 8
+  "sorries": 6
 }

--- a/src/data/research/problems/erdos-179-incomplete-01-oq-02.json
+++ b/src/data/research/problems/erdos-179-incomplete-01-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-179-incomplete-01-oq-02",
   "title": "Can a quantitative lower bound on countAPs for structured sets (e.g.",
-  "phase": "OBSERVE",
+  "phase": "ORIENT",
   "status": "available",
   "tier": "B",
   "path": "full",
@@ -23,19 +23,27 @@
     "goal": "Formalize the question in Lean 4 (or establish a rigorous negative result), reusing the parent entry's lemmas."
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ORIENT",
     "since": "2026-07-09T00:00:00Z",
-    "iteration": 0,
-    "focus": "Newly seeded by Seeker; awaiting Researcher OBSERVE pass."
+    "iteration": 1,
+    "focus": "researcher-2: axiom-free sorry elimination (F def completed, AP_free_has_2APs proved); remaining sorries deep."
   },
   "knowledge": {
-    "progressSummary": "Seeded stub. No research performed yet.",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS (researcher-2, 2026-07-23): eliminated 2 of 8 sorries in Erdos179Problem.lean, both axiom-free (#print axioms = propext/Classical.choice/Quot.sound). (1) Completed the F(k,N,ℓ) supersaturation-threshold DEFINITION: its Nat.find existence witness was a def-sorry; replaced witness N²+1 with 2^N+1 and discharged it via countAPs A k ≤ |A.powerset| = 2^N (card_filter_le + card_powerset), so the hypothesis countAPs A k ≥ 2^N+1 is vacuous. (2) Proved AP_free_has_2APs: countAPs A 2 = C(|A|,2) for EVERY finite A (the 3-AP-free hypothesis is unnecessary) — every 2-subset {x,y} is the 2-AP {x, x+(y-x)}; the 2-AP finset filter equals A.powersetCard 2, then card_powersetCard. Added helper arithmeticProgression_two: arithmeticProgression a d 2 = {a, a+d}. Remaining 6 sorries are DEEP (Fox-Pohoata / Leng-Sah-Sawhney asymptotics, exponent_is_2 limit, F_upper_trivial N² bound, F_2_well_defined possibly false-as-stated off-by-one).",
+    "builtItems": [
+      "arithmeticProgression_two (Erdos179Problem.lean): arithmeticProgression a d 2 = {a, a+d}",
+      "Completed def F via 2^N+1 Nat.find witness (Erdos179Problem.lean:66) — F is now sorry-free",
+      "AP_free_has_2APs proved (Erdos179Problem.lean): countAPs A 2 = A.card.choose 2"
+    ],
+    "insights": [
+      "countAPs A k ≤ 2^(|A|) trivially (filter of A.powerset), so the F supersaturation threshold always exists — no density input needed for well-definedness.",
+      "countAPs A 2 = C(|A|,2) identically: every unordered pair is a 2-term AP, so the 3-AP-free hypothesis in AP_free_has_2APs is vacuous.",
+      "F_2_well_defined (F 2 N ℓ ≤ C(N,2)) looks FALSE as stated: since countAPs A 2 = C(N,2) always, the property at M=C(N,2) would force every size-N set to contain an ℓ-AP; only M=C(N,2)+1 is vacuously satisfiable, giving F 2 N ℓ ≤ C(N,2)+1."
+    ],
     "nextSteps": [
-      "Survey the parent gallery entry and its Lean source.",
-      "State the question precisely in Lean 4.",
-      "Identify supporting Mathlib theory."
+      "F_upper_trivial (F k N ℓ ≤ N²): prove reusable countAPs A k ≤ (|A|)² for k≥2 via injection (a,d)↦(min two AP elements) into A×A.",
+      "Reconsider/correct F_2_well_defined (likely off-by-one, ≤ C(N,2)+1).",
+      "Remaining asymptotic sorries depend on the deep Fox-Pohoata / Leng-Sah-Sawhney axioms — not elementary."
     ]
   },
   "tags": [
@@ -47,7 +55,7 @@
     "research"
   ],
   "started": "2026-07-09T00:00:00Z",
-  "lastUpdate": "2026-07-09T00:00:00Z",
+  "lastUpdate": "2026-07-23",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Two axiom-free `sorry` eliminations in `proofs/Proofs/Erdos179Problem.lean` (Erdős #179, AP supersaturation). Sorries **8 → 6**, axioms unchanged (14).

### 1. Completed the `F` supersaturation-threshold definition (def-sorry)

`F k N ℓ` is defined as `Nat.find` over an existence proof `supersaturation_exists`, whose witness (`N²+1`) was left as `sorry` — so `F` was **ill-defined**. Since the specific witness does not affect `F`'s value (it is the *least* `M` with the property), I swapped it for the trivially-bounded `2^N+1`:

```
countAPs A k = (A.powerset.filter …).card ≤ A.powerset.card = 2^(A.card) = 2^N
```

so the hypothesis `countAPs A k ≥ 2^N+1` is vacuous. `F` is now a complete, `sorry`-free definition (`#print axioms Erdos179.F` = foundational only).

### 2. Proved `AP_free_has_2APs`

`countAPs A 2 = C(|A|, 2)` for **every** finite `A` — every unordered pair `{x,y}` is the 2-term AP `{x, x+(y-x)}`, so the stated `¬ContainsAP A 3` hypothesis is unnecessary (binder renamed `_hA`). Proof shows the 2-AP filter equals `A.powersetCard 2`, then applies `card_powersetCard`. Added helper `arithmeticProgression_two : arithmeticProgression a d 2 = {a, a+d}`.

## Verification

- Host-verified: `lake env lean Proofs/Erdos179Problem.lean` (Lean v4.31.0), **EXIT 0**, 0 errors.
- `#print axioms` on `F`, `AP_free_has_2APs`, `arithmeticProgression_two` → `{propext, Classical.choice, Quot.sound}` only. No `sorryAx`, no `native_decide`/`ofReduceBool`.

## Remaining work (out of scope)

The 6 remaining sorries are deep asymptotics resting on the file's Fox–Pohoata / Leng–Sah–Sawhney axioms. Note recorded in the tracker: `F_2_well_defined` (`F 2 N ℓ ≤ C(N,2)`) appears **false as stated** (off-by-one — it should be `≤ C(N,2)+1`, since `countAPs A 2 = C(N,2)` always).
