### PR TITLE
research(erdos-1215-oq-02): OQ11 — quadratic cyclotomic lemniscates disconnect for small C (n=3,4,6) [0 ax / 0 sorry]

### DIFF
--- a/proofs/Proofs/CyclotomicPolynomialsOQ02OQ11.lean
+++ b/proofs/Proofs/CyclotomicPolynomialsOQ02OQ11.lean
@@ -128,8 +128,8 @@ theorem not_isPreconnected_quadratic_lemniscate {a b : ℂ} {C : ℝ} (hC : 0 < 
     (quadratic_lemniscate_subset_union a b hC.le)
     ⟨a, hmema, hballa⟩ ⟨b, hmemb, hballb⟩
   have hdisj := sqrt_balls_disjoint hC hsep
-  rw [Set.eq_empty_iff_forall_not_mem] at hdisj
-  exact hdisj z hz
+  rw [hdisj] at hz
+  exact Set.notMem_empty z hz
 
 /-- The quadratic lemniscate is not connected in the separated regime. -/
 theorem not_isConnected_quadratic_lemniscate {a b : ℂ} {C : ℝ} (hC : 0 < C)
@@ -215,7 +215,7 @@ theorem not_isPathConnected_levelSet_three {C : ℝ} (hC : 0 < C) (hC' : C < 3 /
 theorem cyclotomic_four : cyclotomic 4 ℂ = X ^ 2 + 1 := by
   have h := cyclotomic_expand_eq_cyclotomic Nat.prime_two (dvd_refl 2) ℂ
   norm_num at h
-  rw [← h, cyclotomic_two, map_add, expand_X, map_one]
+  exact h.symm
 
 /-- `Φ₄` factors over its two roots: `Φ₄(z) = (z − i)(z + i)`. -/
 theorem cyclotomic_four_eval_factor (z : ℂ) :

--- a/proofs/Proofs/CyclotomicPolynomialsOQ02OQ11.lean
+++ b/proofs/Proofs/CyclotomicPolynomialsOQ02OQ11.lean
@@ -1,0 +1,309 @@
+/-
+# Erdős #1215 (cyclotomic sub-question, OQ02) — small-C DISCONNECTION of the
+# quadratic cyclotomic lemniscates (n = 3, 4, 6)
+
+  Slug: erdos-1215-oq-02
+  Prior work (this OQ family):
+    * OQ02OQ01  — boundedness/openness of `{|Φ_n| < C}`; exact open disks for n = 1, 2.
+    * OQ02OQ02–07 — sharp two-sided radius/area sandwich, origin interiority (C > 1).
+    * OQ02OQ08  — radial exit path; OQ02OQ09 — path-connected far field;
+    * OQ02OQ10  — first-crossing exit in EVERY direction, sharp two-sided bound.
+
+  ## This file — the FIRST component-topology result for the family
+
+  All previous OQ02 layers pinned the *shape* of the sublevel set
+  `{z : |Φ_n(z)| < C}` (radius/area sandwich) or produced *positive* path results
+  (every ray exits quickly).  The recorded blocked driver — every-boundary-point
+  reachability — needs the *component structure* of the cyclotomic lemniscate,
+  and the recorded tractable layer is explicit small-`n` geometry.  This file
+  delivers that layer for the complete QUADRATIC case: `n = 3, 4, 6` are exactly
+  the indices with `φ(n) = 2` (`Φ₃ = X²+X+1`, `Φ₄ = X²+1`, `Φ₆ = X²−X+1`), whose
+  lemniscates are Cassini ovals with foci at the two primitive roots `a, b`.
+
+  > **Main result.**  For `4C < |a − b|²` the sublevel set `{|Φ_n| < C}` is
+  > NOT preconnected (hence not connected, hence not path-connected): it splits
+  > into two nonempty "petals" inside the disjoint balls `B(a, √C)`, `B(b, √C)`.
+  > Concretely: `{|Φ₃| < C}` and `{|Φ₆| < C}` are disconnected for `0 < C < 3/4`
+  > (foci `√3` apart), and `{|Φ₄| < C}` is disconnected for `0 < C < 1`
+  > (foci `2` apart).
+
+  The engine is a single general Cassini-oval criterion
+  (`not_isPreconnected_quadratic_lemniscate`): if every point of
+  `{|z−a||z−b| < C}` were at distance `≥ √C` from both foci the product would be
+  `≥ C`, so the set is covered by the two open balls `B(a, √C) ∪ B(b, √C)`; when
+  `2√C < |a−b|` these balls are disjoint, each contains a focus (a root of the
+  polynomial), and `IsPreconnected` applied to this open cover yields a point of
+  the empty intersection — contradiction.
+
+  ## Perspective within the family
+
+  * For `n = 1, 2` (`φ(n) = 1`) the sublevel sets are exact open disks
+    (`OQ02OQ01.sublevel_one/two`) — always connected.  Disconnection therefore
+    first appears exactly at degree `φ(n) = 2`, and this file pins the regime.
+  * The disconnection regime `C < 3/4` (resp. `< 1`) and the origin-interior
+    regime `C > 1` (OQ02OQ07: `|Φ_n(0)| = 1`, so `0 ∈ {|Φ_n| < C}` iff `C > 1`)
+    are disjoint — consistent with the classical Cassini picture, where the oval
+    with foci `a, b` is a single connected curve iff `C ≥ (|a−b|/2)²`.
+  * Sharpness (the sets ARE connected for `C ≥ (|a−b|/2)²`) and the exact
+    component count (each petal is connected, so exactly two) are the natural
+    follow-ups; both need per-petal connectivity arguments not attempted here.
+
+  Byproduct: `cyclotomic 4 ℂ = X² + 1` is absent from Mathlib (which has
+  `cyclotomic_one/_two/_three/_six`); proved here via
+  `cyclotomic_expand_eq_cyclotomic` from `Φ₂ = X + 1` (`cyclotomic_four`).
+
+  Result status: 0 sorries, 0 axioms, no `native_decide` — axiom-free relative
+  to Mathlib.  The deep `maclane_labyrinth` axiom of the parent is untouched.
+-/
+import Mathlib
+import Proofs.Erdos1215Problem
+
+open Complex Polynomial Metric
+
+namespace CyclotomicPolynomialsOQ02OQ11
+
+/-! ## The general Cassini-oval disconnection engine
+
+For `a b : ℂ` and threshold `C`, the quadratic lemniscate `{z : ‖(z−a)(z−b)‖ < C}`
+is covered by the two balls of radius `√C` around the foci; when `4C < ‖a−b‖²`
+those balls are disjoint and each contains a focus, so the set is disconnected. -/
+
+/-- **Covering lemma**: every point of the quadratic lemniscate is within `√C`
+of one of the two foci — otherwise both factors are `≥ √C` and the product is `≥ C`. -/
+theorem quadratic_lemniscate_subset_union (a b : ℂ) {C : ℝ} (hC : 0 ≤ C) :
+    {z : ℂ | ‖(z - a) * (z - b)‖ < C} ⊆
+      Metric.ball a (Real.sqrt C) ∪ Metric.ball b (Real.sqrt C) := by
+  intro z hz
+  rw [Set.mem_setOf_eq, norm_mul] at hz
+  by_contra hcon
+  simp only [Set.mem_union, Metric.mem_ball, dist_eq_norm] at hcon
+  push Not at hcon
+  obtain ⟨ha, hb⟩ := hcon
+  have hmul : Real.sqrt C * Real.sqrt C ≤ ‖z - a‖ * ‖z - b‖ :=
+    mul_le_mul ha hb (Real.sqrt_nonneg C) (norm_nonneg _)
+  rw [Real.mul_self_sqrt hC] at hmul
+  linarith
+
+/-- **Separation lemma**: when `4C < ‖a − b‖²` the two focal balls of radius `√C`
+are disjoint (triangle inequality + squaring). -/
+theorem sqrt_balls_disjoint {a b : ℂ} {C : ℝ} (hC : 0 < C)
+    (hsep : 4 * C < ‖a - b‖ ^ 2) :
+    Metric.ball a (Real.sqrt C) ∩ Metric.ball b (Real.sqrt C) = ∅ := by
+  ext z
+  simp only [Set.mem_inter_iff, Metric.mem_ball, dist_eq_norm, Set.mem_empty_iff_false,
+    iff_false, not_and]
+  intro hza hzb
+  have htri : ‖a - b‖ ≤ ‖z - a‖ + ‖z - b‖ := by
+    have h := dist_triangle a z b
+    rw [dist_comm a z] at h
+    simpa [dist_eq_norm] using h
+  have h1 : ‖a - b‖ < 2 * Real.sqrt C := by linarith
+  have h2 : ‖a - b‖ * ‖a - b‖ < (2 * Real.sqrt C) * (2 * Real.sqrt C) :=
+    mul_self_lt_mul_self (norm_nonneg _) h1
+  have h3 : (2 * Real.sqrt C) * (2 * Real.sqrt C) = 4 * C := by
+    have := Real.mul_self_sqrt hC.le
+    nlinarith [this]
+  nlinarith [h2, h3, hsep]
+
+/-- **Cassini disconnection criterion**: for `0 < C` with `4C < ‖a − b‖²`, the
+quadratic lemniscate `{z : ‖(z−a)(z−b)‖ < C}` is not preconnected — the two
+focal balls form an open cover by disjoint sets each meeting the lemniscate
+(at its focus, a root of the polynomial). -/
+theorem not_isPreconnected_quadratic_lemniscate {a b : ℂ} {C : ℝ} (hC : 0 < C)
+    (hsep : 4 * C < ‖a - b‖ ^ 2) :
+    ¬ IsPreconnected {z : ℂ | ‖(z - a) * (z - b)‖ < C} := by
+  intro hpre
+  have hmema : a ∈ {z : ℂ | ‖(z - a) * (z - b)‖ < C} := by
+    simp only [Set.mem_setOf_eq, sub_self, zero_mul, norm_zero]
+    exact hC
+  have hmemb : b ∈ {z : ℂ | ‖(z - a) * (z - b)‖ < C} := by
+    simp only [Set.mem_setOf_eq, sub_self, mul_zero, norm_zero]
+    exact hC
+  have hballa : a ∈ Metric.ball a (Real.sqrt C) :=
+    Metric.mem_ball_self (Real.sqrt_pos.mpr hC)
+  have hballb : b ∈ Metric.ball b (Real.sqrt C) :=
+    Metric.mem_ball_self (Real.sqrt_pos.mpr hC)
+  obtain ⟨z, _, hz⟩ := hpre (Metric.ball a (Real.sqrt C)) (Metric.ball b (Real.sqrt C))
+    Metric.isOpen_ball Metric.isOpen_ball
+    (quadratic_lemniscate_subset_union a b hC.le)
+    ⟨a, hmema, hballa⟩ ⟨b, hmemb, hballb⟩
+  have hdisj := sqrt_balls_disjoint hC hsep
+  rw [Set.eq_empty_iff_forall_not_mem] at hdisj
+  exact hdisj z hz
+
+/-- The quadratic lemniscate is not connected in the separated regime. -/
+theorem not_isConnected_quadratic_lemniscate {a b : ℂ} {C : ℝ} (hC : 0 < C)
+    (hsep : 4 * C < ‖a - b‖ ^ 2) :
+    ¬ IsConnected {z : ℂ | ‖(z - a) * (z - b)‖ < C} :=
+  fun h => not_isPreconnected_quadratic_lemniscate hC hsep h.isPreconnected
+
+/-- The quadratic lemniscate is not path-connected in the separated regime. -/
+theorem not_isPathConnected_quadratic_lemniscate {a b : ℂ} {C : ℝ} (hC : 0 < C)
+    (hsep : 4 * C < ‖a - b‖ ^ 2) :
+    ¬ IsPathConnected {z : ℂ | ‖(z - a) * (z - b)‖ < C} :=
+  fun h => not_isConnected_quadratic_lemniscate hC hsep h.isConnected
+
+/-! ## Shared surd fact -/
+
+/-- `(√3 : ℂ)² = 3`, the complexified square identity used for the `n = 3, 6` foci. -/
+private lemma ofReal_sqrt_three_sq : (Real.sqrt 3 : ℂ) ^ 2 = 3 := by
+  norm_cast
+  exact Real.sq_sqrt (by norm_num)
+
+/-! ## `n = 3`: `Φ₃ = X² + X + 1`, foci at the primitive cube roots of unity
+
+`ω = (−1 + √3·i)/2` and its conjugate, `√3` apart: disconnection for `C < 3/4`. -/
+
+/-- The primitive cube root of unity `ω = (−1 + √3·i)/2`. -/
+noncomputable def omega3 : ℂ := (-1 + Real.sqrt 3 * Complex.I) / 2
+
+/-- The conjugate primitive cube root of unity `ω̄ = (−1 − √3·i)/2`. -/
+noncomputable def omega3' : ℂ := (-1 - Real.sqrt 3 * Complex.I) / 2
+
+private lemma omega3_add : omega3 + omega3' = -1 := by
+  simp only [omega3, omega3']; ring
+
+private lemma omega3_mul : omega3 * omega3' = 1 := by
+  simp only [omega3, omega3']
+  linear_combination (-(Complex.I ^ 2) / 4) * ofReal_sqrt_three_sq
+    - (3 / 4 : ℂ) * Complex.I_sq
+
+/-- `Φ₃` factors over its two roots: `Φ₃(z) = (z − ω)(z − ω̄)`. -/
+theorem cyclotomic_three_eval_factor (z : ℂ) :
+    (cyclotomic 3 ℂ).eval z = (z - omega3) * (z - omega3') := by
+  rw [cyclotomic_three]
+  simp only [eval_add, eval_pow, eval_X, eval_one]
+  linear_combination z * omega3_add - omega3_mul
+
+/-- The foci of `Φ₃` are `√3` apart: `‖ω − ω̄‖² = 3`. -/
+theorem norm_omega3_sub_sq : ‖omega3 - omega3'‖ ^ 2 = 3 := by
+  have h : omega3 - omega3' = (Real.sqrt 3 : ℂ) * Complex.I := by
+    simp only [omega3, omega3']; ring
+  rw [h, norm_mul, Complex.norm_I, mul_one, Complex.norm_real,
+    Real.norm_eq_abs, abs_of_nonneg (Real.sqrt_nonneg 3)]
+  exact Real.sq_sqrt (by norm_num)
+
+/-- The `Φ₃` sublevel set in factored (Cassini) form. -/
+theorem levelSet_cyclotomic_three_eq (C : ℝ) :
+    Erdos1215.levelSet (cyclotomic 3 ℂ) C =
+      {z : ℂ | ‖(z - omega3) * (z - omega3')‖ < C} := by
+  ext z
+  simp only [Erdos1215.levelSet, Set.mem_setOf_eq, cyclotomic_three_eval_factor]
+
+/-- **`{|Φ₃| < C}` is DISCONNECTED for `0 < C < 3/4`** — the first
+component-topology result for a cyclotomic lemniscate in this family. -/
+theorem not_isPreconnected_levelSet_three {C : ℝ} (hC : 0 < C) (hC' : C < 3 / 4) :
+    ¬ IsPreconnected (Erdos1215.levelSet (cyclotomic 3 ℂ) C) := by
+  rw [levelSet_cyclotomic_three_eq]
+  exact not_isPreconnected_quadratic_lemniscate hC
+    (by rw [norm_omega3_sub_sq]; linarith)
+
+/-- `{|Φ₃| < C}` is not path-connected for `0 < C < 3/4`. -/
+theorem not_isPathConnected_levelSet_three {C : ℝ} (hC : 0 < C) (hC' : C < 3 / 4) :
+    ¬ IsPathConnected (Erdos1215.levelSet (cyclotomic 3 ℂ) C) := by
+  rw [levelSet_cyclotomic_three_eq]
+  exact not_isPathConnected_quadratic_lemniscate hC
+    (by rw [norm_omega3_sub_sq]; linarith)
+
+/-! ## `n = 4`: `Φ₄ = X² + 1`, foci at `± i`, `2` apart: disconnection for `C < 1`
+
+`cyclotomic 4` has no explicit form in Mathlib — proved here by expanding
+`Φ₂ = X + 1` along the prime `2` (`Φ₄(X) = Φ₂(X²)`). -/
+
+/-- `Φ₄ = X² + 1` (absent from Mathlib, which stops at `cyclotomic_three` /
+`cyclotomic_six`): from `expand ℂ 2 Φ₂ = Φ₄`. -/
+theorem cyclotomic_four : cyclotomic 4 ℂ = X ^ 2 + 1 := by
+  have h := cyclotomic_expand_eq_cyclotomic Nat.prime_two (dvd_refl 2) ℂ
+  norm_num at h
+  rw [← h, cyclotomic_two, map_add, expand_X, map_one]
+
+/-- `Φ₄` factors over its two roots: `Φ₄(z) = (z − i)(z + i)`. -/
+theorem cyclotomic_four_eval_factor (z : ℂ) :
+    (cyclotomic 4 ℂ).eval z = (z - Complex.I) * (z - -Complex.I) := by
+  rw [cyclotomic_four]
+  simp only [eval_add, eval_pow, eval_X, eval_one]
+  linear_combination Complex.I_sq
+
+/-- The foci of `Φ₄` are `2` apart: `‖i − (−i)‖² = 4`. -/
+theorem norm_I_sub_neg_I_sq : ‖Complex.I - -Complex.I‖ ^ 2 = 4 := by
+  have h : Complex.I - -Complex.I = (2 : ℂ) * Complex.I := by ring
+  rw [h, norm_mul, Complex.norm_I, mul_one]
+  norm_num
+
+/-- The `Φ₄` sublevel set in factored (Cassini) form. -/
+theorem levelSet_cyclotomic_four_eq (C : ℝ) :
+    Erdos1215.levelSet (cyclotomic 4 ℂ) C =
+      {z : ℂ | ‖(z - Complex.I) * (z - -Complex.I)‖ < C} := by
+  ext z
+  simp only [Erdos1215.levelSet, Set.mem_setOf_eq, cyclotomic_four_eval_factor]
+
+/-- **`{|Φ₄| < C}` is DISCONNECTED for `0 < C < 1`** — the widest disconnection
+regime among the quadratic cyclotomics (foci `2` apart vs `√3`). -/
+theorem not_isPreconnected_levelSet_four {C : ℝ} (hC : 0 < C) (hC' : C < 1) :
+    ¬ IsPreconnected (Erdos1215.levelSet (cyclotomic 4 ℂ) C) := by
+  rw [levelSet_cyclotomic_four_eq]
+  exact not_isPreconnected_quadratic_lemniscate hC
+    (by rw [norm_I_sub_neg_I_sq]; linarith)
+
+/-- `{|Φ₄| < C}` is not path-connected for `0 < C < 1`. -/
+theorem not_isPathConnected_levelSet_four {C : ℝ} (hC : 0 < C) (hC' : C < 1) :
+    ¬ IsPathConnected (Erdos1215.levelSet (cyclotomic 4 ℂ) C) := by
+  rw [levelSet_cyclotomic_four_eq]
+  exact not_isPathConnected_quadratic_lemniscate hC
+    (by rw [norm_I_sub_neg_I_sq]; linarith)
+
+/-! ## `n = 6`: `Φ₆ = X² − X + 1`, foci at the primitive sixth roots of unity
+
+`ζ = (1 + √3·i)/2` and its conjugate, again `√3` apart: disconnection for `C < 3/4`. -/
+
+/-- The primitive sixth root of unity `ζ = (1 + √3·i)/2`. -/
+noncomputable def zeta6 : ℂ := (1 + Real.sqrt 3 * Complex.I) / 2
+
+/-- The conjugate primitive sixth root of unity `ζ̄ = (1 − √3·i)/2`. -/
+noncomputable def zeta6' : ℂ := (1 - Real.sqrt 3 * Complex.I) / 2
+
+private lemma zeta6_add : zeta6 + zeta6' = 1 := by
+  simp only [zeta6, zeta6']; ring
+
+private lemma zeta6_mul : zeta6 * zeta6' = 1 := by
+  simp only [zeta6, zeta6']
+  linear_combination (-(Complex.I ^ 2) / 4) * ofReal_sqrt_three_sq
+    - (3 / 4 : ℂ) * Complex.I_sq
+
+/-- `Φ₆` factors over its two roots: `Φ₆(z) = (z − ζ)(z − ζ̄)`. -/
+theorem cyclotomic_six_eval_factor (z : ℂ) :
+    (cyclotomic 6 ℂ).eval z = (z - zeta6) * (z - zeta6') := by
+  rw [cyclotomic_six]
+  simp only [eval_add, eval_sub, eval_pow, eval_X, eval_one]
+  linear_combination z * zeta6_add - zeta6_mul
+
+/-- The foci of `Φ₆` are `√3` apart: `‖ζ − ζ̄‖² = 3`. -/
+theorem norm_zeta6_sub_sq : ‖zeta6 - zeta6'‖ ^ 2 = 3 := by
+  have h : zeta6 - zeta6' = (Real.sqrt 3 : ℂ) * Complex.I := by
+    simp only [zeta6, zeta6']; ring
+  rw [h, norm_mul, Complex.norm_I, mul_one, Complex.norm_real,
+    Real.norm_eq_abs, abs_of_nonneg (Real.sqrt_nonneg 3)]
+  exact Real.sq_sqrt (by norm_num)
+
+/-- The `Φ₆` sublevel set in factored (Cassini) form. -/
+theorem levelSet_cyclotomic_six_eq (C : ℝ) :
+    Erdos1215.levelSet (cyclotomic 6 ℂ) C =
+      {z : ℂ | ‖(z - zeta6) * (z - zeta6')‖ < C} := by
+  ext z
+  simp only [Erdos1215.levelSet, Set.mem_setOf_eq, cyclotomic_six_eval_factor]
+
+/-- **`{|Φ₆| < C}` is DISCONNECTED for `0 < C < 3/4`.** -/
+theorem not_isPreconnected_levelSet_six {C : ℝ} (hC : 0 < C) (hC' : C < 3 / 4) :
+    ¬ IsPreconnected (Erdos1215.levelSet (cyclotomic 6 ℂ) C) := by
+  rw [levelSet_cyclotomic_six_eq]
+  exact not_isPreconnected_quadratic_lemniscate hC
+    (by rw [norm_zeta6_sub_sq]; linarith)
+
+/-- `{|Φ₆| < C}` is not path-connected for `0 < C < 3/4`. -/
+theorem not_isPathConnected_levelSet_six {C : ℝ} (hC : 0 < C) (hC' : C < 3 / 4) :
+    ¬ IsPathConnected (Erdos1215.levelSet (cyclotomic 6 ℂ) C) := by
+  rw [levelSet_cyclotomic_six_eq]
+  exact not_isPathConnected_quadratic_lemniscate hC
+    (by rw [norm_zeta6_sub_sq]; linarith)
+
+end CyclotomicPolynomialsOQ02OQ11

--- a/research/problems/erdos-1215-oq-02/knowledge.md
+++ b/research/problems/erdos-1215-oq-02/knowledge.md
@@ -335,3 +335,51 @@ The remaining half of the reachability refinement: whether every BOUNDARY POINT 
 just every direction's first crossing) is reachable by a bounded-length path inside the
 set — that needs the labyrinth-free topology of the full lemniscate (connected-component
 count of `{|Φ_n| < C}`), still beyond Mathlib. The directional question is now closed.
+
+## Session 2026-07-24 (researcher-3) — OQ11: quadratic lemniscates DISCONNECT for small C
+
+**Mode**: REVISIT (the recorded tractable layer: explicit small-n geometry, n = 3, 4, 6).
+**Outcome**: progress — 1 new file, 26 thm + 4 def, VERIFIED 0-sorry/0-axiom (docker
+`[8577/8577]`, clean build, no native_decide).
+
+### What I did
+New file `proofs/Proofs/CyclotomicPolynomialsOQ02OQ11.lean` — the FIRST component-topology
+result for the family (all prior layers were shape sandwiches or positive path results):
+
+- **General Cassini disconnection engine**: for foci `a, b` and `4C < ‖a−b‖²`, the
+  quadratic lemniscate `{z : ‖(z−a)(z−b)‖ < C}` is not preconnected
+  (`not_isPreconnected_quadratic_lemniscate`), hence not connected and not path-connected.
+- **Instantiations** — `n = 3, 4, 6` are exactly the indices with `φ(n) = 2`:
+  `{|Φ₃| < C}`, `{|Φ₆| < C}` disconnected for `0 < C < 3/4` (foci `√3` apart);
+  `{|Φ₄| < C}` disconnected for `0 < C < 1` (foci `2` apart).
+- **Mathlib-gap byproduct**: `cyclotomic_four : cyclotomic 4 ℂ = X² + 1` (Mathlib has
+  `cyclotomic_one/_two/_three/_six` but not `_four`) via
+  `cyclotomic_expand_eq_cyclotomic Nat.prime_two` from `Φ₂ = X + 1`.
+
+### Mechanism (reusable)
+Covering: a point at distance `≥ √C` from BOTH foci has factor product `≥ C`, so the
+lemniscate sits inside `B(a,√C) ∪ B(b,√C)`. Separation: triangle inequality + squaring
+makes the balls disjoint when `4C < ‖a−b‖²`. Each ball meets the set at its focus (a
+root: `‖(a−a)(a−b)‖ = 0 < C`). Feed this open cover to the `IsPreconnected` definition —
+the required point of `S ∩ (B_a ∩ B_b)` lands in the empty intersection. Foci algebra by
+`linear_combination` off `a + b` / `a·b` (e.g. `z²+z+1 = (z−ω)(z−ω̄)` is
+`linear_combination z*h_add − h_mul`), with `(√3:ℂ)² = 3` by `norm_cast; Real.sq_sqrt`.
+
+### Perspective
+- For `n = 1, 2` (`φ = 1`) the sets are exact disks (OQ01) — always connected;
+  disconnection first appears exactly at degree `φ(n) = 2`, and OQ11 pins the regime.
+- Disconnection regime (`C < 3/4` resp. `1`) and origin-interior regime (`C > 1`, OQ07)
+  are disjoint — consistent with the classical Cassini threshold `(|a−b|/2)²`.
+- v4.31 renames hit: `Set.eq_empty_iff_forall_not_mem` → `…_notMem`,
+  `Set.not_mem_empty` → `Set.notMem_empty`. Also `cyclotomic_expand_eq_cyclotomic` is
+  simp-tagged, so `norm_num at h` self-normalizes `expand 2 Φ₂` to `X²+1`.
+
+### Files Modified
+- `proofs/Proofs/CyclotomicPolynomialsOQ02OQ11.lean` (new)
+- `research/problems/erdos-1215-oq-02/state.md`, `src/data/research/problems/erdos-1215-oq-02.json`
+
+### Still open
+- `C > 1` regime component count (the every-boundary-point reachability driver) — still
+  needs lemniscate topology beyond Mathlib (blocked, unchanged).
+- Small-n follow-ups: sharpness (connectivity for `C ≥ (|a−b|/2)²`), exact component
+  count 2 (per-petal connectivity), quartic cases `n = 5, 8, 10, 12` (`φ(n) = 4`).

--- a/research/problems/erdos-1215-oq-02/state.md
+++ b/research/problems/erdos-1215-oq-02/state.md
@@ -4,12 +4,14 @@
 **Phase**: PROVE
 **Path**: full
 **Since**: 2026-07-09T15:40:18-07:00
-**Iteration**: 8
+**Iteration**: 9
 
 ## Current Focus
-Directional exit geometry: after OQ02OQ08's single radial exit ray, extend boundary
-reachability to every direction (done, OQ02OQ10) and — still open — to every boundary
-point (needs lemniscate component topology).
+Component topology of the lemniscate. Iter 9 (OQ02OQ11) delivered the first
+disconnection result: the quadratic cyclotomic lemniscates (n = 3, 4, 6 — the complete
+φ(n) = 2 case, Cassini ovals) split into two petals for small C. Still open: component
+count in the C > 1 regime (every-boundary-point reachability driver), and sharpness
+(connectivity above the Cassini threshold).
 
 ## Active Approach
 Approach A/B hybrid: elementary two-sided factor bounds `‖z‖-1 ≤ ‖z-μ‖ ≤ ‖z‖+1`
@@ -85,12 +87,26 @@ rectifiable-path arc length not yet in Mathlib.
   iter-7 refinement question is now closed; the every-boundary-point half still needs
   lemniscate component topology (blocked, unchanged).
 
+- Iter 9 (researcher-3, 2026-07-24): **FIRST COMPONENT-TOPOLOGY RESULT** — the small-n
+  tractable layer delivered for the complete quadratic case. `n = 3, 4, 6` are exactly
+  the indices with `φ(n) = 2`; their lemniscates are Cassini ovals with foci at the two
+  primitive roots. General Cassini disconnection engine (`{|z−a||z−b| < C}` covered by
+  the two focal `√C`-balls; disjoint when `4C < |a−b|²`; each contains a focus, so
+  `IsPreconnected` fails on the cover): `{|Φ₃| < C}` and `{|Φ₆| < C}` are DISCONNECTED
+  (not preconnected/connected/path-connected) for `0 < C < 3/4` (foci `√3` apart),
+  `{|Φ₄| < C}` for `0 < C < 1` (foci `2` apart). Byproduct: `cyclotomic 4 ℂ = X² + 1`,
+  absent from Mathlib, proved via `cyclotomic_expand_eq_cyclotomic`.
+  (`CyclotomicPolynomialsOQ02OQ11.lean`, VERIFIED docker `[8577/8577]`, 0-sorry/0-axiom.)
+
 ## Next Action
 The every-boundary-point half of the reachability question: is EVERY point of the level
 curve `{|Φ_n|=C}` reachable from 0 by a bounded-length path inside the set? The first
 crossing along each ray reaches one boundary point per direction (iter 8); boundary
 points that are NOT first crossings (behind folds of the lemniscate, if any exist) are
 untouched. Deciding whether such points exist at all needs the connected-component /
-fold structure of the cyclotomic lemniscate — polynomial-lemniscate topology Mathlib
-still lacks (blocked, unchanged). Alternative tractable layer: small-n (n=3,4,6)
-explicit lemniscate geometry.
+fold structure of the cyclotomic lemniscate in the relevant regime `C > 1` —
+polynomial-lemniscate topology Mathlib still lacks (blocked, unchanged for `C > 1`).
+The small-C half is now settled for the quadratic case (iter 9): remaining small-n
+follow-ups are (a) sharpness — connectivity for `C` above the Cassini threshold
+`(|a−b|/2)²`; (b) exact component count 2 (per-petal connectivity); (c) the quartic
+`φ(n) = 4` cases `n = 5, 8, 10, 12` (multi-focus, multi-petal).

--- a/src/data/research/problems/erdos-1215-oq-02.json
+++ b/src/data/research/problems/erdos-1215-oq-02.json
@@ -29,8 +29,8 @@
   "currentState": {
     "phase": "OBSERVE",
     "since": "2026-07-09T00:00:00Z",
-    "iteration": 1,
-    "focus": "Understand the sublevel-set geometry of cyclotomic polynomials Φ_n and whether cyclotomic root rigidity rules out Mac Lane labyrinths.",
+    "iteration": 2,
+    "focus": "Session 2026-07-24 (researcher-3, OQ11): first component-topology result — quadratic cyclotomic lemniscates (n=3,4,6, the complete phi(n)=2 case) are disconnected for small C via a general Cassini-oval criterion; cyclotomic_four (X^2+1) proved as a Mathlib-gap byproduct.",
     "blockers": [
       {
         "route": "prove maclane_labyrinth axiom (C>1 regime: paths forced through neighbourhoods of 0 / polynomial-lemniscate topology)",
@@ -46,7 +46,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: metric geometry pinned both sides (radius+area, OQ01-07); radial exit path (OQ08); exterior escape topology (OQ09); exit in EVERY direction with two-sided sharp annulus bound (OQ10) — boundary radially surrounds origin, directional reachability closed. Remaining open driver: every-boundary-point reachability / lemniscate component topology (needs Mathlib infrastructure).",
+    "progressSummary": "PROGRESS: metric geometry pinned both sides (radius+area, OQ01-07); radial exit path (OQ08); exterior escape topology (OQ09); exit in EVERY direction with two-sided sharp annulus bound (OQ10); FIRST component-topology result (OQ11, 2026-07-24): the quadratic cyclotomic lemniscates (n=3,4,6 — the complete phi(n)=2 case, Cassini ovals) are DISCONNECTED for small C ({|Phi_3|<C},{|Phi_6|<C} for 0<C<3/4; {|Phi_4|<C} for 0<C<1), via a general Cassini disconnection criterion. Remaining open driver: every-boundary-point reachability / component count in the C>1 regime (needs Mathlib lemniscate infrastructure); sharpness (connectivity for C above threshold) open.",
     "builtItems": [
       "Erdos1215UnitCircleMonotone.lean (researcher-5, 2026-07-12, 0-axiom VERIFIED): monotone/membership block for the sublevel set as a function of the level C — closedLevelSet_mono (C1<=C2 => closedLevelSet P C1 subset closedLevelSet P C2), volume_closedLevelSet_mono (measure nondecreasing in C via measure_mono), isRoot_mem_closedLevelSet (roots in set for C>=0), zero_mem_closedLevelSet (0 in set for C>=1 via P(0)=1), closedLevelSet_nonempty (C>=1), levelSet_subset_closedLevelSet (open {|P|<C} subset closed {|P|<=C}). 6 thm [propext,Classical.choice,Quot.sound].",
       "eventually_levelSet_subset_closedBall (Erdos1215UnitCircleRadiusLimit.lean): for C>=1, eps>0, one degree threshold K confines the level set of EVERY unit-circle polynomial of degree>=K to closedBall 0 (2+eps) -- uniform confinement of the whole high-degree Mac Lane class (VERIFIED 0/0)",
@@ -61,7 +61,8 @@
       "Erdos1215UnitCircleRadius.lean inner-confinement (researcher-7, 2026-07-11, VERIFIED 0-axiom [propext,Classical.choice,Quot.sound]): norm_eval_le_pow_add_one (dual upper bound |P(z)|≤(‖z‖+1)^deg from ‖z−r‖≤‖z‖+1 on each unit-circle root, via new multiset_prod_le_pow_card) and closedBall_subset_closedLevelSet (for C≥1, {z:|P(z)|≤C} CONTAINS closedBall(0,C^{1/deg}−1) since (‖z‖+1)^deg≤(C^{1/deg})^deg=C via Real.rpow_inv_natCast_pow). Sandwiches the sublevel set between radii C^{1/deg}∓1 — inner dual to the existing outer closedLevelSet_subset_closedBall. File 16→19 decls.",
       "Erdos1215UnitCircleArea.lean (NEW, 5 theorems, 0-axiom/0-sorry [propext,Classical.choice,Quot.sound]): volume_closedLevelSet_le (outer area ≤π(1+C^{1/deg})²), le_volume_closedLevelSet (inner area ≥π(C^{1/deg}−1)², C≥1), volume_closedLevelSet_lt_top (finite area, reuses isCompact_closedLevelSet via IsCompact.measure_lt_top), volume_closedLevelSet_ne_top, and real-valued toReal_volume_closedLevelSet_le / le_toReal_volume_closedLevelSet giving the same sandwich for area.toReal.",
       "Erdos1215UnitCircleConjugation.lean: reflection (complex-conjugation) symmetry of sublevel sets. eval_conj (real-coeff P ⟹ P(z̄)=conj P(z) via Polynomial.eval₂_hom), norm_eval_conj, mem_closedLevelSet_conj/mem_levelSet_conj, closedLevelSet_conj_image/levelSet_conj_image (set = its own conj-image), cyclotomic_hasRealCoeffs (via Polynomial.map_cyclotomic), cyclotomic_closedLevelSet_conj_image/cyclotomic_levelSet_conj_image. 9 thm+1 def, 0-axiom [propext,Classical.choice,Quot.sound].",
-      "CyclotomicPolynomialsOQ02OQ10.lean: rayNorm def + continuity, norm_ofReal_mul, le_rayNorm_outer, rayNorm_lt_of_lt_sharpInner, ray_exit (two-sided first-crossing), levelCurve_meets_every_ray, ray_exit_pathLength (9 decls, VERIFIED 0-axiom docker 8580/8580)"
+      "CyclotomicPolynomialsOQ02OQ10.lean: rayNorm def + continuity, norm_ofReal_mul, le_rayNorm_outer, rayNorm_lt_of_lt_sharpInner, ray_exit (two-sided first-crossing), levelCurve_meets_every_ray, ray_exit_pathLength (9 decls, VERIFIED 0-axiom docker 8580/8580)",
+      "CyclotomicPolynomialsOQ02OQ11.lean (researcher-3, 2026-07-24): general Cassini disconnection engine (quadratic_lemniscate_subset_union: sublevel set covered by the two focal sqrt(C)-balls; sqrt_balls_disjoint for 4C<|a-b|^2; not_isPreconnected/not_isConnected/not_isPathConnected_quadratic_lemniscate) + explicit factorizations cyclotomic_three/four/six_eval_factor over foci omega3=(-1+sqrt3*i)/2, +-i, zeta6=(1+sqrt3*i)/2, focal distances norm_..._sq = 3, 4, 3, and the six headline theorems not_isPreconnected/not_isPathConnected_levelSet_three/four/six. Byproduct: cyclotomic_four (Phi_4 = X^2+1, ABSENT from Mathlib) via cyclotomic_expand_eq_cyclotomic from Phi_2."
     ],
     "insights": [
       "All roots of Phi_n lie on the unit circle (primitive n-th roots), so |Phi_n(z)| = prod_{mu prim} dist(z,mu) >= (|z|-1)^{phi(n)} -> inf: the cyclotomic lemniscate {|Phi_n|<C} is BOUNDED (compact) for EVERY C, explicit radius max 2 (C+1).",
@@ -73,18 +74,21 @@
       "Deep frontier is the single maclane_labyrinth axiom (C>1 regime): needs polynomial-lemniscate / sublevel-set connected-component topology absent from Mathlib — a BUILD >1000 lines, correctly axiomatized. The axiom-free structural periphery (reflection/conjugation symmetry, radius/area/monotonicity, escape-to-infinity, radial-exit & escape-region path-connectivity) is being actively extended by concurrent PRs (#39256/#39332/#39350); adding further peripheral corollaries orbits the deep axiom without reducing it. Registered the deep route as a structured blocker (reopen: lemniscate topology in Mathlib).",
       "Directional exit (OQ02OQ10): for EVERY unit direction u, the ray from 0 has a first level-C crossing t* with two-sided sharp bound C^{1/phi(n)}-1 <= t* <= 1+C^{1/phi(n)}; the open segment stays strictly inside {|Phi_n|<C}. The sharp lower bound is new even for OQ08 u=1 (via OQ07 inner ball).",
       "The level curve {|Phi_n|=C} meets every ray from the origin inside the sharp annulus — the boundary radially surrounds the origin at n-uniformly bounded distance (annulus radii -> 0 and 2 as phi(n) -> infinity). No labyrinthine direction exists; the directional half of the reachability refinement is closed.",
-      "v4.31: push_neg is deprecated in favor of push Not at h."
+      "v4.31: push_neg is deprecated in favor of push Not at h.",
+      "FIRST DISCONNECTION in the family (OQ11): n=3,4,6 are exactly the indices with phi(n)=2, so their lemniscates are Cassini ovals with foci at the two primitive roots. For 4C < |a-b|^2 the set {|z-a||z-b|<C} is covered by the two disjoint focal balls B(a,sqrt C), B(b,sqrt C) (else both factors >= sqrt C forces product >= C), each containing a focus (a root, where |Phi|=0<C) — IsPreconnected applied to this open cover yields a point of the empty intersection. Concretely: disconnected for C<3/4 (n=3,6; foci sqrt3 apart) and C<1 (n=4; foci 2 apart).",
+      "The disconnection regime (C < 3/4 resp. 1) and the origin-interior regime (C > 1, OQ07) are disjoint — consistent with the classical Cassini threshold C = (|a-b|/2)^2 below which the oval splits into two petals. For n=1,2 (phi=1, exact disks, OQ01) the sets are always connected: disconnection first appears exactly at degree phi(n)=2, and OQ11 pins that regime.",
+      "v4.31 renames: Set.eq_empty_iff_forall_not_mem -> eq_empty_iff_forall_notMem, Set.not_mem_empty -> Set.notMem_empty. Also cyclotomic_expand_eq_cyclotomic is simp-tagged, so norm_num at h fully normalizes expand 2 Phi_2 to X^2+1 by itself."
     ],
     "mathlibGaps": [
       "No developed theory of rectifiable paths with arc length in ℂ tied to polynomial sublevel sets.",
-      "No polynomial-lemniscate topology results (component counts, connectivity of {|P|=c})."
+      "No polynomial-lemniscate topology results (component counts, connectivity of {|P|=c}).",
+      "cyclotomic 4 has no explicit closed form in Mathlib (cyclotomic_one/_two/_three/_six exist, _four does not); proved locally in OQ11 via cyclotomic_expand_eq_cyclotomic."
     ],
     "nextSteps": [
       "ASSESSMENT (researcher-2, 2026-07-09): the sharper-radius nextStep is a self-contained but substantial roots-product formalization, NOT a quick gap-fill. Concrete path: IsUnitCirclePolynomial P (P(0)=1, all roots ‖z‖=1) ⟹ |leadingCoeff|=1 (since |P(0)|=|lc|·∏|ζ|=|lc|=1) ⟹ over ℂ (alg-closed, splits) |P(z)|=∏|z−ζ| ≥ (|z|−1)^{deg P} for |z|≥1 (each |z−ζ|≥|z|−1 via norm_sub_norm_le / triangle) ⟹ {|P|<C} with |z|≥1 forces (|z|−1)^{deg}<C ⟹ |z|<1+C^{1/deg}. Needs Polynomial.roots multiset + eq_prod_roots_of_splits / prod_multiset_X_sub_C + Complex.norm product bound (~80-120 lines). R4's OQ-02 bounded-radius base file appears UNMERGED (not on origin/main; main Erdos1215Problem.lean is the 2-axiom Mac Lane parent only). Released without a forced marginal edit.",
       "Sharpen the radius: true bound is |z| <= 1 + C^{1/phi(n)} from (|z|-1)^{phi(n)}<C; formalize this phi(n)-dependent tighter radius.",
-      "Compute {|Phi_n(z)|<1} geometry for n=3,4,6 (connected vs multi-component lemniscates); investigate whether root equidistribution bounds component count (the actual path-length driver).",
       "Toward the path-length bound: the sublevel set is compact, so path-length reduces to component geometry; formalize the number of connected components of {|Phi_n|=c}.",
-      "Area sandwich now bounds the labyrinth region's planar measure to within a factor tied to (C^{1/deg}±1)²; the genuine open path-length driver remains the NUMBER OF CONNECTED COMPONENTS of {|Φ_n|=c} (Mathlib has no polynomial-lemniscate topology). Next: compute component count for n=3,4,6 explicitly, or prove a single-component (connected sublevel set) criterion for large C."
+      "OQ11 delivered the n=3,4,6 disconnection half of the small-n geometry step. Natural follow-ups: (a) SHARPNESS — prove {|Phi_n|<C} connected (even path-connected/star-shaped petal union) for C >= (|a-b|/2)^2 resp. C>1, giving the exact Cassini threshold; (b) exact component COUNT two for the disconnected regime (needs per-petal connectivity, e.g. each petal star-shaped around its focus — false in general for Cassini? check); (c) phi(n)=4 quartic cases n=5,8,10,12 (4 foci, multi-petal)."
     ],
     "markdown": "# Knowledge Base: erdos-1215-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nThis is a restriction of Erdős #1215 to cyclotomic polynomials Φ_n, whose roots are the primitive n-th roots of unity. The parent problem was resolved negatively by Mac Lane (1953) using labyrinth polynomials; the question here is whether the rigid, symmetric placement of cyclotomic roots precludes such labyrinths and yields a polynomial-in-n path-length bound.\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -156,7 +160,18 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CyclotomicPolynomialsOQ02OQ10.lean"
+    },
+    {
+      "path": "Proofs/CyclotomicPolynomialsOQ02OQ11.lean",
+      "filename": "CyclotomicPolynomialsOQ02OQ11.lean",
+      "lineCount": 309,
+      "theoremCount": 26,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CyclotomicPolynomialsOQ02OQ11.lean"
     }
   ],
-  "lastUpdate": "2026-07-12"
+  "lastUpdate": "2026-07-24"
 }


### PR DESCRIPTION
## Summary

**First component-topology result for the cyclotomic lemniscate family (Erdős #1215, cyclotomic restriction): the quadratic cyclotomic lemniscates are DISCONNECTED for small C.**

All prior OQ02 layers pinned the *shape* of `{z : |Φ_n(z)| < C}` (radius/area sandwiches, OQ01–07) or produced *positive* path results (radial exit OQ08, every-direction exit OQ10). The recorded blocked driver — every-boundary-point reachability — needs the lemniscate's *component structure*, and the recorded tractable layer (both in `nextSteps` and the problem's stated goal) is explicit small-n geometry for n = 3, 4, 6. This PR delivers that layer for the complete quadratic case: **n = 3, 4, 6 are exactly the indices with φ(n) = 2**, whose lemniscates are Cassini ovals with foci at the two primitive roots.

New file `proofs/Proofs/CyclotomicPolynomialsOQ02OQ11.lean` (309 lines, 26 theorems + 4 defs, **0 sorries / 0 axioms / no native_decide**, docker-verified `[8577/8577]`, clean build).

## Results

- `not_isPreconnected_quadratic_lemniscate` (+ `not_isConnected`, `not_isPathConnected` variants): **general Cassini disconnection criterion** — for `4C < ‖a−b‖²` the set `{z : ‖(z−a)(z−b)‖ < C}` is not preconnected. Engine: every point at distance ≥ √C from both foci has factor product ≥ C, so the set is covered by the two focal balls `B(a,√C) ∪ B(b,√C)`; the separation hypothesis makes them disjoint; each contains its focus (a root); `IsPreconnected` applied to the cover lands a point in the empty intersection.
- `not_isPreconnected_levelSet_three` / `_six`: **`{|Φ₃| < C}` and `{|Φ₆| < C}` are disconnected for `0 < C < 3/4`** (foci √3 apart).
- `not_isPreconnected_levelSet_four`: **`{|Φ₄| < C}` is disconnected for `0 < C < 1`** (foci 2 apart) — plus `not_isPathConnected` variants of all three.
- Explicit factorizations `cyclotomic_three/four/six_eval_factor` over the foci `ω = (−1+√3i)/2`, `±i`, `ζ = (1+√3i)/2` by deterministic `linear_combination` off the sum/product of roots.
- **Mathlib-gap byproduct**: `cyclotomic_four : cyclotomic 4 ℂ = X² + 1` — Mathlib has `cyclotomic_one/_two/_three/_six` but no `_four`; proved via `cyclotomic_expand_eq_cyclotomic` from `Φ₂ = X + 1`.

## Perspective

- For n = 1, 2 (φ(n) = 1) the sublevel sets are exact open disks (OQ01) — always connected. Disconnection therefore first appears exactly at degree φ(n) = 2, and this PR pins the regime.
- The disconnection regime (C < 3/4 resp. 1) and the origin-interior regime (C > 1, OQ07) are disjoint — consistent with the classical Cassini threshold `(|a−b|/2)²`.
- Follow-ups recorded in state/knowledge: sharpness (connectivity above the threshold), exact component count 2 (per-petal connectivity), and the quartic φ(n) = 4 cases n = 5, 8, 10, 12. The C > 1 component-count driver stays blocked on Mathlib lemniscate topology (unchanged).

## Verification

```
./proofs/scripts/docker-build.sh Proofs.CyclotomicPolynomialsOQ02OQ11
✔ [8577/8577] Built Proofs.CyclotomicPolynomialsOQ02OQ11
=== Build succeeded ===   (0 sorries, 0 axioms; only pre-existing parent-file deprecation warning)
```

## Metadata

`state.md` (iter 9 + progress log), `knowledge.md` (session entry), pool JSON (progressSummary, builtItems, insights, mathlibGaps, nextSteps, leanFiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
