### PR TITLE
Track audit: law-of-cosines-oq-04 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21999,12 +21999,12 @@
     },
     "law-of-cosines-oq-04": {
       "agentId": "lean-mechanic",
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "https://github.com/rjwalters/lean-genius/issues/8640",
         "True stub (angle_bisector_stewarts) converted to comment; closed #8640"
       ],
-      "lastAudited": "2026-05-04T04:06:33Z",
+      "lastAudited": "2026-07-24T08:00:53Z",
       "result": "clean"
     },
     "law-of-cosines-oq-04-oq-01": {


### PR DESCRIPTION
Records completion of the law-of-cosines-oq-04 gallery integrity audit. No issues found: counts match exactly, no phantom section decls, no native_decide.