### PR TITLE
Update audit tracker: pythagorean-triples-oq-02 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24136,9 +24136,9 @@
       "issues": []
     },
     "pythagorean-triples-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:37Z",
+      "lastAudited": "2026-07-24T17:03:35Z",
       "result": "clean"
     },
     "pythagorean-triples-oq-02-oq-01": {


### PR DESCRIPTION
## Summary
- Re-audited `pythagorean-triples-oq-02` (queue drained, round-robin oldest re-serve).
- Verified counts exactly: 14 theorems, 4 defs, 0 sorries, 0 axioms, no native_decide.
- annotations.json declaration names all correspond to real Lean declarations; cross-references resolve.
- `original` badge is justified — Mathlib's `PythagoreanTriple` is used only as a disclosed predicate wrapper, not the core proof engine.
- Result: clean, no issues found.

🤖 Generated with gallery integrity audit.