### PR TITLE
research(erdos-85-wip-01): f(14) ≥ 4 via fourth surgery rung — f(14) ∈ {4,5} [0 ax / 0 sorry]

### DIFF
--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -3053,4 +3053,99 @@ theorem minDegreeForC4_thirtyone_le : minDegreeForC4 31 ≤ 6 := by
 
 end TightPoints
 
+/-! ## `f(14) ≥ 4`: one more surgery rung — `f(14) ∈ {4, 5}`
+
+The next lower-bound rung past the projective-plane threshold `f(13) = 4`.
+Strategy identical to `f(13) ≥ 4`, one level up: materialise the `13`-vertex
+witness as an explicit edge list (`petersen13` — the `a = 4, b = 9, c = 7`
+surgery on `petersen12`, i.e. delete the spoke `4–9` and join the new vertex
+`12` to `4`, `9`, `7`), certify it by `13`-vertex kernel checks, then apply
+the **abstract** surgery with the configuration `a = 0, b = 4, c = 3`:
+
+* the edges `0–4` (outer) and `4–3` (outer) each lie in no triangle — the
+  only triangles of `petersen13` are `10–1–6`, `11–3–8`, `12–9–7`, one per
+  surgery vertex, and they avoid both edges;
+* `0 ≁ 3`, so the surgery hypotheses are met and the surgered graph on
+  `14` vertices is `C₄`-free with minimum degree `≥ 3`.
+
+No `14`-vertex graph is ever `decide`d.  The upper counting bound at `k = 5`
+(`14 ≤ 5·4`) gives `f(14) ≤ 5`; pinning `f(14) = 4` (the literature value)
+needs an upper-bound mechanism beyond the cherry count — `14` is not a tight
+point `k(k−1)+1`, so the friendship-theorem argument does not apply.  Honest
+result: `f(14) ∈ {4, 5}`. -/
+
+section Fourteen
+
+/-- The twenty-one edges of the `13`-vertex thrice-extended Petersen graph:
+`petersen12Edges` with the spoke `(4, 9)` deleted and the new vertex `12`
+joined to `4`, `9`, and `7` — the `f(13)` surgery, materialised. -/
+def petersen13Edges : List (Fin 13 × Fin 13) :=
+  [(1,2), (3,4), (4,0),
+   (5,7), (7,9), (9,6), (6,8), (8,5),
+   (0,5), (1,6), (2,7), (3,8),
+   (10,0), (10,1), (10,6),
+   (11,2), (11,3), (11,8),
+   (12,4), (12,9), (12,7)]
+
+/-- **A `13`-vertex `C₄`-free graph of minimum degree `3`**: the Petersen
+graph after three vertex-adding surgeries.  Vertices `6`, `7`, `8` have
+degree `4`; all other vertices have degree `3`. -/
+def petersen13 : SimpleGraph (Fin 13) where
+  Adj i j := (i, j) ∈ petersen13Edges ∨ (j, i) ∈ petersen13Edges
+  symm.symm := fun _ _ h => Or.symm h
+  loopless.irrefl := by decide
+
+instance : DecidableRel petersen13.Adj := fun i j =>
+  decidable_of_iff ((i, j) ∈ petersen13Edges ∨ (j, i) ∈ petersen13Edges) Iff.rfl
+
+/-- Every vertex of `petersen13` has degree at least `3` — a `13`-vertex
+kernel check. -/
+theorem petersen13_degree : ∀ v, 3 ≤ petersen13.degree v := by decide
+
+/-- **Every pair of distinct `petersen13` vertices has at most one common
+neighbour** — the `13 × 13` kernel check certifying `C₄`-freeness. -/
+theorem petersen13_common_le_one : ∀ x y : Fin 13, x ≠ y →
+    (petersen13.neighborFinset x ∩ petersen13.neighborFinset y).card ≤ 1 := by
+  decide
+
+/-- **`f(14) ≥ 4`** — the abstract surgery applied to `petersen13` with the
+configuration `a = 0, b = 4, c = 3`: the edges `0–4` and `4–3` are
+triangle-free, `0 ≁ 3`, and all remaining hypotheses are `13`-vertex kernel
+checks.  No `14`-vertex graph is ever `decide`d. -/
+theorem four_le_minDegreeForC4_fourteen : 4 ≤ minDegreeForC4 14 := by
+  have hab : petersen13.Adj 0 4 := by decide
+  have hbc : petersen13.Adj 4 3 := by decide
+  have hac : ¬ petersen13.Adj 0 3 := by decide
+  have hane : (0 : Fin 13) ≠ 3 := by decide
+  have htriab : ∀ z, petersen13.Adj 0 z → petersen13.Adj 4 z → False := by decide
+  have htribc : ∀ z, petersen13.Adj 4 z → petersen13.Adj 3 z → False := by decide
+  have hcommon := surgery_common_le_one hab hbc hac hane htriab htribc
+    petersen13_common_le_one
+  have hC4 : ¬ containsC4 (Fin 14) (surgeryFin petersen13 0 4 3) :=
+    surgeryFin_not_containsC4 petersen13 0 4 3
+      (not_containsC4_of_forall_common_le_one hcommon)
+  have hdeg : 3 ≤ (surgeryFin petersen13 0 4 3).minDegree := by
+    apply SimpleGraph.le_minDegree_of_forall_le_degree
+    intro u
+    refine le_trans ?_ (surgeryFin_degree_ge petersen13 0 4 3 u)
+    rcases h : finSuccEquiv 13 u with _ | x
+    · exact surgery_degree_none (by decide) (by decide) (by decide)
+    · exact le_trans (petersen13_degree x)
+        (surgery_degree_some (by decide) x)
+  exact four_le_minDegreeForC4_of_witness (by norm_num)
+    (surgeryFin petersen13 0 4 3) hdeg hC4
+
+/-- **`f(14) ∈ {4, 5}`**: the lower bound is the fourth surgery rung; the
+upper bound is the counting bound at `k = 5` (`14 ≤ 5·4`).  `14` is not a
+tight point `k(k−1)+1`, so the friendship-theorem pinning of `f(13)` does not
+extend — closing this gap needs a genuine `ex(n; C₄)` upper-bound mechanism. -/
+theorem minDegreeForC4_fourteen_mem :
+    minDegreeForC4 14 = 4 ∨ minDegreeForC4 14 = 5 := by
+  have hle : minDegreeForC4 14 ≤ 5 :=
+    minDegreeForC4_le_of_le_mul_pred (by norm_num) (by norm_num)
+  have hge := four_le_minDegreeForC4_fourteen
+  omega
+
+end Fourteen
+
 end Erdos85

--- a/src/data/research/problems/erdos-85-wip-01.json
+++ b/src/data/research/problems/erdos-85-wip-01.json
@@ -54,7 +54,7 @@
         "blockedAt": "2026-07-24"
       }
     ],
-    "nextAction": "Optional: chain surgery for f(14..19) lower rungs (config per step, cheap decides); general all-n>=10 theorem needs config-EXISTENCE argument (blocked route: not automatic in arbitrary C4-free graphs). Upper halves beyond n=12 need real ex(n;C4) input (blocked). Deep: KST asymptotics, monotonicity core.",
+    "nextAction": "Optional: chain surgery for f(15..19) lower rungs (materialise petersen14 edge list from the a=0,b=4,c=3 surgery, pick next config avoiding triangles 10-1-6, 11-3-8, 12-9-7, 13-4-3(new); cheap decides). Upper halves beyond n=13 need real ex(n;C4) input (blocked). Deep: KST asymptotics, monotonicity conjecture.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -62,7 +62,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: exact table 1..13 complete (f = 1,2,3,2,3,3,3,3,3,4,4,4,4). f(13)=4 closed 2026-07-24 by a materially new upper-bound mechanism: cherry-count EQUALITY at the projective-plane point 13=4*3+1 forces 4-regularity + the friendship condition, and the Mathlib Archive friendship theorem (politician) gives the contradiction — no ex(n;C4) input. Blocked: upper bounds at non-tight n>13 (need ex(n;C4)); tight points n=k*k-k+1 generalize the friendship route (candidate). Next lower rung: f(14)>=4 via surgery. Deep: KST asymptotics, monotonicity (the actual #85).",
+    "progressSummary": "PROGRESS: exact table f(1..13) + f(14) in {4,5} (lower rung via fourth surgery); f(21)<=5, f(31)<=6 tight-point bounds; next rungs f(15..19) same recipe, upper halves blocked on ex(n;C4)",
     "builtItems": [
       "C4_adj_zero_one/one_two/two_three/three_zero (four cycle edges) in Erdos85Problem.lean",
       "C4_not_adj_zero_two (diagonal non-edge) in Erdos85Problem.lean",
@@ -111,7 +111,8 @@
       "four_le_minDegreeForC4_thirteen, minDegreeForC4_thirteen_mem (f(13) in {4,5})",
       "common_le_one_of_not_containsC4 (converse criterion: no C4 => common neighbours <= 1) in Erdos85Problem.lean section Thirteen",
       "containsC4_of_thirteen_minDegree_four: 13 vertices, min degree >= 4, C4-free is impossible (cherry tightness + friendship theorem)",
-      "minDegreeForC4_le_four_thirteen + minDegreeForC4_thirteen: f(13) = 4, the fourth exact value, first beyond the counting range"
+      "minDegreeForC4_le_four_thirteen + minDegreeForC4_thirteen: f(13) = 4, the fourth exact value, first beyond the counting range",
+      "petersen13/petersen13_degree/petersen13_common_le_one + four_le_minDegreeForC4_fourteen + minDegreeForC4_fourteen_mem (section Fourteen, Erdos85Problem.lean)"
     ],
     "insights": [
       "Erdos85Problem.lean was a definitions-only stub (7 defs, 0 theorems). Asymptotics f(n)=(1+o(1))sqrt(n), f(4)=2, and the Ramsey reformulation need extremal graph theory beyond Mathlib; tractable axiom-free content is structural facts about C4, containsC4, and starGraph.",
@@ -154,7 +155,8 @@
       "n=13=4*3+1 is the projective-plane parameter point: 13*C(4,2)=C(13,2)=78 exactly, so the cherry double-count is TIGHT and tightness gives rigidity (4-regularity + every pair covered) instead of a pigeonhole collision",
       "Tight cherry count + injectivity = the friendship condition; Mathlib Archive friendship_theorem (Wiedijk #83) then produces a politician of degree n-1, contradicting regularity — a C4-free upper bound with NO edge-extremal (Reiman) input",
       "import Archive.Wiedijk100Theorems.FriendshipGraphs builds in this toolchain — the whole Mathlib Archive is usable as INPUT for gallery proofs",
-      "Classical-instance-baked defs (Archive Friendship): prove the statement with the synthesized instance in a have, then convert h using 2 — Subsingleton.elim closes the Fintype instance mismatch; refine/rw/@-hole all fail on kernel defeq"
+      "Classical-instance-baked defs (Archive Friendship): prove the statement with the synthesized instance in a have, then convert h using 2 — Subsingleton.elim closes the Fintype instance mismatch; refine/rw/@-hole all fail on kernel defeq",
+      "f(14) rung landed: materialise the previous surgery result as an explicit edge list (petersen13), then apply the abstract surgery again — config a=0,b=4,c=3 (edges 0-4, 4-3 triangle-free; triangles of petersen13 are exactly 10-1-6, 11-3-8, 12-9-7, one per surgery vertex). Only 13-vertex kernel decides; no 14-vertex graph decided. f(14) ∈ {4,5}; pinning 4 blocked (14 not a tight point, friendship argument inapplicable)."
     ],
     "mathlibGaps": [
       "Fin n has NO global CommRing instance (only scoped Fin.instCommRing via `open Fin.CommRing`, gated on NeZero n); needed for ring/linear_combination on cycleGraph differences"


### PR DESCRIPTION
## Summary

Research session for `erdos-85-wip-01` (Erdős #85: minimum degree forcing C4): **the f(14) lower rung** — `f(14) >= 4`, hence `f(14) ∈ {4, 5}`, extending the surgery ladder one step past the projective-plane threshold `f(13) = 4`.

## Progress

New `section Fourteen` in `proofs/Proofs/Erdos85Problem.lean`:

- `petersen13` — the 13-vertex witness materialised as an explicit edge list (the f(13) surgery on `petersen12`: spoke 4-9 deleted, new vertex 12 joined to 4, 9, 7), certified by 13-vertex kernel checks (`petersen13_degree`, `petersen13_common_le_one`).
- `four_le_minDegreeForC4_fourteen` — the abstract surgery applied to `petersen13` with configuration a=0, b=4, c=3: edges 0-4 and 4-3 are triangle-free (the only triangles of `petersen13` are 10-1-6, 11-3-8, 12-9-7, one per surgery vertex), 0 ≁ 3. No 14-vertex graph is ever `decide`d.
- `minDegreeForC4_fourteen_mem` — `f(14) ∈ {4, 5}`: upper half is the counting bound at k=5 (14 <= 5·4). 14 is not a tight point k(k-1)+1, so the friendship-theorem pinning of f(13) does not extend; pinning f(14) = 4 (the literature value) needs a genuine ex(n; C4) mechanism — honest remaining gap, recorded in the tracker.

This executes the tracker's own nextAction ("chain surgery for f(14..19) lower rungs"). Tracker JSON updated with the config-selection recipe for the next rungs.

## Verification

- Docker: `docker-build.sh Proofs.Erdos85Problem` green (8577 jobs; only pre-existing linter warnings from the earlier surgery sections).
- `#print axioms` (docker check file) on `four_le_minDegreeForC4_fourteen`, `minDegreeForC4_fourteen_mem`, `petersen13_common_le_one` = `[propext, Classical.choice, Quot.sound]`.
- Host `lake env lean` is not applicable to this file (it imports `Archive.Wiedijk100Theorems.FriendshipGraphs`; Archive oleans exist only in the Docker image).

## Status

**Outcome**: progress — f(14) lower rung proved; exact-value table stands at f(1..13) exact + f(14) ∈ {4,5}.
**Next Steps**: f(15..19) same recipe (materialise petersen14 edges, pick configs avoiding the four triangles); upper halves blocked on ex(n;C4).

🤖 Generated by researcher-3
