### PR TITLE
research(weak-goldbach-oq-03): S9 — Schnirelmann–Goldbach bridge (density hypothesis ⟹ bounded prime sums)

### DIFF
--- a/proofs/Proofs/WeakGoldbach.lean
+++ b/proofs/Proofs/WeakGoldbach.lean
@@ -495,6 +495,185 @@ lemma schnirelmannDensity_primes_eq_zero :
     primes_sumset_positive_density (Schnirelmann): σ(P + P) > 0;
     the set of sums of two primes has positive Schnirelmann density. -/
 
+/-! ## The Schnirelmann–Goldbach Bridge (S9)
+
+With `schnirelmann_basis_theorem` now a genuine theorem (the axiom was
+discharged in `Proofs.SchnirelmannTheorem`), the classical Schnirelmann
+route to "every integer ≥ 2 is a sum of a bounded number of primes"
+becomes formalizable end-to-end *modulo a single density input*:
+Schnirelmann's 1930 sieve estimate σ({0,1} ∪ (P+P)) > 0, proved
+historically via Brun's sieve and still unformalized (HEROIC tier).
+
+This section proves the **bridge**: that density input alone — taken as
+a *hypothesis*, not an axiom — implies the bounded-primes theorem. The
+argument is Schnirelmann's own: apply the basis theorem to the sumset
+G = {0,1} ∪ (P+P) at `n - 2`, split the representing multiset into ones
+and prime pairs, then absorb `2 + (number of ones)` into a multiset of
+2s and 3s. A closing corollary cross-validates the conclusion
+unconditionally (k = 4) through the axiomatized Helfgott result. -/
+
+/-- The Schnirelmann–Goldbach sumset G = {0, 1} ∪ (P + P): zero, one, and
+    all sums of two primes. Schnirelmann's sieve theorem (unformalized,
+    HEROIC) states σ(G) > 0; the bridge below shows that this single input
+    yields the bounded-primes theorem. -/
+def goldbachSumset : Set ℕ := {0, 1} ∪ {n | IsSumOfTwoPrimes n}
+
+/-- Membership in the Schnirelmann–Goldbach sumset, unfolded. -/
+lemma mem_goldbachSumset {n : ℕ} :
+    n ∈ goldbachSumset ↔ n = 0 ∨ n = 1 ∨ IsSumOfTwoPrimes n := by
+  simp [goldbachSumset, Set.mem_union, Set.mem_insert_iff, Set.mem_singleton_iff,
+    Set.mem_setOf_eq, or_assoc]
+
+instance : DecidablePred (· ∈ goldbachSumset) := fun n =>
+  decidable_of_iff (n = 0 ∨ n = 1 ∨ IsSumOfTwoPrimes n) mem_goldbachSumset.symm
+
+/-- Every `m ≥ 2` is the sum of a multiset of at most `m` primes drawn from
+    {2, 3} (the "absorb the ones" step of Schnirelmann's argument). Even `m`
+    uses `m/2` copies of 2; odd `m ≥ 3` uses one 3 and `(m-3)/2` copies of 2. -/
+lemma exists_two_three_multiset (m : ℕ) (hm : 2 ≤ m) :
+    ∃ U : Multiset ℕ, (∀ p ∈ U, Nat.Prime p) ∧ U.card ≤ m ∧ U.sum = m := by
+  rcases Nat.even_or_odd m with he | ho
+  · obtain ⟨k, rfl⟩ := he
+    refine ⟨Multiset.replicate k 2, ?_, ?_, ?_⟩
+    · intro p hp
+      rw [Multiset.eq_of_mem_replicate hp]
+      exact Nat.prime_two
+    · rw [Multiset.card_replicate]; omega
+    · rw [Multiset.sum_replicate, smul_eq_mul]; omega
+  · obtain ⟨k, rfl⟩ := ho
+    refine ⟨3 ::ₘ Multiset.replicate (k - 1) 2, ?_, ?_, ?_⟩
+    · intro p hp
+      rcases Multiset.mem_cons.mp hp with rfl | hp
+      · exact Nat.prime_three
+      · rw [Multiset.eq_of_mem_replicate hp]
+        exact Nat.prime_two
+    · simp only [Multiset.card_cons, Multiset.card_replicate]; omega
+    · simp only [Multiset.sum_cons, Multiset.sum_replicate, smul_eq_mul]; omega
+
+/-- **Decomposition step.** A multiset of `goldbachSumset` elements splits
+    into `r` ones (`r` at most the cardinality) and a multiset of primes with
+    at most twice the cardinality, preserving the sum: each element is 0
+    (dropped), 1 (counted by `r`), or `p + q` (contributing two primes). -/
+lemma goldbachSumset_multiset_decomp :
+    ∀ S : Multiset ℕ, (∀ x ∈ S, x ∈ goldbachSumset) →
+      ∃ (r : ℕ) (T : Multiset ℕ), (∀ p ∈ T, Nat.Prime p) ∧
+        r ≤ S.card ∧ T.card ≤ 2 * S.card ∧ S.sum = r + T.sum := by
+  intro S
+  induction S using Multiset.induction_on with
+  | empty => exact fun _ => ⟨0, 0, by simp, by simp, by simp, by simp⟩
+  | cons x S ih =>
+    intro hS
+    obtain ⟨r, T, hTp, hr, hTc, hsum⟩ :=
+      ih (fun y hy => hS y (Multiset.mem_cons_of_mem hy))
+    have hx := hS x (Multiset.mem_cons_self x S)
+    rw [mem_goldbachSumset] at hx
+    rcases hx with rfl | rfl | ⟨p, q, hp, hq, hpq⟩
+    · exact ⟨r, T, hTp, by simp only [Multiset.card_cons]; omega,
+        by simp only [Multiset.card_cons]; omega,
+        by simp only [Multiset.sum_cons]; omega⟩
+    · exact ⟨r + 1, T, hTp, by simp only [Multiset.card_cons]; omega,
+        by simp only [Multiset.card_cons]; omega,
+        by simp only [Multiset.sum_cons]; omega⟩
+    · refine ⟨r, p ::ₘ q ::ₘ T, ?_, ?_, ?_, ?_⟩
+      · intro y hy
+        rcases Multiset.mem_cons.mp hy with rfl | hy
+        · exact hp
+        rcases Multiset.mem_cons.mp hy with rfl | hy
+        · exact hq
+        · exact hTp y hy
+      · simp only [Multiset.card_cons]; omega
+      · simp only [Multiset.card_cons]; omega
+      · simp only [Multiset.sum_cons]; omega
+
+/-- Schnirelmann's conclusion for Goldbach's problem: some uniform `k`
+    bounds the number of primes needed to represent every integer `n ≥ 2`. -/
+def BoundedPrimeSums : Prop :=
+  ∃ k : ℕ, ∀ n : ℕ, 2 ≤ n →
+    ∃ T : Multiset ℕ, (∀ p ∈ T, Nat.Prime p) ∧ T.card ≤ k ∧ T.sum = n
+
+/-- **The Schnirelmann–Goldbach bridge.** If the Schnirelmann sumset
+    G = {0,1} ∪ (P+P) has positive Schnirelmann density — Schnirelmann's
+    1930 sieve estimate, here a *hypothesis*, not an axiom — then every
+    integer `n ≥ 2` is a sum of at most `k` primes for a uniform `k`
+    (with `k = 3h + 2` where `h` is the basis order of G).
+
+    This is Schnirelmann's theorem on Goldbach's problem, now derived
+    end-to-end from the machine-checked basis theorem: apply the basis
+    representation to `n - 2`, decompose into ones and prime pairs, and
+    absorb `2 + (number of ones)` into 2s and 3s. -/
+theorem schnirelmann_goldbach_bridge
+    (hδ : schnirelmannDensity goldbachSumset > 0) : BoundedPrimeSums := by
+  obtain ⟨h, hbasis⟩ := schnirelmann_basis_theorem goldbachSumset hδ
+  refine ⟨3 * h + 2, fun n hn => ?_⟩
+  obtain ⟨S, hSmem, hScard, hSsum⟩ := hbasis (n - 2)
+  obtain ⟨r, T, hTp, hr, hTc, hdecomp⟩ := goldbachSumset_multiset_decomp S hSmem
+  obtain ⟨U, hUp, hUc, hUs⟩ := exists_two_three_multiset (2 + r) (by omega)
+  refine ⟨U + T, ?_, ?_, ?_⟩
+  · intro p hp
+    rcases Multiset.mem_add.mp hp with hp | hp
+    · exact hUp p hp
+    · exact hTp p hp
+  · simp only [Multiset.card_add]
+    omega
+  · simp only [Multiset.sum_add]
+    omega
+
+/-- **Unconditional cross-validation via Helfgott.** Every `n ≥ 2` is a sum
+    of at most 4 primes, derived from the axiomatized `helfgott_weak_goldbach`:
+    odd `n > 5` needs 3 primes; even `n ≥ 10` applies Helfgott to `n - 3` and
+    adjoins a 3; the cases `2 ≤ n ≤ 9` have explicit kernel-checked witnesses.
+    Thus the conclusion Schnirelmann could only reach with an unspecified `k`
+    holds (conditionally on Helfgott's theorem) with `k = 4`. -/
+theorem sum_of_at_most_four_primes :
+    ∀ n : ℕ, 2 ≤ n →
+      ∃ T : Multiset ℕ, (∀ p ∈ T, Nat.Prime p) ∧ T.card ≤ 4 ∧ T.sum = n := by
+  intro n hn
+  rcases Nat.lt_or_ge n 10 with hsmall | hlarge
+  · interval_cases n
+    · exact ⟨{2}, by decide, by decide, by decide⟩
+    · exact ⟨{3}, by decide, by decide, by decide⟩
+    · exact ⟨{2, 2}, by decide, by decide, by decide⟩
+    · exact ⟨{5}, by decide, by decide, by decide⟩
+    · exact ⟨{3, 3}, by decide, by decide, by decide⟩
+    · exact ⟨{7}, by decide, by decide, by decide⟩
+    · exact ⟨{3, 5}, by decide, by decide, by decide⟩
+    · exact ⟨{2, 7}, by decide, by decide, by decide⟩
+  · rcases Nat.even_or_odd n with he | ho
+    · obtain ⟨k, rfl⟩ := he
+      have hodd3 : Odd (k + k - 3) := ⟨k - 2, by omega⟩
+      have hgt : k + k - 3 > 5 := by omega
+      obtain ⟨p, q, s, hp, hq, hs, heq⟩ := helfgott_weak_goldbach _ hgt hodd3
+      refine ⟨{3, p, q, s}, ?_, by simp, ?_⟩
+      · intro y hy
+        simp only [Multiset.insert_eq_cons, Multiset.mem_cons,
+          Multiset.mem_singleton] at hy
+        rcases hy with rfl | rfl | rfl | rfl
+        · exact Nat.prime_three
+        · exact hp
+        · exact hq
+        · exact hs
+      · simp only [Multiset.insert_eq_cons, Multiset.sum_cons,
+          Multiset.sum_singleton]
+        omega
+    · obtain ⟨p, q, s, hp, hq, hs, heq⟩ :=
+        helfgott_weak_goldbach n (by omega) ho
+      refine ⟨{p, q, s}, ?_, by simp, ?_⟩
+      · intro y hy
+        simp only [Multiset.insert_eq_cons, Multiset.mem_cons,
+          Multiset.mem_singleton] at hy
+        rcases hy with rfl | rfl | rfl
+        · exact hp
+        · exact hq
+        · exact hs
+      · simp only [Multiset.insert_eq_cons, Multiset.sum_cons,
+          Multiset.sum_singleton]
+        omega
+
+/-- The bounded-prime-sums property holds outright (conditionally on the
+    axiomatized Helfgott theorem), with `k = 4`. -/
+theorem boundedPrimeSums_of_helfgott : BoundedPrimeSums :=
+  ⟨4, sum_of_at_most_four_primes⟩
+
 /-- Tao's theorem (2014): every odd integer > 1 is a sum of at most 5 primes.
 
     **S5 ACT (axiom elimination):** This historical-attribution axiom is upgraded

--- a/research/problems/weak-goldbach-oq-03/knowledge.md
+++ b/research/problems/weak-goldbach-oq-03/knowledge.md
@@ -490,3 +490,99 @@ in meta.json: 7 deep claims vs 9 mixed historical-and-deep claims) but
 do not contribute new mathematical content. Per `researcher.md`'s
 "Honesty Standards" the value is in the gallery-integrity improvement,
 not in any new theorem-power.
+
+---
+
+## S9 ACT Session (researcher-1, 2026-07-24)
+
+### Situation on arrival
+
+- Tracker had been BLOCKED since 2026-06-13 (Docker blackout). Docker is
+  back (`docker info` OK); flag lifted.
+- **Census drift**: sibling weak-goldbach-oq-01 (PR #34353, 2026-07-03)
+  proved `schnirelmann_basis_theorem` outright
+  (`SchnirelmannTheorem.schnirelmann_basis`, assembled from
+  `SchnirelmannCounting.schnirelmann_inequality` +
+  `SchnirelmannBasis` covering bookkeeping). The axiom floor is **4**,
+  not the 5 recorded by S7/S8 PREP, and the planned S9 Approach D
+  (density-to-basis machinery) was consumed wholesale by the sibling.
+- Gallery meta (`src/data/proofs/weak-goldbach/meta.json`) was already
+  synced to 4 axioms / 764 LOC by the sibling's PR; only this tracker's
+  state.md was stale.
+
+### What S9 built (the bridge)
+
+With the basis theorem now genuine, Schnirelmann's classical 1930
+argument for "every n ≥ 2 is a sum of a bounded number of primes"
+becomes formalizable end-to-end **modulo one input**: σ({0,1} ∪ (P+P)) > 0
+(Brun sieve, unformalized HEROIC). S9 formalizes exactly that
+implication, keeping the density input a *hypothesis* — axiom count
+unchanged.
+
+Pieces (all in `WeakGoldbach.lean`, lines 498–675):
+
+1. `goldbachSumset := {0, 1} ∪ {n | IsSumOfTwoPrimes n}` +
+   `mem_goldbachSumset` + decidable membership via the file's existing
+   `decidableIsSumOfTwoPrimes` (needed because both the local
+   `schnirelmannDensity` abbrev and Mathlib's definition demand
+   `[DecidablePred (· ∈ A)]`).
+2. `exists_two_three_multiset (m ≥ 2)`: multiset of primes from {2,3}
+   with card ≤ m and sum m. **No strong induction needed**: parity
+   split with `Multiset.replicate` witnesses (`k` copies of 2, or
+   `3 ::ₘ replicate (k-1) 2`). `Multiset.sum_replicate` produces `n • a`;
+   add `smul_eq_mul` to the simp set so `omega` can finish.
+3. `goldbachSumset_multiset_decomp`: ∀ S with elements in G,
+   ∃ r ≤ S.card and prime multiset T with T.card ≤ 2·S.card and
+   S.sum = r + T.sum. `Multiset.induction_on` (case names
+   `empty`/`cons`); each cons case closes with
+   `simp only [Multiset.card_cons / sum_cons]; omega`.
+4. `BoundedPrimeSums` (Prop) and `schnirelmann_goldbach_bridge`:
+   σ(G) > 0 → BoundedPrimeSums with k = 3h+2. Apply basis at n−2,
+   decompose, absorb 2+r (≤ h+2) into 2s and 3s, `U + T` via
+   `Multiset.card_add`/`sum_add` + omega.
+5. `sum_of_at_most_four_primes` (unconditional, k = 4, via the
+   axiomatized Helfgott): odd n > 5 → {p,q,r}; even n ≥ 10 → Helfgott
+   at n−3 (Odd (k+k−3) witness `⟨k−2, by omega⟩`) plus a 3 → 4 primes;
+   n ∈ [2,9] by `interval_cases` + literal multiset witnesses, each
+   closed by three `by decide`s (`Multiset.decidableDforallMultiset`
+   makes `∀ p ∈ {2,7}, Nat.Prime p` decidable).
+   `boundedPrimeSums_of_helfgott := ⟨4, sum_of_at_most_four_primes⟩`.
+
+### Lean idioms that worked first-try (docker-verified, 8579 jobs)
+
+- `decidable_of_iff` + existing sound/complete pair for set-membership
+  instances: `decidable_of_iff (n = 0 ∨ n = 1 ∨ IsSumOfTwoPrimes n)
+  mem_goldbachSumset.symm`.
+- `Multiset.eq_of_mem_replicate` to prove all-elements-prime for
+  replicate witnesses.
+- Multiset literals `{3, p, q, s}` with variables: normalize with
+  `Multiset.insert_eq_cons` before `Multiset.mem_cons`/`sum_cons` simp.
+- `Even n` destructures to `n = k + k` (not `2*k`); omega copes.
+
+### Counts delta
+
+| Field | Before S9 | After S9 |
+|-------|-----------|----------|
+| lineCount | 764 | 943 |
+| axiomCount | 4 | 4 (unchanged) |
+| theoremCount (meta) | 32 | 38 |
+| definitionCount | 15 | 17 |
+| sorries | 0 | 0 |
+
+Gallery meta: sections re-anchored (Part III split into III/III(b)
+bridge/III(c) cascade; Parts IV+ shifted +179). NOTE: annotations.json
+ranges were already stale before S9 (anchored to a ~481-line ancestor,
+max endLine 451) — left untouched; that is enricher re-anchoring work,
+not researcher scope.
+
+### S10+ options
+
+- (a) Any piece of σ(G) > 0: Brun/Selberg sieve — multi-quarter HEROIC;
+  Mathlib has no sieve infrastructure as of v4.31.
+- (b) Quantitative bookkeeping: from a hypothesized explicit lower bound
+  σ(G) ≥ δ, extract an explicit basis order h(δ) and hence explicit k —
+  requires making `SchnirelmannTheorem.schnirelmann_basis` quantitative
+  (inspect whether its h is already computable from the proof).
+  Moderate, ~150–250 LOC.
+- (c) Park: the elementary tier is genuinely saturated now — the 4
+  remaining axioms are all HEROIC-or-computational.

--- a/research/problems/weak-goldbach-oq-03/sessions/2026-07-24-s9-act-schnirelmann-goldbach-bridge.md
+++ b/research/problems/weak-goldbach-oq-03/sessions/2026-07-24-s9-act-schnirelmann-goldbach-bridge.md
@@ -1,0 +1,30 @@
+# S9 ACT — Schnirelmann–Goldbach Bridge (researcher-1, 2026-07-24)
+
+## Summary
+
+Unblocked the tracker (Docker recovered from the 2026-06-13 blackout),
+corrected the census (axiom floor is 4, not 5 — sibling oq-01 PR #34353
+proved `schnirelmann_basis_theorem`, consuming the planned Approach D),
+and shipped the classical Schnirelmann–Goldbach bridge as new content:
+
+- `schnirelmann_goldbach_bridge`: σ({0,1} ∪ (P+P)) > 0 (hypothesis, not
+  axiom) ⟹ every n ≥ 2 is a sum of at most 3h+2 primes.
+- `sum_of_at_most_four_primes` + `boundedPrimeSums_of_helfgott`:
+  unconditional k = 4 via the axiomatized Helfgott theorem
+  (cross-validation of the bridge's conclusion).
+- Supporting: `goldbachSumset` (+ decidable membership),
+  `exists_two_three_multiset`, `goldbachSumset_multiset_decomp`,
+  `BoundedPrimeSums`.
+
+## Verification
+
+`./proofs/scripts/docker-build.sh Proofs.WeakGoldbach` — Build completed
+successfully (8579 jobs), first attempt. 0 sorries, 4 axioms (unchanged),
+943 LOC.
+
+## Files
+
+- `proofs/Proofs/WeakGoldbach.lean` (+179 LOC, lines 498–675)
+- `src/data/proofs/weak-goldbach/meta.json` (leanFile counts; sections
+  split/shift)
+- `research/problems/weak-goldbach-oq-03/{state,knowledge}.md`

--- a/research/problems/weak-goldbach-oq-03/state.md
+++ b/research/problems/weak-goldbach-oq-03/state.md
@@ -1,10 +1,41 @@
 # Current State
 
-**Phase**: BLOCKED (verification blackout, 2026-06-13) — slug is at its axiom floor (5 irreducible deep axioms per S7/S8 PREP); the only forward path (S9 Approach D — Schnirelmann sumset inequality, ~250–350 LOC) adds new Lean code that requires Docker verification, and both routes are down this session (`docker info` exit 124; Aristotle 404). Source / gallery meta / research JSON / state.md are all in sync (axiomCount 5, sorries 0, 680 LOC, status `axiomatized`). Re-open when Docker recovers. Last shipped: S8 ACT (axiom elimination 7→5).
-**Since**: 2026-06-13 (S9 BLOCKED; S8 was 2026-06-10)
-**Iteration**: 8
+**Phase**: ACTIVE — S9 ACT shipped (Schnirelmann–Goldbach bridge). Docker recovered; the 2026-06-13 BLOCKED flag is lifted. **Census correction**: the axiom floor is now **4**, not 5 — sibling weak-goldbach-oq-01 (PR #34353, merged 2026-07-03) *proved* `schnirelmann_basis_theorem` outright in `Proofs/SchnirelmannTheorem.lean`, consuming this tracker's planned S9 Approach D (Schnirelmann sumset inequality) wholesale. S9 here instead formalized the classical **bridge**: `schnirelmann_goldbach_bridge` derives "every n ≥ 2 is a sum of ≤ 3h+2 primes" from the single hypothesis σ({0,1} ∪ (P+P)) > 0 (Schnirelmann's Brun-sieve estimate, unformalized HEROIC — kept as a hypothesis, NOT a new axiom), plus unconditional cross-validation `sum_of_at_most_four_primes` (k = 4 via Helfgott). File: 943 LOC, 4 axioms (`helfgott_weak_goldbach`, `circle_method_asymptotic`, `chen_theorem`, `binary_goldbach_verified`), 0 sorries, docker-verified.
+**Since**: 2026-07-24 (S9 ACT; S8 was 2026-06-10)
+**Iteration**: 9
 
 ## Current Focus
+
+S9 (researcher-1, 2026-07-24): ACT — Schnirelmann–Goldbach bridge.
+New in `WeakGoldbach.lean` (all docker-verified, no new axioms):
+
+- `goldbachSumset : Set ℕ` = {0,1} ∪ {n | IsSumOfTwoPrimes n}, with a
+  decidable-membership instance riding the existing verified decision
+  procedure.
+- `exists_two_three_multiset`: every m ≥ 2 is a sum of ≤ m primes from
+  {2,3} (parity split; replicate-multiset witnesses).
+- `goldbachSumset_multiset_decomp`: a multiset of G-elements splits into
+  r ones (r ≤ card) and a prime multiset (card ≤ 2·card) preserving sums
+  (Multiset.induction_on).
+- `schnirelmann_goldbach_bridge`: σ(G) > 0 → BoundedPrimeSums (every
+  n ≥ 2 is a sum of ≤ 3h+2 primes, h the basis order). Applies the
+  now-genuine `schnirelmann_basis_theorem` at n−2, decomposes, absorbs
+  2+r into 2s and 3s.
+- `sum_of_at_most_four_primes` / `boundedPrimeSums_of_helfgott`:
+  unconditional k = 4 via `helfgott_weak_goldbach` (odd n>5 → 3 primes;
+  even n≥10 → Helfgott at n−3 plus a 3; n∈[2,9] kernel-checked
+  witnesses).
+
+**Remaining axiom set (4, all deep)**: `helfgott_weak_goldbach` (HEROIC
+central), `circle_method_asymptotic` (HEROIC), `chen_theorem` (HEROIC
+sieve), `binary_goldbach_verified` (computational, 4·10¹⁸ — inherently
+axiomatic at this scale). **Next candidates (S10+)**: (a) formalize any
+piece of σ(G) > 0 (Brun sieve / Selberg sieve — multi-quarter HEROIC);
+(b) quantitative Schnirelmann constant bookkeeping (extract explicit k
+from an assumed density lower bound σ(G) ≥ δ — moderate, ~150 LOC);
+(c) park the slug — the elementary tier is now genuinely saturated.
+
+## Previous Focus (S8)
 
 S8 (researcher-1, 2026-06-10): ACT — Axiom elimination, second pass.
 Discharged the two remaining historical-attribution axioms that are
@@ -63,11 +94,22 @@ lines, +27 theorem+docstring lines); `theoremCount` 29 → 31; `sorries`
   4-step discharge roadmap. Merged #18552.
 - S8 PREP-2 (researcher-4): doc-only — Mathlib v4.26.0 bearer audit
   revealing Step C is already a Mathlib theorem. Merged #18670.
-- S8 ACT (researcher-1, this iteration): Axiom elimination —
+- S8 ACT (researcher-1): Axiom elimination —
   `vinogradov_ternary_goldbach` and `helfgott_explicit_bound` upgraded
   from `axiom` to `theorem` proved from `helfgott_weak_goldbach`.
   axiomCount 7 → 5. Build pending under the documented parent-drift
-  precedent.
+  precedent. Merged #22808.
+- (external) Sibling weak-goldbach-oq-01 proved
+  `schnirelmann_basis_theorem` (axiom → theorem via
+  `Proofs/SchnirelmannTheorem.lean`), axiomCount 5 → 4. Merged #34353,
+  2026-07-03. Consumed this tracker's planned S9 Approach D.
+- S9 ACT (researcher-1, 2026-07-24, this iteration): unblocked (Docker
+  recovered); Schnirelmann–Goldbach bridge —
+  `schnirelmann_goldbach_bridge` (σ(G)>0 hypothesis ⟹ bounded prime
+  sums, k = 3h+2) + unconditional cross-validation
+  `sum_of_at_most_four_primes` (k = 4 via Helfgott). +179 LOC
+  (764 → 943), +6 theorems, +2 defs, axioms unchanged at 4, 0 sorries,
+  docker-verified.
 
 ## Earlier Plan (S1, kept for context)
 

--- a/src/data/proofs/weak-goldbach/meta.json
+++ b/src/data/proofs/weak-goldbach/meta.json
@@ -134,28 +134,42 @@
       "id": "sec-schnirelmann",
       "title": "Part III: Schnirelmann Density and Additive Bases",
       "startLine": 443,
-      "endLine": 606,
-      "summary": "Schnirelmann density and the `IsAdditiveBasis` predicate; `schnirelmann_basis_theorem` (σ(A) > 0 ⟹ A is an additive basis) is now PROVED outright via `SchnirelmannTheorem.schnirelmann_basis` (S-r8 axiom elimination), not axiomatized; `schnirelmannDensity_primes_eq_zero` exercises the genuine Mathlib density; and the cascade of bounds `ramare_six_primes` (≤6), `tao_five_primes` (≤5), `helfgott_improves_tao` (exactly 3), all theorems derived from `helfgott_weak_goldbach`."
+      "endLine": 497,
+      "summary": "Schnirelmann density and the `IsAdditiveBasis` predicate; `schnirelmann_basis_theorem` (σ(A) > 0 ⟹ A is an additive basis) is now PROVED outright via `SchnirelmannTheorem.schnirelmann_basis` (S-r8 axiom elimination), not axiomatized; `schnirelmannDensity_primes_eq_zero` exercises the genuine Mathlib density."
+    },
+    {
+      "id": "sec-schnirelmann-goldbach-bridge",
+      "title": "Part III(b): The Schnirelmann–Goldbach Bridge",
+      "startLine": 498,
+      "endLine": 675,
+      "summary": "S9: with the basis theorem machine-checked, Schnirelmann's classical route to Goldbach is formalized end-to-end modulo one density input taken as a hypothesis (not an axiom): `schnirelmann_goldbach_bridge` shows σ({0,1} ∪ (P+P)) > 0 implies every n ≥ 2 is a sum of at most 3h+2 primes, via `goldbachSumset_multiset_decomp` (basis representations split into ones and prime pairs) and `exists_two_three_multiset` (absorbing the ones into 2s and 3s). `sum_of_at_most_four_primes` / `boundedPrimeSums_of_helfgott` cross-validate the conclusion unconditionally (k = 4) through the axiomatized Helfgott result."
+    },
+    {
+      "id": "sec-prime-bound-cascade",
+      "title": "Part III(c): Cascade of Prime-Count Bounds",
+      "startLine": 676,
+      "endLine": 785,
+      "summary": "The cascade of bounds `ramare_six_primes` (≤6), `tao_five_primes` (≤5), `helfgott_improves_tao` (exactly 3 for odd n > 5), all theorems derived from `helfgott_weak_goldbach` (S5/S8 axiom eliminations)."
     },
     {
       "id": "sec-strong-goldbach",
       "title": "Part IV: Connections to Strong Goldbach and Open Problems",
-      "startLine": 607,
-      "endLine": 686,
+      "startLine": 786,
+      "endLine": 865,
       "summary": "Relates the weak conjecture to the still-open strong (binary) Goldbach and known partial results: `binary_stronger_than_ternary`, Chen's theorem via the `IsP2` (almost-prime) predicate (`chen_theorem` axiom), Oliveira e Silva's computational verification (`binary_goldbach_verified` axiom to 4×10¹⁸, `binary_goldbach_verified_small`), and the trivial-input Goldbach-representation bound `linnik_goldbach_representations`."
     },
     {
       "id": "sec-comet-levy",
       "title": "Goldbach Comet, Twin-Prime Constant & Lévy's Conjecture",
-      "startLine": 687,
-      "endLine": 736,
+      "startLine": 866,
+      "endLine": 915,
       "summary": "The tail's open-problem material: the Goldbach-comet heuristic G(n) ~ 2C₂ Π_{p|n,p>2}(p−1)/(p−2)·n/(log n)² and its `twinPrimeConstant` C₂ ≈ 0.6601618; Helfgott's explicit bound `helfgott_explicit_bound` (re-derived from the main axiom, threshold 8.875×10³⁰ being content, not a new assumption); and the formalization of Lévy's conjecture — `LevyConjecture` (n = p + 2q), `levy_implies_weak_goldbach` (p + 2q = p + q + q), and the small-case witnesses `levy_7` / `levy_9` / `levy_11`."
     },
     {
       "id": "sec-verification-checks",
       "title": "Verification Checks (#check Roster)",
-      "startLine": 737,
-      "endLine": 764,
+      "startLine": 916,
+      "endLine": 943,
       "summary": "A closing `#check` roster grouped by part (circle method, Schnirelmann density, strong Goldbach) that pins the public names of the file's key declarations, serving as a compile-time table of contents and guarding against silent renames or removals."
     }
   ],
@@ -171,10 +185,10 @@
   },
   "leanFile": {
     "namespace": "WeakGoldbach",
-    "lineCount": 764,
+    "lineCount": 943,
     "axiomCount": 4,
-    "theoremCount": 32,
-    "definitionCount": 15,
+    "theoremCount": 38,
+    "definitionCount": 17,
     "path": "Proofs/WeakGoldbach.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

**weak-goldbach-oq-03 S9 ACT** — unblock the tracker (Docker recovered from the 2026-06-13 blackout), correct the axiom census, and formalize the classical **Schnirelmann–Goldbach bridge** in `Proofs/WeakGoldbach.lean`.

### Census correction

Sibling `weak-goldbach-oq-01` (PR #34353, merged 2026-07-03) proved `schnirelmann_basis_theorem` outright, consuming this tracker's planned S9 Approach D. The axiom floor is **4** (not the 5 recorded by the stale BLOCKED state): `helfgott_weak_goldbach`, `circle_method_asymptotic`, `chen_theorem`, `binary_goldbach_verified`.

### New content (+179 LOC, no new axioms, 0 sorries)

With the basis theorem now machine-checked, Schnirelmann's 1930 route to "every integer >= 2 is a bounded sum of primes" is formalized end-to-end **modulo a single density input kept as a hypothesis** (sigma(G) > 0 for G = {0,1} + sums of two primes; Brun sieve, unformalized HEROIC):

- `goldbachSumset` + `mem_goldbachSumset` + decidable membership (rides the file's verified decision procedure)
- `exists_two_three_multiset` — every m >= 2 is a sum of <= m primes from {2,3}
- `goldbachSumset_multiset_decomp` — basis representations split into ones and prime pairs
- `schnirelmann_goldbach_bridge` — sigma(G) > 0 implies every n >= 2 is a sum of <= 3h+2 primes (h = basis order)
- `sum_of_at_most_four_primes` / `boundedPrimeSums_of_helfgott` — unconditional cross-validation with k = 4 via the axiomatized Helfgott result

### Verification

`./proofs/scripts/docker-build.sh Proofs.WeakGoldbach` — **Build completed successfully (8579 jobs)**, first attempt. File: 943 LOC, 4 axioms (unchanged), 0 sorries.

### Gallery sync

- `meta.json` leanFile counts (764 -> 943 lines, 32 -> 38 theorems, 15 -> 17 defs); status stays `axiomatized`/`axiom`/4.
- Sections re-anchored: Part III split into III (density/basis), III(b) (bridge, new), III(c) (prime-count cascade); Parts IV+ shifted +179. Note: `annotations.json` ranges were already stale pre-S9 (anchored to a ~481-line ancestor) — left for enricher re-anchoring.
- Tracker `state.md`/`knowledge.md` updated; session file added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
