### PR TITLE
Enrich bertrands-postulate-oq-05: cover header docstring (4->5 sections)

### DIFF
--- a/src/data/proofs/bertrands-postulate-oq-05/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-05/meta.json
@@ -100,6 +100,14 @@
   },
   "sections": [
     {
+      "id": "sec-header",
+      "title": "Problem Statement: Two Arithmetic Facts Bertrand Buys You",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Imports and module docstring. States the open question: applying Bertrand's postulate to ⌊n/2⌋ yields a prime n/2 < p ≤ n; the docstring previews both consequences — p divides n! (a large prime factor) and p is unramified in n! (v_p(n!) = 1), the latter forcing n! to never be a perfect square for n ≥ 2.",
+      "mathContext": "Bertrand gives a prime $p$ with $n/2 < p \\leq n$. Since $p \\leq n$, $p \\mid n!$; since $p \\leq n < 2p$ and $p^2 > n$, Legendre's formula collapses to $v_p(n!) = 1$, so $p^2 \\nmid n!$ and $n!$ cannot be a perfect square."
+    },
+    {
       "id": "sec-bertrand-half",
       "title": "Bertrand in the Lower Half: a Prime in (n/2, n]",
       "startLine": 41,


### PR DESCRIPTION
## Summary

- Entry's 4 sections covered lines 41-110; lines 1-39 (imports + module
  docstring stating the open question and its two-part resolution) had no
  section coverage.
- Adds a `sec-header` section (lines 1-39) so sections now cover the full
  112-line file, bringing the quality-scan sections field to target (5
  sections, matching the enricher's "sections covering all major parts of
  the proof" requirement).
- No other fields touched — annotations (5/5 with mathContext/significance),
  keyInsights (5), historicalContext, conclusion, and crossReferences were
  already at target.

## Test plan

- [x] `meta.json` re-serializes as valid JSON
- [x] File size well under the 60 KB cap (14 KB)
- [x] New section's line range and content checked against
      `proofs/Proofs/BertrandsPostulateOQ05.lean`