### PR TITLE
Research: desargues-theorem-oq-02-oq-02 - intra-plane Desargues => converse (derived-configuration argument)

### DIFF
--- a/proofs/Proofs/DesarguesTheoremOQ02OQ02.lean
+++ b/proofs/Proofs/DesarguesTheoremOQ02OQ02.lean
@@ -92,7 +92,14 @@
     Desarguesian.
   * The *intra-plane* implication "a projective plane satisfying (D) also
     satisfies (D\*)" is a genuine geometric theorem (apply (D) to a derived
-    configuration); it is NOT purely formal duality and is left open here.
+    configuration); it is NOT purely formal duality.  It is now proved here
+    as `isDesarguesian_implies_converse` (with the mirror
+    `isConverseDesarguesian_implies_desargues` recovered by duality), for
+    configurations satisfying eight explicit extra nondegeneracy hypotheses
+    — the derived configuration must itself be nondegenerate, and a
+    degenerate labelling can escape the raw `IsConverseDesarguesian`
+    schema, so the single-property upgrade is stated at exactly the
+    nondegeneracy it needs.
   * The parent's Moulton model is affine, and affine planes are not self-dual
     (parallels have no point-dual); this file therefore lives at the abstract
     incidence layer, one level above its parent, as recorded in the survey.
@@ -314,6 +321,121 @@ theorem desargues_package_self_dual :
 a projective plane (with the point/line type order swapped), so all the
 statements above genuinely live on projective planes and their duals. -/
 example [ProjectivePlane P L] : ProjectivePlane (Dual L) (Dual P) := inferInstance
+
+/-- **Desargues implies its own converse, intra-plane** — the classical
+derived-configuration argument, and the geometric half of "Desargues is its
+own converse" that `isDesarguesian_dual_iff` (a pure statement swap between
+a plane and its dual) deliberately leaves open.
+
+Given an axially perspective labelled pair of triangles in a projective
+plane satisfying `IsDesarguesian`, apply Desargues **inside the same plane**
+to the *derived* configuration: center `p`, triangles `(q, B, B')` and
+`(r, A, A')`.  Its three perspectivity lines through `p` are `ℓ` (through
+`q, r`), `ab` (through `B, A`) and `ab'` (through `B', A'`); the three pairs
+of corresponding sides meet in `C = bc·ca`, `X = la·lb` (which exists
+because any two lines of a projective plane meet) and `C' = bc'·ca'`.
+Desargues makes `C`, `X`, `C'` collinear, and the line carrying them shares
+the two distinct points `C ≠ C'` with `lc`, so it *is* `lc`; hence
+`X ∈ la ∩ lb ∩ lc` and the three joins concur.
+
+The derived configuration must itself be nondegenerate, which costs eight
+hypotheses beyond the `IsConverseDesarguesian` schema: honest triangles
+(`A ≠ B`, `A' ≠ B'`, `C ∉ ab`, `C' ∉ ab'`), vertices `A`, `A'` off the axis
+`ℓ`, and `C`, `C'` off the perspectivity line `la`.  Conversely it only
+consumes four of the schema's twelve inequalities (`C ≠ C'`, `q ≠ r`,
+`la ≠ lb`, `ab ≠ ab'`), so the statement below lists exactly the hypotheses
+used. -/
+theorem isDesarguesian_implies_converse [ProjectivePlane P L]
+    (hD : IsDesarguesian P L)
+    (A B C A' B' C' p q r : P) (ℓ la lb lc ab ab' bc bc' ca ca' : L)
+    (hCC' : C ≠ C') (hqr : q ≠ r) (hlab : la ≠ lb) (hab' : ab ≠ ab')
+    (hAB : A ≠ B) (hA'B' : A' ≠ B') (hCab : C ∉ ab) (hC'ab' : C' ∉ ab')
+    (hAell : A ∉ ℓ) (hA'ell : A' ∉ ℓ) (hCla : C ∉ la) (hC'la : C' ∉ la)
+    (hpl : p ∈ ℓ) (hql : q ∈ ℓ) (hrl : r ∈ ℓ)
+    (hAla : A ∈ la) (hA'la : A' ∈ la) (hBlb : B ∈ lb) (hB'lb : B' ∈ lb)
+    (hClc : C ∈ lc) (hC'lc : C' ∈ lc)
+    (hAab : A ∈ ab) (hBab : B ∈ ab) (hpab : p ∈ ab)
+    (hA'ab' : A' ∈ ab') (hB'ab' : B' ∈ ab') (hpab' : p ∈ ab')
+    (hBbc : B ∈ bc) (hCbc : C ∈ bc) (hqbc : q ∈ bc)
+    (hB'bc' : B' ∈ bc') (hC'bc' : C' ∈ bc') (hqbc' : q ∈ bc')
+    (hCca : C ∈ ca) (hAca : A ∈ ca) (hrca : r ∈ ca)
+    (hC'ca' : C' ∈ ca') (hA'ca' : A' ∈ ca') (hrca' : r ∈ ca') :
+    LinesConcurrent P L la lb lc := by
+  -- the meet of the two joins `la`, `lb`: the candidate center
+  obtain ⟨X, hXla, hXlb⟩ : ∃ X : P, X ∈ la ∧ X ∈ lb :=
+    ⟨HasPoints.mkPoint (P := P) hlab, HasPoints.mkPoint_ax (P := P) hlab⟩
+  -- nondegeneracy of the derived configuration
+  have hCX : C ≠ X := fun h => hCla (h ▸ hXla)
+  have hXC' : X ≠ C' := fun h => hC'la (h ▸ hXla)
+  have hellab : ℓ ≠ ab := fun h => hAell (h ▸ hAab)
+  have hellab' : ℓ ≠ ab' := fun h => hA'ell (h ▸ hA'ab')
+  have hbcca : bc ≠ ca := by
+    intro h
+    rcases Nondegenerate.eq_or_eq hAab hBab (h.symm ▸ hAca) hBbc with h' | h'
+    · exact hAB h'
+    · exact hCab (h'.symm ▸ hCbc)
+  have hbc'ca' : bc' ≠ ca' := by
+    intro h
+    rcases Nondegenerate.eq_or_eq hA'ab' hB'ab' (h.symm ▸ hA'ca') hB'bc' with h' | h'
+    · exact hA'B' h'
+    · exact hC'ab' (h'.symm ▸ hC'bc')
+  -- Desargues on the derived configuration: center `p`, triangles
+  -- `(q, B, B')` and `(r, A, A')`, perspectivity lines `ℓ`, `ab`, `ab'`,
+  -- side pairs `(bc, ca)`, `(lb, la)`, `(bc', ca')` with axis candidates
+  -- `C`, `X`, `C'`
+  obtain ⟨m, hCm, hXm, hC'm⟩ :=
+    hD p q B B' r A A' C X C' ℓ ab ab' bc ca lb la bc' ca'
+      hqr hAB.symm hA'B'.symm hCX hCC' hXC'
+      hellab hellab' hab' hbcca hlab.symm hbc'ca'
+      hpl hpab hpab'
+      hql hrl hBab hAab hB'ab' hA'ab'
+      hqbc hBbc hCbc hrca hAca hCca
+      hBlb hB'lb hXlb hAla hA'la hXla
+      hB'bc' hqbc' hC'bc' hA'ca' hrca' hC'ca'
+  -- the axis of the derived configuration is `lc` (it shares `C ≠ C'` with it)
+  rcases Nondegenerate.eq_or_eq hCm hC'm hClc hC'lc with h | h
+  · exact absurd h hCC'
+  · exact ⟨X, hXla, hXlb, h ▸ hXm⟩
+
+/-- **Converse Desargues implies Desargues, intra-plane** — the mirror
+implication, for free by plane duality: `IsConverseDesarguesian P L` is
+`IsDesarguesian` of the dual plane (`isDesarguesian_dual_iff`), so running
+`isDesarguesian_implies_converse` in the dual plane and reading the result
+back through the polarity dictionary turns a nondegenerate centrally
+perspective pair of triangles into an axially perspective one.  The eight
+extra nondegeneracy hypotheses are the duals of the previous theorem's:
+honest dual triangles (`bc' ≠ ca'`, `bc ≠ ca`, `C' ∉ ab'`, `C ∉ ab`), dual
+vertices off the dual axis (`o ∉ bc'`, `o ∉ bc`), and dual points off the
+dual perspectivity line (`q ∉ ab'`, `q ∉ ab`). -/
+theorem isConverseDesarguesian_implies_desargues [ProjectivePlane P L]
+    (hC : IsConverseDesarguesian P L)
+    (o A B C A' B' C' p q r : P) (la lb lc ab ab' bc bc' ca ca' : L)
+    (hCC' : C ≠ C') (hqr : q ≠ r) (hlab : la ≠ lb) (hab' : ab ≠ ab')
+    (hbc'ca' : bc' ≠ ca') (hbcca : bc ≠ ca) (hC'ab' : C' ∉ ab') (hCab : C ∉ ab)
+    (hobc' : o ∉ bc') (hobc : o ∉ bc) (hqab' : q ∉ ab') (hqab : q ∉ ab)
+    (hola : o ∈ la) (holb : o ∈ lb) (holc : o ∈ lc)
+    (hAla : A ∈ la) (hA'la : A' ∈ la) (hBlb : B ∈ lb) (hB'lb : B' ∈ lb)
+    (hClc : C ∈ lc) (hC'lc : C' ∈ lc)
+    (hAab : A ∈ ab) (hBab : B ∈ ab) (hpab : p ∈ ab)
+    (hA'ab' : A' ∈ ab') (hB'ab' : B' ∈ ab') (hpab' : p ∈ ab')
+    (hBbc : B ∈ bc) (hCbc : C ∈ bc) (hqbc : q ∈ bc)
+    (hB'bc' : B' ∈ bc') (hC'bc' : C' ∈ bc') (hqbc' : q ∈ bc')
+    (hCca : C ∈ ca) (hAca : A ∈ ca) (hrca : r ∈ ca)
+    (hC'ca' : C' ∈ ca') (hA'ca' : A' ∈ ca') (hrca' : r ∈ ca') :
+    PointsCollinear P L p q r := by
+  obtain ⟨x, hx1, hx2, hx3⟩ :=
+    isDesarguesian_implies_converse (Dual L) (Dual P)
+      ((isDesarguesian_dual_iff P L).mpr hC)
+      bc' ca' ab' bc ca ab lc la lb o q r p C' C A' A B' B
+      hab'.symm hlab hqr hCC'.symm
+      hbc'ca' hbcca hC'ab' hCab
+      hobc' hobc hqab' hqab
+      holc hola holb
+      hqbc' hqbc hrca' hrca hpab' hpab
+      hC'bc' hC'ca' hC'lc hCbc hCca hClc
+      hA'ca' hA'ab' hA'la hAca hAab hAla
+      hB'ab' hB'bc' hB'lb hBab hBbc hBlb
+  exact ⟨x, hx3, hx1, hx2⟩
 
 end Abstract
 

--- a/research/problems/desargues-theorem-oq-02-oq-02/problem.md
+++ b/research/problems/desargues-theorem-oq-02-oq-02/problem.md
@@ -160,3 +160,41 @@ Ways THIS claim could be wrong, and what to check:
   latter is an overclaim.
 - **Circularity.** No axioms, no sorries; Layer 2 uses only hypothesis
   shuffling; Layer 1 only kernel `decide` on `Fin 10`/`Fin 5` data.
+
+## Adversarial Checklist addendum (2026-07-24, researcher-2 session 2 — intra-plane theorems)
+
+The new claim: `isDesarguesian_implies_converse` proves the intra-plane
+implication (D) ⟹ (D\*) (with mirror `isConverseDesarguesian_implies_desargues`),
+resolving the "left open" item of the previous checklist entry. Ways THIS
+claim could be wrong:
+
+- **Silently weaker than the classical theorem via over-strong hypotheses.**
+  The theorem carries 8 nondegeneracy hypotheses beyond the raw
+  `IsConverseDesarguesian` schema (`A ≠ B`, `A' ≠ B'`, `C ∉ ab`, `C' ∉ ab'`,
+  `A ∉ ℓ`, `A' ∉ ℓ`, `C ∉ la`, `C' ∉ la`). Check these are genuine
+  triangle/configuration nondegeneracy (they are satisfied by any honest
+  Desargues configuration), not hidden strength that trivializes the
+  conclusion — none of them mentions `lb`, `lc`, or the concurrency point,
+  so they cannot smuggle the conclusion in.
+- **Conclusion could concur at the wrong point.** The concurrency witness is
+  `X = mkPoint hlab ∈ la ∩ lb`; membership in `lc` is derived from
+  Desargues' output axis being equal to `lc` (shared distinct points
+  `C ≠ C'`, `Nondegenerate.eq_or_eq`). Check the final witness is
+  `⟨X, X ∈ la, X ∈ lb, X ∈ lc⟩`, all three joins.
+- **Circular use of the converse.** The proof must use only `hD :
+  IsDesarguesian P L` plus projective-plane axioms (`mkPoint`, `eq_or_eq`).
+  Check no appeal to `IsConverseDesarguesian`, and that the mirror theorem
+  uses only `isDesarguesian_dual_iff` (statement swap) + theorem 1 in the
+  dual plane — that iff is duality-transfer, not the intra-plane claim, so
+  no circularity.
+- **Derived-configuration mislabelling.** The 36-argument instantiation of
+  `hD` could permute roles and accidentally prove a different (still true)
+  collinearity. Check the instantiation comment against the argument list:
+  center `p`; triangles `(q, B, B')`, `(r, A, A')`; lines `ℓ, ab, ab'`;
+  side pairs `(bc, ca), (lb, la), (bc', ca')`; axis candidates `C, X, C'`.
+  The conclusion type `PointsCollinear P L C X C'` pins the axis candidates.
+- **Vacuity via contradictory hypotheses.** A projective plane could a
+  priori make the combined 12 + 27 hypothesis set unsatisfiable (vacuous
+  theorem). Sanity anchor: any Desarguesian plane's honest Desargues
+  configurations (e.g. PG(2, ℝ)) satisfy all of them; the hypotheses are the
+  standard general-position conditions.

--- a/research/problems/desargues-theorem-oq-02-oq-02/sessions/2026-07-24-intra-plane-converse.md
+++ b/research/problems/desargues-theorem-oq-02-oq-02/sessions/2026-07-24-intra-plane-converse.md
@@ -1,0 +1,39 @@
+# Session 2 (2026-07-24, researcher-2): intra-plane (D) ⟹ (D*)
+
+**Goal**: discharge session 1's follow-up — Desargues implies its own
+converse *inside one plane* (real geometry, not the formal duality swap).
+
+**Result**: two new theorems in `DesarguesTheoremOQ02OQ02.lean`, docker
+green, 0 sorries / 0 axioms.
+
+1. `isDesarguesian_implies_converse [ProjectivePlane P L]`:
+   derived-configuration argument. Given axial data (axis `ℓ` through
+   `p q r`, joins `la lb lc`, sides `ab/ab' bc/bc' ca/ca'`), apply
+   `IsDesarguesian` to the configuration with center `p`, triangles
+   `(q, B, B')` and `(r, A, A')`:
+   - perspectivity lines through `p`: `ℓ` (carries `q, r`), `ab`
+     (carries `B, A`), `ab'` (carries `B', A'`);
+   - side pairs and axis candidates: `(bc, ca) ↦ C`, `(lb, la) ↦ X`,
+     `(bc', ca') ↦ C'`, where `X := HasPoints.mkPoint hlab` is the meet of
+     `la, lb` (exists in any projective plane);
+   - Desargues gives `C, X, C'` collinear on a line `m`; `m` shares the two
+     distinct points `C ≠ C'` with `lc`, so `m = lc` by
+     `Nondegenerate.eq_or_eq`, hence `X ∈ la ∩ lb ∩ lc`.
+
+2. `isConverseDesarguesian_implies_desargues`: mirror, by instantiating
+   theorem 1 in the dual plane via `(isDesarguesian_dual_iff P L).mpr` and
+   translating all hypotheses along the (definitional) polarity dictionary.
+
+**Cost accounting (honest scope)**: the derived configuration must itself
+be nondegenerate. This consumes only 4 of the schema's 12 inequalities
+(`C ≠ C'`, `q ≠ r`, `la ≠ lb`, `ab ≠ ab'`) but needs 8 extra hypotheses:
+honest triangles (`A ≠ B`, `A' ≠ B'`, `C ∉ ab`, `C' ∉ ab'`), vertices `A, A'`
+off the axis, `C, C'` off the join `la`. Of these, `bc ≠ ca` / `bc' ≠ ca'`
+are *derived* (via `eq_or_eq` + triangle nondegeneracy), as are `ℓ ≠ ab`,
+`ℓ ≠ ab'`, `C ≠ X`, `X ≠ C'`.
+
+**Insight**: the raw `IsConverseDesarguesian` schema is too weak to run the
+derived-configuration proof — a degenerate labelling (e.g. `A = B`) escapes
+it. So "single-property self-duality" holds at exactly the nondegeneracy
+the derived configuration needs, and that hypothesis set is the honest
+statement of the classical theorem.

--- a/research/problems/desargues-theorem-oq-02-oq-02/state.md
+++ b/research/problems/desargues-theorem-oq-02-oq-02/state.md
@@ -60,3 +60,31 @@ checklist added to problem.md.
 ## Next Action
 None — target answered. Candidate follow-up: the intra-plane implication
 "(D) ⟹ (D*) in the same projective plane" (real geometry, not formal duality).
+
+## Status (researcher-2, 2026-07-24, session 2) — follow-up DISCHARGED: intra-plane (D) ⟹ (D*)
+
+The candidate follow-up from session 1 is now proved, docker green, still
+0 sorries / 0 axioms:
+
+- `isDesarguesian_implies_converse` — in a projective plane satisfying
+  `IsDesarguesian`, every axially perspective labelled triangle pair that is
+  nondegenerate (eight explicit extra hypotheses: `A ≠ B`, `A' ≠ B'`,
+  `C ∉ ab`, `C' ∉ ab'`, `A ∉ ℓ`, `A' ∉ ℓ`, `C ∉ la`, `C' ∉ la`) is centrally
+  perspective. Proof = the classical derived-configuration argument: apply
+  (D) to center `p`, triangles `(q, B, B')` / `(r, A, A')`, perspectivity
+  lines `ℓ, ab, ab'`, side pairs `(bc, ca), (lb, la), (bc', ca')` with axis
+  candidates `C`, `X := la·lb` (`HasPoints.mkPoint`), `C'`; the resulting
+  axis shares `C ≠ C'` with `lc`, so equals `lc` by `Nondegenerate.eq_or_eq`.
+- `isConverseDesarguesian_implies_desargues` — mirror implication, obtained
+  for free by running the first theorem in the dual plane through
+  `isDesarguesian_dual_iff` and the polarity dictionary.
+
+Honest scope: the intra-plane implication is proved for configurations
+nondegenerate in the stated sense, not for the raw 12-inequality
+`IsConverseDesarguesian` schema — the derived configuration must itself be
+nondegenerate, and the extra hypotheses are exactly what that costs.
+
+## Next Action
+Optional only: bridge the finite 10₃ model to the abstract predicates
+(instantiate `Membership (Fin 10) (Fin 10)` and derive the abstract polarity
+from `polarity_reverses`).

--- a/src/data/research/problems/desargues-theorem-oq-02-oq-02.json
+++ b/src/data/research/problems/desargues-theorem-oq-02-oq-02.json
@@ -27,25 +27,25 @@
   "currentState": {
     "phase": "COMPLETED",
     "since": "2026-06-13",
-    "iteration": 1,
-    "focus": "COMPLETED 2026-07-24: self-duality formalized explicitly at both layers (finite 10_3 polarity + class-level isDesarguesian_dual_iff) — researcher-2",
-    "blockers": [
-      "Verification blackout 2026-06-13: Docker down + Aristotle 404 (both confirmed live this session)"
-    ],
-    "nextAction": "None — question answered. Candidate follow-up: intra-plane (D) => (D*) in a projective plane (real geometry, not formal duality).",
+    "iteration": 2,
+    "focus": "COMPLETED 2026-07-24 (session 2): intra-plane (D)=>(D*) discharged — single-property self-duality proved at explicit nondegeneracy — researcher-2",
+    "blockers": [],
+    "nextAction": "None — question answered and follow-up discharged. Remaining item is optional (finite-to-abstract bridge).",
     "attemptCounts": {
-      "total": 0,
+      "total": 2,
       "currentApproach": 0,
       "approachesTried": 0
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED 2026-07-24: the self-duality of Desargues theorem is formalized EXPLICITLY. Finite layer: the 10_3 Desargues configuration in the pairs model with an explicit incidence-reversing polarity (kernel decide; O<->axis, vertex<->opposite side, perspectivity line<->axis point). Abstract layer (on Membership P L + Configuration.Dual): isDesarguesian_dual_iff proves IsDesarguesian (Dual L) (Dual P) <-> IsConverseDesarguesian P L — Desargues is its own dual = its own converse — plus the mirror iff (definitional involutivity) and package invariance. Honest scope: duality-transfer only; the intra-plane (D)=>(D*) implication is real geometry, left open.",
+    "progressSummary": "COMPLETED (sessions 1-2, 2026-07-24): self-duality of Desargues formalized explicitly at both layers (finite 10_3 polarity, kernel decide; class-level isDesarguesian_dual_iff on Membership P L + Configuration.Dual), AND the intra-plane geometric half is now proved: isDesarguesian_implies_converse (Desargues => its own converse inside one projective plane, via the classical derived-configuration argument) with the mirror isConverseDesarguesian_implies_desargues by duality. 0 axioms / 0 sorries. Honest scope: the intra-plane implication requires eight explicit nondegeneracy hypotheses beyond the raw schema — exactly the nondegeneracy of the derived configuration.",
     "builtItems": [
       "DesarguesTheoremOQ02OQ02.lean: pairOf/lineOf/Inc + 10_3 certificates + desargues_roles_* + ptToLn/lnToPt + polarity_reverses (all decide)",
       "PointsCollinear/LinesConcurrent + Iff.rfl dual swaps on Configuration.Dual",
       "IsDesarguesian / IsConverseDesarguesian (universal incidence forms, polarity-closed 12-inequality schema)",
-      "isDesarguesian_dual_iff + isConverseDesarguesian_dual_iff + desargues_package_self_dual: THE TARGET, 0 sorries 0 axioms"
+      "isDesarguesian_dual_iff + isConverseDesarguesian_dual_iff + desargues_package_self_dual: THE TARGET, 0 sorries 0 axioms",
+      "isDesarguesian_implies_converse in DesarguesTheoremOQ02OQ02.lean — intra-plane Desargues => converse on nondegenerate configurations (ProjectivePlane, mkPoint + eq_or_eq)",
+      "isConverseDesarguesian_implies_desargues in DesarguesTheoremOQ02OQ02.lean — mirror implication via the dual plane and the polarity dictionary"
     ],
     "insights": [
       "Duality dictionary: point↔line, lies-on↔passes-through, collinear↔concurrent, join↔meet — sends a triangle to a trilateral and central perspectivity to axial perspectivity",
@@ -55,14 +55,15 @@
       "Cheapest first compile = finite Desargues 10₃ configuration self-duality: Fin 10 incidence matrix + duality permutation σ, goal inc p l = inc (σ l) (σ p) by decide — no Mathlib Configuration dependency",
       "The nondegeneracy schema must be CLOSED under the polarity or duality is not a pure statement swap: converse-Desargues natural hypotheses (distinct axis points, distinct corresponding vertices) are exactly the polarity image of Desargues (distinct perspectivity lines, distinct corresponding sides)",
       "Dual being a plain type synonym makes double-dual collapse and membership swap definitional: the mirror iff is (isDesarguesian_dual_iff (Dual L) (Dual P)).symm with defeq lifting Dual(Dual P)=P, and primal-typed incidence hypotheses are accepted verbatim in dual positions",
-      "The pairs model (points and lines = 2-subsets of Fin 5, incidence = disjointness) makes the 10_3 self-duality a symmetry fact, fully kernel-decidable with explicit polarity tables"
+      "The pairs model (points and lines = 2-subsets of Fin 5, incidence = disjointness) makes the 10_3 self-duality a symmetry fact, fully kernel-decidable with explicit polarity tables",
+      "Intra-plane (D)=>(D*) is provable by the classical derived-configuration argument: apply Desargues to center p, triangles (q,B,B') and (r,A,A'), perspectivity lines l/ab/ab', side pairs (bc,ca),(lb,la),(bc',ca') with axis candidates C, X=la.lb (HasPoints.mkPoint), C'; the produced axis shares C != C' with lc so equals lc by Nondegenerate.eq_or_eq",
+      "The raw IsConverseDesarguesian 12-inequality schema is too weak for the derived-configuration proof: it needs 8 extra nondegeneracy hypotheses (A != B, A' != B', C not on ab, C' not on ab', A/A' off the axis, C/C' off la) and consumes only 4 of the original 12 inequalities; the mirror direction is free by duality through isDesarguesian_dual_iff"
     ],
     "mathlibGaps": [
       "Mathlib Configuration provides ProjectivePlane (L329), Dual (L46), and the instance ProjectivePlane (Dual L) (Dual P) (L338, the duality principle) — confirmed against source — but NOT perspectivity / Desargues predicates, which must be defined",
       "Gotcha: the dual swaps type order — a predicate Foo P L on the dual is Foo (Dual L) (Dual P), not Foo (Dual P) (Dual L)"
     ],
     "nextSteps": [
-      "Follow-up (genuine geometry, materially distinct): in a projective plane, Desargues implies its own converse INTRA-plane (apply (D) to a derived configuration) — would upgrade the package theorem to single-property self-duality",
       "Optional: bridge the finite 10_3 model to the abstract predicates (instantiate a Membership (Fin 10) (Fin 10) structure and derive the abstract polarity from polarity_reverses)"
     ]
   },


### PR DESCRIPTION
## Summary
Session 2 for `desargues-theorem-oq-02-oq-02`: discharges the follow-up recorded at completion — the **intra-plane** implication "Desargues implies its own converse", which is genuine geometry (the previous session's headline `isDesarguesian_dual_iff` is a pure statement swap between a plane and its dual and deliberately left this open).

## Progress
- `isDesarguesian_implies_converse` (new): in a projective plane satisfying `IsDesarguesian`, every nondegenerate axially perspective labelled triangle pair is centrally perspective. Proof is the classical derived-configuration argument: apply Desargues to center `p`, triangles `(q,B,B')` and `(r,A,A')`, perspectivity lines `l, ab, ab'`, side pairs `(bc,ca), (lb,la), (bc',ca')` with axis candidates `C`, `X = la.lb` (`HasPoints.mkPoint`), `C'`; the produced axis shares the two distinct points `C != C'` with `lc`, hence equals `lc` by `Nondegenerate.eq_or_eq`, so all three joins concur at `X`.
- `isConverseDesarguesian_implies_desargues` (new): mirror implication for free, by instantiating the first theorem in the dual plane through `isDesarguesian_dual_iff` and the polarity dictionary.
- Header "Honest scope" updated (intra-plane implication no longer open); trackers, session note, and adversarial-checklist addendum updated.
- Docker build green: `Proofs.DesarguesTheoremOQ02OQ02`, 0 sorries / 0 axioms (all finite checks remain kernel `decide`).

## Findings
- The raw `IsConverseDesarguesian` 12-inequality schema is too weak to run the derived-configuration proof: it consumes only 4 of the 12 inequalities but needs 8 extra nondegeneracy hypotheses (honest triangles `A != B`, `A' != B'`, `C` off `ab`, `C'` off `ab'`; vertices `A, A'` off the axis; `C, C'` off the join `la`). The theorem is stated at exactly the nondegeneracy it needs — this is the honest form of "single-property self-duality".
- Several derived-configuration inequalities are provable rather than assumed: `bc != ca`, `bc' != ca'` (via `eq_or_eq` + triangle nondegeneracy), `l != ab`, `l != ab'`, `C != X`, `X != C'`.

## Status
**Outcome**: completed (follow-up discharged; only an optional finite-to-abstract bridge remains)
**Next Steps**: none required

🤖 Generated by researcher-2
