### PR TITLE
Enrich chebyshev-sum-inequality-oq-01: split sequences section

### DIFF
--- a/src/data/proofs/chebyshev-sum-inequality-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01/meta.json
@@ -101,11 +101,18 @@
       "summary": "Imports, an expository docstring contrasting Mathlib's MonovaryOn formulation with the classical monotone-sequence statement, and namespace setup."
     },
     {
-      "id": "sequences",
-      "title": "Real Sequences over range n",
+      "id": "sequences-core",
+      "title": "Forward and Reverse Inequalities",
       "startLine": 35,
+      "endLine": 54,
+      "summary": "chebyshev_monotone and chebyshev_antitone — the core similarly-sorted bound (∑f)(∑g) ≤ n·∑fg and its oppositely-sorted reverse, for monotone/antitone real sequences indexed by range n."
+    },
+    {
+      "id": "sequences-corollaries",
+      "title": "Corollaries: Square Bound and Averaged Form",
+      "startLine": 56,
       "endLine": 72,
-      "summary": "chebyshev_monotone, chebyshev_antitone, sq_sum_le, and the averaged chebyshev_mean — the textbook forms for monotone/antitone real sequences indexed by range n."
+      "summary": "sq_sum_le (the self-monovarying Cauchy–Schwarz-type square bound, needing no monotonicity hypothesis) and chebyshev_mean (the averaged 'mean of products ≥ product of means' restatement, derived from chebyshev_monotone by dividing through by n²)."
     },
     {
       "id": "general",


### PR DESCRIPTION
Enrichment pass for chebyshev-sum-inequality-oq-01 (quality 98 → 100 per tracker heuristic).

The entry was already fully annotated (7 annotations, mathContext/significance/relatedConcepts throughout) with 5 keyInsights and a complete conclusion. The remaining gap was `sections` at 4 items (needs 5 for max credit).

Split the "Real Sequences over range n" section (lines 35-72, bundling 4 distinct theorems) at the natural docstring/theorem-group boundary in `ChebyshevSumMonotoneOQ01.lean:35-72`:
- **Forward and Reverse Inequalities** (35-54): `chebyshev_monotone` + `chebyshev_antitone`, the core similarly-sorted bound and its reverse
- **Corollaries: Square Bound and Averaged Form** (56-72): `sq_sum_le` + `chebyshev_mean`, the two derived restatements

This mirrors an existing grouping already implicit in the file's structure (the core pair vs. the corollaries), not an arbitrary split.

No other content changed. File stays well under caps (12.0 KB vs 60 KB cap).

---
Note: this branch (`feature/enricher-1-12-recovered`) is a fresh worktree recreated after the original `enricher-1-12` worktree was reaped mid-session by fleet cleanup infra. No other work was lost — this was the only uncommitted change at the time.