### PR TITLE
Research: szemeredi-regularity-oq-04 - S27b-ii restoration complete + S28a: unbounded target is degenerate (0-axiom)

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ04Assemble.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Assemble.lean
@@ -1,0 +1,228 @@
+/-
+  Szemerédi Regularity OQ04 — S27b-ii: invariant restoration and the deficit form
+  of the maintained step
+
+  This file composes the whole S20–S27b-i pipeline into the two statements the
+  Chain oracle (`exists_afksTwoLevel_of_maintained_oracle`) actually consumes:
+
+  * `exists_invariant_restore` — the modular capstone.  ANY covering, pairwise
+    disjoint family refining the coarse partition `Vparts` (blocks pairwise
+    disjoint with per-block mass `m² ≤ |A|`) can be rebuilt into a family
+    satisfying the FULL Chain loop invariant — covering, pairwise disjoint,
+    refining `Vparts`, globally ±1-equitable, mass floor `m` — at explicit
+    ambient energy cost `2·|q₁|·m/n + 2·|Vparts|·m²/n`.  Empty pieces are
+    stripped for free (`partitionEnergy_filter_card_ne_zero`), the per-block
+    ground floors come from `fiber_ground_eq_block`, and the rebuild is
+    S27b-i's `exists_equitable_recut_blocks` over `T = Vparts`.
+
+  * `exists_maintained_next_deficit` — the DEFICIT form of the maintained step:
+    an invariant-satisfying partition that is not AFKS-fine-regular has a
+    successor satisfying the full invariant whose energy exceeds the parent's
+    by the bare-split gain `E⁴m²/n²` MINUS the restoration cost above.
+
+  ## Honesty note — why this does NOT close the oracle (S28 blocker)
+
+  The Chain oracle needs the deficit to be positive: restoration cost strictly
+  below the retained gain.  It never is.  The gain `E⁴m²/n²` comes from ONE
+  witnessed deviating pair (S18/S19: the sharp single-witness floor), while any
+  re-equitization that moves even a single piece of mass `≈ m` costs on the
+  order of `2m/n`, and `2m/n > E⁴m²/n²  ⟺  2n > E⁴m`, which holds for every
+  admissible parameter choice (`E ≤ 1`, `m ≤ n`).  Even the single absorption
+  term `2m²/n` alone exceeds the gain (`2m²/n > E⁴m²/n² ⟺ 2n > E⁴`).  So no
+  parameter bookkeeping can close the maintained oracle from the single-witness
+  step: the per-step gain must first be AMPLIFIED to a constant scale — the
+  true AFKS mechanism, where ¬regularity yields a mass-weighted ε-fraction of
+  irregular pairs and the summed energy increment is `≥ ε⁵`-scale, independent
+  of `m/n`.  That amplification (a mass-weighted defect extraction from
+  `¬ IsAFKSFineRegular`, S28) is a materially new mechanism, recorded as the
+  blocked route's reopen criterion.  These two theorems are exactly the
+  interface it will consume: an S28 gain `γ` feeds the same
+  `exists_invariant_restore`, and the oracle closes when `γ` exceeds the cost.
+
+  All results are fully machine-checked (0 axioms, 0 sorries).
+
+  Reference: Alon–Fischer–Krivelevich–Szegedy, "Efficient testing of large
+  graphs", Combinatorica 20 (2000); Komlós–Simonovits (1996).
+-/
+import Mathlib
+import Proofs.SzemerediRegularityOQ04Iterate
+import Proofs.SzemerediRegularityOQ04Chain
+
+namespace Szemeredi.RegularityOQ04Assemble
+
+open Szemeredi.Core Szemeredi.Regularity
+open Szemeredi.RegularityOQ04Energy Szemeredi.RegularityOQ04Bridge
+open Szemeredi.RegularityOQ04TwoLevel Szemeredi.RegularityOQ04ToleranceBridge
+open Szemeredi.RegularityOQ04Iterate Szemeredi.RegularityOQ04Chain
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+omit [Fintype V] in
+/-- **Fiber grounds are whole blocks.**  If `q` covers `V` and refines the
+pairwise-disjoint block family `Vparts`, then the ground set of the fiber of a
+block `A` (the pieces of `q` contained in `A`) is exactly `A`: containment one
+way is by definition of the fiber, and a vertex `v ∈ A` lies in some piece `P`,
+which sits inside some block `A'`; blocks are disjoint and `v ∈ A ∩ A'`, so
+`A' = A` and `P` is in the fiber. -/
+theorem fiber_ground_eq_block (Vparts q : Finset (Finset V)) {A : Finset V}
+    (hA : A ∈ Vparts)
+    (hVdisj : (↑Vparts : Set (Finset V)).PairwiseDisjoint id)
+    (hcover : ∀ v : V, ∃ P ∈ q, v ∈ P)
+    (href : IsRefinement q Vparts) :
+    (q.filter (· ⊆ A)).biUnion id = A := by
+  apply Finset.Subset.antisymm
+  · exact Finset.biUnion_subset.mpr (fun c hc => (Finset.mem_filter.mp hc).2)
+  · intro v hv
+    obtain ⟨P, hP, hvP⟩ := hcover v
+    obtain ⟨A', hA', hPA'⟩ := href P hP
+    have hAA' : A = A' := by
+      by_contra hne
+      have hd := hVdisj (Finset.mem_coe.mpr hA) (Finset.mem_coe.mpr hA') hne
+      have hd' : Disjoint A A' := by simpa [Function.onFun] using hd
+      exact absurd (hPA' hvP) (Finset.disjoint_left.mp hd' hv)
+    refine Finset.mem_biUnion.mpr ⟨P, Finset.mem_filter.mpr ⟨hP, ?_⟩, hvP⟩
+    rw [hAA']
+    exact hPA'
+
+/-- **Invariant restoration (S27b-ii modular capstone).**  Any covering,
+pairwise-disjoint family `q₁` refining the pairwise-disjoint coarse partition
+`Vparts` (each block of ground mass at least `m²`) can be rebuilt into a family
+satisfying the FULL Chain loop invariant — covering, pairwise disjoint,
+refining `Vparts`, globally ±1-equitable (all sizes in `{m, m+1}`), mass floor
+`m` — at ambient energy cost at most `2·|q₁|·m/n + 2·|Vparts|·m²/n`.
+
+Pipeline: strip empty pieces (free, `partitionEnergy_filter_card_ne_zero`);
+per-block ground floors from `fiber_ground_eq_block`; rebuild all blocks with
+S27b-i's `exists_equitable_recut_blocks` (`T = Vparts`); global equitability
+follows because every rebuilt piece sits inside a block (the locality clause)
+and is therefore sized `{m, m+1}`.
+
+This is the exact interface a future amplified-gain step (S28) composes with:
+successor + restoration = maintained oracle, provided the gain beats the cost. -/
+theorem exists_invariant_restore (G : SimpleGraph V) [DecidableRel G.Adj]
+    (m : ℕ) (hm : 1 ≤ m) (Vparts q₁ : Finset (Finset V))
+    (hVdisj : (↑Vparts : Set (Finset V)).PairwiseDisjoint id)
+    (hVfloor : ∀ A ∈ Vparts, m * m ≤ A.card)
+    (hcover : ∀ v : V, ∃ P ∈ q₁, v ∈ P)
+    (hdisj : ∀ P Q : Finset V, P ∈ q₁ → Q ∈ q₁ → P ≠ Q → Disjoint P Q)
+    (href : IsRefinement q₁ Vparts) :
+    ∃ q' : Finset (Finset V),
+      (∀ v : V, ∃ P ∈ q', v ∈ P) ∧
+      (∀ P Q : Finset V, P ∈ q' → Q ∈ q' → P ≠ Q → Disjoint P Q) ∧
+      IsRefinement q' Vparts ∧
+      (∀ P Q : Finset V, P ∈ q' → Q ∈ q' → (P.card : ℤ) - Q.card ≤ 1) ∧
+      (∀ P ∈ q', (m : ℚ) ≤ P.card) ∧
+      partitionEnergy G q₁
+          - (2 * ((q₁.card : ℚ) * (m : ℚ)) / (Fintype.card V : ℚ)
+             + 2 * ((Vparts.card : ℚ) * ((m : ℚ) * (m : ℚ))) / (Fintype.card V : ℚ)) ≤
+        partitionEnergy G q' := by
+  classical
+  set Q₀ : Finset (Finset V) := q₁.filter (fun P => P.card ≠ 0) with hQ₀def
+  have hQ₀sub : Q₀ ⊆ q₁ := Finset.filter_subset _ _
+  have hQ₀cover : ∀ v : V, ∃ P ∈ Q₀, v ∈ P := by
+    intro v
+    obtain ⟨P, hP, hvP⟩ := hcover v
+    exact ⟨P, Finset.mem_filter.mpr ⟨hP, Finset.card_ne_zero_of_mem hvP⟩, hvP⟩
+  have hQ₀ne : ∀ c ∈ Q₀, c.Nonempty := fun c hc =>
+    Finset.card_pos.mp (Nat.pos_of_ne_zero (Finset.mem_filter.mp hc).2)
+  have hQ₀disj : (↑Q₀ : Set (Finset V)).PairwiseDisjoint id := by
+    intro a ha b hb hab
+    simpa [Function.onFun] using
+      hdisj a b (hQ₀sub (Finset.mem_coe.mp ha)) (hQ₀sub (Finset.mem_coe.mp hb)) hab
+  have hQ₀ref : IsRefinement Q₀ Vparts := fun c hc => href c (hQ₀sub hc)
+  have hfloor : ∀ A ∈ Vparts, m * m ≤ ((Q₀.filter (· ⊆ A)).biUnion id).card := by
+    intro A hA
+    rw [fiber_ground_eq_block Vparts Q₀ hA hVdisj hQ₀cover hQ₀ref]
+    exact hVfloor A hA
+  obtain ⟨Q₁, hground, hQ₁disj, hQ₁ne, hQ₁sized, _hfib, hpe, hloc⟩ :=
+    exists_equitable_recut_blocks G m hm Vparts Q₀ hVdisj hQ₀disj hQ₀ne hfloor
+  have hQ₁ref : IsRefinement Q₁ Vparts := by
+    intro c hc
+    rcases hloc c hc with h0 | h
+    · exact hQ₀ref c h0
+    · exact h
+  have hsize : ∀ c ∈ Q₁, c.card = m ∨ c.card = m + 1 := by
+    intro c hc
+    obtain ⟨A, hA, hcA⟩ := hQ₁ref c hc
+    exact hQ₁sized A hA c hc hcA
+  refine ⟨Q₁, ?_, ?_, hQ₁ref, ?_, ?_, ?_⟩
+  · -- covering: the ground set is preserved by the rebuild
+    intro v
+    obtain ⟨P, hP, hvP⟩ := hQ₀cover v
+    have hv : v ∈ Q₁.biUnion id := by
+      rw [hground]
+      exact Finset.mem_biUnion.mpr ⟨P, hP, hvP⟩
+    obtain ⟨P', hP', hvP'⟩ := Finset.mem_biUnion.mp hv
+    exact ⟨P', hP', hvP'⟩
+  · -- pairwise disjointness, pointwise form
+    intro P Q hP hQ hne
+    have := hQ₁disj (Finset.mem_coe.mpr hP) (Finset.mem_coe.mpr hQ) hne
+    simpa [Function.onFun] using this
+  · -- global ±1 equitability: all sizes lie in {m, m+1}
+    intro P Q hP hQ
+    rcases hsize P hP with h1 | h1 <;> rcases hsize Q hQ with h2 | h2 <;>
+      rw [h1, h2] <;> omega
+  · -- mass floor (the `card = m` branch auto-closes under `rw`)
+    intro P hP
+    rcases hsize P hP with h | h <;> rw [h]
+    exact_mod_cast Nat.le_succ m
+  · -- energy accounting
+    have hpe0 : partitionEnergy G Q₀ = partitionEnergy G q₁ := by
+      rw [hQ₀def]
+      exact partitionEnergy_filter_card_ne_zero G q₁
+    have hcost := recut_blocks_cost_le (V := V) m Vparts Q₀ hVdisj hQ₀ne
+    have hb1 : 2 * ((Q₀.card : ℚ) * (m : ℚ)) / (Fintype.card V : ℚ)
+        ≤ 2 * ((q₁.card : ℚ) * (m : ℚ)) / (Fintype.card V : ℚ) := by
+      rw [div_eq_mul_inv, div_eq_mul_inv]
+      refine mul_le_mul_of_nonneg_right ?_ (inv_nonneg.mpr (by positivity))
+      have h := Nat.mul_le_mul_right m (Finset.card_le_card hQ₀sub)
+      have h' : ((Q₀.card * m : ℕ) : ℚ) ≤ ((q₁.card * m : ℕ) : ℚ) := by
+        exact_mod_cast h
+      push_cast at h'
+      linarith
+    linarith [hpe, hcost, hb1, hpe0]
+
+/-- **The maintained step, deficit form (S27b-ii).**  An invariant-satisfying
+partition `q` (covering, disjoint, refining `Vparts`, ±1-equitable, mass floor
+`m`) that is not AFKS-fine-regular admits a successor satisfying the FULL
+invariant whose energy exceeds `partitionEnergy G q` by the bare-split gain
+`E⁴m²/n²` minus the restoration cost `2·|q₁|·m/n + 2·|Vparts|·m²/n` (with `q₁`
+the intermediate bare-split successor, exposed by the existential).
+
+This is everything the Chain oracle needs EXCEPT positivity of the deficit —
+which fails for every admissible parameter choice (see the module docstring):
+the single-witness gain is dominated by even one absorption's cost.  Closing
+the oracle requires amplifying the gain to the summed mass-weighted defect of
+all irregular pairs (`≥ ε⁵`-scale, the true AFKS mechanism) — the S28 target,
+which composes with `exists_invariant_restore` verbatim. -/
+theorem exists_maintained_next_deficit
+    (G : SimpleGraph V) [DecidableRel G.Adj] (ε E : ℚ) (m : ℕ)
+    (hε : 0 ≤ ε) (hE : 0 < E) (hE1 : E ≤ 1) (hm : 1 ≤ m)
+    (Vparts q : Finset (Finset V))
+    (hVdisj : (↑Vparts : Set (Finset V)).PairwiseDisjoint id)
+    (hVfloor : ∀ A ∈ Vparts, m * m ≤ A.card)
+    (hcover : ∀ v : V, ∃ P ∈ q, v ∈ P)
+    (hdisj : ∀ P Q : Finset V, P ∈ q → Q ∈ q → P ≠ Q → Disjoint P Q)
+    (href : IsRefinement q Vparts)
+    (hequit : ∀ P Q : Finset V, P ∈ q → Q ∈ q → (P.card : ℤ) - Q.card ≤ 1)
+    (hmass : ∀ P ∈ q, (m : ℚ) ≤ P.card)
+    (hnot : ¬ IsAFKSFineRegular G ε E q) :
+    ∃ q' q₁ : Finset (Finset V),
+      (∀ v : V, ∃ P ∈ q', v ∈ P) ∧
+      (∀ P Q : Finset V, P ∈ q' → Q ∈ q' → P ≠ Q → Disjoint P Q) ∧
+      IsRefinement q' Vparts ∧
+      (∀ P Q : Finset V, P ∈ q' → Q ∈ q' → (P.card : ℤ) - Q.card ≤ 1) ∧
+      (∀ P ∈ q', (m : ℚ) ≤ P.card) ∧
+      partitionEnergy G q + E ^ 4 * (m : ℚ) ^ 2 / (Fintype.card V : ℚ) ^ 2
+          - (2 * ((q₁.card : ℚ) * (m : ℚ)) / (Fintype.card V : ℚ)
+             + 2 * ((Vparts.card : ℚ) * ((m : ℚ) * (m : ℚ))) / (Fintype.card V : ℚ)) ≤
+        partitionEnergy G q' := by
+  obtain ⟨q₁, hc₁, hd₁, hr₁, hgain⟩ :=
+    exists_energy_next_of_not_afksFineRegular G ε E (m : ℚ) hε hE hE1
+      (by exact_mod_cast (by omega : 0 < m)) q hcover hdisj hequit hmass hnot
+  obtain ⟨q', hc', hd', hr', he', hm', hrestore⟩ :=
+    exists_invariant_restore G m hm Vparts q₁ hVdisj hVfloor hc₁ hd₁
+      (hr₁ Vparts href)
+  exact ⟨q', q₁, hc', hd', hr', he', hm', by linarith [hgain, hrestore]⟩
+
+end Szemeredi.RegularityOQ04Assemble

--- a/proofs/Proofs/SzemerediRegularityOQ04Discrete.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Discrete.lean
@@ -1,0 +1,158 @@
+/-
+  Szemerédi Regularity OQ04 — S28a: the unbounded two-level statement is DEGENERATE
+
+  ## The finding
+
+  The formalized AFKS target `IsAFKSTwoLevel G ε E Vparts Wparts` (TwoLevel.lean)
+  asks for a fine partition that (i) refines `Vparts`, (ii) sits over an ε-regular
+  coarse partition, and (iii) is `E(k)`-regular on all but an ε-fraction of pairs.
+  Unlike the actual Alon–Fischer–Krivelevich–Szegedy strong lemma, it does NOT
+  bound the number of fine parts (`|Wparts| ≤ L(ε, k)`).
+
+  That omission is fatal to the statement's content: for any positive fine
+  tolerance, EVERY pair of singletons is `E`-regular — a subset of a singleton
+  carrying at least `E·1 > 0` mass is the singleton itself, so the density
+  difference in the regularity test is literally `0`.  Hence the DISCRETE
+  partition (all singletons) is equitable, refines every covering coarse
+  partition, and has zero irregular pairs: `IsAFKSTwoLevel` is witnessed
+  trivially (`exists_afksTwoLevel_discrete` below), with no graph theory at all.
+
+  ## What this means for the program
+
+  The S12–S27 oracle machinery is NOT wasted — its mass-floor invariant is
+  precisely what excludes this degeneracy, and the machinery targets the
+  *bounded* statement the real AFKS lemma makes.  This file:
+
+  * proves the degeneracy honestly (`isEpsilonRegular_singleton`,
+    `exists_afksTwoLevel_discrete`);
+  * defines the corrected target `IsAFKSTwoLevelBounded` — the same three
+    clauses plus the part-count bound `Wparts.card ≤ L` that carries the actual
+    mathematical content.  The S27 restoration layer keeps `|Wparts| ≤ n/m`
+    (mass floor `m`), so the oracle route proves the bounded statement with an
+    `n`-dependent bound; the genuine AFKS bound `L(ε,k)` (n-independent,
+    tower-type) additionally needs the S28 gain amplification recorded in the
+    tracker blocker.
+
+  All results are fully machine-checked (0 axioms, 0 sorries).
+
+  Reference: Alon–Fischer–Krivelevich–Szegedy, "Efficient testing of large
+  graphs", Combinatorica 20 (2000), Lemma 3.2 (note the explicit bound on the
+  number of parts there).
+-/
+import Mathlib
+import Proofs.SzemerediRegularityOQ04TwoLevel
+
+namespace Szemeredi.RegularityOQ04Discrete
+
+open Szemeredi.Core
+open Szemeredi.RegularityOQ04TwoLevel Szemeredi.RegularityOQ04ToleranceBridge
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+omit [Fintype V] [DecidableEq V] in
+/-- **Singleton pairs are `eps`-regular for every positive tolerance.**  A subset
+of a singleton carrying mass at least `eps · 1 > 0` must be the singleton itself,
+so the only instance of the regularity test compares the pair's density with
+itself: the difference is `0`.  This is the engine of the degeneracy: regularity
+testing has no content at singleton scale. -/
+theorem isEpsilonRegular_singleton (G : SimpleGraph V) [DecidableRel G.Adj]
+    {eps : ℚ} (heps : 0 < eps) (a b : V) :
+    IsEpsilonRegular G eps ({a} : Finset V) ({b} : Finset V) := by
+  intro A' B' hA' hB' hcardA hcardB
+  have hAcard : (({a} : Finset V).card : ℚ) = 1 := by simp
+  have hBcard : (({b} : Finset V).card : ℚ) = 1 := by simp
+  rw [hAcard, mul_one] at hcardA
+  rw [hBcard, mul_one] at hcardB
+  have hA'ne : A'.Nonempty := by
+    rcases Finset.eq_empty_or_nonempty A' with rfl | h
+    · simp at hcardA
+      linarith
+    · exact h
+  have hB'ne : B'.Nonempty := by
+    rcases Finset.eq_empty_or_nonempty B' with rfl | h
+    · simp at hcardB
+      linarith
+    · exact h
+  have hA'eq : A' = {a} := by
+    rcases Finset.subset_singleton_iff.mp hA' with h | h
+    · exact absurd h (Finset.nonempty_iff_ne_empty.mp hA'ne)
+    · exact h
+  have hB'eq : B' = {b} := by
+    rcases Finset.subset_singleton_iff.mp hB' with h | h
+    · exact absurd h (Finset.nonempty_iff_ne_empty.mp hB'ne)
+    · exact h
+  rw [hA'eq, hB'eq, sub_self, abs_zero]
+  exact le_of_lt heps
+
+/-- **The discrete partition trivially witnesses the unbounded two-level target.**
+For any `ε ≥ 0`, any coarse partition `Vparts` that is `ε`-regular and covers `V`,
+and any positive fine tolerance `E |Vparts|`, the all-singletons partition
+`Finset.univ.image ({·})` satisfies `IsAFKSTwoLevel G ε E Vparts ·` — covering,
+disjoint, ±1-equitable, refining, with ZERO irregular pairs.
+
+No graph-theoretic input is used: this shows the formalized target, which (unlike
+AFKS Lemma 3.2) does not bound the number of fine parts, is degenerate.  The
+mathematical content of the strong lemma lives in the part-count bound — see
+`IsAFKSTwoLevelBounded` below and the S28 program notes. -/
+theorem exists_afksTwoLevel_discrete (G : SimpleGraph V) [DecidableRel G.Adj]
+    (ε : ℚ) (E : ℕ → ℚ) (hε : 0 ≤ ε)
+    (Vparts : Finset (Finset V))
+    (hcoarse : IsRegularPartition G ε Vparts)
+    (hVcover : ∀ v : V, ∃ A ∈ Vparts, v ∈ A)
+    (hE : 0 < E Vparts.card) :
+    ∃ Wparts : Finset (Finset V), IsAFKSTwoLevel G ε E Vparts Wparts := by
+  classical
+  refine ⟨Finset.univ.image (fun v => ({v} : Finset V)), ?_, ?_, ?_, ?_⟩
+  · exact hcoarse
+  · -- refinement: each singleton sits inside the coarse block containing its point
+    intro W hW
+    obtain ⟨v, _, rfl⟩ := Finset.mem_image.mp hW
+    obtain ⟨A, hA, hvA⟩ := hVcover v
+    exact ⟨A, hA, Finset.singleton_subset_iff.mpr hvA⟩
+  · -- equitability: all parts are singletons
+    intro P Q hP hQ
+    obtain ⟨p, _, rfl⟩ := Finset.mem_image.mp hP
+    obtain ⟨q, _, rfl⟩ := Finset.mem_image.mp hQ
+    simp
+  · -- zero irregular pairs: singleton pairs are always regular
+    have hempty : ((Finset.univ.image (fun v => ({v} : Finset V))).product
+        (Finset.univ.image (fun v => ({v} : Finset V)))).filter
+          (fun pq => pq.1 ≠ pq.2 ∧
+            ¬IsEpsilonRegular G (E Vparts.card) pq.1 pq.2) = ∅ := by
+      rw [Finset.filter_eq_empty_iff]
+      intro pq hpq
+      obtain ⟨h1, h2⟩ := Finset.mem_product.mp hpq
+      obtain ⟨p, _, hp⟩ := Finset.mem_image.mp h1
+      obtain ⟨q, _, hq⟩ := Finset.mem_image.mp h2
+      rintro ⟨-, hirr⟩
+      exact hirr (hp ▸ hq ▸ isEpsilonRegular_singleton G hE p q)
+    rw [hempty]
+    have hk : (0 : ℚ) ≤ ((Finset.univ.image (fun v => ({v} : Finset V))).card : ℚ)
+        * (((Finset.univ.image (fun v => ({v} : Finset V))).card : ℚ) - 1) := by
+      rcases Nat.eq_zero_or_pos (Finset.univ.image (fun v => ({v} : Finset V))).card
+        with h | h
+      · rw [h]; norm_num
+      · have h1 : (1 : ℚ) ≤ ((Finset.univ.image (fun v => ({v} : Finset V))).card : ℚ) := by
+          exact_mod_cast h
+        nlinarith
+    simpa using mul_nonneg hε hk
+
+/-- **The corrected (bounded) two-level target.**  The AFKS strong lemma
+(Lemma 3.2 of the paper) bounds the number of fine parts by a function
+`L = L(ε, |Vparts|)` independent of the vertex count.  Adding that clause
+restores the mathematical content that the unbounded statement lacks — the
+discrete witness of `exists_afksTwoLevel_discrete` has `n` parts and is excluded
+as soon as `L < n`.
+
+The S12–S27 oracle machinery targets exactly this statement: its mass-floor-`m`
+invariant keeps `|Wparts| ≤ n/m` throughout the chain.  Producing an
+`n`-independent `L` additionally requires the amplified (summed, mass-weighted)
+energy increment recorded as the S28 blocker in the problem tracker. -/
+structure IsAFKSTwoLevelBounded (G : SimpleGraph V) [DecidableRel G.Adj]
+    (ε : ℚ) (E : ℕ → ℚ) (L : ℕ) (Vparts Wparts : Finset (Finset V)) : Prop
+    extends IsAFKSTwoLevel G ε E Vparts Wparts where
+  /-- The fine partition has at most `L` parts — the clause carrying the actual
+      content of the strong lemma. -/
+  sizeBound : Wparts.card ≤ L
+
+end Szemeredi.RegularityOQ04Discrete

--- a/proofs/Proofs/SzemerediRegularityOQ04Iterate.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ04Iterate.lean
@@ -83,20 +83,22 @@ theorem exists_equitable_recut_blocks (G : SimpleGraph V) [DecidableRel G.Adj]
       partitionEnergy G Q₀ -
           ∑ A ∈ T, (2 * ((Q₀.filter (· ⊆ A)).card * m : ℚ) / (Fintype.card V : ℚ)
             + 2 * (m * m : ℚ) / (Fintype.card V : ℚ)) ≤
-        partitionEnergy G Q₁ := by
+        partitionEnergy G Q₁ ∧
+      (∀ c ∈ Q₁, c ∈ Q₀ ∨ ∃ A ∈ T, c ⊆ A) := by
   classical
   revert hTdisj hfloor
   induction T using Finset.induction_on with
   | empty =>
       intro _ _
-      refine ⟨Q₀, rfl, hQdisj, hQne, ?_, fun B _ => rfl, by simp⟩
+      refine ⟨Q₀, rfl, hQdisj, hQne, ?_, fun B _ => rfl, by simp,
+        fun c hc => Or.inl hc⟩
       intro A hA
       exact absurd hA (by simp)
   | @insert A T' hA ih =>
       intro hTdisj hfloor
       have hsubT' : (↑T' : Set (Finset V)) ⊆ (↑(insert A T') : Set (Finset V)) :=
         Finset.coe_subset.mpr (Finset.subset_insert A T')
-      obtain ⟨Q', hQ'cov, hQ'disj, hQ'ne, hQ'sized, hQ'fib, hQ'pe⟩ :=
+      obtain ⟨Q', hQ'cov, hQ'disj, hQ'ne, hQ'sized, hQ'fib, hQ'pe, hQ'loc⟩ :=
         ih (hTdisj.subset hsubT')
           (fun A' hA' => hfloor A' (Finset.mem_insert_of_mem hA'))
       -- `A` is disjoint from every block of `T'`
@@ -129,7 +131,7 @@ theorem exists_equitable_recut_blocks (G : SimpleGraph V) [DecidableRel G.Adj]
         have hpos : 0 < c.card := by
           rcases hRsize c hc with h | h <;> omega
         exact Finset.card_pos.mp hpos
-      refine ⟨(Q' \ Q'.filter (· ⊆ A)) ∪ R, ?_, hdisj₂, ?_, ?_, ?_, ?_⟩
+      refine ⟨(Q' \ Q'.filter (· ⊆ A)) ∪ R, ?_, hdisj₂, ?_, ?_, ?_, ?_, ?_⟩
       · rw [hcov]
         exact hQ'cov
       · intro c hc
@@ -170,6 +172,13 @@ theorem exists_equitable_recut_blocks (G : SimpleGraph V) [DecidableRel G.Adj]
         rw [show ((Q'.filter (· ⊆ A)).card : ℚ) = ((Q₀.filter (· ⊆ A)).card : ℚ) from
           by rw [hfibA]] at hpe₂
         linarith [hQ'pe, hpe₂]
+      · -- piece locality: every rebuilt piece is an original piece or sits in a block
+        intro c hc
+        rcases Finset.mem_union.mp hc with h | h
+        · rcases hQ'loc c (Finset.mem_sdiff.mp h).1 with h0 | ⟨A', hA', hcA'⟩
+          · exact Or.inl h0
+          · exact Or.inr ⟨A', Finset.mem_insert_of_mem hA', hcA'⟩
+        · exact Or.inr ⟨A, Finset.mem_insert_self A T', hR_in_A c h⟩
 
 omit [Fintype V] in
 /-- **Disjoint blocks have disjoint fibers.**  Since pieces are nonempty and

--- a/research/problems/szemeredi-regularity-oq-04/knowledge.md
+++ b/research/problems/szemeredi-regularity-oq-04/knowledge.md
@@ -1245,3 +1245,33 @@ hypothesis at all (`exists_afksTwoLevel_of_maintained_oracle_unit`).
 **Residual = S27b-ii only** (assembly): T = Vparts on the bare-split successor, per-block
 m² floors from the maintained invariant, parameter choice loss < retained ε⁴m²/n² fraction,
 into `exists_afksTwoLevel_of_maintained_oracle`.
+
+## Session 2026-07-24 evening (researcher-1): S27b-ii — restoration done, deficit provably negative, S28 named
+
+`SzemerediRegularityOQ04Assemble.lean` (3 thm, 0 ax/0 sorry) + additive locality
+clause on `exists_equitable_recut_blocks` (`∀ c ∈ Q₁, c ∈ Q₀ ∨ ∃ A ∈ T, c ⊆ A` —
+needed to recover IsRefinement/global equitability of the rebuilt family; proof:
+Or.inl in base, lift IH/R-pieces in step).
+
+- `fiber_ground_eq_block`: cover+refines+block-disjoint ⟹ fiber ground = block.
+- `exists_invariant_restore`: any cover/disjoint/refining family → FULL Chain
+  invariant at cost 2|q₁|m/n + 2|Vparts|m²/n. Empty pieces stripped free via
+  Bridge's `partitionEnergy_filter_card_ne_zero`.
+- `exists_maintained_next_deficit`: maintained step, deficit form.
+
+**Mathematical finding (the real content):** the S27 plan's final inequality
+CANNOT close — single-witness gain E⁴m²/n² < any moving cost (2m/n > E⁴m²/n² ⟺
+2n > E⁴m always; even 2m²/n > gain ⟺ 2n > E⁴). Structured blocker recorded;
+reopen = S28 gain amplification (mass-weighted summed defect over ALL irregular
+pairs from ¬IsAFKSFineRegular, ε⁵-scale). With an amplified gain γ the SAME
+`exists_invariant_restore` closes the oracle when γ > cost — pick m ≪ γn/|q₁|.
+
+Lean notes: worktree olean chain was largely missing/pre-v4.31 — rebuilt 20
+files bottom-up with `bin/lake env lean -o` (Tolerance→ToleranceBridge→TwoLevel→
+Dichotomy→SplitProper→CoreOQ01→StepThree→DefectGain→Assembly→Outer→OuterBoth→
+Packaging→Freshness→MassFloor→Fresh→StepRealize→Chain→Iterate), ~5-15s each
+warm. Gotchas hit: S22's "`rw [h]` auto-closes `↑m ≤ ↑m`, never bullet after
+`<;> rw`" (recurred verbatim); `omit [Fintype V] in` BEFORE docstring. Cast
+ascriptions `(a * m : ℚ)` elaborate per-atom (`↑a * ↑m`) so recut_blocks_cost_le
+shapes matched the canonical `((X.card : ℚ) * (m : ℚ))` budget forms with NO
+push_cast needed (a `push_cast at` there is a no-op lint).

--- a/research/problems/szemeredi-regularity-oq-04/knowledge.md
+++ b/research/problems/szemeredi-regularity-oq-04/knowledge.md
@@ -1275,3 +1275,26 @@ warm. Gotchas hit: S22's "`rw [h]` auto-closes `↑m ≤ ↑m`, never bullet aft
 ascriptions `(a * m : ℚ)` elaborate per-atom (`↑a * ↑m`) so recut_blocks_cost_le
 shapes matched the canonical `((X.card : ℚ) * (m : ℚ))` budget forms with NO
 push_cast needed (a `push_cast at` there is a no-op lint).
+
+## Session 2026-07-24 evening, part 2 (researcher-1): S28a — the unbounded target is degenerate
+
+`SzemerediRegularityOQ04Discrete.lean` (2 thm + 1 def, 0 ax/0 sorry).
+
+★★STATEMENT-LEVEL FINDING: `IsAFKSTwoLevel` has no part-count bound, and without
+one it is TRIVIAL: `isEpsilonRegular_singleton` (0 < eps ⟹ every singleton pair
+is eps-regular — the only qualifying subset of a singleton is itself, density
+diff = 0) ⟹ `exists_afksTwoLevel_discrete` (the all-singletons partition
+witnesses the target from coverage + coarse regularity + 0 < E alone). The real
+AFKS Lemma 3.2's `|Wparts| ≤ L(ε,k)` clause carries ALL the content. Corrected
+target `IsAFKSTwoLevelBounded` defined (extends + sizeBound).
+
+Consequences: S12–S27 mass-floor machinery = the bounded-statement route
+(L = n/m); S28 amplification still needed for n-independent L. Future sessions
+should target `IsAFKSTwoLevelBounded`, not the bare statement.
+
+Lean notes: `Szemeredi.Regularity` namespace does NOT exist in the TwoLevel
+import chain — IsEpsilonRegular/IsRegularPartition/partitionEnergy all live in
+`Szemeredi.Core`. Nonemptiness from mass: `rcases Finset.eq_empty_or_nonempty`
++ `simp at hcard; linarith` beats card_pos/by_contra (push_neg now deprecated
+in v4.31 — "Prefer using push Not"). `structure ... extends` for Prop
+structures works fine for the bounded variant.

--- a/research/problems/szemeredi-regularity-oq-04/state.md
+++ b/research/problems/szemeredi-regularity-oq-04/state.md
@@ -4,7 +4,42 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-24 (S27a, researcher-1)
-**Iteration**: 14
+**Iteration**: 15
+
+## Status (S27b-ii, researcher-1, 2026-07-24) — invariant restoration DONE; oracle deficit is NEGATIVE (S28 blocker)
+
+New file `SzemerediRegularityOQ04Assemble.lean` (3 thm, 0 ax, 0 sorry, host-verified
+first-try after one known-gotcha fix) + additive locality clause on S27b-i's
+`exists_equitable_recut_blocks` (`∀ c ∈ Q₁, c ∈ Q₀ ∨ ∃ A ∈ T, c ⊆ A`).
+
+- **`fiber_ground_eq_block`**: cover + refinement + block disjointness ⟹ the fiber
+  ground of every coarse block is the whole block (supplies the per-block m² floors).
+- **`exists_invariant_restore`** (modular capstone): ANY covering, disjoint family
+  refining Vparts (blocks pairwise disjoint, m² ≤ |A|) rebuilds to the FULL Chain
+  loop invariant — cover, disjoint, refines, globally ±1-equitable (sizes {m,m+1}),
+  mass floor m — at ambient cost ≤ 2·|q₁|·m/n + 2·|Vparts|·m²/n.  Empty pieces
+  stripped free (`partitionEnergy_filter_card_ne_zero`); rebuild = S27b-i over
+  T = Vparts; global equitability from the new locality clause.
+- **`exists_maintained_next_deficit`**: the maintained step in DEFICIT form —
+  invariant + ¬fine-regular ⟹ successor with FULL invariant and energy
+  ≥ pe(q) + E⁴m²/n² − (2|q₁|m/n + 2|Vparts|m²/n).
+
+**★THE DEFICIT IS NEVER POSITIVE — the S27 plan's final inequality is impossible.**
+The gain E⁴m²/n² is a SINGLE-WITNESS floor (S18/S19), while any re-equitization
+moving even one piece of mass ≈ m costs ≈ 2m/n, and 2m/n > E⁴m²/n² ⟺ 2n > E⁴m,
+true for every admissible choice (E ≤ 1, m ≤ n).  Even the lone absorption term
+2m²/n exceeds the gain (⟺ 2n > E⁴).  researcher-3's S26 sizing caution was
+correct and understated.  No parameter bookkeeping closes the oracle from the
+single-witness step.
+
+**S28 (reopen criterion / the materially new mechanism):** amplify the per-step
+gain to constant scale — from ¬IsAFKSFineRegular extract the mass-weighted
+ε-fraction of irregular pairs and sum their defect gains (true AFKS increment,
+≥ ε⁵-scale independent of m/n).  The interface is ready: an amplified-gain
+successor composes with `exists_invariant_restore` verbatim, and the oracle
+closes when γ > 2|q₁|m/n + 2|Vparts|m²/n (now satisfiable: pick m with
+m/n ≪ γ/|q₁|-scale).  Everything else (chain, seed, recut, absorption,
+restoration) is DONE.
 
 ## Status (S27a, researcher-1, 2026-07-24) — ambient surgery: in-place fiber re-equitization DONE
 

--- a/research/problems/szemeredi-regularity-oq-04/state.md
+++ b/research/problems/szemeredi-regularity-oq-04/state.md
@@ -4,7 +4,39 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-24 (S27a, researcher-1)
-**Iteration**: 15
+**Iteration**: 16
+
+## Status (S28a, researcher-1, 2026-07-24) — ★THE UNBOUNDED TARGET IS DEGENERATE (discrete witness)
+
+New file `SzemerediRegularityOQ04Discrete.lean` (2 thm + 1 def, 0 ax, 0 sorry,
+host-verified). While scoping S28 gain amplification, a statement-level finding
+that supersedes the bookkeeping question entirely:
+
+**`IsAFKSTwoLevel` (TwoLevel.lean) has NO bound on the number of fine parts —
+and without one the statement is trivially witnessable.** For any `0 < E`,
+every singleton pair is `E`-regular (`isEpsilonRegular_singleton`: a subset of
+a singleton with mass ≥ E·1 > 0 IS the singleton, so the regularity test
+compares the density with itself). Hence the all-singletons partition is
+equitable, refines any covering coarse partition, and has ZERO irregular
+pairs: `exists_afksTwoLevel_discrete` proves `∃ Wparts, IsAFKSTwoLevel G ε E
+Vparts Wparts` from just `IsRegularPartition G ε Vparts` + coverage + `0 <
+E |Vparts|` — no graph theory at all.
+
+The real AFKS Lemma 3.2 bounds `|Wparts| ≤ L(ε, k)` (n-independent,
+tower-type); that clause carries the entire content. Corrected target defined:
+`IsAFKSTwoLevelBounded` (= IsAFKSTwoLevel + `sizeBound : Wparts.card ≤ L`).
+
+**Program status after this finding:**
+- The S12–S27 machinery is NOT wasted: its mass-floor invariant is exactly what
+  excludes the degeneracy, and the oracle route proves the BOUNDED statement
+  with `L = n/m` (n-dependent).
+- The S27b-ii deficit blocker + S28 amplification remain the genuine path to
+  a stronger bounded result; for an n-INDEPENDENT `L(ε,k)` the amplified
+  ε⁵-scale increment is necessary (iteration count must not depend on n).
+- Downstream consumers of `exists_afksTwoLevel_of_maintained_oracle` etc.
+  should be re-read with this in mind: their conclusions are honest
+  (constructive, bounded-by-construction) but the bare `IsAFKSTwoLevel`
+  existence they imply is weaker than it appears.
 
 ## Status (S27b-ii, researcher-1, 2026-07-24) — invariant restoration DONE; oracle deficit is NEGATIVE (S28 blocker)
 

--- a/src/data/research/problems/szemeredi-regularity-oq-04.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-04.json
@@ -32,7 +32,7 @@
     "nextAction": "S26: parameter bookkeeping only — choose m with 2|P|m/n below the retained eps^4 m^2/n^2-scale gain and feed exists_afksTwoLevel_of_maintained_oracle; apply S22 n = a*m + b*(m+1) global-equitability packaging to the recut output."
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: S12-S27b-ii complete (0 axioms throughout). The re-equitization program is DONE: exists_invariant_restore rebuilds any covering refining family to the full Chain invariant at cost 2|q1|m/n + 2|Vparts|m^2/n, and exists_maintained_next_deficit gives the maintained step in deficit form. The deficit is provably NEGATIVE for the single-witness gain E^4m^2/n^2 (structured blocker) - the single remaining gap is S28: amplify the per-step gain to the summed mass-weighted defect of all irregular pairs (eps^5-scale), which then composes with exists_invariant_restore verbatim and closes exists_afksTwoLevel_of_maintained_oracle.",
+    "progressSummary": "PROGRESS: S12-S27b-ii complete + S28a statement audit. MAJOR FINDING: the bare IsAFKSTwoLevel target is degenerate (discrete partition witnesses it trivially - exists_afksTwoLevel_discrete); the content lives in the part-count bound, now formalized as IsAFKSTwoLevelBounded. The oracle machinery proves the bounded statement with L = n/m; the S28 amplified increment (structured blocker) is the path to an n-independent L(eps,k). Future sessions: target IsAFKSTwoLevelBounded.",
     "builtItems": [
       "gap_forces_complement_nonempty in SzemerediRegularityOQ04SplitProper.lean (S16) — the eps-density gap |d(A1,B1)-d(A,B)| >= eps > 0 forbids a doubly-trivial split: A2.Nonempty OR B2.Nonempty (both empty would force A1=A,B1=B, gap=0). exists_sharp_split_nontrivial_of_not_afksFineRegular appends this disjunction to the S11 extracted sharp split.",
       "edgeDensity_union_mul in SzemerediRegularityOQ04Energy.lean — weighted-average identity |A1cupA2||B|d = |A1||B|d1+|A2||B|d2 for disjoint A-split (reusable public API; previously trapped inside density_sq_convex proof).",
@@ -123,7 +123,10 @@
       "fiber_ground_eq_block in SzemerediRegularityOQ04Assemble.lean",
       "exists_invariant_restore (S27b-ii modular capstone) in SzemerediRegularityOQ04Assemble.lean",
       "exists_maintained_next_deficit (deficit-form maintained step) in SzemerediRegularityOQ04Assemble.lean",
-      "locality clause on exists_equitable_recut_blocks in SzemerediRegularityOQ04Iterate.lean"
+      "locality clause on exists_equitable_recut_blocks in SzemerediRegularityOQ04Iterate.lean",
+      "isEpsilonRegular_singleton in SzemerediRegularityOQ04Discrete.lean",
+      "exists_afksTwoLevel_discrete (degeneracy witness) in SzemerediRegularityOQ04Discrete.lean",
+      "IsAFKSTwoLevelBounded (corrected target) in SzemerediRegularityOQ04Discrete.lean"
     ],
     "insights": [
       "The complement pieces A2=A\\A1, B2=B\\B1 of the AFKS sharp 2x2 split are NOT both forced nonempty by the analytic data: the density gap only forbids BOTH being empty (S16). When one corner exhausts its block (A1=A) the honest refinement is the asymmetric 3-piece split {A,B1,B2}; the 4-piece IsWitnessedSharpStep shape (S14 isWitnessedSharpStep_of_split_of_gap) requires an asymmetric-step packaging for that degenerate branch, not a further nonemptiness lemma.",
@@ -183,7 +186,9 @@
       "S27b-ii: invariant restoration is fully modular - exists_invariant_restore rebuilds ANY covering/disjoint/refining family to the complete Chain loop invariant (cover, disjoint, refines, +-1 equitable, mass floor m) at explicit cost 2|q1|m/n + 2|Vparts|m^2/n; an S28 amplified-gain successor composes with it verbatim.",
       "THE S27 DEFICIT IS PROVABLY NEGATIVE: the single-witness gain E^4m^2/n^2 is below ANY re-equitization cost (2m/n > E^4m^2/n^2 iff 2n > E^4m, always true for E<=1, m<=n; even the lone absorption term 2m^2/n exceeds the gain). researcher-3 sizing caution confirmed and sharpened - closing the oracle REQUIRES gain amplification, not bookkeeping.",
       "Locality clause added to exists_equitable_recut_blocks (every rebuilt piece is an original piece or sits inside a processed block) - the missing link from the recut output to IsRefinement and global equitability of the restored family.",
-      "Empty-piece stripping is free: Bridge partitionEnergy_filter_card_ne_zero lets the restoration accept bare-split successors without a nonemptiness hypothesis."
+      "Empty-piece stripping is free: Bridge partitionEnergy_filter_card_ne_zero lets the restoration accept bare-split successors without a nonemptiness hypothesis.",
+      "DEGENERACY: IsAFKSTwoLevel (no part-count bound) is trivially witnessable - every singleton pair is eps-regular for 0 < eps, so the discrete partition satisfies all three clauses with zero graph theory (exists_afksTwoLevel_discrete). The mathematical content of AFKS Lemma 3.2 lives entirely in the |Wparts| <= L(eps,k) bound the formalization omitted.",
+      "Corrected target IsAFKSTwoLevelBounded defined (adds sizeBound : Wparts.card <= L). The S12-S27 mass-floor machinery proves the bounded statement with L = n/m; an n-independent L(eps,k) additionally requires the S28 amplified eps^5-scale increment (iteration count must not depend on n)."
     ],
     "mathlibGaps": [],
     "nextSteps": [

--- a/src/data/research/problems/szemeredi-regularity-oq-04.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-04.json
@@ -22,11 +22,17 @@
     "since": "2026-07-24",
     "iteration": 12,
     "focus": "S25 ACT (researcher-1, 2026-07-24): equitable re-cut DONE — merging half combinatorial step. New SzemerediRegularityOQ04Recut.lean: exists_equitable_recut (any pairwise-disjoint P re-cuts into R, same ground set, pieces nonempty <= m, AT MOST ONE deficient globally, energy loss <= 2|P|m/n) via S23 chop-refinement + pooled-deficient re-cut (S22 engine) + S24 replace bound; plus m=1 unit instance. Docker-GREEN, 0 ax / 0 sorry.",
-    "blockers": [],
+    "blockers": [
+      {
+        "route": "S27 maintained-oracle closure from the single-witness gain E^4 m^2/n^2 (parameter bookkeeping over restoration cost 2|q1|m/n + 2|Vparts|m^2/n)",
+        "reopenCriterion": "materially new mechanism required: S28 gain amplification - extract the mass-weighted defect summed over ALL irregular pairs from not-IsAFKSFineRegular (true AFKS eps^5-scale increment, independent of m/n); the deficit 2m/n > E^4 m^2/n^2 holds for every admissible parameter choice, so no bookkeeping closes it",
+        "blockedAt": "2026-07-24"
+      }
+    ],
     "nextAction": "S26: parameter bookkeeping only — choose m with 2|P|m/n below the retained eps^4 m^2/n^2-scale gain and feed exists_afksTwoLevel_of_maintained_oracle; apply S22 n = a*m + b*(m+1) global-equitability packaging to the recut output."
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: AFKS re-equitization combinatorially complete AND ambient-composable: S23-S26 pipeline + S27a in-place forms (exists_equitable_recut_within: fiber S of ambient Q0 with m^2 <= |U S| re-cuts in place to sizes {m,m+1} at ambient cost 2|S|m/n + 2m^2/n). All 0-axiom. S27b = iterate over the coarse blocks of the bare-split successor (Finset induction, per-block ground-mass floor) + parameter choice feeding exists_afksTwoLevel_of_maintained_oracle.",
+    "progressSummary": "PROGRESS: S12-S27b-ii complete (0 axioms throughout). The re-equitization program is DONE: exists_invariant_restore rebuilds any covering refining family to the full Chain invariant at cost 2|q1|m/n + 2|Vparts|m^2/n, and exists_maintained_next_deficit gives the maintained step in deficit form. The deficit is provably NEGATIVE for the single-witness gain E^4m^2/n^2 (structured blocker) - the single remaining gap is S28: amplify the per-step gain to the summed mass-weighted defect of all irregular pairs (eps^5-scale), which then composes with exists_invariant_restore verbatim and closes exists_afksTwoLevel_of_maintained_oracle.",
     "builtItems": [
       "gap_forces_complement_nonempty in SzemerediRegularityOQ04SplitProper.lean (S16) — the eps-density gap |d(A1,B1)-d(A,B)| >= eps > 0 forbids a doubly-trivial split: A2.Nonempty OR B2.Nonempty (both empty would force A1=A,B1=B, gap=0). exists_sharp_split_nontrivial_of_not_afksFineRegular appends this disjunction to the S11 extracted sharp split.",
       "edgeDensity_union_mul in SzemerediRegularityOQ04Energy.lean — weighted-average identity |A1cupA2||B|d = |A1||B|d1+|A2||B|d2 for disjoint A-split (reusable public API; previously trapped inside density_sq_convex proof).",
@@ -113,7 +119,11 @@
       "S27a SzemerediRegularityOQ04Surgery.lean: exists_absorb_deficient_within (in-place absorption, ambient loss <= 2m^2/n)",
       "S27a: exists_chop_refinement_within (fiber chop as ambient refinement, zero loss)",
       "S27a: exists_equitable_recut_within (per-block brick: fiber -> exact {m,m+1} in place, ambient cost 2|S|m/n + 2m^2/n)",
-      "SzemerediRegularityOQ04Iterate.lean: exists_equitable_recut_blocks + sum_fiber_card_le + recut_blocks_cost_le (3 thm, 0 axioms, 0 sorries, docker 8589 jobs first-try)"
+      "SzemerediRegularityOQ04Iterate.lean: exists_equitable_recut_blocks + sum_fiber_card_le + recut_blocks_cost_le (3 thm, 0 axioms, 0 sorries, docker 8589 jobs first-try)",
+      "fiber_ground_eq_block in SzemerediRegularityOQ04Assemble.lean",
+      "exists_invariant_restore (S27b-ii modular capstone) in SzemerediRegularityOQ04Assemble.lean",
+      "exists_maintained_next_deficit (deficit-form maintained step) in SzemerediRegularityOQ04Assemble.lean",
+      "locality clause on exists_equitable_recut_blocks in SzemerediRegularityOQ04Iterate.lean"
     ],
     "insights": [
       "The complement pieces A2=A\\A1, B2=B\\B1 of the AFKS sharp 2x2 split are NOT both forced nonempty by the analytic data: the density gap only forbids BOTH being empty (S16). When one corner exhausts its block (A1=A) the honest refinement is the asymmetric 3-piece split {A,B1,B2}; the 4-piece IsWitnessedSharpStep shape (S14 isWitnessedSharpStep_of_split_of_gap) requires an asymmetric-step packaging for that degenerate branch, not a further nonemptiness lemma.",
@@ -169,7 +179,11 @@
       "S27a ambient surgery: the fiber energy is NOT a summand of ambient energy (cross-block pairs), so per-block re-equitization must be stated on the AMBIENT family; chopping only the fiber IS an ambient refinement (refine_mono with trivial cells {A} outside the fiber), and pool/absorb are S24 replacements with small mass - the whole S25/S26 pipeline transfers in-place",
       "The untouched ambient part identity A2 \\\\ R1 = Q0 \\\\ S needs fiber pieces nonempty + contained in the fiber ground set: an old piece equal to a fiber piece would be a nonempty subset of U S yet disjoint from every member of S",
       "Lean: Finset.union_biUnion (NOT biUnion_union, which is pointwise) distributes biUnion over family union; after simp [mem_sdiff] in an ext goal both sides unfold to conjunctions - return mem_sdiff.mp h directly",
-      "S27b-i (researcher-1, 2026-07-24): block-family iteration DONE in new SzemerediRegularityOQ04Iterate.lean. exists_equitable_recut_blocks — Finset.induction_on over disjoint blocks T; the composable invariant is FIBER PRESERVATION AS FINSETS (Q1.filter (⊆B) = Q0.filter (⊆B) for B disjoint from all processed blocks), which keeps both the m² floors and the cost terms anchored to the ORIGINAL family, so costs telescope to Σ_A (2|fiber(A)|m/n + 2m²/n). recut_blocks_cost_le bounds the sum by 2|Q0|m/n + 2|T|m²/n via disjoint-fibers card_biUnion. Key trick: rw the CARD-CAST equation (not the raw fiber equation) into the step inequality — rewriting the fiber Finset equation would also rewrite the family expression in the conclusion."
+      "S27b-i (researcher-1, 2026-07-24): block-family iteration DONE in new SzemerediRegularityOQ04Iterate.lean. exists_equitable_recut_blocks — Finset.induction_on over disjoint blocks T; the composable invariant is FIBER PRESERVATION AS FINSETS (Q1.filter (⊆B) = Q0.filter (⊆B) for B disjoint from all processed blocks), which keeps both the m² floors and the cost terms anchored to the ORIGINAL family, so costs telescope to Σ_A (2|fiber(A)|m/n + 2m²/n). recut_blocks_cost_le bounds the sum by 2|Q0|m/n + 2|T|m²/n via disjoint-fibers card_biUnion. Key trick: rw the CARD-CAST equation (not the raw fiber equation) into the step inequality — rewriting the fiber Finset equation would also rewrite the family expression in the conclusion.",
+      "S27b-ii: invariant restoration is fully modular - exists_invariant_restore rebuilds ANY covering/disjoint/refining family to the complete Chain loop invariant (cover, disjoint, refines, +-1 equitable, mass floor m) at explicit cost 2|q1|m/n + 2|Vparts|m^2/n; an S28 amplified-gain successor composes with it verbatim.",
+      "THE S27 DEFICIT IS PROVABLY NEGATIVE: the single-witness gain E^4m^2/n^2 is below ANY re-equitization cost (2m/n > E^4m^2/n^2 iff 2n > E^4m, always true for E<=1, m<=n; even the lone absorption term 2m^2/n exceeds the gain). researcher-3 sizing caution confirmed and sharpened - closing the oracle REQUIRES gain amplification, not bookkeeping.",
+      "Locality clause added to exists_equitable_recut_blocks (every rebuilt piece is an original piece or sits inside a processed block) - the missing link from the recut output to IsRefinement and global equitability of the restored family.",
+      "Empty-piece stripping is free: Bridge partitionEnergy_filter_card_ne_zero lets the restoration accept bare-split successors without a nonemptiness hypothesis."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for szemeredi-regularity-oq-04 (AFKS two-level regularity). Two results, one session:

1. **S27b-ii: the re-equitization program is complete** (`SzemerediRegularityOQ04Assemble.lean`), with the honest finding that the S27 oracle deficit is provably negative — the gap is isolated to S28 gain amplification.
2. **S28a: the formalized target itself is degenerate** (`SzemerediRegularityOQ04Discrete.lean`) — `IsAFKSTwoLevel` omits the AFKS part-count bound, and without it the statement is trivially witnessable. The corrected bounded target is defined.

## Part 1 — S27b-ii (Assemble.lean, 3 theorems, 0 ax / 0 sorry)
- `fiber_ground_eq_block` — cover + refinement + block disjointness imply each coarse block's fiber ground is the whole block.
- `exists_invariant_restore` (modular capstone) — ANY covering, pairwise-disjoint family refining `Vparts` rebuilds to the FULL Chain loop invariant (cover, disjoint, refines, +-1 equitable with sizes {m, m+1}, mass floor m) at ambient cost at most `2|q1|m/n + 2|Vparts|m^2/n`.
- `exists_maintained_next_deficit` — the maintained step in deficit form.
- Additive locality clause on S27b-i's `exists_equitable_recut_blocks` (every rebuilt piece is an original piece or sits inside a block).

**Finding: the deficit is provably negative for every admissible parameter choice.** The single-witness gain `E^4 m^2/n^2` is below any re-equitization cost (`2m/n > E^4 m^2/n^2` iff `2n > E^4 m`, always). No parameter bookkeeping closes the maintained oracle; researcher-3's S26 sizing caution was correct and understated. Structured blocker recorded (reopen: S28 summed mass-weighted defect over all irregular pairs, eps^5-scale).

## Part 2 — S28a (Discrete.lean, 2 theorems + 1 def, 0 ax / 0 sorry)
**The unbounded target is degenerate.** `isEpsilonRegular_singleton`: for `0 < eps`, every singleton pair is eps-regular (the only qualifying subset of a singleton is itself, so the regularity test compares a density with itself). Hence `exists_afksTwoLevel_discrete`: the all-singletons partition witnesses `IsAFKSTwoLevel G eps E Vparts _` from coverage + coarse regularity + `0 < E |Vparts|` alone — no graph theory. The real AFKS Lemma 3.2 bounds `|Wparts| <= L(eps, k)`; that clause carries the entire content and is now formalized as `IsAFKSTwoLevelBounded` (extends the old target with `sizeBound`).

**Program status:** the S12-S27 mass-floor machinery is exactly the bounded-statement route (it keeps `|Wparts| <= n/m`); the S28 amplification is the path to an n-independent `L(eps,k)`. Future sessions should target `IsAFKSTwoLevelBounded`.

## Files Modified
- `proofs/Proofs/SzemerediRegularityOQ04Assemble.lean` (new), `SzemerediRegularityOQ04Discrete.lean` (new), `SzemerediRegularityOQ04Iterate.lean` (additive clause)
- `research/problems/szemeredi-regularity-oq-04/state.md`, `knowledge.md`; tracker JSON (structured blocker + 6 insights + 7 builtItems)

## Status
**Outcome**: progress (restoration layer complete; target degeneracy found and corrected; the genuine remaining gap is S28 amplification toward `IsAFKSTwoLevelBounded`)
**Next Steps**: target the bounded statement; S28 = mass-weighted summed-defect extraction from the fine-regularity negation.

All 6 touched/new theorems: `#print axioms` = `[propext, Classical.choice, Quot.sound]`, host-verified v4.31.

🤖 Generated by researcher-1
