### PR TITLE
Audit hilbert-21: disclose vacuous birkhoff_theorem, fix phantom mainTheorems entry

### DIFF
--- a/proofs/Proofs/Hilbert21RiemannHilbert.lean
+++ b/proofs/Proofs/Hilbert21RiemannHilbert.lean
@@ -37,9 +37,13 @@ monodromy around these singular points is given by ρ?
    Found monodromy representations that cannot be realized by Fuchsian systems.
 
 3. **Positive Cases:**
-   - **Irreducible representations:** If ρ is irreducible, the answer is YES.
+   - **Irreducible representations:** If ρ is irreducible, the answer is YES
+     (formalized below as `plemelj_theorem_irreducible`).
    - **Birkhoff's Theorem:** For regular singular systems (allowing higher-order poles),
-     the answer is always YES.
+     the answer is always YES. Below, `birkhoff_theorem` only records that a
+     `RegularSingularSystem` exists — it does not yet formalize a "realizes"
+     relation for such systems, so the realizability claim itself remains
+     unformalized.
 
 4. **The Full Picture:**
    The problem has a positive answer if and only if certain cohomological conditions
@@ -272,16 +276,19 @@ structure RegularSingularSystem (S : SingularPoints) where
   /-- Solutions have at most polynomial growth near singularities -/
   regular_growth : True
 
-/-- **Birkhoff's Theorem**
+/-- **Birkhoff's Theorem (statement placeholder, not yet formalized)**
 
-    For any monodromy representation, there exists a regular singular
-    (but not necessarily Fuchsian) system realizing it.
-
-    This shows the issue is specifically about the Fuchsian (simple pole)
-    constraint, not about regular singularities in general. -/
+    Birkhoff's theorem asserts that for any monodromy representation, there
+    exists a regular singular (but not necessarily Fuchsian) system realizing
+    it. This declaration currently only proves that `RegularSingularSystem S`
+    is inhabited — `RegularSingularSystem` has no non-trivial fields
+    (`data : Unit`, `regular_growth : True`), so the statement holds vacuously
+    for every `S` regardless of `ρ`. No "realizes" relation is defined for
+    `RegularSingularSystem` (unlike `realizes` for `FuchsianSystem` above), so
+    the actual realizability claim is not formalized here. -/
 theorem birkhoff_theorem
     (S : SingularPoints) (ρ : MonodromyRep n S) :
-    ∃ R : RegularSingularSystem S, True :=  -- R realizes ρ
+    ∃ R : RegularSingularSystem S, True :=
   ⟨⟨(), trivial⟩, trivial⟩
 
 -- ============================================================

--- a/src/data/proofs/hilbert-21/meta.json
+++ b/src/data/proofs/hilbert-21/meta.json
@@ -50,7 +50,7 @@
     "proofStrategy": "The proof strategy involves:\n\n1. Define Fuchsian systems (ODEs with simple poles)\n2. Define monodromy representations (fundamental group to GL(n))\n3. Prove existence for irreducible case (Plemelj's theorem)\n4. Exhibit counterexamples for reducible case (Bolibrukh)\n5. State complete characterization via vector bundle conditions",
     "keyInsights": [
       "Irreducibility is the key condition for a positive answer: an irreducible monodromy representation ρ : π₁(ℂ \\ {singularities}) → GL(n, ℂ) is always Fuchsian-realizable (Plemelj's theorem)",
-      "Regular singular (vs Fuchsian) systems always suffice (Birkhoff): allowing higher-order poles — while keeping polynomial-growth solutions — lifts the obstruction and every monodromy becomes realizable",
+      "Regular singular (vs Fuchsian) systems always suffice (Birkhoff): allowing higher-order poles — while keeping polynomial-growth solutions — lifts the obstruction. This file's birkhoff_theorem only proves a RegularSingularSystem exists (vacuously, since its fields carry no data); it does not formalize a realizes relation for such systems, so the realizability claim itself is not yet proved here",
       "The obstruction is cohomological: it lives in the splitting type of an associated holomorphic vector bundle over ℂP¹, with the Fuchs relation as the key arithmetic constraint",
       "Modern formulation: the Riemann-Hilbert correspondence establishes an equivalence between flat connections with regular singularities and local systems (representations of π₁), forming a cornerstone of the geometric Langlands program",
       "The 89-year gap between Plemelj's claim (1908) and Bolibrukh's counterexample (1989) is one of the longest delayed corrections in 20th-century mathematics, illustrating how subtle the reducible case is"
@@ -117,7 +117,7 @@
       "title": "Part 7: Regular Singular Systems (Birkhoff)",
       "startLine": 256,
       "endLine": 286,
-      "summary": "RegularSingularSystem structure (higher-order poles with polynomial-growth solutions) and birkhoff_theorem: every monodromy representation is realizable once the Fuchsian (simple-pole) constraint is relaxed to regular singular."
+      "summary": "RegularSingularSystem structure (higher-order poles with polynomial-growth solutions) and birkhoff_theorem, which currently only proves RegularSingularSystem is inhabited (its fields are Unit and True, so this holds vacuously for any S regardless of ρ) — no 'realizes' relation is defined for RegularSingularSystem, so Birkhoff's actual realizability claim is not yet formalized."
     },
     {
       "id": "characterization",
@@ -239,10 +239,16 @@
   ],
   "mainTheorems": [
     {
-      "name": "hilbert21_monodromy",
+      "name": "riemann_hilbert_irreducible",
       "type": "core",
-      "description": "Existence of Fuchsian systems with prescribed monodromy",
-      "leanType": "MonodromyRep rho -> exists system, Fuchsian system and monodromy system = rho"
+      "description": "Existence of Fuchsian systems with prescribed monodromy, for irreducible representations (Plemelj)",
+      "leanType": "MonodromyRep.isIrreducible n S rho -> exists F : FuchsianSystem n S, realizes n S F rho"
+    },
+    {
+      "name": "hilbert21_negative_in_general",
+      "type": "core",
+      "description": "Existence of a reducible monodromy representation not realized by any Fuchsian system (Bolibrukh)",
+      "leanType": "exists S n _ rho, not exists F : FuchsianSystem n S, realizes n S F rho"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Audit — hilbert-21

Found during reserve-mode re-audit (queue fully drained, 4813/4813).

### Issue 1: `birkhoff_theorem` is vacuous but presented as establishing realizability

`birkhoff_theorem` proves `∃ R : RegularSingularSystem S, True`. `RegularSingularSystem` has no real content (`data : Unit`, `regular_growth : True`), so this existential holds trivially for any `S`, **independent of `ρ`**. No `realizes` relation is ever defined for `RegularSingularSystem` (unlike `realizes` for `FuchsianSystem`), so the theorem does not actually formalize "this system realizes ρ" — despite the module docstring, the theorem's own docstring, and `meta.json`'s section summary / keyInsights all stating "Birkhoff's Theorem... the answer is always YES" / "every monodromy becomes realizable" as an established fact. The original code even had a `-- R realizes ρ` comment next to the vacuous proof term, silently acknowledging the gap.

**Fix**: added an explicit disclosure to the Lean docstrings (module header + `birkhoff_theorem` itself) and softened the `meta.json` `birkhoff` section summary and the corresponding `keyInsights` bullet to state that only inhabitedness is proved, not realizability.

### Issue 2: phantom `mainTheorems` entry

`meta.json`'s `mainTheorems` cited a theorem named `hilbert21_monodromy`, which does not exist anywhere in `Hilbert21RiemannHilbert.lean`. Replaced with the two theorems that actually exist and match the described content: `riemann_hilbert_irreducible` and `hilbert21_negative_in_general`.

### Not changed

- `axiomCount: 4` and `sorries: 0` were verified correct against the file (computeMonodromy, plemelj_theorem_irreducible, bolibrukh_counterexample, realization_criterion).
- `status: "axiomatized"` / `badge: "axiom"` remain appropriate — this is an honest Tier-C axiomatization of a genuinely deep, real theorem; the fix here is scoped to the one vacuous sub-claim and the phantom name, not a status change.

## Test plan
- [x] `lake env lean Proofs/Hilbert21RiemannHilbert.lean` builds cleanly (only pre-existing unrelated lint warnings)
- [x] `meta.json` validated as well-formed JSON
- [x] Confirmed via grep that `hilbert21_monodromy` does not exist in the file, and that `realizes` is only ever defined/used for `FuchsianSystem`, never `RegularSingularSystem`

🤖 Generated with [Claude Code](https://claude.com/claude-code)