### PR TITLE
Fix furstenberg-correspondence-oq-01: sync stale nested meta to verified (Prokhorov axiom eliminated)

### DIFF
--- a/src/data/proofs/furstenberg-correspondence-oq-01/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-01/meta.json
@@ -2,12 +2,12 @@
   "id": "furstenberg-correspondence-oq-01",
   "title": "Shift Dynamics on Cantor Space: Toward the Furstenberg Correspondence",
   "slug": "furstenberg-correspondence-oq-01",
-  "description": "Builds the shift dynamical system on Cantor space {0,1}^ℕ — the infrastructure needed to formalize the Furstenberg correspondence principle. Proves the shift is continuous and measurable, cylinder sets are clopen and measurable, and the k-fold return property connecting dynamical intersections to combinatorial patterns. All theorems are now proved, including shift-invariance of the limit measure (limit_invariant_on_cylinder: T-invariance of the Cesàro limit on clopen sets, via the Portmanteau null-frontier criterion and the vanishing 1/(N+1) telescoping error). 1 local axiom remains: sequential compactness of probability measures on Cantor space, pending full Prokhorov formalization in Mathlib.",
+  "description": "Builds the shift dynamical system on Cantor space {0,1}^ℕ — the infrastructure needed to formalize the Furstenberg correspondence principle. Proves the shift is continuous and measurable, cylinder sets are clopen and measurable, and the k-fold return property connecting dynamical intersections to combinatorial patterns. All theorems are now proved, including shift-invariance of the limit measure (limit_invariant_on_cylinder: T-invariance of the Cesàro limit on clopen sets, via the Portmanteau null-frontier criterion and the vanishing 1/(N+1) telescoping error). The former local axiom — sequential compactness of probability measures on Cantor space — was discharged in S14 (2026-07-24) using Mathlib v4.31's Prokhorov development, so the construction is now fully machine-checked with 0 axioms and 0 sorries.",
   "meta": {
     "author": "Furstenberg (1977)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Furstenberg%27s_proof_of_the_infinitude_of_primes",
     "date": "1977",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/FurstenbergCorrespondenceOQ01.lean",
     "tags": [
       "ergodic-theory",
@@ -18,10 +18,10 @@
       "cantor-space",
       "correspondence-principle"
     ],
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
-    "axiomCount": 1,
-    "assumptions": "0 sorries (limit_invariant_on_cylinder proved 2026-07-23: clopen sets have empty frontier, so weak convergence gives measure convergence on S and shift⁻¹S by ProbabilityMeasure.tendsto_measure_of_null_frontier_of_tendsto'; the approximate T-invariance bounds cesaroMeasure_preimage_le/ge pass to the limit as the 1/(N+1) error vanishes; le_antisymm closes). 1 local axiom: seqCompact_probabilityMeasure_cantor — every sequence of probability measures on Cantor space (ℕ → Bool) has a weak-* convergent subsequence (Prokhorov's theorem). Mathlib v4.31 has the ingredients but they are not yet assembled into this exact statement. All other theorems (shift continuity, cylinder sets, k-fold return property, orbit-density connection, Tychonoff compactness) are proved from Mathlib.",
+    "axiomCount": 0,
+    "assumptions": "0 sorries, 0 axioms (fully machine-checked as of S14, 2026-07-24). The former local axiom seqCompact_probabilityMeasure_cantor — sequential compactness of probability measures on Cantor space in the topology of weak convergence — is now proved from Mathlib v4.31's Prokhorov development (CompactSpace (ProbabilityMeasure E) for compact E, Mathlib.MeasureTheory.Measure.Prokhorov) plus Lévy–Prokhorov metrizability and CompactSpace.tendsto_subseq. limit_invariant_on_cylinder (T-invariance of the Cesàro limit on clopen sets) is proved via the Portmanteau null-frontier criterion and the vanishing 1/(N+1) telescoping error. All other theorems (shift continuity, cylinder sets, k-fold return property, orbit-density connection, Tychonoff compactness) are proved from Mathlib.",
     "dateAdded": "2026-03-30",
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Problem

`furstenberg-correspondence-oq-01` was left internally inconsistent after the S14 research work (commit `a88db2`, 2026-07-24, "Prokhorov axiom eliminated; Furstenberg OQ01 file fully verified [0 ax / 0 sorry]").

That commit discharged the `seqCompact_probabilityMeasure_cantor` axiom and updated the **top-level** `status`/`badge`/`axiomCount`/`assumptions` to `verified`/`original`/`0`, but left the **nested `meta` block** and the top-level `description` still claiming "1 local axiom remains".

## Ground truth (Lean source)

`proofs/Proofs/FurstenbergCorrespondenceOQ01.lean`:
- 0 `axiom` declarations
- `seqCompact_probabilityMeasure_cantor` is now a `theorem` (line 619, proved in S14)
- 0 real sorries
- `leanFile` block already reports `axiomCount: 0, sorries: 0` ✓

## Before / After

| Field | Before (nested `meta`) | After |
|-------|------------------------|-------|
| `meta.status` | `axiomatized` | `verified` |
| `meta.badge` | `axiom` | `original` |
| `meta.axiomCount` | `1` | `0` |
| `meta.assumptions` | "1 local axiom: seqCompact…" | "0 sorries, 0 axioms (fully machine-checked as of S14)…" |
| top-level `description` | "1 local axiom remains…" | "…discharged in S14…now fully machine-checked with 0 axioms and 0 sorries" |

Nested `meta`, top-level, and `leanFile` now all consistently report `verified` / `original` / 0 axioms / 0 sorries, matching the Lean source. Metadata-only change; JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
