### PR TITLE
Fix: erdos-1021-oq-01 sorry-count undercount 3→4 in Part VI summary

### DIFF
--- a/proofs/Proofs/Erdos1021OQ01.lean
+++ b/proofs/Proofs/Erdos1021OQ01.lean
@@ -184,7 +184,8 @@ theorem lower_bound_exponent_tendsto :
     - 2 provable results (big_O ≠ little_o, lower bound exponent approaches 3/2)
     - 1 axiomatic result: KST trivial bound
     - 1 axiomatic result: probabilistic lower bound
-    - 3 sorry results: k3 weak conjecture proof, k3/k independence, and o() bound uniformity
+    - 4 sorry results: k3 weak conjecture proof, k3/k independence, o() bound uniformity,
+      and lower-bound exponent → 3/2 (the 1/(k-1) → 0 limit step)
 
     Status: SURVEY + INFRASTRUCTURE
 -/

--- a/src/data/proofs/erdos-1021-oq-01/meta.json
+++ b/src/data/proofs/erdos-1021-oq-01/meta.json
@@ -94,7 +94,7 @@
       "title": "Part VI: The OQ-01 in Context",
       "startLine": 170,
       "endLine": 193,
-      "summary": "Survey framing of OQ-01's status: k = 3 is SOLVED (ex(n, G_3) ≍ ex(n, C_6) ≪ n^{7/6} < n^{3/2}) while k ≥ 4 is OPEN (even the weak o(n^{3/2}) bound is unknown). Records the KST trivial upper bound ≪ n^{3/2} and the probabilistic lower bound ≥ c·n^{3/2 − 1/(k−1)}, and inventories the file itself: 2 provable results, 2 axiomatic results (KST bound, probabilistic lower bound), and 3 remaining `sorry` results — an honest 'SURVEY + INFRASTRUCTURE' status marker."
+      "summary": "Survey framing of OQ-01's status: k = 3 is SOLVED (ex(n, G_3) ≍ ex(n, C_6) ≪ n^{7/6} < n^{3/2}) while k ≥ 4 is OPEN (even the weak o(n^{3/2}) bound is unknown). Records the KST trivial upper bound ≪ n^{3/2} and the probabilistic lower bound ≥ c·n^{3/2 − 1/(k−1)}, and inventories the file itself: 2 provable results, 2 axiomatic results (KST bound, probabilistic lower bound), and 4 remaining `sorry` results — an honest 'SURVEY + INFRASTRUCTURE' status marker."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-1021-oq-01

**Problem**: The file's "Part VI: The OQ-01 in Context" docstring inventory
claimed "3 sorry results" and named only 3 of the 4 actual sorries. This
same undercounted sentence was mirrored verbatim into meta.json's `context`
section `summary` (public gallery text).

## Evidence

- `grep -n sorry proofs/Proofs/Erdos1021OQ01.lean` shows 4 real sorry
  declarations: `oq01_strictly_beyond_kst` (L114), `k3_strong_implies_weak`
  (L129), `ex_not_obviously_monotone_in_k` (L138), and
  `lower_bound_exponent_tendsto` (L167) — the last one was omitted from the
  Part VI inventory.
- The top-level `meta.json` fields (`sorries: 4`, `leanFile.sorries: 4`, and
  the `assumptions` text: "4 sorries in dependency chain: 4 in this file...")
  were already correct.
- `annotations.json` also correctly documents all 4 sorries individually.
- Only the aggregate prose sentence in the Lean docstring and the mirrored
  `sections[].summary` in meta.json undercounted to 3.

## Fix

- Updated the Lean file's Part VI docstring to say "4 sorry results" and
  list all four, including the `lower_bound_exponent_tendsto` limit step.
- Updated meta.json's `context` section summary to match (3 → 4).

No axiom/theorem/definition/line counts were affected — those were all
already correct (verified against `grep`/`wc -l`).

---
Discovered during gallery integrity audit (erdos-1021-oq-01, round-robin
re-serve; queue fully drained, 4813/4813 audited, 0 open issues).