### PR TITLE
research(researcher-3): batched — hyp2F1 uniform convergence/continuity (amgm-oq-04-oq-03) + Noether degree-bound Stages 1-3 (hilbert-14-oq-04)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ04OQ03.lean
+++ b/proofs/Proofs/AmgmInequalityOQ04OQ03.lean
@@ -312,4 +312,63 @@ theorem hyp2F1_mtest_inputs_on_closedBall
   rw [Real.norm_eq_abs]
   exact hypCoeff_mul_pow_abs_le_of_abs_le R n x hx
 
+-- ============================================================================
+-- §9 : Uniform convergence on closed balls + continuity            (S5 ACT)
+-- ============================================================================
+--
+-- Consumes the §8 M-test package through Mathlib's Weierstrass M-test
+-- (`tendstoUniformlyOn_tsum_nat`) and extracts the payoff: the partial sums
+-- of the hypergeometric series converge to `hyp2F1` UNIFORMLY on every closed
+-- ball `{x : |x| ≤ R}`, `R < 1`; being polynomials, they are continuous, so
+-- `hyp2F1` is continuous on each closed ball and hence at every point of the
+-- open unit ball. Continuity is the analytic ingredient the eventual Gauss
+-- AGM-limit argument needs on the `K`-side of the axiomatized identity
+-- (`ellipticK_eq_hyp2F1`): the AGM iteration's limit exchange happens inside
+-- the open unit ball of the modulus.
+
+/-- **Weierstrass M-test payoff** (S5 ACT): on the closed ball `{x : |x| ≤ R}`
+with `R < 1`, the partial sums `x ↦ ∑_{n < N} cₙ xⁿ` converge uniformly to
+`hyp2F1`. One-liner from the §8 package + `tendstoUniformlyOn_tsum_nat`,
+exactly as the S4b design intended. -/
+theorem hyp2F1_tendstoUniformlyOn_closedBall (R : ℝ) (hR : R < 1) (hRnn : 0 ≤ R) :
+    TendstoUniformlyOn
+      (fun N : ℕ => fun x : ℝ => ∑ n ∈ Finset.range N, hypCoeff n * x ^ n)
+      hyp2F1 Filter.atTop {y : ℝ | |y| ≤ R} := by
+  obtain ⟨hsum, hbound⟩ := hyp2F1_mtest_inputs_on_closedBall R hR hRnn
+  exact tendstoUniformlyOn_tsum_nat hsum hbound
+
+/-- The partial sums are polynomials, hence continuous. -/
+private lemma continuous_partialSum (N : ℕ) :
+    Continuous (fun x : ℝ => ∑ n ∈ Finset.range N, hypCoeff n * x ^ n) :=
+  continuous_finset_sum _ fun n _ => (continuous_pow n).const_mul (hypCoeff n)
+
+/-- **Continuity of `₂F₁(1/2,1/2;1;·)` on closed balls** (S5 ACT): a uniform
+limit of continuous partial sums is continuous on `{x : |x| ≤ R}`, `R < 1`. -/
+theorem hyp2F1_continuousOn_closedBall (R : ℝ) (hR : R < 1) (hRnn : 0 ≤ R) :
+    ContinuousOn hyp2F1 {y : ℝ | |y| ≤ R} :=
+  (hyp2F1_tendstoUniformlyOn_closedBall R hR hRnn).continuousOn
+    (Filter.Eventually.frequently (Filter.Eventually.of_forall fun N =>
+      (continuous_partialSum N).continuousOn))
+
+/-- **Continuity of `₂F₁(1/2,1/2;1;·)` at every point of the open unit ball**
+(S5 ACT): each `x` with `|x| < 1` lies in the interior of the closed ball of
+radius `(|x| + 1)/2 < 1`, on which `hyp2F1` is continuous. -/
+theorem hyp2F1_continuousAt {x : ℝ} (hx : |x| < 1) : ContinuousAt hyp2F1 x := by
+  set R : ℝ := (|x| + 1) / 2 with hRdef
+  have hxR : |x| < R := by
+    rw [hRdef]; linarith
+  have hR : R < 1 := by
+    rw [hRdef]; linarith
+  have hRnn : 0 ≤ R := le_trans (abs_nonneg x) hxR.le
+  have hmem : {y : ℝ | |y| ≤ R} ∈ nhds x := by
+    refine Filter.mem_of_superset ?_ (fun y (hy : |y| < R) => le_of_lt hy)
+    exact (isOpen_lt continuous_abs continuous_const).mem_nhds hxR
+  exact (hyp2F1_continuousOn_closedBall R hR hRnn).continuousAt hmem
+
+/-- **Continuity on the open unit ball** (S5 ACT), packaged as `ContinuousOn`
+for downstream use with the axiomatized identity `ellipticK_eq_hyp2F1` (whose
+modulus square `k²` ranges over `[0, 1)`). -/
+theorem hyp2F1_continuousOn_ball : ContinuousOn hyp2F1 {y : ℝ | |y| < 1} :=
+  fun _ hy => (hyp2F1_continuousAt hy).continuousWithinAt
+
 end AmgmInequalityOQ04OQ03

--- a/proofs/Proofs/AmgmInequalityOQ04OQ03.lean
+++ b/proofs/Proofs/AmgmInequalityOQ04OQ03.lean
@@ -340,7 +340,7 @@ theorem hyp2F1_tendstoUniformlyOn_closedBall (R : ℝ) (hR : R < 1) (hRnn : 0 �
 /-- The partial sums are polynomials, hence continuous. -/
 private lemma continuous_partialSum (N : ℕ) :
     Continuous (fun x : ℝ => ∑ n ∈ Finset.range N, hypCoeff n * x ^ n) :=
-  continuous_finset_sum _ fun n _ => (continuous_pow n).const_mul (hypCoeff n)
+  continuous_finsetSum _ fun n _ => (continuous_pow n).const_mul (hypCoeff n)
 
 /-- **Continuity of `₂F₁(1/2,1/2;1;·)` on closed balls** (S5 ACT): a uniform
 limit of continuous partial sums is continuous on `{x : |x| ≤ R}`, `R < 1`. -/

--- a/proofs/Proofs/Hilbert14OQ04.lean
+++ b/proofs/Proofs/Hilbert14OQ04.lean
@@ -97,4 +97,105 @@ theorem hilbert_finiteness :
   -- Step 5e: translate Subalgebra.FG back to Algebra.FiniteType.
   exact ⟨h_kB_fg⟩
 
+/-!
+## S5 ACT — toward Noether's degree bound: charpoly coefficient API (Stages 1–3)
+
+The quantitative half of Noether 1916 (`generators ⊆ deg ≤ |G|`) factors through
+the orbit characteristic polynomial `MulSemiringAction.charpoly G b = ∏ g, (X - C (g • b))`
+(PREP-2/PREP-3 design, PRs #19294 + follow-up). This section lands the three
+self-contained stages:
+
+* **Stage 1** — every coefficient of `charpoly G b` is `G`-invariant, i.e. lies in
+  `FixedPoints.subalgebra k R G` (from Mathlib's `smul_coeff_charpoly`);
+* **Stage 2** — `(charpoly G b).natDegree = |G|` (product of `|G|` monic linear factors);
+* **Stage 3** — with the graded-action hypothesis
+  `h_graded : ∀ g p, (g • p).totalDegree ≤ p.totalDegree` (NOT automatic from
+  `MulSemiringAction`; PREP-3 §2 Option A), the `j`-th coefficient has total degree
+  at most `(|G| - j) · deg b`, via Vieta (`Multiset.prod_X_sub_C_coeff`) and the
+  elementary symmetric expansion (`Finset.esymm_map_val`).
+
+Stage 5 (Reynolds-operator extraction of a generating set in degree `≤ |G|`,
+requiring `¬ (ringChar k ∣ |G|)`) remains for a dedicated S6 iteration.
+-/
+
+section DegreeBound
+
+open MulSemiringAction
+
+/-- **Stage 1**: every coefficient of the orbit characteristic polynomial
+`charpoly G b = ∏ g, (X - C (g • b))` is fixed by the `G`-action, hence lies in
+the invariant subalgebra. This is the source of the integrality relations that
+the eventual degree-bound generating set is drawn from. -/
+theorem coeff_charpoly_mem_fixedPoints (b : MvPolynomial (Fin n) k) (j : ℕ) :
+    (charpoly G b).coeff j ∈
+      FixedPoints.subalgebra k (MvPolynomial (Fin n) k) G :=
+  fun g => smul_coeff_charpoly b j g
+
+/-- **Stage 2**: the orbit characteristic polynomial has `natDegree` exactly
+`|G|` — it is a product of `|G|` monic linear factors. -/
+theorem natDegree_charpoly (b : MvPolynomial (Fin n) k) :
+    (charpoly G b).natDegree = Fintype.card G := by
+  rw [charpoly_eq,
+    Polynomial.natDegree_prod_of_monic _ _ (fun g _ => Polynomial.monic_X_sub_C _)]
+  simp [Polynomial.natDegree_X_sub_C]
+
+/-- **Stage 3**: under a degree-nonincreasing (graded) action — the standard
+Noether-1916 setting of a linear action on the variables, stated as the explicit
+hypothesis `h_graded` per PREP-3 §2 (it is NOT implied by `MulSemiringAction`
+alone) — the `j`-th coefficient of `charpoly G b` has total degree at most
+`(|G| - j) · deg b`.
+
+Route: Vieta expresses the coefficient as `(-1)^(|G|-j) · esymm_{|G|-j}` of the
+orbit multiset `{g • b}`; the elementary symmetric function is a sum over
+`(|G|-j)`-subsets of products of orbit elements, each of total degree
+`≤ deg b` by `h_graded`. -/
+theorem totalDegree_coeff_charpoly_le
+    (h_graded : ∀ (g : G) (p : MvPolynomial (Fin n) k),
+      (g • p).totalDegree ≤ p.totalDegree)
+    (b : MvPolynomial (Fin n) k) (j : ℕ) (hj : j ≤ Fintype.card G) :
+    ((charpoly G b).coeff j).totalDegree
+      ≤ (Fintype.card G - j) * b.totalDegree := by
+  classical
+  -- the orbit multiset
+  set s : Multiset (MvPolynomial (Fin n) k) :=
+    Finset.univ.val.map (fun g : G => g • b) with hs
+  have hcard : Multiset.card s = Fintype.card G := by
+    rw [hs, Multiset.card_map]
+    exact Finset.card_univ
+  -- charpoly as a multiset product of linear factors
+  have hprod : charpoly G b =
+      (s.map fun t => Polynomial.X - Polynomial.C t).prod := by
+    rw [charpoly_eq, Finset.prod_eq_multiset_prod, hs, Multiset.map_map]
+    rfl
+  -- Vieta: the coefficient is a signed elementary symmetric function
+  have hcoeff : (charpoly G b).coeff j =
+      (-1) ^ (Fintype.card G - j) * s.esymm (Fintype.card G - j) := by
+    rw [hprod, Multiset.prod_X_sub_C_coeff s (by rw [hcard]; exact hj), hcard]
+  rw [hcoeff]
+  set m : ℕ := Fintype.card G - j with hm
+  -- the sign factor is a constant
+  have hsign : ((-1 : MvPolynomial (Fin n) k) ^ m).totalDegree = 0 := by
+    have hC : ((-1 : MvPolynomial (Fin n) k) ^ m) =
+        MvPolynomial.C ((-1 : k) ^ m) := by
+      rw [map_pow, map_neg, map_one]
+    rw [hC, MvPolynomial.totalDegree_C]
+  -- the esymm factor: sum over m-subsets of degree-bounded products
+  have hesymm : (s.esymm m).totalDegree ≤ m * b.totalDegree := by
+    rw [hs, Finset.esymm_map_val]
+    refine le_trans (MvPolynomial.totalDegree_finsetSum _ _) ?_
+    refine Finset.sup_le fun t ht => ?_
+    have htcard : t.card = m := (Finset.mem_powersetCard.mp ht).2
+    refine le_trans (MvPolynomial.totalDegree_finsetProd _ _) ?_
+    calc ∑ g ∈ t, ((g • b).totalDegree)
+        ≤ ∑ _g ∈ t, b.totalDegree := Finset.sum_le_sum fun g _ => h_graded g b
+      _ = t.card * b.totalDegree := by rw [Finset.sum_const, smul_eq_mul]
+      _ = m * b.totalDegree := by rw [htcard]
+  calc ((-1 : MvPolynomial (Fin n) k) ^ m * s.esymm m).totalDegree
+      ≤ ((-1 : MvPolynomial (Fin n) k) ^ m).totalDegree
+          + (s.esymm m).totalDegree := MvPolynomial.totalDegree_mul _ _
+    _ = (s.esymm m).totalDegree := by rw [hsign, zero_add]
+    _ ≤ m * b.totalDegree := hesymm
+
+end DegreeBound
+
 end Hilbert14OQ04

--- a/proofs/Proofs/Hilbert14OQ04.lean
+++ b/proofs/Proofs/Hilbert14OQ04.lean
@@ -131,14 +131,16 @@ theorem coeff_charpoly_mem_fixedPoints (b : MvPolynomial (Fin n) k) (j : ℕ) :
       FixedPoints.subalgebra k (MvPolynomial (Fin n) k) G :=
   fun g => smul_coeff_charpoly b j g
 
+omit [SMulCommClass G k (MvPolynomial (Fin n) k)] in
 /-- **Stage 2**: the orbit characteristic polynomial has `natDegree` exactly
 `|G|` — it is a product of `|G|` monic linear factors. -/
 theorem natDegree_charpoly (b : MvPolynomial (Fin n) k) :
     (charpoly G b).natDegree = Fintype.card G := by
   rw [charpoly_eq,
     Polynomial.natDegree_prod_of_monic _ _ (fun g _ => Polynomial.monic_X_sub_C _)]
-  simp [Polynomial.natDegree_X_sub_C]
+  simp
 
+omit [SMulCommClass G k (MvPolynomial (Fin n) k)] in
 /-- **Stage 3**: under a degree-nonincreasing (graded) action — the standard
 Noether-1916 setting of a linear action on the variables, stated as the explicit
 hypothesis `h_graded` per PREP-3 §2 (it is NOT implied by `MulSemiringAction`

--- a/research/problems/amgm-inequality-oq-04-oq-03/sessions/2026-07-24-s5-act-marker.md
+++ b/research/problems/amgm-inequality-oq-04-oq-03/sessions/2026-07-24-s5-act-marker.md
@@ -1,1 +1,12 @@
-S5 ACT in progress (researcher-3, 2026-07-24): TendstoUniformlyOn wrap + continuity of hyp2F1 on the open unit ball.
+# S5 ACT — 2026-07-24 (researcher-3)
+
+Shipped §9 of `AmgmInequalityOQ04OQ03.lean`: `hyp2F1_tendstoUniformlyOn_closedBall`
+(M-test wrap via `tendstoUniformlyOn_tsum_nat`, consuming the S4b input package),
+`continuous_partialSum`, `hyp2F1_continuousOn_closedBall`, `hyp2F1_continuousAt`,
+`hyp2F1_continuousOn_ball`. 1 stated axiom / 0 sorries (unchanged). Verified with
+v4.31.0 toolchain against pinned Mathlib oleans; parent modules compiled to scratch
+oleans (`lean -o`) because the recreated worktree lacked `.lake`.
+
+v4.31 gotcha: `continuous_finset_sum` deprecated → `continuous_finsetSum`.
+
+See state.md Iteration 7 for the full entry and S6 candidates.

--- a/research/problems/amgm-inequality-oq-04-oq-03/sessions/2026-07-24-s5-act-marker.md
+++ b/research/problems/amgm-inequality-oq-04-oq-03/sessions/2026-07-24-s5-act-marker.md
@@ -1,0 +1,1 @@
+S5 ACT in progress (researcher-3, 2026-07-24): TendstoUniformlyOn wrap + continuity of hyp2F1 on the open unit ball.

--- a/research/problems/amgm-inequality-oq-04-oq-03/state.md
+++ b/research/problems/amgm-inequality-oq-04-oq-03/state.md
@@ -1,10 +1,35 @@
 # Research State: amgm-inequality-oq-04-oq-03
 
 ## Current State
-**Phase**: BLOCKED (S5 — renewed Docker outage; remaining discharge legs Docker-gated)
+**Phase**: ACT (S5 SHIPPED — researcher-3, 2026-07-24). The Docker-blackout BLOCKED flag
+(2026-06-13) is cleared; S5 delivered exactly the banked leg plus its payoff. New §9 in
+`AmgmInequalityOQ04OQ03.lean` (315 → ~380 LOC, still 1 stated axiom / 0 sorries):
+- `hyp2F1_tendstoUniformlyOn_closedBall` — the `TendstoUniformlyOn` wrap via Mathlib's
+  `tendstoUniformlyOn_tsum_nat` consuming the §8 M-test package (the planned one-liner).
+- `hyp2F1_continuousOn_closedBall` (uniform limit of polynomial partial sums),
+  `hyp2F1_continuousAt` (each `|x| < 1` interior to a radius-`(|x|+1)/2` closed ball),
+  `hyp2F1_continuousOn_ball` — continuity of `₂F₁(1/2,1/2;1;·)` on the open unit ball,
+  the analytic ingredient for the eventual AGM-limit ↔ `K` argument.
+Verified with the v4.31.0 toolchain against the pinned Mathlib olean cache; parent modules
+(`AmgmInequalityOQ04`, `…OQ01`) compiled to scratch oleans first (worktree had no `.lake`).
 **Path**: fast
-**Since**: 2026-06-01 (S2 ACT — researcher-1) → 2026-06-13 (S5 BLOCKED, this session)
-**Iteration**: 6
+**Since**: 2026-07-24 (S5 ACT)
+**Iteration**: 7
+
+## S5 ACT 2026-07-24 (researcher-3) — §9 uniform convergence + continuity
+
+Consumed `hyp2F1_mtest_inputs_on_closedBall` (S4b) through
+`tendstoUniformlyOn_tsum_nat`; partial sums continuous via `continuous_finsetSum`
+(NOTE v4.31 rename: `continuous_finset_sum` is deprecated); closed-ball → open-ball
+continuity via `ContinuousOn.continuousAt` with the `|y| < R` sub-neighborhood
+(`isOpen_lt continuous_abs continuous_const`). All first-try; no new axioms.
+
+**Next (S6+)**: the genuinely deep remaining work, in increasing order of ambition:
+(a) `hyp2F1_pos` / monotonicity on `[0,1)` from coefficient positivity (elementary, session-sized);
+(b) AGM-side: formalize the AGM iteration limit `M(a,b)` (parent file has the iteration) and its
+continuity/convergence rate; (c) discharging `ellipticK_eq_hyp2F1` (elliptic-integral ↔ series,
+term-by-term integration — DEEP, the problem's stated axiom; check whether Mathlib's growing
+elliptic-integral/hypergeometric support at future pins reaches it).
 
 ## S5 — BLOCKED + JSON STATE-SYNC 2026-06-13 (researcher-2)
 

--- a/research/problems/hilbert-14-oq-04/state.md
+++ b/research/problems/hilbert-14-oq-04/state.md
@@ -1,8 +1,43 @@
 # Current State
 
-**Phase**: ACT (S2-finite ACT shipped — `hilbert_finiteness` verified; S4 PREP-3 totalDegree-bearer + grading-action gap surface; pre-ACT for S3-bound)
-**Since**: 2026-05-16T00:00:00Z
-**Iteration**: 4
+**Phase**: ACT (S5 ACT shipped, researcher-3, 2026-07-24 — **degree-bound Stages 1–3 landed**;
+next = Stage 5 Reynolds extraction, a dedicated S6)
+**Since**: 2026-07-24T12:10:00Z
+**Iteration**: 5
+
+## S5 ACT 2026-07-24 (researcher-3) — degree-bound Stages 1–3 (0 ax / 0 sorry)
+
+New `section DegreeBound` in `proofs/Proofs/Hilbert14OQ04.lean` (100 → ~210 LOC),
+executing PREP-2/PREP-3 Stages 1–3 exactly as designed:
+
+* **Stage 1** `coeff_charpoly_mem_fixedPoints` — every `(charpoly G b).coeff j` lies in
+  `FixedPoints.subalgebra k R G`; one-liner from `smul_coeff_charpoly` (membership in the
+  fixed-points subalgebra is definitionally `∀ g, g • x = x`).
+* **Stage 2** `natDegree_charpoly` — `(charpoly G b).natDegree = |G|` via
+  `Polynomial.natDegree_prod_of_monic` + `monic_X_sub_C` (this small lemma is ABSENT from
+  Mathlib's `RingTheory/Invariant/Basic.lean` — upstream candidate).
+* **Stage 3** `totalDegree_coeff_charpoly_le` — with the PREP-3 §2 Option-A hypothesis
+  `h_graded : ∀ g p, (g • p).totalDegree ≤ p.totalDegree`:
+  `((charpoly G b).coeff j).totalDegree ≤ (|G| - j) * b.totalDegree` for `j ≤ |G|`.
+  Route as planned: orbit multiset `s := univ.val.map (· • b)`;
+  `Multiset.prod_X_sub_C_coeff` (Vieta) turns the coefficient into
+  `(-1)^(|G|-j) * s.esymm (|G|-j)`; `Finset.esymm_map_val` (a bearer BETTER than the
+  PREP-3 plan's raw powersetCard expansion — it lands directly in Finset-sum form);
+  `totalDegree_finsetSum` (sup bound) + `totalDegree_finsetProd` + `h_graded` per factor;
+  sign factor is `C ((-1)^m)` hence totalDegree 0. All first-try at v4.31.
+
+v4.31 drift notes: `totalDegree_finset_sum/prod` renamed `totalDegree_finsetSum/Prod`
+(old names deprecated); `omit [SMulCommClass …] in` needed on Stages 2–3 (unused
+section variable linter).
+
+**Remaining for the full Noether bound (S6+)**: Stage 5 — Reynolds-operator extraction
+of a generating set in degree ≤ |G| (needs `h_char : ¬ (ringChar k ∣ |G|)`, averaging,
+and the graded structure; ~80–120 LOC, the genuinely hard leg). Stages 1–3 are its
+complete coefficient-side toolkit.
+
+---
+
+## Previous State (S2-finite, 2026-05-16, iteration 4)
 
 > _Phase note_: this skill maps "S4 PREP-3" to the canonical ORIENT phase
 > (the post-S2-finite-ACT design-iteration count: 1 ACT + S3 PREP (#19188)

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "amgm-inequality-oq-04-oq-03",
   "title": "Gauss AGM Theorem via Hypergeometric Elliptic Integral Identity",
-  "phase": "BLOCKED",
-  "status": "blocked",
+  "phase": "ACT",
+  "status": "active",
   "tier": "C",
   "path": "fast",
   "problemStatement": {
@@ -29,19 +29,18 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-06-02T00:55:00Z",
-    "iteration": 6,
-    "focus": "S5 BLOCKED + STATE-SYNC (researcher-2, 2026-06-13): renewed Docker daemon outage (`timeout 5 docker info` exits 124) makes the remaining discharge legs unverifiable. Also syncs the JSON tracker forward from its stale iteration-3/2026-06-02 reading to the actual state.md S4b state (2026-06-09): S3 Wallis closed form was already shipped (wallisHalf_even, PR #22046, in AmgmInequalityOQ04OQ03Wallis.lean); S4a added the x-independent per-term M-test bound (hypCoeff_mul_pow_abs_le_of_abs_le); S4b added the M-test packaging on closed balls (summable_hyp2F1_on_closedBall + hyp2F1_mtest_inputs_on_closedBall), Docker-verified, 0 new axioms / 0 new sorries. AmgmInequalityOQ04OQ03.lean: 315 LOC, 1 axiom (ellipticK_eq_hyp2F1 — the problem's STATED hypergeometric-series identity hypothesis, legitimate per the problem statement), 0 real sorries. Status active->blocked: the next leg (S5 TendstoUniformlyOn wrap via tendstoUniformlyOn_tsum, then combining legs to the Gauss AGM<->K main result) is Lean proof work requiring Docker builds, unavailable during the outage.",
+    "since": "2026-07-24T11:45:00Z",
+    "iteration": 7,
+    "focus": "S5 ACT (researcher-3, 2026-07-24): SHIPPED the banked TendstoUniformlyOn leg + continuity payoff. New Section 9 in AmgmInequalityOQ04OQ03.lean: hyp2F1_tendstoUniformlyOn_closedBall (Weierstrass M-test via tendstoUniformlyOn_tsum_nat consuming the S4b package), hyp2F1_continuousOn_closedBall, hyp2F1_continuousAt, hyp2F1_continuousOn_ball (continuity of 2F1(1/2,1/2;1;.) on the open unit ball). Still 1 stated axiom (ellipticK_eq_hyp2F1, the problem's hypergeometric identity hypothesis) / 0 sorries. Docker-blackout BLOCKED flag cleared; verified with v4.31.0 toolchain against pinned Mathlib oleans (parents compiled to scratch oleans).",
     "activeApproach": "Power-series realization of 2F1 with central-binomial coefficients c_n = (centralBinom n / 4^n)^2, building on the verified ellipticK from oq-04-oq-01. S2 ACT adds the summability infrastructure via central-binomial upper bound + geometric comparison.",
-    "blockers": [
-      "B-INFRA Docker daemon outage at S5 entry 2026-06-13: `timeout 5 docker info` exits 124 (Server section unresponsive). Fleet-wide outage (same pathology cleared 2026-05-30, down again). Disk recovered (17% used). Aristotle backend 404s. Every remaining discharge leg (S5 TendstoUniformlyOn wrap + leg-combination toward Gauss AGM<->K) is Lean proof work needing >=1 Docker build to verify -> slug set blocked until Docker recovers."
-    ],
-    "nextAction": "WHEN Docker recovers (`timeout 10 docker info` exit 0): resume S5 ACT — wrap the S4b M-test inputs (hyp2F1_mtest_inputs_on_closedBall) into TendstoUniformlyOn via Mathlib's tendstoUniformlyOn_tsum (near-mechanical per state.md S4b), then continue combining the discharged legs (Wallis closed form + binomial series ₂F₁ realization) toward the Gauss AGM-limit <-> elliptic K identity. Each leg needs a Docker build. Spec/legs detailed in state.md (Active Approach) + knowledge.md.",
+    "blockers": [],
+    "nextAction": "S6 candidates: (a) hyp2F1 positivity/monotonicity on [0,1) from coefficient positivity (session-sized); (b) AGM-side limit M(a,b) convergence/continuity; (c) discharge ellipticK_eq_hyp2F1 (term-by-term integration of the elliptic integral - DEEP, the stated axiom).",
     "attemptCounts": {
-      "total": 6,
+      "total": 7,
       "currentApproach": 2,
       "approachesTried": 1
-    }
+    },
+    "lastUpdate": "2026-07-24T11:45:00.000Z"
   },
   "knowledge": {
     "progressSummary": "S1 ACT (PR #20885) shipped the scaffold Proofs/AmgmInequalityOQ04OQ03.lean (158 LOC, 1 axiom, 0 sorries): defs hypCoeff, hyp2F1; proved c0=1, c1=1/4, c_n>0, 2F1(...;0)=1, k=0 consistency. Axiomatized ellipticK_eq_hyp2F1. S2 ACT (this session) added section 6 Summability of the Hypergeometric Series (+64 LOC -> 222 LOC, 0 new axioms, 0 sorries): centralBinom_le_four_pow (Mathlib gap-filler), hypCoeff_le_one, summable_hyp2F1 for |x| < 1 (via absolute-summability comparison with the geometric series + Summable.of_norm). Closes the summability leg of the five-leg axiom-discharge plan; the remaining four legs are: Wallis closed form, binomial series for (1-u)^(-1/2), uniform summability on compacta, DCT interchange + final discharge.",

--- a/src/data/research/problems/hilbert-14-oq-04.json
+++ b/src/data/research/problems/hilbert-14-oq-04.json
@@ -32,16 +32,17 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-16T00:00:00.000Z",
-    "iteration": 4,
-    "focus": "S2-finite ACT shipped (PR #18988, Docker 7743/7743 jobs); S3 PREP coordination (#19188) + S3 PREP-2 pin-verify + Vieta-gap close (#19294); S4 PREP-3 (this iter, doc-only): closes totalDegree-of-charpoly-coefficient bearer gap (W1-W6 across Mathlib/Algebra/MvPolynomial/Degrees.lean + Symmetric/Defs.lean) AND surfaces hidden grading-preservation hypothesis (MulSemiringAction G R alone does NOT imply degree-preservation; Option A: add explicit h_graded).",
+    "since": "2026-07-24T12:10:00Z",
+    "iteration": 5,
+    "focus": "S5 ACT (researcher-3, 2026-07-24): degree-bound Stages 1-3 shipped in Hilbert14OQ04.lean section DegreeBound (0 ax / 0 sorry, v4.31-verified): coeff_charpoly_mem_fixedPoints (Stage 1), natDegree_charpoly = |G| (Stage 2, absent from Mathlib - upstream candidate), totalDegree_coeff_charpoly_le with the h_graded Option-A hypothesis (Stage 3, via Multiset.prod_X_sub_C_coeff + Finset.esymm_map_val + totalDegree_finsetSum/Prod).",
     "blockers": [],
-    "nextAction": "S3-bound ACT (Docker-blocked): prove Noether degree bound using PREP-2 §3 (V1-V7) + PREP-3 §1 (W1-W6) bearer chain; per PREP-3 §2 must add `h_graded : ∀ g : G, ∀ b, (g • b).totalDegree ≤ b.totalDegree` as explicit hypothesis (Option A). Paste-ready skeleton in PREP-3 §4 (~150-200 LOC across Stage 1/2/3 lemmas + main `noether_degree_bound` theorem in NEW file `proofs/Proofs/Hilbert14OQ04Bound.lean`).",
+    "nextAction": "S6: Stage 5 Reynolds-operator extraction - generating set in degree <= |G| under h_char : not (ringChar k | |G|); ~80-120 LOC, the hard leg. Stages 1-3 provide the coefficient toolkit.",
     "attemptCounts": {
       "total": 12,
       "currentApproach": 1,
       "approachesTried": 2
-    }
+    },
+    "lastUpdate": "2026-07-24T12:10:00.000Z"
   },
   "knowledge": {
     "progressSummary": "UNBLOCKED (researcher-3, 2026-07-23): Docker restored, B1 blackout blocker cleared; existing Hilbert14OQ04.lean re-verified clean at v4.31 (8576 jobs, 0 axiom/0 sorry). Next step ready: the paste-ready noether_degree_bound ACT (PREP-3 §4, new file Hilbert14OQ04Bound.lean). | S2-finite ACT shipped (PR pending): hilbert_finiteness theorem verified by Docker build (7743/7743). The qualitative half of Noether 1916 — invariant ring of a finite-group linear action on MvPolynomial is finitely generated as a k-algebra — is now formalized in proofs/Proofs/Hilbert14OQ04.lean (102 LOC). Five-step proof chains through Algebra.IsInvariant → Algebra.IsInvariant.isIntegral → Algebra.FiniteType.of_restrictScalars_finiteType → Algebra.IsIntegral.finite → Artin-Tate fg_of_fg_of_fg, all pinned at Mathlib v4.26.0. Two supporting instances (Algebra.IsInvariant and Algebra.IsIntegral) discharged definitionally via FixedPoints.subalgebra membership. The quantitative half (Noether degree bound) is deferred to S3-bound ACT. Predecessor PREP chain: PRs #18248 (S1) + #18435/18501/18562/18589/18667/18714/18750 (S2-S2g).",


### PR DESCRIPTION
Batched research PR — two completed, independently verified deliverables from researcher-3 (both **0 axioms added / 0 sorries**; the AMGM file keeps its 1 problem-stated axiom, unchanged).

## 1. amgm-inequality-oq-04-oq-03 — S5: hyp2F1 uniform convergence + continuity

New §9 in `proofs/Proofs/AmgmInequalityOQ04OQ03.lean` (clears the 2026-06-13 Docker-blackout BLOCKED flag; ships the banked leg):

- `hyp2F1_tendstoUniformlyOn_closedBall` — partial sums of `₂F₁(1/2,1/2;1;·)` converge uniformly on every `{|x| ≤ R}`, `R < 1`: the planned one-liner consuming the S4b M-test package through `tendstoUniformlyOn_tsum_nat`.
- `hyp2F1_continuousOn_closedBall` / `hyp2F1_continuousAt` / `hyp2F1_continuousOn_ball` — continuity of the hypergeometric function on the open unit ball (uniform limit of polynomial partial sums; open-ball upgrade via the radius-`(|x|+1)/2` sub-ball). The analytic ingredient for the eventual AGM-limit ↔ `K(k)` argument.

Axiom status unchanged: 1 stated axiom (`ellipticK_eq_hyp2F1`, the problem's hypergeometric identity hypothesis), 0 sorries. Trackers: BLOCKED cleared, Iteration 7, S6 candidates listed.

## 2. hilbert-14-oq-04 — S5: Noether degree-bound Stages 1–3 (charpoly coefficient API)

New `section DegreeBound` in `proofs/Proofs/Hilbert14OQ04.lean`, executing the banked PREP-2/PREP-3 design:

- **Stage 1** `coeff_charpoly_mem_fixedPoints` — all coefficients of `MulSemiringAction.charpoly G b` are `G`-invariant.
- **Stage 2** `natDegree_charpoly` — `(charpoly G b).natDegree = |G|` (absent from Mathlib's `RingTheory/Invariant/Basic.lean`; upstream candidate).
- **Stage 3** `totalDegree_coeff_charpoly_le` — under the explicit graded-action hypothesis `h_graded` (PREP-3 §2 Option A): `((charpoly G b).coeff j).totalDegree ≤ (|G| − j) · deg b`, via Vieta (`Multiset.prod_X_sub_C_coeff`) + `Finset.esymm_map_val` + `totalDegree_finsetSum/Prod`. All first-try at v4.31.

Remaining for the full Noether bound: Stage 5 Reynolds-operator extraction (dedicated S6); Stages 1–3 are its complete coefficient-side toolkit. Trackers synced (iteration 5).

## Verification

Both files compiled clean (0 errors, 0 warnings) with the pinned `leanprover/lean4:v4.31.0` toolchain binary against the pinned Mathlib olean cache (lake-manifest mathlib rev `9a9483a929`, identical to origin/main). AMGM parent modules compiled to scratch oleans first (recreated worktree had no `.lake`). v4.31 renames handled: `continuous_finset_sum` → `continuous_finsetSum`, `totalDegree_finset_sum/prod` → `totalDegree_finsetSum/Prod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
