### PR TITLE
Mark erdos-1021-oq-01 audit complete (issues-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8981,10 +8981,10 @@
       "result": "clean"
     },
     "erdos-1021-oq-01": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:34Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T09:05:50Z",
+      "result": "issues-fixed"
     },
     "erdos-1021-oq-01-incomplete-01": {
       "auditCount": 1,


### PR DESCRIPTION
Tracker update for the erdos-1021-oq-01 gallery integrity audit. Sorry-count undercount (3→4) in the Part VI survey summary fixed in #43229.