### PR TITLE
Enrich general-quartic: close coverage gap after OQ-02.a Pan k=1 tangency merge

### DIFF
--- a/src/data/proofs/general-quartic/annotations.json
+++ b/src/data/proofs/general-quartic/annotations.json
@@ -207,5 +207,53 @@
       "the Renaissance algebraists (del Ferro, Tartaglia, Cardano, Ferrari)",
       "Cardano's Ars Magna (1545)"
     ]
+  },
+  {
+    "id": "ann-pan-witness-k1-tangency",
+    "proofId": "general-quartic",
+    "range": {
+      "startLine": 749,
+      "endLine": 803
+    },
+    "type": "insight",
+    "title": "OQ-02.a: The Pan k=1 Tangency Witness",
+    "content": "`pan_witness_k1_tangency` and its resolvent-cubic form `pan_witness_k1_resolvent_root` give, for every `0 < t ≤ 1`, an exact-arithmetic real root `m` of the Pan-family resolvent cubic `resolventCubic (-1) t² (1/4 - t² + t⁴/4)`, with its Ferrari intermediate `α² = 2m - 1` pinned strictly between `t²/4` and `t²`. This is the S12 capstone of the OQ-02 line: it certifies that along the Pan family, the resolvent root exists at exact arithmetic precision, but the corresponding Ferrari intermediate `α = √(2m-1) ∈ (t/2, t)` shrinks linearly with `t` while the family of quartics stays uniformly well-separated — the source of the `Ω(t⁻¹)` blow-up in Ferrari's explicit formula near the biquadratic boundary. Proved via the intermediate value theorem on the cleaned resolvent (`panCleanedResolvent`), bracketing a sign change between `t²/4` and `t²`.",
+    "mathContext": "$\\forall\\, 0 < t \\le 1,\\ \\exists\\, m \\in \\mathbb{R}$ with $\\mathrm{resolventCubic}(-1, t^2, \\tfrac14 - t^2 + \\tfrac{t^4}{4})(m) = 0$ and $\\tfrac{t^2}{4} < 2m-1 < t^2$ — pinning $\\alpha = \\sqrt{2m-1} \\in (t/2, t)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Pan family of quartics",
+      "resolvent cubic",
+      "intermediate value theorem",
+      "biquadratic boundary instability"
+    ],
+    "prerequisites": [
+      "the resolvent cubic and Ferrari's intermediate α = √(2m+p)",
+      "intermediate value theorem",
+      "the biquadratic-limit removable singularity (OQ-02.c)"
+    ]
+  },
+  {
+    "id": "ann-ferrari-biquad-limit",
+    "proofId": "general-quartic",
+    "range": {
+      "startLine": 819,
+      "endLine": 887
+    },
+    "type": "theorem",
+    "title": "OQ-02.c Closure: ferrari_biquad_limit",
+    "content": "Closes the α=0 boundary case of `ferrariRoots`. For any `(p, r) ≠ (0, 0)`, a non-degenerate resolvent root `m` (with `2m + p ≠ 0`) exists, and every Ferrari root squared lands in the two-element biquadratic pair `{(-p+√(p²-4r))/2, (-p-√(p²-4r))/2}`. The existence half uses Mathlib's algebraic closedness of ℂ (`IsAlgClosed.exists_root` on `X² + C(-r)`) to find `u` with `u² = r`, then checks that `m₁ = -p+u` or (if `m₁` degenerates) `m₂ = -p-u` is non-degenerate — a case split resolved by the `(p,r)≠(0,0)` hypothesis. The 'roots squared' half reuses `ferrari_roots_are_roots` plus the biquadratic characterization `biquadratic_simple`, bypassing any explicit-formula expansion.",
+    "mathContext": "$(p,r)\\neq(0,0) \\Rightarrow \\exists\\, m,\\ 2m+p\\neq 0,\\ (\\mathrm{resolventCubic}\\,p\\,0\\,r)(m)=0$, and every Ferrari root $y_i$ has $y_i^2 \\in \\{(-p\\pm\\sqrt{p^2-4r})/2\\}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "algebraic closure of ℂ",
+      "biquadratic characterization",
+      "resolvent cubic degeneracy",
+      "removable singularity"
+    ],
+    "prerequisites": [
+      "IsAlgClosed.exists_root",
+      "biquadratic_simple",
+      "ferrari_roots_are_roots"
+    ]
   }
 ]

--- a/src/data/proofs/general-quartic/meta.json
+++ b/src/data/proofs/general-quartic/meta.json
@@ -37,12 +37,13 @@
       "Explicit Ferrari root formulas",
       "Biquadratic special case simplification",
       "Four-roots existence discharged from Mathlib FTA (quartic_has_four_roots)",
-      "Biquadratic forward/backward solved by radicals via the complex quadratic formula (no axioms)"
+      "Biquadratic forward/backward solved by radicals via the complex quadratic formula (no axioms)",
+      "OQ-02.a discharged: pan_witness_k1_tangency / pan_witness_k1_resolvent_root give an exact-arithmetic real resolvent root along the Pan family at the k=1 tangency order, witnessing the Ω(t⁻¹)-amplification of Ferrari's formula near the biquadratic stratum"
     ],
     "dateAdded": "2025-12-28",
     "wiedijkNumber": 46,
     "axiomCount": 0,
-    "lineCount": 816,
+    "lineCount": 936,
     "prerequisites": [
       "Complex numbers and polynomial evaluation",
       "Cubic equation solution (Cardano's formula)",
@@ -51,8 +52,8 @@
     ],
     "assumptions": "0 axioms, 0 sorries — the entry is fully machine-checked. All results, including the previously-axiomatized `quartic_has_four_roots`, `biquadratic_forward`, and `biquadratic_backward`, are now proved: the monic degree-4 quartic splits over ℂ via Mathlib's FTA infrastructure (`IsAlgClosed.splits`, `splits_iff_card_roots`, `Multiset.card_eq_three`, `mem_roots`), and the biquadratic cases follow from the complex quadratic formula (`Complex.cpow_nat_inv_pow`, `linear_combination`). `#print axioms` on the main theorems reports only `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `Lean.ofReduceBool`). The Ferrari factorization / root-verification lemmas (`ferrari_factorization`, `ferrari_roots_verify_ne`) carry an `α ≠ 0` (equivalently `2m + p ≠ 0`) non-degeneracy hypothesis, threaded from every call site — this replaced the earlier `*_forward/backward` and `ferrari_roots_verify` axioms, which were latently unsound at `α = 0`. Docker build verified (3058 jobs, success).",
     "mathlib_version": "4.31.0",
-    "theoremCount": 24,
-    "definitionCount": 5
+    "theoremCount": 29,
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "The quartic formula represents the culmination of Renaissance algebra. While Cardano's Ars Magna (1545) is famous for the cubic formula, it was his student Lodovico Ferrari who, at age 18, discovered how to solve the quartic by reducing it to a cubic.\n\nThe key insight is brilliant: by adding a parameter m and completing the square, the quartic can be written as a difference of squares, which factors. Finding the right m requires solving a cubic equation (the 'resolvent cubic'). This creates a tower of solutions:\n- Quadratic: Direct formula\n- Cubic: Cardano's formula\n- Quartic: Ferrari's method (uses cubic)\n- Quintic and beyond: Abel-Ruffini (1824) proves no general formula exists!\n\nThis historical sequence explains why we can solve up to degree 4 but not degree 5+: the Galois groups S2, S3, S4 are solvable, but S5 is not.",
@@ -126,16 +127,16 @@
     },
     {
       "id": "biquadratic-limit-oq02c",
-      "title": "Part VI.5: Biquadratic-Limit Removable Singularity (OQ-02.c)",
+      "title": "Part VI.5: Biquadratic-Limit Removable Singularity (OQ-02.c) and the Pan k=1 Tangency (OQ-02.a)",
       "startLine": 536,
-      "endLine": 767,
-      "summary": "Discharges the α=0 boundary of `ferrariRoots`: `resolvent_cubic_q_zero`, `resolvent_root_neg_p_half_at_q_zero` (the trivial degenerate root m=−p/2), the Newton-polygon-cleaned `resolvent_cubic_eval_s_form` (s=2m+p), the Pan-witness scaffolding (`pan_witness_cleaned_resolvent`, `pan_witness_t_zero_factorisation` s²(s−2), `pan_witness_t_zero_nondegenerate_root` m=3/2), and `ferrari_biquad_limit`: for (p,r)≠(0,0) a non-degenerate resolvent root exists and each Ferrari root squared lands in the biquadratic pair {(−p±√(p²−4r))/2}."
+      "endLine": 887,
+      "summary": "Discharges the α=0 boundary of `ferrariRoots`: `resolvent_cubic_q_zero`, `resolvent_root_neg_p_half_at_q_zero` (the trivial degenerate root m=−p/2), the Newton-polygon-cleaned `resolvent_cubic_eval_s_form` (s=2m+p), the Pan-witness scaffolding (`pan_witness_cleaned_resolvent`, `pan_witness_t_zero_factorisation` s²(s−2), `pan_witness_t_zero_nondegenerate_root` m=3/2, `panCleanedResolvent_bridge`, `pan_witness_no_root_below`, `pan_witness_pos_at_t_sq`), the S12 capstone `pan_witness_k1_tangency`/`pan_witness_k1_resolvent_root` (OQ-02.a: an exact-arithmetic real resolvent root at the k=1 tangency order, for every 0<t≤1, with Ferrari intermediate α²=2m−1 pinned in (t²/4, t²)), and `ferrari_biquad_limit`: for (p,r)≠(0,0) a non-degenerate resolvent root exists and each Ferrari root squared lands in the biquadratic pair {(−p±√(p²−4r))/2}."
     },
     {
       "id": "history",
       "title": "Part VII: Historical Context and Significance",
-      "startLine": 768,
-      "endLine": 816,
+      "startLine": 888,
+      "endLine": 936,
       "summary": "Ferrari's discovery (1540), why solvability by radicals stops at degree 4, and the connection to Abel-Ruffini and the solvable Galois group S₄ ▷ A₄ ▷ V₄ ▷ {e}."
     }
   ],
@@ -215,10 +216,10 @@
       "Complex"
     ],
     "namespace": "GeneralQuartic",
-    "lineCount": 816,
+    "lineCount": 936,
     "axiomCount": 0,
-    "theoremCount": 24,
-    "definitionCount": 5,
+    "theoremCount": 29,
+    "definitionCount": 6,
     "path": "Proofs/GeneralQuartic.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary
- `Proofs/GeneralQuartic.lean` grew from 816 to 936 lines in PR #43276 (research: OQ-02.a discharged), adding `pan_witness_k1_tangency`/`pan_witness_k1_resolvent_root` (the S12 capstone) plus supporting lemmas — but the gallery's `sections`/`annotations.json` had zero coverage of the new content, and the pre-existing "history" section's line range had silently drifted stale (Part VII shifted from 768-816 to 888-936).
- Extends the `biquadratic-limit-oq02c` section (536-767 → 536-887) to summarize the new Pan-witness theorems, and corrects `history` to 888-936.
- Adds two annotations: the OQ-02.a k=1 tangency witness and the `ferrari_biquad_limit` closure theorem (previously undocumented at the annotation level despite being mentioned in a section summary).
- Updates `lineCount` (816→936), `theoremCount` (24→29), `definitionCount` (5→6) in both `meta.meta` and `leanFile`.
- Adds an `originalContributions` entry for the OQ-02.a discharge.

## Test plan
- [x] `python3 -c "import json; json.load(...)"` validates both JSON files
- [x] `pnpm build` ran the full gallery build; scanned/enriched this proof without error (unrelated build noise elsewhere discarded, not part of this PR)
- [x] File sizes: meta.json 15.3 KB, annotations.json 12.6 KB — both well under the 60 KB cap