### PR TITLE
Research: shapley-folkman-oq-01 - S2-D ℓ² lift, negative answer VERIFIED (0-axiom)

### DIFF
--- a/proofs/Proofs/ShapleyFolkmanOQ01.lean
+++ b/proofs/Proofs/ShapleyFolkmanOQ01.lean
@@ -35,6 +35,7 @@ import Mathlib.Analysis.Normed.Module.Convex
 import Mathlib.Analysis.InnerProductSpace.PiL2
 import Mathlib.Analysis.Convex.Hull
 import Mathlib.Analysis.Convex.Segment
+import Mathlib.Analysis.Normed.Lp.lpSpace
 import Proofs.ShapleyFolkman
 
 set_option linter.unusedVariables false
@@ -394,6 +395,83 @@ theorem no_universal_shapley_folkman_bound :
   intro K
   refine ⟨midpointDecomp (K + 1), ?_⟩
   rw [tight_excess_count (K + 1) (midpointDecomp (K + 1))]
+  exact Nat.lt_succ_self K
+
+/-! ### S2-D — the genuine `ℓ²` infinite-dimensional lift
+
+    The results above live in `EuclideanSpace ℝ (Fin N)`, which is
+    finite-dimensional; they show the parent `Module.finrank` bound is *sharp*
+    but stay inside finite dimensions. This section carries the tightness family
+    into the honest infinite-dimensional Hilbert space `ℓ² = lp (fun _ : ℕ => ℝ) 2`
+    via an injective linear embedding `ιN : EuclideanSpace ℝ (Fin N) →ₗ[ℝ] ℓ²`
+    and the `Decomposition.map` transport core, producing a *literal* family of
+    subsets of `ℓ²` whose Shapley–Folkman excess count is unbounded. Since
+    `Module.finrank ℝ ℓ² = 0`, this refutes the literal `card ≤ finrank` parent
+    bound in `ℓ²` and confirms the negative answer to OQ-01: the finite-dimensional
+    hypothesis cannot be dropped. -/
+
+/-- **The embedding** `EuclideanSpace ℝ (Fin N) →ₗ[ℝ] lp (fun _ : ℕ => ℝ) 2`.
+
+    A finite sum of single-coordinate injections: coordinate `i : Fin N` of the
+    input is placed at coordinate `i.val : ℕ` of the `ℓ²` output via `lp.lsingle`. -/
+noncomputable def ιN (N : ℕ) :
+    EuclideanSpace ℝ (Fin N) →ₗ[ℝ] lp (fun _ : ℕ => ℝ) 2 where
+  toFun v := ∑ i : Fin N, lp.lsingle 2 (i.val) (v i)
+  map_add' v w := by
+    simp only [PiLp.add_apply, map_add, Finset.sum_add_distrib]
+  map_smul' c v := by
+    simp only [PiLp.smul_apply, map_smul, RingHom.id_apply, Finset.smul_sum]
+
+/-- Coordinate `j.val` of `ιN N v` is exactly `v j`: distinct `Fin N` indices
+    land at distinct `ℕ` coordinates, so the single-coordinate injections do not
+    interfere. -/
+lemma ιN_apply_coord (N : ℕ) (v : EuclideanSpace ℝ (Fin N)) (j : Fin N) :
+    (ιN N v : ℕ → ℝ) j.val = v j := by
+  have hcoe : (ιN N v : ℕ → ℝ)
+      = ∑ i : Fin N, (Pi.single (i.val) (v i) : ℕ → ℝ) := by
+    simp only [ιN, LinearMap.coe_mk, AddHom.coe_mk, lp.coeFn_sum]
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [← lp.coeFn_single 2 (i.val) (v i)]
+  rw [hcoe, Finset.sum_apply]
+  simp only [Pi.single_apply, Fin.val_eq_val]
+  exact Fintype.sum_ite_eq j (fun i => v i)
+
+/-- `ιN N` is injective (it preserves every coordinate). -/
+lemma ιN_injective (N : ℕ) : Function.Injective (ιN N) := by
+  intro v w h
+  ext j
+  have hj := congrArg (fun y : lp (fun _ : ℕ => ℝ) 2 => (y : ℕ → ℝ) (j.val)) h
+  simpa only [ιN_apply_coord] using hj
+
+/-- **S2-D — Shapley–Folkman excess is unbounded in `ℓ²`.**
+    For every candidate bound `K : ℕ` there is a finite family of subsets of the
+    genuine infinite-dimensional Hilbert space `lp (fun _ : ℕ => ℝ) 2` (the images
+    under `ιN` of the finite-dimensional tightness family) and a target point whose
+    every `Decomposition` has `excessIndices.card > K`.
+
+    This is the honest infinite-dimensional negative result: the excess count is
+    unbounded in `ℓ²`, lifted from the `Fin N` tightness (`tight_excess_count`) via
+    the injective embedding `ιN` and the `Decomposition.map` transport core
+    (injectivity preserves the excess set, `map_excessIndices_card_of_injective`).
+    Because `Module.finrank ℝ (lp (fun _ : ℕ => ℝ) 2) = 0`, no `card ≤ finrank`
+    bound can hold here — the finite-dimensionality hypothesis of `shapley_folkman`
+    is essential and cannot be replaced by any fixed finite bound. -/
+theorem shapley_folkman_excess_unbounded_in_lp :
+    ∀ K : ℕ, ∃ (N : ℕ)
+      (D : ShapleyFolkman.Decomposition
+             (fun i : Fin N =>
+               (ιN N) '' ({0, EuclideanSpace.single i 1} :
+                   Set (EuclideanSpace ℝ (Fin N))))
+             (Finset.univ : Finset (Fin N))
+             ((ιN N) ((1 / 2 : ℝ) •
+                 ∑ i : Fin N, EuclideanSpace.single i (1 : ℝ) :
+                   EuclideanSpace ℝ (Fin N)))),
+      D.excessIndices.card > K := by
+  intro K
+  refine ⟨K + 1, (midpointDecomp (K + 1)).map (ιN (K + 1)), ?_⟩
+  rw [ShapleyFolkman.Decomposition.map_excessIndices_card_of_injective
+        (midpointDecomp (K + 1)) (ιN_injective (K + 1)),
+      tight_excess_count (K + 1) (midpointDecomp (K + 1))]
   exact Nat.lt_succ_self K
 
 end ShapleyFolkmanOQ01

--- a/proofs/Proofs/ShapleyFolkmanOQ01.lean
+++ b/proofs/Proofs/ShapleyFolkmanOQ01.lean
@@ -418,23 +418,26 @@ noncomputable def ιN (N : ℕ) :
     EuclideanSpace ℝ (Fin N) →ₗ[ℝ] lp (fun _ : ℕ => ℝ) 2 where
   toFun v := ∑ i : Fin N, lp.lsingle 2 (i.val) (v i)
   map_add' v w := by
-    simp only [PiLp.add_apply, map_add, Finset.sum_add_distrib]
+    rw [← Finset.sum_add_distrib]
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [PiLp.add_apply, map_add]
   map_smul' c v := by
-    simp only [PiLp.smul_apply, map_smul, RingHom.id_apply, Finset.smul_sum]
+    simp only [RingHom.id_apply, Finset.smul_sum]
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [PiLp.smul_apply, map_smul]
 
 /-- Coordinate `j.val` of `ιN N v` is exactly `v j`: distinct `Fin N` indices
     land at distinct `ℕ` coordinates, so the single-coordinate injections do not
     interfere. -/
 lemma ιN_apply_coord (N : ℕ) (v : EuclideanSpace ℝ (Fin N)) (j : Fin N) :
     (ιN N v : ℕ → ℝ) j.val = v j := by
-  have hcoe : (ιN N v : ℕ → ℝ)
-      = ∑ i : Fin N, (Pi.single (i.val) (v i) : ℕ → ℝ) := by
-    simp only [ιN, LinearMap.coe_mk, AddHom.coe_mk, lp.coeFn_sum]
-    refine Finset.sum_congr rfl (fun i _ => ?_)
-    rw [← lp.coeFn_single 2 (i.val) (v i)]
-  rw [hcoe, Finset.sum_apply]
-  simp only [Pi.single_apply, Fin.val_eq_val]
-  exact Fintype.sum_ite_eq j (fun i => v i)
+  simp only [ιN, LinearMap.coe_mk, AddHom.coe_mk, lp.coeFn_sum, Finset.sum_apply]
+  refine (Finset.sum_eq_single j ?_ ?_).trans ?_
+  · intro i _ hij
+    exact lp.single_apply_ne (E := fun _ : ℕ => ℝ) 2 (i.val) (v i)
+      (fun h => hij (Fin.val_injective h.symm))
+  · intro h; exact absurd (Finset.mem_univ j) h
+  · exact lp.single_apply_self (E := fun _ : ℕ => ℝ) 2 (j.val) (v j)
 
 /-- `ιN N` is injective (it preserves every coordinate). -/
 lemma ιN_injective (N : ℕ) : Function.Injective (ιN N) := by

--- a/research/problems/shapley-folkman-oq-01/sessions/2026-07-23-s2d-act-lp2-lift-verified.md
+++ b/research/problems/shapley-folkman-oq-01/sessions/2026-07-23-s2d-act-lp2-lift-verified.md
@@ -1,0 +1,81 @@
+# Session 21 — S2-D ACT: genuine ℓ² lift, VERIFIED (researcher-3, 2026-07-23)
+
+**Mode.** ACT (`.lean` + JSON + docs). **Outcome: COMPLETED, 0-axiom VERIFIED.**
+
+## 1. What shipped
+
+Executed the S2-D recipe from the Session-20 doc §4 (with v4.31 API
+adjustments) and **Docker-verified the whole file** — the sole reason the
+problem was `blocked` was that the Session-20 S2-C transport core had never
+been built (2026-06-13 Docker blackout). Docker is back up on the host.
+
+Added to `proofs/Proofs/ShapleyFolkmanOQ01.lean` (namespace
+`ShapleyFolkmanOQ01`, before `end`):
+
+| Decl | Role |
+|------|------|
+| `ιN (N)` | injective linear embedding `EuclideanSpace ℝ (Fin N) →ₗ[ℝ] lp (fun _:ℕ => ℝ) 2`, `∑ i, lp.lsingle 2 i.val (v i)` |
+| `ιN_apply_coord` | `(ιN N v) j.val = v j` — coordinate-preserving |
+| `ιN_injective` | injectivity (one-coordinate evaluation) |
+| `shapley_folkman_excess_unbounded_in_lp` | **capstone**: `∀ K, ∃ N (D : Decomposition … over ℓ² subsets), D.excessIndices.card > K` |
+
+New import: `Mathlib.Analysis.Normed.Lp.lpSpace`.
+
+**Build:** `docker-build.sh Proofs.ShapleyFolkmanOQ01` at
+`leanprover/lean4:v4.31.0` — `✔ Built (8577 jobs)`, 0 sorries, 0 axioms.
+Only warnings are pre-existing `EuclideanSpace.single_apply` deprecations at
+lines 257/259 (unrelated to this session, in `tight_excess_count`).
+
+## 2. Mathematical content
+
+`shapley_folkman_excess_unbounded_in_lp` takes the finite-dimensional
+tightness family `S i = {0, eᵢ}` with target `x = ½ ∑ eᵢ`
+(whose every decomposition has `excessIndices.card = N`,
+`tight_excess_count`) and pushes it forward along the injective embedding
+`ιN` via the `Decomposition.map` transport core (S2-C). Because `ιN` is
+injective, `map_excessIndices_card_of_injective` gives that the image
+decomposition `(midpointDecomp (K+1)).map (ιN (K+1))` still has excess card
+`= K+1 > K`. The image family lives in the **genuine** infinite-dimensional
+Hilbert space `ℓ² = lp (fun _:ℕ => ℝ) 2`.
+
+Since `Module.finrank ℝ ℓ² = 0`, this simultaneously (i) refutes the literal
+`card ≤ Module.finrank` parent bound in ℓ² and (ii) shows no *fixed finite*
+bound survives. Combined with the finite-dim results (S2-A, S2-B1), the
+negative answer to OQ-01 is now machine-verified end to end: the
+`FiniteDimensional` hypothesis of `shapley_folkman` is essential.
+
+## 3. v4.31 API notes (recipe drift from v4.26.0 pins)
+
+- **`lp.single_apply_self` / `lp.single_apply_ne` need `(E := fun _:ℕ => ℝ)`.**
+  The `E : α → Type*` family is a higher-order metavariable that cannot be
+  inferred from the value argument `v i : ℝ` (unifying `?E i =?= ℝ` is
+  ambiguous); the goal's concrete `lp` type does not back-propagate through
+  `exact`. Supplying `E` explicitly fixes it.
+- **`PiLp.add_apply` / `PiLp.smul_apply` are still `rfl`** and fire; the
+  `map_add'`/`map_smul'` fields close with `rw [← Finset.sum_add_distrib];
+  Finset.sum_congr … rw [PiLp.add_apply, map_add]` and the `smul` analog. The
+  original recipe's one-line `simp only [PiLp.add_apply, map_add,
+  Finset.sum_add_distrib]` left `X = X` unclosed under v4.31 — the explicit
+  `sum_congr` form is robust.
+- **EuclideanSpace coordinate access displays as `v.ofLp i`** (WithLp
+  refactor) but behaves as `v i`.
+- `ιN_apply_coord` closes via `simp only [ιN, LinearMap.coe_mk,
+  AddHom.coe_mk, lp.coeFn_sum, Finset.sum_apply]` then
+  `Finset.sum_eq_single j` + `single_apply_self`/`single_apply_ne` +
+  `Fin.val_injective` — no `Fintype.sum_ite_eq` needed (that route hit a
+  stuck `AddCommMonoid` metavariable).
+
+## 4. Race-safety log
+
+- Worktree reaped once mid-session by the janitor (before any edit);
+  recreated at `/Volumes/Stripe/lean-genius/researcher-3` off `origin/main`.
+- Branch `research/shapley-folkman-oq-01-s2d-lp2-lift` off `origin/main`
+  (feature/researcher-3 was 3605 commits behind — not used).
+- Pre-PR: no open OQ01 PRs; `check-superseded.sh` run before opening.
+
+## 5. Status
+
+**COMPLETED — OQ-01 answered NO, machine-verified (0 axioms, 0 sorries).**
+No follow-up OQ generated: the negative answer is complete, and the only open
+direction (positive Aumann/Lyapunov analog) needs new Mathlib measure-theory
+infrastructure and belongs to a separate problem, not a child of this OQ.

--- a/research/problems/shapley-folkman-oq-01/state.md
+++ b/research/problems/shapley-folkman-oq-01/state.md
@@ -1,18 +1,35 @@
 # Research State: shapley-folkman-oq-01
 
 ## Current State
-**Phase**: ACT (S2-C ACT — Session 20, researcher-2, 2026-06-13.
-Shipped the `Decomposition.map` transport core: general linear-map
-transport `Decomposition S t x → Decomposition (f '' S ·) t (f x)` plus
-`map_point`, `map_excessIndices_of_injective`, and its card form. This
-is the reusable engine for the S2-B₂ `lp 2` lift. +~55 LOC, 0 sorries,
-0 axioms. **Build UNVERIFIED locally — Docker daemon down on host;**
-CI/doctor to verify on PR. S2-B₂ embedding (`ιN` + injectivity + final
-theorem) made paste-ready in the Session 20 doc §4.)
+**Phase**: COMPLETED (S2-D ACT — Session 21, researcher-3, 2026-07-23.
+Shipped and **Docker-verified** the genuine ℓ² lift: injective embedding
+`ιN : EuclideanSpace ℝ (Fin N) →ₗ[ℝ] lp (fun _:ℕ => ℝ) 2`, `ιN_apply_coord`,
+`ιN_injective`, and the capstone `shapley_folkman_excess_unbounded_in_lp`
+(excess card unbounded over ℓ² subsets, lifted from `Fin N` tightness via
+the S2-C `Decomposition.map` core). Build clean at v4.31.0 — 8577 jobs,
+0 sorries, 0 axioms — which ALSO retro-verifies the Session-20 S2-C core
+left unverified during the 2026-06-13 Docker blackout, the sole reason
+this problem was `blocked`. **OQ-01 answered NO, machine-verified end to
+end.** Only remaining direction is the separate positive Aumann/Lyapunov
+analog, out of scope for this OQ.)
 **Path**: full
 **Since**: 2026-06-13
-**Last Updated**: 2026-06-13 (S2-C ACT, researcher-2)
-**Iteration**: 20
+**Last Updated**: 2026-07-23 (S2-D ACT VERIFIED, researcher-3)
+**Iteration**: 21
+
+## Session 21 — S2-D ACT: genuine ℓ² lift, VERIFIED (researcher-3, 2026-07-23)
+
+**Mode.** ACT (`.lean` + JSON + docs). **Outcome: COMPLETED, 0-axiom VERIFIED.**
+
+Executed the Session-20 §4 S2-D recipe with v4.31 API fixes and ran the
+first Docker build since the blackout: `✔ Built Proofs.ShapleyFolkmanOQ01
+(8577 jobs)`, 0 sorries, 0 axioms. Added `ιN`, `ιN_apply_coord`,
+`ιN_injective`, `shapley_folkman_excess_unbounded_in_lp` (+ import
+`Mathlib.Analysis.Normed.Lp.lpSpace`). The negative answer to OQ-01 is now
+complete and machine-checked in both `EuclideanSpace` (tightness) and `ℓ²`
+(unboundedness). Full write-up: `sessions/2026-07-23-s2d-act-lp2-lift-verified.md`.
+Key v4.31 drift: `lp.single_apply_self/ne` need explicit `(E := fun _:ℕ => ℝ)`;
+`map_add'/map_smul'` want the explicit `Finset.sum_congr` form, not one-shot simp.
 
 ## Session 20 — S2-C ACT: `Decomposition.map` transport core (researcher-2, 2026-06-13)
 

--- a/src/data/research/problems/shapley-folkman-oq-01.json
+++ b/src/data/research/problems/shapley-folkman-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "shapley-folkman-oq-01",
   "title": "Shapley–Folkman extension to infinite-dim Hilbert spaces",
   "phase": "ACT",
-  "status": "blocked",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -28,15 +28,14 @@
     "goal": "Create proofs/Proofs/ShapleyFolkmanOQ01.lean with a formalized negative result (Approach C: ℓ² counter-example to literal Shapley–Folkman extension), documenting the obstruction precisely. Approach A (Aumann/Lyapunov) is deferred to a future sub-OQ given its multi-session upstream prerequisites."
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-06-13T00:00:00Z",
     "iteration": 20,
-    "focus": "S2-C ACT — Decomposition.map transport core shipped (researcher-2, 2026-06-13). Added a ShapleyFolkman-namespace block to ShapleyFolkmanOQ01.lean: Decomposition.map (general linear-map transport Decomposition S t x → Decomposition (f  S ·) t (f x)), map_point (rfl simp lemma), map_excessIndices_of_injective (injective f ⟹ excess sets equal), and map_excessIndices_card_of_injective (card form, the transfer lemma). This is the reusable engine for the S2-B₂ lp 2 lift. ~55 LOC, 0 sorries, 0 axioms. BUILD UNVERIFIED LOCALLY: Docker daemon down on host and .lake symlink loop persists; CI/doctor verifies on PR. Bearers pinned via GitHub API at v4.26.0 (LinearMap.image_convexHull Hull.lean:167, Function.Injective.mem_set_image Image.lean:192, Finset.filter_congr Filter.lean:179).",
+    "focus": "S2-D ACT COMPLETE (researcher-3, 2026-07-23). The genuine ℓ² infinite-dimensional negative result is Docker-verified (v4.31.0, 8577 jobs, 0 sorries, 0 axioms). Added ιN : EuclideanSpace ℝ (Fin N) →ₗ[ℝ] lp (fun _:ℕ => ℝ) 2 (injective linear embedding, sum of lp.lsingle), ιN_apply_coord (coordinate-preserving), ιN_injective, and shapley_folkman_excess_unbounded_in_lp (excess card unbounded over ℓ² subsets, lifted from Fin N tightness via Decomposition.map). This ALSO verifies the Session-20 S2-C transport core, previously build-unverified during the 2026-06-13 Docker blackout — the sole reason the problem was marked blocked. OQ-01 negative answer now complete and machine-checked: the FiniteDimensional hypothesis of shapley_folkman cannot be dropped, and no fixed finite bound survives in genuine infinite dimensions (Module.finrank ℝ ℓ² = 0).",
     "blockers": [
-      "Docker daemon down on host (verification blackout 2026-06-13): S2-D ACT is a paste-ready ~60-90 LOC build-dependent extension and cannot be verified locally; CI does not build Lean during the blackout. Flagged blocked 2026-06-13 (researcher-1) - re-open the moment Docker returns; S2-D is ~5-10 min wall-clock from the paste-ready recipe. Slug is otherwise fully synced (origin/main .lean at 399 LOC, 0 sorries, 0 axioms; S2-A + S2-B1 + S2-C lines complete; no open PRs).",
-      "Lyapunov's convexity theorem (Approach A prerequisite): not in Mathlib; multi-session formalization project."
+      "Lyapunov/Aumann positive infinite-dim analog (Approach A, OUT OF SCOPE for OQ-01 negative answer): Lyapunov convexity theorem not in Mathlib; multi-session formalization project. Not a blocker on the (completed) negative answer."
     ],
-    "nextAction": "S2-D ACT (next session): paste the S2-B₂ embedding from session 2026-06-13 doc §4 — ιN : EuclideanSpace ℝ (Fin N) →ₗ[ℝ] lp (fun _ : ℕ => ℝ) 2 (sum of lp.lsingle 2 i.val), ιN_injective (coordinate evaluation via lp.single_apply + Fin.val_injective), and shapley_folkman_excess_unbounded_in_lp = (midpointDecomp (K+1)).map (ιN (K+1)) + map_excessIndices_card_of_injective + tight_excess_count. ~60-90 LOC; only real risk is lp/PiLp coercion friction in ιN_apply_coord. lp bearers re-pinned v4.26.0 in doc §4.4.",
+    "nextAction": "None required for the negative answer — OQ-01 is answered (NO) and machine-verified in EuclideanSpace (tightness) and ℓ² (unboundedness). A distinct, deferred direction is the POSITIVE infinite-dim analog (Aumann 1965 / Lyapunov 1940 convexity), which needs set-valued measure machinery absent from Mathlib (~200-300 LOC) and belongs to a separate problem, not this OQ.",
     "attemptCounts": {
       "total": 20,
       "currentApproach": 19,
@@ -101,7 +100,7 @@
     }
   ],
   "knowledge": {
-    "progressSummary": "S2-A ACT-1 (Session 8, 2026-05-13): first .lean discharge after 7 doc-only PREPs. Landed proofs/Proofs/ShapleyFolkmanOQ01.lean (~130 LOC, 0 axioms, 2 sorries) with imports, namespace, attribute [local instance] Classical.propDecidable (mirroring parent), and three named results — convexHull_pair_zero_basis_extract helper lemma (attempted proof per S3 PREP §3.1), mem_convexHull_finset_sum (sorry-stubbed), tight_excess_count main theorem (sorry-stubbed). Registered in proofs/Proofs.lean (alphabetical between Aristotle and OQ03). Build verification deferred. Prior PREP chain (Sessions 1–7): S1 OBSERVE — literal finrank extension is vacuous in infinite-dim, Aumann/Lyapunov are correct analogs (neither in Mathlib); S1b — Aumann/Lyapunov Mathlib prerequisite audit; S2/S2b — Approach C ℓ² counter-example design + numeric verification at N=1..4; S3 — pair convex-hull parameter extraction Lean recipe (verbatim Mathlib chain); S3b — Mathlib v4.26.0 citation audit with 3 phantom-lemma corrections; S4 — parent ShapleyFolkman.lean source audit (Decomposition decidability + sum_close_to_convexHull bridge). Session 9 (STATE-SYNC, 2026-05-14, researcher-12): catch-up for merged S5 PREP (#18929) that explicitly scoped itself doc-only and did not touch state.md / JSON. Both surviving sorries in ShapleyFolkmanOQ01.lean now have verbatim Lean recipes (S5 PREP §3 for mem_convexHull_finset_sum, S3 PREP §4 + S4 PREP §3 for tight_excess_count). Remaining ACT-2 uncertainty is build-side only. Session 16 (S2-A ACT-4 PREP, 2026-06-04, researcher-1): doc-only PREP materialising the existence form `exists_tight_decomposition` into a 32-LOC paste-ready Lean recipe across three named results (helper lemma midpoint_mem_convexHull_pair_zero_basis, noncomputable def midpointDecomp, theorem exists_tight_decomposition). All five Mathlib v4.26.0 bearers re-verified at lake SHA; the only new bearer relative to the existing OQ01 file is Finset.smul_sum at Algebra/BigOperators/GroupWithZero/Action.lean:57-59. Four failure-mode fallbacks documented (§5 of session file). Race-safety probes clean: 0 open OQ01 PRs at claim time; OQ01 .lean file unchanged on origin/main since 2026-06-01T02:20Z. ACT deferred to next docker-available session — paste-ready recipe means the next session is ~5-10 min wall-clock. Session 17 (S2-A ACT-4 ACT, 2026-06-04, researcher-1, PR #22322): executed Session 16 recipe verbatim, file 228 → 306 LOC, +2 theorems + 1 def, 0 new sorries/axioms; PR merged 2026-06-05T01:45Z. S2-A line complete: parent bound is both unavoidable (tight_excess_count) and achievable (exists_tight_decomposition). Session 18 (S2-B PREP, 2026-06-09, researcher-1): doc-only PREP designing the truncation-lift line. Split S2-B into S2-B₁ (paste-ready ~15 LOC recipe for no_universal_shapley_folkman_bound, using existing midpointDecomp + tight_excess_count + Nat.lt_succ_self) and S2-B₂ (deferred multi-session lp 2 lift, ~150-250 LOC, requires linear-isometric embedding ι_N + Decomposition.map transport). Preliminary S2-B₂ bearer pins recorded for lp.single/lsingle/isometry_single/singleContinuousLinearMap from Analysis/Normed/Lp/lpSpace.lean (audited via GitHub raw at v4.26.0; researcher worktree .lake symlink loop precluded local audit). Race-safety probes clean: 0 open OQ01 PRs at claim time (2026-06-09 ~17:18Z); .lean file unchanged on origin/main since 2026-06-05T01:45Z. Session 19 (S2-B₁ ACT, 2026-06-10, researcher-10): executed Session 18 §3.1 recipe verbatim — pasted 33 LOC (docstring + theorem no_universal_shapley_folkman_bound) immediately before end ShapleyFolkmanOQ01. File 306 → 339 LOC, +1 theorem (total 7), 0 sorries, 0 axioms. Docker build clean: ✔ Built Proofs.ShapleyFolkmanOQ01 (231s, 7744/7744). The recipe body is three tactics as designed: refine ⟨midpointDecomp (K + 1), ?_⟩; rw [tight_excess_count (K + 1) (midpointDecomp (K + 1))]; exact Nat.lt_succ_self K. No fallbacks fired. S2-A and S2-B₁ lines complete. Race-safety probes clean: 0 open OQ01 PRs at claim time (2026-06-10 ~09:00Z). Session 20 (S2-C ACT, 2026-06-13): shipped the Decomposition.map transport core (general linear-map transport + injective excess-/card-preservation), the reusable engine reducing S2-B₂ to one injective embedding; build unverified locally (Docker down).",
+    "progressSummary": "COMPLETED (S2-D, researcher-3, 2026-07-23, VERIFIED 0-axiom). OQ-01 asked whether the FiniteDimensional hypothesis of shapley_folkman can be dropped by replacing Module.finrank with a suitable infinite-dim notion. Answer: NO, now machine-verified end to end. Finite-dim sharpness (tight_excess_count / exists_tight_decomposition, S2-A) shows the finrank bound is achieved with equality for every N; the truncation lift (no_universal_shapley_folkman_bound, S2-B1) rules out any ambient-dimension-blind bound; the Decomposition.map transport core (S2-C) plus the injective embedding ιN (S2-D) carry the tightness into the genuine infinite-dim Hilbert space ℓ², where shapley_folkman_excess_unbounded_in_lp gives unbounded excess and (finrank ℝ ℓ² = 0) refutes the literal parent bound. Docker build clean at v4.31.0 (8577 jobs, 0 sorries, 0 axioms), which also retro-verifies the S2-C core left unverified during the 2026-06-13 Docker blackout. The only remaining direction is the separate POSITIVE analog (Aumann/Lyapunov), out of scope here.",
     "builtItems": [
       "research/problems/shapley-folkman-oq-01/problem.md: full template fill-in with three approaches and references",
       "research/problems/shapley-folkman-oq-01/state.md: Session 1–8 entries with iteration history table",
@@ -114,14 +113,20 @@
       "research/problems/shapley-folkman-oq-01/sessions/2026-05-12-s3b-prep-mathlib-citation-audit.md: S3b v4.26.0 phantom-lemma corrections",
       "research/problems/shapley-folkman-oq-01/sessions/2026-05-13-s4-prep-parent-decomposition-source-audit.md: S4 parent file audit (decidability, sum_close_to_convexHull bridge)",
       "proofs/Proofs/ShapleyFolkmanOQ01.lean: S2-A ACT-1 scaffold (~130 LOC, 0 axioms, 2 sorries) — helper lemma with attempted proof + 2 stubbed theorems",
-      "proofs/Proofs.lean: registered import Proofs.ShapleyFolkmanOQ01 alphabetically"
+      "proofs/Proofs.lean: registered import Proofs.ShapleyFolkmanOQ01 alphabetically",
+      "ιN (N) in ShapleyFolkmanOQ01.lean: injective linear embedding EuclideanSpace ℝ (Fin N) →ₗ[ℝ] lp (fun _:ℕ => ℝ) 2",
+      "ιN_apply_coord, ιN_injective in ShapleyFolkmanOQ01.lean",
+      "shapley_folkman_excess_unbounded_in_lp in ShapleyFolkmanOQ01.lean: the ℓ² unbounded-excess capstone (S2-D)"
     ],
     "insights": [
       "Module.finrank ℝ E = 0 for any non-finite-dim ℝ-module in Lean's convention; this collapses the Shapley–Folkman bound to '≤ 0' which is vacuously false for any Minkowski sum with non-convex summands.",
       "excess_vertices_affine_dependent at ShapleyFolkman.lean:151 is the only step where [FiniteDimensional ℝ E] is load-bearing; in infinite-dim, AffineIndependent can hold for ω-sized families, so no Nat-valued dimension notion can recover the Carathéodory-style extraction.",
       "The correct infinite-dim analog of Shapley–Folkman is Aumann (1965)'s convexity of set-valued integrals, which is engine'd by Lyapunov (1940)'s vector-measure convexity. Neither theorem is in Mathlib.",
       "An explicit ℓ² (or EuclideanSpace ℝ (Fin n)) counter-example x = (1/2) ∑ᵢ eᵢ ∈ convexHull ℝ (∑ᵢ Sᵢ) with Sᵢ = {0, eᵢ} forces every index to be 'excess' (since each component is constrained to the orthogonal axis), giving excessIndices.card = n unbounded as n → ∞.",
-      "S5 PREP (PR #18929) names the Mathlib v4.26.0 lemma Set.finset_sum_mem_finset_sum (Mathlib/Algebra/Group/Pointwise/Set/BigOperators.lean:142, multiplicative + @[to_additive]) as the n-ary additive Minkowski-membership primitive — this supersedes the Set.add_mem_finset_sum guess in Session 8's Next Action, which is not the actual Mathlib v4.26.0 name at the lake-pinned SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67."
+      "S5 PREP (PR #18929) names the Mathlib v4.26.0 lemma Set.finset_sum_mem_finset_sum (Mathlib/Algebra/Group/Pointwise/Set/BigOperators.lean:142, multiplicative + @[to_additive]) as the n-ary additive Minkowski-membership primitive — this supersedes the Set.add_mem_finset_sum guess in Session 8's Next Action, which is not the actual Mathlib v4.26.0 name at the lake-pinned SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67.",
+      "S2-D VERIFIED (2026-07-23, v4.31.0): shapley_folkman_excess_unbounded_in_lp exhibits, for every K, a finite family of subsets of ℓ² = lp (fun _:ℕ => ℝ) 2 whose every Shapley-Folkman Decomposition has excessIndices.card > K. Honest infinite-dim negative result — no fixed finite bound holds.",
+      "The embedding ιN : EuclideanSpace ℝ (Fin N) →ₗ[ℝ] ℓ² is a sum of single-coordinate injections ∑ i, lp.lsingle 2 i.val (v i); injectivity is a one-coordinate evaluation (Finset.sum_eq_single + lp.single_apply_self/ne + Fin.val_injective).",
+      "v4.31 gotcha: lp.single_apply_self / single_apply_ne need explicit (E := fun _:ℕ => ℝ) — the E family is a higher-order metavariable that cannot be inferred from the value argument v i : ℝ alone. EuclideanSpace coordinate access now displays as v.ofLp i (WithLp refactor); PiLp.add_apply/smul_apply are still rfl."
     ],
     "techniques": [
       "EuclideanSpace ℝ (Fin n) + EuclideanSpace.basisFun for concrete finite-dim counter-example",
@@ -135,7 +140,7 @@
     ]
   },
   "createdAt": "2026-05-12",
-  "updatedAt": "2026-06-13T03:10:00Z",
+  "updatedAt": "2026-07-23T00:00:00Z",
   "relatedProofs": [
     "shapley-folkman",
     "shapley-folkman-oq-03",


### PR DESCRIPTION
## Summary
Research session for **shapley-folkman-oq-01** — completes and machine-verifies the negative answer to the open question "can `[FiniteDimensional ℝ E]` be dropped from `shapley_folkman` by replacing `Module.finrank ℝ E` with an infinite-dim notion?" **Answer: NO.**

This is the **S2-D** step: the genuine infinite-dimensional (ℓ²) lift, and the **first Docker build of this file since the 2026-06-13 blackout** — the sole reason the problem was marked `blocked`.

## Progress
- New import `Mathlib.Analysis.Normed.Lp.lpSpace`.
- `ιN : EuclideanSpace ℝ (Fin N) →ₗ[ℝ] lp (fun _ : ℕ => ℝ) 2` — injective linear embedding (`∑ i, lp.lsingle 2 i.val (v i)`), with `ιN_apply_coord` (coordinate-preserving) and `ιN_injective`.
- `shapley_folkman_excess_unbounded_in_lp`: for every `K` there is a finite family of subsets of ℓ² whose **every** Shapley–Folkman `Decomposition` has `excessIndices.card > K`, lifted from the `Fin N` tightness (`tight_excess_count`) via the S2-C `Decomposition.map` transport core.
- Tracker: `blocked → completed`; Docker blocker cleared; knowledge/state/session doc updated.

## Verification
`./proofs/scripts/docker-build.sh Proofs.ShapleyFolkmanOQ01` at `leanprover/lean4:v4.31.0` → **✔ Built (8577 jobs)**, **0 sorries, 0 axioms**. This build also retro-verifies the Session-20 **S2-C transport core**, previously build-unverified during the Docker blackout. (Pre-existing `EuclideanSpace.single_apply` deprecation warnings at lines 257/259 are unrelated to this change.)

## Findings
- Because `Module.finrank ℝ ℓ² = 0`, the ℓ² family both refutes the literal `card ≤ finrank` parent bound and shows no fixed finite bound survives in genuine infinite dimensions.
- v4.31 API drift from the v4.26 recipe pins: `lp.single_apply_self/ne` need explicit `(E := fun _:ℕ => ℝ)` (higher-order metavariable); `map_add'/map_smul'` want the explicit `Finset.sum_congr` form, not one-shot simp; `PiLp.add_apply/smul_apply` are still `rfl`.

## Status
**Outcome**: completed (OQ-01 answered NO, machine-verified end to end).
**Next Steps**: none for the negative answer. The distinct positive infinite-dim analog (Aumann 1965 / Lyapunov 1940 convexity) needs set-valued measure machinery absent from Mathlib and belongs to a separate problem, not a child of this OQ.

🤖 Generated by researcher-3
