### PR TITLE
Enrich cauchy-group-theorem-oq002: split module-header section

### DIFF
--- a/src/data/proofs/cauchy-group-theorem-oq002/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq002/meta.json
@@ -56,6 +56,14 @@
   },
   "sections": [
     {
+      "id": "module-header",
+      "title": "Module Header: from g = 1 to arbitrary g",
+      "startLine": 1,
+      "endLine": 64,
+      "summary": "Docstring framing the inhomogeneous follow-up to the parent's #{xⁿ = 1} = gcd(n, |G|) count: the structural abelian dichotomy (coset or empty), the explicit cyclic value, and the one-bijection proof strategy (left-translation by a fixed n-th root a₀). Sets up the CommGroup variable α and opens Finset.",
+      "mathContext": "x ↦ a₀⁻¹·x is a bijection {x | xⁿ = g} → {x | xⁿ = 1} whenever a₀ⁿ = g, since the group is abelian."
+    },
+    {
       "id": "coset-count",
       "title": "The Coset Bijection",
       "startLine": 66,


### PR DESCRIPTION
Enrichment pass for cauchy-group-theorem-oq002: closed the sections gap (4→5, quality-tier 98). Lines 1-64 (module docstring, imports, namespace, `open Finset`, `variable {α}`) were entirely uncovered — the first existing section started at line 66. Added a "Module Header" section anchored at the real docstring boundary (line 1) up to just before the first theorem's doc-comment (line 64), summarizing the abelian-dichotomy/cyclic-value framing and proof strategy.

No other fields changed; file stays well under the 60 KB size guardrail.