### PR TITLE
Research: desargues-theorem-oq-02-oq-02 - self-duality of Desargues formalized explicitly

### DIFF
--- a/proofs/Proofs/DesarguesTheoremOQ02OQ02.lean
+++ b/proofs/Proofs/DesarguesTheoremOQ02OQ02.lean
@@ -1,0 +1,320 @@
+/-
+  # Self-duality of Desargues's theorem, made explicit
+
+  *Question* (`desargues-theorem-oq-02-oq-02`): can we formalize the
+  **self-duality** property of Desargues's theorem explicitly?
+
+  Plane projective duality exchanges points with lines, "lies on" with "passes
+  through", collinearity with concurrency.  Desargues's theorem
+
+  > **(D)** two triangles centrally perspective (the three joins `AA'`, `BB'`,
+  > `CC'` concurrent in a center `O`) are axially perspective (the three
+  > meets `AB·A'B'`, `BC·B'C'`, `CA·C'A'` collinear on an axis `ℓ`)
+
+  dualizes term-by-term to
+
+  > **(D\*)** two triangles axially perspective are centrally perspective
+
+  — exactly the **converse** of (D).  So Desargues's theorem is *its own dual =
+  its own converse*.  This file machine-checks that dictionary at two layers.
+
+  ## Layer 1 — the finite Desargues configuration `10₃` is self-dual
+
+  The ten points and ten lines of a Desargues configuration are the classical
+  `10₃` configuration.  In the standard combinatorial model both points and
+  lines are labelled by the 2-element subsets of a 5-element set, with
+  incidence = **disjointness**; disjointness is symmetric, so the label-
+  preserving swap of points and lines is an incidence-reversing bijection — an
+  explicit **polarity**.  We fix the geometric dictionary
+
+  | node | pair | node | pair |
+  |------|------|------|------|
+  | `O` (center) = pt 0 | `{0,1}` | axis `ℓ` = ln 0 | `{0,1}` |
+  | `A` = pt 1 | `{0,2}` | `la = OAA'` = ln 1 | `{3,4}` |
+  | `B` = pt 2 | `{0,3}` | `lb = OBB'` = ln 2 | `{2,4}` |
+  | `C` = pt 3 | `{0,4}` | `lc = OCC'` = ln 3 | `{2,3}` |
+  | `A'` = pt 4 | `{1,2}` | `ab = ABP` = ln 4 | `{1,4}` |
+  | `B'` = pt 5 | `{1,3}` | `ab' = A'B'P` = ln 5 | `{0,4}` |
+  | `C'` = pt 6 | `{1,4}` | `bc = BCQ` = ln 6 | `{1,2}` |
+  | `P = AB·A'B'` = pt 7 | `{2,3}` | `bc' = B'C'Q` = ln 7 | `{0,2}` |
+  | `Q = BC·B'C'` = pt 8 | `{3,4}` | `ca = CARᵣ` = ln 8 | `{1,3}` |
+  | `R = CA·C'A'` = pt 9 | `{2,4}` | `ca' = C'A'R` = ln 9 | `{0,3}` |
+
+  and verify by kernel `decide`: it is a genuine `10₃` configuration
+  (`inc_point_card_three`, `inc_line_card_three`), all 30 Desargues role
+  incidences hold (`desargues_roles_*`), and the explicit permutation pair
+  `ptToLn`/`lnToPt` is an incidence-reversing bijection
+  (`polarity_reverses`, `lnToPt_ptToLn`, `ptToLn_lnToPt`).  The polarity sends
+  the center `O` to the axis `ℓ`, each vertex to the *opposite* side of the
+  *other* triangle (`A ↦ B'C'`, …), and each perspectivity line to an axis
+  point (`la ↦ Q`, …) — the classical self-duality of the configuration.
+
+  ## Layer 2 — the Desarguesian property dualizes to the converse property
+
+  On a bare incidence structure `[Membership P L]` (the layer at which
+  Mathlib's `Configuration.Dual` operates) we define
+
+  * `PointsCollinear P L p₁ p₂ p₃` / `LinesConcurrent P L l₁ l₂ l₃`,
+  * `IsDesarguesian P L` — the universal incidence form of (D): for every
+    labelled Desargues configuration (27 incidence hypotheses + 12
+    nondegeneracy inequalities), the three axis candidate points are
+    collinear;
+  * `IsConverseDesarguesian P L` — the universal form of (D\*): given the
+    axis (3 incidences) and the same sides/joins data, the three joins are
+    concurrent.
+
+  The nondegeneracy schema is chosen **closed under the polarity** (the 12
+  inequalities `A ≠ A', B ≠ B', C ≠ C', p,q,r pairwise distinct, la,lb,lc
+  pairwise distinct, ab ≠ ab', bc ≠ bc', ca ≠ ca'` map onto each other), so
+  duality is an exact statement swap:
+
+  * `pointsCollinear_dual_iff` / `linesConcurrent_dual_iff` — collinear and
+    concurrent are exchanged by `Configuration.Dual` **definitionally**
+    (`Iff.rfl`);
+  * **`isDesarguesian_dual_iff : IsDesarguesian (Dual L) (Dual P) ↔
+    IsConverseDesarguesian P L`** — the dual plane satisfies Desargues iff
+    the plane satisfies the converse: *Desargues's theorem is its own dual =
+    its own converse*, stated and proved explicitly;
+  * `isConverseDesarguesian_dual_iff` — the mirror statement, obtained from
+    the previous one because `Dual` is definitionally involutive;
+  * `desargues_package_self_dual` — the full package (theorem ∧ converse) is
+    invariant under dualization.
+
+  The type-order gotcha is respected throughout: the dual of the plane
+  `(P, L)` is `(Dual L, Dual P)` — dual *points* are the original *lines*.
+
+  ## Honest scope
+
+  * Desargues is NOT a theorem of the projective-plane axioms (the parent
+    entry's Moulton plane is a non-Desarguesian counterexample), so
+    self-duality is necessarily a statement about the *Desarguesian property*,
+    not a proof of (D) itself.  Nothing here claims any particular plane is
+    Desarguesian.
+  * The *intra-plane* implication "a projective plane satisfying (D) also
+    satisfies (D\*)" is a genuine geometric theorem (apply (D) to a derived
+    configuration); it is NOT purely formal duality and is left open here.
+  * The parent's Moulton model is affine, and affine planes are not self-dual
+    (parallels have no point-dual); this file therefore lives at the abstract
+    incidence layer, one level above its parent, as recorded in the survey.
+
+  ## Verification status: verified (axiom-free)
+
+  All finite checks are kernel `decide` on `Fin 10`/`Fin 5` data (no
+  `native_decide`); the abstract layer is constructive shuffling of incidence
+  hypotheses along `Configuration.Dual`.  0 sorries, 0 axioms.
+-/
+import Mathlib
+
+namespace DesarguesTheoremOQ02OQ02
+
+/- ## Layer 1: the finite Desargues configuration and its explicit polarity -/
+
+/-- The ten POINTS of the Desargues configuration, encoded by 2-element
+subsets of `Fin 5` (order: `O, A, B, C, A', B', C', P, Q, R`). -/
+def pairOf : Fin 10 → Finset (Fin 5) :=
+  ![{0, 1}, {0, 2}, {0, 3}, {0, 4}, {1, 2}, {1, 3}, {1, 4}, {2, 3}, {3, 4}, {2, 4}]
+
+/-- The ten LINES of the Desargues configuration, same encoding (order:
+`axis, la = OAA', lb = OBB', lc = OCC', ab, ab', bc, bc', ca, ca'`). -/
+def lineOf : Fin 10 → Finset (Fin 5) :=
+  ![{0, 1}, {3, 4}, {2, 4}, {2, 3}, {1, 4}, {0, 4}, {1, 2}, {0, 2}, {1, 3}, {0, 3}]
+
+/-- Incidence: a point lies on a line iff their label pairs are disjoint —
+the classical combinatorial model of the Desargues `10₃` configuration. -/
+def Inc (p l : Fin 10) : Prop := pairOf p ∩ lineOf l = ∅
+
+instance (p l : Fin 10) : Decidable (Inc p l) := by unfold Inc; infer_instance
+
+/-- Each line passes through exactly 3 points: the `10₃` line condition. -/
+theorem inc_line_card_three :
+    ∀ l : Fin 10, ((Finset.univ : Finset (Fin 10)).filter fun p => Inc p l).card = 3 := by
+  decide
+
+/-- Each point lies on exactly 3 lines: the `10₃` point condition. -/
+theorem inc_point_card_three :
+    ∀ p : Fin 10, ((Finset.univ : Finset (Fin 10)).filter fun l => Inc p l).card = 3 := by
+  decide
+
+/-- Central perspectivity in the model: the center `O` (pt 0) lies on all
+three perspectivity lines `la, lb, lc` (ln 1, 2, 3), which carry the
+corresponding vertex pairs `A,A'`, `B,B'`, `C,C'`. -/
+theorem desargues_roles_central :
+    Inc 0 1 ∧ Inc 1 1 ∧ Inc 4 1 ∧
+    Inc 0 2 ∧ Inc 2 2 ∧ Inc 5 2 ∧
+    Inc 0 3 ∧ Inc 3 3 ∧ Inc 6 3 := by decide
+
+/-- The six sides carry their two vertices and the matching axis point:
+`ab = {A, B, P}`, `ab' = {A', B', P}`, `bc = {B, C, Q}`, `bc' = {B', C', Q}`,
+`ca = {C, A, R}`, `ca' = {C', A', R}`. -/
+theorem desargues_roles_sides :
+    Inc 1 4 ∧ Inc 2 4 ∧ Inc 7 4 ∧
+    Inc 4 5 ∧ Inc 5 5 ∧ Inc 7 5 ∧
+    Inc 2 6 ∧ Inc 3 6 ∧ Inc 8 6 ∧
+    Inc 5 7 ∧ Inc 6 7 ∧ Inc 8 7 ∧
+    Inc 3 8 ∧ Inc 1 8 ∧ Inc 9 8 ∧
+    Inc 6 9 ∧ Inc 4 9 ∧ Inc 9 9 := by decide
+
+/-- Axial perspectivity in the model: the three axis points `P, Q, R`
+(pts 7, 8, 9) all lie on the axis (ln 0) — the conclusion of Desargues's
+theorem holds in the configuration. -/
+theorem desargues_roles_axis : Inc 7 0 ∧ Inc 8 0 ∧ Inc 9 0 := by decide
+
+/-- The polarity, point-to-line half: each point maps to the line carrying the
+same label pair.  Geometrically: `O ↦ axis`, each vertex to the opposite side
+of the other triangle (`A ↦ bc' = B'C'`, `B ↦ ca' = C'A'`, `C ↦ ab' = A'B'`,
+`A' ↦ bc = BCQ`, `B' ↦ ca`, `C' ↦ ab`), each axis point to a perspectivity
+line (`P ↦ lc`, `Q ↦ la`, `R ↦ lb`). -/
+def ptToLn : Fin 10 → Fin 10 := ![0, 7, 9, 5, 6, 8, 4, 3, 1, 2]
+
+/-- The polarity, line-to-point half (the inverse table). -/
+def lnToPt : Fin 10 → Fin 10 := ![0, 8, 9, 7, 6, 3, 4, 1, 5, 2]
+
+/-- The two halves are mutually inverse: the polarity is a bijection. -/
+theorem lnToPt_ptToLn : ∀ p, lnToPt (ptToLn p) = p := by decide
+
+theorem ptToLn_lnToPt : ∀ l, ptToLn (lnToPt l) = l := by decide
+
+/-- **The Desargues configuration is self-dual**: the explicit polarity
+reverses incidence — `p` lies on `l` iff the dual point `lnToPt l` lies on
+the dual line `ptToLn p`.  (In the pair model this is just symmetry of
+disjointness, transported through the label tables.) -/
+theorem polarity_reverses : ∀ p l, Inc p l ↔ Inc (lnToPt l) (ptToLn p) := by decide
+
+/- ## Layer 2: duality exchanges the Desarguesian and converse-Desarguesian
+     properties -/
+
+open Configuration
+
+section Abstract
+
+variable (P L : Type*) [Membership P L]
+
+/-- Three points are collinear: some line passes through all three. -/
+def PointsCollinear (p₁ p₂ p₃ : P) : Prop :=
+  ∃ l : L, p₁ ∈ l ∧ p₂ ∈ l ∧ p₃ ∈ l
+
+/-- Three lines are concurrent: some point lies on all three. -/
+def LinesConcurrent (l₁ l₂ l₃ : L) : Prop :=
+  ∃ p : P, p ∈ l₁ ∧ p ∈ l₂ ∧ p ∈ l₃
+
+/-- Collinearity in the dual plane IS concurrency in the original plane —
+definitionally (note the type order: dual points are original lines). -/
+theorem pointsCollinear_dual_iff (l₁ l₂ l₃ : L) :
+    PointsCollinear (Dual L) (Dual P) l₁ l₂ l₃ ↔ LinesConcurrent P L l₁ l₂ l₃ :=
+  Iff.rfl
+
+/-- Concurrency in the dual plane IS collinearity in the original plane —
+definitionally. -/
+theorem linesConcurrent_dual_iff (p₁ p₂ p₃ : P) :
+    LinesConcurrent (Dual L) (Dual P) p₁ p₂ p₃ ↔ PointsCollinear P L p₁ p₂ p₃ :=
+  Iff.rfl
+
+/-- **The Desarguesian property**, in universal incidence form: for every
+labelled Desargues configuration — center `o`, vertices `A B C` / `A' B' C'`,
+axis candidates `p q r`, perspectivity lines `la lb lc`, sides
+`ab ab' bc bc' ca ca'`, subject to the polarity-symmetric nondegeneracy
+schema (12 inequalities) and the 27 incidence hypotheses of central
+perspectivity — the axis candidates are collinear.
+
+The hypothesis schema is chosen to be exactly interchanged with that of
+`IsConverseDesarguesian` under plane duality; see `isDesarguesian_dual_iff`. -/
+def IsDesarguesian : Prop :=
+  ∀ (o A B C A' B' C' p q r : P) (la lb lc ab ab' bc bc' ca ca' : L),
+    A ≠ A' → B ≠ B' → C ≠ C' →
+    p ≠ q → p ≠ r → q ≠ r →
+    la ≠ lb → la ≠ lc → lb ≠ lc →
+    ab ≠ ab' → bc ≠ bc' → ca ≠ ca' →
+    o ∈ la → o ∈ lb → o ∈ lc →
+    A ∈ la → A' ∈ la → B ∈ lb → B' ∈ lb → C ∈ lc → C' ∈ lc →
+    A ∈ ab → B ∈ ab → p ∈ ab → A' ∈ ab' → B' ∈ ab' → p ∈ ab' →
+    B ∈ bc → C ∈ bc → q ∈ bc → B' ∈ bc' → C' ∈ bc' → q ∈ bc' →
+    C ∈ ca → A ∈ ca → r ∈ ca → C' ∈ ca' → A' ∈ ca' → r ∈ ca' →
+    PointsCollinear P L p q r
+
+/-- **The converse-Desarguesian property** (axial ⟹ central), in the same
+universal incidence form: given the axis `ℓ` through `p q r` and the same
+sides/joins data (27 incidence hypotheses in total, 12 nondegeneracy
+inequalities), the three joins `la lb lc` are concurrent. -/
+def IsConverseDesarguesian : Prop :=
+  ∀ (A B C A' B' C' p q r : P) (ℓ la lb lc ab ab' bc bc' ca ca' : L),
+    A ≠ A' → B ≠ B' → C ≠ C' →
+    p ≠ q → p ≠ r → q ≠ r →
+    la ≠ lb → la ≠ lc → lb ≠ lc →
+    ab ≠ ab' → bc ≠ bc' → ca ≠ ca' →
+    p ∈ ℓ → q ∈ ℓ → r ∈ ℓ →
+    A ∈ la → A' ∈ la → B ∈ lb → B' ∈ lb → C ∈ lc → C' ∈ lc →
+    A ∈ ab → B ∈ ab → p ∈ ab → A' ∈ ab' → B' ∈ ab' → p ∈ ab' →
+    B ∈ bc → C ∈ bc → q ∈ bc → B' ∈ bc' → C' ∈ bc' → q ∈ bc' →
+    C ∈ ca → A ∈ ca → r ∈ ca → C' ∈ ca' → A' ∈ ca' → r ∈ ca' →
+    LinesConcurrent P L la lb lc
+
+/-- **Self-duality of Desargues's theorem, class level**: the dual plane is
+Desarguesian **iff** the original plane satisfies the *converse* of
+Desargues.  The proof is the explicit statement swap along the polarity
+dictionary (center ↔ axis, vertex ↔ opposite side of the other triangle,
+perspectivity line ↔ axis point) — the same dictionary verified finitely by
+`polarity_reverses`.  This is the precise sense in which Desargues's theorem
+"is its own dual = its own converse". -/
+theorem isDesarguesian_dual_iff :
+    IsDesarguesian (Dual L) (Dual P) ↔ IsConverseDesarguesian P L := by
+  constructor
+  · -- Desargues in the dual plane ⟹ converse Desargues in `P`
+    intro h A B C A' B' C' p q r ℓ la lb lc ab ab' bc bc' ca ca'
+      hAA' hBB' hCC' hpq hpr hqr hlab hlac hlbc hab' hbc' hca'
+      hpl hql hrl hAla hA'la hBlb hB'lb hClc hC'lc
+      hAab hBab hpab hA'ab' hB'ab' hpab'
+      hBbc hCbc hqbc hB'bc' hC'bc' hqbc'
+      hCca hAca hrca hC'ca' hA'ca' hrca'
+    obtain ⟨x, hx1, hx2, hx3⟩ :=
+      h ℓ bc' ca' ab' bc ca ab lc la lb q r p C' C A' A B' B
+        hbc'.symm hca'.symm hab'.symm hlac.symm hlbc.symm hlab
+        hqr hpq.symm hpr.symm hCC'.symm hAA'.symm hBB'.symm
+        hql hrl hpl
+        hqbc' hqbc hrca' hrca hpab' hpab
+        hC'bc' hC'ca' hC'lc hCbc hCca hClc
+        hA'ca' hA'ab' hA'la hAca hAab hAla
+        hB'ab' hB'bc' hB'lb hBab hBbc hBlb
+    exact ⟨x, hx2, hx3, hx1⟩
+  · -- converse Desargues in `P` ⟹ Desargues in the dual plane
+    intro h o A B C A' B' C' p q r la lb lc ab ab' bc bc' ca ca'
+      hAA' hBB' hCC' hpq hpr hqr hlab hlac hlbc hab' hbc' hca'
+      hola holb holc hAla hA'la hBlb hB'lb hClc hC'lc
+      hAab hBab hpab hA'ab' hB'ab' hpab'
+      hBbc hCbc hqbc hB'bc' hC'bc' hqbc'
+      hCca hAca hrca hC'ca' hA'ca' hrca'
+    obtain ⟨x, hx1, hx2, hx3⟩ :=
+      h bc' ca' ab' bc ca ab lc la lb o q r p C' C A' A B' B
+        hbc'.symm hca'.symm hab'.symm hlac.symm hlbc.symm hlab
+        hqr hpq.symm hpr.symm hCC'.symm hAA'.symm hBB'.symm
+        holc hola holb
+        hqbc' hqbc hrca' hrca hpab' hpab
+        hC'bc' hC'ca' hC'lc hCbc hCca hClc
+        hA'ca' hA'ab' hA'la hAca hAab hAla
+        hB'ab' hB'bc' hB'lb hBab hBbc hBlb
+    exact ⟨x, hx3, hx1, hx2⟩
+
+/-- The mirror statement: the dual plane satisfies the *converse* of
+Desargues iff the original plane is Desarguesian.  Follows from
+`isDesarguesian_dual_iff` applied to the dual plane, because `Dual` is
+definitionally involutive. -/
+theorem isConverseDesarguesian_dual_iff :
+    IsConverseDesarguesian (Dual L) (Dual P) ↔ IsDesarguesian P L :=
+  (isDesarguesian_dual_iff (Dual L) (Dual P)).symm
+
+/-- **The full Desargues package is self-dual**: a plane satisfies
+(Desargues ∧ converse) iff its dual does.  In particular the class of planes
+with the full package is closed under dualization. -/
+theorem desargues_package_self_dual :
+    IsDesarguesian P L ∧ IsConverseDesarguesian P L ↔
+      IsDesarguesian (Dual L) (Dual P) ∧ IsConverseDesarguesian (Dual L) (Dual P) := by
+  rw [isDesarguesian_dual_iff, isConverseDesarguesian_dual_iff]
+  exact and_comm
+
+/-- Context: Mathlib's duality principle — the dual of a projective plane is
+a projective plane (with the point/line type order swapped), so all the
+statements above genuinely live on projective planes and their duals. -/
+example [ProjectivePlane P L] : ProjectivePlane (Dual L) (Dual P) := inferInstance
+
+end Abstract
+
+end DesarguesTheoremOQ02OQ02

--- a/research/problems/desargues-theorem-oq-02-oq-02/knowledge.md
+++ b/research/problems/desargues-theorem-oq-02-oq-02/knowledge.md
@@ -171,3 +171,44 @@ Parts B–C ~120–200 LOC contingent on the exact `Configuration.Dual` API.
   instead (Insight 3).
 - **Modelling "complexity"-style cost.** N/A here — this OQ is a logical/incidence
   statement, not an algorithmic one; no cost-monad needed.
+
+---
+
+## Session 2026-07-24 (researcher-2) — ACT executed: self-duality FORMALIZED (both layers)
+
+The build-gated plan from the 2026-06-13 survey is now implemented in the new
+file `proofs/Proofs/DesarguesTheoremOQ02OQ02.lean` (docker build green,
+0 sorries / 0 axioms, kernel `decide` only — no native_decide).
+
+- **Part A (finite)**: pairs model (points AND lines = 2-subsets of Fin 5,
+  incidence = disjointness) with the geometric dictionary in explicit `![…]`
+  tables. `decide` certifies: 10₃ regularity, all 30 Desargues role
+  incidences, and the explicit polarity `ptToLn`/`lnToPt` (mutually inverse,
+  incidence-reversing: `polarity_reverses`). Polarity = O↔axis, vertex↔
+  opposite side of the OTHER triangle (A↦B'C'), perspectivity line↔axis point.
+- **Parts B–C (abstract)**: `PointsCollinear`/`LinesConcurrent` with
+  `Iff.rfl` dual swaps; `IsDesarguesian`/`IsConverseDesarguesian` universal
+  incidence forms with a polarity-CLOSED 12-inequality nondegeneracy schema;
+  **`isDesarguesian_dual_iff : IsDesarguesian (Dual L) (Dual P) ↔
+  IsConverseDesarguesian P L`** proved by explicit 39-hypothesis transposition
+  (both directions); `isConverseDesarguesian_dual_iff` from definitional
+  involutivity of `Dual` (Dual (Dual P) = P is rfl — one-line proof);
+  `desargues_package_self_dual`.
+
+### Lean notes
+- The survey's type-order gotcha is real and the whole file respects
+  `(Dual L) (Dual P)`.
+- `Dual` being a plain type synonym (`def Dual := P`) makes BOTH the double-
+  dual collapse and the membership swap definitional: the mirror iff is just
+  `(isDesarguesian_dual_iff (Dual L) (Dual P)).symm` with defeq doing the
+  `Dual ∘ Dual = id` lift, and primal-typed incidence hypotheses are accepted
+  verbatim where dual-typed ones are expected.
+- Key design: the nondegeneracy schema must be closed under the polarity or
+  the duality is not a pure statement swap (converse-Desargues' natural
+  hypotheses = exact polarity image of Desargues').
+
+### Question status: ANSWERED (yes — formalized explicitly)
+
+### Remaining open (recorded as candidate follow-up)
+- The INTRA-plane theorem: in a projective plane, (D) ⟹ (D*) via applying
+  (D) to a derived configuration — genuine geometry, not formal duality.

--- a/research/problems/desargues-theorem-oq-02-oq-02/problem.md
+++ b/research/problems/desargues-theorem-oq-02-oq-02/problem.md
@@ -118,3 +118,45 @@ tractability: 6
 tier: B
 category: extension
 ```
+
+## Adversarial Checklist (added 2026-07-24, researcher-2 — audit guide for the SOLVED claim)
+
+The claim: self-duality of Desargues's theorem is formalized explicitly in
+`proofs/Proofs/DesarguesTheoremOQ02OQ02.lean` — finitely (`polarity_reverses`
+on the 10₃ configuration) and at class level (`isDesarguesian_dual_iff`).
+Ways THIS claim could be wrong, and what to check:
+
+- **Wrong carrier (the parent's affine trap).** The parent Moulton model is
+  affine and affine planes are NOT self-dual. Check: nothing in the file
+  touches `MPoint`/`MLine`/`onLine`; Layer 2 lives on `[Membership P L]` +
+  `Configuration.Dual`, and the `example` pins Mathlib's
+  `ProjectivePlane (Dual L) (Dual P)` instance for context.
+- **Type-order swap.** The dual plane is `(Dual L, Dual P)` — dual points ARE
+  original lines. A silent `(Dual P, Dual L)` would make the statements
+  vacuous or ill-typed-but-fixable-by-unification into something else. Check
+  every `Dual` occurrence keeps the `(Dual L) (Dual P)` order.
+- **"Self-duality" could be smuggled as a tautology.** If
+  `IsConverseDesarguesian` were DEFINED as `IsDesarguesian (Dual L) (Dual P)`,
+  the headline would be `Iff.rfl` and content-free. Check both predicates are
+  defined independently, each by its own 39-hypothesis universal incidence
+  form in `P, L`, and that the proof genuinely transposes the hypothesis list
+  (the polarity dictionary), not `Iff.rfl`.
+- **Degenerate-configuration hypotheses.** The nondegeneracy schema (12
+  inequalities) was chosen polarity-CLOSED; dropping any of them silently
+  would still let the duality proof go through (fewer hypotheses to
+  transpose) but would change which planes count as Desarguesian. The
+  specific check: the schema in both definitions is exactly
+  {A≠A', B≠B', C≠C', p≠q, p≠r, q≠r, la≠lb, la≠lc, lb≠lc, ab≠ab', bc≠bc',
+  ca≠ca'} — the polarity image of itself.
+- **The finite layer could fail to be THE Desargues configuration.** A wrong
+  incidence table would still be "some" self-dual structure. Check
+  `desargues_roles_central/sides/axis` certify all 30 role incidences of a
+  labelled Desargues configuration, and `inc_*_card_three` certify 10₃
+  regularity (both by kernel `decide`, no `native_decide`).
+- **Conflation of duality-transfer with the intra-plane theorem.** The file
+  proves "dual plane Desarguesian ⟺ plane converse-Desarguesian". It does
+  NOT prove "a projective plane satisfying (D) satisfies (D*)" — that is
+  real geometry, explicitly left open in the header. Any prose claiming the
+  latter is an overclaim.
+- **Circularity.** No axioms, no sorries; Layer 2 uses only hypothesis
+  shuffling; Layer 1 only kernel `decide` on `Fin 10`/`Fin 5` data.

--- a/research/problems/desargues-theorem-oq-02-oq-02/sessions/2026-07-24-self-duality-act.md
+++ b/research/problems/desargues-theorem-oq-02-oq-02/sessions/2026-07-24-self-duality-act.md
@@ -1,0 +1,52 @@
+# Session 2026-07-24 (researcher-2): ACT — self-duality formalized at both layers
+
+## Context
+S1 SURVEY (2026-06-13) fully mapped the math; ACT was build-gated by the
+then-live Docker blackout. Infra has long since returned; this session
+executes the recorded 4-part plan (Parts A–C; Part D folded into docstrings).
+
+## What was built (`proofs/Proofs/DesarguesTheoremOQ02OQ02.lean`, new file)
+
+### Layer 1 — finite Desargues 10₃ configuration (Part A)
+Pairs model: points AND lines = 2-subsets of Fin 5 (explicit `![…]` tables
+`pairOf`/`lineOf` with the geometric dictionary O={0,1}, A={0,2}, …,
+axis=l_{01}, la=l_{34}, …), incidence `Inc p l := pairOf p ∩ lineOf l = ∅`.
+By kernel `decide` (no native_decide):
+- `inc_line_card_three` / `inc_point_card_three` — genuine 10₃;
+- `desargues_roles_central/sides/axis` — all 30 role incidences hold;
+- `ptToLn`/`lnToPt` explicit polarity tables, mutually inverse, and
+  `polarity_reverses : Inc p l ↔ Inc (lnToPt l) (ptToLn p)`.
+The polarity realizes the classical dictionary: O ↔ axis, vertex ↔ opposite
+side of the OTHER triangle (A↦B'C'), perspectivity line ↔ axis point (la↦Q).
+
+### Layer 2 — class-level duality (Parts B–C)
+On bare `[Membership P L]` (the layer of Mathlib's `Configuration.Dual`):
+- `PointsCollinear`/`LinesConcurrent` + `Iff.rfl` dual swaps
+  (`pointsCollinear_dual_iff`, `linesConcurrent_dual_iff`);
+- `IsDesarguesian` / `IsConverseDesarguesian` — universal incidence forms
+  with a 12-inequality nondegeneracy schema chosen CLOSED under the polarity
+  (A≠A',B≠B',C≠C'; p,q,r pairwise; la,lb,lc pairwise; ab≠ab',bc≠bc',ca≠ca');
+- **`isDesarguesian_dual_iff : IsDesarguesian (Dual L) (Dual P) ↔
+  IsConverseDesarguesian P L`** — the headline; proof = explicit statement
+  swap along the polarity (39 hypotheses transposed by hand, both directions);
+- `isConverseDesarguesian_dual_iff` via definitional involutivity of `Dual`;
+- `desargues_package_self_dual` — (D) ∧ (D*) invariant under dualization;
+- `example`: Mathlib's `ProjectivePlane (Dual L) (Dual P)` instance situates
+  everything on genuine projective planes.
+
+## Key design decision
+The nondegeneracy schema must be polarity-closed or the duality is NOT a pure
+statement swap. The 12-inequality set maps onto itself: la≠lb ↦ q≠r,
+ab≠ab' ↦ C'≠C, etc. This is why converse-Desargues' "natural" hypotheses
+(distinct axis points, distinct corresponding vertices) are exactly the dual
+of Desargues' (distinct perspectivity lines, distinct corresponding sides).
+
+## Honest scope (recorded in file header)
+- No claim that any plane IS Desarguesian (Moulton parent refutes generality).
+- The INTRA-plane implication "(D) in a projective plane ⟹ (D*) in the same
+  plane" is genuine geometry (apply D to a derived configuration), NOT formal
+  duality — left open, a natural follow-up.
+
+## Build
+GREEN on first attempt: `./proofs/scripts/docker-build.sh Proofs.DesarguesTheoremOQ02OQ02`
+— 8576 jobs, exit 0, zero errors. 0 sorries, 0 axioms, kernel decide only.

--- a/research/problems/desargues-theorem-oq-02-oq-02/state.md
+++ b/research/problems/desargues-theorem-oq-02-oq-02/state.md
@@ -46,3 +46,17 @@ Configuration dependency, so it compiles regardless of API drift), then **Parts
 B–C** on `Configuration.ProjectivePlane`/`Configuration.Dual` (API confirmed:
 `ProjectivePlane` L329, `Dual` L46, duality instance `ProjectivePlane (Dual L)
 (Dual P)` L338 — mind the swapped type order when stating `desarguesian_dual_iff`).
+
+## Status (researcher-2, 2026-07-24) — ACT DONE: question ANSWERED
+
+`DesarguesTheoremOQ02OQ02.lean` created per the survey plan; docker green,
+0 sorries / 0 axioms. Self-duality explicit at both layers: finite 10₃
+polarity (`polarity_reverses`, all-`decide`) and class-level
+`isDesarguesian_dual_iff : IsDesarguesian (Dual L) (Dual P) ↔
+IsConverseDesarguesian P L` (+ mirror + package invariance). The
+verification-blackout blocker is obsolete. Problem COMPLETED; adversarial
+checklist added to problem.md.
+
+## Next Action
+None — target answered. Candidate follow-up: the intra-plane implication
+"(D) ⟹ (D*) in the same projective plane" (real geometry, not formal duality).

--- a/src/data/research/problems/desargues-theorem-oq-02-oq-02.json
+++ b/src/data/research/problems/desargues-theorem-oq-02-oq-02.json
@@ -25,14 +25,14 @@
     "goal": "An explicit Lean formalization of the self-duality of Desargues's theorem: the class-level dual↔converse equivalence plus a decidable finite self-dual 10₃ configuration."
   },
   "currentState": {
-    "phase": "ORIENT",
+    "phase": "COMPLETED",
     "since": "2026-06-13",
     "iteration": 1,
-    "focus": "Core math resolved on paper (self-dual = own converse via the duality dictionary); formalization layered as finite-decidable 10₃ + abstract Configuration.Dual swap. Build-gated by the 2026-06-13 verification blackout.",
+    "focus": "COMPLETED 2026-07-24: self-duality formalized explicitly at both layers (finite 10_3 polarity + class-level isDesarguesian_dual_iff) — researcher-2",
     "blockers": [
       "Verification blackout 2026-06-13: Docker down + Aristotle 404 (both confirmed live this session)"
     ],
-    "nextAction": "When infra returns, create DesarguesTheoremOQ02OQ02.lean: Part A finite 10₃ self-duality by decide (blackout-proof), then Parts B–C on Configuration.ProjectivePlane/Configuration.Dual.",
+    "nextAction": "None — question answered. Candidate follow-up: intra-plane (D) => (D*) in a projective plane (real geometry, not formal duality).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -40,23 +40,30 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED (ORIENT): self-duality of Desargues fully resolved on paper. The plane-dual of Desargues's theorem is its converse (point↔line, collinear↔concurrent, central↔axial perspectivity). Formalizable at the projective layer via Mathlib Configuration.Dual; the parent's affine Moulton model is the wrong carrier (affine planes are not self-dual).",
-    "builtItems": [],
+    "progressSummary": "COMPLETED 2026-07-24: the self-duality of Desargues theorem is formalized EXPLICITLY. Finite layer: the 10_3 Desargues configuration in the pairs model with an explicit incidence-reversing polarity (kernel decide; O<->axis, vertex<->opposite side, perspectivity line<->axis point). Abstract layer (on Membership P L + Configuration.Dual): isDesarguesian_dual_iff proves IsDesarguesian (Dual L) (Dual P) <-> IsConverseDesarguesian P L — Desargues is its own dual = its own converse — plus the mirror iff (definitional involutivity) and package invariance. Honest scope: duality-transfer only; the intra-plane (D)=>(D*) implication is real geometry, left open.",
+    "builtItems": [
+      "DesarguesTheoremOQ02OQ02.lean: pairOf/lineOf/Inc + 10_3 certificates + desargues_roles_* + ptToLn/lnToPt + polarity_reverses (all decide)",
+      "PointsCollinear/LinesConcurrent + Iff.rfl dual swaps on Configuration.Dual",
+      "IsDesarguesian / IsConverseDesarguesian (universal incidence forms, polarity-closed 12-inequality schema)",
+      "isDesarguesian_dual_iff + isConverseDesarguesian_dual_iff + desargues_package_self_dual: THE TARGET, 0 sorries 0 axioms"
+    ],
     "insights": [
       "Duality dictionary: point↔line, lies-on↔passes-through, collinear↔concurrent, join↔meet — sends a triangle to a trilateral and central perspectivity to axial perspectivity",
       "Dual of Desargues's statement = its converse, so the theorem is self-dual (its own dual)",
       "Right layer is projective/abstract: affine planes (the parent's onLine over ℚ²) are NOT self-dual because parallel lines have no dual point",
       "Desargues is false in general projective planes (parent counterexample), so self-duality must be stated class-level: Desarguesian(Dual P) ↔ ConverseDesarguesian P, not 'D holds ⇒ converse holds'",
-      "Cheapest first compile = finite Desargues 10₃ configuration self-duality: Fin 10 incidence matrix + duality permutation σ, goal inc p l = inc (σ l) (σ p) by decide — no Mathlib Configuration dependency"
+      "Cheapest first compile = finite Desargues 10₃ configuration self-duality: Fin 10 incidence matrix + duality permutation σ, goal inc p l = inc (σ l) (σ p) by decide — no Mathlib Configuration dependency",
+      "The nondegeneracy schema must be CLOSED under the polarity or duality is not a pure statement swap: converse-Desargues natural hypotheses (distinct axis points, distinct corresponding vertices) are exactly the polarity image of Desargues (distinct perspectivity lines, distinct corresponding sides)",
+      "Dual being a plain type synonym makes double-dual collapse and membership swap definitional: the mirror iff is (isDesarguesian_dual_iff (Dual L) (Dual P)).symm with defeq lifting Dual(Dual P)=P, and primal-typed incidence hypotheses are accepted verbatim in dual positions",
+      "The pairs model (points and lines = 2-subsets of Fin 5, incidence = disjointness) makes the 10_3 self-duality a symmetry fact, fully kernel-decidable with explicit polarity tables"
     ],
     "mathlibGaps": [
       "Mathlib Configuration provides ProjectivePlane (L329), Dual (L46), and the instance ProjectivePlane (Dual L) (Dual P) (L338, the duality principle) — confirmed against source — but NOT perspectivity / Desargues predicates, which must be defined",
       "Gotcha: the dual swaps type order — a predicate Foo P L on the dual is Foo (Dual L) (Dual P), not Foo (Dual P) (Dual L)"
     ],
     "nextSteps": [
-      "Part A: finite 10₃ self-dual configuration (Fin 10, incidence Bool matrix, σ : Perm (Fin 10), decide) — blackout-proof milestone",
-      "Part B: define Concurrent/Collinear, centrally/axially perspective, Desarguesian/ConverseDesarguesian on Configuration.ProjectivePlane",
-      "Part C: swap lemmas under Configuration.Dual → desarguesian_dual_iff and converse_iff_desarguesian"
+      "Follow-up (genuine geometry, materially distinct): in a projective plane, Desargues implies its own converse INTRA-plane (apply (D) to a derived configuration) — would upgrade the package theorem to single-property self-duality",
+      "Optional: bridge the finite 10_3 model to the abstract predicates (instantiate a Membership (Fin 10) (Fin 10) structure and derive the abstract polarity from polarity_reverses)"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Answers the target question of `desargues-theorem-oq-02-oq-02` — *"can we formalize the self-duality property of Desargues's theorem explicitly?"* — **yes**, at both layers mapped by the 2026-06-13 survey (this executes the build-gated ACT plan; the Docker-blackout blocker is long obsolete). New file `proofs/Proofs/DesarguesTheoremOQ02OQ02.lean`.

## Layer 1 — the finite Desargues `10₃` configuration is self-dual (kernel `decide`)
Pairs model: points AND lines are the 2-element subsets of `Fin 5`, incidence = disjointness, with the explicit geometric dictionary (`O = {0,1}`, `A = {0,2}`, …, axis `= l_{01}`, `la = l_{34}`, …). Certified by kernel `decide` (no `native_decide`):
- `inc_line_card_three` / `inc_point_card_three` — genuine `10₃` regularity;
- `desargues_roles_central/sides/axis` — all 30 role incidences of a labelled Desargues configuration;
- `ptToLn`/`lnToPt` — an explicit, mutually inverse, **incidence-reversing polarity** (`polarity_reverses`), realizing the classical dictionary: center ↔ axis, vertex ↔ opposite side of the *other* triangle (`A ↦ B'C'`), perspectivity line ↔ axis point (`la ↦ Q`).

## Layer 2 — the Desarguesian property dualizes to the converse property
On a bare incidence structure `[Membership P L]` (the layer of Mathlib's `Configuration.Dual`, respecting the type-order gotcha `(Dual L, Dual P)` throughout):
- `PointsCollinear` / `LinesConcurrent`, exchanged by duality **definitionally** (`Iff.rfl`);
- `IsDesarguesian` / `IsConverseDesarguesian` in universal incidence form (27 incidences + 12 nondegeneracy inequalities), with the schema chosen **closed under the polarity** — the key design decision that makes duality an exact statement swap;
- **`isDesarguesian_dual_iff : IsDesarguesian (Dual L) (Dual P) ↔ IsConverseDesarguesian P L`** — *Desargues's theorem is its own dual = its own converse*, proved by explicit transposition of all 39 hypotheses in both directions;
- `isConverseDesarguesian_dual_iff` — one-liner via the definitional involutivity of `Dual`;
- `desargues_package_self_dual` — the package (theorem ∧ converse) is invariant under dualization;
- an `example` pinning Mathlib's `ProjectivePlane (Dual L) (Dual P)` duality instance for context.

## Honest scope (in the file header and adversarial checklist)
- No claim any particular plane is Desarguesian (the parent Moulton plane refutes generality) — self-duality is about the *property*, as the survey's Insight 3 required.
- The **intra-plane** implication "(D) ⟹ (D\*) in the same projective plane" is genuine geometry (not formal duality) and is explicitly left open — recorded as the natural follow-up.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.DesarguesTheoremOQ02OQ02` — exit 0 (8576 jobs), zero errors on the first build
- 0 sorries, 0 `axiom` declarations, no `native_decide`

## Status
**Outcome**: completed — target question answered
**Next steps**: candidate follow-up: the intra-plane (D) ⟹ (D\*) theorem (derived-configuration argument, real geometry).

🤖 Generated by researcher-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
