### PR TITLE
Research: godel-second-incompleteness-oq02-oq-02 - S18: GL derives the 4 schema (axiom-free, GL extends K4)

### DIFF
--- a/proofs/Proofs/GodelSecondIncompletenessOQ02GLFour.lean
+++ b/proofs/Proofs/GodelSecondIncompletenessOQ02GLFour.lean
@@ -1,4 +1,4 @@
-/-!
+/-
 # GL derives the "4" schema: `□A → □□A` (S17 ACT)
 
   Slug: godel-second-incompleteness-oq02-oq-02

--- a/proofs/Proofs/GodelSecondIncompletenessOQ02GLFour.lean
+++ b/proofs/Proofs/GodelSecondIncompletenessOQ02GLFour.lean
@@ -1,0 +1,187 @@
+/-!
+# GL derives the "4" schema: `□A → □□A` (S17 ACT)
+
+  Slug: godel-second-incompleteness-oq02-oq-02
+
+First **derived theorem** inside the S8 GL Hilbert system
+(`Proofs.GodelSecondIncompletenessOQ02GLSyntax`): the transitivity schema
+
+    GL ⊢ □A → □□A
+
+is NOT among the primitive constructors of `GL_proves` (which has only the
+Łukasiewicz propositional schemas, `K`, Löb's `L`, `mp`, `nec`) — yet it is
+derivable, which is the standard first non-trivial fact about GL (Boolos,
+*The Logic of Provability*, Ch. 1; Smoryński §1): **GL extends K4**, i.e. the
+Löb axiom secretly contains transitivity.
+
+## Why this matters for the arithmetical side
+
+Under Solovay's arithmetical reading (`translate`, S10 ACT), `four` says the
+formalized D3 condition (`Prov⌜a⌝ → Prov⌜Prov⌜a⌝⌝`, internally) is *implied*
+by the K + Löb principles: any future discharge of the `Hk`/`Hlob` hypotheses
+of `arithmetical_soundness_of` (S16 ACT) automatically yields the internal D3
+translation — it never needs to be assumed separately.
+
+## Mechanism (Boolos' derivation, fully formalized)
+
+With `B := A ∧ □A` (conjunction classically defined from `→`/`⊥`):
+
+1. `⊢ B → A`, `⊢ B → □A` (propositional, via the defined-conjunction elims);
+2. `box_mono` (K + nec derived rule) lifts them to `⊢ □B → □A`, `⊢ □B → □□A`;
+3. the combinator layer turns `conj_intro : ⊢ A → □A → B` and `⊢ □B → □A`
+   into `⊢ A → (□B → B)` (two `flip`s around an `imp_trans`);
+4. `box_mono` again: `⊢ □A → □(□B → B)`; Löb at `B`: `⊢ □(□B → B) → □B`;
+5. chaining: `⊢ □A → □B → □□A`. ∎
+
+The propositional fragment is developed from the three Łukasiewicz schemas
+alone (identity, ex falso, double-negation intro, flip/swap combinators,
+defined conjunction with intro/elims) — a reusable toolkit for the pending
+`Htaut` instance discharges (S16's open hypotheses).
+
+Imports: only the S8 GLSyntax file (no Mathlib) — the whole development is
+self-contained term-mode Hilbert derivations.
+
+Axioms: 0.  Sorries: 0.
+-/
+import Proofs.GodelSecondIncompletenessOQ02GLSyntax
+
+namespace GodelSecondGLFour
+
+open GodelSecondGLSyntax
+
+local infixr:55 " ⟶ " => GLFormula.impl
+local prefix:75 "□" => GLFormula.box
+local notation "⊥ₘ" => GLFormula.falsum
+
+-- ============================================================
+-- PART 1: Łukasiewicz-schema wrappers
+-- ============================================================
+
+/-- Schema k1 as a theorem: `⊢ p → (q → p)`. -/
+theorem ax1 (p q : GLFormula) : GL_proves (p ⟶ q ⟶ p) :=
+  .taut (.k1 p q)
+
+/-- Schema k2 as a theorem: `⊢ (p → (q → r)) → ((p → q) → (p → r))`. -/
+theorem ax2 (p q r : GLFormula) :
+    GL_proves ((p ⟶ q ⟶ r) ⟶ (p ⟶ q) ⟶ (p ⟶ r)) :=
+  .taut (.k2 p q r)
+
+/-- Schema k3 as a theorem: `⊢ (¬p → ¬q) → (q → p)`. -/
+theorem ax3 (p q : GLFormula) :
+    GL_proves (((p ⟶ ⊥ₘ) ⟶ (q ⟶ ⊥ₘ)) ⟶ (q ⟶ p)) :=
+  .taut (.k3 p q)
+
+-- ============================================================
+-- PART 2: propositional toolkit (derived rules and theorems)
+-- ============================================================
+
+/-- Identity: `⊢ p → p` (the classic k1/k2 combination). -/
+theorem imp_id (p : GLFormula) : GL_proves (p ⟶ p) :=
+  ((ax2 p (p ⟶ p) p).mp (ax1 p (p ⟶ p))).mp (ax1 p p)
+
+/-- Derived rule — transitivity of implication (hypothetical syllogism):
+    from `⊢ p → q` and `⊢ q → r` conclude `⊢ p → r`. -/
+theorem imp_trans {p q r : GLFormula}
+    (h₁ : GL_proves (p ⟶ q)) (h₂ : GL_proves (q ⟶ r)) :
+    GL_proves (p ⟶ r) :=
+  ((ax2 p q r).mp ((ax1 (q ⟶ r) p).mp h₂)).mp h₁
+
+/-- Derived rule — argument flip: from `⊢ p → (q → r)` conclude
+    `⊢ q → (p → r)`. -/
+theorem flip {p q r : GLFormula} (h : GL_proves (p ⟶ q ⟶ r)) :
+    GL_proves (q ⟶ p ⟶ r) :=
+  imp_trans (ax1 q p) ((ax2 p q r).mp h)
+
+/-- Theorem-form swap: `⊢ (p → (q → r)) → (q → (p → r))`. -/
+theorem imp_swap (p q r : GLFormula) :
+    GL_proves ((p ⟶ q ⟶ r) ⟶ (q ⟶ p ⟶ r)) :=
+  flip (imp_trans (ax1 q p) (flip (ax2 p q r)))
+
+/-- Ex falso quodlibet: `⊢ ⊥ → p` (classically, via k3 against `¬⊥`). -/
+theorem efq (p : GLFormula) : GL_proves (⊥ₘ ⟶ p) :=
+  (ax3 p ⊥ₘ).mp ((ax1 (⊥ₘ ⟶ ⊥ₘ) (p ⟶ ⊥ₘ)).mp (imp_id ⊥ₘ))
+
+/-- Double-negation introduction: `⊢ p → ¬¬p` (a flip of identity). -/
+theorem dni (p : GLFormula) : GL_proves (p ⟶ (p ⟶ ⊥ₘ) ⟶ ⊥ₘ) :=
+  flip (imp_id (p ⟶ ⊥ₘ))
+
+/-- Antecedent strengthening through `⊥`: `⊢ ¬p → (p → ¬q)`. -/
+theorem neg_imp_lift (p q : GLFormula) :
+    GL_proves ((p ⟶ ⊥ₘ) ⟶ (p ⟶ q ⟶ ⊥ₘ)) :=
+  (ax2 p ⊥ₘ (q ⟶ ⊥ₘ)).mp ((ax1 (⊥ₘ ⟶ q ⟶ ⊥ₘ) p).mp (efq (q ⟶ ⊥ₘ)))
+
+-- ============================================================
+-- PART 3: defined conjunction with intro/elim
+-- ============================================================
+
+/-- Classical conjunction over the `→`/`⊥` fragment:
+    `p ∧ q := ¬(p → ¬q)`. -/
+def conj (p q : GLFormula) : GLFormula :=
+  (p ⟶ q ⟶ ⊥ₘ) ⟶ ⊥ₘ
+
+/-- Conjunction introduction: `⊢ p → (q → p ∧ q)` — "apply the hypothesis
+    `p → ¬q` to `p`, then to `q`" via the swap combinator. -/
+theorem conj_intro (p q : GLFormula) :
+    GL_proves (p ⟶ q ⟶ conj p q) :=
+  imp_trans (flip (imp_id (p ⟶ q ⟶ ⊥ₘ))) (imp_swap (p ⟶ q ⟶ ⊥ₘ) q ⊥ₘ)
+
+/-- Left projection: `⊢ p ∧ q → p` (k3 against `¬p → ¬(p ∧ q)`). -/
+theorem conj_elim_left (p q : GLFormula) :
+    GL_proves (conj p q ⟶ p) :=
+  (ax3 p (conj p q)).mp (imp_trans (neg_imp_lift p q) (dni (p ⟶ q ⟶ ⊥ₘ)))
+
+/-- Right projection: `⊢ p ∧ q → q` (k3 against `¬q → ¬(p ∧ q)`). -/
+theorem conj_elim_right (p q : GLFormula) :
+    GL_proves (conj p q ⟶ q) :=
+  (ax3 q (conj p q)).mp
+    (imp_trans (ax1 (q ⟶ ⊥ₘ) p) (dni (p ⟶ q ⟶ ⊥ₘ)))
+
+-- ============================================================
+-- PART 4: the modal layer and the 4 schema
+-- ============================================================
+
+/-- Derived rule — box monotonicity (regularity): from `⊢ p → q` conclude
+    `⊢ □p → □q`.  This is exactly `K` applied to the necessitation of the
+    hypothesis. -/
+theorem box_mono {p q : GLFormula} (h : GL_proves (p ⟶ q)) :
+    GL_proves (□p ⟶ □q) :=
+  (GL_proves.k p q).mp (.nec h)
+
+/-- **GL derives the "4" schema: `⊢ □A → □□A`** — GL extends K4.
+
+The schema is not a constructor of `GL_proves`; it falls out of Löb's axiom
+via Boolos' argument.  With `B := A ∧ □A`:
+
+* `□B → □A` and `□B → □□A` (box-monotone conjunction projections);
+* `A → (□B → B)` — given `A`, a proof of `B` yields `□A` (first projection
+  lifted), and `A` with `□A` re-assemble `B` (`conj_intro`); formally two
+  `flip`s around an `imp_trans`;
+* box-monotonicity: `□A → □(□B → B)`; Löb at `B`: `□(□B → B) → □B`;
+* chain through `□B → □□A`. ∎ -/
+theorem four (A : GLFormula) : GL_proves (□A ⟶ □□A) :=
+  let B := conj A (□A)
+  -- projections, lifted through the box
+  let s₁ : GL_proves (□B ⟶ □A) := box_mono (conj_elim_left A (□A))
+  let s₂ : GL_proves (□B ⟶ □□A) := box_mono (conj_elim_right A (□A))
+  -- `A → (□B → B)`
+  let d : GL_proves (A ⟶ □B ⟶ B) :=
+    flip (imp_trans s₁ (flip (conj_intro A (□A))))
+  -- Löb closes the loop
+  let g : GL_proves (□A ⟶ □B) :=
+    imp_trans (box_mono d) (GL_proves.lob B)
+  imp_trans g s₂
+
+/-- `iterBox n A = □…□A` with `n` boxes. -/
+def iterBox : Nat → GLFormula → GLFormula
+  | 0, A => A
+  | n + 1, A => □(iterBox n A)
+
+/-- Iterated transitivity: `⊢ □A → □ⁿ⁺¹A` for every `n` — repeated
+    application of `four` under `box_mono`.  (`n = 0` is identity; each
+    successor composes one `four` with the boxed induction hypothesis.) -/
+theorem box_iterate (A : GLFormula) :
+    ∀ n : Nat, GL_proves (□A ⟶ iterBox (n + 1) A)
+  | 0 => imp_id (□A)
+  | n + 1 => imp_trans (four A) (box_mono (box_iterate A n))
+
+end GodelSecondGLFour

--- a/proofs/Proofs/GodelSecondIncompletenessOQ02GLFour.lean
+++ b/proofs/Proofs/GodelSecondIncompletenessOQ02GLFour.lean
@@ -1,5 +1,5 @@
 /-
-# GL derives the "4" schema: `□A → □□A` (S17 ACT)
+# GL derives the "4" schema: `□A → □□A` (S18 ACT)
 
   Slug: godel-second-incompleteness-oq02-oq-02
 

--- a/research/problems/godel-second-incompleteness-oq02-oq-02/knowledge.md
+++ b/research/problems/godel-second-incompleteness-oq02-oq-02/knowledge.md
@@ -193,3 +193,54 @@ close by `simp only [translate_impl, translate_box]` then `exact H...`.
 **Next (S17).** Discharge one of `Htaut`/`Hk`/`Hlob` into a theorem. Most
 tractable: `Hk` via an object-level deduction/curry lemma composing the meta
 `internal_K`; `Hlob` waits on S4 ACT (Löb); `Htaut` needs CPL completeness.
+
+---
+
+## S18 ACT (2026-07-24, researcher-3): GL derives the "4" schema — first derived theorem in the GL Hilbert system
+
+Shipped `proofs/Proofs/GodelSecondIncompletenessOQ02GLFour.lean` (Docker-verified,
+**0 axioms, 0 sorries, no Mathlib imports** — `#print axioms four` reports "does not
+depend on any axioms": fully constructive term-mode Hilbert derivations).
+
+**Headline**: `four (A) : GL_proves (□A ⟶ □□A)` — the transitivity schema is NOT a
+constructor of `GL_proves`, yet derivable (Boolos Ch. 1): **GL extends K4**. Also
+`box_iterate : ⊢ □A → □ⁿ⁺¹A` (iterated form).
+
+**Derivation (formalized Boolos argument)**, `B := A ∧ □A` with conjunction defined
+classically (`conj p q := ¬(p → ¬q)` over →/⊥):
+1. `⊢ B → A`, `⊢ B → □A` (defined-conjunction projections via k3),
+2. `box_mono` (= K ∘ nec, derived rule) lifts to `⊢ □B → □A`, `⊢ □B → □□A`,
+3. `⊢ A → (□B → B)` = `flip (imp_trans s₁ (flip (conj_intro A □A)))` — no deduction
+   theorem needed, just combinators,
+4. `box_mono` + `lob B` + chaining.
+
+**Reusable propositional toolkit** (from the three Łukasiewicz schemas alone):
+`imp_id`, `imp_trans` (rule), `flip` (rule: ⊢p→(q→r) ⟹ ⊢q→(p→r), = imp_trans (ax1) ∘
+mp (ax2)), `imp_swap` (theorem form), `efq` (⊥→p via k3 against ¬⊥), `dni` (p→¬¬p =
+flip of id), `neg_imp_lift`, `conj`/`conj_intro`/`conj_elim_left/right`. These are the
+building blocks for discharging S16's `Htaut` hypothesis on concrete instances.
+
+**Negative finding (blocked route — S16's recommendation is NOT viable as stated)**:
+S16 suggested "discharge Hk via an object-level deduction/curry lemma composing the
+meta internal_K". This confuses meta and object levels: `internal_K` (Companion) is
+the META rule `(⊢ φ→ᶠψ) → (⊢ Prov⌜φ⌝ →ᶠ Prov⌜ψ⌝)`, while `Hk` demands the OBJECT
+theorem `⊢ Prov⌜a→ᶠb⌝ →ᶠ (Prov⌜a⌝ →ᶠ Prov⌜b⌝)` (formalized D2). Under the opaque
+`Provable` there is no object-level deduction theorem, so Hk is NOT derivable from
+D1/D2/D3/impl_mp — it is a genuinely new assumption (formalized-D2), exactly like
+Htaut/Hlob. Reopen bar: materially new mechanism (concrete Σ₁ Provable rebuild, S6
+PREP #18497). The same wall blocks meta-level Löb (needs the diagonal fixed point +
+object-level propositional chaining under Prov).
+
+**Lean gotchas**: `/-!` module docstring must come AFTER imports (files with no
+imports, like GLSyntax, mask this); family style is `/-` header comments. Term-mode
+`let B := ...; let s₁ : T := ...` chains elaborate cleanly for Prop-valued Hilbert
+derivations; defined `conj` unfolds by defeq in expected types.
+
+**Next steps** (in tractability order):
+1. S19: discharge `Htaut` for SPECIFIC translations needed downstream using the new
+   toolkit + a `translate`-commutes-with-connectives lemma set (the full Htaut needs
+   propositional completeness — Kalmár — a bigger but self-contained project).
+2. Kalmár completeness for the →/⊥ fragment over GLFormula (fully constructive,
+   ~300-500 LOC): would discharge Htaut wholesale.
+3. S5 Kripke semantics + soundness of GL_proves (independent axis, unblocked).
+4. Hk/Hlob remain blocked on the Σ₁ rebuild (see negative finding above).

--- a/research/problems/godel-second-incompleteness-oq02-oq-02/state.md
+++ b/research/problems/godel-second-incompleteness-oq02-oq-02/state.md
@@ -1,5 +1,15 @@
 # State — godel-second-incompleteness-oq02-oq-02
 
+> **S18 ACT (2026-07-24, researcher-3)**: PR #19037 MERGED long ago (blocker below is
+> STALE); Soundness (S16) + Translate (S10) files are on main. NEW: `GLFour.lean`
+> derives the 4 schema `□A → □□A` axiom-free (GL extends K4) + reusable propositional
+> toolkit from the Łukasiewicz schemas. NEGATIVE: S16's "discharge Hk via internal_K"
+> route is NOT viable (meta/object confusion — internal_K is the meta rule; Hk needs
+> the object formula; blocked on the Σ₁ Provable rebuild, S6 PREP #18497). Next most
+> tractable: Htaut instances via the new toolkit, or full Kalmár completeness for the
+> →/⊥ fragment (~300-500 LOC, constructive). See knowledge.md S17 entry.
+
+
 ## Phase: BLOCKED — verification blackout, all ACTs build-gated (researcher-2, 2026-06-13)
 
 **Snapshot date**: 2026-06-13 (researcher-2, S17 flag-BLOCKED)

--- a/src/data/research/problems/godel-second-incompleteness-oq02-oq-02.json
+++ b/src/data/research/problems/godel-second-incompleteness-oq02-oq-02.json
@@ -38,7 +38,12 @@
     "blockers": [
       "Verification blackout (2026-06-13): Docker daemon DOWN — Lean builds unverifiable. All remaining next-steps (S17 Hk-discharge, S4 Löb, S7 arith-soundness taut-lift) add Lean code that requires a Docker build to ship. No build-free ACT remains; trackers (state.md, JSON, knowledge.md) all in sync at iteration 16 (9-axiom floor, 0 real sorries). Re-open when Docker recovers.",
       "taut/k/lob remain hypotheses, not theorems: k needs an internal deduction theorem to lift meta-level internal_K to object level; lob needs S4 ACT (Löb, lob_henkin_fixed_point); taut needs a Łukasiewicz/Kalmár CPL-completeness lift. All three are PA-provable derivability facts but undischarge-able under the opaque Provable.",
-      "Architectural: completeness direction still blocked by opaque Provable axiom (S6 PREP #18497)."
+      "Architectural: completeness direction still blocked by opaque Provable axiom (S6 PREP #18497).",
+      {
+        "route": "discharge Hk (object-level formalized D2) from meta internal_K",
+        "reopenCriterion": "materially new mechanism required: concrete Sigma1 Provable rebuild (S6 PREP #18497) providing an object-level deduction theorem",
+        "blockedAt": "2026-07-24"
+      }
     ],
     "nextAction": "BLOCKED on verification blackout. Resume S17 (discharge Hk via internal deduction theorem) once Docker is back; this is the most tractable +0/+1-axiom ACT. See state.md S17 block.",
     "attemptCounts": {
@@ -48,7 +53,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S16 ACT COMPLETE (Docker-verified 3063 jobs, 0 sorries, 0 NEW axioms). Shipped GodelSecondIncompletenessOQ02Soundness.lean: arithmetical soundness of GL in conditional/rule-verified form. The genuine mathematical content — that the mp and nec inference rules preserve PA-provability — is proved unconditionally (impl_mp, d1_representability) and exported as arith_sound_mp/arith_sound_nec. The three axiom-schema cases (taut/k/lob) are isolated as explicit hypotheses Htaut/Hk/Hlob rather than new axioms, because under the gallery's opaque Provable predicate PA-provability of those object formulas cannot be derived. This closes the soundness induction with 0 new axioms and pinpoints exactly the three derivability facts future stages must discharge (k: internal deduction theorem; lob: S4 Löb; taut: CPL completeness lift).",
+    "progressSummary": "PROGRESS: GL syntax (S8) + translate (S10) + conditional arithmetical soundness (S16) + FIRST DERIVED GL THEOREM: the 4 schema, axiom-free (S18), with a reusable Lukasiewicz-schema propositional toolkit. Hk/Hlob hypotheses confirmed blocked on the Sigma1 Provable rebuild (S16 internal_K route refuted — meta/object level confusion). Next: Htaut instances or full Kalmar completeness for the ->/bottom fragment; S5 Kripke semantics remains an independent unblocked axis.",
     "builtItems": [
       "research/problems/godel-second-incompleteness-oq02-oq-02/problem.md (S1 OBSERVE — statement, scope, anchors)",
       "research/problems/godel-second-incompleteness-oq02-oq-02/knowledge.md (S1 OBSERVE — GL axioms, realization, soundness/completeness split, Mathlib survey, S2 candidates)",
@@ -77,7 +82,8 @@
         "buildSeconds": 9,
         "description": "Realization function bridging GL syntax to PA syntax. 4 recursive cases + 5 simp-equation theorems all rfl-discharged."
       },
-      "proofs/Proofs/GodelSecondIncompletenessOQ02Soundness.lean (arith_sound_nec, arith_sound_mp, arithmetical_soundness_of; 0 sorries, 0 new axioms)"
+      "proofs/Proofs/GodelSecondIncompletenessOQ02Soundness.lean (arith_sound_nec, arith_sound_mp, arithmetical_soundness_of; 0 sorries, 0 new axioms)",
+      "GodelSecondIncompletenessOQ02GLFour.lean: four (GL |- box A -> box box A), box_iterate, box_mono, propositional toolkit (12 decls) — 0 axioms, 0 sorries, no Mathlib imports, docker-verified"
     ],
     "insights": [
       "S14 STATE-SYNC (researcher-1, 2026-05-25T10:00Z): PR #19037 (S2-α ACT) MERGED 2026-05-19T18:15:15Z (commit 84055877c4a, squash-merge, rebased by deployer/champion path with loom:pr + loom:merge-conflict labels). The S13 bottleneck is cleared. Ships GodelSecondIncompletenessOQ02Companion.lean (~225 LOC) with impl_formula, impl_mp, d2_distribution, d3_internal_necessitation, derived internal_K theorem. No new PRs on this slug in the 6 days since merge (2026-05-19 → 2026-05-25); next-action handoff for S10 translate ACT or S4 Löb ACT is needed.",
@@ -88,7 +94,10 @@
       "Completeness direction has a fundamental architectural mismatch: the opaque Provable predicate in GodelFirstIncompletenessOQ01 is incompatible with Solovay's concrete Σ_1-construction.",
       "Löb's theorem (currently informal at line 213 of parent) becomes a stepping stone: a side-product of S2-α + D2/D3 with a Henkin fixed-point axiom.",
       "GL Kripke completeness (Segerberg 1971) is itself a substantial modal-logic theorem and a prerequisite for Solovay's completeness — not currently in Mathlib.",
-      "S15 ACT (2026-06-01, researcher-1): shipped `translate : (PropAtom → Formula) → GLFormula → Formula` per S10 PREP #18678 §3.3 — new companion file `proofs/Proofs/GodelSecondIncompletenessOQ02Translate.lean` (132 LOC) with 4 recursive cases (`atom`/`falsum`/`impl`/`box`) + 5 `rfl`-discharged simp-equation theorems. **0 new axioms** (clean structural-theorem-add per CLAUDE.md §Axiom Integrity). Docker 3062 jobs clean at HEAD; target built 9.0s on cached Mathlib pin `2df2f0150c`. The S10 PREP design implemented verbatim with no API surprises at v4.26.0. Unblocks S16 arithmetical soundness induction (5-case dispatch over `GL_proves`)."
+      "S15 ACT (2026-06-01, researcher-1): shipped `translate : (PropAtom → Formula) → GLFormula → Formula` per S10 PREP #18678 §3.3 — new companion file `proofs/Proofs/GodelSecondIncompletenessOQ02Translate.lean` (132 LOC) with 4 recursive cases (`atom`/`falsum`/`impl`/`box`) + 5 `rfl`-discharged simp-equation theorems. **0 new axioms** (clean structural-theorem-add per CLAUDE.md §Axiom Integrity). Docker 3062 jobs clean at HEAD; target built 9.0s on cached Mathlib pin `2df2f0150c`. The S10 PREP design implemented verbatim with no API surprises at v4.26.0. Unblocks S16 arithmetical soundness induction (5-case dispatch over `GL_proves`).",
+      "S18: GL derives the 4 schema box A -> box box A axiom-free (GL extends K4) — first derived theorem in the S8 GL Hilbert system; Boolos argument with B := A and-def box A, Lob constructor closing the loop. #print axioms four: does not depend on ANY axioms (fully constructive, no Mathlib).",
+      "BLOCKED ROUTE (S16 recommendation not viable): discharging Hk from internal_K confuses meta and object levels — internal_K is the META rule (|- phi->psi) -> (|- Prov phi ->f Prov psi); Hk needs the OBJECT theorem |- Prov(a->b) ->f (Prov a ->f Prov b) (formalized D2). No object-level deduction theorem exists under the opaque Provable; Hk/Hlob genuinely blocked on the Sigma1 rebuild (S6 PREP #18497).",
+      "Reusable propositional toolkit from the 3 Lukasiewicz schemas: imp_id, imp_trans, flip (rule form = imp_trans(ax1) . mp(ax2)), imp_swap (theorem), efq (via k3 against not-bottom), dni (flip of id), conj := not(p -> not q) with intro/elims. Enables Htaut instance discharges; full Htaut = Kalmar completeness (~300-500 LOC constructive, next big tractable target)."
     ],
     "mathlibGaps": [
       "No modal logic / provability logic library in Mathlib.",


### PR DESCRIPTION
## Summary
Research session for **godel-second-incompleteness-oq02-oq-02** (GL / provability-logic track, RICH tier, S18 ACT).

## Progress
- New file `proofs/Proofs/GodelSecondIncompletenessOQ02GLFour.lean` (~200 lines, 17 decls): the **first derived theorem inside the S8 GL Hilbert system** — `four : GL_proves (box A -> box (box A))`, i.e. **GL extends K4**: the transitivity schema is not among the `GL_proves` constructors, yet falls out of Löb's axiom via Boolos' classic argument (`B := A ∧ box A`, defined conjunction, box-monotonicity, Löb at `B`).
- Reusable **propositional toolkit** derived from the three Łukasiewicz schemas alone: `imp_id`, `imp_trans`, `flip`, `imp_swap`, `efq`, `dni`, defined `conj` with intro/elims, plus the `box_mono` derived rule and an iterated-box corollary `box_iterate`. These are the building blocks for future `Htaut` instance discharges (S16's open hypothesis).
- **Negative finding recorded as a structured blocked route**: S16's suggestion to discharge `Hk` "via internal_K" is not viable — `internal_K` is the *meta* rule while `Hk` demands the *object-level* formalized-D2 theorem; with the opaque `Provable` there is no object deduction theorem, so `Hk`/`Hlob` genuinely wait on the Σ₁ rebuild (S6 PREP #18497).
- State sync: PR #19037 is long merged; stale blocker entries corrected.

## Verification
- Docker build succeeded (3 jobs — the file imports only the dependency-free GLSyntax file, no Mathlib).
- `#print axioms four` / `box_iterate`: **"does not depend on any axioms"** — fully constructive, not even `propext`/`Classical.choice`.
- 0 sorries, 0 axiom declarations.

## Status
**Outcome**: progress
**Next Steps**: Kalmár completeness for the →/⊥ fragment (~300-500 LOC, constructive) to discharge `Htaut` wholesale, or per-instance `Htaut` discharges with the new toolkit; S5 Kripke semantics remains an independent unblocked axis.

🤖 Generated by researcher-3
