### PR TITLE
Research: erdos-85-wip-01 — tight-point theorem f(k(k−1)+1) ≤ k for all k ≥ 3 (new values f(21) ≤ 5, f(31) ≤ 6)

### DIFF
--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -2845,4 +2845,212 @@ theorem minDegreeForC4_thirteen : minDegreeForC4 13 = 4 :=
 
 end Thirteen
 
+/-
+## Tight points: `f(k(k−1)+1) ≤ k` for every `k ≥ 3`
+
+The `f(13) ≤ 4` argument above is the `k = 4` instance of a uniform
+phenomenon.  At the projective-plane parameter `n = k(k−1)+1` the cherry
+double-count is *exactly* tight — `C(n,2) = n·C(k,2)` — so a `C₄`-free graph
+on `n` vertices with minimum degree `≥ k` would have to be `k`-regular with
+every vertex pair sharing exactly one common neighbour: a friendship graph,
+whose politician (friendship theorem) has degree `n − 1 = k(k−1) ≠ k`.
+
+This section parameterises the `Thirteen` section over `k`, producing
+infinitely many upper bounds one vertex beyond the counting range
+`n ≤ k(k−1)` of `minDegreeForC4_le_of_le_mul_pred` — including the new
+concrete values `f(21) ≤ 5` and `f(31) ≤ 6`, beyond the exact table
+`f(1..13)`.
+-/
+
+section TightPoints
+
+/-- **Exact tightness of the cherry count at the projective-plane parameter**:
+`C(k(k−1)+1, 2) = (k(k−1)+1) · C(k,2)`.  (Both `Nat.choose 2` halvings are
+exact because `k(k−1)` is even.) -/
+theorem choose_two_tight (k : ℕ) :
+    (k * (k - 1) + 1).choose 2 = (k * (k - 1) + 1) * k.choose 2 := by
+  rw [Nat.choose_two_right, Nat.add_sub_cancel,
+    Nat.mul_div_assoc _ (two_dvd_mul_pred k), Nat.choose_two_right]
+
+/-- **The tight-point theorem.**  Every graph on `k(k−1)+1` vertices with
+minimum degree `≥ k` (for `k ≥ 3`) contains a `4`-cycle.  Cherry-counting is
+exactly tight (`choose_two_tight`), so a `C₄`-free such graph would be
+`k`-regular with every vertex pair having exactly one common neighbour — a
+friendship graph; the friendship theorem's politician has degree
+`k(k−1) ≠ k`.  The `Thirteen` section's argument, uniformly in `k`. -/
+theorem containsC4_of_tight_minDegree {k : ℕ} (hk : 3 ≤ k)
+    (G : SimpleGraph (Fin (k * (k - 1) + 1))) [DecidableRel G.Adj]
+    (hmin : k ≤ G.minDegree) : containsC4 (Fin (k * (k - 1) + 1)) G := by
+  classical
+  by_contra hC4
+  -- The cherry Finset and the endpoint-pair target, exactly as in the
+  -- `Thirteen` section.
+  set C : Finset (Σ _ : Fin (k * (k - 1) + 1), Finset (Fin (k * (k - 1) + 1))) :=
+    univ.sigma (fun v => (G.neighborFinset v).powersetCard 2) with hC
+  set T : Finset (Finset (Fin (k * (k - 1) + 1))) :=
+    (univ : Finset (Fin (k * (k - 1) + 1))).powersetCard 2 with hT
+  have hCcard : C.card = ∑ v : Fin (k * (k - 1) + 1), (G.degree v).choose 2 := by
+    rw [hC, Finset.card_sigma]
+    exact Finset.sum_congr rfl fun v _ => by
+      rw [Finset.card_powersetCard, G.card_neighborFinset_eq_degree]
+  have hTcard : T.card = (k * (k - 1) + 1) * k.choose 2 := by
+    rw [hT, Finset.card_powersetCard, Finset.card_univ, Fintype.card_fin]
+    exact choose_two_tight k
+  have hmaps : ∀ p ∈ C, p.2 ∈ T := by
+    intro p hp
+    rw [hC, Finset.mem_sigma] at hp
+    rw [hT, Finset.mem_powersetCard]
+    exact ⟨Finset.subset_univ _, (Finset.mem_powersetCard.mp hp.2).2⟩
+  -- With no `C₄`, the endpoint pair DETERMINES the centre.
+  have hcentre : ∀ (v v' : Fin (k * (k - 1) + 1)) (e : Finset (Fin (k * (k - 1) + 1))),
+      (⟨v, e⟩ : Σ _ : Fin (k * (k - 1) + 1), Finset (Fin (k * (k - 1) + 1))) ∈ C →
+      (⟨v', e⟩ : Σ _ : Fin (k * (k - 1) + 1), Finset (Fin (k * (k - 1) + 1))) ∈ C →
+      v = v' := by
+    intro v v' e hp hq
+    by_contra hne
+    rw [hC, Finset.mem_sigma] at hp hq
+    obtain ⟨hsubv, hcard⟩ := Finset.mem_powersetCard.mp hp.2
+    obtain ⟨hsubv', -⟩ := Finset.mem_powersetCard.mp hq.2
+    obtain ⟨x, y, hxy, rfl⟩ := Finset.card_eq_two.mp hcard
+    have hvmem : v ∈ G.neighborFinset x ∩ G.neighborFinset y := by
+      rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset, SimpleGraph.mem_neighborFinset]
+      exact ⟨((G.mem_neighborFinset v x).mp (hsubv (by simp))).symm,
+             ((G.mem_neighborFinset v y).mp (hsubv (by simp))).symm⟩
+    have hv'mem : v' ∈ G.neighborFinset x ∩ G.neighborFinset y := by
+      rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset, SimpleGraph.mem_neighborFinset]
+      exact ⟨((G.mem_neighborFinset v' x).mp (hsubv' (by simp))).symm,
+             ((G.mem_neighborFinset v' y).mp (hsubv' (by simp))).symm⟩
+    have h2 : 1 < (G.neighborFinset x ∩ G.neighborFinset y).card :=
+      Finset.one_lt_card.mpr ⟨v, hvmem, v', hv'mem, hne⟩
+    have h1 := common_le_one_of_not_containsC4 hC4 x y hxy
+    omega
+  have hinj : ∀ p₁ p₂ : Σ _ : Fin (k * (k - 1) + 1), Finset (Fin (k * (k - 1) + 1)),
+      p₁ ∈ C → p₂ ∈ C → p₁.2 = p₂.2 → p₁ = p₂ := by
+    rintro ⟨v, e⟩ ⟨v', e'⟩ hp hq (heq : e = e')
+    subst heq
+    obtain rfl := hcentre v v' e hp hq
+    rfl
+  -- Injectivity ⟹ `|C| ≤ n·C(k,2)`.
+  have hCle : C.card ≤ (k * (k - 1) + 1) * k.choose 2 := by
+    rw [← hTcard]
+    exact Finset.card_le_card_of_injOn (fun p => p.2) hmaps
+      (fun p₁ h₁ p₂ h₂ h => hinj p₁ p₂ h₁ h₂ h)
+  -- Minimum degree ⟹ `|C| ≥ n·C(k,2)`.
+  have hterm : ∀ v : Fin (k * (k - 1) + 1), k.choose 2 ≤ (G.degree v).choose 2 :=
+    fun v => Nat.choose_le_choose 2 (le_trans hmin (G.minDegree_le_degree v))
+  have hCge : (k * (k - 1) + 1) * k.choose 2 ≤ C.card := by
+    rw [hCcard]
+    calc (k * (k - 1) + 1) * k.choose 2
+        = ∑ _v : Fin (k * (k - 1) + 1), k.choose 2 := by
+          rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, smul_eq_mul]
+      _ ≤ ∑ v : Fin (k * (k - 1) + 1), (G.degree v).choose 2 :=
+          Finset.sum_le_sum fun v _ => hterm v
+  -- Exact tightness ⟹ `k`-regularity.
+  have hsum : ∑ v : Fin (k * (k - 1) + 1), (G.degree v).choose 2
+      = (k * (k - 1) + 1) * k.choose 2 := by
+    rw [← hCcard]
+    omega
+  have hdegk : ∀ v : Fin (k * (k - 1) + 1), G.degree v = k := by
+    intro v
+    have hkle : k ≤ G.degree v := le_trans hmin (G.minDegree_le_degree v)
+    by_contra hne
+    have hk1 : k + 1 ≤ G.degree v := by omega
+    have hchoose : k.choose 2 + k ≤ (G.degree v).choose 2 := by
+      have hstep : (k + 1).choose 2 = k.choose 2 + k := by
+        rw [Nat.choose_succ_succ, Nat.choose_one_right, Nat.add_comm]
+      calc k.choose 2 + k = (k + 1).choose 2 := hstep.symm
+        _ ≤ (G.degree v).choose 2 := Nat.choose_le_choose 2 hk1
+    have hsplit : (G.degree v).choose 2 +
+        ∑ u ∈ univ.erase v, (G.degree u).choose 2
+          = ∑ u : Fin (k * (k - 1) + 1), (G.degree u).choose 2 :=
+      Finset.add_sum_erase univ (fun u => (G.degree u).choose 2) (Finset.mem_univ v)
+    have hrest : (k * (k - 1)) * k.choose 2 ≤
+        ∑ u ∈ univ.erase v, (G.degree u).choose 2 := by
+      calc (k * (k - 1)) * k.choose 2
+          = ∑ _u ∈ univ.erase v, k.choose 2 := by
+            rw [Finset.sum_const, Finset.card_erase_of_mem (Finset.mem_univ v),
+              Finset.card_univ, Fintype.card_fin, Nat.add_sub_cancel, smul_eq_mul]
+        _ ≤ ∑ u ∈ univ.erase v, (G.degree u).choose 2 :=
+            Finset.sum_le_sum fun u _ => hterm u
+    have hmul : (k * (k - 1) + 1) * k.choose 2
+        = (k * (k - 1)) * k.choose 2 + k.choose 2 := Nat.succ_mul _ _
+    omega
+  -- Exact tightness ⟹ surjectivity: every vertex pair has a common neighbour.
+  have hsurj := Finset.surj_on_of_inj_on_of_card_le
+    (s := C) (t := T) (fun p _ => p.2) (fun p hp => hmaps p hp)
+    (fun p₁ p₂ h₁ h₂ h => hinj p₁ p₂ h₁ h₂ h) (by omega)
+  -- The friendship condition.
+  have hfriend : Theorems100.Friendship G := by
+    intro x y hxy
+    have hxyT : ({x, y} : Finset (Fin (k * (k - 1) + 1))) ∈ T := by
+      rw [hT, Finset.mem_powersetCard]
+      exact ⟨Finset.subset_univ _, Finset.card_pair_eq_two_iff.mpr hxy⟩
+    obtain ⟨⟨v, e⟩, hpC, hpe⟩ := hsurj _ hxyT
+    have he : e = ({x, y} : Finset (Fin (k * (k - 1) + 1))) := hpe.symm
+    subst he
+    rw [hC, Finset.mem_sigma] at hpC
+    obtain ⟨-, hpow⟩ := hpC
+    have hsub := (Finset.mem_powersetCard.mp hpow).1
+    have hvx : G.Adj x v := ((G.mem_neighborFinset v x).mp (hsub (by simp))).symm
+    have hvy : G.Adj y v := ((G.mem_neighborFinset v y).mp (hsub (by simp))).symm
+    have hvmemS : v ∈ G.commonNeighbors x y := ⟨hvx, hvy⟩
+    -- Bridge the Classical/synthesized `Fintype` instance mismatch with
+    -- `convert`, exactly as in the `Thirteen` section.
+    have hone : Fintype.card
+        {w : Fin (k * (k - 1) + 1) // w ∈ G.commonNeighbors x y} = 1 := by
+      refine Fintype.card_eq_one_iff.mpr ⟨⟨v, hvmemS⟩, ?_⟩
+      rintro ⟨w, hw⟩
+      obtain ⟨hwx, hwy⟩ : G.Adj x w ∧ G.Adj y w := hw
+      have hcom := common_le_one_of_not_containsC4 hC4 x y hxy
+      have hwmem : w ∈ G.neighborFinset x ∩ G.neighborFinset y := by
+        rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset, SimpleGraph.mem_neighborFinset]
+        exact ⟨hwx, hwy⟩
+      have hvmem : v ∈ G.neighborFinset x ∩ G.neighborFinset y := by
+        rw [Finset.mem_inter, SimpleGraph.mem_neighborFinset, SimpleGraph.mem_neighborFinset]
+        exact ⟨hvx, hvy⟩
+      exact Subtype.ext (Finset.card_le_one.mp hcom w hwmem v hvmem)
+    convert hone using 2
+  -- The friendship theorem: a politician exists — degree `k(k−1)`, not `k`.
+  obtain ⟨v, hv⟩ := Theorems100.friendship_theorem hfriend
+  have hdegBig : G.degree v = k * (k - 1) := by
+    rw [← SimpleGraph.card_neighborFinset_eq_degree]
+    have huniv : G.neighborFinset v = univ.erase v := by
+      ext w
+      rw [SimpleGraph.mem_neighborFinset, Finset.mem_erase]
+      constructor
+      · intro h
+        exact ⟨(G.ne_of_adj h).symm, Finset.mem_univ _⟩
+      · rintro ⟨hne, -⟩
+        exact hv w (Ne.symm hne)
+    rw [huniv, Finset.card_erase_of_mem (Finset.mem_univ v),
+      Finset.card_univ, Fintype.card_fin, Nat.add_sub_cancel]
+  have hdeg := hdegk v
+  have h2k : k * 2 ≤ k * (k - 1) := Nat.mul_le_mul_left k (by omega)
+  omega
+
+/-- **`f(k(k−1)+1) ≤ k` for every `k ≥ 3`** — infinitely many upper bounds at
+the projective-plane parameters, each one vertex beyond the counting range
+`n ≤ k(k−1)` of `minDegreeForC4_le_of_le_mul_pred`. -/
+theorem minDegreeForC4_le_tight {k : ℕ} (hk : 3 ≤ k) :
+    minDegreeForC4 (k * (k - 1) + 1) ≤ k := by
+  apply Nat.sInf_le
+  intro G _ hmin
+  exact containsC4_of_tight_minDegree hk G hmin
+
+/-- Sanity check: the `k = 4` instance recovers `f(13) ≤ 4`. -/
+example : minDegreeForC4 13 ≤ 4 := by
+  simpa using minDegreeForC4_le_tight (k := 4) (by norm_num)
+
+/-- **`f(21) ≤ 5`** — the first bound beyond the exact table `f(1..13)`:
+`21 = 5·4+1` is the parameter of the projective plane of order `4`. -/
+theorem minDegreeForC4_twentyone_le : minDegreeForC4 21 ≤ 5 := by
+  simpa using minDegreeForC4_le_tight (k := 5) (by norm_num)
+
+/-- **`f(31) ≤ 6`**: `31 = 6·5+1`, the parameter of the projective plane of
+order `5`. -/
+theorem minDegreeForC4_thirtyone_le : minDegreeForC4 31 ≤ 6 := by
+  simpa using minDegreeForC4_le_tight (k := 6) (by norm_num)
+
+end TightPoints
+
 end Erdos85

--- a/research/problems/erdos-85-wip-01/sessions/2026-07-24-tight-points-generalization.md
+++ b/research/problems/erdos-85-wip-01/sessions/2026-07-24-tight-points-generalization.md
@@ -1,0 +1,64 @@
+# Session 2026-07-24 (researcher-3) — tight-point theorem: f(k(k−1)+1) ≤ k for all k ≥ 3
+
+## Result
+
+The candidate target named in state.md's Blockers ("generalization f(k²−k+1) ≤ k")
+is proved. New section `TightPoints` in `Proofs/Erdos85Problem.lean` (+208 LOC,
+0 sorries, 0 axioms; docker build 8577 jobs, exit 0, zero warnings in the new
+section, first try):
+
+- `choose_two_tight (k) : (k*(k-1)+1).choose 2 = (k*(k-1)+1) * k.choose 2`
+- `containsC4_of_tight_minDegree {k} (hk : 3 ≤ k) (G : SimpleGraph (Fin (k*(k-1)+1)))
+  [DecidableRel G.Adj] (hmin : k ≤ G.minDegree) : containsC4 _ G`
+- `minDegreeForC4_le_tight {k} (hk : 3 ≤ k) : minDegreeForC4 (k*(k-1)+1) ≤ k`
+- `minDegreeForC4_twentyone_le : minDegreeForC4 21 ≤ 5` — NEW value beyond the
+  exact table f(1..13)
+- `minDegreeForC4_thirtyone_le : minDegreeForC4 31 ≤ 6` — ditto
+- `example : minDegreeForC4 13 ≤ 4` — k = 4 instance recovers the Thirteen result
+
+## Method — parameterising the `Thirteen` section
+
+The f(13) proof structure survives verbatim; only the literals needed lemmas:
+
+| f(13) literal | general form | mechanism |
+|---|---|---|
+| `T.card = 78` (decide) | `T.card = (k(k−1)+1)·C(k,2)` | `choose_two_tight` via `Nat.choose_two_right` + `Nat.add_sub_cancel` + `Nat.mul_div_assoc _ (two_dvd_mul_pred k)` (helper already in file at line 807) |
+| `6 = C(4,2)` per-vertex bound | `k.choose 2` kept as an atom | `Nat.choose_le_choose 2` |
+| `10 = C(5,2)` regularity pinch | `(k+1).choose 2 = k.choose 2 + k` | Pascal: `Nat.choose_succ_succ` + `Nat.choose_one_right` + `Nat.add_comm` |
+| `72 = 12·6` erase-sum bound | `(k(k−1))·C(k,2)` | `sum_const` over `univ.erase` + `Nat.add_sub_cancel` |
+| final `omega` on literals | `omega` on atoms | supply `hmul : (k(k−1)+1)·A = (k(k−1))·A + A := Nat.succ_mul _ _` so omega's atom abstraction sees only linear facts |
+| politician degree `12` | `k(k−1)` | `Nat.add_sub_cancel` on the card; clash via `h2k : k*2 ≤ k*(k−1) := Nat.mul_le_mul_left k (2 ≤ k−1)` + omega |
+
+Statement uses `k * (k - 1) + 1` (NOT `k^2 - k + 1`) so that `n − 1 = k*(k−1)`
+is `Nat.add_sub_cancel` and all arithmetic stays linear-in-atoms for omega —
+no nonlinear nat-subtraction identities needed anywhere.
+
+**omega + nonlinear atoms**: omega abstracts `(k*(k-1))*(k.choose 2)` and
+`(k*(k-1)+1)*(k.choose 2)` as opaque atoms; providing their relation explicitly
+(`Nat.succ_mul`) lets it close the tightness pinches. This worked first try.
+
+The friendship half (Classical-vs-synthesized Fintype `convert hone using 2`
+bridge) is dimension-independent and copied unchanged.
+
+## Why k ≥ 3
+
+k = 0,1,2 degenerate: the politician clash needs k(k−1) ≠ k, i.e. k ≠ 2 and
+k ≠ 0-trivialities; f(3) ≤ 2 etc. are already covered by the elementary bounds.
+The hypothesis is consumed only in the final omega (via `2 ≤ k − 1`).
+
+## Interpretation
+
+Infinitely many upper bounds one vertex beyond the crude counting range
+`n ≤ k(k−1)` (`minDegreeForC4_le_of_le_mul_pred`). At tight points the bound
+beats the closed form `f(n) ≤ √n + 2` by 1: e.g. √21+2 = 6 vs f(21) ≤ 5,
+√31+2 = 7 vs f(31) ≤ 6. These are exactly the projective-plane parameters:
+when a projective plane of order k−1 exists, its incidence structure is the
+conjectured extremal configuration, so these bounds are plausibly exact
+(f(21) = 5 would need a matching lower-bound witness — see Blockers).
+
+## Next steps
+
+- f(14) ≥ 4 via the surgery engine (next accessible lower-bound rung).
+- Matching lower bounds at tight points (incidence-graph witnesses on 21/31
+  vertices — heavier: needs a C₄-free min-degree-(k−1)... construction).
+- Reiman-type ex(n;C₄) bound for non-tight n.

--- a/research/problems/erdos-85-wip-01/state.md
+++ b/research/problems/erdos-85-wip-01/state.md
@@ -48,11 +48,36 @@ this toolchain!) yields a degree-12 politician — contradiction with 4-regulari
 `minDegreeForC4_thirteen : minDegreeForC4 13 = 4` — exact table now 1..13.
 0 sorries, 0 axioms. See knowledge.md session 2026-07-24.
 
+## Status (researcher-3, 2026-07-24) — **tight-point theorem: f(k(k−1)+1) ≤ k ∀ k ≥ 3**
+
+The "generalization f(k²−k+1) ≤ k is a candidate target" blocker item is DONE:
+new section `TightPoints` in `Erdos85Problem.lean` (+208 LOC, 0 sorries,
+0 axioms, docker-verified) parameterises the entire `Thirteen` argument over k:
+
+- `choose_two_tight : C(k(k−1)+1, 2) = (k(k−1)+1)·C(k,2)` — exact tightness at
+  every projective-plane parameter (two-line proof reusing `two_dvd_mul_pred`).
+- `containsC4_of_tight_minDegree (hk : 3 ≤ k)` — every graph on k(k−1)+1
+  vertices with δ ≥ k contains C₄. Same skeleton as `Thirteen`: cherry count
+  exactly tight ⟹ k-regular + cherry→pair surjective ⟹ `Theorems100.Friendship`
+  ⟹ politician degree k(k−1) ≠ k (needs k ≥ 3). Literal constants (78, 6, 72,
+  10, 12) replaced by atom-level arithmetic omega handles: Pascal
+  `(k+1).choose 2 = k.choose 2 + k` for the regularity pinch, `Nat.succ_mul`
+  for the sum split, `Nat.mul_le_mul_left` (2 ≤ k−1) for the final clash.
+- `minDegreeForC4_le_tight (hk : 3 ≤ k) : minDegreeForC4 (k*(k-1)+1) ≤ k` —
+  infinitely many upper bounds one vertex beyond the counting range.
+- NEW concrete values beyond the exact table: `minDegreeForC4_twentyone_le :
+  f(21) ≤ 5`, `minDegreeForC4_thirtyone_le : f(31) ≤ 6` (k = 5, 6 instances,
+  `simpa` numerals); the k = 4 instance re-derives f(13) ≤ 4 as an `example`.
+
+Session memo: `sessions/2026-07-24-tight-points-generalization.md`.
+
 ## Blockers
-- Upper bounds beyond n = 13: the friendship mechanism is SPECIFIC to the tight
-  points n = k²−k+1 (generalization f(k²−k+1) ≤ k is a candidate target); other
-  n still need real ex(n;C₄) edge-extremal input. Reopen: formalize a
-  Reiman-type bound.
+- Upper bounds at NON-tight n > 13: the friendship mechanism only covers
+  n = k(k−1)+1 exactly (now formalized ∀ k ≥ 3); other n still need real
+  ex(n;C₄) edge-extremal input. Reopen: formalize a Reiman-type bound.
+- Matching lower bounds at tight points: f(21) ≥ 5 would need a C₄-free
+  4-regular-ish witness on 21 vertices (incidence graph route) — the surgery
+  engine gives f(14) ≥ 4 as the next accessible rung instead.
 - General ∀ n ≥ 10 f(n) ≥ 4: needs config EXISTENCE (edge pair ab, bc both
   triangle-free, a≁c) in iterated witnesses — not automatic in arbitrary
   C₄-free min-deg-3 graphs. Reopen: invariant-maintaining induction or


### PR DESCRIPTION
## Summary

**Tight-point theorem: `f(k(k-1)+1) <= k` for every `k >= 3`** — the generalization named as the candidate target in state.md's Blockers after f(13) = 4 (PR #43279). New `TightPoints` section in `Proofs/Erdos85Problem.lean` (+208 LOC, 0 sorries, 0 axioms), parameterising the entire f(13) friendship-theorem argument over k.

## New theorems

- `choose_two_tight`: exact tightness of the cherry double-count at every projective-plane parameter — `C(k(k-1)+1, 2) = (k(k-1)+1) * C(k,2)` (two-line proof reusing the file's `two_dvd_mul_pred`).
- `containsC4_of_tight_minDegree`: every graph on `k(k-1)+1` vertices with min degree `>= k` contains a C4. Cherry count exactly tight => k-regular + cherry-to-pair surjective => `Theorems100.Friendship` => the friendship theorem's politician has degree `k(k-1) != k`.
- `minDegreeForC4_le_tight`: `f(k(k-1)+1) <= k` — infinitely many upper bounds one vertex beyond the counting range `n <= k(k-1)` of `minDegreeForC4_le_of_le_mul_pred`.
- **New concrete values beyond the exact table f(1..13)**: `minDegreeForC4_twentyone_le : f(21) <= 5` and `minDegreeForC4_thirtyone_le : f(31) <= 6`. At these tight points the bound beats the file's closed form `f(n) <= sqrt(n) + 2` by 1. The k = 4 instance re-derives `f(13) <= 4` as an `example` (sanity check; the independent `Thirteen` proof is untouched).

## Method notes

The statement uses `k * (k - 1) + 1` (not `k^2 - k + 1`) so `n - 1 = k*(k-1)` is `Nat.add_sub_cancel` and every pinch stays linear-in-atoms for omega: the literals of the f(13) proof (78, 6, 72, 10, 12) become Pascal (`(k+1).choose 2 = k.choose 2 + k`), `Nat.succ_mul` for the sum split, and `Nat.mul_le_mul_left` (from `2 <= k - 1`, the only use of `k >= 3`) for the final politician clash. The Classical-vs-synthesized Fintype `convert` bridge from the `Thirteen` section is dimension-independent and reused unchanged.

## Verification

- Docker build `Proofs.Erdos85Problem`: **exit 0, 8577 jobs**, zero warnings in the new section (all reported warnings pre-existing, lines <= 2401).
- File remains 0 sorries, 0 axioms.

## State

`research/problems/erdos-85-wip-01/state.md` updated (blocker item discharged; remaining: non-tight upper bounds need Reiman-type ex(n;C4), matching lower bounds at tight points, f(14) >= 4 surgery rung) + session memo added.
