### PR TITLE
audit(lovasz-local-lemma): fix stale 'last theorem in file' claim

### DIFF
--- a/src/data/proofs/lovasz-local-lemma/meta.json
+++ b/src/data/proofs/lovasz-local-lemma/meta.json
@@ -206,7 +206,7 @@
       "name": "symmetric_lll_complete",
       "type": "core",
       "statement": "Symmetric LLL summary at $T(d)$ threshold",
-      "significance": "**The headline summary theorem.** Combines the symmetric threshold analysis ($T(d) \\le 1/4$), the avoidance product positivity, and the symmetric-to-general bridge into a single statement describing the complete symmetric LLL framework over $\\mathbb{Q}$. Last theorem in the file (line 352).",
+      "significance": "**The headline summary theorem.** Combines the symmetric threshold analysis ($T(d) \\le 1/4$), the avoidance product positivity, and the symmetric-to-general bridge into a single statement describing the complete symmetric LLL framework over $\\mathbb{Q}$. Part XI (threshold monotonicity, lines 365-471) extends the file further, so this is no longer the last theorem.",
       "description": "Lean signature: `theorem symmetric_lll_complete (n d : ℕ) (hd : 0 < d) (adj : Fin n → Finset (Fin n)) (h_max : HasMaxDegree n adj d) ...`. Synthesizes the preceding results."
     }
   ],


### PR DESCRIPTION
## Integrity Fix

**Proof**: lovasz-local-lemma

**Problem**: `mainTheorems[].significance` for `symmetric_lll_complete` claimed "Last theorem in the file (line 352)". PR #39984 later appended Part XI (threshold monotonicity: `lllThreshold_mul_succ`, `threshold_mono_key`, `lllThreshold_succ_le`, `lllThreshold_antitone`, lines 365-471) without updating this claim, so it's now false.

## Evidence

**meta.json claimed**: "... Last theorem in the file (line 352)."
**Lean file shows**: 4 more theorems follow `symmetric_lll_complete`, through line 471 (`wc -l` = 471, matching `lineCount`).

## Fix

Reworded to note Part XI extends the file further, so `symmetric_lll_complete` is no longer the last theorem.

## Audit scope

Full re-audit of this entry (round-robin re-serve, queue fully drained/0 unaudited):
- 0 axioms, 0 sorries, 0 `native_decide` — matches file (`grep` confirms)
- 29 theorems, 3 definitions (1 def + 1 structure + 1 def) — matches `theoremCount`/`definitionCount`
- No True-stub placeholders
- Description/proofStrategy honestly frame this as an algebraic-core formalization (avoids measure theory), consistent with prior reframe PR #36416
- annotations.json (8 entries, covers lines 25-363) spot-checked against source — no phantom names, all consistent

Only the one stale claim found; everything else in this entry is accurate and well-disclosed.

---
Discovered during gallery integrity audit.