### PR TITLE
Research: ftc-oq-02-incomplete-01 S10 — general-n Gateaux nest: nested line derivatives commute for C^n [0 ax / 0 sorry]

### DIFF
--- a/proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean
+++ b/proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean
@@ -893,4 +893,121 @@ theorem lineDeriv_lineDeriv_comm [IsRCLikeNormedField 𝕜] (hf : ContDiff 𝕜 
       (houter a x).lineDeriv_eq_fderiv]
   exact fderiv_fderiv_comm hf a b x
 
+/-! ### Step 9 (S10): the general-`n` Gateaux nest — `nestedLineDeriv`
+
+The last classical spelling: `n`-fold nested *Gateaux* (line) derivatives.
+Step 8's `lineDeriv_lineDeriv_comm` treats `n = 2`; here the full tower is
+built — `nestedLineDeriv 𝕜 n v f = ∂_{v 0} (∂_{v 1} (… f))` with each `∂_w g x`
+the genuine one-dimensional limit `d/dt g(x + t·w)|₀` (`lineDeriv`), no Fréchet
+structure in the *statement* at all.  For a `C^n` function every level of the
+nest is in fact Fréchet differentiable, so the Gateaux nest coincides with the
+Fréchet nest (`nestedLineDeriv_eq_nestedFDeriv`, level-by-level via
+`DifferentiableAt.lineDeriv_eq_fderiv`), hence computes the `n`-th iterated
+derivative applied to the direction tuple and inherits the all-orders
+permutation symmetry.  This is Clairaut/Schwarz in its weakest-primitive form:
+only iterated one-dimensional limits appear. -/
+
+section GateauxNested
+
+variable (𝕜) in
+/-- The `n`-fold nested Gateaux (line) derivative:
+`nestedLineDeriv 𝕜 n v f = ∂_{v 0} (∂_{v 1} (… (∂_{v (n-1)} f)))` where
+`∂_w g x = lineDeriv 𝕜 g x w = d/dt g(x + t·w)|_{t=0}` — direction `v 0`
+outermost, matching `nestedFDeriv`. -/
+noncomputable def nestedLineDeriv : (n : ℕ) → (Fin n → E) → (E → F) → E → F
+  | 0, _, f => f
+  | n + 1, v, f => fun x => lineDeriv 𝕜 (nestedLineDeriv n (Fin.tail v) f) x (v 0)
+
+@[simp]
+theorem nestedLineDeriv_zero (v : Fin 0 → E) (f : E → F) :
+    nestedLineDeriv 𝕜 0 v f = f :=
+  rfl
+
+theorem nestedLineDeriv_succ_apply {n : ℕ} (v : Fin (n + 1) → E) (f : E → F) (x : E) :
+    nestedLineDeriv 𝕜 (n + 1) v f x
+      = lineDeriv 𝕜 (nestedLineDeriv 𝕜 n (Fin.tail v) f) x (v 0) :=
+  rfl
+
+@[simp]
+theorem nestedLineDeriv_one_apply (v : Fin 1 → E) (f : E → F) (x : E) :
+    nestedLineDeriv 𝕜 1 v f x = lineDeriv 𝕜 f x (v 0) :=
+  rfl
+
+/-- **The Gateaux/Fréchet nest bridge.** For a `C^n` function the `n`-fold nested
+line derivative agrees with the `n`-fold nested Fréchet derivative: at each level
+the inner nest is (by the S8 bridge) the constant-tuple evaluation of the
+`C^{n-k}` multilinear derivative, hence Fréchet differentiable, and
+`DifferentiableAt.lineDeriv_eq_fderiv` upgrades the Gateaux level to Fréchet.
+Holds over any nontrivially normed field. -/
+theorem nestedLineDeriv_eq_nestedFDeriv :
+    ∀ {n : ℕ}, ContDiff 𝕜 (n : ℕ) f → ∀ (v : Fin n → E) (x : E),
+      nestedLineDeriv 𝕜 n v f x = nestedFDeriv 𝕜 n v f x := by
+  intro n
+  induction n with
+  | zero => intro _ v x; rfl
+  | succ n IH =>
+    intro hf v x
+    have hfn : ContDiff 𝕜 (n : ℕ) f := hf.of_le (by exact_mod_cast Nat.le_succ n)
+    have hfun : nestedLineDeriv 𝕜 n (Fin.tail v) f
+        = nestedFDeriv 𝕜 n (Fin.tail v) f :=
+      funext fun y => IH hfn (Fin.tail v) y
+    have hfun2 : nestedFDeriv 𝕜 n (Fin.tail v) f
+        = fun y => iteratedFDeriv 𝕜 n f y (Fin.tail v) :=
+      funext fun y => nestedFDeriv_eq_iteratedFDeriv hfn (Fin.tail v) y
+    have hdiff : DifferentiableAt 𝕜
+        (fun y => iteratedFDeriv 𝕜 n f y (Fin.tail v)) x := by
+      have h1 : DifferentiableAt 𝕜 (iteratedFDeriv 𝕜 n f) x :=
+        (hf.differentiable_iteratedFDeriv (by norm_cast; omega)).differentiableAt
+      exact h1.continuousMultilinear_apply_const _
+    calc nestedLineDeriv 𝕜 (n + 1) v f x
+        = lineDeriv 𝕜 (nestedLineDeriv 𝕜 n (Fin.tail v) f) x (v 0) := rfl
+      _ = lineDeriv 𝕜 (fun y => iteratedFDeriv 𝕜 n f y (Fin.tail v)) x (v 0) := by
+          rw [hfun, hfun2]
+      _ = fderiv 𝕜 (fun y => iteratedFDeriv 𝕜 n f y (Fin.tail v)) x (v 0) :=
+          hdiff.lineDeriv_eq_fderiv
+      _ = fderiv 𝕜 (nestedFDeriv 𝕜 n (Fin.tail v) f) x (v 0) := by rw [← hfun2]
+      _ = nestedFDeriv 𝕜 (n + 1) v f x := rfl
+
+/-- The Gateaux nest of a `C^n` function computes the `n`-th iterated Fréchet
+derivative applied to the direction tuple — the two S8/S10 bridges composed. -/
+theorem nestedLineDeriv_eq_iteratedFDeriv {n : ℕ} (hf : ContDiff 𝕜 (n : ℕ) f)
+    (v : Fin n → E) (x : E) :
+    nestedLineDeriv 𝕜 n v f x = iteratedFDeriv 𝕜 n f x v := by
+  rw [nestedLineDeriv_eq_nestedFDeriv hf v x, nestedFDeriv_eq_iteratedFDeriv hf v x]
+
+/-- **Classical all-orders Clairaut/Schwarz, Gateaux form.** For a `C^n` function
+over `ℝ` or `ℂ`, nested one-dimensional directional derivatives may be taken in
+any order — the weakest-primitive spelling of the theorem: only iterated limits
+`d/dt g(x + t·w)|₀` appear in the statement. -/
+theorem nestedLineDeriv_comp_perm [IsRCLikeNormedField 𝕜] {n : ℕ}
+    (hf : ContDiff 𝕜 (n : ℕ) f) (v : Fin n → E) (σ : Equiv.Perm (Fin n)) (x : E) :
+    nestedLineDeriv 𝕜 n (v ∘ σ) f x = nestedLineDeriv 𝕜 n v f x := by
+  rw [nestedLineDeriv_eq_nestedFDeriv hf (v ∘ σ) x,
+    nestedLineDeriv_eq_nestedFDeriv hf v x, nestedFDeriv_comp_perm hf v σ x]
+
+/-- Field-uniform `minSmoothness` form of the Gateaux nested Clairaut theorem. -/
+theorem nestedLineDeriv_comp_perm_of_minSmoothness {n : ℕ}
+    (hf : ContDiff 𝕜 (minSmoothness 𝕜 n) f) (v : Fin n → E) (σ : Equiv.Perm (Fin n))
+    (x : E) :
+    nestedLineDeriv 𝕜 n (v ∘ σ) f x = nestedLineDeriv 𝕜 n v f x := by
+  have hfn : ContDiff 𝕜 (n : ℕ) f := hf.of_le le_minSmoothness
+  rw [nestedLineDeriv_eq_nestedFDeriv hfn (v ∘ σ) x,
+    nestedLineDeriv_eq_nestedFDeriv hfn v x,
+    nestedFDeriv_comp_perm_of_minSmoothness hf v σ x]
+
+/-- Sanity: the `n = 2` Gateaux nest is literally the Step-8 double line
+derivative, so `nestedLineDeriv_comp_perm` at `n = 2` recovers
+`lineDeriv_lineDeriv_comm`. -/
+theorem nestedLineDeriv_two_apply (a b : E) (f : E → F) (x : E) :
+    nestedLineDeriv 𝕜 2 ![a, b] f x
+      = lineDeriv 𝕜 (fun y => lineDeriv 𝕜 f y b) x a := by
+  have ha : Fin.tail (![a, b] : Fin 2 → E) = ![b] := by
+    funext i
+    fin_cases i
+    rfl
+  rw [nestedLineDeriv_succ_apply, ha]
+  rfl
+
+end GateauxNested
+
 end FTCOQ02Incomplete01

--- a/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01/state.md
+++ b/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01/state.md
@@ -1,5 +1,31 @@
 # Research State: fundamental-theorem-calculus-oq-02-incomplete-01
 
+## S10 ACT 2026-07-24 (researcher-3) — general-n Gateaux nest [HOST + DOCKER VERIFIED]
+
+`section GateauxNested` (~896 → 1010 LOC): `nestedLineDeriv` (n-fold nested
+`lineDeriv`, direction `v 0` outermost, mirroring `nestedFDeriv`), simp lemmas
+(`_zero`, `_succ_apply`, `_one_apply`, `_two_apply` sanity bridge to S9's
+`lineDeriv_lineDeriv_comm` shape), and:
+
+- `nestedLineDeriv_eq_nestedFDeriv` — the Gateaux/Fréchet nest bridge for `C^n`
+  (any nontrivially normed field). Induction exactly as S8, one extra move per
+  level: rewrite the inner nest to the constant-tuple evaluation
+  `fun y => iteratedFDeriv 𝕜 n f y (tail v)` (S8 bridge), get
+  `DifferentiableAt` via `ContDiff.differentiable_iteratedFDeriv` +
+  `DifferentiableAt.continuousMultilinear_apply_const`, then
+  `DifferentiableAt.lineDeriv_eq_fderiv` upgrades the level to Fréchet.
+- `nestedLineDeriv_eq_iteratedFDeriv` — composed bridges.
+- `nestedLineDeriv_comp_perm` (+ `_of_minSmoothness`) — all-orders
+  Clairaut/Schwarz in the weakest-primitive spelling: only iterated
+  one-dimensional limits `d/dt g(x + t·w)|₀` appear in the statement.
+
+0 axioms / 0 sorries; `#print axioms` foundational trio; first-try compile.
+Fragment 1 nested development now spans: multilinear (S5–S7), Fréchet nest
+(S8), Within nest (S9), Gateaux nest (S10). Remaining live: Mathlib upstream
+PR (needs mathlib4 clone — out of host scope); possible S11 =
+`nestedLineDerivWithin` (Mathlib has `lineDerivWithin`) combining S9+S10;
+Fragments 2–6 (manifold Stokes) are DEEP multi-session.
+
 ## Current State
 
 **Phase**: ACT — **Fragment 1 COMPLETE** (researcher-3, 2026-07-24). S5 ACT shipped:

--- a/src/data/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01.json
+++ b/src/data/research/problems/fundamental-theorem-calculus-oq-02-incomplete-01.json
@@ -43,7 +43,7 @@
     "lastUpdate": "2026-07-24T17:55:00.000Z"
   },
   "knowledge": {
-    "progressSummary": "Fragment 1 (all-orders Schwarz/Clairaut for iteratedFDeriv) is COMPLETE and upstream-ready: S5 global C^n theorem over ℝ, S6 IsRCLikeNormedField/minSmoothness generalization, S7 full Within/UniqueDiffOn version, S8 classical nested directional-derivative layer (general-n nested/multilinear bridge + nested Clairaut + fderiv_fderiv_comm). 0 axioms, 0 sorries throughout. Remaining: an actual Mathlib PR (no mathlib4 checkout on this host), optional S9 Within/lineDeriv nested corollaries, and the DEEP Fragments 2-6 (manifold Stokes).",
+    "progressSummary": "PROGRESS: Fragment 1 nested development complete across multilinear (S5-S7), Frechet nest (S8), Within nest (S9), Gateaux nest (S10); remaining = Mathlib upstream PR or S11 nestedLineDerivWithin; Fragments 2-6 deep",
     "builtItems": [
       "S7 (researcher-3, 2026-07-24): full `Within`/`UniqueDiffOn` version added to `FundamentalTheoremCalculusOQ02Incomplete01.lean` — `iteratedFDerivWithin_comp_perm` (UniqueDiffOn s + s ⊆ closure (interior s), C^n on s, symmetry at every point of s incl. boundary), `iteratedFDerivWithin_comp_perm_of_convex` (convex sets w/ nonempty interior over ℝ: closed balls, Icc, simplices), `iteratedFDerivWithin_comp_perm_of_minSmoothness` (field-uniform), `iteratedFDerivWithin_domDomCongr`; whole induction redone with fderivWithin. 0 axioms, 0 sorries; host-verified on pinned v4.31.0 (rev 9a9483a929).",
       "S5 ACT (researcher-3 PR, 2026-07-24): `proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean` — `iteratedFDeriv_comp_perm` (C^n, finite smoothness, over R), plus `iteratedFDeriv_domDomCongr` and a C^infty specialization; 0 axioms, 0 sorries.",
@@ -59,7 +59,8 @@
       "nestedFDeriv + rfl-lemmas (zero/succ_apply/one_apply) in FundamentalTheoremCalculusOQ02Incomplete01.lean (S8)",
       "nestedFDeriv_eq_iteratedFDeriv: general-n nested/multilinear bridge, any NontriviallyNormedField (S8)",
       "nestedFDeriv_comp_perm + nestedFDeriv_comp_perm_of_minSmoothness: classical all-orders Clairaut, nested form (S8)",
-      "fderiv_fderiv_comm: C² nested second-derivative commutation (S8)"
+      "fderiv_fderiv_comm: C² nested second-derivative commutation (S8)",
+      "nestedLineDeriv + bridges + nestedLineDeriv_comp_perm(_of_minSmoothness) + _two_apply (section GateauxNested, S10)"
     ],
     "insights": [
       "FTC is represented as the 1D Stokes theorem with M=[a,b], omega=F, and d omega=F' dx.",
@@ -72,7 +73,8 @@
       "v4.31: smoothness-exponent notations (nat-infty-omega, omega, infty) are scoped[ContDiff]; files using minSmoothness need open scoped ContDiff even with import Mathlib. minSmoothness is irreducible_def — unfold via simp [minSmoothness, h].",
       "The general-n bridge between nested directional derivatives and iteratedFDeriv is a one-induction proof once fderiv_continuousMultilinear_apply_const_apply is known: the IH turns the inner nest into a CONSTANT CMM-application of D^n f, which commutes past fderiv; Mathlib had the bridge only at n=2 (iteratedFDeriv_two_apply).",
       "Mathlib Analysis/Distribution/DerivNotation.lean defines an abstract iterated line-derivative operator (LineDeriv.iteratedLineDerivOp, notation ∂^{v}) but provides NO instance for plain functions E → F and NO relation to iteratedFDeriv — the concrete nested/multilinear bridge was genuinely missing.",
-      "fderiv_fderiv_comm (nested C² Clairaut, evaluation INSIDE the outer derivative) is not IsSymmSndFDerivAt (evaluation OUTSIDE): the two differ exactly by the constant-application commutation step, and Mathlib has no lemma of the nested shape."
+      "fderiv_fderiv_comm (nested C² Clairaut, evaluation INSIDE the outer derivative) is not IsSymmSndFDerivAt (evaluation OUTSIDE): the two differ exactly by the constant-application commutation step, and Mathlib has no lemma of the nested shape.",
+      "S10: the Gateaux nest (nestedLineDeriv) equals the Frechet nest for C^n over any nontrivially normed field — per level, rewrite inner nest to constant-tuple evaluation of iteratedFDeriv (S8 bridge), DifferentiableAt.continuousMultilinear_apply_const, then lineDeriv_eq_fderiv. Weakest-primitive Clairaut: only iterated 1-D limits in the statement."
     ],
     "mathlibGaps": [
       "`iteratedFDeriv_comp_perm` for C^n (finite smoothness) functions is still absent from Mathlib v4.31 (only n=2 and the analytic case exist) — now proved in this slug's file; upstream candidate.",


### PR DESCRIPTION
## Summary

Research session S10 for `fundamental-theorem-calculus-oq-02-incomplete-01` (all-orders Schwarz/Clairaut): **the general-n Gateaux nest** — nested one-dimensional directional derivatives (`lineDeriv`) commute in any order for C^n functions. This is Clairaut/Schwarz in its weakest-primitive spelling: only iterated limits `d/dt g(x + t·w)|_0` appear in the statement.

## Progress

New `section GateauxNested` in `proofs/Proofs/FundamentalTheoremCalculusOQ02Incomplete01.lean` (~896 -> 1010 LOC):

- `nestedLineDeriv` — the n-fold nested Gateaux derivative, mirroring S8's `nestedFDeriv`, plus `_zero`/`_succ_apply`/`_one_apply`/`_two_apply` lemmas.
- `nestedLineDeriv_eq_nestedFDeriv` — the Gateaux/Frechet nest bridge for C^n over any nontrivially normed field: per level, the inner nest is the constant-tuple evaluation of the multilinear derivative (S8 bridge), which is Frechet differentiable (`ContDiff.differentiable_iteratedFDeriv` + `DifferentiableAt.continuousMultilinear_apply_const`), so `DifferentiableAt.lineDeriv_eq_fderiv` upgrades each Gateaux level.
- `nestedLineDeriv_eq_iteratedFDeriv` — composed bridges.
- `nestedLineDeriv_comp_perm` (+ `_of_minSmoothness` field-uniform form) — all-orders permutation symmetry of the Gateaux nest.

Fragment 1's nested development now spans all four spellings: multilinear (S5–S7), Frechet nest (S8), Within nest (S9, #43497), Gateaux nest (S10).

## Verification

- Host: `bin/lake env lean` exit 0, zero warnings, first-try compile.
- Docker: `docker-build.sh Proofs.FundamentalTheoremCalculusOQ02Incomplete01` green.
- `#print axioms` on the four key declarations = `[propext, Classical.choice, Quot.sound]`.

## Status

**Outcome**: progress — S10 complete, 0 axioms / 0 sorries.
**Next Steps**: Mathlib upstream PR for Fragment 1 (needs a mathlib4 checkout, out of host scope), or S11 `nestedLineDerivWithin`; Fragments 2–6 (manifold Stokes) remain deep multi-session work.

🤖 Generated by researcher-3
