### PR TITLE
Research: erdos-876-incomplete-01 - S3: Part X structural results + stale-meta repair (docker-verified)

### DIFF
--- a/proofs/Proofs/Erdos876Problem.lean
+++ b/proofs/Proofs/Erdos876Problem.lean
@@ -331,4 +331,95 @@ theorem erdos_876_summary :
   obtain ⟨a, hincr, hsum, N, hgap⟩ := graham_result ε hε
   exact ⟨a, hsum, N, hgap⟩
 
+/-
+## Part X: Structural Results Around the Open Question
+-/
+
+/--
+**Super-increasing sequences are sum-free (Erdős sense).**
+
+If a strictly increasing sequence dominates the sum of all its predecessors
+(`∑_{k<n} a k < a n`), then its range is Erdős-sum-free: any finite set of
+distinct terms lying below `a m` is contained in `{a 0, …, a (m-1)}`, whose
+*total* sum is already `< a m`. This generalizes `powers_of_two_sumfree`
+(where `∑_{k<n} 2^k = 2^n - 1`), and isolates exactly the mechanism that
+proof used.
+-/
+theorem superIncreasing_sumfree {a : ℕ → ℕ} (hmono : StrictMono a)
+    (hsup : ∀ n, ∑ k ∈ Finset.range n, a k < a n) :
+    IsSumFreeErdos (Set.range a) := by
+  intro x hx S hS hlt _hcard
+  obtain ⟨m, rfl⟩ := hx
+  have hsub : S ⊆ (Finset.range m).image a := by
+    intro b hb
+    obtain ⟨j, rfl⟩ := hS (Finset.mem_coe.mpr hb)
+    have hj : j < m := by
+      by_contra hjm
+      have hmle : a m ≤ a j := hmono.monotone (Nat.le_of_not_lt hjm)
+      have hblt := hlt _ hb
+      omega
+    exact Finset.mem_image.mpr ⟨j, Finset.mem_range.mpr hj, rfl⟩
+  have hle : S.sum id ≤ ((Finset.range m).image a).sum id :=
+    Finset.sum_le_sum_of_subset hsub
+  have himg : ((Finset.range m).image a).sum id = ∑ j ∈ Finset.range m, a j := by
+    rw [Finset.sum_image fun x _ y _ h => hmono.injective h]
+    simp
+  intro hsum
+  have hs := hsup m
+  omega
+
+/--
+**The canonical example fails the linear-gap requirement.**
+
+The powers of two are sum-free by *domination* (each term exceeds the sum of
+all predecessors), but domination forces exponential gaps: already
+`gap 1 = 2² - 2¹ = 2 ≥ 1`. Any construction answering Question 876
+affirmatively must therefore be genuinely different from the super-increasing
+examples of Part VII.
+-/
+theorem powers_of_two_not_linearGapBound :
+    ¬ HasLinearGapBound (2 ^ ·) := by
+  intro h
+  have h1 := h 1 le_rfl
+  norm_num [gap] at h1
+
+/--
+**Linear gaps force at-most-quadratic growth.**
+
+If `aₙ₊₁ - aₙ < n` for all `n ≥ 1` then `2·aₙ + n ≤ 2·a₁ + n²` (equivalently
+`aₙ ≤ a₁ + n(n-1)/2`; stated over `ℕ` in doubled form to avoid division).
+This is why Question 876 is sharp: an affirmative answer would give a
+sum-free set growing like `n²`, strictly better than the
+Deshouillers–Erdős–Melfi `n^{3+o(1)}` construction, and sitting right at the
+`|A ∩ [1,N]| ≫ N^{1/2}` edge of the Łuczak–Schoen counting bound
+`|A ∩ [1,N]| ≪ (N log N)^{1/2}`.
+-/
+theorem hasLinearGapBound_quadratic {a : ℕ → ℕ} (h : HasLinearGapBound a) :
+    ∀ n, 1 ≤ n → 2 * a n + n ≤ 2 * a 1 + n * n := by
+  intro n hn
+  induction n, hn using Nat.le_induction with
+  | base => omega
+  | succ m hm ih =>
+      have hgap := h m hm
+      have hg : gap a m = a (m + 1) - a m := rfl
+      have hsq : (m + 1) * (m + 1) = m * m + 2 * m + 1 := by ring
+      rw [hsq]
+      generalize m * m = q at ih ⊢
+      omega
+
+/--
+**An affirmative answer to Question 876 yields a quadratically-growing
+sum-free set.**
+
+Packaging of `hasLinearGapBound_quadratic` against the question statement:
+the witness enumeration of `ErdosQuestion876` would have at-most-quadratic
+growth — better than every known construction.
+-/
+theorem erdosQuestion876_implies_quadratic_growth :
+    ErdosQuestion876 →
+      ∃ a : ℕ → ℕ, IsIncreasingEnumeration a ∧ IsSumFreeErdos (Set.range a) ∧
+        ∀ n, 1 ≤ n → 2 * a n + n ≤ 2 * a 1 + n * n := by
+  rintro ⟨a, hinc, hsf, hgap⟩
+  exact ⟨a, hinc, hsf, hasLinearGapBound_quadratic hgap⟩
+
 end Erdos876

--- a/research/problems/erdos-876-incomplete-01/knowledge.md
+++ b/research/problems/erdos-876-incomplete-01/knowledge.md
@@ -58,3 +58,35 @@ Host-verified (`lake env lean`, v4.31, exit 0); `#print axioms powers_of_two_sum
 The genuinely open content (linear gaps, `ErdosQuestion876`) has no elementary path — node COMPLETE.
 Gallery meta/annotations synced (sorries 0, lineCount 334, stale meta.sorries=2 fixed,
 powers-of-two annotation re-anchored 244–283 and reworded to proved).
+
+## 2026-07-24 (researcher-2) — S3: Part X structural results + stale-meta repair
+
+**Triage:** node's original mandate (2 sorries) already complete — file sorry-free
+since PR #41769. Remaining `graham_result` axiom is a deep person-named external
+result (not de-axiomatizable). Session = structural extension per pool convention.
+
+**Shipped (Docker-verified, 8576 jobs, exit 0, v4.31.0):** new Part X in
+`Erdos876Problem.lean` (334 → 425 lines, 4 → 8 theorems, 0 sorries, 1 axiom):
+
+- `superIncreasing_sumfree` — any strictly-monotone sequence dominating the sum
+  of its predecessors is Erdős-sum-free (generalizes `powers_of_two_sumfree`,
+  isolating its mechanism).
+- `powers_of_two_not_linearGapBound` — the canonical example fails Question
+  876's linear-gap requirement (gap 1 = 2); sum-freeness-by-domination forces
+  huge gaps, so any affirmative construction must be genuinely different.
+- `hasLinearGapBound_quadratic` — linear gaps force `2·aₙ + n ≤ 2·a₁ + n²`
+  (quadratic growth; doubled ℕ form avoids division). Proof: `Nat.le_induction`
+  + `generalize m*m` + omega.
+- `erdosQuestion876_implies_quadratic_growth` — packaging: an affirmative
+  answer beats DEM's `n^{3+o(1)}` construction.
+
+**Stale-meta repair (gallery erdos-876):** meta.json still claimed 1 sorry
+(`powers_of_two_sumfree`) in 8 places despite #41769 — counts (sorries 1→0,
+theoremCount → 8, lineCount → 425), assumptions string, originalContributions,
+section summaries, conclusion, proofStrategy all corrected; Part X added to
+proofStrategy. Part X appended at end of file, so existing annotation anchors
+(≤ line 332) do not drift.
+
+**Remaining:** `graham_result` de-axiomatization (DEEP — full construction),
+DEM/Łuczak-Schoen results are prose-only (would need major sessions). Node's
+completion mandate is exhausted; recommend `completed`.

--- a/src/data/proofs/erdos-876/meta.json
+++ b/src/data/proofs/erdos-876/meta.json
@@ -17,7 +17,7 @@
       "partially-solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 876,
     "erdosUrl": "https://erdosproblems.com/876",
     "erdosProblemStatus": "open",
@@ -42,13 +42,14 @@
       "ErdosQuestion876: the main open question",
       "graham_result axiom: gaps < n^{1+ε} achievable (the only axiom)",
       "cubicGrowthExponent := 3 and reciprocalSum definition (via tsum)",
-      "powers_of_two_sumfree theorem sketch (sorry)",
-      "Density-zero, Łuczak-Schoen, DEM, and Sullivan results appear only as prose comments — they are NOT formalized as axioms or theorems"
+      "powers_of_two_sumfree proved (binary domination argument)",
+      "Density-zero, Łuczak-Schoen, DEM, and Sullivan results appear only as prose comments — they are NOT formalized as axioms or theorems",
+      "Part X structural results: superIncreasing_sumfree generalization, powers_of_two_not_linearGapBound, hasLinearGapBound_quadratic (linear gaps force quadratic growth), erdosQuestion876_implies_quadratic_growth"
     ],
     "axiomCount": 1,
-    "lineCount": 305,
-    "assumptions": "1 axiom: graham_result. 1 sorry (powers_of_two_sumfree).",
-    "theoremCount": 3,
+    "lineCount": 425,
+    "assumptions": "1 axiom: graham_result (Graham's near-linear gap construction, deep external result). 0 sorries.",
+    "theoremCount": 8,
     "definitionCount": 9,
     "additionalFiles": [
       "Proofs/Erdos876ProblemAristotle.lean"
@@ -58,7 +59,7 @@
     "historicalContext": "**Erdős Problem #876: Sum-Free Sets and Gap Growth**\n\nA **sum-free set** in Erdős's sense is an infinite set $A = \\{a_1 < a_2 < \\cdots\\} \\subset \\mathbb{N}$ where no element equals a sum of distinct smaller elements from $A$. This is strictly stronger than the classical sum-free condition (no $a + b = c$), as it forbids all subset sums, not just pairs.\n\nPaul Erdős proved in 1962 that such sets must have asymptotic density zero, establishing a fundamental sparsity constraint. The natural follow-up question — how sparse must they be? — was pursued through several key developments:\n\n- **Erdős (1962):** Proved density zero and the crude reciprocal sum bound $\\sum_{a \\in A} 1/a < 100$.\n- **Ronald Graham (c. 1998):** Showed that for any $\\varepsilon > 0$, there exists a sum-free set with gaps $a_{n+1} - a_n < n^{1+\\varepsilon}$ for large $n$. This is the best positive result toward the linear gap question.\n- **Jean-Marc Deshouillers, Erdős, and Giuseppe Melfi (1999):** Constructed a sum-free set with $a_n \\sim n^{3+o(1)}$, establishing the cubic growth rate as achievable.\n- **Tomasz Łuczak and Tomasz Schoen (2000):** Proved tight bounds on the counting function: $|A \\cap [1,N]| = O(\\sqrt{N \\log N})$ for any sum-free $A$, and there exists $B$ with $|B \\cap [1,N]| \\gg \\sqrt{N/(\\log N)^{1/2+o(1)}}$.\n- **Steven Sullivan:** Improved Erdős's reciprocal sum bound to $\\sum 1/a < 4$ and conjectured the supremum is slightly above 2.\n\nThe central open question remains: **can the gaps be made linear**, i.e., is $a_{n+1} - a_n < n$ achievable? Graham's result shows we can get arbitrarily close to linear ($n^{1+\\varepsilon}$), suggesting the answer might be yes, but the problem has resisted resolution for over two decades.",
     "problemStatement": "**Problem Statement (Partially Solved)**\n\nLet $A = \\{a_1 < a_2 < \\cdots\\} \\subset \\mathbb{N}$ be an infinite sum-free set, meaning no $a \\in A$ equals $b_1 + b_2 + \\cdots + b_r$ for distinct $b_i \\in A$ with $b_i < a$.\n\n**Questions:**\n1. How small can the gaps $a_{n+1} - a_n$ be?\n2. Is it possible that $a_{n+1} - a_n < n$?\n\n**Known:**\n- Graham: Gaps can be $< n^{1+o(1)}$\n- Main question (linear gaps) is OPEN\n\n**Additional Question:**\nWhat is $\\max \\sum_{a \\in A} 1/a$? Sullivan shows $< 4$, conjectures $\\approx 2$.",
     "text": "For an infinite sum-free set A = {a₁ < a₂ < ⋯}, how small can gaps aₙ₊₁ - aₙ be? Graham showed n^{1+o(1)} is achievable; whether gaps < n is possible remains OPEN.",
-    "proofStrategy": "**Formalization Approach**\n\nThe formalization distinguishes two sum-free notions and builds toward the open question:\n\n1. **Two Definitions (Lines 49–76):** `IsSumFreeErdos` forbids any subset sum of distinct predecessors equaling an element; `IsSumFreeClassical` only forbids $a + b = c$. The naive implication `IsSumFreeErdos → IsSumFreeClassical` is **false** (`not_isSumFreeErdos_imp_isSumFreeClassical`: $\\{2,4\\}$ is Erdős-sum-free but $2+2=4\\in A$); the correct `erdos_implies_classical_of_pos` holds only for distinct positive summands. Both are axiom- and sorry-free.\n\n2. **Gap Machinery (Lines 84–109):** Defines `gap a n = a(n+1) - a(n)`, `HasGapBound`, and the critical `HasLinearGapBound` condition $a_{n+1} - a_n < n$.\n\n3. **The Open Question (Lines 117–136):** `ErdosQuestion876` existentially asserts a sum-free set with linear gaps. Graham's axiom shows near-linear ($n^{1+\\varepsilon}$) gaps are achievable.\n\n4. **Density and Growth (Lines 140–169):** Erdős's density-zero result, Łuczak-Schoen's counting bounds $\\Theta(\\sqrt{N \\log N})$, and DEM's cubic growth construction are recorded in prose comments only — none are formalized as axioms or theorems. The only declaration is `def cubicGrowthExponent := 3`.\n\n5. **Reciprocal Sums (Lines 175–193):** Defines `reciprocalSum` via `tsum`; Erdős's bound, Sullivan's improvement, and Sullivan's conjecture are described in comments, not axiomatized.\n\n6. **Examples and Summary (Lines 198–305):** Powers of 2 as a basic sum-free set (sorry in proof), connections to Sidon sets and $B_h$ sequences, and the closing `erdos_876_summary` theorem, which restates Graham's axiom rather than adding new content.",
+    "proofStrategy": "**Formalization Approach**\n\nThe formalization distinguishes two sum-free notions and builds toward the open question:\n\n1. **Two Definitions (Lines 49–76):** `IsSumFreeErdos` forbids any subset sum of distinct predecessors equaling an element; `IsSumFreeClassical` only forbids $a + b = c$. The naive implication `IsSumFreeErdos → IsSumFreeClassical` is **false** (`not_isSumFreeErdos_imp_isSumFreeClassical`: $\\{2,4\\}$ is Erdős-sum-free but $2+2=4\\in A$); the correct `erdos_implies_classical_of_pos` holds only for distinct positive summands. Both are axiom- and sorry-free.\n\n2. **Gap Machinery (Lines 84–109):** Defines `gap a n = a(n+1) - a(n)`, `HasGapBound`, and the critical `HasLinearGapBound` condition $a_{n+1} - a_n < n$.\n\n3. **The Open Question (Lines 117–136):** `ErdosQuestion876` existentially asserts a sum-free set with linear gaps. Graham's axiom shows near-linear ($n^{1+\\varepsilon}$) gaps are achievable.\n\n4. **Density and Growth (Lines 140–169):** Erdős's density-zero result, Łuczak-Schoen's counting bounds $\\Theta(\\sqrt{N \\log N})$, and DEM's cubic growth construction are recorded in prose comments only — none are formalized as axioms or theorems. The only declaration is `def cubicGrowthExponent := 3`.\n\n5. **Reciprocal Sums (Lines 175–193):** Defines `reciprocalSum` via `tsum`; Erdős's bound, Sullivan's improvement, and Sullivan's conjecture are described in comments, not axiomatized.\n\n6. **Examples and Summary (Lines 198–305):** Powers of 2 proved sum-free via binary domination, connections to Sidon sets and $B_h$ sequences, and the closing `erdos_876_summary` theorem, which restates Graham's axiom rather than adding new content.\n\n7. **Structural Results (Part X, Lines 334–425):** `superIncreasing_sumfree` generalizes the powers-of-two argument (any sequence dominating the sum of its predecessors is Erdős-sum-free); `powers_of_two_not_linearGapBound` shows the canonical example fails Question 876's linear-gap requirement; `hasLinearGapBound_quadratic` proves linear gaps force at-most-quadratic growth ($2a_n + n \\leq 2a_1 + n^2$), so an affirmative answer would beat the DEM $n^{3+o(1)}$ construction (`erdosQuestion876_implies_quadratic_growth`).",
     "keyInsights": [
       "**Erdős vs Classical Sum-Free:** The Erdős condition ($\\nexists$ subset sum of predecessors $= a$) is strictly stronger than classical ($a + b \\neq c$). The set $\\{1, 5, 6\\}$ is classically sum-free ($1+5=6$ violates classical!) but illustrates the distinction — Erdős sum-free sets avoid ALL subset sums, making them much sparser.",
       "**Density-Growth Duality:** The Łuczak-Schoen counting bound $|A \\cap [1,N]| = O(\\sqrt{N \\log N})$ and the DEM growth rate $a_n \\sim n^{3+o(1)}$ are dual perspectives: if $|A \\cap [1,N]| \\sim \\sqrt{N}$, inverting gives $a_n \\sim n^2$. The $\\log N$ correction explains the cubic (rather than quadratic) growth.",
@@ -83,10 +84,10 @@
     {
       "id": "sum-free-sets",
       "title": "Sum-Free Set Definitions",
-      "summary": "Defines `IsSumFreeErdos A`: $\\forall a \\in A,\\; \\forall S \\subseteq A$ with $|S| \\geq 2$ and $\\max S < a$, we have $\\sum S \\neq a$. Defines `IsSumFreeClassical A`: $\\forall a,b \\in A,\\; a+b \\notin A$. Proves (with sorry) that Erdős implies classical.",
+      "summary": "Defines `IsSumFreeErdos A`: $\\forall a \\in A,\\; \\forall S \\subseteq A$ with $|S| \\geq 2$ and $\\max S < a$, we have $\\sum S \\neq a$. Defines `IsSumFreeClassical A`: $\\forall a,b \\in A,\\; a+b \\notin A$. Refutes the naive implication (counterexample $\\{2,4\\}$) and proves the corrected `erdos_implies_classical_of_pos` for distinct positive summands.",
       "startLine": 43,
       "endLine": 77,
-      "mathContext": "Defines `IsSumFreeErdos A`: $\\forall a \\in A,\\; \\forall S \\subseteq A$ with $|S| \\geq 2$ and $\\max S < a$, we have $\\sum S \\neq a$. Defines `IsSumFreeClassical A`: $\\forall a,b \\in A,\\; a+b \\notin A$. Proves (with sorry) that Erdős implies classical."
+      "mathContext": "Defines `IsSumFreeErdos A`: $\\forall a \\in A,\\; \\forall S \\subseteq A$ with $|S| \\geq 2$ and $\\max S < a$, we have $\\sum S \\neq a$. Defines `IsSumFreeClassical A`: $\\forall a,b \\in A,\\; a+b \\notin A$. Refutes the naive implication (counterexample $\\{2,4\\}$) and proves the corrected `erdos_implies_classical_of_pos` for distinct positive summands."
     },
     {
       "id": "gap-sequences",
@@ -131,10 +132,10 @@
     {
       "id": "examples",
       "title": "Examples and Connections",
-      "summary": "States `powers_of_two_sumfree`: $\\{2^n : n \\in \\mathbb{N}\\}$ is sum-free (sorry — the proof uses binary uniqueness). Notes connections to Sidon sets and $B_h$ sequences.",
+      "summary": "Proves `powers_of_two_sumfree`: $\\{2^n : n \\in \\mathbb{N}\\}$ is sum-free (proved via binary domination: $\\sum_{j<k} 2^j = 2^k - 1 < 2^k$). Notes connections to Sidon sets and $B_h$ sequences.",
       "startLine": 227,
       "endLine": 257,
-      "mathContext": "States `powers_of_two_sumfree`: $\\{$2^{n}$ : n \\in \\mathbb{N}\\}$ is sum-free (sorry — the proof uses binary uniqueness). Notes connections to Sidon sets and $B_h$ sequences."
+      "mathContext": "Proves `powers_of_two_sumfree`: $\\{$2^{n}$ : n \\in \\mathbb{N}\\}$ is sum-free (proved via binary domination: $\\sum_{j<k} 2^j = 2^k - 1 < 2^k$). Notes connections to Sidon sets and $B_h$ sequences."
     },
     {
       "id": "sidon-and-summary",
@@ -146,7 +147,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #876 asks how small gaps in infinite sum-free sets can be. Graham showed gaps $< n^{1+\\varepsilon}$ are achievable for any $\\varepsilon > 0$, but whether gaps can be made linear ($< n$) remains open. The counting function is $\\Theta(\\sqrt{N \\log N})$ (Łuczak-Schoen), elements grow as $n^{3+o(1)}$ (DEM), and the reciprocal sum is bounded between 2 and 4 (Sullivan). The formalization has 1 sorry statement, in the `powers_of_two_sumfree` proof; the former `erdos_implies_classical` sorry was resolved by replacing a *false* claim with the correct `erdos_implies_classical_of_pos` plus an explicit counterexample.",
+    "summary": "Erdős Problem #876 asks how small gaps in infinite sum-free sets can be. Graham showed gaps $< n^{1+\\varepsilon}$ are achievable for any $\\varepsilon > 0$, but whether gaps can be made linear ($< n$) remains open. The counting function is $\\Theta(\\sqrt{N \\log N})$ (Łuczak-Schoen), elements grow as $n^{3+o(1)}$ (DEM), and the reciprocal sum is bounded between 2 and 4 (Sullivan). The formalization is sorry-free: `powers_of_two_sumfree` is proved via binary domination, and the former `erdos_implies_classical` sorry was resolved by replacing a *false* claim with the correct `erdos_implies_classical_of_pos` plus an explicit counterexample.",
     "implications": "**Theoretical Significance**: **Broader Mathematical Connections**\n\n1. **Schur's Theorem and Ramsey Theory:** Sum-free subsets of $\\{1,\\ldots,N\\}$ are exactly the independent sets avoiding Schur triples $x + y = z$. Schur's theorem (1916) guarantees any $r$-coloring of $[N]$ contains a monochromatic Schur triple for large $N$, so no single color class can be sum-free and cover all of $[N]$.\n\n2. **Subset Sum Problem:** The Erdős sum-free condition is intimately related to the NP-complete Subset Sum problem.\n\nA sum-free set is one where the subset sum problem has no solutions of a specific form, connecting combinatorics to computational complexity.\n\n3. **Binary Representation and Uniqueness:** The powers-of-2 example connects to number representation theory: uniqueness of binary representation is equivalent to sum-freeness of $\\{2^n\\}$, linking to the theory of numeration systems.\n\n4. **Greedy Algorithms:** Sum-free sets can be constructed greedily (add the smallest number not representable as a subset sum of existing elements). The greedy construction gives cubic growth, matching the DEM bound — suggesting the greedy approach is near-optimal.\n\n5. **Probabilistic Methods:** Random constructions provide lower bounds on counting functions and suggest that most sum-free sets have gaps close to $n^{3+o(1)}$, far from the linear gap frontier.",
     "openQuestions": [
       "Is the linear gap bound $a_{n+1} - a_n < n$ achievable for an infinite sum-free set? This is the central open question of Problem #876.",
@@ -168,12 +169,12 @@
       "BigOperators"
     ],
     "namespace": "Erdos876",
-    "lineCount": 305,
+    "lineCount": 425,
     "axiomCount": 1,
-    "theoremCount": 4,
+    "theoremCount": 8,
     "definitionCount": 9,
     "path": "Proofs/Erdos876Problem.lean",
-    "sorries": 1,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos876ProblemAristotle.lean"
     ]
@@ -195,5 +196,5 @@
       "description": "Related Erdős problem sharing themes: combinatorics, partially-solved"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

S3 for `erdos-876-incomplete-01` (Erdős #876: sum-free sets and gap growth). The node's original mandate (2 sorries) was completed in #41469/#41769; this session ships a structural extension around the open question plus a repair of stale gallery metadata.

- **Build**: `./proofs/scripts/docker-build.sh Proofs.Erdos876Problem` — 8576 jobs, exit 0 (v4.31.0)
- **File**: 334 -> 425 lines, 4 -> 8 theorems, **0 sorries**, 1 axiom (unchanged: `graham_result`, deep external result)

### New Part X (namespace `Erdos876`)

| Theorem | Content |
|---------|---------|
| `superIncreasing_sumfree` | Any strictly-monotone sequence dominating the sum of its predecessors is Erdős-sum-free — generalizes `powers_of_two_sumfree`, isolating its mechanism |
| `powers_of_two_not_linearGapBound` | The canonical example fails Question 876's linear-gap requirement (gap 1 = 2): domination forces huge gaps, so an affirmative construction must be genuinely different |
| `hasLinearGapBound_quadratic` | Linear gaps force at-most-quadratic growth (doubled ℕ form avoids division): why the question sharpens the Deshouillers-Erdős-Melfi n^(3+o(1)) construction |
| `erdosQuestion876_implies_quadratic_growth` | Packaging: an affirmative answer yields a quadratically-growing sum-free set |

### Stale-meta repair (gallery erdos-876)

`src/data/proofs/erdos-876/meta.json` still claimed 1 sorry in `powers_of_two_sumfree` (in counts, assumptions, originalContributions, section summaries, conclusion, and proofStrategy) despite the fix merging in #41769. All corrected; counts synced (sorries 0, theoremCount 8, lineCount 425); Part X added to proofStrategy. Part X is appended at end of file, so existing annotation anchors do not drift.

### Honesty block

- The four new theorems are elementary (structural/pedagogical): they contextualize the open question rather than advance it. No progress on the open question itself or on de-axiomatizing `graham_result`.
- The node's completion mandate is exhausted (file sorry-free); pool status set to `completed`.

Session note: `research/problems/erdos-876-incomplete-01/knowledge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
