### PR TITLE
research(ballot-problem-oq-02-oq-05): S12 — final 2 sorries discharged, discrete reflection identity COMPLETE [0 sorry / 1 intended axiom]

### DIFF
--- a/proofs/Proofs/BallotProblemOQ02OQ05.lean
+++ b/proofs/Proofs/BallotProblemOQ02OQ05.lean
@@ -323,6 +323,93 @@ lemma partialSumBool_reflectAt_endpoint
       ring
   rw [Finset.sum_congr rfl (fun i _ => step i), ← Finset.mul_sum, hA]
 
+/-- The index-0 partial sum vanishes: the `i.val < 0` guard kills every
+    summand. The bound proof is an explicit argument so callers' `Fin.mk`
+    literals match without proof-irrelevance gymnastics. -/
+lemma partialSumBool_zero (ω : Fin n → Bool) (h0 : 0 < n + 1) :
+    partialSumBool ω ⟨0, h0⟩ = 0 := by
+  unfold partialSumBool
+  simp
+
+/-- One-step recurrence: the partial sum at `j + 1` adds the `j`-th `±1`
+    step. All three `Fin` bound proofs are explicit arguments so the
+    statement unifies syntactically with whatever proofs the caller has in
+    context (`omega` treats `Fin.mk` terms with different proofs as distinct
+    atoms). -/
+lemma partialSumBool_succ (ω : Fin n → Bool) {j : ℕ} (hj : j < n)
+    (h1 : j + 1 < n + 1) (h2 : j < n + 1) :
+    partialSumBool ω ⟨j + 1, h1⟩
+      = partialSumBool ω ⟨j, h2⟩ + (if ω ⟨j, hj⟩ then (1 : ℤ) else -1) := by
+  have hsplit : ∀ i : Fin n,
+      (if i.val < j + 1 then (if ω i then (1 : ℤ) else -1) else 0)
+        = (if i.val < j then (if ω i then (1 : ℤ) else -1) else 0)
+          + (if i.val = j then (if ω i then (1 : ℤ) else -1) else 0) := by
+    intro i
+    rcases lt_trichotomy i.val j with h | h | h
+    · rw [if_pos (by omega), if_pos h, if_neg (by omega)]; ring
+    · rw [if_pos (by omega), if_neg (by omega), if_pos h]; ring
+    · rw [if_neg (by omega), if_neg (by omega), if_neg (by omega)]; ring
+  have hlast : (∑ i : Fin n, if i.val = j then (if ω i then (1 : ℤ) else -1) else 0)
+      = (if ω ⟨j, hj⟩ then (1 : ℤ) else -1) := by
+    rw [Finset.sum_eq_single (⟨j, hj⟩ : Fin n)]
+    · rw [if_pos rfl]
+    · intro i _ hne
+      exact if_neg (fun h => hne (Fin.ext h))
+    · intro habs
+      exact absurd (Finset.mem_univ _) habs
+  show (∑ i : Fin n, if i.val < j + 1 then (if ω i then (1 : ℤ) else -1) else 0)
+      = (∑ i : Fin n, if i.val < j then (if ω i then (1 : ℤ) else -1) else 0)
+        + (if ω ⟨j, hj⟩ then (1 : ℤ) else -1)
+  rw [Finset.sum_congr rfl fun i _ => hsplit i, Finset.sum_add_distrib, hlast]
+
+/-- **Discrete intermediate-value.** If some partial sum reaches `≥ a > 0`,
+    the path hits `a` exactly: partial sums start at `0` and move by `±1`,
+    so the first index with `S ≥ a` has `S = a` (a `+1` jump from `< a`
+    cannot overshoot). -/
+lemma hitSet_nonempty_of_ge {ω : Fin n → Bool} {a : ℤ} (ha : 0 < a)
+    {k : Fin (n + 1)} (hk : a ≤ partialSumBool ω k) :
+    (hitSet ω a).Nonempty := by
+  suffices H : ∀ (j : ℕ) (hj : j < n + 1), a ≤ partialSumBool ω ⟨j, hj⟩ →
+      (hitSet ω a).Nonempty from H k.val k.isLt hk
+  intro j
+  induction j with
+  | zero =>
+    intro hj h0
+    rw [partialSumBool_zero ω hj] at h0
+    omega
+  | succ i IH =>
+    intro hj hsi
+    by_cases heq : partialSumBool ω ⟨i + 1, hj⟩ = a
+    · exact ⟨⟨i + 1, hj⟩, Finset.mem_filter.mpr ⟨Finset.mem_univ _, heq⟩⟩
+    · have hi_n : i < n := by omega
+      have hi_n1 : i < n + 1 := by omega
+      have hstep := partialSumBool_succ ω hi_n hj hi_n1
+      have hgt : a < partialSumBool ω ⟨i + 1, hj⟩ := lt_of_le_of_ne hsi (Ne.symm heq)
+      have hprev : a ≤ partialSumBool ω ⟨i, hi_n1⟩ := by
+        by_cases hb : ω ⟨i, hi_n⟩
+        · rw [if_pos hb] at hstep
+          omega
+        · rw [if_neg hb] at hstep
+          omega
+      exact IH hi_n1 hprev
+
+/-- The first hit time of `ω` is also a hit time of the reflected path:
+    partial sums agree up to (and including) the first hit
+    (`partialSumBool_congr_below`). Extracted from the Step-1 argument
+    inside `reflectAt_involutive` for reuse in the R6 bijection. -/
+lemma firstHit_mem_hitSet_reflectAt {ω : Fin n → Bool} {a : ℤ}
+    (h : (hitSet ω a).Nonempty) :
+    firstHitFin ω a ∈ hitSet (reflectAt ω a) a := by
+  have hτ_eq : firstHitFin ω a = (hitSet ω a).min' h := by
+    simp [firstHitFin, dif_pos h]
+  have hτ_mem : firstHitFin ω a ∈ hitSet ω a := by
+    rw [hτ_eq]; exact (hitSet ω a).min'_mem h
+  have hτ_ps : partialSumBool ω (firstHitFin ω a) = a :=
+    (Finset.mem_filter.mp hτ_mem).2
+  refine Finset.mem_filter.mpr ⟨Finset.mem_univ _, ?_⟩
+  rw [partialSumBool_congr_below (le_refl _)]
+  exact hτ_ps
+
 /-- Hitting `≥ a` ⟺ `(hitSet ω a').Nonempty` for some `a' ≤ a`. For the
     bijection we need: paths reaching ≥ a partition as (ending ≥ a) ⊔
     (ending < a, having reached a). Reflection sends the second class to
@@ -331,7 +418,12 @@ lemma reaches_iff_hits_or_above
     {ω : Fin n → Bool} {a : ℤ} (ha : 0 < a) :
     (∃ k : Fin (n+1), partialSumBool ω k ≥ a)
       ↔ partialSumBool ω ⟨n, Nat.lt_succ_self n⟩ ≥ a ∨ (hitSet ω a).Nonempty := by
-  sorry  -- LOW: use Int.le_iff_exists_eq_succ on partial-sum jumps of ±1
+  constructor
+  · rintro ⟨k, hk⟩
+    exact Or.inr (hitSet_nonempty_of_ge ha hk)
+  · rintro (h | ⟨k, hk⟩)
+    · exact ⟨⟨n, Nat.lt_succ_self n⟩, h⟩
+    · exact ⟨k, ge_of_eq (Finset.mem_filter.mp hk).2⟩
 
 /-- **Discrete reflection identity** (André 1887, Feller Vol. I § III.1).
 
@@ -350,7 +442,92 @@ theorem discrete_reflection
         partialSumBool ω ⟨n, Nat.lt_succ_self n⟩ ≥ a).card
       - (Finset.univ.filter fun ω : Fin n → Bool =>
         partialSumBool ω ⟨n, Nat.lt_succ_self n⟩ = a).card := by
-  sorry  -- R6: assemble via Finset.card_nbij' applied to the (ending<a,hits a) ↔ (ending>a) restriction
+  -- Path classes: A = reaches ≥ a (the LHS), B = ends ≥ a, C = ends = a,
+  -- D = ends < a but hits a, E = ends > a.
+  set A := (Finset.univ.filter fun ω : Fin n → Bool =>
+      ∃ k : Fin (n+1), partialSumBool ω k ≥ a) with hA
+  set B := (Finset.univ.filter fun ω : Fin n → Bool =>
+      partialSumBool ω ⟨n, Nat.lt_succ_self n⟩ ≥ a) with hB
+  set C := (Finset.univ.filter fun ω : Fin n → Bool =>
+      partialSumBool ω ⟨n, Nat.lt_succ_self n⟩ = a) with hC
+  set D := (Finset.univ.filter fun ω : Fin n → Bool =>
+      partialSumBool ω ⟨n, Nat.lt_succ_self n⟩ < a ∧ (hitSet ω a).Nonempty) with hD
+  set E := (Finset.univ.filter fun ω : Fin n → Bool =>
+      a < partialSumBool ω ⟨n, Nat.lt_succ_self n⟩) with hE
+  -- Partition 1: A = B ⊔ D (by `reaches_iff_hits_or_above`).
+  have hAeq : A = B ∪ D := by
+    ext ω
+    simp only [hA, hB, hD, Finset.mem_union, Finset.mem_filter, Finset.mem_univ, true_and]
+    constructor
+    · intro hr
+      by_cases hend : partialSumBool ω ⟨n, Nat.lt_succ_self n⟩ ≥ a
+      · exact Or.inl hend
+      · rcases (reaches_iff_hits_or_above ha).mp hr with h | h
+        · exact Or.inl h
+        · exact Or.inr ⟨lt_of_not_ge hend, h⟩
+    · rintro (h | ⟨_, hne⟩)
+      · exact (reaches_iff_hits_or_above ha).mpr (Or.inl h)
+      · exact (reaches_iff_hits_or_above ha).mpr (Or.inr hne)
+  have hdisjBD : Disjoint B D := by
+    rw [Finset.disjoint_left]
+    intro ω hb hd
+    simp only [hB, hD, Finset.mem_filter, Finset.mem_univ, true_and] at hb hd
+    exact absurd hb (not_le.mpr hd.1)
+  have h1 : A.card = B.card + D.card := by
+    rw [hAeq, Finset.card_union_of_disjoint hdisjBD]
+  -- Partition 2: B = C ⊔ E (ends ≥ a splits as = a / > a).
+  have hBeq : B = C ∪ E := by
+    ext ω
+    simp only [hB, hC, hE, Finset.mem_union, Finset.mem_filter, Finset.mem_univ, true_and]
+    constructor
+    · intro h
+      rcases eq_or_lt_of_le h with heq | hlt
+      · exact Or.inl heq.symm
+      · exact Or.inr hlt
+    · rintro (h | h)
+      · exact ge_of_eq h
+      · exact le_of_lt h
+  have hdisjCE : Disjoint C E := by
+    rw [Finset.disjoint_left]
+    intro ω hc he
+    simp only [hC, hE, Finset.mem_filter, Finset.mem_univ, true_and] at hc he
+    omega
+  have h2 : B.card = C.card + E.card := by
+    rw [hBeq, Finset.card_union_of_disjoint hdisjCE]
+  -- The reflection bijection: |D| = |E| via `reflectAt · a` both ways
+  -- (involutive on paths that hit `a`, by R4; endpoint formula by R5).
+  have h3 : D.card = E.card := by
+    apply Finset.card_nbij' (fun ω => reflectAt ω a) (fun ω => reflectAt ω a)
+    · -- MapsTo D → E: ends < a and hits a ⟹ reflection ends at 2a − S > a.
+      intro ω hω
+      rw [Finset.mem_coe] at hω ⊢
+      simp only [hD, Finset.mem_filter, Finset.mem_univ, true_and] at hω
+      simp only [hE, Finset.mem_filter, Finset.mem_univ, true_and]
+      have hR5 := partialSumBool_reflectAt_endpoint hω.2
+      rw [hR5]
+      omega
+    · -- MapsTo E → D: ends > a ⟹ hits a (discrete IVT), reflection ends
+      -- at 2a − S < a, and the reflected path still hits a at the same
+      -- first-hit index.
+      intro ω hω
+      rw [Finset.mem_coe] at hω ⊢
+      simp only [hE, Finset.mem_filter, Finset.mem_univ, true_and] at hω
+      simp only [hD, Finset.mem_filter, Finset.mem_univ, true_and]
+      have hne : (hitSet ω a).Nonempty := hitSet_nonempty_of_ge ha (le_of_lt hω)
+      have hR5 := partialSumBool_reflectAt_endpoint hne
+      exact ⟨by rw [hR5]; omega, ⟨firstHitFin ω a, firstHit_mem_hitSet_reflectAt hne⟩⟩
+    · -- Left inverse on D: R4 involution (D-membership includes the hit).
+      intro ω hω
+      rw [Finset.mem_coe] at hω
+      simp only [hD, Finset.mem_filter, Finset.mem_univ, true_and] at hω
+      exact reflectAt_involutive hω.2
+    · -- Right inverse on E: E-paths hit a by the discrete IVT, so R4 applies.
+      intro ω hω
+      rw [Finset.mem_coe] at hω
+      simp only [hE, Finset.mem_filter, Finset.mem_univ, true_and] at hω
+      exact reflectAt_involutive (hitSet_nonempty_of_ge ha (le_of_lt hω))
+  -- Assemble: |A| = |B| + |D| = |B| + |E| = |B| + (|B| − |C|) = 2|B| − |C|.
+  omega
 
 end DiscreteReflection
 

--- a/proofs/Proofs/BallotProblemOQ02OQ05.lean
+++ b/proofs/Proofs/BallotProblemOQ02OQ05.lean
@@ -36,7 +36,7 @@ arcsine identity) as theorems.
 - [x] Interpolated rescaled walk definition
 - [x] Ad hoc weak-convergence predicate on $C([0,1])$
 - [x] Donsker FCLT axiom statement
-- [ ] Discrete reflection identity (S3, sorry-free target)
+- [x] Discrete reflection identity (S12, 2026-07-24: fully proved, 0 sorries)
 - [ ] Continuous-mapping-for-sup axiom (S4)
 - [ ] Reflection-principle theorem deriving parent's axiom (S4)
 - [ ] First-passage-time event theorem (S5)
@@ -129,12 +129,12 @@ axiom donsker_fclt
 
 /-! ## Part IV: Discrete reflection identity (S6 ACT — paste-ready skeleton)
 
-This section is the S6 ACT paste-ready skeleton from S5 PREP §5, dropped
-in here so future researchers (or Aristotle) can discharge the
-acknowledged `sorry`s. R4 (`reflectAt_involutive`) and R5
-(`partialSumBool_reflectAt_endpoint`) are now proved; 2 `sorry`s remain
-(`reaches_iff_hits_or_above`, R6 `discrete_reflection`). The design is
-fully scoped in S5 PREP:
+This section began as the S6 ACT paste-ready skeleton from S5 PREP §5.
+R4 (`reflectAt_involutive`) and R5 (`partialSumBool_reflectAt_endpoint`)
+were proved in S9/S10; S12 (2026-07-24) discharged the final two
+(`reaches_iff_hits_or_above` via a discrete intermediate-value lemma, and
+R6 `discrete_reflection` via the `card_nbij'` reflection bijection) — the
+section is now **fully proved, 0 sorries**. The design followed S5 PREP:
 
 - §3.1 Option C: `partialSumBool : (Fin n → Bool) → Fin (n+1) → ℤ` via
   bounded sum over `Fin n` with `if h : i.val < k.val` guard.
@@ -143,9 +143,8 @@ fully scoped in S5 PREP:
   (non-dependent, inverse-pair form — `Mathlib/Data/Finset/Card.lean:398`),
   with `i = j = reflectAt _ a` (involutive).
 
-Build status: VERIFIED 2026-06-12 (Docker, 7744 jobs successful) with R4
-and R5 proved; the only remaining `sorry` warnings are
-`reaches_iff_hits_or_above` and R6 `discrete_reflection`. Leaf-only file
+Build status: VERIFIED 2026-07-24 (Docker, 8577 jobs successful) with the
+whole section proved — **0 `sorry`s in this file**. Leaf-only file
 (no downstream importers). -/
 
 section DiscreteReflection

--- a/proofs/Proofs/BallotProblemOQ02OQ05.lean
+++ b/proofs/Proofs/BallotProblemOQ02OQ05.lean
@@ -345,14 +345,25 @@ lemma partialSumBool_succ (ω : Fin n → Bool) {j : ℕ} (hj : j < n)
         = (if i.val < j then (if ω i then (1 : ℤ) else -1) else 0)
           + (if i.val = j then (if ω i then (1 : ℤ) else -1) else 0) := by
     intro i
+    -- Bind each condition proof BEFORE `rw [if_pos/if_neg]`: an unanchored
+    -- `if_pos (by omega)` leaves the condition a metavariable and can unify
+    -- with the wrong `ite` (e.g. the inner `if ω i` payload).
     rcases lt_trichotomy i.val j with h | h | h
-    · rw [if_pos (by omega), if_pos h, if_neg (by omega)]; ring
-    · rw [if_pos (by omega), if_neg (by omega), if_pos h]; ring
-    · rw [if_neg (by omega), if_neg (by omega), if_neg (by omega)]; ring
+    · have c1 : i.val < j + 1 := by omega
+      have c3 : ¬(i.val = j) := by omega
+      rw [if_pos c1, if_pos h, if_neg c3]; ring
+    · have c1 : i.val < j + 1 := by omega
+      have c2 : ¬(i.val < j) := by omega
+      rw [if_pos c1, if_neg c2, if_pos h]; ring
+    · have c1 : ¬(i.val < j + 1) := by omega
+      have c2 : ¬(i.val < j) := by omega
+      have c3 : ¬(i.val = j) := by omega
+      rw [if_neg c1, if_neg c2, if_neg c3]; ring
   have hlast : (∑ i : Fin n, if i.val = j then (if ω i then (1 : ℤ) else -1) else 0)
       = (if ω ⟨j, hj⟩ then (1 : ℤ) else -1) := by
     rw [Finset.sum_eq_single (⟨j, hj⟩ : Fin n)]
-    · rw [if_pos rfl]
+    · have hc : (⟨j, hj⟩ : Fin n).val = j := rfl
+      rw [if_pos hc]
     · intro i _ hne
       exact if_neg (fun h => hne (Fin.ext h))
     · intro habs

--- a/research/problems/ballot-problem-oq-02-oq-05/problem.md
+++ b/research/problems/ballot-problem-oq-02-oq-05/problem.md
@@ -242,3 +242,40 @@ Each of S2–S5 is a ~50–100-line single-session deliverable. S6 is ambitious 
 - **Axiom-count honesty**: the parent's status is `axiomatized` with 3 axioms. After S2–S6 the count becomes 1 (Donsker itself) + possibly 1 (continuous mapping for $\sup$) + possibly 1 (arcsine-density limit) = up to 3 axioms total. The status should remain `axiomatized` unless Donsker is itself proved (well beyond single-session scope).
 - **Wiedijk #45 visibility**: any future "Donsker's theorem in Lean" statement MUST clearly say "axiom" until a Mathlib proof exists, to avoid over-claiming on the 100-theorems tracker.
 - **Sibling slug conflicts**: `ballot-problem-oq-03-oq-01-oq-01` and `ballot-problem-oq-01-oq-04-oq-01` are reflection-principle slugs in adjacent positions; coordinate with their state-files to avoid duplicating the discrete reflection identity in S3.
+
+## Adversarial Checklist (SOLVED claim, 2026-07-24 — discrete-reflection scope)
+
+The S12 claim: the **discrete-reflection section** of
+`proofs/Proofs/BallotProblemOQ02OQ05.lean` is fully proved (0 sorries; the sole
+axiom is the intended `donsker_fclt` statement axiom). Ways THIS claim could be
+wrong, and why each is excluded:
+
+- **Scope inflation.** The claim is NOT that OQ-05's continuous-side plan
+  (S4–S7: deriving the parent's 3 axioms from Donsker) is done — those remain
+  future DEEP work and `donsker_fclt` remains an axiom (Wiedijk #45 stays
+  "axiom", per the Risk Notes above). The completed unit is exactly what S11
+  pinned as "the only work left on this slug": `reaches_iff_hits_or_above` +
+  `discrete_reflection`.
+- **Degenerate reflection branch.** `reflectAt` defaults `firstHitFin` to
+  `⟨0,_⟩` on paths that never hit `a`; the S7-PREP counterexample showed the
+  unconditional involution is FALSE. Confirm every use of
+  `reflectAt_involutive` supplies `(hitSet ω a).Nonempty`: the D-class carries
+  it by definition; the E-class derives it via `hitSet_nonempty_of_ge`
+  (endpoint `> a ≥ a` + discrete IVT). No use is unconditioned.
+- **Overshoot in the IVT.** `hitSet_nonempty_of_ge` requires `0 < a` (paths
+  start at `S₀ = 0 < a`); a `+1` jump from `< a` lands `≤ a`. For `a ≤ 0` the
+  claim would be false as stated (e.g. `a = 0` is hit at index 0 regardless) —
+  the lemma and both consumers carry `0 < a`.
+- **Double-counting in the partition.** `A = B ∪ D` uses the DISJOINTIFIED
+  form (`D` requires `S_n < a`), not the raw `reaches ↔ ends-≥ ∨ hits`
+  disjunction whose disjuncts overlap. `card_union_of_disjoint` demands the
+  proved `Disjoint` terms — no double count.
+- **ℕ-subtraction truncation.** The statement uses `2·|B| − |C|` in ℕ;
+  truncation would silently weaken it if `|C| > 2·|B|`. From `B = C ⊔ E`,
+  `|C| ≤ |B|`, so the subtraction is exact; the closing `omega` uses the three
+  card equations, not truncation coincidences.
+- **Wrong-multiplicity near-miss.** The bijection is between `D` (ends `< a`,
+  hits) and `E` (ends `> a`) — NOT the classical-but-different pairing with
+  "ends ≥ a". The final identity was cross-checked against the partition
+  algebra `|A| = |B| + |E|` and `|E| = |B| − |C|`, which is exactly André's
+  count.

--- a/research/problems/ballot-problem-oq-02-oq-05/sessions/2026-07-24-s12-act-final-sorries-discharged.md
+++ b/research/problems/ballot-problem-oq-02-oq-05/sessions/2026-07-24-s12-act-final-sorries-discharged.md
@@ -1,0 +1,60 @@
+# Session 2026-07-24 — S12 (researcher-2): final 2 sorries discharged — discrete reflection identity COMPLETE
+
+## Phase: ACT (unblock — the S11 BLOCKED flag was Docker-blackout-only; Docker is GREEN today)
+
+## What was blocked, now done
+
+S11 (2026-06-13) flagged this slug BLOCKED with both remaining sorries carrying
+paste-ready sketches, gated purely on verification infra. Docker recovered, so
+this session discharged both:
+
+1. **`reaches_iff_hits_or_above`** — via a new **discrete intermediate-value
+   lemma** `hitSet_nonempty_of_ge` (if any partial sum reaches `≥ a > 0`, the
+   path hits `a` exactly): induction on the index; at each step `S_{j+1} > a`
+   forces `S_j ≥ a` because the jump is `±1` (a `+1` jump from `< a` cannot
+   overshoot). The S11 sketch's `Int.le_iff_exists_eq_succ` route was replaced
+   by this cleaner induction. Supporting recurrence
+   `partialSumBool_succ : S_{j+1} = S_j + (if ω j then 1 else -1)` proved by
+   summand trichotomy + `Finset.sum_eq_single`; `partialSumBool_zero = 0`.
+2. **`discrete_reflection`** (R6, the section's headline) —
+   `|reaches ≥ a| = 2·|ends ≥ a| − |ends = a|` (André 1887):
+   - Partition 1: `A = B ⊔ D` (reaches = ends-≥-a ⊔ (ends-<-a ∧ hits-a)) via
+     `reaches_iff_hits_or_above`; `Finset.card_union_of_disjoint`.
+   - Partition 2: `B = C ⊔ E` (ends-≥ = ends-= ⊔ ends->).
+   - **`|D| = |E|` by `Finset.card_nbij'`** with `i = j = reflectAt · a`:
+     MapsTo via R5 (`S_n(reflect) = 2a − S_n`, so `< a ↔ > a` swap); E-side
+     hit-set nonemptiness via the discrete IVT; inverses via R4
+     (`reflectAt_involutive`, whose `Nonempty` hypothesis is exactly what both
+     memberships supply). New helper `firstHit_mem_hitSet_reflectAt` extracts
+     the Step-1 argument of R4's proof (first hit survives reflection).
+   - Final assembly is one `omega` over the three card equations.
+
+## Lean gotchas (v4.31)
+
+- **`rw [if_pos (by omega)]` with an unanchored condition is a trap**: the
+  condition stays a metavariable during `kabstract`, so the rewrite can unify
+  with the WRONG `ite` (here: the inner `if ω i then 1 else -1` payload), and
+  `omega` then sees an unprovable/Boolean side goal or `ring` faces a
+  mismatched goal. Fix: `have c1 : i.val < j + 1 := by omega` FIRST, then
+  `rw [if_pos c1]` — the fixed type anchors unification. Same for
+  `if_pos rfl` (bind `have hc : (⟨j,hj⟩ : Fin n).val = j := rfl`).
+- `Fin.mk` bound proofs: state helper lemmas with EXPLICIT bound-proof
+  arguments (`partialSumBool_succ ω hj h1 h2`) so `omega` sees identical
+  atoms — `⟨j, by omega⟩` with different proof terms are distinct atoms.
+- `Finset.card_nbij'` (v4.31): takes `Set.MapsTo`/`Set.LeftInvOn`/
+  `Set.RightInvOn` on the coerced finsets; `rw [Finset.mem_coe]` bridges to
+  `Finset.mem_filter` cleanly.
+
+## File status after this session
+
+`BallotProblemOQ02OQ05.lean`: **0 sorries** (was 2), 1 axiom (`donsker_fclt`,
+the intended Donsker FCLT statement axiom — Wiedijk #45, open by design).
+Per S11: these two sorries were "the only work left on this slug" — the
+discrete-reflection section is now fully machine-checked, so the thread is
+COMPLETE. The remaining continuous-side content (deriving the parent's three
+axioms from `donsker_fclt`) was already recorded as out-of-scope DEEP work.
+
+## Build
+
+`./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ02OQ05` — see PR.
+First attempt failed only on the unanchored-`if_pos` gotcha above.

--- a/research/problems/ballot-problem-oq-02-oq-05/state.md
+++ b/research/problems/ballot-problem-oq-02-oq-05/state.md
@@ -1,9 +1,39 @@
 # Current State
 
-**Phase**: BLOCKED (S11 — final 2 sorries are build-gated; verification infra down)
-**Since**: 2026-06-13 (S11 BLOCKED)
-**Iteration**: 11 (S1 OBSERVE + S2 ACT + S3 PREP + S4 STATE-SYNC + S5 PREP + S6 ACT + S7 PREP + S8 ACT + S9 ACT + S10 ACT + S11 BLOCKED, this entry)
-**Last Updated**: 2026-06-14 (STATE-SYNC)
+**Phase**: COMPLETE (S12 — final 2 sorries discharged, Docker-GREEN)
+**Since**: 2026-07-24 (S12 ACT, researcher-2)
+**Iteration**: 12
+**Last Updated**: 2026-07-24
+
+## S12 ACT (researcher-2, 2026-07-24) — THREAD COMPLETE: final 2 sorries discharged
+
+The S11 BLOCKED flag was verification-infra-only; Docker is GREEN today, so
+both build-gated sorries were discharged (Docker 8577 jobs, exit 0):
+
+1. **`reaches_iff_hits_or_above`** — via new discrete intermediate-value lemma
+   `hitSet_nonempty_of_ge` (any partial sum `≥ a > 0` forces an exact hit of
+   `a`; induction on the index, a `+1` jump from `< a` cannot overshoot), with
+   recurrence `partialSumBool_succ` and base `partialSumBool_zero` (both take
+   explicit `Fin.mk` bound proofs so `omega` atoms unify).
+2. **R6 `discrete_reflection`** — `|reaches ≥ a| = 2·|ends ≥ a| − |ends = a|`:
+   partitions `A = B ⊔ D`, `B = C ⊔ E` (`card_union_of_disjoint`), the
+   reflection bijection `|D| = |E|` via `Finset.card_nbij'` with
+   `i = j = reflectAt · a` (R4 involution + R5 endpoint formula + new helper
+   `firstHit_mem_hitSet_reflectAt`), and a closing `omega`.
+
+**File**: `BallotProblemOQ02OQ05.lean` 545 LOC, **0 sorries** (was 2), 1 axiom
+(`donsker_fclt` — the intended Donsker FCLT statement axiom, Wiedijk #45).
+Per S11, these two sorries were "the only work left on this slug" — the
+discrete-reflection section (André 1887) is now fully machine-checked and the
+thread is COMPLETE. The continuous-side derivations (S4-S7 checklist items:
+deriving the parent's axioms from `donsker_fclt`) remain out-of-scope DEEP
+work, already recorded as such.
+
+**Gotcha recorded**: `rw [if_pos (by omega)]` with unanchored condition can
+unify with the wrong `ite` — bind `have c : cond := by omega` first.
+Session memo: `sessions/2026-07-24-s12-act-final-sorries-discharged.md`.
+
+---
 
 > STATE-SYNC (2026-06-14, researcher-6): the S11 BLOCKED flag had not
 > reached the registry or the pool. The registry

--- a/src/data/research/problems/ballot-problem-oq-02-oq-05.json
+++ b/src/data/research/problems/ballot-problem-oq-02-oq-05.json
@@ -1,8 +1,8 @@
 {
   "slug": "ballot-problem-oq-02-oq-05",
   "title": "Donsker's functional CLT — connecting discrete and continuous ballot",
-  "phase": "BLOCKED",
-  "status": "blocked",
+  "phase": "COMPLETE",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -33,13 +33,11 @@
     "goal": "Formalize in Lean: (1) interpolatedRescaled definition + WeakConvergesInC01 predicate; (2) donsker_fclt as an axiom at the right type; (3) discrete_reflection as a sorry-free theorem (lattice-path bijection); (4) continuous_mapping_sup as a one-line axiom; (5) derive parent's reflection_principle as a theorem from (2)+(3)+(4); (6) downgrade parent's firstPassageTime_eq_maxEvent from axiom to theorem using BrownianMotion.pathContinuous + Real.csInf_mem; (7) Sparre Andersen as a sorry-free theorem (bijective combinatorics); (8) derive parent's arcsine identity as a theorem from Sparre Andersen + Stirling + continuous-mapping-for-integral."
   },
   "currentState": {
-    "phase": "BLOCKED",
-    "since": "2026-06-13",
-    "iteration": 11,
-    "focus": "STATE-SYNC (researcher-6, 2026-06-14): propagated state.md's S11 BLOCKED flag (researcher-1, 2026-06-13) into this registry + the candidate pool, which had been left at iteration 10 / phase ACT / status active / empty blockers with the pool stuck at in-progress (so claim-random kept re-serving this Docker-gated slug). Also de-staled the leanFiles[] array, which still read 229 LOC / 4 thm / 6 sorry while the merged source — and this very focus prose — is 357 LOC / 6 col-0 lemmas+theorems / 2 real sorries (synced to 357 / 6 / 2; defCount 7, axiomCount 1 already correct). The 2 remaining sorries (reaches_iff_hits_or_above line 334; discrete_reflection line 353) are paste-ready but build-gated; verification blackout this session (docker info times out; Aristotle MCP \"Resource not found\"). PRIOR FOCUS (S10 ACT, retained): S10 ACT (#22924, 2026-06-13 05:51, Docker-verified 7744 jobs): discharged R5 partialSumBool_reflectAt_endpoint (reflected lattice path's endpoint = 2a - S_n(ω); split both endpoints into full signed sums, terms double below the first-hit time tau and cancel at/above, close via S_tau(omega)=a from min'_mem). The PR touched ONLY proofs/Proofs/BallotProblemOQ02OQ05.lean (1 file) and did NOT advance state.md or this JSON, so trackers had drifted ~4 iterations behind. Source now: 357 LOC, 6 col-0 lemmas/theorems, 7 defs (4 noncomputable), 1 axiom (donsker_fclt), 2 real sorries remaining -- reaches_iff_hits_or_above (LOW, line 334) and discrete_reflection (R6, line 353). R4 (reflectAt_involutive) was discharged in S9 ACT (researcher-1, 2026-06-01) via the partialSumBool_congr_below helper + Helper-1 reflectAt_eq_below_firstHit; R5 now also closed. Sorry trajectory: S6 4 -> S8 4 -> S9 3 -> S10 2. All discharges Docker-verified (Docker daemon flickered green for #22924 at 05:51 today despite the intermittent outage).",
-    "blockers": [
-      "Verification blackout 2026-06-14: Docker build route down (docker info times out) and Aristotle MCP backend returns \"Resource not found\". The 2 remaining sorries (reaches_iff_hits_or_above line 334; discrete_reflection line 353) have paste-ready S5/S10 proof sketches but need a build or Aristotle prove_file to land — must not be blind-shipped."
-    ],
+    "phase": "COMPLETE",
+    "since": "2026-07-24",
+    "iteration": 12,
+    "focus": "S12 ACT (researcher-2, 2026-07-24): THREAD COMPLETE. The S11 verification-blackout blocker cleared (Docker GREEN); both build-gated sorries discharged, Docker 8577 jobs exit 0. (1) reaches_iff_hits_or_above via new discrete intermediate-value lemma hitSet_nonempty_of_ge (any partial sum >= a > 0 forces an exact hit; +1 jumps cannot overshoot) with explicit-Fin-proof recurrence partialSumBool_succ. (2) R6 discrete_reflection |reaches >= a| = 2|ends >= a| - |ends = a| (Andre 1887): two disjoint partitions + Finset.card_nbij with reflectAt both ways (R4 involution, R5 endpoint formula, new firstHit_mem_hitSet_reflectAt) + closing omega. File: 545 LOC, 0 sorries (was 2), 1 axiom (donsker_fclt — intended Donsker FCLT statement axiom, Wiedijk #45). Continuous-side S4-S7 derivations remain out-of-scope DEEP work.",
+    "blockers": [],
     "nextAction": "S11 ACT (any researcher or Aristotle, Docker-gated): discharge the 2 remaining sorries -- (1) reaches_iff_hits_or_above (LOW, line 334, ~8 LOC) via Int.le_iff_exists_eq_succ on the +/-1 partial-sum jumps (S_0=0, S_k>=a>0 forces an exact hit); (2) discrete_reflection (R6, line 353, ~20 LOC) via Finset.card_nbij' with i=j=reflectAt _ a, using R4 (reflectAt_involutive) for left_inv/right_inv and R5 (partialSumBool_reflectAt_endpoint) for the (ending<a, hits a) <-> (ending>a) membership image, then linear arithmetic for 2*card_ge - card_eq. Both are well-scoped Aristotle candidates. Build-verify when Docker is up. Beyond this slug: S8+ parent OQ-02 axiom downgrades (continuous_mapping_sup S8, reflection_principle S9, sparre_andersen S10).",
     "attemptCounts": {
       "total": 8,
@@ -48,12 +46,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S10 ACT (#22924, 2026-06-13, Docker-verified 7744 jobs): proved R5 partialSumBool_reflectAt_endpoint (reflected endpoint = 2a - S_n). Sorries 3 -> 2; remaining: reaches_iff_hits_or_above (LOW) + discrete_reflection (R6). PR touched only the .lean. S9 ACT (researcher-1, 2026-06-01, Docker-verified 7744): added partialSumBool_congr_below helper + inline-discharged the R4-sub htau (firstHitFin(reflectAt omega a) a = firstHitFin omega a via le_antisymm over min' of hitSet); reflectAt_involutive R4 now fully proved. Sorries 4 -> 3, LOC -> 325. S8 ACT (researcher-1, 2026-05-31, Docker-verified 7744): added Helper-1 reflectAt_eq_below_firstHit (if_neg collapse: reflection = identity below first-hit time) + restructured R4 signature to {omega}{a}(h:(hitSet omega a).Nonempty) with sorry-free body modulo one honest sub-sorry; fixed 3 build bugs left by the never-built S6 skeleton (unused if-binder, reflectAt must be noncomputable, R4 unfold/show precedence). LOC -> 266. S6 ACT (researcher-9, 2026-05-16, build pending): pasted S5 PREP §5 paste-ready ~99-LOC skeleton verbatim into proofs/Proofs/BallotProblemOQ02OQ05.lean before `end BallotOQ05` (line 130 → file 229 LOC). File now has 3 defs + 1 noncomputable def + 3 lemmas + 1 theorem + 1 axiom (donsker_fclt) + 4 acknowledged sorries on R4/R5/LOW/R6. Sorry inventory: reflectAt_involutive R4 MEDIUM ~10 LOC, partialSumBool_reflectAt_endpoint R5 HIGH ~25 LOC, reaches_iff_hits_or_above LOW ~8 LOC, discrete_reflection R6 HIGH ~20 LOC — all theorem/lemma sorries (none on defs). 10 bearer pins all GREEN at lake-pinned Mathlib SHA 2df2f0150c (card_bij/card_bij'/card_nbij/card_nbij' Card.lean:341,366,383,398; min'/min'_mem/min'_le/le_min' Max.lean:196,207,210,213; BrownianMotion/iIndepFun unchanged since S2). Build pending — Docker daemon hung (timeout 8 docker info no Server section; disk 100% / 5.4Gi avail). Leaf-only file (0 downstream importers) — sorry add cannot cascade. S5 PREP (researcher-6, 2026-05-16, doc-only): round-tripped S4-published S3 ACT sketch against actual file API on main (cff3fd36c83) and Mathlib v4.26.0 at SHA 2df2f0150c. Surfaced 4 issues, documented 3 design choices (Option C bounded Fin (n+1) index, Option β Finset.min', Option iv card_nbij' inverse-pair), produced paste-ready skeleton w/ 4 acknowledged sorries on R4/R5/LOW/R6. Added 6 new bearer pins not in S4 (card_nbij/card_nbij'/min'/min'_mem/min'_le/le_min'). S4 STATE-SYNC (researcher-6, 2026-05-16): doc-only post-drain catch-up after #19282 (S2 ACT) + #19288 (S3 PREP) merged 2026-05-15. PR #19065 (duplicate S2 ACT, recommended-for-close) still OPEN+CONFLICTING. S2 (researcher-9, 2026-05-15) ACT: shipped statement layer ~95 LOC build-verified 7744 jobs. S1 (researcher-6, 2026-05-12) OBSERVE: established axiomatize-Donsker architecture, 13-ingredient Mathlib gap census, S2-S7 decomposition.",
+    "progressSummary": "COMPLETE: the discrete reflection identity |reaches >= a| = 2|ends >= a| - |ends = a| is fully machine-checked (0 sorries; the sole axiom is the intended donsker_fclt statement axiom). Full chain: partialSumBool/hitSet/firstHitFin/reflectAt defs; R4 involution on the hit branch; R5 endpoint formula S_n(reflect) = 2a - S_n; discrete IVT hitSet_nonempty_of_ge; partition + card_nbij bijection assembly.",
     "builtItems": [
       "proofs/Proofs/BallotProblemOQ02OQ05.lean (S2 ACT, ~95 LOC, build-verified by Docker): partialSum + interpolatedRescaled definitions, WeakConvergesInC01 ad hoc predicate, donsker_fclt axiom (Wiedijk #45). Uses iIndepFun (mutual independence) — strengthened from S1 sketch's Pairwise IndepFun (which is insufficient for classical Donsker).",
       "proofs/Proofs/BallotProblemOQ02OQ05.lean (S8 ACT, Docker-verified 7744): Helper-1 reflectAt_eq_below_firstHit (reflection is identity below the first-hit time) + R4 reflectAt_involutive restructured to take a Nonempty hypothesis.",
       "proofs/Proofs/BallotProblemOQ02OQ05.lean (S9 ACT, Docker-verified 7744): partialSumBool_congr_below helper + full inline discharge of R4 reflectAt_involutive (R4-sub htau closed via min'-of-hitSet antisymmetry).",
-      "proofs/Proofs/BallotProblemOQ02OQ05.lean (S10 ACT #22924, Docker-verified 7744): R5 partialSumBool_reflectAt_endpoint proved (reflected path endpoint = 2a - S_n via signed-sum split + S_tau=a)."
+      "proofs/Proofs/BallotProblemOQ02OQ05.lean (S10 ACT #22924, Docker-verified 7744): R5 partialSumBool_reflectAt_endpoint proved (reflected path endpoint = 2a - S_n via signed-sum split + S_tau=a).",
+      "S12: partialSumBool_zero / partialSumBool_succ (explicit Fin.mk bound-proof args so omega atoms unify) — BallotProblemOQ02OQ05.lean",
+      "S12: hitSet_nonempty_of_ge — discrete intermediate-value: any partial sum >= a > 0 forces an exact hit of a",
+      "S12: firstHit_mem_hitSet_reflectAt — first hit survives reflection (extracted from R4 Step 1)",
+      "S12: reaches_iff_hits_or_above proved (sorry eliminated)",
+      "S12: discrete_reflection proved (sorry eliminated) — card_nbij with reflectAt both directions + two disjoint partitions + omega"
     ],
     "insights": [
       "Axiomatize-Donsker pipeline: a single named axiom for Donsker's FCLT replaces three ad hoc axioms in the parent file. The continuous mapping theorem for the sup-functional is the second axiom needed; an optional third axiom handles the integral functional for Lévy arcsine. Net axiom count is neutral (3 → 2 or 3) but concentrated into named classical statements rather than ad hoc lemmas.",
@@ -70,7 +73,11 @@
       "S2 ACT: partialSum xi k ω is a useful named definition (not inline ∑) because S3 needs Finset.sum_range_succ-style algebraic identities to reason about the random walk one-step-at-a-time. Named definitions enable reusable lemmas across S3-S6.",
       "Duplicate-S2-ACT race resolved by deployer overriding the S3 PREP audit memo's recommendation: PR #19282 (newer, bundled with cross-slug commit) merged instead of PR #19065 (older, scope-clean). PR #19065 left stranded OPEN + CONFLICTING; champion should close-not-rebase (work is byte-equivalent modulo partialSum named helper, which is on main via #19282).",
       "PR #19282's cross-slug-bundled commit b519c2ebeec (erdos-735-oq-04 S2 PREP) was independently merged via PR #19278 at 2026-05-15T18:01:56Z, so the coordination hazard flagged in #19288 § 4 was retroactively resolved: erdos-735-oq-04 went through its own review track at #19278; #19282's bundled copy was a no-op against the post-#19278-merge state.",
-      "Finset.card_bij' (line 366, with explicit inverse j : ∀ a ∈ t, α) is a closer fit for the André-Feller reflection bijection than card_bij (line 341), because the reflect-at-first-hit-a map is its own inverse on the relevant event. State.md L40 names card_bij; S3 implementer should consider card_bij' as the cleaner shape."
+      "Finset.card_bij' (line 366, with explicit inverse j : ∀ a ∈ t, α) is a closer fit for the André-Feller reflection bijection than card_bij (line 341), because the reflect-at-first-hit-a map is its own inverse on the relevant event. State.md L40 names card_bij; S3 implementer should consider card_bij' as the cleaner shape.",
+      "rw [if_pos (by omega)] with an unanchored condition is a trap: the condition metavariable can unify with the WRONG ite (e.g. an inner if-payload). Bind have c : cond := by omega first, then rw [if_pos c].",
+      "State index-recurrence lemmas with EXPLICIT Fin.mk bound-proof arguments; omega treats mk-terms with different proof terms as distinct atoms.",
+      "The discrete IVT (+1 jumps cannot overshoot) is the right replacement for the sketched Int.le_iff_exists_eq_succ route — a 25-line induction.",
+      "card_nbij (v4.31) takes Set.MapsTo/LeftInvOn/RightInvOn on coerced finsets; rw [Finset.mem_coe] bridges to mem_filter; the R4 Nonempty hypothesis is exactly what both class memberships supply."
     ],
     "mathlibGaps": [
       "No Polish-space instance for C([0, 1], ℝ) at v4.26.0 — needs separability of BoundedContinuousFunction proved via Stone-Weierstrass. Polish + Borel-σ-algebra is prerequisite for the canonical weak-convergence development on C([0, 1]).",
@@ -82,13 +89,8 @@
       "No first-class Brownian motion construction — the parent file axiomatizes via a BrownianMotion structure with W : ℝ → Ω → ℝ + properties; this is the existence problem, distinct from but prerequisite to Donsker."
     ],
     "nextSteps": [
-      "S7 discharge: prove reaches_iff_hits_or_above (LOW, ~8 LOC) via ±1-jump IVT — partial sums of ±1 change by exactly 1 each step so S_k ≥ a > 0 with S_0 = 0 ⟹ ∃ j ≤ k, S_j = a.",
-      "S7 discharge: prove discrete_reflection (R6 HIGH, ~20 LOC) via Finset.card_nbij' with i = j = fun ω _ => reflectAt ω a, using R4 for left_inv/right_inv + R5 for membership-image (ending<a, hits a) ↔ (ending>a) + linear arithmetic over ℕ for 2*card_ge - card_eq.",
-      "S8: state continuous_mapping_sup : (X_n ⇒ X in C([0,1])) → (sup X_n ⇒ sup X) as axiom. Combine with donsker_fclt + discrete_reflection (S7) to derive parent's reflection_principle as theorem. Expected ~50 lines, 1 new axiom, 1 new theorem.",
-      "S9: downgrade parent's firstPassageTime_eq_maxEvent from axiom to theorem using BrownianMotion.pathContinuous + Real.csInf_mem (no Donsker dependency). Expected ~30 lines.",
-      "S10: prove sparre_andersen for ±1 walk via cycle-lemma bijection. State continuous_mapping_integral axiom. Derive parent's arcsine identity. Expected ~150 lines.",
-      "S11: update parent file to depend on BallotProblemOQ02OQ05, downgrading 3 parent axioms to theorems. Update meta.json axiomCount.",
-      "S12+ (deferred, multi-year): downgrade donsker_fclt itself once Mathlib gains Polish-C([0,1]) + Prokhorov + Kolmogorov-Centsov + multivariate CLT. Track as upstream Mathlib contribution."
+      "Thread complete. Continuous-side derivations (parent axioms from donsker_fclt: continuous mapping, reflection principle, arcsine) remain DEEP multi-week work, out of scope for this slug per S11.",
+      "leanFiles sync: 545 LOC, 0 sorries, 1 axiom (donsker_fclt)."
     ]
   },
   "tags": [
@@ -168,7 +170,7 @@
     ]
   },
   "started": "2026-05-12T18:15:00.000Z",
-  "lastUpdate": "2026-06-14T00:00:00.000Z",
+  "lastUpdate": "2026-07-24",
   "significance": 8,
   "tractability": 3,
   "leanFiles": [
@@ -417,11 +419,11 @@
     {
       "path": "Proofs/BallotProblemOQ02OQ05.lean",
       "filename": "BallotProblemOQ02OQ05.lean",
-      "lineCount": 358,
-      "theoremCount": 6,
+      "lineCount": 545,
+      "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 7,
-      "sorryCount": 6,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ02OQ05.lean"
     },


### PR DESCRIPTION
## Summary
S12 session for `ballot-problem-oq-02-oq-05` — the S11 BLOCKED flag was
verification-infrastructure-only (June Docker blackout); Docker is GREEN, so this
session discharges the **final 2 sorries** of the discrete-reflection section.
**The thread's remaining pinned work is now complete: 0 sorries** (the sole axiom
is the intended `donsker_fclt` statement axiom — Wiedijk #45, disclosed as such).

## Progress
`proofs/Proofs/BallotProblemOQ02OQ05.lean` (545 LOC, Docker exit 0, 8577 jobs):

- **`reaches_iff_hits_or_above`** (sorry 1) — via a new discrete
  intermediate-value lemma `hitSet_nonempty_of_ge`: any partial sum reaching
  `>= a > 0` forces an exact hit of `a` (induction on the index; a `+1` jump from
  `< a` cannot overshoot). Supporting recurrence `partialSumBool_succ` and base
  `partialSumBool_zero`, both with explicit `Fin.mk` bound-proof arguments so
  `omega` atoms unify.
- **`discrete_reflection`** (sorry 2, R6 — Andre 1887, Feller III.1):
  `|reaches >= a| = 2 |ends >= a| - |ends = a|`. Two disjoint partitions
  (`card_union_of_disjoint`) plus the reflection bijection
  `|ends < a, hits a| = |ends > a|` via `Finset.card_nbij'` with
  `reflectAt . a` in both directions — R4 involution (its `Nonempty` hypothesis is
  exactly what both class memberships supply), R5 endpoint formula, and a new
  helper `firstHit_mem_hitSet_reflectAt`. Closing `omega`.
- Stale in-file prose synced (status checklist, skeleton docstring).
- problem.md: adversarial checklist for the SOLVED claim (scope pinned to the
  discrete-reflection unit; continuous-side S4-S7 derivations remain DEEP work).

## Findings
- v4.31 gotcha: `rw [if_pos (by omega)]` with an unanchored condition can unify
  with the WRONG `ite` (the inner `if omega-i` payload) — bind
  `have c : cond := by omega` first, then `rw [if_pos c]`.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ02OQ05` — exit 0
  (8577 jobs). Remaining warnings are pre-existing (deprecated `push_neg`,
  unused `hn` binder).
- Supersession guard: NOT_SUPERSEDED.

## Status
**Outcome**: completed (the S11-pinned remaining work; `donsker_fclt` stays an
axiom by design)
**Next Steps**: none on this slug. Continuous-side derivations from Donsker are
recorded as out-of-scope DEEP work.

🤖 Generated by researcher-2
