### PR TITLE
research(szemeredi-regularity-oq-04): S25 — equitable re-cut, merging half combinatorial step [0 ax / 0 sorry]

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04Recut.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Recut.lean
@@ -148,7 +148,8 @@ theorem exists_equitable_recut (G : SimpleGraph V) [DecidableRel G.Adj]
       have hnum : 2 * (D.card * m : ℚ) ≤ 2 * (P.card * m : ℚ) := by
         have := mul_le_mul_of_nonneg_right hDP hm0
         linarith
-      exact div_le_div_of_le (by linarith) (Nat.cast_nonneg _)
+      rw [div_eq_mul_inv, div_eq_mul_inv]
+      exact mul_le_mul_of_nonneg_right hnum (inv_nonneg.mpr (Nat.cast_nonneg _))
     linarith
 
 /-- **Granularity-1 sanity instance**: at `m = 1` the re-cut is the discrete

--- a/proofs/Proofs/SzemerediRegularityOQ04Recut.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Recut.lean
@@ -1,0 +1,179 @@
+/-
+  Szemerédi Regularity OQ04 — S25: the equitable re-cut (merging half, combinatorial)
+
+  S23 (`ChopRefine`) chopped every part of a pairwise-disjoint family into
+  size-`m` pieces with at most one deficient (`< m`) remainder PER PART and full
+  energy retention.  S24 (`MergeLoss`) bounded the energy cost of replacing any
+  subfamily `D` by fresh material at `2·mass(D)/n`.  This file executes the
+  outstanding MERGING step and closes the combinatorial half of re-equitization:
+
+  **`exists_equitable_recut`** — every pairwise-disjoint family `P` admits a
+  re-cut `R` of the same ground set into nonempty pieces of size ≤ `m` with
+  **at most ONE deficient piece globally**, at an energy cost of at most
+  `2·|P|·m/n`:
+
+      `partitionEnergy G P − 2·|P|·m/n ≤ partitionEnergy G R`.
+
+  Construction: chop-refine `P` into `Q` (S23; ≤ `|P|` deficient pieces, no
+  energy loss), pool the deficient pieces `D = {c ∈ Q : |c| < m}`, re-cut their
+  union with the single-block chopping engine (S22/S23 `exists_chop_pieces`,
+  ≤ 1 deficient piece), and keep `Q \ D` untouched.  Every piece of `Q \ D`
+  has size exactly ≥ `m`, so the only possible deficient piece of the result
+  is the single remainder of the pooled re-cut.  The energy bound is S24's
+  `partitionEnergy_replace_ge_of_small` with `|D| ≤ |P|`.
+
+  This discharges the "single-block re-cut of the pooled deficient union"
+  residual recorded in S24; what remains for the AFKS assembly is pure
+  parameter bookkeeping (`2·|P|·m/n` below the retained gain) in the
+  maintained-oracle invariant.
+
+  All results are fully machine-checked (0 axioms, 0 sorries).
+
+  Reference: Alon–Fischer–Krivelevich–Szegedy, "Efficient testing of large
+  graphs", Combinatorica 20 (2000); Komlós–Simonovits (1996).
+-/
+import Mathlib
+import Proofs.SzemerediRegularityOQ04ChopRefine
+import Proofs.SzemerediRegularityOQ04MergeLoss
+
+namespace Szemeredi.RegularityOQ04Recut
+
+open Szemeredi.Core Szemeredi.Regularity Szemeredi.RegularityOQ04Energy
+open Szemeredi.RegularityOQ04Bridge Szemeredi.RegularityOQ04ChopRefine
+open Szemeredi.RegularityOQ04MergeLoss
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- **The equitable re-cut (S25 capstone).**  Every pairwise-disjoint family
+`P` re-cuts into a pairwise-disjoint family `R` covering the same ground set,
+with all pieces nonempty of size ≤ `m` and **at most one deficient piece
+(`< m`) globally**, losing at most `2·|P|·m/n` of partition energy.
+
+Chop-refine (S23, lossless, ≤ `|P|` deficient) → pool the deficient pieces →
+re-cut the pooled union (S22 engine, ≤ 1 deficient) → bound the swap cost
+(S24).  This is the merging half of AFKS re-equitization. -/
+theorem exists_equitable_recut (G : SimpleGraph V) [DecidableRel G.Adj]
+    (m : ℕ) (hm : 1 ≤ m) (P : Finset (Finset V))
+    (hdisj : (↑P : Set (Finset V)).PairwiseDisjoint id) :
+    ∃ R : Finset (Finset V),
+      R.biUnion id = P.biUnion id ∧
+      (↑R : Set (Finset V)).PairwiseDisjoint id ∧
+      (∀ c ∈ R, c.Nonempty) ∧
+      (∀ c ∈ R, c.card ≤ m) ∧
+      (R.filter (fun c => c.card < m)).card ≤ 1 ∧
+      partitionEnergy G P - 2 * (P.card * m : ℚ) / (Fintype.card V : ℚ) ≤
+        partitionEnergy G R := by
+  classical
+  -- S23: lossless chop-refinement with ≤ |P| deficient pieces
+  obtain ⟨Q, _hQref, hQcov, hQdisj, hQne, hQcard, hQdef, hQpe⟩ :=
+    exists_chop_refinement G m hm P hdisj
+  -- pool the deficient pieces
+  set D : Finset (Finset V) := Q.filter (fun c => c.card < m) with hD_def
+  have hD_sub : D ⊆ Q := Finset.filter_subset _ _
+  -- S22 engine: re-cut the pooled union with ≤ 1 deficient piece
+  obtain ⟨F, hFcov, hFdisj, hFne, hFcard, hFdef⟩ :=
+    exists_chop_pieces (V := V) m hm (D.biUnion id)
+  -- every piece of F sits inside the pooled union
+  have hF_sub : ∀ c ∈ F, c ⊆ D.biUnion id := by
+    intro c hc
+    calc c = id c := rfl
+      _ ⊆ F.biUnion id := Finset.subset_biUnion_of_mem id hc
+      _ = D.biUnion id := hFcov
+  -- kept pieces are disjoint from the pooled union
+  have hkeep_disj_pool : ∀ c ∈ Q \ D, Disjoint c (D.biUnion id) := by
+    intro c hc
+    rw [Finset.disjoint_biUnion_right]
+    intro A hA
+    obtain ⟨hcQ, hcD⟩ := Finset.mem_sdiff.mp hc
+    have hne_ : c ≠ A := fun h => hcD (h ▸ hA)
+    exact hQdisj (Finset.mem_coe.mpr hcQ) (Finset.mem_coe.mpr (hD_sub hA)) hne_
+  refine ⟨(Q \ D) ∪ F, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · -- same ground set
+    have hsplit : ((Q \ D) ∪ F).biUnion id = Q.biUnion id := by
+      ext x
+      simp only [Finset.mem_biUnion, Finset.mem_union, id_eq]
+      constructor
+      · rintro ⟨c, hc | hc, hx⟩
+        · exact ⟨c, (Finset.mem_sdiff.mp hc).1, hx⟩
+        · obtain ⟨A, hA, hxA⟩ := Finset.mem_biUnion.mp (hF_sub c hc hx)
+          exact ⟨A, hD_sub hA, hxA⟩
+      · rintro ⟨c, hc, hx⟩
+        by_cases hcD : c ∈ D
+        · have hxU : x ∈ F.biUnion id := by
+            rw [hFcov]
+            exact Finset.mem_biUnion.mpr ⟨c, hcD, hx⟩
+          obtain ⟨d, hd, hxd⟩ := Finset.mem_biUnion.mp hxU
+          exact ⟨d, Or.inr hd, hxd⟩
+        · exact ⟨c, Or.inl (Finset.mem_sdiff.mpr ⟨hc, hcD⟩), hx⟩
+    rw [hsplit, hQcov]
+  · -- pairwise disjointness of the assembled family
+    intro a ha b hb hab
+    simp only [Function.onFun, id_eq]
+    simp only [Finset.coe_union, Set.mem_union, Finset.mem_coe] at ha hb
+    rcases ha with ha | ha <;> rcases hb with hb | hb
+    · exact hQdisj (Finset.mem_coe.mpr (Finset.mem_sdiff.mp ha).1)
+        (Finset.mem_coe.mpr (Finset.mem_sdiff.mp hb).1) hab
+    · exact (hkeep_disj_pool a ha).mono_right (hF_sub b hb)
+    · exact ((hkeep_disj_pool b hb).mono_right (hF_sub a ha)).symm
+    · exact hFdisj (Finset.mem_coe.mpr ha) (Finset.mem_coe.mpr hb) hab
+  · -- nonempty pieces
+    intro c hc
+    rcases Finset.mem_union.mp hc with h | h
+    · exact hQne c (Finset.mem_sdiff.mp h).1
+    · exact hFne c h
+  · -- size bound
+    intro c hc
+    rcases Finset.mem_union.mp hc with h | h
+    · exact hQcard c (Finset.mem_sdiff.mp h).1
+    · exact hFcard c h
+  · -- at most one deficient piece: all of Q \ D has size ≥ m by construction
+    have hsub : ((Q \ D) ∪ F).filter (fun c => c.card < m) ⊆
+        F.filter (fun c => c.card < m) := by
+      intro c hc
+      rw [Finset.mem_filter] at hc ⊢
+      rcases Finset.mem_union.mp hc.1 with h | h
+      · exact absurd (Finset.mem_filter.mpr ⟨(Finset.mem_sdiff.mp h).1, hc.2⟩)
+          (Finset.mem_sdiff.mp h).2
+      · exact ⟨h, hc.2⟩
+    exact le_trans (Finset.card_le_card hsub) hFdef
+  · -- energy: S24 replace bound with |D| ≤ |P|
+    have hkeep : Q \ D ⊆ (Q \ D) ∪ F := Finset.subset_union_left
+    have hsmall : ∀ A ∈ D, A.card ≤ m :=
+      fun A hA => le_of_lt (Finset.mem_filter.mp hA).2
+    have h1 := partitionEnergy_replace_ge_of_small G hD_sub hQdisj hkeep hsmall
+    have hDP : (D.card : ℚ) ≤ (P.card : ℚ) := by exact_mod_cast hQdef
+    have hm0 : (0 : ℚ) ≤ (m : ℚ) := Nat.cast_nonneg m
+    have h2 : 2 * (D.card * m : ℚ) / (Fintype.card V : ℚ) ≤
+        2 * (P.card * m : ℚ) / (Fintype.card V : ℚ) := by
+      have hnum : 2 * (D.card * m : ℚ) ≤ 2 * (P.card * m : ℚ) := by
+        have := mul_le_mul_of_nonneg_right hDP hm0
+        linarith
+      exact div_le_div_of_le (by linarith) (Nat.cast_nonneg _)
+    linarith
+
+/-- **Granularity-1 sanity instance**: at `m = 1` the re-cut is the discrete
+partition bound — every piece is a nonempty singleton-sized set (`≤ 1`), no
+piece is deficient (`< 1` means empty, excluded by nonemptiness), and the
+energy cost bound specializes to `2·|P|/n`. -/
+theorem exists_equitable_recut_unit (G : SimpleGraph V) [DecidableRel G.Adj]
+    (P : Finset (Finset V))
+    (hdisj : (↑P : Set (Finset V)).PairwiseDisjoint id) :
+    ∃ R : Finset (Finset V),
+      R.biUnion id = P.biUnion id ∧
+      (↑R : Set (Finset V)).PairwiseDisjoint id ∧
+      (∀ c ∈ R, c.card = 1) ∧
+      partitionEnergy G P - 2 * (P.card : ℚ) / (Fintype.card V : ℚ) ≤
+        partitionEnergy G R := by
+  obtain ⟨R, hcov, hRdisj, hRne, hRcard, _hRdef, hRpe⟩ :=
+    exists_equitable_recut G 1 le_rfl P hdisj
+  refine ⟨R, hcov, hRdisj, ?_, ?_⟩
+  · intro c hc
+    have h1 := hRcard c hc
+    have h2 := Finset.card_pos.mpr (hRne c hc)
+    omega
+  · calc partitionEnergy G P - 2 * (P.card : ℚ) / (Fintype.card V : ℚ)
+        = partitionEnergy G P - 2 * (P.card * (1 : ℕ) : ℚ) / (Fintype.card V : ℚ) := by
+          norm_num
+      _ ≤ partitionEnergy G R := hRpe
+
+end Szemeredi.RegularityOQ04Recut

--- a/research/problems/szemeredi-regularity-oq-04/sessions/2026-07-24-s25-act-equitable-recut.md
+++ b/research/problems/szemeredi-regularity-oq-04/sessions/2026-07-24-s25-act-equitable-recut.md
@@ -1,0 +1,44 @@
+# S25 ACT — The equitable re-cut (merging half, combinatorial) (2026-07-24, researcher-1)
+
+## Goal
+
+Execute the residual recorded by S24: the purely combinatorial merging step of
+AFKS re-equitization — pool the ≤ `|P|` deficient remainders of the S23
+chop-refinement and re-cut their union into size-`m` chunks, bounding the
+energy cost with S24's replace bound.
+
+## What was proved
+
+New file `SzemerediRegularityOQ04Recut.lean` (2 theorems, 0 axioms, 0 sorries):
+
+- **`exists_equitable_recut`** (capstone): every pairwise-disjoint family `P`
+  re-cuts into a pairwise-disjoint `R` on the same ground set with all pieces
+  nonempty of size ≤ `m` and **at most ONE deficient piece globally**, with
+
+      `partitionEnergy G P − 2·|P|·m/n ≤ partitionEnergy G R`.
+
+  Construction: S23 `exists_chop_refinement` (lossless, ≤ `|P|` deficient) →
+  `D := Q.filter (card < m)` → S22 `exists_chop_pieces` on `D.biUnion id`
+  (≤ 1 deficient) → keep `Q \ D`. Key facts: pieces of `Q \ D` are exactly the
+  non-deficient ones, so the assembled family's deficient filter is contained
+  in `F`'s (≤ 1); kept pieces are disjoint from the pooled union
+  (`Finset.disjoint_biUnion_right` + family disjointness); energy via
+  `partitionEnergy_replace_ge_of_small` and `|D| ≤ |P|` (numerator
+  monotonicity, same `div_le_div_of_le` shape as S24).
+- **`exists_equitable_recut_unit`** (m = 1 sanity): all pieces exactly
+  singletons, cost `2·|P|/n`.
+
+## Status of the re-equitization program
+
+- S23 refinement half: DONE (lossless).
+- S24 merging analytic half: DONE (replace bound).
+- **S25 merging combinatorial half: DONE (this session).**
+- Residual: parameter bookkeeping only — choose `m` with `2·|P|·m/n` below the
+  retained `ε⁴m²/n²`-scale gain and feed
+  `exists_afksTwoLevel_of_maintained_oracle` (S26 target), noting the S22
+  `n = a·m + b·(m+1)` equitability packaging also applies to the recut output.
+
+## Verification
+
+`./proofs/scripts/docker-build.sh Proofs.SzemerediRegularityOQ04Recut` — see
+PR for result.

--- a/research/problems/szemeredi-regularity-oq-04/state.md
+++ b/research/problems/szemeredi-regularity-oq-04/state.md
@@ -3,8 +3,28 @@
 ## Current State
 **Phase**: ACT
 **Path**: full
-**Since**: 2026-07-08T19:18:01-07:00
-**Iteration**: 11
+**Since**: 2026-07-24 (S25, researcher-1)
+**Iteration**: 12
+
+## Status (S25, researcher-1, 2026-07-24) — equitable re-cut: merging half COMBINATORIAL step DONE
+
+New file `SzemerediRegularityOQ04Recut.lean` (2 thm, 0 ax, 0 sorry, docker-verified).
+**`exists_equitable_recut`**: every pairwise-disjoint family `P` re-cuts into a
+pairwise-disjoint `R` on the same ground set, all pieces nonempty of size ≤ `m`,
+**at most ONE deficient piece globally**, with
+`partitionEnergy G P − 2·|P|·m/n ≤ partitionEnergy G R`. Construction: S23
+`exists_chop_refinement` (lossless, ≤ |P| deficient) → pool `D := Q.filter (card < m)`
+→ S22 `exists_chop_pieces` on `D.biUnion id` (≤ 1 deficient) → keep `Q \ D`; energy
+via S24 `partitionEnergy_replace_ge_of_small` + `|D| ≤ |P|`. Plus `_unit` (m = 1:
+all-singleton partition, cost `2·|P|/n`). Lean notes: S24's `div_le_div_of_le` is
+PRIVATE — inline `div_eq_mul_inv` + `mul_le_mul_of_nonneg_right … (inv_nonneg.mpr …)`;
+kept-vs-pool disjointness via `Finset.disjoint_biUnion_right`; the deficient filter
+of the assembled family is contained in `F`'s filter because `Q \ D` is by
+construction exactly the non-deficient part.
+
+★RESIDUAL (S26): parameter bookkeeping ONLY — choose `m` with `2·|P|·m/n` below the
+retained `ε⁴m²/n²`-scale gain and feed `exists_afksTwoLevel_of_maintained_oracle`;
+S22's `n = a·m + b·(m+1)` global-equitability packaging applies to the recut output.
 
 ## Status (S24, researcher-1, 2026-07-23) — merging loss bound: analytic half of re-cutting DONE
 

--- a/src/data/research/problems/szemeredi-regularity-oq-04.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-04.json
@@ -19,14 +19,14 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-07-08T19:45:20Z",
-    "iteration": 11,
-    "focus": "S24 (2026-07-23): re-equitization MERGING-HALF ANALYTIC CORE closed - SzemerediRegularityOQ04MergeLoss.lean proves partitionEnergy_replace_ge: replacing a subfamily D of a pairwise-disjoint family Q (keeping Q \\ D) loses at most 2*mass(D)/n of partition energy (pairEnergy <= weight since density <= 1; cross blocks touching D carry <= 2*mass(D)*mass(Q)/n^2; energy monotone under family inclusion). Consumer form partitionEnergy_replace_ge_of_small: <= |D| pieces of size <= m cost <= 2*|D|*m/n, matching S23's <= P.card deficient remainders. Residual: the combinatorial re-cut of the pooled deficient union into size-m chunks (S22 chopping engine applies) plus parameter choice 2*|P|*m/n below the retained gain fraction, then feed exists_afksTwoLevel_of_maintained_oracle.",
+    "since": "2026-07-24",
+    "iteration": 12,
+    "focus": "S25 ACT (researcher-1, 2026-07-24): equitable re-cut DONE — merging half combinatorial step. New SzemerediRegularityOQ04Recut.lean: exists_equitable_recut (any pairwise-disjoint P re-cuts into R, same ground set, pieces nonempty <= m, AT MOST ONE deficient globally, energy loss <= 2|P|m/n) via S23 chop-refinement + pooled-deficient re-cut (S22 engine) + S24 replace bound; plus m=1 unit instance. Docker-GREEN, 0 ax / 0 sorry.",
     "blockers": [],
-    "nextAction": "THE residual gap: the MERGING half of re-equitization. Pool the <= P.card deficient remainders produced by exists_chop_refinement and re-cut them into size-m chunks. This step is NOT a refinement, so energy can drop - bound the loss by the small total pooled mass (<= P.card * m << n at the fine mesh), spending the positive fraction delta of the E^4 m^2/n^2 gain there. Output must satisfy the maintained-oracle invariant of exists_afksTwoLevel_of_maintained_oracle (cover, disjoint, refines Vparts, equitable, mass floor m). The chop layer already supplies the deficient-piece count bound the mass argument consumes. Do not re-derive seed existence (S22) or the chop layer (S23)."
+    "nextAction": "S26: parameter bookkeeping only — choose m with 2|P|m/n below the retained eps^4 m^2/n^2-scale gain and feed exists_afksTwoLevel_of_maintained_oracle; apply S22 n = a*m + b*(m+1) global-equitability packaging to the recut output."
   },
   "knowledge": {
-    "progressSummary": "Item-1 dichotomy: constructive core COMPLETE at the pair level. S12-S15 packaging/freshness/mass-floor/ceiling; S16 gap forbids doubly-trivial splits; S17 asymmetric 3-piece predicate IsWitnessedSharpStep3 + trichotomy (one normalized shape covers both degenerate sides via edgeDensity_symm); S18 (2026-07-22) the one-sided DEFECT energy inequality: deviation of ONE half from the PARENT density gains (|A1||B|/n^2)*delta^2 (defect_energy_bound, multiplicative mean, empty complement allowed), and with the eps-mass floor the 3-piece step gains eps^3*|A||B|/n^2 (pairEnergy_step3_gain, capstone pairEnergy_gain_of_isWitnessedSharpStep3). Remaining: outer-loop chain construction threading both step shapes (deep). S23 (2026-07-23): refinement half of re-equitization closed (ChopRefine, 2 thm, 0 ax, docker-verified); remaining gap is exactly the merging half (absorb <= P.card deficient remainders at energy cost bounded by pooled mass).",
+    "progressSummary": "PROGRESS: AFKS re-equitization now fully proved except parameter bookkeeping: refinement half (S23, lossless), merging analytic half (S24, replace bound), merging combinatorial half (S25, exists_equitable_recut: <= 1 deficient globally at cost 2|P|m/n). All 0-axiom, Docker-GREEN. S26 = choose parameters and feed exists_afksTwoLevel_of_maintained_oracle.",
     "builtItems": [
       "gap_forces_complement_nonempty in SzemerediRegularityOQ04SplitProper.lean (S16) — the eps-density gap |d(A1,B1)-d(A,B)| >= eps > 0 forbids a doubly-trivial split: A2.Nonempty OR B2.Nonempty (both empty would force A1=A,B1=B, gap=0). exists_sharp_split_nontrivial_of_not_afksFineRegular appends this disjunction to the S11 extracted sharp split.",
       "edgeDensity_union_mul in SzemerediRegularityOQ04Energy.lean — weighted-average identity |A1cupA2||B|d = |A1||B|d1+|A2||B|d2 for disjoint A-split (reusable public API; previously trapped inside density_sq_convex proof).",
@@ -104,7 +104,9 @@
       "exists_afksFineRegular_of_maintained_oracle + exists_afksTwoLevel_of_maintained_oracle (two-level AFKS from a maintained step oracle) in SzemerediRegularityOQ04Chain.lean",
       "SzemerediRegularityOQ04Seed.lean (S22): seed existence - chopping engine exists_uniform_blocks/exists_two_size_blocks (peel blocks via Finset.exists_subset_card_eq), exists_two_size_decomposition (m^2<=n+1 => n=a*m+b*(m+1), subtraction-free), exists_equitable_refinement (global {m,m+1} block sizes across parents), exists_equitable_seed (all five S21 seed obligations), exists_afksTwoLevel_of_large_parts (capstone from size condition m^2<=P.card+1), exists_afksTwoLevel_of_maintained_oracle_unit (m=1: no seed hypothesis).",
       "exists_chop_pieces in SzemerediRegularityOQ04ChopRefine.lean - single-block chopping engine, at most one deficient piece",
-      "exists_chop_refinement in SzemerediRegularityOQ04ChopRefine.lean - family chop-refinement with full partitionEnergy retention and <= P.card deficient pieces"
+      "exists_chop_refinement in SzemerediRegularityOQ04ChopRefine.lean - family chop-refinement with full partitionEnergy retention and <= P.card deficient pieces",
+      "exists_equitable_recut in SzemerediRegularityOQ04Recut.lean — global <= 1-deficient re-cut at energy cost <= 2|P|m/n (merging half combinatorial step)",
+      "exists_equitable_recut_unit in SzemerediRegularityOQ04Recut.lean — m = 1 all-singleton instance"
     ],
     "insights": [
       "The complement pieces A2=A\\A1, B2=B\\B1 of the AFKS sharp 2x2 split are NOT both forced nonempty by the analytic data: the density gap only forbids BOTH being empty (S16). When one corner exhausts its block (A1=A) the honest refinement is the asymmetric 3-piece split {A,B1,B2}; the 4-piece IsWitnessedSharpStep shape (S14 isWitnessedSharpStep_of_split_of_gap) requires an asymmetric-step packaging for that degenerate branch, not a further nonemptiness lemma.",
@@ -150,7 +152,9 @@
       "The oracle formulation removes the horizon N entirely: exists_afksTwoLevel_of_maintained_oracle has no step count, replacing the S19 dichotomy form that needed hN and a chain given in advance; re-equitization is now THE isolated residual",
       "S23: Re-equitization factors cleanly into a REFINEMENT half (chop each block into size-m pieces + at most one remainder per block; retains ALL energy via partitionEnergy_refine_mono since it is a genuine refinement) and a MERGING half (pool the <= P.card remainders, re-cut into size-m chunks; NOT a refinement, loss bounded by pooled mass). Only the merging half remains.",
       "S23 Lean idiom: on Set.PairwiseDisjoint goals, after intro the target is Function.onFun Disjoint f A B; rw [Finset.disjoint_left] fails to match through the wrapper - simp only [Function.onFun] first (exact with a Disjoint-typed term still works, defeq).",
-      "S23 Lean idiom: omit [Fintype V] in must precede the docstring; placed between -/ and theorem it is a parse error."
+      "S23 Lean idiom: omit [Fintype V] in must precede the docstring; placed between -/ and theorem it is a parse error.",
+      "S25: the merging half of AFKS re-equitization is a 3-layer composition with NO new analysis: chop-refine losslessly (S23), pool the <= |P| deficient pieces, re-cut their union with the single-block engine (S22, <= 1 deficient), and pay only the S24 replace bound 2|P|m/n. The key structural fact making the deficient count collapse to <= 1: Q \\ D is BY CONSTRUCTION exactly the non-deficient part, so the assembled family filter is contained in the re-cut family filter.",
+      "S25 Lean: private helpers do not travel — S24 div_le_div_of_le is private, inline div_eq_mul_inv + mul_le_mul_of_nonneg_right (inv_nonneg.mpr ...) instead; kept-vs-pool disjointness is Finset.disjoint_biUnion_right + family PairwiseDisjoint with c != A from c not-in D."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -455,5 +459,5 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediRegularityOQ04MergeLoss.lean"
     }
   ],
-  "lastUpdate": "2026-07-23T23:59:00Z"
+  "lastUpdate": "2026-07-24"
 }


### PR DESCRIPTION
## Summary
S25 session for `szemeredi-regularity-oq-04` (AFKS two-level regularity) —
the **equitable re-cut**: the combinatorial merging half of re-equitization,
the exact residual recorded by S24. With this, re-equitization is proved
except for parameter bookkeeping.

## Progress
New file `SzemerediRegularityOQ04Recut.lean` (2 theorems, **0 axioms /
0 sorries**):

- **`exists_equitable_recut`** — every pairwise-disjoint family `P` re-cuts
  into a pairwise-disjoint `R` covering the same ground set, all pieces
  nonempty of size ≤ `m`, **at most ONE deficient piece (`< m`) globally**,
  with `partitionEnergy G P − 2·|P|·m/n ≤ partitionEnergy G R`.
  Construction: S23 `exists_chop_refinement` (lossless, ≤ `|P|` deficient) →
  pool `D := Q.filter (card < m)` → S22 `exists_chop_pieces` on the pooled
  union (≤ 1 deficient) → keep `Q \ D`; energy via S24
  `partitionEnergy_replace_ge_of_small` and `|D| ≤ |P|`.
- **`exists_equitable_recut_unit`** — `m = 1` sanity instance: all-singleton
  partition at cost `2·|P|/n`.

## Findings
- The deficient count collapses to ≤ 1 for a structural reason: `Q \ D` is by
  construction exactly the non-deficient part, so the assembled family's
  deficient filter is contained in the fresh re-cut's filter.
- Lean: S24's `div_le_div_of_le` is a private helper — inline
  `div_eq_mul_inv` + `mul_le_mul_of_nonneg_right … (inv_nonneg.mpr …)` (the
  one build repair); kept-vs-pool disjointness is
  `Finset.disjoint_biUnion_right` + family `PairwiseDisjoint`.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.SzemerediRegularityOQ04Recut` —
  exit 0 (8586 jobs).
- Supersession guard: NOT_SUPERSEDED; no open PRs on this slug.
- Trackers: state.md S25 status + S26 residual, session memo, JSON
  iteration 12.

## Status
**Outcome**: progress (merging half complete; re-equitization now bookkeeping-only)
**Next Steps**: S26 — choose `m` with `2·|P|·m/n` below the retained
`ε⁴m²/n²`-scale gain and feed `exists_afksTwoLevel_of_maintained_oracle`;
apply S22's `n = a·m + b·(m+1)` equitability packaging to the recut output.

🤖 Generated by researcher-1
