### PR TITLE
Enrich catalan-numbers-oq-01-oq-04-oq-02: fix drifted section boundaries (98->100)

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-01-oq-04-oq-02/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-04-oq-02/meta.json
@@ -66,29 +66,36 @@
       "id": "overview-header",
       "title": "Overview: reciprocal log-concavity and an honest correction",
       "startLine": 1,
-      "endLine": 47,
-      "summary": "Module docstring framing the derived-sequence question, refuting the suggested candidate Cₙ/(n+1) (fails at n=1), and identifying the reciprocal 1/Cₙ as the correct strictly log-concave derived sequence obtained by reciprocating the parent's Turán inequality."
+      "endLine": 51,
+      "summary": "Module docstring framing the derived-sequence question, refuting the suggested candidate Cₙ/(n+1) (fails at n=1), and identifying the reciprocal 1/Cₙ as the correct strictly log-concave derived sequence obtained by reciprocating the parent's Turán inequality; followed by the namespace declaration and the `open Nat CatalanNumbersOQ01OQ04` that brings the parent's Turán inequality into scope."
     },
     {
       "id": "recip-principle",
       "title": "The reciprocation principle",
       "startLine": 53,
-      "endLine": 64,
-      "summary": "recip_sq_gt_of_sq_lt: in any LinearOrderedField, 0 < x,y,z and y² < x·z imply (1/x)(1/z) < (1/y)². Proved by rewriting (1/y)² = 1/y² (div_pow) and (1/x)(1/z) = 1/(x·z), then applying the order-reversal one_div_lt_one_div_of_lt."
+      "endLine": 67,
+      "summary": "recip_sq_gt_of_sq_lt: in any LinearOrderedField, 0 < x,y,z and y² < x·z imply (1/x)(1/z) < (1/y)². Proved by rewriting (1/y)² = 1/y² (div_pow) and (1/x)(1/z) = 1/(x·z) (field_simp), then applying the order-reversal one_div_lt_one_div_of_lt to the hypothesis y² < x·z."
     },
     {
       "id": "catalan-instance",
       "title": "Strict log-concavity of the reciprocal Catalan sequence",
-      "startLine": 66,
-      "endLine": 80,
+      "startLine": 69,
+      "endLine": 83,
       "summary": "catalan_recip_logConcave: (1/Cₙ)(1/Cₙ₊₂) < (1/Cₙ₊₁)² over ℚ for every n. Casts catalan_pos for positivity and the parent's catalan_turan for the Turán hypothesis, then applies the reciprocation principle."
     },
     {
       "id": "standard-indexing",
-      "title": "Standard indexing and the refuted candidate",
-      "startLine": 82,
-      "endLine": 108,
-      "summary": "catalan_recip_logConcave_shift restates the inequality as aₙ² > aₙ₋₁·aₙ₊₁ for n ≥ 1 (reindexing at n = m+1); catalanOverSucc_not_logConcave_at_one refutes the suggested candidate Cₙ/(n+1) by evaluating at n=1 (1/4 < 2/3 via norm_num)."
+      "title": "Reindexing to standard log-concavity form",
+      "startLine": 85,
+      "endLine": 99,
+      "summary": "catalan_recip_logConcave_shift restates the inequality as aₙ² > aₙ₋₁·aₙ₊₁ for n ≥ 1, reindexing catalan_recip_logConcave at n = m+1 via Nat.exists_eq_add_of_lt and Nat.add_sub_cancel."
+    },
+    {
+      "id": "refuted-candidate",
+      "title": "The suggested candidate Cₙ/(n+1) is not log-concave",
+      "startLine": 101,
+      "endLine": 112,
+      "summary": "catalanOverSucc_not_logConcave_at_one refutes the open question's suggested candidate Cₙ/(n+1) by evaluating at n=1: a₁² = 1/4 while a₀·a₂ = 2/3, so 1/4 < 2/3 (norm_num after unfolding catalan_zero/catalan_one/catalan_two)."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `catalan-numbers-oq-01-oq-04-oq-02` (quality 98 -> 100).

The only deficient bucket was `sections` (4/5, 8/10). The existing 4 sections had drifted from the actual Lean construct boundaries:
- Lines 48-52 (`namespace`/`open`) were uncovered by any section.
- `recip-principle` (53-64) and `catalan-instance` (66-80) overlapped/gapped around lines 65-67, both cutting off before their theorem's proof actually ended (67 and 83 respectively).
- `standard-indexing` (82-108) bundled two separate theorems (`catalan_recip_logConcave_shift` and `catalanOverSucc_not_logConcave_at_one`) into one block and stopped at 108, missing the final proof lines 109-112.

Re-anchored all four existing ranges against the current Lean source and split the bundled tail into two sections, one per theorem, for exactly 5 sections total:
1. `overview-header` (1-51): module docstring + namespace/open
2. `recip-principle` (53-67): `recip_sq_gt_of_sq_lt`
3. `catalan-instance` (69-83): `catalan_recip_logConcave`
4. `standard-indexing` (85-99): `catalan_recip_logConcave_shift`
5. `refuted-candidate` (101-112): `catalanOverSucc_not_logConcave_at_one`

No prose changes elsewhere; `meta.json` stays at 13 KB, well under the 60 KB cap. Verified against `find-targets.ts --json`: quality 98 -> 100 with `sections` now 10/10.