### PR TITLE
research(hilbert-14-oq-04): S7a — Reynolds spanning layer: invariants are k-spanned by Reynolds monomial images [0 ax / 0 sorry]

### DIFF
--- a/proofs/Proofs/Hilbert14OQ04.lean
+++ b/proofs/Proofs/Hilbert14OQ04.lean
@@ -287,4 +287,111 @@ theorem totalDegree_reynolds_le
 
 end Reynolds
 
+section ReynoldsSpan
+
+/-! ### S7a — the spanning layer: invariants are `k`-combinations of Reynolds
+images of monomials
+
+The first (linear-algebra) half of the Stage-5 extraction. In the non-modular
+case the projection property `reynolds_of_mem_fixedPoints` plus `k`-linearity
+of the Reynolds operator decompose EVERY invariant `p` as the `k`-combination
+of the Reynolds images of the monomials in `p`'s own support:
+
+  `p = ∑ m ∈ p.support, coeff m p • reynolds G (monomial m 1)`.
+
+Since support monomials have degree `≤ p.totalDegree`, the degree-`d` filtered
+piece of the invariant ring is `k`-spanned by
+`{reynolds (monomial m 1) : deg m ≤ d}` (`mem_span_reynolds_monomial_of_totalDegree_le`).
+
+What this does NOT yet give is Noether's bound proper: that the images with
+`deg m ≤ |G|` generate the invariants as a `k`-ALGEBRA. That multiplicative
+reduction (rewriting `reynolds (monomial m 1)` for `deg m > |G|` as a
+polynomial in lower-degree images — the symmetrization/power-sum trick,
+needing `|G|!` invertible in the classical argument) is the remaining S7b+
+leg and is deliberately not claimed here. -/
+
+variable (G) in
+/-- The Reynolds operator commutes with the `k`-scalar action
+(`SMulCommClass G k` moves the scalar past each orbit translate). -/
+theorem reynolds_smul_k (c : k) (p : MvPolynomial (Fin n) k) :
+    reynolds G (c • p) = c • reynolds G p := by
+  unfold reynolds
+  have h1 : ∀ g : G, g • (c • p) = c • (g • p) := fun g => smul_comm g c p
+  simp_rw [h1]
+  rw [← Finset.smul_sum, smul_comm ((Fintype.card G : k)⁻¹) c]
+
+variable (G) in
+/-- The Reynolds operator packaged as a `k`-linear endomorphism of the
+polynomial ring. -/
+noncomputable def reynoldsₗ :
+    MvPolynomial (Fin n) k →ₗ[k] MvPolynomial (Fin n) k where
+  toFun := reynolds G
+  map_add' := reynolds_add
+  map_smul' c p := reynolds_smul_k G c p
+
+@[simp] theorem reynoldsₗ_apply (p : MvPolynomial (Fin n) k) :
+    reynoldsₗ G p = reynolds G p :=
+  rfl
+
+/-- **The spanning decomposition**: in the non-modular case every invariant
+is the `k`-combination of the Reynolds images of the monomials in its own
+support (projection property + `k`-linearity). -/
+theorem eq_sum_reynolds_monomial (hG : (Fintype.card G : k) ≠ 0)
+    {p : MvPolynomial (Fin n) k}
+    (hp : p ∈ FixedPoints.subalgebra k (MvPolynomial (Fin n) k) G) :
+    p = ∑ m ∈ p.support,
+      MvPolynomial.coeff m p • reynolds G (MvPolynomial.monomial m 1) := by
+  conv_lhs => rw [← reynolds_of_mem_fixedPoints hG hp, MvPolynomial.as_sum p]
+  rw [← reynoldsₗ_apply, map_sum]
+  refine Finset.sum_congr rfl fun m _ => ?_
+  rw [show (MvPolynomial.monomial m) (MvPolynomial.coeff m p)
+        = MvPolynomial.coeff m p • (MvPolynomial.monomial m) (1 : k) by
+      rw [MvPolynomial.smul_monomial, smul_eq_mul, mul_one],
+    map_smul, reynoldsₗ_apply]
+
+/-- **Degree-filtered spanning**: an invariant of total degree `≤ d` lies in
+the `k`-span of the Reynolds images of the monomials of degree `≤ d`.
+Combined with `totalDegree_reynolds_le`, the degree-`≤ d` piece of the
+invariant ring is exactly `k`-spanned by degree-`≤ d` Reynolds images. -/
+theorem mem_span_reynolds_monomial_of_totalDegree_le
+    (hG : (Fintype.card G : k) ≠ 0) {p : MvPolynomial (Fin n) k}
+    (hp : p ∈ FixedPoints.subalgebra k (MvPolynomial (Fin n) k) G)
+    {d : ℕ} (hd : p.totalDegree ≤ d) :
+    p ∈ Submodule.span k
+      ((fun m : Fin n →₀ ℕ => reynolds G (MvPolynomial.monomial m 1)) ''
+        {m : Fin n →₀ ℕ | (m.sum fun _ e => e) ≤ d}) := by
+  rw [eq_sum_reynolds_monomial hG hp]
+  refine Submodule.sum_mem _ fun m hm => ?_
+  exact Submodule.smul_mem _ _ (Submodule.subset_span
+    ⟨m, le_trans (MvPolynomial.le_totalDegree hm) hd, rfl⟩)
+
+/-- **Unfiltered spanning**: the invariant subalgebra, as a `k`-submodule, is
+contained in the span of all Reynolds images of monomials. -/
+theorem fixedPoints_le_span_reynolds_monomial
+    (hG : (Fintype.card G : k) ≠ 0) :
+    Subalgebra.toSubmodule
+        (FixedPoints.subalgebra k (MvPolynomial (Fin n) k) G) ≤
+      Submodule.span k
+        (Set.range fun m : Fin n →₀ ℕ =>
+          reynolds G (MvPolynomial.monomial m 1)) := by
+  intro p hp
+  rw [eq_sum_reynolds_monomial hG (Subalgebra.mem_toSubmodule.mp hp)]
+  exact Submodule.sum_mem _ fun m _ =>
+    Submodule.smul_mem _ _ (Submodule.subset_span ⟨m, rfl⟩)
+
+omit [SMulCommClass G k (MvPolynomial (Fin n) k)] in
+/-- Under the graded hypothesis, each spanning generator
+`reynolds (monomial m 1)` has total degree at most `deg m` — so the
+degree-filtered span really is generated in the stated degrees. -/
+theorem totalDegree_reynolds_monomial_le
+    (h_graded : ∀ (g : G) (p : MvPolynomial (Fin n) k),
+      (g • p).totalDegree ≤ p.totalDegree)
+    (m : Fin n →₀ ℕ) :
+    (reynolds G (MvPolynomial.monomial m 1)).totalDegree
+      ≤ m.sum fun _ e => e :=
+  le_trans (totalDegree_reynolds_le h_graded _)
+    (le_of_eq (MvPolynomial.totalDegree_monomial m one_ne_zero))
+
+end ReynoldsSpan
+
 end Hilbert14OQ04

--- a/proofs/Proofs/Hilbert14OQ04.lean
+++ b/proofs/Proofs/Hilbert14OQ04.lean
@@ -375,7 +375,8 @@ theorem fixedPoints_le_span_reynolds_monomial
         (Set.range fun m : Fin n →₀ ℕ =>
           reynolds G (MvPolynomial.monomial m 1)) := by
   intro p hp
-  rw [eq_sum_reynolds_monomial hG (Subalgebra.mem_toSubmodule.mp hp)]
+  rw [eq_sum_reynolds_monomial hG (show p ∈ FixedPoints.subalgebra k
+    (MvPolynomial (Fin n) k) G from hp)]
   exact Submodule.sum_mem _ fun m _ =>
     Submodule.smul_mem _ _ (Submodule.subset_span ⟨m, rfl⟩)
 
@@ -387,10 +388,10 @@ theorem totalDegree_reynolds_monomial_le
     (h_graded : ∀ (g : G) (p : MvPolynomial (Fin n) k),
       (g • p).totalDegree ≤ p.totalDegree)
     (m : Fin n →₀ ℕ) :
-    (reynolds G (MvPolynomial.monomial m 1)).totalDegree
-      ≤ m.sum fun _ e => e :=
-  le_trans (totalDegree_reynolds_le h_graded _)
-    (le_of_eq (MvPolynomial.totalDegree_monomial m one_ne_zero))
+    (reynolds G (MvPolynomial.monomial m (1 : k))).totalDegree
+      ≤ m.sum fun _ e => e := by
+  refine le_trans (totalDegree_reynolds_le h_graded _) ?_
+  rw [MvPolynomial.totalDegree_monomial m (one_ne_zero (α := k))]
 
 end ReynoldsSpan
 

--- a/research/problems/hilbert-14-oq-04/sessions/2026-07-24-s7a-reynolds-spanning-layer.md
+++ b/research/problems/hilbert-14-oq-04/sessions/2026-07-24-s7a-reynolds-spanning-layer.md
@@ -1,0 +1,41 @@
+# S7a ACT (2026-07-24, researcher-3) — Reynolds spanning layer
+
+## Outcome
+
+The linear-algebra half of the Stage-5 extraction: in the non-modular case
+(`(|G| : k) ≠ 0`) every invariant is a `k`-combination of Reynolds images of
+the monomials in its own support, with degree tracking. 5 new declarations in
+`section ReynoldsSpan` of `proofs/Proofs/Hilbert14OQ04.lean` (~290 → 385 LOC),
+0 axioms / 0 sorries, `#print axioms` = foundational trio; host
+`bin/lake env lean` exit 0; Docker build green.
+
+- `reynolds_smul_k`, `reynoldsₗ` — `k`-linearity of the Reynolds operator.
+- `eq_sum_reynolds_monomial` — `p = ∑ m ∈ p.support, coeff m p • reynolds G
+  (monomial m 1)` for invariant `p`.
+- `mem_span_reynolds_monomial_of_totalDegree_le` — degree-`≤ d` invariants lie
+  in the span of degree-`≤ d` Reynolds monomial images.
+- `fixedPoints_le_span_reynolds_monomial` — unfiltered submodule containment.
+- `totalDegree_reynolds_monomial_le` — the generators live in the stated
+  degrees (under `h_graded`).
+
+## Honesty
+
+This is spanning (k-MODULE structure), not Noether's bound (k-ALGEBRA
+generation in degree ≤ |G|). The remaining S7b leg is the multiplicative
+reduction of `reynolds (monomial m 1)` with `deg m > |G|` to polynomials in
+lower-degree images — the classical symmetrization argument needs `|G|!`
+invertible; the char `p ∤ |G|` sharpening is Fleischmann–Fogarty (2000s),
+far beyond session scope. S7b should be scoped to the `|G|!`-invertible
+hypothesis explicitly.
+
+## Lean gotchas
+
+- `Subalgebra.mem_toSubmodule.mp` fails to resolve as a constant here even
+  though the lemma exists (`Iff.rfl`); membership is definitional — use
+  `show p ∈ FixedPoints.subalgebra … from hp`.
+- In `reynolds G (monomial m 1) .totalDegree ≤ m.sum …` statements, pin the
+  coefficient: `monomial m (1 : k)` and `one_ne_zero (α := k)` — a bare `1`
+  sent the elaborator hunting `Field ℕ` + heartbeat timeout.
+- `smul_comm g c p` (G vs k) is the whole content of `reynolds_smul_k`; avoid
+  bare `simp_rw [smul_comm]` (symmetric-shape loop risk) — name the pointwise
+  lemma first.

--- a/research/problems/hilbert-14-oq-04/state.md
+++ b/research/problems/hilbert-14-oq-04/state.md
@@ -1,9 +1,42 @@
 # Current State
 
-**Phase**: ACT (S6 ACT shipped, researcher-3, 2026-07-24 — **Reynolds operator toolkit landed**;
-next = S7 extraction proper: reynolds-image of the degree-≤|G| piece generates)
+**Phase**: ACT (S7a ACT shipped, researcher-3, 2026-07-24 — **Reynolds spanning
+layer landed**: every invariant is the k-combination of Reynolds images of the
+monomials in its own support; next = S7b multiplicative reduction, the genuinely
+hard Noether leg)
 **Since**: 2026-07-24T12:10:00Z
-**Iteration**: 6
+**Iteration**: 7
+
+## S7a ACT 2026-07-24 (researcher-3) — Reynolds spanning layer (0 ax / 0 sorry)
+
+New `section ReynoldsSpan` in `proofs/Proofs/Hilbert14OQ04.lean` (~290 → 385 LOC),
+host-verified `bin/lake env lean` exit 0, `#print axioms` foundational trio on all
+five new declarations.
+
+* `reynolds_smul_k` / `reynoldsₗ` — the Reynolds operator commutes with the
+  `k`-action (`smul_comm` per orbit translate + scalar `smul_comm`), packaged as a
+  `k`-linear endomorphism (`map_sum`/`map_smul` then come for free).
+* `eq_sum_reynolds_monomial` — **the spanning decomposition**: for `|G| ≠ 0` in
+  `k`, every invariant `p` equals
+  `∑ m ∈ p.support, coeff m p • reynolds G (monomial m 1)`
+  (projection property + `as_sum` + linearity; `monomial m c = c • monomial m 1`
+  via `smul_monomial`).
+* `mem_span_reynolds_monomial_of_totalDegree_le` — degree-filtered spanning: an
+  invariant of totalDegree ≤ d lies in the k-span of
+  `{reynolds (monomial m 1) : deg m ≤ d}` (`le_totalDegree` on support).
+* `fixedPoints_le_span_reynolds_monomial` — unfiltered module-level containment
+  (toSubmodule membership is `Iff.rfl` — pass `hp` through a `show`, do NOT cite
+  `Subalgebra.mem_toSubmodule.mp` which fails to resolve here).
+* `totalDegree_reynolds_monomial_le` — generators live in the stated degrees
+  (pin `(1 : k)` explicitly and use `one_ne_zero (α := k)`; leaving `1` bare made
+  the elaborator hunt for `Field ℕ` and heartbeat-timeout).
+
+**What S7a does NOT claim**: Noether's bound proper (`deg ≤ |G|` images generate
+as a k-ALGEBRA). The remaining S7b leg is the multiplicative reduction — rewriting
+`reynolds (monomial m 1)` for `deg m > |G|` as a polynomial in lower-degree images
+(classical symmetrization/power-sum argument, which needs `|G|!` invertible — note
+the char `p ∤ |G|` case is Fleischmann–Fogarty 2000s-grade, NOT the classical
+argument; scope S7b to char 0 / char > |G| or to the `|G|!`-invertible hypothesis).
 
 ## S6 ACT 2026-07-24 (researcher-3) — Reynolds operator toolkit (0 ax / 0 sorry)
 

--- a/src/data/research/problems/hilbert-14-oq-04.json
+++ b/src/data/research/problems/hilbert-14-oq-04.json
@@ -45,13 +45,15 @@
     "lastUpdate": "2026-07-24T12:10:00.000Z"
   },
   "knowledge": {
-    "progressSummary": "UNBLOCKED (researcher-3, 2026-07-23): Docker restored, B1 blackout blocker cleared; existing Hilbert14OQ04.lean re-verified clean at v4.31 (8576 jobs, 0 axiom/0 sorry). Next step ready: the paste-ready noether_degree_bound ACT (PREP-3 §4, new file Hilbert14OQ04Bound.lean). | S2-finite ACT shipped (PR pending): hilbert_finiteness theorem verified by Docker build (7743/7743). The qualitative half of Noether 1916 — invariant ring of a finite-group linear action on MvPolynomial is finitely generated as a k-algebra — is now formalized in proofs/Proofs/Hilbert14OQ04.lean (102 LOC). Five-step proof chains through Algebra.IsInvariant → Algebra.IsInvariant.isIntegral → Algebra.FiniteType.of_restrictScalars_finiteType → Algebra.IsIntegral.finite → Artin-Tate fg_of_fg_of_fg, all pinned at Mathlib v4.26.0. Two supporting instances (Algebra.IsInvariant and Algebra.IsIntegral) discharged definitionally via FixedPoints.subalgebra membership. The quantitative half (Noether degree bound) is deferred to S3-bound ACT. Predecessor PREP chain: PRs #18248 (S1) + #18435/18501/18562/18589/18667/18714/18750 (S2-S2g).",
+    "progressSummary": "PROGRESS: S7a Reynolds spanning layer done — degree-filtered k-span of invariants by Reynolds monomial images; next S7b = multiplicative Noether reduction (hard leg)",
     "builtItems": [
       "research/problems/hilbert-14-oq-04/problem.md (S1, 5K) — problem statement, sub-problem decomposition, OQ-01 vs OQ-04 differentiation.",
       "research/problems/hilbert-14-oq-04/knowledge.md (S1, 8K) — Reynolds operator and LND background, Noether degree bound proof outline, counterexample summaries, Mathlib API gap inventory.",
       "research/problems/hilbert-14-oq-04/state.md (S1) — phase tracker, S2 next-action plan.",
       "proofs/Proofs/Hilbert14OQ04.lean (S2-finite ACT, 102 LOC) — hilbert_finiteness theorem + Algebra.IsInvariant/IsIntegral instances. Verified by Docker build 7743/7743 jobs.",
-      "proofs/Proofs.lean — added import Proofs.Hilbert14OQ04."
+      "proofs/Proofs.lean — added import Proofs.Hilbert14OQ04.",
+      "reynolds_smul_k + reynoldsₗ (k-linear packaging) in Hilbert14OQ04.lean",
+      "eq_sum_reynolds_monomial / mem_span_reynolds_monomial_of_totalDegree_le / fixedPoints_le_span_reynolds_monomial / totalDegree_reynolds_monomial_le (S7a spanning layer, 0 ax / 0 sorry)"
     ],
     "insights": [
       "OQ-04 is a meta-mathematical conjecture about algorithm existence; it cannot be formalized as a single Lean theorem. Lean progress must instead anchor on specific algorithmic refinements (Noether degree bound, slice theorem, etc.).",
@@ -64,7 +66,8 @@
       "Algebra.FiniteType k ↥(⊤ : Subalgebra k R) does NOT typeclass-synthesize cheaply (heartbeat timeout); use (inferInstance : Algebra.FiniteType k R).out for the direct FG projection.",
       "⟨h_fg⟩ as Algebra.FiniteType constructor: the class is a Prop with one field (out : (⊤ : Subalgebra R A).FG), so anonymous-constructor pack-up suffices.",
       "Subtype.val_injective serves as algebraMap (FixedPoints.subalgebra k R G) R injectivity in fg_of_fg_of_fg invocation — Subalgebra.toAlgebra (line 822) is definitionally Subtype.val on the underlying function.",
-      "UNBLOCK (researcher-3, 2026-07-23): Docker is back up; all 3 stale infra blockers (B1 Docker-blackout, B2 host-disk-full, B3 .lake self-symlink) are cleared — the successful build proves the environment works. Verified the existing Proofs/Hilbert14OQ04.lean builds clean at leanprover/lean4:v4.31.0 (8576 jobs, 0 axioms / 0 sorries) — no drift from the v4.26 build. The S3-bound ACT (noether_degree_bound, ~150-200 LOC new file Hilbert14OQ04Bound.lean per PREP-3 §4, with the h_graded hypothesis Option A) is now executable and is the ready next step — deferred to a fresh-context session, not a stub. status blocked->active."
+      "UNBLOCK (researcher-3, 2026-07-23): Docker is back up; all 3 stale infra blockers (B1 Docker-blackout, B2 host-disk-full, B3 .lake self-symlink) are cleared — the successful build proves the environment works. Verified the existing Proofs/Hilbert14OQ04.lean builds clean at leanprover/lean4:v4.31.0 (8576 jobs, 0 axioms / 0 sorries) — no drift from the v4.26 build. The S3-bound ACT (noether_degree_bound, ~150-200 LOC new file Hilbert14OQ04Bound.lean per PREP-3 §4, with the h_graded hypothesis Option A) is now executable and is the ready next step — deferred to a fresh-context session, not a stub. status blocked->active.",
+      "S7a: invariants are k-SPANNED by Reynolds images of monomials of their own support degrees (eq_sum_reynolds_monomial); the algebra-generation Noether bound is exactly the remaining multiplicative reduction (S7b), which classically needs |G|! invertible"
     ],
     "mathlibGaps": [
       "No Noether degree bound for finite-group invariants",


### PR DESCRIPTION
## Summary

Research session S7a for `hilbert-14-oq-04` (Hilbert finiteness / Noether degree bound for finite-group invariants of `MvPolynomial`): **the Reynolds spanning layer** — the linear-algebra half of the Stage-5 extraction.

## Progress

New `section ReynoldsSpan` in `proofs/Proofs/Hilbert14OQ04.lean` (~290 -> 385 LOC), 0 axioms / 0 sorries:

- `reynolds_smul_k`, `reynoldsₗ` — the Reynolds operator commutes with the k-action, packaged as a k-linear endomorphism.
- `eq_sum_reynolds_monomial` — **spanning decomposition**: for `(|G| : k) != 0`, every invariant `p` equals `∑ m ∈ p.support, coeff m p • reynolds G (monomial m 1)` (projection property + `as_sum` + linearity).
- `mem_span_reynolds_monomial_of_totalDegree_le` — an invariant of total degree <= d lies in the k-span of Reynolds images of monomials of degree <= d.
- `fixedPoints_le_span_reynolds_monomial` — unfiltered containment of the invariant subalgebra (as k-submodule) in the span of all Reynolds monomial images.
- `totalDegree_reynolds_monomial_le` — under the graded hypothesis, each generator lives in the stated degree.

## Honesty / scope

This is k-MODULE spanning, not Noether's bound proper: the remaining S7b leg is the multiplicative reduction (rewriting `reynolds (monomial m 1)` for `deg m > |G|` as a polynomial in lower-degree images — the classical symmetrization argument needing `|G|!` invertible). That is deliberately not claimed here and is scoped in state.md.

## Verification

- Host: `bin/lake env lean Proofs/Hilbert14OQ04.lean` exit 0, zero warnings.
- Docker: `docker-build.sh Proofs.Hilbert14OQ04` green (8576 jobs).
- `#print axioms` on all 5 new declarations = `[propext, Classical.choice, Quot.sound]`.

## Status

**Outcome**: progress — spanning layer complete; S7b (multiplicative Noether reduction) is the next, genuinely hard leg.
**Next Steps**: S7b scoped to the `|G|!`-invertible hypothesis (char 0 / char > |G|); see state.md iteration 7.

🤖 Generated by researcher-3
