### PR TITLE
Cross-reference even-n sibling: burnside-counting-oq-05-oq-02

### DIFF
--- a/src/data/proofs/burnside-counting-oq-05-oq-02/meta.json
+++ b/src/data/proofs/burnside-counting-oq-05-oq-02/meta.json
@@ -138,6 +138,11 @@
       "targetId": "burnside-counting-oq-03",
       "relationship": "related",
       "description": "Reuses the oq-03 Pólya rotation identity ∑_{r} k^gcd(r,n) = ∑_{d|n} φ(n/d) k^d as the rotation half of the assembled dihedral total."
+    },
+    {
+      "targetId": "burnside-counting-oq-05-oq-01",
+      "relationship": "sibling",
+      "description": "The even-n counterpart: already supplies both reflection counts needed for openQuestions[1] here (vertex-axis k^(n/2+1), edge-axis k^(n/2)), but does not yet assemble them with the rotation total into an even bracelet count. This file's odd-case assembly (dihedralTotal, braceletCount) is the direct template for that remaining step."
     }
   ],
   "conclusion": {
@@ -145,7 +150,7 @@
     "implications": "Completes the dihedral half of the Burnside/Pólya necklace program for odd cycles in verified form, reusing the rotation and reflection counts rather than re-deriving them, and exhibits the tetrahedral-number identity B(3,k) = C(k+2,3) as a dihedral bracelet count.",
     "openQuestions": [
       "Can braceletCount be identified with the literal orbit count of DihedralGroup n acting on colorings, via Mathlib's MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group, giving the general integral count for all odd n rather than case by case?",
-      "What is the even-n bracelet count, where reflections split into vertex-axis and edge-axis types with different fixed-point counts?"
+      "What is the even-n bracelet count, where reflections split into vertex-axis and edge-axis types with different fixed-point counts? `burnside-counting-oq-05-oq-01` already supplies both counts (k^(n/2+1) and k^(n/2)); only the assembly into a Burnside-average bracelet count, following the odd-case pattern here, remains."
     ]
   },
   "leanFile": {


### PR DESCRIPTION
## Summary
- `burnside-counting-oq-05-oq-02` (odd-cycle dihedral bracelet assembly) asks in `openQuestions[1]` for the even-n bracelet count, where reflections split into vertex-axis and edge-axis types with different fixed-point counts.
- The sibling entry `burnside-counting-oq-05-oq-01` already proves exactly those two counts (`k^(n/2+1)` and `k^(n/2)`), but this entry had no reciprocal cross-reference pointing to it.
- Adds a `sibling` `crossReferences` entry noting the sibling supplies the missing reflection-count building blocks, and points `openQuestions[1]` at it — this file's `dihedralTotal`/`braceletCount` odd-case assembly is the direct template for the remaining even-case assembly step.
- No content deleted; existing text preserved.

## Test plan
- [x] `python3 -c "import json; json.load(open('src/data/proofs/burnside-counting-oq-05-oq-02/meta.json'))"` — valid JSON
- [x] File remains well under the 60 KB size cap (13.6 KB)
- [x] Full `pnpm build` blocked in this worktree by a pre-existing missing-`tsc`/node-v26 `better-sqlite3` build environment issue, unrelated to this change