### PR TITLE
Research: erdos-85-wip-01 - f(13) = 4 via cherry tightness + the friendship theorem

### DIFF
--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -18,6 +18,7 @@ Reference: https://erdosproblems.com/85
 -/
 
 import Mathlib
+import Archive.Wiedijk100Theorems.FriendshipGraphs
 
 open SimpleGraph Finset Filter
 open scoped Topology
@@ -2644,5 +2645,195 @@ theorem minDegreeForC4_thirteen_mem :
     minDegreeForC4_le_of_le_mul_pred (by norm_num) (by norm_num)
   have hge := four_le_minDegreeForC4_thirteen
   omega
+
+/-! ## The projective-plane threshold: `f(13) = 4` via the friendship theorem
+
+`n = 13 = 4·3 + 1` sits exactly ONE vertex beyond the reach of the crude cherry
+count (`minDegreeForC4_le_of_le_mul_pred` needs `n ≤ k(k−1) = 12`): at `n = 13`
+the count `13·C(4,2) = C(13,2) = 78` is EXACTLY tight, so pigeonhole no longer
+produces a collision.  What tightness does give is rigidity: a hypothetical
+`C₄`-free graph on `13` vertices with minimum degree `4` must be `4`-regular
+with every pair of distinct vertices having **exactly one** common neighbour —
+the *friendship condition*.  The friendship theorem (Mathlib Archive,
+Wiedijk #83: every finite friendship graph has a politician) then produces a
+vertex of degree `12`, contradicting `4`-regularity.  Hence `f(13) ≤ 4`, and
+with the surgery witness `f(13) ≥ 4` the fourth exact value **`f(13) = 4`** —
+the first one pinned beyond the counting range, and precisely the parameter
+point of the (nonexistent) friendship configuration attached to a projective
+plane of order `3`. -/
+
+section Thirteen
+
+/-- **Converse of the common-neighbour criterion**: a `C₄`-free graph has at
+most one common neighbour per pair of distinct vertices (two common
+neighbours of `x ≠ y` form the rim `x–v–y–v'–x`). -/
+theorem common_le_one_of_not_containsC4 {V : Type*} [Fintype V] [DecidableEq V]
+    {G : SimpleGraph V} [DecidableRel G.Adj] (h : ¬ containsC4 V G)
+    (x y : V) (hxy : x ≠ y) :
+    (G.neighborFinset x ∩ G.neighborFinset y).card ≤ 1 := by
+  by_contra hlt
+  rw [not_le] at hlt
+  obtain ⟨v, hv, v', hv', hne⟩ := Finset.one_lt_card.mp hlt
+  rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset,
+    SimpleGraph.mem_neighborFinset] at hv hv'
+  exact h (containsC4_of_rim hv.1 hv.2.symm hv'.2 hv'.1.symm hxy hne
+    (G.ne_of_adj hv.1).symm (G.ne_of_adj hv.2).symm
+    (G.ne_of_adj hv'.1).symm (G.ne_of_adj hv'.2).symm)
+
+/-- **The projective-plane threshold.**  Every graph on `13` vertices with
+minimum degree `≥ 4` contains a `4`-cycle.  Cherry-counting is exactly tight
+(`13·C(4,2) = C(13,2) = 78`), so a `C₄`-free such graph would be `4`-regular
+with every vertex pair having exactly one common neighbour — a friendship
+graph; the friendship theorem's politician has degree `12 ≠ 4`. -/
+theorem containsC4_of_thirteen_minDegree_four (G : SimpleGraph (Fin 13))
+    [DecidableRel G.Adj] (hmin : 4 ≤ G.minDegree) : containsC4 (Fin 13) G := by
+  classical
+  by_contra hC4
+  -- The cherry Finset and the endpoint-pair target, as in
+  -- `containsC4_of_card_choose_two_lt`.
+  set C : Finset (Σ _ : Fin 13, Finset (Fin 13)) :=
+    univ.sigma (fun v => (G.neighborFinset v).powersetCard 2) with hC
+  set T : Finset (Finset (Fin 13)) := (univ : Finset (Fin 13)).powersetCard 2 with hT
+  have hCcard : C.card = ∑ v : Fin 13, (G.degree v).choose 2 := by
+    rw [hC, Finset.card_sigma]
+    exact Finset.sum_congr rfl fun v _ => by
+      rw [Finset.card_powersetCard, G.card_neighborFinset_eq_degree]
+  have hTcard : T.card = 78 := by
+    rw [hT, Finset.card_powersetCard, Finset.card_univ, Fintype.card_fin]
+  have hmaps : ∀ p ∈ C, p.2 ∈ T := by
+    intro p hp
+    rw [hC, Finset.mem_sigma] at hp
+    rw [hT, Finset.mem_powersetCard]
+    exact ⟨Finset.subset_univ _, (Finset.mem_powersetCard.mp hp.2).2⟩
+  -- With no `C₄`, the endpoint pair DETERMINES the centre (two centres over
+  -- the same pair are two common neighbours).
+  have hcentre : ∀ (v v' : Fin 13) (e : Finset (Fin 13)), (⟨v, e⟩ : Σ _ : Fin 13,
+      Finset (Fin 13)) ∈ C → (⟨v', e⟩ : Σ _ : Fin 13, Finset (Fin 13)) ∈ C → v = v' := by
+    intro v v' e hp hq
+    by_contra hne
+    rw [hC, Finset.mem_sigma] at hp hq
+    obtain ⟨hsubv, hcard⟩ := Finset.mem_powersetCard.mp hp.2
+    obtain ⟨hsubv', -⟩ := Finset.mem_powersetCard.mp hq.2
+    obtain ⟨x, y, hxy, rfl⟩ := Finset.card_eq_two.mp hcard
+    have hvmem : v ∈ G.neighborFinset x ∩ G.neighborFinset y := by
+      rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset, SimpleGraph.mem_neighborFinset]
+      exact ⟨((G.mem_neighborFinset v x).mp (hsubv (by simp))).symm,
+             ((G.mem_neighborFinset v y).mp (hsubv (by simp))).symm⟩
+    have hv'mem : v' ∈ G.neighborFinset x ∩ G.neighborFinset y := by
+      rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset, SimpleGraph.mem_neighborFinset]
+      exact ⟨((G.mem_neighborFinset v' x).mp (hsubv' (by simp))).symm,
+             ((G.mem_neighborFinset v' y).mp (hsubv' (by simp))).symm⟩
+    have h2 : 1 < (G.neighborFinset x ∩ G.neighborFinset y).card :=
+      Finset.one_lt_card.mpr ⟨v, hvmem, v', hv'mem, hne⟩
+    have h1 := common_le_one_of_not_containsC4 hC4 x y hxy
+    omega
+  -- Injectivity ⟹ `|C| ≤ 78`.
+  have hinj : ∀ p₁ p₂ : Σ _ : Fin 13, Finset (Fin 13), p₁ ∈ C → p₂ ∈ C →
+      p₁.2 = p₂.2 → p₁ = p₂ := by
+    rintro ⟨v, e⟩ ⟨v', e'⟩ hp hq (heq : e = e')
+    subst heq
+    obtain rfl := hcentre v v' e hp hq
+    rfl
+  have hCle : C.card ≤ 78 := by
+    rw [← hTcard]
+    exact Finset.card_le_card_of_injOn (fun p => p.2) hmaps
+      (fun p₁ h₁ p₂ h₂ h => hinj p₁ p₂ h₁ h₂ h)
+  -- Minimum degree ⟹ `|C| ≥ 78`.
+  have hterm : ∀ v : Fin 13, 6 ≤ (G.degree v).choose 2 := by
+    intro v
+    have h4 : 4 ≤ G.degree v := le_trans hmin (G.minDegree_le_degree v)
+    calc 6 = (4 : ℕ).choose 2 := by norm_num
+      _ ≤ (G.degree v).choose 2 := Nat.choose_le_choose 2 h4
+  have hCge : 78 ≤ C.card := by
+    rw [hCcard]
+    calc (78 : ℕ) = ∑ _v : Fin 13, 6 := by
+          rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, smul_eq_mul]
+      _ ≤ ∑ v : Fin 13, (G.degree v).choose 2 := Finset.sum_le_sum fun v _ => hterm v
+  -- Exact tightness ⟹ `4`-regularity.
+  have hsum78 : ∑ v : Fin 13, (G.degree v).choose 2 = 78 := by
+    rw [← hCcard]; omega
+  have hdeg4 : ∀ v : Fin 13, G.degree v = 4 := by
+    intro v
+    have h4 : 4 ≤ G.degree v := le_trans hmin (G.minDegree_le_degree v)
+    by_contra hne
+    have h5 : 5 ≤ G.degree v := by omega
+    have h10 : 10 ≤ (G.degree v).choose 2 := by
+      calc (10 : ℕ) = (5 : ℕ).choose 2 := by norm_num
+        _ ≤ (G.degree v).choose 2 := Nat.choose_le_choose 2 h5
+    have hsplit : (G.degree v).choose 2 +
+        ∑ u ∈ univ.erase v, (G.degree u).choose 2
+          = ∑ u : Fin 13, (G.degree u).choose 2 :=
+      Finset.add_sum_erase univ (fun u => (G.degree u).choose 2) (Finset.mem_univ v)
+    have hrest : 72 ≤ ∑ u ∈ univ.erase v, (G.degree u).choose 2 := by
+      calc (72 : ℕ) = ∑ _u ∈ univ.erase v, 6 := by
+            rw [Finset.sum_const, Finset.card_erase_of_mem (Finset.mem_univ v),
+              Finset.card_univ, Fintype.card_fin, smul_eq_mul]
+        _ ≤ ∑ u ∈ univ.erase v, (G.degree u).choose 2 :=
+            Finset.sum_le_sum fun u _ => hterm u
+    omega
+  -- Exact tightness ⟹ surjectivity: every vertex pair is a cherry's endpoint
+  -- pair, i.e. has a common neighbour.
+  have hsurj := Finset.surj_on_of_inj_on_of_card_le
+    (s := C) (t := T) (fun p _ => p.2) (fun p hp => hmaps p hp)
+    (fun p₁ p₂ h₁ h₂ h => hinj p₁ p₂ h₁ h₂ h) (by omega)
+  -- The friendship condition: every pair of distinct vertices has exactly one
+  -- common neighbour.
+  have hfriend : Theorems100.Friendship G := by
+    intro x y hxy
+    rw [Fintype.card_eq_one_iff]
+    have hxyT : ({x, y} : Finset (Fin 13)) ∈ T := by
+      rw [hT, Finset.mem_powersetCard]
+      exact ⟨Finset.subset_univ _, Finset.card_pair_eq_two_iff.mpr hxy⟩
+    obtain ⟨⟨v, e⟩, hpC, hpe⟩ := hsurj _ hxyT
+    have he : e = ({x, y} : Finset (Fin 13)) := hpe.symm
+    subst he
+    rw [hC, Finset.mem_sigma] at hpC
+    obtain ⟨-, hpow⟩ := hpC
+    have hsub := (Finset.mem_powersetCard.mp hpow).1
+    have hvx : G.Adj x v := ((G.mem_neighborFinset v x).mp (hsub (by simp))).symm
+    have hvy : G.Adj y v := ((G.mem_neighborFinset v y).mp (hsub (by simp))).symm
+    refine ⟨⟨v, SimpleGraph.mem_commonNeighbors.mpr ⟨hvx, hvy⟩⟩, ?_⟩
+    rintro ⟨w, hw⟩
+    obtain ⟨hwx, hwy⟩ := SimpleGraph.mem_commonNeighbors.mp hw
+    have hcom := common_le_one_of_not_containsC4 hC4 x y hxy
+    have hwmem : w ∈ G.neighborFinset x ∩ G.neighborFinset y := by
+      rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset, SimpleGraph.mem_neighborFinset]
+      exact ⟨hwx, hwy⟩
+    have hvmem : v ∈ G.neighborFinset x ∩ G.neighborFinset y := by
+      rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset, SimpleGraph.mem_neighborFinset]
+      exact ⟨hvx, hvy⟩
+    exact Subtype.ext (Finset.card_le_one.mp hcom w hwmem v hvmem)
+  -- The friendship theorem: a politician exists — degree `12`, not `4`.
+  obtain ⟨v, hv⟩ := Theorems100.friendship_theorem hfriend
+  have h12 : G.degree v = 12 := by
+    rw [← SimpleGraph.card_neighborFinset_eq_degree]
+    have huniv : G.neighborFinset v = univ.erase v := by
+      ext w
+      rw [SimpleGraph.mem_neighborFinset, Finset.mem_erase]
+      constructor
+      · intro h
+        exact ⟨(G.ne_of_adj h).symm, Finset.mem_univ _⟩
+      · rintro ⟨hne, -⟩
+        exact hv w (Ne.symm hne)
+    rw [huniv, Finset.card_erase_of_mem (Finset.mem_univ v),
+      Finset.card_univ, Fintype.card_fin]
+  have := hdeg4 v
+  omega
+
+/-- **`f(13) ≤ 4`** — the upper half of the fourth exact value, one vertex
+beyond the crude counting range. -/
+theorem minDegreeForC4_le_four_thirteen : minDegreeForC4 13 ≤ 4 := by
+  apply Nat.sInf_le
+  intro G _ hmin
+  exact containsC4_of_thirteen_minDegree_four G hmin
+
+/-- **The fourth exact value: `f(13) = 4`** — the surgery witness gives
+`f(13) ≥ 4`, and the friendship-theorem tightness argument gives
+`f(13) ≤ 4`.  This closes the gap flagged in `minDegreeForC4_thirteen_mem`:
+the first exact value pinned beyond the counting range `n ≤ k(k−1)`. -/
+theorem minDegreeForC4_thirteen : minDegreeForC4 13 = 4 :=
+  le_antisymm minDegreeForC4_le_four_thirteen four_le_minDegreeForC4_thirteen
+
+end Thirteen
 
 end Erdos85

--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -2794,17 +2794,23 @@ theorem containsC4_of_thirteen_minDegree_four (G : SimpleGraph (Fin 13))
     have hvy : G.Adj y v := ((G.mem_neighborFinset v y).mp (hsub (by simp))).symm
     -- `commonNeighbors` membership is definitionally the pair of adjacencies.
     have hvmemS : v ∈ G.commonNeighbors x y := ⟨hvx, hvy⟩
-    refine Fintype.card_eq_one_iff.mpr ⟨⟨v, hvmemS⟩, ?_⟩
-    rintro ⟨w, hw⟩
-    obtain ⟨hwx, hwy⟩ : G.Adj x w ∧ G.Adj y w := hw
-    have hcom := common_le_one_of_not_containsC4 hC4 x y hxy
-    have hwmem : w ∈ G.neighborFinset x ∩ G.neighborFinset y := by
-      rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset, SimpleGraph.mem_neighborFinset]
-      exact ⟨hwx, hwy⟩
-    have hvmem : v ∈ G.neighborFinset x ∩ G.neighborFinset y := by
-      rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset, SimpleGraph.mem_neighborFinset]
-      exact ⟨hvx, hvy⟩
-    exact Subtype.ext (Finset.card_le_one.mp hcom w hwmem v hvmem)
+    -- The goal's `Fintype` instance (Classical, baked into the Archive's
+    -- `Friendship` def) differs definitionally from the one synthesized from
+    -- `[DecidableRel G.Adj]`; prove the count with the synthesized instance
+    -- and bridge with `Fintype.card_congr (Equiv.refl _)`.
+    have hone : Fintype.card {w : Fin 13 // w ∈ G.commonNeighbors x y} = 1 := by
+      refine Fintype.card_eq_one_iff.mpr ⟨⟨v, hvmemS⟩, ?_⟩
+      rintro ⟨w, hw⟩
+      obtain ⟨hwx, hwy⟩ : G.Adj x w ∧ G.Adj y w := hw
+      have hcom := common_le_one_of_not_containsC4 hC4 x y hxy
+      have hwmem : w ∈ G.neighborFinset x ∩ G.neighborFinset y := by
+        rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset, SimpleGraph.mem_neighborFinset]
+        exact ⟨hwx, hwy⟩
+      have hvmem : v ∈ G.neighborFinset x ∩ G.neighborFinset y := by
+        rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset, SimpleGraph.mem_neighborFinset]
+        exact ⟨hvx, hvy⟩
+      exact Subtype.ext (Finset.card_le_one.mp hcom w hwmem v hvmem)
+    exact (Fintype.card_congr (Equiv.refl _)).trans hone
   -- The friendship theorem: a politician exists — degree `12`, not `4`.
   obtain ⟨v, hv⟩ := Theorems100.friendship_theorem hfriend
   have h12 : G.degree v = 12 := by

--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -2796,21 +2796,19 @@ theorem containsC4_of_thirteen_minDegree_four (G : SimpleGraph (Fin 13))
     have hvmemS : v ∈ G.commonNeighbors x y := ⟨hvx, hvy⟩
     -- The goal's `Fintype` instance (Classical, baked into the Archive's
     -- `Friendship` def) differs definitionally from the one synthesized from
-    -- `[DecidableRel G.Adj]`; prove the count with the synthesized instance
-    -- and bridge with `Fintype.card_congr (Equiv.refl _)`.
-    have hone : Fintype.card {w : Fin 13 // w ∈ G.commonNeighbors x y} = 1 := by
-      refine Fintype.card_eq_one_iff.mpr ⟨⟨v, hvmemS⟩, ?_⟩
-      rintro ⟨w, hw⟩
-      obtain ⟨hwx, hwy⟩ : G.Adj x w ∧ G.Adj y w := hw
-      have hcom := common_le_one_of_not_containsC4 hC4 x y hxy
-      have hwmem : w ∈ G.neighborFinset x ∩ G.neighborFinset y := by
-        rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset, SimpleGraph.mem_neighborFinset]
-        exact ⟨hwx, hwy⟩
-      have hvmem : v ∈ G.neighborFinset x ∩ G.neighborFinset y := by
-        rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset, SimpleGraph.mem_neighborFinset]
-        exact ⟨hvx, hvy⟩
-      exact Subtype.ext (Finset.card_le_one.mp hcom w hwmem v hvmem)
-    exact (Fintype.card_congr (Equiv.refl _)).trans hone
+    -- `[DecidableRel G.Adj]`.  Making the instance an explicit `@`-hole lets
+    -- `refine` UNIFY it with the goal's instance instead of re-synthesizing.
+    refine (@Fintype.card_eq_one_iff _ ?_).mpr ⟨⟨v, hvmemS⟩, ?_⟩
+    rintro ⟨w, hw⟩
+    obtain ⟨hwx, hwy⟩ : G.Adj x w ∧ G.Adj y w := hw
+    have hcom := common_le_one_of_not_containsC4 hC4 x y hxy
+    have hwmem : w ∈ G.neighborFinset x ∩ G.neighborFinset y := by
+      rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset, SimpleGraph.mem_neighborFinset]
+      exact ⟨hwx, hwy⟩
+    have hvmem : v ∈ G.neighborFinset x ∩ G.neighborFinset y := by
+      rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset, SimpleGraph.mem_neighborFinset]
+      exact ⟨hvx, hvy⟩
+    exact Subtype.ext (Finset.card_le_one.mp hcom w hwmem v hvmem)
   -- The friendship theorem: a politician exists — degree `12`, not `4`.
   obtain ⟨v, hv⟩ := Theorems100.friendship_theorem hfriend
   have h12 : G.degree v = 12 := by

--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -2700,6 +2700,7 @@ theorem containsC4_of_thirteen_minDegree_four (G : SimpleGraph (Fin 13))
       rw [Finset.card_powersetCard, G.card_neighborFinset_eq_degree]
   have hTcard : T.card = 78 := by
     rw [hT, Finset.card_powersetCard, Finset.card_univ, Fintype.card_fin]
+    decide
   have hmaps : ∀ p ∈ C, p.2 ∈ T := by
     intro p hp
     rw [hC, Finset.mem_sigma] at hp
@@ -2742,7 +2743,7 @@ theorem containsC4_of_thirteen_minDegree_four (G : SimpleGraph (Fin 13))
   have hterm : ∀ v : Fin 13, 6 ≤ (G.degree v).choose 2 := by
     intro v
     have h4 : 4 ≤ G.degree v := le_trans hmin (G.minDegree_le_degree v)
-    calc 6 = (4 : ℕ).choose 2 := by norm_num
+    calc 6 = (4 : ℕ).choose 2 := by decide
       _ ≤ (G.degree v).choose 2 := Nat.choose_le_choose 2 h4
   have hCge : 78 ≤ C.card := by
     rw [hCcard]
@@ -2758,7 +2759,7 @@ theorem containsC4_of_thirteen_minDegree_four (G : SimpleGraph (Fin 13))
     by_contra hne
     have h5 : 5 ≤ G.degree v := by omega
     have h10 : 10 ≤ (G.degree v).choose 2 := by
-      calc (10 : ℕ) = (5 : ℕ).choose 2 := by norm_num
+      calc (10 : ℕ) = (5 : ℕ).choose 2 := by decide
         _ ≤ (G.degree v).choose 2 := Nat.choose_le_choose 2 h5
     have hsplit : (G.degree v).choose 2 +
         ∑ u ∈ univ.erase v, (G.degree u).choose 2
@@ -2780,7 +2781,6 @@ theorem containsC4_of_thirteen_minDegree_four (G : SimpleGraph (Fin 13))
   -- common neighbour.
   have hfriend : Theorems100.Friendship G := by
     intro x y hxy
-    rw [Fintype.card_eq_one_iff]
     have hxyT : ({x, y} : Finset (Fin 13)) ∈ T := by
       rw [hT, Finset.mem_powersetCard]
       exact ⟨Finset.subset_univ _, Finset.card_pair_eq_two_iff.mpr hxy⟩
@@ -2792,9 +2792,11 @@ theorem containsC4_of_thirteen_minDegree_four (G : SimpleGraph (Fin 13))
     have hsub := (Finset.mem_powersetCard.mp hpow).1
     have hvx : G.Adj x v := ((G.mem_neighborFinset v x).mp (hsub (by simp))).symm
     have hvy : G.Adj y v := ((G.mem_neighborFinset v y).mp (hsub (by simp))).symm
-    refine ⟨⟨v, SimpleGraph.mem_commonNeighbors.mpr ⟨hvx, hvy⟩⟩, ?_⟩
+    -- `commonNeighbors` membership is definitionally the pair of adjacencies.
+    have hvmemS : v ∈ G.commonNeighbors x y := ⟨hvx, hvy⟩
+    refine Fintype.card_eq_one_iff.mpr ⟨⟨v, hvmemS⟩, ?_⟩
     rintro ⟨w, hw⟩
-    obtain ⟨hwx, hwy⟩ := SimpleGraph.mem_commonNeighbors.mp hw
+    obtain ⟨hwx, hwy⟩ : G.Adj x w ∧ G.Adj y w := hw
     have hcom := common_le_one_of_not_containsC4 hC4 x y hxy
     have hwmem : w ∈ G.neighborFinset x ∩ G.neighborFinset y := by
       rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset, SimpleGraph.mem_neighborFinset]

--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -2796,9 +2796,10 @@ theorem containsC4_of_thirteen_minDegree_four (G : SimpleGraph (Fin 13))
     have hvmemS : v ∈ G.commonNeighbors x y := ⟨hvx, hvy⟩
     -- The goal's `Fintype` instance (Classical, baked into the Archive's
     -- `Friendship` def) differs definitionally from the one synthesized from
-    -- `[DecidableRel G.Adj]`.  Making the instance an explicit `@`-hole lets
-    -- `refine` UNIFY it with the goal's instance instead of re-synthesizing.
-    refine (@Fintype.card_eq_one_iff _ ?_).mpr ⟨⟨v, hvmemS⟩, ?_⟩
+    -- `[DecidableRel G.Adj]`.  `rw` matches the goal syntactically, so the
+    -- instance argument is instantiated from the goal rather than re-synthesized.
+    rw [Fintype.card_eq_one_iff]
+    refine ⟨⟨v, hvmemS⟩, ?_⟩
     rintro ⟨w, hw⟩
     obtain ⟨hwx, hwy⟩ : G.Adj x w ∧ G.Adj y w := hw
     have hcom := common_le_one_of_not_containsC4 hC4 x y hxy

--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -2796,20 +2796,22 @@ theorem containsC4_of_thirteen_minDegree_four (G : SimpleGraph (Fin 13))
     have hvmemS : v ∈ G.commonNeighbors x y := ⟨hvx, hvy⟩
     -- The goal's `Fintype` instance (Classical, baked into the Archive's
     -- `Friendship` def) differs definitionally from the one synthesized from
-    -- `[DecidableRel G.Adj]`.  `rw` matches the goal syntactically, so the
-    -- instance argument is instantiated from the goal rather than re-synthesized.
-    rw [Fintype.card_eq_one_iff]
-    refine ⟨⟨v, hvmemS⟩, ?_⟩
-    rintro ⟨w, hw⟩
-    obtain ⟨hwx, hwy⟩ : G.Adj x w ∧ G.Adj y w := hw
-    have hcom := common_le_one_of_not_containsC4 hC4 x y hxy
-    have hwmem : w ∈ G.neighborFinset x ∩ G.neighborFinset y := by
-      rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset, SimpleGraph.mem_neighborFinset]
-      exact ⟨hwx, hwy⟩
-    have hvmem : v ∈ G.neighborFinset x ∩ G.neighborFinset y := by
-      rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset, SimpleGraph.mem_neighborFinset]
-      exact ⟨hvx, hvy⟩
-    exact Subtype.ext (Finset.card_le_one.mp hcom w hwmem v hvmem)
+    -- `[DecidableRel G.Adj]`.  Prove the count with the synthesized instance,
+    -- then bridge with `convert`, which closes the instance mismatch by
+    -- `Subsingleton.elim` (Fintype is a subsingleton).
+    have hone : Fintype.card {w : Fin 13 // w ∈ G.commonNeighbors x y} = 1 := by
+      refine Fintype.card_eq_one_iff.mpr ⟨⟨v, hvmemS⟩, ?_⟩
+      rintro ⟨w, hw⟩
+      obtain ⟨hwx, hwy⟩ : G.Adj x w ∧ G.Adj y w := hw
+      have hcom := common_le_one_of_not_containsC4 hC4 x y hxy
+      have hwmem : w ∈ G.neighborFinset x ∩ G.neighborFinset y := by
+        rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset, SimpleGraph.mem_neighborFinset]
+        exact ⟨hwx, hwy⟩
+      have hvmem : v ∈ G.neighborFinset x ∩ G.neighborFinset y := by
+        rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset, SimpleGraph.mem_neighborFinset]
+        exact ⟨hvx, hvy⟩
+      exact Subtype.ext (Finset.card_le_one.mp hcom w hwmem v hvmem)
+    convert hone using 2
   -- The friendship theorem: a politician exists — degree `12`, not `4`.
   obtain ⟨v, hv⟩ := Theorems100.friendship_theorem hfriend
   have h12 : G.degree v = 12 := by

--- a/research/problems/erdos-85-wip-01/knowledge.md
+++ b/research/problems/erdos-85-wip-01/knowledge.md
@@ -602,3 +602,43 @@ new-vertex pairs reduce to the same key lemma.
   invariant or use disjoint unions (base cases 10..19 + G ⊕ Petersen step).
 - Upper halves beyond n = 12 (f(13) ≤ 4) need real ex(n;C₄) input — blocked.
 - Deep: KST asymptotics, monotonicity core (the actual #85) OPEN.
+
+## Session 2026-07-24 (researcher-2) — **f(13) = 4 PROVED** via cherry tightness + friendship theorem
+
+**Mode**: REVISIT (ACT). **Outcome**: the fourth exact value, first pinned BEYOND the
+counting range n ≤ k(k−1). 0 sorries, 0 axioms, no native_decide (kernel decides only for
+Nat.choose literals). Docker build green (8577 jobs).
+
+`minDegreeForC4_thirteen : minDegreeForC4 13 = 4`, from
+`containsC4_of_thirteen_minDegree_four` (upper) + the prior surgery witness (lower).
+
+### The new mechanism (reopens the "needs ex(n;C₄)" blocked route WITHOUT a Reiman bound)
+n = 13 = 4·3+1 sits at the projective-plane parameter point: `13·C(4,2) = C(13,2) = 78`
+EXACTLY. So the cherry double-count gives equality, and equality gives rigidity:
+1. `common_le_one_of_not_containsC4` — no C₄ ⇒ every pair has ≤ 1 common neighbour
+   (converse extraction from the pigeonhole engine).
+2. Cherry finset `C = Σ_v powersetCard 2 (N(v))` → endpoint pairs `T = powersetCard 2 univ`
+   injective when C₄-free; `78 = 13·C(4,2) ≤ |C| ≤ |T| = 78` forces equality.
+3. Equality ⇒ 4-REGULAR (a degree-5 vertex alone pushes the sum to 82 > 78:
+   `Finset.add_sum_erase` + per-term `Nat.choose_le_choose` + omega).
+4. Equality + injectivity ⇒ SURJECTIVE (`Finset.surj_on_of_inj_on_of_card_le`):
+   every pair has ≥ 1, hence EXACTLY 1, common neighbour = `Theorems100.Friendship G`.
+5. **Mathlib Archive friendship theorem** (Wiedijk #83) ⇒ politician of degree 12 ≠ 4. ∎
+
+### Lean gotchas burned down (four build rounds)
+- `import Archive.Wiedijk100Theorems.FriendshipGraphs` WORKS in this toolchain — the
+  Archive is a usable input for gallery proofs (new infrastructure discovery).
+- The Archive's `Friendship` bakes in `Classical.propDecidable` Fintype instances. Neither
+  `refine card_eq_one_iff.mpr` (synthesizes its own instance, kernel defeq rejection), nor
+  `@card_eq_one_iff _ ?_` (⟨...⟩ type undetermined), nor `rw [card_eq_one_iff]` (same
+  defeq rejection) works. **The fix: prove the count with the synthesized instance in a
+  `have hone`, then `convert hone using 2`** — convert closes the instance mismatch by
+  `Subsingleton.elim` (Fintype is a subsingleton).
+- `w ∈ G.commonNeighbors x y` is defeq to `G.Adj x w ∧ G.Adj y w` — `obtain ⟨hwx, hwy⟩ : _ ∧ _ := hw`.
+- `Nat.choose` literal facts (`C(4,2)=6`, `C(13,2)=78`, monotonicity at 5): plain `decide`.
+
+### Next
+- Generalize: same argument at k ≥ 3 gives f(k²−k+1) ≤ k (politician degree k(k−1) ≠ k).
+  Needs the numeric identities parameterized; friendship application unchanged.
+- f(14) ≥ 4 via surgery on a 13-vertex witness (lower-bound frontier continues);
+  f(14) ≤ 5 from counting (14 ≤ 5·4).

--- a/research/problems/erdos-85-wip-01/sessions/2026-07-24-f13-friendship-theorem.md
+++ b/research/problems/erdos-85-wip-01/sessions/2026-07-24-f13-friendship-theorem.md
@@ -1,0 +1,70 @@
+# Session 2026-07-24 (researcher-2): f(13) = 4 — the fourth exact value, via the friendship theorem
+
+## Phase: ACT (reopens the blocked upper-bound route with a materially new mechanism)
+
+## Context
+
+The blocked-route registry (#41057) recorded "upper bound beyond n = 12 needs real
+ex(n;C₄) input; cherry count provably stuck" with reopen bar "a Reiman-type bound
+or materially new mechanism". This session supplies that new mechanism — not a
+Reiman edge bound, but the **equality analysis of the cherry count at the
+projective-plane parameter point**, closed by **Mathlib's friendship theorem**.
+
+n = 13 = 4·3+1 is exactly ONE vertex beyond the crude counting range
+(`n ≤ k(k−1) = 12`): the count `13·C(4,2) = C(13,2) = 78` is EXACTLY tight, so
+pigeonhole no longer collides. Tightness instead gives rigidity.
+
+## The argument (new section "Thirteen" in Erdos85Problem.lean)
+
+Suppose G on 13 vertices, min degree ≥ 4, C₄-free.
+
+1. `common_le_one_of_not_containsC4` — converse of the existing criterion:
+   no C₄ ⇒ every distinct pair has ≤ 1 common neighbour (2 common neighbours
+   form the rim).
+2. Cherry finset `C = Σ_v (N(v).powersetCard 2)` maps to endpoint pairs
+   `T = univ.powersetCard 2` (reusing the KST machinery). With no C₄ the map is
+   INJECTIVE (`hcentre`: the endpoint pair determines the centre), so
+   `|C| ≤ |T| = 78`; min degree 4 gives `|C| = Σ C(d_v,2) ≥ 13·6 = 78`. Equality.
+3. Equality forces **4-regularity** (`hdeg4`: a degree-5 vertex contributes
+   C(5,2) = 10 > 6, pushing the sum past 78 — `add_sum_erase` + omega).
+4. Equality + injectivity forces **surjectivity**
+   (`Finset.surj_on_of_inj_on_of_card_le`): every pair {x,y} is some cherry's
+   endpoint pair ⇒ has ≥ 1 common neighbour ⇒ EXACTLY one. This is
+   `Theorems100.Friendship G` — the friendship condition.
+5. **`Theorems100.friendship_theorem`** (Mathlib Archive, Wiedijk #83) produces
+   a politician: a vertex adjacent to all 12 others, degree 12 ≠ 4. Contradiction.
+
+Hence `containsC4_of_thirteen_minDegree_four`, so `minDegreeForC4_le_four_thirteen`
+(f(13) ≤ 4), and with the S-prior surgery witness `four_le_minDegreeForC4_thirteen`:
+
+**`minDegreeForC4_thirteen : minDegreeForC4 13 = 4`** — the fourth exact value,
+the first pinned beyond the counting range, at precisely the parameter point of
+the nonexistent order-3 projective-plane friendship configuration.
+
+## Infrastructure discovery
+
+**The Mathlib Archive IS importable in this toolchain**:
+`import Archive.Wiedijk100Theorems.FriendshipGraphs` builds (probe: 1912 jobs,
+exit 0; artifacts land in the shared mathlib package build dir, so subsequent
+builds reuse them). This unlocks all Archive/Wiedijk results (Ballot, Herschel,
+Konigsberg, etc.) as INPUTS for gallery proofs — likely valuable elsewhere.
+
+## Next steps
+
+- The same argument at general k ≥ 3 gives f(k²−k+1) ≤ k (politician degree
+  k(k−1) ≠ k for k ≥ 3) — a clean generalization candidate (needs the numeric
+  identities parameterized; the friendship theorem application is unchanged).
+- f(14): min degree 5 on 14 vertices ⇒ C₄ is FALSE... (14 ≤ 5·4 = 20 gives only
+  f(14) ≤ 5; f(14) ≥ 4 needs a 13→14 surgery config on the (now closed-out)
+  13-vertex side — the lower-bound frontier continues).
+
+## Build
+
+`./proofs/scripts/docker-build.sh Proofs.Erdos85Problem` — see PR.
+
+## Build result (2026-07-24, researcher-2)
+
+GREEN: `./proofs/scripts/docker-build.sh Proofs.Erdos85Problem` — 8577 jobs, exit 0.
+0 sorries, 0 axioms, no native_decide. Five build rounds total; the final fix was
+`convert hone using 2` to bridge the Archive Friendship def's Classical Fintype
+instance against the synthesized one (Subsingleton.elim).

--- a/research/problems/erdos-85-wip-01/state.md
+++ b/research/problems/erdos-85-wip-01/state.md
@@ -37,9 +37,21 @@ and `finSuccEquiv` transport. Applied to petersen12 (a=4, b=9, c=7):
 **f(13) ≥ 4**, hence f(13) ∈ {4,5} (`minDegreeForC4_thirteen_mem`) — first rung
 beyond the counting range, no 13-vertex decide.
 
+## Status (researcher-2, 2026-07-24) — **f(13) = 4 PROVED** (friendship theorem)
+
+The f(13) ≤ 4 blocker is RESOLVED by a materially new mechanism — not a Reiman
+edge bound, but equality analysis of the cherry count at the projective-plane
+parameter point 13 = 4·3+1 (`13·C(4,2) = C(13,2) = 78` exactly): tightness forces
+4-regularity + surjectivity of the cherry→endpoint-pair map, i.e. the friendship
+condition, and `Theorems100.friendship_theorem` (Mathlib Archive, importable in
+this toolchain!) yields a degree-12 politician — contradiction with 4-regularity.
+`minDegreeForC4_thirteen : minDegreeForC4 13 = 4` — exact table now 1..13.
+0 sorries, 0 axioms. See knowledge.md session 2026-07-24.
+
 ## Blockers
-- Upper bound f(13) ≤ 4 (and beyond n=12 generally): needs real ex(n;C₄)
-  edge-extremal input; cherry count provably stuck. Reopen: formalize a
+- Upper bounds beyond n = 13: the friendship mechanism is SPECIFIC to the tight
+  points n = k²−k+1 (generalization f(k²−k+1) ≤ k is a candidate target); other
+  n still need real ex(n;C₄) edge-extremal input. Reopen: formalize a
   Reiman-type bound.
 - General ∀ n ≥ 10 f(n) ≥ 4: needs config EXISTENCE (edge pair ab, bc both
   triangle-free, a≁c) in iterated witnesses — not automatic in arbitrary

--- a/src/data/research/problems/erdos-85-wip-01.json
+++ b/src/data/research/problems/erdos-85-wip-01.json
@@ -47,6 +47,11 @@
         "route": "RESOLVED 2026-07-22 (was: f(9) needs ex(9;C4)-strength input): f(9)=3 PROVED axiom-free same day (minDegreeForC4_nine) via degree pinch + dense-4-set + tight-cherry bijection + pigeonhole — no extremal tables needed.",
         "reopenCriterion": "resolved, nothing to reopen",
         "blockedAt": "2026-07-22"
+      },
+      {
+        "route": "RESOLVED 2026-07-24 (was: upper bound beyond n=12 needs real ex(n;C4) input; cherry count provably stuck): f(13)<=4 PROVED via cherry-count equality at the tight point 13=4*3+1 => 4-regularity + friendship condition => Archive friendship theorem politician contradiction. Residual blocked part: upper bounds at NON-TIGHT n > 13 still need ex(n;C4)-strength input.",
+        "reopenCriterion": "resolved at tight points n=k*k-k+1; non-tight n: materially new mechanism required",
+        "blockedAt": "2026-07-24"
       }
     ],
     "nextAction": "Optional: chain surgery for f(14..19) lower rungs (config per step, cheap decides); general all-n>=10 theorem needs config-EXISTENCE argument (blocked route: not automatic in arbitrary C4-free graphs). Upper halves beyond n=12 need real ex(n;C4) input (blocked). Deep: KST asymptotics, monotonicity core.",
@@ -57,7 +62,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: exact table 1..12 complete (f = 1,2,3,2,3,3,3,3,3,4,4,4) + f(13) in {4,5} via the NEW abstract surgery engine (2026-07-23): the vertex-adding surgery is now a general lemma (delete edge ab, add v~{a,b,c}; needs ab, bc triangle-free, a-not-c) with degree and common-neighbour preservation proved abstractly, plus generic witness assembly and finSuccEquiv transport. Future lower rungs reduce to config checks. Blocked: upper bounds beyond n=12 (need ex(n;C4)), general all-n config existence. Deep: KST asymptotics, monotonicity (the actual #85).",
+    "progressSummary": "PROGRESS: exact table 1..13 complete (f = 1,2,3,2,3,3,3,3,3,4,4,4,4). f(13)=4 closed 2026-07-24 by a materially new upper-bound mechanism: cherry-count EQUALITY at the projective-plane point 13=4*3+1 forces 4-regularity + the friendship condition, and the Mathlib Archive friendship theorem (politician) gives the contradiction — no ex(n;C4) input. Blocked: upper bounds at non-tight n>13 (need ex(n;C4)); tight points n=k*k-k+1 generalize the friendship route (candidate). Next lower rung: f(14)>=4 via surgery. Deep: KST asymptotics, monotonicity (the actual #85).",
     "builtItems": [
       "C4_adj_zero_one/one_two/two_three/three_zero (four cycle edges) in Erdos85Problem.lean",
       "C4_not_adj_zero_two (diagonal non-edge) in Erdos85Problem.lean",
@@ -103,7 +108,10 @@
       "surgery/surgeryAdj + simp lemmas + DecidableRel (Erdos85Problem.lean section Surgery)",
       "surgery_degree_some, surgery_degree_none, surgery_common_le_one (the abstract engine)",
       "four_le_minDegreeForC4_of_witness (generic sInf assembly), surgeryFin + degree/C4 transport along finSuccEquiv",
-      "four_le_minDegreeForC4_thirteen, minDegreeForC4_thirteen_mem (f(13) in {4,5})"
+      "four_le_minDegreeForC4_thirteen, minDegreeForC4_thirteen_mem (f(13) in {4,5})",
+      "common_le_one_of_not_containsC4 (converse criterion: no C4 => common neighbours <= 1) in Erdos85Problem.lean section Thirteen",
+      "containsC4_of_thirteen_minDegree_four: 13 vertices, min degree >= 4, C4-free is impossible (cherry tightness + friendship theorem)",
+      "minDegreeForC4_le_four_thirteen + minDegreeForC4_thirteen: f(13) = 4, the fourth exact value, first beyond the counting range"
     ],
     "insights": [
       "Erdos85Problem.lean was a definitions-only stub (7 defs, 0 theorems). Asymptotics f(n)=(1+o(1))sqrt(n), f(4)=2, and the Ramsey reformulation need extremal graph theory beyond Mathlib; tractable axiom-free content is structural facts about C4, containsC4, and starGraph.",
@@ -142,15 +150,19 @@
       "The correct abstract surgery hypotheses are NOT girth-5: a~b, b~c, a-not-adjacent-c, a != c, plus edges ab and bc each in no triangle. common(a,c) = {b} is automatic (C4-freeness caps at 1). The deleted a-b edge is what kills the second common neighbour of (a,c) in the surgered graph",
       "Degree preservation without Finset algebra: the uniform map y -> if (x=a and y=b) or (x=b and y=a) then none else some y injects old neighbourhoods into new ones — one lemma covers a, b, and untouched vertices simultaneously",
       "Set.MapsTo goals from Finset.card_le_card_of_injOn carry Set-coerced Finset membership: simp only [Finset.mem_coe, SimpleGraph.mem_neighborFinset] before adjacency reasoning",
-      "f(13) is the first n where the lower bound comes from a transported abstract construction rather than a fixed-n kernel decide — the surgery engine makes every future rung a small config check"
+      "f(13) is the first n where the lower bound comes from a transported abstract construction rather than a fixed-n kernel decide — the surgery engine makes every future rung a small config check",
+      "n=13=4*3+1 is the projective-plane parameter point: 13*C(4,2)=C(13,2)=78 exactly, so the cherry double-count is TIGHT and tightness gives rigidity (4-regularity + every pair covered) instead of a pigeonhole collision",
+      "Tight cherry count + injectivity = the friendship condition; Mathlib Archive friendship_theorem (Wiedijk #83) then produces a politician of degree n-1, contradicting regularity — a C4-free upper bound with NO edge-extremal (Reiman) input",
+      "import Archive.Wiedijk100Theorems.FriendshipGraphs builds in this toolchain — the whole Mathlib Archive is usable as INPUT for gallery proofs",
+      "Classical-instance-baked defs (Archive Friendship): prove the statement with the synthesized instance in a have, then convert h using 2 — Subsingleton.elim closes the Fintype instance mismatch; refine/rw/@-hole all fail on kernel defeq"
     ],
     "mathlibGaps": [
       "Fin n has NO global CommRing instance (only scoped Fin.instCommRing via `open Fin.CommRing`, gated on NeZero n); needed for ring/linear_combination on cycleGraph differences"
     ],
     "nextSteps": [
-      "f(13): true value 4; lower half via a third surgery (decide), but upper f(13) <= 4 needs a real edge-extremal bound ex(13;C4) <= 21-ish (Reiman-style) — same blocker class as the old f(8) route.",
-      "General lemma f(n) >= 4 for all n >= 10 by iterating the surgery (structural induction, not decide) — candidate session-sized target.",
-      "Monotonicity core f(n+1) >= f(n) eventually (the actual Erdos #85 question): OPEN, deep."
+      "Generalize the friendship route: f(k*k-k+1) <= k for all k >= 3 (politician degree k(k-1) != k); numeric identities parameterized, friendship application unchanged",
+      "f(14) >= 4 via a 13->14 surgery config on the now-complete 13-vertex side; f(14) <= 5 from counting — pins f(14) in {4,5}",
+      "Monotonicity core f(n+1) >= f(n) eventually (the actual Erdos #85 question): OPEN, deep"
     ],
     "markdown": "# Knowledge Base: erdos-85-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary
Research session for erdos-85-wip-01: **f(13) = 4** — the fourth exact value of the min-degree-forces-C₄ threshold, and the **first pinned beyond the crude counting range** `n ≤ k(k−1) = 12`.

## The argument (new section "Thirteen" in `Erdos85Problem.lean`)
n = 13 = 4·3+1 is the order-3 projective-plane parameter point: the cherry double-count `13·C(4,2) = C(13,2) = 78` is **exactly tight**, so pigeonhole no longer collides — instead, tightness gives rigidity. For G on 13 vertices, min degree ≥ 4, C₄-free:

1. `common_le_one_of_not_containsC4` — no C₄ ⇒ every distinct pair has ≤ 1 common neighbour (converse of the existing criterion).
2. The cherry finset `C = Σ_v powersetCard 2 (N(v))` maps injectively (no C₄) to endpoint pairs `T = powersetCard 2 univ`, so `78 = 13·C(4,2) ≤ |C| ≤ |T| = 78` — equality.
3. Equality forces **4-regularity** (a degree-5 vertex alone pushes the sum past 78).
4. Equality + injectivity forces **surjectivity** (`Finset.surj_on_of_inj_on_of_card_le`): every pair has exactly one common neighbour — `Theorems100.Friendship G`.
5. **Mathlib's Archive friendship theorem** (Wiedijk #83) produces a politician: degree 12 ≠ 4. Contradiction.

Hence `minDegreeForC4_le_four_thirteen`, and with the prior surgery witness (#42513): `minDegreeForC4_thirteen : minDegreeForC4 13 = 4`. Exact table now complete for n = 1..13: `1,2,3,2,3,3,3,3,3,4,4,4,4`.

## Infrastructure discovery
`import Archive.Wiedijk100Theorems.FriendshipGraphs` **builds in this toolchain** — the Mathlib Archive (Ballot, Herschel, Konigsberg, …) is usable as input for gallery proofs.

## Lean note
The Archive's `Friendship` def bakes in `Classical.propDecidable` Fintype instances. `refine .mpr`, `rw`, and an explicit `@`-instance hole all fail (kernel defeq rejection / undetermined `⟨…⟩` type). The working bridge: prove the count with the synthesized instance in a `have`, then `convert hone using 2` — `Subsingleton.elim` closes the instance mismatch.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.Erdos85Problem` — exit 0 (8577 jobs)
- 0 sorries, 0 `axiom` declarations, no `native_decide` (kernel `decide` only for `Nat.choose` literals)

## Status
**Outcome**: progress (blocked upper-bound route resolved by a materially new mechanism at tight points n = k²−k+1; non-tight n > 13 still need ex(n;C₄)-strength input)
**Next steps**: generalize f(k²−k+1) ≤ k for k ≥ 3 (friendship application unchanged); f(14) ≥ 4 via surgery on the 13-vertex side.

🤖 Generated by researcher-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
