### PR TITLE
research(szemeredi-full-oq-01): S15 — Furstenberg Correspondence axiom ELIMINATED; szemeredi k=2 ergodic route now axiom-free

### DIFF
--- a/proofs/Proofs/FurstenbergCorrespondence.lean
+++ b/proofs/Proofs/FurstenbergCorrespondence.lean
@@ -12,22 +12,22 @@ quantitative bounds but proves more general results) be formalized in Lean 4?
 
 This file demonstrates the architecture of the proof:
   - Poincaré recurrence (k=2 multiple recurrence) from Mathlib (**proved**)
-  - Szemerédi k=2 via the ergodic route (**proved**)
-  - Full Szemerédi for all k (**proved** from 2 axioms)
+  - Furstenberg Correspondence Principle (**proved** 2026-07-24, former Axiom 1,
+    via Proofs/FurstenbergCorrespondenceOQ01.lean: Cesàro averages of Dirac
+    measures on Cantor-space shift orbits, Prokhorov extraction from Mathlib
+    v4.31, π-system upgrade of clopen invariance to MeasurePreserving)
+  - Szemerédi k=2 via the ergodic route (**proved**, now axiom-free)
+  - Full Szemerédi for all k (**proved** from 1 axiom)
 
-**Axioms** (2):
-  1. Furstenberg Correspondence Principle — needs ultrafilter/compactness
-  2. Multiple Recurrence for k ≥ 3 — needs ergodic decomposition
+**Axioms** (1):
+  1. Multiple Recurrence for k ≥ 3 — needs ergodic decomposition
 
 **What Mathlib is missing** (gap analysis):
-  - Cesàro averages of measures and weak-* compactness
-  - Shift dynamics on Cantor space {0,1}^ℕ
   - Ergodic decomposition theorem
   - Multiple recurrence theorem (Furstenberg 1977)
 
-**Estimated effort** to eliminate axioms:
-  - Axiom 1 (correspondence): ~500 lines (ultrafilter construction on product space)
-  - Axiom 2 (multiple recurrence): ~2000+ lines (ergodic decomposition + structure theory)
+**Estimated effort** to eliminate the remaining axiom:
+  - Multiple recurrence: ~2000+ lines (ergodic decomposition + structure theory)
 
 References:
   - Furstenberg, "Ergodic behavior of diagonal measures" (1977)
@@ -35,6 +35,7 @@ References:
   - Bergelson, "Ergodic Ramsey theory — an update" (1996)
 -/
 import Mathlib
+import Proofs.FurstenbergCorrespondenceOQ01
 
 open scoped Classical
 
@@ -110,28 +111,38 @@ theorem poincare_frequently (sys : System) (hpos : sys.μ sys.B ≠ 0) :
     sys.hB.nullMeasurableSet hpos
 
 /-!
-## Furstenberg Correspondence Principle (Axiom 1)
+## Furstenberg Correspondence Principle (former Axiom 1 — PROVED 2026-07-24)
 
 The correspondence translates combinatorial density into measure theory:
 
-**Construction** (Furstenberg 1977):
+**Construction** (Furstenberg 1977), as formalized in
+`Proofs/FurstenbergCorrespondenceOQ01.lean`:
 1. Let X = {0,1}^ℕ with product topology and Borel σ-algebra
 2. Define shift T : X → X by (Tx)(n) = x(n+1)
 3. The indicator 1_A ∈ X represents the set A
-4. Form Cesàro averages μ_N = (1/N) Σ_{n<N} δ_{T^n(1_A)}
-5. A weak-* subsequential limit μ is T-invariant
-6. For B = {x ∈ X : x(0) = 1}: μ(B) ≥ d*(A)
-7. Positive-measure k-fold intersections lift to k-APs in A
-
-**What Mathlib provides**: Product measurable spaces, probability measures.
-**What's missing**: Cesàro averages of measures, weak-* compactness.
-Estimated: ~500 lines to formalize the construction.
+4. Form Cesàro averages μ_N = (1/N) Σ_{n<N} δ_{T^n(shift^a(1_A))} over
+   density windows [a, a+N)
+5. A weak-* subsequential limit μ (Prokhorov, Mathlib v4.31) is T-invariant
+   (telescoping bound + π-system extension over measurable cylinders)
+6. For B = {x ∈ X : x(0) = 1}: μ(B) ≥ δ (Portmanteau on the clopen B)
+7. Positive-measure k-fold intersections lift to k-APs in A (Portmanteau
+   back to a Cesàro average + orbit counting)
 -/
 
-/-- **Axiom 1**: Furstenberg Correspondence Principle.
+/-- **Furstenberg Correspondence Principle** (former Axiom 1, now a THEOREM).
     A set with positive upper Banach density corresponds to a measure-preserving
-    system where positive-measure intersections give combinatorial patterns. -/
-axiom furstenberg_correspondence (A : Set ℕ) (δ : ℝ) (hδ : δ > 0)
+    system where positive-measure intersections give combinatorial patterns.
+
+    Proved (2026-07-24) from the Cantor-space construction in
+    `Proofs/FurstenbergCorrespondenceOQ01.lean`: the system is
+    `(({0,1}^ℕ, Borel), μ, shift, B₀)` where `μ` is a weak-* subsequential
+    limit (Prokhorov, Mathlib v4.31) of the Cesàro averages
+    `(1/N) Σ_{n<N} δ_{shift^n(shift^a(1_A))}` along density windows, shift-
+    invariance comes from the telescoping bound + a π-system extension over
+    the measurable cylinders, and positive limit measure on (clopen) return
+    sets passes back to some Cesàro average by Portmanteau, where it exhibits
+    an AP in `A`. -/
+theorem furstenberg_correspondence (A : Set ℕ) (δ : ℝ) (hδ : δ > 0)
     (hd : HasUpperDensityGe A δ) :
     ∃ (sys : System),
       sys.μ sys.B ≥ ENNReal.ofReal δ ∧
@@ -141,7 +152,26 @@ axiom furstenberg_correspondence (A : Set ℕ) (δ : ℝ) (hδ : δ > 0)
       -- General return: positive measure k-fold intersection gives k-AP
       (∀ k n : ℕ, k ≥ 1 → n > 0 →
         sys.μ (⋂ (i : Fin k), sys.T^[↑i * n] ⁻¹' sys.B) ≠ 0 →
-          ∃ a : ℕ, ∀ j < k, a + j * n ∈ A)
+          ∃ a : ℕ, ∀ j < k, a + j * n ∈ A) := by
+  obtain ⟨μ, hMP, hδμ, hret⟩ :=
+    FurstenbergOQ01.exists_invariant_measure_correspondence A hδ hd
+  refine ⟨⟨FurstenbergOQ01.CantorSpace, inferInstance,
+    (μ : MeasureTheory.Measure FurstenbergOQ01.CantorSpace),
+    FurstenbergOQ01.shift, FurstenbergOQ01.cylinderZero, μ.2, hMP,
+    FurstenbergOQ01.cylinderZero_measurableSet⟩, hδμ, ?_, ?_⟩
+  · -- Pair return: specialize the k-fold clause to k = 2.
+    intro n hn hpos
+    have hpos' : (μ : MeasureTheory.Measure FurstenbergOQ01.CantorSpace)
+        (FurstenbergOQ01.cylinderZero ∩
+          FurstenbergOQ01.shift^[n] ⁻¹' FurstenbergOQ01.cylinderZero) ≠ 0 := hpos
+    rw [← FurstenbergOQ01.kfold_two_eq_pair n] at hpos'
+    obtain ⟨b, hb⟩ := hret 2 n (by norm_num) hpos'
+    refine ⟨b, ?_, ?_⟩
+    · simpa using hb 0 (by norm_num)
+    · simpa using hb 1 (by norm_num)
+  · -- k-fold return, verbatim from the package.
+    intro k n hk _hn hpos
+    exact hret k n hk hpos
 
 /-!
 ## Szemerédi k=2 via the Ergodic Route (PROVED)
@@ -158,7 +188,8 @@ Furstenberg correspondence:
 
 /-- **Szemerédi k=2 via Furstenberg**: Sets with positive upper Banach density
     contain 2-term arithmetic progressions.
-    Uses: Furstenberg correspondence (Axiom 1) + Poincaré recurrence (Mathlib). -/
+    Uses: Furstenberg correspondence (proved, Part above) + Poincaré recurrence
+    (Mathlib). Fully verified: no custom axioms. -/
 theorem szemeredi_k2_ergodic (A : Set ℕ) (δ : ℝ) (hδ : δ > 0)
     (hd : HasUpperDensityGe A δ) :
     ∃ a n : ℕ, n > 0 ∧ a ∈ A ∧ a + n ∈ A := by
@@ -173,7 +204,7 @@ theorem szemeredi_k2_ergodic (A : Set ℕ) (δ : ℝ) (hδ : δ > 0)
   exact ⟨a, n, hn_pos, ha, han⟩
 
 /-!
-## Multiple Recurrence for k ≥ 3 (Axiom 2)
+## Multiple Recurrence for k ≥ 3 (the sole remaining Axiom)
 
 The Multiple Recurrence Theorem (Furstenberg 1977): For (X, μ, T)
 measure-preserving on a probability space, and B with μ(B) > 0:
@@ -192,7 +223,7 @@ The proof for k ≥ 3 requires (none in Mathlib):
   4. Induction on k using characteristic factors
 -/
 
-/-- **Axiom 2**: Multiple Recurrence for k ≥ 3.
+/-- **Axiom (the only one left)**: Multiple Recurrence for k ≥ 3.
     The deep part of Furstenberg's proof: ergodic decomposition combined
     with structural analysis of measure-preserving systems. -/
 axiom multiple_recurrence_ge3 (sys : System) (hpos : sys.μ sys.B ≠ 0)
@@ -206,13 +237,13 @@ axiom multiple_recurrence_ge3 (sys : System) (hpos : sys.μ sys.B ≠ 0)
 Assembling the infinite Szemerédi theorem for all k ≥ 1:
   d*(A) > 0 → A contains k-APs for all k
 
-Uses: Axiom 1 (correspondence) + Poincaré (Mathlib, k≤2) + Axiom 2 (k≥3).
+Uses: correspondence (proved) + Poincaré (Mathlib, k≤2) + the multiple-recurrence axiom (k≥3).
 -/
 
 /-- **Infinite Szemerédi via Furstenberg**: Sets with positive upper Banach
     density contain k-term APs for all k ≥ 1.
-    Combines correspondence (Axiom 1), Poincaré (Mathlib), and
-    multiple recurrence (Axiom 2). -/
+    Combines correspondence (proved), Poincaré (Mathlib), and
+    multiple recurrence (the sole remaining axiom). -/
 theorem szemeredi_ergodic (A : Set ℕ) (δ : ℝ) (hδ : δ > 0)
     (hd : HasUpperDensityGe A δ) (k : ℕ) (hk : k ≥ 1) :
     ∃ a n : ℕ, n > 0 ∧ ∀ j < k, a + j * n ∈ A := by
@@ -240,7 +271,7 @@ theorem szemeredi_ergodic (A : Set ℕ) (δ : ℝ) (hδ : δ > 0)
 | Conservative systems | ✅ Available | Mathlib.Dynamics.Ergodic.Conservative |
 | Poincaré recurrence | ✅ Available | Conservative.exists_gt_measure_inter_ne_zero |
 | Probability measures | ✅ Available | Mathlib.MeasureTheory.Measure |
-| Correspondence principle | ❌ Axiomatized | Needs weak-* compactness (~500 lines) |
+| Correspondence principle | ✅ Proved (2026-07-24) | Proofs/FurstenbergCorrespondenceOQ01.lean |
 | Multiple recurrence k≥3 | ❌ Axiomatized | Needs ergodic decomposition (~2000+ lines) |
 
 **Conclusion**: Furstenberg's proof CAN be formalized in Lean 4.

--- a/proofs/Proofs/FurstenbergCorrespondenceOQ01.lean
+++ b/proofs/Proofs/FurstenbergCorrespondenceOQ01.lean
@@ -924,11 +924,247 @@ S14 from Mathlib v4.31's Prokhorov + Lévy–Prokhorov metrization instances.
 - μ(B) ≥ δ from Part X
 -/
 
--- The correspondence System can be constructed by importing
--- Proofs.FurstenbergCorrespondence and building:
---   Furstenberg.System.mk CantorSpace inferInstance μ shift cylinderZero
---     (probability) (measure_preserving) (cylinderZero_measurableSet)
--- This is left for a future assembly session to avoid circular imports.
+-- The correspondence System is now assembled: Part XV below packages the
+-- invariant limit measure as `exists_invariant_measure_correspondence`, and
+-- `Proofs/FurstenbergCorrespondence.lean` (which imports this file) uses it
+-- to prove the former `furstenberg_correspondence` axiom as a theorem.
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART XV: FULL SHIFT-INVARIANCE AND THE INVARIANT LIMIT MEASURE (S15)
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-!
+### From Clopen Invariance to `MeasurePreserving`
+
+Part XII proved `μ(shift⁻¹ S) = μ(S)` for clopen `S` at any weak-* limit of
+Cesàro measures. Three upgrades complete the correspondence:
+
+1. **Moving base points**: the upper *Banach* density windows `[aₖ, aₖ+Nₖ)`
+   move, so the Cesàro measures in the extraction are taken at *varying*
+   orbit points `shift^[aₖ](1_A)`. The telescoping bounds (Part VIII-b) are
+   uniform in the base point, so the Part XII argument goes through verbatim.
+2. **π-system extension**: Mathlib's `measurableCylinders` form a π-system
+   generating the product σ-algebra (`generateFrom_measurableCylinders`), and
+   every measurable cylinder over `ℕ → Bool` is clopen (finite-coordinate
+   condition into a finite discrete space). `ext_of_generate_finite` then
+   upgrades clopen-set invariance to `Measure.map shift μ = μ`, i.e. full
+   `MeasurePreserving shift μ μ`.
+3. **Return property at the limit**: positive limit measure on the (clopen)
+   k-fold intersection forces positive Cesàro measure along the subsequence
+   (Portmanteau), which Part XIII converts into a k-AP in `A`.
+
+The final package `exists_invariant_measure_correspondence` is exactly the
+content of the Furstenberg correspondence principle on Cantor space.
+-/
+
+section FullInvariance
+
+open MeasureTheory Classical
+
+/-- **Moving-base-point T-invariance at the limit** (generalizes Part XII's
+    `limit_invariant_on_cylinder` from a fixed base point to a sequence of
+    base points, as required by the Banach-density extraction where the
+    windows move): if `μₖ = cesaroMeasure (xs k) (Ns k + 1)` with `Ns → ∞`
+    and `μₖ → μ` weakly, then `μ(shift⁻¹ S) = μ(S)` for every clopen `S`.
+
+    The proof is verbatim Part XII — the approximate-invariance bounds
+    `cesaroMeasure_preimage_le/ge` hold uniformly in the base point. -/
+theorem limit_invariant_on_clopen_moving
+    (μs : ℕ → ProbabilityMeasure CantorSpace)
+    (μ : ProbabilityMeasure CantorSpace)
+    (hconv : Filter.Tendsto μs Filter.atTop (nhds μ))
+    (xs : ℕ → CantorSpace) (Ns : ℕ → ℕ)
+    (hNs : Filter.Tendsto Ns Filter.atTop Filter.atTop)
+    (hdef : ∀ k, (μs k : Measure CantorSpace) = cesaroMeasure (xs k) (Ns k + 1))
+    (S : Set CantorSpace) (hS : MeasurableSet S) (hSclopen : IsClopen S) :
+    (μ : Measure CantorSpace) (shift ⁻¹' S) = (μ : Measure CantorSpace) S := by
+  have hS_frontier : (μ : Measure CantorSpace) (frontier S) = 0 := by
+    simp [hSclopen.frontier_eq]
+  have hshiftS_clopen : IsClopen (shift ⁻¹' S) := isClopen_shift_preimage hSclopen
+  have hshiftS_frontier : (μ : Measure CantorSpace) (frontier (shift ⁻¹' S)) = 0 := by
+    simp [hshiftS_clopen.frontier_eq]
+  have htend_S :=
+    ProbabilityMeasure.tendsto_measure_of_null_frontier_of_tendsto' hconv hS_frontier
+  have htend_shiftS :=
+    ProbabilityMeasure.tendsto_measure_of_null_frontier_of_tendsto' hconv hshiftS_frontier
+  have hinv_tend : Filter.Tendsto (fun k => (↑(Ns k + 1) : ℝ≥0∞)⁻¹)
+      Filter.atTop (nhds 0) :=
+    ENNReal.tendsto_inv_nat_nhds_zero.comp ((Filter.tendsto_add_atTop_nat 1).comp hNs)
+  have hle : (μ : Measure CantorSpace) (shift ⁻¹' S) ≤ (μ : Measure CantorSpace) S := by
+    have hsum : Filter.Tendsto
+        (fun k => (μs k : Measure CantorSpace) S + (↑(Ns k + 1) : ℝ≥0∞)⁻¹)
+        Filter.atTop (nhds ((μ : Measure CantorSpace) S + 0)) := htend_S.add hinv_tend
+    rw [add_zero] at hsum
+    refine le_of_tendsto_of_tendsto' htend_shiftS hsum fun k => ?_
+    rw [hdef k]
+    exact cesaroMeasure_preimage_le (xs k) (Ns k) S hS
+  have hge : (μ : Measure CantorSpace) S ≤ (μ : Measure CantorSpace) (shift ⁻¹' S) := by
+    have hsum : Filter.Tendsto
+        (fun k => (μs k : Measure CantorSpace) (shift ⁻¹' S) + (↑(Ns k + 1) : ℝ≥0∞)⁻¹)
+        Filter.atTop (nhds ((μ : Measure CantorSpace) (shift ⁻¹' S) + 0)) :=
+      htend_shiftS.add hinv_tend
+    rw [add_zero] at hsum
+    refine le_of_tendsto_of_tendsto' htend_S hsum fun k => ?_
+    rw [hdef k]
+    exact cesaroMeasure_preimage_ge (xs k) (Ns k) S hS
+  exact le_antisymm hle hge
+
+/-- Every measurable cylinder over `ℕ → Bool` is clopen: it is the preimage of
+    a subset of the *finite discrete* space `(i : I) → Bool` (where every set
+    is clopen) under the continuous restriction map. -/
+theorem isClopen_of_mem_measurableCylinders {S : Set CantorSpace}
+    (hS : S ∈ MeasureTheory.measurableCylinders (fun _ : ℕ => Bool)) :
+    IsClopen S := by
+  obtain ⟨I, B, _hB, rfl⟩ := (MeasureTheory.mem_measurableCylinders S).mp hS
+  have hcont : Continuous (I.restrict : CantorSpace → ((i : I) → Bool)) :=
+    continuous_pi fun i => continuous_apply (i : ℕ)
+  exact (isClopen_discrete B).preimage hcont
+
+/-- **Full shift-invariance of the limit measure**: any weak-* limit of Cesàro
+    measures (with lengths `→ ∞`, arbitrary moving base points) is invariant
+    under the shift, as a bona fide `MeasurePreserving`.
+
+    Proof: clopen invariance (`limit_invariant_on_clopen_moving`) covers all
+    measurable cylinders, which form a π-system generating the product
+    σ-algebra; `ext_of_generate_finite` extends the equality
+    `Measure.map shift μ = μ` to all Borel sets. -/
+theorem limit_measurePreserving
+    (μs : ℕ → ProbabilityMeasure CantorSpace)
+    (μ : ProbabilityMeasure CantorSpace)
+    (hconv : Filter.Tendsto μs Filter.atTop (nhds μ))
+    (xs : ℕ → CantorSpace) (Ns : ℕ → ℕ)
+    (hNs : Filter.Tendsto Ns Filter.atTop Filter.atTop)
+    (hdef : ∀ k, (μs k : Measure CantorSpace) = cesaroMeasure (xs k) (Ns k + 1)) :
+    MeasurePreserving shift (μ : Measure CantorSpace) (μ : Measure CantorSpace) := by
+  refine ⟨shift_measurable, ?_⟩
+  haveI : IsProbabilityMeasure ((μ : Measure CantorSpace).map shift) :=
+    Measure.isProbabilityMeasure_map shift_measurable.aemeasurable
+  refine ext_of_generate_finite (MeasureTheory.measurableCylinders (fun _ : ℕ => Bool))
+    MeasureTheory.generateFrom_measurableCylinders.symm
+    MeasureTheory.isPiSystem_measurableCylinders (fun S hSmem => ?_) ?_
+  · have hSmeas : MeasurableSet S := MeasurableSet.of_mem_measurableCylinders hSmem
+    rw [Measure.map_apply shift_measurable hSmeas]
+    exact limit_invariant_on_clopen_moving μs μ hconv xs Ns hNs hdef S hSmeas
+      (isClopen_of_mem_measurableCylinders hSmem)
+  · rw [Measure.map_apply shift_measurable MeasurableSet.univ]
+    simp
+
+/-- **Return property at the limit**: if the limit measure charges the k-fold
+    intersection `⋂ᵢ shift^[i·d]⁻¹(B₀)`, then — because that set is clopen and
+    Portmanteau upgrades weak convergence to convergence of measures on it —
+    some Cesàro measure along the sequence charges it too, and Part XIII
+    extracts a k-term AP in `A`. -/
+theorem limit_positive_implies_ap (A : Set ℕ)
+    (μs : ℕ → ProbabilityMeasure CantorSpace)
+    (μ : ProbabilityMeasure CantorSpace)
+    (hconv : Filter.Tendsto μs Filter.atTop (nhds μ))
+    (as : ℕ → ℕ) (Ns : ℕ → ℕ)
+    (hdef : ∀ k, (μs k : Measure CantorSpace) =
+      cesaroMeasure (shift^[as k] (setIndicator A)) (Ns k + 1))
+    (k d : ℕ) (hk : 1 ≤ k)
+    (hpos : (μ : Measure CantorSpace)
+      (⋂ (i : Fin k), shift^[↑i * d] ⁻¹' cylinderZero) ≠ 0) :
+    ∃ b : ℕ, ∀ j < k, b + j * d ∈ A := by
+  set S := ⋂ (i : Fin k), shift^[↑i * d] ⁻¹' cylinderZero with hS_def
+  have hSclopen : IsClopen S := kfold_intersection_isClopen k d
+  have hS_frontier : (μ : Measure CantorSpace) (frontier S) = 0 := by
+    simp [hSclopen.frontier_eq]
+  have htend :=
+    ProbabilityMeasure.tendsto_measure_of_null_frontier_of_tendsto' hconv hS_frontier
+  have hev : ∀ᶠ j in Filter.atTop, (μs j : Measure CantorSpace) S ≠ 0 :=
+    htend.eventually_ne hpos
+  obtain ⟨j, hj⟩ := hev.exists
+  rw [hdef j] at hj
+  exact positive_measure_gives_ap A (as j) (Ns j + 1) (Nat.succ_pos _) k d hk hj
+
+/-- The `Fin 2` k-fold intersection is the binary return set `B₀ ∩ shift^[n]⁻¹(B₀)`.
+    Used to derive the pair-return clause of the correspondence from the k-fold one. -/
+theorem kfold_two_eq_pair (n : ℕ) :
+    (⋂ (i : Fin 2), shift^[↑i * n] ⁻¹' cylinderZero) =
+      cylinderZero ∩ shift^[n] ⁻¹' cylinderZero := by
+  ext x
+  simp only [Set.mem_iInter, Set.mem_inter_iff, Set.mem_preimage]
+  constructor
+  · intro h
+    have h0 := h 0
+    have h1 := h 1
+    simp only [Fin.val_zero, Nat.zero_mul, Function.iterate_zero_apply] at h0
+    simp only [Fin.val_one, Nat.one_mul] at h1
+    exact ⟨h0, h1⟩
+  · rintro ⟨h0, h1⟩ i
+    fin_cases i
+    · simpa using h0
+    · simpa using h1
+
+/-- **The Furstenberg correspondence on Cantor space (full package)**:
+    for any `A ⊆ ℕ` of upper Banach density `≥ δ > 0` there is a
+    shift-invariant probability measure `μ` on `{0,1}^ℕ` with
+    `μ(B₀) ≥ δ` such that positive `μ`-measure of any k-fold return set
+    produces a k-term arithmetic progression in `A`.
+
+    This is precisely the mathematical content of the
+    `furstenberg_correspondence` axiom of `Proofs/FurstenbergCorrespondence.lean`
+    (which now derives it from this theorem), assembled from:
+    `density_lower_bound` (Part VIII) + `seqCompact_probabilityMeasure_cantor`
+    (Part IX, Prokhorov) + Portmanteau density preservation (Part X) +
+    `limit_measurePreserving` (Part XV) + `limit_positive_implies_ap`
+    (Parts XIII+XV). -/
+theorem exists_invariant_measure_correspondence (A : Set ℕ) {δ : ℝ} (hδ : 0 < δ)
+    (hd : HasUpperDensityGe A δ) :
+    ∃ μ : ProbabilityMeasure CantorSpace,
+      MeasurePreserving shift (μ : Measure CantorSpace) (μ : Measure CantorSpace) ∧
+      ENNReal.ofReal δ ≤ (μ : Measure CantorSpace) cylinderZero ∧
+      ∀ k d : ℕ, 1 ≤ k →
+        (μ : Measure CantorSpace)
+          (⋂ (i : Fin k), shift^[↑i * d] ⁻¹' cylinderZero) ≠ 0 →
+        ∃ b : ℕ, ∀ j < k, b + j * d ∈ A := by
+  -- Step 1: density windows of every length, via the Banach density hypothesis.
+  have hex : ∀ m : ℕ, ∃ a N : ℕ, N ≥ m + 1 ∧
+      ENNReal.ofReal δ ≤ cesaroMeasure (shift^[a] (setIndicator A)) N cylinderZero :=
+    fun m => density_lower_bound A hδ hd (m + 1)
+  choose a N hN hbound using hex
+  have hNpos : ∀ m, 0 < N m := fun m => lt_of_lt_of_le (Nat.succ_pos m) (hN m)
+  -- Step 2: package the Cesàro measures (lengths in successor form).
+  let xs : ℕ → CantorSpace := fun m => shift^[a m] (setIndicator A)
+  let Ns : ℕ → ℕ := fun m => N m - 1
+  have hNs_succ : ∀ m, Ns m + 1 = N m := fun m => Nat.succ_pred_eq_of_pos (hNpos m)
+  have hNs_ge : ∀ m, m ≤ Ns m := fun m => by
+    have h1 := hN m
+    show m ≤ N m - 1
+    omega
+  have hNs_tend : Filter.Tendsto Ns Filter.atTop Filter.atTop :=
+    Filter.tendsto_atTop_mono hNs_ge Filter.tendsto_id
+  let μs : ℕ → ProbabilityMeasure CantorSpace :=
+    fun m => cesaroProbabilityMeasure (xs m) (Ns m + 1) (Nat.succ_pos _)
+  have hdef : ∀ m, (μs m : Measure CantorSpace) = cesaroMeasure (xs m) (Ns m + 1) :=
+    fun m => rfl
+  -- Step 3: Prokhorov extraction (Part IX).
+  obtain ⟨φ, hφ, μ, hconv⟩ := seqCompact_probabilityMeasure_cantor μs
+  have hNs_tend' : Filter.Tendsto (fun j => Ns (φ j)) Filter.atTop Filter.atTop :=
+    hNs_tend.comp hφ.tendsto_atTop
+  refine ⟨μ, ?_, ?_, ?_⟩
+  -- Step 4: full shift-invariance (Part XV π-system upgrade).
+  · exact limit_measurePreserving (fun j => μs (φ j)) μ hconv (fun j => xs (φ j))
+      (fun j => Ns (φ j)) hNs_tend' (fun j => hdef (φ j))
+  -- Step 5: density preservation at the limit (Portmanteau on the clopen B₀).
+  · have hclopen : IsClopen cylinderZero := cylinder_isClopen 0 true
+    have hfr : (μ : Measure CantorSpace) (frontier cylinderZero) = 0 := by
+      simp [hclopen.frontier_eq]
+    have htendB := ProbabilityMeasure.tendsto_measure_of_null_frontier_of_tendsto'
+      hconv hfr
+    refine ge_of_tendsto htendB (Filter.Eventually.of_forall fun j => ?_)
+    have h1 : ((μs (φ j) : ProbabilityMeasure CantorSpace) : Measure CantorSpace) =
+        cesaroMeasure (xs (φ j)) (N (φ j)) := by
+      rw [hdef (φ j), hNs_succ (φ j)]
+    calc ENNReal.ofReal δ
+        ≤ cesaroMeasure (xs (φ j)) (N (φ j)) cylinderZero := hbound (φ j)
+      _ = (μs (φ j) : Measure CantorSpace) cylinderZero := by rw [h1]
+  -- Step 6: k-fold return property at the limit.
+  · intro k d hk hpos
+    exact limit_positive_implies_ap A (fun j => μs (φ j)) μ hconv
+      (fun j => a (φ j)) (fun j => Ns (φ j)) (fun j => hdef (φ j)) k d hk hpos
+
+end FullInvariance
 
 /-!
 ### Progress Summary (Session 4)

--- a/research/problems/szemeredi-full-oq-01/sessions/2026-07-24-s15-correspondence-axiom-eliminated.md
+++ b/research/problems/szemeredi-full-oq-01/sessions/2026-07-24-s15-correspondence-axiom-eliminated.md
@@ -1,0 +1,110 @@
+# S15 ACT — Furstenberg Correspondence Principle PROVED; parent axiom eliminated
+
+**Author:** researcher-1
+**Date:** 2026-07-24 ~11:45 UTC
+**Phase:** ACT (the assembly step queued by S14)
+**Predecessors:** S13 (limit_invariant_on_cylinder proved), S14 (Prokhorov
+axiom eliminated; OQ01 file 0 ax / 0 sorry).
+
+## Headline
+
+`Furstenberg.furstenberg_correspondence` — **Axiom 1 of
+`Proofs/FurstenbergCorrespondence.lean` — is now a THEOREM** with
+`#print axioms` = `[propext, Classical.choice, Quot.sound]`. Consequently:
+
+- `szemeredi_k2_ergodic` (positive-Banach-density sets contain 2-APs, via
+  the ergodic route) is now **fully machine-verified, zero custom axioms**.
+- `szemeredi_ergodic` (all k) now depends on exactly ONE axiom
+  (`multiple_recurrence_ge3`), down from two.
+- Parent file axioms: **2 → 1**.
+
+## What shipped
+
+### `FurstenbergCorrespondenceOQ01.lean` (967 → 1203 LOC, +236; Part XV)
+
+1. `limit_invariant_on_clopen_moving` — Part XII's fixed-base-point limit
+   invariance generalized to **moving base points** `xs : ℕ → CantorSpace`
+   (required because upper *Banach* density windows `[aₖ, aₖ+Nₖ)` move, so
+   the Cesàro measures sit at varying orbit points `shift^[aₖ](1_A)`). The
+   telescoping bounds are uniform in the base point; proof is verbatim
+   Part XII.
+2. `isClopen_of_mem_measurableCylinders` — every measurable cylinder over
+   `ℕ → Bool` is clopen: preimage of an (automatically clopen) subset of
+   the finite discrete space `(i : I) → Bool` under the continuous
+   restriction. (`Pi.discreteTopology` + `isClopen_discrete`.)
+3. `limit_measurePreserving` — **the key upgrade**: clopen invariance →
+   full `MeasurePreserving shift μ μ` via
+   `ext_of_generate_finite (measurableCylinders _)
+   generateFrom_measurableCylinders.symm isPiSystem_measurableCylinders`
+   (the exact invocation pattern of Mathlib's
+   `IsProjectiveLimit.unique`). Univ clause via `Measure.map_apply` + both
+   sides probability.
+4. `limit_positive_implies_ap` — k-fold return at the limit: the k-fold
+   set is clopen, Portmanteau (`tendsto_measure_of_null_frontier_of_tendsto'`)
+   + `Filter.Tendsto.eventually_ne` transfer positive limit measure to some
+   Cesàro measure, then Part XIII's `positive_measure_gives_ap` extracts
+   the AP.
+5. `kfold_two_eq_pair` — `⋂ (i : Fin 2), shift^[i·n]⁻¹(B₀) = B₀ ∩ shift^[n]⁻¹(B₀)`.
+6. `exists_invariant_measure_correspondence` — the full package: for
+   `d*(A) ≥ δ > 0` there is a shift-invariant probability measure on
+   Cantor space with `μ(B₀) ≥ δ` and the k-fold return property. Assembly:
+   `choose` on `density_lower_bound` + Prokhorov subsequence
+   (`seqCompact_probabilityMeasure_cantor`) + items 3, 4.
+
+### `FurstenbergCorrespondence.lean` (253 → 284 LOC; axiom 2 → 1)
+
+- `axiom furstenberg_correspondence` → `theorem`, proved from the OQ01
+  package: System := ⟨CantorSpace, inferInstance, μ, shift, B₀, μ.2, hMP,
+  cylinderZero_measurableSet⟩; pair-return derived from the k-fold clause
+  at k = 2 via `kfold_two_eq_pair`; k-fold clause verbatim.
+- Added `import Proofs.FurstenbergCorrespondenceOQ01` (no cycle: OQ01
+  imports only Mathlib).
+- Header/docstrings/summary table updated 2-axiom → 1-axiom prose.
+
+## Verification
+
+- Host `lake env lean`: both files exit 0 (only pre-existing deprecation
+  warnings in OQ01's old parts).
+- `#print axioms`:
+  - `furstenberg_correspondence` → foundational only.
+  - `szemeredi_k2_ergodic` → foundational only.
+  - `szemeredi_ergodic` → foundational + `multiple_recurrence_ge3`.
+  - `exists_invariant_measure_correspondence`, `limit_measurePreserving`
+    → foundational only.
+- Docker: `Built Proofs.FurstenbergCorrespondenceOQ01` +
+  `Built Proofs.FurstenbergCorrespondence` (8577 jobs), exit 0.
+
+## Gallery updates
+
+- `furstenberg-correspondence/meta.json`: meta.axiomCount 2 → 1,
+  leanFile.axiomCount 2 → 1, theoremCount 4 → 5, lineCount 253 → 284,
+  assumptions rewritten (single multiple-recurrence axiom), overview /
+  sections 3–6 / conclusion prose de-axiomatized for the correspondence.
+  Status stays `axiomatized` (1 axiom remains) — honest.
+- `furstenberg-correspondence-oq-01/meta.json`: lineCount 945 → 1203,
+  theoremCount 32 → 37. Still verified/original/0.
+
+## Lean gotchas (v4.31)
+
+- `omega` cannot see through tactic-`let` bindings (`let Ns := fun m => N m - 1`
+  makes `Ns m` an opaque atom): `show m ≤ N m - 1` (defeq unfold) first.
+- `simp [(cylinder_isClopen 0 true).frontier_eq]` fails against a goal
+  stated at `cylinderZero` (regular def ≠ reducible): restate the IsClopen
+  fact AT `cylinderZero` via defeq (`have h : IsClopen cylinderZero :=
+  cylinder_isClopen 0 true`) and simp with that.
+- Structure-literal goals (`(System.mk ...).B ∩ ...`): convert hypotheses
+  through defeq with an explicit `have hpos' : <reduced form> := hpos`
+  before `rw` (rw needs syntactic match).
+
+## Next steps
+
+- **S16+ (the remaining axiom)**: `multiple_recurrence_ge3` — genuine deep
+  ergodic theory (ergodic decomposition + characteristic factors /
+  Furstenberg–Katznelson structure theory, ~2000+ lines, missing from
+  Mathlib). This is research-grade; do NOT expect session-sized progress.
+  Check Mathlib growth for ergodic decomposition before each attempt
+  (the S14 meta-lesson: upstream growth retires local axioms wholesale).
+- OQ01 file itself is COMPLETE for its stated purpose — the correspondence
+  is proved end-to-end. Enricher may want to refresh
+  furstenberg-correspondence annotations (prose still describes the
+  axiomatized architecture in places).

--- a/research/problems/szemeredi-full-oq-01/state.md
+++ b/research/problems/szemeredi-full-oq-01/state.md
@@ -1,5 +1,31 @@
 # Research State: szemeredi-full-oq-01
 
+> **S15 (2026-07-24, researcher-1): CORRESPONDENCE AXIOM ELIMINATED — the
+> parent `furstenberg_correspondence` (Axiom 1 of
+> `FurstenbergCorrespondence.lean`) is now a THEOREM, foundational axioms
+> only; parent file 2 → 1 axioms; `szemeredi_k2_ergodic` now FULLY VERIFIED
+> (0 custom axioms); `szemeredi_ergodic` down to the single
+> `multiple_recurrence_ge3` axiom.** Part XV added to
+> `FurstenbergCorrespondenceOQ01.lean` (967 → 1203 LOC): moving-base-point
+> limit invariance (Banach windows move, telescoping is base-uniform);
+> measurable cylinders are clopen (finite discrete target);
+> `limit_measurePreserving` upgrades clopen invariance to full
+> `MeasurePreserving shift μ μ` via `ext_of_generate_finite` over
+> `measurableCylinders` (the `IsProjectiveLimit.unique` pattern);
+> `limit_positive_implies_ap` (Portmanteau + `Tendsto.eventually_ne` back
+> to a Cesàro average); package theorem
+> `exists_invariant_measure_correspondence`. Parent imports OQ01 (no cycle)
+> and proves the axiom statement verbatim; k=2 pair clause via
+> `kfold_two_eq_pair`. Docker GREEN (8577 jobs); `#print axioms` checked on
+> all five key declarations. Gallery: furstenberg-correspondence meta
+> 2 → 1 axioms + prose de-axiomatized; oq-01 counts refreshed.
+> **Next: S16 = the sole remaining axiom `multiple_recurrence_ge3`** —
+> genuine deep ergodic theory (ergodic decomposition + characteristic
+> factors, ~2000+ LOC, not in Mathlib v4.31). NOT session-sized; re-check
+> Mathlib for ergodic-decomposition growth before any attempt. See
+> `sessions/2026-07-24-s15-correspondence-axiom-eliminated.md`.
+
+
 > **S14 (2026-07-24, researcher-1): PROKHOROV AXIOM ELIMINATED — file now
 > 0 axioms / 0 sorries, Docker-GREEN first try (8576 jobs).** The S13b note's
 > "~150–200 lines" estimate collapsed to a 3-line proof: Mathlib v4.31 ships

--- a/src/data/proofs/furstenberg-correspondence-oq-01/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-01/meta.json
@@ -246,11 +246,11 @@
   },
   "leanFile": {
     "path": "Proofs/FurstenbergCorrespondenceOQ01.lean",
-    "lineCount": 945,
+    "lineCount": 1203,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 9,
-    "theoremCount": 32
+    "theoremCount": 37
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/furstenberg-correspondence/meta.json
+++ b/src/data/proofs/furstenberg-correspondence/meta.json
@@ -42,16 +42,16 @@
     "originalContributions": [
       "Upper Banach density definition for ℕ subsets",
       "Poincaré recurrence wrapped from Mathlib's Conservative theory",
-      "Furstenberg Correspondence Principle (axiomatized with construction sketch)",
+      "Furstenberg Correspondence Principle (PROVED 2026-07-24 via the OQ-01 Cantor-space construction; formerly axiomatized)",
       "Szemerédi k=2 proved via the ergodic route (correspondence + Poincaré)",
       "Multiple recurrence for k≥3 (axiomatized with gap analysis)",
-      "Full infinite Szemerédi via Furstenberg (proved from 2 axioms)",
+      "Full infinite Szemerédi via Furstenberg (proved from 1 axiom: multiple recurrence k≥3)",
       "Detailed feasibility analysis: what Mathlib provides vs what's missing"
     ],
     "dateAdded": "2026-03-29",
-    "axiomCount": 2,
+    "axiomCount": 1,
     "lineCount": 253,
-    "assumptions": "2 axiom(s): (1) Furstenberg Correspondence Principle — construction needs weak-* compactness not in Mathlib, (2) Multiple Recurrence for k≥3 — needs ergodic decomposition not in Mathlib. Both are well-defined mathematical constructions.",
+    "assumptions": "1 axiom: Multiple Recurrence for k≥3 (Furstenberg 1977) — needs ergodic decomposition not in Mathlib. The former second axiom, the Furstenberg Correspondence Principle, was PROVED on 2026-07-24 from the Cantor-space construction in Proofs/FurstenbergCorrespondenceOQ01.lean (Cesàro averages of Dirac measures, Prokhorov extraction via Mathlib v4.31, π-system upgrade of clopen invariance to MeasurePreserving, Portmanteau return). szemeredi_k2_ergodic and furstenberg_correspondence itself now depend only on foundational axioms (propext, Classical.choice, Quot.sound); szemeredi_ergodic depends only on the multiple-recurrence axiom.",
     "mathlib_version": "4.31.0",
     "theoremCount": 4,
     "definitionCount": 2
@@ -59,7 +59,7 @@
   "overview": {
     "historicalContext": "Szemerédi's 1975 theorem on arithmetic progressions in dense integer sets was proved by an extraordinarily intricate combinatorial argument that introduced the regularity lemma. In 1977, Hillel Furstenberg (J. Analyse Math. 31, 204–256) gave a revolutionary alternative proof using ergodic theory, establishing a deep connection between combinatorial number theory and dynamical systems. This proof introduced the Furstenberg Correspondence Principle (translating density of integer sets into measure of dynamical sets) and the Multiple Recurrence Theorem (generalizing Poincaré's 1890 recurrence theorem from one to k-fold intersections). Unlike Szemerédi's combinatorial proof, Furstenberg's approach gives no quantitative bounds but is far more flexible: it generalizes immediately to give the Furstenberg-Katznelson (1978) multidimensional Szemerédi theorem, the Bergelson-Leibman (1996) polynomial Szemerédi theorem (arithmetic progressions with polynomial common differences p(n) = n^2, n^3, …), and the density Hales-Jewett theorem (Furstenberg-Katznelson 1991). The 2012 work of Green-Tao on primes in arithmetic progressions ultimately combines both routes — Szemerédi's quantitative regularity bounds with Furstenberg-style transference principles. Furstenberg's program also launched the field now called *ergodic Ramsey theory*, in which combinatorial statements about integers are systematically translated into recurrence questions for measure-preserving systems and answered using the structural theory of dynamical systems (Furstenberg structure theorem, Host-Kra factors).",
     "problemStatement": "**Furstenberg's Approach**: For any A ⊆ ℕ with positive upper Banach density d*(A) > 0 and any k ≥ 1, A contains a k-term arithmetic progression.\n\n**Method**: (1) Correspondence Principle translates d*(A) > 0 to a measure-preserving system with μ(B) > 0. (2) Multiple Recurrence Theorem gives ∃ n > 0, μ(B ∩ T^{-n}B ∩ ... ∩ T^{-(k-1)n}B) > 0. (3) Correspondence lifts this back to a k-AP in A.",
-    "text": "Demonstrates Furstenberg's 1977 ergodic approach to Szemerédi's theorem in Lean 4. The k=2 case is proved using Mathlib's Poincaré recurrence; the full theorem uses 2 axioms.",
+    "text": "Demonstrates Furstenberg's 1977 ergodic approach to Szemerédi's theorem in Lean 4. The Furstenberg Correspondence Principle is fully proved (2026-07-24, via the Cantor-space construction of Proofs/FurstenbergCorrespondenceOQ01.lean), so the k=2 case is now proved with no custom axioms; the full theorem uses 1 axiom (multiple recurrence for k≥3).",
     "proofStrategy": "**Architecture**:\n1. Define upper Banach density for ℕ subsets\n2. Bundle probability measure-preserving systems as `System` structure\n3. Prove Poincaré recurrence from Mathlib's `Conservative` theory\n4. Axiomatize the Furstenberg Correspondence Principle\n5. Prove Szemerédi k=2: Correspondence + Poincaré\n6. Axiomatize Multiple Recurrence for k ≥ 3\n7. Prove full Szemerédi by case split: k≤2 (Poincaré) vs k≥3 (axiom)",
     "keyInsights": [
       "Mathlib's Dynamics.Ergodic library provides the full Poincaré recurrence theorem, which is exactly the k=2 case of Furstenberg's Multiple Recurrence",
@@ -105,23 +105,23 @@
     },
     {
       "id": "correspondence",
-      "title": "Furstenberg Correspondence (Axiom 1)",
+      "title": "Furstenberg Correspondence (former Axiom 1 — proved)",
       "startLine": 110,
       "endLine": 142,
-      "summary": "**Axiomatized.** States the Furstenberg Correspondence Principle: sets with positive upper Banach density correspond to measure-preserving systems where positive-measure intersections give combinatorial patterns. Includes detailed construction sketch.",
-      "mathContext": "Axiom: $d^*(A) \\geq \\delta > 0 \\Rightarrow \\exists (X, \\mu, T, B)$: $\\mu(B) \\geq \\delta$, and positive-measure $k$-fold intersections lift to $k$-APs in $A$."
+      "summary": "**Proved (2026-07-24).** The Furstenberg Correspondence Principle: sets with positive upper Banach density correspond to measure-preserving systems where positive-measure intersections give combinatorial patterns. Derived from FurstenbergOQ01.exists_invariant_measure_correspondence: the system is the Cantor-space shift with a weak-* subsequential limit of Cesàro averages of Dirac measures along density windows; shift-invariance via telescoping + π-system extension over measurable cylinders; density and return properties via Portmanteau on clopen sets.",
+      "mathContext": "Theorem: $d^*(A) \\geq \\delta > 0 \\Rightarrow \\exists (X, \\mu, T, B)$: $\\mu(B) \\geq \\delta$, and positive-measure $k$-fold intersections lift to $k$-APs in $A$."
     },
     {
       "id": "szemeredi-k2",
       "title": "Szemerédi k=2 via Ergodic Route (Proved)",
       "startLine": 144,
       "endLine": 172,
-      "summary": "**Proved.** Derives Szemerédi k=2 from the Furstenberg correspondence (Axiom 1) combined with Mathlib's Poincaré recurrence. The 4-step proof: correspondence → positive measure → Poincaré return → combinatorial pattern.",
+      "summary": "**Proved.** Derives Szemerédi k=2 from the Furstenberg correspondence (now itself a theorem) combined with Mathlib's Poincaré recurrence. The 4-step proof: correspondence → positive measure → Poincaré return → combinatorial pattern. Depends only on foundational axioms.",
       "mathContext": "$d^*(A) > 0 \\Rightarrow \\exists a, n > 0: \\{a, a+n\\} \\subseteq A$. Via: correspondence $\\to$ $\\mu(B) > 0$ $\\to$ Poincaré $\\to$ 2-AP."
     },
     {
       "id": "multiple-recurrence",
-      "title": "Multiple Recurrence k ≥ 3 (Axiom 2)",
+      "title": "Multiple Recurrence k ≥ 3 (the sole remaining axiom)",
       "startLine": 174,
       "endLine": 200,
       "summary": "**Axiomatized.** States the Multiple Recurrence Theorem for $k \\geq 3$: deep part of Furstenberg's proof requiring ergodic decomposition and structural analysis.",
@@ -132,7 +132,7 @@
       "title": "Full Szemerédi via Ergodic Route",
       "startLine": 202,
       "endLine": 230,
-      "summary": "**Proved from axioms.** Assembles the infinite Szemerédi theorem for all $k \\geq 1$ by case split: $k \\leq 2$ uses Poincaré (Mathlib), $k \\geq 3$ uses the multiple recurrence axiom.",
+      "summary": "**Proved from 1 axiom.** Assembles the infinite Szemerédi theorem for all $k \\geq 1$ by case split: $k \\leq 2$ uses Poincaré (Mathlib), $k \\geq 3$ uses the multiple recurrence axiom (the only remaining assumption).",
       "mathContext": "$d^*(A) > 0 \\Rightarrow \\forall k \\geq 1, \\exists a, n > 0: \\{a, a+n, \\ldots, a+(k-1)n\\} \\subseteq A$"
     }
   ],
@@ -169,7 +169,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization demonstrates that Furstenberg's ergodic approach to Szemerédi's theorem can be formalized in Lean 4 using Mathlib. The k=2 case is fully proved using Mathlib's Poincaré recurrence; the full theorem requires only 2 well-defined axioms (correspondence principle + k≥3 multiple recurrence).",
+    "summary": "This formalization demonstrates that Furstenberg's ergodic approach to Szemerédi's theorem can be formalized in Lean 4 using Mathlib. The Correspondence Principle is fully machine-checked (2026-07-24) via the Cantor-space construction of the OQ-01 companion file, making the k=2 case axiom-free; the full theorem rests on the single multiple-recurrence axiom (k≥3), whose elimination needs ergodic decomposition (~2000+ lines, not yet in Mathlib).",
     "implications": "The ergodic approach to combinatorics is within reach of current Lean 4 + Mathlib infrastructure. The main bottleneck is the ~2000+ lines needed for ergodic decomposition and multiple recurrence, not any foundational limitation. This opens a path to formalizing:\n- Polynomial Szemerédi theorem (Bergelson-Leibman)\n- IP Szemerédi theorem\n- Furstenberg-Katznelson multidimensional Szemerédi",
     "openQuestions": [
       "Can the Furstenberg correspondence construction be fully formalized using Mathlib's ultrafilter/compactness tools?",
@@ -186,9 +186,9 @@
       "Set"
     ],
     "namespace": "Furstenberg",
-    "lineCount": 253,
-    "axiomCount": 2,
-    "theoremCount": 4,
+    "lineCount": 284,
+    "axiomCount": 1,
+    "theoremCount": 5,
     "definitionCount": 2,
     "path": "Proofs/FurstenbergCorrespondence.lean",
     "sorries": 0

--- a/src/data/research/problems/szemeredi-full-oq-01.json
+++ b/src/data/research/problems/szemeredi-full-oq-01.json
@@ -18,20 +18,21 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-24",
-    "iteration": 15,
-    "focus": "S14 ACT (researcher-1, 2026-07-24): PROKHOROV AXIOM ELIMINATED. seqCompact_probabilityMeasure_cantor converted axiom -> theorem in 3 lines: Mathlib v4.31 Prokhorov (CompactSpace (ProbabilityMeasure E) for compact E) + Levy-Prokhorov metrizability (=> first-countable) + CompactSpace.tendsto_subseq. FurstenbergCorrespondenceOQ01.lean now 0 axioms / 0 sorries, Docker-GREEN (8576 jobs). Gallery meta upgraded to verified/original/0; annotations refreshed.",
+    "iteration": 16,
+    "focus": "S15 (researcher-1, 2026-07-24): CORRESPONDENCE AXIOM ELIMINATED. Part XV added to FurstenbergCorrespondenceOQ01.lean (967->1203 LOC): moving-base limit invariance, clopen measurable cylinders, limit_measurePreserving (pi-system upgrade via ext_of_generate_finite over measurableCylinders), limit_positive_implies_ap, package theorem exists_invariant_measure_correspondence. Parent FurstenbergCorrespondence.lean: axiom furstenberg_correspondence -> theorem (foundational axioms only), file 2 -> 1 axioms. szemeredi_k2_ergodic now fully verified; szemeredi_ergodic depends only on multiple_recurrence_ge3. Docker GREEN 8577 jobs.",
     "blockers": [
       "RESOLVED (S13, 2026-07-23): the 28-error v4.26 build regression was repaired by the v4.31 toolchain migration (#39062); baseline and post-fill docker builds are clean."
     ],
-    "nextAction": "S15 ACT: assemble Furstenberg.System on (CantorSpace, shift, cylinderZero) — all ingredients are now proved (Prokhorov extraction, limit_invariant_on_cylinder T-invariance, density_preserved_at_limit). Then use the assembled system to eliminate the furstenberg_correspondence axiom in the parent FurstenbergCorrespondence.lean, which is the actual szemeredi-full-oq-01 target.",
+    "nextAction": "S16: the sole remaining axiom multiple_recurrence_ge3 (Furstenberg multiple recurrence, k>=3) — deep ergodic theory (ergodic decomposition + characteristic factors, ~2000+ LOC, not in Mathlib v4.31). NOT session-sized. Before any attempt, grep current Mathlib for ergodic decomposition (S14 meta-lesson: upstream growth retires local axioms wholesale).",
     "attemptCounts": {
       "total": 9,
       "currentApproach": 1,
       "approachesTried": 4
-    }
+    },
+    "lastUpdate": "2026-07-24T11:50:00.000Z"
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: FurstenbergCorrespondenceOQ01.lean is fully machine-checked — 0 axioms, 0 sorries (S13 killed the last sorry, S14 the last axiom). Gallery entry furstenberg-correspondence-oq-01 upgraded verified/original. Remaining for the OQ target: assemble Furstenberg.System from the proved pieces and eliminate the parent correspondence axiom in FurstenbergCorrespondence.lean.",
+    "progressSummary": "S15 (2026-07-24): Furstenberg Correspondence Principle PROVED end-to-end — parent axiom eliminated (2->1 axioms), szemeredi_k2_ergodic fully machine-verified with zero custom axioms, szemeredi_ergodic down to the single multiple-recurrence axiom. The OQ-01 Cantor-space construction is complete: Cesaro averages + Prokhorov (S14) + moving-base T-invariance + pi-system MeasurePreserving upgrade + Portmanteau return (S15).",
     "builtItems": [
       "finsetDirac_apply: sum of Dirac measures on measurable set = filter cardinality (OQ01.lean:316)",
       "cesaroMeasure: N-step Cesaro probability measure definition (OQ01.lean:334)",
@@ -43,7 +44,9 @@
       "limit_invariant_on_cylinder: complete proof structure (~60 lines) replacing T-invariance sorry at FurstenbergCorrespondenceOQ01.lean:748 — uses ProbabilityMeasure.tendsto_measure_of_null_frontier_of_tendsto + ENNReal.Tendsto.add + telescoping bounds; not locally validated due to file-wide build blocker",
       "PR #14878: 6 Mathlib API drift fixes in FurstenbergCorrespondenceOQ01.lean — restores buildability after 35-error cascade (Session 7, 2026-05-02)",
       "limit_invariant_on_cylinder PROVED in Proofs/FurstenbergCorrespondenceOQ01.lean:762 (exact T-invariance of weak-* limit of Cesaro measures on clopen sets) — docker-verified 2026-07-23, sorry count 1->0",
-      "seqCompact_probabilityMeasure_cantor in FurstenbergCorrespondenceOQ01.lean — former local axiom, now a theorem (Prokhorov + Levy-Prokhorov metrization + CompactSpace.tendsto_subseq)"
+      "seqCompact_probabilityMeasure_cantor in FurstenbergCorrespondenceOQ01.lean — former local axiom, now a theorem (Prokhorov + Levy-Prokhorov metrization + CompactSpace.tendsto_subseq)",
+      "S15: Part XV of FurstenbergCorrespondenceOQ01.lean — limit_invariant_on_clopen_moving, isClopen_of_mem_measurableCylinders, limit_measurePreserving, limit_positive_implies_ap, kfold_two_eq_pair, exists_invariant_measure_correspondence",
+      "S15: FurstenbergCorrespondence.lean furstenberg_correspondence axiom -> theorem (foundational only); szemeredi_k2_ergodic now axiom-free; gallery furstenberg-correspondence meta 2 -> 1 axioms"
     ],
     "insights": [
       "FurstenbergCorrespondence.lean already exists with szemeredi_k2_ergodic proved via Poincaré recurrence",
@@ -68,7 +71,10 @@
       "File status after S13: 0 sorries, 1 axiom (seqCompact_probabilityMeasure_cantor). The full Furstenberg correspondence now reduces to Prokhorov sequential compactness alone.",
       "S14: Mathlib v4.31 ships Prokhorov upstream (Mathlib.MeasureTheory.Measure.Prokhorov, Gouezel 2025): CompactSpace (ProbabilityMeasure E) for any compact T2 Borel E, with NO second-countability needed (proof via Riesz-Markov-Kakutani on ultrafilters). Combined with LevyProkhorovMetric metrizability (separable pseudo-metrizable Borel X) sequential compactness is just CompactSpace.tendsto_subseq — the 150-200-line local-axiom estimate from 2026-05 became 3 lines.",
       "S14: BorelSpace (N -> Bool) is found by typeclass search (Pi.borelSpace, countable index, discrete factors) — no manual instance needed for the Prokhorov instance to fire on CantorSpace.",
-      "S14 meta-lesson: before hand-assembling a stated-as-axiom classical analysis fact, grep the CURRENT Mathlib tree for the exact instance (ls Mathlib/MeasureTheory/Measure/ | grep -i prokhorov) — upstream growth between toolchain bumps retires local axioms wholesale."
+      "S14 meta-lesson: before hand-assembling a stated-as-axiom classical analysis fact, grep the CURRENT Mathlib tree for the exact instance (ls Mathlib/MeasureTheory/Measure/ | grep -i prokhorov) — upstream growth between toolchain bumps retires local axioms wholesale.",
+      "pi-system upgrade recipe (S15, reusable): clopen-set measure equality extends to all Borel sets via ext_of_generate_finite (measurableCylinders alpha) generateFrom_measurableCylinders.symm isPiSystem_measurableCylinders — the exact IsProjectiveLimit.unique invocation pattern; measurable cylinders over (nat -> Bool) are clopen because the finite discrete target makes every base set clopen (Pi.discreteTopology + isClopen_discrete).",
+      "Moving base points are REQUIRED for upper Banach density: the windows [a_k, a_k+N_k) move, so Cesaro measures sit at varying orbit points shift^[a_k](1_A); the telescoping approximate-invariance bounds are uniform in the base point, so the fixed-base limit argument generalizes verbatim.",
+      "v4.31 gotchas (S15): omega cannot see through tactic-let bindings (show-unfold first); simp with an IsClopen fact stated at (cylinder 0 true) fails against a goal at cylinderZero (regular def) — restate the fact at cylinderZero via defeq have; structure-literal projection goals need an explicit defeq have before rw."
     ],
     "mathlibGaps": [
       "Prokhorov theorem: sequential compactness of ProbabilityMeasure on compact metrizable space (~150-200 lines to assemble from Mathlib v4.26 ingredients)",
@@ -99,7 +105,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.383Z",
-  "lastUpdate": "2026-07-24",
+  "lastUpdate": "2026-07-24T11:50:00.000Z",
   "significance": 9,
   "tractability": 4,
   "leanFiles": [
@@ -113,6 +119,28 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediFullOQ02.lean"
+    },
+    {
+      "path": "Proofs/FurstenbergCorrespondenceOQ01.lean",
+      "filename": "FurstenbergCorrespondenceOQ01.lean",
+      "lineCount": 1203,
+      "theoremCount": 37,
+      "axiomCount": 0,
+      "defCount": 9,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FurstenbergCorrespondenceOQ01.lean"
+    },
+    {
+      "path": "Proofs/FurstenbergCorrespondence.lean",
+      "filename": "FurstenbergCorrespondence.lean",
+      "lineCount": 284,
+      "theoremCount": 5,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FurstenbergCorrespondence.lean"
     }
   ],
   "lastUpdated": "2026-07-23"


### PR DESCRIPTION
## Summary

Research session S15 for **szemeredi-full-oq-01**: the **Furstenberg Correspondence Principle — Axiom 1 of `Proofs/FurstenbergCorrespondence.lean` — is now a machine-checked THEOREM** (`#print axioms` = `propext, Classical.choice, Quot.sound`). This completes the arc S13 (T-invariance on cylinders) → S14 (Prokhorov axiom eliminated) → S15 (full assembly + parent axiom elimination).

Downstream consequences:
- `szemeredi_k2_ergodic` (positive upper-Banach-density sets contain 2-term APs, via the ergodic route) is now **fully verified with zero custom axioms**.
- `szemeredi_ergodic` (k-APs for all k) is down to exactly **one** axiom (`multiple_recurrence_ge3`), from two.
- Parent file: **2 → 1 axioms**.

## Progress

`FurstenbergCorrespondenceOQ01.lean` 967 → 1203 LOC (Part XV, 6 new theorems, still 0 ax / 0 sorry):
- `limit_invariant_on_clopen_moving` — Part XII's limit T-invariance generalized to **moving base points** (upper *Banach* density windows move; the telescoping bounds are base-uniform).
- `isClopen_of_mem_measurableCylinders` — measurable cylinders over `ℕ → Bool` are clopen (finite discrete target + continuous restriction).
- `limit_measurePreserving` — **the key upgrade**: clopen-set invariance → full `MeasurePreserving shift μ μ` via `ext_of_generate_finite` over Mathlib's `measurableCylinders` π-system (the `IsProjectiveLimit.unique` invocation pattern).
- `limit_positive_implies_ap` — positive limit measure on the clopen k-fold return set transfers back to some Cesàro average (Portmanteau + `Tendsto.eventually_ne`), where Part XIII extracts the AP.
- `kfold_two_eq_pair` + `exists_invariant_measure_correspondence` — the full correspondence package (invariant measure, `μ(B₀) ≥ δ`, k-fold return ⇒ k-AP).

`FurstenbergCorrespondence.lean` 253 → 284 LOC: `axiom furstenberg_correspondence` → `theorem`, proved by instantiating `System` on `(CantorSpace, shift, B₀)` with the package measure; pair-return clause derived from the k-fold clause at k = 2. Header/docstrings/summary table de-axiomatized honestly.

## Verification

- Host `lake env lean`: both files exit 0.
- `#print axioms`: `furstenberg_correspondence`, `szemeredi_k2_ergodic`, `exists_invariant_measure_correspondence`, `limit_measurePreserving` → foundational only; `szemeredi_ergodic` → foundational + `multiple_recurrence_ge3`.
- Docker: `Built Proofs.FurstenbergCorrespondenceOQ01` + `Built Proofs.FurstenbergCorrespondence` (8577 jobs), exit 0.

## Gallery

- `furstenberg-correspondence/meta.json`: axiomCount 2 → 1 (meta + leanFile), theoremCount 4 → 5, assumptions/overview/sections/conclusion prose updated; status stays `axiomatized` (1 axiom remains).
- `furstenberg-correspondence-oq-01/meta.json`: counts refreshed (1203 LOC / 37 thm), still verified/original/0.

## Status

**Outcome**: progress (major: correspondence axiom eliminated)
**Next Steps**: S16 = the sole remaining axiom `multiple_recurrence_ge3` — genuine deep ergodic theory (ergodic decomposition + characteristic factors, ~2000+ LOC, not in Mathlib v4.31). Not session-sized; re-check Mathlib growth first.

🤖 Generated by researcher-1
