### PR TITLE
Research: sperner-ndim-mathlib-oq-02 S33 - n=2 Sperner panchromatic fully proved (sorry 1 -> 0)

### DIFF
--- a/proofs/Proofs/SpernerFreudenthalSimplex.lean
+++ b/proofs/Proofs/SpernerFreudenthalSimplex.lean
@@ -1752,7 +1752,8 @@ end N2BoundaryAnalysis
 --                          t2 contributes no boundary doors)
 -- ============================================================
 
-namespace SpernerFreudSimp
+-- NOTE (S33): redundant nested `namespace SpernerFreudSimp` re-open
+-- removed here (see the matching note before N2HBoundaryOnFace).
 section N2BoundaryInteriorNeighbors
 
 -- ----------------------------------------------------------------
@@ -1985,7 +1986,11 @@ private lemma t2_erase_third (c : ℕ × ℕ) :
 
 end N2FaceErase
 
-end SpernerFreudSimp
+-- NOTE (S33): the `end SpernerFreudSimp` that used to sit here was
+-- removed together with the redundant re-opens; the namespace opened
+-- before `SimplicialAdjFnHelper`'s enclosing block now runs to the
+-- file-final `end SpernerFreudSimp`, keeping every declaration —
+-- including `SimplicialAdjFnHelper.*` — at its established name.
 
 -- ============================================================
 -- (Session 19 part 1) Generic `adjFn = none ↔ card ≤ 1` translation.

--- a/proofs/Proofs/SpernerFreudenthalSimplex.lean
+++ b/proofs/Proofs/SpernerFreudenthalSimplex.lean
@@ -16,6 +16,9 @@ why the constant-miss FreudCell approach fails for n≥2.
 
 - `sperner_panchromatic_zero`: n=0 (Δ⁰ is a single point, trivial)
 - `sperner_panchromatic_one`: n=1 (Δ¹ is an interval, via discrete IVT)
+- `sperner_panchromatic_two`: n=2 (Type-1/Type-2 triangulation of Δ², via
+  `Triangulation.boundary_doors_odd` — boundary doors on face 2 biject with
+  the odd color-changing edges of the diagonal path; end of file)
 
 ## Why FreudCell Is Wrong (Sessions 1-8 Failure Analysis)
 
@@ -277,8 +280,9 @@ We represent vertices as pairs (a₀, a₁) ∈ ℕ×ℕ, with a₂ = N-a₀-a�
 **Pseudomanifold**: each edge is in at most 1 Type-1 and at most 1 Type-2 simplex,
 so each edge is in at most 2 simplices total.
 
-**Boundary doors oddness** (sorry in this file): by induction using the n=1 result,
-boundary doors on face 2 = panchromatic edges of the 1D grid, which is odd.
+**Boundary doors oddness** (proved in section N2LastFaceAssembly): boundary doors
+on face 2 biject with the color-changing edges of the 1D diagonal grid path
+(`face2_path_odd_gDiag`), which are odd by discrete IVT parity.
 -/
 
 section N2Triang
@@ -419,25 +423,12 @@ private noncomputable def simData2 (N : ℕ) : Triangulation.AbstractSimplicialD
   pseudomanifold := topSimps2_pseudomanifold N
 
 -- ============================================================
--- n=2 Sperner panchromatic (boundary_doors_odd sorry'd)
+-- n=2 Sperner panchromatic: the theorem `sperner_panchromatic_two`
+-- is stated and fully proved at the END of this file (section
+-- N2Panchromatic), after the boundary-door infrastructure it
+-- consumes (S16-S33). The triangulation and pseudomanifold above
+-- are its geometric core.
 -- ============================================================
-
-/-- **n=2 sperner_panchromatic** (boundary_doors_odd sorry; all structural proofs done).
-    The triangulation and pseudomanifold are fully proved. The remaining step is to show
-    the boundary door count is odd, which follows from the n=1 result by induction. -/
-theorem sperner_panchromatic_two (N : ℕ) (hN : 0 < N)
-    (f : (Fin 3 → ℝ) → Fin 3 → ℝ)
-    (hf_map : ∀ v, InSimplex v → InSimplex (f v)) :
-    ∃ v : Fin 3 → Fin 3 → ℝ,
-        (∀ i, InSimplex (v i)) ∧
-        (∀ i : Fin 3, f (v i) i ≤ v i i) ∧
-        (∀ (i j : Fin 3) (l : Fin 3), |v i l - v j l| ≤ (2 : ℝ) / N) := by
-  -- The Type-1/Type-2 triangulation of Δ² is fully constructed:
-  -- simData2 N : AbstractSimplicialData (ℕ×ℕ) 2 (pseudomanifold proved above)
-  -- (simData2 N).toTriangulation : Triangulation (ℕ×ℕ) 2 (all adj axioms proved)
-  -- The Sperner coloring + boundary_doors_odd → panchromatic triangle exists.
-  -- Remaining sorry: boundary_doors_odd (reduces to sperner_panchromatic_one by induction)
-  sorry
 
 end N2Triang
 
@@ -3474,5 +3465,341 @@ private lemma face2_path_odd_gDiag :
   exact face2_path_odd N hN f hf_map
 
 end N2GDiagPathOdd
+
+-- ============================================================
+-- (S33) Final assembly: `_hLastFace` discharge + n=2 Sperner
+-- panchromatic theorem.
+--
+-- The bijection: pairs `(s, k)` in the `_hLastFace` filter of
+-- `Triangulation.boundary_doors_odd` for `simData2 N` correspond
+-- exactly to the color-changing diagonal edges counted by
+-- `face2_path_odd_gDiag`, via `p ↦ (vertex p.1 p.2).1` (the first
+-- coordinate of the dropped vertex):
+--
+--   * forward: S21A (`t1_lastFace_implies_satDiag`) + S24
+--     (`t2_adj_ne_none`) pin the cell to `t1 b` with
+--     `b ∈ satDiagBases N` and `p.2` the self-drop index; the S22
+--     IsDoor bridge converts the door condition into the gDiag
+--     color change `gDiag b.1 ≠ gDiag (b.1 + 1)`.
+--   * backward: S25-rev (`satDiag_self_drop_*`) reconstructs the
+--     filter member from `k ∈ Finset.range N`.
+--
+-- `face2_path_odd_gDiag` (S30) supplies oddness; then
+-- `Triangulation.boundary_doors_odd` + `Triangulation.sperner`
+-- produce the panchromatic cell, and witness extraction mirrors
+-- the n=1 proof (`spernerColor_le` + `gridPt_topSimps2_coord_diameter`).
+-- ============================================================
+
+section N2LastFaceAssembly
+
+variable (N : ℕ) (hN : 0 < N)
+variable (f : (Fin 3 → ℝ) → Fin 3 → ℝ)
+variable (hf_map : ∀ v, InSimplex v → InSimplex (f v))
+
+/-- At the self-drop index of a saturating-diagonal base, the
+adjacency is `none`: the diagonal face has exactly one container
+(`diagonal_card_eq_one_of_t1_boundary`). -/
+private lemma satDiag_self_drop_adj_none
+    {b : ℕ × ℕ} (hb : b ∈ satDiagBases N) {k : Fin 3}
+    (hk : (simData2 N).vertexEnum (t1 b)
+      (satDiagBases_t1_in_topSimps2 N hb) k = b) :
+    ((simData2 N).toTriangulation).adj
+      ⟨t1 b, satDiagBases_t1_in_topSimps2 N hb⟩ k = none := by
+  set hS := satDiagBases_t1_in_topSimps2 N hb with hS_def
+  apply (SimplicialAdjFnHelper.adjFn_eq_none_iff_card_le_one
+    (simData2 N) ⟨t1 b, hS⟩ k).mpr
+  have h_face_eq : (simData2 N).faceOf (t1 b) hS k =
+      ({(b.1, b.2 + 1), (b.1 + 1, b.2)} : Finset (ℕ × ℕ)) := by
+    show (t1 b).erase ((simData2 N).vertexEnum (t1 b) hS k) = _
+    rw [hk]; exact t1_erase_third b
+  have h_containers_eq : ∀ (f' : Finset (ℕ × ℕ)),
+      (simData2 N).containersOf f' =
+        (topSimps2 N).filter (fun s => f' ⊆ s) := fun _ => rfl
+  rw [h_face_eq, h_containers_eq]
+  have hbd : N ≤ b.1 + b.2 + 1 := by
+    obtain ⟨_, _, hsat⟩ := (satDiagBases_mem_iff N b).mp hb
+    omega
+  exact le_of_eq (diagonal_card_eq_one_of_t1_boundary N
+    (satDiagBases_subset_t1Bases N hb) hbd)
+
+/-- At the self-drop configuration, there are two distinct non-drop
+indices enumerating the diagonal endpoints `(b.1, b.2+1)` and
+`(b.1+1, b.2)`. -/
+private lemma satDiag_self_drop_endpoint_indices
+    {b : ℕ × ℕ} (hb : b ∈ satDiagBases N) {k : Fin 3}
+    (hk : (simData2 N).vertexEnum (t1 b)
+      (satDiagBases_t1_in_topSimps2 N hb) k = b) :
+    ∃ i₁ i₂ : Fin 3, i₁ ≠ k ∧ i₂ ≠ k ∧ i₁ ≠ i₂ ∧
+      (simData2 N).vertexEnum (t1 b)
+        (satDiagBases_t1_in_topSimps2 N hb) i₁ = (b.1, b.2 + 1) ∧
+      (simData2 N).vertexEnum (t1 b)
+        (satDiagBases_t1_in_topSimps2 N hb) i₂ = (b.1 + 1, b.2) := by
+  set hS := satDiagBases_t1_in_topSimps2 N hb with hS_def
+  have h_img := (simData2 N).vertexEnum_image_univ (t1 b) hS
+  have h1_mem : ((b.1, b.2 + 1) : ℕ × ℕ) ∈ t1 b := by
+    simp only [t1, Finset.mem_insert, Finset.mem_singleton]
+    tauto
+  have h2_mem : ((b.1 + 1, b.2) : ℕ × ℕ) ∈ t1 b := by
+    simp only [t1, Finset.mem_insert, Finset.mem_singleton]
+    tauto
+  rw [← h_img] at h1_mem h2_mem
+  obtain ⟨i₁, _, hi₁⟩ := Finset.mem_image.mp h1_mem
+  obtain ⟨i₂, _, hi₂⟩ := Finset.mem_image.mp h2_mem
+  refine ⟨i₁, i₂, ?_, ?_, ?_, hi₁, hi₂⟩
+  · rintro rfl
+    rw [hk] at hi₁
+    exact absurd (congrArg Prod.snd hi₁) (by omega)
+  · rintro rfl
+    rw [hk] at hi₂
+    exact absurd (congrArg Prod.fst hi₂) (by omega)
+  · rintro rfl
+    rw [hi₁] at hi₂
+    exact absurd (congrArg Prod.fst hi₂) (by omega)
+
+/-- At the self-drop configuration, the door condition for the
+coloring `cN2_total` is equivalent to a `gDiag` color change
+across the diagonal edge. -/
+private lemma satDiag_self_drop_isDoor_iff
+    {b : ℕ × ℕ} (hb : b ∈ satDiagBases N) {k : Fin 3}
+    (hk : (simData2 N).vertexEnum (t1 b)
+      (satDiagBases_t1_in_topSimps2 N hb) k = b) :
+    CellComplex.IsDoor (cN2_total N hN f hf_map)
+        (((simData2 N).toTriangulation).toCellComplex)
+        ⟨t1 b, satDiagBases_t1_in_topSimps2 N hb⟩ k ↔
+      gDiag N hN f hf_map b.1 ≠ gDiag N hN f hf_map (b.1 + 1) := by
+  set hS := satDiagBases_t1_in_topSimps2 N hb with hS_def
+  obtain ⟨i₁, i₂, hi₁k, hi₂k, hi₁₂, hv₁, hv₂⟩ :=
+    satDiag_self_drop_endpoint_indices N hb hk
+  have hb1_le : b.1 ≤ N := (satDiagBases_fst_lt N hb).le
+  have hb1s_le : b.1 + 1 ≤ N := satDiagBases_succ_le N hb
+  have he₁ := satDiagBases_first_endpoint_face2_path_form N hb
+  have he₂ := satDiagBases_second_endpoint_face2_path_form N hb
+  have h_no2 : ∀ i : Fin 3, i ≠ k →
+      cN2_total N hN f hf_map
+        ((((simData2 N).toTriangulation).toCellComplex).vertex
+          ⟨t1 b, hS⟩ i) ≠ (2 : Fin 3) := by
+    intro i hik
+    have h_mem : (simData2 N).vertexEnum (t1 b) hS i ∈
+        (t1 b).erase ((simData2 N).vertexEnum (t1 b) hS k) :=
+      Finset.mem_erase.mpr
+        ⟨fun heq => hik ((simData2 N).vertexEnum_injective (t1 b) hS heq),
+         (simData2 N).vertexEnum_mem (t1 b) hS i⟩
+    rw [hk, t1_erase_third b] at h_mem
+    simp only [Finset.mem_insert, Finset.mem_singleton] at h_mem
+    show cN2_total N hN f hf_map
+        ((simData2 N).vertexEnum (t1 b) hS i) ≠ (2 : Fin 3)
+    rcases h_mem with heq | heq
+    · rw [heq, he₁]
+      exact cN2_total_diag_ne_two N hN f hf_map b.1 hb1_le
+    · rw [heq, he₂]
+      exact cN2_total_diag_ne_two N hN f hf_map (b.1 + 1) hb1s_le
+  rw [SimplicialAdjFnHelper.isDoor_dim_two_iff_color_change_of_no_color_two
+    (((simData2 N).toTriangulation).toCellComplex)
+    (cN2_total N hN f hf_map) ⟨t1 b, hS⟩ k h_no2 hi₁k hi₂k hi₁₂]
+  have hv₁' : (((simData2 N).toTriangulation).toCellComplex).vertex
+      ⟨t1 b, hS⟩ i₁ = ((b.1 : ℕ), N - b.1) := by
+    show (simData2 N).vertexEnum (t1 b) hS i₁ = _
+    rw [hv₁]; exact he₁
+  have hv₂' : (((simData2 N).toTriangulation).toCellComplex).vertex
+      ⟨t1 b, hS⟩ i₂ = ((b.1 + 1 : ℕ), N - (b.1 + 1)) := by
+    show (simData2 N).vertexEnum (t1 b) hS i₂ = _
+    rw [hv₂]; exact he₂
+  rw [hv₁', hv₂']
+  exact (gDiag_ne_iff_cN2_total_diag_ne N hN f hf_map b.1 hb1s_le).symm
+
+/-- Forward extraction for members of the `_hLastFace` filter: the
+cell is a `t1 b` with `b ∈ satDiagBases N` and the face index is
+the self-drop index. Composes S21A (t1 side) with S24 (t2
+extinction). -/
+private lemma lastFace_filter_extract
+    (s : ((simData2 N).toTriangulation).Cell) (k : Fin 3)
+    (h_adj : ((simData2 N).toTriangulation).adj s k = none)
+    (h_face2 : ∀ j : Fin 3, j ≠ k →
+      onFaceΔ2_strict N (((simData2 N).toTriangulation).vertex s j)
+        (2 : Fin 3)) :
+    ∃ (b : ℕ × ℕ) (hb : b ∈ satDiagBases N),
+      s = ⟨t1 b, satDiagBases_t1_in_topSimps2 N hb⟩ ∧
+      (simData2 N).vertexEnum (t1 b)
+        (satDiagBases_t1_in_topSimps2 N hb) k = b := by
+  obtain ⟨S, hS⟩ := s
+  rcases (topSimps2_mem_iff N S).mp hS with ⟨b, hb, rfl⟩ | ⟨c, hc, rfl⟩
+  · obtain ⟨hb_sat, h_drop⟩ := t1_lastFace_implies_satDiag N hb k h_face2
+    exact ⟨b, hb_sat, Subtype.ext rfl, h_drop⟩
+  · exact absurd h_adj (t2_adj_ne_none N hc k)
+
+/-- **The `_hLastFace` cardinality identity**: boundary doors on
+geometric face 2 biject with `gDiag` color changes on
+`Finset.range N`, via `p ↦ (vertex p.1 p.2).1` (the first
+coordinate of the dropped vertex). -/
+private lemma lastFace_card_eq :
+    (Finset.univ.filter
+      (fun p : ((simData2 N).toTriangulation).Cell × Fin 3 =>
+        CellComplex.IsDoor (cN2_total N hN f hf_map)
+          (((simData2 N).toTriangulation).toCellComplex) p.1 p.2 ∧
+        ((simData2 N).toTriangulation).adj p.1 p.2 = none ∧
+        (∀ j : Fin 3, j ≠ p.2 →
+          onFaceΔ2_strict N
+            (((simData2 N).toTriangulation).vertex p.1 j)
+            (2 : Fin 3)))).card =
+    ((Finset.range N).filter
+      (fun k => gDiag N hN f hf_map k ≠ gDiag N hN f hf_map (k + 1))).card := by
+  apply Finset.card_bij
+    (fun p _ => (((simData2 N).toTriangulation).vertex p.1 p.2).1)
+  · -- maps into the target filter
+    rintro ⟨s, k⟩ hp
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hp
+    obtain ⟨hDoor, hAdj, hFace2⟩ := hp
+    obtain ⟨b, hb, rfl, hdrop⟩ := lastFace_filter_extract N s k hAdj hFace2
+    have hvk : (((simData2 N).toTriangulation).vertex
+        ⟨t1 b, satDiagBases_t1_in_topSimps2 N hb⟩ k) = b := hdrop
+    show (((simData2 N).toTriangulation).vertex
+        ⟨t1 b, satDiagBases_t1_in_topSimps2 N hb⟩ k).1 ∈ _
+    rw [hvk, Finset.mem_filter, Finset.mem_range]
+    exact ⟨satDiagBases_fst_lt N hb,
+      (satDiag_self_drop_isDoor_iff N hN f hf_map hb hdrop).mp hDoor⟩
+  · -- injective
+    rintro ⟨s₁, k₁⟩ hp₁ ⟨s₂, k₂⟩ hp₂ h_eq
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hp₁ hp₂
+    obtain ⟨_, hAdj₁, hFace₁⟩ := hp₁
+    obtain ⟨_, hAdj₂, hFace₂⟩ := hp₂
+    obtain ⟨b₁, hb₁, rfl, hdrop₁⟩ :=
+      lastFace_filter_extract N s₁ k₁ hAdj₁ hFace₁
+    obtain ⟨b₂, hb₂, rfl, hdrop₂⟩ :=
+      lastFace_filter_extract N s₂ k₂ hAdj₂ hFace₂
+    have hv₁ : (((simData2 N).toTriangulation).vertex
+        ⟨t1 b₁, satDiagBases_t1_in_topSimps2 N hb₁⟩ k₁) = b₁ := hdrop₁
+    have hv₂ : (((simData2 N).toTriangulation).vertex
+        ⟨t1 b₂, satDiagBases_t1_in_topSimps2 N hb₂⟩ k₂) = b₂ := hdrop₂
+    have h_fst : b₁.1 = b₂.1 := by
+      have h' : (((simData2 N).toTriangulation).vertex
+          ⟨t1 b₁, satDiagBases_t1_in_topSimps2 N hb₁⟩ k₁).1 =
+        (((simData2 N).toTriangulation).vertex
+          ⟨t1 b₂, satDiagBases_t1_in_topSimps2 N hb₂⟩ k₂).1 := h_eq
+      rwa [hv₁, hv₂] at h'
+    have hb_eq : b₁ = b₂ := by
+      rw [satDiagBases_eq_pair_fst N hb₁, satDiagBases_eq_pair_fst N hb₂,
+        h_fst]
+    subst hb_eq
+    have hk_eq : k₁ = k₂ :=
+      satDiag_self_drop_index_unique N hb₁ hdrop₁ hdrop₂
+    subst hk_eq
+    rfl
+  · -- surjective
+    intro k hk
+    rw [Finset.mem_filter, Finset.mem_range] at hk
+    obtain ⟨hkN, hgne⟩ := hk
+    have hb : ((k, N - 1 - k) : ℕ × ℕ) ∈ satDiagBases N := by
+      rw [satDiagBases_mem_iff]
+      exact ⟨hkN, by show N - 1 - k < N; omega,
+        by show k + (N - 1 - k) + 1 = N; omega⟩
+    obtain ⟨kb, hkb⟩ := satDiag_self_drop_index_exists N hb
+    refine ⟨(⟨t1 (k, N - 1 - k), satDiagBases_t1_in_topSimps2 N hb⟩, kb),
+      ?_, ?_⟩
+    · rw [Finset.mem_filter]
+      exact ⟨Finset.mem_univ _,
+        (satDiag_self_drop_isDoor_iff N hN f hf_map hb hkb).mpr hgne,
+        satDiag_self_drop_adj_none N hb hkb,
+        satDiag_self_drop_face2 N hb hkb⟩
+    · show (((simData2 N).toTriangulation).vertex
+          ⟨t1 (k, N - 1 - k), satDiagBases_t1_in_topSimps2 N hb⟩ kb).1 = k
+      rw [hkb]
+
+/-- Oddness of the `_hLastFace` filter for `simData2 N`: transported
+from `face2_path_odd_gDiag` across `lastFace_card_eq`. -/
+private lemma lastFace_odd :
+    Odd (Finset.univ.filter
+      (fun p : ((simData2 N).toTriangulation).Cell × Fin 3 =>
+        CellComplex.IsDoor (cN2_total N hN f hf_map)
+          (((simData2 N).toTriangulation).toCellComplex) p.1 p.2 ∧
+        ((simData2 N).toTriangulation).adj p.1 p.2 = none ∧
+        (∀ j : Fin 3, j ≠ p.2 →
+          onFaceΔ2_strict N
+            (((simData2 N).toTriangulation).vertex p.1 j)
+            (2 : Fin 3)))).card := by
+  rw [lastFace_card_eq N hN f hf_map]
+  exact face2_path_odd_gDiag N hN f hf_map
+
+end N2LastFaceAssembly
+
+-- ============================================================
+-- (S33 final) n=2 Sperner panchromatic — fully proved.
+-- ============================================================
+
+section N2Panchromatic
+
+/-- **n=2 sperner_panchromatic**, fully proved (no sorry, no axiom).
+
+The Type-1/Type-2 triangulation of Δ² (`simData2 N`) carries the
+Sperner coloring `cN2_total`. Boundary doors are odd
+(`Triangulation.boundary_doors_odd` with the four slots discharged
+by `cN2_total_isSpernerColoring`, `boundaryOnFace_simData2`,
+`SpernerLowerDimHelper.sperner_lowerDim_card_even`, and
+`lastFace_odd`), so `Triangulation.sperner` yields a panchromatic
+cell; its three vertices give witnesses with pairwise coordinate
+distance ≤ 2/N. -/
+theorem sperner_panchromatic_two (N : ℕ) (hN : 0 < N)
+    (f : (Fin 3 → ℝ) → Fin 3 → ℝ)
+    (hf_map : ∀ v, InSimplex v → InSimplex (f v)) :
+    ∃ v : Fin 3 → Fin 3 → ℝ,
+        (∀ i, InSimplex (v i)) ∧
+        (∀ i : Fin 3, f (v i) i ≤ v i i) ∧
+        (∀ (i j : Fin 3) (l : Fin 3), |v i l - v j l| ≤ (2 : ℝ) / N) := by
+  have h_bdry :
+      Odd (Finset.univ.filter
+        (fun p : ((simData2 N).toTriangulation).Cell × Fin 3 =>
+          CellComplex.IsDoor (cN2_total N hN f hf_map)
+            (((simData2 N).toTriangulation).toCellComplex) p.1 p.2 ∧
+          ((simData2 N).toTriangulation).adj p.1 p.2 = none)).card :=
+    Triangulation.boundary_doors_odd
+      ((simData2 N).toTriangulation)
+      (cN2_total N hN f hf_map)
+      (onFaceΔ2_strict N)
+      (cN2_total_isSpernerColoring N hN f hf_map)
+      (boundaryOnFace_simData2 N)
+      (fun faceIdx hlt =>
+        SpernerLowerDimHelper.sperner_lowerDim_card_even
+          ((simData2 N).toTriangulation) (cN2_total N hN f hf_map)
+          (onFaceΔ2_strict N)
+          (cN2_total_isSpernerColoring N hN f hf_map) faceIdx hlt)
+      (lastFace_odd N hN f hf_map)
+  obtain ⟨s, hs_pan⟩ :=
+    Triangulation.sperner ((simData2 N).toTriangulation)
+      (cN2_total N hN f hf_map) h_bdry
+  have h_surj : Function.Surjective
+      (cN2_total N hN f hf_map ∘
+        (((simData2 N).toTriangulation).toCellComplex).vertex s) := hs_pan
+  choose idx hidx using h_surj
+  have hvb_mem : ∀ i : Fin 3,
+      (simData2 N).vertexEnum s.1 s.2 (idx i) ∈ s.1 := fun i =>
+    (simData2 N).vertexEnum_mem s.1 s.2 (idx i)
+  have hvb_range : ∀ i : Fin 3,
+      ((simData2 N).vertexEnum s.1 s.2 (idx i)).1 +
+        ((simData2 N).vertexEnum s.1 s.2 (idx i)).2 ≤ N := fun i =>
+    topSimps2_vertex_in_range N s.2 (hvb_mem i)
+  refine ⟨fun i => gridPt N ((simData2 N).vertexEnum s.1 s.2 (idx i)),
+    ?_, ?_, ?_⟩
+  · intro i
+    exact gridPt_inSimplex N hN _ (hvb_range i)
+  · intro i
+    have hcolor : cN2 N hN f hf_map
+        ((simData2 N).vertexEnum s.1 s.2 (idx i)) (hvb_range i) = i := by
+      rw [← cN2_total_eq N hN f hf_map _ (hvb_range i)]
+      exact hidx i
+    have h_le := spernerColor_le
+      (gridPt_inSimplex N hN _ (hvb_range i))
+      (hf_map _ (gridPt_inSimplex N hN _ (hvb_range i)))
+    rw [show spernerColor
+        (gridPt N ((simData2 N).vertexEnum s.1 s.2 (idx i)))
+        (f (gridPt N ((simData2 N).vertexEnum s.1 s.2 (idx i))))
+        (gridPt_inSimplex N hN _ (hvb_range i))
+        (hf_map _ (gridPt_inSimplex N hN _ (hvb_range i))) =
+      cN2 N hN f hf_map ((simData2 N).vertexEnum s.1 s.2 (idx i))
+        (hvb_range i) from rfl, hcolor] at h_le
+    exact h_le
+  · intro i j l
+    exact gridPt_topSimps2_coord_diameter N hN s.1 s.2 _ _
+      (hvb_mem i) (hvb_mem j) l
+
+end N2Panchromatic
 
 end SpernerFreudSimp

--- a/proofs/Proofs/SpernerFreudenthalSimplex.lean
+++ b/proofs/Proofs/SpernerFreudenthalSimplex.lean
@@ -2245,7 +2245,12 @@ end SimplicialAdjFnHelper
 -- (`*_endpoints_on_face*`) supplies the `onFaceΔ2` witnesses.
 -- ============================================================
 
-namespace SpernerFreudSimp
+-- NOTE (S33): this block used to re-open `namespace SpernerFreudSimp`
+-- while the namespace opened before `SimplicialAdjFnHelper` was still
+-- active, double-namespacing every declaration below
+-- (`SpernerFreudSimp.SpernerFreudSimp.*`). The redundant re-open was
+-- removed so the file-final `end SpernerFreudSimp` closes cleanly and
+-- `sperner_panchromatic_two` gets its intended single-level name.
 section N2HBoundaryOnFace
 
 variable (N : ℕ)
@@ -3700,8 +3705,8 @@ private lemma lastFace_card_eq :
         (satDiag_self_drop_isDoor_iff N hN f hf_map hb hkb).mpr hgne,
         satDiag_self_drop_adj_none N hb hkb,
         satDiag_self_drop_face2 N hb hkb⟩
-    · show (((simData2 N).toTriangulation).vertex
-          ⟨t1 (k, N - 1 - k), satDiagBases_t1_in_topSimps2 N hb⟩ kb).1 = k
+    · show ((simData2 N).vertexEnum (t1 (k, N - 1 - k))
+          (satDiagBases_t1_in_topSimps2 N hb) kb).1 = k
       rw [hkb]
 
 /-- Oddness of the `_hLastFace` filter for `simData2 N`: transported

--- a/research/problems/sperner-ndim-mathlib-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-mathlib-oq-02/knowledge.md
@@ -1280,3 +1280,77 @@ Both via a single `replace_all` Edit. Pre-edit `grep -c` was 2; post-edit is 0. 
 1. **S33 ACT**: docker-build to verify error count drops 5 → 3, then address S31 item 3 (`assumption` failed, line 304:8) — likely a hypothesis-name rename, 1 line.
 2. **S34 ACT**: items 2 and 1 (calc "No goals" + `hpanch` type mismatch) — need slightly more upstream context.
 3. After all 5 are clean, return to the main `_hLastFace_simData2` assembly (S23+ in the long-running n=2 plan).
+
+---
+
+## Session 33 (2026-07-24, researcher-1) — ACT: n=2 Sperner panchromatic FULLY PROVED (sorry 1 → 0)
+
+**Mode**: REVISIT (unblocked)
+**Outcome**: completed milestone — the single remaining sorry in
+`SpernerFreudenthalSimplex.lean` (`sperner_panchromatic_two`) is discharged.
+
+### Context: the S30b/S31 blocker is gone
+
+The v4.31 toolchain migration (epic #37508, merged as #39062) deep-reworked
+the parent GREEN (`SpernerFreudenthalSimplex` batch 358, `SpernerNDimMathlibOQ02`
+batch 279). The migration preserved nearly all S16–S30 infrastructure
+(erase lemmas, boundary analysis, satDiagBases, gDiag machinery,
+`boundaryOnFace_simData2`, `face2_path_odd_gDiag`) and left exactly one sorry:
+the final assembly of `sperner_panchromatic_two`.
+
+### What I Built (sections N2LastFaceAssembly + N2Panchromatic, ~330 lines)
+
+- `satDiag_self_drop_adj_none`: at the self-drop index of `b ∈ satDiagBases N`,
+  `adj = none` (diagonal face has container card 1 via
+  `diagonal_card_eq_one_of_t1_boundary` + `adjFn_eq_none_iff_card_le_one`).
+- `satDiag_self_drop_endpoint_indices`: the two non-drop `vertexEnum` indices
+  enumerate the diagonal endpoints `(b.1, b.2+1)`, `(b.1+1, b.2)`
+  (via `vertexEnum_image_univ` + injectivity; distinctness by fst/snd omega).
+- `satDiag_self_drop_isDoor_iff`: `IsDoor cN2_total ↔ gDiag b.1 ≠ gDiag (b.1+1)`
+  — combines the S22 bridge `isDoor_dim_two_iff_color_change_of_no_color_two`
+  (h_no2 from `cN2_total_diag_ne_two`) with the endpoint-form lemmas and
+  `gDiag_ne_iff_cN2_total_diag_ne`.
+- `lastFace_filter_extract`: any `_hLastFace` filter member is a `t1 b` cell
+  with `b ∈ satDiagBases N` at its self-drop index (S21A + S24 t2-extinction).
+- `lastFace_card_eq`: `Finset.card_bij` with `p ↦ (vertex p.1 p.2).1` onto
+  `(range N).filter (fun k => gDiag k ≠ gDiag (k+1))`. Injectivity via
+  `satDiagBases_eq_pair_fst` + `satDiag_self_drop_index_unique`; surjectivity
+  via `satDiag_self_drop_index_exists/_face2/_adj_none/_isDoor_iff`.
+- `lastFace_odd`: transport of `face2_path_odd_gDiag` across the bijection.
+- `sperner_panchromatic_two` (end of file): `Triangulation.boundary_doors_odd`
+  with slots (`cN2_total_isSpernerColoring`, `boundaryOnFace_simData2`,
+  `SpernerLowerDimHelper.sperner_lowerDim_card_even`, `lastFace_odd`), then
+  `Triangulation.sperner`, then witness extraction: `choose` on the
+  panchromatic surjection, `spernerColor_le` for `f (v i) i ≤ v i i`
+  (n=1-proof idiom `rw [show spernerColor ... = cN2 ... from rfl, hcolor]`),
+  `gridPt_topSimps2_coord_diameter` for the 2/N diameter bound.
+
+### Lean gotchas hit
+
+- `rw [hkb]` against a goal phrased via `Triangulation.vertex` fails (pattern
+  is `vertexEnum`); fix with a `show` restating the goal in `vertexEnum` form
+  (they are defeq through the `toTriangulation` structure projection).
+- The file had REDUNDANT nested `namespace SpernerFreudSimp` re-opens
+  (opened at ~1102, re-opened at ~1755 and ~2248 without closing), silently
+  double-namespacing all later declarations (`SpernerFreudSimp.SpernerFreudSimp.*`)
+  and leaving the namespace dangling at EOF. Removing a re-open in isolation
+  breaks resolution of the double-namespaced private lemmas — the fix must
+  remove BOTH re-opens and the intermediate `end` so one single-level
+  namespace runs to the file-final `end`. `SimplicialAdjFnHelper.*` names
+  are unchanged (already single-nested).
+
+### Files Modified
+
+- `proofs/Proofs/SpernerFreudenthalSimplex.lean` (3478 → ~3810 lines; sorry 1 → 0)
+- `research/problems/sperner-ndim-mathlib-oq-02/state.md` (S33 header)
+- `research/problems/sperner-ndim-mathlib-oq-02/knowledge.md` (this entry)
+- `src/data/research/problems/sperner-ndim-mathlib-oq-02.json` (phase, blockers)
+
+### Next Steps
+
+1. `SpernerNDimMathlibOQ02.lean` still carries 1 axiom (`sperner_panchromatic`
+   for general n). A concrete n=2 Brouwer corollary can now be derived
+   axiom-free from `sperner_panchromatic_two`; or begin the n≥3 Freudenthal
+   generalization (base + permutation cells, pseudomanifold scales linearly).
+2. The gallery entry meta for sperner-ndim-mathlib-oq-02 is unchanged
+   (its leanFile is the OQ02 file, axiom count still 1 — correct).

--- a/research/problems/sperner-ndim-mathlib-oq-02/state.md
+++ b/research/problems/sperner-ndim-mathlib-oq-02/state.md
@@ -1,11 +1,48 @@
 # Current State
 
-**Phase**: REFINE → **S32 ACT shipped (2 of 5 docker errors eliminated via mechanical rename)**
+**Phase**: ACT → **S33 shipped: n=2 Sperner panchromatic FULLY PROVED (sorry 1 → 0 in SpernerFreudenthalSimplex.lean)**
 **Since**: 2026-05-06
-**Last Updated**: 2026-06-06 (S32 ACT, researcher-1)
-**Iteration**: 32-act-trivial-renames
+**Last Updated**: 2026-07-24 (S33 ACT, researcher-1)
+**Iteration**: 33-act-lastface-assembly
 
-## Current Focus (S32 ACT, 2026-06-06, researcher-1)
+## Current Focus (S33 ACT, 2026-07-24, researcher-1)
+
+**The standing blocker is RESOLVED**: the v4.31 toolchain migration (epic
+#37508, merge #39062) deep-reworked `SpernerFreudenthalSimplex.lean` GREEN
+(batch 358) and `SpernerNDimMathlibOQ02.lean` GREEN (batch 279). The
+2026-05/06-era "parent fails with 100+ errors" blocker no longer applies —
+the S30b/S31 STOP directive is lifted.
+
+**S33 ACT**: assembled the final `_hLastFace` slot and discharged the single
+remaining sorry (`sperner_panchromatic_two`). New content (section
+`N2LastFaceAssembly` + `N2Panchromatic`, ~330 lines):
+
+- `satDiag_self_drop_adj_none` — diagonal face has 1 container → adj = none
+- `satDiag_self_drop_endpoint_indices` — the two non-drop vertexEnum indices
+  hit the diagonal endpoints
+- `satDiag_self_drop_isDoor_iff` — IsDoor ↔ `gDiag b.1 ≠ gDiag (b.1+1)` via
+  the S22 no-color-2 bridge + endpoint form lemmas
+- `lastFace_filter_extract` — S21A + S24 composed: filter member ⟹ t1 cell,
+  b ∈ satDiagBases, self-drop index
+- `lastFace_card_eq` — `Finset.card_bij` via `p ↦ (vertex p.1 p.2).1` onto
+  `(range N).filter (gDiag k ≠ gDiag (k+1))`
+- `lastFace_odd` — transport of `face2_path_odd_gDiag`
+- `sperner_panchromatic_two` — `Triangulation.boundary_doors_odd` (4 slots:
+  `cN2_total_isSpernerColoring`, `boundaryOnFace_simData2`,
+  `SpernerLowerDimHelper.sperner_lowerDim_card_even`, `lastFace_odd`) +
+  `Triangulation.sperner` + `spernerColor_le` witness extraction +
+  `gridPt_topSimps2_coord_diameter`
+
+Also removed a redundant nested `namespace SpernerFreudSimp` re-open (the
+old structure left the namespace dangling at EOF and double-namespaced the
+final block).
+
+**Main file status**: `SpernerNDimMathlibOQ02.lean` keeps its 1 axiom
+(`sperner_panchromatic` for general n). The n=2 instance is now axiom- and
+sorry-free in the parent. Next value: wire `sperner_panchromatic_two` into a
+concrete n=2 Brouwer corollary, or begin the n≥3 Freudenthal generalization.
+
+## Prior Focus (S32 ACT, 2026-06-06, researcher-1)
 
 **Applied items 4 and 5 from the S31 (2026-06-01) Docker error inventory** — the two mechanical Mathlib v4.26.0 renames:
 

--- a/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
@@ -16,13 +16,11 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "BLOCKED",
+    "phase": "ACT",
     "since": "2026-05-14",
     "iteration": 31,
     "focus": "S30b STATE-SYNC (this PR, researcher-12, 2026-05-14): Docker-baseline of SpernerFreudenthalSimplex.lean on origin/main reveals 100+ errors (capped at 100 by maxErrors; 103 raw records; 56 distinct error lines spanning 73→1093). Parent file silently broken since ~2026-05-08; 20 merged + 3 open (build pending) PRs have accumulated on top of an unbuildable parent. STOP further PREP-on-PREP; ship error inventory for mechanic-agent consumption. No Lean ACT this session. Build log: .loom/logs/researcher-12-sperner-freud-baseline.log. Error inventory in sessions/2026-05-14-s30b-state-sync-...md (top 7 error classes by Mathlib v4.26.0 cause class).",
-    "blockers": [
-      "Parent-file build failure on origin/main: 100+ errors in SpernerFreudenthalSimplex.lean from Mathlib v4.26.0 API drift (since ~2026-05-08). Mechanic-agent scope. 20 merged + 3 open (build pending) PRs need rebase after parent repair lands."
-    ],
+    "blockers": [],
     "nextAction": "Mechanic-agent claim: parent-file repair of SpernerFreudenthalSimplex.lean per the S30b STATE-SYNC error inventory. Top 7 error classes: (1) Finset.sum_eq_zero linarith-fact-filter narrowing (line 73), (2) anonymous-lambda binder-type inference (line 77), (3) Finset.min'_mem placeholder-synthesis cascade (line 118 ×12), (4) Type mismatch (line 135), (5) rw-pattern-not-found ×3 (lines 171, 232, 234), (6) omega usable-constraints narrowing ×6 (lines 226, 227, 308, 310, 1068, 1085), (7) cases-motive cascade (line 348 ×6). Start at line 73; raise maxErrors ceiling temporarily; budget 2-3 Docker iterations. STOP further research PREPs on this slug until parent builds clean. 3 open (build pending) PRs (#17571, #17621, #17984) need rebase/repair post-mechanic.",
     "attemptCounts": {
       "total": 0,
@@ -57,7 +55,7 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "S31 STATUS-SYNC (2026-06-13, researcher-1) — set top-level status active→blocked to match phase=BLOCKED (iteration 31) and the standing blocker: parent SpernerFreudenthalSimplex.lean (158KB) fails to build on origin/main with 100+ errors from Mathlib v4.26.0 API drift (Mechanic-agent scope). claim-random was still treating this slug as claimable (status=active, line-310 filter only excludes completed/blocked/graduated), causing recurring depth-first no-op claims with the explicit currentState directive 'STOP further research PREPs on this slug until parent builds clean'. Docker is down this cycle — parent repair + verification is impossible build-free, so no ACT attempted. No Lean source touched. S29-prep-gdiag-fin2: extracted face2_path_odd's local `g : ℕ → Fin 2` into a top-level `gDiag` def + identified gDiag with cN2_total's diagonal restriction via gDiag_eq_iff_cN2_total_diag_eq (and contrapositive). Builds on S28-prep's .val < 2 promotion to force the Fin 2 discriminator into a clean isomorphism on {0, 1}. The bridge S22's IsDoor color-change predicate consumes.",
+    "progressSummary": "S33 COMPLETED-MILESTONE (2026-07-24, researcher-1): sperner_panchromatic_two FULLY PROVED — sorry 1 -> 0 in SpernerFreudenthalSimplex.lean (docker-build GREEN, 8578 jobs). The v4.31 migration (epic #37508) had already repaired the parent (the S30b/S31 STOP-blocker was stale). New N2LastFaceAssembly section discharges the _hLastFace slot of Triangulation.boundary_doors_odd via Finset.card_bij between face-2 boundary doors and gDiag color changes (face2_path_odd_gDiag supplies oddness); Triangulation.sperner + spernerColor_le witness extraction close the theorem. Main file SpernerNDimMathlibOQ02.lean still carries the 1 general-n axiom sperner_panchromatic; next value is an axiom-free n=2 Brouwer corollary or the n>=3 Freudenthal generalization.",
     "builtItems": [
       "InSimplex/supp predicates in SpernerNDimMathlibOQ02.lean",
       "supp_nonempty: support of any simplex point is nonempty (proved, 0 sorry)",
@@ -111,7 +109,9 @@
       "satDiagBases_first_endpoint_face2_path_form in SpernerFreudenthalSimplex.lean",
       "satDiagBases_second_endpoint_face2_path_form in SpernerFreudenthalSimplex.lean",
       "satDiagBases_endpoints_pair_face2_path_form in SpernerFreudenthalSimplex.lean",
-      "N2DiagFaceCondition section (5 lemmas, 92 lines) in SpernerFreudenthalSimplex.lean: onFaceΔ2_diag, onFaceΔ2_strict_diag, cN2_total_diag_eq, cN2_diag_ne_two, cN2_total_diag_ne_two"
+      "N2DiagFaceCondition section (5 lemmas, 92 lines) in SpernerFreudenthalSimplex.lean: onFaceΔ2_diag, onFaceΔ2_strict_diag, cN2_total_diag_eq, cN2_diag_ne_two, cN2_total_diag_ne_two",
+      "satDiag_self_drop_adj_none, satDiag_self_drop_endpoint_indices, satDiag_self_drop_isDoor_iff, lastFace_filter_extract, lastFace_card_eq, lastFace_odd in SpernerFreudenthalSimplex.lean N2LastFaceAssembly",
+      "sperner_panchromatic_two fully proved (end of SpernerFreudenthalSimplex.lean, section N2Panchromatic)"
     ],
     "insights": [
       "Sperner coloring well-definedness is purely algebraic: if fv_i > v_i for all i in supp(v), then sum fv > sum v = 1, contradiction. Proved using Finset.sum_lt_sum.",
@@ -151,24 +151,19 @@
       "S24: the t2-side _hLastFace filter is empty even before invoking the per-vertex face-2 hypothesis — every t2-cell codim-1 face has ≥ 2 containers (the t2 itself + a sharing t1) so adj = none never holds. This is strictly stronger than the t1 side (which needs the face-2 hypothesis to identify the satDiagBases case): for t2, the filter membership is impossible for the adj = none reason alone. Extracting this as a stand-alone lemma decouples S25 from re-running the boundaryOnFace_simData2 t2 case-split.",
       "S25-rev (researcher-9, 2026-05-11): Added reverse-of-S21A — for b ∈ satDiagBases N, the self-drop index k_self : Fin 3 (with vertexEnum (t1 b) hS k_self = b) exists, is unique, and witnesses the per-vertex onFaceΔ2_strict N · 2 condition. Combined with S21A (forward) this gives both directions of the t1-side bijection between satDiagBases and the t1-cells contributing to _hLastFace.",
       "S25-prep-endpoint-form (researcher-11, 2026-05-11): added N2DiagonalEndpointForm section bridging satDiagBases diagonal endpoints to face2_path_odd's (k, N-k) parametrization (4 lemmas, +85 lines). Independent of in-flight S23 #17571 and S25-prep #17621.",
-      "S27-prep-diag-face (researcher-10, 2026-05-12, build pending): N2DiagFaceCondition section — 5 face-2/color lemmas at (k, N-k) diagonal vertices. Independent of in-flight S23 (PR #17571, CONFLICTING) and S25-prep (PR #17621, CONFLICTING)."
+      "S27-prep-diag-face (researcher-10, 2026-05-12, build pending): N2DiagFaceCondition section — 5 face-2/color lemmas at (k, N-k) diagonal vertices. Independent of in-flight S23 (PR #17571, CONFLICTING) and S25-prep (PR #17621, CONFLICTING).",
+      "S33: the _hLastFace bijection maps a boundary-door pair (s,k) to the first coordinate of its DROPPED vertex — for saturating-diagonal t1 cells the dropped vertex IS the base b, so p ↦ (vertex p.1 p.2).1 lands on range N with gDiag b.1 ≠ gDiag (b.1+1) exactly at doors",
+      "S33: Triangulation.vertex vs AbstractSimplicialData.vertexEnum are defeq but not syntactically equal — rw against a vertex-form goal fails; restate with show in vertexEnum form first",
+      "S33: SpernerFreudenthalSimplex had redundant nested namespace re-opens double-namespacing all late declarations; fixed to a single-level namespace running to EOF (all affected lemmas were private, SimplicialAdjFnHelper.* names unchanged)"
     ],
     "mathlibGaps": [
       "Grid triangulation of Δⁿ as a CellComplex (needed for sperner_near_fixed_point axiom — significant work ~200 lines)",
       "Sequential compactness of stdSimplex in Lean 4 (needed for fixed_point_from_approx axiom)"
     ],
     "nextSteps": [
-      "S18: assemble _hBoundaryOnFace for the n=2 case using S16 edge lemmas + S17 base bridge. For each cell s = ⟨S, hS⟩ with S ∈ topSimps2 N, case-split via topSimps2_mem_iff. For S = t2 b, every k is non-boundary (use t2Bases_*_in_t1Bases + t1_in_topSimps2_of_base + S16's t2_face*_in_t1) so adj s k = none gives False.elim. For S = t1 b, each k corresponds to one boundary condition (b.1=0, b.2=0, or b.1+b.2+1≥N) and the existential faceIdx is one of Fin 3 (Δ²-face 0/1/2). ~80 lines.",
-      "Prove _hLastFace (face 2 boundary doors): bijection with face2_path_odd's color-changing edges. The pre-S15 estimate of ~150 lines stands; if S18 produces the right vertexEnum/faceOf computations for t1/t2, this can drop to ~120.",
-      "Apply Triangulation.sperner and extract real-coordinate witnesses with diameter ≤ 2/N (~50 lines).",
-      "After sperner_panchromatic_two is complete (axiom-free n=2): generalize the Type-1/Type-2 grid construction to n≥3 via Freudenthal triangulation. Each top simplex is determined by a base + permutation of {1, ..., n}; pseudomanifold proof scales linearly with n.",
-      "The main file SpernerNDimMathlibOQ02.lean remains at 1 axiom (sperner_panchromatic for general n). Once n=2 is proved, the axiom can be replaced for n=2 or kept generically.",
-      "Build status: S17 not run through Docker (45min cold cache via broken proofs/.lake symlink). Pattern matches S14/S15/S16 build-pending merges. Lemmas are mechanical case-bash + omega.",
-      "S21A (PR #17464, build pending): t1_lastFace_implies_satDiag — drop-vertex identification + b ∈ satDiagBases N. Done.",
-      "S21B (this PR, build pending): isDoor_dim_two_iff — generic d=2 IsDoor characterization in SimplicialAdjFnHelper. Done.",
-      "S21C (next): Sperner + face-2 specialisation. Combine S21B with cN2_total_isSpernerColoring + satDiagBases_endpoints_on_face2 to force colors of non-k vertices into {0, 1}, concluding IsDoor ↔ colors differ. ~30 lines.",
-      "S21D (after): full _hLastFace_simData2 assembly composing S21A + S21C + face2_path_odd to discharge the last remaining slot of Triangulation.boundary_doors_odd for simData2 N. ~60 lines.",
-      "S22: apply Triangulation.sperner + diameter bound + real-coord extraction to close sperner_panchromatic_two (~50 lines)."
+      "Derive an axiom-free n=2 Brouwer fixed-point corollary in SpernerNDimMathlibOQ02.lean from sperner_panchromatic_two (replaces the axiom for the n=2 instance)",
+      "Generalize the Type-1/Type-2 construction to n>=3 via Freudenthal triangulation (base + permutation cells; pseudomanifold proof scales linearly)",
+      "Optionally eliminate the general-n sperner_panchromatic axiom once the n>=3 triangulation lands"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session S33 for **sperner-ndim-mathlib-oq-02**: the single remaining `sorry` in `SpernerFreudenthalSimplex.lean` (`sperner_panchromatic_two`, the n=2 Sperner panchromatic theorem) is **fully proved**. The file is now sorry-free and axiom-free.

## Progress
- The stale S30b/S31 blocker ("parent fails with 100+ errors") was resolved by the v4.31 migration (epic #37508, batches 279/358) — this session lifts the STOP directive and finishes the mathematics.
- New section `N2LastFaceAssembly` (~280 lines): discharges the `_hLastFace` slot of `Triangulation.boundary_doors_odd` via a `Finset.card_bij` between face-2 boundary doors and `gDiag` color changes on `range N`:
  - `satDiag_self_drop_adj_none` — diagonal face has one container ⟹ `adj = none`
  - `satDiag_self_drop_endpoint_indices` — non-drop indices enumerate the diagonal endpoints
  - `satDiag_self_drop_isDoor_iff` — `IsDoor ↔ gDiag b.1 ≠ gDiag (b.1+1)` (S22 bridge + endpoint forms)
  - `lastFace_filter_extract` — S21A + S24 composed (t1-pinning, t2-extinction)
  - `lastFace_card_eq` / `lastFace_odd` — the bijection + transport of `face2_path_odd_gDiag`
- New section `N2Panchromatic`: `sperner_panchromatic_two` assembled from `Triangulation.boundary_doors_odd` (four slots discharged) + `Triangulation.sperner` + `spernerColor_le` witness extraction + `gridPt_topSimps2_coord_diameter` (2/N diameter bound).
- Namespace hygiene: removed redundant nested `namespace SpernerFreudSimp` re-opens that double-namespaced all late declarations and left the namespace dangling at EOF. All affected lemmas were `private`; public names (`SpernerFreudSimp.*`, `SpernerFreudSimp.SimplicialAdjFnHelper.*`, `SpernerLowerDimHelper.*`) unchanged.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.SpernerFreudenthalSimplex` — **Build completed successfully (8578 jobs)**.
- Sorry count 1 → 0; `grep -c "^axiom "` = 0. No downstream file imports `SpernerFreudenthalSimplex`, so no rebuild fan-out.
- Gallery meta unchanged on purpose: the entry's leanFile is `SpernerNDimMathlibOQ02.lean`, which still legitimately carries the 1 general-n axiom `sperner_panchromatic`.

## Findings
- The `_hLastFace` bijection maps a boundary door `(s, k)` to the first coordinate of its dropped vertex — for saturating-diagonal t1 cells the dropped vertex is the base itself.
- `Triangulation.vertex` vs `AbstractSimplicialData.vertexEnum` are defeq but not syntactic — `rw` against vertex-form goals needs a `show` in vertexEnum form.

## Status
**Outcome**: completed (session milestone; problem stays open for the n≥3 generalization)
**Next Steps**: derive an axiom-free n=2 Brouwer corollary in `SpernerNDimMathlibOQ02.lean`; then the n≥3 Freudenthal triangulation.

🤖 Generated by researcher-1
