### PR TITLE
Update audit tracker: quadratic-reciprocity-algorithm-oq-01 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24298,9 +24298,9 @@
       "result": "clean"
     },
     "quadratic-reciprocity-algorithm-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:37Z",
+      "lastAudited": "2026-07-24T17:00:24Z",
       "result": "clean"
     },
     "quadratic-reciprocity-algorithm-oq-02": {


### PR DESCRIPTION
## Summary
- Re-audited `quadratic-reciprocity-algorithm-oq-01` (round-robin re-serve, unaudited queue is drained).
- Verified against `proofs/Proofs/QuadraticReciprocityAlgorithmOQ01.lean`: 0 sorries, 0 axioms, 2 defs, 3 theorems, 220 lines — all match meta.json exactly.
- `native_decide` used only in 7 anonymous `example` blocks, correctly disclosed in `assumptions` text (no named declaration depends on it).
- `annotations.json` cites only real Mathlib lemmas present in the source (`jacobiSym.div_four_left`, `.even_odd`, `.quadratic_reciprocity_if`, `.mod_left`, `.eq_zero_iff`, `.legendreSym.to_jacobiSym`).
- Result: **clean**, no issues found.

## Test plan
- [x] Diffed meta.json fields against `grep`/`wc -l` output on the Lean source.
- [x] Cross-checked annotations.json Mathlib lemma names against file body.