### PR TITLE
Gallery integrity: burnside-counting-oq-03 stale openQuestions contradict own conclusion.summary

### DIFF
--- a/src/data/proofs/burnside-counting-oq-03/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03/meta.json
@@ -168,11 +168,9 @@
   },
   "conclusion": {
     "summary": "Formalizes the Pólya enumeration theorem for cyclic groups: proves the general fixed-point formula |Fix(r)| = k^{gcd(r,n)} in full generality (the orbit-bijection argument is fully discharged, with no sorries), verifies all concrete computations for binary 4-necklaces by native_decide, and establishes both forms of the Pólya sum (rotational and divisor sum) along with the reindexing identity.",
-    "implications": "This entry achieves two goals: (1) it replaces axioms from burnside-counting with proofs, demonstrating the power of computation via native_decide for concrete instances; (2) it states the general formula polya_cyclic_fixed_count which, once proved, will fully generalize Burnside's lemma to the Pólya enumeration theorem for all cyclic groups. The fiber_card_eq_totient lemma (fully proved) is the hardest combinatorial step and may be reusable for other Pólya-type arguments.",
+    "implications": "This entry achieves two goals: (1) it replaces axioms from burnside-counting with proofs, demonstrating the power of computation via native_decide for concrete instances; (2) it proves the general formula polya_cyclic_fixed_count, fully generalizing Burnside's lemma to the Pólya enumeration theorem for all cyclic groups. The fiber_card_eq_totient lemma (fully proved) is the hardest combinatorial step and may be reusable for other Pólya-type arguments.",
     "openQuestions": [
-      "Complete polya_cyclic_fixed_count: the bijection {fixed colorings} ↔ (Fin d → Fin k) remains as a sorry — the invFun half (backward map) is defined but left_inv requires showing that coloring by orbit representative and then evaluating at a representative gives back the original coloring.",
-      "Generalize from cyclic groups to arbitrary finite groups: the full Pólya enumeration theorem uses the cycle index of an arbitrary permutation group. Can the Lean formalization be extended to, e.g., the dihedral group acting on necklaces?",
-      "Interface with Burnside's lemma in Mathlib: MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group is cited but not directly applied. A future formalization could connect polya_necklace_formula_statement to this Mathlib theorem."
+      "Generalize from cyclic groups to arbitrary finite groups: the full Pólya enumeration theorem uses the cycle index of an arbitrary permutation group. Can the Lean formalization be extended to, e.g., the dihedral group acting on necklaces?"
     ]
   },
   "crossReferences": [
@@ -205,6 +203,12 @@
       "targetId": "binomial-theorem",
       "relationship": "related",
       "description": "Pólya enumeration generalizes binomial-style counting from unordered selections (color $k$ objects from $n$ with no symmetry) to selections under group action (color $k$ objects from $n$ modulo cyclic rotation). The identity $\\sum_{d \\mid n} \\varphi(n/d) k^d = n \\cdot N(n, k)$ specialises to $k^n$ when the symmetry group is trivial, recovering plain binomial counting; the divisor sum is the symmetry-aware refinement."
+    },
+    {
+      "id": "xref-oq02-arbitrary-group",
+      "targetId": "burnside-counting-oq-03-oq-02",
+      "relationship": "extended-by",
+      "description": "Answers the openQuestions entry above: generalizes the cyclic fixed-point formula to an arbitrary finite group action, recovering both the cyclic (k^gcd) and dihedral reflection counts as special cases."
     }
   ],
   "references": [


### PR DESCRIPTION
## Integrity Issue

**Proof**: burnside-counting-oq-03

**Problem**: `conclusion.openQuestions` contained two entries that were already resolved, one of which directly contradicts `conclusion.summary` in the *same* JSON object.

## Evidence

**meta.json claims** (before this PR):
- `openQuestions[0]`: "Complete polya_cyclic_fixed_count: ... remains as a sorry — the invFun half (backward map) is defined but left_inv requires showing..."
- `openQuestions[2]`: "Interface with Burnside's lemma in Mathlib: ... A future formalization could connect polya_necklace_formula_statement to this Mathlib theorem."

**Lean file shows** (`Proofs/BurnsideCountingOQ03.lean`):
- `polya_cyclic_fixed_count` (line 184) is fully proved — both `left_inv` and `right_inv` of the bijection are completely discharged, no `sorry` token anywhere in the file (confirmed by direct grep and read).
- This matches `conclusion.summary` in the very same meta.json: "...in full generality (the orbit-bijection argument is fully discharged, with no sorries)..." and `meta.assumptions`: "The core theorem polya_cyclic_fixed_count is independently proved via explicit bijection." Both were already correct; only `openQuestions` was stale.
- The Mathlib-interface question is already resolved by the companion file `Proofs/BurnsideCountingOQ03OQ03.lean`, which `leanFile.additionalFiles` in this same meta.json already describes in full: "OQ-03 (MulAction bridge): connects the cyclic rotation AddAction ... derives Burnside's orbit-counting identity for cyclic necklaces." That file is literally titled "Interfacing Burnside's Lemma with Mathlib MulAction Framework" and states "Answer: YES."

Separately, the remaining open question (generalizing to arbitrary finite groups) is already answered by the sibling gallery entry `burnside-counting-oq-03-oq-02` ("General Orbit-Counting for Colorings under an Arbitrary Finite Group"), which even self-declares itself as extending this parent entry in its own `crossReferences` — but the parent had no matching `extended-by` backlink, breaking this gallery's established parent/child open-question convention (see `burnside-counting-oq-03-oq-02`'s own `crossReferences` for the pattern).

## Fix Applied

- Removed the stale `sorry`-claim open question (resolved in-place, no sorries exist).
- Removed the stale Mathlib-interface open question (resolved by a companion file already documented in `leanFile.additionalFiles`).
- Reworded `conclusion.implications` from "which, once proved, will fully generalize..." (hedging on an already-proved result) to "fully generalizing..." (present tense, matches reality).
- Added the missing `extended-by` crossReference to `burnside-counting-oq-03-oq-02` for the one open question that remains genuinely open at this file's level.

No sorry/axiom/badge/status counts were touched — this is a pure prose-accuracy fix.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)