### PR TITLE
Enrich picks-theorem-oq-04-oq-02: add 5th keyInsight

### DIFF
--- a/src/data/proofs/picks-theorem-oq-04-oq-02/meta.json
+++ b/src/data/proofs/picks-theorem-oq-04-oq-02/meta.json
@@ -56,7 +56,8 @@
       "The distinguished basepoint of shoelace (its head serves as both start and loop-close) is exactly what couples reversal and rotation; factoring through the basepoint-agnostic edgeSum decouples them.",
       "Orientation reversal is, at bottom, the single algebraic fact cross a b = -cross b a lifted along a structural induction.",
       "Cyclic rotation invariance is not an analytic statement but a re-association: the reversed/rotated loop sums the same edges in a different order.",
-      "Reversing the whole polygon changes the basepoint, so the reversal law genuinely needs rotation invariance as a lemma — the two symmetries are proved together, not independently."
+      "Reversing the whole polygon changes the basepoint, so the reversal law genuinely needs rotation invariance as a lemma — the two symmetries are proved together, not independently.",
+      "shoelace_rotl_iterate lifts single-step invariance to the full ⟨rotl⟩ orbit via Function.iterate_succ_apply, so the sum is shown constant not just under one generator but under the entire cyclic group of rotations — formally exhibiting the vertex list as a necklace (a cyclic sequence up to relabelling of the start) rather than a linear list with a privileged first entry."
     ],
     "prerequisites": [
       "PicksTheoremOQ04 (the general shoelace sum and its cross/shoelace primitives)",


### PR DESCRIPTION
Enrichment pass for `picks-theorem-oq-04-oq-02` (orientation and cyclic-rotation symmetry of the shoelace sum).

The entry had 4 `keyInsights`. Added a genuine 5th: `shoelace_rotl_iterate` lifts the single-step rotation invariance to the full `⟨rotl⟩` orbit via `Function.iterate_succ_apply`, which formally exhibits the vertex list as a necklace (cyclic sequence up to relabelling of the start) rather than a linear list with a privileged first entry — distinct from the existing insights about the basepoint/edgeSum decoupling, the antisymmetry driving reversal, and the coupling between reversal and rotation.

No other content changed; `meta.json` stays well under the 60 KB size cap (~14.5 KB).