### PR TITLE
audit: tracker update for erdos-157 (issues-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11213,12 +11213,12 @@
       "result": "clean"
     },
     "erdos-157": {
-      "auditCount": 7,
+      "auditCount": 8,
       "issues": [
         "sorry mismatch corrected in meta.json"
       ],
-      "lastAudited": "2026-05-04T04:06:35Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T12:07:07Z",
+      "result": "issues-fixed"
     },
     "erdos-158": {
       "auditCount": 4,


### PR DESCRIPTION
Tracker-only update recording the erdos-157 re-audit result.

Re-audit found stale sorry-status labels in `annotations.json` (fixed in #43335).

---
Discovered during gallery integrity audit.