### PR TITLE
Enrich cantor-diagonalization-oq-07: split bijection/complex-corollary sections

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-07/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-07/meta.json
@@ -114,11 +114,19 @@
     },
     {
       "id": "bijection",
-      "title": "Bijection and Complex Corollary",
+      "title": "The Cardinal Equality Unpacks to a Bijection",
       "startLine": 47,
+      "endLine": 52,
+      "summary": "nonempty_equiv_prod_real: Nonempty (ℝ × ℝ ≃ ℝ), obtained from Cardinal.eq applied to mk_prod_real — recovering Cantor's 1878 line-plane bijection as a corollary of the cardinal computation rather than an explicit construction.",
+      "mathContext": "$\\#(\\mathbb{R}\\times\\mathbb{R}) = \\#\\mathbb{R} \\iff \\mathrm{Nonempty}(\\mathbb{R}\\times\\mathbb{R} \\simeq \\mathbb{R})$."
+    },
+    {
+      "id": "complex-corollary",
+      "title": "The Complex Plane Corollary",
+      "startLine": 54,
       "endLine": 60,
-      "summary": "nonempty_equiv_prod_real (an explicit bijection ℝ × ℝ ≃ ℝ via Cardinal.eq) and mk_complex_eq_mk_real (#ℂ = #ℝ via ℂ ≃ ℝ × ℝ).",
-      "mathContext": "$\\mathbb{R} \\times \\mathbb{R} \\simeq \\mathbb{R}$ and $\\#\\mathbb{C} = \\#\\mathbb{R}$."
+      "summary": "mk_complex_eq_mk_real: #ℂ = #ℝ, immediate from Complex.equivRealProd (ℂ ≃ ℝ × ℝ) together with Cardinal.mk_complex and Cardinal.mk_real both giving 𝔠.",
+      "mathContext": "$\\#\\mathbb{C} = \\#\\mathbb{R}$."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `cantor-diagonalization-oq-07` (quality 98, sections
bucket 8/10 = 4 sections instead of the 5-item cap; all other buckets
already maxed).

The `bijection` section bundled two independent results (lines 47-60):
`nonempty_equiv_prod_real` (the cardinal equality unpacked to an explicit
`Equiv`) and `mk_complex_eq_mk_real` (the separate complex-plane corollary).
Split at the real theorem boundary into:

- `bijection` (47-52): the cardinal-equality-to-bijection unpacking
- `complex-corollary` (54-60): `#ℂ = #ℝ`

Verified both new line ranges against the current Lean source
(`proofs/Proofs/CantorDiagonalizationOQ07.lean`, 60 lines) — no drift in the
other 3 existing sections. `meta.json` stays well under the 60 KB cap.

No overlap with other open PRs on this entry (checked via `gh pr list --search`).