### PR TITLE
Update audit tracker: randomized-maxcut-oq-02 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24426,9 +24426,9 @@
       "result": "issues-fixed"
     },
     "randomized-maxcut-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:37Z",
+      "lastAudited": "2026-07-24T16:54:27Z",
       "result": "clean"
     },
     "randomized-maxcut-oq-04": {


### PR DESCRIPTION
## Summary
- Gallery integrity audit of `randomized-maxcut-oq-02` (Weighted MaxCut Approximation): clean.
- Verified `meta.json`/`leanFile` counts (1 axiom, 0 sorries, 3 theorems, 5 definitions) against `proofs/Proofs/RandomizedMaxcutOQ02.lean` — all match.
- Status `axiomatized` / badge `axiom` correctly reflect the single `exists_good_partition` axiom (probabilistic method step). No True stubs. `overview`/`annotations.json` honestly disclose the trivial-sanity-check nature of `random_partition_expected_cut` and the placeholder Goemans-Williamson ratio (`gw_ratio_lower`/`gw_beats_random` are trivially true).
- No fix needed; updating `audit-tracker.json` only.

## Test plan
- N/A (tracker JSON only)