### PR TITLE
Enrich catalan-numbers-oq-01-oq-01: add 5th keyInsight

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-01-oq-01/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-01/meta.json
@@ -65,7 +65,8 @@
       "**The difference form is not a Mathlib re-export.** Mathlib has the division form catalan n = centralBinom n / (n+1); the subtraction form C(2n,n) - C(2n,n+1) needs the neighbour relation and a genuine cancellation, so it is derived here rather than imported.",
       "**Work additively, conclude subtractively.** Proving the partition C(2n,n) = catalan n + C(2n,n+1) first — with no ℕ truncated subtraction — keeps the algebra honest; omega then delivers both the difference form and the inequality C(2n,n+1) ≤ C(2n,n) for free.",
       "**One neighbour relation does the work.** Nat.choose_succ_right_eq, specialized at the central column with 2n - n = n, is exactly the fact (n+1)*C(2n,n+1) = n*C(2n,n) that, against the Catalan bridge, forces the partition.",
-      "**Reflection, arithmetically.** C(2n,n) counts all paths, C(2n,n+1) counts the reflected (bad) paths, and their difference is the Dyck count catalan n — André's reflection principle visible as a one-line identity."
+      "**Reflection, arithmetically.** C(2n,n) counts all paths, C(2n,n+1) counts the reflected (bad) paths, and their difference is the Dyck count catalan n — André's reflection principle visible as a one-line identity.",
+      "**The subtraction form trades a divisibility fact for an order fact.** Mathlib's division form catalan n = centralBinom n / (n+1) is exact only because (n+1) ∣ centralBinom n — a fact that must be established (or silently relied on) wherever that identity is used. The reflection form needs no divisibility argument at all: choose_succ_le_centralBinom supplies only the inequality C(2n,n+1) ≤ C(2n,n), which is all ℕ subtraction ever requires to avoid truncation, making the identity easier to deploy in contexts that have not already proved exact divisibility."
     ],
     "exampleSections": [
       {


### PR DESCRIPTION
Enrichment pass for `catalan-numbers-oq-01-oq-01` (quality 98).

`qualityBreakdown` showed everything at cap except `keyInsights: 8/10` (4 of
the 5-item cap). The existing 4 insights cover the proof technique (additive
partition, the one neighbour relation, reflection-principle framing) but not
why the subtraction form is worth having alongside Mathlib's existing division
form.

Added a 5th insight: Mathlib's `catalan_eq_centralBinom_div` is only exact
because `(n+1) ∣ centralBinom n`, a divisibility fact any downstream use must
establish or rely on; the reflection form instead only needs the order fact
`choose_succ_le_centralBinom : C(2n,n+1) ≤ C(2n,n)` (already proved in the
file) to avoid ℕ-subtraction truncation — an easier condition to supply in a
context that hasn't already proved exact divisibility. Verified directly
against `CatalanReflectionFormOQ01.lean`. No other content changed; `meta.json`
stays at ~14.3 KB, well under the 60 KB cap.