### PR TITLE
Enrich borsuk-ulam-oq004: add header section (5th section)

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq004/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq004/meta.json
@@ -88,6 +88,14 @@
   },
   "sections": [
     {
+      "id": "header-strategy",
+      "title": "Statement of the Open Question and Proof Strategy",
+      "startLine": 1,
+      "endLine": 58,
+      "summary": "Module docstring stating the parent's open question (is the dihedral lower bound tight?), the three-part strategy (uniform Finset.sup packaging, unconditional lower bound, tightness-to-upper-bound reduction), and the honesty note that all topological content is inherited from the parent's axiomatization. Followed by the imports and the dihedralLowerBound docstring.",
+      "mathContext": "The parent file proved the lower bound only case-by-case ($D_p$, $D_5$, $D_6$); this file's contribution is the uniform-in-$n$ packaging and the precise isolation of the one missing (Fadell-Husseini) ingredient, without adding any new axioms."
+    },
+    {
       "id": "uniform-formula",
       "title": "The Conjectured Exact Value, Uniform in n",
       "startLine": 60,


### PR DESCRIPTION
Enrichment pass for `borsuk-ulam-oq004` (quality 98 → targets full coverage).

`qualityBreakdown` showed everything at cap except `sections: 8/10` (4 sections
instead of 5) while `keyInsights` was already at its 5-item cap. The Lean file's
module docstring + imports + namespace/open + the `dihedralLowerBound` doc
comment (lines 1-58) had no corresponding `sections` entry, even though an
existing annotation (`ann-01-strategy`, range 1-58) already recognized this
span as a coherent conceptual unit.

Added a `header-strategy` section (startLine 1, endLine 58) matching that
annotation's boundary exactly, summarizing the open question and the file's
three-part proof strategy. No other content changed; existing sections
untouched. `meta.json` stays at ~16.9 KB, well under the 60 KB cap.