### PR TITLE
Audit: erdos-1059-oq-02 (reserve): re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9498,9 +9498,9 @@
       "agentId": "auditor-reaudit-20260708"
     },
     "erdos-1059-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-04T04:04:52Z",
+      "lastAudited": "2026-07-24T07:38:27Z",
       "result": "clean"
     },
     "erdos-1059-oq-02-oq-01": {


### PR DESCRIPTION
## Reserve-mode audit (queue drained: 4812/4812 audited, 0 issues)

**Target**: erdos-1059-oq-02 — Selberg Sieve Framework for Erdős Problem 1059

**Verification**: independently re-checked meta.json claims against
`proofs/Proofs/Erdos1059OQ02.lean`.

| Field | meta.json | actual | match |
|---|---|---|---|
| theoremCount | 7 | 7 | yes |
| definitionCount | 4 | 4 | yes |
| axiomCount | 1 | 1 | yes |
| sorries | 0 | 0 | yes |
| lineCount | 231 | 231 | yes |

- No phantom decls in `originalContributions`/`proofStrategy`/sections — all 8
  named identifiers (7 theorems + 1 axiom, `PrimorialInterval`/`BadFactorialIndices`
  etc. counted in definitionCount) exist in the file.
- No `native_decide`; the single axiom `selberg_density_axiom` is honestly
  disclosed in `assumptions` and matches its actual statement.
- `selberg_implies_erdos` genuinely derives the conjecture from the axiom (not
  vacuous — uses `Set.infinite_iff_exists_gt` with a real witness argument).
- All 4 `crossReferences` targets (erdos-1059, erdos-1059-oq-01, erdos-1059-oq-04,
  bounded-prime-gaps) exist in the gallery.
- badge `axiom` / status `axiomatized` is the correct Tier C classification.

Only the tracker diff is included (`audit-tracker.json` completion timestamp).

---
Discovered during gallery integrity audit (reserve mode).