### PR TITLE
Enrich gcd-algorithm-oq-05: split bundled partial-sums section (98->100)

### DIFF
--- a/src/data/proofs/gcd-algorithm-oq-05/meta.json
+++ b/src/data/proofs/gcd-algorithm-oq-05/meta.json
@@ -165,8 +165,15 @@
     {
       "id": "partial-sums",
       "title": "Closed Form of the Partial Sums",
-      "summary": "gaussKuzmin_partial (∑_{n<N} P(n) = G(0) − G(N)), G_zero (G(0) = 1), G_nonneg, and G_tendsto_zero (G(N) → 0 via (n+2)/(n+1) → 1 and continuity of log₂ at 1)",
+      "summary": "gaussKuzmin_partial: ∑_{n<N} P(n) = G(0) − G(N), obtained by telescoping gaussKuzmin_eq_sub across the range via Finset.sum_range_sub'.",
       "startLine": 82,
+      "endLine": 87
+    },
+    {
+      "id": "G-asymptotics",
+      "title": "Properties of the Antiderivative G Needed for Convergence",
+      "summary": "G_zero (G(0) = log₂(2/1) = 1, anchoring the closed-form partial sum), G_nonneg (G(n) ≥ 0 since (n+2)/(n+1) ≥ 1), and G_tendsto_zero (G(n) → 0, via (n+2)/(n+1) → 1 and continuity of log₂ at 1) — the three facts about G that turn the closed-form partial sum G(0) − G(N) into a convergent, normalized series.",
+      "startLine": 89,
       "endLine": 121
     },
     {


### PR DESCRIPTION
Enrichment pass for `gcd-algorithm-oq-05` (quality 98 -> 100).

The only deficient bucket was `sections` (4/5, 8/10). The existing `partial-sums` section (82-121, 40 lines) bundled the closed-form partial-sum theorem `gaussKuzmin_partial` (82-87) together with three separate lemmas about the antiderivative `G` (`G_zero`, `G_nonneg`, `G_tendsto_zero`, 89-121) that exist purely to support the later convergence proof.

Split at the natural boundary between the closed-form statement and the supporting `G` lemmas:
1. `header-and-defs` (1-60): unchanged, already correct
2. `positivity-and-telescoping` (61-81): unchanged, already correct
3. `partial-sums` (82-87): `gaussKuzmin_partial` only
4. `G-asymptotics` (89-121): `G_zero`, `G_nonneg`, `G_tendsto_zero` — the properties of `G` needed for convergence
5. `normalization` (122-167): unchanged, already correct

No prose changes elsewhere; `meta.json` stays at 17 KB, well under the 60 KB cap. Verified against `find-targets.ts --json`: quality 98 -> 100 with `sections` now 10/10.