### PR TITLE
Research: erdos-szekeres-oq-03 - S8 ACT-F: ramsey_existence proven (hypergraph Ramsey, 0 sorries, 0 axioms)

### DIFF
--- a/proofs/Proofs/RamseyHypergraph.lean
+++ b/proofs/Proofs/RamseyHypergraph.lean
@@ -773,6 +773,7 @@ theorem ramsey_existence_of_one_le :
           have hA_card : ((Finset.univ : Finset (Fin (m + 1))).erase v).card = m := by
             rw [Finset.card_erase_of_mem (Finset.mem_univ v), Finset.card_univ,
               Fintype.card_fin]
+            omega
           -- Run the `k`-uniform certificate on the link coloring at `v`,
           -- inside the complement of `v`.
           rcases hm.within (kColoring.link χ v) (Finset.univ.erase v) hA_card with

--- a/proofs/Proofs/RamseyHypergraph.lean
+++ b/proofs/Proofs/RamseyHypergraph.lean
@@ -21,14 +21,13 @@ diagonal hypergraph Ramsey number `R_k(s,t)` as the least `n` such that every
 monochromatic `s`-clique of one color or a monochromatic `t`-clique of the
 other.
 
-After **S4 ACT-C** (this revision) the structural foundations of
-`ramsey_existence` are in place: anti-monotonicity of the Ramsey condition
-in both target sizes, and the `s = k` / `t = k` boundary cases proved at
-`n = t` / `n = s` via a direct case-split on whether some `k`-subset is
-colored `false`. `ramsey_existence` itself is rewritten to discharge both
-boundaries; only the genuine inductive case `s > k ∧ t > k` (the Ramsey 1930
-recursive bound through uniformity `k-1`) remains `sorry`-marked, deferred to
-S5+ per `research/problems/erdos-szekeres-oq-03/state.md`.
+After **S8 ACT-F** (this revision) `ramsey_existence` is **fully proved** —
+the file is 0-sorry / 0-axiom. The Ramsey 1930 two-layer induction runs in
+`ramsey_existence_of_one_le`: outer structural induction on the uniformity
+`k` (base `k = 1` is the S3 pigeonhole), inner bounded induction on the
+target sum `s + t` (boundaries `s = k` / `t = k` are the S4
+`is_ramsey_self_*` lemmas), with the genuine step assembled from the S6/S7
+link-and-splice machinery through the new transfer lemma `IsRamsey.within`.
 
 ## Status
 
@@ -45,8 +44,13 @@ S5+ per `research/problems/erdos-szekeres-oq-03/state.md`.
   in the target sizes, by extracting a sub-clique of the desired smaller size.
 - [x] **`is_ramsey_self_right` / `is_ramsey_self_left` (S4 ACT-C)**: the
   `s = k` and `t = k` boundary cases at `n = t` and `n = s`, respectively.
-- [ ] `ramsey_existence` (OQ-03a): boundaries closed; the genuine inductive
-  case `s > k ∧ t > k` is `sorry`. Proof strategy in `state.md` (S5+).
+- [x] **`kColoring.link` / `IsMonochromatic.link_lifts` (S6 ACT-D)**: the
+  link (neighborhood) coloring and its `(k-1) → k` monochromaticity transfer.
+- [x] **`IsMonochromatic.insert_vertex` (S7 ACT-E)**: the splice composing a
+  non-vertex-side sub-clique with vertex-side link coverage.
+- [x] **`IsRamsey.within` / `ramsey_existence_of_one_le` /
+  `ramsey_existence` (S8 ACT-F)**: the transfer lemma and the full Ramsey
+  1930 double induction — OQ-03a is closed, 0 sorries, 0 axioms.
 
 ## Approach
 
@@ -648,37 +652,183 @@ lemma IsMonochromatic.insert_vertex {n k : ℕ} {χ : kColoring n} {c : Bool}
       · exact hxS'
     exact hS' T (Finset.mem_powersetCard.mpr ⟨hT_sub_S', hTcard⟩)
 
+/-! ### S8 ACT-F: the Ramsey 1930 recursion body — `ramsey_existence` closes
+
+Two final pieces complete the proof:
+
+* `IsRamsey.within` — a **transfer lemma**: an `IsRamsey ν k s t` certificate
+  can be run inside any `ν`-element vertex subset `A ⊆ Fin m`. The order
+  embedding `Fin ν ↪o Fin m` enumerating `A` (`Finset.orderEmbOfFin`) pulls
+  a coloring of `[m]^{(k)}` back to `[ν]^{(k)}`; the extracted clique maps
+  forward into `A`, with monochromaticity transported along
+  `Finset.subset_map_iff` exactly as in `IsRamsey.mono_n`.
+* `ramsey_existence_of_one_le` — the two-layer Ramsey 1930 induction:
+  **outer** structural induction on the uniformity `k` (base `k = 1` is the
+  S3 pigeonhole `isRamsey_one_iff`), **inner** bounded induction on the
+  target sum `s + t` (boundaries `s = k` / `t = k` are the S4
+  `is_ramsey_self_*` lemmas). The genuine step at uniformity `k + 1` picks
+  `n₁` with `IsRamsey n₁ (k+1) (s-1) t` and `n₂` with
+  `IsRamsey n₂ (k+1) s (t-1)` from the inner IH, then `m` with
+  `IsRamsey m k n₁ n₂` from the outer IH, and shows `m + 1` works: run the
+  `k`-uniform certificate on the link coloring at the last vertex `v`
+  (inside the `m`-element complement of `v`), then run the appropriate
+  `(k+1)`-uniform certificate inside the resulting link-monochromatic
+  clique; either it produces the *other*-colored target clique outright, or
+  a same-colored clique one short of target, which `insert_vertex` splices
+  with `v` (via `link_lifts`) to full size.
+-/
+
+/-- **Transfer lemma.** An `IsRamsey ν k s t` certificate can be run inside
+any `ν`-element vertex subset `A` of `Fin m`: every coloring of `[m]^{(k)}`
+admits a monochromatic `s`- or `t`-clique **contained in `A`**.
+
+The proof pulls `χ` back along the order embedding `Fin ν ↪o Fin m`
+enumerating `A` (`Finset.orderEmbOfFin`), extracts the clique on the `Fin ν`
+side, and maps it forward; monochromaticity transports along
+`Finset.subset_map_iff` exactly as in `IsRamsey.mono_n` (of which this is
+the relativized refinement: `mono_n` is essentially the case `A = univ`). -/
+lemma IsRamsey.within {ν k s t : ℕ} (hR : IsRamsey ν k s t)
+    {m : ℕ} (χ : kColoring m) (A : Finset (Fin m)) (hA : A.card = ν) :
+    (∃ S : Finset (Fin m), S ⊆ A ∧ S.card = s ∧ IsMonochromatic χ k S false) ∨
+    (∃ S : Finset (Fin m), S ⊆ A ∧ S.card = t ∧ IsMonochromatic χ k S true) := by
+  classical
+  let f : Fin ν ↪ Fin m := (A.orderEmbOfFin hA).toEmbedding
+  have hf_mem : ∀ i, f i ∈ A := fun i => A.orderEmbOfFin_mem hA i
+  let χ' : kColoring ν := fun S => χ (S.map f)
+  -- Monochromaticity for the pulled-back coloring pushes forward along `f`.
+  have transfer : ∀ (S : Finset (Fin ν)) (c : Bool), IsMonochromatic χ' k S c →
+      IsMonochromatic χ k (S.map f) c := by
+    intro S c hSm T hT
+    rw [Finset.mem_powersetCard] at hT
+    obtain ⟨hTsub, hTcard⟩ := hT
+    obtain ⟨T₀, hT₀sub, hT₀eq⟩ := Finset.subset_map_iff.mp hTsub
+    have hT₀card : T₀.card = k := by
+      have hcard := congrArg Finset.card hT₀eq
+      rw [Finset.card_map] at hcard
+      omega
+    have key : χ' T₀ = c := hSm T₀ (Finset.mem_powersetCard.mpr ⟨hT₀sub, hT₀card⟩)
+    rw [hT₀eq]
+    exact key
+  have hsub : ∀ S : Finset (Fin ν), S.map f ⊆ A := by
+    intro S x hx
+    rcases Finset.mem_map.mp hx with ⟨i, _, rfl⟩
+    exact hf_mem i
+  rcases hR χ' with ⟨S, hSc, hSm⟩ | ⟨S, hSc, hSm⟩
+  · exact Or.inl ⟨S.map f, hsub S, by rw [Finset.card_map]; exact hSc,
+      transfer S false hSm⟩
+  · exact Or.inr ⟨S.map f, hsub S, by rw [Finset.card_map]; exact hSc,
+      transfer S true hSm⟩
+
+/-- **Ramsey's hypergraph theorem, full parameter range `k ≥ 1`.** The
+two-layer Ramsey 1930 induction; see the section docstring above for the
+architecture. Stated with explicit `∀` binders so both induction layers can
+be run without generalization bookkeeping. -/
+theorem ramsey_existence_of_one_le :
+    ∀ k s t : ℕ, 1 ≤ k → k ≤ s → k ≤ t → ∃ n, IsRamsey n k s t := by
+  intro k
+  induction k with
+  | zero => intro s t h1 _ _; exact absurd h1 (by omega)
+  | succ k ihk =>
+    rcases Nat.eq_zero_or_pos k with rfl | hk1
+    · -- Uniformity 1: the pigeonhole bound `n = s + t - 1` (S3).
+      intro s t _ hs ht
+      exact ⟨s + t - 1, (isRamsey_one_iff (s + t - 1) s t hs ht).mpr le_rfl⟩
+    · -- Uniformity `k + 1 ≥ 2`. Outer IH is available at uniformity `k`.
+      have IH : ∀ s' t', k ≤ s' → k ≤ t' → ∃ n, IsRamsey n k s' t' :=
+        fun s' t' => ihk s' t' hk1
+      -- Inner bounded induction on the target sum `s + t`.
+      have H : ∀ N s t, s + t ≤ N → k + 1 ≤ s → k + 1 ≤ t →
+          ∃ n, IsRamsey n (k + 1) s t := by
+        intro N
+        induction N with
+        | zero => intro s t hsum hs _; exact absurd hsum (by omega)
+        | succ N ihN =>
+          intro s t hsum hs ht
+          rcases eq_or_lt_of_le hs with hs_eq | hs_lt
+          · -- `s = k + 1` boundary: `n = t` via `is_ramsey_self_right`.
+            refine ⟨t, ?_⟩
+            rw [← hs_eq]
+            exact is_ramsey_self_right (k + 1) t (by omega) ht
+          rcases eq_or_lt_of_le ht with ht_eq | ht_lt
+          · -- `t = k + 1` boundary: `n = s` via `is_ramsey_self_left`.
+            refine ⟨s, ?_⟩
+            rw [← ht_eq]
+            exact is_ramsey_self_left (k + 1) s (by omega) hs
+          -- Genuine case `s > k + 1 ∧ t > k + 1`: the Ramsey 1930 recursion.
+          -- Inner IH at the two shrunk targets (each sum drops below `N + 1`).
+          obtain ⟨n₁', hn₁'⟩ := ihN (s - 1) t (by omega) (by omega) ht
+          obtain ⟨n₂', hn₂'⟩ := ihN s (t - 1) (by omega) hs (by omega)
+          -- Enlarge both witnesses to `≥ k` so they are legal `k`-uniform targets.
+          have hn₁ : IsRamsey (max n₁' k) (k + 1) (s - 1) t :=
+            IsRamsey.mono_n (le_max_left _ _) hn₁'
+          have hn₂ : IsRamsey (max n₂' k) (k + 1) s (t - 1) :=
+            IsRamsey.mono_n (le_max_left _ _) hn₂'
+          -- Outer IH: a `k`-uniform certificate targeting those two sizes.
+          obtain ⟨m, hm⟩ := IH (max n₁' k) (max n₂' k)
+            (le_max_right _ _) (le_max_right _ _)
+          refine ⟨m + 1, ?_⟩
+          intro χ
+          -- Distinguished vertex and its `m`-element complement.
+          set v : Fin (m + 1) := Fin.last m
+          have hA_card : ((Finset.univ : Finset (Fin (m + 1))).erase v).card = m := by
+            rw [Finset.card_erase_of_mem (Finset.mem_univ v), Finset.card_univ,
+              Fintype.card_fin]
+          -- Run the `k`-uniform certificate on the link coloring at `v`,
+          -- inside the complement of `v`.
+          rcases hm.within (kColoring.link χ v) (Finset.univ.erase v) hA_card with
+            ⟨S, hSsub, hScard, hSm⟩ | ⟨S, hSsub, hScard, hSm⟩
+          · -- Link-mono-**false** `(k)`-clique `S`, `|S| = max n₁' k ≥ n₁'`.
+            have hvS : v ∉ S := fun hv' => (Finset.mem_erase.mp (hSsub hv')).1 rfl
+            -- Run the `(k+1)`-uniform certificate `hn₁` inside `S`.
+            rcases hn₁.within χ S hScard with
+              ⟨S', hS'sub, hS'card, hS'm⟩ | ⟨S', _, hS'card, hS'm⟩
+            · -- χ-mono-false `(s-1)`-clique `S' ⊆ S`: splice `v` in.
+              have hvS' : v ∉ S' := fun hv' => hvS (hS'sub hv')
+              have hLink : ∀ T ∈ (insert v S').powersetCard (k + 1), v ∈ T →
+                  χ T = false := fun T hT hvT =>
+                IsMonochromatic.link_lifts (k := k + 1) χ v false S hvS hSm T
+                  (Finset.powersetCard_mono (Finset.insert_subset_insert v hS'sub) hT)
+                  hvT
+              refine Or.inl ⟨insert v S', ?_,
+                IsMonochromatic.insert_vertex hvS' hS'm hLink⟩
+              rw [Finset.card_insert_of_notMem hvS', hS'card]
+              omega
+            · -- χ-mono-true `t`-clique: done outright.
+              exact Or.inr ⟨S', hS'card, hS'm⟩
+          · -- Link-mono-**true** `(k)`-clique `S`, `|S| = max n₂' k ≥ n₂'`: symmetric.
+            have hvS : v ∉ S := fun hv' => (Finset.mem_erase.mp (hSsub hv')).1 rfl
+            rcases hn₂.within χ S hScard with
+              ⟨S', _, hS'card, hS'm⟩ | ⟨S', hS'sub, hS'card, hS'm⟩
+            · -- χ-mono-false `s`-clique: done outright.
+              exact Or.inl ⟨S', hS'card, hS'm⟩
+            · -- χ-mono-true `(t-1)`-clique `S' ⊆ S`: splice `v` in.
+              have hvS' : v ∉ S' := fun hv' => hvS (hS'sub hv')
+              have hLink : ∀ T ∈ (insert v S').powersetCard (k + 1), v ∈ T →
+                  χ T = true := fun T hT hvT =>
+                IsMonochromatic.link_lifts (k := k + 1) χ v true S hvS hSm T
+                  (Finset.powersetCard_mono (Finset.insert_subset_insert v hS'sub) hT)
+                  hvT
+              refine Or.inr ⟨insert v S', ?_,
+                IsMonochromatic.insert_vertex hvS' hS'm hLink⟩
+              rw [Finset.card_insert_of_notMem hvS', hS'card]
+              omega
+      intro s t _ hs ht
+      exact H (s + t) s t le_rfl hs ht
+
 /-- (OQ-03a) **Ramsey's hypergraph theorem.** For every uniformity `k ≥ 2`
 and every pair of target sizes `s, t ≥ k`, there is a finite `n` such that
 every 2-coloring of `[n]^{(k)}` contains a monochromatic `s`- or `t`-clique.
 
-This is the main result of the OQ-03 entry. The proof is the classical Ramsey
-1930 two-layer induction on `k` (uniformity) and `s + t` (target sizes), with
-the two boundary cases `s = k` and `t = k` discharged by `is_ramsey_self_right`
-and `is_ramsey_self_left`, respectively. The genuine inductive case
-`s > k ∧ t > k` (which requires the neighborhood-collapse construction of
-Ramsey 1930) is deferred to S5+.
-
-Status after S4 ACT-C:
-* `s = k`: closed via `is_ramsey_self_right`, take `n = t`.
-* `t = k`: closed via `is_ramsey_self_left`, take `n = s`.
-* `s > k ∧ t > k`: `sorry` (S5 target — the recursive Ramsey bound). -/
+This is the main result of the OQ-03 entry, now fully proved (S8 ACT-F): it
+is the `k ≥ 2` restriction of `ramsey_existence_of_one_le`, the classical
+Ramsey 1930 two-layer induction on `k` (uniformity, outer layer) and `s + t`
+(target sizes, inner layer). Boundary cases `s = k` / `t = k` are
+`is_ramsey_self_right` / `is_ramsey_self_left`; the genuine inductive case
+runs the neighborhood-collapse recursion through `kColoring.link`,
+`IsRamsey.within`, `IsMonochromatic.link_lifts`, and
+`IsMonochromatic.insert_vertex`. -/
 theorem ramsey_existence (k s t : ℕ) (hk : 2 ≤ k) (hs : k ≤ s) (ht : k ≤ t) :
-    ∃ n, IsRamsey n k s t := by
-  rcases eq_or_lt_of_le hs with hs_eq | hs_lt
-  · -- s = k boundary: n = t suffices by `is_ramsey_self_right`.
-    refine ⟨t, ?_⟩
-    rw [← hs_eq]
-    exact is_ramsey_self_right k t (by omega) ht
-  · rcases eq_or_lt_of_le ht with ht_eq | ht_lt
-    · -- t = k boundary: n = s suffices by `is_ramsey_self_left`.
-      refine ⟨s, ?_⟩
-      rw [← ht_eq]
-      exact is_ramsey_self_left k s (by omega) hs
-    · -- s > k ∧ t > k: the genuine inductive case (Ramsey 1930 recursive
-      -- bound). Deferred to S5+: the neighborhood-collapse construction
-      -- reduces uniformity `k` to `k-1` on a `(k-1)`-uniform induced
-      -- coloring, then recurses on `s + t`.
-      sorry
+    ∃ n, IsRamsey n k s t :=
+  ramsey_existence_of_one_le k s t (by omega) hs ht
 
 end RamseyK

--- a/research/problems/erdos-szekeres-oq-03/state.md
+++ b/research/problems/erdos-szekeres-oq-03/state.md
@@ -1,16 +1,60 @@
 # Current State
 
-**BLOCKED** (2026-06-13, researcher-6): S8 ACT-F (close the last `ramsey_existence` sorry via `Nat.strongRecOn`) is Docker-gated, and the S4/S6/S7 ACT-stack in `RamseyHypergraph.lean` is build-pending/unverified (S7 session: "Build status — NOT verified locally"). All forward progress needs a Docker build; daemon down (blackout 2026-06-13). Trackers in sync with source (688 LOC, 1 real sorry) — holding for Docker, no further PREP.
+**OQ-03a PROVED** (2026-07-24, researcher-1, S8 ACT-F): the last
+`ramsey_existence` sorry is closed — `RamseyHypergraph.lean` is
+**0-sorry / 0-axiom** (835 LOC, 21 theorems). The June Docker blackout
+blocker is resolved; the whole S4–S8 stack host-verified under v4.31
+(`lake env lean` exit 0, no errors, no sorry warnings). Remaining
+sub-goals: OQ-03b (Erdős–Rado tower upper bound) and OQ-03c
+(Erdős–Hajnal stepping-up lower bound).
 
-**Phase**: ACT (S7 lands the splice lemma `IsMonochromatic.insert_vertex`,
-the last non-recursive ingredient for the Ramsey 1930 induction; the
-`s > k ∧ t > k` sorry in `ramsey_existence` remains, but is now a pure
-recursion-body question with no missing sub-lemmas)
-**Since**: 2026-06-04 (S7 ACT-E, researcher-1)
-**Iteration**: 7
-**Researcher**: researcher-1 (S7 ACT-E, S5-prep, S4-prep); researcher-9 (S6 ACT-D, S4 ACT-C, S2); researcher-11 (S3); researcher-8 (S1)
+**Phase**: ACT (S8 closes OQ-03a; S9 targets the quantitative
+Erdős–Rado recursion, OQ-03b)
+**Since**: 2026-07-24 (S8 ACT-F, researcher-1)
+**Iteration**: 8
+**Researcher**: researcher-1 (S8 ACT-F, S7 ACT-E, S5-prep, S4-prep); researcher-9 (S6 ACT-D, S4 ACT-C, S2); researcher-11 (S3); researcher-8 (S1)
 
 ## Current Focus
+
+Session 8 (S8 ACT-F, researcher-1, 2026-07-24): run the Ramsey 1930
+recursion body, close the file's last sorry. Two new declarations
+(lines 684 → 835, +151):
+
+* `IsRamsey.within {ν k s t} (hR : IsRamsey ν k s t) {m}
+  (χ : kColoring m) (A : Finset (Fin m)) (hA : A.card = ν)` — the
+  **transfer lemma**: run a Ramsey certificate inside any size-matched
+  vertex subset `A`, producing a monochromatic `s`- or `t`-clique
+  **contained in `A`**. Pulls `χ` back along
+  `(A.orderEmbOfFin hA).toEmbedding`, extracts the clique on the
+  `Fin ν` side, pushes forward; monochromaticity transports along
+  `Finset.subset_map_iff` (the `mono_n` pattern, relativized). This one
+  lemma serves both restriction steps of the classical proof.
+* `ramsey_existence_of_one_le : ∀ k s t, 1 ≤ k → k ≤ s → k ≤ t →
+  ∃ n, IsRamsey n k s t` — the two-layer induction. Outer: structural
+  induction on `k`; base `k = 1` is `isRamsey_one_iff` with
+  `n = s + t - 1`. Inner: **bounded** induction on `s + t ≤ N` (plain
+  `Nat.rec` — deliberately avoids `Nat.strongRecOn` naming/API drift);
+  boundaries `s = k` / `t = k` via `is_ramsey_self_right/left`. Genuine
+  step (`s, t > k + 1`): inner IH gives `n₁` for `(s-1, t)` and `n₂`
+  for `(s, t-1)`, bumped to `max nᵢ k` via `mono_n` to satisfy the
+  outer IH's target-size side conditions; outer IH gives `m` with
+  `IsRamsey m k (max n₁ k) (max n₂ k)`; witness is `m + 1`. For any
+  `χ`: run the `k`-uniform certificate on `kColoring.link χ v`
+  (`v = Fin.last m`) within `univ.erase v` (`IsRamsey.within`); in the
+  link-mono-`c` clique `S`, run `hn₁`/`hn₂` within `S`; either the
+  opposite-color full-size clique appears outright, or a `c`-colored
+  clique one short of target is spliced with `v` via `link_lifts` +
+  `insert_vertex` (`powersetCard_mono` bridges
+  `insert v S' ⊆ insert v S`).
+* `ramsey_existence` now delegates to `ramsey_existence_of_one_le`.
+
+Build: host-verified via sibling-worktree Mathlib oleans
+(`lake env lean`, toolchain v4.31.0), exit 0. `leanFile` counts:
+lineCount 684 → 835, theoremCount 19 → 21 (+`within`,
++`ramsey_existence_of_one_le`), defCount 5, sorryCount 1 → 0,
+axiomCount 0.
+
+## Prior Session Focus (S7 ACT-E)
 
 Session 7 (S7 ACT-E, researcher-1, 2026-06-04): land the splice lemma
 `IsMonochromatic.insert_vertex` — the single missing ingredient
@@ -206,52 +250,39 @@ adequate but verbose.
 
 ## Next Action
 
-**S8 ACT-F — Run the Ramsey 1930 induction body, close the file's
-last sorry.**
+**S9 — Quantitative Erdős–Rado recursion (OQ-03b).**
 
-With S7 ACT-E's `IsMonochromatic.insert_vertex` landed, the
-non-recursive ingredients of the Ramsey 1930 proof are complete:
+OQ-03a is closed (S8 ACT-F). The next quantitative layer:
 
-* Monotonicity toolkit: `anti_s`, `anti_t`, `mono_n`, `mono`, `swap`.
-* Boundary cases: `is_ramsey_self_right` (s = k), `is_ramsey_self_left`
-  (t = k).
-* Link/neighborhood machinery: `kColoring.link`, `link_apply`,
-  `link_lifts` (vertex-side `(k-1) → k` mono transfer).
-* Splice: `IsMonochromatic.insert_vertex` (this PR).
-
-The remaining work for the `s > k ∧ t > k` case of `ramsey_existence`
-is the recursion body itself:
-
-1. Set `n = R_{k-1}(R_k(s-1, t) + 1, R_k(s, t-1) + 1) + 1` (IH on
-   `k - 1` at the lifted target sizes).
-2. Pick vertex `v = ⟨0, _⟩`.
-3. Restrict `χ.link v` to `Fin (n-1)` (need a `castLE`-style
-   embedding) ⇒ apply `IH(k-1)` to extract a `(k-1)`-mono clique `S`
-   of size `R_k(s-1, t) + 1` (false case) or `R_k(s, t-1) + 1` (true
-   case).
-4. WLOG false case: apply `IH(k, s' + t)` with `s' = s - 1` to `χ`
-   restricted to `S` (size `> R_k(s-1, t)` by `mono_n`) ⇒ either a
-   `k`-mono-false `(s-1)`-clique `S' ⊆ S` (use `insert_vertex` to
-   extend by `v` to a `k`-mono-false `s`-clique) or a `k`-mono-true
-   `t`-clique on `S` (done).
-
-The induction needs to be on the lexicographic pair `(k, s + t)`,
-which requires an explicit termination argument
-(`WellFoundedRecursion` or `decreasing_by`-style). Estimated 80–120
-LOC. Once landed, the file becomes 0-sorry / 0-axiom and the gallery
-badge can flip from `wip` to `verified` for the OQ-03 entry.
-
-S9+ will state the Erdős–Rado tower upper bound `erdos_rado_upper`.
+1. **S9-prep glue lemmas** relating `ramseyNumber` (an `sInf`) to the
+   S8 witnesses:
+   * `ramseyNumber_le_of_isRamsey : IsRamsey n k s t →
+     ramseyNumber k s t ≤ n` (`Nat.sInf_le`);
+   * `isRamsey_ramseyNumber : 1 ≤ k → k ≤ s → k ≤ t →
+     IsRamsey (ramseyNumber k s t) k s t` (`Nat.sInf_mem` on the set
+     shown nonempty by `ramsey_existence_of_one_le`; note the set
+     `{n | IsRamsey n k s t}` is upward-closed by `mono_n`, so its
+     `sInf` is a genuine member).
+2. **S9 main**: the recursive Erdős–Rado inequality
+   `ramseyNumber (k+1) s t ≤
+    ramseyNumber k (ramseyNumber (k+1) (s-1) t) (ramseyNumber (k+1) s (t-1)) + 1`
+   — the proof is exactly the S8 genuine-case body run at the `sInf`
+   witnesses instead of bare existentials (reuse `IsRamsey.within`,
+   `link_lifts`, `insert_vertex` verbatim).
+3. **S10+**: unwind the recursion into the tower bound
+   `tower (k-1) (c_k * s)`, and/or spawn OQ-03c (Erdős–Hajnal
+   stepping-up lower bound) per the S-up-4 PREP notes below.
 
 ## Attempt Counts
 
-- Total attempts: 7
-- Current approach attempts: 7
-- Approaches tried: 7 (literature survey + Lean API design; S2 scaffold;
+- Total attempts: 8
+- Current approach attempts: 8
+- Approaches tried: 8 (literature survey + Lean API design; S2 scaffold;
   S3 `ramseyNumber_one` via pigeonhole iff helper; S4 ACT-C boundary
   factoring + anti-monotonicity; S5-prep monotonicity helpers; S6 ACT-D
   link/neighborhood coloring infrastructure; S7 ACT-E splice lemma
-  `insert_vertex`)
+  `insert_vertex`; S8 ACT-F transfer lemma `IsRamsey.within` + two-layer
+  induction `ramsey_existence_of_one_le` — OQ-03a closed)
 
 ## Outcome of S1
 

--- a/src/data/research/problems/erdos-szekeres-oq-03.json
+++ b/src/data/research/problems/erdos-szekeres-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "erdos-szekeres-oq-03",
   "title": "Ramsey Numbers for k-Uniform Hypergraphs (generalization of Erdős–Szekeres)",
   "phase": "ORIENT",
-  "status": "blocked",
+  "status": "in-progress",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -29,21 +29,19 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-06-04",
-    "iteration": 7,
-    "focus": "S7 ACT-E (researcher-1): landed IsMonochromatic.insert_vertex — the splice lemma composing a non-vertex-side k-mono sub-clique S' (hvS' : v ∉ S', hS' : IsMonochromatic χ k S' c) with vertex-side link-derived coverage (hLink, produced by IsMonochromatic.link_lifts) to yield the k-mono clique insert v S' of size |S'|+1, by a by_cases on v ∈ T for each k-subset T ⊆ insert v S' (v ∈ T discharged by hLink, v ∉ T by hS' on T ⊆ S'). One sorry-free declaration; lines 654 → 688 (+34), theoremCount 18 → 19, defCount unchanged, sorries unchanged at 1, axioms 0. With insert_vertex landed, the non-recursive ingredients of the Ramsey 1930 proof are complete; the lone surviving sorry is the genuine s>k ∧ t>k recursive case in ramsey_existence.",
-    "blockers": [
-      "Docker daemon down (blackout 2026-06-13): S8 ACT-F and the build-pending S4/S6/S7 ACT-stack in RamseyHypergraph.lean cannot be verified; all forward progress is Docker-gated."
-    ],
-    "nextAction": "S8 ACT-F: run the Nat.strongRecOn induction body in ramsey_existence to close the file's last sorry (the genuine s>k ∧ t>k recursive case of Ramsey 1930), now that all non-recursive ingredients — insert_vertex (the splice), link_lifts (the (k-1)→k transfer), kColoring.link, and the anti_s / anti_t / mono_n / swap infrastructure — are in place. Build-gated: requires a docker-build.sh verification of RamseyHypergraph.lean.",
+    "since": "2026-07-24",
+    "iteration": 8,
+    "focus": "S8 ACT-F (researcher-1, 2026-07-24): CLOSED the last sorry in ramsey_existence — OQ-03a (Ramsey 1930 existence for k-uniform hypergraphs) is fully proved, 0 sorries / 0 axioms. Two new declarations in RamseyHypergraph.lean: (1) IsRamsey.within, a transfer lemma running an IsRamsey ν k s t certificate inside any ν-element vertex subset A ⊆ Fin m via Finset.orderEmbOfFin pull-back (relativized mono_n); (2) ramsey_existence_of_one_le, the two-layer Ramsey 1930 induction — outer structural induction on uniformity k (base k=1 via isRamsey_one_iff pigeonhole), inner bounded induction on s+t (boundaries via is_ramsey_self_right/left), genuine step: inner IH gives n1 (for (s-1,t)) and n2 (for (s,t-1)), bumped to ≥ k via mono_n; outer IH gives m with IsRamsey m k n1 n2; at n = m+1, run the k-uniform certificate on kColoring.link χ v (v = Fin.last m) within the m-element complement of v (IsRamsey.within), then run hn1/hn2 within the resulting link-mono clique S: either the opposite-color full-size clique appears outright, or a same-color clique one short of target is spliced with v via link_lifts + insert_vertex. ramsey_existence delegates. Verified: lake env lean exit 0 (v4.31, sibling-olean host check), 0 errors, no sorry warnings. Lines 684 → 835, theoremCount 19 → 21, defCount 5, sorryCount 1 → 0, axiomCount 0.",
+    "blockers": [],
+    "nextAction": "S9: state and prove the Erdős–Rado tower upper bound (OQ-03b): erdos_rado_upper as ramseyNumber (k) s s ≤ tower (k-1) (c_k * s), or the recursive bound ramseyNumber k s t ≤ ramseyNumber (k-1) (ramseyNumber k (s-1) t) (ramseyNumber k s (t-1)) + 1 — the quantitative refinement of the (now proven) existence recursion. Requires relating sInf-defined ramseyNumber to the constructive witnesses of ramsey_existence_of_one_le (Nat.sInf_le + membership). OQ-03c (Erdős–Hajnal stepping-up lower) remains the deep half.",
     "attemptCounts": {
-      "total": 7,
-      "currentApproach": 7,
-      "approachesTried": 7
+      "total": 8,
+      "currentApproach": 8,
+      "approachesTried": 8
     }
   },
   "knowledge": {
-    "progressSummary": "S7 ACT-E (researcher-1 2026-06-04): landed IsMonochromatic.insert_vertex in RamseyHypergraph.lean — the sorry-free splice lemma that composes a non-vertex-side k-mono sub-clique S' with the vertex-side link-derived coverage hLink (from link_lifts) to produce the k-mono clique insert v S' of size |S'|+1, via by_cases on v-membership of each k-subset T. Lines 654→688 (+34), theoremCount 18→19, sorries unchanged at 1, axioms 0. This completes all non-recursive ingredients of the Ramsey 1930 induction; the lone surviving sorry is the genuine s>k ∧ t>k recursive case in ramsey_existence, scheduled for S8 ACT-F (Nat.strongRecOn body). S6 ACT-D scaffolding (researcher-9 2026-05-12): added 2 sorry-free declarations to RamseyHypergraph.lean — kColoring.link (the link/neighborhood coloring at a vertex v, χ.link v T = χ (insert v T), with a defining simp lemma kColoring.link_apply) and IsMonochromatic.link_lifts (the vertex-side (k-1) → k monochromaticity transfer: if S ⊆ Fin n \\ {v} is (k-1)-mono for χ.link v at colour c, then every k-subset T ⊆ insert v S containing v has χ T = c). Proof of link_lifts: decompose T = insert v T' where T' = T.erase v, show T' ⊆ S and |T'| = k-1, then evaluate hSm on T' through kColoring.link_apply. Lines 584→654 (+70), sorries unchanged at 1, axioms 0. Previous S5-prep monotonicity helpers (researcher-1 PR #18122) provided IsMonochromatic.mono, IsRamsey.mono_n, ramseyNumber_swap.",
+    "progressSummary": "S8 ACT-F (researcher-1 2026-07-24): OQ-03a PROVED — ramsey_existence (Ramsey 1930, k-uniform hypergraph Ramsey existence for k ≥ 2, s,t ≥ k) is sorry-free via the new IsRamsey.within transfer lemma + ramsey_existence_of_one_le double induction (outer on k with pigeonhole base, inner bounded on s+t with is_ramsey_self_* boundaries, genuine step by link-coloring neighborhood collapse + insert_vertex splice). RamseyHypergraph.lean is now 0-sorry / 0-axiom (835 lines, 21 theorems). Host-verified exit 0 under v4.31. Prior: S7 ACT-E (researcher-1 2026-06-04): landed IsMonochromatic.insert_vertex in RamseyHypergraph.lean — the sorry-free splice lemma that composes a non-vertex-side k-mono sub-clique S' with the vertex-side link-derived coverage hLink (from link_lifts) to produce the k-mono clique insert v S' of size |S'|+1, via by_cases on v-membership of each k-subset T. Lines 654→688 (+34), theoremCount 18→19, sorries unchanged at 1, axioms 0. This completes all non-recursive ingredients of the Ramsey 1930 induction; the lone surviving sorry is the genuine s>k ∧ t>k recursive case in ramsey_existence, scheduled for S8 ACT-F (Nat.strongRecOn body). S6 ACT-D scaffolding (researcher-9 2026-05-12): added 2 sorry-free declarations to RamseyHypergraph.lean — kColoring.link (the link/neighborhood coloring at a vertex v, χ.link v T = χ (insert v T), with a defining simp lemma kColoring.link_apply) and IsMonochromatic.link_lifts (the vertex-side (k-1) → k monochromaticity transfer: if S ⊆ Fin n \\ {v} is (k-1)-mono for χ.link v at colour c, then every k-subset T ⊆ insert v S containing v has χ T = c). Proof of link_lifts: decompose T = insert v T' where T' = T.erase v, show T' ⊆ S and |T'| = k-1, then evaluate hSm on T' through kColoring.link_apply. Lines 584→654 (+70), sorries unchanged at 1, axioms 0. Previous S5-prep monotonicity helpers (researcher-1 PR #18122) provided IsMonochromatic.mono, IsRamsey.mono_n, ramseyNumber_swap.",
     "builtItems": [
       "proofs/Proofs/RamseyHypergraph.lean — IsRamsey.anti_s, IsRamsey.anti_t, is_ramsey_self_right, is_ramsey_self_left + boundary-discharging ramsey_existence (S4 ACT-C, researcher-9).",
       "proofs/Proofs/RamseyHypergraph.lean — IsRamsey.swap (color symmetry), ramseyNumber_zero_false, ramseyNumber_zero_true (S4-prep, researcher-1).",
@@ -57,7 +55,10 @@
       "proofs/Proofs/RamseyHypergraph.lean — ramseyNumber_swap (S5-prep: sInf-set congruence corollary of IsRamsey.swap; researcher-1).",
       "proofs/Proofs/RamseyHypergraph.lean — kColoring.link + kColoring.link_apply (S6 ACT-D: link/neighborhood coloring at a vertex with defining simp lemma; researcher-9).",
       "proofs/Proofs/RamseyHypergraph.lean — IsMonochromatic.link_lifts (S6 ACT-D: vertex-side (k-1) → k monochromaticity transfer for the Ramsey 1930 recursion; researcher-9).",
-      "proofs/Proofs/RamseyHypergraph.lean — IsMonochromatic.insert_vertex (S7 ACT-E: the splice lemma joining a non-vertex-side k-mono sub-clique with vertex-side link coverage to form insert v S' of size |S'|+1; the last non-recursive ingredient of Ramsey 1930; researcher-1)."
+      "proofs/Proofs/RamseyHypergraph.lean — IsMonochromatic.insert_vertex (S7 ACT-E: the splice lemma joining a non-vertex-side k-mono sub-clique with vertex-side link coverage to form insert v S' of size |S'|+1; the last non-recursive ingredient of Ramsey 1930; researcher-1).",
+      "IsRamsey.within in RamseyHypergraph.lean — transfer lemma: an IsRamsey ν k s t certificate yields a monochromatic s- or t-clique inside any ν-element A ⊆ Fin m, via orderEmbOfFin pull-back + subset_map_iff transport",
+      "ramsey_existence_of_one_le in RamseyHypergraph.lean — full k ≥ 1 hypergraph Ramsey existence, two-layer Ramsey 1930 induction",
+      "ramsey_existence (OQ-03a) in RamseyHypergraph.lean — now sorry-free, delegates to ramsey_existence_of_one_le"
     ],
     "insights": [
       "The s=k boundary case is settled at n=t by a direct Bool case-split: either some k-subset is colored false (it IS the mono-false k-clique, since |S|=k forces |T|=|S| ⇒ T=S for any k-sub-subset T ⊆ S, via Finset.eq_of_subset_of_card_le), or every k-subset is colored true (and Finset.univ : Finset (Fin t) is the mono-true t-clique).",
@@ -74,7 +75,11 @@
       "The link_lifts proof relies on the Finset.insert_erase + Finset.card_erase_of_mem decomposition: every k-subset T ⊆ insert v S containing v factors uniquely as insert v T' where T' = T.erase v ⊆ S has card k-1, so monochromaticity of S for the link at uniformity k-1 transfers to χ-monochromaticity of T.",
       "S-up-4 PREP (2026-05-13, researcher-6): the standard (2s−1)-clique formula for the stepping-up lemma is sufficient for the ES-based extraction proof path only at s=2. For s≥3 the tight clique size (s−1)²+2 is mandatory (since δ-walk of length (2s−1)−1 = 2s−2 is too short for sequence ES to extract a monotone-of-length-s subsequence: (s−1)²+1 elements are needed; (2s−2) − ((s−1)²+1) = −(s−2)² ≤ 0 with equality only at s=2). The textbook (2s−1) clique size derives from a different recursive-link-coloring proof, not from ES extraction; S-up-4 must use the tight formula or commit to the textbook proof path as a separate sub-OQ.",
       "The δ-walk of a clique T₀ ⊆ Fin(2^N) is not injective in general (concrete N=3 counterexample: T₀={0,1,4,5,6} ⟹ δ-walk = (0,0,0,0)), so neither the in-repo erdos_szekeres_existence (ErdosSzekeres.lean:141, requires Injective f) nor the Mathlib archive Theorems100.erdos_szekeres (AscendingDescendingSequences.lean:139, also requires Injective f) applies directly to δ-walks. Resolution: prove erdos_szekeres_existence_weak (no injectivity requirement, weakly monotone output) as a corollary of the existing axiom via the lex-paired sequence f̃(j) = (f j, j); the weak output upgrades to strict on monochromatic sub-cliques via Lemma A.1 case 3.",
-      "Nat.eq_of_testBit_eq (used by S-up-1 PREP §2.3 for the differing-bit witness in stepUp.delta) is in Lean core at src/Init/Data/Nat/Bitwise/Lemmas.lean:189, not in Mathlib — no extra Mathlib import is required beyond Nat.testBit. Companion bit-arithmetic citations pinned for S-up-2/S-up-4: Nat.lt_of_testBit at Mathlib/Data/Nat/Bitwise.lean:192 (the inequality powering Lemma A.1 case-split), StrictMono.injective at Mathlib/Order/Monotone/Basic.lean:402, Nat.find_spec at Mathlib/Data/Nat/Find.lean:74. Phantom to avoid: Monotone.injective does not exist (constant functions are monotone but not injective)."
+      "Nat.eq_of_testBit_eq (used by S-up-1 PREP §2.3 for the differing-bit witness in stepUp.delta) is in Lean core at src/Init/Data/Nat/Bitwise/Lemmas.lean:189, not in Mathlib — no extra Mathlib import is required beyond Nat.testBit. Companion bit-arithmetic citations pinned for S-up-2/S-up-4: Nat.lt_of_testBit at Mathlib/Data/Nat/Bitwise.lean:192 (the inequality powering Lemma A.1 case-split), StrictMono.injective at Mathlib/Order/Monotone/Basic.lean:402, Nat.find_spec at Mathlib/Data/Nat/Find.lean:74. Phantom to avoid: Monotone.injective does not exist (constant functions are monotone but not injective).",
+      "The Ramsey 1930 recursion needs no ramseyNumber arithmetic at existence level: carrying bare witnesses (n1, n2, m) through ∃-statements avoids all sInf reasoning; only OQ-03b (quantitative bound) needs ramseyNumber lemmas.",
+      "IsRamsey.within (certificate transfer into any size-matched vertex subset via Finset.orderEmbOfFin) subsumes both restriction steps of the classical proof — restricting to the complement of v AND to the link-monochromatic clique — and generalizes mono_n at zero extra cost.",
+      "Bumping IH witnesses to max n k via mono_n is the clean way to meet the k ≤ s, k ≤ t side conditions of the outer induction hypothesis; no separate lower-bound lemma for Ramsey witnesses is needed.",
+      "Bounded induction (s + t ≤ N over plain Nat.rec) avoids Nat.strongRecOn / strong_induction_on naming drift entirely — more robust under toolchain migration than the originally planned strongRecOn body."
     ],
     "mathlibGaps": [
       "No general hypergraph Ramsey number — only SimpleGraph.ramseyNumber (k=2).",
@@ -82,10 +87,9 @@
       "Tower function (iterated 2^·) is not packaged but can be obtained via Nat.iterate."
     ],
     "nextSteps": [
-      "S7 ACT-E: combine kColoring.link / link_lifts (S6) with anti_s / anti_t / mono_n (S4-S5) to discharge the genuine inductive case s>k ∧ t>k of ramsey_existence. Build IsMonochromatic.insert_vertex first (splice lemma: a k-mono sub-clique S' ⊆ S plus link-monochromaticity of S at colour c imply insert v S' is k-mono at c), then double-induct on k and s+t with is_ramsey_self_* as base.",
-      "S8: state erdos_rado_upper as ramseyNumber k s s ≤ tower (k-1) (c_k * s) and unwind R_k(s,t) ≤ R_{k-1}(R_k(s-1,t), R_k(s,t-1)) + 1.",
-      "S9+: spawn the Erdős–Hajnal stepping-up lower bound (OQ-03c) as a separate sub-OQ if S8 lands cleanly.",
-      "S-up-4 ACT (after S-up-1/2/3 land): state stepUp.stepping_up_lower_bound with clique size (s−1)²+2 (not 2s−1); first define WeaklyIncreasingSubseq / WeaklyDecreasingSubseq and prove erdos_szekeres_existence_weak via lex-paired sequence bridge (~30 LOC, no new axiom); then assemble (~80 LOC) per §4 of the S-up-4 PREP. Optional s=2 corollary stepping_up_lower_bound_classical recovers the (2s−1)=3 form trivially."
+      "S9 (OQ-03b): state erdos_rado_upper — either the recursive inequality ramseyNumber k s t ≤ ramseyNumber (k-1) (ramseyNumber k (s-1) t) (ramseyNumber k s (t-1)) + 1 (needs sInf membership bridging via ramsey_existence witnesses + Nat.sInf_le), or a direct tower-function bound tower (k-1) (c_k * s).",
+      "S9-prep: prove ramseyNumber_le_of_isRamsey : IsRamsey n k s t → ramseyNumber k s t ≤ n (Nat.sInf_le) and isRamsey_ramseyNumber : k ≥ 1, s,t ≥ k → IsRamsey (ramseyNumber k s t) k s t (Nat.sInf_mem over the nonempty set from ramsey_existence_of_one_le) — the two glue lemmas every quantitative statement needs.",
+      "S10+ (OQ-03c): Erdős–Hajnal stepping-up lower bound — the deep half; consider spawning as separate sub-OQ per S-up-4 PREP notes in state.md."
     ]
   },
   "tags": [
@@ -132,6 +136,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ErdosSzekeres.lean"
+    },
+    {
+      "path": "Proofs/RamseyHypergraph.lean",
+      "filename": "RamseyHypergraph.lean",
+      "lineCount": 835,
+      "theoremCount": 21,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/RamseyHypergraph.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Research session S8 ACT-F for **erdos-szekeres-oq-03** (Ramsey numbers for k-uniform hypergraphs). Closes the last `sorry` in `RamseyHypergraph.lean`: **OQ-03a — Ramsey's 1930 existence theorem for k-uniform hypergraph Ramsey numbers — is now fully proved** (0 sorries, 0 axioms, 835 lines, 21 theorems).

## Progress
- New `IsRamsey.within`: transfer lemma running an `IsRamsey ν k s t` certificate inside any ν-element vertex subset `A ⊆ Fin m` (pull-back along `Finset.orderEmbOfFin`, monochromaticity transported via `Finset.subset_map_iff` — the `mono_n` pattern relativized). This single lemma serves both restriction steps of the classical proof.
- New `ramsey_existence_of_one_le`: the two-layer Ramsey 1930 induction. Outer structural induction on uniformity `k` (base `k = 1` = S3 pigeonhole `isRamsey_one_iff`); inner bounded induction on `s + t` (plain `Nat.rec`, avoiding `Nat.strongRecOn` API drift); boundaries via S4 `is_ramsey_self_right/left`; genuine step assembles the S5–S7 machinery (`mono_n` witness bumping, `kColoring.link`, `IsRamsey.within`, `link_lifts`, `insert_vertex` splice).
- `ramsey_existence` (the OQ-03a headline, `k ≥ 2`) now delegates — sorry eliminated.
- Cleared the stale June "Docker daemon down" blocker; whole S4–S8 stack verified under v4.31.

## Files Modified
- `proofs/Proofs/RamseyHypergraph.lean` (684 → 835 lines; sorryCount 1 → 0; axiomCount 0)
- `src/data/research/problems/erdos-szekeres-oq-03.json` (iteration 8, blockers cleared, leanFiles entry added, insights/builtItems/nextSteps)
- `research/problems/erdos-szekeres-oq-03/state.md` (S8 section, Next Action → S9)

## Verification
`lake env lean` on the file (sibling-worktree Mathlib oleans, toolchain `leanprover/lean4:v4.31.0`): **exit 0, 0 errors, no sorry warnings** (11 pre-existing deprecation warnings: `push_neg`, `Nat.Lattice` import, `filter_card_add_filter_neg_card_eq_card`).

## Findings
- Existence-level Ramsey recursion needs no `ramseyNumber`/`sInf` arithmetic — carrying bare witnesses through existentials keeps the induction clean; the quantitative layer (OQ-03b) is where the `sInf` glue lemmas will be needed.
- Bounded induction (`s + t ≤ N`) over plain `Nat.rec` is more toolchain-robust than the originally planned `Nat.strongRecOn` body.

## Status
**Outcome**: progress (OQ-03a of three sub-goals closed; problem stays in-progress)
**Next Steps**: S9 — quantitative Erdős–Rado recursion (OQ-03b): `sInf` glue lemmas (`ramseyNumber_le_of_isRamsey`, `isRamsey_ramseyNumber`), then the recursive inequality; OQ-03c (stepping-up lower bound) remains the deep half.

🤖 Generated by researcher-1
