### PR TITLE
Research: elementary-quadratic-reciprocity-oq-03-oq-02-wip-01 - classical product form from the independent Gauss-sum engine

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01GaussOdd.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01GaussOdd.lean
@@ -573,7 +573,7 @@ theorem legendreSym_neg_one_eq_pow (q : ℕ) [hq : Fact q.Prime] (hq2 : q ≠ 2)
     rcases Nat.even_or_odd ((q - 1) / 2) with h | h
     · exact Or.inl h.neg_one_pow
     · exact Or.inr h.neg_one_pow
-  exact int_pm_one_cast_inj hq2 (legendreSym.eq_one_or_neg_one hne) hpow hcast
+  exact int_pm_one_cast_inj hq2 (legendreSym.eq_one_or_neg_one (p := q) hne) hpow hcast
 
 /-- **Quadratic reciprocity, classical product form** — derived from the
 `q*` form by parity bookkeeping, independent of Mathlib's

--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01GaussOdd.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01GaussOdd.lean
@@ -541,6 +541,84 @@ theorem quadratic_reciprocity_qstar (p q : ℕ) [hp : Fact p.Prime] [hq : Fact q
   rw [hbridge]
   exact hmain
 
+/-! ### The classical product form
+
+`quadratic_reciprocity_qstar` packages reciprocity in Euler's `q*` form.
+This subsection derives the textbook product form
+
+    `(q | p) · (p | q) = (−1)^{((p−1)/2)·((q−1)/2)}`
+
+by parity bookkeeping only: the first supplement in exponent form
+(`legendreSym_neg_one_eq_pow`, via Euler's criterion — not Mathlib's QR
+file), multiplicativity of the Legendre symbol, and `sq_one`. Mathlib's
+`legendreSym.quadratic_reciprocity` is **not** used anywhere in this
+chain, preserving the independence claim of the Gauss-sum engine. -/
+
+/-- **First supplement, exponent form** (via Euler's criterion only):
+`(−1 | q) = (−1)^((q−1)/2)` for an odd prime `q`. Both sides are `±1`
+integers agreeing mod `q > 2`, hence equal. -/
+theorem legendreSym_neg_one_eq_pow (q : ℕ) [hq : Fact q.Prime] (hq2 : q ≠ 2) :
+    legendreSym q (-1) = (-1) ^ ((q - 1) / 2) := by
+  have hoddq : Odd q := hq.out.odd_of_ne_two hq2
+  have hdiv : q / 2 = (q - 1) / 2 := by rcases hoddq with ⟨t, ht⟩; omega
+  have hne : ((-1 : ℤ) : ZMod q) ≠ 0 := by
+    push_cast
+    exact neg_ne_zero.mpr one_ne_zero
+  have hcast : ((legendreSym q (-1) : ℤ) : ZMod q)
+      = (((-1 : ℤ) ^ ((q - 1) / 2) : ℤ) : ZMod q) := by
+    rw [legendreSym.eq_pow, hdiv]
+    push_cast
+    ring
+  have hpow : ((-1 : ℤ) ^ ((q - 1) / 2) = 1) ∨ ((-1 : ℤ) ^ ((q - 1) / 2) = -1) := by
+    rcases Nat.even_or_odd ((q - 1) / 2) with h | h
+    · exact Or.inl h.neg_one_pow
+    · exact Or.inr h.neg_one_pow
+  exact int_pm_one_cast_inj hq2 (legendreSym.eq_one_or_neg_one hne) hpow hcast
+
+/-- **Quadratic reciprocity, classical product form** — derived from the
+`q*` form by parity bookkeeping, independent of Mathlib's
+`legendreSym.quadratic_reciprocity`:
+
+    `(q | p) · (p | q) = (−1)^{((p−1)/2)·((q−1)/2)}`
+
+for distinct odd primes `p ≠ q`. If `(q−1)/2` is even, `q* = q` and the
+two symbols coincide, so the product is `1`; if odd, `q* = −q` and the
+extra factor `(−1 | p) = (−1)^((p−1)/2)` is exactly the right-hand side. -/
+theorem quadratic_reciprocity_product (p q : ℕ) [hp : Fact p.Prime] [hq : Fact q.Prime]
+    (hp2 : p ≠ 2) (hq2 : q ≠ 2) (hpq : p ≠ q) :
+    legendreSym q p * legendreSym p q = (-1) ^ ((p - 1) / 2 * ((q - 1) / 2)) := by
+  have hqstar := quadratic_reciprocity_qstar p q hp2 hq2 hpq
+  have hqp : ((q : ℤ) : ZMod p) ≠ 0 := by
+    intro h0
+    exact (Nat.Prime.coprime_iff_not_dvd hp.out).mp
+      ((Nat.coprime_primes hp.out hq.out).mpr hpq)
+      ((ZMod.natCast_eq_zero_iff q p).mp (by exact_mod_cast h0))
+  have hsq : legendreSym p q * legendreSym p q = 1 := by
+    have h := legendreSym.sq_one (p := p) hqp
+    rwa [sq] at h
+  rcases Nat.even_or_odd ((q - 1) / 2) with hn | hn
+  · -- `(q−1)/2` even: `q* = q`, both sides collapse to `1`.
+    have hε : legendreSym q (-1) = 1 := by
+      rw [legendreSym_neg_one_eq_pow q hq2, hn.neg_one_pow]
+    rw [hε, one_mul] at hqstar
+    have hrhs : ((-1 : ℤ)) ^ ((p - 1) / 2 * ((q - 1) / 2)) = 1 :=
+      (Nat.even_mul.mpr (Or.inr hn)).neg_one_pow
+    rw [hrhs, ← hqstar]
+    exact hsq
+  · -- `(q−1)/2` odd: `q* = −q`, the supplement supplies `(−1)^((p−1)/2)`.
+    have hε : legendreSym q (-1) = -1 := by
+      rw [legendreSym_neg_one_eq_pow q hq2, hn.neg_one_pow]
+    rw [hε] at hqstar
+    rw [legendreSym.mul] at hqstar
+    have hpneg : legendreSym p (-1) = (-1) ^ ((p - 1) / 2) :=
+      legendreSym_neg_one_eq_pow p hp2
+    have hrhs : ((-1 : ℤ)) ^ ((p - 1) / 2 * ((q - 1) / 2)) = (-1) ^ ((p - 1) / 2) := by
+      rw [pow_mul]
+      rcases Nat.even_or_odd ((p - 1) / 2) with hm | hm
+      · rw [hm.neg_one_pow, one_pow]
+      · rw [hm.neg_one_pow, hn.neg_one_pow]
+    rw [hrhs, ← hqstar, hpneg, mul_assoc, hsq, mul_one]
+
 end Reciprocity
 
 end KroneckerSymbol

--- a/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/knowledge.md
+++ b/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/knowledge.md
@@ -212,3 +212,17 @@ explicit args. Host `lake env lean` sidesteps the documented Docker olean-write 
 ### Still open
 - Target 2 ONLY: generalized reciprocity for fundamental discriminants (Gauss sums) — deep,
   NOT session-sized. Everything else on this file is done.
+
+## Session 2026-07-24 (researcher-1) — classical product form
+
+**Route (by mechanism): parity bookkeeping over the qstar form (no new number theory).**
+
+- `legendreSym_neg_one_eq_pow q hq2 : legendreSym q (-1) = (-1)^((q-1)/2)` — Euler
+  criterion (`legendreSym.eq_pow`) + `q/2 = (q-1)/2` for odd q + file-private
+  `int_pm_one_cast_inj` for ±1 descent. Deliberately avoids Mathlib `χ₄`/`at_neg_one`
+  (those live in the QR file) to keep the independence claim airtight.
+- `quadratic_reciprocity_product` — case split on parity of `(q-1)/2`: even ⇒ qstar
+  says (p|q) = (q|p) and RHS = 1 via `Nat.even_mul`; odd ⇒ `legendreSym.mul` splits
+  (−1·q), the supplement supplies `(-1)^((p-1)/2)`, `pow_mul` + 2-case parity closes RHS.
+- Gotcha: `legendreSym.eq_one_or_neg_one` takes the prime as an explicit arg — bare
+  application elaborates the hypothesis as the prime (type mismatch at ℕ).

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01.json
@@ -47,7 +47,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "TARGET 2 CLOSED (2026-07-23, researcher-1-5): full quadratic reciprocity proved independently of Mathlib jacobiSym.quadratic_reciprocity — quadratic_reciprocity_qstar : (chi_q(-1)*q | p) = (p | q) for distinct odd primes, via the self-contained odd-prime Gauss sum engine (g^2 = chi(-1)q), Frobenius covariance in GaloisField p k, and descent to ZMod p. All 0-axiom 0-sorry, Docker-verified. Node now: Kronecker file complete; QR-via-Gauss-sums programme complete for both the prime 2 (PR #42263) and odd primes. Only remaining open item: kronecker2 def-rewiring at even moduli (blocked).",
+    "progressSummary": "TARGET 2 CLOSED (2026-07-23, researcher-1-5): full quadratic reciprocity proved independently of Mathlib jacobiSym.quadratic_reciprocity — quadratic_reciprocity_qstar : (chi_q(-1)*q | p) = (p | q) for distinct odd primes, via the self-contained odd-prime Gauss sum engine (g^2 = chi(-1)q), Frobenius covariance in GaloisField p k, and descent to ZMod p. All 0-axiom 0-sorry, Docker-verified. Node now: Kronecker file complete; QR-via-Gauss-sums programme complete for both the prime 2 (PR #42263) and odd primes. Only remaining open item: kronecker2 def-rewiring at even moduli (blocked). UPDATE 2026-07-24 (researcher-1): the optional product-form item is now DONE — quadratic_reciprocity_product proved from qstar (parity bookkeeping only, Mathlib QR unused). Only remaining open item: kronecker2 def-rewiring at even moduli (blocked, materially new mechanism required).",
     "builtItems": [
       "kronecker2_periodic (ElementaryQuadraticReciprocityOQ03OQ02.lean): (a+8/2)=(a/2), period-8 of the (·/2) character; with kronecker2_mul this makes kronecker2 a Dirichlet character mod 8 (foundation for the Gauss-sum route to Target 2).",
       "kronecker2_mul (ElementaryQuadraticReciprocityOQ03OQ02.lean): (ab/2)=(a/2)(b/2) unconditional multiplicativity of the (·/2) mod-8 character, via x%8 reduction + 64-case decide.",
@@ -76,7 +76,8 @@
       "GaussOdd: gaussSumOdd_sq — Gauss square formula g_q^2 = chi_q(-1)*q (MAIN); legendre-symbol form; gaussSumOdd_ne_zero (char K != q)",
       "GaussOdd: gaussSumOdd_pow_char (Frobenius covariance), chi_neg_one_mul_q_pow_eq_chi (Euler-criterion identity)",
       "GaussOdd: exists_qth_root (order-q root in GaloisField p k, k = ord_q(p))",
-      "GaussOdd: quadratic_reciprocity_qstar — FULL quadratic reciprocity (Euler q* form), independent of Mathlib QR (0-axiom)"
+      "GaussOdd: quadratic_reciprocity_qstar — FULL quadratic reciprocity (Euler q* form), independent of Mathlib QR (0-axiom)",
+      "legendreSym_neg_one_eq_pow + quadratic_reciprocity_product in ElementaryQuadraticReciprocityOQ03OQ02WIP01GaussOdd.lean (+78 lines, 0 axioms, 0 sorries, docker-verified)"
     ],
     "insights": [
       "For odd positive moduli the Kronecker symbol IS the Jacobi symbol (kronecker_eq_jacobi), so mul-in-n and QR come for free from jacobiSym.mul_right' and jacobiSym.quadratic_reciprocity.",
@@ -103,14 +104,14 @@
       "Elaboration gotchas hit: chiK (-1) / gaussSumOdd zeta cannot infer implicit q (q only in index type) — every use needs (q := q) or (-1 : ZMod q) ascription; Finset.sum_erase with a product-form row needs explicit (f := ...) or HO-unification picks f := id and demands DecidableEq K",
       "FULL QR landed same-session as the engine: Frobenius covariance g^p = chi(pbar)*g needs only sum_pow_char + chi(a)^p=chi(a) (odd p) + zetapow_pow + a -> a*pbar reindex; cancellation vs g^p = g*(g^2)^((p-1)/2) gives (chi(-1)q)^((p-1)/2) = chi(pbar) in K",
       "Descent recipe: integer-cast identities in GaloisField p k descend to ZMod p via map_intCast + (algebraMap (ZMod p) K).injective; then legendreSym.eq_pow (Euler) converts the power to a Legendre symbol and int_pm_one_cast_inj separates +-1 mod p>2",
-      "orderOf_eq_card_of_forall_mem_zpowers now returns Nat.card (not Fintype.card) in Mathlib v4.31 vintage — no Nat.card_eq_fintype_card bridge needed; GaloisField derives Finite/CharP/Algebra(ZMod p) so instances are free"
+      "orderOf_eq_card_of_forall_mem_zpowers now returns Nat.card (not Fintype.card) in Mathlib v4.31 vintage — no Nat.card_eq_fintype_card bridge needed; GaloisField derives Finite/CharP/Algebra(ZMod p) so instances are free",
+      "Classical product form closed (2026-07-24, researcher-1): quadratic_reciprocity_product (q|p)(p|q) = (-1)^(((p-1)/2)((q-1)/2)) derived from quadratic_reciprocity_qstar by parity bookkeeping in GaussOdd; helper legendreSym_neg_one_eq_pow (first supplement in exponent form) proved via Euler criterion + the file-private int_pm_one_cast_inj, NOT Mathlib χ₄/QR — independence of the Gauss-sum engine preserved. Gotcha: legendreSym.eq_one_or_neg_one needs the prime explicit ((p := q)) or it consumes the hypothesis as the prime."
     ],
     "mathlibGaps": [
       "No Kronecker symbol in Mathlib (only jacobiSym for odd positive denominators).",
       "No supplementary-law lemmas connecting (2/n)/(-1/n) to the odd part for a generalized reciprocity."
     ],
     "nextSteps": [
-      "Optional: product form (p|q)(q|p) = (-1)^((p-1)/2*(q-1)/2) from quadratic_reciprocity_qstar via chi_q(-1) = (-1)^((q-1)/2) (chi4 supplement) — parity bookkeeping only",
       "kronecker2 def-rewiring at even moduli (2-adic factorization refactor, ~100-200L) — still blocked, materially new mechanism required"
     ]
   },


### PR DESCRIPTION
## Summary
Research session for `elementary-quadratic-reciprocity-oq-03-oq-02-wip-01` (re-served COMPLETED slug; sanctioned optional next-step executed).

## Progress
- Closed the tracker's remaining optional item: **classical product form of quadratic reciprocity** derived from the node's independent Gauss-sum engine.
- `legendreSym_neg_one_eq_pow` — first supplement in exponent form `(-1 | q) = (-1)^((q-1)/2)`, proved via Euler's criterion + the file's private ±1-descent lemma. Deliberately avoids Mathlib's `χ₄`/`at_neg_one` (they live in Mathlib's QR file) so the independence claim stays airtight.
- `quadratic_reciprocity_product` — `(q|p)(p|q) = (-1)^(((p-1)/2)((q-1)/2))` for distinct odd primes, by parity bookkeeping over `quadratic_reciprocity_qstar`: even `(q-1)/2` collapses both sides to 1 (`sq_one`); odd case splits `(-1·q)` with `legendreSym.mul` and matches `(-1)^((p-1)/2)` via `pow_mul`.
- **Mathlib's `legendreSym.quadratic_reciprocity` is not used anywhere in the chain** — the QR-via-Gauss-sums programme now delivers the textbook product form end-to-end independently.
- +78 lines, 0 axioms, 0 sorries; Docker-verified at v4.31.0 (2969 jobs; only the two pre-existing warnings at lines 303/494 remain).

## Files Modified
- `proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02WIP01GaussOdd.lean` (+78 lines)
- `src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01.json`
- `research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01/knowledge.md`

## Status
**Outcome**: completed (optional next-step closed; slug remains COMPLETED)
**Next Steps**: only the structurally-blocked kronecker2 even-moduli rewiring remains (reopen bar: materially new mechanism). No new OQ spawned.

🤖 Generated by researcher-1
