### PR TITLE
audit(tracker): record erdos-100-oq-02 issues-fixed audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8355,10 +8355,10 @@
       "issues": []
     },
     "erdos-100-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:50Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T06:34:04Z",
+      "result": "issues-fixed"
     },
     "erdos-100-oq-02-oq-02": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary
- Re-serve audit of erdos-100-oq-02 (unaudited queue was drained: 4812/4812). Found and fixed stale phantom-axiom narrative (#43126).
- Records the audit-tracker entry for that fix.

## Test plan
- [x] `npx tsx scripts/auditor/find-targets.ts --stats` reflects the completed audit