### PR TITLE
Audit: szemeredi-hypergraph-core — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -26011,9 +26011,9 @@
       "result": "clean"
     },
     "szemeredi-hypergraph-core": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:36Z",
+      "lastAudited": "2026-07-24T12:20:02Z",
       "result": "clean"
     },
     "szemeredi-hypergraph-core-oq-01": {


### PR DESCRIPTION
## Audit result: clean

Verified `szemeredi-hypergraph-core` against `Proofs/SzemerediHypergraphCore.lean`:

- sorries: 0 (matches)
- axioms: 0 (matches, no `axiom` declarations)
- theoremCount: 4 (matches — edgeCount_empty, kPartiteDensity_nonneg, kPartiteDensity_le_one, kPartiteDensity_empty)
- definitionCount: 7 (matches — 1 structure + 6 defs: edgeCount, empty, transversals, kPartiteDensity, IsHypergraphRegular, fromSimpleGraph)
- mathlibDependencies (Finset.powerset, SimpleGraph, Fintype) all genuinely referenced in source
- No True stubs, no native_decide
- crossReferences (szemeredi-core, szemeredi-regularity, szemeredi-counting) all resolve to real gallery entries
- Badge "original" + "infrastructure" tag is consistent with sibling szemeredi-core convention

No issues found. Updates audit-tracker.json only.

---
Discovered during gallery integrity audit.