### PR TITLE
Research: general-quartic-oq-02 - S13: formalize the Ω(t⁻¹) amplification theorem (OQ-02.a capstone) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/GeneralQuartic.lean
+++ b/proofs/Proofs/GeneralQuartic.lean
@@ -2,6 +2,7 @@ import Mathlib.Algebra.Polynomial.Basic
 import Mathlib.Algebra.Polynomial.Degree.Definitions
 import Mathlib.Algebra.Polynomial.FieldDivision
 import Mathlib.Analysis.Complex.Polynomial.Basic
+import Mathlib.Analysis.SpecialFunctions.Sqrt
 import Mathlib.Data.Complex.Basic
 import Mathlib.Tactic
 
@@ -786,6 +787,41 @@ theorem pan_witness_k1_resolvent_root (t : ℝ) (ht0 : 0 < t) (ht1 : t ≤ 1) :
   rw [show ((((s + 1) / 2 : ℝ) : ℂ)) = ((s : ℂ) + 1) / 2 by push_cast; ring]
   simpa using hbridge
 
+/-- **The `Ω(t⁻¹)` amplification theorem (S13, OQ-02.a capstone).**
+
+This formalizes the amplification mechanism that the prose of
+`pan_witness_k1_resolvent_root` only asserted: along the Pan witness,
+Ferrari's intermediate `α = √s` (where `s = α²` is the cleaned-resolvent
+root pinned in `(t²/4, t²)` by `pan_witness_k1_tangency`) satisfies
+
+* `t/2 < α < t` — the cancellation is of order exactly `t¹`, and
+* the square-root extraction step of Ferrari's formula has sensitivity
+  `dα/ds = 1/(2√s) > 1/(2t)` at `s` — an `Ω(t⁻¹)` error-amplification
+  factor that blows up as the Pan family approaches the biquadratic
+  stratum `t → 0`, while the exact root `s` stays well inside `(0, t²)`.
+
+Together with the S4c Newton-polygon bound (no smooth family can achieve
+`k ≥ 2`) this is the complete, quantitative form of OQ-02.a: Ferrari's
+formula is numerically unstable near the biquadratic stratum with
+amplification factor at least `1/(2t)`, and the Pan family attains this
+order exactly. -/
+theorem pan_witness_amplification (t : ℝ) (ht0 : 0 < t) (ht1 : t ≤ 1) :
+    ∃ s : ℝ, panCleanedResolvent t s = 0 ∧
+      t / 2 < Real.sqrt s ∧ Real.sqrt s < t ∧
+      HasDerivAt Real.sqrt (1 / (2 * Real.sqrt s)) s ∧
+      1 / (2 * t) < 1 / (2 * Real.sqrt s) := by
+  obtain ⟨s, hs1, hs2, hs0⟩ := pan_witness_k1_tangency t ht0 ht1
+  have hspos : 0 < s := lt_trans (by positivity) hs1
+  have hsq1 : t / 2 < Real.sqrt s := by
+    have h := Real.sqrt_lt_sqrt (by positivity) hs1
+    rwa [show t ^ 2 / 4 = (t / 2) ^ 2 by ring, Real.sqrt_sq (by positivity)] at h
+  have hsq2 : Real.sqrt s < t := by
+    have h := Real.sqrt_lt_sqrt hspos.le hs2
+    rwa [Real.sqrt_sq ht0.le] at h
+  refine ⟨s, hs0, hsq1, hsq2, Real.hasDerivAt_sqrt (ne_of_gt hspos), ?_⟩
+  have hsqrtpos : 0 < Real.sqrt s := lt_trans (by positivity) hsq1
+  exact one_div_lt_one_div_of_lt (by positivity) (by linarith)
+
 /-- **Biquadratic limit (OQ-02.c, S3 DISCHARGE)**
 
 In the biquadratic limit `q = 0`, Ferrari's formula admits a
@@ -934,3 +970,4 @@ end GeneralQuartic
 #check GeneralQuartic.pan_witness_t_zero_nondegenerate_root
 #check GeneralQuartic.ferrari_biquad_limit
 #check GeneralQuartic.biquadratic_simple
+#check GeneralQuartic.pan_witness_amplification

--- a/src/data/proofs/general-quartic/meta.json
+++ b/src/data/proofs/general-quartic/meta.json
@@ -43,7 +43,7 @@
     "dateAdded": "2025-12-28",
     "wiedijkNumber": 46,
     "axiomCount": 0,
-    "lineCount": 936,
+    "lineCount": 973,
     "prerequisites": [
       "Complex numbers and polynomial evaluation",
       "Cubic equation solution (Cardano's formula)",
@@ -52,7 +52,7 @@
     ],
     "assumptions": "0 axioms, 0 sorries — the entry is fully machine-checked. All results, including the previously-axiomatized `quartic_has_four_roots`, `biquadratic_forward`, and `biquadratic_backward`, are now proved: the monic degree-4 quartic splits over ℂ via Mathlib's FTA infrastructure (`IsAlgClosed.splits`, `splits_iff_card_roots`, `Multiset.card_eq_three`, `mem_roots`), and the biquadratic cases follow from the complex quadratic formula (`Complex.cpow_nat_inv_pow`, `linear_combination`). `#print axioms` on the main theorems reports only `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `Lean.ofReduceBool`). The Ferrari factorization / root-verification lemmas (`ferrari_factorization`, `ferrari_roots_verify_ne`) carry an `α ≠ 0` (equivalently `2m + p ≠ 0`) non-degeneracy hypothesis, threaded from every call site — this replaced the earlier `*_forward/backward` and `ferrari_roots_verify` axioms, which were latently unsound at `α = 0`. Docker build verified (3058 jobs, success).",
     "mathlib_version": "4.31.0",
-    "theoremCount": 29,
+    "theoremCount": 30,
     "definitionCount": 6
   },
   "overview": {
@@ -158,7 +158,7 @@
     {
       "targetId": "abel-ruffini",
       "relationship": "complementary",
-      "description": "The quartic is the last degree solvable by radicals. Abel-Ruffini (Wiedijk #16) proves no general formula exists for degree 5+, because S\u2085 is not solvable while S\u2084 is."
+      "description": "The quartic is the last degree solvable by radicals. Abel-Ruffini (Wiedijk #16) proves no general formula exists for degree 5+, because S₅ is not solvable while S₄ is."
     },
     {
       "targetId": "fundamental-theorem-algebra",
@@ -168,22 +168,22 @@
     {
       "targetId": "angle-trisection",
       "relationship": "related",
-      "description": "Both connect to constructibility: quartic roots with degree 4 = 2\u00b2 ARE constructible (4 divides 2\u00b2), while the cubic case (degree 3) is the obstruction for trisection"
+      "description": "Both connect to constructibility: quartic roots with degree 4 = 2² ARE constructible (4 divides 2²), while the cubic case (degree 3) is the obstruction for trisection"
     },
     {
       "targetId": "lagrange-theorem",
       "relationship": "foundational",
-      "description": "Lagrange's theorem underpins the Galois-theoretic explanation: S\u2084 has order 24 and its solvable derived series S\u2084 \u25b7 A\u2084 \u25b7 V\u2084 \u25b7 {e} enables radical solutions"
+      "description": "Lagrange's theorem underpins the Galois-theoretic explanation: S₄ has order 24 and its solvable derived series S₄ ▷ A₄ ▷ V₄ ▷ {e} enables radical solutions"
     },
     {
       "targetId": "sylow-theorems",
       "relationship": "related",
-      "description": "Sylow theory reveals the subgroup structure of S\u2084 (Sylow 2-subgroups of order 8, Sylow 3-subgroups of order 3) that enables the composition series making S\u2084 solvable"
+      "description": "Sylow theory reveals the subgroup structure of S₄ (Sylow 2-subgroups of order 8, Sylow 3-subgroups of order 3) that enables the composition series making S₄ solvable"
     },
     {
       "targetId": "abel-ruffini-oq-04",
       "relationship": "complementary",
-      "description": "The A\u2085 simplicity proof chain exposes each step from A\u2085 simple to 'no quintic formula' \u2014 this quartic file is the complementary 'last solvable case' showing S\u2084 solvable (derived series S\u2084 \u25b7 A\u2084 \u25b7 V\u2084 \u25b7 {e}) while S\u2085 is not"
+      "description": "The A₅ simplicity proof chain exposes each step from A₅ simple to 'no quintic formula' — this quartic file is the complementary 'last solvable case' showing S₄ solvable (derived series S₄ ▷ A₄ ▷ V₄ ▷ {e}) while S₅ is not"
     }
   ],
   "references": [
@@ -191,7 +191,7 @@
       "authors": "Ferrari, Lodovico (via Cardano)",
       "title": "Ars Magna",
       "year": "1545",
-      "venue": "N\u00fcrnberg: Petreius",
+      "venue": "Nürnberg: Petreius",
       "note": "First publication of the quartic formula, discovered by Ferrari (Cardano's student) and published in Cardano's treatise"
     },
     {
@@ -216,9 +216,9 @@
       "Complex"
     ],
     "namespace": "GeneralQuartic",
-    "lineCount": 936,
+    "lineCount": 973,
     "axiomCount": 0,
-    "theoremCount": 29,
+    "theoremCount": 30,
     "definitionCount": 6,
     "path": "Proofs/GeneralQuartic.lean",
     "sorries": 0


### PR DESCRIPTION
## S13: the Ω(t⁻¹) amplification theorem — OQ-02.a capstone

**Problem**: `general-quartic-oq-02` (Ferrari-formula numerical instability near the biquadratic stratum).

### What this PR proves

`pan_witness_amplification` — the file's docstrings asserted "the Ω(t⁻¹)-amplification mechanism" in prose only; this PR turns it into a theorem. For every `0 < t ≤ 1`, along the Pan witness there is a cleaned-resolvent root `s` with:

- `t/2 < √s < t` — Ferrari's cancelling intermediate `α = √s` is of order exactly `t¹` (k = 1 tangency, as pinned by S12 + the S4c Newton-polygon bound), and
- `HasDerivAt Real.sqrt (1/(2√s)) s` with `1/(2t) < 1/(2√s)` — the square-root extraction step of Ferrari's formula has sensitivity **greater than `1/(2t)`**, the quantitative Ω(t⁻¹) error amplification that blows up as the family approaches the biquadratic stratum `t → 0`.

This is the complete, quantitative form of OQ-02.a. ~40 LOC packaging `pan_witness_k1_tangency` with `Real.hasDerivAt_sqrt` + `Real.sqrt_lt_sqrt` (new import: `Mathlib.Analysis.SpecialFunctions.Sqrt`).

### Completion status of the OQ-02 chain

- **OQ-02.a**: DONE (S12 k=1 tangency + this quantitative capstone)
- **OQ-02.b** (conditioning-number formulation): remains blocked on condNum infrastructure absent from Mathlib — recorded as the structured blocker
- **OQ-02.c**: DONE since S3/S7

### Verification

- Host `lake env lean`: exit 0; Docker: `./proofs/scripts/docker-build.sh Proofs.GeneralQuartic` — **success** (3357 jobs, 0 sorry warnings); file stays 0-axiom / 0-sorry
- Gallery meta counts synced (lineCount 936→973, theoremCount +1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
