### PR TITLE
Enrich cantor-diagonalization-oq004: split sections

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq004/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq004/meta.json
@@ -111,8 +111,15 @@
       "id": "gap-strictly-stronger",
       "title": "The Gap Is Strictly Stronger",
       "startLine": 66,
-      "endLine": 85,
-      "summary": "not_surjective_of_cardinality_gap re-derives the parent's non-surjectivity from the gap: a surjection A ↠ (A → Prop) would force #(A → Prop) ≤ #A (Cardinal.mk_le_of_surjective), contradicting #A < #(A → Prop). A definitional-equality sanity-check example and #check lines close the file. Thus the quantitative statement subsumes the qualitative one."
+      "endLine": 74,
+      "summary": "not_surjective_of_cardinality_gap re-derives the parent's non-surjectivity from the gap: a surjection A ↠ (A → Prop) would force #(A → Prop) ≤ #A (Cardinal.mk_le_of_surjective), contradicting #A < #(A → Prop). Thus the quantitative statement subsumes the qualitative one."
+    },
+    {
+      "id": "sanity-check",
+      "title": "Definitional-Equality Sanity Check",
+      "startLine": 76,
+      "endLine": 84,
+      "summary": "A closing example confirms #A < #(A → Prop) and #A < #(Set A) are the same proposition by rfl (Set A ≡ A → Prop, no transport lemma needed), followed by #check lines auditing the three headline theorems."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `cantor-diagonalization-oq004` (quality 98, sections
bucket 8/10 = 4 sections instead of the 5-item cap; all other buckets already
maxed).

The `gap-strictly-stronger` section bundled the re-implication theorem
(`not_surjective_of_cardinality_gap`, lines 66-74) together with an unrelated
closing sanity-check block (the `rfl` example plus `#check` audit lines,
76-84). Split at the real boundary into:

- `gap-strictly-stronger` (66-74): the theorem alone
- `sanity-check` (76-84): the definitional-equality example and `#check` audit

Verified both new line ranges against the current Lean source
(`proofs/Proofs/CantorDiagonalizationOQ03OQ01Incomplete01OQ01OQ03.lean`, 84
lines) — no drift in the other 3 existing sections. `meta.json` stays well
under the 60 KB cap.

No overlap with other open PRs on this entry (checked via `gh pr list --search`).