### PR TITLE
research(erdos-531): eliminate folkman_theorem axiom via Hindman + Rado selection (2→1 axioms)

### DIFF
--- a/proofs/Proofs/Erdos531Problem.lean
+++ b/proofs/Proofs/Erdos531Problem.lean
@@ -183,7 +183,8 @@ nonempty subset sums are monochromatic. -/
 theorem exists_monochromatic_of_coloring (c : Coloring) (k : ℕ) :
     ∃ A : Finset ℕ, A.card = k ∧ (∀ a ∈ A, 1 ≤ a) ∧ MonochromaticSubsetSums c A := by
   -- the stream 1, 2, 3, … of positive integers
-  have ha : ∀ i, 1 ≤ (fun n => n + 1 : Stream' ℕ).get i := fun i => Nat.le_add_left 1 i
+  have ha : ∀ i, 1 ≤ Stream'.get (fun n => n + 1 : Stream' ℕ) i :=
+    fun i => Nat.le_add_left 1 i
   -- cover the finite sums of that stream by the two color classes,
   -- intersected with the positive integers
   have scov : FS (fun n => n + 1 : Stream' ℕ) ⊆
@@ -191,8 +192,8 @@ theorem exists_monochromatic_of_coloring (c : Coloring) (k : ℕ) :
     intro x hx
     have hx1 : 1 ≤ x := fs_pos hx ha
     rcases Bool.eq_false_or_eq_true (c x) with h | h
-    · exact Set.mem_sUnion.mpr ⟨_, Set.mem_insert_of_mem _ rfl, hx1, h⟩
     · exact Set.mem_sUnion.mpr ⟨_, Set.mem_insert _ _, hx1, h⟩
+    · exact Set.mem_sUnion.mpr ⟨_, Set.mem_insert_of_mem _ rfl, hx1, h⟩
   obtain ⟨cl, hcl, b, hb⟩ := FS_partition_regular (fun n => n + 1 : Stream' ℕ) _
     ((Set.finite_singleton _).insert _) scov
   obtain ⟨col, rfl⟩ : ∃ col : Bool, cl = {x : ℕ | 1 ≤ x ∧ c x = col} := by
@@ -240,7 +241,7 @@ theorem folkman_theorem :
     ∀ k : ℕ, k ≥ 1 → ∃ N : ℕ, ExistsMonochromaticSet N k := by
   intro k _
   by_contra hcon
-  push_neg at hcon
+  push Not at hcon
   -- for every `N` pick a coloring with no monochromatic `k`-set inside `{1, …, N}`
   have hbad : ∀ N : ℕ, ∃ cb : Coloring, ∀ A : Finset ℕ,
       ¬(A.card = k ∧ (∀ a ∈ A, 1 ≤ a ∧ a ≤ N) ∧ MonochromaticSubsetSums cb A) := by
@@ -256,7 +257,7 @@ theorem folkman_theorem :
   · intro x hx
     exact ⟨hpos x hx, Finset.le_sup (f := id) (hst (self_mem_subsetSums hx))⟩
   · intro s hs
-    rw [← hagree s (hst hs)]
+    rw [← hagree s hs]
     exact hcol s hs
 
 /-- F(k) is well-defined (the set ValidN k is non-empty). -/

--- a/proofs/Proofs/Erdos531Problem.lean
+++ b/proofs/Proofs/Erdos531Problem.lean
@@ -565,9 +565,13 @@ The equation system is:
 - We want all yₛ to be monochromatic.
 
 Rado's theorem guarantees this for any k.
+
+(This is the classical alternative route. The formal proof of `folkman_theorem`
+above instead derives it from Hindman's theorem plus Rado's *selection
+principle*, both available in Mathlib.)
 -/
 
-/-  Folkman follows from Rado's theorem. -/
+/-  Folkman follows from Rado's theorem (classical alternative derivation). -/
 /-
 ## The Main Question
 

--- a/proofs/Proofs/Erdos531Problem.lean
+++ b/proofs/Proofs/Erdos531Problem.lean
@@ -64,14 +64,200 @@ noncomputable def F (k : ℕ) : ℕ := sInf (ValidN k)
 /-
 ## Folkman's Theorem
 
-The existence of F(k) is Folkman's theorem. For any k, F(k) is finite.
-This follows from Rado's theorem applied to the system of equations
-x₁ + x₂ + ... + xⱼ = s for all non-empty subsets.
+The existence of F(k) is Folkman's theorem. We derive it here as a genuine
+theorem (no axiom) from two Mathlib results:
+
+1. **Hindman's theorem** (`Hindman.FS_partition_regular`): in any finite cover
+   of an FS-set (the set of finite sums of a stream), some part contains an
+   FS-set. Applying this to the stream 1, 2, 3, … and the cover of its finite
+   sums by the two color classes (intersected with the positive integers)
+   yields a stream `b` whose finite sums are all positive and monochromatic.
+   Grouping `b` into consecutive blocks, each one longer than the previous
+   block's sum, makes the block sums strictly increasing; the sums of `k`
+   blocks then form a `k`-element set of positive integers all of whose
+   nonempty subset sums lie in `FS b`, hence are monochromatic.
+2. **Rado's selection principle** (`Finset.rado_selection`): the compactness
+   step. If no single `N` worked uniformly, the bad colorings `c_N` chosen for
+   each `N` could be stitched into one coloring `χ` of ℕ agreeing with some
+   `c_N` on any prescribed finite set; a monochromatic `k`-set for `χ` (from
+   step 1) would then be monochromatic for some bad `c_N` with all elements
+   `≤ N`, a contradiction.
 -/
 
-/-- Folkman's Theorem: F(k) exists for all k. -/
-axiom folkman_theorem :
-  ∀ k : ℕ, k ≥ 1 → ∃ N : ℕ, ExistsMonochromaticSet N k
+/-- Every element of `A` is itself a subset sum of `A`, via the singleton subset. -/
+theorem self_mem_subsetSums {A : Finset ℕ} {a : ℕ} (ha : a ∈ A) : a ∈ SubsetSums A := by
+  simp only [SubsetSums, Finset.mem_image, Finset.mem_filter, Finset.mem_powerset]
+  exact ⟨{a}, ⟨Finset.singleton_subset_iff.mpr ha, Finset.singleton_ne_empty a⟩, by simp⟩
+
+open Hindman in
+/-- Every finite sum from a stream of positive naturals is positive. -/
+theorem fs_pos {a : Stream' ℕ} {m : ℕ} (hm : m ∈ FS a) : (∀ i, 1 ≤ a.get i) → 1 ≤ m := by
+  induction hm with
+  | head' a => exact fun ha => ha 0
+  | tail' a m h ih => exact fun ha => ih fun i => ha (i + 1)
+  | cons' a m h ih =>
+    exact fun ha => le_trans (ih fun i => ha (i + 1)) (Nat.le_add_left m a.head)
+
+/-- Block boundaries for the Folkman construction: `(folkmanBlocks b j).1` is the
+start index of the `j`-th block of the stream `b` and `(folkmanBlocks b j).2` its
+length. Each block is one longer than the previous block's sum, which forces the
+block sums to be strictly increasing when all entries of `b` are positive. -/
+def folkmanBlocks (b : Stream' ℕ) : ℕ → ℕ × ℕ
+  | 0 => (0, 1)
+  | j + 1 =>
+    ((folkmanBlocks b j).1 + (folkmanBlocks b j).2,
+      (∑ i ∈ Finset.Ico (folkmanBlocks b j).1
+        ((folkmanBlocks b j).1 + (folkmanBlocks b j).2), b.get i) + 1)
+
+/-- The `j`-th block of indices. -/
+def blockFinset (b : Stream' ℕ) (j : ℕ) : Finset ℕ :=
+  Finset.Ico (folkmanBlocks b j).1 ((folkmanBlocks b j).1 + (folkmanBlocks b j).2)
+
+/-- The sum of the stream `b` over the `j`-th block. -/
+def blockSum (b : Stream' ℕ) (j : ℕ) : ℕ := ∑ i ∈ blockFinset b j, b.get i
+
+theorem folkmanBlocks_succ_fst (b : Stream' ℕ) (j : ℕ) :
+    (folkmanBlocks b (j + 1)).1 = (folkmanBlocks b j).1 + (folkmanBlocks b j).2 := by
+  simp [folkmanBlocks]
+
+theorem folkmanBlocks_succ_snd (b : Stream' ℕ) (j : ℕ) :
+    (folkmanBlocks b (j + 1)).2 = blockSum b j + 1 := by
+  simp [folkmanBlocks, blockSum, blockFinset]
+
+theorem blockLen_pos (b : Stream' ℕ) (j : ℕ) : 1 ≤ (folkmanBlocks b j).2 := by
+  cases j with
+  | zero => simp [folkmanBlocks]
+  | succ j => rw [folkmanBlocks_succ_snd]; omega
+
+theorem blockFinset_nonempty (b : Stream' ℕ) (j : ℕ) : (blockFinset b j).Nonempty :=
+  Finset.nonempty_Ico.mpr (by have := blockLen_pos b j; omega)
+
+/-- When all entries of `b` are positive, each block sum is at least the block length. -/
+theorem blockLen_le_blockSum (b : Stream' ℕ) (hb : ∀ i, 1 ≤ b.get i) (j : ℕ) :
+    (folkmanBlocks b j).2 ≤ blockSum b j := by
+  have h := Finset.card_nsmul_le_sum (blockFinset b j) (fun i => b.get i) 1
+    (fun i _ => hb i)
+  simpa [blockFinset, blockSum, Nat.card_Ico, smul_eq_mul] using h
+
+theorem blockSum_pos (b : Stream' ℕ) (hb : ∀ i, 1 ≤ b.get i) (j : ℕ) :
+    1 ≤ blockSum b j :=
+  le_trans (blockLen_pos b j) (blockLen_le_blockSum b hb j)
+
+/-- The block sums are strictly increasing: each block is longer than the
+previous block's sum, and every entry is at least 1. -/
+theorem blockSum_strictMono (b : Stream' ℕ) (hb : ∀ i, 1 ≤ b.get i) :
+    StrictMono (blockSum b) := by
+  apply strictMono_nat_of_lt_succ
+  intro j
+  have h1 := blockLen_le_blockSum b hb (j + 1)
+  rw [folkmanBlocks_succ_snd] at h1
+  omega
+
+theorem blockStart_mono (b : Stream' ℕ) : Monotone fun j => (folkmanBlocks b j).1 := by
+  apply monotone_nat_of_le_succ
+  intro j
+  rw [folkmanBlocks_succ_fst]
+  exact Nat.le_add_right _ _
+
+/-- Distinct blocks are disjoint (they are consecutive intervals). -/
+theorem blockFinset_disjoint (b : Stream' ℕ) {i j : ℕ} (hij : i ≠ j) :
+    Disjoint (blockFinset b i) (blockFinset b j) := by
+  wlog h : i < j generalizing i j
+  · exact (this (Ne.symm hij) (by omega)).symm
+  rw [Finset.disjoint_left]
+  intro x hxi hxj
+  simp only [blockFinset, Finset.mem_Ico] at hxi hxj
+  have h2 : (folkmanBlocks b i).1 + (folkmanBlocks b i).2 ≤ (folkmanBlocks b j).1 := by
+    rw [← folkmanBlocks_succ_fst]
+    exact blockStart_mono b h
+  omega
+
+open Hindman in
+theorem blockSum_mem_FS (b : Stream' ℕ) (j : ℕ) : blockSum b j ∈ FS b :=
+  FS.finsetSum b (blockFinset b j) (blockFinset_nonempty b j)
+
+open Hindman in
+/-- **Infinite Folkman theorem** (via Hindman's theorem): every 2-coloring of ℕ
+admits, for every `k`, a `k`-element set of positive integers all of whose
+nonempty subset sums are monochromatic. -/
+theorem exists_monochromatic_of_coloring (c : Coloring) (k : ℕ) :
+    ∃ A : Finset ℕ, A.card = k ∧ (∀ a ∈ A, 1 ≤ a) ∧ MonochromaticSubsetSums c A := by
+  -- the stream 1, 2, 3, … of positive integers
+  have ha : ∀ i, 1 ≤ (fun n => n + 1 : Stream' ℕ).get i := fun i => Nat.le_add_left 1 i
+  -- cover the finite sums of that stream by the two color classes,
+  -- intersected with the positive integers
+  have scov : FS (fun n => n + 1 : Stream' ℕ) ⊆
+      ⋃₀ {{x : ℕ | 1 ≤ x ∧ c x = true}, {x : ℕ | 1 ≤ x ∧ c x = false}} := by
+    intro x hx
+    have hx1 : 1 ≤ x := fs_pos hx ha
+    rcases Bool.eq_false_or_eq_true (c x) with h | h
+    · exact Set.mem_sUnion.mpr ⟨_, Set.mem_insert_of_mem _ rfl, hx1, h⟩
+    · exact Set.mem_sUnion.mpr ⟨_, Set.mem_insert _ _, hx1, h⟩
+  obtain ⟨cl, hcl, b, hb⟩ := FS_partition_regular (fun n => n + 1 : Stream' ℕ) _
+    ((Set.finite_singleton _).insert _) scov
+  obtain ⟨col, rfl⟩ : ∃ col : Bool, cl = {x : ℕ | 1 ≤ x ∧ c x = col} := by
+    rcases Set.mem_insert_iff.mp hcl with h | h
+    · exact ⟨true, h⟩
+    · exact ⟨false, Set.mem_singleton_iff.mp h⟩
+  have hbFS : ∀ x ∈ FS b, 1 ≤ x ∧ c x = col := fun x hx => hb hx
+  have hbpos : ∀ i, 1 ≤ b.get i := fun i => (hbFS _ (FS.singleton b i)).1
+  refine ⟨(Finset.range k).image (blockSum b), ?_, ?_, col, ?_⟩
+  · rw [Finset.card_image_of_injective _ (blockSum_strictMono b hbpos).injective,
+      Finset.card_range]
+  · intro x hx
+    obtain ⟨j, -, rfl⟩ := Finset.mem_image.mp hx
+    exact (hbFS _ (blockSum_mem_FS b j)).1
+  · -- every nonempty subset sum is a sum of `b` over a union of disjoint
+    -- blocks, hence lies in `FS b` and carries the color `col`
+    intro s hs
+    simp only [SubsetSums, Finset.mem_image, Finset.mem_filter, Finset.mem_powerset] at hs
+    obtain ⟨t, ⟨hts, htne⟩, rfl⟩ := hs
+    obtain ⟨u, hu, rfl⟩ := Finset.subset_image_iff.mp hts
+    have hinj : ∀ x ∈ u, ∀ y ∈ u, blockSum b x = blockSum b y → x = y :=
+      fun x _ y _ hxy => (blockSum_strictMono b hbpos).injective hxy
+    have hune : u.Nonempty := by
+      rcases Finset.eq_empty_or_nonempty u with rfl | h
+      · simp at htne
+      · exact h
+    have hbiune : (u.biUnion (blockFinset b)).Nonempty := by
+      obtain ⟨j, hj⟩ := hune
+      obtain ⟨i, hi⟩ := blockFinset_nonempty b j
+      exact ⟨i, Finset.mem_biUnion.mpr ⟨j, hj, hi⟩⟩
+    have hdisj : (↑u : Set ℕ).PairwiseDisjoint (blockFinset b) :=
+      fun i _ j _ hij => blockFinset_disjoint b hij
+    have hsum : ∑ x ∈ Finset.image (blockSum b) u, id x
+        = ∑ i ∈ u.biUnion (blockFinset b), b.get i := by
+      rw [Finset.sum_image hinj, Finset.sum_biUnion hdisj]
+      simp [blockSum]
+    calc c (∑ x ∈ Finset.image (blockSum b) u, id x)
+        = c (∑ i ∈ u.biUnion (blockFinset b), b.get i) := by rw [hsum]
+      _ = col := (hbFS _ (FS.finsetSum b _ hbiune)).2
+
+/-- **Folkman's Theorem**: F(k) exists for all k. Derived from Hindman's theorem
+together with Rado's selection principle (the compactness step); both are
+Mathlib theorems, so this carries no axioms beyond Lean's foundations. -/
+theorem folkman_theorem :
+    ∀ k : ℕ, k ≥ 1 → ∃ N : ℕ, ExistsMonochromaticSet N k := by
+  intro k _
+  by_contra hcon
+  push_neg at hcon
+  -- for every `N` pick a coloring with no monochromatic `k`-set inside `{1, …, N}`
+  have hbad : ∀ N : ℕ, ∃ cb : Coloring, ∀ A : Finset ℕ,
+      ¬(A.card = k ∧ (∀ a ∈ A, 1 ≤ a ∧ a ≤ N) ∧ MonochromaticSubsetSums cb A) := by
+    intro N
+    obtain ⟨cb, hcb⟩ := not_forall.mp (hcon N)
+    exact ⟨cb, not_exists.mp hcb⟩
+  choose cN hcN using hbad
+  -- stitch the bad colorings together with Rado's selection principle
+  obtain ⟨χ, hχ⟩ := Finset.rado_selection (fun s => cN (s.sup id))
+  obtain ⟨A, hcard, hpos, col, hcol⟩ := exists_monochromatic_of_coloring χ k
+  obtain ⟨t, hst, hagree⟩ := hχ (SubsetSums A)
+  refine hcN (t.sup id) A ⟨hcard, ?_, col, ?_⟩
+  · intro x hx
+    exact ⟨hpos x hx, Finset.le_sup (f := id) (hst (self_mem_subsetSums hx))⟩
+  · intro s hs
+    rw [← hagree s (hst hs)]
+    exact hcol s hs
 
 /-- F(k) is well-defined (the set ValidN k is non-empty). -/
 theorem F_well_defined (k : ℕ) (hk : k ≥ 1) : (ValidN k).Nonempty :=

--- a/research/problems/erdos-531-incomplete-01/knowledge.md
+++ b/research/problems/erdos-531-incomplete-01/knowledge.md
@@ -24,6 +24,41 @@ This rfl-bridge pattern applies to ANY Aristotle companion that re-declares the
 parent's definitions instead of importing them — no proof duplication needed
 (the F 2 = 8 kernel certificate is NOT re-run in the companion).
 
+## Session 2026-07-24 (researcher-3): folkman_theorem AXIOM ELIMINATED (2→1 axioms)
+
+PR #43308. `folkman_theorem` is now a PROVED theorem — `#print axioms` shows
+foundational only. Derivation (all-Mathlib, no new assumptions):
+
+1. **Infinite Folkman from Hindman**: `Hindman.FS_partition_regular` applied to
+   the stream `fun n => n + 1` with the cover `{positives ∩ true-class,
+   positives ∩ false-class}` (intersecting with positives is REQUIRED — the
+   theorem returns only `FS b ⊆ c`, dropping `FS b ⊆ FS a`, so positivity must
+   ride inside the cover sets). `fs_pos` (induction over the `FS` inductive,
+   stating the hypothesis as an implication so it generalizes over tails)
+   gives positivity of `FS` of a positive stream.
+2. **Distinct elements**: `folkmanBlocks` groups `b` into consecutive `Ico`
+   blocks, each one longer than the previous block sum → block sums strictly
+   increasing (`Finset.card_nsmul_le_sum`). Subset sums = sums over disjoint
+   block unions ∈ `FS b` via `Hindman.FS.finsetSum` + `Finset.sum_biUnion`.
+3. **Compactness**: `Finset.rado_selection` (Mathlib Combinatorics/Compactness,
+   Bhavik Mehta 2025) with `g s = c_N (s.sup id)` stitches per-N bad colorings;
+   apply infinite version to `χ`, take `t ⊇ SubsetSums A`, `N = t.sup id`.
+
+Lean gotchas: `(fun n => n+1 : Stream' ℕ).get` FAILS field resolution (type
+shows as `ℕ → ℕ`) — write `Stream'.get (fun n => n+1 : Stream' ℕ) i` explicitly;
+`push_neg` deprecated in this Mathlib → `push Not at h`; `Bool.eq_false_or_eq_true`
+branch order surprising — compile and swap.
+
+## File inventory (post-session)
+- `Erdos531Problem.lean`: 0 sorries, 1 axiom (balogh_2017 — literature, stays).
+- 29 theorems, 12 defs, 614 lines. F_2 kernel certificate untouched.
+
+## Remaining
+Only balogh_2017 (deep 2017 paper lower bound — multi-quarter, stand down) and
+the OPEN growth-rate question. Elementary layer FULLY exhausted; the only
+axiom left is a genuine literature citation.
+
+<!-- superseded inventory below -->
 ## File inventory (post-session)
 - `Erdos531Problem.lean`: 0 sorries, 2 axioms (folkman_theorem, balogh_2017 — literature, stay).
 - `Erdos531Incomplete01.lean`: 0 sorries, 0 axioms.

--- a/src/data/proofs/erdos-531/annotations.json
+++ b/src/data/proofs/erdos-531/annotations.json
@@ -227,7 +227,7 @@
     "proofId": "erdos-531",
     "range": {
       "startLine": 558,
-      "endLine": 571
+      "endLine": 576
     },
     "type": "concept",
     "title": "Connection to Rado's Theorem",

--- a/src/data/proofs/erdos-531/annotations.json
+++ b/src/data/proofs/erdos-531/annotations.json
@@ -227,7 +227,7 @@
     "proofId": "erdos-531",
     "range": {
       "startLine": 558,
-      "endLine": 576
+      "endLine": 574
     },
     "type": "concept",
     "title": "Connection to Rado's Theorem",

--- a/src/data/proofs/erdos-531/annotations.json
+++ b/src/data/proofs/erdos-531/annotations.json
@@ -114,30 +114,32 @@
     "id": "ann-e531-folkman",
     "proofId": "erdos-531",
     "range": {
-      "startLine": 72,
-      "endLine": 78
+      "startLine": 240,
+      "endLine": 262
     },
     "type": "concept",
     "title": "Folkman's Theorem",
-    "content": "**folkman_theorem:**\n\nFor all k ≥ 1, there exists N such that any 2-coloring of {1,...,N} has a k-element set with monochromatic subset sums.\n\n```lean\naxiom folkman_theorem :\n  ∀ k : ℕ, k ≥ 1 → ∃ N : ℕ, ExistsMonochromaticSet N k\n```\n\nThis can be derived from Rado's theorem on partition regularity of linear systems.",
-    "mathContext": "Originally proved by Sanders and Folkman in the 1960s.",
+    "content": "**folkman_theorem — now a proved theorem (formerly an axiom):**\n\nFor all k ≥ 1, there exists N such that any 2-coloring of {1,...,N} has a k-element set with monochromatic subset sums.\n\n```lean\ntheorem folkman_theorem :\n    ∀ k : ℕ, k ≥ 1 → ∃ N : ℕ, ExistsMonochromaticSet N k\n```\n\nThe proof combines two Mathlib results. **Hindman's theorem** (`Hindman.FS_partition_regular`) gives the infinite version (`exists_monochromatic_of_coloring`): covering the finite sums of the stream 1, 2, 3, … by the two color classes (intersected with the positive integers) yields a stream `b` whose finite sums are positive and monochromatic; grouping `b` into consecutive blocks, each one longer than the previous block's sum, makes the block sums strictly increasing, and k block sums form the required set. **Rado's selection principle** (`Finset.rado_selection`) supplies the compactness step: if no uniform N existed, the per-N bad colorings would stitch into a single coloring with no monochromatic k-set at all, contradicting the infinite version. `#print axioms` confirms only propext, Classical.choice, Quot.sound.",
+    "mathContext": "Originally proved by Sanders and Folkman in the 1960s; here derived from Hindman's theorem (1974), whose Galvin–Glazer ultrafilter proof is formalized in Mathlib.",
     "significance": "key",
     "relatedConcepts": [
-      "Rado's theorem",
+      "Hindman's theorem",
+      "Rado's selection principle",
       "Partition regularity"
     ],
     "prerequisites": [
       "combinatorics",
       "additive number theory",
-      "Lean 4 axiom declarations"
+      "Hindman's theorem",
+      "compactness arguments"
     ]
   },
   {
     "id": "ann-e531-erdos-spencer",
     "proofId": "erdos-531",
     "range": {
-      "startLine": 90,
-      "endLine": 92
+      "startLine": 270,
+      "endLine": 277
     },
     "type": "concept",
     "title": "Erdős-Spencer Lower Bound (1989)",
@@ -158,8 +160,8 @@
     "id": "ann-e531-balogh",
     "proofId": "erdos-531",
     "range": {
-      "startLine": 94,
-      "endLine": 96
+      "startLine": 278,
+      "endLine": 280
     },
     "type": "concept",
     "title": "Balogh et al. (2017)",
@@ -180,8 +182,8 @@
     "id": "ann-e531-small-cases",
     "proofId": "erdos-531",
     "range": {
-      "startLine": 104,
-      "endLine": 361
+      "startLine": 283,
+      "endLine": 548
     },
     "type": "concept",
     "title": "Small Cases",
@@ -202,8 +204,8 @@
     "id": "ann-e531-upper-bound",
     "proofId": "erdos-531",
     "range": {
-      "startLine": 122,
-      "endLine": 125
+      "startLine": 550,
+      "endLine": 556
     },
     "type": "concept",
     "title": "Upper Bounds",
@@ -224,8 +226,8 @@
     "id": "ann-e531-rado",
     "proofId": "erdos-531",
     "range": {
-      "startLine": 140,
-      "endLine": 146
+      "startLine": 558,
+      "endLine": 571
     },
     "type": "concept",
     "title": "Connection to Rado's Theorem",

--- a/src/data/proofs/erdos-531/meta.json
+++ b/src/data/proofs/erdos-531/meta.json
@@ -54,7 +54,7 @@
       "erdos_531 theorem: main result"
     ],
     "axiomCount": 1,
-    "lineCount": 615,
+    "lineCount": 614,
     "assumptions": "1 axiom: balogh_2017 (deep published lower bound). folkman_theorem is now a proved theorem (derived from Mathlib's Hindman theorem plus Rado's selection principle). 0 sorries.",
     "theoremCount": 29,
     "definitionCount": 12,
@@ -176,7 +176,7 @@
     ],
     "opens": [],
     "namespace": "Erdos531",
-    "lineCount": 615,
+    "lineCount": 614,
     "axiomCount": 1,
     "theoremCount": 29,
     "definitionCount": 12,

--- a/src/data/proofs/erdos-531/meta.json
+++ b/src/data/proofs/erdos-531/meta.json
@@ -47,17 +47,17 @@
       "MonochromaticSubsetSums definition: all sums same color",
       "ExistsMonochromaticSet definition: N guarantees k-set with monochromatic sums",
       "F function: minimum N for given k",
-      "folkman_theorem axiom: existence of F(k)",
+      "folkman_theorem: existence of F(k), PROVED (no axiom) from Mathlib's Hindman theorem (FS_partition_regular) plus Rado's selection principle (Finset.rado_selection) for the compactness step; includes the infinite Folkman theorem exists_monochromatic_of_coloring and a block-sum construction (folkmanBlocks) turning a monochromatic FS-stream into k distinct positive integers with monochromatic subset sums",
       "balogh_2017 axiom: F(k) ≥ 2^{2^{k-1}/k}",
       "F_1 theorem (F(1) = 1): fully proven via one_mem_validN_one and validN_one_ge_one (no sorry)",
       "F_2 theorem (F(2) = 8): value corrected from an earlier false F(2) = 3; fully proven via a kernel-decide finite-coloring reduction (forcedCheck_all over all 256 restrictions to {1,...,8}, plus the explicit N = 7 witness coloring). F(3) ≥ 11 documented in source comment only (no Lean declaration)",
       "erdos_531 theorem: main result"
     ],
-    "axiomCount": 2,
-    "lineCount": 423,
-    "assumptions": "2 axioms: folkman_theorem, balogh_2017 (deep published results). 0 sorries.",
-    "theoremCount": 14,
-    "definitionCount": 9,
+    "axiomCount": 1,
+    "lineCount": 610,
+    "assumptions": "1 axiom: balogh_2017 (deep published lower bound). folkman_theorem is now a proved theorem (derived from Mathlib's Hindman theorem plus Rado's selection principle). 0 sorries.",
+    "theoremCount": 29,
+    "definitionCount": 12,
     "additionalFiles": [
       "Proofs/Erdos531Aristotle.lean"
     ]
@@ -66,7 +66,7 @@
     "historicalContext": "**Erdős Problem #531: Folkman's Theorem**\n\nThis problem asks about the quantitative aspects of Folkman's theorem, a fundamental result in Ramsey theory.\n\n**Key History:**\n- Sanders and Folkman (1960s): Proved the existence of F(k)\n- Rado's theorem (1933): Provides an alternative proof via partition regularity\n- Erdős-Spencer (1989): First non-trivial lower bound F(k) ≥ 2^{ck²/log k}\n- Balogh et al. (2017): Improved to F(k) ≥ 2^{2^{k-1}/k}\n\n**Mathematical Setting:**\nThe function F(k) is the Folkman number: the minimum N such that any 2-coloring of {1,...,N} contains a k-element subset where all 2^k - 1 non-empty subset sums are monochromatic.",
     "problemStatement": "**Problem Statement (Bounds Established, Exact Growth Open)**\n\nLet F(k) be the minimal N such that if we two-colour {1,...,N}, there is a set A of size k such that all subset sums (for non-empty subsets) are monochromatic. Estimate F(k).\n\n**Known Results:**\n$$F(k) \\geq 2^{2^{k-1}/k}$$\n\nBalogh-Eberhard-Narayanan-Treglown-Wagner (2017) proved this doubly-exponential lower bound, improving on Erdős-Spencer (1989).\n\nThe upper bound (from Folkman's existence proof) is much larger, leaving a huge gap.",
     "text": "Estimate F(k), the minimal N such that any 2-coloring of {1,...,N} has a k-element set with monochromatic subset sums. Lower bound: F(k) ≥ 2^{2^{k-1}/k}.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Core Definitions:**\n   - Coloring: ℕ → Bool\n   - SubsetSums: all non-empty subset sums of a finite set\n   - MonochromaticSubsetSums: all sums have same color\n   - F(k): minimum N using sInf\n\n2. **Main Theorems as Axioms:**\n   - folkman_theorem: F(k) exists (finite for all k ≥ 1)\n   - balogh_2017: F(k) ≥ 2^{2^{k-1}/k}\n   - erdos_spencer_1989 (documented in source comment only; no Lean declaration exists)\n\n3. **Small Cases:** F_1 (F(1) = 1) is fully proven; F_2 (F(2) = 8) is fully proven: a kernel-decide check over all 256 colorings of {1,...,8} shows each forces a direct pair or a conflict sum, and the explicit N = 7 witness coloring gives the lower bound (an earlier draft's F(2) = 3 was false for the distinct-pair Folkman number defined here). F(3) ≥ 11 is documented in a source comment only (no Lean declaration)\n\n4. **Connections:** Link to Rado's theorem on partition regularity",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Core Definitions:**\n   - Coloring: ℕ → Bool\n   - SubsetSums: all non-empty subset sums of a finite set\n   - MonochromaticSubsetSums: all sums have same color\n   - F(k): minimum N using sInf\n\n2. **Folkman's theorem PROVED (was an axiom):** folkman_theorem (F(k) exists for all k ≥ 1) is derived from Mathlib's Hindman theorem (Hindman.FS_partition_regular) and Rado's selection principle (Finset.rado_selection). The infinite step covers the finite sums of the stream 1, 2, 3, … by the two color classes intersected with the positives, extracts a stream b with positive monochromatic finite sums, and groups b into consecutive blocks (each one longer than the previous block's sum) so the block sums are strictly increasing — k of them form the required set. The compactness step stitches per-N bad colorings into one coloring via Rado selection, contradicting the infinite version.\n   Remaining axiom: balogh_2017 (F(k) ≥ 2^{2^{k-1}/k}); erdos_spencer_1989 is documented in a source comment only (no Lean declaration exists)\n\n3. **Small Cases:** F_1 (F(1) = 1) is fully proven; F_2 (F(2) = 8) is fully proven: a kernel-decide check over all 256 colorings of {1,...,8} shows each forces a direct pair or a conflict sum, and the explicit N = 7 witness coloring gives the lower bound (an earlier draft's F(2) = 3 was false for the distinct-pair Folkman number defined here). F(3) ≥ 11 is documented in a source comment only (no Lean declaration)\n\n4. **Connections:** Link to Rado's theorem on partition regularity",
     "keyInsights": [
       "A $k$-element set $A$ has $2^k - 1$ non-empty subsets, each producing a sum. Monochromaticity requires ALL these sums to get the same color — an exponentially growing constraint that explains why $F(k)$ grows so fast",
       "The lower bound $F(k) \\geq 2^{2^{k-1}/k}$ is doubly exponential: even the exponent $2^{k-1}/k$ grows exponentially in $k$. This means $F(5) \\geq 2^{16/5} \\approx 10$, but $F(20) \\geq 2^{2^{19}/20} \\approx 2^{26000}$ — enormous growth",
@@ -176,10 +176,10 @@
     ],
     "opens": [],
     "namespace": "Erdos531",
-    "lineCount": 423,
-    "axiomCount": 2,
-    "theoremCount": 14,
-    "definitionCount": 9,
+    "lineCount": 610,
+    "axiomCount": 1,
+    "theoremCount": 29,
+    "definitionCount": 12,
     "path": "Proofs/Erdos531Problem.lean",
     "sorries": 0,
     "additionalFiles": [

--- a/src/data/proofs/erdos-531/meta.json
+++ b/src/data/proofs/erdos-531/meta.json
@@ -54,7 +54,7 @@
       "erdos_531 theorem: main result"
     ],
     "axiomCount": 1,
-    "lineCount": 610,
+    "lineCount": 615,
     "assumptions": "1 axiom: balogh_2017 (deep published lower bound). folkman_theorem is now a proved theorem (derived from Mathlib's Hindman theorem plus Rado's selection principle). 0 sorries.",
     "theoremCount": 29,
     "definitionCount": 12,
@@ -176,7 +176,7 @@
     ],
     "opens": [],
     "namespace": "Erdos531",
-    "lineCount": 610,
+    "lineCount": 615,
     "axiomCount": 1,
     "theoremCount": 29,
     "definitionCount": 12,


### PR DESCRIPTION
## Summary

Eliminates the `folkman_theorem` axiom from `Proofs/Erdos531Problem.lean` (Erdős Problem #531) by **proving it** from two Mathlib theorems. The file drops from 2 axioms to 1 (only the literature lower bound `balogh_2017` remains).

## The proof

`folkman_theorem : ∀ k ≥ 1, ∃ N, ExistsMonochromaticSet N k` — every 2-coloring of `{1..N}` admits a k-element set with monochromatic nonempty subset sums.

1. **Infinite version via Hindman's theorem** (`Hindman.FS_partition_regular`, Mathlib): cover the finite sums of the stream 1, 2, 3, … by the two color classes *intersected with the positive integers*; Hindman yields a stream `b` whose finite sums are all positive and monochromatic. Grouping `b` into consecutive blocks — each block one longer than the previous block's sum (`folkmanBlocks`) — makes the block sums strictly increasing, so k block sums form a k-element set of positive integers; every nonempty subset sum is a sum of `b` over a union of disjoint blocks, hence lies in `FS b` (`Hindman.FS.finsetSum`) and is monochromatic (`exists_monochromatic_of_coloring`).
2. **Compactness via Rado's selection principle** (`Finset.rado_selection`, Mathlib): if no uniform N existed, the per-N bad colorings would stitch into a single coloring of ℕ agreeing with some bad `c_N` on any prescribed finite set; a monochromatic k-set for that coloring (from step 1) contradicts `c_N`'s badness at `N = t.sup id`.

## Verification

- Host-verified with Lean v4.31.0 (`lean` against Mathlib oleans): 0 errors, 0 warnings, 0 sorries.
- `#print axioms Erdos531.folkman_theorem` → `[propext, Classical.choice, Quot.sound]` (foundational only; no `native_decide`).
- `#print axioms Erdos531.erdos_531` (main existence result) → foundational only.
- `#print axioms Erdos531.F_2` unchanged → foundational only.

## Gallery updates

- `meta.json`: `axiomCount` 2 → 1 (both blocks), `assumptions`, `proofStrategy`, `originalContributions`, counts (29 theorems, 12 defs, 614 lines).
- `annotations.json`: `ann-e531-folkman` rewritten (axiom → proved theorem, Hindman/Rado route) and all line anchors re-based to the grown file.
- Status stays `axiomatized`/`axiom` — `balogh_2017` (Balogh–Eberhard–Narayanan–Treglown–Wagner 2017 doubly-exponential lower bound) is still a deep literature axiom.

Problem: erdos-531-incomplete-01 (researcher-3 session 2026-07-24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
