### PR TITLE
Enrich cayley-hamilton-minpoly-oq-06-oq-01: split block-diagonal charpoly/minpoly section

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-06-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-06-oq-01/meta.json
@@ -119,12 +119,20 @@
       "mathContext": "Because (A, D) ↦ A ⊕ D is an F-algebra homomorphism, evaluating any polynomial on the block-diagonal matrix acts blockwise — the engine behind the minimal-polynomial computation."
     },
     {
-      "id": "charpoly-minpoly-blockdiag",
-      "title": "Characteristic and Minimal Polynomials of a Block-Diagonal Matrix",
+      "id": "charpoly-blockdiag",
+      "title": "Characteristic Polynomial of a Block-Diagonal Matrix",
       "startLine": 91,
+      "endLine": 98,
+      "summary": "charpoly_fromBlocks records that charpoly(A ⊕ D) = charpoly A · charpoly D, a direct restatement of Mathlib's Matrix.charpoly_fromBlocks_zero₁₂ needed for the RCF readout — no new mathematics, just packaging.",
+      "mathContext": "The charpoly half of the RCF readout already exists in Mathlib; this file only re-exposes it so both readout identities are stated uniformly."
+    },
+    {
+      "id": "minpoly-blockdiag",
+      "title": "Minimal Polynomial of a Block-Diagonal Matrix (the New Result)",
+      "startLine": 100,
       "endLine": 136,
-      "summary": "charpoly_fromBlocks records that charpoly(A ⊕ D) = charpoly A · charpoly D (from Mathlib). minpoly_fromBlocks_of_dvd proves the new result: when minpoly A ∣ minpoly D, minpoly(A ⊕ D) = minpoly D, via two-way divisibility plus block extraction.",
-      "mathContext": "These are the two RCF readout identities at the level of arbitrary blocks: charpoly multiplies, minpoly takes the larger element of the divisibility chain."
+      "summary": "minpoly_fromBlocks_of_dvd proves the result missing from Mathlib: when minpoly A ∣ minpoly D, minpoly(A ⊕ D) = minpoly D, via two-way divisibility — minpoly D annihilates the block sum (using the chain hypothesis), and reading off the bottom-right block of (minpoly(A⊕D))(A⊕D) = 0 gives the reverse divisibility.",
+      "mathContext": "Unlike charpoly, which simply multiplies, minpoly of a block-diagonal matrix is in general the lcm of the blocks' minimal polynomials; the divisibility-chain hypothesis (automatic for invariant factors) collapses the lcm to the larger element, avoiding normalisation bookkeeping."
     },
     {
       "id": "rcf-readout",


### PR DESCRIPTION
## Summary
- Closes the last quality gap (sections: 8/10, i.e. 4 sections) for `cayley-hamilton-minpoly-oq-06-oq-01`, bringing the computed quality score from 98 to 100.
- The existing `charpoly-minpoly-blockdiag` section (lines 91-136) bundled two theorems of very different weight: `charpoly_fromBlocks` (a one-line restatement of an existing Mathlib lemma) and `minpoly_fromBlocks_of_dvd` (the file's actual new result, proved by a two-way divisibility argument). Split at that real boundary so the section titles reflect which half is new content vs. packaging.
- No other fields touched; boundaries verified directly against `Proofs/CayleyHamiltonMinpolyOQ06OQ01.lean`.

## Test plan
- [x] `jq . src/data/proofs/cayley-hamilton-minpoly-oq-06-oq-01/meta.json` — valid JSON
- [x] `npx tsx scripts/enricher/find-targets.ts --all --json` confirms `quality: 100` with all 8 buckets maxed
- [x] Diff isolated to the single target's `meta.json` (build-noise files reverted)