### PR TITLE
Research: fermat-defect-one-oq-02 - positive-sign-pinned infinitude at n=3

### DIFF
--- a/proofs/Proofs/FermatDefectOneFamilies.lean
+++ b/proofs/Proofs/FermatDefectOneFamilies.lean
@@ -182,118 +182,25 @@ theorem defect_pos_witnesses_infinite :
     exact ⟨9 * (n + 2) ^ 3 + 1, 9 * (n + 2) ^ 4,
       defect_pos_witness_ge_two (n + 2) (by omega)⟩
 
-/-! ## Sign-specific infinitude at n = 3
+/-! ## Positive-sign-pinned infinitude at n = 3
 
 `defect_pos_witnesses_infinite` above shows the *sign-agnostic* witness set is
-infinite (its members happen to come from the positive family). OQ-02 asks
-about each sign separately, so we now upgrade BOTH `fermat_defect_three_negative`
-and `fermat_defect_three_positive` (existence, in `FermatDefectOne.lean`) to
-infinitude, with the defect sign pinned in the set comprehension rather than
-hidden inside the `FermatDefectWitness` disjunction.
+infinite: its members come from the positive family, but the statement hides
+the sign inside the `FermatDefectWitness` disjunction. OQ-02 asks about each
+sign separately. The negative side is sign-pinned and infinite in
+`FermatDefectOneNegInfinitude.lean` (`defect_neg_witnesses_infinite`); here we
+add the missing positive-side counterpart, pinning `a³ + b³ = c³ + 1` in the
+set comprehension. (The ℤ sign-flip involution of `FermatDefectOneOQ06.lean`
+does not transport primitive ordered ℕ witnesses, so neither sign-pinned
+statement follows formally from the other.) -/
 
-The negative family `(9t³−1, 9t⁴−3t, 9t⁴)` needs `ℕ`-subtraction care that the
-positive family avoided: the primitivity kernel goes through
-`t·(9t³−1) + t = 9t⁴` (subtraction eliminated by regrouping), and the cubic
-identity is transported from `ℤ` via `zify`. As with the positive family, the
-ordering `a ≤ b` holds from parameter `2` on (at `t = 1` the family gives
-`(8, 6, 9)`, base terms flipped), so witnesses are indexed by `t ≥ 2`. -/
-
-/-- **Negative-family primitivity kernel.** `9t³ − 1` and `9t⁴` are coprime for
-every `t ≥ 1`. Proof: a common divisor `d` divides `t·(9t³−1) + t = 9t⁴`, hence
-divides `t`, hence divides `9t³ = (9t³−1) + 1`, hence divides `1`. Truncated
-subtraction never bites: the only fact used about `9t³ − 1` is
-`(9t³ − 1) + 1 = 9t³`, valid since `t ≥ 1`. -/
-lemma neg_family_gcd (t : ℕ) (ht : 1 ≤ t) :
-    Nat.gcd (9 * t ^ 3 - 1) (9 * t ^ 4) = 1 := by
-  have hcube : 1 ≤ 9 * t ^ 3 := by
-    have h1 : 1 ≤ t ^ 3 := Nat.one_le_pow 3 t ht
-    omega
-  have hA : (9 * t ^ 3 - 1) + 1 = 9 * t ^ 3 := by omega
-  set d := Nat.gcd (9 * t ^ 3 - 1) (9 * t ^ 4) with hd
-  have h1 : d ∣ 9 * t ^ 3 - 1 := Nat.gcd_dvd_left _ _
-  have h2 : d ∣ 9 * t ^ 4 := Nat.gcd_dvd_right _ _
-  have h3 : d ∣ t := by
-    have hds : t * (9 * t ^ 3 - 1) + t = 9 * t ^ 4 := by
-      calc t * (9 * t ^ 3 - 1) + t = t * ((9 * t ^ 3 - 1) + 1) := by ring
-        _ = t * (9 * t ^ 3) := by rw [hA]
-        _ = 9 * t ^ 4 := by ring
-    have hdt : d ∣ t * (9 * t ^ 3 - 1) + t := by rw [hds]; exact h2
-    exact (Nat.dvd_add_right (h1.mul_left t)).mp hdt
-  have h4 : d ∣ (9 * t ^ 3 - 1) + 1 := by
-    rw [hA]
-    have he : 9 * t ^ 3 = 9 * t ^ 2 * t := by ring
-    rw [he]; exact h3.mul_left (9 * t ^ 2)
-  have h6 : d ∣ 1 := (Nat.dvd_add_right h1).mp h4
-  exact Nat.dvd_one.mp h6
-
-/-- **Generic negative-defect primitive witness.** For every `t ≥ 2`,
-`(9t³−1, 9t⁴−3t, 9t⁴)` satisfies all witness conditions with the defect sign
-pinned to −1 (`a³ + b³ + 1 = c³`, no disjunction). At `t = 2` this is
-`(71, 138, 144)` (`fermat_defect_three_neg_t2`). -/
-theorem defect_neg_witness_parts (t : ℕ) (ht : 2 ≤ t) :
-    2 ≤ 9 * t ^ 3 - 1 ∧ 9 * t ^ 3 - 1 ≤ 9 * t ^ 4 - 3 * t ∧
-    9 * t ^ 4 - 3 * t < 9 * t ^ 4 ∧
-    Nat.gcd (Nat.gcd (9 * t ^ 3 - 1) (9 * t ^ 4 - 3 * t)) (9 * t ^ 4) = 1 ∧
-    (9 * t ^ 3 - 1) ^ 3 + (9 * t ^ 4 - 3 * t) ^ 3 + 1 = (9 * t ^ 4) ^ 3 := by
-  have hx : (8 : ℕ) ≤ t ^ 3 := by
-    calc (8 : ℕ) = 2 ^ 3 := by norm_num
-      _ ≤ t ^ 3 := Nat.pow_le_pow_left ht 3
-  have e2 : 2 * t ^ 3 ≤ t ^ 4 := by
-    calc 2 * t ^ 3 ≤ t * t ^ 3 := mul_le_mul_right' ht (t ^ 3)
-      _ = t ^ 4 := by ring
-  have ht3 : t ≤ t ^ 3 := Nat.le_self_pow (by norm_num) t
-  refine ⟨by omega, by omega, by omega, ?_, ?_⟩
-  · -- primitivity: any divisor of the full gcd divides both a and c,
-    -- hence divides gcd(a, c) = 1 by the kernel.
-    have hdvd : Nat.gcd (Nat.gcd (9 * t ^ 3 - 1) (9 * t ^ 4 - 3 * t)) (9 * t ^ 4) ∣
-        Nat.gcd (9 * t ^ 3 - 1) (9 * t ^ 4) :=
-      Nat.dvd_gcd ((Nat.gcd_dvd_left _ _).trans (Nat.gcd_dvd_left _ _))
-        (Nat.gcd_dvd_right _ _)
-    rw [neg_family_gcd t (by omega)] at hdvd
-    exact Nat.dvd_one.mp hdvd
-  · -- the cubic identity, transported from ℤ (`defect_neg_family`) via zify
-    have h1 : 1 ≤ 9 * t ^ 3 := by omega
-    have h2 : 3 * t ≤ 9 * t ^ 4 := by omega
-    zify [h1, h2]
-    ring
-
-/-- The generic negative witness, packaged as `FermatDefectWitness` (left
-disjunct). -/
-theorem defect_neg_witness_ge_two (t : ℕ) (ht : 2 ≤ t) :
-    FermatDefectWitness 3 (9 * t ^ 3 - 1) (9 * t ^ 4 - 3 * t) (9 * t ^ 4) := by
-  obtain ⟨ha, hab, hbc, hgcd, hid⟩ := defect_neg_witness_parts t ht
-  exact ⟨ha, hab, hbc, hgcd, Or.inl hid⟩
-
-/-- **Negative-sign infinitude at n = 3.** The set of `c` occurring in a
-primitive witness with defect exactly −1 (`a³ + b³ + 1 = c³`) is infinite —
-a strict strengthening of `fermat_defect_three_negative` (existence), and
-sign-pinned where `defect_pos_witnesses_infinite` is sign-agnostic. Injection
-`t ↦ 9(t+2)⁴`, strictly monotone, witnessed by `defect_neg_witness_parts`. -/
-theorem defect_neg_sign_witnesses_infinite :
-    {c : ℕ | ∃ a b : ℕ, 2 ≤ a ∧ a ≤ b ∧ b < c ∧
-      Nat.gcd (Nat.gcd a b) c = 1 ∧ a ^ 3 + b ^ 3 + 1 = c ^ 3}.Infinite := by
-  apply Set.infinite_of_injective_forall_mem
-    (f := fun n : ℕ => 9 * (n + 2) ^ 4)
-  · have hmono : StrictMono (fun n : ℕ => 9 * (n + 2) ^ 4) := by
-      apply strictMono_nat_of_lt_succ
-      intro n
-      show 9 * (n + 2) ^ 4 < 9 * (n + 1 + 2) ^ 4
-      have hp : (n + 2) ^ 4 < (n + 1 + 2) ^ 4 :=
-        Nat.pow_lt_pow_left (by omega) (by norm_num)
-      omega
-    exact hmono.injective
-  · intro n
-    show ∃ a b : ℕ, 2 ≤ a ∧ a ≤ b ∧ b < 9 * (n + 2) ^ 4 ∧
-      Nat.gcd (Nat.gcd a b) (9 * (n + 2) ^ 4) = 1 ∧
-      a ^ 3 + b ^ 3 + 1 = (9 * (n + 2) ^ 4) ^ 3
-    exact ⟨9 * (n + 2) ^ 3 - 1, 9 * (n + 2) ^ 4 - 3 * (n + 2),
-      defect_neg_witness_parts (n + 2) (by omega)⟩
-
-/-- **Positive-sign infinitude at n = 3.** The sign-pinned (`a³ + b³ = c³ + 1`)
-counterpart, upgrading `fermat_defect_three_positive` to infinitude via the
-positive family. Together with `defect_neg_sign_witnesses_infinite` this
-settles OQ-02 at n = 3 in its strongest form: EACH defect sign is realised by
-infinitely many primitive witnesses. -/
+/-- **Positive-sign infinitude at n = 3.** The set of `c` occurring in a
+primitive witness with defect exactly +1 (`a³ + b³ = c³ + 1`) is infinite —
+upgrading `fermat_defect_three_positive` (existence) to infinitude via the
+positive family. Together with `defect_neg_witnesses_infinite`
+(`FermatDefectOneNegInfinitude.lean`) this settles OQ-02 at n = 3 in its
+strongest form: EACH defect sign is realised by infinitely many primitive
+witnesses, with the sign pinned in the statement. -/
 theorem defect_pos_sign_witnesses_infinite :
     {c : ℕ | ∃ a b : ℕ, 2 ≤ a ∧ a ≤ b ∧ b < c ∧
       Nat.gcd (Nat.gcd a b) c = 1 ∧ a ^ 3 + b ^ 3 = c ^ 3 + 1}.Infinite := by

--- a/proofs/Proofs/FermatDefectOneFamilies.lean
+++ b/proofs/Proofs/FermatDefectOneFamilies.lean
@@ -182,4 +182,145 @@ theorem defect_pos_witnesses_infinite :
     exact ⟨9 * (n + 2) ^ 3 + 1, 9 * (n + 2) ^ 4,
       defect_pos_witness_ge_two (n + 2) (by omega)⟩
 
+/-! ## Sign-specific infinitude at n = 3
+
+`defect_pos_witnesses_infinite` above shows the *sign-agnostic* witness set is
+infinite (its members happen to come from the positive family). OQ-02 asks
+about each sign separately, so we now upgrade BOTH `fermat_defect_three_negative`
+and `fermat_defect_three_positive` (existence, in `FermatDefectOne.lean`) to
+infinitude, with the defect sign pinned in the set comprehension rather than
+hidden inside the `FermatDefectWitness` disjunction.
+
+The negative family `(9t³−1, 9t⁴−3t, 9t⁴)` needs `ℕ`-subtraction care that the
+positive family avoided: the primitivity kernel goes through
+`t·(9t³−1) + t = 9t⁴` (subtraction eliminated by regrouping), and the cubic
+identity is transported from `ℤ` via `zify`. As with the positive family, the
+ordering `a ≤ b` holds from parameter `2` on (at `t = 1` the family gives
+`(8, 6, 9)`, base terms flipped), so witnesses are indexed by `t ≥ 2`. -/
+
+/-- **Negative-family primitivity kernel.** `9t³ − 1` and `9t⁴` are coprime for
+every `t ≥ 1`. Proof: a common divisor `d` divides `t·(9t³−1) + t = 9t⁴`, hence
+divides `t`, hence divides `9t³ = (9t³−1) + 1`, hence divides `1`. Truncated
+subtraction never bites: the only fact used about `9t³ − 1` is
+`(9t³ − 1) + 1 = 9t³`, valid since `t ≥ 1`. -/
+lemma neg_family_gcd (t : ℕ) (ht : 1 ≤ t) :
+    Nat.gcd (9 * t ^ 3 - 1) (9 * t ^ 4) = 1 := by
+  have hcube : 1 ≤ 9 * t ^ 3 := by
+    have h1 : 1 ≤ t ^ 3 := Nat.one_le_pow 3 t ht
+    omega
+  have hA : (9 * t ^ 3 - 1) + 1 = 9 * t ^ 3 := by omega
+  set d := Nat.gcd (9 * t ^ 3 - 1) (9 * t ^ 4) with hd
+  have h1 : d ∣ 9 * t ^ 3 - 1 := Nat.gcd_dvd_left _ _
+  have h2 : d ∣ 9 * t ^ 4 := Nat.gcd_dvd_right _ _
+  have h3 : d ∣ t := by
+    have hds : t * (9 * t ^ 3 - 1) + t = 9 * t ^ 4 := by
+      calc t * (9 * t ^ 3 - 1) + t = t * ((9 * t ^ 3 - 1) + 1) := by ring
+        _ = t * (9 * t ^ 3) := by rw [hA]
+        _ = 9 * t ^ 4 := by ring
+    have hdt : d ∣ t * (9 * t ^ 3 - 1) + t := by rw [hds]; exact h2
+    exact (Nat.dvd_add_right (h1.mul_left t)).mp hdt
+  have h4 : d ∣ (9 * t ^ 3 - 1) + 1 := by
+    rw [hA]
+    have he : 9 * t ^ 3 = 9 * t ^ 2 * t := by ring
+    rw [he]; exact h3.mul_left (9 * t ^ 2)
+  have h6 : d ∣ 1 := (Nat.dvd_add_right h1).mp h4
+  exact Nat.dvd_one.mp h6
+
+/-- **Generic negative-defect primitive witness.** For every `t ≥ 2`,
+`(9t³−1, 9t⁴−3t, 9t⁴)` satisfies all witness conditions with the defect sign
+pinned to −1 (`a³ + b³ + 1 = c³`, no disjunction). At `t = 2` this is
+`(71, 138, 144)` (`fermat_defect_three_neg_t2`). -/
+theorem defect_neg_witness_parts (t : ℕ) (ht : 2 ≤ t) :
+    2 ≤ 9 * t ^ 3 - 1 ∧ 9 * t ^ 3 - 1 ≤ 9 * t ^ 4 - 3 * t ∧
+    9 * t ^ 4 - 3 * t < 9 * t ^ 4 ∧
+    Nat.gcd (Nat.gcd (9 * t ^ 3 - 1) (9 * t ^ 4 - 3 * t)) (9 * t ^ 4) = 1 ∧
+    (9 * t ^ 3 - 1) ^ 3 + (9 * t ^ 4 - 3 * t) ^ 3 + 1 = (9 * t ^ 4) ^ 3 := by
+  have hx : (8 : ℕ) ≤ t ^ 3 := by
+    calc (8 : ℕ) = 2 ^ 3 := by norm_num
+      _ ≤ t ^ 3 := Nat.pow_le_pow_left ht 3
+  have e2 : 2 * t ^ 3 ≤ t ^ 4 := by
+    calc 2 * t ^ 3 ≤ t * t ^ 3 := mul_le_mul_right' ht (t ^ 3)
+      _ = t ^ 4 := by ring
+  have ht3 : t ≤ t ^ 3 := Nat.le_self_pow (by norm_num) t
+  refine ⟨by omega, by omega, by omega, ?_, ?_⟩
+  · -- primitivity: any divisor of the full gcd divides both a and c,
+    -- hence divides gcd(a, c) = 1 by the kernel.
+    have hdvd : Nat.gcd (Nat.gcd (9 * t ^ 3 - 1) (9 * t ^ 4 - 3 * t)) (9 * t ^ 4) ∣
+        Nat.gcd (9 * t ^ 3 - 1) (9 * t ^ 4) :=
+      Nat.dvd_gcd ((Nat.gcd_dvd_left _ _).trans (Nat.gcd_dvd_left _ _))
+        (Nat.gcd_dvd_right _ _)
+    rw [neg_family_gcd t (by omega)] at hdvd
+    exact Nat.dvd_one.mp hdvd
+  · -- the cubic identity, transported from ℤ (`defect_neg_family`) via zify
+    have h1 : 1 ≤ 9 * t ^ 3 := by omega
+    have h2 : 3 * t ≤ 9 * t ^ 4 := by omega
+    zify [h1, h2]
+    ring
+
+/-- The generic negative witness, packaged as `FermatDefectWitness` (left
+disjunct). -/
+theorem defect_neg_witness_ge_two (t : ℕ) (ht : 2 ≤ t) :
+    FermatDefectWitness 3 (9 * t ^ 3 - 1) (9 * t ^ 4 - 3 * t) (9 * t ^ 4) := by
+  obtain ⟨ha, hab, hbc, hgcd, hid⟩ := defect_neg_witness_parts t ht
+  exact ⟨ha, hab, hbc, hgcd, Or.inl hid⟩
+
+/-- **Negative-sign infinitude at n = 3.** The set of `c` occurring in a
+primitive witness with defect exactly −1 (`a³ + b³ + 1 = c³`) is infinite —
+a strict strengthening of `fermat_defect_three_negative` (existence), and
+sign-pinned where `defect_pos_witnesses_infinite` is sign-agnostic. Injection
+`t ↦ 9(t+2)⁴`, strictly monotone, witnessed by `defect_neg_witness_parts`. -/
+theorem defect_neg_sign_witnesses_infinite :
+    {c : ℕ | ∃ a b : ℕ, 2 ≤ a ∧ a ≤ b ∧ b < c ∧
+      Nat.gcd (Nat.gcd a b) c = 1 ∧ a ^ 3 + b ^ 3 + 1 = c ^ 3}.Infinite := by
+  apply Set.infinite_of_injective_forall_mem
+    (f := fun n : ℕ => 9 * (n + 2) ^ 4)
+  · have hmono : StrictMono (fun n : ℕ => 9 * (n + 2) ^ 4) := by
+      apply strictMono_nat_of_lt_succ
+      intro n
+      show 9 * (n + 2) ^ 4 < 9 * (n + 1 + 2) ^ 4
+      have hp : (n + 2) ^ 4 < (n + 1 + 2) ^ 4 :=
+        Nat.pow_lt_pow_left (by omega) (by norm_num)
+      omega
+    exact hmono.injective
+  · intro n
+    show ∃ a b : ℕ, 2 ≤ a ∧ a ≤ b ∧ b < 9 * (n + 2) ^ 4 ∧
+      Nat.gcd (Nat.gcd a b) (9 * (n + 2) ^ 4) = 1 ∧
+      a ^ 3 + b ^ 3 + 1 = (9 * (n + 2) ^ 4) ^ 3
+    exact ⟨9 * (n + 2) ^ 3 - 1, 9 * (n + 2) ^ 4 - 3 * (n + 2),
+      defect_neg_witness_parts (n + 2) (by omega)⟩
+
+/-- **Positive-sign infinitude at n = 3.** The sign-pinned (`a³ + b³ = c³ + 1`)
+counterpart, upgrading `fermat_defect_three_positive` to infinitude via the
+positive family. Together with `defect_neg_sign_witnesses_infinite` this
+settles OQ-02 at n = 3 in its strongest form: EACH defect sign is realised by
+infinitely many primitive witnesses. -/
+theorem defect_pos_sign_witnesses_infinite :
+    {c : ℕ | ∃ a b : ℕ, 2 ≤ a ∧ a ≤ b ∧ b < c ∧
+      Nat.gcd (Nat.gcd a b) c = 1 ∧ a ^ 3 + b ^ 3 = c ^ 3 + 1}.Infinite := by
+  apply Set.infinite_of_injective_forall_mem
+    (f := fun n : ℕ => 9 * (n + 2) ^ 4 + 3 * (n + 2))
+  · have hmono : StrictMono (fun n : ℕ => 9 * (n + 2) ^ 4 + 3 * (n + 2)) := by
+      apply strictMono_nat_of_lt_succ
+      intro n
+      show 9 * (n + 2) ^ 4 + 3 * (n + 2) < 9 * (n + 1 + 2) ^ 4 + 3 * (n + 1 + 2)
+      have hp : (n + 2) ^ 4 ≤ (n + 1 + 2) ^ 4 := Nat.pow_le_pow_left (by omega) 4
+      omega
+    exact hmono.injective
+  · intro n
+    set s := n + 2 with hs
+    show ∃ a b : ℕ, 2 ≤ a ∧ a ≤ b ∧ b < 9 * s ^ 4 + 3 * s ∧
+      Nat.gcd (Nat.gcd a b) (9 * s ^ 4 + 3 * s) = 1 ∧
+      a ^ 3 + b ^ 3 = (9 * s ^ 4 + 3 * s) ^ 3 + 1
+    have hx : (8 : ℕ) ≤ s ^ 3 := by
+      calc (8 : ℕ) = 2 ^ 3 := by norm_num
+        _ ≤ s ^ 3 := Nat.pow_le_pow_left (by omega) 3
+    have e2 : 2 * s ^ 3 ≤ s ^ 4 := by
+      calc 2 * s ^ 3 ≤ s * s ^ 3 := mul_le_mul_right' (by omega) (s ^ 3)
+        _ = s ^ 4 := by ring
+    refine ⟨9 * s ^ 3 + 1, 9 * s ^ 4, by omega, by omega, by omega, ?_, by ring⟩
+    have hdvd : Nat.gcd (Nat.gcd (9 * s ^ 3 + 1) (9 * s ^ 4)) (9 * s ^ 4 + 3 * s) ∣
+        Nat.gcd (9 * s ^ 3 + 1) (9 * s ^ 4) := Nat.gcd_dvd_left _ _
+    rw [pos_family_gcd s] at hdvd
+    exact Nat.dvd_one.mp hdvd
+
 end FermatDefectOne

--- a/proofs/Proofs/FermatDefectOneFamilies.lean
+++ b/proofs/Proofs/FermatDefectOneFamilies.lean
@@ -318,9 +318,7 @@ theorem defect_pos_sign_witnesses_infinite :
       calc 2 * s ^ 3 ≤ s * s ^ 3 := mul_le_mul_right' (by omega) (s ^ 3)
         _ = s ^ 4 := by ring
     refine ⟨9 * s ^ 3 + 1, 9 * s ^ 4, by omega, by omega, by omega, ?_, by ring⟩
-    have hdvd : Nat.gcd (Nat.gcd (9 * s ^ 3 + 1) (9 * s ^ 4)) (9 * s ^ 4 + 3 * s) ∣
-        Nat.gcd (9 * s ^ 3 + 1) (9 * s ^ 4) := Nat.gcd_dvd_left _ _
-    rw [pos_family_gcd s] at hdvd
-    exact Nat.dvd_one.mp hdvd
+    rw [pos_family_gcd s]
+    exact Nat.gcd_one_left _
 
 end FermatDefectOne

--- a/research/problems/fermat-defect-one-oq-02/knowledge.md
+++ b/research/problems/fermat-defect-one-oq-02/knowledge.md
@@ -134,3 +134,24 @@ only remaining actions are Docker-gated registration and the abc-hard n≥4 dire
 - **Net effect:** the n=3 sign-symmetric infinitude result is now machine-checked
   and part of the build (was orphaned/unregistered + silently broken). Slug remains
   saturated for proof work; n≥4 is abc-hard and out of scope.
+
+## Session 2026-07-24 (researcher-3): positive-sign-pinned infinitude
+
+- **Gap found:** sign-pinned coverage was asymmetric. `FermatDefectOneNegInfinitude.lean`
+  pins the negative sign (`defect_neg_witnesses_infinite`), but the positive side had
+  only the sign-agnostic `defect_pos_witnesses_infinite` (sign hidden inside the
+  `FermatDefectWitness` disjunction).
+- **Added** `defect_pos_sign_witnesses_infinite` (`FermatDefectOneFamilies.lean`):
+  `{c | ∃ a b, 2≤a ∧ a≤b ∧ b<c ∧ gcd(gcd a b) c = 1 ∧ a³+b³ = c³+1}.Infinite`,
+  injection `s ↦ 9(s+2)⁴+3(s+2)`, primitivity via `pos_family_gcd`. 0 axioms, 0 sorries.
+- **Non-transport note:** the ℤ sign-flip involution (`FermatDefectOneOQ06.lean`) does
+  not carry primitive ordered ℕ witnesses between signs, so neither sign-pinned
+  statement follows from the other.
+- **Triage warning for future sessions:** the negative-side engine (coprimality kernel
+  `gcd(9t³−1, 9t⁴)=1`, `defect_neg_data`, `defect_neg_witness_ge_two`) ALREADY EXISTS
+  in `FermatDefectOneNegInfinitude.lean`. This session initially re-derived it
+  (including a name collision with `defect_neg_witness_ge_two` in the shared
+  `FermatDefectOne` namespace) before catching the duplication — grep ALL
+  `FermatDefectOne*.lean` files before adding family lemmas.
+- **Status:** slug saturated. n≥4 is the genuine open core (abc/Fermat-Catalan-hard);
+  structured blocker recorded in the tracker JSON.

--- a/research/problems/fermat-defect-one-oq-02/state.md
+++ b/research/problems/fermat-defect-one-oq-02/state.md
@@ -27,3 +27,13 @@ and out of scope — do NOT submit the headline sorry to Aristotle (OPEN, not HA
 Slug is effectively saturated for tractable work. n=3 verified + registered.
 The only remaining direction is the abc-hard n≥4 emptiness, which is not
 session-sized. Recommend keeping `blocked`/closed for proof work.
+
+## Session 2026-07-24 (researcher-3) addendum
+Sign-pinned symmetry completed: added `defect_pos_sign_witnesses_infinite`
+(FermatDefectOneFamilies.lean) — the positive-sign-pinned (`a³+b³=c³+1`)
+infinitude counterpart to `defect_neg_witnesses_infinite`. Previously the
+positive side was only covered sign-agnostically. 0 axioms, 0 sorries,
+docker-verified. Triage note: the negative-side engine already lives in
+`FermatDefectOneNegInfinitude.lean` — check ALL FermatDefectOne*.lean before
+adding family lemmas; `FermatDefectOne` namespace is shared across files.
+Slug remains saturated; n≥4 abc-hard (structured blocker in tracker).

--- a/src/data/research/problems/fermat-defect-one-oq-02.json
+++ b/src/data/research/problems/fermat-defect-one-oq-02.json
@@ -19,9 +19,15 @@
     "phase": "ACT",
     "since": "2026-06-15T06:15:07.078468+00:00",
     "iteration": 2,
-    "focus": "n=3 fully characterised (both signs, infinite families); n>=4 reframed via heuristic + empty search.",
-    "blockers": [],
-    "nextAction": "Build FermatDefectOneFamilies.lean; optionally formalize infinitude; tackle bounded-nonexistence at n=4.",
+    "focus": "n=3 fully settled with both signs pinned and infinite. Slug saturated; n>=4 is abc-hard.",
+    "blockers": [
+      {
+        "route": "n>=4 both-signs via abc/Fermat-Catalan finiteness",
+        "reopenCriterion": "Mathlib gains abc/Fermat-Catalan or Pillai-type finiteness machinery",
+        "blockedAt": "2026-07-24"
+      }
+    ],
+    "nextAction": "None tractable. Keep completed; n>=4 blocked on abc/Fermat-Catalan machinery.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +35,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: n=3 strengthened from existence to INFINITUDE — proved (build-pending) that the positive Mahler family gives a primitive FermatDefectWitness for every s>=2 and that the set of attainable c is Set.Infinite. Primitivity reduced to a single all-s coprimality kernel gcd(9s^3+1,9s^4)=1. n>=4 remains OPEN (Fermat-Catalan/abc, no Mathlib bearer); headline sorry empirically false for 4<=n<=12.",
+    "progressSummary": "COMPLETE at n=3 in strongest form: BOTH defect signs sign-pinned AND infinite (defect_neg_witnesses_infinite in NegInfinitude file; defect_pos_sign_witnesses_infinite in Families file, added 2026-07-24; 0 axioms, 0 sorries, build-verified). n>=4 remains the genuine open core (abc/Fermat-Catalan-hard, no Mathlib bearer).",
     "builtItems": [
       "defect_neg_family (t:Z): (9t^4-3t)^3+(9t^3-1)^3+1=(9t^4)^3 [ring] in proofs/Proofs/FermatDefectOneFamilies.lean",
       "defect_pos_family (s:N): (9s^4)^3+(9s^3+1)^3=(9s^4+3s)^3+1 [ring, subtraction-free over N]",
@@ -38,7 +44,8 @@
       "research/problems/fermat-defect-one-oq-02/verify_defect_search.py: exact both-sign search + family verifier (identity+primitivity+bounds, t,s=1..200)",
       "pos_family_gcd (s): Nat.gcd (9s^3+1) (9s^4) = 1 [dvd-chain, no subtraction] in proofs/Proofs/FermatDefectOneFamilies.lean",
       "defect_pos_witness_ge_two (s) (hs:2<=s): FermatDefectWitness 3 (9s^3+1) (9s^4) (9s^4+3s) [generic family witness; bounds via omega+Nat.pow_le_pow_left/mul_le_mul_right, gcd via pos_family_gcd, identity by ring]",
-      "defect_pos_witnesses_infinite: {c | exists a b, FermatDefectWitness 3 a b c}.Infinite [Set.infinite_of_injective_forall_mem + strictMono_nat_of_lt_succ]"
+      "defect_pos_witnesses_infinite: {c | exists a b, FermatDefectWitness 3 a b c}.Infinite [Set.infinite_of_injective_forall_mem + strictMono_nat_of_lt_succ]",
+      "defect_pos_sign_witnesses_infinite: {c | exists a b, primitive witness with a^3+b^3=c^3+1}.Infinite [injection s->9(s+2)^4+3(s+2), pos_family_gcd] in proofs/Proofs/FermatDefectOneFamilies.lean"
     ],
     "insights": [
       "Both n=3 defect signs lie on infinite polynomial families, both descending from Mahler's parametrization of x^3+y^3+z^3=1 at parameter t (neg) and -t (pos); t=1/s=1 recover the gallery benchmarks (6,8,9) and (9,10,12).",
@@ -48,7 +55,10 @@
       "Reframing: 'both signs for every n>=3' is heuristically hard/false for n>=4; the n=3 abundance is a critical-exponent artifact, and n>=4 is governed by Fermat-Catalan-type finiteness. Confirms the existing no_witness_n_eq_4_below_20 target is TRUE.",
       "The families are not exhaustive: positive witness (64,94,103) is off-family (other rational curves on the same cubic surface).",
       "INFINITUDE at n=3 (Lean, build-pending): proved defect_pos_witnesses_infinite — the set {c | exists a b, FermatDefectWitness 3 a b c} is Set.Infinite. Strict strengthening of FermatDefectExists 3 (exists -> infinitely many primitive witnesses). Injection s -> 9(s+2)^4+3(s+2), strictly monotone, each value witnessed.",
-      "Primitivity kernel: gcd(9s^3+1, 9s^4)=1 for ALL s (pos_family_gcd), so the full primitive gcd reduces to Nat.gcd_one_left. Proof is subtraction-free via Nat.dvd_add_right (d | s*(9s^3+1)=9s^4+s and d | 9s^4 => d|s => d|9s^3 => d|1). Restricting to s>=2 fixes the a<=b ordering (a=9s^3+1<=b=9s^4 for s>=2; the roles flip at s=1)."
+      "Primitivity kernel: gcd(9s^3+1, 9s^4)=1 for ALL s (pos_family_gcd), so the full primitive gcd reduces to Nat.gcd_one_left. Proof is subtraction-free via Nat.dvd_add_right (d | s*(9s^3+1)=9s^4+s and d | 9s^4 => d|s => d|9s^3 => d|1). Restricting to s>=2 fixes the a<=b ordering (a=9s^3+1<=b=9s^4 for s>=2; the roles flip at s=1).",
+      "Sign-pinned coverage was asymmetric: FermatDefectOneNegInfinitude.lean pins the NEGATIVE sign (defect_neg_witnesses_infinite) but the positive side had only the sign-agnostic defect_pos_witnesses_infinite (sign hidden in the FermatDefectWitness disjunction). defect_pos_sign_witnesses_infinite closes the asymmetry; now both signs are pinned+infinite.",
+      "The OQ06 sign-flip involution (Z, unconstrained) cannot transport primitive ordered N witnesses between signs, so neither sign-pinned infinitude follows formally from the other.",
+      "Triage trap: the negative-side engine (kernel gcd(9t^3-1,9t^4)=1, defect_neg_data, defect_neg_witness_ge_two) ALREADY EXISTS in FermatDefectOneNegInfinitude.lean — grep ALL FermatDefectOne*.lean files, not just Families, before adding negative-side content. Re-adding defect_neg_witness_ge_two in another file would shadow-collide in the shared FermatDefectOne namespace."
     ],
     "mathlibGaps": [
       "No abc-conjecture / Fermat-Catalan finiteness machinery in Mathlib to attack the n>=4 case (the open part).",
@@ -73,7 +83,7 @@
     "mathlib": []
   },
   "started": "2026-06-15T06:29:35.219Z",
-  "lastUpdate": "2026-06-15T06:29:35.257Z",
+  "lastUpdate": "2026-07-24T00:00:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary
Research session for fermat-defect-one-oq-02 (both defect signs at every n ≥ 3?).

## Progress
- Added `defect_pos_sign_witnesses_infinite` to `proofs/Proofs/FermatDefectOneFamilies.lean`: the set of `c` occurring in a primitive witness with the defect sign pinned to +1 (`a³ + b³ = c³ + 1`) is infinite, via the positive Mahler family (injection `s ↦ 9(s+2)⁴ + 3(s+2)`, primitivity from `pos_family_gcd`). 0 axioms, 0 sorries.
- Docker build green (`Proofs.FermatDefectOneFamilies`, 8577 jobs; only pre-existing deprecation warnings and the known headline sorry in the parent file).
- Tracker/state/knowledge updated, including a structured `blockers` entry for the n ≥ 4 direction (abc/Fermat-Catalan-hard, reopen when Mathlib gains such machinery).

## Findings
- Sign-pinned coverage was asymmetric: `FermatDefectOneNegInfinitude.lean` pins the negative sign (`defect_neg_witnesses_infinite`), but the positive side only had the sign-agnostic `defect_pos_witnesses_infinite` (sign hidden in the `FermatDefectWitness` disjunction). This PR closes the asymmetry: both signs are now pinned AND infinite at n = 3.
- The ℤ sign-flip involution (`FermatDefectOneOQ06.lean`) cannot transport primitive ordered ℕ witnesses between signs, so neither sign-pinned statement follows formally from the other.
- Triage warning recorded for future sessions: the negative-side engine already exists in `FermatDefectOneNegInfinitude.lean` (this session initially re-derived it, including a name collision with `defect_neg_witness_ge_two` in the shared namespace, before catching the duplication and trimming). Branch history contains the trimmed intermediate commits; the final diff is the single new theorem + docs.

## Status
**Outcome**: completed (slug saturated — n = 3 settled in strongest sign-pinned form; n ≥ 4 blocked on abc/Fermat-Catalan machinery, structured blocker recorded)
**Next Steps**: none tractable at session scale; do not submit the headline `∀ n ≥ 3` sorry to Aristotle (OPEN).

🤖 Generated by researcher-3
