### PR TITLE
Research: combinations-formula-oq-03-oq-04 - Sylvester unimodality k=4 closed (exact band-recursion solution, 0-axiom)

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ03OQ04.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ03OQ04.lean
@@ -52,18 +52,28 @@ cancellation is q^{(k+1)(n-k)}·(1/q)^{k+1} = q^{(k+1)(n-k-1)}, valid since q �
       increments `qBinom_X_three_band`), with no `𝔰𝔩₂`/O'Hara input
 - [x] High-codimension cases `k ≥ n − 3` via `[n,k]_q = [n,n−k]_q`
       (`qBinomCoeff_unimodal_of_codim_le_three`)
-- [ ] OPEN: coefficient unimodality for the interior range `4 ≤ k ≤ n − 4`
-      (Sylvester/Proctor) — the substantive crux; first open instance `[8,4]_q`
+- [x] Coefficient unimodality, `k = 4` case (`qBinomCoeff_unimodal_four`) — the two-point
+      center-band recursion `u_{N+1} = δ(N+1) − v_N`, `v_{N+1} = δ(N) − u_N` (with `δ` the
+      `k = 3` box-free prefix increment) admits the exact closed solution `v ≡ 0`,
+      `u = δ` (`qBinom_X_four_band`); nonnegativity of the band increments is then the
+      already-proved `k = 3` first-half monotonicity
+- [x] High-codimension cases `k ≥ n − 4` via symmetry
+      (`qBinomCoeff_unimodal_of_codim_le_four`)
+- [ ] OPEN: coefficient unimodality for the interior range `5 ≤ k ≤ n − 5`
+      (Sylvester/Proctor) — the substantive crux; first open instance `[10,5]_q`
 
 ## Honesty Note
 This is the palindromy/symmetry ingredient plus the structural scaffolding
 (degree, monicity, coefficient nonnegativity, pinned extreme coefficients) AND the first
-unimodality content: the `Unimodal` predicate/API, the `k ≤ 3` cases (`k = 2` the first
-rise-then-fall array, `k = 3` the first box-crossing first half), and their `k ↦ n − k`
-mirrors. It does NOT prove unimodality in the interior range `4 ≤ k ≤ n − 4`, which is the
-remaining substantive content of the open question: there the center band of the recursion
-widens with `k` and the elementary bookkeeping no longer closes; the general case requires
-either an sl₂-action argument or O'Hara's combinatorial decomposition, not attempted here.
+unimodality content: the `Unimodal` predicate/API, the `k ≤ 4` cases (`k = 2` the first
+rise-then-fall array, `k = 3` the first box-crossing first half, `k = 4` the exactly
+solvable two-point band recursion), and their `k ↦ n − k` mirrors. It does NOT prove
+unimodality in the interior range `5 ≤ k ≤ n − 5`, which is the remaining substantive
+content of the open question. At `k = 5` the box growth step adds `5/2` indices per box —
+the band alternates between 2 and 3 points across parity classes, the compensating term is
+a `k = 4` increment that is itself only implicitly known, and the clean closed solution of
+the `k = 4` band has no evident analogue; the general case requires either an sl₂-action
+argument or O'Hara's combinatorial decomposition, not attempted here.
 
 ## Gaussian polynomial layer (over `ℤ[X]`)
 The palindromy above lives over a field (it uses `q⁻¹`). To reason about the actual
@@ -1148,6 +1158,209 @@ theorem qBinomCoeff_unimodal_of_codim_le_three {n k : ℕ} (hk : k ≤ n) (hnk :
   · exact qBinomCoeff_unimodal_of_codim_le_two hk (by omega)
   · rw [qBinom_symm (X : ℤ[X]) n k hk, show n - k = 3 from by omega]
     exact qBinomCoeff_unimodal_three n
+
+/-! ### `k = 4`: first-half monotonicity via the two-point center-band recursion
+
+The `k = 3` template extends to `k = 4` — with a *different, and strikingly clean*, band
+solution.  Write the box as `4×N` (`n = N + 4`, degree `4N`, midpoint `2N`).  The dual
+`q`-Pascal form gives the recurrence
+
+  `coeff j [N+5,4] = coeff j [N+4,4] + [N+1 ≤ j]·coeff (j-(N+1)) [N+4,3]`,
+
+whose correction term is a **`k = 3` coefficient** — exactly known on its box-free prefix
+(indices `≤ N+1`), which is the only range the first-half argument ever touches.  Growing
+the box `N → N+1` extends the first half by exactly **two** indices `j = 2N, 2N+1` (the
+center band); everywhere below the band, monotonicity is (IH) + (`k = 3` first-half
+increment `≥ 0`, `qBinom_X_three_coeff_first_half_mono`).
+
+For the band itself, let `u_N, v_N` denote the last two first-half increments of the
+`4×N` array and `δ(N) = p₃(N) − p₃(N-1)` the `k = 3` box-free prefix increment (the
+number of partitions of `N` into parts `2` and `3`, though the closed form is never
+needed).  Palindromy reflects the just-past-half increments onto `−u_N, −v_N`, so the
+recurrence collapses the band to the two-term linear recursion
+
+  `u_{N+1} = δ(N+1) − v_N`,   `v_{N+1} = δ(N) − u_N`,
+
+which has the exact closed solution **`v_N = 0` and `u_N = δ(N)`** — the pattern visible
+in the data (`[8,4]_q = 1,1,2,3,5,5,7,7,8,…`: increments `…,0,2,0,1` end in `v = 0`,
+`u = 1 = δ(4)`).  Nonnegativity of the band increments is then exactly the already-proved
+`k = 3` first-half monotonicity.  No `𝔰𝔩₂`/O'Hara input: the quantitative compensation
+those tools provide is, at `k = 4`, the identity `v ≡ 0`. -/
+
+open Polynomial in
+/-- **The second-form `k = 4` coefficient recurrence.**  From the dual `q`-Pascal identity
+`[N+5,4]_q = q^{N+1}·[N+4,3]_q + [N+4,4]_q` (`qBinom_pascal'` at `k = 3`), the coefficient
+array of the `4×(N+1)` box is the `4×N` array plus the `q^{N+1}`-shifted `k = 3` array:
+
+  `(qBinom X (N+5) 4).coeff j = (qBinom X (N+4) 4).coeff j + [N+1 ≤ j]·(qBinom X (N+4) 3).coeff (j-(N+1))`.
+
+The correction term is a `k = 3` coefficient — fully understood on its box-free prefix,
+which is the only range the `k = 4` first-half argument needs. -/
+theorem qBinom_X_four_coeff_succ' (N j : ℕ) :
+    (qBinom (X : ℤ[X]) (N + 5) 4).coeff j
+      = (qBinom (X : ℤ[X]) (N + 4) 4).coeff j
+        + (if N + 1 ≤ j then (qBinom (X : ℤ[X]) (N + 4) 3).coeff (j - (N + 1)) else 0) := by
+  have hp := qBinom_pascal' (X : ℤ[X]) (N + 4) 3 (by omega)
+  rw [show N + 4 + 1 = N + 5 from by omega, show N + 4 - 3 = N + 1 from by omega,
+      show (3 : ℕ) + 1 = 4 from by omega] at hp
+  rw [hp, coeff_add, mul_comm (X ^ (N + 1)) (qBinom (X : ℤ[X]) (N + 4) 3),
+      coeff_mul_X_pow']
+  ring
+
+open Polynomial in
+/-- **The `k = 4` center-band recursion — exact solution.**  For every `N`, in the
+`4×(N+1)` box array (the polynomial `[N+5,4]_q`, degree `4N+4`, midpoint `2N+2`):
+
+* (`v` band point) `coeff (2N+1) = coeff (2N)` — the first band increment is exactly `0`;
+* (`u` band point) `coeff (2N+2) = coeff (2N+1) + (coeff (N+1) [N+4,3] − coeff N [N+4,3])`
+  — the second band increment is exactly the `k = 3` box-free prefix increment `δ(N+1)`.
+
+Joint induction on `N`.  The step writes both band coefficients of the `4×(N+2)` box over
+the `4×(N+1)` box via `qBinom_X_four_coeff_succ'`; palindromy of the `4×(N+1)` array
+reflects the just-past-half indices back onto the band, where the `u`/`v` values from the
+induction hypothesis cancel the reflected terms exactly; the `k = 3` prefix stability
+(second-form `k = 3` recurrence, correction absent below the shift) identifies the two
+`δ` normalisations.  Base case: `[5,4]_q = [5,1]_q` and `[4,3]_q = [4,1]_q` are flat
+`1`-sequences. -/
+theorem qBinom_X_four_band :
+    ∀ N : ℕ,
+      ((qBinom (X : ℤ[X]) (N + 5) 4).coeff (2 * N + 1)
+          = (qBinom (X : ℤ[X]) (N + 5) 4).coeff (2 * N))
+      ∧ ((qBinom (X : ℤ[X]) (N + 5) 4).coeff (2 * N + 2)
+          = (qBinom (X : ℤ[X]) (N + 5) 4).coeff (2 * N + 1)
+            + ((qBinom (X : ℤ[X]) (N + 4) 3).coeff (N + 1)
+                - (qBinom (X : ℤ[X]) (N + 4) 3).coeff N))
+  | 0 => by
+      have h54 : qBinom (X : ℤ[X]) 5 4 = qBinom (X : ℤ[X]) 5 1 := by
+        rw [qBinom_symm (X : ℤ[X]) 5 4 (by omega)]
+      have h43 : qBinom (X : ℤ[X]) 4 3 = qBinom (X : ℤ[X]) 4 1 := by
+        rw [qBinom_symm (X : ℤ[X]) 4 3 (by omega)]
+      refine ⟨?_, ?_⟩ <;> norm_num [h54, h43, qBinom_X_coeff_one_seq]
+  | N + 1 => by
+      obtain ⟨hv, hu⟩ := qBinom_X_four_band N
+      have h2 := qBinom_X_four_coeff_succ' (N + 1) (2 * N + 2)
+      have h3 := qBinom_X_four_coeff_succ' (N + 1) (2 * N + 3)
+      have h4 := qBinom_X_four_coeff_succ' (N + 1) (2 * N + 4)
+      rw [show N + 1 + 5 = N + 6 from by omega, show N + 1 + 4 = N + 5 from by omega,
+          show N + 1 + 1 = N + 2 from by omega] at h2 h3 h4
+      rw [if_pos (show N + 2 ≤ 2 * N + 2 from by omega),
+          show 2 * N + 2 - (N + 2) = N from by omega] at h2
+      rw [if_pos (show N + 2 ≤ 2 * N + 3 from by omega),
+          show 2 * N + 3 - (N + 2) = N + 1 from by omega] at h3
+      rw [if_pos (show N + 2 ≤ 2 * N + 4 from by omega),
+          show 2 * N + 4 - (N + 2) = N + 2 from by omega] at h4
+      -- palindromy of the `4×(N+1)` array: reflect the just-past-half indices
+      have hp3 := qBinom_X_coeff_symm' (n := N + 5) (k := 4) (by omega)
+        (j := 2 * N + 1) (by omega)
+      rw [show 4 * (N + 5 - 4) - (2 * N + 1) = 2 * N + 3 from by omega] at hp3
+      have hp4 := qBinom_X_coeff_symm' (n := N + 5) (k := 4) (by omega)
+        (j := 2 * N) (by omega)
+      rw [show 4 * (N + 5 - 4) - (2 * N) = 2 * N + 4 from by omega] at hp4
+      -- `k = 3` prefix stability: the two `δ` normalisations agree below the shift
+      have hs0 := qBinom_X_three_coeff_succ' (N + 1) N
+      have hs1 := qBinom_X_three_coeff_succ' (N + 1) (N + 1)
+      rw [show N + 1 + 4 = N + 5 from by omega, show N + 1 + 3 = N + 4 from by omega,
+          show N + 1 + 1 = N + 2 from by omega,
+          if_neg (show ¬ (N + 2 ≤ N) from by omega), add_zero] at hs0
+      rw [show N + 1 + 4 = N + 5 from by omega, show N + 1 + 3 = N + 4 from by omega,
+          show N + 1 + 1 = N + 2 from by omega,
+          if_neg (show ¬ (N + 2 ≤ N + 1) from by omega), add_zero] at hs1
+      rw [show N + 1 + 5 = N + 6 from by omega, show N + 1 + 4 = N + 5 from by omega,
+          show 2 * (N + 1) + 1 = 2 * N + 3 from by omega,
+          show 2 * (N + 1) + 2 = 2 * N + 4 from by omega,
+          show 2 * (N + 1) = 2 * N + 2 from by omega,
+          show N + 1 + 1 = N + 2 from by omega]
+      constructor
+      · linarith [h2, h3, hp3, hu, hs0, hs1]
+      · linarith [h3, h4, hp3, hp4, hv, hs1]
+
+open Polynomial in
+/-- **First-half monotonicity for `k = 4` — the full inequality.**  For every `N` and every
+`j` in the first half (`2j + 2 ≤ 4N`), the coefficient array of the `4×N` box satisfies
+`coeff j ≤ coeff (j+1)`.  Induction on `N` via the second-form recurrence
+`qBinom_X_four_coeff_succ'`:
+
+* below the previous box's first half the increment is (IH) + (`k = 3` first-half
+  increment `≥ 0`, `qBinom_X_three_coeff_first_half_mono` — the shifted index always lands
+  in the `k = 3` first half);
+* at the two center-band indices `j = 2N, 2N+1` the increment is the exact value from
+  `qBinom_X_four_band` (`0`, resp. the `k = 3` prefix increment `δ(N+1) ≥ 0`).
+
+This settles the genuinely box-binding range of Sylvester's first-half inequality at
+`k = 4` elementarily. -/
+theorem qBinom_X_four_coeff_first_half_mono :
+    ∀ (N j : ℕ), 2 * j + 2 ≤ 4 * N →
+      (qBinom (X : ℤ[X]) (N + 4) 4).coeff j
+        ≤ (qBinom (X : ℤ[X]) (N + 4) 4).coeff (j + 1)
+  | 0, j, hj => by omega
+  | N + 1, j, hj => by
+      rcases Nat.lt_or_ge (2 * j + 2) (4 * N + 1) with hin' | hband'
+      · -- interior: previous box's first half; recurrence + IH + `k = 3` increment
+        have hin : 2 * j + 2 ≤ 4 * N := by omega
+        have hIH := qBinom_X_four_coeff_first_half_mono N j hin
+        have h1 := qBinom_X_four_coeff_succ' N j
+        have h2 := qBinom_X_four_coeff_succ' N (j + 1)
+        rw [show N + 1 + 4 = N + 5 from by omega, h1, h2]
+        rcases Nat.lt_or_ge (j + 1) (N + 1) with hlt | hge
+        · -- both correction terms vanish
+          rw [if_neg (show ¬ (N + 1 ≤ j) from by omega),
+              if_neg (show ¬ (N + 1 ≤ j + 1) from by omega)]
+          simpa using hIH
+        · rcases eq_or_lt_of_le hge with heq | hgt
+          · -- `j + 1 = N + 1`: right correction is `coeff 0 ≥ 0`
+            rw [if_neg (show ¬ (N + 1 ≤ j) from by omega),
+                if_pos (show N + 1 ≤ j + 1 from by omega),
+                show j + 1 - (N + 1) = 0 from by omega]
+            have h0 := qBinom_X_coeff_nonneg (N + 4) 3 0
+            linarith
+          · -- `N + 1 ≤ j`: both corrections are `k = 3` coefficients in its first half
+            rw [if_pos (show N + 1 ≤ j from by omega),
+                if_pos (show N + 1 ≤ j + 1 from by omega)]
+            have hd := qBinom_X_three_coeff_first_half_mono (N + 1) (j - (N + 1))
+              (by omega)
+            rw [show N + 1 + 3 = N + 4 from by omega,
+                show j - (N + 1) + 1 = j + 1 - (N + 1) from by omega] at hd
+            linarith
+      · -- center band of the `4×(N+1)` box: exact increments from the band recursion
+        rw [show N + 1 + 4 = N + 5 from by omega]
+        obtain ⟨hv, hu⟩ := qBinom_X_four_band N
+        have hj' : j = 2 * N ∨ j = 2 * N + 1 := by omega
+        rcases hj' with rfl | rfl
+        · exact hv.ge
+        · have hd := qBinom_X_three_coeff_first_half_mono (N + 1) N (by omega)
+          rw [show N + 1 + 3 = N + 4 from by omega] at hd
+          rw [show 2 * N + 1 + 1 = 2 * N + 2 from by omega]
+          linarith [hu]
+
+open Polynomial in
+/-- **Sylvester's unimodality theorem, `k = 4`.**  The coefficient sequence of
+`[n choose 4]_q` is unimodal for every `n` — settled elementarily by the exact solution
+`v ≡ 0`, `u = δ` of the two-point center-band recursion (no `𝔰𝔩₂`-representation theory
+or O'Hara decomposition).  For `n < 4` the polynomial is `0`; otherwise feed
+`qBinom_X_four_coeff_first_half_mono` to the general reduction
+`qBinomCoeff_unimodal_of_first_half_mono`. -/
+theorem qBinomCoeff_unimodal_four (n : ℕ) :
+    Unimodal (fun j => (qBinom (X : ℤ[X]) n 4).coeff j) := by
+  rcases Nat.lt_or_ge n 4 with hn | hn
+  · have hz : qBinom (X : ℤ[X]) n 4 = 0 := qBinom_eq_zero_of_lt (X : ℤ[X]) n 4 (by omega)
+    simpa [hz] using unimodal_const (0 : ℤ)
+  · obtain ⟨N, rfl⟩ : ∃ N, n = N + 4 := ⟨n - 4, by omega⟩
+    apply qBinomCoeff_unimodal_of_first_half_mono (show 4 ≤ N + 4 from by omega)
+    intro j hj
+    exact qBinom_X_four_coeff_first_half_mono N j (by omega)
+
+open Polynomial in
+/-- **Sylvester unimodality for `k ≤ 4` and for codimension `≤ 4`.**  Combining the closed
+cases with `qBinomCoeff_unimodal_four` and the symmetry `[n,k]_q = [n,n−k]_q`: the
+coefficient sequence of `[n choose k]_q` is unimodal whenever `k ≤ 4` or `k ≥ n − 4`.
+The open range of Sylvester's theorem in this development is now the interior
+`5 ≤ k ≤ n − 5` (first genuinely open instance: `[10,5]_q`). -/
+theorem qBinomCoeff_unimodal_of_codim_le_four {n k : ℕ} (hk : k ≤ n) (hnk : n - 4 ≤ k) :
+    Unimodal (fun j => (qBinom (X : ℤ[X]) n k).coeff j) := by
+  rcases Nat.lt_or_ge (n - k) 4 with h3 | h4
+  · exact qBinomCoeff_unimodal_of_codim_le_three hk (by omega)
+  · rw [qBinom_symm (X : ℤ[X]) n k hk, show n - k = 4 from by omega]
+    exact qBinomCoeff_unimodal_four n
 
 end QBinomialCoefficients
 

--- a/research/problems/combinations-formula-oq-03-oq-04/knowledge.md
+++ b/research/problems/combinations-formula-oq-03-oq-04/knowledge.md
@@ -147,3 +147,40 @@ Lean idioms: canonicalize every index with `rw [show a = b from by omega]` BEFOR
 + if M % 2 = 0 then 1 else 0` via `by_cases` + `exact_mod_cast (by omega)`; equation-compiler
 mutual recursion packaged as `∀ M, O M ∧ E2 M` with helper `E2_of_O`. GOTCHA: `le_or_lt` is
 gone at v4.31-era Mathlib — use `Nat.lt_or_ge` (bare `lt_or_ge`/`eq_or_lt_of_le` still exist).
+
+## Session 2026-07-24 (researcher-1): k = 4 closed — exact solution of the two-point band recursion
+
+Sylvester unimodality for `[n,4]_q` (`qBinomCoeff_unimodal_four`) + codim-4 mirror
+(`qBinomCoeff_unimodal_of_codim_le_four`). 5 new theorems, 0 ax / 0 sorry,
+host-verified first try. Open interior now `5 ≤ k ≤ n−5` (first instance `[10,5]_q`).
+
+Key idea: for `4×N` boxes the box-growth step adds exactly TWO first-half indices.
+Writing `u_N, v_N` for the last two first-half increments and `δ(N)` for the k=3
+box-free prefix increment, palindromy turns the dual-Pascal recurrence into the
+linear band recursion `u_{N+1} = δ(N+1) − v_N`, `v_{N+1} = δ(N) − u_N`, which has
+the EXACT closed solution `v ≡ 0`, `u = δ`. Band nonnegativity is then literally
+k=3 first-half monotonicity — the k=3 theorem is consumed as a black box, and no
+closed form for δ (= #partitions into 2s and 3s) is ever needed.
+
+Lean recipe (all landed in `CombinationsFormulaOQ03OQ04.lean`):
+- `qBinom_X_four_coeff_succ'` — mirror of the k=3 second-form recurrence, verbatim
+  recipe (`qBinom_pascal'` + `mul_comm` + `coeff_mul_X_pow'` + `ring`).
+- `qBinom_X_four_band` — joint `∀ N, (v) ∧ (u)` equation-compiler induction, base
+  via `qBinom_symm` to `[5,4]=[5,1]`, `[4,3]=[4,1]` + `qBinom_X_coeff_one_seq` +
+  `norm_num`; step = 3 recurrence instances + 2 palindromy reflections
+  (`qBinom_X_coeff_symm'`) + 2 prefix-stability facts (k=3 `succ'` with `if_neg`,
+  `add_zero`) + `linarith`. Index canonicalization via `rw [show a = b from by
+  omega]` throughout (the established file idiom).
+- `qBinom_X_four_coeff_first_half_mono` — same case skeleton as the k=3 analogue:
+  interior (IH + k=3 increment; shifted index `j−(N+1) ≤ N−2` always inside the
+  k=3 first half since `2(N−2)+2 ≤ 3(N+1)`) then two band points from the band
+  theorem.
+
+No new gotchas — the session compiled green on the first `lake env lean` run,
+entirely by following the k=3 template + the memory-file idioms.
+
+**k=5 wall (analyzed, honest):** box step adds 5/2 indices (band alternates 2/3
+by parity), and the reflected increments hit interior near-center k=4 increments
+that `u = δ, v = 0` does NOT pin (only the last two are known). No evident closed
+solution; the linear-recursion trick as-is does not extend. Next session should
+verify this concretely before attempting anything.

--- a/research/problems/combinations-formula-oq-03-oq-04/state.md
+++ b/research/problems/combinations-formula-oq-03-oq-04/state.md
@@ -4,7 +4,39 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-09T16:03:14-07:00
-**Iteration**: 2
+**Iteration**: 8
+
+## Status (S8, researcher-1, 2026-07-24) — k = 4 CLOSED: exact solution of the two-point band recursion
+
+`qBinomCoeff_unimodal_four (n) : Unimodal (coeff [n,4]_q)` and
+`qBinomCoeff_unimodal_of_codim_le_four (hk : k ≤ n) (hnk : n−4 ≤ k)` — 5 new thms
+(`qBinom_X_four_coeff_succ'`, `qBinom_X_four_band`,
+`qBinom_X_four_coeff_first_half_mono`, + the two above), 0 ax, 0 sorry,
+host-verified v4.31 first try (`lake env lean` exit 0; `#print axioms` =
+`[propext, Classical.choice, Quot.sound]` on all 5). Sylvester unimodality now
+covers `k ≤ 4 ∨ k ≥ n−4`; the open interior is `5 ≤ k ≤ n−5` (first instance
+`[10,5]_q`).
+
+**Mechanism (the k=4 surprise — cleaner than k=3):** dual-Pascal recurrence
+`coeff j [N+5,4] = coeff j [N+4,4] + [N+1 ≤ j]·coeff (j−(N+1)) [N+4,3]`. Growing
+the box adds exactly TWO first-half indices (the band). With `u_N, v_N` the last
+two first-half increments of the `4×N` array and `δ(N)` the k=3 box-free prefix
+increment (`p₃(N)−p₃(N−1)`, = #partitions of N into 2s and 3s, closed form never
+needed), palindromy reflects the just-past-half increments onto `−u_N, −v_N`,
+giving the linear band recursion `u_{N+1} = δ(N+1) − v_N`, `v_{N+1} = δ(N) − u_N`
+with EXACT closed solution `v ≡ 0`, `u = δ` (verified base `[5,4]=[5,1]` flat).
+Band nonnegativity is then literally the k=3 first-half monotonicity — no new
+analytic input. Below the band: IH + k=3 first-half increment ≥ 0 (the shifted
+index always lands in the k=3 first half: `j−(N+1) ≤ N−2 < ⌈3(N+1)/2⌉`).
+δ box-independence = k=3 prefix stability, inlined via `qBinom_X_three_coeff_succ'`
+if_neg (no new lemma).
+
+**Why k=5 does NOT follow the same way (recorded honestly):** the box step adds
+5/2 indices — the band alternates 2/3 points across parity classes, the
+compensating term is a k=4 increment that is itself only implicitly known
+(`u = δ` gives the LAST band increment but not the interior near-center ones the
+reflection would hit), and no analogue of the exact `v ≡ 0` solution is evident.
+The general interior needs sl₂/O'Hara (existing blocked-route entry stands).
 
 ## Status (S4, researcher-1, 2026-07-21) — high-codimension cases k ≥ n−2 closed via symmetry
 
@@ -64,12 +96,15 @@ removed the last *structural* obstacle for all remaining k:
 Both 0-axiom / 0-sorry, host-verified (`lake env lean` exit 0, axioms
 `[propext, Classical.choice, Quot.sound]`).
 
-## Next Action (item toward k = 3)
-`[n,3]_q` = generating function of partitions in a `3×(n-3)` box. Derive the first-half
-coefficient behaviour (`coeff` weakly increasing up to `⌊3(n-3)/2⌋`) and feed it to
-`qBinomCoeff_unimodal_of_first_half_mono`. The degree `3(n-3)` is odd exactly when `n` is
-even, so this is the first case that genuinely exercises the new odd-degree branch. The
-first-half monotonicity itself remains the open crux (sl₂ / O'Hara).
+## Next Action
+The elementary per-k ladder has now closed k ∈ {0,1,2,3,4} and codim ≤ 4. A k=5
+session should FIRST check whether the band analysis extends: derive the 2/3-point
+band structure for `5×N` boxes, express the reflected increments via the k=4 band
+solution (`u = δ`, `v = 0`), and see whether the resulting linear recursion again
+has a closed solution. If the interior near-center k=4 increments (not covered by
+`u = δ`) are needed, that is the wall — record it as the blocked-route extension
+and stop. The general interior `5 ≤ k ≤ n−5` remains sl₂/O'Hara territory
+(existing blocked-route entry: "materially new mechanism required").
 
 ## --- S1 template (never filled) below ---
 

--- a/src/data/research/problems/combinations-formula-oq-03-oq-04.json
+++ b/src/data/research/problems/combinations-formula-oq-03-oq-04.json
@@ -710,7 +710,11 @@
       "BREAKTHROUGH mechanism (reopens the k>=3 elementary block legitimately): the SECOND q-Pascal form [N+4,3] = [N+3,3] + q^(N+1)[N+3,2] (qBinom_pascal-prime, already in OQ03) makes the increment correction the UNSHIFTED k=2 ramp, exactly known — unlike the first form whose shifted term crosses the [n,2] peak uncontrolled",
       "Center-band recursion: the first half of box 3x(N+1) extends past box 3xN by at most TWO indices; there the smaller-box increment is exact via palindromy (odd-degree center pair = 0; even-box pair reflects onto the PREVIOUS band). Band increments: odd box 2M+1 at j=3M: 0; even box 2M+2 at j=3M+1,3M+2: [M even],[M odd] — all 0/1, period-2 self-contained induction",
       "Sylvester k=3 is now CLOSED elementarily (no sl2/OHara): qBinomCoeff_unimodal_three; with symmetry the open range shrinks to interior 4<=k<=n-4, first open instance [8,4]_q",
-      "Why k=4 does not fall to the same trick: the center band widens (about k-1 indices) and the increments needed there are no longer exactly-known ramp parities — the recursion would need exact k=3 band VALUES at general offsets, i.e. the quasi-polynomial P3, which is where sl2/OHara re-enter"
+      "Why k=4 does not fall to the same trick: the center band widens (about k-1 indices) and the increments needed there are no longer exactly-known ramp parities — the recursion would need exact k=3 band VALUES at general offsets, i.e. the quasi-polynomial P3, which is where sl2/OHara re-enter",
+      "k=4 band recursion is EXACTLY solvable: with u_N, v_N the last two first-half increments of the 4xN box and delta(N) the k=3 box-free prefix increment, palindromy gives u_{N+1} = delta(N+1) - v_N, v_{N+1} = delta(N) - u_N, with closed solution v = 0, u = delta. Band nonnegativity reduces to the k=3 first-half monotonicity consumed as a black box.",
+      "For 4xN boxes the box-growth step adds exactly 2 first-half indices, and the shifted k=3 correction index j-(N+1) <= N-2 always lands inside the k=3 first half (2(N-2)+2 <= 3(N+1)) — so below the band, monotonicity is pure IH + k=3 increment.",
+      "delta box-independence (k=3 prefix stability) needs no new lemma: qBinom_X_three_coeff_succ' with if_neg + add_zero inlines it.",
+      "k=5 does NOT extend the same way: the box step adds 5/2 indices (band alternates 2/3 by parity) and the reflected increments hit interior near-center k=4 increments that the u=delta, v=0 solution does not pin. No evident closed solution — the general interior 5<=k<=n-5 stays sl2/O.Hara territory."
     ],
     "builtItems": [
       "qBinom_reciprocal (CombinationsFormulaOQ03OQ04.lean): [n,k]_q = q^{k(n-k)} times [n,k]_{q inverse} over a field, induction on n using both q-Pascal identities",
@@ -734,7 +738,12 @@
       "qBinom_X_three_coeff_succ-prime (second-form k=3 coefficient recurrence) in CombinationsFormulaOQ03OQ04.lean",
       "qBinom_X_three_center_pair/outer_pair/even_pair (palindromy reflection pairs), qBinom_X_three_band_O_zero, qBinom_X_three_band_E2_of_O, qBinom_X_three_band (O and E2 mutual recursion), qBinom_X_three_band_E1",
       "qBinom_X_three_coeff_first_half_mono (FULL k=3 first-half monotonicity, box-binding tail included)",
-      "qBinomCoeff_unimodal_three, qBinomCoeff_unimodal_of_codim_le_three (Sylvester closed for k<=3 and k>=n-3)"
+      "qBinomCoeff_unimodal_three, qBinomCoeff_unimodal_of_codim_le_three (Sylvester closed for k<=3 and k>=n-3)",
+      "qBinom_X_four_coeff_succ' (second-form k=4 coefficient recurrence) in CombinationsFormulaOQ03OQ04.lean",
+      "qBinom_X_four_band (exact two-point center-band solution v=0, u=delta) in CombinationsFormulaOQ03OQ04.lean",
+      "qBinom_X_four_coeff_first_half_mono (full k=4 first-half inequality) in CombinationsFormulaOQ03OQ04.lean",
+      "qBinomCoeff_unimodal_four (Sylvester unimodality k=4) in CombinationsFormulaOQ03OQ04.lean",
+      "qBinomCoeff_unimodal_of_codim_le_four (k <= 4 or k >= n-4) in CombinationsFormulaOQ03OQ04.lean"
     ],
     "mathlibGaps": [
       "No direct need: proof uses only parent q-binomial API plus elementary field/power lemmas (mul_inv_cancel_left_zero, inv_pow, pow_ne_zero, pow_add).",
@@ -748,7 +757,7 @@
       "Attempt unimodality proper: sl₂ raising/lowering operator action (Proctor 1982) or an O'Hara-style explicit injection between adjacent coefficient levels.",
       "k=3 box-binding tail N<j<=floor((3N-2)/2): needs strict/quantitative monotonicity or an explicit injection (OHara k=3 special case) to compensate the negative [n,2] increment past its peak. Assess an explicit-formula route: coeff_{n,3}(j) via inclusion-exclusion a_N(j)=P3(j)-P3(j-N-1)-... with P3(j)=round((j+3)^2/12), then finite-difference monotonicity on the tail."
     ],
-    "progressSummary": "MAJOR: Sylvester unimodality k=3 CLOSED elementarily (researcher-1, 2026-07-22, lake env lean exit 0, 0-axiom). Second q-Pascal form + center-band recursion (band increments exactly 0/1 by palindromy + k=2 ramp parity) settles the box-binding tail the 07-21 session left open — no sl2/OHara needed at k=3. Sylvester now proved for k<=3 and k>=n-3; open range = interior 4<=k<=n-4 (first instance [8,4]_q), where the band widens and genuinely needs sl2/OHara."
+    "progressSummary": "PROGRESS: Sylvester unimodality closed for k <= 4 and codim <= 4 (0 axioms, 0 sorries throughout). k=4 fell via the exactly-solvable two-point band recursion (v=0, u=delta); open interior is now 5 <= k <= n-5 (first instance [10,5]_q), which needs either a genuinely new band mechanism or sl2/O.Hara."
   },
   "currentState": "Bridged the two forked unimodality predicates (researcher-1): isCoeffUnimodal_iff_unimodal_coeff proves IsCoeffUnimodal p ↔ Unimodal p.coeff, unifying CombinationsFormulaOQ03OQ04Unimodal.lean (IsCoeffUnimodal, was k≤1) with CombinationsFormulaOQ03OQ04.lean (Unimodal, has k=0,1,2 + palindrome criterion). k=2 transported (qBinom_X_unimodal_two), no re-proof. 0 axioms. k≥3 open.",
   "lastUpdate": "2026-07-22",


### PR DESCRIPTION
## Summary
Research session for combinations-formula-oq-03-oq-04 (Sylvester unimodality of Gaussian binomial coefficients). **k = 4 is closed**: the coefficient sequence of `[n,4]_q` is unimodal for every n, and via symmetry so is every case with codimension <= 4. The open interior of Sylvester's theorem in this development is now `5 <= k <= n-5` (first open instance `[10,5]_q`).

## Progress
Five new theorems appended to `proofs/Proofs/CombinationsFormulaOQ03OQ04.lean` (1153 -> ~1350 lines), all 0-axiom / 0-sorry, host-verified on v4.31 (`lake env lean` exit 0, first try; `#print axioms` = `[propext, Classical.choice, Quot.sound]` on all five):

- `qBinom_X_four_coeff_succ'` — second-form k=4 coefficient recurrence from the dual q-Pascal identity; the correction term is a k=3 coefficient.
- `qBinom_X_four_band` — **the k=4 center-band recursion has an exact closed solution.** Growing the `4xN` box adds exactly two first-half indices. With `u_N, v_N` the last two first-half increments and `delta(N)` the k=3 box-free prefix increment, palindromy collapses the recurrence to `u_{N+1} = delta(N+1) - v_N`, `v_{N+1} = delta(N) - u_N`, whose solution is exactly `v = 0`, `u = delta`. Band nonnegativity is then literally the already-proved k=3 first-half monotonicity — consumed as a black box, no closed form for delta needed.
- `qBinom_X_four_coeff_first_half_mono` — the full k=4 first-half inequality (below the band: IH + k=3 increment; the shifted index always lands in the k=3 first half).
- `qBinomCoeff_unimodal_four` — Sylvester's theorem at k=4.
- `qBinomCoeff_unimodal_of_codim_le_four` — coverage `k <= 4 or k >= n-4` via `[n,k]_q = [n,n-k]_q`.

No sl2-representation theory or O'Hara decomposition input — the quantitative compensation those tools supply is, at k=4, the identity `v = 0`.

## Findings
- The k=3 center-band template not only extends to k=4 — it gets *cleaner*: the band values satisfy a two-term linear recursion with an exact closed solution, so the whole case rests on k=3 monotonicity.
- **k=5 wall (recorded honestly in state.md/knowledge.md):** the box step adds 5/2 indices per step (the band alternates between 2 and 3 points by parity), and the palindromy reflections hit interior near-center k=4 increments that `u = delta, v = 0` does not pin. The linear-recursion trick as-is does not extend; the existing sl2/O'Hara blocked-route entry stands for the general interior.

## Files Modified
- `proofs/Proofs/CombinationsFormulaOQ03OQ04.lean` (+5 theorems, header status updated)
- `research/problems/combinations-formula-oq-03-oq-04/state.md` (S8 status), `knowledge.md` (session recipe)
- `src/data/research/problems/combinations-formula-oq-03-oq-04.json` (4 insights, 5 builtItems, progressSummary)

## Status
**Outcome**: progress (k=4 + codim-4 closed; interior 5 <= k <= n-5 remains open)
**Next Steps**: a k=5 session should first check concretely whether any band analysis survives the 2/3-point alternation before attempting a proof; otherwise the problem is at its elementary ceiling pending sl2/O'Hara infrastructure.

Housekeeping: stale PR #39342 (k=1 snapshot, CONFLICTING, content merged long ago via #39438/#39392) flagged for closure by comment — `gh pr close` is permission-gated for agents.

🤖 Generated by researcher-1
