### PR TITLE
Research: erdos-30-wip-01 - Erdős–Turán construction: h(N) ≥ √N/4 (order of magnitude settled)

### DIFF
--- a/proofs/Proofs/Erdos30WIP01.lean
+++ b/proofs/Proofs/Erdos30WIP01.lean
@@ -26,6 +26,17 @@
                               `1 ≤ h(N) ≤ √(2N) + 1` with the bound above.
   * `sidonNumber_mono`      : `N ≤ M ⟹ h(N) ≤ h(M)` — `h` is monotone in the range.
 
+  Polynomial lower bound — the Erdős–Turán construction (all axiom-free):
+
+  * `sidonNumber_ge_of_odd_prime` : for every odd prime `p`, the set
+                              `{2pi + (i² mod p) : i < p}` is a Sidon set in
+                              `{0,…,2p²−1}`, so `h(2p²−1) ≥ p`.
+  * `sidonNumber_sqrt_lower`  : `h(N) > ⌊√((N+1)/2)⌋/2` for `N ≥ 49`, via
+                              Bertrand's postulate.
+  * `sidonNumber_ge_real_sqrt` : `√N/4 ≤ h(N)` for `N ≥ 49` — together with
+                              `sidonNumber_le_real` this settles the order of
+                              magnitude `h(N) ≍ √N` elementarily.
+
   The mechanism: for a Sidon set the differences a − b (a ≠ b) are all distinct
   (a − b = c − d rewrites to a + d = c + b, and the Sidon property forces the
   pair to match), and they are nonzero integers in [−N, N], of which there are
@@ -1665,5 +1676,208 @@ theorem sidonNumber_twentyeight : sidonNumber 28 = 7 := by
       (fun A hsub hA => no_sidon_card_eight_range_twentynine A hsub hA)
   · calc 7 = ({0, 1, 4, 10, 18, 23, 25} : Finset ℕ).card := by decide
       _ ≤ sidonNumber 28 := sidonNumber_ge_card (by decide) isSidonSet_0_1_4_10_18_23_25
+
+/- ## The Erdős–Turán construction: a polynomial lower bound `h(N) ≳ √N/4`
+
+The powers-of-two family above shows `h(N)` is unbounded, but only
+logarithmically.  Here we formalize the classical Erdős–Turán (1941)
+*construction*: for an odd prime `p`, the `p` numbers
+
+  `2·p·i + (i² mod p)`,  `0 ≤ i < p`
+
+form a Sidon set inside `{0, …, 2p² − 1}`.  Writing each element in "base
+`2p`" as `(quotient, remainder) = (i, i² mod p)`, a coincidence of pairwise
+sums forces `i + j = k + l` (quotients) and `i² + j² ≡ k² + l² (mod p)`
+(remainders); over the field `ZMod p` this pins down the elementary symmetric
+functions `i + j` and `i·j` of the pair, so `{i, j} = {k, l}` as roots of the
+same monic quadratic.  Hence `h(2p² − 1) ≥ p`, and Bertrand's postulate turns
+this single-prime bound into the uniform polynomial bound `h(N) > ⌊√((N+1)/2)⌋/2`
+for all `N ≥ 49` — order `√N`, matching the `√(2N) + 1` upper bound
+(`sidonNumber_le_real`) up to a constant factor. -/
+
+/-- The Erdős–Turán map `i ↦ 2·p·i + (i² mod p)`: "base-`2p`" encoding of the
+pair `(i, i² mod p)`. -/
+private def etMap (p i : ℕ) : ℕ := 2 * p * i + i ^ 2 % p
+
+/-- Base-`2p` digit extraction: if `2p·a + r = 2p·b + s` with both remainders
+`< 2p`, then the quotients and remainders agree separately. -/
+private theorem base_two_p_eq {p a b r s : ℕ} (hp : 0 < p) (hr : r < 2 * p)
+    (hs : s < 2 * p) (h : 2 * p * a + r = 2 * p * b + s) : a = b ∧ r = s := by
+  have hd : (2 * p * a + r) / (2 * p) = (2 * p * b + s) / (2 * p) := by rw [h]
+  rw [Nat.mul_add_div (by omega), Nat.mul_add_div (by omega),
+    Nat.div_eq_of_lt hr, Nat.div_eq_of_lt hs] at hd
+  have hab : a = b := by omega
+  subst hab
+  exact ⟨rfl, by omega⟩
+
+/-- The quadratic step of the Erdős–Turán argument: if `i + j = k + l` and
+`i² + j² ≡ k² + l² (mod p)` for an odd prime `p` and `i, j, k, l < p`, then
+`{i, j} = {k, l}`.  Over `ZMod p` the two pairs share both elementary symmetric
+functions, so they are the root multisets of one monic quadratic. -/
+private theorem et_quadratic {p : ℕ} (hp : p.Prime) (hodd : p ≠ 2)
+    {i j k l : ℕ} (hi : i < p) (_hj : j < p) (hk : k < p) (hl : l < p)
+    (hsum : i + j = k + l)
+    (hsq : i ^ 2 % p + j ^ 2 % p = k ^ 2 % p + l ^ 2 % p) :
+    (i = k ∧ j = l) ∨ (i = l ∧ j = k) := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  haveI : NeZero p := ⟨hp.pos.ne'⟩
+  have h1 := congrArg (Nat.cast : ℕ → ZMod p) hsum
+  push_cast at h1
+  have h2 := congrArg (Nat.cast : ℕ → ZMod p) hsq
+  push_cast [ZMod.natCast_mod] at h2
+  -- 2 is invertible mod an odd prime
+  have h2ne : (2 : ZMod p) ≠ 0 := by
+    have hlt : 2 < p := lt_of_le_of_ne hp.two_le (Ne.symm hodd)
+    intro h20
+    have hval : ((2 : ℕ) : ZMod p).val = 2 := ZMod.val_cast_of_lt hlt
+    rw [show ((2 : ℕ) : ZMod p) = (2 : ZMod p) from by norm_cast, h20,
+      ZMod.val_zero] at hval
+    norm_num at hval
+  -- equal power sums + equal first symmetric function ⟹ equal products
+  have hq : (2 : ZMod p) * ((i : ZMod p) * (j : ZMod p))
+      = 2 * ((k : ZMod p) * (l : ZMod p)) := by
+    linear_combination ((i : ZMod p) + (j : ZMod p) + (k : ZMod p) + (l : ZMod p)) * h1 - h2
+  have hq' : (i : ZMod p) * (j : ZMod p) = (k : ZMod p) * (l : ZMod p) :=
+    mul_left_cancel₀ h2ne hq
+  -- i is a root of (X − k)(X − l)
+  have hroot : ((i : ZMod p) - (k : ZMod p)) * ((i : ZMod p) - (l : ZMod p)) = 0 := by
+    linear_combination (i : ZMod p) * h1 - hq'
+  have hcast : ∀ {a b : ℕ}, a < p → b < p → (a : ZMod p) = (b : ZMod p) → a = b := by
+    intro a b ha hb hab
+    have hva := ZMod.val_cast_of_lt ha
+    have hvb := ZMod.val_cast_of_lt hb
+    rw [hab] at hva
+    omega
+  rcases mul_eq_zero.mp hroot with h | h
+  · exact Or.inl ⟨hcast hi hk (sub_eq_zero.mp h), by
+      have := hcast hi hk (sub_eq_zero.mp h); omega⟩
+  · exact Or.inr ⟨hcast hi hl (sub_eq_zero.mp h), by
+      have := hcast hi hl (sub_eq_zero.mp h); omega⟩
+
+/-- The Erdős–Turán Sidon set: the image of `{0, …, p−1}` under
+`i ↦ 2·p·i + (i² mod p)`. -/
+private def etSet (p : ℕ) : Finset ℕ := (Finset.range p).image (etMap p)
+
+/-- The Erdős–Turán set has distinct pairwise sums: a sum coincidence forces
+the base-`2p` digits to match (`base_two_p_eq`), and the quadratic step
+(`et_quadratic`) then matches the pairs. -/
+private theorem hasDistinctSums_etSet {p : ℕ} (hp : p.Prime) (hodd : p ≠ 2) :
+    HasDistinctSums (etSet p) := by
+  intro a b c d ha hb hc hd habcd
+  simp only [etSet, Finset.mem_image, Finset.mem_range] at ha hb hc hd
+  obtain ⟨i, hi, rfl⟩ := ha
+  obtain ⟨j, hj, rfl⟩ := hb
+  obtain ⟨k, hk, rfl⟩ := hc
+  obtain ⟨l, hl, rfl⟩ := hd
+  have hppos : 0 < p := hp.pos
+  have m1 : i ^ 2 % p < p := Nat.mod_lt _ hppos
+  have m2 : j ^ 2 % p < p := Nat.mod_lt _ hppos
+  have m3 : k ^ 2 % p < p := Nat.mod_lt _ hppos
+  have m4 : l ^ 2 % p < p := Nat.mod_lt _ hppos
+  have hsum : 2 * p * (i + j) + (i ^ 2 % p + j ^ 2 % p)
+      = 2 * p * (k + l) + (k ^ 2 % p + l ^ 2 % p) := by
+    unfold etMap at habcd
+    linarith
+  obtain ⟨hIJ, hRes⟩ := base_two_p_eq hppos (by omega) (by omega) hsum
+  rcases et_quadratic hp hodd hi hj hk hl hIJ hRes with ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩
+  · exact Or.inl ⟨rfl, rfl⟩
+  · exact Or.inr ⟨rfl, rfl⟩
+
+/-- **The Erdős–Turán set is a Sidon set** (for `p` an odd prime). -/
+private theorem isSidonSet_etSet {p : ℕ} (hp : p.Prime) (hodd : p ≠ 2) :
+    IsSidonSet (etSet p) :=
+  (sidon_iff_distinct_sums _).mpr (hasDistinctSums_etSet hp hodd)
+
+/-- The Erdős–Turán set has exactly `p` elements: the map `etMap p` is
+injective on `{0, …, p−1}` since the base-`2p` quotient recovers `i`. -/
+private theorem etSet_card {p : ℕ} (hp : 0 < p) : (etSet p).card = p := by
+  rw [etSet, Finset.card_image_of_injOn, Finset.card_range]
+  intro a ha b hb hab
+  simp only [Finset.coe_range, Set.mem_Iio] at ha hb
+  have m1 : a ^ 2 % p < p := Nat.mod_lt _ hp
+  have m2 : b ^ 2 % p < p := Nat.mod_lt _ hp
+  unfold etMap at hab
+  exact (base_two_p_eq hp (by omega) (by omega) hab).1
+
+/-- Each element of the Erdős–Turán set is `< 2p²`. -/
+private theorem etSet_subset {p : ℕ} (hp : 0 < p) :
+    etSet p ⊆ Finset.range (2 * p ^ 2) := by
+  intro x hx
+  simp only [etSet, Finset.mem_image, Finset.mem_range] at hx ⊢
+  obtain ⟨i, hi, rfl⟩ := hx
+  have h2 : i ^ 2 % p < p := Nat.mod_lt _ hp
+  have h1 : 2 * p * (i + 1) ≤ 2 * p * p := Nat.mul_le_mul_left _ hi
+  unfold etMap
+  nlinarith
+
+/-- **Erdős–Turán (1941) lower bound, single-prime form**: for every odd prime
+`p` the interval `{0, …, 2p² − 1}` contains a Sidon set of size `p`, so
+`h(2p² − 1) ≥ p`.  This is the first polynomial-order lower bound in this
+file — order `√N`, versus the logarithmic powers-of-two bound. -/
+theorem sidonNumber_ge_of_odd_prime {p : ℕ} (hp : p.Prime) (hodd : p ≠ 2) :
+    p ≤ sidonNumber (2 * p ^ 2 - 1) := by
+  have hppos : 0 < p := hp.pos
+  have hrange : 2 * p ^ 2 - 1 + 1 = 2 * p ^ 2 :=
+    Nat.sub_add_cancel (Nat.one_le_iff_ne_zero.mpr (by positivity))
+  calc p = (etSet p).card := (etSet_card hppos).symm
+    _ ≤ sidonNumber (2 * p ^ 2 - 1) :=
+        sidonNumber_ge_card (by rw [hrange]; exact etSet_subset hppos)
+          (isSidonSet_etSet hp hodd)
+
+/-- **Uniform polynomial lower bound via Bertrand's postulate**: for `N ≥ 49`,
+`h(N) > ⌊√((N+1)/2)⌋ / 2` — order `√N`.  Bertrand supplies an odd prime `p`
+with `m/2 < p ≤ m` for `m = ⌊√((N+1)/2)⌋`; then `2p² − 1 ≤ N`, and the
+Erdős–Turán set for `p` fits inside `{0, …, N}`. -/
+theorem sidonNumber_sqrt_lower {N : ℕ} (hN : 49 ≤ N) :
+    Nat.sqrt ((N + 1) / 2) / 2 < sidonNumber N := by
+  set m := Nat.sqrt ((N + 1) / 2) with hm
+  have hm5 : 5 ≤ m := by
+    rw [hm]
+    exact Nat.le_sqrt.mpr (by omega)
+  obtain ⟨p, hp, hlow, hhigh⟩ := Nat.exists_prime_lt_and_le_two_mul (m / 2) (by omega)
+  have hodd : p ≠ 2 := by omega
+  have hpm : p ≤ m := by omega
+  have hsq : p ^ 2 ≤ (N + 1) / 2 := by
+    calc p ^ 2 ≤ m ^ 2 := Nat.pow_le_pow_left hpm 2
+      _ ≤ (N + 1) / 2 := by rw [hm]; exact Nat.sqrt_le' _
+  have h2p : 2 * p ^ 2 ≤ N + 1 := by
+    have hd : 2 * ((N + 1) / 2) ≤ N + 1 := by omega
+    linarith
+  calc m / 2 < p := hlow
+    _ ≤ sidonNumber (2 * p ^ 2 - 1) := sidonNumber_ge_of_odd_prime hp hodd
+    _ ≤ sidonNumber N := sidonNumber_mono (Nat.sub_le_iff_le_add.mpr h2p)
+
+/-- **The `√N` shape of the lower bound**: `√N / 4 ≤ h(N)` for `N ≥ 49`.
+Together with `sidonNumber_le_real` (`h(N) ≤ √(2N) + 1`) this settles the
+order of magnitude `h(N) ≍ √N` — entirely elementarily. -/
+theorem sidonNumber_ge_real_sqrt {N : ℕ} (hN : 49 ≤ N) :
+    Real.sqrt N / 4 ≤ (sidonNumber N : ℝ) := by
+  set m := Nat.sqrt ((N + 1) / 2) with hm
+  have hmain : m / 2 + 1 ≤ sidonNumber N := sidonNumber_sqrt_lower hN
+  -- `N < 2(m+1)²`, hence `N ≤ (2(m+1))²` with room to spare
+  have hN2 : N < 2 * (m + 1) ^ 2 := by
+    have h1 : (N + 1) / 2 < (m + 1) ^ 2 := by
+      rw [hm]
+      have := Nat.lt_succ_sqrt' ((N + 1) / 2)
+      simpa using this
+    have h2 : N + 1 ≤ 2 * ((N + 1) / 2) + 1 := by omega
+    linarith
+  have hN4 : N ≤ (2 * (m + 1)) ^ 2 := by
+    have h3 : (2 * (m + 1)) ^ 2 = 4 * (m + 1) ^ 2 := by ring
+    linarith
+  have hsqrt : Real.sqrt N ≤ ((2 * (m + 1) : ℕ) : ℝ) := by
+    have hc : (N : ℝ) ≤ (((2 * (m + 1) : ℕ) : ℝ)) ^ 2 := by exact_mod_cast hN4
+    calc Real.sqrt N ≤ Real.sqrt ((((2 * (m + 1) : ℕ) : ℝ)) ^ 2) := Real.sqrt_le_sqrt hc
+      _ = ((2 * (m + 1) : ℕ) : ℝ) := Real.sqrt_sq (by positivity)
+  have hdiv : ((m : ℝ) + 1) / 2 ≤ ((m / 2 : ℕ) : ℝ) + 1 := by
+    have hfloor : m ≤ 2 * (m / 2) + 1 := by omega
+    have hc : (m : ℝ) ≤ 2 * ((m / 2 : ℕ) : ℝ) + 1 := by exact_mod_cast hfloor
+    linarith
+  have hcast2 : ((2 * (m + 1) : ℕ) : ℝ) = 2 * ((m : ℝ) + 1) := by push_cast; ring
+  have hmainR : ((m / 2 : ℕ) : ℝ) + 1 ≤ (sidonNumber N : ℝ) := by exact_mod_cast hmain
+  calc Real.sqrt N / 4 ≤ ((2 * (m + 1) : ℕ) : ℝ) / 4 := by linarith
+    _ = ((m : ℝ) + 1) / 2 := by rw [hcast2]; ring
+    _ ≤ ((m / 2 : ℕ) : ℝ) + 1 := hdiv
+    _ ≤ (sidonNumber N : ℝ) := hmainR
 
 end Erdos30

--- a/research/problems/erdos-30-wip-01/knowledge.md
+++ b/research/problems/erdos-30-wip-01/knowledge.md
@@ -196,3 +196,53 @@ value ≡ 2 (mod 4) with class multiset {4,2,1,1} arranged c₀c₂+c₁c₃ = 6
 the double count) — needs either a mod-4+mod-3 combination, endpoint-pinned
 sum-collision pruning (a+b = 29 forbidden pairs), or the C(28,6) ≈ 376k kernel
 search. DEEP targets unchanged.
+
+## Session 2026-07-24 (researcher-1) — Erdős–Turán construction: polynomial lower bound h(N) ≥ √N/4
+
+Added ~215 lines to `Erdos30WIP01.lean` (0 sorries, 0 axioms; `#print axioms` =
+propext/Classical.choice/Quot.sound on all three headline theorems):
+- `etMap`/`etSet` (private): the Erdős–Turán (1941) construction — for odd prime p,
+  the p numbers `2pi + (i² mod p)` (i < p) form a Sidon set in {0,…,2p²−1}.
+- `base_two_p_eq` (private): base-2p digit extraction (quotient/remainder both match).
+- `et_quadratic` (private): the crux — i+j = k+l and i²+j² ≡ k²+l² (mod p) with all
+  < p forces {i,j} = {k,l}. Over ZMod p: equal power sums + equal e₁ ⟹ equal e₂
+  (2 invertible, p odd), so both pairs are root multisets of one monic quadratic;
+  (x−k)(x−l) = 0 at x = i via `linear_combination`, split by `mul_eq_zero`.
+- `sidonNumber_ge_of_odd_prime`: p ≤ h(2p²−1).
+- `sidonNumber_sqrt_lower`: h(N) > ⌊√((N+1)/2)⌋/2 for N ≥ 49 (Bertrand:
+  `Nat.exists_prime_lt_and_le_two_mul` on m/2 with m = ⌊√((N+1)/2)⌋; m ≥ 5 makes
+  the prime ≥ 3, hence odd).
+- `sidonNumber_ge_real_sqrt`: √N/4 ≤ h(N) for N ≥ 49. **With `sidonNumber_le_real`
+  (h(N) ≤ √(2N)+1) the file now settles h(N) ≍ √N elementarily** — the former
+  DEEP target "Singer √N lower bound" is achieved via Erdős–Turán instead of
+  Singer difference sets (no projective planes needed).
+
+**Lean recipe notes:**
+- `omega` atomizes `2*p*a` and `2*p*b` as DISTINCT atoms — after extracting a = b
+  from the base-2p division, `subst` first so both sides share one atom, then omega.
+- Cast to ZMod p via `congrArg (Nat.cast : ℕ → ZMod p)` + `push_cast [ZMod.natCast_mod]`
+  (folds `(i² % p : ℕ)` cast to `(i : ZMod p)²` in one pass).
+- `(2 : ZMod p) ≠ 0` for odd prime p: via `ZMod.val_cast_of_lt (2 < p)`; needs
+  `haveI : NeZero p := ⟨hp.pos.ne'⟩` alongside `Fact p.Prime`.
+- Both symmetric-function identities are one-shot `linear_combination`:
+  `(x+y+z+w) * h1 - h2` gives 2xy = 2zw; `x * h1 - hq'` gives (x−z)(x−w) = 0.
+- `Nat.sub_le_iff_le_add` avoids omega-on-pow when feeding `2*p^2 − 1 ≤ N` to
+  `sidonNumber_mono` (omega rejects `^`; linarith with atoms p², (N+1)/2 works).
+
+**h(29) wall CORRECTION (prior note wrong):** the earlier claim "parity ⟹ missing
+diff d odd" is FALSE. Mod-2 class count: signed even diffs = 28 − 2[d even] =
+o(o−1)+e(e−1) = o²+e²−8 with o+e = 8; d odd needs o²+e² = 36 — impossible
+({32,34,40,50,64}) — so **d is EVEN**. Then mod-4: d ≡ 0 (mod 4) gives same-class
+12 ⟹ profile {3,3,1,1} but cross-class stays 14 ⟹ c₀c₂+c₁c₃ = 7 ∉ {10,6} —
+contradiction. So **d ≡ 2 (mod 4)**, d ∈ {2,6,10,14,18,22,26}. Mod-3: 3∤d ⟹
+profile (4,3,1); 3∣d (d ∈ {6,18}) ⟹ profile (4,2,2) — NOT excluded (prior note
+also overclaimed "mod-3 forces 3∤d"). Residue invariants alone still don't close
+h(29); remaining routes: mod-6/mod-8 cross counts against the narrowed d-list, or
+span dichotomy (span 28 dies on the h(28) theorem by translation; span 29 pins
+{0,29}, sum-collision kills complementary pairs a+(29−a), C(14,6)·2⁶ ≈ 192k
+candidates — still beyond decide+kernel comfort).
+
+**Remaining targets:** h(29..33) per-N nonexistence (above), N^{1/4} refinement
+(Erdős–Turán exact form √N + N^{1/4} + 1), $1000 N^ε conjecture (stays a Prop).
+The construction side is now DONE at order √N; constant-sharpening (h ≥ (1−o(1))√N
+via Singer) would need genuine finite-geometry infra.

--- a/research/problems/erdos-30-wip-01/state.md
+++ b/research/problems/erdos-30-wip-01/state.md
@@ -20,9 +20,9 @@ chained span dichotomy + pinned-endpoint kernel search for the in-between
 values. `SidonCheck` converse bridge certifies witnesses with one `decide`.
 
 ## Attempt Count
-- Total attempts: 7 sessions
-- Current approach attempts: 4 (h(16), h(17..21), h(22..27), h(28) — all landed)
-- Approaches tried: parity wall, mod-3 class count, span dichotomy, mod-4 double count
+- Total attempts: 8 sessions
+- Current approach attempts: 5 (h(16), h(17..21), h(22..27), h(28), Erdős–Turán √N lower bound — all landed)
+- Approaches tried: parity wall, mod-3 class count, span dichotomy, mod-4 double count, Erdős–Turán construction + Bertrand
 
 ## Blockers
 h(29..33) wall: perfect ruler no longer forced (28 diffs in {1,…,N} miss
@@ -32,6 +32,11 @@ alone checked INSUFFICIENT at N=29 (a {4,2,1,1} arrangement with the missing
 value ≡ 2 mod 4 survives). Elementary layer near-saturated.
 
 ## Next Action
-Either combine mod-3 × mod-4 (or endpoint sum-collision pruning: pairs
-summing to N are forbidden when {0,N} ⊆ A) to fell h(29), or switch to DEEP
-targets: Singer √N lower bound, N^{1/4} refinement, $1000 N^ε conjecture.
+DONE 2026-07-24: Erdős–Turán construction landed — √N/4 ≤ h(N) ≤ √(2N)+1
+for N ≥ 49, order h(N) ≍ √N settled elementarily (former DEEP target
+"Singer √N lower bound" achieved via Erdős–Turán instead; no projective
+planes). h(29) narrowed: missing diff d ≡ 2 (mod 4) (prior "d odd" note was
+WRONG — mod-2 class count forces d even). Remaining: fell h(29) via
+mod-6/mod-8 cross counts on the narrowed d-list or the ≈192k span-29
+search; or DEEP: N^{1/4} refinement, Singer (1−o(1))√N constant, $1000
+N^ε conjecture.

--- a/src/data/research/problems/erdos-30-wip-01.json
+++ b/src/data/research/problems/erdos-30-wip-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Exact sidonNumber table COMPLETE through h(28): h(0..2)=1,2,2; h(3..5)=3; h(6..10)=4; h(11..16)=5; h(17..24)=6; h(25..28)=7 (h(28) via mod-4 class double count against the forced perfect 8-mark ruler — no kernel search). Two-sided elementary bounds stand. NEXT wall: h(29..33) (perfect ruler no longer forced; mod-4 alone insufficient at N=29). DEEP unchanged: Singer sqrt(N) lower construction, N^{1/4} refinement, $1000 conjecture.",
+    "progressSummary": "Two-sided √N bounds COMPLETE: √N/4 ≤ h(N) ≤ √(2N)+1 for N ≥ 49 (Erdős–Turán construction + Bertrand; 0 axioms) — order of magnitude h(N) ≍ √N settled elementarily. Exact table h(0..28) complete. NEXT wall: h(29..33) (missing diff d ≡ 2 mod 4 now pinned; residue invariants alone insufficient; span-29 search ≈192k after sum-collision pruning). DEEP remaining: N^{1/4} refinement (exact Erdős–Turán form), Singer (1−o(1))√N constant, $1000 N^ε conjecture.",
     "builtItems": [
       "Erdos30WIP01.lean: diffMap_injOn (Set.InjOn of difference map on Sidon off-diagonal)",
       "Erdos30WIP01.lean: sidon_offDiag_card_le (|A.offDiag| ≤ 2N for Sidon A ⊆ {0..N})",
@@ -57,7 +57,11 @@
       "isSidonSet_0_1_4_10_18_23_25 (optimal 7-mark Golomb ruler witness, decide-certified) in Erdos30WIP01.lean",
       "sidonNumber_twentytwo..twentyseven (h(22..24)=6, h(25..27)=7 — exact table now h(0..27)) in Erdos30WIP01.lean",
       "no_sidon_card_eight_range_twentynine in Erdos30WIP01.lean — no 8-element Sidon set in {0..28}, via forced perfect ruler + mod-4 class double count (cross-class fibration T2.filter(p.1%4=r) = A_r ×ˢ A_{(r+2)%4})",
-      "sidonNumber_twentyeight in Erdos30WIP01.lean — h(28)=7; exact table complete h(0..28)"
+      "sidonNumber_twentyeight in Erdos30WIP01.lean — h(28)=7; exact table complete h(0..28)",
+      "etMap/etSet + base_two_p_eq + et_quadratic (private) in Erdos30WIP01.lean",
+      "sidonNumber_ge_of_odd_prime: p ≤ sidonNumber (2p²−1)",
+      "sidonNumber_sqrt_lower: Nat.sqrt((N+1)/2)/2 < sidonNumber N for N ≥ 49",
+      "sidonNumber_ge_real_sqrt: √N/4 ≤ h(N) for N ≥ 49 (0 axioms)"
     ],
     "insights": [
       "Erdős–Turán upper bound is provable elementarily via difference-map injectivity: for a Sidon set A the map (a,b)↦a−b is injective on the off-diagonal (a−b=c−d ⇒ a+d=c+b ⇒ pair matches by the Sidon property), its image is nonzero integers in [−N,N] (2N of them), so |A.offDiag|=|A|²−|A| ≤ 2N.",
@@ -77,7 +81,10 @@
       "h(25)=h(26)=h(27)=7 come free once the ruler {0,1,4,10,18,23,25} is certified: 8²=64 > 2N+8 through N=27. The table now ends exactly where counting goes slack for eight: 64 = 2*28+8 at N=28, and the optimal 8-mark ruler has span 34, so h(28..33) is a six-value wall needing C(N-1,6)-scale searches (~296k at N=28).",
       "h(28)=7 needs NO kernel search: at N=28 the perfect 8-mark ruler is FORCED (C(8,2)=28 distinct positive differences must exhaust {1..28}), and a mod-4 class double count refutes it — same-class Σc_r(c_r−1)=14 with cross-class Σc_r·c_{(r+2)%4}=14 and Σc_r=8 is unsatisfiable (class multiset must be {4,2,1,1} or {3,3,2,0}, giving c0c2+c1c3 ∈ {6,9}, never 7)",
       "Mod-obstruction ladder at the perfect-ruler walls N=k(k−1)/2: h(10) parity (odd sum), h(15) mod-3 same-class, h(21) parity, h(28) mod-4 same+cross-class — every wall so far falls to a residue count, no exhaustive search",
-      "Mod-4 checked INSUFFICIENT at N=29: 28 diffs in {1..29} miss one value; missing ≡2 (mod 4) with class multiset {4,2,1,1} arranged c0c2+c1c3=6 survives the double count — h(29) needs mod-3×mod-4 combination, endpoint sum-collision pruning, or a C(28,6)≈376k kernel search"
+      "Mod-4 checked INSUFFICIENT at N=29: 28 diffs in {1..29} miss one value; missing ≡2 (mod 4) with class multiset {4,2,1,1} arranged c0c2+c1c3=6 survives the double count — h(29) needs mod-3×mod-4 combination, endpoint sum-collision pruning, or a C(28,6)≈376k kernel search",
+      "Erdős–Turán construction {2pi + (i² mod p) : i < p} formalized: base-2p digit extraction + ZMod p quadratic-roots argument gives Sidon property; p ≤ h(2p²−1) for odd primes p",
+      "Bertrand postulate converts the single-prime bound to uniform √N/4 ≤ h(N) for N ≥ 49 — with the √(2N)+1 upper bound the file settles h(N) ≍ √N elementarily, no projective planes needed",
+      "h(29) wall correction: mod-2 class count forces missing diff d EVEN (not odd as previously recorded), mod-4 then forces d ≡ 2 (mod 4); mod-3 allows both (4,3,1) with 3∤d and (4,2,2) with d ∈ {6,18}; residue invariants alone still insufficient"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for **erdos-30-wip-01** (Erdős Problem #30 — Sidon/B₂ sets, $1000 problem).

Formalizes the classical **Erdős–Turán (1941) construction**, giving the file its first polynomial-order lower bound: `h(N) ≥ √N/4` for `N ≥ 49`. Combined with the existing upper bound `h(N) ≤ √(2N)+1`, the file now settles the order of magnitude `h(N) ≍ √N` entirely elementarily — the former DEEP target "√N lower bound" is achieved via Erdős–Turán instead of Singer difference sets (no projective-plane infrastructure needed).

## Progress
- `etMap`/`etSet` (private): the Erdős–Turán Sidon set `{2pi + (i² mod p) : i < p}` for odd prime `p`
- `base_two_p_eq` (private): base-`2p` digit extraction
- `et_quadratic` (private): the crux — over `ZMod p`, equal pair-sums and equal power-sums mod `p` pin both elementary symmetric functions, so the pairs are root multisets of one monic quadratic; closed by two one-shot `linear_combination` identities
- `sidonNumber_ge_of_odd_prime`: `p ≤ h(2p² − 1)` for every odd prime `p`
- `sidonNumber_sqrt_lower`: `h(N) > ⌊√((N+1)/2)⌋/2` for `N ≥ 49`, via Bertrand's postulate (`Nat.exists_prime_lt_and_le_two_mul`)
- `sidonNumber_ge_real_sqrt`: `√N/4 ≤ h(N)` for `N ≥ 49`

File: `proofs/Proofs/Erdos30WIP01.lean` (+214 lines, 0 sorries, 0 axioms; `#print axioms` on all three headline theorems = `propext`/`Classical.choice`/`Quot.sound` only). Docker-verified.

## Findings
- The construction replaces the previous logarithmic (powers-of-two) lower bound as the strongest growth result in the file.
- **h(29) wall correction** (knowledge update): the prior note "missing diff d is odd" was WRONG — a mod-2 class count forces d EVEN, and mod-4 then forces d ≡ 2 (mod 4), d ∈ {2,6,10,14,18,22,26}. Residue invariants alone still do not close h(29).
- Remaining targets: h(29..33) per-N nonexistence (mod-6/mod-8 cross counts or ≈192k span-29 search), N^(1/4) refinement (exact Erdős–Turán form), Singer (1−o(1))√N constant, and the open $1000 N^ε conjecture (stays a `Prop`).

## Status
**Outcome**: progress (major — order of magnitude of h(N) settled)
**Next Steps**: h(29) via combined residue invariants or pinned-endpoint search; constant sharpening toward (1−o(1))√N would need finite-geometry infrastructure.

🤖 Generated by researcher-1
