### PR TITLE
Enrich burnside-counting-oq-06-oq-02: split identification/Fermat section

### DIFF
--- a/src/data/proofs/burnside-counting-oq-06-oq-02/meta.json
+++ b/src/data/proofs/burnside-counting-oq-06-oq-02/meta.json
@@ -116,11 +116,19 @@
       "mathContext": "$p\\,L(p) = k^p - k$."
     },
     {
-      "id": "identification-and-fermat",
-      "title": "Identification with the Möbius sum, and Fermat",
+      "id": "identification",
+      "title": "Identification with the Möbius Sum",
       "startLine": 99,
+      "endLine": 106,
+      "summary": "aperiodic_eq_mobius_companion: p·L(p) = ∑_{d∣p} μ(d)·k^{p/d}, ties the combinatorial aperiodic count from the previous section to the Möbius closed form of mobius_companion_prime by a single linear_combination.",
+      "mathContext": "$p\\,L(p) = \\sum_{d\\mid p}\\mu(d)k^{p/d}$."
+    },
+    {
+      "id": "fermat-aperiodic",
+      "title": "Fermat's Little Theorem via the Aperiodic Witness",
+      "startLine": 108,
       "endLine": 129,
-      "summary": "aperiodic_eq_mobius_companion: p·L(p) = ∑_{d∣p} μ(d)·k^{p/d}; fermat_dvd / fermat_dvd_nat: p ∣ k^p − k with witness L(p); fermat_modEq: k^p ≡ k [MOD p].",
+      "summary": "fermat_dvd / fermat_dvd_nat: p ∣ k^p − k, with the aperiodic necklace count L(p) (rather than the parent's total count N) as the explicit witness; fermat_modEq: k^p ≡ k [MOD p], via Nat.modEq_iff_dvd'.",
       "mathContext": "$p \\mid k^p - k,\\qquad k^p \\equiv k \\pmod p$."
     }
   ],


### PR DESCRIPTION
Enrichment pass for `burnside-counting-oq-06-oq-02` (quality 98, sections
bucket 8/10 = 4 sections instead of the 5-item cap; all other buckets already
maxed).

The `identification-and-fermat` section bundled two conceptually distinct
results into one block (lines 99-129): `aperiodic_eq_mobius_companion` (tying
the aperiodic count to the Möbius closed form) and the three Fermat theorems
(`fermat_dvd`, `fermat_dvd_nat`, `fermat_modEq`). The module docstring itself
lists these as separate bullets. Split at that real boundary into:

- `identification` (99-106): the Möbius-sum identification
- `fermat-aperiodic` (108-129): Fermat's little theorem via the aperiodic witness

Verified both new line ranges against the current Lean source
(`proofs/Proofs/BurnsideCountingOQ06OQ02.lean`, 129 lines) — no drift in the
other 3 existing sections. `meta.json` stays well under the 60 KB cap.

No overlap with other open PRs on this entry (checked via `gh pr list --search`).