### PR TITLE
Fix sylow-theorem-oq-01: section boundary cuts theorem mid-declaration

### DIFF
--- a/src/data/proofs/sylow-theorem-oq-01/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-01/meta.json
@@ -76,15 +76,15 @@
       "id": "sylow-p-analysis",
       "title": "Part III: Sylow p-Subgroup Analysis",
       "startLine": 161,
-      "endLine": 196,
-      "summary": "sylow_p_count: n_p ∈ {1, q} (since n_p | q prime). unique_sylow_p_when_coprime: if p ∤ (q-1) then n_p ≠ q (else q ≡ 1 mod p implies p | q-1), so n_p = 1. both_normal_when_coprime: when p ∤ (q-1), both Sylow subgroups are normal."
+      "endLine": 187,
+      "summary": "sylow_p_count: n_p ∈ {1, q} (since n_p | q prime). unique_sylow_p_when_coprime: if p ∤ (q-1) then n_p ≠ q (else q ≡ 1 mod p implies p | q-1), so n_p = 1."
     },
     {
       "id": "cyclic-proof",
       "title": "Part IV: Cyclicity from Two Normal Sylow Subgroups",
-      "startLine": 197,
+      "startLine": 188,
       "endLine": 304,
-      "summary": "The 80-line original proof of cyclic_of_both_sylow_normal and cyclic_when_coprime. Four steps: (1) P ∩ Q = {1} via coprime order divisibility; (2) commutator argument shows generators g ∈ P, k ∈ Q commute; (3) orders p, q are coprime so ord(gk) = pq = |G|; (4) zpowers(gk) = ⊤ so G is cyclic."
+      "summary": "both_normal_when_coprime: when p ∤ (q-1), both Sylow subgroups are normal. The 80-line original proof of cyclic_of_both_sylow_normal and cyclic_when_coprime. Four steps: (1) P ∩ Q = {1} via coprime order divisibility; (2) commutator argument shows generators g ∈ P, k ∈ Q commute; (3) orders p, q are coprime so ord(gk) = pq = |G|; (4) zpowers(gk) = ⊤ so G is cyclic."
     },
     {
       "id": "nonabelian-classification",
@@ -97,7 +97,7 @@
       "id": "concrete-examples",
       "title": "Part VII: Concrete Examples",
       "startLine": 361,
-      "endLine": 387,
+      "endLine": 383,
       "summary": "Four norm_num/omega examples: order 15 (3 ∤ 4 → only ℤ/15), order 6 (2 | 2 → also S₃), order 35 (5 ∤ 6 → only ℤ/35), order 21 (3 | 6 → also non-abelian). #check statements for IsPQGroup, pqClassification, pq_cyclic_classification."
     }
   ],


### PR DESCRIPTION
## Integrity Fix

**Proof**: sylow-theorem-oq-01

**Problem**: `sections[]` boundary between `sylow-p-analysis` (Part III) and
`cyclic-proof` (Part IV) split `theorem both_normal_when_coprime`'s
docstring+signature mid-declaration: `sylow-p-analysis.endLine` (196) covered
only the docstring and the opening signature line, while the rest of the
signature/body fell into `cyclic-proof` (startLine 197) — whose own summary
never mentions `both_normal_when_coprime`. Same bug class as #42748 in a
sibling Sylow file.

Also `concrete-examples.endLine` was 387, past the file's actual 383 lines.

## Fix

- Moved the III/IV boundary to line 187/188, matching the file's own
  `## Part III` / `## Part IV` comment split (so the theorem's docstring +
  full declaration now falls entirely in `cyclic-proof`).
- Moved the `both_normal_when_coprime` summary sentence from
  `sylow-p-analysis` to `cyclic-proof` to match.
- Corrected `concrete-examples.endLine` 387 → 383 (EOF).

Sorry/axiom/theorem/def counts (0/0/21/3) and all other public claims were
verified against `proofs/Proofs/SylowTheoremOQ01.lean` and are accurate —
this PR only fixes section line-range/summary drift.

---
Discovered during gallery integrity audit.