### PR TITLE
Gallery integrity: erdos-756 phantom bhowmick_general/clemen_dumitrescu_liu axioms

### DIFF
--- a/src/data/proofs/erdos-756/annotations.json
+++ b/src/data/proofs/erdos-756/annotations.json
@@ -330,7 +330,7 @@
     },
     "type": "concept",
     "title": "Bhowmick's General Result",
-    "content": "**bhowmick_general:**\n\nFor higher multiplicities: ⌊n/(2(m+1))⌋ distances can occur ≥ n+m times.\n\n```lean\naxiom bhowmick_general (m n : ℕ) (hn : n ≥ 2 * (m + 1)) :\n  ∃ A : PointSet, A.card = n ∧\n    (((allDistances A).filter fun d =>\n      distanceMultiplicity A d ≥ n + m).card : ℕ) ≥ n / (2 * (m + 1))\n```\n\n**Trade-off:** Higher multiplicity (n+m instead of n+1) means fewer such distances.",
+    "content": "**Bhowmick's general trade-off result:**\n\nFor higher multiplicities: ⌊n/(2(m+1))⌋ distances can occur ≥ n+m times.\n\n*Not formalized* — this generalization is described only in a source comment (line 128); no `bhowmick_general` declaration exists in the file. Only the m=1 case (`bhowmick_main`) is axiomatized.\n\n**Trade-off:** Higher multiplicity (n+m instead of n+1) means fewer such distances.",
     "mathContext": "This generalizes the main result to multiplicities beyond the n+1 threshold.",
     "significance": "key",
     "relatedConcepts": [
@@ -375,7 +375,7 @@
     },
     "type": "concept",
     "title": "Square Grid Results (2025)",
-    "content": "**clemen_dumitrescu_liu:**\n\nOn the n×n square grid: superpolynomially many rich distances.\n\n```lean\naxiom clemen_dumitrescu_liu (n : ℕ) (hn : n ≥ 2) :\n  ∃ c : ℝ, c > 0 ∧\n    let A := squareGrid n\n    let k := n^2  -- number of grid points\n    (numRichDistances A : ℝ) ≥ k^(c / Real.log (Real.log k))\n```\n\n**Growth:** n^{c/log log n} rich distances among n² = k grid points.\n\nThe grid structure creates many distances with high multiplicity!",
+    "content": "**Clemen-Dumitrescu-Liu (2025):**\n\nOn the n×n square grid: superpolynomially many rich distances.\n\n*Not formalized* — this result is described only in a source comment (Part VII); no `clemen_dumitrescu_liu` declaration exists in the file. Only the grid point set itself (`squareGrid`) is axiomatized, not the multiplicity bound.\n\n**Growth (per the cited paper, not Lean-verified here):** n^{c/log log n} rich distances among n² = k grid points.\n\nThe grid structure creates many distances with high multiplicity!",
     "mathContext": "Clemen-Dumitrescu-Liu (2025) showed structured sets like grids can achieve superpolynomial richness.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-756/meta.json
+++ b/src/data/proofs/erdos-756/meta.json
@@ -67,7 +67,7 @@
       "max_distance_not_rich theorem: largest is never rich (proved)",
       "bhowmick_main axiom: ⌊n/4⌋ rich distances exist",
       "erdos_756_answer theorem: YES answer to the question",
-      "squareGrid definition: n×n grid points",
+      "squareGrid axiom: n×n grid points (axiomatized construction)",
       "richDistanceRatio definition: ratio of rich distances to n",
       "bhowmick_ratio theorem: achieves ratio ≥ 1/4",
       "multiplicity_trivial_upper theorem: multiplicity ≤ n²",
@@ -134,7 +134,7 @@
     {
       "id": "bhowmick",
       "title": "Bhowmick's Answer (2024)",
-      "summary": "bhowmick_construction, bhowmick_main, bhowmick_general axioms",
+      "summary": "bhowmick_main axiom (general m-multiplicity trade-off is described only in a comment, not formalized)",
       "startLine": 117,
       "endLine": 137,
       "mathContext": "Bhowmick (2024): $\\exists A \\subseteq \\mathbb{R}^2,\\, |A| = n$ with $\\lfloor n/4 \\rfloor$ rich distances. General: for any $m$, $\\lfloor n/(2(m+1)) \\rfloor$ distances with multiplicity $\\geq n + m$."
@@ -150,7 +150,7 @@
     {
       "id": "grid-results",
       "title": "Square Grid Results (2025)",
-      "summary": "squareGrid, clemen_dumitrescu_liu, grid_super_linear_multiplicity",
+      "summary": "squareGrid axiom (Clemen-Dumitrescu-Liu superpolynomial richness result is described only in a comment, not formalized)",
       "startLine": 157,
       "endLine": 178,
       "mathContext": "Clemen-Dumitrescu-Liu (2025): on the $\\sqrt{n} \\times \\sqrt{n}$ integer grid, $n^{c/\\log\\log n}$ distances have multiplicity $\\geq n^{1+c/\\log\\log n}$ — superpolynomial richness from lattice point theory."


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-756 (Rich Distances in the Plane)
**Problem**: `meta.json` section summaries and `annotations.json` reference 4 Lean declaration names that don't exist anywhere in `Proofs/Erdos756Problem.lean`: `bhowmick_construction`, `bhowmick_general`, `clemen_dumitrescu_liu`, `grid_super_linear_multiplicity`. Two of these (`bhowmick_general`, `clemen_dumitrescu_liu`) were shown in `annotations.json` as complete fabricated ` ```lean axiom ... ``` ` code blocks styled as real declarations — but the actual source only has plain prose comments at those line ranges (Bhowmick's general m-multiplicity trade-off, and the Clemen-Dumitrescu-Liu 2025 grid superpolynomial-richness result are both un-formalized). Separately, `squareGrid` was mislabeled "definition" in `originalContributions` when it's actually declared `noncomputable axiom`.

## Evidence

**meta.json claims** (before fix):
- `originalContributions`: `"squareGrid definition: n×n grid points"`
- `sections[bhowmick].summary`: `"bhowmick_construction, bhowmick_main, bhowmick_general axioms"`
- `sections[grid-results].summary`: `"squareGrid, clemen_dumitrescu_liu, grid_super_linear_multiplicity"`

**annotations.json claims** (before fix): `ann-e756-bhowmick-general` and `ann-e756-cdl` entries embedded fabricated Lean code (` ```lean axiom bhowmick_general ...``` ` and ` ```lean axiom clemen_dumitrescu_liu ...``` `) not present in the source.

**Lean file shows**: `grep -n "^axiom\|^noncomputable axiom" Proofs/Erdos756Problem.lean` finds exactly 5 axioms: `hopf_pannwitz`, `bhowmick_main`, `squareGrid`, `regularPolygon`, `latticeInDisk`. None of the 4 phantom names appear anywhere in the file (`grep` returns no matches). The disclosed `axiomCount: 5` was already numerically correct — this is a prose/annotation overclaim, not a count mismatch.

## Fix Applied

- `originalContributions`: `squareGrid` relabeled from "definition" to "axiom".
- `sections[bhowmick].summary` and `sections[grid-results].summary`: phantom names removed, replaced with accurate text noting the general/grid results are "described only in a comment, not formalized".
- `annotations.json` `ann-e756-bhowmick-general` / `ann-e756-cdl`: fabricated code blocks replaced with honest "*Not formalized*" disclosure.

Verified: 5 axioms / 0 sorries / 8 theorems / 17 definitions / 274 lines all match `meta.json`'s numeric fields exactly; only the phantom-declaration prose was wrong.

---
Discovered during gallery integrity audit.