### PR TITLE
audit(tracker): record euler-polyhedral-formula-oq-02-oq-01 clean audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -18190,9 +18190,9 @@
       "result": "clean"
     },
     "euler-polyhedral-formula-oq-02-oq-01": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:49Z",
+      "lastAudited": "2026-07-24T05:38:54Z",
       "result": "clean"
     },
     "euler-polyhedral-formula-oq-02-oq-02": {


### PR DESCRIPTION
## Summary
- Re-serve audit of `euler-polyhedral-formula-oq-02-oq-01` (Smooth Gauss-Bonnet Theorem)
- Verified: 0 sorries, 0 True stubs, no native_decide
- `axiomCount=9` correctly counts assumption-carrying structure fields (gauss_bonnet, chi_genus, chern_gauss_bonnet, gauss_bonnet_boundary, gauss_bonnet_polygon, curvature_is_K_area, gauss_bonnet_triangle, poincare_hopf, morse_relation) — no bare `axiom` decls
- `definitionCount=15` matches 9 structures + 6 defs
- `theoremCount=61` matches grep count
- Badge `axiom` / status `axiomatized` correctly reflects Tier C; prose does not overclaim the core theorem as proved
- Cross-references resolve to existing gallery entries

Result: **clean**, no changes needed to meta.json.

## Test plan
- [x] Tracker JSON diff only touches `auditCount`/`lastAudited` for this entry

Discovered during gallery integrity audit.