### PR TITLE
Enrich binary-gcd-oq-03-oq-02-incomplete-01-oq-01: split header (4->5)

### DIFF
--- a/src/data/proofs/binary-gcd-oq-03-oq-02-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/binary-gcd-oq-03-oq-02-incomplete-01-oq-01/meta.json
@@ -132,10 +132,18 @@
   "sections": [
     {
       "id": "module-header",
-      "title": "Module Header and the Halving-Regularity Condition",
+      "title": "Module Header: the Size-Reduction Recurrence",
       "startLine": 1,
+      "endLine": 53,
+      "summary": "Module docstring situating the entry as the deferred complexity strand of the Schönhage HGCD family: the recurrence T(n) ≤ 2·T(⌊n/2⌋) + M(n) with T(n) ≤ M(n) for n ≤ 1, the classical solution T(n) = O(M(n)·log n) under the halving-regularity hypothesis, and why floor division is used (the standard divide-and-conquer normalization, ceiling differing only by ±1 rounding)."
+    },
+    {
+      "id": "halving-regular",
+      "title": "The Halving-Regularity Condition",
+      "startLine": 55,
       "endLine": 78,
-      "summary": "Module docstring situating the entry as the deferred complexity strand of the Schönhage HGCD family and fixing the floor-division normalization of the recurrence. Imports Nat.Log, Nat.Size, and Tactic. Defines HalvingRegular M := ∀ n ≥ 2, 2·M(⌊n/2⌋) ≤ M(n) — the master-theorem regularity (superlinear-multiplication) hypothesis — and proves halvingRegular_of_superadditive: every super-additive monotone M is halving-regular."
+      "summary": "Imports Nat.Log, Nat.Size, Tactic. Defines HalvingRegular M := ∀ n ≥ 2, 2·M(⌊n/2⌋) ≤ M(n) — the master-theorem regularity (superlinear-multiplication) hypothesis satisfied by schoolbook, Karatsuba, and quasi-linear multiplication — and proves halvingRegular_of_superadditive: every super-additive monotone M is halving-regular, via M(⌊n/2⌋)+M(⌊n/2⌋) ≤ M(⌊n/2⌋+⌊n/2⌋) ≤ M(n).",
+      "mathContext": "$\\mathrm{HalvingRegular}(M) :\\iff \\forall n \\ge 2,\\ 2M(\\lfloor n/2\\rfloor) \\le M(n)$; super-additive monotone $M$ automatically satisfies this."
     },
     {
       "id": "master-bound",


### PR DESCRIPTION
## Summary

- The `module-header` section (lines 1-78) bundled the module docstring with
  the `HalvingRegular` definition and its `halvingRegular_of_superadditive`
  lemma — the file's full four sections already covered the whole 161-line
  file, but this one bundled prose with code.
- Splits at the docstring/code boundary (line 53/55) into `module-header`
  (prose) and `halving-regular` (the definition + lemma), reaching the
  5-section target.
- No other fields touched — annotations (5/5 with mathContext/significance),
  keyInsights, historicalContext, conclusion, and crossReferences were
  already at target.

## Test plan

- [x] `meta.json` re-serializes as valid JSON
- [x] File size well under the 60 KB cap (19.8 KB)
- [x] New section boundary checked against
      `proofs/Proofs/BinaryGcdOQ03OQ02Incomplete01OQ01.lean`