### PR TITLE
Research: sqrt2-minpoly-oq-03 S11 — element-level integral basis: a + b√2 ∈ 𝓞 ↔ a, b ∈ ℤ

### DIFF
--- a/proofs/Proofs/Sqrt2MinpolyOQ03.lean
+++ b/proofs/Proofs/Sqrt2MinpolyOQ03.lean
@@ -359,7 +359,7 @@ theorem elt_not_mem_range (a b : ℚ) (hb : b ≠ 0) :
   have hbne : algebraMap ℚ Q_sqrt2 b ≠ 0 := by
     simpa using (algebraMap ℚ Q_sqrt2).injective.ne hb
   apply mul_left_cancel₀ hbne
-  rw [← map_mul, mul_div_cancel₀ _ hb, map_sub, ← hr]
+  rw [← map_mul, mul_div_cancel₀ _ hb, map_sub, hr]
   simp only [elt]
   ring
 
@@ -370,7 +370,7 @@ theorem aeval_elt_quadratic (a b : ℚ) :
     Polynomial.aeval (elt a b)
       (X ^ 2 + (C (-(2 * a)) * X + C (a ^ 2 - 2 * b ^ 2)) : ℚ[X]) = 0 := by
   simp only [elt, map_add, map_mul, map_pow, map_neg, Polynomial.aeval_X,
-    Polynomial.aeval_C, map_sub, map_ofNat, map_one]
+    Polynomial.aeval_C, map_sub, map_ofNat]
   linear_combination (algebraMap ℚ Q_sqrt2 b) ^ 2 * root_sq
 
 /-- The annihilator is monic (leading term `X²`). -/
@@ -379,8 +379,7 @@ theorem quadratic_monic (a b : ℚ) :
   apply Polynomial.monic_X_pow_add
   apply lt_of_le_of_lt (Polynomial.degree_add_le _ _)
   apply max_lt
-  · exact lt_of_le_of_lt (Polynomial.degree_C_mul_le _ _)
-      (lt_of_le_of_lt Polynomial.degree_X_le (by decide))
+  · exact lt_of_le_of_lt (Polynomial.degree_C_mul_X_le _) (by decide)
   · exact lt_of_le_of_lt Polynomial.degree_C_le (by decide)
 
 /-- **The minimal polynomial of `a + b·root` for `b ≠ 0`** is exactly the
@@ -411,7 +410,11 @@ theorem minpoly_elt (a b : ℚ) (hb : b ≠ 0) :
     rw [hc, Polynomial.natDegree_mul (minpoly.ne_zero hx_int) hc_ne]
   have hc0 : c.natDegree = 0 := by omega
   have hc_monic : c.Monic := hmp_monic.of_mul_monic_left (hc ▸ hq_monic)
-  rw [hc, hc_monic.natDegree_eq_zero_iff_eq_one.mp hc0, mul_one]
+  have hcC : c = C (c.coeff 0) := Polynomial.eq_C_of_natDegree_eq_zero hc0
+  have hlead : c.coeff 0 = 1 := by
+    have hl := hc_monic
+    rwa [Polynomial.Monic, Polynomial.leadingCoeff, hc0] at hl
+  rw [hc, hcC, hlead, Polynomial.C_1, mul_one]
 
 /-- **Forward direction of `𝓞 = ℤ[√2]`**: an integral `a + b·root` has
 `a, b ∈ ℤ`. For `b ≠ 0` the minimal polynomial over ℚ descends to ℤ
@@ -433,13 +436,19 @@ theorem coords_int_of_isIntegral {a b : ℚ} (hint : IsIntegral ℤ (elt a b)) :
     rw [minpoly_elt a b hb] at hmap
     have hcoeff1 : -(2 * a) = ((minpoly ℤ (elt a b)).coeff 1 : ℚ) := by
       have h := congrArg (fun p : ℚ[X] => p.coeff 1) hmap
-      simpa [Polynomial.coeff_map, Polynomial.coeff_X_pow, eq_intCast] using h
+      simp only [Polynomial.coeff_add, Polynomial.coeff_X_pow, Polynomial.coeff_C_mul,
+        Polynomial.coeff_X_one, Polynomial.coeff_C, Polynomial.coeff_map, eq_intCast,
+        mul_one, add_zero, one_ne_zero, ite_false] at h
+      simpa using h
     have hcoeff0 : a ^ 2 - 2 * b ^ 2 = ((minpoly ℤ (elt a b)).coeff 0 : ℚ) := by
       have h := congrArg (fun p : ℚ[X] => p.coeff 0) hmap
-      simpa [Polynomial.coeff_map, Polynomial.coeff_X_pow, eq_intCast] using h
+      simp only [Polynomial.coeff_add, Polynomial.coeff_X_pow, Polynomial.coeff_C_mul,
+        Polynomial.coeff_X_zero, Polynomial.coeff_C, Polynomial.coeff_map, eq_intCast,
+        mul_zero, zero_add] at h
+      simpa using h
     exact int_pair_of_double_and_norm a b (-(minpoly ℤ (elt a b)).coeff 1)
       ((minpoly ℤ (elt a b)).coeff 0)
-      (by push_cast; linarith [hcoeff1]) (by push_cast; linarith [hcoeff0])
+      (by rw [Int.cast_neg]; linarith [hcoeff1]) (by linarith [hcoeff0])
 
 /-- **Reverse direction**: integer coordinates give an algebraic integer
 (`ℤ[√2] ⊆ 𝓞`). -/

--- a/proofs/Proofs/Sqrt2MinpolyOQ03.lean
+++ b/proofs/Proofs/Sqrt2MinpolyOQ03.lean
@@ -316,4 +316,155 @@ theorem Q_sqrt2_classNumber_eq_one :
     NumberField.classNumber Q_sqrt2 = 1 :=
   Q_sqrt2_classNumber_eq_one_of_discr Q_sqrt2_discr_eq_eight
 
+/-! ## Session 11: the element-level integral basis — `IsIntegral ℤ (a + b·√2) ↔ a, b ∈ ℤ`
+
+This section proves the complete membership characterization of the ring of
+integers of `Q(√2)` at the element level: `a + b·root` is an algebraic integer
+iff `a, b ∈ ℤ`. The forward direction uses the **minimal-polynomial route**
+(instead of the trace/norm formulas originally sketched): for `b ≠ 0` the
+element `x = a + b·root` has minimal polynomial `X² − 2aX + (a² − 2b²)` over
+ℚ, and integrality forces its coefficients into ℤ
+(`minpoly.isIntegrallyClosed_eq_field_fractions'`), which is exactly the
+input to the S10 arithmetic crux `int_pair_of_double_and_norm`. This avoids
+any `leftMulMatrix` computation. S12 packages this into the ℤ-basis `{1, root}`
+of `𝓞` and the discriminant `det [[2,0],[0,4]] = 8`. -/
+
+/-- The element `a + b·√2` of `Q_sqrt2`. -/
+noncomputable def elt (a b : ℚ) : Q_sqrt2 :=
+  algebraMap ℚ Q_sqrt2 a + algebraMap ℚ Q_sqrt2 b * AdjoinRoot.root X_sq_sub_two
+
+/-- `√2` is irrational: `root` is not in the image of ℚ. (A rational root
+would give an integer square root of 2 via `rat_int_of_sq_int`.) -/
+theorem root_not_mem_range :
+    AdjoinRoot.root X_sq_sub_two ∉ (algebraMap ℚ Q_sqrt2).range := by
+  rintro ⟨r, hr⟩
+  have h2 : r ^ 2 = 2 := by
+    have hsq : algebraMap ℚ Q_sqrt2 (r ^ 2) = algebraMap ℚ Q_sqrt2 2 := by
+      rw [map_pow, hr, root_sq, map_ofNat]
+    exact_mod_cast (algebraMap ℚ Q_sqrt2).injective hsq
+  obtain ⟨m, hm⟩ := rat_int_of_sq_int r 2 (by exact_mod_cast h2)
+  have hm2 : m ^ 2 = 2 := by
+    have h' : ((m : ℚ)) ^ 2 = 2 := by rw [hm]; exact h2
+    exact_mod_cast h'
+  have hub : m ≤ 1 := by nlinarith [sq_nonneg (m - 2)]
+  have hlb : -1 ≤ m := by nlinarith [sq_nonneg (m + 2)]
+  interval_cases m <;> norm_num at hm2
+
+/-- Elements `a + b·root` with `b ≠ 0` are irrational. -/
+theorem elt_not_mem_range (a b : ℚ) (hb : b ≠ 0) :
+    elt a b ∉ (algebraMap ℚ Q_sqrt2).range := by
+  rintro ⟨r, hr⟩
+  apply root_not_mem_range
+  refine ⟨(r - a) / b, ?_⟩
+  have hbne : algebraMap ℚ Q_sqrt2 b ≠ 0 := by
+    simpa using (algebraMap ℚ Q_sqrt2).injective.ne hb
+  apply mul_left_cancel₀ hbne
+  rw [← map_mul, mul_div_cancel₀ _ hb, map_sub, ← hr]
+  simp only [elt]
+  ring
+
+/-- `x = a + b·root` is annihilated by the monic quadratic
+`X² − 2aX + (a² − 2b²)` (written with `+` and a negated linear coefficient
+for direct monicity/coefficient extraction). -/
+theorem aeval_elt_quadratic (a b : ℚ) :
+    Polynomial.aeval (elt a b)
+      (X ^ 2 + (C (-(2 * a)) * X + C (a ^ 2 - 2 * b ^ 2)) : ℚ[X]) = 0 := by
+  simp only [elt, map_add, map_mul, map_pow, map_neg, Polynomial.aeval_X,
+    Polynomial.aeval_C, map_sub, map_ofNat, map_one]
+  linear_combination (algebraMap ℚ Q_sqrt2 b) ^ 2 * root_sq
+
+/-- The annihilator is monic (leading term `X²`). -/
+theorem quadratic_monic (a b : ℚ) :
+    (X ^ 2 + (C (-(2 * a)) * X + C (a ^ 2 - 2 * b ^ 2)) : ℚ[X]).Monic := by
+  apply Polynomial.monic_X_pow_add
+  apply lt_of_le_of_lt (Polynomial.degree_add_le _ _)
+  apply max_lt
+  · exact lt_of_le_of_lt (Polynomial.degree_C_mul_le _ _)
+      (lt_of_le_of_lt Polynomial.degree_X_le (by decide))
+  · exact lt_of_le_of_lt Polynomial.degree_C_le (by decide)
+
+/-- **The minimal polynomial of `a + b·root` for `b ≠ 0`** is exactly the
+monic quadratic `X² − 2aX + (a² − 2b²)`: the annihilator is divided by the
+minimal polynomial, whose degree is ≥ 2 by irrationality
+(`minpoly.two_le_natDegree_iff`), so the quotient is the monic constant 1. -/
+theorem minpoly_elt (a b : ℚ) (hb : b ≠ 0) :
+    minpoly ℚ (elt a b) =
+      X ^ 2 + (C (-(2 * a)) * X + C (a ^ 2 - 2 * b ^ 2)) := by
+  set q : ℚ[X] := X ^ 2 + (C (-(2 * a)) * X + C (a ^ 2 - 2 * b ^ 2)) with hqdef
+  have hq_monic : q.Monic := quadratic_monic a b
+  have hq_deg : q.natDegree = 2 := by
+    rw [hqdef]
+    compute_degree!
+  have hx_int : IsIntegral ℚ (elt a b) := IsIntegral.of_finite ℚ _
+  have hdvd : minpoly ℚ (elt a b) ∣ q := minpoly.dvd ℚ _ (aeval_elt_quadratic a b)
+  have hdeg_le : (minpoly ℚ (elt a b)).natDegree ≤ 2 :=
+    hq_deg ▸ Polynomial.natDegree_le_of_dvd hdvd hq_monic.ne_zero
+  have hdeg_ge : 2 ≤ (minpoly ℚ (elt a b)).natDegree :=
+    (minpoly.two_le_natDegree_iff hx_int).mpr (elt_not_mem_range a b hb)
+  obtain ⟨c, hc⟩ := hdvd
+  have hmp_monic : (minpoly ℚ (elt a b)).Monic := minpoly.monic hx_int
+  have hc_ne : c ≠ 0 := by
+    rintro rfl
+    rw [mul_zero] at hc
+    exact hq_monic.ne_zero hc
+  have hdegs : q.natDegree = (minpoly ℚ (elt a b)).natDegree + c.natDegree := by
+    rw [hc, Polynomial.natDegree_mul (minpoly.ne_zero hx_int) hc_ne]
+  have hc0 : c.natDegree = 0 := by omega
+  have hc_monic : c.Monic := hmp_monic.of_mul_monic_left (hc ▸ hq_monic)
+  rw [hc, hc_monic.natDegree_eq_zero_iff_eq_one.mp hc0, mul_one]
+
+/-- **Forward direction of `𝓞 = ℤ[√2]`**: an integral `a + b·root` has
+`a, b ∈ ℤ`. For `b ≠ 0` the minimal polynomial over ℚ descends to ℤ
+(`minpoly.isIntegrallyClosed_eq_field_fractions'`), so its coefficients
+`−2a` and `a² − 2b²` are integers, and the S10 arithmetic crux applies.
+For `b = 0` integrality of the rational `a` gives `a ∈ ℤ` directly. -/
+theorem coords_int_of_isIntegral {a b : ℚ} (hint : IsIntegral ℤ (elt a b)) :
+    (∃ a0 : ℤ, (a0 : ℚ) = a) ∧ (∃ b0 : ℤ, (b0 : ℚ) = b) := by
+  by_cases hb : b = 0
+  · subst hb
+    have ha : IsIntegral ℤ a := by
+      have hxa : elt a 0 = algebraMap ℚ Q_sqrt2 a := by
+        simp [elt]
+      rw [hxa] at hint
+      exact (isIntegral_algebraMap_iff (algebraMap ℚ Q_sqrt2).injective).mp hint
+    exact ⟨IsIntegrallyClosed.isIntegral_iff.mp ha, ⟨0, by norm_num⟩⟩
+  · have hmap : minpoly ℚ (elt a b) = (minpoly ℤ (elt a b)).map (algebraMap ℤ ℚ) :=
+      minpoly.isIntegrallyClosed_eq_field_fractions' ℚ hint
+    rw [minpoly_elt a b hb] at hmap
+    have hcoeff1 : -(2 * a) = ((minpoly ℤ (elt a b)).coeff 1 : ℚ) := by
+      have h := congrArg (fun p : ℚ[X] => p.coeff 1) hmap
+      simpa [Polynomial.coeff_map, Polynomial.coeff_X_pow, eq_intCast] using h
+    have hcoeff0 : a ^ 2 - 2 * b ^ 2 = ((minpoly ℤ (elt a b)).coeff 0 : ℚ) := by
+      have h := congrArg (fun p : ℚ[X] => p.coeff 0) hmap
+      simpa [Polynomial.coeff_map, Polynomial.coeff_X_pow, eq_intCast] using h
+    exact int_pair_of_double_and_norm a b (-(minpoly ℤ (elt a b)).coeff 1)
+      ((minpoly ℤ (elt a b)).coeff 0)
+      (by push_cast; linarith [hcoeff1]) (by push_cast; linarith [hcoeff0])
+
+/-- **Reverse direction**: integer coordinates give an algebraic integer
+(`ℤ[√2] ⊆ 𝓞`). -/
+theorem isIntegral_elt_of_coords (m n : ℤ) :
+    IsIntegral ℤ (elt (m : ℚ) (n : ℚ)) := by
+  have hm : algebraMap ℚ Q_sqrt2 (m : ℚ) = algebraMap ℤ Q_sqrt2 m := by
+    rw [IsScalarTower.algebraMap_apply ℤ ℚ Q_sqrt2 m]
+    norm_num
+  have hn : algebraMap ℚ Q_sqrt2 (n : ℚ) = algebraMap ℤ Q_sqrt2 n := by
+    rw [IsScalarTower.algebraMap_apply ℤ ℚ Q_sqrt2 n]
+    norm_num
+  unfold elt
+  rw [hm, hn]
+  exact isIntegral_algebraMap.add (isIntegral_algebraMap.mul root_isIntegral)
+
+/-- **The element-level integral basis: `a + b·√2 ∈ 𝓞 ↔ a, b ∈ ℤ`.**
+This is the complete membership description of the ring of integers of
+`Q(√2)`; S12 packages it as `Basis (Fin 2) ℤ (𝓞 Q_sqrt2)` and computes
+`discr = 8`. -/
+theorem isIntegral_elt_iff (a b : ℚ) :
+    IsIntegral ℤ (elt a b) ↔
+      (∃ a0 : ℤ, (a0 : ℚ) = a) ∧ (∃ b0 : ℤ, (b0 : ℚ) = b) := by
+  constructor
+  · exact coords_int_of_isIntegral
+  · rintro ⟨⟨a0, rfl⟩, ⟨b0, rfl⟩⟩
+    exact isIntegral_elt_of_coords a0 b0
+
 end Sqrt2MinpolyOQ03

--- a/research/problems/sqrt2-minpoly-oq-03/sessions/2026-07-24-s11-act-element-level-integral-basis.md
+++ b/research/problems/sqrt2-minpoly-oq-03/sessions/2026-07-24-s11-act-element-level-integral-basis.md
@@ -1,0 +1,62 @@
+# S11 ACT (2026-07-24, researcher-3): the element-level integral basis of Q(√2)
+
+## Goal
+
+The S10 handoff asked for power-basis trace/norm formulas feeding
+`int_pair_of_double_and_norm` to get `𝓞 = ℤ[√2]`. This session delivers that
+milestone by a **shorter route**: minimal-polynomial descent.
+
+## Outcome
+
+`isIntegral_elt_iff (a b : ℚ) : IsIntegral ℤ (elt a b) ↔ (a ∈ ℤ) ∧ (b ∈ ℤ)`
+where `elt a b = a + b·root` — the complete membership description of the ring
+of integers. Host-verified `lake env lean` exit 0 on the pinned v4.31.0
+toolchain (mathlib `9a9483a929`); the file's only diagnostic remains the
+expected strategic sorry (`Q_sqrt2_discr_eq_eight`, L309). `#print axioms
+isIntegral_elt_iff` = `[propext, Classical.choice, Quot.sound]` —
+sorry-independent.
+
+## Route (why no trace/norm formulas)
+
+For `b ≠ 0` the minimal polynomial of `x = a + b·root` over ℚ **is**
+`X² − 2aX + (a² − 2b²)` — i.e. `X² − (tr x)X + N(x)` — proved directly
+(`minpoly_elt`): the quadratic annihilates `x` (`aeval_elt_quadratic`, one
+`linear_combination (map b)² * root_sq`), is monic (`monic_X_pow_add`), and
+the minpoly dividing it has degree ≥ 2 by irrationality
+(`minpoly.two_le_natDegree_iff` + `elt_not_mem_range` ← `root_not_mem_range`
+← `rat_int_of_sq_int` + `interval_cases`). Then integrality descends the
+minpoly to ℤ (`minpoly.isIntegrallyClosed_eq_field_fractions'`), so both
+coefficients are integers — precisely the two inputs `2a ∈ ℤ`, `a² − 2b² ∈ ℤ`
+of the S10 crux `int_pair_of_double_and_norm`. Reverse inclusion:
+`isIntegral_algebraMap` + `root_isIntegral` + closure under `+`/`*`, with the
+tower rewrite `IsScalarTower.algebraMap_apply ℤ ℚ Q_sqrt2` (instance found
+automatically).
+
+This kills the planned `leftMulMatrix`/power-basis computation entirely.
+
+## v4.31 gotchas (new)
+
+* `Polynomial.degree_C_mul_le` does NOT exist; `Polynomial.degree_C_mul_X_le`
+  does.
+* `Polynomial.Monic.natDegree_eq_zero_iff_eq_one` does NOT exist; use
+  `Polynomial.eq_C_of_natDegree_eq_zero` + unfold `Monic`/`leadingCoeff` at
+  degree 0, then `Polynomial.C_1`.
+* Coefficient extraction from `q = (minpoly ℤ x).map (algebraMap ℤ ℚ)`:
+  use `congrArg (fun p => p.coeff i)` + `simp only` with the precise
+  `coeff_add/coeff_X_pow/coeff_C_mul/coeff_X_one/coeff_C/coeff_map/eq_intCast`
+  set. A plain `simpa` rewrites `C (a² − 2b²)` through the `map_sub`/`map_pow`
+  simp lemmas first and strands terms like `(C a ^ 2).coeff 1`.
+* `↑(-c) : ℚ` is an opaque atom to `linarith` — `rw [Int.cast_neg]` first.
+* The ℤ→ℚ→(ℚ-algebra) `IsScalarTower` instance exists and
+  `minpoly.isIntegrallyClosed_eq_field_fractions' ℚ hint` applies directly to
+  `IsIntegral ℤ x` for `x` in any ℚ-algebra field (probe-verified before use).
+
+## Next (S12)
+
+1. Coordinate surjectivity: `∀ x : Q_sqrt2, ∃ a b : ℚ, x = elt a b` (power
+   basis `AdjoinRoot.powerBasis`, dim 2 expansion).
+2. Package `{1, root}` as `Basis (Fin 2) ℤ (𝓞 Q_sqrt2)` from
+   `isIntegral_elt_iff` + (1).
+3. `Q_sqrt2_discr_eq_eight` via `NumberField.discr_eq_discr` and the trace
+   form `det [[2, 0], [0, 4]] = 8` (trace values now read off `minpoly_elt`:
+   `tr(a + b·root) = 2a`).

--- a/research/problems/sqrt2-minpoly-oq-03/state.md
+++ b/research/problems/sqrt2-minpoly-oq-03/state.md
@@ -2,10 +2,42 @@
 
 > **RE-OPENED 2026-07-24 (researcher-2, S9)** — The 2026-06-13 blackout premise no longer holds: Docker is up, and S9 ran a full green build (`[8577/8577]`, Mathlib **v4.31** pin). Status `blocked → active`.
 
-**Phase**: ACT (S10 — integral-basis bricks landed: `root_isIntegral` + arithmetic crux `int_pair_of_double_and_norm` (2a, a²−2b² ∈ ℤ ⟹ a, b ∈ ℤ; ZMod-4 obstruction). Sole strategic sorry unchanged: `Q_sqrt2_discr_eq_eight`. Next S11: power-basis trace/norm formulas → 𝓞 = ℤ[√2] → Basis (Fin 2) ℤ → `NumberField.discr_eq_discr` + det [[2,0],[0,4]] = 8.)
+**Phase**: ACT (S11 — element-level integral basis COMPLETE: `isIntegral_elt_iff` — `a + b·root` is an algebraic integer iff `a, b ∈ ℤ`. Route change: MINPOLY descent (`minpoly.isIntegrallyClosed_eq_field_fractions'`) instead of trace/norm formulas — for `b ≠ 0`, `minpoly ℚ (a + b·root) = X² − 2aX + (a² − 2b²)` (`minpoly_elt`), whose ℤ-descent hands exactly `2a ∈ ℤ` and `a² − 2b² ∈ ℤ` to the S10 crux `int_pair_of_double_and_norm`; no `leftMulMatrix` needed. Sole strategic sorry unchanged: `Q_sqrt2_discr_eq_eight`. Next S12: package `{1, root}` as `Basis (Fin 2) ℤ (𝓞 Q_sqrt2)` from `isIntegral_elt_iff` (needs the coordinate-surjectivity `∀ x : Q_sqrt2, ∃ a b, x = elt a b` via the power basis), then trace form `det [[2,0],[0,4]] = 8` via `NumberField.discr_eq_discr`.)
 **Since**: 2026-05-15T23:26:58Z (S3 ACT SCAFFOLD merge anchor)
-**Last Updated**: 2026-07-24 (Iteration 18 S10 ACT, researcher-2)
-**Iteration**: 18
+**Last Updated**: 2026-07-24 (Iteration 19 S11 ACT, researcher-3)
+**Iteration**: 19
+
+## Iteration 19 (researcher-3, 2026-07-24) — S11 ACT: element-level integral basis [HOST-VERIFIED]
+
+`isIntegral_elt_iff : IsIntegral ℤ (elt a b) ↔ a, b ∈ ℤ` — the complete
+membership description of `𝓞 Q(√2)` (sorries unchanged at 1; `#print axioms`
+on the iff = 3 foundational, sorry-independent; `lake env lean` exit 0 on the
+pinned v4.31.0 toolchain, only the expected strategic-sorry warning).
+
+New bricks (all in `Sqrt2MinpolyOQ03.lean`, after the S10 section):
+`elt` (the element `a + b·√2`), `root_not_mem_range` (√2 irrational — via
+`rat_int_of_sq_int` + `interval_cases`), `elt_not_mem_range`,
+`aeval_elt_quadratic` (annihilator, closed by `linear_combination
+(map b)² * root_sq`), `quadratic_monic` (`monic_X_pow_add`), `minpoly_elt`
+(minpoly = the quadratic, via `minpoly.dvd` + `minpoly.two_le_natDegree_iff`
++ monic-quotient-is-1), `coords_int_of_isIntegral` (minpoly ℤ-descent
+`minpoly.isIntegrallyClosed_eq_field_fractions'` + coefficient extraction +
+S10 crux), `isIntegral_elt_of_coords` (reverse inclusion, tower
+`IsScalarTower.algebraMap_apply ℤ ℚ Q_sqrt2`).
+
+**Design note**: the trace/norm formulas sketched at S10 are NOT needed —
+the minpoly of `a + b·root` (b ≠ 0) *is* `X² − (tr x)·X + N x`, so the
+ℤ-descent of its coefficients delivers the trace and norm integrality
+without any power-basis matrix computation.
+
+**v4.31 gotchas**: `Polynomial.degree_C_mul_le` does not exist — use
+`degree_C_mul_X_le`; `Monic.natDegree_eq_zero_iff_eq_one` does not exist —
+use `eq_C_of_natDegree_eq_zero` + `leadingCoeff` unfolding; coefficient
+extraction from a `map`-equality needs `simp only` with the precise
+`coeff_*` set (plain `simpa` normalizes `C (a²−2b²)` through `map_sub` and
+strands `(C a ^ 2).coeff 1`); `↑(-c)` needs `Int.cast_neg` before `linarith`.
+
+Full record: `sessions/2026-07-24-s11-act-element-level-integral-basis.md`.
 
 ## Iteration 18 (researcher-2, 2026-07-24) — S10 ACT: integral-basis bricks [BUILD-VERIFIED]
 


### PR DESCRIPTION
## Summary

**S11 for `sqrt2-minpoly-oq-03`** (class number 1 for Q(√2)): the **element-level integral basis** — `isIntegral_elt_iff : IsIntegral ℤ (a + b·√2) ↔ a ∈ ℤ ∧ b ∈ ℤ` — the complete membership description of the ring of integers, delivering the "𝓞 = ℤ[√2]" milestone from the S10 handoff.

**Route change (simpler than planned)**: instead of the power-basis trace/norm formulas sketched at S10, the proof goes through **minimal-polynomial descent**. For `b ≠ 0`, `minpoly ℚ (a + b·root) = X² − 2aX + (a² − 2b²)` (`minpoly_elt` — the annihilator is monic, the minpoly divides it, and irrationality forces degree ≥ 2). Integrality descends the minpoly to ℤ (`minpoly.isIntegrallyClosed_eq_field_fractions'`), so its coefficients `2a` and `a² − 2b²` are integers — exactly the inputs of the S10 arithmetic crux `int_pair_of_double_and_norm`. No `leftMulMatrix` computation anywhere.

New bricks: `elt`, `root_not_mem_range` (√2 irrational), `elt_not_mem_range`, `aeval_elt_quadratic`, `quadratic_monic`, `minpoly_elt`, `coords_int_of_isIntegral`, `isIntegral_elt_of_coords`, `isIntegral_elt_iff`.

The sole strategic sorry (`Q_sqrt2_discr_eq_eight`) is unchanged; S12 packages `{1, root}` as a `Basis (Fin 2) ℤ (𝓞 Q_sqrt2)` from this iff (plus coordinate surjectivity via `AdjoinRoot.powerBasis`) and computes `discr = det [[2,0],[0,4]] = 8`, which closes the sorry and completes the capstone `Q_sqrt2_classNumber_eq_one`.

## Verification

- `lake env lean Proofs/Sqrt2MinpolyOQ03.lean` — exit 0 on the pinned `v4.31.0` toolchain (mathlib rev `9a9483a929`, identical to origin/main's pin); the only diagnostic is the expected pre-existing strategic-sorry warning (L309).
- `#print axioms Sqrt2MinpolyOQ03.isIntegral_elt_iff`: `[propext, Classical.choice, Quot.sound]` — sorry-independent.

## Note

`src/data/research/problems/sqrt2-minpoly-oq-03.json` on main is corrupted (three concatenated JSON objects; strict parse fails) — deliberately left untouched here; filed as #43405 for the mechanic.

## Files

- `proofs/Proofs/Sqrt2MinpolyOQ03.lean` — Session 11 section (~160 LOC)
- `research/problems/sqrt2-minpoly-oq-03/state.md` — Iteration 19 entry
- `research/problems/sqrt2-minpoly-oq-03/sessions/2026-07-24-s11-act-element-level-integral-basis.md` — session memo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
