### PR TITLE
Enrich cantor-diagonalization-oq-01-oq-01-oq-03: add 5th keyInsight

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-03/meta.json
@@ -43,7 +43,8 @@
       "König's constraint, stated as a Prop in the parent, is a direct corollary of Mathlib's Cardinal.lt_cof_power — no axiom needed.",
       "The strict inequality is between an index and its own value (Cantor); between distinct indices only ≤ holds — the continuum function is monotone but NOT strictly monotone (e.g. 2^{ℵ₀} = 2^{ℵ₁} under Martin's Axiom).",
       "Together monotonicity, Cantor and König are exactly the Easton constraints, so this is a faithful formal answer to 'which patterns are consistent'.",
-      "König's constraint concretely forbids 2^{ℵ₀} = ℵ_ω: because cf(ℵ_ω) = ℵ₀ is not > ℵ₀, the value ℵ_ω fails cf(2^{ℵ₀}) > ℵ₀. So ℵ_ω is the smallest cardinal above all the ℵ_n that the continuum provably cannot equal — even though Cantor's inequality 2^{ℵ₀} > ℵ₀ alone would permit it. This is the sense in which König strictly sharpens Cantor."
+      "König's constraint concretely forbids 2^{ℵ₀} = ℵ_ω: because cf(ℵ_ω) = ℵ₀ is not > ℵ₀, the value ℵ_ω fails cf(2^{ℵ₀}) > ℵ₀. So ℵ_ω is the smallest cardinal above all the ℵ_n that the continuum provably cannot equal — even though Cantor's inequality 2^{ℵ₀} > ℵ₀ alone would permit it. This is the sense in which König strictly sharpens Cantor.",
+      "The three proved theorems hold at every ordinal α, but Easton's freeness claim (any constraint-respecting pattern is consistent) is only established for α indexing REGULAR cardinals. contFn_monotone, aleph_lt_contFn, and aleph_lt_cof_contFn are unconditional ZFC facts even where ℵ_α is singular (e.g. α = ω), but at singular indices Silver's theorem and Shelah's PCF theory impose further ZFC-provable constraints not implied by monotonicity, Cantor, and König alone — so this file's three theorems are necessary conditions everywhere, yet a complete list of constraints only at the regular indices where Easton's theorem applies."
     ],
     "prerequisites": [
       "Cardinal arithmetic and the aleph hierarchy",


### PR DESCRIPTION
Enrichment pass for `cantor-diagonalization-oq-01-oq-01-oq-03` (quality 98,
keyInsights bucket 8/10 = 4 insights instead of the 5-item cap; all other
buckets already maxed).

Adds a 5th `keyInsight` distinguishing the scope of the three proved theorems
from Easton's freeness claim: `contFn_monotone`, `aleph_lt_contFn`, and
`aleph_lt_cof_contFn` are unconditional ZFC facts for every ordinal α
(including where `ℵ_α` is singular), but Easton's theorem only guarantees
that any constraint-respecting pattern is consistent at *regular* indices —
at singular indices (e.g. α = ω) Silver's theorem and Shelah's PCF theory
impose further ZFC-provable constraints not implied by monotonicity, Cantor,
and König alone. This is consistent with (and does not duplicate) the
existing `openQuestions` entry on singular cardinals.

`meta.json` stays well under the 60 KB cap. No overlap with other open PRs on
this entry (checked via `gh pr list --search`).