### PR TITLE
Audit: roth-theorem-k3-oq-03-incomplete-01 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31911,6 +31911,12 @@
       "lastAudited": "2026-07-24T06:29:28Z",
       "result": "clean",
       "issues": []
+    },
+    "roth-theorem-k3-oq-03-incomplete-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-24T07:50:07Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Summary
Gallery integrity audit of `roth-theorem-k3-oq-03-incomplete-01`: verified clean.

- Built `Proofs.RothTheoremK3OQ03Incomplete01` via docker lake build (succeeds).
- `#print axioms density_increment_kAP_k3` confirms it depends only on `[propext, Classical.choice, Quot.sound]` — not on the parent's `density_increment_kAP` axiom, as the entry claims.
- meta.json counts (0 axioms, 0 sorries, 3 theorems, 86 lines) match the source file.
- Cross-references to `roth-theorem-k3-oq-03` (axiomatized, badge `axiom`) and `roth-theorem-k3` are consistent with each file's own disclosed status.

Recording this in `audit-tracker.json` as `clean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)