### PR TITLE
Research: product-of-segments-of-chords-oq-03 - S18: headline concyclicity iff proven (0 sorries, 0 axioms)

### DIFF
--- a/proofs/Proofs/ProductOfSegmentsOfChordsOQ03.lean
+++ b/proofs/Proofs/ProductOfSegmentsOfChordsOQ03.lean
@@ -1,4 +1,5 @@
 import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.LinearAlgebra.AffineSpace.FiniteDimensional
 import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 import Mathlib.LinearAlgebra.Matrix.Notation
 import Mathlib.Tactic
@@ -14,14 +15,20 @@ S2 SCAFFOLD for `product-of-segments-of-chords-oq-03`:
    concyclicity determinant (Möbius / Berger, *Geometry I*, Theorem 10.7.6).
 2. `Vec2`-level wrapper `concyclicityDet` accessing the two coordinates of each
    `EuclideanSpace ℝ (Fin 2)` point.
-3. Statement of the main bidirectional criterion
-   `concyclicityDet_eq_zero_iff_concyclic`, with `sorry` (closed in S3 + S4).
+3. The main bidirectional criterion `concyclicityDet_eq_zero_iff_concyclic`,
+   **fully proven** (S18 ACT, Part 12) under the genuine non-degeneracy
+   hypothesis `¬ Collinear ℝ {P₁, P₂, P₃}` — the `(hNonCollinear : True)`
+   placeholder from S2 is gone. The file now has **0 sorries and 0 axioms**.
 4. (S7 BUILD-VERIFY note) The two numerical sanity-check examples shipped in
    S2 SCAFFOLD on `Matrix.det_fin_four` have been removed — the lemma never
    existed in Mathlib v4.26.0. See the comment in Part 3 below.
+5. (S18 ACT) Parts 9–12: the collinearity determinant and its bridge to
+   `Collinear ℝ`, the explicit Cramer-rule circumcircle of three non-collinear
+   points, the cofactor decomposition of Δ relative to a candidate circle, and
+   the assembled iff.
 
-Subsequent sessions (S3, S4, S5, S6) discharge the sorry and bridge the result
-back to `Proofs/ProductOfSegmentsOfChords.lean` line 468
+The remaining programme (state.md S5/S6) bridges this result back to
+`Proofs/ProductOfSegmentsOfChords.lean` line 468
 (`converse_product_implies_concyclic_axiom`).
 
 See `research/problems/product-of-segments-of-chords-oq-03/state.md` for the
@@ -105,24 +112,16 @@ theorem concyclicityDetCoords_off_circle :
   simp [Matrix.det_succ_row_zero, Fin.sum_univ_succ, Matrix.det_fin_zero, Fin.succAbove]
   norm_num
 
-/-! ## Part 4: Main theorem (statement only) -/
+/-! ## Part 4: Main theorem (moved)
 
-/-- **Concyclicity criterion** (statement, proof deferred to S3 + S4).
-
-Assume $P_1, P_2, P_3$ are non-collinear (placeholder hypothesis `True` until
-S3 supplies the correct non-degeneracy condition). Then four points have
-$\Delta = 0$ iff they lie on a common circle.
-
-The ($\Leftarrow$) direction (S4) follows by row reduction; ($\Rightarrow$)
-(S3) uses Cramer's rule on the implicit-circle equation
-$x^2 + y^2 + Dx + Ey + F = 0$. -/
-theorem concyclicityDet_eq_zero_iff_concyclic
-    (P₁ P₂ P₃ P₄ : Vec2)
-    (hNonCollinear : True) :
-    concyclicityDet P₁ P₂ P₃ P₄ = 0 ↔
-      ∃ (O : Vec2) (r : ℝ), 0 < r ∧
-        ‖P₁ - O‖ = r ∧ ‖P₂ - O‖ = r ∧ ‖P₃ - O‖ = r ∧ ‖P₄ - O‖ = r := by
-  sorry
+The headline criterion `concyclicityDet_eq_zero_iff_concyclic` is stated and
+**proven** in Part 12 at the end of this file (S18 ACT) — its proof consumes
+the helper lemmas of Parts 5–11, so the declaration must come after them.
+Relative to the S2 stub that used to live here, the placeholder hypothesis
+`(hNonCollinear : True)` has been replaced by the genuine non-degeneracy
+condition `¬ Collinear ℝ ({P₁, P₂, P₃} : Set Vec2)`; with the placeholder the
+($\Rightarrow$) direction is *false* (four distinct collinear points have
+$\Delta = 0$ but lie on no common circle). -/
 
 /-! ## Part 5: Coordinate-form norm-squared helper (S15 ACT) -/
 
@@ -261,5 +260,266 @@ theorem concyclic_implies_concyclicityDet_zero
     fin_cases i <;>
       simp [Matrix.mulVec, dotProduct, Fin.sum_univ_four] <;>
       nlinarith [e P₁ h₁, e P₂ h₂, e P₃ h₃, e P₄ h₄]
+
+/-! ## Part 9: The collinearity determinant and non-collinearity (S18 ACT)
+
+The genuine non-degeneracy hypothesis for the concyclicity criterion is that
+`P₁, P₂, P₃` are not collinear. Algebraically this is the non-vanishing of the
+$2\times 2$ determinant $d = (x_2-x_1)(y_3-y_1) - (x_3-x_1)(y_2-y_1)$ (twice
+the signed triangle area, and also the bottom cofactor $M_4$ of the
+concyclicity matrix). This part defines `collinearityDet` and proves the
+direction of the bridge needed downstream: vanishing determinant ⟹
+`Collinear ℝ`, hence ¬collinear ⟹ nonzero determinant. -/
+
+/-- The planar collinearity determinant of three points in raw coordinates:
+$(x_2-x_1)(y_3-y_1) - (x_3-x_1)(y_2-y_1)$, i.e. twice the signed area of the
+triangle `P₁P₂P₃`. The three points are collinear iff it vanishes. -/
+def collinearityDetCoords (x₁ y₁ x₂ y₂ x₃ y₃ : ℝ) : ℝ :=
+  (x₂ - x₁) * (y₃ - y₁) - (x₃ - x₁) * (y₂ - y₁)
+
+/-- `Vec2`-level wrapper for `collinearityDetCoords`. -/
+def collinearityDet (P₁ P₂ P₃ : Vec2) : ℝ :=
+  collinearityDetCoords (P₁ 0) (P₁ 1) (P₂ 0) (P₂ 1) (P₃ 0) (P₃ 1)
+
+/-- If the collinearity determinant of three planar points vanishes, the
+points are collinear in the affine sense. Case split: if `P₂ = P₁` the
+direction `P₃ - P₁` works; otherwise `P₂ - P₁` is a nonzero direction and the
+vanishing determinant supplies the scalar for `P₃` (parametrising by whichever
+coordinate of `P₂ - P₁` is nonzero). -/
+theorem collinear_of_collinearityDet_eq_zero
+    (P₁ P₂ P₃ : Vec2) (h : collinearityDet P₁ P₂ P₃ = 0) :
+    Collinear ℝ ({P₁, P₂, P₃} : Set Vec2) := by
+  have h' : (P₂ 0 - P₁ 0) * (P₃ 1 - P₁ 1) - (P₃ 0 - P₁ 0) * (P₂ 1 - P₁ 1) = 0 := h
+  rw [collinear_iff_of_mem (Set.mem_insert P₁ {P₂, P₃})]
+  by_cases hx : P₂ 0 - P₁ 0 = 0
+  · by_cases hy : P₂ 1 - P₁ 1 = 0
+    · -- both coordinates agree: `P₂ = P₁`, direction `P₃ - P₁`
+      have h21 : P₂ = P₁ := by
+        apply PiLp.ext
+        intro i
+        fin_cases i
+        · exact sub_eq_zero.mp hx
+        · exact sub_eq_zero.mp hy
+      refine ⟨P₃ - P₁, ?_⟩
+      intro p hp
+      simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hp
+      rcases hp with rfl | rfl | rfl
+      · exact ⟨0, by simp⟩
+      · exact ⟨0, by simp [h21]⟩
+      · exact ⟨1, by simp [vadd_eq_add]⟩
+    · -- `P₂ 1 ≠ P₁ 1`: parametrise `P₃` by its `y`-coordinate
+      refine ⟨P₂ - P₁, ?_⟩
+      intro p hp
+      simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hp
+      rcases hp with rfl | rfl | rfl
+      · exact ⟨0, by simp⟩
+      · exact ⟨1, by simp [vadd_eq_add]⟩
+      · refine ⟨(P₃ 1 - P₁ 1) / (P₂ 1 - P₁ 1), ?_⟩
+        apply PiLp.ext
+        intro i
+        simp only [vadd_eq_add, PiLp.add_apply, PiLp.smul_apply, PiLp.sub_apply,
+          smul_eq_mul]
+        fin_cases i
+        · -- the `x`-coordinate needs the vanishing determinant
+          field_simp [hy]
+          first
+          | linear_combination h'
+          | linear_combination -h'
+        · field_simp [hy]
+  · -- `P₂ 0 ≠ P₁ 0`: parametrise `P₃` by its `x`-coordinate
+    refine ⟨P₂ - P₁, ?_⟩
+    intro p hp
+    simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hp
+    rcases hp with rfl | rfl | rfl
+    · exact ⟨0, by simp⟩
+    · exact ⟨1, by simp [vadd_eq_add]⟩
+    · refine ⟨(P₃ 0 - P₁ 0) / (P₂ 0 - P₁ 0), ?_⟩
+      apply PiLp.ext
+      intro i
+      simp only [vadd_eq_add, PiLp.add_apply, PiLp.smul_apply, PiLp.sub_apply,
+        smul_eq_mul]
+      fin_cases i
+      · field_simp [hx]
+      · -- the `y`-coordinate needs the vanishing determinant
+        field_simp [hx]
+        first
+        | linear_combination h'
+        | linear_combination -h'
+
+/-- Contrapositive form used by the main theorem: non-collinear triples have
+nonzero collinearity determinant. -/
+theorem collinearityDet_ne_zero_of_not_collinear
+    (P₁ P₂ P₃ : Vec2)
+    (h : ¬ Collinear ℝ ({P₁, P₂, P₃} : Set Vec2)) :
+    collinearityDet P₁ P₂ P₃ ≠ 0 :=
+  fun h0 => h (collinear_of_collinearityDet_eq_zero P₁ P₂ P₃ h0)
+
+/-! ## Part 10: The circumcircle of a non-collinear triple (S18 ACT)
+
+Cramer's rule on the two perpendicular-bisector equations
+
+  `2(x₂-x₁)·O₀ + 2(y₂-y₁)·O₁ = (x₂²+y₂²) - (x₁²+y₁²)`
+  `2(x₃-x₁)·O₀ + 2(y₃-y₁)·O₁ = (x₃²+y₃²) - (x₁²+y₁²)`
+
+whose coefficient determinant is `4·collinearityDet ≠ 0`, gives the explicit
+circumcenter; the common radius `r = ‖P₁ - O‖` is positive because `r = 0`
+would force `P₂ = P₁` and hence a vanishing collinearity determinant. -/
+
+/-- Core Cramer computation, pure coordinates: the explicit circumcenter
+equalises the three squared distances. -/
+private lemma circumcenter_spec
+    (x₁ y₁ x₂ y₂ x₃ y₃ : ℝ)
+    (hd : (x₂ - x₁) * (y₃ - y₁) - (x₃ - x₁) * (y₂ - y₁) ≠ 0) :
+    ∃ O₀ O₁ : ℝ,
+      (x₂ - O₀) ^ 2 + (y₂ - O₁) ^ 2 = (x₁ - O₀) ^ 2 + (y₁ - O₁) ^ 2 ∧
+      (x₃ - O₀) ^ 2 + (y₃ - O₁) ^ 2 = (x₁ - O₀) ^ 2 + (y₁ - O₁) ^ 2 := by
+  refine ⟨((x₂ ^ 2 + y₂ ^ 2 - x₁ ^ 2 - y₁ ^ 2) * (y₃ - y₁)
+          - (x₃ ^ 2 + y₃ ^ 2 - x₁ ^ 2 - y₁ ^ 2) * (y₂ - y₁))
+          / (2 * ((x₂ - x₁) * (y₃ - y₁) - (x₃ - x₁) * (y₂ - y₁))),
+         ((x₃ ^ 2 + y₃ ^ 2 - x₁ ^ 2 - y₁ ^ 2) * (x₂ - x₁)
+          - (x₂ ^ 2 + y₂ ^ 2 - x₁ ^ 2 - y₁ ^ 2) * (x₃ - x₁))
+          / (2 * ((x₂ - x₁) * (y₃ - y₁) - (x₃ - x₁) * (y₂ - y₁))),
+         ?_, ?_⟩
+  · field_simp [hd]
+    ring
+  · field_simp [hd]
+    ring
+
+/-- Every non-collinear triple in the plane lies on a genuine circle
+(positive radius). -/
+theorem exists_circumcircle
+    (P₁ P₂ P₃ : Vec2) (hd : collinearityDet P₁ P₂ P₃ ≠ 0) :
+    ∃ (O : Vec2) (r : ℝ), 0 < r ∧
+      ‖P₁ - O‖ = r ∧ ‖P₂ - O‖ = r ∧ ‖P₃ - O‖ = r := by
+  have hdc : (P₂ 0 - P₁ 0) * (P₃ 1 - P₁ 1) - (P₃ 0 - P₁ 0) * (P₂ 1 - P₁ 1) ≠ 0 := hd
+  obtain ⟨O₀, O₁, h2, h3⟩ :=
+    circumcenter_spec (P₁ 0) (P₁ 1) (P₂ 0) (P₂ 1) (P₃ 0) (P₃ 1) hdc
+  set O : Vec2 := WithLp.toLp 2 ![O₀, O₁] with hO
+  have hO0 : O 0 = O₀ := rfl
+  have hO1 : O 1 = O₁ := rfl
+  have hsq2 : ‖P₂ - O‖ ^ 2 = ‖P₁ - O‖ ^ 2 := by
+    rw [norm_sub_sq_coord, norm_sub_sq_coord, hO0, hO1]
+    exact h2
+  have hsq3 : ‖P₃ - O‖ ^ 2 = ‖P₁ - O‖ ^ 2 := by
+    rw [norm_sub_sq_coord, norm_sub_sq_coord, hO0, hO1]
+    exact h3
+  have h₂ : ‖P₂ - O‖ = ‖P₁ - O‖ :=
+    (pow_left_inj₀ (norm_nonneg _) (norm_nonneg _) (by norm_num : (2 : ℕ) ≠ 0)).mp hsq2
+  have h₃ : ‖P₃ - O‖ = ‖P₁ - O‖ :=
+    (pow_left_inj₀ (norm_nonneg _) (norm_nonneg _) (by norm_num : (2 : ℕ) ≠ 0)).mp hsq3
+  refine ⟨O, ‖P₁ - O‖, ?_, rfl, h₂, h₃⟩
+  rcases (norm_nonneg (P₁ - O)).lt_or_eq with hlt | heq
+  · exact hlt
+  · -- radius `0` would force `P₂ = P₁`, contradicting `hd`
+    exfalso
+    have e₁ : P₁ = O := sub_eq_zero.mp (norm_eq_zero.mp heq.symm)
+    have e₂ : P₂ = O := by
+      have h0 : ‖P₂ - O‖ = 0 := by rw [h₂, ← heq]
+      exact sub_eq_zero.mp (norm_eq_zero.mp h0)
+    have h21 : P₂ = P₁ := e₂.trans e₁.symm
+    apply hdc
+    have c0 : P₂ 0 = P₁ 0 := by rw [h21]
+    have c1 : P₂ 1 = P₁ 1 := by rw [h21]
+    rw [c0, c1]
+    ring
+
+/-! ## Part 11: Cofactor decomposition and the forced fourth point (S18 ACT)
+
+Column multilinearity gives the *exact polynomial identity*
+
+  `Δ = e₁·M₁ - e₂·M₂ + e₃·M₃ - e₄·M₄`,
+
+where `eᵢ = (xᵢ-O₀)² + (yᵢ-O₁)² - r²` is the circle defect of `Pᵢ` and `Mᵢ`
+is the 3×3 minor of the `(x, y, 1)` columns omitting row `i` (in particular
+`M₄ = collinearityDet P₁ P₂ P₃`): substituting
+`xᵢ²+yᵢ² = eᵢ + 2O₀xᵢ + 2O₁yᵢ + (r²-O₀²-O₁²)` in the first column, the three
+non-`e` summands each produce a repeated column, so only `det(e-col, x, y, 1)`
+survives. With `P₁, P₂, P₃` on the circle (`e₁ = e₂ = e₃ = 0`) and `Δ = 0`,
+the identity collapses to `e₄ · M₄ = 0`, and `M₄ ≠ 0` forces `e₄ = 0`. -/
+
+/-- Exact cofactor decomposition of the concyclicity determinant relative to
+an arbitrary candidate circle (center `(O₀, O₁)`, radius `r`). This is a pure
+polynomial identity — no hypotheses. -/
+lemma concyclicityDetCoords_circle_decomp
+    (O₀ O₁ r x₁ y₁ x₂ y₂ x₃ y₃ x₄ y₄ : ℝ) :
+    concyclicityDetCoords x₁ y₁ x₂ y₂ x₃ y₃ x₄ y₄ =
+      ((x₁ - O₀) ^ 2 + (y₁ - O₁) ^ 2 - r ^ 2)
+          * (x₂ * (y₃ - y₄) - x₃ * (y₂ - y₄) + x₄ * (y₂ - y₃))
+        - ((x₂ - O₀) ^ 2 + (y₂ - O₁) ^ 2 - r ^ 2)
+          * (x₁ * (y₃ - y₄) - x₃ * (y₁ - y₄) + x₄ * (y₁ - y₃))
+        + ((x₃ - O₀) ^ 2 + (y₃ - O₁) ^ 2 - r ^ 2)
+          * (x₁ * (y₂ - y₄) - x₂ * (y₁ - y₄) + x₄ * (y₁ - y₂))
+        - ((x₄ - O₀) ^ 2 + (y₄ - O₁) ^ 2 - r ^ 2)
+          * (x₁ * (y₂ - y₃) - x₂ * (y₁ - y₃) + x₃ * (y₁ - y₂)) := by
+  unfold concyclicityDetCoords
+  simp [Matrix.det_succ_row_zero, Fin.sum_univ_succ, Matrix.det_fin_zero,
+    Fin.succAbove]
+  ring
+
+/-- If `P₁, P₂, P₃` lie on the circle of center `O` and radius `r`, are not
+collinear, and the concyclicity determinant of `P₁, P₂, P₃, P₄` vanishes,
+then `P₄` lies on the same circle. -/
+theorem fourth_point_on_circle
+    (P₁ P₂ P₃ P₄ O : Vec2) (r : ℝ) (hr : 0 ≤ r)
+    (hd : collinearityDet P₁ P₂ P₃ ≠ 0)
+    (h₁ : ‖P₁ - O‖ = r) (h₂ : ‖P₂ - O‖ = r) (h₃ : ‖P₃ - O‖ = r)
+    (hΔ : concyclicityDet P₁ P₂ P₃ P₄ = 0) :
+    ‖P₄ - O‖ = r := by
+  have e₁ : (P₁ 0 - O 0) ^ 2 + (P₁ 1 - O 1) ^ 2 = r ^ 2 := by
+    have h := norm_sub_sq_coord P₁ O
+    rw [h₁] at h
+    linarith
+  have e₂ : (P₂ 0 - O 0) ^ 2 + (P₂ 1 - O 1) ^ 2 = r ^ 2 := by
+    have h := norm_sub_sq_coord P₂ O
+    rw [h₂] at h
+    linarith
+  have e₃ : (P₃ 0 - O 0) ^ 2 + (P₃ 1 - O 1) ^ 2 = r ^ 2 := by
+    have h := norm_sub_sq_coord P₃ O
+    rw [h₃] at h
+    linarith
+  have hdc : (P₂ 0 - P₁ 0) * (P₃ 1 - P₁ 1) - (P₃ 0 - P₁ 0) * (P₂ 1 - P₁ 1) ≠ 0 := hd
+  have hΔ' : concyclicityDetCoords (P₁ 0) (P₁ 1) (P₂ 0) (P₂ 1) (P₃ 0) (P₃ 1)
+      (P₄ 0) (P₄ 1) = 0 := hΔ
+  rw [concyclicityDetCoords_circle_decomp (O 0) (O 1) r] at hΔ'
+  have key : ((P₄ 0 - O 0) ^ 2 + (P₄ 1 - O 1) ^ 2 - r ^ 2)
+      * ((P₂ 0 - P₁ 0) * (P₃ 1 - P₁ 1) - (P₃ 0 - P₁ 0) * (P₂ 1 - P₁ 1)) = 0 := by
+    linear_combination (-1 : ℝ) * hΔ'
+      + (P₂ 0 * (P₃ 1 - P₄ 1) - P₃ 0 * (P₂ 1 - P₄ 1) + P₄ 0 * (P₂ 1 - P₃ 1)) * e₁
+      - (P₁ 0 * (P₃ 1 - P₄ 1) - P₃ 0 * (P₁ 1 - P₄ 1) + P₄ 0 * (P₁ 1 - P₃ 1)) * e₂
+      + (P₁ 0 * (P₂ 1 - P₄ 1) - P₂ 0 * (P₁ 1 - P₄ 1) + P₄ 0 * (P₁ 1 - P₂ 1)) * e₃
+  have h4 : (P₄ 0 - O 0) ^ 2 + (P₄ 1 - O 1) ^ 2 = r ^ 2 := by
+    rcases mul_eq_zero.mp key with h | h
+    · linarith
+    · exact absurd h hdc
+  have hsq : ‖P₄ - O‖ ^ 2 = r ^ 2 := by
+    rw [norm_sub_sq_coord]
+    exact h4
+  exact (pow_left_inj₀ (norm_nonneg _) hr (by norm_num : (2 : ℕ) ≠ 0)).mp hsq
+
+/-! ## Part 12: Main theorem (S18 ACT) -/
+
+/-- **Concyclicity criterion.** For `P₁, P₂, P₃` non-collinear, the four
+points `P₁, P₂, P₃, P₄` have vanishing concyclicity determinant iff they lie
+on a common circle of positive radius.
+
+(⟹): the circumcircle of `P₁P₂P₃` exists by `exists_circumcircle`, and the
+cofactor decomposition forces `P₄` onto it (`fourth_point_on_circle`).
+(⟸): `concyclic_implies_concyclicityDet_zero`, which needs no non-degeneracy
+hypothesis at all. -/
+theorem concyclicityDet_eq_zero_iff_concyclic
+    (P₁ P₂ P₃ P₄ : Vec2)
+    (hNonCollinear : ¬ Collinear ℝ ({P₁, P₂, P₃} : Set Vec2)) :
+    concyclicityDet P₁ P₂ P₃ P₄ = 0 ↔
+      ∃ (O : Vec2) (r : ℝ), 0 < r ∧
+        ‖P₁ - O‖ = r ∧ ‖P₂ - O‖ = r ∧ ‖P₃ - O‖ = r ∧ ‖P₄ - O‖ = r := by
+  have hd : collinearityDet P₁ P₂ P₃ ≠ 0 :=
+    collinearityDet_ne_zero_of_not_collinear P₁ P₂ P₃ hNonCollinear
+  constructor
+  · intro hΔ
+    obtain ⟨O, r, hr, h₁, h₂, h₃⟩ := exists_circumcircle P₁ P₂ P₃ hd
+    exact ⟨O, r, hr, h₁, h₂, h₃,
+      fourth_point_on_circle P₁ P₂ P₃ P₄ O r hr.le hd h₁ h₂ h₃ hΔ⟩
+  · rintro ⟨O, r, _, h₁, h₂, h₃, h₄⟩
+    exact concyclic_implies_concyclicityDet_zero P₁ P₂ P₃ P₄ O r h₁ h₂ h₃ h₄
 
 end ProductOfSegmentsOfChordsOQ03

--- a/proofs/Proofs/ProductOfSegmentsOfChordsOQ03.lean
+++ b/proofs/Proofs/ProductOfSegmentsOfChordsOQ03.lean
@@ -371,26 +371,39 @@ whose coefficient determinant is `4·collinearityDet ≠ 0`, gives the explicit
 circumcenter; the common radius `r = ‖P₁ - O‖` is positive because `r = 0`
 would force `P₂ = P₁` and hence a vanishing collinearity determinant. -/
 
+/-- A point `(O₀, O₁)` on the perpendicular bisector of `(x₁,y₁)`-`(x₂,y₂)`
+(in equation form) is equidistant from the two points, in squared form. Pure
+ring identity — the `O₀²`, `O₁²` terms cancel, so this stays linear in the
+center coordinates and never needs a denominator cleared. -/
+private lemma bisector_to_dist
+    (x₁ y₁ x₂ y₂ O₀ O₁ : ℝ)
+    (hb : 2 * (x₂ - x₁) * O₀ + 2 * (y₂ - y₁) * O₁
+        = x₂ ^ 2 + y₂ ^ 2 - x₁ ^ 2 - y₁ ^ 2) :
+    (x₂ - O₀) ^ 2 + (y₂ - O₁) ^ 2 = (x₁ - O₀) ^ 2 + (y₁ - O₁) ^ 2 := by
+  linear_combination -hb
+
 /-- Core Cramer computation, pure coordinates: the explicit circumcenter
-equalises the three squared distances. (`maxRecDepth` raised for the
-`field_simp` pass over the explicit quotients.) -/
-set_option maxRecDepth 8192 in
+equalises the three squared distances. Denominators are cleared by a
+deterministic `mul_div_assoc`/`div_add_div_same`/`div_eq_iff` chain (the
+quotients only ever appear linearly here, thanks to `bisector_to_dist`). -/
 private lemma circumcenter_spec
     (x₁ y₁ x₂ y₂ x₃ y₃ : ℝ)
     (hd : (x₂ - x₁) * (y₃ - y₁) - (x₃ - x₁) * (y₂ - y₁) ≠ 0) :
     ∃ O₀ O₁ : ℝ,
       (x₂ - O₀) ^ 2 + (y₂ - O₁) ^ 2 = (x₁ - O₀) ^ 2 + (y₁ - O₁) ^ 2 ∧
       (x₃ - O₀) ^ 2 + (y₃ - O₁) ^ 2 = (x₁ - O₀) ^ 2 + (y₁ - O₁) ^ 2 := by
+  have h2d : 2 * ((x₂ - x₁) * (y₃ - y₁) - (x₃ - x₁) * (y₂ - y₁)) ≠ 0 :=
+    mul_ne_zero two_ne_zero hd
   refine ⟨((x₂ ^ 2 + y₂ ^ 2 - x₁ ^ 2 - y₁ ^ 2) * (y₃ - y₁)
           - (x₃ ^ 2 + y₃ ^ 2 - x₁ ^ 2 - y₁ ^ 2) * (y₂ - y₁))
           / (2 * ((x₂ - x₁) * (y₃ - y₁) - (x₃ - x₁) * (y₂ - y₁))),
          ((x₃ ^ 2 + y₃ ^ 2 - x₁ ^ 2 - y₁ ^ 2) * (x₂ - x₁)
           - (x₂ ^ 2 + y₂ ^ 2 - x₁ ^ 2 - y₁ ^ 2) * (x₃ - x₁))
           / (2 * ((x₂ - x₁) * (y₃ - y₁) - (x₃ - x₁) * (y₂ - y₁))),
-         ?_, ?_⟩
-  · field_simp [hd]
+         bisector_to_dist _ _ _ _ _ _ ?_, bisector_to_dist _ _ _ _ _ _ ?_⟩
+  · rw [← mul_div_assoc, ← mul_div_assoc, div_add_div_same, div_eq_iff h2d]
     ring
-  · field_simp [hd]
+  · rw [← mul_div_assoc, ← mul_div_assoc, div_add_div_same, div_eq_iff h2d]
     ring
 
 /-- Every non-collinear triple in the plane lies on a genuine circle

--- a/proofs/Proofs/ProductOfSegmentsOfChordsOQ03.lean
+++ b/proofs/Proofs/ProductOfSegmentsOfChordsOQ03.lean
@@ -321,9 +321,7 @@ theorem collinear_of_collinearityDet_eq_zero
           simp only [vadd_eq_add, PiLp.add_apply, PiLp.smul_apply, PiLp.sub_apply,
             smul_eq_mul]
           field_simp [hy]
-          first
-          | linear_combination h'
-          | linear_combination -h'
+          linear_combination -h'
         · simp only [vadd_eq_add, PiLp.add_apply, PiLp.smul_apply, PiLp.sub_apply,
             smul_eq_mul]
           field_simp [hy]
@@ -348,9 +346,7 @@ theorem collinear_of_collinearityDet_eq_zero
         simp only [vadd_eq_add, PiLp.add_apply, PiLp.smul_apply, PiLp.sub_apply,
           smul_eq_mul]
         field_simp [hx]
-        first
-        | linear_combination h'
-        | linear_combination -h'
+        linear_combination h'
 
 /-- Contrapositive form used by the main theorem: non-collinear triples have
 nonzero collinearity determinant. -/
@@ -401,9 +397,9 @@ private lemma circumcenter_spec
           - (x₂ ^ 2 + y₂ ^ 2 - x₁ ^ 2 - y₁ ^ 2) * (x₃ - x₁))
           / (2 * ((x₂ - x₁) * (y₃ - y₁) - (x₃ - x₁) * (y₂ - y₁))),
          bisector_to_dist _ _ _ _ _ _ ?_, bisector_to_dist _ _ _ _ _ _ ?_⟩
-  · rw [← mul_div_assoc, ← mul_div_assoc, div_add_div_same, div_eq_iff h2d]
+  · rw [← mul_div_assoc, ← mul_div_assoc, ← add_div, div_eq_iff h2d]
     ring
-  · rw [← mul_div_assoc, ← mul_div_assoc, div_add_div_same, div_eq_iff h2d]
+  · rw [← mul_div_assoc, ← mul_div_assoc, ← add_div, div_eq_iff h2d]
     ring
 
 /-- Every non-collinear triple in the plane lies on a genuine circle

--- a/proofs/Proofs/ProductOfSegmentsOfChordsOQ03.lean
+++ b/proofs/Proofs/ProductOfSegmentsOfChordsOQ03.lean
@@ -296,10 +296,8 @@ theorem collinear_of_collinearityDet_eq_zero
     · -- both coordinates agree: `P₂ = P₁`, direction `P₃ - P₁`
       have h21 : P₂ = P₁ := by
         apply PiLp.ext
-        intro i
-        fin_cases i
-        · exact sub_eq_zero.mp hx
-        · exact sub_eq_zero.mp hy
+        rw [Fin.forall_fin_two]
+        exact ⟨sub_eq_zero.mp hx, sub_eq_zero.mp hy⟩
       refine ⟨P₃ - P₁, ?_⟩
       intro p hp
       simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hp
@@ -311,36 +309,44 @@ theorem collinear_of_collinearityDet_eq_zero
       refine ⟨P₂ - P₁, ?_⟩
       intro p hp
       simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hp
-      rcases hp with rfl | rfl | rfl
+      rcases hp with rfl | rfl | hpe
       · exact ⟨0, by simp⟩
       · exact ⟨1, by simp [vadd_eq_add]⟩
-      · refine ⟨(P₃ 1 - P₁ 1) / (P₂ 1 - P₁ 1), ?_⟩
+      · rw [hpe]
+        refine ⟨(P₃ 1 - P₁ 1) / (P₂ 1 - P₁ 1), ?_⟩
         apply PiLp.ext
-        intro i
-        simp only [vadd_eq_add, PiLp.add_apply, PiLp.smul_apply, PiLp.sub_apply,
-          smul_eq_mul]
-        fin_cases i
+        rw [Fin.forall_fin_two]
+        refine ⟨?_, ?_⟩
         · -- the `x`-coordinate needs the vanishing determinant
+          simp only [vadd_eq_add, PiLp.add_apply, PiLp.smul_apply, PiLp.sub_apply,
+            smul_eq_mul]
           field_simp [hy]
           first
           | linear_combination h'
           | linear_combination -h'
-        · field_simp [hy]
+        · simp only [vadd_eq_add, PiLp.add_apply, PiLp.smul_apply, PiLp.sub_apply,
+            smul_eq_mul]
+          field_simp [hy]
+          try ring
   · -- `P₂ 0 ≠ P₁ 0`: parametrise `P₃` by its `x`-coordinate
     refine ⟨P₂ - P₁, ?_⟩
     intro p hp
     simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hp
-    rcases hp with rfl | rfl | rfl
+    rcases hp with rfl | rfl | hpe
     · exact ⟨0, by simp⟩
     · exact ⟨1, by simp [vadd_eq_add]⟩
-    · refine ⟨(P₃ 0 - P₁ 0) / (P₂ 0 - P₁ 0), ?_⟩
+    · rw [hpe]
+      refine ⟨(P₃ 0 - P₁ 0) / (P₂ 0 - P₁ 0), ?_⟩
       apply PiLp.ext
-      intro i
-      simp only [vadd_eq_add, PiLp.add_apply, PiLp.smul_apply, PiLp.sub_apply,
-        smul_eq_mul]
-      fin_cases i
-      · field_simp [hx]
+      rw [Fin.forall_fin_two]
+      refine ⟨?_, ?_⟩
+      · simp only [vadd_eq_add, PiLp.add_apply, PiLp.smul_apply, PiLp.sub_apply,
+          smul_eq_mul]
+        field_simp [hx]
+        try ring
       · -- the `y`-coordinate needs the vanishing determinant
+        simp only [vadd_eq_add, PiLp.add_apply, PiLp.smul_apply, PiLp.sub_apply,
+          smul_eq_mul]
         field_simp [hx]
         first
         | linear_combination h'
@@ -366,7 +372,9 @@ circumcenter; the common radius `r = ‖P₁ - O‖` is positive because `r = 0`
 would force `P₂ = P₁` and hence a vanishing collinearity determinant. -/
 
 /-- Core Cramer computation, pure coordinates: the explicit circumcenter
-equalises the three squared distances. -/
+equalises the three squared distances. (`maxRecDepth` raised for the
+`field_simp` pass over the explicit quotients.) -/
+set_option maxRecDepth 8192 in
 private lemma circumcenter_spec
     (x₁ y₁ x₂ y₂ x₃ y₃ : ℝ)
     (hd : (x₂ - x₁) * (y₃ - y₁) - (x₃ - x₁) * (y₂ - y₁) ≠ 0) :

--- a/research/problems/product-of-segments-of-chords-oq-03/knowledge.md
+++ b/research/problems/product-of-segments-of-chords-oq-03/knowledge.md
@@ -212,3 +212,49 @@ healthy worktree.
 - **S6**: Replace `converse_product_implies_concyclic_axiom` with a theorem proved from
   S3 + S5 (~10 lines). Update parent meta.json: `axiomCount` 1 → 0,
   `status` axiomatized → verified.
+
+## S18 ACT (researcher-1, 2026-07-24)
+
+Headline iff proven (see state.md banner and the S18 session memo). Portable
+lessons:
+
+1. **The `(hNonCollinear : True)` placeholder was mathematically load-bearing**:
+   with it the (⟹) direction is false (distinct collinear points give Δ = 0,
+   no circle). The S2-era "S3 will pick the right non-degeneracy form" debt
+   had to be paid before the sorry could close. Installed form:
+   `¬ Collinear ℝ ({P₁, P₂, P₃} : Set Vec2)`, bridged to the algebraic
+   `collinearityDet ≠ 0` via `collinear_iff_of_mem` + coordinate-ratio
+   witnesses.
+2. **No `Matrix.cramer` needed — and no `field_simp` on squared quotients.**
+   The S1/S18-note plan (Cramer API on the implicit-circle system) is heavier
+   than explicit quotient circumcenter coordinates. But `field_simp; ring`
+   directly on the squared-distance equality FAILS: the `(x-O₀)²` terms
+   square the quotients and field_simp leaves uncancelled `(...)⁻¹ ^ 2`
+   atoms that `ring` cannot kill (a first attempt also blew
+   `maxRecDepth 512` inside field_simp). Working pattern: a division-free
+   helper `bisector_to_dist` (`linear_combination -hb` — the `O₀²/O₁²` terms
+   cancel, so the identity is *linear* in the center coordinates), plus a
+   deterministic denominator-clearing chain on the linear bisector equations:
+   `rw [← mul_div_assoc, ← mul_div_assoc, div_add_div_same, div_eq_iff h2d];
+   ring`.
+3. **Column-multilinearity beats row reduction for the forced fourth point**:
+   `Δ = e₁M₁ − e₂M₂ + e₃M₃ − e₄M₄` (eᵢ = circle defects, Mᵢ = (x,y,1)-minors,
+   M₄ = collinearityDet) is an *exact* polynomial identity; the S7b simp set
+   (`Matrix.det_succ_row_zero, Fin.sum_univ_succ, Matrix.det_fin_zero,
+   Fin.succAbove`) + `ring` proves it first try, and
+   `linear_combination -hΔ' + M₁*e₁ - M₂*e₂ + M₃*e₃` collapses it to
+   `e₄·M₄ = 0`.
+4. **v4.31 `WithLp` is a structure** (`toLp`/`ofLp`, `CoeFun` via `ofLp`):
+   build points with `WithLp.toLp 2 ![a, b]`; coordinate projections are
+   `rfl`. Point equality via `PiLp.ext`. **Avoid `fin_cases` on coordinate
+   indices** — it produces `⟨0, ⋯⟩`/`⟨1, ⋯⟩` Fin atoms that `ring`/
+   `linear_combination` treat as distinct from the literal `0`/`1` atoms;
+   `rw [Fin.forall_fin_two]` after `apply PiLp.ext` keeps everything literal.
+5. **`rcases hp with rfl | rfl | rfl` on `p ∈ {P₁, P₂, P₃}` has
+   non-deterministic subst orientation** across sibling branches (one branch
+   kept `P₃`, another eliminated it as `p`), producing "Unknown identifier"
+   only in *some* branches. Deterministic fix: bind the last case as
+   `hpe : p = P₃` and `rw [hpe]` in the goal instead of substituting.
+6. `pow_left_inj₀ (norm_nonneg _) hr (two_ne_zero-proof)` is the v4.31 name
+   for squaring-injectivity on nonnegatives (old `pow_left_injective` /
+   `sq_eq_sq'` searches dead-end).

--- a/research/problems/product-of-segments-of-chords-oq-03/sessions/2026-07-24-s18-act-headline-iff-proven.md
+++ b/research/problems/product-of-segments-of-chords-oq-03/sessions/2026-07-24-s18-act-headline-iff-proven.md
@@ -4,7 +4,7 @@
 
 The S17-era single sorry — the headline criterion
 `concyclicityDet_eq_zero_iff_concyclic` — is discharged. The file
-`Proofs/ProductOfSegmentsOfChordsOQ03.lean` grows 265 → 525 LOC and now has
+`Proofs/ProductOfSegmentsOfChordsOQ03.lean` grows 265 → 542 LOC and now has
 **0 sorries, 0 axioms**.
 
 Two things beyond a plain "paste the Cramer proof" were required:
@@ -51,7 +51,9 @@ Two things beyond a plain "paste the Cramer proof" were required:
 
 - Baseline docker build at origin/main HEAD first (v4.31 drift check): GREEN,
   only the expected line-119 sorry warning, 3034 jobs.
-- Post-change docker build: see PR (expected GREEN, 0 warnings).
+- Post-change docker build (after fix rounds 1–3): **GREEN, 3038 jobs, 0
+  warnings** — no sorry/axiom/native_decide anywhere in the file
+  (`docker-build.sh Proofs.ProductOfSegmentsOfChordsOQ03`, 2026-07-24).
 
 ## What the next session owes
 

--- a/research/problems/product-of-segments-of-chords-oq-03/sessions/2026-07-24-s18-act-headline-iff-proven.md
+++ b/research/problems/product-of-segments-of-chords-oq-03/sessions/2026-07-24-s18-act-headline-iff-proven.md
@@ -1,0 +1,72 @@
+# S18 ACT (researcher-1, 2026-07-24): headline iff PROVEN — file 0 sorries, 0 axioms
+
+## What happened
+
+The S17-era single sorry — the headline criterion
+`concyclicityDet_eq_zero_iff_concyclic` — is discharged. The file
+`Proofs/ProductOfSegmentsOfChordsOQ03.lean` grows 265 → 525 LOC and now has
+**0 sorries, 0 axioms**.
+
+Two things beyond a plain "paste the Cramer proof" were required:
+
+1. **The statement itself had to change.** The S2 stub carried
+   `(hNonCollinear : True)` as a placeholder. With that placeholder the (⟹)
+   direction is *false*: four distinct collinear points have Δ = 0 (the
+   `(x, y, 1)` columns are already dependent) but lie on no common circle of
+   positive radius. S18 installs the genuine hypothesis
+   `¬ Collinear ℝ ({P₁, P₂, P₃} : Set Vec2)` — the affine-geometry notion, not
+   a bare determinant inequality — and proves the bridge to the algebraic form.
+2. **The declaration moved to the end of the file** (new Part 12) because its
+   proof consumes Parts 5–11; Part 4 now holds a pointer note. Any tooling
+   anchored to line 119 should re-anchor.
+
+## New material (Parts 9–12)
+
+- Part 9 — `collinearityDetCoords` / `collinearityDet` (= 2·signed triangle
+  area, also the bottom cofactor M₄ of the concyclicity matrix) and
+  `collinear_of_collinearityDet_eq_zero`: vanishing determinant ⟹
+  `Collinear ℝ`, via `collinear_iff_of_mem` with direction `P₂ - P₁`
+  (or `P₃ - P₁` in the degenerate `P₂ = P₁` case); the scalar for `P₃` is the
+  coordinate ratio, with `field_simp` + `linear_combination h` supplying the
+  determinant-driven second coordinate. Contrapositive wrapper
+  `collinearityDet_ne_zero_of_not_collinear`.
+- Part 10 — `circumcenter_spec` (private, pure coordinates): explicit Cramer
+  solution of the two perpendicular-bisector equations; both equal-radius
+  facts close by `field_simp [hd]; ring`. `exists_circumcircle` lifts it to
+  `Vec2` (center built with `WithLp.toLp 2 ![O₀, O₁]`; coordinate projections
+  are `rfl`), converts squared-distance equalities to norm equalities via
+  `pow_left_inj₀`, and gets `0 < r` because `r = 0` would force `P₂ = P₁`
+  and hence a vanishing collinearity determinant.
+- Part 11 — `concyclicityDetCoords_circle_decomp`: the exact polynomial
+  identity `Δ = e₁M₁ - e₂M₂ + e₃M₃ - e₄M₄` (eᵢ = circle defect of Pᵢ, Mᵢ =
+  3×3 minor of the (x,y,1) columns omitting row i; M₄ = collinearityDet).
+  Proof: the S7b det-expansion simp set + `ring`; hand-verified numerically
+  on two (O, r) instances before shipping. `fourth_point_on_circle` then
+  collapses the identity to `e₄ · M₄ = 0` by `linear_combination` with the
+  three explicit minor coefficients and forces `e₄ = 0`.
+- Part 12 — the assembled iff; (⟸) is the S17-era
+  `concyclic_implies_concyclicityDet_zero`, unchanged.
+
+## Verification
+
+- Baseline docker build at origin/main HEAD first (v4.31 drift check): GREEN,
+  only the expected line-119 sorry warning, 3034 jobs.
+- Post-change docker build: see PR (expected GREEN, 0 warnings).
+
+## What the next session owes
+
+The S1 decomposition's remaining steps, unchanged in scope:
+
+- **S5 bridge**: signed chord-product hypothesis ⟹ Δ = 0, using
+  `signed_inner_product_to_scalar_coord` + `coord_of_smul_diff` (Parts 6-7,
+  already merged) + the S12-§3.2 closed-form witness.
+- **S6 parent integration**: replace
+  `converse_product_implies_concyclic_axiom` in
+  `Proofs/ProductOfSegmentsOfChords.lean` (line ~468) by a theorem derived
+  from Part 12 + the S5 bridge, then parent gallery meta
+  axiomatized → verified. Note the parent axiom's hypothesis must be the
+  *signed* product (S9 PREP counterexample kills the unsigned form) and a
+  non-collinearity side condition now provably enters.
+
+No gallery entry exists for oq-03 itself (never created; integration is the
+parent's, at S6).

--- a/research/problems/product-of-segments-of-chords-oq-03/state.md
+++ b/research/problems/product-of-segments-of-chords-oq-03/state.md
@@ -1,6 +1,38 @@
 # Research State: product-of-segments-of-chords-oq-03
 
-## Current State
+> **S18 ACT (2026-07-24, researcher-1): HEADLINE IFF PROVEN — file now
+> 0 sorries / 0 axioms, 265 → 525 LOC.**
+> `concyclicityDet_eq_zero_iff_concyclic` is fully proven; the S2 placeholder
+> `(hNonCollinear : True)` is REPLACED by the genuine hypothesis
+> `¬ Collinear ℝ ({P₁, P₂, P₃} : Set Vec2)` (with the placeholder the (⟹)
+> direction is false — distinct collinear points have Δ = 0 with no circle),
+> and the declaration MOVED from Part 4 (old line 119) to a new Part 12 at
+> end of file (its proof consumes Parts 5–11). New material: Part 9
+> `collinearityDet` + bridge `collinear_of_collinearityDet_eq_zero`
+> (`collinear_iff_of_mem`, coordinate-ratio scalars, `Fin.forall_fin_two`
+> instead of `fin_cases` to keep ring atoms literal); Part 10 explicit Cramer
+> circumcenter (`circumcenter_spec` pure-coords via the
+> division-free `bisector_to_dist` + deterministic denominator clearing —
+> field_simp on the squared quotients fails, see knowledge.md item 2;
+> `exists_circumcircle` on `Vec2` with center
+> `WithLp.toLp 2 ![O₀, O₁]`, `0 < r` from non-collinearity); Part 11 exact
+> cofactor decomposition `Δ = e₁M₁ − e₂M₂ + e₃M₃ − e₄M₄`
+> (`concyclicityDetCoords_circle_decomp`, S7b simp set + `ring`, passed
+> first try) and `fourth_point_on_circle` (`linear_combination` with the
+> three explicit minor coefficients ⇒ `e₄·M₄ = 0`). The old plan's
+> `Matrix.cramer`-API route was NOT needed — explicit quotient formulas
+> are shorter. Baseline v4.31 docker check at HEAD was GREEN
+> before edits (only the expected L119 sorry warning).
+> **Next: S5-bridge session** (signed chord-product ⟹ Δ = 0, consuming the
+> merged Parts 6–7 helpers + S12-§3.2 closed-form witness), then **S6 parent
+> integration** (replace `converse_product_implies_concyclic_axiom` in the
+> parent, gallery axiomatized → verified — the parent axiom's hypothesis
+> must become the *signed* product per the S9 counterexample, plus a
+> non-collinearity side condition). Pool status blocked → in-progress
+> (Docker healthy again). See
+> `sessions/2026-07-24-s18-act-headline-iff-proven.md`.
+
+## Current State (pre-S18, retained for ledger)
 
 **Phase**: BLOCKED (S18, verification blackout 2026-06-13) — no build-free
 work remains. S17 STATE-SYNC (#23000) already brought the registry current;

--- a/research/problems/product-of-segments-of-chords-oq-03/state.md
+++ b/research/problems/product-of-segments-of-chords-oq-03/state.md
@@ -1,7 +1,8 @@
 # Research State: product-of-segments-of-chords-oq-03
 
 > **S18 ACT (2026-07-24, researcher-1): HEADLINE IFF PROVEN — file now
-> 0 sorries / 0 axioms, 265 → 525 LOC.**
+> 0 sorries / 0 axioms, 265 → 542 LOC, post-change docker build GREEN
+> (3038 jobs, 0 warnings, 2026-07-24).**
 > `concyclicityDet_eq_zero_iff_concyclic` is fully proven; the S2 placeholder
 > `(hNonCollinear : True)` is REPLACED by the genuine hypothesis
 > `¬ Collinear ℝ ({P₁, P₂, P₃} : Set Vec2)` (with the placeholder the (⟹)

--- a/src/data/research/problems/product-of-segments-of-chords-oq-03.json
+++ b/src/data/research/problems/product-of-segments-of-chords-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "product-of-segments-of-chords-oq-03",
   "title": "Power-of-a-point ↔ four-point concyclicity determinant",
-  "phase": "BLOCKED",
-  "status": "blocked",
+  "phase": "ACT",
+  "status": "active",
   "tier": "B",
   "path": "full",
   "significance": 6,
@@ -32,26 +32,28 @@
     "goal": "Build companion file Proofs/ProductOfSegmentsOfChordsOQ03.lean (~210 lines, 4 main theorems + 1 def) that discharges the parent axiom. After all sorries close: parent axiomCount 1 → 0, parent moves toward status verified."
   },
   "currentState": {
-    "phase": "BLOCKED",
-    "since": "2026-06-13T00:00:00.000Z",
+    "phase": "ACT",
+    "since": "2026-07-24T00:00:00.000Z",
     "iteration": 18,
-    "focus": "S18 BLOCKED (verification blackout, researcher-1, 2026-06-13): no build-free work remains. S17 STATE-SYNC (#23000) already brought the registry current — file is 265 LOC, 1 genuine sorry (line 125, the (⟹) Cramer direction of the headline iff), 0 axioms on origin/main; the (⟸) half is proven unconditionally as concyclic_implies_concyclicityDet_zero. The single open sorry is build-dependent ACT (Cramer paste, ~80 LOC) and both verification routes are down this session: docker info reports the daemon down and the Aristotle MCP backend returns 'Resource not found' (404). Flagged blocked (status active→blocked) to stop claim churn during the blackout rather than re-surveying or writing another PREP memo.",
-    "blockers": [
-      "Verification blackout 2026-06-13: Docker daemon down + Aristotle MCP backend 404 — the only open work (the (⟹) Cramer direction, sorry @ ProductOfSegmentsOfChordsOQ03.lean:125) is build-dependent ACT and cannot be verified."
-    ],
-    "nextAction": "S18 ACT (when Docker recovers): (a) wire the proven concyclic_implies_concyclicityDet_zero into the (⟸) branch of concyclicityDet_eq_zero_iff_concyclic, leaving only the (⟹) sorry; (b) replace the (hNonCollinear : True) placeholder with the algebraic 2×2 non-collinearity (S3 PREP Choice 1b); (c) discharge (⟹) via Matrix.cramer on the implicit-circle system (S3 ACT, ~80 LOC). Build: ./proofs/scripts/docker-build.sh Proofs.ProductOfSegmentsOfChordsOQ03.",
+    "focus": "S18 ACT (researcher-1, 2026-07-24): HEADLINE IFF PROVEN. concyclicityDet_eq_zero_iff_concyclic fully discharged — file 542 LOC, 0 sorries, 0 axioms, docker build GREEN (3038 jobs, 0 warnings). The S2 placeholder (hNonCollinear : True) was replaced by the genuine hypothesis ¬ Collinear ℝ {P₁, P₂, P₃} (with the placeholder the (⟹) direction is FALSE: distinct collinear points give Δ = 0 with no circle); bridge collinear_of_collinearityDet_eq_zero proves ¬Collinear ⟹ collinearityDet ≠ 0. (⟹) via explicit Cramer circumcenter (circumcenter_spec + exists_circumcircle) + exact cofactor decomposition Δ = e₁M₁ − e₂M₂ + e₃M₃ − e₄M₄ (concyclicityDetCoords_circle_decomp) forcing e₄ = 0 (fourth_point_on_circle). Declaration moved to Part 12 (end of file).",
+    "blockers": [],
+    "nextAction": "S19 (= old S5 bridge): signed chord-product hypothesis ⟹ Δ = 0, consuming Parts 6–7 helpers (signed_inner_product_to_scalar_coord, coord_of_smul_diff) + S12-§3.2 closed-form witness. Then S20 (= old S6): replace converse_product_implies_concyclic_axiom in parent Proofs/ProductOfSegmentsOfChords.lean (hypothesis must become the SIGNED product per the S9 counterexample, plus a non-collinearity side condition) and move parent gallery meta axiomatized → verified.",
     "attemptCounts": {
-      "total": 17,
-      "currentApproach": 17,
-      "approachesTried": 17
+      "total": 18,
+      "currentApproach": 18,
+      "approachesTried": 18
     }
   },
   "knowledge": {
-    "progressSummary": "S17 STATE-SYNC (researcher-2, 2026-06-13, build-free): registry catch-up after S7b ACT (#22967) and easy-direction ACT (#22917) merged without updating state.md/JSON. File is now 265 LOC, 1 sorry, 0 axioms on origin/main. The (⟸) direction is PROVEN unconditionally as standalone theorem concyclic_implies_concyclicityDet_zero (kernel vector (1,-2O₀,-2O₁,O₀²+O₁²-r²) + Matrix.exists_mulVec_eq_zero_iff); only the (⟹) Cramer direction of the headline iff remains open. Also corrected a genuine math error: the S1 numerical-sanity figure Δ=-8 (off-circle point (0,-2)) is wrong — the correct value is Δ=-6, hand-verified (row-reduce + col-4 cofactor → minor 6, sign -1) and machine-checked by the merged concyclicityDetCoords_off_circle lemma. Docker daemon is down 2026-06-13 so no Lean edit this iteration. Earlier ACT lemmas in place: norm_sub_sq_coord, signed_inner_product_to_scalar(_coord) (S15), coord_of_smul_diff (S16). Bearer notes retained: real_inner_self_eq_norm_sq at :871; ⟪x,y⟫_ℝ fails in binder position (use scoped ⟪x,y⟫).",
+    "progressSummary": "S18 ACT (researcher-1, 2026-07-24): headline iff concyclicityDet_eq_zero_iff_concyclic PROVEN — file 542 LOC, 0 sorries, 0 axioms, docker GREEN. Genuine non-collinearity hypothesis (¬ Collinear ℝ) installed in place of the True placeholder (which made (⟹) false). Remaining scope: S19 signed chord-product → Δ = 0 bridge, S20 parent-axiom discharge (signed restatement) + gallery meta flip.",
     "builtItems": [
       "norm_sub_sq_coord (ProductOfSegmentsOfChordsOQ03.lean:117-120) — coord-form norm-squared for Vec2: ‖X-Y‖² = (X 0 - Y 0)² + (X 1 - Y 1)² (S15 ACT)",
       "signed_inner_product_to_scalar (ProductOfSegmentsOfChordsOQ03.lean:155-166) — abstract scalar bridge under chord-collinearity (S15 ACT)",
-      "signed_inner_product_to_scalar_coord (ProductOfSegmentsOfChordsOQ03.lean:171-183) — coordinate form of the above (S15 ACT)"
+      "signed_inner_product_to_scalar_coord (ProductOfSegmentsOfChordsOQ03.lean:171-183) — coordinate form of the above (S15 ACT)",
+      "collinearityDet / collinearityDetCoords + collinear_of_collinearityDet_eq_zero + collinearityDet_ne_zero_of_not_collinear (ProductOfSegmentsOfChordsOQ03.lean Part 9, S18)",
+      "bisector_to_dist + circumcenter_spec (explicit Cramer circumcenter, private) + exists_circumcircle (Part 10, S18)",
+      "concyclicityDetCoords_circle_decomp (exact cofactor decomposition Δ = e₁M₁ − e₂M₂ + e₃M₃ − e₄M₄) + fourth_point_on_circle (Part 11, S18)",
+      "concyclicityDet_eq_zero_iff_concyclic PROVEN with ¬ Collinear ℝ hypothesis (Part 12, S18)"
     ],
     "insights": [
       "The implicit-circle equation x^2 + y^2 + Dx + Ey + F = 0 gives an immediate translation between power-of-a-point and concyclicity: power(P) = x_P^2 + y_P^2 + D x_P + E y_P + F evaluated against any circle through three reference points.",
@@ -61,7 +63,10 @@
       "Mathlib has Affine.Simplex.circumcenter / circumradius which could in principle short-circuit the (⇐) direction, but using it requires bridging the parent's Vec2 = Fin 2 → ℝ convention with EuclideanSpace ℝ (Fin 2). The direct Cramer's rule proof is cleaner and stays inside the parent's existing convention.",
       "Parent gallery openQuestion #3 (conclusion.openQuestions[2]) is exactly this problem: 'How does the power of a point relate to the determinant criterion for concyclicity?' OQ-03 is the natural follow-up to ship the parent toward verified status.",
       "S14 PREP bearer drift: real_inner_self_eq_norm_sq is at Basic.lean:871 (not :384); EuclideanSpace.norm_sq_eq does NOT exist (closest is EuclideanSpace.norm_eq at PiL2.lean:107)",
-      "S15 gotcha: notation3:max form ⟪x, y⟫_ℝ FAILS in binder position (unexpected identifier; expected ´)´). Use scoped RealInnerProductSpace notation ⟪x, y⟫ instead — scoped notation parses cleanly in binders"
+      "S15 gotcha: notation3:max form ⟪x, y⟫_ℝ FAILS in binder position (unexpected identifier; expected ´)´). Use scoped RealInnerProductSpace notation ⟪x, y⟫ instead — scoped notation parses cleanly in binders",
+      "S18: the True-placeholder form of the iff is mathematically FALSE in the (⟹) direction — four distinct collinear points have Δ = 0 (the (x,y,1) columns are dependent) but no circumscribing circle of positive radius. The genuine hypothesis is ¬ Collinear ℝ {P₁,P₂,P₃}.",
+      "S18: explicit quotient formulas for the circumcenter beat the Matrix.cramer API route — the two perpendicular-bisector equations are linear in (O₀,O₁), so bisector_to_dist keeps everything division-free until a single deterministic div_eq_iff clearing.",
+      "S18 v4.31 gotchas: div_add_div_same is absent (use ← add_div); field_simp on squared quotients loops (clear denominators first via mul_div_assoc/add_div/div_eq_iff chain); Fin.forall_fin_two beats fin_cases for keeping ring atoms literal; WithLp.toLp 2 ![a,b] gives rfl coordinate projections on EuclideanSpace ℝ (Fin 2)."
     ],
     "mathlibGaps": [
       "No specialised concyclicity-determinant lemma in Mathlib v4.26.0. Matrix.det_fin_four handles the expansion but there is no `Matrix.concyclicityDet_eq_zero_iff` or equivalent. Candidate for upstream contribution.",
@@ -69,11 +74,8 @@
       "No bridge between power-of-a-point and the implicit-circle equation. The identity ‖P − A‖ · ‖P − B‖ = |D · x_P + E · y_P + F + x_P^2 + y_P^2| is implicit in chord_product_algebraic but not named in either parent or Mathlib."
     ],
     "nextSteps": [
-      "S5 ACT × Option A × Path α (recommended next, S10 §4.1 skeleton): paste concyclicityDet_eq_zero_of_signed_chord_product. Signed inner-product hypothesis ⟪A-P, B-P⟫_ℝ = ⟪C-P, D-P⟫_ℝ collapses S5 PREP §4.3's case (a)/(b) split to single scalar equation t·‖A-P‖² = s·‖C-P‖² (via inner_smul_right + real_inner_self_eq_norm_sq at Basic.lean:384); close concyclicityDet = 0 via det_succ_row_zero + det_fin_three cofactor expansion + S5 PREP §4.3 case (a) algebra witness for linear_combination. ~25-35 LOC.",
-      "S4 ACT × Patched Path A (S8 §5.2, orthogonal to S5 per S10 §4.3): close (⇒) direction concyclic → Δ = 0 via column-update (det_updateCol_add_smul_self ×3 to zero out three columns) + det_eq_zero_of_column_eq_zero. ~35-40 LOC.",
-      "S3 ACT × Cramer with S8 §4 bearer corrections (orthogonal to S5 per S10 §4.4): replace (hNonCollinear : True) placeholder with 2×2 algebraic det non-collinearity (Choice 1b); discharge (⇐) Δ = 0 ∧ non-collinear(P_1, P_2, P_3) → ∃ O r > 0, ‖P_i − O‖ = r via Matrix.cramer (cramer_apply is rfl at pin) on the implicit-circle 3x3 system for (D, E, F), then translate to (O, r) = (-D/2, -E/2, √(D²/4 + E²/4 − F)). ~80-90 LOC.",
-      "S6 ACT — 4-step parent axiom discharge (S10 §5; requires S3+S4+S5 ACT first): 6a restate parent axiom under Option A signature (Proofs/ProductOfSegmentsOfChords.lean:468 + line 481 caller); 6b update one downstream caller (only line 481 known); 6c chain S3+S4+S5 ACT and discharge restated axiom (~10 LOC assembly); 6d update parent gallery src/data/proofs/product-of-segments-of-chords/meta.json: axiomCount 1→0, status toward verified. ~25-40 LOC total.",
-      "S7b ACT (optional, non-blocking): re-add unit-square Δ=0 + perturbed Δ=-8 numerical sanity checks (removed by S7 ACT BUILD-VERIFY because Matrix.det_fin_four does not exist in Mathlib4) via Matrix.det_succ_row_zero / Matrix.det_fin_three cascade or Matrix.det_eq_zero_of_row_eq row-dependence proof (rows 1+3 = rows 2+4 for the unit square). ~15 LOC."
+      "S19 bridge: signed chord-product hypothesis ⟪A−P,B−P⟫ = ⟪C−P,D−P⟫ with chord-collinearity ⟹ concyclicityDet A B C D = 0, via signed_inner_product_to_scalar_coord + coord_of_smul_diff + the S12-§3.2 closed-form linear_combination witness.",
+      "S20 parent integration: restate converse_product_implies_concyclic_axiom in Proofs/ProductOfSegmentsOfChords.lean under the signed hypothesis + non-collinearity side condition, discharge it from concyclicityDet_eq_zero_iff_concyclic + S19 bridge, update parent gallery meta axiomCount 1 → 0 (axiomatized → verified)."
     ]
   },
   "relatedGalleryProofs": [


### PR DESCRIPTION
## Summary
S18 ACT for `product-of-segments-of-chords-oq-03`: the headline concyclicity
criterion `concyclicityDet_eq_zero_iff_concyclic` is fully proven. The file
`proofs/Proofs/ProductOfSegmentsOfChordsOQ03.lean` (265 -> 542 LOC) now has
**0 sorries, 0 axioms** — its only remaining sorry (the (=>) Cramer
direction, open since S2) is discharged.

## Progress
- **Statement fixed, then proven.** The S2 stub hypothesis
  `(hNonCollinear : True)` made the (=>) direction false (distinct collinear
  points have determinant 0 but no circumscribing circle). S18 installs the
  genuine hypothesis `¬ Collinear ℝ ({P₁, P₂, P₃} : Set Vec2)` and proves the
  bridge `collinear_of_collinearityDet_eq_zero` (vanishing 2x2 determinant =>
  affine collinearity), so the hypothesis is the honest geometric one, not a
  bare algebraic inequality.
- **Part 10**: explicit Cramer circumcenter (`circumcenter_spec`,
  `exists_circumcircle`) — perpendicular-bisector system solved by explicit
  quotient formulas; radius positivity from non-collinearity.
- **Part 11**: exact cofactor decomposition
  `Δ = e₁M₁ − e₂M₂ + e₃M₃ − e₄M₄` (`concyclicityDetCoords_circle_decomp`,
  pure polynomial identity) and `fourth_point_on_circle` forcing the fourth
  point onto the circumcircle when `Δ = 0`.
- **Part 12**: assembled iff; (<=) is the previously merged
  `concyclic_implies_concyclicityDet_zero`, unchanged.
- Registry synced: tracker JSON BLOCKED -> ACT (Docker blackout over),
  state.md + session note `2026-07-24-s18-act-headline-iff-proven.md`.

## Verification
`./proofs/scripts/docker-build.sh Proofs.ProductOfSegmentsOfChordsOQ03`
GREEN on Lean v4.31: 3038 jobs, 0 warnings. File contains no sorry, no axiom,
no native_decide.

## Findings
- v4.31: `div_add_div_same` absent (use `← add_div`); `field_simp` loops on
  squared quotients — clear denominators deterministically via
  `mul_div_assoc`/`add_div`/`div_eq_iff`; `Fin.forall_fin_two` beats
  `fin_cases` for keeping `ring` atoms literal; `WithLp.toLp 2 ![a, b]` gives
  `rfl` coordinate projections on `EuclideanSpace ℝ (Fin 2)`.
- Explicit quotient circumcenter formulas beat the `Matrix.cramer` API route.

## Status
**Outcome**: progress (headline theorem of the OQ proven; problem stays
active)
**Next Steps**: S19 signed chord-product => Δ = 0 bridge (Parts 6-7 helpers
already merged), then S20 discharge of the parent's
`converse_product_implies_concyclic_axiom` under the signed restatement and
parent gallery meta axiomatized -> verified.

🤖 Generated by researcher-1
