### PR TITLE
Enrich cauchy-group-theorem-oq-01-oq-01: split additive/concrete-instances section (4->5)

### DIFF
--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01/meta.json
@@ -88,11 +88,19 @@
     },
     {
       "id": "additive",
-      "title": "Additive Form and Concrete Instances",
+      "title": "Additive Form: Doubling is Surjective",
       "startLine": 128,
+      "endLine": 138,
+      "summary": "exists_two_nsmul_eq_of_odd_card translates the squaring argument to additive groups: doubling y ↦ 2•y is surjective in a finite additive group of odd order, with explicit witness y = (m+1)•x where |G| = 2m+1.",
+      "mathContext": "Odd order ⟹ doubling y ↦ 2•y is surjective, via the additive analogue card_nsmul_eq_zero of pow_card_eq_one."
+    },
+    {
+      "id": "concrete-instances",
+      "title": "Concrete Instances: ZMod 3 and ZMod 5",
+      "startLine": 140,
       "endLine": 151,
-      "summary": "exists_two_nsmul_eq_of_odd_card: doubling is surjective in odd-order additive groups. ZMod 3 and ZMod 5 witnesses (zmod3/zmod5_double_surjective, zmod3_no_involution) by kernel decide keep the file 0-axiom.",
-      "mathContext": "Odd order ⟹ doubling y ↦ 2•y is surjective; realized concretely in ℤ/3 and ℤ/5."
+      "summary": "Ground the abstract theorems in the smallest odd-order additive groups: zmod3_double_surjective, zmod3_no_involution, and zmod5_double_surjective are all discharged by kernel decide rather than native_decide, keeping the file genuinely 0-axiom.",
+      "mathContext": "Realized concretely in ℤ/3 and ℤ/5 by kernel decide (no Lean.ofReduceBool dependency)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `cauchy-group-theorem-oq-01-oq-01` (quality 98/100 — `sections` was the sole deficient bucket at 4 items, cap wants 5).

The existing `additive` section (lines 128-151) bundled two conceptually distinct parts: the abstract additive theorem `exists_two_nsmul_eq_of_odd_card` and the concrete `ZMod 3`/`ZMod 5` witness instances. The source itself marks this boundary with a `/-! ### Concrete instances (kernel decide, no native_decide) -/` divider at line 140. Split there:

- **Additive Form (128-138)**: the abstract doubling-surjective theorem.
- **Concrete Instances (140-151)**: the `ZMod 3`/`ZMod 5` witnesses, discharged by kernel `decide` (not `native_decide`) to stay 0-axiom.

Verified both ranges against `proofs/Proofs/CauchyGroupTheoremOQ01OQ01.lean` directly (`cat -n`) — line boundaries land exactly on the divider comment and theorem declarations. No other content changed; `meta.json` stays at ~14 KB, far under the 60 KB cap. `pnpm build` passes (JSON validation + tsc + vite + bundle-budget all green).