### PR TITLE
audit(erdos-105-oq-05): fix stale "0 axioms" narrative vs axiomCount:2

### DIFF
--- a/src/data/proofs/erdos-105-oq-05/meta.json
+++ b/src/data/proofs/erdos-105-oq-05/meta.json
@@ -127,14 +127,14 @@
     {
       "id": "dimension-reduction",
       "title": "Dimension Reduction",
-      "summary": "Part VII. Counterexamples lift: counterexample_lifts states that if the higher-dim line conjecture fails in R^d (d≥2) it also fails in R^(d+1), since a counterexample embeds in higher dimensions. Closes with the file Summary block cataloguing the 4 theorems, 9 definitions, 0 axioms, 0 sorries.",
+      "summary": "Part VII. Counterexamples lift: counterexample_lifts states that if the higher-dim line conjecture fails in R^d (d≥2) it also fails in R^(d+1), since a counterexample embeds in higher dimensions. Closes with the file Summary block cataloguing the 4 theorems, 9 definitions, 0 own axioms, 0 sorries (2 axioms inherited via import from Erdos105Problem.lean).",
       "startLine": 176,
       "endLine": 206,
       "mathContext": "counterexample_lifts: embedding R^d into R^(d+1) preserves counterexample properties"
     }
   ],
   "conclusion": {
-    "summary": "This formalization establishes the geometric framework for studying the Erdos #105 phenomenon in higher dimensions. With 4 proved theorems, 0 axioms, and 0 sorries, it provides a clean foundation for future work on rich k-flat blocking in R^d.",
+    "summary": "This formalization establishes the geometric framework for studying the Erdos #105 phenomenon in higher dimensions. With 4 proved theorems, 0 own axioms, and 0 sorries (2 axioms inherited from Erdos105Problem.lean), it provides a clean foundation for future work on rich k-flat blocking in R^d.",
     "implications": "The key structural insight is that counterexamples lift to higher dimensions, so the R^2 disproof of Erdos-Purdy extends to all R^d. The open question is whether the positive Beck-Szemeredi-Trotter result also generalizes.",
     "openQuestions": [
       "Does the Beck-Szemeredi-Trotter positive result (cn obstacles insufficient) generalize to rich lines in R^d?",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-105-oq-05

**Problem**: `meta.json` was internally inconsistent about axiom count.
`meta.axiomCount` is `2` and the `assumptions` field correctly explains these
are 2 axioms (`xichuan_counterexample`, `beck_szemeredi_trotter_positive`)
transitively inherited via `import Proofs.Erdos105Problem` — the file itself
declares 0 axioms directly (`leanFile.axiomCount: 0`, confirmed by grep).
However, `conclusion.summary` and the `dimension-reduction` section summary
both stated "0 axioms" outright, contradicting `axiomCount` and the
`assumptions` field within the same file.

## Evidence

- `meta.axiomCount`: 2
- `assumptions`: "2 axioms inherited from Erdos105Problem.lean: ... 0 own axioms."
- `conclusion.summary` (before): "With 4 proved theorems, 0 axioms, and 0 sorries..."
- `sections[6].summary` (before): "...0 axioms, 0 sorries." (mirrors the Lean file's own internal docstring, which only counts axioms declared in this specific file)
- `proofs/Proofs/Erdos105OQ05.lean`: 0 `axiom` declarations (grep-confirmed), imports `Proofs.Erdos105Problem` which has 2 `axiom` declarations at lines 102 and 126

## Fix

Reworded `conclusion.summary` and the `dimension-reduction` section summary
to say "0 own axioms ... (2 axioms inherited from Erdos105Problem.lean)",
consistent with `axiomCount` and `assumptions`. No code change; narrative-only,
JSON-validated.

---
Discovered during gallery integrity audit.