### PR TITLE
audit(erdos-25): fix stale crossReferences/annotation refs to removed axiom

### DIFF
--- a/src/data/proofs/erdos-25/annotations.json
+++ b/src/data/proofs/erdos-25/annotations.json
@@ -116,30 +116,6 @@
     ]
   },
   {
-    "id": "erdos-25-coprime-positive",
-    "proofId": "erdos-25",
-    "type": "insight",
-    "range": {
-      "startLine": 100,
-      "endLine": 105
-    },
-    "title": "Positive Density Under Coprimality",
-    "content": "When all moduli are pairwise coprime, the logarithmic density (if it exists) is strictly positive, since each congruence class removes only a 1/nᵢ fraction.",
-    "mathContext": "If the moduli are pairwise coprime and $d = \\delta_\\ell(A(\\sigma))$ exists, then $d > 0$. By CRT independence, $d \\approx \\prod_{i} (1 - 1/n_i)$. Since $n_i$ are strictly increasing positive integers, $\\sum 1/n_i < \\infty$ is not guaranteed, but the strict monotonicity $n_i \\ge i$ gives $\\sum 1/n_i \\le \\sum 1/i = \\infty$. Under coprimality, the product $\\prod(1-1/n_i)$ converges to a positive value when $\\sum 1/n_i < \\infty$; the axiom covers this case.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "Chinese Remainder Theorem",
-      "Euler product",
-      "Mertens' theorem",
-      "infinite products"
-    ],
-    "prerequisites": [
-      "Nat.Coprime",
-      "logDensity axiom",
-      "product convergence"
-    ]
-  },
-  {
     "id": "erdos-25-monotone",
     "proofId": "erdos-25",
     "type": "insight",

--- a/src/data/proofs/erdos-25/meta.json
+++ b/src/data/proofs/erdos-25/meta.json
@@ -135,7 +135,7 @@
     {
       "targetId": "chinese-remainder-constructive",
       "relationship": "foundational",
-      "description": "CRT provides the independence framework for coprime sieves: when moduli are pairwise coprime, the exclusion events $m \\equiv a_i \\pmod{n_i}$ are independent, so $\\delta_\\ell(A) \\approx \\prod(1 - 1/n_i)$. The axiom `sieve_density_positive` relies on this CRT-based analysis"
+      "description": "CRT provides the independence framework for coprime sieves: when moduli are pairwise coprime, the exclusion events $m \\equiv a_i \\pmod{n_i}$ are independent in the finite case, suggesting $\\delta_\\ell(A) \\approx \\prod(1 - 1/n_i)$. This heuristic was formerly stated as an axiom (`sieve_density_positive`) but the axiom was removed after a counterexample was found (prime moduli leave only $\\{1\\}$, density 0), so the file no longer relies on any CRT-independence axiom"
     },
     {
       "targetId": "prime-number-theorem",
@@ -150,7 +150,7 @@
     {
       "targetId": "fundamental-arithmetic",
       "relationship": "foundational",
-      "description": "Unique prime factorization underpins the multiplicative structure that makes coprime sieve analysis via CRT possible. The coprimality hypothesis in `sieve_density_positive` is meaningful precisely because of FTA"
+      "description": "Unique prime factorization underlies the counterexample that falsified the file's original density-positivity conjecture: taking $n_i$ to be the $i$-th prime gives pairwise-coprime moduli (by FTA) whose sieved set is nonetheless only $\\{1\\}$, i.e. density 0, not positive. The formerly-stated `sieve_density_positive` axiom was removed as a result"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-25
**Problem**: `meta.json` crossReferences and an `annotations.json` insight still describe the `sieve_density_positive` axiom as existing and mathematically valid, but it was removed from `Proofs/Erdos25Problem.lean` in May 2026 (commit ecb47b3560) after a counterexample showed it FALSE.

## Evidence

**meta.json claims** (crossReferences):
- `chinese-remainder-constructive`: "The axiom `sieve_density_positive` relies on this CRT-based analysis"
- `fundamental-arithmetic`: "The coprimality hypothesis in `sieve_density_positive` is meaningful precisely because of FTA"

**annotations.json claims** (`erdos-25-coprime-positive`, lines 100-105): "the logarithmic density (if it exists) is strictly positive... the axiom covers this case."

**Lean file shows** (`Proofs/Erdos25Problem.lean:147-153`, comment): the axiom was mathematically false — taking `seq_n i = pᵢ` (i-th prime) gives pairwise-coprime moduli but the sieved set is `{1}` (density 0, not positive). No `axiom` declarations exist in the file (`grep '^axiom'` → 0 hits). The file's own `membership-bounds` section (meta.json) and `erdos-25-membership` annotation already correctly document this removal — the stale entries elsewhere just weren't updated when the axiom was deleted.

Additionally the stale annotation's line range (100-105) no longer even points at the right content — those lines are now part of the `finite_sieve_density_exists` docstring, not a coprimality-positivity claim.

## Fix Applied

- Rewrote both crossReferences descriptions to describe the counterexample instead of citing a nonexistent, falsified axiom.
- Deleted the stale `erdos-25-coprime-positive` annotation (redundant with the correct counterexample writeup already in `erdos-25-membership`).
- No count fields (axiomCount, sorries, theoremCount, definitionCount, lineCount) needed changes — those were already accurate.

---
Discovered during gallery integrity audit (round-robin re-serve, queue fully drained).