### PR TITLE
Research: erdos-30-wip-01 - h(29)=7 via verified backtracking Sidon search (recovery)

### DIFF
--- a/proofs/Proofs/Erdos30WIP01.lean
+++ b/proofs/Proofs/Erdos30WIP01.lean
@@ -1880,4 +1880,203 @@ theorem sidonNumber_ge_real_sqrt {N : ℕ} (hN : 49 ≤ N) :
     _ ≤ ((m / 2 : ℕ) : ℝ) + 1 := hdiv
     _ ≤ (sidonNumber N : ℝ) := hmainR
 
+/-! ### `h(29) = 7` — a verified backtracking search fells the span-29 wall
+
+At `N = 29` the perfect ruler is **no longer forced**: an 8-element Sidon set in
+`{0,…,29}` has `C(8,2) = 28` distinct positive differences inside `{1,…,29}`, so
+exactly one value escapes, and the `h(28)` mod-4 double count goes silent — the
+count only shows the *missing* difference must be `≡ 2 (mod 4)` (a parity count
+rules out an odd missing value, and `≡ 0 (mod 4)` forces class sizes `{3,3,1,1}`
+with cross-count `∈ {6,10}`, never the required `7`), and a configuration with
+class sizes `{4,2,1,1}` and missing value `≡ 2 (mod 4)` survives every mod-4
+constraint.  So the `h(16)`/`h(22..24)` span dichotomy returns instead: sliding a
+hypothetical 8-element Sidon set down by its minimum either drops the span to
+`≤ 28` — killed outright by the `h(28)` theorem — or pins both endpoints
+`{0, 29}`, leaving the six interior elements.
+
+The flat kernel search of the `h(22..24)` walls does **not** scale here: it would
+enumerate `C(28,6) = 376740` interior candidates, 11× the `h(24)` search (measured
+at ≳ 3 CPU-hours).  Instead we verify a **pruned backtracking search**
+(`searchOK`): extend the partial set one element at a time in increasing order,
+and abandon a branch the moment the partial set stops being Sidon.  Only `26651`
+extension tests survive the pruning — 14× fewer than the flat enumeration, with
+most tests failing on an early sum collision.  Its completeness lemma
+(`searchOK_complete`, an induction on the number of missing elements: any true
+extension would be rediscovered smallest-element-first) turns the kernel-computed
+`searchOK {0,29} 1 28 6 = false` into the nonexistence theorem.  The engine is
+parametric in the interval, so the coming walls `h(30..33)` — the optimal 8-mark
+ruler has span `34` — are one `searchOK_complete` application each. -/
+
+/-- Bounded backtracking Sidon-extension search.  `searchOK A lo hi k = true`
+whenever the partial set `A` extends to a Sidon set by `k` further elements drawn
+from `{lo,…,hi}` (completeness, `searchOK_complete`); branches that already
+violate the Sidon condition are pruned immediately, which is what makes the
+kernel evaluation feasible where the flat `C(28,6)` enumeration is not. -/
+private def searchOK (A : Finset ℕ) (lo hi k : ℕ) : Bool :=
+  match k with
+  | 0 => true
+  | k + 1 => (List.range' lo (hi + 1 - lo)).any fun x =>
+      decide (SidonCheck (insert x A)) && searchOK (insert x A) (x + 1) hi k
+
+/-- The bounded Sidon predicate is hereditary (the quantifiers just restrict). -/
+private theorem sidonCheck_mono {A B : Finset ℕ} (hBA : B ⊆ A) (hA : SidonCheck A) :
+    SidonCheck B :=
+  fun a ha b hb c hc d hd hab hcd heq =>
+    hA a (hBA ha) b (hBA hb) c (hBA hc) d (hBA hd) hab hcd heq
+
+/-- **Completeness of the backtracking search**: if some `B ⊆ {lo,…,hi}` with
+`|B| = k` extends `A` to a set satisfying `SidonCheck`, then the pruned search
+reports success.  Induction on `k`: the smallest element `x` of `B` lies in the
+scan range, the partial set `insert x A` inherits `SidonCheck` from `A ∪ B`
+(so the branch is *not* pruned), and the remaining `B.erase x` lives in
+`{x+1,…,hi}`, closing the induction. -/
+private theorem searchOK_complete (k : ℕ) :
+    ∀ (A : Finset ℕ) (lo hi : ℕ) (B : Finset ℕ),
+      B ⊆ Finset.Icc lo hi → B.card = k → SidonCheck (A ∪ B) →
+      searchOK A lo hi k = true := by
+  induction k with
+  | zero => intro A lo hi B _ _ _; rfl
+  | succ k ih =>
+    intro A lo hi B hBsub hBcard hcheck
+    have hBne : B.Nonempty := Finset.card_pos.mp (by omega)
+    set x := B.min' hBne with hxdef
+    have hxB : x ∈ B := B.min'_mem hBne
+    have hxIcc : lo ≤ x ∧ x ≤ hi := Finset.mem_Icc.mp (hBsub hxB)
+    have hxmem : x ∈ List.range' lo (hi + 1 - lo) := by
+      rw [List.mem_range'_1]
+      omega
+    have hSC : SidonCheck (insert x A) := by
+      refine sidonCheck_mono (fun y hy => ?_) hcheck
+      rcases Finset.mem_insert.mp hy with rfl | hyA
+      · exact Finset.mem_union_right _ hxB
+      · exact Finset.mem_union_left _ hyA
+    simp only [searchOK, List.any_eq_true]
+    refine ⟨x, hxmem, ?_⟩
+    rw [Bool.and_eq_true]
+    refine ⟨decide_eq_true hSC, ?_⟩
+    refine ih (insert x A) (x + 1) hi (B.erase x) (fun y hy => ?_) ?_ ?_
+    · -- the remaining elements live in {x+1,…,hi}
+      have hyB := Finset.mem_of_mem_erase hy
+      have hyne := (Finset.mem_erase.mp hy).1
+      have hymin := B.min'_le y hyB
+      have hyIcc := Finset.mem_Icc.mp (hBsub hyB)
+      rw [Finset.mem_Icc]
+      omega
+    · rw [Finset.card_erase_of_mem hxB, hBcard]
+    · have hEq : insert x A ∪ B.erase x = A ∪ B := by
+        rw [Finset.insert_union, ← Finset.union_insert, Finset.insert_erase hxB]
+      rw [hEq]
+      exact hcheck
+
+set_option maxRecDepth 100000 in
+/-- **The kernel-verified search**: no six elements of `{1,…,28}` extend the pinned
+endpoints `{0, 29}` to an 8-element Sidon set.  The pruned backtracking evaluation
+visits `26651` extension tests (`5362` surviving partial sets), against `376740`
+candidates for the flat enumeration. -/
+private theorem search_zero_twentynine_eq_false :
+    searchOK {0, 29} 1 28 6 = false := by
+  decide +kernel
+
+/-- **No 8-element Sidon set fits in `{0,…,29}`.**  Span dichotomy: after sliding
+the minimum to `0`, either the set lies in `{0,…,28}` (killed by the `h(28)` mod-4
+double count) or its span is exactly `29` and the six interior elements fall to
+the verified backtracking search. -/
+theorem no_sidon_card_eight_range_thirty (A : Finset ℕ)
+    (hsub : A ⊆ Finset.range 30) (hA : IsSidonSet A) : A.card ≤ 7 := by
+  by_contra hcard
+  rw [not_le] at hcard
+  have hup : A.card * A.card ≤ 58 + A.card := by
+    have := sidon_card_sq_le 29 hsub hA; omega
+  have hc8 : A.card = 8 := by
+    by_contra hne
+    have h9 : 9 ≤ A.card := by omega
+    have hmul : 9 * A.card ≤ A.card * A.card := Nat.mul_le_mul h9 (le_refl A.card)
+    omega
+  have hne : A.Nonempty := Finset.card_pos.mp (by omega)
+  set m := A.min' hne with hm
+  have hmle : ∀ x ∈ A, m ≤ x := fun x hx => A.min'_le x hx
+  have hbound : ∀ x ∈ A, x ≤ 29 := fun x hx => by
+    have := hsub hx; rw [Finset.mem_range] at this; omega
+  set A' := A.image (fun x => x - m) with hA'
+  have hinj : Set.InjOn (fun x => x - m) ↑A := by
+    intro x hx y hy hxy
+    have hx' := hmle x (Finset.mem_coe.mp hx)
+    have hy' := hmle y (Finset.mem_coe.mp hy)
+    have hxy' : x - m = y - m := hxy
+    omega
+  have hA'card : A'.card = 8 := by
+    rw [hA', Finset.card_image_of_injOn hinj, hc8]
+  have hA'sidon : IsSidonSet A' := by
+    intro a b c d ha hb hc hd hab hcd heq
+    rw [hA'] at ha hb hc hd
+    simp only [Finset.mem_image] at ha hb hc hd
+    obtain ⟨a₀, ha₀, rfl⟩ := ha
+    obtain ⟨b₀, hb₀, rfl⟩ := hb
+    obtain ⟨c₀, hc₀, rfl⟩ := hc
+    obtain ⟨d₀, hd₀, rfl⟩ := hd
+    have hma := hmle a₀ ha₀; have hmb := hmle b₀ hb₀
+    have hmc := hmle c₀ hc₀; have hmd := hmle d₀ hd₀
+    obtain ⟨h1, h2⟩ := hA a₀ b₀ c₀ d₀ ha₀ hb₀ hc₀ hd₀ (by omega) (by omega) (by omega)
+    exact ⟨by omega, by omega⟩
+  have hzero : (0 : ℕ) ∈ A' := by
+    rw [hA']
+    exact Finset.mem_image.mpr ⟨m, A.min'_mem hne, Nat.sub_self m⟩
+  have hA'ne : A'.Nonempty := ⟨0, hzero⟩
+  have hA'bound : ∀ x ∈ A', x ≤ 29 := by
+    intro x hx
+    rw [hA'] at hx
+    obtain ⟨x₀, hx₀, hx₀eq⟩ := Finset.mem_image.mp hx
+    have hb := hbound x₀ hx₀
+    have hx₀eq' : x₀ - m = x := hx₀eq
+    omega
+  rcases Nat.lt_or_ge (A'.max' hA'ne) 29 with hM | hM
+  · -- Span ≤ 28: the slid set lives in {0,…,28}; the h(28) obstruction applies.
+    have hsub' : A' ⊆ Finset.range 29 := fun x hx => by
+      rw [Finset.mem_range]
+      exact lt_of_le_of_lt (A'.le_max' x hx) hM
+    have := no_sidon_card_eight_range_twentynine A' hsub' hA'sidon
+    omega
+  · -- Span = 29: both endpoints pinned; the six interior elements fall to the search.
+    have h29 : (29 : ℕ) ∈ A' := by
+      have hMle : A'.max' hA'ne ≤ 29 := hA'bound _ (A'.max'_mem hA'ne)
+      have hMeq : A'.max' hA'ne = 29 := le_antisymm hMle hM
+      rw [← hMeq]
+      exact A'.max'_mem hA'ne
+    set B := (A'.erase 0).erase 29 with hB
+    have h29' : (29 : ℕ) ∈ A'.erase 0 := Finset.mem_erase.mpr ⟨by omega, h29⟩
+    have hrecon : insert 0 (insert 29 B) = A' := by
+      rw [hB, Finset.insert_erase h29', Finset.insert_erase hzero]
+    have hBcard : B.card = 6 := by
+      rw [hB, Finset.card_erase_of_mem h29', Finset.card_erase_of_mem hzero, hA'card]
+    have hBsub : B ⊆ Finset.Icc 1 28 := by
+      intro x hx
+      rw [hB] at hx
+      have hx29 := (Finset.mem_erase.mp hx).1
+      have hx' := Finset.mem_of_mem_erase hx
+      have hx0 := (Finset.mem_erase.mp hx').1
+      have hxA := Finset.mem_of_mem_erase hx'
+      have := hA'bound x hxA
+      rw [Finset.mem_Icc]
+      omega
+    have hcheckU : SidonCheck ({0, 29} ∪ B) := by
+      have hU : ({0, 29} : Finset ℕ) ∪ B = insert 0 (insert 29 B) := by
+        rw [Finset.insert_union, Finset.singleton_union]
+      rw [hU, hrecon]
+      exact sidonCheck_of_isSidonSet hA'sidon
+    have htrue : searchOK {0, 29} 1 28 6 = true :=
+      searchOK_complete 6 {0, 29} 1 28 B hBsub hBcard hcheckU
+    rw [search_zero_twentynine_eq_false] at htrue
+    exact Bool.false_ne_true htrue
+
+/-- `h(29) = 7` — the wall continues.  The optimal 8-mark Golomb ruler
+`{0,1,4,9,15,22,32,34}` has span `34`, so `h(N) = 7` is expected throughout
+`25 ≤ N ≤ 33`; this settles `N = 29`, the first value past the forced-ruler
+regime. -/
+theorem sidonNumber_twentynine : sidonNumber 29 = 7 := by
+  refine le_antisymm ?_ ?_
+  · exact sidonNumber_le_of_card
+      (fun A hsub hA => no_sidon_card_eight_range_thirty A hsub hA)
+  · calc 7 = ({0, 1, 4, 10, 18, 23, 25} : Finset ℕ).card := by decide
+      _ ≤ sidonNumber 29 := sidonNumber_ge_card (by decide) isSidonSet_0_1_4_10_18_23_25
+
 end Erdos30

--- a/research/problems/erdos-30-wip-01/knowledge.md
+++ b/research/problems/erdos-30-wip-01/knowledge.md
@@ -246,3 +246,54 @@ candidates — still beyond decide+kernel comfort).
 (Erdős–Turán exact form √N + N^{1/4} + 1), $1000 N^ε conjecture (stays a Prop).
 The construction side is now DONE at order √N; constant-sharpening (h ≥ (1−o(1))√N
 via Singer) would need genuine finite-geometry infra.
+
+## 2026-07-24 h(29) session + evening recovery (researcher-1)
+
+**h(29) = 7 LANDED — verified backtracking search.** The 01:24 session
+built the engine, pushed branch `research/erdos30-wip01-h29`, and died
+before PR; the evening session recovered it (cherry-pick onto fresh
+origin/main, append-conflict vs the ET section resolved, host-verified,
+PR'd). New in `Erdos30WIP01.lean` (+199 LOC):
+
+- `searchOK A lo hi k : Bool` — pruned backtracking Sidon-extension
+  search: extend the partial set one element at a time in increasing
+  order, abandon a branch the moment `SidonCheck` fails. 26,651
+  extension tests vs C(28,6) = 376,740 flat candidates (14×), and most
+  tests die on an early sum collision.
+- `searchOK_complete` — completeness by induction on k: a true extension
+  would be rediscovered smallest-element-first (min' of the residual B
+  is in the scan range; `SidonCheck` is hereditary via `sidonCheck_mono`;
+  `B.erase min'` lives in `{x+1,…,hi}`).
+- `search_zero_twentynine_eq_false : searchOK {0,29} 1 28 6 = false` —
+  one `decide +kernel`.
+- `no_sidon_card_eight_range_thirty` — span dichotomy: slide min to 0;
+  span ≤ 28 dies on `no_sidon_card_eight_range_twentynine` (the h(28)
+  mod-4 theorem); span 29 pins {0,29} and the six interior elements fall
+  to the search via `searchOK_complete` + the `SidonCheck` bridge.
+- `sidonNumber_twentynine : sidonNumber 29 = 7` (lower bound: the span-25
+  optimal 7-mark ruler still attains 7).
+
+**Counting route CLOSED (evening session, exhaustive check):** for EVERY
+modulus m = 2..16 there are class profiles satisfying all symmetric
+difference-bucket counts of {1..29}\{d} for some admissible d (48
+survivors at m = 8, 42 at m = 6, 144 at m = 12, 330 at m = 15). The
+"mod-6/mod-8 cross counts" route suggested by the prior session cannot
+work at any single modulus — recorded as a structured blocker.
+
+**Kernel-performance data (evening session, host v4.31):**
+- Flat `powersetCard` + quartic `SidonCheck` `decide +kernel`:
+  ~105 ms/candidate (2002-candidate slice = 211 s) ⟹ flat C(28,6)
+  ≈ 11 CPU-hours — validates the pruned-engine approach.
+- ★`Finset.sort` is WF-recursive and does NOT kernel-reduce: any
+  `decide +kernel` predicate touching `.sort` gets stuck at
+  `instDecidablePairwise`. Keep kernel predicates list-native.
+- List-native alternative (`List.sublistsLen` over `List.range'`,
+  sublists of a sorted list are sorted — no sort call; explicit
+  `diffList` + `Nodup` with early-exit): 2002 candidates ≈ 2 s,
+  C(27,5) = 80,730 ≈ 6.5 min (4.8 ms each) — 20–100× faster than the
+  Finset formulation. This is the fallback engine if `searchOK` cost
+  grows too fast at h(32)/h(33).
+
+**Next:** h(30..33) each = one `searchOK_complete` application + a
+constant-bumped span-dichotomy copy; then h(34) = 8 witness
+{0,1,4,9,15,22,32,34}. Completes the 8-mark story.

--- a/research/problems/erdos-30-wip-01/state.md
+++ b/research/problems/erdos-30-wip-01/state.md
@@ -3,40 +3,71 @@
 ## Current State
 **Phase**: ACT
 **Path**: full
-**Since**: 2026-07-23T10:45:00-07:00
-**Iteration**: 7
+**Since**: 2026-07-24T18:00:00-07:00
+**Iteration**: 8
 
 ## Current Focus
-Exact Sidon table h(N) = sidonNumber N. COMPLETE for h(0..28) as of the
-2026-07-23b session (h(28)=7 via a mod-4 class double count — the perfect
-8-mark ruler is forced at N=28 and the residue-class counts
-Σcᵣ(cᵣ−1)=14, Σcᵣ·c_{r+2}=14, Σcᵣ=8 are jointly unsatisfiable; no kernel
-search needed).
+Exact Sidon table h(N) = sidonNumber N. COMPLETE for h(0..29) — the
+2026-07-24 h(29) session (recovered; see below) felled the first
+non-forced-ruler wall with a **verified backtracking search**: pruned
+engine `searchOK` + completeness lemma `searchOK_complete` + one
+`decide +kernel` evaluation `searchOK {0,29} 1 28 6 = false` (26,651
+extension tests vs C(28,6) = 376,740 flat candidates), chained through
+the span dichotomy to `no_sidon_card_eight_range_thirty` and
+`sidonNumber_twentynine : sidonNumber 29 = 7`.
+
+**Recovery note (2026-07-24 evening session, researcher-1):** the h(29)
+work was completed and pushed at 01:24 on branch
+`research/erdos30-wip01-h29` but its session died before creating a PR;
+the later ET-construction PR #43219 (08:54) merged unaware of it. This
+session recovered it: cherry-picked onto fresh origin/main, resolved the
+end-of-file append conflict against the ET section, host-verified, PR'd.
 
 ## Active Approach
-Residue-class double counting against forced perfect rulers at the wall
-values N = k(k−1)/2 (h(10) parity, h(15) mod-3, h(21) parity, h(28) mod-4);
-chained span dichotomy + pinned-endpoint kernel search for the in-between
-values. `SidonCheck` converse bridge certifies witnesses with one `decide`.
+Verified backtracking search for the h(29..33) wall values (the engine
+is parametric in the interval — each remaining wall is one
+`searchOK_complete` application + a copy of the span-dichotomy theorem);
+residue-class double counting for forced-ruler walls (exhausted for
+29..33 — see Blockers); `SidonCheck` converse bridge certifies witnesses
+with one `decide`.
 
 ## Attempt Count
-- Total attempts: 8 sessions
-- Current approach attempts: 5 (h(16), h(17..21), h(22..27), h(28), Erdős–Turán √N lower bound — all landed)
-- Approaches tried: parity wall, mod-3 class count, span dichotomy, mod-4 double count, Erdős–Turán construction + Bertrand
+- Total attempts: 9 sessions
+- Current approach attempts: 6 (h(16), h(17..21), h(22..27), h(28), Erdős–Turán √N lower bound, h(29) verified-search — all landed)
+- Approaches tried: parity wall, mod-3 class count, span dichotomy, mod-4 double count, Erdős–Turán construction + Bertrand, verified backtracking search
 
 ## Blockers
-h(29..33) wall: perfect ruler no longer forced (28 diffs in {1,…,N} miss
-N−28 values); span dichotomy returns but the span-N branch needs per-N
-nonexistence with C(N−1,6)-scale kernel searches (~376k at N=29). Mod-4
-alone checked INSUFFICIENT at N=29 (a {4,2,1,1} arrangement with the missing
-value ≡ 2 mod 4 survives). Elementary layer near-saturated.
+- **Residue-class double counting is DEAD for h(29..33)** (2026-07-24,
+  researcher-1): exhaustive computational sweep of ALL moduli m = 2..16
+  — for every m there exist class profiles (c₀..c_{m−1}, Σ=8) jointly
+  satisfying every symmetric difference-bucket count of {1..29}\{d} for
+  some admissible missing d (e.g. 48 surviving profiles at m = 8, 42 at
+  m = 6, 144 at m = 12). The prior note "fell h(29) via mod-6/mod-8
+  cross counts" is therefore impossible — no single-modulus class count
+  can work. Reopen bar: materially new mechanism required (constraints
+  beyond residue-class counts).
+- **Flat kernel search is cost-infeasible**: measured ~105 ms/candidate
+  host-side for `powersetCard` + quartic `SidonCheck` under
+  `decide +kernel` (C(14,5) = 2002 slice in 211 s) ⟹ C(28,6) flat
+  ≈ 11 CPU-hours. The pruned `searchOK` engine (26,651 tests) is the
+  viable route — landed.
+- **Kernel gotcha**: `Finset.sort` is defined by well-founded recursion
+  and does NOT reduce in the kernel — any `decide +kernel` whose
+  predicate touches `.sort` gets stuck ("Reduction got stuck at …
+  instDecidablePairwise"). List-native formulations
+  (`List.sublistsLen` + explicit diff list + `Nodup`) reduce fine and
+  measured 20–100× faster than Finset + quartic SidonCheck (2002
+  candidates in ~2 s vs 211 s; C(27,5) = 80,730 candidates in 6.5 min
+  ≈ 4.8 ms each) — the scaling fallback if `searchOK` slows at the
+  larger walls.
 
 ## Next Action
-DONE 2026-07-24: Erdős–Turán construction landed — √N/4 ≤ h(N) ≤ √(2N)+1
-for N ≥ 49, order h(N) ≍ √N settled elementarily (former DEEP target
-"Singer √N lower bound" achieved via Erdős–Turán instead; no projective
-planes). h(29) narrowed: missing diff d ≡ 2 (mod 4) (prior "d odd" note was
-WRONG — mod-2 class count forces d even). Remaining: fell h(29) via
-mod-6/mod-8 cross counts on the narrowed d-list or the ≈192k span-29
-search; or DEEP: N^{1/4} refinement, Singer (1−o(1))√N constant, $1000
-N^ε conjecture.
+h(30)..h(33) = 7: each is one `searchOK_complete` application
+(`searchOK {0,N} 1 (N-1) 6 = false`) plus a constant-bumped copy of
+`no_sidon_card_eight_range_thirty` chained to the previous range
+theorem; then h(34) = 8 via the optimal 8-mark ruler witness
+{0,1,4,9,15,22,32,34} (SidonCheck decide) — completing the 8-mark story
+h(N) = 7 for 25 ≤ N ≤ 33, h(34) = 8. Watch kernel cost growth with the
+interval; switch the engine's inner check to the list-native
+formulation if a wall exceeds ~10 min kernel time. Beyond: DEEP only
+(N^{1/4} refinement, Singer (1−o(1))√N constant, $1000 N^ε conjecture).

--- a/src/data/research/problems/erdos-30-wip-01.json
+++ b/src/data/research/problems/erdos-30-wip-01.json
@@ -19,11 +19,22 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-07-09T17:33:20-07:00",
-    "iteration": 3,
-    "focus": "h(22)..h(27) SHIPPED (2026-07-23): table extended to h(0..27). h(22)=h(23)=h(24)=6 via the SCALED span dichotomy chained across three N values: slide down by the minimum; reduced span appeals to the previous N's obstruction (anchored at the merged h(21) parity theorem no_sidon_card_seven_range_twentytwo), span=N pins endpoints {0,N} and the FIVE interior elements fall to decide +kernel over C(N-1,5) subsets (20349 / 26334 / 33649 candidates for N=22,23,24). h(25)=h(26)=h(27)=7: the optimal 7-mark Golomb ruler {0,1,4,10,18,23,25} (span 25, sharp by no_sidon_card_seven_range_twentyfive) gives the witness, certified via the new converse bridge isSidonSet_of_sidonCheck (decide replaces the 7^4=2401-case rcases sweep); counting blocks eight (64 > 2N+8 through N=27).",
-    "blockers": [],
-    "nextAction": "Table h(0..27) complete. Next wall is N=28: counting goes slack for eight (64 = 2*28+8) and the optimal 8-mark ruler {0,1,4,9,15,22,32,34} has span 34, so h(28..33) need per-N nonexistence of an 8-element Sidon set — span dichotomy would need C(N-1,6) kernel searches (~296k at N=28, likely still feasible but growing). Or pivot to the DEEP targets: Singer/Bose difference-set lower bound h(N)>=(1-o(1))sqrt(N) (finite projective geometry, likely axiomatize), N^{1/4} constant refinement, and the $1000 N^eps conjecture (stays a Prop).",
+    "since": "2026-07-24T18:00:00.000Z",
+    "iteration": 4,
+    "focus": "h(29) = 7 LANDED via verified backtracking search (recovered from stranded branch research/erdos30-wip01-h29 — session died after push, before PR; evening session cherry-picked onto fresh main, resolved append conflict vs the Erdos-Turan section, host-verified, PRd). Engine: searchOK (pruned backtracking, 26651 extension tests vs C(28,6)=376740 flat) + completeness lemma searchOK_complete + one decide +kernel evaluation, chained through the span dichotomy to no_sidon_card_eight_range_thirty and sidonNumber_twentynine. Exact table now COMPLETE h(0..29). Evening session also closed the residue-counting route exhaustively (all moduli 2..16 have surviving profiles) and measured kernel costs (flat search 11 CPU-hours — infeasible; Finset.sort kernel-irreducible; list-native formulation 20-100x faster as scaling fallback).",
+    "blockers": [
+      {
+        "route": "single-modulus residue-class double counting for h(29..33)",
+        "reopenCriterion": "materially new mechanism required (constraints beyond class counts — exhaustively checked m=2..16, all have surviving profiles)",
+        "blockedAt": "2026-07-24"
+      },
+      {
+        "route": "flat powersetCard kernel search for span-29",
+        "reopenCriterion": "kernel throughput improvement or list-native reformulation (measured ~105 ms/candidate, C(28,6) = 11 CPU-hours)",
+        "blockedAt": "2026-07-24"
+      }
+    ],
+    "nextAction": "h(30)..h(33) = 7: each is one searchOK_complete application (searchOK {0,N} 1 (N-1) 6 = false) plus a constant-bumped copy of no_sidon_card_eight_range_thirty chained to the previous range theorem; then h(34) = 8 via the optimal 8-mark ruler witness {0,1,4,9,15,22,32,34}. Watch kernel cost growth; switch the engine inner check to the list-native formulation (sublistsLen/diffList/Nodup) if a wall exceeds ~10 min kernel time.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Two-sided √N bounds COMPLETE: √N/4 ≤ h(N) ≤ √(2N)+1 for N ≥ 49 (Erdős–Turán construction + Bertrand; 0 axioms) — order of magnitude h(N) ≍ √N settled elementarily. Exact table h(0..28) complete. NEXT wall: h(29..33) (missing diff d ≡ 2 mod 4 now pinned; residue invariants alone insufficient; span-29 search ≈192k after sum-collision pruning). DEEP remaining: N^{1/4} refinement (exact Erdős–Turán form), Singer (1−o(1))√N constant, $1000 N^ε conjecture.",
+    "progressSummary": "2026-07-24: h(29) = 7 landed — first non-forced-ruler wall, via a verified backtracking search engine (searchOK + completeness + decide +kernel; 26651 tests vs 376740 flat). Exact Sidon table complete h(0..29); two-sided bounds sqrt(N)/4 <= h(N) <= sqrt(2N)+1 for N >= 49. Counting route for h(29..33) exhaustively closed (all moduli 2..16 fail). Engine is parametric — h(30..33) are one application each, then h(34) = 8 witness completes the 8-mark story. Two-sided √N bounds COMPLETE: √N/4 ≤ h(N) ≤ √(2N)+1 for N ≥ 49 (Erdős–Turán construction + Bertrand; 0 axioms) — order of magnitude h(N) ≍ √N settled elementarily. Exact table h(0..28) complete. NEXT wall: h(29..33) (missing diff d ≡ 2 mod 4 now pinned; residue invariants alone insufficient; span-29 search ≈192k after sum-collision pruning). DEEP remaining: N^{1/4} refinement (exact Erdős–Turán form), Singer (1−o(1))√N constant, $1000 N^ε conjecture.",
     "builtItems": [
       "Erdos30WIP01.lean: diffMap_injOn (Set.InjOn of difference map on Sidon off-diagonal)",
       "Erdos30WIP01.lean: sidon_offDiag_card_le (|A.offDiag| ≤ 2N for Sidon A ⊆ {0..N})",
@@ -61,7 +72,12 @@
       "etMap/etSet + base_two_p_eq + et_quadratic (private) in Erdos30WIP01.lean",
       "sidonNumber_ge_of_odd_prime: p ≤ sidonNumber (2p²−1)",
       "sidonNumber_sqrt_lower: Nat.sqrt((N+1)/2)/2 < sidonNumber N for N ≥ 49",
-      "sidonNumber_ge_real_sqrt: √N/4 ≤ h(N) for N ≥ 49 (0 axioms)"
+      "sidonNumber_ge_real_sqrt: √N/4 ≤ h(N) for N ≥ 49 (0 axioms)",
+      "searchOK (Erdos30WIP01.lean ~1908) — pruned backtracking Sidon-extension search engine, parametric in interval and count",
+      "searchOK_complete (Erdos30WIP01.lean ~1930) — completeness: any true extension is rediscovered smallest-element-first",
+      "search_zero_twentynine_eq_false (Erdos30WIP01.lean ~1970) — the kernel-verified span-29 search",
+      "no_sidon_card_eight_range_thirty (Erdos30WIP01.lean ~1980) — span dichotomy chaining h(28) + the search",
+      "sidonNumber_twentynine (Erdos30WIP01.lean ~2074) — h(29) = 7"
     ],
     "insights": [
       "Erdős–Turán upper bound is provable elementarily via difference-map injectivity: for a Sidon set A the map (a,b)↦a−b is injective on the off-diagonal (a−b=c−d ⇒ a+d=c+b ⇒ pair matches by the Sidon property), its image is nonzero integers in [−N,N] (2N of them), so |A.offDiag|=|A|²−|A| ≤ 2N.",
@@ -84,7 +100,11 @@
       "Mod-4 checked INSUFFICIENT at N=29: 28 diffs in {1..29} miss one value; missing ≡2 (mod 4) with class multiset {4,2,1,1} arranged c0c2+c1c3=6 survives the double count — h(29) needs mod-3×mod-4 combination, endpoint sum-collision pruning, or a C(28,6)≈376k kernel search",
       "Erdős–Turán construction {2pi + (i² mod p) : i < p} formalized: base-2p digit extraction + ZMod p quadratic-roots argument gives Sidon property; p ≤ h(2p²−1) for odd primes p",
       "Bertrand postulate converts the single-prime bound to uniform √N/4 ≤ h(N) for N ≥ 49 — with the √(2N)+1 upper bound the file settles h(N) ≍ √N elementarily, no projective planes needed",
-      "h(29) wall correction: mod-2 class count forces missing diff d EVEN (not odd as previously recorded), mod-4 then forces d ≡ 2 (mod 4); mod-3 allows both (4,3,1) with 3∤d and (4,2,2) with d ∈ {6,18}; residue invariants alone still insufficient"
+      "h(29) wall correction: mod-2 class count forces missing diff d EVEN (not odd as previously recorded), mod-4 then forces d ≡ 2 (mod 4); mod-3 allows both (4,3,1) with 3∤d and (4,2,2) with d ∈ {6,18}; residue invariants alone still insufficient",
+      "h(29): single-modulus residue-class double counting provably CANNOT fell the span-29 wall — exhaustive sweep m=2..16 finds surviving class profiles at every modulus (48 at m=8, 42 at m=6, 144 at m=12). The h(28)-style counting argument is special to forced perfect rulers.",
+      "Verified pruned search beats flat enumeration in kernel decides: searchOK visits 26651 extension tests vs C(28,6)=376740 flat (14x), and each pruned test short-circuits early; completeness is a clean induction on the residual-set cardinality via min-first rediscovery.",
+      "★Finset.sort is defined by well-founded recursion and does NOT reduce under decide +kernel (stuck at instDecidablePairwise) — kernel-facing decidable predicates must stay list-native (List.sublistsLen over List.range gives sorted sublists for free).",
+      "Kernel cost calibration (host v4.31): quartic SidonCheck over powersetCard ~105 ms/candidate; list-native diffList+Nodup ~4.8 ms/candidate at C(27,5) scale (20-100x) — the fallback engine for h(32)/h(33) if searchOK slows."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for erdos-30-wip-01 (Erdős Problem #30, Sidon/B₂ sets). Completes the exact Sidon table through h(29): `sidonNumber_twentynine : sidonNumber 29 = 7`.

This is a recovery PR: the h(29) work was completed and pushed on branch `research/erdos30-wip01-h29` at 01:24 on 2026-07-24, but that session died before creating a PR, and the later ET-construction PR #43219 merged unaware of it. This branch cherry-picks the work onto fresh origin/main and resolves the end-of-file append conflict against the ET section.

## Progress
- **Verified backtracking search engine** `searchOK`: pruned Sidon-extension search, parametric in the interval, with completeness lemma `searchOK_complete` (induction on the number of missing elements, smallest-element-first rediscovery).
- **Kernel-verified evaluation** `search_zero_twentynine_eq_false`: `searchOK {0,29} 1 28 6 = false` — 26,651 extension tests, versus C(28,6) = 376,740 flat candidates (measured at >= 3 CPU-hours flat, infeasible).
- **Span dichotomy** `no_sidon_card_eight_range_thirty` chains to the existing h(28) mod-4 theorem; yields `sidonNumber_twentynine : sidonNumber 29 = 7`.
- Table now complete h(0..29). The engine is reusable for the remaining h(30..33) walls (one `searchOK_complete` application each).
- Knowledge artifacts: state.md / knowledge.md / tracker updated, including a structured blocker recording that residue-class double counting is exhaustively dead for h(29..33) (all moduli 2..16 have surviving class profiles).

## Findings
- The fifth wall h(29) is the first table entry where NO single-modulus class count can work — verified by exhaustive profile sweep over moduli 2..16.
- Kernel cost data: flat `powersetCard` + quartic SidonCheck ~105 ms/candidate under `decide +kernel`; `Finset.sort` is kernel-irreducible (well-founded recursion); list-native formulations are 20-100x faster (fallback engine for h(32)/h(33)).

## Files Modified
- `proofs/Proofs/Erdos30WIP01.lean` (+199 lines, 0 axioms, 0 sorries)
- `research/problems/erdos-30-wip-01/state.md`, `knowledge.md`
- `src/data/research/problems/erdos-30-wip-01.json`

## Status
**Outcome**: progress (h(29) landed; vein continues at h(30..33), then h(34)=8)
**Next Steps**: h(30..33) via one `searchOK_complete` application each + per-N span-dichotomy copy; DEEP targets (Singer sqrt(N) lower bound, N^(1/4) refinement, $1000 conjecture) remain open.

🤖 Generated by researcher-1
