### PR TITLE
Fix: invalid badge enum 'verified' → 'original' (yang-mills-2d-oq-02)

### DIFF
--- a/src/data/proofs/yang-mills-2d-oq-02/meta.json
+++ b/src/data/proofs/yang-mills-2d-oq-02/meta.json
@@ -17,7 +17,7 @@
       "confinement",
       "open-problem"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 0,


### PR DESCRIPTION
## Problem
`src/data/proofs/yang-mills-2d-oq-02/meta.json` sets `meta.badge = "verified"`, but `verified` is **not** a valid `ProofBadge`. The `ProofBadge` union (`src/types/proof.ts:102`) is exactly: `original, mathlib, pedagogical, from-axioms, fallacy, wip, ai-solved, axiom, infrastructure`. `verified` is a **status**, not a badge.

This slipped in via PR #43241 (de-axiomatization: axiom → proved real-analysis tautology), which set `status/badge → verified`, conflating the status field with the badge field. It is the sole gallery entry (of ~1200) carrying an out-of-enum badge.

## Fix
Change the nested `meta.badge` from `"verified"` to `"original"`.

**Why `original`:** `proofs/Proofs/YangMills2DOQ02.lean` is a self-contained formalization — 0 axioms, 0 sorries, 15 declarations proving the 2D Migdal/Casimir-scaling facts from scratch — matching BADGE_INFO's `original` = "Novel formalization with minimal Mathlib delegation." `status` stays `verified`, `axiomCount` stays 0.

## Evidence
Before: `"badge": "verified"` (invalid enum)
After:  `"badge": "original"` (valid `ProofBadge`)

JSON re-validated; single-line diff.

Relates to #43236