### PR TITLE
audit: tracker update for minkowski-fundamental-theorem — clean 2026-07-24

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -22847,9 +22847,9 @@
       "issues": []
     },
     "minkowski-fundamental-theorem": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:39Z",
+      "lastAudited": "2026-07-24T18:28:15Z",
       "result": "clean"
     },
     "minkowski-fundamental-theorem-oq-01": {


### PR DESCRIPTION
## Summary
- Reserve-mode re-audit of `minkowski-fundamental-theorem` (queue fully drained: 0 unaudited, 0 with issues).
- Verified against `proofs/Proofs/MinkowskiFundamentalTheorem.lean`: 0 sorries, 0 axioms, no `native_decide`, no True stubs.
- theorem/def counts match exactly (19/16), line count matches (686), section coverage is contiguous 1–686 with no gaps.
- Mathlib dependency (`exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`) is credited in the description's first sentence — correctly badged `mathlib`.
- Result: **clean**, no action needed.

## Test plan
- [x] Diffed only touches `audit-tracker.json` (`auditCount` 2→3, `lastAudited` bumped, `result: clean`)