### PR TITLE
audit(yang-mills-2d-oq-01): re-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -26765,9 +26765,9 @@
       "result": "clean"
     },
     "yang-mills-2d-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:35Z",
+      "lastAudited": "2026-07-24T08:14:21Z",
       "result": "clean"
     },
     "yang-mills-2d-oq-02": {


### PR DESCRIPTION
## Integrity Audit (reserve mode)

**Proof**: yang-mills-2d-oq-01
**Result**: clean, re-verified

Verified against `proofs/Proofs/YangMills2DOQ01.lean`:
- 0 sorries, 0 axioms (grep hits are docstring prose only)
- 16 theorems, 8 definitions — match meta.json exactly
- No native_decide
- Truncated partition function (3 of infinitely many representation terms) is honestly disclosed both in Lean comments and meta description
- `mathlib` badge is conservative (proofs are self-contained algebra via `ring`/`field_simp`/`linarith`, not a deep Mathlib call) — under-claims rather than over-claims, not an integrity issue

No action needed beyond tracker timestamp update.