### PR TITLE
Enrich bernoulli-inequality-oq-01-oq-01: 5th keyInsight (98->100)

### DIFF
--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-01/meta.json
@@ -67,7 +67,8 @@
       "**The sign change of $1 + a$ is the real obstruction, not the sign of $a$.** The parent's induction needs $1 + a > 0$; it has nothing to say once $a \\le -1$. The extension is therefore not a cosmetic widening — it requires a genuinely different argument on $-2 \\le a \\le -1$.",
       "**On the negative tail the power is trapped in $[-1,1]$ while the line escapes.** Because $|1+a| \\le 1$, the power $(1+a)^n$ never leaves $[-1,1]$; but the linear lower bound $1 + na$ falls to $1 - n$, which is below $-1$ as soon as $n \\ge 3$. The inequality then holds for the blunt reason that the line has dropped beneath the entire range of the power.",
       "**Only $n = 2$ resists the size argument, and it needs none.** At $n = 2$ the gap is exactly $a^2$, positive for every $a \\ne 0$ — so the boundary case is the most elementary one, valid even at $a = -2$.",
-      "**Matching Mathlib's reach.** The result now holds precisely on $-2 \\le a$, the domain of `one_add_mul_le_pow`, so the strict integer-power Bernoulli is available wherever the weak one is."
+      "**Matching Mathlib's reach.** The result now holds precisely on $-2 \\le a$, the domain of `one_add_mul_le_pow`, so the strict integer-power Bernoulli is available wherever the weak one is.",
+      "**The two `iff` lemmas are corollaries, not new theorems.** Once `one_add_mul_lt_pow_full` is in hand, both sharp characterizations fall out mechanically: the failure direction of `one_add_mul_lt_pow_full_iff` only needs `interval_cases n` on the finitely many $n \\le 1$ (checked by `simp`) plus the trivial $a = 0$ case, and the forward direction of `one_add_mul_eq_pow_full_iff` is exactly the strict inequality read as $\\neg(=)$ by contradiction. No independent argument is needed for either boundary — the hard work was entirely in extending the strict inequality itself."
     ],
     "prerequisites": [
       "The weak Bernoulli inequality one_add_mul_le_pow on −2 ≤ a",


### PR DESCRIPTION
## Summary

`bernoulli-inequality-oq-01-oq-01` (strict Bernoulli on Mathlib's full weak domain −2 ≤ a) had only 4 `keyInsights`, scoring 8/10 on that axis (98/100 overall) — every other quality axis was already at target.

Added a 5th keyInsight noting that the file's two `iff` characterization lemmas (`one_add_mul_lt_pow_full_iff`, `one_add_mul_eq_pow_full_iff`) are corollaries rather than independent arguments: their harder directions reduce to `interval_cases n` on the finitely many small n, or to reading the main strict inequality as a negation — all the substantive work lives in `one_add_mul_lt_pow_full` itself. This is verified directly against the Lean source (`proofs/Proofs/BernoulliInequalityOQ01OQ01.lean` lines 94-121).

No other fields changed. `meta.json` remains well under the size cap (14.1 KB).

## Test plan

- [x] `meta.json` validated as well-formed JSON
- [x] `pnpm gallery:check-size` — all entries within caps
- [x] `pnpm gallery:check-verified-companions` — passes
- [x] `find-targets.ts` now scores this entry 100/100 (was 98/100)