### PR TITLE
audit(prob-method-second-moment-oq-01): fix stale theorem name after migration rename

### DIFF
--- a/src/data/proofs/prob-method-second-moment-oq-01/annotations.json
+++ b/src/data/proofs/prob-method-second-moment-oq-01/annotations.json
@@ -82,17 +82,17 @@
     },
     "type": "insight",
     "title": "Probability Form: |above|/|s| \u2265 (1-\u03b8)\u00b2\u00b7(mean)\u00b2/E[f\u00b2]",
-    "content": "`paley_zygmund_probability` divides the counting form by $\\sum f^2$: $(1-\\theta)^2 (\\sum f)^2 / \\sum f^2 \\leq |\\text{above}|$. The proof uses `div_le_iff hf2_pos` to convert division to multiplication, then applies `paley_zygmund_quantitative`. The hypothesis `hf2_pos : 0 < \u2211f\u00b2` is needed for safe division. This is the classical 'probability form' matching $P[X > \\theta E[X]] \\geq (1-\\theta)^2 E[X]^2/E[X^2]$.",
+    "content": "`paley_zygmund_probability` divides the counting form by $\\sum f^2$: $(1-\\theta)^2 (\\sum f)^2 / \\sum f^2 \\leq |\\text{above}|$. The proof uses `div_le_iff hf2_pos` to convert division to multiplication, then applies `paley_zygmund_quantitative_counting`. The hypothesis `hf2_pos : 0 < \u2211f\u00b2` is needed for safe division. This is the classical 'probability form' matching $P[X > \\theta E[X]] \\geq (1-\\theta)^2 E[X]^2/E[X^2]$.",
     "mathContext": "Dividing both sides by $\\sum f^2$: $|\\text{above}| \\geq (1-\\theta)^2 (\\sum f)^2 / \\sum f^2$. Normalizing by $|s|^2$: $|\\text{above}|/|s| \\geq (1-\\theta)^2 E[f]^2 / E[f^2]$.",
     "significance": "supporting",
     "relatedConcepts": [
       "div_le_iff",
-      "paley_zygmund_quantitative",
+      "paley_zygmund_quantitative_counting",
       "probability form",
       "Paley-Zygmund"
     ],
     "prerequisites": [
-      "paley_zygmund_quantitative",
+      "paley_zygmund_quantitative_counting",
       "div_le_iff"
     ]
   },
@@ -105,17 +105,17 @@
     },
     "type": "insight",
     "title": "\u03b8=0 Special Case: Recovers Qualitative Second Moment Method",
-    "content": "`paley_zygmund_at_zero` sets $\\theta = 0$, recovering $(\\sum f)^2 \\leq |\\{f > 0\\}| \\cdot \\sum f^2$. The proof applies `paley_zygmund_quantitative` with `\u03b8 = 0`, then `simp` reduces $(1-0)^2 = 1$ and $0 \\cdot \\mu = 0$. The `convert` tactic handles the filter predicate change from `0\u00b7\u03bc < f a` to `0 < f a`. This shows that the quantitative Paley-Zygmund subsumes the qualitative second moment: $|\\text{supp}(f)| \\geq (\\sum f)^2 / \\sum f^2$, i.e., $P[X>0] \\geq E[X]^2/E[X^2]$.",
+    "content": "`paley_zygmund_at_zero` sets $\\theta = 0$, recovering $(\\sum f)^2 \\leq |\\{f > 0\\}| \\cdot \\sum f^2$. The proof applies `paley_zygmund_quantitative_counting` with `\u03b8 = 0`, then `simp` reduces $(1-0)^2 = 1$ and $0 \\cdot \\mu = 0$. The `convert` tactic handles the filter predicate change from `0\u00b7\u03bc < f a` to `0 < f a`. This shows that the quantitative Paley-Zygmund subsumes the qualitative second moment: $|\\text{supp}(f)| \\geq (\\sum f)^2 / \\sum f^2$, i.e., $P[X>0] \\geq E[X]^2/E[X^2]$.",
     "mathContext": "$P[X > 0] \\geq E[X]^2/E[X^2]$ (second moment lower bound on support). Implies $P[X > 0] > 0$ when $E[X] > 0$. Tightness: equality iff $X$ is essentially constant on its support.",
     "significance": "key",
     "relatedConcepts": [
       "second moment method",
-      "paley_zygmund_quantitative",
+      "paley_zygmund_quantitative_counting",
       "convert tactic",
       "support lower bound"
     ],
     "prerequisites": [
-      "paley_zygmund_quantitative",
+      "paley_zygmund_quantitative_counting",
       "qualitative second moment method"
     ]
   }

--- a/src/data/proofs/prob-method-second-moment-oq-01/meta.json
+++ b/src/data/proofs/prob-method-second-moment-oq-01/meta.json
@@ -23,7 +23,7 @@
     "definitionCount": 0,
     "assumptions": "None. 0 axioms, 0 sorries. Fully verified in Lean 4 with Mathlib.",
     "originalContributions": [
-      "paley_zygmund_quantitative: (1-θ)²·(∑f)² ≤ |{a : f(a) > θ·mean}| · ∑f² (counting form)",
+      "paley_zygmund_quantitative_counting: (1-θ)²·(∑f)² ≤ |{a : f(a) > θ·mean}| · ∑f² (counting form)",
       "paley_zygmund_probability: (1-θ)²·(∑f)²/∑f² ≤ |above| (probability form)",
       "paley_zygmund_at_zero: θ=0 recovers the qualitative second moment method"
     ],
@@ -56,7 +56,7 @@
       "**Cauchy-Schwarz bridges first and second moments**: The private `sq_sum_le` lemma converts $\\sum_{\\text{above}} f \\geq (1-\\theta)\\sum f$ (first moment bound) into $(1-\\theta)^2 (\\sum f)^2 \\leq |\\text{above}| \\cdot \\sum f^2$ (first-second moment relationship). This is the core of the second moment method.",
       "**θ=0 recovers the qualitative method**: Setting $\\theta = 0$ gives $|\\{f > 0\\}| \\geq (\\sum f)^2 / \\sum f^2$, which implies $|\\{f > 0\\}| > 0$ when $\\sum f > 0$. This is the qualitative second moment principle, recovered as a special case.",
       "**Finite discrete setting avoids measure theory**: By working over ℚ-valued functions on Finsets, all inequalities reduce to elementary algebra over ℚ. The `hpos : 0 < ∑f` and `hnn : ∀ a, 0 ≤ f a` hypotheses replace σ-algebra measurability. This makes the proof accessible without MeasureTheory.Lp.",
-      "**Three formulations for different uses**: The counting form (`paley_zygmund_quantitative`) is best for combinatorial applications. The probability form (`paley_zygmund_probability`) matches the classical statement. The θ=0 form connects to the parent. Together they cover the main uses of Paley-Zygmund in the probabilistic method."
+      "**Three formulations for different uses**: The counting form (`paley_zygmund_quantitative_counting`) is best for combinatorial applications. The probability form (`paley_zygmund_probability`) matches the classical statement. The θ=0 form connects to the parent. Together they cover the main uses of Paley-Zygmund in the probabilistic method."
     ],
     "prerequisites": [
       "Cauchy-Schwarz inequality for finite sums (sq_sum_le)",
@@ -85,7 +85,7 @@
       "title": "Main Paley-Zygmund Inequality (Counting Form)",
       "startLine": 54,
       "endLine": 86,
-      "summary": "paley_zygmund_quantitative: 6-step proof via above/below decomposition, below-sum bound, Cauchy-Schwarz on above, filter-subset monotonicity, and sq_le_sq' to close.",
+      "summary": "paley_zygmund_quantitative_counting: 6-step proof via above/below decomposition, below-sum bound, Cauchy-Schwarz on above, filter-subset monotonicity, and sq_le_sq' to close.",
       "mathContext": "$(1-\\theta)^2(\\sum f)^2 \\leq |\\text{above}| \\cdot \\sum f^2$ where above = {f > θμ}."
     },
     {


### PR DESCRIPTION
## Integrity Issue

**Proof**: prob-method-second-moment-oq-01
**Problem**: Stale theorem identifier left in gallery metadata after a source rename.

The v4.31 toolchain migration (commit e458f73d99, "ProbMethodSecondMomentOQ01 RESIDUAL->GREEN") renamed the main theorem in `proofs/Proofs/ProbMethodSecondMomentOQ01.lean` from `paley_zygmund_quantitative` to `paley_zygmund_quantitative_counting` (likely to disambiguate from the sibling `paley_zygmund_probability`/`paley_zygmund_at_zero` corollaries, or a naming collision surfaced by the toolchain bump). The Lean source is correct and has used the new name ever since.

However, `meta.json` and `annotations.json` were never updated and still referenced the deleted `paley_zygmund_quantitative` name in 9 places (originalContributions, keyInsights, a section summary, and annotations content/relatedConcepts/prerequisites).

## Evidence

**meta.json / annotations.json claimed**: theorem named `paley_zygmund_quantitative`
**Lean file shows**: `theorem paley_zygmund_quantitative_counting {α : Type*} ...` (proofs/Proofs/ProbMethodSecondMomentOQ01.lean:62)

## Fix

Replaced all 9 stale `paley_zygmund_quantitative` references with the correct `paley_zygmund_quantitative_counting` in both `meta.json` and `annotations.json`. No behavioral/status/axiom/sorry claims changed — this is a pure identifier-accuracy fix so the public docs match the actual Lean declaration name.

---
Discovered during gallery integrity audit (reserve-mode re-serve; audit queue is fully drained at 4814/4814).