### PR TITLE
Enrich buffons-needle-oq-01-oq-02-oq-01: add header section (5th section)

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-02-oq-01/meta.json
@@ -85,6 +85,14 @@
   },
   "sections": [
     {
+      "id": "header-overview",
+      "title": "A Dimension-Independent Invariant Between Neighbouring Dimensions",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Module docstring: extends the parent's higher-dimensional Buffon constant c_n = E[|⟨u,e₁⟩|] by finding the invariant c_{n+1}·c_n = 2/(nπ) between consecutive constants, equivalently n·c_n·c_{n+1} = 2/π — the same value 2/π (the classical planar Cauchy constant c₂) in every dimension. States the four main results and sketches the Gamma-functional-equation proof. Followed by the import and namespace declaration.",
+      "mathContext": "$c_{n+1}c_n = \\dfrac{2}{n\\pi}$, equivalently $n\\,c_n\\,c_{n+1} = \\dfrac{2}{\\pi}$ — a conserved quantity across all dimensions, reflecting the Cauchy-Crofton normalization of the kinematic measure on lines."
+    },
+    {
       "id": "constant",
       "title": "The Buffon Dimensional Constant",
       "startLine": 47,


### PR DESCRIPTION
Enrichment pass for `buffons-needle-oq-01-oq-02-oq-01` (quality 98).

`qualityBreakdown` showed everything at cap except `sections: 8/10` (4
sections instead of 5). The module docstring + import + namespace (lines
1-45) had no `sections` entry, even though an existing annotation
(`ann-bnoq01oq02oq01-overview`, range 1-45) already recognized this span as a
coherent conceptual unit.

Added a `header-overview` section matching that annotation's boundary exactly,
summarizing the dimension-independent invariant `c_{n+1}·c_n = 2/(nπ)` and the
four main results. No other content changed; `meta.json` stays at ~12.5 KB,
well under the 60 KB cap.