### PR TITLE
Enrich chebyshev-sum-inequality-oq-01-oq-03-oq-03: add header section (98->100)

### DIFF
--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-03-oq-03/meta.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-03-oq-03/meta.json
@@ -100,6 +100,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Overview: the probabilistic reading of Chebyshev's inequality",
+      "startLine": 1,
+      "endLine": 66,
+      "summary": "Imports the parent module and states the plan in the module docstring: recast the parent's deterministic inequality (∫f)(∫g) ≤ (b−a)∫fg as Cov(f(X),g(X)) ≥ 0 for X uniform on [a,b] and f, g monotone, then connect it to the Harris–FKG correlation inequality — on the totally ordered chain [a,b] the FKG log-supermodularity hypothesis is automatic, so FKG collapses to exactly this covariance statement.",
+      "mathContext": "$\\mathrm{Cov}(f(X),g(X)) = E[fg]-E[f]E[g] \\ge 0$ for monotone $f,g$; the chain case of Harris–FKG."
+    },
+    {
       "id": "definitions",
       "title": "Uniform-law expectation and covariance",
       "startLine": 67,


### PR DESCRIPTION
## Summary

The entry's `sections[]` covered lines 67-123 of `ChebyshevCovarianceOQ010303.lean` but left the module docstring (lines 1-66, which already has a matching annotation `ann-cheby-cov-header`) with no corresponding section — the sole gap keeping the quality-tracker score at 98/100 (sections: 4 × 2 = 8/10 vs. cap 10/10). Added a `header` section for lines 1-66 summarizing the module's stated plan (recast the parent's deterministic Chebyshev inequality as a covariance/FKG statement), so `sections[]` now covers the full 125-line file.

No other content changed; all existing keyInsights, annotations, conclusion, and cross-references preserved as-is.

## Verification

- `meta.json` parses as valid JSON, 15.6 KB (well under the 60 KB cap)
- `pnpm build`'s gallery/data steps (`gallery:check-size`, `annotations:build`, `research:build`, `gallery:check-search-index`, `gallery:loading-facts`, `gallery:build-redirects`) all ran cleanly against the updated file
- `tsc -b` could not complete in this worktree due to a pre-existing, unrelated infra gap (`node_modules/.bin` missing `tsc`; host Node 26 breaks `better-sqlite3` rebuild) — confirmed via `tsc -b --dry` from a sibling worktree with a working install: no stale/affected TS projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)