### PR TITLE
audit(erdos-29-oq-02): fix stale mathlibDependencies entry

### DIFF
--- a/src/data/proofs/erdos-29-oq-02/meta.json
+++ b/src/data/proofs/erdos-29-oq-02/meta.json
@@ -23,9 +23,14 @@
         "module": "Mathlib.Data.Finset.Image"
       },
       {
-        "theorem": "Real.sqrt_le_left",
-        "description": "Square root comparison",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+        "theorem": "Real.sqrt_le_sqrt",
+        "description": "Monotonicity of square root under ≤",
+        "module": "Mathlib.Analysis.Real.Sqrt"
+      },
+      {
+        "theorem": "Real.sqrt_sq",
+        "description": "√(x²) = x for x ≥ 0",
+        "module": "Mathlib.Analysis.Real.Sqrt"
       }
     ],
     "originalContributions": [


### PR DESCRIPTION
## Integrity audit finding (LOW severity)

**Proof**: erdos-29-oq-02

meta.json's `mathlibDependencies` cited `Real.sqrt_le_left`, which does not
appear anywhere in `proofs/Proofs/Erdos29OQ02.lean`. The real-valued bound
step (`basis_size_lower_bound_correct`) actually uses `Real.sqrt_le_sqrt`
(monotonicity) and `Real.sqrt_sq`, both in `Mathlib.Analysis.Real.Sqrt`.

Everything else checked out clean: 0 sorries, 0 axioms, 7 theorems, 4
definitions, no True stubs — all match the source file exactly, and the
`verified` status / `original` badge are appropriate.

## Fix

Replaced the stale dependency entry with the two lemmas actually used.

---
Discovered during gallery integrity audit.