### PR TITLE
Research: erdos-1210 - restore clobbered [Er80] corrected axiom + metadata integrity (verified->axiomatized)

### DIFF
--- a/proofs/Proofs/Erdos1210Problem.lean
+++ b/proofs/Proofs/Erdos1210Problem.lean
@@ -3,27 +3,34 @@
 
 Source: https://erdosproblems.com/1210
 
-## Problem Statement
+## Problem Statement (corrected form, per [Er80])
 
 Let A ⊆ [1,n) be a set of integers such that gcd(a,b) = 1 for all distinct
 a,b ∈ A (pairwise coprime). Is it true that
 
-  ∑_{a ∈ A} 1/(n - a) ≤ ∑_{p prime, p < n} 1/(n - p)?
+  ∑_{a ∈ A} 1/(n - a) ≤ ∑_{p prime, p < n} 1/p + O(1)?
 
-In other words: among all pairwise coprime subsets of {1,...,n-1}, does the
-set of primes below n maximize the weighted harmonic sum ∑ 1/(n-a)?
+The RHS is the Mertens sum (~ log log n). Erdős noted in [Er80] that the
+statement in [Er77c] was "not quite correct"; the O(1) term is essential.
 
-## Status: OPEN
+## Status: OPEN (axiomatized), with two machine-checked side results
 
-This is an open conjecture of Erdős. The inequality asserts that primes are
-"optimal" for this particular density measure among pairwise coprime sets.
+1. **The literal transcription is FALSE.** The mis-transcribed form (RHS
+   ∑_{p<n} 1/(n-p), no O(1) term) is refuted by n = 5, A = {4}
+   (`not_Erdos1210Statement`). The corrected form is consistent with this
+   witness for any C ≥ 1/6 (`corrected_statement_consistent_at_five`).
+2. **Unconditional harmonic baseline.** For ANY A ⊆ [1,n) (coprimality not
+   needed), ∑_{a∈A} 1/(n-a) ≤ H_{n-1} ≤ 1 + log(n-1)
+   (`erdos_1210_trivial_upper_bound`). The conjectured strengthening to
+   log log n + O(1) is where coprimality must do work, via a sieve/Mertens
+   comparison unavailable in current Mathlib (no Mertens' second theorem).
 
 ## Key Observations
 
 1. Primes < n are pairwise coprime, so they form a valid candidate set A.
-2. The sum ∑_{p<n} 1/(n-p) is a finite positive quantity for n ≥ 3.
-3. Any pairwise coprime set A has at most one even element.
-4. The inequality is tight when A = {primes < n}.
+2. Any pairwise coprime set A has at most one even element.
+3. The map a ↦ n - a is injective on A with image in [1, n-1] — the source
+   of the unconditional harmonic bound.
 
 ## References
 
@@ -242,6 +249,90 @@ theorem not_Erdos1210Statement : ¬ Erdos1210Statement := by
   simp only [Nat.cast_ofNat] at hle
   rw [primesBelow_five_sum] at hle
   norm_num at hle
+
+/-
+## The Corrected Conjecture ([Er80]) — restored
+
+The section above refutes the *literal transcription*. The genuine Erdős
+conjecture (recovered from erdosproblems.com/1210 and Erdős's own correction
+note [Er80] in the 2026-06-13 S3 iteration, PR #22965) reads:
+
+> Let A ⊆ [1,n) be pairwise coprime. Is it true that
+>   ∑_{a∈A} 1/(n-a) ≤ ∑_{p<n} 1/p + O(1)?
+
+Two corrections vs. the transcription refuted above:
+1. the RHS is the Mertens sum ∑_{p<n} **1/p** (~ log log n), not ∑ 1/(n-p);
+2. there is an additive **O(1)** term — the n = 5 counterexample above imposes
+   only C ≥ 1/6 and does not contradict this form.
+
+This section was first landed in PR #22965 (2026-06-13) and was accidentally
+reverted on 2026-06-30 when the stale sibling PR #22935 (branched before
+#22965 merged) overwrote the file with its older refutation-only version.
+Restored 2026-07-24 (S5 iteration) alongside the new unconditional bound
+below. The axiom `erdos_1210` is the honest formalization of the open
+conjecture; it is consistent with the refutation above (see
+`corrected_statement_consistent_at_five`).
+-/
+
+/-- The corrected right-hand side: the sum of prime reciprocals ∑_{p<n} 1/p
+    (the Mertens sum ~ log log n). NOTE: this is 1/p, **not** 1/(n-p). -/
+noncomputable def primeReciprocalSum (n : ℕ) : ℝ :=
+  ∑ p ∈ primesBelow n, (1 : ℝ) / (p : ℝ)
+
+/-- Each prime reciprocal 1/p is nonneg, so the prime-reciprocal sum is nonneg. -/
+theorem primeReciprocalSum_nonneg (n : ℕ) : 0 ≤ primeReciprocalSum n := by
+  unfold primeReciprocalSum
+  apply Finset.sum_nonneg
+  intro p _
+  positivity
+
+/-- The prime-reciprocal sum is positive for n ≥ 3 (it contains the term 1/2). -/
+theorem primeReciprocalSum_pos {n : ℕ} (hn : 3 ≤ n) : 0 < primeReciprocalSum n := by
+  unfold primeReciprocalSum
+  refine Finset.sum_pos ?_ (primesBelow_nonempty hn)
+  intro p hp
+  simp only [primesBelow, Finset.mem_filter, Finset.mem_range] at hp
+  exact div_pos one_pos (by exact_mod_cast hp.2.pos)
+
+/-- **Erdős Problem 1210 (Open, corrected form per [Er80])**. There is an
+    absolute constant C such that for every n ≥ 3 and every pairwise coprime
+    A ⊆ {1,…,n-1},
+
+      ∑_{a ∈ A} 1/(n-a) ≤ ∑_{p prime, p < n} 1/p + C.
+
+    Equivalently, the weighted harmonic sum over any pairwise coprime set is
+    bounded by the Mertens sum (~ log log n) up to an additive constant. -/
+axiom erdos_1210 :
+    ∃ C : ℝ, ∀ (n : ℕ), 3 ≤ n → ∀ (A : Finset ℕ),
+      ValidSubset n A → PairwiseCoprime A →
+      ∑ a ∈ A, (1 : ℝ) / ((n : ℝ) - a) ≤ primeReciprocalSum n + C
+
+/-- The corrected right-hand side at n = 5 equals 5/6 (= 1/2 + 1/3). -/
+theorem primeReciprocalSum_five : primeReciprocalSum 5 = 5 / 6 := by
+  unfold primeReciprocalSum
+  rw [primesBelow_five]
+  rw [show ({2, 3} : Finset ℕ) = insert 2 {3} from rfl,
+      Finset.sum_insert (by decide), Finset.sum_singleton]
+  norm_num
+
+/-- **The naive (C = 0) corrected statement still fails at n = 5, A = {4}**:
+    the A-sum (= 1) strictly exceeds the prime-reciprocal sum (= 5/6). This is
+    why the additive O(1) constant is essential in the conjecture. -/
+theorem naive_statement_fails_at_five :
+    primeReciprocalSum 5 < ∑ a ∈ ({4} : Finset ℕ), (1 : ℝ) / ((5 : ℝ) - a) := by
+  rw [primeReciprocalSum_five, Finset.sum_singleton]
+  push_cast
+  norm_num
+
+/-- **The corrected (O(1)) statement is consistent at n = 5, A = {4}**: for any
+    constant C ≥ 1/6, the A-sum is bounded by the prime-reciprocal sum plus C.
+    The n = 5 counterexample therefore imposes only the lower bound C ≥ 1/6 —
+    no contradiction with the corrected conjecture. -/
+theorem corrected_statement_consistent_at_five (C : ℝ) (hC : 1 / 6 ≤ C) :
+    ∑ a ∈ ({4} : Finset ℕ), (1 : ℝ) / ((5 : ℝ) - a) ≤ primeReciprocalSum 5 + C := by
+  rw [primeReciprocalSum_five, Finset.sum_singleton]
+  push_cast
+  linarith
 
 /-
 ## S5: Unconditional Harmonic Upper Bound (verified, axiom-free)

--- a/research/problems/erdos-1210/sessions/2026-07-24-s5-harmonic-bound-and-clobber-repair.md
+++ b/research/problems/erdos-1210/sessions/2026-07-24-s5-harmonic-bound-and-clobber-repair.md
@@ -1,0 +1,77 @@
+# Session 2026-07-24 — S5 ACT: harmonic baseline + stale-PR clobber repair
+
+**Researcher**: researcher-3
+**Phase**: BLOCKED → ACT (S5 COMPLETE)
+**Files**: `proofs/Proofs/Erdos1210Problem.lean` (244 → 392 lines),
+`src/data/proofs/erdos-1210/meta.json`, registry JSON, this state sync.
+
+## 1. Unblock
+
+The 2026-06-13 BLOCKED flag cited the Docker/Aristotle blackout. Docker is
+restored (verified: two clean builds this session), so the S4-designated
+regime-(1) ACT was shipped.
+
+## 2. Regression discovered: the S3 corrected axiom was clobbered
+
+Triage found `state.md` describing S3/S4 content (corrected O(1) axiom,
+`primeReciprocalSum`, meta `axiomatized`) that was **absent from main**.
+Git forensics:
+
+| Date | PR | Event |
+|------|----|-------|
+| 06-12 | #22935 branched | refutation-only version of the file |
+| 06-13 | **#22965 MERGED** | S3: corrected [Er80] statement, `axiom erdos_1210`, meta → axiomatized |
+| 06-30 | **#22935 MERGED (stale)** | silently overwrote the file + meta back to the pre-S3 refutation-only version |
+
+This is precisely the claim-expiry/stale-PR failure mode the researcher role
+warns about. Both versions were individually sound, so no audit tripped: main
+simply lost the recovered form of the actual Erdős conjecture for 3+ weeks
+while meta read `verified`/`mathlib`.
+
+**Repair (append-only, annotation-friendly)**: restored `primeReciprocalSum`
+(+ nonneg/pos), `axiom erdos_1210` (corrected ∃C form),
+`primeReciprocalSum_five`, `naive_statement_fails_at_five`,
+`corrected_statement_consistent_at_five` — appended after the existing 244
+lines so the recently re-anchored (#40128) section structure survives with a
+deterministic shift; meta.json sections re-anchored accordingly, plus 2 new
+sections. Dropped only `erdos_1210_uniform_bound` (a verbatim restatement of
+the axiom). Also corrected the header docstring, which still presented the
+refuted mis-transcription as "the problem".
+
+Also noted: S4's STATE-SYNC claims about the registry (iter 4 / BLOCKED) were
+not reflected on main either (registry sat at iteration 2 / ACT). Synced now.
+
+## 3. S5 deliverable (new mathematics, axiom-free)
+
+* `sum_reciprocal_le_harmonic` — for ANY `A ⊆ [1,n)` (coprimality NOT
+  needed): `∑_{a∈A} 1/(n-a) ≤ H_{n-1}`.
+  Proof: `a ↦ n - a` is injective on `A` (omega, using `1 ≤ a < n`), image
+  inside `Icc 1 (n-1)`; reindex with `Finset.sum_image`, cast with
+  `Nat.cast_sub`, compare with `Finset.sum_le_sum_of_subset_of_nonneg`
+  (+ `positivity`); identify the RHS with Mathlib's `harmonic (n-1)` via
+  `harmonic_eq_sum_Icc` + `Rat.cast_*`.
+* `erdos_1210_trivial_upper_bound` — under the conjecture's full hypotheses:
+  `∑_{a∈A} 1/(n-a) ≤ 1 + log(n-1)`, by chaining `harmonic_le_one_add_log`.
+  The coprimality hypothesis is displayed but unused (`_hcop`) — documented
+  honestly in-file: the `log n → log log n` gap is exactly where it must
+  work, and that needs Mertens' second theorem (absent from Mathlib).
+
+Both Docker-verified (2 builds, both clean first try; 3351 jobs).
+
+## Counts
+
+```
+Erdos1210Problem.lean: 244 → 392 lines, 14 → 21 theorems, 4 → 5 defs,
+0 → 1 axiom (erdos_1210, the open conjecture), 0 sorries
+meta.json: status verified → axiomatized, badge mathlib → axiom,
+axiomCount 0 → 1, assumptions populated, 6 → 8 sections (re-anchored)
+```
+
+The status flip is *mandatory* per the Axiom Integrity Policy: the entry now
+carries a genuine open-conjecture axiom. The previous `verified` state was an
+artifact of the clobber, not a deliberate demotion.
+
+## Next
+
+Long-horizon only: Mertens' second theorem in Mathlib. The elementary
+(coprimality-free) vein is exhausted — `H_{n-1}` is the best such bound.

--- a/research/problems/erdos-1210/state.md
+++ b/research/problems/erdos-1210/state.md
@@ -1,5 +1,48 @@
 # Current State
 
+**Phase**: ACT (S5 COMPLETE — unblocked; harmonic baseline proved + clobbered S3 axiom restored, Docker-verified on Lean v4.31.0)
+**Since**: 2026-07-24 (researcher-3)
+**Iteration**: 5
+
+## S5 ACT + regression repair (researcher-3, 2026-07-24)
+
+**Two deliverables in one iteration:**
+
+1. **Stale-PR clobber discovered and repaired.** The S3 rewrite (#22965,
+   merged 2026-06-13: `primeReciprocalSum` + corrected [Er80] O(1) axiom) was
+   **accidentally reverted on 2026-06-30** when the stale sibling PR #22935
+   (branched 06-12, before S3 merged) landed its older refutation-only version
+   of the file. Until today `main` had NO corrected-form axiom, and meta.json
+   read `verified`/`mathlib`/0 axioms — out of sync with this state file's
+   S3/S4 description. Restored **append-only** (annotation anchors for the
+   first 244 lines preserved modulo a +2 import / header shift, sections
+   re-anchored in meta.json): `primeReciprocalSum`, nonneg/pos, `axiom
+   erdos_1210` (corrected O(1) form), `primeReciprocalSum_five`,
+   `naive_statement_fails_at_five`, `corrected_statement_consistent_at_five`.
+   (Dropped only the trivial restatement `erdos_1210_uniform_bound`.)
+   NOTE: S4's STATE-SYNC claim that the registry was moved to iter-4/BLOCKED
+   was also not on main — the registry sat at iteration 2. Both synced now.
+
+2. **S5 regime-(1) baseline shipped** (the planned build-gated ACT; Docker
+   restored): `sum_reciprocal_le_harmonic` — for ANY `A ⊆ [1,n)`,
+   `∑_{a∈A} 1/(n-a) ≤ H_{n-1}` via the injective reindex `a ↦ n-a` into
+   `Icc 1 (n-1)` (`Finset.sum_image` + `Nat.cast_sub`), then
+   `erdos_1210_trivial_upper_bound`: `≤ 1 + log(n-1)` via Mathlib's
+   `harmonic_le_one_add_log`. Axiom-free; coprimality displayed but unused
+   (documented honestly — that's where the `log → log log` gap lives).
+
+**File**: 244 → 392 lines, 14 → 21 theorems, 4 → 5 defs, 0 → 1 axiom
+(the open conjecture), 0 sorries. **meta.json**: status `verified` →
+`axiomatized`, badge `mathlib` → `axiom`, axiomCount 1, `assumptions`
+populated, sections re-anchored + 2 new sections.
+
+**Remaining blocker (unchanged)**: the conjectured `log log n` RHS asymptotic
+needs Mertens' second theorem, absent from Mathlib — long-horizon.
+
+---
+
+# Prior State (2026-06-13, superseded)
+
 **Phase**: BLOCKED (next ACT is build-gated; conjecture is Mathlib-gap-blocked)
 **Since**: 2026-06-13T15:00:00Z
 **Iteration**: 4

--- a/src/data/proofs/erdos-1210/meta.json
+++ b/src/data/proofs/erdos-1210/meta.json
@@ -2,11 +2,11 @@
   "id": "erdos-1210",
   "title": "Pairwise Coprime Subset Sum Inequality",
   "slug": "erdos-1210",
-  "description": "Let A ⊆ {1,...,n-1} be pairwise coprime. Is ∑_{a∈A} 1/(n-a) ≤ ∑_{p prime, p<n} 1/(n-p)? Erdős conjectured the primes maximize this weighted harmonic sum. The literal transcription is FALSE: this entry proves a machine-checked counterexample at n=5, A={4} (1 > 5/6) and refutes the literal statement (not_Erdos1210Statement). The correctly-stated Erdős problem (with the intended, unrecovered hypotheses on A) remains open.",
+  "description": "Let A ⊆ {1,...,n-1} be pairwise coprime. Erdős asked ([Er77c], corrected in [Er80]) whether ∑_{a∈A} 1/(n-a) ≤ ∑_{p<n} 1/p + O(1), the RHS being the Mertens sum ~ log log n. This entry (i) refutes the literal mis-transcription (RHS ∑ 1/(n-p), no O(1)) via a machine-checked counterexample at n=5, A={4} (not_Erdos1210Statement); (ii) axiomatizes the corrected O(1)-form conjecture (axiom erdos_1210), machine-checking that the counterexample imposes only C ≥ 1/6; and (iii) proves the unconditional harmonic baseline ∑_{a∈A} 1/(n-a) ≤ H_{n-1} ≤ 1 + log(n-1) for ANY A ⊆ [1,n) — the log n → log log n gap is exactly where coprimality must do work, blocked on Mertens' second theorem in Mathlib.",
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1210",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1210Problem.lean",
     "tags": [
       "erdos",
@@ -16,13 +16,13 @@
       "harmonic-sums",
       "extremal-combinatorics"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1210,
     "erdosUrl": "https://erdosproblems.com/1210",
     "erdosProblemStatus": "open",
-    "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries: fully machine-checked. The literal Erdős-1210 transcription (Erdos1210Statement, a plain def — NOT assumed) is disproven by the verified theorem not_Erdos1210Statement, via the counterexample n=5, A={4} (A-sum 1 > prime-sum 5/6). A prior revision unsoundly declared this statement as an axiom; that has been removed. The correctly-stated Erdős problem remains open.",
+    "axiomCount": 1,
+    "assumptions": "Erdős #1210, corrected form per [Er80] (axiom erdos_1210): there is an absolute constant C such that for all n ≥ 3 and every pairwise coprime A ⊆ [1,n), ∑_{a∈A} 1/(n-a) ≤ ∑_{p<n} 1/p + C. Open conjecture; the Mertens-sum RHS (~ log log n) is not yet expressible asymptotically in Mathlib (no Mertens' second theorem). All other results in the entry are axiom-free: the refutation of the literal transcription and the unconditional harmonic baseline ∑ 1/(n-a) ≤ 1 + log(n-1).",
     "lineCount": 244,
     "mathlib_version": "4.31.0",
     "theoremCount": 14,
@@ -50,58 +50,75 @@
       "id": "preamble",
       "title": "Problem Statement and Module Header",
       "startLine": 1,
-      "endLine": 49,
+      "endLine": 58,
       "summary": "Module docstring states Erdős Problem #1210: does the prime set maximize ∑ 1/(n-a) among all pairwise coprime A ⊆ [1,n)? Lists key observations: primes are pairwise coprime, the prime sum is positive for n≥3, coprime sets have ≤1 even element, and the bound is tight at A = {primes}. References Er77c and Er80.",
       "mathContext": "$\\sum_{a \\in A} \\frac{1}{n-a} \\le \\sum_{p < n,\\, p \\text{ prime}} \\frac{1}{n-p}$ for all pairwise coprime $A \\subseteq [1,n)$."
     },
     {
       "id": "definitions",
       "title": "Core Definitions",
-      "startLine": 50,
-      "endLine": 64,
+      "startLine": 59,
+      "endLine": 69,
       "summary": "Defines primesBelow, PairwiseCoprime, ValidSubset.",
       "mathContext": "$\\text{primesBelow}(n) = \\{p < n : p \\text{ prime}\\}$. $\\text{PairwiseCoprime}(A)$: $\\gcd(a,b)=1$ for distinct $a,b\\in A$."
     },
     {
       "id": "prime-properties",
       "title": "Properties of Primes and Coprimality",
-      "startLine": 66,
-      "endLine": 102,
+      "startLine": 70,
+      "endLine": 108,
       "summary": "Proves primes are pairwise coprime, primesBelow is valid and nonempty for n≥3, and pairwise coprime sets have ≤1 even element.",
       "mathContext": "Distinct primes are coprime. $|\\text{primesBelow}(n)| \\geq 1$ for $n \\geq 3$ (since $2 \\in \\text{primesBelow}(n)$). $|\\{a \\in A : 2 \\mid a\\}| \\leq 1$ for pairwise coprime $A$."
     },
     {
       "id": "sum-bounds",
       "title": "Sum Bounds",
-      "startLine": 104,
-      "endLine": 130,
+      "startLine": 109,
+      "endLine": 131,
       "summary": "Proves the prime sum is nonneg and strictly positive.",
       "mathContext": "$0 < \\sum_{p \\in \\text{primesBelow}(n)} \\frac{1}{n-p}$ for $n \\geq 3$."
     },
     {
       "id": "conjecture",
       "title": "Literal Conjecture (Packaged, Not Assumed) and Consequences",
-      "startLine": 131,
-      "endLine": 162,
+      "startLine": 132,
+      "endLine": 172,
       "summary": "Packages the literal Erdős-1210 inequality as a proposition (Erdos1210Statement) — deliberately a def, NOT an axiom, since it is false and assuming it would make the development inconsistent. Records two genuine consequences that hold unconditionally: the empty-set bound (erdos_1210_empty) and the prime-singleton bound (erdos_1210_prime_singleton, {p} ≤ full prime sum via sum_le_sum_of_subset_of_nonneg).",
       "mathContext": "$\\sum_{a\\in A} \\frac{1}{n-a} \\leq \\sum_{p \\in \\text{primesBelow}(n)} \\frac{1}{n-p}$ for all pairwise coprime $A \\subseteq [1,n)$."
     },
     {
       "id": "counterexample",
       "title": "Counterexample: The Literal Statement Is False (n = 5, A = {4})",
-      "startLine": 164,
-      "endLine": 244,
+      "startLine": 173,
+      "endLine": 252,
       "summary": "Machine-checks the concrete refutation. Computes primesBelow 5 = {2,3} (primesBelow_five, decide) and its weighted sum 5/6 (primesBelow_five_sum); verifies {4} satisfies ValidSubset 5 and PairwiseCoprime (singleton_four_valid_at_five); shows the A-sum 1/(5−4) = 1 strictly exceeds 5/6 (erdos_1210_literal_counterexample); and concludes ¬ Erdos1210Statement (not_Erdos1210Statement). A prior revision unsoundly declared the statement as an axiom, which combined with this counterexample derives False — the docstring records the fix.",
       "mathContext": "At $n=5,\\ A=\\{4\\}$: $\\sum_{a\\in A}\\frac{1}{5-a} = 1 > \\tfrac{5}{6} = \\frac{1}{3}+\\frac{1}{2} = \\sum_{p<5,\\,p\\text{ prime}}\\frac{1}{5-p}$, so the literal inequality fails."
+    },
+    {
+      "id": "corrected-conjecture-restored",
+      "title": "The Corrected Conjecture ([Er80]) — Restored Axiomatization",
+      "startLine": 253,
+      "endLine": 336,
+      "summary": "Restores the S3 (PR #22965) recovery of the genuine Erdős statement, accidentally clobbered on 2026-06-30 by the stale sibling PR #22935: the corrected RHS primeReciprocalSum n = ∑_{p<n} 1/p (Mertens sum), its positivity, the open conjecture as axiom erdos_1210 (∃ C, ∀ n ≥ 3, ∀ pairwise-coprime valid A, ∑ 1/(n-a) ≤ primeReciprocalSum n + C), and the machine-checked consistency analysis at n = 5: the naive C = 0 form still fails (naive_statement_fails_at_five), while any C ≥ 1/6 absorbs the gap (corrected_statement_consistent_at_five).",
+      "mathContext": "Erdős noted in [Er80] that the [Er77c] statement was 'not quite correct'. The corrected inequality bounds the weighted harmonic sum by the Mertens sum ∑_{p<n} 1/p ~ log log n plus an absolute constant. The O(1) term is essential: the same n = 5, A = {4} witness that kills the literal transcription shows C = 0 is impossible, but imposes only C ≥ 1/6 on the corrected form."
+    },
+    {
+      "id": "s5-unconditional-harmonic-bound",
+      "title": "S5: Unconditional Harmonic Upper Bound (axiom-free)",
+      "startLine": 337,
+      "endLine": 392,
+      "summary": "The trivial baseline instantiating the conjecture's shape with f(n) = H_{n-1}: for ANY A ⊆ [1,n) — no coprimality needed — the values {n-a} are distinct integers in [1, n-1], so ∑_{a∈A} 1/(n-a) ≤ H_{n-1} (sum_reciprocal_le_harmonic, via an injective reindex a ↦ n-a and Mathlib's harmonic_eq_sum_Icc), hence ≤ 1 + log(n-1) (erdos_1210_trivial_upper_bound, via harmonic_le_one_add_log). Fully proved, no axioms.",
+      "mathContext": "The bound log n is exponentially weaker than the conjectured log log n + O(1): closing that gap is precisely where pairwise coprimality (at most one element per prime) must enter, via a sieve/Mertens comparison. Mathlib currently lacks Mertens' second theorem, so even stating the asymptotic RHS is out of reach — the axiom erdos_1210 quantifies it with an explicit existential constant instead."
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem 1210. The literal transcription is REFUTED by a machine-checked counterexample (n=5, A={4}); 14 theorems proved, 0 axioms, 0 sorries. The correctly-stated Erdős problem (with the intended, unrecovered hypotheses on A) remains open.",
+    "summary": "The formalization captures Erdős Problem 1210 in its corrected [Er80] form. The literal transcription is REFUTED by a machine-checked counterexample (n=5, A={4}); the corrected O(1)-form conjecture is axiomatized (1 axiom, shown consistent with the counterexample for C ≥ 1/6); and the unconditional harmonic baseline ∑ 1/(n-a) ≤ 1 + log(n-1) is fully proved. 21 theorems, 1 axiom (the open conjecture), 0 sorries.",
     "implications": "Resolution would advance our understanding of extremal properties of pairwise coprime sets and connect to Mertens' theorem and related prime counting results.",
     "openQuestions": [
-      "Is ∑_{a∈A} 1/(n-a) ≤ ∑_{p<n} 1/(n-p) for all pairwise coprime A?",
-      "What is the growth rate of ∑_{p<n} 1/(n-p) as n → ∞?",
-      "Do other 'optimal' pairwise coprime sets exist for related sums?"
+      "Is ∑_{a∈A} 1/(n-a) ≤ ∑_{p<n} 1/p + O(1) for all pairwise coprime A ⊆ [1,n) (the corrected [Er80] form, axiom erdos_1210)?",
+      "Can the unconditional H_{n-1} ~ log n baseline be improved toward log log n using pairwise coprimality, short of the full conjecture?",
+      "What is the optimal constant C in the corrected inequality (the n=5 witness forces C ≥ 1/6)?",
+      "Formalize Mertens' second theorem in Mathlib so the RHS asymptotic log log n + O(1) becomes expressible."
     ]
   },
   "leanFile": {
@@ -109,8 +126,10 @@
       "Mathlib.Data.Nat.Prime.Basic",
       "Mathlib.Data.Nat.GCD.Basic",
       "Mathlib.Data.Finset.Basic",
-      "Mathlib.Algebra.BigOperators.Group.Finset",
+      "Mathlib.Algebra.BigOperators.Group.Finset.Basic",
       "Mathlib.Data.Real.Basic",
+      "Mathlib.NumberTheory.Harmonic.Defs",
+      "Mathlib.NumberTheory.Harmonic.Bounds",
       "Mathlib.Tactic"
     ],
     "opens": [
@@ -118,10 +137,10 @@
       "BigOperators"
     ],
     "namespace": "Erdos1210",
-    "lineCount": 244,
-    "axiomCount": 0,
-    "theoremCount": 14,
-    "definitionCount": 4,
+    "lineCount": 392,
+    "axiomCount": 1,
+    "theoremCount": 21,
+    "definitionCount": 5,
     "path": "Proofs/Erdos1210Problem.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/erdos-1210.json
+++ b/src/data/research/problems/erdos-1210.json
@@ -17,11 +17,11 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-06-12",
-    "iteration": 2,
-    "focus": "SOUNDNESS FIX (researcher-2, 2026-06-12): the file declared `axiom erdos_1210` (the conjectured inequality) AND proved `erdos_1210_literal_counterexample` (n=5, A={4}: A-sum 1 > prime-sum 5/6) — i.e. the axiom was provably false, making the development inconsistent (axiom + counterexample ⊢ False). Demoted the axiom to a non-asserting `def Erdos1210Statement : Prop`, ADDED the verified refutation `theorem not_Erdos1210Statement : ¬ Erdos1210Statement` (via the counterexample, with Nat.cast_ofNat + primesBelow_five_sum normalization), and removed the two consequence theorems that relied on the false axiom (erdos_1210_bound, erdos_1210_singleton_bounded). Kept genuine results (prime properties, erdos_1210_empty, erdos_1210_prime_singleton — fixed its unused `hn`->`_hn`). Docker green: 0 errors/warnings/sorries/AXIOMS. File 246->244 LOC, 14 theorems + 4 defs. meta.json: status axiomatized->verified, badge axiom->verified, axiomCount 1->0, and misleading prose (proofStrategy, the false 'via the axiom' keyInsight, conclusion) corrected.",
+    "since": "2026-07-24",
+    "iteration": 5,
+    "focus": "S5 COMPLETE (researcher-3, 2026-07-24): (1) discovered+repaired a stale-PR clobber — the S3 corrected [Er80] O(1) axiomatization (#22965, merged 06-13) had been silently reverted on 06-30 by the stale sibling #22935; restored append-only (primeReciprocalSum, axiom erdos_1210, n=5 consistency theorems). (2) Shipped the S5 regime-(1) unconditional baseline: sum_reciprocal_le_harmonic (∑ 1/(n-a) ≤ H_{n-1}, injective reindex) and erdos_1210_trivial_upper_bound (≤ 1 + log(n-1), via harmonic_le_one_add_log). File 244→392 lines, 14→21 thm, 4→5 def, 0→1 axiom (the open conjecture), 0 sorries. meta.json flipped verified/mathlib → axiomatized/axiom with assumptions populated. Docker-verified (Lean v4.31.0). Remaining: log log n RHS needs Mertens' second theorem (Mathlib gap).",
     "blockers": [],
-    "nextAction": "Recover the INTENDED Erdős-1210 hypotheses from the primary sources [Er77c, Er80] (the transcribed form is false; likely missing a constraint such as A ⊆ (n/2, n) or a > √n, or a different weight like 1/a). Once recovered, state the corrected proposition and prove or disprove it. Until then the slug is sound and fully verified (refutes the literal form).",
+    "nextAction": "Long-horizon only: formalize Mertens' second theorem in Mathlib (or await it) to state the asymptotic RHS; meanwhile the elementary vein is exhausted (harmonic baseline is the best coprimality-free bound).",
     "attemptCounts": {
       "total": 2,
       "currentApproach": 2,
@@ -84,10 +84,10 @@
     {
       "path": "Proofs/Erdos1210Problem.lean",
       "filename": "Erdos1210Problem.lean",
-      "lineCount": 245,
-      "theoremCount": 14,
-      "axiomCount": 0,
-      "defCount": 4,
+      "lineCount": 392,
+      "theoremCount": 21,
+      "axiomCount": 1,
+      "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1210Problem.lean"


### PR DESCRIPTION
## Summary

Completes the erdos-1210 S5 iteration. The first half of this work (the S5 unconditional harmonic bound, commit d8a850179e) was swept into #43107 by the deployer's fast merge mid-session; this PR carries the remaining two commits.

### 1. Stale-PR regression repaired (restored [Er80] corrected axiomatization)

Git forensics this session found that PR #22965 (S3, merged 2026-06-13: corrected Erdos statement per [Er80] with `primeReciprocalSum` and the O(1)-form `axiom erdos_1210`) was **silently clobbered on 2026-06-30** when the stale sibling PR #22935 (branched 06-12, before S3 merged) landed its older refutation-only version of the file. Main then carried `verified`/`mathlib`/0-axiom metadata for an entry about an open conjecture, and the recovered form of the actual conjecture was lost for 3+ weeks.

Restored **append-only** (the recently re-anchored annotation structure for the original lines survives with a deterministic shift; meta.json sections re-anchored): `primeReciprocalSum` + nonneg/pos, `axiom erdos_1210` (corrected existential-constant form), `primeReciprocalSum_five`, `naive_statement_fails_at_five` (C = 0 still fails), `corrected_statement_consistent_at_five` (any C >= 1/6 absorbs the n = 5 gap). Header docstring updated - it still presented the refuted mis-transcription as "the problem".

### 2. Metadata integrity (Axiom Integrity Policy)

meta.json: status `verified` -> `axiomatized`, badge `mathlib` -> `axiom`, axiomCount 0 -> 1, `assumptions` populated, leanFile counts synced (244 -> 392 lines, 14 -> 21 theorems, 4 -> 5 defs, 0 sorries), sections re-anchored + 2 new sections. Research registry + state.md synced (both had drifted; state.md described S3/S4 content absent from main).

### 3. S5 baseline (already on main via #43107, documented here)

`sum_reciprocal_le_harmonic`: for ANY `A ⊆ [1,n)`, `∑ 1/(n-a) <= H_{n-1}` (injective reindex `a ↦ n-a`); `erdos_1210_trivial_upper_bound`: `<= 1 + log(n-1)` via Mathlib's `harmonic_le_one_add_log`. Axiom-free; coprimality displayed but unused - the `log n -> log log n` gap is where it must work, blocked on Mertens' second theorem (absent from Mathlib).

## Verification

Docker build (Lean v4.31.0, pinned Mathlib): `Built Proofs.Erdos1210Problem` clean, 3351 jobs, no warnings in the file, two consecutive green builds (post-S5 and post-restoration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
