### PR TITLE
Research: erdos-18-wip-01 — salvage: octave [64,128) closed + t=9 record-setter is 348, NOT 2^9 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos18WIP01.lean
+++ b/proofs/Proofs/Erdos18WIP01.lean
@@ -3445,4 +3445,164 @@ the floor thins from six members to two. -/
 theorem hErdos_twofiftytwo : hErdos 252 = 5 :=
   le_antisymm hErdos_twofiftytwo_le five_le_hErdos_twofiftytwo
 
+/-! ### Closing out the octave `[64, 128)`: every exact value, and the index-`4` floor
+
+The octave `[64, 128)` contains fifteen practical numbers.  Previous sessions
+pinned eight exact values (`64, 66, 78, 88, 90, 100, 104, 126`); the remaining
+seven (`72, 80, 84, 96, 108, 112, 120`) fall here, completing the table:
+
+| `m`      | 64 | 66 | 72 | 78 | 80 | 84 | 88 | 90 | 96 | 100 | 104 | 108 | 112 | 120 | 126 |
+|----------|----|----|----|----|----|----|----|----|----|-----|-----|-----|-----|-----|-----|
+| `hErdos` |  6 |  5 |  4 |  6 |  5 |  4 |  6 |  4 |  4 |   6 |   6 |   5 |   5 |   4 |   4 |
+
+Method: uppers by the full witness engine for `d(m) = 12` targets
+(`2^{12} = 4096` subsets, known affordable) and by a `9`-coin sub-family chain
+for `120` (whose `d(120) = 16` makes the full powerset infeasible — the same
+obstruction the sub-family engine removed at `168`); lowers uniformly by the
+graded-slice engine at one hard target each (`299`–`794` subsets).  `80` and
+`108` have UNIQUE hard targets (`79` resp. `107`), like `210` and `240`.
+
+The payoff is the octave's index-`4` floor as a THEOREM
+(`index_four_floor_sixtyfour_octave`): among the fifteen practicals of
+`[64, 128)` exactly `72, 84, 90, 96, 120, 126` attain the octave minimum `4`.
+Combined with `hErdos_onesixtyeight`/`hErdos_oneeighty` (the doublings `2·84`,
+`2·90` stay at `4`) and `hErdos_twoforty`/`hErdos_twofiftytwo` (the doublings
+`2·120`, `2·126` rise to `5`), four of the six floor members now have their
+doubling behaviour formal — the remaining two, `144 = 2·72` and `192 = 2·96`,
+rise to `5` by Python DP but await tight uppers. -/
+
+/-- `72` is practical — doubling `36`. -/
+theorem seventytwo_practical : IsPractical 72 := by
+  simpa using two_mul_practical thirtysix_practical
+
+set_option maxRecDepth 40000 in
+/-- **`hErdos 72 = 4`** — upper by the full witness engine (`d(72) = 12`,
+`4096` subsets); lower by the graded-slice engine at hard target `k = 59`
+(no `≤ 3` of the twelve divisors sum to `59`; `299` graded subsets).  The
+first of the four remaining floor members pinned this session. -/
+theorem hErdos_seventytwo : hErdos 72 = 4 := by
+  refine le_antisymm (hErdos_le_of_witnesses (by decide)) ?_
+  exact le_hErdos_of_no_small_subset (k := 59) seventytwo_practical
+    (by norm_num) (by decide)
+
+/-- `80` is practical — doubling `40`. -/
+theorem eighty_practical : IsPractical 80 := by
+  simpa using two_mul_practical forty_practical
+
+set_option maxRecDepth 40000 in
+/-- **`hErdos 80 = 5`** — upper by the full witness engine (`d(80) = 10`,
+`1024` subsets); lower at the UNIQUE hard target `k = 79 = m − 1` (no `≤ 4`
+of the ten divisors sum to `79`; `386` graded subsets).  The divisor gap
+`5 → 8 → 10` in `{1,2,4,5,8,10,16,20,40}` keeps `79` five-divisor-hard. -/
+theorem hErdos_eighty : hErdos 80 = 5 := by
+  refine le_antisymm (hErdos_le_of_witnesses (by decide)) ?_
+  exact le_hErdos_of_no_small_subset (k := 79) eighty_practical
+    (by norm_num) (by decide)
+
+set_option maxRecDepth 40000 in
+/-- **`hErdos 84 = 4`** — upper by the full witness engine (`d(84) = 12`);
+lower at hard target `k = 83` (`299` graded subsets).  `84`'s doubling `168`
+was already shown to STAY on the floor (`hErdos_onesixtyeight`); this pins
+the base point of that doubling. -/
+theorem hErdos_eightyfour : hErdos 84 = 4 := by
+  refine le_antisymm (hErdos_le_of_witnesses (by decide)) ?_
+  exact le_hErdos_of_no_small_subset (k := 83) eightyfour_practical
+    (by norm_num) (by decide)
+
+/-- `96` is practical — doubling `48`. -/
+theorem ninetysix_practical : IsPractical 96 := by
+  simpa using two_mul_practical fortyeight_practical
+
+set_option maxRecDepth 40000 in
+/-- **`hErdos 96 = 4`** — upper by the full witness engine (`d(96) = 12`);
+lower at hard target `k = 87` (`299` graded subsets).  Like `72`, a
+`2^a · 3`-smooth number sitting on the floor; its doubling `192` rises to
+`5` (Python DP — tight upper not yet formal). -/
+theorem hErdos_ninetysix : hErdos 96 = 4 := by
+  refine le_antisymm (hErdos_le_of_witnesses (by decide)) ?_
+  exact le_hErdos_of_no_small_subset (k := 87) ninetysix_practical
+    (by norm_num) (by decide)
+
+/-- `108` is practical — doubling `54`. -/
+theorem onehundredeight_practical : IsPractical 108 := by
+  simpa using two_mul_practical fiftyfour_practical
+
+set_option maxRecDepth 40000 in
+/-- `5 ≤ hErdos 108` — the graded-slice engine at the UNIQUE hard target
+`k = 107 = m − 1` (no `≤ 4` of the twelve divisors sum to `107`; `794` graded
+subsets). -/
+theorem five_le_hErdos_onehundredeight : 5 ≤ hErdos 108 :=
+  le_hErdos_of_no_small_subset (k := 107) onehundredeight_practical
+    (by norm_num) (by decide)
+
+/-- **`hErdos 108 = 5`** — the subadditive upper `hErdos (2·54) ≤ 1 + 4`
+(`hErdos_onehundredeight_le`, from a previous session) is TIGHT: like `80`
+(and `64`), doubling a practical half costs the full subadditive unit here
+(`54` has index `4`).  Unique hard target `107`. -/
+theorem hErdos_onehundredeight : hErdos 108 = 5 :=
+  le_antisymm hErdos_onehundredeight_le five_le_hErdos_onehundredeight
+
+/-- `112` is practical — doubling `56`. -/
+theorem onehundredtwelve_practical : IsPractical 112 := by
+  simpa using two_mul_practical fiftysix_practical
+
+set_option maxRecDepth 40000 in
+/-- **`hErdos 112 = 5`** — upper by the full witness engine (`d(112) = 10`,
+tightening the subadditive `≤ 6` of `hErdos_onehundredtwelve_le` by one);
+lower at hard target `k = 111` (`386` graded subsets).  Doubling `56` (index
+`5`, Python) is FREE here — the octave's only zero-cost doubling OFF the
+index-`4` floor (`72, 84, 96, 120` are zero-cost too, but along the floor). -/
+theorem hErdos_onehundredtwelve : hErdos 112 = 5 := by
+  refine le_antisymm (hErdos_le_of_witnesses (by decide)) ?_
+  exact le_hErdos_of_no_small_subset (k := 111) onehundredtwelve_practical
+    (by norm_num) (by decide)
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 120 ≤ 4` — sub-family engine on the `9`-coin chain
+`{1, 2, 4, 8, 15, 20, 30, 40, 60}` (`2^9 = 512` subsets, versus the
+infeasible `2^{16}` full powerset: `d(120) = 16` was exactly the obstruction
+that blocked this value before the sub-family engine existed).  Tightens the
+subadditive `≤ 6` of `hErdos_onetwenty_le` by two full units. -/
+theorem hErdos_onetwenty_le_four : hErdos 120 ≤ 4 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 4, 8, 15, 20, 30, 40, 60}
+    ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `4 ≤ hErdos 120` — the graded-slice engine at hard target `k = 97`: no
+subset of at most `3` of the `16` divisors of `120` sums to `97` (`697`
+graded subsets). -/
+theorem four_le_hErdos_onetwenty : 4 ≤ hErdos 120 :=
+  le_hErdos_of_no_small_subset (k := 97) onetwenty_practical
+    (by norm_num) (by decide)
+
+/-- **`hErdos 120 = 4`** — the highest-divisor-count member of the octave's
+floor: `d(120) = 16` (a record among numbers `< 128`), yet the index equals
+`4 = hErdos 16`.  Both engines at work: neither bound was feasible with the
+plain full-powerset engines. -/
+theorem hErdos_onetwenty : hErdos 120 = 4 :=
+  le_antisymm hErdos_onetwenty_le_four four_le_hErdos_onetwenty
+
+set_option maxRecDepth 40000 in
+set_option maxHeartbeats 1600000 in
+/-- **The index-`4` floor of the octave `[64, 128)`, characterised**: a
+practical number in `[64, 128)` has `hErdos m = 4` exactly when
+`m ∈ {72, 84, 90, 96, 120, 126}`.  Previously a Python observation, now a
+theorem — the fifteen practicals of the octave each have a pinned exact value
+(`4` for the six floor members; `5` for `66, 80, 108, 112`; `6` for
+`64, 78, 88, 100, 104`), and the forty-nine non-practical `m` are refuted by
+kernel evaluation.  This is the octave-level input to the floor-thinning
+phenomenon: the `[128, 256)` floor is exactly `{168, 180} = {2·84, 2·90}`. -/
+theorem index_four_floor_sixtyfour_octave :
+    ∀ m, IsPractical m → 64 ≤ m → m < 128 →
+      (hErdos m = 4 ↔ m = 72 ∨ m = 84 ∨ m = 90 ∨ m = 96 ∨ m = 120 ∨ m = 126) := by
+  intro m hm h64 h128
+  interval_cases m <;>
+    first
+    | exact absurd hm (by decide)
+    | simp [hErdos_sixtyfour, hErdos_sixtysix, hErdos_seventytwo,
+        hErdos_seventyeight, hErdos_eighty, hErdos_eightyfour,
+        hErdos_eightyeight, hErdos_ninety, hErdos_ninetysix,
+        hErdos_onehundred, hErdos_onehundredfour, hErdos_onehundredeight,
+        hErdos_onehundredtwelve, hErdos_onetwenty, hErdos_onetwentysix]
+
 end Erdos18

--- a/proofs/Proofs/Erdos18WIP01.lean
+++ b/proofs/Proofs/Erdos18WIP01.lean
@@ -3605,4 +3605,457 @@ theorem index_four_floor_sixtyfour_octave :
         hErdos_onehundred, hErdos_onehundredfour, hErdos_onehundredeight,
         hErdos_onehundredtwelve, hErdos_onetwenty, hErdos_onetwentysix]
 
+/-! ### The record-setter at `t = 9`: the powers-of-two pattern BREAKS at `348`
+
+Every previous rung extended the record-setter sequence `2, 4, 8, 16, 32, 64,
+128, 256 = 2^t`, and the section comments repeatedly recorded the open
+question of whether `2^t` persists — noting it would follow from the
+conjectured bound `hErdos m ≤ log₂ m` for practical `m`, which resisted the
+greedy argument (`t ≤ 5` section comment).  This rung settles the question,
+NEGATIVELY: the least practical number with index `9` is
+
+  `348 = 2² · 3 · 29`,   with `348 < 512 = 2⁹`.
+
+`348` is *extremally* practical: `29 = σ(2² · 3) + 1 = 28 + 1` is the largest
+prime admissible over the prefix `2² · 3` (Stewart's structure theorem), so
+its divisor list `1, 2, 3, 4, 6, 12, 29, 58, 87, 116, 174` jumps by the ratio
+`29/12 ≈ 2.42` right after the six-element prefix.  The unique hard target is
+`k = 347 = 348 - 1`: writing `347 = 174 + 116 + 29 + (28)` forces the ENTIRE
+prefix `28 = 12 + 6 + 4 + 3 + 2 + 1`, nine divisors in all — the kernel
+verifies (`2¹² = 4096` subsets) that no eight divisors of `348` sum to `347`.
+Hence `hErdos 348 = 9 > 8 = ⌊log₂ 348⌋`:
+
+* `hErdos_le_log_fails` — the conjectured `hErdos m ≤ log₂ m` is FALSE;
+* `record_setter_pattern_fails` — `2^t` is NOT the record-setter for all `t`;
+* `minimal_hErdos_nine` — the true `t = 9` record-setter is `348`.
+
+The supporting threshold (`hErdos_le_eight_of_lt_threefortyeight`) pins every
+practical number below `348` at index `≤ 8` by the established split-vs-engine
+dichotomy: eight of the nineteen practicals in `(256, 348)` double a practical
+half (`264, 280, 288, 300, 312, 320, 324, 336` — five splits are kernel-free,
+three fall back to the engine because the half — `140, 150, 162` — is itself
+practically-unsplittable and carries no practicality lemma), and the engine
+pins the rest.  Two structural bonuses:
+
+* **Local uniqueness fails again at `t = 8`**
+  (`record_index_eight_not_locally_unique`): `272 = 2⁴ · 17` and
+  `304 = 2⁴ · 19` tie the record `hErdos 256 = 8` strictly inside
+  `(256, 348)`.  Their divisor lists `1, 2, 4, 8, 16, 17, 34, 68, 136` and
+  `1, 2, 4, 8, 16, 19, 38, 76, 152` are NEAR-DOUBLING chains of length `9`
+  (`17, 19 ≈ 16`), so both behave like `256 = 2⁸` — nine-term doubling —
+  rather than like their divisor-rich neighbours.
+* **A new practicality engine** (`isPractical_of_witnesses_from`): the same
+  coin-chain kernel search that certifies the index upper bound also certifies
+  practicality, so `272`, `304`, `348` never pay the full `2^d(m)` powerset
+  practicality `decide`. -/
+
+/-- **Practicality from a coin chain**: if a sub-family `S ⊆ divisors m`
+reaches every `1 ≤ k < m` as a distinct-subset sum, then `m` is practical.
+Companion to `hErdos_le_of_witnesses_from`: one shared kernel coverage search
+certifies BOTH practicality and the index upper bound (the cardinality bound
+`t` is simply discarded here). -/
+theorem isPractical_of_witnesses_from (S : Finset ℕ) {m t : ℕ} (hm : 1 ≤ m)
+    (hS : S ⊆ divisors m)
+    (h : ∀ k ∈ Finset.range m, ∃ T ∈ S.powerset, T.card ≤ t ∧ T.sum id = k) :
+    IsPractical m := by
+  refine ⟨hm, fun k _ hkm => ?_⟩
+  obtain ⟨T, hTpow, -, hTsum⟩ := h k (Finset.mem_range.mpr hkm)
+  exact ⟨T, (Finset.mem_powerset.mp hTpow).trans hS, hTsum⟩
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 260 ≤ 6` — sub-family engine: `260 = 2²·5·13` has no practical
+split (`130, 65, 52, 26` non-practical or odd).  The kernel finds `≤ 6`-divisor
+representations of every `k < 260` inside the 10-element coin chain below
+(`2¹⁰ = 1024` subsets searched). -/
+theorem hErdos_twosixty_le : hErdos 260 ≤ 6 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 4, 5, 10, 20, 26, 52, 65, 130} ?_ ?_ <;> decide
+
+/-- `hErdos 264 ≤ 7` — subadditivity at the practical split `264 = 2 · 132`. -/
+theorem hErdos_twosixtyfour_le : hErdos 264 ≤ 7 := by
+  have h132p : IsPractical 132 := by
+    simpa using two_mul_practical sixtysix_practical
+  have h : hErdos (2 * 132) ≤ hErdos 2 + hErdos 132 :=
+    hErdos_mul_le two_practical h132p
+  have hhalf := hErdos_onethirtytwo_le
+  rw [hErdos_two] at h
+  have hm : hErdos 264 = hErdos (2 * 132) := by norm_num
+  omega
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 270 ≤ 6` — sub-family engine: `270 = 2·3³·5` is practically
+unsplittable (`135, 45, 27` odd; `54·5, 90·3, 10·27` all involve a
+non-practical factor).  10-element coin chain, `2¹⁰` subsets. -/
+theorem hErdos_twoseventy_le : hErdos 270 ≤ 6 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 3, 5, 6, 15, 27, 45, 90, 135} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+set_option maxHeartbeats 800000 in
+/-- Shared kernel coverage for `272`: every `k < 272` is a `≤ 8`-divisor
+subset sum of the nine proper divisors of `272 = 2⁴ · 17`.  Feeds both
+`twoseventytwo_practical` and the upper half of `hErdos_twoseventytwo`. -/
+theorem twoseventytwo_cover :
+    ∀ k ∈ Finset.range 272, ∃ T ∈ ({1, 2, 4, 8, 16, 17, 34, 68, 136} : Finset ℕ).powerset,
+      T.card ≤ 8 ∧ T.sum id = k := by decide
+
+/-- `272 = 2⁴ · 17` is practical — via the shared coverage search, not a
+`2^d(272)` powerset `decide`. -/
+theorem twoseventytwo_practical : IsPractical 272 :=
+  isPractical_of_witnesses_from _ (by norm_num) (by decide) twoseventytwo_cover
+
+set_option maxRecDepth 40000 in
+set_option maxHeartbeats 800000 in
+/-- **`hErdos 272 = 8` — the record index `8` is TIED strictly inside the
+octave.**  The divisor list of `272 = 2⁴ · 17` is the near-doubling chain
+`1, 2, 4, 8, 16, 17, 34, 68, 136` (`17 ≈ 16`), so `272` behaves like the
+nine-term doubling chain of `256 = 2⁸`.  Hard target `k = 270 = 272 - 2`:
+reaching it needs the whole `17`-chain (`255 = 17 + 34 + 68 + 136`) plus
+`15 = 1 + 2 + 4 + 8` from the `2`-chain.  The kernel checks (`2¹⁰` subsets) that
+no seven divisors of `272` sum to `270` — the representation
+`270 = 136 + 68 + 34 + 17 + 8 + 4 + 2 + 1` (eight divisors) is optimal. -/
+theorem hErdos_twoseventytwo : hErdos 272 = 8 := by
+  refine le_antisymm (hErdos_le_of_witnesses_from _ (by decide) twoseventytwo_cover) ?_
+  exact le_hErdos_of_card (k := 270) twoseventytwo_practical (by omega) (by omega)
+    (by decide)
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 276 ≤ 6` — sub-family engine: `276 = 2²·3·23` has no practical
+split (`138, 69, 46, 23` non-practical or odd).  10-element coin chain. -/
+theorem hErdos_twoseventysix_le : hErdos 276 ≤ 6 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 3, 4, 6, 12, 23, 46, 69, 138} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 280 ≤ 6` — sub-family engine: the only candidate half `140` is
+practically-unsplittable and carries no practicality lemma, so the split route
+is closed; the 9-element coin chain (`2⁹` subsets) certifies `≤ 6` directly
+(the true index is `5`). -/
+theorem hErdos_twoeighty_le : hErdos 280 ≤ 6 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 4, 7, 10, 20, 40, 70, 140} ?_ ?_ <;> decide
+
+/-- `hErdos 288 ≤ 7` — subadditivity at the practical split `288 = 2 · 144`. -/
+theorem hErdos_twoeightyeight_le : hErdos 288 ≤ 7 := by
+  have h72p : IsPractical 72 := by
+    simpa using two_mul_practical thirtysix_practical
+  have h144p : IsPractical 144 := by
+    simpa using two_mul_practical h72p
+  have h : hErdos (2 * 144) ≤ hErdos 2 + hErdos 144 :=
+    hErdos_mul_le two_practical h144p
+  have hhalf := hErdos_onefortyfour_le
+  rw [hErdos_two] at h
+  have hm : hErdos 288 = hErdos (2 * 144) := by norm_num
+  omega
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 294 ≤ 7` — sub-family engine: `294 = 2·3·7²` is practically
+unsplittable (`147, 49, 21` odd; `6·49, 14·21, 42·7` involve non-practical
+factors).  10-element coin chain. -/
+theorem hErdos_twoninetyfour_le : hErdos 294 ≤ 7 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 3, 6, 7, 14, 21, 49, 98, 147} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 300 ≤ 6` — sub-family engine: the only practical-candidate half
+`150` is itself practically-unsplittable (`75` odd) and carries no
+practicality lemma, so the split route is closed.  10-element coin chain. -/
+theorem hErdos_threehundred_le : hErdos 300 ≤ 6 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 3, 4, 10, 12, 30, 50, 100, 150} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+set_option maxHeartbeats 800000 in
+/-- Shared kernel coverage for `304`: every `k < 304` is a `≤ 8`-divisor
+subset sum of the nine proper divisors of `304 = 2⁴ · 19`.  Feeds both
+`threehundredfour_practical` and the upper half of `hErdos_threehundredfour`. -/
+theorem threehundredfour_cover :
+    ∀ k ∈ Finset.range 304, ∃ T ∈ ({1, 2, 4, 8, 16, 19, 38, 76, 152} : Finset ℕ).powerset,
+      T.card ≤ 8 ∧ T.sum id = k := by decide
+
+/-- `304 = 2⁴ · 19` is practical — via the shared coverage search. -/
+theorem threehundredfour_practical : IsPractical 304 :=
+  isPractical_of_witnesses_from _ (by norm_num) (by decide) threehundredfour_cover
+
+set_option maxRecDepth 40000 in
+set_option maxHeartbeats 800000 in
+/-- **`hErdos 304 = 8` — a SECOND tie of the record index `8` inside
+`(256, 348)`.**  `304 = 2⁴ · 19` is the second near-doubling chain
+(`1, 2, 4, 8, 16, 19, 38, 76, 152`; `19 ≤ 32 = σ(2⁴) + 1` keeps it practical).
+Hard target `k = 300`: the kernel checks (`2¹⁰` subsets) that no seven
+divisors of `304` sum to `300` — `300 = 152 + 76 + 38 + 19 + 8 + 4 + 2 + 1`
+(eight divisors) is optimal. -/
+theorem hErdos_threehundredfour : hErdos 304 = 8 := by
+  refine le_antisymm (hErdos_le_of_witnesses_from _ (by decide) threehundredfour_cover) ?_
+  exact le_hErdos_of_card (k := 300) threehundredfour_practical (by omega) (by omega)
+    (by decide)
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 306 ≤ 6` — sub-family engine: `306 = 2·3²·17` is practically
+unsplittable (`153, 51, 17` odd; `18·17, 6·51` involve non-practical factors).
+10-element coin chain. -/
+theorem hErdos_threehundredsix_le : hErdos 306 ≤ 6 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 3, 6, 9, 17, 34, 51, 102, 153} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 308 ≤ 6` — sub-family engine: `308 = 2²·7·11` has no practical
+split (`154, 77, 44-cofactor 7, 28-cofactor 11` all blocked).  10-element coin
+chain. -/
+theorem hErdos_threehundredeight_le : hErdos 308 ≤ 6 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 4, 7, 11, 14, 22, 44, 77, 154} ?_ ?_ <;> decide
+
+/-- `hErdos 312 ≤ 7` — subadditivity at the practical split `312 = 2 · 156`. -/
+theorem hErdos_threetwelve_le : hErdos 312 ≤ 7 := by
+  have h156p : IsPractical 156 := by
+    simpa using two_mul_practical seventyeight_practical
+  have h : hErdos (2 * 156) ≤ hErdos 2 + hErdos 156 :=
+    hErdos_mul_le two_practical h156p
+  have hhalf := hErdos_onefiftysix_le
+  rw [hErdos_two] at h
+  have hm : hErdos 312 = hErdos (2 * 156) := by norm_num
+  omega
+
+/-- `hErdos 320 ≤ 6` — subadditivity at the practical split `320 = 2 · 160`. -/
+theorem hErdos_threetwenty_le : hErdos 320 ≤ 6 := by
+  have h80p : IsPractical 80 := by
+    simpa using two_mul_practical forty_practical
+  have h160p : IsPractical 160 := by
+    simpa using two_mul_practical h80p
+  have h : hErdos (2 * 160) ≤ hErdos 2 + hErdos 160 :=
+    hErdos_mul_le two_practical h160p
+  have hhalf := hErdos_onesixty_le
+  rw [hErdos_two] at h
+  have hm : hErdos 320 = hErdos (2 * 160) := by norm_num
+  omega
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 324 ≤ 6` — sub-family engine: `324 = 2²·3⁴` — the half `162`
+is practically-unsplittable (`81` odd) with no practicality lemma, closing
+the split route.  10-element coin chain certifies the TIGHT bound `6`. -/
+theorem hErdos_threetwentyfour_le : hErdos 324 ≤ 6 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 3, 6, 9, 18, 27, 54, 81, 162} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 330 ≤ 6` — sub-family engine: `330 = 2·3·5·11` is practically
+unsplittable (`165, 55, 33, 11` odd; `6·55, 10·33, 30·11, 66·5, 110·3` all
+involve a non-practical factor).  10-element coin chain. -/
+theorem hErdos_threethirty_le : hErdos 330 ≤ 6 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 3, 5, 6, 15, 30, 55, 110, 165} ?_ ?_ <;> decide
+
+/-- `hErdos 336 ≤ 7` — subadditivity at the practical split `336 = 2 · 168`. -/
+theorem hErdos_threethirtysix_le : hErdos 336 ≤ 7 := by
+  have h84p : IsPractical 84 := by
+    simpa using two_mul_practical fortytwo_practical
+  have h168p : IsPractical 168 := by
+    simpa using two_mul_practical h84p
+  have h : hErdos (2 * 168) ≤ hErdos 2 + hErdos 168 :=
+    hErdos_mul_le two_practical h168p
+  have hhalf := hErdos_onesixtyeight_le
+  rw [hErdos_two] at h
+  have hm : hErdos 336 = hErdos (2 * 168) := by norm_num
+  omega
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 340 ≤ 7` — sub-family engine: `340 = 2²·5·17` has no practical
+split (`170, 85, 68-cofactor 5, 20-cofactor 17` all blocked).  10-element
+coin chain certifies the TIGHT bound `7` — one shy of the record `8`. -/
+theorem hErdos_threeforty_le : hErdos 340 ≤ 7 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 4, 5, 10, 17, 34, 68, 85, 170} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `hErdos 342 ≤ 6` — sub-family engine: `342 = 2·3²·19` is practically
+unsplittable (`171, 57, 19` odd; `18·19, 6·57` involve non-practical factors).
+10-element coin chain. -/
+theorem hErdos_threefortytwo_le : hErdos 342 ≤ 6 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 3, 6, 9, 19, 38, 57, 114, 171} ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+set_option maxHeartbeats 800000 in
+/-- Shared kernel coverage for `348`: every `k < 348` is a `≤ 9`-divisor
+subset sum of the 10-element coin chain `{1, 2, 3, 4, 6, 12, 29, 58, 87, 174}`
+(the proper divisors of `348` minus `116`; `2¹⁰ = 1024` subsets).  Feeds both
+`threefortyeight_practical` and the upper half of `hErdos_threefortyeight`. -/
+theorem threefortyeight_cover :
+    ∀ k ∈ Finset.range 348, ∃ T ∈ ({1, 2, 3, 4, 6, 12, 29, 58, 87, 174} : Finset ℕ).powerset,
+      T.card ≤ 9 ∧ T.sum id = k := by decide
+
+/-- **`348 = 2² · 3 · 29` is practical — extremally so.**  `29 = σ(2² · 3) + 1
+= 28 + 1` is the LARGEST prime admissible over the prefix `2² · 3` (Stewart's
+structure theorem), so the divisor list jumps `12 → 29`, ratio `≈ 2.42` — the
+same shape (`78 = 2·3·13`, gap `6 → 13`) that defeated the greedy argument for
+the conjectured `hErdos m ≤ log₂ m` bound.  Here the shape finally BREAKS the
+bound itself (`hErdos_le_log_fails`). -/
+theorem threefortyeight_practical : IsPractical 348 :=
+  isPractical_of_witnesses_from _ (by norm_num) (by decide) threefortyeight_cover
+
+set_option maxRecDepth 40000 in
+set_option maxHeartbeats 1600000 in
+/-- **`hErdos 348 = 9` — an index-`9` practical number BELOW `2⁹ = 512`.**
+Upper: the shared coverage search.  Lower: the unique hard target is
+`k = 347 = 348 - 1`.  The divisors of `348` split into the prefix
+`D(12) = {1, 2, 3, 4, 6, 12}` (sum `28`) and the layer `29 · D(12)`; since
+`347 ≡ 28 (mod 29)` and `28` needs ALL SIX prefix divisors, every
+representation of `347` spends six divisors on the prefix and still needs
+three from the `29`-layer (`319 = 174 + 116 + 29 = 174 + 87 + 58`).  The
+kernel checks ALL `2¹² = 4096` divisor subsets and finds none of cardinality
+`≤ 8` summing to `347`:
+`347 = 174 + 116 + 29 + 12 + 6 + 4 + 3 + 2 + 1` (nine divisors) is optimal. -/
+theorem hErdos_threefortyeight : hErdos 348 = 9 := by
+  refine le_antisymm (hErdos_le_of_witnesses_from _ (by decide) threefortyeight_cover) ?_
+  exact le_hErdos_of_card (k := 347) threefortyeight_practical (by omega) (by omega)
+    (by decide)
+
+set_option maxRecDepth 200000 in
+/-- **Every practical number below `348` has index at most `8`.**  Below `256`
+this is `hErdos_le_seven_of_lt_twofiftysix`; in `[256, 348)` the twenty
+practical numbers are bounded by the engine values and subadditive splits
+above (each non-practical value excluded by a kernel `decide`).  This is the
+threshold feeding the `t = 9` record-setter — and unlike every previous rung,
+the record it certifies is NOT the next power of two. -/
+theorem hErdos_le_eight_of_lt_threefortyeight {m : ℕ} (hm : IsPractical m)
+    (hlt : m < 348) : hErdos m ≤ 8 := by
+  by_cases h256 : m < 256
+  · exact (hErdos_le_seven_of_lt_twofiftysix hm h256).trans (by norm_num)
+  · push Not at h256
+    interval_cases m
+    · exact hErdos_twofiftysix.le
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_twosixty_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_twosixtyfour_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_twoseventy_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact hErdos_twoseventytwo.le
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_twoseventysix_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_twoeighty_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_twoeightyeight_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_twoninetyfour_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_threehundred_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_threehundredfour.le
+    · exact absurd hm (by decide)
+    · exact hErdos_threehundredsix_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact hErdos_threehundredeight_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_threetwelve_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_threetwenty_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_threetwentyfour_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_threethirty_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_threethirtysix_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact hErdos_threeforty_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact hErdos_threefortytwo_le.trans (by norm_num)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+    · exact absurd hm (by decide)
+
+/-- **Record-setter at `t = 9`: the least practical number with index `9` is
+`348` — NOT `512 = 2⁹`.  The powers-of-two pattern BREAKS.**  The record-setter
+sequence, which ran `2, 4, 8, 16, 32, 64, 128, 256` through `t = 8`, continues
+`…, 348`: the first non-power-of-two record-setter, and the answer (negative)
+to the question left open since the `t ≤ 5` section.  `348 = 2² · 3 · 29` sits
+`164` below the power of two, so the conjectured bound `hErdos m ≤ log₂ m` for
+practical `m` fails with it (`hErdos_le_log_fails`). -/
+theorem minimal_hErdos_nine :
+    IsLeast { m : ℕ | IsPractical m ∧ hErdos m = 9 } 348 := by
+  constructor
+  · exact ⟨threefortyeight_practical, hErdos_threefortyeight⟩
+  · rintro m ⟨hpr, h9⟩
+    by_contra hlt
+    push Not at hlt
+    have := hErdos_le_eight_of_lt_threefortyeight hpr hlt
+    omega
+
+/-- **The conjectured logarithmic bound is FALSE**: it is not the case that
+`hErdos m ≤ log₂ m` for every practical `m`.  The `t ≤ 5` section comment
+recorded this bound as the natural route to `2^t` remaining the record-setter
+forever, noting only that the greedy argument fails on divisor gaps of ratio
+`> 2` (like `6 → 13` in `78`).  The gap `12 → 29` of `348` (ratio `≈ 2.42`,
+extremal by Stewart's criterion: `29 = σ(2² · 3) + 1`) turns the greedy
+obstruction into an actual counterexample: `hErdos 348 = 9 > 8 = log₂ 348`. -/
+theorem hErdos_le_log_fails : ¬ ∀ m : ℕ, IsPractical m → hErdos m ≤ Nat.log 2 m := by
+  intro h
+  have h348 := h 348 threefortyeight_practical
+  rw [hErdos_threefortyeight] at h348
+  have hlog : Nat.log 2 348 = 8 :=
+    Nat.log_eq_of_pow_le_of_lt_pow (by norm_num) (by norm_num)
+  omega
+
+/-- **The powers of two do NOT stay the record-setters**: `2^t` fails to be
+the least practical number of index `t` at `t = 9` (where `348 < 512` takes
+the record).  This settles — negatively — the question recorded at the
+`t ≤ 5, 6, 7, 8` rungs. -/
+theorem record_setter_pattern_fails :
+    ¬ ∀ t : ℕ, IsLeast { m : ℕ | IsPractical m ∧ hErdos m = t } (2 ^ t) := by
+  intro h
+  have h9 := (h 9).2 ⟨threefortyeight_practical, hErdos_threefortyeight⟩
+  norm_num at h9
+
+/-- **Local uniqueness of the record fails at `t = 8`** — for the second time
+(after `t = 6`): practical numbers strictly between `256` and `348` attain
+index `8`.  Witness `272 = 2⁴ · 17` (in fact `304 = 2⁴ · 19` does too — see
+`hErdos_threehundredfour`); both are near-doubling divisor chains of length
+`9`, structurally the closest neighbours of `256 = 2⁸` in the octave.
+Contrast `t = 7`, where `128` was locally alone
+(`record_index_seven_locally_unique`). -/
+theorem record_index_eight_not_locally_unique :
+    ∃ m, IsPractical m ∧ 256 < m ∧ m < 348 ∧ hErdos m = 8 :=
+  ⟨272, twoseventytwo_practical, by norm_num, by norm_num, hErdos_twoseventytwo⟩
+
 end Erdos18

--- a/proofs/Proofs/Erdos18WIP01.lean
+++ b/proofs/Proofs/Erdos18WIP01.lean
@@ -3605,6 +3605,10 @@ theorem index_four_floor_sixtyfour_octave :
         hErdos_onehundred, hErdos_onehundredfour, hErdos_onehundredeight,
         hErdos_onehundredtwelve, hErdos_onetwenty, hErdos_onetwentysix]
 
+-- The engine decides below search 2^10–2^12 subset spaces; the default 200000-
+-- heartbeat budget is insufficient for their elaboration, so raise it for the
+-- remainder of the file (kernel evaluation is unaffected and deterministic).
+set_option maxHeartbeats 1600000
 /-! ### The record-setter at `t = 9`: the powers-of-two pattern BREAKS at `348`
 
 Every previous rung extended the record-setter sequence `2, 4, 8, 16, 32, 64,

--- a/proofs/Proofs/Erdos18WIP01.lean
+++ b/proofs/Proofs/Erdos18WIP01.lean
@@ -3663,6 +3663,7 @@ theorem isPractical_of_witnesses_from (S : Finset ℕ) {m t : ℕ} (hm : 1 ≤ m
   exact ⟨T, (Finset.mem_powerset.mp hTpow).trans hS, hTsum⟩
 
 set_option maxRecDepth 40000 in
+set_option maxHeartbeats 1600000 in
 /-- `hErdos 260 ≤ 6` — sub-family engine: `260 = 2²·5·13` has no practical
 split (`130, 65, 52, 26` non-practical or odd).  The kernel finds `≤ 6`-divisor
 representations of every `k < 260` inside the 10-element coin chain below
@@ -3682,6 +3683,7 @@ theorem hErdos_twosixtyfour_le : hErdos 264 ≤ 7 := by
   omega
 
 set_option maxRecDepth 40000 in
+set_option maxHeartbeats 1600000 in
 /-- `hErdos 270 ≤ 6` — sub-family engine: `270 = 2·3³·5` is practically
 unsplittable (`135, 45, 27` odd; `54·5, 90·3, 10·27` all involve a
 non-practical factor).  10-element coin chain, `2¹⁰` subsets. -/
@@ -3718,6 +3720,7 @@ theorem hErdos_twoseventytwo : hErdos 272 = 8 := by
     (by decide)
 
 set_option maxRecDepth 40000 in
+set_option maxHeartbeats 1600000 in
 /-- `hErdos 276 ≤ 6` — sub-family engine: `276 = 2²·3·23` has no practical
 split (`138, 69, 46, 23` non-practical or odd).  10-element coin chain. -/
 theorem hErdos_twoseventysix_le : hErdos 276 ≤ 6 := by
@@ -3745,6 +3748,7 @@ theorem hErdos_twoeightyeight_le : hErdos 288 ≤ 7 := by
   omega
 
 set_option maxRecDepth 40000 in
+set_option maxHeartbeats 1600000 in
 /-- `hErdos 294 ≤ 7` — sub-family engine: `294 = 2·3·7²` is practically
 unsplittable (`147, 49, 21` odd; `6·49, 14·21, 42·7` involve non-practical
 factors).  10-element coin chain. -/
@@ -3752,6 +3756,7 @@ theorem hErdos_twoninetyfour_le : hErdos 294 ≤ 7 := by
   refine hErdos_le_of_witnesses_from {1, 2, 3, 6, 7, 14, 21, 49, 98, 147} ?_ ?_ <;> decide
 
 set_option maxRecDepth 40000 in
+set_option maxHeartbeats 1600000 in
 /-- `hErdos 300 ≤ 6` — sub-family engine: the only practical-candidate half
 `150` is itself practically-unsplittable (`75` odd) and carries no
 practicality lemma, so the split route is closed.  10-element coin chain. -/
@@ -3785,6 +3790,7 @@ theorem hErdos_threehundredfour : hErdos 304 = 8 := by
     (by decide)
 
 set_option maxRecDepth 40000 in
+set_option maxHeartbeats 1600000 in
 /-- `hErdos 306 ≤ 6` — sub-family engine: `306 = 2·3²·17` is practically
 unsplittable (`153, 51, 17` odd; `18·17, 6·51` involve non-practical factors).
 10-element coin chain. -/

--- a/proofs/Proofs/Erdos18WIP01.lean
+++ b/proofs/Proofs/Erdos18WIP01.lean
@@ -3248,4 +3248,201 @@ theorem record_index_seven_locally_unique :
   have := hErdos_le_six_of_lt_twofiftysix_of_ne hm hlt hne
   omega
 
+/-! ### The restricted lower-bound engine: exact values at high divisor counts
+
+The lower-bound engine `le_hErdos_of_card` quantifies over the FULL powerset of
+`divisors m` — `2^{d(m)}` subsets — infeasible already at `d(210) = 16` (65,536
+subsets) and hopeless at `d(240) = 20` (over a million).  The previous session
+therefore left the exact values of every `d > 12` target of the octave
+`[128, 256)` blocked on "a restricted lower engine that does not exist",
+observing that a lower bound cannot be a witness-LIST check: it must rule out
+ALL small subsets of the full divisor set.
+
+This section supplies that engine.  The key observation: ruling out all small
+subsets does not require visiting all subsets.  To certify `t ≤ repLength m k`
+it suffices to rule out witnesses of each cardinality `s < t` — a kernel check
+over the graded slices `(divisors m).powersetCard s`, totalling
+`C(d,0) + C(d,1) + ⋯ + C(d,t-1)` subsets instead of `2^d`.  For `240` at
+`t = 5` that is `6,196` subsets instead of `1,048,576` — a 169-fold saving that
+grows exponentially with `d`.  Soundness is exactly `repLength_spec'`: for
+practical `m` the minimum is ATTAINED, so `repLength m k < t` would place an
+attaining witness inside a searched slice.  (The upper-bound side of the same
+asymmetry went the other way: witnesses may be exhibited from a chosen
+sub-family, but small-witness refutation must grade the full divisor set.)
+
+With the engine, the octave's blocked exact values fall:
+
+* **`hErdos 210 = 5`** and **`hErdos 240 = 5`** — the two flagship blocked
+  cases.  Each has a UNIQUE hard target (`209` resp. `237`; every other `k`
+  is representable by `4` divisors), and both indices equal `5` despite
+  record divisor counts: `240` is the least number of ANY kind with `20`
+  divisors, yet its index matches `32 = 2^5` with its mere `6`.
+* **`hErdos 168 = 4` and `hErdos 180 = 4`** — the index-`4` FLOOR of the
+  octave (Python DP: every other practical in `[128, 256)` has index `≥ 5`).
+  The floor THINS under doubling: the previous octave's floor is the six
+  numbers `72, 84, 90, 96, 120, 126` (all index `4`), but of their doublings
+  `144, 168, 180, 192, 240, 252` only `168 = 2·84` and `180 = 2·90` stay on
+  the floor — the other four rise to `5`, and for `240` and `252` the rise is
+  formalised below.  For `180`, NO sub-family of `≤ 11` divisors covers all
+  targets at `t = 4` (exhaustive search over all `C(17,≤11)` sub-families);
+  the 12-coin chain used below is minimal, and its `2^{12} × 180` kernel
+  witness search is the heaviest decide in the file.
+* **`hErdos 252 = 5`** — the crude subadditive bound `hErdos (2·126) ≤ 1 + 4`
+  is TIGHT here (contrast `200 = 2·100`, where doubling an index-`6` number
+  drops to `5`): doubling a floor member can genuinely cost a full unit.
+-/
+
+/-- **Restricted lower-bound engine (per target)**: to certify
+`t ≤ repLength m k` it suffices that no divisor subset of cardinality `s < t`
+sums to `k` — a kernel check over the graded slices
+`(divisors m).powersetCard s`, i.e. `C(d, 0) + ⋯ + C(d, t-1)` subsets rather
+than the full powerset's `2^d`.  Sound because the minimum is attained
+(`repLength_spec'`): were `repLength m k < t`, an attaining witness would lie
+in a searched slice. -/
+theorem le_repLength_of_no_small_subset {m k t : ℕ} (hm : IsPractical m)
+    (hkm : k < m)
+    (h : ∀ s ∈ Finset.range t, ∀ T ∈ (divisors m).powersetCard s,
+      T.sum id ≠ k) :
+    t ≤ repLength m k := by
+  by_contra hlt
+  push Not at hlt
+  obtain ⟨T, hTsub, hTcard, hTsum⟩ := repLength_spec' hm hkm
+  exact h (repLength m k) (Finset.mem_range.mpr hlt) T
+    (Finset.mem_powersetCard.mpr ⟨hTsub, hTcard⟩) hTsum
+
+/-- **Restricted lower-bound engine (index)**: one hard target `k < m` with no
+small-cardinality representation forces `t ≤ hErdos m`, at graded-slice cost. -/
+theorem le_hErdos_of_no_small_subset {m k t : ℕ} (hm : IsPractical m)
+    (hkm : k < m)
+    (h : ∀ s ∈ Finset.range t, ∀ T ∈ (divisors m).powersetCard s,
+      T.sum id ≠ k) :
+    t ≤ hErdos m := by
+  refine (le_repLength_of_no_small_subset hm hkm h).trans ?_
+  unfold hErdos
+  exact Finset.le_sup (Finset.mem_range.mpr hkm)
+
+set_option maxRecDepth 40000 in
+/-- `5 ≤ hErdos 210` — the restricted engine at the unique hard target
+`k = 209`: no subset of at most `4` of the `16` divisors of `210` sums to
+`209` (`2,517` graded subsets searched; the full powerset's `65,536` made this
+exact value infeasible for the plain engine last session). -/
+theorem five_le_hErdos_twohundredten : 5 ≤ hErdos 210 :=
+  le_hErdos_of_no_small_subset (k := 209) two_hundred_ten_practical
+    (by norm_num) (by decide)
+
+/-- **`hErdos 210 = 5`** — first exact value at `d > 12`: the primorial
+`210 = 2·3·5·7` needs exactly `5` summands at `k = 209` and nowhere more.
+Its index equals that of `32 = 2^5`, despite carrying `16` divisors. -/
+theorem hErdos_twohundredten : hErdos 210 = 5 :=
+  le_antisymm hErdos_twohundredten_le five_le_hErdos_twohundredten
+
+/-- `120` is practical — doubling `60`. -/
+theorem onetwenty_practical : IsPractical 120 := by
+  simpa using two_mul_practical sixty_practical
+
+/-- `240` is practical — doubling `120`. -/
+theorem twoforty_practical : IsPractical 240 := by
+  simpa using two_mul_practical onetwenty_practical
+
+set_option maxRecDepth 40000 in
+/-- `5 ≤ hErdos 240` — the restricted engine at the unique hard target
+`k = 237`: no subset of at most `4` of the `20` divisors of `240` sums to
+`237` (`6,196` graded subsets, versus the hopeless `2^{20}` full powerset). -/
+theorem five_le_hErdos_twoforty : 5 ≤ hErdos 240 :=
+  le_hErdos_of_no_small_subset (k := 237) twoforty_practical
+    (by norm_num) (by decide)
+
+/-- **`hErdos 240 = 5`** — the extreme divisor-count case of the octave:
+`240` is the least number of any kind with `20` divisors, yet its index is
+`5`, the same as `32 = 2^5` with its `6` divisors.  Together with
+`hErdos 210 = 5` this pins both targets the previous session declared blocked
+on a restricted lower engine. -/
+theorem hErdos_twoforty : hErdos 240 = 5 :=
+  le_antisymm hErdos_twoforty_le five_le_hErdos_twoforty
+
+/-- `84` is practical — doubling `42`. -/
+theorem eightyfour_practical : IsPractical 84 := by
+  simpa using two_mul_practical fortytwo_practical
+
+/-- `168` is practical — doubling `84`. -/
+theorem onesixtyeight_practical : IsPractical 168 := by
+  simpa using two_mul_practical eightyfour_practical
+
+set_option maxRecDepth 40000 in
+set_option maxHeartbeats 800000 in
+/-- `hErdos 168 ≤ 4` — sub-family engine, TIGHTENING the subadditive
+`hErdos_onesixtyeight_le` (`≤ 6` via `2·84`) by two full units.  The kernel
+finds `≤ 4`-divisor representations of every `k < 168` inside the 11-element
+coin chain below (`2^{11} = 2048` subsets searched; heartbeat budget as for
+the other `2^{11}` run at `224`). -/
+theorem hErdos_onesixtyeight_le_four : hErdos 168 ≤ 4 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 3, 4, 6, 12, 21, 28, 42, 56, 84}
+    ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `4 ≤ hErdos 168` — the restricted engine at hard target `k = 121`: no
+subset of at most `3` of the `16` divisors of `168` sums to `121` (`697`
+graded subsets). -/
+theorem four_le_hErdos_onesixtyeight : 4 ≤ hErdos 168 :=
+  le_hErdos_of_no_small_subset (k := 121) onesixtyeight_practical
+    (by norm_num) (by decide)
+
+/-- **`hErdos 168 = 4`** — joint index-`4` floor of the octave `[128, 256)`
+(with `180`; Python DP confirms every other practical in the octave has index
+`≥ 5`). -/
+theorem hErdos_onesixtyeight : hErdos 168 = 4 :=
+  le_antisymm hErdos_onesixtyeight_le_four four_le_hErdos_onesixtyeight
+
+/-- `180` is practical — doubling `90`. -/
+theorem oneeighty_practical : IsPractical 180 := by
+  simpa using two_mul_practical ninety_practical
+
+set_option maxRecDepth 40000 in
+set_option maxHeartbeats 3200000 in
+/-- `hErdos 180 ≤ 4` — sub-family engine, tightening the subadditive
+`hErdos_oneeighty_le` (`≤ 5` via `2·90`) to the floor.  NO sub-family of
+`≤ 11` of the `17` proper divisors covers every target at `t = 4`
+(exhaustively checked offline), so the 12-element coin chain below is
+minimal; its `2^{12} = 4096`-subset search over `180` targets is the heaviest
+kernel decide in the file, hence the quadrupled heartbeat budget. -/
+theorem hErdos_oneeighty_le_four : hErdos 180 ≤ 4 := by
+  refine hErdos_le_of_witnesses_from {1, 2, 3, 6, 9, 10, 18, 20, 30, 45, 60, 90}
+    ?_ ?_ <;> decide
+
+set_option maxRecDepth 40000 in
+/-- `4 ≤ hErdos 180` — the restricted engine at hard target `k = 133`: no
+subset of at most `3` of the `18` divisors of `180` sums to `133` (`988`
+graded subsets). -/
+theorem four_le_hErdos_oneeighty : 4 ≤ hErdos 180 :=
+  le_hErdos_of_no_small_subset (k := 133) oneeighty_practical
+    (by norm_num) (by decide)
+
+/-- **`hErdos 180 = 4`** — the other member of the octave's index-`4` floor:
+`180` is highly composite (`18` divisors, more than any smaller number), yet
+needs only `4` summands for every target, matching `16 = 2^4`. -/
+theorem hErdos_oneeighty : hErdos 180 = 4 :=
+  le_antisymm hErdos_oneeighty_le_four four_le_hErdos_oneeighty
+
+/-- `252` is practical — doubling `126`. -/
+theorem twofiftytwo_practical : IsPractical 252 := by
+  simpa using two_mul_practical onetwentysix_practical
+
+set_option maxRecDepth 40000 in
+/-- `5 ≤ hErdos 252` — the restricted engine at the unique hard target
+`k = 251`: no subset of at most `4` of the `18` divisors of `252` sums to
+`251` (`4,047` graded subsets). -/
+theorem five_le_hErdos_twofiftytwo : 5 ≤ hErdos 252 :=
+  le_hErdos_of_no_small_subset (k := 251) twofiftytwo_practical
+    (by norm_num) (by decide)
+
+/-- **`hErdos 252 = 5`** — doubling can genuinely cost the full subadditive
+unit: `126` sits on the previous octave's index-`4` floor, and
+`hErdos (2·126) ≤ hErdos 2 + hErdos 126 = 5` is TIGHT.  Of the six floor
+members `72, 84, 90, 96, 120, 126` of `[64, 128)`, the doublings of `84` and
+`90` stay on the floor (`hErdos_onesixtyeight`, `hErdos_oneeighty`) while
+those of `120` and `126` provably rise (`hErdos_twoforty`, this theorem) —
+the floor thins from six members to two. -/
+theorem hErdos_twofiftytwo : hErdos 252 = 5 :=
+  le_antisymm hErdos_twofiftytwo_le five_le_hErdos_twofiftytwo
+
 end Erdos18

--- a/research/problems/erdos-18-wip-01/knowledge.md
+++ b/research/problems/erdos-18-wip-01/knowledge.md
@@ -582,3 +582,94 @@ chains); the graded-slice engine now covers any hard-target lower bound the
 record proof might want. (c) previous-octave floor completion (72, 84, 96,
 120 exact values) is cheap and would make the 6 → 2 thinning fully formal.
 Deep Vose bound unchanged.
+
+## Session 2026-07-24b (researcher-2) — octave [64,128) closed out: 7 exact values + floor theorem
+
+Same branch (research/erdos18-lower-engine), stacked on the engine session.
+All fifteen practicals of [64,128) now have pinned exact values (0-axiom):
+
+| m      | 64 | 66 | 72 | 78 | 80 | 84 | 88 | 90 | 96 | 100 | 104 | 108 | 112 | 120 | 126 |
+| hErdos |  6 |  5 |  4 |  6 |  5 |  4 |  6 |  4 |  4 |   6 |   6 |   5 |   5 |   4 |   4 |
+
+New this session: 72, 80, 84, 96, 108, 112, 120. Method fully symmetric now:
+
+* Uppers: full witness engine at d = 12 (72/84/96, 4096 subsets) and d = 10
+  (80/112, 1024 subsets); 120 needs the SUB-FAMILY engine (d(120) = 16) — the
+  9-coin chain {1,2,4,8,15,20,30,40,60} is minimal (Python: no 8-coin chain
+  covers at t = 4), 2^9 × 120 trivially cheap. 108's tight upper was already
+  on file (subadditive 2·54 ≤ 1+4, TIGHT).
+* Lowers: graded-slice engine at one hard target each — 72@59, 84@83, 96@87,
+  120@97 (t=4, C(d,≤3) = 299/697); 80@79, 108@107, 112@111 (t=5, C(d,≤4) =
+  386/794). 80 and 108 have UNIQUE hard targets (79 = m−1, 107 = m−1).
+
+`index_four_floor_sixtyfour_octave`: for practical m ∈ [64,128),
+hErdos m = 4 ↔ m ∈ {72,84,90,96,120,126}. interval_cases over 64 cases;
+non-practicals refuted by decide; practicals closed by simp with the 15 value
+lemmas. maxHeartbeats 1600000 budgeted (64 branches × decide attempts).
+
+Structural corrections to prior notes (Python, worth formalizing later):
+* hErdos 40 = 4 (NOT 5 — the t=6 session only recorded the ≤5 subadditive
+  upper). The [32,64) floor is {36,40,42,48,54,60} — SIX members again, with
+  32 and 56 at index 5. Floor sizes: [32,64): 6 → [64,128): 6 → [128,256): 2.
+* The [64,128) floor members are exactly: doublings of [32,64) floor members
+  that stay (72=2·36, 84=2·42, 96=2·48, 120=2·60 stay; 80=2·40, 108=2·54
+  RISE) plus the practically-unsplittable 90, 126. Unit-cost doublings from
+  practical halves: 64, 80, 108; zero-cost off-floor doubling: 112=2·56.
+
+NEXT: (a) [32,64) exact-value completion (36/40/42/48/54/56/60 — all d ≤ 10,
+both engines trivial) would make the 6→6→2 floor cascade fully formal at the
+[32,64)→[64,128) step and expose the false ≤5 pin at 40. (b) [128,256) octave
+completion: remaining d ≤ 12 targets all cheap; 132/144/192/216 need tight
+uppers (sub-family chains). (c) t = 9 rung [256,512): record + threshold —
+both engines ready; unsplittable census first. Deep Vose bound unchanged.
+
+## Session 2026-07-24 (researcher-2): t = 9 — THE POWERS-OF-TWO PATTERN BREAKS
+
+**Headline: `minimal_hErdos_nine` = 348, not 512 = 2^9.** The record-setter
+sequence 2, 4, 8, 16, 32, 64, 128, 256 continues …, 348 = 2^2·3·29 — the first
+non-power-of-two record-setter. This settles (negatively) the open question
+recorded since the t ≤ 5 section: `hErdos_le_log_fails` (hErdos m ≤ log₂ m is
+FALSE for practical m: hErdos 348 = 9 > 8 = log₂ 348) and
+`record_setter_pattern_fails` (¬∀ t, IsLeast {…} (2^t)).
+
+Mechanism: 348 = 12 · 29 with 29 = σ(12) + 1 EXACTLY (Stewart-extremal), so
+divisors = D(12) ∪ 29·D(12) with gap 12 → 29 (ratio 2.42). Unique hard target
+k = 347 ≡ 28 (mod 29): the prefix contribution must be ≡ 28, and 28 = sum of
+ALL SIX prefix divisors, leaving 319 = 29·11 to the 29-layer (min 3 divisors)
+— 9 total. The same gap shape (6 → 13 in 78) that defeated greedy halving now
+breaks the conjecture itself.
+
+Bonuses: local uniqueness fails AGAIN at t = 8
+(`record_index_eight_not_locally_unique`): 272 = 2^4·17 and 304 = 2^4·19 tie
+index 8 — their divisor lists are NEAR-DOUBLING 9-chains (17, 19 ≈ 16), i.e.
+the structural neighbours of 256 = 2^8. Exact values via hard targets 270
+(272−2, needs whole 17-chain + 15) and 300.
+
+New engine: `isPractical_of_witnesses_from` — the SAME coin-chain coverage
+decide (∀ k ∈ range m, ∃ T ∈ S.powerset, card ≤ t ∧ sum = k, stated as a
+shared standalone theorem `<m>_cover`) certifies practicality AND the index
+upper bound; 272/304/348 never pay the full 2^d practicality decide. Pattern:
+one `by decide` theorem, two consumers.
+
+Octave census (256, 348): 19 practicals. Kernel-free splits: 264, 288, 312,
+320, 336 (half practical with existing lemma chain). Engine (half practical
+but lemma-less: 280/150-cofactor, 300, 324; or unsplittable: 260, 270, 276,
+294, 306, 308, 330, 340, 342 + exact 272, 304, 348). All coin chains |S| ≤ 10
+(2^10 worst); threshold `hErdos_le_eight_of_lt_threefortyeight` at
+maxRecDepth 200000, 92 interval cases, non-practicals all fail by k = 16.
+Full-octave values: 260:6 264:≤7 270:≤6 272:8 276:≤6 280:≤6 288:≤7 294:≤7
+300:≤6 304:8 306:≤6 308:≤6 312:≤7 320:≤6 324:≤6 330:≤6 336:≤7 340:≤7 342:≤6.
+
+NEXT: (a) t = 10 rung: where is the least index-10 practical? Python census
+FIRST — after 348 the record game changes qualitatively (next Stewart-extremal
+shapes: 2·p at p = 3 = σ(2)+1 gave 6; 12·29 = 348; next layer 348·(σ(348)+1)?
+= 348·1009?? — no: candidates are m = q·(σ(q)+1) for practical q; check
+28·29? (29 = σ(28)+1? σ(28) = 56 no). Compute, don't guess.) (b) The
+[348, 512) remainder of the old octave is now LOW priority (the threshold to
+512 no longer feeds a record-setter; 360/420/480 have d = 24 — engine-only).
+(c) The conjecture layer needs re-homing: with hErdos m ≤ log₂ m dead, what is
+the true growth envelope? Vose says lim inf hErdos ≪ √log m; 348 shows single
+values can EXCEED log₂ m. Is hErdos m ≤ C·log m still plausible? (348 gives
+C ≥ 9/8.44 ≈ 1.07 at one point; iterating the Stewart-extremal construction
+m ↦ m·(σ(m)+1) may push C — each step roughly doubles log while adding
+d(m)-ish to the index. Worth a targeted Python sweep to 10^5.)

--- a/research/problems/erdos-18-wip-01/knowledge.md
+++ b/research/problems/erdos-18-wip-01/knowledge.md
@@ -532,3 +532,53 @@ default 200000-heartbeat elaboration budget up to 2^10 subsets x ~230 targets;
 the single 2^11 run (224, 11 proper divisors, no 10-coin sub-family covers)
 needs `set_option maxHeartbeats 800000`. Budget scales with 2^|S| x m — plan
 t = 9 coin chains at |S| <= 10 where possible, or expect heartbeat bumps.
+
+## Session 2026-07-24 (researcher-2) — restricted lower engine; exact values at d > 12: 210, 240 (blocked pair), 168/180 (octave floor), 252
+
+The "restricted lower engine that does not exist" (last session's blocker for
+every d > 12 exact value) now exists, and is nearly free: to certify
+`t ≤ repLength m k` one need not search all 2^d divisor subsets — only refute
+witnesses of cardinality BELOW t, i.e. the graded slices
+`(divisors m).powersetCard s` for s < t, at cost C(d,0)+...+C(d,t-1).
+`le_repLength_of_no_small_subset` / `le_hErdos_of_no_small_subset`; soundness
+is exactly `repLength_spec'` (the minimum is attained, so a value < t would
+put an attaining witness in a searched slice). For 240 at t = 5 this is 6,196
+subsets instead of 2^20 = 1,048,576 — the asymmetry with the upper side is
+now symmetric in cost: sub-family chains for uppers, graded slices for lowers.
+
+Exact values pinned (all 0-axiom, le_antisymm of existing upper + new lower):
+
+* `hErdos 210 = 5`, `hErdos 240 = 5` — the two flagship blocked targets.
+  Each has a UNIQUE hard target (209 resp. 237). 240 is the least number of
+  any kind with 20 divisors, yet its index ties 32 = 2^5.
+* `hErdos 168 = 4`, `hErdos 180 = 4` — the index-4 FLOOR of [128,256)
+  (Python DP: every other practical in the octave is ≥ 5). Tight sub-family
+  uppers: 168 via an 11-coin chain {1,2,3,4,6,12,21,28,42,56,84}; 180 has NO
+  ≤11-coin chain at t = 4 (exhaustively checked offline) — the 12-coin chain
+  {1,2,3,6,9,10,18,20,30,45,60,90} is minimal, 2^12 × 180 search,
+  maxHeartbeats 3200000, heaviest decide in the file.
+* `hErdos 252 = 5` — doubling a floor member can cost the full subadditive
+  unit (126 is on the [64,128) floor; hErdos(2·126) ≤ 1+4 is TIGHT).
+
+Structural picture (octave floors under doubling): the [64,128) floor is SIX
+practicals {72, 84, 90, 96, 120, 126} (Python; 72/96/120 exact values not yet
+formalized — only 84 ≤ 5, 90 = 4, 126 = 4 are on file, and 84's tight value 4
+is NOT yet in Lean either). The [128,256) floor is exactly {168, 180} = the
+doublings of 84 and 90; the other four doublings rise to 5 (240, 252 now
+formal; 144, 192 Python-only). The floor thins 6 → 2 under doubling.
+
+Costs (calibration for t = 9): graded-slice lower decides are trivial —
+C(16,≤4) = 2517 (210), C(20,≤4) = 6196 (240), C(18,≤3) = 988 (180) all run at
+maxRecDepth 40000, default heartbeats. Sub-family upper 2^11 × 168 fits
+maxHeartbeats 800000; 2^12 × 180 needs 3200000.
+
+NEXT: (a) octave [128,256) exact-value completion is now unblocked — remaining
+d ≤ 12 targets (140, 150, 156, 160, 162, 176, 196, 198, 200, 204, 208, 220,
+224, 228, 234) are all cheap with the graded-slice engine (lowers) + existing
+uppers; 132, 144, 192, 216 need tight uppers first (144: exact 5 vs upper 6;
+192: exact 5 vs 6; 216: exact 5 vs 6; 132: exact 5 = upper 5 ✓ lower only).
+(b) t = 9 rung [256,512): threshold needs uppers only (splits + sub-family
+chains); the graded-slice engine now covers any hard-target lower bound the
+record proof might want. (c) previous-octave floor completion (72, 84, 96,
+120 exact values) is cheap and would make the 6 → 2 thinning fully formal.
+Deep Vose bound unchanged.

--- a/research/problems/erdos-18-wip-01/problem.md
+++ b/research/problems/erdos-18-wip-01/problem.md
@@ -119,3 +119,36 @@ created: 2026-07-09T17:33:19-07:00
 
 **Significance**: 7/10
 **Tractability**: 5/10
+
+## Adversarial checklist — t = 9 record-setter claim (2026-07-24, researcher-2)
+
+Claim under audit: `minimal_hErdos_nine : IsLeast {m | IsPractical m ∧ hErdos m = 9} 348`,
+`hErdos_le_log_fails`, `record_setter_pattern_fails` (Erdos18WIP01.lean).
+
+1. **Index mismatch (hErdos vs h)**: the refuted conjecture concerns `hErdos`
+   (max-representation-length, the corrected Erdős #18 index defined mid-file),
+   NOT the parent's universal-set `h`. Confirm the theorems reference `hErdos`
+   and that no claim is made about the parent `h` or about the $250 `h(n!)`
+   conjecture — which remains open and untouched.
+2. **Floor-log artifact**: `hErdos_le_log_fails` uses `Nat.log 2`. Since
+   `hErdos` is a natural number, `hErdos m ≤ log₂ m` (real) ⟺ `hErdos m ≤
+   ⌊log₂ m⌋` = `Nat.log 2 m`; and concretely 9 > 8.44 = log₂ 348, so the
+   refutation is NOT a floor artifact.
+3. **Set-shape drift**: the `IsLeast` set comprehension is verbatim the shape
+   used at t = 1..8 (`minimal_hErdos_two` … `_eight`) — same `IsPractical m ∧
+   hErdos m = t`.
+4. **Boundary traps**: threshold `hErdos_le_eight_of_lt_threefortyeight` covers
+   `m < 348` strictly; membership of 348 is proved separately
+   (`threefortyeight_practical`, `hErdos_threefortyeight`); hard target
+   `k = 347 < 348` is in `Finset.range 348`.
+5. **Circularity**: no axiom or hypothesis as strong as the claim — upper
+   bounds are kernel coverage decides over explicit coin chains, the lower
+   bound is a full `2¹²`-powerset kernel decide at `k = 347`; the file stays
+   0-axiom/0-sorry.
+6. **Wrong-multiplicity near-miss**: `record_setter_pattern_fails` refutes
+   `∀ t, IsLeast … (2^t)`, witnessed at `t = 9` via the lower-bound half —
+   it does not merely prove "348 attains 9" but that 2⁹ = 512 is NOT a lower
+   bound of the index-9 set, which is exactly the pattern claim.
+7. **Cross-check**: Python full-powerset enumeration (independent of the Lean
+   DP semantics) confirmed hErdos 348 = 9 (unique argmax k = 347), hErdos 272
+   = hErdos 304 = 8, and every octave value used in the threshold.

--- a/research/problems/erdos-18-wip-01/state.md
+++ b/research/problems/erdos-18-wip-01/state.md
@@ -116,3 +116,21 @@ Next: t = 9 ([256, 512), sub-family engine mandatory, count unsplittables
 first); exact values in [128,256) blocked for d > 12 (no restricted LOWER
 engine exists — lower bounds must search the full powerset). Deep Vose
 unchanged.
+
+## 2026-07-24 (researcher-2): t = 9 — record-setter is 348, pattern BREAKS
+
+`minimal_hErdos_nine` = 348 = 2^2·3·29 < 512 = 2^9: first non-power-of-two
+record-setter. Refutations now theorems: `hErdos_le_log_fails` (hErdos m ≤
+log₂ m FALSE — hErdos 348 = 9 > 8) and `record_setter_pattern_fails`.
+348 is Stewart-extremal (29 = σ(12)+1); unique hard target 347 ≡ 28 (mod 29)
+forces all six small divisors + three of the 29-layer.
+
+Also: `record_index_eight_not_locally_unique` — 272 = 2^4·17, 304 = 2^4·19
+(near-doubling 9-chains) tie index 8 in (256, 348); exact via hard targets
+270/300. New shared-coverage engine `isPractical_of_witnesses_from`
+(practicality + upper bound from ONE kernel decide). Threshold
+`hErdos_le_eight_of_lt_threefortyeight`.
+
+Next: t = 10 census (Python first; record game now open-ended); growth
+envelope question re-homed — is hErdos ≤ C log m plausible, or does iterating
+m ↦ m(σ(m)+1) push C up? [348,512) remainder is low priority.

--- a/src/data/research/problems/erdos-18-wip-01.json
+++ b/src/data/research/problems/erdos-18-wip-01.json
@@ -25,9 +25,9 @@
     "phase": "ACT",
     "since": "2026-07-09T17:33:19-07:00",
     "iteration": 2,
-    "focus": "2026-07-23: exact table extended + RECORD-SETTERS proved — hErdos 18 = 3 (engine-only, no practical factorisation), hErdos 20 = 4 (unique hard target 18; NON-MONOTONICITY: 20 < 24 but hErdos 20 = 4 > 3 = hErdos 24, and d(20) = 6 < 8 = d(24)), hErdos 28 = 4 (hard target 27), hErdos 8/16/32 via the power formula, and minimal_hErdos_two/three/four/five (IsLeast): the least practical m with hErdos m = t is 2^t for t = 2..5 — record-setter sequence 2, 4, 8, 16, 32. All 0-axiom, docker-verified. Open question crystallised: is the record-setter 2^t for ALL t? Would follow from hErdos m <= log2 m (practical m), but the greedy proof FAILS (practical 78 has divisor-gap ratio 13/6 > 2), so a non-greedy argument is needed.",
+    "focus": "2026-07-24: t=9 record rung CLOSED — minimal_hErdos_nine = 348 (powers-of-two pattern breaks; hErdos_le_log_fails now a theorem); octave [64,128) fully pinned with index-4 floor theorem; restricted lower engine + shared-coverage practicality engine on file. All 0-axiom, docker-verified.",
     "blockers": [],
-    "nextAction": "t = 8 rung ([128,256)) or octave index-6 census via witness-list engine; record-setter proved through t = 7",
+    "nextAction": "t = 10 rung: Python census of Stewart-extremal candidates m = q*(sigma(q)+1) FIRST; or growth-envelope sweep (is hErdos <= C log m plausible?); [348,512) octave remainder is LOW priority",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -35,7 +35,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: restricted lower engine (graded powersetCard slices, C(d,<t) vs 2^d) closes last session's blocker; exact values hErdos 168=4, 180=4 (octave floor), 210=5, 240=5 (blocked pair), 252=5 all 0-axiom. Record sequence 2^t for t=1..8 unchanged; t=9 rung and octave exact-value completion now fully unblocked.",
+    "progressSummary": "PROGRESS: record-setter sequence settled for t=1..9 — 2,4,8,16,32,64,128,256,348: the powers-of-two pattern BREAKS at t=9 (348 = 2^2*3*29 < 2^9, Stewart-extremal 29 = sigma(12)+1); conjectured hErdos <= log2 bound REFUTED as a theorem (hErdos_le_log_fails); local uniqueness fails at t=8 (272/304 tie); new shared-coverage practicality engine. Same day: restricted lower engine (graded powersetCard slices, C(d,<t) vs 2^d); octave [64,128) fully closed out (15/15 exact values) with index-4 floor theorem; [128,256) exacts 168/180/210/240/252 pinned. Next: t=10 census + growth-envelope sweep",
     "builtItems": [
       "decidableIsRepresentable / decidableIsPractical instances (Erdos18Problem.lean)",
       "zero_isRepresentable, one_isRepresentable, isRepresentable_self, isRepresentable_le_sigma, mem_divisors_le (Erdos18Problem.lean)",
@@ -82,7 +82,14 @@
       "record_index_seven_locally_unique + twofiftysix_practical + hErdos_twofiftysix in Erdos18WIP01.lean",
       "le_repLength_of_no_small_subset / le_hErdos_of_no_small_subset (restricted lower engine, graded powersetCard slices) in Erdos18WIP01.lean",
       "hErdos_twohundredten (=5), hErdos_twoforty (=5), hErdos_onesixtyeight (=4), hErdos_oneeighty (=4), hErdos_twofiftytwo (=5) exact values + lower bounds + tight uppers hErdos_onesixtyeight_le_four / hErdos_oneeighty_le_four",
-      "Practicality lemmas: onetwenty_practical, twoforty_practical, eightyfour_practical, onesixtyeight_practical, oneeighty_practical, twofiftytwo_practical"
+      "Practicality lemmas: onetwenty_practical, twoforty_practical, eightyfour_practical, onesixtyeight_practical, oneeighty_practical, twofiftytwo_practical",
+      "isPractical_of_witnesses_from (practicality engine from coin-chain coverage) in Erdos18WIP01.lean",
+      "twoseventytwo_cover/threehundredfour_cover/threefortyeight_cover shared coverage decides; twoseventytwo/threehundredfour/threefortyeight_practical",
+      "hErdos_twoseventytwo = 8, hErdos_threehundredfour = 8 (hard targets 270/300); hErdos_threefortyeight = 9 (hard target 347, 2^12 lower decide)",
+      "14 octave upper bounds hErdos_twosixty_le..hErdos_threefortytwo_le (5 kernel-free splits + 9 sub-family engine runs, |S| <= 10)",
+      "hErdos_le_eight_of_lt_threefortyeight (92-case threshold); minimal_hErdos_nine; hErdos_le_log_fails; record_setter_pattern_fails; record_index_eight_not_locally_unique",
+      "hErdos_seventytwo/eighty/eightyfour/ninetysix/onehundredeight/onehundredtwelve/onetwenty exact values in Erdos18WIP01.lean (with 5 new practicality lemmas + hErdos_onetwenty_le_four 9-coin sub-family chain)",
+      "index_four_floor_sixtyfour_octave theorem in Erdos18WIP01.lean"
     ],
     "insights": [
       "Erdos18Problem.lean stub developed: representability (IsRepresentable) and practicality (IsPractical) are DECIDABLE via a finite powerset search over the divisor set — a single decision procedure subsuming all future example checks; all lemmas axiom-free (plain kernel decide, no native_decide/Lean.ofReduceBool).",
@@ -129,13 +136,24 @@
       "hErdos 210 = 5 and hErdos 240 = 5 (unique hard targets 209/237): both previously-blocked d>12 exact values; 240 is the least number with 20 divisors yet ties 32 = 2^5",
       "Index-4 floor of [128,256) is exactly {168, 180} = doublings of 84, 90; the [64,128) floor {72,84,90,96,120,126} thins 6 -> 2 under doubling; 240/252 rises formalized, 144/192 Python-only",
       "hErdos 252 = 5: subadditive hErdos(2*126) <= 1+4 is TIGHT — doubling a floor member can cost the full unit (contrast 200 = 2*100 which drops)",
-      "180 tight upper needs a 12-coin chain (no <=11-coin sub-family covers at t=4, exhaustively checked); 2^12 x 180 decide fits maxHeartbeats 3200000"
+      "180 tight upper needs a 12-coin chain (no <=11-coin sub-family covers at t=4, exhaustively checked); 2^12 x 180 decide fits maxHeartbeats 3200000",
+      "T=9 BREAKS THE PATTERN: minimal_hErdos_nine = 348 = 2^2*3*29 < 512 = 2^9 — first non-power-of-two record-setter; hErdos 348 = 9",
+      "Refuted (now theorems): hErdos_le_log_fails — hErdos m <= log2 m is FALSE for practical m (348: 9 > 8); record_setter_pattern_fails — 2^t is not the record-setter for all t",
+      "Mechanism: 348 = 12*29 with 29 = sigma(12)+1 exactly (Stewart-extremal); divisors = D(12) ∪ 29*D(12); unique hard target 347 ≡ 28 (mod 29) forces all 6 prefix divisors + 3 of the 29-layer = 9",
+      "Local uniqueness fails again at t=8: 272 = 2^4*17 and 304 = 2^4*19 tie index 8 — near-doubling 9-chains (17,19 ≈ 16), the structural neighbours of 2^8",
+      "Shared-coverage pattern: one standalone 'cover' decide theorem feeds BOTH isPractical_of_witnesses_from and hErdos_le_of_witnesses_from — practicality never pays the full 2^d powerset",
+      "Growth envelope re-homed: with log2 m dead, question becomes hErdos <= C*log m? Iterating Stewart-extremal m -> m*(sigma(m)+1) may push C; Python sweep to 1e5 is the next cheap probe",
+      "Octave [64,128) fully pinned: all 15 practicals have exact hErdos values (6 floor members at 4; 66/80/108/112 at 5; 64/78/88/100/104 at 6); 80 and 108 have unique hard targets 79 and 107 (both m-1)",
+      "index_four_floor_sixtyfour_octave: the index-4 floor {72,84,90,96,120,126} of [64,128) is now a theorem (interval_cases + decide refutation of non-practicals + 15 value lemmas)",
+      "Python correction: hErdos 40 = 4, not 5 (t=6 session only pinned the subadditive upper). [32,64) floor = {36,40,42,48,54,60}, six members; floor cascade 6 -> 6 -> 2 across three octaves",
+      "[64,128) floor structure: doublings of [32,64) floor members that stay (72,84,96,120) plus practically-unsplittable 90,126; risers 80=2*40, 108=2*54; unique zero-cost off-floor doubling 112=2*56"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "t = 8 rung: sweep [128, 256) (~21 practicals) with the split-vs-engine dichotomy; count practically-unsplittable numbers first",
-      "Octave index-6 census: are 78/88/100/104 the only ties in (64,128)? Needs engine uppers for 80, 112 (cheap) and 120 (d=16 - build a witness-list engine: explicit per-target witness lists, O(m) decide instead of O(m*2^d))",
-      "Exact values for 40, 56, 60 (cheap hard-target lower bounds)",
+      "t = 10 rung: Python census first — where is the least index-10 practical? Candidates: Stewart-extremal m = q*(sigma(q)+1) for practical q; compute, do not guess",
+      "Growth envelope: with hErdos <= log2 m refuted, probe hErdos <= C*log m by iterating the Stewart-extremal construction (Python sweep to 1e5) before formalizing",
+      "[32,64) floor-cascade completion (exact values already there; floor theorem for {36,40,42,48,54,60} would make the 6->6->2 cascade fully formal)",
+      "[128,256) octave exact-value completion: remaining d<=12 targets cheap via graded-slice lowers; 132/144/192/216 need tight uppers first",
       "Investigate gap-type vs dense-type dichotomy as a theorem: does a divisor-ratio gap > 2 above the prefix force index >= prefix-length-based bound?"
     ],
     "markdown": "# Knowledge Base: erdos-18-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"

--- a/src/data/research/problems/erdos-18-wip-01.json
+++ b/src/data/research/problems/erdos-18-wip-01.json
@@ -35,7 +35,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: record-setter sequence 2^t proved for t=1..8 (minimal_hErdos_two..eight, all 0-axiom); STRUCTURAL: local uniqueness of the record returns at t=7 (128 alone below 256) after failing at t=6; new sub-family upper engine hErdos_le_of_witnesses_from unblocks d(210)=16/d(240)=20; next rung t=9 needs [256,512) sweep with unsplittable census first",
+    "progressSummary": "PROGRESS: restricted lower engine (graded powersetCard slices, C(d,<t) vs 2^d) closes last session's blocker; exact values hErdos 168=4, 180=4 (octave floor), 210=5, 240=5 (blocked pair), 252=5 all 0-axiom. Record sequence 2^t for t=1..8 unchanged; t=9 rung and octave exact-value completion now fully unblocked.",
     "builtItems": [
       "decidableIsRepresentable / decidableIsPractical instances (Erdos18Problem.lean)",
       "zero_isRepresentable, one_isRepresentable, isRepresentable_self, isRepresentable_le_sigma, mem_divisors_le (Erdos18Problem.lean)",
@@ -79,7 +79,10 @@
       "24 octave upper bounds hErdos_onethirtytwo_le .. hErdos_twofiftytwo_le (7 subadditive splits + 17 tight sub-family engine runs) in Erdos18WIP01.lean",
       "hErdos_le_six_of_lt_twofiftysix_of_ne + hErdos_le_seven_of_lt_twofiftysix (octave thresholds, 128-case interval_cases sweep) in Erdos18WIP01.lean",
       "minimal_hErdos_eight : IsLeast {m | IsPractical m and hErdos m = 8} 256 in Erdos18WIP01.lean",
-      "record_index_seven_locally_unique + twofiftysix_practical + hErdos_twofiftysix in Erdos18WIP01.lean"
+      "record_index_seven_locally_unique + twofiftysix_practical + hErdos_twofiftysix in Erdos18WIP01.lean",
+      "le_repLength_of_no_small_subset / le_hErdos_of_no_small_subset (restricted lower engine, graded powersetCard slices) in Erdos18WIP01.lean",
+      "hErdos_twohundredten (=5), hErdos_twoforty (=5), hErdos_onesixtyeight (=4), hErdos_oneeighty (=4), hErdos_twofiftytwo (=5) exact values + lower bounds + tight uppers hErdos_onesixtyeight_le_four / hErdos_oneeighty_le_four",
+      "Practicality lemmas: onetwenty_practical, twoforty_practical, eightyfour_practical, onesixtyeight_practical, oneeighty_practical, twofiftytwo_practical"
     ],
     "insights": [
       "Erdos18Problem.lean stub developed: representability (IsRepresentable) and practicality (IsPractical) are DECIDABLE via a finite powerset search over the divisor set — a single decision procedure subsuming all future example checks; all lemmas axiom-free (plain kernel decide, no native_decide/Lean.ofReduceBool).",
@@ -121,7 +124,12 @@
       "Octave [128,256) census: 25 practicals; 15 fall to the 2*m-prime split, 10 practically-unsplittable (140,150,162,196,198,204,210,220,228,234); 7 splittable ones still need the engine for tight bounds because the crude split lands at 7",
       "Sub-family engine unblocks large divisor counts: d(210)=16 and d(240)=20 make the full-powerset witness decide infeasible, but greedy-pruned coin chains of 8-11 divisors certify the tight bound at 2^8..2^11 subsets; sub-families found by Python min-card DP with random-restart greedy pruning",
       "No restricted LOWER engine is possible by the same trick: an upper bound needs one witness family, a lower bound must search ALL of divisors m, so exact values for d>12 numbers in [128,256) stay open",
-      "Threshold decide depth scales linearly with octave top: maxRecDepth 40000 for (32,64), 80000 for (64,128), 200000 for (128,256)"
+      "Threshold decide depth scales linearly with octave top: maxRecDepth 40000 for (32,64), 80000 for (64,128), 200000 for (128,256)",
+      "Restricted lower engine: t <= repLength m k needs only refutation of witnesses of card < t — graded powersetCard slices cost C(d,<t) not 2^d (240: 6196 vs 1048576 subsets); soundness = repLength_spec' attainment",
+      "hErdos 210 = 5 and hErdos 240 = 5 (unique hard targets 209/237): both previously-blocked d>12 exact values; 240 is the least number with 20 divisors yet ties 32 = 2^5",
+      "Index-4 floor of [128,256) is exactly {168, 180} = doublings of 84, 90; the [64,128) floor {72,84,90,96,120,126} thins 6 -> 2 under doubling; 240/252 rises formalized, 144/192 Python-only",
+      "hErdos 252 = 5: subadditive hErdos(2*126) <= 1+4 is TIGHT — doubling a floor member can cost the full unit (contrast 200 = 2*100 which drops)",
+      "180 tight upper needs a 12-coin chain (no <=11-coin sub-family covers at t=4, exhaustively checked); 2^12 x 180 decide fits maxHeartbeats 3200000"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Salvage: two stranded overnight erdos-18 sessions — octave close-out + t=9 record-setter 348 (pattern break)

**Problem**: `erdos-18-wip-01` (Erdős #18: fewest-divisors index `hErdos` on practical numbers).

### Context: stranded work recovered

Two overnight sessions (2026-07-24 ~00:15–00:30) pushed substantial results to branches `research/erdos18-lower-engine` and `research/erdos18-t9-record-348` but died before PR'ing (uncommitted tracker debris left in their worktrees; claims expired). This PR salvages both onto one branch off current main, resolves the EOF-append conflict between them (no declaration overlap), and fixes the verification gap that likely killed the t=9 session: its engine decides ran out of the default 200000-heartbeat elaboration budget — fixed with a section-scoped `set_option maxHeartbeats 1600000` (kernel evaluation unaffected).

### Mathematical content (~810 new lines, all 0-axiom/0-sorry)

**Lower-engine session** (3 commits):
- `le_repLength_of_no_small_subset` / `le_hErdos_of_no_small_subset` — the **restricted lower engine**: kernel-decide lower bounds at high divisor counts
- Exact values `hErdos 168 = 180 = 4`, `hErdos 210 = 240 = 252 = 5`
- **Octave [64,128) closed out**: 7 exact values + the index-4 floor theorem

**t=9 session** (1 commit) — the headline result:
- **`minimal_hErdos_nine`: the t=9 record-setter is `348 = 2²·3·29`, NOT `2⁹ = 512`** — the powers-of-two pattern `2,4,8,…,256` breaks at t=9
- **`hErdos_le_log_fails`**: the conjectured bound `hErdos m ≤ log₂ m` for practical `m` is FALSE (`hErdos 348 = 9 > 8 = ⌊log₂ 348⌋`) — settles the open question recorded in the file's section comments, negatively
- `record_setter_pattern_fails`, threshold `hErdos_le_eight_of_lt_threefortyeight`, ~20 exact/upper values in (256, 348], plus `isPractical_of_witnesses_from` (witness-cover practicality engine)

### Verification

- Host `lake env lean`: exit 0 (pinned v4.31)
- Docker: `./proofs/scripts/docker-build.sh Proofs.Erdos18WIP01` — **success** (8577 jobs, 0 sorry warnings)
- File remains 0-axiom; all decides are kernel (`decide`), no `native_decide`

### Salvage notes

- Original commits preserved with authorship/dates (cherry-pick); two follow-up commits add only the `maxHeartbeats` raises
- The stranded sessions' uncommitted tracker edits in their worktrees were NOT touched (other agents' territory); knowledge DB updated instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)
