### PR TITLE
Fix: erdos-1007-oq-05 axiomCount 4→3 (stale after parent axiom elimination)

### DIFF
--- a/src/data/proofs/erdos-1007-oq-05/meta.json
+++ b/src/data/proofs/erdos-1007-oq-05/meta.json
@@ -37,10 +37,10 @@
       "Proved completeBipartiteAdj is irreflexive, enabling corollary for K_{m,n}"
     ],
     "dateAdded": "2026-03-30",
-    "axiomCount": 4,
+    "axiomCount": 3,
     "lineCount": 127,
     "mathlib_version": "4.31.0",
-    "assumptions": "4 axioms inherited from Erdos1007Problem.lean: hasUnitEmbedding_exists (unit-distance graph embeddability), min_edges_dimension_4 (minimum edges in 4D unit-distance graph), k33_unique_minimum (K₃,₃ is unique minimum in dimension 3), min_edges_dimension_5 (minimum edges in 5D). 0 own axioms. 0 sorries.",
+    "assumptions": "3 axioms inherited from Erdos1007Problem.lean: min_edges_dimension_4 (minimum edges in 4D unit-distance graph), k33_unique_minimum (K₃,₃ is unique minimum in dimension 3), min_edges_dimension_5 (minimum edges in 5D). The former fourth axiom hasUnitEmbedding_exists is no longer an assumption: it was replaced in the parent by a proved theorem (issue #43115, PR #43124) and is re-proved here as hasUnitEmbedding_exists_irr with an added irreflexivity hypothesis (∀ v, ¬adj v v) correcting the original's logical error (self-loops force dist(v,v)=0≠1). 0 own axioms. 0 sorries.",
     "theoremCount": 4,
     "definitionCount": 0
   },


### PR DESCRIPTION
## Problem

The audit tracker re-flagged `erdos-1007-oq-05` (result: issues-found, empty detail = the post-fix re-audit). Investigation found a **genuine stale-inheritance** left behind by my own merged parent fix.

`Erdos1007OQ05.lean` imports `Proofs.Erdos1007Problem` and has **0 own axioms**. Its `meta.json` counts axioms as those inherited from the parent. After PR #43124 (issue #43115) replaced the inconsistent `hasUnitEmbedding_exists` axiom with a proved irreflexive theorem, the parent declares exactly **3** axioms:

```
$ git show origin/main:proofs/Proofs/Erdos1007Problem.lean | grep '^axiom '
axiom min_edges_dimension_4 ...
axiom k33_unique_minimum ...
axiom min_edges_dimension_5 ...
```

But oq-05's meta still read `axiomCount: 4` and listed `hasUnitEmbedding_exists` among the inherited axioms — even though this same entry (titled "Axiom Elimination Analysis") **re-proves** the corrected theorem as `hasUnitEmbedding_exists_irr`. The narrative fields (description, problemStatement, historicalContext, section summaries) already state "4→3"; only the two machine-read fields lagged.

## Fix (metadata only)

- `meta.axiomCount`: `4` → `3`
- `meta.assumptions`: drop `hasUnitEmbedding_exists` from the inherited list; note it was replaced in the parent (issue #43115 / PR #43124) and re-proved here with an added irreflexivity hypothesis.

## Evidence

| field | before | after |
|-------|--------|-------|
| parent axioms on main | — | 3 (`grep '^axiom '`) |
| oq-05 own axioms | 0 | 0 |
| oq-05 `meta.axiomCount` | 4 | 3 |

`python3 -c "import json; json.load(...)"` confirms valid JSON. No Lean source change; nested `mainTheorems[].axiomCount` (a per-theorem field) untouched.

Follow-up to #43115 / #43124.