### PR TITLE
Fix erdos-986: Nat-division exponent bug in Bohman-Keevash axiom

### DIFF
--- a/proofs/Proofs/Erdos986Problem.lean
+++ b/proofs/Proofs/Erdos986Problem.lean
@@ -151,7 +151,7 @@ This is weaker than the conjectured n^(k-1) / (log n)^c for k ≥ 5.
 axiom bohman_keevash_2010 :
   ∀ k : ℕ, k ≥ 3 →
     (fun n => (RamseyNumber k n : ℝ)) ≫
-    (fun n => (n : ℝ)^((k+1)/2) / (log n)^(1/(k-2 : ℝ) - (k+1)/2))
+    (fun n => (n : ℝ)^(((k : ℝ)+1)/2) / (log n)^(1/(k-2 : ℝ) - (k+1)/2))
 
 /-
 ## Part VII: The Gap for k ≥ 5
@@ -214,7 +214,7 @@ theorem erdos_986_summary :
     -- General bounds exist
     (∀ k : ℕ, k ≥ 3 →
       (fun n => (RamseyNumber k n : ℝ)) ≫
-      (fun n => (n : ℝ)^((k+1)/2) / (log n)^(1/(k-2 : ℝ) - (k+1)/2))) := by
+      (fun n => (n : ℝ)^(((k : ℝ)+1)/2) / (log n)^(1/(k-2 : ℝ) - (k+1)/2))) := by
   constructor
   · exact erdos_986_k3_solved
   constructor


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-986 (Erdős Problem #986: Ramsey Number Lower Bounds)

## Problem

The `bohman_keevash_2010` axiom (and its mirrored use inside `erdos_986_summary`)
wrote the lower-bound exponent as a bare `(k+1)/2` inside `(n : ℝ)^((k+1)/2)`.
Since this term is not otherwise forced to be real-typed, Lean's default
elaboration picks the `HPow ℝ ℕ ℝ` instance and treats `(k+1)/2` as **Nat
division** (floor) rather than the intended real division.

This silently weakens the formalized Bohman-Keevash 2010 bound for every even
`k`: e.g. for `k = 4` the axiom asserts exponent `2` (`(4+1)/2 = 2` in ℕ)
instead of the documented `2.5`. The adjacent exponent on the `(log n)^(...)`
factor was unaffected, because it's combined via subtraction with an
already-real term (`1/(k-2 : ℝ) - (k+1)/2`), which forces real elaboration
there — only the standalone occurrence was affected.

Confirmed via scratch lemmas (closed by `rfl`) that:
- `(fun n : ℝ => n ^ ((4+1)/2)) = (fun n : ℝ => n ^ (2:ℕ))` — Nat-floor confirmed.
- The paired log-exponent already elaborates as real division, unaffected.

This is the same footgun class previously found in erdos-420 (#41066):
bare-literal/rational exponents on `ℝ` default to `HPow ℝ ℕ ℝ` unless a real
type is forced elsewhere in the expression.

## Fix

Cast `k+1` to `ℝ` explicitly in the two affected occurrences (`bohman_keevash_2010`
axiom and the matching clause in `erdos_986_summary`), forcing real division
(`Real.rpow`) as intended and as already documented in the file's docstrings
and `meta.json`'s `originalContributions`. No other counts change (axioms: 3,
sorries: 0, theorems/defs unchanged) — this is a pure correctness fix to the
formalized statement, not a disclosure change.

Rebuilt `Erdos986Problem.lean` with `lake env lean` after the fix — no errors.

---
Discovered during gallery integrity audit (reserve-mode re-audit).