### PR TITLE
Fix: mark erdos-1052 axiomatized (native_decide → Lean.ofReduceBool)

### DIFF
--- a/src/data/proofs/erdos-1052/meta.json
+++ b/src/data/proofs/erdos-1052/meta.json
@@ -7,7 +7,7 @@
     "author": "Wall",
     "sourceUrl": "https://erdosproblems.com/1052",
     "date": "1972",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1052Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "perfect-numbers",
       "open-problem"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1052,
     "erdosUrl": "https://erdosproblems.com/1052",
@@ -58,9 +58,9 @@
       "Three verified examples (6, 60, 90) via native_decide",
       "erdos_1052_conjecture: finiteness conjecture described in comment (not formally axiomatized)"
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 529,
-    "assumptions": "No mathematical axioms and 0 sorries. even_of_isUnitaryPerfect is fully proved via multiplicativity + prime decomposition, and the finiteness conjecture is not formally stated as an axiom (open problem described in the closing comment). Compiler-trust disclosure: the concrete unitary-perfect verifications (isUnitaryPerfect_6, isUnitaryPerfect_60, isUnitaryPerfect_90, isUnitaryPerfect_87360) are discharged with native_decide, so their axiom footprint includes Lean.ofReduceBool (kernel reduction trusts the compiled decision procedure). These are finite decidable computations and add no mathematical assumption; leanFile.axiomCount remains 0 (no literal axiom declarations).",
+    "assumptions": "The mathematical content (even_of_isUnitaryPerfect — all unitary perfect numbers are even) is fully proved via multiplicativity + prime decomposition with no assumptions, and the finiteness conjecture is not formally stated as an axiom (open problem described in the closing comment). Compiler-trust assumption (axiomCount 1): the concrete unitary-perfect verifications (isUnitaryPerfect_6/_60/_90/_87360), stated as named theorems the entry presents as verified, are discharged with native_decide (the 87360 case enumerates divisors of a 5-digit number, infeasible for kernel decide), so their proof term depends on Lean.ofReduceBool (the kernel trusts the compiled decision procedure). These are finite decidable computations that add no mathematical assumption, but per the Axiom Integrity Policy native_decide on a presented-verified result is counted: meta.axiomCount = 1 (Lean.ofReduceBool), status axiomatized. leanFile.axiomCount remains 0 (no literal axiom declarations).",
     "theoremCount": 24,
     "definitionCount": 3,
     "additionalFiles": [


### PR DESCRIPTION
## Problem

`erdos-1052` was `status: verified` / `badge: original` / `axiomCount: 0`, but the named theorems `isUnitaryPerfect_6/_60/_90/_87360` — presented as verified results in the "Main Results" / "Verified Examples" sections — are discharged by `native_decide`. Per the Axiom Integrity Policy, `native_decide` on a presented-verified result pulls in `Lean.ofReduceBool` (the kernel trusts the compiled decision procedure), so the entry is not axiom-free.

Unlike [erdos-399], the `native_decide` here **cannot** be eliminated: `isUnitaryPerfect_87360` enumerates the proper unitary divisors of 87360 (a 5-digit number) in `(Finset.Ico 1 87360).filter …`, which is infeasible for kernel `decide`.

## Fix (metadata only)

Aligned the status/badge/count with the dependency the `assumptions` field already disclosed:
- `status`: `verified` → `axiomatized`
- `badge`: `original` → `axiom`
- `meta.axiomCount`: `0` → `1` (the `Lean.ofReduceBool` from native_decide)
- `leanFile.axiomCount`: stays `0` (no literal `axiom` declarations)
- Rewrote `assumptions` to state axiomCount = 1 and cite the policy.

This matches the established convention for native_decide-dependent entries (e.g. `abel-ruffini-oq-04-oq-01`, `abel-ruffini-galois-extensions`: `axiomatized`/`axiom`/`axc=1`).

## Not affected

The core mathematical contribution `even_of_isUnitaryPerfect` (all unitary perfect numbers are even) remains **fully proved with no assumptions** via multiplicativity + prime decomposition — no native_decide, no axioms.

No Lean source change; JSON validated.
