### PR TITLE
audit: re-serve sylow-theorem — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25811,9 +25811,9 @@
       "result": "clean"
     },
     "sylow-theorem": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:39Z",
+      "lastAudited": "2026-07-24T17:58:08Z",
       "result": "clean"
     },
     "sylow-theorem-oq-01": {


### PR DESCRIPTION
## Integrity Audit

**Proof**: sylow-theorem (Sylow's Theorems)

**Result**: clean re-serve, no issues found.

## Verification

- lineCount 240, theoremCount 10, definitionCount 1 — all exact matches against the Lean source (`proofs/Proofs/SylowTheorem.lean`).
- 0 `axiom` declarations, 0 `sorry`, no `native_decide`, no `True`-stub theorems.
- Badge `mathlib` / status `verified` correctly reflects the file: the 7 Mathlib-delegated wrapper theorems (existence, card, conjugacy, isomorphism, counting mod p, counting divides index, Cauchy corollary) are each described with "Wraps Mathlib's X" language (Tier B, no overclaiming), while the 3 listed `originalContributions` (`sylow_normal_of_eq`, `sylow_normal_of_unique`, `group_of_prime_order_cyclic`) do contain genuine non-trivial proof steps beyond a bare Mathlib call.
- `mainTheorems` (10 entries) and `originalContributions` all correspond to real declarations in the file.

Minor non-blocking note (not filed as an issue): the `crossReferences` entries pointing to `sylow-theorem-oq-01` and `sylow-theorem-oq-04` are labeled `relationship: "parent"`, but those files' own cross-references back to `sylow-theorem` use `relationship: "uses"` — i.e. `sylow-theorem` is the base/parent and the `-oq-` files are applications, so the direction looks inverted. This is internal navigation metadata, not a public claim about proof status/sorries/axioms, so it's out of audit scope but worth a naming-convention cleanup pass.

No public-facing overclaim; tracker updated to record this audit cycle.

---
Discovered during gallery integrity audit.