### PR TITLE
research(erdos-1151-oq-04): S39 — continuous saturation witness via clamped Lagrange polynomial (Sorry 2 ingredient (a) closed)

### DIFF
--- a/proofs/Proofs/Erdos1151OQ04.lean
+++ b/proofs/Proofs/Erdos1151OQ04.lean
@@ -48,6 +48,13 @@ The non-sorry results proved here:
   - `chebyshev_trig_sum_pos`: strict positivity of S(θ,n) per term [Session 20]
   - `chebyshev_quarter_floor_log_asymp_lb`: (1/4)·log(n+1) ≤ (1/2)·log(m+2)−1
     for `n ≥ N₀(θ)` and `(m : ℝ) ≥ n·θ/(4π) − 1` (Step 7a residue) [Session 24]
+  - `lagrangeBasis_apply_self` / `lagrangeBasis_apply_ne`: Lagrange delta
+    property ℓₖ(xⱼ) = δₖⱼ for injective nodes [Session 39]
+  - `lagrangeBasis_continuous`: continuity of ℓₖ in the evaluation point [Session 39]
+  - `exists_continuous_bounded_through_nodes`: continuous ‖f‖_∞ ≤ 1 interpolant
+    through prescribed node values via clamped Lagrange polynomial [Session 39]
+  - `chebyshev_lebesgue_saturated_continuous`: CONTINUOUS saturation witness
+    ‖f‖ ≤ 1, Lₙf(x) = Λₙ(x) — ingredient (a) of Sorry 2 closed [Session 39]
 
 ## Sorry 1: trig_sum_harmonic_lb (was: chebyshev_trig_sum_lb Case 2)
 Now factored as a SELF-CONTAINED lemma for general θ ∈ (0, π):
@@ -58,8 +65,12 @@ Now factored as a SELF-CONTAINED lemma for general θ ∈ (0, π):
 
 ## Sorry 2: divergence_from_lebesgue_growth
 Proof requires:
-  a) For each n, existence of optimizing continuous function with ‖f‖ ≤ 1 and Lₙf(x) = Λₙ(x)
-  b) Lacunary subsequence construction [has known gap: UBP gives lim sup, not lim]
+  a) For each n, existence of optimizing continuous function with ‖f‖ ≤ 1 and
+     Lₙf(x) = Λₙ(x) — DONE (Session 39, `chebyshev_lebesgue_saturated_continuous`)
+  b) Lacunary subsequence construction [has known gap: UBP gives lim sup, not lim;
+     the stated conclusion is the strong full-limit form Lₙf(x) → +∞, which needs
+     polynomial-reproduction (Lₙp = p for deg p < n) + gliding-hump cross-term
+     control, not just Banach–Steinhaus]
 
 Tags: analysis, approximation-theory, chebyshev, lebesgue-function, erdos-problems
 -/
@@ -350,11 +361,11 @@ theorem cos_rational_pi_nonzero_along_multiples (p q m : ℕ) (hp : Odd p)
     `chebyshevInterp n f x` unbounded.
 
     The witness `f` here is *not* continuous (it is `0` off the finite
-    Chebyshev-node set); a future session wiring this through Mathlib's
-    `ContinuousLinearMap` / `BanachSteinhaus` infrastructure will lift the
-    witness to a continuous function via Tietze extension. The discrete
-    saturation proved here is the mathematical content; the topological lift is
-    routine. -/
+    Chebyshev-node set); see `chebyshev_lebesgue_saturated_continuous` (Session 39)
+    for the continuous upgrade via a clamped Lagrange interpolation polynomial —
+    no Tietze extension needed. The discrete saturation proved here is the
+    mathematical content; the continuous version is what the Banach–Steinhaus /
+    lacunary-series closure of Sorry 2 consumes. -/
 private lemma chebyshev_lebesgue_saturated (n : ℕ) (x : ℝ) :
     ∃ f : ℝ → ℝ, (∀ t, |f t| ≤ 1) ∧
       chebyshevInterp n f x = chebyshevLebesgue n x := by
@@ -432,6 +443,123 @@ private lemma chebyshev_lebesgue_saturated (n : ℕ) (x : ℝ) :
             * lagrangeBasis n (chebyshevNode n) k₀ x
             = |lagrangeBasis n (chebyshevNode n) k₀ x|
       rw [hf_eval, hw_sat k₀]
+
+/-! ## Session 39: Lagrange Delta Property and Continuous Saturation Witness -/
+
+/-- **Lagrange basis delta property (diagonal)**: ℓₖ(xₖ) = 1 for injective nodes.
+
+    Each factor (xₖ - xᵢ)/(xₖ - xᵢ) over i ≠ k equals 1; injectivity of the
+    node family makes every denominator nonzero. -/
+theorem lagrangeBasis_apply_self (n : ℕ) (nodes : Fin n → ℝ)
+    (hinj : Function.Injective nodes) (k : Fin n) :
+    lagrangeBasis n nodes k (nodes k) = 1 := by
+  simp only [lagrangeBasis]
+  apply Finset.prod_eq_one
+  intro i hi
+  exact div_self (sub_ne_zero.mpr (hinj.ne (Ne.symm (Finset.mem_erase.mp hi).1)))
+
+/-- **Lagrange basis delta property (off-diagonal)**: ℓₖ(xⱼ) = 0 for j ≠ k.
+
+    The factor at i = j vanishes: (xⱼ - xⱼ)/(xₖ - xⱼ) = 0. No injectivity
+    hypothesis is needed. -/
+theorem lagrangeBasis_apply_ne (n : ℕ) (nodes : Fin n → ℝ) {j k : Fin n}
+    (hjk : j ≠ k) :
+    lagrangeBasis n nodes k (nodes j) = 0 := by
+  simp only [lagrangeBasis]
+  exact Finset.prod_eq_zero (Finset.mem_erase.mpr ⟨hjk, Finset.mem_univ j⟩)
+    (by rw [sub_self, zero_div])
+
+/-- The Lagrange basis is continuous in the evaluation point: each factor
+    t ↦ (t - xᵢ)/(xₖ - xᵢ) is affine, and ℓₖ is their finite product. -/
+theorem lagrangeBasis_continuous (n : ℕ) (nodes : Fin n → ℝ) (k : Fin n) :
+    Continuous fun t => lagrangeBasis n nodes k t := by
+  simp only [lagrangeBasis]
+  exact continuous_finset_prod _ fun i _ =>
+    (continuous_id.sub continuous_const).div_const _
+
+/-- **Continuous bounded interpolant through prescribed node values.**
+
+    For any injective node family and target values w with |wₖ| ≤ 1, there is a
+    continuous f : ℝ → ℝ with ‖f‖_∞ ≤ 1 and f(xₖ) = wₖ for every k.
+
+    Construction: the Lagrange interpolation polynomial g = Σₖ wₖ·ℓₖ passes
+    through the prescribed values (delta property `lagrangeBasis_apply_self` /
+    `lagrangeBasis_apply_ne`) and is continuous (`lagrangeBasis_continuous`);
+    clamping to [-1, 1] via t ↦ max (-1) (min 1 (g t)) preserves continuity and
+    the node values (which already lie in [-1, 1]) while enforcing the global
+    sup bound. This avoids both Tietze extension and any piecewise-linear
+    construction. -/
+theorem exists_continuous_bounded_through_nodes (n : ℕ) (nodes : Fin n → ℝ)
+    (hinj : Function.Injective nodes) (w : Fin n → ℝ) (hw : ∀ k, |w k| ≤ 1) :
+    ∃ f : ℝ → ℝ, Continuous f ∧ (∀ t, |f t| ≤ 1) ∧ ∀ k, f (nodes k) = w k := by
+  classical
+  -- The (unclamped) Lagrange interpolation polynomial through the target values.
+  have hg_cont : Continuous fun t => ∑ k : Fin n, w k * lagrangeBasis n nodes k t :=
+    continuous_finset_sum _ fun k _ =>
+      (lagrangeBasis_continuous n nodes k).const_mul (w k)
+  have hg_node : ∀ j : Fin n,
+      (∑ k : Fin n, w k * lagrangeBasis n nodes k (nodes j)) = w j := by
+    intro j
+    have hzero : ∀ k ∈ Finset.univ, k ≠ j →
+        w k * lagrangeBasis n nodes k (nodes j) = 0 := fun k _ hkj => by
+      rw [lagrangeBasis_apply_ne n nodes (Ne.symm hkj), mul_zero]
+    rw [Finset.sum_eq_single_of_mem j (Finset.mem_univ j) hzero,
+      lagrangeBasis_apply_self n nodes hinj j, mul_one]
+  -- Clamp to [-1, 1]: preserves continuity and node values, forces the bound.
+  refine ⟨fun t => max (-1) (min 1 (∑ k : Fin n, w k * lagrangeBasis n nodes k t)),
+    continuous_const.max (continuous_const.min hg_cont), fun t => ?_, fun j => ?_⟩
+  · show |max (-1) (min 1 (∑ k : Fin n, w k * lagrangeBasis n nodes k t))| ≤ 1
+    rw [abs_le]
+    exact ⟨le_max_left _ _, max_le (by norm_num) (min_le_left _ _)⟩
+  · show max (-1) (min 1 (∑ k : Fin n, w k * lagrangeBasis n nodes k (nodes j))) = w j
+    obtain ⟨h₁, h₂⟩ := abs_le.mp (hw j)
+    rw [hg_node j, min_eq_right h₂, max_eq_right h₁]
+
+/-- **Continuous operator-norm saturation witness.**
+
+    Upgrades `chebyshev_lebesgue_saturated`: for any `n : ℕ` and `x : ℝ` the
+    saturating function can be taken *continuous* — there is a continuous
+    `f : ℝ → ℝ` with `|f t| ≤ 1` for all `t` and
+    `chebyshevInterp n f x = chebyshevLebesgue n x`.
+
+    Together with `chebyshev_upper_bound`, this pins the exact operator norm of
+    the evaluation functional `f ↦ chebyshevInterp n f x` on `C(ℝ)` with the sup
+    norm: `sup {|Lₙf(x)| : ‖f‖_∞ ≤ 1, f continuous} = Λₙ(x)`, attained. This is
+    ingredient (a) of Sorry 2 (`divergence_from_lebesgue_growth`) as documented
+    in the file header; the remaining gap is only ingredient (b), the lacunary
+    series assembling these witnesses into a single `f` with full-limit
+    divergence `Lₙf(x) → +∞`. -/
+private lemma chebyshev_lebesgue_saturated_continuous (n : ℕ) (x : ℝ) :
+    ∃ f : ℝ → ℝ, Continuous f ∧ (∀ t, |f t| ≤ 1) ∧
+      chebyshevInterp n f x = chebyshevLebesgue n x := by
+  classical
+  rcases Nat.eq_zero_or_pos n with rfl | hn
+  · -- n = 0: both sides are empty sums; the zero function works.
+    exact ⟨fun _ => 0, continuous_const, fun t => by simp,
+      by simp [chebyshevInterp, lagrangeInterp, chebyshevLebesgue]⟩
+  · -- Sign weights at each node so that w k * ℓₖ(x) = |ℓₖ(x)|.
+    let w : Fin n → ℝ := fun k =>
+      if 0 ≤ lagrangeBasis n (chebyshevNode n) k x then (1 : ℝ) else -1
+    have hw_abs : ∀ k, |w k| ≤ 1 := by
+      intro k
+      show |(if 0 ≤ lagrangeBasis n (chebyshevNode n) k x then (1 : ℝ) else -1)| ≤ 1
+      split <;> norm_num
+    have hw_sat : ∀ k, w k * lagrangeBasis n (chebyshevNode n) k x =
+        |lagrangeBasis n (chebyshevNode n) k x| := by
+      intro k
+      show (if 0 ≤ lagrangeBasis n (chebyshevNode n) k x then (1 : ℝ) else -1) *
+          lagrangeBasis n (chebyshevNode n) k x =
+        |lagrangeBasis n (chebyshevNode n) k x|
+      by_cases h : 0 ≤ lagrangeBasis n (chebyshevNode n) k x
+      · rw [if_pos h, one_mul, abs_of_nonneg h]
+      · push_neg at h
+        rw [if_neg (not_le.mpr h), neg_one_mul, abs_of_neg h]
+    obtain ⟨f, hf_cont, hf_bd, hf_node⟩ :=
+      exists_continuous_bounded_through_nodes n (chebyshevNode n)
+        (chebyshevNode_injective n hn) w hw_abs
+    refine ⟨f, hf_cont, hf_bd, ?_⟩
+    simp only [chebyshevInterp, lagrangeInterp, chebyshevLebesgue]
+    exact Finset.sum_congr rfl fun k _ => by rw [hf_node k, hw_sat k]
 
 /-! ## Chebyshev Product Formula and Trig Helpers (Session 5) -/
 

--- a/proofs/Proofs/Erdos1151OQ04.lean
+++ b/proofs/Proofs/Erdos1151OQ04.lean
@@ -474,7 +474,7 @@ theorem lagrangeBasis_apply_ne (n : ℕ) (nodes : Fin n → ℝ) {j k : Fin n}
 theorem lagrangeBasis_continuous (n : ℕ) (nodes : Fin n → ℝ) (k : Fin n) :
     Continuous fun t => lagrangeBasis n nodes k t := by
   simp only [lagrangeBasis]
-  exact continuous_finset_prod _ fun i _ =>
+  exact continuous_finsetProd _ fun i _ =>
     (continuous_id.sub continuous_const).div_const _
 
 /-- **Continuous bounded interpolant through prescribed node values.**
@@ -495,7 +495,7 @@ theorem exists_continuous_bounded_through_nodes (n : ℕ) (nodes : Fin n → ℝ
   classical
   -- The (unclamped) Lagrange interpolation polynomial through the target values.
   have hg_cont : Continuous fun t => ∑ k : Fin n, w k * lagrangeBasis n nodes k t :=
-    continuous_finset_sum _ fun k _ =>
+    continuous_finsetSum _ fun k _ =>
       (lagrangeBasis_continuous n nodes k).const_mul (w k)
   have hg_node : ∀ j : Fin n,
       (∑ k : Fin n, w k * lagrangeBasis n nodes k (nodes j)) = w j := by

--- a/research/problems/erdos-1151-oq-04/session-39-continuous-saturation-witness.md
+++ b/research/problems/erdos-1151-oq-04/session-39-continuous-saturation-witness.md
@@ -1,0 +1,90 @@
+# Session 39 (researcher-3, 2026-07-24) — Continuous saturation witness via clamped Lagrange polynomial
+
+## Summary
+
+**Sorry 2 ingredient (a) CLOSED.** The file header has documented Sorry 2
+(`divergence_from_lebesgue_growth`) as needing (a) a *continuous* optimizing
+function with ‖f‖_∞ ≤ 1 and Lₙf(x) = Λₙ(x), and (b) the lacunary series
+assembly. S31/S33 proved the *discrete* saturation witness
+(`chebyshev_lebesgue_saturated`, 0 off the node set) and deferred the
+continuous lift to "Tietze extension" (S32+ plan, S38 roadmap). This session
+delivers the continuous lift — with **no Tietze extension and no
+piecewise-linear construction**:
+
+> Clamp the Lagrange interpolation polynomial. g = Σₖ wₖ·ℓₖ is continuous and
+> passes through the target values wₖ = sign(ℓₖ(x)) by the delta property
+> ℓₖ(xⱼ) = δₖⱼ; then f = max(−1, min(1, g)) is continuous, globally bounded by
+> 1, and still passes through the values (they lie in [−1, 1]). Since Lₙ only
+> reads f at the nodes, Lₙf(x) = Σₖ wₖ ℓₖ(x) = Σₖ |ℓₖ(x)| = Λₙ(x).
+
+## New declarations (Erdos1151OQ04.lean, +135/−7 lines → 2842 lines, 36 top-level theorems)
+
+| Declaration | Content |
+|---|---|
+| `lagrangeBasis_apply_self` (public) | ℓₖ(xₖ) = 1 for injective nodes (`Finset.prod_eq_one` + `div_self`) |
+| `lagrangeBasis_apply_ne` (public) | ℓₖ(xⱼ) = 0 for j ≠ k (`Finset.prod_eq_zero` at the i = j factor); no injectivity needed |
+| `lagrangeBasis_continuous` (public) | t ↦ ℓₖ(t) continuous (`continuous_finsetProd` of affine factors) |
+| `exists_continuous_bounded_through_nodes` (public) | for injective nodes and \|wₖ\| ≤ 1: ∃ continuous f, ‖f‖_∞ ≤ 1, f(xₖ) = wₖ — **no `0 < n` hypothesis** (vacuous at n = 0) |
+| `chebyshev_lebesgue_saturated_continuous` (private) | ∃ continuous f, \|f\| ≤ 1, `chebyshevInterp n f x = chebyshevLebesgue n x` for ALL n, x |
+
+Also: `chebyshev_lebesgue_saturated` docstring updated to point at the
+continuous upgrade; file-header architecture list and Sorry 2 description
+updated ((a) marked DONE).
+
+## Build
+
+`./proofs/scripts/docker-build.sh Proofs.Erdos1151OQ04` — **clean on first
+attempt** (3355 jobs, exit 0), exactly 1 sorry warning (line 2820 =
+`divergence_from_lebesgue_growth`, the intended survivor). Follow-up commit
+swapped `continuous_finset_prod`/`continuous_finset_sum` for the
+non-deprecated `continuous_finsetProd`/`continuous_finsetSum` (v4.31
+deprecation warnings) and was re-verified.
+
+## Why this unblocks both endgames
+
+- **UBP route** (S32+ plan): the operator-norm identity ‖Λₙ_x‖ =
+  chebyshevLebesgue n x on C(ℝ) needed the saturating f to be continuous;
+  the discrete witness could not feed `ContinuousLinearMap` packaging.
+- **Strong-form route** (what the sorry actually states): the gliding-hump /
+  lacunary construction needs, for each n, a continuous near-saturating
+  block. This is that block, with exact (not ε-approximate) saturation.
+
+## Correction to the S34/S38 roadmap — UBP alone CANNOT close Sorry 2
+
+The S34 §6 roadmap (CLM packaging → operator-norm identity → Banach–Steinhaus
+contrapositive → "Sorry 2 discharge") silently assumed the S30 statement
+refactor (PR #17593, weakening the conclusion to unboundedness
+`∀ M, ∃ n, M < |Lₙf(x)|`). **That PR was closed unmerged** (administratively,
+as branch-rot supersession, not on the merits), so `origin/main` still states
+the STRONG full-limit form:
+
+```
+∃ f, Continuous f ∧ ∀ M, ∃ N, ∀ n ≥ N, M < chebyshevInterp n f x
+```
+
+Banach–Steinhaus delivers only `limsup |Lₙf(x)| = ∞`. Closing the strong form
+needs the lacunary construction:
+
+1. **Polynomial reproduction** (next missing piece, S40 candidate):
+   `chebyshevInterp n p x = p x` for polynomials p with degree < n
+   (Lagrange interpolation is a projection onto degree-< n polynomials).
+   With it, earlier gliding-hump blocks become *transparent* at later levels:
+   approximate each continuous saturating block fⱼ by a polynomial pⱼ
+   (interpolation only reads node values, so Weierstrass approximation
+   transfers with error Λₙ·ε), and for n > deg pⱼ, Lₙpⱼ(x) = pⱼ(x) ∈ [−1−ε, 1+ε].
+2. **Block assembly**: f = Σⱼ aⱼpⱼ with aⱼ chosen inductively
+   (aⱼ ≤ 2^{−j}/max(1, Λ_{n₁}(x), …, Λ_{n_{j−1}}(x)) kills cross terms from
+   the tail; nⱼ chosen after aⱼ using Λₙ(x) → ∞ so aⱼΛ_{nⱼ}(x) ≥ j + 3).
+   NOTE: this yields divergence along the subsequence nⱼ; upgrading to the
+   stated full-limit `∀ n ≥ N` needs blocks that stay uniformly large on
+   whole ranges nⱼ ≤ n ≤ deg pⱼ — genuinely harder, needs the sign structure
+   of ℓₖⁿ(x) across n. Whether the strong form should instead be weakened to
+   the ground-truth-faithful `limsup` form (reviving S30's refactor on its
+   merits) is a decision for the next PLAN step.
+
+## Files touched
+
+`proofs/Proofs/Erdos1151OQ04.lean` (+135/−7 then deprecation swap),
+`src/data/research/problems/erdos-1151-oq-04.json` (lineCount 2714→2842,
+theoremCount 32→36 per S38 conventions), `state.md`, this session file.
+0 axiom / 0 sorry change (1 sorry preserved at `divergence_from_lebesgue_growth`).

--- a/research/problems/erdos-1151-oq-04/state.md
+++ b/research/problems/erdos-1151-oq-04/state.md
@@ -1,5 +1,24 @@
 # Research State: erdos-1151-oq-04
 
+> **S39 ACT — CONTINUOUS SATURATION WITNESS (researcher-3, 2026-07-24).**
+> UNBLOCKED: Docker recovered (build clean, 3355 jobs, first attempt). Sorry 2
+> ingredient (a) CLOSED: `chebyshev_lebesgue_saturated_continuous` gives, for
+> every n, x, a CONTINUOUS f with |f| ≤ 1 and Lₙf(x) = Λₙ(x) — via clamped
+> Lagrange polynomial (max(−1, min(1, Σ wₖℓₖ))), NOT Tietze. New public infra:
+> `lagrangeBasis_apply_self` / `lagrangeBasis_apply_ne` (delta property),
+> `lagrangeBasis_continuous`, `exists_continuous_bounded_through_nodes`
+> (general injective nodes, |wₖ| ≤ 1, no 0 < n hypothesis). File 2714→2842
+> lines, 32→36 top-level theorems, still exactly 1 sorry
+> (`divergence_from_lebesgue_growth`). **ROADMAP CORRECTION**: the S34 §6 UBP
+> chain (CLM packaging → op-norm → Banach–Steinhaus) CANNOT close Sorry 2 as
+> stated — the S30 statement-weakening PR #17593 was closed unmerged, so main
+> still states the STRONG full-limit form `∀ M, ∃ N, ∀ n ≥ N, M < Lₙf(x)`;
+> UBP gives only limsup. Next (S40): either (i) polynomial-reproduction lemma
+> `chebyshevInterp n p x = p x` for deg p < n (the missing lacunary-assembly
+> piece, works toward the strong form), or (ii) a PLAN decision to revive
+> S30's limsup refactor on its merits. See
+> session-39-continuous-saturation-witness.md.
+
 > **S38 STATE-SYNC + BLOCKED (researcher-1, 2026-06-13).** Two tracker drifts
 > fixed after S37 BUILD-VERIFY (#22947, 2026-06-12) grew the file: research-JSON
 > `leanFiles` lineCounts were stale (`Erdos1151OQ04` 2692→**2714**, `…Aristotle`
@@ -17,11 +36,11 @@
 > S37 left the file BUILD-VERIFY clean (3084 jobs, 1 sorry). No Lean touched.
 
 ## Current State
-**Phase**: ACT (S36 CLUSTER-A-CLOSE — researcher folds chebyshevInterp_sub proof into a single `simp only` matching sibling chebyshevInterp_neg pattern; Cluster A (1 error) eliminated, Cluster B (21 errors at lines 952–1247) deferred to subsequent mechanic-handoff sub-cluster PRs)
+**Phase**: ACT (S39 CONTINUOUS-SATURATION — Sorry 2 ingredient (a) closed via clamped Lagrange polynomial; build-verified clean; 1 sorry remains: `divergence_from_lebesgue_growth`, whose strong full-limit conclusion needs the lacunary assembly (b) — see S39 header note for the roadmap correction)
 **Path**: full
-**Since**: 2026-06-09T18:55:00Z (S36 CLUSTER-A-CLOSE)
-**Iteration**: 36
-**Last Updated**: 2026-06-09 (researcher-3)
+**Since**: 2026-07-24T12:30:00Z (S39 CONTINUOUS-SATURATION)
+**Iteration**: 39
+**Last Updated**: 2026-07-24 (researcher-3)
 
 ## Session 36 (researcher-3, 2026-06-09, build pending — Cluster A surgically closed; Cluster B still 21 errors) — fold chebyshevInterp_sub to single `simp only` matching sibling chebyshevInterp_neg
 

--- a/src/data/research/problems/erdos-1151-oq-04.json
+++ b/src/data/research/problems/erdos-1151-oq-04.json
@@ -178,8 +178,8 @@
     {
       "path": "Proofs/Erdos1151OQ04.lean",
       "filename": "Erdos1151OQ04.lean",
-      "lineCount": 2714,
-      "theoremCount": 32,
+      "lineCount": 2842,
+      "theoremCount": 36,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 3,


### PR DESCRIPTION
## S39 — Continuous saturation witness via clamped Lagrange polynomial

**Sorry 2 ingredient (a) CLOSED.** The file header documents `divergence_from_lebesgue_growth` (the last remaining sorry) as needing (a) a *continuous* optimizing function with sup-norm at most 1 and Ln f(x) = Lambda_n(x), and (b) a lacunary series assembly. S31/S33 proved only the discrete witness (0 off the node set) and deferred the continuous lift to a future Tietze extension. This PR delivers the continuous lift with **no Tietze extension and no piecewise-linear construction**:

> Clamp the Lagrange interpolation polynomial: g = sum_k w_k * l_k is continuous and passes through the target sign values by the delta property l_k(x_j) = delta_kj; then f = max(-1, min(1, g)) is continuous, globally bounded by 1, and preserves the node values (they lie in [-1,1]). Since interpolation only reads f at the nodes, Ln f(x) = Lambda_n(x) exactly.

### New declarations (`proofs/Proofs/Erdos1151OQ04.lean`, +135/-7 -> 2842 lines)

- `lagrangeBasis_apply_self` (public): l_k(x_k) = 1 for injective nodes
- `lagrangeBasis_apply_ne` (public): l_k(x_j) = 0 for j != k (no injectivity needed)
- `lagrangeBasis_continuous` (public): continuity of l_k in the evaluation point
- `exists_continuous_bounded_through_nodes` (public): continuous, sup-norm <= 1 interpolant through any prescribed values |w_k| <= 1 at any injective node family — no `0 < n` hypothesis
- `chebyshev_lebesgue_saturated_continuous` (private): the continuous saturation witness for all n, x

Header architecture list + Sorry 2 description updated; `chebyshev_lebesgue_saturated` docstring now points at the continuous upgrade.

### Build

`./proofs/scripts/docker-build.sh Proofs.Erdos1151OQ04` — clean on first attempt (3355 jobs, exit 0), re-verified after swapping deprecated `continuous_finset_prod`/`_sum` for `continuous_finsetProd`/`Sum`. Exactly 1 sorry warning survives (line 2820, `divergence_from_lebesgue_growth` — the intended one). 0 axiom / 0 sorry change.

### Roadmap correction (documented in state.md)

The S34 UBP chain (CLM packaging -> operator norm -> Banach-Steinhaus) cannot close Sorry 2 as stated: the S30 statement-weakening PR #17593 was closed unmerged, so main still states the strong full-limit form, while UBP delivers only limsup unboundedness. S40 options recorded in state.md: (i) polynomial-reproduction lemma (interpolation is a projection onto low-degree polynomials — the missing lacunary-assembly piece), or (ii) revive S30's limsup refactor on its merits.

### Tracker sync

`src/data/research/problems/erdos-1151-oq-04.json`: lineCount 2714 -> 2842, theoremCount 32 -> 36 (S38 canonical conventions). Session file + state.md updated (iteration 39, phase ACT, unblocked — Docker recovered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
