### PR TITLE
Enrich binomial-theorem-oq-06-oq-01-oq-02: split bundled sanity-check section (4->5)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-06-oq-01-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-06-oq-01-oq-02/meta.json
@@ -80,12 +80,20 @@
       "mathContext": "A fixed-point-free sign-reversing involution on a finite set forces the alternating sum to vanish: $S=-S\\Rightarrow S=0$. No polynomials or generating functions are used, only reflection and parity."
     },
     {
-      "id": "sanity",
-      "title": "Numerical Sanity Checks",
+      "id": "sanity-three",
+      "title": "Numerical Sanity Check: n = 3",
       "startLine": 111,
+      "endLine": 115,
+      "summary": "Kernel-`decide` check: check_three establishes ∑_{k=0}^3 (-1)^k C(3,k)^2 = 1-9+9-1 = 0, the smallest odd instance of the vanishing.",
+      "mathContext": "Concrete instantiation at $n=3$: $1-9+9-1=0$, verified by kernel reduction (`decide`, not `native_decide`, so no `Lean.ofReduceBool` axiom is introduced)."
+    },
+    {
+      "id": "sanity-five",
+      "title": "Numerical Sanity Check: n = 5, and Axiom Audit",
+      "startLine": 117,
       "endLine": 123,
-      "summary": "Kernel-`decide` checks: check_three ∑_{k=0}^3 (-1)^k C(3,k)^2 = 1-9+9-1 = 0 and check_five ∑_{k=0}^5 (-1)^k C(5,k)^2 = 1-25+100-100+25-1 = 0, plus `#print axioms` confirming the reflection theorem is axiom-free.",
-      "mathContext": "Both odd cases evaluate to $0$, illustrating the involution vanishing, verified by kernel reduction (no Lean.ofReduceBool)."
+      "summary": "Kernel-`decide` check: check_five establishes ∑_{k=0}^5 (-1)^k C(5,k)^2 = 1-25+100-100+25-1 = 0. The closing `#print axioms alternating_choose_sq_odd_reflect` confirms the main reflection theorem depends on no axioms beyond the Lean/Mathlib foundational ones.",
+      "mathContext": "Concrete instantiation at $n=5$: $1-25+100-100+25-1=0$, again by kernel `decide`. Both sanity checks are independent confirmations, not part of the general reflection proof."
     }
   ],
   "sorries": [],


### PR DESCRIPTION
Enrichment pass for `binomial-theorem-oq-06-oq-01-oq-02` (quality 98, sections
bucket 8/10 = 4 sections instead of the 5-item cap; all other buckets already
maxed).

The final "Numerical Sanity Checks" section bundled two independent kernel-`decide`
theorems (`check_three`, `check_five`) plus the closing `#print axioms` line into
one block spanning lines 111-123. Split at the real boundary (blank line 116)
into:

- `sanity-three` (111-115): the n=3 check
- `sanity-five` (117-123): the n=5 check + the axiom-print audit line

Verified all 5 sections' line ranges against the current Lean source
(`proofs/Proofs/BinomialTheoremOQ06OQ01OQ02.lean`, 123 lines) — no drift in the
other 3 existing sections. `meta.json` stays at ~10.4 KB, far under the 60 KB cap.

No overlap with the other open PR on this entry (#43239, annotation enum-value
fixes only, `annotations.json`).