### PR TITLE
Enrich chebyshev-pnt-bridge-oq-03: add 5th section

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge-oq-03/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-03/meta.json
@@ -130,12 +130,20 @@
       "mathContext": "π'(n+1) ≤ π'(p) < π'(p+1) ≤ π'(2n+1) via monotonicity and the count_succ jump at the prime p."
     },
     {
-      "id": "examples",
-      "title": "Strictness and Explicit Cases",
+      "id": "strict-doubling",
+      "title": "π Strictly Increases",
       "startLine": 75,
+      "endLine": 79,
+      "summary": "primeCounting_lt_two_mul: π(n) < π(2n) strictly, a direct corollary of the ≥ π(n)+1 bound.",
+      "mathContext": "Since π(2n) ≥ π(n) + 1 > π(n), the ≤ from primeCounting_two_mul_ge upgrades to strict < with no extra work — omega closes the arithmetic."
+    },
+    {
+      "id": "examples",
+      "title": "Explicit Small Cases",
+      "startLine": 81,
       "endLine": 89,
-      "summary": "π(n) < π(2n) strictly, and explicit primes in (1,2] and (5,10].",
-      "mathContext": "Bertrand at n = 1 gives 2; at n = 5 gives 7."
+      "summary": "Worked instances of Bertrand's postulate: a prime in (1,2] and a prime in (5,10].",
+      "mathContext": "Bertrand at n = 1 gives the prime 2; at n = 5 gives the prime 7 ∈ (5,10]."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for chebyshev-pnt-bridge-oq-03 (quality 98/100, sections bucket 8/10).

Splits the mislabeled "Strictness and Explicit Cases" section (lines 75-89) at
its docstring boundary (`/- ## Explicit small cases -/`, line 81) into two
genuine sections:

- `strict-doubling` (75-79): the `primeCounting_lt_two_mul` theorem, a real
  standalone result (π(n) < π(2n) strictly), previously bundled in with the
  examples.
- `examples` (81-89): the actual worked instances (primes in (1,2] and (5,10]).

No content deleted; existing sections/annotations/keyInsights untouched.

Note: `pnpm build` JSON-validation stages (check-size, check-verified-companions,
annotations:build, research:build, check-search-index, loading-facts,
build-redirects) all passed on this change. Full `tsc -b`/`vite build` could not
run in this worktree — `node_modules` is broken host-wide by a Node v26.5.0 /
better-sqlite3 native-build incompatibility unrelated to this change.