### PR TITLE
Fix: yang-mills-2d-oq-02 vacuous axiom → proved theorem (#43236)

### DIFF
--- a/proofs/Proofs/YangMills2DOQ02.lean
+++ b/proofs/Proofs/YangMills2DOQ02.lean
@@ -13,10 +13,12 @@
   This file proves:
   - Part I: In 2D, the potential ratio exactly equals the Casimir ratio for all r > 0
   - Part II: String breaking implies the potential ratio decreases after r_break
-  - Part III: The 4D approximate Casimir scaling conjecture (axiomatized as open)
+  - Part III: The 4D approximate Casimir scaling predicate (with a formalization caveat)
 
-  Parts I and II: 0 axioms, 0 sorries.
-  Part III: 1 axiom (the open 4D conjecture).
+  Parts I, II, and III: 0 axioms, 0 sorries.
+  Part III note: the free-existential predicate is a tautology of real analysis and is
+  stated as a proved theorem, NOT an axiom. It does not capture the (still open) physical
+  small-ε conjecture, which needs an explicit bound on ε (see the caveat before Part III).
 
   References:
   - Migdal, "Recursion equations in gauge theories" (1975)
@@ -180,7 +182,7 @@ theorem exact_casimir_scaling_fails_4d
   exact ⟨h_ratio, h_post, h_post.trans_eq h_ratio.symm⟩
 
 -- ============================================================
--- PART III: 4D Approximate Casimir Scaling (Axiomatized as Open)
+-- PART III: 4D Approximate Casimir Scaling (a formalization caveat)
 -- ============================================================
 
 /-
@@ -189,27 +191,40 @@ approximate Casimir scaling at intermediate distances (r < r_break):
 
   |σ_R/σ_fund - C₂(R)/C₂(fund)| < ε  for small ε > 0
 
-The deviation arises from non-perturbative QCD effects. Proving this analytically
-requires constructive QFT methods beyond current Mathlib infrastructure.
+The genuine physics conjecture asserts this holds for a SMALL, physically-motivated
+ε tied to measured lattice deviations. That statement is genuinely open and would
+require constructive QFT methods beyond current Mathlib.
 
 Key lattice measurements (Bali et al. 2000):
   SU(2): σ_adj/σ_fund = C₂(adj)/C₂(fund) = 8/3 ≈ 2.67, measured ≈ 2.5 ± 0.2
   SU(3): σ_adj/σ_fund = C₂(adj)/C₂(fund) = 9/4 = 2.25, measured ≈ 2.2 ± 0.1
+
+CAVEAT (formalization honesty): the predicate below, with ε a *free, unbounded*
+existential, does NOT capture that physics. Any two reals are within |x - y| + 1
+of each other, so `∃ ε, ApproximateCasimirScaling4D ...` is a tautology of real
+analysis — it holds unconditionally, needs no positivity hypotheses, and encodes
+zero physical content. We therefore state it as an ordinary `theorem` (proved
+trivially), NOT an axiom, so the entry makes no false "open conjecture" claim.
+Formalizing the real conjecture requires an explicit, physically-grounded bound
+on ε (e.g. ε ≤ 0.2 for SU(2)); that remains future work.
 -/
 
 /-- Approximate Casimir scaling: the string tension ratio is within ε of the Casimir ratio. -/
 def ApproximateCasimirScaling4D (sigma_R sigma_fund casimir_R casimir_fund ε : ℝ) : Prop :=
   ε > 0 ∧ |sigma_R / sigma_fund - casimir_R / casimir_fund| < ε
 
-/-- **Conjecture (OPEN)**: 4D Yang-Mills exhibits approximate Casimir scaling at intermediate
-    distances. The approximation error ε is small but nonzero due to non-perturbative effects.
-
-    Status: Supported by lattice QCD (Bali et al. 2000) but not analytically proved.
-    Proving this requires non-perturbative QFT methods beyond current Mathlib. -/
-axiom casimir_scaling_4d_approximate :
+/-- The free-existential form of approximate Casimir scaling is a **tautology**, not an
+    open conjecture: for any reals it holds with `ε := |σ_R/σ_fund - C₂(R)/C₂(fund)| + 1`,
+    without any positivity hypotheses. This makes explicit that the predicate as written
+    does not encode the physical (small-ε) conjecture — see the caveat above. -/
+theorem casimir_scaling_4d_approximate :
     ∀ (sigma_R sigma_fund casimir_R casimir_fund : ℝ),
     sigma_R > 0 → sigma_fund > 0 → casimir_R > 0 → casimir_fund > 0 →
-    ∃ ε : ℝ, ApproximateCasimirScaling4D sigma_R sigma_fund casimir_R casimir_fund ε
+    ∃ ε : ℝ, ApproximateCasimirScaling4D sigma_R sigma_fund casimir_R casimir_fund ε := by
+  intro sR sf cR cf _ _ _ _
+  refine ⟨|sR / sf - cR / cf| + 1, ?_, ?_⟩
+  · positivity
+  · linarith [abs_nonneg (sR / sf - cR / cf)]
 
 -- ============================================================
 -- SUMMARY

--- a/src/data/proofs/yang-mills-2d-oq-02/meta.json
+++ b/src/data/proofs/yang-mills-2d-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Migdal (1975); Bali et al. (2000)",
     "date": "2000",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/YangMills2DOQ02.lean",
     "tags": [
       "mathematical-physics",
@@ -17,11 +17,11 @@
       "confinement",
       "open-problem"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 1,
-    "assumptions": "1 axiom: casimir_scaling_4d_approximate (the 4D approximate Casimir scaling conjecture). Parts I and II are fully proved: 2D exact scaling follows from Migdal formula; exact 4D scaling fails from string breaking.",
+    "axiomCount": 0,
+    "assumptions": "None. Parts I and II are fully proved: 2D exact Casimir scaling follows from the Migdal formula; exact 4D scaling fails from string breaking. Part III's free-existential predicate is a tautology of real analysis, stated as a proved theorem (not an axiom); it does NOT capture the physical small-ε conjecture, which remains open.",
     "lineCount": 242,
     "originalContributions": [
       "linearPotential: V(r) = σ·r definition",
@@ -34,7 +34,7 @@
       "post_break_ratio_lt_tension_ratio (proved): after breaking, ratio < σ_R/σ_fund",
       "exact_casimir_scaling_fails_4d (proved): ratio changes → exact scaling fails",
       "ApproximateCasimirScaling4D: |σ_R/σ_f - C₂_R/C₂_f| < ε",
-      "casimir_scaling_4d_approximate (axiom): approximate 4D scaling conjecture",
+      "casimir_scaling_4d_approximate (theorem): the free-existential form of approximate 4D scaling is a tautology (proved), making explicit it does not encode the physical conjecture",
       "casimir_scaling_2d_exact_4d_approximate (proved): summary theorem"
     ],
     "theoremCount": 10,
@@ -75,10 +75,10 @@
     },
     {
       "id": "approx-conjecture",
-      "title": "Part III: 4D Approximate Casimir Scaling (Axiomatized)",
+      "title": "Part III: 4D Approximate Casimir Scaling (formalization caveat)",
       "startLine": 184,
       "endLine": 214,
-      "summary": "Defines ApproximateCasimirScaling4D: |σ_R/σ_fund - C₂(R)/C₂(fund)| < ε. Axiom casimir_scaling_4d_approximate: approximate scaling holds at intermediate distances (open conjecture, supported by lattice QCD but not analytically proved). Includes lattice data: SU(2) measured ≈ 2.5 vs Casimir 8/3 ≈ 2.67; SU(3) measured ≈ 2.2 vs Casimir 9/4 = 2.25.",
+      "summary": "Defines ApproximateCasimirScaling4D: |σ_R/σ_fund - C₂(R)/C₂(fund)| < ε. The free-existential form (∃ ε, ...) is a tautology of real analysis — any two reals are within |x-y|+1 of each other — so it is stated as a proved theorem casimir_scaling_4d_approximate, NOT an axiom. This makes explicit that the predicate as written does not capture the physical small-ε conjecture (which remains open and would need an explicit bound on ε). Lattice data for context: SU(2) measured ≈ 2.5 vs Casimir 8/3 ≈ 2.67; SU(3) measured ≈ 2.2 vs Casimir 9/4 = 2.25.",
       "mathContext": "$|\\sigma_R/\\sigma_{\\text{fund}} - C_2(R)/C_2(\\text{fund})| < \\varepsilon$ for $r < r_{\\text{break}}$. The deviation $\\varepsilon$ arises from non-perturbative effects: string tension receives corrections from gluon self-energy, renormalon divergences, and higher-order operators in the effective string theory."
     },
     {
@@ -100,7 +100,7 @@
       "4D: String breaking occurs for screened (N-ality 0) representations like the adjoint at distance r_break = 2m_gluelump/σ_R",
       "After breaking, the potential ratio V_R/V_fund = 2m_gluelump/(σ_fund·r) → 0, contradicting the constant Casimir ratio",
       "The key inequality: r > r_break ⟹ σ_R·r > 2·m_gluelump ⟹ post-break ratio < σ_R/σ_fund",
-      "Approximate Casimir scaling (at intermediate r) is observed in lattice QCD but not analytically proved"
+      "Approximate Casimir scaling at intermediate r is observed in lattice QCD but not analytically proved; the free-existential formalization of it is a tautology, so the genuine small-ε conjecture remains open"
     ],
     "prerequisites": [
       "2D Yang-Mills: Migdal formula, area law, string tension from heat kernel",
@@ -111,8 +111,8 @@
   },
   "leanFile": {
     "namespace": "YangMills2DOQ02",
-    "lineCount": 242,
-    "axiomCount": 1,
+    "lineCount": 257,
+    "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 5,
     "path": "Proofs/YangMills2DOQ02.lean",


### PR DESCRIPTION
## Summary

Repairs the gallery-integrity finding in #43236: the single `axiom`
`casimir_scaling_4d_approximate` in `YangMills2DOQ02.lean` was **vacuous** — a
free, unbounded existential `∃ ε, |σ_R/σ_fund - C₂(R)/C₂(fund)| < ε` is a
tautology of real analysis (any two reals are within `|x−y|+1` of each other),
yet meta.json and the Lean docstring narrated it as a hard open physics
conjecture requiring "non-perturbative QFT methods beyond current Mathlib."

This is the free-existential vacuity class (cf. erdos-63 / erdos-1025).

## Fix (auditor option 1 — prove trivially + annotate honestly)

**Lean** (`proofs/Proofs/YangMills2DOQ02.lean`):
- Replaced the `axiom` with a `theorem casimir_scaling_4d_approximate` proved
  by `⟨|sR/sf - cR/cf| + 1, positivity, linarith [abs_nonneg …]⟩` — no physics,
  no positivity hypotheses needed.
- Rewrote the Part III docstring / header to state plainly that the
  free-existential predicate does **not** capture the physical (small-ε)
  conjecture, which remains open and would require an explicit bound on ε.

**meta.json** (`src/data/proofs/yang-mills-2d-oq-02/meta.json`):
- `status` `axiomatized` → `verified`; `badge` `axiom` → `verified`;
  `axiomCount` 1 → 0; `leanFile.axiomCount` 1 → 0; `lineCount` → 257.
- Rewrote `assumptions`, `originalContributions[10]`, `sections[4]`
  (summary/title), and `keyInsights[4]` so nothing claims the axiom is an open
  conjecture requiring non-perturbative QFT.

## Verification

`./proofs/scripts/docker-build.sh Proofs.YangMills2DOQ02` → **Build succeeded**
(0 axioms, 0 sorries). `#print axioms` dependency reduced to the foundational
`propext`/`Classical.choice`/`Quot.sound` only.

Closes #43236
