### PR TITLE
audit: lebesgue-measure-oq-03 clean (re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -22178,9 +22178,9 @@
       "result": "clean"
     },
     "lebesgue-measure-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:35Z",
+      "lastAudited": "2026-07-24T11:55:02Z",
       "result": "clean"
     },
     "lebesgue-measure-oq-03-oq-01": {


### PR DESCRIPTION
## Audit result: clean

**Proof**: lebesgue-measure-oq-03 (Infinite-Dimensional Measure Theory)

Re-audit found no issues. Honest Tier-C `axiomatized` entry:
- 0 axioms, 0 sorries, 2 theorems — matches `meta.json`/`leanFile` counts and actual file exactly.
- No True stubs; no `native_decide`.
- The file's closing comment claims "3 axioms" but this is prose only inside a `/- ... -/` block — no actual `axiom` declarations exist. `meta.json`'s `axiomCount: 0` is accurate, and the `sections[]` summary for `closing-summary` already explicitly discloses this discrepancy as non-reportable.
- Cross-reference to `lebesgue-measure-oq-03-oq-01` claiming it's "the rigorous formalization of this entry's central impossibility claim" checked against that file's source — confirmed accurate (4 real theorems proving the impossibility result, 0 axioms/sorries, status `verified`).

Updates `audit-tracker.json` only (auditCount 3→4, lastAudited timestamp).