### PR TITLE
Enrich beta-integral-recurrence-oq-01-oq-02: split recurrence section (4->5)

### DIFF
--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-02/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-02/meta.json
@@ -109,11 +109,19 @@
       "mathContext": "$B(1/2,1/2) = \\Gamma(1/2)^2/\\Gamma(1) = \\pi$."
     },
     {
-      "id": "three-half",
-      "title": "One Recurrence Step: B(3/2,3/2) = π/8",
+      "id": "gamma-three-half",
+      "title": "The Recurrence Step: Γ(3/2) = ½·Γ(1/2)",
       "startLine": 76,
+      "endLine": 80,
+      "summary": "gamma_three_half rewrites Γ(3/2) as Γ(1/2 + 1) and applies the Gamma functional equation Gamma_add_one at s = 1/2, giving Γ(3/2) = (1/2)·Γ(1/2) — the single step that propagates the Gauss value up the half-integer lattice.",
+      "mathContext": "$\\Gamma(3/2) = \\Gamma(1/2+1) = \\tfrac12\\Gamma(1/2)$ via $\\Gamma(s+1)=s\\Gamma(s)$ at $s=1/2$."
+    },
+    {
+      "id": "three-half",
+      "title": "One Rung Up: B(3/2,3/2) = π/8",
+      "startLine": 81,
       "endLine": 99,
-      "summary": "gamma_three_half (Γ(3/2) = (1/2)·Γ(1/2) from Gamma_add_one) and betaIntegral_three_half_three_half: the Beta–Gamma split at u = v = 3/2 with Γ(3) = 2! = 2, substitution of Γ(3/2), and the same π^(1/2) recombination, finishing with ring arithmetic to π/8.",
+      "summary": "betaIntegral_three_half_three_half applies the Beta–Gamma split at u = v = 3/2, evaluates Γ(3) = 2! = 2 via Gamma_nat_eq_factorial, substitutes Γ(3/2) = (1/2)·Γ(1/2) and Γ(1/2) = π^(1/2), and recombines the two half-powers with ring arithmetic to reach π/8.",
       "mathContext": "$B(3/2,3/2) = \\Gamma(3/2)^2/\\Gamma(3) = (\\sqrt\\pi/2)^2/2 = \\pi/8$."
     }
   ],


### PR DESCRIPTION
## Summary

- The `three-half` section (lines 76-99) bundled the private recurrence
  lemma `gamma_three_half` (Γ(3/2) = ½·Γ(1/2)) with the headline theorem
  `betaIntegral_three_half_three_half` (B(3/2,3/2) = π/8).
- Splits into `gamma-three-half` (76-80, the functional-equation step) and
  `three-half` (81-99, the theorem it feeds), reaching the 5-section target
  and giving each real theorem boundary its own section.
- No other fields touched — annotations (5/5), keyInsights, historicalContext,
  conclusion, and crossReferences were already at target.

## Test plan

- [x] `meta.json` re-serializes as valid JSON
- [x] File size well under the 60 KB cap (14.6 KB)
- [x] New section boundaries checked against
      `proofs/Proofs/BetaIntegralHalfValue.lean`