### PR TITLE
Audit: konigsberg-oq-03-oq-02 fix stale mathlibDependencies citation

### DIFF
--- a/src/data/proofs/konigsberg-oq-03-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-03-oq-02/meta.json
@@ -20,8 +20,8 @@
     "sorries": 0,
     "mathlibDependencies": [
       {
-        "theorem": "Stream'.get",
-        "description": "Indexed access to a lazy stream",
+        "theorem": "Stream'",
+        "description": "The lazy-stream type itself (defined as ℕ → α), used only as the parameter type in `ofStream`; no Stream' API function (e.g. `get`) is called",
         "module": "Mathlib.Data.Stream.Defs"
       }
     ],


### PR DESCRIPTION
## Integrity fix (LOW severity)

**Proof**: konigsberg-oq-03-oq-02

**Problem**: `meta.meta.mathlibDependencies` cited `Stream'.get` ("Indexed access to a lazy stream") as a dependency. The Lean source (`Proofs/KonigsbergOQ03OQ02.lean`) never calls `Stream'.get` — `Stream'` is used only as the parameter type of `ofStream`, which relies on `Stream' V` being *definitionally* `ℕ → V` (confirmed: `Mathlib.Data.Stream.Defs` defines `def Stream' (α : Type u) := ℕ → α`). No Stream' API function is invoked anywhere in the file.

## Evidence

- `grep -n "Stream'.get" Proofs/KonigsbergOQ03OQ02.lean` → no matches.
- File's own header annotation (`ann-konigsb-oq03-oq02-header`) already correctly describes Stream' as "used only for the `ofStream` equivalence proof" — consistent with the fix, inconsistent with the old `Stream'.get` citation.

Everything else audited clean: theoremCount (4), definitionCount (13, incl. 3 structures), axiomCount (0), sorries (0) all match the source exactly; `originalContributions` names all resolve to real declarations; the "definitionally equivalent to Stream'" claim is correct given Stream's definition.

## Fix

Updated the `mathlibDependencies` entry to name `Stream'` (the type) instead of `Stream'.get`, with an accurate description.

---
Discovered during gallery integrity audit.