### PR TITLE
Enrich ballot-problem-oq-03-oq-02-oq-01: split trailing section (98->100)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02-oq-01/meta.json
@@ -110,11 +110,18 @@
       "summary": "comp_matrix: H(W₁∘W₂)=H(W₁)·H(W₂) via Matrix.mul_apply + Fintype.sum_sigma + Fintype.sum_mul_sum (the distributive law over the intermediate layer). det_comp: det H(W₁∘W₂)=det H(W₁)·det H(W₂) via Matrix.det_mul (Cauchy–Binet). det_comp_comm: determinant-level commutativity of composition."
     },
     {
-      "id": "iterated-and-bridges",
-      "title": "Iterated Stack Law, Unweighted Specialisation, and Family-Sum Bridge",
+      "id": "iterated-stack-law",
+      "title": "Iterated Stack Law for a List of Layers",
       "startLine": 115,
+      "endLine": 130,
+      "summary": "det_comp_list: folding composition over a list Ws of weighted path systems with base layer W₀ gives det H(W₁∘⋯∘Wₙ∘W₀)=(∏ᵢ det H(Wᵢ))·det H(W₀), proved by List.foldr induction using det_comp at each cons step."
+    },
+    {
+      "id": "unweighted-and-bridge",
+      "title": "Unweighted Specialisation and the Family-Sum Bridge",
+      "startLine": 132,
       "endLine": 154,
-      "summary": "det_comp_list: the iterated product law det H(W₁∘⋯∘Wₙ∘W₀)=(∏ᵢ det H(Wᵢ))·det H(W₀) by List.foldr induction. comp_card_matrix: the unweighted (weight-1) entry counts length-two concatenated paths. det_comp_signed_family_sum: the composite determinant as a product of two signed family sums, bridging to the sibling's det_matrix_eq_signed_family_sum."
+      "summary": "comp_card_matrix: the unweighted (weight-1) entry counts length-two concatenated paths, H(W₁∘W₂) i j = #(Σ k, Path₁ i k × Path₂ k j). det_comp_signed_family_sum: the composite determinant as a product of two signed family sums, bridging to the sibling's det_matrix_eq_signed_family_sum."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- `sections` was 4/5 (quality 98), the only deficient bucket per `find-targets.ts --json`
- The trailing `iterated-and-bridges` section (lines 115-154) bundled three distinct theorems: `det_comp_list`, `comp_card_matrix`, `det_comp_signed_family_sum`
- Split at the real theorem boundary (line 132, between `det_comp_list` and `comp_card_matrix`) into `iterated-stack-law` and `unweighted-and-bridge`

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — meta.json valid
- [x] File size (18 KB) well under the 60 KB cap
- [x] Verified line ranges against actual Lean source (`proofs/Proofs/BallotProblemOQ03OQ02OQ01.lean`)
- [x] No open PR touching this target at time of push