### PR TITLE
audit(erdos-44): fix phantom originalContributions credit + stale sorry notes

### DIFF
--- a/src/data/proofs/erdos-44/annotations.json
+++ b/src/data/proofs/erdos-44/annotations.json
@@ -101,7 +101,7 @@
     "type": "concept",
     "title": "Formal Upper Bound (2sqrt(N))",
     "content": "The formal statement: |A| <= 2*sqrt(N) for any Sidon A in [1,N]. This requires converting from the weaker sqrt(2N)+1 bound to the nicer 2sqrt(N) form.",
-    "mathContext": "The proof needs sqrt(2N)+1 <= 2sqrt(N) for N >= 3, which involves Real.sqrt inequalities. Currently has sorry.",
+    "mathContext": "The proof needs sqrt(2N)+1 <= 2sqrt(N) for N >= 3, which involves Real.sqrt inequalities. Fully proved (case split on N < 3 vs N >= 3); no sorry.",
     "significance": "key",
     "relatedConcepts": [
       "real analysis",
@@ -170,7 +170,7 @@
     "type": "concept",
     "title": "Main Conjecture (OPEN)",
     "content": "**Erdős Problem #44**: Given any Sidon set A in [1,N] and eps > 0, there exists M > N and B in [N+1,M] such that A U B is Sidon with size >= (1-eps)*sqrt(M). This conjecture remains OPEN.",
-    "mathContext": "Stated with sorry since it's an unsolved mathematical problem. No known counterexamples exist, but no proof either.",
+    "mathContext": "Stated as an axiom (erdos_44) since it's an unsolved mathematical problem. No known counterexamples exist, but no proof either.",
     "significance": "key",
     "relatedConcepts": [
       "extension problem",

--- a/src/data/proofs/erdos-44/meta.json
+++ b/src/data/proofs/erdos-44/meta.json
@@ -43,7 +43,7 @@
       "Verification that {1,2,4,8,13} is a Sidon set",
       "Upper bound: Sidon sets have at most 2sqrt(N) elements",
       "Infrastructure for proving powers of 2 form Sidon sets",
-      "Proof that isSidon_singleton holds"
+      "Lower bound: explicit modular-parabola Sidon set of size floor(sqrt(N))/2 (Erdos44SidonLowerBound.lean)"
     ],
     "axiomCount": 1,
     "lineCount": 353,


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-44
**Problem**: `originalContributions` credited erdos-44 with "Proof that isSidon_singleton holds" — but `isSidon_singleton` is declared in `Erdos340GreedySidon.lean` (already credited to `erdos-340-greedy-sidon`'s own `originalContributions`), not in any of erdos-44's three Lean files (`Erdos44Problem.lean`, `Erdos44Aristotle.lean`, `Erdos44SidonLowerBound.lean`), and is never referenced by them.

Also found two stale `annotations.json` `mathContext` notes claiming a theorem/axiom is "stated with sorry" when the file actually has 0 sorries: `maxSidonSubsetCard_icc_bound` is fully proved (verified — no `sorry` anywhere in the 3 Lean files), and the open conjecture `erdos_44` is stated as an `axiom`, not a `sorry`.

## Evidence

**meta.json claims**: `originalContributions` includes `"Proof that isSidon_singleton holds"`.
**Lean file shows**: `grep -rn isSidon_singleton proofs/Proofs/Erdos44*.lean` returns no hits; the only declaration is `Erdos340GreedySidon.lean:82`, already listed in `erdos-340-greedy-sidon/meta.json`'s own `originalContributions` ("isSidon_empty, isSidon_singleton, isSidon_pair: base cases").

**annotations.json claims**: `ann-e44-formal-bound` mathContext says "Currently has sorry"; `ann-e44-main` mathContext says "Stated with sorry".
**Lean file shows**: `grep -n sorry proofs/Proofs/Erdos44*.lean` returns 0 hits (`maxSidonSubsetCard_icc_bound` is a complete proof by case split on N; the open conjecture is `axiom erdos_44 ...`).

All other counts verified accurate: 353 lines, 8 theorems/lemmas, 1 axiom (`erdos_44`), 0 defs, 0 sorries — matches `meta.json`/`leanFile` exactly.

## Recommended Fix

- `meta.json`: replaced the phantom bullet with the file's actual, previously-uncredited contribution — the modular-parabola Sidon lower-bound construction in `Erdos44SidonLowerBound.lean` (`sidon_set_lower_bound_exists`, fully proved, no sorries).
- `annotations.json`: corrected both stale "sorry" mentions to reflect the current fully-proved/axiomatized state.

---
Discovered during gallery integrity audit (reserve-mode re-serve, erdos-44).