### PR TITLE
audit: erdos-793 clean (re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16409,8 +16409,8 @@
     },
     "erdos-793": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:06:35Z",
+      "auditCount": 5,
+      "lastAudited": "2026-07-24T12:02:20Z",
       "result": "clean"
     },
     "erdos-794": {


### PR DESCRIPTION
## Summary
Reserve-mode re-audit of `erdos-793` (queue fully drained, round-robin oldest re-serve).

- axiomCount 5, theoremCount 1, definitionCount 13 all match `proofs/Proofs/Erdos793Problem.lean` exactly.
- The one theorem (`large_primes_satisfy_condition`) is a genuine, correct proof (Euclid's lemma argument).
- `status: axiomatized`, `badge: axiom`, `erdosProblemStatus: open` all honestly disclosed — no overclaiming.
- `Erdos793Aristotle.lean` (additionalFiles stub) has several `sorry`s, but this is the standard automated-proof-search staging pattern used across 54 gallery entries — intentionally excluded from the public sorry count, not a discrepancy.

Result: **clean**. Only bumps `audit-tracker.json`'s `auditCount`/`lastAudited` for erdos-793.

## Test plan
- [x] Verified axiom/theorem/def counts via grep against Lean source
- [x] Manually checked the proved theorem's proof term is valid
- [x] Confirmed Aristotle stub sorry convention against other gallery entries