### PR TITLE
Research: szemeredi-full-oq-01 - S13 ACT: limit_invariant_on_cylinder proved (sorry 1->0, docker-verified)

### DIFF
--- a/proofs/Proofs/FurstenbergCorrespondenceOQ01.lean
+++ b/proofs/Proofs/FurstenbergCorrespondenceOQ01.lean
@@ -768,29 +768,43 @@ theorem limit_invariant_on_cylinder
     (hdef : ∀ k, (μs k : Measure CantorSpace) = cesaroMeasure x (Ns k + 1))
     (S : Set CantorSpace) (hS : MeasurableSet S) (hSclopen : IsClopen S) :
     (μ : Measure CantorSpace) (shift ⁻¹' S) = (μ : Measure CantorSpace) S := by
-  -- Proof structure (drafted session 5, BLOCKED on file-wide Mathlib API drift):
-  --
-  -- set ν := (μ : Measure CantorSpace)
-  -- set νs := fun k => ((μs k) : Measure CantorSpace)
-  -- Step 1 (ENNReal Portmanteau, both directions):
-  --   ProbabilityMeasure.tendsto_measure_of_null_frontier_of_tendsto' hconv
-  --     (frontier = ∅ since clopen, so measure of frontier = 0)
-  --   gives μ_k(S) → μ(S) and μ_k(shift⁻¹S) → μ(shift⁻¹S) in ℝ≥0∞.
-  -- Step 2 (error term → 0):
-  --   ENNReal.tendsto_nat_nhds_top.comp (Ns k + 1 → ∞) ⟹ (Ns k + 1 : ℝ≥0∞) → ⊤
-  --   then ENNReal.continuous_inv at ⊤ gives 0, so (Ns k + 1)⁻¹ → 0.
-  -- Step 3 (algebra at limit, both directions):
-  --   ENNReal.Tendsto.add htend_S herr_zero (Or.inl (measure_ne_top μ S))
-  --   gives μ_k S + (Ns k + 1)⁻¹ → ν S + 0 = ν S.
-  --   Then le_of_tendsto_of_tendsto' applied to:
-  --     hbound: νs k (shift⁻¹S) ≤ νs k S + (Ns k + 1)⁻¹  (cesaroMeasure_preimage_le)
-  --   gives ν (shift⁻¹S) ≤ ν S. Symmetric direction via cesaroMeasure_preimage_ge.
-  -- Step 4: le_antisymm.
-  --
-  -- Cannot fill in this proof until the surrounding file's 35 Mathlib API drift
-  -- errors are repaired (see research/problems/szemeredi-full-oq-01/knowledge.md
-  -- session 5). Adding ~60 unvalidated lines here would mask the real blocker.
-  sorry
+  -- Step 1 (ENNReal Portmanteau, both directions): clopen sets have empty
+  -- frontier, hence null frontier, so weak convergence gives convergence of
+  -- measures on S and on shift⁻¹' S.
+  have hS_frontier : (μ : Measure CantorSpace) (frontier S) = 0 := by
+    simp [hSclopen.frontier_eq]
+  have hshiftS_clopen : IsClopen (shift ⁻¹' S) := isClopen_shift_preimage hSclopen
+  have hshiftS_frontier : (μ : Measure CantorSpace) (frontier (shift ⁻¹' S)) = 0 := by
+    simp [hshiftS_clopen.frontier_eq]
+  have htend_S :=
+    ProbabilityMeasure.tendsto_measure_of_null_frontier_of_tendsto' hconv hS_frontier
+  have htend_shiftS :=
+    ProbabilityMeasure.tendsto_measure_of_null_frontier_of_tendsto' hconv hshiftS_frontier
+  -- Step 2 (error term → 0): (Ns k + 1 : ℝ≥0∞)⁻¹ → 0 since Ns k + 1 → ∞.
+  have hinv_tend : Filter.Tendsto (fun k => (↑(Ns k + 1) : ℝ≥0∞)⁻¹)
+      Filter.atTop (nhds 0) :=
+    ENNReal.tendsto_inv_nat_nhds_zero.comp ((Filter.tendsto_add_atTop_nat 1).comp hNs)
+  -- Step 3 (≤ direction): pass cesaroMeasure_preimage_le to the limit.
+  have hle : (μ : Measure CantorSpace) (shift ⁻¹' S) ≤ (μ : Measure CantorSpace) S := by
+    have hsum : Filter.Tendsto
+        (fun k => (μs k : Measure CantorSpace) S + (↑(Ns k + 1) : ℝ≥0∞)⁻¹)
+        Filter.atTop (nhds ((μ : Measure CantorSpace) S + 0)) := htend_S.add hinv_tend
+    rw [add_zero] at hsum
+    refine le_of_tendsto_of_tendsto' htend_shiftS hsum fun k => ?_
+    rw [hdef k]
+    exact cesaroMeasure_preimage_le x (Ns k) S hS
+  -- Step 3' (≥ direction): symmetric, via cesaroMeasure_preimage_ge.
+  have hge : (μ : Measure CantorSpace) S ≤ (μ : Measure CantorSpace) (shift ⁻¹' S) := by
+    have hsum : Filter.Tendsto
+        (fun k => (μs k : Measure CantorSpace) (shift ⁻¹' S) + (↑(Ns k + 1) : ℝ≥0∞)⁻¹)
+        Filter.atTop (nhds ((μ : Measure CantorSpace) (shift ⁻¹' S) + 0)) :=
+      htend_shiftS.add hinv_tend
+    rw [add_zero] at hsum
+    refine le_of_tendsto_of_tendsto' htend_S hsum fun k => ?_
+    rw [hdef k]
+    exact cesaroMeasure_preimage_ge x (Ns k) S hS
+  -- Step 4: antisymmetry.
+  exact le_antisymm hle hge
 
 end ShiftInvariance
 

--- a/proofs/Proofs/FurstenbergCorrespondenceOQ01.lean
+++ b/proofs/Proofs/FurstenbergCorrespondenceOQ01.lean
@@ -903,12 +903,13 @@ We now have all the components to prove the Furstenberg correspondence principle
 - `seqCompact_probabilityMeasure_cantor`: Prokhorov compactness (Part IX, axiom)
 - `density_preserved_at_limit`: μ(B₀) ≥ δ at limit (Part X, proved)
 - `cesaroMeasure_preimage_le/ge`: approximate T-invariance (Part VIII-b, proved)
+- `limit_invariant_on_cylinder`: exact T-invariance at the limit on clopen
+  sets (Part XII, proved 2026-07-23 — Portmanteau null-frontier + vanishing
+  1/(N+1) error + le_of_tendsto_of_tendsto')
 - `positive_measure_gives_ap`: positive measure → AP (Part XIII, proved)
 
-**Remaining sorry** (1):
-- `limit_shift_invariant_on_cylinder` → full T-invariance (Part XII)
-  Mathematically clear: telescoping + Portmanteau + π-λ theorem.
-  Requires assembling Portmanteau limit algebra in ENNReal.
+**Remaining sorries**: 0. The sole remaining assumption is the Prokhorov
+axiom `seqCompact_probabilityMeasure_cantor` (Part IX).
 
 **Architecture**: We construct the `Furstenberg.System` directly on Cantor space:
 - X = CantorSpace, T = shift, B = cylinderZero
@@ -945,14 +946,15 @@ We now have all the components to prove the Furstenberg correspondence principle
 | `cesaro_positive_implies_orbit_member` | ✅ Proved | 4 |
 | `positive_measure_gives_ap` | ✅ Proved | 4 |
 | `correspondenceSystem` (System constructor) | ✅ Defined | 4 |
-| `limit_shift_invariant_on_cylinder` | ❌ Sorry | 4 |
+| `limit_invariant_on_cylinder` | ✅ Proved | S13 (2026-07-23) |
 
 **Net result**: The `furstenberg_correspondence` axiom in FurstenbergCorrespondence.lean
 reduces to:
   1. `seqCompact_probabilityMeasure_cantor` (Prokhorov axiom, standard analysis)
-  2. One sorry for T-invariance limit algebra (ENNReal Portmanteau → Measure equality)
 
-Both are standard analysis facts, not deep mathematics.
+The T-invariance limit algebra (formerly a sorry) is now proved
+(`limit_invariant_on_cylinder`, Part XII). The Prokhorov axiom is a
+standard analysis fact, not deep mathematics.
 The combinatorial-dynamical bridge (Parts III-V, XIII) is fully proved.
 -/
 

--- a/research/problems/szemeredi-full-oq-01/knowledge.md
+++ b/research/problems/szemeredi-full-oq-01/knowledge.md
@@ -617,3 +617,26 @@ attempt the full file build. S11 did, and the gap was exposed.
   fine; the only real isolation blocker is local Lean tactic mode
   (e.g. tooling that follows the symlink directly). Future
   isolation-worktree researchers can attempt Docker builds.
+
+## S13 Session Notes (2026-07-23, researcher-2 — ACT, sorry 1→0)
+
+- Stale-blocker lesson (2nd occurrence this cycle): S12/S13 BLOCKED was based
+  on the v4.26 drift; migration epic #39062 repaired all 28 errors. Baseline
+  docker build FIRST, before honoring recorded blockers.
+- Banked-proof discipline paid off: the S9-audited 60-line draft compiled at
+  v4.31 with only minor simplification (no `convert … using 2` needed —
+  `rw [hdef k]` aligns `(μs k : Measure)` with `cesaroMeasure x (Ns k + 1)`
+  exactly; then `cesaroMeasure_preimage_le/ge` applies verbatim).
+- v4.31 API confirmations: `IsClopen.frontier_eq` (simp alias, Clopen.lean:38),
+  `ProbabilityMeasure.tendsto_measure_of_null_frontier_of_tendsto'`
+  (Portmanteau.lean:336), `ENNReal.tendsto_inv_nat_nhds_zero`
+  (ENNReal/Lemmas.lean:486), `Filter.tendsto_add_atTop_nat`,
+  `le_of_tendsto_of_tendsto'` — all unchanged from the S9 audit.
+- Error-term composition idiom: `ENNReal.tendsto_inv_nat_nhds_zero.comp
+  ((Filter.tendsto_add_atTop_nat 1).comp hNs)` gives
+  `(↑(Ns k + 1))⁻¹ → 0` definitionally — no `simpa [Function.comp]` needed.
+- Remaining: 1 axiom `seqCompact_probabilityMeasure_cantor` (Prokhorov).
+  S14 route: CantorSpace is a compact metrizable space, so
+  `ProbabilityMeasure` on it should be compact (Prokhorov/tightness or
+  direct via Riesz—check `Mathlib.MeasureTheory.Measure.Prokhorov` and
+  `instCompactSpaceProbabilityMeasure`-style instances at v4.31).

--- a/research/problems/szemeredi-full-oq-01/state.md
+++ b/research/problems/szemeredi-full-oq-01/state.md
@@ -1,5 +1,26 @@
 # Research State: szemeredi-full-oq-01
 
+> **S13b/S14-note (2026-07-23, researcher-2): S13 ACT EXECUTED — sorry 1→0,
+> BLOCKED state was STALE.** The S11 28-error build regression in
+> `FurstenbergCorrespondenceOQ01.lean` was repaired on main by the v4.31
+> toolchain migration epic (#39062, merged before 2026-07-23). Verified by
+> baseline docker build at HEAD (clean, only the L762 sorry warning), then
+> pasted the banked S9-audited `limit_invariant_on_cylinder` proof at L770
+> and re-built clean (0 errors, 0 sorry warnings). File now: **0 sorries,
+> 1 axiom** (`seqCompact_probabilityMeasure_cantor`, Prokhorov). Proof as
+> banked: `IsClopen.frontier_eq` null frontier → Portmanteau
+> `tendsto_measure_of_null_frontier_of_tendsto'` on S and shift⁻¹S;
+> `ENNReal.tendsto_inv_nat_nhds_zero` kills the 1/(N+1) error;
+> `le_of_tendsto_of_tendsto'` passes `cesaroMeasure_preimage_le/ge` to the
+> limit; `le_antisymm`. The draft's anticipated `convert … using 2`
+> reconciliation was unnecessary — `rw [hdef k]` matches exactly.
+> Gallery meta + annotations for `furstenberg-correspondence-oq-01`
+> updated (sorries 1→0, stale sorry-prose rewritten). Pool → in-progress /
+> ACT / iteration 14. **Next: S14 ACT — discharge the Prokhorov axiom**
+> (~150-200 lines; CantorSpace is compact metrizable so tightness is free;
+> check Mathlib v4.31 Prokhorov coverage), then assemble Furstenberg.System.
+
+
 > **S12 (2026-06-13, researcher-1): POOL STATUS → `blocked`.** The S11 build
 > regression in `FurstenbergCorrespondenceOQ01.lean` (28 hard Mathlib-API-drift
 > errors) is **unchanged at HEAD** — no repair commit since 2026-06-09, error

--- a/src/data/proofs/furstenberg-correspondence-oq-01/annotations.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-01/annotations.json
@@ -328,8 +328,8 @@
       "endLine": 781
     },
     "type": "concept",
-    "title": "Wrapping as ProbabilityMeasure and Exact Limit Invariance (1 sorry)",
-    "content": "Packages the Cesàro measures as `ProbabilityMeasure CantorSpace` (`cesaroProbabilityMeasure`) so Prokhorov and Portmanteau apply, and works toward exact T-invariance of the limit on cylinders (`limit_invariant_on_cylinder`). The latter is the file’s sole `sorry`: the intended proof combines the $O(1/N)$ approximate invariance with the ENNReal Portmanteau limit algebra and `le_antisymm`, but is deliberately left open pending repair of surrounding Mathlib-API drift — the author notes that filling ~60 unvalidated lines would mask the real blocker. The `sorry` is disclosed honestly rather than papered over.",
+    "title": "Wrapping as ProbabilityMeasure and Exact Limit Invariance (proved)",
+    "content": "Packages the Cesàro measures as `ProbabilityMeasure CantorSpace` (`cesaroProbabilityMeasure`) so Prokhorov and Portmanteau apply, and proves exact T-invariance of the limit on clopen sets (`limit_invariant_on_cylinder`) — formerly the file's sole `sorry`, filled 2026-07-23 once the surrounding Mathlib-API drift was repaired. The proof follows the long-banked plan: clopen sets have empty frontier (`IsClopen.frontier_eq`), so the null-frontier Portmanteau criterion (`ProbabilityMeasure.tendsto_measure_of_null_frontier_of_tendsto'`) upgrades weak-* convergence to convergence of measures on both S and shift⁻¹S; the approximate T-invariance bounds `cesaroMeasure_preimage_le/ge` hold at each stage with error 1/(N+1), which tends to 0 in ℝ≥0∞ (`ENNReal.tendsto_inv_nat_nhds_zero`); `le_of_tendsto_of_tendsto'` passes both one-sided bounds to the limit, and `le_antisymm` closes.",
     "significance": "supporting",
     "relatedConcepts": "Goal: $\\mu(T^{-1}S) = \\mu(S)$ for clopen $S$, obtained from $|\\mu_k(T^{-1}S)-\\mu_k(S)|\\le 1/N_k\\to 0$ plus Portmanteau convergence. Currently a disclosed `sorry`.",
     "mathContext": [
@@ -378,7 +378,7 @@
     },
     "type": "concept",
     "title": "Assembling the Correspondence and Honest Status",
-    "content": "The final assembly plan: build a `Furstenberg.System` on $(\\Omega, T, B_0)$ with $\\mu$ the weak-* limit of Cesàro measures, deriving T-invariance from the limit-invariance result and $\\mu(B_0)\\ge\\delta$ from density preservation. The progress summary is candid: the combinatorial–dynamical bridge (orbit-density, telescoping invariance, return property) is fully proved and axiom-free, and the whole correspondence reduces to just two standard analysis facts — the Prokhorov axiom and the one T-invariance `sorry` — neither of which is deep mathematics. This transparent accounting is the entry’s \"open question\" framing toward eliminating the correspondence axiom.",
+    "content": "The final assembly plan: build a `Furstenberg.System` on $(\\Omega, T, B_0)$ with $\\mu$ the weak-* limit of Cesàro measures, deriving T-invariance from the limit-invariance result and $\\mu(B_0)\\ge\\delta$ from density preservation. The combinatorial–dynamical bridge (orbit-density, telescoping invariance, return property) is fully proved and axiom-free, and with `limit_invariant_on_cylinder` now proved (2026-07-23) the whole correspondence reduces to a single standard analysis fact — the Prokhorov sequential-compactness axiom `seqCompact_probabilityMeasure_cantor` — which is not deep mathematics, just unassembled in Mathlib. This transparent accounting is the entry's open-question framing toward eliminating the correspondence axiom.",
     "significance": "supporting",
     "relatedConcepts": "Target: a measure-preserving system $(\\Omega, \\mu, T)$ with $\\mu(B_0)\\ge\\overline d(A)$, recovering multiple recurrence ⟹ Szemerédi. Remaining dependencies: Prokhorov (axiom) + one T-invariance sorry.",
     "mathContext": [

--- a/src/data/proofs/furstenberg-correspondence-oq-01/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "furstenberg-correspondence-oq-01",
   "title": "Shift Dynamics on Cantor Space: Toward the Furstenberg Correspondence",
   "slug": "furstenberg-correspondence-oq-01",
-  "description": "Builds the shift dynamical system on Cantor space {0,1}^ℕ — the infrastructure needed to formalize the Furstenberg correspondence principle. Proves the shift is continuous and measurable, cylinder sets are clopen and measurable, and the k-fold return property connecting dynamical intersections to combinatorial patterns. All theorems proved except shift-invariance of the limit measure (1 sorry: T-invariance of Cesàro limit on clopen sets). Also has 1 local axiom: sequential compactness of probability measures on Cantor space, pending full Prokhorov formalization in Mathlib.",
+  "description": "Builds the shift dynamical system on Cantor space {0,1}^ℕ — the infrastructure needed to formalize the Furstenberg correspondence principle. Proves the shift is continuous and measurable, cylinder sets are clopen and measurable, and the k-fold return property connecting dynamical intersections to combinatorial patterns. All theorems are now proved, including shift-invariance of the limit measure (limit_invariant_on_cylinder: T-invariance of the Cesàro limit on clopen sets, via the Portmanteau null-frontier criterion and the vanishing 1/(N+1) telescoping error). 1 local axiom remains: sequential compactness of probability measures on Cantor space, pending full Prokhorov formalization in Mathlib.",
   "meta": {
     "author": "Furstenberg (1977)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Furstenberg%27s_proof_of_the_infinitude_of_primes",
@@ -19,9 +19,9 @@
       "correspondence-principle"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 1,
-    "assumptions": "1 sorry: limit_shift_invariant_on_cylinder (T-invariance of Cesàro limit measure on clopen sets — mathematically clear via Portmanteau + telescoping, requires ENNReal limit algebra assembly). 1 local axiom: seqCompact_probabilityMeasure_cantor — every sequence of probability measures on Cantor space (ℕ → Bool) has a weak-* convergent subsequence (Prokhorov's theorem). Mathlib v4.26 has the ingredients but they are not yet assembled into this exact statement. All other theorems (shift continuity, cylinder sets, k-fold return property, orbit-density connection, Tychonoff compactness) are proved from Mathlib.",
+    "assumptions": "0 sorries (limit_invariant_on_cylinder proved 2026-07-23: clopen sets have empty frontier, so weak convergence gives measure convergence on S and shift⁻¹S by ProbabilityMeasure.tendsto_measure_of_null_frontier_of_tendsto'; the approximate T-invariance bounds cesaroMeasure_preimage_le/ge pass to the limit as the 1/(N+1) error vanishes; le_antisymm closes). 1 local axiom: seqCompact_probabilityMeasure_cantor — every sequence of probability measures on Cantor space (ℕ → Bool) has a weak-* convergent subsequence (Prokhorov's theorem). Mathlib v4.31 has the ingredients but they are not yet assembled into this exact statement. All other theorems (shift continuity, cylinder sets, k-fold return property, orbit-density connection, Tychonoff compactness) are proved from Mathlib.",
     "dateAdded": "2026-03-30",
     "mathlibDependencies": [
       {
@@ -248,7 +248,7 @@
     "path": "Proofs/FurstenbergCorrespondenceOQ01.lean",
     "lineCount": 945,
     "axiomCount": 1,
-    "sorries": 1,
+    "sorries": 0,
     "definitionCount": 9,
     "theoremCount": 32
   },
@@ -286,5 +286,5 @@
       "venue": "Princeton University Press"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }

--- a/src/data/research/problems/szemeredi-full-oq-01.json
+++ b/src/data/research/problems/szemeredi-full-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "szemeredi-full-oq-01",
   "title": "Szemerédi Theorem: Furstenberg Ergodic-Theoretic Proof Formalization",
   "phase": "BLOCKED",
-  "status": "blocked",
+  "status": "in-progress",
   "tier": "S",
   "path": "full",
   "problemStatement": {
@@ -16,14 +16,14 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "BLOCKED",
+    "phase": "ACT",
     "since": "2026-04-22T13:03:46.383Z",
-    "iteration": 12,
-    "focus": "S11 OBSERVE-BUILD-REGRESSION (researcher-5, this PR, 2026-06-09T17:55Z): Docker baseline build at HEAD 162265bae2c returns 'Build failed exit 1' at job 7743/7743 elaboration of Proofs.FurstenbergCorrespondenceOQ01. S10's 'ACT-ready' claim is falsified. Mathlib pin unchanged from S9/S10 (2df2f0150c v4.26.0); breakage is in the file itself. 28 hard errors + 45 warnings: 5 surface/parse cascade (expected token at L336/L434/L508/L532/L551), 12 type/instance synthesis (L101 IsClopen ctor, L139/L206/L211/L219/L220/L324/L431 etc., L669 Tendsto site), 9 tactic-level (L146/L153 split_ifs, L181/L222 unsolved goals, L214 ext, L246 function expected, L484 invalid notation, L485 omega, L507 calc), 1 Mathlib rename (L674 Filter.eventually_of_forall -> Filter.Eventually.of_forall), 1 cast (L329 mod_cast). S9's 5-lemma audit remains valid but was insufficient: lemma existence at proof-site does not imply file builds. Full inventory in sessions/2026-06-09-s11-observe-build-regression.md. S11 author did NOT attempt Lean edits; 60-line proof draft remains banked for S13 ACT (post-Mechanic repair). Docker symlink-blocker claim from S9/S10 is falsified: docker-build.sh works from isolation worktrees (recent #22680 'Docker-verified' PR + this S11 run both confirm). Real blocker is the file's own breakage.",
+    "iteration": 14,
+    "focus": "S13 ACT complete (2026-07-23): limit_invariant_on_cylinder PROVED (sorry 1->0). File builds clean at v4.31. Next: S14 ACT — discharge the Prokhorov axiom seqCompact_probabilityMeasure_cantor (~150-200 lines), then assemble the Furstenberg.System.",
     "blockers": [
-      "BUILD REGRESSION: Proofs.FurstenbergCorrespondenceOQ01 elaboration fails at HEAD 162265bae2c with 28 hard errors. Mechanic repair required before any Researcher ACT can proceed."
+      "RESOLVED (S13, 2026-07-23): the 28-error v4.26 build regression was repaired by the v4.31 toolchain migration (#39062); baseline and post-fill docker builds are clean."
     ],
-    "nextAction": "S13 BLOCKED-PROPAGATION (researcher-5, 2026-06-14): the S12 BLOCKED decision (state.md, researcher-1) was applied to the pool only and got reverted by a sync from this JSON, which still read status=in-progress/phase=OBSERVE — so claim-random kept re-serving the slug (6th+ landing on the same unrepaired surface) during the Docker blackout. Set status=blocked/phase=BLOCKED here so the block sticks across pool re-syncs, and re-set the pool. Build-regression confirmed unrepaired at HEAD: L674 still `Filter.eventually_of_forall` (renamed to Filter.Eventually.of_forall in v4.26.0), L101 IsClopen-ctor site present, no repair commit on FurstenbergCorrespondenceOQ01.lean since 2026-06-09, 3 sorries remain. This is Mechanic-domain Lean repair (28 hard errors), Docker-gated, NOT Researcher work — un-actionable under the blackout. Operator/Mechanic clears to available after repair. PRIOR S12 MECHANIC (Lean repair, isolation-worktree OK): (1) one-liner fixes first to test cascade collapse - L101 IsClopen ctor (likely needs IsClopen.mk or order swap) + L674 Filter.eventually_of_forall -> Filter.Eventually.of_forall rename; (2) re-build, watch 5 'expected token' parse cascades collapse; (3) address residual 12 instance synthesis failures one-by-one; (4) tactic-level (L146/L153 split_ifs - likely use simp only or by_cases; L214 ext - new lemma name; L485 omega - hypothesis context; L507 calc); (5) verify ./proofs/scripts/docker-build.sh Proofs.FurstenbergCorrespondenceOQ01 returns clean; (6) ship Mechanic PR. S13 ACT (Researcher, banked): once main HEAD compiles, paste 60-line limit_invariant_on_cylinder proof at L779 (S9-audited template in state.md S10 Next Action L178-219). Pool transition (advisory): BLOCKED until S12 ships; S11 author does not invoke the transition, recommends an operator do so.",
+    "nextAction": "S14 ACT: prove seqCompact_probabilityMeasure_cantor (sequential compactness of ProbabilityMeasure on CantorSpace) from Mathlib v4.31 Prokhorov/tightness ingredients (CantorSpace is compact metrizable, so every measure family is tight; check Mathlib.MeasureTheory.Measure.Prokhorov coverage). Then construct the Furstenberg.System and connect to FurstenbergCorrespondence.lean.",
     "attemptCounts": {
       "total": 9,
       "currentApproach": 1,
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "REGRESSION: S11 (2026-06-09) Docker baseline build at HEAD 162265bae2c FAILS with 28 hard errors in FurstenbergCorrespondenceOQ01.lean. Pin unchanged from S9/S10 (v4.26.0). S10's 'ACT-ready' narrative falsified. S9's 5-lemma audit remains valid but insufficient. Mechanic repair (S12) required before Researcher ACT (S13) can paste the banked 60-line limit_invariant_on_cylinder proof at L779.",
+    "progressSummary": "S13 ACT (2026-07-23, researcher-2): limit_invariant_on_cylinder PROVED — the banked S9-audited Portmanteau proof pasted and docker-verified at v4.31 (the S11 28-error regression was repaired by migration epic #39062; S12/S13 BLOCKED state was stale). FurstenbergCorrespondenceOQ01.lean now has 0 sorries, 1 axiom. The correspondence reduces entirely to the Prokhorov axiom seqCompact_probabilityMeasure_cantor — S14 target.",
     "builtItems": [
       "finsetDirac_apply: sum of Dirac measures on measurable set = filter cardinality (OQ01.lean:316)",
       "cesaroMeasure: N-step Cesaro probability measure definition (OQ01.lean:334)",
@@ -41,7 +41,8 @@
       "density_lower_bound: elementary half of Furstenberg correspondence, no compactness needed (OQ01.lean:404)",
       "seqCompact_probabilityMeasure_cantor: local axiom for Prokhorov sequential compactness (OQ01.lean:484)",
       "limit_invariant_on_cylinder: complete proof structure (~60 lines) replacing T-invariance sorry at FurstenbergCorrespondenceOQ01.lean:748 — uses ProbabilityMeasure.tendsto_measure_of_null_frontier_of_tendsto + ENNReal.Tendsto.add + telescoping bounds; not locally validated due to file-wide build blocker",
-      "PR #14878: 6 Mathlib API drift fixes in FurstenbergCorrespondenceOQ01.lean — restores buildability after 35-error cascade (Session 7, 2026-05-02)"
+      "PR #14878: 6 Mathlib API drift fixes in FurstenbergCorrespondenceOQ01.lean — restores buildability after 35-error cascade (Session 7, 2026-05-02)",
+      "limit_invariant_on_cylinder PROVED in Proofs/FurstenbergCorrespondenceOQ01.lean:762 (exact T-invariance of weak-* limit of Cesaro measures on clopen sets) — docker-verified 2026-07-23, sorry count 1->0"
     ],
     "insights": [
       "FurstenbergCorrespondence.lean already exists with szemeredi_k2_ergodic proved via Poincaré recurrence",
@@ -60,7 +61,10 @@
       "Session 6 (2026-04-27, ~5h after Session 5): no Mathlib pin upgrade, no commit to FurstenbergCorrespondenceOQ01.lean. Re-claim via depth-first selector wastes researcher cycles when blocker is unchanged.",
       "Action: pool entry marked status='blocked' (claim-problem.sh:292 excludes both completed and blocked from claim-random selection) so other researchers stop re-discovering the same blocker. Operator must explicitly clear status to 'available' after Mathlib upgrade session.",
       "Mathlib API drift root causes (6 fixes): isOpen_eq_of_isOpen_singleton removed → (isOpen_discrete s).preimage; Finite.instCompactSpace removed → inferInstance; shift_iterate proof wrong without generalizing k (ih too weak); ring_nf left unsolved goals → congr 1; omega; split failed on if-then-else after simp → split_ifs; all 4 cascade to ~35 errors",
-      "shift_iterate original proof had a mathematical bug: induction on n without generalizing k means ih only covers position k, but succ case needs position k+1; proof worked in older Lean by accident (comp_def simp behavior changed)"
+      "shift_iterate original proof had a mathematical bug: induction on n without generalizing k means ih only covers position k, but succ case needs position k+1; proof worked in older Lean by accident (comp_def simp behavior changed)",
+      "S13 (2026-07-23): The S11/S12 build-regression block was stale — the v4.31 migration epic (#39062) repaired all 28 errors; baseline docker build passes at HEAD. Re-verify recorded blockers before honoring them.",
+      "The banked S9-audited Portmanteau proof compiled essentially as drafted at v4.31: IsClopen.frontier_eq + ProbabilityMeasure.tendsto_measure_of_null_frontier_of_tendsto (prime) + ENNReal.tendsto_inv_nat_nhds_zero.comp (tendsto_add_atTop_nat 1).comp hNs + le_of_tendsto_of_tendsto (prime) + le_antisymm. The convert-using-2 steps anticipated in the draft were unnecessary — rw [hdef k] closes the bound gap exactly.",
+      "File status after S13: 0 sorries, 1 axiom (seqCompact_probabilityMeasure_cantor). The full Furstenberg correspondence now reduces to Prokhorov sequential compactness alone."
     ],
     "mathlibGaps": [
       "Prokhorov theorem: sequential compactness of ProbabilityMeasure on compact metrizable space (~150-200 lines to assemble from Mathlib v4.26 ingredients)",
@@ -108,5 +112,6 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediFullOQ02.lean"
     }
-  ]
+  ],
+  "lastUpdated": "2026-07-23"
 }


### PR DESCRIPTION
## Summary
Research session for `szemeredi-full-oq-01` (S13 ACT). The S12/S13 BLOCKED state was stale: the 28-error v4.26 build regression in `FurstenbergCorrespondenceOQ01.lean` was repaired by the v4.31 toolchain migration (#39062). Verified with a clean baseline docker build, then executed the long-banked S13 ACT step.

## Progress
- **`limit_invariant_on_cylinder` PROVED** (`proofs/Proofs/FurstenbergCorrespondenceOQ01.lean:762`, formerly the file's sole sorry): exact T-invariance of the weak-* limit of Cesàro measures on clopen sets. Proof follows the S9-audited banked plan:
  - clopen ⇒ empty frontier ⇒ null frontier (`IsClopen.frontier_eq`);
  - Portmanteau null-frontier criterion (`ProbabilityMeasure.tendsto_measure_of_null_frontier_of_tendsto'`) upgrades weak-* convergence to measure convergence on `S` and `shift ⁻¹' S`;
  - the 1/(N+1) Cesàro error vanishes (`ENNReal.tendsto_inv_nat_nhds_zero`);
  - `le_of_tendsto_of_tendsto'` passes the approximate T-invariance bounds (`cesaroMeasure_preimage_le/ge`) to the limit; `le_antisymm` closes.
- Gallery `furstenberg-correspondence-oq-01`: meta sorries 1→0, stale sorry-prose in description/assumptions/annotations rewritten; in-file status tables updated.
- Tracker: blocked → in-progress, phase ACT, iteration 14.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.FurstenbergCorrespondenceOQ01` — **clean** twice (post-fill and post-comment-edit; 8576 jobs, 0 errors, 0 "uses sorry" warnings, 2026-07-23).

## Findings
- The banked proof compiled essentially as drafted; the anticipated `convert … using 2` reconciliation was unnecessary (`rw [hdef k]` aligns the measure coercion with `cesaroMeasure x (Ns k + 1)` exactly).
- File status: **0 sorries, 1 axiom**. The full Furstenberg correspondence now reduces to Prokhorov sequential compactness alone (`seqCompact_probabilityMeasure_cantor`).

## Status
**Outcome**: progress (sorry 1→0; axiom count unchanged at 1)
**Next Steps**: S14 ACT — discharge the Prokhorov axiom from Mathlib v4.31 ingredients (CantorSpace is compact metrizable, so tightness is automatic), then assemble the `Furstenberg.System`.

🤖 Generated by researcher-2
