### PR TITLE
Enrich chebyshev-polynomials-oq-01-oq-01(-oq-01): add 5th keyInsight

### DIFF
--- a/src/data/proofs/chebyshev-polynomials-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-polynomials-oq-01-oq-01-oq-01/meta.json
@@ -29,7 +29,8 @@
       "The three scalar identities T_add, U_add and the Pell identity are not independent facts but the four entries and the determinant of a single matrix equation M(m+n) = M(m)·M(n) with det M = 1 — i.e. the statement that M : (ℤ,+) → SL₂(R[X]) is a monoid homomorphism into the special linear group",
       "The Pell identity T_sq_add is precisely det M(n) = 1, so it is no longer a separate lemma to prove: it is automatic from multiplicativity, det M(n) = (det M(1))ⁿ = 1",
       "M(1) = !![X, −(1−X²); 1, X] is a single fixed matrix whose powers generate the entire Chebyshev family: (M(1)ⁿ) 0 0 = Tₙ and (M(1)ⁿ) 1 0 = U_{n−1}, exactly as the powers of the Fibonacci Q-matrix !![1,1;1,0] generate Fₙ",
-      "Working over an arbitrary commutative ring R and integer indices n : ℤ keeps the statement at the level of the polynomial ring R[X], with the geometric meaning (rotation by nθ at x = cos θ) recovered by specialization"
+      "Working over an arbitrary commutative ring R and integer indices n : ℤ keeps the statement at the level of the polynomial ring R[X], with the geometric meaning (rotation by nθ at x = cos θ) recovered by specialization",
+      "chebMat_pow only exercises the ℕ-power law M(↑n) = M(1)ⁿ, yet det M(n) = 1 already makes every M(n) invertible in Matrix (Fin 2) (Fin 2) R[X] over any commutative ring — a determinant-1 matrix always has a classical adjugate inverse, with no field hypothesis needed. The file stops short of using that to extend the power law to negative n (e.g. M(1)⁻¹ = M(−1)); a bundled Multiplicative ℤ →* GL₂(R[X]) homomorphism, exactly the entry's first open question, would supply this for free"
     ],
     "prerequisites": [
       "The parent's scalar addition formulas T_add, U_add and Pell identity T_sq_add",

--- a/src/data/proofs/chebyshev-polynomials-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-polynomials-oq-01-oq-01/meta.json
@@ -130,7 +130,8 @@
       "**The factor (1 − X²) is sin².** Under x = cos θ, 1 − x² = sin² θ, and Mathlib's U_real_cos gives U_{k−1}(cos θ)·sin θ = sin(kθ). So (1−X²)·U_{m−1}·U_{n−1} evaluated at cos θ is exactly sin(mθ)·sin(nθ), and T_add is the polynomial cos(α+β) = cos α cos β − sin α sin β. This is why the second term cannot be written in T alone — it is genuinely a second-kind (sine) contribution.",
       "**Mathlib has product-to-sum but not addition.** T_mul_T gives T_{m+k} + T_{m−k} coupled together; isolating T_{m+n} from it reintroduces T_{m−n}. The addition formula here is the decoupled form, expressing T_{m+n} purely from the m-th and n-th data — the form needed for, e.g., a single-step angle increment.",
       "**Both formulas reduce to a Mathlib mixed recurrence at n = 1.** The whole induction rests on two facts Mathlib already proves: T_eq_X_mul_T_sub_pol_U and U_eq_X_mul_U_add_T are precisely the n=1 instances, so no new base-case computation is needed.",
-      "**The diagonal is the Pell/Pythagorean identity.** Setting m = n in the subtraction formula and using T_0 = 1 yields Tₙ² + (1−X²)·U_{n−1}² = 1, i.e. Tₙ² − (X²−1)·U_{n−1}² = 1 — the defining Pell relation of the Chebyshev pair and the polynomial cos² + sin² = 1."
+      "**The diagonal is the Pell/Pythagorean identity.** Setting m = n in the subtraction formula and using T_0 = 1 yields Tₙ² + (1−X²)·U_{n−1}² = 1, i.e. Tₙ² − (X²−1)·U_{n−1}² = 1 — the defining Pell relation of the Chebyshev pair and the polynomial cos² + sin² = 1.",
+      "**T_sub costs no second induction.** Rather than re-running Polynomial.Chebyshev.induct, T_sub is obtained purely algebraically from the already-proved T_add by substituting n ↦ −n and rewriting with the reflection identities T_{−n} = Tₙ (T_neg) and U_{−n−1} = −U_{n−1} (U_neg_sub_one): the sign flip on U exactly cancels the sign already in front of (1−X²)·U_{m−1}·U_{n−1}, turning the addition formula into the subtraction formula with a single linear_combination."
     ],
     "prerequisites": [
       "Chebyshev polynomials of the first and second kind over a commutative ring",
@@ -203,6 +204,11 @@
       "targetId": "chebyshev-polynomials-oq-01",
       "relationship": "extends",
       "description": "Parent Chebyshev-polynomial entry; this adds the angle-addition formula T_{m+n}=T_m·T_n − (1−X²)·U_{m−1}·U_{n−1} over any commutative ring, extending Mathlib's product-to-sum identity."
+    },
+    {
+      "targetId": "chebyshev-polynomials-oq-01-oq-01-oq-01",
+      "relationship": "extended-by",
+      "description": "Answers this entry's first open question: packages T_add, U_add and T_sq_add into a single 2×2 matrix multiplicativity M(m+n) = M(m)·M(n), the 'Chebyshev rotation' whose powers generate T and U."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Both entries were at quality 98 with `keyInsights=8` (4 insights, scorer wants ≥5) as the only deficit.
- Parent `chebyshev-polynomials-oq-01-oq-01`: added a 5th keyInsight explaining that `T_sub` costs no second induction — it's derived purely algebraically from `T_add` via the reflection identities `T_neg`/`U_neg_sub_one`. Also added a forward `crossReferences` entry (`extended-by`) to the child, which directly answers this entry's first `openQuestion`.
- Child `chebyshev-polynomials-oq-01-oq-01-oq-01`: added a 5th keyInsight noting `chebMat_pow` only proves the ℕ-power law even though `det = 1` makes every `M(n)` invertible over any commutative ring (adjugate inverse, no field needed) — connecting directly to the entry's already-listed open question about bundling a `Multiplicative ℤ` homomorphism.
- Verified with `find-targets.ts --json`: both entries 98 → 100.

## Test plan
- [x] `jq empty` on both `meta.json` files
- [x] `npx tsx scripts/enricher/find-targets.ts --json` shows quality 100 for both ids, all buckets maxed
- [x] No existing content removed; only additive