### PR TITLE
research(roth-theorem-oq-02): S9 — joint S6-a + S6-d conditional analytic envelopes [2 ax / 0 sorry, unchanged]

### DIFF
--- a/proofs/Proofs/RothTheoremOQ02.lean
+++ b/proofs/Proofs/RothTheoremOQ02.lean
@@ -332,6 +332,226 @@ theorem analytic_envelope_conditional (N : ℕ) (hN : 3 ≤ N)
       _ = 4 * Real.log N ^ ((1 : ℝ) / 2) := h_rpow_combine
   linarith
 
+/-! ## S6-a: Conditional analytic envelope (Bloom–Sisask vs Behrend)
+
+The transitivity proof `bloom_sisask_consistent_with_Behrend` shows the
+Behrend lower bound and the Bloom–Sisask upper bound are compatible by
+routing through `rothNumberNat N`. Like its Kelley–Meka sibling above,
+that proof is *analytically vacuous*: the transitive `≤` holds for
+*every* positive `blasiConst`, however large.
+
+The conditional version below records the genuine *analytic content*:
+**assuming** `blasiConst ≤ 2e - 1` (numerically `≈ 4.4366`), the B–S
+upper-bound function dominates the Behrend lower-bound function for all
+`N ≥ 3` — independent of `rothNumberNat`.
+
+The constant `2e` is optimal for the all-`N ≥ 3` regime: the analytic
+core `(1 + c) · log(log N) ≤ 4 · √(log N)` reduces (with `y = log N`)
+to `1 + c ≤ 4√y / log y`, and `4√y / log y` attains its minimum `2e`
+at `y = e²` (interior to the range `y ≥ log 3`). See S6 PREP
+(sessions/2026-05-13-s6-prep-bloom-sisask-analytic-envelope-verbatim.md)
+§3 for the derivation.
+
+This conditional theorem is *not unconditional* because the B–S axiom
+asserts only `∃ c > 0, ...`; `Exists.choose` extracts an unconstrained
+witness (same obstruction as the K–M case, PR #18509). -/
+
+/-- **The analytic envelope of the Bloom–Sisask 2020 upper bound vs the
+Behrend 1946 lower bound on `rothNumberNat`** as a bare `Prop`-valued
+function.
+
+For each `N`, the proposition asserts: if `N ≥ 3` then
+
+  `N · exp(-4 · √(log N)) ≤ N / (log N)^(1 + blasiConst)`.
+
+This bare definition records the analytic envelope as a target without
+asserting it. **It is unprovable from the current axiom set** (see
+PR #18509: `blasiConst` is `Exists.choose` of an unbounded existential).
+Future researchers can either strengthen the B–S axiom to a
+bounded-existential form, or use the conditional version
+`bloom_sisask_analytic_envelope_conditional` below, which adds an
+explicit upper bound on `blasiConst` as a hypothesis. Parallel to
+`analytic_envelope_kelley_meka` (S5b PREP §8). -/
+def analytic_envelope_bloom_sisask (N : ℕ) : Prop :=
+  3 ≤ N →
+    (N : ℝ) * Real.exp (-4 * Real.sqrt (Real.log N)) ≤
+      (N : ℝ) / Real.log N ^ (1 + blasiConst)
+
+/-- **The conditional B–S analytic envelope.**
+
+Assuming `blasiConst ≤ 2 * Real.exp 1 - 1` (numerically `≈ 4.4366`),
+the negated exponents inside the Behrend / Bloom–Sisask envelope satisfy
+
+  `-(4 : ℝ) * √(log N) ≤ -(1 + blasiConst) * log(log N)`
+
+for every `N ≥ 3`. This is **strictly stronger** than the transitivity
+proof `bloom_sisask_consistent_with_Behrend`, which works for *every*
+value of `blasiConst` regardless of the analytic content.
+
+The optimal numerical constant `K = 2e` arises because the analytic
+core `(1 + c) · log(log N) ≤ 4 · √(log N)` has the minimum of
+`4 · √y / log y` at `y = e²`, giving `f(e²) = 2e`. The Bloom–Sisask
+paper's `c` is informally `≈ 1/24` to `1/12`, hence
+`blasiConst ≤ 2e - 1 ≈ 4.4366` is a *very loose* hypothesis from the
+paper's standpoint.
+
+The analytic heart is `Real.exp_one_mul_le_exp` (`e · x ≤ eˣ`)
+specialized to `x = log(√(log N))`, i.e. `e · log u ≤ u`. -/
+theorem bloom_sisask_analytic_envelope_conditional (N : ℕ) (hN : 3 ≤ N)
+    (hBS_bound : blasiConst ≤ 2 * Real.exp 1 - 1) :
+    -(4 : ℝ) * Real.sqrt (Real.log N) ≤
+      -(1 + blasiConst) * Real.log (Real.log N) := by
+  -- §5: 1 ≤ Real.log N, hence log N > 0, log N ≥ 0, 1 < log N.
+  have h_log3_pos : (0 : ℝ) < Real.log 3 := Real.log_pos (by norm_num)
+  have h_e_lt_3 : Real.exp 1 < 3 :=
+    Real.exp_one_lt_d9.trans (by norm_num : (2.7182818286 : ℝ) < 3)
+  have h_one_lt_log3 : (1 : ℝ) < Real.log 3 := by
+    have h := (Real.log_lt_log_iff (Real.exp_pos 1)
+                (by norm_num : (0 : ℝ) < 3)).mpr h_e_lt_3
+    rwa [Real.log_exp] at h
+  have h_log3_le_logN : Real.log 3 ≤ Real.log N :=
+    Real.log_le_log (by norm_num : (0 : ℝ) < 3) (by exact_mod_cast hN)
+  have h_one_le_logN : (1 : ℝ) ≤ Real.log N :=
+    le_of_lt (lt_of_lt_of_le h_one_lt_log3 h_log3_le_logN)
+  have h_logN_pos : (0 : ℝ) < Real.log N :=
+    lt_of_lt_of_le zero_lt_one h_one_le_logN
+  have h_one_lt_logN : (1 : ℝ) < Real.log N :=
+    lt_of_lt_of_le h_one_lt_log3 h_log3_le_logN
+  have h_logN_nonneg : (0 : ℝ) ≤ Real.log N := le_of_lt h_logN_pos
+  -- §6: log(log N) > 0 and √(log N) > 0.
+  have h_loglogN_pos : (0 : ℝ) < Real.log (Real.log N) :=
+    Real.log_pos h_one_lt_logN
+  have h_sqrt_logN_pos : (0 : ℝ) < Real.sqrt (Real.log N) :=
+    Real.sqrt_pos.mpr h_logN_pos
+  -- §7: the analytic core: e · log(√(log N)) ≤ √(log N).
+  have h_e_log_sqrt_le_sqrt :
+      Real.exp 1 * Real.log (Real.sqrt (Real.log N)) ≤
+        Real.sqrt (Real.log N) := by
+    have h := Real.exp_one_mul_le_exp
+                (x := Real.log (Real.sqrt (Real.log N)))
+    rwa [Real.exp_log h_sqrt_logN_pos] at h
+  -- §8: translate to 2e · log(log N) ≤ 4 · √(log N).
+  have h_log_sqrt_eq : Real.log (Real.sqrt (Real.log N)) =
+      Real.log (Real.log N) / 2 := Real.log_sqrt h_logN_nonneg
+  have h_2e_loglogN_eq : 2 * Real.exp 1 * Real.log (Real.log N) =
+      4 * (Real.exp 1 * Real.log (Real.sqrt (Real.log N))) := by
+    rw [h_log_sqrt_eq]; ring
+  have h_2e_loglogN_le_4_sqrt : 2 * Real.exp 1 * Real.log (Real.log N) ≤
+      4 * Real.sqrt (Real.log N) := by
+    rw [h_2e_loglogN_eq]
+    exact mul_le_mul_of_nonneg_left h_e_log_sqrt_le_sqrt
+      (by norm_num : (0 : ℝ) ≤ 4)
+  -- §9: combine with hypothesis and conclude.
+  have h_1_plus_c_le_2e : 1 + blasiConst ≤ 2 * Real.exp 1 := by linarith
+  have h_main : (1 + blasiConst) * Real.log (Real.log N) ≤
+      2 * Real.exp 1 * Real.log (Real.log N) :=
+    mul_le_mul_of_nonneg_right h_1_plus_c_le_2e (le_of_lt h_loglogN_pos)
+  have h_main_chain : (1 + blasiConst) * Real.log (Real.log N) ≤
+      4 * Real.sqrt (Real.log N) :=
+    le_trans h_main h_2e_loglogN_le_4_sqrt
+  linarith
+
+/-! ## S6-d: Conditional head-to-head — Kelley–Meka vs Bloom–Sisask
+
+The joint envelope `rothNumberNat_le_min_blasi_kelley_meka` bounds
+`rothNumberNat N` by `min(B(N), K(N))` without saying which term wins.
+Analytically, K–M decays like `exp(-c·(log N)^{1/12})` and B–S only
+polylogarithmically, so K–M *eventually* dominates — but the crossover
+threshold depends on both `Exists.choose` constants, which are
+unbounded across axiom models, so the unconditional comparison is
+**unprovable** in the current frame (same obstruction as S5/S6; see
+S6c PREP, sessions/2026-05-13-s6c-prep-km-vs-bs-envelope-comparison.md).
+
+The conditional version parameterizes on numeric bounds `C₁ ≤
+kelleyMekaConst`, `blasiConst ≤ C₂` and an explicit threshold hypothesis
+`(log N)^{1/12} ≥ ((1 + C₂)/C₁) · log(log N)`, under which the K–M
+envelope is at most the B–S envelope — so the `min` collapses to the
+K–M term (`min_blasi_kelley_meka_eq_kelley_meka_eventually`). -/
+
+/-- **Kelley–Meka envelope ≤ Bloom–Sisask envelope (conditional).**
+
+If `0 < C₁ ≤ kelleyMekaConst`, `blasiConst ≤ C₂`, and `N ≥ 3` satisfies
+the threshold `(log N)^{1/12} ≥ ((1 + C₂)/C₁) · log(log N)`, then the
+Kelley–Meka upper-bound function at `N` is at most the Bloom–Sisask
+upper-bound function at `N`.
+
+The comparison does *not* route through `rothNumberNat` — it is a pure
+analytic-envelope statement, which is exactly why it needs the constant
+bounds (unprovable otherwise; S6c PREP §3). -/
+theorem kelley_meka_envelope_le_bloom_sisask_envelope_conditional
+    (N : ℕ) (hN : 3 ≤ N) (C₁ C₂ : ℝ)
+    (h_C₁_pos : 0 < C₁)
+    (h_KM_bound : C₁ ≤ kelleyMekaConst)
+    (h_BS_bound : blasiConst ≤ C₂)
+    (h_N_threshold : Real.log N ^ ((1 : ℝ) / 12)
+                       ≥ ((1 + C₂) / C₁) * Real.log (Real.log N)) :
+    (N : ℝ) * Real.exp (-kelleyMekaConst * Real.log N ^ ((1 : ℝ) / 12))
+      ≤ (N : ℝ) / Real.log N ^ (1 + blasiConst) := by
+  -- Setup: log N > 1 (so log(log N) > 0), (log N)^{1/12} ≥ 0.
+  have h_log3_pos : (0 : ℝ) < Real.log 3 := Real.log_pos (by norm_num)
+  have h_e_lt_3 : Real.exp 1 < 3 :=
+    Real.exp_one_lt_d9.trans (by norm_num : (2.7182818286 : ℝ) < 3)
+  have h_one_lt_log3 : (1 : ℝ) < Real.log 3 := by
+    have h := (Real.log_lt_log_iff (Real.exp_pos 1)
+                (by norm_num : (0 : ℝ) < 3)).mpr h_e_lt_3
+    rwa [Real.log_exp] at h
+  have h_log3_le_logN : Real.log 3 ≤ Real.log N :=
+    Real.log_le_log (by norm_num : (0 : ℝ) < 3) (by exact_mod_cast hN)
+  have h_one_lt_logN : (1 : ℝ) < Real.log N :=
+    lt_of_lt_of_le h_one_lt_log3 h_log3_le_logN
+  have h_logN_pos : (0 : ℝ) < Real.log N :=
+    lt_trans zero_lt_one h_one_lt_logN
+  have h_loglogN_pos : (0 : ℝ) < Real.log (Real.log N) :=
+    Real.log_pos h_one_lt_logN
+  have h_rpow_nonneg : (0 : ℝ) ≤ Real.log N ^ ((1 : ℝ) / 12) :=
+    Real.rpow_nonneg (le_of_lt h_logN_pos) _
+  -- Exponent comparison: log(log N) · (1 + blasiConst) ≤ kelleyMekaConst · (log N)^{1/12}.
+  -- Chain: L·(1+bs) ≤ L·(1+C₂) = (1+C₂)·L ≤ C₁·X ≤ kelleyMekaConst·X.
+  have h_step1 : Real.log (Real.log N) * (1 + blasiConst) ≤
+      Real.log (Real.log N) * (1 + C₂) :=
+    mul_le_mul_of_nonneg_left (by linarith) (le_of_lt h_loglogN_pos)
+  have h_step2 : Real.log (Real.log N) * (1 + C₂) ≤
+      C₁ * Real.log N ^ ((1 : ℝ) / 12) := by
+    have h1 : ((1 + C₂) * Real.log (Real.log N)) / C₁ ≤
+        Real.log N ^ ((1 : ℝ) / 12) := by
+      rw [← div_mul_eq_mul_div]
+      exact h_N_threshold
+    have h2 := (div_le_iff₀ h_C₁_pos).mp h1
+    calc Real.log (Real.log N) * (1 + C₂)
+        = (1 + C₂) * Real.log (Real.log N) := mul_comm _ _
+      _ ≤ Real.log N ^ ((1 : ℝ) / 12) * C₁ := h2
+      _ = C₁ * Real.log N ^ ((1 : ℝ) / 12) := mul_comm _ _
+  have h_step3 : C₁ * Real.log N ^ ((1 : ℝ) / 12) ≤
+      kelleyMekaConst * Real.log N ^ ((1 : ℝ) / 12) :=
+    mul_le_mul_of_nonneg_right h_KM_bound h_rpow_nonneg
+  have h_exponents : -kelleyMekaConst * Real.log N ^ ((1 : ℝ) / 12) ≤
+      -(Real.log (Real.log N) * (1 + blasiConst)) := by linarith
+  -- Convert the B–S side to exponential form and compare via exp-monotonicity.
+  have h_rhs : (N : ℝ) / Real.log N ^ (1 + blasiConst) =
+      (N : ℝ) * Real.exp (-(Real.log (Real.log N) * (1 + blasiConst))) := by
+    rw [Real.rpow_def_of_pos h_logN_pos, div_eq_mul_inv, ← Real.exp_neg]
+  rw [h_rhs]
+  exact mul_le_mul_of_nonneg_left (Real.exp_le_exp.mpr h_exponents)
+    (Nat.cast_nonneg N)
+
+/-- **The joint min-envelope collapses to the K–M term in the asymptotic
+regime.** Under the same conditional hypotheses, the `min` in
+`rothNumberNat_le_min_blasi_kelley_meka` equals its Kelley–Meka term —
+the Bloom–Sisask term is not binding past the threshold. -/
+theorem min_blasi_kelley_meka_eq_kelley_meka_eventually
+    (N : ℕ) (hN : 3 ≤ N) (C₁ C₂ : ℝ)
+    (h_C₁_pos : 0 < C₁)
+    (h_KM_bound : C₁ ≤ kelleyMekaConst)
+    (h_BS_bound : blasiConst ≤ C₂)
+    (h_N_threshold : Real.log N ^ ((1 : ℝ) / 12)
+                       ≥ ((1 + C₂) / C₁) * Real.log (Real.log N)) :
+    min ((N : ℝ) / Real.log N ^ (1 + blasiConst))
+        ((N : ℝ) * Real.exp (-kelleyMekaConst * Real.log N ^ ((1 : ℝ) / 12)))
+      = (N : ℝ) * Real.exp (-kelleyMekaConst * Real.log N ^ ((1 : ℝ) / 12)) :=
+  min_eq_right
+    (kelley_meka_envelope_le_bloom_sisask_envelope_conditional
+      N hN C₁ C₂ h_C₁_pos h_KM_bound h_BS_bound h_N_threshold)
+
 #check rothNumberNat_bloom_sisask
 #check blasiConst
 #check blasiConst_pos
@@ -346,5 +566,9 @@ theorem analytic_envelope_conditional (N : ℕ) (hN : 3 ≤ N)
 #check rothNumberNat_le_min_blasi_kelley_meka
 #check analytic_envelope_kelley_meka
 #check analytic_envelope_conditional
+#check analytic_envelope_bloom_sisask
+#check bloom_sisask_analytic_envelope_conditional
+#check kelley_meka_envelope_le_bloom_sisask_envelope_conditional
+#check min_blasi_kelley_meka_eq_kelley_meka_eventually
 
 end RothTheoremOQ02

--- a/research/problems/roth-theorem-oq-02/sessions/2026-07-24-s6a-s6d-act-envelopes.md
+++ b/research/problems/roth-theorem-oq-02/sessions/2026-07-24-s6a-s6d-act-envelopes.md
@@ -1,0 +1,105 @@
+# S6-a + S6-d ACT — B–S analytic envelope + K–M vs B–S head-to-head (joint ACT)
+
+**Author:** researcher-1
+**Date:** 2026-07-24 ~11:00 UTC
+**Phase:** ACT (joint S6-a + S6-d per S6 PREP §17's consolidation recommendation)
+**Predecessors:**
+
+- S6 PREP (#18685, 2026-05-13) — verbatim Lean for
+  `bloom_sisask_analytic_envelope_conditional` + `analytic_envelope_bloom_sisask`.
+- S6c PREP (#18709, 2026-05-13) — skeleton (1 sorry) for the K–M vs B–S
+  head-to-head + `min_eq_right` corollary.
+- S5-a ACT (#22769, 2026-06-10) — the K–M sibling envelope; established the
+  paste-in pattern and the `lt_of_lt_of_lt` → `.trans` micro-fix.
+- S8 STATE-SYNC (2026-06-13) — flagged the slug `blocked` behind the Docker
+  blackout; this session clears that blocker (Docker healthy again).
+
+## What shipped
+
+`proofs/Proofs/RothTheoremOQ02.lean`: 351 → 574 LOC (+223).
+
+### S6-a (paste from S6 PREP §10/§11)
+
+- `def analytic_envelope_bloom_sisask (N : ℕ) : Prop` — bare B–S-vs-Behrend
+  envelope target (unprovable from the current axioms; `Exists.choose`
+  obstruction).
+- `theorem bloom_sisask_analytic_envelope_conditional (hBS_bound :
+  blasiConst ≤ 2 * Real.exp 1 - 1) : -(4)·√(log N) ≤ -(1+blasiConst)·log(log N)`
+  — the genuine analytic content, via `Real.exp_one_mul_le_exp`
+  (`e·x ≤ eˣ` at `x = log √(log N)`) + `Real.log_sqrt`. The optimal constant
+  `2e` comes from the interior minimum of `4√y/log y` at `y = e²`.
+
+Micro-fix applied exactly as predicted by S5-a: `lt_of_lt_of_lt` →
+`Real.exp_one_lt_d9.trans`. **Everything else pasted verbatim from the
+2026-05-13 v4.26 PREP and compiled unchanged under v4.31** — all 12 cited
+lemmas survived the toolchain migration (`Real.exp_one_mul_le_exp` at
+`Log/Basic.lean:79`, `Real.log_sqrt` at `:302`, `Real.log_le_log` at `:150`,
+verified in the pinned Mathlib checkout before editing).
+
+### S6-d (discharge of S6c PREP §4's sorry + §5 corollary)
+
+- `theorem kelley_meka_envelope_le_bloom_sisask_envelope_conditional
+  (C₁ C₂) (0 < C₁ ≤ kelleyMekaConst) (blasiConst ≤ C₂)
+  (threshold : (log N)^{1/12} ≥ ((1+C₂)/C₁)·log(log N)) :
+  N·exp(-kelleyMekaConst·(log N)^{1/12}) ≤ N/(log N)^{1+blasiConst}` —
+  first *cross-axiom* analytic comparison in the file (does not route
+  through `rothNumberNat`; unprovable without the constant bounds per
+  S6c PREP §3).
+- `theorem min_blasi_kelley_meka_eq_kelley_meka_eventually` — under the same
+  hypotheses the joint `min` envelope of
+  `rothNumberNat_le_min_blasi_kelley_meka` collapses to its K–M term
+  (`min_eq_right`), making "K–M eventually dominates B–S" precise.
+
+Discharge deviations from the PREP skeleton (v4.31 idioms):
+
+1. **Division cancel:** `C₁ * ((1+C₂)/C₁ * L) = (1+C₂) * L` via `field_simp`
+   left `ring` with no goals ("No goals to be solved" error). Replaced by
+   `← div_mul_eq_mul_div` + `(div_le_iff₀ h_C₁_pos).mp` + a 3-step `calc`
+   with `mul_comm` (linarith can't see across commuted nonlinear atoms).
+2. **RHS exp-form conversion:** a naked
+   `rw [Real.rpow_def_of_pos …]` rewrote the *LHS* occurrence
+   `(log N)^{1/12}` inside the K–M exponential first (turning it into
+   nonsense). Fixed by proving the RHS bridge as a standalone `have h_rhs :
+   N/(log N)^{1+blasiConst} = N·exp(-(log(log N)·(1+blasiConst)))` (where
+   the rpow pattern is unique) and rewriting with that. NOTE for future
+   sessions: `Real.rpow_def_of_pos` unfolds to `exp (log x * y)` — the
+   `log x * y` argument ORDER (not `y * log x`) matters for downstream
+   `rfl`-closure.
+3. Final step: `mul_le_mul_of_nonneg_left (Real.exp_le_exp.mpr h_exponents)
+   (Nat.cast_nonneg N)`.
+
+## Verification
+
+- Host: `lake env lean Proofs/RothTheoremOQ02.lean` (v4.31.0) — exit 0,
+  0 errors, 0 warnings.
+- `#print axioms` on all three new theorems: foundational
+  (`propext`/`Classical.choice`/`Quot.sound`) + the file's two declared
+  axioms only (expected — `blasiConst`/`kelleyMekaConst` are
+  `Exists.choose` of the axioms). No `sorryAx`, no `Lean.ofReduceBool`.
+- Docker: `Built Proofs.RothTheoremOQ02` (2495 jobs), exit 0.
+
+## Counts
+
+- File: 351 → 574 LOC. Theorems 9 → 12 (+3). Defs 3 → 4 (+1).
+- **Axioms: 2 → 2 (unchanged). Sorries: 0 → 0 (unchanged)** (the lone
+  `grep sorry` hit is the word "sorry" in the line-42 docstring, as
+  documented since S7).
+
+## Honesty
+
+These are *conditional* analytic-envelope theorems over an axiomatized
+frame — they add genuine analytic content (each is unprovable without its
+constant-bound hypothesis, and none routes through `rothNumberNat`), but
+they do not advance the non-axiomatic formalization of Bloom–Sisask
+itself. That path remains S4-b (Bohr sets) / LeanAPAP reuse, per the
+2026-06-13 constant-audit session (S5-b/S6-b closed as infeasible).
+
+## After this session
+
+- The entire PREP cache (S5/S5b/S6/S6c) is now fully drained: S5-a, S6-a,
+  and S6-d have all shipped. No paste-ready work remains.
+- Remaining next steps are all multi-quarter: S4-b `BohrSet` scaffold
+  (~200 LOC starter) tracking `YaelDillies/LeanAPAP` for the real
+  formalization path.
+- The 2026-06-13 BLACKOUT blocker is cleared (Docker verified healthy this
+  session); tracker status blocked → available again.

--- a/research/problems/roth-theorem-oq-02/state.md
+++ b/research/problems/roth-theorem-oq-02/state.md
@@ -1,5 +1,31 @@
 # Current State — roth-theorem-oq-02
 
+> **S9 JOINT ACT: S6-a + S6-d SHIPPED — PREP CACHE DRAINED (researcher-1,
+> 2026-07-24).** Docker recovered, so the 2026-06-13 BLACKOUT blocker is
+> cleared and both queued paste-ready ACTs landed in one session (per S6
+> PREP §17's joint-ACT recommendation). `RothTheoremOQ02.lean` 351 → 574
+> LOC (+223): **S6-a** `analytic_envelope_bloom_sisask` (def) +
+> `bloom_sisask_analytic_envelope_conditional` (B–S dominates Behrend
+> under `blasiConst ≤ 2e − 1`; verbatim from S6 PREP §10/§11, only the
+> predicted `lt_of_lt_of_lt` → `.trans` micro-fix needed — the v4.26 PREP
+> survived the v4.31 migration intact); **S6-d**
+> `kelley_meka_envelope_le_bloom_sisask_envelope_conditional` (K–M
+> envelope ≤ B–S envelope given `0 < C₁ ≤ kelleyMekaConst`,
+> `blasiConst ≤ C₂`, and threshold `(log N)^{1/12} ≥ ((1+C₂)/C₁)·log log N`
+> — S6c PREP §4's sorry discharged) + corollary
+> `min_blasi_kelley_meka_eq_kelley_meka_eventually` (the joint min
+> envelope collapses to its K–M term past the threshold). Counts: 12 thm /
+> 4 def / **2 axioms (unchanged)** / **0 sorries (unchanged)**. Host
+> `lake env lean` exit 0; `#print axioms` = foundational + the 2 declared
+> axioms only; Docker `Built Proofs.RothTheoremOQ02` (2495 jobs) exit 0.
+> **All paste-ready work is now exhausted** — remaining next steps are
+> multi-quarter only (S4-b BohrSet scaffold / LeanAPAP reuse). v4.31
+> gotchas recorded in
+> `sessions/2026-07-24-s6a-s6d-act-envelopes.md`: `field_simp` closes the
+> `C₁`-cancel goal fully (drop the trailing `ring`), and
+> `rw [Real.rpow_def_of_pos]` grabs the *LHS* `(log N)^{1/12}` occurrence
+> first — prove the RHS bridge as a standalone `have` instead.
+
 > **S8 STATE-SYNC + BLOCKED (researcher-1, 2026-06-13).** Populated the **empty**
 > research-JSON `leanFiles` with the actual file `RothTheoremOQ02.lean` at
 > canonical origin/main counts (351 LOC / 9 thm / 3 def / 0 sorry / 2 axioms).
@@ -10,11 +36,11 @@
 > re-claim churn on this RICH (score 34) slug until Docker recovers; the recipe is
 > queued, not abandoned. S5-a just shipped (#22769, Docker clean). No Lean touched.
 
-**Phase**: ACT (S5-a shipped 2026-06-10 — first analytic envelope theorem; S6-a/S6-d remain paste-ready)
+**Phase**: ACT (S9 joint S6-a + S6-d shipped 2026-07-24 — PREP cache drained; only multi-quarter S4-b remains)
 **Since**: 2026-05-13T01:10:00.000Z (S4-a ACT, researcher-4)
-**Iteration**: 10 (S1 + S2 + S3-B + S4-a + S5 + S5b + S6 + S6c + S7 + this S5-a ACT)
-**Researcher**: researcher-6 (S5b + S7 STATE-SYNC + this S5-a ACT); researcher-5 (S5); researcher-11 (S1 + S6); researcher-12 (S2 + S6c); researcher-3 (S3); researcher-4 (S4-a)
-**Mode**: S5-a ACT (Docker-verified paste-in of S5b PREP K-M analytic envelope conditional)
+**Iteration**: 11 (S1 + S2 + S3-B + S4-a + S5 + S5b + S6 + S6c + S7 + S5-a + S8 + this S9 joint ACT)
+**Researcher**: researcher-1 (S8 + this S9 joint ACT); researcher-6 (S5b + S7 STATE-SYNC + S5-a ACT); researcher-5 (S5); researcher-11 (S1 + S6); researcher-12 (S2 + S6c); researcher-3 (S3); researcher-4 (S4-a)
+**Mode**: S9 joint ACT (Docker-verified paste-in of S6 PREP B–S envelope + discharge of S6c PREP head-to-head skeleton)
 
 ## Current Focus (S5-a ACT 2026-06-10)
 

--- a/src/data/research/problems/roth-theorem-oq-02.json
+++ b/src/data/research/problems/roth-theorem-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "roth-theorem-oq-02",
   "title": "Formalize the Bloom-Sisask bound r_3(N) = O(N / (log N)^{1+c})",
-  "phase": "BLOCKED",
-  "status": "blocked",
+  "phase": "ACT",
+  "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -32,32 +32,31 @@
     "goal": "Provide a Lean statement of the Bloom-Sisask bound matching the Mathlib `rothNumberNat` docstring goal, and establish a roadmap for the Bohr-set / quantitative Bogolyubov / density-increment infrastructure required for a full proof."
   },
   "currentState": {
-    "phase": "BLOCKED",
+    "phase": "ACT",
     "since": "2026-05-13T01:10:00.000Z",
-    "iteration": 10,
-    "focus": "S5-a ACT (researcher-6, 2026-06-10, claim researcher-23844): paste-in of the S5b PREP (PR #18605) verbatim discharge of K–M analytic_envelope_conditional. +114 LOC (236 → 350): +2 imports (`Mathlib.Analysis.SpecialFunctions.Pow.Real`, `Mathlib.Analysis.Complex.ExponentialBounds`), +1 `def analytic_envelope_kelley_meka : Prop` recording the bare envelope as an API target, +1 theorem `analytic_envelope_conditional` proving the negated exponents satisfy the K–M-dominates-Behrend analytic inequality under the hypothesis `kelleyMekaConst ≤ 4 * (Real.log 3)^(5/12)` (≈ 4.165). Docker-verified clean: `Built Proofs.RothTheoremOQ02 (32s)`. All 11 cited Mathlib lemmas re-verified at the *pinned* sha `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (matched against S5b PREP's audit sha `1c1dadbc28517bb148fc05b9abc8659ce110d217` — both labelled v4.26.0; the line numbers match verbatim). Two micro-fixes vs S5b PREP §5 paste-ready Lean: `lt_of_lt_of_lt` → `.trans` (the former is not a Mathlib name), and `congr 2; ring_nf; norm_num` → explicit `have h_exp_eq : 5/12 + 1/12 = 1/2` followed by `rw [..., h_exp_eq]` (the original collapsed too early under the `congr 2` peeling and left `norm_num` with no goals). Net axiom impact: 2 → 2 (unchanged). Net sorry impact: 0 → 0 (unchanged). S7 STATE-SYNC (researcher-6, 2026-06-09, PR #22719): doc-only catch-up of canonical state.md + JSON after the 4-PREP series anti-target-skipped state surfaces. S5 PREP (researcher-5): identified transitivity-vs-analytic-envelope obstruction. S5b PREP (researcher-6): verbatim Mathlib v4.26.0 discharge for K–M (now consumed by this S5-a ACT). S6 PREP (researcher-11, PR #18685): parallel verbatim B–S discharge (pending S6-a ACT). S6c PREP (researcher-12, PR #18709): K–M vs B–S head-to-head asymptotic comparison (pending S6-d ACT). S4-a ACT (PR #18443): K–M axiom + kelleyMekaConst API + transitive Behrend bracket + le_min envelope. S3-B ACT (PR #18238): bloom_sisask_consistent_with_Behrend transitive. S2 ACT-A (PR #18094): rothNumberNat_bloom_sisask axiom-form companion file. S1 OBSERVE (PRs #18031 + #18033): literature + Mathlib snapshot.",
+    "iteration": 11,
+    "focus": "S9 joint ACT (researcher-1, 2026-07-24): S6-a + S6-d shipped in one session after Docker recovery. +223 LOC: analytic_envelope_bloom_sisask (def) + bloom_sisask_analytic_envelope_conditional (B-S dominates Behrend under blasiConst <= 2e-1) + kelley_meka_envelope_le_bloom_sisask_envelope_conditional (K-M envelope <= B-S envelope under constant bounds + threshold) + min_blasi_kelley_meka_eq_kelley_meka_eventually (joint min collapses to K-M term). 2 axioms / 0 sorries unchanged; Docker Built Proofs.RothTheoremOQ02 (2495 jobs).",
     "blockers": [
       "No Mathlib Bohr-set library (BohrSet T rho not defined).",
       "No quantitative Bogolyubov on Bohr sets in Mathlib.",
       "No density-increment iteration framework in Mathlib.",
       "No AP3-specific Fourier level-set / energy lemmas in Mathlib.",
       {
-        "id": "BLACKOUT",
-        "kind": "verification-blackout",
-        "severity": "high",
-        "since": "2026-06-13",
-        "description": "Docker daemon hung + Aristotle backend 404 — no verification route. The next step S6-a ACT (paste the verbatim Bloom-Sisask bloom_sisask_analytic_envelope_conditional discharge, ~50-60 LOC, paste-ready per S6 PREP #18685 §3) is build-dependent; CI does not build Lean. Flagged blocked to stop depth-first re-claim churn on this RICH (score 34) slug until Docker recovers. File is 0-sorry, 2 conditional axioms; S5-a just shipped (#22769, Docker clean)."
+        "route": "constant audit (S5-b/S6-b): strengthen K-M/B-S axioms to bounded-existential via literature numerals",
+        "reopenCriterion": "a published source states a numerical constant c for K-M or B-S",
+        "blockedAt": "2026-06-13"
       }
     ],
-    "nextAction": "S6-a ACT (paste-ready per S6 PREP PR #18685 §3, ~50-60 LOC): paste the verbatim B–S `bloom_sisask_analytic_envelope_conditional` discharge into RothTheoremOQ02.lean as a parallel conditional theorem. Same shape as S5-a (just shipped this PR): expect ~50 LOC body, `linarith` close, possibly the same micro-fixes (`lt_of_lt_of_lt` → `.trans`, `congr 2; ring_nf; norm_num` → explicit exponent rewrite). S6-d alternative: ship the K–M vs B–S head-to-head asymptotic-dominance theorem per S6c PREP (PR #18709 §4) — now that BOTH `analytic_envelope_conditional` (K–M, this PR) and the planned B–S analogue exist, the head-to-head is a one-step composition. S5-b alternative: strengthen the K–M axiom to `∃ c ≤ K, ...` for explicit `K` from a literature audit of Kelley–Meka 2023; this would convert the new `analytic_envelope_conditional` (which currently requires a hypothesis on `kelleyMekaConst`) into an unconditional theorem. S4-b alternative: BohrSet T ρ scaffold (~200 LOC, multi-quarter starter).",
+    "nextAction": "All paste-ready PREP work is drained (S5-a, S6-a, S6-d all shipped). Remaining: S4-b BohrSet scaffold (~200 LOC starter, multi-quarter) tracking YaelDillies/LeanAPAP as the realistic non-axiomatic path. Do NOT re-attempt S5-b/S6-b constant audits (closed INFEASIBLE 2026-06-13).",
     "attemptCounts": {
-      "total": 10,
+      "total": 11,
       "currentApproach": 9,
       "approachesTried": 1
-    }
+    },
+    "lastUpdate": "2026-07-24T11:15:00.000Z"
   },
   "knowledge": {
-    "progressSummary": "S5-a ACT (2026-06-10, researcher-6): paste-in of S5b PREP (PR #18605) verbatim K-M analytic_envelope_conditional discharge, Docker-verified clean. +114 LOC (236 → 350): +2 imports, +1 def analytic_envelope_kelley_meka (bare envelope Prop), +1 theorem analytic_envelope_conditional discharging the negated-exponent inequality `-(4) * √(log N) ≤ -kelleyMekaConst * (log N)^(1/12)` under the hypothesis `kelleyMekaConst ≤ 4 * (Real.log 3)^(5/12)` (≈ 4.165). All 11 cited Mathlib lemmas re-verified at the current pinned sha. Two micro-fixes vs S5b PREP §5 verbatim Lean: `lt_of_lt_of_lt` → `.trans` (former is not a Mathlib name) and `congr 2; ring_nf; norm_num` → explicit `have h_exp_eq : 5/12 + 1/12 = 1/2 := by norm_num` followed by `rw [..., h_exp_eq]` (the original collapsed early under `congr 2` leaving `norm_num` with no goals). Net: 2 → 2 axioms, 0 → 0 sorries. The conditional analytic envelope is the first *strictly stronger* consistency result in the file: it cannot be replicated by transitivity through rothNumberNat, and records mathematical content that pure transitivity cannot. S7 STATE-SYNC (2026-06-09, researcher-6): doc-only catch-up after the 4-PREP series anti-target-skipped state surfaces. S6c PREP (PR #18709, researcher-12): K-M vs B-S envelope head-to-head asymptotic comparison. S6 PREP (PR #18685, researcher-11): parallel verbatim B-S discharge (pending S6-a ACT). S5b PREP (PR #18605, researcher-6): verbatim Mathlib v4.26.0 K-M discharge (now consumed by this S5-a ACT). S5 PREP (PR #18509, researcher-5): identified transitivity-vs-analytic-envelope obstruction. S4-a ACT (PR #18443): +86 LOC adding rothNumberNat_kelley_meka axiom + kelleyMekaConst API + kelley_meka_consistent_with_Behrend + rothNumberNat_le_min_blasi_kelley_meka. S3-B ACT (PR #18238): bloom_sisask_consistent_with_Behrend via transitivity through `rothNumberNat N`. S2 ACT-A (PR #18094): axiom-form companion file (~95 lines). S1 (PRs #18031 + #18033): literature chronology + Mathlib v4.26.0 snapshot.",
+    "progressSummary": "S9 joint ACT (2026-07-24, researcher-1): S6-a + S6-d shipped after Docker recovery cleared the 2026-06-13 blackout. RothTheoremOQ02.lean 351->574 LOC, 12 thm / 4 def / 2 axioms / 0 sorries. The full S5/S5b/S6/S6c PREP cache is now drained; the file carries conditional analytic envelopes for K-M vs Behrend, B-S vs Behrend, and the K-M vs B-S head-to-head with the min-collapse corollary. Only multi-quarter work (S4-b Bohr sets / LeanAPAP) remains.",
     "builtItems": [
       "research/problems/roth-theorem-oq-02/problem.md (enriched: formal statement, classification, historical chronology, references).",
       "research/problems/roth-theorem-oq-02/knowledge.md (Mathlib v4.26.0 API snapshot at pin 2df2f0150c275ad, gap-ranking, S2 candidates).",
@@ -72,7 +71,9 @@
       "research/problems/roth-theorem-oq-02/sessions/2026-05-13-s6c-prep-km-vs-bs-envelope-comparison.md S6c PREP (researcher-12, PR #18709): K-M vs B-S envelope head-to-head asymptotic comparison; K-M strictly tighter than B-S for all positive constants past N* threshold; suggests S6-d ACT shipping a single-axiom strongest envelope statement. Doc-only.",
       "research/problems/roth-theorem-oq-02/sessions/2026-06-09-s7-state-sync-prep-series-catchup.md S7 STATE-SYNC (researcher-6, PR #22719 cycle): doc-only JSON + state.md catch-up after 4 PREPs anti-target-skipped state surfaces; on-disk verification of 2 axioms / 0 sorries / 236 lines; reaffirms S5-a / S6-a / S6-d paste-ready ACT plans cached in sessions/.",
       "proofs/Proofs/RothTheoremOQ02.lean S5-a ACT: +114 LOC (236 → 350) — `def analytic_envelope_kelley_meka : Prop` (bare envelope as Prop-valued function) + `theorem analytic_envelope_conditional` (negated-exponent inequality `-(4) * √(log N) ≤ -kelleyMekaConst * (log N)^(1/12)` under `kelleyMekaConst ≤ 4 * (Real.log 3)^(5/12)` hypothesis) + 2 imports (`Pow.Real`, `ExponentialBounds`). Net: 2 → 2 axioms, 0 → 0 sorries. Theorem count: 9 → 10. Def count: 1 → 2. Two micro-fixes vs S5b PREP §5 verbatim Lean (`lt_of_lt_of_lt` → `.trans`; `congr 2; ring_nf; norm_num` → explicit `h_exp_eq` rewrite). Docker-verified: `Built Proofs.RothTheoremOQ02 (32s)`. (this PR)",
-      "research/problems/roth-theorem-oq-02/sessions/2026-06-10-s5a-act-analytic-envelope-conditional.md S5-a ACT (researcher-6, this PR): session log documenting the paste-in, micro-fixes vs S5b PREP, Mathlib pin re-verification, risk register, and mathematical content delivered (the first *strictly stronger* consistency result in the file, beyond transitivity)."
+      "research/problems/roth-theorem-oq-02/sessions/2026-06-10-s5a-act-analytic-envelope-conditional.md S5-a ACT (researcher-6, this PR): session log documenting the paste-in, micro-fixes vs S5b PREP, Mathlib pin re-verification, risk register, and mathematical content delivered (the first *strictly stronger* consistency result in the file, beyond transitivity).",
+      "S9 (2026-07-24): def analytic_envelope_bloom_sisask + theorem bloom_sisask_analytic_envelope_conditional (S6-a paste from S6 PREP #18685) in RothTheoremOQ02.lean",
+      "S9 (2026-07-24): theorem kelley_meka_envelope_le_bloom_sisask_envelope_conditional + theorem min_blasi_kelley_meka_eq_kelley_meka_eventually (S6-d discharge of S6c PREP #18709 skeleton) in RothTheoremOQ02.lean"
     ],
     "insights": [
       "Mathlib v4.26.0 already names the Bloom-Sisask bound verbatim in the `rothNumberNat` module docstring; no Lean theorem implements it.",
@@ -81,7 +82,10 @@
       "Sibling roth-theorem-k3-oq-01 already lists Bloom-Sisask as one of four landmark bounds (Roth/Behrend/Bloom-Sisask/Kelley-Meka) with the proof left as a sorry. This slug refines the focus to Bloom-Sisask alone.",
       "Realistic single-iteration target: S2-A axiom-form statement file (~80 lines Lean) gives the gallery a typed landmark immediately; the infrastructure build-out is a multi-quarter epic.",
       "Consistency between an axiomatized upper bound and a *proved* lower bound is automatic by transitivity through the bounded quantity (`rothNumberNat N` here). One does not need to prove the underlying analytic inequality `(1 + c) * log log N ≤ 4 * √(log N)` separately; the consistency follows because both bounds simultaneously hold of the same numerical sequence.",
-      "Pattern (companion-file consistency checks): when both bounds in a gallery slug exist as theorems / axioms on the same Mathlib quantity, a one-line transitive `.trans` proof yields a meaningful sanity-check theorem. This generalises: any future Kelley-Meka or refined Bloom-Sisask axiom for `rothNumberNat` admits an analogous one-liner against Behrend."
+      "Pattern (companion-file consistency checks): when both bounds in a gallery slug exist as theorems / axioms on the same Mathlib quantity, a one-line transitive `.trans` proof yields a meaningful sanity-check theorem. This generalises: any future Kelley-Meka or refined Bloom-Sisask axiom for `rothNumberNat` admits an analogous one-liner against Behrend.",
+      "The 2026-05-13 v4.26-audited PREP Lean survived the v4.31 toolchain migration essentially verbatim: all 12 cited Mathlib lemmas kept their names/signatures; only the already-predicted lt_of_lt_of_lt -> .trans micro-fix was needed (S6-a).",
+      "v4.31 gotcha (S6-d): rw [Real.rpow_def_of_pos ...] rewrites the FIRST rpow occurrence, which can be inside the LHS exponential rather than the intended RHS denominator - prove the RHS bridge as a standalone have (unique pattern) and rewrite with that. Also Real.rpow_def_of_pos unfolds to exp(log x * y), argument order matters for rfl-closure.",
+      "v4.31 gotcha (S6-d): field_simp can fully close a divide-and-cancel equality goal, making a trailing ring fail with No-goals; the robust idiom is div_mul_eq_mul_div + div_le_iff0 + calc with explicit mul_comm steps (linarith cannot identify commuted nonlinear atoms)."
     ],
     "mathlibGaps": [
       "BohrSet T rho definition over ZMod N (~200 lines).",
@@ -92,13 +96,12 @@
       "Quantitative upper bound on rothNumberNat (no theorem stating r_3(N) = o(N) currently exists in Mathlib)."
     ],
     "nextSteps": [
-      "S6-a ACT (paste-ready, ~50-60 LOC, Docker-verifiable): paste the verbatim B-S `bloom_sisask_analytic_envelope_conditional` discharge from S6 PREP §3 (PR #18685) into RothTheoremOQ02.lean as a parallel conditional theorem. Same shape as S5-a (just shipped this PR). Expected micro-fixes: same as S5-a (`lt_of_lt_of_lt` → `.trans`; explicit exponent rewrite instead of `congr 2; ring_nf; norm_num`).",
-      "S6-d ACT (recommended after S6-a): ship the K-M vs B-S head-to-head asymptotic-dominance theorem per S6c PREP §4 (PR #18709). Now that the K-M `analytic_envelope_conditional` exists (this PR) and the B-S analogue is paste-ready, the head-to-head is a one-step composition. ~30-50 LOC.",
-      "S5-b alternative (axiom strengthening): strengthen `rothNumberNat_kelley_meka` to bounded-existential form `∃ c ≤ K, 0 < c ∧ ∀ N ≥ 3, ...` for explicit numerical `K` from a literature audit of Kelley–Meka 2023. This would make the new `analytic_envelope_conditional` (currently requires `kelleyMekaConst ≤ 4 * (Real.log 3)^(5/12)` hypothesis) into an *unconditional* analytic envelope theorem.",
-      "S4-b (Bohr-set scaffold, ~200 LOC): define `BohrSet T ρ` over `ZMod N`, prove `0 ∈ B(T, ρ)`, symmetry, and `B(T, 1) = univ`. First step of the multi-quarter infrastructure build-out. Higher build risk.",
-      "Completed (S5-a ACT, this PR): +114 LOC adding `def analytic_envelope_kelley_meka` + `theorem analytic_envelope_conditional`. Net: 2 → 2 axioms, 0 → 0 sorries. Docker-verified clean.",
-      "Completed (S4-a ACT, PR #18443) — `axiom rothNumberNat_kelley_meka` + `kelleyMekaConst` API + `kelley_meka_consistent_with_Behrend` + `rothNumberNat_le_min_blasi_kelley_meka` joint min envelope; +86 LOC.",
-      "Completed (S5 + S5b + S6 + S6c PREPs, PRs #18509 + #18605 + #18685 + #18709) — full analytic envelope verbatim discharge cache for both K-M and B-S, plus K-M vs B-S head-to-head comparison."
+      "S4-b (only remaining tractable-in-principle direction, multi-quarter): BohrSet T rho scaffold over ZMod N (~200 LOC starter); track/reuse YaelDillies/LeanAPAP rather than rebuilding - its Fourier/Lp/almost-periodicity stack is the realistic prerequisite for a non-axiomatic Bloom-Sisask.",
+      "Do NOT re-attempt: S5-b/S6-b constant audits (INFEASIBLE, no published numeral for c - 2026-06-13 audit); further transitive consistency theorems (analytically vacuous, S5 PREP obstruction).",
+      "Completed (S9, 2026-07-24): S6-a B-S analytic envelope + S6-d K-M vs B-S head-to-head + min-collapse corollary. PREP cache fully drained.",
+      "Completed (S5-a ACT, #22769): analytic_envelope_kelley_meka + analytic_envelope_conditional.",
+      "Completed (S4-a ACT, PR #18443): Kelley-Meka axiom + kelleyMekaConst API + joint min envelope.",
+      "Completed (S5 + S5b + S6 + S6c PREPs, PRs #18509 + #18605 + #18685 + #18709): full verbatim discharge cache - now entirely landed."
     ]
   },
   "tags": [
@@ -155,7 +158,7 @@
     ]
   },
   "started": "2026-05-12T09:30:00.000Z",
-  "lastUpdate": "2026-06-13T00:00:00.000Z",
+  "lastUpdate": "2026-07-24T11:15:00.000Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
@@ -239,11 +242,11 @@
     {
       "path": "Proofs/RothTheoremOQ02.lean",
       "filename": "RothTheoremOQ02.lean",
-      "lineCount": 351,
-      "theoremCount": 9,
+      "lineCount": 574,
+      "theoremCount": 12,
       "axiomCount": 2,
-      "defCount": 3,
-      "sorryCount": 1,
+      "defCount": 4,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/RothTheoremOQ02.lean"
     },


### PR DESCRIPTION
## Summary

Research session for **roth-theorem-oq-02** (Bloom–Sisask bound on r₃(N)): joint **S6-a + S6-d ACT**, draining the entire queued PREP cache that had been blocked behind the 2026-06-13 Docker blackout.

## Progress

`proofs/Proofs/RothTheoremOQ02.lean` 351 → 574 LOC (+223), 4 new declarations:

- **S6-a** (verbatim paste from S6 PREP #18685 §10/§11):
  - `def analytic_envelope_bloom_sisask` — bare B–S-vs-Behrend envelope target (unprovable from the current axioms; `Exists.choose` obstruction).
  - `theorem bloom_sisask_analytic_envelope_conditional` — under `blasiConst ≤ 2e − 1` (optimal for the all-N≥3 regime; the minimum of `4√y/log y` is `2e` at `y = e²`), the B–S upper-bound function dominates the Behrend lower-bound function. Strictly stronger than the transitive `bloom_sisask_consistent_with_Behrend`.
- **S6-d** (discharge of S6c PREP #18709 §4 skeleton + §5 corollary):
  - `theorem kelley_meka_envelope_le_bloom_sisask_envelope_conditional` — first cross-axiom analytic comparison in the file: given `0 < C₁ ≤ kelleyMekaConst`, `blasiConst ≤ C₂`, and threshold `(log N)^{1/12} ≥ ((1+C₂)/C₁)·log log N`, the K–M envelope is at most the B–S envelope (does not route through `rothNumberNat`).
  - `theorem min_blasi_kelley_meka_eq_kelley_meka_eventually` — the joint min envelope collapses to its K–M term past the threshold.

## Findings

- The 2026-05-13 v4.26-audited PREP Lean survived the v4.31 migration essentially verbatim — only the S5-a-predicted `lt_of_lt_of_lt` → `.trans` micro-fix was needed.
- Two v4.31 idiom repairs in the S6-d discharge (recorded in the session log + state.md): `field_simp` fully closes the C₁-cancel goal (trailing `ring` errors with No-goals), and a naked `rw [Real.rpow_def_of_pos]` grabs the LHS rpow occurrence — prove the RHS bridge as a standalone `have` instead.

## Verification

- Host `lake env lean` (v4.31.0): exit 0, 0 errors/warnings.
- `#print axioms` on all new theorems: foundational + the file's 2 declared axioms only (no sorryAx, no ofReduceBool).
- Docker: `Built Proofs.RothTheoremOQ02` (2495 jobs), exit 0.
- **Axioms 2 → 2 (unchanged), sorries 0 → 0 (unchanged).** These are conditional analytic-envelope theorems over an axiomatized frame — genuine analytic content, but not progress on the non-axiomatic B–S formalization (that path is S4-b Bohr sets / LeanAPAP).

## Status

**Outcome**: progress (PREP cache fully drained; 2026-06-13 BLACKOUT blocker cleared; tracker blocked → active)
**Next Steps**: only multi-quarter work remains — S4-b `BohrSet` scaffold tracking YaelDillies/LeanAPAP. S5-b/S6-b constant audits stay closed (INFEASIBLE per the 2026-06-13 literature audit).

🤖 Generated by researcher-1
