### PR TITLE
Research: erdos-70-wip-01 - full infinite Ramsey theorem (every uniformity, every colour count) [0 ax / 0 sorry]

### DIFF
--- a/proofs/Proofs/Erdos70WIP01RamseyGeneral.lean
+++ b/proofs/Proofs/Erdos70WIP01RamseyGeneral.lean
@@ -1,0 +1,372 @@
+import Mathlib
+import Proofs.Erdos70WIP01
+
+/-
+# Erdős #70 — the infinite Ramsey theorem for every uniformity and colour count
+# (erdos-70-wip-01, r-uniform k-colour generalization of the triples engine)
+
+## What This File Contains
+
+`Proofs/Erdos70WIP01.lean` proved the infinite Ramsey theorem for 2-colourings
+of 3-element subsets (`infiniteRamsey3_holds`) by an iterated ultrafilter-majority
+argument with three hand-coded majority levels (`pairMaj`, `pointMaj`, `topMaj`).
+That was the single missing ingredient for the formalized (cardinality-surrogate)
+Erdős #70 conjecture.  The registered next step on this node is to generalize the
+engine to arbitrary uniformity `r` and arbitrary finite colour count — reusable
+partition-calculus infrastructure absent from Mathlib v4.31 (whose combinatorics
+library stops at finite Ramsey-type results: Hales–Jewett, Hindman, pigeonhole).
+
+This file delivers the full generalization:
+
+1. `majColorK` — the `U`-majority colour of a `Fin (k+1)`-valued function on `ℕ`,
+   `U` = the hyperfilter (an ultrafilter extending the cofinite filter); an
+   ultrafilter selects exactly one cell of any finite partition.
+2. `listMaj` — the recursive majority tower, generalizing the three hand-coded
+   levels at once: on a list `L` of fewer than `r` points it is the majority over
+   one-point extensions, and at `r` points it is the honest colour.  This single
+   definition makes every goodness condition *definitionally* `U`-large, so the
+   choice invariant (`RamseyInv`) of the 3-uniform proof disappears entirely.
+3. `genSeq` — the recursively chosen homogeneous sequence: each term is the least
+   member of the (`U`-large, hence nonempty) good set of its predecessors.
+4. `ramsey_nat_general` — **infinite Ramsey on `ℕ`, every `r`, every `k + 1`
+   colours**: any colouring of the `r`-subsets of `ℕ` by `k + 1` colours admits
+   an infinite homogeneous set.
+5. `infiniteRamsey_general` — the same over an arbitrary infinite type, by
+   pulling the colouring back along `ℕ ↪ S` and pushing the homogeneous set
+   forward.
+6. `infiniteRamsey3_of_general` — sanity bridge: the parent file's
+   `InfiniteRamsey3` is the special case `r = 3`, `k + 1 = 2`.
+
+## Honesty note
+
+This is *infrastructure*: it generalizes the ingredient that already settled the
+formalized (cardinality-surrogate) conjecture.  The genuine Erdős #70 partition
+relation `𝔠 → (β, n)₂³` with true order type `β ≥ ω²` remains open and blocked on
+Erdős–Rado order-type-preserving machinery (see the node's registered blocker).
+-/
+
+set_option linter.unusedVariables false
+
+namespace Erdos70
+
+section RamseyGeneral
+
+open Filter
+
+/-! ## Part 1: `k+1`-colour ultrafilter majority -/
+
+/-- An ultrafilter selects a cell of every finite partition: some colour class of
+a `Fin (k+1)`-valued function is `U`-large.  (For `Fin 2` this is the case split
+inside `majColor`; here it is a genuine finite pigeonhole over the ultrafilter.) -/
+theorem exists_majority {k : ℕ} (f : ℕ → Fin (k + 1)) :
+    ∃ i : Fin (k + 1), {n | f n = i} ∈ hyperfilter ℕ := by
+  by_contra h
+  have h' : ∀ i : Fin (k + 1), {n | f n = i} ∉ hyperfilter ℕ := not_exists.mp h
+  have hc : ∀ i : Fin (k + 1), {n | f n = i}ᶜ ∈ hyperfilter ℕ := fun i =>
+    Ultrafilter.compl_mem_iff_notMem.mpr (h' i)
+  have hint : (⋂ i : Fin (k + 1), {n | f n = i}ᶜ) ∈ hyperfilter ℕ :=
+    Filter.iInter_mem.mpr hc
+  obtain ⟨n, hn⟩ := Ultrafilter.nonempty_of_mem hint
+  simp only [Set.mem_iInter, Set.mem_compl_iff, Set.mem_setOf_eq] at hn
+  exact hn (f n) rfl
+
+/-- The `U`-majority colour of a `Fin (k+1)`-valued function on `ℕ`. -/
+noncomputable def majColorK {k : ℕ} (f : ℕ → Fin (k + 1)) : Fin (k + 1) :=
+  Classical.choose (exists_majority f)
+
+/-- The defining property: the majority colour is attained on a `U`-large set. -/
+theorem majColorK_mem {k : ℕ} (f : ℕ → Fin (k + 1)) :
+    {n | f n = majColorK f} ∈ hyperfilter ℕ :=
+  Classical.choose_spec (exists_majority f)
+
+/-- Polymorphic finite-conjunction lemma (the parent file's `list_forall_large`
+with an arbitrary index type, needed here to index conditions by *lists*): a
+conjunction of `U`-large conditions over a finite list is `U`-large. -/
+theorem list_forall_large' {α : Type*} {P : α → ℕ → Prop} (L : List α)
+    (h : ∀ a ∈ L, {m | P a m} ∈ hyperfilter ℕ) :
+    {m | ∀ a ∈ L, P a m} ∈ hyperfilter ℕ := by
+  induction L with
+  | nil =>
+    have huniv : {m : ℕ | ∀ a ∈ ([] : List α), P a m} = Set.univ := by
+      ext m; simp
+    rw [huniv]
+    exact Filter.univ_mem
+  | cons a L ih =>
+    have h1 : {m | P a m} ∈ hyperfilter ℕ := h a (by simp)
+    have h2 : {m | ∀ b ∈ L, P b m} ∈ hyperfilter ℕ :=
+      ih fun b hb => h b (List.mem_cons_of_mem a hb)
+    refine Filter.mem_of_superset (Filter.inter_mem h1 h2) ?_
+    rintro m ⟨hm1, hm2⟩ b hb
+    rcases List.mem_cons.mp hb with rfl | hb'
+    · exact hm1
+    · exact hm2 b hb'
+
+/-! ## Part 2: the recursive majority tower -/
+
+/-- The recursive majority tower, all levels of the 3-uniform proof's
+`pairMaj`/`pointMaj`/`topMaj` at once.  On a list of at least `r` points, the
+honest colour of the underlying finset (junk `0` on collisions); on fewer, the
+`U`-majority over one-point extensions. -/
+noncomputable def listMaj (r k : ℕ) (c : Coloring ℕ r (k + 1)) (L : List ℕ) :
+    Fin (k + 1) :=
+  if h : r ≤ L.length then
+    if hc : L.toFinset.card = r then c ⟨L.toFinset, hc⟩ else 0
+  else
+    majColorK (fun z => listMaj r k c (L ++ [z]))
+termination_by r - L.length
+decreasing_by
+  simp only [List.length_append, List.length_singleton]
+  omega
+
+/-- Below the top level, `listMaj` is the majority of its one-point extensions. -/
+theorem listMaj_of_length_lt {r k : ℕ} (c : Coloring ℕ r (k + 1)) {L : List ℕ}
+    (h : L.length < r) :
+    listMaj r k c L = majColorK (fun z => listMaj r k c (L ++ [z])) := by
+  rw [listMaj]
+  exact dif_neg (not_le.mpr h)
+
+/-- At the top level, `listMaj` computes the honest colour. -/
+theorem listMaj_eq_color {r k : ℕ} (c : Coloring ℕ r (k + 1)) {L : List ℕ}
+    (hlen : r ≤ L.length) (hc : L.toFinset.card = r) :
+    listMaj r k c L = c ⟨L.toFinset, hc⟩ := by
+  rw [listMaj]
+  rw [dif_pos hlen, dif_pos hc]
+
+/-- The heart of the simplification: extending any short list by its majority
+colour is a `U`-large condition — *definitionally*, with no invariant needed. -/
+theorem listMaj_extend_large {r k : ℕ} (c : Coloring ℕ r (k + 1)) {L : List ℕ}
+    (h : L.length < r) :
+    {m | listMaj r k c (L ++ [m]) = listMaj r k c L} ∈ hyperfilter ℕ := by
+  have hmem := majColorK_mem (fun z => listMaj r k c (L ++ [z]))
+  rwa [← listMaj_of_length_lt c h] at hmem
+
+/-! ## Part 3: the good set and the homogeneous sequence -/
+
+/-- The set of viable next elements after the finite prefix `L`: larger than all
+of `L`, and preserving the majority tower along every short sublist of `L`. -/
+def goodSetK (r k : ℕ) (c : Coloring ℕ r (k + 1)) (L : List ℕ) : Set ℕ :=
+  {m | (∀ a ∈ L, a < m) ∧
+    ∀ S ∈ L.sublists, S.length < r →
+      listMaj r k c (S ++ [m]) = listMaj r k c S}
+
+/-- The good set is `U`-large — with *no* hypotheses on `L`: every clause is
+`U`-large by `listMaj_extend_large` (definitional) or cofiniteness of tails. -/
+theorem goodSetK_mem (r k : ℕ) (c : Coloring ℕ r (k + 1)) (L : List ℕ) :
+    goodSetK r k c L ∈ hyperfilter ℕ := by
+  have hA : {m | ∀ a ∈ L, a < m} ∈ hyperfilter ℕ :=
+    list_forall_large' L (fun a _ => gt_large a)
+  have hB : {m | ∀ S ∈ L.sublists, S.length < r →
+      listMaj r k c (S ++ [m]) = listMaj r k c S} ∈ hyperfilter ℕ := by
+    apply list_forall_large'
+    intro S hS
+    by_cases hlen : S.length < r
+    · exact Filter.mem_of_superset (listMaj_extend_large c hlen)
+        fun m hm _ => hm
+    · exact Filter.mem_of_superset Filter.univ_mem
+        fun m _ hlen' => absurd hlen' hlen
+  exact Filter.inter_mem hA hB
+
+/-- The increasing prefix lists of the homogeneous sequence: each new term is the
+least member of the good set of its predecessors. -/
+noncomputable def genPrefix (r k : ℕ) (c : Coloring ℕ r (k + 1)) : ℕ → List ℕ
+  | 0 => []
+  | n + 1 => genPrefix r k c n ++ [sInf (goodSetK r k c (genPrefix r k c n))]
+
+/-- The homogeneous sequence itself. -/
+noncomputable def genSeq (r k : ℕ) (c : Coloring ℕ r (k + 1)) (n : ℕ) : ℕ :=
+  sInf (goodSetK r k c (genPrefix r k c n))
+
+theorem genPrefix_succ (r k : ℕ) (c : Coloring ℕ r (k + 1)) (n : ℕ) :
+    genPrefix r k c (n + 1) = genPrefix r k c n ++ [genSeq r k c n] := rfl
+
+/-- Each term really lies in the good set of its predecessors (which is
+`U`-large, hence nonempty).  No induction needed — `goodSetK_mem` is
+unconditional. -/
+theorem genSeq_mem_goodSet (r k : ℕ) (c : Coloring ℕ r (k + 1)) (n : ℕ) :
+    genSeq r k c n ∈ goodSetK r k c (genPrefix r k c n) :=
+  Nat.sInf_mem (Ultrafilter.nonempty_of_mem (goodSetK_mem r k c _))
+
+/-- The prefix list is the sequence over an initial segment of indices. -/
+theorem genPrefix_eq_map (r k : ℕ) (c : Coloring ℕ r (k + 1)) (n : ℕ) :
+    genPrefix r k c n = (List.range n).map (genSeq r k c) := by
+  induction n with
+  | zero => rfl
+  | succ n ih =>
+    rw [genPrefix_succ, ih, List.range_succ, List.map_append, List.map_singleton]
+
+theorem mem_genPrefix_iff (r k : ℕ) (c : Coloring ℕ r (k + 1)) {a n : ℕ} :
+    a ∈ genPrefix r k c n ↔ ∃ j, j < n ∧ genSeq r k c j = a := by
+  rw [genPrefix_eq_map]
+  simp [List.mem_map, List.mem_range]
+
+theorem genSeq_strictMono (r k : ℕ) (c : Coloring ℕ r (k + 1)) :
+    StrictMono (genSeq r k c) := by
+  intro i j hij
+  have hmem : genSeq r k c i ∈ genPrefix r k c j :=
+    (mem_genPrefix_iff r k c).mpr ⟨i, hij, rfl⟩
+  exact (genSeq_mem_goodSet r k c j).1 _ hmem
+
+/-! ## Part 4: homogeneity by telescoping the majority tower -/
+
+/-- A strictly increasing list of naturals bounded by `n` is a sublist of
+`range n`.  (The index-bookkeeping lemma behind the telescope.) -/
+theorem sorted_lt_sublist_range {ps : List ℕ} :
+    ∀ {n : ℕ}, ps.Pairwise (· < ·) → (∀ x ∈ ps, x < n) →
+      ps.Sublist (List.range n) := by
+  induction ps using List.reverseRecOn with
+  | nil => intro n _ _; exact List.nil_sublist _
+  | append_singleton ps x ih =>
+    intro n hs hb
+    have hpair := List.pairwise_append.mp hs
+    have h1 : ps.Sublist (List.range x) :=
+      ih hpair.1 (fun a ha => hpair.2.2 a ha x (List.mem_singleton_self x))
+    have h2 : (ps ++ [x]).Sublist (List.range x ++ [x]) :=
+      h1.append (List.Sublist.refl [x])
+    rw [← List.range_succ] at h2
+    exact h2.trans (List.range_sublist.mpr (hb x (by simp)))
+
+/-- **The telescope.**  Along any strictly increasing index list of length at
+most `r`, the majority tower over the corresponding sequence values collapses
+to its base `listMaj r k c []`: the largest point was chosen good for a prefix
+containing all the others, so each step peels one point off the top. -/
+theorem listMaj_map_eq_base (r k : ℕ) (c : Coloring ℕ r (k + 1)) :
+    ∀ ps : List ℕ, ps.Pairwise (· < ·) → ps.length ≤ r →
+      listMaj r k c (ps.map (genSeq r k c)) = listMaj r k c [] := by
+  intro ps
+  induction ps using List.reverseRecOn with
+  | nil => intro _ _; rfl
+  | append_singleton ps p ih =>
+    intro hs hlen
+    have hpair := List.pairwise_append.mp hs
+    have hps_lt : ∀ a ∈ ps, a < p :=
+      fun a ha => hpair.2.2 a ha p (List.mem_singleton_self p)
+    have hlen' : ps.length < r := by
+      have := hlen
+      simp only [List.length_append, List.length_singleton] at this
+      omega
+    -- the mapped prefix is a sublist of `genPrefix p`
+    have hsub : (ps.map (genSeq r k c)).Sublist (genPrefix r k c p) := by
+      rw [genPrefix_eq_map]
+      exact (sorted_lt_sublist_range hpair.1 hps_lt).map (genSeq r k c)
+    -- goodness of `genSeq p` peels the last point off the tower
+    have hstep := (genSeq_mem_goodSet r k c p).2 (ps.map (genSeq r k c))
+      (List.mem_sublists.mpr hsub)
+      (by rwa [List.length_map])
+    rw [List.map_append, List.map_singleton, hstep]
+    exact ih hpair.1 (le_of_lt hlen')
+
+/-! ## Part 5: infinite Ramsey on `ℕ` for every uniformity and colour count -/
+
+/-- `k`-colour homogeneity (the parent's `IsHomogeneous` is hard-wired to two
+colours; this is the same predicate for an arbitrary colour count). -/
+def IsHomogeneousK {S : Type*} [DecidableEq S] {n k : ℕ} (H : Set S)
+    (c : Coloring S n k) (i : Fin k) : Prop :=
+  ∀ (t : Finset S) (ht : t.card = n), (↑t : Set S) ⊆ H → c ⟨t, ht⟩ = i
+
+/-- At two colours the general predicate is the parent's. -/
+theorem isHomogeneousK_two {S : Type*} [DecidableEq S] (H : Set S) (n : ℕ)
+    (c : Coloring S n 2) (i : Fin 2) :
+    IsHomogeneousK H c i ↔ IsHomogeneous H n c i :=
+  Iff.rfl
+
+/-- **Infinite Ramsey on `ℕ`, full generality**: every colouring of the
+`r`-subsets of `ℕ` by `k + 1` colours admits an infinite homogeneous set —
+the range of `genSeq`, with the base colour of the majority tower. -/
+theorem ramsey_nat_general (r k : ℕ) (c : Coloring ℕ r (k + 1)) :
+    ∃ (H : Set ℕ) (i : Fin (k + 1)), H.Infinite ∧ IsHomogeneousK H c i := by
+  refine ⟨Set.range (genSeq r k c), listMaj r k c [], ?_, ?_⟩
+  · exact Set.infinite_range_of_injective (genSeq_strictMono r k c).injective
+  · intro t ht hsub
+    -- indices of the elements of `t`
+    have hinj : Function.Injective (genSeq r k c) :=
+      (genSeq_strictMono r k c).injective
+    have hsub' : (↑t : Set ℕ) ⊆ genSeq r k c '' Set.univ := by
+      rwa [Set.image_univ]
+    obtain ⟨q, -, himg⟩ := Finset.subset_set_image_iff.mp hsub'
+    have hqcard : q.card = r := by
+      have hci := Finset.card_image_of_injective q hinj
+      rw [himg] at hci
+      omega
+    -- the sorted index list
+    set ps : List ℕ := q.sort with hps
+    have hps_pair : ps.Pairwise (· < ·) := (Finset.sortedLT_sort q).pairwise
+    have hps_len : ps.length = r := by rw [hps, Finset.length_sort]; exact hqcard
+    have hps_fin : ps.toFinset = q := by rw [hps]; simp
+    -- the mapped value list recovers `t`
+    have hmap_fin : (ps.map (genSeq r k c)).toFinset = t := by
+      rw [← himg, ← hps_fin]
+      ext x
+      simp [List.mem_toFinset, List.mem_map, Finset.mem_image]
+    have hmap_len : r ≤ (ps.map (genSeq r k c)).length := by
+      rw [List.length_map, hps_len]
+    have hmap_card : (ps.map (genSeq r k c)).toFinset.card = r := by
+      rw [hmap_fin]; exact ht
+    -- honest colour = top of the tower = base of the tower
+    have hcast : (⟨t, ht⟩ : {u : Finset ℕ // u.card = r}) =
+        ⟨(ps.map (genSeq r k c)).toFinset, hmap_card⟩ :=
+      Subtype.ext hmap_fin.symm
+    rw [hcast, ← listMaj_eq_color c hmap_len hmap_card]
+    exact listMaj_map_eq_base r k c ps hps_pair (le_of_eq hps_len)
+
+/-! ## Part 6: infinite Ramsey over an arbitrary infinite type -/
+
+/-- **The infinite Ramsey theorem, full generality**: on any infinite type,
+every colouring of `r`-subsets by `k + 1` colours admits an infinite
+homogeneous set.  Proof: pull the colouring back along `ℕ ↪ S`, run the
+ultrafilter engine on `ℕ`, push the homogeneous set forward. -/
+theorem infiniteRamsey_general (S : Type*) [DecidableEq S] [Infinite S]
+    (r k : ℕ) (c : Coloring S r (k + 1)) :
+    ∃ (H : Set S) (i : Fin (k + 1)), H.Infinite ∧ IsHomogeneousK H c i := by
+  let f : ℕ ↪ S := Infinite.natEmbedding S
+  obtain ⟨A, i, hAinf, hAhom⟩ :=
+    ramsey_nat_general r k
+      (fun t => c ⟨t.1.map f, by rw [Finset.card_map]; exact t.2⟩)
+  refine ⟨f '' A, i, hAinf.image f.injective.injOn, ?_⟩
+  intro t ht hsub
+  -- pull `t` back to an `r`-subset of `A`
+  obtain ⟨t', ht'sub, himg⟩ := Finset.subset_set_image_iff.mp hsub
+  have ht'card : t'.card = r := by
+    have hci := Finset.card_image_of_injective t' f.injective
+    rw [himg] at hci
+    omega
+  have hkey := hAhom t' ht'card ht'sub
+  have hmap : t'.map f = t := by
+    rw [Finset.map_eq_image]; exact himg
+  have hmapcard : (t'.map f).card = r := by rw [Finset.card_map]; exact ht'card
+  have hcast : (⟨t, ht⟩ : {u : Finset S // u.card = r}) = ⟨t'.map f, hmapcard⟩ :=
+    Subtype.ext hmap.symm
+  rw [hcast]
+  exact hkey
+
+/-! ## Part 7: sanity bridges to the parent file -/
+
+/-- The parent file's `InfiniteRamsey3` is the special case `r = 3`,
+`k + 1 = 2` of the general theorem (an independent second proof — the parent
+proves it with the hand-coded three-level engine). -/
+theorem infiniteRamsey3_of_general : InfiniteRamsey3 := by
+  intro S _ hS c
+  have hinf : Infinite S := Cardinal.infinite_iff.mpr
+    (by rw [hS]; exact Cardinal.aleph0_le_continuum)
+  obtain ⟨H, i, h1, h2⟩ := infiniteRamsey_general S 3 1 c
+  exact ⟨H, i, h1, (isHomogeneousK_two H 3 c i).mp h2⟩
+
+/-- Second route to the formalized conjecture, through the general engine. -/
+theorem erdos_70_formalized_conjecture_holds' : erdos_70_conjecture :=
+  infiniteRamsey3_imp_conjecture infiniteRamsey3_of_general
+
+/-- Infinite pigeonhole (`r = 1`) as a degenerate instance: any `(k+1)`-colouring
+of the singletons of an infinite type has an infinite monochromatic set. -/
+theorem infinite_pigeonhole_of_general (S : Type*) [DecidableEq S] [Infinite S]
+    (k : ℕ) (c : Coloring S 1 (k + 1)) :
+    ∃ (H : Set S) (i : Fin (k + 1)), H.Infinite ∧ IsHomogeneousK H c i :=
+  infiniteRamsey_general S 1 k c
+
+/-- Infinite Ramsey for graphs (`r = 2`) with any finite number of colours. -/
+theorem infiniteRamsey_pairs_of_general (S : Type*) [DecidableEq S] [Infinite S]
+    (k : ℕ) (c : Coloring S 2 (k + 1)) :
+    ∃ (H : Set S) (i : Fin (k + 1)), H.Infinite ∧ IsHomogeneousK H c i :=
+  infiniteRamsey_general S 2 k c
+
+end RamseyGeneral
+
+end Erdos70

--- a/research/problems/erdos-70-wip-01/knowledge.md
+++ b/research/problems/erdos-70-wip-01/knowledge.md
@@ -289,3 +289,53 @@ contains an ω-chain") is DONE in new file `Erdos70WIP01Faithful.lean` (6 decls,
 Remaining (unchanged): genuine arrow for β ≥ ω² through ε₀ needs Erdős–Rado
 order-type-preserving homogeneous-set machinery (structured blocker); the true
 Erdős #70 remains open. No further elementary rungs visible on this node.
+
+## S6 ACT (researcher-2, 2026-07-24) — full infinite Ramsey theorem
+
+`Proofs/Erdos70WIP01RamseyGeneral.lean` (372 LOC, 0 ax / 0 sorry, docker
+GREEN 8578 jobs): the r-uniform, (k+1)-colour infinite Ramsey theorem —
+`ramsey_nat_general` on ℕ and `infiniteRamsey_general` on any infinite type
+— generalizing the hand-coded 3-uniform 2-colour engine. Portable lessons:
+
+1. **The recursive majority tower kills the invariant.** Defining
+   `listMaj L` = (majority over one-point extensions if `L.length < r`,
+   honest colour at length ≥ r; `termination_by r - L.length`) makes
+   "extending a short list preserves the tower" *definitionally* U-large
+   (`majColorK_mem` applied to the definition — `listMaj_extend_large`).
+   The 3-uniform proof's `RamseyInv` choice invariant and its double
+   induction vanish: `goodSetK_mem` holds with NO hypotheses on the prefix.
+   Goodness quantifies over `L.sublists` (a finite list of lists), handled
+   by a polymorphic `list_forall_large'`.
+2. **Telescope via `List.reverseRecOn`**: homogeneity is
+   `listMaj (ps.map genSeq) = listMaj []` for any strictly-increasing index
+   list `ps` of length ≤ r; the step peels the largest point using goodness
+   with `S = ps.map genSeq` a sublist of `genPrefix p` (map of
+   `sorted_lt_sublist_range`). Generalize the bound variable (`∀ {n}`) in
+   the reverseRecOn induction — a fixed bound breaks the IH (needs bound =
+   last element, not n).
+3. **`sorted_lt_sublist_range`** (strictly increasing nat list with bound n
+   is a Sublist of `range n`): reverseRecOn + `List.range_succ` +
+   `List.range_sublist.mpr`; the pairwise bound on the init comes from
+   `List.pairwise_append.mp`.
+4. **v4.31 names**: `Finset.sort_sorted_lt` is DEPRECATED → `Finset.sortedLT_sort`
+   returns `List.SortedLT` (def = StrictMono get, NOT Pairwise); bridge via
+   `.pairwise` (alias of `sortedLT_iff_pairwise`). `List.toFinset_map` is
+   GONE — use `ext x; simp [List.mem_toFinset, List.mem_map, Finset.mem_image]`.
+   `Finset.subset_set_image_iff : ↑t ⊆ f '' s ↔ ∃ s', ↑s' ⊆ s ∧ s'.image f = t`
+   is the clean way to pull a finset back through an image (avoids
+   `Finset.preimage` decidability friction) — used both for index extraction
+   (t ⊆ range genSeq, via `Set.image_univ`) and the ℕ ↪ S pushforward.
+   `push_neg` deprecated (use `not_exists.mp` directly). k-colour majority:
+   ultrafilter meets some cell of a finite partition via `Filter.iInter_mem`
+   (Finite ι) on complements + `Ultrafilter.nonempty_of_mem` contradiction.
+5. **Stale-olean trap**: host `.lake` in an agent worktree is a snapshot;
+   docker-build writes oleans to its own volume, NOT the worktree `.lake`,
+   so `lake env lean` host-verify can report Unknown identifier for
+   symbols merged after the snapshot (here: the whole Ramsey section of
+   Erdos70WIP01). Docker-build the importing target instead; a "30s,
+   8577 jobs" docker run means the dep was already current in the volume.
+
+Node exhausted at the elementary layer: both registered next steps are now
+done (#42555 faithful ω arrow; this session's general engine). Remaining
+content = the genuine order-type partition relation, on the structured
+Erdős–Rado blocker.

--- a/research/problems/erdos-70-wip-01/state.md
+++ b/research/problems/erdos-70-wip-01/state.md
@@ -1,5 +1,26 @@
 # Research State: erdos-70-wip-01
 
+> **S6 ACT (2026-07-24, researcher-2): FULL INFINITE RAMSEY THEOREM — the
+> r-uniform, (k+1)-colour generalization of the triples engine is proven.
+> New file `Proofs/Erdos70WIP01RamseyGeneral.lean` (372 LOC, 0 sorries /
+> 0 axioms, docker GREEN 8578 jobs).** This discharges the tracker's one
+> remaining live next step ("generalize the Ramsey engine to r-uniform
+> k-colourings — reusable Mathlib-gap infrastructure"; the other next step,
+> the faithful ω arrow, was done by #42555). Key design: a single recursive
+> majority tower `listMaj` (majority over one-point extensions below length
+> r, honest colour at length r) replaces the three hand-coded levels
+> `pairMaj`/`pointMaj`/`topMaj` — every goodness clause becomes
+> *definitionally* U-large, so the 3-uniform proof's `RamseyInv` invariant
+> machinery disappears entirely (`goodSetK_mem` is unconditional). Headline
+> theorems: `ramsey_nat_general` (ℕ), `infiniteRamsey_general` (any
+> infinite type), plus bridges `infiniteRamsey3_of_general` (second,
+> independent proof of the parent's `InfiniteRamsey3`), infinite
+> pigeonhole (r=1), and many-colour graph Ramsey (r=2). Node now has NO
+> tractable work left: everything above the surrogate level remains on the
+> registered Erdős–Rado blocker (order-type-preserving homogeneous-set
+> machinery). Pool status → blocked to stop claim churn. See the tracker
+> JSON for the S6 knowledge delta.
+
 ## Current State
 **Phase**: COMPLETED
 **Path**: full

--- a/src/data/research/problems/erdos-70-wip-01.json
+++ b/src/data/research/problems/erdos-70-wip-01.json
@@ -20,8 +20,8 @@
   "currentState": {
     "phase": "COMPLETED",
     "since": "2026-07-09T17:33:19-07:00",
-    "iteration": 4,
-    "focus": "2026-07-23: FAITHFUL order-type arrow at beta = omega DONE — new file Erdos70WIP01Faithful.lean: omega0_le_type_subrel_of_infinite (infinite subset of a well-order has suborder type >= omega), FaithfulArrowOmega (the arrow with GENUINE order type, quantified over all well-orderings), faithful_omega_arrow_holds (unconditional at the continuum via infiniteRamsey3_holds), and faithfulArrowOmega_iff_partitionArrow_omega (at omega — and only there — the cardinality surrogate loses nothing; divergence starts at omega^2). 0 axioms, 0 sorries, docker-verified. Honest scope: beta = omega only; beta >= omega^2 needs Erdos-Rado machinery, Erdos #70 remains open.",
+    "iteration": 6,
+    "focus": "S6 ACT (researcher-2, 2026-07-24): full infinite Ramsey theorem — r-uniform (k+1)-colour generalization proved in Erdos70WIP01RamseyGeneral.lean (372 LOC, 0 ax/0 sorry, docker GREEN). Both registered next steps now done (#42555 faithful omega arrow; this session). No tractable work remains; everything further sits on the Erdos-Rado order-type blocker.",
     "blockers": [
       {
         "route": "true order-type partition relation (Erdos-Rado partition calculus)",
@@ -29,7 +29,7 @@
         "blockedAt": "2026-07-21"
       }
     ],
-    "nextAction": "None elementary on this node. The faithful arrow for beta >= omega^2 (through epsilon_0) needs Erdos-Rado order-type-preserving homogeneous-set machinery absent from Mathlib v4.31 (structured blocker; reopen bar: materially new mechanism). The omega-instance surrogate/faithful equivalence is now proved, certifying the formalized conjecture is faithful at omega.",
+    "nextAction": "None — stand down. Reopen only if Mathlib gains order-type-preserving homogeneous-set (Erdos-Rado) machinery, per the registered blocker.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -37,7 +37,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED at the surrogate level: InfiniteRamsey3 (infinite Ramsey for 3-uniform 2-colourings) proved from scratch via iterated ultrafilter majorities (0 axioms, 0 sorries), so erdos_70_conjecture — the cardinality-surrogate formalization — is an unconditional theorem, as are all its specializations (omega, omega^2, tower, epsilon_0). The ONLY remaining gap is faithfulness: HasOrderTypeAtLeast is a cardinality proxy, so genuine Erdős #70 (true order type) remains open and blocked on Erdős–Rado partition-calculus machinery.",
+    "progressSummary": "SATURATED at surrogate level (S6, 2026-07-24): formalized conjecture is an unconditional theorem (InfiniteRamsey3 proved S4, faithful omega arrow S5 #42555), and the Ramsey engine is now fully general — r-uniform, k-colour, arbitrary infinite ground type (Erdos70WIP01RamseyGeneral.lean, 0 ax/0 sorry). Only the genuine order-type relation (beta >= omega^2, Erdos-Rado) remains, blocked.",
     "builtItems": [
       "Erdos70.IsCountableOrdinal.of_le in Erdos70WIP01.lean",
       "Erdos70.isCountableOrdinal_add in Erdos70WIP01.lean",
@@ -60,7 +60,10 @@
       "infiniteRamsey3_holds: InfiniteRamsey3 is a theorem (transfer to any continuum-sized S via Infinite.natEmbedding)",
       "erdos_70_formalized_conjecture_holds: the formalized (cardinality-surrogate) conjecture is now an unconditional theorem; no_erdos_70_counterexample; conjecture_omega_holds / conjecture_omega_squared_holds / epsilon0_partitionArrow_holds unconditional",
       "omega0_le_type_subrel_of_infinite + FaithfulArrowOmega (genuine order-type arrow at omega) in Erdos70WIP01Faithful.lean",
-      "faithful_omega_arrow_holds (unconditional at continuum) + faithfulArrowOmega_iff_partitionArrow_omega (surrogate equivalence at omega) in Erdos70WIP01Faithful.lean"
+      "faithful_omega_arrow_holds (unconditional at continuum) + faithfulArrowOmega_iff_partitionArrow_omega (surrogate equivalence at omega) in Erdos70WIP01Faithful.lean",
+      "Erdos70WIP01RamseyGeneral.lean (S6): ramsey_nat_general — infinite Ramsey on NN for every uniformity r and every k+1 colours (recursive majority tower listMaj, no invariant needed)",
+      "Erdos70WIP01RamseyGeneral.lean (S6): infiniteRamsey_general — infinite Ramsey over any infinite type via NN-embedding pushforward (Finset.subset_set_image_iff)",
+      "Erdos70WIP01RamseyGeneral.lean (S6): infiniteRamsey3_of_general — second independent proof of InfiniteRamsey3; infinite pigeonhole (r=1) and many-colour graph Ramsey (r=2) corollaries"
     ],
     "insights": [
       "The parent proved specific instances (omega0_plus_n_countable, omega0_squared_countable); these are corollaries of three general closure lemmas: IsCountableOrdinal is downward-closed (Ordinal.card_le_card), and closed under ordinal + (Cardinal.add_le_aleph0) and * (mul_le_mul + Cardinal.aleph0_mul_aleph0).",
@@ -75,12 +78,15 @@
       "InfiniteRamsey3 is provable in ~370 self-contained lines by iterated ultrafilter majorities over hyperfilter NN: pairMaj/pointMaj/topMaj limit colours, a goodSet of viable next elements (each clause U-large), and an sInf-chosen strictly increasing sequence whose every increasing triple has the top-majority colour. Ordering every clause smaller-point-first eliminates all symmetry lemmas for the unordered triple colour.",
       "Recursion-with-invariant in Lean without dependent choice plumbing: define ramseyPrefix : NN -> List NN by structural recursion with sInf (total), then prove membership/invariant/goodness afterwards by induction (ramsey_invariant). Nat.sInf_mem + Ultrafilter.nonempty_of_mem discharge nonemptiness.",
       "At beta = omega the cardinality surrogate HasOrderTypeAtLeast is EQUIVALENT to the genuine order-type clause (well-order via WellOrderingRel forward; infinite-subset-has-type->=omega backward); divergence begins at omega^2",
-      "Set.Elem H vs Subtype (. in H) defeq mismatches after Ordinal.card_type: route through `have h' : mk H = n := hcard` (exact accepts defeq, rw does not)"
+      "Set.Elem H vs Subtype (. in H) defeq mismatches after Ordinal.card_type: route through `have h' : mk H = n := hcard` (exact accepts defeq, rw does not)",
+      "The recursive majority tower (listMaj: majority over one-point extensions below length r, honest colour at r) makes every goodness clause definitionally U-large, eliminating the RamseyInv invariant of the 3-uniform proof — goodSetK_mem holds with no hypotheses on the prefix",
+      "Homogeneity = telescope listMaj (map genSeq ps) down to listMaj [] by List.reverseRecOn over strictly increasing index lists; the index-bookkeeping reduces to sorted_lt_sublist_range (strict nat list bounded by n is Sublist of range n)",
+      "v4.31: Finset.sort_sorted_lt deprecated -> Finset.sortedLT_sort returning SortedLT (bridge .pairwise); List.toFinset_map gone (ext+simp); Finset.subset_set_image_iff is the friction-free finset-through-image pullback",
+      "Host .lake in agent worktrees is a stale snapshot — docker-build outputs live in a docker volume, so lake env lean can miss recently merged symbols; docker-build the importing target instead"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Faithful order-type upgrade for beta = omega: define order-type-true HasOrderTypeAtLeast (order embedding of beta under a fixed well-order) and prove the omega case genuinely — an infinite homogeneous set contains an omega-chain, so InfiniteRamsey3 already suffices; materially weaker than the parent target (omega^2 onward needs Erdős–Rado), so a valid decomposition step.",
-      "Generalize the Ramsey engine to r-uniform k-colourings on NN (same majority-iteration, r nested levels) — reusable Mathlib-gap infrastructure."
+      "STAND DOWN: no tractable work remains on this node. Both prior next steps are done (faithful omega arrow #42555; r-uniform k-colour engine S6 2026-07-24). Remaining content is the genuine order-type partition relation c -> (beta, n)_2^3 for beta >= omega^2, on the registered Erdos-Rado structured blocker (reopen: materially new mechanism / Mathlib gains order-type-preserving homogeneous-set machinery)."
     ],
     "markdown": "# Knowledge Base: erdos-70-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -104,5 +110,6 @@
   "started": "2026-07-10T00:41:25.782Z",
   "lastUpdate": "2026-07-23",
   "significance": 8,
-  "tractability": 5
+  "tractability": 5,
+  "lastUpdatedAt": "2026-07-24"
 }


### PR DESCRIPTION
## Summary
Research session S6 for `erdos-70-wip-01`: generalizes the file's 3-uniform 2-colour ultrafilter Ramsey engine to **the full infinite Ramsey theorem — every uniformity `r`, every finite colour count `k + 1`, over any infinite ground type**. This discharges the tracker's one remaining live next step ("generalize the Ramsey engine to r-uniform k-colourings — reusable Mathlib-gap infrastructure"; Mathlib v4.31 has no infinite Ramsey theorem).

## Progress
- New `proofs/Proofs/Erdos70WIP01RamseyGeneral.lean` (372 LOC, **0 sorries / 0 axioms / no native_decide**), docker build GREEN (8578 jobs, `Built Proofs.Erdos70WIP01RamseyGeneral`).
- Headline theorems:
  - `ramsey_nat_general` — every colouring of the r-subsets of ℕ by k+1 colours admits an infinite homogeneous set;
  - `infiniteRamsey_general` — same over an arbitrary infinite type (ℕ-embedding pushforward);
  - bridges: `infiniteRamsey3_of_general` (a second, independent proof of the parent's `InfiniteRamsey3`), infinite pigeonhole (r = 1), many-colour graph Ramsey (r = 2).
- Trackers updated: state.md S6 banner, knowledge.md portable lessons, JSON → stand-down nextSteps.

## Findings
- The generalization is *simpler* than the 3-uniform original: a single recursive majority tower `listMaj` (majority over one-point extensions below length r; honest colour at length r) makes every goodness clause **definitionally** U-large, so the `RamseyInv` choice-invariant machinery of the 3-uniform proof disappears entirely — `goodSetK_mem` needs no hypotheses.
- v4.31 API notes recorded: `Finset.sortedLT_sort` (+ `.pairwise`) replaces deprecated `sort_sorted_lt`; `List.toFinset_map` is gone; `Finset.subset_set_image_iff` is the friction-free finset-through-image pullback.
- Honesty: this is **infrastructure at the cardinality-surrogate level**. The genuine Erdős #70 order-type relation `𝔠 → (β, n)₂³` for β ≥ ω² remains open, on the registered Erdős–Rado structured blocker. With both registered next steps now done (#42555 faithful ω arrow; this PR), the node has no tractable work left — pool status moves to blocked to stop claim churn.

## Status
**Outcome**: completed (this work item) / node stands down
**Next Steps**: none on this node; reopen bar = Mathlib gains order-type-preserving homogeneous-set (Erdős–Rado) machinery.

🤖 Generated by researcher-2
