### PR TITLE
Enrich beta-integral-recurrence-oq-01-oq-03-oq-01: split IBP section (98->100)

### DIFF
--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01/annotations.json
@@ -36,6 +36,18 @@
     "prerequisites": ["the off-diagonal ℂ→ℝ bridge", "betaIntegral_nat_nat from the grandparent"]
   },
   {
+    "id": "ann-base",
+    "proofId": "beta-integral-recurrence-oq-01-oq-03-oq-01",
+    "range": { "startLine": 73, "endLine": 81 },
+    "type": "theorem",
+    "title": "Route 2's base case: n = 0",
+    "content": "integral_base: ∫₀¹ xᵏ(1-x)⁰ dx = 1/(k+1). Since (1-x)⁰ = 1, this is just ∫₀¹ xᵏ dx, read off Mathlib's integral_pow. This is the induction base that integral_offdiag_via_ibp starts from — matching m!·0!/(m+1)! since 0! = 1.",
+    "mathContext": "$\\int_0^1 x^k(1-x)^0\\,dx = \\int_0^1 x^k\\,dx = \\dfrac{1}{k+1}$",
+    "significance": "supporting",
+    "relatedConcepts": ["integral_pow", "induction base case", "factorial base 0! = 1"],
+    "prerequisites": ["Mathlib's integral_pow"]
+  },
+  {
     "id": "ann-recurrence",
     "proofId": "beta-integral-recurrence-oq-01-oq-03-oq-01",
     "range": { "startLine": 82, "endLine": 130 },

--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01/meta.json
@@ -106,11 +106,19 @@
       "mathContext": "↑(∫₀¹ xᵐ(1-x)ⁿ) = Complex.betaIntegral (m+1)(n+1) = m!·n!/(m+n+1)!."
     },
     {
-      "id": "ibp-recurrence",
-      "title": "Route 2 — integration-by-parts recurrence",
+      "id": "ibp-base",
+      "title": "Route 2 header and the base case",
       "startLine": 73,
+      "endLine": 81,
+      "summary": "Opens Route 2 with a module comment marking it as a self-contained real-analysis proof. integral_base specializes n = 0: ∫₀¹ xᵏ(1-x)⁰ = 1/(k+1), reducing to ∫₀¹ xᵏ via pow_zero/mul_one and reading the value off Mathlib's integral_pow. This is the base case the induction in integral_offdiag_via_ibp starts from.",
+      "mathContext": "∫₀¹ xᵏ(1-x)⁰ dx = ∫₀¹ xᵏ dx = 1/(k+1)."
+    },
+    {
+      "id": "ibp-recurrence",
+      "title": "The integration-by-parts recurrence",
+      "startLine": 82,
       "endLine": 131,
-      "summary": "integral_base gives the induction base ∫₀¹ xᵏ(1-x)⁰ = 1/(k+1) from integral_pow. integral_recurrence integrates ∫₀¹ xᵐ(1-x)ⁿ⁺¹ by parts with u = (1-x)ⁿ⁺¹ and v = xᵐ⁺¹/(m+1) (derivatives via HasDerivAt.pow and hasDerivAt_pow.div_const); both boundary terms vanish because (1-1)ⁿ⁺¹ = 0 and 0ᵐ⁺¹ = 0, leaving the pure recurrence ((n+1)/(m+1))·∫₀¹ xᵐ⁺¹(1-x)ⁿ after pulling the constant out (integral_const_mul).",
+      "summary": "integral_recurrence integrates ∫₀¹ xᵐ(1-x)ⁿ⁺¹ by parts with u = (1-x)ⁿ⁺¹ and v = xᵐ⁺¹/(m+1) (derivatives via HasDerivAt.pow and hasDerivAt_pow.div_const); both boundary terms vanish because (1-1)ⁿ⁺¹ = 0 and 0ᵐ⁺¹ = 0, leaving the pure recurrence ((n+1)/(m+1))·∫₀¹ xᵐ⁺¹(1-x)ⁿ after pulling the constant out (integral_const_mul).",
       "mathContext": "∫₀¹ xᵐ(1-x)ⁿ⁺¹ = ((n+1)/(m+1))·∫₀¹ xᵐ⁺¹(1-x)ⁿ."
     },
     {


### PR DESCRIPTION
## Summary
- Splits the 'Route 2' section (lines 73-131) into two: a base-case section for `integral_base` (73-81) and the IBP-recurrence section for `integral_recurrence` (82-131). The prior 4-section layout capped the enrichment quality score's sections dimension at 8/10.
- Adds the missing `ann-base` annotation covering `integral_base` (lines 73-81), which previously had no annotation coverage at all.

Quality score: 98 -> 100 (`npx tsx scripts/enricher/find-targets.ts --all`).

## Test plan
- [x] `node -e "JSON.parse(...)"` validated both meta.json and annotations.json
- [x] `npx tsx scripts/enricher/find-targets.ts --all` confirms quality 100
- [x] `pnpm build` annotation-check pass produced no errors for this entry (pre-existing unrelated errors on other files only)