### PR TITLE
Enrich cauchy-interlacing-theorem-oq001: split docstring section

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq001/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq001/meta.json
@@ -87,11 +87,18 @@
   },
   "sections": [
     {
-      "id": "docstring",
-      "title": "Overview: the unitary-invariance corollary",
+      "id": "docstring-motivation",
+      "title": "Docstring: why this corollary is isolated here",
       "startLine": 3,
+      "endLine": 13,
+      "summary": "Module docstring opening: the parent entry (cauchy-interlacing-theorem-oq-01-oq-01-oq-01) proved the bridge lemma eigenvalues_eq_of_eigenbasis and, in its own docstring, recorded but did not formalize the unitary-conjugation headline corollary — flagging it as that entry's lead open question. This file exists to isolate exactly that corollary as a reusable lemma."
+    },
+    {
+      "id": "docstring-summary",
+      "title": "Docstring: the two lemmas, proof recipe, and application",
+      "startLine": 15,
       "endLine": 37,
-      "summary": "Module docstring: the parent proved the bridge lemma eigenvalues_eq_of_eigenbasis and flagged the unitary-conjugation corollary as its lead open question. This file isolates that corollary, names the two results, sketches the eigenbasis-transport recipe, and explains the payoff for principal-submatrix Cauchy interlacing. Notes the file is intentionally not registered in Proofs.lean (research file)."
+      "summary": "Names and states the two results (isSymmetric_of_isometryConj, eigenvalues_isometryConj), sketches the eigenbasis-transport proof recipe, and explains the payoff: this is the tool that finishes principal-submatrix Cauchy interlacing by identifying an orthogonal compression's spectrum with an isometric conjugate's. Notes the field generality (any RCLike 𝕜) and that the file is intentionally not registered in Proofs.lean (research file)."
     },
     {
       "id": "setup",


### PR DESCRIPTION
Closes the `sections: 8/10` quality-breakdown gap (4 sections, cap is 5).

The former "docstring" section (lines 3-37) bundled two rhetorically distinct
parts of the module docstring: the motivation for why this corollary gets its
own file (referencing the parent entry's flagged-but-unformalized open
question, lines 3-13), and the actual content summary — naming the two
lemmas, sketching the proof recipe, and explaining the principal-submatrix
interlacing payoff (lines 15-37). Split at that real boundary into
"docstring-motivation" and "docstring-summary", bringing sections coverage to
5/5.

No changes to annotations.json (ranges unaffected) or any other field.