### PR TITLE
Enrich binomial-theorem-oq-02-oq-01-oq-01-incomplete-01: 5th keyInsight

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-incomplete-01/meta.json
@@ -39,7 +39,8 @@
       "The singularity has a one-line cause: on the support of the multinomial every composition k satisfies ∑ⱼkⱼ=n, so the centered partner sum ∑ⱼ(kⱼ−n·pⱼ) collapses to n−n·1=0. No cancellation between distinct covariance entries is required — the row sum vanishes term by term.",
       "This is the linear-algebra dual of the negative-correlation fact: Cov(Xᵢ,Xⱼ)=−n·pᵢ·pⱼ<0 for i≠j is exactly what is needed for the rows npᵢ(1−pᵢ) − ∑_{j≠i}npᵢpⱼ = 0 to vanish.",
       "Var(Xᵢ)=−∑_{j≠i}Cov(Xᵢ,Xⱼ): the diagonal of Σ is determined by its off-diagonals. This gives a third, purely structural derivation of the variance npᵢ(1−pᵢ) — complementary to the MGF route (BinomialTheoremOQ02OQ01) and the binomial-marginal route (BinomialTheoremOQ02OQ01OQ04).",
-      "Rank Σ ≤ |s|−1 is the formal content behind dropping a baseline category in multinomial logistic regression: the full covariance/information matrix is never invertible."
+      "Rank Σ ≤ |s|−1 is the formal content behind dropping a baseline category in multinomial logistic regression: the full covariance/information matrix is never invertible.",
+      "multinomial_cov_total_sum_zero (∑ᵢⱼCov(Xᵢ,Xⱼ)=0) is not a separate argument but a one-line corollary of the row-sum theorem — summing the already-zero rows over i — and it reads directly as Var(∑ᵢXᵢ)=0, the variance-level statement that the total count n is deterministic."
     ],
     "prerequisites": [
       "Multinomial distribution and its covariance Cov(Xᵢ,Xⱼ)=−n·pᵢ·pⱼ (parent file)",


### PR DESCRIPTION
## Summary

- `overview.keyInsights` had 4 items (target: 5+).
- Adds a genuine 5th insight grounded in the already-proved
  `multinomial_cov_total_sum_zero`: it is a one-line corollary of the
  row-sum theorem (`Finset.sum_eq_zero` over the already-zero rows), and
  reads directly as `Var(∑ᵢXᵢ) = 0` — the variance-level statement that the
  total trial count `n` is deterministic.
- No other fields touched — annotations (5/5 with mathContext/significance),
  sections (5), historicalContext, conclusion, and crossReferences were
  already at target.

## Test plan

- [x] `meta.json` re-serializes as valid JSON
- [x] File size well under the 60 KB cap (12.8 KB)
- [x] New insight checked against `multinomial_cov_total_sum_zero` in
      `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01Incomplete01.lean`