### PR TITLE
research(erdos-227-wip-01): Part 12 — unconditional Cauchy estimate μ(r) ≤ M(r) via ofScalars/cauchyPowerSeries bridge

### DIFF
--- a/proofs/Proofs/Erdos227Problem.lean
+++ b/proofs/Proofs/Erdos227Problem.lean
@@ -21,9 +21,12 @@
 -/
 
 import Mathlib.Analysis.Complex.Basic
+import Mathlib.Analysis.Complex.CauchyIntegral
+import Mathlib.Analysis.Analytic.OfScalars
 import Mathlib.Analysis.SpecialFunctions.Pow.Complex
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Analysis.Normed.Field.Basic
+import Mathlib.MeasureTheory.Integral.CircleIntegral
 import Mathlib.Topology.MetricSpace.Basic
 import Mathlib.Data.Real.Basic
 import Mathlib.Algebra.Order.Archimedean.Real.Basic
@@ -31,7 +34,7 @@ import Mathlib.Order.Filter.Basic
 
 namespace Erdos227
 
-open Complex Filter Topology
+open Complex Filter Topology FormalMultilinearSeries
 
 /-
 ## Part 1: Basic Definitions
@@ -427,5 +430,198 @@ theorem expFunction_ratio_le_one {r : ℝ} (hr : 0 ≤ r) :
     termModulusRatio expFunction r ≤ 1 :=
   termModulusRatio_le_one_of_nonneg expFunction hr expFunction_coeff_nonneg
     (expFunction_isEntire r hr)
+
+/-
+## Part 12: The Unconditional Cauchy Estimate — μ(r) ≤ M(r) for ALL coefficients
+
+Part 11 proved `μ(r) ≤ M(r)` only for non-negative real coefficients (where it
+is elementary: the maximum term is one summand of the positive series summing
+to `f(r)`). This part removes the coefficient hypothesis entirely via genuine
+complex analysis: the coefficients of a power series with infinite radius of
+convergence are Cauchy integrals over circles, so Cauchy's estimate
+
+    ‖aₙ‖ · rⁿ ≤ max_{|z| = r} ‖f(z)‖ = M(r)
+
+holds for every `n` and every `r > 0`.
+
+The Mathlib bridge: `FormalMultilinearSeries.ofScalars ℂ f.coeff` packages the
+coefficients as a formal power series `p`; `IsEntire` forces `p.radius = ⊤`,
+so `p.sum` is an entire function represented by `p`
+(`FormalMultilinearSeries.hasFPowerSeriesOnBall`), hence differentiable.
+`Differentiable.hasFPowerSeriesOnBall` represents the same function by the
+Cauchy power series `cauchyPowerSeries p.sum 0 r` on every ball, and
+one-dimensional uniqueness (`HasFPowerSeriesAt.eq_formalMultilinearSeries`)
+identifies the two series. Mathlib's `norm_cauchyPowerSeries_le` then bounds
+`‖aₙ‖` by the circle average of `‖f‖` times `r⁻ⁿ`, and the circle average is
+at most the sup `M(r)`.
+
+Consequences: the ratio bound `μ/M ≤ 1` and the limit membership `L ∈ [0, 1]`
+now hold for EVERY genuinely entire function — the Part-11 `_of_nonneg`
+versions become special cases. The deep Clunie–Hayman refinement (`L ≤ 1/2`)
+remains axiomatized; this part is axiom-free.
+-/
+
+/-- The sum function `z ↦ Σ aₙ zⁿ` of the power series, packaged as
+`FormalMultilinearSeries.sum` of the scalar series. -/
+noncomputable def seriesSum (f : EntireFunction) : ℂ → ℂ :=
+  (ofScalars ℂ f.coeff).sum
+
+/-- `seriesSum` is pointwise the naive `tsum` of the power series. -/
+theorem seriesSum_apply (f : EntireFunction) (z : ℂ) :
+    seriesSum f z = ∑' n, f.coeff n * z ^ n := by
+  have h := ofScalars_sum_eq (E := ℂ) f.coeff z
+  simpa [seriesSum, ofScalarsSum, smul_eq_mul] using h
+
+/-- Genuine entireness forces infinite radius of convergence for the
+formal scalar series. -/
+theorem ofScalars_radius_eq_top (f : EntireFunction) (hent : IsEntire f) :
+    (ofScalars ℂ f.coeff).radius = ⊤ := by
+  refine ENNReal.eq_top_of_forall_nnreal_le fun r => ?_
+  refine le_radius_of_summable _ ?_
+  refine ((hent r r.coe_nonneg).congr fun n => ?_)
+  rw [ofScalars_norm]
+
+/-- The sum function is represented by the scalar series on all of `ℂ`. -/
+theorem hasFPowerSeriesOnBall_seriesSum (f : EntireFunction) (hent : IsEntire f) :
+    HasFPowerSeriesOnBall (seriesSum f) (ofScalars ℂ f.coeff) 0 ⊤ := by
+  have h := (ofScalars ℂ f.coeff).hasFPowerSeriesOnBall
+    (by rw [ofScalars_radius_eq_top f hent]; simp)
+  rwa [ofScalars_radius_eq_top f hent] at h
+
+/-- A genuinely entire `f` has a complex-differentiable sum function. -/
+theorem differentiable_seriesSum (f : EntireFunction) (hent : IsEntire f) :
+    Differentiable ℂ (seriesSum f) := by
+  intro z
+  have h := hasFPowerSeriesOnBall_seriesSum f hent
+  exact (h.analyticAt_of_mem (by simp)).differentiableAt
+
+/-- Pointwise bound on the circle: `‖(seriesSum f)(circleMap 0 r θ)‖ ≤ M(r)`.
+The parametrisations `circleMap 0 r θ = r·e^{θi}` and `r·e^{iθ}` agree. -/
+theorem norm_seriesSum_circleMap_le (f : EntireFunction) {r : ℝ} (hr : 0 ≤ r)
+    (hent : IsEntire f) (θ : ℝ) :
+    ‖seriesSum f (circleMap 0 r θ)‖ ≤ maxModulus f r := by
+  have hmap : circleMap 0 r θ = (r : ℂ) * exp (I * θ) := by
+    rw [circleMap_zero, mul_comm I (θ : ℂ)]
+  rw [hmap, seriesSum_apply]
+  exact le_ciSup (bddAbove_range_norm f hr (hent r hr)) θ
+
+/-- **Cauchy's estimate, unconditional**: for a genuinely entire function and
+every `r > 0`, each term of the power series is bounded by the maximum
+modulus: `‖aₙ‖ · rⁿ ≤ M(r)`. No hypothesis on the coefficients. -/
+theorem norm_coeff_mul_pow_le_maxModulus (f : EntireFunction) {r : ℝ} (hr : 0 < r)
+    (hent : IsEntire f) (n : ℕ) :
+    ‖f.coeff n‖ * r ^ n ≤ maxModulus f r := by
+  set R : NNReal := ⟨r, hr.le⟩ with hR
+  have hRpos : 0 < R := by
+    rw [← NNReal.coe_lt_coe]
+    exact hr
+  have hRr : (R : ℝ) = r := rfl
+  -- the Cauchy series at radius r equals the scalar series, by uniqueness
+  have h1 : HasFPowerSeriesAt (seriesSum f) (ofScalars ℂ f.coeff) 0 :=
+    (hasFPowerSeriesOnBall_seriesSum f hent).hasFPowerSeriesAt
+  have h2 : HasFPowerSeriesAt (seriesSum f)
+      (cauchyPowerSeries (seriesSum f) 0 R) 0 :=
+    ((differentiable_seriesSum f hent).hasFPowerSeriesOnBall 0 hRpos).hasFPowerSeriesAt
+  have heq : ofScalars ℂ f.coeff = cauchyPowerSeries (seriesSum f) 0 R :=
+    h1.eq_formalMultilinearSeries h2
+  -- Cauchy's coefficient bound
+  have hbound := norm_cauchyPowerSeries_le (seriesSum f) 0 R n
+  rw [← heq, ofScalars_norm] at hbound
+  -- bound the circle average by the sup M(r)
+  have hFcont : Continuous fun θ : ℝ => ‖seriesSum f (circleMap 0 (R : ℝ) θ)‖ :=
+    ((differentiable_seriesSum f hent).continuous.comp
+      (continuous_circleMap 0 (R : ℝ))).norm
+  have hint : (∫ θ : ℝ in (0)..(2 * Real.pi), ‖seriesSum f (circleMap 0 (R : ℝ) θ)‖)
+      ≤ 2 * Real.pi * maxModulus f r := by
+    have hmono : ∀ θ ∈ Set.Icc (0 : ℝ) (2 * Real.pi),
+        ‖seriesSum f (circleMap 0 (R : ℝ) θ)‖ ≤ maxModulus f r := fun θ _ => by
+      rw [hRr]
+      exact norm_seriesSum_circleMap_le f hr.le hent θ
+    calc (∫ θ : ℝ in (0)..(2 * Real.pi), ‖seriesSum f (circleMap 0 (R : ℝ) θ)‖)
+        ≤ ∫ _ : ℝ in (0)..(2 * Real.pi), maxModulus f r :=
+          intervalIntegral.integral_mono_on (by positivity)
+            (hFcont.intervalIntegrable _ _) intervalIntegrable_const hmono
+      _ = 2 * Real.pi * maxModulus f r := by
+          rw [intervalIntegral.integral_const, smul_eq_mul, sub_zero]
+  -- assemble: ‖aₙ‖ ≤ M(r) · r⁻ⁿ, then multiply through by rⁿ
+  have hC : ((2 * Real.pi)⁻¹ *
+      ∫ θ : ℝ in (0)..(2 * Real.pi), ‖seriesSum f (circleMap 0 (R : ℝ) θ)‖)
+      ≤ maxModulus f r := by
+    have hstep := mul_le_mul_of_nonneg_left hint
+      (by positivity : (0 : ℝ) ≤ (2 * Real.pi)⁻¹)
+    calc (2 * Real.pi)⁻¹ *
+        ∫ θ : ℝ in (0)..(2 * Real.pi), ‖seriesSum f (circleMap 0 (R : ℝ) θ)‖
+        ≤ (2 * Real.pi)⁻¹ * (2 * Real.pi * maxModulus f r) := hstep
+      _ = maxModulus f r := by
+          field_simp
+  have hcoeff : ‖f.coeff n‖ ≤ maxModulus f r * (r⁻¹) ^ n := by
+    have habs : |(R : ℝ)| = r := by rw [hRr, abs_of_pos hr]
+    have hstep := hbound.trans
+      (mul_le_mul_of_nonneg_right hC (by positivity : (0 : ℝ) ≤ |(R : ℝ)|⁻¹ ^ n))
+    rwa [habs] at hstep
+  calc ‖f.coeff n‖ * r ^ n
+      ≤ (maxModulus f r * (r⁻¹) ^ n) * r ^ n := by
+        gcongr
+    _ = maxModulus f r := by
+        rw [mul_assoc, ← mul_pow, inv_mul_cancel₀ (ne_of_gt hr), one_pow, mul_one]
+
+/-- **Unconditional `μ(r) ≤ M(r)`** for every genuinely entire function and
+every `r ≥ 0` — the Part-11 `maxTerm_le_maxModulus_of_nonneg` without the
+non-negativity hypothesis. `r > 0` is Cauchy's estimate; at `r = 0` both
+sides collapse to `‖a₀‖`. -/
+theorem maxTerm_le_maxModulus (f : EntireFunction) {r : ℝ} (hr : 0 ≤ r)
+    (hent : IsEntire f) :
+    maxTerm f r ≤ maxModulus f r := by
+  rcases hr.eq_or_lt with rfl | hrpos
+  · -- r = 0: every term with n > 0 vanishes and the n = 0 term is ‖a₀‖ = ‖f(0)‖
+    apply ciSup_le
+    intro n
+    have h0 : ‖∑' m, f.coeff m * ((0 : ℝ) * exp (I * (0 : ℝ))) ^ m‖ = ‖f.coeff 0‖ := by
+      have hz : ((0 : ℝ) : ℂ) * exp (I * (0 : ℝ)) = 0 := by simp
+      rw [hz]
+      have : (∑' m, f.coeff m * (0 : ℂ) ^ m) = f.coeff 0 := by
+        rw [tsum_eq_single 0 (fun m hm => by
+          rw [zero_pow hm, mul_zero])]
+        simp
+      rw [this]
+    have hM : ‖f.coeff 0‖ ≤ maxModulus f 0 := by
+      rw [← h0]
+      exact le_ciSup (bddAbove_range_norm f le_rfl (hent 0 le_rfl)) (0 : ℝ)
+    rcases Nat.eq_zero_or_pos n with rfl | hn
+    · simpa using hM
+    · have hzero : ‖f.coeff n‖ * (0 : ℝ) ^ n = 0 := by
+        rw [zero_pow hn.ne', mul_zero]
+      rw [hzero]
+      exact Real.iSup_nonneg fun _ => norm_nonneg _
+  · exact ciSup_le fun n => norm_coeff_mul_pow_le_maxModulus f hrpos hent n
+
+/-- The term/modulus ratio is at most `1` for every genuinely entire function
+— unconditional version of `termModulusRatio_le_one_of_nonneg`. -/
+theorem termModulusRatio_le_one (f : EntireFunction) {r : ℝ} (hr : 0 ≤ r)
+    (hent : IsEntire f) :
+    termModulusRatio f r ≤ 1 := by
+  rcases (maxModulus_nonneg f r).eq_or_lt with hM | hM
+  · unfold termModulusRatio
+    rw [← hM, div_zero]
+    exact zero_le_one
+  · unfold termModulusRatio
+    rw [div_le_one hM]
+    exact maxTerm_le_maxModulus f hr hent
+
+/-- Any limit of the term/modulus ratio of a genuinely entire function lies in
+`[0, 1]` — unconditional version of `limit_mem_Icc_of_nonneg`. Together with
+the axiomatized Clunie–Hayman results (`ratio_upper_bound`: `L ≤ 1/2`;
+`clunie_hayman_1964`: every `L ∈ [0, 1/2]` is achieved), this brackets the
+achievable-limit analysis with an axiom-free outer bound. -/
+theorem limit_mem_Icc (f : EntireFunction) (hent : IsEntire f) {L : ℝ}
+    (hL : Tendsto (termModulusRatio f) atTop (nhds L)) :
+    L ∈ Set.Icc (0 : ℝ) 1 := by
+  constructor
+  · refine ge_of_tendsto hL ?_
+    filter_upwards [eventually_ge_atTop (0 : ℝ)] with r hr
+    exact termModulusRatio_nonneg f hr
+  · refine le_of_tendsto hL ?_
+    filter_upwards [eventually_ge_atTop (0 : ℝ)] with r hr
+    exact termModulusRatio_le_one f hr hent
 
 end Erdos227

--- a/research/problems/erdos-227-wip-01/sessions/2026-07-24-s3-act-cauchy-estimate-bridge.md
+++ b/research/problems/erdos-227-wip-01/sessions/2026-07-24-s3-act-cauchy-estimate-bridge.md
@@ -1,0 +1,62 @@
+# S3 ACT — Unconditional Cauchy estimate μ(r) ≤ M(r) (Part 12)
+
+**Date**: 2026-07-24
+**Researcher**: researcher-2
+**Branch**: `research/erdos-227-wip01-cauchy-estimate-bridge`
+**Build**: host `lake env lean` clean; Docker verification run before PR.
+
+## What landed
+
+The state.md route-1 target: the **HasFPowerSeriesOnBall bridge** giving the
+unconditional Cauchy estimate. Part 11's `μ(r) ≤ M(r)` needed non-negative
+real coefficients (elementary argument). Part 12 (new, ~200 LOC) removes the
+coefficient hypothesis entirely:
+
+* `seriesSum f := (ofScalars ℂ f.coeff).sum`, with `seriesSum_apply`
+  identifying it with the naive `∑' n, aₙ zⁿ`.
+* `ofScalars_radius_eq_top` — `IsEntire` ⇒ radius = ⊤, via
+  `ENNReal.eq_top_of_forall_nnreal_le` + `le_radius_of_summable` +
+  `ofScalars_norm` (ℂ is `NormOneClass`).
+* `hasFPowerSeriesOnBall_seriesSum`, `differentiable_seriesSum`.
+* `norm_coeff_mul_pow_le_maxModulus` — **Cauchy's estimate** `‖aₙ‖rⁿ ≤ M(r)`
+  for `r > 0`: uniqueness (`HasFPowerSeriesAt.eq_formalMultilinearSeries`,
+  one-dimensional 𝕜 = ℂ) identifies `ofScalars ℂ f.coeff` with
+  `cauchyPowerSeries (seriesSum f) 0 R`; `norm_cauchyPowerSeries_le` bounds
+  `‖aₙ‖ ≤ ((2π)⁻¹ ∫₀^{2π} ‖f(circleMap 0 r θ)‖) · r⁻ⁿ`; the circle average
+  is ≤ M(r) by `intervalIntegral.integral_mono_on` (integrand continuous:
+  `Differentiable.continuous.comp continuous_circleMap`).
+* `maxTerm_le_maxModulus` — unconditional, `0 ≤ r` (at `r = 0` both sides are
+  `‖a₀‖`; `tsum_eq_single 0` collapses the series).
+* `termModulusRatio_le_one`, `limit_mem_Icc` — unconditional `L ∈ [0,1]`
+  bracket; Part-11 `_of_nonneg` versions are now special cases.
+
+0 new axioms, 0 new sorries. File: 431 → ~640 lines. The 3 deep axioms
+(Clunie / Clunie–Hayman) and the 1 sorry (`positive_coeffs_normal`,
+Wiman–Valiron) are untouched — still "materially new mechanism required".
+
+## Mathlib API notes (v4.31)
+
+* `FormalMultilinearSeries.ofScalars E c` (E explicit), `ofScalars_norm`
+  needs `[NormOneClass E]`; `coeff_ofScalars`; `ofScalars_sum_eq` states
+  `ofScalarsSum c x = ∑' n, c n • x ^ n` — unfold `ofScalarsSum` to reach
+  `(ofScalars E c).sum`.
+* `ENNReal.top_pos` is GONE — use `simp` (or `zero_lt_top`).
+* `le_radius_of_summable` lives in `Analysis/Analytic/ConvergenceRadius.lean`.
+* `cauchyPowerSeries` + `norm_cauchyPowerSeries_le` live in
+  `MeasureTheory/Integral/CircleIntegral.lean`; `circleMap` in
+  `Analysis/SpecialFunctions/Complex/CircleMap.lean`
+  (`circleMap 0 R θ = R * exp (θ * I)` — note `θ * I`, not `I * θ`;
+  bridge with `mul_comm`).
+* `Differentiable.hasFPowerSeriesOnBall` takes `R : ℝ≥0`, yields radius `∞`;
+  build `R := ⟨r, hr.le⟩` and `(R : ℝ) = r` is `rfl`.
+* `gcongr` auto-discharges nonneg side conditions — a following bullet
+  `exact ...` then errors "No goals to be solved"; don't pre-supply them.
+
+## Next
+
+Remaining routes unchanged from state.md: the sorry and 3 axioms need
+Clunie/Clunie–Hayman/Wiman–Valiron theory absent from Mathlib (DEEP).
+The elementary + bridge layers are now both saturated. Plausible future
+increments: relate `maxModulus` to `sSup` over the closed ball via the
+maximum principle (Mathlib `Complex.AbsMax`), or an `AnalyticAt`-based
+restatement of `IsEntire`.

--- a/research/problems/erdos-227-wip-01/state.md
+++ b/research/problems/erdos-227-wip-01/state.md
@@ -3,24 +3,31 @@
 ## Current State
 **Phase**: ACT
 **Path**: full
-**Since**: 2026-07-22
-**Iteration**: 2
+**Since**: 2026-07-24
+**Iteration**: 3
 
 ## Current Focus
-Elementary maxTerm/maxModulus layer landed (Part 11, 13 axiom-free theorems,
-session 2026-07-22): IsEntire predicate, μ(r) ≤ M(r) for non-negative
-coefficients, ratio ≤ 1, ratio limits in [0,1], exp witness.
+Route 1 (the optional Mathlib bridge) is DONE: Part 12 (session 2026-07-24,
+researcher-2, 10 new axiom-free theorems) proves the **unconditional** Cauchy
+estimate `μ(r) ≤ M(r)` for every genuinely entire function — no coefficient
+hypothesis — via `FormalMultilinearSeries.ofScalars` + radius = ⊤ +
+one-dimensional power-series uniqueness + `norm_cauchyPowerSeries_le`.
+Corollaries `termModulusRatio_le_one` and `limit_mem_Icc` (L ∈ [0,1]) are now
+unconditional; the Part-11 `_of_nonneg` versions are special cases.
+Docker build exit 0. Sorry/axiom profile unchanged (1 sorry, 3 axioms).
 
 ## Active Approach
-Elementary-layer saturation done. Remaining routes:
-1. OPTIONAL Mathlib bridge to HasFPowerSeriesOnBall for the unconditional
-   Cauchy estimate μ(r) ≤ M(r) (~300–500 lines).
-2. DEEP (blocked): the sorry (`positive_coeffs_normal`) and all 3 axioms need
+Both the elementary layer (Part 11) and the complex-analytic bridge (Part 12)
+are saturated. Remaining:
+1. DEEP (blocked): the sorry (`positive_coeffs_normal`) and all 3 axioms need
    Clunie / Clunie–Hayman / Wiman–Valiron theory absent from Mathlib.
+2. OPTIONAL polish veins (small): maximum-principle restatement of
+   `maxModulus` via `Complex.AbsMax`; `AnalyticAt`-based characterisation of
+   `IsEntire`.
 
 ## Attempt Count
-- Total attempts: 1
-- Current approach attempts: 1
+- Total attempts: 3
+- Current approach attempts: 3
 - Approaches tried: 1
 
 ## Blockers
@@ -28,5 +35,13 @@ Elementary-layer saturation done. Remaining routes:
   Wiman–Valiron theory and the Clunie–Hayman constructions).
 
 ## Next Action
-If re-served: attempt the HasFPowerSeriesOnBall bridge (route 1). Do not
-re-attempt axiom/sorry elimination from current Mathlib.
+If re-served: only the small polish veins above, or stand down — do NOT
+re-attempt axiom/sorry elimination from current Mathlib, and route 1
+(HasFPowerSeriesOnBall bridge) is already done (session 2026-07-24).
+
+## Session History
+- 2026-07-22 (iteration 2): Part 11 elementary layer — 13 axiom-free
+  theorems: IsEntire, μ(r) ≤ M(r) for non-negative coefficients, ratio ≤ 1,
+  limits in [0,1], exp witness.
+- 2026-07-24 (iteration 3): Part 12 Cauchy-estimate bridge — unconditional
+  μ(r) ≤ M(r); see sessions/2026-07-24-s3-act-cauchy-estimate-bridge.md.

--- a/src/data/research/problems/erdos-227-wip-01.json
+++ b/src/data/research/problems/erdos-227-wip-01.json
@@ -21,19 +21,19 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-07-09T17:33:19-07:00",
-    "iteration": 2,
-    "focus": "Elementary maxTerm/maxModulus layer proved axiom-free; deep Clunie/Clunie-Hayman core remains axiomatized",
+    "since": "2026-07-24T00:00:00.000Z",
+    "iteration": 3,
+    "focus": "S3 (researcher-2, 2026-07-24): ACT — Part 12 Cauchy-estimate bridge landed. Unconditional μ(r) ≤ M(r) for every genuinely entire function (no coefficient hypothesis): FormalMultilinearSeries.ofScalars packages the coefficients, IsEntire forces radius = ⊤, the sum function is differentiable, one-dimensional uniqueness identifies the scalar series with cauchyPowerSeries, and norm_cauchyPowerSeries_le bounds ‖aₙ‖rⁿ by the circle average ≤ M(r). Corollaries termModulusRatio_le_one and limit_mem_Icc (L ∈ [0,1]) now unconditional. 10 new axiom-free theorems, 0 new sorries. Docker build exit 0. Sorry/axiom profile unchanged (1 sorry, 3 axioms — Clunie/Clunie–Hayman/Wiman–Valiron, absent from Mathlib).",
     "blockers": [],
-    "nextAction": "Optional: bridge EntireFunction to Mathlib HasFPowerSeriesOnBall to get Cauchy estimate mu(r) <= M(r) unconditionally (not just nonneg coeffs)",
+    "nextAction": "Only small polish veins remain (Complex.AbsMax maximum-principle restatement of maxModulus; AnalyticAt characterisation of IsEntire) — or stand down. Do NOT re-attempt axiom/sorry elimination; route 1 (HasFPowerSeriesOnBall bridge) is done.",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 1,
+      "total": 3,
+      "currentApproach": 3,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Part 11 added (13 axiom-free theorems, session 2026-07-22). IsEntire predicate fixes the structure gap (EntireFunction never required convergence). Proved mu(r) <= M(r) for nonneg real coefficients (Clunie setting), ratio <= 1, and any ratio limit lies in [0,1] — elementary companion to the deep axiomatized L <= 1/2 (ratio_upper_bound) and L = 0 (clunie_positive_coeffs). expFunction (coeffs 1/n!) is a concrete IsEntire witness. Remaining sorry (positive_coeffs_normal) and all 3 axioms are Clunie/Clunie-Hayman-deep: NOT provable from current Mathlib.",
+    "progressSummary": "Elementary layer (Part 11) AND complex-analytic bridge (Part 12) both saturated: μ(r) ≤ M(r) holds unconditionally via Cauchy's estimate; ratio ≤ 1 and limit ∈ [0,1] axiom-free for all genuinely entire functions. Remaining sorry + 3 axioms are DEEP (Wiman–Valiron / Clunie–Hayman theory absent from Mathlib).",
     "builtItems": [
       "IsEntire predicate + maxTerm_nonneg/maxModulus_nonneg (Erdos227Problem.lean Part 11)",
       "norm_series_term / summable_series_term / norm_tsum_le_sum_norm / bddAbove_range_norm / maxModulus_le_tsum (circle-of-radius-r toolkit)",
@@ -77,7 +77,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.780Z",
-  "lastUpdate": "2026-07-22T20:00:00Z",
+  "lastUpdate": "2026-07-24",
   "significance": 6,
   "tractability": 7
 }


### PR DESCRIPTION
## Summary

Lands the route flagged in `state.md` as the remaining non-DEEP work on erdos-227-wip-01: the **HasFPowerSeriesOnBall bridge** giving the unconditional Cauchy estimate. Part 11 (2026-07-22) proved `μ(r) ≤ M(r)` only for non-negative real coefficients; the new **Part 12** removes the coefficient hypothesis entirely via genuine complex analysis.

## Mathematical content

For a genuinely entire `f` (i.e. `IsEntire f`: absolute convergence at every radius) and every `r > 0`:

- `norm_coeff_mul_pow_le_maxModulus` — **Cauchy's estimate** `‖aₙ‖·rⁿ ≤ M(r)`, no hypothesis on the coefficients.
- `maxTerm_le_maxModulus` — unconditional `μ(r) ≤ M(r)` for all `r ≥ 0` (at `r = 0` both sides collapse to `‖a₀‖`).
- `termModulusRatio_le_one`, `limit_mem_Icc` — the ratio bound and the limit bracket `L ∈ [0, 1]` now hold for every genuinely entire function; the Part-11 `_of_nonneg` versions become special cases.

## Proof route (all in Mathlib, no new axioms)

`FormalMultilinearSeries.ofScalars ℂ f.coeff` packages the coefficients; `IsEntire` forces `radius = ⊤` (`le_radius_of_summable` + `ofScalars_norm`); `p.sum` is represented by `p` on all of `ℂ` and hence differentiable; `Differentiable.hasFPowerSeriesOnBall` represents the same function by `cauchyPowerSeries` on every ball; one-dimensional uniqueness (`HasFPowerSeriesAt.eq_formalMultilinearSeries`) identifies the two series; `norm_cauchyPowerSeries_le` bounds `‖aₙ‖` by the circle average of `‖f‖` times `r⁻ⁿ`, and the average is at most the sup `M(r)` (`intervalIntegral.integral_mono_on`).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos227Problem` — **exit 0** (2686 jobs).
- 10 new theorems + 1 def, all axiom-free, **0 new sorries**. File 431 → 640 lines.
- Sorry/axiom profile unchanged: 1 sorry (`positive_coeffs_normal`), 3 axioms (Clunie / Clunie–Hayman / Wiman–Valiron — absent from Mathlib, still DEEP). Gallery meta (`sorries: 1`, `axiomCount: 3`, badge `wip`) remains accurate.

## Docs

- `state.md` → iteration 3, route 1 marked DONE; do-not-re-chase guidance updated.
- New session note `sessions/2026-07-24-s3-act-cauchy-estimate-bridge.md` with v4.31 API notes (`ENNReal.top_pos` gone; `circleMap` uses `θ * I`; `gcongr` auto-discharges nonneg side goals).
- `src/data/research/problems/erdos-227-wip-01.json` refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
