### PR TITLE
Research: szemeredi-regularity-oq-04 - S27b-i: block-family iteration of the ambient equitable re-cut (docker-verified)

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04Iterate.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Iterate.lean
@@ -1,0 +1,235 @@
+/-
+  Szemerédi Regularity OQ04 — S27b-i: block-family iteration of the ambient re-cut
+
+  S27a (`SzemerediRegularityOQ04Surgery.lean`) produced the per-block brick
+  `exists_equitable_recut_within`: one fiber `S ⊆ Q₀` of an ambient family gets
+  re-cut in place to exact sizes {m, m+1} at ambient energy cost
+  `2·|S|·m/n + 2·m²/n`, without moving any vertex across blocks.
+
+  The Chain oracle's successor must be re-equitized over EVERY coarse block of
+  `Vparts` simultaneously.  This file supplies that iteration:
+
+  * `exists_equitable_recut_blocks` — Finset induction over a pairwise-disjoint
+    block family `T`.  Given the per-block fiber mass floor `m² ≤ |⋃ fiber(A)|`,
+    the ambient family `Q₀` is rebuilt so that every piece lying inside a block
+    of `T` has size in {m, m+1}, pieces outside the `T`-blocks are untouched
+    (fiber preservation), ground set and pairwise disjointness survive, and the
+    total ambient energy loss telescopes to
+    `∑_{A ∈ T} (2·|fiber(A)|·m/n + 2·m²/n)`.
+    The induction invariant that makes the iteration compose: processing block
+    `A` only touches pieces contained in `A`, so the fibers of the remaining
+    (pairwise-disjoint) blocks are preserved *as Finsets*, keeping both their
+    mass floors and their cost terms anchored to the ORIGINAL family `Q₀`.
+
+  * `sum_fiber_card_le` / `recut_blocks_cost_le` — bookkeeping: distinct blocks
+    have disjoint fibers (pieces are nonempty), so the summed fiber cost is at
+    most `2·|Q₀|·m/n + 2·|T|·m²/n` — the `2|q'|m/n + 2|Vparts|m²/n` budget of
+    the S27 plan.
+
+  S27b-ii residual (next session): apply this to the bare-split successor of
+  `exists_energy_next_of_not_afksFineRegular` (blocks `T = Vparts`, fibers of
+  the refining successor), choose parameters so the loss stays below a retained
+  fraction of the `ε⁴m²/n²` energy gain, and feed the resulting maintaining
+  oracle into `exists_afksTwoLevel_of_maintained_oracle`.
+
+  All results are fully machine-checked (0 axioms, 0 sorries).
+
+  Reference: Alon–Fischer–Krivelevich–Szegedy, "Efficient testing of large
+  graphs", Combinatorica 20 (2000); Komlós–Simonovits (1996).
+-/
+import Mathlib
+import Proofs.SzemerediRegularityOQ04Surgery
+
+namespace Szemeredi.RegularityOQ04Iterate
+
+open Szemeredi.Core Szemeredi.Regularity Szemeredi.RegularityOQ04Energy
+open Szemeredi.RegularityOQ04Bridge Szemeredi.RegularityOQ04MergeLoss
+open Szemeredi.RegularityOQ04Recut Szemeredi.RegularityOQ04Absorb
+open Szemeredi.RegularityOQ04ChopRefine Szemeredi.RegularityOQ04FullRefine
+open Szemeredi.RegularityOQ04Surgery
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- **Block-family iteration of the ambient equitable re-cut (S27b-i).**
+
+Let `T` be a pairwise-disjoint family of coarse blocks and `Q₀` a
+pairwise-disjoint ambient family with nonempty pieces, such that the fiber of
+every block `A ∈ T` (the pieces of `Q₀` contained in `A`) has ground mass at
+least `m²`.  Then `Q₀` can be rebuilt into `Q₁` with:
+
+* the same ground set and pairwise disjointness, all pieces nonempty;
+* every piece inside a block of `T` has size `m` or `m + 1`;
+* the fiber of any set disjoint from all `T`-blocks is untouched
+  (in particular pieces outside `⋃ T` survive verbatim);
+* ambient energy loss at most `∑_{A ∈ T} (2·|fiber(A)|·m/n + 2·m²/n)`,
+  every cost term anchored to the ORIGINAL fibers of `Q₀`.
+
+Each step applies `exists_equitable_recut_within` to the (preserved) fiber of
+the next block; disjointness of the blocks and nonemptiness of the pieces are
+what keep the untouched fibers frozen. -/
+theorem exists_equitable_recut_blocks (G : SimpleGraph V) [DecidableRel G.Adj]
+    (m : ℕ) (hm : 1 ≤ m) (T Q₀ : Finset (Finset V))
+    (hTdisj : (↑T : Set (Finset V)).PairwiseDisjoint id)
+    (hQdisj : (↑Q₀ : Set (Finset V)).PairwiseDisjoint id)
+    (hQne : ∀ c ∈ Q₀, c.Nonempty)
+    (hfloor : ∀ A ∈ T, m * m ≤ ((Q₀.filter (· ⊆ A)).biUnion id).card) :
+    ∃ Q₁ : Finset (Finset V),
+      Q₁.biUnion id = Q₀.biUnion id ∧
+      (↑Q₁ : Set (Finset V)).PairwiseDisjoint id ∧
+      (∀ c ∈ Q₁, c.Nonempty) ∧
+      (∀ A ∈ T, ∀ c ∈ Q₁, c ⊆ A → (c.card = m ∨ c.card = m + 1)) ∧
+      (∀ B : Finset V, (∀ A ∈ T, Disjoint A B) →
+          Q₁.filter (· ⊆ B) = Q₀.filter (· ⊆ B)) ∧
+      partitionEnergy G Q₀ -
+          ∑ A ∈ T, (2 * ((Q₀.filter (· ⊆ A)).card * m : ℚ) / (Fintype.card V : ℚ)
+            + 2 * (m * m : ℚ) / (Fintype.card V : ℚ)) ≤
+        partitionEnergy G Q₁ := by
+  classical
+  revert hTdisj hfloor
+  induction T using Finset.induction_on with
+  | empty =>
+      intro _ _
+      refine ⟨Q₀, rfl, hQdisj, hQne, ?_, fun B _ => rfl, by simp⟩
+      intro A hA
+      exact absurd hA (by simp)
+  | @insert A T' hA ih =>
+      intro hTdisj hfloor
+      have hsubT' : (↑T' : Set (Finset V)) ⊆ (↑(insert A T') : Set (Finset V)) :=
+        Finset.coe_subset.mpr (Finset.subset_insert A T')
+      obtain ⟨Q', hQ'cov, hQ'disj, hQ'ne, hQ'sized, hQ'fib, hQ'pe⟩ :=
+        ih (hTdisj.subset hsubT')
+          (fun A' hA' => hfloor A' (Finset.mem_insert_of_mem hA'))
+      -- `A` is disjoint from every block of `T'`
+      have hAdisjT' : ∀ A' ∈ T', Disjoint A' A := by
+        intro A' hA'
+        have hne : A' ≠ A := by
+          intro h
+          exact hA (h ▸ hA')
+        have := hTdisj (Finset.mem_coe.mpr (Finset.mem_insert_of_mem hA'))
+          (Finset.mem_coe.mpr (Finset.mem_insert_self A T')) hne
+        simpa [Function.onFun] using this
+      -- the fiber of `A` in `Q'` is untouched, so its floor and cost transfer
+      have hfibA : Q'.filter (· ⊆ A) = Q₀.filter (· ⊆ A) := hQ'fib A hAdisjT'
+      have hground : m * m ≤ ((Q'.filter (· ⊆ A)).biUnion id).card := by
+        rw [hfibA]
+        exact hfloor A (Finset.mem_insert_self A T')
+      obtain ⟨R, hRcov, hRsize, hcov, hdisj₂, hpe₂⟩ :=
+        exists_equitable_recut_within G m hm Q' (Q'.filter (· ⊆ A))
+          (Finset.filter_subset _ _) hQ'disj hground
+      -- pieces of `R` live inside `A` and are nonempty
+      have hSA : (Q'.filter (· ⊆ A)).biUnion id ⊆ A :=
+        Finset.biUnion_subset.mpr (fun c hc => (Finset.mem_filter.mp hc).2)
+      have hRunion_A : R.biUnion id ⊆ A := by
+        rw [hRcov]
+        exact hSA
+      have hR_in_A : ∀ c ∈ R, c ⊆ A := fun c hc =>
+        (Finset.subset_biUnion_of_mem id hc).trans hRunion_A
+      have hRne : ∀ c ∈ R, c.Nonempty := by
+        intro c hc
+        have hpos : 0 < c.card := by
+          rcases hRsize c hc with h | h <;> omega
+        exact Finset.card_pos.mp hpos
+      refine ⟨(Q' \ Q'.filter (· ⊆ A)) ∪ R, ?_, hdisj₂, ?_, ?_, ?_, ?_⟩
+      · rw [hcov]
+        exact hQ'cov
+      · intro c hc
+        rcases Finset.mem_union.mp hc with h | h
+        · exact hQ'ne c (Finset.mem_sdiff.mp h).1
+        · exact hRne c h
+      · intro A' hA' c hc hcA'
+        rcases Finset.mem_insert.mp hA' with rfl | hA'mem
+        · -- `A' = A`: survivors of `Q'` inside `A` would have been in the fiber
+          rcases Finset.mem_union.mp hc with h | h
+          · exact absurd (Finset.mem_filter.mpr ⟨(Finset.mem_sdiff.mp h).1, hcA'⟩)
+              (Finset.mem_sdiff.mp h).2
+          · exact hRsize c h
+        · rcases Finset.mem_union.mp hc with h | h
+          · exact hQ'sized A' hA'mem c (Finset.mem_sdiff.mp h).1 hcA'
+          · -- a piece of `R` sits inside `A`, hence not inside the disjoint `A'`
+            obtain ⟨x, hx⟩ := hRne c h
+            exact absurd (hcA' hx)
+              (Finset.disjoint_right.mp (hAdisjT' A' hA'mem) (hR_in_A c h hx))
+      · intro B hB
+        have hAB : Disjoint A B := hB A (Finset.mem_insert_self A T')
+        have hB' : Q'.filter (· ⊆ B) = Q₀.filter (· ⊆ B) :=
+          hQ'fib B (fun A' hA' => hB A' (Finset.mem_insert_of_mem hA'))
+        rw [← hB']
+        ext c
+        simp only [Finset.mem_filter, Finset.mem_union, Finset.mem_sdiff]
+        constructor
+        · rintro ⟨h | h, hcB⟩
+          · exact ⟨h.1, hcB⟩
+          · obtain ⟨x, hx⟩ := hRne c h
+            exact absurd (hcB hx) (Finset.disjoint_left.mp hAB (hR_in_A c h hx))
+        · rintro ⟨hcQ', hcB⟩
+          refine ⟨Or.inl ⟨hcQ', ?_⟩, hcB⟩
+          rintro ⟨-, hcA⟩
+          obtain ⟨x, hx⟩ := hQ'ne c hcQ'
+          exact absurd (hcB hx) (Finset.disjoint_left.mp hAB (hcA hx))
+      · rw [Finset.sum_insert hA]
+        rw [show ((Q'.filter (· ⊆ A)).card : ℚ) = ((Q₀.filter (· ⊆ A)).card : ℚ) from
+          by rw [hfibA]] at hpe₂
+        linarith [hQ'pe, hpe₂]
+
+/-- **Disjoint blocks have disjoint fibers.**  Since pieces are nonempty and
+the blocks of `T` are pairwise disjoint, a piece of `Q₀` lies in the fiber of
+at most one block, so the fiber cardinalities sum to at most `|Q₀|`. -/
+theorem sum_fiber_card_le (T Q₀ : Finset (Finset V))
+    (hTdisj : (↑T : Set (Finset V)).PairwiseDisjoint id)
+    (hQne : ∀ c ∈ Q₀, c.Nonempty) :
+    ∑ A ∈ T, (Q₀.filter (· ⊆ A)).card ≤ Q₀.card := by
+  classical
+  have hdisj : ∀ A ∈ T, ∀ A' ∈ T, A ≠ A' →
+      Disjoint (Q₀.filter (· ⊆ A)) (Q₀.filter (· ⊆ A')) := by
+    intro A hAmem A' hA'mem hne
+    rw [Finset.disjoint_left]
+    intro c hc hc'
+    have hcA : c ⊆ A := (Finset.mem_filter.mp hc).2
+    have hcA' : c ⊆ A' := (Finset.mem_filter.mp hc').2
+    obtain ⟨x, hx⟩ := hQne c (Finset.mem_filter.mp hc).1
+    have hd : Disjoint A A' := by
+      have := hTdisj (Finset.mem_coe.mpr hAmem) (Finset.mem_coe.mpr hA'mem) hne
+      simpa [Function.onFun] using this
+    exact absurd (hcA' hx) (Finset.disjoint_left.mp hd (hcA hx))
+  calc ∑ A ∈ T, (Q₀.filter (· ⊆ A)).card
+      = (T.biUnion (fun A => Q₀.filter (· ⊆ A))).card := (Finset.card_biUnion hdisj).symm
+    _ ≤ Q₀.card := Finset.card_le_card (Finset.biUnion_subset.mpr
+        (fun A _ => Finset.filter_subset _ _))
+
+/-- **Total cost budget (S27b-i bookkeeping).**  The summed per-block cost of
+`exists_equitable_recut_blocks` is at most `2·|Q₀|·m/n + 2·|T|·m²/n` — the
+`2|q'|m/n + 2|Vparts|m²/n` budget of the S27 plan. -/
+theorem recut_blocks_cost_le (m : ℕ) (T Q₀ : Finset (Finset V))
+    (hTdisj : (↑T : Set (Finset V)).PairwiseDisjoint id)
+    (hQne : ∀ c ∈ Q₀, c.Nonempty) :
+    ∑ A ∈ T, (2 * ((Q₀.filter (· ⊆ A)).card * m : ℚ) / (Fintype.card V : ℚ)
+        + 2 * (m * m : ℚ) / (Fintype.card V : ℚ)) ≤
+      2 * (Q₀.card * m : ℚ) / (Fintype.card V : ℚ)
+        + 2 * (T.card * (m * m) : ℚ) / (Fintype.card V : ℚ) := by
+  classical
+  have hsumQ : (∑ A ∈ T, ((Q₀.filter (· ⊆ A)).card : ℚ)) ≤ (Q₀.card : ℚ) := by
+    exact_mod_cast sum_fiber_card_le T Q₀ hTdisj hQne
+  rw [Finset.sum_add_distrib]
+  have h1 : ∑ A ∈ T, 2 * (((Q₀.filter (· ⊆ A)).card : ℚ) * m) / (Fintype.card V : ℚ)
+      ≤ 2 * ((Q₀.card : ℚ) * m) / (Fintype.card V : ℚ) := by
+    have hterm : ∀ A : Finset V,
+        2 * (((Q₀.filter (· ⊆ A)).card : ℚ) * m) / (Fintype.card V : ℚ)
+          = ((Q₀.filter (· ⊆ A)).card : ℚ) * (2 * (m : ℚ) / (Fintype.card V : ℚ)) := by
+      intro A
+      ring
+    simp only [hterm]
+    rw [← Finset.sum_mul]
+    have h2m : (0 : ℚ) ≤ 2 * (m : ℚ) / (Fintype.card V : ℚ) := by positivity
+    calc (∑ A ∈ T, ((Q₀.filter (· ⊆ A)).card : ℚ))
+          * (2 * (m : ℚ) / (Fintype.card V : ℚ))
+        ≤ (Q₀.card : ℚ) * (2 * (m : ℚ) / (Fintype.card V : ℚ)) :=
+          mul_le_mul_of_nonneg_right hsumQ h2m
+      _ = 2 * ((Q₀.card : ℚ) * m) / (Fintype.card V : ℚ) := by ring
+  have h2 : (∑ _A ∈ T, 2 * (m * m : ℚ) / (Fintype.card V : ℚ))
+      = 2 * ((T.card : ℚ) * ((m : ℚ) * m)) / (Fintype.card V : ℚ) := by
+    rw [Finset.sum_const, nsmul_eq_mul]
+    ring
+  rw [h2]
+  exact add_le_add h1 le_rfl
+
+end Szemeredi.RegularityOQ04Iterate

--- a/proofs/Proofs/SzemerediRegularityOQ04Iterate.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Iterate.lean
@@ -171,6 +171,7 @@ theorem exists_equitable_recut_blocks (G : SimpleGraph V) [DecidableRel G.Adj]
           by rw [hfibA]] at hpe₂
         linarith [hQ'pe, hpe₂]
 
+omit [Fintype V] in
 /-- **Disjoint blocks have disjoint fibers.**  Since pieces are nonempty and
 the blocks of `T` are pairwise disjoint, a piece of `Q₀` lies in the fiber of
 at most one block, so the fiber cardinalities sum to at most `|Q₀|`. -/

--- a/research/problems/szemeredi-regularity-oq-04/knowledge.md
+++ b/research/problems/szemeredi-regularity-oq-04/knowledge.md
@@ -1222,3 +1222,26 @@ hypothesis at all (`exists_afksTwoLevel_of_maintained_oracle_unit`).
 - `research/problems/szemeredi-regularity-oq-04/{state.md,knowledge.md}`
 - `src/data/research/problems/szemeredi-regularity-oq-04.json` (leanFiles += ChopRefine
   [omitted by S23], MergeLoss; currentState S24)
+
+## Session 2026-07-24 (researcher-1) — S27b-i block-family iteration
+
+**Route: Finset induction with fiber-preservation invariant.**
+
+- `exists_equitable_recut_blocks` (SzemerediRegularityOQ04Iterate.lean): iterate S27a's
+  `exists_equitable_recut_within` over a pairwise-disjoint block family T. Invariant that
+  makes it compose: fibers of untouched blocks preserved AS FINSETS (not just ground sets)
+  — proved from piece-nonemptiness + block-disjointness (a piece inside two disjoint
+  blocks would be empty). Costs stay anchored to Q₀'s original fibers, telescoping to
+  Σ_A (2|fiber(A)|m/n + 2m²/n).
+- `sum_fiber_card_le`: disjoint blocks ⟹ disjoint fibers ⟹ Σ|fiber| ≤ |Q₀| via
+  `Finset.card_biUnion`. `recut_blocks_cost_le`: total ≤ 2|Q₀|m/n + 2|T|m²/n
+  (junk-safe: factor per-term with `ring`, `Finset.sum_mul`, `mul_le_mul_of_nonneg_right`).
+- ★Gotcha: in the energy step, rw the CARD-CAST equality
+  `((Q'.filter (·⊆A)).card : ℚ) = ((Q₀.filter (·⊆A)).card : ℚ)` into hpe₂ — rewriting the
+  raw Finset equation hfibA would also rewrite the family expression `(Q' \ Q'.filter …) ∪ R`
+  in hpe₂'s conclusion and desync it from the goal.
+- Docker 8589 jobs GREEN first-try; lint `omit [Fintype V] in` before docstring.
+
+**Residual = S27b-ii only** (assembly): T = Vparts on the bare-split successor, per-block
+m² floors from the maintained invariant, parameter choice loss < retained ε⁴m²/n² fraction,
+into `exists_afksTwoLevel_of_maintained_oracle`.

--- a/src/data/research/problems/szemeredi-regularity-oq-04.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-04.json
@@ -112,7 +112,8 @@
       "S26: exists_equitable_recut_absorbed + prime variant (S25+absorption capstone: all sizes in {m,m+1}, cost 2|P|m/n + 2m^2/n)",
       "S27a SzemerediRegularityOQ04Surgery.lean: exists_absorb_deficient_within (in-place absorption, ambient loss <= 2m^2/n)",
       "S27a: exists_chop_refinement_within (fiber chop as ambient refinement, zero loss)",
-      "S27a: exists_equitable_recut_within (per-block brick: fiber -> exact {m,m+1} in place, ambient cost 2|S|m/n + 2m^2/n)"
+      "S27a: exists_equitable_recut_within (per-block brick: fiber -> exact {m,m+1} in place, ambient cost 2|S|m/n + 2m^2/n)",
+      "SzemerediRegularityOQ04Iterate.lean: exists_equitable_recut_blocks + sum_fiber_card_le + recut_blocks_cost_le (3 thm, 0 axioms, 0 sorries, docker 8589 jobs first-try)"
     ],
     "insights": [
       "The complement pieces A2=A\\A1, B2=B\\B1 of the AFKS sharp 2x2 split are NOT both forced nonempty by the analytic data: the density gap only forbids BOTH being empty (S16). When one corner exhausts its block (A1=A) the honest refinement is the asymmetric 3-piece split {A,B1,B2}; the 4-piece IsWitnessedSharpStep shape (S14 isWitnessedSharpStep_of_split_of_gap) requires an asymmetric-step packaging for that degenerate branch, not a further nonemptiness lemma.",
@@ -167,11 +168,12 @@
       "Lean gotcha: fun v => insert (v : V) ((e v : Finset V)) type-ascribes the BINDER to V breaking the attach subtype; use .1 projections (insert v.1 (e v).1). Also subset_union_left needs explicit (s2 := New) when the superfamily is only determined by the replace-lemma conclusion",
       "S27a ambient surgery: the fiber energy is NOT a summand of ambient energy (cross-block pairs), so per-block re-equitization must be stated on the AMBIENT family; chopping only the fiber IS an ambient refinement (refine_mono with trivial cells {A} outside the fiber), and pool/absorb are S24 replacements with small mass - the whole S25/S26 pipeline transfers in-place",
       "The untouched ambient part identity A2 \\\\ R1 = Q0 \\\\ S needs fiber pieces nonempty + contained in the fiber ground set: an old piece equal to a fiber piece would be a nonempty subset of U S yet disjoint from every member of S",
-      "Lean: Finset.union_biUnion (NOT biUnion_union, which is pointwise) distributes biUnion over family union; after simp [mem_sdiff] in an ext goal both sides unfold to conjunctions - return mem_sdiff.mp h directly"
+      "Lean: Finset.union_biUnion (NOT biUnion_union, which is pointwise) distributes biUnion over family union; after simp [mem_sdiff] in an ext goal both sides unfold to conjunctions - return mem_sdiff.mp h directly",
+      "S27b-i (researcher-1, 2026-07-24): block-family iteration DONE in new SzemerediRegularityOQ04Iterate.lean. exists_equitable_recut_blocks — Finset.induction_on over disjoint blocks T; the composable invariant is FIBER PRESERVATION AS FINSETS (Q1.filter (⊆B) = Q0.filter (⊆B) for B disjoint from all processed blocks), which keeps both the m² floors and the cost terms anchored to the ORIGINAL family, so costs telescope to Σ_A (2|fiber(A)|m/n + 2m²/n). recut_blocks_cost_le bounds the sum by 2|Q0|m/n + 2|T|m²/n via disjoint-fibers card_biUnion. Key trick: rw the CARD-CAST equation (not the raw fiber equation) into the step inequality — rewriting the fiber Finset equation would also rewrite the family expression in the conclusion."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Construct the recursive refinement chain realizing the S17 case split as witnessed steps (freshness + equitable mass floors discharged) — the remaining input to exists_afksTwoLevel_of_dichotomy_both."
+      "S27b-ii (final assembly): apply exists_equitable_recut_blocks to the bare-split successor of exists_energy_next_of_not_afksFineRegular with T = Vparts (per-block floor m² ≤ |block| from the maintained invariant), bound total loss via recut_blocks_cost_le, choose parameters so 2|q′|m/n + 2|Vparts|m²/n stays below a retained fraction of the ε⁴m²/n² gain, and feed the maintaining oracle into exists_afksTwoLevel_of_maintained_oracle."
     ],
     "markdown": "# Knowledge Base: szemeredi-regularity-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n",
     "score": 63


### PR DESCRIPTION
## Summary
Research session for `szemeredi-regularity-oq-04` — S27b-i: block-family iteration of the S27a ambient re-cut (researcher-1's active vein).

## Progress
New file `proofs/Proofs/SzemerediRegularityOQ04Iterate.lean` (3 theorems, 0 axioms, 0 sorries, docker-verified 8589 jobs, first-try elaboration, lint-clean):

- `exists_equitable_recut_blocks` — Finset induction iterating S27a's `exists_equitable_recut_within` over a pairwise-disjoint block family `T`: every piece inside a `T`-block ends at size {m, m+1}, ground/disjointness/nonemptiness survive, and pieces outside the `T`-blocks are untouched. The invariant that makes the iteration compose is **fiber preservation as Finsets** (`Q₁.filter (· ⊆ B) = Q₀.filter (· ⊆ B)` for `B` disjoint from processed blocks), proved from piece-nonemptiness + block-disjointness; it keeps both the m² floors and the cost terms anchored to the original family, so the ambient energy loss telescopes to `∑_A (2·|fiber(A)|·m/n + 2·m²/n)`.
- `sum_fiber_card_le` — disjoint blocks have disjoint fibers, so `∑ |fiber| ≤ |Q₀|` (`Finset.card_biUnion`).
- `recut_blocks_cost_le` — total cost within the S27-plan budget `2|Q₀|m/n + 2|T|m²/n`.

Lean note for the file's knowledge base: in the energy step one must rewrite the **card-cast** equality into the step inequality rather than the raw fiber Finset equation — the latter also rewrites the successor-family expression and desyncs it from the goal.

## Files Modified
- `proofs/Proofs/SzemerediRegularityOQ04Iterate.lean` (new, ~230 lines)
- `src/data/research/problems/szemeredi-regularity-oq-04.json`
- `research/problems/szemeredi-regularity-oq-04/knowledge.md`

## Status
**Outcome**: progress (S27b-i done; the re-equitization engine is now fully block-parallel)
**Next Steps**: S27b-ii final assembly — apply with `T = Vparts` to the bare-split successor, per-block m² floors from the maintained invariant, parameter choice keeping `2|q′|m/n + 2|Vparts|m²/n` below a retained fraction of the ε⁴m²/n² gain, then `exists_afksTwoLevel_of_maintained_oracle` closes the two-level conclusion.

🤖 Generated by researcher-1
