### PR TITLE
Fix: correct sylow-theorems-oq-04 annotations to match actual proof technique

### DIFF
--- a/src/data/proofs/sylow-theorems-oq-04/annotations.json
+++ b/src/data/proofs/sylow-theorems-oq-04/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "sylow-theorems-oq-04",
     "range": {
       "startLine": 40,
-      "endLine": 50
+      "endLine": 48
     },
     "type": "definition",
     "title": "Defining A₅ and Computing Its Order",
@@ -27,13 +27,13 @@
     "id": "ann-sylow-constraints",
     "proofId": "sylow-theorems-oq-04",
     "range": {
-      "startLine": 73,
-      "endLine": 97
+      "startLine": 77,
+      "endLine": 102
     },
     "type": "insight",
     "title": "Sylow III Constrains All Three Primes",
     "content": "Sylow III gives two constraints for each prime p dividing 60: n_p ≡ 1 (mod p) and n_p divides the index [A₅ : P_p]. These are Mathlib's card_sylow_modEq_one and card_sylow_dvd_index applied to A₅.",
-    "mathContext": "For p=2: n₂ ≡ 1 (mod 2) and n₂ | 15, so n₂ ∈ {1, 3, 5, 15}. For p=3: n₃ ≡ 1 (mod 3) and n₃ | 20, so n₃ ∈ {1, 4, 10}. For p=5: n₅ ≡ 1 (mod 5) and n₅ | 12, so n₅ ∈ {1, 6}. The exact values (5, 10, 6) are determined by native_decide in the next section.",
+    "mathContext": "For p=2: n₂ ≡ 1 (mod 2) and n₂ | 15, so n₂ ∈ {1, 3, 5, 15}. For p=3: n₃ ≡ 1 (mod 3) and n₃ | 20, so n₃ ∈ {1, 4, 10}. For p=5: n₅ ≡ 1 (mod 5) and n₅ | 12, so n₅ ∈ {1, 6}. The exact values (5, 10, 6) are determined in the next section by constructing explicit Sylow subgroups and computing their normalizer indices.",
     "significance": "key",
     "relatedConcepts": [
       "card_sylow_modEq_one",
@@ -51,55 +51,58 @@
     "id": "ann-exact-sylow-numbers",
     "proofId": "sylow-theorems-oq-04",
     "range": {
-      "startLine": 111,
-      "endLine": 117
+      "startLine": 115,
+      "endLine": 190
     },
     "type": "insight",
-    "title": "Exact Sylow Numbers via native_decide",
-    "content": "The exact Sylow numbers n₂ = 5, n₃ = 10, n₅ = 6 are computed by native_decide, which exhaustively enumerates all Sylow p-subgroups of A₅. The 5 Sylow 2-subgroups are Klein 4-groups V₄ ≅ ℤ/2 × ℤ/2; the 10 Sylow 3-subgroups are cyclic ⟨(ijk)⟩; the 6 Sylow 5-subgroups are cyclic ⟨(ijklm)⟩.",
-    "mathContext": "native_decide evaluates Fintype.card (Sylow p A5) by computing the number of Sylow p-subgroups as a Fintype. This requires the Fintype instance for Sylow p G, which Mathlib provides via the orbit-stabilizer theorem.",
+    "title": "Exact Sylow Numbers via Explicit Subgroups and Normalizer Index",
+    "content": "The exact Sylow numbers n₂ = 5, n₃ = 10, n₅ = 6 are established by constructing, for each prime p ∈ {2,3,5}, an explicit Sylow p-subgroup of A₅ from concrete permutations — the Klein 4-group H₂ = {1, (01)(23), (02)(13), (01)(23)·(02)(13)} for p = 2, the cyclic ⟨(0 1 2)⟩ for p = 3, and the cyclic ⟨finRotate 5⟩ for p = 5 — then computing each subgroup's normalizer as a literal Finset and applying Lagrange's theorem to get n_p = [A₅ : N(Sₚ)]. The normalizers have orders 12, 6, 10, giving indices 5, 10, 6 respectively.",
+    "mathContext": "native_decide is applied only to Finset-level facts (e.g. card_NF5, card_Fin5) — never directly to Fintype.card (Sylow p A5), because the ambient Fintype (Sylow p A5) instance factors through the noncomputable SetLike.instFintype and so Sylow p A5 is not directly enumerable. Instead each explicit subgroup Sₚ is built by hand via Sylow.ofCard, its normalizer is computed as an explicit Finset, and Sylow.card_eq_index_normalizer together with Subgroup.card_mul_index (Lagrange) recover Nat.card (Sylow p A5) = [A₅ : N_{A₅}(Sₚ)].",
     "significance": "key",
     "relatedConcepts": [
-      "native_decide",
-      "Fintype.card",
-      "Sylow p-subgroup enumeration",
-      "Klein 4-group"
+      "Sylow.card_eq_index_normalizer",
+      "Subgroup.card_mul_index",
+      "Sylow.ofCard",
+      "explicit normalizer Finset",
+      "native_decide"
     ],
     "prerequisites": [
       "Sylow III constraints from previous section",
-      "computational decidability in Lean"
+      "Lagrange's theorem",
+      "normalizer of a subgroup"
     ]
   },
   {
     "id": "ann-non-normality",
     "proofId": "sylow-theorems-oq-04",
     "range": {
-      "startLine": 134,
-      "endLine": 152
+      "startLine": 338,
+      "endLine": 377
     },
     "type": "insight",
-    "title": "No Sylow Subgroup is Normal: Clean Contradiction",
-    "content": "The proof of non-normality uses a clean contradiction: if a Sylow p-subgroup P were normal, Sylow.unique_of_normal would give Unique (Sylow p A5), forcing Fintype.card = 1. But we computed n₂ = 5, n₃ = 10, n₅ = 6 — contradiction.",
-    "mathContext": "The key Mathlib lemma is Sylow.unique_of_normal: a normal Sylow p-subgroup is the unique Sylow p-subgroup (all conjugates of a normal subgroup equal itself). Uniqueness then forces Fintype.card (Sylow p G) = 1 via Fintype.card_unique.",
+    "title": "No Sylow Subgroup is Normal: via Simplicity",
+    "content": "Non-normality follows directly from the simplicity of A₅, independently of the exact counts n₂/n₃/n₅. A Sylow p-subgroup P has Nat.card P = p^(v_p(60)) ∈ {4, 3, 5} (Sylow.card_eq_multiplicity), which is neither 1 nor 60. Since A₅ is simple, any normal subgroup is ⊥ or ⊤; as |⊥| = 1 and |⊤| = 60, P can be neither, so no Sylow p-subgroup is normal.",
+    "mathContext": "The key lemmas are Sylow.card_eq_multiplicity (|P| = p^(v_p(|G|))) and IsSimpleGroup.eq_bot_or_eq_top_of_normal. Combined with Subgroup.card_bot (|⊥| = 1) and Subgroup.card_top (|⊤| = |G| = 60), the theorems sylow2_not_normal / sylow3_not_normal / sylow5_not_normal derive a contradiction (via omega) from a hypothetical normal Sylow subgroup.",
     "significance": "key",
     "relatedConcepts": [
-      "Sylow.unique_of_normal",
-      "Fintype.card_unique",
+      "IsSimpleGroup.eq_bot_or_eq_top_of_normal",
+      "Sylow.card_eq_multiplicity",
       "normal subgroup",
-      "Sylow conjugacy"
+      "Subgroup.card_bot",
+      "Subgroup.card_top"
     ],
     "prerequisites": [
-      "Sylow II (conjugacy of Sylow subgroups)",
-      "normal subgroup ↔ unique Sylow",
-      "exact counts n₂=5, n₃=10, n₅=6"
+      "simplicity of A₅",
+      "order of a Sylow p-subgroup",
+      "normal subgroups of a simple group"
     ]
   },
   {
     "id": "ann-conjugacy-arithmetic",
     "proofId": "sylow-theorems-oq-04",
     "range": {
-      "startLine": 185,
-      "endLine": 190
+      "startLine": 410,
+      "endLine": 415
     },
     "type": "insight",
     "title": "Conjugacy Class Arithmetic via decide",
@@ -122,17 +125,17 @@
     "id": "ann-simplicity",
     "proofId": "sylow-theorems-oq-04",
     "range": {
-      "startLine": 208,
-      "endLine": 209
+      "startLine": 331,
+      "endLine": 336
     },
     "type": "insight",
     "title": "A₅ is Simple: Mathlib's Definitive Result",
-    "content": "Mathlib's alternatingGroup.isSimpleGroup_five provides the definitive simplicity result. The Sylow counting and conjugacy class analysis above give the concrete arithmetic reason why A₅ is simple.",
-    "mathContext": "IsSimpleGroup G states that G has exactly two normal subgroups: ⊥ (trivial) and ⊤ (the whole group). Mathlib proves this for all alternating groups Aₙ with n ≥ 5 via alternatingGroup.isSimpleGroup_five, which encapsulates the full proof.",
+    "content": "Mathlib's alternatingGroup.isSimpleGroup provides the definitive simplicity result; the file discharges its 5 ≤ Nat.card α hypothesis with (by simp). The Sylow counting and conjugacy class analysis above give the concrete arithmetic reason why A₅ is simple.",
+    "mathContext": "IsSimpleGroup G states that G has exactly two normal subgroups: ⊥ (trivial) and ⊤ (the whole group). Mathlib proves this for all alternating groups Aₙ with n ≥ 5 via alternatingGroup.isSimpleGroup, which encapsulates the full proof (the specialized alternatingGroup.isSimpleGroup_five instance is itself defined as this general result applied to n = 5).",
     "significance": "key",
     "relatedConcepts": [
       "IsSimpleGroup",
-      "alternatingGroup.isSimpleGroup_five",
+      "alternatingGroup.isSimpleGroup",
       "PSL(2,5)",
       "composition series"
     ],
@@ -146,8 +149,8 @@
     "id": "ann-not-solvable",
     "proofId": "sylow-theorems-oq-04",
     "range": {
-      "startLine": 221,
-      "endLine": 235
+      "startLine": 439,
+      "endLine": 452
     },
     "type": "insight",
     "title": "A₅ Not Solvable: Key to Abel-Ruffini",

--- a/src/data/proofs/sylow-theorems-oq-04/meta.json
+++ b/src/data/proofs/sylow-theorems-oq-04/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. Simplicity uses Mathlib's alternatingGroup.isSimpleGroup_five; the presented theorem `card_A5` (|A₅| = 60) and the exact Sylow-number computations are discharged by `native_decide`, which the kernel accepts via `Lean.ofReduceBool` (compiler trust) rather than kernel reduction. Under the gallery convention (CLAUDE.md), native_decide on a presented result makes the entry `axiomatized` (axiomCount 1); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
+    "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. Simplicity uses Mathlib's alternatingGroup.isSimpleGroup; the presented theorem `card_A5` (|A₅| = 60) and the supporting Finset-level cardinality facts underlying the exact Sylow-number computations are discharged by `native_decide`, which the kernel accepts via `Lean.ofReduceBool` (compiler trust) rather than kernel reduction. Under the gallery convention (CLAUDE.md), native_decide on a presented result makes the entry `axiomatized` (axiomCount 1); `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "lineCount": 498,
     "theoremCount": 21,
     "definitionCount": 1
@@ -28,12 +28,12 @@
   "overview": {
     "historicalContext": "The simplicity of A₅ was first understood by Galois (1832), who recognized that A₅ is the smallest non-abelian simple group. The Sylow counting approach, using theorems from Sylow's 1872 paper, provides a concrete arithmetic proof: for |A₅| = 60 = 2²·3·5, the Sylow constraints force n₂ = 5, n₃ = 10, n₅ = 6, meaning no Sylow subgroup is normal. Combined with the conjugacy class sizes {1, 12, 12, 15, 20} (no subset sum divides 60), this proves A₅ has no proper nontrivial normal subgroups. This result is foundational for the Abel-Ruffini theorem (unsolvability of the quintic) and the classification of finite simple groups.",
     "problemStatement": "Prove that A₅ is simple using Sylow counting arguments: compute the exact number of Sylow p-subgroups for each prime p dividing |A₅| = 60, show all are greater than 1, and verify no intermediate normal subgroup exists.",
-    "text": "A 260-line formalization proving the simplicity of A₅ via Sylow theory. Establishes |A₅| = 60, computes the p-adic valuations (v₂ = 2, v₃ = 1, v₅ = 1), derives Sylow counting constraints from Sylow III, and verifies the exact Sylow numbers n₂ = 5, n₃ = 10, n₅ = 6 by native_decide. Proves no Sylow subgroup is normal (via uniqueness contradiction), verifies the conjugacy class arithmetic prevents intermediate normal subgroups, and establishes A₅ is simple and not solvable.",
-    "proofStrategy": "**Step 1**: Compute |A₅| = 60 = 2²·3·5 using native_decide.\n**Step 2**: Apply Sylow III to get n_p ≡ 1 (mod p) and n_p | [A₅ : P_p].\n**Step 3**: Compute exact Sylow numbers by exhaustive enumeration via native_decide.\n**Step 4**: Show n_p > 1 for all p, so no Sylow subgroup is unique/normal.\n**Step 5**: Verify conjugacy class arithmetic: no subset of {1,12,12,15,20} sums to a proper divisor of 60 greater than 1.\n**Step 6**: Conclude simplicity via Mathlib's alternatingGroup.isSimpleGroup_five.",
+    "text": "A 498-line formalization proving the simplicity of A₅ via Sylow theory. Establishes |A₅| = 60, computes the p-adic valuations (v₂ = 2, v₃ = 1, v₅ = 1), derives Sylow counting constraints from Sylow III, and verifies the exact Sylow numbers n₂ = 5, n₃ = 10, n₅ = 6 by constructing explicit Sylow subgroups and computing their normalizer indices via Lagrange's theorem. Proves no Sylow subgroup is normal (via the simplicity of A₅), verifies the conjugacy class arithmetic prevents intermediate normal subgroups, and establishes A₅ is simple and not solvable.",
+    "proofStrategy": "**Step 1**: Compute |A₅| = 60 = 2²·3·5 using native_decide.\n**Step 2**: Apply Sylow III to get n_p ≡ 1 (mod p) and n_p | [A₅ : P_p].\n**Step 3**: Compute exact Sylow numbers by building an explicit Sylow p-subgroup for each p, computing its normalizer as a literal Finset, and applying Lagrange (n_p = [A₅ : N(Sₚ)]).\n**Step 4**: Show n_p > 1 for all p; prove no Sylow subgroup is normal via the simplicity of A₅ (card_eq_multiplicity gives |P| ∈ {4,3,5}, so P is neither ⊥ nor ⊤).\n**Step 5**: Verify conjugacy class arithmetic: no subset of {1,12,12,15,20} sums to a proper divisor of 60 greater than 1.\n**Step 6**: Conclude simplicity via Mathlib's alternatingGroup.isSimpleGroup.",
     "keyInsights": [
       "**Sylow counting forces non-normality**: For |G| = 60, the constraints n₂ | 15, n₂ ≡ 1 (mod 2) give n₂ ∈ {1,3,5,15}; n₃ | 20, n₃ ≡ 1 (mod 3) give n₃ ∈ {1,4,10}; n₅ | 12, n₅ ≡ 1 (mod 5) give n₅ ∈ {1,6}. For A₅ specifically, n₂ = 5, n₃ = 10, n₅ = 6.",
       "**Conjugacy class arithmetic**: The 5 conjugacy classes of A₅ have sizes {1, 12, 12, 15, 20}. A normal subgroup must be a union of classes including {e}. No partial sum 1 + (subset of {12,12,15,20}) divides 60 except 1 and 60 themselves.",
-      "**A₅ is the smallest non-abelian simple group**: With only 60 elements, it's computationally feasible to verify all Sylow subgroups by native_decide, making this a fully decidable result.",
+      "**A₅ is the smallest non-abelian simple group**: With only 60 elements, the Sylow p-subgroups can be exhibited explicitly and their normalizers computed by brute force (native_decide on Finset cardinalities), since the type `Sylow p A5` is not itself directly enumerable.",
       "**Connection to Abel-Ruffini**: The non-solvability of A₅ (proved from simplicity via the short exact sequence A₅ → S₅ → ℤ/2) is the key ingredient in proving the general quintic is not solvable by radicals.",
       "**Element counting as an obstruction**: The Sylow subgroups collectively account for a large fraction of A_5's 60 elements -- the 6 Sylow 5-subgroups contribute 24 elements of order 5, and the 10 Sylow 3-subgroups contribute 20 elements of order 3, leaving only 16 elements for the 5 Sylow 2-subgroups (which share elements). This tight element budget is what forces the exact Sylow numbers and prevents any from being 1."
     ],
@@ -82,7 +82,7 @@
       "title": "Exact Sylow Numbers",
       "startLine": 105,
       "endLine": 338,
-      "summary": "Computes by native_decide: n₂ = 5 (Klein 4-groups), n₃ = 10 (cyclic order 3), n₅ = 6 (cyclic order 5). All are greater than 1.",
+      "summary": "Constructs an explicit Sylow subgroup for each prime and computes its normalizer index via Lagrange to get n₂ = 5 (Klein 4-groups), n₃ = 10 (cyclic order 3), n₅ = 6 (cyclic order 5). All are greater than 1.",
       "mathContext": "The 5 Sylow 2-subgroups are the Klein 4-groups $V_4 \\cong \\mathbb{Z}/2 \\times \\mathbb{Z}/2$ inside $A_5$."
     },
     {
@@ -90,7 +90,7 @@
       "title": "Non-Normality of Sylow Subgroups",
       "startLine": 339,
       "endLine": 379,
-      "summary": "Proves no Sylow p-subgroup of A₅ is normal: if any were, Sylow.unique_of_normal would force Fintype.card = 1, contradicting the computed values 5, 10, 6.",
+      "summary": "Proves no Sylow p-subgroup of A₅ is normal: a Sylow subgroup has order p^(v_p(60)) ∈ {4,3,5} (card_eq_multiplicity), so it is neither ⊥ nor ⊤; since A₅ is simple, it cannot be normal.",
       "mathContext": "$n_p = 1 \\iff P_p \\trianglelefteq G$. Since $n_2 = 5,\\, n_3 = 10,\\, n_5 = 6$, no Sylow subgroup is normal."
     },
     {
@@ -106,7 +106,7 @@
       "title": "Simplicity of A₅",
       "startLine": 418,
       "endLine": 433,
-      "summary": "States A₅ is simple using Mathlib's alternatingGroup.isSimpleGroup_five. The Sylow analysis provides the concrete counting argument for why this holds.",
+      "summary": "States A₅ is simple using Mathlib's alternatingGroup.isSimpleGroup (discharging the 5 ≤ Nat.card α hypothesis with `by simp`). The Sylow analysis provides the concrete counting argument for why this holds.",
       "mathContext": "$A_5$ is the smallest non-abelian simple group. Simplicity: the only normal subgroups are $\\{e\\}$ and $A_5$ itself."
     },
     {


### PR DESCRIPTION
## Summary

Repairs the gallery integrity issue in #43348. After `SylowTheoremOQ04.lean` was rewritten/expanded (238/276 → 498 lines, PRs #39981/#40024 re-anchored `meta.json` `sections[]` but not `annotations.json`), two annotation entries narrated a proof *technique the file no longer uses*, and all 7 entries carried pre-rewrite line ranges.

## Changes

**`annotations.json`**
- **`ann-exact-sylow-numbers`** (was: "computed by native_decide, which exhaustively enumerates all Sylow p-subgroups") → rewritten to describe the actual method: explicit Sylow subgroup construction + normalizer computed as a literal `Finset` + Lagrange (`Sylow.card_eq_index_normalizer` / `Subgroup.card_mul_index`). Notes `native_decide` is applied only to `Finset`-level facts, never to `Fintype.card (Sylow p A5)` (which the file's own comment says is impossible). Range 111–117 → 115–190.
- **`ann-non-normality`** (was: "`Sylow.unique_of_normal` would give `Unique (Sylow p A5)`") → rewritten to the actual simplicity-based route (`A5_isSimple.eq_bot_or_eq_top_of_normal` + `Sylow.card_eq_multiplicity`). `Sylow.unique_of_normal`/`Fintype.card_unique` do not appear in the current file. Range 134–152 → 338–377.
- **`ann-simplicity`**: `alternatingGroup.isSimpleGroup_five` → `alternatingGroup.isSimpleGroup (by simp)` (the actual call at line 336). Range 208–209 → 331–336.
- Re-anchored line ranges for the 4 remaining entries (content unchanged): ann-a5-order 40–48, ann-sylow-constraints 77–102, ann-conjugacy-arithmetic 410–415, ann-not-solvable 439–452. Also corrected ann-sylow-constraints' stale "determined by native_decide" clause.

**`meta.json`** (same root cause — stale post-rewrite narration)
- `overview.text`: "260-line" → "498-line"; exact-Sylow-numbers method and non-normality method corrected.
- `overview.proofStrategy`: steps 3, 4, 6 corrected.
- `overview.keyInsights[2]`: softened the "verify all Sylow subgroups by native_decide" overstatement.
- `assumptions`, `sections[exact-sylow].summary`, `sections[non-normality].summary`, `sections[simplicity].summary`: technique/citation corrected.

Axiom status unchanged (`axiomatized`, axiomCount 1) — `native_decide` on supporting `Finset` cardinalities still pulls in `Lean.ofReduceBool`.

## Validation
Both JSON files parse. No `lake build` needed (metadata only); no Lean source touched.

Closes #43348