### PR TITLE
Enrich banach-fixed-point-oq-01-oq-01-oq-02: 5th keyInsight (98->100)

### DIFF
--- a/src/data/proofs/banach-fixed-point-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/banach-fixed-point-oq-01-oq-01-oq-02/meta.json
@@ -78,7 +78,8 @@
       "**The iterates are an explicit polynomial, not a black-box limit.** picardIter n t = ∑_{k=0}^{n} tᵏ/k! makes every successive approximation a concrete Taylor partial sum, so the Picard–Lindelöf fixed point of the parent becomes a runnable, fully transparent computation.",
       "**Picard's method reconstructs both the solution and the exponential series.** Feeding the constant 1 through P repeatedly generates the exponential's power series term by term — the successive approximations literally build ∑ tᵏ/k!, exhibiting the solution as the limit of approximations and re-deriving exp along the way.",
       "**The contraction constant is the interval length.** The estimate |P y t − P z t| ≤ C·|t| shows P contracts on [0, ε] with constant ε; choosing ε < 1 gives a genuine contraction, the concrete instance of the abstract Lipschitz-forces-contraction mechanism used in the parent's Banach argument.",
-      "**Fixed point ⇒ solution.** exp is not merely the limit of the iterates but a genuine fixed point exp t = 1 + ∫₀ᵗ exp s ds solving the IVP, closing the loop between the integral fixed-point equation and the differential equation."
+      "**Fixed point ⇒ solution.** exp is not merely the limit of the iterates but a genuine fixed point exp t = 1 + ∫₀ᵗ exp s ds solving the IVP, closing the loop between the integral fixed-point equation and the differential equation.",
+      "**The proven contraction is only local, but the actual convergence is global.** picard_contraction only pins down P as a genuine contraction on a short interval [0, ε] with ε < 1, matching the parent's local existence guarantee; yet picardIter_tendsto proves picardIter n t → exp t for every real t, with no restriction on t at all — for this concrete f = id the successive approximations converge far beyond the range the abstract local theorem promises."
     ],
     "exampleSections": []
   },


### PR DESCRIPTION
## Summary
- `keyInsights` was 4/5 (quality 98), `sections` already at its cap (6 sections)
- Added a 5th insight: `picard_contraction` only proves a local contraction (interval [0, ε], ε < 1), but `picardIter_tendsto` proves convergence to `exp t` for every real `t` with no restriction — the concrete example converges far beyond the abstract theorem's local guarantee

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — meta.json valid
- [x] File size (16.5 KB) well under the 60 KB cap
- [x] Verified against actual theorem statements in `proofs/Proofs/PicardIterationExplicitOQ0102.lean` (`picard_contraction` vs `picardIter_tendsto`)
- [x] No open PR touching this target at time of push