### PR TITLE
Gallery integrity: erdos-395-oq-01 drops unused eliminated axiom

### DIFF
--- a/proofs/Proofs/Erdos395OQ01.lean
+++ b/proofs/Proofs/Erdos395OQ01.lean
@@ -233,7 +233,7 @@ theorem sqrt2_is_critical :
       isUnitVector z → probSmallSum z ≥ c / n) ∧
     -- But fails for some configuration at threshold 1
     (∃ n : ℕ, n > 0 ∧ ¬erdos_original_question n) :=
-  ⟨hjns_2024, erdos_original_is_false⟩
+  ⟨hjns_2024, erdos_original_is_false_proved⟩
 
 -- ══════════════════════════════════════════════════════════════════
 -- § 5. Optimality of the 1/n Rate


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-395-oq-01
**Problem**: `sqrt2_is_critical` (§4) invoked the imported axiom `erdos_original_is_false` even though the file already proves the identical statement locally, sorry-free, as `erdos_original_is_false_proved` (§2). The file's own header comment claims "Key axiom elimination: erdos_original_is_false is NOW A THEOREM" — but the code contradicted that claim by still depending on the axiom in a downstream theorem.

## Evidence

**File header (line 17)**: "Key axiom elimination: erdos_original_is_false is NOW A THEOREM"
**Actual code (line 236, before fix)**: `⟨hjns_2024, erdos_original_is_false⟩` — used the axiom, not the theorem
**Local proof available**: `erdos_original_is_false_proved : ∃ n : ℕ, n > 0 ∧ ¬erdos_original_question n` (lines 177-208), identical type, no axioms, no sorries.

## Fix

Swapped `erdos_original_is_false` → `erdos_original_is_false_proved` in `sqrt2_is_critical`. Verified via `./proofs/scripts/docker-build.sh Proofs.Erdos395OQ01` — builds successfully. This removes an unnecessary axiom dependency from a public headline theorem ("§4. The √2 Threshold is Critical") without touching `meta.json` (axiomCount/assumptions already only disclosed the file's 2 local axioms, `counterexample_always_large` and `extremal_example_tight`, which is unaffected by this change).

---
Discovered during gallery integrity audit.