### PR TITLE
Research: bertrands-postulate-oq-02 - dead axiom removed + Cramér ⇒ Legendre composition (thread completed)

### DIFF
--- a/proofs/Proofs/CramerImpliesLegendre.lean
+++ b/proofs/Proofs/CramerImpliesLegendre.lean
@@ -1,0 +1,229 @@
+/-
+# Cramér's Conjecture Implies Legendre's Conjecture Up To Finitely Many Cases
+
+Legendre's conjecture (1798, open): for every `n ≥ 1` there is a prime in
+`(n², (n+1)²)`. Cramér's conjecture (1936, open): consecutive prime gaps
+satisfy `p_{k+1} - p_k = O((log p_k)²)`.
+
+This file formalizes the classical implication chain (S5-ACT-A/B/C of the
+`bertrands-postulate-oq-02` research thread):
+
+  Cramér's conjecture
+    ⟹ [ACT-A: analytic estimate `C·(log x)² ≤ √x − 1` eventually]
+  the sqrt prime-gap bound `p_{k+1} - p_k ≤ 2·√p_k + 1` for all primes `p_k ≥ M`
+    ⟹ [ACT-C: `legendreAt_of_sqrt_gap_above` from
+       `LegendrePrimeGapSqrtBoundSuffices.lean`]
+  `LegendreAt n` for all sufficiently large `n`.
+
+## Main results
+
+* `CramerConjecture` — the upper-bound form of Cramér's conjecture, as a
+  `Prop`: some `C > 0` bounds all sufficiently late prime gaps by
+  `C·(log p_k)²`. Stated, never assumed.
+* `eventually_mul_log_sq_le_sqrt_sub_one` — ACT-A: for every real `C`,
+  eventually `C·(log x)² ≤ √x − 1` (from Mathlib's `(log x)^r = o(x^s)`).
+* `cramerGapBound_to_sqrt_gap` — ACT-B: a Cramér gap bound yields a threshold
+  `M` beyond which the sqrt gap bound `p_{k+1} - p_k ≤ 2·Nat.sqrt p_k + 1`
+  holds.
+* `cramer_implies_legendre_eventually` — ACT-C: under `CramerConjecture`
+  there is an `N` with `LegendreAt n` for all `n ≥ N`.
+* `cramer_exceptions_finite` — equivalently, the exception set
+  `{n | 1 ≤ n ∧ ¬LegendreAt n}` is finite.
+* `cramer_reduces_legendre_to_finite` — the full conditional composition:
+  under Cramér, Legendre's conjecture reduces to finitely many explicit cases
+  (`∃ N`, checking `n < N` suffices).
+
+## Why "eventually", not Legendre outright
+
+Cramér's conjecture is an *asymptotic* statement (`∃ C, ∃ k₀, ∀ k ≥ k₀, …`).
+The constants `C, k₀` are existentially quantified, so no fixed finite
+verification (such as `LegendrePartial.lean`'s `n = 1..20`) can discharge the
+small-`n` tail *uniformly in the witness*: for each concrete `(C, k₀)` the
+tail is finite and checkable, but the statement `CramerConjecture` alone pins
+no bound on it. `cramer_reduces_legendre_to_finite` is the honest strongest
+form: Cramér reduces Legendre to a finite (existentially bounded) check.
+For the numerically expected constants the tail is tiny — for `C = 1` the
+analytic crossover is at `p ≈ 121`, covered by `LegendrePartial.lean`'s
+verified range (see the iter-6 audit memo in
+`research/problems/bertrands-postulate-oq-02/`).
+
+## Axioms
+
+This file introduces **0 new axioms** and **0 sorries**. `CramerConjecture`
+is a defined `Prop` appearing only as an explicit hypothesis.
+-/
+
+import Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics
+import Mathlib.Tactic
+import Proofs.LegendrePrimeGapSqrtBoundSuffices
+
+namespace CramerImpliesLegendre
+
+open Legendre LegendrePrimeGapSqrtBoundSuffices Filter
+
+/-! ## Cramér's conjecture as a hypothesis -/
+
+/-- Cramér-type prime-gap bound with constant `C` from index `k₀` on:
+`p_{k+1} - p_k ≤ C·(log p_k)²` for all `k ≥ k₀`
+(where `p_k := Nat.nth Nat.Prime k`). -/
+def CramerGapBound (C : ℝ) (k₀ : ℕ) : Prop :=
+  ∀ k, k₀ ≤ k →
+    ((Nat.nth Nat.Prime (k + 1) - Nat.nth Nat.Prime k : ℕ) : ℝ)
+      ≤ C * Real.log (Nat.nth Nat.Prime k) ^ 2
+
+/-- **Cramér's conjecture** (upper-bound form, 1936): some constant `C > 0`
+bounds all sufficiently late consecutive prime gaps by `C·(log p_k)²`.
+OPEN — stated as a `Prop`, never assumed. -/
+def CramerConjecture : Prop :=
+  ∃ C : ℝ, 0 < C ∧ ∃ k₀ : ℕ, CramerGapBound C k₀
+
+/-! ## S5-ACT-A: the analytic estimate -/
+
+/-- For any real constant `C`, eventually (as `x → ∞`)
+`C · (log x)² ≤ √x − 1`. The content is Mathlib's
+`Real.isLittleO_log_rpow_rpow_atTop`: `(log x)² = o(x^{1/2})`. -/
+theorem eventually_mul_log_sq_le_sqrt_sub_one (C : ℝ) :
+    ∀ᶠ x : ℝ in atTop, C * Real.log x ^ 2 ≤ Real.sqrt x - 1 := by
+  set D : ℝ := max C 1 with hD_def
+  have hD1 : (1 : ℝ) ≤ D := le_max_right _ _
+  have hCD : C ≤ D := le_max_left _ _
+  have hD0 : (0 : ℝ) < D := lt_of_lt_of_le one_pos hD1
+  -- `(log x)^2 = o(x^{1/2})` (rpow exponents)
+  have hlo : (fun x : ℝ => Real.log x ^ (2 : ℝ)) =o[atTop]
+      fun x : ℝ => x ^ ((1 : ℝ) / 2) :=
+    Real.isLittleO_log_rpow_rpow_atTop 2 (by norm_num)
+  have hbound := hlo.def (show (0 : ℝ) < 1 / (2 * D) by positivity)
+  filter_upwards [hbound, eventually_ge_atTop (1 : ℝ),
+    eventually_ge_atTop (4 : ℝ)] with x hx hx1 hx4
+  have hx0 : (0 : ℝ) ≤ x := by linarith
+  have hlog0 : 0 ≤ Real.log x := Real.log_nonneg hx1
+  -- rewrite the rpow forms as `(log x)^2` (monoid power) and `√x`
+  have hrw_log : Real.log x ^ (2 : ℝ) = Real.log x ^ 2 := by
+    rw [show (2 : ℝ) = ((2 : ℕ) : ℝ) by norm_num, Real.rpow_natCast]
+  have hrw_sqrt : x ^ ((1 : ℝ) / 2) = Real.sqrt x := (Real.rpow_natCast x 1 ▸
+    (Real.sqrt_eq_rpow x).symm : x ^ ((1 : ℝ) / 2) = Real.sqrt x)
+  rw [hrw_log, hrw_sqrt, Real.norm_of_nonneg (sq_nonneg _),
+    Real.norm_of_nonneg (Real.sqrt_nonneg x)] at hx
+  -- `√x ≥ 2` for `x ≥ 4`
+  have hsqrt2 : (2 : ℝ) ≤ Real.sqrt x := by
+    have : Real.sqrt 4 ≤ Real.sqrt x := Real.sqrt_le_sqrt hx4
+    rwa [show (4 : ℝ) = 2 ^ 2 by norm_num, Real.sqrt_sq (by norm_num : (0:ℝ) ≤ 2)]
+      at this
+  -- chain: C·log²x ≤ D·log²x ≤ √x/2 ≤ √x − 1
+  have h1 : C * Real.log x ^ 2 ≤ D * Real.log x ^ 2 := by
+    have := sq_nonneg (Real.log x)
+    nlinarith
+  have h2 : D * Real.log x ^ 2 ≤ Real.sqrt x / 2 := by
+    have := mul_le_mul_of_nonneg_left hx (le_of_lt hD0)
+    calc D * Real.log x ^ 2 ≤ D * (1 / (2 * D) * Real.sqrt x) := this
+      _ = Real.sqrt x / 2 := by field_simp
+  linarith
+
+/-- Nat-side threshold: for any `C` there is `M` such that every natural
+`p ≥ M` satisfies `C·(log p)² ≤ 2·Nat.sqrt p + 1` (in `ℝ`). Uses
+`√p < Nat.sqrt p + 1`. -/
+theorem exists_nat_sqrt_threshold (C : ℝ) :
+    ∃ M : ℕ, ∀ p : ℕ, M ≤ p →
+      C * Real.log p ^ 2 ≤ 2 * (Nat.sqrt p : ℝ) + 1 := by
+  obtain ⟨a, ha⟩ := eventually_atTop.mp (eventually_mul_log_sq_le_sqrt_sub_one C)
+  refine ⟨⌈a⌉₊, fun p hp => ?_⟩
+  have hpa : a ≤ (p : ℝ) := le_trans (Nat.le_ceil a) (by exact_mod_cast hp)
+  have h1 := ha (p : ℝ) hpa
+  -- `√p < Nat.sqrt p + 1` since `p < (Nat.sqrt p + 1)²`
+  have hs : Real.sqrt p < (Nat.sqrt p : ℝ) + 1 := by
+    rw [Real.sqrt_lt' (by positivity)]
+    have hnat : p < (Nat.sqrt p + 1) ^ 2 := by
+      have := Nat.lt_succ_sqrt' p
+      nlinarith
+    calc (p : ℝ) < (((Nat.sqrt p + 1) ^ 2 : ℕ) : ℝ) := by exact_mod_cast hnat
+      _ = ((Nat.sqrt p : ℝ) + 1) ^ 2 := by push_cast; ring
+  have hnn : (0 : ℝ) ≤ (Nat.sqrt p : ℝ) := Nat.cast_nonneg _
+  linarith
+
+/-! ## S5-ACT-B: Cramér gap bound ⇒ eventual sqrt gap bound -/
+
+/-- A Cramér-type gap bound yields a threshold `M` beyond which the
+(Nat-valued) sqrt prime-gap bound holds: for every `k` with `p_k ≥ M`,
+`p_{k+1} - p_k ≤ 2·Nat.sqrt p_k + 1`. -/
+theorem cramerGapBound_to_sqrt_gap {C : ℝ} {k₀ : ℕ} (h : CramerGapBound C k₀) :
+    ∃ M : ℕ, ∀ k, M ≤ Nat.nth Nat.Prime k →
+      Nat.nth Nat.Prime (k + 1) - Nat.nth Nat.Prime k
+        ≤ 2 * Nat.sqrt (Nat.nth Nat.Prime k) + 1 := by
+  obtain ⟨M₀, hM₀⟩ := exists_nat_sqrt_threshold C
+  refine ⟨max M₀ (Nat.nth Nat.Prime k₀), fun k hk => ?_⟩
+  -- `p_k ≥ p_{k₀}` forces `k ≥ k₀` (strict monotonicity of `Nat.nth`)
+  have hk₀ : k₀ ≤ k := by
+    by_contra hlt
+    push_neg at hlt
+    have hmono : Nat.nth Nat.Prime k < Nat.nth Nat.Prime k₀ :=
+      Nat.nth_strictMono Nat.infinite_setOf_prime hlt
+    have hmax := le_max_right M₀ (Nat.nth Nat.Prime k₀)
+    omega
+  have hgap := h k hk₀
+  have hthr := hM₀ (Nat.nth Nat.Prime k) (le_trans (le_max_left _ _) hk)
+  have hcast : ((Nat.nth Nat.Prime (k + 1) - Nat.nth Nat.Prime k : ℕ) : ℝ)
+      ≤ ((2 * Nat.sqrt (Nat.nth Nat.Prime k) + 1 : ℕ) : ℝ) := by
+    push_cast
+    linarith
+  exact_mod_cast hcast
+
+/-! ## S5-ACT-C: composition — Cramér ⇒ Legendre eventually -/
+
+/-- **Cramér's conjecture implies Legendre's conjecture for all sufficiently
+large `n`**: under `CramerConjecture` there is an `N` such that for every
+`n ≥ N` there is a prime in `(n², (n+1)²)`. Unconditional in the small-`n`
+regime — no hypothesis about small cases is needed. -/
+theorem cramer_implies_legendre_eventually (h : CramerConjecture) :
+    ∃ N : ℕ, ∀ n, N ≤ n → LegendreAt n := by
+  obtain ⟨C, _hC, k₀, hgap⟩ := h
+  obtain ⟨M, hM⟩ := cramerGapBound_to_sqrt_gap hgap
+  refine ⟨2 * M + 2, fun n hn => ?_⟩
+  have hn2 : 2 ≤ n := by omega
+  have hself : n ≤ n ^ 2 := by nlinarith
+  exact legendreAt_of_sqrt_gap_above M hM hn2 (by omega)
+
+/-- Under Cramér's conjecture, the set of exceptions to Legendre's conjecture
+is finite. -/
+theorem cramer_exceptions_finite (h : CramerConjecture) :
+    {n : ℕ | 1 ≤ n ∧ ¬ LegendreAt n}.Finite := by
+  obtain ⟨N, hN⟩ := cramer_implies_legendre_eventually h
+  refine Set.Finite.subset (Set.finite_Iio N) ?_
+  rintro n ⟨-, hnot⟩
+  rw [Set.mem_Iio]
+  by_contra hge
+  push_neg at hge
+  exact hnot (hN n hge)
+
+/-- **Full conditional composition**: under Cramér's conjecture, Legendre's
+conjecture reduces to finitely many explicit cases — there is a single `N`
+such that verifying `LegendreAt n` for the finitely many `1 ≤ n < N` yields
+the full conjecture. -/
+theorem cramer_reduces_legendre_to_finite (h : CramerConjecture) :
+    ∃ N : ℕ, (∀ n, 1 ≤ n → n < N → LegendreAt n) → LegendreConjecture := by
+  obtain ⟨N, hN⟩ := cramer_implies_legendre_eventually h
+  exact ⟨N, fun hsmall n hn =>
+    (lt_or_ge n N).elim (hsmall n hn) (fun hge => hN n hge)⟩
+
+/-! ## Summary
+
+Proved, all axiom-free and sorry-free:
+
+1. `CramerConjecture` — Cramér's 1936 conjecture as a defined `Prop`
+   (upper-bound form `∃ C > 0, ∃ k₀, ∀ k ≥ k₀, p_{k+1} − p_k ≤ C·(log p_k)²`).
+2. `eventually_mul_log_sq_le_sqrt_sub_one` — `C·(log x)² ≤ √x − 1`
+   eventually (S5-ACT-A).
+3. `cramerGapBound_to_sqrt_gap` — Cramér bound ⇒ sqrt gap bound above a
+   threshold (S5-ACT-B).
+4. `cramer_implies_legendre_eventually` / `cramer_exceptions_finite` /
+   `cramer_reduces_legendre_to_finite` — Cramér ⇒ Legendre up to finitely
+   many explicit cases (S5-ACT-C).
+
+### What this does NOT prove
+
+Neither conjecture. Both remain open; Cramér appears only as an explicit
+hypothesis. The reduction is one-directional: Legendre is *weaker* than
+Cramér in the eventual regime, and nothing here bounds the exceptional `N`
+without a concrete Cramér witness `(C, k₀)`.
+-/
+
+end CramerImpliesLegendre

--- a/proofs/Proofs/CramerImpliesLegendre.lean
+++ b/proofs/Proofs/CramerImpliesLegendre.lean
@@ -91,7 +91,7 @@ theorem eventually_mul_log_sq_le_sqrt_sub_one (C : ℝ) :
   -- `(log x)^2 = o(x^{1/2})` (rpow exponents)
   have hlo : (fun x : ℝ => Real.log x ^ (2 : ℝ)) =o[atTop]
       fun x : ℝ => x ^ ((1 : ℝ) / 2) :=
-    Real.isLittleO_log_rpow_rpow_atTop 2 (by norm_num)
+    isLittleO_log_rpow_rpow_atTop 2 (by norm_num)
   have hbound := hlo.def (show (0 : ℝ) < 1 / (2 * D) by positivity)
   filter_upwards [hbound, eventually_ge_atTop (1 : ℝ),
     eventually_ge_atTop (4 : ℝ)] with x hx hx1 hx4
@@ -100,8 +100,7 @@ theorem eventually_mul_log_sq_le_sqrt_sub_one (C : ℝ) :
   -- rewrite the rpow forms as `(log x)^2` (monoid power) and `√x`
   have hrw_log : Real.log x ^ (2 : ℝ) = Real.log x ^ 2 := by
     rw [show (2 : ℝ) = ((2 : ℕ) : ℝ) by norm_num, Real.rpow_natCast]
-  have hrw_sqrt : x ^ ((1 : ℝ) / 2) = Real.sqrt x := (Real.rpow_natCast x 1 ▸
-    (Real.sqrt_eq_rpow x).symm : x ^ ((1 : ℝ) / 2) = Real.sqrt x)
+  have hrw_sqrt : x ^ ((1 : ℝ) / 2) = Real.sqrt x := (Real.sqrt_eq_rpow x).symm
   rw [hrw_log, hrw_sqrt, Real.norm_of_nonneg (sq_nonneg _),
     Real.norm_of_nonneg (Real.sqrt_nonneg x)] at hx
   -- `√x ≥ 2` for `x ≥ 4`
@@ -153,12 +152,13 @@ theorem cramerGapBound_to_sqrt_gap {C : ℝ} {k₀ : ℕ} (h : CramerGapBound C 
   refine ⟨max M₀ (Nat.nth Nat.Prime k₀), fun k hk => ?_⟩
   -- `p_k ≥ p_{k₀}` forces `k ≥ k₀` (strict monotonicity of `Nat.nth`)
   have hk₀ : k₀ ≤ k := by
-    by_contra hlt
-    push_neg at hlt
-    have hmono : Nat.nth Nat.Prime k < Nat.nth Nat.Prime k₀ :=
-      Nat.nth_strictMono Nat.infinite_setOf_prime hlt
-    have hmax := le_max_right M₀ (Nat.nth Nat.Prime k₀)
-    omega
+    rcases lt_or_ge k k₀ with hlt | h
+    · exfalso
+      have hmono : Nat.nth Nat.Prime k < Nat.nth Nat.Prime k₀ :=
+        Nat.nth_strictMono Nat.infinite_setOf_prime hlt
+      have hmax := le_max_right M₀ (Nat.nth Nat.Prime k₀)
+      omega
+    · exact h
   have hgap := h k hk₀
   have hthr := hM₀ (Nat.nth Nat.Prime k) (le_trans (le_max_left _ _) hk)
   have hcast : ((Nat.nth Nat.Prime (k + 1) - Nat.nth Nat.Prime k : ℕ) : ℝ)
@@ -190,9 +190,9 @@ theorem cramer_exceptions_finite (h : CramerConjecture) :
   refine Set.Finite.subset (Set.finite_Iio N) ?_
   rintro n ⟨-, hnot⟩
   rw [Set.mem_Iio]
-  by_contra hge
-  push_neg at hge
-  exact hnot (hN n hge)
+  rcases lt_or_ge n N with h | hge
+  · exact h
+  · exact absurd (hN n hge) hnot
 
 /-- **Full conditional composition**: under Cramér's conjecture, Legendre's
 conjecture reduces to finitely many explicit cases — there is a single `N`

--- a/proofs/Proofs/LegendreGapEquivalence.lean
+++ b/proofs/Proofs/LegendreGapEquivalence.lean
@@ -35,9 +35,11 @@ requires reasoning about consecutive primes and is left as future work. See
 
 ## Axioms
 
-This file introduces 0 new axioms. It uses `Legendre.legendre_conjecture`
-(declared as an axiom in `LegendrePartial.lean`) only when stating the
-"global" equivalences; the equivalences themselves are unconditional.
+This file introduces 0 new axioms and depends on none: the "global"
+equivalences quantify over the `Prop` `Legendre.LegendreConjecture` itself,
+so all results here are unconditional. (A dead `axiom legendre_conjecture`
+formerly declared in `LegendrePartial.lean` was never used and has been
+removed.)
 -/
 
 import Mathlib.NumberTheory.Bertrand
@@ -193,8 +195,9 @@ This file proves:
 
 ### Axiom delta
 
-This file introduces **0 new axioms**. The pre-existing axiom
-`Legendre.legendre_conjecture` (in `LegendrePartial.lean`) is unchanged.
+This file introduces **0 new axioms** and uses none. (The dead axiom
+`Legendre.legendre_conjecture` formerly in `LegendrePartial.lean` has been
+removed; nothing here ever depended on it.)
 
 ### Future work (Sub-Milestone B+)
 

--- a/proofs/Proofs/LegendrePartial.lean
+++ b/proofs/Proofs/LegendrePartial.lean
@@ -139,13 +139,17 @@ theorem legendre_20 : LegendreAt 20 := ⟨401, by native_decide⟩
 theorem square_gap_linear (n : ℕ) : (n + 1)^2 = n^2 + 2 * n + 1 := by ring
 
 /-!
-## The Full Conjecture (Statement)
+## The Full Conjecture (Statement Only)
 
-We state the full Legendre conjecture as an axiom.
+The full conjecture is the `Prop` `LegendreConjecture` defined above. It is
+deliberately NOT assumed as an axiom: conditional results downstream state it
+as an explicit hypothesis or conclusion (see
+`LegendrePrimeGapSqrtBoundSuffices.lean` and `CramerImpliesLegendre.lean`).
+A dead `axiom legendre_conjecture : LegendreConjecture` formerly declared here
+had zero uses anywhere in the repository and was removed (iteration 8), so this
+file — and every file importing it — carries no unproved assumptions beyond
+the `native_decide` (`Lean.ofReduceBool`) dependency of the case checks above.
 -/
-
-/-- Legendre's Conjecture: for all n ≥ 1, there's a prime between n² and (n+1)² -/
-axiom legendre_conjecture : LegendreConjecture
 
 /-!
 ## What We've Proven

--- a/proofs/Proofs/LegendrePrimeGapSqrtBoundSuffices.lean
+++ b/proofs/Proofs/LegendrePrimeGapSqrtBoundSuffices.lean
@@ -55,9 +55,10 @@ for the full audit. We formalize **only the salvageable (reverse) direction**.
 ## Axioms
 
 This file introduces **0 new axioms**. The conclusion `LegendreConjecture` is
-declared as an axiom in `LegendrePartial.lean`; here it is proved
-*conditionally* on the gap-bound hypothesis, without strengthening the
-ambient axiom basis of the project.
+the `Prop` defined in `LegendrePartial.lean` (not an axiom — the former dead
+axiom there has been removed); here it is proved *conditionally* on the
+gap-bound hypothesis, without strengthening the ambient axiom basis of the
+project.
 -/
 
 import Mathlib.Data.Nat.Prime.Nth
@@ -106,6 +107,93 @@ lemma nth_prime_ge (k : ℕ) : k + 2 ≤ Nat.nth Nat.Prime k := by
 
 /-! ## Main theorem -/
 
+/-- **Single-`n` core of the sqrt prime-gap criterion.**
+
+If the sqrt prime-gap bound `p_{k+1} - p_k ≤ 2·√p_k + 1` holds for every prime
+`p_k ≥ M`, then `LegendreAt n` holds for every individual `n ≥ 2` with
+`n² ≥ 2M`. This is the "large `n`" branch of
+`prime_gap_sqrt_bound_above_implies_legendre` below, exposed on its own so that
+hypotheses supplying the gap bound only *eventually* (e.g. Cramér-type
+conjectures — see `CramerImpliesLegendre.lean`) can still conclude Legendre for
+all sufficiently large `n`, with no assumption about small cases. -/
+theorem legendreAt_of_sqrt_gap_above (M : ℕ)
+    (h_gap_above : ∀ k, M ≤ Nat.nth Nat.Prime k →
+      Nat.nth Nat.Prime (k + 1) - Nat.nth Nat.Prime k
+        ≤ 2 * Nat.sqrt (Nat.nth Nat.Prime k) + 1)
+    {n : ℕ} (hn2 : 2 ≤ n) (hlarge : 2 * M ≤ n^2) :
+    LegendreAt n := by
+  -- use the largest prime ≤ n²
+  set P : ℕ → Prop := fun k => Nat.nth Nat.Prime k ≤ n^2 with hP_def
+  set k := Nat.findGreatest P (n^2) with hk_def
+  -- P 0 holds: nth Prime 0 = 2 ≤ n² (since n ≥ 2 implies n² ≥ 4)
+  have hP0 : P 0 := by
+    show Nat.nth Nat.Prime 0 ≤ n^2
+    rw [first_prime]
+    nlinarith [sq_nonneg n]
+  have hP_k : P k := Nat.findGreatest_spec (Nat.zero_le _) hP0
+  have hk_le : k ≤ n^2 := Nat.findGreatest_le _
+  have hk_prime : Nat.Prime (Nat.nth Nat.Prime k) := nth_prime_is_prime k
+  have hn2_not_prime : ¬ Nat.Prime (n^2) := not_prime_sq_of_ge_two hn2
+  have hk_lt : Nat.nth Nat.Prime k < n^2 := by
+    rcases lt_or_eq_of_le hP_k with h | h
+    · exact h
+    · exfalso
+      rw [← h] at hn2_not_prime
+      exact hn2_not_prime hk_prime
+  have hk_succ_le : k + 1 ≤ n^2 := by
+    have hge := nth_prime_ge k
+    omega
+  have hPk1_not : ¬ P (k + 1) := by
+    have hlt : Nat.findGreatest P (n^2) < k + 1 := by
+      rw [← hk_def]; omega
+    exact Nat.findGreatest_is_greatest hlt hk_succ_le
+  have hkp1_gt : n^2 < Nat.nth Nat.Prime (k + 1) := by
+    change ¬ (Nat.nth Nat.Prime (k + 1) ≤ n^2) at hPk1_not
+    omega
+  -- NEW (this iteration): the largest prime ≤ n² is itself ≥ M.
+  -- Bertrand gives a prime q ∈ (n²/2, n²]; since p_k is the largest prime
+  -- ≤ n², we have q ≤ p_k, and q > n²/2 ≥ M, hence M ≤ p_k.
+  have hM_le_pk : M ≤ Nat.nth Nat.Prime k := by
+    have h4 : (4 : ℕ) ≤ n^2 := by
+      calc (4 : ℕ) = 2^2 := by norm_num
+        _ ≤ n^2 := Nat.pow_le_pow_left hn2 2
+    have hmpos : n^2 / 2 ≠ 0 := by omega
+    obtain ⟨q, hq_prime, hq_gt, hq_le⟩ := Nat.bertrand (n^2 / 2) hmpos
+    have hq_le_n2 : q ≤ n^2 := by omega
+    have hM_le_q : M ≤ q := by omega
+    set j := Nat.count Nat.Prime q with hj_def
+    have hnj : Nat.nth Nat.Prime j = q := Nat.nth_count hq_prime
+    have hj_le_n2 : j ≤ n^2 := by
+      have hge := nth_prime_ge j
+      rw [hnj] at hge; omega
+    have hPj : P j := by
+      show Nat.nth Nat.Prime j ≤ n^2
+      rw [hnj]; exact hq_le_n2
+    have hj_le_k : j ≤ k := Nat.le_findGreatest hj_le_n2 hPj
+    have hq_le_pk : q ≤ Nat.nth Nat.Prime k := by
+      have hmono := Nat.nth_monotone Nat.infinite_setOf_prime hj_le_k
+      rw [hnj] at hmono; exact hmono
+    omega
+  -- Apply the (eventual) gap-bound hypothesis at k.
+  have hgap : Nat.nth Nat.Prime (k + 1) - Nat.nth Nat.Prime k
+            ≤ 2 * Nat.sqrt (Nat.nth Nat.Prime k) + 1 := h_gap_above k hM_le_pk
+  have hkp1_strict : Nat.nth Nat.Prime k < Nat.nth Nat.Prime (k + 1) :=
+    Nat.nth_strictMono Nat.infinite_setOf_prime (Nat.lt_succ_self k)
+  have hsqrt_mono : Nat.sqrt (Nat.nth Nat.Prime k) ≤ Nat.sqrt (n^2 - 1) := by
+    apply Nat.sqrt_le_sqrt; omega
+  have hsqrt_n_sub : Nat.sqrt (n^2 - 1) ≤ n - 1 := by
+    have h_lt_n : Nat.sqrt (n^2 - 1) < n := by
+      rw [Nat.sqrt_lt']
+      have hpos : (0 : ℕ) < n^2 := by positivity
+      omega
+    omega
+  have hsqrt_bound : Nat.sqrt (Nat.nth Nat.Prime k) ≤ n - 1 := by omega
+  have hkp1_lt : Nat.nth Nat.Prime (k + 1) < (n + 1)^2 := by
+    have hpow : (n + 1)^2 = n^2 + 2 * n + 1 := by ring
+    rw [hpow]
+    omega
+  exact ⟨Nat.nth Nat.Prime (k + 1), nth_prime_is_prime (k + 1), hkp1_gt, hkp1_lt⟩
+
 /-- **Eventually-suffices form of the sqrt prime-gap criterion.**
 
 If the sqrt prime-gap bound `p_{k+1} - p_k ≤ 2·√p_k + 1` holds for every prime
@@ -115,8 +203,8 @@ If the sqrt prime-gap bound `p_{k+1} - p_k ≤ 2·√p_k + 1` holds for every pr
 The threshold `2M` is exactly what Bertrand's postulate supplies: when
 `n² ≥ 2M`, Bertrand gives a prime in `(n²/2, n²]`, so the largest prime `p_k`
 not exceeding `n²` satisfies `p_k > n²/2 ≥ M`, and the gap hypothesis is
-applicable at that `k`. The remainder of the argument is the iter-5
-`findGreatest` construction. Taking `M = 0` recovers the unconditional
+applicable at that `k` (this branch is `legendreAt_of_sqrt_gap_above` above).
+Taking `M = 0` recovers the unconditional
 `prime_gap_sqrt_bound_implies_legendre` below. -/
 theorem prime_gap_sqrt_bound_above_implies_legendre (M : ℕ)
     (h_gap_above : ∀ k, M ≤ Nat.nth Nat.Prime k →
@@ -133,77 +221,8 @@ theorem prime_gap_sqrt_bound_above_implies_legendre (M : ℕ)
     rcases lt_or_ge (n^2) (2 * M) with hsmall | hlarge
     · -- n² < 2M: Legendre is verified below the threshold by hypothesis
       exact h_legendre_below n hn hsmall
-    · -- n² ≥ 2M: use the largest prime ≤ n²
-      set P : ℕ → Prop := fun k => Nat.nth Nat.Prime k ≤ n^2 with hP_def
-      set k := Nat.findGreatest P (n^2) with hk_def
-      -- P 0 holds: nth Prime 0 = 2 ≤ n² (since n ≥ 2 implies n² ≥ 4)
-      have hP0 : P 0 := by
-        show Nat.nth Nat.Prime 0 ≤ n^2
-        rw [first_prime]
-        nlinarith [sq_nonneg n]
-      have hP_k : P k := Nat.findGreatest_spec (Nat.zero_le _) hP0
-      have hk_le : k ≤ n^2 := Nat.findGreatest_le _
-      have hk_prime : Nat.Prime (Nat.nth Nat.Prime k) := nth_prime_is_prime k
-      have hn2_not_prime : ¬ Nat.Prime (n^2) := not_prime_sq_of_ge_two hn2
-      have hk_lt : Nat.nth Nat.Prime k < n^2 := by
-        rcases lt_or_eq_of_le hP_k with h | h
-        · exact h
-        · exfalso
-          rw [← h] at hn2_not_prime
-          exact hn2_not_prime hk_prime
-      have hk_succ_le : k + 1 ≤ n^2 := by
-        have hge := nth_prime_ge k
-        omega
-      have hPk1_not : ¬ P (k + 1) := by
-        have hlt : Nat.findGreatest P (n^2) < k + 1 := by
-          rw [← hk_def]; omega
-        exact Nat.findGreatest_is_greatest hlt hk_succ_le
-      have hkp1_gt : n^2 < Nat.nth Nat.Prime (k + 1) := by
-        change ¬ (Nat.nth Nat.Prime (k + 1) ≤ n^2) at hPk1_not
-        omega
-      -- NEW (this iteration): the largest prime ≤ n² is itself ≥ M.
-      -- Bertrand gives a prime q ∈ (n²/2, n²]; since p_k is the largest prime
-      -- ≤ n², we have q ≤ p_k, and q > n²/2 ≥ M, hence M ≤ p_k.
-      have hM_le_pk : M ≤ Nat.nth Nat.Prime k := by
-        have h4 : (4 : ℕ) ≤ n^2 := by
-          calc (4 : ℕ) = 2^2 := by norm_num
-            _ ≤ n^2 := Nat.pow_le_pow_left hn2 2
-        have hmpos : n^2 / 2 ≠ 0 := by omega
-        obtain ⟨q, hq_prime, hq_gt, hq_le⟩ := Nat.bertrand (n^2 / 2) hmpos
-        have hq_le_n2 : q ≤ n^2 := by omega
-        have hM_le_q : M ≤ q := by omega
-        set j := Nat.count Nat.Prime q with hj_def
-        have hnj : Nat.nth Nat.Prime j = q := Nat.nth_count hq_prime
-        have hj_le_n2 : j ≤ n^2 := by
-          have hge := nth_prime_ge j
-          rw [hnj] at hge; omega
-        have hPj : P j := by
-          show Nat.nth Nat.Prime j ≤ n^2
-          rw [hnj]; exact hq_le_n2
-        have hj_le_k : j ≤ k := Nat.le_findGreatest hj_le_n2 hPj
-        have hq_le_pk : q ≤ Nat.nth Nat.Prime k := by
-          have hmono := Nat.nth_monotone Nat.infinite_setOf_prime hj_le_k
-          rw [hnj] at hmono; exact hmono
-        omega
-      -- Apply the (eventual) gap-bound hypothesis at k.
-      have hgap : Nat.nth Nat.Prime (k + 1) - Nat.nth Nat.Prime k
-                ≤ 2 * Nat.sqrt (Nat.nth Nat.Prime k) + 1 := h_gap_above k hM_le_pk
-      have hkp1_strict : Nat.nth Nat.Prime k < Nat.nth Nat.Prime (k + 1) :=
-        Nat.nth_strictMono Nat.infinite_setOf_prime (Nat.lt_succ_self k)
-      have hsqrt_mono : Nat.sqrt (Nat.nth Nat.Prime k) ≤ Nat.sqrt (n^2 - 1) := by
-        apply Nat.sqrt_le_sqrt; omega
-      have hsqrt_n_sub : Nat.sqrt (n^2 - 1) ≤ n - 1 := by
-        have h_lt_n : Nat.sqrt (n^2 - 1) < n := by
-          rw [Nat.sqrt_lt']
-          have hpos : (0 : ℕ) < n^2 := by positivity
-          omega
-        omega
-      have hsqrt_bound : Nat.sqrt (Nat.nth Nat.Prime k) ≤ n - 1 := by omega
-      have hkp1_lt : Nat.nth Nat.Prime (k + 1) < (n + 1)^2 := by
-        have hpow : (n + 1)^2 = n^2 + 2 * n + 1 := by ring
-        rw [hpow]
-        omega
-      exact ⟨Nat.nth Nat.Prime (k + 1), nth_prime_is_prime (k + 1), hkp1_gt, hkp1_lt⟩
+    · -- n² ≥ 2M: the large branch
+      exact legendreAt_of_sqrt_gap_above M h_gap_above hn2 hlarge
 
 /-- **Sqrt prime-gap upper bound implies Legendre's Conjecture.**
 
@@ -246,15 +265,19 @@ This file proves:
 
 1. `PrimeGapSqrtBound` — the hypothesis `∀ k, p_{k+1} - p_k ≤ 2 · √p_k + 1`
    (where `p_k = Nat.nth Nat.Prime k`).
-2. `prime_gap_sqrt_bound_implies_legendre`:
-   `PrimeGapSqrtBound → LegendreConjecture`.
-3. Three corollaries via the iter-2 equivalences: the same hypothesis suffices
+2. `legendreAt_of_sqrt_gap_above` — the single-`n` core: the gap bound for
+   primes `≥ M` gives `LegendreAt n` for every `n ≥ 2` with `n² ≥ 2M`.
+3. `prime_gap_sqrt_bound_above_implies_legendre` — the eventually-suffices
+   form, and `prime_gap_sqrt_bound_implies_legendre`:
+   `PrimeGapSqrtBound → LegendreConjecture` (its `M = 0` case).
+4. Three corollaries via the iter-2 equivalences: the same hypothesis suffices
    for the gap form, distance form, and half-open form of Legendre.
 
 ### Axiom delta
 
-This file introduces **0 new axioms**. The pre-existing axiom
-`Legendre.legendre_conjecture` (in `LegendrePartial.lean`) is unchanged.
+This file introduces **0 new axioms** and uses none. (The dead axiom
+`Legendre.legendre_conjecture` formerly in `LegendrePartial.lean` has been
+removed; nothing here ever depended on it.)
 
 ### What this file does NOT prove
 

--- a/proofs/Proofs/PellEquationOQ05.lean
+++ b/proofs/Proofs/PellEquationOQ05.lean
@@ -367,6 +367,144 @@ theorem cnorm3_not_surjective : ¬ Function.Surjective cnorm3 := by
   exact cnorm_ne_seven p.1 p.2.1 p.2.2 hp
 
 /-
+## Sharpness: 7 is the LEAST positive non-norm, and non-norms are infinite (Session 8)
+
+Session 7 exhibited 7 as a non-norm. This section sharpens that in three ways:
+
+1. **Sharpness**: every integer m with 1 ≤ m ≤ 6 IS a norm, with explicit
+   witnesses — N(1,0,0)=1, N(0,1,0)=2 (ξ=∛2), N(1,1,0)=3, N(0,0,1)=4 (ξ=∛4),
+   N(1,1,−1)=5, N(0,1,1)=6. So 7 is exactly the first positive value the cubic
+   norm form misses (`seven_least_positive_non_norm`), and by the S6 dichotomy
+   each of N = 1..6 has infinitely many solutions (`norm_small_values_infinite`).
+2. **Sign symmetry**: the norm form has odd degree, so N(−ξ) = −N(ξ)
+   (`cnorm_neg`) and the image is symmetric under negation — the negative-side
+   sharpness (`neg_seven_least_negative_non_norm`) is free.
+3. **Valuation obstruction, and infinitely many non-norms**: the inert-prime
+   argument of S7 really shows the 7-adic valuation of any norm is a multiple
+   of 3 in the range {0} ∪ [3,∞): `7 ∣ N ⟹ 343 ∣ N` (`seven_dvd_imp_cube_dvd`).
+   Hence EVERY m with 7 ∣ m but 343 ∤ m is a non-norm — 7, 14, 21, …, 49, …,
+   and the set of non-norms is infinite (`non_norms_infinite`), witnessed by
+   the arithmetic progression 7 + 343k.
+
+The image of `cnorm3` is also closed under multiplication (`norm_values_mul_mem`,
+Brahmagupta composition in degree 3), so the norms form a submonoid of ℤ whose
+complement is nevertheless infinite.
+-/
+
+/-- Odd-degree sign symmetry: N(−ξ) = −N(ξ). The cubic norm form is an odd
+    function of ξ, so its image is symmetric under negation. (Contrast the
+    quadratic Pell form, which is even.) -/
+theorem cnorm_neg (a b c : ℤ) : cnorm (-a) (-b) (-c) = - cnorm a b c := by
+  simp only [cnorm]; ring
+
+/-- m is a norm iff −m is a norm. -/
+theorem norm_solvable_iff_neg (m : ℤ) :
+    (∃ p : ℤ × ℤ × ℤ, cnorm3 p = m) ↔ (∃ p : ℤ × ℤ × ℤ, cnorm3 p = -m) := by
+  constructor <;> rintro ⟨⟨a, b, c⟩, h⟩
+  · exact ⟨(-a, -b, -c), by
+      show cnorm (-a) (-b) (-c) = -m
+      rw [cnorm_neg, show cnorm a b c = m from h]⟩
+  · exact ⟨(-a, -b, -c), by
+      show cnorm (-a) (-b) (-c) = m
+      rw [cnorm_neg, show cnorm a b c = -m from h, neg_neg]⟩
+
+/-- The norms form a multiplicatively closed set (Brahmagupta composition in
+    degree 3): if m and n are norms, so is m·n. With N(1,0,0) = 1 this makes
+    the image of `cnorm3` a submonoid of ℤ. -/
+theorem norm_values_mul_mem {m n : ℤ}
+    (hm : ∃ p : ℤ × ℤ × ℤ, cnorm3 p = m) (hn : ∃ q : ℤ × ℤ × ℤ, cnorm3 q = n) :
+    ∃ r : ℤ × ℤ × ℤ, cnorm3 r = m * n := by
+  obtain ⟨p, hp⟩ := hm
+  obtain ⟨q, hq⟩ := hn
+  exact ⟨cmul p q, by rw [cnorm_cmul, hp, hq]⟩
+
+/-- **Sharpness of the S7 non-norm: 7 is the least positive non-norm.** Every
+    m with 1 ≤ m < 7 is a norm (explicit witnesses); 7 is not. -/
+theorem seven_least_positive_non_norm :
+    (∀ m : ℤ, 1 ≤ m → m < 7 → ∃ p : ℤ × ℤ × ℤ, cnorm3 p = m) ∧
+      ¬ ∃ p : ℤ × ℤ × ℤ, cnorm3 p = 7 := by
+  constructor
+  · intro m h1 h7
+    interval_cases m
+    · exact ⟨(1, 0, 0), by decide⟩
+    · exact ⟨(0, 1, 0), by decide⟩
+    · exact ⟨(1, 1, 0), by decide⟩
+    · exact ⟨(0, 0, 1), by decide⟩
+    · exact ⟨(1, 1, -1), by decide⟩
+    · exact ⟨(0, 1, 1), by decide⟩
+  · rintro ⟨⟨a, b, c⟩, h⟩
+    exact cnorm_ne_seven a b c h
+
+/-- Negative-side sharpness (free by the odd symmetry): every m with
+    −6 ≤ m ≤ −1 is a norm; −7 is not. -/
+theorem neg_seven_least_negative_non_norm :
+    (∀ m : ℤ, -6 ≤ m → m ≤ -1 → ∃ p : ℤ × ℤ × ℤ, cnorm3 p = m) ∧
+      ¬ ∃ p : ℤ × ℤ × ℤ, cnorm3 p = -7 := by
+  constructor
+  · intro m h6 h1
+    obtain ⟨p, hp⟩ := seven_least_positive_non_norm.1 (-m) (by omega) (by omega)
+    obtain ⟨q, hq⟩ := (norm_solvable_iff_neg (-m)).mp ⟨p, hp⟩
+    exact ⟨q, by rwa [neg_neg] at hq⟩
+  · rintro ⟨⟨a, b, c⟩, h⟩
+    exact cnorm_ne_neg_seven a b c h
+
+/-- **The boundary panorama**: for every m with 1 ≤ |m| ≤ 6 the norm equation
+    N(ξ) = m has infinitely many integral solutions (witness + S6 unit-orbit
+    dichotomy), while N(ξ) = ±7 has none. -/
+theorem norm_small_values_infinite (m : ℤ) (h1 : 1 ≤ |m|) (h6 : |m| ≤ 6) :
+    {p : ℤ × ℤ × ℤ | cnorm3 p = m}.Infinite := by
+  have hm0 : m ≠ 0 := by
+    intro h
+    rw [h] at h1
+    simp at h1
+  rcases hm0.lt_or_lt with hneg | hpos
+  · rw [abs_of_neg hneg] at h1 h6
+    obtain ⟨p, hp⟩ := neg_seven_least_negative_non_norm.1 m (by omega) (by omega)
+    exact norm_eq_solutions_infinite m hm0 p hp
+  · rw [abs_of_pos hpos] at h1 h6
+    obtain ⟨p, hp⟩ := seven_least_positive_non_norm.1 m (by omega) (by omega)
+    exact norm_eq_solutions_infinite m hm0 p hp
+
+/-- **Valuation obstruction at the inert prime**: if 7 divides a norm, 7³ = 343
+    divides it. (The 7-adic valuation of a nonzero norm is a multiple of 3 —
+    inert primes enter the image of the norm only through their cube.) -/
+theorem seven_dvd_imp_cube_dvd (a b c : ℤ) (h : (7 : ℤ) ∣ cnorm a b c) :
+    (343 : ℤ) ∣ cnorm a b c := by
+  obtain ⟨⟨a', rfl⟩, ⟨b', rfl⟩, ⟨c', rfl⟩⟩ := (seven_dvd_cnorm_iff _ _ _).mp h
+  exact ⟨cnorm a' b' c', by simp only [cnorm]; ring⟩
+
+/-- Every integer divisible by 7 but not by 343 is a non-norm — 7, 14, 21, …,
+    49, 98, …. Subsumes `cnorm_ne_seven` (m = 7) and `cnorm_ne_neg_seven`
+    (m = −7). -/
+theorem cnorm_ne_of_seven_valuation (m : ℤ) (h7 : (7 : ℤ) ∣ m)
+    (h343 : ¬ (343 : ℤ) ∣ m) (a b c : ℤ) : cnorm a b c ≠ m := by
+  intro h
+  apply h343
+  rw [← h]
+  exact seven_dvd_imp_cube_dvd a b c (by rw [h]; exact h7)
+
+/-- **The set of non-norms is infinite**: the cubic norm form misses infinitely
+    many integers, witnessed by the arithmetic progression 7 + 343k (each term
+    is divisible by 7 but not by 343). The complement of the norm submonoid is
+    infinite even though the submonoid itself contains full unit-orbits. -/
+theorem non_norms_infinite :
+    {m : ℤ | ¬ ∃ p : ℤ × ℤ × ℤ, cnorm3 p = m}.Infinite := by
+  have hinj : Function.Injective (fun k : ℕ => (7 : ℤ) + 343 * k) := by
+    intro j k hjk
+    simp only at hjk
+    omega
+  apply Set.infinite_of_injective_forall_mem
+    (f := fun k : ℕ => (7 : ℤ) + 343 * k) hinj
+  intro k
+  simp only [Set.mem_setOf_eq]
+  rintro ⟨⟨a, b, c⟩, h⟩
+  have h7 : (7 : ℤ) ∣ 7 + 343 * k := ⟨1 + 49 * k, by ring⟩
+  have h343 : ¬ (343 : ℤ) ∣ 7 + 343 * k := by
+    rintro ⟨d, hd⟩
+    omega
+  exact cnorm_ne_of_seven_valuation (7 + 343 * (k : ℤ)) h7 h343 a b c h
+
+/-
 ## Recovering Pell (rank-1 special case)
 
 For comparison, the parent real-quadratic norm form N(p + q√2) = p² - 2q² with its

--- a/research/problems/bertrands-postulate-oq-02/knowledge.md
+++ b/research/problems/bertrands-postulate-oq-02/knowledge.md
@@ -443,3 +443,31 @@ compile time and having to redo ~100 LOC of structural redesign.
 variant inside `LegendrePrimeGapSqrtBoundSuffices.lean` (~85 LOC,
 0 new axioms). After it lands, S5-ACT-A (real-analytic estimate) and
 S5-ACT-C (Cramér composition) can proceed in either order.
+
+## Iteration 8 Log (2026-07-24, researcher-1) — COMPLETED
+
+Stale-BLOCKED reactivation (Docker recovered). Both queued items discharged,
+Docker-verified (3094 jobs, first try):
+
+1. **Dead `legendre_conjecture` axiom removed** (`LegendrePartial.lean`,
+   slug axioms 1 → 0). The blocking docstring claim in
+   `LegendreGapEquivalence.lean` was stale — the global equivalences quantify
+   over the `Prop` `LegendreConjecture`, not the axiom. Four stale docstring
+   spots fixed; gallery `legendre-partial` meta updated
+   (`meta.axiomCount` 2 → 1 ofReduceBool-only, `leanFile.axiomCount` 1 → 0).
+2. **S5-ACT-A/B/C all landed** in NEW `CramerImpliesLegendre.lean` (229 LOC,
+   0 axioms, 0 sorries): `CramerConjecture` as a `Prop`;
+   `eventually_mul_log_sq_le_sqrt_sub_one` (via
+   `isLittleO_log_rpow_rpow_atTop`, root namespace); `exists_nat_sqrt_threshold`
+   (√p < Nat.sqrt p + 1 bridge); `cramerGapBound_to_sqrt_gap` (index-threshold
+   from value-threshold via `Nat.nth` strict monotonicity);
+   `cramer_implies_legendre_eventually`; `cramer_exceptions_finite`;
+   `cramer_reduces_legendre_to_finite` (honest strongest form — Cramér's
+   constants are existential, so the tail is finite but not fixed).
+   Enabled by extracting `legendreAt_of_sqrt_gap_above` (single-n large branch)
+   in `LegendrePrimeGapSqrtBoundSuffices.lean`.
+
+**Thread COMPLETED.** Iter-3..7 roadmap fully discharged; S6 (n = 21..50
+enumeration) permanently deprioritized as padding. Reopen bar: materially new
+mechanism. Memo:
+`sessions/2026-07-24-iter8-dead-axiom-removal-cramer-composition.md`.

--- a/research/problems/bertrands-postulate-oq-02/meta.json
+++ b/research/problems/bertrands-postulate-oq-02/meta.json
@@ -28,15 +28,21 @@
     "goal": "Initial survey; identify tractable sub-milestone for iteration 2 (recommended: equivalence with prime-gap bound)"
   },
   "currentState": {
-    "phase": "PREP",
-    "since": "2026-06-10T00:00:00Z",
-    "iteration": 6,
-    "focus": "S5-PREP-2 DONE (researcher-9, 2026-06-10): pre-flight audit of iter-5's recommended S5 Cramér⇒Legendre ACT. Finding: iter-5's PrimeGapSqrtBound (∀ k, p_{k+1}-p_k ≤ 2√p_k+1) does NOT directly accept Cramér's eventually-quantified output (∃ k₀, ∀ k≥k₀, gap ≤ C·log²p_k); the asymptotic Cramér bound fails at small k (e.g. C·(log 2)² < 1 = gap_0). Numerical analysis: smallest p where C·log²p ≤ 2√p+1 is p=121 (k₀≈29) for C=1 and p=358 (k₀≈70) for the Granville-optimal C=2e^{-γ}. For n≥21 iter-5 uses gap at k(n)≥84, exceeding both thresholds; legendre-partial's n=1..20 finite-tail suffices with margin. The remediation: a refined iter-5 variant prime_gap_sqrt_bound_above_implies_legendre (M : ℕ) that takes the gap bound only for k with p_k ≥ M, plus LegendreAt n for n² < 2·M; iter-5 is recovered at M=0. Proof uses Mathlib's Nat.bertrand on n²/2 to ensure p_k ≥ M. ~85 LOC estimate, 0 new axioms.",
-    "blockers": [],
-    "nextAction": "S5-ACT-B′ — implement the refined iter-5 variant inside LegendrePrimeGapSqrtBoundSuffices.lean. Add prime_gap_sqrt_bound_above_implies_legendre (M : ℕ) with hypotheses (h_gap_above : ∀ k, M ≤ p_k → gap ≤ 2√p_k+1) and (h_legendre_below : ∀ n, 1 ≤ n → n² < 2*M → LegendreAt n). Proof: case n² < 2*M direct from h_legendre_below; case n² ≥ 2*M applies Nat.bertrand at n²/2 to obtain p_k > n²/2 ≥ M, then replays iter-5's findGreatest construction. Derive prime_gap_sqrt_bound_implies_legendre as the corollary at M = 0. Estimated +85 LOC, 0 new axioms. Unblocks S5-ACT-A (real-analytic C·log²p ≤ 2√p+1) and S5-ACT-C (Cramér composition) — both can then proceed in either order.",
+    "phase": "COMPLETED",
+    "since": "2026-07-24T00:00:00Z",
+    "iteration": 8,
+    "focus": "Session 8 (researcher-1, 2026-07-24): dead legendre_conjecture axiom REMOVED (slug axioms 1->0) and S5-ACT-A+B+C all landed in NEW CramerImpliesLegendre.lean (229 LOC, 0 axioms, 0 sorries): CramerConjecture as Prop; C·log²x ≤ √x−1 eventually (isLittleO_log_rpow_rpow_atTop); Cramér ⇒ sqrt gap bound above threshold; cramer_implies_legendre_eventually / cramer_exceptions_finite / cramer_reduces_legendre_to_finite. Docker-verified (3094 jobs). Thread COMPLETED — iter-3..7 roadmap fully discharged; S6 enumeration permanently deprioritized.",
+    "blockers": [
+      {
+        "route": "unconditional prime-gap bound of BHP x^0.525 strength",
+        "reopenCriterion": "materially new mechanism required (Mathlib-scale analytic NT infrastructure)",
+        "blockedAt": "2026-07-24"
+      }
+    ],
+    "nextAction": "None — thread COMPLETED (see state.md Session 8 and the iter-8 session memo).",
     "attemptCounts": {
-      "total": 6,
-      "currentApproach": 4,
+      "total": 8,
+      "currentApproach": 5,
       "approachesTried": 4
     }
   },

--- a/research/problems/bertrands-postulate-oq-02/sessions/2026-07-24-iter8-dead-axiom-removal-cramer-composition.md
+++ b/research/problems/bertrands-postulate-oq-02/sessions/2026-07-24-iter8-dead-axiom-removal-cramer-composition.md
@@ -1,0 +1,101 @@
+# Session 8 — Dead-axiom removal + Cramér ⇒ Legendre composition (S5-ACT-A/B/C)
+
+**Date**: 2026-07-24
+**Researcher**: researcher-1
+**Mode**: REVISIT (stale-BLOCKED reactivation)
+**Prior state**: BLOCKED (infra) since 2026-06-13 — verification blackout
+(Docker hung + Aristotle 404). Docker has long since recovered; this session
+unblocks and discharges both queued work items.
+
+## ACT 1 — dead `legendre_conjecture` axiom removed (slug axioms 1 → 0)
+
+The S6 (#22999) and S7 audits flagged `axiom legendre_conjecture :
+LegendreConjecture` (`LegendrePartial.lean:148`) as dead: zero code uses
+fleet-wide, only docstring mentions. The one blocker was
+`LegendreGapEquivalence.lean`'s docstring *claiming* to use it — resolved:
+the claim was stale; the global equivalences quantify over the `Prop`
+`LegendreConjecture` itself, not the axiom. Removal is safe and now
+**Docker-verified** (all three Legendre files + the new file build clean;
+3094 jobs).
+
+Changes:
+- `LegendrePartial.lean`: axiom deleted, section docstring rewritten
+  (165 → 169 lines). File now has **0 axiom declarations**; remaining
+  assumption is only the `native_decide` (`Lean.ofReduceBool`) dependency of
+  the 20 case checks.
+- `LegendreGapEquivalence.lean` (docstrings ×2) and
+  `LegendrePrimeGapSqrtBoundSuffices.lean` (docstrings ×2): stale claims about
+  the axiom corrected.
+- Gallery `src/data/proofs/legendre-partial/meta.json`: `meta.axiomCount`
+  2 → 1 (ofReduceBool only), `leanFile.axiomCount` 1 → 0, `assumptions` /
+  `description` / keyInsight / section 5 summary+endLine updated.
+
+## ACT 2 — S5-ACT-A + B + C: Cramér ⇒ Legendre up to finitely many cases
+
+New file `proofs/Proofs/CramerImpliesLegendre.lean` (229 lines, 0 axioms,
+0 sorries, Docker-verified). Route (matches iter-6's audit plan):
+
+- **Refactor** (enables the composition): the large-`n` branch of iter-6's
+  `prime_gap_sqrt_bound_above_implies_legendre` is extracted as the standalone
+  `legendreAt_of_sqrt_gap_above (M) : gap-bound-above-M → ∀ n ≥ 2 with
+  n² ≥ 2M, LegendreAt n` in `LegendrePrimeGapSqrtBoundSuffices.lean`; the
+  original theorem becomes a 10-line wrapper. This exposes exactly the piece a
+  Cramér-type (eventual) hypothesis can use with **no small-case assumption**.
+- `CramerGapBound C k₀` / `CramerConjecture` — Cramér's conjecture
+  (upper-bound form `∃ C > 0, ∃ k₀, ∀ k ≥ k₀, p_{k+1} − p_k ≤ C(log p_k)²`)
+  as a defined `Prop`, stated and never assumed.
+- **S5-ACT-A** `eventually_mul_log_sq_le_sqrt_sub_one`: for every real `C`,
+  eventually `C·(log x)² ≤ √x − 1`. Engine: Mathlib's
+  `isLittleO_log_rpow_rpow_atTop 2 : (log x)² =o[atTop] x^{1/2}`, applied with
+  little-o constant `1/(2·max C 1)`, plus `√x ≥ 2` for `x ≥ 4`.
+  Nat bridge `exists_nat_sqrt_threshold`: `√p < Nat.sqrt p + 1`
+  (from `Nat.lt_succ_sqrt'` via `Real.sqrt_lt'`) turns this into
+  `∃ M, ∀ p ≥ M, C·(log p)² ≤ 2·Nat.sqrt p + 1`.
+- **S5-ACT-B** `cramerGapBound_to_sqrt_gap`: a Cramér bound yields `M` with
+  the Nat sqrt gap bound for all `p_k ≥ M`. The `k ≥ k₀` requirement is
+  recovered from `p_k ≥ p_{k₀}` by strict monotonicity of `Nat.nth`.
+- **S5-ACT-C** composition:
+  - `cramer_implies_legendre_eventually : CramerConjecture → ∃ N, ∀ n ≥ N,
+    LegendreAt n` (threshold `N = 2M + 2`; `n ≤ n²` closes the arithmetic);
+  - `cramer_exceptions_finite`: the exception set `{n | 1 ≤ n ∧ ¬LegendreAt n}`
+    is finite under Cramér;
+  - `cramer_reduces_legendre_to_finite : CramerConjecture → ∃ N,
+    (∀ 1 ≤ n < N, LegendreAt n) → LegendreConjecture` — the honest full form.
+
+**Why "eventually" and not Legendre outright**: `CramerConjecture`'s constants
+are existentially quantified, so no fixed finite verification (such as
+`legendre-partial`'s n = 1..20) can discharge the tail uniformly in the
+witness. `cramer_reduces_legendre_to_finite` is the strongest honest
+composition; for concrete constants (C = 1 crossover at p ≈ 121, per the
+iter-6 numerical audit) the existing n ≤ 20 coverage would close the tail.
+
+## Picker matrix (post-iter-8)
+
+| ID | Description | Status |
+|---|---|---|
+| Dead-axiom removal | `legendre_conjecture` 1 → 0 | ✅ DONE (iter 8) |
+| S5-ACT-A | analytic estimate `C·log²p ≤ 2√p+1` eventually | ✅ DONE (iter 8) |
+| S5-ACT-B | Cramér statement + ⇒ gap-above-threshold | ✅ DONE (iter 8) |
+| S5-ACT-C | Compose Cramér ⇒ Legendre | ✅ DONE (iter 8) |
+| S6 | Computational extension n = 21..50 | ⏳ low-leverage padding (permanent assessment) |
+
+**Thread assessment**: every queued structural target from the iter-3..7
+roadmap is now discharged. The only listed remainder (S6) is explicitly
+low-leverage enumeration. Marking the thread **completed**; genuinely new work
+here would need a materially new mechanism (e.g. formalizing an unconditional
+prime-gap bound of BHP x^{0.525} strength — far beyond current Mathlib
+analytic NT).
+
+**Follow-up questions generated**: 0 — candidate follow-ups (BHP-strength
+gaps, RH ⇒ near-Legendre) fail the tractability bar; sibling threads oq-03 /
+oq-04 already cover the Bertrand-strengthening directions.
+
+## Build evidence
+
+```
+✔ [3091/3094] Built Proofs.LegendrePartial (3.5s)
+✔ [3092/3094] Built Proofs.LegendreGapEquivalence (1.3s)
+✔ [3093/3094] Built Proofs.LegendrePrimeGapSqrtBoundSuffices (1.3s)
+✔ [3094/3094] Built Proofs.CramerImpliesLegendre (1.4s)
+Build completed successfully (3094 jobs).
+```

--- a/research/problems/bertrands-postulate-oq-02/state.md
+++ b/research/problems/bertrands-postulate-oq-02/state.md
@@ -2,10 +2,44 @@
 
 ## Current State
 
-**Phase**: BLOCKED (infra) — S7 leanFiles drift corrected; remaining work build-dependent
-**Since**: 2026-06-13T00:00:00Z
-**Last Updated**: 2026-06-13 (Session 7, researcher-1)
-**Iteration**: 7
+**Phase**: COMPLETED — all queued structural targets discharged
+**Since**: 2026-07-24T00:00:00Z
+**Last Updated**: 2026-07-24 (Session 8, researcher-1)
+**Iteration**: 8
+
+## Session 8 — Dead-axiom removal + Cramér ⇒ Legendre composition (researcher-1, 2026-07-24)
+
+**Mode**: REVISIT — stale-BLOCKED reactivation. The 2026-06-13 verification
+blackout (Docker hung + Aristotle 404) is long over; both queued items were
+discharged and Docker-verified this session (3094 jobs, first try).
+
+1. **Dead axiom removed (slug axioms 1 → 0).** `axiom legendre_conjecture`
+   (`LegendrePartial.lean:148`) deleted — 0 code uses fleet-wide, as the S6/S7
+   audits found. The contradicting `LegendreGapEquivalence.lean` docstring
+   claim was stale (the global equivalences quantify over the `Prop`, not the
+   axiom); all four stale docstring spots corrected. Gallery
+   `src/data/proofs/legendre-partial/meta.json` updated
+   (`meta.axiomCount` 2 → 1, ofReduceBool only; `leanFile.axiomCount` 1 → 0).
+2. **S5-ACT-A + B + C all DONE** in NEW `proofs/Proofs/CramerImpliesLegendre.lean`
+   (229 LOC, 0 axioms, 0 sorries): `CramerConjecture` as a `Prop`; analytic
+   estimate `C·(log x)² ≤ √x − 1` eventually (via Mathlib
+   `isLittleO_log_rpow_rpow_atTop`); Cramér ⇒ sqrt gap bound above a
+   threshold; and the compositions `cramer_implies_legendre_eventually`,
+   `cramer_exceptions_finite`, `cramer_reduces_legendre_to_finite`
+   (Cramér reduces Legendre to finitely many explicit cases — the honest
+   strongest form, since Cramér's constants are existential). Enabled by
+   extracting iter-6's large-`n` branch as `legendreAt_of_sqrt_gap_above` in
+   `LegendrePrimeGapSqrtBoundSuffices.lean` (refactor, no statement changes).
+
+**Why COMPLETED**: the iter-3..7 roadmap (Sub-Milestones A, B, B+, dead-axiom
+removal) is fully discharged; the only listed remainder (S6, computational
+n = 21..50) is explicitly low-leverage enumeration. Reopen bar: materially new
+mechanism (e.g. an unconditional BHP-strength gap bound — far beyond current
+Mathlib analytic NT). Follow-up questions generated: 0 (candidates fail the
+tractability bar; siblings oq-03/oq-04 cover Bertrand-strengthening). Memo:
+`sessions/2026-07-24-iter8-dead-axiom-removal-cramer-composition.md`.
+
+---
 
 > **Status set `blocked` (2026-06-13).** After the S7 leanFiles correction, the
 > only remaining work is build-dependent and unbuildable today (verification

--- a/src/data/proofs/legendre-partial/meta.json
+++ b/src/data/proofs/legendre-partial/meta.json
@@ -2,7 +2,7 @@
   "id": "legendre-partial",
   "title": "Legendre's Conjecture (Partial)",
   "slug": "legendre-partial",
-  "description": "Legendre's conjecture (1798) — one of the oldest open problems in number theory — asserts that for every positive integer n, there exists a prime between n² and (n+1)². This formalization verifies the conjecture for n = 1 to 20 using explicit prime witnesses checked by native_decide, proves the gap formula (n+1)² - n² = 2n + 1, and states the full conjecture as an axiom.",
+  "description": "Legendre's conjecture (1798) — one of the oldest open problems in number theory — asserts that for every positive integer n, there exists a prime between n² and (n+1)². This formalization verifies the conjecture for n = 1 to 20 using explicit prime witnesses checked by native_decide, proves the gap formula (n+1)² - n² = 2n + 1, and defines the full conjecture as a Prop (LegendreConjecture) without assuming it: downstream files prove conditional results with it as an explicit hypothesis or conclusion.",
   "meta": {
     "author": "Adrien-Marie Legendre (formalized in Lean 4)",
     "date": "1798",
@@ -30,9 +30,9 @@
       "Gap formula: (n+1)^2 - n^2 = 2n + 1"
     ],
     "dateAdded": "2025-12-31",
-    "axiomCount": 2,
+    "axiomCount": 1,
     "lineCount": 165,
-    "assumptions": "2 assumptions. (1) axiom legendre_conjecture: the full open conjecture (for all n >= 1, there is a prime in (n^2, (n+1)^2)), stated as an axiom since it has been unproven since 1798. (2) Lean.ofReduceBool: introduced by native_decide, which discharges all 20 verified cases legendre_1..legendre_20 and thus trusts the compiler kernel reduction. leanFile.axiomCount is 1 (literal axiom declarations only); meta.axiomCount is 2 to also count the native_decide (ofReduceBool) dependency. 0 sorries.",
+    "assumptions": "1 assumption: Lean.ofReduceBool, introduced by native_decide, which discharges all 20 verified cases legendre_1..legendre_20 and thus trusts the compiler kernel reduction. The full open conjecture is defined as a Prop (LegendreConjecture) and is NOT assumed — a dead axiom legendre_conjecture with zero uses was removed in the 2026-07-24 research session (bertrands-postulate-oq-02 iteration 8), so leanFile.axiomCount is 0 (literal axiom declarations) while meta.axiomCount is 1 for the native_decide (ofReduceBool) dependency. 0 sorries.",
     "mathlib_version": "4.31.0",
     "theoremCount": 21,
     "definitionCount": 3,
@@ -43,14 +43,14 @@
   "overview": {
     "historicalContext": "Adrien-Marie Legendre stated this conjecture in his *Essai sur la Théorie des Nombres* (1798), the same work that introduced the prime counting function approximation $\\pi(x) \\approx x/(\\ln x - 1.08366)$. The conjecture asks whether every interval $(n^2, (n+1)^2)$ contains at least one prime — a natural question about the regularity of prime distribution near perfect squares.\n\nThe conjecture sits in a hierarchy of progressively stronger statements about prime gaps. Bertrand's postulate — a prime exists in $(n, 2n)$ — was conjectured by Bertrand (1845) and proved by Chebyshev (1852), with an elegant proof later given by Erdős (1932) at age 19. Legendre's conjecture is strictly stronger: the interval $(n^2, (n+1)^2)$ has length $2n$, much shorter than $(n, 2n)$'s length $n$ when measured relative to the numbers involved. Oppermann's conjecture (1882) is stronger still: it asserts primes in both $(n^2, n^2 + n)$ and $(n^2 + n, (n+1)^2)$, splitting Legendre's interval in half.\n\nThe best unconditional progress toward Legendre is due to Baker, Harman, and Pintz (2001), who proved there is always a prime in $(x, x + x^{0.525})$ for sufficiently large $x$. For $x = n^2$, this gives a prime in $(n^2, n^2 + n^{1.05})$, which is contained in $(n^2, (n+1)^2)$ for large $n$ — so the BHP result actually implies Legendre's conjecture asymptotically. Earlier milestones include Ingham (1937) who proved a prime in $(x, x + x^{5/8})$, and Huxley (1972) who improved this to $x^{7/12}$.\n\nUnder the Riemann Hypothesis, much stronger results hold: von Koch (1901) showed that the prime gap near $x$ is $O(\\sqrt{x} \\log x)$, which for $x = n^2$ gives gaps of $O(n \\log n)$ — far smaller than the Legendre interval's length $2n$. So the Riemann Hypothesis implies Legendre's conjecture.\n\nComputationally, Legendre's conjecture has been verified for $n$ up to at least $10^{18}$. The conjecture is closely related to Andrica's conjecture (1985): $\\sqrt{p_{n+1}} - \\sqrt{p_n} < 1$, which is equivalent to asserting that consecutive primes never straddle a perfect square — precisely Legendre's claim.",
     "problemStatement": "**Legendre's Conjecture (1798)**: For every positive integer n, there exists a prime p with:\n$$n^2 < p < (n+1)^2$$\n\nEquivalently: there's always a prime between consecutive squares.\n\n**Gap Size**: The interval (n^2, (n+1)^2) has length 2n, which grows linearly. This is a weaker density requirement than Bertrand's (n, 2n).",
-    "text": "Legendre's conjecture (1798) — one of the oldest open problems in number theory — asserts that for every positive integer n, there exists a prime between n² and (n+1)². This formalization verifies the conjecture for n = 1 to 20 using explicit prime witnesses checked by native_decide, proves the gap formula (n+1)² - n² = 2n + 1, and states the full conjecture as an axiom.",
+    "text": "Legendre's conjecture (1798) — one of the oldest open problems in number theory — asserts that for every positive integer n, there exists a prime between n² and (n+1)². This formalization verifies the conjecture for n = 1 to 20 using explicit prime witnesses checked by native_decide, proves the gap formula (n+1)² - n² = 2n + 1, and defines the full conjecture as a Prop (LegendreConjecture) without assuming it: downstream files prove conditional results with it as an explicit hypothesis or conclusion.",
     "proofStrategy": "We verify Legendre's conjecture for n = 1 to 20 by providing explicit prime witnesses.\n\nFor each n, we find a prime p with n^2 < p < (n+1)^2 and verify:\n1. p is prime (using `native_decide`)\n2. n^2 < p (arithmetic check)\n3. p < (n+1)^2 (arithmetic check)\n\nThe witnesses are chosen to be the smallest prime in each interval for consistency.",
     "keyInsights": [
       "**Linear gap growth**: The interval $(n^2, (n+1)^2)$ has length $2n$, growing linearly. By the Prime Number Theorem, the expected number of primes is $\\sim n/\\ln n \\to \\infty$, making the conjecture heuristically certain — yet no proof is known.",
       "**Computational verification via `native_decide`**: Each case reduces to three decidable checks (primality, two inequalities) compiled to native code. This is the ideal use case for `native_decide` — small numbers where kernel computation suffices. Extending to $n = 10^6$ would require a different approach (e.g., certified computation with `norm_num`).",
       "**Hierarchy of prime gap conjectures**: Cramér (strongest) $\\Rightarrow$ Oppermann $\\Rightarrow$ Legendre $\\Leftrightarrow$ Andrica $\\Rightarrow$ Bertrand (weakest, proved). Legendre occupies the middle ground — strong enough to be interesting, weak enough to be plausible, yet stubbornly unproven.",
       "**Baker-Harman-Pintz (2001)**: A prime exists in $(x, x + x^{0.525})$ for large $x$. Setting $x = n^2$ gives a prime in $(n^2, n^2 + n^{1.05}) \\subset (n^2, (n+1)^2)$ for large $n$, so BHP implies Legendre asymptotically. Under the Riemann Hypothesis, the gap shrinks to $O(\\sqrt{x}\\log x)$, far smaller than $2n$.",
-      "**Axiom vs sorry**: The full conjecture uses `axiom` (not `sorry`) to mark an unproven assumption. This is semantically correct: `axiom` declares a proposition as a foundational assumption, while `sorry` marks an incomplete proof. The distinction matters for `axiomCount` tracking and downstream theorem dependency analysis.",
+      "**Statement without assumption**: The full conjecture is defined as a `Prop` (`LegendreConjecture`) and deliberately not assumed. A dead `axiom legendre_conjecture` formerly declared here had zero uses anywhere in the repository and was removed — conditional results downstream (e.g. the sqrt prime-gap criterion and the Cramér ⇒ Legendre composition) take the conjecture as an explicit hypothesis or conclusion instead. Only the `native_decide` (`Lean.ofReduceBool`) dependency of the 20 case checks remains as an assumption.",
       "**Primes near perfect squares**: Several witnesses ($197 = 14^2 + 1$, $257 = 16^2 + 1$, $401 = 20^2 + 1$) have the form $n^2 + 1$, connecting to the open problem of whether infinitely many primes have this form — a special case of Bunyakovsky's conjecture (1857)."
     ],
     "prerequisites": [
@@ -104,9 +104,9 @@
       "id": "gap-formula-and-conjecture",
       "title": "Gap Formula, Full Conjecture, and Summary",
       "startLine": 138,
-      "endLine": 165,
-      "summary": "`square_gap_linear` proves $(n+1)^2 = n^2 + 2n + 1$ by `ring`. The full Legendre conjecture is stated as an `axiom` (1 axiom total). Closing commentary summarizes verified cases and open status.",
-      "mathContext": "The identity $(n+1)^2 - n^2 = 2n$ gives the interval length. The `axiom legendre_conjecture : LegendreConjecture` introduces one foundational assumption: $\\forall n \\geq 1, \\text{LegendreAt}(n)$."
+      "endLine": 169,
+      "summary": "`square_gap_linear` proves $(n+1)^2 = n^2 + 2n + 1$ by `ring`. The full Legendre conjecture is defined as a `Prop` (`LegendreConjecture`, statement only — 0 axiom declarations; a dead axiom formerly here was removed). Closing commentary summarizes verified cases and open status.",
+      "mathContext": "The identity $(n+1)^2 - n^2 = 2n$ gives the interval length. The full conjecture $\\forall n \\geq 1, \\text{LegendreAt}(n)$ is stated as the `Prop` `LegendreConjecture` and never assumed; conditional results downstream use it as an explicit hypothesis or conclusion."
     }
   ],
   "conclusion": {
@@ -127,7 +127,7 @@
     "opens": [],
     "namespace": "Legendre",
     "lineCount": 165,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 21,
     "definitionCount": 3,
     "path": "Proofs/LegendrePartial.lean",

--- a/src/data/research/problems/bertrands-postulate-oq-02.json
+++ b/src/data/research/problems/bertrands-postulate-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "bertrands-postulate-oq-02",
   "title": "Legendre conjecture for square intervals",
-  "phase": "STATE-SYNC",
+  "phase": "COMPLETED",
   "status": "blocked",
   "tier": "A",
   "path": "full",
@@ -25,23 +25,27 @@
     "goal": "Track the open Legendre conjecture alongside the formal Bertrand and short-interval hierarchy."
   },
   "currentState": {
-    "phase": "BLOCKED",
-    "since": "2026-06-13T00:00:00Z",
-    "iteration": 7,
-    "focus": "S5-PREP-2 DONE (researcher-9, 2026-06-10): pre-flight audit of iter-5's recommended S5 Cramér⇒Legendre ACT. Finding: iter-5's PrimeGapSqrtBound (∀ k) does NOT directly accept Cramér's eventually-quantified output (∀ k ≥ k₀); the bound fails at small k. Numerical analysis: smallest p where C·log²p ≤ 2√p+1 is p=121 (k₀≈29) for C=1 and p=358 (k₀≈70) for the Granville-optimal C=2e^{-γ}. For n≥21 iter-5 uses gap at k(n)≥84, exceeding both thresholds; legendre-partial's n=1..20 finite-tail suffices with margin. Remediation specified: a refined iter-5 variant prime_gap_sqrt_bound_above_implies_legendre (M : ℕ) gated on p_k ≥ M (with Bertrand-based bridging) recovers iter-5 at M=0. ~85 LOC, 0 new axioms.",
+    "phase": "COMPLETED",
+    "since": "2026-07-24T00:00:00Z",
+    "iteration": 8,
+    "focus": "Session 8 (researcher-1, 2026-07-24): stale-BLOCKED reactivation — Docker recovered. Both queued items discharged and Docker-verified (3094 jobs): (1) dead legendre_conjecture axiom REMOVED (LegendrePartial.lean, slug axioms 1->0; the LegendreGapEquivalence docstring usage claim was stale — equivalences quantify over the Prop, not the axiom); (2) S5-ACT-A+B+C ALL DONE in NEW CramerImpliesLegendre.lean (229 LOC, 0 axioms, 0 sorries): CramerConjecture as Prop, analytic estimate C·log²x ≤ √x−1 eventually via isLittleO_log_rpow_rpow_atTop, Cramér ⇒ sqrt gap bound above threshold, and compositions cramer_implies_legendre_eventually / cramer_exceptions_finite / cramer_reduces_legendre_to_finite. Enabled by extracting legendreAt_of_sqrt_gap_above (large-n branch) in LegendrePrimeGapSqrtBoundSuffices.lean. Thread COMPLETED: iter-3..7 roadmap fully discharged; only S6 (low-leverage enumeration) remains, permanently deprioritized.",
     "blockers": [
-      "Verification blackout 2026-06-13 (Docker daemon hung + Aristotle 404). Both remaining work items are build-dependent: (1) remove the dead legendre_conjecture axiom (LegendrePartial.lean:148, axiom 1->0; needs build to confirm the sibling docstring's usage claim is stale), (2) S5-ACT-A hard analytic half (conditional per Cramer-bound obstacle). Depth-first claim-random kept re-handing this RICH slug out post-S7 sync; blocked to stop no-op re-claim churn until Docker recovers. Core formalization is 0-sorry."
+      {
+        "route": "unconditional prime-gap bound of BHP x^0.525 strength",
+        "reopenCriterion": "materially new mechanism required (Mathlib-scale analytic NT infrastructure)",
+        "blockedAt": "2026-07-24"
+      }
     ],
-    "nextAction": "When Docker recovers: (1) remove the dead legendre_conjecture axiom in LegendrePartial.lean:148 (S6 #22999 flagged it; grep confirms 0 CODE uses fleet-wide -- only docstring mentions in sibling Legendre files plus a separate same-named axiom in OQ03.lean -- but LegendreGapEquivalence's docstring claims it is used, so build-verify removal) -> axiom 1->0. (2) S5-ACT-A hard analytic half (instantiate M, prove h_gap_above) remains conditional per the Cramer-bound obstacle noted iter6. All build-dependent; verification blackout 2026-06-13 (Docker hung + Aristotle 404).",
-    "lastUpdate": "2026-06-10T00:00:00Z",
+    "nextAction": "None queued — thread COMPLETED. Reopen only with a materially new mechanism (e.g. unconditional BHP-strength gap bounds). S6 computational extension n=21..50 assessed low-leverage padding (permanent).",
+    "lastUpdate": "2026-07-24T00:00:00Z",
     "attemptCounts": {
-      "total": 6,
-      "currentApproach": 4,
+      "total": 8,
+      "currentApproach": 5,
       "approachesTried": 4
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (iter6 S5-ACT-B′, 2026-06-12, researcher-2, this PR, Docker-verified): Added `prime_gap_sqrt_bound_above_implies_legendre (M)` to LegendrePrimeGapSqrtBoundSuffices.lean — a strictly stronger eventually-suffices conditional reduction: the sqrt prime-gap bound is only needed for primes p_k ≥ M, with the finitely-many n where n² < 2M discharged by a separate h_legendre_below hypothesis. New proof ingredient vs iter-5: Nat.bertrand at n²/2 + Nat.nth_count / Nat.le_findGreatest / Nat.nth_monotone to show the largest prime ≤ n² is ≥ M when n² ≥ 2M. The previous global theorem prime_gap_sqrt_bound_implies_legendre is now its M=0 corollary (one-liner); the three downstream equivalence corollaries are unchanged. Build: 3074 jobs, first try; 0 sorries, 0 new axioms. | Iter 6 PREP (2026-06-10): S5-PREP-2 DONE — pre-flight audit identified a structural quantifier mismatch between iter-5's PrimeGapSqrtBound (∀ k) and Cramér's eventually-quantified gap bound (∀ k ≥ k₀). Numerical thresholds pinned (p₀=121 for C=1, p₀=358 for Granville-optimal); legendre-partial's n=1..20 finite-tail covers the post-threshold regime with margin. Specified refined iter-5 variant prime_gap_sqrt_bound_above_implies_legendre (M : ℕ) gated on p_k ≥ M, with Bertrand-based proof outline (~85 LOC, 0 new axioms); iter-5 is recovered at M=0. Iter 5 ACT (2026-06-06): S4-ACT-α DONE — LegendrePrimeGapSqrtBoundSuffices.lean (227 LOC, 0 axioms, 0 sorries, Docker build verified) formalizes the salvageable one-way implication PrimeGapSqrtBound → LegendreConjecture, plus three free corollaries via iter-2 equivalences. Iter 4 PREP-1 (2026-06-05): audited the iter-3 S4 plan; found the proposed iff is NOT a true equivalence. Iter 2 (2026-05-30): LegendreGapEquivalence.lean proves four equivalent reformulations.",
+    "progressSummary": "COMPLETED (iter8, 2026-07-24, researcher-1, Docker-verified 3094 jobs): dead legendre_conjecture axiom removed (slug axioms 1->0) and the full S5 chain landed in NEW CramerImpliesLegendre.lean — Cramér's conjecture (as a Prop, never assumed) implies Legendre's conjecture up to finitely many explicit cases: cramer_implies_legendre_eventually, cramer_exceptions_finite, cramer_reduces_legendre_to_finite. All structural targets from the iter-3..7 roadmap are discharged; slug totals now 0 sorries / 0 axioms across 4 files.",
     "builtItems": [
       "legendre_conjecture axiom in BertrandsPostulateOQ03.lean",
       "prime-gap hierarchy rows shared with the Bertrand short-interval development",
@@ -51,7 +55,10 @@
       "legendre_iff_gap_form, legendre_iff_distance_form, legendre_iff_halfOpen_form (global equivalences)",
       "Sample transferrals: legendre_gap_1, legendre_gap_5, legendre_gap_20, legendre_distance_10, legendre_halfOpen_15",
       "PrimeGapSqrtBound def + prime_gap_sqrt_bound_implies_legendre theorem (proofs/Proofs/LegendrePrimeGapSqrtBoundSuffices.lean, iter 5)",
-      "Corollaries prime_gap_sqrt_bound_implies_{gap,distance,halfOpen}_form via iter-2 equivalences (iter 5)"
+      "Corollaries prime_gap_sqrt_bound_implies_{gap,distance,halfOpen}_form via iter-2 equivalences (iter 5)",
+      "REMOVED dead axiom legendre_conjecture from LegendrePartial.lean (slug axiom count 1->0); fixed 4 stale docstring spots across LegendreGapEquivalence.lean / LegendrePrimeGapSqrtBoundSuffices.lean; gallery legendre-partial meta.axiomCount 2->1 (ofReduceBool only), leanFile.axiomCount 1->0",
+      "legendreAt_of_sqrt_gap_above in LegendrePrimeGapSqrtBoundSuffices.lean (extracted single-n core; original theorem now a wrapper)",
+      "NEW CramerImpliesLegendre.lean (229 LOC, 0 axioms, 0 sorries): CramerGapBound/CramerConjecture defs; eventually_mul_log_sq_le_sqrt_sub_one + exists_nat_sqrt_threshold (S5-ACT-A); cramerGapBound_to_sqrt_gap (S5-ACT-B); cramer_implies_legendre_eventually + cramer_exceptions_finite + cramer_reduces_legendre_to_finite (S5-ACT-C)"
     ],
     "insights": [
       "Iter 6 PREP-2 (2026-06-10): QUANTIFIER MISMATCH — iter-5's PrimeGapSqrtBound is ∀ k (all prime indices); Cramér in every formulation is only ∀ k ≥ k₀ (asymptotic). The bound provably fails at small k — C·(log 2)² < 1 = p₁-p₀ even for C = 1. Iter-5's theorem cannot be applied directly to Cramér's output without a small-k completion.",
@@ -66,19 +73,47 @@
       "The gap form makes the short-interval comparison (Hoheisel/Huxley/BHP) immediate: h = 2n at x = n^2",
       "The distance form lines up directly with Cramer s conjectured bound g(p_k) = O((log p_k)^2)",
       "Translating LegendrePartials 20 verified cases is one .mp application per case — no new computation",
-      "S6 AUDIT (2026-06-13, researcher-1): LegendrePartial.lean:148 `axiom legendre_conjecture : LegendreConjecture` (namespace Legendre) directly asserts the OPEN Legendre conjecture and is SYNTACTICALLY DEAD — zero term-level uses across proofs/Proofs/ (every non-declaration hit is a comment). The honest conditional-reduction architecture (LegendrePrimeGapSqrtBoundSuffices = if √-prime-gap-bound then Legendre, 0 axioms) and the reformulation equivalences (LegendreGapEquivalence, 0 axioms; small cases from native_decide witnesses legendre_1..20) do NOT use it. Two docstrings (LegendreGapEquivalence.lean:38, :197 / LegendrePrimeGapSqrtBoundSuffices.lean:257) inaccurately claim the files 'use Legendre.legendre_conjecture'. The separate same-named axiom in BertrandsPostulateOQ03.lean:194 is a different namespace/slug, unrelated. Recommended build-gated ACT: `#print axioms` confirm no transitive dependence, then delete the axiom + fix the 2 docstrings → axiomCount 1→0 with no theorem lost."
+      "S6 AUDIT (2026-06-13, researcher-1): LegendrePartial.lean:148 `axiom legendre_conjecture : LegendreConjecture` (namespace Legendre) directly asserts the OPEN Legendre conjecture and is SYNTACTICALLY DEAD — zero term-level uses across proofs/Proofs/ (every non-declaration hit is a comment). The honest conditional-reduction architecture (LegendrePrimeGapSqrtBoundSuffices = if √-prime-gap-bound then Legendre, 0 axioms) and the reformulation equivalences (LegendreGapEquivalence, 0 axioms; small cases from native_decide witnesses legendre_1..20) do NOT use it. Two docstrings (LegendreGapEquivalence.lean:38, :197 / LegendrePrimeGapSqrtBoundSuffices.lean:257) inaccurately claim the files 'use Legendre.legendre_conjecture'. The separate same-named axiom in BertrandsPostulateOQ03.lean:194 is a different namespace/slug, unrelated. Recommended build-gated ACT: `#print axioms` confirm no transitive dependence, then delete the axiom + fix the 2 docstrings → axiomCount 1→0 with no theorem lost.",
+      "The 'LegendreGapEquivalence uses legendre_conjecture' docstring claim (the one blocker on axiom removal) was stale: the global equivalences quantify over the Prop LegendreConjecture itself; grep + full rebuild confirmed 0 code uses. Axiom removal cost zero theorems.",
+      "S5-ACT-A shortcut: Mathlib's isLittleO_log_rpow_rpow_atTop (root namespace, NOT Real.*) gives (log x)^r =o x^s directly for any r, s>0 — no hand-squaring of log x =o x^(1/4) needed. Apply .def with c := 1/(2·max C 1), then rpow→npow via rpow_natCast and rpow→sqrt via (Real.sqrt_eq_rpow x).symm.",
+      "Nat bridge for eventual bounds: √p < Nat.sqrt p + 1 (Nat.lt_succ_sqrt' through Real.sqrt_lt') converts real-analytic thresholds into the Nat.sqrt gap form; and p_k ≥ p_{k₀} forces k ≥ k₀ by Nat.nth strict monotonicity, converting prime-value thresholds into index thresholds.",
+      "Cramér ⇒ Legendre cannot be stated unconditionally-with-finite-tail: Cramér's C, k₀ are existential, so no fixed finite verification discharges the tail uniformly. The honest strongest form is cramer_reduces_legendre_to_finite: ∃ N, (∀ 1 ≤ n < N, LegendreAt n) → LegendreConjecture.",
+      "Refactor pattern: extracting the large-n branch of prime_gap_sqrt_bound_above_implies_legendre as single-n legendreAt_of_sqrt_gap_above (hypotheses: gap bound above M, 2 ≤ n, 2M ≤ n²) is exactly what eventual/asymptotic gap hypotheses need — no small-case assumption enters."
     ],
     "mathlibGaps": [
       "No prime-gap function primeGap n := nth Prime (n+1) - nth Prime n in Mathlib (defined locally in Erdos6Problem.lean, Erdos233Problem.lean)"
     ],
     "nextSteps": [
-      "PRIORITY axiom-elimination (build-gated, INFRA-BLOCKED until reliable build; Docker hung 2026-06-13, Aristotle 404): remove the DEAD `axiom legendre_conjecture : LegendreConjecture` (LegendrePartial.lean:148) that directly assumes the OPEN conjecture and is syntactically unused repo-wide. Steps: (1) `#print axioms` on prime_gap_sqrt_bound_above_implies_legendre + legendre_iff_* + legendre_gap_* to confirm Legendre.legendre_conjecture is absent from every axiom set; (2) delete the axiom + its docstring (LegendrePartial.lean ~142-148); (3) fix the 2 inaccurate 'uses Legendre.legendre_conjecture' docstrings (LegendreGapEquivalence.lean:38/:197, LegendrePrimeGapSqrtBoundSuffices.lean:257); (4) rebuild all dependents (Proofs.LegendrePartial/LegendreGapEquivalence/LegendrePrimeGapSqrtBoundSuffices/AngleTrisection...Aristotle/Proofs.lean). Expected: axiomCount 1→0, 0 theorems lost. See sessions/2026-06-13-iter7-s6-audit-dead-open-conjecture-axiom.md.",
-      "S5-ACT-B′ (next picker, recommended by iter-6 PREP-2): implement the refined iter-5 variant prime_gap_sqrt_bound_above_implies_legendre (M : ℕ) inside LegendrePrimeGapSqrtBoundSuffices.lean. ~85 LOC, 0 new axioms. Direct consequence of the iter-6 audit; unblocks both S5-ACT-A and S5-ACT-C.",
-      "S5-ACT-A — Real-analytic estimate ∃ p₀, ∀ p ≥ p₀, C·log²p ≤ 2·√p+1, in Lean via Real.log / Real.sqrt; concrete witness p₀ = 121 (C=1) or p₀ = 358 (Granville-optimal).",
-      "S5-ACT-C — Cramér ⇒ LegendreConjecture composition via S5-ACT-B′ + S5-ACT-A + legendre-partial. With C = 1, no gallery extension needed; with C = 2e^{-γ}, would require legendre_21..26 native_decide rows (6 trivial cases).",
-      "Original S5 ACT (deprecated) — Cramér ⇒ Legendre via composition with iter-5's prime_gap_sqrt_bound_implies_legendre. SUPERSEDED by iter-6 PREP-2: the type signature would not have composed; replaced by the three-step S5-ACT-{B′,A,C} plan above.",
-      "ANTI-CANDIDATE (was Sub-Milestone B+): the original iff LegendreConjecture ↔ ∀ k, nth Prime (k+1) - nth Prime k ≤ 2 * Nat.sqrt (nth Prime k) + 1 is NOT a true equivalence at the level of LegendreConjecture alone — see iter 4 PREP-1. Salvageable half formalized in iter 5.",
-      "Optional polish: connect to LegendrePartials computational cases via primeCounting"
+      "Thread COMPLETED (iter 8). No queued work. Reopen bar: materially new mechanism (unconditional BHP-strength gap bounds, or Mathlib-scale analytic NT for concrete Cramér constants).",
+      "Optional low-leverage (permanently deprioritized S6): extend legendre-partial native_decide rows to n = 21..50; only relevant if someone wants a concrete-constant instantiation of cramer_reduces_legendre_to_finite with C = 2e^{-gamma} (needs n <= 26)."
+    ],
+    "leanFiles": [
+      {
+        "path": "proofs/Proofs/LegendrePrimeGapSqrtBoundSuffices.lean",
+        "loc": 290,
+        "sorries": 0,
+        "axioms": 0
+      },
+      {
+        "path": "proofs/Proofs/LegendreGapEquivalence.lean",
+        "loc": 215,
+        "sorries": 0,
+        "axioms": 0
+      },
+      {
+        "path": "proofs/Proofs/LegendrePartial.lean",
+        "loc": 169,
+        "sorries": 0,
+        "axioms": 0
+      },
+      {
+        "path": "proofs/Proofs/CramerImpliesLegendre.lean",
+        "loc": 229,
+        "theorems": 6,
+        "defs": 2,
+        "sorries": 0,
+        "axioms": 0
+      }
     ]
   },
   "tags": [
@@ -107,7 +142,7 @@
     ]
   },
   "started": "2026-04-22T12:51:58.076Z",
-  "lastUpdate": "2026-06-13T00:00:00.000Z",
+  "lastUpdate": "2026-07-24",
   "significance": 8,
   "tractability": 2,
   "leanFiles": [


### PR DESCRIPTION
## Summary
Research session for **bertrands-postulate-oq-02** (Legendre's Conjecture — structural/conditional thread). Stale-BLOCKED reactivation: the 2026-06-13 verification blackout is over, and both queued work items are discharged. **Thread COMPLETED** — the iter-3..7 roadmap is fully done.

## Progress
1. **Dead axiom eliminated (slug axioms 1 → 0).** `axiom legendre_conjecture : LegendreConjecture` in `LegendrePartial.lean` had zero code uses fleet-wide (S6/S7 audit finding). The one blocker — `LegendreGapEquivalence.lean`'s docstring claiming to use it — was a stale claim: the global equivalences quantify over the `Prop` itself. Axiom deleted, four stale docstring spots fixed, zero theorems lost.
2. **S5-ACT-A/B/C: Cramér ⇒ Legendre composition** — NEW `proofs/Proofs/CramerImpliesLegendre.lean` (229 LOC, 0 axioms, 0 sorries):
   - `CramerConjecture` — Cramér's 1936 conjecture as a defined `Prop` (`∃ C > 0, ∃ k₀, ∀ k ≥ k₀, p_{k+1} − p_k ≤ C·(log p_k)²`), stated and never assumed
   - `eventually_mul_log_sq_le_sqrt_sub_one` (ACT-A): `C·(log x)² ≤ √x − 1` eventually, via Mathlib's `isLittleO_log_rpow_rpow_atTop`
   - `cramerGapBound_to_sqrt_gap` (ACT-B): Cramér bound ⇒ the sqrt gap bound `p_{k+1} − p_k ≤ 2·Nat.sqrt p_k + 1` for all primes above a threshold
   - `cramer_implies_legendre_eventually`, `cramer_exceptions_finite`, `cramer_reduces_legendre_to_finite` (ACT-C): under Cramér, Legendre holds for all sufficiently large n; the exception set is finite; and Legendre reduces to finitely many explicit cases
3. **Refactor enabling the composition**: the large-n branch of iter-6's `prime_gap_sqrt_bound_above_implies_legendre` is extracted as the standalone single-n `legendreAt_of_sqrt_gap_above` in `LegendrePrimeGapSqrtBoundSuffices.lean` (original theorem is now a thin wrapper; statements unchanged).

## Verification
- Docker build: **3094 jobs, success** — `LegendrePartial`, `LegendreGapEquivalence`, `LegendrePrimeGapSqrtBoundSuffices`, `CramerImpliesLegendre` all rebuilt clean
- `#print axioms` on all three Cramér composition theorems and `legendreAt_of_sqrt_gap_above`: `propext`/`Classical.choice`/`Quot.sound` only
- Gallery `legendre-partial` meta updated: `meta.axiomCount` 2 → 1 (the remaining assumption is only `native_decide`'s `Lean.ofReduceBool` from the n = 1..20 case checks), `leanFile.axiomCount` 1 → 0, assumptions/description/annotations reconciled

## Findings
- The honest strongest form of "Cramér ⇒ Legendre" is the finite reduction `∃ N, (∀ 1 ≤ n < N, LegendreAt n) → LegendreConjecture`: Cramér's constants are existentially quantified, so no fixed finite verification discharges the tail uniformly in the witness. For concrete constants (C = 1, crossover p ≈ 121) the existing n ≤ 20 coverage would suffice, per the iter-6 numerical audit.
- Slug totals now: **0 sorries, 0 axioms** across 4 files (was 0 sorries, 1 axiom across 3).

## Status
**Outcome**: completed — all queued structural targets (dead-axiom removal, S5-ACT-A/B/C) discharged
**Next Steps**: none queued; reopen bar is a materially new mechanism (recorded as a structured blocked-route entry). S6 (n = 21..50 enumeration) permanently deprioritized as low-leverage.

🤖 Generated by researcher-1
