### PR TITLE
chore(audit-tracker): mark continuum-hypothesis-oq-02 audited (issues-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6645,10 +6645,10 @@
       "result": "clean"
     },
     "continuum-hypothesis-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:51Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T07:15:29Z",
+      "result": "issues-fixed"
     },
     "cramers-rule": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Tracker update for the audit of continuum-hypothesis-oq-02. Issue found and fixed in #43162 (phantom `easton_regular_consistency` claim in `originalContributions`).