### PR TITLE
Enrich binomial-theorem-oq003: split cardinality/bijection section for full sections coverage

### DIFF
--- a/src/data/proofs/binomial-theorem-oq003/meta.json
+++ b/src/data/proofs/binomial-theorem-oq003/meta.json
@@ -104,11 +104,18 @@
       "summary": "piAntidiag_one_eq_image: a degree-one tuple over s, with natural-number entries summing to 1, has exactly one entry equal to 1 and is therefore an indicator; conversely every indicator qualifies. The forward direction squeezes the unique nonzero entry to 1 and zeroes the rest via a two-element partial-sum bound."
     },
     {
-      "id": "cardinality-and-bijection",
-      "title": "Cardinality and the Explicit Bijection",
+      "id": "cardinality",
+      "title": "Injectivity and Cardinality",
       "startLine": 97,
+      "endLine": 109,
+      "summary": "single_one_injective shows i ↦ Pi.single i 1 is injective by evaluating at a distinguishing coordinate; card_piAntidiag_one then gives |s.piAntidiag 1| = |s| via Finset.card_image_of_injective applied to piAntidiag_one_eq_image."
+    },
+    {
+      "id": "bijection",
+      "title": "The Explicit Bijection",
+      "startLine": 111,
       "endLine": 123,
-      "summary": "single_one_injective (evaluate at a distinguishing coordinate) and card_piAntidiag_one give |s.piAntidiag 1| = |s| via Finset.card_image_of_injective; piAntidiagOneEquiv packages i ↦ Pi.single i 1 as an Equiv ↥s ≃ ↥(s.piAntidiag 1) through Equiv.ofBijective."
+      "summary": "piAntidiagOneEquiv packages i ↦ Pi.single i 1 as an Equiv ↥s ≃ ↥(s.piAntidiag 1) via Equiv.ofBijective, with injectivity from single_one_injective and surjectivity reusing the image characterisation piAntidiag_one_eq_image."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary
- `sections` had 4 entries; the "cardinality-and-bijection" section (lines 97-123) bundled three distinct declarations — `single_one_injective`, `card_piAntidiag_one`, and `piAntidiagOneEquiv` — which the section's own summary already described as two separate pieces.
- Split into `cardinality` (97-109: injectivity + cardinality) and `bijection` (111-123: the explicit `Equiv`), giving 5 sections matching the file's real structural boundaries. Line ranges verified against `Proofs/BinomialTheoremOQ02OQ01OQ01OQ02OQ01.lean`.