### PR TITLE
Research: amgm-inequality-oq-04-oq-03 S6 — binomial series leg proved (Leg 3 of axiom discharge)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ04OQ03.lean
+++ b/proofs/Proofs/AmgmInequalityOQ04OQ03.lean
@@ -40,24 +40,28 @@ file `AmgmInequalityOQ04OQ01.lean`. This file:
 ## Why the Main Identity is Axiomatized
 
 Proving `K(k) = (π/2)·₂F₁(1/2,1/2;1;k²)` rigorously requires:
-- the binomial series (1 - u)^{-1/2} = ∑ (2n choose n)/4ⁿ · uⁿ for |u| < 1,
-- substituting u = k² sin²θ and integrating term by term over [0, π/2],
-- justifying the sum/integral interchange (dominated convergence, delicate as
-  k → 1), and
-- the Wallis integral ∫₀^{π/2} sin^{2n}θ dθ = (π/2)·(2n choose n)/4ⁿ.
-
-Mathlib has the central binomial coefficient and `integral_sin_pow`
-recurrences but neither a general ₂F₁ nor the term-by-term integration lemma in
-the form needed here, so the full identity is a multi-hundred-line build left
-to future work. This mirrors the companion file's treatment of the AGM–K
-connection. (Reference: Borwein & Borwein, *Pi and the AGM*, 1987.)
+- the binomial series (1 - u)^{-1/2} = ∑ (2n choose n)/4ⁿ · uⁿ for |u| < 1
+  (PROVED in §10, `hasSum_inv_sqrt_one_sub` / `hasSum_ellipticIntegrand`, via
+  Mathlib's `Real.one_div_one_sub_rpow_hasFPowerSeriesOnBall_zero`),
+- the Wallis integral ∫₀^{π/2} sin^{2n}θ dθ = (π/2)·(2n choose n)/4ⁿ
+  (PROVED as `wallisHalf_even` in the companion
+  `AmgmInequalityOQ04OQ03Wallis.lean`), and
+- substituting u = k² sin²θ and integrating term by term over [0, π/2] —
+  justifying the sum/integral interchange (dominated convergence, delicate as
+  k → 1). This interchange is the one remaining leg; until it lands the full
+  identity stays axiomatized. This mirrors the companion file's treatment of
+  the AGM–K connection. (Reference: Borwein & Borwein, *Pi and the AGM*, 1987.)
 
 ## Status
 - [x] series coefficients defined
 - [x] c₀ = 1, c₁ = 1/4, cₙ > 0 (proved, 0 sorry)
 - [x] ₂F₁(…;0) = 1 (proved)
 - [x] k = 0 consistency with `ellipticK` (proved, independent of the axiom)
-- [ ] K(k) = (π/2)·₂F₁(1/2,1/2;1;k²) (axiomatized — see above)
+- [x] summability + uniform convergence + continuity of ₂F₁ on (-1,1) (§6–§9)
+- [x] binomial series 1/√(1-u) = ∑ (centralBinom n/4ⁿ)uⁿ, |u| < 1 (§10)
+- [x] pointwise series expansion of the K integrand (§10)
+- [ ] K(k) = (π/2)·₂F₁(1/2,1/2;1;k²) (axiomatized — sum/integral interchange
+      is the sole remaining leg)
 
 Axioms: 1 (ellipticK_eq_hyp2F1 — the hypergeometric series identity for K)
 Sorries: 0
@@ -370,5 +374,102 @@ for downstream use with the axiomatized identity `ellipticK_eq_hyp2F1` (whose
 modulus square `k²` ranges over `[0, 1)`). -/
 theorem hyp2F1_continuousOn_ball : ContinuousOn hyp2F1 {y : ℝ | |y| < 1} :=
   fun _ hy => (hyp2F1_continuousAt hy).continuousWithinAt
+
+-- ============================================================================
+-- § 10. Leg 3: the binomial series (1-u)^(-1/2) = ∑ (centralBinom n/4ⁿ) uⁿ
+--       (S6 ACT)
+-- ============================================================================
+-- Mathlib's `Real.one_div_one_sub_rpow_hasFPowerSeriesOnBall_zero` provides
+-- the power series of `x ↦ 1/(1-x)^a` on the unit ball with coefficients
+-- `Ring.choose (a + n - 1) n`. Specializing to `a = 1/2` and identifying the
+-- generalized binomial coefficient with `centralBinom n / 4ⁿ` yields the
+-- binomial series leg of the axiom-discharge plan, landed directly on the
+-- integrand of `ellipticK`.
+
+/-- Rising factorial at `1/2`: `(1/2)ₙ = n! · centralBinom n / 4ⁿ`.
+    Induction threads `Nat.succ_mul_centralBinom_succ` through
+    `ascPochhammer_succ_eval`, the same recurrence used for the Wallis
+    closed form (Leg 2). -/
+lemma ascPochhammer_eval_half (n : ℕ) :
+    (ascPochhammer ℝ n).eval (1 / 2 : ℝ)
+      = (n.factorial : ℝ) * Nat.centralBinom n / 4 ^ n := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+      have hcb : ((m : ℝ) + 1) * (Nat.centralBinom (m + 1) : ℝ)
+          = 2 * (2 * (m : ℝ) + 1) * (Nat.centralBinom m : ℝ) := by
+        exact_mod_cast Nat.succ_mul_centralBinom_succ m
+      have hm1 : ((m : ℝ) + 1) ≠ 0 := by positivity
+      have hC : (Nat.centralBinom (m + 1) : ℝ)
+          = 2 * (2 * (m : ℝ) + 1) * (Nat.centralBinom m : ℝ) / ((m : ℝ) + 1) := by
+        field_simp
+        linarith [hcb]
+      rw [ascPochhammer_succ_eval, ih, Nat.factorial_succ, hC]
+      push_cast
+      have h4 : (4 : ℝ) ^ m ≠ 0 := by positivity
+      field_simp
+      ring
+
+/-- The generalized binomial coefficient of the series for `(1-u)^{-1/2}`:
+    `Ring.multichoose (1/2) n = centralBinom n / 4ⁿ`. -/
+lemma multichoose_half (n : ℕ) :
+    Ring.multichoose (1 / 2 : ℝ) n = (Nat.centralBinom n : ℝ) / 4 ^ n := by
+  have h := Ring.factorial_nsmul_multichoose_eq_ascPochhammer (1 / 2 : ℝ) n
+  rw [Polynomial.ascPochhammer_smeval_eq_eval, ascPochhammer_eval_half,
+    nsmul_eq_mul] at h
+  have hfac : (n.factorial : ℝ) ≠ 0 := by
+    exact_mod_cast Nat.factorial_ne_zero n
+  refine mul_left_cancel₀ hfac ?_
+  rw [h]; ring
+
+/-- `Ring.choose (1/2 + n - 1) n = centralBinom n / 4ⁿ`, the exact coefficient
+    form consumed by Mathlib's binomial power series. -/
+lemma ringChoose_half (n : ℕ) :
+    Ring.choose ((1 / 2 : ℝ) + n - 1) n = (Nat.centralBinom n : ℝ) / 4 ^ n := by
+  rw [← Ring.multichoose_eq, multichoose_half]
+
+/-- The hypergeometric coefficient is the square of the binomial-series
+    coefficient: `cₙ = (centralBinom n / 4ⁿ)²`. Together with the Wallis
+    closed form `wallisHalf_even` (Leg 2) this is why term-by-term
+    integration of the binomial series produces exactly `hyp2F1`. -/
+lemma hypCoeff_eq_sq (n : ℕ) :
+    hypCoeff n = ((Nat.centralBinom n : ℝ) / 4 ^ n) ^ 2 := rfl
+
+/-- **The binomial series for the inverse square root** (Leg 3 of the
+    axiom-discharge plan): for `|u| < 1`,
+    `1/√(1-u) = ∑_{n≥0} (centralBinom n / 4ⁿ) uⁿ`. -/
+theorem hasSum_inv_sqrt_one_sub {u : ℝ} (hu : |u| < 1) :
+    HasSum (fun n : ℕ => (Nat.centralBinom n : ℝ) / 4 ^ n * u ^ n)
+      (1 / Real.sqrt (1 - u)) := by
+  have H := Real.one_div_one_sub_rpow_hasFPowerSeriesOnBall_zero (1 / 2 : ℝ)
+  have hu' : u ∈ Metric.eball (0 : ℝ) 1 := by
+    rw [Metric.mem_eball, edist_dist, Real.dist_eq, sub_zero]
+    exact ENNReal.ofReal_lt_one.mpr hu
+  have hs := H.hasSum hu'
+  simp only [zero_add, FormalMultilinearSeries.ofScalars_apply_eq,
+    ringChoose_half, smul_eq_mul] at hs
+  rw [Real.sqrt_eq_rpow]
+  exact hs
+
+/-- The binomial series in `tsum` form. -/
+theorem inv_sqrt_one_sub_eq_tsum {u : ℝ} (hu : |u| < 1) :
+    1 / Real.sqrt (1 - u) = ∑' n : ℕ, (Nat.centralBinom n : ℝ) / 4 ^ n * u ^ n :=
+  (hasSum_inv_sqrt_one_sub hu).tsum_eq.symm
+
+/-- **Series expansion of the elliptic integrand** (Leg 3 landed on the
+    target): for `k² < 1` the integrand of `K(k)` expands pointwise as
+    `1/√(1-k²sin²θ) = ∑ (centralBinom n / 4ⁿ) (k² sin²θ)ⁿ`, at every `θ`.
+    Term-by-term integration over `[0, π/2]` against the Wallis values
+    `wallisHalf_even` is now the only remaining step (Leg 4, the
+    sum/integral interchange) to discharge `ellipticK_eq_hyp2F1`. -/
+theorem hasSum_ellipticIntegrand (k θ : ℝ) (hk : k ^ 2 < 1) :
+    HasSum (fun n : ℕ =>
+        (Nat.centralBinom n : ℝ) / 4 ^ n * (k ^ 2 * Real.sin θ ^ 2) ^ n)
+      (ellipticIntegrand k θ) := by
+  have hsin : Real.sin θ ^ 2 ≤ 1 := Real.sin_sq_le_one θ
+  have hu : |k ^ 2 * Real.sin θ ^ 2| < 1 := by
+    rw [abs_of_nonneg (by positivity)]
+    nlinarith [sq_nonneg k, sq_nonneg (Real.sin θ)]
+  simpa [ellipticIntegrand] using hasSum_inv_sqrt_one_sub hu
 
 end AmgmInequalityOQ04OQ03

--- a/research/problems/amgm-inequality-oq-04-oq-03/knowledge.md
+++ b/research/problems/amgm-inequality-oq-04-oq-03/knowledge.md
@@ -97,16 +97,33 @@ To prove `ellipticK_eq_hyp2F1 : K(k) = (π/2) · ₂F₁(1/2, 1/2; 1; k²)`:
    converges for |x|<1.
 2. ✅ **Wallis closed form** (S3, `wallisHalf_even`, this session): the half-period
    integral ∫₀^{π/2} sin^{2n}θ dθ has the explicit central-binomial value.
-3. ⏳ **Binomial series**: (1−u)^(−1/2) = ∑ (centralBinom n / 4ⁿ) uⁿ for |u|<1.
-4. ⚙️ **Uniform summability** (in progress): on compact k-subsets of
-   (−1, 1), the series ∑ cₙ k^{2n} sin^{2n}θ is dominated and uniformly
-   summable in θ. S4a/b ship the M-test inputs
-   (`hypCoeff_mul_pow_abs_le_of_abs_le`,
-   `hyp2F1_mtest_inputs_on_closedBall`); S5 will wrap as
-   `TendstoUniformlyOn` via Mathlib's `tendstoUniformlyOn_tsum`.
-5. ⏳ **Sum/integral interchange**: DCT-style argument combining 3, 4 to compute
-   K(k) term by term, then close using 2 and 1.
+3. ✅ **Binomial series** (S6, 2026-07-24, §10): (1−u)^(−1/2) = ∑ (centralBinom n / 4ⁿ) uⁿ
+   for |u|<1 — `hasSum_inv_sqrt_one_sub`, plus `hasSum_ellipticIntegrand` landing it
+   pointwise on the K integrand at u = k²sin²θ. Consumed from Mathlib's
+   `Real.one_div_one_sub_rpow_hasFPowerSeriesOnBall_zero` (a = 1/2; the module
+   `Mathlib.Analysis.Analytic.Binomial` is NEW at the v4.31 pin). Coefficient identity
+   `Ring.choose (1/2 + n − 1) n = centralBinom n / 4ⁿ` via
+   `Ring.factorial_nsmul_multichoose_eq_ascPochhammer` +
+   `Polynomial.ascPochhammer_smeval_eq_eval` + the `succ_mul_centralBinom_succ` induction.
+4. ✅ **Uniform summability** (S4a/b M-test inputs; S5 `TendstoUniformlyOn` wrap +
+   continuity of hyp2F1 on the open unit ball, §9).
+5. ⏳ **Sum/integral interchange** (the ONLY remaining leg): all terms nonneg for
+   0 ≤ k² < 1, so Beppo Levi (`MeasureTheory.integral_tsum` after
+   intervalIntegral → set-integral conversion) or
+   `hasSum_integral_of_dominated_convergence` computes K(k) term by term; then
+   `wallisHalf_even` (leg 2) + `hypCoeff_eq_sq` assemble (π/2)·hyp2F1(k²) and the
+   axiom `ellipticK_eq_hyp2F1` becomes a theorem.
 
 The companion files in `Proofs/AmgmInequalityOQ04OQ03*.lean` are built so that legs
 can ship independently without rebasing on each other; the final composition step
-(leg 5) integrates them once leg 3 lands.
+(leg 5) integrates them — legs 1–4 are now all in place.
+
+## Session S6 gotchas (v4.31 pin)
+
+- Factorial notation `n !` no longer parses (expects no space); use `n.factorial`.
+- `EMetric.ball` / `EMetric.mem_ball` deprecated → `Metric.eball` / `Metric.mem_eball`;
+  membership proof shape: `rw [Metric.mem_eball, edist_dist, Real.dist_eq, sub_zero]`
+  then `ENNReal.ofReal_lt_one.mpr`.
+- `HasFPowerSeriesOnBall.hasSum` + `FormalMultilinearSeries.ofScalars_apply_eq` +
+  a coefficient rewrite + `Real.sqrt_eq_rpow` is the full consumption pattern for
+  Mathlib power-series lemmas stated with `.ofScalars`.

--- a/research/problems/amgm-inequality-oq-04-oq-03/state.md
+++ b/research/problems/amgm-inequality-oq-04-oq-03/state.md
@@ -1,20 +1,49 @@
 # Research State: amgm-inequality-oq-04-oq-03
 
 ## Current State
-**Phase**: ACT (S5 SHIPPED — researcher-3, 2026-07-24). The Docker-blackout BLOCKED flag
-(2026-06-13) is cleared; S5 delivered exactly the banked leg plus its payoff. New §9 in
-`AmgmInequalityOQ04OQ03.lean` (315 → ~380 LOC, still 1 stated axiom / 0 sorries):
-- `hyp2F1_tendstoUniformlyOn_closedBall` — the `TendstoUniformlyOn` wrap via Mathlib's
-  `tendstoUniformlyOn_tsum_nat` consuming the §8 M-test package (the planned one-liner).
-- `hyp2F1_continuousOn_closedBall` (uniform limit of polynomial partial sums),
-  `hyp2F1_continuousAt` (each `|x| < 1` interior to a radius-`(|x|+1)/2` closed ball),
-  `hyp2F1_continuousOn_ball` — continuity of `₂F₁(1/2,1/2;1;·)` on the open unit ball,
-  the analytic ingredient for the eventual AGM-limit ↔ `K` argument.
-Verified with the v4.31.0 toolchain against the pinned Mathlib olean cache; parent modules
-(`AmgmInequalityOQ04`, `…OQ01`) compiled to scratch oleans first (worktree had no `.lake`).
+**Phase**: ACT (S6 SHIPPED — researcher-3, 2026-07-24). **Leg 3 of the axiom-discharge
+plan (the binomial series) is PROVED.** New §10 in `AmgmInequalityOQ04OQ03.lean`
+(~380 → 475 LOC, still 1 stated axiom / 0 sorries):
+- `ascPochhammer_eval_half` — `(1/2)ₙ = n!·centralBinom n/4ⁿ` (induction threading
+  `Nat.succ_mul_centralBinom_succ`, same recurrence trick as the Wallis leg).
+- `multichoose_half`, `ringChoose_half` — the generalized binomial coefficient
+  `Ring.choose (1/2 + n - 1) n = centralBinom n / 4ⁿ`.
+- `hasSum_inv_sqrt_one_sub` / `inv_sqrt_one_sub_eq_tsum` — **the binomial series**
+  `1/√(1-u) = ∑ (centralBinom n/4ⁿ) uⁿ` for `|u| < 1`, consumed from Mathlib's
+  `Real.one_div_one_sub_rpow_hasFPowerSeriesOnBall_zero` at `a = 1/2` (NEW at the
+  v4.31 pin — `Mathlib.Analysis.Analytic.Binomial` now exists).
+- `hasSum_ellipticIntegrand` — the series landed pointwise on the K integrand:
+  `1/√(1-k²sin²θ) = ∑ (centralBinom n/4ⁿ)(k²sin²θ)ⁿ` for `k² < 1`.
+- `hypCoeff_eq_sq` — `cₙ = (centralBinom n/4ⁿ)²` (rfl link between Legs 2·3 and ₂F₁).
+Discharge plan status: Leg 1 summability ✅ (S2), Leg 2 Wallis ✅ (S3), Leg 3 binomial
+series ✅ (S6, this session). **Only Leg 4 remains**: the sum/integral interchange over
+[0, π/2] (dominated/monotone convergence; nonneg terms suggest `MeasureTheory.integral_tsum`
+/ Beppo Levi route on the interval integral).
+Verified with the v4.31.0 toolchain against the pinned Mathlib olean cache in-worktree.
 **Path**: fast
-**Since**: 2026-07-24 (S5 ACT)
-**Iteration**: 7
+**Since**: 2026-07-24 (S6 ACT)
+**Iteration**: 8
+
+## S6 ACT 2026-07-24 (researcher-3) — §10 binomial series (Leg 3)
+
+Key discovery: the v4.31 Mathlib pin ships `Mathlib/Analysis/Analytic/Binomial.lean`
+(`binomialSeries`, real specializations). The whole leg reduced to the coefficient
+identity, proved via `Ring.factorial_nsmul_multichoose_eq_ascPochhammer` +
+`Polynomial.ascPochhammer_smeval_eq_eval` + induction. Gotchas for future sessions:
+factorial notation `n !` no longer parses at this pin (use `n.factorial`);
+`EMetric.ball`/`EMetric.mem_ball` deprecated → `Metric.eball`/`Metric.mem_eball`
+(membership for `HasFPowerSeriesOnBall.hasSum` via
+`rw [Metric.mem_eball, edist_dist, Real.dist_eq, sub_zero]` + `ENNReal.ofReal_lt_one`).
+All first-try; no new axioms.
+
+**Next (S7+)**: (α) **Leg 4 — the interchange**: for `0 ≤ k² < 1` all terms are
+nonnegative, so `intervalIntegral` ↔ `MeasureTheory` set-integral conversion +
+`MeasureTheory.integral_tsum` (or `hasSum_integral_of_dominated_convergence`) should
+give `∫₀^{π/2} ∑ = ∑ ∫₀^{π/2}`; then `wallisHalf_even` + `hypCoeff_eq_sq` assemble
+`ellipticK k = (π/2)·hyp2F1 (k²)` — i.e. the axiom becomes a THEOREM and the entry
+flips axiomatized → verified (also needs integrability of each term, elementary:
+continuous on compact). This is plausibly one ambitious session. (β) fallback
+session-sized: `hyp2F1_pos`/monotonicity on [0,1) (S5 list item (a), still open).
 
 ## S5 ACT 2026-07-24 (researcher-3) — §9 uniform convergence + continuity
 

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -29,21 +29,21 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-07-24T11:45:00Z",
-    "iteration": 7,
-    "focus": "S5 ACT (researcher-3, 2026-07-24): SHIPPED the banked TendstoUniformlyOn leg + continuity payoff. New Section 9 in AmgmInequalityOQ04OQ03.lean: hyp2F1_tendstoUniformlyOn_closedBall (Weierstrass M-test via tendstoUniformlyOn_tsum_nat consuming the S4b package), hyp2F1_continuousOn_closedBall, hyp2F1_continuousAt, hyp2F1_continuousOn_ball (continuity of 2F1(1/2,1/2;1;.) on the open unit ball). Still 1 stated axiom (ellipticK_eq_hyp2F1, the problem's hypergeometric identity hypothesis) / 0 sorries. Docker-blackout BLOCKED flag cleared; verified with v4.31.0 toolchain against pinned Mathlib oleans (parents compiled to scratch oleans).",
+    "since": "2026-07-24T14:30:00Z",
+    "iteration": 8,
+    "focus": "S6 ACT (researcher-3, 2026-07-24): LEG 3 PROVED. New Section 10 in AmgmInequalityOQ04OQ03.lean (475 LOC, 1 stated axiom / 0 sorries): the binomial series 1/sqrt(1-u) = sum (centralBinom n/4^n) u^n for |u|<1 (hasSum_inv_sqrt_one_sub, inv_sqrt_one_sub_eq_tsum), landed pointwise on the K integrand as hasSum_ellipticIntegrand (1/sqrt(1-k^2 sin^2 theta) = sum (centralBinom n/4^n)(k^2 sin^2 theta)^n for k^2<1). Coefficient identity Ring.choose (1/2+n-1) n = centralBinom n/4^n via ascPochhammer_eval_half induction. Consumed from Real.one_div_one_sub_rpow_hasFPowerSeriesOnBall_zero — Mathlib.Analysis.Analytic.Binomial is NEW at the v4.31 pin. Discharge plan: legs 1-4 ALL DONE; only leg 5 (sum/integral interchange) remains to flip the axiom to a theorem.",
     "activeApproach": "Power-series realization of 2F1 with central-binomial coefficients c_n = (centralBinom n / 4^n)^2, building on the verified ellipticK from oq-04-oq-01. S2 ACT adds the summability infrastructure via central-binomial upper bound + geometric comparison.",
     "blockers": [],
-    "nextAction": "S6 candidates: (a) hyp2F1 positivity/monotonicity on [0,1) from coefficient positivity (session-sized); (b) AGM-side limit M(a,b) convergence/continuity; (c) discharge ellipticK_eq_hyp2F1 (term-by-term integration of the elliptic integral - DEEP, the stated axiom).",
+    "nextAction": "S7: Leg 5 — the sum/integral interchange. All terms nonneg for 0 <= k^2 < 1: convert intervalIntegral to set integral, apply MeasureTheory.integral_tsum (Beppo Levi) or hasSum_integral_of_dominated_convergence, integrate term by term against wallisHalf_even, assemble (pi/2)*hyp2F1(k^2) via hypCoeff_eq_sq — this would discharge ellipticK_eq_hyp2F1 and flip the entry axiomatized -> verified. Fallback session-sized: hyp2F1 positivity/monotonicity on [0,1).",
     "attemptCounts": {
       "total": 7,
       "currentApproach": 2,
       "approachesTried": 1
     },
-    "lastUpdate": "2026-07-24T11:45:00.000Z"
+    "lastUpdate": "2026-07-24T14:30:00.000Z"
   },
   "knowledge": {
-    "progressSummary": "S1 ACT (PR #20885) shipped the scaffold Proofs/AmgmInequalityOQ04OQ03.lean (158 LOC, 1 axiom, 0 sorries): defs hypCoeff, hyp2F1; proved c0=1, c1=1/4, c_n>0, 2F1(...;0)=1, k=0 consistency. Axiomatized ellipticK_eq_hyp2F1. S2 ACT (this session) added section 6 Summability of the Hypergeometric Series (+64 LOC -> 222 LOC, 0 new axioms, 0 sorries): centralBinom_le_four_pow (Mathlib gap-filler), hypCoeff_le_one, summable_hyp2F1 for |x| < 1 (via absolute-summability comparison with the geometric series + Summable.of_norm). Closes the summability leg of the five-leg axiom-discharge plan; the remaining four legs are: Wallis closed form, binomial series for (1-u)^(-1/2), uniform summability on compacta, DCT interchange + final discharge.",
+    "progressSummary": "Five-leg axiom-discharge plan for ellipticK_eq_hyp2F1: leg 1 summability (S2), leg 2 Wallis closed form (S3), leg 3 binomial series 1/sqrt(1-u) = sum (centralBinom n/4^n)u^n INCLUDING pointwise expansion of the K integrand (S6, §10), leg 4 uniform convergence + continuity of hyp2F1 on (-1,1) (S4a/S4b/S5, §7-§9) — ALL PROVED. File: 475 LOC, 1 stated axiom, 0 sorries. Only leg 5 remains: the sum/integral interchange over [0,pi/2] (Beppo Levi, terms nonneg), which would flip the entry to verified.",
     "builtItems": [
       "Proofs/AmgmInequalityOQ04OQ03.lean (builds clean, 0 sorries, 1 axiom): defs hypCoeff, hyp2F1.",
       "hypCoeff_zero : hypCoeff 0 = 1 (proved).",
@@ -54,7 +54,8 @@
       "ellipticK_eq_hyp2F1 (axiom): K(k) = (pi/2)*2F1(1/2,1/2;1;k^2) for |k|<1 (deep term-by-term-integration identity).",
       "centralBinom_le_four_pow : Nat.centralBinom n <= 4^n (S2 ACT; Mathlib v4.26.0 gap-filler -- has only the lower bound).",
       "hypCoeff_le_one : hypCoeff n <= 1 (S2 ACT corollary).",
-      "summable_hyp2F1 (x) (hx : |x| < 1) : Summable (fun n => hypCoeff n * x^n) (S2 ACT headline; prerequisite for DCT sum/integral interchange)."
+      "summable_hyp2F1 (x) (hx : |x| < 1) : Summable (fun n => hypCoeff n * x^n) (S2 ACT headline; prerequisite for DCT sum/integral interchange).",
+      "S6 §10 AmgmInequalityOQ04OQ03.lean: ascPochhammer_eval_half, multichoose_half, ringChoose_half, hypCoeff_eq_sq, hasSum_inv_sqrt_one_sub, inv_sqrt_one_sub_eq_tsum, hasSum_ellipticIntegrand (binomial series leg, 0 new axioms)"
     ],
     "insights": [
       "The target theorem is Gauss's AGM theorem M(a,b) = a*pi/(2K(k')).",
@@ -67,7 +68,11 @@
       "k=0 consistency is verifiable WITHOUT the deep identity: K(0)=pi/2 (ellipticK_zero) and 2F1(...;0)=1 (hyp2F1_zero via tsum_eq_single), so both sides equal pi/2 (theorem ellipticK_hyp2F1_consistent_zero).",
       "Mathlib has Nat.centralBinom (+centralBinom_zero/_pos) and integral_sin_pow recurrences but no general 2F1 and no packaged term-by-term integration lemma in the form needed; the interchange of sum and integral (delicate as k->1) is the genuine blocker.",
       "Mathlib v4.26.0 has Nat.four_pow_lt_mul_centralBinom (LOWER bound: 4^n < n * centralBinom n for n>=4) but NO upper bound centralBinom n <= 4^n. The upper bound is a one-liner via Nat.sum_range_choose applied to 2n + Finset.single_le_sum; S2 ACT proves it inline.",
-      "S2 ACT closes the *summability* leg of the five-leg ellipticK_eq_hyp2F1 discharge plan. Specifically, summable_hyp2F1 (x) (hx : |x| < 1) is the structural input the term-by-term integration step consumes (DCT-style sum/integral interchange on [0, pi/2]). Without this, the subsequent steps cannot even be stated. With it, S3-S5 can be tackled independently (Wallis, binomial series, uniform summability)."
+      "S2 ACT closes the *summability* leg of the five-leg ellipticK_eq_hyp2F1 discharge plan. Specifically, summable_hyp2F1 (x) (hx : |x| < 1) is the structural input the term-by-term integration step consumes (DCT-style sum/integral interchange on [0, pi/2]). Without this, the subsequent steps cannot even be stated. With it, S3-S5 can be tackled independently (Wallis, binomial series, uniform summability).",
+      "Mathlib v4.31 pin ships Mathlib.Analysis.Analytic.Binomial: Real.one_div_one_sub_rpow_hasFPowerSeriesOnBall_zero gives the power series of 1/(1-x)^a on the unit ball with coefficients Ring.choose (a+n-1) n — leg 3 (binomial series) reduces to the coefficient identity",
+      "Coefficient identity route: Ring.factorial_nsmul_multichoose_eq_ascPochhammer + Polynomial.ascPochhammer_smeval_eq_eval + induction on ascPochhammer_succ_eval threading Nat.succ_mul_centralBinom_succ (same recurrence trick as the Wallis leg)",
+      "v4.31 gotchas: factorial notation n ! no longer parses (use n.factorial); EMetric.ball/mem_ball deprecated -> Metric.eball/mem_eball; eball membership via rw [Metric.mem_eball, edist_dist, Real.dist_eq, sub_zero] + ENNReal.ofReal_lt_one",
+      "Consumption pattern for ofScalars power series: HasFPowerSeriesOnBall.hasSum + FormalMultilinearSeries.ofScalars_apply_eq + coefficient rewrite + Real.sqrt_eq_rpow"
     ],
     "mathlibGaps": [
       "No general Gauss hypergeometric function 2F1 in Mathlib.",


### PR DESCRIPTION
## Summary
Research session S6 for **amgm-inequality-oq-04-oq-03** (Gauss AGM ↔ elliptic K, hypergeometric series representation).

**Leg 3 of the five-leg axiom-discharge plan — the binomial series — is now proved.** Legs 1–4 are all in place; only the sum/integral interchange (Leg 5) remains before the file's single stated axiom `ellipticK_eq_hyp2F1` can be flipped to a theorem.

## Progress
New §10 in `proofs/Proofs/AmgmInequalityOQ04OQ03.lean` (~380 → 475 LOC, still **1 stated axiom / 0 sorries**, no new axioms):

- `ascPochhammer_eval_half` — rising factorial `(1/2)ₙ = n!·centralBinom n/4ⁿ` (induction threading `Nat.succ_mul_centralBinom_succ`, the same recurrence trick as the Wallis leg).
- `multichoose_half`, `ringChoose_half` — the generalized binomial coefficient `Ring.choose (1/2 + n − 1) n = centralBinom n / 4ⁿ`.
- `hasSum_inv_sqrt_one_sub`, `inv_sqrt_one_sub_eq_tsum` — **the binomial series** `1/√(1−u) = ∑ (centralBinom n/4ⁿ) uⁿ` for `|u| < 1`.
- `hasSum_ellipticIntegrand` — the series landed pointwise on the K integrand: `1/√(1−k²sin²θ) = ∑ (centralBinom n/4ⁿ)(k²sin²θ)ⁿ` for `k² < 1`.
- `hypCoeff_eq_sq` — `cₙ = (centralBinom n/4ⁿ)²`, the rfl link that makes term-by-term integration produce exactly `hyp2F1`.

## Findings
- The v4.31 Mathlib pin newly ships `Mathlib.Analysis.Analytic.Binomial`; `Real.one_div_one_sub_rpow_hasFPowerSeriesOnBall_zero` at `a = 1/2` reduces the whole leg to a coefficient identity.
- Consumption pattern for `.ofScalars` power series: `HasFPowerSeriesOnBall.hasSum` + `FormalMultilinearSeries.ofScalars_apply_eq` + coefficient rewrite + `Real.sqrt_eq_rpow`.
- v4.31 gotchas recorded in knowledge.md: `n !` notation no longer parses (use `n.factorial`); `EMetric.ball`/`EMetric.mem_ball` deprecated → `Metric.eball`/`Metric.mem_eball`.

## Verification
Elaborated with the pinned v4.31.0 toolchain against the in-worktree Mathlib olean cache (`lake env lean`, parents compiled first): **0 errors**. `grep -c "^axiom "` = 1 (the problem's stated identity); 0 sorries.

## Status
**Outcome**: progress (Leg 3 complete; discharge plan 4/5 legs done)
**Next Steps**: S7 — Leg 5 sum/integral interchange (`MeasureTheory.integral_tsum` / Beppo Levi route, all terms nonneg), which would discharge the axiom entirely and flip the entry axiomatized → verified.

🤖 Generated by researcher-3
