### PR TITLE
Research: ftc-oq-02-incomplete-01 - S8 nested directional-derivative bridge + classical Clairaut form [0 ax / 0 sorry]

### DIFF
--- a/proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean
+++ b/proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean
@@ -571,4 +571,134 @@ theorem iteratedFDerivWithin_comp_perm_of_convex [NormedSpace ℝ E] [NormedSpac
 
 end Within
 
+/-! ### Step 7 (S8): the classical nested form — iterated directional derivatives
+
+Everything above is phrased through `iteratedFDeriv`, the multilinear-map packaging of the
+`n`-th derivative. Classical texts state Clairaut/Schwarz differently: *nested* directional
+derivatives commute,
+
+  `∂_{v₀} (∂_{v₁} (… (∂_{vₙ₋₁} f))) = ∂_{v_{σ(0)}} (∂_{v_{σ(1)}} (… (∂_{v_{σ(n-1)}} f)))`,
+
+where `∂_w g = fun y => fderiv 𝕜 g y w`. Mathlib (v4.31) has the bridge between the two
+forms only at `n = 2` (`iteratedFDeriv_two_apply`); the general-`n` bridge — nested
+directional derivatives of a `C^n` function compute the `n`-th iterated derivative applied
+to the direction vector — is proved here (`nestedFDeriv_eq_iteratedFDeriv`), and the
+classical nested Clairaut theorem follows from `iteratedFDeriv_comp_perm`.
+
+(`Mathlib.Analysis.Distribution.DerivNotation` defines an abstract iterated
+line-derivative operator `∂^{v}` via the `LineDeriv` notation typeclass, but provides no
+instance for plain functions `E → F` and no relation to `iteratedFDeriv` — the concrete
+bridge below is not there.) -/
+
+variable (𝕜) in
+/-- The `n`-fold nested directional derivative:
+`nestedFDeriv 𝕜 n v f = ∂_{v 0} (∂_{v 1} (… (∂_{v (n-1)} f)))` where
+`∂_w g = fun y => fderiv 𝕜 g y w` — direction `v 0` is applied *outermost*, matching the
+left-to-right reading of `∂_{v₀} ∂_{v₁} … f`. -/
+noncomputable def nestedFDeriv : (n : ℕ) → (Fin n → E) → (E → F) → E → F
+  | 0, _, f => f
+  | n + 1, v, f => fun x => fderiv 𝕜 (nestedFDeriv n (Fin.tail v) f) x (v 0)
+
+@[simp]
+theorem nestedFDeriv_zero (v : Fin 0 → E) (f : E → F) : nestedFDeriv 𝕜 0 v f = f :=
+  rfl
+
+theorem nestedFDeriv_succ_apply {n : ℕ} (v : Fin (n + 1) → E) (f : E → F) (x : E) :
+    nestedFDeriv 𝕜 (n + 1) v f x = fderiv 𝕜 (nestedFDeriv 𝕜 n (Fin.tail v) f) x (v 0) :=
+  rfl
+
+@[simp]
+theorem nestedFDeriv_one_apply (v : Fin 1 → E) (f : E → F) (x : E) :
+    nestedFDeriv 𝕜 1 v f x = fderiv 𝕜 f x (v 0) :=
+  rfl
+
+/-- **The general-`n` nested/multilinear bridge.** For a `C^n` function, the `n`-fold
+nested directional derivative along `v 0, …, v (n-1)` equals the `n`-th iterated Fréchet
+derivative applied to `v`. Mathlib (v4.31) has this only at `n = 2`
+(`iteratedFDeriv_two_apply`). Holds over any nontrivially normed field.
+
+Inductive step: by the IH the inner `n`-fold nest is `y ↦ iteratedFDeriv 𝕜 n f y (tail v)`,
+i.e. the multilinear-map-valued function `iteratedFDeriv 𝕜 n f` applied to the *constant*
+tuple `tail v`; `fderiv_continuousMultilinear_apply_const_apply` commutes the constant
+application past `fderiv` (differentiability of `iteratedFDeriv 𝕜 n f` comes from
+`ContDiff.differentiable_iteratedFDeriv`), and `iteratedFDeriv_succ_apply_left` reassembles
+the `(n+1)`-st derivative. -/
+theorem nestedFDeriv_eq_iteratedFDeriv :
+    ∀ {n : ℕ}, ContDiff 𝕜 (n : ℕ) f → ∀ (v : Fin n → E) (x : E),
+      nestedFDeriv 𝕜 n v f x = iteratedFDeriv 𝕜 n f x v := by
+  intro n
+  induction n with
+  | zero =>
+    intro _ v x
+    exact (iteratedFDeriv_zero_apply v).symm
+  | succ n IH =>
+    intro hf v x
+    have hfn : ContDiff 𝕜 (n : ℕ) f := hf.of_le (by exact_mod_cast Nat.le_succ n)
+    have hfun : nestedFDeriv 𝕜 n (Fin.tail v) f =
+        fun y => iteratedFDeriv 𝕜 n f y (Fin.tail v) :=
+      funext fun y => IH hfn (Fin.tail v) y
+    have hdiff : DifferentiableAt 𝕜 (iteratedFDeriv 𝕜 n f) x :=
+      (hf.differentiable_iteratedFDeriv (by norm_cast; omega)).differentiableAt
+    calc nestedFDeriv 𝕜 (n + 1) v f x
+        = fderiv 𝕜 (nestedFDeriv 𝕜 n (Fin.tail v) f) x (v 0) := rfl
+      _ = fderiv 𝕜 (fun y => iteratedFDeriv 𝕜 n f y (Fin.tail v)) x (v 0) := by
+          rw [hfun]
+      _ = fderiv 𝕜 (iteratedFDeriv 𝕜 n f) x (v 0) (Fin.tail v) :=
+          fderiv_continuousMultilinear_apply_const_apply hdiff (Fin.tail v) (v 0)
+      _ = iteratedFDeriv 𝕜 (n + 1) f x v := (iteratedFDeriv_succ_apply_left v).symm
+
+/-- **Classical all-orders Clairaut/Schwarz, nested form.** For a `C^n` function over `ℝ`
+or `ℂ`, nested directional derivatives may be taken in any order:
+
+  `∂_{v_{σ(0)}} (∂_{v_{σ(1)}} (… f)) = ∂_{v_0} (∂_{v_1} (… f))`  at every point. -/
+theorem nestedFDeriv_comp_perm [IsRCLikeNormedField 𝕜] {n : ℕ}
+    (hf : ContDiff 𝕜 (n : ℕ) f) (v : Fin n → E) (σ : Equiv.Perm (Fin n)) (x : E) :
+    nestedFDeriv 𝕜 n (v ∘ σ) f x = nestedFDeriv 𝕜 n v f x := by
+  rw [nestedFDeriv_eq_iteratedFDeriv hf (v ∘ σ) x, nestedFDeriv_eq_iteratedFDeriv hf v x,
+    iteratedFDeriv_comp_perm hf x v σ]
+
+/-- Field-uniform `minSmoothness` form of the nested Clairaut theorem: over `ℝ`/`ℂ` the
+hypothesis is `C^n`; over any other nontrivially normed field it degrades to analyticity.
+The bridge itself only ever needs `C^n`, which `le_minSmoothness` extracts. -/
+theorem nestedFDeriv_comp_perm_of_minSmoothness {n : ℕ}
+    (hf : ContDiff 𝕜 (minSmoothness 𝕜 n) f) (v : Fin n → E) (σ : Equiv.Perm (Fin n))
+    (x : E) :
+    nestedFDeriv 𝕜 n (v ∘ σ) f x = nestedFDeriv 𝕜 n v f x := by
+  have hfn : ContDiff 𝕜 (n : ℕ) f := hf.of_le le_minSmoothness
+  rw [nestedFDeriv_eq_iteratedFDeriv hfn (v ∘ σ) x, nestedFDeriv_eq_iteratedFDeriv hfn v x,
+    iteratedFDeriv_comp_perm_of_minSmoothness hf x v σ]
+
+/-- **Second derivatives commute, nested classical form**: for a `C²` function over `ℝ` or
+`ℂ`,
+
+  `∂_a (∂_b f) = ∂_b (∂_a f)`,  i.e.
+  `fderiv 𝕜 (fun y => fderiv 𝕜 f y b) x a = fderiv 𝕜 (fun y => fderiv 𝕜 f y a) x b`.
+
+This differs from Mathlib's `IsSymmSndFDerivAt` (which swaps the two arguments of
+`fderiv 𝕜 (fderiv 𝕜 f) x`, evaluation *outside* the outer derivative) precisely by the
+bridge `nestedFDeriv_eq_iteratedFDeriv`; the nested spelling is the one in which the
+classical `∂²f/∂x∂y = ∂²f/∂y∂x` is usually written. -/
+theorem fderiv_fderiv_comm [IsRCLikeNormedField 𝕜] (hf : ContDiff 𝕜 2 f) (a b x : E) :
+    fderiv 𝕜 (fun y => fderiv 𝕜 f y b) x a = fderiv 𝕜 (fun y => fderiv 𝕜 f y a) x b := by
+  have h2 : ContDiff 𝕜 ((2 : ℕ) : ℕ∞ω) f := by exact_mod_cast hf
+  have hab : (![b, a] : Fin 2 → E) ∘ ⇑(Equiv.swap 0 1) = ![a, b] := by
+    funext i
+    fin_cases i <;> simp
+  have ha : Fin.tail (![a, b] : Fin 2 → E) = ![b] := by
+    funext i
+    fin_cases i <;> rfl
+  have hb : Fin.tail (![b, a] : Fin 2 → E) = ![a] := by
+    funext i
+    fin_cases i <;> rfl
+  have key := nestedFDeriv_comp_perm h2 (![b, a] : Fin 2 → E) (Equiv.swap 0 1) x
+  rw [hab] at key
+  calc fderiv 𝕜 (fun y => fderiv 𝕜 f y b) x a
+      = nestedFDeriv 𝕜 2 ![a, b] f x := by
+        rw [nestedFDeriv_succ_apply, ha]
+        rfl
+    _ = nestedFDeriv 𝕜 2 ![b, a] f x := key
+    _ = fderiv 𝕜 (fun y => fderiv 𝕜 f y a) x b := by
+        rw [nestedFDeriv_succ_apply, hb]
+        rfl
+
 end FTCOQ02Incomplete01

--- a/proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean
+++ b/proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean
@@ -686,10 +686,12 @@ theorem fderiv_fderiv_comm [IsRCLikeNormedField 𝕜] (hf : ContDiff 𝕜 2 f) (
     fin_cases i <;> simp
   have ha : Fin.tail (![a, b] : Fin 2 → E) = ![b] := by
     funext i
-    fin_cases i <;> rfl
+    fin_cases i
+    rfl
   have hb : Fin.tail (![b, a] : Fin 2 → E) = ![a] := by
     funext i
-    fin_cases i <;> rfl
+    fin_cases i
+    rfl
   have key := nestedFDeriv_comp_perm h2 (![b, a] : Fin 2 → E) (Equiv.swap 0 1) x
   rw [hab] at key
   calc fderiv 𝕜 (fun y => fderiv 𝕜 f y b) x a

--- a/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01/sessions/2026-07-24-s8-nested-directional-clairaut.md
+++ b/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01/sessions/2026-07-24-s8-nested-directional-clairaut.md
@@ -1,0 +1,63 @@
+# S8 (2026-07-24, researcher-3) — nested directional-derivative bridge + classical Clairaut form
+
+## Outcome
+
+New "Step 7 (S8)" section in `proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean`
+(~130 LOC, 0 axioms, 0 sorries, host-verified `lake env lean` exit 0, zero diagnostics,
+pinned v4.31.0 toolchain, lake-manifest mathlib rev identical to origin/main).
+
+Everything shipped in S5–S7 is phrased through `iteratedFDeriv` — the multilinear-map
+packaging. Classical texts state Clairaut/Schwarz as *nested* directional derivatives
+commuting: `∂_{v₀} ∂_{v₁} … f` order-independent, where `∂_w g = fun y => fderiv 𝕜 g y w`.
+Mathlib (v4.31) bridges the two forms only at `n = 2` (`iteratedFDeriv_two_apply`); the
+general-`n` bridge did not exist. S8 adds it and derives the classical nested statements:
+
+* `nestedFDeriv 𝕜 n v f` — the `n`-fold nested directional derivative
+  `∂_{v 0} (∂_{v 1} (… (∂_{v (n-1)} f)))`, direction `v 0` outermost (matches the design of
+  Mathlib's abstract `LineDeriv.iteratedLineDerivOp`, which has NO instance for plain
+  functions and NO `iteratedFDeriv` relation — checked `Analysis/Distribution/DerivNotation.lean`).
+* `nestedFDeriv_eq_iteratedFDeriv` — **the general-`n` bridge**: for `C^n` `f` (any
+  nontrivially normed field), `nestedFDeriv 𝕜 n v f x = iteratedFDeriv 𝕜 n f x v`.
+  Induction: IH turns the inner nest into `y ↦ D^n f y (tail v)` = the CMM-valued map
+  `iteratedFDeriv 𝕜 n f` applied to the CONSTANT tuple `tail v`;
+  `fderiv_continuousMultilinear_apply_const_apply` (Mathlib, `FDeriv/CompCLM.lean`) commutes
+  the constant application past `fderiv`; differentiability of `D^n f` from
+  `ContDiff.differentiable_iteratedFDeriv (n < n+1)`; reassemble with
+  `iteratedFDeriv_succ_apply_left` (rfl at v4.31).
+* `nestedFDeriv_comp_perm` — classical all-orders Clairaut, nested form, over ℝ/ℂ:
+  `nestedFDeriv 𝕜 n (v ∘ σ) f x = nestedFDeriv 𝕜 n v f x` for `C^n` `f`. Two bridge
+  rewrites + `iteratedFDeriv_comp_perm`.
+* `nestedFDeriv_comp_perm_of_minSmoothness` — field-uniform version; the bridge itself only
+  needs `C^n`, extracted from the `minSmoothness` hypothesis via `le_minSmoothness`.
+* `fderiv_fderiv_comm` — the `C²` special case spelled out:
+  `fderiv 𝕜 (fun y => fderiv 𝕜 f y b) x a = fderiv 𝕜 (fun y => fderiv 𝕜 f y a) x b`.
+  This is genuinely different from Mathlib's `IsSymmSndFDerivAt` (there the evaluation is
+  OUTSIDE the outer derivative: `fderiv 𝕜 (fderiv 𝕜 f) x v w`); the nested spelling is the
+  one in which `∂²f/∂x∂y = ∂²f/∂y∂x` is classically written, and Mathlib has no
+  `fderiv_fderiv`-commutation lemma of this shape (grepped).
+
+## Lean notes (v4.31)
+
+* `nestedFDeriv` defined by structural recursion on `n` with `variable (𝕜) in`; recursive
+  call inside the equations takes only the varying args (`nestedFDeriv n (Fin.tail v) f`) —
+  fixed section params are auto-applied. All three unfolding lemmas (`_zero`, `_succ_apply`,
+  `_one_apply`) are `rfl`.
+* `nestedFDeriv 𝕜 2 ![a,b] f x = fderiv 𝕜 (fun y => fderiv 𝕜 f y b) x a` is `rfl` after
+  `rw [nestedFDeriv_succ_apply, (Fin.tail ![a,b] = ![b])]` — `![b] 0` and `![a,b] 0` reduce
+  definitionally, and `rw` matched the `2 = ?n + 1` literal without a `show`.
+* `fin_cases i` on `i : Fin 1` leaves ONE goal — `fin_cases i <;> rfl` trips the
+  `unnecessarySeqFocus` linter; use `fin_cases i` then `rfl` on separate lines.
+* Compiled clean on first verification pass (only the two linter warnings above).
+
+## Remaining
+
+* An actual Mathlib upstream PR — Fragment 1 (now including the nested/classical API layer,
+  which is precisely what an upstream reviewer would ask for as the "user-facing" form).
+  No mathlib4 checkout exists on this host; a submission session needs a clone + cache
+  (~several GB) and a port to current master (this file is pinned at v4.31 idioms).
+* S9 candidates (session-sized): `Within` version of the nested bridge
+  (`nestedFDerivWithin` via `fderivWithin_continuousMultilinear_apply_const_apply`, which
+  exists at the same place in Mathlib); `lineDeriv`-flavored corollaries via
+  `DifferentiableAt.lineDeriv_eq_fderiv` (each intermediate nest is differentiable by the
+  bridge, since it equals a CMM-application of `D^k f`).
+* Fragments 2–6 (manifold Stokes) — DEEP multi-session, unchanged.

--- a/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01/state.md
+++ b/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01/state.md
@@ -13,9 +13,44 @@ Mathlib v4.26→v4.31 changed the landscape and a lighter proof replaced it (see
 S6 (researcher-2, 2026-07-24) then generalized the file to upstream-ready generality —
 see Iteration 6. S7 (researcher-3, 2026-07-24) added the full `Within`/`UniqueDiffOn`
 version — Fragment 1 is now **feature-complete for upstream** — see Iteration 7.
+S8 (researcher-3, 2026-07-24) added the classical *nested* directional-derivative layer:
+the general-`n` bridge `nestedFDeriv_eq_iteratedFDeriv` (Mathlib has only `n = 2`) and the
+nested Clairaut statements — see Iteration 8.
 **Path**: full
-**Since**: 2026-07-24 (S7 Within/UniqueDiffOn complete)
-**Iteration**: 7
+**Since**: 2026-07-24 (S8 nested/classical form complete)
+**Iteration**: 8
+
+## Iteration 8 (researcher-3, 2026-07-24) — S8: nested directional-derivative bridge + classical Clairaut (0 ax / 0 sorry)
+
+**Outcome**: new "Step 7 (S8)" section in `FundamentalTheoremCalculusOQ02Incomplete01.lean`
+(~130 LOC; host-verified `lake env lean` exit 0, zero diagnostics, pinned v4.31.0,
+lake-manifest mathlib rev identical to origin/main):
+
+* `nestedFDeriv 𝕜 n v f` — the `n`-fold nested directional derivative
+  `∂_{v 0} (∂_{v 1} (… (∂_{v (n-1)} f)))`, `∂_w g = fun y => fderiv 𝕜 g y w`.
+* `nestedFDeriv_eq_iteratedFDeriv` — the **general-`n` nested/multilinear bridge** for
+  `C^n` functions over any nontrivially normed field; Mathlib (v4.31) has this only at
+  `n = 2` (`iteratedFDeriv_two_apply`). Key ingredients:
+  `fderiv_continuousMultilinear_apply_const_apply` (constant CMM-application commutes past
+  `fderiv`) + `ContDiff.differentiable_iteratedFDeriv` + `iteratedFDeriv_succ_apply_left`.
+* `nestedFDeriv_comp_perm` / `nestedFDeriv_comp_perm_of_minSmoothness` — classical
+  all-orders Clairaut in nested form (ℝ/ℂ, resp. field-uniform via `le_minSmoothness`).
+* `fderiv_fderiv_comm` — `C²` nested form
+  `fderiv 𝕜 (fun y => fderiv 𝕜 f y b) x a = fderiv 𝕜 (fun y => fderiv 𝕜 f y a) x b`;
+  distinct from `IsSymmSndFDerivAt` (evaluation inside vs outside the outer derivative);
+  no Mathlib lemma of this shape exists (grepped).
+
+Checked: `Mathlib.Analysis.Distribution.DerivNotation`'s abstract `iteratedLineDerivOp`
+(`∂^{v}`) has NO instance for plain functions and NO `iteratedFDeriv` bridge — no overlap.
+
+**Remaining**: an actual Mathlib upstream PR (Fragment 1 now includes the user-facing
+nested API layer an upstream reviewer would ask for; note: no mathlib4 checkout on this
+host — a submission session needs a clone + cache + port to current master). S9 candidates
+(session-sized): `Within` nested bridge via
+`fderivWithin_continuousMultilinear_apply_const_apply`; `lineDeriv` corollaries via
+`DifferentiableAt.lineDeriv_eq_fderiv`. Fragments 2–6 unchanged — DEEP multi-session.
+
+Session memo: `sessions/2026-07-24-s8-nested-directional-clairaut.md`.
 
 ## Iteration 7 (researcher-3, 2026-07-24) — S7: full `Within` version on `UniqueDiffOn` sets (0 ax / 0 sorry)
 

--- a/src/data/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01.json
+++ b/src/data/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01.json
@@ -31,19 +31,19 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-07-24",
-    "iteration": 6,
-    "focus": "Iteration 6 (researcher-2, 2026-07-24, S6 upstream-prep COMPLETE): Fragment 1 generalized in place to upstream-ready generality (docker exit 0, 8576 jobs, 0 ax / 0 sorry). Steps 1-3 core now over arbitrary NontriviallyNormedField; main theorem + swap-0-1 step gated by IsRCLikeNormedField (exactly Mathlib n=2 Schwarz hypothesis). NEW: iteratedFDeriv_comp_perm_of_minSmoothness — field-uniform statement in Mathlib minSmoothness idiom (non-RCLike branch delegates to analytic ContDiffAt.iteratedFDeriv_comp_perm), mirroring ContDiffAt.isSymmSndFDerivAt; iteratedFDerivWithin_comp_perm_of_isOpen (Within on open sets). Remaining S7 candidate: full UniqueDiffOn Within induction via fderivWithin. Fragments 2-6 (manifold Stokes) DEEP multi-session, unchanged.",
+    "iteration": 8,
+    "focus": "Iteration 8 (researcher-3, 2026-07-24, S8 COMPLETE): classical nested directional-derivative layer added to FundamentalTheoremCalculusOQ02Incomplete01.lean (0 ax / 0 sorry, host-verified lake env lean exit 0). nestedFDeriv (n-fold nested ∂_{v0}∂_{v1}…f operator), nestedFDeriv_eq_iteratedFDeriv (general-n nested/multilinear bridge — Mathlib v4.31 has only n=2 iteratedFDeriv_two_apply), nestedFDeriv_comp_perm(_of_minSmoothness) (classical all-orders Clairaut in nested form), fderiv_fderiv_comm (C² nested ∂_a∂_b f = ∂_b∂_a f — distinct from IsSymmSndFDerivAt, evaluation inside vs outside the outer derivative).",
     "blockers": [],
-    "nextAction": "Fragment 1 done (the S4-planned `IteratedFDerivSymmetric.lean` target is superseded by `FundamentalTheoremCalculusOQ02Incomplete01.lean`). Honest next options: (i) S6 Mathlib upstream-prep of `iteratedFDeriv_comp_perm` (natural home: near `Mathlib.Analysis.Analytic.IteratedFDeriv`; generalize R to IsRCLikeNormedField via `minSmoothness`); (ii) Fragments 2-6 (differential-form integration on manifolds with boundary) remain DEEP and are NOT session-sized — do not chase without a dedicated multi-session plan. Within-versions (iteratedFDerivWithin on UniqueDiffOn sets) are a plausible medium extension.",
+    "nextAction": "Fragment 1 feature-complete incl. classical nested API. Honest next options: (i) actual Mathlib upstream PR — needs a mathlib4 clone + cache + port to current master (none on this host); (ii) S9 session-sized: Within nested bridge via fderivWithin_continuousMultilinear_apply_const_apply, or lineDeriv corollaries via DifferentiableAt.lineDeriv_eq_fderiv; (iii) Fragments 2-6 (manifold Stokes) DEEP multi-session — do not chase without a dedicated plan.",
     "attemptCounts": {
       "total": 4,
       "currentApproach": 0,
       "approachesTried": 0
     },
-    "lastUpdate": "2026-07-24T10:20:00.000Z"
+    "lastUpdate": "2026-07-24T17:55:00.000Z"
   },
   "knowledge": {
-    "progressSummary": "Fragment 1 (all-orders Schwarz/Clairaut for iteratedFDeriv) is COMPLETE and upstream-ready: S5 proved the C^n global theorem over ℝ, S6 generalized to IsRCLikeNormedField/minSmoothness, S7 added the full Within/UniqueDiffOn version (boundary points of convex Stokes domains included). 0 axioms, 0 sorries throughout. Remaining work: an actual Mathlib PR, and the DEEP Fragments 2-6 (manifold Stokes).",
+    "progressSummary": "Fragment 1 (all-orders Schwarz/Clairaut for iteratedFDeriv) is COMPLETE and upstream-ready: S5 global C^n theorem over ℝ, S6 IsRCLikeNormedField/minSmoothness generalization, S7 full Within/UniqueDiffOn version, S8 classical nested directional-derivative layer (general-n nested/multilinear bridge + nested Clairaut + fderiv_fderiv_comm). 0 axioms, 0 sorries throughout. Remaining: an actual Mathlib PR (no mathlib4 checkout on this host), optional S9 Within/lineDeriv nested corollaries, and the DEEP Fragments 2-6 (manifold Stokes).",
     "builtItems": [
       "S7 (researcher-3, 2026-07-24): full `Within`/`UniqueDiffOn` version added to `FundamentalTheoremCalculusOQ02Incomplete01.lean` — `iteratedFDerivWithin_comp_perm` (UniqueDiffOn s + s ⊆ closure (interior s), C^n on s, symmetry at every point of s incl. boundary), `iteratedFDerivWithin_comp_perm_of_convex` (convex sets w/ nonempty interior over ℝ: closed balls, Icc, simplices), `iteratedFDerivWithin_comp_perm_of_minSmoothness` (field-uniform), `iteratedFDerivWithin_domDomCongr`; whole induction redone with fderivWithin. 0 axioms, 0 sorries; host-verified on pinned v4.31.0 (rev 9a9483a929).",
       "S5 ACT (researcher-3 PR, 2026-07-24): `proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean` — `iteratedFDeriv_comp_perm` (C^n, finite smoothness, over R), plus `iteratedFDeriv_domDomCongr` and a C^infty specialization; 0 axioms, 0 sorries.",
@@ -55,7 +55,11 @@
       "S6: fderiv_comp_perm_eq / iteratedFDeriv_comp_tailLift / iteratedFDeriv_add_two_apply generalized to arbitrary NontriviallyNormedField (FundamentalTheoremCalculusOQ02Incomplete01.lean)",
       "S6: iteratedFDeriv_comp_perm + corollaries now over IsRCLikeNormedField (R or C), not just R",
       "S6: iteratedFDeriv_comp_perm_of_minSmoothness — field-uniform minSmoothness statement over any nontrivially normed field",
-      "S6: iteratedFDerivWithin_comp_perm_of_isOpen — Within version on open sets"
+      "S6: iteratedFDerivWithin_comp_perm_of_isOpen — Within version on open sets",
+      "nestedFDeriv + rfl-lemmas (zero/succ_apply/one_apply) in FundamentalTheoremCalculusOQ02Incomplete01.lean (S8)",
+      "nestedFDeriv_eq_iteratedFDeriv: general-n nested/multilinear bridge, any NontriviallyNormedField (S8)",
+      "nestedFDeriv_comp_perm + nestedFDeriv_comp_perm_of_minSmoothness: classical all-orders Clairaut, nested form (S8)",
+      "fderiv_fderiv_comm: C² nested second-derivative commutation (S8)"
     ],
     "insights": [
       "FTC is represented as the 1D Stokes theorem with M=[a,b], omega=F, and d omega=F' dx.",
@@ -65,7 +69,10 @@
       "v4.31 Mathlib gained the analytic-case n-th-derivative symmetry (Gouezel, Mathlib.Analysis.Analytic.IteratedFDeriv) and the n=2 IsSymmSndFDeriv API; the finite-smoothness C^n general-n case was the surviving gap and is exactly what Fragment 1 needed. Peel-left + decomposeFin + conjugated swaps avoids Subgroup.closure entirely; the S4 fear about case i=0 currying (65-100 LOC) shrank to ~30 LOC because `iteratedFDeriv_succ_apply_left`/`iteratedFDeriv_succ_eq_comp_left` are rfl and `LinearIsometryEquiv.comp_fderiv` (with EXPLICIT type args — implicit unification times out at whnf on CMM instance paths) gives the currying step in one line.",
       "The ONLY R/C-specific input to the C^n Schwarz induction is the n=2 base (ContDiffAt.isSymmSndFDerivAt); everything else (domDomCongr isometry transport, tail lifts, decomposeFin conjugation) is field-generic.",
       "Mathlib minSmoothness idiom unifies the C^n (RCLike) and C^omega (general field) versions into one statement — the natural upstream form; by_cases IsRCLikeNormedField with the non-RCLike branch delegating to the analytic version, exactly like isSymmSndFDerivAt itself.",
-      "v4.31: smoothness-exponent notations (nat-infty-omega, omega, infty) are scoped[ContDiff]; files using minSmoothness need open scoped ContDiff even with import Mathlib. minSmoothness is irreducible_def — unfold via simp [minSmoothness, h]."
+      "v4.31: smoothness-exponent notations (nat-infty-omega, omega, infty) are scoped[ContDiff]; files using minSmoothness need open scoped ContDiff even with import Mathlib. minSmoothness is irreducible_def — unfold via simp [minSmoothness, h].",
+      "The general-n bridge between nested directional derivatives and iteratedFDeriv is a one-induction proof once fderiv_continuousMultilinear_apply_const_apply is known: the IH turns the inner nest into a CONSTANT CMM-application of D^n f, which commutes past fderiv; Mathlib had the bridge only at n=2 (iteratedFDeriv_two_apply).",
+      "Mathlib Analysis/Distribution/DerivNotation.lean defines an abstract iterated line-derivative operator (LineDeriv.iteratedLineDerivOp, notation ∂^{v}) but provides NO instance for plain functions E → F and NO relation to iteratedFDeriv — the concrete nested/multilinear bridge was genuinely missing.",
+      "fderiv_fderiv_comm (nested C² Clairaut, evaluation INSIDE the outer derivative) is not IsSymmSndFDerivAt (evaluation OUTSIDE): the two differ exactly by the constant-application commutation step, and Mathlib has no lemma of the nested shape."
     ],
     "mathlibGaps": [
       "`iteratedFDeriv_comp_perm` for C^n (finite smoothness) functions is still absent from Mathlib v4.31 (only n=2 and the analytic case exist) — now proved in this slug's file; upstream candidate.",


### PR DESCRIPTION
## Summary
Research session S8 for `fundamental-theorem-calculus-oq-02-incomplete-01` (Fragment 1: all-orders Schwarz/Clairaut).

S5–S7 phrased everything through `iteratedFDeriv` (the multilinear packaging). Classical texts state Clairaut/Schwarz as *nested* directional derivatives commuting: `∂_{v₀}∂_{v₁}…f` is order-independent, where `∂_w g = fun y => fderiv 𝕜 g y w`. Mathlib (v4.31) bridges the two forms only at `n = 2` (`iteratedFDeriv_two_apply`). S8 adds the general-`n` bridge and derives the classical nested statements.

## Progress
- `nestedFDeriv 𝕜 n v f` — the `n`-fold nested directional derivative, with `rfl` unfolding lemmas
- `nestedFDeriv_eq_iteratedFDeriv` — **general-`n` nested/multilinear bridge** for `C^n` functions over any `NontriviallyNormedField` (one induction: the IH turns the inner nest into a constant CMM-application of `D^n f`, which `fderiv_continuousMultilinear_apply_const_apply` commutes past `fderiv`)
- `nestedFDeriv_comp_perm` / `_of_minSmoothness` — classical all-orders Clairaut in nested form (ℝ/ℂ, resp. field-uniform)
- `fderiv_fderiv_comm` — `C²` nested form `∂_a∂_b f = ∂_b∂_a f`; genuinely distinct from `IsSymmSndFDerivAt` (evaluation inside vs outside the outer derivative), no Mathlib lemma of this shape

Files: `proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean` (+130 LOC), state.md Iteration 8, session memo, tracker JSON.

## Findings
- Mathlib's `Analysis/Distribution/DerivNotation.lean` (`iteratedLineDerivOp`, `∂^{v}`) is an abstract notation typeclass with no instance for plain functions and no `iteratedFDeriv` relation — the concrete bridge was genuinely missing
- The bridge itself needs only `C^n` (no RCLike): symmetry is the only step gated by the field

## Verification
- Host-verified: `lake env lean` exit 0, **zero diagnostics**, pinned v4.31.0 toolchain, lake-manifest mathlib rev identical to origin/main
- 0 axioms, 0 sorries (whole file)

## Status
**Outcome**: progress (Fragment 1 now includes the user-facing classical API layer)
**Next Steps**: (i) actual Mathlib upstream PR (needs mathlib4 clone + cache + port to master — none on this host); (ii) S9 session-sized: `Within` nested bridge, `lineDeriv` corollaries; (iii) Fragments 2–6 remain DEEP multi-session.

🤖 Generated by researcher-3
