### PR TITLE
Enrich cayley-hamilton-oq001: add missing imports/setup section

### DIFF
--- a/src/data/proofs/cayley-hamilton-oq001/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq001/meta.json
@@ -145,6 +145,14 @@
       "summary": "Module docstring. Recalls the parent (vecAnnIdeal / IsCyclicVector framework) and grandparent (reverse direction minpoly = charpoly ⟹ ∃ cyclic vector), states the four main results, and lays out the forward direction as a degree squeeze: deg(minpoly) ≤ n from Cayley–Hamilton, deg(minpoly) ≥ n from cyclicity."
     },
     {
+      "id": "imports-setup",
+      "title": "Imports and Ambient Setup",
+      "startLine": 56,
+      "endLine": 65,
+      "summary": "Imports the grandparent file `CayleyHamiltonOQ01OQ01OQ01` (the bridge lemma and reverse-direction existence theorem), opens `Matrix Polynomial Module BigOperators` plus the two ancestor namespaces, and fixes the ambient `variable {K : Type*} [Field K] {n : ℕ}` shared by every theorem below.",
+      "mathContext": "Everything downstream is stated for an n × n matrix over an arbitrary field K, reusing the ancestor files' vecAnnIdeal / IsCyclicVector API rather than redefining it."
+    },
+    {
       "id": "forward-degree",
       "title": "Part I — A cyclic vector forces full-degree minimal polynomial",
       "startLine": 66,


### PR DESCRIPTION
## Summary
- Closes the last quality gap (sections: 8/10, i.e. 4 sections) for `cayley-hamilton-oq001`, bringing the computed quality score from 98 to 100.
- Lines 56-65 of `CayleyHamiltonOQ01OQ01OQ01OQ01.lean` — the `import`, `open`, `namespace`, and ambient `variable` declarations — were entirely uncovered by any section: `header` ends at line 55 (the module docstring) and `forward-degree` starts at line 66 (the first theorem). Added an `imports-setup` section spanning the gap.
- No other fields touched; boundary verified directly against the Lean source.

## Test plan
- [x] `jq . src/data/proofs/cayley-hamilton-oq001/meta.json` — valid JSON
- [x] `npx tsx scripts/enricher/find-targets.ts --all --json` confirms `quality: 100` with all 8 buckets maxed
- [x] Diff isolated to the single target's `meta.json` (build-noise files reverted)