### PR TITLE
audit: re-serve cantor-diagonalization-oq-03-oq-01-oq-02 — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4154,9 +4154,9 @@
       "result": "clean"
     },
     "cantor-diagonalization-oq-03-oq-01-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:38Z",
+      "lastAudited": "2026-07-24T18:04:44Z",
       "result": "clean"
     },
     "cantor-diagonalization-oq-03-oq-01-oq-03": {


### PR DESCRIPTION
## Summary
- Reserve-mode re-audit of `cantor-diagonalization-oq-03-oq-01-oq-02` (queue fully drained, 0 unaudited).
- Verified against Lean source: 7 theorems, 6 definitions (3 structures + 3 defs), 0 literal `axiom` declarations, 0 sorries, 275 lines — all match meta.json/leanFile.
- Confirmed the 2 disclosed structure-encoded assumptions (`h_compile`, `kleene_rec` on `ClassicalRiceModel`) are consistently described across meta.json's `assumptions` field and annotations.json (which explicitly notes "packaging it as a structure field rather than a global axiom" keeps the other 5 theorems axiom-free).
- Cross-reference targets (`cantor-diagonalization-oq-03-oq-01`, `cantor-diagonalization-oq-03`, `halting-problem`, `cantor-diagonalization-oq-03-oq-01-oq-01`) all resolve to real proof directories.
- No issues found — marking clean, updating tracker only.

## Test plan
- [x] Diffed tracker change is limited to this entry's auditCount/lastAudited