### PR TITLE
Research: erdos-227-wip-01 - Part 13: disk maximum principle + radius characterisation of IsEntire

### DIFF
--- a/proofs/Proofs/Erdos227Problem.lean
+++ b/proofs/Proofs/Erdos227Problem.lean
@@ -21,6 +21,7 @@
 -/
 
 import Mathlib.Analysis.Complex.Basic
+import Mathlib.Analysis.Complex.AbsMax
 import Mathlib.Analysis.Complex.CauchyIntegral
 import Mathlib.Analysis.Analytic.OfScalars
 import Mathlib.Analysis.SpecialFunctions.Pow.Complex
@@ -623,5 +624,128 @@ theorem limit_mem_Icc (f : EntireFunction) (hent : IsEntire f) {L : ℝ}
   · refine le_of_tendsto hL ?_
     filter_upwards [eventually_ge_atTop (0 : ℝ)] with r hr
     exact termModulusRatio_le_one f hr hent
+
+/-
+## Part 13: The Maximum Principle and the Radius Characterisation
+
+Two structural refinements of the Part-12 bridge, both axiom-free.
+
+First, `IsEntire` — defined "by hand" as absolute convergence of the
+coefficient series at every radius — is shown to be *equivalent* to the
+Mathlib-native condition that the formal scalar series has infinite radius of
+convergence. Part 12 proved the forward implication
+(`ofScalars_radius_eq_top`); here `FormalMultilinearSeries.summable_norm_mul_pow`
+supplies the converse, closing the loop between the ad-hoc and library notions
+of entireness.
+
+Second, the name "maximum modulus" is justified: `maxModulus f r` was defined
+as a supremum over the *circle* `|z| = r`, and the maximum modulus principle
+(`Complex.norm_le_of_forall_mem_frontier_norm_le`, applied to the ball of
+radius `r`) upgrades this to a bound over the entire closed *disk*
+`‖z‖ ≤ r`. Monotonicity of both `M(r)` and `μ(r)` in `r` — the first
+standing assumptions of Wiman–Valiron theory — follow as corollaries.
+-/
+
+/-- **Radius characterisation of entireness**: the hand-rolled `IsEntire`
+predicate (absolute convergence at every non-negative radius) is equivalent
+to the Mathlib condition that the formal scalar power series has radius `⊤`.
+The forward direction is Part 12's `ofScalars_radius_eq_top`; the converse is
+`FormalMultilinearSeries.summable_norm_mul_pow` inside the radius. -/
+theorem isEntire_iff_radius_eq_top (f : EntireFunction) :
+    IsEntire f ↔ (ofScalars ℂ f.coeff).radius = ⊤ := by
+  constructor
+  · exact ofScalars_radius_eq_top f
+  · intro hrad r hr
+    set R : NNReal := ⟨r, hr⟩ with hR
+    have hRr : (R : ℝ) = r := rfl
+    have hlt : (R : ENNReal) < (ofScalars ℂ f.coeff).radius := by
+      rw [hrad]
+      exact ENNReal.coe_lt_top
+    have hs := (ofScalars ℂ f.coeff).summable_norm_mul_pow hlt
+    refine hs.congr fun n => ?_
+    rw [ofScalars_norm, hRr]
+
+/-- Every point of the sphere `|z| = r` is `circleMap 0 r θ` for some angle,
+so the circle bound `norm_seriesSum_circleMap_le` transfers to arbitrary
+sphere points. -/
+theorem norm_seriesSum_le_maxModulus_of_mem_sphere (f : EntireFunction)
+    {r : ℝ} (hr : 0 ≤ r) (hent : IsEntire f) {z : ℂ}
+    (hz : z ∈ Metric.sphere (0 : ℂ) r) :
+    ‖seriesSum f z‖ ≤ maxModulus f r := by
+  have hrange : z ∈ Set.range (circleMap 0 r) := by
+    rw [range_circleMap, abs_of_nonneg hr]
+    exact hz
+  obtain ⟨θ, rfl⟩ := hrange
+  exact norm_seriesSum_circleMap_le f hr hent θ
+
+/-- **Maximum modulus principle for the disk**: for a genuinely entire
+function, `M(r)` bounds `‖f‖` on the whole closed disk `‖z‖ ≤ r`, not just on
+its boundary circle. For `r > 0` this is
+`Complex.norm_le_of_forall_mem_frontier_norm_le` on the ball of radius `r`
+(the sum function is differentiable by Part 12, and the frontier is the
+sphere); at `r = 0` the disk degenerates to `{0}` and the value `‖a₀‖` is the
+`θ = 0` member of the defining supremum. -/
+theorem norm_seriesSum_le_maxModulus (f : EntireFunction) {r : ℝ} (hr : 0 ≤ r)
+    (hent : IsEntire f) {z : ℂ} (hz : ‖z‖ ≤ r) :
+    ‖seriesSum f z‖ ≤ maxModulus f r := by
+  rcases hr.eq_or_lt with rfl | hrpos
+  · -- r = 0: the disk is the single point z = 0
+    have hz0 : z = 0 := norm_le_zero_iff.mp hz
+    subst hz0
+    rw [seriesSum_apply]
+    have h0 : ‖∑' m, f.coeff m * ((0 : ℝ) * exp (I * ((0 : ℝ) : ℂ))) ^ m‖
+        = ‖∑' m, f.coeff m * (0 : ℂ) ^ m‖ := by
+      have hzz : ((0 : ℝ) : ℂ) * exp (I * ((0 : ℝ) : ℂ)) = 0 := by simp
+      rw [hzz]
+    rw [← h0]
+    exact le_ciSup (bddAbove_range_norm f le_rfl (hent 0 le_rfl)) (0 : ℝ)
+  · -- r > 0: maximum modulus principle on the ball of radius r
+    have hd : DiffContOnCl ℂ (seriesSum f) (Metric.ball 0 r) :=
+      (differentiable_seriesSum f hent).diffContOnCl
+    refine Complex.norm_le_of_forall_mem_frontier_norm_le Metric.isBounded_ball hd
+      (fun w hw => ?_) ?_
+    · rw [frontier_ball (0 : ℂ) hrpos.ne'] at hw
+      exact norm_seriesSum_le_maxModulus_of_mem_sphere f hrpos.le hent hw
+    · rw [closure_ball (0 : ℂ) hrpos.ne']
+      exact mem_closedBall_zero_iff.mpr hz
+
+/-- **`M(r)` is monotone** for genuinely entire functions: each circle point
+at radius `r₁` lies inside the closed disk of radius `r₂`, so the maximum
+principle bounds its value by `M(r₂)`. -/
+theorem maxModulus_mono (f : EntireFunction) (hent : IsEntire f)
+    {r₁ r₂ : ℝ} (h1 : 0 ≤ r₁) (h12 : r₁ ≤ r₂) :
+    maxModulus f r₁ ≤ maxModulus f r₂ := by
+  apply ciSup_le
+  intro θ
+  have hexp : ‖exp (I * (θ : ℂ))‖ = 1 := by
+    rw [Complex.norm_exp]
+    simp [Complex.mul_re]
+  have hz : ‖(r₁ : ℂ) * exp (I * (θ : ℂ))‖ ≤ r₂ := by
+    rw [norm_mul, hexp, mul_one, Complex.norm_real, Real.norm_eq_abs,
+      abs_of_nonneg h1]
+    exact h12
+  have h := norm_seriesSum_le_maxModulus f (h1.trans h12) hent hz
+  rwa [seriesSum_apply] at h
+
+/-- **`μ(r)` is monotone** for genuinely entire functions: termwise
+`‖aₙ‖r₁ⁿ ≤ ‖aₙ‖r₂ⁿ`, and the `r₂`-family is bounded above (by Cauchy's
+estimate for `r₂ > 0`, trivially at `r₂ = 0`), so the suprema compare. -/
+theorem maxTerm_mono (f : EntireFunction) (hent : IsEntire f)
+    {r₁ r₂ : ℝ} (h1 : 0 ≤ r₁) (h12 : r₁ ≤ r₂) :
+    maxTerm f r₁ ≤ maxTerm f r₂ := by
+  have h2 : 0 ≤ r₂ := h1.trans h12
+  have hb : BddAbove (Set.range fun n : ℕ => ‖f.coeff n‖ * r₂ ^ n) := by
+    rcases h2.eq_or_lt with rfl | h2pos
+    · refine ⟨‖f.coeff 0‖, ?_⟩
+      rintro x ⟨n, rfl⟩
+      rcases Nat.eq_zero_or_pos n with rfl | hn
+      · simp
+      · rw [zero_pow hn.ne', mul_zero]
+        exact norm_nonneg _
+    · refine ⟨maxModulus f r₂, ?_⟩
+      rintro x ⟨n, rfl⟩
+      exact norm_coeff_mul_pow_le_maxModulus f h2pos hent n
+  refine ciSup_le fun n => le_ciSup_of_le hb n ?_
+  gcongr
 
 end Erdos227

--- a/proofs/Proofs/Erdos227Problem.lean
+++ b/proofs/Proofs/Erdos227Problem.lean
@@ -740,7 +740,8 @@ theorem maxTerm_mono (f : EntireFunction) (hent : IsEntire f)
       rintro x ⟨n, rfl⟩
       rcases Nat.eq_zero_or_pos n with rfl | hn
       · simp
-      · rw [zero_pow hn.ne', mul_zero]
+      · show ‖f.coeff n‖ * (0 : ℝ) ^ n ≤ ‖f.coeff 0‖
+        rw [zero_pow hn.ne', mul_zero]
         exact norm_nonneg _
     · refine ⟨maxModulus f r₂, ?_⟩
       rintro x ⟨n, rfl⟩

--- a/src/data/research/problems/erdos-227-wip-01.json
+++ b/src/data/research/problems/erdos-227-wip-01.json
@@ -22,30 +22,34 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-24T00:00:00.000Z",
-    "iteration": 3,
-    "focus": "S3 (researcher-2, 2026-07-24): ACT — Part 12 Cauchy-estimate bridge landed. Unconditional μ(r) ≤ M(r) for every genuinely entire function (no coefficient hypothesis): FormalMultilinearSeries.ofScalars packages the coefficients, IsEntire forces radius = ⊤, the sum function is differentiable, one-dimensional uniqueness identifies the scalar series with cauchyPowerSeries, and norm_cauchyPowerSeries_le bounds ‖aₙ‖rⁿ by the circle average ≤ M(r). Corollaries termModulusRatio_le_one and limit_mem_Icc (L ∈ [0,1]) now unconditional. 10 new axiom-free theorems, 0 new sorries. Docker build exit 0. Sorry/axiom profile unchanged (1 sorry, 3 axioms — Clunie/Clunie–Hayman/Wiman–Valiron, absent from Mathlib).",
+    "iteration": 4,
+    "focus": "S4 (researcher-3, 2026-07-24): ACT — Part 13 polish veins drained. isEntire_iff_radius_eq_top (IsEntire <-> ofScalars radius = top, converse via summable_norm_mul_pow); norm_seriesSum_le_maxModulus (maximum modulus principle: M(r) bounds the whole closed disk, via Complex.norm_le_of_forall_mem_frontier_norm_le on the ball, frontier_ball/closure_ball); maxModulus_mono and maxTerm_mono (monotonicity of M(r) and mu(r), the standing Wiman-Valiron assumptions). 5 new axiom-free theorems, 0 new sorries. Host-verified v4.31 (lake env lean, sibling cache). Sorry/axiom profile unchanged (1 sorry, 3 axioms).",
     "blockers": [],
-    "nextAction": "Only small polish veins remain (Complex.AbsMax maximum-principle restatement of maxModulus; AnalyticAt characterisation of IsEntire) — or stand down. Do NOT re-attempt axiom/sorry elimination; route 1 (HasFPowerSeriesOnBall bridge) is done.",
+    "nextAction": "STAND DOWN — both polish veins named after S3 are now done (AnalyticAt/radius characterisation AND AbsMax maximum-principle restatement, plus monotonicity corollaries). Remaining sorry + 3 axioms are DEEP (Clunie/Clunie-Hayman/Wiman-Valiron, absent from Mathlib); do NOT re-attempt. No polish veins remain.",
     "attemptCounts": {
-      "total": 3,
-      "currentApproach": 3,
+      "total": 4,
+      "currentApproach": 4,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "Elementary layer (Part 11) AND complex-analytic bridge (Part 12) both saturated: μ(r) ≤ M(r) holds unconditionally via Cauchy's estimate; ratio ≤ 1 and limit ∈ [0,1] axiom-free for all genuinely entire functions. Remaining sorry + 3 axioms are DEEP (Wiman–Valiron / Clunie–Hayman theory absent from Mathlib).",
+    "progressSummary": "Elementary layer (Part 11), complex-analytic bridge (Part 12) and polish layer (Part 13: radius characterisation of IsEntire, disk maximum principle, monotonicity of M(r)/mu(r)) all saturated and axiom-free. Remaining sorry + 3 axioms are DEEP (Wiman-Valiron / Clunie-Hayman theory absent from Mathlib). Entry is complete short of deep theory.",
     "builtItems": [
       "IsEntire predicate + maxTerm_nonneg/maxModulus_nonneg (Erdos227Problem.lean Part 11)",
       "norm_series_term / summable_series_term / norm_tsum_le_sum_norm / bddAbove_range_norm / maxModulus_le_tsum (circle-of-radius-r toolkit)",
       "norm_tsum_at_zero_of_nonneg + maxTerm_le_maxModulus_of_nonneg (mu(r) <= M(r), Clunie setting)",
       "termModulusRatio_le_one_of_nonneg + limit_mem_Icc_of_nonneg (ratio limit in [0,1], axiom-free)",
-      "expFunction + expFunction_coeff_nonneg + expFunction_isEntire + expFunction_ratio_le_one (exp witness)"
+      "expFunction + expFunction_coeff_nonneg + expFunction_isEntire + expFunction_ratio_le_one (exp witness)",
+      "isEntire_iff_radius_eq_top (Erdos227Problem.lean Part 13)",
+      "norm_seriesSum_le_maxModulus_of_mem_sphere + norm_seriesSum_le_maxModulus (disk maximum principle)",
+      "maxModulus_mono + maxTerm_mono (monotonicity in r)"
     ],
     "insights": [
       "EntireFunction structure imposes NO convergence: divergent-coefficient members give junk tsum=0/iSup=0, making ratio identically 0 for large r — so the axioms remain sound over the weak structure (junk regime always yields L=0)",
       "The lone sorry (positive_coeffs_normal) asserts existence of the limit for nonneg coeffs — that existence IS Clunie s unpublished theorem; do not close it with an axiom or a False-risking strengthening",
       "mu(r) <= M(r) for nonneg coeffs needs no Cauchy integral: each term a_n r^n is a summand of f(r) = M-candidate at theta=0; general-coefficient mu <= M genuinely needs Cauchy estimates (Mathlib bridge to HasFPowerSeriesOnBall would be ~300-500 lines)",
-      "Complex.ofReal_tsum (not RCLike.ofReal_tsum) is the syntactically-matching rewrite for coercion-through-tsum in goals elaborated with Complex.ofReal"
+      "Complex.ofReal_tsum (not RCLike.ofReal_tsum) is the syntactically-matching rewrite for coercion-through-tsum in goals elaborated with Complex.ofReal",
+      "Beta-unreduced ciSup goals: rintro x <n, rfl> over Set.range leaves (fun n => ...) n unapplied; rw fails to find the pattern — insert a `show` with the beta-reduced statement first"
     ],
     "mathlibGaps": [
       "Wiman-Valiron theory (maximum term, central index) absent from Mathlib",
@@ -53,7 +57,6 @@
       "No lemma linking a raw coefficient sequence to HasFPowerSeriesOnBall without building the FormalMultilinearSeries by hand"
     ],
     "nextSteps": [
-      "OPTIONAL (300-500 lines): bridge EntireFunction+IsEntire to Mathlib power-series API and prove unconditional mu(r) <= M(r) via Cauchy estimates",
       "DEEP (do not attempt from Mathlib): eliminate positive_coeffs_normal sorry (needs Clunie limit-existence) or any of the 3 axioms"
     ],
     "markdown": "# Knowledge Base: erdos-227-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary
Research session for erdos-227-wip-01 (Erdős #227, maximum term vs maximum modulus). Drains both polish veins named by the S3 tracker note after the Part 12 Cauchy-estimate bridge.

## Progress
- `isEntire_iff_radius_eq_top`: the hand-rolled `IsEntire` predicate is equivalent to the Mathlib-native condition `(ofScalars ℂ f.coeff).radius = ⊤` (converse via `FormalMultilinearSeries.summable_norm_mul_pow`), closing the loop between the ad-hoc and library notions of entireness.
- `norm_seriesSum_le_maxModulus_of_mem_sphere` + `norm_seriesSum_le_maxModulus`: **maximum modulus principle for the disk** — M(r) bounds ‖f‖ on the whole closed disk ‖z‖ ≤ r, not just the boundary circle, via `Complex.norm_le_of_forall_mem_frontier_norm_le` on the ball of radius r (with the degenerate r = 0 disk handled separately).
- `maxModulus_mono` + `maxTerm_mono`: monotonicity of M(r) and μ(r) in r — the standing assumptions of Wiman–Valiron theory — as corollaries of the maximum principle and Cauchy's estimate.
- Files: `proofs/Proofs/Erdos227Problem.lean` (Part 13, +1 import `Mathlib.Analysis.Complex.AbsMax`), tracker `src/data/research/problems/erdos-227-wip-01.json` (S4).

## Findings
- 5 new theorems, all axiom-free; sorry/axiom profile unchanged (1 pre-existing sorry `positive_coeffs_normal`, 3 person-named deep axioms — Clunie / Clunie–Hayman / Wiman–Valiron, absent from Mathlib).
- Host-verified on the real v4.31 toolchain: `lake env lean` full-file elaboration, exit 0, sole warning is the pre-existing sorry.
- Lean gotcha recorded: `rintro x ⟨n, rfl⟩` over `Set.range` leaves a beta-unreduced `(fun n => …) n` goal on which `rw` cannot find patterns — insert `show` with the reduced statement.

## Status
**Outcome**: completed (polish layer drained)
**Next Steps**: STAND DOWN on this entry — no polish veins remain; the sorry and 3 axioms are deep (Clunie/Clunie–Hayman/Wiman–Valiron theory absent from Mathlib), do not re-attempt without materially new mechanism.

🤖 Generated by researcher-3
