### PR TITLE
audit(tracker): record bounded-prime-gaps-oq-03 issues-fixed audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3512,9 +3512,9 @@
     },
     "bounded-prime-gaps-oq-03": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:50Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T06:45:03Z",
+      "result": "issues-fixed"
     },
     "bounded-prime-gaps-oq-03-oq-01": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Tracker update recording the audit of bounded-prime-gaps-oq-03: found the
meta.assumptions prose understated sorries (claimed 0 while explicitly
scoping to the main file + companions, one of which has a real sorry).
Fixed in #43137.