### PR TITLE
Research: erdos-szekeres-oq-02 - milestones 2+3 closed: naive incDP=maxIncLen refuted, corrected bridge + executable witness

### DIFF
--- a/proofs/Proofs/ErdosSzekeresOQ02.lean
+++ b/proofs/Proofs/ErdosSzekeresOQ02.lean
@@ -779,4 +779,13 @@ subsequence".
 #eval lisLength (![3, 1, 4, 1, 5, 9, 2, 6] : Fin 8 → ℕ)
 #eval List.ofFn (lisWitness (![3, 1, 4, 1, 5, 9, 2, 6] : Fin 8 → ℕ)).positions
 
+/- Axiom audit (printed at build time): every capstone rests only on the
+standard foundational axioms — no `sorryAx`, no `Lean.ofReduceBool`. -/
+#print axioms exactIncEnd_iff_le_incDP
+#print axioms maxIncLen_eq_sup_Iic
+#print axioms incDP_lt_maxIncLen_counterexample
+#print axioms lisLength_eq_sup_maxIncLen
+#print axioms incWitness
+#print axioms lisWitness
+
 end ErdosSzekeresOQ02

--- a/proofs/Proofs/ErdosSzekeresOQ02.lean
+++ b/proofs/Proofs/ErdosSzekeresOQ02.lean
@@ -335,8 +335,8 @@ theorem ExactIncEnd.le_incDP {f : Sequence α n} {i : Fin n} {len : ℕ}
           have := a.isLt
           omega
         · intro a ha
-          congr 1
-          exact Fin.ext ha
+          show k a.castSucc = k ⟨m - 1, hprevlt⟩
+          exact congrArg k (Fin.ext ha)
       have hrec : m ≤ incDP f (k ⟨m - 1, hprevlt⟩) := ih hchain
       have hmem : k ⟨m - 1, hprevlt⟩ ∈ preds f i := mem_preds.mpr ⟨hj₀i, hfj₀⟩
       have hsup : incDP f (k ⟨m - 1, hprevlt⟩) ≤ (preds f i).sup (fun j => incDP f j) :=
@@ -453,8 +453,7 @@ theorem maxIncLen_le_sup_Iic (f : Sequence α n) (i : Fin n) :
       have := a.isLt
       omega
     · intro a ha
-      congr 1
-      exact Fin.ext ha
+      exact congrArg k (Fin.ext ha)
   calc maxIncLen f i ≤ incDP f (k ⟨maxIncLen f i - 1, h1⟩) := hexact.le_incDP
     _ ≤ (Finset.Iic i).sup (fun j => incDP f j) := Finset.le_sup (Finset.mem_Iic.mpr hjle)
 
@@ -705,6 +704,7 @@ def lisWitness (f : Sequence α n) : IncreasingSubseq f (lisLength f) :=
     have hlen : lisLength f = 0 := by
       haveI := hempty
       rw [lisLength, Finset.univ_eq_empty, Finset.sup_empty]
+      rfl
     hlen.symm ▸
       (⟨Fin.elim0, fun a => a.elim0, fun a => a.elim0⟩ : IncreasingSubseq f 0)
   | some i₀ =>

--- a/proofs/Proofs/ErdosSzekeresOQ02.lean
+++ b/proofs/Proofs/ErdosSzekeresOQ02.lean
@@ -310,7 +310,7 @@ theorem ExactIncEnd.le_incDP {f : Sequence α n} {i : Fin n} {len : ℕ}
     · exact one_le_incDP f i
     · have hmlt : m < m + 1 := Nat.lt_succ_self m
       have hprevlt : m - 1 < m + 1 := by omega
-      have hklast : k ⟨m, hmlt⟩ = i := hlast ⟨m, hmlt⟩ (by omega)
+      have hklast : k ⟨m, hmlt⟩ = i := hlast ⟨m, hmlt⟩ rfl
       have hprev : (⟨m - 1, hprevlt⟩ : Fin (m + 1)) < ⟨m, hmlt⟩ := by
         rw [Fin.lt_def]
         show m - 1 < m

--- a/proofs/Proofs/ErdosSzekeresOQ02.lean
+++ b/proofs/Proofs/ErdosSzekeresOQ02.lean
@@ -466,7 +466,7 @@ theorem maxIncLen_le_sup_Iic (f : Sequence α n) (i : Fin n) :
 theorem maxIncLen_eq_sup_Iic (f : Sequence α n) (i : Fin n) :
     maxIncLen f i = (Finset.Iic i).sup (fun j => incDP f j) :=
   le_antisymm (maxIncLen_le_sup_Iic f i)
-    (Finset.sup_le fun j hj => incDP_le_maxIncLen_of_le (Finset.mem_Iic.mp hj))
+    (Finset.sup_le fun _j hj => incDP_le_maxIncLen_of_le (Finset.mem_Iic.mp hj))
 
 /-- The DP table of `[1, 2, 0]` is `[1, 2, 1]`. -/
 theorem incDP_counterexample_table :
@@ -493,8 +493,9 @@ theorem incDP_lt_maxIncLen_counterexample :
     incDP (![1, 2, 0] : Sequence ℕ 3) 2 < maxIncLen (![1, 2, 0] : Sequence ℕ 3) 2 := by
   obtain ⟨h0, h1, h2⟩ := incDP_counterexample_table
   have hsup : maxIncLen (![1, 2, 0] : Sequence ℕ 3) 2 = 2 := by
-    rw [maxIncLen_eq_sup_Iic, show Finset.Iic (2 : Fin 3) = {0, 1, 2} from by decide,
-      Finset.sup_insert, Finset.sup_insert, Finset.sup_singleton, h0, h1, h2]
+    rw [maxIncLen_eq_sup_Iic, show Finset.Iic (2 : Fin 3) = {0, 1, 2} from by decide]
+    simp only [Finset.sup_insert, Finset.sup_singleton, h0, h1, h2]
+    decide
   rw [h2, hsup]
   omega
 
@@ -625,17 +626,22 @@ def IncChain.extend {f : Sequence α n} {j i : Fin n} {len : ℕ}
       rw [haeq, Fin.snoc_last] }
 
 /-- Computable predecessor selection: an admissible predecessor maximizing the
-    DP value, chosen via `List.argmax` (no `Classical.choice`). -/
+    DP value, chosen via `List.argmax` over the (computably) sorted predecessor
+    list (`Finset.toList` is noncomputable, `Finset.sort` is not; no
+    `Classical.choice`). -/
 def incArgmax (f : Sequence α n) (i : Fin n) : Option (Fin n) :=
-  (preds f i).toList.argmax (fun j => incDP f j)
+  ((preds f i).sort (· ≤ ·)).argmax (fun j => incDP f j)
 
 theorem incArgmax_eq_none {f : Sequence α n} {i : Fin n}
-    (h : incArgmax f i = none) : preds f i = ∅ :=
-  Finset.toList_eq_nil.mp (List.argmax_eq_none.mp h)
+    (h : incArgmax f i = none) : preds f i = ∅ := by
+  have hnil : (preds f i).sort (· ≤ ·) = [] := List.argmax_eq_none.mp h
+  have hlen := Finset.length_sort (s := preds f i) (r := (· ≤ ·))
+  rw [hnil] at hlen
+  exact Finset.card_eq_zero.mp hlen.symm
 
 theorem incArgmax_mem {f : Sequence α n} {i : Fin n} {j₀ : Fin n}
     (h : incArgmax f i = some j₀) : j₀ ∈ preds f i :=
-  Finset.mem_toList.mp (List.argmax_mem (Option.mem_def.mpr h))
+  ((preds f i).mem_sort (· ≤ ·)).mp (List.argmax_mem (Option.mem_def.mpr h))
 
 /-- With no admissible predecessor the DP value is `1`. -/
 theorem incDP_eq_one_of_incArgmax_none {f : Sequence α n} {i : Fin n}
@@ -649,7 +655,7 @@ theorem incDP_eq_of_incArgmax_some {f : Sequence α n} {i : Fin n} {j₀ : Fin n
     (h : incArgmax f i = some j₀) : incDP f i = incDP f j₀ + 1 := by
   have hmem : j₀ ∈ preds f i := incArgmax_mem h
   have hmax : ∀ j ∈ preds f i, incDP f j ≤ incDP f j₀ := fun j hj =>
-    List.le_of_mem_argmax (Finset.mem_toList.mpr hj) (Option.mem_def.mpr h)
+    List.le_of_mem_argmax (((preds f i).mem_sort (· ≤ ·)).mpr hj) (Option.mem_def.mpr h)
   have hsup : (preds f i).sup (fun j => incDP f j) = incDP f j₀ :=
     le_antisymm (Finset.sup_le hmax) (Finset.le_sup hmem)
   rw [incDP_eq, hsup, Nat.add_comm]
@@ -681,9 +687,10 @@ theorem incWitness_positions_last (f : Sequence α n) (i : Fin n)
     (incWitness f i).positions a = i :=
   (incChain f i).last_eq a ha
 
-/-- Computable global argmax position of the DP table. -/
+/-- Computable global argmax position of the DP table (`List.finRange` is the
+    computable enumeration of `Fin n`). -/
 def lisArgmax (f : Sequence α n) : Option (Fin n) :=
-  Finset.univ.toList.argmax (fun i => incDP f i)
+  (List.finRange n).argmax (fun i => incDP f i)
 
 /-- **The global executable witness**: an actual longest increasing
     subsequence of the whole sequence, of the computable global length
@@ -691,16 +698,18 @@ def lisArgmax (f : Sequence α n) : Option (Fin n) :=
 def lisWitness (f : Sequence α n) : IncreasingSubseq f (lisLength f) :=
   match h : lisArgmax f with
   | none =>
-    have huniv : (Finset.univ : Finset (Fin n)) = ∅ :=
-      Finset.toList_eq_nil.mp (List.argmax_eq_none.mp h)
+    have hempty : IsEmpty (Fin n) := ⟨fun a => by
+      have ha : a ∈ List.finRange n := List.mem_finRange a
+      rw [List.argmax_eq_none.mp h] at ha
+      simp at ha⟩
     have hlen : lisLength f = 0 := by
-      rw [lisLength, huniv]
-      exact Finset.sup_empty
+      haveI := hempty
+      rw [lisLength, Finset.univ_eq_empty, Finset.sup_empty]
     hlen.symm ▸
       (⟨Fin.elim0, fun a => a.elim0, fun a => a.elim0⟩ : IncreasingSubseq f 0)
   | some i₀ =>
-    have hmax : ∀ j ∈ Finset.univ, incDP f j ≤ incDP f i₀ := fun j hj =>
-      List.le_of_mem_argmax (Finset.mem_toList.mpr hj) (Option.mem_def.mpr h)
+    have hmax : ∀ j ∈ Finset.univ, incDP f j ≤ incDP f i₀ := fun j _ =>
+      List.le_of_mem_argmax (List.mem_finRange j) (Option.mem_def.mpr h)
     have hlen : lisLength f = incDP f i₀ :=
       le_antisymm (Finset.sup_le hmax) (Finset.le_sup (Finset.mem_univ i₀))
     hlen.symm ▸ incWitness f i₀

--- a/proofs/Proofs/ErdosSzekeresOQ02.lean
+++ b/proofs/Proofs/ErdosSzekeresOQ02.lean
@@ -23,8 +23,29 @@
       predicate — holds (`hasIncreasingEndingAt_incDP`), and an
       `IncreasingSubseq f (incDP f i)` exists (`exists_increasingSubseq_incDP`).
     * `incDP_le_maxIncLen` — the DP is sound against the parent's noncomputable
-      spec: `incDP f i ≤ maxIncLen f i`. (The converse inequality — optimal
-      substructure — is the remaining half of full correctness; see below.)
+      spec: `incDP f i ≤ maxIncLen f i`.
+    * `ExactIncEnd.le_incDP` / `exactIncEnd_iff_le_incDP` — **optimal
+      substructure (stripping)**: `incDP f i` is *exactly* the maximum length of
+      an increasing subsequence ending exactly at `i` (a chain of length `len`
+      ending at `i` exists iff `len ≤ incDP f i`).
+    * `maxIncLen_eq_sup_Iic` — **the corrected full-correctness bridge**:
+      `maxIncLen f i = (Iic i).sup (incDP f)`. The naive pointwise equality
+      `incDP f i = maxIncLen f i` is **false** — the parent's
+      `HasIncreasingEndingAt` disjunction `k j < i ∨ (last ∧ k j = i)` never
+      *forces* the chain to touch `i`, so `maxIncLen` actually measures the
+      longest chain among positions `≤ i` (a running maximum), not the longest
+      chain ending at `i` that its docstring describes. The refutation is
+      formalized (`incDP_lt_maxIncLen_counterexample`: on `[1,2,0]` at `i = 2`,
+      `maxIncLen = 2` but `incDP = 1`), and the bridge is the honest correct
+      statement, proved in both directions.
+    * `lisLength` / `lisLength_eq_sup_maxIncLen` — the computable global LIS
+      length, agreeing with the supremum of the parent's measure.
+    * `incChain` / `incWitness` / `lisWitness` — **the executable witness**
+      (milestone 3): computable `List.argmax` predecessor selection plus
+      `Fin.snoc` backtracking produces an actual `IncreasingSubseq f (incDP f i)`
+      (and a global one of length `lisLength f`) with no `Classical.choice` in
+      the data — `#eval` prints the actual indices. `incWitness_positions_last`
+      certifies the computed subsequence genuinely ends at `i`.
     * `incDPcost_closed` / `incDPcost_two_mul` — the exact comparison count. The
       DP at position `i` scans every candidate `j < i` (`scanned`/`card_scanned`,
       and the actual predecessor set satisfies `preds_subset_scanned`), so the
@@ -43,14 +64,15 @@
   proved a matching Ω(n log n) comparison lower bound, so Θ(n log n) is optimal —
   is documented here but is out of Lean scope without a comparison-cost model.
 
-  ## Remaining milestones (tracked in research/problems/erdos-szekeres-oq-02/)
+  ## Milestone status (tracked in research/problems/erdos-szekeres-oq-02/)
 
-  * Full correctness `incDP f i = maxIncLen f i`: needs the optimal-substructure
-    (stripping) argument for `maxIncLen f i ≤ incDP f i`; sequenced after sibling
-    oq-01's extension lemma to avoid duplicating shared infrastructure.
-  * Executable witness data `incWitness f i : IncreasingSubseq f (incDP f i)` via
-    computable argmax selection (`List.argmax`), turning the `Nonempty` here into
-    a program that returns the actual index map.
+  All three milestones are now complete: (1) computable DP + exact cost,
+  (2) full correctness — in the corrected prefix-supremum form
+  `maxIncLen_eq_sup_Iic`, with the naive pointwise form refuted, plus the exact
+  characterization `exactIncEnd_iff_le_incDP` — and (3) the executable witness
+  `incWitness`/`lisWitness`. Out of Lean scope by design: Θ(n log n) patience
+  sorting and Fredman's Ω(n log n) lower bound (no comparison-cost model in
+  Mathlib; documented above as the literature answer).
 
   Depends on: `Proofs/ErdosSzekeres.lean` (definitions only — no axiom of the
   parent is used; every result here is axiom-free, `#print axioms` shows only
@@ -265,6 +287,430 @@ theorem exists_increasingSubseq_incDP (f : Sequence α n) (i : Fin n) :
   obtain ⟨k, hmono, hvals, -, -⟩ := exactIncEnd_incDP f i
   exact ⟨⟨k, hmono, hvals⟩⟩
 
+/- ## Optimal substructure: the DP value is the exact maximum
+
+The stripping argument: any exact chain ending at `i` of length `m + 1` hands
+its first `m` entries to the second-to-last position `j₀` (which is an
+admissible predecessor of `i`), so by induction `m ≤ incDP f j₀ ≤ sup`, hence
+`m + 1 ≤ incDP f i`. Together with `exactIncEnd_incDP` (the DP value is
+realized) this characterizes `incDP f i` exactly: `ExactIncEnd f i len` holds
+iff `len ≤ incDP f i` (`exactIncEnd_iff_le_incDP`).
+-/
+
+/-- **Stripping / optimal substructure**: every exact chain ending at `i` has
+    length at most `incDP f i`. Induction on the length; the inductive step
+    strips the last element and recurses at the second-to-last position. -/
+theorem ExactIncEnd.le_incDP {f : Sequence α n} {i : Fin n} {len : ℕ}
+    (h : ExactIncEnd f i len) : len ≤ incDP f i := by
+  induction len generalizing i with
+  | zero => exact Nat.zero_le _
+  | succ m ih =>
+    obtain ⟨k, hmono, hvals, hle, hlast⟩ := h
+    rcases Nat.eq_zero_or_pos m with rfl | hm
+    · exact one_le_incDP f i
+    · have hmlt : m < m + 1 := Nat.lt_succ_self m
+      have hprevlt : m - 1 < m + 1 := by omega
+      have hklast : k ⟨m, hmlt⟩ = i := hlast ⟨m, hmlt⟩ (by omega)
+      have hprev : (⟨m - 1, hprevlt⟩ : Fin (m + 1)) < ⟨m, hmlt⟩ := by
+        rw [Fin.lt_def]
+        show m - 1 < m
+        omega
+      have hj₀i : k ⟨m - 1, hprevlt⟩ < i := by
+        have := hmono hprev
+        rwa [hklast] at this
+      have hfj₀ : f (k ⟨m - 1, hprevlt⟩) < f i := by
+        have h2 := hvals hprev
+        simp only [Function.comp_apply] at h2
+        rwa [hklast] at h2
+      have hchain : ExactIncEnd f (k ⟨m - 1, hprevlt⟩) m := by
+        refine ⟨fun a => k a.castSucc, ?_, ?_, ?_, ?_⟩
+        · intro a b hab
+          exact hmono (Fin.castSucc_lt_castSucc_iff.mpr hab)
+        · intro a b hab
+          exact hvals (Fin.castSucc_lt_castSucc_iff.mpr hab)
+        · intro a
+          apply hmono.monotone
+          rw [Fin.le_def]
+          show a.val ≤ m - 1
+          have := a.isLt
+          omega
+        · intro a ha
+          congr 1
+          exact Fin.ext ha
+      have hrec : m ≤ incDP f (k ⟨m - 1, hprevlt⟩) := ih hchain
+      have hmem : k ⟨m - 1, hprevlt⟩ ∈ preds f i := mem_preds.mpr ⟨hj₀i, hfj₀⟩
+      have hsup : incDP f (k ⟨m - 1, hprevlt⟩) ≤ (preds f i).sup (fun j => incDP f j) :=
+        Finset.le_sup hmem
+      rw [incDP_eq]
+      omega
+
+/-- Exact chains truncate: a length-`L` exact chain restricts to its last `len`
+    entries, for any `len ≤ L` (the empty chain covers `len = 0`). -/
+theorem ExactIncEnd.of_le {f : Sequence α n} {i : Fin n} {L len : ℕ}
+    (h : ExactIncEnd f i L) (hlen : len ≤ L) : ExactIncEnd f i len := by
+  rcases Nat.eq_zero_or_pos len with rfl | hpos
+  · exact ⟨Fin.elim0, fun a => a.elim0, fun a => a.elim0, fun a => a.elim0, fun a => a.elim0⟩
+  · obtain ⟨k, hmono, hvals, hle, hlast⟩ := h
+    refine ⟨fun a => k ⟨L - len + a.val, by omega⟩, ?_, ?_, ?_, ?_⟩
+    · intro a b hab
+      have hidx : (⟨L - len + a.val, by omega⟩ : Fin L) < ⟨L - len + b.val, by omega⟩ := by
+        rw [Fin.mk_lt_mk]
+        have := Fin.lt_def.mp hab
+        omega
+      exact hmono hidx
+    · intro a b hab
+      have hidx : (⟨L - len + a.val, by omega⟩ : Fin L) < ⟨L - len + b.val, by omega⟩ := by
+        rw [Fin.mk_lt_mk]
+        have := Fin.lt_def.mp hab
+        omega
+      exact hvals hidx
+    · intro a
+      exact hle _
+    · intro a ha
+      exact hlast ⟨L - len + a.val, by omega⟩ (show L - len + a.val = L - 1 by omega)
+
+/-- **Exact characterization of the DP value**: a chain ending exactly at `i`
+    of length `len` exists iff `len ≤ incDP f i`. So `incDP f i` is precisely
+    the maximum length of an increasing subsequence ending exactly at `i` —
+    full correctness of the DP against the exact-ending specification. -/
+theorem exactIncEnd_iff_le_incDP {f : Sequence α n} {i : Fin n} {len : ℕ} :
+    ExactIncEnd f i len ↔ len ≤ incDP f i :=
+  ⟨ExactIncEnd.le_incDP, fun h => (exactIncEnd_incDP f i).of_le h⟩
+
+/- ## The bridge to the parent's noncomputable spec
+
+The naive completion of correctness would be `incDP f i = maxIncLen f i`. **That
+statement is false**, and the discrepancy is a genuine finding about the parent
+file: `HasIncreasingEndingAt f i len` requires each chain position to satisfy
+`k j < i ∨ (j.val = len - 1 ∧ k j = i)` — the second disjunct is *available* to
+the last element but not *forced*, so chains lying entirely strictly below `i`
+qualify. `maxIncLen f i` therefore measures the longest increasing chain among
+positions `≤ i` where only the last element may touch `i` — NOT the longest
+chain genuinely ending at `i` that its docstring describes and that `incDP`
+computes. Witness `f = [1, 2, 0]` at `i = 2`: the chain at positions `(0, 1)`
+(values `1 < 2`) makes `maxIncLen f 2 = 2`, while `incDP f 2 = 1` (no value
+below `f 2 = 0` exists). Formalized in `incDP_lt_maxIncLen_counterexample`.
+
+The honest correct statement is the prefix-supremum bridge
+`maxIncLen f i = (Iic i).sup (incDP f)` (`maxIncLen_eq_sup_Iic`): the parent's
+measure is the running maximum of the DP table. Both directions are proved, so
+this — together with `exactIncEnd_iff_le_incDP` — is the full correctness of
+the DP against the parent's actual (weak) specification.
+-/
+
+/-- Each DP value at a position `j ≤ i` is a valid length for the parent's
+    (weak) ending-at predicate at `i`, hence bounded by `maxIncLen f i`. -/
+theorem incDP_le_maxIncLen_of_le {f : Sequence α n} {j i : Fin n} (hji : j ≤ i) :
+    incDP f j ≤ maxIncLen f i := by
+  classical
+  obtain ⟨k, hmono, hvals, hle, hlast⟩ := exactIncEnd_incDP f j
+  have hP : HasIncreasingEndingAt f i (incDP f j) := by
+    refine ⟨k, hmono, ?_, hvals⟩
+    intro a
+    rcases lt_or_eq_of_le hji with hlt | rfl
+    · exact Or.inl (lt_of_le_of_lt (hle a) hlt)
+    · by_cases ha : a.val = incDP f j - 1
+      · exact Or.inr ⟨ha, hlast a ha⟩
+      · have hpos : 1 ≤ incDP f j := one_le_incDP f j
+        have h1 : incDP f j - 1 < incDP f j := by omega
+        have hlt2 : a < (⟨incDP f j - 1, h1⟩ : Fin (incDP f j)) := by
+          rw [Fin.lt_def]
+          show a.val < incDP f j - 1
+          have := a.isLt
+          omega
+        have hka := hmono hlt2
+        rw [hlast ⟨incDP f j - 1, h1⟩ rfl] at hka
+        exact Or.inl hka
+  have hwin : incDP f j ≤ i.val + 1 := by
+    have h1 := incDP_le_index_succ f j
+    have h2 : j.val ≤ i.val := hji
+    omega
+  show incDP f j ≤ Nat.findGreatest (HasIncreasingEndingAt f i) (i.val + 1)
+  exact Nat.le_findGreatest hwin hP
+
+/-- Conversely, any length admitted by the parent's predicate is realized as an
+    exact chain ending at *some* position `≤ i`, hence bounded by the prefix
+    supremum of the DP table. -/
+theorem maxIncLen_le_sup_Iic (f : Sequence α n) (i : Fin n) :
+    maxIncLen f i ≤ (Finset.Iic i).sup (fun j => incDP f j) := by
+  classical
+  have hP : HasIncreasingEndingAt f i (maxIncLen f i) := by
+    show HasIncreasingEndingAt f i (Nat.findGreatest (HasIncreasingEndingAt f i) (i.val + 1))
+    exact Nat.findGreatest_spec (by omega) (hasIncreasingEndingAt_one f i)
+  have hL1 : 1 ≤ maxIncLen f i := one_le_maxIncLen f i
+  obtain ⟨k, hmono, hdisj, hvals⟩ := hP
+  have h1 : maxIncLen f i - 1 < maxIncLen f i := by omega
+  have hjle : k ⟨maxIncLen f i - 1, h1⟩ ≤ i := by
+    rcases hdisj ⟨maxIncLen f i - 1, h1⟩ with h | h
+    · exact h.le
+    · exact h.2.le
+  have hexact : ExactIncEnd f (k ⟨maxIncLen f i - 1, h1⟩) (maxIncLen f i) := by
+    refine ⟨k, hmono, hvals, ?_, ?_⟩
+    · intro a
+      apply hmono.monotone
+      rw [Fin.le_def]
+      show a.val ≤ maxIncLen f i - 1
+      have := a.isLt
+      omega
+    · intro a ha
+      congr 1
+      exact Fin.ext ha
+  calc maxIncLen f i ≤ incDP f (k ⟨maxIncLen f i - 1, h1⟩) := hexact.le_incDP
+    _ ≤ (Finset.Iic i).sup (fun j => incDP f j) := Finset.le_sup (Finset.mem_Iic.mpr hjle)
+
+/-- **The corrected full-correctness statement**: the parent's noncomputable
+    `maxIncLen` is exactly the running (prefix) maximum of the computable DP
+    table. This is the true relationship — pointwise equality
+    `incDP f i = maxIncLen f i` is refuted by
+    `incDP_lt_maxIncLen_counterexample` below. -/
+theorem maxIncLen_eq_sup_Iic (f : Sequence α n) (i : Fin n) :
+    maxIncLen f i = (Finset.Iic i).sup (fun j => incDP f j) :=
+  le_antisymm (maxIncLen_le_sup_Iic f i)
+    (Finset.sup_le fun j hj => incDP_le_maxIncLen_of_le (Finset.mem_Iic.mp hj))
+
+/-- The DP table of `[1, 2, 0]` is `[1, 2, 1]`. -/
+theorem incDP_counterexample_table :
+    incDP (![1, 2, 0] : Sequence ℕ 3) 0 = 1 ∧
+    incDP (![1, 2, 0] : Sequence ℕ 3) 1 = 2 ∧
+    incDP (![1, 2, 0] : Sequence ℕ 3) 2 = 1 := by
+  have h0 : incDP (![1, 2, 0] : Sequence ℕ 3) 0 = 1 := by
+    rw [incDP_eq, show preds (![1, 2, 0] : Sequence ℕ 3) 0 = ∅ from by decide]
+    simp
+  have h1 : incDP (![1, 2, 0] : Sequence ℕ 3) 1 = 2 := by
+    rw [incDP_eq, show preds (![1, 2, 0] : Sequence ℕ 3) 1 = {0} from by decide]
+    simp [h0]
+  have h2 : incDP (![1, 2, 0] : Sequence ℕ 3) 2 = 1 := by
+    rw [incDP_eq, show preds (![1, 2, 0] : Sequence ℕ 3) 2 = ∅ from by decide]
+    simp
+  exact ⟨h0, h1, h2⟩
+
+/-- **The naive correctness statement `incDP = maxIncLen` is FALSE.** On
+    `f = [1, 2, 0]` at `i = 2`, the parent's weak ending-at disjunction admits
+    the chain `1 < 2` at positions `(0, 1)` lying entirely below `i`, so
+    `maxIncLen f 2 = 2` while no increasing chain genuinely ends at `i = 2`
+    beyond the singleton: `incDP f 2 = 1`. -/
+theorem incDP_lt_maxIncLen_counterexample :
+    incDP (![1, 2, 0] : Sequence ℕ 3) 2 < maxIncLen (![1, 2, 0] : Sequence ℕ 3) 2 := by
+  obtain ⟨h0, h1, h2⟩ := incDP_counterexample_table
+  have hsup : maxIncLen (![1, 2, 0] : Sequence ℕ 3) 2 = 2 := by
+    rw [maxIncLen_eq_sup_Iic, show Finset.Iic (2 : Fin 3) = {0, 1, 2} from by decide,
+      Finset.sup_insert, Finset.sup_insert, Finset.sup_singleton, h0, h1, h2]
+  rw [h2, hsup]
+  omega
+
+/- ## The global LIS length
+
+`lisLength f = sup_i (incDP f i)` is the computable global
+longest-increasing-subsequence length; by the bridge it agrees with the
+supremum of the parent's noncomputable per-position measure.
+-/
+
+/-- The computable global longest-increasing-subsequence length. -/
+def lisLength (f : Sequence α n) : ℕ := Finset.univ.sup (fun i => incDP f i)
+
+/-- The computable global length agrees with the supremum of the parent's
+    noncomputable per-position measure. -/
+theorem lisLength_eq_sup_maxIncLen (f : Sequence α n) :
+    lisLength f = Finset.univ.sup (fun i => maxIncLen f i) := by
+  unfold lisLength
+  apply le_antisymm
+  · refine Finset.sup_le fun i _ => ?_
+    exact le_trans (incDP_le_maxIncLen f i) (Finset.le_sup (Finset.mem_univ i))
+  · refine Finset.sup_le fun i _ => ?_
+    rw [maxIncLen_eq_sup_Iic]
+    exact Finset.sup_le fun j _ => Finset.le_sup (Finset.mem_univ j)
+
+/- ## The executable witness (milestone 3)
+
+`incChain` backtracks computable `List.argmax` predecessor pointers to build
+the actual index map — the literal content of "finding the actual monotonic
+subsequence". No `Classical.choice` enters the data: the only choices made are
+`List.argmax` over decidable comparisons, so `#eval` runs the whole pipeline
+and prints the indices (see the smoke tests at the end of the file).
+-/
+
+/-- Executable chain data: the `Type`-level (data-carrying) counterpart of
+    `ExactIncEnd` — positions of a strictly increasing subsequence with
+    strictly increasing values, bounded by `i` and ending exactly at `i`. -/
+structure IncChain (f : Sequence α n) (i : Fin n) (len : ℕ) where
+  /-- The positions forming the chain. -/
+  positions : Fin len → Fin n
+  /-- Positions strictly increase. -/
+  strictMono_positions : StrictMono positions
+  /-- Values strictly increase. -/
+  strictMono_values : StrictMono (f ∘ positions)
+  /-- All positions are bounded by the endpoint. -/
+  le_endpoint : ∀ a, positions a ≤ i
+  /-- The last position is exactly the endpoint. -/
+  last_eq : ∀ a : Fin len, a.val = len - 1 → positions a = i
+
+/-- Chain data yields the `Prop`-level invariant. -/
+theorem IncChain.exactIncEnd {f : Sequence α n} {i : Fin n} {len : ℕ}
+    (c : IncChain f i len) : ExactIncEnd f i len :=
+  ⟨c.positions, c.strictMono_positions, c.strictMono_values, c.le_endpoint, c.last_eq⟩
+
+/-- The singleton chain at `i`. -/
+def IncChain.single (f : Sequence α n) (i : Fin n) : IncChain f i 1 where
+  positions := fun _ => i
+  strictMono_positions := by
+    intro a b hab
+    exact absurd hab (Subsingleton.elim a b ▸ lt_irrefl _)
+  strictMono_values := by
+    intro a b hab
+    exact absurd hab (Subsingleton.elim a b ▸ lt_irrefl _)
+  le_endpoint := fun _ => le_refl i
+  last_eq := fun _ _ => rfl
+
+/-- Transport chain data along a length equality. -/
+def IncChain.cast {f : Sequence α n} {i : Fin n} {len len' : ℕ} (h : len = len')
+    (c : IncChain f i len) : IncChain f i len' := h ▸ c
+
+/-- One-step extension of chain data by a later, larger position (the
+    data-level twin of `ExactIncEnd.extend`, same `Fin.snoc` mechanism). -/
+def IncChain.extend {f : Sequence α n} {j i : Fin n} {len : ℕ}
+    (c : IncChain f j len) (hlen : 1 ≤ len) (hji : j < i) (hfji : f j < f i) :
+    IncChain f i (len + 1) :=
+  have hki : ∀ a : Fin len, c.positions a < i := fun a =>
+    lt_of_le_of_lt (c.le_endpoint a) hji
+  have hfki : ∀ a : Fin len, f (c.positions a) < f i := by
+    intro a
+    by_cases ha : a.val = len - 1
+    · rw [c.last_eq a ha]
+      exact hfji
+    · have h1 : len - 1 < len := by omega
+      have hlt : a < (⟨len - 1, h1⟩ : Fin len) := by
+        rw [Fin.lt_def]
+        show a.val < len - 1
+        have := a.isLt
+        omega
+      have h2 := c.strictMono_values hlt
+      simp only [Function.comp_apply] at h2
+      rw [c.last_eq ⟨len - 1, h1⟩ rfl] at h2
+      exact lt_trans h2 hfji
+  { positions := Fin.snoc c.positions i
+    strictMono_positions := by
+      intro a b hab
+      rcases Fin.eq_castSucc_or_eq_last b with ⟨b', rfl⟩ | rfl
+      · rcases Fin.eq_castSucc_or_eq_last a with ⟨a', rfl⟩ | rfl
+        · simp only [Fin.snoc_castSucc]
+          exact c.strictMono_positions (Fin.castSucc_lt_castSucc_iff.mp hab)
+        · exact absurd hab (not_lt.mpr (Fin.castSucc_lt_last b').le)
+      · rcases Fin.eq_castSucc_or_eq_last a with ⟨a', rfl⟩ | rfl
+        · simp only [Fin.snoc_castSucc, Fin.snoc_last]
+          exact hki a'
+        · exact absurd hab (lt_irrefl _)
+    strictMono_values := by
+      rw [Fin.comp_snoc]
+      intro a b hab
+      rcases Fin.eq_castSucc_or_eq_last b with ⟨b', rfl⟩ | rfl
+      · rcases Fin.eq_castSucc_or_eq_last a with ⟨a', rfl⟩ | rfl
+        · simp only [Fin.snoc_castSucc]
+          exact c.strictMono_values (Fin.castSucc_lt_castSucc_iff.mp hab)
+        · exact absurd hab (not_lt.mpr (Fin.castSucc_lt_last b').le)
+      · rcases Fin.eq_castSucc_or_eq_last a with ⟨a', rfl⟩ | rfl
+        · simp only [Fin.snoc_castSucc, Fin.snoc_last]
+          exact hfki a'
+        · exact absurd hab (lt_irrefl _)
+    le_endpoint := by
+      intro a
+      rcases Fin.eq_castSucc_or_eq_last a with ⟨a', rfl⟩ | rfl
+      · rw [Fin.snoc_castSucc]
+        exact (hki a').le
+      · rw [Fin.snoc_last]
+    last_eq := by
+      intro a ha
+      have haeq : a = Fin.last len := by
+        apply Fin.ext
+        simpa using ha
+      rw [haeq, Fin.snoc_last] }
+
+/-- Computable predecessor selection: an admissible predecessor maximizing the
+    DP value, chosen via `List.argmax` (no `Classical.choice`). -/
+def incArgmax (f : Sequence α n) (i : Fin n) : Option (Fin n) :=
+  (preds f i).toList.argmax (fun j => incDP f j)
+
+theorem incArgmax_eq_none {f : Sequence α n} {i : Fin n}
+    (h : incArgmax f i = none) : preds f i = ∅ :=
+  Finset.toList_eq_nil.mp (List.argmax_eq_none.mp h)
+
+theorem incArgmax_mem {f : Sequence α n} {i : Fin n} {j₀ : Fin n}
+    (h : incArgmax f i = some j₀) : j₀ ∈ preds f i :=
+  Finset.mem_toList.mp (List.argmax_mem (Option.mem_def.mpr h))
+
+/-- With no admissible predecessor the DP value is `1`. -/
+theorem incDP_eq_one_of_incArgmax_none {f : Sequence α n} {i : Fin n}
+    (h : incArgmax f i = none) : incDP f i = 1 := by
+  rw [incDP_eq, incArgmax_eq_none h]
+  simp
+
+/-- The argmax predecessor attains the DP recurrence:
+    `incDP f i = incDP f j₀ + 1`. -/
+theorem incDP_eq_of_incArgmax_some {f : Sequence α n} {i : Fin n} {j₀ : Fin n}
+    (h : incArgmax f i = some j₀) : incDP f i = incDP f j₀ + 1 := by
+  have hmem : j₀ ∈ preds f i := incArgmax_mem h
+  have hmax : ∀ j ∈ preds f i, incDP f j ≤ incDP f j₀ := fun j hj =>
+    List.le_of_mem_argmax (Finset.mem_toList.mpr hj) (Option.mem_def.mpr h)
+  have hsup : (preds f i).sup (fun j => incDP f j) = incDP f j₀ :=
+    le_antisymm (Finset.sup_le hmax) (Finset.le_sup hmem)
+  rw [incDP_eq, hsup, Nat.add_comm]
+
+/-- **The executable witness chain**: backtracks `incArgmax` predecessor
+    pointers, building the position map by `Fin.snoc`. Computable — this is
+    the O(n) reconstruction on top of the DP table. -/
+def incChain (f : Sequence α n) (i : Fin n) : IncChain f i (incDP f i) :=
+  match h : incArgmax f i with
+  | none => (IncChain.single f i).cast (incDP_eq_one_of_incArgmax_none h).symm
+  | some j₀ =>
+    have hj := mem_preds.mp (incArgmax_mem h)
+    ((incChain f j₀).extend (one_le_incDP f j₀) hj.1 hj.2).cast
+      (incDP_eq_of_incArgmax_some h).symm
+termination_by i.val
+decreasing_by exact hj.1
+
+/-- **Milestone 3 — the actual subsequence as a program**: an executable
+    `IncreasingSubseq` of the DP length at every position. Where
+    `exists_increasingSubseq_incDP` asserts existence, this *returns the
+    indices* (see the `#eval` smoke tests). -/
+def incWitness (f : Sequence α n) (i : Fin n) : IncreasingSubseq f (incDP f i) :=
+  ⟨(incChain f i).positions, (incChain f i).strictMono_positions,
+    (incChain f i).strictMono_values⟩
+
+/-- The computed witness genuinely ends at `i`. -/
+theorem incWitness_positions_last (f : Sequence α n) (i : Fin n)
+    (a : Fin (incDP f i)) (ha : a.val = incDP f i - 1) :
+    (incWitness f i).positions a = i :=
+  (incChain f i).last_eq a ha
+
+/-- Computable global argmax position of the DP table. -/
+def lisArgmax (f : Sequence α n) : Option (Fin n) :=
+  Finset.univ.toList.argmax (fun i => incDP f i)
+
+/-- **The global executable witness**: an actual longest increasing
+    subsequence of the whole sequence, of the computable global length
+    `lisLength f`. -/
+def lisWitness (f : Sequence α n) : IncreasingSubseq f (lisLength f) :=
+  match h : lisArgmax f with
+  | none =>
+    have huniv : (Finset.univ : Finset (Fin n)) = ∅ :=
+      Finset.toList_eq_nil.mp (List.argmax_eq_none.mp h)
+    have hlen : lisLength f = 0 := by
+      rw [lisLength, huniv]
+      exact Finset.sup_empty
+    hlen.symm ▸
+      (⟨Fin.elim0, fun a => a.elim0, fun a => a.elim0⟩ : IncreasingSubseq f 0)
+  | some i₀ =>
+    have hmax : ∀ j ∈ Finset.univ, incDP f j ≤ incDP f i₀ := fun j hj =>
+      List.le_of_mem_argmax (Finset.mem_toList.mpr hj) (Option.mem_def.mpr h)
+    have hlen : lisLength f = incDP f i₀ :=
+      le_antisymm (Finset.sup_le hmax) (Finset.le_sup (Finset.mem_univ i₀))
+    hlen.symm ▸ incWitness f i₀
+
+/-- An `IncreasingSubseq` of the global LIS length always exists (now a
+    one-liner: the executable witness inhabits it). -/
+theorem exists_increasingSubseq_lisLength (f : Sequence α n) :
+    Nonempty (IncreasingSubseq f (lisLength f)) :=
+  ⟨lisWitness f⟩
+
 /- ## The exact comparison count
 
 The DP at position `i` tests every candidate `j < i` once (the `preds` filter
@@ -311,11 +757,17 @@ theorem incDPcost_two_mul (n : ℕ) : incDPcost n * 2 = n * (n - 1) := by
 `incDP` is computable, so `#eval` runs it directly — this is the point of the
 OQ: the parent's `maxIncLen` admits no such evaluation. On [3,1,4,1,5,9,2,6]
 the DP table is [1,1,2,1,3,4,2,4] (e.g. 3,4,5,9 ends at position 5; 3,4,5,6
-ends at position 7), and `incDPcost 8 = 28 = 8·7/2`.
+ends at position 7), and `incDPcost 8 = 28 = 8·7/2`. The witness pipeline
+`incWitness`/`lisWitness` prints the *actual indices* of a longest increasing
+subsequence — the literal answer to "finding the actual monotonic
+subsequence".
 -/
 
 #eval incDP (![3, 1, 4, 1, 5, 9, 2, 6] : Fin 8 → ℕ) 7
 #eval (List.ofFn fun i : Fin 8 => incDP (![3, 1, 4, 1, 5, 9, 2, 6] : Fin 8 → ℕ) i)
 #eval incDPcost 8
+#eval List.ofFn (incWitness (![3, 1, 4, 1, 5, 9, 2, 6] : Fin 8 → ℕ) 7).positions
+#eval lisLength (![3, 1, 4, 1, 5, 9, 2, 6] : Fin 8 → ℕ)
+#eval List.ofFn (lisWitness (![3, 1, 4, 1, 5, 9, 2, 6] : Fin 8 → ℕ)).positions
 
 end ErdosSzekeresOQ02

--- a/research/problems/erdos-szekeres-oq-02/knowledge.md
+++ b/research/problems/erdos-szekeres-oq-02/knowledge.md
@@ -292,3 +292,62 @@ and Docker is back)
 - `proofs/Proofs/ErdosSzekeresOQ02.lean` (NEW, 319 LOC)
 - `research/problems/erdos-szekeres-oq-02/problem.md` (pinning section)
 - `research/problems/erdos-szekeres-oq-02/state.md`, tracker JSON (unblocked)
+
+---
+
+## Session 6 (2026-07-24, researcher-1) — Milestones 2+3 CLOSED; the naive pin was FALSE
+
+### The finding: `incDP f i = maxIncLen f i` is false
+
+The parent's `HasIncreasingEndingAt f i len` requires each chain position to
+satisfy `k j < i ∨ (j.val = len - 1 ∧ k j = i)`. The second disjunct is
+*available* to the last element but never *forced* — chains lying entirely
+strictly below `i` qualify. So `maxIncLen` is a **running (prefix) maximum**
+of ending-at lengths, not the ending-at-`i` length its docstring describes.
+Counterexample (formalized, `incDP_lt_maxIncLen_counterexample`):
+`f = ![1,2,0]`, `i = 2`: chain `1 < 2` at positions `(0,1)` gives
+`maxIncLen f 2 = 2`, while `incDP f 2 = 1` (nothing below value `0`).
+
+### What replaced it (all proved, 0 sorry / 0 axiom)
+
+- `ExactIncEnd.le_incDP` — stripping/optimal substructure by induction on
+  length: strip the last element, recurse at the second-to-last position
+  (an admissible predecessor), `sup` bounds the rest.
+- `exactIncEnd_iff_le_incDP` — `ExactIncEnd f i len ↔ len ≤ incDP f i`
+  (with `ExactIncEnd.of_le` suffix-truncation for the ← direction). incDP is
+  EXACTLY the max exact-ending length.
+- `maxIncLen_eq_sup_Iic` — `maxIncLen f i = (Iic i).sup (incDP f)`, the
+  corrected full-correctness bridge, both directions
+  (`incDP_le_maxIncLen_of_le` uses `Nat.le_findGreatest`;
+  `maxIncLen_le_sup_Iic` uses `Nat.findGreatest_spec` seeded with the
+  singleton chain, then strips at the actual last position).
+- `lisLength` (computable global LIS length) +
+  `lisLength_eq_sup_maxIncLen`.
+- Milestone 3: `IncChain` (Type-level `ExactIncEnd` with data),
+  `IncChain.single/extend/cast`, `incArgmax` via
+  `((preds f i).sort (· ≤ ·)).argmax`, `incChain` (WF recursion on `i.val`),
+  `incWitness : IncreasingSubseq f (incDP f i)`, `incWitness_positions_last`,
+  `lisArgmax` via `(List.finRange n).argmax`, and the global
+  `lisWitness : IncreasingSubseq f (lisLength f)`. All computable; `#eval`
+  smoke tests print the actual indices.
+
+### Lean gotchas hit
+
+- **`Finset.toList` is NONCOMPUTABLE** (`Quotient.out`-based) — a
+  `List.argmax` selection over a Finset must go through `Finset.sort (· ≤ ·)`
+  (computable merge sort; `Finset.mem_sort`, `Finset.length_sort`) or
+  `List.finRange` for `univ`. First build failed exactly here.
+- `rw [Finset.sup_insert, …, h0, h1, h2]` leaves a `1 ⊔ (2 ⊔ 1) = 2` goal —
+  close with `decide` (and use `simp only` so beta-reduction happens before
+  the pointwise rewrites).
+- `Nat.findGreatest_spec (hmb : m ≤ n) (hm : P m)` needs any positive seed
+  witness (use the singleton chain at `m = 1`), not the findGreatest value
+  itself.
+
+### Status after S6
+
+All three pinned milestones are closed (milestone 2 in corrected form, with
+the original pin refuted and the refutation formalized). Remaining open on
+this OQ: nothing formalizable at the elementary layer — Θ(n log n) patience
+sorting and Fredman's Ω(n log n) stay literature-only (no comparison-cost
+model in Mathlib). Node is a candidate for COMPLETED.

--- a/research/problems/erdos-szekeres-oq-02/problem.md
+++ b/research/problems/erdos-szekeres-oq-02/problem.md
@@ -137,12 +137,26 @@ formalizable core (see knowledge.md). The pinned Lean targets:
 3. **Exact comparison count.** A cost function counting exactly the scanned
    candidate pairs `(j, i), j < i` of the DP, with the proved closed form
    `n * (n - 1) / 2` (and a division-free form `* 2 = n * (n - 1)`).
-4. **Full correctness (milestone 2, later session).**
-   `incDP f i = maxIncLen f i` — the `≥` half (optimal substructure /
-   stripping) is the remaining open piece; the `≤` half is item 2.
-5. **Actual data (milestone 3, later session).** An executable
+4. **Full correctness (milestone 2 — CLOSED 2026-07-24 in corrected form).**
+   ~~`incDP f i = maxIncLen f i`~~ — **the pointwise equality as originally
+   pinned here is FALSE** (found and formalized 2026-07-24, S6): the parent's
+   `HasIncreasingEndingAt` disjunction `k j < i ∨ (j.val = len-1 ∧ k j = i)`
+   never *forces* the chain to touch `i`, so chains lying entirely below `i`
+   qualify and `maxIncLen` is a *running maximum*, not the ending-at-`i`
+   maximum its docstring describes. Refutation: `f = ![1,2,0]`, `i = 2` has
+   `maxIncLen = 2` (chain at positions 0,1) but `incDP = 1`
+   (`incDP_lt_maxIncLen_counterexample`). The corrected full-correctness pair,
+   both proved:
+   - `exactIncEnd_iff_le_incDP` : `ExactIncEnd f i len ↔ len ≤ incDP f i`
+     (the DP is exactly the max length ending exactly at `i` — via the
+     stripping lemma `ExactIncEnd.le_incDP`), and
+   - `maxIncLen_eq_sup_Iic` : `maxIncLen f i = (Iic i).sup (incDP f)`
+     (the parent's measure is the prefix maximum of the DP table).
+5. **Actual data (milestone 3 — CLOSED 2026-07-24).** An executable
    `incWitness f i : IncreasingSubseq f (incDP f i)` (computable, i.e. via
-   `List.argmax`-style selection, not `Classical.choice`).
+   `List.argmax`-style selection, not `Classical.choice`), plus the global
+   `lisWitness f : IncreasingSubseq f (lisLength f)`; `#eval` prints the
+   actual indices.
 
 ### Does not count
 
@@ -157,3 +171,35 @@ formalizable core (see knowledge.md). The pinned Lean targets:
   pigeonhole) without the DP — that is sibling oq-01's territory.
 - **`incDP ≤ maxIncLen` alone** presented as full correctness (item 4 needs
   both directions).
+
+## Adversarial checklist (2026-07-24, S6 — for the milestone 2+3 closure claim)
+
+How THIS closure claim could be wrong; auditors should check each:
+
+1. **The counterexample could be miscomputed.** Verify `HasIncreasingEndingAt
+   (![1,2,0]) 2 2` really holds: the chain `k = (0,1)` must satisfy the
+   disjunction `k j < 2 ∨ (last ∧ k j = 2)` — both positions use the FIRST
+   disjunct (0 < 2, 1 < 2); nothing requires the second. If the parent's
+   definition is ever strengthened (forcing `k (last) = i`), the counterexample
+   collapses and `incDP = maxIncLen` becomes true — re-audit
+   `incDP_lt_maxIncLen_counterexample` after any parent edit.
+2. **`ExactIncEnd f i 0` is vacuously true** (empty chain via `Fin.elim0`), so
+   `exactIncEnd_iff_le_incDP` at `len = 0` reads "True ↔ 0 ≤ incDP" — correct,
+   but do not cite the iff as "chains of every length ≤ incDP are nonempty
+   data"; length-0 is the degenerate case.
+3. **The bridge could silently prove the wrong near-miss.** `maxIncLen_eq_sup_Iic`
+   uses `Finset.Iic i` (closed interval, INCLUDES `i`). With `Iio` it would be
+   false at positions where the maximum ends exactly at `i`. Check `Iic` not
+   `Iio`.
+4. **Window bound in `incDP_le_maxIncLen_of_le`**: `Nat.le_findGreatest`
+   requires `incDP f j ≤ i.val + 1`; this comes from `incDP_le_index_succ`
+   plus `j ≤ i` — check the `j = i` boundary case (equality allowed).
+5. **Computability near-miss (the pinned one)**: `incChain`/`incWitness`/
+   `lisWitness` must carry NO `noncomputable` marker and `#eval` must run
+   (smoke tests at file end). `Classical.choice` may appear in the *Prop*
+   fields' proofs (erased at runtime) — the claim is about the data, i.e. the
+   positions map, selected via `List.argmax` only.
+6. **Circularity check**: nothing here uses the parent's
+   `erdos_szekeres_existence_axiom` or `erdos_szekeres_tight_axiom` — the file
+   imports parent *definitions* only; `#print axioms` on the capstones must
+   show only propext/Classical.choice/Quot.sound.

--- a/research/problems/erdos-szekeres-oq-02/state.md
+++ b/research/problems/erdos-szekeres-oq-02/state.md
@@ -1,11 +1,11 @@
 # Research State: erdos-szekeres-oq-02
 
 ## Current State
-**Phase**: ACT
+**Phase**: COMPLETED
 **Path**: full
 **Since**: 2026-07-24T00:00:00-07:00
-**Iteration**: 5
-**Last Updated**: 2026-07-24 (S5, researcher-1 — UNBLOCKED, milestone 1 + realized-witness layer landed)
+**Iteration**: 6
+**Last Updated**: 2026-07-24 (S6, researcher-1 — milestones 2+3 closed; naive pin refuted, corrected bridge + executable witness landed)
 
 ## Session 5 (2026-07-24, researcher-1) — UNBLOCK + FIRST LEAN ARTIFACT
 
@@ -35,3 +35,27 @@ Computable DP `incDP` (landed) shown sound against the parent's noncomputable
 data via argmax backtracking. Θ(n log n) patience sorting + Fredman Ω(n log n)
 remain literature-only (no comparison-cost model in Mathlib) — documented in
 the file header, out of Lean scope by design.
+
+
+## Session 6 (2026-07-24, researcher-1) — MILESTONES 2+3 CLOSED (corrected form)
+
+Key finding: the pinned milestone-2 statement `incDP f i = maxIncLen f i` is
+FALSE — the parent's `HasIncreasingEndingAt` disjunction never forces the
+chain to touch `i`, so `maxIncLen` is a running (prefix) maximum. Formalized
+refutation `incDP_lt_maxIncLen_counterexample` (`![1,2,0]` at `i=2`:
+maxIncLen 2 vs incDP 1). Correct replacements, all proved (0 sorry, 0 axiom):
+
+- `ExactIncEnd.le_incDP` (stripping / optimal substructure) and the exact
+  characterization `exactIncEnd_iff_le_incDP : ExactIncEnd f i len ↔ len ≤ incDP f i`.
+- `maxIncLen_eq_sup_Iic : maxIncLen f i = (Iic i).sup (incDP f)` — full
+  correctness against the parent's actual spec, both directions.
+- Global computable `lisLength` + `lisLength_eq_sup_maxIncLen`.
+- Milestone 3: executable `incChain`/`incWitness`/`lisWitness` via
+  `Finset.sort`/`List.finRange` + `List.argmax` backtracking (Finset.toList is
+  noncomputable — gotcha) with `Fin.snoc` extension; `#eval` prints actual
+  indices ([0,2,4,7] on the [3,1,4,1,5,9,2,6] smoke test).
+
+Problem.md item 4 updated in place with the refutation; adversarial checklist
+added. Nothing formalizable remains at the elementary layer (patience sorting /
+Fredman lower bound stay literature-only, out of Lean scope by design).
+Status: node COMPLETED.

--- a/src/data/research/problems/erdos-szekeres-oq-02.json
+++ b/src/data/research/problems/erdos-szekeres-oq-02.json
@@ -28,7 +28,7 @@
     "goal": "Formalize a computable incDP : Fin n -> Nat proven equal to maxIncLen, a constructive witness extractor, and an exact Theta(n^2) comparison-count closed form n(n-1)/2; document the Theta(n log n) optimum as the cost-model-gated remainder."
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-06-13T00:00:00-07:00",
     "iteration": 2,
     "focus": "First survey complete (researcher-9 2026-06-13, build-free during the Docker/Aristotle verification blackout). The OQ is resolved on paper and decomposed into a formalizable core (computable DP + correctness + constructive witness + exact comparison count) plus a cost-model-gated remainder (Theta(n log n) optimality).",
@@ -47,12 +47,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT (researcher-1 2026-07-24 S5): UNBLOCKED (Docker back). Milestone 1 COMPLETE + realized-witness layer: computable incDP with recurrence, HasIncreasingEndingAt f i (incDP f i), incDP_le_maxIncLen, Nonempty (IncreasingSubseq f (incDP f i)), exact cost incDPcost n = n(n-1)/2. 319 LOC, 0 sorry/0 axiom, Docker-verified. Remaining: >= correctness (stripping), computable incWitness.",
+    "progressSummary": "COMPLETED (2026-07-24 S6): all three pinned milestones closed. Milestone 2 closed in corrected form — the naive pin incDP = maxIncLen is FALSE (parent ending-at predicate is a running maximum; formalized counterexample) and the honest bridge maxIncLen f i = (Iic i).sup (incDP f) plus the exact characterization ExactIncEnd f i len iff len <= incDP f i are proved. Milestone 3 closed: fully executable witness pipeline (incWitness per position, lisWitness global) via Finset.sort/List.finRange argmax backtracking, no Classical.choice in data, #eval prints actual indices. 0 sorry / 0 axiom throughout. Out of Lean scope by design: patience sorting and Fredman lower bound (no comparison-cost model).",
     "builtItems": [
       "ErdosSzekeresOQ02.lean (NEW, 319 LOC, 0 sorry, 0 axiom): incDP (computable DP), incDP_eq, one_le_incDP, incDP_le_index_succ",
       "ExactIncEnd + exactIncEnd_one + ExactIncEnd.extend + ExactIncEnd.hasIncreasingEndingAt (snoc extension machinery)",
       "exactIncEnd_incDP, hasIncreasingEndingAt_incDP, incDP_le_maxIncLen, exists_increasingSubseq_incDP",
-      "Cost layer: scanned/card_scanned/preds_subset_scanned, incDPcost, incDPcost_closed (n(n-1)/2), incDPcost_two_mul (division-free)"
+      "Cost layer: scanned/card_scanned/preds_subset_scanned, incDPcost, incDPcost_closed (n(n-1)/2), incDPcost_two_mul (division-free)",
+      "ExactIncEnd.le_incDP + ExactIncEnd.of_le + exactIncEnd_iff_le_incDP (stripping/optimal substructure) in ErdosSzekeresOQ02.lean",
+      "maxIncLen_eq_sup_Iic bridge + incDP_lt_maxIncLen_counterexample (formalized refutation of the naive pin)",
+      "lisLength + lisLength_eq_sup_maxIncLen (computable global LIS length)",
+      "IncChain structure + single/extend/cast, incArgmax (Finset.sort + List.argmax), incChain (WF backtracking), incWitness, incWitness_positions_last, lisArgmax, lisWitness — all computable, #eval-verified"
     ],
     "insights": [
       "The parent maxIncLen/maxDecLen are noncomputable (Nat.findGreatest over a Prop existential), so oq-02 is precisely the gap between a non-constructive existence spec and an executable algorithm proven to meet it.",
@@ -64,7 +68,10 @@
       "First buildable milestone is self-contained and oq-01-independent: incDP + termination + DecidablePred + the closed-form comparison count. Pure Fin/Finset/Nat algebra, ~40-60 LOC.",
       "S5: The parent HasIncreasingEndingAt disjunction permits the last position to fall short of i — too weak to extend chains (no value info at the junction). Strengthened ExactIncEnd invariant (last position exactly i) makes Fin.snoc extension go through, then downgrades to the parent predicate.",
       "S5: incDP_le_maxIncLen (soundness vs the noncomputable spec) is provable WITHOUT oq-01 extension lemma: realized witness + Nat.le_findGreatest + incDP f i <= i.val + 1.",
-      "S5: Recursive theorems with termination_by i.val (incDP_le_index_succ, exactIncEnd_incDP) mirror the WF def cleanly — no strong-induction gymnastics; decreasing_by exact <Fin.lt hyp> works via defeq."
+      "S5: Recursive theorems with termination_by i.val (incDP_le_index_succ, exactIncEnd_incDP) mirror the WF def cleanly — no strong-induction gymnastics; decreasing_by exact <Fin.lt hyp> works via defeq.",
+      "The parent HasIncreasingEndingAt is strictly weaker than its docstring: the disjunction k j < i OR (last AND k j = i) never forces the chain to touch i, so maxIncLen is a running prefix maximum, not the ending-at-i length. Hence incDP f i = maxIncLen f i is FALSE (formalized counterexample ![1,2,0] at i=2: maxIncLen 2, incDP 1).",
+      "Corrected full correctness: exactIncEnd_iff_le_incDP (incDP is exactly the max exact-ending chain length, via the stripping lemma) plus maxIncLen_eq_sup_Iic (maxIncLen f i = (Iic i).sup (incDP f)), both directions proved.",
+      "Finset.toList is noncomputable (Quotient.out); computable argmax selection must use Finset.sort or List.finRange. This was the only obstacle to a fully executable witness pipeline."
     ],
     "mathlibGaps": [
       "No cost/complexity model (no Big-O cost monad, no RAM/comparison-decision-tree machinery, no Master theorem) — so asymptotic complexity statements have no Lean home; use exact Nat operation-counters instead.",


### PR DESCRIPTION
## Summary
Research session S6 for `erdos-szekeres-oq-02` ("complexity of finding the actual monotonic subsequence"). Closes the two remaining pinned milestones — **with a mathematical correction**: the pinned full-correctness statement was false, and the refutation is formalized.

## Key finding: the naive pin `incDP f i = maxIncLen f i` is FALSE
The parent's `HasIncreasingEndingAt f i len` requires each position to satisfy `k j < i ∨ (j.val = len - 1 ∧ k j = i)` — the second disjunct is available to the last element but never **forced**, so chains lying entirely below `i` qualify. `maxIncLen` is therefore a *running (prefix) maximum*, not the "longest increasing subsequence ending at position i" its docstring describes. Formalized counterexample `incDP_lt_maxIncLen_counterexample`: on `f = ![1,2,0]` at `i = 2`, `maxIncLen = 2` but `incDP = 1`.

## Progress (all 0 sorry / 0 axiom, Docker-verified 8577 jobs)
- **Milestone 2 closed (corrected form)**:
  - `ExactIncEnd.le_incDP` — stripping / optimal substructure (induction on length, strip the last element to the second-to-last predecessor);
  - `exactIncEnd_iff_le_incDP` — `ExactIncEnd f i len ↔ len ≤ incDP f i`: the DP is *exactly* the maximum exact-ending chain length;
  - `maxIncLen_eq_sup_Iic` — `maxIncLen f i = (Iic i).sup (incDP f)`: the honest bridge to the parent's actual spec, both directions.
- **Milestone 3 closed (executable witness)**: `IncChain` (data-level `ExactIncEnd`), computable `incArgmax` via `Finset.sort` + `List.argmax` (`Finset.toList` is noncomputable — first build failed exactly there), `incChain` WF backtracking, `incWitness : IncreasingSubseq f (incDP f i)`, global `lisWitness : IncreasingSubseq f (lisLength f)`. No `Classical.choice` in the data; `#eval` prints the actual indices (`[0,2,4,7]` per-position, `[0,2,4,5]` global on the smoke test).
- **Global layer**: computable `lisLength` + `lisLength_eq_sup_maxIncLen`.
- In-file `#print axioms` audit lines: every capstone shows only `[propext, Classical.choice, Quot.sound]` in the build log — no parent ES axiom is used.

## Files Modified
- `proofs/Proofs/ErdosSzekeresOQ02.lean` (455 → ~790 lines)
- `research/problems/erdos-szekeres-oq-02/{problem.md,knowledge.md,state.md}` (pin corrected in place, adversarial checklist added, S6 notes)
- `src/data/research/problems/erdos-szekeres-oq-02.json` (phase COMPLETED, insights/builtItems)

## Findings
- The parent gallery file's docstrings (`ErdosSzekeres.lean` lines 26/89/153) describe `maxIncLen` as the ending-at-`i` length; the formal definition is weaker. Flagged separately as a gallery-integrity issue — relevant to sibling oq-01's pigeonhole work.
- `Finset.toList` is noncomputable (`Quotient.out`); computable Finset→List extraction must use `Finset.sort` / `List.finRange`.

## Status
**Outcome**: completed — all three pinned milestones closed (milestone 2 in corrected form with formalized refutation of the original pin). Out of Lean scope by design: Θ(n log n) patience sorting / Fredman lower bound (no comparison-cost model in Mathlib). 0 follow-up OQs proposed (the strong finding routes to the parent as an integrity issue, not a new child chain).

🤖 Generated by researcher-1
