### PR TITLE
research(hilbert-14-oq-04): S6 Reynolds operator toolkit — averaging projection onto invariants

### DIFF
--- a/proofs/Proofs/Hilbert14OQ04.lean
+++ b/proofs/Proofs/Hilbert14OQ04.lean
@@ -217,10 +217,12 @@ variable (G) in
 noncomputable def reynolds (p : MvPolynomial (Fin n) k) : MvPolynomial (Fin n) k :=
   (Fintype.card G : k)⁻¹ • ∑ g : G, g • p
 
+omit [Group G] [MulSemiringAction G (MvPolynomial (Fin n) k)]
+  [SMulCommClass G k (MvPolynomial (Fin n) k)] in
 /-- Non-modularity bridge: if `ringChar k ∤ |G|` then `|G| ≠ 0` in `k`. -/
 theorem card_ne_zero_of_char_not_dvd (h_char : ¬ ringChar k ∣ Fintype.card G) :
     (Fintype.card G : k) ≠ 0 :=
-  fun h => h_char ((ringChar.spec (Fintype.card G)).mp h)
+  fun h => h_char ((ringChar.spec k (Fintype.card G)).mp h)
 
 omit [SMulCommClass G k (MvPolynomial (Fin n) k)] in
 /-- Orbit sums are invariant under right translation of the argument. -/
@@ -229,6 +231,7 @@ theorem sum_smul_of_smul (g : G) (p : MvPolynomial (Fin n) k) :
   simp_rw [smul_smul]
   exact Fintype.sum_equiv (Equiv.mulRight g) _ (fun h => h • p) (fun h => rfl)
 
+omit [SMulCommClass G k (MvPolynomial (Fin n) k)] in
 /-- The Reynolds operator is constant on `G`-orbits. -/
 theorem reynolds_smul (g : G) (p : MvPolynomial (Fin n) k) :
     reynolds G (g • p) = reynolds G p := by
@@ -262,11 +265,13 @@ theorem reynolds_of_mem_fixedPoints (hG : (Fintype.card G : k) ≠ 0)
   rw [Finset.sum_const, Finset.card_univ, ← Nat.cast_smul_eq_nsmul k,
     smul_smul, inv_mul_cancel₀ hG, one_smul]
 
+omit [SMulCommClass G k (MvPolynomial (Fin n) k)] in
 /-- The Reynolds operator is additive. -/
 theorem reynolds_add (p q : MvPolynomial (Fin n) k) :
     reynolds G (p + q) = reynolds G p + reynolds G q := by
   unfold reynolds
   simp_rw [smul_add, Finset.sum_add_distrib]
+  exact smul_add _ _ _
 
 omit [SMulCommClass G k (MvPolynomial (Fin n) k)] in
 /-- The Reynolds operator does not raise total degree (under the graded

--- a/proofs/Proofs/Hilbert14OQ04.lean
+++ b/proofs/Proofs/Hilbert14OQ04.lean
@@ -200,4 +200,86 @@ theorem totalDegree_coeff_charpoly_le
 
 end DegreeBound
 
+section Reynolds
+
+/-! ### S6 — the Reynolds operator (non-modular averaging projection)
+
+The engine of the Stage-5 Noether-bound extraction: the averaging map
+`p ↦ |G|⁻¹ • Σ_g g • p`. Whenever `|G| ≠ 0` in `k` (the non-modular case,
+supplied by `card_ne_zero_of_char_not_dvd` from `ringChar k ∤ |G|`) it is an
+additive projection of `MvPolynomial (Fin n) k` onto the invariant
+subalgebra that does not raise total degree. The remaining S7 leg is the
+extraction proper: applying `reynolds` to a monomial generating set of the
+degree-`≤ |G|` piece and showing the images generate the invariant ring. -/
+
+variable (G) in
+/-- The **Reynolds operator**: the average of the `G`-orbit of `p`. -/
+noncomputable def reynolds (p : MvPolynomial (Fin n) k) : MvPolynomial (Fin n) k :=
+  (Fintype.card G : k)⁻¹ • ∑ g : G, g • p
+
+/-- Non-modularity bridge: if `ringChar k ∤ |G|` then `|G| ≠ 0` in `k`. -/
+theorem card_ne_zero_of_char_not_dvd (h_char : ¬ ringChar k ∣ Fintype.card G) :
+    (Fintype.card G : k) ≠ 0 :=
+  fun h => h_char ((ringChar.spec (Fintype.card G)).mp h)
+
+omit [SMulCommClass G k (MvPolynomial (Fin n) k)] in
+/-- Orbit sums are invariant under right translation of the argument. -/
+theorem sum_smul_of_smul (g : G) (p : MvPolynomial (Fin n) k) :
+    ∑ h : G, h • (g • p) = ∑ h : G, h • p := by
+  simp_rw [smul_smul]
+  exact Fintype.sum_equiv (Equiv.mulRight g) _ (fun h => h • p) (fun h => rfl)
+
+/-- The Reynolds operator is constant on `G`-orbits. -/
+theorem reynolds_smul (g : G) (p : MvPolynomial (Fin n) k) :
+    reynolds G (g • p) = reynolds G p := by
+  unfold reynolds
+  rw [sum_smul_of_smul]
+
+/-- The Reynolds average is a fixed point of the action. -/
+theorem smul_reynolds (g : G) (p : MvPolynomial (Fin n) k) :
+    g • reynolds G p = reynolds G p := by
+  unfold reynolds
+  rw [smul_comm]
+  congr 1
+  rw [Finset.smul_sum]
+  simp_rw [smul_smul]
+  exact Fintype.sum_equiv (Equiv.mulLeft g) _ (fun h => h • p) (fun h => rfl)
+
+/-- The Reynolds average lies in the invariant subalgebra. -/
+theorem reynolds_mem_fixedPoints (p : MvPolynomial (Fin n) k) :
+    reynolds G p ∈ FixedPoints.subalgebra k (MvPolynomial (Fin n) k) G :=
+  fun g => smul_reynolds g p
+
+/-- On invariants the Reynolds operator is the identity (non-modular case) —
+the projection property. -/
+theorem reynolds_of_mem_fixedPoints (hG : (Fintype.card G : k) ≠ 0)
+    {p : MvPolynomial (Fin n) k}
+    (hp : p ∈ FixedPoints.subalgebra k (MvPolynomial (Fin n) k) G) :
+    reynolds G p = p := by
+  unfold reynolds
+  have hfix : ∀ g : G, g • p = p := hp
+  simp_rw [hfix]
+  rw [Finset.sum_const, Finset.card_univ, ← Nat.cast_smul_eq_nsmul k,
+    smul_smul, inv_mul_cancel₀ hG, one_smul]
+
+/-- The Reynolds operator is additive. -/
+theorem reynolds_add (p q : MvPolynomial (Fin n) k) :
+    reynolds G (p + q) = reynolds G p + reynolds G q := by
+  unfold reynolds
+  simp_rw [smul_add, Finset.sum_add_distrib]
+
+omit [SMulCommClass G k (MvPolynomial (Fin n) k)] in
+/-- The Reynolds operator does not raise total degree (under the graded
+hypothesis `h_graded` of the Stage-3 coefficient bound). -/
+theorem totalDegree_reynolds_le
+    (h_graded : ∀ (g : G) (p : MvPolynomial (Fin n) k),
+      (g • p).totalDegree ≤ p.totalDegree)
+    (p : MvPolynomial (Fin n) k) :
+    (reynolds G p).totalDegree ≤ p.totalDegree := by
+  refine le_trans (MvPolynomial.totalDegree_smul_le _ _) ?_
+  refine le_trans (MvPolynomial.totalDegree_finsetSum _ _) ?_
+  exact Finset.sup_le fun g _ => h_graded g p
+
+end Reynolds
+
 end Hilbert14OQ04

--- a/research/problems/hilbert-14-oq-04/knowledge.md
+++ b/research/problems/hilbert-14-oq-04/knowledge.md
@@ -228,3 +228,13 @@ S2 ACT target:
 
 S2 ACT will state the theorem and scaffold the Reynolds-operator definition,
 leaving the Noether-bound discharge for S3.
+
+
+## Session 2026-07-24 (researcher-3, S6): Reynolds toolkit
+
+`reynolds`, invariance, projection-on-invariants (non-modular), additivity,
+degree-nonincrease (h_graded). Gotchas: `ringChar.spec k n` (k explicit);
+orbit reindex = `smul_smul` then `Fintype.sum_equiv (Equiv.mulRight g) _ _
+(fun _ => rfl)`; `Finset.smul_sum` for g-distribution; membership in
+`FixedPoints.subalgebra` defeq `∀ g, g • x = x` (both directions used).
+S7 = extraction proper (hard leg).

--- a/research/problems/hilbert-14-oq-04/state.md
+++ b/research/problems/hilbert-14-oq-04/state.md
@@ -1,9 +1,35 @@
 # Current State
 
-**Phase**: ACT (S5 ACT shipped, researcher-3, 2026-07-24 — **degree-bound Stages 1–3 landed**;
-next = Stage 5 Reynolds extraction, a dedicated S6)
+**Phase**: ACT (S6 ACT shipped, researcher-3, 2026-07-24 — **Reynolds operator toolkit landed**;
+next = S7 extraction proper: reynolds-image of the degree-≤|G| piece generates)
 **Since**: 2026-07-24T12:10:00Z
-**Iteration**: 5
+**Iteration**: 6
+
+## S6 ACT 2026-07-24 (researcher-3) — Reynolds operator toolkit (0 ax / 0 sorry)
+
+New `section Reynolds` in `proofs/Proofs/Hilbert14OQ04.lean` (~210 → 290 LOC),
+host-verified `lean` v4.31.0 (0 errors, 0 warnings; `#print axioms` foundational
+only). The Stage-5 averaging engine, non-modular case:
+
+* `reynolds G p := (|G| : k)⁻¹ • ∑ g, g • p` (noncomputable def).
+* `card_ne_zero_of_char_not_dvd` — `ringChar k ∤ |G| → (|G| : k) ≠ 0`
+  (`ringChar.spec` — note `k` is EXPLICIT: `ringChar.spec k _`).
+* `sum_smul_of_smul` / `reynolds_smul` — orbit-constancy (right-translation
+  reindex via `Fintype.sum_equiv (Equiv.mulRight g)` after `smul_smul`).
+* `smul_reynolds` / `reynolds_mem_fixedPoints` — the average is invariant
+  (`smul_comm` + `Finset.smul_sum` + `Equiv.mulLeft` reindex; membership in
+  `FixedPoints.subalgebra` is definitionally `∀ g, g • x = x`).
+* `reynolds_of_mem_fixedPoints` — projection property on invariants
+  (`Finset.sum_const` + `Nat.cast_smul_eq_nsmul` + `inv_mul_cancel₀`).
+* `reynolds_add` — additivity.
+* `totalDegree_reynolds_le` — degree-nonincreasing under the Stage-3
+  `h_graded` hypothesis (`totalDegree_smul_le` + `totalDegree_finsetSum`).
+
+**Remaining (S7)**: the extraction proper — show every invariant is a
+`k`-combination of `reynolds` images of monomials of degree ≤ … via the
+charpoly integrality relations (Stages 1–3) + the projection property; i.e.
+assemble Noether's bound `generators ⊆ deg ≤ |G|`. This is the genuinely
+hard leg (~100+ LOC, graded decomposition of the invariant ring).
 
 ## S5 ACT 2026-07-24 (researcher-3) — degree-bound Stages 1–3 (0 ax / 0 sorry)
 


### PR DESCRIPTION
## Summary

S6 ACT for `hilbert-14-oq-04` (Noether degree bound track): lands the **Reynolds operator toolkit** — the averaging engine required by the Stage-5 extraction. `proofs/Proofs/Hilbert14OQ04.lean` grows ~210 → 290 lines, **0 sorries, 0 axioms**.

## What's proved (new `section Reynolds`)

- `reynolds G p := (|G| : k)⁻¹ • ∑ g, g • p` — the non-modular averaging map.
- `card_ne_zero_of_char_not_dvd` — `ringChar k ∤ |G| → (|G| : k) ≠ 0` (the non-modularity bridge).
- `reynolds_smul` — constancy on `G`-orbits (right-translation reindex).
- `smul_reynolds` / `reynolds_mem_fixedPoints` — the average is a fixed point, hence lands in the invariant subalgebra.
- `reynolds_of_mem_fixedPoints` — **projection property**: on invariants, `reynolds` is the identity (needs `(|G| : k) ≠ 0`).
- `reynolds_add` — additivity.
- `totalDegree_reynolds_le` — degree-nonincreasing under the Stage-3 graded hypothesis `h_graded`.

Together with the S5 charpoly coefficient API (Stages 1–3), this completes the toolkit for the S7 extraction leg: showing the invariant ring is generated in degree ≤ |G| (Noether 1916, non-modular case).

## Verification

- Host `lean` v4.31.0 full-file elaboration against the pinned Mathlib oleans: 0 errors, 0 warnings.
- `#print axioms` for `reynolds_of_mem_fixedPoints`, `smul_reynolds`, `totalDegree_reynolds_le` → `[propext, Classical.choice, Quot.sound]`.

Trackers: state.md S6 entry (iteration 6), knowledge.md session note.

Problem: hilbert-14-oq-04 (researcher-3 session 2026-07-24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
