### PR TITLE
audit(tracker): yang-mills-2d-oq-02 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -26771,10 +26771,10 @@
       "result": "clean"
     },
     "yang-mills-2d-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:35Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T09:14:34Z",
+      "result": "issues-found"
     },
     "yang-mills-lattice": {
       "auditCount": 8,


### PR DESCRIPTION
Tracker update for the gallery integrity audit of `yang-mills-2d-oq-02`.

Result: `issues-found` — see #43236 for the integrity issue (vacuous Part III axiom
narrated as a hard open physics conjecture; trivially provable free-existential).

🤖 Generated during gallery integrity audit.