### PR TITLE
Fix invalid annotation enum values in bezout-identity-oq-01-oq-02-oq-02

### DIFF
--- a/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-02-oq-02/annotations.json
@@ -3,11 +3,11 @@
     "id": "ann-overview",
     "proofId": "bezout-identity-oq-01-oq-02-oq-02",
     "range": { "startLine": 1, "endLine": 57 },
-    "type": "context",
+    "type": "concept",
     "title": "The Goal: SLₙ(ℤ)-Transitivity on Primitive Vectors",
     "content": "Orients the whole file. The parent bezout-identity-oq-01-oq-02 solves n=2: it builds bezoutSL a b ∈ SL₂(ℤ) carrying a coprime pair (a,b) to (1,0). The open question is the n-coordinate generalization: is the SLₙ(ℤ)-action transitive on primitive integer vectors, i.e. does every primitive v admit a unimodular U with U·v = e₁? This file answers it in full. It builds the coordinate-free predicate IsPrimitive v := ∃ w, w ⬝ᵥ v = 1, proves its SLₙ(ℤ)-invariance in both directions, packages the transvection generators transvectionSL that realize the atomic Euclidean-descent moves inside SLₙ(ℤ), and proves orbit_e_isPrimitive — the 'necessity' half (the orbit of eᵢ consists of primitive vectors). Driving a strong induction on the ℓ¹ measure ∑ₖ|vₖ|, it then proves exists_sl_mulVec_single_of_isPrimitive — the 'sufficiency' converse in EVERY dimension: every primitive vector is reachable. For n ≥ 2 this sharpens to full transitivity onto e₁ (with the sign pinned down) and to the classical unimodular completion of a primitive vector to a ℤ-basis; the n = 1 obstruction (the primitive vectors (1) and (-1) lying in distinct SL₁(ℤ)-orbits) is documented and proved genuinely sharp, not a proof artefact.",
     "mathContext": "$\\text{Resolved: }\\mathrm{SL}_n(\\mathbb Z)\\curvearrowright\\{\\text{primitive } v\\}\\text{ is transitive for }n\\ge2\\quad\\big(\\forall v\\text{ prim }\\exists U\\in\\mathrm{SL}_n(\\mathbb Z),\\ Uv=e_1\\big)$",
-    "significance": "context",
+    "significance": "supporting",
     "relatedConcepts": [
       "transitivity of a group action",
       "primitive vector",


### PR DESCRIPTION
## Summary

Follow-up to #43209 (already merged). Its `ann-overview` annotation carried `type: "context"` and `significance: "context"` — neither is a valid member of `AnnotationType` / `AnnotationSignificance` (`src/types/proof.ts`), so `AnnotationPanel.tsx` renders a blank badge and no line-dot color for it. This is the same class of defect tracked in #31246 ("Gallery data defect: invalid type/significance enum values").

## Changes

- `type: "context"` → `concept` (matches #31246's remediation map: `context|example|application|observation|note → concept`)
- `significance: "context"` → `supporting` (matches #31246's map: `context|technical|standard|... → supporting`)

## Test plan

- [x] Verified both fields against the `AnnotationType`/`AnnotationSignificance` unions in `src/types/proof.ts`