### PR TITLE
audit(tracker): record euler-polyhedral-formula-oq-01 issues-fixed audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -18155,9 +18155,9 @@
     },
     "euler-polyhedral-formula-oq-01": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:49Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T05:45:43Z",
+      "result": "issues-fixed"
     },
     "euler-polyhedral-formula-oq-01-oq-01": {
       "agentId": "auditor-agent",


### PR DESCRIPTION
Records the audit-tracker.json update for the euler-polyhedral-formula-oq-01 audit (see #43076 for the actual fix — vacuous Six Color Theorem degeneracy-coloring claims corrected).