### PR TITLE
Research: abundant-number-oq-03-oq-03 - every odd abundant number has >= 3 distinct prime factors (0 axioms, docker-verified)

### DIFF
--- a/proofs/Proofs/AbundantNumberOQ03OQ03OmegaThree.lean
+++ b/proofs/Proofs/AbundantNumberOQ03OQ03OmegaThree.lean
@@ -40,7 +40,8 @@ theorem pred_mul_geom_sum_add_one {p : ℕ} (hp : 1 ≤ p) (a : ℕ) :
     (p - 1) * (∑ i ∈ Finset.range (a + 1), p ^ i) + 1 = p ^ (a + 1) := by
   induction a with
   | zero =>
-      simp only [Finset.range_one, Finset.sum_singleton, pow_zero, pow_one, mul_one]
+      have h0 : ∑ i ∈ Finset.range (0 + 1), p ^ i = 1 := by simp
+      rw [h0, zero_add, pow_one, mul_one]
       omega
   | succ a ih =>
       rw [Finset.sum_range_succ, mul_add]
@@ -74,7 +75,7 @@ theorem pred_prod_mul_sum_divisors_lt {n : ℕ} (hn : 2 ≤ n) :
       < (∏ p ∈ n.primeFactors, p) * n := by
   induction n using Nat.recOnPosPrimePosCoprime with
   | prime_pow p k hp hk =>
-      have hpp : p.Prime := hp.nat_prime
+      have hpp : p.Prime := Nat.prime_iff.mpr hp
       obtain ⟨m, rfl⟩ : ∃ m, k = m + 1 := ⟨k - 1, by omega⟩
       rw [Nat.primeFactors_pow_succ, hpp.primeFactors,
         Finset.prod_singleton, Finset.prod_singleton]
@@ -164,8 +165,8 @@ theorem three_le_primeFactors_card_of_odd_abundant {n : ℕ}
   have h4 : (∑ d ∈ n.divisors, d) < 2 * n := Nat.lt_of_mul_lt_mul_left h3
   omega
 
-/-- Sanity anchor: the bound is attained — `945` is odd, abundant, and has
-exactly three distinct prime factors (`3, 5, 7`). -/
-example : (945 : ℕ).primeFactors.card = 3 := by decide
+/-- Sanity anchor: the bound is attained — `945 = 3³·5·7` (odd, abundant per
+the parent file's `abundant_945`) has exactly three distinct prime factors. -/
+example : (945 : ℕ) = 3 ^ 3 * 5 * 7 := by norm_num
 
 end AbundantNumberOQ03OQ03

--- a/proofs/Proofs/AbundantNumberOQ03OQ03OmegaThree.lean
+++ b/proofs/Proofs/AbundantNumberOQ03OQ03OmegaThree.lean
@@ -75,7 +75,7 @@ theorem pred_prod_mul_sum_divisors_lt {n : ℕ} (hn : 2 ≤ n) :
       < (∏ p ∈ n.primeFactors, p) * n := by
   induction n using Nat.recOnPosPrimePosCoprime with
   | prime_pow p k hp hk =>
-      have hpp : p.Prime := Nat.prime_iff.mpr hp
+      have hpp : p.Prime := hp
       obtain ⟨m, rfl⟩ : ∃ m, k = m + 1 := ⟨k - 1, by omega⟩
       rw [Nat.primeFactors_pow_succ, hpp.primeFactors,
         Finset.prod_singleton, Finset.prod_singleton]

--- a/proofs/Proofs/AbundantNumberOQ03OQ03OmegaThree.lean
+++ b/proofs/Proofs/AbundantNumberOQ03OQ03OmegaThree.lean
@@ -1,0 +1,171 @@
+/-
+  Abundant numbers OQ03-OQ03 satellite: every odd abundant number has at
+  least three distinct prime factors.
+
+  The tracker's session-sized follow-up to the completed infinitude result
+  (`OddPrimitiveAbundant.Infinite`, PR #43297): with at most two odd prime
+  divisors the abundancy index is below `(3/2)·(5/4) = 15/8 < 2`, so an odd
+  abundant number needs `ω(n) ≥ 3`.  (The bound is sharp: `945 = 3³·5·7` has
+  exactly three.)
+
+  Everything is carried out in subtraction-safe ℕ arithmetic:
+
+  * `pred_mul_geom_sum_add_one` — `(p−1)·(1 + p + ⋯ + p^a) + 1 = p^(a+1)`.
+  * `pred_mul_sum_divisors_prime_pow_lt` — `(p−1)·σ(p^a) < p·p^a`.
+  * `pred_prod_mul_sum_divisors_lt` — for `n ≥ 2`,
+    `(∏_{p ∣ n} (p−1))·σ(n) < (∏_{p ∣ n} p)·n`, the ℕ-arithmetic form of the
+    strict abundancy bound `σ(n)/n < ∏_{p ∣ n} p/(p−1)`; proved by
+    `Nat.recOnPosPrimePosCoprime` with `σ` multiplicativity on the coprime
+    step.
+  * `three_le_primeFactors_card_of_odd_abundant` — the headline: `Odd n` and
+    `n.Abundant` force `3 ≤ n.primeFactors.card`.  With `|primeFactors| ≤ 2`
+    and every prime factor `≥ 3` (oddness), `∏ p ≤ 2·∏(p−1)` — the
+    `card = 2` case is exactly `(p−2)(q−2) ≥ 2` for distinct odd primes —
+    whence `σ(n) < 2n`, contradicting abundance.
+
+  All results are fully machine-checked (0 axioms, 0 sorries).
+
+  Reference: classical; see Dickson, "Finiteness of the odd perfect and
+  primitive abundant numbers with n distinct prime factors" (1913).
+-/
+import Mathlib
+
+namespace AbundantNumberOQ03OQ03
+
+open Nat Finset
+
+/-- **Geometric-sum identity, subtraction-safe**:
+`(p − 1) · (1 + p + ⋯ + p^a) + 1 = p^(a+1)` for `1 ≤ p`. -/
+theorem pred_mul_geom_sum_add_one {p : ℕ} (hp : 1 ≤ p) (a : ℕ) :
+    (p - 1) * (∑ i ∈ Finset.range (a + 1), p ^ i) + 1 = p ^ (a + 1) := by
+  induction a with
+  | zero =>
+      simp only [Finset.range_one, Finset.sum_singleton, pow_zero, pow_one, mul_one]
+      omega
+  | succ a ih =>
+      rw [Finset.sum_range_succ, mul_add]
+      have h1 : (p - 1) * p ^ (a + 1) + p ^ (a + 1) = p ^ (a + 1 + 1) := by
+        have hpp : (p - 1) + 1 = p := by omega
+        calc (p - 1) * p ^ (a + 1) + p ^ (a + 1)
+            = ((p - 1) + 1) * p ^ (a + 1) := by ring
+          _ = p * p ^ (a + 1) := by rw [hpp]
+          _ = p ^ (a + 1 + 1) := by ring
+      linarith [ih, h1]
+
+/-- **Strict prime-power abundancy bound**: `(p − 1) · σ(p^a) < p · p^a` —
+the ℕ-arithmetic form of `σ(p^a)/p^a < p/(p−1)`. -/
+theorem pred_mul_sum_divisors_prime_pow_lt {p : ℕ} (hp : p.Prime) (a : ℕ) :
+    (p - 1) * (∑ d ∈ (p ^ a).divisors, d) < p * p ^ a := by
+  rw [Nat.sum_divisors_prime_pow hp]
+  have h := pred_mul_geom_sum_add_one hp.one_lt.le a
+  have h2 : p * p ^ a = p ^ (a + 1) := by ring
+  linarith [h, h2]
+
+/-- **Strict abundancy-index product bound**: for `n ≥ 2`,
+
+    `(∏_{p ∈ primeFactors n} (p − 1)) · σ(n) < (∏_{p ∈ primeFactors n} p) · n`,
+
+the ℕ-arithmetic form of `σ(n)/n < ∏_{p ∣ n} p/(p−1)`.  Induction over the
+factorization (`Nat.recOnPosPrimePosCoprime`): prime powers are the previous
+lemma; on coprime products both sides factor (σ is multiplicative, prime
+factors split as a disjoint union) and the strict inequalities multiply. -/
+theorem pred_prod_mul_sum_divisors_lt {n : ℕ} (hn : 2 ≤ n) :
+    (∏ p ∈ n.primeFactors, (p - 1)) * (∑ d ∈ n.divisors, d)
+      < (∏ p ∈ n.primeFactors, p) * n := by
+  induction n using Nat.recOnPosPrimePosCoprime with
+  | prime_pow p k hp hk =>
+      have hpp : p.Prime := hp.nat_prime
+      obtain ⟨m, rfl⟩ : ∃ m, k = m + 1 := ⟨k - 1, by omega⟩
+      rw [Nat.primeFactors_pow_succ, hpp.primeFactors,
+        Finset.prod_singleton, Finset.prod_singleton]
+      exact pred_mul_sum_divisors_prime_pow_lt hpp (m + 1)
+  | zero => exact absurd hn (by omega)
+  | one => exact absurd hn (by omega)
+  | coprime a b ha hb hab iha ihb =>
+      have hkeya := iha (by omega)
+      have hkeyb := ihb (by omega)
+      rw [hab.primeFactors_mul,
+        Finset.prod_union hab.disjoint_primeFactors,
+        Finset.prod_union hab.disjoint_primeFactors]
+      have hσ : (∑ d ∈ (a * b).divisors, d)
+          = (∑ d ∈ a.divisors, d) * (∑ d ∈ b.divisors, d) := by
+        rw [← ArithmeticFunction.sigma_one_apply, ← ArithmeticFunction.sigma_one_apply,
+          ← ArithmeticFunction.sigma_one_apply]
+        exact ArithmeticFunction.isMultiplicative_sigma.map_mul_of_coprime hab
+      rw [hσ]
+      have h1 := mul_lt_mul'' hkeya hkeyb (Nat.zero_le _) (Nat.zero_le _)
+      calc (∏ p ∈ a.primeFactors, (p - 1)) * (∏ p ∈ b.primeFactors, (p - 1))
+            * ((∑ d ∈ a.divisors, d) * (∑ d ∈ b.divisors, d))
+          = (∏ p ∈ a.primeFactors, (p - 1)) * (∑ d ∈ a.divisors, d)
+            * ((∏ p ∈ b.primeFactors, (p - 1)) * (∑ d ∈ b.divisors, d)) := by ring
+        _ < (∏ p ∈ a.primeFactors, p) * a * ((∏ p ∈ b.primeFactors, p) * b) := h1
+        _ = (∏ p ∈ a.primeFactors, p) * (∏ p ∈ b.primeFactors, p) * (a * b) := by ring
+
+/-- **Every odd abundant number has at least three distinct prime factors.**
+
+With at most two prime factors, all `≥ 3` by oddness, the product bound gives
+`∏ p ≤ 2·∏(p − 1)` (the two-prime case is `(p−2)(q−2) ≥ 2` for distinct odd
+primes), and the strict abundancy bound then forces `σ(n) < 2n` — contradicting
+abundance.  Sharp: `945 = 3³·5·7` is odd abundant with exactly three. -/
+theorem three_le_primeFactors_card_of_odd_abundant {n : ℕ}
+    (hodd : Odd n) (hab : n.Abundant) :
+    3 ≤ n.primeFactors.card := by
+  by_contra hcard
+  have hc2 : n.primeFactors.card ≤ 2 := by omega
+  have habs : 2 * n < ∑ d ∈ n.divisors, d := Nat.abundant_iff_sum_divisors.mp hab
+  have hn2 : 2 ≤ n := by
+    by_contra hlt
+    have hn1 : n < 2 := by omega
+    interval_cases n
+    · norm_num [Nat.divisors_zero] at habs
+    · norm_num [Nat.divisors_one] at habs
+  have hodd_p : ∀ p ∈ n.primeFactors, 3 ≤ p := by
+    intro p hp
+    have hprime : p.Prime := Nat.prime_of_mem_primeFactors hp
+    have hdvd : p ∣ n := Nat.dvd_of_mem_primeFactors hp
+    have hp2 : p ≠ 2 := by
+      rintro rfl
+      have h1 : n % 2 = 1 := Nat.odd_iff.mp hodd
+      omega
+    have := hprime.two_le
+    omega
+  have hprod : (∏ p ∈ n.primeFactors, p) ≤ 2 * ∏ p ∈ n.primeFactors, (p - 1) := by
+    have hc : n.primeFactors.card = 0 ∨ n.primeFactors.card = 1
+        ∨ n.primeFactors.card = 2 := by omega
+    rcases hc with hc | hc | hc
+    · rw [Finset.card_eq_zero.mp hc]
+      simp
+    · obtain ⟨p, hP⟩ := Finset.card_eq_one.mp hc
+      have hp3 : 3 ≤ p := hodd_p p (by rw [hP]; exact Finset.mem_singleton_self p)
+      rw [hP, Finset.prod_singleton, Finset.prod_singleton]
+      omega
+    · obtain ⟨p, q, hpq, hP⟩ := Finset.card_eq_two.mp hc
+      have hp3 : 3 ≤ p := hodd_p p (by rw [hP]; simp)
+      have hq3 : 3 ≤ q := hodd_p q (by rw [hP]; simp)
+      rw [hP, Finset.prod_insert (by simp [hpq]), Finset.prod_singleton,
+        Finset.prod_insert (by simp [hpq]), Finset.prod_singleton]
+      -- `p·q ≤ 2·(p−1)·(q−1)` for distinct primes `≥ 3`: `(p−2)(q−2) ≥ 2`.
+      obtain ⟨s, rfl⟩ : ∃ s, p = s + 3 := ⟨p - 3, by omega⟩
+      obtain ⟨t, rfl⟩ : ∃ t, q = t + 3 := ⟨q - 3, by omega⟩
+      have hst : 1 ≤ s + t := by omega
+      have hsub1 : s + 3 - 1 = s + 2 := by omega
+      have hsub2 : t + 3 - 1 = t + 2 := by omega
+      rw [hsub1, hsub2]
+      nlinarith
+  have hkey := pred_prod_mul_sum_divisors_lt hn2
+  have h2 : (∏ p ∈ n.primeFactors, p) * n ≤ 2 * (∏ p ∈ n.primeFactors, (p - 1)) * n :=
+    Nat.mul_le_mul_right n hprod
+  have h3 : (∏ p ∈ n.primeFactors, (p - 1)) * (∑ d ∈ n.divisors, d)
+      < (∏ p ∈ n.primeFactors, (p - 1)) * (2 * n) := by
+    calc (∏ p ∈ n.primeFactors, (p - 1)) * (∑ d ∈ n.divisors, d)
+        < (∏ p ∈ n.primeFactors, p) * n := hkey
+      _ ≤ 2 * (∏ p ∈ n.primeFactors, (p - 1)) * n := h2
+      _ = (∏ p ∈ n.primeFactors, (p - 1)) * (2 * n) := by ring
+  have h4 : (∑ d ∈ n.divisors, d) < 2 * n := Nat.lt_of_mul_lt_mul_left h3
+  omega
+
+/-- Sanity anchor: the bound is attained — `945` is odd, abundant, and has
+exactly three distinct prime factors (`3, 5, 7`). -/
+example : (945 : ℕ).primeFactors.card = 3 := by decide
+
+end AbundantNumberOQ03OQ03

--- a/research/problems/abundant-number-oq-03-oq-03/knowledge.md
+++ b/research/problems/abundant-number-oq-03-oq-03/knowledge.md
@@ -261,3 +261,18 @@ classical primorial-tail construction; likely first Lean formalization.
   odd primitive abundants) — deep.
 - Every odd abundant number has ≥ 3 distinct prime factors (elementary,
   session-sized: I(3^a·p^b) < (3/2)(5/4) < 2).
+
+## Session 2026-07-24 (researcher-1) — ω ≥ 3 follow-up closed
+
+**Route: strict abundancy product bound via factorization recursion.**
+
+- `pred_prod_mul_sum_divisors_lt` : `(∏(p−1))·σ(n) < (∏p)·n` for n ≥ 2 —
+  `Nat.recOnPosPrimePosCoprime`; prime-power leg from the subtraction-free geometric
+  identity `(p−1)·(1+⋯+p^a) + 1 = p^{a+1}`; coprime leg multiplies strict inequalities
+  (`mul_lt_mul''`) after σ-multiplicativity + disjoint primeFactors union.
+- `three_le_primeFactors_card_of_odd_abundant`: card ≤ 2 + oddness (every p ≥ 3) give
+  `∏p ≤ 2∏(p−1)` (two-prime case = (p−2)(q−2) ≥ 2), cancel `∏(p−1)` with
+  `Nat.lt_of_mul_lt_mul_left` → σ < 2n, contradicting `abundant_iff_sum_divisors`.
+- Gotchas: recursor's `Prime p` binder is ALREADY `Nat.Prime` (namespace Nat) — no
+  `prime_iff` conversion; `decide` cannot compute `primeFactors 945` (minFac WF
+  recursion) — avoid; kill ℕ-subtraction before `nlinarith` by `p = s + 3` substitution.

--- a/src/data/research/problems/abundant-number-oq-03-oq-03.json
+++ b/src/data/research/problems/abundant-number-oq-03-oq-03.json
@@ -86,7 +86,8 @@
       "sum_divisors_prod_nth_ne_two_mul: squarefree odd products are never perfect (mod-4)",
       "exists_crossing: the single analytic input (Nat.Primes.not_summable_one_div + hand-rolled Weierstrass 1+sum <= prod(1+.))",
       "crossing / consecutivePrimeWitness + lt_crossing, erase_prod_deficient, consecutivePrimeWitness_mem, consecutivePrimeWitness_injective",
-      "oddPrimitiveAbundant_infinite + infinitely_many_odd_primitive_abundant: THE TARGET, 0 sorries 0 axioms"
+      "oddPrimitiveAbundant_infinite + infinitely_many_odd_primitive_abundant: THE TARGET, 0 sorries 0 axioms",
+      "AbundantNumberOQ03OQ03OmegaThree.lean: pred_mul_geom_sum_add_one, pred_mul_sum_divisors_prime_pow_lt, pred_prod_mul_sum_divisors_lt, three_le_primeFactors_card_of_odd_abundant (4 thm, 0 axioms, 0 sorries, docker 8576 jobs)"
     ],
     "insights": [
       "945 = 3³·5·7 is not just the smallest odd abundant number but is odd PRIMITIVE abundant (OEIS A006038): all 15 proper divisors 1,3,5,7,9,15,21,27,35,45,63,105,135,189,315 are deficient — verified axiom-free.",
@@ -105,15 +106,16 @@
       "The saturation fixated on two SHAPES (base x one appended prime; divisor extraction); the third shape — grow the base through the abundance boundary — needs no odd family with I(m)->2- at all: divergence of sum 1/p supplies the crossing for every start",
       "First-crossing minimality is exactly the primitivity engine: predecessor sigma<=2n, equality excluded mod 4 for squarefree odd (>=2 factors: 4 | prod(p_i+1) but 2n == 2 mod 4), and swapping the omitted prime only helps (p_i(p_c+1) <= p_c(p_i+1))",
       "Injectivity for free: distinct starting indices give witnesses with distinct least prime factors — no crossing comparison needed",
-      "Lean: inline anonymous Equiv into Equiv.summable_iff (have-bound equivs are opaque, comp will not reduce); v4.31 Finset.range_subset_range replaces range_subset for the range-subset-range iff; Nat.Ico_succ_right_eq_insert_Ico is Nat-namespaced; mul_prod_erase needs explicit f against set-variables"
+      "Lean: inline anonymous Equiv into Equiv.summable_iff (have-bound equivs are opaque, comp will not reduce); v4.31 Finset.range_subset_range replaces range_subset for the range-subset-range iff; Nat.Ico_succ_right_eq_insert_Ico is Nat-namespaced; mul_prod_erase needs explicit f against set-variables",
+      "Follow-up omega>=3 CLOSED (researcher-1, 2026-07-24): three_le_primeFactors_card_of_odd_abundant in new satellite AbundantNumberOQ03OQ03OmegaThree.lean. Engine: strict N-arithmetic abundancy bound pred_prod_mul_sum_divisors_lt ((prod (p-1))·σ(n) < (prod p)·n for n≥2) via Nat.recOnPosPrimePosCoprime — NOTE the recursor binder Prime resolves to Nat.Prime already (no conversion needed). Coprime step: Coprime.primeFactors_mul + prod_union disjoint_primeFactors + ArithmeticFunction.isMultiplicative_sigma.map_mul_of_coprime + mul_lt_mul (alias of Left.mul_lt_mul_of_nonneg). Card<=2 case: prod p <= 2 prod (p-1) reduces to (p-2)(q-2)>=2 for distinct odd primes — substitute p=s+3,q=t+3 to kill Nat subtraction before nlinarith."
     ],
     "mathlibGaps": [
       "No Nat.Coprime.divisors_mul (Finset equality for divisors of a coprime product) in Mathlib v4.31 — only Nat.Coprime.sum_divisors_mul (the sum) and card_divisors_mul (the count). Blocks a clean coprime proper-divisor decomposition."
     ],
     "nextSteps": [
-      "Follow-up (materially weaker than parent, does not yield it back): infinitely many odd primitive abundants with least prime factor 3 — needs non-squarefree exponent-crossings, new proper-divisor analysis",
-      "Follow-up (elementary, session-sized): every odd abundant number has at least 3 distinct prime factors (I(3^a p^b) < (3/2)(5/4) < 2)",
-      "Deep: Dickson 1913 finiteness — for each k, finitely many odd primitive abundants with exactly k prime factors"
+      "Follow-up (materially weaker than parent): infinitely many odd primitive abundants with least prime factor 3 — needs non-squarefree exponent-crossings, new proper-divisor analysis",
+      "Deep: Dickson 1913 finiteness — for each k, finitely many odd primitive abundants with exactly k prime factors",
+      "Gallery wiring: add AbundantNumberOQ03OQ03OmegaThree.lean to the entry additionalFiles (enricher-sized)"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session for `abundant-number-oq-03-oq-03` (re-served COMPLETED slug; executed the tracker's sanctioned session-sized follow-up).

## Progress
New satellite `proofs/Proofs/AbundantNumberOQ03OQ03OmegaThree.lean` (4 theorems, 0 axioms, 0 sorries, docker-verified 8576 jobs):

- `three_le_primeFactors_card_of_odd_abundant` — **every odd abundant number has at least three distinct prime factors** (sharp at 945 = 3³·5·7, the parent entry's witness).
- Engine: `pred_prod_mul_sum_divisors_lt` — the strict ℕ-arithmetic abundancy bound `(∏_{p∣n}(p−1))·σ(n) < (∏_{p∣n}p)·n` for n ≥ 2, by `Nat.recOnPosPrimePosCoprime` (prime-power leg from the subtraction-free geometric identity `(p−1)(1+⋯+p^a)+1 = p^{a+1}`; coprime leg multiplies the strict inequalities using σ multiplicativity and the disjoint primeFactors union).
- Endgame: with ≤ 2 prime factors, all ≥ 3 by oddness, `∏p ≤ 2∏(p−1)` (two-prime case is `(p−2)(q−2) ≥ 2` for distinct odd primes), forcing σ(n) < 2n against `abundant_iff_sum_divisors`.

Lean notes recorded in knowledge: the recursor's `Prime` binder is already `Nat.Prime`; `decide` cannot evaluate `primeFactors 945` (minFac well-founded recursion); substitute `p = s + 3` to eliminate ℕ-subtraction before `nlinarith`.

## Files Modified
- `proofs/Proofs/AbundantNumberOQ03OQ03OmegaThree.lean` (new, ~170 lines)
- `src/data/research/problems/abundant-number-oq-03-oq-03.json`
- `research/problems/abundant-number-oq-03-oq-03/knowledge.md`

## Status
**Outcome**: completed (follow-up ω ≥ 3 closed; slug remains COMPLETED)
**Next Steps**: remaining follow-ups are the least-prime-3 infinitude (needs non-squarefree crossings) and deep Dickson finiteness; gallery wiring of the satellite file is enricher-sized. No new OQ.

🤖 Generated by researcher-1
