### PR TITLE
Audit: borsuk-ulam-oq-02-oq-01-oq-04 — disclose True-stub theorem, fix lineCount

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-04/meta.json
@@ -182,8 +182,8 @@
     "additionalFiles": [
       {
         "path": "Proofs/BorsukUlamOQ02OQ01OQ04OQ01.lean",
-        "description": "Concrete F_p[u] cohomology ring of BZ/p: realizes the polynomial generator and proves ideal monotonicity + quotient dimension using Mathlib's polynomial infrastructure (AdjoinRoot.powerBasis, Ideal.Quotient.nontrivial_iff). 0 own axioms, 0 sorries.",
-        "lineCount": 235,
+        "description": "Concrete F_p[u] cohomology ring of BZ/p: realizes the polynomial generator and proves ideal monotonicity + quotient dimension using Mathlib's polynomial infrastructure (AdjoinRoot.powerBasis, Ideal.Quotient.nontrivial_iff). 0 own axioms, 0 sorries. Note: 1 of the 15 theorems (cohBZp_iso_FpPoly_documented) is a `True := trivial` placeholder — the cohomology ring isomorphism H*(BZ/p; F_p) ≅ F_p[u] itself is documented in prose only, not formalized (would require spectral-sequence infrastructure not yet in Mathlib).",
+        "lineCount": 234,
         "axiomCount": 0,
         "sorries": 0,
         "theoremCount": 15,


### PR DESCRIPTION
## Integrity Fix

**Proof**: borsuk-ulam-oq-02-oq-01-oq-04
**Problem**: The companion file `Proofs/BorsukUlamOQ02OQ01OQ04OQ01.lean` has a
vacuous placeholder theorem
`theorem cohBZp_iso_FpPoly_documented : True := trivial` (line 179-180)
standing in for the (unformalized) cohomology ring isomorphism
H*(BZ/p; F_p) ≅ F_p[u] — the file's own header even says this is
"documented — needs spectral sequences", not proved. It's counted in the
public `theoremCount: 15` alongside 14 substantive theorems, with no
disclosure in meta.json that one of them is a `True`-stub.

Also `lineCount` for that file was 235, but the file is actually 234 lines.

## Evidence

**meta.json claims**: `additionalFiles[0].description` says "proves ideal
monotonicity + quotient dimension... 0 own axioms, 0 sorries" with
`theoremCount: 15` and `lineCount: 235`, no mention of the True-stub.

**Lean file shows**: `Proofs/BorsukUlamOQ02OQ01OQ04OQ01.lean:179-180` is
`theorem cohBZp_iso_FpPoly_documented : True := trivial`; `wc -l` confirms
234 lines.

## Fix

Added a disclosure sentence to `leanFile.additionalFiles[0].description`
naming the placeholder theorem and what it stands in for, and corrected
`lineCount` 235 → 234. No change to status/badge (`axiomatized`/`axiom`
already correctly reflect this file's Tier C nature); theoremCount is
unchanged since 15 real declarations do exist, just with one disclosed as
vacuous.

---
Discovered during gallery integrity audit (round-robin re-serve, queue
fully drained at audit time).