### PR TITLE
Enrich carnot-theorem-oq-01-oq-01: add 5th keyInsight

### DIFF
--- a/src/data/proofs/carnot-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/carnot-theorem-oq-01-oq-01/meta.json
@@ -85,7 +85,8 @@
       "**The gap to 3/2 is a perfect square plus a nonnegative product**: cos A + cos B + cos C = 3/2 - 2(sin(C/2) - 1/2)² - 2 sin(C/2)(1 - cos((A-B)/2)), so the bound, its equality case, and the equilateral extremizer all fall out of one decomposition",
       "**Range correspondence**: through the parent identity cos sum = 1 + r/R, the analytic range (1, 3/2] of the cosine sum is exactly the geometric range (0, 1/2] of r/R — Euler's inequality is the upper bound restated",
       "**Sign-agnostic**: the proof uses only A, B, C > 0 and A + B + C = π, avoiding the acute/obtuse case split that the metric signed-distance form of Carnot's theorem requires",
-      "**Two simple endpoint facts pin the extremizer**: sin(C/2) = 1/2 (via injectivity of sin near 0) gives C = π/3, and cos((A-B)/2) = 1 (via cos x = 1 ⟺ x = 0) gives A = B — together the equilateral triangle"
+      "**Two simple endpoint facts pin the extremizer**: sin(C/2) = 1/2 (via injectivity of sin near 0) gives C = π/3, and cos((A-B)/2) = 1 (via cos x = 1 ⟺ x = 0) gives A = B — together the equilateral triangle",
+      "**The two bounds are attained asymmetrically**: the upper bound 3/2 is attained by an honest triangle (the equilateral one, `cos_sum_eq_three_halves_iff`), but the lower bound 1 is never attained for any A, B, C > 0 with A + B + C = π — it is only approached as the triangle degenerates (one angle → 0, the other two → supplementary), which is exactly why `one_lt_cos_sum` is stated as a strict inequality with no matching equality-case lemma."
     ],
     "prerequisites": [
       "Real trigonometric functions sin and cos",


### PR DESCRIPTION
Enrichment pass for `carnot-theorem-oq-01-oq-01` (quality 98).

`qualityBreakdown` showed everything at cap except `keyInsights: 8/10` (4 of
the 5-item cap). The existing 4 insights cover the algebraic decomposition,
the range correspondence to r/R, the sign-agnostic argument, and how the
extremizer is pinned down — none address why the file proves an equality case
for the upper bound but not the lower one.

Added a 5th insight: the upper bound 3/2 is attained by an honest triangle
(equilateral, `cos_sum_eq_three_halves_iff`), but the lower bound 1 is never
attained for any genuine triangle — only approached as it degenerates (one
angle → 0) — which is exactly why `one_lt_cos_sum` is a strict inequality with
no matching equality lemma. Verified directly against
`CarnotTheoremOQ01OQ01.lean`. No other content changed; `meta.json` stays at
~15 KB, well under the 60 KB cap.