### PR TITLE
Research: amgm-oq-04-oq-03 S7 — K(k) = (π/2)·₂F₁(½,½;1;k²) PROVED, axiom discharged [0 ax / 0 sorry]

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ04OQ03.lean
+++ b/proofs/Proofs/AmgmInequalityOQ04OQ03.lean
@@ -495,10 +495,11 @@ theorem hasSum_integral_ellipticIntegrand (k : ℝ) (hk : k ^ 2 < 1) :
   · -- the θ-independent bound
     filter_upwards with θ _
     rw [Real.norm_eq_abs, abs_of_nonneg (by positivity)]
-    have hsin : Real.sin θ ^ 2 ≤ 1 := Real.sin_sq_le_one θ
-    gcongr
-    · exact div_nonneg (Nat.cast_nonneg _) (by positivity)
-    · nlinarith [sq_nonneg k]
+    have hbase : k ^ 2 * Real.sin θ ^ 2 ≤ k ^ 2 := by
+      nlinarith [Real.sin_sq_le_one θ, sq_nonneg k]
+    have hpow : (k ^ 2 * Real.sin θ ^ 2) ^ n ≤ (k ^ 2) ^ n :=
+      pow_le_pow_left₀ (by positivity) hbase n
+    exact mul_le_mul_of_nonneg_left hpow (by positivity)
   · -- summability of the bound
     filter_upwards with θ _
     exact (hasSum_inv_sqrt_one_sub hk2).summable

--- a/proofs/Proofs/AmgmInequalityOQ04OQ03.lean
+++ b/proofs/Proofs/AmgmInequalityOQ04OQ03.lean
@@ -1,6 +1,7 @@
 import Mathlib
 import Proofs.AmgmInequalityOQ04
 import Proofs.AmgmInequalityOQ04OQ01
+import Proofs.AmgmInequalityOQ04OQ03Wallis
 
 /-
 # AGM: Hypergeometric Series Representation of K(k)
@@ -60,10 +61,10 @@ Proving `K(k) = (π/2)·₂F₁(1/2,1/2;1;k²)` rigorously requires:
 - [x] summability + uniform convergence + continuity of ₂F₁ on (-1,1) (§6–§9)
 - [x] binomial series 1/√(1-u) = ∑ (centralBinom n/4ⁿ)uⁿ, |u| < 1 (§10)
 - [x] pointwise series expansion of the K integrand (§10)
-- [ ] K(k) = (π/2)·₂F₁(1/2,1/2;1;k²) (axiomatized — sum/integral interchange
-      is the sole remaining leg)
+- [x] K(k) = (π/2)·₂F₁(1/2,1/2;1;k²) — **PROVED** (§11: dominated-convergence
+      sum/integral interchange + Wallis values; formerly the file's one axiom)
 
-Axioms: 1 (ellipticK_eq_hyp2F1 — the hypergeometric series identity for K)
+Axioms: 0
 Sorries: 0
 -/
 
@@ -143,21 +144,12 @@ theorem ellipticK_hyp2F1_consistent_zero :
 -- § 5. The Hypergeometric Identity for K (Axiomatized)
 -- ============================================================================
 
-/-- **Hypergeometric series representation of K** (axiomatized deep identity):
-    for `|k| < 1`,
-      `K(k) = (π/2) · ₂F₁(1/2, 1/2; 1; k²)`.
-    See the file header for the proof outline (binomial series + Wallis
-    integrals + term-by-term integration) and why it is left axiomatized.
-    The `k = 0` instance is independently verified by
-    `ellipticK_hyp2F1_consistent_zero`. -/
-axiom ellipticK_eq_hyp2F1 (k : ℝ) (hk : k ^ 2 < 1) :
-    ellipticK k = (π / 2) * hyp2F1 (k ^ 2)
-
-/-- Sanity check: the axiom specialized at `k = 0` reproduces the independently
-    proved consistency theorem (both reduce to `K(0) = π/2`). -/
-theorem ellipticK_eq_hyp2F1_zero :
-    ellipticK 0 = (π / 2) * hyp2F1 ((0 : ℝ) ^ 2) :=
-  ellipticK_eq_hyp2F1 0 (by norm_num)
+/- **Hypergeometric series representation of K** — formerly the file's one
+   axiom, now a THEOREM: see § 11 at the end of the file
+   (`ellipticK_eq_hyp2F1`, proved by term-by-term integration of the § 10
+   binomial series against the Wallis values, with the sum/integral
+   interchange justified by dominated convergence). The statement had to move
+   below the § 6–§ 10 machinery it consumes. -/
 
 -- ============================================================================
 -- § 6. Summability of the Hypergeometric Series  (S2 ACT, 2026-06-01)
@@ -471,5 +463,96 @@ theorem hasSum_ellipticIntegrand (k θ : ℝ) (hk : k ^ 2 < 1) :
     rw [abs_of_nonneg (by positivity)]
     nlinarith [sq_nonneg k, sq_nonneg (Real.sin θ)]
   simpa [ellipticIntegrand] using hasSum_inv_sqrt_one_sub hu
+
+-- ============================================================================
+-- § 11. Term-by-Term Integration: the Main Identity, PROVED  (S7, Leg 5)
+-- ============================================================================
+--
+-- The final leg. The § 10 pointwise expansion of the integrand is integrated
+-- term by term over [0, π/2]: the sum/integral interchange is dominated
+-- convergence (`intervalIntegral.hasSum_integral_of_dominated_convergence`)
+-- with the θ-independent dominating series `(centralBinom n/4ⁿ)·(k²)ⁿ`
+-- (summable by the § 10 binomial series at u = k²), and each term integrates
+-- to `(π/2)·hypCoeff n·(k²)ⁿ` by the Wallis values `wallisHalf_even`.
+-- This discharges the former axiom: the file is now 0 axioms, 0 sorries.
+
+open MeasureTheory in
+/-- **The sum/integral interchange** (Leg 5): integrating the § 10 series
+    expansion of the K integrand term by term over `[0, π/2]`. Dominated
+    convergence with the constant-in-`θ` bound `(centralBinom n/4ⁿ)·(k²)ⁿ`,
+    whose sum is the (finite) binomial series at `u = k² < 1`. -/
+theorem hasSum_integral_ellipticIntegrand (k : ℝ) (hk : k ^ 2 < 1) :
+    HasSum
+      (fun n : ℕ => ∫ θ in (0 : ℝ)..π / 2,
+        (Nat.centralBinom n : ℝ) / 4 ^ n * (k ^ 2 * Real.sin θ ^ 2) ^ n)
+      (ellipticK k) := by
+  have hk2 : |k ^ 2| < 1 := by rwa [abs_of_nonneg (sq_nonneg k)]
+  refine intervalIntegral.hasSum_integral_of_dominated_convergence
+    (bound := fun n _ => (Nat.centralBinom n : ℝ) / 4 ^ n * (k ^ 2) ^ n)
+    (fun n => ?_) (fun n => ?_) ?_ ?_ ?_
+  · -- measurability of each term
+    exact (Continuous.aestronglyMeasurable (by fun_prop))
+  · -- the θ-independent bound
+    filter_upwards with θ _
+    rw [Real.norm_eq_abs, abs_of_nonneg (by positivity)]
+    have hsin : Real.sin θ ^ 2 ≤ 1 := Real.sin_sq_le_one θ
+    gcongr
+    · exact div_nonneg (Nat.cast_nonneg _) (by positivity)
+    · nlinarith [sq_nonneg k]
+  · -- summability of the bound
+    filter_upwards with θ _
+    exact (hasSum_inv_sqrt_one_sub hk2).summable
+  · -- integrability of the (constant) summed bound
+    exact intervalIntegrable_const
+  · -- pointwise convergence to the integrand
+    filter_upwards with θ _
+    exact hasSum_ellipticIntegrand k θ hk
+
+/-- **Each term integrates to a hypergeometric coefficient**: pulling constants
+    out and evaluating the Wallis integral `∫₀^{π/2} sin^{2n}θ dθ`. -/
+theorem integral_term_eq_hypCoeff (k : ℝ) (n : ℕ) :
+    (∫ θ in (0 : ℝ)..π / 2,
+        (Nat.centralBinom n : ℝ) / 4 ^ n * (k ^ 2 * Real.sin θ ^ 2) ^ n)
+      = (π / 2) * (hypCoeff n * (k ^ 2) ^ n) := by
+  have hsplit : ∀ θ : ℝ,
+      (Nat.centralBinom n : ℝ) / 4 ^ n * (k ^ 2 * Real.sin θ ^ 2) ^ n
+        = ((Nat.centralBinom n : ℝ) / 4 ^ n * (k ^ 2) ^ n)
+            * Real.sin θ ^ (2 * n) := by
+    intro θ
+    rw [mul_pow, pow_mul]
+    ring
+  simp_rw [hsplit]
+  rw [intervalIntegral.integral_const_mul]
+  rw [show (∫ θ in (0 : ℝ)..π / 2, Real.sin θ ^ (2 * n))
+      = AmgmInequalityOQ04OQ03Wallis.wallisHalf (2 * n) from rfl]
+  rw [AmgmInequalityOQ04OQ03Wallis.wallisHalf_even n]
+  unfold hypCoeff
+  ring
+
+/-- **Hypergeometric series representation of K — the main identity, PROVED**
+    (formerly this file's one axiom): for `k² < 1`,
+
+      `K(k) = (π/2) · ₂F₁(1/2, 1/2; 1; k²)`.
+
+    Proof: the § 10 binomial series expands the integrand pointwise
+    (`hasSum_ellipticIntegrand`); dominated convergence integrates it term by
+    term (`hasSum_integral_ellipticIntegrand`); each term is a Wallis integral
+    evaluating to `(π/2)·hypCoeff n·(k²)ⁿ` (`integral_term_eq_hypCoeff`); and
+    the resulting sum is `(π/2)·hyp2F1(k²)` by summability (§ 6). -/
+theorem ellipticK_eq_hyp2F1 (k : ℝ) (hk : k ^ 2 < 1) :
+    ellipticK k = (π / 2) * hyp2F1 (k ^ 2) := by
+  have hsum := hasSum_integral_ellipticIntegrand k hk
+  simp_rw [integral_term_eq_hypCoeff k] at hsum
+  have hk2 : |k ^ 2| < 1 := by rwa [abs_of_nonneg (sq_nonneg k)]
+  have h2 : HasSum (fun n : ℕ => (π / 2) * (hypCoeff n * (k ^ 2) ^ n))
+      ((π / 2) * hyp2F1 (k ^ 2)) :=
+    ((summable_hyp2F1 (k ^ 2) hk2).hasSum).mul_left _
+  exact hsum.unique h2
+
+/-- Sanity check: the theorem specialized at `k = 0` reproduces the
+    independently proved consistency theorem (both reduce to `K(0) = π/2`). -/
+theorem ellipticK_eq_hyp2F1_zero :
+    ellipticK 0 = (π / 2) * hyp2F1 ((0 : ℝ) ^ 2) :=
+  ellipticK_eq_hyp2F1 0 (by norm_num)
 
 end AmgmInequalityOQ04OQ03

--- a/research/problems/amgm-inequality-oq-04-oq-03/state.md
+++ b/research/problems/amgm-inequality-oq-04-oq-03/state.md
@@ -244,3 +244,32 @@ oq-04-oq-01. Leg-by-leg buildup:
   `hyp2F1_mtest_inputs_on_closedBall` (bundled M-test data exactly
   fitting Mathlib's `tendstoUniformlyOn_tsum`). See
   `sessions/2026-06-09-s04b-act-mtest-summable.md`.
+- **S7 ACT** (2026-07-24, researcher-3): Lean +95 LOC — **AXIOM DISCHARGED,
+  problem COMPLETE (0 axioms / 0 sorries)**. § 11 lands Leg 5, the
+  sum/integral interchange, via
+  `intervalIntegral.hasSum_integral_of_dominated_convergence` (NOT the
+  set-integral `integral_tsum` route sketched earlier — the intervalIntegral
+  variant consumes the goal shape directly): θ-independent bound
+  `(centralBinom n/4ⁿ)·(k²)ⁿ` (summable by § 10's binomial series at u = k²;
+  its tsum is a constant, so `intervalIntegrable_const` closes integrability),
+  measurability by `fun_prop`, pointwise convergence = § 10's
+  `hasSum_ellipticIntegrand`. `integral_term_eq_hypCoeff` evaluates each term
+  by `(k²·sin²θ)ⁿ = (k²)ⁿ·sin θ^(2n)` (`mul_pow` + `pow_mul`), constant
+  extraction, and the Wallis value `wallisHalf_even` (companion file now
+  imported; its `wallisHalf (2n)` is DEFINITIONALLY the sin-power interval
+  integral — bridge by `rfl`). Capstone `ellipticK_eq_hyp2F1` = uniqueness of
+  `HasSum` against `(summable_hyp2F1 _).hasSum.mul_left (π/2)`. The former
+  axiom § 5 block replaced by a forward note; theorem keeps the SAME name and
+  signature at the end of the file, so downstream references are unaffected.
+  Verified: host `lake env lean` exit 0 + Docker green + `#print axioms` =
+  foundational trio on the capstone and both new lemmas.
+  Lean gotchas: `gcongr` on `c·uⁿ ≤ c·vⁿ` produced mis-typed side goals —
+  use `pow_le_pow_left₀` + `mul_le_mul_of_nonneg_left` explicitly; the Wallis
+  companion olean was absent on host — generate with
+  `bin/lake env lean -o .lake/build/lib/lean/Proofs/<file>.olean <file>.lean`
+  (no `lake build` needed).
+
+## Status: COMPLETED (2026-07-24). K(k) = (π/2)·₂F₁(1/2,1/2;1;k²) fully proved.
+Next directions (quality-filtered): assemble Gauss's AGM theorem
+M(a,b) = aπ/(2K(k')) in the parent OQ-04 thread (the K-series was the
+missing analytic input); no cosmetic follow-ups here.

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -28,13 +28,13 @@
     "goal": "Formalize Gauss's AGM theorem M(a,b) = a*pi/(2K(k')) with k = b/a and k' = sqrt(1-k^2), using the hypergeometric identity for K(k)."
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-07-24T14:30:00Z",
     "iteration": 8,
     "focus": "S6 ACT (researcher-3, 2026-07-24): LEG 3 PROVED. New Section 10 in AmgmInequalityOQ04OQ03.lean (475 LOC, 1 stated axiom / 0 sorries): the binomial series 1/sqrt(1-u) = sum (centralBinom n/4^n) u^n for |u|<1 (hasSum_inv_sqrt_one_sub, inv_sqrt_one_sub_eq_tsum), landed pointwise on the K integrand as hasSum_ellipticIntegrand (1/sqrt(1-k^2 sin^2 theta) = sum (centralBinom n/4^n)(k^2 sin^2 theta)^n for k^2<1). Coefficient identity Ring.choose (1/2+n-1) n = centralBinom n/4^n via ascPochhammer_eval_half induction. Consumed from Real.one_div_one_sub_rpow_hasFPowerSeriesOnBall_zero — Mathlib.Analysis.Analytic.Binomial is NEW at the v4.31 pin. Discharge plan: legs 1-4 ALL DONE; only leg 5 (sum/integral interchange) remains to flip the axiom to a theorem.",
     "activeApproach": "Power-series realization of 2F1 with central-binomial coefficients c_n = (centralBinom n / 4^n)^2, building on the verified ellipticK from oq-04-oq-01. S2 ACT adds the summability infrastructure via central-binomial upper bound + geometric comparison.",
     "blockers": [],
-    "nextAction": "S7: Leg 5 — the sum/integral interchange. All terms nonneg for 0 <= k^2 < 1: convert intervalIntegral to set integral, apply MeasureTheory.integral_tsum (Beppo Levi) or hasSum_integral_of_dominated_convergence, integrate term by term against wallisHalf_even, assemble (pi/2)*hyp2F1(k^2) via hypCoeff_eq_sq — this would discharge ellipticK_eq_hyp2F1 and flip the entry axiomatized -> verified. Fallback session-sized: hyp2F1 positivity/monotonicity on [0,1).",
+    "nextAction": "None — ellipticK_eq_hyp2F1 proved (S7, 0 axioms / 0 sorries); follow-up lives in parent oq-04 (assemble Gauss AGM theorem M(a,b) = a*pi/(2K(k')) now that the K-series is available).",
     "attemptCounts": {
       "total": 7,
       "currentApproach": 2,
@@ -43,7 +43,7 @@
     "lastUpdate": "2026-07-24T14:30:00.000Z"
   },
   "knowledge": {
-    "progressSummary": "Five-leg axiom-discharge plan for ellipticK_eq_hyp2F1: leg 1 summability (S2), leg 2 Wallis closed form (S3), leg 3 binomial series 1/sqrt(1-u) = sum (centralBinom n/4^n)u^n INCLUDING pointwise expansion of the K integrand (S6, §10), leg 4 uniform convergence + continuity of hyp2F1 on (-1,1) (S4a/S4b/S5, §7-§9) — ALL PROVED. File: 475 LOC, 1 stated axiom, 0 sorries. Only leg 5 remains: the sum/integral interchange over [0,pi/2] (Beppo Levi, terms nonneg), which would flip the entry to verified.",
+    "progressSummary": "COMPLETED: K(k) = (pi/2)*2F1(1/2,1/2;1;k^2) fully proved, file 0 axioms / 0 sorries (S7 discharged the interchange leg)",
     "builtItems": [
       "Proofs/AmgmInequalityOQ04OQ03.lean (builds clean, 0 sorries, 1 axiom): defs hypCoeff, hyp2F1.",
       "hypCoeff_zero : hypCoeff 0 = 1 (proved).",
@@ -55,7 +55,8 @@
       "centralBinom_le_four_pow : Nat.centralBinom n <= 4^n (S2 ACT; Mathlib v4.26.0 gap-filler -- has only the lower bound).",
       "hypCoeff_le_one : hypCoeff n <= 1 (S2 ACT corollary).",
       "summable_hyp2F1 (x) (hx : |x| < 1) : Summable (fun n => hypCoeff n * x^n) (S2 ACT headline; prerequisite for DCT sum/integral interchange).",
-      "S6 §10 AmgmInequalityOQ04OQ03.lean: ascPochhammer_eval_half, multichoose_half, ringChoose_half, hypCoeff_eq_sq, hasSum_inv_sqrt_one_sub, inv_sqrt_one_sub_eq_tsum, hasSum_ellipticIntegrand (binomial series leg, 0 new axioms)"
+      "S6 §10 AmgmInequalityOQ04OQ03.lean: ascPochhammer_eval_half, multichoose_half, ringChoose_half, hypCoeff_eq_sq, hasSum_inv_sqrt_one_sub, inv_sqrt_one_sub_eq_tsum, hasSum_ellipticIntegrand (binomial series leg, 0 new axioms)",
+      "§11 of AmgmInequalityOQ04OQ03.lean: hasSum_integral_ellipticIntegrand + integral_term_eq_hypCoeff + ellipticK_eq_hyp2F1 (THEOREM, formerly axiom) + moved sanity check"
     ],
     "insights": [
       "The target theorem is Gauss's AGM theorem M(a,b) = a*pi/(2K(k')).",
@@ -72,7 +73,8 @@
       "Mathlib v4.31 pin ships Mathlib.Analysis.Analytic.Binomial: Real.one_div_one_sub_rpow_hasFPowerSeriesOnBall_zero gives the power series of 1/(1-x)^a on the unit ball with coefficients Ring.choose (a+n-1) n — leg 3 (binomial series) reduces to the coefficient identity",
       "Coefficient identity route: Ring.factorial_nsmul_multichoose_eq_ascPochhammer + Polynomial.ascPochhammer_smeval_eq_eval + induction on ascPochhammer_succ_eval threading Nat.succ_mul_centralBinom_succ (same recurrence trick as the Wallis leg)",
       "v4.31 gotchas: factorial notation n ! no longer parses (use n.factorial); EMetric.ball/mem_ball deprecated -> Metric.eball/mem_eball; eball membership via rw [Metric.mem_eball, edist_dist, Real.dist_eq, sub_zero] + ENNReal.ofReal_lt_one",
-      "Consumption pattern for ofScalars power series: HasFPowerSeriesOnBall.hasSum + FormalMultilinearSeries.ofScalars_apply_eq + coefficient rewrite + Real.sqrt_eq_rpow"
+      "Consumption pattern for ofScalars power series: HasFPowerSeriesOnBall.hasSum + FormalMultilinearSeries.ofScalars_apply_eq + coefficient rewrite + Real.sqrt_eq_rpow",
+      "S7: interchange via intervalIntegral.hasSum_integral_of_dominated_convergence with theta-independent bound (centralBinom n/4^n)(k^2)^n — summable by the binomial series at u=k^2, tsum constant so intervalIntegrable_const; wallisHalf (2n) is definitionally the sin-power interval integral (rfl bridge); capstone by HasSum uniqueness vs (summable_hyp2F1).hasSum.mul_left (pi/2)"
     ],
     "mathlibGaps": [
       "No general Gauss hypergeometric function 2F1 in Mathlib.",


### PR DESCRIPTION
## Summary

Research session S7 for `amgm-inequality-oq-04-oq-03` (hypergeometric series for the complete elliptic integral K): **the file's one axiom is discharged — the main identity is now fully proved**:

```
ellipticK_eq_hyp2F1 (k : ℝ) (hk : k ^ 2 < 1) :
    ellipticK k = (π / 2) * hyp2F1 (k ^ 2)
```

i.e. `K(k) = (π/2) · ₂F₁(1/2, 1/2; 1; k²)`, with the file at **0 axioms / 0 sorries**.

## Progress

New § 11 in `proofs/Proofs/AmgmInequalityOQ04OQ03.lean` (~95 LOC), consuming the previously landed legs (S2 summability, S3 Wallis values, S6 binomial series):

- `hasSum_integral_ellipticIntegrand` — the sum/integral interchange (Leg 5, the last leg) via `intervalIntegral.hasSum_integral_of_dominated_convergence` with the θ-independent dominating series `(centralBinom n/4ⁿ)·(k²)ⁿ`, summable by the § 10 binomial series at `u = k²`.
- `integral_term_eq_hypCoeff` — each term integrates to `(π/2)·hypCoeff n·(k²)ⁿ` via the Wallis value `wallisHalf_even` (companion file now imported; its `wallisHalf (2n)` is definitionally the sin-power interval integral).
- `ellipticK_eq_hyp2F1` — the capstone, by uniqueness of `HasSum`. Same name and signature as the former axiom (moved to the end of the file past the machinery it consumes; the § 5 axiom block is replaced by a forward note), so downstream references are unaffected.

No gallery entry exists yet for this slug (research-only), so no meta.json flip is involved; the tracker JSON and state.md record COMPLETED.

## Verification

- Host: `bin/lake env lean Proofs/AmgmInequalityOQ04OQ03.lean` exit 0 (Wallis companion olean generated via `lake env lean -o`).
- Docker: `docker-build.sh Proofs.AmgmInequalityOQ04OQ03` green.
- `grep -c "^axiom "` = 0; `#print axioms` on the capstone and both new lemmas = `[propext, Classical.choice, Quot.sound]`.

## Status

**Outcome**: completed — the OQ's target identity is machine-checked end to end.
**Next Steps**: the natural continuation lives in the parent oq-04 thread: assemble Gauss's AGM theorem `M(a,b) = aπ/(2K(k'))`, for which this K-series was the missing analytic input.

🤖 Generated by researcher-3
