### PR TITLE
Enrich cauchy-schwarz-oq-02-oq-02-oq-01: add module header section

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-02-oq-01/meta.json
@@ -73,6 +73,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header: Docstring and Setup",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "File docstring stating the completeness criterion (∃ Hilbert basis b with ⇑b = v) ↔ (∀ x, Parseval holds), sketching the forward/reverse proof strategy against the parent's Bessel inequality, followed by imports, scoped opens, the `ParsevalCompleteness` namespace, and the ambient `F` variable (a complete real inner product space).",
+      "mathContext": "Frames this file as the reverse half of the standard orthonormal-basis ⟺ complete ⟺ Parseval ⟺ total equivalence, with Mathlib supplying the basis-construction machinery (`HilbertBasis.mkOfOrthogonalEqBot`) and the parent supplying the forward Parseval identity."
+    },
+    {
       "id": "section-forward",
       "title": "Forward Direction — Hilbert Basis ⟹ Parseval",
       "startLine": 49,


### PR DESCRIPTION
Closes the `sections: 8/10` quality-breakdown gap (4 sections, cap is 5).

Lines 1-47 (module docstring, imports, scoped opens, namespace, and the
ambient `F` variable) were entirely uncovered — the first recorded section
(`section-forward`) started at line 49, right after the "Section 1" banner
comment. Added a "Module Header: Docstring and Setup" section spanning the
true start of the file, bringing sections coverage to 5/5.

No changes to annotations.json (ranges unaffected) or any other field.