### PR TITLE
Enrich cayley-hamilton-minpoly-oq-06: split matrix-similarity section

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-06/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-06/meta.json
@@ -113,9 +113,17 @@
       "id": "matrix-similarity",
       "title": "Matrix Specialisation: Similar Matrices Share a Minimal Polynomial",
       "startLine": 66,
-      "endLine": 79,
-      "summary": "minpoly_matrix_units_conj: for a unit matrix U, minpoly K (U⁻¹·M·U) = minpoly K M (and the U·M·U⁻¹ form), the classical similarity invariance of the minimal polynomial.",
+      "endLine": 72,
+      "summary": "minpoly_matrix_units_conj: for a unit matrix U, minpoly K (U⁻¹·M·U) = minpoly K M, the classical similarity invariance of the minimal polynomial, obtained directly from minpoly_units_conj'.",
       "mathContext": "Specialising A = Matrix n n K, the abstract result becomes the textbook fact that similar matrices N = U⁻¹·M·U have equal minimal polynomials — the minimal-polynomial companion of charpoly_units_conj."
+    },
+    {
+      "id": "matrix-similarity-reversed",
+      "title": "The Reversed Presentation U·M·U⁻¹",
+      "startLine": 74,
+      "endLine": 79,
+      "summary": "minpoly_matrix_units_conj': the U·M·U⁻¹ form of matrix similarity invariance, minpoly K (U·M·U⁻¹) = minpoly K M, obtained from minpoly_units_conj by re-using U itself rather than U⁻¹ — the same one-line pattern as minpoly_units_conj/minpoly_units_conj' one level up.",
+      "mathContext": "Both conjugation conventions N = U⁻¹MU and N = UMU⁻¹ appear in the literature; recording both forms as separate corollaries means either presentation of matrix similarity plugs in directly without a manual inverse-swap."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Closes the last quality gap (sections: 8/10, i.e. 4 sections) for `cayley-hamilton-minpoly-oq-06`, bringing the computed quality score from 98 to 100.
- The existing `matrix-similarity` section (lines 66-79) bundled two distinct theorems: `minpoly_matrix_units_conj` (the `U⁻¹MU` form) and `minpoly_matrix_units_conj'` (the `UMU⁻¹` form). Split it into two sections at that real theorem boundary, matching the established primary/corollary split pattern already used one level up in the file (`minpoly_units_conj` / `minpoly_units_conj'`).
- No other fields touched; boundaries verified directly against `Proofs/CayleyHamiltonMinpolyOQ06.lean`.

## Test plan
- [x] `jq . src/data/proofs/cayley-hamilton-minpoly-oq-06/meta.json` — valid JSON
- [x] `npx tsx scripts/enricher/find-targets.ts --all --json` confirms `quality: 100` with all 8 buckets maxed
- [x] Diff isolated to the single target's `meta.json` (build-noise files reverted)