### PR TITLE
audit: tracker update for erdos-1131-oq-01 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10273,9 +10273,9 @@
       "result": "issues-fixed"
     },
     "erdos-1131-oq-01": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:35Z",
+      "lastAudited": "2026-07-24T12:11:26Z",
       "result": "clean"
     },
     "erdos-1132": {


### PR DESCRIPTION
## Summary
Re-audit of `erdos-1131-oq-01` came back clean — no gallery integrity issues found.

## Verification
- theoremCount (11), definitionCount (3), axiomCount (1), sorries (0), lineCount (293) all match `proofs/Proofs/Erdos1131OQ01.lean`.
- The single axiom (`erdos_1131_variance_conjecture`) is honestly scoped to Part VI's open-conjecture reformulation; the headline theorem `erdos_1131_oq01` is fully proved and does not depend on it.
- annotations.json entity names cross-checked against source (own file + parent `Erdos1131Problem.lean` for imported lemmas) — no phantom references.
- No True stubs, no native_decide, no Mathlib-wrapper masking.

This PR only updates `src/data/proofs/audit-tracker.json` (auditCount + lastAudited + result).

🤖 Generated with [Claude Code](https://claude.com/claude-code)