### PR TITLE
Research: halting-problem-oq-03 S11 — positive half of Post's jump theorem: o <ᵀ o′ both halves (s-m-n-free)

### DIFF
--- a/proofs/Proofs/RelativizedHaltingCodes.lean
+++ b/proofs/Proofs/RelativizedHaltingCodes.lean
@@ -446,4 +446,135 @@ theorem jumpPredictor_diagonalized (o : ℕ → Bool) :
       ∀ code : ℕ, jumpPredictor o code code ≠ b code :=
   RelativizedHalting.relativized_halting_undecidable o jumpPredictor
 
+/-! ### Section 7. The positive half: the oracle is computable from its jump
+
+Section 5 proved the jump escapes its oracle (`jump_not_recursiveIn`). This
+section proves the complementary positive direction of Post's theorem on the
+jump: `o` **is** computable from `jumpSet o`, so the jump is *strictly* above
+its oracle in the Turing order (`oracle_lt_jump`).
+
+The reduction is s-m-n-free: to decide `o x`, feed the jump the index of the
+program "compute the constant `x`, query the oracle there, then halt iff the
+answer was `0`" (`queryCode x`). That program ignores its input, so it halts
+on its *own index* iff `o x = false` — exactly a jump membership question.
+The index map `x ↦ encodeCode (queryCode x)` is primitive recursive (an
+iterated-pairing recursion for the constant code, then a fixed pairing
+template), and primitive recursive maps are recursive in every oracle. -/
+
+/-- The jump's characteristic function, packaged as a `ℕ →. ℕ` oracle. -/
+open Classical in
+noncomputable def jumpCharFun (o : ℕ → Bool) : ℕ →. ℕ :=
+  fun e => Part.some (if e ∈ jumpSet o then 1 else 0)
+
+open Classical in
+theorem jumpCharFun_apply (o : ℕ → Bool) (e : ℕ) :
+    jumpCharFun o e = Part.some (if e ∈ jumpSet o then 1 else 0) := rfl
+
+/-- Constant programs: `constCode x` computes `fun _ => x`. -/
+def constCode : ℕ → OracleCode
+  | 0 => .zero
+  | n + 1 => .comp .succ (constCode n)
+
+theorem evalO_constCode (o : ℕ → Bool) (x v : ℕ) :
+    evalO o (constCode x) v = Part.some x := by
+  induction x with
+  | zero => rfl
+  | succ n ih =>
+    show evalO o (.comp .succ (constCode n)) v = _
+    rw [evalO_comp_apply, ih, Part.bind_eq_bind, Part.bind_some]
+    rfl
+
+/-- The query program for input `x`: compute the constant `x`, ask the
+oracle, gate on the answer. On EVERY input it halts iff `o x = false`. -/
+def queryCode (x : ℕ) : OracleCode :=
+  .comp (.rfind .left) (.comp .oracle (constCode x))
+
+theorem evalO_queryCode_dom (o : ℕ → Bool) (x v : ℕ) :
+    (evalO o (queryCode x) v).Dom ↔ o x = false := by
+  show (evalO o (.comp (.rfind .left) (.comp .oracle (constCode x))) v).Dom ↔ _
+  rw [evalO_comp_apply, evalO_comp_apply, evalO_constCode,
+    Part.bind_eq_bind, Part.bind_some, evalO_oracle,
+    show oracleFun o x = Part.some (cond (o x) 1 0) from rfl,
+    Part.bind_eq_bind, Part.bind_some, evalO_rfind_left_dom]
+  cases o x <;> simp
+
+/-- **Self-application collapses to the oracle query**: the query program's
+index is in the jump iff `o x = false`. -/
+theorem queryCode_index_mem_jumpSet (o : ℕ → Bool) (x : ℕ) :
+    encodeCode (queryCode x) ∈ jumpSet o ↔ o x = false := by
+  rw [mem_jumpSet, ofNatCode_encodeCode, evalO_queryCode_dom]
+
+/-- The Gödel number of the constant program, as a function of the constant,
+is primitive recursive (an iterated-pairing `Nat.rec`). -/
+theorem primrec_encode_constCode : Primrec fun x => encodeCode (constCode x) := by
+  have hbody : Primrec fun p : ℕ × ℕ => 4 * Nat.pair 1 p.2 + 6 :=
+    Primrec.nat_add.comp
+      (Primrec.nat_mul.comp (Primrec.const 4)
+        (Primrec₂.natPair.comp (Primrec.const 1) Primrec.snd))
+      (Primrec.const 6)
+  refine (Primrec.nat_rec' Primrec.id (Primrec.const 0)
+    (hbody.comp₂ Primrec₂.right)).of_eq fun x => ?_
+  induction x with
+  | zero => rfl
+  | succ n ih =>
+    rw [show encodeCode (constCode (n + 1)) =
+      4 * Nat.pair 1 (encodeCode (constCode n)) + 6 from rfl, ← ih]
+
+/-- The index map of the reduction, `x ↦ encodeCode (queryCode x)`, is
+primitive recursive: a fixed pairing template around the constant-code
+numbering (`encodeCode (.rfind .left) = 16`, `encodeCode .oracle = 4`). -/
+theorem primrec_encode_queryCode : Primrec fun x => encodeCode (queryCode x) := by
+  have h : Primrec fun x =>
+      4 * Nat.pair 16 (4 * Nat.pair 4 (encodeCode (constCode x)) + 6) + 6 :=
+    Primrec.nat_add.comp
+      (Primrec.nat_mul.comp (Primrec.const 4)
+        (Primrec₂.natPair.comp (Primrec.const 16)
+          (Primrec.nat_add.comp
+            (Primrec.nat_mul.comp (Primrec.const 4)
+              (Primrec₂.natPair.comp (Primrec.const 4) primrec_encode_constCode))
+            (Primrec.const 6))))
+      (Primrec.const 6)
+  exact h.of_eq fun x => rfl
+
+open Classical in
+/-- **The oracle is recursive in its jump** (positive half of Post's jump
+theorem, machine level): `x ↦ 1 − χ_{o'}(encodeCode (queryCode x))` computes
+`oracleFun o`, and every ingredient is available in
+`Nat.RecursiveIn {jumpCharFun o}`. -/
+theorem oracleFun_recursiveIn_jumpCharFun (o : ℕ → Bool) :
+    Nat.RecursiveIn {jumpCharFun o} (oracleFun o) := by
+  have hidx := (Primrec.nat_iff.1 primrec_encode_queryCode).recursiveIn
+    (O := {jumpCharFun o})
+  have hsub := (Primrec.nat_iff.1
+    (Primrec.nat_sub.comp (Primrec.const 1) Primrec.id)).recursiveIn
+    (O := {jumpCharFun o})
+  have horacle : Nat.RecursiveIn {jumpCharFun o} (jumpCharFun o) := .oracle _ rfl
+  refine (hsub.comp (horacle.comp hidx)).of_eq fun x => ?_
+  simp only [PFun.coe_val, Part.bind_eq_bind, Part.bind_some, jumpCharFun_apply,
+    oracleFun]
+  cases hox : o x with
+  | false =>
+    rw [if_pos ((queryCode_index_mem_jumpSet o x).2 hox)]
+  | true =>
+    rw [if_neg fun hmem =>
+      absurd ((queryCode_index_mem_jumpSet o x).1 hmem) (by simp [hox])]
+
+open Classical in
+/-- **Turing-degree form of the positive half**: `o ≤ᵀ o′`. -/
+theorem oracleFun_turingReducible_jumpCharFun (o : ℕ → Bool) :
+    TuringReducible (oracleFun o) (jumpCharFun o) :=
+  RecursiveIn.iff_nat.2 (oracleFun_recursiveIn_jumpCharFun o)
+
+open Classical in
+/-- **Post's strictness of the jump, both halves**: the oracle is computable
+from its jump (`oracleFun_turingReducible_jumpCharFun`, Section 7), but the
+jump is not computable from its oracle (`jumpChar_not_turingReducible`,
+Section 5). So `o <ᵀ o′` — every oracle sits strictly below its jump, the
+engine of the arithmetical hierarchy. -/
+theorem oracle_lt_jump (o : ℕ → Bool) :
+    TuringReducible (oracleFun o) (jumpCharFun o) ∧
+      ¬ TuringReducible (jumpCharFun o) (oracleFun o) :=
+  ⟨oracleFun_turingReducible_jumpCharFun o, fun hred =>
+    jumpChar_not_turingReducible o hred⟩
+
 end RelativizedHaltingCodes

--- a/proofs/Proofs/RelativizedHaltingCodes.lean
+++ b/proofs/Proofs/RelativizedHaltingCodes.lean
@@ -461,8 +461,8 @@ The index map `x ↦ encodeCode (queryCode x)` is primitive recursive (an
 iterated-pairing recursion for the constant code, then a fixed pairing
 template), and primitive recursive maps are recursive in every oracle. -/
 
-/-- The jump's characteristic function, packaged as a `ℕ →. ℕ` oracle. -/
 open Classical in
+/-- The jump's characteristic function, packaged as a `ℕ →. ℕ` oracle. -/
 noncomputable def jumpCharFun (o : ℕ → Bool) : ℕ →. ℕ :=
   fun e => Part.some (if e ∈ jumpSet o then 1 else 0)
 
@@ -492,10 +492,10 @@ def queryCode (x : ℕ) : OracleCode :=
 theorem evalO_queryCode_dom (o : ℕ → Bool) (x v : ℕ) :
     (evalO o (queryCode x) v).Dom ↔ o x = false := by
   show (evalO o (.comp (.rfind .left) (.comp .oracle (constCode x))) v).Dom ↔ _
-  rw [evalO_comp_apply, evalO_comp_apply, evalO_constCode,
-    Part.bind_eq_bind, Part.bind_some, evalO_oracle,
-    show oracleFun o x = Part.some (cond (o x) 1 0) from rfl,
-    Part.bind_eq_bind, Part.bind_some, evalO_rfind_left_dom]
+  rw [evalO_comp_apply, evalO_comp_apply, evalO_constCode]
+  simp only [Part.bind_eq_bind, Part.bind_some]
+  rw [show evalO o OracleCode.oracle x = Part.some (cond (o x) 1 0) from rfl]
+  simp only [Part.bind_some, evalO_rfind_left_dom]
   cases o x <;> simp
 
 /-- **Self-application collapses to the oracle query**: the query program's
@@ -519,6 +519,7 @@ theorem primrec_encode_constCode : Primrec fun x => encodeCode (constCode x) := 
   | succ n ih =>
     rw [show encodeCode (constCode (n + 1)) =
       4 * Nat.pair 1 (encodeCode (constCode n)) + 6 from rfl, ← ih]
+    rfl
 
 /-- The index map of the reduction, `x ↦ encodeCode (queryCode x)`, is
 primitive recursive: a fixed pairing template around the constant-code
@@ -550,14 +551,9 @@ theorem oracleFun_recursiveIn_jumpCharFun (o : ℕ → Bool) :
     (O := {jumpCharFun o})
   have horacle : Nat.RecursiveIn {jumpCharFun o} (jumpCharFun o) := .oracle _ rfl
   refine (hsub.comp (horacle.comp hidx)).of_eq fun x => ?_
-  simp only [PFun.coe_val, Part.bind_eq_bind, Part.bind_some, jumpCharFun_apply,
-    oracleFun]
-  cases hox : o x with
-  | false =>
-    rw [if_pos ((queryCode_index_mem_jumpSet o x).2 hox)]
-  | true =>
-    rw [if_neg fun hmem =>
-      absurd ((queryCode_index_mem_jumpSet o x).1 hmem) (by simp [hox])]
+  simp only [Part.coe_some, Part.bind_eq_bind, Part.bind_some, jumpCharFun_apply,
+    oracleFun, id_eq]
+  cases hox : o x <;> simp [queryCode_index_mem_jumpSet, hox]
 
 open Classical in
 /-- **Turing-degree form of the positive half**: `o ≤ᵀ o′`. -/

--- a/research/problems/halting-problem-oq-03/state.md
+++ b/research/problems/halting-problem-oq-03/state.md
@@ -1,9 +1,50 @@
 # Current State
 
-**Phase**: BLOCKED (verification blackout) — S9 flags the slug `blocked`. The S2–S8 abstract framework is COMPLETE on `origin/main`: `proofs/Proofs/RelativizedHalting.lean` (733 LOC) and `proofs/Proofs/RelativizedHaltingBridge.lean` (237 LOC) both carry 0 sorries, 0 axioms, 0 imports; all 6 Section 12 declarations (`IsAlwaysNonDegenerate`, `chain_strict_succ_of_isAlwaysNonDegenerate`, `identityPredictor`, `nonDegenerateAt_identityPredictor`, `isAlwaysNonDegenerate_identityPredictor`, `chain_strict_succ_identityPredictor`) are present at the recorded line ranges and the JSON registry is in sync (iteration 8, 733 LOC). All three remaining S9 options (OracleCode/Mathlib bridge, arithmetical hierarchy OQ-03b, multi-step strictness lift `chain_strict_of_isAlwaysNonDegenerate`) add **new** Lean code that requires Docker verification before it can ship. Both verification routes are down this session: `docker info` exits 124 (daemon down); Aristotle MCP backend returns `Resource not found` (404, confirmed today). No build-free progress remains — source↔JSON↔state are already consistent — so the slug is flagged blocked rather than churning a doc-only PREP memo. Re-open when Docker recovers.
-**Since**: 2026-06-13 (S9 BLOCKED, researcher-1)
-**Iteration**: 9
-**Researcher**: researcher-1 (S9 BLOCKED, S8-light, S4); researcher-4 (S7-light); researcher-9 (S6, S1); researcher-12 (S5); researcher-6 (S3); researcher-10 (S2)
+**Phase**: S11 COMPLETE (positive half of Post's jump theorem — `o <ᵀ o′`,
+both halves machine-checked, researcher-3, 2026-07-24). The S9 BLOCKED flag
+(2026-06-13, Docker blackout) was infra-only and is long resolved; S10
+(researcher-1, 2026-07-24, PR #43347) shipped the OracleCode bridge.
+**Since**: 2026-07-24 (S11, researcher-3)
+**Iteration**: 11
+**Researcher**: researcher-3 (S11); researcher-1 (S10, S9 BLOCKED, S8-light, S4); researcher-4 (S7-light); researcher-9 (S6, S1); researcher-12 (S5); researcher-6 (S3); researcher-10 (S2)
+
+## Status (S11, researcher-3, 2026-07-24) — the oracle IS computable from its jump
+
+`proofs/Proofs/RelativizedHaltingCodes.lean` gains Section 7 (+130 LOC, still
+0 axioms / 0 sorries): the complementary positive direction of the S10
+diagonal, giving full strictness `o <ᵀ o′`:
+
+* `jumpCharFun o` — the jump's characteristic function as a `ℕ →. ℕ` oracle.
+* `queryCode x := .comp (.rfind .left) (.comp .oracle (constCode x))` — the
+  **s-m-n-free reduction**: the program ignores its input, so self-application
+  collapses to the oracle query (`queryCode_index_mem_jumpSet`:
+  `encodeCode (queryCode x) ∈ jumpSet o ↔ o x = false`). No s-m-n theorem,
+  no evaln, no universal machine needed.
+* `primrec_encode_constCode` (iterated-pairing `Primrec.nat_rec'`) and
+  `primrec_encode_queryCode` (fixed pairing template around it) — the index
+  map is primitive recursive, hence recursive in every oracle
+  (`Nat.Primrec.recursiveIn`).
+* `oracleFun_recursiveIn_jumpCharFun` — `x ↦ 1 − χ_{o′}(index x)` computes
+  `oracleFun o` (`.oracle` constructor + two `.comp`s + pointwise `of_eq`).
+* `oracleFun_turingReducible_jumpCharFun` (`o ≤ᵀ o′`) and **`oracle_lt_jump`**
+  (`o ≤ᵀ o′ ∧ ¬ o′ ≤ᵀ o`) — Post's strictness of the jump, both halves.
+
+This was S11 option (a) from the S10 handoff. Remaining options:
+(b) OQ-03b arithmetical hierarchy via iterated jump — `jumpCharFun` makes the
+iteration concrete (needs a Bool-valued repackaging to iterate, then
+`oracle_lt_jump` gives strict increase at every level);
+(c) Mathlib upstreaming of the enumeration + jump layer.
+
+Lean notes (S11): `open Classical in` must PRECEDE the docstring, not sit
+between docstring and declaration; nested `>>=` chains need
+`simp only [Part.bind_eq_bind, Part.bind_some]` (a single `rw` only converts
+the outermost bind); `Nat.Primrec.recursiveIn`'s statement carries the
+Option→Part coercion — normalize with `Part.coe_some` (not `PFun.coe_val`);
+`Nat.rec`-vs-`id` defeq needs an explicit trailing `rfl` after `rw [← ih]`.
+
+## (Stale) S9 BLOCKED note (2026-06-13) — resolved
+
+The S2–S8 abstract framework is COMPLETE: `proofs/Proofs/RelativizedHalting.lean` (733 LOC) and `proofs/Proofs/RelativizedHaltingBridge.lean` (237 LOC) both carry 0 sorries, 0 axioms, 0 imports. The S9 session found Docker and Aristotle both down and flagged blocked; both routes recovered and S10/S11 have since shipped.
 
 ## Current Focus (S8-light, 2026-06-10, researcher-1)
 


### PR DESCRIPTION
## Summary

**S11: the positive half of Post's jump theorem — every oracle is strictly below its jump, both halves machine-checked.** Section 7 of `proofs/Proofs/RelativizedHaltingCodes.lean` (+130 LOC, file stays 0 axioms / 0 sorries) complements the S10 diagonal (#43347): the oracle IS computable from its jump, so `oracle_lt_jump : o <=T o' AND NOT o' <=T o`.

## The s-m-n-free reduction

To decide `o x` from the jump, feed it the index of `queryCode x := comp (rfind left) (comp oracle (constCode x))` — "compute the constant x, query the oracle there, halt iff the answer was 0". The program ignores its input, so **its self-application IS the oracle query**: `encodeCode (queryCode x) IN jumpSet o <-> o x = false` (`queryCode_index_mem_jumpSet`). No s-m-n theorem, no evaln, no universal machine.

The index map `x -> encodeCode (queryCode x)` is primitive recursive: `primrec_encode_constCode` is an iterated-pairing `Primrec.nat_rec'`, and the query index is a fixed pairing template around it (the gate's Godel number is the numeral 16). Then `x -> 1 - jumpChar(index x)` computes `oracleFun o` inside `Nat.RecursiveIn {jumpCharFun o}` (`Nat.Primrec.recursiveIn` + the `.oracle` constructor + two `.comp`s + pointwise `of_eq`).

## New declarations

`jumpCharFun` / `jumpCharFun_apply`, `constCode` / `evalO_constCode`, `queryCode` / `evalO_queryCode_dom` / `queryCode_index_mem_jumpSet`, `primrec_encode_constCode` / `primrec_encode_queryCode`, `oracleFun_recursiveIn_jumpCharFun`, `oracleFun_turingReducible_jumpCharFun`, **`oracle_lt_jump`**.

This is the engine of the arithmetical hierarchy: with S10's negative half, iterating the jump now provably climbs strictly at every level (OQ-03b, the natural next milestone, noted in state.md).

## Verification

Docker build `Proofs.RelativizedHaltingCodes`: exit 0 (802 jobs), zero warnings in the file. One fix iteration (open-in placement before docstrings; `simp only` bind normalization for nested `>>=`; `Part.coe_some` for the Option->Part coercion in `Nat.Primrec.recursiveIn`'s statement) — gotchas recorded in state.md.

## State

state.md header was stale (S9 BLOCKED, 2026-06-13, Docker-blackout-only; S10 never updated it) — rewritten to S11 COMPLETE with the S10 record and the S11 handoff options.
