### PR TITLE
Fix: reconcile stale yang-mills-2d-oq-02 tracker flag (#43236)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -26774,7 +26774,8 @@
       "auditCount": 5,
       "issues": [],
       "lastAudited": "2026-07-24T09:14:34Z",
-      "result": "issues-found"
+      "result": "issues-fixed",
+      "notes": "Drift resolved on origin/main: the vacuous axiom finding (#43236) is fully repaired and the issue is CLOSED. Fix PRs merged: #43241 (axiom casimir_scaling_4d_approximate -> proved theorem with honest tautology caveat), #43243 (removed stale 'axiomatized' prose from description/proofStrategy/mathContext/reference), #43306 (badge enum verified -> original). Current source: 0 axioms, casimir_scaling_4d_approximate is a proved theorem. Current meta: status=verified, badge=original, axiomCount=0, assumptions honestly state the free-existential predicate is a tautology and the physical small-epsilon conjecture remains open. The remaining 'issues-found' flag was stale bookkeeping lag; no code or metadata defect remains."
     },
     "yang-mills-lattice": {
       "auditCount": 8,


### PR DESCRIPTION
## Summary

Reconciles the `audit-tracker.json` entry for **yang-mills-2d-oq-02** from
`issues-found` to `issues-fixed`. The underlying vacuous-axiom finding
(issue #43236) is fully repaired and the issue is **CLOSED** — the tracker's
`issues-found` flag (last written 2026-07-24T09:14Z) was stale bookkeeping lag,
not a live defect.

## Evidence (state on origin/main)

Fix PRs already merged:
- **#43241** — `axiom casimir_scaling_4d_approximate` → proved `theorem` with honest tautology caveat
- **#43243** — removed stale `axiomatized` prose from description/proofStrategy/mathContext/reference
- **#43306** — badge enum `verified` → `original`

Current source (`proofs/Proofs/YangMills2DOQ02.lean`): 0 axioms;
`casimir_scaling_4d_approximate` is a proved theorem.

Current meta (`src/data/proofs/yang-mills-2d-oq-02/meta.json`):
`status=verified`, `badge=original`, `axiomCount=0`; `assumptions` honestly
state the free-existential predicate is a tautology and the physical
small-ε conjecture remains open.

## Change

Single entry in `src/data/proofs/audit-tracker.json`: `result` → `issues-fixed`
plus a reconciliation `notes` field documenting the merged fix PRs. No code or
metadata defect remained to repair.

Closes #43236