### PR TITLE
audit(erdos-780): fix phantom tightness_construction axiom claim

### DIFF
--- a/src/data/proofs/erdos-780/annotations.json
+++ b/src/data/proofs/erdos-780/annotations.json
@@ -167,7 +167,7 @@
     },
     "type": "concept",
     "title": "Tightness Construction",
-    "content": "**`tightBound k r t`** $= kr - 1 + (t-1)(k-1)$: one less than the threshold.\n\n**`tightness_construction`** (axiom): For $n = n_0 - 1$, there exists a $t$-coloring with no monochromatic $k$-matching. The construction partitions $[n] = X_1 \\cup X_2 \\cup \\cdots \\cup X_t$ with $|X_1| = kr - 1$ and $|X_i| = k - 1$ for $i \\geq 2$, coloring each edge by its first non-empty intersection.",
+    "content": "**`tightBound k r t`** $= kr - 1 + (t-1)(k-1)$: one less than the threshold.\n\n**`tightness_construction`** (documented in source comments only, no Lean declaration): For $n = n_0 - 1$, there exists a $t$-coloring with no monochromatic $k$-matching. The construction partitions $[n] = X_1 \\cup X_2 \\cup \\cdots \\cup X_t$ with $|X_1| = kr - 1$ and $|X_i| = k - 1$ for $i \\geq 2$, coloring each edge by its first non-empty intersection.",
     "mathContext": "The tightness construction is the standard 'sunflower-avoiding' partition coloring. Each edge $e \\in \\binom{[n]}{r}$ receives color $i$ where $i$ is the smallest index with $e \\cap X_i \\neq \\emptyset$. Since $|X_1| = kr - 1$, any $k$ disjoint $r$-sets colored 1 would require $kr$ elements in $X_1$, a contradiction. For colors $i \\geq 2$, each $r$-set colored $i$ must contain an element of $X_i$, but $|X_i| = k-1$ limits the matching size to $k-1$.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-780/meta.json
+++ b/src/data/proofs/erdos-780/meta.json
@@ -55,7 +55,7 @@
       "chromaticNumber as proper noncomputable def (sInf of valid colorings)",
       "Threshold function: n₀ = kr + (t-1)(k-1)",
       "alon_frankl_lovasz_1986 main theorem (axiom) with kneser_hypergraph_chromatic_number equivalent",
-      "tightness_construction showing the bound is optimal",
+      "tightness of the bound documented in source comments (not a Lean declaration)",
       "kneser_conjecture axiom (k=2 special case, Lovász 1978)",
       "Four small cases proved from kneser_conjecture axiom: Petersen graph KG(5,2)=3, KG(7,3)=3, KG(2r,r)=2, KG(2r+1,r)=3",
       "erdos_ko_rado proved from ErdosKoRado.Star construction (was axiom)",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-780
**Problem**: `annotations.json` labeled `tightness_construction` as `(axiom)`, and `meta.json`'s `originalContributions` listed "tightness_construction showing the bound is optimal" as if it were a real Lean declaration. No such declaration exists in `Proofs/Erdos780Problem.lean` — Part 4 only documents the construction in a comment block; there is no `axiom`, `def`, or `theorem` named `tightness_construction`.

## Evidence

**meta.json claims** (originalContributions): `"tightness_construction showing the bound is optimal"`
**annotations.json claims**: `"**tightness_construction** (axiom): For n = n_0 - 1, there exists a t-coloring with no monochromatic k-matching. ..."`
**Lean file shows**: `grep -n tightness_construction proofs/Proofs/Erdos780Problem.lean` finds zero declarations — only a `/- ... -/` comment block in Part 4. The file's own `axiomCount: 2` (matching the two real axioms `alon_frankl_lovasz_1986` and `kneser_conjecture`) confirms no third axiom exists. Notably, `meta.json`'s own `sections` entry for the "tightness" section already discloses this correctly: "documents in source comments `tightness_construction` (no Lean declaration exists)" — so the fix brings `originalContributions` and `annotations.json` in line with what the file's own sections array already says.

## Fix Applied

- `meta.json`: reworded the originalContributions bullet to "tightness of the bound documented in source comments (not a Lean declaration)".
- `annotations.json`: reworded `(axiom)` to `(documented in source comments only, no Lean declaration)`.

No change to `status: "axiomatized"`, `badge: "axiom"`, or `axiomCount: 2` — those were already correct.

---
Discovered during gallery integrity audit.