### PR TITLE
Track audit: intermediate-value-theorem-oq-03 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21100,12 +21100,12 @@
     },
     "intermediate-value-theorem-oq-03": {
       "agentId": "lean-mechanic",
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "https://github.com/rjwalters/lean-genius/issues/8637",
         "True stubs (ivt_from_brouwer_sketch, dimensional_summary) converted to comments; closed #8637"
       ],
-      "lastAudited": "2026-05-04T04:06:33Z",
+      "lastAudited": "2026-07-24T08:03:12Z",
       "result": "clean"
     },
     "intermediate-value-theorem-oq-03-oq-01": {


### PR DESCRIPTION
## Audit result

**Proof**: intermediate-value-theorem-oq-03
**Result**: clean

Verified meta.json claims against the Lean source (`proofs/Proofs/IntermediateValueTheoremOQ03.lean`):
- 1 axiom (`brouwer_2d`) — matches disclosed `axiomCount: 1`, Tier C `axiom` badge is correct
- 0 sorries, matches
- 2 theorems (`brouwer_1d`, `ivt_fails_2d`), matches disclosed `theoremCount: 2`
- No True stubs, no native_decide
- `ivt_fails_2d` is a tautological statement, but this is honestly disclosed in the section's `mathContext` ("This is tautological...")
- Both crossReference targets (`intermediate-value-theorem`, `schauder-fixed-point-oq-03`) exist in the gallery

Updates `src/data/proofs/audit-tracker.json` only.

---
Discovered during gallery integrity audit.