### PR TITLE
Enrich binomial-theorem-oq-01-oq-01-oq-03: cover header docstring (4->5)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-03/meta.json
@@ -86,6 +86,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Statement: The Closed Form at α = -1/2",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Module docstring stating the open question — the general closed form C(-1/2,k) = (-1)^k·C(2k,k)/4^k, connecting the negative half-integer binomial coefficient to central binomial and Catalan coefficients — and outlining the matching-ratios proof strategy that pairs the parent's ode_recurrence with Mathlib's central-binomial recurrence via a single linear_combination.",
+      "mathContext": "$\\binom{-1/2}{k} = (-1)^k\\binom{2k}{k}/4^k$: the Taylor coefficients of $1/\\sqrt{1+x}$, generalizing the parent's small-$k$ evaluation of $\\binom{1/2}{k}$ to a uniform closed form."
+    },
+    {
       "id": "central-recurrence",
       "title": "The Central-Binomial Recurrence over ℝ",
       "startLine": 52,


### PR DESCRIPTION
## Summary

- Entry's 4 sections covered lines 52-150; lines 1-51 (module docstring
  stating the open question and proof strategy) had no section coverage.
- Adds a `header` section (lines 1-51) so sections now cover the full
  152-line file, reaching the 5-section target.
- No other fields touched — annotations (9/9 with mathContext/significance),
  keyInsights (5), historicalContext, conclusion, and crossReferences were
  already at target.

## Test plan

- [x] `meta.json` re-serializes as valid JSON
- [x] File size well under the 60 KB cap (13.6 KB)
- [x] New section's line range checked against
      `proofs/Proofs/BinomialTheoremOQ01OQ01OQ03.lean`