### PR TITLE
audit: re-serve cantor-diagonalization-oq-03-oq-01-oq-01 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4148,9 +4148,9 @@
       "result": "clean"
     },
     "cantor-diagonalization-oq-03-oq-01-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:38Z",
+      "lastAudited": "2026-07-24T18:01:20Z",
       "result": "clean"
     },
     "cantor-diagonalization-oq-03-oq-01-oq-02": {


### PR DESCRIPTION
## Integrity Audit — Clean Re-serve

**Proof**: cantor-diagonalization-oq-03-oq-01-oq-01
**Result**: clean, no issues

Audit queue was fully drained (0 unaudited); this is a round-robin re-serve
of the oldest audit per the auditor cadence.

## Checks performed

- **Theorem/def counts**: 11 theorems, 6 defs (4 `def` + 2 `structure`) —
  exact match to meta.json (definitionCount correctly includes structure decls).
- **Axioms**: 0 real `axiom` declarations. The word "axiomatize" appears only
  in prose comments ("We axiomatize the minimum needed...").
- **Sorries**: 0 real `sorry` tactics. The word "sorry" appears only in a
  stale prose comment at line 274 ("The full categorical proof has a sorry")
  — this is already correctly disclosed and contradicted in
  `sections[].mathContext` for the summary section, which notes the comment
  is stale and the 0-sorry count is accurate.
- **True stubs / native_decide**: none found.
- **Mathlib dependency**: `Function.Surjective` is the only listed dependency
  and is genuinely used (not doing the core proof work — badge `original`
  is correct).
- **Cross-references**: parent (`cantor-diagonalization-oq-03-oq-01`),
  grandparent (`cantor-diagonalization`), and sibling
  (`cantor-diagonalization-oq-03`) entries all exist. Parent entry's own
  sorry/status fields are consistent (0 sorries, verified).

No fix needed — only bumping `audit-tracker.json`'s `auditCount` and
`lastAudited` for this entry.

---
Discovered during gallery integrity audit.