### PR TITLE
audit(erdos-157): fix stale sorry-status labels in annotations.json

### DIFF
--- a/src/data/proofs/erdos-157/annotations.json
+++ b/src/data/proofs/erdos-157/annotations.json
@@ -163,7 +163,7 @@
     },
     "type": "definition",
     "title": "Pilatte's Existence Theorem (2023)",
-    "content": "**theorem pilatte_existence**: Erdos157Conjecture\n\n**Status**: sorry (existential construction not formalized)\n\n**Pilatte's proof** (2023) uses a probabilistic construction:\n1. Carefully select elements to maintain the Sidon property\n2. Ensure enough density to cover all large integers with 3 terms\n3. Balance the competing constraints through delicate analysis\n\nThe construction is non-explicit - it proves existence without giving a concrete set.",
+    "content": "**axiom pilatte_existence**: Erdos157Conjecture\n\n**Status**: axiomatized (existential construction not formalized; Pilatte's ~1000+ line probabilistic proof is not a Lean `sorry` but a declared `axiom`)\n\n**Pilatte's proof** (2023) uses a probabilistic construction:\n1. Carefully select elements to maintain the Sidon property\n2. Ensure enough density to cover all large integers with 3 terms\n3. Balance the competing constraints through delicate analysis\n\nThe construction is non-explicit - it proves existence without giving a concrete set.",
     "mathContext": "Probabilistic existence proofs are common in combinatorics. They show something exists without constructing it explicitly.",
     "significance": "key",
     "relatedConcepts": [
@@ -186,7 +186,7 @@
     },
     "type": "concept",
     "title": "Sidon Sets Cannot Be Order-2 Bases",
-    "content": "**theorem sidon_not_basis_2 (A : Set ℕ)**:\n  A.Infinite → IsSidon A → ¬IsAsymptoticBasis A 2\n\n**Status**: sorry\n\n**Why it's true**:\n- Sidon sets satisfy |A ∩ [1,N]| ≤ √N + O(N^{1/4})\n- Order-2 bases require |A ∩ [1,N]| ≫ √N (to cover N different sums)\n- These constraints are incompatible!\n\nThis explains why Erdős asked about order 3, not order 2.",
+    "content": "**theorem sidon_not_basis_2 (A : Set ℕ)**:\n  A.Infinite → IsSidon A → ¬IsAsymptoticBasis A 2\n\n**Status**: fully proved (0 sorries) — direct counting argument, no axioms used in the proof itself\n\n**Why it's true**:\n- Sidon sets satisfy |A ∩ [1,N]| ≤ √N + O(N^{1/4})\n- Order-2 bases require |A ∩ [1,N]| ≫ √N (to cover N different sums)\n- These constraints are incompatible!\n\nThis explains why Erdős asked about order 3, not order 2.",
     "mathContext": "The impossibility of order 2 is a density argument. Sidon sets grow too slowly to form pairwise sums covering all integers.",
     "significance": "key",
     "relatedConcepts": [
@@ -275,7 +275,7 @@
     },
     "type": "concept",
     "title": "Finite Sidon Example",
-    "content": "**def exampleSidonSet**: Finset ℕ := {1, 2, 5, 11}\n\n**theorem example_is_sidon**: IsSidon exampleSidonSet\n  Status: sorry\n\n**Verification**: The pairwise sums are:\n- 1+2=3, 1+5=6, 1+11=12, 2+5=7, 2+11=13, 5+11=16\n- All distinct ✓\n\n**Historical note**: The original set {1, 2, 5, 10, 11, 13} was NOT Sidon (1+11 = 2+10 = 12). Aristotle proof search discovered this bug!",
+    "content": "**def exampleSidonSet**: Finset ℕ := {1, 2, 5, 11}\n\n**theorem example_is_sidon**: IsSidon exampleSidonSet\n  Status: fully proved (0 sorries; proved by Aristotle)\n\n**Verification**: The pairwise sums are:\n- 1+2=3, 1+5=6, 1+11=12, 2+5=7, 2+11=13, 5+11=16\n- All distinct ✓\n\n**Historical note**: The original set {1, 2, 5, 10, 11, 13} was NOT Sidon (1+11 = 2+10 = 12). Aristotle proof search discovered this bug!",
     "mathContext": "Small Sidon sets are useful for testing. The bug-finding note shows the value of formal verification even for 'obvious' claims.",
     "significance": "supporting",
     "relatedConcepts": [


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-157
**Problem**: annotations.json contains 3 stale/incorrect "Status: sorry" labels that don't match the actual Lean source (0 sorries, verified by grep).

## Evidence

**annotations.json claims** (before fix):
- `ann-e157-pilatte`: "**theorem pilatte_existence** ... **Status**: sorry (existential construction not formalized)"
- `ann-e157-not-basis-2`: "**theorem sidon_not_basis_2** ... **Status**: sorry"
- `ann-e157-example`: "**theorem example_is_sidon** ... Status: sorry"

**Lean file shows** (`proofs/Proofs/Erdos157Problem.lean`):
- `pilatte_existence` is declared `axiom`, not a theorem with a `sorry` — a different (and correctly disclosed elsewhere) trust category.
- `sidon_not_basis_2` (line 460) is fully proved, 0 sorries — a direct counting argument.
- `example_is_sidon` (line 532) is fully proved, 0 sorries — completed by Aristotle.

`grep sorry proofs/Proofs/Erdos157Problem.lean` returns zero hits, matching `meta.json`'s `sorries: 0` and the overview/proofStrategy prose ("sorry-free direct counting argument", "Aristotle-proved"). The stale annotation text was left over from an earlier draft (before PR #9219/#9226 completed these proofs) and never updated when the enrichment pass (#26564) added per-annotation prerequisites.

This is understating, not overstating — but per repo convention a "Sorry'd" claim on a proved theorem is still gallery text asserting something false about the Lean source, and it's inconsistent with the entry's own top-level `meta.json` narrative.

## Fix

Updated the 3 `content` strings in `src/data/proofs/erdos-157/annotations.json` to reflect actual status: `pilatte_existence` labeled as an axiom (not theorem/sorry), and the two completed theorems marked "fully proved (0 sorries)".

---
Discovered during gallery integrity audit.