### PR TITLE
Enrich bounded-prime-gaps-oq-01-oq-01: add 5th keyInsight

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01-oq-01/meta.json
@@ -77,7 +77,8 @@
       "The gap-sieve axioms are derivable, not primitive: passing from 'two nearby primes' to 'a bounded CONSECUTIVE gap' is arithmetic, not analytic. Only one sieve axiom (the density statement) is truly irreducible.",
       "Admissibility is a red herring for the reduction. The gap extraction uses solely the diameter bound forall h in H, h <= D; admissibility matters only to make the density antecedent true. This cleanly localises the analytic difficulty.",
       "The index bookkeeping is the only subtlety: relating the analytic shift n to the prime index k is handled by the Nat.nth / Nat.count inverse-and-monotone API (nth_count, count_nth_of_infinite, nth_monotone, count_monotone) over the infinite set of primes.",
-      "The {0,d} specialisation makes the content concrete: the twin-prime density statement (two primes among {n, n+2} infinitely often) already entails infinitely many consecutive gaps <= 2 - no sieve axiom required for that last step."
+      "The {0,d} specialisation makes the content concrete: the twin-prime density statement (two primes among {n, n+2} infinitely often) already entails infinitely many consecutive gaps <= 2 - no sieve axiom required for that last step.",
+      "The unconditional (k >= 50) and Elliott-Halberstam-conditional (k >= 5) sieve axioms are eliminated by the literal same proof term: sieve_conclusion_from_density and sieve_eh_conclusion_from_density both delegate verbatim to density_two_implies_bounded_gaps, with their admissibility/cardinality hypotheses left unused (underscore-named). So Elliott-Halberstam's role in the bounded-gaps program is confined entirely to shrinking the admissible tuple size needed to secure the density witness (50 to 5) - it never touches the elementary gap-extraction step itself."
     ],
     "prerequisites": [
       "Bounded prime gaps setup (BoundedPrimeGaps.lean definitions)",


### PR DESCRIPTION
Enrichment pass for bounded-prime-gaps-oq-01-oq-01 (quality 98 → 100).

qualityBreakdown showed everything at cap except `keyInsights` (8/10, 4 items
instead of 5). Added a 5th, non-redundant insight verified against
`Proofs/BoundedPrimeGapsOQ01OQ01.lean`: `sieve_conclusion_from_density` (k ≥
50, unconditional) and `sieve_eh_conclusion_from_density` (k ≥ 5,
Elliott–Halberstam-conditional) both delegate to the literal same proof term
`density_two_implies_bounded_gaps H D hD hdens`, with their admissibility and
cardinality hypotheses left syntactically unused (underscore-named). So EH's
role in this reduction is confined entirely to shrinking the admissible tuple
size needed to secure the density witness — it never touches the elementary
gap-extraction step itself.

No other content changed — sections, historicalContext, conclusion,
crossReferences, and annotations were already at target. `meta.json` stays
well under the size cap (14.6 KB vs 60 KB).