### PR TITLE
Enrich bezout-identity-oq001: split accumulated-product section (4->5)

### DIFF
--- a/src/data/proofs/bezout-identity-oq001/meta.json
+++ b/src/data/proofs/bezout-identity-oq001/meta.json
@@ -86,10 +86,18 @@
     },
     {
       "id": "remainder-product",
-      "title": "§II The accumulated product Rₖ and the full invariant",
+      "title": "§II.a The accumulated product Rₖ and its unimodularity",
       "startLine": 90,
+      "endLine": 115,
+      "summary": "Defines Rprod [q_k,…,q_1] = Q(q_k)·⋯·Q(q_1) by list recursion (with simp lemmas Rprod_nil, Rprod_cons). det_Rprod proves det (Rprod qs) = (−1)^(qs.length) by induction (Matrix.det_mul + det_Q), so every accumulated transformation is unimodular."
+    },
+    {
+      "id": "remainder-product-invariant",
+      "title": "§II.b The full matrix–Euclidean invariant",
+      "startLine": 117,
       "endLine": 126,
-      "summary": "Defines Rprod [q_k,…,q_1] = Q(q_k)·⋯·Q(q_1) by list recursion (with simp lemmas Rprod_nil, Rprod_cons). det_Rprod proves det (Rprod qs) = (−1)^(qs.length) by induction (Matrix.det_mul + det_Q), so every accumulated transformation is unimodular. Rprod_mulVec proves (Rprod qs).mulVec v = qs.foldr euclidStep v: applying the product folds the individual Euclidean steps."
+      "summary": "Rprod_mulVec proves (Rprod qs).mulVec v = qs.foldr euclidStep v by induction on qs, threading Matrix.mulVec_mulVec through Q_mulVec: applying the accumulated product folds the individual Euclidean steps.",
+      "mathContext": "$R_k \\cdot v = \\mathrm{foldr}\\ \\mathrm{euclidStep}\\ v\\ [q_k,\\ldots,q_1]$: the accumulated matrix product reproduces the composition of the $k$ individual Euclidean steps."
     },
     {
       "id": "examples",


### PR DESCRIPTION
## Summary

- Part II (`remainder-product`, lines 90-126) bundled the `Rprod` definition
  and its unimodularity theorem `det_Rprod` together with the separate
  matrix-Euclidean-fold theorem `Rprod_mulVec`.
- Splits at the theorem boundary (line 117) into `remainder-product`
  (definition + `det_Rprod`) and `remainder-product-invariant`
  (`Rprod_mulVec`), reaching the 5-section target.
- No other fields touched — annotations (5/5 with mathContext/significance),
  keyInsights, historicalContext, conclusion, and crossReferences were
  already at target.

## Test plan

- [x] `meta.json` re-serializes as valid JSON
- [x] File size well under the 60 KB cap (17 KB)
- [x] New section boundary checked against
      `proofs/Proofs/BezoutIdentityOQ01OQ01OQ01OQ02.lean`