### PR TITLE
Update audit tracker: prime-reciprocal-divergence-oq-03 (issues-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23741,10 +23741,10 @@
       "issues": []
     },
     "prime-reciprocal-divergence-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:38Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T17:42:22Z",
+      "result": "issues-fixed"
     },
     "primitive-roots": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Records the audit result for prime-reciprocal-divergence-oq-03 following fix PR #43521 (vacuous `IsRough` definition + phantom rough-count narrative in annotations.json).