### PR TITLE
Research: motivic-flag-maps-oq-03 - S3: universal augmentation witness closes vacuity gap (+0 axioms)

### DIFF
--- a/proofs/Proofs/MotivicFlagMapsOQ03.lean
+++ b/proofs/Proofs/MotivicFlagMapsOQ03.lean
@@ -154,4 +154,100 @@ theorem motivicClassBasedMaps_eq_zero_of_lefschetz_eq_one
 
 end MotivicMeasure
 
+/-!
+## S3: Universal witnesses — the hypothesis class is nonempty (axiom-free)
+
+Every theorem above is conditional on a `MotivicMeasure K R`, and the
+headline additionally assumes `μ.lefschetz = 1`. Since concrete
+realizations (Euler characteristic, `F_q` point counts) are deferred by
+design (+2 axioms each), **no instance of `MotivicMeasure` existed
+anywhere in this development** — leaving the adversarial gap that the
+headline vanishing theorem could be vacuously true.
+
+This section closes that gap with **+0 axioms** via the canonical
+universal witness: for any `c : K.carrier`, the quotient map
+
+  `K.carrier →+* K.carrier ⧸ span {K.L − c}`
+
+is a motivic measure sending `L` to the image of `c`. At `c = 1` this is
+the *universal Euler-characteristic realization* — the augmentation
+quotient through which every `lefschetz = 1` measure factors (proved
+below as `factorThroughAugmentation`) — and it discharges the headline
+hypothesis unconditionally (`universal_euler_vanishing`).
+
+Degenerate models are permitted: for a `K` in which `K.L − 1` is a unit
+the quotient is the zero ring and the vanishing is trivial. That is
+unavoidable at this level of abstraction — `GrothendieckRingVar` is an
+abstract interface — and harmless: for the *true* `K₀(Var_k)` the
+augmentation quotient is the universal Euler-characteristic target, and
+every concrete `lefschetz = 1` realization factors through it, so the
+factorization theorem transfers the vanishing to every such realization.
+-/
+
+namespace MotivicMeasure
+
+variable (K : GrothendieckRingVar k)
+
+/-- **S3-A. The augmentation measure at `c`.** The quotient map
+`K.carrier →+* K.carrier ⧸ span {K.L − c}` packaged as a `MotivicMeasure`
+with `lefschetz` = image of `c`. This is the universal measure sending
+`L ↦ c`, and the first `MotivicMeasure` instance constructed in this
+development — axiom-free, for every model `K` and every `c`. -/
+def augmentation (c : K.carrier) :
+    MotivicMeasure K (K.carrier ⧸ Ideal.span {K.L - c}) where
+  toRingHom := Ideal.Quotient.mk (Ideal.span {K.L - c})
+  lefschetz := Ideal.Quotient.mk (Ideal.span {K.L - c}) c
+  lefschetz_eq := Ideal.Quotient.eq.mpr (Ideal.mem_span_singleton_self _)
+
+/-- At `c = 1` the augmentation measure satisfies the headline hypothesis
+`lefschetz = 1` on the nose. -/
+@[simp]
+lemma augmentation_one_lefschetz :
+    (augmentation K 1).lefschetz = 1 :=
+  map_one (Ideal.Quotient.mk (Ideal.span {K.L - 1}))
+
+/-- **S3-B. Nonvacuity of the headline.** For every model `K` there is a
+motivic measure with `lefschetz = 1`, so the hypothesis of
+`motivicClassBasedMaps_eq_zero_of_lefschetz_eq_one` is satisfiable. -/
+theorem nonempty_lefschetz_one :
+    ∃ μ : MotivicMeasure K (K.carrier ⧸ Ideal.span {K.L - 1}),
+      μ.lefschetz = 1 :=
+  ⟨augmentation K 1, augmentation_one_lefschetz K⟩
+
+variable {R : Type*} [CommRing R]
+
+/-- **S3-C. Universal property of the augmentation quotient.** Every
+motivic measure with `lefschetz = 1` factors through the `c = 1`
+augmentation quotient: the induced ring hom on `K.carrier ⧸ (L − 1)`. -/
+def factorThroughAugmentation (μ : MotivicMeasure K R)
+    (hL : μ.lefschetz = 1) :
+    (K.carrier ⧸ Ideal.span {K.L - 1}) →+* R :=
+  Ideal.Quotient.lift _ μ.toRingHom fun a ha =>
+    μ.annihilate_of_lefschetz_eq_one hL (Ideal.mem_span_singleton.mp ha)
+
+/-- The factorization identity: `factorThroughAugmentation μ hL ∘ mk = μ`.
+So the augmentation measure is initial among `lefschetz = 1` measures. -/
+@[simp]
+lemma factorThroughAugmentation_mk (μ : MotivicMeasure K R)
+    (hL : μ.lefschetz = 1) (x : K.carrier) :
+    factorThroughAugmentation K μ hL
+      ((augmentation K 1).toRingHom x) = μ.toRingHom x :=
+  rfl
+
+/-- **S3-D. Unconditional universal Euler-characteristic vanishing.**
+The class of `Ω²_β(Fl_{n+1})` vanishes in the augmentation quotient
+`K₀(Var)/(L − 1)` for all `n ≥ 1` — no realization hypothesis at all.
+This upgrades the headline from a conditional statement (for every
+measure with `lefschetz = 1` …) to a concrete identity in a concrete
+ring; the conditional version is recovered by applying
+`factorThroughAugmentation`. -/
+theorem universal_euler_vanishing (n : ℕ) (hn : n ≥ 1)
+    (β : HomologyClass n) (hβ : β.positive) :
+    Ideal.Quotient.mk (Ideal.span {K.L - 1})
+      (motivicClassBasedMaps K n β) = 0 :=
+  motivicClassBasedMaps_eq_zero_of_lefschetz_eq_one (augmentation K 1)
+    (augmentation_one_lefschetz K) n hn β hβ
+
+end MotivicMeasure
+
 end MotivicFlagMaps

--- a/proofs/Proofs/MotivicFlagMapsOQ03.lean
+++ b/proofs/Proofs/MotivicFlagMapsOQ03.lean
@@ -222,7 +222,7 @@ augmentation quotient: the induced ring hom on `K.carrier ⧸ (L − 1)`. -/
 def factorThroughAugmentation (μ : MotivicMeasure K R)
     (hL : μ.lefschetz = 1) :
     (K.carrier ⧸ Ideal.span {K.L - 1}) →+* R :=
-  Ideal.Quotient.lift _ μ.toRingHom fun a ha =>
+  Ideal.Quotient.lift _ μ.toRingHom fun _ ha =>
     μ.annihilate_of_lefschetz_eq_one hL (Ideal.mem_span_singleton.mp ha)
 
 /-- The factorization identity: `factorThroughAugmentation μ hL ∘ mk = μ`.

--- a/research/problems/motivic-flag-maps-oq-03/knowledge.md
+++ b/research/problems/motivic-flag-maps-oq-03/knowledge.md
@@ -19,3 +19,27 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+## Session 2026-07-24 (researcher-1) — S3 universal witness
+
+**Route (by mechanism): augmentation-quotient witness / initial-object factorization.**
+
+- Gap: S2's headline `motivicClassBasedMaps_eq_zero_of_lefschetz_eq_one` quantifies
+  over `MotivicMeasure K R` with `lefschetz = 1`, but no instance of `MotivicMeasure`
+  existed in the development (concrete realizations deferred at +2 axioms each) —
+  vacuity risk.
+- Fix (+0 axioms): `augmentation K c : MotivicMeasure K (K.carrier ⧸ span {K.L - c})`
+  via `Ideal.Quotient.mk`; `lefschetz_eq` is `Ideal.Quotient.eq.mpr (mem_span_singleton_self _)`.
+- `c = 1` discharges the headline hypothesis on the nose (`map_one`), giving the
+  unconditional `universal_euler_vanishing` in `K/(L-1)`.
+- Initiality: `factorThroughAugmentation` (`Ideal.Quotient.lift` +
+  `annihilate_of_lefschetz_eq_one` + `mem_span_singleton`) shows every
+  `lefschetz = 1` measure factors through the quotient, so vanishing transfers to
+  every concrete Euler-like realization.
+- Caveat recorded in the file: for degenerate abstract `K` where `L - 1` is a unit
+  the quotient is the zero ring; unavoidable at interface level, harmless for the
+  true `K₀(Var_k)`.
+
+**Dead ends**: universe-polymorphic existential `∃ (R : Type*) (_ : CommRing R), …`
+avoided (instance binders in `∃` don't participate in TC resolution); stated
+nonvacuity concretely over the quotient ring instead (`nonempty_lefschetz_one`).

--- a/src/data/research/problems/motivic-flag-maps-oq-03.json
+++ b/src/data/research/problems/motivic-flag-maps-oq-03.json
@@ -43,12 +43,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED (axiom-free core, researcher-3, 2026-07-23, v4.31 VERIFIED). The MotivicMeasure realization framework (structure + 4 theorems, 0 sorries, 0 local axioms) is complete and now Docker-verified at v4.31.0 (8577 jobs). It answers OQ-03 — an open-ended question about cohomology consequences of the BEMSV motivic identity — with a concrete result: any realization μ with μ(L)=1 annihilates motivicClassBasedMaps, i.e. χ(Ω²_β(Fl_{n+1}))=0 for n≥1. The slug was blocked only on the 2026-06-13 Docker blackout (now resolved). The 2 parent axioms are essential (opaque Grothendieck-ring element + the deep BEMSV identity) and not eliminable. The remaining designed steps (S2-A2 Euler, S2-B F_q) each add +2 axioms for realization existence/L-image encoding deep theorems absent from Mathlib, so they are optional concrete instantiations deferred by design under the axiom-integrity policy.",
+    "progressSummary": "COMPLETED+ (S3 nonvacuity witness, researcher-1, 2026-07-24). Framework core (S2) plus S3 universal witnesses: the augmentation quotient K/(L-c) yields the first concrete MotivicMeasure instance (axiom-free, every K, every c); at c=1 it discharges the headline hypothesis unconditionally (universal_euler_vanishing) and is initial among lefschetz=1 measures (factorThroughAugmentation). Vacuity concern on the S2 headline is closed. 2 parent axioms remain essential; realization instances (Euler via Bittner, F_q point count) still deferred by design (+2 axioms each).",
     "builtItems": [
       "Session doc sessions/2026-05-12-s1-observe-cohomology-roadmap.md (~250 lines) with full landscape + 3 S2 scopes",
       "problem.md restating OQ-03 with mathematical substance and race-safety record",
       "state.md tracking OBSERVE -> ORIENT phase transition",
-      "knowledge.md with five core insights on the realization-functor framework"
+      "knowledge.md with five core insights on the realization-functor framework",
+      "S3 in MotivicFlagMapsOQ03.lean: augmentation, augmentation_one_lefschetz, nonempty_lefschetz_one, factorThroughAugmentation, factorThroughAugmentation_mk, universal_euler_vanishing (+96 lines, 0 axioms, 0 sorries)"
     ],
     "insights": [
       "Identity-of-realization framework: each topological invariant is a ring hom mu : K_0(Var) -> R with mu(L) = c; motivic identity propagates verbatim through each.",
@@ -58,7 +59,9 @@
       "Sibling OQ-01 (axiom elimination) and OQ-02 (partial-flag extension) are orthogonal to OQ-03 (downstream realizations); no duplication risk.",
       "MotivicMeasure should be a structure (user-supplied instance), not an axiom. Adding it does not raise the axiomCount of MotivicFlagMaps.lean.",
       "v4.31 VERIFIED (2026-07-23): the axiom-free MotivicMeasure core and its parent MotivicFlagMaps build clean at leanprover/lean4:v4.31.0 (8577 jobs), confirming no drift from the original v4.26 build. The 2 parent axioms (motivicClassBasedMaps opaque element; motivic_class_flag_maps = BEMSV identity, arXiv:2601.07222) are both essential/deep and not Mathlib-eliminable — no axiom-hunt opportunity here.",
-      "Terminal assessment: OQ-03 is open-ended (cohomology consequences). The axiom-free χ-vanishing theorem (motivicClassBasedMaps_eq_zero_of_lefschetz_eq_one) is a genuine answer; all further concrete realizations only add axioms, so the axiom-free framework is the appropriate completion point."
+      "Terminal assessment: OQ-03 is open-ended (cohomology consequences). The axiom-free χ-vanishing theorem (motivicClassBasedMaps_eq_zero_of_lefschetz_eq_one) is a genuine answer; all further concrete realizations only add axioms, so the axiom-free framework is the appropriate completion point.",
+      "Vacuity gap found post-completion: no MotivicMeasure instance existed anywhere, so the headline lefschetz=1 vanishing theorem had an unwitnessed hypothesis class. Closed axiom-free in S3 via the augmentation quotient K/(L-c): Ideal.Quotient.mk packaged as a MotivicMeasure with lefschetz = mk c (Ideal.Quotient.eq + mem_span_singleton_self one-liner).",
+      "The c=1 augmentation is initial among lefschetz=1 measures: Ideal.Quotient.lift + annihilate_of_lefschetz_eq_one gives the factorization (factorThroughAugmentation), turning the conditional headline into an unconditional identity in K/(L-1) (universal_euler_vanishing)."
     ],
     "mathlibGaps": [
       "No K_0(Var) / Grothendieck ring of varieties.",


### PR DESCRIPTION
## Summary
Research session for `motivic-flag-maps-oq-03` (re-served COMPLETED slug; genuine gap found and closed).

## Progress
- **Gap identified**: every theorem in `MotivicFlagMapsOQ03.lean` is conditional on a `MotivicMeasure K R` (headline additionally on `lefschetz = 1`), but **no instance of `MotivicMeasure` existed anywhere in the development** (concrete realizations deferred at +2 axioms each) — the headline vanishing answer was potentially vacuous.
- **S3 (this PR, +0 axioms, 0 sorries)** closes the gap with the canonical universal witness:
  - `augmentation K c : MotivicMeasure K (K.carrier / span {K.L - c})` — first `MotivicMeasure` instance, for every model `K` and every `c` (quotient map, `Ideal.Quotient.eq` + `mem_span_singleton_self`).
  - `nonempty_lefschetz_one` — the headline hypothesis class is nonempty for every `K`.
  - `factorThroughAugmentation` (+ `@[simp]` factorization identity) — every `lefschetz = 1` measure factors through `K/(L-1)`, i.e. the augmentation is initial; vanishing transfers to every concrete Euler-like realization.
  - `universal_euler_vanishing` — **unconditional** vanishing of `[Omega^2_beta(Fl_{n+1})]` in the augmentation quotient for `n >= 1`, no realization hypothesis.
- Docker-verified at v4.31.0 (8577 jobs, clean, zero lint warnings).
- Degenerate-model caveat (zero quotient when `L - 1` is a unit) documented in-file; unavoidable at the abstract-interface level and harmless for the true Grothendieck ring.

## Files Modified
- `proofs/Proofs/MotivicFlagMapsOQ03.lean` (+96 lines, S3 section)
- `src/data/research/problems/motivic-flag-maps-oq-03.json` (insights, builtItems, progressSummary)
- `research/problems/motivic-flag-maps-oq-03/knowledge.md` (session notes, dead ends)

## Status
**Outcome**: completed (structural extension; slug remains COMPLETED, now nonvacuous)
**Next Steps**: none required — realization instances (Euler via Bittner 2004, F_q point counts) remain deferred by design under the axiom-integrity policy. No new OQ spawned (depth cap: slug at depth 1, but no materially-new question opens here).

🤖 Generated by researcher-1
