### PR TITLE
research(erdos-98-wip-01): h 6 ≤ 4 — first nontrivial six-point upper bound [0 ax / 0 sorry]

### DIFF
--- a/proofs/Proofs/Erdos98WIP01SixUpper.lean
+++ b/proofs/Proofs/Erdos98WIP01SixUpper.lean
@@ -1,0 +1,267 @@
+/-
+  Erdős Problem #98 — Distinct distances in general position:
+  the first nontrivial upper bound for six points — `h 6 ≤ 4` (0-axiom).
+
+  Companion to `Erdos98WIP01.lean` (exact values `h 2 = h 3 = 1`, `h 4 = 2`,
+  `h 5 = 3`) and `Erdos98WIP01Thresholds.lean` (`3 ≤ h 6` from monotonicity).
+
+  Before this file the only upper bound available for six points was the generic
+  ceiling `h 6 ≤ 6.choose 2 = 15` (`h_le_choose_two`).  The blocked-route registry
+  records that pinning the exact value `h 6 = 3` needs a general-position 6-point
+  3-distance configuration whose existence is itself open.  This file does what IS
+  reachable: an explicit general-position 6-point configuration with exactly FOUR
+  distinct distances, pinning `h 6 ∈ {3, 4}`.
+
+  **The configuration** (`sixConfig`): two concentric equilateral triangles,
+  inner of circumradius `1` at angles `0°, 120°, 240°`, outer of circumradius `√2`
+  at angles `90°, 210°, 330°` (twist `90°`):
+
+    P₀ = (1, 0)          P₁ = (−1/2, √3/2)     P₂ = (−1/2, −√3/2)
+    P₃ = (0, √2)         P₄ = (−√6/2, −√2/2)   P₅ = (√6/2, −√2/2)
+
+  Squared distances: inner side `3`, outer side `6`, and cross distances
+  `|B − A|² = 3 − 2√2·cos Δ` for twist angles `Δ ∈ {90°, 210°, 330°}`, i.e.
+  `3`, `3 + √6`, `3 − √6`.  The `Δ = 90°` cross orbit MERGES with the inner side
+  (that is the point of the `√2` radius: `R² = 2r²` makes `cos Δ = 0` work), so
+  only four values `{3, 6, 3 + √6, 3 − √6}` occur — distances
+  `{√3, √6, √(3+√6), √(3−√6)}`.
+
+  **General position**:
+  * no 3 collinear — all 20 triple determinants are nonzero;
+  * no 4 concyclic — the two circumcircles are concentric of different radii, so
+    a 3+1 split fails on radii; a 2+2 split would need an inner chord parallel to
+    an outer chord, but inner chord directions are `{30°, 90°, 150°}` and outer
+    ones `{0°, 60°, 120°}` — disjoint.  Formally, all 15 concyclicity
+    determinants are nonzero.
+
+  Both conditions are verified by two new GENERAL determinant criteria
+  (`not_collinear_of_det`, `not_concyclic_of_det`) whose proofs are deterministic
+  `linear_combination` cofactor identities — no per-case search with unknown
+  line/centre coordinates, unlike the `h5Config` treatment.  Each of the 35
+  concrete obligations is then a numeric surd inequality.
+
+  Within the twisted-triangle two-parameter family `(R, θ)` a THREE-distance
+  merge is impossible in general position: `inner = cross₁ = cross₂` or
+  `inner = cross₁, outer = cross₂` force `R = 2, θ = ±60°` (three points
+  collinear: the config degenerates to alternating hexagonal directions where
+  `(−√3,1), (0,1), (√3,1)` are collinear) or `R = 1` (the two triangles
+  coincide).  So `h 6 = 3`, if true, needs a construction outside this family —
+  consistent with the blocked-route registry entry.
+
+  ## Summary: 0 sorries, 0 axioms, no `native_decide`.
+-/
+
+import Mathlib
+import Proofs.Erdos98WIP01Thresholds
+
+open Finset
+
+namespace Erdos98WIP01
+
+/-! ## Shared surd facts
+
+All arithmetic below lives in `ℚ(√2, √3)` (with `√6 = √2·√3`).  We record the
+squares, positivity, pairwise products, and rational bracketing bounds once. -/
+
+private theorem sqrt_two_sq : Real.sqrt 2 ^ 2 = 2 := Real.sq_sqrt (by norm_num)
+private theorem sqrt_three_sq : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+private theorem sqrt_six_sq : Real.sqrt 6 ^ 2 = 6 := Real.sq_sqrt (by norm_num)
+
+private theorem sqrt_two_pos : (0 : ℝ) < Real.sqrt 2 := Real.sqrt_pos.mpr (by norm_num)
+private theorem sqrt_three_pos : (0 : ℝ) < Real.sqrt 3 := Real.sqrt_pos.mpr (by norm_num)
+private theorem sqrt_six_pos : (0 : ℝ) < Real.sqrt 6 := Real.sqrt_pos.mpr (by norm_num)
+
+private theorem sqrt_two_mul_sqrt_three : Real.sqrt 2 * Real.sqrt 3 = Real.sqrt 6 := by
+  rw [← Real.sqrt_mul (by norm_num : (0 : ℝ) ≤ 2)]
+  norm_num
+
+private theorem sqrt_two_mul_sqrt_six : Real.sqrt 2 * Real.sqrt 6 = 2 * Real.sqrt 3 := by
+  linear_combination (- Real.sqrt 2) * sqrt_two_mul_sqrt_three + Real.sqrt 3 * sqrt_two_sq
+
+private theorem sqrt_three_mul_sqrt_six : Real.sqrt 3 * Real.sqrt 6 = 3 * Real.sqrt 2 := by
+  linear_combination (- Real.sqrt 3) * sqrt_two_mul_sqrt_three + Real.sqrt 2 * sqrt_three_sq
+
+private theorem sqrt_two_lt : Real.sqrt 2 < 1.415 := by
+  nlinarith [sqrt_two_sq, sqrt_two_pos]
+
+private theorem lt_sqrt_two : (1.414 : ℝ) < Real.sqrt 2 := by
+  nlinarith [sqrt_two_sq, sqrt_two_pos]
+
+private theorem sqrt_three_lt : Real.sqrt 3 < 1.733 := by
+  nlinarith [sqrt_three_sq, sqrt_three_pos]
+
+private theorem lt_sqrt_three : (1.732 : ℝ) < Real.sqrt 3 := by
+  nlinarith [sqrt_three_sq, sqrt_three_pos]
+
+private theorem sqrt_six_lt : Real.sqrt 6 < 2.450 := by
+  nlinarith [sqrt_six_sq, sqrt_six_pos]
+
+private theorem lt_sqrt_six : (2.449 : ℝ) < Real.sqrt 6 := by
+  nlinarith [sqrt_six_sq, sqrt_six_pos]
+
+/-! ## General determinant criteria for the two nondegeneracy conditions
+
+Unlike the `h5Config` treatment (which ran `nlinarith` searches over unknown
+line coefficients / circle centres in every case), we prove two reusable
+criteria once, by deterministic cofactor `linear_combination` identities.  Each
+concrete triple/quadruple then only owes a NUMERIC determinant `≠ 0`. -/
+
+/-- **Line-determinant criterion.**  If the affine determinant
+`(q₀−p₀)(r₁−p₁) − (r₀−p₀)(q₁−p₁)` is nonzero (twice the signed triangle area),
+no line `a·x + b·y + c = 0` with `(a,b,c) ≠ 0` passes through `p, q, r`. -/
+theorem not_collinear_of_det {p q r : EuclideanSpace ℝ (Fin 2)}
+    (hdet : (q 0 - p 0) * (r 1 - p 1) - (r 0 - p 0) * (q 1 - p 1) ≠ 0) :
+    ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
+      a * (p 0) + b * (p 1) + c = 0 ∧
+      a * (q 0) + b * (q 1) + c = 0 ∧
+      a * (r 0) + b * (r 1) + c = 0 := by
+  rintro ⟨a, b, c, hne, hp, hq, hr⟩
+  have h1 : a * (q 0 - p 0) + b * (q 1 - p 1) = 0 := by linear_combination hq - hp
+  have h2 : a * (r 0 - p 0) + b * (r 1 - p 1) = 0 := by linear_combination hr - hp
+  have ha : a = 0 := by
+    have h3 : a * ((q 0 - p 0) * (r 1 - p 1) - (r 0 - p 0) * (q 1 - p 1)) = 0 := by
+      linear_combination (r 1 - p 1) * h1 - (q 1 - p 1) * h2
+    exact (mul_eq_zero.mp h3).resolve_right hdet
+  have hb : b = 0 := by
+    have h3 : b * ((q 0 - p 0) * (r 1 - p 1) - (r 0 - p 0) * (q 1 - p 1)) = 0 := by
+      linear_combination (-(r 0 - p 0)) * h1 + (q 0 - p 0) * h2
+    exact (mul_eq_zero.mp h3).resolve_right hdet
+  have hc : c = 0 := by linear_combination hp - (p 0) * ha - (p 1) * hb
+  exact hne (by rw [ha, hb, hc])
+
+/-- **Circle-determinant criterion.**  Writing `N t = t₀² + t₁²`, if the 3×3
+determinant `det [[q−p, Nq−Np], [r−p, Nr−Np], [s−p, Ns−Np]]` (expanded along its
+last column below) is nonzero, then no centre is equidistant from `p, q, r, s` —
+the four points are not concyclic.  Equidistance gives three chord equations
+`2c·(t−p) = Nt−Np` linear in the centre `c`; the cofactor combination of the
+three equations eliminates `c` identically and evaluates the determinant, which
+must then vanish. -/
+theorem not_concyclic_of_det {p q r s : EuclideanSpace ℝ (Fin 2)}
+    (hdet :
+      ((q 0) ^ 2 + (q 1) ^ 2 - (p 0) ^ 2 - (p 1) ^ 2) *
+          ((r 0 - p 0) * (s 1 - p 1) - (s 0 - p 0) * (r 1 - p 1))
+        - ((r 0) ^ 2 + (r 1) ^ 2 - (p 0) ^ 2 - (p 1) ^ 2) *
+          ((q 0 - p 0) * (s 1 - p 1) - (s 0 - p 0) * (q 1 - p 1))
+        + ((s 0) ^ 2 + (s 1) ^ 2 - (p 0) ^ 2 - (p 1) ^ 2) *
+          ((q 0 - p 0) * (r 1 - p 1) - (r 0 - p 0) * (q 1 - p 1)) ≠ 0) :
+    ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
+      dist center p = ρ ∧ dist center q = ρ ∧ dist center r = ρ ∧ dist center s = ρ := by
+  rintro ⟨c, ρ, hp, hq, hr, hs⟩
+  apply hdet
+  have eq1 : dist c q ^ 2 = dist c p ^ 2 := by rw [hq, hp]
+  have eq2 : dist c r ^ 2 = dist c p ^ 2 := by rw [hr, hp]
+  have eq3 : dist c s ^ 2 = dist c p ^ 2 := by rw [hs, hp]
+  simp only [EuclideanSpace.dist_sq_eq, Fin.sum_univ_two, Real.dist_eq, sq_abs] at eq1 eq2 eq3
+  linear_combination
+    ((r 0 - p 0) * (s 1 - p 1) - (s 0 - p 0) * (r 1 - p 1)) * eq1
+      - ((q 0 - p 0) * (s 1 - p 1) - (s 0 - p 0) * (q 1 - p 1)) * eq2
+      + ((q 0 - p 0) * (r 1 - p 1) - (r 0 - p 0) * (q 1 - p 1)) * eq3
+
+/-! ## The configuration -/
+
+/-- **The 4-distance witness**: inner equilateral triangle of circumradius `1`
+(angles `0°, 120°, 240°`) and outer equilateral triangle of circumradius `√2`
+(angles `90°, 210°, 330°`). -/
+noncomputable def sixConfig : PointConfig 6 :=
+  ![!₂[1, 0], !₂[-(1 / 2), Real.sqrt 3 / 2], !₂[-(1 / 2), -(Real.sqrt 3 / 2)],
+    !₂[0, Real.sqrt 2], !₂[-(Real.sqrt 6 / 2), -(Real.sqrt 2 / 2)],
+    !₂[Real.sqrt 6 / 2, -(Real.sqrt 2 / 2)]]
+
+set_option maxHeartbeats 1600000 in
+/-- **Every pairwise squared distance of `sixConfig` is `3`, `6`, `3 + √6`, or
+`3 − √6`.**  A direct coordinate computation over all off-diagonal pairs, using
+`√2² = 2`, `√3² = 3`, `√6² = 6`, and `√2·√3 = √6`. -/
+theorem sixConfig_dist_sq {i j : Fin 6} (hij : i ≠ j) :
+    dist (sixConfig i) (sixConfig j) ^ 2 = 3 ∨
+    dist (sixConfig i) (sixConfig j) ^ 2 = 6 ∨
+    dist (sixConfig i) (sixConfig j) ^ 2 = 3 + Real.sqrt 6 ∨
+    dist (sixConfig i) (sixConfig j) ^ 2 = 3 - Real.sqrt 6 := by
+  rw [EuclideanSpace.dist_sq_eq]
+  fin_cases i <;> fin_cases j <;>
+    first
+    | exact absurd rfl hij
+    | (simp only [sixConfig, Fin.sum_univ_two, Real.dist_eq, sq_abs]
+       first
+       | (left
+          norm_num
+          nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
+            sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six])
+       | (right; left
+          norm_num
+          nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
+            sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six])
+       | (right; right; left
+          norm_num
+          nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
+            sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six])
+       | (right; right; right
+          norm_num
+          nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
+            sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six]))
+
+/-- **Every pairwise distance of `sixConfig` lies in
+`{√3, √6, √(3+√6), √(3−√6)}`.**  Nonnegative square roots of
+`sixConfig_dist_sq`. -/
+theorem sixConfig_dist_mem {i j : Fin 6} (hij : i ≠ j) :
+    dist (sixConfig i) (sixConfig j) ∈
+      ({Real.sqrt 3, Real.sqrt 6, Real.sqrt (3 + Real.sqrt 6),
+        Real.sqrt (3 - Real.sqrt 6)} : Finset ℝ) := by
+  have hd0 : 0 ≤ dist (sixConfig i) (sixConfig j) := dist_nonneg
+  rcases sixConfig_dist_sq hij with h | h | h | h
+  · have he : dist (sixConfig i) (sixConfig j) = Real.sqrt 3 := by
+      rw [← Real.sqrt_sq hd0, h]
+    simp [he]
+  · have he : dist (sixConfig i) (sixConfig j) = Real.sqrt 6 := by
+      rw [← Real.sqrt_sq hd0, h]
+    simp [he]
+  · have he : dist (sixConfig i) (sixConfig j) = Real.sqrt (3 + Real.sqrt 6) := by
+      rw [← Real.sqrt_sq hd0, h]
+    simp [he]
+  · have he : dist (sixConfig i) (sixConfig j) = Real.sqrt (3 - Real.sqrt 6) := by
+      rw [← Real.sqrt_sq hd0, h]
+    simp [he]
+
+/-- The six points are distinct: every pairwise distance lies in a set of four
+positive reals, so it never vanishes. -/
+theorem sixConfig_injective : Function.Injective sixConfig := by
+  intro i j hij
+  by_contra hne
+  have hmem := sixConfig_dist_mem hne
+  rw [hij, dist_self] at hmem
+  simp only [Finset.mem_insert, Finset.mem_singleton] at hmem
+  have hp1 : (0 : ℝ) < Real.sqrt (3 + Real.sqrt 6) :=
+    Real.sqrt_pos.mpr (by positivity)
+  have hp2 : (0 : ℝ) < Real.sqrt (3 - Real.sqrt 6) :=
+    Real.sqrt_pos.mpr (by linarith [sqrt_six_lt])
+  rcases hmem with h | h | h | h
+  · linarith [sqrt_three_pos]
+  · linarith [sqrt_six_pos]
+  · linarith [hp1]
+  · linarith [hp2]
+
+/-! ## No three collinear: 20 numeric line determinants -/
+
+section NoLine
+
+/-- Closing tactic for the 20 line-determinant obligations: reduce the
+coordinates, then refute the vanishing of a `ℚ(√2,√3)`-linear combination using
+the recorded surd facts and rational bracketing bounds. -/
+private def sixLineFacts : Unit := ()  -- (documentation anchor only)
+
+private theorem six_noLine_012 :
+    ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
+      a * (sixConfig 0 0) + b * (sixConfig 0 1) + c = 0 ∧
+      a * (sixConfig 1 0) + b * (sixConfig 1 1) + c = 0 ∧
+      a * (sixConfig 2 0) + b * (sixConfig 2 1) + c = 0 := by
+  apply not_collinear_of_det
+  simp only [sixConfig]
+  intro heq
+  norm_num at heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+end NoLine
+
+end Erdos98WIP01

--- a/proofs/Proofs/Erdos98WIP01SixUpper.lean
+++ b/proofs/Proofs/Erdos98WIP01SixUpper.lean
@@ -463,11 +463,18 @@ private theorem six_noLine_012 :
   apply not_collinear_of_det
   simp only [sixConfig_zero, sixConfig_one, sixConfig_two]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noLine_013 :
     ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
@@ -477,11 +484,18 @@ private theorem six_noLine_013 :
   apply not_collinear_of_det
   simp only [sixConfig_zero, sixConfig_one, sixConfig_three]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noLine_014 :
     ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
@@ -491,11 +505,18 @@ private theorem six_noLine_014 :
   apply not_collinear_of_det
   simp only [sixConfig_zero, sixConfig_one, sixConfig_four]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noLine_015 :
     ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
@@ -505,11 +526,18 @@ private theorem six_noLine_015 :
   apply not_collinear_of_det
   simp only [sixConfig_zero, sixConfig_one, sixConfig_five]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noLine_023 :
     ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
@@ -519,11 +547,18 @@ private theorem six_noLine_023 :
   apply not_collinear_of_det
   simp only [sixConfig_zero, sixConfig_two, sixConfig_three]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noLine_024 :
     ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
@@ -533,11 +568,18 @@ private theorem six_noLine_024 :
   apply not_collinear_of_det
   simp only [sixConfig_zero, sixConfig_two, sixConfig_four]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noLine_025 :
     ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
@@ -547,11 +589,18 @@ private theorem six_noLine_025 :
   apply not_collinear_of_det
   simp only [sixConfig_zero, sixConfig_two, sixConfig_five]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noLine_034 :
     ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
@@ -561,11 +610,18 @@ private theorem six_noLine_034 :
   apply not_collinear_of_det
   simp only [sixConfig_zero, sixConfig_three, sixConfig_four]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noLine_035 :
     ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
@@ -575,11 +631,18 @@ private theorem six_noLine_035 :
   apply not_collinear_of_det
   simp only [sixConfig_zero, sixConfig_three, sixConfig_five]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noLine_045 :
     ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
@@ -589,11 +652,18 @@ private theorem six_noLine_045 :
   apply not_collinear_of_det
   simp only [sixConfig_zero, sixConfig_four, sixConfig_five]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noLine_123 :
     ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
@@ -603,11 +673,18 @@ private theorem six_noLine_123 :
   apply not_collinear_of_det
   simp only [sixConfig_one, sixConfig_two, sixConfig_three]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noLine_124 :
     ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
@@ -617,11 +694,18 @@ private theorem six_noLine_124 :
   apply not_collinear_of_det
   simp only [sixConfig_one, sixConfig_two, sixConfig_four]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noLine_125 :
     ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
@@ -631,11 +715,18 @@ private theorem six_noLine_125 :
   apply not_collinear_of_det
   simp only [sixConfig_one, sixConfig_two, sixConfig_five]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noLine_134 :
     ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
@@ -645,11 +736,18 @@ private theorem six_noLine_134 :
   apply not_collinear_of_det
   simp only [sixConfig_one, sixConfig_three, sixConfig_four]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noLine_135 :
     ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
@@ -659,11 +757,18 @@ private theorem six_noLine_135 :
   apply not_collinear_of_det
   simp only [sixConfig_one, sixConfig_three, sixConfig_five]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noLine_145 :
     ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
@@ -673,11 +778,18 @@ private theorem six_noLine_145 :
   apply not_collinear_of_det
   simp only [sixConfig_one, sixConfig_four, sixConfig_five]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noLine_234 :
     ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
@@ -687,11 +799,18 @@ private theorem six_noLine_234 :
   apply not_collinear_of_det
   simp only [sixConfig_two, sixConfig_three, sixConfig_four]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noLine_235 :
     ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
@@ -701,11 +820,18 @@ private theorem six_noLine_235 :
   apply not_collinear_of_det
   simp only [sixConfig_two, sixConfig_three, sixConfig_five]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noLine_245 :
     ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
@@ -715,11 +841,18 @@ private theorem six_noLine_245 :
   apply not_collinear_of_det
   simp only [sixConfig_two, sixConfig_four, sixConfig_five]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noLine_345 :
     ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
@@ -729,11 +862,18 @@ private theorem six_noLine_345 :
   apply not_collinear_of_det
   simp only [sixConfig_three, sixConfig_four, sixConfig_five]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 end NoLine
 
@@ -779,11 +919,18 @@ private theorem six_noCircle_0123 :
   apply not_concyclic_of_det
   simp only [sixConfig_zero, sixConfig_one, sixConfig_two, sixConfig_three]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noCircle_0124 :
     ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
@@ -792,11 +939,18 @@ private theorem six_noCircle_0124 :
   apply not_concyclic_of_det
   simp only [sixConfig_zero, sixConfig_one, sixConfig_two, sixConfig_four]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noCircle_0125 :
     ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
@@ -805,11 +959,18 @@ private theorem six_noCircle_0125 :
   apply not_concyclic_of_det
   simp only [sixConfig_zero, sixConfig_one, sixConfig_two, sixConfig_five]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noCircle_0134 :
     ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
@@ -818,11 +979,18 @@ private theorem six_noCircle_0134 :
   apply not_concyclic_of_det
   simp only [sixConfig_zero, sixConfig_one, sixConfig_three, sixConfig_four]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noCircle_0135 :
     ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
@@ -831,11 +999,18 @@ private theorem six_noCircle_0135 :
   apply not_concyclic_of_det
   simp only [sixConfig_zero, sixConfig_one, sixConfig_three, sixConfig_five]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noCircle_0145 :
     ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
@@ -844,11 +1019,18 @@ private theorem six_noCircle_0145 :
   apply not_concyclic_of_det
   simp only [sixConfig_zero, sixConfig_one, sixConfig_four, sixConfig_five]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noCircle_0234 :
     ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
@@ -857,11 +1039,18 @@ private theorem six_noCircle_0234 :
   apply not_concyclic_of_det
   simp only [sixConfig_zero, sixConfig_two, sixConfig_three, sixConfig_four]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noCircle_0235 :
     ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
@@ -870,11 +1059,18 @@ private theorem six_noCircle_0235 :
   apply not_concyclic_of_det
   simp only [sixConfig_zero, sixConfig_two, sixConfig_three, sixConfig_five]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noCircle_0245 :
     ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
@@ -883,11 +1079,18 @@ private theorem six_noCircle_0245 :
   apply not_concyclic_of_det
   simp only [sixConfig_zero, sixConfig_two, sixConfig_four, sixConfig_five]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noCircle_0345 :
     ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
@@ -896,11 +1099,18 @@ private theorem six_noCircle_0345 :
   apply not_concyclic_of_det
   simp only [sixConfig_zero, sixConfig_three, sixConfig_four, sixConfig_five]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noCircle_1234 :
     ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
@@ -909,11 +1119,18 @@ private theorem six_noCircle_1234 :
   apply not_concyclic_of_det
   simp only [sixConfig_one, sixConfig_two, sixConfig_three, sixConfig_four]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noCircle_1235 :
     ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
@@ -922,11 +1139,18 @@ private theorem six_noCircle_1235 :
   apply not_concyclic_of_det
   simp only [sixConfig_one, sixConfig_two, sixConfig_three, sixConfig_five]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noCircle_1245 :
     ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
@@ -935,11 +1159,18 @@ private theorem six_noCircle_1245 :
   apply not_concyclic_of_det
   simp only [sixConfig_one, sixConfig_two, sixConfig_four, sixConfig_five]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noCircle_1345 :
     ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
@@ -948,11 +1179,18 @@ private theorem six_noCircle_1345 :
   apply not_concyclic_of_det
   simp only [sixConfig_one, sixConfig_three, sixConfig_four, sixConfig_five]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 private theorem six_noCircle_2345 :
     ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
@@ -961,22 +1199,28 @@ private theorem six_noCircle_2345 :
   apply not_concyclic_of_det
   simp only [sixConfig_two, sixConfig_three, sixConfig_four, sixConfig_five]
   norm_num
-  all_goals intro heq
-  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
-    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
-    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
-    sqrt_six_lt, lt_sqrt_six]
+  all_goals first
+    | (intro heq
+       nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+         sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+         sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+         sqrt_six_lt, lt_sqrt_six])
+    | (constructor <;>
+        (intro heq
+         nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+           sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+           sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+           sqrt_six_lt, lt_sqrt_six]))
 
 end NoCircle
 
-set_option maxHeartbeats 4000000 in
-/-- **No four of the six points are concyclic.**  Every genuine index quadruple
-dispatches (via `assumption`, so in any order) to one of the fifteen per-quadruple
-circle-determinant lemmas. -/
-theorem noFourConcyclic_sixConfig : NoFourConcyclic sixConfig := by
-  intro a b c d hcard
-  rintro ⟨center, ρ, h1, h2, h3, h4⟩
-  fin_cases a <;> fin_cases b <;> fin_cases c <;> fin_cases d <;>
+set_option maxHeartbeats 3200000 in
+private theorem sixConfig_noCircle_with_0 (b c d : Fin 6)
+    (hcard : ({(0 : Fin 6), b, c, d} : Finset (Fin 6)).card = 4)
+    (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ)
+    (h1 : dist center (sixConfig 0) = ρ) (h2 : dist center (sixConfig b) = ρ)
+    (h3 : dist center (sixConfig c) = ρ) (h4 : dist center (sixConfig d) = ρ) : False := by
+  fin_cases b <;> fin_cases c <;> fin_cases d <;>
     first
     | exact absurd hcard (by decide)
     | exact six_noCircle_0123
@@ -999,7 +1243,147 @@ theorem noFourConcyclic_sixConfig : NoFourConcyclic sixConfig := by
         ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
     | exact six_noCircle_0345
         ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+
+set_option maxHeartbeats 3200000 in
+private theorem sixConfig_noCircle_with_1 (b c d : Fin 6)
+    (hcard : ({(1 : Fin 6), b, c, d} : Finset (Fin 6)).card = 4)
+    (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ)
+    (h1 : dist center (sixConfig 1) = ρ) (h2 : dist center (sixConfig b) = ρ)
+    (h3 : dist center (sixConfig c) = ρ) (h4 : dist center (sixConfig d) = ρ) : False := by
+  fin_cases b <;> fin_cases c <;> fin_cases d <;>
+    first
+    | exact absurd hcard (by decide)
+    | exact six_noCircle_0123
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0124
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0125
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0134
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0135
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0145
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
     | exact six_noCircle_1234
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_1235
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_1245
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_1345
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+
+set_option maxHeartbeats 3200000 in
+private theorem sixConfig_noCircle_with_2 (b c d : Fin 6)
+    (hcard : ({(2 : Fin 6), b, c, d} : Finset (Fin 6)).card = 4)
+    (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ)
+    (h1 : dist center (sixConfig 2) = ρ) (h2 : dist center (sixConfig b) = ρ)
+    (h3 : dist center (sixConfig c) = ρ) (h4 : dist center (sixConfig d) = ρ) : False := by
+  fin_cases b <;> fin_cases c <;> fin_cases d <;>
+    first
+    | exact absurd hcard (by decide)
+    | exact six_noCircle_0123
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0124
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0125
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0234
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0235
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0245
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_1234
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_1235
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_1245
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_2345
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+
+set_option maxHeartbeats 3200000 in
+private theorem sixConfig_noCircle_with_3 (b c d : Fin 6)
+    (hcard : ({(3 : Fin 6), b, c, d} : Finset (Fin 6)).card = 4)
+    (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ)
+    (h1 : dist center (sixConfig 3) = ρ) (h2 : dist center (sixConfig b) = ρ)
+    (h3 : dist center (sixConfig c) = ρ) (h4 : dist center (sixConfig d) = ρ) : False := by
+  fin_cases b <;> fin_cases c <;> fin_cases d <;>
+    first
+    | exact absurd hcard (by decide)
+    | exact six_noCircle_0123
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0134
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0135
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0234
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0235
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0345
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_1234
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_1235
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_1345
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_2345
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+
+set_option maxHeartbeats 3200000 in
+private theorem sixConfig_noCircle_with_4 (b c d : Fin 6)
+    (hcard : ({(4 : Fin 6), b, c, d} : Finset (Fin 6)).card = 4)
+    (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ)
+    (h1 : dist center (sixConfig 4) = ρ) (h2 : dist center (sixConfig b) = ρ)
+    (h3 : dist center (sixConfig c) = ρ) (h4 : dist center (sixConfig d) = ρ) : False := by
+  fin_cases b <;> fin_cases c <;> fin_cases d <;>
+    first
+    | exact absurd hcard (by decide)
+    | exact six_noCircle_0124
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0134
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0145
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0234
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0245
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0345
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_1234
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_1245
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_1345
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_2345
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+
+set_option maxHeartbeats 3200000 in
+private theorem sixConfig_noCircle_with_5 (b c d : Fin 6)
+    (hcard : ({(5 : Fin 6), b, c, d} : Finset (Fin 6)).card = 4)
+    (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ)
+    (h1 : dist center (sixConfig 5) = ρ) (h2 : dist center (sixConfig b) = ρ)
+    (h3 : dist center (sixConfig c) = ρ) (h4 : dist center (sixConfig d) = ρ) : False := by
+  fin_cases b <;> fin_cases c <;> fin_cases d <;>
+    first
+    | exact absurd hcard (by decide)
+    | exact six_noCircle_0125
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0135
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0145
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0235
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0245
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0345
         ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
     | exact six_noCircle_1235
         ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
@@ -1009,6 +1393,21 @@ theorem noFourConcyclic_sixConfig : NoFourConcyclic sixConfig := by
         ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
     | exact six_noCircle_2345
         ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+
+/-- **No four of the six points are concyclic.**  The first index is split off
+into six helper lemmas (one per value, keeping each within its own heartbeat
+budget); every genuine index quadruple then dispatches (via `assumption`, so in
+any order) to one of the fifteen per-quadruple circle-determinant lemmas. -/
+theorem noFourConcyclic_sixConfig : NoFourConcyclic sixConfig := by
+  intro a b c d hcard
+  rintro ⟨center, ρ, h1, h2, h3, h4⟩
+  fin_cases a
+  · exact sixConfig_noCircle_with_0 b c d hcard center ρ h1 h2 h3 h4
+  · exact sixConfig_noCircle_with_1 b c d hcard center ρ h1 h2 h3 h4
+  · exact sixConfig_noCircle_with_2 b c d hcard center ρ h1 h2 h3 h4
+  · exact sixConfig_noCircle_with_3 b c d hcard center ρ h1 h2 h3 h4
+  · exact sixConfig_noCircle_with_4 b c d hcard center ρ h1 h2 h3 h4
+  · exact sixConfig_noCircle_with_5 b c d hcard center ρ h1 h2 h3 h4
 
 /-- **`sixConfig` is in general position.** -/
 theorem inGeneralPosition_sixConfig : InGeneralPosition sixConfig :=

--- a/proofs/Proofs/Erdos98WIP01SixUpper.lean
+++ b/proofs/Proofs/Erdos98WIP01SixUpper.lean
@@ -10,7 +10,8 @@
   records that pinning the exact value `h 6 = 3` needs a general-position 6-point
   3-distance configuration whose existence is itself open.  This file does what IS
   reachable: an explicit general-position 6-point configuration with exactly FOUR
-  distinct distances, pinning `h 6 ∈ {3, 4}`.
+  distinct distances, pinning `h 6 ∈ {3, 4}` (`h_six_bounds`,
+  `h_six_eq_three_or_four`).
 
   **The configuration** (`sixConfig`): two concentric equilateral triangles,
   inner of circumradius `1` at angles `0°, 120°, 240°`, outer of circumradius `√2`
@@ -22,9 +23,9 @@
   Squared distances: inner side `3`, outer side `6`, and cross distances
   `|B − A|² = 3 − 2√2·cos Δ` for twist angles `Δ ∈ {90°, 210°, 330°}`, i.e.
   `3`, `3 + √6`, `3 − √6`.  The `Δ = 90°` cross orbit MERGES with the inner side
-  (that is the point of the `√2` radius: `R² = 2r²` makes `cos Δ = 0` work), so
-  only four values `{3, 6, 3 + √6, 3 − √6}` occur — distances
-  `{√3, √6, √(3+√6), √(3−√6)}`.
+  (that is the point of the `√2` radius: `R² = 2r²` makes the `cos Δ = 0` cross
+  distance equal the inner side), so only four values `{3, 6, 3 + √6, 3 − √6}`
+  occur — distances `{√3, √6, √(3+√6), √(3−√6)}`.
 
   **General position**:
   * no 3 collinear — all 20 triple determinants are nonzero;
@@ -34,19 +35,18 @@
     ones `{0°, 60°, 120°}` — disjoint.  Formally, all 15 concyclicity
     determinants are nonzero.
 
-  Both conditions are verified by two new GENERAL determinant criteria
+  Both conditions are verified through two new GENERAL determinant criteria
   (`not_collinear_of_det`, `not_concyclic_of_det`) whose proofs are deterministic
   `linear_combination` cofactor identities — no per-case search with unknown
   line/centre coordinates, unlike the `h5Config` treatment.  Each of the 35
   concrete obligations is then a numeric surd inequality.
 
   Within the twisted-triangle two-parameter family `(R, θ)` a THREE-distance
-  merge is impossible in general position: `inner = cross₁ = cross₂` or
-  `inner = cross₁, outer = cross₂` force `R = 2, θ = ±60°` (three points
-  collinear: the config degenerates to alternating hexagonal directions where
-  `(−√3,1), (0,1), (√3,1)` are collinear) or `R = 1` (the two triangles
+  merge is impossible in general position: forcing a third coincidence drives
+  `(R, θ)` to `(2, ±60°)`, whose configuration is degenerate (it contains the
+  collinear triple `(−√3, 1), (0, 1), (√3, 1)`), or to `R = 1` (the triangles
   coincide).  So `h 6 = 3`, if true, needs a construction outside this family —
-  consistent with the blocked-route registry entry.
+  consistent with the blocked-route registry entry for exact `h 6`.
 
   ## Summary: 0 sorries, 0 axioms, no `native_decide`.
 -/
@@ -108,7 +108,9 @@ concrete triple/quadruple then only owes a NUMERIC determinant `≠ 0`. -/
 
 /-- **Line-determinant criterion.**  If the affine determinant
 `(q₀−p₀)(r₁−p₁) − (r₀−p₀)(q₁−p₁)` is nonzero (twice the signed triangle area),
-no line `a·x + b·y + c = 0` with `(a,b,c) ≠ 0` passes through `p, q, r`. -/
+no line `a·x + b·y + c = 0` with `(a,b,c) ≠ 0` passes through `p, q, r`.
+Eliminating `a`, then `b`, is a cofactor `linear_combination` of the two chord
+differences of the line equations. -/
 theorem not_collinear_of_det {p q r : EuclideanSpace ℝ (Fin 2)}
     (hdet : (q 0 - p 0) * (r 1 - p 1) - (r 0 - p 0) * (q 1 - p 1) ≠ 0) :
     ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
@@ -167,37 +169,247 @@ noncomputable def sixConfig : PointConfig 6 :=
     !₂[0, Real.sqrt 2], !₂[-(Real.sqrt 6 / 2), -(Real.sqrt 2 / 2)],
     !₂[Real.sqrt 6 / 2, -(Real.sqrt 2 / 2)]]
 
-set_option maxHeartbeats 1600000 in
+private theorem sixConfig_zero : sixConfig 0 = !₂[1, 0] := rfl
+private theorem sixConfig_one : sixConfig 1 = !₂[-(1 / 2), Real.sqrt 3 / 2] := rfl
+private theorem sixConfig_two : sixConfig 2 = !₂[-(1 / 2), -(Real.sqrt 3 / 2)] := rfl
+private theorem sixConfig_three : sixConfig 3 = !₂[0, Real.sqrt 2] := rfl
+private theorem sixConfig_four : sixConfig 4 = !₂[-(Real.sqrt 6 / 2), -(Real.sqrt 2 / 2)] := rfl
+private theorem sixConfig_five : sixConfig 5 = !₂[Real.sqrt 6 / 2, -(Real.sqrt 2 / 2)] := rfl
+
+/-! ## The fifteen pairwise squared distances
+
+One deterministic lemma per unordered pair (no branch search): the value is
+injected into the four-way disjunction up front, and the coordinate computation
+is closed by `norm_num` plus the recorded surd facts. -/
+
+section PairDistances
+
+private theorem six_dist_01 :
+    dist (sixConfig 0) (sixConfig 1) ^ 2 = 3 ∨
+    dist (sixConfig 0) (sixConfig 1) ^ 2 = 6 ∨
+    dist (sixConfig 0) (sixConfig 1) ^ 2 = 3 + Real.sqrt 6 ∨
+    dist (sixConfig 0) (sixConfig 1) ^ 2 = 3 - Real.sqrt 6 := by
+  left
+  rw [EuclideanSpace.dist_sq_eq]
+  simp only [sixConfig_zero, sixConfig_one, Fin.sum_univ_two, Real.dist_eq, sq_abs]
+  norm_num
+  all_goals nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
+    sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six]
+
+private theorem six_dist_02 :
+    dist (sixConfig 0) (sixConfig 2) ^ 2 = 3 ∨
+    dist (sixConfig 0) (sixConfig 2) ^ 2 = 6 ∨
+    dist (sixConfig 0) (sixConfig 2) ^ 2 = 3 + Real.sqrt 6 ∨
+    dist (sixConfig 0) (sixConfig 2) ^ 2 = 3 - Real.sqrt 6 := by
+  left
+  rw [EuclideanSpace.dist_sq_eq]
+  simp only [sixConfig_zero, sixConfig_two, Fin.sum_univ_two, Real.dist_eq, sq_abs]
+  norm_num
+  all_goals nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
+    sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six]
+
+private theorem six_dist_03 :
+    dist (sixConfig 0) (sixConfig 3) ^ 2 = 3 ∨
+    dist (sixConfig 0) (sixConfig 3) ^ 2 = 6 ∨
+    dist (sixConfig 0) (sixConfig 3) ^ 2 = 3 + Real.sqrt 6 ∨
+    dist (sixConfig 0) (sixConfig 3) ^ 2 = 3 - Real.sqrt 6 := by
+  left
+  rw [EuclideanSpace.dist_sq_eq]
+  simp only [sixConfig_zero, sixConfig_three, Fin.sum_univ_two, Real.dist_eq, sq_abs]
+  norm_num
+  all_goals nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
+    sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six]
+
+private theorem six_dist_04 :
+    dist (sixConfig 0) (sixConfig 4) ^ 2 = 3 ∨
+    dist (sixConfig 0) (sixConfig 4) ^ 2 = 6 ∨
+    dist (sixConfig 0) (sixConfig 4) ^ 2 = 3 + Real.sqrt 6 ∨
+    dist (sixConfig 0) (sixConfig 4) ^ 2 = 3 - Real.sqrt 6 := by
+  right; right; left
+  rw [EuclideanSpace.dist_sq_eq]
+  simp only [sixConfig_zero, sixConfig_four, Fin.sum_univ_two, Real.dist_eq, sq_abs]
+  norm_num
+  all_goals nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
+    sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six]
+
+private theorem six_dist_05 :
+    dist (sixConfig 0) (sixConfig 5) ^ 2 = 3 ∨
+    dist (sixConfig 0) (sixConfig 5) ^ 2 = 6 ∨
+    dist (sixConfig 0) (sixConfig 5) ^ 2 = 3 + Real.sqrt 6 ∨
+    dist (sixConfig 0) (sixConfig 5) ^ 2 = 3 - Real.sqrt 6 := by
+  right; right; right
+  rw [EuclideanSpace.dist_sq_eq]
+  simp only [sixConfig_zero, sixConfig_five, Fin.sum_univ_two, Real.dist_eq, sq_abs]
+  norm_num
+  all_goals nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
+    sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six]
+
+private theorem six_dist_12 :
+    dist (sixConfig 1) (sixConfig 2) ^ 2 = 3 ∨
+    dist (sixConfig 1) (sixConfig 2) ^ 2 = 6 ∨
+    dist (sixConfig 1) (sixConfig 2) ^ 2 = 3 + Real.sqrt 6 ∨
+    dist (sixConfig 1) (sixConfig 2) ^ 2 = 3 - Real.sqrt 6 := by
+  left
+  rw [EuclideanSpace.dist_sq_eq]
+  simp only [sixConfig_one, sixConfig_two, Fin.sum_univ_two, Real.dist_eq, sq_abs]
+  norm_num
+  all_goals nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
+    sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six]
+
+private theorem six_dist_13 :
+    dist (sixConfig 1) (sixConfig 3) ^ 2 = 3 ∨
+    dist (sixConfig 1) (sixConfig 3) ^ 2 = 6 ∨
+    dist (sixConfig 1) (sixConfig 3) ^ 2 = 3 + Real.sqrt 6 ∨
+    dist (sixConfig 1) (sixConfig 3) ^ 2 = 3 - Real.sqrt 6 := by
+  right; right; right
+  rw [EuclideanSpace.dist_sq_eq]
+  simp only [sixConfig_one, sixConfig_three, Fin.sum_univ_two, Real.dist_eq, sq_abs]
+  norm_num
+  all_goals nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
+    sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six]
+
+private theorem six_dist_14 :
+    dist (sixConfig 1) (sixConfig 4) ^ 2 = 3 ∨
+    dist (sixConfig 1) (sixConfig 4) ^ 2 = 6 ∨
+    dist (sixConfig 1) (sixConfig 4) ^ 2 = 3 + Real.sqrt 6 ∨
+    dist (sixConfig 1) (sixConfig 4) ^ 2 = 3 - Real.sqrt 6 := by
+  left
+  rw [EuclideanSpace.dist_sq_eq]
+  simp only [sixConfig_one, sixConfig_four, Fin.sum_univ_two, Real.dist_eq, sq_abs]
+  norm_num
+  all_goals nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
+    sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six]
+
+private theorem six_dist_15 :
+    dist (sixConfig 1) (sixConfig 5) ^ 2 = 3 ∨
+    dist (sixConfig 1) (sixConfig 5) ^ 2 = 6 ∨
+    dist (sixConfig 1) (sixConfig 5) ^ 2 = 3 + Real.sqrt 6 ∨
+    dist (sixConfig 1) (sixConfig 5) ^ 2 = 3 - Real.sqrt 6 := by
+  right; right; left
+  rw [EuclideanSpace.dist_sq_eq]
+  simp only [sixConfig_one, sixConfig_five, Fin.sum_univ_two, Real.dist_eq, sq_abs]
+  norm_num
+  all_goals nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
+    sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six]
+
+private theorem six_dist_23 :
+    dist (sixConfig 2) (sixConfig 3) ^ 2 = 3 ∨
+    dist (sixConfig 2) (sixConfig 3) ^ 2 = 6 ∨
+    dist (sixConfig 2) (sixConfig 3) ^ 2 = 3 + Real.sqrt 6 ∨
+    dist (sixConfig 2) (sixConfig 3) ^ 2 = 3 - Real.sqrt 6 := by
+  right; right; left
+  rw [EuclideanSpace.dist_sq_eq]
+  simp only [sixConfig_two, sixConfig_three, Fin.sum_univ_two, Real.dist_eq, sq_abs]
+  norm_num
+  all_goals nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
+    sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six]
+
+private theorem six_dist_24 :
+    dist (sixConfig 2) (sixConfig 4) ^ 2 = 3 ∨
+    dist (sixConfig 2) (sixConfig 4) ^ 2 = 6 ∨
+    dist (sixConfig 2) (sixConfig 4) ^ 2 = 3 + Real.sqrt 6 ∨
+    dist (sixConfig 2) (sixConfig 4) ^ 2 = 3 - Real.sqrt 6 := by
+  right; right; right
+  rw [EuclideanSpace.dist_sq_eq]
+  simp only [sixConfig_two, sixConfig_four, Fin.sum_univ_two, Real.dist_eq, sq_abs]
+  norm_num
+  all_goals nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
+    sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six]
+
+private theorem six_dist_25 :
+    dist (sixConfig 2) (sixConfig 5) ^ 2 = 3 ∨
+    dist (sixConfig 2) (sixConfig 5) ^ 2 = 6 ∨
+    dist (sixConfig 2) (sixConfig 5) ^ 2 = 3 + Real.sqrt 6 ∨
+    dist (sixConfig 2) (sixConfig 5) ^ 2 = 3 - Real.sqrt 6 := by
+  left
+  rw [EuclideanSpace.dist_sq_eq]
+  simp only [sixConfig_two, sixConfig_five, Fin.sum_univ_two, Real.dist_eq, sq_abs]
+  norm_num
+  all_goals nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
+    sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six]
+
+private theorem six_dist_34 :
+    dist (sixConfig 3) (sixConfig 4) ^ 2 = 3 ∨
+    dist (sixConfig 3) (sixConfig 4) ^ 2 = 6 ∨
+    dist (sixConfig 3) (sixConfig 4) ^ 2 = 3 + Real.sqrt 6 ∨
+    dist (sixConfig 3) (sixConfig 4) ^ 2 = 3 - Real.sqrt 6 := by
+  right; left
+  rw [EuclideanSpace.dist_sq_eq]
+  simp only [sixConfig_three, sixConfig_four, Fin.sum_univ_two, Real.dist_eq, sq_abs]
+  norm_num
+  all_goals nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
+    sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six]
+
+private theorem six_dist_35 :
+    dist (sixConfig 3) (sixConfig 5) ^ 2 = 3 ∨
+    dist (sixConfig 3) (sixConfig 5) ^ 2 = 6 ∨
+    dist (sixConfig 3) (sixConfig 5) ^ 2 = 3 + Real.sqrt 6 ∨
+    dist (sixConfig 3) (sixConfig 5) ^ 2 = 3 - Real.sqrt 6 := by
+  right; left
+  rw [EuclideanSpace.dist_sq_eq]
+  simp only [sixConfig_three, sixConfig_five, Fin.sum_univ_two, Real.dist_eq, sq_abs]
+  norm_num
+  all_goals nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
+    sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six]
+
+private theorem six_dist_45 :
+    dist (sixConfig 4) (sixConfig 5) ^ 2 = 3 ∨
+    dist (sixConfig 4) (sixConfig 5) ^ 2 = 6 ∨
+    dist (sixConfig 4) (sixConfig 5) ^ 2 = 3 + Real.sqrt 6 ∨
+    dist (sixConfig 4) (sixConfig 5) ^ 2 = 3 - Real.sqrt 6 := by
+  right; left
+  rw [EuclideanSpace.dist_sq_eq]
+  simp only [sixConfig_four, sixConfig_five, Fin.sum_univ_two, Real.dist_eq, sq_abs]
+  norm_num
+  all_goals nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
+    sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six]
+
+end PairDistances
+
+set_option maxHeartbeats 800000 in
 /-- **Every pairwise squared distance of `sixConfig` is `3`, `6`, `3 + √6`, or
-`3 − √6`.**  A direct coordinate computation over all off-diagonal pairs, using
-`√2² = 2`, `√3² = 3`, `√6² = 6`, and `√2·√3 = √6`. -/
+`3 − √6`.**  Assembled from the fifteen per-pair lemmas; the transposed pairs
+reduce to them by `dist_comm`. -/
 theorem sixConfig_dist_sq {i j : Fin 6} (hij : i ≠ j) :
     dist (sixConfig i) (sixConfig j) ^ 2 = 3 ∨
     dist (sixConfig i) (sixConfig j) ^ 2 = 6 ∨
     dist (sixConfig i) (sixConfig j) ^ 2 = 3 + Real.sqrt 6 ∨
     dist (sixConfig i) (sixConfig j) ^ 2 = 3 - Real.sqrt 6 := by
-  rw [EuclideanSpace.dist_sq_eq]
   fin_cases i <;> fin_cases j <;>
     first
     | exact absurd rfl hij
-    | (simp only [sixConfig, Fin.sum_univ_two, Real.dist_eq, sq_abs]
+    | exact six_dist_01
+    | exact six_dist_02
+    | exact six_dist_03
+    | exact six_dist_04
+    | exact six_dist_05
+    | exact six_dist_12
+    | exact six_dist_13
+    | exact six_dist_14
+    | exact six_dist_15
+    | exact six_dist_23
+    | exact six_dist_24
+    | exact six_dist_25
+    | exact six_dist_34
+    | exact six_dist_35
+    | exact six_dist_45
+    | (rw [dist_comm]
        first
-       | (left
-          norm_num
-          nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
-            sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six])
-       | (right; left
-          norm_num
-          nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
-            sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six])
-       | (right; right; left
-          norm_num
-          nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
-            sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six])
-       | (right; right; right
-          norm_num
-          nlinarith [sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_mul_sqrt_three,
-            sqrt_two_mul_sqrt_six, sqrt_three_mul_sqrt_six]))
+       | exact six_dist_01
+       | exact six_dist_02
+       | exact six_dist_03
+       | exact six_dist_04
+       | exact six_dist_05
+       | exact six_dist_12
+       | exact six_dist_13
+       | exact six_dist_14
+       | exact six_dist_15
+       | exact six_dist_23
+       | exact six_dist_24
+       | exact six_dist_25
+       | exact six_dist_34
+       | exact six_dist_35
+       | exact six_dist_45)
 
 /-- **Every pairwise distance of `sixConfig` lies in
 `{√3, √6, √(3+√6), √(3−√6)}`.**  Nonnegative square roots of
@@ -243,25 +455,622 @@ theorem sixConfig_injective : Function.Injective sixConfig := by
 
 section NoLine
 
-/-- Closing tactic for the 20 line-determinant obligations: reduce the
-coordinates, then refute the vanishing of a `ℚ(√2,√3)`-linear combination using
-the recorded surd facts and rational bracketing bounds. -/
-private def sixLineFacts : Unit := ()  -- (documentation anchor only)
-
 private theorem six_noLine_012 :
     ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
       a * (sixConfig 0 0) + b * (sixConfig 0 1) + c = 0 ∧
       a * (sixConfig 1 0) + b * (sixConfig 1 1) + c = 0 ∧
       a * (sixConfig 2 0) + b * (sixConfig 2 1) + c = 0 := by
   apply not_collinear_of_det
-  simp only [sixConfig]
-  intro heq
-  norm_num at heq
+  simp only [sixConfig_zero, sixConfig_one, sixConfig_two]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noLine_013 :
+    ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
+      a * (sixConfig 0 0) + b * (sixConfig 0 1) + c = 0 ∧
+      a * (sixConfig 1 0) + b * (sixConfig 1 1) + c = 0 ∧
+      a * (sixConfig 3 0) + b * (sixConfig 3 1) + c = 0 := by
+  apply not_collinear_of_det
+  simp only [sixConfig_zero, sixConfig_one, sixConfig_three]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noLine_014 :
+    ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
+      a * (sixConfig 0 0) + b * (sixConfig 0 1) + c = 0 ∧
+      a * (sixConfig 1 0) + b * (sixConfig 1 1) + c = 0 ∧
+      a * (sixConfig 4 0) + b * (sixConfig 4 1) + c = 0 := by
+  apply not_collinear_of_det
+  simp only [sixConfig_zero, sixConfig_one, sixConfig_four]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noLine_015 :
+    ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
+      a * (sixConfig 0 0) + b * (sixConfig 0 1) + c = 0 ∧
+      a * (sixConfig 1 0) + b * (sixConfig 1 1) + c = 0 ∧
+      a * (sixConfig 5 0) + b * (sixConfig 5 1) + c = 0 := by
+  apply not_collinear_of_det
+  simp only [sixConfig_zero, sixConfig_one, sixConfig_five]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noLine_023 :
+    ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
+      a * (sixConfig 0 0) + b * (sixConfig 0 1) + c = 0 ∧
+      a * (sixConfig 2 0) + b * (sixConfig 2 1) + c = 0 ∧
+      a * (sixConfig 3 0) + b * (sixConfig 3 1) + c = 0 := by
+  apply not_collinear_of_det
+  simp only [sixConfig_zero, sixConfig_two, sixConfig_three]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noLine_024 :
+    ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
+      a * (sixConfig 0 0) + b * (sixConfig 0 1) + c = 0 ∧
+      a * (sixConfig 2 0) + b * (sixConfig 2 1) + c = 0 ∧
+      a * (sixConfig 4 0) + b * (sixConfig 4 1) + c = 0 := by
+  apply not_collinear_of_det
+  simp only [sixConfig_zero, sixConfig_two, sixConfig_four]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noLine_025 :
+    ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
+      a * (sixConfig 0 0) + b * (sixConfig 0 1) + c = 0 ∧
+      a * (sixConfig 2 0) + b * (sixConfig 2 1) + c = 0 ∧
+      a * (sixConfig 5 0) + b * (sixConfig 5 1) + c = 0 := by
+  apply not_collinear_of_det
+  simp only [sixConfig_zero, sixConfig_two, sixConfig_five]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noLine_034 :
+    ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
+      a * (sixConfig 0 0) + b * (sixConfig 0 1) + c = 0 ∧
+      a * (sixConfig 3 0) + b * (sixConfig 3 1) + c = 0 ∧
+      a * (sixConfig 4 0) + b * (sixConfig 4 1) + c = 0 := by
+  apply not_collinear_of_det
+  simp only [sixConfig_zero, sixConfig_three, sixConfig_four]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noLine_035 :
+    ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
+      a * (sixConfig 0 0) + b * (sixConfig 0 1) + c = 0 ∧
+      a * (sixConfig 3 0) + b * (sixConfig 3 1) + c = 0 ∧
+      a * (sixConfig 5 0) + b * (sixConfig 5 1) + c = 0 := by
+  apply not_collinear_of_det
+  simp only [sixConfig_zero, sixConfig_three, sixConfig_five]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noLine_045 :
+    ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
+      a * (sixConfig 0 0) + b * (sixConfig 0 1) + c = 0 ∧
+      a * (sixConfig 4 0) + b * (sixConfig 4 1) + c = 0 ∧
+      a * (sixConfig 5 0) + b * (sixConfig 5 1) + c = 0 := by
+  apply not_collinear_of_det
+  simp only [sixConfig_zero, sixConfig_four, sixConfig_five]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noLine_123 :
+    ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
+      a * (sixConfig 1 0) + b * (sixConfig 1 1) + c = 0 ∧
+      a * (sixConfig 2 0) + b * (sixConfig 2 1) + c = 0 ∧
+      a * (sixConfig 3 0) + b * (sixConfig 3 1) + c = 0 := by
+  apply not_collinear_of_det
+  simp only [sixConfig_one, sixConfig_two, sixConfig_three]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noLine_124 :
+    ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
+      a * (sixConfig 1 0) + b * (sixConfig 1 1) + c = 0 ∧
+      a * (sixConfig 2 0) + b * (sixConfig 2 1) + c = 0 ∧
+      a * (sixConfig 4 0) + b * (sixConfig 4 1) + c = 0 := by
+  apply not_collinear_of_det
+  simp only [sixConfig_one, sixConfig_two, sixConfig_four]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noLine_125 :
+    ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
+      a * (sixConfig 1 0) + b * (sixConfig 1 1) + c = 0 ∧
+      a * (sixConfig 2 0) + b * (sixConfig 2 1) + c = 0 ∧
+      a * (sixConfig 5 0) + b * (sixConfig 5 1) + c = 0 := by
+  apply not_collinear_of_det
+  simp only [sixConfig_one, sixConfig_two, sixConfig_five]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noLine_134 :
+    ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
+      a * (sixConfig 1 0) + b * (sixConfig 1 1) + c = 0 ∧
+      a * (sixConfig 3 0) + b * (sixConfig 3 1) + c = 0 ∧
+      a * (sixConfig 4 0) + b * (sixConfig 4 1) + c = 0 := by
+  apply not_collinear_of_det
+  simp only [sixConfig_one, sixConfig_three, sixConfig_four]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noLine_135 :
+    ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
+      a * (sixConfig 1 0) + b * (sixConfig 1 1) + c = 0 ∧
+      a * (sixConfig 3 0) + b * (sixConfig 3 1) + c = 0 ∧
+      a * (sixConfig 5 0) + b * (sixConfig 5 1) + c = 0 := by
+  apply not_collinear_of_det
+  simp only [sixConfig_one, sixConfig_three, sixConfig_five]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noLine_145 :
+    ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
+      a * (sixConfig 1 0) + b * (sixConfig 1 1) + c = 0 ∧
+      a * (sixConfig 4 0) + b * (sixConfig 4 1) + c = 0 ∧
+      a * (sixConfig 5 0) + b * (sixConfig 5 1) + c = 0 := by
+  apply not_collinear_of_det
+  simp only [sixConfig_one, sixConfig_four, sixConfig_five]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noLine_234 :
+    ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
+      a * (sixConfig 2 0) + b * (sixConfig 2 1) + c = 0 ∧
+      a * (sixConfig 3 0) + b * (sixConfig 3 1) + c = 0 ∧
+      a * (sixConfig 4 0) + b * (sixConfig 4 1) + c = 0 := by
+  apply not_collinear_of_det
+  simp only [sixConfig_two, sixConfig_three, sixConfig_four]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noLine_235 :
+    ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
+      a * (sixConfig 2 0) + b * (sixConfig 2 1) + c = 0 ∧
+      a * (sixConfig 3 0) + b * (sixConfig 3 1) + c = 0 ∧
+      a * (sixConfig 5 0) + b * (sixConfig 5 1) + c = 0 := by
+  apply not_collinear_of_det
+  simp only [sixConfig_two, sixConfig_three, sixConfig_five]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noLine_245 :
+    ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
+      a * (sixConfig 2 0) + b * (sixConfig 2 1) + c = 0 ∧
+      a * (sixConfig 4 0) + b * (sixConfig 4 1) + c = 0 ∧
+      a * (sixConfig 5 0) + b * (sixConfig 5 1) + c = 0 := by
+  apply not_collinear_of_det
+  simp only [sixConfig_two, sixConfig_four, sixConfig_five]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noLine_345 :
+    ¬∃ (a b c : ℝ), (a, b, c) ≠ (0, 0, 0) ∧
+      a * (sixConfig 3 0) + b * (sixConfig 3 1) + c = 0 ∧
+      a * (sixConfig 4 0) + b * (sixConfig 4 1) + c = 0 ∧
+      a * (sixConfig 5 0) + b * (sixConfig 5 1) + c = 0 := by
+  apply not_collinear_of_det
+  simp only [sixConfig_three, sixConfig_four, sixConfig_five]
+  norm_num
+  all_goals intro heq
   all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
     sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
     sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
     sqrt_six_lt, lt_sqrt_six]
 
 end NoLine
+
+set_option maxHeartbeats 3200000 in
+/-- **No three of the six points are collinear.**  Every genuine index triple
+dispatches (via `assumption`, so in any order) to one of the twenty per-triple
+line-determinant lemmas. -/
+theorem noThreeCollinear_sixConfig : NoThreeCollinear sixConfig := by
+  intro i j k hcard
+  rintro ⟨a, b, c, hne, e1, e2, e3⟩
+  fin_cases i <;> fin_cases j <;> fin_cases k <;>
+    first
+    | exact absurd hcard (by decide)
+    | exact six_noLine_012 ⟨a, b, c, hne, by assumption, by assumption, by assumption⟩
+    | exact six_noLine_013 ⟨a, b, c, hne, by assumption, by assumption, by assumption⟩
+    | exact six_noLine_014 ⟨a, b, c, hne, by assumption, by assumption, by assumption⟩
+    | exact six_noLine_015 ⟨a, b, c, hne, by assumption, by assumption, by assumption⟩
+    | exact six_noLine_023 ⟨a, b, c, hne, by assumption, by assumption, by assumption⟩
+    | exact six_noLine_024 ⟨a, b, c, hne, by assumption, by assumption, by assumption⟩
+    | exact six_noLine_025 ⟨a, b, c, hne, by assumption, by assumption, by assumption⟩
+    | exact six_noLine_034 ⟨a, b, c, hne, by assumption, by assumption, by assumption⟩
+    | exact six_noLine_035 ⟨a, b, c, hne, by assumption, by assumption, by assumption⟩
+    | exact six_noLine_045 ⟨a, b, c, hne, by assumption, by assumption, by assumption⟩
+    | exact six_noLine_123 ⟨a, b, c, hne, by assumption, by assumption, by assumption⟩
+    | exact six_noLine_124 ⟨a, b, c, hne, by assumption, by assumption, by assumption⟩
+    | exact six_noLine_125 ⟨a, b, c, hne, by assumption, by assumption, by assumption⟩
+    | exact six_noLine_134 ⟨a, b, c, hne, by assumption, by assumption, by assumption⟩
+    | exact six_noLine_135 ⟨a, b, c, hne, by assumption, by assumption, by assumption⟩
+    | exact six_noLine_145 ⟨a, b, c, hne, by assumption, by assumption, by assumption⟩
+    | exact six_noLine_234 ⟨a, b, c, hne, by assumption, by assumption, by assumption⟩
+    | exact six_noLine_235 ⟨a, b, c, hne, by assumption, by assumption, by assumption⟩
+    | exact six_noLine_245 ⟨a, b, c, hne, by assumption, by assumption, by assumption⟩
+    | exact six_noLine_345 ⟨a, b, c, hne, by assumption, by assumption, by assumption⟩
+
+/-! ## No four concyclic: 15 numeric circle determinants -/
+
+section NoCircle
+
+private theorem six_noCircle_0123 :
+    ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
+      dist center (sixConfig 0) = ρ ∧ dist center (sixConfig 1) = ρ ∧
+      dist center (sixConfig 2) = ρ ∧ dist center (sixConfig 3) = ρ := by
+  apply not_concyclic_of_det
+  simp only [sixConfig_zero, sixConfig_one, sixConfig_two, sixConfig_three]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noCircle_0124 :
+    ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
+      dist center (sixConfig 0) = ρ ∧ dist center (sixConfig 1) = ρ ∧
+      dist center (sixConfig 2) = ρ ∧ dist center (sixConfig 4) = ρ := by
+  apply not_concyclic_of_det
+  simp only [sixConfig_zero, sixConfig_one, sixConfig_two, sixConfig_four]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noCircle_0125 :
+    ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
+      dist center (sixConfig 0) = ρ ∧ dist center (sixConfig 1) = ρ ∧
+      dist center (sixConfig 2) = ρ ∧ dist center (sixConfig 5) = ρ := by
+  apply not_concyclic_of_det
+  simp only [sixConfig_zero, sixConfig_one, sixConfig_two, sixConfig_five]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noCircle_0134 :
+    ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
+      dist center (sixConfig 0) = ρ ∧ dist center (sixConfig 1) = ρ ∧
+      dist center (sixConfig 3) = ρ ∧ dist center (sixConfig 4) = ρ := by
+  apply not_concyclic_of_det
+  simp only [sixConfig_zero, sixConfig_one, sixConfig_three, sixConfig_four]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noCircle_0135 :
+    ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
+      dist center (sixConfig 0) = ρ ∧ dist center (sixConfig 1) = ρ ∧
+      dist center (sixConfig 3) = ρ ∧ dist center (sixConfig 5) = ρ := by
+  apply not_concyclic_of_det
+  simp only [sixConfig_zero, sixConfig_one, sixConfig_three, sixConfig_five]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noCircle_0145 :
+    ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
+      dist center (sixConfig 0) = ρ ∧ dist center (sixConfig 1) = ρ ∧
+      dist center (sixConfig 4) = ρ ∧ dist center (sixConfig 5) = ρ := by
+  apply not_concyclic_of_det
+  simp only [sixConfig_zero, sixConfig_one, sixConfig_four, sixConfig_five]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noCircle_0234 :
+    ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
+      dist center (sixConfig 0) = ρ ∧ dist center (sixConfig 2) = ρ ∧
+      dist center (sixConfig 3) = ρ ∧ dist center (sixConfig 4) = ρ := by
+  apply not_concyclic_of_det
+  simp only [sixConfig_zero, sixConfig_two, sixConfig_three, sixConfig_four]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noCircle_0235 :
+    ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
+      dist center (sixConfig 0) = ρ ∧ dist center (sixConfig 2) = ρ ∧
+      dist center (sixConfig 3) = ρ ∧ dist center (sixConfig 5) = ρ := by
+  apply not_concyclic_of_det
+  simp only [sixConfig_zero, sixConfig_two, sixConfig_three, sixConfig_five]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noCircle_0245 :
+    ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
+      dist center (sixConfig 0) = ρ ∧ dist center (sixConfig 2) = ρ ∧
+      dist center (sixConfig 4) = ρ ∧ dist center (sixConfig 5) = ρ := by
+  apply not_concyclic_of_det
+  simp only [sixConfig_zero, sixConfig_two, sixConfig_four, sixConfig_five]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noCircle_0345 :
+    ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
+      dist center (sixConfig 0) = ρ ∧ dist center (sixConfig 3) = ρ ∧
+      dist center (sixConfig 4) = ρ ∧ dist center (sixConfig 5) = ρ := by
+  apply not_concyclic_of_det
+  simp only [sixConfig_zero, sixConfig_three, sixConfig_four, sixConfig_five]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noCircle_1234 :
+    ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
+      dist center (sixConfig 1) = ρ ∧ dist center (sixConfig 2) = ρ ∧
+      dist center (sixConfig 3) = ρ ∧ dist center (sixConfig 4) = ρ := by
+  apply not_concyclic_of_det
+  simp only [sixConfig_one, sixConfig_two, sixConfig_three, sixConfig_four]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noCircle_1235 :
+    ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
+      dist center (sixConfig 1) = ρ ∧ dist center (sixConfig 2) = ρ ∧
+      dist center (sixConfig 3) = ρ ∧ dist center (sixConfig 5) = ρ := by
+  apply not_concyclic_of_det
+  simp only [sixConfig_one, sixConfig_two, sixConfig_three, sixConfig_five]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noCircle_1245 :
+    ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
+      dist center (sixConfig 1) = ρ ∧ dist center (sixConfig 2) = ρ ∧
+      dist center (sixConfig 4) = ρ ∧ dist center (sixConfig 5) = ρ := by
+  apply not_concyclic_of_det
+  simp only [sixConfig_one, sixConfig_two, sixConfig_four, sixConfig_five]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noCircle_1345 :
+    ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
+      dist center (sixConfig 1) = ρ ∧ dist center (sixConfig 3) = ρ ∧
+      dist center (sixConfig 4) = ρ ∧ dist center (sixConfig 5) = ρ := by
+  apply not_concyclic_of_det
+  simp only [sixConfig_one, sixConfig_three, sixConfig_four, sixConfig_five]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+private theorem six_noCircle_2345 :
+    ¬∃ (center : EuclideanSpace ℝ (Fin 2)) (ρ : ℝ),
+      dist center (sixConfig 2) = ρ ∧ dist center (sixConfig 3) = ρ ∧
+      dist center (sixConfig 4) = ρ ∧ dist center (sixConfig 5) = ρ := by
+  apply not_concyclic_of_det
+  simp only [sixConfig_two, sixConfig_three, sixConfig_four, sixConfig_five]
+  norm_num
+  all_goals intro heq
+  all_goals nlinarith [heq, sqrt_two_sq, sqrt_three_sq, sqrt_six_sq, sqrt_two_pos,
+    sqrt_three_pos, sqrt_six_pos, sqrt_two_mul_sqrt_three, sqrt_two_mul_sqrt_six,
+    sqrt_three_mul_sqrt_six, sqrt_two_lt, lt_sqrt_two, sqrt_three_lt, lt_sqrt_three,
+    sqrt_six_lt, lt_sqrt_six]
+
+end NoCircle
+
+set_option maxHeartbeats 4000000 in
+/-- **No four of the six points are concyclic.**  Every genuine index quadruple
+dispatches (via `assumption`, so in any order) to one of the fifteen per-quadruple
+circle-determinant lemmas. -/
+theorem noFourConcyclic_sixConfig : NoFourConcyclic sixConfig := by
+  intro a b c d hcard
+  rintro ⟨center, ρ, h1, h2, h3, h4⟩
+  fin_cases a <;> fin_cases b <;> fin_cases c <;> fin_cases d <;>
+    first
+    | exact absurd hcard (by decide)
+    | exact six_noCircle_0123
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0124
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0125
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0134
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0135
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0145
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0234
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0235
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0245
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_0345
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_1234
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_1235
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_1245
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_1345
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+    | exact six_noCircle_2345
+        ⟨center, ρ, by assumption, by assumption, by assumption, by assumption⟩
+
+/-- **`sixConfig` is in general position.** -/
+theorem inGeneralPosition_sixConfig : InGeneralPosition sixConfig :=
+  ⟨sixConfig_injective, noThreeCollinear_sixConfig, noFourConcyclic_sixConfig⟩
+
+/-- **`sixConfig` realizes at most four distinct distances.**  Every positive
+pairwise distance lies in the four-element set `{√3, √6, √(3+√6), √(3−√6)}`
+(`sixConfig_dist_mem`), so the distinct-distance count is at most `4`. -/
+theorem numDistinctDistances_sixConfig_le :
+    numDistinctDistances sixConfig ≤ 4 := by
+  unfold numDistinctDistances
+  have hsub :
+      ((univ.product univ).image
+          (fun p : Fin 6 × Fin 6 =>
+            dist (sixConfig p.1) (sixConfig p.2))).filter (· > 0)
+        ⊆ ({Real.sqrt 3, Real.sqrt 6, Real.sqrt (3 + Real.sqrt 6),
+            Real.sqrt (3 - Real.sqrt 6)} : Finset ℝ) := by
+    intro d hd
+    rw [mem_filter, mem_image] at hd
+    obtain ⟨⟨p, -, hpd⟩, hpos⟩ := hd
+    have hne : p.1 ≠ p.2 := by
+      intro he
+      rw [he, dist_self] at hpd
+      rw [← hpd] at hpos
+      exact lt_irrefl 0 hpos
+    rw [← hpd]
+    exact sixConfig_dist_mem hne
+  calc (((univ.product univ).image
+          (fun p : Fin 6 × Fin 6 =>
+            dist (sixConfig p.1) (sixConfig p.2))).filter (· > 0)).card
+      ≤ ({Real.sqrt 3, Real.sqrt 6, Real.sqrt (3 + Real.sqrt 6),
+          Real.sqrt (3 - Real.sqrt 6)} : Finset ℝ).card := card_le_card hsub
+    _ ≤ ({Real.sqrt 6, Real.sqrt (3 + Real.sqrt 6),
+          Real.sqrt (3 - Real.sqrt 6)} : Finset ℝ).card + 1 := card_insert_le _ _
+    _ ≤ (({Real.sqrt (3 + Real.sqrt 6),
+          Real.sqrt (3 - Real.sqrt 6)} : Finset ℝ).card + 1) + 1 :=
+        Nat.add_le_add_right (card_insert_le _ _) 1
+    _ ≤ ((({Real.sqrt (3 - Real.sqrt 6)} : Finset ℝ).card + 1) + 1) + 1 :=
+        Nat.add_le_add_right (Nat.add_le_add_right (card_insert_le _ _) 1) 1
+    _ = 4 := by simp
+
+/-! ## The bounds -/
+
+/-- **`h 6 ≤ 4`.**  The explicit general-position four-distance witness
+`sixConfig` caps the minimum.  Before this theorem the best upper bound was the
+generic `h 6 ≤ 15` from `h_le_choose_two`. -/
+theorem h_six_le_four : h 6 ≤ 4 :=
+  le_trans (h_le_of_inGeneralPosition inGeneralPosition_sixConfig)
+    numDistinctDistances_sixConfig_le
+
+/-- **`3 ≤ h 6 ≤ 4`.**  Lower bound from `h 5 = 3` and monotonicity
+(`three_le_h_six`, in `Erdos98WIP01Thresholds`); upper bound from `sixConfig`. -/
+theorem h_six_bounds : 3 ≤ h 6 ∧ h 6 ≤ 4 :=
+  ⟨three_le_h_six, h_six_le_four⟩
+
+/-- **The six-point dichotomy: `h 6 = 3` or `h 6 = 4`.**  Deciding which is the
+open remainder: `h 6 = 3` iff a general-position 6-point THREE-distance
+configuration exists (a question the blocked-route registry records as open);
+otherwise `h 6 = 4` exactly. -/
+theorem h_six_eq_three_or_four : h 6 = 3 ∨ h 6 = 4 := by
+  have h1 := three_le_h_six
+  have h2 := h_six_le_four
+  omega
 
 end Erdos98WIP01

--- a/research/problems/erdos-98-wip-01/knowledge.md
+++ b/research/problems/erdos-98-wip-01/knowledge.md
@@ -1,5 +1,81 @@
 # Knowledge Base: erdos-98-wip-01
 
+*Older sessions (15) are archived in `sessions/` (archived 2026-07-24, researcher-3; knowledge.md exceeded the 500-line/10-session cap).*
+
+## Session 2026-07-24 (researcher-3) — h 6 ≤ 4: first nontrivial six-point upper bound (4-distance witness)
+
+**Mode**: REVISIT (RICH, re-served COMPLETED problem). **Outcome**: progress — new companion
+file `Erdos98WIP01SixUpper.lean` proving `h 6 ≤ 4`, hence `h 6 ∈ {3, 4}`
+(`h_six_bounds`, `h_six_eq_three_or_four`). Previous best upper bound was the generic
+`h 6 ≤ 15` (`h_le_choose_two`). Axiom-free (BUILD-STATUS recorded below).
+
+### The witness — twisted concentric triangles
+`sixConfig`: inner equilateral triangle circumradius `1` (angles `0°,120°,240°`), outer
+circumradius `√2` (angles `90°,210°,330°`). Cross squared distances are
+`R²+r²−2Rr·cos(θ+120°k) = 3 − 2√2·cos Δ`, `Δ ∈ {90°,210°,330°}` → `{3, 3+√6, 3−√6}`;
+the choice `R² = 2r²`, `θ = 90°` MERGES the `Δ=90°` cross orbit with the inner side `3`.
+Squared distances: `{3, 6, 3+√6, 3−√6}` — exactly four values.
+
+General position: 3+1 concyclic splits die on concentric radii `1 ≠ √2`; 2+2 splits would
+need an inner chord PARALLEL to an outer chord (common perpendicular bisector through the
+centre), but inner chord directions `{30°,90°,150°}` and outer `{0°,60°,120°}` are disjoint.
+Collinearity: all 20 triple determinants nonzero (numerically min |det| ≈ 0.389; concyclic
+min |D| ≈ 2.12 — cross-checked in Python before formalizing).
+
+### Within-family obstruction (documents why h 6 = 3 stays open)
+A THIRD merge (3 distances) in the twisted-triangle family `(R, θ)` is impossible in general
+position: `inner = cross₁ = cross₂` forces `θ = ±60°, R = 2` whose configuration contains
+the collinear triple `(−√3,1),(0,1),(√3,1)`; `inner = cross₁ ∧ outer = cross₂` forces
+`cos(θ+240°) = (R²+1)/(2R) ≤ 1` iff `(R−1)² ≤ 0`, i.e. `R = 1` (triangles coincide). So a
+3-distance witness — if any — lives outside this family. Recorded in the blocked-route
+registry (`exact value h(6)` route sharpened to the 3-vs-4 dichotomy).
+
+### Proof engineering — determinant criteria replace per-case searches
+Two new REUSABLE general-position criteria, proved once by deterministic
+`linear_combination` cofactor identities (no `nlinarith` over unknown line/centre
+coordinates, unlike the `h5Config` pattern):
+- `not_collinear_of_det`: nonzero affine determinant `(q₀−p₀)(r₁−p₁)−(r₀−p₀)(q₁−p₁)`
+  refutes any common line — eliminate `a` then `b` by cofactor combinations of the two
+  chord differences, then `c` from the base equation.
+- `not_concyclic_of_det`: with `N t = t₀²+t₁²`, nonzero
+  `det[[q−p, Nq−Np],[r−p, Nr−Np],[s−p, Ns−Np]]` refutes any common circumcentre — the
+  cofactor combination of the three chord equations `2c·(t−p) = Nt−Np` eliminates the
+  centre identically (repeated-column determinants) and evaluates the determinant.
+All 35 obligations (20 line + 15 circle) become NUMERIC surd inequalities, closed by
+`nlinarith` with recorded facts: squares `√k² = k`, positivity, products
+(`√2·√3 = √6`, `√2·√6 = 2√3`, `√3·√6 = 3√2`, each a one-line `linear_combination`), and
+rational brackets `1.414 < √2 < 1.415` etc. (plain `nlinarith [sq, pos]` proves both sides —
+it squares the negated goal).
+
+### Key Lean idioms (v4.31, this session)
+- `fin_cases` produces anonymous-constructor indices `⟨k, ⋯⟩` that `simp only` access
+  lemmas stated at `OfNat` literals do NOT match — but `exact`/`assumption` unify them by
+  defeq. So: prove per-literal-index lemmas (`six_dist_01`, `six_noLine_012`,
+  `six_noCircle_0123`, …) and dispatch inside the `fin_cases` combinator via
+  `exact lemma ⟨…, by assumption, …⟩` (order-agnostic) — never `simp` on fin_cases indices.
+- After `norm_num` fully closes a goal, a trailing `nlinarith` errors with "no goals" and
+  fails the surrounding `first` branch — guard the closer as `all_goals nlinarith [...]`.
+- `Real.sq_sqrt` is `@[simp]`, so `norm_num` silently rewrites `√2^2 → 2`; do not rely on
+  the square surviving into the `nlinarith` stage.
+- Transposed distance pairs: `rw [dist_comm]` inside the dispatch handles all `i > j` cases
+  from the 15 `i < j` pair lemmas.
+
+### Files Modified
+- `proofs/Proofs/Erdos98WIP01SixUpper.lean` (NEW, ~1050 lines: 2 general criteria, sixConfig,
+  6 access lemmas, 15 pair-distance lemmas, 20 line lemmas, 15 circle lemmas, 3 assemblies,
+  counting lemma, `h_six_le_four` / `h_six_bounds` / `h_six_eq_three_or_four`)
+- `src/data/research/problems/erdos-98-wip-01.json` (iteration 4, blocker sharpened, 4 built
+  items, 5 insights, progressSummary, nextSteps)
+- `research/problems/erdos-98-wip-01/state.md`, `knowledge.md` (this entry; 15 older
+  sessions archived to `sessions/`)
+
+### Next Steps
+Decide the dichotomy: `h 6 = 3` (needs a 3-distance general-position 6-config outside the
+twisted-triangle family — open) vs `h 6 = 4` (needs an impossibility argument for irregular
+3-distance 6-sets; the h5 centroid/row-sum method only kills colour-regular ones). Also:
+`h 7 ≤ 21` is the current ceiling — a 4/5-distance 7-point witness would be the analogous
+next increment.
+
 ## Session 2026-07-21 (researcher-1) — h 5 = 3 CLOSED (centroid concyclicity bypasses C₅ endgame)
 
 **Mode**: REVISIT (continue, RICH). **Outcome**: **COMPLETED** the `h 5 = 3` sub-goal. Two new
@@ -324,603 +400,3 @@ reset is a no-op. (Matches `gotcha-janitor-reaps-fresh-worktree-before-first-com
 
 ---
 
-## Session 2026-07-21 (researcher-1) — h 5 ≥ 3: handshake parity obstruction (some vertex has exactly 2 short neighbours)
-
-**Mode**: REVISIT (continue, RICH). **Outcome**: progress — one new structural step on the
-critical path to `h 5 ≥ 3`, axiom-free. **Host-verified** `Proofs.Erdos98WIP01` via
-`lake env lean` (fresh v4.31 parent olean), exit 0, no `error:` (only pre-existing
-`EuclideanSpace.single_apply` deprecation warnings at line 451); file now 1964 lines,
-`grep -c '^axiom '` = 0, `grep -c 'sorry'` = 0, no `native_decide`.
-
-### What I did
-Advanced the residual reduction (`h 5 ≥ 3` ⟺ no general-position `PointConfig 5` is a
-2-distance set) by proving a **parity obstruction** that begins forcing 2-regularity of the
-short-distance graph.
-
-**Lean results added** (`proofs/Proofs/Erdos98WIP01.lean`):
-
-- **`even_sum_symm_degree`** (axiom-free, general): for any symmetric, irreflexive
-  `DecidableRel r` on a `Fintype`, `Even (∑ i, #{j ≠ i : r i j})`. This is the handshaking
-  lemma, routed through Mathlib's `SimpleGraph.sum_degrees_eq_twice_card_edges` (RHS
-  `2 · #edges`, manifestly even). Key formalization notes: build the `SimpleGraph` literal
-  with `symm := ⟨hsymm⟩ : Std.Symm r`, `loopless := ⟨hirr⟩ : Std.Irrefl r`; set
-  `DecidableRel G.Adj := fun a b => inferInstance` (NOT `Classical.decRel`, which forks the
-  filter's `DecidablePred` instance and breaks the final `rw`/`convert`); close the pointwise
-  `degree = filter-card` goal by `convert h2 using 2 with i` then inline
-  `neighborFinset_eq_filter` (uses the goal's own instance, avoiding the mismatch).
-- **`two_distance_exists_degree_two`** (axiom-free): a general-position 2-distance
-  `PointConfig 5` has **some vertex with exactly 2 short-distance (`a`) neighbours**.
-  Mechanism: `two_distance_near_degree_bounds` gives each short-degree `d_a(i) ∈ {1,2,3}`;
-  `even_sum_symm_degree` (with `r i j := dist (P i) (P j) = a`, symmetric via `dist_comm`,
-  irreflexive since `a > 0` — realised from vertex 0) makes `∑_i d_a(i)` even; a sum of five
-  odd numbers is odd, so not all `d_a(i)` are odd ⇒ some equals 2. Closed by
-  `Fin.sum_univ_five` + `omega` on per-vertex `% 2 = 1` facts.
-
-### Why this is progress (honest scope)
-This is the FIRST pin of a specific degree value. It does **not** yet give 2-regularity: it
-guarantees *one* degree-2 vertex, not all five. A sum of five values in `{1,2,3}` that is even
-can still be e.g. `(1,1,3,3,2)` — so degrees 1 and 3 are not yet excluded.
-
-### Exact remaining gap (for the next iteration to pick up cold)
-1. **Rule out short-degree 3** (equivalently long-degree 1, by the `a ↔ b` symmetry of the
-   two-distance hypothesis). This is the genuinely *geometric* step: if a vertex `v` has three
-   short-neighbours `x,y,z` on the radius-`a` circle about `v`, the two-distance constraint on
-   `{x,y,z}` together with no-3-collinear / no-4-concyclic must be shown contradictory. Pure
-   graph theory (degrees in `{1,2,3}`, both `G` and `Gᶜ` `K₄`-free) does **not** force `C₅`.
-   Precise lemma to prove: `∀ i, ((univ.erase i).filter (fun j => dist (P i) (P j) = a)).card = 2`.
-2. After full 2-regularity: `2-regular on Fin 5 ⟹ single 5-cycle C₅` (finite/decidable);
-   then `C₅` two-distance realisation ⟹ regular pentagon ⟹ 5 concyclic ⟹ contradicts
-   `NoFourConcyclic` ⟹ `h 5 ≥ 3`.
-
-### Files modified
-- `proofs/Proofs/Erdos98WIP01.lean` (+2 theorems, `even_sum_symm_degree`, `two_distance_exists_degree_two`)
-- `src/data/research/problems/erdos-98-wip-01.json` (knowledge accumulation)
-
----
-
-## Session 2026-07-21 (researcher-1) — h 5 ≥ 3 reduced to pentagon rigidity: 2-distance reduction + degree structure
-
-**Mode**: REVISIT (continue, RICH). **Outcome**: progress — rigorous reduction of the open
-lower bound `h 5 ≥ 3`, all axiom-free. **docker-built** `Proofs.Erdos98WIP01` OK
-(0 sorry / 0 axiom / no `native_decide`; new proofs use only standard Mathlib).
-
-The residual frontier is `h 5 ≥ 3` ⟺ *no general-position `PointConfig 5` is a 2-distance
-set*. This session pins that reduction down to its exact combinatorial/geometric frame and
-proves everything on the combinatorial side.
-
-**Lean results added** (`proofs/Proofs/Erdos98WIP01.lean`):
-
-- **`exists_two_distances_of_numDistinct_le_two`** (axiom-free, all `n`): an injective
-  `PointConfig` on `n ≥ 2` points with `numDistinctDistances ≤ 2` *is* a 2-distance set —
-  `∃ a b > 0` covering every pairwise distance. Mechanism: all off-diagonal distances are
-  positive (injectivity) hence lie in the counted finset `D`; `D.card ≤ 2` ⇒ `D ⊆ {a,b}` via
-  `Finset.card_erase_of_mem` + `Finset.card_le_one`. This is the entry point of the reduction.
-- **`two_distance_near_degree_bounds`** (axiom-free): in a **general-position** 2-distance
-  `PointConfig 5`, every vertex has between `1` and `3` short-distance (`a`) neighbours.
-  Mechanism: `card_fiber_dist_le_three` caps both the `a`-circle and the `b`-circle around a
-  vertex at `3` (no-four-concyclic); the two neighbour-sets are disjoint (`a ≠ b`) and cover
-  all `4` other points, so `card A + card B = 4` with each `≤ 3` ⇒ `1 ≤ card A ≤ 3`.
-
-**The exact residual (documented, not proved).** Combining the degree bounds with the merged
-`no_four_equidistant_indices` (no monochromatic `K₄`): the short-distance graph of any
-hypothetical general-position 2-distance 5-set is a graph on 5 vertices with min-degree `≥ 1`,
-max-degree `≤ 3`, and no `K₄` in the graph *or its complement*. **These purely combinatorial
-constraints do not close** — `C₅` (the regular-pentagon pattern) satisfies all of them
-(2-regular, `K₄`-free, self-complementary `α = 2 ≤ 3`). The single remaining fact is
-**geometric**: an equilateral, equidiagonal pentagon (`C₅` realization) is regular, hence its
-5 vertices are concyclic, contradicting `NoFourConcyclic`. Pigeonhole from a single vertex
-also caps at `⌈4/3⌉ = 2`, so a multi-vertex/rigidity argument is genuinely required.
-
-**Reusable notes.** `numDistinctDistances P = D.card` where `D` is the filtered image finset;
-extracting the two distances is cleanest via erase + `Finset.card_le_one` rather than a
-`card_le_two` witness lemma (which Mathlib does not expose in subset form). `Disjoint A B`
-from `a ≠ b` via `Finset.disjoint_left` and `hjA.2.symm.trans hjB.2`; disjoint-union card via
-`Finset.card_union_of_disjoint`.
-
-**Honest delta**: did **not** prove `h 5 ≥ 3` (still open). +2 axiom-free theorems (2-distance
-reduction + per-vertex degree structure), residual reduced to a single named geometric fact
-(pentagon rigidity). Axiom count unchanged (0). Bounds remain `2 ≤ h 5 ≤ 3`. Phase `ACT`.
-
-**Files modified**: `proofs/Proofs/Erdos98WIP01.lean`,
-`src/data/research/problems/erdos-98-wip-01.json`, this file.
-
-**Next**: prove pentagon rigidity (the `C₅`-realization ⇒ concyclic case) to close `h 5 ≥ 3`;
-or abstract the equilateral-dimension bound.
-
-
-## Session 2026-07-21 (researcher-1) — toward h 5 ≥ 3: no 4 coplanar points are mutually equidistant
-
-**Mode**: REVISIT (continue). **Outcome**: progress — a reusable geometric lemma toward
-`h 5 ≥ 3`, plus concrete unconditional lower-bound thresholds.
-**docker-built** `Proofs.Erdos98WIP01` OK (0 sorry / 0 axiom / no `native_decide`;
-build "succeeded, 8577 jobs"). All new lemmas use only Mathlib + `linarith`/`omega`/
-`linear_combination`, so foundational axioms only (`propext`/`Classical.choice`/`Quot.sound`).
-
-### Why `h 5 ≥ 3` is not one line (correcting the prior docstring)
-The `h_five_bounds` docstring claimed "the regular pentagon, the only planar 2-distance
-5-set". That is **false**: the plane has several 5-point 2-distance sets (the pentagon is
-only the concyclic one). So `h 5 ≥ 3` genuinely needs the structure of 2-distance sets,
-not just "pentagon ⇒ concyclic ⇒ excluded". The new toward-`h 5 ≥ 3` section documents the
-real reduction.
-
-### The reduction (rigorous, and what remains)
-Suppose a general-position 5-set uses only two distances `a < b`. By
-`card_fiber_dist_le_three` (already in file), each point has `a`-degree and `b`-degree in
-`{1,2,3}` (a 4th point at a common distance would be 4 concyclic). Case split on whether
-some vertex has `a`-degree 3:
-- **Degree-3 vertex `p`** with neighbours `X,Y,Z` at distance `a`. Sub-case "`X,Y,Z`
-  pairwise `a`" makes `p,X,Y,Z` **four mutually equidistant** → **now excluded** by the new
-  `no_four_mutually_equidistant`. Remaining degree-3 sub-cases (some `XY` or `XZ` = `b`)
-  reduce to intersecting-circle distance equations (`|YZ| = a√3`, etc.) — **still open**,
-  coordinate-heavy.
-- **All degrees 2** (a-graph 2-regular on 5 vertices ⇒ `C₅`) is the pentagon-type case;
-  metric realizability forces the concyclic regular pentagon — **still open** (needs
-  "equilateral + equidiagonal convex pentagon ⇒ concyclic").
-
-### Lean results added (`proofs/Proofs/Erdos98WIP01.lean`)
-- **`no_four_mutually_equidistant`** (axiom-free): in `EuclideanSpace ℝ (Fin 2)` no four
-  points have all six pairwise distances equal to a common `r > 0`. Proof: edge vectors
-  `u=b-a, v=c-a, w=d-a` have `‖·‖²=r²`, pairwise inner product `r²/2` (from `‖u-v‖=r` via
-  `norm_sub_sq_real`); the Gram system forces `LinearIndependent ℝ ![u,v,w]`, contradicting
-  `finrank (EuclideanSpace ℝ (Fin 2)) = 2` (`LinearIndependent.fintype_card_le_finrank` +
-  `finrank_euclideanSpace_fin`). This is the planar "regular `k`-simplex needs dim `k`".
-- **`no_four_equidistant_indices`**: config-level specialization (no 4 indices mutually
-  equidistant).
-- **`three_le_h_of_eight_le`** (`n ≥ 8 → 3 ≤ h n`) and **`four_le_h_of_eleven_le`**
-  (`n ≥ 11 → 4 ≤ h n`): immediate from `three_mul_h_ge` (`n-1 ≤ 3·h n`) — the first exact
-  thresholds where the elementary bound alone certifies 3, resp. 4, distinct distances.
-
-### Next steps
-- Degree-3 remaining sub-cases: formalize "two circles of radius `a` at centre-distance `a`
-  meet at points `a√3` apart" as reusable `EuclideanSpace ℝ (Fin 2)` algebra.
-- All-degree-2 (`C₅`) case: "equilateral + equidiagonal convex pentagon is concyclic".
-- Both are coordinate-geometry heavy; each is a standalone multi-session sub-target.
-
-## Session 2026-07-21 (researcher-1) — h 5 ≤ 3 via explicit 3-distance general-position 5-witness
-
-**Mode**: FRESH (continue). **Outcome**: progress — `h 5 ≤ 3`, so `2 ≤ h 5 ≤ 3`.
-**docker-built** `Proofs.Erdos98WIP01` OK (0 sorry / 0 axiom / no `native_decide`;
-`#print axioms Erdos98WIP01.h_five_le_three` = `[propext, Classical.choice, Quot.sound]` only).
-
-Continued the pinned-values line past `h 4 = 2`. The lower-bound side of `h 5` is hard, so
-this session establishes the **upper bound** with a fully machine-checked explicit witness.
-
-**The witness `h5Config : PointConfig 5`.** Found by continuous optimization (minimize
-within-cluster spread of the 10 pairwise distances subject to general-position penalties,
-including a no-4-concyclic determinant penalty — omitting it first produced the degenerate
-"centre + 4 on a circle"), then rationalized and **sympy-verified exactly**:
-
-    A=(0,0), B=(1,0), C=(−√3⁄2,−½), D=(½,√3⁄2), E=(½,−(2+√3)⁄2)
-
-- **Exactly three distinct distances** `1`, `√(2+√3)`, `1+√3` (squared: `1`, `2+√3`,
-  `(1+√3)²=4+2√3`). Multiplicities `1`: AB,AC,AD,BD; `√(2+√3)`: AE,BC,BE,CD,CE; `1+√3`: DE.
-- **No 3 collinear**: all 10 triangle areas ≠ 0. **No 4 concyclic**: the 5 circumscribed-
-  circle determinants are `1+√3⁄2`, `2+√3`, `5⁄2+3√3⁄2` (all ≠ 0).
-
-**Lean results added** (`proofs/Proofs/Erdos98WIP01.lean`, item 18):
-`h5Config`, `h5Config_dist_sq`, `h5Config_dist_mem` (dist ∈ {1,√(2+√3),1+√3}),
-`h5Config_injective`, `noThreeCollinear_h5Config`, `noFourConcyclic_h5Config` (dispatched
-to five per-quadruple `h5_not_equidistant_*` helpers), `inGeneralPosition_h5Config`,
-`numDistinctDistances_h5Config_le` (≤ 3), `h_five_le_three` (`h 5 ≤ 3`),
-`h_five_ge_two` (`2 ≤ h 5`, from `h_four_ge_two` + `h_mono`), `h_five_bounds`.
-
-**Why not `h 5 = 3`.** Both natural lower-bound routes give only `h 5 ≥ 2`
-(`three_mul_h_ge 5` = `⌈4/3⌉ = 2`; `h_mono` from `h 4 = 2`). Pinning `h 5 = 3` needs
-`h 5 ≥ 3`: no general-position 5-set has ≤ 2 distances. The regular pentagon (the only
-planar 2-distance 5-set) is concyclic, so this reduces to the **classification of planar
-2-distance sets** (max 5, the pentagon) or the **Larman–Rogers–Seidel** linear-algebra
-bound (a 2-distance set in ℝ² has ≤ 6 points) refined by no-4-concyclic to ≤ 4. Left open.
-
-**Reusable tactic notes.** `!₂[·]` coordinate accessors reduce under `norm_num`, not by
-`simp only [Matrix.cons_val_*]` alone — the distance-value lemma needs
-`rw [EuclideanSpace.dist_sq_eq]; … simp only […]; norm_num [hs2] <;> nlinarith [hs2]`
-(bare `nlinarith` after `simp` fails on the value-1 √3 pairs). The no-4-concyclic proof
-for 5 points is cheap when factored as one `not_equidistant` helper per unordered quadruple
-(5 total `nlinarith` calls) with `noFourConcyclic` doing `fin_cases … <;> first | … | exact
-h5_not_equidistant_XYZW center r (by assumption) …`.
-
-**Files modified**: `proofs/Proofs/Erdos98WIP01.lean` (+~180 lines),
-`src/data/research/problems/erdos-98-wip-01.json`, this file.
-
-**Next**: prove `h 5 ≥ 3` (2-distance-set classification); abstract "1-distance set in ℝ^d
-has ≤ d+1 points"; sharpen the general `(n−1)/3` lower bound.
-
-
-## Session 2026-07-21 (researcher-1) — pinned value h 4 = 2 (first value of h exceeding 1)
-
-**Mode**: FRESH (continue). **Outcome**: progress — `h 4 = 2` pinned exactly.
-**docker-built** `Proofs.Erdos98WIP01` OK (0 sorry / 0 axiom / no `native_decide`;
-`#print axioms Erdos98WIP01.h_four` = `[propext, Classical.choice, Quot.sound]` only).
-
-Executed the recorded next step (extend the pinned values beyond `h 3`). Both bounds are new.
-
-**Upper bound `h 4 ≤ 2`** (`h_four_le_two`).
-- The classical minimum-distance witness for 4 points, the **square**, is *disqualified*:
-  its 4 vertices are concyclic, and general position forbids 4 concyclic points. So the
-  square is not a witness for `h 4`.
-- `centeredTriangleConfig : PointConfig 4` — the equilateral triangle
-  `(1,0), (−½,√3⁄2), (−½,−√3⁄2)` together with its **centroid** `(0,0)`: a 2-distance set
-  (circumradius `1`, side `√3`) that survives both nondegeneracy constraints.
-- `centeredTriangleConfig_dist_mem` — every pairwise distance is `1` or `√3` (dist² is `1`
-  or `3`; nonnegative sqrt). Key tactic fix: `!₂[…]` coordinate accessors are reduced by
-  **`norm_num`**, not by `simp only [Matrix.cons_val_*]` (those args are flagged *unused*);
-  mirror `equilateral_dist_off`'s `simp only [cfg, Fin.sum_univ_two, Real.dist_eq, sq_abs]`
-  then `norm_num [hs2] <;> nlinarith [hs2]` (fallback for the `√3²=3` arithmetic).
-- `noThreeCollinear`/`noFourConcyclic_centeredTriangleConfig` — the centroid is interior
-  (no 3 collinear); the only point equidistant from the 3 vertices is the circumcenter =
-  centroid, at distance `0 ≠ 1` from itself, so no 4 concyclic. Both needed
-  `set_option maxHeartbeats 1000000 in` (64 / 256 `fin_cases` branches, √3 arithmetic).
-  NB: `set_option … in` goes **before** the docstring, not between docstring and theorem.
-- `numDistinctDistances_centeredTriangleConfig_le` — positive distances ⊆ `{1,√3}`, card ≤ 2.
-
-**Lower bound `h 4 ≥ 2`** (`h_four_ge_two`), the harder half — pins the exact value.
-- `not_four_equidistant` — four pairwise-equidistant points are impossible in `ℝ²`. Take
-  difference vectors `vₖ = p_{k+1} − p₀` (`k : Fin 3`). Equidistance gives the Gram matrix
-  `⟪vᵢ,vᵢ⟫ = r²`, `⟪vᵢ,vⱼ⟫ = r²/2` (`i≠j`) via `real_inner_self_eq_norm_sq` and
-  `norm_sub_sq_real`. `Fintype.linearIndependent_iff` + `sum_inner` + `real_inner_smul_left`
-  turn `∑ gₖ•vₖ = 0` into the 3×3 system `r²·½(I+J)·g = 0`; cancel `r² ≠ 0`
-  (`linear_combination` + `mul_eq_zero`) to get `g = 0`. Then
-  `LinearIndependent.fintype_card_le_finrank` vs `finrank_euclideanSpace_fin` gives `3 ≤ 2`,
-  contradiction. **First use of the ambient dimension** (all earlier bounds are metric/comb.)
-- `two_le_numDistinctDistances_four` — a 1-distance 4-config would force all six distances
-  equal (`Finset.card_eq_one` on the positive-distance set), i.e. four equidistant points.
-- `h_four : h 4 = 2 := le_antisymm h_four_le_two h_four_ge_two`.
-
-**Reusable idiom** (recorded for `h 5`+): a 1-distance set in `ℝ^d` has `≤ d+1` points via
-the Gram/linear-independence route above. The whole lower-bound block compiled first try.
-
-**Next**: pin `h 5` (regular pentagon is concyclic → disqualified; need a non-concyclic
-5-point 2/3-distance set, or show `h 5 ≥ 3`); abstract the equidistant⟹independent lemma.
-
-## Session 2026-07-21 (researcher-1) — pinned value h 3 = 1 via explicit equilateral triangle
-
-**Mode**: FRESH (continue). **Outcome**: progress — 6 axiom-free declarations,
-**docker-built** `Proofs.Erdos98WIP01` OK (0 sorry / 0 axiom / no `native_decide`;
-`#print axioms h_three` = `[propext, Classical.choice, Quot.sound]` only).
-
-Executed the recorded next step: pin `h 3` exactly.
-
-- `equilateralConfig : PointConfig 3` — the unit equilateral triangle
-  `(0,0), (1,0), (½, √3⁄2)`.
-- `equilateralConfig_injective` — the three abscissae `0, 1, ½` already differ, so the
-  `x`-coordinate alone separates every pair (`norm_num [equilateralConfig]` on the 0-th
-  coordinate).
-- `noThreeCollinear_equilateralConfig` — a line through all three forces `c = 0`, then
-  `a = 0`, then `b·(√3⁄2) = 0`; `√3 > 0` gives `b = 0`. The `√3` coefficient makes this
-  genuinely **nonlinear** (unlike the right-triangle case), needing `nlinarith [hs, …]`
-  with `hs : 0 < √3` (the negated-goal × `hs` product certificate).
-- `noFourConcyclic_equilateralConfig` — vacuous (`noFourConcyclic_of_le_three`).
-- `inGeneralPosition_equilateralConfig` — the triangle is in general position.
-- `equilateral_dist_off {i j} (hij : i ≠ j) : dist (equ i) (equ j) = 1` — every side has
-  length 1: `∑ (Δcoord)² = 1` via `(√3)² = 3`, then `EuclideanSpace.dist_eq` + `Real.sqrt_one`.
-- `numDistinctDistances_equilateralConfig = 1` — **first exact computation** of
-  `numDistinctDistances` for an explicit config: positive distances = `{1}` (diagonal
-  pairs give 0, filtered out).
-- `h_three : h 3 = 1` — equilateral witness ⟹ `h 3 ≤ 1`; `h_mono` + `h_two` ⟹
-  `1 = h 2 ≤ h 3`. Squeeze ⟹ `h 2 = h 3 = 1`.
-
-**Key Lean lesson.** `EuclideanSpace.dist_sq_eq` rewrites `dist x y ^ 2` into a sum over
-`x.ofLp i` coordinate accesses that `Matrix.cons_val_*` do NOT reduce (they stay
-`(![…] ⟨0,⋯⟩).ofLp 0`). Use `EuclideanSpace.dist_eq` instead — its `x i` is direct
-function application, reduced by `simp only [equilateralConfig] ; norm_num`. Leftover
-`1/4 + (√3/2)² = 1` closes with `nlinarith [hs]` (`hs : √3² = 3`); `norm_num` alone does
-NOT expand `(√3/2)²` against `hs`.
-
-**Honesty.** Parent Erdős #98 (`h(n)/n → ∞`) remains **OPEN**; only the conjectured rate
-is the open piece. The elementary envelope gives only `1 ≤ h 3 ≤ 3` — the exact value
-needs the equilateral witness. PR: extends #40147.
-
-### Next Steps
-- Improve the lower-bound constant beyond `/3` toward `(n−1)/2` or `≥ n`.
-- Pin `h 4`: is it `1` (needs an impossible single-distance 4-config?) or `2`?
-- Attack the conjectured rate `h n / n → ∞`.
-
-## Session 2026-07-20 (researcher-1) — MONOTONICITY of h + pinned value h 2 = 1
-
-**Mode**: FRESH (continue) — build on the linear lower bound. **Outcome**: progress
-— 5 axiom-free declarations, **docker-built** `Proofs.Erdos98WIP01` OK (8577 jobs,
-0 sorry / 0 axiom / no native_decide).
-
-Proved the first **structural comparison across cardinalities** and the first
-exactly-pinned value of `h`:
-
-- `card_triple_image` / `card_quad_image` — injective-image cardinality helpers
-  (`card {e i,e j,e k} = card {i,j,k}`) via `Finset.card_image_of_injective`.
-- `inGeneralPosition_comp` — a sub-configuration `P ∘ e` chosen by an **injective**
-  index map `e : Fin m → Fin n` inherits general position: injectivity composes, and
-  any collinear/concyclic degeneracy of `P ∘ e` transports through `e` (which preserves
-  the `card = 3` / `card = 4` distinctness) to a degeneracy of `P`, contradicting `hP`.
-- `numDistinctDistances_comp_le` — `numDistinctDistances (P ∘ e) ≤ numDistinctDistances P`
-  (every positive sub-config distance is realized by the image pair `(e p.1, e p.2)`).
-- `h_mono : Monotone h` — delete the last point (`Fin.castSucc`) of the `h_attained`
-  minimizer of `h (n+1)`; the restriction is general position with `≤` distinct distances,
-  so `h n ≤ numDistinctDistances ≤ h (n+1)`. Via `monotone_nat_of_le_succ`.
-- `h_two : h 2 = 1` — squeeze `1 ≤ 3·h 2` (`three_mul_h_ge 2`) against
-  `h 2 ≤ (2 choose 2) = 1` (`h_le_choose_two 2`); `omega` closes. First exact value,
-  no explicit distance computation.
-
-**Why this is progress**: monotonicity is a genuine structural fact none of the
-pointwise bounds provides; `h_two` demonstrates the lower/upper envelope is tight at
-`n = 2`. At `n = 3` the same squeeze gives only `1 ≤ h 3 ≤ 3` (pinning `h 3 = 1` needs
-an explicit equilateral-triangle witness — next step).
-
-### Next
-- Pin `h 3 = 1` via an explicit equilateral triangle (numDistinctDistances = 1); with
-  `h_mono` this gives `h 2 = h 3 = 1`.
-- Improve the lower-bound constant beyond `/3` (combine no-3-collinear + no-4-concyclic,
-  or count from two base points) toward `h n ≥ (n-1)/2` / the conjectured `≥ n`.
-- The conjectured RATE `h n / n → ∞` (Erdős #98 itself) is the sole remaining open piece;
-  divergence `h n → ∞` is already elementary (`tendsto_h_atTop`).
-
-## Session 2026-07-21 (researcher-1) — ELEMENTARY LINEAR LOWER BOUND n−1 ≤ 3·h n + unconditional h(n)→∞
-
-**Mode**: FRESH build on the now-closed existence tower. **Outcome**: progress — first
-lower bound on `h n` that **grows with n**, and an **unconditional** proof of `h(n)→∞`.
-Docker-built `Proofs.Erdos98WIP01` (Build succeeded, 8577 jobs); 0 sorry / 0 axiom / no
-native_decide.
-
-**The idea (elementary, uses no-4-concyclic).** Fix a base point `P b`. Any circle centred
-at `P b` meets the other `n−1` points in **at most three** of them — a fourth would be four
-points equidistant from `P b`, i.e. four concyclic points (centre `P b`), which
-`NoFourConcyclic` forbids. So the `n−1` distances `dist (P b) (P i)` (`i ≠ b`) take at least
-`(n−1)/3` distinct values, each a genuine distinct distance. Hence
-`n−1 ≤ 3·numDistinctDistances P` for **every** general-position `P`, so `n−1 ≤ 3·h n`.
-
-**Added declarations** (all in `Erdos98WIP01.lean`, results #10–12 in the header):
-- `card_fiber_dist_le_three (hgp)(b)(v)` — the fibre of `i ↦ dist (P b)(P i)` over `v`,
-  restricted to `i ≠ b`, has `card ≤ 3`. Crux.
-- `numDistinctDistances_lower (hgp)(0<n) : n−1 ≤ 3·numDistinctDistances P` — the per-config
-  pigeonhole bound.
-- `three_mul_h_ge (n) : n−1 ≤ 3·h n` — same bound for the extremal quantity, via `h_attained`.
-- `tendsto_h_atTop : Tendsto h atTop atTop` — **h(n)→∞ UNCONDITIONALLY**, no imported theorem.
-- helper `card_quad_of_pairwise_ne` (converse of `card_quad_pairwise_ne`, via `Finset.card_eq_four`).
-
-**Why this matters.** `tendsto_h_atTop` strictly sharpens the earlier `guthKatz_imp_tendsto`
-(which assumed the imported Guth–Katz `Ω(n/log n)` baseline) and `weak_imp_tendsto` (which
-assumed the *open* weak conjecture): the divergence of `h` is now an **elementary theorem**.
-Only the conjectured *rate* `h(n)/n→∞` (Erdős #98) stays open — and even the linear order here
-is `/3` of the conjectured `n`, so this is honestly a weak-but-real lower bound, not the target.
-
-**Reusable Lean recipe (pigeonhole distinct-distance lower bound):**
-- `Finset.card_le_mul_card_image (f := …) s k hfib : s.card ≤ k · (s.image f).card` — supply
-  `hfib : ∀ v ∈ s.image f, (s.filter (f · = v)).card ≤ k`. Here `s = univ.erase b`, `k = 3`.
-- Extract the `k+1` colliding elements from `¬(card ≤ k)` via `Finset.three_lt_card.mp
-  (not_le.mp hlt)` (gives `∃ a∈s ∃ b∈s ∃ c∈s ∃ d∈s, pairwise ≠`); rebuild the 4-set cardinality
-  with `Finset.card_eq_four.mpr`.
-- `s.card = n−1` via `Finset.card_erase_of_mem (mem_univ _)` + `card_univ`/`Fintype.card_fin`.
-- Positivity/subset: distances from `P b` land in the `numDistinctDistances` filtered image
-  (each `>0` by injectivity `hib` since `i ≠ b`); `card_le_card` on the subset.
-- Descent to `h`: `three_mul_h_ge` applies `numDistinctDistances_lower` to the `h_attained`
-  minimiser; the `n = 0` case is `simp`. `tendsto_h_atTop` = `Filter.tendsto_atTop.mpr` +
-  `filter_upwards [eventually_ge_atTop (3M+1)]` + `omega` on `n−1 ≤ 3·h n`.
-
-### Next (genuinely remaining — the parent is OPEN)
-- Monotonicity `h n ≤ h (n+1)`: a subconfiguration of a general-position config is general
-  position (Injective / NoThreeCollinear / NoFourConcyclic all inherit under restriction
-  `Fin n ↪ Fin (n+1)`); pair with the extremal witness.
-- Sharpen the `/3` constant, or a per-basepoint-pair refinement.
-- Parent Erdős #98 `h(n)/n→∞` (and even weak `h(n)≥n`) remains OPEN; not reachable by the /3
-  bound.
-
-## Session 2026-07-21 (researcher-1) — general-position existence for ALL n (parabola, positive abscissae)
-
-**Mode**: FRESH build on the n≤4 tower. **Outcome**: progress — **resolved the "deep
-constructive piece"** that every prior session flagged as open. Docker-built
-`Proofs.Erdos98WIP01` (Build succeeded, 8577 jobs); 0 sorry / 0 axiom / no native_decide.
-
-**The key realization that unblocked it.** Prior sessions dismissed the parabola construction
-`(t, t²)` because "any 4 parabola points with abscissae summing to 0 are concyclic". True, but
-the fix is trivial: **make all abscissae positive**. Four parabola points are concyclic *iff*
-their abscissae sum to `0` (Vieta: the 4 abscissae are the roots of the monic quartic
-`x⁴ + (1−2c₁)x² − 2c₀x + s` cut by a circle, whose `x³`-coeff is `0`). Positive abscissae ⟹
-every 4-subset sum `≥ 4 > 0` ⟹ no four concyclic. And on `y = x²` **no three points are ever
-collinear** (strict convexity). So the config `parabolaConfig n : i ↦ (i+1, (i+1)²)` — abscissae
-`1,…,n` — is in general position for **every** `n`. The genericity/perturbation argument the
-earlier notes proposed is NOT needed; this is fully elementary.
-
-**Added declarations** (all in `Erdos98WIP01.lean`):
-- `parabolaConfig n` (def) + `parabolaConfig_zero/one` (coordinate simp lemmas via `simp [parabolaConfig]`).
-- `parabolaConfig_injective`, `noThreeCollinear_parabolaConfig`, `noFourConcyclic_parabolaConfig`.
-- `exists_inGeneralPosition (n) : ∃ P, InGeneralPosition P` — **for all n** (supersedes `_of_le_four`).
-- `h_attained (n) : ∃ P, InGeneralPosition P ∧ numDistinctDistances P = h n` — via `Nat.sInf_mem`,
-  so `h n` is a genuine attained minimum for EVERY n, never the `sInf ∅ = 0` junk value. This
-  removes the honesty caveat on `h_le_choose_two` (its nonempty branch is now unconditional).
-
-**Reusable Lean recipe (elementary algebraic general-position, no measure theory):**
-- Distinctness helpers `card_triple_pairwise_ne` / `card_quad_pairwise_ne`: from `card = k` derive
-  pairwise `≠` via `Finset.insert_eq_self.mpr` (collapse a duplicate) + `Finset.card_insert_of_notMem`
-  (NB: `notMem`, not `not_mem` — renamed in v4.31) + `card_insert_le`, closed by `omega`.
-- No-3-collinear as abstract real lemma `parabola_collinear_trivial`: from `a·xₜ+b·xₜ²+c=0` at 3
-  distinct abscissae, cancel `(xᵢ-xⱼ)` via `mul_eq_zero` + `sub_eq_zero.mp` to get `a+b(xᵢ+xⱼ)=0`,
-  hence `b=0,a=0,c=0`. Each cancellation step is `linear_combination hi - hj` producing the factored
-  product, then `rcases mul_eq_zero`.
-- No-4-concyclic as abstract real lemma `parabola_concyclic_sum_zero`: THREE rounds of
-  difference-and-cancel (`M(t,u)` linear-in-centre → `N(u,v)` symmetric-quadratic → abscissa sum),
-  each round `linear_combination (prev diff)` + `mul_eq_zero`/`sub_eq_zero`. Gives `w+x+y+z=0`;
-  `positivity` on the (all-≥1) sum + `linarith` closes.
-- Bridge metric→squared: `dist center (P t) = r` ⟹ `(c₀-xₜ)²+(c₁-xₜ²)² = r²` via
-  `simp only [EuclideanSpace.dist_sq_eq, Fin.sum_univ_two, <coord lemmas>, Real.dist_eq, sq_abs]`
-  then `linear_combination`.
-
-### Next (genuinely remaining — the parent is OPEN)
-- The constructive existence question is now CLOSED. What remains is purely the parent Erdős #98
-  quantitative content: `h(n)/n → ∞` (strong) and even `h(n) ≥ n` (weak) — both OPEN in mathematics,
-  not attackable by construction. A tractable formal increment would be a concrete lower bound like
-  `2 ≤ h n` for `n ≥ 3` (distinct-distance counting on a general-position witness), or monotonicity
-  `h n ≤ h (n+1)` (subconfiguration of general position is general position). No further "existence"
-  work is needed.
-
-## Session 2026-07-20 (researcher-1) — n=4 general-position existence (first non-vacuous concyclic case)
-
-**Mode**: build on the n=3 triangle. **Outcome**: progress — 6 axiom-free declarations
-(1 def + 5 theorems), host-verified v4.31 (`lake env lean` exit 0; `#print axioms` =
-`[propext, Classical.choice, Quot.sound]`; no sorry/native_decide).
-
-Discharged general-position existence for `n = 4` — the first case where **no-four-concyclic**
-is a genuine constraint. Config `(0,0),(1,0),(0,1),(1,-1)`:
-- `fourConfig` (uses `!₂[·,·]` Euclidean notation; the 4th vertex isn't an axis point so not a
-  `single`), `fourConfig_injective`, `noThreeCollinear_fourConfig` (4 triples, triangle recipe).
-- `fourConfig_not_equidistant` (crux): no centre equidistant from all four. The three squared
-  equalities `‖c-P₀‖²=‖c-Pᵢ‖²` reduce (via `EuclideanSpace.dist_sq_eq`) to linear constraints
-  forcing `c₀=½, c₁=½, c₀-c₁=1` — contradiction by `nlinarith`.
-- `noFourConcyclic_fourConfig`, `exists_inGeneralPosition_four`, `exists_inGeneralPosition_of_le_four`.
-
-**Reusable Lean recipe (metric general-position in EuclideanSpace ℝ (Fin 2)):**
-- `EuclideanSpace.dist_sq_eq : dist x y ^2 = ∑ i, dist (x i)(y i)^2` — AVOIDS manual sqrt.
-  Then `Fin.sum_univ_two`, `Real.dist_eq`, `sq_abs` → `(x0-y0)^2+(x1-y1)^2`. The `c₀²,c₁²`
-  terms cancel across the equidistance equalities, so `nlinarith` finishes.
-- `!₂[a,b]` = Euclidean vector; coordinate access `!₂[a,b] i` reduces via `Matrix.cons_val_*`
-  (`cons_val_three` EXISTS; no `cons_val_four`). `PiLp.toLp_apply` is the raw coord lemma but
-  usually unneeded (simp reduces through it).
-- Concyclic quantifies `∀ a b c d, card=4 → ...`: prove an order-independent helper
-  `..._not_equidistant center r h0 h1 h2 h3`, then `fin_cases a<;>b<;>c<;>d`, kill card≠4 by
-  `decide`, close each of the 24 perms with `exact helper center r (by assumption) ×4` (the
-  `by assumption` picks the hyp matching each expected `dist center (P i)=r` type — uniform!).
-
-### Next
-- **n=5** or **general n**: failure locus `(3-collinear ∪ 4-concyclic)` is a finite union of
-  proper algebraic subvarieties of `(ℝ²)ⁿ`; complement nonempty by a dimension/genericity
-  argument (the deep constructive piece). Parent Erdős #98 (`h(n)/n → ∞`) remains OPEN.
-
-## Session 2026-07-20 (researcher-1) — general-position existence for n ≤ 2 + vacuity lemmas
-
-Added to `Erdos98WIP01.lean` (host-verified, parent `Erdos98Problem` is
-Mathlib-only; all three depend only on `[propext, Classical.choice, Quot.sound]`,
-0 sorry / 0 axiom):
-
-- `noThreeCollinear_of_le_two (P) (n ≤ 2) : NoThreeCollinear P` — vacuous:
-  `card {i,j,k} = 3` is impossible among `n ≤ 2` points
-  (`Finset.card_le_card (subset_univ ..)` + `card_univ`/`Fintype.card_fin`, `omega`).
-- `noFourConcyclic_of_le_three (P) (n ≤ 3) : NoFourConcyclic P` — vacuous:
-  `card {a,b,c,d} = 4` impossible among `n ≤ 3` points.
-- `exists_inGeneralPosition_of_le_two (n ≤ 2) : ∃ P, InGeneralPosition P` — the
-  injective embedding `i ↦ EuclideanSpace.single 0 (i:ℝ)` (distinct first
-  coordinates) is general-position since both nondegeneracy conditions are
-  vacuous. **Consequence:** the defining set of `h n` is nonempty for `n ≤ 2`, so
-  `h n` is an *attained* minimum there, not the `sInf ∅ = 0` junk value that the
-  empty branch of `h_le_choose_two` falls back to.
-
-### Key obstruction (negative knowledge)
-The natural **parabola** construction `(t, t²)` does NOT give general position:
-- No 3 collinear ✓ (a line meets `y = x²` in ≤ 2 points).
-- No 4 concyclic ✗ — a circle meets `y = x²` in the quartic
-  `x⁴ + (1−2q)x² − 2px + (p²+q²−r²) = 0`, whose **cubic coefficient is 0**, so the
-  4 roots sum to `0`. Hence any 4 parabola points with `x`-coordinates summing to
-  `0` (e.g. `x = −3,−1,1,3`) ARE concyclic. Full GP existence needs a
-  genericity/perturbation argument (config space minus finitely many proper
-  algebraic subvarieties), not a single explicit algebraic curve.
-
-### v4.31 gotcha
-`EuclideanSpace.single_apply` is deprecated → use `PiLp.single_apply`. Extract a
-coordinate from an equality of `EuclideanSpace` points via
-`congrArg (fun f => f 0) hij` then `simpa [PiLp.single_apply]`.
-
-### Next
-- `n = 3` (first non-vacuous no-3-collinear case): explicit triangle
-  `(0,0),(1,0),(0,1)`, needing the 6-permutation collinearity computation.
-- Full GP existence for all `n` via genericity (deep constructive piece).
-
-## Session 2026-07-20 (researcher-1) — h(n)→∞ is UNCONDITIONAL (Guth–Katz baseline)
-
-Added 2 axiom-free theorems to `Erdos98WIP01.lean` (host-verified v4.31.0 via fresh-parent-olean;
-`#print axioms` = propext/Classical.choice/Quot.sound):
-
-- `tendsto_const_mul_div_log_atTop` — `c·n/log n → ∞` for `c>0`. Path: `Real.isLittleO_log_id_atTop`
-  ∘ `tendsto_natCast_atTop_atTop` ⟹ `log n =o n` ⟹ `log n / n → 0` (`IsLittleO.tendsto_div_nhds_zero`);
-  eventually positive (`Real.log_pos`, n≥2) ⟹ `→ 𝓝[>]0` ⟹ reciprocal `→ atTop`
-  (`Filter.Tendsto.inv_tendsto_nhdsGT_zero`); `inv_div` + `const_mul_atTop`.
-- `guthKatz_imp_tendsto` — `GuthKatzBaseline ⟹ Tendsto h atTop atTop`. The imported (proven)
-  Ω(n/log n) lower bound `c·n/log n ≤ h(n)` + the divergence above ⟹ `(h n:ℝ)→∞`
-  (`tendsto_atTop_mono'`), then descend to ℕ (`Filter.tendsto_atTop.mpr` + `exact_mod_cast`).
-
-KEY POINT: this sharpens the existing `weak_imp_tendsto`, which derived the SAME divergence
-`h(n)→∞` from the OPEN weak conjecture. In fact the divergence is a THEOREM (unconditional,
-from Guth–Katz). What genuinely remains open is only the RATE — `h(n)/n→∞` (strong) and
-`h(n)≥n` (weak).
-
-### Remaining open
-- `h n ≤ n.choose 2` needs a general-position existence witness for all n (constructive, missing).
-- Parent Erdős #98 (`h(n)/n→∞`) remains OPEN in mathematics.
-
-## Session 2026-07-21 (researcher-1) — unconditional upper bound h(n) ≤ n.choose 2
-
-Added 2 axiom-free theorems to `Erdos98WIP01.lean` (theoremCount 10→12, host-verified
-v4.31 via fresh parent olean + `lake env lean`, exit 0; `#print axioms` =
-propext/Classical.choice/Quot.sound on both):
-
-- `h_le_choose_two (n) : h n ≤ n.choose 2` — **resolves the open item** flagged last
-  session ("`h n ≤ n.choose 2` needs a general-position existence witness"). The witness
-  is *not* needed: split on whether the defining set
-  `{numDistinctDistances P | InGeneralPosition P}` is empty. Nonempty ⟹
-  `h n ≤ numDistinctDistances P ≤ n.choose 2` (`h_le_of_inGeneralPosition` +
-  `numDistinctDistances_le_choose_two`). Empty ⟹ `h n = sInf ∅ = 0 ≤ n.choose 2`
-  (`Nat.sInf_empty`). Combined with the unconditional divergence `guthKatz_imp_tendsto`,
-  the minimum is now sandwiched: `h n → ∞` yet `h n ≤ n.choose 2` for every n.
-- `h_eq_zero_of_le_one (n≤1) : h n = 0` — concrete degenerate values, since
-  `n.choose 2 = 0` there (`Nat.choose_eq_zero_of_lt`) caps `h n` at 0.
-
-### Note on honesty
-`h_le_choose_two` is vacuous in the (believed-impossible for ℝ²) empty regime; its real
-content is the nonempty branch. Proving general-position configs exist for all n
-(`Injective ∧ NoThreeCollinear ∧ NoFourConcyclic`) remains the missing constructive piece
-and the genuine next target — it would make `h n` a true minimum over a nonempty set.
-
-### Remaining open (UNCHANGED)
-Existence of general-position configurations for all n (constructive); parent Erdős #98
-(`h(n)/n → ∞`, and even the weak `h(n) ≥ n`) remains OPEN in mathematics.
-
-## Session 2026-07-20 (researcher-1) — n=3 general-position existence (explicit triangle)
-
-**Mode**: build on the n≤2 vacuity result. **Outcome**: progress — 5 axiom-free
-declarations (1 def + 4 theorems), **host-verified v4.31** (`lake env lean` exit 0;
-`#print axioms` = `[propext, Classical.choice, Quot.sound]`; no sorry/native_decide).
-
-Discharged general-position existence for `n = 3` — the first case where no-three-collinear
-is a genuine (non-vacuous) constraint:
-
-- `triangleConfig` — the right triangle `(0,0), (1,0), (0,1)`, each vertex built with
-  `EuclideanSpace.single` for uniform `single_apply` coordinate access.
-- `triangleConfig_injective`, `noThreeCollinear_triangleConfig` (the crux),
-  `noFourConcyclic_triangleConfig` (vacuous via `noFourConcyclic_of_le_three`).
-- `exists_inGeneralPosition_three` and `exists_inGeneralPosition_of_le_three`: GP configs
-  exist for all `n ≤ 3`, so `h n` is a genuine attained minimum (not `sInf ∅`) through `n=3`
-  (previously only `n ≤ 2`).
-
-**Proof technique** (no-3-collinear): a line `a·x+b·y+c=0` through all three vertices
-forces `c=0` (origin), `a=0` ((1,0)), `b=0` ((0,1)). Formalized by `fin_cases` over the 27
-index triples `(i,j,k)`: the degenerate (repeated-index) triples are killed by
-`exact absurd hcard (by decide)` on `card{i,j,k}=3`; the 6 genuine permutations reduce via
-`simp only [Matrix.cons_val_zero/one/two, head_cons, tail_cons, EuclideanSpace.single_apply]`
-then `norm_num` (decides the `ite` conditions + arithmetic), closed by `linarith` on the
-three linear facts. Injectivity: `fin_cases` + full `simp` closes the false coordinate
-equalities.
-
-### Next
-- **n=4** (first non-vacuous no-4-concyclic case): analog of this step for concyclicity —
-  needs the four-points-on-a-circle determinant computation over `EuclideanSpace`.
-- **All n**: failure locus `(3-collinear ∪ 4-concyclic)` is a finite union of proper
-  algebraic subvarieties of `(ℝ²)ⁿ`; complement nonempty by a dimension/genericity argument
-  (the deep constructive piece). Parent Erdős #98 (`h(n)/n → ∞`) remains OPEN.
-
-## Session 2026-07-21 (researcher-1) — general closed-form lower bound (consolidation)
-
-**Mode**: build on the mature file (h pinned for n≤5, general GP existence, ladder rungs).
-**Outcome**: progress — 1 new general theorem + consolidation, host-verified v4.31
-(`lake env lean` exit 0; warnings only, no errors/sorry/axiom).
-
-The lower-bound "ladder" (`three_le_h_of_eight_le`, `four_le_h_of_eleven_le`) consisted of
-per-rung `omega` specializations of the single linear counting bound
-`three_mul_h_ge : n − 1 ≤ 3 · h n`. Adding further rungs would be enumeration theater, so
-instead I proved the **general closed form** that subsumes the whole ladder:
-
-- `le_h_of_three_mul_sub_one_le {k} (hn : 3*k − 1 ≤ n) : k ≤ h n` — for every target `k`,
-  `h n ≥ k` as soon as `n ≥ 3k − 1`. Proof: from `3·h n ≥ n − 1 ≥ 3k − 2 > 3(k−1)`,
-  `omega` gives `h n ≥ k`. Axiom-free (only `three_mul_h_ge` + `omega`).
-- Rewrote `three_le_h_of_eight_le` / `four_le_h_of_eleven_le` as one-line `k=3` / `k=4`
-  specializations `le_h_of_three_mul_sub_one_le (by omega)`, and added
-  `five_le_h_of_fourteen_le` (`k=5`, `3·5−1=14`) as an illustrative rung.
-
-### Next (unchanged, deep)
-Improving the linear `(n−1)/3` bound toward the conjectured super-linear rate is the genuine
-open direction. The parent Erdős #98 (`h n / n → ∞`, even the weak `h n ≥ n`) is OPEN in
-mathematics; the elementary counting layer here is essentially saturated.

--- a/research/problems/erdos-98-wip-01/sessions/2026-07-20-s02.md
+++ b/research/problems/erdos-98-wip-01/sessions/2026-07-20-s02.md
@@ -1,0 +1,33 @@
+## Session 2026-07-20 (researcher-1) — n=3 general-position existence (explicit triangle)
+
+**Mode**: build on the n≤2 vacuity result. **Outcome**: progress — 5 axiom-free
+declarations (1 def + 4 theorems), **host-verified v4.31** (`lake env lean` exit 0;
+`#print axioms` = `[propext, Classical.choice, Quot.sound]`; no sorry/native_decide).
+
+Discharged general-position existence for `n = 3` — the first case where no-three-collinear
+is a genuine (non-vacuous) constraint:
+
+- `triangleConfig` — the right triangle `(0,0), (1,0), (0,1)`, each vertex built with
+  `EuclideanSpace.single` for uniform `single_apply` coordinate access.
+- `triangleConfig_injective`, `noThreeCollinear_triangleConfig` (the crux),
+  `noFourConcyclic_triangleConfig` (vacuous via `noFourConcyclic_of_le_three`).
+- `exists_inGeneralPosition_three` and `exists_inGeneralPosition_of_le_three`: GP configs
+  exist for all `n ≤ 3`, so `h n` is a genuine attained minimum (not `sInf ∅`) through `n=3`
+  (previously only `n ≤ 2`).
+
+**Proof technique** (no-3-collinear): a line `a·x+b·y+c=0` through all three vertices
+forces `c=0` (origin), `a=0` ((1,0)), `b=0` ((0,1)). Formalized by `fin_cases` over the 27
+index triples `(i,j,k)`: the degenerate (repeated-index) triples are killed by
+`exact absurd hcard (by decide)` on `card{i,j,k}=3`; the 6 genuine permutations reduce via
+`simp only [Matrix.cons_val_zero/one/two, head_cons, tail_cons, EuclideanSpace.single_apply]`
+then `norm_num` (decides the `ite` conditions + arithmetic), closed by `linarith` on the
+three linear facts. Injectivity: `fin_cases` + full `simp` closes the false coordinate
+equalities.
+
+### Next
+- **n=4** (first non-vacuous no-4-concyclic case): analog of this step for concyclicity —
+  needs the four-points-on-a-circle determinant computation over `EuclideanSpace`.
+- **All n**: failure locus `(3-collinear ∪ 4-concyclic)` is a finite union of proper
+  algebraic subvarieties of `(ℝ²)ⁿ`; complement nonempty by a dimension/genericity argument
+  (the deep constructive piece). Parent Erdős #98 (`h(n)/n → ∞`) remains OPEN.
+

--- a/research/problems/erdos-98-wip-01/sessions/2026-07-20-s04.md
+++ b/research/problems/erdos-98-wip-01/sessions/2026-07-20-s04.md
@@ -1,0 +1,22 @@
+## Session 2026-07-20 (researcher-1) — h(n)→∞ is UNCONDITIONAL (Guth–Katz baseline)
+
+Added 2 axiom-free theorems to `Erdos98WIP01.lean` (host-verified v4.31.0 via fresh-parent-olean;
+`#print axioms` = propext/Classical.choice/Quot.sound):
+
+- `tendsto_const_mul_div_log_atTop` — `c·n/log n → ∞` for `c>0`. Path: `Real.isLittleO_log_id_atTop`
+  ∘ `tendsto_natCast_atTop_atTop` ⟹ `log n =o n` ⟹ `log n / n → 0` (`IsLittleO.tendsto_div_nhds_zero`);
+  eventually positive (`Real.log_pos`, n≥2) ⟹ `→ 𝓝[>]0` ⟹ reciprocal `→ atTop`
+  (`Filter.Tendsto.inv_tendsto_nhdsGT_zero`); `inv_div` + `const_mul_atTop`.
+- `guthKatz_imp_tendsto` — `GuthKatzBaseline ⟹ Tendsto h atTop atTop`. The imported (proven)
+  Ω(n/log n) lower bound `c·n/log n ≤ h(n)` + the divergence above ⟹ `(h n:ℝ)→∞`
+  (`tendsto_atTop_mono'`), then descend to ℕ (`Filter.tendsto_atTop.mpr` + `exact_mod_cast`).
+
+KEY POINT: this sharpens the existing `weak_imp_tendsto`, which derived the SAME divergence
+`h(n)→∞` from the OPEN weak conjecture. In fact the divergence is a THEOREM (unconditional,
+from Guth–Katz). What genuinely remains open is only the RATE — `h(n)/n→∞` (strong) and
+`h(n)≥n` (weak).
+
+### Remaining open
+- `h n ≤ n.choose 2` needs a general-position existence witness for all n (constructive, missing).
+- Parent Erdős #98 (`h(n)/n→∞`) remains OPEN in mathematics.
+

--- a/research/problems/erdos-98-wip-01/sessions/2026-07-20-s05.md
+++ b/research/problems/erdos-98-wip-01/sessions/2026-07-20-s05.md
@@ -1,0 +1,38 @@
+## Session 2026-07-20 (researcher-1) — general-position existence for n ≤ 2 + vacuity lemmas
+
+Added to `Erdos98WIP01.lean` (host-verified, parent `Erdos98Problem` is
+Mathlib-only; all three depend only on `[propext, Classical.choice, Quot.sound]`,
+0 sorry / 0 axiom):
+
+- `noThreeCollinear_of_le_two (P) (n ≤ 2) : NoThreeCollinear P` — vacuous:
+  `card {i,j,k} = 3` is impossible among `n ≤ 2` points
+  (`Finset.card_le_card (subset_univ ..)` + `card_univ`/`Fintype.card_fin`, `omega`).
+- `noFourConcyclic_of_le_three (P) (n ≤ 3) : NoFourConcyclic P` — vacuous:
+  `card {a,b,c,d} = 4` impossible among `n ≤ 3` points.
+- `exists_inGeneralPosition_of_le_two (n ≤ 2) : ∃ P, InGeneralPosition P` — the
+  injective embedding `i ↦ EuclideanSpace.single 0 (i:ℝ)` (distinct first
+  coordinates) is general-position since both nondegeneracy conditions are
+  vacuous. **Consequence:** the defining set of `h n` is nonempty for `n ≤ 2`, so
+  `h n` is an *attained* minimum there, not the `sInf ∅ = 0` junk value that the
+  empty branch of `h_le_choose_two` falls back to.
+
+### Key obstruction (negative knowledge)
+The natural **parabola** construction `(t, t²)` does NOT give general position:
+- No 3 collinear ✓ (a line meets `y = x²` in ≤ 2 points).
+- No 4 concyclic ✗ — a circle meets `y = x²` in the quartic
+  `x⁴ + (1−2q)x² − 2px + (p²+q²−r²) = 0`, whose **cubic coefficient is 0**, so the
+  4 roots sum to `0`. Hence any 4 parabola points with `x`-coordinates summing to
+  `0` (e.g. `x = −3,−1,1,3`) ARE concyclic. Full GP existence needs a
+  genericity/perturbation argument (config space minus finitely many proper
+  algebraic subvarieties), not a single explicit algebraic curve.
+
+### v4.31 gotcha
+`EuclideanSpace.single_apply` is deprecated → use `PiLp.single_apply`. Extract a
+coordinate from an equality of `EuclideanSpace` points via
+`congrArg (fun f => f 0) hij` then `simpa [PiLp.single_apply]`.
+
+### Next
+- `n = 3` (first non-vacuous no-3-collinear case): explicit triangle
+  `(0,0),(1,0),(0,1)`, needing the 6-permutation collinearity computation.
+- Full GP existence for all `n` via genericity (deep constructive piece).
+

--- a/research/problems/erdos-98-wip-01/sessions/2026-07-20-s06.md
+++ b/research/problems/erdos-98-wip-01/sessions/2026-07-20-s06.md
@@ -1,0 +1,32 @@
+## Session 2026-07-20 (researcher-1) — n=4 general-position existence (first non-vacuous concyclic case)
+
+**Mode**: build on the n=3 triangle. **Outcome**: progress — 6 axiom-free declarations
+(1 def + 5 theorems), host-verified v4.31 (`lake env lean` exit 0; `#print axioms` =
+`[propext, Classical.choice, Quot.sound]`; no sorry/native_decide).
+
+Discharged general-position existence for `n = 4` — the first case where **no-four-concyclic**
+is a genuine constraint. Config `(0,0),(1,0),(0,1),(1,-1)`:
+- `fourConfig` (uses `!₂[·,·]` Euclidean notation; the 4th vertex isn't an axis point so not a
+  `single`), `fourConfig_injective`, `noThreeCollinear_fourConfig` (4 triples, triangle recipe).
+- `fourConfig_not_equidistant` (crux): no centre equidistant from all four. The three squared
+  equalities `‖c-P₀‖²=‖c-Pᵢ‖²` reduce (via `EuclideanSpace.dist_sq_eq`) to linear constraints
+  forcing `c₀=½, c₁=½, c₀-c₁=1` — contradiction by `nlinarith`.
+- `noFourConcyclic_fourConfig`, `exists_inGeneralPosition_four`, `exists_inGeneralPosition_of_le_four`.
+
+**Reusable Lean recipe (metric general-position in EuclideanSpace ℝ (Fin 2)):**
+- `EuclideanSpace.dist_sq_eq : dist x y ^2 = ∑ i, dist (x i)(y i)^2` — AVOIDS manual sqrt.
+  Then `Fin.sum_univ_two`, `Real.dist_eq`, `sq_abs` → `(x0-y0)^2+(x1-y1)^2`. The `c₀²,c₁²`
+  terms cancel across the equidistance equalities, so `nlinarith` finishes.
+- `!₂[a,b]` = Euclidean vector; coordinate access `!₂[a,b] i` reduces via `Matrix.cons_val_*`
+  (`cons_val_three` EXISTS; no `cons_val_four`). `PiLp.toLp_apply` is the raw coord lemma but
+  usually unneeded (simp reduces through it).
+- Concyclic quantifies `∀ a b c d, card=4 → ...`: prove an order-independent helper
+  `..._not_equidistant center r h0 h1 h2 h3`, then `fin_cases a<;>b<;>c<;>d`, kill card≠4 by
+  `decide`, close each of the 24 perms with `exact helper center r (by assumption) ×4` (the
+  `by assumption` picks the hyp matching each expected `dist center (P i)=r` type — uniform!).
+
+### Next
+- **n=5** or **general n**: failure locus `(3-collinear ∪ 4-concyclic)` is a finite union of
+  proper algebraic subvarieties of `(ℝ²)ⁿ`; complement nonempty by a dimension/genericity
+  argument (the deep constructive piece). Parent Erdős #98 (`h(n)/n → ∞`) remains OPEN.
+

--- a/research/problems/erdos-98-wip-01/sessions/2026-07-20-s09.md
+++ b/research/problems/erdos-98-wip-01/sessions/2026-07-20-s09.md
@@ -1,0 +1,37 @@
+## Session 2026-07-20 (researcher-1) — MONOTONICITY of h + pinned value h 2 = 1
+
+**Mode**: FRESH (continue) — build on the linear lower bound. **Outcome**: progress
+— 5 axiom-free declarations, **docker-built** `Proofs.Erdos98WIP01` OK (8577 jobs,
+0 sorry / 0 axiom / no native_decide).
+
+Proved the first **structural comparison across cardinalities** and the first
+exactly-pinned value of `h`:
+
+- `card_triple_image` / `card_quad_image` — injective-image cardinality helpers
+  (`card {e i,e j,e k} = card {i,j,k}`) via `Finset.card_image_of_injective`.
+- `inGeneralPosition_comp` — a sub-configuration `P ∘ e` chosen by an **injective**
+  index map `e : Fin m → Fin n` inherits general position: injectivity composes, and
+  any collinear/concyclic degeneracy of `P ∘ e` transports through `e` (which preserves
+  the `card = 3` / `card = 4` distinctness) to a degeneracy of `P`, contradicting `hP`.
+- `numDistinctDistances_comp_le` — `numDistinctDistances (P ∘ e) ≤ numDistinctDistances P`
+  (every positive sub-config distance is realized by the image pair `(e p.1, e p.2)`).
+- `h_mono : Monotone h` — delete the last point (`Fin.castSucc`) of the `h_attained`
+  minimizer of `h (n+1)`; the restriction is general position with `≤` distinct distances,
+  so `h n ≤ numDistinctDistances ≤ h (n+1)`. Via `monotone_nat_of_le_succ`.
+- `h_two : h 2 = 1` — squeeze `1 ≤ 3·h 2` (`three_mul_h_ge 2`) against
+  `h 2 ≤ (2 choose 2) = 1` (`h_le_choose_two 2`); `omega` closes. First exact value,
+  no explicit distance computation.
+
+**Why this is progress**: monotonicity is a genuine structural fact none of the
+pointwise bounds provides; `h_two` demonstrates the lower/upper envelope is tight at
+`n = 2`. At `n = 3` the same squeeze gives only `1 ≤ h 3 ≤ 3` (pinning `h 3 = 1` needs
+an explicit equilateral-triangle witness — next step).
+
+### Next
+- Pin `h 3 = 1` via an explicit equilateral triangle (numDistinctDistances = 1); with
+  `h_mono` this gives `h 2 = h 3 = 1`.
+- Improve the lower-bound constant beyond `/3` (combine no-3-collinear + no-4-concyclic,
+  or count from two base points) toward `h n ≥ (n-1)/2` / the conjectured `≥ n`.
+- The conjectured RATE `h n / n → ∞` (Erdős #98 itself) is the sole remaining open piece;
+  divergence `h n → ∞` is already elementary (`tendsto_h_atTop`).
+

--- a/research/problems/erdos-98-wip-01/sessions/2026-07-21-s01.md
+++ b/research/problems/erdos-98-wip-01/sessions/2026-07-21-s01.md
@@ -1,0 +1,22 @@
+## Session 2026-07-21 (researcher-1) — general closed-form lower bound (consolidation)
+
+**Mode**: build on the mature file (h pinned for n≤5, general GP existence, ladder rungs).
+**Outcome**: progress — 1 new general theorem + consolidation, host-verified v4.31
+(`lake env lean` exit 0; warnings only, no errors/sorry/axiom).
+
+The lower-bound "ladder" (`three_le_h_of_eight_le`, `four_le_h_of_eleven_le`) consisted of
+per-rung `omega` specializations of the single linear counting bound
+`three_mul_h_ge : n − 1 ≤ 3 · h n`. Adding further rungs would be enumeration theater, so
+instead I proved the **general closed form** that subsumes the whole ladder:
+
+- `le_h_of_three_mul_sub_one_le {k} (hn : 3*k − 1 ≤ n) : k ≤ h n` — for every target `k`,
+  `h n ≥ k` as soon as `n ≥ 3k − 1`. Proof: from `3·h n ≥ n − 1 ≥ 3k − 2 > 3(k−1)`,
+  `omega` gives `h n ≥ k`. Axiom-free (only `three_mul_h_ge` + `omega`).
+- Rewrote `three_le_h_of_eight_le` / `four_le_h_of_eleven_le` as one-line `k=3` / `k=4`
+  specializations `le_h_of_three_mul_sub_one_le (by omega)`, and added
+  `five_le_h_of_fourteen_le` (`k=5`, `3·5−1=14`) as an illustrative rung.
+
+### Next (unchanged, deep)
+Improving the linear `(n−1)/3` bound toward the conjectured super-linear rate is the genuine
+open direction. The parent Erdős #98 (`h n / n → ∞`, even the weak `h n ≥ n`) is OPEN in
+mathematics; the elementary counting layer here is essentially saturated.

--- a/research/problems/erdos-98-wip-01/sessions/2026-07-21-s03.md
+++ b/research/problems/erdos-98-wip-01/sessions/2026-07-21-s03.md
@@ -1,0 +1,27 @@
+## Session 2026-07-21 (researcher-1) — unconditional upper bound h(n) ≤ n.choose 2
+
+Added 2 axiom-free theorems to `Erdos98WIP01.lean` (theoremCount 10→12, host-verified
+v4.31 via fresh parent olean + `lake env lean`, exit 0; `#print axioms` =
+propext/Classical.choice/Quot.sound on both):
+
+- `h_le_choose_two (n) : h n ≤ n.choose 2` — **resolves the open item** flagged last
+  session ("`h n ≤ n.choose 2` needs a general-position existence witness"). The witness
+  is *not* needed: split on whether the defining set
+  `{numDistinctDistances P | InGeneralPosition P}` is empty. Nonempty ⟹
+  `h n ≤ numDistinctDistances P ≤ n.choose 2` (`h_le_of_inGeneralPosition` +
+  `numDistinctDistances_le_choose_two`). Empty ⟹ `h n = sInf ∅ = 0 ≤ n.choose 2`
+  (`Nat.sInf_empty`). Combined with the unconditional divergence `guthKatz_imp_tendsto`,
+  the minimum is now sandwiched: `h n → ∞` yet `h n ≤ n.choose 2` for every n.
+- `h_eq_zero_of_le_one (n≤1) : h n = 0` — concrete degenerate values, since
+  `n.choose 2 = 0` there (`Nat.choose_eq_zero_of_lt`) caps `h n` at 0.
+
+### Note on honesty
+`h_le_choose_two` is vacuous in the (believed-impossible for ℝ²) empty regime; its real
+content is the nonempty branch. Proving general-position configs exist for all n
+(`Injective ∧ NoThreeCollinear ∧ NoFourConcyclic`) remains the missing constructive piece
+and the genuine next target — it would make `h n` a true minimum over a nonempty set.
+
+### Remaining open (UNCHANGED)
+Existence of general-position configurations for all n (constructive); parent Erdős #98
+(`h(n)/n → ∞`, and even the weak `h(n) ≥ n`) remains OPEN in mathematics.
+

--- a/research/problems/erdos-98-wip-01/sessions/2026-07-21-s07.md
+++ b/research/problems/erdos-98-wip-01/sessions/2026-07-21-s07.md
@@ -1,0 +1,48 @@
+## Session 2026-07-21 (researcher-1) — general-position existence for ALL n (parabola, positive abscissae)
+
+**Mode**: FRESH build on the n≤4 tower. **Outcome**: progress — **resolved the "deep
+constructive piece"** that every prior session flagged as open. Docker-built
+`Proofs.Erdos98WIP01` (Build succeeded, 8577 jobs); 0 sorry / 0 axiom / no native_decide.
+
+**The key realization that unblocked it.** Prior sessions dismissed the parabola construction
+`(t, t²)` because "any 4 parabola points with abscissae summing to 0 are concyclic". True, but
+the fix is trivial: **make all abscissae positive**. Four parabola points are concyclic *iff*
+their abscissae sum to `0` (Vieta: the 4 abscissae are the roots of the monic quartic
+`x⁴ + (1−2c₁)x² − 2c₀x + s` cut by a circle, whose `x³`-coeff is `0`). Positive abscissae ⟹
+every 4-subset sum `≥ 4 > 0` ⟹ no four concyclic. And on `y = x²` **no three points are ever
+collinear** (strict convexity). So the config `parabolaConfig n : i ↦ (i+1, (i+1)²)` — abscissae
+`1,…,n` — is in general position for **every** `n`. The genericity/perturbation argument the
+earlier notes proposed is NOT needed; this is fully elementary.
+
+**Added declarations** (all in `Erdos98WIP01.lean`):
+- `parabolaConfig n` (def) + `parabolaConfig_zero/one` (coordinate simp lemmas via `simp [parabolaConfig]`).
+- `parabolaConfig_injective`, `noThreeCollinear_parabolaConfig`, `noFourConcyclic_parabolaConfig`.
+- `exists_inGeneralPosition (n) : ∃ P, InGeneralPosition P` — **for all n** (supersedes `_of_le_four`).
+- `h_attained (n) : ∃ P, InGeneralPosition P ∧ numDistinctDistances P = h n` — via `Nat.sInf_mem`,
+  so `h n` is a genuine attained minimum for EVERY n, never the `sInf ∅ = 0` junk value. This
+  removes the honesty caveat on `h_le_choose_two` (its nonempty branch is now unconditional).
+
+**Reusable Lean recipe (elementary algebraic general-position, no measure theory):**
+- Distinctness helpers `card_triple_pairwise_ne` / `card_quad_pairwise_ne`: from `card = k` derive
+  pairwise `≠` via `Finset.insert_eq_self.mpr` (collapse a duplicate) + `Finset.card_insert_of_notMem`
+  (NB: `notMem`, not `not_mem` — renamed in v4.31) + `card_insert_le`, closed by `omega`.
+- No-3-collinear as abstract real lemma `parabola_collinear_trivial`: from `a·xₜ+b·xₜ²+c=0` at 3
+  distinct abscissae, cancel `(xᵢ-xⱼ)` via `mul_eq_zero` + `sub_eq_zero.mp` to get `a+b(xᵢ+xⱼ)=0`,
+  hence `b=0,a=0,c=0`. Each cancellation step is `linear_combination hi - hj` producing the factored
+  product, then `rcases mul_eq_zero`.
+- No-4-concyclic as abstract real lemma `parabola_concyclic_sum_zero`: THREE rounds of
+  difference-and-cancel (`M(t,u)` linear-in-centre → `N(u,v)` symmetric-quadratic → abscissa sum),
+  each round `linear_combination (prev diff)` + `mul_eq_zero`/`sub_eq_zero`. Gives `w+x+y+z=0`;
+  `positivity` on the (all-≥1) sum + `linarith` closes.
+- Bridge metric→squared: `dist center (P t) = r` ⟹ `(c₀-xₜ)²+(c₁-xₜ²)² = r²` via
+  `simp only [EuclideanSpace.dist_sq_eq, Fin.sum_univ_two, <coord lemmas>, Real.dist_eq, sq_abs]`
+  then `linear_combination`.
+
+### Next (genuinely remaining — the parent is OPEN)
+- The constructive existence question is now CLOSED. What remains is purely the parent Erdős #98
+  quantitative content: `h(n)/n → ∞` (strong) and even `h(n) ≥ n` (weak) — both OPEN in mathematics,
+  not attackable by construction. A tractable formal increment would be a concrete lower bound like
+  `2 ≤ h n` for `n ≥ 3` (distinct-distance counting on a general-position witness), or monotonicity
+  `h n ≤ h (n+1)` (subconfiguration of general position is general position). No further "existence"
+  work is needed.
+

--- a/research/problems/erdos-98-wip-01/sessions/2026-07-21-s08.md
+++ b/research/problems/erdos-98-wip-01/sessions/2026-07-21-s08.md
@@ -1,0 +1,50 @@
+## Session 2026-07-21 (researcher-1) — ELEMENTARY LINEAR LOWER BOUND n−1 ≤ 3·h n + unconditional h(n)→∞
+
+**Mode**: FRESH build on the now-closed existence tower. **Outcome**: progress — first
+lower bound on `h n` that **grows with n**, and an **unconditional** proof of `h(n)→∞`.
+Docker-built `Proofs.Erdos98WIP01` (Build succeeded, 8577 jobs); 0 sorry / 0 axiom / no
+native_decide.
+
+**The idea (elementary, uses no-4-concyclic).** Fix a base point `P b`. Any circle centred
+at `P b` meets the other `n−1` points in **at most three** of them — a fourth would be four
+points equidistant from `P b`, i.e. four concyclic points (centre `P b`), which
+`NoFourConcyclic` forbids. So the `n−1` distances `dist (P b) (P i)` (`i ≠ b`) take at least
+`(n−1)/3` distinct values, each a genuine distinct distance. Hence
+`n−1 ≤ 3·numDistinctDistances P` for **every** general-position `P`, so `n−1 ≤ 3·h n`.
+
+**Added declarations** (all in `Erdos98WIP01.lean`, results #10–12 in the header):
+- `card_fiber_dist_le_three (hgp)(b)(v)` — the fibre of `i ↦ dist (P b)(P i)` over `v`,
+  restricted to `i ≠ b`, has `card ≤ 3`. Crux.
+- `numDistinctDistances_lower (hgp)(0<n) : n−1 ≤ 3·numDistinctDistances P` — the per-config
+  pigeonhole bound.
+- `three_mul_h_ge (n) : n−1 ≤ 3·h n` — same bound for the extremal quantity, via `h_attained`.
+- `tendsto_h_atTop : Tendsto h atTop atTop` — **h(n)→∞ UNCONDITIONALLY**, no imported theorem.
+- helper `card_quad_of_pairwise_ne` (converse of `card_quad_pairwise_ne`, via `Finset.card_eq_four`).
+
+**Why this matters.** `tendsto_h_atTop` strictly sharpens the earlier `guthKatz_imp_tendsto`
+(which assumed the imported Guth–Katz `Ω(n/log n)` baseline) and `weak_imp_tendsto` (which
+assumed the *open* weak conjecture): the divergence of `h` is now an **elementary theorem**.
+Only the conjectured *rate* `h(n)/n→∞` (Erdős #98) stays open — and even the linear order here
+is `/3` of the conjectured `n`, so this is honestly a weak-but-real lower bound, not the target.
+
+**Reusable Lean recipe (pigeonhole distinct-distance lower bound):**
+- `Finset.card_le_mul_card_image (f := …) s k hfib : s.card ≤ k · (s.image f).card` — supply
+  `hfib : ∀ v ∈ s.image f, (s.filter (f · = v)).card ≤ k`. Here `s = univ.erase b`, `k = 3`.
+- Extract the `k+1` colliding elements from `¬(card ≤ k)` via `Finset.three_lt_card.mp
+  (not_le.mp hlt)` (gives `∃ a∈s ∃ b∈s ∃ c∈s ∃ d∈s, pairwise ≠`); rebuild the 4-set cardinality
+  with `Finset.card_eq_four.mpr`.
+- `s.card = n−1` via `Finset.card_erase_of_mem (mem_univ _)` + `card_univ`/`Fintype.card_fin`.
+- Positivity/subset: distances from `P b` land in the `numDistinctDistances` filtered image
+  (each `>0` by injectivity `hib` since `i ≠ b`); `card_le_card` on the subset.
+- Descent to `h`: `three_mul_h_ge` applies `numDistinctDistances_lower` to the `h_attained`
+  minimiser; the `n = 0` case is `simp`. `tendsto_h_atTop` = `Filter.tendsto_atTop.mpr` +
+  `filter_upwards [eventually_ge_atTop (3M+1)]` + `omega` on `n−1 ≤ 3·h n`.
+
+### Next (genuinely remaining — the parent is OPEN)
+- Monotonicity `h n ≤ h (n+1)`: a subconfiguration of a general-position config is general
+  position (Injective / NoThreeCollinear / NoFourConcyclic all inherit under restriction
+  `Fin n ↪ Fin (n+1)`); pair with the extremal witness.
+- Sharpen the `/3` constant, or a per-basepoint-pair refinement.
+- Parent Erdős #98 `h(n)/n→∞` (and even weak `h(n)≥n`) remains OPEN; not reachable by the /3
+  bound.
+

--- a/research/problems/erdos-98-wip-01/sessions/2026-07-21-s10.md
+++ b/research/problems/erdos-98-wip-01/sessions/2026-07-21-s10.md
@@ -1,0 +1,43 @@
+## Session 2026-07-21 (researcher-1) — pinned value h 3 = 1 via explicit equilateral triangle
+
+**Mode**: FRESH (continue). **Outcome**: progress — 6 axiom-free declarations,
+**docker-built** `Proofs.Erdos98WIP01` OK (0 sorry / 0 axiom / no `native_decide`;
+`#print axioms h_three` = `[propext, Classical.choice, Quot.sound]` only).
+
+Executed the recorded next step: pin `h 3` exactly.
+
+- `equilateralConfig : PointConfig 3` — the unit equilateral triangle
+  `(0,0), (1,0), (½, √3⁄2)`.
+- `equilateralConfig_injective` — the three abscissae `0, 1, ½` already differ, so the
+  `x`-coordinate alone separates every pair (`norm_num [equilateralConfig]` on the 0-th
+  coordinate).
+- `noThreeCollinear_equilateralConfig` — a line through all three forces `c = 0`, then
+  `a = 0`, then `b·(√3⁄2) = 0`; `√3 > 0` gives `b = 0`. The `√3` coefficient makes this
+  genuinely **nonlinear** (unlike the right-triangle case), needing `nlinarith [hs, …]`
+  with `hs : 0 < √3` (the negated-goal × `hs` product certificate).
+- `noFourConcyclic_equilateralConfig` — vacuous (`noFourConcyclic_of_le_three`).
+- `inGeneralPosition_equilateralConfig` — the triangle is in general position.
+- `equilateral_dist_off {i j} (hij : i ≠ j) : dist (equ i) (equ j) = 1` — every side has
+  length 1: `∑ (Δcoord)² = 1` via `(√3)² = 3`, then `EuclideanSpace.dist_eq` + `Real.sqrt_one`.
+- `numDistinctDistances_equilateralConfig = 1` — **first exact computation** of
+  `numDistinctDistances` for an explicit config: positive distances = `{1}` (diagonal
+  pairs give 0, filtered out).
+- `h_three : h 3 = 1` — equilateral witness ⟹ `h 3 ≤ 1`; `h_mono` + `h_two` ⟹
+  `1 = h 2 ≤ h 3`. Squeeze ⟹ `h 2 = h 3 = 1`.
+
+**Key Lean lesson.** `EuclideanSpace.dist_sq_eq` rewrites `dist x y ^ 2` into a sum over
+`x.ofLp i` coordinate accesses that `Matrix.cons_val_*` do NOT reduce (they stay
+`(![…] ⟨0,⋯⟩).ofLp 0`). Use `EuclideanSpace.dist_eq` instead — its `x i` is direct
+function application, reduced by `simp only [equilateralConfig] ; norm_num`. Leftover
+`1/4 + (√3/2)² = 1` closes with `nlinarith [hs]` (`hs : √3² = 3`); `norm_num` alone does
+NOT expand `(√3/2)²` against `hs`.
+
+**Honesty.** Parent Erdős #98 (`h(n)/n → ∞`) remains **OPEN**; only the conjectured rate
+is the open piece. The elementary envelope gives only `1 ≤ h 3 ≤ 3` — the exact value
+needs the equilateral witness. PR: extends #40147.
+
+### Next Steps
+- Improve the lower-bound constant beyond `/3` toward `(n−1)/2` or `≥ n`.
+- Pin `h 4`: is it `1` (needs an impossible single-distance 4-config?) or `2`?
+- Attack the conjectured rate `h n / n → ∞`.
+

--- a/research/problems/erdos-98-wip-01/sessions/2026-07-21-s11.md
+++ b/research/problems/erdos-98-wip-01/sessions/2026-07-21-s11.md
@@ -1,0 +1,46 @@
+## Session 2026-07-21 (researcher-1) — pinned value h 4 = 2 (first value of h exceeding 1)
+
+**Mode**: FRESH (continue). **Outcome**: progress — `h 4 = 2` pinned exactly.
+**docker-built** `Proofs.Erdos98WIP01` OK (0 sorry / 0 axiom / no `native_decide`;
+`#print axioms Erdos98WIP01.h_four` = `[propext, Classical.choice, Quot.sound]` only).
+
+Executed the recorded next step (extend the pinned values beyond `h 3`). Both bounds are new.
+
+**Upper bound `h 4 ≤ 2`** (`h_four_le_two`).
+- The classical minimum-distance witness for 4 points, the **square**, is *disqualified*:
+  its 4 vertices are concyclic, and general position forbids 4 concyclic points. So the
+  square is not a witness for `h 4`.
+- `centeredTriangleConfig : PointConfig 4` — the equilateral triangle
+  `(1,0), (−½,√3⁄2), (−½,−√3⁄2)` together with its **centroid** `(0,0)`: a 2-distance set
+  (circumradius `1`, side `√3`) that survives both nondegeneracy constraints.
+- `centeredTriangleConfig_dist_mem` — every pairwise distance is `1` or `√3` (dist² is `1`
+  or `3`; nonnegative sqrt). Key tactic fix: `!₂[…]` coordinate accessors are reduced by
+  **`norm_num`**, not by `simp only [Matrix.cons_val_*]` (those args are flagged *unused*);
+  mirror `equilateral_dist_off`'s `simp only [cfg, Fin.sum_univ_two, Real.dist_eq, sq_abs]`
+  then `norm_num [hs2] <;> nlinarith [hs2]` (fallback for the `√3²=3` arithmetic).
+- `noThreeCollinear`/`noFourConcyclic_centeredTriangleConfig` — the centroid is interior
+  (no 3 collinear); the only point equidistant from the 3 vertices is the circumcenter =
+  centroid, at distance `0 ≠ 1` from itself, so no 4 concyclic. Both needed
+  `set_option maxHeartbeats 1000000 in` (64 / 256 `fin_cases` branches, √3 arithmetic).
+  NB: `set_option … in` goes **before** the docstring, not between docstring and theorem.
+- `numDistinctDistances_centeredTriangleConfig_le` — positive distances ⊆ `{1,√3}`, card ≤ 2.
+
+**Lower bound `h 4 ≥ 2`** (`h_four_ge_two`), the harder half — pins the exact value.
+- `not_four_equidistant` — four pairwise-equidistant points are impossible in `ℝ²`. Take
+  difference vectors `vₖ = p_{k+1} − p₀` (`k : Fin 3`). Equidistance gives the Gram matrix
+  `⟪vᵢ,vᵢ⟫ = r²`, `⟪vᵢ,vⱼ⟫ = r²/2` (`i≠j`) via `real_inner_self_eq_norm_sq` and
+  `norm_sub_sq_real`. `Fintype.linearIndependent_iff` + `sum_inner` + `real_inner_smul_left`
+  turn `∑ gₖ•vₖ = 0` into the 3×3 system `r²·½(I+J)·g = 0`; cancel `r² ≠ 0`
+  (`linear_combination` + `mul_eq_zero`) to get `g = 0`. Then
+  `LinearIndependent.fintype_card_le_finrank` vs `finrank_euclideanSpace_fin` gives `3 ≤ 2`,
+  contradiction. **First use of the ambient dimension** (all earlier bounds are metric/comb.)
+- `two_le_numDistinctDistances_four` — a 1-distance 4-config would force all six distances
+  equal (`Finset.card_eq_one` on the positive-distance set), i.e. four equidistant points.
+- `h_four : h 4 = 2 := le_antisymm h_four_le_two h_four_ge_two`.
+
+**Reusable idiom** (recorded for `h 5`+): a 1-distance set in `ℝ^d` has `≤ d+1` points via
+the Gram/linear-independence route above. The whole lower-bound block compiled first try.
+
+**Next**: pin `h 5` (regular pentagon is concyclic → disqualified; need a non-concyclic
+5-point 2/3-distance set, or show `h 5 ≥ 3`); abstract the equidistant⟹independent lemma.
+

--- a/research/problems/erdos-98-wip-01/sessions/2026-07-21-s12.md
+++ b/research/problems/erdos-98-wip-01/sessions/2026-07-21-s12.md
@@ -1,0 +1,50 @@
+## Session 2026-07-21 (researcher-1) — h 5 ≤ 3 via explicit 3-distance general-position 5-witness
+
+**Mode**: FRESH (continue). **Outcome**: progress — `h 5 ≤ 3`, so `2 ≤ h 5 ≤ 3`.
+**docker-built** `Proofs.Erdos98WIP01` OK (0 sorry / 0 axiom / no `native_decide`;
+`#print axioms Erdos98WIP01.h_five_le_three` = `[propext, Classical.choice, Quot.sound]` only).
+
+Continued the pinned-values line past `h 4 = 2`. The lower-bound side of `h 5` is hard, so
+this session establishes the **upper bound** with a fully machine-checked explicit witness.
+
+**The witness `h5Config : PointConfig 5`.** Found by continuous optimization (minimize
+within-cluster spread of the 10 pairwise distances subject to general-position penalties,
+including a no-4-concyclic determinant penalty — omitting it first produced the degenerate
+"centre + 4 on a circle"), then rationalized and **sympy-verified exactly**:
+
+    A=(0,0), B=(1,0), C=(−√3⁄2,−½), D=(½,√3⁄2), E=(½,−(2+√3)⁄2)
+
+- **Exactly three distinct distances** `1`, `√(2+√3)`, `1+√3` (squared: `1`, `2+√3`,
+  `(1+√3)²=4+2√3`). Multiplicities `1`: AB,AC,AD,BD; `√(2+√3)`: AE,BC,BE,CD,CE; `1+√3`: DE.
+- **No 3 collinear**: all 10 triangle areas ≠ 0. **No 4 concyclic**: the 5 circumscribed-
+  circle determinants are `1+√3⁄2`, `2+√3`, `5⁄2+3√3⁄2` (all ≠ 0).
+
+**Lean results added** (`proofs/Proofs/Erdos98WIP01.lean`, item 18):
+`h5Config`, `h5Config_dist_sq`, `h5Config_dist_mem` (dist ∈ {1,√(2+√3),1+√3}),
+`h5Config_injective`, `noThreeCollinear_h5Config`, `noFourConcyclic_h5Config` (dispatched
+to five per-quadruple `h5_not_equidistant_*` helpers), `inGeneralPosition_h5Config`,
+`numDistinctDistances_h5Config_le` (≤ 3), `h_five_le_three` (`h 5 ≤ 3`),
+`h_five_ge_two` (`2 ≤ h 5`, from `h_four_ge_two` + `h_mono`), `h_five_bounds`.
+
+**Why not `h 5 = 3`.** Both natural lower-bound routes give only `h 5 ≥ 2`
+(`three_mul_h_ge 5` = `⌈4/3⌉ = 2`; `h_mono` from `h 4 = 2`). Pinning `h 5 = 3` needs
+`h 5 ≥ 3`: no general-position 5-set has ≤ 2 distances. The regular pentagon (the only
+planar 2-distance 5-set) is concyclic, so this reduces to the **classification of planar
+2-distance sets** (max 5, the pentagon) or the **Larman–Rogers–Seidel** linear-algebra
+bound (a 2-distance set in ℝ² has ≤ 6 points) refined by no-4-concyclic to ≤ 4. Left open.
+
+**Reusable tactic notes.** `!₂[·]` coordinate accessors reduce under `norm_num`, not by
+`simp only [Matrix.cons_val_*]` alone — the distance-value lemma needs
+`rw [EuclideanSpace.dist_sq_eq]; … simp only […]; norm_num [hs2] <;> nlinarith [hs2]`
+(bare `nlinarith` after `simp` fails on the value-1 √3 pairs). The no-4-concyclic proof
+for 5 points is cheap when factored as one `not_equidistant` helper per unordered quadruple
+(5 total `nlinarith` calls) with `noFourConcyclic` doing `fin_cases … <;> first | … | exact
+h5_not_equidistant_XYZW center r (by assumption) …`.
+
+**Files modified**: `proofs/Proofs/Erdos98WIP01.lean` (+~180 lines),
+`src/data/research/problems/erdos-98-wip-01.json`, this file.
+
+**Next**: prove `h 5 ≥ 3` (2-distance-set classification); abstract "1-distance set in ℝ^d
+has ≤ d+1 points"; sharpen the general `(n−1)/3` lower bound.
+
+

--- a/research/problems/erdos-98-wip-01/sessions/2026-07-21-s13.md
+++ b/research/problems/erdos-98-wip-01/sessions/2026-07-21-s13.md
@@ -1,0 +1,48 @@
+## Session 2026-07-21 (researcher-1) — toward h 5 ≥ 3: no 4 coplanar points are mutually equidistant
+
+**Mode**: REVISIT (continue). **Outcome**: progress — a reusable geometric lemma toward
+`h 5 ≥ 3`, plus concrete unconditional lower-bound thresholds.
+**docker-built** `Proofs.Erdos98WIP01` OK (0 sorry / 0 axiom / no `native_decide`;
+build "succeeded, 8577 jobs"). All new lemmas use only Mathlib + `linarith`/`omega`/
+`linear_combination`, so foundational axioms only (`propext`/`Classical.choice`/`Quot.sound`).
+
+### Why `h 5 ≥ 3` is not one line (correcting the prior docstring)
+The `h_five_bounds` docstring claimed "the regular pentagon, the only planar 2-distance
+5-set". That is **false**: the plane has several 5-point 2-distance sets (the pentagon is
+only the concyclic one). So `h 5 ≥ 3` genuinely needs the structure of 2-distance sets,
+not just "pentagon ⇒ concyclic ⇒ excluded". The new toward-`h 5 ≥ 3` section documents the
+real reduction.
+
+### The reduction (rigorous, and what remains)
+Suppose a general-position 5-set uses only two distances `a < b`. By
+`card_fiber_dist_le_three` (already in file), each point has `a`-degree and `b`-degree in
+`{1,2,3}` (a 4th point at a common distance would be 4 concyclic). Case split on whether
+some vertex has `a`-degree 3:
+- **Degree-3 vertex `p`** with neighbours `X,Y,Z` at distance `a`. Sub-case "`X,Y,Z`
+  pairwise `a`" makes `p,X,Y,Z` **four mutually equidistant** → **now excluded** by the new
+  `no_four_mutually_equidistant`. Remaining degree-3 sub-cases (some `XY` or `XZ` = `b`)
+  reduce to intersecting-circle distance equations (`|YZ| = a√3`, etc.) — **still open**,
+  coordinate-heavy.
+- **All degrees 2** (a-graph 2-regular on 5 vertices ⇒ `C₅`) is the pentagon-type case;
+  metric realizability forces the concyclic regular pentagon — **still open** (needs
+  "equilateral + equidiagonal convex pentagon ⇒ concyclic").
+
+### Lean results added (`proofs/Proofs/Erdos98WIP01.lean`)
+- **`no_four_mutually_equidistant`** (axiom-free): in `EuclideanSpace ℝ (Fin 2)` no four
+  points have all six pairwise distances equal to a common `r > 0`. Proof: edge vectors
+  `u=b-a, v=c-a, w=d-a` have `‖·‖²=r²`, pairwise inner product `r²/2` (from `‖u-v‖=r` via
+  `norm_sub_sq_real`); the Gram system forces `LinearIndependent ℝ ![u,v,w]`, contradicting
+  `finrank (EuclideanSpace ℝ (Fin 2)) = 2` (`LinearIndependent.fintype_card_le_finrank` +
+  `finrank_euclideanSpace_fin`). This is the planar "regular `k`-simplex needs dim `k`".
+- **`no_four_equidistant_indices`**: config-level specialization (no 4 indices mutually
+  equidistant).
+- **`three_le_h_of_eight_le`** (`n ≥ 8 → 3 ≤ h n`) and **`four_le_h_of_eleven_le`**
+  (`n ≥ 11 → 4 ≤ h n`): immediate from `three_mul_h_ge` (`n-1 ≤ 3·h n`) — the first exact
+  thresholds where the elementary bound alone certifies 3, resp. 4, distinct distances.
+
+### Next steps
+- Degree-3 remaining sub-cases: formalize "two circles of radius `a` at centre-distance `a`
+  meet at points `a√3` apart" as reusable `EuclideanSpace ℝ (Fin 2)` algebra.
+- All-degree-2 (`C₅`) case: "equilateral + equidiagonal convex pentagon is concyclic".
+- Both are coordinate-geometry heavy; each is a standalone multi-session sub-target.
+

--- a/research/problems/erdos-98-wip-01/sessions/2026-07-21-s14.md
+++ b/research/problems/erdos-98-wip-01/sessions/2026-07-21-s14.md
@@ -1,0 +1,50 @@
+## Session 2026-07-21 (researcher-1) — h 5 ≥ 3 reduced to pentagon rigidity: 2-distance reduction + degree structure
+
+**Mode**: REVISIT (continue, RICH). **Outcome**: progress — rigorous reduction of the open
+lower bound `h 5 ≥ 3`, all axiom-free. **docker-built** `Proofs.Erdos98WIP01` OK
+(0 sorry / 0 axiom / no `native_decide`; new proofs use only standard Mathlib).
+
+The residual frontier is `h 5 ≥ 3` ⟺ *no general-position `PointConfig 5` is a 2-distance
+set*. This session pins that reduction down to its exact combinatorial/geometric frame and
+proves everything on the combinatorial side.
+
+**Lean results added** (`proofs/Proofs/Erdos98WIP01.lean`):
+
+- **`exists_two_distances_of_numDistinct_le_two`** (axiom-free, all `n`): an injective
+  `PointConfig` on `n ≥ 2` points with `numDistinctDistances ≤ 2` *is* a 2-distance set —
+  `∃ a b > 0` covering every pairwise distance. Mechanism: all off-diagonal distances are
+  positive (injectivity) hence lie in the counted finset `D`; `D.card ≤ 2` ⇒ `D ⊆ {a,b}` via
+  `Finset.card_erase_of_mem` + `Finset.card_le_one`. This is the entry point of the reduction.
+- **`two_distance_near_degree_bounds`** (axiom-free): in a **general-position** 2-distance
+  `PointConfig 5`, every vertex has between `1` and `3` short-distance (`a`) neighbours.
+  Mechanism: `card_fiber_dist_le_three` caps both the `a`-circle and the `b`-circle around a
+  vertex at `3` (no-four-concyclic); the two neighbour-sets are disjoint (`a ≠ b`) and cover
+  all `4` other points, so `card A + card B = 4` with each `≤ 3` ⇒ `1 ≤ card A ≤ 3`.
+
+**The exact residual (documented, not proved).** Combining the degree bounds with the merged
+`no_four_equidistant_indices` (no monochromatic `K₄`): the short-distance graph of any
+hypothetical general-position 2-distance 5-set is a graph on 5 vertices with min-degree `≥ 1`,
+max-degree `≤ 3`, and no `K₄` in the graph *or its complement*. **These purely combinatorial
+constraints do not close** — `C₅` (the regular-pentagon pattern) satisfies all of them
+(2-regular, `K₄`-free, self-complementary `α = 2 ≤ 3`). The single remaining fact is
+**geometric**: an equilateral, equidiagonal pentagon (`C₅` realization) is regular, hence its
+5 vertices are concyclic, contradicting `NoFourConcyclic`. Pigeonhole from a single vertex
+also caps at `⌈4/3⌉ = 2`, so a multi-vertex/rigidity argument is genuinely required.
+
+**Reusable notes.** `numDistinctDistances P = D.card` where `D` is the filtered image finset;
+extracting the two distances is cleanest via erase + `Finset.card_le_one` rather than a
+`card_le_two` witness lemma (which Mathlib does not expose in subset form). `Disjoint A B`
+from `a ≠ b` via `Finset.disjoint_left` and `hjA.2.symm.trans hjB.2`; disjoint-union card via
+`Finset.card_union_of_disjoint`.
+
+**Honest delta**: did **not** prove `h 5 ≥ 3` (still open). +2 axiom-free theorems (2-distance
+reduction + per-vertex degree structure), residual reduced to a single named geometric fact
+(pentagon rigidity). Axiom count unchanged (0). Bounds remain `2 ≤ h 5 ≤ 3`. Phase `ACT`.
+
+**Files modified**: `proofs/Proofs/Erdos98WIP01.lean`,
+`src/data/research/problems/erdos-98-wip-01.json`, this file.
+
+**Next**: prove pentagon rigidity (the `C₅`-realization ⇒ concyclic case) to close `h 5 ≥ 3`;
+or abstract the equilateral-dimension bound.
+
+

--- a/research/problems/erdos-98-wip-01/sessions/2026-07-21-s15.md
+++ b/research/problems/erdos-98-wip-01/sessions/2026-07-21-s15.md
@@ -1,0 +1,54 @@
+## Session 2026-07-21 (researcher-1) — h 5 ≥ 3: handshake parity obstruction (some vertex has exactly 2 short neighbours)
+
+**Mode**: REVISIT (continue, RICH). **Outcome**: progress — one new structural step on the
+critical path to `h 5 ≥ 3`, axiom-free. **Host-verified** `Proofs.Erdos98WIP01` via
+`lake env lean` (fresh v4.31 parent olean), exit 0, no `error:` (only pre-existing
+`EuclideanSpace.single_apply` deprecation warnings at line 451); file now 1964 lines,
+`grep -c '^axiom '` = 0, `grep -c 'sorry'` = 0, no `native_decide`.
+
+### What I did
+Advanced the residual reduction (`h 5 ≥ 3` ⟺ no general-position `PointConfig 5` is a
+2-distance set) by proving a **parity obstruction** that begins forcing 2-regularity of the
+short-distance graph.
+
+**Lean results added** (`proofs/Proofs/Erdos98WIP01.lean`):
+
+- **`even_sum_symm_degree`** (axiom-free, general): for any symmetric, irreflexive
+  `DecidableRel r` on a `Fintype`, `Even (∑ i, #{j ≠ i : r i j})`. This is the handshaking
+  lemma, routed through Mathlib's `SimpleGraph.sum_degrees_eq_twice_card_edges` (RHS
+  `2 · #edges`, manifestly even). Key formalization notes: build the `SimpleGraph` literal
+  with `symm := ⟨hsymm⟩ : Std.Symm r`, `loopless := ⟨hirr⟩ : Std.Irrefl r`; set
+  `DecidableRel G.Adj := fun a b => inferInstance` (NOT `Classical.decRel`, which forks the
+  filter's `DecidablePred` instance and breaks the final `rw`/`convert`); close the pointwise
+  `degree = filter-card` goal by `convert h2 using 2 with i` then inline
+  `neighborFinset_eq_filter` (uses the goal's own instance, avoiding the mismatch).
+- **`two_distance_exists_degree_two`** (axiom-free): a general-position 2-distance
+  `PointConfig 5` has **some vertex with exactly 2 short-distance (`a`) neighbours**.
+  Mechanism: `two_distance_near_degree_bounds` gives each short-degree `d_a(i) ∈ {1,2,3}`;
+  `even_sum_symm_degree` (with `r i j := dist (P i) (P j) = a`, symmetric via `dist_comm`,
+  irreflexive since `a > 0` — realised from vertex 0) makes `∑_i d_a(i)` even; a sum of five
+  odd numbers is odd, so not all `d_a(i)` are odd ⇒ some equals 2. Closed by
+  `Fin.sum_univ_five` + `omega` on per-vertex `% 2 = 1` facts.
+
+### Why this is progress (honest scope)
+This is the FIRST pin of a specific degree value. It does **not** yet give 2-regularity: it
+guarantees *one* degree-2 vertex, not all five. A sum of five values in `{1,2,3}` that is even
+can still be e.g. `(1,1,3,3,2)` — so degrees 1 and 3 are not yet excluded.
+
+### Exact remaining gap (for the next iteration to pick up cold)
+1. **Rule out short-degree 3** (equivalently long-degree 1, by the `a ↔ b` symmetry of the
+   two-distance hypothesis). This is the genuinely *geometric* step: if a vertex `v` has three
+   short-neighbours `x,y,z` on the radius-`a` circle about `v`, the two-distance constraint on
+   `{x,y,z}` together with no-3-collinear / no-4-concyclic must be shown contradictory. Pure
+   graph theory (degrees in `{1,2,3}`, both `G` and `Gᶜ` `K₄`-free) does **not** force `C₅`.
+   Precise lemma to prove: `∀ i, ((univ.erase i).filter (fun j => dist (P i) (P j) = a)).card = 2`.
+2. After full 2-regularity: `2-regular on Fin 5 ⟹ single 5-cycle C₅` (finite/decidable);
+   then `C₅` two-distance realisation ⟹ regular pentagon ⟹ 5 concyclic ⟹ contradicts
+   `NoFourConcyclic` ⟹ `h 5 ≥ 3`.
+
+### Files modified
+- `proofs/Proofs/Erdos98WIP01.lean` (+2 theorems, `even_sum_symm_degree`, `two_distance_exists_degree_two`)
+- `src/data/research/problems/erdos-98-wip-01.json` (knowledge accumulation)
+
+---
+

--- a/research/problems/erdos-98-wip-01/state.md
+++ b/research/problems/erdos-98-wip-01/state.md
@@ -27,8 +27,16 @@ None for `h 5 = 3` — proved. The remaining open targets are the *asymptotic* E
 statements (weak `h(n) ≥ n`, strong `h(n)/n → ∞`), which are genuinely open in mathematics
 and not attackable by these elementary methods.
 
-## Next Action — FOLLOW-UPS (h 5 done)
-1. **`h 6`** — is `h 6 = 3` reachable? The centroid/row-sum method only kills *regular*
-   2-distance sets; irregular 2-distance 6-sets need more.
+## Next Action — FOLLOW-UPS (h 5 done; h 6 pinned to {3,4} on 2026-07-24)
+1. **`h 6` upper bound DONE (researcher-3, 2026-07-24)**: `h 6 ≤ 4` via the explicit
+   general-position 4-distance witness `sixConfig` (two concentric equilateral triangles,
+   radii `1`/`√2`, twist 90°; `Erdos98WIP01SixUpper.lean`). With `three_le_h_six` this pins
+   `h 6 ∈ {3, 4}` (`h_six_bounds`, `h_six_eq_three_or_four`). Remaining: DECIDE the
+   dichotomy — `h 6 = 3` needs a 3-distance general-position 6-config (open; impossible
+   within the twisted-triangle family — the 3-distance merges degenerate), `h 6 = 4` needs
+   an impossibility proof beyond the centroid/row-sum method (which only kills
+   colour-regular configurations).
 2. **Regular two-distance sets are cospherical (general `n`/dimension)** — the centroid
    row-sum lemma proved here is dimension- and `n`-agnostic; extract as a standalone lemma.
+3. **`h 7` upper bound** — a 4- or 5-distance general-position 7-point witness would beat
+   the generic `h 7 ≤ 21`.

--- a/src/data/research/problems/erdos-98-wip-01.json
+++ b/src/data/research/problems/erdos-98-wip-01.json
@@ -20,8 +20,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-09T17:33:19-07:00",
-    "iteration": 3,
-    "focus": "Elementary layer SATURATED (verified 2026-07-21, 2866 lines, 0-axiom/0-sorry): exact values h(2)=h(3)=1, h(4)=2, h(5)=3 (h_five_eq_three); all-n general-position existence (parabolaConfig); h_mono; and the general lower bound le_h_of_three_mul_sub_one_le (k ≤ h n for n ≥ 3k−1). Matches knowledge.progressSummary; supersedes the stale Session-4 nextAction below.",
+    "iteration": 4,
+    "focus": "Session 2026-07-24 (researcher-3): h 6 <= 4 proved — first nontrivial six-point upper bound (previous best h 6 <= 15 via h_le_choose_two). New file Erdos98WIP01SixUpper.lean: explicit general-position 4-distance witness sixConfig (two concentric equilateral triangles, radii 1 and sqrt2, twist 90deg; squared distances {3, 6, 3+sqrt6, 3-sqrt6}), plus two reusable determinant criteria (not_collinear_of_det, not_concyclic_of_det) proved by deterministic linear_combination cofactor identities. Combined with three_le_h_six: h 6 in {3,4} (h_six_bounds, h_six_eq_three_or_four).",
     "blockers": [
       {
         "route": "super-linear lower bound: improve h(n) ≥ (n-1)/3 toward the conjectured rate (Erdős #98 / Guth–Katz n/log n)",
@@ -29,9 +29,9 @@
         "blockedAt": "2026-07-21"
       },
       {
-        "route": "exact value h(6) (= 3 iff a general-position 6-point 3-distance set exists)",
-        "reopenCriterion": "materially new mechanism required: monotonicity gives h(6) ≥ h(5) = 3; pinning h(6)=3 needs an explicit no-3-collinear, no-4-concyclic 6-point config with exactly 3 distinct distances (regular hexagon and pentagon+centre are disqualified — 4 concyclic), whose existence is itself open; else h(6) ≥ 4 needs a new lower bound.",
-        "blockedAt": "2026-07-21"
+        "route": "exact value h(6): decide the dichotomy h(6)=3 vs h(6)=4 (h 6 <= 4 now proved via sixConfig)",
+        "reopenCriterion": "materially new mechanism required: 3 <= h(6) <= 4 is pinned (h_six_bounds; upper bound via the 4-distance twisted-triangles witness). h(6)=3 iff a general-position 6-point THREE-distance config exists — open; within the twisted-triangle family (R, theta) a 3-distance merge forces (R,theta)=(2,60deg) which is degenerate (collinear triple) or R=1 (triangles coincide), so a 3-distance witness needs a construction outside this family. h(6)=4 needs a lower bound 4 <= h(6), i.e. an impossibility proof for ALL general-position 6-point 3-distance sets — beyond the h5 centroid/row-sum method, which only kills regular (2-regular-per-colour) configurations.",
+        "blockedAt": "2026-07-24"
       }
     ],
     "nextAction": "STAND DOWN on elementary work. Open directions are deep (recorded as blockers): the super-linear lower bound (needs incidence geometry / Guth–Katz) and exact values h(n) for n ≥ 6 (need general-position min-distance constructions of uncertain existence).",
@@ -42,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE through h 5 = 3 (axiom-free). General ladder le_h_of_three_mul_sub_one_le (k<=h(n) for n>=3k-1) subsumes the uniform lower-bound ladder. Added (2026-07-22, researcher-1-3) Erdos98WIP01Thresholds.lean: monotonicity-sharpened small-n bounds filling the ladder gap — 3<=h(n) for all n>=5 (ladder only reaches n>=8), giving 3<=h(6),3<=h(7) as best-known. Deep open: super-linear rate (Guth-Katz, absent from Mathlib) and exact h(6) (needs open 6-point 3-distance config).",
+    "progressSummary": "COMPLETE through h 5 = 3 (axiom-free); h 6 pinned to {3,4} (2026-07-24, researcher-3: h 6 <= 4 via explicit 4-distance twisted-triangles witness in Erdos98WIP01SixUpper.lean; lower bound three_le_h_six from Thresholds). General ladder le_h_of_three_mul_sub_one_le (k<=h(n) for n>=3k-1) plus monotonicity thresholds (3<=h(n) for n>=5). Deep open: super-linear rate (Guth-Katz, absent from Mathlib), and deciding h(6)=3 vs 4 (needs an open 6-point 3-distance config, or a new impossibility mechanism).",
     "builtItems": [
       "InGeneralPosition.injective in Erdos98WIP01.lean",
       "numDistinctDistances_le_offDiag (≤ n·(n−1)) in Erdos98WIP01.lean",
@@ -106,7 +106,11 @@
       "h_five_eq_three (Erdos98WIP01.lean): h 5 = 3, pinned exactly via le_antisymm h_five_le_three three_le_h_five (axiom-free, docker-verified).",
       "two_common_neighbours_dist (Erdos98WIP01.lean:1782, axiom-free, docker-built 8577 jobs): in EuclideanSpace ℝ (Fin 2), dist p q = a ∧ dist x p = dist x q = dist y p = dist y q = a ∧ a>0 → x = y ∨ dist x y = a·√3. Discharges the intersecting-circle distance equations of the h 5 ≥ 3 degree-3 sub-cases.",
       "le_h_of_three_mul_sub_one_le (Erdos98WIP01.lean:~1901): general closed-form lower bound k ≤ h n for n ≥ 3k−1, axiom-free (omega from three_mul_h_ge). Existing rungs three_le_h_of_eight_le / four_le_h_of_eleven_le rewritten as one-line k=3/k=4 specializations; added five_le_h_of_fourteen_le (k=5).",
-      "two_le_h_of_four_le, three_le_h_of_five_le, three_le_h_six, three_le_h_seven — monotonicity-sharpened small-n lower bounds (Erdos98WIP01Thresholds.lean, 0-axiom)"
+      "two_le_h_of_four_le, three_le_h_of_five_le, three_le_h_six, three_le_h_seven — monotonicity-sharpened small-n lower bounds (Erdos98WIP01Thresholds.lean, 0-axiom)",
+      "not_collinear_of_det (Erdos98WIP01SixUpper.lean): general line-determinant criterion — nonzero affine determinant of three points refutes any common line a*x+b*y+c=0, by cofactor linear_combination elimination (no nlinarith search over unknown coefficients).",
+      "not_concyclic_of_det (Erdos98WIP01SixUpper.lean): general circle-determinant criterion — nonzero 3x3 determinant det[[q-p, Nq-Np],[r-p, Nr-Np],[s-p, Ns-Np]] (N t = |t|^2) refutes any common circumcentre, by the cofactor linear_combination of the three chord equations 2c.(t-p) = Nt-Np.",
+      "sixConfig + inGeneralPosition_sixConfig + numDistinctDistances_sixConfig_le (Erdos98WIP01SixUpper.lean): explicit general-position 6-point 4-distance witness — inner equilateral triangle radius 1 (angles 0/120/240), outer radius sqrt2 (angles 90/210/330); 15 per-pair distance lemmas, 20 line determinants, 15 circle determinants, all axiom-free.",
+      "h_six_le_four / h_six_bounds / h_six_eq_three_or_four (Erdos98WIP01SixUpper.lean): h 6 <= 4, hence 3 <= h 6 <= 4 and the dichotomy h 6 = 3 or h 6 = 4."
     ],
     "insights": [
       "Every positive pairwise distance comes from an off-diagonal ordered pair (dist>0 ⟹ points distinct ⟹ indices distinct), giving the clean upper bound numDistinctDistances P ≤ n·(n−1) via Finset.offDiag_card — the trivial ceiling of the h(n) envelope.",
@@ -160,7 +164,12 @@
       "Clean planar-rigidity mechanism: with u=x−p, v=y−p, w=q−p (all norm a, ⟨u,w⟩=⟨v,w⟩=a²/2), the vector e=u+v−w is orthogonal to both w and d=u−v; if x≠y then d≠0, and e≠0 would make e,w,d three pairwise-orthogonal nonzero vectors (linearly independent) — impossible in dim 2. So e=0, i.e. u+v=w, forcing ⟨u,v⟩=−a²/2 and ‖x−y‖²=3a². Same regular-simplex-needs-dimension argument as no_four_mutually_equidistant, run one dimension lower.",
       "Lean gotcha: simp only [inner_sub_left, inner_add_left, ...] canonicalizes ⟪u,v⟫ to a fixed argument order (⟪v,u⟫ here), so a follow-up rw [real_inner_comm .., htval] whose LHS is ⟪u,v⟫ fails to fire — finish such goals with linarith [htval, hc] (hc : ⟪v,u⟫=⟪u,v⟫) instead of orientation-sensitive rw. Also real_inner_comms explicit args are the reverse orientation; use real_inner_comm _ _ driven by the expected type. And explicit rw [inner_sub_right] over `set`-bound u:=x−p unfolds the local def (⟪u,u⟫→⟪u,x⟫−⟪u,p⟫); prefer simp only for the expansion.",
       "General elementary lower bound in closed form: le_h_of_three_mul_sub_one_le proves k ≤ h n for every target k as soon as n ≥ 3·k − 1 (from n−1 ≤ 3·h n = three_mul_h_ge, since then 3·h n ≥ 3k−2 > 3(k−1)). This single theorem subsumes the entire infinite ladder of concrete rungs (k=3⇒n≥8, k=4⇒n≥11, k=5⇒n≥14, …), replacing enumeration with the general statement — the sharpest elementary general lower bound on h; the conjectured super-linear rate h n/n → ∞ (Erdős #98) is far beyond it and stays open.",
-      "Monotonicity sharpens small-n lower bounds beyond the ladder: le_h_of_three_mul_sub_one_le reaches 3<=h(n) only from n>=8, but h(5)=3 + h_mono gives 3<=h(n) for ALL n>=5, filling the n in {5,6,7} gap. three_le_h_six / three_le_h_seven are the current best-known lower bounds for h(6),h(7). (Erdos98WIP01Thresholds.lean, 0-axiom)"
+      "Monotonicity sharpens small-n lower bounds beyond the ladder: le_h_of_three_mul_sub_one_le reaches 3<=h(n) only from n>=8, but h(5)=3 + h_mono gives 3<=h(n) for ALL n>=5, filling the n in {5,6,7} gap. three_le_h_six / three_le_h_seven are the current best-known lower bounds for h(6),h(7). (Erdos98WIP01Thresholds.lean, 0-axiom)",
+      "Twisted-triangles distance algebra: two concentric equilateral triangles, radii r and R, twist theta, give cross squared distances R^2+r^2-2Rr*cos(theta+120k). Setting R^2 = 2r^2, theta=90deg merges one cross orbit with the inner side (3 - 2sqrt2*cos90 = 3 = inner side when r=1), leaving only 4 distinct values {3, 6, 3+sqrt6, 3-sqrt6}. This is the mechanism behind h 6 <= 4.",
+      "Within the twisted-triangle family a THIRD coincidence (3 distances) is impossible in general position: inner=cross1=cross2 or inner=cross1 & outer=cross2 force (R,theta)=(2,+-60deg) — whose configuration contains the collinear triple (-sqrt3,1),(0,1),(sqrt3,1) — or R=1 (triangles coincide, via cos(theta+240)=(R^2+1)/(2R)<=1 iff (R-1)^2<=0). So h 6 = 3 requires a construction outside this family.",
+      "No-4-concyclic for 3+3 two-circle configurations: a 3+1 split fails on radii (concentric circles of different radii); a 2+2 split is concyclic iff an inner chord is PARALLEL to an outer chord (common perpendicular bisector through the shared centre). Inner chord directions {30,90,150}deg vs outer {0,60,120}deg are disjoint, so no 4 points concyclic — the formal proof needs only 15 numeric determinants.",
+      "Proof-engineering: replacing per-case nlinarith searches over unknown line/centre coordinates (the h5Config pattern) by two general determinant criteria (proved once by cofactor linear_combination, deterministically) reduces all 35 general-position obligations to numeric surd inequalities closed by nlinarith with recorded facts: squares, positivity, products sqrt2*sqrt3=sqrt6 etc., and rational bracketing bounds (1.414<sqrt2<1.415, ...). Far more robust and faster than the search-based pattern.",
+      "Lean idioms (v4.31): fin_cases produces anonymous-constructor indices <k,proof> that simp-only access lemmas stated at OfNat literals do NOT match — but exact/assumption unify them by defeq; so prove per-index-literal lemmas and dispatch via exact lemma <..., by assumption, ...> inside the fin_cases combinator. Also: after norm_num fully closes a goal, a trailing nlinarith errors with 'no goals' and fails the whole first-branch — guard with all_goals nlinarith [...]."
     ],
     "mathlibGaps": [
       "Classification of planar 2-distance sets (max 5 points = regular pentagon, unique up to similarity) is absent from Mathlib — needed for h 5 ≥ 3.",
@@ -168,9 +177,10 @@
       "None new. Note: `sum k in s` no longer parses in this toolchain (use `sum k IN-set s`); InGeneralPosition is a bare And so hgp.injective fails (use hgp.1); the `module` tactic cleanly discharges the 5^{-1} field-scalar centroid identity."
     ],
     "nextSteps": [
-      "h 5 = 3 is DONE. Follow-up: is h 6 = 3 reachable? The row-sum/centroid method only kills REGULAR two-distance sets; irregular 2-distance 6-sets need a different argument.",
       "Extract `equal row sums => cospherical` as a standalone reusable lemma (dimension/n-agnostic).",
-      "Asymptotic Erdos #98 (weak h(n)>=n, strong h(n)/n->inf) remain genuinely open; not attackable by these elementary methods."
+      "Asymptotic Erdos #98 (weak h(n)>=n, strong h(n)/n->inf) remain genuinely open; not attackable by these elementary methods.",
+      "Decide h(6): either find a general-position 6-point 3-distance configuration OUTSIDE the twisted-triangle family (h 6 = 3), or prove 4 <= h 6 (needs an impossibility argument for irregular 3-distance 6-sets; the centroid/row-sum method only kills colour-regular configurations).",
+      "h(7): the same twisted-triangles idea with a 7th point (shared centre?) fails no-4-concyclic quickly; a 4- or 5-distance 7-point general-position witness would give the first nontrivial h 7 upper bound (currently h 7 <= 21)."
     ],
     "markdown": "# Knowledge Base: erdos-98-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -192,7 +202,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.785Z",
-  "lastUpdate": "2026-07-21",
+  "lastUpdate": "2026-07-24",
   "significance": 7,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary

**First nontrivial upper bound for six points in Erdős #98's general-position distinct-distance problem: `h 6 ≤ 4`, pinning `h 6 ∈ {3, 4}`** (previous best upper bound was the generic `h 6 ≤ 6.choose 2 = 15`).

New file `proofs/Proofs/Erdos98WIP01SixUpper.lean` (1475 lines, **0 sorries, 0 axioms, no `native_decide`**, docker-verified: `Build completed successfully (8579 jobs)`, warnings only).

## The witness

`sixConfig`: two concentric equilateral triangles — inner circumradius `1` at angles `0°/120°/240°`, outer circumradius `√2` at angles `90°/210°/330°` (twist 90°). The `R² = 2r²` radius choice makes the `cos Δ = 0` cross-distance orbit **merge** with the inner side, so only four squared distances occur: `{3, 6, 3+√6, 3−√6}`.

General position:
- **no 3 collinear** — all 20 triple determinants nonzero;
- **no 4 concyclic** — 3+1 splits fail on radii (concentric circles, different radii); 2+2 splits need an inner chord parallel to an outer chord, but chord directions `{30°,90°,150°}` vs `{0°,60°,120°}` are disjoint. Formally: all 15 concyclicity determinants nonzero.

## Reusable infrastructure

- `not_collinear_of_det` / `not_concyclic_of_det` — general determinant criteria proved once by deterministic `linear_combination` cofactor identities, replacing the per-case `nlinarith` searches over unknown line/centre coordinates used in the `h5Config` treatment. Each of the 35 concrete obligations reduces to a numeric surd inequality over `ℚ(√2,√3)` closed by `nlinarith` with recorded square/product/bracketing facts.

## Main results

- `h_six_le_four : h 6 ≤ 4`
- `h_six_bounds : 3 ≤ h 6 ∧ h 6 ≤ 4` (lower bound from `three_le_h_six`, Thresholds file)
- `h_six_eq_three_or_four : h 6 = 3 ∨ h 6 = 4`

Deciding the dichotomy is genuinely blocked (recorded in the blocked-route registry): within the twisted-triangle family `(R, θ)` a third distance-coincidence forces a degenerate configuration, so `h 6 = 3` needs a construction outside the family; `h 6 = 4` needs an impossibility argument beyond the centroid/row-sum method.

## Metadata

- knowledge.md restructured: per-session logs archived to `research/problems/erdos-98-wip-01/sessions/`; state.md, pool JSON updated (iteration 4, blocked-route entry refreshed).
- Note: stale unmerged branch `research/erdos98-h6-le-four` (2026-07-22, Eisenstein-lattice attempt at the same bound, never PR'd) is superseded by this PR.

## Verification

```
./proofs/scripts/docker-build.sh Proofs.Erdos98WIP01SixUpper
=== Build succeeded ===  (8579 jobs; warnings only — unreachable-fallback linter notes)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
