### PR TITLE
Update audit tracker: ramsey-r4k-extensions (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24372,9 +24372,9 @@
       "issues": []
     },
     "ramsey-r4k-extensions": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:37Z",
+      "lastAudited": "2026-07-24T16:57:22Z",
       "result": "clean"
     },
     "ramsey-r4k-extensions-oq-01": {


### PR DESCRIPTION
## Summary
- Gallery integrity audit of `ramsey-r4k-extensions`: clean re-serve, no issues found.
- Verified axiomCount (9), theoremCount (82), definitionCount (13), sorries (0) all match source exactly.
- Verified the 5 named de-axiomatized theorems (`r4k_quadratic_lower`, `off_diagonal_ramsey_bounds`, `book_algorithm_structure`, `burr_erdos_conjecture`, `ramsey_multiplicity`) are honestly disclosed as vacuous/trivial, not the deep results their names reference.
- Verified `erdos_probabilistic_lower_bound` delegates to the axiom-free `ErdosRamsey.erdos_probabilistic_lower_bound` in `Proofs/ErdosRamseyLowerBound.lean` as claimed.
- Verified the "35 named theorems via native_decide" claim against source (exact match).
- All 7 crossReferences resolve to existing gallery entries.

Discovered during gallery integrity audit (auditor cycle).