### PR TITLE
Fix stale phantom-axiom docstring in pell-equation-oq-01

### DIFF
--- a/proofs/Proofs/PellEquationOQ01.lean
+++ b/proofs/Proofs/PellEquationOQ01.lean
@@ -9,7 +9,8 @@ Heuristic: log(x₁ + y₁√D) ≈ √D, but the distribution is poorly underst
 
 ## What This Proves
 1. **Pell regulator definition**: R(D) = log(x₁ + y₁√D) where (x₁,y₁) is fundamental
-2. **Lower bound**: x₁ ≥ 2 for the fundamental solution (from minimality)
+2. **Basic bounds**: for any solution with x ≥ 1, y ≥ 0, the norm x + y√D ≥ 1
+   and hence the regulator R(D) ≥ 0
 3. **Explicit small solutions**: For D = n²-1 (n≥2), the fundamental solution is
    (n, 1), giving R(D) = log(n + √(n²-1)) ≈ log(2n) — much smaller than √D.
 4. **Explicit large solutions**: Fermat's D=61 has x₁ = 1766319049, demonstrating
@@ -18,9 +19,8 @@ Heuristic: log(x₁ + y₁√D) ≈ √D, but the distribution is poorly underst
 6. **Connection to class numbers**: The regulator-class number relationship.
 
 ## Axioms
-- pell_fundamental_x_ge_two: The fundamental solution has x₁ ≥ 2.
-  This follows from minimality (x > 1 in Mathlib's IsFundamental), but converting
-  1 < x to x ≥ 2 in ℤ requires careful handling.
+None. The bounds below only need `hx : 1 ≤ x`, not the stronger x₁ ≥ 2, so no
+axiom is required.
 
 ## Status: OPEN (the distribution of R(D) is a major open problem)
 


### PR DESCRIPTION
## Integrity Fix

**Proof**: pell-equation-oq-01

**Problem**: `proofs/Proofs/PellEquationOQ01.lean`'s header docstring listed an
axiom `pell_fundamental_x_ge_two` (fundamental solution has x₁ ≥ 2) under a
`## Axioms` section, describing it as a real formal assumption. No such
`axiom` declaration (or any theorem proving this bound) exists anywhere in
the file — grep confirms zero `axiom` keyword hits. `meta.json`'s
`axiomCount: 0` and `assumptions` field were already accurate; the
inconsistency was confined to the .lean file's own docstring, which claimed
a kernel-tracked commitment that doesn't exist (comment-only "axiomatized"
overclaim, per the `erdos-496` pattern).

Also fixed the adjacent "What This Proves" item 2, which claimed "Lower
bound: x₁ ≥ 2 for the fundamental solution (from minimality)" — no theorem
in the file proves this; the actual lemmas (`pellNorm_pos_of_pos`,
`pellRegulator_nonneg`) only *assume* `hx : 1 ≤ x` as a hypothesis, they
don't derive x ≥ 2.

## Evidence

**Docstring claims**: axiom `pell_fundamental_x_ge_two` exists; "Lower bound:
x₁ ≥ 2 ... proved"
**Lean file shows**: `grep axiom` → no declarations; the only lemmas
concerning x take `1 ≤ x` as a hypothesis, never conclude x ≥ 2

## Fix

Rewrote the `## Axioms` section to say "None" with a one-line explanation of
why (the real lemmas only need `1 ≤ x`), and rewrote "What This Proves" item
2 to describe what Part 2 (`pellNorm_pos_of_pos`, `pellRegulator_nonneg`)
actually proves (norm ≥ 1 ⟹ regulator ≥ 0). Comment-only change, verified via
`./proofs/scripts/docker-build.sh Proofs.PellEquationOQ01` — build succeeds
(pre-existing unused-variable lint warnings only, unrelated to this change).

---
Discovered during gallery integrity audit.