### PR TITLE
Enrich chebyshev-polynomials-oq-01: add 5th keyInsight

### DIFF
--- a/src/data/proofs/chebyshev-polynomials-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-polynomials-oq-01/meta.json
@@ -130,7 +130,8 @@
       "**Commutativity under composition is the structural payoff.** The composition law plus m·n = n·m gives T_m ∘ T_n = T_n ∘ T_m for free, yet this is exactly what makes the Chebyshev polynomials a commuting family — the property that places them, alongside the monomials xⁿ, at the centre of Ritt's classification of commuting polynomials. Mathlib has the composition law but not this consequence.",
       "**n ↦ Tₙ is a monoid morphism.** With T₁ = X the identity for composition and T_{m·n} = T_m ∘ T_n the multiplicativity, the Chebyshev indexing turns multiplication of integers into composition of polynomials. The unit, associativity, and commutativity laws collected here are precisely the morphism axioms made explicit.",
       "**The law is a polynomial identity, valid over any commutative ring.** Although the trigonometric definition lives over ℝ, the composition law T_{m·n} = T_m ∘ T_n holds over an arbitrary commutative ring R and for all integer indices, positive or negative.",
-      "**The trigonometric origin.** Over ℝ, Tₙ(cos θ) = cos(n θ), so T_m(T_n(cos θ)) = T_m(cos(n θ)) = cos(m·n·θ): the composition law is the polynomial shadow of the obvious angle identity cos(m·(n θ)) = cos((m n) θ)."
+      "**The trigonometric origin.** Over ℝ, Tₙ(cos θ) = cos(n θ), so T_m(T_n(cos θ)) = T_m(cos(n θ)) = cos(m·n·θ): the composition law is the polynomial shadow of the obvious angle identity cos(m·(n θ)) = cos((m n) θ).",
+      "**The monoid morphism n ↦ Tₙ is not injective.** Mathlib's T_neg gives T_{-n} = T_n, so the composition law and its consequences here (commutativity, associativity) genuinely only see the multiplicative monoid (ℤ, ·) through its quotient by n ↦ |n| — reflecting that cos((-n)θ) = cos(nθ). Working with all of ℤ rather than just ℕ costs nothing extra in this file, but the morphism T lands on the same polynomial for n and −n."
     ],
     "prerequisites": [
       "Chebyshev polynomials of the first kind",


### PR DESCRIPTION
Enrichment pass for chebyshev-polynomials-oq-01 (quality 98 → 100 per tracker heuristic).

The entry was already fully annotated (6 annotations covering all 6 sections, lines 1-119) with complete historicalContext/conclusion. The only gap was `overview.keyInsights` at 4/5 items.

Added a 5th keyInsight noting that the monoid-morphism framing (existing keyInsight 2) is not injective: Mathlib's `Polynomial.Chebyshev.T_neg : T R (-n) = T R n` (confirmed in `Mathlib/RingTheory/Polynomial/Chebyshev.lean`) means the composition/commutativity/associativity results proved here for all `n : ℤ` genuinely only see the multiplicative monoid through its quotient by `n ↦ |n|` — reflecting `cos((-n)θ) = cos(nθ)`. This is a real, previously-uncaptured structural point about the file's ℤ-indexing choice.

No other content changed. File stays well under caps (16.6 KB vs 60 KB cap).