### PR TITLE
audit: tracker update for prob-method-second-moment-oq-01 (#43550)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23871,10 +23871,10 @@
       "result": "issues-fixed"
     },
     "prob-method-second-moment-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:39Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T18:19:56Z",
+      "result": "issues-fixed"
     },
     "prob-method-second-moment-oq-01-oq-01": {
       "auditCount": 1,


### PR DESCRIPTION
Records the issues-fixed audit result for prob-method-second-moment-oq-01 (stale theorem name fix, #43550) in audit-tracker.json.