### PR TITLE
audit(tracker): continuum-hypothesis-oq-01 clean audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6640,8 +6640,8 @@
     },
     "continuum-hypothesis-oq-01": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:50Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T06:39:17Z",
       "result": "clean"
     },
     "continuum-hypothesis-oq-02": {


### PR DESCRIPTION
## Summary
Re-audited `continuum-hypothesis-oq-01` (reserve-mode re-serve, queue fully drained). Verified:
- 10 axioms match the `assumptions` disclosure exactly by name
- 0 sorries, no `native_decide`
- lineCount (317), theoremCount (20), definitionCount (4, incl. `MeasurableCardinal` structure) all match the actual file
- `gch_implies_ch` (used to derive `VeqL_implies_CH`) is a genuinely proved theorem in the parent `ContinuumHypothesis.lean`, not a phantom cross-file reference
- Tier C "axiomatized" status/badge honestly applied; originalContributions correctly scope claims to what's proved vs. axiom-conditioned

No integrity issues found. Bumps `audit-tracker.json` auditCount 4→5, result: clean.

## Test plan
- [x] Diff limited to `src/data/proofs/audit-tracker.json`