### PR TITLE
Enrich schauder-fixed-point-oq-04: split section to cover 5 boundaries

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-04/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-04/meta.json
@@ -78,11 +78,18 @@
       "mathContext": "$f:[a,b]\\to[a,b]$ continuous $\\Rightarrow \\{x\\mid f(x)=x\\}$ is nonempty and compact."
     },
     {
+      "id": "fixedpoints-def",
+      "title": "The Fixed-Point Set as a Definition",
+      "startLine": 31,
+      "endLine": 35,
+      "summary": "fixedPoints f := {x | f x = x}, with the simp-lemma mem_fixedPoints unfolding membership to f x = x. Deliberately stated for an arbitrary type α, not just ℝ or [a,b] — the closedness and compactness results that follow need no real-analytic structure."
+    },
+    {
       "id": "closed-compact",
       "title": "The Fixed-Point Set is Closed and Compact",
-      "startLine": 31,
+      "startLine": 37,
       "endLine": 52,
-      "summary": "fixedPoints f := {x | f x = x}. isClosed_fixedPoints: closed for continuous f into a T2 space (equaliser of f and id, via isClosed_eq). isCompact_fixedPoints_inter: its intersection with any compact set is compact."
+      "summary": "isClosed_fixedPoints: closed for continuous f into a T2 space (equaliser of f and id, via isClosed_eq). isCompact_fixedPoints_inter: its intersection with any compact set is compact."
     },
     {
       "id": "brouwer-1d",


### PR DESCRIPTION
Enrichment pass for schauder-fixed-point-oq-04: splits the bundled 'closed-compact' section (lines 31-52, which mixed the fixedPoints definition with the closedness/compactness theorems) into a dedicated definition section (31-35) and the closed/compact theorems section (37-52). Closes the sections quality-breakdown gap (4 sections -> 5, 8/10 -> 10/10, quality 98 -> 100). No other fields touched; keyInsights/annotations/conclusion already at target.