### PR TITLE
research(szemeredi-full-oq-01): S14 — Prokhorov axiom eliminated; Furstenberg OQ01 file fully verified [0 ax / 0 sorry]

### DIFF
--- a/proofs/Proofs/FurstenbergCorrespondenceOQ01.lean
+++ b/proofs/Proofs/FurstenbergCorrespondenceOQ01.lean
@@ -295,7 +295,7 @@ This satisfies μ_{a,N}(B₀) = |A ∩ [a,a+N)| / N ≥ δ. **Proved below.**
 
 **Step 2**: Extract a convergent subsequence from these measures
   (Prokhorov's theorem: compact space → tight → convergent subsequence).
-  Stated as a local axiom (Mathlib v4.26 has ingredients but not assembled).
+  Proved (S14) via Mathlib v4.31's `Mathlib.MeasureTheory.Measure.Prokhorov`.
 
 **Step 3**: Any limit point is T-invariant with μ(B₀) ≥ δ.
   T-invariance: |∫f d(T_*(μ_{a,N})) - ∫f dμ_{a,N}| ≤ 2‖f‖/N → 0.
@@ -578,7 +578,7 @@ theorem cesaroMeasure_preimage_ge (x : CantorSpace) (N : ℕ)
 end TInvariance
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
-PART IX: THE MINIMAL REMAINING AXIOM (PROKHOROV)
+PART IX: PROKHOROV SEQUENTIAL COMPACTNESS (former axiom, proved in S14)
 ═══════════════════════════════════════════════════════════════════════════════ -/
 
 /-!
@@ -597,28 +597,33 @@ What remains:
    So any limit μ is T-invariant.
 3. **Density at limit**: μ(B₀) ≥ δ (by lower semi-continuity + density lower bound).
 
-Mathlib v4.26.0 has the ingredients:
-- `IsTightMeasureSet.of_compactSpace` (all measures tight on compact spaces)
-- `LevyProkhorov.eq_convergenceInDistribution` (metrizes weak convergence)
-- `WeakDual.isSeqCompact_closedBall` (sequential Banach-Alaoglu)
-
-The gap is ~150–200 lines assembling these into sequential compactness for
-`ProbabilityMeasure CantorSpace`.
+Mathlib v4.31 closed this gap upstream: `Mathlib.MeasureTheory.Measure.Prokhorov`
+(Gouëzel, 2025) provides `CompactSpace (ProbabilityMeasure E)` for any compact
+`E`, and `Mathlib.MeasureTheory.Measure.LevyProkhorovMetric` provides
+`MetrizableSpace (ProbabilityMeasure X)` for separable pseudo-metrizable Borel
+`X` — so sequential compactness follows from general topology
+(`CompactSpace.tendsto_subseq`), with no hand-assembly needed.
 -/
 
-/-- **Local Axiom (Prokhorov)**: Sequential compactness of probability measures
-    on Cantor space ℕ → Bool in the weak-* topology.
+/-- **Prokhorov (S14: former local axiom, now a theorem)**: Sequential
+    compactness of probability measures on Cantor space ℕ → Bool in the
+    topology of weak convergence.
 
-    Mathematical status: This is a standard consequence of Prokhorov's theorem.
-    Cantor space is compact metrizable separable. All sets of probability measures
-    on a compact space are tight (Mathlib: `IsTightMeasureSet.of_compactSpace`).
-    Prokhorov's theorem (tight + compact metrizable → sequentially compact)
-    then applies. Estimated formalization: ~150–200 lines. -/
-axiom seqCompact_probabilityMeasure_cantor :
+    Cantor space is compact, T2, second-countable and Borel, so Mathlib's
+    Prokhorov instance (`Mathlib.MeasureTheory.Measure.Prokhorov`, 2025) makes
+    `ProbabilityMeasure CantorSpace` a **compact** space; the Lévy–Prokhorov
+    metrization makes it **metrizable**, hence first-countable. A sequence in
+    a compact first-countable space has a convergent subsequence
+    (`CompactSpace.tendsto_subseq`). The 2026-05 estimate of "~150–200 lines
+    of assembly" is now three lines of instance plumbing. -/
+theorem seqCompact_probabilityMeasure_cantor :
     ∀ (f : ℕ → ProbabilityMeasure CantorSpace),
     ∃ (φ : ℕ → ℕ), StrictMono φ ∧
     ∃ μ : ProbabilityMeasure CantorSpace,
-    Filter.Tendsto (fun k => f (φ k)) Filter.atTop (nhds μ)
+    Filter.Tendsto (fun k => f (φ k)) Filter.atTop (nhds μ) := by
+  intro f
+  obtain ⟨μ, φ, hφ, hconv⟩ := CompactSpace.tendsto_subseq f
+  exact ⟨φ, hφ, μ, hconv⟩
 
 /-!
 ### Progress Summary
@@ -635,7 +640,7 @@ axiom seqCompact_probabilityMeasure_cantor :
 | `mem_cylinderZero_shifted` | ✅ Proved | This session |
 | `cesaroMeasure_cylinderZero` (orbit-density formula) | ✅ Proved | This session |
 | `density_lower_bound` (elementary half) | ✅ Proved | This session |
-| Prokhorov sequential compactness | ⚠ Local axiom | Session 2 |
+| Prokhorov sequential compactness | ✅ Proved (S14) | Session 2 → S14 |
 | T-invariance telescoping bound | ✅ Proved | Session 3 |
 | Density preservation at limit | ❌ Remaining | ~30 lines |
 
@@ -900,7 +905,7 @@ We now have all the components to prove the Furstenberg correspondence principle
 
 **Components (all proved except Prokhorov)**:
 - `density_lower_bound`: Cesàro measures have μ(B₀) ≥ δ (Part VIII)
-- `seqCompact_probabilityMeasure_cantor`: Prokhorov compactness (Part IX, axiom)
+- `seqCompact_probabilityMeasure_cantor`: Prokhorov compactness (Part IX, proved S14)
 - `density_preserved_at_limit`: μ(B₀) ≥ δ at limit (Part X, proved)
 - `cesaroMeasure_preimage_le/ge`: approximate T-invariance (Part VIII-b, proved)
 - `limit_invariant_on_cylinder`: exact T-invariance at the limit on clopen
@@ -908,8 +913,9 @@ We now have all the components to prove the Furstenberg correspondence principle
   1/(N+1) error + le_of_tendsto_of_tendsto')
 - `positive_measure_gives_ap`: positive measure → AP (Part XIII, proved)
 
-**Remaining sorries**: 0. The sole remaining assumption is the Prokhorov
-axiom `seqCompact_probabilityMeasure_cantor` (Part IX).
+**Remaining sorries**: 0. **Remaining axioms**: 0 — the former Prokhorov
+local axiom `seqCompact_probabilityMeasure_cantor` (Part IX) was proved in
+S14 from Mathlib v4.31's Prokhorov + Lévy–Prokhorov metrization instances.
 
 **Architecture**: We construct the `Furstenberg.System` directly on Cantor space:
 - X = CantorSpace, T = shift, B = cylinderZero
@@ -937,7 +943,7 @@ axiom `seqCompact_probabilityMeasure_cantor` (Part IX).
 | `cesaroMeasure` + `cesaroMeasure_isProbability` | ✅ Proved | 2 |
 | `cesaroMeasure_cylinderZero` (orbit-density formula) | ✅ Proved | 2 |
 | `density_lower_bound` (elementary half) | ✅ Proved | 2 |
-| Prokhorov sequential compactness | ⚠ Axiom | 2 |
+| Prokhorov sequential compactness | ✅ Proved (S14) | 2 → S14 |
 | T-invariance telescoping bounds | ✅ Proved | 3 |
 | `density_preserved_at_limit` (Portmanteau) | ✅ Proved | 4 |
 | `cylinder_measure_tendsto_of_tendsto` | ✅ Proved | 4 |

--- a/research/problems/szemeredi-full-oq-01/state.md
+++ b/research/problems/szemeredi-full-oq-01/state.md
@@ -1,5 +1,25 @@
 # Research State: szemeredi-full-oq-01
 
+> **S14 (2026-07-24, researcher-1): PROKHOROV AXIOM ELIMINATED — file now
+> 0 axioms / 0 sorries, Docker-GREEN first try (8576 jobs).** The S13b note's
+> "~150–200 lines" estimate collapsed to a 3-line proof: Mathlib v4.31 ships
+> `Mathlib.MeasureTheory.Measure.Prokhorov` (Gouëzel, 2025) with
+> `instance [CompactSpace E] : CompactSpace (ProbabilityMeasure E)`, and
+> `LevyProkhorovMetric` provides `MetrizableSpace (ProbabilityMeasure X)`
+> for separable pseudo-metrizable Borel `X` — so `ProbabilityMeasure
+> CantorSpace` is compact + first-countable and
+> `CompactSpace.tendsto_subseq f` IS the axiom statement (typeclass search
+> finds `BorelSpace (ℕ → Bool)` via `Pi.borelSpace` on its own).
+> `seqCompact_probabilityMeasure_cantor` converted `axiom → theorem`; 5
+> stale prose sites updated (Part IX header, 2 progress tables, Step-2 note,
+> honest-status block). Gallery `furstenberg-correspondence-oq-01`:
+> meta axiomatized/axiom/1 → **verified/original/0**, assumptions rewritten,
+> annotations 6/11/15 updated (11 retitled "Former Axiom, Now a Theorem").
+> **Next: S15 ACT — assemble `Furstenberg.System`** on (Ω, shift, B₀) from
+> the now-complete pieces (all of: Prokhorov extraction, T-invariance at
+> limit, density preservation), then attack the parent
+> `FurstenbergCorrespondence.lean` correspondence axiom.
+
 > **S13b/S14-note (2026-07-23, researcher-2): S13 ACT EXECUTED — sorry 1→0,
 > BLOCKED state was STALE.** The S11 28-error build regression in
 > `FurstenbergCorrespondenceOQ01.lean` was repaired on main by the v4.31

--- a/src/data/proofs/furstenberg-correspondence-oq-01/annotations.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-01/annotations.json
@@ -159,7 +159,7 @@
     },
     "type": "concept",
     "title": "Compactness of Cantor Space and Gap Analysis",
-    "content": "Records that Cantor space $\\Omega = \\{0,1\\}^{\\mathbb N}$ is a `CompactSpace` and `MetrizableSpace` (from Tychonoff in Mathlib), the topological prerequisites for the measure-theoretic construction. The accompanying gap analysis enumerates exactly what is already proved (shift, cylinders, indicators, return property, orbit-density, compactness — all axiom-free) versus what the full Furstenberg correspondence still needs: Dirac/Cesàro measures, weak-* sequential compactness (Prokhorov), T-invariance of the limit, and the density lower bound. This honest scoping frames the rest of the file.",
+    "content": "Records that Cantor space $\\Omega = \\{0,1\\}^{\\mathbb N}$ is a `CompactSpace` and `MetrizableSpace` (from Tychonoff in Mathlib), the topological prerequisites for the measure-theoretic construction. The accompanying gap analysis enumerates exactly what is already proved (shift, cylinders, indicators, return property, orbit-density, compactness — all axiom-free) versus what the full Furstenberg correspondence still needed at the time: Dirac/Cesàro measures, weak-* sequential compactness (Prokhorov), T-invariance of the limit, and the density lower bound. Every one of these has since been discharged — the Prokhorov step last, in S14 (2026-07-24) — so the scoping list is now fully checked off.",
     "significance": "supporting",
     "relatedConcepts": "Cantor space $\\Omega = \\{0,1\\}^{\\mathbb N}$ is compact (Tychonoff) and metrizable, hence a Polish space — the setting in which probability measures form a weak-* sequentially compact (Prokhorov) family.",
     "mathContext": [
@@ -279,10 +279,15 @@
       "endLine": 637
     },
     "type": "concept",
-    "title": "The Minimal Remaining Axiom: Prokhorov Sequential Compactness",
-    "content": "Isolates the single classical analysis fact not yet assembled in Mathlib: every sequence of probability measures on Cantor space has a weak-* convergent subsequence (`seqCompact_probabilityMeasure_cantor`). Mathematically this is immediate from Prokhorov’s theorem — Cantor space is compact metrizable, so all probability-measure families are tight (`IsTightMeasureSet.of_compactSpace`) and tightness + Polish gives sequential compactness. The file documents that Mathlib v4.26 has the ingredients (`LevyProkhorov`, sequential Banach–Alaoglu) but not the ~150–200-line assembly, and so states it as a clearly-labelled local axiom rather than claiming it.",
+    "title": "Prokhorov Sequential Compactness: Former Axiom, Now a Theorem",
+    "content": "Proves (S14, 2026-07-24) the fact that was this file's single local axiom for fourteen sessions: every sequence of probability measures on Cantor space has a convergent subsequence in the topology of weak convergence (`seqCompact_probabilityMeasure_cantor`). The 2026-05 assessment estimated ~150–200 lines of assembly from tightness (`IsTightMeasureSet.of_compactSpace`) and the Lévy–Prokhorov metric; instead, Mathlib's 2025 Prokhorov development (`Mathlib.MeasureTheory.Measure.Prokhorov`, Gouëzel) supplies `CompactSpace (ProbabilityMeasure E)` for compact `E` outright, and the Lévy–Prokhorov metrization makes `ProbabilityMeasure CantorSpace` metrizable, hence first-countable. Sequential compactness is then pure general topology: `CompactSpace.tendsto_subseq`. The proof is three lines — a case study in how upstream Mathlib growth retires local axioms.",
     "significance": "key",
-    "relatedConcepts": "Prokhorov (axiomatized here): every sequence $(\\mu_n)$ in $\\mathcal P(\\Omega)$ on compact metrizable $\\Omega$ has a subsequence $\\mu_{\\varphi(k)} \\rightharpoonup \\mu$ weakly. Tightness is automatic on compact spaces.",
+    "relatedConcepts": [
+      "Prokhorov's theorem",
+      "compactness of the space of probability measures",
+      "Lévy–Prokhorov metric",
+      "first-countability and sequential compactness"
+    ],
     "mathContext": [
       "Prokhorov theorem",
       "tightness",
@@ -378,7 +383,7 @@
     },
     "type": "concept",
     "title": "Assembling the Correspondence and Honest Status",
-    "content": "The final assembly plan: build a `Furstenberg.System` on $(\\Omega, T, B_0)$ with $\\mu$ the weak-* limit of Cesàro measures, deriving T-invariance from the limit-invariance result and $\\mu(B_0)\\ge\\delta$ from density preservation. The combinatorial–dynamical bridge (orbit-density, telescoping invariance, return property) is fully proved and axiom-free, and with `limit_invariant_on_cylinder` now proved (2026-07-23) the whole correspondence reduces to a single standard analysis fact — the Prokhorov sequential-compactness axiom `seqCompact_probabilityMeasure_cantor` — which is not deep mathematics, just unassembled in Mathlib. This transparent accounting is the entry's open-question framing toward eliminating the correspondence axiom.",
+    "content": "The final assembly plan: build a `Furstenberg.System` on $(\\Omega, T, B_0)$ with $\\mu$ the weak-* limit of Cesàro measures, deriving T-invariance from the limit-invariance result and $\\mu(B_0)\\ge\\delta$ from density preservation. The combinatorial–dynamical bridge (orbit-density, telescoping invariance, return property) is fully proved, and with `limit_invariant_on_cylinder` proved (2026-07-23) and the Prokhorov sequential-compactness statement proved from Mathlib's Prokhorov instances (S14, 2026-07-24), the file is now entirely axiom-free and sorry-free: 0 axioms, 0 sorries. What remains toward eliminating the parent's correspondence axiom is pure assembly — instantiating `Furstenberg.System` from the pieces this file provides.",
     "significance": "supporting",
     "relatedConcepts": "Target: a measure-preserving system $(\\Omega, \\mu, T)$ with $\\mu(B_0)\\ge\\overline d(A)$, recovering multiple recurrence ⟹ Szemerédi. Remaining dependencies: Prokhorov (axiom) + one T-invariance sorry.",
     "mathContext": [

--- a/src/data/proofs/furstenberg-correspondence-oq-01/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-01/meta.json
@@ -247,7 +247,7 @@
   "leanFile": {
     "path": "Proofs/FurstenbergCorrespondenceOQ01.lean",
     "lineCount": 945,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 9,
     "theoremCount": 32
@@ -286,5 +286,9 @@
       "venue": "Princeton University Press"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "status": "verified",
+  "badge": "original",
+  "axiomCount": 0,
+  "assumptions": "0 sorries, 0 axioms (fully machine-checked as of S14, 2026-07-24). The former local axiom seqCompact_probabilityMeasure_cantor — sequential compactness of probability measures on Cantor space in the topology of weak convergence — is now proved from Mathlib v4.31's Prokhorov development (CompactSpace (ProbabilityMeasure E) for compact E, Mathlib.MeasureTheory.Measure.Prokhorov) plus Lévy–Prokhorov metrizability and CompactSpace.tendsto_subseq. All other components (shift dynamics, cylinder sets, k-fold return property, orbit-density formula, Cesàro measures, density lower bound, T-invariance at the limit via Portmanteau) were already proved from Mathlib."
 }

--- a/src/data/research/problems/szemeredi-full-oq-01.json
+++ b/src/data/research/problems/szemeredi-full-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "szemeredi-full-oq-01",
   "title": "Szemerédi Theorem: Furstenberg Ergodic-Theoretic Proof Formalization",
-  "phase": "BLOCKED",
+  "phase": "ACT",
   "status": "in-progress",
   "tier": "S",
   "path": "full",
@@ -17,13 +17,13 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-04-22T13:03:46.383Z",
-    "iteration": 14,
-    "focus": "S13 ACT complete (2026-07-23): limit_invariant_on_cylinder PROVED (sorry 1->0). File builds clean at v4.31. Next: S14 ACT — discharge the Prokhorov axiom seqCompact_probabilityMeasure_cantor (~150-200 lines), then assemble the Furstenberg.System.",
+    "since": "2026-07-24",
+    "iteration": 15,
+    "focus": "S14 ACT (researcher-1, 2026-07-24): PROKHOROV AXIOM ELIMINATED. seqCompact_probabilityMeasure_cantor converted axiom -> theorem in 3 lines: Mathlib v4.31 Prokhorov (CompactSpace (ProbabilityMeasure E) for compact E) + Levy-Prokhorov metrizability (=> first-countable) + CompactSpace.tendsto_subseq. FurstenbergCorrespondenceOQ01.lean now 0 axioms / 0 sorries, Docker-GREEN (8576 jobs). Gallery meta upgraded to verified/original/0; annotations refreshed.",
     "blockers": [
       "RESOLVED (S13, 2026-07-23): the 28-error v4.26 build regression was repaired by the v4.31 toolchain migration (#39062); baseline and post-fill docker builds are clean."
     ],
-    "nextAction": "S14 ACT: prove seqCompact_probabilityMeasure_cantor (sequential compactness of ProbabilityMeasure on CantorSpace) from Mathlib v4.31 Prokhorov/tightness ingredients (CantorSpace is compact metrizable, so every measure family is tight; check Mathlib.MeasureTheory.Measure.Prokhorov coverage). Then construct the Furstenberg.System and connect to FurstenbergCorrespondence.lean.",
+    "nextAction": "S15 ACT: assemble Furstenberg.System on (CantorSpace, shift, cylinderZero) — all ingredients are now proved (Prokhorov extraction, limit_invariant_on_cylinder T-invariance, density_preserved_at_limit). Then use the assembled system to eliminate the furstenberg_correspondence axiom in the parent FurstenbergCorrespondence.lean, which is the actual szemeredi-full-oq-01 target.",
     "attemptCounts": {
       "total": 9,
       "currentApproach": 1,
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S13 ACT (2026-07-23, researcher-2): limit_invariant_on_cylinder PROVED — the banked S9-audited Portmanteau proof pasted and docker-verified at v4.31 (the S11 28-error regression was repaired by migration epic #39062; S12/S13 BLOCKED state was stale). FurstenbergCorrespondenceOQ01.lean now has 0 sorries, 1 axiom. The correspondence reduces entirely to the Prokhorov axiom seqCompact_probabilityMeasure_cantor — S14 target.",
+    "progressSummary": "PROGRESS: FurstenbergCorrespondenceOQ01.lean is fully machine-checked — 0 axioms, 0 sorries (S13 killed the last sorry, S14 the last axiom). Gallery entry furstenberg-correspondence-oq-01 upgraded verified/original. Remaining for the OQ target: assemble Furstenberg.System from the proved pieces and eliminate the parent correspondence axiom in FurstenbergCorrespondence.lean.",
     "builtItems": [
       "finsetDirac_apply: sum of Dirac measures on measurable set = filter cardinality (OQ01.lean:316)",
       "cesaroMeasure: N-step Cesaro probability measure definition (OQ01.lean:334)",
@@ -42,7 +42,8 @@
       "seqCompact_probabilityMeasure_cantor: local axiom for Prokhorov sequential compactness (OQ01.lean:484)",
       "limit_invariant_on_cylinder: complete proof structure (~60 lines) replacing T-invariance sorry at FurstenbergCorrespondenceOQ01.lean:748 — uses ProbabilityMeasure.tendsto_measure_of_null_frontier_of_tendsto + ENNReal.Tendsto.add + telescoping bounds; not locally validated due to file-wide build blocker",
       "PR #14878: 6 Mathlib API drift fixes in FurstenbergCorrespondenceOQ01.lean — restores buildability after 35-error cascade (Session 7, 2026-05-02)",
-      "limit_invariant_on_cylinder PROVED in Proofs/FurstenbergCorrespondenceOQ01.lean:762 (exact T-invariance of weak-* limit of Cesaro measures on clopen sets) — docker-verified 2026-07-23, sorry count 1->0"
+      "limit_invariant_on_cylinder PROVED in Proofs/FurstenbergCorrespondenceOQ01.lean:762 (exact T-invariance of weak-* limit of Cesaro measures on clopen sets) — docker-verified 2026-07-23, sorry count 1->0",
+      "seqCompact_probabilityMeasure_cantor in FurstenbergCorrespondenceOQ01.lean — former local axiom, now a theorem (Prokhorov + Levy-Prokhorov metrization + CompactSpace.tendsto_subseq)"
     ],
     "insights": [
       "FurstenbergCorrespondence.lean already exists with szemeredi_k2_ergodic proved via Poincaré recurrence",
@@ -64,7 +65,10 @@
       "shift_iterate original proof had a mathematical bug: induction on n without generalizing k means ih only covers position k, but succ case needs position k+1; proof worked in older Lean by accident (comp_def simp behavior changed)",
       "S13 (2026-07-23): The S11/S12 build-regression block was stale — the v4.31 migration epic (#39062) repaired all 28 errors; baseline docker build passes at HEAD. Re-verify recorded blockers before honoring them.",
       "The banked S9-audited Portmanteau proof compiled essentially as drafted at v4.31: IsClopen.frontier_eq + ProbabilityMeasure.tendsto_measure_of_null_frontier_of_tendsto (prime) + ENNReal.tendsto_inv_nat_nhds_zero.comp (tendsto_add_atTop_nat 1).comp hNs + le_of_tendsto_of_tendsto (prime) + le_antisymm. The convert-using-2 steps anticipated in the draft were unnecessary — rw [hdef k] closes the bound gap exactly.",
-      "File status after S13: 0 sorries, 1 axiom (seqCompact_probabilityMeasure_cantor). The full Furstenberg correspondence now reduces to Prokhorov sequential compactness alone."
+      "File status after S13: 0 sorries, 1 axiom (seqCompact_probabilityMeasure_cantor). The full Furstenberg correspondence now reduces to Prokhorov sequential compactness alone.",
+      "S14: Mathlib v4.31 ships Prokhorov upstream (Mathlib.MeasureTheory.Measure.Prokhorov, Gouezel 2025): CompactSpace (ProbabilityMeasure E) for any compact T2 Borel E, with NO second-countability needed (proof via Riesz-Markov-Kakutani on ultrafilters). Combined with LevyProkhorovMetric metrizability (separable pseudo-metrizable Borel X) sequential compactness is just CompactSpace.tendsto_subseq — the 150-200-line local-axiom estimate from 2026-05 became 3 lines.",
+      "S14: BorelSpace (N -> Bool) is found by typeclass search (Pi.borelSpace, countable index, discrete factors) — no manual instance needed for the Prokhorov instance to fire on CantorSpace.",
+      "S14 meta-lesson: before hand-assembling a stated-as-axiom classical analysis fact, grep the CURRENT Mathlib tree for the exact instance (ls Mathlib/MeasureTheory/Measure/ | grep -i prokhorov) — upstream growth between toolchain bumps retires local axioms wholesale."
     ],
     "mathlibGaps": [
       "Prokhorov theorem: sequential compactness of ProbabilityMeasure on compact metrizable space (~150-200 lines to assemble from Mathlib v4.26 ingredients)",
@@ -74,10 +78,8 @@
       "FurstenbergCorrespondenceOQ01.lean Mathlib upgrade: ~35 specific errors (see knowledge.md session 5)"
     ],
     "nextSteps": [
-      "S10 ACT (from main checkout, NOT isolated worktree): build-verify current main HEAD via ./proofs/scripts/docker-build.sh Proofs.FurstenbergCorrespondenceOQ01.",
-      "S10 ACT: paste 60-line limit_invariant_on_cylinder proof at FurstenbergCorrespondenceOQ01.lean:779 — template + lemma citations in state.md Next Action section. All 5 Mathlib lemmas verified to exist at pin 2df2f0150c… by S9 API audit.",
-      "After limit_invariant_on_cylinder: prove seqCompact_probabilityMeasure_cantor via Mathlib Prokhorov ingredients (~150-200 lines).",
-      "S9 API audit findings (verified at pin 2df2f0150c…): tendsto_measure_of_null_frontier_of_tendsto' at Portmanteau.lean:333; IsClopen.frontier_eq at Clopen.lean:38; le_of_tendsto_of_tendsto' at OrderClosed.lean:631; ENNReal.tendsto_nat_nhds_top at Lemmas.lean:148; ENNReal.tendsto_inv_nat_nhds_zero at Lemmas.lean:488."
+      "S15: assemble Furstenberg.System on (CantorSpace, shift, cylinderZero) from the proved Prokhorov/T-invariance/density pieces.",
+      "S16+: eliminate the furstenberg_correspondence axiom in the parent FurstenbergCorrespondence.lean using the assembled system."
     ]
   },
   "tags": [
@@ -97,7 +99,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.383Z",
-  "lastUpdate": "2026-06-09T17:55:00.000Z",
+  "lastUpdate": "2026-07-24",
   "significance": 9,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary
S14 session for `szemeredi-full-oq-01` — **axiom elimination**: the Prokhorov
sequential-compactness local axiom `seqCompact_probabilityMeasure_cantor`,
the sole remaining assumption of `FurstenbergCorrespondenceOQ01.lean` since
Session 2, is now a **theorem**. The file is fully machine-checked:
**0 axioms / 0 sorries**.

## Progress
- The 2026-05 assessment estimated "~150–200 lines assembling tightness +
  Lévy–Prokhorov". Mathlib v4.31 made that obsolete:
  `Mathlib.MeasureTheory.Measure.Prokhorov` (Gouëzel, 2025) ships
  `instance [CompactSpace E] : CompactSpace (ProbabilityMeasure E)` (no
  second-countability needed — Riesz–Markov–Kakutani on ultrafilters), and
  `LevyProkhorovMetric` provides `MetrizableSpace (ProbabilityMeasure X)`
  for separable pseudo-metrizable Borel `X`. So `ProbabilityMeasure
  CantorSpace` is compact + first-countable and the axiom statement is
  exactly `CompactSpace.tendsto_subseq f` — a **3-line proof**
  (`BorelSpace (ℕ → Bool)` is found by typeclass search via `Pi.borelSpace`).
- 5 stale prose sites updated (Part IX header, two progress tables, the
  Step-2 plan note, the honest-status block).
- Gallery `furstenberg-correspondence-oq-01`: meta upgraded
  `axiomatized`/`axiom`/1 → **`verified`/`original`/0** (no structure-encoded
  assumptions, no `native_decide`); `assumptions` rewritten; annotations
  6/11/15 refreshed (11 retitled "Prokhorov Sequential Compactness: Former
  Axiom, Now a Theorem").

## Findings
- Meta-lesson: before hand-assembling a stated-as-axiom classical analysis
  fact, grep the current Mathlib tree for the exact instance — upstream
  growth between toolchain bumps retires local axioms wholesale.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.FurstenbergCorrespondenceOQ01` —
  exit 0 (8576 jobs), **first-try GREEN**.
- `grep "^axiom"` on the file: 0. Sorries: 0.
- Supersession guard: NOT_SUPERSEDED; no open PRs on this slug.

## Status
**Outcome**: progress (axiom eliminated; entry now verified)
**Next Steps**: S15 — assemble `Furstenberg.System` on (Ω, shift, B₀) from
the now-complete pieces; then eliminate the parent
`FurstenbergCorrespondence.lean` correspondence axiom (the actual OQ target).

🤖 Generated by researcher-1
