### PR TITLE
Enrich burnside-counting-oq001: split header/imports sections

### DIFF
--- a/src/data/proofs/burnside-counting-oq001/meta.json
+++ b/src/data/proofs/burnside-counting-oq001/meta.json
@@ -93,9 +93,17 @@
       "id": "header",
       "title": "Problem Statement and Results",
       "startLine": 1,
-      "endLine": 45,
-      "summary": "Module docstring stating the parent's request to push the integer-form Burnside total to divisor form and the three results — (D) the range-form identity Σ_{r<n} k^{gcd(n,r)} = Σ_{d∣n} φ(n/d) k^d, (E) its ZMod n version, and (F) the necklace count (#necklaces)·n = Σ_{d∣n} φ(n/d) k^d — followed by the setup: import Mathlib and the parent file Proofs.BurnsideCountingOQ03OQ02OQ01, the Finset/BigOperators/MulAction opens, the namespace, and the open pulling in the parent's Rot, rotation, and sum_pow_gcd_eq_card_necklaces_mul.",
+      "endLine": 36,
+      "summary": "Module docstring stating the parent's request to push the integer-form Burnside total to divisor form and the three results — (D) the range-form identity Σ_{r<n} k^{gcd(n,r)} = Σ_{d∣n} φ(n/d) k^d, (E) its ZMod n version, and (F) the necklace count (#necklaces)·n = Σ_{d∣n} φ(n/d) k^d.",
       "mathContext": "$\\sum_{r} k^{\\gcd(n,r)} = \\sum_{d\\mid n} \\varphi(n/d)\\,k^d$"
+    },
+    {
+      "id": "imports-namespace",
+      "title": "Imports and the Reused Cyclic Machinery",
+      "startLine": 38,
+      "endLine": 45,
+      "summary": "Imports Mathlib and the parent file Proofs.BurnsideCountingOQ03OQ02OQ01, opens Finset/BigOperators/MulAction, declares the namespace, and selectively opens the parent's Rot, rotation, and sum_pow_gcd_eq_card_necklaces_mul — the single result (C) this entry pushes to divisor form.",
+      "mathContext": "$(\\#\\text{necklaces})\\cdot n = \\sum_{r:\\mathbb{Z}/n} k^{\\gcd(n,r)}$ (parent's result (C), reused)"
     },
     {
       "id": "divisor-form",


### PR DESCRIPTION
Enrichment pass for `burnside-counting-oq001` (quality 98, sections bucket
8/10 = 4 sections instead of the 5-item cap; all other buckets already maxed).

The `header` section bundled the mathematical module docstring (lines 1-36:
problem statement and results D/E/F) together with the technical setup (lines
38-45: imports, opens, namespace, and the selective open of the parent's
`sum_pow_gcd_eq_card_necklaces_mul`). Split at the real boundary (the closing
`-/` of the docstring) into:

- `header` (1-36): the docstring alone
- `imports-namespace` (38-45): imports and the reused cyclic machinery

This mirrors the same header/imports split already used elsewhere in the
gallery (e.g. `burnside-counting-oq-06`'s `imports-namespace` section).
Verified both new line ranges against the current Lean source
(`proofs/Proofs/BurnsideCountingOQ03OQ02OQ01OQ02.lean`, 105 lines) — no drift
in the other 3 existing sections. `meta.json` stays well under the 60 KB cap.

No overlap with other open PRs on this entry (checked via `gh pr list --search`).