### PR TITLE
Enrich erdos-876: cover Part X structural results

### DIFF
--- a/src/data/proofs/erdos-876/annotations.json
+++ b/src/data/proofs/erdos-876/annotations.json
@@ -279,5 +279,52 @@
       "IsSumFreeErdos",
       "gap"
     ]
+  },
+  {
+    "id": "ann-876-13",
+    "proofId": "erdos-876",
+    "range": {
+      "startLine": 334,
+      "endLine": 354
+    },
+    "type": "insight",
+    "title": "Super-Increasing Sequences: the Domination Mechanism, Generalized",
+    "content": "`superIncreasing_sumfree` isolates the exact mechanism that made `powers_of_two_sumfree` work: if a strictly increasing sequence $a$ satisfies $\\sum_{k<n} a_k < a_n$ (each term dominates the sum of all its predecessors), its range is Erdős-sum-free. The proof shows any candidate subset $S$ below $a_m$ embeds into $\\{a_0,\\dots,a_{m-1}\\}$ by injectivity of $a$ on the index set, so $\\sum S \\leq \\sum_{k<m} a_k < a_m$, contradicting $\\sum S = a_m$. This single lemma subsumes powers of 2 (and any other geometric-or-faster growing domination sequence) as instances, rather than re-proving the argument each time.",
+    "mathContext": "$a$ strictly increasing with $\\sum_{k<n} a_k < a_n\\ \\forall n \\Rightarrow \\mathrm{IsSumFreeErdos}(\\mathrm{range}\\,a)$. Powers of 2 are the special case $\\sum_{k<n} 2^k = 2^n - 1 < 2^n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "domination sequences",
+      "strict monotonicity",
+      "generalization of powers_of_two_sumfree"
+    ],
+    "prerequisites": [
+      "IsSumFreeErdos",
+      "StrictMono",
+      "Finset.sum_le_sum_of_subset"
+    ]
+  },
+  {
+    "id": "ann-876-14",
+    "proofId": "erdos-876",
+    "range": {
+      "startLine": 380,
+      "endLine": 407
+    },
+    "type": "insight",
+    "title": "Why an Affirmative Answer Would Be a Genuine Improvement",
+    "content": "`hasLinearGapBound_quadratic` proves that if a sum-free set has linear gaps ($a_{n+1}-a_n < n$ for all $n \\geq 1$), its growth is bounded above by a quadratic: $2a_n + n \\leq 2a_1 + n^2$. Combined with `erdosQuestion876_implies_quadratic_growth`, this shows that a 'yes' to Question 876 would not just be a qualitative curiosity — it would immediately produce a sum-free set growing at rate $O(n^2)$, strictly better than the best known explicit construction (DEM, $n^{3+o(1)}$), and landing exactly at the boundary the Łuczak-Schoen counting bound $|A\\cap[1,N]| \\ll (N\\log N)^{1/2}$ permits. This is why the open question is considered sharp rather than merely plausible.",
+    "mathContext": "$\\mathrm{HasLinearGapBound}(a) \\Rightarrow \\forall n \\geq 1,\\ 2a_n + n \\leq 2a_1 + n^2$, proved by induction using $a_{m+1} = a_m + \\mathrm{gap}(a,m) < a_m + m$ and $(m+1)^2 = m^2+2m+1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "quadratic growth bound",
+      "Deshouillers-Erdős-Melfi construction",
+      "Łuczak-Schoen counting bound",
+      "sharpness of an open question"
+    ],
+    "prerequisites": [
+      "HasLinearGapBound",
+      "Nat.le_induction",
+      "gap"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-876/meta.json
+++ b/src/data/proofs/erdos-876/meta.json
@@ -65,7 +65,8 @@
       "**Density-Growth Duality:** The Łuczak-Schoen counting bound $|A \\cap [1,N]| = O(\\sqrt{N \\log N})$ and the DEM growth rate $a_n \\sim n^{3+o(1)}$ are dual perspectives: if $|A \\cap [1,N]| \\sim \\sqrt{N}$, inverting gives $a_n \\sim n^2$. The $\\log N$ correction explains the cubic (rather than quadratic) growth.",
       "**Graham's Near-Linear Gaps:** Graham's construction achieves gaps $< n^{1+\\varepsilon}$ for any $\\varepsilon > 0$ using a careful recursive procedure that balances element selection with sum-avoidance. The gap between $n^{1+\\varepsilon}$ (achievable) and $n$ (open) represents a fundamental barrier in understanding subset-sum structure.",
       "**Reciprocal Sum as Structure Measure:** The convergence $\\sum 1/a < 4$ (Sullivan) quantifies sparsity differently from density: it says elements grow fast enough that their reciprocals converge. Sullivan's conjecture that the supremum is $\\approx 2$ would determine the precise balance between density and growth.",
-      "**Powers of 2 as Base Case:** $\\{1, 2, 4, 8, \\ldots\\}$ is sum-free by uniqueness of binary representation: $2^n$ cannot equal any sum of distinct smaller powers of $2$ since each power contributes to a unique bit. This gives exponential gaps ($2^{n+1} - 2^n = 2^n$), far from linear."
+      "**Powers of 2 as Base Case:** $\\{1, 2, 4, 8, \\ldots\\}$ is sum-free by uniqueness of binary representation: $2^n$ cannot equal any sum of distinct smaller powers of $2$ since each power contributes to a unique bit. This gives exponential gaps ($2^{n+1} - 2^n = 2^n$), far from linear.",
+      "**Why Question 876 is Sharp:** `hasLinearGapBound_quadratic` shows a linear gap bound would force at-most-quadratic growth ($2a_n + n \\le 2a_1 + n^2$) — strictly better than the best known $n^{3+o(1)}$ construction (DEM) and sitting right at the edge of the Łuczak-Schoen counting bound $|A \\cap [1,N]| \\ll (N\\log N)^{1/2}$. This is why the open question, if answered affirmatively, would be a genuine improvement rather than a re-derivation of known bounds."
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -144,6 +145,14 @@
       "startLine": 259,
       "endLine": 305,
       "mathContext": "`erdos_876_summary : \\forall \\varepsilon > 0, \\exists a, \\text{IsSumFreeErdos}(\\text{range } a) \\land \\exists N, \\forall n \\ge N, \\text{gap}(a,n) < n^{1+\\varepsilon}$ — obtained by destructuring `graham_result ε hε` and discarding the increasing-enumeration component."
+    },
+    {
+      "id": "part-x-structural",
+      "title": "Part X: Structural Results Around the Open Question",
+      "summary": "`superIncreasing_sumfree` generalizes `powers_of_two_sumfree`: any strictly increasing sequence dominating the sum of its predecessors ($\\sum_{k<n} a_k < a_n$) is Erdős-sum-free. `powers_of_two_not_linearGapBound` shows the canonical domination example fails Question 876's linear-gap requirement (its gaps are exponential, not linear) — any affirmative answer must use a genuinely different construction. `hasLinearGapBound_quadratic` is the sharpest result here: linear gaps would force at-most-quadratic growth ($2a_n + n \\le 2a_1 + n^2$), which would beat the DEM $n^{3+o(1)}$ construction and sit at the edge of the Łuczak-Schoen counting bound. `erdosQuestion876_implies_quadratic_growth` packages this as a direct consequence of the open question.",
+      "startLine": 306,
+      "endLine": 425,
+      "mathContext": "$\\sum_{k<n} a_k < a_n \\Rightarrow$ Erdős-sum-free (superIncreasing_sumfree); powers of 2 fail linear gaps; linear gaps $\\Rightarrow 2a_n + n \\le 2a_1 + n^2$ (hasLinearGapBound_quadratic), sharper than the known $n^{3+o(1)}$ construction."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- PR #43140 (research: Part X structural results) added `superIncreasing_sumfree`, `powers_of_two_not_linearGapBound`, `hasLinearGapBound_quadratic`, and `erdosQuestion876_implies_quadratic_growth` to `Erdos876Problem.lean`. The top-level `meta.json` fields (`lineCount`, `theoremCount`, `definitionCount`, `originalContributions`, `proofStrategy`) were already updated to describe Part X, but `sections`/`annotations.json` still stopped at line 305, leaving the entire 120-line section (306-425) with zero section/annotation coverage.
- Adds a `part-x-structural` section (306-425) summarizing all four theorems.
- Adds two new annotations: `superIncreasing_sumfree` (the domination mechanism, generalized from the powers-of-2 base case) and `hasLinearGapBound_quadratic` (why the open question is sharp — an affirmative answer would beat the best known $n^{3+o(1)}$ construction).
- Adds one `keyInsight` on the same sharpness point.

## Test plan
- [x] `python3 -c "import json; json.load(...)"` validates both JSON files
- [x] `pnpm build` ran the full gallery build; scanned/enriched this proof without error (unrelated build noise elsewhere discarded, not part of this PR)
- [x] File sizes: meta.json 21.3 KB, annotations.json 17.8 KB — both well under the 60 KB cap