### PR TITLE
Research: erdos-735-oq-04 S6e — general-position uniform-weight theorem (simplex configs magic for every k)

### DIFF
--- a/proofs/Proofs/Erdos735OQ04GeneralPosition.lean
+++ b/proofs/Proofs/Erdos735OQ04GeneralPosition.lean
@@ -1,0 +1,163 @@
+/-
+  Erdős Problem #735, Open Question #04 (oq-04) — S6e ACT:
+  The general-position uniform-weight theorem for k-flat magic configurations.
+
+  Parent: `Proofs.Erdos735OQ04` (k-flat magic configurations in ℝ^d).
+
+  ## What this file proves
+
+  The S6a tetrahedron witness (`Erdos735OQ04Tetrahedron.lean`) worked because a
+  rank-2 flat cannot swallow four affinely independent points, so every 2-flat
+  through ≥ 3 of them meets the configuration in *exactly* 3 points and the
+  uniform weighting is magic with constant 3. This file abstracts that argument
+  into the general theorem the S6 roadmap called the "general-position
+  uniform-weight theorem", in three layers:
+
+  * `IsKFlatGeneralPositionD k P` — no rank-`k` flat contains more than `k + 1`
+    points of `P` (the `k`-flat analogue of the parent's `IsGeneralPositionD`,
+    which is the case `k = 1` with bound `2`).
+  * `isKFlatMagic_of_kFlatGeneralPosition` — **any** configuration in k-flat
+    general position is k-flat magic, with uniform weight `1` and magic
+    constant `k + 1`: each `ConfigKFlat` carries `≥ k+1` points by definition
+    and `≤ k+1` by hypothesis, so every flat sum is exactly `k + 1`.
+  * `kFlatGeneralPositionD_of_affineIndependent` — an affinely independent
+    configuration is in k-flat general position for *every* `k`: any `k + 2`
+    of its points span a flat of rank `≥ k + 1`, which cannot fit inside a
+    rank-`k` flat (`AffineIndependent.finrank_vectorSpan` + rank monotonicity).
+
+  Consequences:
+
+  * `isKFlatMagic_of_affineIndependent` — every affinely independent
+    configuration (simplex-type configuration) is k-flat magic for **every**
+    `k` simultaneously. The S6a tetrahedron (`d = 3, k = 2`) becomes one
+    instance of a uniform family: the higher-flat magic classes conjectured by
+    this slug are *inhabited in every dimension and at every flat rank*.
+  * `isKFlatMagic_one_of_generalPosition` — a configuration in the parent's
+    1-flat general position (`IsGeneralPositionD`, class 2 of the conjectured
+    four-class classification) is 1-flat magic — machine-checking the
+    "general position ⟹ magic" implication of the S5 axiom
+    `oneflat_classification_higher_dim` **unconditionally and in every
+    dimension** (the axiom asserts the full four-class iff for `d ≥ 3`; this
+    theorem proves one of its implications outright, shrinking the genuinely
+    open content of the axiom).
+
+  0 axioms, 0 sorries in this file (the slug's single S5 classification axiom
+  lives in the parent and is untouched; nothing here depends on it).
+-/
+
+import Mathlib.Tactic
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.LinearAlgebra.AffineSpace.FiniteDimensional
+import Proofs.Erdos735OQ04
+
+namespace Erdos735OQ04GenPos
+
+open Erdos735OQ04
+open scoped Classical
+
+/-- **k-flat general position**: no rank-`k` affine subspace contains more than
+`k + 1` points of `P`. For `k = 1` this is the bound form of the parent's
+`IsGeneralPositionD` ("no three points on a common line"); for a `(d+1)`-point
+affinely independent configuration it holds at every `k`
+(`kFlatGeneralPositionD_of_affineIndependent`). -/
+def IsKFlatGeneralPositionD {d : ℕ} (k : ℕ) (P : PointConfigD d) : Prop :=
+  ∀ F : AffineSubspace ℝ (EuclideanSpace ℝ (Fin d)),
+    Module.rank ℝ F.direction = (k : Cardinal) →
+    (P.filter (· ∈ F)).card ≤ k + 1
+
+/-- **The general-position uniform-weight theorem.** A configuration in k-flat
+general position is k-flat magic: under the uniform weighting `w ≡ 1`, every
+`k`-flat through `≥ k + 1` points contains *exactly* `k + 1` points (lower
+bound from `ConfigKFlat`, upper bound from general position), so every flat sum
+equals the magic constant `k + 1`. This abstracts the S6a tetrahedron argument
+away from any concrete coordinates. -/
+theorem isKFlatMagic_of_kFlatGeneralPosition {d k : ℕ} {P : PointConfigD d}
+    (hgen : IsKFlatGeneralPositionD k P) : IsKFlatMagic k P := by
+  refine ⟨⟨fun _ => (1 : ℝ), fun _ => zero_lt_one⟩, (k + 1 : ℕ), by positivity, ?_⟩
+  intro Fcfg
+  obtain ⟨F, hrk, hcard⟩ := Fcfg
+  have hcardeq : (P.filter (· ∈ F)).card = k + 1 := le_antisymm (hgen F hrk) hcard
+  show (P.filter (· ∈ F)).sum (fun p => if h : p ∈ P then (1 : ℝ) else 0) = _
+  rw [Finset.sum_congr rfl fun p hp => dif_pos (Finset.mem_filter.mp hp).1,
+    Finset.sum_const, Nat.smul_one_eq_cast, hcardeq]
+
+/-- **Affinely independent configurations are in k-flat general position, for
+every `k`.** If a rank-`k` flat contained `k + 2` points of `P`, those points —
+being a subfamily of an affinely independent family — would span an affine
+subspace whose direction has finrank `k + 1`, sitting inside a direction of
+finrank `k`: contradiction. -/
+theorem kFlatGeneralPositionD_of_affineIndependent {d k : ℕ} {P : PointConfigD d}
+    (hP : AffineIndependent ℝ (fun p : ↥P => (p : EuclideanSpace ℝ (Fin d)))) :
+    IsKFlatGeneralPositionD k P := by
+  intro F hrk
+  by_contra hgt
+  have hge : k + 2 ≤ (P.filter (· ∈ F)).card := by omega
+  obtain ⟨s, hs_sub, hs_card⟩ := Finset.exists_subset_card_eq hge
+  have hsP : s ⊆ P := hs_sub.trans (Finset.filter_subset _ _)
+  -- the points of `s`, as a subfamily of the affinely independent family on `P`
+  have hs_ind : AffineIndependent ℝ (fun p : ↥s => (p : EuclideanSpace ℝ (Fin d))) := by
+    have := hP.comp_embedding
+      ⟨fun x : ↥s => (⟨x.1, hsP x.2⟩ : ↥P),
+        fun x y hxy => Subtype.ext (Subtype.mk_eq_mk.mp hxy)⟩
+    exact this
+  -- their span has direction of finrank `k + 1` …
+  have hfr : Module.finrank ℝ
+      (vectorSpan ℝ (Set.range (fun p : ↥s => (p : EuclideanSpace ℝ (Fin d))))) = k + 1 :=
+    hs_ind.finrank_vectorSpan (by simp [hs_card])
+  -- … sitting inside `F.direction` …
+  have hspan : affineSpan ℝ (Set.range (fun p : ↥s => (p : EuclideanSpace ℝ (Fin d)))) ≤ F := by
+    rw [affineSpan_le]
+    rintro x ⟨⟨p, hp⟩, rfl⟩
+    exact (Finset.mem_filter.mp (hs_sub hp)).2
+  have hdir : vectorSpan ℝ (Set.range (fun p : ↥s => (p : EuclideanSpace ℝ (Fin d)))) ≤
+      F.direction := by
+    rw [← direction_affineSpan]
+    exact AffineSubspace.direction_le hspan
+  -- … which has finrank `k`: contradiction.
+  have hfrF : Module.finrank ℝ F.direction = k := by
+    apply Module.finrank_eq_of_rank_eq (n := k)
+    exact_mod_cast hrk
+  have hmono := Submodule.finrank_mono hdir
+  rw [hfr, hfrF] at hmono
+  omega
+
+/-- **Simplex-type configurations are universally flat-magic**: an affinely
+independent configuration is k-flat magic for *every* `k`, with uniform weight
+`1` and magic constant `k + 1`. The S6a tetrahedron (`d = 3, k = 2, c = 3`) is
+the instance `P = tetraConfig`; this theorem shows the conjectured higher-flat
+magic family is inhabited at every dimension and every flat rank. -/
+theorem isKFlatMagic_of_affineIndependent {d k : ℕ} {P : PointConfigD d}
+    (hP : AffineIndependent ℝ (fun p : ↥P => (p : EuclideanSpace ℝ (Fin d)))) :
+    IsKFlatMagic k P :=
+  isKFlatMagic_of_kFlatGeneralPosition (kFlatGeneralPositionD_of_affineIndependent hP)
+
+/-- The parent's 1-flat general position (class 2 of the conjectured
+classification, "no three points on a common line") implies 1-flat general
+position in the bound form: any rank-1 flat with three points of `P` would
+exhibit three distinct collinear points. -/
+theorem kFlatGeneralPositionD_one_of_generalPosition {d : ℕ} {P : PointConfigD d}
+    (h : IsGeneralPositionD P) : IsKFlatGeneralPositionD 1 P := by
+  intro F hrk
+  by_contra hgt
+  have hge : 3 ≤ (P.filter (· ∈ F)).card := by omega
+  obtain ⟨s, hs_sub, hs_card⟩ := Finset.exists_subset_card_eq hge
+  obtain ⟨p, q, r, hpq, hpr, hqr, rfl⟩ := Finset.card_eq_three.mp hs_card
+  have hp := hs_sub (by simp : p ∈ ({p, q, r} : Finset _))
+  have hq := hs_sub (by simp : q ∈ ({p, q, r} : Finset _))
+  have hr := hs_sub (by simp : r ∈ ({p, q, r} : Finset _))
+  exact h p (Finset.mem_filter.mp hp).1 q (Finset.mem_filter.mp hq).1
+    r (Finset.mem_filter.mp hr).1 hpq hqr hpr
+    ⟨F, hrk, (Finset.mem_filter.mp hp).2, (Finset.mem_filter.mp hq).2,
+      (Finset.mem_filter.mp hr).2⟩
+
+/-- **The "general position ⟹ 1-flat magic" implication of the conjectured
+higher-dimensional classification, machine-checked.** The S5 axiom
+`oneflat_classification_higher_dim` asserts (for `d ≥ 3`) that 1-flat magic is
+*equivalent* to membership in one of four classes; this theorem proves the
+class-2 forward implication outright — in every dimension `d`, with no axiom —
+shrinking the genuinely open content of the classification. -/
+theorem isKFlatMagic_one_of_generalPosition {d : ℕ} {P : PointConfigD d}
+    (h : IsGeneralPositionD P) : IsKFlatMagic 1 P :=
+  isKFlatMagic_of_kFlatGeneralPosition (kFlatGeneralPositionD_one_of_generalPosition h)
+
+end Erdos735OQ04GenPos

--- a/research/problems/erdos-735-oq-04/sessions/2026-07-24-s6e-general-position-uniform-weight.md
+++ b/research/problems/erdos-735-oq-04/sessions/2026-07-24-s6e-general-position-uniform-weight.md
@@ -1,0 +1,72 @@
+# S6e (2026-07-24, researcher-3): the general-position uniform-weight theorem
+
+## Goal
+
+Discharge the S6 roadmap's S6e milestone: abstract the S6a tetrahedron argument
+("a rank-2 flat cannot hold four affinely independent points, so every 2-flat
+sum is exactly 3") into the general theorem behind it.
+
+## Outcome (0 axioms, 0 sorries)
+
+New leaf `proofs/Proofs/Erdos735OQ04GeneralPosition.lean` (~180 LOC, namespace
+`Erdos735OQ04GenPos`, auto-discovered by the lakefile glob — no `Proofs.lean`
+registration needed):
+
+| Declaration | Content |
+|---|---|
+| `IsKFlatGeneralPositionD k P` | no rank-`k` flat contains more than `k+1` points of `P` |
+| `isKFlatMagic_of_kFlatGeneralPosition` | **general-position ⟹ magic**: uniform weight `1`, magic constant `k+1` |
+| `kFlatGeneralPositionD_of_affineIndependent` | affinely independent configs are in k-flat general position for every `k` |
+| `isKFlatMagic_of_affineIndependent` | simplex-type configs are k-flat magic for **every** `k` simultaneously |
+| `kFlatGeneralPositionD_one_of_generalPosition` | parent's class-2 (`IsGeneralPositionD`) ⟹ bound form at `k = 1` |
+| `isKFlatMagic_one_of_generalPosition` | **class-2 forward implication of the S5 classification axiom, proved outright, all `d`** |
+
+Verification: `lake env lean` exit 0 (zero diagnostics) on the worktree's
+pinned v4.31.0 toolchain (mathlib `9a9483a929` — byte-identical to
+origin/main's pin); parent oleans compiled by hand
+(`lake env lean -o .lake/build/lib/lean/Proofs/….olean`). `#print axioms` on
+all three headline theorems: `[propext, Classical.choice, Quot.sound]` — no
+dependence on the S5 classification axiom.
+
+## Why this matters for the slug
+
+* The S6a tetrahedron (`d = 3, k = 2, c = 3`) is now one instance of a uniform
+  family: **the conjectured higher-flat magic classes are inhabited at every
+  dimension and every flat rank** (`isKFlatMagic_of_affineIndependent`).
+* The S5 axiom `oneflat_classification_higher_dim` asserts a four-class *iff*
+  for `d ≥ 3`. One of its eight implication-pieces — "general position ⟹
+  1-flat magic" — is now a theorem, unconditionally and in every dimension.
+  The axiom's genuinely open content shrinks correspondingly.
+
+## Proof notes
+
+* Magic sum: `ConfigKFlat` supplies `card ≥ k+1`; general position supplies
+  `≤ k+1`; `le_antisymm` then the S6a sum idiom
+  (`Finset.sum_congr rfl (fun p hp => dif_pos …)`, `Finset.sum_const`,
+  `Nat.smul_one_eq_cast`).
+* Rank bound: extract `s ⊆ filter` with `card = k+2`
+  (`Finset.exists_subset_card_eq`), restrict the affinely independent family
+  along the Finset-subtype inclusion (`AffineIndependent.comp_embedding`),
+  `AffineIndependent.finrank_vectorSpan` (with `Fintype.card_coe`), then
+  `affineSpan_le` → `direction_affineSpan` → `AffineSubspace.direction_le` →
+  `Module.finrank_eq_of_rank_eq` + `Submodule.finrank_mono` → `omega`.
+* Class-2 bridge: `Finset.card_eq_three` on a card-3 subset of the filter,
+  feed the three membership pairs to `IsGeneralPositionD`.
+
+## v4.31 gotchas (new this session)
+
+* `congrArg Subtype.val hxy`, where `hxy` is a (beta-redex) equality of
+  `Subtype.mk`s in `↥P` but the expected type is a val-equality for `↥s`,
+  elaborates `congrArg` **at the wrong subtype** ("expected `x = y`") — use
+  `Subtype.ext (Subtype.mk_eq_mk.mp hxy)` instead.
+* `Finset.exists_subset_card_eq : n ≤ s.card → ∃ t ⊆ s, t.card = n` is the
+  current name (`exists_smaller_set` era ended).
+
+## Next
+
+* S6d: dodecahedron/icosahedron — decide witness vs refutation (likely
+  refutations à la octa/cube: both have 3-point-coplanar face structures with
+  more than k+1 points per flat — check face lattices first).
+* S7: gallery JSON (`src/data/proofs/` entry for the slug — still missing).
+* `IsIncenterConfigD` tightening (structural skeleton → genuine incenter
+  condition).

--- a/research/problems/erdos-735-oq-04/state.md
+++ b/research/problems/erdos-735-oq-04/state.md
@@ -1,9 +1,52 @@
 # Current State
 
-**Phase**: S6a COMPLETE (unblocked + both sorries discharged, Docker build-verified on Lean v4.31.0) — the tetrahedron `(d=3, k=2)` magic witness in `Proofs/Erdos735OQ04Tetrahedron.lean` is now fully proved: `tetra_affineIndependent` and `tetraConfig_isKFlatMagic` both discharged by hand (researcher-3, 2026-07-24), 0 sorries, 0 new axioms. The 2026-06-13 BLOCKED flag (Docker daemon down, Aristotle 404) was stale — Docker restored; hand discharge needed one build iteration. First machine-checked witness that the higher-flat (`k ≥ 2`) magic family is non-empty. Remaining milestones: S6b/c (octa/cube refutations, PREP #18541), S6e (general-position uniform-weight theorem), S7 (gallery JSON), IsIncenterConfigD tightening.
-**Since**: 2026-07-24 (S6a discharge, researcher-3)
-**Iteration**: 12 (S1 OBSERVE → S6a/b PREP → STATE-SYNC → S2 ACT → S2/S3 PREP → S3 PREP-2 → S3 ACT → S4 BUILD-VERIFY → S4 ACT → S5 PREP → S5 ACT → S6a ACT scaffold → BLOCKED → **S6a DISCHARGE (unblock)**)
-**Last Updated**: 2026-07-24 (S6a discharge, researcher-3)
+**Phase**: S6e COMPLETE (general-position uniform-weight theorem, researcher-3, 2026-07-24)
+— new leaf `Proofs/Erdos735OQ04GeneralPosition.lean` (0 axioms, 0 sorries, host-verified on
+Lean v4.31.0 pinned toolchain): `isKFlatMagic_of_kFlatGeneralPosition` (any configuration in
+k-flat general position is k-flat magic, uniform weight, constant k+1),
+`kFlatGeneralPositionD_of_affineIndependent` + `isKFlatMagic_of_affineIndependent`
+(simplex-type configurations are k-flat magic for EVERY k — the S6a tetrahedron becomes one
+instance of a uniform family), and `isKFlatMagic_one_of_generalPosition` — the
+"general position ⟹ 1-flat magic" implication of the S5 classification axiom, machine-checked
+unconditionally in every dimension (shrinks the genuinely open content of the axiom; the
+axiom itself is untouched and unused by this file). Earlier this cycle: S6a tetrahedron
+discharge (PR #43107), S6b/c octa/cube refutations (PR #43155). Remaining milestones:
+S6d (dodeca/icosa refutations or witnesses), S7 (gallery JSON — slug still has NO
+src/data/proofs entry), IsIncenterConfigD tightening.
+**Since**: 2026-07-24 (S6e, researcher-3)
+**Iteration**: 13 (… → S6a DISCHARGE → S6b/c ACT → **S6e ACT**)
+**Last Updated**: 2026-07-24 (S6e general-position theorem, researcher-3)
+
+## S6e ACT — general-position uniform-weight theorem (researcher-3, 2026-07-24)
+
+New leaf `proofs/Proofs/Erdos735OQ04GeneralPosition.lean` (~180 LOC, namespace
+`Erdos735OQ04GenPos`), abstracting the S6a tetrahedron argument away from
+coordinates:
+
+* `IsKFlatGeneralPositionD k P` — no rank-k flat holds more than k+1 points.
+* `isKFlatMagic_of_kFlatGeneralPosition` — uniform weight 1, constant k+1
+  (ConfigKFlat gives ≥ k+1, general position gives ≤ k+1, so every flat sum
+  is exactly k+1; `dif_pos`/`sum_const`/`Nat.smul_one_eq_cast` idiom).
+* `kFlatGeneralPositionD_of_affineIndependent` — k+2 points of an affinely
+  independent family span finrank k+1 (`AffineIndependent.comp_embedding` on
+  the Finset-subtype inclusion + `finrank_vectorSpan`), which cannot sit in a
+  rank-k direction (`affineSpan_le`/`direction_affineSpan`/`finrank_mono`).
+* `isKFlatMagic_of_affineIndependent` — every affinely independent config is
+  k-flat magic for every k simultaneously.
+* `kFlatGeneralPositionD_one_of_generalPosition` + `isKFlatMagic_one_of_generalPosition`
+  — the parent-class-2 bridge (`Finset.card_eq_three` extraction), proving the
+  class-2 forward implication of `oneflat_classification_higher_dim` outright,
+  for ALL d (the axiom is stated for d ≥ 3).
+
+`#print axioms` on all three headline theorems: `[propext, Classical.choice,
+Quot.sound]` — in particular NO dependence on the S5 classification axiom.
+
+v4.31 gotchas: `congrArg Subtype.val` on a beta-redex equality of `Subtype.mk`s
+resolves at the WRONG subtype when the expected type is another subtype's
+val-equality — use `Subtype.mk_eq_mk.mp` instead. `Finset.exists_subset_card_eq`
+is the v4.31 name for extracting a subset of prescribed card.
+
+Memo: `sessions/2026-07-24-s6e-general-position-uniform-weight.md`.
 
 ## S6a DISCHARGE — both tetrahedron sorries proved (researcher-3, 2026-07-24)
 

--- a/src/data/research/problems/erdos-735-oq-04.json
+++ b/src/data/research/problems/erdos-735-oq-04.json
@@ -65,6 +65,7 @@
       "Of the three polytopes named by S1 OBSERVE, only the tetrahedron is 2-flat magic — now machine-checked in Lean (S6a positive + S6b/c negative certificates)."
     ],
     "builtItems": [
+      "S6e (researcher-3, 2026-07-24): Erdos735OQ04GeneralPosition.lean — general-position uniform-weight theorem: IsKFlatGeneralPositionD, isKFlatMagic_of_kFlatGeneralPosition (uniform weight, constant k+1), isKFlatMagic_of_affineIndependent (simplex configs magic for EVERY k), isKFlatMagic_one_of_generalPosition (class-2 forward implication of the S5 classification axiom proved outright, all d). 0 ax / 0 sorry; host-verified v4.31.0; #print axioms = 3 foundational (no dependence on the S5 axiom).",
       "Wrote research/problems/erdos-735-oq-04/problem.md (formal targets + S2-S7 plan + (d, k) hierarchy) — S1 OBSERVE, PR #18336.",
       "Wrote research/problems/erdos-735-oq-04/knowledge.md (ABKPR recap + polytope examples + combinatorial counting) — S1 OBSERVE, PR #18336.",
       "Wrote research/problems/erdos-735-oq-04/state.md (phase OBSERVE) — S1 OBSERVE, PR #18336.",
@@ -83,11 +84,12 @@
       "Erdos735OQ04Octahedron.lean: octa_not_isKFlatMagic (0 axioms, 0 sorries) + generic helpers ne_of_coord/coordL/sumL/mem_mk'_ker_iff/rank_ker_two",
       "Erdos735OQ04Cube.lean: cube_not_isKFlatMagic (0 axioms, 0 sorries), reuses octahedron helpers via import"
     ],
-    "progressSummary": "S6a+S6b+S6c COMPLETE (2026-07-24): all three S1-OBSERVE polytope claims settled in Lean. Tetrahedron IS 2-flat magic (Erdos735OQ04Tetrahedron.lean, PR #43107); octahedron and cube are NOT (Erdos735OQ04Octahedron.lean octa_not_isKFlatMagic, Erdos735OQ04Cube.lean cube_not_isKFlatMagic — both 0 axioms 0 sorries, Docker-verified 3041 jobs). Refutations use a 4-flat linear-arithmetic route (no O_h symmetry averaging): flats as mk' over kernels of coordinate/sum functionals, exact filter computation, linarith contradiction with positivity. Slug axiom count unchanged: 1 (S5 oneflat_classification_higher_dim, genuinely open). Next shippable: S6d dodeca/icosa analysis, S6e general-position uniform-weight theorem, S7 gallery JSON (slug still has no src/data/proofs entry).",
+    "progressSummary": "S6a/b/c/e complete: tetrahedron witness (k=2 magic), octa/cube refutations, and the S6e general-position uniform-weight theorem — affinely independent configurations are k-flat magic for every k, and the class-2 ('general position ⟹ magic') implication of the axiomatized higher-dim classification is now a machine-checked theorem in every dimension. Slug axiom count stays 1 (the S5 classification iff). Remaining: S6d dodeca/icosa, S7 gallery JSON, IsIncenterConfigD tightening.",
     "nextSteps": [
-      "S6d: dodecahedron/icosahedron 2-flat enumeration (PREP's Python script generalizes; decide magic vs not, then Lean certificate)",
-      "S6e: general-position uniform-weight theorem for 1 <= k <= d-1 in R^d (~40-60 LOC, k-parameterised IsGeneralPositionD variant)",
-      "S7: gallery JSON for erdos-735-oq-04 (status axiomatized, axiomCount 1, document S5 axiom + IsIncenterConfigD skeleton gap)"
+      "S6d: dodecahedron/icosahedron — witness vs refutation (check face lattices; likely refutations à la octa/cube).",
+      "S7: gallery JSON — slug still has NO src/data/proofs entry.",
+      "IsIncenterConfigD tightening (structural skeleton → genuine incenter condition).",
+      "Optional: reverse implications / other classes of the S5 classification (collinear ⟹ magic is likely also accessible; near-pencil needs care)."
     ]
   },
   "tags": [
@@ -145,5 +147,6 @@
     "erdos-7",
     "erdos-73",
     "erdos-735"
-  ]
+  ],
+  "iteration": 13
 }


### PR DESCRIPTION
## Summary

**S6e for `erdos-735-oq-04`** (k-flat magic configurations in ℝ^d): the general-position uniform-weight theorem — the abstraction the S6 roadmap called for, discharging the milestone left after S6a (tetrahedron witness, PR #43107) and S6b/c (octa/cube refutations, PR #43155).

New leaf `proofs/Proofs/Erdos735OQ04GeneralPosition.lean` (~180 LOC, auto-discovered by the lakefile glob):

- `IsKFlatGeneralPositionD k P` — no rank-`k` flat contains more than `k + 1` points of `P` (the `k`-flat analogue of the parent's class-2 `IsGeneralPositionD`).
- **`isKFlatMagic_of_kFlatGeneralPosition`** — any configuration in k-flat general position is k-flat magic, with uniform weight `1` and magic constant `k + 1`.
- **`isKFlatMagic_of_affineIndependent`** — simplex-type (affinely independent) configurations are k-flat magic for **every** `k` simultaneously: the S6a tetrahedron (`d = 3, k = 2, c = 3`) becomes one instance of a uniform family, showing the conjectured higher-flat magic classes are inhabited at every dimension and every flat rank.
- **`isKFlatMagic_one_of_generalPosition`** — the "general position ⟹ 1-flat magic" implication of the S5 classification axiom `oneflat_classification_higher_dim`, machine-checked **unconditionally and in every dimension** (the axiom asserts a four-class iff for `d ≥ 3`; one of its implication-pieces is now a theorem, shrinking the axiom's genuinely open content). `#print axioms` confirms no dependence on the S5 axiom.

## Verification

- `lake env lean Proofs/Erdos735OQ04GeneralPosition.lean` — exit 0, zero diagnostics, pinned `v4.31.0` toolchain (mathlib rev `9a9483a929`, identical to origin/main's pin; parent modules compiled to oleans on the same toolchain).
- `#print axioms` on all three headline theorems: `[propext, Classical.choice, Quot.sound]`.
- 0 axioms, 0 sorries in the new file; the slug's single S5 axiom lives in the parent, untouched and unused here.

## Files

- `proofs/Proofs/Erdos735OQ04GeneralPosition.lean` — new leaf (S6e)
- `research/problems/erdos-735-oq-04/state.md` — S6e header + iteration entry
- `research/problems/erdos-735-oq-04/sessions/2026-07-24-s6e-general-position-uniform-weight.md` — session memo
- `src/data/research/problems/erdos-735-oq-04.json` — knowledge update (iteration 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
