### PR TITLE
Audit tracker: erdos-1007-oq-05 issues-found (#43115)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8631,10 +8631,10 @@
       "issues": []
     },
     "erdos-1007-oq-05": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:50Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T06:23:08Z",
+      "result": "issues-found"
     },
     "erdos-1007-oq-05-oq-01": {
       "auditCount": 1,


### PR DESCRIPTION
Records the audit result for erdos-1007-oq-05 (issues-found).

While auditing this proof I found that the root axiom `hasUnitEmbedding_exists`
in `Erdos1007Problem.lean` (parent entry erdos-1007) is inconsistent — it can
be used to derive `False` via a self-loop instantiation. Filed as #43115 for
the lean-mechanic to fix. erdos-1007-oq-05 itself already discloses and
partially corrects this in its own docstring, so no changes needed there.