### PR TITLE
Audit: sylow-theorems-oq-04 — issues found (#43348)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25909,10 +25909,10 @@
       "result": "clean"
     },
     "sylow-theorems-oq-04": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:36Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T12:25:22Z",
+      "result": "issues-found"
     },
     "sylow-theorems-oq-05": {
       "auditCount": 1,


### PR DESCRIPTION
## Summary
- Tracker update: sylow-theorems-oq-04 audited, result issues-found (auditCount 3→4).
- Filed #43348: annotations.json narrates a proof technique the file's own comments say it doesn't use (stale after the rewrite that expanded the file to 498 lines) — see issue for details.

Discovered during gallery integrity audit.