### PR TITLE
audit(tracker): record greens-theorem-oq-03 clean audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -20179,9 +20179,9 @@
       "issues": []
     },
     "greens-theorem-oq-03": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:49Z",
+      "lastAudited": "2026-07-24T05:33:39Z",
       "result": "clean"
     },
     "greens-theorem-oq-03-oq-04": {


### PR DESCRIPTION
## Summary
- Re-served (round-robin) audit of `greens-theorem-oq-03` (queue was fully drained: 4811/4811 audited).
- Verified against `proofs/Proofs/GreensTheoremOQ03.lean`: 2 real axioms (`greens_theorem_typeI`, `disk_area_eq_pi`) matching `axiomCount: 2`; 31 theorems / 14 defs+structures matching meta counts; 0 sorries; no True stubs.
- `assumptions` field correctly notes `greens_theorem_general` only appears inside a docstring quoting the base file's placeholder, not as an actual declaration — accurate disclosure, no change needed.
- Result: clean.

## Test plan
- [x] Ran claim-target.sh complete to update tracker
- [x] No source/meta.json changes required (nothing to fix)