### PR TITLE
Enrich burnside-counting-oq-04-oq-01-oq-02: split Part IV/V sections

### DIFF
--- a/src/data/proofs/burnside-counting-oq-04-oq-01-oq-02/meta.json
+++ b/src/data/proofs/burnside-counting-oq-04-oq-01-oq-02/meta.json
@@ -160,9 +160,17 @@
       "id": "match",
       "title": "The Closed Form Matches the Orbit Counts, n = 3..6",
       "startLine": 130,
-      "endLine": 183,
-      "summary": "braceletClosed evaluates to 4, 6, 8, 13 by kernel decide and equals the genuine orbit count Fintype.card (orbitRel.Quotient (DihedralGroup n) (Coloring n)) for each n = 3,4,5,6; the formula then predicts b(7)=18, b(8)=30, b(9)=46, b(10)=78 by arithmetic alone.",
-      "mathContext": "$\\mathrm{braceletClosed}(n) = |\\,\\mathrm{Coloring}(n)/D_n\\,|\\ (n \\le 6);\\quad b(7,8,9,10) = 18, 30, 46, 78.$"
+      "endLine": 165,
+      "summary": "braceletClosed evaluates to 4, 6, 8, 13 by kernel decide and equals the genuine orbit count Fintype.card (orbitRel.Quotient (DihedralGroup n) (Coloring n)) for each n = 3,4,5,6 (b(3), b(4) freshly proved above; b(5), b(6) imported from the grandparent) — pinning the formula to Lean-checked ground truth rather than an OEIS lookup.",
+      "mathContext": "$\\mathrm{braceletClosed}(n) = |\\,\\mathrm{Coloring}(n)/D_n\\,|\\quad\\text{for } n = 3,4,5,6.$"
+    },
+    {
+      "id": "predictions",
+      "title": "Onward Predictions Beyond the Computational Ceiling, n = 7..10",
+      "startLine": 167,
+      "endLine": 181,
+      "summary": "The closed form now predicts b(7)=18, b(8)=30, b(9)=46, b(10)=78 (A000029(7..10)) by pure arithmetic on braceletClosed, with no orbit quotient built or enumerated — precisely the lengths where decide on the quotient (the parents' method) becomes computationally infeasible.",
+      "mathContext": "$b(7,8,9,10) = 18,\\,30,\\,46,\\,78$ from $\\mathrm{braceletClosed}(n)$ alone, no orbit quotient enumerated."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `burnside-counting-oq-04-oq-01-oq-02` (quality 98, sections
bucket 8/10 = 4 sections instead of the 5-item cap; all other buckets already
maxed).

The `match` section bundled two conceptually distinct parts of the Lean file
into one block (lines 130-183): Part IV (closed form matches the genuine
dihedral orbit counts for n=3..6, ground-truth anchored) and Part V (onward
arithmetic predictions for n=7..10, beyond the parents' decide-on-quotient
ceiling). The Lean file itself demarcates these with separate `## Part IV` /
`## Part V` docstring headers. Split at that real boundary into:

- `match` (130-165): Part IV, the ground-truth match for n=3..6
- `predictions` (167-181): Part V, the onward predictions for n=7..10

Verified both new line ranges against the current Lean source
(`proofs/Proofs/BurnsideCountingOQ04OQ01OQ02.lean`, 189 lines) — no drift in
the other 3 existing sections. `meta.json` stays well under the 60 KB cap.

No overlap with other open PRs on this entry (checked via `gh pr list --search`).