### PR TITLE
Enrich automorphic-number-oq-01-oq-03: cover header docstring (98->100)

### DIFF
--- a/src/data/proofs/automorphic-number-oq-01-oq-03/meta.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-03/meta.json
@@ -145,6 +145,14 @@
   ],
   "sections": [
     {
+      "id": "header",
+      "title": "Header: the tower structure left unexplained by counting and pairing",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Module docstring framing the gap between the sibling entries (counting the four idempotents of ZMod (10^k), pairing them as 0, 1, a, 1-a) and the tower question: why does each k-digit automorphic residue extend uniquely to a (k+1)-digit one. States the five results (map_idem, ker_red_nilpotent, red_injOn_idem, red_image_idem, unique_digit_extension) before opening the AutomorphicNumberOQ01OQ03 namespace.",
+      "mathContext": "Recasts the digit-by-digit growth of automorphic numbers ($5\\to25\\to625\\to\\dots$) as the statement that the reduction $\\mathrm{red}_k:\\mathbb{Z}/10^{k+1}\\to\\mathbb{Z}/10^k$ restricts to a bijection on idempotent sets — the finite shadow of Hensel lifting."
+    },
+    {
       "id": "reduction-hom",
       "title": "Part I: The digit-dropping reduction homomorphism",
       "startLine": 52,


### PR DESCRIPTION
## Summary
- `sections` was 4/5 (quality 98), the only deficient bucket per `find-targets.ts --json`
- Lines 1-51 (module docstring framing the tower question and listing the five results, namespace open) were uncovered by any section
- Adds a `header` section spanning lines 1-51

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — meta.json valid
- [x] File size (20.7 KB) well under the 60 KB cap
- [x] Verified against actual Lean source (`proofs/Proofs/AutomorphicNumberOQ01OQ03.lean`)
- [x] No open PR touching this target at time of push