### PR TITLE
Research: fodor-pressing-down-oq-04 - S13: Part XII omega-family of disjoint stationary sets (docker-verified)

### DIFF
--- a/proofs/Proofs/FodorPressingDown.lean
+++ b/proofs/Proofs/FodorPressingDown.lean
@@ -915,7 +915,7 @@ theorem stationary_splits_binary_aleph1 {S : Set Ordinal.{0}}
 theorem stationary_omega_family_aleph1 {S : Set Ordinal.{0}}
     (hS : IsStationaryBelow S (ℵ₁).ord) :
     ∃ T : ℕ → Set Ordinal,
-      (∀ n, T n ⊆ S) ∧ Pairwise (Disjoint on T) ∧
+      (∀ n, T n ⊆ S) ∧ (∀ m n, m ≠ n → Disjoint (T m) (T n)) ∧
       ∀ n, IsStationaryBelow (T n) (ℵ₁).ord := by
   -- one splitting step, as a choice function on the subtype of stationary sets
   have hstep : ∀ p : {X : Set Ordinal.{0} // IsStationaryBelow X (ℵ₁).ord},
@@ -967,11 +967,11 @@ theorem stationary_omega_family_aleph1 {S : Set Ordinal.{0}}
 theorem stationary_splits_finite_aleph1 {S : Set Ordinal.{0}}
     (hS : IsStationaryBelow S (ℵ₁).ord) (n : ℕ) :
     ∃ T : Fin n → Set Ordinal,
-      (∀ i, T i ⊆ S) ∧ Pairwise (Disjoint on T) ∧
+      (∀ i, T i ⊆ S) ∧ (∀ i j, i ≠ j → Disjoint (T i) (T j)) ∧
       ∀ i, IsStationaryBelow (T i) (ℵ₁).ord := by
   obtain ⟨T, hsub, hdisj, hstat⟩ := stationary_omega_family_aleph1 hS
   exact ⟨fun i => T i.1, fun i => hsub i.1,
-    fun i j hij => hdisj (Fin.val_injective.ne hij), fun i => hstat i.1⟩
+    fun i j hij => hdisj i.1 j.1 (Fin.val_injective.ne hij), fun i => hstat i.1⟩
 
 -- ══════════════════════════════════════════════════════════════════
 -- § Summary and Open Next Steps

--- a/proofs/Proofs/FodorPressingDown.lean
+++ b/proofs/Proofs/FodorPressingDown.lean
@@ -894,6 +894,86 @@ theorem stationary_splits_binary_aleph1 {S : Set Ordinal.{0}}
     isRegular_aleph_one aleph0_lt_aleph_one hS
 
 -- ══════════════════════════════════════════════════════════════════
+-- § Part XII: Countably Many Disjoint Stationary Sets
+-- ══════════════════════════════════════════════════════════════════
+--
+-- Iterating the binary split of Part XI on the second piece yields an
+-- ℕ-indexed family of pairwise disjoint stationary subsets of any
+-- stationary S ⊆ ω₁. This is a strict strengthening of the binary case
+-- and a stepping stone toward the full Solovay theorem (Jech 8.10),
+-- which asks for an exhaustive partition into ℵ₁-many pieces; the
+-- family produced here is countable and need not exhaust S.
+
+/-- **ℵ₀-many pairwise disjoint stationary subsets** of any stationary
+    `S ⊆ ω₁`, by iterating `stationary_splits_binary_aleph1`: split `S`
+    into `T 0 ⊔ R 0`, then `R 0` into `T 1 ⊔ R 1`, and so on. Piece `T m`
+    is disjoint from remainder `R m`, which contains every later piece.
+
+    (Not a partition: the union of the `T n` need not exhaust `S`. The
+    full Solovay theorem — an exhaustive ℵ₁-piece partition — remains
+    open here.) -/
+theorem stationary_omega_family_aleph1 {S : Set Ordinal.{0}}
+    (hS : IsStationaryBelow S (ℵ₁).ord) :
+    ∃ T : ℕ → Set Ordinal,
+      (∀ n, T n ⊆ S) ∧ Pairwise (Disjoint on T) ∧
+      ∀ n, IsStationaryBelow (T n) (ℵ₁).ord := by
+  -- one splitting step, as a choice function on the subtype of stationary sets
+  have hstep : ∀ p : {X : Set Ordinal.{0} // IsStationaryBelow X (ℵ₁).ord},
+      ∃ pair : Set Ordinal × Set Ordinal,
+        pair.1 ⊆ p.1 ∧ pair.2 ⊆ p.1 ∧ Disjoint pair.1 pair.2 ∧
+        IsStationaryBelow pair.1 (ℵ₁).ord ∧
+        IsStationaryBelow pair.2 (ℵ₁).ord := by
+    rintro ⟨X, hX⟩
+    obtain ⟨S₁, S₂, h1, h2, hd, hs1, hs2⟩ := stationary_splits_binary_aleph1 hX
+    exact ⟨(S₁, S₂), h1, h2, hd, hs1, hs2⟩
+  choose q hq1 hq2 hqd hqs1 hqs2 using hstep
+  -- iterate on the remainder (second component)
+  let step : {X : Set Ordinal.{0} // IsStationaryBelow X (ℵ₁).ord} →
+      {X : Set Ordinal.{0} // IsStationaryBelow X (ℵ₁).ord} :=
+    fun p => ⟨(q p).2, hqs2 p⟩
+  let R : ℕ → {X : Set Ordinal.{0} // IsStationaryBelow X (ℵ₁).ord} :=
+    fun n => step^[n] ⟨S, hS⟩
+  have hRsucc : ∀ n, R (n + 1) = step (R n) :=
+    fun n => Function.iterate_succ_apply' step n ⟨S, hS⟩
+  have hRmono : ∀ n, (R (n + 1)).1 ⊆ (R n).1 := by
+    intro n
+    rw [hRsucc]
+    exact hq2 (R n)
+  have hRchain : ∀ m n, m ≤ n → (R n).1 ⊆ (R m).1 := by
+    intro m n hmn
+    induction n, hmn using Nat.le_induction with
+    | base => exact fun x hx => hx
+    | succ k _hk ih => exact fun x hx => ih (hRmono k hx)
+  have hRsub : ∀ n, (R n).1 ⊆ S := fun n => hRchain 0 n (Nat.zero_le n)
+  refine ⟨fun n => (q (R n)).1, fun n => (hq1 (R n)).trans (hRsub n), ?_,
+    fun n => hqs1 (R n)⟩
+  -- pairwise disjointness: piece m is disjoint from remainder m, which
+  -- contains every later piece
+  have key : ∀ m n, m < n → Disjoint (q (R m)).1 (q (R n)).1 := by
+    intro m n hmn
+    have hsub : (q (R n)).1 ⊆ (R (m + 1)).1 :=
+      (hq1 (R n)).trans (hRchain (m + 1) n hmn)
+    have hEq : (R (m + 1)).1 = (q (R m)).2 := by rw [hRsucc]
+    rw [hEq] at hsub
+    exact (hqd (R m)).mono_right hsub
+  intro m n hmn
+  rcases hmn.lt_or_lt with h | h
+  · exact key m n h
+  · exact (key n m h).symm
+
+/-- **Finite Solovay splitting at ω₁**: every stationary `S ⊆ ω₁` contains
+    `n` pairwise disjoint stationary subsets, for every `n : ℕ` — the
+    restriction of the ω-indexed family along `Fin.val`. -/
+theorem stationary_splits_finite_aleph1 {S : Set Ordinal.{0}}
+    (hS : IsStationaryBelow S (ℵ₁).ord) (n : ℕ) :
+    ∃ T : Fin n → Set Ordinal,
+      (∀ i, T i ⊆ S) ∧ Pairwise (Disjoint on T) ∧
+      ∀ i, IsStationaryBelow (T i) (ℵ₁).ord := by
+  obtain ⟨T, hsub, hdisj, hstat⟩ := stationary_omega_family_aleph1 hS
+  exact ⟨fun i => T i.1, fun i => hsub i.1,
+    fun i j hij => hdisj (Fin.val_injective.ne hij), fun i => hstat i.1⟩
+
+-- ══════════════════════════════════════════════════════════════════
 -- § Summary and Open Next Steps
 -- ══════════════════════════════════════════════════════════════════
 
@@ -930,14 +1010,21 @@ Key results:
   ✓ `exists_omegaSeq_high_fibers_stationary`: unbounded-index pigeonhole (production step)
   ✓ `stationary_splits_binary_of_cof_omega`: binary Solovay split, ω-cofinal case
   ✓ `stationary_splits_binary_aleph1`: **binary Solovay splitting at ω₁** (0 sorries)
+  ✓ `stationary_omega_family_aleph1`: ℵ₀-many pairwise disjoint stationary subsets
+    of any stationary S ⊆ ω₁ (iterated splitting; not a partition)
+  ✓ `stationary_splits_finite_aleph1`: n pairwise disjoint stationary subsets
+    for every n : ℕ (restriction along Fin.val)
 
 Sorries remaining: 0
 
-Open next step: the full κ-piece Solovay partition (Jech 8.10) — iterate the
-Part XI production step across κ-many target values (the binary case is done;
-the κ-partition needs the counting/bookkeeping layer), and extend past the
-ω-cofinal case to general regular κ (requires the cf α < α trace analysis;
-at ω₁ every limit is ω-cofinal so the theorem there is complete).
+Open next step: the full κ-piece Solovay partition (Jech 8.10) — an
+*exhaustive* partition into ℵ₁-many stationary pieces. The iterated binary
+split (Part XII) produces countably many disjoint pieces but neither
+exhausts S nor reaches length ω₁ (the remainder chain has no useful limit
+stage without new ideas: ⋂ₙ Rₙ can be non-stationary). The κ-partition
+needs the counting/bookkeeping layer over the Part XI production step, and
+the general-κ case additionally needs the cf α < α trace analysis (at ω₁
+every limit is ω-cofinal so the theorem there is complete).
 
 Connection to parent (CantorDiagonalizationOQ02OQ03):
   The parent proves that for regular uncountable κ, ordinals below κ.ord cannot

--- a/proofs/Proofs/FodorPressingDown.lean
+++ b/proofs/Proofs/FodorPressingDown.lean
@@ -957,7 +957,7 @@ theorem stationary_omega_family_aleph1 {S : Set Ordinal.{0}}
     rw [hEq] at hsub
     exact (hqd (R m)).mono_right hsub
   intro m n hmn
-  rcases hmn.lt_or_lt with h | h
+  rcases lt_or_gt_of_ne hmn with h | h
   · exact key m n h
   · exact (key n m h).symm
 

--- a/research/problems/fodor-pressing-down-oq-04/sessions/2026-07-24-s13-act-omega-family.md
+++ b/research/problems/fodor-pressing-down-oq-04/sessions/2026-07-24-s13-act-omega-family.md
@@ -1,0 +1,51 @@
+# S13 ACT — Part XII: ℵ₀-many pairwise disjoint stationary subsets of ω₁
+
+**Date**: 2026-07-24
+**Researcher**: researcher-2
+**Mode**: ACT (substantive Lean delivery, Docker-verified)
+**Branch**: `research/fodor-oq04-s13-omega-family`
+
+## 1. What shipped
+
+New Part XII of `proofs/Proofs/FodorPressingDown.lean` (955 → 1042 lines,
+24 → 26 theorems, 0 sorries, 0 axioms), iterating the S12 binary split:
+
+- `stationary_omega_family_aleph1` — every stationary `S ⊆ ω₁` contains an
+  ℕ-indexed family of **pairwise disjoint stationary** subsets. Construction:
+  `choose` a splitting function on the subtype of stationary sets from
+  `stationary_splits_binary_aleph1`, iterate it on the remainder with
+  `Function.iterate` (`R n = step^[n] ⟨S, hS⟩`), take pieces
+  `T n = (q (R n)).1`. Disjointness: piece `m` is disjoint from remainder
+  `m`, which contains every later piece (chain lemma by `Nat.le_induction`).
+- `stationary_splits_finite_aleph1` — `n` pairwise disjoint stationary
+  subsets for every `n : ℕ`, by restriction along `Fin.val`.
+
+## 2. Honesty block
+
+- This is a **strict strengthening of the binary case** but NOT the full
+  Solovay theorem (Jech 8.10): the family is countable (not ℵ₁-many pieces)
+  and is **not a partition** — the union need not exhaust `S`
+  (⋂ₙ Rₙ can be non-stationary, and no limit-stage extraction is attempted).
+  The docstrings state this explicitly.
+- The mathematical work is plumbing (choice + iteration + chain lemma) on
+  top of S12's binary split; no new set-theoretic ideas.
+
+## 3. Lean notes
+
+- `Pairwise (Disjoint on T)` FAILED to elaborate in this file (`Disjoint on
+  T` elaborates to `Prop` — ambiguity from the file's `open Cardinal Order
+  Ordinal Set`). Used the explicit form
+  `∀ m n, m ≠ n → Disjoint (T m) (T n)` instead. Second build repair:
+  `hmn.lt_or_lt` dot-call failed to resolve — use `lt_or_gt_of_ne hmn`.
+  Two fix commits total after the pre-build commit.
+- Dependent iteration via subtype `{X // IsStationaryBelow X (ℵ₁).ord}` +
+  `Function.iterate_succ_apply'` avoids any well-founded recursion.
+- `choose q hq1 hq2 hqd hqs1 hqs2 using hstep` on a `∃ pair : Set × Set`
+  packaged existential gives clean spec lemmas.
+
+## 4. Remaining open (unchanged difficulty)
+
+- Full κ-piece Solovay partition: needs length-ω₁ transfinite bookkeeping
+  (the ω-family here has no useful limit stage) — full sessions.
+- General regular κ: Jech 8.10 trace analysis for the non-ω-cofinal part
+  (vacuous at ω₁).

--- a/research/problems/fodor-pressing-down-oq-04/state.md
+++ b/research/problems/fodor-pressing-down-oq-04/state.md
@@ -1,9 +1,24 @@
 # State — fodor-pressing-down-oq-04
 
-## Phase: ACT (S12 — binary Solovay splitting at ω₁ PROVED; blocker discharged)
+## Phase: ACT (S13 — Part XII ω-family of disjoint stationary sets; next = full Solovay partition, DEEP)
 
-> **Iteration**: 12
-> **Last Updated**: 2026-07-24 (S12 ACT — researcher-2).
+> **Iteration**: 13
+> **Last Updated**: 2026-07-24 (S13 ACT — researcher-2).
+
+### S13 ACT (researcher-2, 2026-07-24) — ℵ₀-many disjoint stationary subsets
+
+Iterated the S12 binary split on the remainder: new Part XII delivers
+`stationary_omega_family_aleph1` (ℕ-indexed pairwise disjoint stationary
+subsets of any stationary S ⊆ ω₁; **not** a partition — union need not
+exhaust S) and `stationary_splits_finite_aleph1` (n pieces for every n, via
+`Fin.val`). 955 → 1042 lines, 24 → 26 theorems, 0 sorries, 0 axioms,
+Docker-verified. Construction: `choose` on the stationary subtype +
+`Function.iterate` on the remainder + `Nat.le_induction` chain lemma.
+Gotcha: `Pairwise (Disjoint on T)` does not elaborate under this file's
+opens — use the explicit `∀ m n, m ≠ n → Disjoint (T m) (T n)`.
+See `sessions/2026-07-24-s13-act-omega-family.md`. Remaining: full ℵ₁-piece
+exhaustive partition (needs limit-stage ideas beyond the ω-iteration) and
+general-κ trace analysis — both DEEP, full sessions.
 
 ### S12 ACT (researcher-2, 2026-07-24) — UNBLOCKED: binary split proved at ω₁
 

--- a/src/data/proofs/fodor-pressing-down/meta.json
+++ b/src/data/proofs/fodor-pressing-down/meta.json
@@ -19,8 +19,8 @@
     ],
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 653,
-    "theoremCount": 14,
+    "lineCount": 1042,
+    "theoremCount": 26,
     "definitionCount": 1
   },
   "overview": {
@@ -251,10 +251,10 @@
   ],
   "leanFile": {
     "path": "Proofs/FodorPressingDown.lean",
-    "lineCount": 955,
+    "lineCount": 1042,
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 24,
+    "theoremCount": 26,
     "definitionCount": 2,
     "imports": [
       "import Mathlib.SetTheory.Cardinal.Ordinal",


### PR DESCRIPTION
## Summary

S13 ACT for `fodor-pressing-down-oq-04` (Solovay splitting): iterates the S12 binary split (#43103, merged this morning) into a new **Part XII** of `proofs/Proofs/FodorPressingDown.lean`, Docker-verified.

- **Build**: `./proofs/scripts/docker-build.sh Proofs.FodorPressingDown` — 2974 jobs, exit 0 (v4.31.0)
- **File**: 955 -> 1042 lines, 24 -> 26 theorems, **0 sorries, 0 axioms** (unchanged)

### New theorems (namespace `FodorPressingDown`)

| Theorem | Content |
|---------|---------|
| `stationary_omega_family_aleph1` | Every stationary S ⊆ ω₁ contains an ℕ-indexed family of pairwise disjoint stationary subsets — `choose` a splitting function on the subtype of stationary sets, iterate on the remainder via `Function.iterate`, chain lemma by `Nat.le_induction` |
| `stationary_splits_finite_aleph1` | n pairwise disjoint stationary subsets for every n, by restriction along `Fin.val` |

Also syncs the stale nested `meta` counts in the gallery entry (theoremCount 14 -> 26, lineCount 653 -> 1042; predated S12).

### Honesty block

- Strict strengthening of the binary case, but **not** the full Solovay theorem (Jech 8.10): the family is countable (not ℵ₁ pieces) and is **not a partition** — the union need not exhaust S. Docstrings and the summary block state this explicitly.
- The set-theoretic content is S12's; this session's work is choice/iteration plumbing on top of it.
- Two build repairs after the pre-build commit: `Pairwise (Disjoint on T)` fails to elaborate under this file's opens (used the explicit ∀-form), and `Ne.lt_or_lt` dot-call did not resolve (used `lt_or_gt_of_ne`).

Session note: `research/problems/fodor-pressing-down-oq-04/sessions/2026-07-24-s13-act-omega-family.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
