### PR TITLE
Fix: erdos-1151 stale sorry count (claimed 1, actual 0)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10444,10 +10444,10 @@
       "result": "clean"
     },
     "erdos-1151": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-07-24T03:31:16Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-07-24T16:42:54Z",
+      "result": "issues-found"
     },
     "erdos-1153": {
       "auditCount": 4,

--- a/src/data/proofs/erdos-1151/meta.json
+++ b/src/data/proofs/erdos-1151/meta.json
@@ -17,7 +17,6 @@
       "interpolation"
     ],
     "badge": "axiom",
-    "sorries": 1,
     "erdosNumber": 1151,
     "erdosUrl": "https://erdosproblems.com/1151",
     "erdosProblemStatus": "open",
@@ -42,6 +41,7 @@
       "Formal statement of the full conjecture with special cases derived",
       "Companion file Erdos1151OQ04.lean: sorry-free proof of the Lebesgue-function divergence theorem (erdos_1941_divergence_from_growth): for x = cos(πp/q) with odd p, q there is a continuous f whose Chebyshev interpolation values at x are unbounded (limsup |Lₙf(x)| = ∞), via Λₙ(x) ≥ C log(n+1) growth plus Banach–Steinhaus (S41). This is the faithful limsup form of the classical argument; the finer full-limit statement of Erdős's paper remains axiomatized as erdos_1941_divergence in the parent file only."
     ],
+    "sorries": 0,
     "axiomCount": 2,
     "assumptions": "2 axioms: erdos_1941_divergence (Erdős 1941 result on divergence at rational cosines, in its strong full-limit form), erdos_1151_conjecture (the open problem). The companion file Erdos1151OQ04.lean (listed under additionalFiles) is sorry-free (0 sorries, 0 axiom declarations) and PROVES the limsup form of the 1941 divergence (erdos_1941_divergence_from_growth, via Lebesgue-function growth + Banach–Steinhaus); the parent's erdos_1941_divergence axiom records the stronger full-limit literature statement, which is not yet formalized.",
     "lineCount": 222,
@@ -178,5 +178,5 @@
       "Proofs/Erdos1151OQ04.lean"
     ]
   },
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-1151
**Problem**: `meta.sorries` and top-level `sorries` both claimed 1 sorry; actual is 0.

## Evidence

**meta.json claims**: `meta.sorries: 1`, top-level `sorries: 1` (while `leanFile.sorries: 0` already had the correct value — the two blocks had drifted).
**Lean file shows**: `grep -noE '\bsorry\b'` across `Erdos1151Problem.lean`, `Erdos1151OQ04.lean`, and `Erdos1151OQ04Aristotle.lean` finds zero actual `sorry` tactic invocations — all hits are docstring prose ("NO remaining sorries", "sorry-free proof", "All proofs are complete (no sorry)"). The companion file's last sorry was closed by #43461 (S41: limsup ground-truthing + Banach–Steinhaus, "0 sorries, 0 axioms") without the parent meta.json's two numeric sorry fields being updated to match.

## Fix

Set `meta.sorries` and top-level `sorries` to `0`, matching `leanFile.sorries` and the actual source. No status/badge change needed — entry stays `axiomatized`/`axiom` (2 real axioms unaffected).

---
Discovered during gallery integrity audit.