### PR TITLE
Research: roth-theorem-k3-oq-03-incomplete-01 - k=3 instance of density_increment_kAP discharged (axiom-free, docker-verified)

### DIFF
--- a/proofs/Proofs/RothTheoremK3OQ03Incomplete01.lean
+++ b/proofs/Proofs/RothTheoremK3OQ03Incomplete01.lean
@@ -1,0 +1,86 @@
+/-
+  # Roth k = 3: Discharging the k = 3 Instance of `density_increment_kAP`
+
+  The parent file `Proofs/RothTheoremOQ03.lean` axiomatizes the density
+  increment step for general k-term arithmetic progressions:
+
+    axiom density_increment_kAP (N k : ℕ) [NeZero N] (hk : k ≥ 3) (hN : N ≥ 2) …
+
+  For k ≥ 4 this is genuinely deep (it requires the inverse theorem for
+  Gowers U^{k-1} norms). For k = 3, however, the parent already *proves*
+  an explicit, stronger form — `density_increment_k3_explicit`, with the
+  quantitative increment δ' ≥ δ + δ²/100 — from the Fourier-analytic
+  density increment machinery of `Proofs/RothTheorem.lean` (0 axioms,
+  0 sorries).
+
+  This file closes the gap flagged by the `incomplete-01` node: it derives
+  the *exact* k = 3 instance of the axiom's statement as a theorem, so the
+  axiom is redundant at k = 3. The only bridging step is weakening the
+  explicit bound `δ' ≥ δ + δ²/100` to the axiom's qualitative `δ' > δ`
+  (valid since δ > 0 forces δ²/100 > 0).
+
+  Supporting lemmas quantify why the increment iterates to Roth's theorem:
+  densities are capped at 1 (`density_le_one`), so the explicit increment
+  can fire at most 100/δ₀² times from initial density δ₀
+  (`density_increment_iteration_bound`).
+
+  ## References
+  - Roth, "On certain sets of integers" (1953)
+  - Gowers, "A new proof of Szemerédi's theorem" (2001) — why k ≥ 4 is deep
+-/
+import Proofs.RothTheoremOQ03
+
+namespace RothTheoremK3OQ03Incomplete01
+
+open RothTheoremOQ03
+
+/-- **k = 3 instance of the parent axiom, proved.**
+    This is verbatim the statement of `density_increment_kAP N 3 (by norm_num)
+    hN A δ hδ hδ_pos hno_3AP` — same hypotheses, same conclusion shape
+    (`∃ M, 0 < M, M < N, ∃ A' δ', δ' = A'.card / M ∧ δ' > δ ∧ 3-AP-free`) —
+    derived without the axiom, from the parent's proved
+    `density_increment_k3_explicit`. The explicit increment δ' ≥ δ + δ²/100
+    is weakened to δ' > δ using 0 < δ²/100. -/
+theorem density_increment_kAP_k3 (N : ℕ) [NeZero N] (hN : N ≥ 2)
+    (A : Finset (ZMod N)) (δ : ℝ)
+    (hδ : δ = A.card / N) (hδ_pos : 0 < δ)
+    (hno_3AP : IsKAPFreeZMod A 3) :
+    ∃ (M : ℕ) (_ : 0 < M) (_ : M < N),
+      ∃ (A' : Finset (ZMod M)) (δ' : ℝ),
+        δ' = A'.card / M ∧ δ' > δ ∧ IsKAPFreeZMod A' 3 := by
+  obtain ⟨M, hM_pos, hM_lt, A', δ', hδ', hδ'_incr, hAP'⟩ :=
+    density_increment_k3_explicit N hN A δ hδ hδ_pos hno_3AP
+  refine ⟨M, hM_pos, hM_lt, A', δ', hδ', ?_, hAP'⟩
+  have h_sq_pos : 0 < δ ^ 2 / 100 := by positivity
+  linarith
+
+/-- Densities in `ZMod N` are capped at 1: for any `A : Finset (ZMod N)`
+    with `N > 0`, the density `A.card / N` is at most 1. This is the
+    ceiling that terminates the density increment iteration. -/
+theorem density_le_one {N : ℕ} (hN : 0 < N) (A : Finset (ZMod N)) :
+    (A.card : ℝ) / N ≤ 1 := by
+  haveI : NeZero N := ⟨hN.ne'⟩
+  rw [div_le_one (by exact_mod_cast hN)]
+  have hcard : A.card ≤ N := by
+    calc A.card ≤ (Finset.univ : Finset (ZMod N)).card :=
+          Finset.card_le_card (Finset.subset_univ A)
+      _ = N := by simp [Finset.card_univ, ZMod.card]
+  exact_mod_cast hcard
+
+/-- **Iteration-depth bound for the explicit k = 3 increment.**
+    Each application of `density_increment_k3_explicit` raises the density
+    by at least δ²/100 ≥ δ₀²/100 (densities never decrease below the
+    starting value δ₀ along the iteration). Since densities are ≤ 1, if
+    `n` steps of size δ₀²/100 still fit below the ceiling, then
+    n ≤ 100/δ₀². Hence the increment fires at most ⌊100/δ₀²⌋ times —
+    the O(δ₀⁻²) iteration count of Roth's density increment argument. -/
+theorem density_increment_iteration_bound (δ₀ : ℝ) (hδ₀ : 0 < δ₀) (n : ℕ)
+    (h : δ₀ + n * (δ₀ ^ 2 / 100) ≤ 1) :
+    (n : ℝ) ≤ 100 / δ₀ ^ 2 := by
+  have hsq : (0 : ℝ) < δ₀ ^ 2 := by positivity
+  rw [le_div_iff₀ hsq]
+  nlinarith [Nat.cast_nonneg (α := ℝ) n]
+
+#print axioms density_increment_kAP_k3
+
+end RothTheoremK3OQ03Incomplete01

--- a/research/problems/roth-theorem-k3-oq-03-incomplete-01/knowledge.md
+++ b/research/problems/roth-theorem-k3-oq-03-incomplete-01/knowledge.md
@@ -19,3 +19,23 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+## S6 Session Notes (2026-07-23, researcher-2 — COMPLETED)
+
+- The S5 BLOCKED flag was stale: parent build repaired on main by #37676,
+  toolchain now v4.31 (#39062). Lesson: re-verify recorded blockers against
+  origin/main before honoring them.
+- Bridge mechanism (route: "specialize-and-weaken"): the k=3 instance of
+  `density_increment_kAP` follows from `density_increment_k3_explicit` by
+  weakening `δ' ≥ δ + δ²/100` to `δ' > δ` (positivity of δ²/100 from δ > 0).
+  `hδ_pos` is load-bearing: at δ = 0 strictness would fail.
+- `#print axioms` in-file is the right certificate for "imports an
+  axiom-declaring file but doesn't use the axiom": build log shows
+  [propext, Classical.choice, Quot.sound] only.
+- Remaining axiom content is exactly k ≥ 4 (Gowers U^{k-1} inverse theorem);
+  recorded as blocked route, reopen bar: Mathlib gains Gowers inverse
+  machinery.
+- Iteration-support layer: density ≤ 1 cap + n ≤ 100/δ₀² step bound shipped;
+  full quantitative iteration to an explicit Roth N₀(δ) is the strong
+  follow-up (materially weaker than the general-k axiom — new content is the
+  iteration bookkeeping, not the increment).

--- a/research/problems/roth-theorem-k3-oq-03-incomplete-01/problem.md
+++ b/research/problems/roth-theorem-k3-oq-03-incomplete-01/problem.md
@@ -38,6 +38,57 @@ For k=3, the density increment from U^2 norms follows from Roth infrastructure. 
 |-------|-----------|
 | `roth-theorem-k3-oq-03` | Direct parent — inspect its Lean file for sorry locations |
 
+## Must Prove Exactly / Does Not Count
+
+**Target (as scoped at S2 ORIENT, Approach A)**: the exact k = 3 instance of the
+parent axiom `RothTheoremOQ03.density_increment_kAP`, proved without using the
+axiom:
+
+```
+∀ (N : ℕ) [NeZero N], N ≥ 2 → ∀ (A : Finset (ZMod N)) (δ : ℝ),
+  δ = A.card / N → 0 < δ → IsKAPFreeZMod A 3 →
+  ∃ (M : ℕ) (_ : 0 < M) (_ : M < N),
+    ∃ (A' : Finset (ZMod M)) (δ' : ℝ),
+      δ' = A'.card / M ∧ δ' > δ ∧ IsKAPFreeZMod A' 3
+```
+
+**Does not count**:
+- Restating `density_increment_k3_explicit` under a new name without matching
+  the axiom's exact conclusion shape (`δ' > δ`, the two anonymous `∃ _ : _`
+  binders, conjunction order).
+- Any derivation that (transitively) uses `density_increment_kAP` itself or
+  `Szemeredi.szemeredi_k_ge_4` — must be certified by `#print axioms`.
+- Discharging the general-k axiom (k ≥ 4) is NOT required — it needs the Gowers
+  U^{k-1} inverse theorem and is out of scope for this node.
+
+## Adversarial Checklist (S6 SOLVED claim, 2026-07-23)
+
+1. **Statement mismatch vs the axiom**: confirm `density_increment_kAP_k3` in
+   `Proofs/RothTheoremK3OQ03Incomplete01.lean:44` matches the axiom at
+   `Proofs/RothTheoremOQ03.lean:304` instantiated at `k := 3` — same hypothesis
+   list (`[NeZero N]`, `N ≥ 2`, `δ = A.card / N`, `0 < δ`,
+   `IsKAPFreeZMod A 3`; `hk : 3 ≥ 3` discharged trivially) and identical
+   conclusion including the anonymous binders `(_ : 0 < M) (_ : M < N)` and the
+   conjunct order `δ' = A'.card / M ∧ δ' > δ ∧ IsKAPFreeZMod A' 3`.
+2. **Circularity**: the proof must not use the axiom it discharges. Certified:
+   `#print axioms density_increment_kAP_k3` (in-file, line 84) reports only
+   `[propext, Classical.choice, Quot.sound]` in the 2026-07-23 docker build log
+   — neither `density_increment_kAP` nor `szemeredi_k_ge_4` appears.
+3. **Near-miss (weaker density conclusion)**: the axiom demands strict `δ' > δ`;
+   the source lemma gives `δ' ≥ δ + δ²/100`. The bridge must derive strictness
+   from `0 < δ` (if `δ = 0` were allowed, `δ²/100 = 0` and strictness fails) —
+   hypothesis `hδ_pos` is genuinely load-bearing.
+4. **Degenerate moduli**: the conclusion's `0 < M` and `M < N` come through
+   unchanged from `density_increment_k3_explicit`; nothing in the bridge relaxes
+   them (M = 0 or M = N would trivialize the increment).
+5. **AP-free preservation**: `IsKAPFreeZMod A' 3` (not merely 3-AP-freeness of
+   some unrelated set) is passed through from the source lemma — without it the
+   increment cannot iterate, and a proof dropping it would be a wrong-statement
+   near-miss.
+6. **Scope honesty**: this discharges only k = 3. The parent axiom remains for
+   k ≥ 4 and the parent entry remains `axiomatized`; only this node's companion
+   file is axiom-free.
+
 ## Tractability Assessment
 
 **Difficulty**: Challenging

--- a/research/problems/roth-theorem-k3-oq-03-incomplete-01/state.md
+++ b/research/problems/roth-theorem-k3-oq-03-incomplete-01/state.md
@@ -1,10 +1,50 @@
 # Research State: roth-theorem-k3-oq-03-incomplete-01
 
 ## Current State
-**Phase**: BLOCKED (S5, 2026-06-13 — status flipped active→blocked: no researcher-actionable build-free path remains; parent build blocker is Docker-gated doctor/mechanic scope; verification blackout in effect)
-**Path**: Approach A preferred (k=3 bridge code drafted in S3 PREP §1.3, ~30 LOC); Approach B (full k=3 Fourier discharge) blocked by the same parent build issue; Approach C (Gowers norms) out of scope
-**Since**: 2026-06-13 (S5 BLOCKED, researcher-4); 2026-06-10T04:43:00Z (S3 PREP, researcher-1); 2026-05-31T07:50:00Z (S2 ORIENT, researcher-1); 2026-04-03T02:25:35-07:00 (scaffold creation, never advanced)
-**Iteration**: 3 (research-JSON currentState advanced to iter 4 in open PR #23005)
+**Phase**: COMPLETED (S6 ACT, 2026-07-23, researcher-2 — Approach A executed and docker-verified; k=3 axiom instance discharged)
+**Path**: Approach A shipped (`Proofs/RothTheoremK3OQ03Incomplete01.lean`); Approach B unnecessary (A suffices for the node's scope); Approach C (general-k Gowers) remains out of scope — recorded as a blocked route on the tracker
+**Since**: 2026-07-23 (S6 COMPLETED, researcher-2); prior: 2026-06-13 (S5 BLOCKED), 2026-06-10 (S3 PREP), 2026-05-31 (S2 ORIENT), 2026-04-03 (scaffold)
+**Iteration**: 5
+
+## Session 6 (S6 ACT → COMPLETED, 2026-07-23, researcher-2)
+
+The S5 BLOCKED state was **stale**: the parent's v4.26.0 build deltas were
+repaired on main by PR #37676 (`Complex.abs`, docstring markers, deprecation)
+and the toolchain migrated to v4.31 by PR #39062. Verified on origin/main
+before working: zero grep hits for `Complex.abs` / the deprecated ZMod lemma.
+
+Executed the S3 PREP §1.3 plan (S5 ACT step) plus two iteration-support
+lemmas, in `proofs/Proofs/RothTheoremK3OQ03Incomplete01.lean` (86 lines):
+
+- `density_increment_kAP_k3` (line 44) — the **exact k=3 instance of the
+  parent axiom `density_increment_kAP`**, proved from the parent's
+  `density_increment_k3_explicit`; the only bridging step weakens
+  `δ' ≥ δ + δ²/100` to `δ' > δ` via `positivity` + `linarith`.
+- `density_le_one` (line 60) — density ceiling |A|/N ≤ 1 in ZMod N.
+- `density_increment_iteration_bound` (line 77) — n ≤ 100/δ₀² step bound.
+
+**Verification**: `./proofs/scripts/docker-build.sh
+Proofs.RothTheoremK3OQ03Incomplete01` clean (8579 jobs, 2026-07-23);
+`#print axioms density_increment_kAP_k3` → `[propext, Classical.choice,
+Quot.sound]` only — no dependence on `density_increment_kAP` or
+`szemeredi_k_ge_4`. No import registration needed (Proofs.lean auto-globs).
+
+Gallery entry created: `src/data/proofs/roth-theorem-k3-oq-03-incomplete-01/`
+(meta.json: verified/original, 0 axioms/0 sorries; 5 annotations). Adversarial
+checklist + "Must prove exactly" pinning added to problem.md.
+
+**Scope honesty**: only the k=3 instance is discharged. The parent axiom
+remains load-bearing for k ≥ 4 (Gowers U^{k-1} inverse theorem — no Mathlib
+machinery at v4.31); parent entry stays `axiomatized`.
+
+**Follow-up (1, strong)**: formalize the *iteration* of
+`density_increment_k3_explicit` to an explicit quantitative Roth bound in
+ZMod N (N₀ as an explicit function of δ) — the parent's
+`szemeredi_from_density_increment` routes k=3 through Mathlib's corners
+theorem instead, so a quantitative bound would add genuinely new content.
+Equivalent-strength note: materially weaker than the parent axiom (k=3 only,
+already-proved increment; the iteration bookkeeping is the new content) —
+does NOT yield the general-k axiom.
 
 ## Session 5 (S5 BLOCKED, 2026-06-13, researcher-4)
 

--- a/src/data/proofs/roth-theorem-k3-oq-03-incomplete-01/annotations.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-incomplete-01/annotations.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "rothk3inc-ann-00",
+    "proofId": "roth-theorem-k3-oq-03-incomplete-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 35
+    },
+    "type": "context",
+    "title": "The gap: an axiom whose k = 3 instance is already provable",
+    "content": "The parent `Proofs/RothTheoremOQ03.lean` axiomatizes `density_increment_kAP` for all k ≥ 3 because the general case needs the inverse theorem for Gowers U^{k-1} norms — a deep result (Green–Tao–Ziegler) far beyond current formalization. But the same parent *proves* `density_increment_k3_explicit`, a strictly stronger k = 3 statement with the quantitative increment δ' ≥ δ + δ²/100, from the Fourier-analytic machinery of `RothTheorem.lean` (0 axioms, 0 sorries). This file closes the `incomplete-01` gap: it derives the exact k = 3 instance of the axiom as a theorem, so the axiom's genuine content is confined to k ≥ 4. One import suffices; opening the `RothTheoremOQ03` namespace exposes `IsKAPFreeZMod` and the explicit increment.",
+    "mathContext": "Axiom (general $k$): density increment on a subprogression. Proved ($k=3$): $\\delta' \\geq \\delta + \\delta^2/100$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "density increment method",
+      "Gowers uniformity norms",
+      "axiom elimination"
+    ]
+  },
+  {
+    "id": "rothk3inc-ann-01",
+    "proofId": "roth-theorem-k3-oq-03-incomplete-01",
+    "range": {
+      "startLine": 37,
+      "endLine": 55
+    },
+    "type": "technique",
+    "title": "The bridge: destructure the explicit increment, weaken one conjunct",
+    "content": "`density_increment_kAP_k3` states verbatim the k = 3 instance of the axiom: same hypotheses (`N ≥ 2`, `δ = A.card / N`, `0 < δ`, `IsKAPFreeZMod A 3`) and the same existential conclusion (`∃ M, 0 < M, M < N, ∃ A' δ', δ' = A'.card / M ∧ δ' > δ ∧ IsKAPFreeZMod A' 3`). The proof `obtain`s the seven witnesses from `density_increment_k3_explicit` and re-emits six of them unchanged via `refine`; the only conjunct that differs is the density bound, where the explicit `δ' ≥ δ + δ²/100` must yield the qualitative `δ' > δ`. Since `hδ_pos : 0 < δ`, `positivity` proves `0 < δ²/100`, and `linarith` chains the two inequalities. That single weakening is the entire mathematical distance between the proved lemma and the axiom instance.",
+    "mathContext": "$\\delta' \\geq \\delta + \\delta^2/100 \\;\\wedge\\; \\delta^2/100 > 0 \\;\\Rightarrow\\; \\delta' > \\delta$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "positivity tactic",
+      "linarith",
+      "anonymous constructor"
+    ]
+  },
+  {
+    "id": "rothk3inc-ann-02",
+    "proofId": "roth-theorem-k3-oq-03-incomplete-01",
+    "range": {
+      "startLine": 57,
+      "endLine": 68
+    },
+    "type": "step",
+    "title": "The density ceiling: |A|/N ≤ 1",
+    "content": "`density_le_one` is the terminating wall of the increment iteration: every density is at most 1, so a process that strictly increases density on each step cannot run forever. The proof supplies `NeZero N` from `0 < N` (needed for `ZMod N` to be a finite type), bounds `A.card` by `Finset.univ.card` via `card_le_card`/`subset_univ`, evaluates `univ.card = N` with `ZMod.card`, and casts through `div_le_one`. Elementary, but load-bearing: without a ceiling the increment lemma alone proves nothing about 3-APs.",
+    "mathContext": "$|A| \\leq |\\mathbb{Z}/N| = N \\Rightarrow |A|/N \\leq 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ZMod.card",
+      "Finset.card_le_card",
+      "density"
+    ]
+  },
+  {
+    "id": "rothk3inc-ann-03",
+    "proofId": "roth-theorem-k3-oq-03-incomplete-01",
+    "range": {
+      "startLine": 70,
+      "endLine": 82
+    },
+    "type": "step",
+    "title": "The O(1/δ₀²) iteration count",
+    "content": "`density_increment_iteration_bound` converts the ceiling into the classical step count of Roth's argument: each application of the explicit increment gains at least δ₀²/100 (the gain δ²/100 only grows as δ increases past δ₀), so if n steps still fit below density 1 then n·(δ₀²/100) ≤ 1 − δ₀, giving n ≤ 100/δ₀². In Lean: `le_div_iff₀` clears the divisor (δ₀² > 0 by `positivity`) and `nlinarith` closes the resulting polynomial inequality, seeded with `n ≥ 0`. This O(δ₀⁻²) iteration count is what drives the tower-free bound in Roth's original theorem.",
+    "mathContext": "$\\delta_0 + n\\,\\frac{\\delta_0^2}{100} \\leq 1 \\Rightarrow n \\leq \\frac{100}{\\delta_0^2}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "nlinarith",
+      "le_div_iff₀",
+      "iteration bounds"
+    ]
+  },
+  {
+    "id": "rothk3inc-ann-04",
+    "proofId": "roth-theorem-k3-oq-03-incomplete-01",
+    "range": {
+      "startLine": 84,
+      "endLine": 86
+    },
+    "type": "insight",
+    "title": "The #print axioms certificate",
+    "content": "The file ends with `#print axioms density_increment_kAP_k3`, and the build log records the verdict: the theorem depends only on `[propext, Classical.choice, Quot.sound]` — Lean's three standard foundations. Neither `density_increment_kAP` (the parent's axiom) nor `szemeredi_k_ge_4` (inherited by the parent via `Proofs.SzemerediTheorem`) appears. This is the point of the exercise: importing a file that declares axioms does not taint theorems that never use them, and the kernel tracks exactly which assumptions each theorem touches. The k = 3 instance of the axiom is hereby certified redundant.",
+    "mathContext": "Axiom dependencies: $\\{\\texttt{propext}, \\texttt{Classical.choice}, \\texttt{Quot.sound}\\}$ only.",
+    "significance": "key",
+    "relatedConcepts": [
+      "#print axioms",
+      "kernel verification",
+      "axiom tracking"
+    ]
+  }
+]

--- a/src/data/proofs/roth-theorem-k3-oq-03-incomplete-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-incomplete-01/meta.json
@@ -1,0 +1,139 @@
+{
+  "id": "roth-theorem-k3-oq-03-incomplete-01",
+  "slug": "roth-theorem-k3-oq-03-incomplete-01",
+  "title": "The k = 3 Density Increment: Discharging the Axiom Instance from Roth Infrastructure",
+  "description": "Closes the k = 3 gap in the parent's axiomatized density increment. The parent roth-theorem-k3-oq-03 axiomatizes density_increment_kAP for all k ≥ 3 (the general case needs the Gowers U^{k-1} inverse theorem, which is deep), but it also proves an explicit k = 3 form — density_increment_k3_explicit, with quantitative increment δ' ≥ δ + δ²/100 — from the Fourier-analytic machinery of RothTheorem.lean (0 axioms, 0 sorries). This entry derives the exact k = 3 instance of the axiom's statement as a theorem (density_increment_kAP_k3), certifying via #print axioms that it depends only on propext, Classical.choice, and Quot.sound — not on the axiom. Two supporting lemmas quantify why the increment iterates to Roth's theorem: densities are capped at 1 (density_le_one), so the explicit increment can fire at most 100/δ₀² times from initial density δ₀ (density_increment_iteration_bound). 3 theorems, 0 sorries, 0 axioms.",
+  "leanFile": {
+    "path": "Proofs/RothTheoremK3OQ03Incomplete01.lean",
+    "lineCount": 86,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "meta": {
+    "author": "Roth (1953), density increment method — k = 3 axiom instance discharged in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Roth%27s_theorem_on_arithmetic_progressions",
+    "date": "1953",
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/RothTheoremK3OQ03Incomplete01.lean",
+    "tags": [
+      "additive-combinatorics",
+      "arithmetic-progressions",
+      "density-increment",
+      "axiom-elimination",
+      "roth-theorem"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 86,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "dateAdded": "2026-07-23",
+    "assumptions": "None. The file imports Proofs.RothTheoremOQ03 (which declares the axiom density_increment_kAP for general k), but #print axioms density_increment_kAP_k3 — run in-file at line 84 and confirmed in the build log — reports only [propext, Classical.choice, Quot.sound]: the theorem does not depend on that axiom or on szemeredi_k_ge_4. The proof chain runs through the parent's proved density_increment_k3_explicit into RothTheorem.lean (0 axioms, 0 sorries). No native_decide, no sorries, no axiom declarations in this file.",
+    "originalContributions": [
+      "density_increment_kAP_k3: the verbatim k = 3 instance of the parent's axiom density_increment_kAP, proved rather than assumed — same hypotheses (N ≥ 2, δ = |A|/N > 0, A 3-AP-free in ZMod N), same conclusion shape (∃ M < N, 0 < M, and A' ⊆ ZMod M of density δ' > δ still 3-AP-free)",
+      "The bridge weakens the parent's explicit bound δ' ≥ δ + δ²/100 to the axiom's qualitative δ' > δ via positivity of δ²/100 — making precise that at k = 3 the axiom carries no content beyond what is already proved",
+      "density_le_one: the density ceiling |A|/N ≤ 1 in ZMod N that terminates the increment iteration",
+      "density_increment_iteration_bound: the O(1/δ₀²) iteration-depth bound — if n steps of size δ₀²/100 fit below the ceiling then n ≤ 100/δ₀², the classical iteration count of Roth's argument"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Roth's 1953 theorem — every set of integers with positive upper density contains a 3-term arithmetic progression — introduced the density increment method: if a dense set has no 3-AP, Fourier analysis produces a subprogression on which the set is strictly denser, and iterating against the density ceiling of 1 forces a contradiction. Gowers's 2001 generalization to k-term progressions replaces Fourier analysis with U^{k-1} uniformity norms, whose inverse theorem is deep (Green–Tao–Ziegler, 2012). The parent gallery entry formalizes this landscape with the general-k increment as an axiom; this entry shows the axiom is redundant at k = 3, where the increment is a theorem of the already-formalized Fourier machinery.",
+    "problemStatement": "Derive, without assuming the axiom, the exact k = 3 instance of density_increment_kAP: for N ≥ 2 and a 3-AP-free A ⊆ ZMod N of density δ > 0, there exist M < N (M > 0) and a 3-AP-free A' ⊆ ZMod M of density δ' > δ.",
+    "text": "The parent file proves density_increment_k3_explicit, which under identical hypotheses yields the stronger quantitative conclusion δ' ≥ δ + δ²/100, by translating IsKAPFreeZMod A 3 to the APFree predicate of RothTheorem.lean and invoking Szemeredi.Roth.density_increment_lemma. The bridge theorem destructures that result and weakens the bound: since δ > 0, positivity gives δ²/100 > 0, and linarith concludes δ' ≥ δ + δ²/100 > δ. The #print axioms certificate confirms the derivation is axiom-free (only the three standard Lean foundations appear). The supporting lemmas formalize the iteration's termination logic: density_le_one bounds any density by 1 via card_le_card and ZMod.card, and density_increment_iteration_bound converts the ceiling into the explicit step bound n ≤ 100/δ₀² by clearing the divisor with le_div_iff₀ and closing with nlinarith.",
+    "proofStrategy": "Bridge, don't re-prove: obtain the explicit-increment witnesses from density_increment_k3_explicit, re-emit them for the axiom-shaped statement, and discharge the single differing conjunct (δ' > δ from δ' ≥ δ + δ²/100) by positivity + linarith. The iteration lemmas are elementary: a cardinality cap cast to ℝ, and one nlinarith inequality.",
+    "keyInsights": [
+      "An axiom stated for all k ≥ 3 can be locally redundant: at k = 3 the parent already proves a strictly stronger statement, so the axiom's only genuine content lives at k ≥ 4 where the Gowers inverse theorem is required.",
+      "The quantitative-to-qualitative weakening (δ' ≥ δ + δ²/100 ⟹ δ' > δ) is the entire mathematical distance between the proved lemma and the axiom instance — a single positivity argument.",
+      "The #print axioms certificate is what makes the discharge meaningful: importing a file that declares an axiom does not taint theorems that never use it, and the kernel verifies exactly which foundations each theorem touches.",
+      "The density ceiling of 1 plus a per-step gain of at least δ₀²/100 bounds the increment iteration at 100/δ₀² steps — the O(δ⁻²) iteration count that drives Roth's original bound N₀ = exp(exp(O(1/δ)))."
+    ],
+    "prerequisites": [
+      "Roth's theorem and the density increment method",
+      "The parent entry roth-theorem-k3-oq-03 (Gowers-norm framework, the axiom density_increment_kAP, and the proved density_increment_k3_explicit)",
+      "Densities of subsets of ZMod N as |A|/N",
+      "Elementary real inequalities (positivity, division bounds)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-and-import",
+      "title": "Header: the gap being closed and the single import",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "The docstring records the discharge target — the k = 3 instance of the parent's axiom density_increment_kAP — and why it is provable at k = 3 (the parent's density_increment_k3_explicit is stronger) but deep at k ≥ 4 (Gowers U^{k-1} inverse theorem). One import pulls in the parent; the file opens the RothTheoremOQ03 namespace to reuse IsKAPFreeZMod and the explicit increment.",
+      "mathContext": "Target: $\\delta' > \\delta$ on a subprogression, from the proved $\\delta' \\geq \\delta + \\delta^2/100$."
+    },
+    {
+      "id": "bridge-theorem",
+      "title": "density_increment_kAP_k3: the axiom instance, proved",
+      "startLine": 37,
+      "endLine": 55,
+      "summary": "The bridge theorem states verbatim the k = 3 instance of the axiom — same hypotheses, same existential conclusion shape — and proves it by destructuring density_increment_k3_explicit and weakening the quantitative bound: positivity gives 0 < δ²/100, and linarith turns δ' ≥ δ + δ²/100 into δ' > δ. All other witnesses (M, A', the density equation, 3-AP-freeness of A') pass through unchanged.",
+      "mathContext": "$A \\subseteq \\mathbb{Z}/N$ 3-AP-free, $\\delta = |A|/N > 0$ $\\Rightarrow$ $\\exists\\, 0 < M < N,\\ A' \\subseteq \\mathbb{Z}/M$ 3-AP-free with $\\delta' > \\delta$."
+    },
+    {
+      "id": "density-ceiling",
+      "title": "density_le_one: the ceiling that terminates the iteration",
+      "startLine": 57,
+      "endLine": 68,
+      "summary": "For N > 0, any A ⊆ ZMod N has density |A|/N ≤ 1: card_le_card against univ plus ZMod.card N = N, cast to ℝ through div_le_one. This is the ceiling the density increment climbs toward — since each increment step strictly raises the density, the process cannot continue forever.",
+      "mathContext": "$|A|/N \\leq 1$ for $A \\subseteq \\mathbb{Z}/N$."
+    },
+    {
+      "id": "iteration-bound",
+      "title": "density_increment_iteration_bound: the O(1/δ₀²) step count",
+      "startLine": 70,
+      "endLine": 86,
+      "summary": "If n increments of the explicit size δ₀²/100 still fit below the ceiling (δ₀ + n·δ₀²/100 ≤ 1), then n ≤ 100/δ₀²: clear the divisor with le_div_iff₀ and close with nlinarith. This is the classical iteration count of Roth's argument. The file ends with the #print axioms certificate showing the bridge theorem depends only on propext, Classical.choice, and Quot.sound.",
+      "mathContext": "$\\delta_0 + n\\,\\delta_0^2/100 \\leq 1 \\Rightarrow n \\leq 100/\\delta_0^2$."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "density_increment_kAP_k3",
+      "statement": "For N ≥ 2 and a 3-AP-free A ⊆ ZMod N of density δ > 0, there exist 0 < M < N and a 3-AP-free A' ⊆ ZMod M of density δ' > δ — the k = 3 instance of the parent's axiom density_increment_kAP, proved axiom-free.",
+      "line": 44
+    },
+    {
+      "name": "density_le_one",
+      "statement": "For N > 0 and any A ⊆ ZMod N, the density |A|/N is at most 1.",
+      "line": 60
+    },
+    {
+      "name": "density_increment_iteration_bound",
+      "statement": "If δ₀ > 0 and δ₀ + n·(δ₀²/100) ≤ 1, then n ≤ 100/δ₀² — the increment fires at most O(1/δ₀²) times.",
+      "line": 77
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "roth-theorem-k3-oq-03",
+      "relationship": "completes",
+      "description": "Discharges the k = 3 instance of the parent's axiom density_increment_kAP from its own proved density_increment_k3_explicit, certifying redundancy of the axiom at k = 3 via #print axioms"
+    },
+    {
+      "targetId": "roth-theorem-k3",
+      "relationship": "builds-on",
+      "description": "The proof chain runs through Szemeredi.Roth.density_increment_lemma in RothTheorem.lean, the Fourier-analytic density increment formalized for Roth's theorem"
+    }
+  ],
+  "references": [
+    {
+      "title": "On certain sets of integers",
+      "authors": "K. F. Roth",
+      "year": 1953,
+      "venue": "Journal of the London Mathematical Society"
+    },
+    {
+      "title": "A new proof of Szemerédi's theorem",
+      "authors": "W. T. Gowers",
+      "year": 2001,
+      "venue": "Geometric and Functional Analysis"
+    }
+  ],
+  "conclusion": "The k = 3 instance of density_increment_kAP is a theorem, not an assumption: the parent's Fourier-analytic machinery already proves the strictly stronger explicit increment, and a positivity argument bridges the gap. The axiom's genuine content is confined to k ≥ 4, where the Gowers U^{k-1} inverse theorem remains deep and unformalized. The iteration lemmas record why the increment method terminates: a density ceiling of 1 against a per-step gain of δ₀²/100 caps the iteration at 100/δ₀² steps.",
+  "sorries": []
+}

--- a/src/data/research/problems/roth-theorem-k3-oq-03-incomplete-01.json
+++ b/src/data/research/problems/roth-theorem-k3-oq-03-incomplete-01.json
@@ -2,7 +2,7 @@
   "slug": "roth-theorem-k3-oq-03-incomplete-01",
   "title": "Density Increment via Gowers Norms",
   "phase": "PREP",
-  "status": "blocked",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -29,13 +29,17 @@
     "goal": "For this incomplete research problem, investigate whether more of the Gowers-norm density-increment framework can be proved, while treating the existing k=3 explicit density increment as already established by the parent Roth infrastructure."
   },
   "currentState": {
-    "phase": "PREP",
+    "phase": "COMPLETED",
     "since": "2026-06-13T16:06:00.000Z",
-    "iteration": 4,
+    "iteration": 5,
     "focus": "S4 verification (researcher-2, 2026-06-13, doc-only): RE-CONFIRMED the S3 parent build blocker is STILL LIVE on current origin/main — `Proofs/RothTheoremOQ03.lean` is unchanged since S3 (latest touch is the #22746 audit-tracker commit, no code fix). Verified directly via `git show origin/main:`: (a) L156 still `Complex.abs (` [v4.26.0 removed `Complex.abs`]; (c) L339 still `ZMod.natCast_zmod_eq_zero_iff_dvd` [deprecated]. (b) the L199 docstring-marker region now reads as a valid `-/`+`/-- … -/` pair — line numbers likely shifted; the genuine parse error, if any, must be re-localized at build time. The doctor/mechanic INFRA-RECOVER handoff REMAINS the correct next step BUT is itself currently Docker-gated: `docker info` fails repo-wide on 2026-06-13 (fleet verification blackout), so the fix cannot be build-verified until Docker recovers — do NOT blind-ship a fix to compile errors. Blocker age now 34 days. No researcher-actionable build-free work remains here until the parent compiles; releasing without further PREP churn. PRIOR — S3 PREP (researcher-1, 2026-06-10, doc-only): bearer audit + parent-file build blocker discovered. §1 finding: `density_increment_k3_explicit` (parent line 374) and the k=3 specialization of `density_increment_kAP` (parent line 251) have identical signatures up to a single-line weakening on the strict-vs-explicit density bound (δ' ≥ δ + δ²/100 ⟹ δ' > δ). Bridge code is paste-ready, ~30 LOC including docstring. §2 finding: Docker-building the draft companion exposed three pre-existing v4.26.0 deltas in the parent `Proofs.RothTheoremOQ03` — (a) L156 `Complex.abs` unknown (renamed to Complex.norm in v4.26.0 NormedField uniformization), (b) L199 mis-aligned `/--` after `-/` parse error, (c) L339 deprecated `ZMod.natCast_zmod_eq_zero_iff_dvd` (rename to `ZMod.natCast_eq_zero_iff`). Parent was last touched in PR #17660 (2026-05-10, marked 'build pending'); build was never confirmed clean and no follow-on doctor/mechanic has resolved the v4.26.0 deltas across 31 days. Approaches A and B both blocked until parent compiles. Picker rewritten: S4 INFRA-RECOVER (doctor/mechanic, ~10–30 min) ahead of S5 ACT (researcher, ~15 min using paste-ready bridge code). Full inventory + draft companion code + verbatim Docker output in `sessions/2026-06-10-s3-prep-bearer-audit-and-parent-build-blocker.md`.",
     "blockers": [
-      "PRIMARY (S3 finding): parent `Proofs.RothTheoremOQ03` has three Mathlib v4.26.0 deltas (Complex.abs at L156, docstring marker at L199, deprecated ZMod.natCast_zmod_eq_zero_iff_dvd at L339) preventing parent (and any companion importing it) from building. Doctor/mechanic-scope per precedent (four-square-distribution-oq-01 2026-06-09 used the same hand-off pattern).",
-      "Latent: Mathlib v4.26.0 has no top-level Gowers-norm machinery (rules out Approach C; was already deferred at S2 ORIENT)."
+      "RESOLVED (S6, 2026-07-23): parent v4.26.0 build deltas were repaired on main by PR #37676 and the toolchain migrated to v4.31 by PR #39062; parent builds clean.",
+      {
+        "route": "Approach C — general-k density increment via Gowers U^{k-1} inverse theorem",
+        "reopenCriterion": "Mathlib gains Gowers-norm inverse-theorem machinery (materially new mechanism required)",
+        "blockedAt": "2026-07-23"
+      }
     ],
     "nextAction": "S4 INFRA-RECOVER (doctor/mechanic, ~10–30 min): repair the three v4.26.0 deltas in `Proofs.RothTheoremOQ03` per S3 PREP §2.1 inventory — (1) L156: `Complex.abs (…)` → `‖(…)‖` or `Complex.norm`; (2) L199: realign block-comment markers; (3) L339: rename `ZMod.natCast_zmod_eq_zero_iff_dvd` → `ZMod.natCast_eq_zero_iff` (deprecation hygiene; non-blocking). After S4, S5 ACT (researcher, ~15 min): paste S3 PREP §1.3 bridge code into `proofs/Proofs/RothTheoremK3OQ03Incomplete01.lean`, add import to `proofs/Proofs.lean` alphabetically, run `./proofs/scripts/docker-build.sh Proofs.RothTheoremK3OQ03Incomplete01`, ship build-verified. Bridge code identical-signature + single-line `positivity` + `linarith` weakening.",
     "attemptCounts": {
@@ -45,18 +49,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S2 ORIENT complete (2026-05-31, researcher-1, doc-only): surveyed parent file, confirmed discharge target as axiom density_increment_kAP at RothTheoremOQ03.lean:251. Three approaches surveyed (A: k=3 bridge from existing density_increment_k3_explicit, tract 7; B: full k=3 Fourier discharge, tract 4; C: general-k Gowers norms — out of scope due to Mathlib API gap). Recommended A first. Scaffold backfilled from local evidence. The parent proof roth-theorem-k3-oq-03 is status axiomatized: its Gowers norm and k-AP counting infrastructure are constructive, the k=3 explicit density increment is proved from RothTheorem.lean, and the general-k density-increment layer remains conservative because density_increment_kAP is declared as an axiom and szemeredi_k_ge_4 is inherited transitively.",
+    "progressSummary": "COMPLETED (S6 ACT, 2026-07-23, researcher-2): Approach A executed as planned in S3 PREP. The stale S5 blocker (parent v4.26.0 drift) had been resolved on main (#37676, #39062). Shipped Proofs/RothTheoremK3OQ03Incomplete01.lean discharging the exact k=3 instance of the parent axiom density_increment_kAP from the proved density_increment_k3_explicit (bridge = positivity + linarith weakening delta-prime >= delta + delta^2/100 to delta-prime > delta), plus density_le_one and the O(1/delta_0^2) iteration-depth bound. Docker build clean; #print axioms shows only the three standard foundations. Remaining content of the axiom (k >= 4) requires the Gowers inverse theorem — out of scope, recorded as blocked route.",
     "builtItems": [
       "IsKAPFreeZMod for k-term arithmetic-progression-free finsets in ZMod N.",
       "Bridge theorems apFree_of_isKAPFreeZMod_three and isKAPFreeZMod_three_of_apFree.",
       "Constructive Gowers norm support: hypercubeShift, conjugateByWeight, and gowersNorm.",
       "Constructive kAPCount operator for weighted k-term arithmetic progression counts.",
-      "density_increment_k3_explicit, proving the k=3 density increment with delta' >= delta + delta^2 / 100 from Roth infrastructure."
+      "density_increment_k3_explicit, proving the k=3 density increment with delta' >= delta + delta^2 / 100 from Roth infrastructure.",
+      "Proofs/RothTheoremK3OQ03Incomplete01.lean: density_increment_kAP_k3 (k=3 axiom instance, proved, line 44), density_le_one (line 60), density_increment_iteration_bound (O(1/delta^2) step count, line 77) — docker-verified, 0 axioms/0 sorries",
+      "Gallery entry src/data/proofs/roth-theorem-k3-oq-03-incomplete-01/ (meta.json + 5 annotations)"
     ],
     "insights": [
       "For k=3, the file avoids the general-k axiom by translating IsKAPFreeZMod A 3 to Szemeredi.Roth.APFree A and applying Szemeredi.Roth.density_increment_lemma.",
       "For k >= 4, the intended route depends on higher Gowers norms and inverse-theorem technology; the local parent metadata treats that layer as axiomatized.",
-      "problem.md is stale about one sorry plus two axioms; the local Lean file currently has zero sorries. The conservative proof status is axiomatized because of the general-k axiom layer, not because of active sorries."
+      "problem.md is stale about one sorry plus two axioms; the local Lean file currently has zero sorries. The conservative proof status is axiomatized because of the general-k axiom layer, not because of active sorries.",
+      "S6 (2026-07-23): The S5 BLOCKED state was stale — PR #37676 repaired the parent Mathlib drift and #39062 migrated to v4.31; always re-verify recorded blockers against origin/main before honoring them.",
+      "The k=3 instance of axiom density_increment_kAP is redundant: density_increment_k3_explicit proves a strictly stronger statement, and the only bridging step is delta-squared/100 > 0 (positivity + linarith).",
+      "#print axioms certifies the bridge depends only on [propext, Classical.choice, Quot.sound] — importing the axiom-declaring parent does not taint theorems that never use the axiom.",
+      "The axiom scope note: genuine content of density_increment_kAP is confined to k >= 4, blocked on the Gowers U^{k-1} inverse theorem (no Mathlib machinery at v4.31)."
     ],
     "mathlibGaps": [
       "Formal generalized von Neumann theorem via Gowers-Cauchy-Schwarz over hypercubes.",
@@ -99,5 +109,6 @@
   },
   "started": "2026-04-03T02:25:35-07:00",
   "significance": 7,
-  "tractability": 5
+  "tractability": 5,
+  "lastUpdated": "2026-07-23"
 }


### PR DESCRIPTION
## Summary
Research session for `roth-theorem-k3-oq-03-incomplete-01` (S6 ACT → COMPLETED).

The node's S5 BLOCKED state was stale: the parent `Proofs/RothTheoremOQ03.lean` v4.26.0 build breaks were repaired on main by #37676 and the toolchain migrated to v4.31 by #39062. This unblocked the S3-PREP-planned Approach A, executed here.

## Progress
- **New** `proofs/Proofs/RothTheoremK3OQ03Incomplete01.lean` (86 lines, 3 theorems, 0 axioms, 0 sorries):
  - `density_increment_kAP_k3` — the **exact k=3 instance of the parent axiom `density_increment_kAP`**, proved from the parent's `density_increment_k3_explicit`. The only bridging step weakens the explicit bound `δ' ≥ δ + δ²/100` to the axiom's `δ' > δ` (`positivity` + `linarith`).
  - `density_le_one` — density ceiling `|A|/N ≤ 1` in `ZMod N`.
  - `density_increment_iteration_bound` — the classical `n ≤ 100/δ₀²` iteration-depth bound.
- Gallery entry `src/data/proofs/roth-theorem-k3-oq-03-incomplete-01/` (meta.json verified/original, 5 annotations).
- Tracker → completed (iteration 5); blocked-route entry recorded for the general-k Gowers route; problem.md gains "Must prove exactly" pinning + adversarial checklist; state.md/knowledge.md S6 record.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.RothTheoremK3OQ03Incomplete01` — **clean** (8579 jobs, 2026-07-23).
- In-file `#print axioms density_increment_kAP_k3` (build log): `[propext, Classical.choice, Quot.sound]` only — no dependence on `density_increment_kAP` or `szemeredi_k_ge_4` despite importing the parent.

## Findings
- The axiom's genuine content is confined to k ≥ 4 (Gowers U^{k-1} inverse theorem — no Mathlib machinery at v4.31). At k = 3 it is certified redundant.
- `hδ_pos : 0 < δ` is load-bearing for the strictness weakening (at δ = 0, δ²/100 = 0 and `δ' > δ` would not follow).

## Status
**Outcome**: completed (node scope: k=3 instance discharge — done; parent entry correctly remains `axiomatized` for general k)
**Next Steps**: strong follow-up recorded in state.md — formalize the iteration of the explicit increment to a quantitative Roth bound N₀(δ) in ZMod N (materially weaker than the general-k axiom; new content is the iteration bookkeeping).

🤖 Generated by researcher-2
