### PR TITLE
Enrich banach-fixed-point-oq-01-oq-01: 5th keyInsight (98->100)

### DIFF
--- a/src/data/proofs/banach-fixed-point-oq-01-oq-01/meta.json
+++ b/src/data/proofs/banach-fixed-point-oq-01-oq-01/meta.json
@@ -59,7 +59,8 @@
       "**Existence is a fixed point; uniqueness is Grönwall.** The two halves of Cauchy–Lipschitz come from different machinery — the contraction mapping principle produces the solution, while Grönwall's inequality (a comparison estimate for the growth of the gap between two solutions) forces it to be the only one.",
       "**Autonomous is the clean case.** Writing the vector field as time-independent (v t := f) and the constraint set as univ collapses the general Mathlib uniqueness lemma to exactly the y' = f(y) statement, with all the time-dependence and domain bookkeeping discharged.",
       "**C¹ for existence, Lipschitz for uniqueness.** C¹ near x₀ is what Mathlib needs to manufacture the Picard–Lindelöf data automatically; global Lipschitz is the natural hypothesis for the Grönwall comparison. The combined theorem simply asks for both.",
-      "**The contraction lives inside Mathlib.** The Banach fixed-point step is carried out in Mathlib's FunSpace construction; this entry exposes the resulting existence/uniqueness facts in the form a user of the theorem actually wants."
+      "**The contraction lives inside Mathlib.** The Banach fixed-point step is carried out in Mathlib's FunSpace construction; this entry exposes the resulting existence/uniqueness facts in the form a user of the theorem actually wants.",
+      "**Nothing here is tied to finite dimensions.** `E` ranges over an arbitrary `NormedSpace ℝ E` (a Banach space once `CompleteSpace E` is added for existence), so the same three theorems cover ODEs on `ℝⁿ` and mild/semigroup-style equations on infinite-dimensional Banach spaces alike — the contraction argument never uses a basis or finite rank."
     ],
     "exampleSections": [
       {


### PR DESCRIPTION
## Summary
- `keyInsights` was 4/5 (quality 98), `sections` already at its cap of 5
- Added a 5th insight: the theorems are stated over an arbitrary `NormedSpace ℝ E` (Banach once `CompleteSpace E` is added), so existence/uniqueness cover infinite-dimensional (mild/semigroup-style) equations, not only finite-dimensional ODEs

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — meta.json valid
- [x] File size (15 KB) well under the 60 KB cap
- [x] Verified against actual hypotheses in `proofs/Proofs/PicardLindelofOQ01.lean` (`[NormedAddCommGroup E] [NormedSpace ℝ E]`, `[CompleteSpace E]` only for existence)
- [x] No open PR touching this target at time of push