### PR TITLE
Research: sperner-simplicial-instance-oq-01 - S4 ACT: triVtx + vertex_injective (m-parametric, docker-verified)

### DIFF
--- a/proofs/Proofs/SpernerSimplicialInstanceOQ01.lean
+++ b/proofs/Proofs/SpernerSimplicialInstanceOQ01.lean
@@ -249,6 +249,47 @@ instance instFintype (m : ℕ) : Fintype (TriCell m) where
 
 end TriCell
 
+/-- Vertex map for the standard subdivision of Δ² at resolution `m`
+(S4 ACT, per PREP #18719 §8, match-pattern form per its §9 risk-note 3).
+
+For `up i j h`, positions `k = 0, 1, 2` give `(i, j)`, `(i+1, j)`,
+`(i, j+1)` (SW → SE → N corner).
+
+For `down i j h`, positions `k = 0, 1, 2` give `(i+1, j)`, `(i, j+1)`,
+`(i+1, j+1)` (W → N → NE corner). All six subtype-membership proofs are
+`omega`-discharged from the constructor bound (`i + j < m` resp.
+`i + j + 1 < m`). -/
+def triVtx (m : ℕ) : TriCell m → Fin 3 → LatticePoint m
+  | TriCell.up i j h, ⟨0, _⟩ =>
+      ⟨(⟨i, by omega⟩, ⟨j, by omega⟩), show i + j ≤ m by omega⟩
+  | TriCell.up i j h, ⟨1, _⟩ =>
+      ⟨(⟨i + 1, by omega⟩, ⟨j, by omega⟩), show i + 1 + j ≤ m by omega⟩
+  | TriCell.up i j h, ⟨_ + 2, _⟩ =>
+      ⟨(⟨i, by omega⟩, ⟨j + 1, by omega⟩), show i + (j + 1) ≤ m by omega⟩
+  | TriCell.down i j h, ⟨0, _⟩ =>
+      ⟨(⟨i + 1, by omega⟩, ⟨j, by omega⟩), show i + 1 + j ≤ m by omega⟩
+  | TriCell.down i j h, ⟨1, _⟩ =>
+      ⟨(⟨i, by omega⟩, ⟨j + 1, by omega⟩), show i + (j + 1) ≤ m by omega⟩
+  | TriCell.down i j h, ⟨_ + 2, _⟩ =>
+      ⟨(⟨i + 1, by omega⟩, ⟨j + 1, by omega⟩), show i + 1 + (j + 1) ≤ m by omega⟩
+
+/-- The three vertices of each cell are pairwise distinct (the
+`vertex_injective` obligation of the eventual
+`Triangulation (LatticePoint m) 2` instance). Each off-diagonal case
+reduces to an impossible `Nat` equation (`i = i + 1` or `j = j + 1`)
+after projecting to the underlying `Fin (m+1) × Fin (m+1)` pair. -/
+theorem vertex_injective_triVtx (m : ℕ) :
+    ∀ c : TriCell m, Function.Injective (triVtx m c) := by
+  intro c k k' hkk'
+  have hpair := congrArg (fun p : LatticePoint m => p.1) hkk'
+  cases c with
+  | up i j h =>
+    fin_cases k <;> fin_cases k' <;>
+      simp [triVtx, Prod.mk.injEq, Fin.mk.injEq] at hpair <;> rfl
+  | down i j h =>
+    fin_cases k <;> fin_cases k' <;>
+      simp [triVtx, Prod.mk.injEq, Fin.mk.injEq] at hpair <;> rfl
+
 end Triangle
 
 end Triangulation

--- a/research/problems/sperner-simplicial-instance-oq-01/state.md
+++ b/research/problems/sperner-simplicial-instance-oq-01/state.md
@@ -1,11 +1,32 @@
 # Research State: sperner-simplicial-instance-oq-01
 
 ## Current State
-**Phase**: ACT (S3 ACT complete — Candidate C data layer shipped + Docker-verified; S4 ACT next)
+**Phase**: ACT (S4 ACT complete — triVtx + vertex_injective shipped + Docker-verified; S5 triAdj next)
 **Path**: full
 **Since**: 2026-05-13T05:18:00Z
-**Last Updated**: 2026-07-24 (Session 8 / S3 ACT researcher-3)
-**Iteration**: 6
+**Last Updated**: 2026-07-24 (Session 9 / S4 ACT researcher-3)
+**Iteration**: 7
+
+## Session 9 — S4 ACT: `triVtx` + `vertex_injective_triVtx` (researcher-3, 2026-07-24)
+
+Same-session follow-up to Session 8 (S3 merged as #43125 mid-session; S4 on a
+fresh branch off updated origin/main). Ships PREP #18719 §8 in match-pattern
+form (its §9 risk-note 3): `triVtx m : TriCell m → Fin 3 → LatticePoint m`
+(up: SW/SE/N corners; down: W/N/NE) and `vertex_injective_triVtx` — the
+`vertex_injective` obligation of the future `Triangulation (LatticePoint m) 2`
+instance, proved `m`-parametrically (no `decide`). Leaf file 254 → 296 LOC,
+0 sorries, 0 axioms; Docker 1117 jobs clean.
+
+**v4.31 drift vs the PREP skeleton** (host-probed): (1) the subtype-membership
+`by omega` proofs fail on unreduced pair projections
+(`(⟨i,_⟩,⟨j,_⟩).1.val` opaque to omega) — use defeq `show i + j ≤ m by omega`
+forms; (2) the `first | rfl | omega` discharge is half-dead — `simp` already
+closes all off-diagonal (contradiction) cases, so plain `rfl` suffices and
+avoids unreachable-tactic lints; (3) `rw [hkk']` replaced by
+`congrArg (fun p => p.1) hkk'` (PREP §9 risk-note 5's own fallback).
+
+**Next**: S5 ACT — `triAdj` adjacency case-table; then the remaining three
+axioms + instance assembly (genuine open core).
 
 ## Session 8 — S3 ACT: `LatticePoint m` + `TriCell m` data layer (researcher-3, 2026-07-24)
 

--- a/src/data/research/problems/sperner-simplicial-instance-oq-01.json
+++ b/src/data/research/problems/sperner-simplicial-instance-oq-01.json
@@ -30,10 +30,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-24",
-    "iteration": 6,
-    "focus": "S3 ACT COMPLETE (researcher-3, 2026-07-24): Docker restored (the S6/S7 BLOCKED cause is gone), shipped the Candidate C data layer into the slug leaf file SpernerSimplicialInstanceOQ01.lean (146→254 LOC): LatticePoint m (Fin(m+1)×Fin(m+1) subtype, DecidableEq/Fintype free), inductive TriCell m (up i j (h : i+j<m) | down i j (h : i+j+1<m), deriving DecidableEq), and a hand-rolled Fintype (TriCell m) via two Finset.filterMap enumerations from Fin m × Fin m (union). 0 sorries, 0 axioms; Docker-verified (1117 jobs, Lean v4.31.0). v4.31 adaptations vs the PREP skeleton: `apply Finset.mem_filterMap.mpr` fails (Unknown constant; use `rw [Finset.mem_filterMap]`), `(Option.noConfusion h).elim` universe-fails (use `cases h`), and Prod/Fin `ext` leaves coerced projection goals (use obtain rfl := Fin.val_injective). Placed in the leaf file, NOT the shared parent, to avoid churn with active sibling slugs (post-PREP architecture).",
+    "iteration": 7,
+    "focus": "S4 ACT COMPLETE (researcher-3, 2026-07-24, same session as S3): triVtx (m-parametric vertex map, match-pattern form per S4 PREP #18719 §9 risk-note 3) + vertex_injective_triVtx shipped into the leaf file (254→296 LOC), 0 sorries, 0 axioms, Docker-verified 1117 jobs. The vertex_injective obligation of the eventual Triangulation (LatticePoint m) 2 instance is now discharged m-parametrically (no decide). v4.31 note: subtype-membership `by omega` fails on unreduced pair projections — use `show i + j ≤ m by omega` defeq forms; `first | rfl | omega` fallback dead (simp closes off-diagonals) → plain rfl.",
     "blockers": [],
-    "nextAction": "S4 ACT: triVtx + vertex_injective_triVtx from S4 PREP #18719 §8 (~52 LOC drop-in) into the same leaf file; then S5+ adjacency table + remaining Triangulation axioms (the genuine open core).",
+    "nextAction": "S5 ACT: triAdj adjacency case-table (~60 LOC, 12 sub-cases, design in S6-era PREPs); then S6+ adj_symm/adj_vertex/adj_ne + instance assembly — the genuine open core.",
     "attemptCounts": {
       "total": 2,
       "currentApproach": 1,
@@ -127,7 +127,7 @@
     {
       "path": "Proofs/SpernerSimplicialInstanceOQ01.lean",
       "filename": "SpernerSimplicialInstanceOQ01.lean",
-      "lineCount": 254,
+      "lineCount": 296,
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 3,


### PR DESCRIPTION
## Summary

Same-session follow-up to #43125 (S3 ACT, merged): ships the **S4 ACT** of `sperner-simplicial-instance-oq-01` from S4 PREP #18719 §8 — the `m`-parametric vertex map and its injectivity for the general standard triangulation of the 2-simplex:

- `triVtx m : TriCell m -> Fin 3 -> LatticePoint m` — match-pattern form (PREP §9 risk-note 3): `up i j` -> `(i,j), (i+1,j), (i,j+1)`; `down i j` -> `(i+1,j), (i,j+1), (i+1,j+1)`; all six subtype-membership proofs omega-discharged from the constructor bounds
- `vertex_injective_triVtx` — the `vertex_injective` obligation of the eventual `Triangulation (LatticePoint m) 2` instance, proved `m`-parametrically (`fin_cases` x `simp` projection to impossible Nat equations; no `decide`, which cannot work parametrically)

Leaf file 254 -> 296 LOC, **0 sorries, 0 axioms**.

## v4.31 drift vs the PREP skeleton (host-probed via `lake env lean`, then Docker-verified)

1. Subtype-membership `by omega` fails on unreduced pair projections (`(⟨i,_⟩,⟨j,_⟩).1.val` is opaque to omega) -> defeq `show i + j ≤ m by omega` forms
2. PREP's `first | rfl | omega` discharge is half-dead — `simp` closes all off-diagonal cases, so plain `rfl` suffices (avoids unreachable-tactic lints)
3. PREP's `rw [hkk']` -> `congrArg (fun p => p.1) hkk'` (the PREP's own §9 risk-note 5 fallback)

## Verification

Docker build (Lean v4.31.0): `Built Proofs.SpernerSimplicialInstanceOQ01` clean, 1117 jobs, no warnings in the new code.

## Next

S5 ACT: `triAdj` adjacency case-table (~60 LOC); then the remaining three axioms + instance assembly (the genuine open core of OQ-01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
