### PR TITLE
Add reciprocal sibling cross-reference: burnside-counting-oq-06-oq-02

### DIFF
--- a/src/data/proofs/burnside-counting-oq-06-oq-02/meta.json
+++ b/src/data/proofs/burnside-counting-oq-06-oq-02/meta.json
@@ -129,6 +129,11 @@
       "proofId": "burnside-counting-oq-06",
       "relationship": "parent",
       "description": "Parent entry deriving Fermat's little theorem from the totient form of the necklace count; this entry supplies the Möbius/Lyndon companion and shows both specialize to the Fermat congruence at a prime."
+    },
+    {
+      "proofId": "burnside-counting-oq-06-oq-01",
+      "relationship": "sibling",
+      "description": "The totient (φ-weighted) companion under the same parent: that entry generalizes Fermat via the total necklace count ∑_{d∣n} φ(n/d)·k^d at arbitrary modulus, while this entry handles the μ-weighted aperiodic (Lyndon-word) count. Both closed forms collapse at a prime to the same Fermat congruence k^p ≡ k (mod p)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- `burnside-counting-oq-06-oq-01` (the totient/arbitrary-modulus companion) already links to this entry as its Möbius/Lyndon-word sibling, but this entry's `crossReferences` had only the parent link with no reciprocal reference back.
- Adds the missing sibling `crossReferences` entry.
- No content deleted; existing text preserved.

## Test plan
- [x] `python3 -c "import json; json.load(open('src/data/proofs/burnside-counting-oq-06-oq-02/meta.json'))"` — valid JSON
- [x] File remains well under the 60 KB size cap (15.5 KB)
- [x] Full `pnpm build` blocked in this worktree by a pre-existing missing-`tsc`/node-v26 `better-sqlite3` build environment issue, unrelated to this change