### PR TITLE
Update audit tracker: burnside-counting-oq-03 (issues-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3946,10 +3946,10 @@
       "result": "clean"
     },
     "burnside-counting-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:37Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T17:12:17Z",
+      "result": "issues-fixed"
     },
     "burnside-counting-oq-03-oq-02": {
       "auditCount": 1,


### PR DESCRIPTION
Marks the burnside-counting-oq-03 re-serve audit complete (result: issues-fixed). Fix in #43495.

🤖 Generated with [Claude Code](https://claude.com/claude-code)