### PR TITLE
Fix: normalize invalid annotation type enums in annotations.source.json (#31246)

### DIFF
--- a/src/data/proofs/arithmetic-series/annotations.source.json
+++ b/src/data/proofs/arithmetic-series/annotations.source.json
@@ -78,7 +78,7 @@
       "name": "gauss_100",
       "kind": "theorem"
     },
-    "type": "context",
+    "type": "concept",
     "title": "Gauss's Original Problem",
     "content": "**Sum of 1 to 100 = 5050.**\n\nThis is the famous problem Gauss allegedly solved as a schoolboy. The proof uses `native_decide` for computational verification.\n\n50 pairs \u00d7 101 = 5050.",
     "mathContext": "$1 + 2 + \\cdots + 100 = 5050$",

--- a/src/data/proofs/birthday-problem/annotations.source.json
+++ b/src/data/proofs/birthday-problem/annotations.source.json
@@ -139,7 +139,7 @@
       "name": "prob_two",
       "kind": "theorem"
     },
-    "type": "context",
+    "type": "concept",
     "title": "Two People: P = 1/365",
     "content": "With 2 people, the probability they share a birthday is:\n\n$$P(2) = 1 - \\frac{365 \\times 364}{365^2} = 1 - \\frac{364}{365} = \\frac{1}{365}$$\n\nThis makes intuitive sense: once person 1's birthday is fixed, person 2 has a 1/365 chance of matching.\n\nIn Lean: `prob_shared_birthday 2 = 1 / 365`",
     "mathContext": "$P(2) = 1/365 \\approx 0.27\\%$",

--- a/src/data/proofs/cantor-diagonalization/annotations.source.json
+++ b/src/data/proofs/cantor-diagonalization/annotations.source.json
@@ -59,7 +59,7 @@
       "name": "diagonal_differs",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Diagonal Differs at Each Position",
     "content": "The key lemma: our constructed diagonal sequence differs from $f(n)$ specifically at position $n$.\n\nSince `diagonal f n = !(f n n)`, we have `diagonal f n != f n n` by the fact that `!b != b` for any boolean.\n\nThis one-line observation is the heart of the proof.",
     "mathContext": "The Lean proof: `unfold diagonal` replaces `diagonal f n` with `!(f n n)`, then `cases f n n <;> simp` performs case analysis on both `Bool.true` and `Bool.false`. In each case `simp` discharges the goal: `!true \u2260 true` becomes `false \u2260 true` (true by `Bool.false_ne_true`), and `!false \u2260 false` becomes `true \u2260 false` (true by `Bool.true_ne_false`). The `<;>` combinator applies `simp` to both cases simultaneously. This lemma encapsulates the one-line core of Cantor's argument: $\\lnot b \\neq b$ for any $b \\in \\{0, 1\\}$, which holds because boolean negation is a fixed-point-free involution.",
@@ -133,7 +133,7 @@
       "name": "cantor_diagonalization",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Constructing the Witness",
     "content": "We exhibit the diagonal sequence as our witness. The `use` tactic provides this existential witness.\n\nNow we must prove this sequence differs from every $f(n)$.",
     "mathContext": "The `use diagonal f` tactic in Lean 4 discharges the `\u2203 s : BinarySeq, ...` goal by substituting `s := diagonal f`, leaving the goal `\u2200 n : \u2115, f n \u2260 diagonal f`. This is a *constructive* witness \u2014 the diagonal sequence is given explicitly as `fun n => !(f n n)`. Classical logic would allow a non-constructive existence proof (by excluded middle, assuming no such sequence and deriving a contradiction), but this proof constructs the witness directly. The `use` tactic corresponds to the existential introduction rule: from `P(t)`, conclude `\u2203 x, P(x)`.",
@@ -158,7 +158,7 @@
       "name": "no_surjection_nat_to_binary",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Deriving the Contradiction",
     "content": "Suppose for contradiction that $f(n) = \\text{diagonal}(f)$ for some $n$.\n\nThen at position $n$: $f(n)(n) = \\text{diagonal}(f)(n)$.\n\nBut $\\text{diagonal}(f)(n) = \\neg f(n)(n)$ by definition.\n\nSo $f(n)(n) = \\neg f(n)(n)$, which is impossible for any boolean.\n\nContradiction! Therefore $f(n) \\neq \\text{diagonal}(f)$ for all $n$.",
     "mathContext": "In `no_surjection_nat_to_binary`: `intro \u27e8f, hf\u27e9` destructs the assumed surjection; `obtain \u27e8s, hs\u27e9 := cantor_diagonalization f` gives the diagonal sequence not in range; `obtain \u27e8n, hn\u27e9 := hf s` uses surjectivity to find $n$ with $f(n) = s$; `exact hs n hn` applies `hs : \u2200 n, f n \u2260 s` to `hn : f n = s`, deriving `False` from `f n \u2260 s` and `f n = s`. The key tactic pattern is `exact hs n hn`: `hs n : f n \u2260 s` is a function `f n = s \u2192 False`, and `hn : f n = s` is the input. The `exact` tactic applies the former to the latter. This is a 4-line proof that neatly separates concerns: Cantor proves non-surjectivity for any enumeration; this theorem packages it as '\u00ac\u2203 surjection'.",
@@ -209,7 +209,7 @@
       "name": "reals_uncountable",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Proof of Uncountability",
     "content": "Assume for contradiction that some surjective $f$ exists.\n\nBy Cantor's theorem, there exists $s$ with $f(n) \\neq s$ for all $n$.\n\nBut surjectivity says every $s$ equals some $f(n)$.\n\nThese contradict: $s = f(n)$ but also $f(n) \\neq s$.",
     "mathContext": "`reals_uncountable` is a one-line alias: `no_surjection_nat_to_binary`. Its docstring explains the informal bridge: binary sequences $(b_n) \\in \\{0,1\\}^{\\mathbb{N}}$ map to reals via $\\sum b_n/2^{n+1} \\in [0,1]$, and $|[0,1]| = |\\mathbb{R}|$. But the Lean type is `\u00ac\u2203 f : \u2115 \u2192 BinarySeq, Function.Surjective f` \u2014 not a statement about $\\mathbb{R}$. The peer review (ai-3) flagged this equivocation; as a resolution, the theorem's name signals the *informal* interpretation while the type gives the *formal* content. This honest naming pattern is common in proof galleries: the formal statement is technically narrower than its name suggests.",

--- a/src/data/proofs/cantors-theorem/annotations.source.json
+++ b/src/data/proofs/cantors-theorem/annotations.source.json
@@ -99,7 +99,7 @@
       "type": "section-doc",
       "contains": "The Core Lemma: Diagonal Paradox -/"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "The Self-Reference Paradox",
     "content": "The **diagonal paradox** is the heart of the argument:\n\nIf f(b) = D where D = {x | x not in f(x)}, then:\n$$b \\in D \\iff b \\notin D$$\n\nThis is a **self-referential contradiction** - b's membership in D depends on whether b is in D.\n\nThis paradox is closely related to:\n- **Russell's Paradox**: Consider R = {x | x not in x}. Is R in R?\n- **The Liar Paradox**: 'This statement is false'\n- **Godel's Incompleteness**: Self-referential sentences about provability\n\nIn type theory, we avoid Russell's paradox by stratifying types into universes.",
     "mathContext": "$b \\in D \\iff b \\notin D$",

--- a/src/data/proofs/central-limit-theorem/annotations.source.json
+++ b/src/data/proofs/central-limit-theorem/annotations.source.json
@@ -74,7 +74,7 @@
       "type": "section-doc",
       "contains": "What This Proves"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Characteristic Function at Zero",
     "content": "At $t = 0$, the characteristic function equals 1 for any probability measure: $\\varphi(0) = \\mathbb{E}[e^{i \\cdot 0 \\cdot X}] = \\mathbb{E}[1] = 1$. This normalization anchors the Fourier representation.",
     "mathContext": "This simple fact is essential: it means all characteristic functions pass through the same point, allowing us to compare different distributions on a common scale.",
@@ -120,7 +120,7 @@
       "name": "charFun_zero",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Taylor Expansion with Error Bound",
     "content": "For small $t$, the characteristic function is well-approximated by its quadratic Taylor polynomial. The error is $O(t^3)$, controlled by the third moment. This approximation is sharp enough to extract the limiting behavior.",
     "mathContext": "The third moment condition $\\mathbb{E}[|X|^3] < \\infty$ ensures the remainder is well-controlled. Without it, convergence may fail (leading to stable distributions instead).",

--- a/src/data/proofs/erdos-1047/annotations.source.json
+++ b/src/data/proofs/erdos-1047/annotations.source.json
@@ -73,7 +73,7 @@
       "name": "erdos_1047_counterexample",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "The Explicit Counterexample",
     "content": "The existential form of the result, packaging the explicit witness: a monic polynomial of positive degree (`goodmanPolynomial`), a positive level (`goodmanCriticalValue`, positive by `positivity`), and a point $z_0$ on the lemniscate whose component is non-convex. The final witness is supplied directly by the certificate `goodman_counterexample_proof`.",
     "mathContext": "$\\exists f \\text{ monic}, \\deg f > 0, \\exists c > 0, \\exists z_0 \\in \\{|f| \\le c\\}$ with the component of $z_0$ non-convex. Instantiated at $f = (z^2+1)(z-2)^2$, $c = 5^{3/2}/4$.",
@@ -95,7 +95,7 @@
       "name": "erdos_1047_answer",
       "kind": "theorem"
     },
-    "type": "context",
+    "type": "concept",
     "title": "The Answer, Stated Cleanly",
     "content": "A streamlined existential restatement of the answer, dropping the monic/degree bookkeeping to leave just the essential claim: there is a polynomial, a level, and a boundary point whose lemniscate component is not convex. Derived in two lines from `erdos_1047_counterexample`.",
     "mathContext": "$\\exists f, \\exists c > 0, \\exists z_0 \\in \\{|f| \\le c\\}$ with a non-convex component — the minimal form of \"some lemniscate component is non-convex\".",

--- a/src/data/proofs/euler-identity/annotations.source.json
+++ b/src/data/proofs/euler-identity/annotations.source.json
@@ -68,7 +68,7 @@
       "type": "block-comment",
       "contains": "For Euler's Identity, we need:"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Key Values at \u03c0",
     "content": "The proof hinges on two fundamental facts about trigonometric functions at $\\pi$ radians (180\u00b0):\n\n$$\\cos(\\pi) = -1$$\n$$\\sin(\\pi) = 0$$\n\nGeometrically: at angle $\\pi$, we're at the leftmost point of the unit circle, which is $(-1, 0)$.\n\nThese values follow from the unit circle definition of sine and cosine, where $\\cos(\\theta)$ is the x-coordinate and $\\sin(\\theta)$ is the y-coordinate.",
     "mathContext": "$(\\cos \\pi, \\sin \\pi) = (-1, 0)$; Lean: `Real.cos_pi : cos \u03c0 = -1`, `Real.sin_pi : sin \u03c0 = 0` from `Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic`",
@@ -161,7 +161,7 @@
       "name": "exp_on_unit_circle",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "The Taylor Series Proof",
     "content": "The classical proof of Euler's formula compares Taylor series:\n\n$$e^{ix} = 1 + ix + \\frac{(ix)^2}{2!} + \\frac{(ix)^3}{3!} + ...$$\n\nUsing $i^2 = -1$, $i^3 = -i$, $i^4 = 1$, etc.:\n\n$$= \\underbrace{1 - \\frac{x^2}{2!} + \\frac{x^4}{4!} - ...}_{\\cos x} + i\\underbrace{\\left(x - \\frac{x^3}{3!} + \\frac{x^5}{5!} - ...\\right)}_{\\sin x}$$\n\nThe series magically separate into the Taylor series for cosine (even powers) and sine (odd powers)!\n\nThis 'coincidence' reflects deep structural connections between $e$, $\\sin$, and $\\cos$.",
     "mathContext": "$e^{ix} = \\sum_{n=0}^\\infty \\frac{(ix)^n}{n!}$; even-power terms give $\\cos x = \\sum \\frac{(-1)^n x^{2n}}{(2n)!}$, odd-power terms give $\\sin x = \\sum \\frac{(-1)^n x^{2n+1}}{(2n+1)!}$",
@@ -208,7 +208,7 @@
       "type": "block-comment",
       "contains": "1714: Roger Cotes discovered a related logarithmic"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Quarter Turn: e^(i\u03c0/2) = i",
     "content": "At $\\theta = \\pi/2$ (90\u00b0), we get:\n\n$$e^{i\\pi/2} = \\cos(\\pi/2) + i\\sin(\\pi/2) = 0 + i \\cdot 1 = i$$\n\nThis confirms the geometric interpretation: rotating 1 by 90\u00b0 gives $i$ (the 'up' direction in the complex plane).\n\nSimilarly:\n- $e^{i\\pi} = -1$ (180\u00b0 rotation)\n- $e^{i \\cdot 3\\pi/2} = -i$ (270\u00b0 rotation)\n- $e^{2\\pi i} = 1$ (360\u00b0 = back to start)",
     "mathContext": "$e^{i\\pi/2} = i$; Lean: `theorem quarter_rotation : Complex.exp (Real.pi / 2 * Complex.I) = Complex.I` proved with `Real.cos_pi_div_two` and `Real.sin_pi_div_two`",

--- a/src/data/proofs/fermat-two-squares/annotations.source.json
+++ b/src/data/proofs/fermat-two-squares/annotations.source.json
@@ -96,7 +96,7 @@
       "name": "sum_two_squares_iff_not_three_mod_four",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "The Prime 2: A Special Case",
     "content": "2 = 1\u00b2 + 1\u00b2 is trivially a sum of two squares.\n\nNote that 2 \u2261 2 (mod 4), so it's neither in the \"1 mod 4\" nor the \"3 mod 4\" category. The theorem correctly handles this edge case.",
     "mathContext": "2 is the only even prime, making it unique in many ways.",

--- a/src/data/proofs/fermats-last-theorem/annotations.source.json
+++ b/src/data/proofs/fermats-last-theorem/annotations.source.json
@@ -77,7 +77,7 @@
       "type": "block-comment",
       "contains": "FreyCurve_is_semistable"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Semi-stability of Frey Curves",
     "content": "An elliptic curve is **semi-stable** if at every prime of bad reduction, the reduction is multiplicative (nodes, not cusps). Frey curves are semi-stable, which is crucial because Wiles' modularity theorem applies specifically to semi-stable curves.",
     "mathContext": "Semi-stability is a technical condition on how the curve reduces modulo primes. The Frey curve has multiplicative reduction at the primes dividing $abc$, and good reduction elsewhere.",
@@ -199,7 +199,7 @@
       "name": "flt_multiple",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Reduction to Primes",
     "content": "If FLT holds for exponent $n$, it holds for all multiples of $n$. Why? If $a^{nm} + b^{nm} = c^{nm}$, then $(a^m)^n + (b^m)^n = (c^m)^n$, contradicting FLT for $n$.",
     "mathContext": "This means we only need to prove FLT for n=4 and all odd primes. Since every n \u2265 3 is divisible by 4 or an odd prime, this covers everything.",

--- a/src/data/proofs/fundamental-theorem-algebra/annotations.source.json
+++ b/src/data/proofs/fundamental-theorem-algebra/annotations.source.json
@@ -6,7 +6,7 @@
       "type": "section-doc",
       "contains": "What This Proves"
     },
-    "type": "context",
+    "type": "concept",
     "title": "Degree of a Polynomial",
     "content": "The **degree** of a polynomial is the highest power of the variable with a non-zero coefficient.\n\nFor $z^2 + 1$, the degree is 2. The polynomial $z^3 - 2z + 5$ has degree 3.\n\nDegree 0 means a constant polynomial. The fundamental theorem requires degree at least 1 (non-constant).",
     "mathContext": "$\\deg(z^n + \\text{lower terms}) = n$\n\n$\\deg(c) = 0$ for constant $c \\neq 0$\n\n$\\deg(0) = -\\infty$ (by convention)",
@@ -152,7 +152,7 @@
       "kind": "theorem",
       "extendBefore": 2
     },
-    "type": "context",
+    "type": "concept",
     "title": "Quadratics Always Have Roots",
     "content": "As a special case: **every quadratic $az^2 + bz + c$ (with $a \\neq 0$) has roots.**\n\nThe famous quadratic formula gives them explicitly:\n$z = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$\n\nIn the complex numbers, $\\sqrt{b^2 - 4ac}$ always exists (complex square roots exist), so roots always exist.\n\nThe proof here derives this from the general FTA.",
     "mathContext": "Quadratic formula: $z = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$\n\nDiscriminant $\\Delta = b^2 - 4ac$:\n- $\\Delta > 0$: two real roots\n- $\\Delta = 0$: one repeated root\n- $\\Delta < 0$: two complex conjugate roots",

--- a/src/data/proofs/fundamental-theorem-calculus/annotations.source.json
+++ b/src/data/proofs/fundamental-theorem-calculus/annotations.source.json
@@ -174,7 +174,7 @@
       "name": "hasDerivAt_zero_implies_constant",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Zero Derivative Implies Constant",
     "content": "**If F'(x) = 0 for all x, then F is constant.**\n\nThis is a consequence of the Mean Value Theorem:\n\nFor any two points x and y, there exists c between them with\n$F(y) - F(x) = F'(c)(y - x) = 0 \\cdot (y - x) = 0$\n\nSo F(y) = F(x) for all x, y.\n\nThis lemma is essential for proving uniqueness of antiderivatives.",
     "mathContext": "Mean Value Theorem: $F(y) - F(x) = F'(c)(y - x)$ for some $c \\in (x, y)$\n\nIf $F' \\equiv 0$, then $F(y) = F(x)$ for all $x, y$.",

--- a/src/data/proofs/gcd-algorithm/annotations.source.json
+++ b/src/data/proofs/gcd-algorithm/annotations.source.json
@@ -327,7 +327,7 @@
       "type": "section-doc",
       "contains": "Worked Examples"
     },
-    "type": "context",
+    "type": "concept",
     "title": "Worked Examples",
     "content": "**Tracing gcd(48, 18)**:\n\n```\ngcd(48, 18) = gcd(18, 48 mod 18) = gcd(18, 12)\ngcd(18, 12) = gcd(12, 18 mod 12) = gcd(12, 6)\ngcd(12, 6)  = gcd(6, 12 mod 6)   = gcd(6, 0)\ngcd(6, 0)   = 6\n```\n\nOnly 4 steps! The algorithm is remarkably efficient.\n\nEach step is verified in Lean using `native_decide` to compute the result directly.",
     "mathContext": "In Lean: each step is verified by `native_decide`, which compiles the decision to native code and evaluates. For `gcd(48, 18) = 6`: the algorithm runs $48 = 2 \\cdot 18 + 12$, $18 = 1 \\cdot 12 + 6$, $12 = 2 \\cdot 6 + 0$, terminating in 3 steps. `native_decide` calls `Nat.decEq` on the reduced expression. Step-tracing examples serve as `#eval`-style tests within the proof system, confirmed by the kernel.",

--- a/src/data/proofs/godel-incompleteness/annotations.source.json
+++ b/src/data/proofs/godel-incompleteness/annotations.source.json
@@ -200,7 +200,7 @@
       "type": "block-comment",
       "contains": "Axiom:** The self-referential property of G."
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "G Is Not Provable",
     "content": "This is the heart of the argument. Assume for contradiction that $G$ is provable.\n\n1. By representability, $\\vdash\\text{Prov}(\\ulcorner G\\urcorner)$\n2. But $G \\iff \\neg\\text{Prov}(\\ulcorner G\\urcorner)$, so $\\vdash\\neg\\text{Prov}(\\ulcorner G\\urcorner)$\n3. We've proved both $\\text{Prov}(\\ulcorner G\\urcorner)$ and $\\neg\\text{Prov}(\\ulcorner G\\urcorner)$\n4. This contradicts consistency!\n\nTherefore, if the system is consistent, $G$ cannot be provable. But $G$ *says* \"I am not provable\"\u2014so $G$ is true! A true sentence that cannot be proved.",
     "mathContext": "$\\text{Consistent}(F) \\implies \\neg\\vdash G$",

--- a/src/data/proofs/halting-problem/annotations.source.json
+++ b/src/data/proofs/halting-problem/annotations.source.json
@@ -127,7 +127,7 @@
       "name": "diagonal_differs",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Diagonal Differs from Oracle",
     "content": "**Key Lemma**: The diagonal behavior always differs from the oracle's prediction at self-application points.\n\nFor any program code $n$:\n$\\text{diagonal}(H)(n) \\neq H(n, n)$\n\nThis follows immediately from the fact that $\\neg b \\neq b$ for any boolean.",
     "mathContext": "$\\text{diagonal}(H)(n) = \\neg H(n, n) \\neq H(n, n)$\n\nBecause $\\neg \\text{true} = \\text{false} \\neq \\text{true}$\nand $\\neg \\text{false} = \\text{true} \\neq \\text{false}$",
@@ -173,7 +173,7 @@
       "name": "no_halting_oracle",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Case: Oracle Says Halt",
     "content": "**Case 1**: Suppose $H(c, c) = \\text{true}$ (oracle predicts halt).\n\nThen by definition of diagonal:\n$\\text{diagonal}(H)(c) = \\neg H(c, c) = \\text{false}$\n\nBut the hypothesis says $c$ correctly implements diagonal, so $c$ halting means diagonal returns true.\n\nContradiction: $\\text{false} = \\text{true}$.",
     "mathContext": "$H(c,c) = \\text{true}$\n$\\Rightarrow \\text{diagonal}(H)(c) = \\text{false}$\n$\\Rightarrow c(c)$ loops\n$\\Rightarrow H(c,c)$ should be $\\text{false}$ (contradiction)",
@@ -196,7 +196,7 @@
       "name": "no_halting_oracle",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Case: Oracle Says Loop",
     "content": "**Case 2**: Suppose $H(c, c) = \\text{false}$ (oracle predicts loop).\n\nThen by definition of diagonal:\n$\\text{diagonal}(H)(c) = \\neg H(c, c) = \\text{true}$\n\nBut the hypothesis says $c$ correctly implements diagonal, so diagonal returning true means $c$ halts.\n\nContradiction: $H$ said $c$ loops but $c$ halts.",
     "mathContext": "$H(c,c) = \\text{false}$\n$\\Rightarrow \\text{diagonal}(H)(c) = \\text{true}$\n$\\Rightarrow c(c)$ halts\n$\\Rightarrow H(c,c)$ should be $\\text{true}$ (contradiction)",

--- a/src/data/proofs/harmonic-divergence/annotations.source.json
+++ b/src/data/proofs/harmonic-divergence/annotations.source.json
@@ -86,7 +86,7 @@
       "type": "section-doc",
       "contains": "Why Does This Happen? Oresme's Grouping Argument"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Terms are Positive",
     "content": "A simple but necessary fact: $1/n > 0$ for all $n > 0$. This ensures all our terms contribute positively to the sum, enabling downward comparison: each term in a group is bounded below by the reciprocal of the group's largest element.",
     "significance": "supporting",

--- a/src/data/proofs/infinitude-primes/annotations.source.json
+++ b/src/data/proofs/infinitude-primes/annotations.source.json
@@ -65,7 +65,7 @@
       "name": "factorial_succ_ge_two",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "n! + 1 Is at Least 2",
     "content": "For any $n$, we have $n! + 1 \\geq 2$. Since $n! \\geq 1$ (factorials are always positive), adding 1 gives us at least 2. This ensures that $n! + 1$ has at least one prime divisor, which is needed for the existence step in Euclid's argument. The proof uses the `omega` tactic \u2014 Lean's decision procedure for Presburger arithmetic (the first-order theory of $(\\mathbb{Z}, +, <)$) \u2014 which handles the linear inequality $n! \\geq 1 \\Rightarrow n! + 1 \\geq 2$ automatically.",
     "mathContext": "$n! \\geq 1 \\Rightarrow n! + 1 \\geq 2$. Combined with `Nat.exists_prime_and_dvd`: $n! + 1 \\geq 2 \\Rightarrow \\exists p$ prime, $p \\mid (n! + 1)$.",
@@ -87,7 +87,7 @@
       "name": "dvd_of_dvd_add_one",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "The Key Divisibility Lemma",
     "content": "If $p$ divides both $a$ and $a+1$, then $p$ divides 1. This is the heart of Euclid's proof. The proof: if $p \\mid a$ and $p \\mid (a+1)$, then $p \\mid ((a+1) - a) = 1$. Since no prime divides 1 (primes satisfy $p \\geq 2$), this creates the contradiction we need. The Lean proof applies `Nat.dvd_sub'` (if $p \\mid b$ and $p \\mid a$ with $a \\leq b$, then $p \\mid (b - a)$) and simplifies $(a+1) - a = 1$.",
     "mathContext": "$p \\mid a \\land p \\mid (a+1) \\Rightarrow p \\mid ((a+1) - a) = 1$. Equivalently: consecutive integers are coprime. This is the structural reason why $n!$ and $n! + 1$ cannot share any prime factors.",

--- a/src/data/proofs/intermediate-value-theorem/annotations.source.json
+++ b/src/data/proofs/intermediate-value-theorem/annotations.source.json
@@ -100,7 +100,7 @@
       "name": "bolzano",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Bolzano Proof Strategy",
     "content": "The proof has two parts:\n\n1. **Get existence in [a, b]**: Since 0 is between f(a) and f(b), IVT gives us some x in [a, b] with f(x) = 0.\n\n2. **Show x is in (a, b)**: We prove x \u2260 a because f(a) < 0 \u2260 f(x) = 0, and similarly x \u2260 b because f(b) > 0 \u2260 f(x) = 0.\n\nThis is a common pattern: use IVT for the closed interval, then refine to the open interval using the hypothesis values.",
     "mathContext": "Strategy:\n1. $0 \\in [f(a), f(b)]$ since $f(a) < 0 < f(b)$\n2. Apply IVT to get $x \\in [a, b]$\n3. $x \\neq a$ since $f(x) = 0 \\neq f(a)$\n4. $x \\neq b$ since $f(x) = 0 \\neq f(b)$",

--- a/src/data/proofs/lagrange-four-squares/annotations.source.json
+++ b/src/data/proofs/lagrange-four-squares/annotations.source.json
@@ -60,7 +60,7 @@
       "type": "doc-comment",
       "contains": "Euler's Four-Square Identity (1748)**"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "The ring Tactic",
     "content": "The `ring` tactic is Lean's automated prover for polynomial ring identities. It expands both sides and verifies they're equal.\n\nThis 8-term polynomial identity would be tedious to prove by hand, but `ring` handles it instantly by normalizing both sides to a canonical form.",
     "mathContext": "Ring arithmetic in any commutative ring R.",
@@ -97,7 +97,7 @@
       "name": "euler_four_squares",
       "kind": "theorem"
     },
-    "type": "context",
+    "type": "concept",
     "title": "The Notorious Seven",
     "content": "7 is the smallest number that requires all four squares:\n$$7 = 1^2 + 1^2 + 1^2 + 2^2 = 1 + 1 + 1 + 4$$\n\nYou can verify: there's no way to write 7 = a² + b² + c² with integers.",
     "mathContext": "7 = 4⁰(8·0 + 7) fits Legendre's obstruction.",

--- a/src/data/proofs/law-of-cosines/annotations.source.json
+++ b/src/data/proofs/law-of-cosines/annotations.source.json
@@ -144,7 +144,7 @@
       "name": "equilateral_example",
       "kind": "theorem"
     },
-    "type": "context",
+    "type": "concept",
     "title": "Worked Examples",
     "content": "**60\u00b0 angle (equilateral triangle)**:\n- $a = b = 1$, $\\cos(60\u00b0) = 1/2$\n- $c^2 = 1 + 1 - 2(1)(1)(1/2) = 1$\n- So $c = 1$ (equilateral!)\n\n**90\u00b0 angle (Pythagorean)**:\n- $a = 3$, $b = 4$, $\\cos(90\u00b0) = 0$\n- $c^2 = 9 + 16 - 0 = 25$\n- So $c = 5$ (the 3-4-5 triangle)\n\n**120\u00b0 angle (obtuse)**:\n- $a = b = 1$, $\\cos(120\u00b0) = -1/2$\n- $c^2 = 1 + 1 - 2(1)(1)(-1/2) = 3$\n- So $c = \\sqrt{3}$",
     "significance": "supporting",

--- a/src/data/proofs/navier-stokes/annotations.source.json
+++ b/src/data/proofs/navier-stokes/annotations.source.json
@@ -83,7 +83,7 @@
       "name": "spectralGap_val",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Bernoulli's Inequality",
     "content": "The classical Bernoulli inequality $(1+x)^n \\geq 1 + nx$ for $x \\geq -1$ is proved by induction. This elementary result becomes surprisingly powerful when applied to backward-time energy growth, establishing that solutions cannot remain bounded while growing at a positive rate.",
     "mathContext": "**Bernoulli's inequality**: For $x \\geq -1$ and $n \\in \\mathbb{N}$, $(1+x)^n \\geq 1 + nx$. Proof by induction: base $n=0$ trivial; step uses $(1+x)^{n+1} = (1+x)^n(1+x) \\geq (1+nx)(1+x) = 1+(n+1)x+nx^2 \\geq 1+(n+1)x$. In the enstrophy argument: starting from $E_0 > 0$ with discrete growth step $h = 1/(\\lambda_1)$, after $n$ steps $E_n = E_0(1+\\lambda_1 h)^n = E_0 \\cdot 2^n$. Bernoulli gives $E_n \\geq E_0(1+n)$, providing the linear lower bound needed to show $E_n \\to \\infty$.",

--- a/src/data/proofs/perfect-numbers/annotations.source.json
+++ b/src/data/proofs/perfect-numbers/annotations.source.json
@@ -168,7 +168,7 @@
       "name": "six_is_perfect",
       "kind": "theorem"
     },
-    "type": "context",
+    "type": "concept",
     "title": "First Perfect Number: 6",
     "content": "$6 = 2^1 \\times 3$ where $3 = 2^2 - 1$ is prime.\n\n**Verification**: Proper divisors of 6 are $1, 2, 3$. Their sum is $1 + 2 + 3 = 6$. \u2713\n\nThe proof uses `native_decide` to verify that $3$ is prime, then applies Euclid's theorem.",
     "mathContext": "$6 = 2^1 \\cdot M_2 = 2 \\cdot 3$",
@@ -187,7 +187,7 @@
       "name": "twentyeight_is_perfect",
       "kind": "theorem"
     },
-    "type": "context",
+    "type": "concept",
     "title": "Second Perfect Number: 28",
     "content": "$28 = 2^2 \\times 7$ where $7 = 2^3 - 1$ is prime.\n\n**Verification**: Proper divisors of 28 are $1, 2, 4, 7, 14$. Their sum is $1 + 2 + 4 + 7 + 14 = 28$. \u2713",
     "mathContext": "$28 = 2^2 \\cdot M_3 = 4 \\cdot 7$",
@@ -205,7 +205,7 @@
       "name": "fourhundredninetysix_is_perfect",
       "kind": "theorem"
     },
-    "type": "context",
+    "type": "concept",
     "title": "Third Perfect Number: 496",
     "content": "$496 = 2^4 \\times 31$ where $31 = 2^5 - 1$ is prime.\n\nThis is the largest perfect number the ancient Greeks knew. Nicomachus of Gerasa listed 6, 28, and 496 in his *Introduction to Arithmetic* (c. 100 CE).",
     "mathContext": "$496 = 2^4 \\cdot M_5 = 16 \\cdot 31$",
@@ -223,7 +223,7 @@
       "name": "eightthousandonetwentyeight_is_perfect",
       "kind": "theorem"
     },
-    "type": "context",
+    "type": "concept",
     "title": "Fourth Perfect Number: 8128",
     "content": "$8128 = 2^6 \\times 127$ where $127 = 2^7 - 1$ is prime.\n\nDiscovered in antiquity, 8128 remained the largest known perfect number for over 1,000 years until the Renaissance.",
     "mathContext": "$8128 = 2^6 \\cdot M_7 = 64 \\cdot 127$",

--- a/src/data/proofs/product-of-segments-of-chords/annotations.source.json
+++ b/src/data/proofs/product-of-segments-of-chords/annotations.source.json
@@ -75,7 +75,7 @@
       "name": "chord_product_algebraic",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Algebraic Approach",
     "content": "**Vieta's Formulas Approach**:\n\nParameterize points on a chord through P in direction $\\vec{d}$:\n$$Q(t) = P + t\\vec{d}$$\n\nA point is on the circle of radius r centered at origin iff:\n$$|P + t\\vec{d}|^2 = r^2$$\n\nExpanding (with $|\\vec{d}| = 1$):\n$$t^2 + 2t\\langle P, \\vec{d}\\rangle + |P|^2 - r^2 = 0$$\n\nBy **Vieta's formulas**, the product of roots is:\n$$t_1 \\cdot t_2 = |P|^2 - r^2$$\n\nSince distances are $|t_1|$ and $|t_2|$, we get $|t_1| \\cdot |t_2| = r^2 - |P|^2$ for interior points.",
     "mathContext": "Parametrize the chord as $Q(t) = P + t\\vec{d}$. Circle equation gives $t^2 + 2t\\langle P, \\vec{d}\\rangle + (\\|P\\|^2 - r^2) = 0$. By Vieta: $t_1 t_2 = \\|P\\|^2 - r^2 = \\text{pow}(P)$.",
@@ -99,7 +99,7 @@
       "name": "center_chord_product",
       "kind": "theorem"
     },
-    "type": "context",
+    "type": "concept",
     "title": "Special Case: Center",
     "content": "When P is at the **center** of the circle:\n\n- Every chord through P is a diameter\n- Both segments have length r (the radius)\n- The product is $r \\cdot r = r^2$\n\nThis confirms our formula since pow(center) = $0^2 - r^2 = -r^2$, and $|\\text{pow}| = r^2$.\n\nThis is the *maximum* value of PA * PB for any interior point.",
     "mathContext": "When $P = O$: $\\text{pow}(O) = -r^2$, so $PA \\cdot PB = r^2$ for every chord (which is a diameter). This is maximal since $r^2 - \\|P-O\\|^2 \\leq r^2$.",
@@ -143,7 +143,7 @@
       "type": "doc-comment",
       "contains": "circle of radius 5"
     },
-    "type": "context",
+    "type": "concept",
     "title": "Worked Examples",
     "content": "**Example 1**: Circle of radius 5, point P at distance 3 from center.\n- Power = $5^2 - 3^2 = 16$\n- For any chord: $PA \\cdot PB = 16$\n- If PA = 2, then PB = 8\n\n**Example 2**: If one chord gives segments 2 and 8:\n- Product = 16\n- Other chord: if PC = 4, then PD = 4\n- (The chord is bisected at P!)\n\n**Example 3**: Segments 1 and 12:\n- Product = 12\n- Other chord: segments could be 2 and 6, or 3 and 4",
     "significance": "supporting",

--- a/src/data/proofs/pythagorean-theorem/annotations.source.json
+++ b/src/data/proofs/pythagorean-theorem/annotations.source.json
@@ -143,7 +143,7 @@
       "name": "pythagorean_theorem",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Bilinearity of Inner Product",
     "content": "The inner product is **bilinear**, meaning it distributes over addition in both arguments:\n\n$$\\langle \\vec{u} + \\vec{v}, \\vec{w} \\rangle = \\langle \\vec{u}, \\vec{w} \\rangle + \\langle \\vec{v}, \\vec{w} \\rangle$$\n$$\\langle \\vec{u}, \\vec{v} + \\vec{w} \\rangle = \\langle \\vec{u}, \\vec{v} \\rangle + \\langle \\vec{u}, \\vec{w} \\rangle$$\n\nThis property is what makes the Pythagorean theorem work: when we expand $\\|\\vec{v} + \\vec{w}\\|^2$, the bilinearity gives us all four terms.\n\nThe theorem states: if $\\vec{v} \\perp \\vec{w}$, then\n\n$$\\|\\vec{v} + \\vec{w}\\|^2 = \\|\\vec{v}\\|^2 + \\|\\vec{w}\\|^2$$\n\nThe proof is a beautiful application of bilinearity:\n\n1. $\\|\\vec{v} + \\vec{w}\\|^2 = \\langle \\vec{v} + \\vec{w}, \\vec{v} + \\vec{w} \\rangle$ (by definition)\n2. $= \\langle \\vec{v}, \\vec{v} \\rangle + \\langle \\vec{v}, \\vec{w} \\rangle + \\langle \\vec{w}, \\vec{v} \\rangle + \\langle \\vec{w}, \\vec{w} \\rangle$ (bilinearity)\n3. $= \\|\\vec{v}\\|^2 + 0 + 0 + \\|\\vec{w}\\|^2$ (perpendicularity!)\n4. $= \\|\\vec{v}\\|^2 + \\|\\vec{w}\\|^2$\n\nThe cross terms vanish because the vectors are perpendicular.",
     "mathContext": "Bilinearity: linear in each argument",
@@ -264,7 +264,7 @@
       "name": "pythagorean_sum",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Computational Verification",
     "content": "Lean can **compute** that these are valid Pythagorean triples using `native_decide`. This tactic evaluates the arithmetic and checks that both sides equal the same value.\n\nFor $(3, 4, 5)$:\n- Left side: $3^2 + 4^2 = 9 + 16 = 25$\n- Right side: $5^2 = 25$\n- Equal? Yes! Proof complete.\n\nThis is one of Lean's strengths: verifiable computation meets rigorous proof.\n\nThe **converse** of the Pythagorean theorem states:\n\n*If the sides of a triangle satisfy $a^2 + b^2 = c^2$, then the angle opposite $c$ is a right angle.*\n\nThis appears as Proposition 48 in Book I of Euclid's Elements. It means we can *test* whether an angle is 90\u00b0 using only length measurements\u2014no protractor needed!\n\nThe converse is crucial in surveying, construction, and navigation.\n\nThe Pythagorean theorem has an extraordinary history:\n\n**Ancient Origins:**\n- ~1800 BCE: Babylonian tablet Plimpton 322 lists Pythagorean triples\n- ~1100 BCE: Chinese mathematicians knew the $(3, 4, 5)$ triple\n- ~570 BCE: Pythagoras (or his school) gave a general proof\n\n**Mathematical Developments:**\n- ~300 BCE: Euclid's *Elements* includes the theorem (I.47) and converse (I.48)\n- 1876: James Garfield discovers a new proof (later becomes US President!)\n- 1940: Elisha Loomis catalogs 367 distinct proofs\n\n**Generalizations:**\n- **Law of Cosines:** $c^2 = a^2 + b^2 - 2ab\\cos(C)$\n- **Higher dimensions:** $\\|\\vec{v}\\|^2 = \\sum_i v_i^2$\n- **Non-Euclidean:** The theorem *fails* in hyperbolic/spherical geometry\u2014it's a defining property of flat space!",
     "significance": "supporting",

--- a/src/data/proofs/quadratic-reciprocity/annotations.source.json
+++ b/src/data/proofs/quadratic-reciprocity/annotations.source.json
@@ -134,7 +134,7 @@
       "name": "euler_criterion",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Euler's Criterion",
     "content": "**Euler's Criterion** provides a computational formula for the Legendre symbol:\n\n$$\\left(\\frac{a}{p}\\right) \\equiv a^{(p-1)/2} \\pmod{p}$$\n\n**Proof sketch**: By Fermat, $a^{p-1} \\equiv 1 \\pmod{p}$. Factor: $a^{p-1} - 1 = (a^{(p-1)/2} - 1)(a^{(p-1)/2} + 1)$. So $a^{(p-1)/2} \\equiv \\pm 1 \\pmod{p}$. If $a \\equiv x^2$ then $a^{(p-1)/2} \\equiv x^{p-1} \\equiv 1$; conversely one shows QNRs give $-1$.\n\n**Computational use**: Euler's criterion reduces Legendre symbol evaluation to a single modular exponentiation computable in $O(\\log p)$ multiplications \u2014 much faster than trial and error.\n\n**In Lean**: `euler_criterion` is proved using `legendreSym.eq_pow p a` from Mathlib. The statement `(legendreSym p a : ZMod p) = (a : ZMod p) ^ (p / 2)` uses Lean integer division, where `p / 2` equals $(p-1)/2$ for odd prime $p$.\n\n**Historical note**: Euler stated this criterion (without the Legendre symbol notation) in 1748. Legendre introduced the symbol notation in 1798.",
     "mathContext": "$(a/p) = a^{(p-1)/2} \\mod p$",
@@ -160,7 +160,7 @@
       "name": "legendre_mul",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Multiplicativity",
     "content": "The Legendre symbol is **completely multiplicative**:\n\n$$\\left(\\frac{ab}{p}\\right) = \\left(\\frac{a}{p}\\right) \\cdot \\left(\\frac{b}{p}\\right)$$\n\nThis means the map $a \\mapsto (a/p)$ is a **group homomorphism** from $(\\mathbb{Z}/p\\mathbb{Z})^\\times$ to $\\{\\pm 1\\}$. Its kernel is precisely the subgroup of quadratic residues (index 2).\n\n**Computational power**: Together with reciprocity and the supplementary laws, multiplicativity reduces $\\left(\\frac{a}{p}\\right)$ for any $a$ to a sequence of smaller reciprocity applications \u2014 an algorithm analogous to the Euclidean algorithm.\n\n**Example**: $(6/7) = (2/7)(3/7)$. We have $(2/7) = 1$ (since $7 \\equiv 7 \\pmod{8}$) and $(3/7) = -(7/3) = -(1/3) = -1$ (since $7 \\equiv 3 \\pmod{4}$ and $3 \\equiv 3 \\pmod{4}$). So $(6/7) = -1$.\n\n**Jacobi symbol generalization**: The multiplicativity property extends to the Jacobi symbol $(a/n)$ for odd $n$, enabling efficient computation without factoring $n$ first.\n\n**In Lean**: `legendre_mul` is proved by `legendreSym.mul p a b` from Mathlib.",
     "mathContext": "$(ab/p) = (a/p)(b/p)$",

--- a/src/data/proofs/ramanujan-sum-fallacy/annotations.source.json
+++ b/src/data/proofs/ramanujan-sum-fallacy/annotations.source.json
@@ -170,7 +170,7 @@
       "name": "grandi_not_summable",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Alternating Naturals Don't Converge Either",
     "content": "The series $1-2+3-4+5-6+\\cdots$ also diverges. Its partial sums grow without bound in absolute value: $1, -1, 2, -2, 3, -3, \\ldots$",
     "mathContext": "Define `alternatingNaturals n = (-1)^n * (n + 1)`. The partial sums satisfy $|S_{2k}| = k+1$ and $|S_{2k+1}| = k+1$ \u2014 both grow without bound. `\u00ac Summable alternatingNaturals` follows from the necessary condition: if `Summable f`, then `Filter.Tendsto f atTop (nhds 0)`. But `|alternatingNaturals n| = n+1 \u2192 \u221e`, so it cannot tend to 0.",
@@ -239,7 +239,7 @@
       "name": "alternating_naturals_not_summable",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Partial Sums Grow Without Bound",
     "content": "The sum $1+2+\\cdots+n = \\frac{n(n+1)}{2}$, which grows without bound as $n \\to \\infty$. This is the formal statement that the series diverges.",
     "mathContext": "The triangular number formula $T_n = \\frac{n(n+1)}{2}$ gives `\u2211 k in Finset.range n, (k+1) = n*(n+1)/2`. For any bound $M$, choosing $n > 2M$ gives $T_n > M$. Formally: `\u2200 M : \u211d, \u2203 N : \u2115, \u2200 n \u2265 N, M < \u2211 k in Finset.range n, naturals k`. This implies `\u00ac Summable naturals` since summable sequences must have terms tending to 0, but `naturals n = n+1 \u2192 \u221e`.",

--- a/src/data/proofs/randomized-maxcut/annotations.source.json
+++ b/src/data/proofs/randomized-maxcut/annotations.source.json
@@ -95,7 +95,7 @@
       "name": "prob_edge_in_cut",
       "kind": "lemma"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Sym2 Induction",
     "content": "To prove something about an unordered pair $e$, we use `induction e using Sym2.ind` to get representatives $u, v$. The hypothesis `h : \u00ace.IsDiag` ensures $u \\neq v$ (edges don't have both endpoints the same).",
     "mathContext": "$\\text{Sym2}(V) = V \\times V / \\sim$ where $(u,v) \\sim (v,u)$. An edge $e \\in E(G)$ satisfies $\\neg e.\\text{IsDiag}$, meaning $e = \\{u, v\\}$ with $u \\neq v$. Induction on the quotient gives representatives.",

--- a/src/data/proofs/russell-1-plus-1/annotations.source.json
+++ b/src/data/proofs/russell-1-plus-1/annotations.source.json
@@ -113,7 +113,7 @@
       "name": "add",
       "kind": "def"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Unfolding the Computation",
     "content": "The `unfold` tactic expands definitions, revealing the computation:\n\n1. `one + one` = `succ zero + succ zero`\n2. By the recursive case of `add`: `succ (succ zero + zero)`\n3. By the base case of `add`: `succ (succ zero)`\n4. Which is exactly `two`\n\nEach step is just applying a definition\u2014no axioms, no magic, just computation. The `rfl` at the end confirms that both sides are definitionally equal.",
     "mathContext": "$S(0) + S(0) = S(S(0) + 0) = S(S(0)) = 2$. The `unfold` tactic makes each definitional step explicit: first expanding `one` and `two`, then applying the recursive and base cases of `add`. After unfolding, both sides are syntactically identical, so `rfl` closes the goal.",
@@ -318,7 +318,7 @@
       "name": "one_plus_one_eq_two'",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Successor Distributes Left",
     "content": "This lemma shows that $S(n) + m = S(n + m)$\u2014the successor can be 'factored out' from the left argument.\n\nThis is NOT definitionally true (unlike `add_succ`) because our `add` recurses on the *right* argument. We need induction on `m` to prove it.\n\nThis asymmetry\u2014one direction is trivial, the other requires proof\u2014reflects the inherent asymmetry in our recursive definition.",
     "mathContext": "$S(n) + m = S(n + m)$. This lemma is the key asymmetry: `add_succ` ($n + S(m) = S(n+m)$) is *definitional* (it IS the recursive case), but `succ_add` ($S(n)+m = S(n+m)$) requires induction. Lean's `simp` and `omega` tactics know both forms, but proving it from scratch requires understanding which direction the recursion unfolds.",

--- a/src/data/proofs/schroeder-bernstein/annotations.source.json
+++ b/src/data/proofs/schroeder-bernstein/annotations.source.json
@@ -175,7 +175,7 @@
       "type": "section-doc",
       "contains": "Corollaries -/"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Composition Preserves Injectivity",
     "content": "A useful corollary: if $f: A \\to B$ and $g: B \\to A$ are both injective, then so is $g \\circ f: A \\to A$.\n\n**Proof**: Suppose $g(f(a_1)) = g(f(a_2))$. Since $g$ is injective, $f(a_1) = f(a_2)$. Since $f$ is injective, $a_1 = a_2$. Thus $g \\circ f$ is injective.\n\nThis composition gives an injective self-map $A \\to A$, which in the finite case would imply $A$ and $B$ have the same size immediately.",
     "mathContext": "If $f: \\alpha \\hookrightarrow \\beta$ and $g: \\beta \\hookrightarrow \\alpha$, then $g \\circ f: \\alpha \\hookrightarrow \\alpha$. Lean: `hg.comp hf`. For finite $\\alpha$, pigeonhole gives bijectivity automatically -- but this fails for infinite sets.",

--- a/src/data/proofs/sqrt2-irrational/annotations.source.json
+++ b/src/data/proofs/sqrt2-irrational/annotations.source.json
@@ -63,7 +63,7 @@
       "type": "section-doc",
       "contains": "What This Proves"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Even Square Implies Even Root",
     "content": "**The key lemma**: If $n^2$ is even, then $n$ is even. The proof uses the contrapositive: assume $n$ is odd, show $n^2$ is odd, contradicting that $n^2$ is even.",
     "mathContext": "Why does odd$^2$ = odd? Write $n = 2k+1$. Then $n^2 = 4k^2 + 4k + 1 = 2(2k^2 + 2k) + 1$, which is odd. The tactic `Odd.pow` handles this in Lean.",
@@ -82,7 +82,7 @@
       "type": "section-doc",
       "contains": "What This Proves"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Square of Odd is Odd",
     "content": "A direct proof that odd$^2$ = odd. If $n = 2k + 1$ (odd), then $n^2 = 4k^2 + 4k + 1 = 2(2k^2 + 2k) + 1$, which has the form $2m + 1$ (odd).",
     "mathContext": "The `ring` tactic handles the algebraic manipulation automatically. The `obtain` tactic destructs the existential in the definition of `Odd`.",
@@ -102,7 +102,7 @@
       "type": "section-doc",
       "contains": "What This Proves"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Divisibility by 2 Preserved by Squaring",
     "content": "A bidirectional lemma: $2 \\mid n^2 \\iff 2 \\mid n$. The forward direction uses `even_of_even_sq`; the reverse is direct calculation: if $n = 2k$, then $n^2 = 4k^2 = 2(2k^2)$.",
     "mathContext": "The `\u2194` (iff) in Lean requires proving both directions. The `constructor` tactic splits this into two goals.",
@@ -168,7 +168,7 @@
       "name": "even_of_sq_even",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Squaring Both Sides",
     "content": "From $\\sqrt{2} = p/q$, we square both sides to get $2 = p^2/q^2$, hence $p^2 = 2q^2$. This eliminates the square root and gives us an equation in integers.",
     "mathContext": "This is the key algebraic step. In Lean, `congrArg (\u00b7^2)` applies squaring to both sides of an equation.",
@@ -355,7 +355,7 @@
       "name": "irrational_sqrt_of_not_square",
       "kind": "theorem"
     },
-    "type": "context",
+    "type": "concept",
     "title": "Perfect Squares vs Non-Squares",
     "content": "The `decide` tactic can verify whether a number is a perfect square. Non-squares: 2, 3, 5, 6, 7, 8, 10, ... Perfect squares: 1 = 1\u00b2, 4 = 2\u00b2, 9 = 3\u00b2, 16 = 4\u00b2, ...",
     "mathContext": "For perfect squares, we provide explicit witnesses: `IsSquare 4` is proven by `\u27e82, by ring\u27e9` showing $4 = 2 \\cdot 2$. The `decide` tactic handles non-squares by computation.",

--- a/src/data/proofs/three-place-identity/annotations.source.json
+++ b/src/data/proofs/three-place-identity/annotations.source.json
@@ -94,7 +94,7 @@
       "name": "IdFromMem",
       "kind": "def"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Same Status Characterization",
     "content": "We prove Id\u2208(x, y, z) \u2194 (y \u2208 x \u2194 z \u2208 x). This elegant characterization shows that D2-identity is exactly biconditional membership: y and z are identified by x iff they have logically equivalent membership in x.",
     "mathContext": "The proof uses case analysis on whether y \u2208 x. This characterization makes the connection to Quine explicit and simplifies later reasoning.",
@@ -115,7 +115,7 @@
       "name": "IdFromMem",
       "kind": "def"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Transitivity by Case Analysis",
     "content": "The transitivity proof is the most intricate. Given Id\u2208(x, y, z) and Id\u2208(x, z, w), we case-split on which disjunct holds for each. Two cases lead to contradictions (z is both member and non-member), and two cases give the result directly.",
     "mathContext": "The four cases: (both,both), (both,neither), (neither,both), (neither,neither). The middle two are impossible by consistency. This is a nice example of exhaustive case analysis in Lean.",
@@ -201,7 +201,7 @@
       "name": "roundtrip",
       "kind": "theorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "The Power of tauto",
     "content": "The alternative proof using 'tauto' is remarkably short: just unfold definitions, introduce the Foundation hypothesis, and let the tautology checker handle the rest. This demonstrates that the core logic is purely propositional.",
     "mathContext": "The 'tauto' tactic in Lean handles classical propositional logic automatically. Once we have \u00ac(x \u2208 x) as a hypothesis, the equivalence MemFromId \u2194 mem is a propositional tautology.",

--- a/src/data/proofs/wilsons-theorem/annotations.source.json
+++ b/src/data/proofs/wilsons-theorem/annotations.source.json
@@ -122,7 +122,7 @@
       "type": "section-doc",
       "contains": "Why This is Computationally Impractical"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Only 1 and -1 Are Self-Inverse",
     "content": "In $(\\mathbb{Z}/p\\mathbb{Z})^*$, the only elements equal to their own inverse are 1 and -1.\n\n**Proof**:\n- $a = a^{-1}$ iff $a^2 = 1$\n- So $(a-1)(a+1) \\equiv 0 \\pmod{p}$\n- Since $p$ is prime, either $a \\equiv 1$ or $a \\equiv -1$\n\nThis is why primes are special\u2014composite moduli can have more than 2 self-inverse elements!",
     "mathContext": "$x^2 \\equiv 1 \\pmod{p} \\implies x \\equiv \\pm 1 \\pmod{p}$. Proof: $p \\mid (x-1)(x+1)$; since $p$ is prime, $p \\mid (x-1)$ or $p \\mid (x+1)$. For composite $n$, $x^2 \\equiv 1 \\pmod{n}$ can have more than 2 solutions (e.g., mod 8: $1^2 = 3^2 = 5^2 = 7^2 \\equiv 1$), explaining why the pairing argument breaks down and Wilson's theorem fails for composite $n$.",
@@ -145,7 +145,7 @@
       "type": "doc-comment",
       "contains": "The product of 1 through p-1 in \u2124/p\u2124 equals -1."
     },
-    "type": "context",
+    "type": "concept",
     "title": "Example: p = 2",
     "content": "For $p = 2$:\n- $(2-1)! = 1! = 1$\n- $-1 \\equiv 1 \\pmod{2}$\n\nSo $1 \\equiv -1 \\pmod{2}$ \u2713\n\nThis works because in $\\mathbb{Z}/2\\mathbb{Z}$, we have $-1 = 1$.",
     "mathContext": "$p = 2$: $1! = 1$ and in $\\text{ZMod}\\,2$ we have $-1 = 1$ (since $1 + 1 = 0$ in $\\mathbb{Z}/2\\mathbb{Z}$). The group $(\\mathbb{Z}/2\\mathbb{Z})^*$ has only one element: $\\{1\\}$, which is simultaneously 1 and $-1$. The pairing argument trivially gives product $= -1 = 1$. In Lean: `(\u2191(2-1).factorial : ZMod 2) = -1` is proved by `ZMod.wilsons_lemma 2` with `Fact (Nat.Prime 2)` inferred from `Nat.prime_two`.",
@@ -168,7 +168,7 @@
       "name": "prod_one_to_pred_prime",
       "kind": "theorem"
     },
-    "type": "context",
+    "type": "concept",
     "title": "Counterexample: n = 4 (Non-Prime)",
     "content": "For $n = 4$ (composite):\n- $(4-1)! = 3! = 6$\n- $6 = 1 \\cdot 4 + 2 \\equiv 2 \\pmod{4}$\n- $-1 \\equiv 3 \\pmod{4}$\n\nSo $6 \\not\\equiv -1 \\pmod{4}$ \u2717\n\nThis confirms 4 is not prime (which we knew). The backward direction tells us: since $(n-1)! \\not\\equiv -1$, the number cannot be prime.",
     "mathContext": "$n = 4$: $3! = 6 \\equiv 2 \\pmod{4}$, while $-1 \\equiv 3 \\pmod{4}$, so $6 \\not\\equiv -1 \\pmod{4}$. Why does the pairing argument fail? In $\\mathbb{Z}/4\\mathbb{Z}$, the units are $\\{1, 3\\}$ (both self-inverse since $1^2 = 1$ and $3^2 = 9 \\equiv 1$), but their product is $3 \\equiv -1$. The issue is $2 \\in \\{1,2,3\\}$ but $2$ is not a unit \u2014 it has no inverse modulo 4 \u2014 so $(n-1)!$ picks up a factor of 2 with no partner, forcing the product away from $-1$.",
@@ -214,7 +214,7 @@
       "type": "namespace",
       "name": "WilsonsTheorem"
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Working with ZMod",
     "content": "In Lean/Mathlib, `ZMod n` represents the integers modulo $n$:\n\n```\nZMod n := if n = 0 then Z else Fin n\n```\n\nFor prime $p$, `ZMod p` is a field (we can divide). The typeclass `Fact (Nat.Prime p)` provides this automatically.\n\nThe coercion `(k : ZMod n)` converts a natural number to its residue class.",
     "significance": "supporting",


### PR DESCRIPTION
## Problem

Issue #31246: gallery annotations carry `type` values outside the `AnnotationType`
enum in `src/types/proof.ts` (`theorem|lemma|definition|tactic|concept|insight|warning`).

PR #43234 (open, mergeable) sweeps the **generated** `annotations.json` files. But
for the 31 proofs that have an `annotations.source.json`, `pnpm build`
(`pnpm annotations:build` → `scripts/annotations/build.ts`) **regenerates**
`annotations.json` from that source (build.ts:198-231), copying the annotation
`type` verbatim. So #43234's fix for those 31 slugs is silently overwritten on the
next build — the invalid values live in the authoritative source.

## Fix

Repair the source data. Value-only, line-preserving text replacement per the
#31246 map:
- `technique` → `tactic` (45 occurrences)
- `context` → `concept` (17 occurrences)

62 replacements across 31 `annotations.source.json` files. No JSON reformat.
Anchor `type` values (`declaration` / `section-doc` / `doc-comment` / `namespace`
/ `imports` / ...) never equal `technique`/`context`, so anchor resolution is
untouched (verified in the diff).

## Evidence

Before: 31 source files, 62 annotation-level `type` values outside the enum.
After: `0` invalid annotation `type` values remaining across all
`src/data/proofs/*/annotations.source.json` (re-scanned). Each edited file
re-parses as valid JSON with all annotation types in the enum.

Complements (does not duplicate) #43234 — that PR fixes generated files; this one
fixes the source so the fix survives regeneration.

Refs #31246
