### PR TITLE
Update audit tracker: erdos-735-oq-04 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -31918,6 +31918,12 @@
       "lastAudited": "2026-07-24T07:50:07Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-735-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-24T16:47:33Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
First audit of erdos-735-oq-04 — verified clean. 1 axiom, 0 sorries, all named theorems/axiom checked against source, no native_decide, no True stubs, lineCount matches exactly.