### PR TITLE
Enrich cayley-hamilton-minpoly-oq-03-oq-03: cover uncovered module header

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-03/meta.json
@@ -60,6 +60,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Docstring, Import, and Setup",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Docstring: the structural follow-up to CayleyHamiltonMinpolyOQ03 (the Krylov sequence goes dependent exactly at deg μ_M). States the two headline identities — the conjugation M·P = P·C(μ_M) for any v once M is nonderogatory, and the similarity P⁻¹·M·P = C(μ_M) once v is cyclic — and lists the five main results. Imports CayleyHamiltonMinpolyOQ03; opens the MinpolyComplexity namespace, Matrix/Polynomial/Finset notation; fixes the ambient variables {K : Type*} [Field K] {n : ℕ}.",
+      "mathContext": "The companion matrix C(μ_M) realizes multiplication-by-X on K[X]/(μ_M) in the basis 1, X, …, X^{n-1}; the Krylov matrix P intertwining M with it is the constructive bridge from the O(n³) Krylov iteration to the module-theoretic rational canonical form."
+    },
+    {
       "id": "part-i-companion-krylov-matrix",
       "title": "Part I: The Companion Matrix and the Krylov Change-of-Basis",
       "startLine": 53,


### PR DESCRIPTION
## Summary
- sections bucket was at 8/10 (4 sections, cap 5×2=10). Lines 1-52 — the file docstring (stating the conjugation identity M·P = P·C(μ_M) and the similarity P⁻¹·M·P = C(μ_M)), the import, namespace, opens, and ambient variables `{K : Type*} [Field K] {n : ℕ}` — were entirely uncovered; the first recorded section (`part-i-companion-krylov-matrix`) started at line 53. Added a `header` section spanning 1-52.
- No other fields touched; all other quality buckets already at cap.

## Test plan
- [x] `pnpm build` passes (JSON structure + gallery data validated)