### PR TITLE
Enrich circumference-via-differentiation-oq-02: add header section (98->100)

### DIFF
--- a/src/data/proofs/circumference-via-differentiation-oq-02/meta.json
+++ b/src/data/proofs/circumference-via-differentiation-oq-02/meta.json
@@ -74,6 +74,13 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Header, Strategy, and Imports",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "States the gap being filled: the parent proves the derivative direction d/dr(πr²) = 2πr and OQ-01 generalizes it to all dimensions, but the integral half V_n(r) = ∫₀ʳ S_{n-1}(ρ)dρ is left informal — the parent's own conclusion admits it 'does not separately formalize the integral.' Four imports supply the tools: the FTC (`integral_eq_sub_of_hasDerivAt`), the concrete evaluators `integral_id`/`integral_pow`, the tactic suite, and OQ-01's n-ball volume/surface definitions and derivative identity."
+    },
+    {
       "id": "continuity",
       "title": "Continuity of the Surface Function",
       "startLine": 47,


### PR DESCRIPTION
## Summary

The entry's `sections[]` covered lines 47-159 of `BallVolumeSurfaceDuality.lean` but left the module docstring (lines 1-46, which already has a matching annotation `cvd02-ann-01`) with no corresponding section — the sole gap keeping the quality-tracker score at 98/100 (sections: 4 x 2 = 8/10 vs. cap 10/10). Added a `header` section for lines 1-46 summarizing the module's stated gap (formalizing the integral half of the volume-surface duality via the FTC) and its four imports, so `sections[]` now covers the full 161-line file.

No other content changed; all existing keyInsights, annotations, conclusion, and cross-references preserved as-is.

## Verification

- `meta.json` parses as valid JSON, 15.5 KB (well under the 60 KB cap)
- `scripts/gallery/check-meta-size.ts circumference-via-differentiation-oq-02`: within caps
- `scripts/enricher/find-targets.ts --all --json`: quality score confirmed 98 -> 100 (sections breakdown 8 -> 10)
- `scripts/annotations/build.ts` ran cleanly against the updated file (no new errors for this entry)
- Full `tsc -b`/`vite build` could not run in this worktree due to a pre-existing, unrelated infra gap (fresh worktree lacked `node_modules`; host Node 26 breaks `better-sqlite3` rebuild) — borrowed a sibling worktree's `node_modules` via symlink for the scripts above; no source/type changes were made so this is JSON-only and low risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)