### PR TITLE
Research: sperner-simplicial-instance-oq-01 - S5-S8 COMPLETE: triAdj + all four obligations + standardTriangleTriangulation m (docker-verified)

### DIFF
--- a/proofs/Proofs/SpernerSimplicialInstanceOQ01.lean
+++ b/proofs/Proofs/SpernerSimplicialInstanceOQ01.lean
@@ -290,6 +290,62 @@ theorem vertex_injective_triVtx (m : ℕ) :
     fin_cases k <;> fin_cases k' <;>
       simp [triVtx, Prod.mk.injEq, Fin.mk.injEq] at hpair <;> rfl
 
+/-- Pseudomanifold adjacency for the standard subdivision of Δ² at
+resolution `m` (S5 ACT): `triAdj m c k` is the neighbour across the edge
+of cell `c` opposite local vertex `k`, or `none` on the boundary.
+
+Case table (edges named by their two lattice-point endpoints):
+
+* `up i j` opposite `0` — hypotenuse `{(i+1,j), (i,j+1)}` on the line
+  `x + y = i + j + 1`: interior iff `i + j + 1 < m`, shared with
+  `down i j` opposite `2`; on the diagonal boundary when `i + j + 1 = m`.
+* `up i j` opposite `1` — vertical edge `{(i,j), (i,j+1)}` on `x = i`:
+  interior iff `0 < i`, shared with `down (i-1) j` opposite `1`; on the
+  left boundary when `i = 0`.
+* `up i j` opposite `2` — horizontal edge `{(i,j), (i+1,j)}` on `y = j`:
+  interior iff `0 < j`, shared with `down i (j-1)` opposite `0`; on the
+  bottom boundary when `j = 0`.
+* `down i j` edges are all interior: opposite `0` is the top edge
+  `{(i,j+1), (i+1,j+1)}` shared with `up i (j+1)` opposite `2`;
+  opposite `1` is the right edge `{(i+1,j), (i+1,j+1)}` shared with
+  `up (i+1) j` opposite `1`; opposite `2` is the hypotenuse
+  `{(i+1,j), (i,j+1)}` shared with `up i j` opposite `0`.
+
+Successor patterns (`up (i+1) j` rather than `i - 1` subtraction) keep
+the arithmetic subtraction-free, so the S6 `adj_symm` round-trips reduce
+by `rfl`-shaped computation. Generalises the `m = 2` table `tadj` above
+(`c0 0 ↔ c3 2`, `c1 1 ↔ c3 1`, `c2 2 ↔ c3 0`). -/
+def triAdj (m : ℕ) : TriCell m → Fin 3 → Option (TriCell m × Fin 3)
+  | TriCell.up i j _, ⟨0, _⟩ =>
+      if h' : i + j + 1 < m then some (TriCell.down i j h', 2) else none
+  | TriCell.up 0 _ _, ⟨1, _⟩ => none
+  | TriCell.up (i + 1) j h, ⟨1, _⟩ =>
+      some (TriCell.down i j (by omega), 1)
+  | TriCell.up _ 0 _, ⟨_ + 2, _⟩ => none
+  | TriCell.up i (j + 1) h, ⟨_ + 2, _⟩ =>
+      some (TriCell.down i j (by omega), 0)
+  | TriCell.down i j h, ⟨0, _⟩ =>
+      some (TriCell.up i (j + 1) (by omega), 2)
+  | TriCell.down i j h, ⟨1, _⟩ =>
+      some (TriCell.up (i + 1) j (by omega), 1)
+  | TriCell.down i j h, ⟨_ + 2, _⟩ =>
+      some (TriCell.up i j (by omega), 0)
+
+/-- Adjacent cells are distinct (the `adj_ne` obligation of the eventual
+`Triangulation (LatticePoint m) 2` instance): every `some` entry of the
+`triAdj` case table pairs an `up`-cell with a `down`-cell, so a cell is
+never its own neighbour. -/
+theorem triAdj_ne (m : ℕ) :
+    ∀ s k s' k', triAdj m s k = some (s', k') → s ≠ s' := by
+  intro s k s' k' hadj
+  rintro rfl
+  rcases s with ⟨i, j, h⟩ | ⟨i, j, h⟩
+  · fin_cases k
+    · by_cases hc : i + j + 1 < m <;> simp [triAdj, hc] at hadj
+    · rcases i with _ | i <;> simp [triAdj] at hadj
+    · rcases j with _ | j <;> simp [triAdj] at hadj
+  · fin_cases k <;> simp [triAdj] at hadj
+
 end Triangle
 
 end Triangulation

--- a/proofs/Proofs/SpernerSimplicialInstanceOQ01.lean
+++ b/proofs/Proofs/SpernerSimplicialInstanceOQ01.lean
@@ -399,42 +399,51 @@ theorem triAdj_vertex (m : ℕ) :
       (Finset.univ.erase k).image (triVtx m s) =
       (Finset.univ.erase k').image (triVtx m s') := by
   intro s k s' k' hadj
+  -- OfNat-literal forms (match the `k'` produced by the `triAdj` table)
   have e0 : (Finset.univ.erase (0 : Fin 3)) = {1, 2} := by decide
   have e1 : (Finset.univ.erase (1 : Fin 3)) = {0, 2} := by decide
   have e2 : (Finset.univ.erase (2 : Fin 3)) = {0, 1} := by decide
+  -- `Fin.mk`-literal forms (match the `k` produced by `fin_cases`;
+  -- simp unifies the membership proofs by proof irrelevance)
+  have e0m : (Finset.univ.erase (⟨0, by omega⟩ : Fin 3)) = {1, 2} := by
+    decide
+  have e1m : (Finset.univ.erase (⟨1, by omega⟩ : Fin 3)) = {0, 2} := by
+    decide
+  have e2m : (Finset.univ.erase (⟨2, by omega⟩ : Fin 3)) = {0, 1} := by
+    decide
   rcases s with ⟨i, j, h⟩ | ⟨i, j, h⟩
   · fin_cases k
     · by_cases hc : i + j + 1 < m
       · simp only [triAdj, dif_pos hc, Option.some.injEq, Prod.mk.injEq]
           at hadj
         obtain ⟨rfl, rfl⟩ := hadj
-        simp only [e0, e2, Finset.image_insert, Finset.image_singleton]
+        simp only [e0m, e2, Finset.image_insert, Finset.image_singleton]
         rfl
       · simp [triAdj, hc] at hadj
     · rcases i with _ | i
       · simp [triAdj] at hadj
       · simp only [triAdj, Option.some.injEq, Prod.mk.injEq] at hadj
         obtain ⟨rfl, rfl⟩ := hadj
-        simp only [e1, Finset.image_insert, Finset.image_singleton]
+        simp only [e1m, e1, Finset.image_insert, Finset.image_singleton]
         rfl
     · rcases j with _ | j
       · simp [triAdj] at hadj
       · simp only [triAdj, Option.some.injEq, Prod.mk.injEq] at hadj
         obtain ⟨rfl, rfl⟩ := hadj
-        simp only [e0, e2, Finset.image_insert, Finset.image_singleton]
+        simp only [e2m, e0, Finset.image_insert, Finset.image_singleton]
         rfl
   · fin_cases k
     · simp only [triAdj, Option.some.injEq, Prod.mk.injEq] at hadj
       obtain ⟨rfl, rfl⟩ := hadj
-      simp only [e0, e2, Finset.image_insert, Finset.image_singleton]
+      simp only [e0m, e2, Finset.image_insert, Finset.image_singleton]
       rfl
     · simp only [triAdj, Option.some.injEq, Prod.mk.injEq] at hadj
       obtain ⟨rfl, rfl⟩ := hadj
-      simp only [e1, Finset.image_insert, Finset.image_singleton]
+      simp only [e1m, e1, Finset.image_insert, Finset.image_singleton]
       rfl
     · simp only [triAdj, Option.some.injEq, Prod.mk.injEq] at hadj
       obtain ⟨rfl, rfl⟩ := hadj
-      simp only [e0, e2, Finset.image_insert, Finset.image_singleton]
+      simp only [e2m, e0, Finset.image_insert, Finset.image_singleton]
       rfl
 
 /-- **The standard regular triangulation of `Δ²` at resolution `m`**

--- a/proofs/Proofs/SpernerSimplicialInstanceOQ01.lean
+++ b/proofs/Proofs/SpernerSimplicialInstanceOQ01.lean
@@ -346,6 +346,46 @@ theorem triAdj_ne (m : ℕ) :
     · rcases j with _ | j <;> simp [triAdj] at hadj
   · fin_cases k <;> simp [triAdj] at hadj
 
+/-- Adjacency is symmetric (the `adj_symm` obligation): each interior
+edge is recorded consistently in both incident cells' rows of the
+`triAdj` case table. The six `some` entries pair up as
+`up i j @ 0 ↔ down i j @ 2`, `up (i+1) j @ 1 ↔ down i j @ 1`, and
+`up i (j+1) @ 2 ↔ down i j @ 0`; each round-trip reduces to a
+constructor-level identity after substituting the neighbour equation,
+with proof irrelevance identifying the regenerated bound proofs. -/
+theorem triAdj_symm (m : ℕ) :
+    ∀ s k s' k', triAdj m s k = some (s', k') →
+      triAdj m s' k' = some (s, k) := by
+  intro s k s' k' hadj
+  rcases s with ⟨i, j, h⟩ | ⟨i, j, h⟩
+  · fin_cases k
+    · by_cases hc : i + j + 1 < m
+      · simp only [triAdj, dif_pos hc, Option.some.injEq, Prod.mk.injEq]
+          at hadj
+        obtain ⟨rfl, rfl⟩ := hadj
+        simp [triAdj]
+      · simp [triAdj, hc] at hadj
+    · rcases i with _ | i
+      · simp [triAdj] at hadj
+      · simp only [triAdj, Option.some.injEq, Prod.mk.injEq] at hadj
+        obtain ⟨rfl, rfl⟩ := hadj
+        simp [triAdj]
+    · rcases j with _ | j
+      · simp [triAdj] at hadj
+      · simp only [triAdj, Option.some.injEq, Prod.mk.injEq] at hadj
+        obtain ⟨rfl, rfl⟩ := hadj
+        simp [triAdj]
+  · fin_cases k
+    · simp only [triAdj, Option.some.injEq, Prod.mk.injEq] at hadj
+      obtain ⟨rfl, rfl⟩ := hadj
+      simp [triAdj]
+    · simp only [triAdj, Option.some.injEq, Prod.mk.injEq] at hadj
+      obtain ⟨rfl, rfl⟩ := hadj
+      simp [triAdj]
+    · simp only [triAdj, Option.some.injEq, Prod.mk.injEq] at hadj
+      obtain ⟨rfl, rfl⟩ := hadj
+      simp [triAdj, h]
+
 end Triangle
 
 end Triangulation

--- a/proofs/Proofs/SpernerSimplicialInstanceOQ01.lean
+++ b/proofs/Proofs/SpernerSimplicialInstanceOQ01.lean
@@ -386,6 +386,93 @@ theorem triAdj_symm (m : ℕ) :
       obtain ⟨rfl, rfl⟩ := hadj
       simp [triAdj, h]
 
+/-- Adjacent cells share the codimension-1 face (the `adj_vertex`
+obligation): for each interior pairing, the two-element edge vertex-sets
+coincide. In every `some` row of the `triAdj` table the shared edge is
+listed in the *same order* on both sides (e.g. `up i j` positions `1, 2`
+and `down i j` positions `0, 1` both enumerate `(i+1, j), (i, j+1)`), so
+after computing `univ.erase k` and pushing the image through the
+two-element set, both sides are definitionally equal (`rfl`, with proof
+irrelevance identifying the subtype membership proofs). -/
+theorem triAdj_vertex (m : ℕ) :
+    ∀ s k s' k', triAdj m s k = some (s', k') →
+      (Finset.univ.erase k).image (triVtx m s) =
+      (Finset.univ.erase k').image (triVtx m s') := by
+  intro s k s' k' hadj
+  have e0 : (Finset.univ.erase (0 : Fin 3)) = {1, 2} := by decide
+  have e1 : (Finset.univ.erase (1 : Fin 3)) = {0, 2} := by decide
+  have e2 : (Finset.univ.erase (2 : Fin 3)) = {0, 1} := by decide
+  rcases s with ⟨i, j, h⟩ | ⟨i, j, h⟩
+  · fin_cases k
+    · by_cases hc : i + j + 1 < m
+      · simp only [triAdj, dif_pos hc, Option.some.injEq, Prod.mk.injEq]
+          at hadj
+        obtain ⟨rfl, rfl⟩ := hadj
+        simp only [e0, e2, Finset.image_insert, Finset.image_singleton]
+        rfl
+      · simp [triAdj, hc] at hadj
+    · rcases i with _ | i
+      · simp [triAdj] at hadj
+      · simp only [triAdj, Option.some.injEq, Prod.mk.injEq] at hadj
+        obtain ⟨rfl, rfl⟩ := hadj
+        simp only [e1, Finset.image_insert, Finset.image_singleton]
+        rfl
+    · rcases j with _ | j
+      · simp [triAdj] at hadj
+      · simp only [triAdj, Option.some.injEq, Prod.mk.injEq] at hadj
+        obtain ⟨rfl, rfl⟩ := hadj
+        simp only [e0, e2, Finset.image_insert, Finset.image_singleton]
+        rfl
+  · fin_cases k
+    · simp only [triAdj, Option.some.injEq, Prod.mk.injEq] at hadj
+      obtain ⟨rfl, rfl⟩ := hadj
+      simp only [e0, e2, Finset.image_insert, Finset.image_singleton]
+      rfl
+    · simp only [triAdj, Option.some.injEq, Prod.mk.injEq] at hadj
+      obtain ⟨rfl, rfl⟩ := hadj
+      simp only [e1, Finset.image_insert, Finset.image_singleton]
+      rfl
+    · simp only [triAdj, Option.some.injEq, Prod.mk.injEq] at hadj
+      obtain ⟨rfl, rfl⟩ := hadj
+      simp only [e0, e2, Finset.image_insert, Finset.image_singleton]
+      rfl
+
+/-- **The standard regular triangulation of `Δ²` at resolution `m`**
+(S8: instance assembly — the answer to OQ-01's general-`m` core).
+Cells are the `m²` up/down triangles of `TriCell m`, vertices the
+lattice points of `Δ²` at resolution `m`, and all four `Triangulation`
+obligations are the `m`-parametric theorems proved above (S4–S7). For
+`m = 0` the triangulation is empty (no cells); `m = 2` recovers the
+combinatorics of the concrete `standardTriangle2` above. -/
+def standardTriangleTriangulation (m : ℕ) :
+    Triangulation (LatticePoint m) 2 where
+  Cell := TriCell m
+  cellDecEq := inferInstance
+  cellFintype := inferInstance
+  vertex := triVtx m
+  vertex_injective := vertex_injective_triVtx m
+  adj := triAdj m
+  adj_symm := triAdj_symm m
+  adj_vertex := triAdj_vertex m
+  adj_ne := triAdj_ne m
+
+/-- **2-d Sperner's lemma at every resolution `m`**: if the boundary
+doors of the standard `Δ²` triangulation at resolution `m` are odd under
+a coloring `c`, then some cell is panchromatic. The `m`-parametric
+generalisation of `standardTriangle2_sperner`, via the abstract
+`Triangulation.sperner`. -/
+theorem standardTriangleTriangulation_sperner (m : ℕ)
+    (c : LatticePoint m → Fin 3)
+    (hbdry : Odd (Finset.univ.filter
+      (fun p : TriCell m × Fin 3 =>
+        CellComplex.IsDoor c
+          (standardTriangleTriangulation m).toCellComplex p.1 p.2 ∧
+        (standardTriangleTriangulation m).adj p.1 p.2 = none)).card) :
+    ∃ s : TriCell m,
+      CellComplex.IsPanchromatic c
+        (standardTriangleTriangulation m).toCellComplex s :=
+  Triangulation.sperner (standardTriangleTriangulation m) c hbdry
+
 end Triangle
 
 end Triangulation

--- a/research/problems/sperner-simplicial-instance-oq-01/problem.md
+++ b/research/problems/sperner-simplicial-instance-oq-01/problem.md
@@ -33,3 +33,49 @@ The Seeker has done the candidate-pool plumbing; the Researcher owns the OODA lo
 1. `gh pr list --search "sperner-simplicial-instance-oq-01"` — confirm no parallel session is already in flight (race-safety re-check at session start).
 2. Inspect `src/data/proofs/sperner-simplicial-instance/meta.json` — `openQuestions` array — for adjacent OQs that may share infrastructure.
 3. Search Mathlib for the central object referenced in the problem statement; the API surface usually dictates the cleanest decomposition.
+
+## Must prove exactly / does not count
+
+**Target**: a concrete instance of the parent's `Triangulation V 2` structure
+(`proofs/Proofs/SpernerSimplicialInstance.lean:81`) for the standard
+triangulated 2-simplex, with all four obligations (`vertex_injective`,
+`adj_symm`, `adj_vertex`, `adj_ne`) machine-checked, 0 sorries, 0 axioms.
+
+- **Counts**: the resolution-2 concrete instance (`standardTriangle2 :
+  Triangulation (Fin 6) 2`) and/or the general-resolution family
+  (`standardTriangleTriangulation m : Triangulation (LatticePoint m) 2`).
+- **Does not count**: the single-cell `trivialTriangle` smoke test (no real
+  subdivision — no interior edge); an instance with `adj ≡ none` everywhere
+  (pseudomanifold fields vacuous); a claim of *geometric* triangulation of
+  |Δ²| ⊂ ℝ² (the structure is combinatorial; no embedding is stated).
+
+## Adversarial checklist (SOLVED claim, 2026-07-24)
+
+1. **Trivial-instance trap** — `Triangulation V 2` is inhabited by the
+   single-cell `trivialTriangle`; confirm the claim rests on
+   `standardTriangleTriangulation m` (`m²` cells via `TriCell m`) and
+   `standardTriangle2` (4 cells), each with genuine interior adjacency.
+2. **All-boundary adjacency cheat** — `adj_symm`/`adj_vertex`/`adj_ne` are
+   vacuous under `adj ≡ none`. Confirm `triAdj` has `some` rows: all three
+   edges of every `down`-cell, and every `up`-cell edge not on the geometric
+   boundary. Cross-check: the m=2 specialization reproduces the
+   independently `decide`-verified `tadj` table (3 interior edges).
+3. **Adjacency-completeness gap (disclosed, structural)** — the structure
+   never requires that geometrically shared faces be recorded as `some`;
+   no theorem here certifies "`triAdj = none` ⟹ geometric boundary". Our
+   table marks all interior edges by construction, but the completeness
+   statement is oq-03 territory (boundary-door parity), not part of this
+   instance claim.
+4. **Vertex-map faithfulness** — a wrong `triVtx` could still satisfy the
+   four obligations. Mitigations actually proved: `vertex_injective_triVtx`
+   (distinct corners) and `triAdj_vertex` (adjacent cells share exactly the
+   2-element edge set in identical lattice coordinates).
+5. **Carrier near-miss** — the claim is the combinatorial instance over
+   `LatticePoint m` (subtype of `Fin (m+1) × Fin (m+1)`), matching the
+   parent's combinatorial structure; it is NOT a geometric realization.
+6. **`decide` scope** — kernel `decide` only on closed `Fin`-indexed goals
+   (m=2 instance; `Finset (Fin 3)` erase equations in `triAdj_vertex`).
+   All general-`m` obligations are parametric proofs. No `native_decide`.
+7. **m = 0 degeneracy** — `TriCell 0` is empty, so the m=0 member of the
+   family is the empty triangulation (structurally legal, not part of the
+   subdivision claim; m ≥ 1 gives real subdivisions, m ≥ 2 interior edges).

--- a/research/problems/sperner-simplicial-instance-oq-01/state.md
+++ b/research/problems/sperner-simplicial-instance-oq-01/state.md
@@ -1,11 +1,48 @@
 # Research State: sperner-simplicial-instance-oq-01
 
 ## Current State
-**Phase**: ACT (S5+S6 ACT complete — triAdj + adj_ne + adj_symm shipped + Docker-verified; S7 adj_vertex next)
+**Phase**: COMPLETED (S5–S8 shipped — `standardTriangleTriangulation m : Triangulation (LatticePoint m) 2` assembled with all four obligations proved m-parametrically; general-m Sperner corollary included)
 **Path**: full
 **Since**: 2026-05-13T05:18:00Z
-**Last Updated**: 2026-07-24 (Session 10 / S5+S6 ACT researcher-2)
-**Iteration**: 8
+**Last Updated**: 2026-07-24 (Session 10–11 / S5–S8 researcher-2)
+**Iteration**: 9
+
+## Session 11 — S7+S8: `triAdj_vertex` + instance assembly = NODE COMPLETE (researcher-2, 2026-07-24)
+
+Same-session continuation on the same branch/PR as Session 10. Ships the last
+two rungs:
+
+* `triAdj_vertex` — the six interior edge-set equalities. Key structural fact:
+  every `some` row of the `triAdj` table lists the shared edge in the SAME
+  order on both sides (e.g. `up i j` positions 1,2 and `down i j` positions
+  0,1 both enumerate `(i+1,j), (i,j+1)`), so each case closes by erase-set
+  computation + `Finset.image_insert`/`image_singleton` + `rfl` (proof
+  irrelevance on the subtype memberships).
+  **v4.31 gotcha (cost one build cycle)**: `fin_cases k` produces
+  `Fin.mk`-literals (`⟨1, ⋯⟩`) while the `triAdj`-table `k'` lands as OfNat
+  literals (`(1 : Fin 3)`) — `simp only` erase lemmas keyed on one form do
+  NOT match the other (bare `rfl` pushed through some but not all unreduced
+  images). Fix: state each erase equation in BOTH forms (`e1 :
+  univ.erase (1 : Fin 3) = {0,2}` and `e1m : univ.erase (⟨1, by omega⟩ :
+  Fin 3) = {0,2}`, all `by decide`); simp unifies mk-form proof args by
+  proof irrelevance.
+* `standardTriangleTriangulation m : Triangulation (LatticePoint m) 2` —
+  instance assembly (Cell := `TriCell m`; S3 instances; S4–S7 theorems slot
+  into the four obligations directly).
+* `standardTriangleTriangulation_sperner` — 2-d Sperner at every resolution
+  `m` via the abstract `Triangulation.sperner` (generalises
+  `standardTriangle2_sperner`).
+
+Leaf file 392 → 531 LOC, 0 sorries, 0 axioms; Docker 1117 jobs clean, no
+warnings in the leaf file.
+
+**Node status**: the OQ ("verify the standard 2-simplex triangulation as a
+concrete Triangulation instance") is now answered at BOTH the concrete m=2
+resolution (`standardTriangle2`, decide-based) and the general resolution
+(`standardTriangleTriangulation m`, fully parametric). Adversarial checklist
+added to problem.md. Follow-ups: **0 new** — the natural continuations are
+exactly the existing sibling OQs (oq-03 boundary-door parity for the standard
+coloring, oq-04 Brouwer, oq-06 Hex), which consume this instance.
 
 ## Session 10 — S5+S6 ACT: `triAdj` + `triAdj_ne` + `triAdj_symm` (researcher-2, 2026-07-24)
 

--- a/research/problems/sperner-simplicial-instance-oq-01/state.md
+++ b/research/problems/sperner-simplicial-instance-oq-01/state.md
@@ -1,11 +1,51 @@
 # Research State: sperner-simplicial-instance-oq-01
 
 ## Current State
-**Phase**: ACT (S4 ACT complete — triVtx + vertex_injective shipped + Docker-verified; S5 triAdj next)
+**Phase**: ACT (S5+S6 ACT complete — triAdj + adj_ne + adj_symm shipped + Docker-verified; S7 adj_vertex next)
 **Path**: full
 **Since**: 2026-05-13T05:18:00Z
-**Last Updated**: 2026-07-24 (Session 9 / S4 ACT researcher-3)
-**Iteration**: 7
+**Last Updated**: 2026-07-24 (Session 10 / S5+S6 ACT researcher-2)
+**Iteration**: 8
+
+## Session 10 — S5+S6 ACT: `triAdj` + `triAdj_ne` + `triAdj_symm` (researcher-2, 2026-07-24)
+
+Same-day follow-up to Session 9 (fresh branch off origin/main). Ships the S5
+adjacency case-table plus, as a stretch, the S6 symmetry proof — three of the
+four `Triangulation` obligations for the general-`m` instance are now closed
+`m`-parametrically (`vertex_injective` S4, `adj_ne` + `adj_symm` this session).
+
+**Shipped** (leaf file 296 → 392 LOC, 0 sorries, 0 axioms; two Docker builds,
+1117 jobs each, both first-try clean, Lean v4.31.0):
+
+* `triAdj m : TriCell m → Fin 3 → Option (TriCell m × Fin 3)` — derived from
+  the `triVtx` geometry: `up i j` edges are interior iff `i + j + 1 < m`
+  (hypotenuse, ↔ `down i j @ 2`), `0 < i` (vertical, ↔ `down (i-1) j @ 1`),
+  `0 < j` (horizontal, ↔ `down i (j-1) @ 0`); all three `down` edges are
+  interior. **Successor patterns** (`up (i+1) j @ 1 ↦ down i j` instead of
+  `i - 1` subtraction) keep the table subtraction-free — this is what made
+  the `adj_symm` round-trips reduce cleanly. Generalises the m=2 `tadj`
+  table (`c0 0 ↔ c3 2`, `c1 1 ↔ c3 1`, `c2 2 ↔ c3 0`).
+* `triAdj_ne` — every `some` entry pairs `up` with `down`, so `s ≠ s'` by
+  constructor disjointness: `rintro rfl`, case split (`fin_cases k`; nested
+  `rcases i/j with _ | _` where the table matches on successor patterns;
+  `by_cases` on the hypotenuse dite), then `simp [triAdj, hc] at hadj`
+  closes every branch (reduceCtorEq handles both `none = some` and
+  `down = up` mismatches).
+* `triAdj_symm` — six interior round-trips: extract the neighbour equation
+  with `simp only [triAdj, Option.some.injEq, Prod.mk.injEq] at hadj`
+  (+ `dif_pos hc` on the hypotenuse arm), `obtain ⟨rfl, rfl⟩`, then
+  `simp [triAdj]` (with `h` feeding the dite condition on the
+  `down @ 2 → up @ 0` leg); proof irrelevance identifies the regenerated
+  constructor bound proofs — no drift issues, no `Fin.mk` friction.
+
+**Remaining for the full `Triangulation (LatticePoint m) 2` instance** (the
+genuine open core): S7 `adj_vertex` — the Finset-image equality
+`(univ.erase k).image (triVtx m s) = (univ.erase k').image (triVtx m s')`
+for the six interior pairings (2-element edge sets; expect `Finset.ext` +
+`fin_cases`/`decide`-free membership chasing, or precompute both images as
+explicit pair-insertions) — then S8 instance assembly
+(`standardTriangleTriangulation m : Triangulation (LatticePoint m) 2` — all
+four obligations then exist; `Cell := TriCell m`, instances from S3).
 
 ## Session 9 — S4 ACT: `triVtx` + `vertex_injective_triVtx` (researcher-3, 2026-07-24)
 

--- a/src/data/research/problems/sperner-simplicial-instance-oq-01.json
+++ b/src/data/research/problems/sperner-simplicial-instance-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "sperner-simplicial-instance-oq-01",
   "title": "Standard 2-simplex triangulation as a concrete Triangulation instance",
   "phase": "ACT",
-  "status": "in-progress",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -28,9 +28,9 @@
     "goal": "Add ~300 LOC namespace Triangle section into proofs/Proofs/SpernerSimplicialInstance.lean (between line 994 and end Triangulation) shipping the 2-d instance and the triangle_sperner corollary; preserve all existing content unchanged."
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-07-24",
-    "iteration": 8,
+    "iteration": 9,
     "focus": "S4 ACT COMPLETE (researcher-3, 2026-07-24, same session as S3): triVtx (m-parametric vertex map, match-pattern form per S4 PREP #18719 §9 risk-note 3) + vertex_injective_triVtx shipped into the leaf file (254→296 LOC), 0 sorries, 0 axioms, Docker-verified 1117 jobs. The vertex_injective obligation of the eventual Triangulation (LatticePoint m) 2 instance is now discharged m-parametrically (no decide). v4.31 note: subtype-membership `by omega` fails on unreduced pair projections — use `show i + j ≤ m by omega` defeq forms; `first | rfl | omega` fallback dead (simp closes off-diagonals) → plain rfl.",
     "blockers": [],
     "nextAction": "S5 ACT: triAdj adjacency case-table (~60 LOC, 12 sub-cases, design in S6-era PREPs); then S6+ adj_symm/adj_vertex/adj_ne + instance assembly — the genuine open core.",
@@ -41,7 +41,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S5+S6 ACT (researcher-2, 2026-07-24): triAdj adjacency case-table + triAdj_ne + triAdj_symm shipped m-parametrically, docker-verified (leaf 296->392 LOC, 0 sorries, 0 axioms). Three of four Triangulation obligations closed (vertex_injective S4, adj_ne+adj_symm S5/S6). Remaining: S7 adj_vertex (Finset-image edge equality, the open core) + S8 instance assembly standardTriangleTriangulation m.",
+    "progressSummary": "COMPLETED (researcher-2, 2026-07-24): standardTriangleTriangulation m : Triangulation (LatticePoint m) 2 assembled with all four obligations proved m-parametrically (S4 vertex_injective, S5 adj_ne, S6 adj_symm, S7 adj_vertex), plus general-m Sperner corollary. Leaf file 531 LOC, 0 sorries, 0 axioms, docker-verified. OQ answered at m=2 (decide-based standardTriangle2) AND general m. Adversarial checklist in problem.md. 0 new follow-ups (oq-03/oq-04/oq-06 consume this).",
     "builtItems": [
       "research/problems/sperner-simplicial-instance-oq-01/problem.md (formal scope, signature targets, sub-OQ index)",
       "research/problems/sperner-simplicial-instance-oq-01/knowledge.md (1-d template recap, 2-d design with adjacency table, axiom proof outlines, Mathlib alignment, detailed LOC estimate)",
@@ -50,7 +50,10 @@
       "research/problems/sperner-simplicial-instance-oq-01/sessions/2026-05-13-s02-act-trivialTriangle.md — S2 ACT session note with patch traces, axiom-discharge audit, build-posture caveat.",
       "triAdj m : TriCell m -> Fin 3 -> Option (TriCell m x Fin 3) in SpernerSimplicialInstanceOQ01.lean (S5, docker-verified)",
       "triAdj_ne (adj_ne obligation) — constructor disjointness via simp/reduceCtorEq (S5)",
-      "triAdj_symm (adj_symm obligation) — six interior-edge round-trips (S6)"
+      "triAdj_symm (adj_symm obligation) — six interior-edge round-trips (S6)",
+      "triAdj_vertex (adj_vertex obligation) — six interior edge-set equalities (S7, docker-verified)",
+      "standardTriangleTriangulation m : Triangulation (LatticePoint m) 2 — general-m instance, OQ-01 core answered (S8)",
+      "standardTriangleTriangulation_sperner — 2-d Sperner at every resolution m (S8)"
     ],
     "insights": [
       "The 1-d intervalTriangulation template generalises cleanly to 2-d via lattice-point indexing plus an up/down inductive cell type.",
@@ -59,15 +62,15 @@
       "Down-triangles are entirely interior — boundary 1-faces are all on up-triangles.",
       "adj_vertex is the strategic case-heavy axiom (12 cases × ~6 LOC); strategic sorry there ships S2 build-pending and closes in S3.",
       "S5: triAdj derived from triVtx geometry — up-cell edges interior iff i+j+1<m (hypotenuse), 0<i (vertical), 0<j (horizontal); all down-cell edges interior. Successor patterns (up (i+1) j -> down i j) instead of subtraction keep adj_symm round-trips rfl-shaped.",
-      "S6: adj_symm was cheap once the table is subtraction-free — simp only [triAdj, Option.some.injEq, Prod.mk.injEq] extraction + obtain rfl + simp [triAdj] closes all six interior round-trips; proof irrelevance silently identifies regenerated constructor bound proofs (no Fin.mk friction, no v4.31 drift)."
+      "S6: adj_symm was cheap once the table is subtraction-free — simp only [triAdj, Option.some.injEq, Prod.mk.injEq] extraction + obtain rfl + simp [triAdj] closes all six interior round-trips; proof irrelevance silently identifies regenerated constructor bound proofs (no Fin.mk friction, no v4.31 drift).",
+      "S7: every some-row of triAdj lists the shared edge in the SAME order on both sides, so adj_vertex closes by erase-set computation + image_insert/image_singleton + rfl. v4.31 gotcha: fin_cases yields Fin.mk literals but table k-primes are OfNat literals — state erase lemmas in BOTH forms (simp unifies mk proof args by proof irrelevance).",
+      "S8: instance assembly is a pure where-block — S3 instances + S4-S7 theorems slot into the four Triangulation obligations; general-m Sperner corollary is a one-line application of Triangulation.sperner."
     ],
     "mathlibGaps": [
       "Mathlib.Combinatorics.SimpleGraph.Triangulation does not exist; the local Triangulation structure in the parent file is the working substitute. No new gap introduced."
     ],
     "nextSteps": [
-      "S7 adj_vertex — (univ.erase k).image (triVtx m s) = (univ.erase k, ).image (triVtx m s, ) for the six interior pairings; expect Finset.ext + explicit two-element image computation.",
-      "S8 — assemble standardTriangleTriangulation m : Triangulation (LatticePoint m) 2 (Cell := TriCell m; all four obligations exist after S7).",
-      "S9 (optional) — boundary-door characterization for the general-m instance, feeding oq-03 boundary_doors_odd."
+      "None for this node - COMPLETED. Consumers: oq-03 (boundary-door parity: characterize triAdj = none <-> geometric boundary + standard-coloring odd door count), oq-04 (Brouwer), oq-06 (Hex)."
     ]
   },
   "tags": [

--- a/src/data/research/problems/sperner-simplicial-instance-oq-01.json
+++ b/src/data/research/problems/sperner-simplicial-instance-oq-01.json
@@ -30,7 +30,7 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-24",
-    "iteration": 7,
+    "iteration": 8,
     "focus": "S4 ACT COMPLETE (researcher-3, 2026-07-24, same session as S3): triVtx (m-parametric vertex map, match-pattern form per S4 PREP #18719 §9 risk-note 3) + vertex_injective_triVtx shipped into the leaf file (254→296 LOC), 0 sorries, 0 axioms, Docker-verified 1117 jobs. The vertex_injective obligation of the eventual Triangulation (LatticePoint m) 2 instance is now discharged m-parametrically (no decide). v4.31 note: subtype-membership `by omega` fails on unreduced pair projections — use `show i + j ≤ m by omega` defeq forms; `first | rfl | omega` fallback dead (simp closes off-diagonals) → plain rfl.",
     "blockers": [],
     "nextAction": "S5 ACT: triAdj adjacency case-table (~60 LOC, 12 sub-cases, design in S6-era PREPs); then S6+ adj_symm/adj_vertex/adj_ne + instance assembly — the genuine open core.",
@@ -41,28 +41,33 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S2 ACT (researcher-1, 2026-05-13): shipped trivialTriangle : Triangulation ℕ 2 (Candidate A) — minimal single-cell smoke-test instance in proofs/Proofs/SpernerSimplicialInstance.lean (+28 LOC, 0 sorries, 0 axioms, build pending). Five data fields + four proof obligations all closed by single terms. Establishes the build-verified 2-d baseline; Candidate C lattice-subdivision chain (the load-bearing path for oq-03 / oq-04 / oq-06) is the S3+ work. S5 STATE-SYNC (researcher-1, 2026-06-05): T+23d stall at S2 ACT confirmed; S3 ACT prerequisites all merged (S3 PREP #18625, S3b PREP #18654, S4 PREP #18719); ready for a Docker-budgeted S3 ACT iteration.",
+    "progressSummary": "S5+S6 ACT (researcher-2, 2026-07-24): triAdj adjacency case-table + triAdj_ne + triAdj_symm shipped m-parametrically, docker-verified (leaf 296->392 LOC, 0 sorries, 0 axioms). Three of four Triangulation obligations closed (vertex_injective S4, adj_ne+adj_symm S5/S6). Remaining: S7 adj_vertex (Finset-image edge equality, the open core) + S8 instance assembly standardTriangleTriangulation m.",
     "builtItems": [
       "research/problems/sperner-simplicial-instance-oq-01/problem.md (formal scope, signature targets, sub-OQ index)",
       "research/problems/sperner-simplicial-instance-oq-01/knowledge.md (1-d template recap, 2-d design with adjacency table, axiom proof outlines, Mathlib alignment, detailed LOC estimate)",
       "research/problems/sperner-simplicial-instance-oq-01/state.md (phase OBSERVE, S2 scope lock, race awareness)",
       "proofs/Proofs/SpernerSimplicialInstance.lean def trivialTriangle : Triangulation ℕ 2 — single-cell smoke-test instance, Cell = Fin 1, vertex = Fin.val, adj = none. +28 LOC, 0 sorries, 0 axioms, build pending. Inserted between end Interval (line 973) and /-! ## Interval Sperner.",
-      "research/problems/sperner-simplicial-instance-oq-01/sessions/2026-05-13-s02-act-trivialTriangle.md — S2 ACT session note with patch traces, axiom-discharge audit, build-posture caveat."
+      "research/problems/sperner-simplicial-instance-oq-01/sessions/2026-05-13-s02-act-trivialTriangle.md — S2 ACT session note with patch traces, axiom-discharge audit, build-posture caveat.",
+      "triAdj m : TriCell m -> Fin 3 -> Option (TriCell m x Fin 3) in SpernerSimplicialInstanceOQ01.lean (S5, docker-verified)",
+      "triAdj_ne (adj_ne obligation) — constructor disjointness via simp/reduceCtorEq (S5)",
+      "triAdj_symm (adj_symm obligation) — six interior-edge round-trips (S6)"
     ],
     "insights": [
       "The 1-d intervalTriangulation template generalises cleanly to 2-d via lattice-point indexing plus an up/down inductive cell type.",
       "Total cell count m² decomposes naturally as T(m) up-triangles + T(m-1) down-triangles, matching the geometric picture.",
       "Up-triangles' three faces map to (hypotenuse, left side, bottom side); each is either adjacent to a down-triangle in a specific position or boundary.",
       "Down-triangles are entirely interior — boundary 1-faces are all on up-triangles.",
-      "adj_vertex is the strategic case-heavy axiom (12 cases × ~6 LOC); strategic sorry there ships S2 build-pending and closes in S3."
+      "adj_vertex is the strategic case-heavy axiom (12 cases × ~6 LOC); strategic sorry there ships S2 build-pending and closes in S3.",
+      "S5: triAdj derived from triVtx geometry — up-cell edges interior iff i+j+1<m (hypotenuse), 0<i (vertical), 0<j (horizontal); all down-cell edges interior. Successor patterns (up (i+1) j -> down i j) instead of subtraction keep adj_symm round-trips rfl-shaped.",
+      "S6: adj_symm was cheap once the table is subtraction-free — simp only [triAdj, Option.some.injEq, Prod.mk.injEq] extraction + obtain rfl + simp [triAdj] closes all six interior round-trips; proof irrelevance silently identifies regenerated constructor bound proofs (no Fin.mk friction, no v4.31 drift)."
     ],
     "mathlibGaps": [
       "Mathlib.Combinatorics.SimpleGraph.Triangulation does not exist; the local Triangulation structure in the parent file is the working substitute. No new gap introduced."
     ],
     "nextSteps": [
-      "S2 ACT — ~300 LOC into proofs/Proofs/SpernerSimplicialInstance.lean (namespace Triangle).",
-      "S3 (optional) — close strategic adj_vertex sorry if any.",
-      "S4 (future, separate slug) — 3-d tetrahedral extension using same template."
+      "S7 adj_vertex — (univ.erase k).image (triVtx m s) = (univ.erase k, ).image (triVtx m s, ) for the six interior pairings; expect Finset.ext + explicit two-element image computation.",
+      "S8 — assemble standardTriangleTriangulation m : Triangulation (LatticePoint m) 2 (Cell := TriCell m; all four obligations exist after S7).",
+      "S9 (optional) — boundary-door characterization for the general-m instance, feeding oq-03 boundary_doors_odd."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Research session for `sperner-simplicial-instance-oq-01` — **completes the node**. Continues today's S3 (#43125) / S4 (#43135) chain on the leaf file `proofs/Proofs/SpernerSimplicialInstanceOQ01.lean`, shipping S5 through S8:

- **S5** `triAdj m : TriCell m -> Fin 3 -> Option (TriCell m x Fin 3)` + `triAdj_ne`
- **S6** `triAdj_symm`
- **S7** `triAdj_vertex`
- **S8** `standardTriangleTriangulation m : Triangulation (LatticePoint m) 2` — the general-resolution instance with all four obligations proved `m`-parametrically — plus `standardTriangleTriangulation_sperner` (2-d Sperner at every resolution `m`)

The OQ ("verify the standard 2-simplex triangulation as a concrete `Triangulation` instance") is now answered at both the concrete resolution (`standardTriangle2`, m=2, decide-based, already on main) and general resolution (fully parametric, no `decide`). Leaf file 296 -> 531 LOC, **0 sorries, 0 axioms**; three Docker builds (1117 jobs), final one clean with no warnings in the leaf file.

## Adjacency design (S5)

Derived from the `triVtx` geometry: `up i j` edges are interior iff `i+j+1 < m` (hypotenuse, pairs `down i j @ 2`), `0 < i` (vertical, pairs `down (i-1) j @ 1`), `0 < j` (horizontal, pairs `down i (j-1) @ 0`); all three `down` edges are interior. **Successor patterns** (`up (i+1) j @ 1 -> down i j` rather than `i - 1` behind a guard) keep the table subtraction-free — this is what let both `adj_symm` and `adj_vertex` reduce cleanly. The m=2 specialization reproduces the independently `decide`-verified `tadj` table.

## Findings

- **Same-order edge listing**: every `some` row of `triAdj` lists the shared edge in the same order on both sides, so each `adj_vertex` case closes by erase-set computation + `Finset.image_insert`/`image_singleton` + `rfl` (proof irrelevance identifies subtype membership proofs).
- **v4.31 gotcha (cost one build cycle)**: `fin_cases` produces `Fin.mk` literals while the `triAdj` table's `k'` lands as OfNat literals — `simp only` erase lemmas keyed on one form silently miss the other. Fix: state each `Finset.univ.erase` equation in both forms (`by decide`); simp unifies mk proof args by proof irrelevance.
- S5/S6 hit zero v4.31 drift (both first-try builds), unlike the S3/S4 sessions.

## Adversarial self-check (details in problem.md checklist)

- Not the trivial-instance trap: `m²` cells with genuine interior adjacency; `adj` is not none-everywhere (all `down` edges are `some`).
- Disclosed structural gap: the `Triangulation` structure never requires geometrically shared faces to be recorded, and no theorem here certifies "`triAdj = none` ⟹ geometric boundary" — that completeness/parity statement is oq-03's territory.
- Combinatorial instance over `LatticePoint m`, not a geometric realization of |Δ²| — matching the parent structure's combinatorial scope.
- Kernel `decide` only on closed `Fin`-goals; no `native_decide`; expected axiom profile propext/Classical.choice/Quot.sound.

## Files Modified

- `proofs/Proofs/SpernerSimplicialInstanceOQ01.lean` (+235 LOC total)
- `research/problems/sperner-simplicial-instance-oq-01/state.md` (Sessions 10-11)
- `research/problems/sperner-simplicial-instance-oq-01/problem.md` (target pinning + adversarial checklist)
- `src/data/research/problems/sperner-simplicial-instance-oq-01.json` (COMPLETED sync)

## Status

**Outcome**: completed
**Follow-ups**: 0 new — the natural continuations are exactly the existing sibling OQs (oq-03 boundary-door parity, oq-04 Brouwer, oq-06 Hex), which consume this instance.

🤖 Generated by researcher-2 with [Claude Code](https://claude.com/claude-code)
