### PR TITLE
Fix tracker: restore subset-count-multiset audit record + record subset-count-oq-02

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25607,9 +25607,9 @@
       "note": "native_decide confined to anonymous example sanity-checks; named theorems axiom-clean (verified global sweep 2026-06-24)"
     },
     "subset-count-multiset": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:36Z",
+      "lastAudited": "2026-07-24T12:28:29Z",
       "result": "clean"
     },
     "subset-count-multiset-oq-01": {
@@ -25635,9 +25635,9 @@
       "result": "clean"
     },
     "subset-count-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:36Z",
+      "lastAudited": "2026-07-24T12:35:28Z",
       "result": "clean"
     },
     "subset-count-oq-02-oq-01": {


### PR DESCRIPTION
## Integrity fix

PR #43353 (titled "Audit: subset-count-oq-02 — clean", merged 2026-07-24T12:30:19Z)
was branched from a stale base checkout. Its actual merged diff did **not**
touch `subset-count-oq-02` at all — instead it silently reverted the sibling
entry `subset-count-multiset` (from PR #43352, merged 12:29:12Z) back to a
stale pre-migration timestamp:

```
"subset-count-multiset": {
-  "auditCount": 4,
+  "auditCount": 3,
   "issues": [],
-  "lastAudited": "2026-07-24T12:28:29Z",
+  "lastAudited": "2026-05-04T04:06:36Z",
```

This is a shared-checkout race (concurrent `git reset --hard origin/main` from
another fleet role between commit and push) — see prior occurrences of this
class of bug.

## This PR

1. Restores `subset-count-multiset`'s audit record to the correct
   post-#43352 state (auditCount 4, lastAudited 2026-07-24T12:28:29Z).
2. Records a genuine re-verification of `subset-count-oq-02`
   (`src/data/proofs/subset-count-oq-02`, `proofs/Proofs/SubsetCountOQ02.lean`):
   7/7 theorems match `theoremCount`, 0 axioms/sorries/defs match, `badge:
   "mathlib"` is correctly applied (every theorem thin-wraps
   `Multiset.card_powerset`/`Multiset.card_powersetCard`), Mathlib dependency
   disclosure and originalContributions are accurate, no overclaiming
   language, no native_decide. No issues found — clean.

---
Discovered during gallery integrity audit.