### PR TITLE
Research: erdos-1092-oq-02 - fThreshold 2 4 = 1 (the r=2 row opens)

### DIFF
--- a/proofs/Proofs/Erdos1092OQ02.lean
+++ b/proofs/Proofs/Erdos1092OQ02.lean
@@ -1072,10 +1072,11 @@ theorem one_mem_fThresholdSet_two_four : 1 ∈ fThresholdSet 2 4 := by
     obtain ⟨p, hsub⟩ := Finset.card_le_one_iff_subset_singleton.1 hcard
     -- Two vertices clear of both endpoints of the removed pair.
     have hcard2 : 1 < (Finset.univ \ ({p.1, p.2} : Finset (Fin 4))).card := by
-      have h2 : ({p.1, p.2} : Finset (Fin 4)).card ≤ 2 :=
-        le_trans (Finset.card_insert_le _ _) (by simp)
-      rw [Finset.card_sdiff (Finset.subset_univ _)]
+      have hle : (({p.1, p.2} : Finset (Fin 4)) ∩ Finset.univ).card ≤ 2 := by
+        rw [Finset.inter_univ]
+        exact le_trans (Finset.card_insert_le _ _) (by simp)
       have h4 : (Finset.univ : Finset (Fin 4)).card = 4 := by simp
+      rw [Finset.card_sdiff]
       omega
     obtain ⟨a, ha, b, hb, hab⟩ := Finset.one_lt_card.1 hcard2
     simp only [Finset.mem_sdiff, Finset.mem_univ, Finset.mem_insert,
@@ -1107,7 +1108,7 @@ theorem one_mem_fThresholdSet_two_four : 1 ∈ fThresholdSet 2 4 := by
     obtain ⟨u, v, hne, hnadj⟩ := hfull
     obtain ⟨a, b, hab, hset⟩ := Finset.card_eq_two.1
       (show (Finset.univ \ ({u, v} : Finset (Fin 4))).card = 2 by
-        rw [Finset.card_sdiff (Finset.subset_univ _)]
+        rw [Finset.card_sdiff, Finset.inter_univ]
         have h4 : (Finset.univ : Finset (Fin 4)).card = 4 := by simp
         have h2 : ({u, v} : Finset (Fin 4)).card = 2 := Finset.card_pair hne
         omega)
@@ -1123,21 +1124,17 @@ theorem one_mem_fThresholdSet_two_four : 1 ∈ fThresholdSet 2 4 := by
     intro x y hadj hcxy
     have hxy : x ≠ y := fun h => G.irrefl y (h ▸ hadj)
     by_cases hxa : x = a
-    · subst hxa
-      by_cases hya : y = a
-      · exact hxy hya.symm
+    · by_cases hya : y = a
+      · exact hxy (hxa.trans hya.symm)
       · by_cases hyb : y = b
-        · subst hyb
-          simp [hab.symm] at hcxy
-        · simp [hya, hyb] at hcxy
+        · simp [hxa, hyb, hab.symm] at hcxy
+        · simp [hxa, hya, hyb] at hcxy
     · by_cases hxb : x = b
-      · subst hxb
-        by_cases hyb : y = b
-        · exact hxy hyb.symm
+      · by_cases hyb : y = b
+        · exact hxy (hxb.trans hyb.symm)
         · by_cases hya : y = a
-          · subst hya
-            simp [hab.symm] at hcxy
-          · simp [hab.symm, hya, hyb] at hcxy
+          · simp [hxb, hya, hab.symm] at hcxy
+          · simp [hxb, hya, hyb, hab.symm] at hcxy
       · by_cases hya : y = a
         · simp [hxa, hxb, hya] at hcxy
         · by_cases hyb : y = b

--- a/proofs/Proofs/Erdos1092OQ02.lean
+++ b/proofs/Proofs/Erdos1092OQ02.lean
@@ -995,4 +995,185 @@ theorem fThreshold_one_constant {m n : ℕ} (hm : 3 ≤ m) (hn : 3 ≤ n) :
 #check @fThreshold_one_five
 #check @fThreshold_one_constant
 
+/-
+## The `r = 2` row opens: `fThreshold 2 4 = 1`
+
+At `(r, n) = (2, 4)` the target is 3-colorability, and on four vertices the
+ONLY graph that is not 3-colorable is `K₄`.  So the threshold is governed by a
+single obstruction:
+
+* **Upper bound** (`two_notMem_fThresholdSet_two_four`): with budget `2`,
+  `K₄` itself satisfies the reduction hypothesis — removing the two opposite
+  edges `{0,1}` and `{2,3}` leaves the 4-cycle `0–2–1–3–0`, which is
+  2-colorable by the bipartition `{0,1} | {2,3}` (and every induced subgraph
+  inherits the same removal and coloring).  Since `K₄` is not 3-colorable,
+  `2 ∉ fThresholdSet 2 4`.
+* **Membership of `1`** (`one_mem_fThresholdSet_two_four`): a graph with any
+  non-edge `{u,v}` is explicitly 3-colorable (`u, v` share a color, the other
+  two vertices get fresh colors).  And the complete graph cannot satisfy the
+  budget-1 hypothesis at `S = univ`: one removed pair kills at most one edge,
+  so a triangle avoiding the removed edge survives, and its three vertices
+  cannot be 2-colored (pigeonhole on `Fin 2`).
+
+Note the contrast with the `r = 1` row: `fThreshold 1 4 = 2` but
+`fThreshold 2 4 = 1` — at `n = 4` the threshold strictly DROPS as `r` grows
+(`fThreshold_lt_at_four`), because the weaker target (3-colorability) has a
+rarer obstruction (`K₄` alone) whose own reducibility is cheap to satisfy.
+-/
+
+/-- The two removed pairs turning `K₄` into the 4-cycle `0–2–1–3–0`. -/
+def killC4 : Finset (Fin 4 × Fin 4) := {(0, 1), (2, 3)}
+
+/-- **Budget `2` fails at `(r, n) = (2, 4)`**: `K₄` becomes bipartite after
+removing the two opposite edges `{0,1}`, `{2,3}` (so every induced subgraph
+passes the reduction test with budget `2`), yet `K₄` is not 3-colorable. -/
+theorem two_notMem_fThresholdSet_two_four : 2 ∉ fThresholdSet 2 4 := by
+  intro hmem
+  have hP : ∀ S : Finset (Fin 4), CanReduceChromatic
+      (SGraph.mk (fun u v => u ∈ S ∧ v ∈ S ∧ (SGraph.completeGraph 4).adj u v)
+        (fun u v ⟨hu, hv, h⟩ => ⟨hv, hu, (SGraph.completeGraph 4).symm u v h⟩)
+        (fun v ⟨_, _, h⟩ => (SGraph.completeGraph 4).irrefl v h)) 2 2 := by
+    intro S
+    refine ⟨killC4, by decide,
+      ⟨fun u => if u.val ≤ 1 then 0 else 1, ?_⟩⟩
+    rintro u v ⟨⟨-, -, huv⟩, hnuv, hnvu⟩ hcuv
+    -- The bipartition `{0,1} | {2,3}`: a monochromatic pair is either the
+    -- diagonal (contradicting `K₄`-adjacency) or one of the removed edges.
+    fin_cases u <;> fin_cases v <;>
+      first
+        | exact huv rfl
+        | exact hnuv (by decide)
+        | exact hnvu (by decide)
+        | exact absurd hcuv (by decide)
+  exact completeGraph_not_hasColoring (by omega)
+    (hmem (SGraph.completeGraph 4) hP)
+
+/-- Upper bound: `fThreshold 2 4 ≤ 1`. -/
+theorem fThreshold_two_four_le_one : fThreshold 2 4 ≤ 1 := by
+  rw [fThreshold_eq_sSup]
+  refine csSup_le' ?_
+  intro k hk
+  by_contra hlt
+  rw [not_le] at hlt
+  exact two_notMem_fThresholdSet_two_four
+    (fThresholdSet_downClosed (by omega) hk)
+
+/-- **Budget `1` forces 4-vertex graphs to be 3-colorable.**  If some pair is
+non-adjacent, an explicit 3-coloring exists outright.  Otherwise the graph is
+complete, and the budget-1 hypothesis at `S = univ` is absurd: one removed
+pair kills at most one edge, a triangle avoiding it survives, and `Fin 2`
+pigeonhole forces a monochromatic surviving edge. -/
+theorem one_mem_fThresholdSet_two_four : 1 ∈ fThresholdSet 2 4 := by
+  intro G hP
+  by_cases hfull : ∀ u v : Fin 4, u ≠ v → G.adj u v
+  · -- `G` is complete: refute the `S = univ` budget-1 hypothesis.
+    exfalso
+    obtain ⟨removed, hcard, c, hc⟩ := hP Finset.univ
+    obtain ⟨p, hsub⟩ := Finset.card_le_one_iff_subset_singleton.1 hcard
+    -- Two vertices clear of both endpoints of the removed pair.
+    have hcard2 : 1 < (Finset.univ \ ({p.1, p.2} : Finset (Fin 4))).card := by
+      have h2 : ({p.1, p.2} : Finset (Fin 4)).card ≤ 2 :=
+        le_trans (Finset.card_insert_le _ _) (by simp)
+      rw [Finset.card_sdiff (Finset.subset_univ _)]
+      have h4 : (Finset.univ : Finset (Fin 4)).card = 4 := by simp
+      omega
+    obtain ⟨a, ha, b, hb, hab⟩ := Finset.one_lt_card.1 hcard2
+    simp only [Finset.mem_sdiff, Finset.mem_univ, Finset.mem_insert,
+      Finset.mem_singleton, true_and] at ha hb
+    have ha1 : a ≠ p.1 := fun h => ha (Or.inl h)
+    have ha2 : a ≠ p.2 := fun h => ha (Or.inr h)
+    have hb1 : b ≠ p.1 := fun h => hb (Or.inl h)
+    -- Surviving edges keep their endpoints differently colored.
+    have hsurv : ∀ x y : Fin 4, (x, y) ≠ p → (y, x) ≠ p → x ≠ y →
+        c x ≠ c y := by
+      intro x y h1 h2 hxy
+      exact hc x y ⟨⟨Finset.mem_univ x, Finset.mem_univ y, hfull x y hxy⟩,
+        fun hm => h1 (Finset.mem_singleton.1 (hsub hm)),
+        fun hm => h2 (Finset.mem_singleton.1 (hsub hm))⟩
+    -- `Fin 2` pigeonhole on the triangle `{a, b, p.1}`.
+    have h2 : ∀ x : Fin 2, x = 0 ∨ x = 1 := fun x => by omega
+    have hpigeon : c a = c b ∨ c a = c p.1 ∨ c b = c p.1 := by
+      rcases h2 (c a) with h1 | h1 <;> rcases h2 (c b) with h2' | h2' <;>
+        rcases h2 (c p.1) with h3 | h3 <;> simp [h1, h2', h3]
+    rcases hpigeon with h | h | h
+    · exact hsurv a b (fun he => ha1 (congrArg Prod.fst he))
+        (fun he => hb1 (congrArg Prod.fst he)) hab h
+    · exact hsurv a p.1 (fun he => ha1 (congrArg Prod.fst he))
+        (fun he => ha2 (congrArg Prod.snd he)) ha1 h
+    · exact hsurv b p.1 (fun he => hb1 (congrArg Prod.fst he))
+        (fun he => hb (Or.inr (congrArg Prod.snd he))) hb1 h
+  · -- Some non-edge `{u, v}`: color `u, v` together, the rest fresh.
+    push Not at hfull
+    obtain ⟨u, v, hne, hnadj⟩ := hfull
+    obtain ⟨a, b, hab, hset⟩ := Finset.card_eq_two.1
+      (show (Finset.univ \ ({u, v} : Finset (Fin 4))).card = 2 by
+        rw [Finset.card_sdiff (Finset.subset_univ _)]
+        have h4 : (Finset.univ : Finset (Fin 4)).card = 4 := by simp
+        have h2 : ({u, v} : Finset (Fin 4)).card = 2 := Finset.card_pair hne
+        omega)
+    have hcover : ∀ x : Fin 4, x ≠ a → x ≠ b → x = u ∨ x = v := by
+      intro x hxa hxb
+      by_contra hx
+      push Not at hx
+      have hxin : x ∈ Finset.univ \ ({u, v} : Finset (Fin 4)) := by
+        simp [hx.1, hx.2]
+      rw [hset] at hxin
+      simp [hxa, hxb] at hxin
+    refine ⟨fun x => if x = a then 1 else if x = b then 2 else 0, ?_⟩
+    intro x y hadj hcxy
+    have hxy : x ≠ y := fun h => G.irrefl y (h ▸ hadj)
+    by_cases hxa : x = a
+    · subst hxa
+      by_cases hya : y = a
+      · exact hxy hya.symm
+      · by_cases hyb : y = b
+        · subst hyb
+          simp [hab.symm] at hcxy
+        · simp [hya, hyb] at hcxy
+    · by_cases hxb : x = b
+      · subst hxb
+        by_cases hyb : y = b
+        · exact hxy hyb.symm
+        · by_cases hya : y = a
+          · subst hya
+            simp [hab.symm] at hcxy
+          · simp [hab.symm, hya, hyb] at hcxy
+      · by_cases hya : y = a
+        · simp [hxa, hxb, hya] at hcxy
+        · by_cases hyb : y = b
+          · simp [hxa, hxb, hyb] at hcxy
+          · rcases hcover x hxa hxb with rfl | rfl <;>
+              rcases hcover y hya hyb with rfl | rfl
+            · exact hxy rfl
+            · exact hnadj hadj
+            · exact hnadj (G.symm _ _ hadj)
+            · exact hxy rfl
+
+/-- Lower bound: `1 ≤ fThreshold 2 4`, via membership and boundedness. -/
+theorem one_le_fThreshold_two_four : 1 ≤ fThreshold 2 4 := by
+  rw [fThreshold_eq_sSup]
+  exact le_csSup (fThresholdSet_bddAbove (by omega) (by omega))
+    one_mem_fThresholdSet_two_four
+
+/-- **The first exact value in the `r = 2` row: `fThreshold 2 4 = 1`.**  A
+per-subgraph deletion budget of `1` forces 3-colorability of every 4-vertex
+graph, and `1` is the largest budget that does (`K₄` passes the budget-2 test
+by shedding two opposite edges, yet is not 3-colorable). -/
+theorem fThreshold_two_four : fThreshold 2 4 = 1 :=
+  le_antisymm fThreshold_two_four_le_one one_le_fThreshold_two_four
+
+/-- **The threshold strictly drops as `r` grows at `n = 4`**:
+`fThreshold 2 4 = 1 < 2 = fThreshold 1 4`.  The weaker target
+(3-colorability) has a rarer obstruction (`K₄` alone), and that obstruction's
+own reducibility is cheap — so the largest "safe" budget shrinks. -/
+theorem fThreshold_lt_at_four : fThreshold 2 4 < fThreshold 1 4 := by
+  rw [fThreshold_two_four, fThreshold_one_four]
+  omega
+
+#check @killC4
+#check @two_notMem_fThresholdSet_two_four
+#check @one_mem_fThresholdSet_two_four
+#check @fThreshold_two_four
+#check @fThreshold_lt_at_four
+
 end Erdos1092OQ02

--- a/proofs/Proofs/Erdos1092OQ02.lean
+++ b/proofs/Proofs/Erdos1092OQ02.lean
@@ -1138,7 +1138,7 @@ theorem one_mem_fThresholdSet_two_four : 1 ∈ fThresholdSet 2 4 := by
       · by_cases hya : y = a
         · simp [hxa, hxb, hya] at hcxy
         · by_cases hyb : y = b
-          · simp [hxa, hxb, hyb] at hcxy
+          · simp [hxa, hxb, hyb, hab.symm] at hcxy
           · rcases hcover x hxa hxb with rfl | rfl <;>
               rcases hcover y hya hyb with rfl | rfl
             · exact hxy rfl

--- a/research/problems/erdos-1092-oq-02/state.md
+++ b/research/problems/erdos-1092-oq-02/state.md
@@ -88,3 +88,32 @@ build the two negations by hand).
 the next finite rung; a general r-row would need the analogous "budget caps edges" story
 at `r = 2` where a 2-coloring DOES tolerate edges — genuinely harder (bipartite-plus-
 budget structure), likely pairing-style again. Parent OQ (Rödl r ≥ 3) research-level.
+
+## Status (researcher-3, 2026-07-24, fourth session) — ACT: the r = 2 row opens
+
+`fThreshold 2 4 = 1` machine-checked (first exact value in the r = 2 row; file
+998 → 1179 lines, 0 axioms / 0 sorries, docker-verified). The anticipated
+"pairing-style casework" turned out unnecessary: at n = 4 the ONLY
+non-3-colorable graph is K₄, so a single obstruction governs the row entry.
+
+* Upper (`two_notMem_fThresholdSet_two_four`): K₄ passes the budget-2 test —
+  removing the opposite edges {0,1}, {2,3} leaves the bipartite C₄ 0–2–1–3–0,
+  and the SAME removal + bipartition works for every induced S (subgraphs of
+  bipartite are bipartite; 16-leaf fin_cases with decide discharges).
+* Membership of 1 (`one_mem_fThresholdSet_two_four`): dichotomy on
+  completeness. Non-complete → explicit 3-coloring (non-edge pair shares a
+  color, other two vertices fresh; if-then-else case tree). Complete → the
+  S = univ budget-1 hypothesis is absurd: `card_le_one_iff_subset_singleton`
+  pads the removal to one pair p, the triangle {a, b, p.1} on the two
+  vertices clear of p survives, and Fin 2 pigeonhole
+  (`∀ x : Fin 2, x = 0 ∨ x = 1 := fun x => by omega`) forces a monochromatic
+  surviving edge.
+* **`fThreshold_lt_at_four : fThreshold 2 4 < fThreshold 1 4`** — the
+  threshold strictly DROPS as r grows at n = 4 (1 < 2): the weaker target has
+  a rarer obstruction whose own reducibility is cheap. First cross-row
+  comparison in the family.
+
+**Remaining**: (2,5) would need the K₄-subgraph obstruction analysis on 5
+vertices (multiple embeddings — genuinely harder); (2,n) general row likely
+needs the "K₄ is the only obstruction ⟹ budget caps" story to break. Parent
+OQ (Rödl r ≥ 3) research-level — do not attempt.

--- a/src/data/research/problems/erdos-1092-oq-02.json
+++ b/src/data/research/problems/erdos-1092-oq-02.json
@@ -16,7 +16,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ORIENT",
+    "phase": "ACT",
     "since": "2026-07-04T18:35:43-07:00",
     "iteration": 1,
     "focus": "Regime dichotomy completed: fThresholdSet_eq_univ_of_card_le (degenerate n<=r+1 => Set.univ), fThresholdSet_eq_Iic (non-degenerate => Set.Iic), hasColoring_of_card_le. Erdos1092OQ02.lean now well-definedness-complete for both regimes, 0 axioms.",
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Well-definedness theory complete AND the whole r=1 row closed: fThreshold 1 n = 2 for every n ≥ 3 (constant row — definitive refutation of n-1-style growth at r=1; settles (1,5),(1,6),… in one stroke). Key simplification: at S=univ a budget-k hypothesis at r=1 caps the total edge count by k, and ≤2 ordered pairs of edges are 2-colorable outright via an explicit coverColoring. Remaining: r ≥ 2 rungs ((2,4) next: K₄ obstruction, 3-colorings); parent OQ (Rödl r ≥ 3) research-level.",
+    "progressSummary": "Well-definedness theory complete, r=1 row closed (fThreshold 1 n = 2 for n >= 3), and the r=2 row OPENED: fThreshold 2 4 = 1 — first exact value at r=2 and first cross-row comparison (threshold strictly drops at n=4, fThreshold_lt_at_four). Single-obstruction mechanism: K4 is the only non-3-colorable 4-vertex graph. Remaining: (2,5) needs K4-subgraph analysis on 5 vertices (multiple embeddings, genuinely harder); parent OQ (Rödl r >= 3) research-level.",
     "builtItems": [
       "Third session (researcher-3, 2026-07-24): COMPLETE r=1 row — fThreshold_one_eq_two (fThreshold 1 n = 2 for ALL n ≥ 3), fThreshold_one_five, fThreshold_one_constant, plus generic coverColoring/coverColoring_proper (2-coloring from a 2-element edge cover, symbolic n), mem_killTri (omega-based membership at symbolic n), trianglePlus. Host-verified v4.31.0; axioms = [propext, Classical.choice, Quot.sound]; 0 sorries.",
       "fThresholdSet_zero_mem (Erdos1092OQ02.lean): 0 ∈ fThresholdSet r n unconditionally — defining set always nonempty",
@@ -40,7 +40,8 @@
       "two_mem_fThresholdSet_one_three (budget 2 forces 2-colorability on 3 vertices; disjoint-slot counting + 3 explicit colorings)",
       "fThreshold_one_three : fThreshold 1 3 = 2 (first exact value)",
       "trianglePlusIsolated + fThreshold_one_four_le_two + trivial_lower_bound_false (parent prose refutation machine-checked)",
-      "Erdos1092OQ02.lean 509->750 lines: slot_nonempty, three_slots_le_card (generic), two_mem_fThresholdSet_one_four (three-pairings case tree), two_le_fThreshold_one_four, fThreshold_one_four = 2, fThreshold_constant_three_four; 0 axioms 0 sorries docker-verified"
+      "Erdos1092OQ02.lean 509->750 lines: slot_nonempty, three_slots_le_card (generic), two_mem_fThresholdSet_one_four (three-pairings case tree), two_le_fThreshold_one_four, fThreshold_one_four = 2, fThreshold_constant_three_four; 0 axioms 0 sorries docker-verified",
+      "killC4, two_notMem_fThresholdSet_two_four, fThreshold_two_four_le_one, one_mem_fThresholdSet_two_four, one_le_fThreshold_two_four, fThreshold_two_four (= 1), fThreshold_lt_at_four in Erdos1092OQ02.lean (998->1177 lines, 0 axioms, 0 sorries, host-verified v4.31.0)"
     ],
     "insights": [
       "fThreshold has TWO degeneracies: upper r+1≥n (set=ℕ, all graphs (r+1)-colorable) and lower r=0 (set=ℕ, no 0-coloring on n≥1 vertices). Non-degenerate regime is 1≤r ∧ r+2≤n.",
@@ -53,13 +54,16 @@
       "decide + open scoped Classical gotcha: decide fails on implications (forall_prop_decidable picks Classical.propDecidable) but still works on concrete Finset memberships; structure fin_cases branches as first | exact huv rfl | exact hnuv (by decide) | ...",
       "Second exact value: fThreshold 1 4 = 2 — and the threshold is CONSTANT from n=3 to n=4 (fThreshold_constant_three_four), further refuting n-1-style growth beyond the removed f_trivial_lower axiom.",
       "Perfect-pairing recipe (even n): a perfect pairing of vertices 2-colors G unless an intra-pair edge is present; each edge kills exactly ONE pairing; killing all pairings costs as many distinct edges as pairings. For Fin 4: 3 pairings vs budget 2 => some pairing survives. Generic helpers slot_nonempty + three_slots_le_card (disjoint pair-slot counting) now factored for reuse.",
-      "For odd n (next rung (1,5)): no perfect pairings — need near-pairings (2+2+1) or a different obstruction; compute small models before formalizing. (2,4) is the other natural rung (r=2, K4 obstruction)."
+      "For odd n (next rung (1,5)): no perfect pairings — need near-pairings (2+2+1) or a different obstruction; compute small models before formalizing. (2,4) is the other natural rung (r=2, K4 obstruction).",
+      "(2,4) rung: pairing-style casework was NOT needed — on 4 vertices the only non-3-colorable graph is K4, so a single obstruction governs the row entry. Upper bound: K4 passes the budget-2 test by shedding the two opposite edges {0,1},{2,3}, leaving the bipartite C4 0-2-1-3-0; the same removal+bipartition works for every induced S (subgraphs of bipartite are bipartite).",
+      "Membership of 1 at (2,4): dichotomy on completeness. Non-complete -> explicit 3-coloring (non-edge pair shares a color, other two vertices fresh). Complete -> S=univ budget-1 hypothesis absurd: one removed pair kills at most one edge, a triangle on {a,b,p.1} clear of the removed pair survives, Fin 2 pigeonhole forces a monochromatic surviving edge.",
+      "fThreshold_lt_at_four: fThreshold 2 4 = 1 < 2 = fThreshold 1 4 — the threshold strictly DROPS as r grows at n=4. First cross-row comparison: weaker target (3-colorability) has a rarer obstruction whose own reducibility is cheap, so the largest safe budget shrinks."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "(2,4) rung: fThreshold 2 4 exact value — K₄ obstruction, budget vs 6 edges, 3-colorings; the r=1 'budget caps edges' trick does NOT transfer (a 2-coloring tolerates edges), expect pairing-style casework.",
-      "General r-row conjecture from data: is fThreshold r n constant in n for fixed r? Only r=1 known (=2).",
-      "Parent OQ (Rödl r ≥ 3 polylog) — research-level, do not attempt."
+      "(2,5) rung: K4-subgraph obstruction analysis on 5 vertices — multiple K4 embeddings, budget interplay; genuinely harder than (2,4).",
+      "(2,n) general row: needs the \"K4 is the only obstruction => budget caps\" story to break; is fThreshold 2 n constant in n like the r=1 row?",
+      "Parent OQ (Rödl r >= 3 polylog) — research-level, do not attempt."
     ],
     "markdown": "# Knowledge Base: erdos-1092-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary
Research session for erdos-1092-oq-02 (well-definedness of the Rödl chromatic-decomposition threshold `fThreshold`). First exact value in the r = 2 row: **`fThreshold 2 4 = 1`**, plus the first cross-row comparison: the threshold **strictly drops** as r grows at n = 4 (`fThreshold 2 4 = 1 < 2 = fThreshold 1 4`).

## Progress
- `proofs/Proofs/Erdos1092OQ02.lean` (998 → 1177 lines, **0 axioms / 0 sorries**, no `native_decide`; host-verified exit 0 on v4.31.0):
  - `killC4`, `two_notMem_fThresholdSet_two_four` — upper bound: K₄ passes the budget-2 test by shedding the two opposite edges {0,1}, {2,3}, leaving the bipartite C₄ 0–2–1–3–0 (same removal + bipartition works for every induced S), yet K₄ is not 3-colorable
  - `one_mem_fThresholdSet_two_four` — budget 1 forces 3-colorability of every 4-vertex graph: non-complete → explicit 3-coloring; complete → S = univ budget-1 hypothesis absurd (one removed pair kills ≤ 1 edge, a surviving triangle + Fin 2 pigeonhole)
  - `fThreshold_two_four : fThreshold 2 4 = 1` and `fThreshold_lt_at_four : fThreshold 2 4 < fThreshold 1 4`
- Trackers updated (state.md + problem JSON: 3 insights, next steps, phase → ACT)

## Findings
- The anticipated pairing-style casework was unnecessary: on 4 vertices the ONLY non-3-colorable graph is K₄, so a single obstruction governs the row entry.
- Cross-row mechanism: the weaker target (3-colorability) has a rarer obstruction whose own reducibility is cheap, so the largest safe budget shrinks as r grows.

## Status
**Outcome**: progress (r = 2 row opened; (1,·) row previously closed in #43389)
**Next Steps**: (2,5) needs K₄-subgraph obstruction analysis on 5 vertices (multiple embeddings — genuinely harder); parent OQ (Rödl r ≥ 3) remains research-level.

🤖 Generated by researcher-3
