### PR TITLE
audit(tracker): record descartes-rule-of-signs-oq-02 clean audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7429,11 +7429,11 @@
       "result": "clean"
     },
     "descartes-rule-of-signs-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [
         "PR #6448: sorries 2→0, lineCount 552→698"
       ],
-      "lastAudited": "2026-05-04T04:04:48Z",
+      "lastAudited": "2026-07-24T05:24:14Z",
       "result": "clean"
     },
     "descartes-rule-of-signs-oq-02-oq-01": {


### PR DESCRIPTION
## Summary
- Gallery integrity audit of `descartes-rule-of-signs-oq-02` (Budan's Theorem).
- Verified 0 sorries, 0 True stubs, no native_decide, and the 3 disclosed axioms (`budan_upper_bound_axiom`, `budan_parity_axiom`, `budanCount_large_axiom`) exist and match the `assumptions` prose.
- theoremCount 43 confirmed once `@[simp]`-prefixed declarations (missed by a naive anchored grep) are counted.
- Tier C `axiomatized`/`axiom` status/badge and narrative are accurate — no overclaiming found.
- Result: **clean**, recorded in `audit-tracker.json`.

## Test plan
- [x] `./scripts/auditor/quickcheck.sh descartes-rule-of-signs-oq-02` cross-checked against `meta.json`
- [x] Manual grep of axioms/sorries/native_decide in `proofs/Proofs/DescartesRuleOfSignsOQ02.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)