### PR TITLE
Audit: sperner-ndim-oq-03 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25174,9 +25174,9 @@
       "issues": []
     },
     "sperner-ndim-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:36Z",
+      "lastAudited": "2026-07-24T12:39:30Z",
       "result": "clean"
     },
     "sperner-ndim-oq-03-oq-01": {


### PR DESCRIPTION
## Integrity Audit

**Proof**: sperner-ndim-oq-03 (Brouwer Fixed Point via Displacement Coloring, n-dimensional)

Verified `src/data/proofs/sperner-ndim-oq-03/meta.json` against
`proofs/Proofs/SpernerNDimOQ03.lean`:

- `theoremCount: 13` matches exactly (13 lemma/theorem declarations incl. 4 private helpers)
- `axiomCount: 0`, `sorries: 0` confirmed by full source read
- The `sperner` hypothesis parameter taken by `approximate_fixed_point` /
  `brouwer_simplex` is an explicit typed argument, not a hidden axiom or sorry
  — and this limitation is honestly disclosed consistently across
  `assumptions`, `proofStrategy`, and `conclusion.openQuestions`
- No native_decide, no True-stub theorems, no overclaiming language
- `badge: "mathlib"` reasonably reflects the Mathlib compactness/continuity
  machinery used for the analytic half of the argument
- `definitionCount: 5` undercounts the true ~9 definitions (structure +
  8 defs), but undercounts are non-reportable per established convention —
  only overclaims matter

No issues found — clean.

---
Discovered during gallery integrity audit.