### PR TITLE
Enrich bezout-identity-oq-04-oq-01-oq-03: add header section (4->5)

### DIFF
--- a/src/data/proofs/bezout-identity-oq-04-oq-01-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01-oq-03/meta.json
@@ -76,6 +76,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Header: What the Two SNF Axioms Cost, and Which One Is Real",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Module docstring stating the two-part finding before opening the BezoutIdentityOQ04OQ01OQ03 namespace: snf_exists is genuinely missing from Mathlib in matrix form (only the module-theoretic Smith Normal Form exists), while snf_solvability_criterion is not an independent axiom — it is proved below as a zero-axiom theorem from the decomposition alone, with the transformed right-hand side corrected from U·b to the genuine inverse U⁻¹·b.",
+      "mathContext": "$A = U D V$ taken as hypothesis (not proved); the goal is $\\exists x,\\ A\\cdot_v x = b \\iff \\forall i,\\ \\mathrm{dEntry}\\,D\\,i \\mid (U^{-1}\\cdot_v b)_i$."
+    },
+    {
       "id": "diagonal-entry",
       "title": "The Diagonal Entry of a Rectangular Matrix",
       "startLine": 50,


### PR DESCRIPTION
Enrichment pass for `bezout-identity-oq-04-oq-01-oq-03` (quality 98/100).

`qualityBreakdown` showed everything at cap except `sections` reading 4/5 —
the module docstring (lines 1-49: the two-axiom finding, the U⁻¹·b convention
correction) had no section covering it; the first existing section
(`diagonal-entry`) started at line 50. Added a `header` section spanning
lines 1-49, following the established pattern for this gap
(see other `header`-section fixes, e.g. PR #43083, #43084).

No other fields needed changes — annotations (5, all with `mathContext`/
`significance`/`relatedConcepts`/`prerequisites`), `historicalContext`,
`keyInsights` (5), `conclusion` (summary + implications + 3 openQuestions),
and `crossReferences` were all already at target. File stays at ~16 KB,
well under the 60 KB cap.