### PR TITLE
Enrich erdos-179: re-anchor sections and annotations to current line numbers

### DIFF
--- a/src/data/proofs/erdos-179/annotations.json
+++ b/src/data/proofs/erdos-179/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "erdos-179",
     "type": "definition",
     "range": {
-      "startLine": 39,
+      "startLine": 46,
       "endLine": 56
     },
     "title": "Arithmetic Progressions and Counting",
@@ -29,7 +29,7 @@
     "proofId": "erdos-179",
     "type": "definition",
     "range": {
-      "startLine": 57,
+      "startLine": 64,
       "endLine": 85
     },
     "title": "Supersaturation Function F_k(N, ℓ)",
@@ -54,7 +54,7 @@
     "proofId": "erdos-179",
     "type": "insight",
     "range": {
-      "startLine": 86,
+      "startLine": 93,
       "endLine": 101
     },
     "title": "Trivial Bounds on F",
@@ -78,7 +78,7 @@
     "proofId": "erdos-179",
     "type": "concept",
     "range": {
-      "startLine": 102,
+      "startLine": 109,
       "endLine": 119
     },
     "title": "Erdős's Two Questions",
@@ -103,7 +103,7 @@
     "proofId": "erdos-179",
     "type": "insight",
     "range": {
-      "startLine": 120,
+      "startLine": 127,
       "endLine": 154
     },
     "title": "Fox-Pohoata Theorem and Corollaries",
@@ -128,7 +128,7 @@
     "proofId": "erdos-179",
     "type": "insight",
     "range": {
-      "startLine": 155,
+      "startLine": 162,
       "endLine": 177
     },
     "title": "Leng-Sah-Sawhney Improvement (2024)",
@@ -153,7 +153,7 @@
     "proofId": "erdos-179",
     "type": "insight",
     "range": {
-      "startLine": 178,
+      "startLine": 185,
       "endLine": 196
     },
     "title": "Szemerédi's Theorem and Dense Sets",
@@ -178,7 +178,7 @@
     "proofId": "erdos-179",
     "type": "insight",
     "range": {
-      "startLine": 197,
+      "startLine": 204,
       "endLine": 259
     },
     "title": "Roth's Theorem and Behrend's Construction",
@@ -206,7 +206,7 @@
     "proofId": "erdos-179",
     "type": "insight",
     "range": {
-      "startLine": 260,
+      "startLine": 265,
       "endLine": 276
     },
     "title": "Special Cases and Asymptotics",
@@ -231,7 +231,7 @@
     "proofId": "erdos-179",
     "type": "insight",
     "range": {
-      "startLine": 277,
+      "startLine": 284,
       "endLine": 303
     },
     "title": "Main Result: Problem Solved",

--- a/src/data/proofs/erdos-179/annotations.json
+++ b/src/data/proofs/erdos-179/annotations.json
@@ -4,8 +4,8 @@
     "proofId": "erdos-179",
     "type": "definition",
     "range": {
-      "startLine": 37,
-      "endLine": 47
+      "startLine": 39,
+      "endLine": 56
     },
     "title": "Arithmetic Progressions and Counting",
     "content": "arithmeticProgression a d k = Finset.image (i ↦ a + i*d) (Finset.range k). ContainsAP requires d > 0. countAPs counts k-APs via powerset filtering.",
@@ -29,8 +29,8 @@
     "proofId": "erdos-179",
     "type": "definition",
     "range": {
-      "startLine": 55,
-      "endLine": 68
+      "startLine": 57,
+      "endLine": 85
     },
     "title": "Supersaturation Function F_k(N, ℓ)",
     "content": "F k N ℓ = Nat.find of the minimum M such that every N-element set with ≥ M k-APs contains an ℓ-AP. SupersaturationProperty captures this threshold property.",
@@ -54,11 +54,11 @@
     "proofId": "erdos-179",
     "type": "insight",
     "range": {
-      "startLine": 76,
-      "endLine": 87
+      "startLine": 86,
+      "endLine": 101
     },
     "title": "Trivial Bounds on F",
-    "content": "Lower: F_k(N, ℓ) ≥ N^{1.99} eventually (axiom, from Behrend-type constructions). Upper: F_k(N, ℓ) ≤ N² (sorry). Random set perspective: expected k-APs ~ p^k·N² (sorry).",
+    "content": "Lower: F_k(N, ℓ) ≥ N^{1.99} eventually (axiom, from Behrend-type constructions). Upper: F_k(N, ℓ) ≤ N² (sorry).",
     "significance": "key",
     "mathContext": "The lower bound N^{1.99} comes from large AP-free sets: Behrend's construction gives a 3-AP-free subset of {1,...,N} of size N/exp(c√(log N)), which still contains ~N^{2-o(1)} pairs (hence 2-APs). More generally, ℓ-AP-free sets can have many k-APs (k < ℓ), showing F_k(N, ℓ) must be large. The trivial upper bound N² holds because any set of size N has at most C(N,2) ~ N²/2 pairs, bounding the number of k-APs. The Filter.atTop in the lower bound captures 'for all sufficiently large N'.",
     "relatedConcepts": [
@@ -78,8 +78,8 @@
     "proofId": "erdos-179",
     "type": "concept",
     "range": {
-      "startLine": 95,
-      "endLine": 103
+      "startLine": 102,
+      "endLine": 119
     },
     "title": "Erdős's Two Questions",
     "content": "Question1: F₃(N, 4) = o(N²), formalized as ∀ε > 0, eventually F₃(N,4) ≤ εN². Question2: lim log F₃(N, ℓ)/log N = 2, using Filter.Tendsto to nhds 2.",
@@ -103,8 +103,8 @@
     "proofId": "erdos-179",
     "type": "insight",
     "range": {
-      "startLine": 111,
-      "endLine": 130
+      "startLine": 120,
+      "endLine": 154
     },
     "title": "Fox-Pohoata Theorem and Corollaries",
     "content": "fox_pohoata_theorem: F_k(N, ℓ) ≤ N²/(log log N)^C for C > 0. Corollaries: question1_solved (1 sorry for final inequality), question2_solved (sorry).",
@@ -128,8 +128,8 @@
     "proofId": "erdos-179",
     "type": "insight",
     "range": {
-      "startLine": 138,
-      "endLine": 148
+      "startLine": 155,
+      "endLine": 177
     },
     "title": "Leng-Sah-Sawhney Improvement (2024)",
     "content": "leng_sah_sawhney: F_k(N, ℓ) ≤ N²/exp((log log N)^c). This is strictly stronger: exp((log log N)^c) >> (log log N)^C for large N.",
@@ -153,13 +153,13 @@
     "proofId": "erdos-179",
     "type": "insight",
     "range": {
-      "startLine": 156,
-      "endLine": 168
+      "startLine": 178,
+      "endLine": 196
     },
     "title": "Szemerédi's Theorem and Dense Sets",
-    "content": "szemeredi_theorem: for δ > 0, large sets with density ≥ δ contain ℓ-APs. F_k relates: dense sets have many k-APs, and supersaturation refines the density threshold.",
+    "content": "szemeredi_theorem: for δ > 0, large sets with density ≥ δ contain ℓ-APs. SzemerediImplication restates this in terms of F, connecting the supersaturation threshold back to the classical density formulation.",
     "significance": "key",
-    "mathContext": "Szemerédi's theorem (1975) is one of the most celebrated results in combinatorics. The formalization uses Finset (Fin N) to represent subsets of {0,...,N-1}, with Fin.valEmbedding to map to ℕ for the ContainsAP check. The SzemerediImplication connects F to density: a set of density δ has ~δ^k·N² many k-APs (by counting), so F_k(N, ℓ) relates to the Szemerédi density threshold r_ℓ(N)/N. The dense_sets_many_3APs axiom (with sorry for the bound) captures this counting argument.",
+    "mathContext": "Szemerédi's theorem (1975) is one of the most celebrated results in combinatorics. The formalization uses Finset (Fin N) to represent subsets of {0,...,N-1}, with Fin.valEmbedding to map to ℕ for the ContainsAP check. SzemerediImplication is a Prop (not yet connected to a proof here) asserting that F 3 N ℓ ≤ (δN)²/4 whenever density ≥ δ — a rough bound relating the two formulations of the density-vs-supersaturation phenomenon.",
     "relatedConcepts": [
       "Szemerédi's theorem",
       "Fin.valEmbedding",
@@ -178,25 +178,52 @@
     "proofId": "erdos-179",
     "type": "insight",
     "range": {
-      "startLine": 176,
-      "endLine": 191
+      "startLine": 197,
+      "endLine": 259
     },
     "title": "Roth's Theorem and Behrend's Construction",
-    "content": "roth_theorem: no 3-AP-free set has positive density. behrend_construction: 3-AP-free sets of size N/exp(c√(log N)). AP_free_has_2APs: pairs in AP-free sets (sorry).",
+    "content": "roth_theorem: no 3-AP-free set has positive density. behrend_construction: 3-AP-free sets of size N/exp(c√(log N)). arithmeticProgression_two and AP_free_has_2APs are fully proved (no axiom, no sorry): every finite set A has exactly A.card.choose 2 many 2-term APs, since every unordered pair {a,b} is itself the 2-AP (min a b, |a-b|) — the 3-AP-free hypothesis in AP_free_has_2APs's statement is not actually needed for the proof.",
     "significance": "supporting",
-    "mathContext": "Roth's theorem (1953) is the k = 3 case of Szemerédi, proved 22 years earlier using Fourier-analytic methods. Behrend's 1946 construction, predating Roth, shows the density bound cannot be much better than 1/exp(c√(log N)). For the supersaturation problem, Behrend's construction is relevant because it shows sets of size ~N/exp(c√(log N)) can avoid 3-APs while having ~N² 2-APs. The AP_free_has_2APs theorem (sorry) formalizes that every pair {a,b} with a ≠ b is a 2-AP, so countAPs(A, 2) = C(|A|, 2).",
+    "mathContext": "Roth's theorem (1953) is the k = 3 case of Szemerédi, proved 22 years earlier using Fourier-analytic methods. Behrend's 1946 construction, predating Roth, shows the density bound cannot be much better than 1/exp(c√(log N)). For the supersaturation problem, Behrend's construction is relevant because it shows sets of size ~N/exp(c√(log N)) can avoid 3-APs while having ~N² 2-APs. AP_free_has_2APs formalizes that every pair {a,b} with a ≠ b is a 2-AP, so countAPs(A, 2) = C(|A|, 2) — proved via `Finset.card_powersetCard` after matching the powerset-filter definition of countAPs against `A.powersetCard 2`.",
     "relatedConcepts": [
       "Roth's theorem",
       "Behrend's construction",
       "Fourier methods",
-      "density bounds"
+      "density bounds",
+      "elementary 2-AP counting"
     ],
     "prerequisites": [
       "roth_theorem",
       "behrend_construction",
       "Real.exp",
       "Real.sqrt",
-      "Real.log"
+      "Real.log",
+      "Finset.card_powersetCard"
+    ]
+  },
+  {
+    "id": "erdos-179-special-cases",
+    "proofId": "erdos-179",
+    "type": "insight",
+    "range": {
+      "startLine": 260,
+      "endLine": 276
+    },
+    "title": "Special Cases and Asymptotics",
+    "content": "F_2_well_defined: F 2 N ℓ ≤ N.choose 2 (sorry — the trivial bound restricted to k = 2, using the C(N,2) count of 2-APs from AP_free_has_2APs). exponent_is_2: the logarithmic ratio log(F k N ℓ)/log N tends to 2 (sorry), combining the Fox-Pohoata upper bound and the F_lower_bound lower bound into the exact exponent claimed by Question 2.",
+    "significance": "supporting",
+    "mathContext": "F_2_well_defined specializes the generic upper bound to k = 2 using the exact 2-AP count from Part VIII rather than the cruder N² bound. exponent_is_2 is the general statement underlying Question2 for arbitrary k, not just k = 3 — both remain sorry, since they require combining the axiomatized asymptotic bounds (fox_pohoata_theorem, F_lower_bound) into a Filter.Tendsto convergence statement.",
+    "relatedConcepts": [
+      "logarithmic exponent",
+      "Filter.Tendsto",
+      "asymptotic bounds",
+      "Nat.choose"
+    ],
+    "prerequisites": [
+      "F_lower_bound",
+      "fox_pohoata_theorem",
+      "AP_free_has_2APs",
+      "Filter.Tendsto"
     ]
   },
   {
@@ -204,8 +231,8 @@
     "proofId": "erdos-179",
     "type": "insight",
     "range": {
-      "startLine": 215,
-      "endLine": 228
+      "startLine": 277,
+      "endLine": 303
     },
     "title": "Main Result: Problem Solved",
     "content": "erdos_179: Question1 ∧ Question2 = ⟨question1_solved, question2_solved⟩. Both questions answered YES. erdos_179_answer is a String summary.",

--- a/src/data/proofs/erdos-179/meta.json
+++ b/src/data/proofs/erdos-179/meta.json
@@ -38,7 +38,7 @@
     "historicalContext": "Erdős posed this problem about arithmetic progression supersaturation: if a set of N integers has 'too many' k-term arithmetic progressions, must it contain a longer ℓ-term AP? The function F_k(N, ℓ), the minimum threshold for this forcing, captures a quantitative supersaturation phenomenon. This is a refinement of Szemerédi's theorem (1975), which says dense sets must contain long APs — supersaturation asks how many short APs are needed, rather than just density.\n\nFox and Pohoata resolved both of Erdős's questions in their 2020 paper. They proved F_k(N, ℓ) ≤ N²/(log log N)^{C_ℓ} for constants C_ℓ > 0 depending on ℓ. This shows F_k(N, ℓ) = N^{2-o(1)}, confirming that F₃(N, 4) = o(N²) (Question 1) and that the limiting exponent lim log F₃(N, ℓ)/log N = 2 (Question 2). Their approach connects the AP count in a set to its additive structure, using the inverse theorem for the Gowers norms.\n\nLeng, Sah, and Sawhney (2024) significantly improved the bound to F_k(N, ℓ) ≤ N²/exp((log log N)^{c_ℓ}), using their breakthrough improvements to Szemerédi's theorem. The exp factor grows much faster than any polynomial of log log N, substantially tightening the gap between the N^{1.99} lower bound (from Behrend-type constructions) and the N^{2-o(1)} upper bound. The exact growth rate of F_k(N, ℓ) remains an active area of research.",
     "problemStatement": "Let 1 ≤ k < ℓ be integers. Define F_k(N, ℓ) as the minimum number such that every set A ⊆ ℕ of size N containing at least F_k(N, ℓ) many k-term APs must contain an ℓ-term AP. Is F₃(N, 4) = o(N²)? For every ℓ > 3, is lim log F₃(N, ℓ) / log N = 2?",
     "text": "For integers 1 ≤ k < ℓ, define F_k(N, ℓ) as the minimum number such that every set A ⊆ ℕ of size N containing at least F_k(N, ℓ) many k-term APs must contain an ℓ-term AP. Questions: Is F₃(N, 4) = o(N²)? Is lim log F₃(N, ℓ) / log N = 2 for all ℓ > 3? Answer: YES to both.",
-    "proofStrategy": "We define arithmeticProgression, ContainsAP, countAPs, and the supersaturation function F via Nat.find. Erdős's two questions (Question1, Question2) use Filter.atTop and nhds for asymptotic statements. Fox-Pohoata and Leng-Sah-Sawhney bounds are axiomatized. Question 1 is partially proved (question1_solved with one sorry). Connections to Szemerédi, Roth, and Behrend are axiomatized. 10 sorries remain.",
+    "proofStrategy": "We define arithmeticProgression, ContainsAP, countAPs, and the supersaturation function F via Nat.find. Erdős's two questions (Question1, Question2) use Filter.atTop and nhds for asymptotic statements. Fox-Pohoata and Leng-Sah-Sawhney bounds are axiomatized. Question 1 is partially proved (question1_solved with one sorry). Connections to Szemerédi, Roth, and Behrend are axiomatized; the elementary 2-AP counting identity (arithmeticProgression_two, AP_free_has_2APs: countAPs A 2 = A.card.choose 2) is fully proved. 6 sorries remain.",
     "keyInsights": [
       "F_k(N, ℓ) captures supersaturation: many short APs force long APs",
       "F_k(N, ℓ) = N^{2-o(1)} — the exponent is exactly 2 with subpolynomial correction",
@@ -73,7 +73,7 @@
       "id": "arithmetic-progressions",
       "title": "Arithmetic Progressions",
       "startLine": 39,
-      "endLine": 55,
+      "endLine": 56,
       "summary": "arithmeticProgression (Finset.image), ContainsAP (∃ AP ⊆ A), countAPs (powerset filter).",
       "mathContext": "Mathematical content: arithmeticProgression (Finset.image), ContainsAP (∃ AP ⊆ A), countAPs (powerset filter)."
     },
@@ -81,63 +81,71 @@
       "id": "supersaturation-function",
       "title": "The Supersaturation Function",
       "startLine": 57,
-      "endLine": 76,
+      "endLine": 85,
       "summary": "F_k(N, ℓ) via Nat.find (sorry for existence), SupersaturationProperty.",
       "mathContext": "Mathematical content: F_k(N, ℓ) via Nat.find (sorry for existence), SupersaturationProperty."
     },
     {
       "id": "trivial-bounds",
       "title": "Trivial Bounds",
-      "startLine": 78,
-      "endLine": 92,
+      "startLine": 86,
+      "endLine": 101,
       "summary": "F_lower_bound ≥ N^{1.99} (axiom, Behrend-type), F_upper_trivial ≤ N² (sorry).",
       "mathContext": "F_lower_bound $\\geq$ N^{1.99} (axiom), F_upper_trivial $\\leq$ N² (sorry)."
     },
     {
       "id": "erdos-questions",
       "title": "Erdős's Questions",
-      "startLine": 94,
-      "endLine": 111,
+      "startLine": 102,
+      "endLine": 119,
       "summary": "Question1: F₃(N,4) = o(N²). Question2: lim log F₃(N,ℓ)/log N = 2.",
       "mathContext": "Mathematical content: Question1: F₃(N,4) = o(N²). Question2: lim log F₃(N,ℓ)/log N = 2."
     },
     {
       "id": "fox-pohoata",
       "title": "Fox-Pohoata Theorem (2020)",
-      "startLine": 112,
-      "endLine": 145,
+      "startLine": 120,
+      "endLine": 154,
       "summary": "fox_pohoata_theorem: F ≤ N²/(log log N)^C. question1_solved (1 sorry). question2_solved (sorry).",
       "mathContext": "fox_pohoata_theorem: F $\\leq$ N²/(log log N)^C. question1_solved (1 sorry). question2_solved (sorry)."
     },
     {
       "id": "leng-sah-sawhney",
       "title": "Leng-Sah-Sawhney Improvement (2024)",
-      "startLine": 147,
-      "endLine": 168,
+      "startLine": 155,
+      "endLine": 177,
       "summary": "leng_sah_sawhney: F ≤ N²/exp((log log N)^c). improvement_significant (sorry).",
       "mathContext": "leng_sah_sawhney: F $\\leq$ N²/exp((log log N)^c). improvement_significant (sorry)."
     },
     {
       "id": "szemeredi-connection",
-      "title": "Connection to Szemerédi and Roth",
-      "startLine": 170,
-      "endLine": 211,
-      "summary": "szemeredi_theorem, roth_theorem, behrend_construction (axioms). SzemerediImplication, AP_free_has_2APs.",
-      "mathContext": "szemeredi_theorem, roth_theorem, behrend_construction (axioms). Dense set AP counting."
+      "title": "Connection to Szemerédi's Theorem",
+      "startLine": 178,
+      "endLine": 196,
+      "summary": "szemeredi_theorem (axiom): density-δ sets in {1,...,N} contain ℓ-term APs for large N. SzemerediImplication: a Prop refining this into a supersaturation-style bound relating F 3 N ℓ to density.",
+      "mathContext": "szemeredi_theorem (axiom). SzemerediImplication restates the density theorem in terms of F, connecting supersaturation back to the classical density formulation."
+    },
+    {
+      "id": "roth-behrend",
+      "title": "Roth's Theorem and Behrend's Construction",
+      "startLine": 197,
+      "endLine": 259,
+      "summary": "The k = 3 case and extremal examples: roth_theorem (axiom, no 3-AP-free set has positive upper density) and behrend_construction (axiom, 3-AP-free sets of size N/exp(c√log N) exist, showing the Szemerédi/Roth bounds cannot be much better than logarithmic). Also proves arithmeticProgression_two (a 2-AP is the pair {a, a+d}) and AP_free_has_2APs (countAPs A 2 = A.card.choose 2 for every finite set — the 3-AP-free hypothesis is not needed for this elementary counting identity), both fully proved with no axioms or sorries.",
+      "mathContext": "Roth's theorem (1953) is the k=3 case of Szemerédi's theorem. Behrend's construction (1946) gives near-optimal 3-AP-free sets, showing Roth-type bounds cannot be much stronger than $N/\\exp(c\\sqrt{\\log N})$. `AP_free_has_2APs` is a genuine (if elementary) combinatorial fact: the number of 2-term APs in any finite set equals $\\binom{|A|}{2}$, since every unordered pair is itself a 2-AP."
     },
     {
       "id": "special-cases",
       "title": "Special Cases and Asymptotics",
-      "startLine": 212,
-      "endLine": 227,
+      "startLine": 260,
+      "endLine": 276,
       "summary": "F_2_well_defined (sorry), exponent_is_2 (sorry).",
       "mathContext": "Mathematical content: F_2_well_defined (sorry), exponent_is_2 (sorry)."
     },
     {
       "id": "main-result",
       "title": "Main Results",
-      "startLine": 229,
-      "endLine": 253,
+      "startLine": 277,
+      "endLine": 303,
       "summary": "erdos_179: Question1 ∧ Question2. erdos_179_answer (String def). #check statements.",
       "mathContext": "Mathematical content: erdos_179: Question1 ∧ Question2. erdos_179_answer (String def). #check statements."
     }
@@ -160,7 +168,8 @@
     "F_k(N, ℓ) via Nat.find with SupersaturationProperty",
     "Question1 and Question2 using Filter.atTop and nhds for asymptotics",
     "Partial proof of question1_solved from fox_pohoata_theorem using filter_upwards",
-    "Axiomatized Fox-Pohoata, Leng-Sah-Sawhney, Szemerédi, Roth, and Behrend"
+    "Axiomatized Fox-Pohoata, Leng-Sah-Sawhney, Szemerédi, Roth, and Behrend",
+    "arithmeticProgression_two and AP_free_has_2APs: fully proved 2-AP counting identity countAPs A 2 = A.card.choose 2, holding for every finite set (the 3-AP-free hypothesis is not needed)"
   ],
   "leanFile": {
     "imports": [


### PR DESCRIPTION
## Summary
`Erdos179Problem.lean` grew from an earlier version by roughly 10-50 lines starting partway through the file (most substantially a new "Part VIII: Roth's Theorem and Behrend's Construction" section, ~63 lines, containing two fully-proved theorems), but neither `meta.json`'s `sections` nor `annotations.json` were ever re-anchored — every recorded line range from "Trivial Bounds" onward pointed at the WRONG content (e.g. the `szemeredi` annotation's range pointed at Leng-Sah-Sawhney proof code, and the `main` annotation's range pointed at the middle of the Roth/Behrend section).

- Re-anchored all 9 stale `sections` entries (`trivial-bounds` through `main-result`) to their actual current line ranges, verified against `## Part N` banner grep positions in the `.lean` source.
- Added a `sections` entry for the previously-uncovered "Part VIII: Roth's Theorem and Behrend's Construction" (axioms `roth_theorem`/`behrend_construction` plus the fully-proved `arithmeticProgression_two`/`AP_free_has_2APs` theorems), closing what a naive line-count scan reported as a 40-line tail gap but which was really part of a much larger internal drift.
- Re-anchored all 10 `annotations.json` entries to their real content (same drift), and added a new annotation for "Special Cases and Asymptotics" (`F_2_well_defined`, `exponent_is_2`), which had no annotation at all under the old numbering.
- Fixed a real accuracy defect surfaced by the drift: the `roth-behrend` annotation's content said `AP_free_has_2APs` has a "(sorry)" — it does not; both `arithmeticProgression_two` and `AP_free_has_2APs` are fully proved with 0 axioms and 0 sorries (verified via `grep sorry`). `meta.json`'s `sorries`/`axiomCount` fields were already accurate (6 sorries, 6 file-axioms) — only the stale `proofStrategy` prose ("10 sorries remain") and the `roth-behrend` annotation text needed fixing.
- Anchored each annotation's `startLine` on the doc-comment of the first real declaration in its range (`scripts/annotations/resolver.ts`'s `findConstructAtLine` check requires this — a banner-comment-only `startLine` is flagged as "No Lean construct found").

No content deleted; `meta.json` stays well under the size cap (~14 KB), `annotations.json` ~12 KB.

## Test plan
- [x] `python3 -c "import json; json.load(...)"` on both edited files
- [x] `pnpm build` — no errors reported for `erdos-179` (was 10/10 misaligned before the final anchor fix, now 0/10)