### PR TITLE
audit(brouwer-fixed-point-oq-04): disclose second axiom in file header

### DIFF
--- a/proofs/Proofs/BrouwerFixedPointOQ04.lean
+++ b/proofs/Proofs/BrouwerFixedPointOQ04.lean
@@ -39,6 +39,9 @@ This is the foundational tool for:
 ## Axioms
 - `kakutani_fixed_point_axiom`: The main Kakutani FPT (requires Brouwer +
   finite-dimensional approximation, which needs algebraic topology)
+- `brouwer_pi_compact_convex`: Brouwer FPT for products of compact convex
+  sets (requires a Schoenflies-type homeomorphism argument not yet in
+  Mathlib; see Part 10)
 
 ## Proved (previously axiomatized)
 - `brouwer_compact_convex`: Brouwer FPT for compact convex subsets


### PR DESCRIPTION
## Summary
- `Proofs/BrouwerFixedPointOQ04.lean`'s header `## Axioms` section only listed `kakutani_fixed_point_axiom`, omitting `brouwer_pi_compact_convex` (Part 10, the product-Brouwer axiom for Nash equilibrium infrastructure).
- `meta.json` already correctly discloses both axioms (axiomCount: 2 for this file, 4 across the chain including the companion file) — this is a docstring-only fix bringing the in-file header into sync with the actual axiom count.

## Evidence
- `grep -n '^axiom' Proofs/BrouwerFixedPointOQ04.lean` → 2 hits: `kakutani_fixed_point_axiom` (line 170) and `brouwer_pi_compact_convex` (line 481).
- Header's `## Axioms` section (pre-fix) named only the first.

## Test plan
- [x] Comment-only change inside a `/- ... -/` block; no code semantics altered.