### PR TITLE
Enrich birthday-problem-oq006: split header/cuberoot section (4->5)

### DIFF
--- a/src/data/proofs/birthday-problem-oq006/meta.json
+++ b/src/data/proofs/birthday-problem-oq006/meta.json
@@ -80,12 +80,20 @@
   },
   "sections": [
     {
-      "id": "header-and-cuberoot",
-      "title": "Problem Statement and the Cube-Root Identity",
-      "summary": "Module docstring explaining the centered-cube sharpening and the depressed cubic m³ - m = c³; cubeRoot_cube: (x³)^(1/3) = x for x ≥ 0 via Real.pow_rpow_inv_natCast",
+      "id": "problem-statement",
+      "title": "Problem Statement and the Centered-Cube Sharpening",
+      "summary": "Module docstring: the parent pins n within the corner-cube band c ≤ n ≤ c + 2; this entry sharpens it to c + 1 ≤ n ≤ c + 1 + 1/(3c) by replacing the corner cube n³ with the centered cube (n-1)³, using the exact identity n(n-1)(n-2) = (n-1)³ - (n-1) to recast the balance equation as the depressed cubic m³ - m = c³ (m := n-1).",
       "startLine": 1,
+      "endLine": 56,
+      "mathContext": "The centered-cube identity $n(n-1)(n-2) = (n-1)^3 - (n-1)$ recasts the balance equation as a depressed cubic $m^3 - m = c^3$; this trick is specific to $k=3$, since the general centered monomial $(n-(k-1)/2)^k$ does not divide the falling factorial exactly for $k>3$."
+    },
+    {
+      "id": "cuberoot-identity",
+      "title": "The Cube-Root Identity",
+      "summary": "cubeRoot_cube: (x³)^(1/3) = x for x ≥ 0, via Real.pow_rpow_inv_natCast — the helper used to pass the cube root through the depressed-cubic bounds.",
+      "startLine": 58,
       "endLine": 65,
-      "mathContext": "$(x^3)^{1/3} = x$ for $x \\ge 0$; the centered-cube identity $n(n-1)(n-2) = (n-1)^3 - (n-1)$ recasts the balance equation as a depressed cubic."
+      "mathContext": "$(x^3)^{1/3} = x$ for $x \\ge 0$, needed to convert $L \\le m^3$ into $c \\le m$ via monotonicity of the cube root."
     },
     {
       "id": "sharp-threshold",
@@ -99,7 +107,7 @@
       "id": "const-one",
       "title": "The Exact Lower-Order Constant",
       "summary": "birthday_triple_threshold_const_one: |n − (c + 1)| ≤ 1/(3c), exhibiting the exact constant term 1 and the vanishing remainder O(d^(-2/3)). Obtained from the two one-sided bounds of birthday_triple_threshold_sharp via abs_le, both branches closing by linarith.",
-      "startLine": 118,
+      "startLine": 117,
       "endLine": 140,
       "mathContext": "$|n - (c + 1)| \\le \\frac{1}{3c}$: the exact lower-order constant is $1$ with remainder $\\frac{1}{3c} = O(d^{-2/3})$, so $n = (6d^2\\ln 2)^{1/3} + 1 + o(1)$."
     },


### PR DESCRIPTION
Enrichment pass for `birthday-problem-oq006` (quality 98, sections bucket 8/10
= 4 sections instead of the 5-item cap; all other buckets already maxed).

Two fixes against `proofs/Proofs/BirthdayProblemOQ03OQ01OQ01OQ03OQ01.lean`
(162 lines):

1. **Bundled-header split.** The `header-and-cuberoot` section (lines 1-65)
   bundled the module docstring (problem statement + sharpening idea) with
   the unrelated `cubeRoot_cube` helper theorem. Split into `problem-statement`
   (1-56, docstring only) and `cuberoot-identity` (58-65, the theorem).
2. **Drifted boundary fix.** `const-one`'s `startLine` was 118, one line past
   the actual docstring start (`/-- **The exact lower-order constant.**` is
   line 117) — re-anchored to 117.

Verified all 5 resulting sections' ranges are contiguous and non-overlapping
against the current source. `meta.json` stays at ~18 KB, well under the 60 KB
cap.