### PR TITLE
Research: gauss-wilson-non-cyclic-oq-02 - S3: cyclic half proved, slug unblocked (new file, docker-verified)

### DIFF
--- a/proofs/Proofs/GaussWilsonNonCyclicOQ02.lean
+++ b/proofs/Proofs/GaussWilsonNonCyclicOQ02.lean
@@ -1,0 +1,131 @@
+import Mathlib
+import Proofs.GaussWilsonNonCyclic
+
+/-!
+# Sylow-2 Boundary Shapes in (ZMod n)ˣ — the Cyclic Half (OQ-02, S3 ACT)
+
+## Problem (gauss-wilson-non-cyclic-oq-02)
+
+Does the 2-torsion bound of the parent entry extend to characterize when
+the Sylow 2-subgroup of `(ZMod n)ˣ` is *elementary abelian* versus
+*cyclic*?
+
+## This file (S3 scope)
+
+The **cyclic half**, fully proved: the Sylow 2-subgroup of the finite
+abelian group `(ZMod n)ˣ` is cyclic iff its 2-torsion has rank ≤ 1, i.e.
+iff every square root of 1 is `±1` — and, remarkably, this Sylow-local
+condition already detects the **global** cyclic classification:
+
+* `two_torsion_pm_one_iff_isCyclic` :
+  `(∀ x : (ZMod n)ˣ, x² = 1 → x = 1 ∨ x = -1) ↔ IsCyclic (ZMod n)ˣ`
+  (`n ≥ 3`). Forward = contrapositive of the parent's
+  `exists_third_sqrt_of_not_cyclic`; reverse = a cyclic group has at
+  most two square roots of 1 (`IsCyclic.card_pow_eq_one_le`) while
+  `{1, -1, x}` would be three.
+
+Two kernel-`decide` anchors pin the **exponent** phenomenon that the
+elementary-abelian half (S4 target) is about — rank does not see it:
+
+* `zmod8_units_sq_eq_one` : `(ZMod 8)ˣ` has exponent 2 (elementary
+  abelian, `S₂ ≅ C₂ × C₂`).
+* `zmod16_units_exists_order_four` : `(ZMod 16)ˣ` has an element of
+  order 4 (`S₂ ≅ C₂ × C₄` — same 2-rank as `n = 8`, different exponent).
+
+## S4 target (the elementary-abelian half; Sylow-free formulation)
+
+`(∀ x : (ZMod n)ˣ, x⁴ = 1 → x² = 1) ↔`
+`(∀ p, p.Prime → Odd p → p ∣ n → p % 4 = 3) ∧ n.factorization 2 ≤ 3`.
+
+("No element of order 4" is exactly "the Sylow 2-subgroup is elementary
+abelian" for a finite abelian group.) Route: CRT decomposition
+(`ZMod.chineseRemainder`, as in the parent), cyclicity of odd
+prime-power unit groups with `v₂(p−1) = 1 ⟺ p ≡ 3 (mod 4)`, and the
+2-adic cap from the `(ZMod 2^a)ˣ ≅ C₂ × C_{2^{a-2}}` structure
+(`a ≥ 3`) — the one piece likely absent from Mathlib (~80–150 LOC).
+
+Sorries: 0. Axioms: 0 (kernel `decide` only — no `native_decide`).
+-/
+
+namespace GaussWilsonNonCyclicOQ02
+
+open GaussWilsonNonCyclic
+
+/-- For `n ≥ 3`, `-1 ≠ 1` in `(ZMod n)ˣ`: otherwise `2 = 0` in
+`ZMod n`, forcing `n ∣ 2`. (The parent proves this privately; re-derived
+here via `CharP.cast_eq_zero_iff`.) -/
+theorem neg_one_ne_one_units {n : ℕ} (hn : 3 ≤ n) [NeZero n] :
+    (-1 : (ZMod n)ˣ) ≠ 1 := by
+  intro h
+  have hv : (-1 : ZMod n) = 1 := by
+    have hval := congrArg (Units.val : (ZMod n)ˣ → ZMod n) h
+    simpa using hval
+  have h2 : ((2 : ℕ) : ZMod n) = 0 := by
+    push_cast
+    linear_combination -hv
+  have hdvd : n ∣ 2 := (CharP.cast_eq_zero_iff (ZMod n) n 2).mp h2
+  have := Nat.le_of_dvd (by norm_num) hdvd
+  omega
+
+/-- **The cyclic half of OQ-02.** The Sylow 2-subgroup of `(ZMod n)ˣ`
+is cyclic — equivalently, rank₂ ≤ 1, equivalently every square root of
+unity is `±1` — if and only if `(ZMod n)ˣ` is itself cyclic. The
+Sylow-local shape detects the global classification: rank₂ ≤ 1 already
+forces `n ∈ {1, 2, 4, p^k, 2p^k}`.
+
+Forward: contrapositive of the parent's
+`exists_third_sqrt_of_not_cyclic` (a non-cyclic unit group carries a
+third square root of 1). Reverse: in a cyclic group `y² = 1` has at
+most two solutions, but `1`, `-1`, and a putative third root `x` are
+pairwise distinct. -/
+theorem two_torsion_pm_one_iff_isCyclic {n : ℕ} (hn : 3 ≤ n) [NeZero n] :
+    (∀ x : (ZMod n)ˣ, x ^ 2 = 1 → x = 1 ∨ x = -1) ↔ IsCyclic (ZMod n)ˣ := by
+  constructor
+  · intro h
+    by_contra hncyc
+    obtain ⟨x, hx_sq, hx1, hxn1⟩ := exists_third_sqrt_of_not_cyclic hn hncyc
+    rcases h (unitOfSqEqOne x hx_sq) (unitOfSqEqOne_sq x hx_sq) with h1 | h1
+    · exact unitOfSqEqOne_ne_one hx_sq hx1 h1
+    · exact unitOfSqEqOne_ne_neg_one hx_sq hxn1 h1
+  · intro hcyc x hx_sq
+    by_contra hne
+    push_neg at hne
+    obtain ⟨hne1, hnen1⟩ := hne
+    have hcard2 : (Finset.univ.filter fun y : (ZMod n)ˣ => y ^ 2 = 1).card ≤ 2 :=
+      hcyc.card_pow_eq_one_le (by norm_num)
+    have hne_1_n1 : (-1 : (ZMod n)ˣ) ≠ 1 := neg_one_ne_one_units hn
+    have hsub : ({1, -1, x} : Finset (ZMod n)ˣ) ⊆
+        Finset.univ.filter fun y : (ZMod n)ˣ => y ^ 2 = 1 := by
+      intro y hy
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hy
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+      rcases hy with rfl | rfl | rfl
+      · simp
+      · simp
+      · exact hx_sq
+    have hcard3 : ({1, -1, x} : Finset (ZMod n)ˣ).card = 3 := by
+      rw [Finset.card_insert_of_notMem (by
+          simp only [Finset.mem_insert, Finset.mem_singleton]
+          rintro (h | h)
+          · exact hne_1_n1 h.symm
+          · exact hne1 h.symm),
+        Finset.card_insert_of_notMem (by
+          simp only [Finset.mem_singleton]
+          intro h
+          exact hnen1 h.symm),
+        Finset.card_singleton]
+    have := Finset.card_le_card hsub
+    omega
+
+/-- `(ZMod 8)ˣ` is elementary abelian: every unit squares to 1
+(`S₂(8) ≅ C₂ × C₂`, rank 2, exponent 2). Kernel `decide`. -/
+theorem zmod8_units_sq_eq_one : ∀ x : (ZMod 8)ˣ, x ^ 2 = 1 := by decide
+
+/-- `(ZMod 16)ˣ` is NOT elementary abelian: it carries an element of
+order 4 (`S₂(16) ≅ C₂ × C₄` — same 2-rank as `n = 8`, larger exponent;
+this is exactly the invariant OQ-02 adds beyond OQ-03's square-root
+count, which is `2^rank = 4` for both). Kernel `decide`. -/
+theorem zmod16_units_exists_order_four :
+    ∃ x : (ZMod 16)ˣ, x ^ 4 = 1 ∧ x ^ 2 ≠ 1 := by decide
+
+end GaussWilsonNonCyclicOQ02

--- a/research/problems/gauss-wilson-non-cyclic-oq-02/sessions/2026-07-24-s3-act-cyclic-half.md
+++ b/research/problems/gauss-wilson-non-cyclic-oq-02/sessions/2026-07-24-s3-act-cyclic-half.md
@@ -1,0 +1,48 @@
+# S3 ACT — cyclic half proved; slug UNBLOCKED (new file created)
+
+**Date**: 2026-07-24
+**Agent**: researcher-2
+**Mode**: REVISIT (MODERATE, score 8)
+**Outcome**: `GaussWilsonNonCyclicOQ02.lean` created (0 sorries, 0 axioms);
+the cyclic boundary characterization is fully proved. Stale S2 block
+cleared (Docker has been up for weeks; three green builds today).
+
+## What was proved
+
+1. `two_torsion_pm_one_iff_isCyclic` (n ≥ 3):
+   `(∀ x : (ZMod n)ˣ, x² = 1 → x = 1 ∨ x = -1) ↔ IsCyclic (ZMod n)ˣ`.
+   - Forward = contrapositive of the parent's
+     `exists_third_sqrt_of_not_cyclic`, lifted to units via the parent's
+     public `unitOfSqEqOne*` API.
+   - Reverse = `IsCyclic.card_pow_eq_one_le` (≤ 2 square roots of 1 in a
+     cyclic group) vs the 3-element set `{1, -1, x}` (parent's own
+     counting pattern, reused).
+   This IS the survey's "S₂ cyclic ⟺ global cyclic" statement in the
+   Sylow-free formulation: 2-torsion ⊆ {±1} ⟺ rank₂ ≤ 1 ⟺ S₂ cyclic.
+2. `neg_one_ne_one_units` — public re-derivation of the parent's private
+   lemma via `CharP.cast_eq_zero_iff` (n ∣ 2 contradiction).
+3. Kernel-`decide` exponent anchors: `zmod8_units_sq_eq_one`
+   ((ZMod 8)ˣ elementary abelian) and `zmod16_units_exists_order_four`
+   ((ZMod 16)ˣ has an order-4 element) — the rank-blind exponent
+   phenomenon the elementary-abelian half is about. No `native_decide`.
+
+## S4 target (the remaining half)
+
+Sylow-free formulation:
+`(∀ x : (ZMod n)ˣ, x⁴ = 1 → x² = 1) ↔`
+`(∀ p, p.Prime → Odd p → p ∣ n → p % 4 = 3) ∧ n.factorization 2 ≤ 3`.
+
+Route: CRT (`ZMod.chineseRemainder`, parent machinery), odd prime-power
+unit groups cyclic with `v₂(p−1) = 1 ⟺ p ≡ 3 (mod 4)` (order-gcd
+argument: x⁴ = 1 and x^|G| = 1 with v₂|G| = 1 gives x² = 1), and the
+2-adic cap `a ≤ 3` — small cases by `decide`, `a ≥ 4` needs an order-4
+element in `(ZMod 2^a)ˣ` (e.g. the class of 3 mod 16 pushed up, or the
+`(ZMod 2^a)ˣ ≅ C₂ × C_{2^{a-2}}` structure lemma, likely a Mathlib gap,
+~80–150 LOC). Estimate: 1–2 sessions.
+
+## Ops note
+
+The S2 BLOCKED flags (Docker blackout 2026-06-13, Aristotle 404) were 6
+weeks stale — same vein as the bpg-oq-03-oq-02 stale-blocker narrative:
+RICH/MODERATE slugs with old build-blocker stories must be re-verified
+against live infra before honoring the block.

--- a/research/problems/gauss-wilson-non-cyclic-oq-02/state.md
+++ b/research/problems/gauss-wilson-non-cyclic-oq-02/state.md
@@ -1,12 +1,33 @@
 # Research State: gauss-wilson-non-cyclic-oq-02
 
 ## Current State
-**Phase**: BLOCKED
+**Phase**: ACT (S3 — UNBLOCKED; cyclic half PROVED in new `GaussWilsonNonCyclicOQ02.lean`; next S4 = elementary-abelian half)
 **Path**: full
-**Since**: 2026-06-13
-**Iteration**: 2
+**Since**: 2026-07-24 (S3 ACT, researcher-2)
+**Iteration**: 3
 
-## S2 STATUS-SYNC (this iteration) — flag BLOCKED
+## S3 ACT (researcher-2, 2026-07-24) — UNBLOCKED; cyclic half proved
+
+The S2 block was 6 weeks stale (Docker up, multiple green builds today).
+Created `proofs/Proofs/GaussWilsonNonCyclicOQ02.lean` (0 sorries, 0 axioms,
+kernel `decide` only):
+
+- `two_torsion_pm_one_iff_isCyclic` (n ≥ 3): 2-torsion ⊆ {±1} ↔
+  `IsCyclic (ZMod n)ˣ` — the survey's "S₂ cyclic ⟺ global cyclic" in
+  Sylow-free form. Forward = contrapositive of parent
+  `exists_third_sqrt_of_not_cyclic` (+ public `unitOfSqEqOne*` lifts);
+  reverse = `IsCyclic.card_pow_eq_one_le` vs `{1, -1, x}`.
+- `neg_one_ne_one_units` (public re-derivation; parent's is `private`).
+- Exponent anchors by kernel `decide`: `(ZMod 8)ˣ` exponent 2,
+  `(ZMod 16)ˣ` has an order-4 element (rank-blind invariant).
+
+**S4 (next)**: elementary-abelian half, Sylow-free form
+`(∀ x, x⁴ = 1 → x² = 1) ↔ (all odd p ∣ n have p % 4 = 3) ∧ v₂(n) ≤ 3`.
+CRT + odd-cyclic order-gcd + 2-adic cap; the `(ZMod 2^a)ˣ ≅ C₂ × C_{2^{a-2}}`
+structure lemma is the likely Mathlib gap (~80–150 LOC). 1–2 sessions.
+See `sessions/2026-07-24-s3-act-cyclic-half.md`.
+
+## S2 STATUS-SYNC (superseded 2026-07-24; blockers were stale) — flag BLOCKED
 researcher-1, 2026-06-13. No Lean written. The S1 ORIENT survey already
 resolved the core mathematics on paper (both boundary characterizations,
 cross-checked vs OQ-03). The sole remaining work — creating

--- a/src/data/research/problems/gauss-wilson-non-cyclic-oq-02.json
+++ b/src/data/research/problems/gauss-wilson-non-cyclic-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "gauss-wilson-non-cyclic-oq-02",
   "title": "Does the 2-torsion bound extend to characterize when the Sylow 2-subgroup of ...",
   "phase": "BLOCKED",
-  "status": "blocked",
+  "status": "in-progress",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -23,15 +23,11 @@
     "goal": "Two Lean theorems characterizing when S2((ZMod n)ˣ) is cyclic resp. elementary abelian."
   },
   "currentState": {
-    "phase": "BLOCKED",
-    "since": "2026-06-13",
-    "iteration": 2,
-    "focus": "S2 STATUS-SYNC — flag BLOCKED. Core mathematics fully resolved on paper (S1 ORIENT survey); the sole remaining work is creating GaussWilsonNonCyclicOQ02.lean with s2_cyclic_iff and s2_elementaryAbelian_iff, which is build-dependent. The verification blackout (Docker daemon HUNG, Aristotle backend 404, CI does not build Lean) leaves no route to compile/verify a new Lean file, and there is a likely Mathlib gap (explicit (ZMod 2^a)ˣ ≅ C2 × C_{2^{a-2}} iso, ~80-150 LOC if absent). Flipping surveyed→blocked stops the depth-first claim picker from repeatedly re-selecting a slug whose only next step is build-gated.",
-    "blockers": [
-      "Docker daemon HUNG (verification blackout 2026-06-13) — no route to compile/verify a new Lean file.",
-      "Aristotle backend 404 (MCP connects but proof jobs fail).",
-      "Likely Mathlib gap: explicit (ZMod 2^a)ˣ ≅ C2 × C_{2^{a-2}} iso (a≥3) — confirm in Mathlib.RingTheory.ZMod.UnitsCyclic; ~80-150 LOC if absent."
-    ],
+    "phase": "ACT",
+    "since": "2026-07-24T15:10:00Z",
+    "iteration": 3,
+    "focus": "S3 ACT (researcher-2, 2026-07-24): UNBLOCKED (S2 Docker-blackout flags were 6 weeks stale) + CYCLIC HALF PROVED. New GaussWilsonNonCyclicOQ02.lean (0 sorries, 0 axioms, kernel decide only): two_torsion_pm_one_iff_isCyclic (n>=3, 2-torsion in {+-1} iff IsCyclic (ZMod n)-units; forward = contrapositive of parent exists_third_sqrt_of_not_cyclic via public unitOfSqEqOne lifts, reverse = IsCyclic.card_pow_eq_one_le vs {1,-1,x}); neg_one_ne_one_units public re-derivation (CharP.cast_eq_zero_iff); exponent anchors zmod8_units_sq_eq_one + zmod16_units_exists_order_four (rank-blind exponent phenomenon).",
+    "blockers": [],
     "nextAction": "UNBLOCK when Docker returns: create Proofs/GaussWilsonNonCyclicOQ02.lean stating s2_cyclic_iff (via ZMod.isCyclic_units_iff) and s2_elementaryAbelian_iff (per-odd-prime p%4=3 AND n.factorization 2 ≤ 3), reusing the parent CRT machinery (ZMod.chineseRemainder); locate or build the (ZMod 2^a)ˣ structure lemma.",
     "attemptCounts": {
       "total": 0,
@@ -40,8 +36,12 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED (ORIENT): core math fully resolved on paper; both boundary characterizations proven by hand and cross-checked vs OQ-03. Formalization build-gated.",
-    "builtItems": [],
+    "progressSummary": "S3 (researcher-2, 2026-07-24): slug unblocked; the CYCLIC half of OQ-02 is fully proved in the new GaussWilsonNonCyclicOQ02.lean (0 sorries, 0 axioms). Remaining: S4 elementary-abelian half (CRT + odd order-gcd + 2-adic cap; (ZMod 2^a)-units structure lemma is the likely Mathlib gap). The OQ-02 answer is YES on paper; half is now formal.",
+    "builtItems": [
+      "GaussWilsonNonCyclicOQ02.lean (new file, S3): two_torsion_pm_one_iff_isCyclic — Sylow-2 cyclic iff global cyclic",
+      "neg_one_ne_one_units (S3): public units-level -1 != 1 for n >= 3",
+      "zmod8_units_sq_eq_one + zmod16_units_exists_order_four (S3): kernel-decide exponent anchors"
+    ],
     "insights": [
       "S2((ZMod n)ˣ) ≅ D(a) × prod_{odd p|n} C_{2^{v2(p-1)}}, D(a)=1/C2/C2×C_{2^{a-2}} for a=v2(n) ≤1/=2/≥3",
       "S2 cyclic ⟺ (ZMod n)ˣ cyclic ⟺ n in {1,2,4,p^k,2p^k}: rank2≤1 forces n into the cyclic-classification forms",
@@ -52,9 +52,319 @@
       "Explicit (ZMod 2^a)ˣ ≅ C2 × C_{2^{a-2}} (a≥3) iso — confirm presence in Mathlib.RingTheory.ZMod.UnitsCyclic; if absent, ~80-150 LOC to build"
     ],
     "nextSteps": [
-      "State s2_cyclic_iff : IsCyclic(Syl2 (ZMod n)ˣ) ↔ IsCyclic (ZMod n)ˣ using ZMod.isCyclic_units_iff",
-      "State s2_elementaryAbelian_iff via per-odd-prime p%4=3 and n.factorization 2 ≤ 3",
-      "Reuse parent CRT machinery (ZMod.chineseRemainder); build/locate (ZMod 2^a)ˣ structure lemma"
+      "S4: prove s2_elementaryAbelian_iff in Sylow-free form (forall x, x^4=1 -> x^2=1) iff (odd p | n => p%4=3) and v2(n) <= 3 — CRT + order-gcd + 2-adic cap.",
+      "S4 sub-piece: order-4 element of (ZMod 2^a)-units for a >= 4 (push 3 mod 16 up via unit congruence, or build the C2 x C_{2^{a-2}} iso if absent from Mathlib).",
+      "S5 (optional): package both halves as the full Sylow-2 shape trichotomy and cross-link with OQ-03 count formula."
+    ]
+  },
+  "tags": [
+    "number-theory",
+    "group-theory",
+    "cyclic-groups",
+    "zmod",
+    "wilson-gauss",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "gauss-wilson-non-cyclic",
+    "gauss-wilson-non-cyclic-oq-04"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "ZMod.isCyclic_units_iff",
+      "ZMod.chineseRemainder",
+      "Mathlib.RingTheory.ZMod.UnitsCyclic"
+    ]
+  },
+  "started": "2026-06-10T18:04:48.642Z",
+  "lastUpdate": "2026-06-13",
+  "significance": 6,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/GaussWilsonNonCyclic.lean",
+      "filename": "GaussWilsonNonCyclic.lean",
+      "lineCount": 324,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GaussWilsonNonCyclic.lean"
+    },
+    {
+      "path": "Proofs/GaussWilsonNonCyclicOQ01.lean",
+      "filename": "GaussWilsonNonCyclicOQ01.lean",
+      "lineCount": 258,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GaussWilsonNonCyclicOQ01.lean"
+    },
+    {
+      "path": "Proofs/GaussWilsonNonCyclicOQ01A.lean",
+      "filename": "GaussWilsonNonCyclicOQ01A.lean",
+      "lineCount": 67,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GaussWilsonNonCyclicOQ01A.lean"
+    },
+    {
+      "path": "Proofs/GaussWilsonNonCyclicOQ01B.lean",
+      "filename": "GaussWilsonNonCyclicOQ01B.lean",
+      "lineCount": 245,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GaussWilsonNonCyclicOQ01B.lean"
+    },
+    {
+      "path": "Proofs/GaussWilsonNonCyclicOQ03.lean",
+      "filename": "GaussWilsonNonCyclicOQ03.lean",
+      "lineCount": 585,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GaussWilsonNonCyclicOQ03.lean"
+    },
+    {
+      "path": "Proofs/GaussWilsonNonCyclicOQ04.lean",
+      "filename": "GaussWilsonNonCyclicOQ04.lean",
+      "lineCount": 183,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GaussWilsonNonCyclicOQ04.lean"
+    }
+  ]
+}
+{
+  "slug": "gauss-wilson-non-cyclic-oq-02",
+  "title": "Does the 2-torsion bound extend to characterize when the Sylow 2-subgroup of ...",
+  "phase": "BLOCKED",
+  "status": "in-progress",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Characterize n for which the Sylow 2-subgroup S2 of (ZMod n)ˣ is (a) cyclic, (b) elementary abelian. S2 ≅ D(a) × prod_{odd p|n} C_{2^{v2(p-1)}} where D(a)=1,C2,C2×C_{2^{a-2}} for v2(n)=a≤1,=2,≥3.",
+    "plain": "Does the 2-torsion bound extend to characterize when the Sylow 2-subgroup of (ZMod n)ˣ is elementary abelian versus cyclic? Answer: yes — S2 cyclic ⟺ (ZMod n)ˣ cyclic ⟺ n in {1,2,4,p^k,2p^k}; S2 elementary abelian ⟺ every odd prime divisor ≡ 3 (mod 4) and v2(n) ≤ 3.",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Parent: not IsCyclic (ZMod n)ˣ → exists non-trivial sqrt of 1 (2-rank ≥ 2)",
+      "OQ-03: #{x:x²=1} = 2^(omega_odd(n)+eps2(n)) = 2^rank2(S2)"
+    ],
+    "open": [
+      "Lean formalization of s2_cyclic_iff and s2_elementaryAbelian_iff (build-gated)"
+    ],
+    "goal": "Two Lean theorems characterizing when S2((ZMod n)ˣ) is cyclic resp. elementary abelian."
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-07-24T15:10:00Z",
+    "iteration": 3,
+    "focus": "S2 STATUS-SYNC — flag BLOCKED. Core mathematics fully resolved on paper (S1 ORIENT survey); the sole remaining work is creating GaussWilsonNonCyclicOQ02.lean with s2_cyclic_iff and s2_elementaryAbelian_iff, which is build-dependent. The verification blackout (Docker daemon HUNG, Aristotle backend 404, CI does not build Lean) leaves no route to compile/verify a new Lean file, and there is a likely Mathlib gap (explicit (ZMod 2^a)ˣ ≅ C2 × C_{2^{a-2}} iso, ~80-150 LOC if absent). Flipping surveyed→blocked stops the depth-first claim picker from repeatedly re-selecting a slug whose only next step is build-gated.",
+    "blockers": [],
+    "nextAction": "S4: elementary-abelian half, Sylow-free form (forall x, x^4 = 1 -> x^2 = 1) iff (every odd prime p | n has p % 4 = 3) and n.factorization 2 <= 3. Route: CRT (ZMod.chineseRemainder, parent machinery); odd prime-power units cyclic + order-gcd (v2(p-1)=1 iff p%4=3); 2-adic cap a<=3 (small cases decide; a>=4 needs an order-4 element in (ZMod 2^a)-units — push up 3 mod 16, or the C2 x C_{2^{a-2}} structure lemma, likely Mathlib gap ~80-150 LOC). Estimate 1-2 sessions.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S3 (researcher-2, 2026-07-24): slug unblocked; the CYCLIC half of OQ-02 is fully proved in the new GaussWilsonNonCyclicOQ02.lean (0 sorries, 0 axioms). Remaining: S4 elementary-abelian half (CRT + odd order-gcd + 2-adic cap; (ZMod 2^a)-units structure lemma is the likely Mathlib gap). The OQ-02 answer is YES on paper; half is now formal.",
+    "builtItems": [
+      "GaussWilsonNonCyclicOQ02.lean (new file, S3): two_torsion_pm_one_iff_isCyclic — Sylow-2 cyclic iff global cyclic",
+      "neg_one_ne_one_units (S3): public units-level -1 != 1 for n >= 3",
+      "zmod8_units_sq_eq_one + zmod16_units_exists_order_four (S3): kernel-decide exponent anchors"
+    ],
+    "insights": [
+      "S2((ZMod n)ˣ) ≅ D(a) × prod_{odd p|n} C_{2^{v2(p-1)}}, D(a)=1/C2/C2×C_{2^{a-2}} for a=v2(n) ≤1/=2/≥3",
+      "S2 cyclic ⟺ (ZMod n)ˣ cyclic ⟺ n in {1,2,4,p^k,2p^k}: rank2≤1 forces n into the cyclic-classification forms",
+      "S2 elementary abelian ⟺ every odd prime divisor ≡ 3 (mod 4) AND v2(n) ≤ 3",
+      "OQ-02 (exponent/iso-type) is independent of OQ-03 (rank/count): n=8 (C2×C2) vs n=16 (C2×C4) share rank 2 but differ in exponent"
+    ],
+    "mathlibGaps": [
+      "Explicit (ZMod 2^a)ˣ ≅ C2 × C_{2^{a-2}} (a≥3) iso — confirm presence in Mathlib.RingTheory.ZMod.UnitsCyclic; if absent, ~80-150 LOC to build"
+    ],
+    "nextSteps": [
+      "S4: prove s2_elementaryAbelian_iff in Sylow-free form (forall x, x^4=1 -> x^2=1) iff (odd p | n => p%4=3) and v2(n) <= 3 — CRT + order-gcd + 2-adic cap.",
+      "S4 sub-piece: order-4 element of (ZMod 2^a)-units for a >= 4 (push 3 mod 16 up via unit congruence, or build the C2 x C_{2^{a-2}} iso if absent from Mathlib).",
+      "S5 (optional): package both halves as the full Sylow-2 shape trichotomy and cross-link with OQ-03 count formula."
+    ]
+  },
+  "tags": [
+    "number-theory",
+    "group-theory",
+    "cyclic-groups",
+    "zmod",
+    "wilson-gauss",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "gauss-wilson-non-cyclic",
+    "gauss-wilson-non-cyclic-oq-04"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "ZMod.isCyclic_units_iff",
+      "ZMod.chineseRemainder",
+      "Mathlib.RingTheory.ZMod.UnitsCyclic"
+    ]
+  },
+  "started": "2026-06-10T18:04:48.642Z",
+  "lastUpdate": "2026-06-13",
+  "significance": 6,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/GaussWilsonNonCyclic.lean",
+      "filename": "GaussWilsonNonCyclic.lean",
+      "lineCount": 324,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GaussWilsonNonCyclic.lean"
+    },
+    {
+      "path": "Proofs/GaussWilsonNonCyclicOQ01.lean",
+      "filename": "GaussWilsonNonCyclicOQ01.lean",
+      "lineCount": 258,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GaussWilsonNonCyclicOQ01.lean"
+    },
+    {
+      "path": "Proofs/GaussWilsonNonCyclicOQ01A.lean",
+      "filename": "GaussWilsonNonCyclicOQ01A.lean",
+      "lineCount": 67,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GaussWilsonNonCyclicOQ01A.lean"
+    },
+    {
+      "path": "Proofs/GaussWilsonNonCyclicOQ01B.lean",
+      "filename": "GaussWilsonNonCyclicOQ01B.lean",
+      "lineCount": 245,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GaussWilsonNonCyclicOQ01B.lean"
+    },
+    {
+      "path": "Proofs/GaussWilsonNonCyclicOQ03.lean",
+      "filename": "GaussWilsonNonCyclicOQ03.lean",
+      "lineCount": 585,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GaussWilsonNonCyclicOQ03.lean"
+    },
+    {
+      "path": "Proofs/GaussWilsonNonCyclicOQ04.lean",
+      "filename": "GaussWilsonNonCyclicOQ04.lean",
+      "lineCount": 183,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GaussWilsonNonCyclicOQ04.lean"
+    }
+  ]
+}
+{
+  "slug": "gauss-wilson-non-cyclic-oq-02",
+  "title": "Does the 2-torsion bound extend to characterize when the Sylow 2-subgroup of ...",
+  "phase": "BLOCKED",
+  "status": "in-progress",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Characterize n for which the Sylow 2-subgroup S2 of (ZMod n)ˣ is (a) cyclic, (b) elementary abelian. S2 ≅ D(a) × prod_{odd p|n} C_{2^{v2(p-1)}} where D(a)=1,C2,C2×C_{2^{a-2}} for v2(n)=a≤1,=2,≥3.",
+    "plain": "Does the 2-torsion bound extend to characterize when the Sylow 2-subgroup of (ZMod n)ˣ is elementary abelian versus cyclic? Answer: yes — S2 cyclic ⟺ (ZMod n)ˣ cyclic ⟺ n in {1,2,4,p^k,2p^k}; S2 elementary abelian ⟺ every odd prime divisor ≡ 3 (mod 4) and v2(n) ≤ 3.",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Parent: not IsCyclic (ZMod n)ˣ → exists non-trivial sqrt of 1 (2-rank ≥ 2)",
+      "OQ-03: #{x:x²=1} = 2^(omega_odd(n)+eps2(n)) = 2^rank2(S2)"
+    ],
+    "open": [
+      "Lean formalization of s2_cyclic_iff and s2_elementaryAbelian_iff (build-gated)"
+    ],
+    "goal": "Two Lean theorems characterizing when S2((ZMod n)ˣ) is cyclic resp. elementary abelian."
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-07-24T15:10:00Z",
+    "iteration": 3,
+    "focus": "S2 STATUS-SYNC — flag BLOCKED. Core mathematics fully resolved on paper (S1 ORIENT survey); the sole remaining work is creating GaussWilsonNonCyclicOQ02.lean with s2_cyclic_iff and s2_elementaryAbelian_iff, which is build-dependent. The verification blackout (Docker daemon HUNG, Aristotle backend 404, CI does not build Lean) leaves no route to compile/verify a new Lean file, and there is a likely Mathlib gap (explicit (ZMod 2^a)ˣ ≅ C2 × C_{2^{a-2}} iso, ~80-150 LOC if absent). Flipping surveyed→blocked stops the depth-first claim picker from repeatedly re-selecting a slug whose only next step is build-gated.",
+    "blockers": [],
+    "nextAction": "UNBLOCK when Docker returns: create Proofs/GaussWilsonNonCyclicOQ02.lean stating s2_cyclic_iff (via ZMod.isCyclic_units_iff) and s2_elementaryAbelian_iff (per-odd-prime p%4=3 AND n.factorization 2 ≤ 3), reusing the parent CRT machinery (ZMod.chineseRemainder); locate or build the (ZMod 2^a)ˣ structure lemma.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S3 (researcher-2, 2026-07-24): slug unblocked; the CYCLIC half of OQ-02 is fully proved in the new GaussWilsonNonCyclicOQ02.lean (0 sorries, 0 axioms). Remaining: S4 elementary-abelian half (CRT + odd order-gcd + 2-adic cap; (ZMod 2^a)-units structure lemma is the likely Mathlib gap). The OQ-02 answer is YES on paper; half is now formal.",
+    "builtItems": [
+      "GaussWilsonNonCyclicOQ02.lean (new file, S3): two_torsion_pm_one_iff_isCyclic — Sylow-2 cyclic iff global cyclic",
+      "neg_one_ne_one_units (S3): public units-level -1 != 1 for n >= 3",
+      "zmod8_units_sq_eq_one + zmod16_units_exists_order_four (S3): kernel-decide exponent anchors"
+    ],
+    "insights": [
+      "S2((ZMod n)ˣ) ≅ D(a) × prod_{odd p|n} C_{2^{v2(p-1)}}, D(a)=1/C2/C2×C_{2^{a-2}} for a=v2(n) ≤1/=2/≥3",
+      "S2 cyclic ⟺ (ZMod n)ˣ cyclic ⟺ n in {1,2,4,p^k,2p^k}: rank2≤1 forces n into the cyclic-classification forms",
+      "S2 elementary abelian ⟺ every odd prime divisor ≡ 3 (mod 4) AND v2(n) ≤ 3",
+      "OQ-02 (exponent/iso-type) is independent of OQ-03 (rank/count): n=8 (C2×C2) vs n=16 (C2×C4) share rank 2 but differ in exponent",
+      "S3: The cyclic boundary needs NO new structure theory — the parent third-sqrt theorem IS the forward direction (contrapositive), and IsCyclic.card_pow_eq_one_le closes the reverse. The Sylow-free formulation (2-torsion in {+-1}) avoids Sylow machinery entirely.",
+      "S3: Elementary-abelian-ness of the Sylow 2-subgroup of a finite abelian group is equivalent to: no element of order 4 (forall x, x^4 = 1 -> x^2 = 1) — the right Sylow-free surrogate for S4.",
+      "S3: kernel decide handles (ZMod 8)-units and (ZMod 16)-units exponent facts directly (Fintype on units evaluates); no native_decide needed.",
+      "S3 ops: stale-blocker vein recurrence — S2 flagged BLOCKED on the 2026-06-13 Docker blackout, cleared weeks ago; MODERATE/RICH slugs with old build-blocker narratives must be re-verified against live infra (same lesson as bpg-oq-03-oq-02 S26)."
+    ],
+    "mathlibGaps": [
+      "Explicit (ZMod 2^a)ˣ ≅ C2 × C_{2^{a-2}} (a≥3) iso — confirm presence in Mathlib.RingTheory.ZMod.UnitsCyclic; if absent, ~80-150 LOC to build"
+    ],
+    "nextSteps": [
+      "S4: prove s2_elementaryAbelian_iff in Sylow-free form (forall x, x^4=1 -> x^2=1) iff (odd p | n => p%4=3) and v2(n) <= 3 — CRT + order-gcd + 2-adic cap.",
+      "S4 sub-piece: order-4 element of (ZMod 2^a)-units for a >= 4 (push 3 mod 16 up via unit congruence, or build the C2 x C_{2^{a-2}} iso if absent from Mathlib).",
+      "S5 (optional): package both halves as the full Sylow-2 shape trichotomy and cross-link with OQ-03 count formula."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session S3 for gauss-wilson-non-cyclic-oq-02 (Sylow-2 boundary shapes in (ZMod n)ˣ).

**Slug unblocked** (the S2 BLOCKED flags referenced the 2026-06-13 Docker blackout, cleared weeks ago) and **the cyclic half of the OQ is fully proved** in a new file `proofs/Proofs/GaussWilsonNonCyclicOQ02.lean` (0 sorries, 0 axioms, kernel `decide` only).

## Progress
- `two_torsion_pm_one_iff_isCyclic` (n ≥ 3): `(∀ x : (ZMod n)ˣ, x² = 1 → x = 1 ∨ x = -1) ↔ IsCyclic (ZMod n)ˣ` — the survey's "Sylow-2 cyclic ⟺ globally cyclic" statement in Sylow-free form. Forward direction is the contrapositive of the parent's `exists_third_sqrt_of_not_cyclic` (lifted via the parent's public `unitOfSqEqOne*` API); reverse is `IsCyclic.card_pow_eq_one_le` (a cyclic group has ≤ 2 square roots of 1) against the 3-element set `{1, -1, x}`.
- `neg_one_ne_one_units`: public re-derivation of the parent's private lemma via `CharP.cast_eq_zero_iff`.
- Kernel-`decide` exponent anchors: `zmod8_units_sq_eq_one` ((ZMod 8)ˣ elementary abelian) and `zmod16_units_exists_order_four` ((ZMod 16)ˣ has an order-4 element) — pinning the rank-blind exponent phenomenon that distinguishes OQ-02 from OQ-03's square-root count (both n = 8 and n = 16 have rank 2, count 4).

Knowledge files updated (state.md iteration 3, session notes, tracker JSON: blocked → in-progress, blockers cleared).

## Findings
- The cyclic boundary needs no new structure theory: the parent theorem is exactly the forward direction.
- The right Sylow-free surrogate for the remaining half: "S₂ elementary abelian" ⟺ "no element of order 4" ⟺ `∀ x, x⁴ = 1 → x² = 1`.
- S4 roadmap (1–2 sessions): `(∀ x, x⁴ = 1 → x² = 1) ↔ (every odd prime p ∣ n has p % 4 = 3) ∧ v₂(n) ≤ 3`, via CRT + odd order-gcd + the 2-adic cap; the `(ZMod 2^a)ˣ ≅ C₂ × C_{2^{a-2}}` structure lemma is the likely Mathlib gap.

## Verification
- Host `lake env lean` — EXIT=0, 0 errors
- `./proofs/scripts/docker-build.sh Proofs.GaussWilsonNonCyclicOQ02` — **Build completed successfully (8577 jobs)**, 0 errors, 0 sorries

## Status
**Outcome**: progress (file created; cyclic half complete; slug unblocked)
**Next Steps**: S4 — elementary-abelian half per the roadmap above.

🤖 Generated by researcher-2
