### PR TITLE
Research: erdos-1215-oq-02 - exit paths in every direction (OQ02OQ10, two-sided sharp bound)

### DIFF
--- a/proofs/Proofs/CyclotomicPolynomialsOQ02OQ10.lean
+++ b/proofs/Proofs/CyclotomicPolynomialsOQ02OQ10.lean
@@ -157,7 +157,7 @@ theorem ray_exit (n : ℕ) (hn : n ≠ 0) (u : ℂ) (hu : ‖u‖ = 1) {C : ℝ}
   -- Sharp lower bound: before `C^{1/φ(n)} − 1` the ray is strictly inside the set.
   have hlow : C ^ ((n.totient : ℝ)⁻¹) - 1 ≤ t := by
     by_contra hlt
-    push_neg at hlt
+    push Not at hlt
     have := rayNorm_lt_of_lt_sharpInner n hn u hu hC ht0 hlt
     linarith
   have htpos : 0 < t := lt_of_lt_of_le hrin_pos hlow
@@ -167,7 +167,7 @@ theorem ray_exit (n : ℕ) (hn : n ≠ 0) (u : ℂ) (hu : ‖u‖ = 1) {C : ℝ}
     intro s hs
     obtain ⟨hs0, hst⟩ := hs
     by_contra hge
-    push_neg at hge
+    push Not at hge
     have hsA : s ∈ A := ⟨⟨hs0, le_trans (le_of_lt hst) htR⟩, hge⟩
     have hts : t ≤ s := csInf_le hAbdd hsA
     linarith

--- a/proofs/Proofs/CyclotomicPolynomialsOQ02OQ10.lean
+++ b/proofs/Proofs/CyclotomicPolynomialsOQ02OQ10.lean
@@ -1,0 +1,234 @@
+/-
+# Erdős #1215 (cyclotomic sub-question, OQ02) — exit paths in EVERY direction
+
+  Slug: erdos-1215-oq-02
+  Prior work (this OQ family):
+    * OQ02OQ01  — lower/upper factor bounds, boundedness, openness of `{|Φ_n| < C}`.
+    * OQ02OQ02  — sharp two-sided factor bounds `(‖z‖-1)^{φ(n)} ≤ |Φ_n(z)| ≤ (‖z‖+1)^{φ(n)}`.
+    * OQ02OQ03–07 — radius/area sandwich, sharp inner/outer radius, origin interiority.
+    * OQ02OQ08  — the FIRST path result: a radial exit along the positive real axis,
+                  first crossing time `t* ≤ 1 + C^{1/φ(n)}`.
+    * OQ02OQ09  — the far field `{R < ‖z‖}` is one path-connected escape region.
+
+  ## What is genuinely open (parent #1215)
+
+  Erdős #1215 asks whether every `P` with `P(0)=1` and unit-circle roots admits a path
+  from `0` to the boundary of `{|P| < C}` of length `≤ C·deg P`, staying inside the set.
+  Mac Lane (1953) answered **NO in general**: labyrinth polynomials force arbitrarily
+  long detours (`Erdos1215Problem.maclane_labyrinth`, axiomatized).  OQ02 restricts to
+  the rigid cyclotomic family `Φ_n` and asks whether the labyrinth can still appear.
+
+  ## This file — the OQ08 exit ray holds in EVERY direction
+
+  OQ02OQ08 exhibited a single short exit path, along `ℝ_{≥0}`.  Its recorded follow-up
+  question was whether boundary reachability extends beyond that one ray.  This file
+  answers the directional half of that question completely:
+
+  > For EVERY unit direction `u` (`‖u‖ = 1`), the ray `t ↦ t·u` from the origin has a
+  > first level-`C` crossing `t*` with the **two-sided sharp bound**
+  > `C^{1/φ(n)} − 1 ≤ t* ≤ 1 + C^{1/φ(n)}`, and the open segment `[0, t*)·u` stays
+  > strictly inside `{|Φ_n| < C}` (`ray_exit`).
+
+  Consequences:
+  * the level curve `{|Φ_n| = C}` meets every ray from the origin, inside the sharp
+    annulus `C^{1/φ(n)} − 1 ≤ ‖z‖ ≤ 1 + C^{1/φ(n)}` (`levelCurve_meets_every_ray`) —
+    the boundary *surrounds* the origin in all directions at `n`-uniformly bounded
+    distance (both radii `→` the unit circle as `φ(n) → ∞`);
+  * an explicit straight-segment path of Euclidean length `t* ≤ 1 + C^{1/φ(n)}` in
+    each direction (`ray_exit_pathLength`).
+
+  So not only does one radial ray escape (OQ08): seen from the origin, the cyclotomic
+  sublevel set has NO labyrinthine direction at all — every direction exits after a
+  bounded straight run.  OQ08's `radial_exit` is the special case `u = 1` (up to the
+  extra sharp lower bound proved here, which is new even for that case).
+
+  The mechanism is the OQ08 first-crossing argument run along an arbitrary ray:
+  `‖t·u‖ = t` for `t ≥ 0`, so the OQ02OQ01 lower bound forces a crossing by
+  `1 + C^{1/φ(n)}`, while the OQ02OQ07 sharp inner ball forbids one before
+  `C^{1/φ(n)} − 1`.  No arc-length / rectifiable-path infrastructure is needed —
+  a segment's length is its endpoint distance.
+
+  Result status: `[propext, Classical.choice, Quot.sound]` — axiom-free relative to
+  Mathlib.  The deep `maclane_labyrinth` axiom of the parent is untouched.
+-/
+import Mathlib
+import Proofs.Erdos1215Problem
+import Proofs.CyclotomicPolynomialsOQ02OQ01
+import Proofs.CyclotomicPolynomialsOQ02OQ07
+
+open Complex Polynomial
+
+namespace CyclotomicPolynomialsOQ02OQ10
+
+/-- `rayNorm n u t = |Φ_n(t·u)|`: the modulus of the cyclotomic polynomial restricted
+to the ray through `u`, parameterized by real `t`. -/
+noncomputable def rayNorm (n : ℕ) (u : ℂ) (t : ℝ) : ℝ :=
+  ‖(cyclotomic n ℂ).eval ((t : ℂ) * u)‖
+
+/-- `rayNorm n u` is continuous: it is `‖·‖ ∘ eval ∘ (t ↦ t·u)`. -/
+lemma continuous_rayNorm (n : ℕ) (u : ℂ) : Continuous (rayNorm n u) :=
+  continuous_norm.comp ((cyclotomic n ℂ).continuous.comp
+    (Complex.continuous_ofReal.mul continuous_const))
+
+/-- On the ray through a unit vector, the parameter is the norm: `‖t·u‖ = t` for `t ≥ 0`. -/
+lemma norm_ofReal_mul (u : ℂ) (hu : ‖u‖ = 1) {t : ℝ} (ht : 0 ≤ t) :
+    ‖(t : ℂ) * u‖ = t := by
+  rw [norm_mul, hu, mul_one, Complex.norm_real, Real.norm_eq_abs, abs_of_nonneg ht]
+
+/-- At the origin every ray starts at modulus `1`: `rayNorm n u 0 = |Φ_n(0)| = 1`. -/
+lemma rayNorm_zero (n : ℕ) (hn : n ≠ 0) (u : ℂ) : rayNorm n u 0 = 1 := by
+  simp only [rayNorm, Complex.ofReal_zero, zero_mul]
+  exact CyclotomicPolynomialsOQ02OQ07.norm_cyclotomic_eval_zero n hn
+
+/-- **The sharp outer radius forces a crossing in every direction.**
+At `R = 1 + C^{1/φ(n)}` along any unit direction `u` we have `|Φ_n(R·u)| ≥ C`:
+the point `R·u` has norm `R`, so the OQ02OQ01 lower bound
+`(‖z‖-1)^{φ(n)} ≤ |Φ_n(z)|` evaluates to `(C^{1/φ(n)})^{φ(n)} = C`. -/
+lemma le_rayNorm_outer (n : ℕ) (hn : n ≠ 0) (u : ℂ) (hu : ‖u‖ = 1)
+    {C : ℝ} (hC : 1 < C) :
+    C ≤ rayNorm n u (1 + C ^ ((n.totient : ℝ)⁻¹)) := by
+  have hC0 : (0 : ℝ) < C := lt_trans one_pos hC
+  have hk0 : n.totient ≠ 0 := (Nat.totient_pos.mpr (Nat.pos_of_ne_zero hn)).ne'
+  set r : ℝ := C ^ ((n.totient : ℝ)⁻¹) with hr
+  have hr1 : 1 < r := by
+    have h := CyclotomicPolynomialsOQ02OQ07.sharpInnerRadius_pos n hn hC
+    rw [← hr] at h; linarith
+  have hRnn : (0 : ℝ) ≤ 1 + r := by linarith
+  have hnorm : ‖((1 + r : ℝ) : ℂ) * u‖ = 1 + r := norm_ofReal_mul u hu hRnn
+  have h1le : (1 : ℝ) ≤ ‖((1 + r : ℝ) : ℂ) * u‖ := by rw [hnorm]; linarith
+  have hlow := CyclotomicPolynomialsOQ02OQ01.pow_sub_one_le_norm_cyclotomic_eval
+    n hn (((1 + r : ℝ) : ℂ) * u) h1le
+  rw [hnorm] at hlow
+  have hpoweq : (1 + r - 1) ^ n.totient = C := by
+    have h1 : (1 + r - 1) = r := by ring
+    rw [h1, hr, Real.rpow_inv_natCast_pow hC0.le hk0]
+  rw [hpoweq] at hlow
+  simpa [rayNorm] using hlow
+
+/-- **No crossing before the sharp inner radius, in any direction.**
+For `0 ≤ s < C^{1/φ(n)} − 1` the point `s·u` lies in the sharp inner ball of OQ02OQ07,
+hence strictly inside the sublevel set: `|Φ_n(s·u)| < C`. -/
+lemma rayNorm_lt_of_lt_sharpInner (n : ℕ) (hn : n ≠ 0) (u : ℂ) (hu : ‖u‖ = 1)
+    {C : ℝ} (hC : 1 < C) {s : ℝ} (hs0 : 0 ≤ s)
+    (hs : s < C ^ ((n.totient : ℝ)⁻¹) - 1) :
+    rayNorm n u s < C := by
+  have hmem : ((s : ℂ) * u) ∈ Metric.ball (0 : ℂ) (C ^ ((n.totient : ℝ)⁻¹) - 1) := by
+    rw [Metric.mem_ball, dist_zero_right, norm_ofReal_mul u hu hs0]
+    exact hs
+  have hlevel := CyclotomicPolynomialsOQ02OQ07.ball_sharpInner_subset_levelSet
+    n hn hC hmem
+  simpa [Erdos1215.levelSet, Set.mem_setOf_eq, rayNorm] using hlevel
+
+/-- **A short exit path in EVERY direction (positive answer, OQ02, directional form).**
+
+For `n ≥ 1`, `C > 1`, and any unit direction `u`, there is a *first crossing time*
+`t > 0` along the ray `t ↦ t·u` with
+
+  * `C^{1/φ(n)} − 1 ≤ t ≤ 1 + C^{1/φ(n)}`  — two-sided sharp bound on the exit distance,
+  * `|Φ_n(t·u)| = C`                        — the segment ends exactly on the boundary,
+  * `∀ s ∈ [0, t), |Φ_n(s·u)| < C`          — the open segment stays inside `{|Φ_n| < C}`.
+
+OQ02OQ08's `radial_exit` is the special case `u = 1` (the sharp lower bound on `t` is
+new even there).  Since the direction `u` is arbitrary, the cyclotomic sublevel set has
+no labyrinthine direction whatsoever: every ray from the origin exits after a straight
+run of length `≤ 1 + C^{1/φ(n)}`, `n`-uniformly bounded (`→ 2` as `φ(n) → ∞`). -/
+theorem ray_exit (n : ℕ) (hn : n ≠ 0) (u : ℂ) (hu : ‖u‖ = 1) {C : ℝ} (hC : 1 < C) :
+    ∃ t : ℝ, 0 < t ∧ C ^ ((n.totient : ℝ)⁻¹) - 1 ≤ t ∧
+      t ≤ 1 + C ^ ((n.totient : ℝ)⁻¹) ∧
+      rayNorm n u t = C ∧ ∀ s ∈ Set.Ico (0 : ℝ) t, rayNorm n u s < C := by
+  set R : ℝ := 1 + C ^ ((n.totient : ℝ)⁻¹) with hR
+  have hcont : Continuous (rayNorm n u) := continuous_rayNorm n u
+  have hg0 : rayNorm n u 0 = 1 := rayNorm_zero n hn u
+  have hgR : C ≤ rayNorm n u R := le_rayNorm_outer n hn u hu hC
+  have hrin_pos : 0 < C ^ ((n.totient : ℝ)⁻¹) - 1 :=
+    CyclotomicPolynomialsOQ02OQ07.sharpInnerRadius_pos n hn hC
+  have hRpos : 0 < R := by rw [hR]; linarith
+  -- The closed, bounded-below, nonempty set of crossing times in `[0, R]`.
+  set A : Set ℝ := Set.Icc 0 R ∩ (rayNorm n u ⁻¹' Set.Ici C) with hA
+  have hAclosed : IsClosed A := isClosed_Icc.inter (isClosed_Ici.preimage hcont)
+  have hAbdd : BddBelow A := ⟨0, fun x hx => hx.1.1⟩
+  have hRmem : R ∈ A := ⟨⟨le_of_lt hRpos, le_refl R⟩, hgR⟩
+  have hAne : A.Nonempty := ⟨R, hRmem⟩
+  -- `t := sInf A` is the first crossing.
+  set t : ℝ := sInf A with ht
+  have htmem : t ∈ A := hAclosed.csInf_mem hAne hAbdd
+  obtain ⟨⟨ht0, htR⟩, htC⟩ := htmem
+  rw [Set.mem_preimage, Set.mem_Ici] at htC
+  -- Sharp lower bound: before `C^{1/φ(n)} − 1` the ray is strictly inside the set.
+  have hlow : C ^ ((n.totient : ℝ)⁻¹) - 1 ≤ t := by
+    by_contra hlt
+    push_neg at hlt
+    have := rayNorm_lt_of_lt_sharpInner n hn u hu hC ht0 hlt
+    linarith
+  have htpos : 0 < t := lt_of_lt_of_le hrin_pos hlow
+  -- Stays strictly inside on `[0, t)`: any `s < t = sInf A` with `rayNorm s ≥ C`
+  -- would sit in `A`, contradicting it being the infimum.
+  have hbelow : ∀ s ∈ Set.Ico (0 : ℝ) t, rayNorm n u s < C := by
+    intro s hs
+    obtain ⟨hs0, hst⟩ := hs
+    by_contra hge
+    push_neg at hge
+    have hsA : s ∈ A := ⟨⟨hs0, le_trans (le_of_lt hst) htR⟩, hge⟩
+    have hts : t ≤ s := csInf_le hAbdd hsA
+    linarith
+  -- Ends exactly on the boundary: `rayNorm t = C`.  We have `C ≤ rayNorm t`;
+  -- if strict, IVT on `[0, t]` (from `1 < C < rayNorm t`) gives an earlier crossing
+  -- `u' ≤ t` in `A`, so `t ≤ u' ≤ t`, forcing `rayNorm t = C` after all.
+  have hboundary : rayNorm n u t = C := by
+    rcases eq_or_lt_of_le htC with h | h
+    · exact h.symm
+    · exfalso
+      have hmemIcc : C ∈ Set.Icc (rayNorm n u 0) (rayNorm n u t) := by
+        rw [hg0]; exact ⟨le_of_lt hC, le_of_lt h⟩
+      obtain ⟨v, hv_mem, hv⟩ :=
+        intermediate_value_Icc ht0 hcont.continuousOn hmemIcc
+      obtain ⟨hv0, hvt⟩ := hv_mem
+      have hvA : v ∈ A := ⟨⟨hv0, le_trans hvt htR⟩, hv.ge⟩
+      have htv : t ≤ v := csInf_le hAbdd hvA
+      have hvt_eq : v = t := le_antisymm hvt htv
+      rw [hvt_eq] at hv
+      rw [hv] at h
+      exact lt_irrefl C h
+  exact ⟨t, htpos, hlow, htR, hboundary, hbelow⟩
+
+/-- **The level curve surrounds the origin: it meets every ray, inside the sharp annulus.**
+
+For every unit direction `u`, the level curve `{z : |Φ_n(z)| = C}` contains a point on
+the open ray `{t·u : t > 0}`, and that point lies in the closed annulus
+`C^{1/φ(n)} − 1 ≤ ‖z‖ ≤ 1 + C^{1/φ(n)}`.  As `φ(n) → ∞` the annulus radii tend to `0`
+and `2` respectively, so the crossing stays `n`-uniformly at distance `≤ 2 + ε`.
+The boundary of the cyclotomic sublevel set is radially visible from the origin in every
+direction — the exact opposite of a Mac Lane labyrinth, whose boundary hides behind
+long detours. -/
+theorem levelCurve_meets_every_ray (n : ℕ) (hn : n ≠ 0) {C : ℝ} (hC : 1 < C)
+    (u : ℂ) (hu : ‖u‖ = 1) :
+    ∃ z : ℂ, ‖(cyclotomic n ℂ).eval z‖ = C ∧
+      (∃ t : ℝ, 0 < t ∧ z = (t : ℂ) * u) ∧
+      C ^ ((n.totient : ℝ)⁻¹) - 1 ≤ ‖z‖ ∧ ‖z‖ ≤ 1 + C ^ ((n.totient : ℝ)⁻¹) := by
+  obtain ⟨t, htpos, hlow, htR, hbdry, _⟩ := ray_exit n hn u hu hC
+  have hznorm : ‖(t : ℂ) * u‖ = t := norm_ofReal_mul u hu htpos.le
+  refine ⟨(t : ℂ) * u, by simpa [rayNorm] using hbdry, ⟨t, htpos, rfl⟩, ?_, ?_⟩
+  · rw [hznorm]; exact hlow
+  · rw [hznorm]; exact htR
+
+/-- **The exit segment in direction `u` realises the length bound.**
+Re-packaging `ray_exit` as an explicit Euclidean segment `γ : [0,1] → ℂ`,
+`γ s = s · (t·u)`, from `0` to the boundary point `t·u`, whose length is
+`dist (γ 0) (γ 1) = t ≤ 1 + C^{1/φ(n)}` — the same `n`-uniform bound in every
+direction.  A segment's length is its endpoint distance, so no rectifiable-path
+arc-length infrastructure is needed. -/
+theorem ray_exit_pathLength (n : ℕ) (hn : n ≠ 0) (u : ℂ) (hu : ‖u‖ = 1)
+    {C : ℝ} (hC : 1 < C) :
+    ∃ (t : ℝ) (γ : ℝ → ℂ),
+      γ = (fun s : ℝ => (s : ℂ) * ((t : ℂ) * u)) ∧ γ 0 = 0 ∧ γ 1 = (t : ℂ) * u ∧
+      dist (γ 0) (γ 1) = t ∧ t ≤ 1 + C ^ ((n.totient : ℝ)⁻¹) ∧
+      ‖(cyclotomic n ℂ).eval (γ 1)‖ = C := by
+  obtain ⟨t, htpos, _hlow, htR, hbdry, _⟩ := ray_exit n hn u hu hC
+  refine ⟨t, (fun s : ℝ => (s : ℂ) * ((t : ℂ) * u)), rfl, by simp, by simp, ?_, htR, ?_⟩
+  · -- `dist 0 (t·u) = ‖t·u‖ = t` (t > 0, ‖u‖ = 1)
+    simp only [Complex.ofReal_zero, Complex.ofReal_one, zero_mul, one_mul, dist_zero_left]
+    exact norm_ofReal_mul u hu htpos.le
+  · -- endpoint modulus equals `C`
+    simpa [rayNorm] using hbdry
+
+end CyclotomicPolynomialsOQ02OQ10

--- a/research/problems/erdos-1215-oq-02/knowledge.md
+++ b/research/problems/erdos-1215-oq-02/knowledge.md
@@ -288,3 +288,50 @@ bounded sublevel labyrinth `{|Φ_n|<C}` — remains blocked: Mathlib lacks polyn
 lemniscate topology / rectifiable-path arc length. The metric frontier (radius/area,
 both sides sharp) and now the exterior escape-region topology are the reachable layers;
 further sublevel-**component** work needs materially new Mathlib infrastructure.
+
+## Session 2026-07-24 (researcher-3) — exit paths in EVERY direction (OQ08 → directional)
+
+**Mode**: REVISIT (built on OQ02OQ08's first-crossing mechanism + OQ02OQ07's sharp inner ball).
+**Outcome**: progress — 1 new file, 9 decls, VERIFIED 0-sorry/0-axiom (docker `[8580/8580]`,
+all three headline theorems `[propext, Classical.choice, Quot.sound]`).
+
+### What I did
+New file `proofs/Proofs/CyclotomicPolynomialsOQ02OQ10.lean`. OQ02OQ08 exhibited ONE exit
+ray (positive real axis); its recorded follow-up asked whether reachability extends beyond
+that ray. This file settles the directional half completely:
+
+- `ray_exit`: for EVERY unit direction `u`, the ray `t ↦ t·u` has a first level-`C`
+  crossing `t*` with the **two-sided sharp bound** `C^{1/φ(n)} − 1 ≤ t* ≤ 1 + C^{1/φ(n)}`,
+  the open segment `[0,t*)·u` staying strictly inside `{|Φ_n| < C}`. The sharp LOWER
+  bound is new even for OQ08's `u = 1` case (OQ08 had only the upper bound).
+- `levelCurve_meets_every_ray`: the level curve `{|Φ_n| = C}` meets every ray from the
+  origin inside the sharp annulus — the boundary radially surrounds the origin with
+  `n`-uniform distance (annulus radii → 0 and 2 as `φ(n) → ∞`).
+- `ray_exit_pathLength`: explicit straight-segment packaging, Euclidean length
+  `= t* ≤ 1 + C^{1/φ(n)}` in every direction.
+
+### Mechanism (reusable)
+Parameterized replay of OQ08's first-crossing argument: `rayNorm n u t = |Φ_n(t·u)|`
+continuous; `‖t·u‖ = t` for `t ≥ 0`, `‖u‖ = 1` (`norm_ofReal_mul`: `norm_mul` + `hu` +
+`Complex.norm_real` + `abs_of_nonneg`); OQ01 lower bound forces crossing at
+`R = 1+C^{1/φ(n)}`; NEW ingredient vs OQ08 — OQ07's `ball_sharpInner_subset_levelSet`
+forbids a crossing before `C^{1/φ(n)}−1` (by_contra + the inner-ball membership at `t*`),
+giving the two-sided pin. First crossing = `sInf` of the closed crossing set
+(`IsClosed.csInf_mem`), exactness on the boundary via `intermediate_value_Icc`.
+v4.31 note: `push_neg` is deprecated → use `push Not at h`.
+
+### Files Modified
+- `proofs/Proofs/CyclotomicPolynomialsOQ02OQ10.lean` (new)
+- `src/data/research/problems/erdos-1215-oq-02.json` (knowledge + leanFiles)
+
+### Infra note
+Worktree `/Volumes/Stripe/lean-genius/researcher-3` was reaped mid-session (janitor,
+pre-commit) — only the freshly Written proof file survived. Recovery: back up file to
+/tmp, `git worktree prune` + `git worktree add -B <branch> <path> origin/main`, restore,
+commit+push IMMEDIATELY.
+
+### Still open (unchanged)
+The remaining half of the reachability refinement: whether every BOUNDARY POINT (not
+just every direction's first crossing) is reachable by a bounded-length path inside the
+set — that needs the labyrinth-free topology of the full lemniscate (connected-component
+count of `{|Φ_n| < C}`), still beyond Mathlib. The directional question is now closed.

--- a/research/problems/erdos-1215-oq-02/state.md
+++ b/research/problems/erdos-1215-oq-02/state.md
@@ -4,12 +4,12 @@
 **Phase**: PROVE
 **Path**: full
 **Since**: 2026-07-09T15:40:18-07:00
-**Iteration**: 6
+**Iteration**: 8
 
 ## Current Focus
-The sharp **inner** radius `C^{1/φ(n)}-1` and origin interiority: closing the
-two-sided *sharp radius* sandwich `ball(0, C^{1/φ(n)}-1) ⊆ {|Φ_n|<C} ⊆
-closedBall(0, 1+C^{1/φ(n)})` to mirror the two-sided *area* sandwich of OQ02OQ03.
+Directional exit geometry: after OQ02OQ08's single radial exit ray, extend boundary
+reachability to every direction (done, OQ02OQ10) and — still open — to every boundary
+point (needs lemniscate component topology).
 
 ## Active Approach
 Approach A/B hybrid: elementary two-sided factor bounds `‖z‖-1 ≤ ‖z-μ‖ ≤ ‖z‖+1`
@@ -74,14 +74,23 @@ rectifiable-path arc length not yet in Mathlib.
   gap for the *general* #1215) — a segment's length is its endpoint distance.
   (`CyclotomicPolynomialsOQ02OQ08.lean`, VERIFIED docker `[8580/8580]`, 0-axiom
   `[propext,Classical.choice,Quot.sound]`; `radial_exit` + `radial_exit_pathLength`.)
+- Iter 8 (researcher-3): **EXIT IN EVERY DIRECTION** — generalized OQ02OQ08's radial
+  exit to arbitrary unit direction `u`: first crossing `t*` along every ray with NEW
+  two-sided sharp bound `C^{1/φ(n)}-1 ≤ t* ≤ 1+C^{1/φ(n)}` (lower bound new even for
+  `u=1`, via OQ07's sharp inner ball); level curve `{|Φ_n|=C}` meets every ray inside
+  the sharp annulus (boundary radially surrounds origin, n-uniformly); straight-segment
+  length packaging. (`CyclotomicPolynomialsOQ02OQ10.lean`, VERIFIED docker
+  `[8580/8580]`, 0-axiom `[propext,Classical.choice,Quot.sound]`; `ray_exit` +
+  `levelCurve_meets_every_ray` + `ray_exit_pathLength`.) The DIRECTIONAL half of the
+  iter-7 refinement question is now closed; the every-boundary-point half still needs
+  lemniscate component topology (blocked, unchanged).
 
 ## Next Action
-Small-n (n=3,4,6) explicit lemniscate geometry / component count (the genuinely open
-driver, needs polynomial-lemniscate topology Mathlib currently lacks). Both radius and
-area are now pinned on BOTH sides (sharp inner `C^{1/φ(n)}-1` / outer `1+C^{1/φ(n)}`);
-note the inner radius `→ 0` while the outer `→ 2` as `φ(n)→∞`, so the two-sided disc
-squeeze is not asymptotically tight — pinning the true interior area needs the exact
-lemniscate boundary, not ball containment. The radial-exit path (iter 7) gives a short
-exit along ℝ_{≥0}; a natural refinement is whether *every* boundary point is reachable by
-a bounded-length path (not just one exit ray) — that likely still needs the labyrinth-free
-topology of the full lemniscate, currently beyond Mathlib.
+The every-boundary-point half of the reachability question: is EVERY point of the level
+curve `{|Φ_n|=C}` reachable from 0 by a bounded-length path inside the set? The first
+crossing along each ray reaches one boundary point per direction (iter 8); boundary
+points that are NOT first crossings (behind folds of the lemniscate, if any exist) are
+untouched. Deciding whether such points exist at all needs the connected-component /
+fold structure of the cyclotomic lemniscate — polynomial-lemniscate topology Mathlib
+still lacks (blocked, unchanged). Alternative tractable layer: small-n (n=3,4,6)
+explicit lemniscate geometry.

--- a/src/data/research/problems/erdos-1215-oq-02.json
+++ b/src/data/research/problems/erdos-1215-oq-02.json
@@ -46,7 +46,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "BLOCKED on deep maclane_labyrinth axiom (C>1 lemniscate topology, absent from Mathlib); registered as structured blocker 2026-07-20 (researcher-1). Axiom-free structural periphery actively extended by concurrent PRs #39256/#39332/#39350 (path/escape/symmetry corollaries) — orbiting the axiom, not reducing it. No session-sized axiom-elimination available until polynomial-lemniscate sublevel-set topology lands in Mathlib.",
+    "progressSummary": "PROGRESS: metric geometry pinned both sides (radius+area, OQ01-07); radial exit path (OQ08); exterior escape topology (OQ09); exit in EVERY direction with two-sided sharp annulus bound (OQ10) — boundary radially surrounds origin, directional reachability closed. Remaining open driver: every-boundary-point reachability / lemniscate component topology (needs Mathlib infrastructure).",
     "builtItems": [
       "Erdos1215UnitCircleMonotone.lean (researcher-5, 2026-07-12, 0-axiom VERIFIED): monotone/membership block for the sublevel set as a function of the level C — closedLevelSet_mono (C1<=C2 => closedLevelSet P C1 subset closedLevelSet P C2), volume_closedLevelSet_mono (measure nondecreasing in C via measure_mono), isRoot_mem_closedLevelSet (roots in set for C>=0), zero_mem_closedLevelSet (0 in set for C>=1 via P(0)=1), closedLevelSet_nonempty (C>=1), levelSet_subset_closedLevelSet (open {|P|<C} subset closed {|P|<=C}). 6 thm [propext,Classical.choice,Quot.sound].",
       "eventually_levelSet_subset_closedBall (Erdos1215UnitCircleRadiusLimit.lean): for C>=1, eps>0, one degree threshold K confines the level set of EVERY unit-circle polynomial of degree>=K to closedBall 0 (2+eps) -- uniform confinement of the whole high-degree Mac Lane class (VERIFIED 0/0)",
@@ -60,7 +60,8 @@
       "norm_le_sharp_of_norm_eval_le / closedLevelSet / isClosed_closedLevelSet / isBounded_closedLevelSet / isCompact_closedLevelSet (Erdos1215UnitCircleRadius.lean): the closed sublevel set {z:|P(z)|≤C} of a positive-degree unit-circle polynomial is COMPACT (closed via continuity of |P|, bounded via sharp radius 1+C^{1/deg}, Heine–Borel in ℂ). Realizes the 'sublevel set is compact' nextStep. 0-axiom, verified lake env lean 4.26.0.",
       "Erdos1215UnitCircleRadius.lean inner-confinement (researcher-7, 2026-07-11, VERIFIED 0-axiom [propext,Classical.choice,Quot.sound]): norm_eval_le_pow_add_one (dual upper bound |P(z)|≤(‖z‖+1)^deg from ‖z−r‖≤‖z‖+1 on each unit-circle root, via new multiset_prod_le_pow_card) and closedBall_subset_closedLevelSet (for C≥1, {z:|P(z)|≤C} CONTAINS closedBall(0,C^{1/deg}−1) since (‖z‖+1)^deg≤(C^{1/deg})^deg=C via Real.rpow_inv_natCast_pow). Sandwiches the sublevel set between radii C^{1/deg}∓1 — inner dual to the existing outer closedLevelSet_subset_closedBall. File 16→19 decls.",
       "Erdos1215UnitCircleArea.lean (NEW, 5 theorems, 0-axiom/0-sorry [propext,Classical.choice,Quot.sound]): volume_closedLevelSet_le (outer area ≤π(1+C^{1/deg})²), le_volume_closedLevelSet (inner area ≥π(C^{1/deg}−1)², C≥1), volume_closedLevelSet_lt_top (finite area, reuses isCompact_closedLevelSet via IsCompact.measure_lt_top), volume_closedLevelSet_ne_top, and real-valued toReal_volume_closedLevelSet_le / le_toReal_volume_closedLevelSet giving the same sandwich for area.toReal.",
-      "Erdos1215UnitCircleConjugation.lean: reflection (complex-conjugation) symmetry of sublevel sets. eval_conj (real-coeff P ⟹ P(z̄)=conj P(z) via Polynomial.eval₂_hom), norm_eval_conj, mem_closedLevelSet_conj/mem_levelSet_conj, closedLevelSet_conj_image/levelSet_conj_image (set = its own conj-image), cyclotomic_hasRealCoeffs (via Polynomial.map_cyclotomic), cyclotomic_closedLevelSet_conj_image/cyclotomic_levelSet_conj_image. 9 thm+1 def, 0-axiom [propext,Classical.choice,Quot.sound]."
+      "Erdos1215UnitCircleConjugation.lean: reflection (complex-conjugation) symmetry of sublevel sets. eval_conj (real-coeff P ⟹ P(z̄)=conj P(z) via Polynomial.eval₂_hom), norm_eval_conj, mem_closedLevelSet_conj/mem_levelSet_conj, closedLevelSet_conj_image/levelSet_conj_image (set = its own conj-image), cyclotomic_hasRealCoeffs (via Polynomial.map_cyclotomic), cyclotomic_closedLevelSet_conj_image/cyclotomic_levelSet_conj_image. 9 thm+1 def, 0-axiom [propext,Classical.choice,Quot.sound].",
+      "CyclotomicPolynomialsOQ02OQ10.lean: rayNorm def + continuity, norm_ofReal_mul, le_rayNorm_outer, rayNorm_lt_of_lt_sharpInner, ray_exit (two-sided first-crossing), levelCurve_meets_every_ray, ray_exit_pathLength (9 decls, VERIFIED 0-axiom docker 8580/8580)"
     ],
     "insights": [
       "All roots of Phi_n lie on the unit circle (primitive n-th roots), so |Phi_n(z)| = prod_{mu prim} dist(z,mu) >= (|z|-1)^{phi(n)} -> inf: the cyclotomic lemniscate {|Phi_n|<C} is BOUNDED (compact) for EVERY C, explicit radius max 2 (C+1).",
@@ -69,7 +70,10 @@
       "The confinement radius argument is stable under passing from the open level set {|P|<C} to the closed sublevel set {|P|≤C}: the same pow_sub_one_le_norm_eval lower bound gives the ≤-variant of the sharp radius by monotone rpow, and continuity of z↦|P(z)| (P.continuous.norm) makes the sublevel set closed. Closed+bounded in the proper space ℂ ⟹ compact — supplying the compactness the path-geometry programme needs with no new analytic input.",
       "AREA SANDWICH (researcher-11, 2026-07-12): the outer/inner radius sandwich on the closed sublevel set {|P|≤C} of an IsUnitCirclePolynomial converts, via monotonicity of 2D Lebesgue volume on ℂ + Mathlib's Complex.volume_closedBall (= ENNReal.ofReal r^2 · π), into an EXPLICIT PLANAR-AREA sandwich: π·(C^{1/deg}−1)² ≤ area({|P|≤C}) ≤ π·(1+C^{1/deg})² for C≥1. Depends only on C and deg P, not the individual roots — a uniform quantitative bound on the Mac Lane labyrinth region.",
       "Cyclotomic rigidity has a clean geometric shadow: Φ_n has real (integer) coefficients, so its sublevel sets {|Φ_n(z)|≤C} and {|Φ_n(z)|<C} are exactly symmetric under reflection across the real axis (roots come in conjugate pairs). A general Mac Lane labyrinth need not respect this mirror symmetry — an orthogonal constraint to the radius/area/monotonicity sandwiches.",
-      "Deep frontier is the single maclane_labyrinth axiom (C>1 regime): needs polynomial-lemniscate / sublevel-set connected-component topology absent from Mathlib — a BUILD >1000 lines, correctly axiomatized. The axiom-free structural periphery (reflection/conjugation symmetry, radius/area/monotonicity, escape-to-infinity, radial-exit & escape-region path-connectivity) is being actively extended by concurrent PRs (#39256/#39332/#39350); adding further peripheral corollaries orbits the deep axiom without reducing it. Registered the deep route as a structured blocker (reopen: lemniscate topology in Mathlib)."
+      "Deep frontier is the single maclane_labyrinth axiom (C>1 regime): needs polynomial-lemniscate / sublevel-set connected-component topology absent from Mathlib — a BUILD >1000 lines, correctly axiomatized. The axiom-free structural periphery (reflection/conjugation symmetry, radius/area/monotonicity, escape-to-infinity, radial-exit & escape-region path-connectivity) is being actively extended by concurrent PRs (#39256/#39332/#39350); adding further peripheral corollaries orbits the deep axiom without reducing it. Registered the deep route as a structured blocker (reopen: lemniscate topology in Mathlib).",
+      "Directional exit (OQ02OQ10): for EVERY unit direction u, the ray from 0 has a first level-C crossing t* with two-sided sharp bound C^{1/phi(n)}-1 <= t* <= 1+C^{1/phi(n)}; the open segment stays strictly inside {|Phi_n|<C}. The sharp lower bound is new even for OQ08 u=1 (via OQ07 inner ball).",
+      "The level curve {|Phi_n|=C} meets every ray from the origin inside the sharp annulus — the boundary radially surrounds the origin at n-uniformly bounded distance (annulus radii -> 0 and 2 as phi(n) -> infinity). No labyrinthine direction exists; the directional half of the reachability refinement is closed.",
+      "v4.31: push_neg is deprecated in favor of push Not at h."
     ],
     "mathlibGaps": [
       "No developed theory of rectifiable paths with arc length in ℂ tied to polynomial sublevel sets.",
@@ -141,6 +145,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1215UnitCircleMonotone.lean"
+    },
+    {
+      "path": "Proofs/CyclotomicPolynomialsOQ02OQ10.lean",
+      "filename": "CyclotomicPolynomialsOQ02OQ10.lean",
+      "lineCount": 234,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CyclotomicPolynomialsOQ02OQ10.lean"
     }
   ],
   "lastUpdate": "2026-07-12"


### PR DESCRIPTION
## Summary
Research session for **erdos-1215-oq-02** (cyclotomic sublevel-set path-length question, RICH tier, iteration 8).

## Progress
- New file `proofs/Proofs/CyclotomicPolynomialsOQ02OQ10.lean` (234 lines, 9 decls, 0 sorry / 0 axiom).
- Generalizes OQ02OQ08's single radial exit (positive real axis) to **every direction**: for every unit vector `u`, the ray `t -> t*u` from the origin has a first level-`C` crossing `t*` with the **two-sided sharp bound** `C^{1/phi(n)} - 1 <= t* <= 1 + C^{1/phi(n)}`, and the open segment stays strictly inside `{|Phi_n| < C}` (`ray_exit`).
- The sharp **lower** bound on the exit distance is new even for OQ08's `u = 1` case (mechanism: OQ07's sharp inner ball forbids an early crossing).
- Corollary `levelCurve_meets_every_ray`: the level curve `{|Phi_n| = C}` meets every ray from the origin inside the sharp annulus — the boundary radially surrounds the origin at `n`-uniformly bounded distance (annulus radii tend to 0 and 2 as `phi(n) -> infinity`).
- Corollary `ray_exit_pathLength`: explicit straight-segment path of Euclidean length `t* <= 1 + C^{1/phi(n)}` in each direction (no arc-length infrastructure needed).

## Findings
- The cyclotomic sublevel set has **no labyrinthine direction at all**: every ray from the origin exits after a bounded straight run. This closes the *directional* half of the reachability refinement recorded after iter 7; the *every-boundary-point* half still needs polynomial-lemniscate component topology Mathlib lacks (blocker unchanged).
- v4.31 note: `push_neg` is deprecated; use `push Not at h`.

## Verification
- Docker build `[8580/8580]` succeeded, no warnings in the new file.
- `#print axioms` on all three headline theorems: `[propext, Classical.choice, Quot.sound]` — axiom-free relative to Mathlib. The parent's deep `maclane_labyrinth` axiom is untouched.

## Status
**Outcome**: progress
**Next Steps**: every-boundary-point reachability / lemniscate component topology (blocked on Mathlib infrastructure); alternative tractable layer is small-n (n=3,4,6) explicit lemniscate geometry.

🤖 Generated by researcher-3
