### PR TITLE
Research: erdos-1215-oq-02 - Iter 10 OQ12 PREP: exact two-component design (sympy-verified certificate)

### DIFF
--- a/research/problems/erdos-1215-oq-02/state.md
+++ b/research/problems/erdos-1215-oq-02/state.md
@@ -4,7 +4,85 @@
 **Phase**: PROVE
 **Path**: full
 **Since**: 2026-07-09T15:40:18-07:00
-**Iteration**: 9
+**Iteration**: 10 (OQ12 PREP — per-petal connectivity design locked, ACT-ready)
+
+## Iter 10 — OQ12 PREP: exact two-path-component structure (researcher-2, 2026-07-24, doc-only)
+
+Design for the next ACT (`CyclotomicPolynomialsOQ02OQ12.lean`): upgrade OQ11's
+disconnection to the EXACT component count — each Cassini petal is
+path-connected (star-shaped about its focus), so `{|(z−a)(z−b)| < C}` has
+exactly two path-components in the separated regime `4C < ‖a−b‖²`.
+
+### Core mathematical content (fully worked, sympy-verified this session)
+
+**Ray monotonicity / star-shapedness.** For `w := z − a`, `c := b − a`,
+`W := ‖w‖`, `D := ‖c‖`, `x := (w * conj c).re`, and `s ∈ [0, 1]` with
+`2W ≤ D`, the Cassini product does not increase toward the focus:
+`‖s•w‖·‖s•w − c‖ ≤ ‖w‖·‖w − c‖`. Squared form is polynomial; certificate:
+
+```
+W²(W²−2x+D²) − s²W²(s²W²−2sx+D²) = W²·[G + 2(1−s³)(WD − x)]   (decomposition)
+G := (1−s⁴)W² − 2WD(1−s³) + (1−s²)D²
+   = (1−s)·(D − W(1+s))·(D(1+s) − W(1+s²))                     (factorization)
+```
+
+All three `G`-factors and `(1−s³)`, `(WD − x)` are ≥ 0 given `0 ≤ s ≤ 1`,
+`2W ≤ D`, Cauchy–Schwarz `x ≤ WD` — so `nlinarith` with product hints
+`mul_nonneg (mul_nonneg h1ms hf1) hf2` and `mul_nonneg h1ms3 hWDx` should
+close the squared inequality. Factor positivity: `D − W(1+s) ≥ D − 2W ≥ 0`;
+`D(1+s) − W(1+s²) ≥ D − 2W ≥ 0` (`W(1+s²) ≤ 2W`, `D ≤ D(1+s)`).
+
+### Lean target statements (new leaf `CyclotomicPolynomialsOQ02OQ12.lean`)
+
+1. `cassini_segment_le {a b z : ℂ} (h : 2*‖z−a‖ ≤ ‖b−a‖) {s : ℝ}
+   (hs0 : 0 ≤ s) (hs1 : s ≤ 1) : ‖(s•(z−a)) * (a + s•(z−a) − b)‖ ≤
+   ‖(z−a)*(z−b)‖` — via the certificate. Note `a + s•(z−a) − b =
+   s•(z−a) − (b−a)` by `ring_nf`; `‖s•w‖ = s*W` by `norm_smul` +
+   `Real.norm_of_nonneg`.
+2. `starConvex_petal` : `StarConvex ℝ a ({z | ‖(z−a)*(z−b)‖ < C} ∩
+   Metric.ball a (Real.sqrt C))` under `4C < ‖a−b‖²` — segment point stays
+   in the ball (`sW ≤ W < √C`) and under the level (`cassini_segment_le`
+   with `2W < 2√C = √(4C) ≤ D`).
+3. `isPathConnected_petal` — from 2 (route A: `StarConvex.isPathConnected`
+   if present in v4.31; route B fallback: explicit `JoinedIn` via the
+   segment path `t ↦ a + t•(z−a)`, continuous affine).
+4. `quadratic_lemniscate_two_path_components {a b C} (hC : 0 < C)
+   (hsep : 4C < ‖a−b‖²) : (∀ z ∈ S, JoinedIn S z a ∨ JoinedIn S z b) ∧
+   ¬ JoinedIn S a b` for `S = {z | ‖(z−a)(z−b)‖ < C}` — cover by OQ11
+   `quadratic_lemniscate_subset_union`; per-petal `JoinedIn` from 3 via
+   `JoinedIn.mono` (petal ⊆ S); negative half from OQ11
+   `sqrt_balls_disjoint` applied to the preconnected range of a putative
+   path (mirror of `not_isPreconnected_quadratic_lemniscate`'s cover
+   argument). b-petal case = a-petal lemma with foci swapped
+   (`mul_comm` inside the norm; `norm_sub_rev` for `‖b−a‖ = ‖a−b‖`).
+5. Specializations n = 3, 4, 6 mirroring OQ11's sections (foci
+   `omega3/omega3'`, `I/−I`, `zeta6/zeta6'`; thresholds `C < 3/4`, `< 1`,
+   `< 3/4`): exactly two path-components sub-threshold.
+
+### v4.31 name-risk list (probe at ACT)
+
+- normSq ↔ norm² bridge: `Complex.sq_abs` / `Complex.normSq_eq_abs` /
+  possibly `Complex.normSq_eq_norm_sq`; expansions `Complex.normSq_sub`,
+  `Complex.normSq_mul`, `Complex.normSq_ofReal`; `Complex.real_smul`.
+- Cauchy–Schwarz step: `Complex.abs_re_le_abs` (may be `…_le_norm`);
+  name-safe fallback: `x² ≤ normSq w * normSq c` from `Complex.normSq_apply`
+  + `sq_nonneg (…).im`, then `x ≤ WD` via `abs_le_abs` on square roots, or
+  feed the squared form to nlinarith.
+- A ≤ B from A² ≤ B² (A,B ≥ 0): avoid `pow_le_pow_iff_left` drift — use
+  `nlinarith [norm_nonneg …, sq_nonneg (A+B)]`.
+- `StarConvex.isPathConnected` existence; `JoinedIn.mono`;
+  `isConnected_range γ.continuous` for the path-range cover argument.
+- Known v4.31: `push_neg` → `push Not at h`; `Set.notMem_empty`.
+
+### Why this rung (and not others)
+
+- Option (a) sharpness (connectivity for `C ≥ (‖a−b‖/2)²`) needs a
+  through-the-neck path construction — genuinely harder, no certificate.
+- Option (c) quartic φ(n)=4 (n=5,8,10,12) needs a 4-focus cover +
+  4-ball disjointness regime — natural AFTER the exact-count template
+  exists at 2 foci.
+- The genuine open driver (C > 1 labyrinth / path-length ≤ C·n) remains
+  blocked ("materially new mechanism required").
 
 ## Current Focus
 Component topology of the lemniscate. Iter 9 (OQ02OQ11) delivered the first

--- a/src/data/research/problems/erdos-1215-oq-02.json
+++ b/src/data/research/problems/erdos-1215-oq-02.json
@@ -29,7 +29,7 @@
   "currentState": {
     "phase": "OBSERVE",
     "since": "2026-07-09T00:00:00Z",
-    "iteration": 2,
+    "iteration": 10,
     "focus": "Session 2026-07-24 (researcher-3, OQ11): first component-topology result — quadratic cyclotomic lemniscates (n=3,4,6, the complete phi(n)=2 case) are disconnected for small C via a general Cassini-oval criterion; cyclotomic_four (X^2+1) proved as a Mathlib-gap byproduct.",
     "blockers": [
       {
@@ -77,7 +77,8 @@
       "v4.31: push_neg is deprecated in favor of push Not at h.",
       "FIRST DISCONNECTION in the family (OQ11): n=3,4,6 are exactly the indices with phi(n)=2, so their lemniscates are Cassini ovals with foci at the two primitive roots. For 4C < |a-b|^2 the set {|z-a||z-b|<C} is covered by the two disjoint focal balls B(a,sqrt C), B(b,sqrt C) (else both factors >= sqrt C forces product >= C), each containing a focus (a root, where |Phi|=0<C) — IsPreconnected applied to this open cover yields a point of the empty intersection. Concretely: disconnected for C<3/4 (n=3,6; foci sqrt3 apart) and C<1 (n=4; foci 2 apart).",
       "The disconnection regime (C < 3/4 resp. 1) and the origin-interior regime (C > 1, OQ07) are disjoint — consistent with the classical Cassini threshold C = (|a-b|/2)^2 below which the oval splits into two petals. For n=1,2 (phi=1, exact disks, OQ01) the sets are always connected: disconnection first appears exactly at degree phi(n)=2, and OQ11 pins that regime.",
-      "v4.31 renames: Set.eq_empty_iff_forall_not_mem -> eq_empty_iff_forall_notMem, Set.not_mem_empty -> Set.notMem_empty. Also cyclotomic_expand_eq_cyclotomic is simp-tagged, so norm_num at h fully normalizes expand 2 Phi_2 to X^2+1 by itself."
+      "v4.31 renames: Set.eq_empty_iff_forall_not_mem -> eq_empty_iff_forall_notMem, Set.not_mem_empty -> Set.notMem_empty. Also cyclotomic_expand_eq_cyclotomic is simp-tagged, so norm_num at h fully normalizes expand 2 Phi_2 to X^2+1 by itself.",
+      "OQ12 PREP (2026-07-24): Cassini petal star-shapedness certificate sympy-verified — squared ray-monotonicity difference = W^2*[G + 2(1-s^3)(WD-x)] with G = (1-s)(D-W(1+s))(D(1+s)-W(1+s^2)); all factors nonneg for 0<=s<=1, 2W<=D, x<=WD (Cauchy-Schwarz). nlinarith product hints pre-computed. Petal path-connectivity => exactly two path-components of the quadratic lemniscate in the 4C<|a-b|^2 regime."
     ],
     "mathlibGaps": [
       "No developed theory of rectifiable paths with arc length in ℂ tied to polynomial sublevel sets.",
@@ -85,10 +86,9 @@
       "cyclotomic 4 has no explicit closed form in Mathlib (cyclotomic_one/_two/_three/_six exist, _four does not); proved locally in OQ11 via cyclotomic_expand_eq_cyclotomic."
     ],
     "nextSteps": [
-      "ASSESSMENT (researcher-2, 2026-07-09): the sharper-radius nextStep is a self-contained but substantial roots-product formalization, NOT a quick gap-fill. Concrete path: IsUnitCirclePolynomial P (P(0)=1, all roots ‖z‖=1) ⟹ |leadingCoeff|=1 (since |P(0)|=|lc|·∏|ζ|=|lc|=1) ⟹ over ℂ (alg-closed, splits) |P(z)|=∏|z−ζ| ≥ (|z|−1)^{deg P} for |z|≥1 (each |z−ζ|≥|z|−1 via norm_sub_norm_le / triangle) ⟹ {|P|<C} with |z|≥1 forces (|z|−1)^{deg}<C ⟹ |z|<1+C^{1/deg}. Needs Polynomial.roots multiset + eq_prod_roots_of_splits / prod_multiset_X_sub_C + Complex.norm product bound (~80-120 lines). R4's OQ-02 bounded-radius base file appears UNMERGED (not on origin/main; main Erdos1215Problem.lean is the 2-axiom Mac Lane parent only). Released without a forced marginal edit.",
-      "Sharpen the radius: true bound is |z| <= 1 + C^{1/phi(n)} from (|z|-1)^{phi(n)}<C; formalize this phi(n)-dependent tighter radius.",
-      "Toward the path-length bound: the sublevel set is compact, so path-length reduces to component geometry; formalize the number of connected components of {|Phi_n|=c}.",
-      "OQ11 delivered the n=3,4,6 disconnection half of the small-n geometry step. Natural follow-ups: (a) SHARPNESS — prove {|Phi_n|<C} connected (even path-connected/star-shaped petal union) for C >= (|a-b|/2)^2 resp. C>1, giving the exact Cassini threshold; (b) exact component COUNT two for the disconnected regime (needs per-petal connectivity, e.g. each petal star-shaped around its focus — false in general for Cassini? check); (c) phi(n)=4 quartic cases n=5,8,10,12 (4 foci, multi-petal)."
+      "OQ12 ACT: CyclotomicPolynomialsOQ02OQ12.lean per Iter-10 PREP in state.md — cassini_segment_le, starConvex_petal, isPathConnected_petal, quadratic_lemniscate_two_path_components, n=3/4/6 specializations (~200 LOC; v4.31 name-risk list in PREP).",
+      "After OQ12: option (c) quartic phi(n)=4 cases n=5,8,10,12 (4-focus cover template).",
+      "Blocked driver unchanged: C>1 labyrinth / path-length <= C*n (materially new mechanism required)."
     ],
     "markdown": "# Knowledge Base: erdos-1215-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nThis is a restriction of Erdős #1215 to cyclotomic polynomials Φ_n, whose roots are the primitive n-th roots of unity. The parent problem was resolved negatively by Mac Lane (1953) using labyrinth polynomials; the question here is whether the rigid, symmetric placement of cyclotomic roots precludes such labyrinths and yields a polynomial-in-n path-length bound.\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Doc-only PREP session for `erdos-1215-oq-02` (quadratic cyclotomic lemniscate topology). Locks the design for the next ACT — `CyclotomicPolynomialsOQ02OQ12.lean` — which upgrades OQ11's disconnection (#43295) to the **exact path-component count**: each Cassini petal is star-shaped about its focus, so `{|(z-a)(z-b)| < C}` has exactly two path-components when `4C < |a-b|^2`.

## Progress

- **Star-shapedness certificate, sympy-verified**: the squared ray-monotonicity difference decomposes as `W^2*[G + 2(1-s^3)(WD - x)]` with `G = (1-s)(D - W(1+s))(D(1+s) - W(1+s^2))` — every factor nonnegative for `0 <= s <= 1`, `2W <= D`, `x <= WD`. The `nlinarith` product hints are pre-computed, so the core lemma should be a one-shot.
- Full ACT statement plan (5 targets, ~200 LOC) recorded in `state.md`: `cassini_segment_le`, `starConvex_petal`, `isPathConnected_petal`, `quadratic_lemniscate_two_path_components`, and n = 3, 4, 6 specializations reusing OQ11's cover/disjointness engine verbatim.
- v4.31 name-risk list recorded (Complex.normSq bridges, Cauchy-Schwarz spelling, `StarConvex.isPathConnected` availability) with name-safe fallbacks for each.

## Files Modified

- `research/problems/erdos-1215-oq-02/state.md` (Iter 10 PREP entry)
- `src/data/research/problems/erdos-1215-oq-02.json` (insight + nextSteps, iteration 10)

## Status

**Outcome**: surveyed (doc-only PREP; no Lean edits)
**Next Steps**: OQ12 ACT per the PREP; then quartic phi(n)=4 cases (n=5,8,10,12). The genuine open driver (C>1 labyrinth / path-length) remains blocked, "materially new mechanism required".

🤖 Generated by researcher-2 with [Claude Code](https://claude.com/claude-code)
