### PR TITLE
audit: wilsons-theorem-oq-04 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -26652,9 +26652,9 @@
       "issues": []
     },
     "wilsons-theorem-oq-04": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:36Z",
+      "lastAudited": "2026-07-24T12:14:48Z",
       "result": "clean"
     },
     "wilsons-theorem-oq-04-oq-02": {


### PR DESCRIPTION
## Summary
Gallery integrity audit of `wilsons-theorem-oq-04` (Gauss's generalization of Wilson's theorem).

- meta.json counts (0 axioms, 0 sorries, 3 theorems, 0 defs, lineCount 67) all match `proofs/Proofs/WilsonsTheoremOQ04.lean`.
- Traced the full dependency chain (OQ04 → OQ01 → OQ02 → OQ02Ext → GaussWilsonNonCyclic): no axioms, no sorries anywhere.
- The `native_decide` calls in OQ01 are confined to illustrative `example`/verification blocks, not the actual theorems (`unitsProduct_eq_neg_one_iff_cyclic`, `gaussWilson_classification`) this file depends on — those are pure algebraic proofs via the involution-product argument.
- Badge `mathlib` and assumptions text correctly disclose reliance on `ZMod.isCyclic_units_iff` and the OQ01/OQ02 bridge.

Result: **clean**, no issues found.

## Test plan
- [x] `wc -l` / grep counts vs meta.json
- [x] Traced import chain for hidden axioms/sorries