### PR TITLE
Enrich cayley-hamilton-oq-04-oq-01: split module-doc section at natural docstring boundary

### DIFF
--- a/src/data/proofs/cayley-hamilton-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-04-oq-01/meta.json
@@ -96,10 +96,19 @@
   "sections": [
     {
       "id": "module-doc",
-      "title": "Module Documentation & Setup",
+      "title": "Module Documentation: the Identity and Why It's Not a Re-export",
       "startLine": 1,
+      "endLine": 28,
+      "summary": "Imports (`Matrix.Adjugate`, `NonsingularInverse`, `Trace`, `Tactic`) and the docstring's opening sections: what is proved (the explicit A³ − (tr A)A² + c₂A − (det A)1 = 0 identity and the cube reduction) and why it is not a re-export of Mathlib's charpoly-based `Matrix.aeval_self_charpoly` — this file gives the bare trace/minor/determinant identity from scratch by entrywise `ring`, rather than the abstract charpoly statement.",
+      "mathContext": "Mathlib's Cayley–Hamilton is stated via `charpoly = det(X•1 − A)`; it does not hand you the concrete trace/minor/determinant polynomial, which is what this file computes directly."
+    },
+    {
+      "id": "coefficient-and-setup",
+      "title": "The Middle Coefficient, Mathematical Significance, and Ambient Setup",
+      "startLine": 30,
       "endLine": 57,
-      "summary": "Imports (`Matrix.Adjugate`, `NonsingularInverse`, `Trace`, `Tactic`) and the module docstring stating the explicit 3×3 Cayley–Hamilton identity and the cube reduction, the definition of the middle coefficient c₂ as the sum of the three 2×2 principal minors, the entrywise from-scratch proof strategy, and why it is not a re-export of Mathlib's charpoly Cayley–Hamilton. Opens the `CayleyHamiltonOQ04OQ01` namespace, `open Matrix`, and fixes the ambient `variable {R : Type*} [CommRing R]` over which everything is stated."
+      "summary": "Docstring sections describing c₂ as the sum of the three 2×2 principal minors, the mathematical significance (3×3 spatial linear algebra: rotations, inertia tensor, triple products — the degree-3 instance of Newton's identities), and the file's place relative to the 2×2 case and Wiedijk #49. Opens the `CayleyHamiltonOQ04OQ01` namespace, `open Matrix`, and fixes the ambient `variable {R : Type*} [CommRing R]`.",
+      "mathContext": "c₂ = (a₀₀a₁₁ − a₀₁a₁₀) + (a₀₀a₂₂ − a₀₂a₂₀) + (a₁₁a₂₂ − a₁₂a₂₁), the second elementary symmetric function of the eigenvalues — the coefficient of X in the characteristic polynomial."
     },
     {
       "id": "c2",


### PR DESCRIPTION
## Summary
- Closes the last quality gap (sections: 8/10, i.e. 4 sections) for `cayley-hamilton-oq-04-oq-01`, bringing the computed quality score from 98 to 100.
- The single `module-doc` section (lines 1-57) bundled two conceptually distinct halves of the module docstring: the theorem statement + why-not-a-re-export motivation (lines 1-28), and the c₂ coefficient description + significance + setup (lines 30-57), separated in the source by its own `##` header boundary (blank line at 29). Split at that real boundary.
- No other fields touched; boundaries verified directly against `Proofs/CayleyHamiltonOQ04OQ01.lean`.

## Test plan
- [x] `jq . src/data/proofs/cayley-hamilton-oq-04-oq-01/meta.json` — valid JSON
- [x] `npx tsx scripts/enricher/find-targets.ts --all --json` confirms `quality: 100` with all 8 buckets maxed
- [x] Diff isolated to the single target's `meta.json` (build-noise files reverted)