### PR TITLE
Fix: infra-guardian reaps the deployer's own worktree as "merged"

### DIFF
--- a/scripts/lean/infra-guardian.sh
+++ b/scripts/lean/infra-guardian.sh
@@ -133,6 +133,19 @@ reap_worktrees() {
         esac
         grep -qxF "$wt" <<<"$locked" && continue
 
+        # Fixed, long-lived role worktrees are reused every cycle rather than
+        # created per-task, and some (the deployer) fast-forward their branch
+        # to exactly match origin/main as part of normal operation -- which
+        # makes the "merged" check below trivially true every cycle. Without
+        # this guard the guardian reaps the deployer's own worktree mid-run
+        # (observed 2026-07-24: fired between the deploy pipeline's "Sync
+        # Branch" step and the rest of the cycle, deregistering the worktree
+        # out from under an in-flight PR-merge loop and requiring manual
+        # `git worktree add` recovery).
+        case "${wt##*/}" in
+            deployer) continue ;;
+        esac
+
         if [[ "$ref" != "DETACHED" ]] && git merge-base --is-ancestor "$ref" origin/main 2>/dev/null; then
             _reap_one "$wt" "merged"
             continue


### PR DESCRIPTION
## Summary
- `infra-guardian.sh`'s `reap_worktrees()` reaps any worktree under the resolved worktree root whose branch is an ancestor of `origin/main`. The deployer's fixed worktree lives at that root and fast-forwards `feature/deployer` to exactly match `origin/main` every cycle, so the "merged" check is trivially true — the guardian deletes the deployer's own worktree registration mid-cycle, every cycle.
- Observed 2026-07-24: the reap fired between the deploy pipeline's "Sync Branch" step and the PR-merge loop, deregistering `/Volumes/Stripe/lean-genius/deployer` out from under an in-flight run (files intact, `.git/worktrees/deployer` admin dir gone) and requiring manual `git worktree add` recovery mid-cycle.
- Excludes the `deployer` worktree by basename from the merged-reap check — it's a fixed, reused-every-cycle role worktree, not a per-task worktree like `enricher-N`/`researcher-N`.

## Test plan
- [x] `bash -n scripts/lean/infra-guardian.sh` — syntax check passes
- [ ] Next deployer cycle should complete without the worktree being reaped mid-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)