### PR TITLE
audit: wilsons-theorem-oq-04-oq-02 verified clean (reserve re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -26658,9 +26658,9 @@
       "result": "clean"
     },
     "wilsons-theorem-oq-04-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:38Z",
+      "lastAudited": "2026-07-24T17:16:11Z",
       "result": "clean"
     },
     "wilsons-theorem-oq-04-oq-02-oq-01": {


### PR DESCRIPTION
## Audit Result: CLEAN

**Proof**: wilsons-theorem-oq-04-oq-02

Reserve-mode re-audit (queue drained, oldest re-served). Verified:
- 6 theorems, 0 axioms, 0 definitions, 0 sorries — exact grep match against meta.json/leanFile
- No native_decide usage, no True stubs
- Tier A classification correct (badge `original`, status `verified` — no axioms/sorries)
- All 3 crossReferences (wilsons-theorem-oq-04, wilsons-theorem-oq-02, wilsons-theorem) resolve to real entries; parent's open question #2 is correctly answered here with matching `extended-by` backlink
- Section line ranges match actual file structure

Minor non-reportable nit: conclusion.summary prose says "235 lines" vs actual/meta 234 — a 1-line drift in descriptive prose only, doesn't affect any trust-bearing claim (status/badge/axioms/sorries), not filed as an issue.

Tracker updated: auditCount 2→3, lastAudited refreshed, result clean.

---
Discovered during gallery integrity audit.