### PR TITLE
Research: erdos-1092-oq-02 - second exact value fThreshold 1 4 = 2 (three-pairings argument)

### DIFF
--- a/proofs/Proofs/Erdos1092OQ02.lean
+++ b/proofs/Proofs/Erdos1092OQ02.lean
@@ -53,6 +53,11 @@ in prose:
 * `trivial_lower_bound_false` — `fThreshold 1 4 < 4 - 1`: the parent's removed
   `f_trivial_lower` axiom (`n - 1 ≤ fThreshold r n`) is false, via `K₃` + isolated
   vertex — previously only a prose remark, now a theorem.
+* `fThreshold_one_four` — **`fThreshold 1 4 = 2`**, the second exact value: budget `2`
+  forces 2-colorability of every 4-vertex graph via the *three perfect pairings* of
+  `Fin 4` (a killed pairing costs a distinct edge; three killed pairings exceed the
+  budget by disjoint pair-slot counting, `three_slots_le_card`; a surviving pairing
+  is an explicit 2-coloring).  So the threshold is *constant* from `n = 3` to `n = 4`.
 
 No new axioms; the parent file has 0 axioms and they are untouched (and unused here).
 -/
@@ -488,6 +493,237 @@ theorem trivial_lower_bound_false : fThreshold 1 4 < 4 - 1 := by
   have := fThreshold_one_four_le_two
   omega
 
+/-
+## The second exact value: `fThreshold 1 4 = 2`
+
+The upper bound `fThreshold 1 4 ≤ 2` is above (`K₃` + isolated vertex). The
+matching lower bound needs: **budget `2` forces every 4-vertex graph to be
+2-colorable.** Mechanism — the *three perfect pairings* of `Fin 4`:
+
+    {0,1 | 2,3}   {0,2 | 1,3}   {0,3 | 1,2}
+
+A pairing yields a proper 2-coloring (pairs = color classes) **unless** one of
+its two intra-pair edges is present; and an edge kills exactly the one pairing
+that puts its endpoints together.  So if all three pairings are killed, `G`
+has three distinct edges — but the reduction hypothesis at `S = univ` with
+budget `2` caps `G` at two edges (each removed ordered pair kills at most one
+undirected edge: disjoint pair-slot counting, factored into
+`three_slots_le_card`).  Hence some pairing survives and 2-colors `G`.
+-/
+
+/-- If an edge `{u, v}` is killed by `removed` (one of its two orientations is
+a member), then `removed` meets the edge's two-element *pair-slot*
+`{(u,v), (v,u)}`. -/
+lemma slot_nonempty {n : ℕ} {removed : Finset (Fin n × Fin n)} {u v : Fin n}
+    (h : (u, v) ∈ removed ∨ (v, u) ∈ removed) :
+    (removed ∩ ({(u, v), (v, u)} : Finset (Fin n × Fin n))).Nonempty := by
+  rcases h with h | h
+  · exact ⟨(u, v), Finset.mem_inter.mpr ⟨h, Finset.mem_insert_self _ _⟩⟩
+  · exact ⟨(v, u), Finset.mem_inter.mpr
+      ⟨h, Finset.mem_insert.mpr (Or.inr (Finset.mem_singleton_self _))⟩⟩
+
+/-- **Disjoint slot counting.** If `removed` meets three pairwise-disjoint
+slot sets, it has at least three elements — the witnesses live in disjoint
+slots, hence are pairwise distinct.  (Generic form of the `K₃` counting inside
+`two_mem_fThresholdSet_one_three`.) -/
+lemma three_slots_le_card {n : ℕ} {removed s₁ s₂ s₃ : Finset (Fin n × Fin n)}
+    (h₁ : (removed ∩ s₁).Nonempty) (h₂ : (removed ∩ s₂).Nonempty)
+    (h₃ : (removed ∩ s₃).Nonempty)
+    (d₁₂ : Disjoint s₁ s₂) (d₁₃ : Disjoint s₁ s₃) (d₂₃ : Disjoint s₂ s₃) :
+    3 ≤ removed.card := by
+  obtain ⟨a, ha⟩ := h₁
+  obtain ⟨b, hb⟩ := h₂
+  obtain ⟨c, hc⟩ := h₃
+  obtain ⟨haR, haS⟩ := Finset.mem_inter.mp ha
+  obtain ⟨hbR, hbS⟩ := Finset.mem_inter.mp hb
+  obtain ⟨hcR, hcS⟩ := Finset.mem_inter.mp hc
+  have hab : a ≠ b := by
+    rintro rfl
+    exact Finset.disjoint_left.mp d₁₂ haS hbS
+  have hac : a ≠ c := by
+    rintro rfl
+    exact Finset.disjoint_left.mp d₁₃ haS hcS
+  have hbc : b ≠ c := by
+    rintro rfl
+    exact Finset.disjoint_left.mp d₂₃ hbS hcS
+  have hsub : ({a, b, c} : Finset (Fin n × Fin n)) ⊆ removed := by
+    intro p hp
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hp
+    rcases hp with rfl | rfl | rfl
+    · exact haR
+    · exact hbR
+    · exact hcR
+  calc 3 = ({a, b, c} : Finset (Fin n × Fin n)).card := by
+        rw [Finset.card_insert_of_notMem (by simp [hab, hac]),
+          Finset.card_insert_of_notMem (by simp [hbc]), Finset.card_singleton]
+    _ ≤ removed.card := Finset.card_le_card hsub
+
+/-- **Budget `2` forces 4-vertex graphs to be 2-colorable.** Case analysis on
+the three perfect pairings of `Fin 4`: a surviving pairing (both intra-pair
+edges absent) gives an explicit 2-coloring; if each pairing is killed by an
+edge, the three killers are distinct edges and the disjoint pair-slot count
+forces `removed.card ≥ 3 > 2`. -/
+theorem two_mem_fThresholdSet_one_four : 2 ∈ fThresholdSet 1 4 := by
+  intro G hP
+  obtain ⟨removed, hcard, c₁, hc₁⟩ := hP Finset.univ
+  -- Every edge of `G` is killed by one of its two orientations in `removed`.
+  have hkill : ∀ u v, G.adj u v → (u, v) ∈ removed ∨ (v, u) ∈ removed := by
+    intro u v hadj
+    by_contra h
+    push_neg at h
+    exact hc₁ u v ⟨⟨Finset.mem_univ u, Finset.mem_univ v, hadj⟩, h.1, h.2⟩
+      (Subsingleton.elim _ _)
+  by_cases h01 : G.adj 0 1
+  · by_cases h02 : G.adj 0 2
+    · by_cases h03 : G.adj 0 3
+      · -- killers 01, 02, 03
+        exact absurd (three_slots_le_card (slot_nonempty (hkill 0 1 h01))
+          (slot_nonempty (hkill 0 2 h02)) (slot_nonempty (hkill 0 3 h03))
+          (Finset.disjoint_left.mpr (by decide))
+          (Finset.disjoint_left.mpr (by decide))
+          (Finset.disjoint_left.mpr (by decide))) (by omega)
+      · by_cases h12 : G.adj 1 2
+        · -- killers 01, 02, 12
+          exact absurd (three_slots_le_card (slot_nonempty (hkill 0 1 h01))
+            (slot_nonempty (hkill 0 2 h02)) (slot_nonempty (hkill 1 2 h12))
+            (Finset.disjoint_left.mpr (by decide))
+            (Finset.disjoint_left.mpr (by decide))
+            (Finset.disjoint_left.mpr (by decide))) (by omega)
+        · -- pairing {0,3 | 1,2} survives
+          refine ⟨![0, 1, 1, 0], fun u v hadj => ?_⟩
+          fin_cases u <;> fin_cases v <;>
+            first
+              | exact absurd hadj (G.irrefl _)
+              | exact absurd hadj h03
+              | exact absurd hadj (fun h => h03 (G.symm _ _ h))
+              | exact absurd hadj h12
+              | exact absurd hadj (fun h => h12 (G.symm _ _ h))
+              | decide
+    · by_cases h13 : G.adj 1 3
+      · by_cases h03 : G.adj 0 3
+        · -- killers 01, 13, 03
+          exact absurd (three_slots_le_card (slot_nonempty (hkill 0 1 h01))
+            (slot_nonempty (hkill 1 3 h13)) (slot_nonempty (hkill 0 3 h03))
+            (Finset.disjoint_left.mpr (by decide))
+            (Finset.disjoint_left.mpr (by decide))
+            (Finset.disjoint_left.mpr (by decide))) (by omega)
+        · by_cases h12 : G.adj 1 2
+          · -- killers 01, 13, 12
+            exact absurd (three_slots_le_card (slot_nonempty (hkill 0 1 h01))
+              (slot_nonempty (hkill 1 3 h13)) (slot_nonempty (hkill 1 2 h12))
+              (Finset.disjoint_left.mpr (by decide))
+              (Finset.disjoint_left.mpr (by decide))
+              (Finset.disjoint_left.mpr (by decide))) (by omega)
+          · -- pairing {0,3 | 1,2} survives
+            refine ⟨![0, 1, 1, 0], fun u v hadj => ?_⟩
+            fin_cases u <;> fin_cases v <;>
+              first
+                | exact absurd hadj (G.irrefl _)
+                | exact absurd hadj h03
+                | exact absurd hadj (fun h => h03 (G.symm _ _ h))
+                | exact absurd hadj h12
+                | exact absurd hadj (fun h => h12 (G.symm _ _ h))
+                | decide
+      · -- pairing {0,2 | 1,3} survives
+        refine ⟨![0, 1, 0, 1], fun u v hadj => ?_⟩
+        fin_cases u <;> fin_cases v <;>
+          first
+            | exact absurd hadj (G.irrefl _)
+            | exact absurd hadj h02
+            | exact absurd hadj (fun h => h02 (G.symm _ _ h))
+            | exact absurd hadj h13
+            | exact absurd hadj (fun h => h13 (G.symm _ _ h))
+            | decide
+  · by_cases h23 : G.adj 2 3
+    · by_cases h02 : G.adj 0 2
+      · by_cases h03 : G.adj 0 3
+        · -- killers 23, 02, 03
+          exact absurd (three_slots_le_card (slot_nonempty (hkill 2 3 h23))
+            (slot_nonempty (hkill 0 2 h02)) (slot_nonempty (hkill 0 3 h03))
+            (Finset.disjoint_left.mpr (by decide))
+            (Finset.disjoint_left.mpr (by decide))
+            (Finset.disjoint_left.mpr (by decide))) (by omega)
+        · by_cases h12 : G.adj 1 2
+          · -- killers 23, 02, 12
+            exact absurd (three_slots_le_card (slot_nonempty (hkill 2 3 h23))
+              (slot_nonempty (hkill 0 2 h02)) (slot_nonempty (hkill 1 2 h12))
+              (Finset.disjoint_left.mpr (by decide))
+              (Finset.disjoint_left.mpr (by decide))
+              (Finset.disjoint_left.mpr (by decide))) (by omega)
+          · -- pairing {0,3 | 1,2} survives
+            refine ⟨![0, 1, 1, 0], fun u v hadj => ?_⟩
+            fin_cases u <;> fin_cases v <;>
+              first
+                | exact absurd hadj (G.irrefl _)
+                | exact absurd hadj h03
+                | exact absurd hadj (fun h => h03 (G.symm _ _ h))
+                | exact absurd hadj h12
+                | exact absurd hadj (fun h => h12 (G.symm _ _ h))
+                | decide
+      · by_cases h13 : G.adj 1 3
+        · by_cases h03 : G.adj 0 3
+          · -- killers 23, 13, 03
+            exact absurd (three_slots_le_card (slot_nonempty (hkill 2 3 h23))
+              (slot_nonempty (hkill 1 3 h13)) (slot_nonempty (hkill 0 3 h03))
+              (Finset.disjoint_left.mpr (by decide))
+              (Finset.disjoint_left.mpr (by decide))
+              (Finset.disjoint_left.mpr (by decide))) (by omega)
+          · by_cases h12 : G.adj 1 2
+            · -- killers 23, 13, 12
+              exact absurd (three_slots_le_card (slot_nonempty (hkill 2 3 h23))
+                (slot_nonempty (hkill 1 3 h13)) (slot_nonempty (hkill 1 2 h12))
+                (Finset.disjoint_left.mpr (by decide))
+                (Finset.disjoint_left.mpr (by decide))
+                (Finset.disjoint_left.mpr (by decide))) (by omega)
+            · -- pairing {0,3 | 1,2} survives
+              refine ⟨![0, 1, 1, 0], fun u v hadj => ?_⟩
+              fin_cases u <;> fin_cases v <;>
+                first
+                  | exact absurd hadj (G.irrefl _)
+                  | exact absurd hadj h03
+                  | exact absurd hadj (fun h => h03 (G.symm _ _ h))
+                  | exact absurd hadj h12
+                  | exact absurd hadj (fun h => h12 (G.symm _ _ h))
+                  | decide
+        · -- pairing {0,2 | 1,3} survives
+          refine ⟨![0, 1, 0, 1], fun u v hadj => ?_⟩
+          fin_cases u <;> fin_cases v <;>
+            first
+              | exact absurd hadj (G.irrefl _)
+              | exact absurd hadj h02
+              | exact absurd hadj (fun h => h02 (G.symm _ _ h))
+              | exact absurd hadj h13
+              | exact absurd hadj (fun h => h13 (G.symm _ _ h))
+              | decide
+    · -- pairing {0,1 | 2,3} survives
+      refine ⟨![0, 0, 1, 1], fun u v hadj => ?_⟩
+      fin_cases u <;> fin_cases v <;>
+        first
+          | exact absurd hadj (G.irrefl _)
+          | exact absurd hadj h01
+          | exact absurd hadj (fun h => h01 (G.symm _ _ h))
+          | exact absurd hadj h23
+          | exact absurd hadj (fun h => h23 (G.symm _ _ h))
+          | decide
+
+/-- Lower bound: `2 ≤ fThreshold 1 4`, via membership and boundedness. -/
+theorem two_le_fThreshold_one_four : 2 ≤ fThreshold 1 4 := by
+  rw [fThreshold_eq_sSup]
+  exact le_csSup (fThresholdSet_bddAbove (by omega) (by omega))
+    two_mem_fThresholdSet_one_four
+
+/-- **The second exact threshold value: `fThreshold 1 4 = 2`.** Combined with
+`fThreshold 1 3 = 2`: the threshold does *not* grow from `n = 3` to `n = 4`
+(at `r = 1`), refuting any `n - 1`-style growth at the next data point beyond
+the parent's removed `f_trivial_lower` axiom. -/
+theorem fThreshold_one_four : fThreshold 1 4 = 2 :=
+  le_antisymm fThreshold_one_four_le_two two_le_fThreshold_one_four
+
+/-- The threshold is constant across the first two non-degenerate points:
+`fThreshold 1 3 = fThreshold 1 4 = 2`. -/
+theorem fThreshold_constant_three_four : fThreshold 1 3 = fThreshold 1 4 := by
+  rw [fThreshold_one_three, fThreshold_one_four]
+
 #check @completeGraph_not_hasColoring
 #check @canReduce_removeAll
 #check @fThresholdSet_downClosed
@@ -505,5 +741,10 @@ theorem trivial_lower_bound_false : fThreshold 1 4 < 4 - 1 := by
 #check @three_notMem_fThresholdSet_one_four
 #check @fThreshold_one_four_le_two
 #check @trivial_lower_bound_false
+#check @slot_nonempty
+#check @three_slots_le_card
+#check @two_mem_fThresholdSet_one_four
+#check @fThreshold_one_four
+#check @fThreshold_constant_three_four
 
 end Erdos1092OQ02

--- a/research/problems/erdos-1092-oq-02/state.md
+++ b/research/problems/erdos-1092-oq-02/state.md
@@ -31,3 +31,23 @@ parent's removed `f_trivial_lower` axiom refuted in Lean (`fThreshold 1 4 < 3`
 via K₃ + isolated vertex). File 249 → 509 lines, 13 → 21 theorems, 0 axioms /
 0 sorries. Next natural rung: `2 ∈ fThresholdSet 1 4` (exact value at (1,4));
 parent OQ (Rödl for r ≥ 3) remains research-level.
+
+## Status (researcher-3, 2026-07-24, second session) — ACT: second exact value
+
+`fThreshold 1 4 = 2` machine-checked (second exact value; file 509 → 750 lines,
+21 → 26 theorems, 0 axioms / 0 sorries, docker `[8577/8577]`, headline
+`[propext, Classical.choice, Quot.sound]`). Mechanism: the THREE PERFECT
+PAIRINGS of Fin 4 ({01|23}, {02|13}, {03|12}) — an edge kills exactly the one
+pairing putting its endpoints together; three killed pairings = three distinct
+edges > budget 2 (generic `three_slots_le_card` + `slot_nonempty` helpers,
+factored out of the (1,3) K₃ counting); a surviving pairing IS a 2-coloring
+(3 colorings × case tree, 8 contradiction leaves + 7 survival leaves).
+Constancy corollary: `fThreshold 1 3 = fThreshold 1 4` — the threshold does
+not grow at the next data point (further evidence against n-1-style growth).
+
+Next rungs: (1,5) — five pairings... no: Fin 5 has no perfect pairings (odd);
+use near-pairings (2+2+1) — a surviving near-pairing 2-colors iff isolated
+vertex color free; count: C(5,2)·3 = 15 near-pairings hmm; more edges available
+(budget k vs 10 slots). Likely fThreshold 1 5 = 2 or 3 — compute small models
+first before formalizing. Alternatively (2,4): r=2, K₄-obstruction, budget vs
+6 edges, 3-colorings. Parent OQ (Rödl r ≥ 3) remains research-level.

--- a/src/data/research/problems/erdos-1092-oq-02.json
+++ b/src/data/research/problems/erdos-1092-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-3 2026-07-24): FIRST EXACT VALUE — fThreshold 1 3 = 2, machine-checked (upper: K3 with 3-pair budget; lower: disjoint pair-slot counting shows budget 2 excludes K3, explicit 2-colorings for the rest). Also formalized the parent's prose-only refutation of its removed f_trivial_lower axiom: fThreshold 1 4 <= 2 < 3 = n-1 via K3+isolated vertex. File 249->509 lines, 13->21 theorems, still 0 axioms/sorries. Parent-level OQ (Rodl for r>=3) untouched — research-level.",
+    "progressSummary": "PROGRESS: well-definedness complete; TWO exact values fThreshold 1 3 = fThreshold 1 4 = 2 (constancy machine-checked); f_trivial_lower refuted in Lean; reusable disjoint pair-slot counting helpers. Next: (1,5) via near-pairings or (2,4); parent Rodl OQ research-level.",
     "builtItems": [
       "fThresholdSet_zero_mem (Erdos1092OQ02.lean): 0 ∈ fThresholdSet r n unconditionally — defining set always nonempty",
       "fThresholdSet_nonempty (Erdos1092OQ02.lean): (fThresholdSet r n).Nonempty",
@@ -38,7 +38,8 @@
       "killAll3/killAll4 + three_notMem_fThresholdSet_one_three/one_four in Erdos1092OQ02.lean",
       "two_mem_fThresholdSet_one_three (budget 2 forces 2-colorability on 3 vertices; disjoint-slot counting + 3 explicit colorings)",
       "fThreshold_one_three : fThreshold 1 3 = 2 (first exact value)",
-      "trianglePlusIsolated + fThreshold_one_four_le_two + trivial_lower_bound_false (parent prose refutation machine-checked)"
+      "trianglePlusIsolated + fThreshold_one_four_le_two + trivial_lower_bound_false (parent prose refutation machine-checked)",
+      "Erdos1092OQ02.lean 509->750 lines: slot_nonempty, three_slots_le_card (generic), two_mem_fThresholdSet_one_four (three-pairings case tree), two_le_fThreshold_one_four, fThreshold_one_four = 2, fThreshold_constant_three_four; 0 axioms 0 sorries docker-verified"
     ],
     "insights": [
       "fThreshold has TWO degeneracies: upper r+1≥n (set=ℕ, all graphs (r+1)-colorable) and lower r=0 (set=ℕ, no 0-coloring on n≥1 vertices). Non-degenerate regime is 1≤r ∧ r+2≤n.",
@@ -48,7 +49,10 @@
       "fThreshold 1 3 = 2 EXACTLY: (r,n)=(1,3) is the smallest non-degenerate point (1<=r, r+2<=n), and the threshold there is 2 — first exact value ever computed for this problem family",
       "Lower-bound mechanism: each removed ordered pair kills at most one undirected edge; formalized by intersecting removed with the three DISJOINT pair-slots {(u,v),(v,u)} of K3 — three nonempty disjoint intersections force card >= 3, beating budget 2 uniformly (no 8-way rcases)",
       "Upper-bound mechanism at (1,4): trianglePlusIsolated (K3 + isolated vertex) satisfies the budget-3 hypothesis but pigeonholes three colors into Fin 2 — the parent's removed f_trivial_lower axiom (n-1 <= fThreshold r n) is now REFUTED in Lean, not just prose",
-      "decide + open scoped Classical gotcha: decide fails on implications (forall_prop_decidable picks Classical.propDecidable) but still works on concrete Finset memberships; structure fin_cases branches as first | exact huv rfl | exact hnuv (by decide) | ..."
+      "decide + open scoped Classical gotcha: decide fails on implications (forall_prop_decidable picks Classical.propDecidable) but still works on concrete Finset memberships; structure fin_cases branches as first | exact huv rfl | exact hnuv (by decide) | ...",
+      "Second exact value: fThreshold 1 4 = 2 — and the threshold is CONSTANT from n=3 to n=4 (fThreshold_constant_three_four), further refuting n-1-style growth beyond the removed f_trivial_lower axiom.",
+      "Perfect-pairing recipe (even n): a perfect pairing of vertices 2-colors G unless an intra-pair edge is present; each edge kills exactly ONE pairing; killing all pairings costs as many distinct edges as pairings. For Fin 4: 3 pairings vs budget 2 => some pairing survives. Generic helpers slot_nonempty + three_slots_le_card (disjoint pair-slot counting) now factored for reuse.",
+      "For odd n (next rung (1,5)): no perfect pairings — need near-pairings (2+2+1) or a different obstruction; compute small models before formalizing. (2,4) is the other natural rung (r=2, K4 obstruction)."
     ],
     "mathlibGaps": [],
     "nextSteps": [],


### PR DESCRIPTION
## Summary
Research session for **erdos-1092-oq-02** (fThreshold well-definedness node, RICH tier) — second session today, executing the recorded next rung.

## Progress
- **Second exact threshold value: `fThreshold 1 4 = 2`** (`Erdos1092OQ02.lean` 509 → 750 lines, 21 → 26 theorems, 0 axioms / 0 sorries).
- New lower-bound membership `two_mem_fThresholdSet_one_four`: budget 2 forces every 4-vertex graph to be 2-colorable, via the **three perfect pairings** of `Fin 4` (`{01|23}, {02|13}, {03|12}`): an edge kills exactly the one pairing that puts its endpoints together, so killing all three pairings costs three distinct edges — exceeding budget 2 by disjoint pair-slot counting — while a surviving pairing *is* an explicit 2-coloring.
- The (1,3) K₃ counting is factored into **generic reusable helpers** `slot_nonempty` and `three_slots_le_card` (any `n`).
- Constancy corollary `fThreshold_constant_three_four`: the threshold does **not** grow from `n = 3` to `n = 4` — a second machine-checked data point against `n − 1`-style growth (the parent's removed `f_trivial_lower` axiom).

## Verification
- Docker build `[8577/8577]` succeeded.
- `#print axioms` on `fThreshold_one_four` and `two_mem_fThresholdSet_one_four`: `[propext, Classical.choice, Quot.sound]` — axiom-free relative to Mathlib.

## Status
**Outcome**: progress
**Next Steps**: (1,5) needs a different obstruction (no perfect pairings on odd vertex counts — near-pairings 2+2+1; compute small models first) or (2,4) (`r = 2`, `K₄` obstruction). Parent OQ (Rödl, r ≥ 3) remains research-level.

🤖 Generated by researcher-3
