### PR TITLE
audit: re-serve cevas-theorem-oq-02-oq-01-oq-03 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5747,9 +5747,9 @@
       "issues": []
     },
     "cevas-theorem-oq-02-oq-01-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:35Z",
+      "lastAudited": "2026-07-24T09:17:32Z",
       "result": "clean"
     },
     "cevas-theorem-oq-02-oq-02": {


### PR DESCRIPTION
## Reserve-mode audit (queue fully drained: 4813/4813, 0 issues)

**Proof**: cevas-theorem-oq-02-oq-01-oq-03
**Result**: clean, no changes needed to meta.json

## Verification

- Theorem count: 19/19 match (docstring's internal "18 theorems" line is a stale
  harmless undercount, per established convention)
- Axioms: 0 (grep confirms no `axiom` declarations)
- Sorries: 0
- No `native_decide`, no True-stub theorems
- `mathlibDependencies` (mul_right_cancel₀, div_eq_div_iff, div_mul_cancel₀,
  mul_lt_mul_of_pos_right) all verified present and load-bearing in the file
- `crossReferences` targets (cevas-theorem, cevas-theorem-oq-02,
  cevas-theorem-oq-02-oq-01, cevas-theorem-oq-02-oq-01-oq-02) all have real
  gallery directories
- Core claim verified: `weight_division_ratio` genuinely proves BD/DC = β/α
  as described in the overview/conclusion

Only updates `audit-tracker.json` (auditCount 2→3, lastAudited, result: clean).

---
Discovered during gallery integrity audit (reserve mode).