### PR TITLE
Enrich cauchy-group-theorem-oq004: add missing header section for module docstring (4->5)

### DIFF
--- a/src/data/proofs/cauchy-group-theorem-oq004/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq004/meta.json
@@ -139,6 +139,14 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Module Header: The Exponent Replaces the Order",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Imports Mathlib.Tactic and gives the module docstring: the parent's image equality range(x ↦ xⁿ) = range(x ↦ x^gcd(n,m)) was only established in the cyclic case via the group order m; this file proves it in every group by replacing m with the exponent exp G, since the hard inclusion is a single Bézout identity. Declares the ambient type variable {α}.",
+      "mathContext": "range(x ↦ xⁿ) = range(x ↦ x^gcd(n, exp G)) holds in every group — no commutativity, no finiteness — because gcd(n,e) = n·A + e·B and x^e = 1."
+    },
+    {
       "id": "zpow-exponent",
       "title": "A ℤ-power form of x ^ exponent = 1",
       "startLine": 50,


### PR DESCRIPTION
Enrichment pass for `cauchy-group-theorem-oq004` (quality 98/100 — `sections` was the sole deficient bucket at 4 items, cap wants 5).

The existing 4 sections started at line 50, leaving the entire 49-line module docstring (lines 1-49 — imports, the parent-recap, the exponent-vs-order statement of the main theorem, and the `variable {α}` declaration) with no section at all. Prepended a `preamble` section spanning 1-49.

Verified against `proofs/Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02OQ01.lean` directly (`cat -n`) — the docstring closes at line 41, `variable {α : Type*}` at line 43, and the next existing section (`zpow-exponent`) correctly starts at line 50, so the new range abuts it with no overlap or gap. No other content changed; `meta.json` stays at ~18 KB, far under the 60 KB cap. `pnpm build` passes (JSON validation + tsc + vite + bundle-budget all green).