### PR TITLE
Enrich chebyshev-pnt-bridge-oq-03-oq-01: ratio-form annotation + 5th keyInsight

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-03-oq-01/annotations.json
@@ -116,5 +116,26 @@
       "chebyshevTheta_le_primeCounting_mul_log",
       "primeCounting_le_add_chebyshevTheta_div_log"
     ]
+  },
+  {
+    "id": "ann-ratio-form",
+    "proofId": "chebyshev-pnt-bridge-oq-03-oq-01",
+    "range": { "startLine": 155, "endLine": 189 },
+    "type": "insight",
+    "title": "Dividing by n: the exact shape a limit argument needs",
+    "content": "primeCounting_mul_log_div_sandwich just divides both inequalities of the packaged sandwich by n, but that division is what makes the statement limit-ready: θ(n)/n ≤ π(n)·log n/n ≤ θ(n)/n · (log n/log y) + y·log n/n. The proof multiplies the lower half π(n) ≤ y + θ(n)/log y through by the nonnegative factor log n/n (mul_le_mul_of_nonneg_right) and re-associates both sides with field_simp/ring; the upper half θ(n) ≤ π(n)·log n divides through directly via gcongr. No new mathematical content is added over the packaged sandwich — this is purely algebraic repackaging — but it is exactly the form needed to conclude π(n)·log n/n → 1 from θ(n)/n → 1 by squeezing, once y = y(n) is chosen so y/n → 0 and log n/log y → 1.",
+    "mathContext": "$\\dfrac{\\theta(n)}{n} \\le \\dfrac{\\pi(n)\\log n}{n} \\le \\dfrac{\\theta(n)}{n}\\cdot\\dfrac{\\log n}{\\log y} + \\dfrac{y\\log n}{n}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "squeeze theorem",
+      "mul_le_mul_of_nonneg_right",
+      "normalized ratio form",
+      "asymptotic squeeze setup"
+    ],
+    "prerequisites": [
+      "chebyshev_theta_primeCounting_sandwich",
+      "positivity of log n / n",
+      "field_simp/ring rearrangement"
+    ]
   }
 ]

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-03-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-03-oq-01/meta.json
@@ -69,7 +69,8 @@
       "The whole reduction is analysis-free: no Abel/partial summation, no integration — only that log is monotone on the positive reals and that a sub-sum of nonnegative terms is bounded by the full sum",
       "The index set of the θ-summation is literally the set counted by π: θ(n) = ∑_{p ∈ filter Prime (range (n+1))} log p and π(n) = |filter Prime (range (n+1))|, so the 'number of terms' in θ(n) is exactly π(n)",
       "The free parameter y trades the two error sources against each other: only the ≤ y small primes escape the log y ≥ tail bound, and only they are dropped from the π·log estimate; taking y ≈ n/(log n)² makes both y·log n and the π(y) loss o(n), collapsing the sandwich to the sharp equivalence",
-      "This modularizes PNT: it reduces the sharp asymptotic for π to the sharp asymptotic for θ (or ψ, which differs from θ by O(√x log²x)), which is the form the analytic (ζ) and elementary (Selberg) proofs actually deliver"
+      "This modularizes PNT: it reduces the sharp asymptotic for π to the sharp asymptotic for θ (or ψ, which differs from θ by O(√x log²x)), which is the form the analytic (ζ) and elementary (Selberg) proofs actually deliver",
+      "The final ratio-form step adds no new mathematics — it is pure algebra (dividing the sandwich by n, needing only log n/n ≥ 0 to preserve the inequality direction) — yet it is exactly this repackaging that turns a static two-sided bound into an active squeeze-theorem input; the limit argument's real content sits entirely in the normalization, not in any additional inequality"
     ],
     "prerequisites": [
       "the prime-counting function π and Chebyshev's function θ(x) = ∑_{p≤x} log p",


### PR DESCRIPTION
Enrichment pass for chebyshev-pnt-bridge-oq-03-oq-01 (quality 98 → 100 per tracker heuristic).

1. **Annotation-coverage gap**: `annotations.json` covered lines 1–155, but `meta.json`'s `sections` list a 7th section, "Limit-ready ratio form" (lines 155–189, `primeCounting_mul_log_div_sandwich`), with no annotation. Added `ann-ratio-form` explaining that this step is pure algebraic repackaging of the sandwich (dividing by `n`) that puts it in squeeze-theorem-ready form — marked `significance: "supporting"` since it genuinely adds no new inequality, only normalization (per the honesty standard against inflating routine steps).

2. Added a 5th `keyInsights` item (was at 4/5) making the same "no new math, but the normalization is the actual content of a limit argument" observation at the meta.json level, grounded in `ChebyshevPNTBridgeOQ03OQ01.lean:163-187`.

No other content changed. File sizes stay well under caps (meta 16.0 KB / annotations 8.3 KB vs 60 KB cap).