### PR TITLE
Enrich bernoulli-inequality-oq-01: cover header docstring (4->5 sections)

### DIFF
--- a/src/data/proofs/bernoulli-inequality-oq-01/meta.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01/meta.json
@@ -73,6 +73,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Statement: The Sharp Strict Bernoulli Inequality",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Module docstring stating the open question: Mathlib's weak Bernoulli inequality 1 + n·a ≤ (1+a)ⁿ becomes strict exactly when a ≠ 0 and n ≥ 2. Previews the three theorems proved (the strict inequality on the full domain a > -1, and the two iff characterizations) and contrasts with the gallery's a > 0 strict form (binomial-theorem-oq-05).",
+      "mathContext": "$1 + na \\le (1+a)^n$ for $a \\ge -1$; the discarded quadratic term $\\binom{n}{2}a^2+\\cdots$ is strictly positive exactly when $a \\ne 0$ and $n \\ge 2$, over the full domain $a > -1$."
+    },
+    {
       "id": "strict",
       "title": "Sharp Strict Inequality",
       "startLine": 42,


### PR DESCRIPTION
## Summary

- Entry's 4 sections covered lines 42-108; lines 1-41 (module docstring
  stating the open question and previewing all three theorems) had no
  section coverage.
- Adds a `header` section (lines 1-41) so sections now cover the full
  108-line file, reaching the 5-section target.
- No other fields touched — annotations (5/5 with mathContext/significance),
  keyInsights (5), historicalContext, conclusion, and crossReferences were
  already at target.

## Test plan

- [x] `meta.json` re-serializes as valid JSON
- [x] File size well under the 60 KB cap (12 KB)
- [x] New section's line range checked against
      `proofs/Proofs/BernoulliInequalityOQ01.lean`