### PR TITLE
Fix prime-reciprocal-divergence-oq-03: vacuous IsRough + phantom rough-count narrative

### DIFF
--- a/proofs/Proofs/PrimeReciprocalDivergenceOQ03.lean
+++ b/proofs/Proofs/PrimeReciprocalDivergenceOQ03.lean
@@ -60,7 +60,7 @@ def IsSmooth (N k : ℕ) : Prop :=
 
 /-- An integer k is N-rough if it has at least one prime factor > N. -/
 def IsRough (N k : ℕ) : Prop :=
-  ∃ p : ℕ, p.Prime → p ∣ k ∧ p > N
+  ∃ p : ℕ, p.Prime ∧ p ∣ k ∧ p > N
 
 /-- The set of N-smooth numbers in {1, ..., n}. -/
 noncomputable def smoothSet (N n : ℕ) : Finset ℕ :=

--- a/src/data/proofs/prime-reciprocal-divergence-oq-03/annotations.json
+++ b/src/data/proofs/prime-reciprocal-divergence-oq-03/annotations.json
@@ -8,7 +8,7 @@
     },
     "type": "concept",
     "title": "Smooth and Rough Numbers: The Counting Dichotomy",
-    "content": "IsSmooth N k holds when every prime factor of k is ≤ N. IsRough N k holds when k has at least one prime factor > N. Together, every integer ≥ 2 is either N-smooth or N-rough for any N. The proof exploits this dichotomy: count smooth numbers from above (≤ √n · 2^π(N)) and rough numbers from above (< n/2 under the convergence assumption), showing both counts sum to less than n — contradiction, since [1..n] has n elements.",
+    "content": "IsSmooth N k holds when every prime factor of k is ≤ N. IsRough N k holds when k has at least one prime factor > N. Together, every integer ≥ 2 is either N-smooth or N-rough for any N. This file's headline theorem (infinitely_many_primes_erdos) uses only the smooth side: assuming all primes are ≤ N makes every integer N-smooth, and the smooth-count bound (≤ √n · 2^π(N)) alone already contradicts that for large n. The rough-number side (rough_count_bound, multiples_count) is proved but unused by the final theorem — see the file's closing 'Notes' section.",
     "mathContext": "Smooth numbers (also called N-smooth or B-smooth) are central to factoring algorithms (e.g., the quadratic sieve, elliptic curve factorization). A number is B-smooth if all its prime factors are ≤ B. The count of B-smooth numbers up to n is denoted Ψ(n, B). Erdős's argument uses the cruder bound Ψ(n, N) ≤ √n · 2^π(N), which suffices for the combinatorial contradiction.",
     "significance": "key",
     "relatedConcepts": [
@@ -104,8 +104,8 @@
     },
     "type": "concept",
     "title": "Multiples Count Bijection: |{p,2p,...} ∩ [1,n]| = ⌊n/p⌋",
-    "content": "multiples_count proves the elementary fact that there are exactly ⌊n/p⌋ multiples of p in [1,n]. The Lean proof establishes the set equality by bijecting {j·p : j ∈ [1, n/p]} with {multiples of p in [1,n]}, then uses Finset.card_image_of_injective (multiplication by p is injective for p > 0). The size of [1, n/p] is n/p by Finset.card_Icc + omega. This result feeds into the rough number count: ≤ Σ_{p>N} n/p rough numbers in [1,n].",
-    "mathContext": "The bound |{rough numbers in [1,n]}| ≤ Σ_{p>N, prime} ⌊n/p⌋ follows by inclusion-exclusion (lower bound by union). Under the assumption Σ_{p>N} 1/p < 1/2, the sum ≤ n/2. Combined with smooth ≤ √n · 2^π(N), the two counts show that for large n, smooth + rough < n — contradicting the fact that [1,n] has n elements.",
+    "content": "multiples_count proves the elementary fact that there are exactly ⌊n/p⌋ multiples of p in [1,n]. The Lean proof establishes the set equality by bijecting {j·p : j ∈ [1, n/p]} with {multiples of p in [1,n]}, then uses Finset.card_image_of_injective (multiplication by p is injective for p > 0). The size of [1, n/p] is n/p by Finset.card_Icc + omega. This bounds the count of multiples of a single prime p; summed over all p > N it would bound the rough-number count, but this file's main theorem (infinitely_many_primes_erdos) does not take this route — it derives its contradiction directly from smooth_count_bound alone.",
+    "mathContext": "The idea |{rough numbers in [1,n]}| ≤ Σ_{p>N, prime} ⌊n/p⌋ (via inclusion-exclusion), combined with Σ_{p>N} 1/p < 1/2 giving rough < n/2 and smooth ≤ √n · 2^π(N), motivates rough_count_bound and is the shape of Erdős's analytic Σ1/p argument. It is NOT what this file's headline theorem executes: infinitely_many_primes_erdos assumes only finitely many primes exist (all ≤ N) and refutes that from the smooth bound alone, so rough_count_bound and multiples_count are proved but unused by the final theorem.",
     "significance": "supporting",
     "relatedConcepts": [
       "divisibility",
@@ -138,7 +138,7 @@
       "erdos-proof"
     ],
     "prerequisites": [
-      "the assumption Σ1/p converges (for contradiction)",
+      "the assumption that only finitely many primes exist, i.e. all primes ≤ N (for contradiction)",
       "the smooth-number counting bound",
       "proof by contradiction"
     ]


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: prime-reciprocal-divergence-oq-03

## Problems

1. **Vacuous definition (Lean bug)**: `IsRough N k := ∃ p : ℕ, p.Prime → p ∣ k ∧ p > N` has the implication nested *inside* the existential, so it's satisfied by any non-prime witness `p` and is trivially `True` for every `N, k` — it never actually requires a large prime factor. This contradicts its own docstring ("An integer k is N-rough if it has at least one prime factor > N") and the annotations.json description of its semantics. `IsRough` is unused anywhere else in the file, so fixing it to `∃ p : ℕ, p.Prime ∧ p ∣ k ∧ p > N` is a pure, isolated correctness fix.

2. **Phantom rough-count narrative**: annotations.json described a smooth+rough inclusion-exclusion strategy (`rough_count_bound`, `multiples_count`, combined under a "Σ_{p>N} 1/p < 1/2" assumption) as if it were the route the headline theorem takes. It is not — `infinitely_many_primes_erdos` derives its contradiction directly from `smooth_count_bound` alone, under the simple hypothesis that only finitely many primes exist (all ≤ N). `rough_count_bound` and `multiples_count` are validly proved but are dead code, unused by the final theorem. One annotation's own `prerequisites` field ("the assumption Σ1/p converges") even contradicted its own `content` field in the same object, which correctly describes the "all primes ≤ N" hypothesis.

## Evidence

- `grep -n "rough_count_bound\|multiples_count" proofs/Proofs/PrimeReciprocalDivergenceOQ03.lean` shows both names only at their own `theorem` declarations — never referenced by `infinitely_many_primes_erdos` or `prime_reciprocals_unbounded`.
- `lake env lean proofs/Proofs/PrimeReciprocalDivergenceOQ03.lean` compiles cleanly after the `IsRough` fix (only pre-existing deprecation warnings).

## Fix

- `proofs/Proofs/PrimeReciprocalDivergenceOQ03.lean`: `IsRough` implication → conjunction.
- `annotations.json`: corrected 3 fields (`ann-erdos-smooth-defs.content`, `ann-erdos-multiples.content`/`mathContext`, `ann-erdos-main.prerequisites`) to describe the actual proof route and flag `rough_count_bound`/`multiples_count` as unused.

No change to meta.json counts — the file's public `sorries`/`axiomCount`/`theoremCount`/`definitionCount`/status/badge claims were all independently verified as accurate; the main verified theorem is genuinely proved.

---
Discovered during gallery integrity audit.