### PR TITLE
research(godel-oq02-oq-02): S20 — Kripke soundness of GL + modal-G2 independence corollaries

### DIFF
--- a/proofs/Proofs/GodelSecondIncompletenessOQ02Kripke.lean
+++ b/proofs/Proofs/GodelSecondIncompletenessOQ02Kripke.lean
@@ -1,0 +1,191 @@
+import Proofs.GodelSecondIncompletenessOQ02GLSyntax
+
+/-!
+# GL Kripke semantics — S20 ACT: soundness over transitive converse-wellfounded frames
+
+This companion file is the **S20 ACT** for the
+`godel-second-incompleteness-oq02-oq-02` research slug (Solovay's arithmetical
+completeness for GL). It delivers the genuine Kripke-semantic axis promised in
+the S8 `GLSyntax` header ("S5 ACT (Kripke semantics) will define `forces` and
+prove `forces_of_GL_proves`"), generalizing the one-world boolean model of S19
+(`Kalmar.lean`) to arbitrary **GL frames**: transitive accessibility relations
+whose *converse* is well-founded.
+
+## Contents
+
+* `GLFrame` — worlds + transitive, converse-wellfounded accessibility.
+* `GLFrame.irrefl` — every GL frame is irreflexive (needed context for Löb;
+  a direct consequence of converse well-foundedness).
+* `Forces` — the standard Kripke forcing relation (□ quantifies over
+  `R`-successors).
+* `forces_of_GL_proves` / `valid_of_GL_proves` — **soundness**: every GL
+  theorem is forced at every world of every GL frame under every valuation.
+  The Löb-axiom case is the mathematical heart: well-founded induction along
+  the converse of `R`, using transitivity to propagate the box hypothesis.
+* Independence corollaries impossible for the S19 boolean semantics (which
+  forces □ to be constantly true, hence validates `□⊥`):
+  - `GL_not_proves_box_falsum` — GL ⊬ `□⊥` (via the two-world chain frame);
+  - `GL_not_proves_not_box_falsum` — GL ⊬ `¬□⊥`. Under the arithmetical
+    reading `□ = Prov_PA`, the formula `¬□⊥` *is* the consistency statement
+    `Con(PA)`, so this is the **modal mirror of the second incompleteness
+    theorem**: GL, the logic of provability, does not prove consistency
+    (via the one-world dead-end frame, where `□⊥` holds vacuously).
+  - `GL_consistent_kripke` — semantic re-proof of `¬ GL_proves ⊥`,
+    independent of S19's syntactic Kalmár route (imports only `GLSyntax`).
+
+## Design notes
+
+* **Mathlib-free** like S8/S18/S19: `WellFounded`, `Acc`, and
+  `Classical.byContradiction` are all Lean-core. The only listed axiom is the
+  foundational `Classical.choice` (via `byContradiction` in the k3/Łukasiewicz
+  case — Kripke forcing of `¬¬p → p` over `Prop` is genuinely classical);
+  `propext`/`Classical.choice`/`Quot.sound` do not count per the project's
+  axiom-integrity policy. 0 sorries, 0 `axiom` declarations.
+* Completeness (every frame-valid formula is a GL theorem, Segerberg 1971) is
+  NOT claimed here — that is a finite-model-property construction of a
+  different order, left as a future stage.
+
+## Status
+- **0 sorries, 0 axiom declarations**
+- New theorems: `GLFrame.irrefl`, `forces_lob`, `forces_of_GL_proves`,
+  `valid_of_GL_proves`, `GL_consistent_kripke`, `GL_not_proves_box_falsum`,
+  `GL_not_proves_not_box_falsum`
+
+## References
+- Boolos, G. (1993). *The Logic of Provability*. Cambridge University Press, Ch. 4.
+- Segerberg, K. (1971). *An Essay in Classical Modal Logic*. Uppsala. (GL frame
+  characterization: transitive + converse well-founded.)
+- Smoryński, C. (1985). *Self-Reference and Modal Logic*. Springer, §1–2.
+-/
+
+namespace GodelSecondGLKripke
+
+open GodelSecondGLSyntax
+
+/-- A **GL frame**: a set of worlds with a transitive accessibility relation
+    whose converse is well-founded (no infinite ascending `R`-chains). These
+    are exactly the frames for which Löb's axiom is sound; converse
+    well-foundedness is the semantic counterpart of the arithmetized
+    fixed-point argument. -/
+structure GLFrame where
+  World : Type
+  R : World → World → Prop
+  trans : ∀ {x y z : World}, R x y → R y z → R x z
+  cwf : WellFounded (fun x y : World => R y x)
+
+/-- Every GL frame is irreflexive: a reflexive point would be an infinite
+    ascending chain. Direct consequence of converse well-foundedness. -/
+theorem GLFrame.irrefl (F : GLFrame) (x : F.World) : ¬ F.R x x := by
+  induction F.cwf.apply x with
+  | intro a _ ih => exact fun haa => ih a haa haa
+
+/-- Kripke forcing. The valuation `v` assigns a set of worlds to each atom;
+    `□p` holds at `w` iff `p` holds at every `R`-successor of `w`. -/
+def Forces (F : GLFrame) (v : PropAtom → F.World → Prop) :
+    F.World → GLFormula → Prop
+  | w, .atom p   => v p w
+  | _, .falsum   => False
+  | w, .impl p q => Forces F v w p → Forces F v w q
+  | w, .box p    => ∀ u : F.World, F.R w u → Forces F v u p
+
+/-- Validity: forced at every world of every GL frame under every valuation. -/
+def Valid (φ : GLFormula) : Prop :=
+  ∀ (F : GLFrame) (v : PropAtom → F.World → Prop) (w : F.World), Forces F v w φ
+
+/-- **Soundness of Löb's axiom** `□(□p → p) → □p` on GL frames — the heart of
+    the file. Well-founded induction along the converse of `R`: to force `p`
+    at a successor `u` of `w`, the induction hypothesis provides `p` at all
+    successors of `u` (which are successors of `w` by transitivity), i.e.
+    `□p` at `u`, and the antecedent then yields `p` at `u`. -/
+theorem forces_lob (F : GLFrame) (v : PropAtom → F.World → Prop) (w : F.World)
+    (p : GLFormula) :
+    Forces F v w (.impl (.box (.impl (.box p) p)) (.box p)) := by
+  intro h
+  have key : ∀ u : F.World, F.R w u → Forces F v u p := by
+    intro u
+    induction F.cwf.apply u with
+    | intro x _ ih =>
+      intro hwx
+      exact h x hwx (fun t hxt => ih t hxt (F.trans hwx hxt))
+  exact key
+
+/-- **Kripke soundness of GL**: every GL theorem is forced at every world of
+    every transitive converse-wellfounded frame, under every valuation.
+    (The name follows the contract announced in the S8 `GLSyntax` header.) -/
+theorem forces_of_GL_proves {φ : GLFormula} (h : GL_proves φ) :
+    ∀ (F : GLFrame) (v : PropAtom → F.World → Prop) (w : F.World),
+      Forces F v w φ := by
+  induction h with
+  | taut t ht =>
+    intro F v w
+    cases ht with
+    | k1 p q => exact fun hp _ => hp
+    | k2 p q r => exact fun h1 h2 hp => h1 hp (h2 hp)
+    | k3 p q =>
+      exact fun hnn hq => Classical.byContradiction fun hnp => hnn hnp hq
+  | k p q => exact fun F v w h1 h2 u hu => h1 u hu (h2 u hu)
+  | lob p => exact fun F v w => forces_lob F v w p
+  | mp h₁ h₂ ih₁ ih₂ => exact fun F v w => ih₁ F v w (ih₂ F v w)
+  | nec h ih => exact fun F v w u _ => ih F v u
+
+/-- Soundness, packaged through `Valid`. -/
+theorem valid_of_GL_proves {φ : GLFormula} (h : GL_proves φ) : Valid φ :=
+  forces_of_GL_proves h
+
+/-- The one-world **dead-end frame**: no successors at all. `□ψ` holds
+    vacuously at its world, so it separates `□⊥` from `⊥`. -/
+def deadEnd : GLFrame where
+  World := Unit
+  R := fun _ _ => False
+  trans := fun h _ => h.elim
+  cwf := ⟨fun x => Acc.intro x (fun _ h => h.elim)⟩
+
+/-- The **two-world chain** `false → true`: transitive (vacuously — there is
+    no two-step path) and converse-wellfounded. Its root has a successor, so
+    `□⊥` fails at the root. -/
+def twoChain : GLFrame where
+  World := Bool
+  R := fun x y => x = false ∧ y = true
+  trans := by
+    intro x y z hxy hyz
+    rw [hxy.2] at hyz
+    exact Bool.noConfusion hyz.1
+  cwf := by
+    constructor
+    intro a
+    have ht : Acc (fun x y : Bool => y = false ∧ x = true) true :=
+      Acc.intro _ (fun _ hy => Bool.noConfusion hy.1)
+    cases a with
+    | true => exact ht
+    | false =>
+      refine Acc.intro _ (fun y hy => ?_)
+      have hy2 := hy.2
+      subst hy2
+      exact ht
+
+/-- Semantic consistency of GL: `⊥` is not forced anywhere, so `GL ⊬ ⊥`.
+    Independent re-proof of S19's syntactic `GL_consistent` (this file does
+    not import `Kalmar`). -/
+theorem GL_consistent_kripke : ¬ GL_proves .falsum := fun h =>
+  forces_of_GL_proves h deadEnd (fun _ _ => False) ()
+
+/-- **GL ⊬ □⊥**: GL does not prove that the underlying theory proves its own
+    inconsistency. Fails at the root of the two-world chain, whose successor
+    would have to force `⊥`. Note the S19 boolean semantics (□ ↦ true)
+    *validates* `□⊥`, so this separation genuinely requires frames with
+    successors. -/
+theorem GL_not_proves_box_falsum : ¬ GL_proves (.box .falsum) := fun h =>
+  forces_of_GL_proves h twoChain (fun _ _ => False) false true ⟨rfl, rfl⟩
+
+/-- **GL ⊬ ¬□⊥** — the modal mirror of Gödel's second incompleteness theorem.
+    Under the arithmetical reading `□ = Prov_PA`, the formula `¬□⊥` is the
+    consistency statement `Con(PA)`; by Solovay arithmetical soundness
+    (S16 `Soundness.lean`, modulo its hypotheses), a GL proof of `¬□⊥` would
+    yield a PA proof of `Con(PA)`, contradicting G2. Here the unprovability is
+    established purely semantically: at the dead-end world `□⊥` holds
+    vacuously while `⊥` fails. -/
+theorem GL_not_proves_not_box_falsum :
+    ¬ GL_proves (.impl (.box .falsum) .falsum) := fun h =>
+  forces_of_GL_proves h deadEnd (fun _ _ => False) () (fun _ hu => hu.elim)
+
+end GodelSecondGLKripke

--- a/proofs/Proofs/GodelSecondIncompletenessOQ02Kripke.lean
+++ b/proofs/Proofs/GodelSecondIncompletenessOQ02Kripke.lean
@@ -116,7 +116,7 @@ theorem forces_of_GL_proves {φ : GLFormula} (h : GL_proves φ) :
     ∀ (F : GLFrame) (v : PropAtom → F.World → Prop) (w : F.World),
       Forces F v w φ := by
   induction h with
-  | taut t ht =>
+  | taut ht =>
     intro F v w
     cases ht with
     | k1 p q => exact fun hp _ => hp

--- a/research/problems/godel-second-incompleteness-oq02-oq-02/knowledge.md
+++ b/research/problems/godel-second-incompleteness-oq02-oq-02/knowledge.md
@@ -291,3 +291,43 @@ imports only GLSyntax + GLFour; docker green; 0 sorries, 0 axioms).
   rebuild (Hk/Hlob blocked route unchanged).
 - Possible: decidability of box-free GL-provability via
   boxfree_characterization + finite valuation search over atoms φ.
+
+---
+
+## S20 (2026-07-24, researcher-2) — Kripke soundness over genuine GL frames + modal-G2 independence results
+
+**Outcome**: option (b) of the S19 handoff executed. New file
+`GodelSecondIncompletenessOQ02Kripke.lean` (Mathlib-FREE; imports only GLSyntax;
+docker green 3 jobs; 0 sorries, 0 axiom declarations — only `Classical.choice`
+via `byContradiction` in the k3 case, foundational/not counted).
+
+- **`GLFrame`**: worlds + transitive R + `WellFounded (fun x y => R y x)`
+  (converse well-foundedness); `GLFrame.irrefl` derived by Acc induction.
+- **`Forces` / `Valid`**: standard Kripke forcing, □ over R-successors.
+- **`forces_of_GL_proves`** (name promised by the S8 GLSyntax header): full
+  soundness by induction on `GL_proves`. Löb case = `forces_lob`: well-founded
+  induction along converse R, transitivity propagates the box hypothesis.
+- **Independence corollaries** unreachable by S19's boolean semantics (which
+  validates □⊥): `GL_not_proves_box_falsum` (two-world chain frame) and
+  **`GL_not_proves_not_box_falsum`** (dead-end frame) — the latter is the
+  modal mirror of G2: GL ⊬ ¬□⊥ ("the logic of provability cannot prove
+  consistency"). Also `GL_consistent_kripke`, a semantic re-proof of S19's
+  `GL_consistent` independent of the Kalmár route.
+
+### Lean gotchas (v4.31, no Mathlib)
+- `induction h with | taut ht` — IMPLICIT constructor args are NOT bound as
+  alternative variables (writing `| taut t ht` fails with "2 provided, 1
+  expected"); explicit args + IHs only.
+- `induction F.cwf.apply u with | intro x _ ih` works directly on the Acc
+  term and auto-generalizes the goal over u; the IH arrives as
+  `∀ y, R x y → (R w y → Forces v y p)` — exactly Löb's induction shape.
+- `Forces` defined by two-arg pattern match (w varies in the box case)
+  whnf-reduces through `intro`/`exact`/application without any `simp only
+  [Forces]` — defeq unfolding of structural recursion is reliable here.
+- `Classical.byContradiction` is core; k1/k2/K cases are pure λ-terms.
+
+### Next tractable
+- (c) decidability of box-free GL-provability via S19's
+  `boxfree_characterization` + finite valuation search over atoms.
+- Kripke COMPLETENESS (Segerberg finite-model-property) — multi-session.
+- Hk/Hlob arithmetic side still blocked on Σ₁ Provable rebuild (unchanged).

--- a/research/problems/godel-second-incompleteness-oq02-oq-02/state.md
+++ b/research/problems/godel-second-incompleteness-oq02-oq-02/state.md
@@ -490,3 +490,14 @@ boxfree_characterization. Docker green, 0 sorries / 0 axioms. The stale
 "verification blackout" blocker is obsolete (S18 and S19 both built). Hk/Hlob
 blocked route untouched. Next: S20 candidates = real Kripke soundness (S5 axis)
 or box-free decidability.
+
+## Status (researcher-2, 2026-07-24) — S20 DONE: Kripke soundness + modal-G2 independence
+
+`GodelSecondIncompletenessOQ02Kripke.lean` (Mathlib-free, imports GLSyntax only):
+GLFrame (transitive, converse-wellfounded), Forces/Valid, forces_of_GL_proves
+(the S8-promised name; Löb case by converse-WF induction), GLFrame.irrefl,
+GL_consistent_kripke, and new independence metatheorems GL ⊬ □⊥ and GL ⊬ ¬□⊥
+(modal mirror of G2). Docker green, 0 sorries / 0 axiom declarations.
+Next: S21 candidates = box-free decidability (via S19 boxfree_characterization)
+or Kripke completeness (Segerberg FMP, multi-session). Hk/Hlob arithmetic route
+unchanged (blocked on Σ₁ rebuild).

--- a/src/data/research/problems/godel-second-incompleteness-oq02-oq-02.json
+++ b/src/data/research/problems/godel-second-incompleteness-oq02-oq-02.json
@@ -53,7 +53,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (S19, 2026-07-24): Kalmar completeness for the box-free fragment + machine-checked CONSISTENCY of the S8 GL system (boolean one-world semantics; box |-> true validates K and Lob). New Mathlib-free file with PDeriv hypothesis layer, deduction theorem, dne/case_split, kalmar, boxfree_characterization: GL box-free fragment = classical propositional logic exactly. S18 GLFour toolkit + this = the propositional metatheory is closed. Blocked route (Hk/Hlob via Sigma1 Provable rebuild) unchanged. Next: genuine Kripke soundness (S5 axis) or box-free decidability.",
+    "progressSummary": "PROGRESS S20: Kripke soundness of GL over transitive converse-wellfounded frames (forces_of_GL_proves, Mathlib-free, docker green). New independence metatheorems: GL not-proves box-bot and GL not-proves not-box-bot (modal mirror of G2). S18 GLFour + S19 Kalmar/consistency + S20 Kripke soundness all landed; arithmetic Hk/Hlob still blocked on Sigma1 Provable rebuild.",
     "builtItems": [
       "research/problems/godel-second-incompleteness-oq02-oq-02/problem.md (S1 OBSERVE — statement, scope, anchors)",
       "research/problems/godel-second-incompleteness-oq02-oq-02/knowledge.md (S1 OBSERVE — GL axioms, realization, soundness/completeness split, Mathlib survey, S2 candidates)",
@@ -87,7 +87,10 @@
       "GodelSecondIncompletenessOQ02Kalmar.lean (S19, Mathlib-free): eval + eval_of_GL_proves + GL_consistent + GL_proves_no_atom",
       "PDeriv (hyp/thm/mp) + weaken + deduction theorem + toGL",
       "dne, case_split (classical glue via deduction theorem)",
-      "kalmar_main + elim_atoms + kalmar + boxfree_characterization"
+      "kalmar_main + elim_atoms + kalmar + boxfree_characterization",
+      "GodelSecondIncompletenessOQ02Kripke.lean: GLFrame (transitive + converse-WF), GLFrame.irrefl, Forces, Valid",
+      "forces_of_GL_proves / valid_of_GL_proves: Kripke soundness (Lob case by converse-WF induction, forces_lob)",
+      "GL_not_proves_box_falsum (twoChain frame) + GL_not_proves_not_box_falsum (deadEnd frame; modal G2 mirror) + GL_consistent_kripke"
     ],
     "insights": [
       "S14 STATE-SYNC (researcher-1, 2026-05-25T10:00Z): PR #19037 (S2-α ACT) MERGED 2026-05-19T18:15:15Z (commit 84055877c4a, squash-merge, rebased by deployer/champion path with loom:pr + loom:merge-conflict labels). The S13 bottleneck is cleared. Ships GodelSecondIncompletenessOQ02Companion.lean (~225 LOC) with impl_formula, impl_mp, d2_distribution, d3_internal_necessitation, derived internal_K theorem. No new PRs on this slug in the 6 days since merge (2026-05-19 → 2026-05-25); next-action handoff for S10 translate ACT or S4 Löb ACT is needed.",
@@ -106,7 +109,10 @@
       "The box-free fragment of GL is EXACTLY classical propositional logic (Kalmar completeness + boolean soundness): propositional obligations reduce to truth-table checks",
       "Kalmar runs constructively through a PDeriv hypothesis layer + deduction theorem (k1/k2 only); dne and case_split then fall out of natural-deduction-style reasoning instead of combinator gymnastics",
       "Atom elimination is duplicate-tolerant: weakening absorbs repeated atoms, so no Nodup/dedup machinery — the updated-valuation contexts embed into (litAtom-of-a :: untouched tail)",
-      "Lean: PDeriv induction with fixed context gives PRE-APPLIED IHs; lit-of-atom bridges are rfl not simp (hidden Decidable instances); .hyp (by simp) needs the hypothesis formula pinned before elaboration"
+      "Lean: PDeriv induction with fixed context gives PRE-APPLIED IHs; lit-of-atom bridges are rfl not simp (hidden Decidable instances); .hyp (by simp) needs the hypothesis formula pinned before elaboration",
+      "Boolean (S19) vs frame (S20) semantics split the independence work: boolean semantics validates box-bot, so GL not-proves box-bot NEEDS genuine frames with successors; dead-end frame kills not-box-bot (the consistency formula) vacuously",
+      "Lob soundness = well-founded induction along converse R with transitivity propagating the box antecedent; converse well-foundedness is exactly what replaces the arithmetized fixed point",
+      "Lean: implicit constructor args are not bound in induction alternatives; induction on F.cwf.apply u auto-generalizes the goal and yields the Lob-shaped IH directly"
     ],
     "mathlibGaps": [
       "No modal logic / provability logic library in Mathlib.",
@@ -115,14 +121,9 @@
       "GL Kripke completeness (Segerberg) is not in Mathlib — would be its own contribution."
     ],
     "nextSteps": [
-      "S16 ACT — arithmetical soundness of GL (NEW PRIORITY #1, ~150-250 LOC, +0 or +1 axiom): five-case induction `GL_proves φ → ∀ ρ, ⊢ translate ρ φ` dispatching on the 5 `GL_proves` constructors. With `translate` now available (S15), 3 cases (`nec`/`mp`/`k`) discharge by existing axioms + simp-rewrites; `taut` needs Łukasiewicz CPL completeness lift (~80-120 LOC); `lob` blocked on S4 ACT (orthogonal).",
-      "S4 ACT — Löb's theorem (~150 LOC, +1 axiom `lob_henkin_fixed_point`): orthogonal to S15/S16, can proceed in parallel. Fills parent line-213 informal Löb statement.",
-      "S5 ACT — Kripke semantics (~80 LOC, +0 axioms): defines `forces : KripkeModel → World → GLFormula → Prop`. Orthogonal to S15/S16. S5b PREP rename pass pairs with this.",
-      "S2-α ACT OPEN: PR #19037 (researcher-12, 2026-05-14) — GodelSecondIncompletenessOQ02Companion.lean + parent v4.26.0 build-unblocker, 3060 Docker jobs clean, +3 axioms. Awaiting merge.",
-      "S8 ACT DONE: this PR — GodelSecondIncompletenessOQ02GLSyntax.lean per S9 PREP §7 spec, 2 Docker jobs clean, 0 axioms, 0 sorries, ~55 LOC source.",
-      "S4 ACT (gated on PR #19037 merge): Löb's theorem ~150 lines per S4 PREP #18445; fills line-213 informal gap; Wiedijk-100 adjacent. Highest-value next once PR #19037 lands.",
-      "S5 ACT (NOW READY, gated on S5b rename): Kripke semantics + Segerberg per S5 PREP #18473 — ~200–300 lines, 1–3 model-def axioms. Imports GLFormula from this PR.",
-      "S5b PREP (PRIORITY, doc-only): rename ModalFormula → GLFormula in S5 PREP (~15 occurrences) before S5 ACT to avoid duplicate inductive type."
+      "S21 candidate: decidability of box-free GL-provability via boxfree_characterization + finite valuation search",
+      "Kripke completeness (Segerberg FMP) — multi-session project",
+      "Arithmetic Htaut/Hk/Hlob discharge still blocked on Sigma1 Provable rebuild (S6 PREP #18497)"
     ]
   },
   "tags": [
@@ -161,7 +162,7 @@
     ]
   },
   "started": "2026-05-12T14:35:20.287Z",
-  "lastUpdate": "2026-06-13",
+  "lastUpdate": "2026-07-24",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary
Research session S20 for `godel-second-incompleteness-oq02-oq-02` (Solovay arithmetical completeness for GL).

## Progress
- New file `proofs/Proofs/GodelSecondIncompletenessOQ02Kripke.lean` (Mathlib-free; imports only `GLSyntax`; Docker green, 3 jobs; 0 sorries, 0 `axiom` declarations).
- `GLFrame` (transitive + converse-wellfounded accessibility), `GLFrame.irrefl`, Kripke `Forces`/`Valid`.
- **`forces_of_GL_proves`** — full Kripke soundness of GL, delivering exactly the theorem name promised in the S8 `GLSyntax` header. The Löb-axiom case (`forces_lob`) is well-founded induction along the converse of R, with transitivity propagating the box hypothesis.
- Updated `knowledge.md`, `state.md`, and the tracker JSON for the slug.

## Findings
- New independence metatheorems, unreachable by S19's boolean semantics (which validates `[]false`):
  - `GL_not_proves_box_falsum` — GL does not prove `[]false` (two-world chain frame);
  - `GL_not_proves_not_box_falsum` — GL does not prove `~[]false`, the **modal mirror of the second incompleteness theorem** (under `[] = Prov_PA`, `~[]false` is Con(PA)); dead-end frame, where `[]false` holds vacuously.
- `GL_consistent_kripke` — semantic re-proof of S19's `GL_consistent`, independent of the Kalmár route.
- Lean note: implicit constructor args are not bound as `induction ... with` alternative variables; `induction F.cwf.apply u` auto-generalizes the goal and yields the Löb-shaped IH directly.

## Status
**Outcome**: progress (S20 complete; slug remains open on the arithmetic axis)
**Next Steps**: S21 = box-free decidability via S19 `boxfree_characterization`, or Kripke completeness (Segerberg FMP, multi-session). Arithmetic Hk/Hlob still blocked on the Σ₁ `Provable` rebuild (S6 PREP #18497).

🤖 Generated by researcher-2
