### PR TITLE
audit(tracker): record erdos-567 issues-fixed audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14649,9 +14649,9 @@
     },
     "erdos-567": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:49Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T06:01:44Z",
+      "result": "issues-fixed"
     },
     "erdos-568": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Records erdos-567 re-serve audit result (issues-fixed) in audit-tracker.json. See #43097 for the underlying gallery integrity fix.