### PR TITLE
research(minkowski-oq-06): S5 ±-pairing rung — doubled threshold 2ζ(n) for symmetric sets

### DIFF
--- a/proofs/Proofs/MinkowskiFundamentalTheoremOQ06.lean
+++ b/proofs/Proofs/MinkowskiFundamentalTheoremOQ06.lean
@@ -47,9 +47,12 @@ identity as an **explicit hypothesis** of the two main theorems — NOT as an `a
 * `hlawka_ball` — for `S` a ball, the avoidance upgrades via the bridge to a
   **minimum-distance** conclusion: some lattice has all nonzero vectors of norm
   `≥ r`. This is Minkowski–Hlawka in min-distance form (the packing-density
-  form `δₙ ≥ ζ(n)/2^n` follows by packing balls of radius `r/2`; the classical
-  `ζ(n)/2^(n-1)` needs the additional `±`-pairing refinement of the identity,
-  deliberately not staged here — see knowledge.md).
+  form `δₙ ≥ ζ(n)/2^n` follows by packing balls of radius `r/2`).
+* `hlawka_avoidance_symm` / `hlawka_ball_symm` — the **`±`-pairing rung** (S5):
+  on a symmetric set a lattice with one primitive vector has two (`v` and
+  `-v`), so the volume threshold doubles to `2·ζ(n)` with the SAME mean-value
+  hypothesis — the classical route to `δₙ ≥ ζ(n)/2^(n-1)` (the residual
+  `2^(1-n)` is ball-volume scaling, not averaging).
 
 **Honesty.** No `axiom` declarations, no sorries; the `hlawka_*` theorems are
 *conditional* on their `hMV` (mean-value) and `hInt` (integrability) hypotheses
@@ -441,12 +444,10 @@ theorem hlawka_avoidance_symm {n : ℕ} (hn : 2 ≤ n) {Ω : Type*}
     obtain ⟨v, hvp, hvS⟩ := h ω
     exact_mod_cast two_le_primCount_of_symm_of_mem (latticeOf ω) S hSymm
       (hFin ω) hvp hvS
-  have hint2 : ∫ ω, (2 : ℝ) ∂μ ≤ ∫ ω, (primCount (latticeOf ω) S : ℝ) ∂μ :=
-    integral_mono (integrable_const 2) hInt h2
-  rw [hMV] at hint2
-  simp only [integral_const, measure_univ, ENNReal.toReal_one, one_smul,
-    smul_eq_mul, one_mul] at hint2
-  rw [le_div_iff₀ hζ] at hint2
+  have hint2 : (2 : ℝ) ≤ ∫ ω, (primCount (latticeOf ω) S : ℝ) ∂μ := by
+    have hmono := integral_mono (integrable_const 2) hInt h2
+    simpa using hmono
+  rw [hMV, le_div_iff₀ hζ] at hint2
   linarith
 
 /-- **Minkowski–Hlawka, minimum-distance form, doubled threshold.** Balls are
@@ -492,5 +493,9 @@ theorem hlawka_ball_symm {n : ℕ} (hn : 2 ≤ n) {Ω : Type*}
 #check @finite_primitive_inter_of_isBounded
 #check @hlawka_avoidance_of_isBounded
 #check @hlawka_ball_of_discrete
+#check @IsPrimitive.neg
+#check @two_le_primCount_of_symm_of_mem
+#check @hlawka_avoidance_symm
+#check @hlawka_ball_symm
 
 end MinkowskiFundamentalTheoremOQ06

--- a/proofs/Proofs/MinkowskiFundamentalTheoremOQ06.lean
+++ b/proofs/Proofs/MinkowskiFundamentalTheoremOQ06.lean
@@ -367,6 +367,119 @@ theorem hlawka_ball_of_discrete {n : ℕ} (hn : 2 ≤ n) {Ω : Type*}
     (fun ω => finite_primitive_inter_of_isBounded (latticeOf ω) (hr₀ ω)
       (hdisc ω) Metric.isBounded_ball) hvol
 
+/-! ## The ±-pairing rung (S5)
+
+Primitive vectors come in pairs `{v, -v}`: negation preserves membership,
+nonzeroness, and primitivity, and `-v ≠ v` in a real vector space (no
+2-torsion). Consequently, on a *symmetric* set `S = -S` a lattice either has
+no primitive vector in `S` or at least **two** — so in the averaging argument
+a mean below `2` (not merely below `1`) already forces an avoiding lattice.
+This doubles the volume threshold of the staged Minkowski–Hlawka theorems
+from `ζ(n)` to `2·ζ(n)`, the classical route to the density bound
+`δ_n ≥ ζ(n)/2^(n-1)` (the remaining factor `2^(1-n)` is the ball-volume
+scaling `vol(ball r) = r^n·vol(ball 1)` in the packing-density bookkeeping,
+not part of the averaging engine). -/
+
+/-- Negation preserves primitivity: if `-v = m • w` with `m ≥ 2` then
+`v = m • (-w)` exhibits the same proper-multiple decomposition. -/
+theorem IsPrimitive.neg {L : AddSubgroup E} {v : E} (h : IsPrimitive L v) :
+    IsPrimitive L (-v) := by
+  obtain ⟨hvL, hv0, hprim⟩ := h
+  refine ⟨neg_mem hvL, neg_ne_zero.mpr hv0, fun m w hw hm heq => ?_⟩
+  apply hprim m (-w) (neg_mem hw) hm
+  rw [← neg_neg v, heq, smul_neg]
+
+/-- In a real vector space, `-v ≠ v` for `v ≠ 0` (no 2-torsion): from `-v = v`
+one gets `(2 : ℝ) • v = 0`, forcing `v = 0`. -/
+theorem neg_ne_self_of_ne_zero {v : E} (hv0 : v ≠ 0) : -v ≠ v := by
+  intro hEq
+  apply hv0
+  have h2v : v + v = 0 := by
+    nth_rewrite 1 [← hEq]
+    exact neg_add_cancel v
+  have h2 : (2 : ℝ) • v = 0 := by rw [two_smul]; exact h2v
+  rcases smul_eq_zero.mp h2 with h | h
+  · norm_num at h
+  · exact h
+
+/-- **The pairing bound.** On a symmetric set, one primitive vector in `S`
+forces two: `v` and `-v` are distinct primitive members. -/
+theorem two_le_primCount_of_symm_of_mem (L : AddSubgroup E)
+    (S : Set E) (hSymm : ∀ v ∈ S, -v ∈ S)
+    (hFin : (S ∩ {u | IsPrimitive L u}).Finite)
+    {v : E} (hvp : IsPrimitive L v) (hvS : v ∈ S) : 2 ≤ primCount L S := by
+  have hne : v ≠ -v := (neg_ne_self_of_ne_zero hvp.2.1).symm
+  have hsub : ({v, -v} : Set E) ⊆ S ∩ {u | IsPrimitive L u} := by
+    intro u hu
+    rcases hu with rfl | hu
+    · exact ⟨hvS, hvp⟩
+    · rw [Set.mem_singleton_iff] at hu
+      subst hu
+      exact ⟨hSymm v hvS, hvp.neg⟩
+  calc 2 = ({v, -v} : Set E).ncard := (Set.ncard_pair hne).symm
+    _ ≤ (S ∩ {u | IsPrimitive L u}).ncard := Set.ncard_le_ncard hsub hFin
+
+/-- **Minkowski–Hlawka, avoidance form, symmetric sets (doubled threshold).**
+For `S = -S` the volume threshold improves from `ζ(n)` to `2·ζ(n)`: a lattice
+with any primitive vector in `S` has at least two (pairing), so a mean below
+`2` already forces an avoiding lattice. -/
+theorem hlawka_avoidance_symm {n : ℕ} (hn : 2 ≤ n) {Ω : Type*}
+    [MeasurableSpace Ω] (μ : Measure Ω) [IsProbabilityMeasure μ]
+    (latticeOf : Ω → AddSubgroup (EuclideanSpace ℝ (Fin n)))
+    (S : Set (EuclideanSpace ℝ (Fin n)))
+    (hSymm : ∀ v ∈ S, -v ∈ S)
+    (hMV : ∫ ω, (primCount (latticeOf ω) S : ℝ) ∂μ = (volume S).toReal / zetaSum n)
+    (hInt : Integrable (fun ω => (primCount (latticeOf ω) S : ℝ)) μ)
+    (hFin : ∀ ω, (S ∩ {v | IsPrimitive (latticeOf ω) v}).Finite)
+    (hvol : (volume S).toReal < 2 * zetaSum n) :
+    ∃ ω, ∀ v, IsPrimitive (latticeOf ω) v → v ∉ S := by
+  have hζ : 0 < zetaSum n := zetaSum_pos hn
+  by_contra h
+  push Not at h
+  have h2 : ∀ ω, (2 : ℝ) ≤ (primCount (latticeOf ω) S : ℝ) := by
+    intro ω
+    obtain ⟨v, hvp, hvS⟩ := h ω
+    exact_mod_cast two_le_primCount_of_symm_of_mem (latticeOf ω) S hSymm
+      (hFin ω) hvp hvS
+  have hint2 : ∫ ω, (2 : ℝ) ∂μ ≤ ∫ ω, (primCount (latticeOf ω) S : ℝ) ∂μ :=
+    integral_mono (integrable_const 2) hInt h2
+  rw [hMV] at hint2
+  simp only [integral_const, measure_univ, ENNReal.toReal_one, one_smul,
+    smul_eq_mul, one_mul] at hint2
+  rw [le_div_iff₀ hζ] at hint2
+  linarith
+
+/-- **Minkowski–Hlawka, minimum-distance form, doubled threshold.** Balls are
+symmetric, so the pairing rung applies: `vol(ball r) < 2·ζ(n)` suffices for a
+lattice of minimum distance `≥ r`. Combined with `vol(ball r) = r^n·vol(ball 1)`
+this is the classical `δ_n ≥ ζ(n)/2^(n-1)` averaging input. -/
+theorem hlawka_ball_symm {n : ℕ} (hn : 2 ≤ n) {Ω : Type*}
+    [MeasurableSpace Ω] (μ : Measure Ω) [IsProbabilityMeasure μ]
+    (latticeOf : Ω → AddSubgroup (EuclideanSpace ℝ (Fin n)))
+    (r₀ : Ω → ℝ) (hr₀ : ∀ ω, 0 < r₀ ω)
+    (hdisc : ∀ ω, ∀ u ∈ latticeOf ω, u ≠ 0 → r₀ ω ≤ ‖u‖)
+    {r : ℝ}
+    (hMV : ∫ ω, (primCount (latticeOf ω) (Metric.ball 0 r) : ℝ) ∂μ =
+      (volume (Metric.ball (0 : EuclideanSpace ℝ (Fin n)) r)).toReal / zetaSum n)
+    (hInt : Integrable
+      (fun ω => (primCount (latticeOf ω) (Metric.ball 0 r) : ℝ)) μ)
+    (hvol : (volume (Metric.ball (0 : EuclideanSpace ℝ (Fin n)) r)).toReal <
+      2 * zetaSum n) :
+    ∃ ω, ∀ v ∈ latticeOf ω, v ≠ 0 → r ≤ ‖v‖ := by
+  have hSymm : ∀ v ∈ Metric.ball (0 : EuclideanSpace ℝ (Fin n)) r,
+      -v ∈ Metric.ball (0 : EuclideanSpace ℝ (Fin n)) r := by
+    intro v hv
+    rw [Metric.mem_ball, dist_zero_right] at hv ⊢
+    simpa using hv
+  obtain ⟨ω, hω⟩ := hlawka_avoidance_symm hn μ latticeOf _ hSymm hMV hInt
+    (fun ω => finite_primitive_inter_of_isBounded (latticeOf ω) (hr₀ ω)
+      (hdisc ω) Metric.isBounded_ball) hvol
+  refine ⟨ω, no_nonzero_of_no_primitive_in_ball (latticeOf ω) (hr₀ ω) (hdisc ω) ?_⟩
+  intro w hwp
+  by_contra hlt
+  push Not at hlt
+  exact hω w hwp (Metric.mem_ball.mpr (by simpa using hlt))
+
 #check @zetaSum_summable
 #check @one_le_zetaSum
 #check @minimal_isPrimitive

--- a/research/problems/minkowski-fundamental-theorem-oq-06/knowledge.md
+++ b/research/problems/minkowski-fundamental-theorem-oq-06/knowledge.md
@@ -175,3 +175,15 @@ fine, 3.3Ti free); recreated via `worktree add -B research/minkowski-oq06-hlawka
   density formalization — assess before attempting).
 - The mean-value identity itself: SL_n(ℤ)\SL_n(ℝ) Haar theory — DEEP, blocked
   (registry entry unchanged).
+
+
+## Session 2026-07-24 (researcher-3, S5): ±-pairing rung DONE
+
+`hlawka_avoidance_symm`/`hlawka_ball_symm`: threshold doubled to `2·ζ(n)`
+with the SAME primitive mean-value hypothesis. Trick: no evenness lemma —
+one primitive in symmetric S forces two ({v,-v} ⊆ S ∩ primitives,
+`Set.ncard_pair` + `ncard_le_ncard`), so count ≥ 2 pointwise where avoidance
+fails, contradicting mean < 2. `IsPrimitive.neg` via `smul_neg`;
+no-2-torsion via `(2:ℝ)•v = 0`. 383→498 LOC, 21 thms, 0 sorry/axiom,
+host-verified v4.31 foundational-only. Next: density form (assess ball-volume
+scaling API) or stand down (identity itself is the registry blocker).

--- a/research/problems/minkowski-fundamental-theorem-oq-06/state.md
+++ b/research/problems/minkowski-fundamental-theorem-oq-06/state.md
@@ -1,10 +1,39 @@
 # Research State: minkowski-fundamental-theorem-oq-06
 
 ## Current State
-**Phase**: ACT (S4 — `hFin` staging hypothesis discharged, Docker-GREEN)
+**Phase**: ACT (S5 — ±-pairing rung landed: doubled threshold `2·ζ(n)` for symmetric sets)
 **Path**: full
-**Since**: 2026-07-24 (S4 ACT, researcher-1)
-**Iteration**: 4
+**Since**: 2026-07-24 (S5 ACT, researcher-3)
+**Iteration**: 5
+
+## S5 ACT Summary (2026-07-24, researcher-3)
+
+**Mode**: ACT (Lean; host-verified `lean` v4.31.0 full-file elaboration against
+the pinned Mathlib oleans, 0 errors; `#print axioms` foundational only).
+
+Rung 2 of the post-#43192 plan: the **±-pairing rung**. File 383 → 498 LOC,
+18 → 21 theorems (+ `IsPrimitive.neg`, `neg_ne_self_of_ne_zero`,
+`two_le_primCount_of_symm_of_mem`, `hlawka_avoidance_symm`,
+`hlawka_ball_symm`), 0 sorry / 0 axiom.
+
+Key simplification vs the menu: NO parity/evenness lemma and NO refined
+mean-value identity needed. On a symmetric `S`, ONE primitive vector `v ∈ S`
+forces TWO (`v`, `-v` distinct — no 2-torsion in a real vector space, and
+negation preserves primitivity), so `primCount ≥ 2` pointwise wherever
+avoidance fails; mean `= vol/ζ < 2` then contradicts. Same `hMV` hypothesis
+as before, threshold doubled: `vol(S) < 2·ζ(n)` (avoidance),
+`vol(ball r) < 2·ζ(n)` (min-distance). This is the classical route to
+`δₙ ≥ ζ(n)/2^(n-1)`; the residual `2^(1-n)` is ball-volume scaling.
+
+Lean bits: `Set.ncard_pair` + `Set.ncard_le_ncard` for the two-element lower
+bound; `integral_mono (integrable_const 2)` + plain `simpa` (per the S1 memo
+gotcha, `integral_const` needs plain simp) + `le_div_iff₀`; `smul_neg` closes
+`IsPrimitive.neg`; `push Not` (push_neg deprecated at v4.31).
+
+**S6 menu**: (1) density-form assessment (pack balls of radius `r/2`,
+`vol(ball r) = r^n · vol(ball 1)` scaling — assess Mathlib bearer
+`EuclideanSpace` ball-volume API first); (2) DEEP: Siegel–Rogers identity
+(Haar on `SLₙ(ℤ)\SLₙ(ℝ)`) — registry blocker, stand down.
 
 ## S4 ACT Summary (2026-07-24, researcher-1)
 


### PR DESCRIPTION
## Summary

S5 ACT for `minkowski-fundamental-theorem-oq-06` (Minkowski–Hlawka): the **±-pairing rung**. On symmetric sets the volume threshold of the staged averaging theorems doubles from `ζ(n)` to `2·ζ(n)` — with the *same* Siegel–Rogers mean-value hypothesis. This is the classical route to the density bound `δₙ ≥ ζ(n)/2^(n-1)` (the residual `2^(1-n)` is ball-volume scaling, not averaging). File `MinkowskiFundamentalTheoremOQ06.lean` 383 → 498 lines, 18 → 21 theorems, **0 sorries, 0 axioms**.

## What's proved (all unconditional)

- `IsPrimitive.neg` — negation preserves primitivity (`-v = m • w` reflects to `v = m • (-w)`).
- `neg_ne_self_of_ne_zero` — no 2-torsion in a real vector space.
- `two_le_primCount_of_symm_of_mem` — **the pairing bound**: one primitive vector in a symmetric `S` forces two (`{v, -v}` distinct primitive members; `Set.ncard_pair` + `Set.ncard_le_ncard`).
- `hlawka_avoidance_symm` — avoidance at `vol(S) < 2·ζ(n)`: where avoidance fails the count is ≥ 2 pointwise, so the mean `vol/ζ < 2` is contradicted. No parity/evenness lemma and no refined mean-value identity needed.
- `hlawka_ball_symm` — minimum-distance form at `vol(ball r) < 2·ζ(n)` (balls are symmetric; `hFin` discharged via the S4 finiteness theorem).

## Verification

- Host `lean` v4.31.0 full-file elaboration against the pinned Mathlib oleans: 0 errors.
- `#print axioms` for both new `hlawka_*_symm` theorems → `[propext, Classical.choice, Quot.sound]`.

## Honesty

The Siegel–Rogers primitive mean-value identity remains an explicit hypothesis (`hMV`) — it is the registry-blocked deep input (Haar measure on `SLₙ(ℤ)\SLₙ(ℝ)`, absent from Mathlib). Everything in this PR is unconditional Mathlib-only mathematics around it.

Trackers: state.md S5 entry, knowledge.md session note, file header updated.

Problem: minkowski-fundamental-theorem-oq-06 (researcher-3 session 2026-07-24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
