### PR TITLE
Update audit tracker: sylow-theorem-oq-04 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25865,9 +25865,9 @@
       "result": "clean"
     },
     "sylow-theorem-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:38Z",
+      "lastAudited": "2026-07-24T17:24:37Z",
       "result": "clean"
     },
     "sylow-theorem-oq-05": {


### PR DESCRIPTION
## Summary
- Re-serve audit of `sylow-theorem-oq-04` (queue drained, round-robin re-audit).
- Verified: 0 sorries, 0 literal axioms (33 `native_decide` uses correctly disclosed via `axiomCount:1`/status `axiomatized`/badge `axiom`), `originalContributions` correctly excludes the Mathlib-delegated `A5_isSimple`, all cited Mathlib lemma names and cross-references are real/valid.
- Result: clean, no issues found.

## Test plan
- [x] Tracker JSON diff limited to the `sylow-theorem-oq-04` entry (auditCount/lastAudited bump only).