### PR TITLE
Audit: sqrt2-examples-oq-01 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25276,9 +25276,9 @@
       "result": "issues-fixed"
     },
     "sqrt2-examples-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:36Z",
+      "lastAudited": "2026-07-24T12:32:05Z",
       "result": "clean"
     },
     "sqrt2-examples-oq-01-oq-01": {


### PR DESCRIPTION
## Audit Result: Clean

**Proof**: sqrt2-examples-oq-01

Re-serve audit (round-robin, queue fully audited). Verified against
`proofs/Proofs/Sqrt2OQ01.lean`:

- 10 theorems, 0 defs, 0 axioms, 0 sorries, 105 lines — all match meta.json
- Badge `mathlib` correctly reflects reliance on `mul_self_nonneg`/`sq_nonneg`
- `square_nonneg_by_cases` is a genuinely independent case-analysis proof
  (not a one-line Mathlib delegation), matching its
  `originalContributions` claim
- Cross-referenced ids (`sqrt2-examples`, `sqrt2-examples-oq-01-oq-01`,
  `amgm-inequality`, `cauchy-schwarz`) all exist
- No native_decide

Updates `audit-tracker.json` only.

---
Discovered during gallery integrity audit.