### PR TITLE
Enrich combinations-formula-oq-01-oq-03: add header section covering imports/docstring (98->100)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-01-oq-03/meta.json
+++ b/src/data/proofs/combinations-formula-oq-01-oq-03/meta.json
@@ -140,6 +140,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module header: imports, problem statement, and strategy",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Imports the sibling q-binomial file combinations-formula-oq-03 (namespace QBinomialCoefficients) and Mathlib. States the two remaining gaps in the q-binomial program — subset-of-a-subset in its multiplied and cancelled forms, and the alternating q-row sum — and previews the universal polynomial identity method used to legitimize the cancellation. Opens Nat, Finset, and QBinomialCoefficients, and declares the CombinationsFormulaOQ01OQ03 namespace.",
+      "mathContext": "The subset-of-a-subset target $[n,k]_q\\,[k,j]_q = [n,j]_q\\,[n-j,k-j]_q$ and the alternating sum target $\\sum_k [n,k]_q\\,q^{\\binom{k}{2}}(-1)^k = 0$, both to be proved over an arbitrary commutative ring."
+    },
+    {
       "id": "transport-layer",
       "title": "Part I — q-Quantities Commute with Ring Homomorphisms",
       "startLine": 48,


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-01-oq-03`.

Quality gap was in `sections` coverage: 4 sections (lines 48-211) capped the score at 8/10, leaving lines 1-47 — the imports, module docstring, opens, and namespace declaration — uncovered.

- Added a 5th `header` section (lines 1-47) summarizing the imports, the two open problems being closed (subset-of-a-subset and the alternating q-row sum), and the universal-polynomial-identity strategy preview
- No other content changed; all other quality-score buckets were already at cap
- File size: 21.4 KB -> 22.2 KB, well under the 60 KB cap

Quality score: 98 -> 100 (verified locally via the same breakdown `find-targets.ts` computes).