### PR TITLE
chore(audit-tracker): mark erdos-1014-oq-02 audited (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8827,9 +8827,9 @@
       "agentId": "auditor-agent-7"
     },
     "erdos-1014-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:51Z",
+      "lastAudited": "2026-07-24T07:08:04Z",
       "result": "clean"
     },
     "erdos-1015": {


### PR DESCRIPTION
## Summary
- Re-audited erdos-1014-oq-02 (round-robin re-serve, queue was fully drained).
- Verified 12 disclosed axioms match Erdos1014Problem.lean exactly, 0 sorries, no native_decide, theorem types match meta.json's mainTheorems, and delegation to `ratio_from_asymptotics` is honestly credited (not phantom).
- Result: clean, no integrity issues found.

## Test plan
- [x] Reviewed proofs/Proofs/Erdos1014OQ02.lean and Erdos1014Problem.lean line-by-line against meta.json claims