### PR TITLE
Enrich cayley-hamilton-minpoly-oq-03-oq-03-oq-01: cover uncovered module header

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-03-oq-01/meta.json
@@ -62,6 +62,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Docstring, Imports, and Setup",
+      "startLine": 1,
+      "endLine": 62,
+      "summary": "Docstring: supplies the converse the parent entry takes for granted -- that the companion matrix C(μ_M) really has μ_M as both its minimal and characteristic polynomial. Lists the four results (Krylov sequence = standard basis, p(C) = 0, μ_C = p, χ_C = p) and notes the determinant-free proof route via the cyclic vector and Cayley-Hamilton rather than cofactor expansion of det(X·I - C). Self-contained: imports only Mathlib.LinearAlgebra.Matrix.Charpoly.{Minpoly,Basic} and Mathlib.Tactic.",
+      "mathContext": "The nonderogatory conclusion μ_C = χ_C = p is exactly the fact that makes companion p the canonical target the parent's similarity P⁻¹·M·P = C(μ_M) conjugates into."
+    },
+    {
       "id": "part-i-krylov-infrastructure",
       "title": "Part I: Krylov Infrastructure",
       "startLine": 63,


### PR DESCRIPTION
## Summary
- sections bucket was at 8/10 (4 sections, cap 5×2=10). Lines 1-62 — the file docstring (the four results: Krylov-sequence-equals-standard-basis, p(C)=0, μ_C=p, χ_C=p), imports, set_options, namespace, opens, and the ambient field variable — were entirely uncovered; the first recorded section (`part-i-krylov-infrastructure`) started at line 63. Added a `header` section spanning 1-62.
- No other fields touched; all other quality buckets already at cap.

## Test plan
- [x] `pnpm build` passes (JSON structure + gallery data validated)