### PR TITLE
Research: sperner-simplicial-instance-oq-01 - S3 ACT: LatticePoint m + TriCell m + Fintype instance (unblock, docker-verified)

### DIFF
--- a/proofs/Proofs/SpernerSimplicialInstanceOQ01.lean
+++ b/proofs/Proofs/SpernerSimplicialInstanceOQ01.lean
@@ -143,4 +143,112 @@ theorem standardTriangle2_sperner
       CellComplex.IsPanchromatic c standardTriangle2.toCellComplex s :=
   Triangulation.sperner standardTriangle2 c hbdry
 
+/-!
+## Candidate C data layer: `LatticePoint m` and `TriCell m` (S3 ACT)
+
+The general-`m` construction (S3 ACT, per PREPs #18625/#18654/#18719):
+the vertex carrier `LatticePoint m` (lattice points of Δ² at resolution
+`m`) and the cell type `TriCell m` (`T(m)` up-triangles + `T(m-1)`
+down-triangles = `m²` cells), with `DecidableEq` and `Fintype` instances —
+the data prerequisites for the eventual
+`Triangulation (LatticePoint m) 2` instance. The vertex map (`triVtx`,
+S4), the adjacency table, and the four `Triangulation` axioms are the
+S4+ continuation; they are the genuine open core of OQ-01 (the
+`decide`-based discharge used by `standardTriangle2` above cannot work
+`m`-parametrically).
+-/
+
+section Triangle
+
+/-- A lattice point in the size-`m` standard 2-simplex Δ²: `(i, j)` with
+`i + j ≤ m`. Carried by `Fin (m+1) × Fin (m+1)` so `DecidableEq` and
+`Fintype` synthesize for free (`Subtype.instDecidableEq`,
+`Subtype.fintype`); the subtype predicate `p.1 + p.2 ≤ m` is the only
+load-bearing constraint. `#(LatticePoint m) = (m+1)(m+2)/2`. -/
+abbrev LatticePoint (m : ℕ) : Type :=
+  {p : Fin (m + 1) × Fin (m + 1) // p.1.val + p.2.val ≤ m}
+
+/-- A cell in the standard subdivision of Δ² at resolution `m`.
+
+`up i j h` is the up-triangle with lower-left corner `(i, j)`; its
+vertices are `(i, j)`, `(i+1, j)`, `(i, j+1)`. Requires `i + j < m`.
+
+`down i j h` is the down-triangle with hypotenuse on `x + y = i + j + 1`;
+its vertices are `(i+1, j)`, `(i, j+1)`, `(i+1, j+1)`. Requires
+`i + j + 1 < m`.
+
+Cardinality: `T(m)` up-cells + `T(m-1)` down-cells = `m²` total. -/
+inductive TriCell (m : ℕ) : Type
+  | up (i j : ℕ) (h : i + j < m) : TriCell m
+  | down (i j : ℕ) (h : i + j + 1 < m) : TriCell m
+  deriving DecidableEq
+
+namespace TriCell
+
+/-- `TriCell m` is a `Fintype`: up-cells and down-cells are enumerated
+from `Fin m × Fin m` via `Finset.filterMap` (the strict bounds
+`i + j < m` and `i + j + 1 < m` each force `i < m` and `j < m`, so the
+square carrier covers all cells). -/
+instance instFintype (m : ℕ) : Fintype (TriCell m) where
+  elems :=
+    (Finset.univ : Finset (Fin m × Fin m)).filterMap
+      (fun ij =>
+        if h : (ij.1 : ℕ) + (ij.2 : ℕ) < m then
+          some (TriCell.up ij.1.val ij.2.val h)
+        else none)
+      (by
+        rintro ⟨i, j⟩ ⟨i', j'⟩ b hb hb'
+        simp only [Option.mem_def] at hb hb'
+        by_cases hij : (i : ℕ) + (j : ℕ) < m
+        · rw [dif_pos hij] at hb
+          by_cases hij' : (i' : ℕ) + (j' : ℕ) < m
+          · rw [dif_pos hij'] at hb'
+            rw [Option.some.injEq] at hb hb'
+            obtain rfl := hb
+            injection hb'.symm with hi hj
+            ext
+            · exact Fin.val_injective hi
+            · exact Fin.val_injective hj
+          · rw [dif_neg hij'] at hb'
+            exact (Option.noConfusion hb').elim
+        · rw [dif_neg hij] at hb
+          exact (Option.noConfusion hb).elim)
+    ∪
+    (Finset.univ : Finset (Fin m × Fin m)).filterMap
+      (fun ij =>
+        if h : (ij.1 : ℕ) + (ij.2 : ℕ) + 1 < m then
+          some (TriCell.down ij.1.val ij.2.val h)
+        else none)
+      (by
+        rintro ⟨i, j⟩ ⟨i', j'⟩ b hb hb'
+        simp only [Option.mem_def] at hb hb'
+        by_cases hij : (i : ℕ) + (j : ℕ) + 1 < m
+        · rw [dif_pos hij] at hb
+          by_cases hij' : (i' : ℕ) + (j' : ℕ) + 1 < m
+          · rw [dif_pos hij'] at hb'
+            rw [Option.some.injEq] at hb hb'
+            obtain rfl := hb
+            injection hb'.symm with hi hj
+            ext
+            · exact Fin.val_injective hi
+            · exact Fin.val_injective hj
+          · rw [dif_neg hij'] at hb'
+            exact (Option.noConfusion hb').elim
+        · rw [dif_neg hij] at hb
+          exact (Option.noConfusion hb).elim)
+  complete := fun c => by
+    rcases c with ⟨i, j, h⟩ | ⟨i, j, h⟩
+    · apply Finset.mem_union_left
+      apply Finset.mem_filterMap.mpr
+      refine ⟨(⟨i, by omega⟩, ⟨j, by omega⟩), Finset.mem_univ _, ?_⟩
+      simp [h]
+    · apply Finset.mem_union_right
+      apply Finset.mem_filterMap.mpr
+      refine ⟨(⟨i, by omega⟩, ⟨j, by omega⟩), Finset.mem_univ _, ?_⟩
+      simp [h]
+
+end TriCell
+
+end Triangle
+
 end Triangulation

--- a/proofs/Proofs/SpernerSimplicialInstanceOQ01.lean
+++ b/proofs/Proofs/SpernerSimplicialInstanceOQ01.lean
@@ -206,13 +206,13 @@ instance instFintype (m : ℕ) : Fintype (TriCell m) where
             rw [Option.some.injEq] at hb hb'
             obtain rfl := hb
             injection hb'.symm with hi hj
-            ext
-            · exact Fin.val_injective hi
-            · exact Fin.val_injective hj
+            obtain rfl : i = i' := Fin.val_injective hi
+            obtain rfl : j = j' := Fin.val_injective hj
+            rfl
           · rw [dif_neg hij'] at hb'
-            exact (Option.noConfusion hb').elim
+            cases hb'
         · rw [dif_neg hij] at hb
-          exact (Option.noConfusion hb).elim)
+          cases hb)
     ∪
     (Finset.univ : Finset (Fin m × Fin m)).filterMap
       (fun ij =>
@@ -229,21 +229,21 @@ instance instFintype (m : ℕ) : Fintype (TriCell m) where
             rw [Option.some.injEq] at hb hb'
             obtain rfl := hb
             injection hb'.symm with hi hj
-            ext
-            · exact Fin.val_injective hi
-            · exact Fin.val_injective hj
+            obtain rfl : i = i' := Fin.val_injective hi
+            obtain rfl : j = j' := Fin.val_injective hj
+            rfl
           · rw [dif_neg hij'] at hb'
-            exact (Option.noConfusion hb').elim
+            cases hb'
         · rw [dif_neg hij] at hb
-          exact (Option.noConfusion hb).elim)
+          cases hb)
   complete := fun c => by
     rcases c with ⟨i, j, h⟩ | ⟨i, j, h⟩
     · apply Finset.mem_union_left
-      apply Finset.mem_filterMap.mpr
+      rw [Finset.mem_filterMap]
       refine ⟨(⟨i, by omega⟩, ⟨j, by omega⟩), Finset.mem_univ _, ?_⟩
       simp [h]
     · apply Finset.mem_union_right
-      apply Finset.mem_filterMap.mpr
+      rw [Finset.mem_filterMap]
       refine ⟨(⟨i, by omega⟩, ⟨j, by omega⟩), Finset.mem_univ _, ?_⟩
       simp [h]
 

--- a/research/problems/sperner-simplicial-instance-oq-01/state.md
+++ b/research/problems/sperner-simplicial-instance-oq-01/state.md
@@ -1,11 +1,53 @@
 # Research State: sperner-simplicial-instance-oq-01
 
 ## Current State
-**Phase**: BLOCKED (S2 ACT complete; S3 ACT Docker-gated — see S6 below; S7 propagated BLOCKED to JSON gate)
+**Phase**: ACT (S3 ACT complete — Candidate C data layer shipped + Docker-verified; S4 ACT next)
 **Path**: full
 **Since**: 2026-05-13T05:18:00Z
-**Last Updated**: 2026-06-14 (Session 7 / S7 BLOCKED-propagation researcher-5)
-**Iteration**: 3
+**Last Updated**: 2026-07-24 (Session 8 / S3 ACT researcher-3)
+**Iteration**: 6
+
+## Session 8 — S3 ACT: `LatticePoint m` + `TriCell m` data layer (researcher-3, 2026-07-24)
+
+**Mode.** ACT (Lean + JSON gate unblock). Docker is restored, removing the
+S6/S7 blackout blocker; this session ships the fully-PREP'd S3 ACT.
+
+**Placement decision.** The S3 PREP (#18625) targeted the *shared parent*
+`SpernerSimplicialInstance.lean`; since then the slug acquired its own leaf
+file `SpernerSimplicialInstanceOQ01.lean` (S6, `standardTriangle2`), and the
+shared parent is actively touched by sibling slugs (oq-05's #22900). The S3
+ACT therefore lands in the **leaf file** (146 → 254 LOC) — same content,
+zero shared-file churn.
+
+**Shipped** (0 sorries, 0 axioms; Docker 1117 jobs clean, Lean v4.31.0):
+
+* `LatticePoint m` — subtype of `Fin (m+1) × Fin (m+1)` with `p.1 + p.2 ≤ m`
+  (per S3 PREP §3.1; `DecidableEq`/`Fintype` synthesize automatically).
+* `inductive TriCell m` — `up i j (h : i + j < m)` /
+  `down i j (h : i + j + 1 < m)`, `deriving DecidableEq` (§4.1/§4.3).
+* `instance Fintype (TriCell m)` — hand-rolled via two `Finset.filterMap`
+  enumerations from `Fin m × Fin m`, unioned (§4.4), with the S3b §4.3
+  `by_cases`/`dif_pos`/`dif_neg` injectivity discharges.
+
+**v4.31 drift vs the PREP/ERRATUM skeletons** (all host-probed via
+`lake env lean` before the Docker round-trip):
+
+1. `apply Finset.mem_filterMap.mpr` → **Unknown constant** in v4.31; use
+   `rw [Finset.mem_filterMap]` instead.
+2. `exact (Option.noConfusion h).elim` → universe unification failure; use
+   `cases h` on the impossible `none = some b` equation.
+3. After `injection`, `ext` on the `Fin m × Fin m` pair goal leaves coerced
+   projection goals `↑(i,j).1 = ↑(i',j').1` that `Fin.val_injective hi`
+   doesn't match; use `obtain rfl : i = i' := Fin.val_injective hi` (twice)
+   then `rfl`.
+4. Prepend `simp only [Option.mem_def] at hb hb'` so the `dif_pos/dif_neg`
+   rewrites see the `dite` (the `f_inj` hypotheses arrive as `b ∈ f a`
+   Option-membership).
+
+**Next**: S4 ACT — `triVtx` + `vertex_injective_triVtx` from S4 PREP #18719
+§8 (~52 LOC drop-in) into the same leaf file; then S5+ (adjacency + the
+remaining `Triangulation` axioms — the genuine open core, no `decide`
+available `m`-parametrically).
 
 ## Session 7 — S7 BLOCKED-propagation to research JSON gate (researcher-5, 2026-06-14)
 

--- a/src/data/research/problems/sperner-simplicial-instance-oq-01.json
+++ b/src/data/research/problems/sperner-simplicial-instance-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "sperner-simplicial-instance-oq-01",
   "title": "Standard 2-simplex triangulation as a concrete Triangulation instance",
-  "phase": "BLOCKED",
-  "status": "blocked",
+  "phase": "ACT",
+  "status": "in-progress",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -28,14 +28,12 @@
     "goal": "Add ~300 LOC namespace Triangle section into proofs/Proofs/SpernerSimplicialInstance.lean (between line 994 and end Triangulation) shipping the 2-d instance and the triangle_sperner corollary; preserve all existing content unchanged."
   },
   "currentState": {
-    "phase": "BLOCKED",
-    "since": "2026-06-12T17:40:00.000Z",
-    "iteration": 5,
-    "focus": "S6 ACT (researcher-2, 2026-06-12T17:40Z, BUILD-VERIFIED): Shipped the smallest genuinely-subdivided 2-d instance in a build-isolatable companion file proofs/Proofs/SpernerSimplicialInstanceOQ01.lean (146 LOC, 0 sorries, 0 axioms). standardTriangle2 : Triangulation (Fin 6) 2 = the standard regular triangulation of Δ² at resolution m=2: 4 cells (c0,c1,c2 up-triangles + c3 central down-triangle), tvtx/tadj as Nat-literal match tables, all four Triangulation axioms machine-checked, plus standardTriangle2_sperner corollary (2-d analogue of interval_sperner). This is the first instance exhibiting REAL 2-d pseudomanifold adjacency (c3 interior to all 3 up-triangles), strictly stronger than the single-cell trivialTriangle. Docker build green: Built Proofs.SpernerSimplicialInstanceOQ01 (6.2s), 1099 jobs, 0 errors. BUILD NOTE: an initial `![…]` vecNotation encoding of tvtx/tadj caused `decide` to emit `Lean.Expr.appArg!` reduction PANICs (~10x) though the olean still built; rewriting both tables as `match s.val, k.val with` Nat-literal definitions eliminated the panics entirely — record this idiom for the general-m ACT (use match/if over .val, not ![…], whenever `decide`-discharging finite Triangulation axioms). Companion-file pattern (cf. SpernerSimplicialInstanceOQ05.lean) keeps the parent untouched and the build surface to ~6s, sidestepping the prior S5 Docker-budget blocker. The general-m standardTriangleTriangulation (inductive TriCell m, m-parametric adj_vertex over 12 pairs) remains the open core. PRIOR S5 STATE-SYNC (researcher-1, 2026-06-05T06:50Z, doc-only): T+23-day stall at S2 ACT since 2026-05-13. Re-verified at S5-time: proofs/Proofs/SpernerSimplicialInstance.lean is byte-identical to its 2026-05-13 S2 ACT state (1022 LOC, 0 sorries, 0 axioms; trivialTriangle Candidate A unchanged). No commits on the slug since 2026-05-13. Last slug PR is S4 PREP #18719 (merged 2026-05-13T09:21:58Z). Recent sperner-* activity has been on sibling sperner-simplicial-instance-oq-05 (#21898 S7 ACT, #22368 S8 PREP), orthogonal to oq-01's Candidate C chain. S3 ACT readiness re-confirmed: S3 PREP #18625 §6 ships ~80 LOC verbatim, S3b PREP #18654 §4.3 ships ~+10 LOC ERRATUM patch (phantom dite_eq_some_iff → by_cases hij + dif_pos/dif_neg + Option.some.injEq), S4 PREP #18719 §8 ships ~52 LOC follow-up. Why S5 is STATE-SYNC not S3 ACT: worktree proofs/.lake symlink loop forces 30–60 min Docker build with full mathlib clone; budget not confident. JSON iteration 2 → 3. Previous: S2 ACT (researcher-1, 2026-05-13) — shipped trivialTriangle : Triangulation ℕ 2 (Candidate A) in proofs/Proofs/SpernerSimplicialInstance.lean (994 → 1022 LOC, +28; 0 sorries, 0 axioms; build pending). Verbatim §3 snippet of S2 PREP #18578 (researcher-9): Cell := Fin 1, vertex _ k := k.val, adj _ _ := none, all four proof obligations closed by single terms (Fin.val_injective for vertex_injective, Option.noConfusion h for adj_symm/adj_vertex/adj_ne). Inserted between end Interval (line 973) and /-! ## Interval Sperner. Smoke-test sibling to intervalTriangulation (line 958).",
-    "blockers": [
-      "S7 BLOCKED-PROPAGATION (researcher-5, 2026-06-14): the next ACT increment (general-m Candidate C: LatticePoint m + TriCell m data defs + Fintype, ~90 LOC, from merged PREPs #18625/#18654/#18719) is NEW Lean that must be Docker-built before shipping. The 2026-06-13 verification blackout (Docker daemon hung, docker ps blocks indefinitely; Aristotle 404) leaves no safe path. The state.md S6 BLOCKED decision (2026-06-13, researcher-2) was never propagated to this JSON gate (status stayed in-progress/ACT) so claim-random kept re-serving the slug — this edit sets status=blocked/phase=BLOCKED here + in the pool. Existing shipped content (companion standardTriangle2 : Triangulation (Fin 6) 2, 0 sorries/0 axioms, Docker-verified S6 2026-06-12) is unaffected. Re-open when Docker recovers."
-    ],
-    "nextAction": "S7 — Extend the resolution-2 instance toward general m. Concrete next increments: (a) generalise standardTriangle2 to a fixed resolution-3 instance (9 cells: 6 up + 3 down) to stress-test the adjacency-table idiom at the next size before parametrising; (b) begin the parametric Candidate C chain per the seeker-init design — LatticePoint m abbrev + inductive TriCell m (up/down), triVtx + vertex_injective, triAdj + adj_ne, then the strategic adj_symm/adj_vertex. Carry forward the match-over-.val idiom from the OQ01 companion (NOT `![…]`) so finite sub-cases stay `decide`-clean; the m-parametric axioms will need genuine proofs (the 1-d iadj_vertex' template at parent line 901 is the model). PRIOR (superseded) nextAction — S3 Candidate C lattice-subdivision chain per the seeker-init JSON design + S1 OBSERVE ranking: (1) LatticePoint m abbrev + TriCell m inductive (~80 LOC), (2) triVtx + vertex_injective (~50 LOC), (3) triAdj + adj_ne (~60 LOC), (4) adj_symm + adj_vertex (~100 LOC, possibly 1 strategic sorry), (5) standardTriangleTriangulation m hm (~10 LOC). Total ~300 LOC across 6-8 sessions. This is the load-bearing chain for oq-03 boundary_doors_odd, oq-04 Brouwer fixed-point, oq-06 Gale Hex.",
+    "phase": "ACT",
+    "since": "2026-07-24",
+    "iteration": 6,
+    "focus": "S3 ACT COMPLETE (researcher-3, 2026-07-24): Docker restored (the S6/S7 BLOCKED cause is gone), shipped the Candidate C data layer into the slug leaf file SpernerSimplicialInstanceOQ01.lean (146→254 LOC): LatticePoint m (Fin(m+1)×Fin(m+1) subtype, DecidableEq/Fintype free), inductive TriCell m (up i j (h : i+j<m) | down i j (h : i+j+1<m), deriving DecidableEq), and a hand-rolled Fintype (TriCell m) via two Finset.filterMap enumerations from Fin m × Fin m (union). 0 sorries, 0 axioms; Docker-verified (1117 jobs, Lean v4.31.0). v4.31 adaptations vs the PREP skeleton: `apply Finset.mem_filterMap.mpr` fails (Unknown constant; use `rw [Finset.mem_filterMap]`), `(Option.noConfusion h).elim` universe-fails (use `cases h`), and Prod/Fin `ext` leaves coerced projection goals (use obtain rfl := Fin.val_injective). Placed in the leaf file, NOT the shared parent, to avoid churn with active sibling slugs (post-PREP architecture).",
+    "blockers": [],
+    "nextAction": "S4 ACT: triVtx + vertex_injective_triVtx from S4 PREP #18719 §8 (~52 LOC drop-in) into the same leaf file; then S5+ adjacency table + remaining Triangulation axioms (the genuine open core).",
     "attemptCounts": {
       "total": 2,
       "currentApproach": 1,
@@ -111,7 +109,7 @@
     ]
   },
   "started": "2026-05-12T21:15:00Z",
-  "lastUpdate": "2026-06-14T17:30:00.000Z",
+  "lastUpdate": "2026-07-24",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
@@ -129,7 +127,7 @@
     {
       "path": "Proofs/SpernerSimplicialInstanceOQ01.lean",
       "filename": "SpernerSimplicialInstanceOQ01.lean",
-      "lineCount": 147,
+      "lineCount": 254,
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 3,


### PR DESCRIPTION
## Summary

Unblocks `sperner-simplicial-instance-oq-01` (BLOCKED since 2026-06-13 solely on the Docker blackout; Docker is restored) and ships the fully-PREP'd **S3 ACT** — the Candidate C data layer for the general-`m` standard triangulation of the 2-simplex:

- `LatticePoint m` — vertex carrier: subtype of `Fin (m+1) x Fin (m+1)` with `p.1 + p.2 <= m` (S3 PREP #18625 §3.1; `DecidableEq`/`Fintype` synthesize for free)
- `inductive TriCell m` — `up i j (h : i+j < m)` / `down i j (h : i+j+1 < m)`, `deriving DecidableEq` (`T(m)` up + `T(m-1)` down = `m^2` cells)
- `instance Fintype (TriCell m)` — hand-rolled via two `Finset.filterMap` enumerations from `Fin m x Fin m`, unioned, with the S3b ERRATUM (#18654 §4.3) `by_cases`/`dif_pos`/`dif_neg` injectivity discharges

**Placement**: in the slug's leaf file `SpernerSimplicialInstanceOQ01.lean` (146 -> 254 LOC) rather than the shared parent the PREP originally targeted — the leaf-file architecture postdates the PREP and the shared parent is actively touched by sibling slugs (e.g. oq-05 #22900). 0 sorries, 0 axioms.

## v4.31 drift vs the PREP skeletons (host-probed, then Docker-verified)

1. `apply Finset.mem_filterMap.mpr` fails with Unknown constant in v4.31 -> `rw [Finset.mem_filterMap]`
2. `exact (Option.noConfusion h).elim` universe-fails -> `cases h` on the impossible `none = some b`
3. `ext` after `injection` leaves coerced projection goals -> `obtain rfl : i = i' := Fin.val_injective hi` (x2) + `rfl`
4. Added `simp only [Option.mem_def]` so `dif_pos/dif_neg` see the `dite` in the `f_inj` hypotheses

## Verification

Docker build (Lean v4.31.0): `Built Proofs.SpernerSimplicialInstanceOQ01` clean, 1117 jobs, no warnings in the new code.

## State sync

state.md Session 8 + registry JSON: BLOCKED -> ACT (iteration 6), blockers cleared, nextAction = S4 ACT (`triVtx` + `vertex_injective_triVtx`, ~52 LOC drop-in from S4 PREP #18719 §8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
