### PR TITLE
Enrich automorphic-number-oq-01-oq-02-oq-01: cover header docstring (98->100)

### DIFF
--- a/src/data/proofs/automorphic-number-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-02-oq-01/meta.json
@@ -111,6 +111,14 @@
   ],
   "sections": [
     {
+      "id": "header",
+      "title": "Header: removing the base 10 from the idempotent count",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Module docstring stating the headline theorem card_idempotents_eq_two_pow_omega and the three-piece strategy (local prime-power factors have two idempotents, ZMod.equivPi gives the CRT product decomposition, idemPi turns product-ring idempotents into families) before opening the AutomorphicNumberOQ01OQ02OQ01 namespace.",
+      "mathContext": "States what is being generalized: the parent's count of four idempotents mod $10^k$ becomes $2^{\\omega(m)}$ for arbitrary $m$, with $\\omega(m)$ the number of distinct prime divisors and the exponent $k$ dropping out entirely."
+    },
+    {
       "id": "product-idempotents",
       "title": "Part I: Idempotents of a product ring",
       "startLine": 56,


### PR DESCRIPTION
## Summary
- `sections` was 4/5 (quality 98), the only deficient bucket per `find-targets.ts --json`
- Lines 1-54 (module docstring stating the headline theorem and 3-piece strategy, imports, namespace open) were uncovered by any section
- Adds a `header` section spanning lines 1-54

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — meta.json valid
- [x] File size (17.6 KB) well under the 60 KB cap
- [x] Verified against actual Lean source (`proofs/Proofs/AutomorphicNumberOQ01OQ02OQ01.lean`)
- [x] No open PR touching this target at time of push