### PR TITLE
Enrich automorphic-number-oq-01-oq-01-oq-02: 5th keyInsight (98->100)

### DIFF
--- a/src/data/proofs/automorphic-number-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-01-oq-02/meta.json
@@ -189,7 +189,8 @@
       "Unitary divisors, squarefree divisors, and idempotents of ℤ/nℤ are all counted by the subsets of the prime-factor set of n — three realizations of the same binary choice at each prime, and all equal to 2^{ω(n)}.",
       "The single new ingredient beyond the squarefree count is factorization_eq_of_unitary: the coprimality gcd(d, n/d)=1 is exactly the condition that prevents a prime power from being split, so a unitary divisor keeps, at each of its primes, the full prime power dividing n.",
       "The 'into' direction is cleanest through the complementary primes: a = ∏_S and b = ∏_{complement} multiply to n and have disjoint prime supports, giving both a ∣ n with n/a = b and the coprimality gcd(a, n/a) = 1 in one stroke — avoiding any explicit computation of n/a.",
-      "Replacing the squarefree count's product ∏_{p∈s} p by the maximal-prime-power product ∏_{p∈s} p^{v_p(n)} reuses the entire powerset-bijection skeleton; only the membership and left-inverse lemmas need the exponent v_p(n)."
+      "Replacing the squarefree count's product ∏_{p∈s} p by the maximal-prime-power product ∏_{p∈s} p^{v_p(n)} reuses the entire powerset-bijection skeleton; only the membership and left-inverse lemmas need the exponent v_p(n).",
+      "Ordered by divisibility, the unitary divisors of n form a Boolean lattice isomorphic to the power set of n.primeFactors — join a=∏_S p^{v_p(n)} and b=∏_T p^{v_p(n)} for disjoint S,T correspond to disjoint union, and complementation S ↦ n.primeFactors\\S realizes d ↦ n/d. This is why the unitary count is always a power of two, in contrast to the full divisor lattice of n (a product of chains of lengths v_p(n)+1, giving d(n) = ∏(v_p(n)+1)), where a unitary divisor is exactly a join of atoms rather than an arbitrary chain element."
     ]
   },
   "conclusion": {


### PR DESCRIPTION
## Summary
- Adds a 5th `overview.keyInsights` item to close the keyInsights quality gap (4→5 items, 8/10 → 10/10 points), bringing the enrichment quality score from 98 to 100.
- New insight: the unitary divisors of n, ordered by divisibility, form a Boolean lattice isomorphic to the power set of `n.primeFactors` — a structural/lattice-theoretic complement to the existing computational insights, contrasting with the full divisor lattice (a product of chains).
- No other fields needed changes: annotations (8, all with mathContext/significance/relatedConcepts), historicalContext (>500 chars), conclusion, sections (5) were already at the scoring cap.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — valid JSON
- [x] `npx tsx scripts/enricher/find-targets.ts --all` confirms quality 98 → 100 for this entry
- [x] `pnpm build` gallery data-manifest generation step passes (pre-existing `tsc: command not found` failure in this worktree is an unrelated environment gap, not caused by this change)