### PR TITLE
Enrich baire-category-theorem-oq-01-oq-03: re-anchor sections (98->100)

### DIFF
--- a/src/data/proofs/baire-category-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/baire-category-theorem-oq-01-oq-03/meta.json
@@ -118,36 +118,44 @@
   ],
   "sections": [
     {
-      "id": "docstring",
-      "title": "Module Docstring: From Uncountable to ≥ Continuum",
-      "startLine": 3,
-      "endLine": 49,
-      "summary": "States the goal — sharpen the Baire-category uncountability of ℝ to a continuum-cardinality lower bound — and the mechanism: the Cantor scheme embeds ℕ → Bool into any nonempty perfect set of a complete metric space (Mathlib's Perfect.exists_nat_bool_injection), and the Cantor space has cardinality 𝔠. Lists the six results and notes Mathlib has the embedding but not the cardinality corollary.",
+      "id": "sec-header",
+      "title": "Header, Imports, and Module Docstring",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Imports Mathlib. Module docstring states the goal — sharpen the parent's Baire-category uncountability of ℝ to a continuum-cardinality lower bound — and the mechanism: the Cantor scheme embeds ℕ → Bool into any nonempty perfect set of a complete metric space (Mathlib's Perfect.exists_nat_bool_injection). Lists the six results and notes Mathlib has the embedding but not the cardinality corollary. Opens Set Cardinal and enters namespace BaireCategoryTheoremOQ01OQ03.",
       "mathContext": "A nonempty perfect set $C$ in a complete metric space satisfies $\\mathfrak{c} = \\#(\\mathbb{N}\\to\\mathrm{Bool}) \\le \\#C$."
     },
     {
       "id": "cantor-cardinality",
       "title": "The Cantor Space Has Cardinality the Continuum",
-      "startLine": 53,
-      "endLine": 58,
-      "summary": "mk_nat_arrow_bool: #(ℕ → Bool) = 𝔠, read off as #Bool ^ #ℕ = 2 ^ ℵ₀ = 𝔠 via Cardinal.power_def, mk_bool, mk_nat, and two_power_aleph0. This is the cardinal that the Cantor-scheme embedding transfers into the perfect set.",
+      "startLine": 42,
+      "endLine": 49,
+      "summary": "mk_nat_arrow_bool: #(ℕ → Bool) = 𝔠, read off as #Bool ^ #ℕ = 2 ^ ℵ₀ = 𝔠 via Cardinal.power_def, mk_bool, mk_nat, and two_power_aleph0. This is the cardinal that the Cantor-scheme embedding transfers into the perfect set. Followed by the shared variable block (α : Type, [MetricSpace α], [CompleteSpace α]) the remaining theorems are stated over.",
       "mathContext": "$\\#(\\mathbb{N}\\to\\mathrm{Bool}) = \\#\\mathrm{Bool}^{\\#\\mathbb{N}} = 2^{\\aleph_0} = \\mathfrak{c}$."
     },
     {
       "id": "perfect-set-bound",
       "title": "The Core Bound on Perfect Sets",
-      "startLine": 60,
-      "endLine": 84,
+      "startLine": 50,
+      "endLine": 75,
       "summary": "continuum_le_mk_of_perfect: a nonempty perfect subset C of a complete metric space has 𝔠 ≤ #C, via corestricting the Cantor-scheme injection to ↥C and applying mk_le_of_injective. not_countable_of_perfect deduces C is uncountable by contradicting #C ≤ ℵ₀ with 𝔠 ≤ #C and ℵ₀ < 𝔠.",
       "mathContext": "$\\mathrm{Perfect}\\,C$, $C \\ne \\varnothing \\Rightarrow \\mathfrak{c} \\le \\#C$, hence $C$ uncountable."
     },
     {
-      "id": "whole-space-and-real",
-      "title": "Whole-Space Form and the Real Line",
-      "startLine": 86,
+      "id": "whole-space-form",
+      "title": "Whole-Space Form",
+      "startLine": 76,
+      "endLine": 87,
+      "summary": "continuum_le_mk_of_perfectSpace applies the core bound at C = univ (PerfectSpace.univ_perfect, mk_univ) to get 𝔠 ≤ #α for a nonempty complete metric space with no isolated points; uncountable_of_perfectSpace chains ℵ₀ < 𝔠 ≤ #α through aleph0_lt_mk_iff to conclude Uncountable α.",
+      "mathContext": "$\\mathrm{PerfectSpace}\\,\\alpha$ complete metric $\\Rightarrow \\mathfrak{c} \\le \\#\\alpha$, hence $\\alpha$ is uncountable."
+    },
+    {
+      "id": "real-witness",
+      "title": "The Concrete Witness: ℝ",
+      "startLine": 88,
       "endLine": 95,
-      "summary": "continuum_le_mk_of_perfectSpace applies the core at C = univ (PerfectSpace.univ_perfect, mk_univ) to get 𝔠 ≤ #X for a nonempty complete metric space with no isolated points; uncountable_of_perfectSpace chains ℵ₀ < 𝔠 ≤ #X through aleph0_lt_mk_iff; continuum_le_mk_real instantiates at ℝ, whose PerfectSpace instance is inferred from connectedness, T1, and nontriviality.",
-      "mathContext": "$\\mathrm{PerfectSpace}\\,X$ complete metric $\\Rightarrow \\mathfrak{c} \\le \\#X$; at $X=\\mathbb{R}$, $\\mathfrak{c} \\le \\#\\mathbb{R}$."
+      "summary": "continuum_le_mk_real : 𝔠 ≤ #ℝ, sharpening the parent's real_uncountable. Proved by a bare term-mode application `:= continuum_le_mk_of_perfectSpace` — no new argument, since ℝ's PerfectSpace instance (from connectedness, T1, and nontriviality) is inferred automatically, letting the whole-space form apply for free.",
+      "mathContext": "$\\mathbb{R}$ is connected, $T_1$, nontrivial $\\Rightarrow \\mathrm{PerfectSpace}\\,\\mathbb{R}$, so $\\mathfrak{c} \\le \\#\\mathbb{R}$."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Quality-98 tier gap: `sections` had 4 items (8/10), `keyInsights` already at cap (5, 10/10).
- Verified against `proofs/Proofs/BaireCategoryTheoremOQ01OQ03.lean` (95 lines) and found the existing section line ranges had drifted from the actual construct boundaries — e.g. the section titled "The Cantor Space Has Cardinality the Continuum" pointed at lines 53-58, which actually fall inside `continuum_le_mk_of_perfect`'s docstring, not `mk_nat_arrow_bool`.
- Re-anchored all sections to real Lean construct boundaries and split into 5, covering the full file (1-95) with accurate titles/summaries matching their line ranges.

## Test plan
- [x] `python3 -c "import json; json.load(...)"` — valid JSON
- [x] `wc -c` — 16.0 KB, well under the 60 KB cap
- [x] `find-targets.ts --json` confirms quality now reads 100
- [x] Cross-checked every section's line range against the actual theorem/docstring boundaries in the Lean source