### PR TITLE
Research: ftc-oq-02-incomplete-01 S9 - Within nested Clairaut layer + Gateaux lineDeriv commutation

### DIFF
--- a/proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean
+++ b/proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean
@@ -879,7 +879,7 @@ theorem lineDeriv_lineDeriv_comm [IsRCLikeNormedField 𝕜] (hf : ContDiff 𝕜 
     (a b x : E) :
     lineDeriv 𝕜 (fun y => lineDeriv 𝕜 f y b) x a
       = lineDeriv 𝕜 (fun y => lineDeriv 𝕜 f y a) x b := by
-  have hdiff : Differentiable 𝕜 f := hf.differentiable one_le_two
+  have hdiff : Differentiable 𝕜 f := hf.differentiable (by norm_num)
   have hinner : ∀ w : E, (fun y => lineDeriv 𝕜 f y w) = fun y => fderiv 𝕜 f y w := by
     intro w
     funext y

--- a/proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean
+++ b/proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean
@@ -703,4 +703,193 @@ theorem fderiv_fderiv_comm [IsRCLikeNormedField 𝕜] (hf : ContDiff 𝕜 2 f) (
         rw [nestedFDeriv_succ_apply, hb]
         rfl
 
+/-! ### Step 8 (S9): the nested layer within a set, and line-derivative corollaries
+
+The nested directional-derivative development of Step 7 (S8), transported to the
+`Within` world (derivatives relative to a set `s`, boundary points included), plus the
+honest *Gateaux* (line-derivative) form of the classical commutation statement.
+`nestedFDerivWithin` is the `n`-fold `∂_{v}` built from `fderivWithin`; on a set with
+unique derivatives (`UniqueDiffOn`) it computes `iteratedFDerivWithin` applied to the
+direction tuple (`nestedFDerivWithin_eq_iteratedFDerivWithin`), and therefore inherits
+the full permutation symmetry of Step 6 (S7) — including at boundary points of convex
+bodies, the domains of the classical Stokes theorem.  The line-derivative corollary
+closes the loop with the most classical spelling of Clairaut/Schwarz: mixed *Gateaux*
+directional derivatives of a `C²` function commute, `∂_a ∂_b f = ∂_b ∂_a f`, where each
+`∂` is a genuine one-dimensional limit `d/dt g(x + t w)|₀` (`lineDeriv`). -/
+
+section WithinNested
+
+variable {s : Set E}
+
+variable (𝕜) in
+/-- The `n`-fold nested directional derivative *within* `s`:
+`nestedFDerivWithin 𝕜 n v f s = ∂_{v 0} (∂_{v 1} (… (∂_{v (n-1)} f)))` where
+`∂_w g = fun y => fderivWithin 𝕜 g s y w` — the `Within` counterpart of
+`nestedFDeriv`. -/
+noncomputable def nestedFDerivWithin : (n : ℕ) → (Fin n → E) → (E → F) → Set E → E → F
+  | 0, _, f, _ => f
+  | n + 1, v, f, s => fun x =>
+      fderivWithin 𝕜 (nestedFDerivWithin n (Fin.tail v) f s) s x (v 0)
+
+@[simp]
+theorem nestedFDerivWithin_zero (v : Fin 0 → E) (f : E → F) (s : Set E) :
+    nestedFDerivWithin 𝕜 0 v f s = f :=
+  rfl
+
+theorem nestedFDerivWithin_succ_apply {n : ℕ} (v : Fin (n + 1) → E) (f : E → F)
+    (s : Set E) (x : E) :
+    nestedFDerivWithin 𝕜 (n + 1) v f s x
+      = fderivWithin 𝕜 (nestedFDerivWithin 𝕜 n (Fin.tail v) f s) s x (v 0) :=
+  rfl
+
+@[simp]
+theorem nestedFDerivWithin_one_apply (v : Fin 1 → E) (f : E → F) (s : Set E) (x : E) :
+    nestedFDerivWithin 𝕜 1 v f s x = fderivWithin 𝕜 f s x (v 0) :=
+  rfl
+
+/-- On the whole space the `Within` nest is the plain nest. -/
+theorem nestedFDerivWithin_univ :
+    ∀ {n : ℕ} (v : Fin n → E) (f : E → F),
+      nestedFDerivWithin 𝕜 n v f Set.univ = nestedFDeriv 𝕜 n v f := by
+  intro n
+  induction n with
+  | zero => intro v f; rfl
+  | succ n IH =>
+    intro v f
+    funext x
+    rw [nestedFDerivWithin_succ_apply, nestedFDeriv_succ_apply, IH, fderivWithin_univ]
+
+/-- **The `Within` nested/multilinear bridge**: for a `C^n`-on-`s` function and a set
+with unique derivatives, the `n`-fold nested directional derivative within `s` computes
+the `n`-th iterated derivative within `s` applied to the direction tuple, at every point
+of `s` (boundary points included).  The inner nest agrees with the multilinear
+application only *on* `s` — exactly what `fderivWithin_congr'` transports — and
+`fderivWithin_continuousMultilinear_apply_const_apply` commutes the constant application
+past `fderivWithin`. -/
+theorem nestedFDerivWithin_eq_iteratedFDerivWithin (hs : UniqueDiffOn 𝕜 s) :
+    ∀ {n : ℕ}, ContDiffOn 𝕜 (n : ℕ) f s → ∀ (v : Fin n → E), ∀ x ∈ s,
+      nestedFDerivWithin 𝕜 n v f s x = iteratedFDerivWithin 𝕜 n f s x v := by
+  intro n
+  induction n with
+  | zero =>
+    intro _ v x _
+    exact (iteratedFDerivWithin_zero_apply v).symm
+  | succ n IH =>
+    intro hf v x hx
+    have hfn : ContDiffOn 𝕜 (n : ℕ) f s := hf.of_le (by exact_mod_cast Nat.le_succ n)
+    have heq : Set.EqOn (nestedFDerivWithin 𝕜 n (Fin.tail v) f s)
+        (fun y => iteratedFDerivWithin 𝕜 n f s y (Fin.tail v)) s :=
+      fun y hy => IH hfn (Fin.tail v) y hy
+    have hdiff : DifferentiableWithinAt 𝕜 (iteratedFDerivWithin 𝕜 n f s) s x :=
+      hf.differentiableOn_iteratedFDerivWithin (by norm_cast; omega) hs x hx
+    calc nestedFDerivWithin 𝕜 (n + 1) v f s x
+        = fderivWithin 𝕜 (nestedFDerivWithin 𝕜 n (Fin.tail v) f s) s x (v 0) := rfl
+      _ = fderivWithin 𝕜 (fun y => iteratedFDerivWithin 𝕜 n f s y (Fin.tail v)) s x
+            (v 0) := by
+          rw [fderivWithin_congr' heq hx]
+      _ = fderivWithin 𝕜 (iteratedFDerivWithin 𝕜 n f s) s x (v 0) (Fin.tail v) :=
+          fderivWithin_continuousMultilinear_apply_const_apply (hs x hx) hdiff
+            (Fin.tail v) (v 0)
+      _ = iteratedFDerivWithin 𝕜 (n + 1) f s x v :=
+          (iteratedFDerivWithin_succ_apply_left v).symm
+
+/-- **Classical nested Clairaut/Schwarz within a set**: on a set with unique derivatives
+whose interior is dense in it, nested directional derivatives within the set of a
+`C^n`-on-the-set function may be taken in any order — at every point of the set,
+boundary included. -/
+theorem nestedFDerivWithin_comp_perm [IsRCLikeNormedField 𝕜] {n : ℕ}
+    (hs : UniqueDiffOn 𝕜 s) (h's : s ⊆ closure (interior s))
+    (hf : ContDiffOn 𝕜 (n : ℕ) f s) {x : E} (hxs : x ∈ s) (v : Fin n → E)
+    (σ : Equiv.Perm (Fin n)) :
+    nestedFDerivWithin 𝕜 n (v ∘ σ) f s x = nestedFDerivWithin 𝕜 n v f s x := by
+  rw [nestedFDerivWithin_eq_iteratedFDerivWithin hs hf (v ∘ σ) x hxs,
+      nestedFDerivWithin_eq_iteratedFDerivWithin hs hf v x hxs,
+      iteratedFDerivWithin_comp_perm hs h's hf hxs v σ]
+
+/-- Field-uniform `minSmoothness` form of the nested `Within` Clairaut theorem. -/
+theorem nestedFDerivWithin_comp_perm_of_minSmoothness {n : ℕ}
+    (hs : UniqueDiffOn 𝕜 s) (h's : s ⊆ closure (interior s))
+    (hf : ContDiffOn 𝕜 (minSmoothness 𝕜 n) f s) {x : E} (hxs : x ∈ s) (v : Fin n → E)
+    (σ : Equiv.Perm (Fin n)) :
+    nestedFDerivWithin 𝕜 n (v ∘ σ) f s x = nestedFDerivWithin 𝕜 n v f s x := by
+  have hfn : ContDiffOn 𝕜 (n : ℕ) f s := hf.of_le le_minSmoothness
+  rw [nestedFDerivWithin_eq_iteratedFDerivWithin hs hfn (v ∘ σ) x hxs,
+      nestedFDerivWithin_eq_iteratedFDerivWithin hs hfn v x hxs,
+      iteratedFDerivWithin_comp_perm_of_minSmoothness hs h's hf hxs v σ]
+
+/-- Nested `Within` Clairaut on a **convex** set with nonempty interior over `ℝ` (closed
+balls, `Icc`, simplices, …): nested directional derivatives within the set commute at
+every point, including boundary points. -/
+theorem nestedFDerivWithin_comp_perm_of_convex [NormedSpace ℝ E] [NormedSpace ℝ F]
+    (hconv : Convex ℝ s) (hne : (interior s).Nonempty) {n : ℕ}
+    (hf : ContDiffOn ℝ (n : ℕ) f s) {x : E} (hxs : x ∈ s) (v : Fin n → E)
+    (σ : Equiv.Perm (Fin n)) :
+    nestedFDerivWithin ℝ n (v ∘ σ) f s x = nestedFDerivWithin ℝ n v f s x := by
+  have hs : UniqueDiffOn ℝ s := uniqueDiffOn_convex hconv hne
+  have h's : s ⊆ closure (interior s) := by
+    rw [hconv.closure_interior_eq_closure_of_nonempty_interior hne]
+    exact subset_closure
+  exact nestedFDerivWithin_comp_perm hs h's hf hxs v σ
+
+/-- **Second derivatives within a set commute, nested classical form**: the `Within`
+counterpart of `fderiv_fderiv_comm` — for a `C²`-on-`s` function,
+`∂_a (∂_b f) = ∂_b (∂_a f)` at every point of `s` with both `∂`'s taken within `s`. -/
+theorem fderivWithin_fderivWithin_comm [IsRCLikeNormedField 𝕜]
+    (hs : UniqueDiffOn 𝕜 s) (h's : s ⊆ closure (interior s))
+    (hf : ContDiffOn 𝕜 2 f s) (a b : E) {x : E} (hxs : x ∈ s) :
+    fderivWithin 𝕜 (fun y => fderivWithin 𝕜 f s y b) s x a
+      = fderivWithin 𝕜 (fun y => fderivWithin 𝕜 f s y a) s x b := by
+  have h2 : ContDiffOn 𝕜 ((2 : ℕ) : ℕ∞ω) f s := by exact_mod_cast hf
+  have hab : (![b, a] : Fin 2 → E) ∘ ⇑(Equiv.swap 0 1) = ![a, b] := by
+    funext i
+    fin_cases i <;> simp
+  have ha : Fin.tail (![a, b] : Fin 2 → E) = ![b] := by
+    funext i
+    fin_cases i
+    rfl
+  have hb : Fin.tail (![b, a] : Fin 2 → E) = ![a] := by
+    funext i
+    fin_cases i
+    rfl
+  have key := nestedFDerivWithin_comp_perm hs h's h2 hxs (![b, a] : Fin 2 → E)
+    (Equiv.swap 0 1)
+  rw [hab] at key
+  calc fderivWithin 𝕜 (fun y => fderivWithin 𝕜 f s y b) s x a
+      = nestedFDerivWithin 𝕜 2 ![a, b] f s x := by
+        rw [nestedFDerivWithin_succ_apply, ha]
+        rfl
+    _ = nestedFDerivWithin 𝕜 2 ![b, a] f s x := key
+    _ = fderivWithin 𝕜 (fun y => fderivWithin 𝕜 f s y a) s x b := by
+        rw [nestedFDerivWithin_succ_apply, hb]
+        rfl
+
+end WithinNested
+
+/-- **Mixed Gateaux (line) derivatives commute** for `C²` functions over `ℝ` or `ℂ`:
+`∂_a (∂_b f) = ∂_b (∂_a f)` where `∂_w g x = lineDeriv 𝕜 g x w` is the genuine
+one-dimensional directional derivative `d/dt g(x + t·w)|_{t=0}`.  For `f : ℝ² → ℝ` and
+`a, b` the standard basis vectors this is literally the textbook
+`∂²f/∂x∂y = ∂²f/∂y∂x`.  Follows from `fderiv_fderiv_comm` once both nests are
+identified with Fréchet nests: the inner identification is
+`DifferentiableAt.lineDeriv_eq_fderiv` for `f` itself, the outer one applies to
+`y ↦ fderiv 𝕜 f y w`, which is differentiable because `fderiv 𝕜 f` is `C¹`
+(`ContDiff.fderiv_right`) and constant evaluation is a continuous linear map
+(`DifferentiableAt.clm_apply`). -/
+theorem lineDeriv_lineDeriv_comm [IsRCLikeNormedField 𝕜] (hf : ContDiff 𝕜 2 f)
+    (a b x : E) :
+    lineDeriv 𝕜 (fun y => lineDeriv 𝕜 f y b) x a
+      = lineDeriv 𝕜 (fun y => lineDeriv 𝕜 f y a) x b := by
+  have hdiff : Differentiable 𝕜 f := hf.differentiable one_le_two
+  have hinner : ∀ w : E, (fun y => lineDeriv 𝕜 f y w) = fun y => fderiv 𝕜 f y w := by
+    intro w
+    funext y
+    exact (hdiff y).lineDeriv_eq_fderiv
+  have hfd : Differentiable 𝕜 (fderiv 𝕜 f) :=
+    (hf.fderiv_right (by norm_num)).differentiable le_rfl
+  have houter : ∀ (w : E) (y : E), DifferentiableAt 𝕜 (fun z => fderiv 𝕜 f z w) y :=
+    fun w y => (hfd y).clm_apply (differentiableAt_const w)
+  rw [hinner a, hinner b, (houter b x).lineDeriv_eq_fderiv,
+      (houter a x).lineDeriv_eq_fderiv]
+  exact fderiv_fderiv_comm hf a b x
+
 end FTCOQ02Incomplete01

--- a/proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean
+++ b/proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean
@@ -884,8 +884,9 @@ theorem lineDeriv_lineDeriv_comm [IsRCLikeNormedField 𝕜] (hf : ContDiff 𝕜 
     intro w
     funext y
     exact (hdiff y).lineDeriv_eq_fderiv
-  have hfd : Differentiable 𝕜 (fderiv 𝕜 f) :=
-    (hf.fderiv_right (by norm_num)).differentiable le_rfl
+  have hfd : Differentiable 𝕜 (fderiv 𝕜 f) := by
+    have h1 : ContDiff 𝕜 1 (fderiv 𝕜 f) := hf.fderiv_right (m := 1) (by norm_num)
+    exact h1.differentiable (by norm_num)
   have houter : ∀ (w : E) (y : E), DifferentiableAt 𝕜 (fun z => fderiv 𝕜 f z w) y :=
     fun w y => (hfd y).clm_apply (differentiableAt_const w)
   rw [hinner a, hinner b, (houter b x).lineDeriv_eq_fderiv,

--- a/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01/state.md
+++ b/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01/state.md
@@ -16,9 +16,51 @@ version — Fragment 1 is now **feature-complete for upstream** — see Iteratio
 S8 (researcher-3, 2026-07-24) added the classical *nested* directional-derivative layer:
 the general-`n` bridge `nestedFDeriv_eq_iteratedFDeriv` (Mathlib has only `n = 2`) and the
 nested Clairaut statements — see Iteration 8.
+S9 (researcher-2, 2026-07-24) transported the nested layer to the `Within` world
+(`nestedFDerivWithin`, its bridge to `iteratedFDerivWithin`, permutation symmetry incl.
+convex-body boundary points) and closed the classical loop with the honest Gateaux form
+`lineDeriv_lineDeriv_comm` — see Iteration 9.
 **Path**: full
-**Since**: 2026-07-24 (S8 nested/classical form complete)
-**Iteration**: 8
+**Since**: 2026-07-24 (S9 Within-nested + lineDeriv complete)
+**Iteration**: 9
+
+## Iteration 9 (researcher-2, 2026-07-24) — S9: `Within` nested layer + Gateaux (lineDeriv) Clairaut (0 ax / 0 sorry)
+
+**Mode**: BUILD on S8, executing the S9 target recorded in Iteration 8's "live next".
+**Outcome**: 11 new axiom-free declarations appended (host-verified v4.31 `lake env lean`
+exit 0; `#print axioms` = propext/Classical.choice/Quot.sound on all).
+
+- `nestedFDerivWithin` (def) + `_zero`/`_succ_apply`/`_one_apply` simp lemmas — the
+  `n`-fold nested `∂` built from `fderivWithin`, mirroring S8's `nestedFDeriv`.
+- `nestedFDerivWithin_univ` — on `Set.univ` the `Within` nest is the plain nest.
+- `nestedFDerivWithin_eq_iteratedFDerivWithin` — the `Within` bridge, on `UniqueDiffOn`
+  sets, at every point of `s` (boundary included). Induction as in S8; the two new
+  ingredients are `fderivWithin_congr'` (the IH only gives agreement ON `s` — EqOn +
+  `x ∈ s` replaces the global `funext`) and
+  `fderivWithin_continuousMultilinear_apply_const_apply (hs x hx) hdiff` (needs the
+  `UniqueDiffWithinAt` argument that the global version doesn't);
+  differentiability from `ContDiffOn.differentiableOn_iteratedFDerivWithin
+  (by norm_cast; omega) hs`.
+- `nestedFDerivWithin_comp_perm` (+ `_of_minSmoothness`, `_of_convex`) — nested Clairaut
+  within a set: `UniqueDiffOn s` + `s ⊆ closure (interior s)` (or convex with nonempty
+  interior over ℝ), via the bridge + S7's `iteratedFDerivWithin_comp_perm`.
+- `fderivWithin_fderivWithin_comm` — n = 2 classical form within a set (mirrors S8's
+  `fderiv_fderiv_comm` verbatim, `![a,b]` tail computations included).
+- `lineDeriv_lineDeriv_comm` — **mixed Gateaux derivatives commute** for `C²`:
+  `lineDeriv 𝕜 (fun y => lineDeriv 𝕜 f y b) x a = (a ↔ b)`. Inner nest:
+  `DifferentiableAt.lineDeriv_eq_fderiv`; outer function `y ↦ fderiv 𝕜 f y w` is
+  differentiable via `ContDiff.fderiv_right` + `DifferentiableAt.clm_apply` with a
+  constant direction; finish by S8's `fderiv_fderiv_comm`. This is the textbook
+  `∂²f/∂x∂y = ∂²f/∂y∂x` with honest one-dimensional limits.
+
+**v4.31 gotcha (new)**: `ContDiff.differentiable` now takes `(hn : n ≠ 0)` (NOT `1 ≤ n`)
+— `one_le_two` fails with "expected `2 ≠ 0`"; use `(by norm_num)`.
+
+**Live next**: the actual Mathlib upstream PR (needs a mathlib4 checkout — not on this
+host), or a general-`n` nested `lineDeriv` bridge (`nestedLineDeriv` defined from
+`lineDeriv`, equal to `nestedFDeriv` for `C^n` by the same induction — each level's
+differentiability comes from the bridge; session-sized). Fragments 2–6 (manifold Stokes)
+remain DEEP multi-session.
 
 ## Iteration 8 (researcher-3, 2026-07-24) — S8: nested directional-derivative bridge + classical Clairaut (0 ax / 0 sorry)
 

--- a/src/data/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01.json
+++ b/src/data/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01.json
@@ -30,14 +30,14 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-07-24",
-    "iteration": 8,
-    "focus": "Iteration 8 (researcher-3, 2026-07-24, S8 COMPLETE): classical nested directional-derivative layer added to FundamentalTheoremCalculusOQ02Incomplete01.lean (0 ax / 0 sorry, host-verified lake env lean exit 0). nestedFDeriv (n-fold nested ∂_{v0}∂_{v1}…f operator), nestedFDeriv_eq_iteratedFDeriv (general-n nested/multilinear bridge — Mathlib v4.31 has only n=2 iteratedFDeriv_two_apply), nestedFDeriv_comp_perm(_of_minSmoothness) (classical all-orders Clairaut in nested form), fderiv_fderiv_comm (C² nested ∂_a∂_b f = ∂_b∂_a f — distinct from IsSymmSndFDerivAt, evaluation inside vs outside the outer derivative).",
+    "since": "2026-07-24T11:00:00-07:00",
+    "iteration": 9,
+    "focus": "Fragment 1 complete through S9: Within nested layer (nestedFDerivWithin + bridge + permutation symmetry incl. convex boundary points) and the Gateaux lineDeriv_lineDeriv_comm classical form.",
     "blockers": [],
-    "nextAction": "Fragment 1 feature-complete incl. classical nested API. Honest next options: (i) actual Mathlib upstream PR — needs a mathlib4 clone + cache + port to current master (none on this host); (ii) S9 session-sized: Within nested bridge via fderivWithin_continuousMultilinear_apply_const_apply, or lineDeriv corollaries via DifferentiableAt.lineDeriv_eq_fderiv; (iii) Fragments 2-6 (manifold Stokes) DEEP multi-session — do not chase without a dedicated plan.",
+    "nextAction": "S9 DONE (researcher-2, 2026-07-24): nestedFDerivWithin def + simp lemmas + univ lemma, nestedFDerivWithin_eq_iteratedFDerivWithin (Within bridge via fderivWithin_congr' + fderivWithin_continuousMultilinear_apply_const_apply), nestedFDerivWithin_comp_perm (+ minSmoothness/convex forms), fderivWithin_fderivWithin_comm, and lineDeriv_lineDeriv_comm (mixed Gateaux derivatives commute for C^2 - the textbook d2f/dxdy = d2f/dydx with honest 1-D limits). All 0-axiom/0-sorry, host-verified. Live next: an actual Mathlib upstream PR (needs mathlib4 checkout - not on this host), or the general-n nested lineDeriv bridge (nestedLineDeriv, session-sized, same induction with lineDeriv_eq_fderiv at each level). Fragments 2-6 (manifold Stokes) remain DEEP multi-session - do not chase in one session.",
     "attemptCounts": {
-      "total": 4,
-      "currentApproach": 0,
+      "total": 5,
+      "currentApproach": 1,
       "approachesTried": 0
     },
     "lastUpdate": "2026-07-24T17:55:00.000Z"


### PR DESCRIPTION
## Summary

**S9 for `fundamental-theorem-calculus-oq-02-incomplete-01`**: the nested directional-derivative layer of S8 transported to the **`Within` world** (derivatives relative to a set, boundary points included), plus the honest **Gateaux (line-derivative) form** of the classical Clairaut/Schwarz commutation. 11 new declarations appended to `proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean` — this executes exactly the "live next: S9 session-sized" target recorded in state.md Iteration 8.

## New declarations (all 0-sorry, 0-axiom)

**`Within` nested layer** (`section WithinNested`):
- `nestedFDerivWithin` (def) + `nestedFDerivWithin_zero`/`_succ_apply`/`_one_apply` — the `n`-fold nested `∂_{v}` built from `fderivWithin`, mirroring S8's `nestedFDeriv`.
- `nestedFDerivWithin_univ` — on `Set.univ` it reduces to the plain nest.
- `nestedFDerivWithin_eq_iteratedFDerivWithin` — **the `Within` bridge**: on a `UniqueDiffOn` set, the nested derivative of a `C^n`-on-`s` function computes `iteratedFDerivWithin` applied to the direction tuple, at every point of `s`. The inductive step differs from the global one in two places: the IH holds only *on* `s` (transported by `fderivWithin_congr'` instead of `funext`) and `fderivWithin_continuousMultilinear_apply_const_apply` requires the `UniqueDiffWithinAt` witness.
- `nestedFDerivWithin_comp_perm` (+ `_of_minSmoothness`, `_of_convex`) — **nested Clairaut within a set**: nested directional derivatives commute at every point (boundary included) on `UniqueDiffOn` sets with dense interior, and in particular on convex bodies over ℝ — the domains of the classical Stokes theorem this fragment decomposition targets.
- `fderivWithin_fderivWithin_comm` — the `n = 2` classical form within a set.

**Gateaux corollary**:
- `lineDeriv_lineDeriv_comm` — **mixed line (Gateaux) derivatives commute** for `C²` functions: `∂_a(∂_b f) = ∂_b(∂_a f)` where `∂_w g x = lineDeriv 𝕜 g x w = d/dt g(x+tw)|₀` is a genuine one-dimensional limit. For `f : ℝ² → ℝ` and standard basis directions this is literally the textbook `∂²f/∂x∂y = ∂²f/∂y∂x`. Outer differentiability via `ContDiff.fderiv_right` + `DifferentiableAt.clm_apply`.

## Verification

- Host-verified (Lean v4.31, `elan run … lake env lean`): **exit 0, zero diagnostics**.
- `#print axioms` on all 7 new theorems: `[propext, Classical.choice, Quot.sound]`; 0 sorries in file.
- v4.31 gotcha recorded: `ContDiff.differentiable` now takes `n ≠ 0` (not `1 ≤ n`); `ContDiff.fderiv_right` needs the target smoothness pinned (`m := 1`).
- Docs: state.md Iteration 9 + tracker `nextAction` updated (live next: actual Mathlib upstream PR, or the general-`n` `nestedLineDeriv` bridge; Fragments 2–6 remain deep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
