### PR TITLE
Enrich lhopital-oq-02-incomplete-01: add 5th keyInsight

### DIFF
--- a/src/data/proofs/lhopital-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/lhopital-oq-02-incomplete-01/meta.json
@@ -106,7 +106,8 @@
       "An abstract L'Hôpital theorem becomes useful only when the hypotheses (derivative lemmas, non-vanishing denominator, divergence of g, and the f'/g' limit) can be assembled mechanically — these three corollaries demonstrate that for the parent rule",
       "The c = 0 cases (log/x and x/eˣ) and the c ≠ 0 case ((x+log x)/x → 1) together confirm the parent theorem handles both vanishing and nonzero target limits",
       "x/eˣ → 0 was listed only as commentary in the parent file; deriving it formally closes the loop between statement and application",
-      "The hard part — the ∞/∞ divergence behaviour — is entirely delegated to the parent's two-variable Cauchy-MVT argument, leaving only routine inverse-limit computations here"
+      "The hard part — the ∞/∞ divergence behaviour — is entirely delegated to the parent's two-variable Cauchy-MVT argument, leaving only routine inverse-limit computations here",
+      "The parent rule is stated over a general basepoint a via ∀ x ∈ Ioi a; all three corollaries instantiate a = 0, even for id and exp whose derivative facts hold on all of ℝ — the shared choice of basepoint is dictated by log's domain (x > 0), not by any of the three functions individually needing the restriction"
     ],
     "conclusion": "All three growth limits are fully machine-checked with no sorries and no extra axioms, depending only on the parent's 0-axiom ∞/∞ L'Hôpital rule and standard Mathlib derivative/limit lemmas."
   },


### PR DESCRIPTION
## Summary
- Quality-gap enrichment pass: the entry was at 98/100 with `keyInsights` capped at 8/10 points (4 items, cap needs 5).
- Added a genuine 5th keyInsight noting that the parent rule's basepoint `a` (via `∀ x ∈ Ioi a`) is shared as `a = 0` across all three corollaries — dictated by `log`'s domain requirement (`x > 0`), even though `id` and `exp`'s derivative facts hold on all of ℝ. Verified against the parent's `lhopital_infty_atTop` signature in `proofs/Proofs/LHopitalOQ02.lean:318-323`.
- No other fields needed changes; annotations, historicalContext, conclusion, sections, and crossRefs were already at their scoring caps.

## Test plan
- [x] `python3 -m json.tool meta.json` — valid JSON
- [x] `pnpm build` — succeeds, gallery loads the entry
- [x] `npx tsx scripts/enricher/find-targets.ts --all` confirms quality score 98 → 100