### PR TITLE
Audit: borsuk-ulam-oq-04 (reserve): re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3467,9 +3467,9 @@
       "issues": []
     },
     "borsuk-ulam-oq-04": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:51Z",
+      "lastAudited": "2026-07-24T07:35:35Z",
       "result": "clean"
     },
     "bounded-prime-gaps": {


### PR DESCRIPTION
## Summary
Reserve-mode re-audit of `borsuk-ulam-oq-04` (queue fully drained, 4812/4812). Re-verified CLEAN.

- Transitive axiom `no_continuous_odd_nonzero_on_sphere` (inherited from `BorsukUlam.lean` via `import Proofs.BorsukUlam`) properly disclosed in `assumptions`; 0 local axioms.
- 0 sorries, 0 `native_decide`, no True-stub theorems.
- `theoremCount:13` and `definitionCount:18` (includes 4 structures) both match the actual file.
- Conclusion/overview language correctly scopes claims: descent proved without sorries, obstruction axiom explicitly disclosed as inherited (Tier C, badge `axiom`).

## Test plan
- [x] Tracker-only diff (`audit-tracker.json` auditCount/lastAudited bump)