### PR TITLE
audit(tracker): erdos-29-oq-02 issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12313,13 +12313,13 @@
     },
     "erdos-29-oq-02": {
       "agentId": "lean-mechanic",
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "https://github.com/rjwalters/lean-genius/issues/8636",
         "True stubs (counterexample_satisfies_correct_bound, why_original_was_wrong) converted to comments; closed #8636"
       ],
-      "lastAudited": "2026-05-04T04:06:33Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T08:22:01Z",
+      "result": "issues-fixed"
     },
     "erdos-290": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Tracker update following #43198 (stale mathlibDependencies entry fixed for
erdos-29-oq-02: 0 sorries / 0 axioms / verified status all confirmed accurate).