### PR TITLE
Audit: erdos-10-oq-01 — clean (#reserve)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8295,9 +8295,9 @@
       "agentId": "auditor-cycle-verify"
     },
     "erdos-10-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:36Z",
+      "lastAudited": "2026-07-24T12:47:33Z",
       "result": "clean"
     },
     "erdos-10-oq-01-incomplete-01": {


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: erdos-10-oq-01
**Result**: clean (reserve re-verification, queue fully drained)

## Verification

- `axiomCount`: 3 — matches `grep '^axiom'` (crocker_theorem, gallagher_density_approach, erdos_graham_conjecture)
- `theoremCount`: 10 — matches `grep '^theorem'`
- `definitionCount`: 6 — matches `grep '^def'`
- `lineCount`: 309 — matches `wc -l`
- `sorries`: 0 — confirmed, no `sorry` in file
- No `native_decide` usage
- No True-stub theorems
- Badge `axiom` / status `axiomatized` is correct Tier-C classification
- Conclusion/assumptions honestly disclose all 3 axioms (2 proven-but-deep external results, 1 open conjecture)
- annotations.json references only real declaration names (spot-checked all 7 entries against source)
- Cross-reference targets (erdos-10, erdos-9) both exist in gallery

Tracker-only change updating `lastAudited`/`auditCount` for this reserve-mode re-verification.

---
Discovered during gallery integrity audit (queue fully drained, 0 unaudited, 0 with issues).