### PR TITLE
Gallery integrity: continuum-hypothesis-oq-02 phantom easton_regular_consistency claim

### DIFF
--- a/src/data/proofs/continuum-hypothesis-oq-02/meta.json
+++ b/src/data/proofs/continuum-hypothesis-oq-02/meta.json
@@ -57,7 +57,7 @@
     "originalContributions": [
       "Proved aleph_omega_cof_eq_omega from Mathlib (Cardinal.cof_aleph + Ordinal.card_omega0)",
       "Proved bounding_le_dominating from dominating_implies_unbounded via Cardinal infimum reasoning",
-      "Proved easton_regular_consistency (conclusion was trivially True)",
+      "Easton's full consistency theorem is noted in prose only (no `easton_regular_consistency` Lean declaration exists — Con(ZFC + 2^aleph_0 = kappa) is a metamathematical statement outside Lean's type theory); the ZFC-provable spectrum facts are formalized directly (successor_alephs_possible, aleph_one_is_possible, aleph_two_is_possible, aleph_three_is_possible, aleph_omega_not_possible)",
       "Converted MartinsAxiom from axiom to opaque (removes from axiom environment)",
       "Formal proof that aleph_omega is singular (from cofinality + regularity API)",
       "Konig's cofinality constraint on the continuum: cf(2^aleph_0) > aleph_0",


### PR DESCRIPTION
## Integrity Issue

**Proof**: continuum-hypothesis-oq-02
**Problem**: `originalContributions` in meta.json claims "Proved easton_regular_consistency (conclusion was trivially True)" but `easton_regular_consistency` is not a Lean declaration anywhere in `proofs/Proofs/ContinuumHypothesisOQ02.lean` — it only appears as a dangling docstring/comment name (lines 33, 207-208), never as an actual `theorem`/`def`.

## Evidence

**meta.json claims**: "Proved easton_regular_consistency (conclusion was trivially True)" — implies a real, trivially-proved Lean declaration.

**Lean file shows**: no `theorem easton_regular_consistency` or `def easton_regular_consistency` exists; the name only labels a `/- ... -/` comment explaining that Easton's full consistency statement (Con(ZFC + 2^aleph_0 = kappa)) can't be formalized in Lean's type theory without model theory. The actual ZFC-provable content is carried by real theorems: `successor_alephs_possible`, `aleph_one_is_possible`, `aleph_two_is_possible`, `aleph_three_is_possible`, `aleph_omega_not_possible`.

`annotations.json` already describes this correctly: "Easton's actual theorem ... is represented by the comment `easton_regular_consistency` with conclusion `True`" — meta.json didn't match that accurate framing.

## Fix

Reworded the `originalContributions` entry to state the fact is prose-only (no such declaration exists) and to point at the real declarations that carry the formalized ZFC-provable spectrum facts, matching annotations.json's existing accurate description.

All other counts/claims in this entry were verified correct: axiomCount 3 (2 `axiom` + 1 `opaque`), theoremCount 32, definitionCount 6, 0 sorries, no native_decide, no unfair True-stub theorems (the one `:= True` is the honestly-disclosed opaque `MartinsAxiom`).

---
Discovered during gallery integrity audit.