### PR TITLE
Enrich chebyshev-sum-inequality-oq-01-oq-03: fix drifted section boundaries (98->100)

### DIFF
--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-03/meta.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-03/meta.json
@@ -107,17 +107,24 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Overview: the continuous Chebyshev sum inequality",
+      "startLine": 1,
+      "endLine": 61,
+      "summary": "Module docstring: states the continuous analogue (∫f)(∫g) ≤ (b−a)∫fg of the parent's discrete Chebyshev inequality, contrasts it with the gallery's existing general comonotone entry (which needs global comonotonicity, boundedness, and measurability rather than a local MonotoneOn hypothesis), and outlines the symmetrised-double-integral / Fubini method and its Mathlib ingredients."
+    },
+    {
       "id": "sign-lemma",
       "title": "Pointwise sign of the symmetrised integrand",
-      "startLine": 53,
-      "endLine": 86,
-      "summary": "sub_mul_sub_nonneg_of_monotoneOn: for x, y ∈ Icc a b, 0 ≤ (f x − f y)(g x − g y), by case-splitting on x ≤ y vs y ≤ x — both factors are ≤ 0 in one case and ≥ 0 in the other. norm_le_of_monotoneOn bounds a monotone function on [a,b] by max|f a||f b|, used to make f·g integrable.",
+      "startLine": 63,
+      "endLine": 99,
+      "summary": "Opens MeasureTheory/Set, declares the ChebyshevIntegralMonotone namespace and the section variables a b f g. sub_mul_sub_nonneg_of_monotoneOn: for x, y ∈ Icc a b, 0 ≤ (f x − f y)(g x − g y), by case-splitting on x ≤ y vs y ≤ x — both factors are ≤ 0 in one case and ≥ 0 in the other. norm_le_of_monotoneOn bounds a monotone function on [a,b] by max|f a||f b|, used to make f·g integrable.",
       "mathContext": "$0 \\le (f(x)-f(y))(g(x)-g(y))$ when $f,g$ are monotone the same way."
     },
     {
       "id": "core-identity",
       "title": "The Fubini identity and the main inequality",
-      "startLine": 88,
+      "startLine": 101,
       "endLine": 171,
       "summary": "chebyshev_integral_monotoneOn_setIntegral. After the degenerate a=b case, sets μ = volume.restrict (Icc a b) (mass b−a), proves integrability of f, g, f·g and of the four product cross-terms, then shows ∫∫(f x−f y)(g x−g y) d(μ×μ) = 2(b−a)∫fg − 2(∫f)(∫g) via integral_prod_mul / integral_fun_fst / integral_fun_snd; nonnegativity of the integrand (transported to the square [a,b]² via Measure.prod_restrict) closes the theorem.",
       "mathContext": "$\\iint (f(x)-f(y))(g(x)-g(y)) = 2(b-a)\\!\\int\\! fg - 2\\big(\\!\\int\\! f\\big)\\big(\\!\\int\\! g\\big) \\ge 0$."


### PR DESCRIPTION
Enrichment pass for `chebyshev-sum-inequality-oq-01-oq-03` (quality 98 -> 100).

The only deficient bucket was `sections` (4/5, 8/10). The existing 4 sections had two problems:
- Lines 1-52 (the bulk of the module docstring) were uncovered by any section.
- `sign-lemma` (53-86) and `core-identity` (88-171) split in the middle of `norm_le_of_monotoneOn`'s proof body: the theorem's proof actually runs 85-99, but `sign-lemma` cut off at 86 and `core-identity` picked up two lines early at 88, both missing/misattributing lines 87-99 and starting `core-identity` 13 lines before its real theorem doc-comment at 101.

Re-anchored against the current Lean source and added a 5th section for the header:
1. `header` (1-61): module docstring
2. `sign-lemma` (63-99): opens/namespace/variable + `sub_mul_sub_nonneg_of_monotoneOn` + `norm_le_of_monotoneOn` (now includes the full proof body of both)
3. `core-identity` (101-171): `chebyshev_integral_monotoneOn_setIntegral` (re-anchored start, unchanged content otherwise)
4. `reverse` (173-184): unchanged, already correct
5. `interval-forms` (186-212): unchanged, already correct

No prose changes elsewhere; `meta.json` stays at 17 KB, well under the 60 KB cap. Verified against `find-targets.ts --json`: quality 98 -> 100 with `sections` now 10/10.