### PR TITLE
audit(tracker): record chinese-remainder-non-coprime-oq-01-oq-02 clean audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31905,6 +31905,12 @@
       "lastAudited": "2026-07-23T18:37:51Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "chinese-remainder-non-coprime-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-24T06:29:28Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Summary
- Audited `chinese-remainder-non-coprime-oq-01-oq-02` (the full k-modulus Garner algorithm, merged fresh via #43121) — last unaudited entry in the gallery.
- Verified meta.json claims against `proofs/Proofs/ChineseRemainderNonCoprimeOQ01OQ02.lean`: 0 sorries, 0 axioms, 33 theorems, 11 definitions, 515 lines, no `native_decide` — all counts match exactly.
- Cross-references (`chinese-remainder-non-coprime-oq-01`, `-oq-01-oq-01`, `chinese-remainder-non-coprime`, `chinese-remainder-constructive`) all resolve to existing gallery entries.
- Result: **clean**.

## Test plan
- [x] `npx tsx scripts/auditor/find-targets.ts --stats` reflects the completed audit