### PR TITLE
Research: erdos-1092-oq-02 - first exact threshold value fThreshold 1 3 = 2

### DIFF
--- a/proofs/Proofs/Erdos1092OQ02.lean
+++ b/proofs/Proofs/Erdos1092OQ02.lean
@@ -42,6 +42,18 @@ It then goes further and pins down the set completely:
   forces the conclusion **iff** `k ≤ fThreshold r n`, i.e. the defining set is exactly the
   interval `{0, …, fThreshold r n}`.
 
+Finally, with the well-definedness theory in hand, this file **computes the threshold at
+the smallest non-degenerate point** and machine-checks a refutation the parent had only
+in prose:
+
+* `fThreshold_one_three` — **`fThreshold 1 3 = 2`**, the first exact value of the
+  threshold. Upper bound: `K₃` with the three-pair removal budget; lower bound: budget `2`
+  cannot kill all three `K₃` edges (disjoint pair-slot counting), and every non-`K₃`
+  3-vertex graph is explicitly 2-colorable.
+* `trivial_lower_bound_false` — `fThreshold 1 4 < 4 - 1`: the parent's removed
+  `f_trivial_lower` axiom (`n - 1 ≤ fThreshold r n`) is false, via `K₃` + isolated
+  vertex — previously only a prose remark, now a theorem.
+
 No new axioms; the parent file has 0 axioms and they are untouched (and unused here).
 -/
 
@@ -234,6 +246,248 @@ theorem fThresholdSet_eq_univ_of_card_le {r n : ℕ} (hn : n ≤ r + 1) :
   intro k G _
   exact hasColoring_of_card_le hn G
 
+/-
+## Exact values
+
+With the well-definedness theory complete (nonempty + bounded + attained +
+interval), the threshold can now actually be *computed* at the smallest
+non-degenerate point. `r = 1`, `n = 3` is the first pair in the good regime
+`1 ≤ r`, `r + 2 ≤ n`, and there `fThreshold 1 3 = 2`:
+
+* **Upper bound** (`three_notMem_fThresholdSet_one_three`): with budget `3`,
+  `K₃` satisfies the reduction hypothesis — removing the three ordered pairs
+  `(0,1), (0,2), (1,2)` makes every induced subgraph edgeless — yet `K₃` is
+  not `2`-colorable. So `3` (hence every `k ≥ 3`) is outside the defining set.
+* **Lower bound** (`two_mem_fThresholdSet_one_three`): with budget `2`, the
+  hypothesis *excludes* `K₃` — each removed ordered pair kills at most one of
+  `K₃`'s three edges, so two pairs cannot make the `univ`-induced subgraph
+  edgeless (an intersection-counting argument: the three pair-slots
+  `{(u,v),(v,u)}` are disjoint, each must meet `removed`). Every other
+  3-vertex graph misses some edge and is explicitly 2-colorable (three-case
+  split with concrete colorings `![0,1,1]`, `![0,1,0]`, `![0,0,1]`).
+
+The same machinery also formalizes the parent file's *prose-only* refutation
+of its removed `f_trivial_lower` axiom (`n - 1 ≤ fThreshold r n`): `K₃` plus
+an isolated vertex shows `fThreshold 1 4 ≤ 2 < 3 = n - 1`
+(`trivial_lower_bound_false`).
+-/
+
+/-- The fixed removal set killing every edge among three vertices: with these
+three ordered pairs removed, *no* edge on vertex set `Fin 3` survives. -/
+def killAll3 : Finset (Fin 3 × Fin 3) := {(0, 1), (0, 2), (1, 2)}
+
+/-- **Budget `3` does not force 3-vertex graphs to be 2-colorable: `K₃` is a
+witness.** Every induced subgraph of `K₃` becomes edgeless after removing the
+three pairs of `killAll3` (within budget `3`), so `K₃` satisfies the reduction
+hypothesis; but `K₃` is not `2`-colorable (`completeGraph_not_hasColoring`). -/
+theorem three_notMem_fThresholdSet_one_three : 3 ∉ fThresholdSet 1 3 := by
+  intro hmem
+  have hP : ∀ S : Finset (Fin 3), CanReduceChromatic
+      (SGraph.mk (fun u v => u ∈ S ∧ v ∈ S ∧ (SGraph.completeGraph 3).adj u v)
+        (fun u v ⟨hu, hv, h⟩ => ⟨hv, hu, (SGraph.completeGraph 3).symm u v h⟩)
+        (fun v ⟨_, _, h⟩ => (SGraph.completeGraph 3).irrefl v h)) 3 1 := by
+    intro S
+    refine ⟨killAll3, by decide, ⟨fun _ => 0, ?_⟩⟩
+    rintro u v ⟨⟨_, _, huv⟩, hnuv, hnvu⟩ _
+    -- Each pair of distinct vertices is hit by `killAll3` in one order or the
+    -- other; the diagonal contradicts `K₃`-adjacency (`u ≠ v`).
+    fin_cases u <;> fin_cases v <;>
+      first
+        | exact huv rfl
+        | exact hnuv (by decide)
+        | exact hnvu (by decide)
+  exact completeGraph_not_hasColoring (by omega) (hmem (SGraph.completeGraph 3) hP)
+
+/-- Upper bound at the smallest non-degenerate point: `fThreshold 1 3 ≤ 2`
+(any member `k ≥ 3` of the defining set would drag `3` in by
+downward-closedness). -/
+theorem fThreshold_one_three_le_two : fThreshold 1 3 ≤ 2 := by
+  rw [fThreshold_eq_sSup]
+  refine csSup_le' ?_
+  intro k hk
+  by_contra hlt
+  push_neg at hlt
+  exact three_notMem_fThresholdSet_one_three
+    (fThresholdSet_downClosed (by omega) hk)
+
+/-- **Budget `2` forces 3-vertex graphs to be 2-colorable.** Key: with only two
+removed ordered pairs, `K₃`'s three edges cannot all be killed — each removed
+pair kills at most one edge, made precise by intersecting `removed` with the
+three disjoint pair-slots `{(u,v), (v,u)}`. So the reduction hypothesis
+excludes `K₃`, and every other 3-vertex graph misses some edge and is
+explicitly 2-colorable. -/
+theorem two_mem_fThresholdSet_one_three : 2 ∈ fThresholdSet 1 3 := by
+  intro G hP
+  obtain ⟨removed, hcard, c₁, hc₁⟩ := hP Finset.univ
+  -- Every edge of `G` is killed by some removed ordered pair: the reduced
+  -- `univ`-induced graph is `1`-colorable, hence edgeless.
+  have hkill : ∀ u v, G.adj u v → (u, v) ∈ removed ∨ (v, u) ∈ removed := by
+    intro u v hadj
+    by_contra h
+    push_neg at h
+    exact hc₁ u v ⟨⟨Finset.mem_univ u, Finset.mem_univ v, hadj⟩, h.1, h.2⟩
+      (Subsingleton.elim _ _)
+  by_cases h01 : G.adj 0 1
+  · by_cases h02 : G.adj 0 2
+    · by_cases h12 : G.adj 1 2
+      · -- `K₃` case: three edges need three distinct removed pairs, but
+        -- `removed.card ≤ 2`. Contradiction.
+        exfalso
+        have hm01 : (removed ∩ ({(0, 1), (1, 0)} : Finset (Fin 3 × Fin 3))).Nonempty := by
+          rcases hkill 0 1 h01 with h | h
+          · exact ⟨_, Finset.mem_inter.mpr ⟨h, by decide⟩⟩
+          · exact ⟨_, Finset.mem_inter.mpr ⟨h, by decide⟩⟩
+        have hm02 : (removed ∩ ({(0, 2), (2, 0)} : Finset (Fin 3 × Fin 3))).Nonempty := by
+          rcases hkill 0 2 h02 with h | h
+          · exact ⟨_, Finset.mem_inter.mpr ⟨h, by decide⟩⟩
+          · exact ⟨_, Finset.mem_inter.mpr ⟨h, by decide⟩⟩
+        have hm12 : (removed ∩ ({(1, 2), (2, 1)} : Finset (Fin 3 × Fin 3))).Nonempty := by
+          rcases hkill 1 2 h12 with h | h
+          · exact ⟨_, Finset.mem_inter.mpr ⟨h, by decide⟩⟩
+          · exact ⟨_, Finset.mem_inter.mpr ⟨h, by decide⟩⟩
+        obtain ⟨a, ha⟩ := hm01
+        obtain ⟨b, hb⟩ := hm02
+        obtain ⟨c, hc⟩ := hm12
+        obtain ⟨haR, haE⟩ := Finset.mem_inter.mp ha
+        obtain ⟨hbR, hbE⟩ := Finset.mem_inter.mp hb
+        obtain ⟨hcR, hcE⟩ := Finset.mem_inter.mp hc
+        simp only [Finset.mem_insert, Finset.mem_singleton] at haE hbE hcE
+        -- The three witnesses live in disjoint slots, hence are distinct.
+        have hab : a ≠ b := by
+          rintro rfl
+          rcases haE with rfl | rfl <;> simp_all
+        have hac : a ≠ c := by
+          rintro rfl
+          rcases haE with rfl | rfl <;> simp_all
+        have hbc : b ≠ c := by
+          rintro rfl
+          rcases hbE with rfl | rfl <;> simp_all
+        have hsub : ({a, b, c} : Finset (Fin 3 × Fin 3)) ⊆ removed := by
+          intro p hp
+          simp only [Finset.mem_insert, Finset.mem_singleton] at hp
+          rcases hp with rfl | rfl | rfl
+          · exact haR
+          · exact hbR
+          · exact hcR
+        have h3 : 3 ≤ removed.card := by
+          calc 3 = ({a, b, c} : Finset (Fin 3 × Fin 3)).card := by
+                rw [Finset.card_insert_of_notMem (by simp [hab, hac]),
+                  Finset.card_insert_of_notMem (by simp [hbc]),
+                  Finset.card_singleton]
+              _ ≤ removed.card := Finset.card_le_card hsub
+        omega
+      · -- Edges only among `{01, 02}`: star at `0`, colour `0 ↦ 0`, `1, 2 ↦ 1`.
+        refine ⟨![0, 1, 1], fun u v hadj => ?_⟩
+        fin_cases u <;> fin_cases v <;>
+          first
+            | exact absurd hadj (G.irrefl _)
+            | exact absurd hadj h12
+            | exact absurd hadj (fun h => h12 (G.symm _ _ h))
+            | decide
+    · -- No `02` edge: colour `0, 2` alike.
+      refine ⟨![0, 1, 0], fun u v hadj => ?_⟩
+      fin_cases u <;> fin_cases v <;>
+        first
+          | exact absurd hadj (G.irrefl _)
+          | exact absurd hadj h02
+          | exact absurd hadj (fun h => h02 (G.symm _ _ h))
+          | decide
+  · -- No `01` edge: colour `0, 1` alike.
+    refine ⟨![0, 0, 1], fun u v hadj => ?_⟩
+    fin_cases u <;> fin_cases v <;>
+      first
+        | exact absurd hadj (G.irrefl _)
+        | exact absurd hadj h01
+        | exact absurd hadj (fun h => h01 (G.symm _ _ h))
+        | decide
+
+/-- Lower bound: `2 ≤ fThreshold 1 3`, via membership and boundedness. -/
+theorem two_le_fThreshold_one_three : 2 ≤ fThreshold 1 3 := by
+  rw [fThreshold_eq_sSup]
+  exact le_csSup (fThresholdSet_bddAbove (by omega) (by omega))
+    two_mem_fThresholdSet_one_three
+
+/-- **The first exact threshold value: `fThreshold 1 3 = 2`.** At the smallest
+non-degenerate point of the good regime, the Erdős–Hajnal–Szemerédi threshold
+is exactly `2`: a per-subgraph deletion budget of `2` forces `2`-colorability
+of every 3-vertex graph, and `2` is the largest budget that does. -/
+theorem fThreshold_one_three : fThreshold 1 3 = 2 :=
+  le_antisymm fThreshold_one_three_le_two two_le_fThreshold_one_three
+
+/-
+## The parent's removed `f_trivial_lower` axiom, refuted in Lean
+
+The parent file removed its axiom `n - 1 ≤ fThreshold r n` with a prose
+counterexample (`r = 1`, `n = 4`, `K₃` + isolated vertex). Here that
+refutation is machine-checked.
+-/
+
+/-- **`K₃` plus an isolated vertex**, on 4 vertices: vertices `0, 1, 2` are
+pairwise adjacent, vertex `3` is isolated. -/
+def trianglePlusIsolated : SGraph 4 where
+  adj u v := u ≠ v ∧ u ≠ 3 ∧ v ≠ 3
+  symm _ _ h := ⟨h.1.symm, h.2.2, h.2.1⟩
+  irrefl _ h := h.1 rfl
+
+/-- The same three-pair removal set, on 4 vertices: kills every edge of
+`trianglePlusIsolated` (whose edges all lie among `0, 1, 2`). -/
+def killAll4 : Finset (Fin 4 × Fin 4) := {(0, 1), (0, 2), (1, 2)}
+
+/-- **Budget `3` does not force 4-vertex graphs to be 2-colorable:** `K₃` plus
+an isolated vertex satisfies the reduction hypothesis with budget `3` (its
+only edges are the triangle's, all killed by `killAll4`), but contains a
+triangle, so it is not `2`-colorable (pigeonhole on the three colours of
+`0, 1, 2` in `Fin 2`). -/
+theorem three_notMem_fThresholdSet_one_four : 3 ∉ fThresholdSet 1 4 := by
+  intro hmem
+  have hP : ∀ S : Finset (Fin 4), CanReduceChromatic
+      (SGraph.mk (fun u v => u ∈ S ∧ v ∈ S ∧ trianglePlusIsolated.adj u v)
+        (fun u v ⟨hu, hv, h⟩ => ⟨hv, hu, trianglePlusIsolated.symm u v h⟩)
+        (fun v ⟨_, _, h⟩ => trianglePlusIsolated.irrefl v h)) 3 1 := by
+    intro S
+    refine ⟨killAll4, by decide, ⟨fun _ => 0, ?_⟩⟩
+    rintro u v ⟨⟨_, _, huv⟩, hnuv, hnvu⟩ _
+    -- Pairs touching vertex `3` are non-adjacent; the rest are killed.
+    fin_cases u <;> fin_cases v <;>
+      first
+        | exact huv.1 rfl
+        | exact huv.2.1 rfl
+        | exact huv.2.2 rfl
+        | exact hnuv (by decide)
+        | exact hnvu (by decide)
+  obtain ⟨c, hc⟩ := hmem trianglePlusIsolated hP
+  -- The triangle `0, 1, 2` needs three distinct colours in `Fin 2`: pigeonhole.
+  have h01 := hc 0 1 ⟨by decide, by decide, by decide⟩
+  have h02 := hc 0 2 ⟨by decide, by decide, by decide⟩
+  have h12 := hc 1 2 ⟨by decide, by decide, by decide⟩
+  have v0 := (c 0).isLt
+  have v1 := (c 1).isLt
+  have v2 := (c 2).isLt
+  have e01 : (c 0).val ≠ (c 1).val := fun h => h01 (Fin.ext h)
+  have e02 : (c 0).val ≠ (c 2).val := fun h => h02 (Fin.ext h)
+  have e12 : (c 1).val ≠ (c 2).val := fun h => h12 (Fin.ext h)
+  omega
+
+/-- **`fThreshold 1 4 ≤ 2`** — the parent file's prose counterexample
+machine-checked. -/
+theorem fThreshold_one_four_le_two : fThreshold 1 4 ≤ 2 := by
+  rw [fThreshold_eq_sSup]
+  refine csSup_le' ?_
+  intro k hk
+  by_contra hlt
+  push_neg at hlt
+  exact three_notMem_fThresholdSet_one_four
+    (fThresholdSet_downClosed (by omega) hk)
+
+/-- The parent's removed axiom `f_trivial_lower` (`n - 1 ≤ fThreshold r n`) is
+**false**: at `r = 1`, `n = 4` the threshold is at most `2 < 3 = n - 1`. The
+"remove a spanning tree" intuition fails because `fThreshold` quantifies over
+*all* graphs, and `K₃` + isolated vertex needs only `3` deletions per subgraph
+while refusing `2`-colorability. -/
+theorem trivial_lower_bound_false : fThreshold 1 4 < 4 - 1 := by
+  have := fThreshold_one_four_le_two
+  omega
+
 #check @completeGraph_not_hasColoring
 #check @canReduce_removeAll
 #check @fThresholdSet_downClosed
@@ -245,5 +499,11 @@ theorem fThresholdSet_eq_univ_of_card_le {r n : ℕ} (hn : n ≤ r + 1) :
 #check @fThresholdSet_eq_Iic
 #check @hasColoring_of_card_le
 #check @fThresholdSet_eq_univ_of_card_le
+#check @three_notMem_fThresholdSet_one_three
+#check @two_mem_fThresholdSet_one_three
+#check @fThreshold_one_three
+#check @three_notMem_fThresholdSet_one_four
+#check @fThreshold_one_four_le_two
+#check @trivial_lower_bound_false
 
 end Erdos1092OQ02

--- a/research/problems/erdos-1092-oq-02/knowledge.md
+++ b/research/problems/erdos-1092-oq-02/knowledge.md
@@ -132,3 +132,51 @@ Regime dichotomy now complete: `fThresholdSet r n` is **either** all of ℕ (`n 
 ### Frontier (UNCHANGED)
 Parent open question (Rödl's construction for r ≥ 3) remains research-level and untouched.
 The OQ02 file's own well-definedness account (both regimes) is now complete.
+
+## Session 2026-07-24 (researcher-3): first exact value — fThreshold 1 3 = 2
+
+With the well-definedness theory complete (both regimes), this session computes the
+threshold at the smallest non-degenerate point (r,n) = (1,3) and machine-checks the
+parent's prose-only refutation of its removed `f_trivial_lower` axiom. All new
+theorems `#print axioms` = [propext, Classical.choice, Quot.sound]. Docker build green.
+
+- `three_notMem_fThresholdSet_one_three`: budget 3 admits K₃ — removal set
+  `killAll3 = {(0,1),(0,2),(1,2)}` makes every induced subgraph edgeless (a single
+  FIXED removal set works for every S), yet K₃ is not 2-colorable. Downward closure
+  then gives `fThreshold_one_three_le_two`.
+- `two_mem_fThresholdSet_one_three`: budget 2 forces 2-colorability of EVERY 3-vertex
+  graph. Mechanism: from a 1-coloring of the reduced univ-induced graph (Fin 1 is
+  subsingleton) extract `hkill : every edge has (u,v) ∈ removed ∨ (v,u) ∈ removed`.
+  K₃ branch: intersect `removed` with the three DISJOINT pair-slots {(u,v),(v,u)} —
+  three nonempty disjoint intersections give three pairwise-distinct members, so
+  card ≥ 3 > 2. This avoids the naive 2³-way rcases entirely. Non-K₃ branches: only
+  THREE cases needed (¬h12 → ![0,1,1]; ¬h02 → ![0,1,0]; ¬h01 → ![0,0,1]), each closed
+  by `fin_cases u <;> fin_cases v <;> first | irrefl | hyp | symm-hyp | decide`.
+- `fThreshold_one_three : fThreshold 1 3 = 2` — first exact value in the family.
+- `trianglePlusIsolated` (K₃ + isolated vertex, adj := u≠v ∧ u≠3 ∧ v≠3) +
+  `three_notMem_fThresholdSet_one_four` + `fThreshold_one_four_le_two` +
+  `trivial_lower_bound_false : fThreshold 1 4 < 4 - 1`: the parent's removed axiom
+  `n-1 ≤ fThreshold r n` is now refuted IN LEAN, not just in a comment. Pigeonhole:
+  triangle colors have pairwise-distinct .val < 2 → omega.
+
+### Lean gotchas (v4.31)
+- `decide` + `open scoped Classical` (parent file opens it): decide FAILS on
+  implications (forall_prop_decidable → Classical.propDecidable, stuck on choice) but
+  still works on concrete `Finset` memberships / card (real instances outrank the
+  classical fallback). Structure per-pair goals as
+  `first | exact huv rfl | exact hnuv (by decide) | exact hnvu (by decide)`.
+- Distinctness of slot witnesses: after `simp only [Finset.mem_insert, mem_singleton]`,
+  `rintro rfl; rcases haE with rfl | rfl <;> simp_all` (simp evaluates concrete
+  Fin-pair equalities via Prod.mk.injEq + Fin.reduceEq).
+- `hc 0 1 ⟨by decide, by decide, by decide⟩` fine for concrete adjacency of a named
+  SGraph (each conjunct decidable).
+
+### Frontier after this session
+- `2 ∈ fThresholdSet 1 4` (would give fThreshold 1 4 = 2 exactly, matching the
+  parent's prose claim): needs "≤ 2 removed pairs ⟹ 2-colorable" on 4 vertices —
+  the two surviving unordered edges force a case split on how they share vertices
+  (disjoint / share one / same); a path a-b-c needs the middle vertex colored alone.
+  Doable (~100 lines), natural next rung.
+- Exact values at (1,5), (2,4): larger case analyses; (2,4) = smallest point with
+  r ≥ 2, likely needs K₄-slot counting (6 slots vs budget).
+- Parent OQ (Rödl for r ≥ 3): research-level, untouched.

--- a/research/problems/erdos-1092-oq-02/state.md
+++ b/research/problems/erdos-1092-oq-02/state.md
@@ -23,3 +23,11 @@ None.
 ## Next Action
 Read problem.md thoroughly and acquire full context.
 Then move to ORIENT phase to explore literature and related proofs.
+
+## Status (researcher-3, 2026-07-24) — ACT: first exact value landed
+
+`fThreshold 1 3 = 2` machine-checked (first exact value in the family), and the
+parent's removed `f_trivial_lower` axiom refuted in Lean (`fThreshold 1 4 < 3`
+via K₃ + isolated vertex). File 249 → 509 lines, 13 → 21 theorems, 0 axioms /
+0 sorries. Next natural rung: `2 ∈ fThresholdSet 1 4` (exact value at (1,4));
+parent OQ (Rödl for r ≥ 3) remains research-level.

--- a/src/data/research/problems/erdos-1092-oq-02.json
+++ b/src/data/research/problems/erdos-1092-oq-02.json
@@ -29,18 +29,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (VERIFIED 0/0, researcher-1 2026-07-20): extended Erdos1092OQ02.lean from an upper bound to a FULL structural characterization of the fThreshold defining set. New (all axiom-free): fThresholdSet_zero_mem (0∈ unconditionally ⇒ set nonempty), fThreshold_mem (threshold is an ATTAINED maximum via Nat.sSup_mem on the nonempty+bounded set), mem_fThresholdSet_iff (k∈set ↔ k≤fThreshold ⇒ set = interval {0,…,fThreshold}) in the non-degenerate regime 1≤r ∧ r+2≤n. Prior session (researcher-5) had proved boundedness (fThreshold_le_sq ≤ n*n) only. The parent-level open question (does Rödl generalize to r≥3) remains research-level and untouched. 0 axioms, 0 sorries.",
+    "progressSummary": "PROGRESS (researcher-3 2026-07-24): FIRST EXACT VALUE — fThreshold 1 3 = 2, machine-checked (upper: K3 with 3-pair budget; lower: disjoint pair-slot counting shows budget 2 excludes K3, explicit 2-colorings for the rest). Also formalized the parent's prose-only refutation of its removed f_trivial_lower axiom: fThreshold 1 4 <= 2 < 3 = n-1 via K3+isolated vertex. File 249->509 lines, 13->21 theorems, still 0 axioms/sorries. Parent-level OQ (Rodl for r>=3) untouched — research-level.",
     "builtItems": [
       "fThresholdSet_zero_mem (Erdos1092OQ02.lean): 0 ∈ fThresholdSet r n unconditionally — defining set always nonempty",
       "fThresholdSet_nonempty (Erdos1092OQ02.lean): (fThresholdSet r n).Nonempty",
       "fThreshold_mem (Erdos1092OQ02.lean): fThreshold r n ∈ fThresholdSet r n for 1≤r ∧ r+2≤n — threshold is an ATTAINED maximum (Nat.sSup_mem)",
-      "mem_fThresholdSet_iff (Erdos1092OQ02.lean): k ∈ fThresholdSet r n ↔ k ≤ fThreshold r n in good regime — set = interval {0,…,fThreshold}"
+      "mem_fThresholdSet_iff (Erdos1092OQ02.lean): k ∈ fThresholdSet r n ↔ k ≤ fThreshold r n in good regime — set = interval {0,…,fThreshold}",
+      "killAll3/killAll4 + three_notMem_fThresholdSet_one_three/one_four in Erdos1092OQ02.lean",
+      "two_mem_fThresholdSet_one_three (budget 2 forces 2-colorability on 3 vertices; disjoint-slot counting + 3 explicit colorings)",
+      "fThreshold_one_three : fThreshold 1 3 = 2 (first exact value)",
+      "trianglePlusIsolated + fThreshold_one_four_le_two + trivial_lower_bound_false (parent prose refutation machine-checked)"
     ],
     "insights": [
       "fThreshold has TWO degeneracies: upper r+1≥n (set=ℕ, all graphs (r+1)-colorable) and lower r=0 (set=ℕ, no 0-coloring on n≥1 vertices). Non-degenerate regime is 1≤r ∧ r+2≤n.",
       "Boundedness of the fThreshold defining set follows from K_n as a witness that satisfies the full-budget hypothesis (empty-graph reduction) yet fails (r+1)-colorability (pigeonhole).",
       "The zero-budget hypothesis (every induced subgraph r-colorable with 0 deletions) already forces (r+1)-colorability: apply at S=univ where the induced graph shares G's adjacency. Hence 0 ∈ fThresholdSet UNCONDITIONALLY (no regime needed).",
-      "Combining nonemptiness (0∈) with bddAbove gives Nat.sSup_mem ⇒ fThreshold is ATTAINED, and downward-closedness upgrades this to the full interval characterization fThresholdSet = {0,…,fThreshold} in the non-degenerate regime."
+      "Combining nonemptiness (0∈) with bddAbove gives Nat.sSup_mem ⇒ fThreshold is ATTAINED, and downward-closedness upgrades this to the full interval characterization fThresholdSet = {0,…,fThreshold} in the non-degenerate regime.",
+      "fThreshold 1 3 = 2 EXACTLY: (r,n)=(1,3) is the smallest non-degenerate point (1<=r, r+2<=n), and the threshold there is 2 — first exact value ever computed for this problem family",
+      "Lower-bound mechanism: each removed ordered pair kills at most one undirected edge; formalized by intersecting removed with the three DISJOINT pair-slots {(u,v),(v,u)} of K3 — three nonempty disjoint intersections force card >= 3, beating budget 2 uniformly (no 8-way rcases)",
+      "Upper-bound mechanism at (1,4): trianglePlusIsolated (K3 + isolated vertex) satisfies the budget-3 hypothesis but pigeonholes three colors into Fin 2 — the parent's removed f_trivial_lower axiom (n-1 <= fThreshold r n) is now REFUTED in Lean, not just prose",
+      "decide + open scoped Classical gotcha: decide fails on implications (forall_prop_decidable picks Classical.propDecidable) but still works on concrete Finset memberships; structure fin_cases branches as first | exact huv rfl | exact hnuv (by decide) | ..."
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -69,10 +77,10 @@
     {
       "path": "Proofs/Erdos1092OQ02.lean",
       "filename": "Erdos1092OQ02.lean",
-      "lineCount": 220,
-      "theoremCount": 10,
+      "lineCount": 509,
+      "theoremCount": 21,
       "axiomCount": 0,
-      "defCount": 2,
+      "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1092OQ02.lean"


### PR DESCRIPTION
## Summary
Research session for erdos-1092-oq-02 (Erdős #1092 chromatic-decomposition threshold, well-definedness node).

## Progress
- **First exact threshold value: `fThreshold 1 3 = 2`**, machine-checked at the smallest non-degenerate point of the good regime.
  - Upper bound: budget 3 admits K3 (fixed removal set `killAll3` makes every induced subgraph edgeless; K3 is not 2-colorable).
  - Lower bound: budget 2 forces 2-colorability of every 3-vertex graph — a disjoint pair-slot counting argument shows two removed ordered pairs cannot kill K3's three edges (no 8-way case explosion), and every non-K3 graph gets an explicit 2-coloring (3-case split).
- **Parent's removed `f_trivial_lower` axiom refuted in Lean**: `trivial_lower_bound_false : fThreshold 1 4 < 4 - 1` via `trianglePlusIsolated` (K3 + isolated vertex) — previously only a prose remark in the parent file.
- `proofs/Proofs/Erdos1092OQ02.lean`: 249 → 509 lines, 13 → 21 theorems, still **0 axioms, 0 sorries**. All new theorems `#print axioms` = `[propext, Classical.choice, Quot.sound]`.
- Docker build green (`Proofs.Erdos1092OQ02`, 8577 jobs).

## Findings
- Each removed ordered pair kills at most one undirected edge; formalizing this as "removed meets three disjoint pair-slots ⟹ card ≥ 3" is uniform and short.
- `decide` under `open scoped Classical` fails on implications but still handles concrete Finset memberships — structure per-pair goals as `first | exact huv rfl | exact hnuv (by decide) | ...`.

## Status
**Outcome**: progress (structural extension; node's own well-definedness story now extended to exact computation)
**Next Steps**: `2 ∈ fThresholdSet 1 4` would pin `fThreshold 1 4 = 2` exactly (case split on how two surviving edges share vertices, ~100 lines); then (2,4) / (1,5). Parent OQ (Rödl for r ≥ 3) remains research-level.

🤖 Generated by researcher-3
