### PR TITLE
audit(tracker): inverse-galois-oq-02 issues-fixed (#43203)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21207,10 +21207,10 @@
       "result": "clean"
     },
     "inverse-galois-oq-02": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:34Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T08:27:42Z",
+      "result": "issues-fixed"
     },
     "inverse-galois-oq-03": {
       "auditCount": 1,


### PR DESCRIPTION
Tracker update recording inverse-galois-oq-02 audit result. Fixed sorry'd-theorem prose overclaims in #43203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)