### PR TITLE
Track audit: pell-equation-oq-01 (issues-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23386,12 +23386,12 @@
     },
     "pell-equation-oq-01": {
       "agentId": "lean-mechanic",
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [
         "status corrected from verified to axiomatized; closed #9693"
       ],
-      "lastAudited": "2026-05-04T04:06:33Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T07:58:19Z",
+      "result": "issues-fixed"
     },
     "pell-equation-oq-01-oq-04": {
       "auditCount": 1,


### PR DESCRIPTION
Records completion of the pell-equation-oq-01 audit claim. The underlying fix (stale phantom-axiom docstring) was merged in #43189; this updates the audit tracker to reflect `issues-fixed` and clears the claim.