### PR TITLE
Enrich brouwer-fixed-point-oq-01-oq-01: split bundled tail section

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-01/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-01/meta.json
@@ -132,9 +132,17 @@
       "id": "sperner",
       "title": "The 1D Sperner Lemma",
       "startLine": 101,
-      "endLine": 136,
-      "summary": "exists_sperner_edge: a false→true path has a bichromatic edge; colorChanges_pos_of_ne: positivity of the count.",
+      "endLine": 123,
+      "summary": "exists_sperner_edge: a false→true path has at least one bichromatic edge {i, i+1} — the discrete intermediate value theorem, obtained by unwrapping the odd count into a nonempty Finset via Finset.card_pos.",
       "mathContext": "Odd ⟹ positive ⟹ the edge set is nonempty (Finset.card_pos)."
+    },
+    {
+      "id": "corollaries-and-checks",
+      "title": "Quantitative Corollary and Sanity Checks",
+      "startLine": 125,
+      "endLine": 136,
+      "summary": "colorChanges_pos_of_ne restates the discrete IVT quantitatively (the count itself, not just an edge, is positive). Closing #check block confirms the three headline statements (even_colorChanges_iff, oddColorChanges_of_ne, exists_sperner_edge) elaborate as stated.",
+      "mathContext": "Positivity of colorChanges c n is the numeric shadow of exists_sperner_edge; both follow from the same oddness fact via Nat.pos_of_ne_zero."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `brouwer-fixed-point-oq-01-oq-01` (quality 98).

`qualityBreakdown` showed everything at cap except `sections: 8/10` (4
sections, 2 pts each, capped at 5). The existing `sperner` section (lines
101-136) bundled three distinct things: the main theorem `exists_sperner_edge`
(108-123), the quantitative corollary `colorChanges_pos_of_ne` (125-130), and
the closing `#check` sanity block (132-134).

Split at the real boundary after `exists_sperner_edge`: `sperner` now covers
just the main 1D Sperner lemma (101-123), and a new `corollaries-and-checks`
section (125-136) covers the quantitative restatement and the sanity checks.
No other content changed. `meta.json` stays at ~12.1 KB, well under the 60 KB
cap.