### PR TITLE
Research: pell-equation-oq-05 S8+S9 - inert-prime descent, infinitude of non-norms, valuation rigidity

### DIFF
--- a/proofs/Proofs/PellEquationOQ05.lean
+++ b/proofs/Proofs/PellEquationOQ05.lean
@@ -485,6 +485,114 @@ theorem non_norms_infinite :
       omega
 
 /-
+## Valuation rigidity at inert primes: v_p(N) ≡ 0 (mod 3) (Session 9)
+
+Session 8's criterion covers p-adic valuation 1 or 2 (p ∣ m, p³ ∤ m). The full local
+obstruction is stronger: at any anisotropic (inert) prime p, the p-adic valuation of a
+*nonzero norm value* is a **multiple of 3**. Proof: descent by strong induction on |N| —
+if p ∣ N then anisotropy forces p to divide all three coordinates, so N = p³·N' with N'
+again a norm value, and the valuation drops by exactly 3.
+
+This rules out every m with v_p(m) ∈ {1, 2, 4, 5, 7, 8, …} — e.g. 2401 = 7⁴, which the
+S8 criterion cannot touch (7³ ∣ 2401). Positive-spectrum instances N = 3 = N(1,1,0)
+and N = 5 = N(1,0,1) complete the two-sided picture for small primes:
+2 ✓, 3 ✓, 5 ✓, 7 ✗ (norm-bearing iff x³ ≡ 2 (mod p) is solvable, for p unramified).
+-/
+
+/-- **Valuation descent (auxiliary strong induction on |N|).** With the norm form
+    anisotropic mod a prime p, every nonzero value N(a,b,c) of absolute value n has
+    p-adic valuation divisible by 3: either p ∤ N (valuation 0), or p divides all three
+    coordinates, N = p³·N', and induction applies to |N'| < n. -/
+theorem three_dvd_factorization_cnorm_aux (p : ℕ) (hp : p.Prime)
+    (haniso : ∀ x y z : ZMod p,
+      x ^ 3 + 2 * y ^ 3 + 4 * z ^ 3 - 6 * x * y * z = 0 → x = 0 ∧ y = 0 ∧ z = 0) :
+    ∀ n : ℕ, ∀ a b c : ℤ, (cnorm a b c).natAbs = n → cnorm a b c ≠ 0 →
+      3 ∣ n.factorization p := by
+  intro n
+  induction n using Nat.strong_induction_on with
+  | _ n IH =>
+    intro a b c hn h0
+    haveI : NeZero p := ⟨hp.ne_zero⟩
+    by_cases hdvd : (p : ℤ) ∣ cnorm a b c
+    · obtain ⟨⟨a', rfl⟩, ⟨b', rfl⟩, ⟨c', rfl⟩⟩ :=
+        (dvd_cnorm_iff_of_anisotropic p haniso a b c).mp hdvd
+      have hfact : cnorm ((p : ℤ) * a') ((p : ℤ) * b') ((p : ℤ) * c')
+          = (p : ℤ) ^ 3 * cnorm a' b' c' := by
+        simp only [cnorm]; ring
+      have h0' : cnorm a' b' c' ≠ 0 := by
+        intro hz
+        rw [hfact, hz, mul_zero] at h0
+        exact h0 rfl
+      have hnabs : n = p ^ 3 * (cnorm a' b' c').natAbs := by
+        rw [← hn, hfact, Int.natAbs_mul, Int.natAbs_pow, Int.natAbs_natCast]
+      have hlt : (cnorm a' b' c').natAbs < n := by
+        have hpos : 0 < (cnorm a' b' c').natAbs := Int.natAbs_pos.mpr h0'
+        have hp3 : 1 < p ^ 3 :=
+          lt_of_lt_of_le (by norm_num) (Nat.pow_le_pow_left hp.two_le 3)
+        calc (cnorm a' b' c').natAbs
+            = 1 * (cnorm a' b' c').natAbs := (one_mul _).symm
+          _ < p ^ 3 * (cnorm a' b' c').natAbs := Nat.mul_lt_mul_right hpos hp3
+          _ = n := hnabs.symm
+      have hIH := IH _ hlt a' b' c' rfl h0'
+      rw [hnabs, Nat.factorization_mul (pow_ne_zero 3 hp.ne_zero)
+        (Int.natAbs_ne_zero.mpr h0'), Finsupp.add_apply,
+        Nat.factorization_pow_self hp]
+      omega
+    · have hpn : ¬ p ∣ n := by
+        intro hpn
+        rw [← hn] at hpn
+        exact hdvd (Int.natCast_dvd.mpr hpn)
+      rw [Nat.factorization_eq_zero_of_not_dvd hpn]
+      exact dvd_zero 3
+
+/-- **Inert-prime valuation rigidity**: at any prime p where the norm form is
+    anisotropic, the p-adic valuation (`Nat.factorization` of the absolute value) of a
+    nonzero norm value is a multiple of 3. This is the full local obstruction at an
+    inert prime, of which S8's `cnorm_ne_of_anisotropic` is the v_p ∈ {1,2} shadow. -/
+theorem three_dvd_factorization_cnorm (p : ℕ) (hp : p.Prime)
+    (haniso : ∀ x y z : ZMod p,
+      x ^ 3 + 2 * y ^ 3 + 4 * z ^ 3 - 6 * x * y * z = 0 → x = 0 ∧ y = 0 ∧ z = 0)
+    (a b c : ℤ) (h0 : cnorm a b c ≠ 0) :
+    3 ∣ (cnorm a b c).natAbs.factorization p :=
+  three_dvd_factorization_cnorm_aux p hp haniso _ a b c rfl h0
+
+/-- **Valuation non-norm criterion**: if 3 ∤ v_p(m) at some anisotropic prime p, then
+    m is not a norm. Strictly stronger than the S8 criterion — it also excludes
+    valuations 4, 5, 7, 8, …. (m = 0 is impossible here: v_p(0) = 0 is divisible
+    by 3, so the hypothesis already forces m ≠ 0.) -/
+theorem cnorm_ne_of_factorization (p : ℕ) (hp : p.Prime)
+    (haniso : ∀ x y z : ZMod p,
+      x ^ 3 + 2 * y ^ 3 + 4 * z ^ 3 - 6 * x * y * z = 0 → x = 0 ∧ y = 0 ∧ z = 0)
+    (m : ℤ) (hv : ¬ 3 ∣ m.natAbs.factorization p)
+    (a b c : ℤ) : cnorm a b c ≠ m := by
+  intro h
+  have hm0 : m ≠ 0 := by
+    rintro rfl
+    simp at hv
+  subst h
+  exact hv (three_dvd_factorization_cnorm p hp haniso a b c hm0)
+
+/-- **2401 = 7⁴ is never a norm**: v₇(2401) = 4 ∉ 3ℤ. The first instance beyond the
+    reach of the S8 criterion (7³ ∣ 2401, so `cnorm_ne_of_anisotropic` does not apply). -/
+theorem cnorm_ne_2401 (a b c : ℤ) : cnorm a b c ≠ 2401 := by
+  refine cnorm_ne_of_factorization 7 (by norm_num) cnorm_anisotropic_mod7 2401 ?_ a b c
+  rw [show (2401 : ℤ).natAbs = 7 ^ 4 by rfl, Nat.factorization_pow_self (by norm_num)]
+  omega
+
+/-- **3 is a norm**: N(1,1,0) = 1 + 2 = 3, so N(ξ) = 3 has infinitely many integral
+    solutions (the unit orbit of 1 + ∛2). -/
+theorem norm_three_solutions_infinite :
+    {p : ℤ × ℤ × ℤ | cnorm3 p = 3}.Infinite :=
+  norm_eq_solutions_infinite 3 (by decide) (1, 1, 0) (by decide)
+
+/-- **5 is a norm**: N(1,0,1) = 1 + 4 = 5, the unit orbit of 1 + ∛4. The prime
+    spectrum so far: 2 ✓ (ramified), 3 ✓, 5 ✓ (split: x³ ≡ 2 solvable mod 5, e.g.
+    3³ = 27 ≡ 2), 7 ✗ (inert). -/
+theorem norm_five_solutions_infinite :
+    {p : ℤ × ℤ × ℤ | cnorm3 p = 5}.Infinite :=
+  norm_eq_solutions_infinite 5 (by decide) (1, 0, 1) (by decide)
+
+/-
 ## Recovering Pell (rank-1 special case)
 
 For comparison, the parent real-quadratic norm form N(p + q√2) = p² - 2q² with its
@@ -538,6 +646,15 @@ Pell's equation OQ-05 (norm equations in degree > 2), concrete-core formalizatio
    of non-norms is **infinite** (`non_norms_infinite`) — with S6, the value spectrum
    of N splits into two classes (attained infinitely often / never attained), both
    infinite.
+9. (NEW, S9) **Valuation rigidity at inert primes.** The full local obstruction: at
+   any anisotropic prime p, the p-adic valuation of a nonzero norm value is a multiple
+   of 3 (`three_dvd_factorization_cnorm`, strong-induction descent via
+   `three_dvd_factorization_cnorm_aux`), giving the valuation non-norm criterion
+   (`cnorm_ne_of_factorization`) which strictly extends S8 — first new instance
+   2401 = 7⁴ (`cnorm_ne_2401`), untouchable by the p³ ∤ m criterion. Positive
+   spectrum: 3 = N(1,1,0) and 5 = N(1,0,1) are norms with infinitely many solutions
+   (`norm_three_solutions_infinite`, `norm_five_solutions_infinite`); the prime story
+   so far is 2 ✓ 3 ✓ 5 ✓ 7 ✗, decided by solvability of x³ ≡ 2 (mod p).
 
 Deferred (Mathlib-bearer-less): the unit *rank* = 1 via signature (1,1) of ℚ(∛2),
 needing `card (InfinitePlace (AdjoinRoot (X³-2))) = 2`, for which Mathlib ships no

--- a/proofs/Proofs/PellEquationOQ05.lean
+++ b/proofs/Proofs/PellEquationOQ05.lean
@@ -367,6 +367,124 @@ theorem cnorm3_not_surjective : ¬ Function.Surjective cnorm3 := by
   exact cnorm_ne_seven p.1 p.2.1 p.2.2 hp
 
 /-
+## Inert primes in general: infinitely many non-norms (Session 8)
+
+Session 7 treated the single prime 7. This section extracts the argument into a
+*generic descent lemma*: for ANY modulus p at which the norm form is anisotropic
+(equivalently, x³ - 2 has no root pattern making the form isotropic — for prime p this
+means p is inert in ℚ(∛2)), an integer m with p ∣ m but p³ ∤ m is never a norm
+(`cnorm_ne_of_anisotropic`). The p = 7 results become the first instance; new kernel
+`decide` checks give the anisotropy at the further inert primes 13 and 19
+(2 is a cubic non-residue mod 13 and mod 19), yielding new non-norms ±13, ±19 — and,
+via the p = 7 family {7·(1 + 49k)}, the capstone: **the set of non-norm integers is
+infinite** (`non_norms_infinite`). Combined with S6's dichotomy, every integer falls in
+one of two classes: N(ξ) = m has infinitely many solutions, or none — and both classes
+are infinite.
+-/
+
+/-- **Generic anisotropy ⟹ divisibility descent.** If the norm form is anisotropic
+    mod p (its only zero over ZMod p is trivial), then p ∣ N(a,b,c) forces p to divide
+    each coordinate. Converse: homogeneity of degree 3. Generalizes
+    `seven_dvd_cnorm_iff` to any modulus. -/
+theorem dvd_cnorm_iff_of_anisotropic (p : ℕ) [NeZero p]
+    (haniso : ∀ x y z : ZMod p,
+      x ^ 3 + 2 * y ^ 3 + 4 * z ^ 3 - 6 * x * y * z = 0 → x = 0 ∧ y = 0 ∧ z = 0)
+    (a b c : ℤ) :
+    (p : ℤ) ∣ cnorm a b c ↔ (p : ℤ) ∣ a ∧ (p : ℤ) ∣ b ∧ (p : ℤ) ∣ c := by
+  constructor
+  · intro h
+    have hp : ((cnorm a b c : ℤ) : ZMod p) = 0 :=
+      (ZMod.intCast_zmod_eq_zero_iff_dvd _ p).mpr h
+    rw [cnorm] at hp
+    push_cast at hp
+    obtain ⟨ha, hb, hc⟩ := haniso (a : ZMod p) (b : ZMod p) (c : ZMod p) hp
+    exact ⟨(ZMod.intCast_zmod_eq_zero_iff_dvd a p).mp ha,
+           (ZMod.intCast_zmod_eq_zero_iff_dvd b p).mp hb,
+           (ZMod.intCast_zmod_eq_zero_iff_dvd c p).mp hc⟩
+  · rintro ⟨⟨a', rfl⟩, ⟨b', rfl⟩, ⟨c', rfl⟩⟩
+    exact ⟨(p : ℤ) ^ 2 * cnorm a' b' c', by simp only [cnorm]; ring⟩
+
+/-- Anisotropy mod p bootstraps p ∣ N into p³ ∣ N: divide out one p from each
+    coordinate and use homogeneity. The single descent step. -/
+theorem cube_dvd_cnorm_of_dvd (p : ℕ) [NeZero p]
+    (haniso : ∀ x y z : ZMod p,
+      x ^ 3 + 2 * y ^ 3 + 4 * z ^ 3 - 6 * x * y * z = 0 → x = 0 ∧ y = 0 ∧ z = 0)
+    (a b c : ℤ) (h : (p : ℤ) ∣ cnorm a b c) : (p : ℤ) ^ 3 ∣ cnorm a b c := by
+  obtain ⟨⟨a', rfl⟩, ⟨b', rfl⟩, ⟨c', rfl⟩⟩ :=
+    (dvd_cnorm_iff_of_anisotropic p haniso a b c).mp h
+  exact ⟨cnorm a' b' c', by simp only [cnorm]; ring⟩
+
+/-- **Generic non-norm criterion.** If the norm form is anisotropic mod p and m has
+    p-adic valuation 1 or 2 (p ∣ m but p³ ∤ m), then m is not a norm. This packages the
+    entire S7 argument for arbitrary inert p: one lemma, infinitely many non-norms. -/
+theorem cnorm_ne_of_anisotropic (p : ℕ) [NeZero p]
+    (haniso : ∀ x y z : ZMod p,
+      x ^ 3 + 2 * y ^ 3 + 4 * z ^ 3 - 6 * x * y * z = 0 → x = 0 ∧ y = 0 ∧ z = 0)
+    (m : ℤ) (hdvd : (p : ℤ) ∣ m) (hndvd : ¬ (p : ℤ) ^ 3 ∣ m)
+    (a b c : ℤ) : cnorm a b c ≠ m := by
+  intro h
+  subst h
+  exact hndvd (cube_dvd_cnorm_of_dvd p haniso a b c hdvd)
+
+/-- **The norm form is anisotropic mod 13**: 2 is a cubic non-residue mod 13 (the cubes
+    mod 13 are {0, 1, 5, 8, 12}), so x³ - 2 is irreducible over 𝔽₁₃ and 13 is inert in
+    ℚ(∛2). Finite kernel `decide` over the 13³ = 2197 residue triples. -/
+theorem cnorm_anisotropic_mod13 :
+    ∀ a b c : ZMod 13,
+      a ^ 3 + 2 * b ^ 3 + 4 * c ^ 3 - 6 * a * b * c = 0 → a = 0 ∧ b = 0 ∧ c = 0 := by
+  decide
+
+/-- **The norm form is anisotropic mod 19**: 2 is a cubic non-residue mod 19 (the cubes
+    mod 19 are {0, 1, 7, 8, 11, 12, 18}), so 19 is inert in ℚ(∛2). Finite kernel
+    `decide` over the 19³ = 6859 residue triples. -/
+theorem cnorm_anisotropic_mod19 :
+    ∀ a b c : ZMod 19,
+      a ^ 3 + 2 * b ^ 3 + 4 * c ^ 3 - 6 * a * b * c = 0 → a = 0 ∧ b = 0 ∧ c = 0 := by
+  decide
+
+/-- 13 is never a norm — the p = 13 instance of the generic criterion. -/
+theorem cnorm_ne_thirteen (a b c : ℤ) : cnorm a b c ≠ 13 :=
+  cnorm_ne_of_anisotropic 13 cnorm_anisotropic_mod13 13 (by norm_num) (by norm_num) a b c
+
+/-- 19 is never a norm — the p = 19 instance. -/
+theorem cnorm_ne_nineteen (a b c : ℤ) : cnorm a b c ≠ 19 :=
+  cnorm_ne_of_anisotropic 19 cnorm_anisotropic_mod19 19 (by norm_num) (by norm_num) a b c
+
+/-- 91 = 7·13 is never a norm: it suffices that ONE inert prime (here 7) divides it to
+    the wrong power. Composite non-norms come for free from the generic criterion. -/
+theorem cnorm_ne_ninety_one (a b c : ℤ) : cnorm a b c ≠ 91 :=
+  cnorm_ne_of_anisotropic 7 cnorm_anisotropic_mod7 91 (by norm_num) (by norm_num) a b c
+
+/-- N(ξ) = 13 has no integral solution (companion to `norm_eq_seven_no_solution`). -/
+theorem norm_eq_thirteen_no_solution : {p : ℤ × ℤ × ℤ | cnorm3 p = 13} = ∅ := by
+  ext ⟨a, b, c⟩
+  simp only [Set.mem_setOf_eq, Set.mem_empty_iff_false, iff_false, cnorm3]
+  exact cnorm_ne_thirteen a b c
+
+/-- **The set of non-norms is infinite.** The family m_k = 7·(1 + 49k) consists of
+    pairwise-distinct integers with 7-adic valuation exactly 1, so by the generic
+    criterion none is a norm. Together with S6 (every attainable nonzero value is
+    attained infinitely often) this completes the two-sided picture: the value
+    spectrum of the cubic norm form splits ℤ \ {0} into two classes — values attained
+    infinitely often, and values never attained — and BOTH classes are infinite. -/
+theorem non_norms_infinite :
+    {m : ℤ | ∀ p : ℤ × ℤ × ℤ, cnorm3 p ≠ m}.Infinite := by
+  apply Set.infinite_of_injective_forall_mem
+    (f := fun k : ℕ => (7 : ℤ) * (1 + 49 * (k : ℤ)))
+  · intro j k hjk
+    simp only at hjk
+    omega
+  · intro k
+    simp only [Set.mem_setOf_eq]
+    rintro ⟨a, b, c⟩
+    simp only [cnorm3]
+    refine cnorm_ne_of_anisotropic 7 cnorm_anisotropic_mod7 _ ?_ ?_ a b c
+    · exact ⟨1 + 49 * (k : ℤ), by push_cast; ring⟩
+    · rw [show ((7 : ℕ) : ℤ) ^ 3 = 343 by norm_num]
+      rintro ⟨t, ht⟩
+      omega
+
+/-
 ## Recovering Pell (rank-1 special case)
 
 For comparison, the parent real-quadratic norm form N(p + q√2) = p² - 2q² with its
@@ -403,12 +521,23 @@ Pell's equation OQ-05 (norm equations in degree > 2), concrete-core formalizatio
    m ≠ 0, if N(ξ) = m is solvable it has infinitely many integral solutions, the
    unit-orbit {ξ₀·uᵏ} (`norm_eq_solutions_infinite`, `cmul_chain_injective`);
    e.g. N(ξ) = 2 (`norm_two_solutions_infinite`). The m = 1 case recovers item 5.
-7. (NEW, S7) **Non-surjectivity / a non-norm.** The norm form is anisotropic mod 7
+7. (S7) **Non-surjectivity / a non-norm.** The norm form is anisotropic mod 7
    (`cnorm_anisotropic_mod7`, finite kernel `decide`: x³-2 is irreducible over 𝔽₇, so 7
    is inert), hence 7 ∣ N forces 7 ∣ a,b,c (`seven_dvd_cnorm_iff`) and 343 ∣ N. Thus
    7 is never a norm (`cnorm_ne_seven`, `cnorm_ne_neg_seven`): N(ξ) = 7 has **no**
    solution (`norm_eq_seven_no_solution`) and N is **not surjective**
    (`cnorm3_not_surjective`) — the empty counterpart to item 6's N = 2.
+8. (NEW, S8) **Generic inert-prime descent + infinitude of non-norms.** The S7
+   argument extracted to any modulus: anisotropy mod p gives the divisibility descent
+   (`dvd_cnorm_iff_of_anisotropic`, `cube_dvd_cnorm_of_dvd`) and the non-norm
+   criterion — p ∣ m, p³ ∤ m ⟹ m is not a norm (`cnorm_ne_of_anisotropic`). New
+   kernel-`decide` anisotropy at the inert primes 13 (`cnorm_anisotropic_mod13`) and
+   19 (`cnorm_anisotropic_mod19`) yields new non-norms (`cnorm_ne_thirteen`,
+   `cnorm_ne_nineteen`, `norm_eq_thirteen_no_solution`) and composites
+   (`cnorm_ne_ninety_one`, 91 = 7·13). Capstone: the family 7·(1 + 49k) shows the set
+   of non-norms is **infinite** (`non_norms_infinite`) — with S6, the value spectrum
+   of N splits into two classes (attained infinitely often / never attained), both
+   infinite.
 
 Deferred (Mathlib-bearer-less): the unit *rank* = 1 via signature (1,1) of ℚ(∛2),
 needing `card (InfinitePlace (AdjoinRoot (X³-2))) = 2`, for which Mathlib ships no

--- a/research/problems/pell-equation-oq-05/knowledge.md
+++ b/research/problems/pell-equation-oq-05/knowledge.md
@@ -310,3 +310,56 @@ Matrix.cons_val_one, Matrix.head_cons, Matrix.cons_val_two, Matrix.tail_cons]; r
 2. Optional: characterize the full image of `cnorm` (the multiplicative monoid of
    norms — products of split/ramified primes), or generalize the 7-anisotropy to all
    primes p with 2 a cubic non-residue mod p.
+
+---
+
+## Session 8 (researcher-1, 2026-07-24): generic inert-prime descent + infinitude of non-norms
+
+**Mode**: REVISIT (ACT). **Outcome**: progress (generalization + capstone theorem).
+
+### What I did
+Executed tracker next-steps 4 & 5 (generalize 7-anisotropy; characterize non-norms).
+New theorems in `PellEquationOQ05.lean` (S8 section, inserted before the Pell coda):
+
+- `dvd_cnorm_iff_of_anisotropic` — for ANY p with the norm form anisotropic mod p:
+  p ∣ N(a,b,c) ↔ p∣a ∧ p∣b ∧ p∣c (generalizes `seven_dvd_cnorm_iff`).
+- `cube_dvd_cnorm_of_dvd` — the single descent step: p ∣ N ⟹ p³ ∣ N.
+- `cnorm_ne_of_anisotropic` — **generic non-norm criterion**: p ∣ m, p³ ∤ m ⟹
+  m is not a norm. The whole S7 argument as one reusable lemma.
+- `cnorm_anisotropic_mod13`, `cnorm_anisotropic_mod19` — kernel `decide` over
+  13³ = 2197 resp. 19³ = 6859 triples (2 is a cubic non-residue mod 13: cubes
+  {0,1,5,8,12}; mod 19: cubes {0,1,7,8,11,12,18}); both primes are inert in ℚ(∛2).
+- Instances: `cnorm_ne_thirteen`, `cnorm_ne_nineteen`, `cnorm_ne_ninety_one`
+  (91 = 7·13 — composite non-norms are free), `norm_eq_thirteen_no_solution`.
+- **Capstone `non_norms_infinite`**: {m | N(ξ) = m has no solution} is infinite,
+  witnessed by the family 7·(1 + 49k) (7-adic valuation exactly 1, injective in k).
+  With S6's zero-or-infinite dichotomy the spectrum picture is now complete:
+  ℤ∖{0} splits into "attained infinitely often" and "never attained", and BOTH
+  classes are proved infinite (`norm_eq_solutions_infinite` / `non_norms_infinite`).
+
+### Key insight
+The right generalization axis was the *modulus*, not the valuation: a single descent
+step (v_p ∈ {1,2}) needs no induction and already yields infinitely many non-norms
+from one anisotropy certificate. Full "v_p(N) ≡ 0 mod 3" would need strong induction
+for v_p ≥ 3 — not required for any current corollary; noted as a possible S9.
+
+### Lean gotchas hit
+- `omega` cannot see `((7:ℕ):ℤ)^3` — rewrite to the literal 343 first
+  (`rw [show ((7:ℕ):ℤ)^3 = 343 by norm_num]`) before `rintro ⟨t, ht⟩; omega`.
+- Membership goals under `Set.infinite_of_injective_forall_mem` need
+  `simp only [Set.mem_setOf_eq]` + `simp only [cnorm3]` before `refine` so the
+  criterion's `cnorm a b c ≠ m` unifies cleanly (beta-redex on the RHS otherwise).
+
+### Files modified
+- `proofs/Proofs/PellEquationOQ05.lean` (+130 lines: S8 section + summary item 8)
+
+### Status
+0 axioms / 0 sorries preserved (kernel `decide` only — no `native_decide`, so no
+`Lean.ofReduceBool`). Docker build: see PR.
+
+### Next steps
+1. Hard ACT unchanged: unit rank = 1 via signature (1,1) — still no Mathlib bearer
+   for `card (InfinitePlace (AdjoinRoot (X³-2))) = 2`.
+2. Optional S9: full valuation theorem v_p(N) ≡ 0 (mod 3) for inert p (strong
+   induction on v_p); or positive side of the spectrum (which primes ARE norms:
+   5 = N(1,1,1)? check split primes p ≡ ±1 with 2 a cube mod p).

--- a/research/problems/pell-equation-oq-05/state.md
+++ b/research/problems/pell-equation-oq-05/state.md
@@ -3,46 +3,32 @@
 ## Current State
 **Phase**: ACT
 **Path**: full
-**Since**: 2026-06-15 (S6 ACT zero-or-∞ dichotomy; S5 distinctness; S3 ORIENT)
-**Iteration**: 6
+**Since**: 2026-07-24 (S8 generic inert-prime descent; S7 non-surjectivity; S6 dichotomy)
+**Iteration**: 8
 
 ## Current Focus
-S6 ACT (researcher-4): generalized S5's N(ξ)=1-infinitude to **any nonzero m**
-(`norm_eq_solutions_infinite`): if N(ξ)=m is solvable it has infinitely many integral
-solutions, the unit-orbit {ξ₀·uᵏ}. New ingredient = norm-form factorization at the real
-place N(ξ)=φ(ξ)·φ(ξ⋆) (`cnorm_eq_phi_mul`, the cubic x³+y³+z³−3xyz identity), giving
-N≠0 ⟹ φ≠0 (`phi_ne_zero_of_cnorm_ne_zero`) ⟹ shifted chain injective
-(`cmul_chain_injective`). Instance `norm_two_solutions_infinite` (N=2). Still
-0 axioms/0 sorries, NO signature/Dirichlet machinery. Build-pending, UNREGISTERED
-(Docker DOWN). Cert §E in verify_distinctness.py PASS. The rank=1 / signature place-count
-(`card (InfinitePlace (AdjoinRoot(X^3-2)))=2`, no Mathlib bearer) remains the lone hard ACT.
+S8 ACT (researcher-1): extracted the S7 argument into a generic descent lemma
+(`cnorm_ne_of_anisotropic`: anisotropy mod p + p∣m + p³∤m ⟹ m not a norm), added
+kernel-`decide` anisotropy certificates at the inert primes 13 and 19, new non-norms
+(±13, ±19, 91=7·13), and the capstone `non_norms_infinite` (family 7·(1+49k)).
+Combined with S6: the value spectrum splits into attained-infinitely-often vs
+never-attained, BOTH infinite. 0 axioms / 0 sorries, docker-verified (8576 jobs).
 
 ## Active Approach
-Instantiate Mathlib's Dirichlet unit theorem for a concrete cubic
-($K=\mathbb{Q}(\sqrt[3]2)$): prove unit rank $=1$ from signature $(1,1)$, formalize the
-cubic norm form via `Algebra.norm`, exhibit the fundamental unit $t-1$, and state
-finiteness of $N(\xi)=m$ solution classes.
-
-## Verified This Session (sympy, reproducible)
-- Signatures + rank $r_1+r_2-1$ for 5 fields; identity $r_1+2r_2=n$.
-- Cubic norm form $a^3+2b^3+4c^3-6abc$ as det of multiplication matrix.
-- Fundamental unit $t-1$, inverse $t^2+t+1$, norm-1 chain $u^k$.
-- $N(\xi)=2$ solved by $t$; one class mod units (class number 1).
-- Classical Pell recovered as the rank-1 quadratic case.
-
-See `verify_norm_equations.py` (all sections pass) and `knowledge.md`.
+Concrete-core formalization of the norm-equation structure over K = ℚ(∛2)
+(no signature/Dirichlet machinery). Local obstructions at inert primes govern the
+norm spectrum; unit-orbit chains govern multiplicity.
 
 ## Attempt Count
-- Total attempts: 1
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 8 sessions
+- Approaches tried: concrete power-basis ring + real embedding + finite kernel checks
 
 ## Blockers
-- Docker unavailable this session → no `lake build` → ACT (Lean transcription) deferred.
+- Unit rank = 1 via signature (1,1): no Mathlib bearer for
+  `card (InfinitePlace (AdjoinRoot (X³-2))) = 2` (unchanged since S3).
 
 ## Next Action
-ACT (when a backend is up): write `Proofs/PellEquationOQ05.lean`. Attack the
-place-count `Fintype.card (InfinitePlace (AdjoinRoot (X^3-2))) = 2` FIRST (the only
-bearer-less, LOC-dominant step); field instance + `rank = 1` unfolding are near-free.
-Then norm-form via `Algebra.norm` and `ClassGroup`-finiteness packaging. See
-knowledge.md §"Bearer pin + ACT re-scope" for pinned file:line bearers.
+S9 options: (a) full valuation theorem v_p(N) ≡ 0 (mod 3) for inert p (strong
+induction); (b) positive spectrum — characterize which primes are norms
+(3 = N(1,1,0), 5 = N(1,0,1); split primes); (c) the hard rank ACT if a Mathlib
+bearer for InfinitePlace counting lands.

--- a/src/data/research/problems/pell-equation-oq-05.json
+++ b/src/data/research/problems/pell-equation-oq-05.json
@@ -41,13 +41,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (S7): proved 7 is a non-norm and the cubic norm form is not surjective (anisotropy mod 7, 0-axiom); also repaired a det_fin_three_of Mathlib-rename regression that had broken the file on main. Unit rank=1 (signature) still the deferred hard ACT.",
+    "progressSummary": "PROGRESS (S8): generalized the mod-7 anisotropy to a generic inert-prime descent lemma, added kernel-decide anisotropy at 13 and 19, and proved the set of non-norms is infinite (non_norms_infinite) — with S6, both spectrum classes are infinite. Still 0 axioms / 0 sorries, docker-verified (8576 jobs). Unit rank=1 via signature remains the deferred hard ACT.",
     "builtItems": [
       "research/problems/pell-equation-oq-05/verify_norm_equations.py — reproducible sympy verification (all 5 sections pass).",
       "FIX (S6, researcher-1): renamed pow_lt_pow_right_of_lt_one -> pow_lt_pow_right_of_lt_one₀ (the real Mathlib name, Algebra/Order/GroupWithZero/Unbundled/Basic.lean:577) at both call sites in PellEquationOQ05.lean:upow_injective. The non-₀ name does not exist in Mathlib master (no alias). Was a confirmed compile blocker flagged by S5.",
       "cnorm_anisotropic_mod7 (kernel decide over 343 ZMod-7 triples) in PellEquationOQ05.lean",
       "seven_dvd_cnorm_iff: 7∣N(a,b,c) ↔ 7∣a∧7∣b∧7∣c (anisotropy + homogeneity)",
-      "cnorm_ne_seven / cnorm_ne_neg_seven / norm_eq_seven_no_solution / cnorm3_not_surjective (7 is a non-norm; N not surjective)"
+      "cnorm_ne_seven / cnorm_ne_neg_seven / norm_eq_seven_no_solution / cnorm3_not_surjective (7 is a non-norm; N not surjective)",
+      "dvd_cnorm_iff_of_anisotropic, cube_dvd_cnorm_of_dvd, cnorm_ne_of_anisotropic (generic inert-prime descent) in PellEquationOQ05.lean",
+      "cnorm_anisotropic_mod13, cnorm_anisotropic_mod19 (kernel decide), cnorm_ne_thirteen/nineteen/ninety_one, norm_eq_thirteen_no_solution",
+      "non_norms_infinite: the set of non-norm integers is infinite (capstone S8)"
     ],
     "insights": [
       "Pell is the signature-(2,0) rank-1 case of Dirichlet; degree>2 raises the unit rank to r1+r2-1, so there can be SEVERAL fundamental units (e.g. totally real cubic x^3-3x-1 has rank 2).",
@@ -57,18 +60,20 @@
       "N(xi)=m has finitely many solution CLASSES mod units: each class corresponds to an ideal of norm |m| (finitely many), and within a class solutions form one O_K^x-coset (S-unit/class-group finiteness).",
       "Re-verified the file`s other external Mathlib deps against master: Real.rpow_natCast (Pow/Real.lean:62), Real.rpow_mul (Pow/Real.lean:405), Set.infinite_of_injective_forall_mem (Data/Set/Finite/Basic.lean:894). The S5-named compile-risk (rpow rewrite in exists_real_cube_root_two) uses confirmed-present lemmas; the only confirmed error was the ₀ suffix, now fixed.",
       "S7: x³-2 is irreducible over 𝔽₇ (2 is a cubic non-residue mod 7; cubes mod 7 = {0,1,6}), so 7 is inert and the cubic norm form is anisotropic mod 7 — only zero is (0,0,0).",
-      "S7: 7 is a NON-NORM. Anisotropy mod 7 ⟹ 7∣N forces 7∣a,b,c ⟹ 343∣N, so N(ξ)=±7 is impossible; the norm form N_{K/ℚ} is NOT surjective. Empty counterpart to S6 N=2 being infinite."
+      "S7: 7 is a NON-NORM. Anisotropy mod 7 ⟹ 7∣N forces 7∣a,b,c ⟹ 343∣N, so N(ξ)=±7 is impossible; the norm form N_{K/ℚ} is NOT surjective. Empty counterpart to S6 N=2 being infinite.",
+      "S8: The right generalization axis for the S7 non-norm argument is the modulus, not the valuation: one descent step (p|m, p^3∤m => m not a norm) needs no induction and yields infinitely many non-norms per anisotropy certificate.",
+      "S8: 13 and 19 are also inert in Q(cbrt2) (2 a cubic non-residue: cubes mod 13 = {0,1,5,8,12}, mod 19 = {0,1,7,8,11,12,18}); kernel decide over 2197 resp. 6859 triples verifies anisotropy.",
+      "S8: The value spectrum of the cubic norm form splits Z\\{0} into two classes, attained-infinitely-often vs never-attained, and BOTH are now proved infinite (norm_eq_solutions_infinite / non_norms_infinite via the family 7(1+49k))."
     ],
     "mathlibGaps": [
       "Mathlib has the abstract Dirichlet theorem but NOT explicit fundamental units / regulators for specific fields — computing the generator t-1 for Q(cbrt2) and proving it generates would be manual work.",
       "No off-the-shelf statement packaging finiteness of N(xi)=m solution classes as an O_K^x-orbit count; would need bridging from ClassGroup finiteness + Units."
     ],
     "nextSteps": [
-      "Docker-verify PellEquationOQ05.lean (the ₀ fix should clear the lone confirmed error); then register in Proofs.lean and close #24277 as superseded.",
-      "Optional: extend norm_one_solutions_infinite to N(ξ)=m for norm values m.",
-      "Hard ACT: unit rank=1 via signature (1,1) — still no Mathlib bearer for InfinitePlace count.",
-      "Generalize 7-anisotropy to all primes p where 2 is a cubic non-residue mod p (each gives a family of non-norms).",
-      "Characterize the full image of cnorm: the multiplicative monoid generated by split/ramified primes."
+      "Hard ACT: unit rank=1 via signature (1,1) — still no Mathlib bearer for card (InfinitePlace (AdjoinRoot (X^3-2))) = 2.",
+      "Optional S9: full valuation theorem v_p(N) ≡ 0 (mod 3) for inert p (strong induction on v_p).",
+      "Optional S9: positive side of the spectrum — which primes ARE norms (split primes; e.g. 3 = N(1,1,0), 5 = N(1,0,1)) — characterize the norm monoid.",
+      "Docker-verify was done S8; file registered via lake globs (no Proofs.lean edit needed)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research sessions S8 + S9 for `pell-equation-oq-05` (one branch, one PR tracking the head).

## Progress
**S8 — generic inert-prime descent + infinitude of non-norms** (`b636f9eb33`):
- `dvd_cnorm_iff_of_anisotropic` / `cube_dvd_cnorm_of_dvd` / `cnorm_ne_of_anisotropic`: the S7 mod-7 argument extracted to any anisotropic modulus (p | m, p^3 not-dvd m => m not a norm)
- Kernel-`decide` anisotropy certificates at the inert primes 13 (2197 triples) and 19 (6859 triples); new non-norms 13, 19, 91 = 7*13
- Capstone `non_norms_infinite` (family 7*(1+49k)): with S6's dichotomy, BOTH spectrum classes (attained-infinitely-often / never-attained) are infinite

**S9 — valuation rigidity at inert primes** (`01ffbdfedc`):
- `three_dvd_factorization_cnorm`: at any anisotropic prime p, 3 divides v_p of every nonzero norm value (strong-induction descent N = p^3 * N')
- `cnorm_ne_of_factorization`: 3 not-dvd v_p(m) => m not a norm — strictly extends the S8 criterion; first new instance `cnorm_ne_2401` (2401 = 7^4, where 7^3 | 2401 defeats S8's hypothesis)
- Positive spectrum: `norm_three_solutions_infinite` (3 = N(1,1,0)), `norm_five_solutions_infinite` (5 = N(1,0,1)); prime story 2 ✓ 3 ✓ 5 ✓ 7 ✗, decided by solvability of x^3 ≡ 2 (mod p)

## Verification
`./proofs/scripts/docker-build.sh Proofs.PellEquationOQ05` GREEN at both S8 and S9 heads (8576 jobs). File: 667 LOC, 45 theorems, 0 sorries, 0 axioms (all `decide`, no `native_decide`).

## Findings
- The valuation aux lemma must quantify over all triples with |N| = n so the strong-induction IH applies to the divided-out triple
- v4.31: `Nat.mul_lt_mul_right` is an iff (use `.mpr`); `Nat.factorization_pow_self` avoids the Finsupp.single detour; `Int.natCast_dvd` bridges Z-dvd to natAbs-dvd

## Status
**Outcome**: progress (norm-spectrum local theory complete at inert primes; unit rank = 1 via signature remains the deferred hard ACT — no Mathlib bearer)
**Next Steps**: S10 menu — sharpness instance v_7 = 3 attained (343 = N(7,0,0)); more split primes (11, 17, 23); norm-monoid characterization

🤖 Generated by researcher-1
