### PR TITLE
Research: abundant-number-oq-03-oq-03 - INFINITUDE PROVED: infinitely many odd primitive abundant numbers

### DIFF
--- a/proofs/Proofs/AbundantNumberOQ03OQ03.lean
+++ b/proofs/Proofs/AbundantNumberOQ03OQ03.lean
@@ -461,4 +461,381 @@ theorem odd_abundant_iff_exists_odd_isWeakPrimitiveAbundant_dvd {n : ℕ}
   · rintro ⟨d, hdvd, -, hdab, -⟩
     exact hdab.of_dvd hdvd hodd.pos.ne'
 
+/- ## INFINITUDE RESOLVED: products of consecutive primes — the first-crossing family
+
+This section settles the target question **positively**: there are infinitely
+many odd primitive abundant numbers (in the strict A006038 sense).
+
+**The mechanism** (materially new versus both recorded routes): for a starting
+index `a ≥ 1`, multiply consecutive primes `p_a, p_{a+1}, …` (nth-indexed, so
+`p_a` is odd) until the product first becomes abundant. Divergence of `∑ 1/p`
+(Mathlib's `not_summable_one_div_on_primes`) forces a first crossing `b`:
+
+* the crossing product `N = p_a ⋯ p_{b-1}` is **abundant** (definition of
+  crossing), and
+* its predecessor `N/p_{b-1}` is **not** abundant; equality `σ = 2n` is
+  impossible for a squarefree odd `n` (with `≥ 2` prime factors, `4 ∣ σ(n)`
+  but `2n ≡ 2 [MOD 4]`), so the predecessor is strictly **deficient**, and so
+  is every maximal divisor `N/p_i` (the computation only improves when the
+  omitted prime is smaller: `p_i ≤ p_{b-1}`). Deficiency is divisor-inherited
+  (`deficient_of_dvd`), so *every* proper divisor of `N` is deficient: `N` is
+  **primitive abundant** — and odd, since all its prime factors are odd.
+
+Distinct starting indices give witnesses with distinct least prime factors, so
+the family is injective and the set is infinite. Unlike Route 1 (append ONE
+prime to an odd deficient base with `σ(m)/m → 2⁻`, which needs an unknown odd
+family), the base here *grows through* the boundary, and unlike Route 2
+(extraction), no divisor of an existing family is taken — the witnesses are
+built from scratch. No Bertrand window is needed anywhere. -/
+
+open Finset
+
+/-- **σ of a product of distinct `nth`-indexed primes** is the product of
+`pᵢ + 1` — the squarefree closed form, generalizing `sum_divisors_mul_prime`
+from one appended prime to any finite index set. -/
+theorem sum_divisors_prod_nth (s : Finset ℕ) :
+    ∑ d ∈ (∏ i ∈ s, Nat.nth Nat.Prime i).divisors, d
+      = ∏ i ∈ s, (Nat.nth Nat.Prime i + 1) := by
+  induction s using Finset.cons_induction with
+  | empty => simp
+  | cons j s hj ih =>
+    rw [Finset.prod_cons, Finset.prod_cons, mul_comm (Nat.nth Nat.Prime j)]
+    have hnd : ¬ Nat.nth Nat.Prime j ∣ ∏ i ∈ s, Nat.nth Nat.Prime i := by
+      intro hdvd
+      obtain ⟨i, hi, hdvd'⟩ :=
+        ((Nat.prime_nth_prime j).prime.dvd_finsetProd_iff _).mp hdvd
+      have heq : Nat.nth Nat.Prime j = Nat.nth Nat.Prime i :=
+        (Nat.prime_dvd_prime_iff_eq (Nat.prime_nth_prime j)
+          (Nat.prime_nth_prime i)).mp hdvd'
+      exact hj (Nat.nth_injective Nat.infinite_setOf_prime heq ▸ hi)
+    rw [sum_divisors_mul_prime (Nat.prime_nth_prime j) hnd, ih,
+      mul_comm (∏ i ∈ s, (Nat.nth Nat.Prime i + 1))]
+
+/-- A product of `nth`-indexed primes with all indices `≥ 1` is **odd**:
+`2 = p₀` is the only even prime, and it is excluded by the index bound. -/
+theorem odd_prod_nth {s : Finset ℕ} (hs : ∀ i ∈ s, 1 ≤ i) :
+    Odd (∏ i ∈ s, Nat.nth Nat.Prime i) := by
+  have h2 : ¬ 2 ∣ ∏ i ∈ s, Nat.nth Nat.Prime i := by
+    intro h
+    obtain ⟨i, hi, h2i⟩ := (Nat.prime_two.prime.dvd_finsetProd_iff _).mp h
+    have heq : (2 : ℕ) = Nat.nth Nat.Prime i :=
+      (Nat.prime_dvd_prime_iff_eq Nat.prime_two (Nat.prime_nth_prime i)).mp h2i
+    have h0 : Nat.nth Nat.Prime 0 = Nat.nth Nat.Prime i := by
+      rw [Nat.nth_prime_zero_eq_two]; exact heq
+    have := Nat.nth_injective Nat.infinite_setOf_prime h0
+    have := hs i hi
+    omega
+  rcases Nat.even_or_odd (∏ i ∈ s, Nat.nth Nat.Prime i) with he | ho
+  · exact absurd he.two_dvd h2
+  · exact ho
+
+/-- A product of `nth`-indexed primes is positive. -/
+theorem prod_nth_pos (s : Finset ℕ) : 0 < ∏ i ∈ s, Nat.nth Nat.Prime i :=
+  Finset.prod_pos fun i _ => (Nat.prime_nth_prime i).pos
+
+/-- **No squarefree odd number with indices `≥ 1` is perfect**: for such a
+product, `σ = 2·n` is impossible.  Zero factors: `σ(1) = 1 ≠ 2`.  One factor:
+`p + 1 = 2p` forces `p = 1`, not prime.  Two or more factors: each `pᵢ + 1` is
+even, so `4 ∣ σ(n)`, while `2·n ≡ 2 [MOD 4]` since `n` is odd. -/
+theorem sum_divisors_prod_nth_ne_two_mul {s : Finset ℕ} (hs : ∀ i ∈ s, 1 ≤ i) :
+    ∑ d ∈ (∏ i ∈ s, Nat.nth Nat.Prime i).divisors, d
+      ≠ 2 * ∏ i ∈ s, Nat.nth Nat.Prime i := by
+  rw [sum_divisors_prod_nth]
+  intro h
+  rcases Nat.lt_or_ge s.card 2 with hcard | hcard
+  · interval_cases hc : s.card
+    · rw [Finset.card_eq_zero] at hc
+      subst hc
+      simp at h
+    · obtain ⟨j, rfl⟩ := Finset.card_eq_one.mp hc
+      have hp := (Nat.prime_nth_prime j).two_le
+      simp only [Finset.prod_singleton] at h
+      omega
+  · -- ≥ 2 factors: 4 ∣ ∏ (pᵢ + 1) but 2·(odd) ≢ 0 [MOD 4]
+    obtain ⟨j, hj, k, hk, hjk⟩ := Finset.one_lt_card.mp hcard
+    have hoddj : Odd (Nat.nth Nat.Prime j) := by
+      have := odd_prod_nth (s := {j}) (fun i hi => by
+        simp only [Finset.mem_singleton] at hi; exact hi ▸ hs j hj)
+      simpa using this
+    have hoddk : Odd (Nat.nth Nat.Prime k) := by
+      have := odd_prod_nth (s := {k}) (fun i hi => by
+        simp only [Finset.mem_singleton] at hi; exact hi ▸ hs k hk)
+      simpa using this
+    have h4 : 4 ∣ ∏ i ∈ s, (Nat.nth Nat.Prime i + 1) := by
+      have hsub : ({j, k} : Finset ℕ) ⊆ s := by
+        intro x hx
+        rcases Finset.mem_insert.mp hx with rfl | hx
+        · exact hj
+        · exact Finset.mem_singleton.mp hx ▸ hk
+      have hpair : ∏ i ∈ ({j, k} : Finset ℕ), (Nat.nth Nat.Prime i + 1)
+          = (Nat.nth Nat.Prime j + 1) * (Nat.nth Nat.Prime k + 1) :=
+        Finset.prod_pair hjk
+      have hdvd4 : 4 ∣ (Nat.nth Nat.Prime j + 1) * (Nat.nth Nat.Prime k + 1) := by
+        obtain ⟨x, hx⟩ := hoddj
+        obtain ⟨y, hy⟩ := hoddk
+        exact ⟨(x + 1) * (y + 1), by rw [hx, hy]; ring⟩
+      exact dvd_trans (hpair ▸ hdvd4)
+        (Finset.prod_dvd_prod_of_subset _ _ _ hsub)
+    rw [h] at h4
+    obtain ⟨w, hw⟩ := odd_prod_nth hs
+    omega
+
+/-- **The crossing exists**: for every starting index `a` there is a `b` such
+that the product of the consecutive primes `p_a ⋯ p_{b-1}` is abundant.  This
+is the single analytic input, powered by the divergence of `∑ 1/p`
+(`Nat.Primes.not_summable_one_div`): the partial sums of `1/pᵢ` over `[a, b)`
+exceed `2`, so `σ(N)/N = ∏ (1 + 1/pᵢ) ≥ 1 + ∑ 1/pᵢ > 2` (Weierstrass). -/
+theorem exists_crossing (a : ℕ) :
+    ∃ b, 2 * ∏ i ∈ Finset.Ico a b, Nat.nth Nat.Prime i
+      < ∑ d ∈ (∏ i ∈ Finset.Ico a b, Nat.nth Nat.Prime i).divisors, d := by
+  -- Step 1: ∑ 1/pᵢ diverges (transport prime-reciprocal divergence along `nth`)
+  have hnth : ¬ Summable (fun i : ℕ => (1 : ℝ) / (Nat.nth Nat.Prime i : ℝ)) := by
+    intro hsum
+    apply Nat.Primes.not_summable_one_div
+    have e : ℕ ≃ Nat.Primes :=
+      { toFun := fun i => ⟨Nat.nth Nat.Prime i, Nat.prime_nth_prime i⟩
+        invFun := fun p => Nat.count Nat.Prime (p : ℕ)
+        left_inv := fun i => Nat.count_nth_of_infinite Nat.infinite_setOf_prime i
+        right_inv := fun p => Subtype.ext (Nat.nth_count p.2) }
+    exact e.summable_iff.mp hsum
+  have hnn : ∀ i, (0 : ℝ) ≤ 1 / (Nat.nth Nat.Prime i : ℝ) := fun i => by positivity
+  have htend := (not_summable_iff_tendsto_nat_atTop_of_nonneg hnn).mp hnth
+  -- Step 2: pick b with the tail sum over [a, b) exceeding 2
+  obtain ⟨b, hb⟩ := (htend.eventually_ge_atTop
+    ((∑ i ∈ Finset.range a, (1 : ℝ) / (Nat.nth Nat.Prime i : ℝ)) + 3)).exists
+  have hab : a ≤ b := by
+    by_contra hab
+    push_neg at hab
+    have hmono : ∑ i ∈ Finset.range b, (1 : ℝ) / (Nat.nth Nat.Prime i : ℝ)
+        ≤ ∑ i ∈ Finset.range a, (1 : ℝ) / (Nat.nth Nat.Prime i : ℝ) :=
+      Finset.sum_le_sum_of_subset_of_nonneg
+        (Finset.range_subset.mpr hab.le) (fun i _ _ => hnn i)
+    linarith
+  have htail : (2 : ℝ) < ∑ i ∈ Finset.Ico a b, (1 : ℝ) / (Nat.nth Nat.Prime i : ℝ) := by
+    rw [Finset.sum_Ico_eq_sub _ hab]
+    linarith
+  -- Step 3: Weierstrass ∏(1 + xᵢ) ≥ 1 + ∑ xᵢ
+  have hweier : ∀ (t : Finset ℕ),
+      1 + ∑ i ∈ t, (1 : ℝ) / (Nat.nth Nat.Prime i : ℝ)
+        ≤ ∏ i ∈ t, (1 + 1 / (Nat.nth Nat.Prime i : ℝ)) := by
+    intro t
+    induction t using Finset.cons_induction with
+    | empty => simp
+    | cons j t hjt ih =>
+      rw [Finset.sum_cons, Finset.prod_cons]
+      have hfj := hnn j
+      have hsum : (0 : ℝ) ≤ ∑ i ∈ t, 1 / (Nat.nth Nat.Prime i : ℝ) :=
+        Finset.sum_nonneg fun i _ => hnn i
+      nlinarith [ih, mul_le_mul_of_nonneg_left ih
+        (by linarith : (0 : ℝ) ≤ 1 + 1 / (Nat.nth Nat.Prime j : ℝ))]
+  -- Step 4: convert the index product to σ-arithmetic and descend to ℕ
+  refine ⟨b, ?_⟩
+  rw [sum_divisors_prod_nth]
+  have hposℝ : ∀ i, (0 : ℝ) < (Nat.nth Nat.Prime i : ℝ) := fun i => by
+    exact_mod_cast (Nat.prime_nth_prime i).pos
+  have hfactor : ∀ i ∈ Finset.Ico a b,
+      (1 : ℝ) + 1 / (Nat.nth Nat.Prime i : ℝ)
+        = ((Nat.nth Nat.Prime i : ℝ) + 1) / (Nat.nth Nat.Prime i : ℝ) := by
+    intro i _
+    rw [add_div, div_self (hposℝ i).ne']
+  have hprodpos : (0 : ℝ) < ∏ i ∈ Finset.Ico a b, (Nat.nth Nat.Prime i : ℝ) :=
+    Finset.prod_pos fun i _ => hposℝ i
+  have hgt2 : (2 : ℝ) < (∏ i ∈ Finset.Ico a b, ((Nat.nth Nat.Prime i : ℝ) + 1))
+      / ∏ i ∈ Finset.Ico a b, (Nat.nth Nat.Prime i : ℝ) := by
+    rw [← Finset.prod_div_distrib]
+    calc (2 : ℝ) < 1 + ∑ i ∈ Finset.Ico a b, (1 : ℝ) / (Nat.nth Nat.Prime i : ℝ) := by
+          linarith
+      _ ≤ ∏ i ∈ Finset.Ico a b, (1 + 1 / (Nat.nth Nat.Prime i : ℝ)) := hweier _
+      _ = ∏ i ∈ Finset.Ico a b,
+            ((Nat.nth Nat.Prime i : ℝ) + 1) / (Nat.nth Nat.Prime i : ℝ) :=
+          Finset.prod_congr rfl hfactor
+  have hR : 2 * ∏ i ∈ Finset.Ico a b, (Nat.nth Nat.Prime i : ℝ)
+      < ∏ i ∈ Finset.Ico a b, ((Nat.nth Nat.Prime i : ℝ) + 1) :=
+    (lt_div_iff₀ hprodpos).mp hgt2
+  exact_mod_cast hR
+
+/-- The first index `b` at which the product of consecutive primes
+`p_a ⋯ p_{b-1}` becomes abundant.  Noncomputable only through `Nat.nth`. -/
+noncomputable def crossing (a : ℕ) : ℕ := Nat.find (exists_crossing a)
+
+/-- **The odd primitive abundant witness for starting index `a`**: the product
+of the consecutive primes `p_a, …, p_{crossing a − 1}`. -/
+noncomputable def consecutivePrimeWitness (a : ℕ) : ℕ :=
+  ∏ i ∈ Finset.Ico a (crossing a), Nat.nth Nat.Prime i
+
+/-- The crossing lies strictly beyond the start: empty products are not
+abundant (`σ(1) = 1`). -/
+theorem lt_crossing (a : ℕ) : a < crossing a := by
+  by_contra h
+  push_neg at h
+  have hspec := Nat.find_spec (exists_crossing a)
+  rw [show crossing a = Nat.find (exists_crossing a) from rfl] at h
+  rw [Finset.Ico_eq_empty (by omega : ¬ a < Nat.find (exists_crossing a))] at hspec
+  simp [Nat.divisors_one] at hspec
+
+/-- **Every maximal divisor `N / pᵢ` of the crossing product is deficient.**
+For the omitted index `i = crossing − 1` this is exactly minimality of the
+crossing (sharpened from `≤` to `<` by `sum_divisors_prod_nth_ne_two_mul`);
+for smaller `i` the inequality only improves, because trading the omitted
+prime `pᵢ` back in for `p_{crossing−1}` multiplies the σ-side by
+`(p_c + 1)/(p_i + 1)` but the `2n`-side by `p_c/p_i ≥ (p_c+1)/(p_i+1)`. -/
+theorem erase_prod_deficient {a : ℕ} (ha : 1 ≤ a) {i : ℕ}
+    (hi : i ∈ Finset.Ico a (crossing a)) :
+    (∏ j ∈ (Finset.Ico a (crossing a)).erase i, Nat.nth Nat.Prime j).Deficient := by
+  rw [deficient_iff_sum_divisors, sum_divisors_prod_nth]
+  obtain ⟨c, hc⟩ : ∃ c, crossing a = c + 1 :=
+    ⟨crossing a - 1, by have := lt_crossing a; omega⟩
+  have hac : a ≤ c := by have := lt_crossing a; omega
+  -- predecessor is strictly deficient
+  have hple : ¬ (2 * ∏ j ∈ Finset.Ico a c, Nat.nth Nat.Prime j
+      < ∑ d ∈ (∏ j ∈ Finset.Ico a c, Nat.nth Nat.Prime j).divisors, d) :=
+    Nat.find_min (exists_crossing a) (by omega)
+  have hpne := sum_divisors_prod_nth_ne_two_mul
+    (s := Finset.Ico a c) (fun j hj => le_trans ha (Finset.mem_Ico.mp hj).1)
+  rw [sum_divisors_prod_nth] at hple hpne
+  have hpred : ∏ j ∈ Finset.Ico a c, (Nat.nth Nat.Prime j + 1)
+      < 2 * ∏ j ∈ Finset.Ico a c, Nat.nth Nat.Prime j := by omega
+  -- split on whether the omitted index is the top one
+  rw [hc] at hi ⊢
+  have hico : Finset.Ico a (c + 1) = insert c (Finset.Ico a c) := by
+    rw [Finset.Ico_succ_right_eq_insert_Ico hac]
+  rcases Finset.mem_Ico.mp hi with ⟨hai, hic1⟩
+  rcases Nat.lt_or_ge i c with hilt | hige
+  · -- i < c: erase i, keep the top prime p_c
+    have herase : (Finset.Ico a (c + 1)).erase i
+        = insert c ((Finset.Ico a c).erase i) := by
+      rw [hico, Finset.erase_insert_of_ne (by omega : c ≠ i)]
+    have hcnot : c ∉ (Finset.Ico a c).erase i := fun hmem =>
+      absurd (Finset.mem_Ico.mp (Finset.mem_of_mem_erase hmem)).2 (lt_irrefl c)
+    have himem : i ∈ Finset.Ico a c := Finset.mem_Ico.mpr ⟨hai, hilt⟩
+    rw [herase, Finset.prod_insert hcnot, Finset.prod_insert hcnot]
+    set A := ∏ j ∈ (Finset.Ico a c).erase i, (Nat.nth Nat.Prime j + 1) with hA
+    set B := ∏ j ∈ (Finset.Ico a c).erase i, Nat.nth Nat.Prime j with hB
+    set pi := Nat.nth Nat.Prime i with hpi
+    set pc := Nat.nth Nat.Prime c with hpc
+    -- hpred in split form: (pi + 1) * A < 2 * (pi * B)
+    have hsplitσ : (pi + 1) * A = ∏ j ∈ Finset.Ico a c, (Nat.nth Nat.Prime j + 1) :=
+      Finset.mul_prod_erase _ _ himem
+    have hsplitn : pi * B = ∏ j ∈ Finset.Ico a c, Nat.nth Nat.Prime j :=
+      Finset.mul_prod_erase _ _ himem
+    have hpred' : (pi + 1) * A < 2 * (pi * B) := by
+      rw [hsplitσ, hsplitn]; exact hpred
+    have hpic : pi ≤ pc :=
+      le_of_lt ((Nat.nth_lt_nth Nat.infinite_setOf_prime).mpr hilt)
+    -- goal: (pc + 1) * A < 2 * (pc * B)
+    have hkey : pi * (pc + 1) ≤ pc * (pi + 1) := by
+      rw [Nat.mul_add, Nat.mul_add, Nat.mul_one, Nat.mul_one, Nat.mul_comm pc pi]
+      exact Nat.add_le_add_left hpic _
+    refine Nat.lt_of_mul_lt_mul_left (a := pi + 1) ?_
+    calc (pi + 1) * ((pc + 1) * A)
+        = (pc + 1) * ((pi + 1) * A) := by ring
+      _ < (pc + 1) * (2 * (pi * B)) :=
+          Nat.mul_lt_mul_left (by omega) hpred'
+      _ = 2 * B * (pi * (pc + 1)) := by ring
+      _ ≤ 2 * B * (pc * (pi + 1)) :=
+          Nat.mul_le_mul_left _ hkey
+      _ = (pi + 1) * (2 * (pc * B)) := by ring
+  · -- i = c: the erase IS the predecessor
+    have hieq : i = c := by omega
+    subst hieq
+    have herase : (Finset.Ico a (i + 1)).erase i = Finset.Ico a i := by
+      rw [hico, Finset.erase_insert (fun hmem =>
+        absurd (Finset.mem_Ico.mp hmem).2 (lt_irrefl i))]
+    rw [herase]
+    exact hpred
+
+/-- **The crossing product is odd primitive abundant** (for start `a ≥ 1`):
+abundant by the crossing, odd because all its prime factors are odd, and every
+proper divisor omits some prime `pᵢ`, hence divides the deficient maximal
+divisor `N / pᵢ` and is deficient itself. -/
+theorem consecutivePrimeWitness_mem {a : ℕ} (ha : 1 ≤ a) :
+    consecutivePrimeWitness a ∈ OddPrimitiveAbundant := by
+  have hodd : Odd (consecutivePrimeWitness a) :=
+    odd_prod_nth fun i hi => le_trans ha (Finset.mem_Ico.mp hi).1
+  refine ⟨hodd, ?_, ?_⟩
+  · rw [Nat.abundant_iff_sum_divisors]
+    exact Nat.find_spec (exists_crossing a)
+  · intro d hd
+    obtain ⟨hdvd, hdlt⟩ := Nat.mem_properDivisors.mp hd
+    have hNpos : 0 < consecutivePrimeWitness a := prod_nth_pos _
+    have hdpos : 0 < d := by
+      rcases Nat.eq_zero_or_pos d with rfl | h
+      · exact absurd (Nat.eq_zero_of_zero_dvd hdvd) hNpos.ne'
+      · exact h
+    -- d omits some prime index i
+    have homit : ∃ i ∈ Finset.Ico a (crossing a), ¬ Nat.nth Nat.Prime i ∣ d := by
+      by_contra hall
+      push_neg at hall
+      have himg : ∏ p ∈ (Finset.Ico a (crossing a)).image (Nat.nth Nat.Prime), p
+          = consecutivePrimeWitness a :=
+        Finset.prod_image fun i _ j _ h =>
+          Nat.nth_injective Nat.infinite_setOf_prime h
+      have hNd : consecutivePrimeWitness a ∣ d := by
+        rw [← himg]
+        refine Finset.prod_primes_dvd d ?_ ?_
+        · intro p hp
+          obtain ⟨i, _, rfl⟩ := Finset.mem_image.mp hp
+          exact (Nat.prime_nth_prime i).prime
+        · intro p hp
+          obtain ⟨i, hi, rfl⟩ := Finset.mem_image.mp hp
+          exact hall i hi
+      exact absurd hdlt (not_lt.mpr (Nat.le_of_dvd hdpos hNd))
+    obtain ⟨i, hi, hnd⟩ := homit
+    -- d divides the deficient maximal divisor N / pᵢ
+    have hsplit : Nat.nth Nat.Prime i
+        * ∏ j ∈ (Finset.Ico a (crossing a)).erase i, Nat.nth Nat.Prime j
+        = consecutivePrimeWitness a :=
+      Finset.mul_prod_erase _ _ hi
+    have hcop : Nat.Coprime d (Nat.nth Nat.Prime i) :=
+      ((Nat.prime_nth_prime i).coprime_iff_not_dvd.mpr hnd).symm
+    have hdM : d ∣ ∏ j ∈ (Finset.Ico a (crossing a)).erase i, Nat.nth Nat.Prime j := by
+      refine hcop.dvd_of_dvd_mul_left ?_
+      rw [hsplit]
+      exact hdvd
+    exact deficient_of_dvd (erase_prod_deficient ha hi) hdM hdpos.ne'
+
+/-- **Distinct starts give distinct witnesses**: `p_a` divides the witness for
+`a` but no witness for a later start (whose prime factors are all larger), and
+`nth` is injective, so the family `k ↦ consecutivePrimeWitness (k + 1)` is
+injective. -/
+theorem consecutivePrimeWitness_injective :
+    Function.Injective fun k : ℕ => consecutivePrimeWitness (k + 1) := by
+  have key : ∀ {k l : ℕ}, k < l →
+      consecutivePrimeWitness (k + 1) ≠ consecutivePrimeWitness (l + 1) := by
+    intro k l hkl heq
+    have hmem : k + 1 ∈ Finset.Ico (k + 1) (crossing (k + 1)) :=
+      Finset.mem_Ico.mpr ⟨le_refl _, lt_crossing _⟩
+    have hdvd : Nat.nth Nat.Prime (k + 1) ∣ consecutivePrimeWitness (k + 1) :=
+      Finset.dvd_prod_of_mem _ hmem
+    rw [heq] at hdvd
+    obtain ⟨i, hi, hdvd'⟩ :=
+      ((Nat.prime_nth_prime (k + 1)).prime.dvd_finsetProd_iff _).mp hdvd
+    have heqp : Nat.nth Nat.Prime (k + 1) = Nat.nth Nat.Prime i :=
+      (Nat.prime_dvd_prime_iff_eq (Nat.prime_nth_prime (k + 1))
+        (Nat.prime_nth_prime i)).mp hdvd'
+    have : k + 1 = i := Nat.nth_injective Nat.infinite_setOf_prime heqp
+    have := (Finset.mem_Ico.mp hi).1
+    omega
+  intro k l h
+  rcases lt_trichotomy k l with hlt | heq | hgt
+  · exact absurd h (key hlt)
+  · exact heq
+  · exact absurd h.symm (key hgt)
+
+/-- **MAIN RESULT — there are infinitely many odd primitive abundant numbers**
+(OEIS A006038 is infinite).  This settles the target question of this entry
+positively: the injective family `k ↦ p_{k+1} p_{k+2} ⋯ p_{crossing−1}` of
+first-crossing consecutive-prime products consists entirely of odd primitive
+abundant numbers. -/
+theorem oddPrimitiveAbundant_infinite : OddPrimitiveAbundant.Infinite :=
+  Set.infinite_of_injective_forall_mem consecutivePrimeWitness_injective
+    fun k => consecutivePrimeWitness_mem (Nat.le_add_left 1 k)
+
+/-- The headline restated without the named set: the odd primitive abundant
+numbers — odd, abundant, every proper divisor deficient — form an infinite
+set. -/
+theorem infinitely_many_odd_primitive_abundant :
+    {n : ℕ | Odd n ∧ n.Abundant ∧ ∀ d ∈ n.properDivisors, d.Deficient}.Infinite :=
+  oddPrimitiveAbundant_infinite
+
 end AbundantNumberOQ03OQ03

--- a/proofs/Proofs/AbundantNumberOQ03OQ03.lean
+++ b/proofs/Proofs/AbundantNumberOQ03OQ03.lean
@@ -592,12 +592,11 @@ theorem exists_crossing (a : ℕ) :
   have hnth : ¬ Summable (fun i : ℕ => (1 : ℝ) / (Nat.nth Nat.Prime i : ℝ)) := by
     intro hsum
     apply Nat.Primes.not_summable_one_div
-    have e : ℕ ≃ Nat.Primes :=
-      { toFun := fun i => ⟨Nat.nth Nat.Prime i, Nat.prime_nth_prime i⟩
-        invFun := fun p => Nat.count Nat.Prime (p : ℕ)
-        left_inv := fun i => Nat.count_nth_of_infinite Nat.infinite_setOf_prime i
-        right_inv := fun p => Subtype.ext (Nat.nth_count p.2) }
-    exact e.summable_iff.mp hsum
+    exact (Equiv.summable_iff
+      (⟨fun i => ⟨Nat.nth Nat.Prime i, Nat.prime_nth_prime i⟩,
+        fun p => Nat.count Nat.Prime (p : ℕ),
+        fun i => Nat.count_nth_of_infinite Nat.infinite_setOf_prime i,
+        fun p => Subtype.ext (Nat.nth_count p.2)⟩ : ℕ ≃ Nat.Primes)).mp hsum
   have hnn : ∀ i, (0 : ℝ) ≤ 1 / (Nat.nth Nat.Prime i : ℝ) := fun i => by positivity
   have htend := (not_summable_iff_tendsto_nat_atTop_of_nonneg hnn).mp hnth
   -- Step 2: pick b with the tail sum over [a, b) exceeding 2
@@ -609,7 +608,7 @@ theorem exists_crossing (a : ℕ) :
     have hmono : ∑ i ∈ Finset.range b, (1 : ℝ) / (Nat.nth Nat.Prime i : ℝ)
         ≤ ∑ i ∈ Finset.range a, (1 : ℝ) / (Nat.nth Nat.Prime i : ℝ) :=
       Finset.sum_le_sum_of_subset_of_nonneg
-        (Finset.range_subset.mpr hab.le) (fun i _ _ => hnn i)
+        (Finset.range_subset.mp hab.le) (fun i _ _ => hnn i)
     linarith
   have htail : (2 : ℝ) < ∑ i ∈ Finset.Ico a b, (1 : ℝ) / (Nat.nth Nat.Prime i : ℝ) := by
     rw [Finset.sum_Ico_eq_sub _ hab]
@@ -715,9 +714,13 @@ theorem erase_prod_deficient {a : ℕ} (ha : 1 ≤ a) {i : ℕ}
     set pc := Nat.nth Nat.Prime c with hpc
     -- hpred in split form: (pi + 1) * A < 2 * (pi * B)
     have hsplitσ : (pi + 1) * A = ∏ j ∈ Finset.Ico a c, (Nat.nth Nat.Prime j + 1) := by
-      rw [hpi, hA]; exact Finset.mul_prod_erase _ _ himem
+      rw [hpi, hA]
+      exact Finset.mul_prod_erase (Finset.Ico a c)
+        (fun j => Nat.nth Nat.Prime j + 1) himem
     have hsplitn : pi * B = ∏ j ∈ Finset.Ico a c, Nat.nth Nat.Prime j := by
-      rw [hpi, hB]; exact Finset.mul_prod_erase _ _ himem
+      rw [hpi, hB]
+      exact Finset.mul_prod_erase (Finset.Ico a c)
+        (fun j => Nat.nth Nat.Prime j) himem
     have hpred' : (pi + 1) * A < 2 * (pi * B) := by
       rw [hsplitσ, hsplitn]; exact hpred
     have hpic : pi ≤ pc :=

--- a/proofs/Proofs/AbundantNumberOQ03OQ03.lean
+++ b/proofs/Proofs/AbundantNumberOQ03OQ03.lean
@@ -689,7 +689,7 @@ theorem erase_prod_deficient {a : ℕ} (ha : 1 ≤ a) {i : ℕ}
   -- predecessor is strictly deficient
   have hple : ¬ (2 * ∏ j ∈ Finset.Ico a c, Nat.nth Nat.Prime j
       < ∑ d ∈ (∏ j ∈ Finset.Ico a c, Nat.nth Nat.Prime j).divisors, d) :=
-    Nat.find_min (exists_crossing a) (by omega)
+    Nat.find_min (exists_crossing a) (show c < crossing a by omega)
   have hpne := sum_divisors_prod_nth_ne_two_mul
     (s := Finset.Ico a c) (fun j hj => le_trans ha (Finset.mem_Ico.mp hj).1)
   rw [sum_divisors_prod_nth] at hple hpne
@@ -697,8 +697,8 @@ theorem erase_prod_deficient {a : ℕ} (ha : 1 ≤ a) {i : ℕ}
       < 2 * ∏ j ∈ Finset.Ico a c, Nat.nth Nat.Prime j := by omega
   -- split on whether the omitted index is the top one
   rw [hc] at hi ⊢
-  have hico : Finset.Ico a (c + 1) = insert c (Finset.Ico a c) := by
-    rw [Finset.Ico_succ_right_eq_insert_Ico hac]
+  have hico : Finset.Ico a (c + 1) = insert c (Finset.Ico a c) :=
+    Nat.Ico_succ_right_eq_insert_Ico hac
   rcases Finset.mem_Ico.mp hi with ⟨hai, hic1⟩
   rcases Nat.lt_or_ge i c with hilt | hige
   · -- i < c: erase i, keep the top prime p_c
@@ -714,10 +714,10 @@ theorem erase_prod_deficient {a : ℕ} (ha : 1 ≤ a) {i : ℕ}
     set pi := Nat.nth Nat.Prime i with hpi
     set pc := Nat.nth Nat.Prime c with hpc
     -- hpred in split form: (pi + 1) * A < 2 * (pi * B)
-    have hsplitσ : (pi + 1) * A = ∏ j ∈ Finset.Ico a c, (Nat.nth Nat.Prime j + 1) :=
-      Finset.mul_prod_erase _ _ himem
-    have hsplitn : pi * B = ∏ j ∈ Finset.Ico a c, Nat.nth Nat.Prime j :=
-      Finset.mul_prod_erase _ _ himem
+    have hsplitσ : (pi + 1) * A = ∏ j ∈ Finset.Ico a c, (Nat.nth Nat.Prime j + 1) := by
+      rw [hpi, hA]; exact Finset.mul_prod_erase _ _ himem
+    have hsplitn : pi * B = ∏ j ∈ Finset.Ico a c, Nat.nth Nat.Prime j := by
+      rw [hpi, hB]; exact Finset.mul_prod_erase _ _ himem
     have hpred' : (pi + 1) * A < 2 * (pi * B) := by
       rw [hsplitσ, hsplitn]; exact hpred
     have hpic : pi ≤ pc :=
@@ -730,10 +730,10 @@ theorem erase_prod_deficient {a : ℕ} (ha : 1 ≤ a) {i : ℕ}
     calc (pi + 1) * ((pc + 1) * A)
         = (pc + 1) * ((pi + 1) * A) := by ring
       _ < (pc + 1) * (2 * (pi * B)) :=
-          Nat.mul_lt_mul_left (by omega) hpred'
+          mul_lt_mul_of_pos_left hpred' (by omega : 0 < pc + 1)
       _ = 2 * B * (pi * (pc + 1)) := by ring
       _ ≤ 2 * B * (pc * (pi + 1)) :=
-          Nat.mul_le_mul_left _ hkey
+          mul_le_mul_left' hkey (2 * B)
       _ = (pi + 1) * (2 * (pc * B)) := by ring
   · -- i = c: the erase IS the predecessor
     have hieq : i = c := by omega

--- a/proofs/Proofs/AbundantNumberOQ03OQ03.lean
+++ b/proofs/Proofs/AbundantNumberOQ03OQ03.lean
@@ -608,7 +608,7 @@ theorem exists_crossing (a : ℕ) :
     have hmono : ∑ i ∈ Finset.range b, (1 : ℝ) / (Nat.nth Nat.Prime i : ℝ)
         ≤ ∑ i ∈ Finset.range a, (1 : ℝ) / (Nat.nth Nat.Prime i : ℝ) :=
       Finset.sum_le_sum_of_subset_of_nonneg
-        (Finset.range_subset.mp hab.le) (fun i _ _ => hnn i)
+        (Finset.range_subset_range.mpr hab.le) (fun i _ _ => hnn i)
     linarith
   have htail : (2 : ℝ) < ∑ i ∈ Finset.Ico a b, (1 : ℝ) / (Nat.nth Nat.Prime i : ℝ) := by
     rw [Finset.sum_Ico_eq_sub _ hab]

--- a/proofs/Proofs/AbundantNumberOQ03OQ03.lean
+++ b/proofs/Proofs/AbundantNumberOQ03OQ03.lean
@@ -1,7 +1,7 @@
 /-
-  # Odd primitive abundant numbers — the base witness 945
+  # Odd primitive abundant numbers — infinitude RESOLVED
 
-  *Open question* (`abundant-number-oq-03-oq-03`): are there infinitely many
+  *Question* (`abundant-number-oq-03-oq-03`): are there infinitely many
   **odd primitive abundant** numbers?  A positive integer `n` is *abundant* when
   `n < σ'(n) := ∑_{d ∣ n, d < n} d`, and *deficient* when `σ'(n) < n`
   (`Nat.Abundant` / `Nat.Deficient` in `Mathlib.NumberTheory.FactorisationProperties`).
@@ -11,17 +11,24 @@
 
   `OddPrimitiveAbundant = { n | Odd n ∧ IsPrimitiveAbundant n }`   (A006038),
 
-  and the open question asks whether it is infinite.
+  and the question asks whether it is infinite.
 
   ## What this file settles
 
-  The infinitude is genuinely open (no explicit odd family is known that is
-  provably primitive abundant for infinitely many members).  What *can* be pinned
-  down, axiom-free, is the **base of the problem**: the smallest odd abundant
-  number, `945 = 3³·5·7`, is in fact odd primitive abundant, so the target set is
-  nonempty with an explicit least element.  This anchors any future infinitude
-  construction (each new witness must, like 945, be abundant with all 15 proper
-  divisors deficient).
+  **The target infinitude is now PROVED** (`oddPrimitiveAbundant_infinite`, at
+  the end of the file): for each starting index `a ≥ 1`, the product of
+  consecutive primes `p_a p_{a+1} ⋯` first crosses the abundance boundary at
+  some finite stage (divergence of `∑ 1/p`), and the first-crossing product is
+  odd primitive abundant — minimality plus a mod-4 exclusion of `σ = 2n` makes
+  every maximal divisor deficient, and deficiency is divisor-inherited.
+  Distinct starts have distinct least prime factors, so the witnesses form an
+  injective family.  Axiom-free (`propext, Classical.choice, Quot.sound`; the
+  one analytic input is Mathlib's sum-of-prime-reciprocals divergence).
+
+  Historically this file first pinned the **base of the problem**: the smallest
+  odd abundant number, `945 = 3³·5·7`, is odd primitive abundant, so the target
+  set is nonempty with an explicit least element (all 15 proper divisors
+  deficient, kernel-`decide`d).
 
   * `IsPrimitiveAbundant`            — the A006038 predicate (abundant, all proper
                                        divisors deficient).
@@ -55,9 +62,8 @@
   `maxRecDepth`.  `#print axioms` for every theorem below lists only
   `propext, Classical.choice, Quot.sound`.
 
-  ## Toward infinitude (recorded, not proved)
+  ## The two failed routes (recorded for contrast — the proof uses NEITHER)
 
-  Two routes, both open:
   1. *Odd analogue of the even `2^k·p` construction* — an odd base `m` with
      `σ(m)/m` just below 2 times an odd prime `p` in a controlled (Bertrand-type)
      window, so `m·p` is abundant for the first time at itself.  The obstruction:
@@ -76,8 +82,12 @@
      divisors, and controlling oddness/unboundedness still needs a pigeonhole that
      a single bounded part could defeat.  (Update 2026-07-22: the A091191
      extraction and the "abundant ⟺ multiple of a weakly primitive abundant"
-     characterization are now PROVED at the end of this file, odd-compatibly;
-     the infinitude of the generators remains open.)
+     characterization are now PROVED in this file, odd-compatibly.)
+
+  The successful third route (2026-07-24, final section): GROW the base through
+  the abundance boundary instead of appending one prime to a fixed base —
+  first-crossing products of consecutive primes, powered by the divergence of
+  `∑ 1/p`.  No Bertrand window, no extraction.
 
   Reference: OEIS A006038 (odd primitive abundant numbers); A091191 (primitive
   abundant numbers).  Sibling gallery entries: `abundant-number-oq-02` (945 is the

--- a/research/problems/abundant-number-oq-03-oq-03/knowledge.md
+++ b/research/problems/abundant-number-oq-03-oq-03/knowledge.md
@@ -207,3 +207,57 @@ not strict = those with a perfect proper divisor — characterize?); (b) any rou
 infinitely many odd weak primitives (still the deep crux, same blocker as Route 1);
 (c) smallest odd weak-primitive abundant — is it still 945? (all odd abundants
 below 945 don't exist, so yes trivially; could pin `decide`-cheap).
+
+## Session 2026-07-24 (researcher-2) — **INFINITUDE PROVED**: consecutive-prime first-crossing family
+
+**Mode**: REVISIT (vein was declared SATURATED 2026-07-21). **Outcome**: the target
+`OddPrimitiveAbundant.Infinite` is PROVED, axiom-free, docker build green (8576 jobs).
+`oddPrimitiveAbundant_infinite` + explicit-predicate restatement
+`infinitely_many_odd_primitive_abundant` in `AbundantNumberOQ03OQ03.lean`.
+
+### Why the saturation verdict was premature
+Both recorded routes fixed the SHAPE "base × one appended prime" (Route 1) or
+"divisor of an existing family" (Route 2). The third shape: **grow the base
+through the boundary**. For start a ≥ 1, N(a) = p_a p_{a+1} ⋯ p_{b-1} with b the
+FIRST index where the product is abundant (exists by divergence of ∑ 1/p —
+Mathlib `Nat.Primes.not_summable_one_div`). First-crossing minimality + the
+mod-4 exclusion of σ = 2n on squarefree odd numbers make every maximal divisor
+N/pᵢ deficient (i = last: minimality; i smaller: cross-multiplication
+pᵢ(p_c+1) ≤ p_c(pᵢ+1)); `deficient_of_dvd` spreads deficiency to ALL proper
+divisors. Odd since all factors odd; injective via distinct least prime factors.
+
+### Lean toolkit (reusable)
+- `Nat.nth Nat.Prime` machinery: `prime_nth_prime`, `nth_injective`/`nth_lt_nth`
+  (with `Nat.infinite_setOf_prime`), `Nat.nth_prime_zero_eq_two`,
+  `Nat.count_nth_of_infinite` + `Nat.nth_count` build the ℕ ≃ Nat.Primes equiv —
+  but INLINE the equiv (a `have`-bound equiv is opaque; `Equiv.summable_iff`
+  needs the composition to reduce definitionally).
+- Divergence → crossing: `not_summable_iff_tendsto_nat_atTop_of_nonneg`,
+  `Tendsto.eventually_ge_atTop`, `Finset.sum_Ico_eq_sub`; hand-rolled Weierstrass
+  `1 + ∑ ≤ ∏(1+·)` by `cons_induction` + one `nlinarith` with a
+  `mul_le_mul_of_nonneg_left` hint.
+- σ multiplicative over index-finsets of distinct primes:
+  `sum_divisors_prod_nth` via `cons_induction` + the file's
+  `sum_divisors_mul_prime`; prime-into-product via `Prime.dvd_finsetProd_iff`
+  (v4.31 name), product-into-number via `Finset.prod_primes_dvd` after
+  `Finset.prod_image` reindexing.
+- v4.31 drift hits this session: `Finset.range_subset` is now
+  `∀ x, x < n → x ∈ s` form — use `Finset.range_subset_range` for the
+  range-⊆-range iff; `Finset.Ico_succ_right_eq_insert_Ico` lives in namespace
+  `Nat.`; `Finset.mul_prod_erase` needs f explicit when the goal holds
+  `set`-variables (stuck `CommMonoid ?m`); `Nat.find`+`omega` need a defeq
+  `show c < crossing a` bridge (omega sees `Nat.find` as an unrelated atom);
+  `mul_le_mul_left'` deprecated (warning) for `_root_.mul_le_mul_right`.
+
+### Classical anchor
+Start a = 1: 3·5·7·11·13 = 15015 (I ≈ 2.148 < 2·14/13). The family is the
+classical primorial-tail construction; likely first Lean formalization.
+
+### Remaining open (for follow-ups)
+- Fixed least-prime families (e.g. infinitely many odd primitive abundants
+  divisible by 3) — needs non-squarefree crossings, genuinely different
+  proper-divisor analysis.
+- Dickson finiteness (each fixed number of prime factors admits finitely many
+  odd primitive abundants) — deep.
+- Every odd abundant number has ≥ 3 distinct prime factors (elementary,
+  session-sized: I(3^a·p^b) < (3/2)(5/4) < 2).

--- a/research/problems/abundant-number-oq-03-oq-03/problem.md
+++ b/research/problems/abundant-number-oq-03-oq-03/problem.md
@@ -116,3 +116,55 @@ difficulty: medium
 source: abundant-number-oq-03
 created: 2026-07-09T16:43:19-07:00
 ```
+
+## Adversarial Checklist (added 2026-07-24, researcher-2 — audit guide for the SOLVED claim)
+
+The claim: `oddPrimitiveAbundant_infinite : OddPrimitiveAbundant.Infinite` in
+`proofs/Proofs/AbundantNumberOQ03OQ03.lean`, via the consecutive-prime
+first-crossing family. Ways THIS claim could be wrong, and what to check:
+
+- **Weak-vs-strict primitivity substitution.** The file contains BOTH
+  `IsPrimitiveAbundant` (strict A006038: every proper divisor *deficient*) and
+  `IsWeakPrimitiveAbundant` (A091191: no *abundant* proper divisor). The target
+  requires the STRICT notion. Check: `OddPrimitiveAbundant` is defined from
+  `IsPrimitiveAbundant`, and `consecutivePrimeWitness_mem` discharges
+  `∀ d ∈ properDivisors, d.Deficient` via `deficient_of_dvd` — not merely
+  `¬ d.Abundant`. The headline `infinitely_many_odd_primitive_abundant`
+  restates the predicate explicitly to prevent silent aliasing.
+- **Oddness could silently fail at the start index.** `p₀ = 2`; if the family
+  ever included index 0 the witness would be even (and the mod-4 perfectness
+  exclusion would also break, since 2+1 is odd). Check: the injective family is
+  `k ↦ consecutivePrimeWitness (k+1)` and every lemma carries `1 ≤ a`
+  (`odd_prod_nth` needs all indices ≥ 1).
+- **Degenerate empty product.** If `crossing a = a` the witness would be `1`
+  (odd, and `∀ d ∈ properDivisors 1, …` is vacuous) — but `1` is NOT abundant,
+  and `lt_crossing` proves `a < crossing a` (σ(1) = 1 refutes the crossing
+  predicate at `b ≤ a`). Injectivity also uses `a ∈ Ico a (crossing a)`, which
+  needs exactly this.
+- **Perfect-predecessor trap (exactness at σ = 2n).** Minimality of the
+  crossing only gives `σ(P) ≤ 2P` for the predecessor `P`; if `σ(P) = 2P`
+  (P perfect) the maximal-divisor deficiency argument collapses. Check
+  `sum_divisors_prod_nth_ne_two_mul`: squarefree odd `P` with ≥ 2 prime
+  factors has `4 ∣ σ(P)` but `2P ≡ 2 [MOD 4]`; one factor: `p+1 = 2p` forces
+  `p = 1`; zero factors: `1 ≠ 2`. An odd-perfect-number assumption is NOT
+  smuggled in anywhere — the exclusion is unconditional for these squarefree
+  products.
+- **Only the top maximal divisor checked.** Deficiency of `N/p_{last}` alone
+  does not bound divisors omitting a SMALLER prime. Check
+  `erase_prod_deficient` handles ALL `i ∈ Ico a (crossing a)` — the `i < c`
+  branch trades `pᵢ` against `p_c` with the cross-multiplication
+  `pᵢ(p_c+1) ≤ p_c(pᵢ+1)`.
+- **Divisor-coverage gap.** Every proper divisor must divide some `N/pᵢ`.
+  Check the `homit` argument: if every `pᵢ ∣ d` then `N ∣ d`
+  (`Finset.prod_primes_dvd` after an injective reindexing via `Finset.prod_image`),
+  contradicting `d < N`; then coprimality (`pᵢ ∤ d`, `pᵢ` prime) gives
+  `d ∣ N/pᵢ` — not just `d ≤ N/pᵢ`.
+- **Injectivity could be vacuous.** Distinctness relies on the least prime
+  factor: `p_{k+1} ∣ W(k+1)` but every prime factor of `W(l+1)` is `p_i` with
+  `i ≥ l+1 > k+1`, and `nth` is injective. Check `consecutivePrimeWitness_injective`
+  does not assume the crossings are equal or ordered.
+- **Circularity.** The analytic input is `Nat.Primes.not_summable_one_div`
+  (divergence of `∑ 1/p`) — strictly weaker than, and independent of, any
+  abundance statement. No `axiom`, no `sorry`, no `native_decide`; the file
+  header's "genuinely open" claims are superseded by this section (updated in
+  the same PR).

--- a/research/problems/abundant-number-oq-03-oq-03/sessions/2026-07-24-consecutive-prime-crossing.md
+++ b/research/problems/abundant-number-oq-03-oq-03/sessions/2026-07-24-consecutive-prime-crossing.md
@@ -1,0 +1,58 @@
+# Session 2026-07-24 (researcher-2): INFINITUDE of odd primitive abundants — consecutive-prime first crossing
+
+## Phase: ACT (reopens the SATURATED vein with a materially new mechanism)
+
+## Context
+
+The 2026-07-21 saturation verdict recorded both routes closed:
+- Route 1 (odd base m × one appended prime p): needs an infinite odd deficient
+  family with I(m) → 2⁻ — "no such odd family is known in the literature".
+- Route 2 (extraction): disproven at strict A071395 strength; A091191-corrected
+  but cannot control distinctness of generators.
+
+Reopen bar: "materially new mechanism for the odd-family construction".
+
+## The new mechanism
+
+Do NOT append one prime to a fixed base. GROW the base through the abundance
+boundary: for start index a ≥ 1, take consecutive primes p_a, p_{a+1}, …
+(nth-indexed) and stop at the FIRST b where N = p_a ⋯ p_{b-1} is abundant.
+
+1. Crossing exists: σ(N)/N = Π(1+1/p_i) ≥ 1 + Σ 1/p_i → ∞ (Weierstrass +
+   Mathlib's sum-of-prime-reciprocals divergence, transported along Nat.nth).
+2. First crossing ⟹ predecessor P = N/p_{b-1} has σ(P) ≤ 2P; equality is
+   impossible (squarefree odd with ≥2 factors: 4 ∣ σ(P) = Π(p_i+1) but
+   2P ≡ 2 mod 4; 1 factor: p+1 = 2p forces p = 1; 0 factors: 1 ≠ 2).
+   So P is strictly deficient.
+3. Every maximal divisor N/p_i is deficient: for i = b−1 it is P; for smaller i
+   swap p_i for p_{b-1}: σ-side gains (p_c+1)/(p_i+1), 2n-side gains
+   p_c/p_i ≥ (p_c+1)/(p_i+1) — pure ℕ cross-multiplication.
+4. Any proper divisor omits some p_i (else N ∣ d), divides N/p_i, and
+   deficiency is divisor-inherited (deficient_of_dvd). N is PRIMITIVE abundant,
+   odd (all factors odd for a ≥ 1).
+5. Distinct starts have distinct least prime factors ⟹ injective family ⟹
+   OddPrimitiveAbundant.Infinite. NO Bertrand window anywhere.
+
+## Lean architecture (appended section in AbundantNumberOQ03OQ03.lean)
+
+- sum_divisors_prod_nth : σ(Π_{i∈s} nth Prime i) = Π (nth Prime i + 1)
+  (generalizes the file's sum_divisors_mul_prime engine to any index finset)
+- odd_prod_nth, prod_nth_pos, sum_divisors_prod_nth_ne_two_mul (mod-4 argument)
+- exists_crossing (the single ℝ ingredient: Nat.Primes.not_summable_one_div +
+  not_summable_iff_tendsto_nat_atTop_of_nonneg + hand-rolled Weierstrass)
+- crossing / consecutivePrimeWitness (noncomputable via Nat.nth + Nat.find)
+- erase_prod_deficient (the ℕ cross-multiplication calc)
+- consecutivePrimeWitness_mem, consecutivePrimeWitness_injective
+- oddPrimitiveAbundant_infinite / infinitely_many_odd_primitive_abundant
+
+## Classical anchor
+
+The construction at a = 1 gives 3·5·7·11·13 = 15015 (I = 2.148 < 2·(14/13) =
+2.154): the smallest squarefree witness of this family (A006038 member). The
+family is the classical "primorial-tail" construction; the formalization is,
+to our knowledge, the first in Lean.
+
+## Build
+
+GREEN: `./proofs/scripts/docker-build.sh Proofs.AbundantNumberOQ03OQ03` — 8576 jobs, exit 0.
+0 sorries, 0 axioms, no native_decide. Four build rounds; v4.31 drift notes in knowledge.md.

--- a/research/problems/abundant-number-oq-03-oq-03/state.md
+++ b/research/problems/abundant-number-oq-03-oq-03/state.md
@@ -95,3 +95,17 @@ until a genuinely new mechanism for the odd-family construction (Route 1) is ava
 BLOCKED (see structured blocker in the tracker). Reopen only with a materially new mechanism
 for the Route-1 odd-family construction — an explicit infinite family of odd deficient `mₖ`
 with `I(mₖ) → 2⁻` and a prime in each window. Route 2 is permanently closed (disproven).
+
+## Status (researcher-2, 2026-07-24) — **TARGET PROVED: OddPrimitiveAbundant.Infinite**
+
+The SATURATED verdict is superseded by a third mechanism neither recorded route
+covered: first-crossing products of consecutive primes (grow the base through
+the abundance boundary; ∑ 1/p divergence forces the crossing, first-crossing
+minimality + mod-4 σ≠2n exclusion give primitivity, distinct least primes give
+injectivity). `oddPrimitiveAbundant_infinite` in AbundantNumberOQ03OQ03.lean,
+0 sorries / 0 axioms, docker green. Problem COMPLETED. See knowledge.md
+session 2026-07-24 and the adversarial checklist in problem.md.
+
+## Next Action
+None — target theorem proved. Follow-up directions recorded in knowledge.md
+(fixed-least-prime infinitude; ω ≥ 3 for odd abundants; Dickson finiteness).

--- a/src/data/research/problems/abundant-number-oq-03-oq-03.json
+++ b/src/data/research/problems/abundant-number-oq-03-oq-03.json
@@ -28,10 +28,10 @@
     "goal": "Formalize {n | Odd n and IsPrimitiveAbundant n}.Infinite in Lean 4 / Mathlib, exhibiting a concrete infinite family of odd primitive abundant witnesses with proofs that each is odd, abundant, and has every proper divisor deficient."
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-07-20",
     "iteration": 4,
-    "focus": "Route-1 primitivity reduced to pure divisor-sum arithmetic; infinitude still open",
+    "focus": "COMPLETED 2026-07-24: OddPrimitiveAbundant.Infinite proved via consecutive-prime first-crossing family (researcher-2)",
     "blockers": [
       {
         "route": "Route 1 — odd deficient family mₖ with I(mₖ)→2⁻ + Bertrand-type prime window",
@@ -42,9 +42,14 @@
         "route": "Route 2 — primitive-part extraction from an abundant number",
         "reopenCriterion": "permanently closed: DISPROVEN under strict IsPrimitiveAbundant (A071395) — not_isPrimitiveAbundant_12 / no_isPrimitiveAbundant_dvd_12",
         "blockedAt": "2026-07-21"
+      },
+      {
+        "route": "RESOLVED 2026-07-24 (was: SATURATED — Route 1 needs unknown odd deficient family with I(m)->2-, Route 2 extraction cannot control generators): target PROVED by a third mechanism — first-crossing products of consecutive primes p_a...p_{b-1} (sum 1/p divergence forces crossing; minimality + mod-4 sigma!=2n exclusion give strict primitivity; distinct least primes give injectivity). No Bertrand window, no extraction.",
+        "reopenCriterion": "resolved, nothing to reopen",
+        "blockedAt": "2026-07-24"
       }
     ],
-    "nextAction": "Exhibit an infinite family of odd deficient m_k with abundancy index I(m_k)->2 and controllable I*(m_k), so the rational prime window (I*/(2-I*), I(m)/(2-I(m))) is nonempty and contains a prime coprime to m_k (Bertrand-type input). Infinitude remains genuinely open.",
+    "nextAction": "None — target proved. Follow-ups: fixed-least-prime infinitude; omega >= 3 for odd abundants; Dickson finiteness.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -52,7 +57,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-1-9, 2026-07-22, host-verified lake env lean exit 0, all new results [propext, Classical.choice, Quot.sound]): corrected Route 2 PROVED at A091191 strength — extraction (every abundant number has a weakly primitive abundant divisor) + characterization (abundant iff multiple of an A091191-primitive), odd-compatible structure theorem included. 12 is weak-primitive but not strict (perfect divisor 6). Infinitude NOT resolved — question sharpens to: infinitely many odd A091191-primitives? Route-1 sigma engine + prime window unchanged; base witness 945 verified in both senses.",
+    "progressSummary": "COMPLETED 2026-07-24: OddPrimitiveAbundant.Infinite (strict A006038) PROVED axiom-free via the consecutive-prime first-crossing family — for each start a>=1 multiply consecutive primes until first abundant; divergence of sum 1/p forces the crossing, first-crossing minimality + mod-4 exclusion of sigma=2n give all-proper-divisors-deficient, distinct least primes give injectivity. Docker build green. The 2026-07-21 SATURATED verdict is resolved: the blocked routes assumed the wrong witness shape. Follow-ups recorded: fixed-least-prime infinitude, omega>=3 for odd abundants, Dickson finiteness.",
     "builtItems": [
       "IsPrimitiveAbundant (A006038 predicate) in proofs/Proofs/AbundantNumberOQ03OQ03.lean",
       "OddPrimitiveAbundant set + mem_oddPrimitiveAbundant_945 (945 is a member) in AbundantNumberOQ03OQ03.lean",
@@ -76,7 +81,12 @@
       "exists_isWeakPrimitiveAbundant_dvd (extraction, strong induction) in AbundantNumberOQ03OQ03.lean",
       "abundant_iff_exists_isWeakPrimitiveAbundant_dvd (characterization) in AbundantNumberOQ03OQ03.lean",
       "odd_abundant_iff_exists_odd_isWeakPrimitiveAbundant_dvd (odd structure theorem) in AbundantNumberOQ03OQ03.lean",
-      "isWeakPrimitiveAbundant_twelve + IsPrimitiveAbundant.isWeakPrimitiveAbundant in AbundantNumberOQ03OQ03.lean"
+      "isWeakPrimitiveAbundant_twelve + IsPrimitiveAbundant.isWeakPrimitiveAbundant in AbundantNumberOQ03OQ03.lean",
+      "sum_divisors_prod_nth: sigma of index-finset products of distinct nth-primes (generalizes sum_divisors_mul_prime)",
+      "sum_divisors_prod_nth_ne_two_mul: squarefree odd products are never perfect (mod-4)",
+      "exists_crossing: the single analytic input (Nat.Primes.not_summable_one_div + hand-rolled Weierstrass 1+sum <= prod(1+.))",
+      "crossing / consecutivePrimeWitness + lt_crossing, erase_prod_deficient, consecutivePrimeWitness_mem, consecutivePrimeWitness_injective",
+      "oddPrimitiveAbundant_infinite + infinitely_many_odd_primitive_abundant: THE TARGET, 0 sorries 0 axioms"
     ],
     "insights": [
       "945 = 3³·5·7 is not just the smallest odd abundant number but is odd PRIMITIVE abundant (OEIS A006038): all 15 proper divisors 1,3,5,7,9,15,21,27,35,45,63,105,135,189,315 are deficient — verified axiom-free.",
@@ -91,16 +101,19 @@
       "Route-2 (primitive-part extraction) as recorded is FALSE under the strict IsPrimitiveAbundant (all proper divisors deficient, A071395): 12 is abundant but no divisor of 12 is strict-primitive-abundant (smallest is 20); a perfect proper divisor (6|12) blocks strict primitivity. Extraction holds only for the weaker A091191 notion (no abundant proper divisor).",
       "Corrected Route 2 PROVED at A091191 strength: every abundant number has a weakly-primitive (no abundant proper divisor) abundant divisor, by strong induction; upgrades to characterization abundant iff multiple of an A091191-primitive, odd-compatibly (Nat.Abundant.of_dvd + Odd.of_dvd_nat)",
       "12 is A091191-weakly-primitive but not A071395-strict-primitive: the two notions part ways exactly at the smallest abundant number, blocked only by its perfect divisor 6",
-      "Extraction does NOT give infinitude: the infinite odd abundant set could in principle be generated by finitely many odd A091191-primitives (e.g. 945 alone for Mathlib witnesses) — the open question sharpens to: are there infinitely many odd A091191-primitives?"
+      "Extraction does NOT give infinitude: the infinite odd abundant set could in principle be generated by finitely many odd A091191-primitives (e.g. 945 alone for Mathlib witnesses) — the open question sharpens to: are there infinitely many odd A091191-primitives?",
+      "The saturation fixated on two SHAPES (base x one appended prime; divisor extraction); the third shape — grow the base through the abundance boundary — needs no odd family with I(m)->2- at all: divergence of sum 1/p supplies the crossing for every start",
+      "First-crossing minimality is exactly the primitivity engine: predecessor sigma<=2n, equality excluded mod 4 for squarefree odd (>=2 factors: 4 | prod(p_i+1) but 2n == 2 mod 4), and swapping the omitted prime only helps (p_i(p_c+1) <= p_c(p_i+1))",
+      "Injectivity for free: distinct starting indices give witnesses with distinct least prime factors — no crossing comparison needed",
+      "Lean: inline anonymous Equiv into Equiv.summable_iff (have-bound equivs are opaque, comp will not reduce); v4.31 Finset.range_subset_range replaces range_subset for the range-subset-range iff; Nat.Ico_succ_right_eq_insert_Ico is Nat-namespaced; mul_prod_erase needs explicit f against set-variables"
     ],
     "mathlibGaps": [
       "No Nat.Coprime.divisors_mul (Finset equality for divisors of a coprime product) in Mathlib v4.31 — only Nat.Coprime.sum_divisors_mul (the sum) and card_divisors_mul (the count). Blocks a clean coprime proper-divisor decomposition."
     ],
     "nextSteps": [
-      "Find infinite odd deficient family m_k with I(m_k)->2 (abundancy index near 2 from below)",
-      "Bound I*(m_k) so the rational prime window is nonempty for infinitely many k",
-      "Bertrand-type prime existence in the window (I*/(2-I*), I(m)/(2-I(m))), coprime to m_k",
-      "Route 2 alternative: primitive-part extraction from Nat.infinite_odd_abundant"
+      "Follow-up (materially weaker than parent, does not yield it back): infinitely many odd primitive abundants with least prime factor 3 — needs non-squarefree exponent-crossings, new proper-divisor analysis",
+      "Follow-up (elementary, session-sized): every odd abundant number has at least 3 distinct prime factors (I(3^a p^b) < (3/2)(5/4) < 2)",
+      "Deep: Dickson 1913 finiteness — for each k, finitely many odd primitive abundants with exactly k prime factors"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
The target question of `abundant-number-oq-03-oq-03` — **are there infinitely many odd primitive abundant numbers (OEIS A006038)?** — is settled **positively**, axiom-free:

`oddPrimitiveAbundant_infinite : OddPrimitiveAbundant.Infinite` in `proofs/Proofs/AbundantNumberOQ03OQ03.lean` (strict A006038 primitivity: abundant with **every** proper divisor deficient), plus an explicit-predicate restatement `infinitely_many_odd_primitive_abundant`.

## The mechanism (reopens the 2026-07-21 SATURATED verdict with a third shape)
Both recorded routes were dead: Route 1 (odd base × one appended prime) needs an unknown odd deficient family with `σ(m)/m → 2⁻`; Route 2 (extraction) is disproven at strict strength and cannot control generators. The proof uses neither — it **grows the base through the abundance boundary**:

1. For start `a ≥ 1`, multiply consecutive primes `p_a p_{a+1} ⋯` until the product is first abundant. The crossing exists because `∑ 1/p` diverges (Mathlib's `Nat.Primes.not_summable_one_div`, transported along `Nat.nth`, plus a hand-rolled Weierstrass `1 + ∑ ≤ ∏(1+·)`).
2. First-crossing minimality gives `σ(P) ≤ 2P` for the predecessor; equality is impossible for squarefree odd products (`≥ 2` factors: `4 ∣ σ` but `2P ≡ 2 mod 4`), so the predecessor is strictly deficient — and swapping the omitted prime only improves the inequality (`pᵢ(p_c+1) ≤ p_c(pᵢ+1)`, pure ℕ cross-multiplication), so **every** maximal divisor `N/pᵢ` is deficient.
3. Every proper divisor omits some `pᵢ` (else `N ∣ d`), divides `N/pᵢ`, and deficiency is divisor-inherited (`deficient_of_dvd`) — `N` is strictly primitive abundant, and odd.
4. Distinct starts have distinct least prime factors → injective family → infinite. **No Bertrand window, no extraction.**

The construction at `a = 1` is the classical primorial-tail witness `3·5·7·11·13 = 15015`.

## Files
- `proofs/Proofs/AbundantNumberOQ03OQ03.lean` — new final section (~340 lines); header updated (infinitude no longer described as open)
- `research/problems/abundant-number-oq-03-oq-03/{problem.md, knowledge.md, state.md, sessions/}` — adversarial checklist (per SOLVED protocol), session record, state → COMPLETED
- `src/data/research/problems/abundant-number-oq-03-oq-03.json` — phase COMPLETED, blocked route resolved, follow-ups recorded

## Verification
- `./proofs/scripts/docker-build.sh Proofs.AbundantNumberOQ03OQ03` — exit 0 (8576 jobs), two consecutive green builds (post-header-edit re-verified)
- 0 sorries, 0 `axiom` declarations, no `native_decide` (the only analytic input is Mathlib's prime-reciprocal divergence; expected axioms: `propext, Classical.choice, Quot.sound`)

## Adversarial checklist highlights (full list in problem.md)
- Strict A006038 (not weak A091191) is what's proved: witnesses discharge `∀ d ∈ properDivisors, d.Deficient` directly.
- Oddness: family starts at index `k+1 ≥ 1`, excluding `p₀ = 2` (also required by the mod-4 argument).
- Degenerate empty product excluded by `lt_crossing`; perfect-predecessor trap excluded unconditionally (no odd-perfect assumption).

## Status
**Outcome**: completed — target theorem proved
**Follow-ups recorded** (depth 2 < cap 3, both materially distinct from the parent): (a) fixed-least-prime infinitude (e.g. infinitely many odd primitive abundants divisible by 3 — needs non-squarefree crossings, a genuinely new proper-divisor analysis); (b) every odd abundant number has ≥ 3 distinct prime factors (elementary, session-sized).

🤖 Generated by researcher-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
