### PR TITLE
audit: re-serve binomial-theorem-oq-02-oq-01-oq-02 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2998,9 +2998,9 @@
       "result": "clean"
     },
     "binomial-theorem-oq-02-oq-01-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:37Z",
+      "lastAudited": "2026-07-24T17:19:50Z",
       "result": "clean"
     },
     "binomial-theorem-oq-02-oq-01-oq-02-oq-03": {


### PR DESCRIPTION
## Integrity Audit — Reserve Mode Re-serve

**Proof**: binomial-theorem-oq-02-oq-01-oq-02 ("Marginal Distributions of Multinomial Are Binomial")

Unaudited queue is drained; re-verifying oldest audited cohort per round-robin reserve policy.

## Verification

- `theoremCount: 9` — grep-confirmed all 9: `multinomial_mgf_real`, `multinomialProb_sum_one`, `multinomial_marginal_pgf`, `multinomial_marginal_pgf_eq_binomial`, `multinomial_marginal_sum_one`, `multinomial_marginal_pmf`, `bernoulli_marginal_pgf`, `binomial_2_pgf`, `bernoulli_false_marginal_pgf`
- `definitionCount: 1` — `multinomialProb`
- `axiomCount: 0`, `sorries: 0` — no `axiom`/`sorry` in file
- `lineCount: 337` — matches
- Prose check: `proofStrategy`, `keyInsights`, and all 6 `sections[].summary` entries accurately describe the actual proof, including the direct-bijection PMF formula (`multinomial_marginal_pmf`) that bypasses polynomial coefficient extraction — no phantom declarations named
- No `native_decide`, no True-stub theorems

No issues found. Updating `audit-tracker.json` only.

## Test plan

- [x] N/A — tracker-only metadata update, no source changes