### PR TITLE
research(researcher-3): batched — C^n all-orders Schwarz (ftc-oq-02-inc-01) + chart-local triangle inequality (triangle-oq-04-oq-01) [0 ax / 0 sorry]

### DIFF
--- a/proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean
+++ b/proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean
@@ -149,7 +149,6 @@ theorem iteratedFDeriv_comp_swap_zero_one {n : ℕ} (hf : ContDiff ℝ (n + 2 : 
     funext i
     simp only [Fin.tail, Function.comp_apply]
     congr 1
-    exact Equiv.swap_apply_of_ne_of_ne (Fin.succ_ne_zero _) (Fin.succ_succ_ne_one _)
   rw [iteratedFDeriv_add_two_apply, iteratedFDeriv_add_two_apply, h0, h1, ht,
     hsym.eq (m 1) (m 0)]
 

--- a/proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean
+++ b/proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean
@@ -1,0 +1,256 @@
+import Mathlib
+
+/-
+# Symmetry of the n-th iterated Fréchet derivative for C^n functions (all orders Schwarz/Clairaut)
+
+Research slug: fundamental-theorem-calculus-oq-02-incomplete-01 (Fragment 1 of the
+generalized-Stokes decomposition; parent gallery entry `fundamental-theorem-calculus-oq-02`).
+
+## What This Formalizes
+
+If `f : E → F` is `C^n` over `ℝ` (finite smoothness — analyticity NOT required), then its
+`n`-th iterated Fréchet derivative at every point is a *symmetric* multilinear map:
+
+  `iteratedFDeriv ℝ n f x (v ∘ σ) = iteratedFDeriv ℝ n f x v`  for every `σ : Perm (Fin n)`.
+
+This is the all-orders Schwarz/Clairaut theorem. It is the analytic backbone of `d ∘ d = 0`
+for differential forms, hence of the generalized Stokes theorem (Fragment 1 of this slug's
+decomposition, designed in the S3/S4 session memos of 2026-06).
+
+## Relation to Mathlib (v4.31 pin)
+
+Mathlib currently has:
+* `second_derivative_symmetric` / `ContDiffAt.isSymmSndFDerivAt` — the `n = 2` case for
+  `C^2` functions over `ℝ` or `ℂ`;
+* `ContDiffAt.iteratedFDeriv_comp_perm` (in `Mathlib.Analysis.Analytic.IteratedFDeriv`) —
+  the general-`n` statement, but only for *analytic* (`C^ω`) functions.
+
+The general-`n`, finite-smoothness statement proved here is (as of the v4.31 pin) NOT in
+Mathlib. It strictly strengthens the analytic version over `ℝ` since `C^ω ⊊ C^n` as
+function classes (`C^n` contains many non-analytic functions).
+
+## Proof structure (elementary, no group-closure machinery)
+
+Induction on `n`, using `Equiv.Perm.decomposeFin` to factor any permutation of `Fin (n+1)`
+as `swap 0 p * (tail lift of τ)`:
+
+1. `fderiv_comp_perm_eq` — if every value of a multilinear-map-valued function `g` is
+   invariant under precomposition by `τ`, so is every value of `fderiv ℝ g x`
+   (postcompose with the linear isometry `ContinuousMultilinearMap.domDomCongrₗᵢ`).
+2. `iteratedFDeriv_comp_tailLift` — symmetry of `D^n f` everywhere lifts to symmetry of
+   `D^(n+1) f` under permutations fixing position 0 (peel one derivative with
+   `iteratedFDeriv_succ_apply_left`).
+3. `iteratedFDeriv_comp_swap_zero_one` — swapping the two outermost directions is the
+   Mathlib `n = 2` case `ContDiffAt.isSymmSndFDerivAt` applied to `g := iteratedFDeriv ℝ n f`
+   (which is `C^2` by `ContDiff.iteratedFDeriv_right`), after rewriting `D^(n+2) f x m` as
+   `fderiv ℝ (fderiv ℝ (D^n f)) x (m 0) (m 1) (tail (tail m))`.
+4. `swap 0 p` for general `p` is conjugate to `swap 0 1` by a tail lift
+   (`Equiv.symm_trans_swap_trans`), so no `Subgroup.closure` argument is needed.
+
+0 axioms, 0 sorries.
+-/
+
+open Function Equiv
+
+namespace FTCOQ02Incomplete01
+
+variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  [NormedAddCommGroup F] [NormedSpace ℝ F] {f : E → F}
+
+/-! ### Step 1: derivatives of pointwise-symmetric multilinear-map-valued functions -/
+
+/-- If every value of `g : E → (E [×n]→L[ℝ] F)` is invariant under precomposition with the
+permutation `τ`, then so is every value of its derivative. The proof postcomposes `g` with
+the linear isometry `domDomCongrₗᵢ τ` and uses that `fderiv` commutes with linear
+isometries. -/
+theorem fderiv_comp_perm_eq {n : ℕ}
+    {g : E → ContinuousMultilinearMap ℝ (fun _ : Fin n => E) F} {τ : Equiv.Perm (Fin n)}
+    (hg : ∀ y (w : Fin n → E), g y (w ∘ τ) = g y w) (x u : E) (w : Fin n → E) :
+    fderiv ℝ g x u (w ∘ τ) = fderiv ℝ g x u w := by
+  set Φ := ContinuousMultilinearMap.domDomCongrₗᵢ ℝ E F τ with hΦ
+  have hgΦ : ⇑Φ ∘ g = g := by
+    funext y
+    exact ContinuousMultilinearMap.ext fun v => hg y v
+  have hfd : fderiv ℝ g x = (Φ : (ContinuousMultilinearMap ℝ (fun _ : Fin n => E) F) →L[ℝ]
+      (ContinuousMultilinearMap ℝ (fun _ : Fin n => E) F)).comp (fderiv ℝ g x) := by
+    conv_lhs => rw [← hgΦ]
+    exact Φ.comp_fderiv
+  have happ : fderiv ℝ g x u = (fderiv ℝ g x u).domDomCongr τ := by
+    conv_lhs => rw [hfd]
+    rfl
+  conv_rhs => rw [happ]
+  simp [ContinuousMultilinearMap.domDomCongr_apply, Function.comp_def]
+
+/-! ### Step 2: tail lift — permutations fixing position 0 -/
+
+/-- If the `n`-th derivative of `f` is `τ`-symmetric at every point, then the `(n+1)`-th
+derivative is symmetric under the tail lift `decomposeFin.symm (0, τ)` of `τ` (the
+permutation of `Fin (n+1)` fixing `0` and acting by `τ` on the tail). -/
+theorem iteratedFDeriv_comp_tailLift {n : ℕ} {τ : Equiv.Perm (Fin n)}
+    (hτ : ∀ y (w : Fin n → E), iteratedFDeriv ℝ n f y (w ∘ τ) = iteratedFDeriv ℝ n f y w)
+    (x : E) (v : Fin (n + 1) → E) :
+    iteratedFDeriv ℝ (n + 1) f x (v ∘ (Equiv.Perm.decomposeFin.symm (0, τ))) =
+      iteratedFDeriv ℝ (n + 1) f x v := by
+  have h0 : (v ∘ (Equiv.Perm.decomposeFin.symm (0, τ))) 0 = v 0 := by simp
+  have ht : Fin.tail (v ∘ (Equiv.Perm.decomposeFin.symm (0, τ))) = Fin.tail v ∘ τ := by
+    funext i
+    simp [Fin.tail, Equiv.Perm.decomposeFin_symm_apply_succ]
+  calc iteratedFDeriv ℝ (n + 1) f x (v ∘ (Equiv.Perm.decomposeFin.symm (0, τ)))
+      = fderiv ℝ (iteratedFDeriv ℝ n f) x ((v ∘ (Equiv.Perm.decomposeFin.symm (0, τ))) 0)
+          (Fin.tail (v ∘ (Equiv.Perm.decomposeFin.symm (0, τ)))) :=
+        iteratedFDeriv_succ_apply_left _
+    _ = fderiv ℝ (iteratedFDeriv ℝ n f) x (v 0) (Fin.tail v ∘ τ) := by rw [h0, ht]
+    _ = fderiv ℝ (iteratedFDeriv ℝ n f) x (v 0) (Fin.tail v) :=
+        fderiv_comp_perm_eq hτ x (v 0) (Fin.tail v)
+    _ = iteratedFDeriv ℝ (n + 1) f x v := (iteratedFDeriv_succ_apply_left _).symm
+
+/-! ### Step 3: the two outermost directions commute (Mathlib's `n = 2` Schwarz) -/
+
+/-- Expand the `(n+2)`-th derivative as the second derivative of the `n`-th derivative,
+applied to the two leading directions. -/
+private theorem iteratedFDeriv_add_two_apply {n : ℕ} (f : E → F) (x : E)
+    (w : Fin (n + 2) → E) :
+    iteratedFDeriv ℝ (n + 2) f x w =
+      fderiv ℝ (fderiv ℝ (iteratedFDeriv ℝ n f)) x (w 0) (w 1)
+        (Fin.tail (Fin.tail w)) := by
+  have h2 := LinearIsometryEquiv.comp_fderiv
+    (𝕜 := ℝ) (G := E)
+    (iso := (continuousMultilinearCurryLeftEquiv ℝ (fun _ : Fin (n + 1) => E) F).symm)
+    (f := fderiv ℝ (iteratedFDeriv ℝ n f)) (x := x)
+  have htw : Fin.tail w 0 = w 1 := by
+    simp [Fin.tail]
+  calc iteratedFDeriv ℝ (n + 2) f x w
+      = fderiv ℝ (iteratedFDeriv ℝ (n + 1) f) x (w 0) (Fin.tail w) :=
+        iteratedFDeriv_succ_apply_left w
+    _ = fderiv ℝ (⇑(continuousMultilinearCurryLeftEquiv ℝ (fun _ : Fin (n + 1) => E) F).symm ∘
+          fderiv ℝ (iteratedFDeriv ℝ n f)) x (w 0) (Fin.tail w) := by
+        rw [← iteratedFDeriv_succ_eq_comp_left]
+    _ = (continuousMultilinearCurryLeftEquiv ℝ (fun _ : Fin (n + 1) => E) F).symm
+          (fderiv ℝ (fderiv ℝ (iteratedFDeriv ℝ n f)) x (w 0)) (Fin.tail w) := by
+        rw [h2]; rfl
+    _ = fderiv ℝ (fderiv ℝ (iteratedFDeriv ℝ n f)) x (w 0) (Fin.tail w 0)
+          (Fin.tail (Fin.tail w)) := rfl
+    _ = fderiv ℝ (fderiv ℝ (iteratedFDeriv ℝ n f)) x (w 0) (w 1)
+          (Fin.tail (Fin.tail w)) := by rw [htw]
+
+/-- Swapping the two outermost differentiation directions: the `n = 2` Schwarz theorem
+(`ContDiffAt.isSymmSndFDerivAt`, which needs only `C^2` over `ℝ`) applied to the
+multilinear-map-valued function `iteratedFDeriv ℝ n f`. -/
+theorem iteratedFDeriv_comp_swap_zero_one {n : ℕ} (hf : ContDiff ℝ (n + 2 : ℕ) f) (x : E)
+    (m : Fin (n + 2) → E) :
+    iteratedFDeriv ℝ (n + 2) f x (m ∘ Equiv.swap 0 1) = iteratedFDeriv ℝ (n + 2) f x m := by
+  have hg : ContDiff ℝ 2 (iteratedFDeriv ℝ n f) :=
+    hf.iteratedFDeriv_right (by norm_cast; omega)
+  have hsym : IsSymmSndFDerivAt ℝ (iteratedFDeriv ℝ n f) x :=
+    hg.contDiffAt.isSymmSndFDerivAt (by simp)
+  have h0 : (m ∘ Equiv.swap 0 1) 0 = m 1 := by simp
+  have h1 : (m ∘ Equiv.swap 0 1) 1 = m 0 := by simp
+  have ht : Fin.tail (Fin.tail (m ∘ Equiv.swap 0 1)) = Fin.tail (Fin.tail m) := by
+    funext i
+    simp only [Fin.tail, Function.comp_apply]
+    congr 1
+    exact Equiv.swap_apply_of_ne_of_ne (Fin.succ_ne_zero _) (Fin.succ_succ_ne_one _)
+  rw [iteratedFDeriv_add_two_apply, iteratedFDeriv_add_two_apply, h0, h1, ht,
+    hsym.eq (m 1) (m 0)]
+
+/-! ### Step 4: the main theorem -/
+
+/-- **Symmetry of the `n`-th iterated Fréchet derivative of a `C^n` function** (all-orders
+Schwarz/Clairaut over `ℝ`, finite smoothness — no analyticity required).
+
+Mathlib (v4.31) has this only for `n = 2` (`ContDiffAt.isSymmSndFDerivAt`) or for
+analytic `f` (`ContDiffAt.iteratedFDeriv_comp_perm`). -/
+theorem iteratedFDeriv_comp_perm :
+    ∀ {n : ℕ}, ContDiff ℝ (n : ℕ) f → ∀ (x : E) (v : Fin n → E) (σ : Equiv.Perm (Fin n)),
+      iteratedFDeriv ℝ n f x (v ∘ σ) = iteratedFDeriv ℝ n f x v := by
+  intro n
+  induction n with
+  | zero =>
+    intro _ x v σ
+    rw [Subsingleton.elim (v ∘ ⇑σ) v]
+  | succ n IH =>
+    intro hf x v σ
+    -- the `n`-th derivative is symmetric at every point, by the induction hypothesis
+    have hsymm : ∀ (τ : Equiv.Perm (Fin n)) (y : E) (w : Fin n → E),
+        iteratedFDeriv ℝ n f y (w ∘ τ) = iteratedFDeriv ℝ n f y w :=
+      fun τ y w => IH (hf.of_le (by exact_mod_cast Nat.le_succ n)) y w τ
+    -- factor σ = swap 0 p * (tail lift of τ) via `decomposeFin`
+    set p : Fin (n + 1) := (Equiv.Perm.decomposeFin σ).1 with hp
+    set τ : Equiv.Perm (Fin n) := (Equiv.Perm.decomposeFin σ).2 with hτdef
+    have hσ : σ = Equiv.Perm.decomposeFin.symm (p, τ) := by
+      rw [hp, hτdef]
+      exact (Equiv.symm_apply_apply Equiv.Perm.decomposeFin σ).symm
+    have hfact : σ = Equiv.swap 0 p * Equiv.Perm.decomposeFin.symm (0, τ) := by
+      rw [hσ]
+      ext i
+      refine Fin.cases ?_ (fun j => ?_) i <;>
+        simp [Equiv.Perm.mul_apply, Equiv.Perm.decomposeFin_symm_apply_succ]
+    have hcomp : v ∘ σ = (v ∘ Equiv.swap 0 p) ∘ ⇑(Equiv.Perm.decomposeFin.symm (0, τ)) := by
+      rw [hfact]
+      funext i
+      simp
+    rw [hcomp,
+      iteratedFDeriv_comp_tailLift (fun y w => hsymm τ y w) x (v ∘ Equiv.swap 0 p)]
+    -- it remains to handle `swap 0 p`; split on `p`
+    clear hcomp hfact hσ hp hτdef
+    refine Fin.cases ?_ (fun j => ?_) p
+    · -- `p = 0`: the swap is the identity
+      have : v ∘ ⇑(Equiv.swap (0 : Fin (n + 1)) 0) = v := by
+        funext i; simp
+      rw [this]
+    · -- `p = j.succ`: conjugate `swap 0 j.succ` into `swap 0 1` by a tail lift
+      cases n with
+      | zero => exact j.elim0
+      | succ k =>
+        set ρ : Equiv.Perm (Fin (k + 1)) := Equiv.swap 0 j with hρ
+        set ρhat : Equiv.Perm (Fin (k + 2)) := Equiv.Perm.decomposeFin.symm (0, ρ) with hρhat
+        have hρ0 : ρhat 0 = 0 := by simp [hρhat]
+        have hρ1 : ρhat 1 = j.succ := by
+          have h01 : (1 : Fin (k + 2)) = (0 : Fin (k + 1)).succ := by
+            simp [Fin.succ_zero_eq_one]
+          rw [h01]
+          simp [hρhat, hρ]
+        have hρinv : ρhat⁻¹ = Equiv.Perm.decomposeFin.symm (0, ρ⁻¹) := by
+          rw [inv_eq_iff_mul_eq_one]
+          ext i
+          refine Fin.cases ?_ (fun i => ?_) i <;>
+            simp [hρhat, Equiv.Perm.mul_apply, Equiv.Perm.decomposeFin_symm_apply_succ]
+        have hconj : Equiv.swap (0 : Fin (k + 2)) j.succ = ρhat * Equiv.swap 0 1 * ρhat⁻¹ := by
+          have h := Equiv.symm_trans_swap_trans (0 : Fin (k + 2)) 1 ρhat
+          rw [hρ0, hρ1] at h
+          rw [← h]
+          rfl
+        have hv : v ∘ ⇑(Equiv.swap (0 : Fin (k + 2)) j.succ) =
+            ((v ∘ ⇑ρhat) ∘ ⇑(Equiv.swap (0 : Fin (k + 2)) 1)) ∘ ⇑ρhat⁻¹ := by
+          rw [hconj]
+          funext i
+          simp
+        calc iteratedFDeriv ℝ (k + 2) f x (v ∘ ⇑(Equiv.swap 0 j.succ))
+            = iteratedFDeriv ℝ (k + 2) f x
+                (((v ∘ ⇑ρhat) ∘ ⇑(Equiv.swap 0 1)) ∘ ⇑ρhat⁻¹) := by rw [hv]
+          _ = iteratedFDeriv ℝ (k + 2) f x ((v ∘ ⇑ρhat) ∘ ⇑(Equiv.swap 0 1)) := by
+              rw [hρinv]
+              exact iteratedFDeriv_comp_tailLift (fun y w => hsymm ρ⁻¹ y w) x _
+          _ = iteratedFDeriv ℝ (k + 2) f x (v ∘ ⇑ρhat) :=
+              iteratedFDeriv_comp_swap_zero_one hf x (v ∘ ⇑ρhat)
+          _ = iteratedFDeriv ℝ (k + 2) f x v :=
+              iteratedFDeriv_comp_tailLift (fun y w => hsymm ρ y w) x v
+
+/-- The `n`-th iterated derivative of a `C^n` function, as a multilinear map, is fixed by
+`domDomCongr` along any permutation. -/
+theorem iteratedFDeriv_domDomCongr {n : ℕ} (hf : ContDiff ℝ (n : ℕ) f) (x : E)
+    (σ : Equiv.Perm (Fin n)) :
+    (iteratedFDeriv ℝ n f x).domDomCongr σ = iteratedFDeriv ℝ n f x := by
+  refine ContinuousMultilinearMap.ext fun v => ?_
+  simpa [ContinuousMultilinearMap.domDomCongr_apply, Function.comp_def] using
+    iteratedFDeriv_comp_perm hf x v σ
+
+/-- Specialization to `C^∞` functions: every iterated derivative is symmetric. This is
+strictly stronger over `ℝ` than Mathlib's analytic version, since smooth functions need
+not be analytic. -/
+theorem iteratedFDeriv_comp_perm_of_contDiff_infty (hf : ContDiff ℝ (⊤ : ℕ∞) f) {n : ℕ}
+    (x : E) (v : Fin n → E) (σ : Equiv.Perm (Fin n)) :
+    iteratedFDeriv ℝ n f x (v ∘ σ) = iteratedFDeriv ℝ n f x v :=
+  iteratedFDeriv_comp_perm (hf.of_le (by exact_mod_cast le_top)) x v σ
+
+end FTCOQ02Incomplete01

--- a/proofs/Proofs/TriangleInequalityOQ04OQ01.lean
+++ b/proofs/Proofs/TriangleInequalityOQ04OQ01.lean
@@ -120,36 +120,89 @@ theorem chartIntrinsicDist_nonneg (p q : E) : 0 ≤ chartIntrinsicDist p q := by
   refine Real.iInf_nonneg (fun _ => ?_)
   exact chartArcLength_nonneg γ.extend zero_le_one
 
-/-- **Reparameterization adapter (left half)** (S3b): for `γ : ℝ → E`
-differentiable on `[0, 1]`, the chart-local arc length of `γ ∘ (· * 2)` on
-`[0, 1/2]` equals the chart-local arc length of `γ` on `[0, 1]`.
+/-- **Unconditional chain rule for the dilation `· * 2`** (S3d): the identity
+`deriv (γ ∘ (· * 2)) t = 2 • deriv γ (t * 2)` holds for EVERY curve `γ`, with no
+differentiability hypothesis. When `γ` is differentiable at `t * 2` this is the
+chain rule (`deriv.scomp`); otherwise both sides are Mathlib's junk value `0`:
+the right by `deriv_zero_of_not_differentiableAt` directly, the left because a
+differentiable `γ ∘ (· * 2)` would transport back through the inverse dilation
+`· * (1/2)` and make `γ` differentiable at `t * 2` — contradiction.
 
-The proof chains three Mathlib bearers: (i) `deriv.scomp` (chain rule, giving
-`deriv (γ ∘ (· * 2)) t = 2 • deriv γ (t * 2)`), (ii) `norm_smul` + `Real.norm_ofNat`
-(extracting the positive scalar `‖(2 : ℝ)‖ = 2`), and (iii)
-`intervalIntegral.smul_integral_comp_mul_right` (substitution `s = t * 2`,
-collapsing the constant scalar and bounds in a single bearer application).
+This unconditional form is what lets the S3d triangle inequality range over
+*all* integrable-speed paths (the infimum class of `chartIntrinsicDist`), not
+just everywhere-differentiable ones. -/
+private lemma deriv_comp_mul_two (γ : ℝ → E) (t : ℝ) :
+    deriv (γ ∘ (· * 2)) t = (2 : ℝ) • deriv γ (t * 2) := by
+  by_cases hγ : DifferentiableAt ℝ γ (t * 2)
+  · have hmul_has : HasDerivAt (fun x : ℝ => x * 2) 2 t := hasDerivAt_mul_const 2
+    rw [deriv.scomp t hγ hmul_has.differentiableAt, hmul_has.deriv]
+  · have hcomp : ¬ DifferentiableAt ℝ (γ ∘ (· * 2)) t := by
+      intro h
+      apply hγ
+      have hg : γ = (γ ∘ (· * 2)) ∘ (· * (1 / 2 : ℝ)) := by
+        funext s
+        simp only [Function.comp_apply]
+        congr 1
+        ring
+      have h' : DifferentiableAt ℝ (γ ∘ (· * 2)) (t * 2 * (1 / 2 : ℝ)) := by
+        rw [show t * 2 * (1 / 2 : ℝ) = t from by ring]
+        exact h
+      rw [hg]
+      exact DifferentiableAt.comp (t * 2) h'
+        (hasDerivAt_mul_const (1 / 2 : ℝ)).differentiableAt
+    rw [deriv_zero_of_not_differentiableAt hcomp,
+      deriv_zero_of_not_differentiableAt hγ, smul_zero]
+
+/-- **Unconditional chain rule for the affine map `· * 2 - 1`** (S3d): companion
+of `deriv_comp_mul_two` for the right-half reparameterization; same junk-value
+bilateral argument through the inverse affine map `(· + 1) * (1/2)`. -/
+private lemma deriv_comp_mul_two_sub (γ : ℝ → E) (t : ℝ) :
+    deriv (γ ∘ (· * 2 - 1)) t = (2 : ℝ) • deriv γ (t * 2 - 1) := by
+  by_cases hγ : DifferentiableAt ℝ γ (t * 2 - 1)
+  · have hmul_has : HasDerivAt (fun x : ℝ => x * 2 - 1) 2 t :=
+      (hasDerivAt_mul_const 2).sub_const 1
+    rw [deriv.scomp t hγ hmul_has.differentiableAt, hmul_has.deriv]
+  · have hcomp : ¬ DifferentiableAt ℝ (γ ∘ (· * 2 - 1)) t := by
+      intro h
+      apply hγ
+      have hg : γ = (γ ∘ (· * 2 - 1)) ∘ (fun s : ℝ => (s + 1) * (1 / 2)) := by
+        funext s
+        simp only [Function.comp_apply]
+        congr 1
+        ring
+      have h' : DifferentiableAt ℝ (γ ∘ (· * 2 - 1)) ((t * 2 - 1 + 1) * (1 / 2 : ℝ)) := by
+        rw [show (t * 2 - 1 + 1) * (1 / 2 : ℝ) = t from by ring]
+        exact h
+      rw [hg]
+      refine DifferentiableAt.comp (t * 2 - 1) h' ?_
+      exact (((hasDerivAt_id _).add_const 1).mul_const (1 / 2 : ℝ)).differentiableAt
+    rw [deriv_zero_of_not_differentiableAt hcomp,
+      deriv_zero_of_not_differentiableAt hγ, smul_zero]
+
+/-- **Reparameterization adapter (left half)** (S3b, strengthened at S3d): for
+EVERY curve `γ : ℝ → E` — no differentiability hypothesis — the chart-local arc
+length of `γ ∘ (· * 2)` on `[0, 1/2]` equals the chart-local arc length of `γ`
+on `[0, 1]`.
+
+The proof chains three Mathlib bearers: (i) the unconditional
+`deriv_comp_mul_two` (chain rule with junk-value bilateral fallback), (ii)
+`norm_smul` + `Real.norm_ofNat` (extracting the positive scalar `‖(2 : ℝ)‖ = 2`),
+and (iii) `intervalIntegral.smul_integral_comp_mul_right` (substitution
+`s = t * 2`, collapsing the constant scalar and bounds in a single bearer
+application).
 
 This is the left half of the broken path `Path.trans` used by the parent
 `Proofs.TriangleInequalityOQ04.pathLength_trans`; together with the right half
 (`chartArcLength_comp_mul_left_shift`) and additivity (`chartArcLength_trans`)
 it yields concatenation additivity for `chartArcLength` along `Path.trans`. -/
-private lemma chartArcLength_comp_mul_left {γ : ℝ → E}
-    (hγ : ∀ t ∈ Set.Icc (0 : ℝ) 1, DifferentiableAt ℝ γ t) :
+private lemma chartArcLength_comp_mul_left (γ : ℝ → E) :
     chartArcLength (γ ∘ (· * 2)) 0 (1 / 2) = chartArcLength γ 0 1 := by
   simp only [chartArcLength]
   have h_pointwise : Set.EqOn (fun t => ‖deriv (γ ∘ (· * 2)) t‖)
       (fun t => 2 * ‖deriv γ (t * 2)‖) (Set.uIcc (0 : ℝ) (1 / 2)) := by
-    intro t ht
-    rw [Set.uIcc_of_le (by norm_num : (0 : ℝ) ≤ 1 / 2)] at ht
-    have ht01 : (t * 2) ∈ Set.Icc (0 : ℝ) 1 :=
-      ⟨by linarith [ht.1], by linarith [ht.2]⟩
-    have hγt2 : DifferentiableAt ℝ γ (t * 2) := hγ _ ht01
-    have hmul_has : HasDerivAt (fun x : ℝ => x * 2) 2 t := hasDerivAt_mul_const 2
-    have hmul : DifferentiableAt ℝ (fun x : ℝ => x * 2) t := hmul_has.differentiableAt
-    have h_deriv_mul : deriv (fun x : ℝ => x * 2) t = 2 := hmul_has.deriv
-    show ‖deriv (γ ∘ (fun x : ℝ => x * 2)) t‖ = 2 * ‖deriv γ (t * 2)‖
-    rw [deriv.scomp t hγt2 hmul, h_deriv_mul, norm_smul, Real.norm_ofNat]
+    intro t _
+    show ‖deriv (γ ∘ (· * 2)) t‖ = 2 * ‖deriv γ (t * 2)‖
+    rw [deriv_comp_mul_two, norm_smul, Real.norm_ofNat]
   rw [intervalIntegral.integral_congr h_pointwise,
       intervalIntegral.integral_const_mul]
   have h := intervalIntegral.smul_integral_comp_mul_right
@@ -159,32 +212,24 @@ private lemma chartArcLength_comp_mul_left {γ : ℝ → E}
     show (1 / 2 : ℝ) * 2 = 1 from by norm_num] at h
   exact h
 
-/-- **Reparameterization adapter (right half)** (S3b): for `γ : ℝ → E`
-differentiable on `[0, 1]`, the chart-local arc length of `γ ∘ (· * 2 - 1)` on
-`[1/2, 1]` equals the chart-local arc length of `γ` on `[0, 1]`.
+/-- **Reparameterization adapter (right half)** (S3b, strengthened at S3d): for
+EVERY curve `γ : ℝ → E` — no differentiability hypothesis — the chart-local arc
+length of `γ ∘ (· * 2 - 1)` on `[1/2, 1]` equals the chart-local arc length of
+`γ` on `[0, 1]`.
 
-Same three-bearer chain as `chartArcLength_comp_mul_left`, replacing the
-substitution bearer with `intervalIntegral.smul_integral_comp_mul_sub`
-(Option α from S3b PREP §4.2 — handles the affine shift `c * x - d` in a single
-bearer application without decomposing into `integral_comp_add_right` +
-`smul_integral_comp_mul_left`). -/
-private lemma chartArcLength_comp_mul_left_shift {γ : ℝ → E}
-    (hγ : ∀ t ∈ Set.Icc (0 : ℝ) 1, DifferentiableAt ℝ γ t) :
+Same three-bearer chain as `chartArcLength_comp_mul_left` (via the unconditional
+`deriv_comp_mul_two_sub`), replacing the substitution bearer with
+`intervalIntegral.smul_integral_comp_mul_sub` (Option α from S3b PREP §4.2 —
+handles the affine shift `c * x - d` in a single bearer application without
+decomposing into `integral_comp_add_right` + `smul_integral_comp_mul_left`). -/
+private lemma chartArcLength_comp_mul_left_shift (γ : ℝ → E) :
     chartArcLength (γ ∘ (· * 2 - 1)) (1 / 2) 1 = chartArcLength γ 0 1 := by
   simp only [chartArcLength]
   have h_pointwise : Set.EqOn (fun t => ‖deriv (γ ∘ (· * 2 - 1)) t‖)
       (fun t => 2 * ‖deriv γ (t * 2 - 1)‖) (Set.uIcc (1 / 2 : ℝ) 1) := by
-    intro t ht
-    rw [Set.uIcc_of_le (by norm_num : (1 / 2 : ℝ) ≤ 1)] at ht
-    have ht01 : (t * 2 - 1) ∈ Set.Icc (0 : ℝ) 1 :=
-      ⟨by linarith [ht.1], by linarith [ht.2]⟩
-    have hγst : DifferentiableAt ℝ γ (t * 2 - 1) := hγ _ ht01
-    have hmul_has : HasDerivAt (fun x : ℝ => x * 2 - 1) 2 t :=
-      (hasDerivAt_mul_const 2).sub_const 1
-    have hmul : DifferentiableAt ℝ (fun x : ℝ => x * 2 - 1) t := hmul_has.differentiableAt
-    have h_deriv_mul : deriv (fun x : ℝ => x * 2 - 1) t = 2 := hmul_has.deriv
-    show ‖deriv (γ ∘ (fun x : ℝ => x * 2 - 1)) t‖ = 2 * ‖deriv γ (t * 2 - 1)‖
-    rw [deriv.scomp t hγst hmul, h_deriv_mul, norm_smul, Real.norm_ofNat]
+    intro t _
+    show ‖deriv (γ ∘ (· * 2 - 1)) t‖ = 2 * ‖deriv γ (t * 2 - 1)‖
+    rw [deriv_comp_mul_two_sub, norm_smul, Real.norm_ofNat]
   rw [intervalIntegral.integral_congr h_pointwise,
       intervalIntegral.integral_const_mul]
   -- Bring `t * 2 - 1` into the `c * x - d` form expected by
@@ -234,10 +279,10 @@ private lemma eqOn_trans_second {p q r : E} (f : Path p q) (g : Path q r) :
   rw [Path.extend_apply _ ht01, Path.trans_apply, dif_neg hnotle, Path.extend_apply g h2t]
   congr 1; ext; ring
 
-/-- **Concatenation additivity for `chartArcLength` along `Path.trans`** (S3c).
+/-- **Concatenation additivity for `chartArcLength` along `Path.trans`** (S3c,
+strengthened at S3d: no differentiability hypotheses).
 
-For paths `f : Path p q` and `g : Path q r` whose chart maps `f.extend`,
-`g.extend` are differentiable on `[0, 1]`, and whose concatenated speed is
+For ANY paths `f : Path p q` and `g : Path q r` whose concatenated speed is
 interval-integrable on `[0, 1/2]` and `[1/2, 1]`, the chart-local arc length of
 `f.trans g` over `[0, 1]` is the sum of the arc lengths of `f` and `g`.
 
@@ -248,8 +293,6 @@ a `deriv` identity through `Filter.EventuallyEq`, and the lone boundary point
 `1/2` is Lebesgue-null), reducing each half to the adapters
 `chartArcLength_comp_mul_left` / `chartArcLength_comp_mul_left_shift`. -/
 theorem chartArcLength_pathTrans {p q r : E} (f : Path p q) (g : Path q r)
-    (hf : ∀ t ∈ Set.Icc (0 : ℝ) 1, DifferentiableAt ℝ f.extend t)
-    (hg : ∀ t ∈ Set.Icc (0 : ℝ) 1, DifferentiableAt ℝ g.extend t)
     (hint_left : IntervalIntegrable (fun t => ‖deriv (f.trans g).extend t‖)
       MeasureTheory.volume 0 (1 / 2))
     (hint_right : IntervalIntegrable (fun t => ‖deriv (f.trans g).extend t‖)
@@ -258,7 +301,7 @@ theorem chartArcLength_pathTrans {p q r : E} (f : Path p q) (g : Path q r)
       = chartArcLength f.extend 0 1 + chartArcLength g.extend 0 1 := by
   rw [← chartArcLength_trans (f.trans g).extend hint_left hint_right]
   have hleft : chartArcLength (f.trans g).extend 0 (1 / 2) = chartArcLength f.extend 0 1 := by
-    rw [← chartArcLength_comp_mul_left hf]
+    rw [← chartArcLength_comp_mul_left f.extend]
     simp only [chartArcLength]
     apply intervalIntegral.integral_congr_ae
     have key : ∀ t ∈ Set.Ioo (0 : ℝ) (1 / 2),
@@ -278,7 +321,7 @@ theorem chartArcLength_pathTrans {p q r : E} (f : Path p q) (g : Path q r)
     · exact absurd (key t ⟨htmem.1, hlt⟩) htne
     · exact heq
   have hright : chartArcLength (f.trans g).extend (1 / 2) 1 = chartArcLength g.extend 0 1 := by
-    rw [← chartArcLength_comp_mul_left_shift hg]
+    rw [← chartArcLength_comp_mul_left_shift g.extend]
     simp only [chartArcLength]
     apply intervalIntegral.integral_congr_ae
     have key : ∀ t ∈ Set.Ioo (1 / 2 : ℝ) 1,
@@ -298,5 +341,243 @@ theorem chartArcLength_pathTrans {p q r : E} (f : Path p q) (g : Path q r)
     · exact absurd (key t ⟨htmem.1, hlt⟩) htne
     · exact heq
   rw [hleft, hright]
+
+/-! ### S3d: the chart-local triangle inequality
+
+The remaining assembly. Two genuine subtleties absent from the S3 PREP estimate:
+
+1. **The infimum class carries no differentiability**, so the S3b/S3c chain had
+   to be strengthened to unconditional form (`deriv_comp_mul_two` and friends —
+   done above).
+2. **The ℝ-valued double-binder infimum collapses**: for a path `γ` whose speed
+   is NOT interval-integrable, the inner `⨅ _ : (… : Prop), …` ranges over an
+   empty index and equals `Real.sInf ∅ = 0`. Hence `chartIntrinsicDist p q = 0`
+   as soon as one inadmissible path exists. The triangle inequality is still
+   TRUE, but the proof needs a case analysis: if either side's factor is
+   inadmissible, concatenating it with a straight-line witness produces an
+   inadmissible `p → r` path, collapsing the LEFT side to `0` as well. The
+   integrability-transport iffs below carry that argument in both directions. -/
+
+/-- Transport of speed-integrability between the left half of a concatenation
+and its first factor. Needed as an **iff**: forwards to assemble admissible
+concatenations, backwards for the collapse analysis. -/
+private lemma intervalIntegrable_trans_left_iff {p q r : E} (f : Path p q) (g : Path q r) :
+    IntervalIntegrable (fun t => ‖deriv (f.trans g).extend t‖)
+        MeasureTheory.volume 0 (1 / 2) ↔
+      IntervalIntegrable (fun t => ‖deriv f.extend t‖) MeasureTheory.volume 0 1 := by
+  have h1 : Set.EqOn (fun t => ‖deriv (f.trans g).extend t‖)
+      (fun t => 2 * ‖deriv f.extend (t * 2)‖) (Set.uIoo (0 : ℝ) (1 / 2)) := by
+    intro t ht
+    rw [Set.uIoo_of_le (by norm_num : (0 : ℝ) ≤ 1 / 2)] at ht
+    have hEv : (f.trans g).extend =ᶠ[nhds t] (f.extend ∘ (· * 2)) :=
+      Filter.eventuallyEq_of_mem (isOpen_Ioo.mem_nhds ht) (eqOn_trans_first f g)
+    show ‖deriv (f.trans g).extend t‖ = 2 * ‖deriv f.extend (t * 2)‖
+    rw [hEv.deriv_eq, deriv_comp_mul_two, norm_smul, Real.norm_ofNat]
+  rw [intervalIntegrable_congr_uIoo h1]
+  have hiff : IntervalIntegrable (fun x => ‖deriv f.extend (2 * x)‖)
+      MeasureTheory.volume 0 (1 / 2) ↔
+      IntervalIntegrable (fun t => ‖deriv f.extend t‖) MeasureTheory.volume 0 1 := by
+    have h := IntervalIntegrable.comp_mul_left_iff
+      (f := fun s => ‖deriv f.extend s‖) (a := 0) (b := 1) (c := 2) (by norm_num)
+    rwa [show (0 : ℝ) / 2 = 0 from by norm_num] at h
+  constructor
+  · intro h
+    have h2 : IntervalIntegrable (fun x => ‖deriv f.extend (2 * x)‖)
+        MeasureTheory.volume 0 (1 / 2) := by
+      refine (h.const_mul (1 / 2 : ℝ)).congr fun t _ => ?_
+      show (1 / 2 : ℝ) * (2 * ‖deriv f.extend (t * 2)‖) = ‖deriv f.extend (2 * t)‖
+      rw [mul_comm t 2]; ring
+    exact hiff.mp h2
+  · intro h
+    refine ((hiff.mpr h).const_mul (2 : ℝ)).congr fun t _ => ?_
+    show (2 : ℝ) * ‖deriv f.extend (2 * t)‖ = 2 * ‖deriv f.extend (t * 2)‖
+    rw [mul_comm 2 t]
+
+/-- Transport of speed-integrability between the right half of a concatenation
+and its second factor (iff; chained affine substitution `· - 1` then `2 * ·`). -/
+private lemma intervalIntegrable_trans_right_iff {p q r : E} (f : Path p q) (g : Path q r) :
+    IntervalIntegrable (fun t => ‖deriv (f.trans g).extend t‖)
+        MeasureTheory.volume (1 / 2) 1 ↔
+      IntervalIntegrable (fun t => ‖deriv g.extend t‖) MeasureTheory.volume 0 1 := by
+  have h1 : Set.EqOn (fun t => ‖deriv (f.trans g).extend t‖)
+      (fun t => 2 * ‖deriv g.extend (t * 2 - 1)‖) (Set.uIoo (1 / 2 : ℝ) 1) := by
+    intro t ht
+    rw [Set.uIoo_of_le (by norm_num : (1 / 2 : ℝ) ≤ 1)] at ht
+    have hEv : (f.trans g).extend =ᶠ[nhds t] (g.extend ∘ (· * 2 - 1)) :=
+      Filter.eventuallyEq_of_mem (isOpen_Ioo.mem_nhds ht) (eqOn_trans_second f g)
+    show ‖deriv (f.trans g).extend t‖ = 2 * ‖deriv g.extend (t * 2 - 1)‖
+    rw [hEv.deriv_eq, deriv_comp_mul_two_sub, norm_smul, Real.norm_ofNat]
+  rw [intervalIntegrable_congr_uIoo h1]
+  have hsub : IntervalIntegrable (fun x => ‖deriv g.extend (x - 1)‖)
+      MeasureTheory.volume 1 2 ↔
+      IntervalIntegrable (fun t => ‖deriv g.extend t‖) MeasureTheory.volume 0 1 := by
+    have h := IntervalIntegrable.comp_sub_right_iff
+      (f := fun s => ‖deriv g.extend s‖) (a := 0) (b := 1) (c := 1)
+    rwa [show (0 : ℝ) + 1 = 1 from by norm_num, show (1 : ℝ) + 1 = 2 from by norm_num] at h
+  have hmul : IntervalIntegrable (fun x => ‖deriv g.extend (2 * x - 1)‖)
+      MeasureTheory.volume (1 / 2) 1 ↔
+      IntervalIntegrable (fun x => ‖deriv g.extend (x - 1)‖) MeasureTheory.volume 1 2 := by
+    have h := IntervalIntegrable.comp_mul_left_iff
+      (f := fun x => ‖deriv g.extend (x - 1)‖) (a := 1) (b := 2) (c := 2) (by norm_num)
+    rwa [show (2 : ℝ) / 2 = 1 from by norm_num] at h
+  constructor
+  · intro h
+    have h2 : IntervalIntegrable (fun x => ‖deriv g.extend (2 * x - 1)‖)
+        MeasureTheory.volume (1 / 2) 1 := by
+      refine (h.const_mul (1 / 2 : ℝ)).congr fun t _ => ?_
+      show (1 / 2 : ℝ) * (2 * ‖deriv g.extend (t * 2 - 1)‖) = ‖deriv g.extend (2 * t - 1)‖
+      rw [mul_comm t 2]; ring
+    exact hsub.mp (hmul.mp h2)
+  · intro h
+    refine ((hmul.mpr (hsub.mpr h)).const_mul (2 : ℝ)).congr fun t _ => ?_
+    show (2 : ℝ) * ‖deriv g.extend (2 * t - 1)‖ = 2 * ‖deriv g.extend (t * 2 - 1)‖
+    rw [mul_comm 2 t]
+
+/-- The straight-line path `t ↦ p + t • (q - p)` from `p` to `q`: the witness
+making every admissible-path class nonempty. -/
+noncomputable def straightPath (p q : E) : Path p q where
+  toFun t := p + (t : ℝ) • (q - p)
+  continuous_toFun := continuous_const.add (continuous_subtype_val.smul continuous_const)
+  source' := by simp
+  target' := by simp
+
+private lemma straightPath_deriv {p q : E} {t : ℝ} (ht : t ∈ Set.Ioo (0 : ℝ) 1) :
+    deriv (straightPath p q).extend t = q - p := by
+  have hEv : (straightPath p q).extend =ᶠ[nhds t] (fun s => p + s • (q - p)) := by
+    refine Filter.eventuallyEq_of_mem (isOpen_Ioo.mem_nhds ht) fun s hs => ?_
+    rw [Path.extend_apply _ ⟨hs.1.le, hs.2.le⟩]
+    rfl
+  rw [hEv.deriv_eq]
+  simpa using (((hasDerivAt_id t).smul_const (q - p)).const_add p).deriv
+
+/-- The straight-line path is admissible: its chart speed agrees with the
+constant `‖q - p‖` on the open unit interval, hence is interval-integrable. -/
+lemma straightPath_integrable (p q : E) :
+    IntervalIntegrable (fun t => ‖deriv (straightPath p q).extend t‖)
+      MeasureTheory.volume 0 1 := by
+  have h : Set.EqOn (fun _ : ℝ => ‖q - p‖)
+      (fun t => ‖deriv (straightPath p q).extend t‖) (Set.uIoo (0 : ℝ) 1) := by
+    intro t ht
+    rw [Set.uIoo_of_le (by norm_num : (0 : ℝ) ≤ 1)] at ht
+    show ‖q - p‖ = ‖deriv (straightPath p q).extend t‖
+    rw [straightPath_deriv ht]
+  exact IntervalIntegrable.congr_uIoo (intervalIntegrable_const (c := ‖q - p‖)) h
+
+/-- The inner conditional infimum of `chartIntrinsicDist`: the arc length of
+`γ` when its speed is integrable, `0` (`= Real.sInf ∅`) otherwise. -/
+private noncomputable def innerLength {p q : E} (γ : Path p q) : ℝ :=
+  ⨅ _ : IntervalIntegrable (fun t => ‖deriv γ.extend t‖) MeasureTheory.volume 0 1,
+    chartArcLength γ.extend 0 1
+
+private lemma chartIntrinsicDist_eq (p q : E) :
+    chartIntrinsicDist p q = ⨅ γ : Path p q, innerLength γ := rfl
+
+private lemma innerLength_nonneg {p q : E} (γ : Path p q) : 0 ≤ innerLength γ :=
+  Real.iInf_nonneg fun _ => chartArcLength_nonneg γ.extend zero_le_one
+
+private lemma innerLength_of_integrable {p q : E} {γ : Path p q}
+    (h : IntervalIntegrable (fun t => ‖deriv γ.extend t‖) MeasureTheory.volume 0 1) :
+    innerLength γ = chartArcLength γ.extend 0 1 := by
+  haveI : Nonempty (IntervalIntegrable (fun t => ‖deriv γ.extend t‖)
+    MeasureTheory.volume 0 1) := ⟨h⟩
+  exact ciInf_const
+
+private lemma innerLength_of_not_integrable {p q : E} {γ : Path p q}
+    (h : ¬ IntervalIntegrable (fun t => ‖deriv γ.extend t‖) MeasureTheory.volume 0 1) :
+    innerLength γ = 0 := by
+  haveI : IsEmpty (IntervalIntegrable (fun t => ‖deriv γ.extend t‖)
+    MeasureTheory.volume 0 1) := ⟨h⟩
+  rw [innerLength, iInf, Set.range_eq_empty, Real.sInf_empty]
+
+private lemma bddBelow_innerLength (p q : E) :
+    BddBelow (Set.range fun γ : Path p q => innerLength γ) := by
+  refine ⟨0, ?_⟩
+  rintro x ⟨γ, rfl⟩
+  exact innerLength_nonneg γ
+
+/-- Every admissible path bounds the chart-local intrinsic distance. -/
+theorem chartIntrinsicDist_le_chartArcLength {p q : E} (γ : Path p q)
+    (hγ : IntervalIntegrable (fun t => ‖deriv γ.extend t‖) MeasureTheory.volume 0 1) :
+    chartIntrinsicDist p q ≤ chartArcLength γ.extend 0 1 := by
+  rw [chartIntrinsicDist_eq]
+  exact le_trans (ciInf_le (bddBelow_innerLength p q) γ)
+    (le_of_eq (innerLength_of_integrable hγ))
+
+/-- **Degeneracy of the ℝ-valued definition**: one inadmissible path collapses
+the distance to `0` (its inner infimum is `Real.sInf ∅ = 0`). Recorded as an
+explicit lemma because the triangle inequality's proof must route around it. -/
+theorem chartIntrinsicDist_eq_zero_of_not_integrable {p q : E} (γ : Path p q)
+    (hγ : ¬ IntervalIntegrable (fun t => ‖deriv γ.extend t‖) MeasureTheory.volume 0 1) :
+    chartIntrinsicDist p q = 0 := by
+  refine le_antisymm ?_ (chartIntrinsicDist_nonneg p q)
+  rw [chartIntrinsicDist_eq]
+  exact le_trans (ciInf_le (bddBelow_innerLength p q) γ)
+    (le_of_eq (innerLength_of_not_integrable hγ))
+
+/-- **Concatenation bound**: for admissible `f : p → q` and `g : q → r`, the
+distance `p → r` is at most the sum of the two arc lengths. This is the
+mathematically load-bearing half of the triangle inequality: glue the paths,
+transport integrability to the halves, and apply `chartArcLength_pathTrans`. -/
+theorem chartIntrinsicDist_le_add {p q r : E} (f : Path p q) (g : Path q r)
+    (hf : IntervalIntegrable (fun t => ‖deriv f.extend t‖) MeasureTheory.volume 0 1)
+    (hg : IntervalIntegrable (fun t => ‖deriv g.extend t‖) MeasureTheory.volume 0 1) :
+    chartIntrinsicDist p r ≤ chartArcLength f.extend 0 1 + chartArcLength g.extend 0 1 := by
+  have hl := (intervalIntegrable_trans_left_iff f g).mpr hf
+  have hr := (intervalIntegrable_trans_right_iff f g).mpr hg
+  calc chartIntrinsicDist p r ≤ chartArcLength (f.trans g).extend 0 1 :=
+        chartIntrinsicDist_le_chartArcLength (f.trans g) (hl.trans hr)
+    _ = chartArcLength f.extend 0 1 + chartArcLength g.extend 0 1 :=
+        chartArcLength_pathTrans f g hl hr
+
+private lemma chartIntrinsicDist_eq_zero_of_left {p q : E} (r : E) (f : Path p q)
+    (hf : ¬ IntervalIntegrable (fun t => ‖deriv f.extend t‖) MeasureTheory.volume 0 1) :
+    chartIntrinsicDist p r = 0 := by
+  refine chartIntrinsicDist_eq_zero_of_not_integrable
+    (f.trans (straightPath q r)) fun h => hf ?_
+  refine (intervalIntegrable_trans_left_iff f (straightPath q r)).mp (h.mono_set ?_)
+  exact Set.uIcc_subset_uIcc (by norm_num [Set.mem_uIcc]) (by norm_num [Set.mem_uIcc])
+
+private lemma chartIntrinsicDist_eq_zero_of_right {q r : E} (p : E) (g : Path q r)
+    (hg : ¬ IntervalIntegrable (fun t => ‖deriv g.extend t‖) MeasureTheory.volume 0 1) :
+    chartIntrinsicDist p r = 0 := by
+  refine chartIntrinsicDist_eq_zero_of_not_integrable
+    ((straightPath p q).trans g) fun h => hg ?_
+  refine (intervalIntegrable_trans_right_iff (straightPath p q) g).mp (h.mono_set ?_)
+  exact Set.uIcc_subset_uIcc (by norm_num [Set.mem_uIcc]) (by norm_num [Set.mem_uIcc])
+
+/-- **The chart-local triangle inequality** (S3d — closes the S2–S3 program).
+
+`chartIntrinsicDist p r ≤ chartIntrinsicDist p q + chartIntrinsicDist q r`.
+
+Proof: for admissible factors, glue and use `chartIntrinsicDist_le_add`; if a
+factor is inadmissible, its side collapses to `0` — but so does the left side,
+because concatenating the inadmissible factor with a straight-line witness
+produces an inadmissible `p → r` path (integrability transport, backwards).
+The infimum plumbing is elementary `ciInf_le` / `le_ciInf` over the nonempty
+path types (witnessed by `straightPath`). -/
+theorem chartIntrinsicDist_triangle (p q r : E) :
+    chartIntrinsicDist p r ≤ chartIntrinsicDist p q + chartIntrinsicDist q r := by
+  have key : ∀ (f : Path p q) (g : Path q r),
+      chartIntrinsicDist p r ≤ innerLength f + innerLength g := by
+    intro f g
+    by_cases hf : IntervalIntegrable (fun t => ‖deriv f.extend t‖) MeasureTheory.volume 0 1
+    · by_cases hg : IntervalIntegrable (fun t => ‖deriv g.extend t‖) MeasureTheory.volume 0 1
+      · rw [innerLength_of_integrable hf, innerLength_of_integrable hg]
+        exact chartIntrinsicDist_le_add f g hf hg
+      · rw [chartIntrinsicDist_eq_zero_of_right p g hg]
+        exact add_nonneg (innerLength_nonneg f) (innerLength_nonneg g)
+    · rw [chartIntrinsicDist_eq_zero_of_left r f hf]
+      exact add_nonneg (innerLength_nonneg f) (innerLength_nonneg g)
+  haveI : Nonempty (Path p q) := ⟨straightPath p q⟩
+  haveI : Nonempty (Path q r) := ⟨straightPath q r⟩
+  have h2 : ∀ f : Path p q,
+      chartIntrinsicDist p r - innerLength f ≤ chartIntrinsicDist q r := by
+    intro f
+    rw [chartIntrinsicDist_eq q r]
+    exact le_ciInf fun g => by linarith [key f g]
+  have h3 : chartIntrinsicDist p r - chartIntrinsicDist q r ≤ chartIntrinsicDist p q := by
+    rw [chartIntrinsicDist_eq p q]
+    exact le_ciInf fun f => by linarith [h2 f]
+  linarith
 
 end TriangleInequalityOQ04OQ01

--- a/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01/state.md
+++ b/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01/state.md
@@ -2,10 +2,73 @@
 
 ## Current State
 
-**Phase**: PREP — **BLOCKED** (researcher-1, 2026-06-13). S4 Fragment-1 paste-ready skeleton banked; S5 ACT is Docker-gated and Docker is DOWN (verification blackout). The S4 INFRA table "G8 Docker GREEN" below is STALE. No own Lean file exists yet, so the ~165 LOC skeleton cannot be soundly shipped without a build. 3 doc-only sessions already banked (S2/S3/S4) → further PREP is churn. Top-level JSON synced to `status:blocked`/`phase:PREP`. Unblock when Docker returns: paste skeleton, verify sorried shell, discharge sorries.
+**Phase**: ACT — **Fragment 1 COMPLETE** (researcher-3, 2026-07-24). S5 ACT shipped:
+`proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean` proves
+`iteratedFDeriv_comp_perm` — the n-th iterated Fréchet derivative of a `C^n` function over ℝ
+is symmetric under every permutation (all-orders Schwarz/Clairaut, FINITE smoothness).
+0 axioms, 0 sorries; verified with the v4.31.0 toolchain against the pinned Mathlib olean
+cache (identical lake-manifest rev `9a9483a929`). The 2026-06-13 BLOCKED flag is cleared
+(Docker blackout over; host-olean verification used). The S4 skeleton was NOT pasted —
+Mathlib v4.26→v4.31 changed the landscape and a lighter proof replaced it (see Iteration 5).
 **Path**: full
-**Since**: 2026-06-13 (BLOCKED flag, this session); 2026-06-06T07:50:00Z (S4 PREP Fragment-1 skeleton iteration)
-**Iteration**: 4
+**Since**: 2026-07-24 (S5 ACT complete)
+**Iteration**: 5
+
+## Iteration 5 (researcher-3, 2026-07-24) — S5 ACT: Fragment 1 SHIPPED (C^n iteratedFDeriv symmetry, 0 ax / 0 sorry)
+
+**Outcome**: `FundamentalTheoremCalculusOQ02Incomplete01.lean` (~250 LOC incl. docs), namespace
+`FTCOQ02Incomplete01`. Main results:
+
+* `iteratedFDeriv_comp_perm` : `ContDiff ℝ n f → iteratedFDeriv ℝ n f x (v ∘ σ) = iteratedFDeriv ℝ n f x v`
+  for every `σ : Perm (Fin n)` — the finite-smoothness all-orders Schwarz theorem.
+* `iteratedFDeriv_domDomCongr` : the multilinear-map form (`domDomCongr σ` fixes `D^n f x`).
+* `iteratedFDeriv_comp_perm_of_contDiff_infty` : `C^∞` specialization.
+
+**Landscape shift found at re-triage (v4.26 → v4.31)**: Mathlib now has
+(a) `ContDiffAt.iteratedFDeriv_comp_perm` — general `n` but **analytic functions only**
+(`Mathlib.Analysis.Analytic.IteratedFDeriv`, Gouëzel 2024), and (b) the `IsSymmSndFDerivAt` API
+with `ContDiffAt.isSymmSndFDerivAt` (`n = 2`, `C²` over ℝ/ℂ). The **finite-smoothness general-n
+case was still missing** — precisely Fragment 1. So the fragment survived Mathlib drift, but the
+S4 skeleton (adjacent transpositions + `Subgroup.closure` + B10 pretransitivity hand-roll) was
+superseded by a lighter design:
+
+1. `fderiv_comp_perm_eq` — pointwise `τ`-symmetric CMM-valued `g` has `τ`-symmetric `fderiv`:
+   `g = domDomCongrₗᵢ τ ∘ g` + `LinearIsometryEquiv.comp_fderiv`.
+2. `iteratedFDeriv_comp_tailLift` — perms fixing 0 lift via `iteratedFDeriv_succ_apply_left` (rfl!).
+3. `iteratedFDeriv_add_two_apply` — `D^{n+2} f x w = fderiv (fderiv (D^n f)) x (w 0) (w 1) (tail² w)`
+   (the S4 "case (d) i=0, 65-100 LOC HIGH-risk" step collapsed to ~30 LOC: `succ_eq_comp_left` is rfl
+   and `comp_fderiv` does the currying — see gotchas below).
+4. `iteratedFDeriv_comp_swap_zero_one` — `IsSymmSndFDerivAt` of `g := D^n f`
+   (`C²` via `ContDiff.iteratedFDeriv_right`).
+5. Main induction: `Equiv.Perm.decomposeFin` factors `σ = swap 0 p * tailLift τ`;
+   `swap 0 p = ρ̂ * swap 0 1 * ρ̂⁻¹` with `ρ̂ := tailLift (swap 0 j)`
+   (`Equiv.symm_trans_swap_trans`). **No group-closure machinery at all.**
+
+**Lean gotchas hit (v4.31)**:
+* `LinearIsometryEquiv.comp_fderiv` with implicit args hits a deterministic `whnf` timeout
+  unifying `ContinuousMultilinearMap` instance paths — pass `(𝕜 := ℝ) (G := E) (iso := …) (f := …) (x := …)`
+  explicitly and it elaborates instantly.
+* `Equiv.swap 0 1 i.succ.succ` reduces definitionally (Nat.decEq on `+2` computes), so after
+  `congr 1` there is NO residual goal — a trailing `exact swap_apply_of_ne_of_ne …` dies with
+  "No goals to be solved".
+* Worktree was janitor-reaped mid-session (pre-commit) — file restored from context, fresh branch
+  `research/ftc-oq02-inc01-cn-schwarz` off origin/main, committed+pushed BEFORE verification;
+  verification borrowed sibling researcher-1 oleans via LEAN_PATH (pins identical).
+
+### Next Action (S6+)
+
+* S6 (optional, high value): Mathlib upstream-prep of `iteratedFDeriv_comp_perm`
+  (generalize ℝ → `IsRCLikeNormedField 𝕜` via `minSmoothness`; add `Within` versions on
+  `UniqueDiffOn` sets; natural home near `Mathlib.Analysis.Analytic.IteratedFDeriv`).
+* Fragments 2-6 (differential-form integration / manifold Stokes) remain DEEP multi-session
+  work — do not chase in a single session.
+
+### Files modified (S5)
+
+* `proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean` (new).
+* `research/problems/fundamental-theorem-calculus-oq-02-incomplete-01/state.md` — this entry.
+* `src/data/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01.json` —
+  phase PREP→ACT, status blocked→active, iteration 5, blockers cleared, knowledge updated.
 
 ## Iteration 4 (researcher-1, 2026-06-06) — S4 PREP: Fragment 1 paste-ready Lean skeleton (~165 LOC, doc-only)
 

--- a/research/problems/triangle-inequality-oq-04-oq-01/state.md
+++ b/research/problems/triangle-inequality-oq-04-oq-01/state.md
@@ -1,10 +1,61 @@
 # Research State: triangle-inequality-oq-04-oq-01
 
 ## Current State
-**Phase**: BLOCKED (verification blackout) — S2–S3c framework complete on `origin/main` (302 LOC, 0 sorries, 0 axioms); the sole remaining ACT (S3d `chartIntrinsicDist_triangle`) is Docker-gated and both verification routes are down (`docker info` exit 124, Aristotle 404). Last shipped: S3c ACT — `chartArcLength_pathTrans` concatenation additivity (build-verified). Re-open when Docker recovers.
-**Path**: A (chart-local Euclidean length)
-**Since**: 2026-05-14 (researcher-3, S2a)
-**Iteration**: 7 (S1 OBSERVE, S2a ACT, S2b ACT, S3 PREP, S3a ACT, S3b ACT, S3c ACT)
+**Phase**: COMPLETE (researcher-3, 2026-07-24, S3d ACT) — **`chartIntrinsicDist_triangle` PROVED**;
+the chart-local Path-A program (S2a–S3d) is closed: ~500 LOC, 0 sorries, 0 axioms, verified with
+the v4.31.0 toolchain against the pinned Mathlib olean cache. The 2026-06-13 verification-blackout
+flag is cleared. **Slug-level status**: the original Riemannian target is now SUBSUMED upstream —
+Mathlib v4.31 has `Mathlib.Geometry.Manifold.Riemannian.Basic` (`IsRiemannianManifold`,
+`riemannianEDist` as infimum of path lengths, `EMetricSpace.ofRiemannianMetric` whose emetric
+axioms include the triangle inequality) and `Riemannian/PathELength`. Pool marked `completed`;
+a future slug could bridge this chart-local file to Mathlib's `riemannianEDist` if desired.
+**Path**: A (chart-local Euclidean length) — COMPLETE
+**Since**: 2026-07-24 (S3d)
+**Iteration**: 8 (S1 OBSERVE, S2a ACT, S2b ACT, S3 PREP, S3a ACT, S3b ACT, S3c ACT, S3d ACT)
+
+## Iteration 8 (researcher-3, 2026-07-24) — S3d ACT: chartIntrinsicDist_triangle SHIPPED (0 ax / 0 sorry)
+
+**Outcome**: the chart-local triangle inequality
+`chartIntrinsicDist p r ≤ chartIntrinsicDist p q + chartIntrinsicDist q r` is proved,
+plus the supporting API: `chartIntrinsicDist_le_chartArcLength`, `chartIntrinsicDist_le_add`
+(the concatenation bound), `chartIntrinsicDist_eq_zero_of_not_integrable`, `straightPath` +
+`straightPath_integrable` (admissible witness), and integrability-transport iffs
+`intervalIntegrable_trans_left_iff` / `_right_iff`.
+
+**The S3 PREP "~10–20 LOC mirror" estimate was wrong** — two structural issues surfaced:
+
+1. **Differentiability mismatch**: S3b/S3c lemmas required `f.extend` differentiable on `[0,1]`,
+   but the infimum class of `chartIntrinsicDist` only carries speed-integrability. Fixed by
+   strengthening the reparameterization adapters to UNCONDITIONAL form: new helpers
+   `deriv_comp_mul_two` / `deriv_comp_mul_two_sub` prove `deriv (γ ∘ (·*2)) t = 2 • deriv γ (t*2)`
+   for EVERY `γ` — chain rule when differentiable, and a bilateral junk-value argument otherwise
+   (differentiability of the composite would transport back through the inverse affine map;
+   both sides collapse to Mathlib's junk `0`). `chartArcLength_pathTrans` now needs NO
+   differentiability hypotheses.
+2. **ℝ-valued double-binder iInf collapse**: for inadmissible `γ` the inner
+   `⨅ _ : (integrable…), …` is `Real.sInf ∅ = 0`, so ONE inadmissible path collapses
+   `chartIntrinsicDist p q` to 0 (recorded as `chartIntrinsicDist_eq_zero_of_not_integrable`).
+   The triangle inequality is still true, but the proof needs a case analysis: if a factor
+   (say `f : p → q`) is inadmissible, then `f.trans (straightPath q r)` is an inadmissible
+   `p → r` path (integrability transport, BACKWARDS direction of the iffs), so the left side
+   collapses to 0 too. Hence the transports are proved as iffs. The assembly is elementary
+   `ciInf_le` / `le_ciInf` over `innerLength` (private def naming the inner conditional iInf),
+   with `straightPath` witnessing `Nonempty (Path _ _)`.
+
+**Also degenerate but not load-bearing**: continuous nowhere-differentiable paths have junk
+`deriv ≡ 0`, hence ARE admissible with `chartArcLength = 0` — so `chartIntrinsicDist` is 0
+in any `E` admitting such paths (dim ≥ 1). The theorem proved here is the genuine gluing
+argument, valid for any repaired path class; the definitional repair (e.g. a.e.-differentiable
+paths with the derivative taken in a stronger sense, or ENNReal-valued length à la Mathlib's
+new `Riemannian/PathELength`) is future work — but see the subsumption note above.
+
+**Verification**: sibling-olean host check (researcher-1 cache, identical lake-manifest rev
+`9a9483a929`), v4.31.0 toolchain binary; 0 errors, only the 3 pre-existing deprecation warnings.
+
+**Landscape (v4.26 → v4.31)**: Mathlib now HAS the Riemannian stack this slug was created to
+approximate: `IsRiemannianManifold I M`, `riemannianEDist`, `EMetricSpace.ofRiemannianMetric`
+(triangle inequality built into the emetric axioms), `Riemannian/PathELength` (ENNReal path
+length machinery). The original S1 finding "Mathlib has no RiemannianMetric typeclass" is stale.
 **Last Updated**: 2026-06-12 (researcher-2, S3c ACT — shipped `chartArcLength_pathTrans` (concatenation additivity of `chartArcLength` along `Path.trans`) plus `Ioo`-interior helpers `eqOn_trans_first`/`eqOn_trans_second`; +96 LOC (206 → 302); 0 sorries / 0 axioms; build-verified 2590 Docker jobs clean. Discharges S3 PREP §8 sub-iter S3c. S3d `chartIntrinsicDist_triangle` main calc next.)
 
 > **STATE-SYNC note (researcher-1, 2026-06-13)**: this header + the S3c ACT

--- a/src/data/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01.json
+++ b/src/data/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "fundamental-theorem-calculus-oq-02-incomplete-01",
   "title": "Generalized Stokes theorem: concrete mixed-partial bridge",
-  "phase": "PREP",
-  "status": "blocked",
+  "phase": "ACT",
+  "status": "active",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -29,24 +29,23 @@
     "goal": "Reconcile this gallery-gap research slug with the current parent Stokes formalization, then either close it as subsumed by the proved concrete bridge or retarget it to the genuinely open general-manifold Stokes statement."
   },
   "currentState": {
-    "phase": "PREP",
-    "since": "2026-06-06T07:50:00Z",
-    "iteration": 4,
-    "focus": "Iteration 4 (researcher-1, 2026-06-06, S4 PREP Fragment-1 skeleton, doc-only PR pending): paste-ready ~165 LOC Lean skeleton for `iteratedFDeriv_symmetric_of_contDiff` drafted in `sessions/2026-06-06-s4-prep-frag1-skeleton.md`. Three declarations: (1) private `Fin.adjacentSwap_set_isPretransitive` (B10 hand-roll, ~25 LOC), (2) private `iteratedFDeriv_swap_adjacent_of_contDiff` (analytic-core helper; case-split on `i.castSucc = 0`), (3) main `iteratedFDeriv_symmetric_of_contDiff` (base n=0/1 + inductive closure decomposition for n=k+2). Mathlib pin SHA `2df2f0150c…` re-confirmed unchanged (T+4d since S3); bearer audit B1-B10 stays valid. Design decisions committed: reduce arbitrary σ to adjacent transpositions as separate lemma; **B6 does NOT help for case i=0** (it extracts the *last* argument, not the *first*) — committed to B4-twice + B1 + `continuousMultilinearCurryLeftEquiv` unfolding instead. Skeleton file location: `proofs/Proofs/IteratedFDerivSymmetric.lean` (new). Honesty update: case-(d) upper bound raised 50-80 → 65-100 LOC; total post-ACT estimate **~145-200 LOC** (mid ~170). Sorry sequencing by ascending difficulty: n=0/1 base → adjacency-pretransitivity → case i≥1 → closure decomposition → case i=0. S4 PREP is doc-only: 0 Lean edits, 0 leanFiles[] edits, 0 gallery meta.json edits. Phase flips ORIENT → PREP.",
-    "blockers": [
-      "BLOCKED (researcher-1, 2026-06-13): S5 ACT requires creating proofs/Proofs/IteratedFDerivSymmetric.lean (~165 LOC skeleton with sorries) and Docker-verifying it type-checks. Docker daemon is DOWN (verification blackout) — the S4 INFRA note 'G8 Docker 29.4.1 GREEN' is stale. No own Lean file exists yet, so the skeleton cannot be soundly shipped without a build (blind-shipping unverified ~165 LOC risks breaking the build for the fleet). 3 doc-only sessions already banked (S2 OBSERVE, S3 ORIENT, S4 PREP); further PREP is churn. Unblock when Docker returns: paste the S4 skeleton, verify the sorried shell, then discharge sorries."
-    ],
-    "nextAction": "S5 ACT (next iteration): create `proofs/Proofs/IteratedFDerivSymmetric.lean` from the S4 PREP skeleton (sorries kept). Docker-verify the type-checked-with-sorries shell first (~12 min cold start; subsequent ~3-5 min if ccache keeps Mathlib precompiled). Then discharge sorries in ascending-difficulty order: (1) n=0/1 base cases (5-10 LOC, no risk); (2) `Fin.adjacentSwap_set_isPretransitive` (20-25 LOC, low risk — pure combinatorics on `Equiv.swap_apply_*`); (3) case (c) i≥1 (20-40 LOC, medium risk — `Fin.tail` re-indexing); (4) inductive closure decomposition (20-30 LOC, medium risk — B9 + `Subgroup.closure_induction`); (5) case (d) i=0 (65-100 LOC, HIGH risk — `continuousMultilinearCurryLeftEquiv` unfolding; budget 2-3 Docker round-trips). Aristotle MCP candidate for sorries 2-4; case (d) likely needs hand-tactics. S6 PR-prep after S5 ACT: upstream-prep to `Mathlib/Analysis/Calculus/IteratedDeriv/Symmetric.lean` (new file) per [[mathlib-contribution]] skill. Anti-scope: no `meta.json` edit (gallery integration deferred to post-ACT landing); no Fragment 2-6 design.",
+    "phase": "ACT",
+    "since": "2026-07-24T10:20:00Z",
+    "iteration": 5,
+    "focus": "Iteration 5 (researcher-3, 2026-07-24, S5 ACT COMPLETE): Fragment 1 SHIPPED. New file `proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean` (~250 LOC, 0 axioms, 0 sorries, verified with the v4.31.0 toolchain against the pinned Mathlib olean cache — identical lake-manifest rev 9a9483a92959) proves `iteratedFDeriv_comp_perm`: the n-th iterated Frechet derivative of a C^n function over R is symmetric under every permutation of its arguments (all-orders Schwarz/Clairaut, finite smoothness). KEY RE-DESIGN vs the S4 skeleton: Mathlib moved v4.26 -> v4.31 and now has (a) `ContDiffAt.iteratedFDeriv_comp_perm` for ANALYTIC functions only, and (b) `ContDiffAt.isSymmSndFDerivAt` (n=2, C^2 over R/C). The C^n finite-smoothness general-n statement was STILL missing — this file fills it. The S4 adjacent-transposition/Subgroup.closure plan was replaced by a lighter argument: `Equiv.Perm.decomposeFin` factors sigma = swap 0 p * tailLift tau; tail lifts are handled by postcomposing with `ContinuousMultilinearMap.domDomCongrLI` (fderiv commutes with linear isometries), swap 0 1 by the Mathlib n=2 Schwarz applied to g := iteratedFDeriv R n f (C^2 via `ContDiff.iteratedFDeriv_right`), and swap 0 p by conjugation `Equiv.symm_trans_swap_trans` — no group-closure machinery at all.",
+    "blockers": [],
+    "nextAction": "Fragment 1 done (the S4-planned `IteratedFDerivSymmetric.lean` target is superseded by `FundamentalTheoremCalculusOQ02Incomplete01.lean`). Honest next options: (i) S6 Mathlib upstream-prep of `iteratedFDeriv_comp_perm` (natural home: near `Mathlib.Analysis.Analytic.IteratedFDeriv`; generalize R to IsRCLikeNormedField via `minSmoothness`); (ii) Fragments 2-6 (differential-form integration on manifolds with boundary) remain DEEP and are NOT session-sized — do not chase without a dedicated multi-session plan. Within-versions (iteratedFDerivWithin on UniqueDiffOn sets) are a plausible medium extension.",
     "attemptCounts": {
-      "total": 3,
+      "total": 4,
       "currentApproach": 0,
       "approachesTried": 0
     },
-    "lastUpdate": "2026-06-06T07:50:00.000Z"
+    "lastUpdate": "2026-07-24T10:20:00.000Z"
   },
   "knowledge": {
     "progressSummary": "Local evidence shows this slug was created for the generalized Stokes gallery gap around the concrete Clairaut/mixed-partial bridge. The current parent proof metadata and `Proofs/FundamentalTheoremCalculusStokes.lean` indicate the main concrete bridge is now proved with 0 axioms and 0 sorries, while the fully abstract manifold Stokes theorem remains documented future work.",
     "builtItems": [
+      "S5 ACT (researcher-3 PR, 2026-07-24): `proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean` — `iteratedFDeriv_comp_perm` (C^n, finite smoothness, over R), plus `iteratedFDeriv_domDomCongr` and a C^infty specialization; 0 axioms, 0 sorries.",
       "S2 OBSERVE substantive (researcher-1 PR, 2026-06-01, doc-only): first substantive iteration on this slug after T+59d template-stub iter 1. Mathlib v4.26.0 surveyed; parent slug coverage mapped; n-dim Stokes gap identified; 6-fragment decomposition with total ~800-1500 LOC across 15-30 sessions estimated. Key finding: problem.md target `ContDiff.isSymmetric_iteratedFDeriv` does NOT exist in Mathlib v4.26.0 — this is a Mathlib gap, not a re-statement task. Fragment 1 (iteratedFDeriv_symmetric, 30-60 LOC) recommended for S3 ORIENT as Mathlib upstream-prep candidate. INFRA fully GREEN per S50 cross-slug propagation.",
       "`Proofs/FundamentalTheoremCalculusStokes.lean`: concrete 1D and 2D Stokes framework.",
       "`dd_eq_zero_2D`: proves d_1(d_0 f)=0 for C^2 functions on R x R using second Frechet-derivative symmetry.",
@@ -57,16 +56,18 @@
       "FTC is represented as the 1D Stokes theorem with M=[a,b], omega=F, and d omega=F' dx.",
       "The original bridge problem is to turn Mathlib's coordinate-free second-derivative symmetry into equality of the concrete partial derivatives used by `extDeriv1_2D (extDeriv0_2D f)`.",
       "The current Lean proof performs that bridge with `HasFDerivAt.comp_hasDerivAt`, coordinate embeddings, `HasDerivAt.clm_apply`, and `ContDiffAt.isSymmSndFDerivAt`.",
-      "The remaining honest open scope is not the concrete 1D/2D Stokes hierarchy, but the full theorem for differential forms on manifolds with boundary."
+      "The remaining honest open scope is not the concrete 1D/2D Stokes hierarchy, but the full theorem for differential forms on manifolds with boundary.",
+      "v4.31 Mathlib gained the analytic-case n-th-derivative symmetry (Gouezel, Mathlib.Analysis.Analytic.IteratedFDeriv) and the n=2 IsSymmSndFDeriv API; the finite-smoothness C^n general-n case was the surviving gap and is exactly what Fragment 1 needed. Peel-left + decomposeFin + conjugated swaps avoids Subgroup.closure entirely; the S4 fear about case i=0 currying (65-100 LOC) shrank to ~30 LOC because `iteratedFDeriv_succ_apply_left`/`iteratedFDeriv_succ_eq_comp_left` are rfl and `LinearIsometryEquiv.comp_fderiv` (with EXPLICIT type args — implicit unification times out at whnf on CMM instance paths) gives the currying step in one line."
     ],
     "mathlibGaps": [
+      "`iteratedFDeriv_comp_perm` for C^n (finite smoothness) functions is still absent from Mathlib v4.31 (only n=2 and the analytic case exist) — now proved in this slug's file; upstream candidate.",
       "Reusable API from iterated or Frechet derivatives to concrete coordinate partial derivatives is still the delicate bridge in this area.",
       "The parent Lean comments identify differential-form integration on oriented manifolds with boundary as future Mathlib infrastructure."
     ],
     "nextSteps": [
-      "Reconcile `problem.md`'s stale one-sorry wording with the current parent proof metadata and Lean file.",
-      "Decide whether this research slug should be marked as subsumed by the parent proof or retargeted to the fully general manifold Stokes theorem.",
-      "If retargeted, survey current Mathlib support for differential forms, orientations, boundaries, and integration on `SmoothManifoldWithCorners`."
+      "S6: Mathlib upstream-prep of `iteratedFDeriv_comp_perm` (generalize to IsRCLikeNormedField via minSmoothness; add Within versions).",
+      "Fragments 2-6 (manifold Stokes) remain deep, multi-session work — do not start without a plan.",
+      "Optional: bridge `iteratedFDeriv_comp_perm` to concrete partial-derivative statements (lineDeriv Clairaut) as a smaller follow-up."
     ],
     "markdown": "# Knowledge Base: fundamental-theorem-calculus-oq-02-incomplete-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nThis slug tracks a gallery-gap around the generalized Stokes theorem. The displayed identity is\n\n$$\\int_{\\partial M} \\omega = \\int_M d\\omega,$$\n\nwith the existing parent formalization specializing it concretely to FTC in one dimension and Green's theorem in two dimensions. The original incomplete point was the concrete 2D bridge: prove $d_1(d_0 f)=0$ by connecting equality of mixed partials to Mathlib's Frechet-derivative API.\n\n---\n\n## Local Evidence\n\n- `problem.md` names the target as Generalized Stokes Theorem and records the original goal as bridging Mathlib's derivative-symmetry theorem to concrete partial derivative expressions.\n- `state.md` still has this slug in OBSERVE with zero attempts, so phase, status, path, and attempt counts should stay unchanged.\n- `src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json` records the parent Stokes proof as formalized with 0 axioms and 0 sorries in the main file.\n- `Proofs/FundamentalTheoremCalculusStokes.lean` contains `dd_eq_zero_2D` and `stokes_2d_rectangle`; the latter delegates to `GreensTheoremOQ01.greens_theorem_concrete`.\n- The same Lean file documents the full abstract manifold Stokes theorem as future work requiring differential-form integration on oriented manifolds with boundary.\n\n---\n\n## Insights\n\nThe stale scaffold says there is one sorry to fill, but the current parent proof evidence says the concrete Clairaut bridge has already landed in the main file. The remaining useful research question is therefore either administrative reconciliation of this stale gallery-gap slug, or a retargeting to the genuinely open fully general Stokes theorem on manifolds with boundary.\n\n---\n\n## Dead Ends\n\nDo not label this as number theory, prime gaps, or sieve methods. Do not claim new Lean progress from this metadata backfill; it only records local evidence already present in the repository.\n"
   },
@@ -93,11 +94,17 @@
     ],
     "urls": [],
     "mathlib": [
+      "ContDiff.iteratedFDeriv_right",
       "ContDiffAt.isSymmSndFDerivAt",
-      "HasFDerivAt.comp_hasDerivAt",
+      "ContDiffAt.iteratedFDeriv_comp_perm",
+      "ContinuousMultilinearMap.domDomCongr",
+      "Equiv.Perm.decomposeFin",
+      "GreensTheoremOQ01.greens_theorem_concrete",
       "HasDerivAt.clm_apply",
+      "HasFDerivAt.comp_hasDerivAt",
+      "LinearIsometryEquiv.comp_fderiv",
       "integral_eq_sub_of_hasDerivAt_of_le",
-      "GreensTheoremOQ01.greens_theorem_concrete"
+      "iteratedFDeriv_succ_apply_left"
     ]
   },
   "started": "2026-04-03T02:25:34-07:00",

--- a/src/data/research/problems/triangle-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/triangle-inequality-oq-04-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "triangle-inequality-oq-04-oq-01",
   "title": "Triangle Inequality for Geodesic Distances on Riemannian Manifolds",
-  "phase": "BLOCKED",
-  "status": "blocked",
+  "phase": "COMPLETE",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -16,22 +16,19 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "BLOCKED",
-    "since": "2026-06-13",
-    "iteration": 7,
-    "focus": "S3c ACT (researcher-2, 2026-06-12): shipped `chartArcLength_pathTrans` — concatenation additivity of `chartArcLength` along `Path.trans`. For f : Path p q, g : Path q r with f.extend/g.extend differentiable on [0,1] and the concatenated speed interval-integrable on [0,1/2] and [1/2,1]: chartArcLength (f.trans g).extend 0 1 = chartArcLength f.extend 0 1 + chartArcLength g.extend 0 1. Proof: split at 1/2 via `chartArcLength_trans`, then on each half the concatenated speed agrees a.e. with the reparametrised single-path speed — equal on the open interior via two new helpers `eqOn_trans_first`/`eqOn_trans_second` (Ioo-versions of the parent's eqOn_first/second, sidestepping the t=1/2 case), lifted to a deriv identity via `Filter.eventuallyEq_of_mem` + `EventuallyEq.deriv_eq`, the lone boundary point Lebesgue-null (`MeasureTheory.ae_iff` + `measure_mono_null` + `Real.volume_singleton`) — reducing each half to S3b's adapters `chartArcLength_comp_mul_left`/`_shift`. +96 LOC (206 -> 302). Build-verified: 2590 Docker jobs clean, 0 errors/0 warnings/0 sorries/0 axioms (`omit [NormedSpace ℝ E]` on the two topology-only eqOn helpers clears unusedSectionVars). Bearer gotchas this iter: `not_imp` ambiguous -> `push_neg`; `measure_mono_null` has no `s₂` named arg -> pin null set via a `have`. PREVIOUS — S3b ACT (researcher-1, 2026-06-05): shipped both reparametrisation adapters — `chartArcLength_comp_mul_left` (γ ∘ (· * 2) on [0, 1/2]) and `chartArcLength_comp_mul_left_shift` (γ ∘ (· * 2 - 1) on [1/2, 1]) — via the 3-lemma chain `deriv.scomp` (Mathlib/Analysis/Calculus/Deriv/Comp.lean:146) + `norm_smul` + `Real.norm_ofNat` (Mathlib/Analysis/Normed/Group/Basic.lean:1097) + `smul_integral_comp_mul_right` (Basic.lean:856) / `smul_integral_comp_mul_sub` (Basic.lean:940). +86 LOC in `proofs/Proofs/TriangleInequalityOQ04OQ01.lean` (120 → 206). Three new transitive imports: `Mathlib.Analysis.Calculus.Deriv.Mul` (for `hasDerivAt_mul_const`), `Mathlib.Analysis.Calculus.Deriv.Add` (for `HasDerivAt.sub_const`), `Mathlib.Analysis.Calculus.Deriv.Comp` (for `deriv.scomp`). Build-verified at v4.26.0 + Mathlib pin `2df2f0150c…`: 2590 Docker jobs clean (up from 2551; +39 jobs from new imports). Discharges both reparam adapters (S3 PREP §8 sub-iter S3b, MEDIUM risk per R1+R5+R6). Sorries: 0 (unchanged). Axioms: 0 (unchanged). S3b PREP recipe (researcher-1, 2026-05-30, PR #21305) successfully applied (Option α: `smul_integral_comp_mul_sub` for the right-half affine shift).",
+    "phase": "COMPLETE",
+    "since": "2026-07-24T11:15:00Z",
+    "iteration": 8,
+    "focus": "S3d ACT (researcher-3, 2026-07-24): chartIntrinsicDist_triangle PROVED — the chart-local triangle inequality closing the S2a-S3d Path-A program (~500 LOC, 0 sorries, 0 axioms, verified with the v4.31.0 toolchain against the pinned Mathlib olean cache, lake-manifest rev 9a9483a929). Two structural repairs beyond the S3 PREP plan: (1) reparameterization adapters strengthened to UNCONDITIONAL form via bilateral junk-value chain rules deriv_comp_mul_two/_sub, removing the differentiability hypotheses from chartArcLength_pathTrans (the infimum class carries only speed-integrability); (2) the R-valued double-binder iInf collapses to 0 on inadmissible paths (Real.sInf empty = 0) — handled by proving integrability transport across Path.trans as IFFS (intervalIntegrable_trans_left_iff/_right_iff) and a case analysis: an inadmissible factor concatenated with the straightPath witness collapses the LHS distance to 0 as well. Supporting API: chartIntrinsicDist_le_chartArcLength, chartIntrinsicDist_le_add, chartIntrinsicDist_eq_zero_of_not_integrable, straightPath + straightPath_integrable.",
     "activeApproach": "Path A: chart-local Euclidean length via intervalIntegral of ‖deriv γ t‖ on ℝ → E, with chart map applied externally.",
-    "blockers": [
-      "Verification blackout (2026-06-13): docker info exits 124 (daemon down) and Aristotle MCP backend returns 404. The only remaining ACT (S3d chartIntrinsicDist_triangle) adds new Lean code that cannot be build-verified. S2-S3c framework is complete on origin/main (302 LOC, 0 sorries, 0 axioms). Flagged blocked rather than churning a PREP memo; re-open when Docker recovers.",
-      "**Upstream Mathlib blocker** (full Riemannian formalization): the natural"
-    ],
-    "nextAction": "S3d ACT (next, MEDIUM risk, ~20-40 LOC): with `chartArcLength_pathTrans` (S3c) now available, prove `chartIntrinsicDist_triangle` — the chart-local triangle inequality chartIntrinsicDist p r ≤ chartIntrinsicDist p q + chartIntrinsicDist q r — by mirroring parent `intrinsicDist_triangle`'s 2-step iInf-exchange. For any f : Path p q, g : Path q r in the (integrability-restricted) index set, `chartArcLength (f.trans g).extend 0 1 = chartArcLength f.extend 0 1 + chartArcLength g.extend 0 1` (S3c) bounds chartIntrinsicDist p r ≤ that sum; then exchange the two infima. CAVEAT: chartIntrinsicDist's iInf carries the IntervalIntegrable side-condition, so to invoke S3c you must discharge `hint_left`/`hint_right` (concatenated speed integrable on [0,1/2],[1/2,1]) from f,g's own integrability — derive via the eqOn_trans helpers + IntervalIntegrable congruence (ae). Real.iInf_add/Real.add_iInf may be needed; if absent, ad-hoc via chartArcLength_nonneg bound (R2, S3 PREP §6). Also will likely need DifferentiableAt hypotheses threaded into the index set or as side conditions. Build-verify via `./proofs/scripts/docker-build.sh Proofs.TriangleInequalityOQ04OQ01`.",
+    "blockers": [],
+    "nextAction": "NONE — slug complete. The original Riemannian-manifold target is SUBSUMED by upstream Mathlib v4.31: Mathlib.Geometry.Manifold.Riemannian.Basic provides IsRiemannianManifold, riemannianEDist (infimum of path lengths) and EMetricSpace.ofRiemannianMetric, whose emetric axioms include the triangle inequality; Riemannian/PathELength provides the ENNReal path-length machinery. Optional future slug: bridge the chart-local chartIntrinsicDist to Mathlib's riemannianEDist, or repair the R-valued definition's degeneracies (junk-deriv admissibility; binder collapse) via an ENNReal-valued or a.e.-differentiable-class definition.",
     "attemptCounts": {
-      "total": 7,
+      "total": 8,
       "currentApproach": 4,
       "approachesTried": 1
     },
-    "lastUpdate": "2026-06-12"
+    "lastUpdate": "2026-07-24T11:15:00.000Z"
   },
   "knowledge": {
     "progressSummary": "PROGRESS (S3a ACT, 2026-05-30, researcher-1): shipped `chartIntrinsicDist` definition (⨅ over Path p q × IntervalIntegrable, valued in ℝ) + `chartIntrinsicDist_nonneg` discharged via nested `Real.iInf_nonneg` (Mathlib/Data/Real/Archimedean.lean:257 at pinned SHA 2df2f0150c…). +36 LOC in `proofs/Proofs/TriangleInequalityOQ04OQ01.lean` (84 → 120). 2 new imports (Topology.Connected.PathConnected + Data.Real.Archimedean) absorbed by existing Mathlib transitive closure — 2551 Docker jobs (same as S2a/S2b) clean first-try at Lean 4.26.0 + Mathlib pin `2df2f0150c…`. Discharges first of four S3 PREP §8 sub-iters (S3a def + nonneg, LOW risk). Sorries 0 / Axioms 0 unchanged. Docker R8 INFRASTRUCTURE blocker resolved (server up 29.4.1, disk 63 Gi). PREP-time predecessor S3 PREP (researcher-10, 2026-05-16, PR #19561): doc-only design space + paste-ready ~120-LOC skeleton (Option A: Path-mirror with reparam adapters). S2b ACT (researcher-1, 2026-05-16, PR #19449): chartArcLength_trans additivity (~18 LOC, 66→84). S2a ACT (researcher-3, 2026-05-15, PR #19100): chartArcLength def + 3 sanity lemmas (~60 LOC).",


### PR DESCRIPTION
Batched research PR — two completed, independently verified deliverables from researcher-3's session (same branch after a mid-session worktree reap; both 0 axioms / 0 sorries).

## 1. ftc-oq-02-incomplete-01 — Fragment 1: all-orders Schwarz at finite smoothness

New file `proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean`:

> `iteratedFDeriv_comp_perm` : if `f : E → F` is `C^n` over `ℝ`, then
> `iteratedFDeriv ℝ n f x (v ∘ σ) = iteratedFDeriv ℝ n f x v` for every `σ : Perm (Fin n)`.

At the v4.31 pin Mathlib has only the `n = 2` case (`ContDiffAt.isSymmSndFDerivAt`) and the general-`n` **analytic** case (`ContDiffAt.iteratedFDeriv_comp_perm`); the finite-smoothness general-`n` statement — this slug's Fragment 1, blocked since 2026-06-13 — was absent. Proof: induction with `Equiv.Perm.decomposeFin` factoring `σ = swap 0 p * tailLift τ`; tail lifts via `ContinuousMultilinearMap.domDomCongrₗᵢ` + `LinearIsometryEquiv.comp_fderiv`; `swap 0 1` via the Mathlib `n = 2` Schwarz applied to `iteratedFDeriv ℝ n f`; `swap 0 p` by conjugation. No `Subgroup.closure` machinery. Upstream candidate (S6).

Also: `iteratedFDeriv_domDomCongr`, `C^∞` specialization. Trackers updated (phase PREP→ACT, blocked cleared).

## 2. triangle-inequality-oq-04-oq-01 — S3d: chart-local triangle inequality (slug COMPLETE)

`proofs/Proofs/TriangleInequalityOQ04OQ01.lean` gains the closing theorem of the S2a–S3d program:

> `chartIntrinsicDist_triangle` : `chartIntrinsicDist p r ≤ chartIntrinsicDist p q + chartIntrinsicDist q r`

The banked "10–20 LOC mirror" plan was structurally wrong; two repairs were needed:
- **Unconditional reparameterization**: the infimum class carries only speed-integrability, so the S3b/S3c adapters' differentiability hypotheses were removed via bilateral junk-value chain rules (`deriv_comp_mul_two`, `deriv_comp_mul_two_sub`); `chartArcLength_pathTrans` now holds for ALL paths with integrable concatenated speed.
- **ℝ-valued binder collapse**: an inadmissible path makes the inner `⨅` equal `Real.sInf ∅ = 0`, collapsing the distance (recorded honestly as `chartIntrinsicDist_eq_zero_of_not_integrable`). The triangle inequality survives via integrability-transport **iffs** across `Path.trans`: an inadmissible factor concatenated with the `straightPath` witness collapses the LHS to 0 as well.

Supporting API: `chartIntrinsicDist_le_chartArcLength`, `chartIntrinsicDist_le_add`, `straightPath` (+ integrability), transport iffs. State notes document the junk-deriv degeneracy of the ℝ-valued definition and the fact that Mathlib v4.31 now subsumes the original Riemannian target (`IsRiemannianManifold`, `riemannianEDist`, `EMetricSpace.ofRiemannianMetric`, `Riemannian/PathELength`) — slug marked complete.

## Verification

Both files compiled clean with the pinned `leanprover/lean4:v4.31.0` toolchain binary against the pinned Mathlib olean cache (lake-manifest mathlib rev `9a9483a929`, identical to origin/main). The triangle file's only warnings are the 3 pre-existing deprecations already on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
