### PR TITLE
Fix: yang-mills-2d-oq-02 stale 'axiomatized' prose (follow-up to #43241)

### DIFF
--- a/src/data/proofs/yang-mills-2d-oq-02/meta.json
+++ b/src/data/proofs/yang-mills-2d-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "yang-mills-2d-oq-02",
   "title": "Casimir Scaling: Exact in 2D, Approximate in 4D",
   "slug": "yang-mills-2d-oq-02",
-  "description": "In 2D Yang-Mills (Migdal formula), Casimir scaling holds exactly for all r: the potential ratio equals C₂(R)/C₂(fund). In 4D, exact Casimir scaling fails due to string breaking—after r_break, the adjoint potential saturates while the fundamental grows linearly, so the ratio decreases. The 4D approximate conjecture is axiomatized as open.",
+  "description": "In 2D Yang-Mills (Migdal formula), Casimir scaling holds exactly for all r: the potential ratio equals C₂(R)/C₂(fund). In 4D, exact Casimir scaling fails due to string breaking—after r_break, the adjoint potential saturates while the fundamental grows linearly, so the ratio decreases. The 4D approximate-scaling predicate is stated as a proved theorem (a tautology of real analysis, not an axiom); the physical small-ε conjecture it gestures at remains open.",
   "meta": {
     "author": "Migdal (1975); Bali et al. (2000)",
     "date": "2000",
@@ -87,14 +87,14 @@
       "startLine": 216,
       "endLine": 244,
       "summary": "casimir_scaling_2d_exact_4d_approximate packages both parts: (1) 2D exact scaling holds for all r > 0 (proved), and (2) 4D post-break ratio < σ_R/σ_fund (proved). Together they answer OQ-02: Casimir scaling holds exactly in 2D, approximately in 4D, and the failure of exactness in 4D is a proved consequence of string breaking.",
-      "mathContext": "The summary theorem is a conjunction: $\\forall r > 0: V_R(r)/V_{\\text{fund}}(r) = C_2(R)/C_2(\\text{fund})$ (2D, proved) AND $\\forall r > r_{\\text{break}}: V_R^{\\text{sat}}/V_{\\text{fund}}(r) < \\sigma_R/\\sigma_{\\text{fund}}$ (4D failure, proved). Together with the axiom, the full picture is formalized."
+      "mathContext": "The summary theorem is a conjunction: $\\forall r > 0: V_R(r)/V_{\\text{fund}}(r) = C_2(R)/C_2(\\text{fund})$ (2D, proved) AND $\\forall r > r_{\\text{break}}: V_R^{\\text{sat}}/V_{\\text{fund}}(r) < \\sigma_R/\\sigma_{\\text{fund}}$ (4D failure, proved). Together with the proved 4D approximate-scaling tautology, the full picture is formalized."
     }
   ],
   "overview": {
     "historicalContext": "Casimir scaling in Yang-Mills theory refers to the hypothesis that the string tension ratio $\\sigma_R/\\sigma_{\\text{fund}}$ equals the ratio of quadratic Casimir eigenvalues $C_2(R)/C_2(\\text{fund})$. In 2D Yang-Mills, this is an exact consequence of the Migdal formula (1975): the partition function decomposes by representation via the heat kernel on the gauge group, giving $\\sigma_R = g^2 C_2(R)/(2 \\dim R)$, so the ratio is exactly $C_2(R)/C_2(\\text{fund})$ for representations of equal dimension. In 4D, Casimir scaling was observed in lattice simulations by Bali et al. (2000) with high precision for SU(2) and SU(3) at intermediate distances — the adjoint/fundamental ratio was measured within ~7% of the Casimir prediction. However, the theoretical status is subtle: string breaking, the physical mechanism by which a high-energy flux tube snaps to create a particle-antiparticle pair, provides a rigorous reason why exact Casimir scaling cannot hold in 4D for screened (N-ality 0) representations. After string breaking at $r = r_{\\text{break}} = 2m_{\\text{gluelump}}/\\sigma_R$, the adjoint potential saturates rather than growing linearly, causing the ratio to decrease — a proved mathematical fact.",
     "problemStatement": "Does Casimir scaling σ_R/σ_fund = C₂(R)/C₂(fund) persist exactly or only approximately in the 4D continuum limit?",
     "text": "In 2D Yang-Mills, Casimir scaling holds exactly from the Migdal formula. In 4D, string breaking at r = r_break = 2m_gluelump/σ_R causes the potential to saturate, violating the constant-ratio requirement of exact Casimir scaling. The 4D conjecture that σ_R/σ_fund ≈ C₂(R)/C₂(fund) at intermediate distances is supported by lattice QCD but remains open analytically.",
-    "proofStrategy": "Part I uses the Migdal formula to show the 2D potential ratio is exactly σ_R/σ_fund = C₂(R)/C₂(fund) for all r > 0. Part II formalizes string breaking: at r > r_break, the adjoint potential is V_R(r) = 2·m_gluelump (constant) while V_fund(r) = σ_fund·r (linear). The key inequality 2·m_gluelump < σ_R·r follows from r > r_break = 2m/σ_R, and div_lt_div_iff converts this to the ratio comparison. The 4D approximate conjecture is axiomatized.",
+    "proofStrategy": "Part I uses the Migdal formula to show the 2D potential ratio is exactly σ_R/σ_fund = C₂(R)/C₂(fund) for all r > 0. Part II formalizes string breaking: at r > r_break, the adjoint potential is V_R(r) = 2·m_gluelump (constant) while V_fund(r) = σ_fund·r (linear). The key inequality 2·m_gluelump < σ_R·r follows from r > r_break = 2m/σ_R, and div_lt_div_iff converts this to the ratio comparison. The 4D approximate-scaling predicate is a free-existential tautology stated as a proved theorem (not an axiom); the physical small-ε conjecture remains open.",
     "keyInsights": [
       "2D: No string breaking — the area law holds for all representations at all distances, giving exact Casimir scaling",
       "4D: String breaking occurs for screened (N-ality 0) representations like the adjoint at distance r_break = 2m_gluelump/σ_R",
@@ -141,7 +141,7 @@
     {
       "targetId": "yang-mills-lattice",
       "relationship": "context",
-      "description": "Lattice Yang-Mills formulation underlying the Bali et al. (2000) lattice QCD measurements of approximate Casimir scaling that motivate the axiomatized 4D conjecture"
+      "description": "Lattice Yang-Mills formulation underlying the Bali et al. (2000) lattice QCD measurements of approximate Casimir scaling that motivate the (still open) 4D conjecture"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Problem

Auditor issue #43236 flagged that yang-mills-2d-oq-02 axiomatized a vacuous 4D predicate and mislabeled it as a hard open conjecture. PR #43241 (merged) correctly converted the axiom to a proved real-analysis tautology and updated `status`, `axiomCount` (→0), `assumptions`, and the keyInsight/summary.

But it left **four** meta.json fields still asserting the old axiomatization, contradicting the corrected fields:

| Field | Stale claim |
|-------|-------------|
| `description` (L5) | "The 4D approximate conjecture is axiomatized as open." |
| `mathContext` (L90) | "Together with the axiom, the full picture is formalized." |
| `proofStrategy` (L97) | "The 4D approximate conjecture is axiomatized." |
| reference desc (L144) | "...motivate the axiomatized 4D conjecture" |

Meanwhile `assumptions` and the keyInsight already say the predicate is a *proved theorem, not an axiom*. `YangMills2DOQ02.lean` on main has **0 axiom declarations, 0 sorries** — so these four claims are factually wrong.

## Fix

Metadata-only. Reworded the four fields to match the honest annotations: the 4D approximate-scaling predicate is a free-existential tautology stated as a proved theorem (not an axiom); the physical small-ε conjecture remains open.

## Evidence

```
$ grep -inE 'axiomatiz|the axiom' meta.json   # after fix
(no matches)
$ python3 -c 'import json; json.load(open(...))'
JSON valid
```

Completes the honesty repair for #43236.