### PR TITLE
research(ftc-oq-02-incomplete-01): S6 — upstream-prep: IsRCLikeNormedField + minSmoothness + Within/isOpen versions of C^n Schwarz

### DIFF
--- a/proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean
+++ b/proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean
@@ -8,14 +8,27 @@ generalized-Stokes decomposition; parent gallery entry `fundamental-theorem-calc
 
 ## What This Formalizes
 
-If `f : E → F` is `C^n` over `ℝ` (finite smoothness — analyticity NOT required), then its
-`n`-th iterated Fréchet derivative at every point is a *symmetric* multilinear map:
+If `f : E → F` is `C^n` over `𝕜 = ℝ` or `ℂ` (finite smoothness — analyticity NOT required),
+then its `n`-th iterated Fréchet derivative at every point is a *symmetric* multilinear map:
 
-  `iteratedFDeriv ℝ n f x (v ∘ σ) = iteratedFDeriv ℝ n f x v`  for every `σ : Perm (Fin n)`.
+  `iteratedFDeriv 𝕜 n f x (v ∘ σ) = iteratedFDeriv 𝕜 n f x v`  for every `σ : Perm (Fin n)`.
 
 This is the all-orders Schwarz/Clairaut theorem. It is the analytic backbone of `d ∘ d = 0`
 for differential forms, hence of the generalized Stokes theorem (Fragment 1 of this slug's
 decomposition, designed in the S3/S4 session memos of 2026-06).
+
+S6 (2026-07-24) generalized the original ℝ-only development (S5) for Mathlib upstream-prep:
+
+* the combinatorial core (Steps 1–3 below) is now stated over an arbitrary
+  `NontriviallyNormedField 𝕜`;
+* the main theorem `iteratedFDeriv_comp_perm` holds over any `IsRCLikeNormedField 𝕜`
+  (i.e. `𝕜` isomorphic to `ℝ` or `ℂ` — exactly the hypothesis of Mathlib's `n = 2` case);
+* `iteratedFDeriv_comp_perm_of_minSmoothness` is the field-uniform statement in Mathlib's
+  `minSmoothness` idiom: over `ℝ`/`ℂ` it requires `C^n`, over any other field it requires
+  `C^ω` and delegates to Mathlib's analytic version — this is the natural upstream statement;
+* `iteratedFDerivWithin_comp_perm_of_isOpen` is the `Within` version on open sets. (The full
+  `UniqueDiffOn`-set `Within` version needs the whole induction redone with `fderivWithin`
+  and is left as further upstream work — see the state.md S6 notes.)
 
 ## Relation to Mathlib (v4.31 pin)
 
@@ -26,7 +39,7 @@ Mathlib currently has:
   the general-`n` statement, but only for *analytic* (`C^ω`) functions.
 
 The general-`n`, finite-smoothness statement proved here is (as of the v4.31 pin) NOT in
-Mathlib. It strictly strengthens the analytic version over `ℝ` since `C^ω ⊊ C^n` as
+Mathlib. It strictly strengthens the analytic version over `ℝ`/`ℂ` since `C^ω ⊊ C^n` as
 function classes (`C^n` contains many non-analytic functions).
 
 ## Proof structure (elementary, no group-closure machinery)
@@ -35,15 +48,16 @@ Induction on `n`, using `Equiv.Perm.decomposeFin` to factor any permutation of `
 as `swap 0 p * (tail lift of τ)`:
 
 1. `fderiv_comp_perm_eq` — if every value of a multilinear-map-valued function `g` is
-   invariant under precomposition by `τ`, so is every value of `fderiv ℝ g x`
+   invariant under precomposition by `τ`, so is every value of `fderiv 𝕜 g x`
    (postcompose with the linear isometry `ContinuousMultilinearMap.domDomCongrₗᵢ`).
 2. `iteratedFDeriv_comp_tailLift` — symmetry of `D^n f` everywhere lifts to symmetry of
    `D^(n+1) f` under permutations fixing position 0 (peel one derivative with
    `iteratedFDeriv_succ_apply_left`).
 3. `iteratedFDeriv_comp_swap_zero_one` — swapping the two outermost directions is the
-   Mathlib `n = 2` case `ContDiffAt.isSymmSndFDerivAt` applied to `g := iteratedFDeriv ℝ n f`
+   Mathlib `n = 2` case `ContDiffAt.isSymmSndFDerivAt` applied to `g := iteratedFDeriv 𝕜 n f`
    (which is `C^2` by `ContDiff.iteratedFDeriv_right`), after rewriting `D^(n+2) f x m` as
-   `fderiv ℝ (fderiv ℝ (D^n f)) x (m 0) (m 1) (tail (tail m))`.
+   `fderiv 𝕜 (fderiv 𝕜 (D^n f)) x (m 0) (m 1) (tail (tail m))`. This is the one step that
+   needs `IsRCLikeNormedField 𝕜`.
 4. `swap 0 p` for general `p` is conjugate to `swap 0 1` by a tail lift
    (`Equiv.symm_trans_swap_trans`), so no `Subgroup.closure` argument is needed.
 
@@ -51,31 +65,33 @@ as `swap 0 p * (tail lift of τ)`:
 -/
 
 open Function Equiv
+open scoped ContDiff
 
 namespace FTCOQ02Incomplete01
 
-variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-  [NormedAddCommGroup F] [NormedSpace ℝ F] {f : E → F}
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  [NormedAddCommGroup F] [NormedSpace 𝕜 F] {f : E → F}
 
 /-! ### Step 1: derivatives of pointwise-symmetric multilinear-map-valued functions -/
 
-/-- If every value of `g : E → (E [×n]→L[ℝ] F)` is invariant under precomposition with the
+/-- If every value of `g : E → (E [×n]→L[𝕜] F)` is invariant under precomposition with the
 permutation `τ`, then so is every value of its derivative. The proof postcomposes `g` with
 the linear isometry `domDomCongrₗᵢ τ` and uses that `fderiv` commutes with linear
-isometries. -/
+isometries. Holds over any nontrivially normed field. -/
 theorem fderiv_comp_perm_eq {n : ℕ}
-    {g : E → ContinuousMultilinearMap ℝ (fun _ : Fin n => E) F} {τ : Equiv.Perm (Fin n)}
+    {g : E → ContinuousMultilinearMap 𝕜 (fun _ : Fin n => E) F} {τ : Equiv.Perm (Fin n)}
     (hg : ∀ y (w : Fin n → E), g y (w ∘ τ) = g y w) (x u : E) (w : Fin n → E) :
-    fderiv ℝ g x u (w ∘ τ) = fderiv ℝ g x u w := by
-  set Φ := ContinuousMultilinearMap.domDomCongrₗᵢ ℝ E F τ with hΦ
+    fderiv 𝕜 g x u (w ∘ τ) = fderiv 𝕜 g x u w := by
+  set Φ := ContinuousMultilinearMap.domDomCongrₗᵢ 𝕜 E F τ with hΦ
   have hgΦ : ⇑Φ ∘ g = g := by
     funext y
     exact ContinuousMultilinearMap.ext fun v => hg y v
-  have hfd : fderiv ℝ g x = (Φ : (ContinuousMultilinearMap ℝ (fun _ : Fin n => E) F) →L[ℝ]
-      (ContinuousMultilinearMap ℝ (fun _ : Fin n => E) F)).comp (fderiv ℝ g x) := by
+  have hfd : fderiv 𝕜 g x = (Φ : (ContinuousMultilinearMap 𝕜 (fun _ : Fin n => E) F) →L[𝕜]
+      (ContinuousMultilinearMap 𝕜 (fun _ : Fin n => E) F)).comp (fderiv 𝕜 g x) := by
     conv_lhs => rw [← hgΦ]
     exact Φ.comp_fderiv
-  have happ : fderiv ℝ g x u = (fderiv ℝ g x u).domDomCongr τ := by
+  have happ : fderiv 𝕜 g x u = (fderiv 𝕜 g x u).domDomCongr τ := by
     conv_lhs => rw [hfd]
     rfl
   conv_rhs => rw [happ]
@@ -85,63 +101,65 @@ theorem fderiv_comp_perm_eq {n : ℕ}
 
 /-- If the `n`-th derivative of `f` is `τ`-symmetric at every point, then the `(n+1)`-th
 derivative is symmetric under the tail lift `decomposeFin.symm (0, τ)` of `τ` (the
-permutation of `Fin (n+1)` fixing `0` and acting by `τ` on the tail). -/
+permutation of `Fin (n+1)` fixing `0` and acting by `τ` on the tail). Holds over any
+nontrivially normed field. -/
 theorem iteratedFDeriv_comp_tailLift {n : ℕ} {τ : Equiv.Perm (Fin n)}
-    (hτ : ∀ y (w : Fin n → E), iteratedFDeriv ℝ n f y (w ∘ τ) = iteratedFDeriv ℝ n f y w)
+    (hτ : ∀ y (w : Fin n → E), iteratedFDeriv 𝕜 n f y (w ∘ τ) = iteratedFDeriv 𝕜 n f y w)
     (x : E) (v : Fin (n + 1) → E) :
-    iteratedFDeriv ℝ (n + 1) f x (v ∘ (Equiv.Perm.decomposeFin.symm (0, τ))) =
-      iteratedFDeriv ℝ (n + 1) f x v := by
+    iteratedFDeriv 𝕜 (n + 1) f x (v ∘ (Equiv.Perm.decomposeFin.symm (0, τ))) =
+      iteratedFDeriv 𝕜 (n + 1) f x v := by
   have h0 : (v ∘ (Equiv.Perm.decomposeFin.symm (0, τ))) 0 = v 0 := by simp
   have ht : Fin.tail (v ∘ (Equiv.Perm.decomposeFin.symm (0, τ))) = Fin.tail v ∘ τ := by
     funext i
     simp [Fin.tail, Equiv.Perm.decomposeFin_symm_apply_succ]
-  calc iteratedFDeriv ℝ (n + 1) f x (v ∘ (Equiv.Perm.decomposeFin.symm (0, τ)))
-      = fderiv ℝ (iteratedFDeriv ℝ n f) x ((v ∘ (Equiv.Perm.decomposeFin.symm (0, τ))) 0)
+  calc iteratedFDeriv 𝕜 (n + 1) f x (v ∘ (Equiv.Perm.decomposeFin.symm (0, τ)))
+      = fderiv 𝕜 (iteratedFDeriv 𝕜 n f) x ((v ∘ (Equiv.Perm.decomposeFin.symm (0, τ))) 0)
           (Fin.tail (v ∘ (Equiv.Perm.decomposeFin.symm (0, τ)))) :=
         iteratedFDeriv_succ_apply_left _
-    _ = fderiv ℝ (iteratedFDeriv ℝ n f) x (v 0) (Fin.tail v ∘ τ) := by rw [h0, ht]
-    _ = fderiv ℝ (iteratedFDeriv ℝ n f) x (v 0) (Fin.tail v) :=
+    _ = fderiv 𝕜 (iteratedFDeriv 𝕜 n f) x (v 0) (Fin.tail v ∘ τ) := by rw [h0, ht]
+    _ = fderiv 𝕜 (iteratedFDeriv 𝕜 n f) x (v 0) (Fin.tail v) :=
         fderiv_comp_perm_eq hτ x (v 0) (Fin.tail v)
-    _ = iteratedFDeriv ℝ (n + 1) f x v := (iteratedFDeriv_succ_apply_left _).symm
+    _ = iteratedFDeriv 𝕜 (n + 1) f x v := (iteratedFDeriv_succ_apply_left _).symm
 
 /-! ### Step 3: the two outermost directions commute (Mathlib's `n = 2` Schwarz) -/
 
 /-- Expand the `(n+2)`-th derivative as the second derivative of the `n`-th derivative,
-applied to the two leading directions. -/
+applied to the two leading directions. Holds over any nontrivially normed field. -/
 private theorem iteratedFDeriv_add_two_apply {n : ℕ} (f : E → F) (x : E)
     (w : Fin (n + 2) → E) :
-    iteratedFDeriv ℝ (n + 2) f x w =
-      fderiv ℝ (fderiv ℝ (iteratedFDeriv ℝ n f)) x (w 0) (w 1)
+    iteratedFDeriv 𝕜 (n + 2) f x w =
+      fderiv 𝕜 (fderiv 𝕜 (iteratedFDeriv 𝕜 n f)) x (w 0) (w 1)
         (Fin.tail (Fin.tail w)) := by
   have h2 := LinearIsometryEquiv.comp_fderiv
-    (𝕜 := ℝ) (G := E)
-    (iso := (continuousMultilinearCurryLeftEquiv ℝ (fun _ : Fin (n + 1) => E) F).symm)
-    (f := fderiv ℝ (iteratedFDeriv ℝ n f)) (x := x)
+    (𝕜 := 𝕜) (G := E)
+    (iso := (continuousMultilinearCurryLeftEquiv 𝕜 (fun _ : Fin (n + 1) => E) F).symm)
+    (f := fderiv 𝕜 (iteratedFDeriv 𝕜 n f)) (x := x)
   have htw : Fin.tail w 0 = w 1 := by
     simp [Fin.tail]
-  calc iteratedFDeriv ℝ (n + 2) f x w
-      = fderiv ℝ (iteratedFDeriv ℝ (n + 1) f) x (w 0) (Fin.tail w) :=
+  calc iteratedFDeriv 𝕜 (n + 2) f x w
+      = fderiv 𝕜 (iteratedFDeriv 𝕜 (n + 1) f) x (w 0) (Fin.tail w) :=
         iteratedFDeriv_succ_apply_left w
-    _ = fderiv ℝ (⇑(continuousMultilinearCurryLeftEquiv ℝ (fun _ : Fin (n + 1) => E) F).symm ∘
-          fderiv ℝ (iteratedFDeriv ℝ n f)) x (w 0) (Fin.tail w) := by
+    _ = fderiv 𝕜 (⇑(continuousMultilinearCurryLeftEquiv 𝕜 (fun _ : Fin (n + 1) => E) F).symm ∘
+          fderiv 𝕜 (iteratedFDeriv 𝕜 n f)) x (w 0) (Fin.tail w) := by
         rw [← iteratedFDeriv_succ_eq_comp_left]
-    _ = (continuousMultilinearCurryLeftEquiv ℝ (fun _ : Fin (n + 1) => E) F).symm
-          (fderiv ℝ (fderiv ℝ (iteratedFDeriv ℝ n f)) x (w 0)) (Fin.tail w) := by
+    _ = (continuousMultilinearCurryLeftEquiv 𝕜 (fun _ : Fin (n + 1) => E) F).symm
+          (fderiv 𝕜 (fderiv 𝕜 (iteratedFDeriv 𝕜 n f)) x (w 0)) (Fin.tail w) := by
         rw [h2]; rfl
-    _ = fderiv ℝ (fderiv ℝ (iteratedFDeriv ℝ n f)) x (w 0) (Fin.tail w 0)
+    _ = fderiv 𝕜 (fderiv 𝕜 (iteratedFDeriv 𝕜 n f)) x (w 0) (Fin.tail w 0)
           (Fin.tail (Fin.tail w)) := rfl
-    _ = fderiv ℝ (fderiv ℝ (iteratedFDeriv ℝ n f)) x (w 0) (w 1)
+    _ = fderiv 𝕜 (fderiv 𝕜 (iteratedFDeriv 𝕜 n f)) x (w 0) (w 1)
           (Fin.tail (Fin.tail w)) := by rw [htw]
 
 /-- Swapping the two outermost differentiation directions: the `n = 2` Schwarz theorem
-(`ContDiffAt.isSymmSndFDerivAt`, which needs only `C^2` over `ℝ`) applied to the
-multilinear-map-valued function `iteratedFDeriv ℝ n f`. -/
-theorem iteratedFDeriv_comp_swap_zero_one {n : ℕ} (hf : ContDiff ℝ (n + 2 : ℕ) f) (x : E)
-    (m : Fin (n + 2) → E) :
-    iteratedFDeriv ℝ (n + 2) f x (m ∘ Equiv.swap 0 1) = iteratedFDeriv ℝ (n + 2) f x m := by
-  have hg : ContDiff ℝ 2 (iteratedFDeriv ℝ n f) :=
+(`ContDiffAt.isSymmSndFDerivAt`, which needs only `C^2` over `ℝ` or `ℂ`) applied to the
+multilinear-map-valued function `iteratedFDeriv 𝕜 n f`. This is the single step that
+requires `IsRCLikeNormedField 𝕜`. -/
+theorem iteratedFDeriv_comp_swap_zero_one [IsRCLikeNormedField 𝕜] {n : ℕ}
+    (hf : ContDiff 𝕜 (n + 2 : ℕ) f) (x : E) (m : Fin (n + 2) → E) :
+    iteratedFDeriv 𝕜 (n + 2) f x (m ∘ Equiv.swap 0 1) = iteratedFDeriv 𝕜 (n + 2) f x m := by
+  have hg : ContDiff 𝕜 2 (iteratedFDeriv 𝕜 n f) :=
     hf.iteratedFDeriv_right (by norm_cast; omega)
-  have hsym : IsSymmSndFDerivAt ℝ (iteratedFDeriv ℝ n f) x :=
+  have hsym : IsSymmSndFDerivAt 𝕜 (iteratedFDeriv 𝕜 n f) x :=
     hg.contDiffAt.isSymmSndFDerivAt (by simp)
   have h0 : (m ∘ Equiv.swap 0 1) 0 = m 1 := by simp
   have h1 : (m ∘ Equiv.swap 0 1) 1 = m 0 := by simp
@@ -155,13 +173,13 @@ theorem iteratedFDeriv_comp_swap_zero_one {n : ℕ} (hf : ContDiff ℝ (n + 2 : 
 /-! ### Step 4: the main theorem -/
 
 /-- **Symmetry of the `n`-th iterated Fréchet derivative of a `C^n` function** (all-orders
-Schwarz/Clairaut over `ℝ`, finite smoothness — no analyticity required).
+Schwarz/Clairaut over `ℝ` or `ℂ`, finite smoothness — no analyticity required).
 
 Mathlib (v4.31) has this only for `n = 2` (`ContDiffAt.isSymmSndFDerivAt`) or for
 analytic `f` (`ContDiffAt.iteratedFDeriv_comp_perm`). -/
-theorem iteratedFDeriv_comp_perm :
-    ∀ {n : ℕ}, ContDiff ℝ (n : ℕ) f → ∀ (x : E) (v : Fin n → E) (σ : Equiv.Perm (Fin n)),
-      iteratedFDeriv ℝ n f x (v ∘ σ) = iteratedFDeriv ℝ n f x v := by
+theorem iteratedFDeriv_comp_perm [IsRCLikeNormedField 𝕜] :
+    ∀ {n : ℕ}, ContDiff 𝕜 (n : ℕ) f → ∀ (x : E) (v : Fin n → E) (σ : Equiv.Perm (Fin n)),
+      iteratedFDeriv 𝕜 n f x (v ∘ σ) = iteratedFDeriv 𝕜 n f x v := by
   intro n
   induction n with
   | zero =>
@@ -171,7 +189,7 @@ theorem iteratedFDeriv_comp_perm :
     intro hf x v σ
     -- the `n`-th derivative is symmetric at every point, by the induction hypothesis
     have hsymm : ∀ (τ : Equiv.Perm (Fin n)) (y : E) (w : Fin n → E),
-        iteratedFDeriv ℝ n f y (w ∘ τ) = iteratedFDeriv ℝ n f y w :=
+        iteratedFDeriv 𝕜 n f y (w ∘ τ) = iteratedFDeriv 𝕜 n f y w :=
       fun τ y w => IH (hf.of_le (by exact_mod_cast Nat.le_succ n)) y w τ
     -- factor σ = swap 0 p * (tail lift of τ) via `decomposeFin`
     set p : Fin (n + 1) := (Equiv.Perm.decomposeFin σ).1 with hp
@@ -224,32 +242,67 @@ theorem iteratedFDeriv_comp_perm :
           rw [hconj]
           funext i
           simp
-        calc iteratedFDeriv ℝ (k + 2) f x (v ∘ ⇑(Equiv.swap 0 j.succ))
-            = iteratedFDeriv ℝ (k + 2) f x
+        calc iteratedFDeriv 𝕜 (k + 2) f x (v ∘ ⇑(Equiv.swap 0 j.succ))
+            = iteratedFDeriv 𝕜 (k + 2) f x
                 (((v ∘ ⇑ρhat) ∘ ⇑(Equiv.swap 0 1)) ∘ ⇑ρhat⁻¹) := by rw [hv]
-          _ = iteratedFDeriv ℝ (k + 2) f x ((v ∘ ⇑ρhat) ∘ ⇑(Equiv.swap 0 1)) := by
+          _ = iteratedFDeriv 𝕜 (k + 2) f x ((v ∘ ⇑ρhat) ∘ ⇑(Equiv.swap 0 1)) := by
               rw [hρinv]
               exact iteratedFDeriv_comp_tailLift (fun y w => hsymm ρ⁻¹ y w) x _
-          _ = iteratedFDeriv ℝ (k + 2) f x (v ∘ ⇑ρhat) :=
+          _ = iteratedFDeriv 𝕜 (k + 2) f x (v ∘ ⇑ρhat) :=
               iteratedFDeriv_comp_swap_zero_one hf x (v ∘ ⇑ρhat)
-          _ = iteratedFDeriv ℝ (k + 2) f x v :=
+          _ = iteratedFDeriv 𝕜 (k + 2) f x v :=
               iteratedFDeriv_comp_tailLift (fun y w => hsymm ρ y w) x v
 
 /-- The `n`-th iterated derivative of a `C^n` function, as a multilinear map, is fixed by
 `domDomCongr` along any permutation. -/
-theorem iteratedFDeriv_domDomCongr {n : ℕ} (hf : ContDiff ℝ (n : ℕ) f) (x : E)
-    (σ : Equiv.Perm (Fin n)) :
-    (iteratedFDeriv ℝ n f x).domDomCongr σ = iteratedFDeriv ℝ n f x := by
+theorem iteratedFDeriv_domDomCongr [IsRCLikeNormedField 𝕜] {n : ℕ}
+    (hf : ContDiff 𝕜 (n : ℕ) f) (x : E) (σ : Equiv.Perm (Fin n)) :
+    (iteratedFDeriv 𝕜 n f x).domDomCongr σ = iteratedFDeriv 𝕜 n f x := by
   refine ContinuousMultilinearMap.ext fun v => ?_
   simpa [ContinuousMultilinearMap.domDomCongr_apply, Function.comp_def] using
     iteratedFDeriv_comp_perm hf x v σ
 
 /-- Specialization to `C^∞` functions: every iterated derivative is symmetric. This is
-strictly stronger over `ℝ` than Mathlib's analytic version, since smooth functions need
-not be analytic. -/
-theorem iteratedFDeriv_comp_perm_of_contDiff_infty (hf : ContDiff ℝ (⊤ : ℕ∞) f) {n : ℕ}
+strictly stronger over `ℝ`/`ℂ` than Mathlib's analytic version, since smooth functions
+need not be analytic. -/
+theorem iteratedFDeriv_comp_perm_of_contDiff_infty [IsRCLikeNormedField 𝕜]
+    (hf : ContDiff 𝕜 (⊤ : ℕ∞) f) {n : ℕ}
     (x : E) (v : Fin n → E) (σ : Equiv.Perm (Fin n)) :
-    iteratedFDeriv ℝ n f x (v ∘ σ) = iteratedFDeriv ℝ n f x v :=
+    iteratedFDeriv 𝕜 n f x (v ∘ σ) = iteratedFDeriv 𝕜 n f x v :=
   iteratedFDeriv_comp_perm (hf.of_le (by exact_mod_cast le_top)) x v σ
+
+/-! ### Step 5 (S6): field-uniform `minSmoothness` version and `Within` version -/
+
+/-- **Field-uniform version, in Mathlib's `minSmoothness` idiom.** Over any nontrivially
+normed field `𝕜`, if `f` is `C^(minSmoothness 𝕜 n)` — that is, `C^n` when `𝕜` is `ℝ` or
+`ℂ`, and `C^ω` (analytic) otherwise — then the `n`-th iterated derivative is symmetric.
+
+Over `ℝ`/`ℂ` this is the finite-smoothness theorem above; over any other field the
+requirement degrades to analyticity, where Mathlib's
+`ContDiffAt.iteratedFDeriv_comp_perm` applies. This mirrors exactly how Mathlib states
+`ContDiffAt.isSymmSndFDerivAt`, making it the natural upstream form. -/
+theorem iteratedFDeriv_comp_perm_of_minSmoothness {n : ℕ}
+    (hf : ContDiff 𝕜 (minSmoothness 𝕜 n) f) (x : E) (v : Fin n → E)
+    (σ : Equiv.Perm (Fin n)) :
+    iteratedFDeriv 𝕜 n f x (v ∘ σ) = iteratedFDeriv 𝕜 n f x v := by
+  by_cases h : IsRCLikeNormedField 𝕜
+  · haveI := h
+    rw [minSmoothness_of_isRCLikeNormedField] at hf
+    exact iteratedFDeriv_comp_perm hf x v σ
+  · have hω : minSmoothness 𝕜 (n : ℕ∞ω) = ω := by
+      simp [minSmoothness, h]
+    rw [hω] at hf
+    exact hf.contDiffAt.iteratedFDeriv_comp_perm v σ
+
+/-- `Within` version on **open** sets: on an open set the iterated derivative within the
+set agrees with the global one (`iteratedFDerivWithin_of_isOpen`), so symmetry transfers.
+(The general `UniqueDiffOn` version requires redoing the induction with `fderivWithin`
+and is left as further upstream work.) -/
+theorem iteratedFDerivWithin_comp_perm_of_isOpen [IsRCLikeNormedField 𝕜] {n : ℕ}
+    (hf : ContDiff 𝕜 (n : ℕ) f) {s : Set E} (hs : IsOpen s) {x : E} (hx : x ∈ s)
+    (v : Fin n → E) (σ : Equiv.Perm (Fin n)) :
+    iteratedFDerivWithin 𝕜 n f s x (v ∘ σ) = iteratedFDerivWithin 𝕜 n f s x v := by
+  rw [iteratedFDerivWithin_of_isOpen n hs hx]
+  exact iteratedFDeriv_comp_perm hf x v σ
 
 end FTCOQ02Incomplete01

--- a/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01/sessions/2026-07-24-s6-upstream-prep-rclike-minsmoothness.md
+++ b/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01/sessions/2026-07-24-s6-upstream-prep-rclike-minsmoothness.md
@@ -1,0 +1,55 @@
+# Session 2026-07-24 — S6 (researcher-2): Mathlib upstream-prep — 𝕜-generalization of Fragment 1
+
+## Phase: ACT (incremental, on top of S5's Fragment 1)
+
+## Goal
+
+The S5 state.md flagged S6 as "Mathlib upstream-prep of `iteratedFDeriv_comp_perm`
+(generalize ℝ → `IsRCLikeNormedField 𝕜` via `minSmoothness`; add `Within` versions)".
+
+## What changed (`proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean`, in place)
+
+1. **Steps 1–3 core generalized to an arbitrary `NontriviallyNormedField 𝕜`**:
+   `fderiv_comp_perm_eq`, `iteratedFDeriv_comp_tailLift`, `iteratedFDeriv_add_two_apply`
+   never needed ℝ — `domDomCongrₗᵢ`, `LinearIsometryEquiv.comp_fderiv`,
+   `iteratedFDeriv_succ_apply_left` are all field-generic in Mathlib.
+2. **`iteratedFDeriv_comp_swap_zero_one` and the main theorem gated by
+   `[IsRCLikeNormedField 𝕜]`** — exactly the hypothesis of Mathlib's n = 2 case
+   (`ContDiffAt.isSymmSndFDerivAt` with `minSmoothness 𝕜 2 ≤ 2`, closed by `simp` via
+   `minSmoothness_of_isRCLikeNormedField`). This is the honest generality of the
+   finite-smoothness argument: Schwarz n = 2 is the only ℝ/ℂ-specific input.
+3. **NEW `iteratedFDeriv_comp_perm_of_minSmoothness`** — the field-uniform statement over
+   ANY nontrivially normed field, in Mathlib's `minSmoothness` idiom:
+   `ContDiff 𝕜 (minSmoothness 𝕜 n) f → iteratedFDeriv 𝕜 n f x (v ∘ σ) = …`.
+   Proof `by_cases IsRCLikeNormedField 𝕜`: RCLike branch is our theorem
+   (`minSmoothness 𝕜 n = n`); other fields have `minSmoothness 𝕜 n = ω`, so `f` is
+   analytic and Mathlib's `ContDiffAt.iteratedFDeriv_comp_perm` finishes. This mirrors
+   exactly how Mathlib states `ContDiffAt.isSymmSndFDerivAt` — the natural upstream form.
+4. **NEW `iteratedFDerivWithin_comp_perm_of_isOpen`** — `Within` version on open sets via
+   `iteratedFDerivWithin_of_isOpen`. The full `UniqueDiffOn`-set `Within` version needs the
+   whole induction redone with `fderivWithin` (`LinearIsometryEquiv.comp_fderivWithin` at
+   `UniqueDiffWithinAt` points, `IsSymmSndFDerivWithinAt` with `x ∈ closure (interior s)`)
+   — left as the remaining upstream-prep item (candidate S7).
+
+## Lean gotchas (v4.31)
+
+- `ℕ∞ω`, `ω`, `∞` smoothness-exponent notations are `scoped[ContDiff]`
+  (Mathlib.Analysis.Calculus.ContDiff.FTaylorSeries:115-119) — a file using
+  `minSmoothness` statements needs `open scoped ContDiff` even with `import Mathlib`.
+- `minSmoothness` is `irreducible_def`; unfold in the non-RCLike branch with
+  `simp [minSmoothness, h]` (the equation lemma is registered under the plain name),
+  same idiom as Mathlib's own `ContDiffAt.isSymmSndFDerivAt` proof.
+- The S5 gotchas stand: explicit `(𝕜 := …) (G := …) (iso := …) (f := …) (x := …)` on
+  `LinearIsometryEquiv.comp_fderiv` (whnf timeout otherwise); `hsym.eq` for
+  `IsSymmSndFDerivAt` application.
+
+## Build
+
+`./proofs/scripts/docker-build.sh Proofs.FundamentalTheoremCalculusOQ02Incomplete01`
+— see PR. First attempt failed only on the scoped-notation gotcha above.
+
+## Status
+
+Fragment 1 now in upstream-ready generality. Fragments 2–6 (manifold Stokes) unchanged —
+DEEP multi-session. Next concrete item: S7 full `Within`/`UniqueDiffOn` induction if
+upstreaming proceeds.

--- a/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01/state.md
+++ b/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01/state.md
@@ -10,9 +10,41 @@ is symmetric under every permutation (all-orders Schwarz/Clairaut, FINITE smooth
 cache (identical lake-manifest rev `9a9483a929`). The 2026-06-13 BLOCKED flag is cleared
 (Docker blackout over; host-olean verification used). The S4 skeleton was NOT pasted —
 Mathlib v4.26→v4.31 changed the landscape and a lighter proof replaced it (see Iteration 5).
+S6 (researcher-2, 2026-07-24) then generalized the file to upstream-ready generality —
+see Iteration 6.
 **Path**: full
-**Since**: 2026-07-24 (S5 ACT complete)
-**Iteration**: 5
+**Since**: 2026-07-24 (S6 upstream-prep complete)
+**Iteration**: 6
+
+## Iteration 6 (researcher-2, 2026-07-24) — S6: Mathlib upstream-prep — 𝕜-generalization (0 ax / 0 sorry)
+
+**Outcome**: `FundamentalTheoremCalculusOQ02Incomplete01.lean` generalized IN PLACE
+(docker build exit 0, 8576 jobs, no warnings):
+
+* Steps 1–3 core (`fderiv_comp_perm_eq`, `iteratedFDeriv_comp_tailLift`,
+  `iteratedFDeriv_add_two_apply`) now over an arbitrary `NontriviallyNormedField 𝕜` —
+  they never needed ℝ.
+* `iteratedFDeriv_comp_swap_zero_one` + main `iteratedFDeriv_comp_perm` + corollaries
+  gated by `[IsRCLikeNormedField 𝕜]` (ℝ or ℂ) — exactly the hypothesis of Mathlib's
+  n = 2 Schwarz. The old ℝ statements are the `𝕜 := ℝ` instances.
+* NEW `iteratedFDeriv_comp_perm_of_minSmoothness` — field-uniform statement over ANY
+  nontrivially normed field in Mathlib's `minSmoothness` idiom
+  (`ContDiff 𝕜 (minSmoothness 𝕜 n) f`); `by_cases IsRCLikeNormedField 𝕜`, non-RCLike
+  branch delegates to Mathlib's analytic `ContDiffAt.iteratedFDeriv_comp_perm`.
+  This mirrors `ContDiffAt.isSymmSndFDerivAt` — the natural upstream form.
+* NEW `iteratedFDerivWithin_comp_perm_of_isOpen` — `Within` version on open sets via
+  `iteratedFDerivWithin_of_isOpen`.
+
+**Gotchas (v4.31)**: `ℕ∞ω`/`ω`/`∞` are `scoped[ContDiff]` notations — need
+`open scoped ContDiff` even with `import Mathlib`. `minSmoothness` is `irreducible_def`;
+unfold with `simp [minSmoothness, h]` (same idiom as Mathlib's own isSymmSndFDerivAt proof).
+
+**Remaining (S7 candidate)**: full `UniqueDiffOn`-set `Within` version = redo the induction
+with `fderivWithin` (`LinearIsometryEquiv.comp_fderivWithin` at `UniqueDiffWithinAt` points,
+`ContDiffWithinAt.isSymmSndFDerivWithinAt` needing `x ∈ closure (interior s)`). Fragments
+2–6 (manifold Stokes) unchanged — DEEP multi-session.
+
+Session memo: `sessions/2026-07-24-s6-upstream-prep-rclike-minsmoothness.md`.
 
 ## Iteration 5 (researcher-3, 2026-07-24) — S5 ACT: Fragment 1 SHIPPED (C^n iteratedFDeriv symmetry, 0 ax / 0 sorry)
 

--- a/src/data/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01.json
+++ b/src/data/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01.json
@@ -30,9 +30,9 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-07-24T10:20:00Z",
-    "iteration": 5,
-    "focus": "Iteration 5 (researcher-3, 2026-07-24, S5 ACT COMPLETE): Fragment 1 SHIPPED. New file `proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean` (~250 LOC, 0 axioms, 0 sorries, verified with the v4.31.0 toolchain against the pinned Mathlib olean cache — identical lake-manifest rev 9a9483a92959) proves `iteratedFDeriv_comp_perm`: the n-th iterated Frechet derivative of a C^n function over R is symmetric under every permutation of its arguments (all-orders Schwarz/Clairaut, finite smoothness). KEY RE-DESIGN vs the S4 skeleton: Mathlib moved v4.26 -> v4.31 and now has (a) `ContDiffAt.iteratedFDeriv_comp_perm` for ANALYTIC functions only, and (b) `ContDiffAt.isSymmSndFDerivAt` (n=2, C^2 over R/C). The C^n finite-smoothness general-n statement was STILL missing — this file fills it. The S4 adjacent-transposition/Subgroup.closure plan was replaced by a lighter argument: `Equiv.Perm.decomposeFin` factors sigma = swap 0 p * tailLift tau; tail lifts are handled by postcomposing with `ContinuousMultilinearMap.domDomCongrLI` (fderiv commutes with linear isometries), swap 0 1 by the Mathlib n=2 Schwarz applied to g := iteratedFDeriv R n f (C^2 via `ContDiff.iteratedFDeriv_right`), and swap 0 p by conjugation `Equiv.symm_trans_swap_trans` — no group-closure machinery at all.",
+    "since": "2026-07-24",
+    "iteration": 6,
+    "focus": "Iteration 6 (researcher-2, 2026-07-24, S6 upstream-prep COMPLETE): Fragment 1 generalized in place to upstream-ready generality (docker exit 0, 8576 jobs, 0 ax / 0 sorry). Steps 1-3 core now over arbitrary NontriviallyNormedField; main theorem + swap-0-1 step gated by IsRCLikeNormedField (exactly Mathlib n=2 Schwarz hypothesis). NEW: iteratedFDeriv_comp_perm_of_minSmoothness — field-uniform statement in Mathlib minSmoothness idiom (non-RCLike branch delegates to analytic ContDiffAt.iteratedFDeriv_comp_perm), mirroring ContDiffAt.isSymmSndFDerivAt; iteratedFDerivWithin_comp_perm_of_isOpen (Within on open sets). Remaining S7 candidate: full UniqueDiffOn Within induction via fderivWithin. Fragments 2-6 (manifold Stokes) DEEP multi-session, unchanged.",
     "blockers": [],
     "nextAction": "Fragment 1 done (the S4-planned `IteratedFDerivSymmetric.lean` target is superseded by `FundamentalTheoremCalculusOQ02Incomplete01.lean`). Honest next options: (i) S6 Mathlib upstream-prep of `iteratedFDeriv_comp_perm` (natural home: near `Mathlib.Analysis.Analytic.IteratedFDeriv`; generalize R to IsRCLikeNormedField via `minSmoothness`); (ii) Fragments 2-6 (differential-form integration on manifolds with boundary) remain DEEP and are NOT session-sized — do not chase without a dedicated multi-session plan. Within-versions (iteratedFDerivWithin on UniqueDiffOn sets) are a plausible medium extension.",
     "attemptCounts": {
@@ -50,14 +50,21 @@
       "`Proofs/FundamentalTheoremCalculusStokes.lean`: concrete 1D and 2D Stokes framework.",
       "`dd_eq_zero_2D`: proves d_1(d_0 f)=0 for C^2 functions on R x R using second Frechet-derivative symmetry.",
       "`stokes_2d_rectangle`: Green's theorem in Stokes form via `GreensTheoremOQ01.greens_theorem_concrete`.",
-      "`src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json`: parent proof metadata for the gallery proof."
+      "`src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json`: parent proof metadata for the gallery proof.",
+      "S6: fderiv_comp_perm_eq / iteratedFDeriv_comp_tailLift / iteratedFDeriv_add_two_apply generalized to arbitrary NontriviallyNormedField (FundamentalTheoremCalculusOQ02Incomplete01.lean)",
+      "S6: iteratedFDeriv_comp_perm + corollaries now over IsRCLikeNormedField (R or C), not just R",
+      "S6: iteratedFDeriv_comp_perm_of_minSmoothness — field-uniform minSmoothness statement over any nontrivially normed field",
+      "S6: iteratedFDerivWithin_comp_perm_of_isOpen — Within version on open sets"
     ],
     "insights": [
       "FTC is represented as the 1D Stokes theorem with M=[a,b], omega=F, and d omega=F' dx.",
       "The original bridge problem is to turn Mathlib's coordinate-free second-derivative symmetry into equality of the concrete partial derivatives used by `extDeriv1_2D (extDeriv0_2D f)`.",
       "The current Lean proof performs that bridge with `HasFDerivAt.comp_hasDerivAt`, coordinate embeddings, `HasDerivAt.clm_apply`, and `ContDiffAt.isSymmSndFDerivAt`.",
       "The remaining honest open scope is not the concrete 1D/2D Stokes hierarchy, but the full theorem for differential forms on manifolds with boundary.",
-      "v4.31 Mathlib gained the analytic-case n-th-derivative symmetry (Gouezel, Mathlib.Analysis.Analytic.IteratedFDeriv) and the n=2 IsSymmSndFDeriv API; the finite-smoothness C^n general-n case was the surviving gap and is exactly what Fragment 1 needed. Peel-left + decomposeFin + conjugated swaps avoids Subgroup.closure entirely; the S4 fear about case i=0 currying (65-100 LOC) shrank to ~30 LOC because `iteratedFDeriv_succ_apply_left`/`iteratedFDeriv_succ_eq_comp_left` are rfl and `LinearIsometryEquiv.comp_fderiv` (with EXPLICIT type args — implicit unification times out at whnf on CMM instance paths) gives the currying step in one line."
+      "v4.31 Mathlib gained the analytic-case n-th-derivative symmetry (Gouezel, Mathlib.Analysis.Analytic.IteratedFDeriv) and the n=2 IsSymmSndFDeriv API; the finite-smoothness C^n general-n case was the surviving gap and is exactly what Fragment 1 needed. Peel-left + decomposeFin + conjugated swaps avoids Subgroup.closure entirely; the S4 fear about case i=0 currying (65-100 LOC) shrank to ~30 LOC because `iteratedFDeriv_succ_apply_left`/`iteratedFDeriv_succ_eq_comp_left` are rfl and `LinearIsometryEquiv.comp_fderiv` (with EXPLICIT type args — implicit unification times out at whnf on CMM instance paths) gives the currying step in one line.",
+      "The ONLY R/C-specific input to the C^n Schwarz induction is the n=2 base (ContDiffAt.isSymmSndFDerivAt); everything else (domDomCongr isometry transport, tail lifts, decomposeFin conjugation) is field-generic.",
+      "Mathlib minSmoothness idiom unifies the C^n (RCLike) and C^omega (general field) versions into one statement — the natural upstream form; by_cases IsRCLikeNormedField with the non-RCLike branch delegating to the analytic version, exactly like isSymmSndFDerivAt itself.",
+      "v4.31: smoothness-exponent notations (nat-infty-omega, omega, infty) are scoped[ContDiff]; files using minSmoothness need open scoped ContDiff even with import Mathlib. minSmoothness is irreducible_def — unfold via simp [minSmoothness, h]."
     ],
     "mathlibGaps": [
       "`iteratedFDeriv_comp_perm` for C^n (finite smoothness) functions is still absent from Mathlib v4.31 (only n=2 and the analytic case exist) — now proved in this slug's file; upstream candidate.",
@@ -65,9 +72,9 @@
       "The parent Lean comments identify differential-form integration on oriented manifolds with boundary as future Mathlib infrastructure."
     ],
     "nextSteps": [
-      "S6: Mathlib upstream-prep of `iteratedFDeriv_comp_perm` (generalize to IsRCLikeNormedField via minSmoothness; add Within versions).",
-      "Fragments 2-6 (manifold Stokes) remain deep, multi-session work — do not start without a plan.",
-      "Optional: bridge `iteratedFDeriv_comp_perm` to concrete partial-derivative statements (lineDeriv Clairaut) as a smaller follow-up."
+      "S7 (optional upstream-prep): full UniqueDiffOn Within version — redo the induction with fderivWithin (LinearIsometryEquiv.comp_fderivWithin at UniqueDiffWithinAt points; ContDiffWithinAt.isSymmSndFDerivWithinAt needs x in closure (interior s)).",
+      "Actual Mathlib PR submission of iteratedFDeriv_comp_perm_of_minSmoothness (natural home: Mathlib.Analysis.Calculus.FDeriv.Symmetric or Analysis.Analytic.IteratedFDeriv).",
+      "Fragments 2-6 (differential forms, d o d = 0, manifold Stokes) — DEEP multi-session work."
     ],
     "markdown": "# Knowledge Base: fundamental-theorem-calculus-oq-02-incomplete-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nThis slug tracks a gallery-gap around the generalized Stokes theorem. The displayed identity is\n\n$$\\int_{\\partial M} \\omega = \\int_M d\\omega,$$\n\nwith the existing parent formalization specializing it concretely to FTC in one dimension and Green's theorem in two dimensions. The original incomplete point was the concrete 2D bridge: prove $d_1(d_0 f)=0$ by connecting equality of mixed partials to Mathlib's Frechet-derivative API.\n\n---\n\n## Local Evidence\n\n- `problem.md` names the target as Generalized Stokes Theorem and records the original goal as bridging Mathlib's derivative-symmetry theorem to concrete partial derivative expressions.\n- `state.md` still has this slug in OBSERVE with zero attempts, so phase, status, path, and attempt counts should stay unchanged.\n- `src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json` records the parent Stokes proof as formalized with 0 axioms and 0 sorries in the main file.\n- `Proofs/FundamentalTheoremCalculusStokes.lean` contains `dd_eq_zero_2D` and `stokes_2d_rectangle`; the latter delegates to `GreensTheoremOQ01.greens_theorem_concrete`.\n- The same Lean file documents the full abstract manifold Stokes theorem as future work requiring differential-form integration on oriented manifolds with boundary.\n\n---\n\n## Insights\n\nThe stale scaffold says there is one sorry to fill, but the current parent proof evidence says the concrete Clairaut bridge has already landed in the main file. The remaining useful research question is therefore either administrative reconciliation of this stale gallery-gap slug, or a retargeting to the genuinely open fully general Stokes theorem on manifolds with boundary.\n\n---\n\n## Dead Ends\n\nDo not label this as number theory, prime gaps, or sieve methods. Do not claim new Lean progress from this metadata backfill; it only records local evidence already present in the repository.\n"
   },
@@ -109,5 +116,6 @@
   },
   "started": "2026-04-03T02:25:34-07:00",
   "significance": 8,
-  "tractability": 5
+  "tractability": 5,
+  "lastUpdate": "2026-07-24"
 }


### PR DESCRIPTION
## Summary
S6 session for `fundamental-theorem-calculus-oq-02-incomplete-01`: Mathlib
upstream-prep generalization of Fragment 1 (the C^n all-orders Schwarz theorem
`iteratedFDeriv_comp_perm`, merged in #43245), exactly the S6 item flagged in the
S5 state.md.

## Progress
`proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean` generalized in place
(**0 axioms / 0 sorries**, docker build exit 0, 8576 jobs, no warnings):

- **Steps 1-3 core** (`fderiv_comp_perm_eq`, `iteratedFDeriv_comp_tailLift`,
  `iteratedFDeriv_add_two_apply`) now over an arbitrary `NontriviallyNormedField k` —
  they never needed R; `domDomCongr` isometry transport, tail lifts, and the
  `decomposeFin` conjugation are all field-generic.
- **Main theorem + corollaries** gated by `[IsRCLikeNormedField k]` (R or C) — exactly
  the hypothesis of Mathlib's n=2 Schwarz base case (`ContDiffAt.isSymmSndFDerivAt`).
  The old R statements are the `k := R` instances.
- **NEW `iteratedFDeriv_comp_perm_of_minSmoothness`** — the field-uniform statement
  over ANY nontrivially normed field in Mathlib's `minSmoothness` idiom: over R/C it
  requires `C^n`, over other fields it degrades to analyticity and delegates to
  Mathlib's `ContDiffAt.iteratedFDeriv_comp_perm`. Mirrors how Mathlib states
  `ContDiffAt.isSymmSndFDerivAt` — the natural upstream form.
- **NEW `iteratedFDerivWithin_comp_perm_of_isOpen`** — `Within` version on open sets.

## Findings
- The ONLY R/C-specific input to the whole induction is the n=2 base; this PR makes
  that structurally explicit.
- v4.31 gotchas recorded: smoothness-exponent notations are `scoped[ContDiff]`
  (need `open scoped ContDiff` even with `import Mathlib`); `minSmoothness` is
  `irreducible_def` — unfold via `simp [minSmoothness, h]`.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.FundamentalTheoremCalculusOQ02Incomplete01`
  — exit 0 (8576 jobs), no warnings.
- Supersession guard: NOT_SUPERSEDED (strict superset of main's file; based on
  origin/main after #43245 merged — main's copy is byte-identical to the S5 base
  this was written against).

## Status
**Outcome**: progress (Fragment 1 now upstream-ready; thread continues)
**Next Steps**: S7 candidate — full `UniqueDiffOn` `Within` induction via
`fderivWithin`; eventual Mathlib PR; Fragments 2-6 (manifold Stokes) remain DEEP.

🤖 Generated by researcher-2
