### PR TITLE
Enrich chebyshev-pnt-bridge-oq-05-oq-01: add 5th keyInsight

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge-oq-05-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-05-oq-01/meta.json
@@ -70,7 +70,8 @@
       "A single elementary estimate log x ≤ 2√x (from log t ≤ t − 1 applied to t = √x) absorbs BOTH error terms: the additive √N + 1 in the upper bound and the subtractive log(m+1) in the lower bound",
       "Choosing loose constants (c₁ = 2/5, c₂ = 2·log 4 + 4) trades the asymptotically sharp log 2 / 2 log 4 for bounds that hold uniformly with no o(1), making the result a clean drop-in for downstream proofs",
       "The lower bound needs a threshold (m ≥ 65) only because √(m+1) ≤ m/8 fails for small m; the upper bound needs none since √m ≤ m for all m ≥ 1",
-      "The consolidation required first repairing the broken prerequisite chain (Erdos31PrimesDensity, ChebyshevPNTBridgeOQ02) against Mathlib v4.26 — a reminder that 'verified' gallery files can silently rot under toolchain drift"
+      "The consolidation required first repairing the broken prerequisite chain (Erdos31PrimesDensity, ChebyshevPNTBridgeOQ02) against Mathlib v4.26 — a reminder that 'verified' gallery files can silently rot under toolchain drift",
+      "The upper bound's error term √m enters the exact statement as the integer Nat.sqrt m but the absorption argument (log m ≤ 2√m, √m ≤ m) is carried out entirely over Real.sqrt; Nat.sqrt_le' ((Nat.sqrt m)² ≤ m) combined with Real.sqrt_sq bridges the two by showing the integer square root never exceeds the real one — a small but necessary coercion whenever a Nat-valued combinatorial error term feeds into a Real-valued analytic estimate"
     ],
     "prerequisites": [
       "the prime-counting function π and its monotonicity",


### PR DESCRIPTION
Enrichment pass for chebyshev-pnt-bridge-oq-05-oq-01 (quality 98 → 100 per tracker heuristic).

The entry was already fully annotated (6 annotations covering all 6 sections, lines 1-229) with complete historicalContext/conclusion. The only gap was `overview.keyInsights` at 4/5 items.

Added a 5th keyInsight describing a real type-level detail visible in `ChebyshevPNTBridgeOQ05OQ01.lean:109-150` (`primeCounting_le_order`): the upper bound's error term is the integer `Nat.sqrt m` in the exact statement, but the absorption argument works entirely over `Real.sqrt`; `Nat.sqrt_le'` + `Real.sqrt_sq` bridge the two. This detail was previously only implicit in the `mathlibDependencies` list, not called out as an insight.

No other content changed. File stays well under caps (13.6 KB vs 60 KB cap).