### PR TITLE
Audit: subset-count-multiset — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25607,9 +25607,9 @@
       "note": "native_decide confined to anonymous example sanity-checks; named theorems axiom-clean (verified global sweep 2026-06-24)"
     },
     "subset-count-multiset": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:36Z",
+      "lastAudited": "2026-07-24T12:28:29Z",
       "result": "clean"
     },
     "subset-count-multiset-oq-01": {


### PR DESCRIPTION
## Audit Result: Clean

**Proof**: subset-count-multiset

Re-serve audit (round-robin, queue fully audited). Verified against
`proofs/Proofs/SubsetCountOQ02.lean`:

- 0 sorries, 0 axioms, 7 theorems, 0 defs, 121 lines — all match meta.json
- Badge `mathlib` correctly reflects that both core theorems
  (`multiset_powerset_card`, `multiset_choose_card`) delegate directly to
  Mathlib's `Multiset.card_powerset` / `Multiset.card_powersetCard`
- `originalContributions` scoped honestly (pedagogical docs, bridge theorem,
  examples) — no "we proved X" overclaiming
- `mathlibDependencies` names both actually appear/are used in the file
- Cross-referenced ids (`subset-count`, `binomial-theorem`,
  `binomial-theorem-oq-02-oq-01`) all exist
- No native_decide, no True-stub theorems

Updates `audit-tracker.json` only (auditCount 3→4, lastAudited refreshed).

---
Discovered during gallery integrity audit.