### PR TITLE
audit(tracker): record erdos-44 issues-fixed audit (#43104)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13632,9 +13632,9 @@
     },
     "erdos-44": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:50Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T06:08:40Z",
+      "result": "issues-fixed"
     },
     "erdos-440": {
       "agentId": "auditor-2026-05-01-session",


### PR DESCRIPTION
Records the erdos-44 audit cycle: found a phantom `originalContributions` credit (`isSidon_singleton`, actually declared/credited in `erdos-340-greedy-sidon`) plus two stale "sorry" mentions in `annotations.json`. Fixed in #43104 (merged).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>