### PR TITLE
Enrich cauchy-schwarz-oq-03-oq-02-oq-01: split docstring from imports/namespace section

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03-oq-02-oq-01/meta.json
@@ -81,11 +81,19 @@
   "sections": [
     {
       "id": "header",
-      "title": "Module Docstring and Setup",
-      "summary": "States the open question from the parent forward-Minkowski entry, explains why 0 < p < 1 reverses the triangle inequality (the p-functional is a concave quasi-norm, hence superadditive), and records that Mathlib has no 0 < p < 1 Holder/Minkowski lemma (all gated on HolderConjugate forcing p, q > 1). Lists the three results and the durable Python numerical certificate. Imports Mathlib and opens Finset, NNReal under namespace ReverseMinkowski.",
+      "title": "Module Docstring",
+      "summary": "States the open question from the parent forward-Minkowski entry, explains why 0 < p < 1 reverses the triangle inequality (the p-functional is a concave quasi-norm, hence superadditive), and records that Mathlib has no 0 < p < 1 Holder/Minkowski lemma (all gated on HolderConjugate forcing p, q > 1). Sketches the reverse-Holder and Riesz reverse-Minkowski proofs, lists the three results, the durable Python numerical certificate, and the Hardy-Littlewood-Polya / Riesz references.",
       "startLine": 1,
-      "endLine": 64,
+      "endLine": 58,
       "mathContext": "Engine is reverse Holder with negative conjugate $q = p/(p-1) < 0$; $1/p + 1/q = 1$."
+    },
+    {
+      "id": "imports-namespace",
+      "title": "Imports and Namespace",
+      "summary": "Imports Mathlib wholesale and opens Finset, NNReal under the ReverseMinkowski namespace, preparing the ambient scope for the three theorems below.",
+      "startLine": 60,
+      "endLine": 64,
+      "mathContext": "The whole-Mathlib import is needed for both Real.HolderConjugate/NNReal.inner_le_Lp_mul_Lq (the forward-Holder engine driving the reverse direction) and the Finset sum manipulations."
     },
     {
       "id": "reverse-holder",


### PR DESCRIPTION
Closes the `sections: 8/10` quality-breakdown gap (4 sections, cap is 5).

The former "Module Docstring and Setup" section (lines 1-64) bundled the
module docstring (lines 1-58, closing at its own `-/`) together with the
`import Mathlib` / `open Finset NNReal` / `namespace ReverseMinkowski` lines
that follow it (60-64). Split at that real boundary into "Module Docstring"
and "Imports and Namespace", bringing sections coverage to 5/5.

No changes to annotations.json (ranges unaffected) or any other field.