### PR TITLE
Enrich birthday-problem-oq003: add strict-inequality keyInsight

### DIFF
--- a/src/data/proofs/birthday-problem-oq003/meta.json
+++ b/src/data/proofs/birthday-problem-oq003/meta.json
@@ -41,7 +41,8 @@
       "The collision excess is *exactly* the squared ℓ² distance from uniform (parent identity), so bounding it below in total variation is precisely the ℓ¹-vs-ℓ² comparison delivered by Cauchy–Schwarz: (∑|xᵢ|)² ≤ d·∑xᵢ² on d coordinates.",
       "The constant 4 is not cosmetic: dTV involves the factor ½ (so ∑|pᵢ − 1/d| = 2·dTV), and squaring turns that into a 4. The final bound (4/d)·dTV² is order-sharp — it is attained up to constants by a two-spike perturbation of uniform that concentrates all the deviation mass on two coordinates.",
       "This is a Pinsker-type inequality for the collision functional: it lower-bounds a smooth quantity (the ℓ² collision excess) by the square of a metric distance (total variation), turning a bias into an effective, computable penalty.",
-      "The quantitative bound subsumes the parent's qualitative equality case: dTV(p, u) = 0 ⟺ p uniform ⟺ ∑ pᵢ² = 1/d, so the effective inequality recovers 'equality iff uniform' as its degenerate boundary."
+      "The quantitative bound subsumes the parent's qualitative equality case: dTV(p, u) = 0 ⟺ p uniform ⟺ ∑ pᵢ² = 1/d, so the effective inequality recovers 'equality iff uniform' as its degenerate boundary.",
+      "The strict form of the parent's extremality — any bias, however small, strictly raises the collision probability — falls out as an immediate corollary rather than needing a separate argument: since 4/d·dTV(p,u)² is strictly positive whenever dTV(p,u) ≠ 0 (positivity alone), the mere existence of bias forces C(p) > 1/d, with no need to know its precise magnitude."
     ],
     "prerequisites": [
       "sq_sum_le_card_mul_sum_sq: (∑ f)² ≤ #s · ∑ f² (Chebyshev/Cauchy–Schwarz), Mathlib.Algebra.Order.Chebyshev",


### PR DESCRIPTION
Enrichment pass for `birthday-problem-oq003` (quality 98, keyInsights bucket
8/10 = 4 items instead of the 5-item cap; sections and all other buckets
already at cap).

Added a 5th `keyInsight` grounded in the file's existing `Examples` section
(`proofs/Proofs/BirthdayProblemOQ02OQ01OQ02OQ02.lean` lines 161-179), which
wasn't yet reflected in `overview.keyInsights`: the strict form of the
parent's extremality (any bias => strictly higher collision probability) falls
out of the quantitative bound for free via positivity, with no need to
compute the exact margin.

`meta.json` stays at ~11.5 KB, far under the 60 KB cap. No open PRs on this
entry at claim time or push time.