### PR TITLE
Fix: stale lemma-name citation in prob-method-expectation-oq-01

### DIFF
--- a/src/data/proofs/prob-method-expectation-oq-01/annotations.json
+++ b/src/data/proofs/prob-method-expectation-oq-01/annotations.json
@@ -56,7 +56,7 @@
     },
     "type": "concept",
     "title": "First Moment Method: Contradiction via integral_mono_ae",
-    "content": "`first_moment_method` proves that if X : Ω → ℕ is measurable and integrable with E[X] < 1, then P({X = 0}) > 0. The proof: `by_contra h; push_neg at h` gives `μ {X=0} = 0`. Then `ae_iff` converts this to `X ω ≥ 1` a.e. (using that X is ℕ-valued, so X < 1 ↔ X = 0). Then `integral_mono_ae (integrable_const 1) hX_integ hae` gives E[X] ≥ 1, and `integral_const, measure_univ, ENNReal.one_toReal` gives ∫ 1 = 1. `linarith` closes with E[X] ≥ 1 contradicting the hypothesis.",
+    "content": "`first_moment_method` proves that if X : Ω → ℕ is measurable and integrable with E[X] < 1, then P({X = 0}) > 0. The proof: `by_contra h; push_neg at h` gives `μ {X=0} = 0`. Then `ae_iff` converts this to `X ω ≥ 1` a.e. (using that X is ℕ-valued, so X < 1 ↔ X = 0). Then `integral_mono_ae (integrable_const 1) hX_integ hae` gives E[X] ≥ 1, and `integral_const, probReal_univ, one_smul` gives ∫ 1 = 1. `linarith` closes with E[X] ≥ 1 contradicting the hypothesis.",
     "mathContext": "The *first moment method* (or Markov's inequality argument): for a non-negative integer-valued random variable $X$, $\\mathbb{E}[X] = \\mathbb{E}[X \\cdot 1_{X \\geq 1}] \\geq \\mathbb{P}(X \\geq 1)$. If $\\mathbb{E}[X] < 1$, then $\\mathbb{P}(X \\geq 1) < 1$, so $\\mathbb{P}(X = 0) > 0$. This is used in the probabilistic method: if the expected number of 'bad' events is less than 1, then with positive probability there are no bad events, so a 'good' configuration exists.",
     "significance": "key",
     "relatedConcepts": [


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: prob-method-expectation-oq-01

**Problem**: The `ann-pmeoq01-first-moment` annotation's `content` field cited
`integral_const, measure_univ, ENNReal.one_toReal` as the lemmas that close
out the first-moment-method proof. Neither `measure_univ` nor
`ENNReal.one_toReal` appears anywhere in `proofs/Proofs/ProbMethodExpectationOQ01.lean`.

## Evidence

- annotations.json claimed: `integral_const, measure_univ, ENNReal.one_toReal`
- Line 90 of the Lean file actually reads:
  `rwa [integral_const, probReal_univ, one_smul] at hle`

Everything else checked out clean during this audit cycle: 0 sorries, 0
axioms, 5 theorems / 2 defs (matching meta.json and leanFile), badge
`mathlib` correctly disclosed (file explicitly bridges to Mathlib's
MeasureTheory), status `verified` accurate.

## Fix

Corrected the annotation content to cite `probReal_univ, one_smul`, matching
the source.

---
Discovered during gallery integrity audit (reserve-mode re-audit, queue fully drained).