### PR TITLE
Enrich cauchy-interlacing-theorem: split module docstring from opens/namespace section

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem/meta.json
@@ -79,11 +79,19 @@
   "sections": [
     {
       "id": "header",
-      "title": "Compression Interface and Statement",
+      "title": "Module Docstring: Compression Interface and Proof Outline",
       "startLine": 1,
-      "endLine": 62,
-      "summary": "File header: the interlacing inequalities to be proved, the compression interface (Rayleigh-agreement hypothesis as the only link between T and TH, satisfied by the orthogonal compression / principal submatrix), and the two-direction proof outline.",
+      "endLine": 54,
+      "summary": "File docstring: the interlacing inequalities to be proved, the compression interface (Rayleigh-agreement hypothesis as the only link between T and TH, satisfied by the orthogonal compression / principal submatrix), and the two-direction proof outline.",
       "mathContext": "Frames interlacing in the abstract operator/compression form so the assembly is purely order-theoretic; the spectral theorem on H and the compression construction supply the hypotheses when specialising to matrices."
+    },
+    {
+      "id": "imports-namespace",
+      "title": "Scoped Opens and Namespace",
+      "startLine": 56,
+      "endLine": 62,
+      "summary": "Opens `InnerProductSpace` notation and the `CauchyInterlacing.Keystone` namespace (bringing the two max–min keystone lemmas and `exists_rayleigh_le_in_subspace` into scope unqualified), then declares the `CauchyInterlacing.Assembly` namespace housing the single theorem below.",
+      "mathContext": "Opening the keystone namespace unqualified is what lets the assembly proof call `eigenvalue_maxmin_lower`/`eigenvalue_maxmin_upper` directly rather than through the fully-qualified `CauchyInterlacing.Keystone.` prefix."
     },
     {
       "id": "statement",


### PR DESCRIPTION
Closes the `sections: 8/10` quality-breakdown gap (4 sections, cap is 5).

The former "header" section (lines 1-62) bundled two conceptually distinct
parts of the file: the module docstring (interlacing statement, compression
interface, proof outline — lines 1-54) and the scoped `open`/`namespace`
declarations that follow it (lines 56-62). Split at that real boundary into
"Module Docstring: Compression Interface and Proof Outline" and "Scoped Opens
and Namespace", bringing sections coverage to 5/5.

No changes to annotations.json (ranges unaffected) or any other field.