### PR TITLE
audit(tracker): record erdos-105-oq-05 issues-fixed audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9365,10 +9365,10 @@
       "result": "clean"
     },
     "erdos-105-oq-05": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:50Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T06:17:48Z",
+      "result": "issues-fixed"
     },
     "erdos-1050": {
       "auditCount": 5,


### PR DESCRIPTION
Tracker update following #43110 (fixed stale "0 axioms" narrative
contradicting axiomCount:2 / assumptions in erdos-105-oq-05/meta.json).