### PR TITLE
Enrich beta-integral-recurrence-oq-01-oq-02-oq-01: split docstring section (4->5)

### DIFF
--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01/meta.json
@@ -97,12 +97,20 @@
   },
   "sections": [
     {
-      "id": "docstring",
-      "title": "Module Docstring: The Half-Integer Beta Diagonal",
-      "startLine": 6,
-      "endLine": 66,
-      "summary": "States the general half-integer diagonal value B(n+1/2,n+1/2) = π·(2n)!/(4^(2n)·(n!)²) = π·C(2n,n)/4^(2n) and frames it as the transcendental mirror of the gallery's rational integer diagonal B(n+1,n+1)=1/((2n+1)·C(2n,n)): the same central binomial coefficient, moved from denominator to numerator and scaled by π. Notes that Mathlib has neither the factorial form of Γ(n+1/2) nor any half-integer Beta value, and outlines the induction-plus-assembly strategy.",
-      "mathContext": "$B(n+\\tfrac12,n+\\tfrac12) = \\dfrac{\\pi\\,(2n)!}{4^{2n}(n!)^2} = \\dfrac{\\pi\\binom{2n}{n}}{4^{2n}}$."
+      "id": "docstring-statement",
+      "title": "Imports and the Diagonal Value Statement",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "Imports the Gamma/Beta special functions, the Gaussian integral (source of Γ(1/2)=√π), central binomial coefficients, and general tactics. The module docstring then states the closed form B(n+1/2,n+1/2) = π·(2n)!/(4^(2n)·(n!)²) = π·C(2n,n)/4^(2n), notes it subsumes the sibling entry's case-by-case values B(1/2,1/2)=π and B(3/2,3/2)=π/8, and contrasts it with the gallery's rational integer diagonal B(n+1,n+1)=1/((2n+1)·C(2n,n)): the same central binomial coefficient appears, but moved from denominator to numerator and scaled by the transcendental π.",
+      "mathContext": "$B(n+\\tfrac12,n+\\tfrac12) = \\dfrac{\\pi\\,(2n)!}{4^{2n}(n!)^2}$ vs. the integer diagonal $B(n+1,n+1) = \\dfrac{1}{(2n+1)\\binom{2n}{n}}$."
+    },
+    {
+      "id": "docstring-approach",
+      "title": "Relation to Mathlib and Proof Approach",
+      "startLine": 39,
+      "endLine": 72,
+      "summary": "Notes that Mathlib supplies the Beta–Gamma division formula, the real/complex Gamma bridge, and the double-factorial half-integer Gamma value Γ(k+1/2)=(2k−1)‼·√π/2^k, but neither the factorial form of Γ(n+1/2) nor any half-integer Beta value — the new content proved here. Outlines the two-step strategy: induct on the Gamma functional equation Γ(s+1)=s·Γ(s) to get the factorial closed form of Γ(n+1/2), then assemble the diagonal value via the Beta–Gamma relation. Opens the `BetaIntegralRecurrenceOQ01OQ02OQ01` namespace and the `Nat`/`Real` scopes used throughout.",
+      "mathContext": "$\\Gamma(n+\\tfrac12)=\\sqrt\\pi\\cdot\\dfrac{(2n)!}{4^n\\,n!}$ via $\\Gamma(s+1)=s\\Gamma(s)$, then $B(u,v)=\\dfrac{\\Gamma u\\,\\Gamma v}{\\Gamma(u+v)}$."
     },
     {
       "id": "gamma-closed-form",
@@ -124,7 +132,7 @@
       "id": "central-binomial",
       "title": "Central Binomial Form and Sanity Checks",
       "startLine": 139,
-      "endLine": 172,
+      "endLine": 173,
       "summary": "betaIntegral_diag_half_centralBinom rewrites (2n)! = C(2n,n)·n!·n! (Nat.choose_mul_factorial_mul_factorial) to express the value as π·C(2n,n)/4^(2n). The two sanity theorems specialize n=0 and n=1, recovering the sibling entry's B(1/2,1/2)=π (C(0,0)=1) and B(3/2,3/2)=π/8 (C(2,1)=2, 4²=16).",
       "mathContext": "$B(n+\\tfrac12,n+\\tfrac12) = \\dfrac{\\pi\\binom{2n}{n}}{4^{2n}}$; $n{=}0\\to\\pi$, $n{=}1\\to\\pi/8$."
     }


### PR DESCRIPTION
## Summary
- The module docstring (lines 6-66) was a single monolithic `sections` entry, capping the sections quality score at 4/5 (8/10 points).
- Split it into two substantive sections along its natural content boundaries: `docstring-statement` (imports + the diagonal value statement + contrast with the integer diagonal) and `docstring-approach` (relation to Mathlib + proof strategy + namespace/open setup).
- Also closed three small coverage gaps that existed before this split: lines 1-5 (imports), lines 67-72 (namespace/open declarations), and line 173 (closing `end` line) were previously outside any section's line range.
- No content deleted; all annotation/mathContext/keyInsight/conclusion fields already at target and left untouched.

Quality score 98 -> 100 (sections 8/10 -> 10/10).

## Test plan
- [x] Verified JSON validity after edit
- [x] `pnpm build` passes end-to-end (annotations:build, research:build, tsc -b, vite build, bundle budget check all green)