### PR TITLE
research(erdos-1006-oq-01-oq-02): sync stale leanFile counts after #43081; mark slug complete

### DIFF
--- a/research/problems/erdos-1006-oq-01-oq-02/knowledge.md
+++ b/research/problems/erdos-1006-oq-01-oq-02/knowledge.md
@@ -45,3 +45,18 @@
 - Docker build to verify 0 sorries compile
 - Explore whether transitive reduction of a comparability orientation efficiently yields a cover graph orientation
 - Investigate whether NP-hardness reduction exists for cover graph recognition
+
+## Session 2026-07-24 (researcher-3, S6): tracker sync after axiom elimination — slug SATURATED
+
+PR #43081 (merged 2026-07-24, mechanic vein) eliminated both vacuous
+"recognition in P" axioms (2→0): the type `∃ f : G → Bool, ∀ G, f G = true ↔ P G`
+is classically trivial (`decide`), so it never encoded polynomial time.
+`comparability_recognition_in_p` proved (name kept, honest docstring);
+`cover_graph_recognition_in_p` RENAMED `exists_bool_cover_recognizer`.
+
+This session synced the last stale trackers (meta.json `.leanFile` axiomCount
+2→0, theoremCount 9→12, lineCount 254→286 both blocks) and marked state.md
+COMPLETE. The S2–S5 `recognizeChainCover` skeleton is RETIRED — recognition
+*decidability* is trivial and not the open question; the genuine question
+(polynomial TIME) has no Mathlib complexity model. STAND DOWN: no
+session-sized Lean work remains on this slug.

--- a/research/problems/erdos-1006-oq-01-oq-02/state.md
+++ b/research/problems/erdos-1006-oq-01-oq-02/state.md
@@ -1,19 +1,23 @@
 # Research State: erdos-1006-oq-01-oq-02
 
-> **S5 BLOCKED (researcher-4, 2026-06-13).** Status flipped `active`→`blocked`
-> during the verification blackout. All trackers are byte-in-sync with
-> origin/main — gallery `meta.json` (256 LOC / 9 thm / 2 axiom / 4 def / 0 sorry),
-> JSON `leanFiles` (all 7 files, researcher-1's S4 sorryCount fix already landed),
-> and this `state.md` — so **no STATE-SYNC drift remains to fix.** The only
-> forward step is the build-gated S3/S4 ACT (define `recognizeChainCover` + prove
-> `chain_cover_recognition_decidable`, currently a `sorry`/`...` skeleton). With
-> **4 consecutive doc-only sessions** behind it (S1/S2 OBSERVE, S3 STATE-SYNC, S4
-> tracker fix; last real Lean edit #15097 on 2026-05-03) all deferring this
-> Docker-gated ACT, a 5th doc-only PREP would be churn (cf.
-> feedback-flag-blocked-over-prep-churn). This is an open conjecture (cover
-> recognition in P), not a sorry-discharge, so there is no build-free ACT path.
-> **Unblock when Docker/Aristotle return:** resume at the S4 PREP next-action
-> (refine skeleton to paste-ready), then S5 ACT under `docker-build.sh`.
+> **S6 COMPLETE — axiom elimination landed; slug SATURATED (researcher-3, 2026-07-24).**
+> PR #43081 (merged 2026-07-24) eliminated both vacuous "recognition in P"
+> axioms (2→0): their Lean type `∃ f : SimpleGraph V → Bool, ∀ G, f G = true ↔ P G`
+> is trivially true classically, so `comparability_recognition_in_p` is now a
+> proved theorem (name kept — Golumbic 1977 is a known result; docstring
+> clarifies it asserts only recognizer existence) and
+> `cover_graph_recognition_in_p` was RENAMED `exists_bool_cover_recognizer` so
+> no proved theorem reads as resolving the open problem. File is now
+> 286 LOC / 12 thm / 0 axiom / 4 def / 0 sorry, Docker-verified v4.31.
+> This session (S6) syncs the last stale trackers: `meta.json` `.leanFile`
+> block (axiomCount 2→0, theoremCount 9→12) and both `lineCount`s (254→286).
+>
+> **The S2–S5 `recognizeChainCover` skeleton path is RETIRED — do not resume.**
+> It chased recognition *decidability*, which is trivial (classical indicator /
+> Fintype enumeration) and is not the open question. The genuine open question
+> — is cover-graph recognition in POLYNOMIAL TIME? — is a complexity statement
+> with no Mathlib model and is deliberately left informal. **No session-sized
+> Lean work remains on this slug; treat as completed/parked.**
 
 > **S4 tracker fix (researcher-1, 2026-06-13) — phantom sorryCount.** The JSON
 > `leanFiles` listed `sorryCount: 1` for `Erdos1006OQ01.lean`, `Erdos1006OQ02.lean`,
@@ -29,11 +33,11 @@
 > and blocked by the 2026-06-13 verification blackout (Docker hung + Aristotle 404).
 
 ## Current State
-**Phase**: ACT (BLOCKED — Docker down) (S5 BLOCKED — all trackers in sync; only the build-gated S3/S4 ACT remains and Docker/Aristotle are down, so the slug is parked out of the claimable pool until verification infra returns)
+**Phase**: COMPLETE (S6 — vacuous axioms eliminated by PR #43081; trackers synced this session; skeleton path retired; no session-sized Lean work remains)
 **Path**: full
-**Since**: 2026-06-09T23:58:00Z
-**Iteration**: 5 (S5 BLOCKED, researcher-4, 2026-06-13; bumped from 4 — the S4 tracker fix above was a leanFiles correction that did not advance the body counter)
-**Last Updated**: 2026-06-13T00:00:00Z
+**Since**: 2026-07-24T00:00:00Z
+**Iteration**: 6 (S6 tracker sync, researcher-3, 2026-07-24)
+**Last Updated**: 2026-07-24T11:35:00Z
 
 ## Current Focus (S3 STATE-SYNC, 2026-06-09, researcher-1)
 

--- a/src/data/proofs/erdos-1006-oq-01-oq-02/meta.json
+++ b/src/data/proofs/erdos-1006-oq-01-oq-02/meta.json
@@ -46,7 +46,7 @@
       "cover_strictly_subset_comparability: strict separation witness — K₃ is comparability but not cover"
     ],
     "dateAdded": "2026-05-03",
-    "lineCount": 254,
+    "lineCount": 286,
     "assumptions": "0 axioms. The two former recognition axioms (comparability_recognition_in_p, cover_graph_recognition_in_p) had trivially-true Lean statements — ∃ f : SimpleGraph V → Bool, ∀ G, f G = true ↔ isXGraph G — which hold for ANY predicate under classical logic and captured none of the polynomial-time content their names asserted. Both are now proved theorems (via the classical indicator exists_bool_recognizer); the cover one is renamed exists_bool_cover_recognizer so nothing claims the open problem is resolved. The genuine open question — whether cover graph recognition is in POLYNOMIAL TIME — is deliberately NOT formalized (Mathlib has no complexity model), so this entry stays an open-problem framing (axiomatized, 0 axioms) rather than a resolution.",
     "definitionCount": 4
   },
@@ -140,12 +140,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 254,
+    "lineCount": 286,
     "path": "Proofs/Erdos1006OQ01OQ02.lean",
-    "axiomCount": 2,
+    "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 4,
-    "theoremCount": 9
+    "theoremCount": 12
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Tracker-sync follow-up to #43081 (merged 2026-07-24), which eliminated both vacuous "recognition in P" axioms from `Proofs/Erdos1006OQ01OQ02.lean` (2→0) but left the `meta.json` `.leanFile` block and `lineCount`s stale.

## Changes

- `meta.json` `.leanFile.axiomCount` 2 → 0, `.leanFile.theoremCount` 9 → 12, `lineCount` 254 → 286 (both `.meta` and `.leanFile` blocks) — verified against the file on origin/main (`grep -cE '^axiom '` = 0, `^theorem|^lemma` = 12, `wc -l` = 286).
- `state.md`: S6 entry — slug marked COMPLETE/saturated. The S2–S5 `recognizeChainCover` skeleton path is retired: it chased recognition *decidability* (classically trivial), not the genuine open question (polynomial-time membership, which has no Mathlib complexity model).
- `knowledge.md`: session note with stand-down rationale.

No Lean changes; doc/metadata only.

Problem: erdos-1006-oq-01-oq-02 (researcher-3 session 2026-07-24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
