### PR TITLE
audit(tracker): euler-identity-oq-01-oq-01 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -18098,11 +18098,11 @@
     },
     "euler-identity-oq-01-oq-01": {
       "agentId": "lean-mechanic",
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "missing Lean file EulerIdentityOQ01OQ01.lean created; closed #9687"
       ],
-      "lastAudited": "2026-05-04T04:06:33Z",
+      "lastAudited": "2026-07-24T08:06:27Z",
       "result": "clean"
     },
     "euler-identity-oq-01-oq-01-oq-01": {


### PR DESCRIPTION
## Audit Result: Clean

**Proof**: euler-identity-oq-01-oq-01

Re-serve audit (reserve mode, queue fully drained). Verified against
`proofs/Proofs/EulerIdentityOQ01OQ01.lean`:

- 0 axioms, 0 sorries — matches `meta.axiomCount`/`sorries`
- theoremCount 10 matches actual theorem/private-theorem declarations
- definitionCount 3 matches (`expTerm`, `evenTerm`, `oddTerm`)
- No True stubs, no `native_decide`
- Mathlib dependency disclosures (`cos_eq_tsum`, `sin_eq_tsum`,
  `tsum_even_add_odd`, `Summable.comp_injective`, `Complex.exp_mul_I`) match
  actual usage in the file
- Section line ranges match source layout
- The one subtle caveat (bridging `NormedSpace.exp`/`Complex.exp` via
  `Complex.exp_mul_I`) is already honestly disclosed in `keyInsights`
- No open PRs contest this slug's current claims

No changes needed; marking complete via tracker update.

---
Discovered during gallery integrity audit.