### PR TITLE
research(gauss-wilson-non-cyclic-oq-03): S6+S7 — CRT multiplicativity + induction close the main theorem (COMPLETE, 0 sorries)

### DIFF
--- a/proofs/Proofs/GaussWilsonNonCyclicOQ03.lean
+++ b/proofs/Proofs/GaussWilsonNonCyclicOQ03.lean
@@ -40,16 +40,21 @@ The formula has been verified numerically for `n = 1..120` (see
   sessions can work entirely inside `(ZMod n)ˣ` where the cyclic-group
   structure (`ZMod.isCyclic_units_of_prime_pow` etc.) applies.
 
-## Subsequent sessions
+## Session history
 
-* **S4**: prime-power count `card_sqrts_one_unit_prime_pow_odd`
-  via `IsCyclic.card_orderOf_eq_totient` (~70 lines).
-* **S5**: CRT multiplicativity (~50 lines).
-* **S6**: assembly by induction on `n.primeFactors.card` (~40 lines).
+* **S4/S4-prep**: order-2 decomposition + generic cyclic-even count = 2.
+* **S5**: odd-prime-power unit count = 2.
+* **S5b.1/2/3**: power-of-2 unit counts (1, 2, 4 for k = 1, 2, ≥ 3).
+* **S6**: CRT multiplicativity of the count across coprime moduli
+  (Section 10), via `ZMod.chineseRemainder` + `MulEquiv.prodUnits`,
+  following the `Nat.totient_mul` template.
+* **S7**: closed-form bookkeeping (Section 11) and the final induction via
+  `Nat.recOnPosPrimePosCoprime` (Section 12), closing the main theorem
+  `card_sqrts_one_eq_numSqrtsOne`.
 
 ## Status
 
-1 sorry (`card_sqrts_one_eq_numSqrtsOne`), 0 axioms.
+**0 sorries, 0 axioms — main theorem fully proved (S6+S7).**
 -/
 
 namespace GaussWilsonNonCyclicOQ03
@@ -109,26 +114,23 @@ example : numSqrtsOne 60 = 8 := by native_decide      -- 2² · 15: ω_odd=2, ε
 example : numSqrtsOne 120 = 16 := by native_decide    -- 2³ · 15: ω_odd=2, ε₂=2
 
 -- ============================================================================
--- Section 3: Main theorem (target of S3..S5)
+-- Section 3: Main theorem (statement moved to Section 12)
 -- ============================================================================
 
-/-- **Main theorem (OQ-03, statement only in S2).**
+/- **Main theorem (OQ-03).**
 
 The number of solutions of `x² = 1` in `ZMod n` equals the closed-form count
 `numSqrtsOne n = 2 ^ (ω_odd(n) + ε₂(n))`.
 
 This is the quantitative upgrade of the parent's qualitative `≥ 3` bound
-(`GaussWilsonNonCyclic.card_sq_eq_one_ge_three`).  The proof strategy
-(deferred to S3..S5) factors through:
+(`GaussWilsonNonCyclic.card_sq_eq_one_ge_three`).
 
-* CRT to reduce to prime-power moduli (S4);
-* Cyclicity of `(ZMod p^a)ˣ` for odd `p` (and the explicit `ℤ/2 × ℤ/2^{a-2}`
-  structure of `(ZMod 2^a)ˣ` for `a ≥ 3`) to count at prime-power level (S3);
-* Induction on `n.primeFactors.card` to assemble (S5).
--/
-theorem card_sqrts_one_eq_numSqrtsOne (n : ℕ) [NeZero n] :
-    (Finset.univ.filter (fun x : ZMod n => x ^ 2 = 1)).card = numSqrtsOne n := by
-  sorry
+From S2 through S5b.3 the theorem `card_sqrts_one_eq_numSqrtsOne` was *stated*
+here with `sorry` while the supporting sections below were built up.  S6/S7
+closed the proof; since Lean requires dependencies to precede their use, the
+theorem now lives at the **end of the file** (Section 12), where it is proved
+from the S3 bridge (Section 4) and the unit-side assembly
+`card_filter_sq_eq_one_units_eq_numSqrtsOne` (Section 12). -/
 
 -- ============================================================================
 -- Section 4: Ring ↔ unit bridge (S3)
@@ -580,5 +582,272 @@ theorem card_filter_sq_eq_one_units_zmod_two_pow_ge_three
   rw [hfilter, Finset.card_image_of_injOn hInj, hS,
     Finset.card_insert_of_notMem hd1, Finset.card_insert_of_notMem hd2,
     Finset.card_insert_of_notMem hd3, Finset.card_singleton]
+
+-- ============================================================================
+-- Section 10: CRT multiplicativity (S6)
+-- ============================================================================
+
+/-! ### S6 — the square-root count is multiplicative across coprime moduli
+
+Following the `Nat.totient_mul` template
+(`Mathlib/Data/Nat/Totient.lean`), the unit group of `ZMod (m * n)` for
+coprime `m, n` decomposes as
+
+```
+  (ZMod (m * n))ˣ  ≃*  (ZMod m × ZMod n)ˣ  ≃*  (ZMod m)ˣ × (ZMod n)ˣ
+```
+
+via `ZMod.chineseRemainder` (lifted to units by `Units.mapEquiv`) and
+`MulEquiv.prodUnits`.  Since a `MulEquiv` preserves the predicate
+`u² = 1`, and 2-torsion of a direct product splits componentwise
+(`(g, h)² = 1 ↔ g² = 1 ∧ h² = 1`), the solution count is multiplicative.
+
+Two generic helper lemmas package the transport and the product split;
+`card_filter_sq_eq_one_units_mul_coprime` specialises to `ZMod`. -/
+
+/-- **Transport of the square-root-of-unity count across a `MulEquiv`.**
+
+A multiplicative equivalence `e : G ≃* H` maps `{g | g² = 1}` bijectively
+onto `{h | h² = 1}` (its image under the injective map `e` is exactly the
+target filter), so the two counts agree. -/
+theorem card_filter_sq_eq_one_of_mulEquiv {G H : Type*} [Group G] [Group H]
+    [Fintype G] [Fintype H] [DecidableEq G] [DecidableEq H] (e : G ≃* H) :
+    (Finset.univ.filter (fun g : G => g ^ 2 = 1)).card =
+      (Finset.univ.filter (fun h : H => h ^ 2 = 1)).card := by
+  have himg : (Finset.univ.filter (fun g : G => g ^ 2 = 1)).image e =
+      Finset.univ.filter (fun h : H => h ^ 2 = 1) := by
+    ext h
+    simp only [Finset.mem_image, Finset.mem_filter, Finset.mem_univ, true_and]
+    constructor
+    · rintro ⟨g, hg, rfl⟩
+      rw [← map_pow, hg, map_one]
+    · intro hh
+      exact ⟨e.symm h, by rw [← map_pow, hh, map_one], e.apply_symm_apply h⟩
+  rw [← himg, Finset.card_image_of_injective _ e.injective]
+
+/-- **2-torsion of a direct product splits componentwise.**
+
+`(g, h)² = 1` iff `g² = 1` and `h² = 1`, so the solution filter of the
+product group is the `Finset` product of the component filters and the
+count factors. -/
+theorem card_filter_sq_eq_one_prod {G H : Type*} [Group G] [Group H]
+    [Fintype G] [Fintype H] [DecidableEq G] [DecidableEq H] :
+    (Finset.univ.filter (fun w : G × H => w ^ 2 = 1)).card =
+      (Finset.univ.filter (fun g : G => g ^ 2 = 1)).card *
+        (Finset.univ.filter (fun h : H => h ^ 2 = 1)).card := by
+  rw [← Finset.card_product]
+  congr 1
+  ext ⟨g, h⟩
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_product,
+    Prod.pow_mk, Prod.mk_eq_one]
+
+/-- **S6 ACT — CRT multiplicativity of the 2-torsion count.**
+
+For coprime moduli `m, n`, the number of square roots of unity in
+`(ZMod (m * n))ˣ` is the product of the counts for `(ZMod m)ˣ` and
+`(ZMod n)ˣ`.  The proof composes the CRT ring isomorphism
+`ZMod.chineseRemainder h : ZMod (m * n) ≃+* ZMod m × ZMod n` (lifted to
+unit groups via `Units.mapEquiv`) with `MulEquiv.prodUnits`, then applies
+the two generic lemmas above — exactly the rewrite chain of Mathlib's
+`Nat.totient_mul`. -/
+theorem card_filter_sq_eq_one_units_mul_coprime {m n : ℕ} [NeZero m] [NeZero n]
+    (h : m.Coprime n) :
+    (Finset.univ.filter (fun u : (ZMod (m * n))ˣ => u ^ 2 = 1)).card =
+      (Finset.univ.filter (fun u : (ZMod m)ˣ => u ^ 2 = 1)).card *
+        (Finset.univ.filter (fun u : (ZMod n)ˣ => u ^ 2 = 1)).card := by
+  haveI : NeZero (m * n) := ⟨Nat.mul_ne_zero (NeZero.ne m) (NeZero.ne n)⟩
+  rw [card_filter_sq_eq_one_of_mulEquiv
+      ((Units.mapEquiv (ZMod.chineseRemainder h).toMulEquiv).trans
+        MulEquiv.prodUnits)]
+  exact card_filter_sq_eq_one_prod
+
+-- ============================================================================
+-- Section 11: Closed-form bookkeeping (S7 helpers)
+-- ============================================================================
+
+/-! ### S7 bookkeeping — `numSqrtsOne` matches the per-prime-power counts
+
+The induction in Section 12 needs the closed form `numSqrtsOne` to mirror
+the behaviour of the actual count: multiplicative across coprime factors
+(matching S6) and evaluating to `2` at odd prime powers, `1 / 2 / 4` at
+`2^1 / 2^2 / 2^(k≥3)` (matching S5/S5b).  Both `omegaOdd` and `epsTwo`
+are additive across coprime products — `omegaOdd` because prime-factor
+sets of coprime numbers are disjoint, `epsTwo` because at most one
+coprime factor is even, so the two-adic data lives entirely in that
+factor. -/
+
+/-- `epsTwo` vanishes on odd numbers (no two-adic correction). -/
+theorem epsTwo_of_odd {n : ℕ} (hn : Odd n) : epsTwo n = 0 := by
+  have h2 : n % 2 = 1 := Nat.odd_iff.mp hn
+  unfold epsTwo
+  split_ifs with h8 h4 <;> omega
+
+/-- Multiplying by an odd factor does not change `epsTwo`: an odd `n` is
+coprime to every power of `2`, so `2^j ∣ m * n ↔ 2^j ∣ m`. -/
+theorem epsTwo_mul_of_odd_right {m n : ℕ} (hn : Odd n) :
+    epsTwo (m * n) = epsTwo m := by
+  have h2 : n % 2 = 1 := Nat.odd_iff.mp hn
+  have hnd : ¬ (2 : ℕ) ∣ n := by omega
+  have hco : ∀ j : ℕ, 2 ^ j ∣ m * n ↔ 2 ^ j ∣ m := fun j =>
+    ⟨fun hd => (Nat.Coprime.pow_left j
+        ((Nat.prime_two.coprime_iff_not_dvd).mpr hnd)).dvd_of_dvd_mul_right hd,
+      fun hd => Dvd.dvd.mul_right hd n⟩
+  have hd8 := hco 3
+  have hd4 := hco 2
+  norm_num at hd8 hd4
+  unfold epsTwo
+  split_ifs <;> omega
+
+/-- `epsTwo` is additive across coprime products: coprimality forces at
+least one factor to be odd, and an odd factor contributes `0`. -/
+theorem epsTwo_mul_of_coprime {m n : ℕ} (h : m.Coprime n) :
+    epsTwo (m * n) = epsTwo m + epsTwo n := by
+  rcases Nat.even_or_odd n with hn | hn
+  · rcases Nat.even_or_odd m with hm | hm
+    · -- both even contradicts coprimality
+      exfalso
+      have hg : (2 : ℕ) ∣ Nat.gcd m n := Nat.dvd_gcd hm.two_dvd hn.two_dvd
+      have h1 : Nat.gcd m n = 1 := h
+      omega
+    · rw [mul_comm, epsTwo_mul_of_odd_right hm, epsTwo_of_odd hm]
+      omega
+  · rw [epsTwo_mul_of_odd_right hn, epsTwo_of_odd hn]
+    omega
+
+/-- `omegaOdd` is additive across coprime products: the prime-factor sets
+are disjoint (`Nat.Coprime.disjoint_primeFactors`), so the odd-prime
+filters partition the union. -/
+theorem omegaOdd_mul_of_coprime {m n : ℕ} (h : m.Coprime n) :
+    omegaOdd (m * n) = omegaOdd m + omegaOdd n := by
+  unfold omegaOdd
+  rw [Nat.Coprime.primeFactors_mul h, Finset.filter_union,
+    Finset.card_union_of_disjoint
+      (Finset.disjoint_filter_filter (Nat.Coprime.disjoint_primeFactors h))]
+
+/-- `numSqrtsOne` is multiplicative across coprime products — the
+closed-form mirror of the S6 CRT multiplicativity. -/
+theorem numSqrtsOne_mul_of_coprime {m n : ℕ} (h : m.Coprime n) :
+    numSqrtsOne (m * n) = numSqrtsOne m * numSqrtsOne n := by
+  unfold numSqrtsOne
+  rw [omegaOdd_mul_of_coprime h, epsTwo_mul_of_coprime h, ← pow_add]
+  congr 1
+  omega
+
+/-- The closed form evaluates to `2` at odd prime powers, matching the S5
+unit-side count: one odd prime factor, no two-adic correction. -/
+theorem numSqrtsOne_prime_pow_odd {p k : ℕ} (hp : p.Prime) (hp2 : p ≠ 2)
+    (hk : 0 < k) :
+    numSqrtsOne (p ^ k) = 2 := by
+  unfold numSqrtsOne omegaOdd
+  rw [Nat.primeFactors_prime_pow (by omega : k ≠ 0) hp,
+    epsTwo_of_odd ((hp.odd_of_ne_two hp2).pow), Finset.filter_singleton]
+  simp [hp2]
+
+/-- Powers of `2` have no odd prime factors. -/
+theorem omegaOdd_two_pow {k : ℕ} (hk : k ≠ 0) : omegaOdd (2 ^ k) = 0 := by
+  unfold omegaOdd
+  rw [Nat.primeFactors_prime_pow hk Nat.prime_two, Finset.filter_singleton]
+  simp
+
+/-- The two-adic correction saturates at `2` once `8 ∣ 2^k`, i.e. `k ≥ 3`. -/
+theorem epsTwo_two_pow_ge_three {k : ℕ} (hk : 3 ≤ k) : epsTwo (2 ^ k) = 2 := by
+  have h8 : (8 : ℕ) ∣ 2 ^ k := by
+    calc (8 : ℕ) = 2 ^ 3 := by norm_num
+    _ ∣ 2 ^ k := pow_dvd_pow 2 hk
+  unfold epsTwo
+  have hm : (2 : ℕ) ^ k % 8 = 0 := by omega
+  simp [hm]
+
+/-- Closed form at modulus `2`: count `1`, matching S5b.1. -/
+theorem numSqrtsOne_two : numSqrtsOne 2 = 1 := by
+  have h := omegaOdd_two_pow (k := 1) one_ne_zero
+  norm_num at h
+  simp [numSqrtsOne, h, epsTwo]
+
+/-- Closed form at modulus `4`: count `2`, matching S5b.2. -/
+theorem numSqrtsOne_four : numSqrtsOne 4 = 2 := by
+  have h := omegaOdd_two_pow (k := 2) two_ne_zero
+  norm_num at h
+  simp [numSqrtsOne, h, epsTwo]
+
+-- ============================================================================
+-- Section 12: Induction assembly and the main theorem (S7)
+-- ============================================================================
+
+/-! ### S7 — assembling the closed form by `Nat.recOnPosPrimePosCoprime`
+
+The four induction cases are exactly the four ingredient groups built in
+S4–S6:
+
+* `zero` — vacuous under `NeZero`.
+* `one` — the trivial unit group `(ZMod 1)ˣ` has count `1 = numSqrtsOne 1`.
+* `prime_pow` — `p = 2` splits into `k = 1 / k = 2 / k ≥ 3`
+  (S5b.1/S5b.2/S5b.3, counts `1 / 2 / 4`); odd `p` is S5 (count `2`).
+* `coprime` — S6 multiplicativity plus the Section-11 closed-form
+  multiplicativity `numSqrtsOne_mul_of_coprime`. -/
+
+/-- **S7 — unit-side assembly.**  For every `n ≠ 0`, the number of square
+roots of unity in `(ZMod n)ˣ` equals the closed form
+`numSqrtsOne n = 2 ^ (ω_odd(n) + ε₂(n))`.  Proved by induction on the
+prime factorisation via `Nat.recOnPosPrimePosCoprime`. -/
+theorem card_filter_sq_eq_one_units_eq_numSqrtsOne :
+    ∀ (n : ℕ) [NeZero n],
+      (Finset.univ.filter (fun u : (ZMod n)ˣ => u ^ 2 = 1)).card =
+        numSqrtsOne n := by
+  intro n
+  induction n using Nat.recOnPosPrimePosCoprime with
+  | prime_pow p k hp hk =>
+    intro _
+    rcases eq_or_ne p 2 with rfl | hp2
+    · -- p = 2: the three S5b regimes
+      rcases (by omega : k = 1 ∨ k = 2 ∨ 3 ≤ k) with rfl | rfl | hk3
+      · show (Finset.univ.filter (fun u : (ZMod 2)ˣ => u ^ 2 = 1)).card =
+          numSqrtsOne 2
+        rw [card_filter_sq_eq_one_units_zmod_two, numSqrtsOne_two]
+      · show (Finset.univ.filter (fun u : (ZMod 4)ˣ => u ^ 2 = 1)).card =
+          numSqrtsOne 4
+        rw [card_filter_sq_eq_one_units_zmod_four, numSqrtsOne_four]
+      · rw [card_filter_sq_eq_one_units_zmod_two_pow_ge_three k hk3]
+        unfold numSqrtsOne
+        rw [omegaOdd_two_pow (by omega), epsTwo_two_pow_ge_three hk3]
+        norm_num
+    · -- p odd: S5
+      rw [card_filter_sq_eq_one_units_zmod_prime_pow_odd hp hp2 hk,
+        numSqrtsOne_prime_pow_odd hp hp2 hk]
+  | zero =>
+    intro h
+    exact absurd rfl h.out
+  | one =>
+    intro inst
+    have hall : ∀ u : (ZMod (1 : ℕ))ˣ, u ^ 2 = 1 := fun u =>
+      Units.ext (Subsingleton.elim _ _)
+    rw [Finset.filter_true_of_mem (fun u _ => hall u), Finset.card_univ,
+      ZMod.card_units_eq_totient, Nat.totient_one]
+    simp [numSqrtsOne, omegaOdd, epsTwo]
+  | coprime a b ha hb hab iha ihb =>
+    intro _
+    haveI ha0 : NeZero a := ⟨by omega⟩
+    haveI hb0 : NeZero b := ⟨by omega⟩
+    rw [card_filter_sq_eq_one_units_mul_coprime hab, iha, ihb,
+      numSqrtsOne_mul_of_coprime hab]
+
+/-- **Main theorem (OQ-03) — exact count of square roots of unity.**
+
+The number of solutions of `x² = 1` in `ZMod n` equals the closed-form
+count `numSqrtsOne n = 2 ^ (ω_odd(n) + ε₂(n))`, where `ω_odd(n)` is the
+number of distinct odd prime factors of `n` and `ε₂(n) ∈ {0, 1, 2}` is
+the two-adic correction.
+
+This is the quantitative upgrade of the parent's qualitative `≥ 3` bound
+(`GaussWilsonNonCyclic.card_sq_eq_one_ge_three`): CRT reduces the count
+to prime-power moduli (S6, Section 10), the per-prime-power counts are
+`2` at odd prime powers and `1 / 2 / 4` at `2^1 / 2^2 / 2^(k≥3)`
+(S5/S5b, Sections 7–9), and induction on the prime factorisation
+assembles the closed form (S7, this section).  The ring-side count
+reduces to the unit-side count through the S3 bridge (Section 4). -/
+theorem card_sqrts_one_eq_numSqrtsOne (n : ℕ) [NeZero n] :
+    (Finset.univ.filter (fun x : ZMod n => x ^ 2 = 1)).card = numSqrtsOne n := by
+  rw [card_sqrts_one_eq_card_units_sqrts_one n,
+    card_filter_sq_eq_one_units_eq_numSqrtsOne n]
 
 end GaussWilsonNonCyclicOQ03

--- a/proofs/Proofs/GaussWilsonNonCyclicOQ03.lean
+++ b/proofs/Proofs/GaussWilsonNonCyclicOQ03.lean
@@ -34,7 +34,8 @@ The formula has been verified numerically for `n = 1..120` (see
   `Nat.primeFactors` — note the contrast with `Nat.factorization`, which is
   `noncomputable` in Mathlib because of `multiplicity`).
 * Verifies the formula at a handful of small `n` via `decide`.
-* States the main theorem `card_sqrts_one_eq_numSqrtsOne` with `sorry`.
+* Originally stated the main theorem `card_sqrts_one_eq_numSqrtsOne` as an
+  open target (closed in S7 — see Section 12; no open targets remain).
 * **S3 NEW**: ring↔unit bridge `card_sqrts_one_eq_card_units_sqrts_one`
   reducing the ZMod-side count to a unit-group count, so that subsequent
   sessions can work entirely inside `(ZMod n)ˣ` where the cyclic-group

--- a/research/problems/gauss-wilson-non-cyclic-oq-03/sessions/2026-07-24-s6-s7-act-crt-multiplicativity-induction.md
+++ b/research/problems/gauss-wilson-non-cyclic-oq-03/sessions/2026-07-24-s6-s7-act-crt-multiplicativity-induction.md
@@ -1,0 +1,109 @@
+# S6+S7 ACT — CRT multiplicativity + induction assembly (main theorem closed)
+
+**Date**: 2026-07-24
+**Researcher**: researcher-2
+**Phase**: ACT (final)
+**Branch**: `research/gauss-wilson-oq03-s6-s7-crt-induction`
+**Build**: `./proofs/scripts/docker-build.sh Proofs.GaussWilsonNonCyclicOQ03`
+— exit 0, 2973 jobs, file built in 2.4 s. **0 sorries, 0 axioms.**
+
+## What closed
+
+The file's sole remaining `sorry` — the main theorem
+
+```lean
+theorem card_sqrts_one_eq_numSqrtsOne (n : ℕ) [NeZero n] :
+    (Finset.univ.filter (fun x : ZMod n => x ^ 2 = 1)).card = numSqrtsOne n
+```
+
+is now fully proved. This completes OQ-03: the exact count
+`#{x ∈ ZMod n : x² = 1} = 2^(ω_odd(n) + ε₂(n))` for every `n ≥ 1`,
+the quantitative upgrade of the parent's `card_sq_eq_one_ge_three`.
+
+This session had been **BLOCKED since 2026-06-13** (Docker verification
+blackout, flagged in PR #23106). Docker is back; the block dissolved.
+
+## S6 (Section 10) — CRT multiplicativity
+
+Exactly as designed in the S6 PREP (#18423) with the corrections from the
+2026-05-13 API audit:
+
+* `card_filter_sq_eq_one_of_mulEquiv` — generic transport of the count
+  across `e : G ≃* H`. Implemented via the **image argument** (mirroring
+  the file's own S3 bridge: image of the filter under the injective `e`
+  equals the target filter + `Finset.card_image_of_injective`), NOT the
+  PREP's `subtypeEquiv` route — the audit-flagged `Prod.pow_def` simp
+  chain made no progress under v4.31 in the `subtypeEquiv` form.
+* `card_filter_sq_eq_one_prod` — 2-torsion of `G × H` splits
+  componentwise; `Finset.card_product` + `Prod.pow_mk` + `Prod.mk_eq_one`
+  (both exist at v4.31 in `Mathlib/Algebra/Notation/Prod.lean`).
+* `card_filter_sq_eq_one_units_mul_coprime` — the `Nat.totient_mul`
+  rewrite chain: `Units.mapEquiv (ZMod.chineseRemainder h).toMulEquiv`
+  `|>.trans MulEquiv.prodUnits`, then the two generic lemmas.
+
+## S7 (Sections 11–12) — bookkeeping + induction
+
+Bookkeeping (all hypothesis-free where the S7 PREP expected positivity —
+`Nat.Coprime.primeFactors_mul` needs no nonzero hypotheses):
+
+* `epsTwo_of_odd`, `epsTwo_mul_of_odd_right` (key: odd `n` is coprime to
+  `2^j`, so `2^j ∣ m*n ↔ 2^j ∣ m`; `split_ifs <;> omega` discharges —
+  omega consumes the dvd-iff hypotheses directly), `epsTwo_mul_of_coprime`.
+* `omegaOdd_mul_of_coprime` via `Nat.Coprime.primeFactors_mul` +
+  `Finset.disjoint_filter_filter ∘ Nat.Coprime.disjoint_primeFactors`.
+* `numSqrtsOne_mul_of_coprime`, `numSqrtsOne_prime_pow_odd`,
+  `omegaOdd_two_pow`, `epsTwo_two_pow_ge_three`, `numSqrtsOne_two`,
+  `numSqrtsOne_four`.
+
+Induction `card_filter_sq_eq_one_units_eq_numSqrtsOne` via
+`Nat.recOnPosPrimePosCoprime` (case names `prime_pow/zero/one/coprime`;
+`Prime p` there **is** `Nat.Prime` — file is inside `namespace Nat`, so
+no `Nat.prime_iff` bridging needed, contrary to the S7 PREP's risk table):
+
+* `zero` — vacuous from the `NeZero` binder (`h.out`).
+* `one` — `(ZMod 1)ˣ` is subsingleton: `Units.ext (Subsingleton.elim _ _)`
+  makes the filter the whole group, `ZMod.card_units_eq_totient` +
+  `Nat.totient_one` gives 1. (**`decide` fails here** — see gotchas.)
+* `prime_pow`, `p = 2` — split `k = 1 ∨ k = 2 ∨ 3 ≤ k` by omega-rcases;
+  `k ≤ 2` cases via `show`-retyping to the *literal* moduli `ZMod 2` /
+  `ZMod 4` (definitionally equal to `ZMod (2^1)` / `ZMod (2^2)`), then the
+  existing S5b.1/S5b.2 `decide` theorems; `k ≥ 3` via S5b.3 +
+  `epsTwo_two_pow_ge_three`.
+* `prime_pow`, `p` odd — S5 + `numSqrtsOne_prime_pow_odd`.
+* `coprime` — S6 + `numSqrtsOne_mul_of_coprime`; `NeZero a/b` from
+  `1 < a/b` via `haveI ⟨by omega⟩`.
+
+Main theorem: S3 ring↔unit bridge + the unit-side assembly. The sorried
+statement was **removed from Section 3** (a forward-pointer comment
+remains) and the theorem now lives in Section 12, after its dependencies.
+Same name, same statement, same namespace — downstream references
+unaffected.
+
+## Gotchas recorded (v4.31)
+
+1. **`decide` rejects goals whose types mention local instances**: inside
+   the induction, `Fintype (ZMod (2^k))ˣ` is synthesized from the
+   *local* `[NeZero (2^k)]` binder, so `decide` fails with "Expected type
+   must not contain free variables" even after `k := 1` specialisation.
+   Fix: `show` with the literal modulus (`ZMod 2`), whose global `NeZero`
+   instance makes the proposition closed — definitional equality lets
+   `show` retype silently.
+2. The S6 PREP's `subtypeEquiv + simp [Prod.pow_def]` bridge does not
+   close under v4.31 (`simp made no progress` on the transported
+   predicate); the image-based argument is robust and matches the file's
+   existing S3 style.
+3. `omega` accepts divisibility-**iff** hypotheses (`8 ∣ m*n ↔ 8 ∣ m`)
+   with opaque products as atoms, letting `split_ifs <;> omega` close all
+   `epsTwo` case splits without manual mod-arithmetic.
+4. `Nat.Coprime` coerces definitionally to `Nat.gcd m n = 1`
+   (`have h1 : Nat.gcd m n = 1 := h`), avoiding any lemma-name lookup for
+   the gcd form.
+
+## Deliverable
+
+* `proofs/Proofs/GaussWilsonNonCyclicOQ03.lean`: 584 → 854 lines,
+  +13 theorems (Sections 10–12), 1 sorry **closed**, 0 axioms,
+  0 `native_decide` in named theorems (the 13 `example`s keep theirs;
+  benign).
+* Docker build verified (exit 0).
+* Problem **COMPLETED** — no open targets remain in this file.

--- a/research/problems/gauss-wilson-non-cyclic-oq-03/state.md
+++ b/research/problems/gauss-wilson-non-cyclic-oq-03/state.md
@@ -1,10 +1,51 @@
 # Current State
 
-**Phase**: ACT
-**Since**: 2026-06-12 (S5b.3)
-**Iteration**: 8
+**Phase**: COMPLETE
+**Since**: 2026-07-24 (S6+S7)
+**Iteration**: 9
 
 ## Current Focus
+
+**PROBLEM COMPLETED** — S6+S7 (researcher-2, 2026-07-24): ACT — closed
+the file's sole remaining sorry. `card_sqrts_one_eq_numSqrtsOne` is now
+fully proved: `#{x ∈ ZMod n : x² = 1} = 2^(ω_odd(n) + ε₂(n))` for every
+`n ≥ 1`, with **0 sorries, 0 axioms** (Docker build exit 0).
+
+The BLOCKED flag from #23106 (2026-06-13 Docker blackout) is dissolved —
+Docker is back and both S6 and S7 landed in one session:
+
+* **S6 (Section 10)**: `card_filter_sq_eq_one_units_mul_coprime` via the
+  `Nat.totient_mul` rewrite chain (`ZMod.chineseRemainder` lifted by
+  `Units.mapEquiv`, then `MulEquiv.prodUnits`), plus two generic helpers:
+  MulEquiv transport of the count (image argument, not the PREP's
+  `subtypeEquiv` route — that simp chain fails under v4.31) and the
+  componentwise 2-torsion split of a product group.
+* **S7 (Sections 11–12)**: additivity of `omegaOdd`/`epsTwo` (hence
+  multiplicativity of `numSqrtsOne`) across coprime products; closed-form
+  evaluations at prime powers; final induction via
+  `Nat.recOnPosPrimePosCoprime` (`Prime` there is `Nat.Prime` — no
+  bridging needed). The sorried Section-3 statement moved to Section 12
+  (same name/statement/namespace), after its dependencies.
+
+Key v4.31 gotchas (details in the 2026-07-24 session note): `decide`
+rejects goals whose Fintype instances mention the local `[NeZero (2^k)]`
+binder — `show`-retype to literal moduli `ZMod 2`/`ZMod 4` first; `omega`
+consumes dvd-iff hypotheses with opaque products as atoms.
+
+File: `proofs/Proofs/GaussWilsonNonCyclicOQ03.lean` 584 → 854 lines
+(+13 theorems, Sections 10–12). Build: **verified via Docker**
+(exit 0, 2973 jobs, 2.4 s file build). **0 axioms, 0 sorries.**
+
+## Next Action
+
+None — problem completed. Possible follow-ups for a future session
+(new OQ nodes, not this tracker): the structural form
+`Nat.card {u : (ZMod n)ˣ // u^2 = 1} = numSqrtsOne n`, or the
+real-Dirichlet-character corollary (count of real characters mod n).
+
+## Prior Sessions
+
+### S5b.3 (researcher-2, 2026-06-12, merged)
 
 S5b.3 (researcher-2, 2026-06-12): ACT — closed the **structural
 power-of-2 unit-side count** (`k ≥ 3`, count = **4**), the last of the

--- a/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
+++ b/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "gauss-wilson-non-cyclic-oq-03",
   "title": "Exact count of square roots of unity in (ZMod n)× via CRT generalization",
-  "phase": "ACT",
-  "status": "blocked",
+  "phase": "COMPLETE",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -20,17 +20,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT (BLOCKED — Docker down)",
-    "since": "2026-06-12T00:00:00.000Z",
-    "iteration": 8,
-    "focus": "S5b.3 (researcher-2, 2026-06-12, merged): ACT — closed the structural power-of-2 unit-side count for k ≥ 3 (count = 4), the last of the three per-prime-power even cases and the ε₂(n)=2 leg of the two-adic correction. New Section 9 with two theorems in proofs/Proofs/GaussWilsonNonCyclicOQ03.lean: two_pow_dvd_split (private ℕ helper) and card_filter_sq_eq_one_units_zmod_two_pow_ge_three (#{u : (ZMod 2^k)ˣ | u²=1} = 4 for k ≥ 3), proved via elementary divisibility rather than the PREP's orderOf_five route. With S5 (odd-prime power, count 2), S5b.1 (k=1, count 1) and S5b.2 (k=2, count 2), this closes ALL per-prime-power unit-side counts feeding S6 (CRT multiplicativity). File: 396 → 584 lines (+188, +2 theorems, +1 new Section 9). 0 axioms, 1 sorry (the main theorem card_sqrts_one_eq_numSqrtsOne, line 131). Source (584 lines, 11 col-0 theorems/lemmas, Sections 1–9) confirmed in sync with state.md via this session's AUDIT against origin/main.",
-    "blockers": [
-      "Docker daemon down on host (2026-06-13 verification blackout, `docker info` hangs/exit 124) → cannot run ./proofs/scripts/docker-build.sh to verify any new proof; direct `lake build` is forbidden (CLAUDE.md).",
-      "Both remaining steps are heavy build-dependent ACT: S6 (CRT multiplicativity, assembles S5+S5b.1+S5b.2+S5b.3 into a multiplicative formula over n.primeFactors) and S7 (induction assembly on n.primeFactors.card, closes the sole remaining sorry card_sqrts_one_eq_numSqrtsOne). Neither is verifiable without a build.",
-      "S6/S7 already have 4 accumulated PREP/audit sessions (2026-05-12 s06-prep-crt-multiplicativity, 2026-05-13 s06-s07-prep-mathlib-api-audit, 2026-05-13 s07-prep-main-theorem-induction, 2026-05-13 s07b-prep-bookkeeping-discharge) — the design is saturated; only the build-gated ACT remains, so further PREP would be churn.",
-      "No build-free win remains: per-prime-power counts all closed (S5/S5b.1/S5b.2/S5b.3), state.md ↔ source ↔ this JSON now in sync. Aristotle backend still 404s during the 2026-06-13 blackout."
-    ],
-    "nextAction": "S5b.3 ACT: substantive even-prime work — (ZMod 2^k)ˣ count for k ≥ 3 via the `orderOf_five` cardinality squeeze (~60-90 LOC). Complete design in S5b PREP #18648 §3.3; the proof adapts `Mathlib/NumberTheory/ArithmeticFunction/Carmichael.lean:135-148`'s established `orderOf_five` idiom. Then S6 ACT (CRT multiplicativity) combines S5 + S5b.1 + S5b.2 + S5b.3 into a multiplicative formula over n.primeFactors (design in S6 PREP #18423). Then S7 ACT (induction assembly) closes the main theorem `card_sqrts_one_eq_numSqrtsOne` (design in S7 PREP #18465).",
+    "phase": "COMPLETE",
+    "since": "2026-07-24T00:00:00.000Z",
+    "iteration": 9,
+    "focus": "S6+S7 (researcher-2, 2026-07-24): ACT — PROBLEM COMPLETED. Closed the file's sole remaining sorry: card_sqrts_one_eq_numSqrtsOne is fully proved (#{x ∈ ZMod n : x² = 1} = 2^(ω_odd(n) + ε₂(n)) for every n ≥ 1). S6 (Section 10): CRT multiplicativity card_filter_sq_eq_one_units_mul_coprime via the Nat.totient_mul rewrite chain (ZMod.chineseRemainder lifted by Units.mapEquiv, then MulEquiv.prodUnits) plus generic MulEquiv-transport and product-2-torsion-split helpers. S7 (Sections 11–12): omegaOdd/epsTwo additivity across coprime products, closed-form prime-power evaluations, and the final induction via Nat.recOnPosPrimePosCoprime. File: proofs/Proofs/GaussWilsonNonCyclicOQ03.lean 584 → 854 lines (+13 theorems). Docker build exit 0 (2973 jobs). 0 sorries, 0 axioms.",
+    "blockers": [],
+    "nextAction": "None — completed. Possible future OQ nodes: structural form Nat.card {u : (ZMod n)ˣ // u^2 = 1} = numSqrtsOne n, or the real-Dirichlet-character-count corollary.",
     "attemptCounts": {
       "total": 6,
       "currentApproach": 6,
@@ -38,7 +33,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S4 closes the generic order-of half: every cyclic group of even order has exactly 2 square roots of 1, dispatched by totient lookup. S5 will plug in the ZMod-side cyclicity + even-order witnesses to get the prime-power specialisation; S6 will multiplicatively assemble via CRT; S7 will close the remaining sorry by induction on n.primeFactors.card.",
+    "progressSummary": "COMPLETE: the exact-count formula #{x ∈ ZMod n : x² = 1} = 2^(ω_odd(n) + ε₂(n)) is fully machine-checked (0 sorries, 0 axioms). S3 ring↔unit bridge; S4 generic cyclic-even count = 2; S5 odd-prime-power count = 2; S5b.1/2/3 power-of-2 counts 1/2/4; S6 CRT multiplicativity; S7 induction assembly via Nat.recOnPosPrimePosCoprime.",
     "builtItems": [
       "research/problems/gauss-wilson-non-cyclic-oq-03/problem.md (new, ~280 lines): full problem statement, two formal-statement variants (counted-form on the ring and structural-form on the unit group), Mathlib infrastructure map, theoretical path through CRT + prime-power cyclicity + (ZMod 2^k)ˣ structure, decomposition into S2–S5 sessions.",
       "research/problems/gauss-wilson-non-cyclic-oq-03/state.md (new): phase NEW → OBSERVE; concrete S2 skeleton for proofs/Proofs/GaussWilsonNonCyclicOQ03.lean with 1 sorry placeholder.",


### PR DESCRIPTION
## Summary

Closes the **sole remaining sorry** of `proofs/Proofs/GaussWilsonNonCyclicOQ03.lean`: the main theorem

```lean
theorem card_sqrts_one_eq_numSqrtsOne (n : ℕ) [NeZero n] :
    (Finset.univ.filter (fun x : ZMod n => x ^ 2 = 1)).card = numSqrtsOne n
```

is now fully proved — the exact count `#{x ∈ ZMod n : x² = 1} = 2^(ω_odd(n) + ε₂(n))` for every `n ≥ 1`, the quantitative upgrade of the parent's `card_sq_eq_one_ge_three` (≥ 3 bound for non-cyclic unit groups). **Problem COMPLETED: 0 sorries, 0 axioms.**

This work had been flagged BLOCKED since 2026-06-13 (#23106, Docker verification blackout); Docker is back, and both remaining steps (S6, S7) landed in this session, following the merged S6 PREP (#18423), S7 PREP (#18465), and the 2026-05-13 Mathlib API audit.

## S6 — CRT multiplicativity (new Section 10)

* `card_filter_sq_eq_one_of_mulEquiv` — generic transport of the count across `e : G ≃* H` (image argument mirroring the file's S3 bridge; the PREP's `subtypeEquiv`+simp route fails under v4.31).
* `card_filter_sq_eq_one_prod` — componentwise 2-torsion split of `G × H` (`Prod.pow_mk`, `Prod.mk_eq_one`).
* `card_filter_sq_eq_one_units_mul_coprime` — the `Nat.totient_mul` rewrite chain: `Units.mapEquiv (ZMod.chineseRemainder h).toMulEquiv |>.trans MulEquiv.prodUnits`.

## S7 — bookkeeping + induction (new Sections 11–12)

* `epsTwo_of_odd`, `epsTwo_mul_of_odd_right`, `epsTwo_mul_of_coprime`, `omegaOdd_mul_of_coprime`, `numSqrtsOne_mul_of_coprime`, `numSqrtsOne_prime_pow_odd`, `omegaOdd_two_pow`, `epsTwo_two_pow_ge_three`, `numSqrtsOne_two`, `numSqrtsOne_four`.
* `card_filter_sq_eq_one_units_eq_numSqrtsOne` — induction via `Nat.recOnPosPrimePosCoprime`: zero vacuous under `NeZero`; one via subsingleton `(ZMod 1)ˣ` + `Nat.totient_one`; `p = 2` split into `k = 1/2/≥3` (S5b.1/2/3); odd `p` via S5; coprime via S6.
* Main theorem = S3 ring↔unit bridge + unit-side assembly. The sorried Section-3 statement moved to Section 12 (same name/statement/namespace), after its dependencies.

## Verification

* `./proofs/scripts/docker-build.sh Proofs.GaussWilsonNonCyclicOQ03` — **exit 0**, 2973 jobs, file built in 2.4 s.
* File: 584 → 854 lines, +13 theorems. `sorry` appears only in prose (session history comments). No `axiom` declarations. `native_decide` only in pre-existing `example`s (benign), none in named theorems.

## Docs

* `state.md` → COMPLETE (iteration 9), session note `2026-07-24-s6-s7-act-crt-multiplicativity-induction.md` (includes v4.31 gotchas: `decide` vs local-instance-dependent Fintype; omega consuming dvd-iff atoms).
* `src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json` → phase COMPLETE / status completed, blockers cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
