### PR TITLE
Fix: populate null top-level badge on 2 verified entries

### DIFF
--- a/src/data/proofs/compactness-finite-subcover-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-01-oq-02-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "compactness-finite-subcover-oq-01-oq-02-oq-01",
   "slug": "compactness-finite-subcover-oq-01-oq-02-oq-01",
   "title": "Nested Closed Intervals Shrinking to a Point",
-  "status": "verified",
+  "status": "verified",  "badge": "mathlib",
   "sorries": 0,
   "overview": {
     "historicalContext": "Cantor's intersection theorem guarantees that a decreasing sequence of nonempty closed subsets of a compact space has nonempty intersection — but it says nothing about the size of that intersection. The classical refinement, the Nested Interval Theorem (the form Bolzano and Cantor used to construct real numbers and to prove the Bolzano–Weierstrass theorem), adds one hypothesis: if the lengths of a nested sequence of closed bounded intervals tend to 0, the intersection is not merely nonempty but a single point. This is the completeness of ℝ made geometric, and it is the engine of the bisection method, of binary expansions, and of the standard construction of the Cantor set as a nested intersection. The parent entry re-derived Cantor's theorem by hand from the finite-intersection dual and recorded, as a concrete instance, only that ⋂ₙ [0, 1/(n+1)] is nonempty. This entry supplies the missing uniqueness half and pins the intersection exactly.",

--- a/src/data/proofs/shannon-entropy-oq-03/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03/meta.json
@@ -231,5 +231,6 @@
     }
   ],
   "sorries": 0,
-  "status": "verified"
+  "status": "verified",
+  "badge": "mathlib"
 }


### PR DESCRIPTION
## Problem

Two gallery `meta.json` files carried a **null top-level `badge`** while their nested `"meta": {...}` block held the source-of-truth value (`mathlib`). The gallery consumes the **top-level** fields — `src/lib/oq-group.ts` groups by `listing.badge`, and `ProofOverview.tsx` renders the badge from top-level `meta.badge` — so the badge did not render and the entries mis-grouped.

- `shannon-entropy-oq-03` — Strong Subadditivity of Shannon Entropy
- `compactness-finite-subcover-oq-01-oq-02-oq-01` — Nested Closed Intervals Shrinking to a Point

## Fix

Mirror the nested source-of-truth badge (`mathlib`) up to the top level. Minimal 1-line-per-file edit; no other fields touched.

## Evidence

Both entries: top-level `status` was already `verified`; nested `meta.badge = "mathlib"`, `meta.axiomCount = 0`. Corroborated against the Lean sources (`Proofs/ShannonEntropySSA.lean`, `Proofs/CompactnessFiniteSubcoverOq01Oq02Oq01.lean`): **0 `axiom` declarations, 0 code sorries, 0 `native_decide`** in each → `verified`/`mathlib` is accurate.

Before: `"badge": null` (top level) → badge does not render.
After: `"badge": "mathlib"` (top level) → renders + groups correctly.

Same vein as merged PR #43318 (which fixed a different set of 3 entries).
