### PR TITLE
Enrich erdos-735-oq-04: add mathContext and relatedConcepts to all 6 annotations

### DIFF
--- a/src/data/proofs/erdos-735-oq-04/annotations.json
+++ b/src/data/proofs/erdos-735-oq-04/annotations.json
@@ -9,7 +9,17 @@
     "type": "concept",
     "significance": "supporting",
     "title": "From lines in the plane to k-flats in ℝᵈ",
-    "content": "The header frames the sub-problem: the parent entry formalizes the ABKPR 2008 solution of Murty's magic-configurations problem — positive weights with equal sums on every line through ≥ 2 points exist iff the configuration is collinear, in general position, a near-pencil, or an incenter configuration. This file replaces 'line' by 'k-flat' in ℝᵈ and asks for equal weight-sums on every k-flat through at least k+1 points. It inventories the contents: three fully proved theorems (the trivial regimes k = 0 and k = d, and the d = 2 parent reduction) plus the single conjectured classification axiom for lines in ℝᵈ, d ≥ 3. The polytope witnesses and the general-position theorem live in four companion files (Tetrahedron, Octahedron, Cube, GeneralPosition)."
+    "content": "The header frames the sub-problem: the parent entry formalizes the ABKPR 2008 solution of Murty's magic-configurations problem — positive weights with equal sums on every line through ≥ 2 points exist iff the configuration is collinear, in general position, a near-pencil, or an incenter configuration. This file replaces 'line' by 'k-flat' in ℝᵈ and asks for equal weight-sums on every k-flat through at least k+1 points. It inventories the contents: three fully proved theorems (the trivial regimes k = 0 and k = d, and the d = 2 parent reduction) plus the single conjectured classification axiom for lines in ℝᵈ, d ≥ 3. The polytope witnesses and the general-position theorem live in four companion files (Tetrahedron, Octahedron, Cube, GeneralPosition).",
+    "mathContext": "A point configuration is $P \\subset \\mathbb{R}^d$, finite. A $k$-flat is an affine subspace whose direction has $\\operatorname{rank}_{\\mathbb{R}} = k$; it 'passes through' $P$ when $|P \\cap F| \\geq k+1$, the minimum count at which the flat is forced by (rather than merely incident to) the points. The generalisation replaces the parent's fixed $(d,k) = (2,1)$ (lines in the plane) with a free pair $(d,k)$, $1 \\leq k \\leq d-1$.",
+    "relatedConcepts": [
+      "Murty magic configuration conjecture",
+      "ABKPR 2008 classification theorem",
+      "affine subspace rank",
+      "k-flat"
+    ],
+    "prerequisites": [
+      "Erdos735Problem (parent d=2, k=1 case)"
+    ]
   },
   {
     "id": "ann-definitions",
@@ -21,7 +31,13 @@
     "type": "definition",
     "significance": "critical",
     "title": "The parameterised magic property",
-    "content": "PointConfigD d is a finite set of points of EuclideanSpace ℝ (Fin d); WeightingD assigns a positive real to each point. A ConfigKFlat k P packages an affine subspace whose direction has Module.rank exactly k together with a proof that it contains at least k+1 points of P — the threshold at which a k-flat is determined by the configuration rather than merely incident to it, generalising the parent's 'line through ≥ 2 points'. kFlatSum sums the weights of the configuration points in the flat (noncomputable: membership in a Finset of real points is classical), and IsKFlatMagic k P asserts a positive weighting exists making every determined k-flat sum equal to a single positive constant. At (d, k) = (2, 1) each definition unfolds to its parent counterpart."
+    "content": "PointConfigD d is a finite set of points of EuclideanSpace ℝ (Fin d); WeightingD assigns a positive real to each point. A ConfigKFlat k P packages an affine subspace whose direction has Module.rank exactly k together with a proof that it contains at least k+1 points of P — the threshold at which a k-flat is determined by the configuration rather than merely incident to it, generalising the parent's 'line through ≥ 2 points'. kFlatSum sums the weights of the configuration points in the flat (noncomputable: membership in a Finset of real points is classical), and IsKFlatMagic k P asserts a positive weighting exists making every determined k-flat sum equal to a single positive constant. At (d, k) = (2, 1) each definition unfolds to its parent counterpart.",
+    "mathContext": "$\\mathrm{ConfigKFlat}\\ k\\ P := \\{F : \\operatorname{rank}_{\\mathbb R} F.\\mathrm{direction} = k \\wedge |P \\cap F| \\geq k+1\\}$. The magic sum is $\\mathrm{kFlatSum}(P, w, F) = \\sum_{p \\in P \\cap F} w(p)$, and $\\mathrm{IsKFlatMagic}\\ k\\ P := \\exists w > 0,\\ \\exists c > 0,\\ \\forall F \\in \\mathrm{ConfigKFlat}\\ k\\ P,\\ \\mathrm{kFlatSum}(P,w,F) = c$.",
+    "relatedConcepts": [
+      "Module.rank over an affine subspace direction",
+      "positive weighting",
+      "Finset.filter membership sum"
+    ]
   },
   {
     "id": "ann-classes",
@@ -33,7 +49,14 @@
     "type": "definition",
     "significance": "key",
     "title": "The four conjectured classes, lifted to ℝᵈ",
-    "content": "The parent's four plane classes are restated for 1-flats in ℝᵈ: IsCollinearD (all points on one line), IsGeneralPositionD (no three points share a line), IsNearPencilD (all but one point on a common line), and IsIncenterConfigD. The fourth is honestly documented as a structural skeleton — an injective (d+1)-simplex into P plus one extra point, with the correct cardinality — rather than the precise ABKPR incenter characterisation, because Mathlib has no ℝᵈ-level angle-bisector or insphere API for d ≥ 3. The docstring points to the design memo recording the tightening plan; the gallery entry lists this tightening as an open question."
+    "content": "The parent's four plane classes are restated for 1-flats in ℝᵈ: IsCollinearD (all points on one line), IsGeneralPositionD (no three points share a line), IsNearPencilD (all but one point on a common line), and IsIncenterConfigD. The fourth is honestly documented as a structural skeleton — an injective (d+1)-simplex into P plus one extra point, with the correct cardinality — rather than the precise ABKPR incenter characterisation, because Mathlib has no ℝᵈ-level angle-bisector or insphere API for d ≥ 3. The docstring points to the design memo recording the tightening plan; the gallery entry lists this tightening as an open question.",
+    "mathContext": "$\\mathrm{IsCollinearD}\\ P := \\exists L,\\ \\operatorname{rank} L = 1 \\wedge \\forall p \\in P,\\ p \\in L$. $\\mathrm{IsGeneralPositionD}\\ P$ negates the existence of a common 1-flat through any three distinct points. $\\mathrm{IsNearPencilD}\\ P$ requires all but one point on a common 1-flat $L$, the exception lying off $L$. $\\mathrm{IsIncenterConfigD}\\ P$ asks for an injective $(d+2)$-tuple ($(d+1)$-simplex vertices plus one incenter-like point) inside $P$ with $|P| = d+3$ — a cardinality skeleton, not the metric incenter condition the parent's $d=2$ class encodes.",
+    "relatedConcepts": [
+      "collinearity in ℝᵈ",
+      "general position (no three collinear)",
+      "near-pencil configuration",
+      "incenter configuration (ABKPR class 4)"
+    ]
   },
   {
     "id": "ann-axiom",
@@ -45,7 +68,13 @@
     "type": "warning",
     "significance": "critical",
     "title": "The single axiom — and what is already proved of it",
-    "content": "oneflat_classification_higher_dim is the slug's only assumption: for d ≥ 3, a configuration is 1-flat magic iff it lies in one of the four lifted classes. This is the natural extension of ABKPR 2008 beyond the plane and is research-level open — no published proof exists for any d ≥ 3. The axiom's docstring records this status explicitly, and for d = 2 the statement is instead a theorem (the parent's magic_classification composed with oneflat_eq_parent below). Notably, the class-2 forward implication — general position implies 1-flat magic — is proved outright and axiom-free for every d in the GeneralPosition companion file (isKFlatMagic_one_of_generalPosition), so the axiom's genuinely open content is strictly smaller than its statement. #print axioms on the companion's headline theorems shows only the three foundational axioms."
+    "content": "oneflat_classification_higher_dim is the slug's only assumption: for d ≥ 3, a configuration is 1-flat magic iff it lies in one of the four lifted classes. This is the natural extension of ABKPR 2008 beyond the plane and is research-level open — no published proof exists for any d ≥ 3. The axiom's docstring records this status explicitly, and for d = 2 the statement is instead a theorem (the parent's magic_classification composed with oneflat_eq_parent below). Notably, the class-2 forward implication — general position implies 1-flat magic — is proved outright and axiom-free for every d in the GeneralPosition companion file (isKFlatMagic_one_of_generalPosition), so the axiom's genuinely open content is strictly smaller than its statement. #print axioms on the companion's headline theorems shows only the three foundational axioms.",
+    "mathContext": "$\\forall d \\geq 3,\\ \\forall P,\\ \\mathrm{IsKFlatMagic}\\ 1\\ P \\iff \\mathrm{IsCollinearD}\\ P \\lor \\mathrm{IsGeneralPositionD}\\ P \\lor \\mathrm{IsNearPencilD}\\ P \\lor \\mathrm{IsIncenterConfigD}\\ P$. Only the reverse ($\\Leftarrow$) direction from the general-position disjunct is open in general; the forward direction from general position ($\\mathrm{IsGeneralPositionD}\\ P \\Rightarrow \\mathrm{IsKFlatMagic}\\ 1\\ P$) is a proved theorem, not part of the axiom's unproved content.",
+    "relatedConcepts": [
+      "ABKPR 2008 planar classification (proved case d=2)",
+      "axiom vs theorem distinction",
+      "isKFlatMagic_one_of_generalPosition (companion, axiom-free)"
+    ]
   },
   {
     "id": "ann-trivial",
@@ -57,7 +86,13 @@
     "type": "theorem",
     "significance": "key",
     "title": "Bracketing the problem: k = 0 and k = d are trivial",
-    "content": "zero_flat_magic_trivial: a rank-0 direction is ⊥, so points of the flat pairwise vsub to 0 and the flat is a single point; the ≥ 1-point constraint makes it {p} for some p ∈ P, and the constant-1 weighting gives every 0-flat sum exactly 1. ambient_flat_magic_trivial splits on |P|: if |P| ≥ d+1, a rank-d direction equals ⊤ by Submodule.eq_top_of_finrank_eq, so the flat is the ambient space (direction_eq_top_iff_of_nonempty) containing all of P, and the uniform weighting sums to |P|; if |P| < d+1 no flat can hold d+1 points and the magic condition is vacuous. Both use the dif_pos / sum_const / Nat.smul_one_eq_cast evaluation idiom that every companion-file witness reuses. Conclusion: all content of the problem lives in 1 ≤ k ≤ d−1."
+    "content": "zero_flat_magic_trivial: a rank-0 direction is ⊥, so points of the flat pairwise vsub to 0 and the flat is a single point; the ≥ 1-point constraint makes it {p} for some p ∈ P, and the constant-1 weighting gives every 0-flat sum exactly 1. ambient_flat_magic_trivial splits on |P|: if |P| ≥ d+1, a rank-d direction equals ⊤ by Submodule.eq_top_of_finrank_eq, so the flat is the ambient space (direction_eq_top_iff_of_nonempty) containing all of P, and the uniform weighting sums to |P|; if |P| < d+1 no flat can hold d+1 points and the magic condition is vacuous. Both use the dif_pos / sum_const / Nat.smul_one_eq_cast evaluation idiom that every companion-file witness reuses. Conclusion: all content of the problem lives in 1 ≤ k ≤ d−1.",
+    "mathContext": "$k=0$: $\\operatorname{rank} F.\\mathrm{direction} = 0 \\Rightarrow F.\\mathrm{direction} = \\bot \\Rightarrow F = \\{p\\}$, so $\\mathrm{kFlatSum} = w(p)$ under any weighting; the constant-$1$ weighting gives sum $1$ uniformly. $k=d$: $\\operatorname{rank} F.\\mathrm{direction} = d = \\operatorname{finrank}(\\mathbb R^d) \\Rightarrow F.\\mathrm{direction} = \\top \\Rightarrow F = \\top$ (given nonemptiness), so $\\mathrm{kFlatSum} = \\sum_{p \\in P} w(p) = |P|$ under uniform weight.",
+    "relatedConcepts": [
+      "Submodule.rank_eq_zero",
+      "Submodule.eq_top_of_finrank_eq",
+      "vacuous universal quantification"
+    ]
   },
   {
     "id": "ann-parent-reduction",
@@ -69,6 +104,13 @@
     "type": "insight",
     "significance": "critical",
     "title": "Exact reduction to the solved plane case — and the k ≥ 2 frontier beyond",
-    "content": "oneflat_eq_parent proves IsKFlatMagic 1 P ↔ Erdos735.IsMagic P for plane configurations: the weighting types unfold identically, the subtypes differ only by a Nat.cast_one rewrite on the rank condition, and the sums are the same term modulo namespace — so witnesses transport in both directions by rintro/refine. This certifies zero definitional drift where the new hierarchy meets the parent's solved problem. The genuinely new mathematics lives in the companion files: the tetrahedron is 2-flat magic in ℝ³ (uniform weight, constant 3) while the octahedron, cube, and icosahedron are provably not — each refuted by four explicit kernel-built flats whose sum equations force a positive weight-pair to vanish (the icosahedron over its golden-ratio vertex coordinates, via the identity φ² = φ+1) — and the general-position uniform-weight theorem shows every affinely independent configuration is k-flat magic for every k, identifying simplices (not regular polytopes) as the inhabitants of the conjectured higher-flat magic family."
+    "content": "oneflat_eq_parent proves IsKFlatMagic 1 P ↔ Erdos735.IsMagic P for plane configurations: the weighting types unfold identically, the subtypes differ only by a Nat.cast_one rewrite on the rank condition, and the sums are the same term modulo namespace — so witnesses transport in both directions by rintro/refine. This certifies zero definitional drift where the new hierarchy meets the parent's solved problem. The genuinely new mathematics lives in the companion files: the tetrahedron is 2-flat magic in ℝ³ (uniform weight, constant 3) while the octahedron, cube, and icosahedron are provably not — each refuted by four explicit kernel-built flats whose sum equations force a positive weight-pair to vanish (the icosahedron over its golden-ratio vertex coordinates, via the identity φ² = φ+1) — and the general-position uniform-weight theorem shows every affinely independent configuration is k-flat magic for every k, identifying simplices (not regular polytopes) as the inhabitants of the conjectured higher-flat magic family.",
+    "mathContext": "The bridge is $\\mathrm{IsKFlatMagic}\\ 1\\ P \\iff \\mathrm{Erdos735.IsMagic}\\ P$ at $d=2$, proved by unfolding both sides to identical terms up to the cast $((1:\\mathbb N):\\mathrm{Cardinal}) = (1:\\mathrm{Cardinal})$. The icosahedron refutation hinges on $\\varphi^2 = \\varphi + 1$ where $\\varphi = \\tfrac{1+\\sqrt5}{2}$: substituting the golden-ratio vertex coordinates into the four flats' sum equations forces a positive weight to equal zero, a contradiction.",
+    "relatedConcepts": [
+      "Platonic solids as k-flat configurations",
+      "golden ratio identity φ² = φ + 1",
+      "affinely independent (simplex) configurations",
+      "companion files: Tetrahedron, Octahedron, Cube, Icosahedron, GeneralPosition"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for erdos-735-oq-04. The entry's `qualityBreakdown` (from `scripts/enricher/find-targets.ts`) showed two buckets at 0/10: `mathContext` and `crossRefs` (annotation `relatedConcepts`) — none of the 6 annotations had either field populated, despite otherwise-rich `content`.

Added, grounded in `proofs/Proofs/Erdos735OQ04.lean`:
- `mathContext`: LaTeX-formalized statements for each annotation (the `ConfigKFlat`/`kFlatSum`/`IsKFlatMagic` definitions, the four lifted classes, the axiom's iff-statement, the k=0/k=d triviality arguments, and the golden-ratio identity φ²=φ+1 driving the icosahedron refutation).
- `relatedConcepts`: concrete cross-referenced concepts per annotation (ABKPR 2008, Module.rank, Platonic solids as k-flat configurations, etc).
- `prerequisites` on the header annotation (parent entry).

Quality score: 80 → 100 (`find-targets.ts` local check). No content deleted; file size 6.5KB → 10.7KB, well under the 60KB cap.

Verified: `pnpm build` JSON/data-manifest/search-index checks pass; `tsc --noEmit` clean (borrowed sibling worktree's `node_modules/.bin/tsc` — this worktree's own `pnpm install` is blocked by the known node v26/better-sqlite3 host issue, unrelated to this change).