### PR TITLE
Update audit tracker: erdos-1059-oq-01 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9485,9 +9485,9 @@
       "result": "clean"
     },
     "erdos-1059-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:37Z",
+      "lastAudited": "2026-07-24T17:06:25Z",
       "result": "clean"
     },
     "erdos-1059-oq-01-oq-01": {


### PR DESCRIPTION
## Summary
- Marks erdos-1059-oq-01 audit as clean (auditCount 2→3)

## Audit notes
Verified against `proofs/Proofs/Erdos1059OQ01.lean`:
- 0 sorries, 1 axiom (`density_one_conjecture`) — matches meta.json exactly
- definitionCount 6, native_decide usage fully disclosed (14 pure computational verifications, plus the `Lean.ofReduceBool` trust caveat spelled out in `assumptions`)
- All `mathlibDependencies` names verified present in file body
- Cross-file import from `Erdos1059OQ02` (selberg_density_axiom, PrimorialInterval, selberg_implies_erdos, ErdosProblem1059) verified to exist in the sibling file, and the definitional-equality claim between the two files' `AllFactorialSubtractionsComposite` bodies checked byte-for-byte identical
- No overclaiming: status `axiomatized`/badge `axiom` correctly reflects the one open conjecture; strong disclosure of the transitively-imported OQ-02 axiom in prose

No issues found.