### PR TITLE
Research: erdos-85-wip-01 - f(15), f(16) surgery rungs: both in {4,5} [0 ax / 0 sorry]

### DIFF
--- a/proofs/Proofs/Erdos85Problem.lean
+++ b/proofs/Proofs/Erdos85Problem.lean
@@ -3148,4 +3148,173 @@ theorem minDegreeForC4_fourteen_mem :
 
 end Fourteen
 
+/-! ## `f(15) ≥ 4` and `f(16) ≥ 4`: two more surgery rungs — `f(15), f(16) ∈ {4, 5}`
+
+The fifth and sixth surgery rungs, by the exact recipe of the `Fourteen`
+section: materialise the previous surgery as an explicit edge list, certify
+it by kernel checks on the *previous* vertex count, and apply the abstract
+surgery with a configuration whose two path edges lie in no triangle.
+
+* `petersen14` = the `a = 0, b = 4, c = 3` surgery on `petersen13`
+  materialised: delete `0–4`, join the new vertex `13` to `0`, `4`, `3`.
+  Its triangles are `1–6–10`, `3–4–13`, `3–8–11`, `7–9–12`.
+  Configuration for the next rung: `a = 0, b = 5, c = 7` (edges `0–5` and
+  `5–7` are triangle-free, `0 ≁ 7`).
+* `petersen15` = that surgery materialised: delete `0–5`, join `14` to
+  `0`, `5`, `7`.  Triangles: the previous four plus `5–7–14`.
+  Configuration: `a = 6, b = 8, c = 5` (edges `6–8` and `8–5` are
+  triangle-free, `6 ≁ 5`).
+
+Upper bounds: `15 ≤ 5·4` and `16 ≤ 5·4`, so `f(15), f(16) ≤ 5` by the
+counting bound.  Neither `15` nor `16` is a tight point `k(k−1)+1`, so the
+friendship-theorem pinning does not apply; the honest results are
+`f(15) ∈ {4, 5}` and `f(16) ∈ {4, 5}`.  (Next tight point: `21 = 5·4+1`,
+where `minDegreeForC4_twentyone_le` already gives the sharp upper `5`.) -/
+
+section Fifteen
+
+/-- The twenty-three edges of the `14`-vertex four-times-extended Petersen
+graph: `petersen13Edges` with the edge `(4, 0)` deleted and the new vertex
+`13` joined to `0`, `4`, and `3` — the `f(14)` surgery, materialised. -/
+def petersen14Edges : List (Fin 14 × Fin 14) :=
+  [(1,2), (3,4),
+   (5,7), (7,9), (9,6), (6,8), (8,5),
+   (0,5), (1,6), (2,7), (3,8),
+   (10,0), (10,1), (10,6),
+   (11,2), (11,3), (11,8),
+   (12,4), (12,9), (12,7),
+   (13,0), (13,4), (13,3)]
+
+/-- **A `14`-vertex `C₄`-free graph of minimum degree `3`**: the Petersen
+graph after four vertex-adding surgeries. -/
+def petersen14 : SimpleGraph (Fin 14) where
+  Adj i j := (i, j) ∈ petersen14Edges ∨ (j, i) ∈ petersen14Edges
+  symm.symm := fun _ _ h => Or.symm h
+  loopless.irrefl := by decide
+
+instance : DecidableRel petersen14.Adj := fun i j =>
+  decidable_of_iff ((i, j) ∈ petersen14Edges ∨ (j, i) ∈ petersen14Edges) Iff.rfl
+
+/-- Every vertex of `petersen14` has degree at least `3` — a `14`-vertex
+kernel check. -/
+theorem petersen14_degree : ∀ v, 3 ≤ petersen14.degree v := by decide
+
+/-- **Every pair of distinct `petersen14` vertices has at most one common
+neighbour** — the `14 × 14` kernel check certifying `C₄`-freeness. -/
+theorem petersen14_common_le_one : ∀ x y : Fin 14, x ≠ y →
+    (petersen14.neighborFinset x ∩ petersen14.neighborFinset y).card ≤ 1 := by
+  decide
+
+/-- **`f(15) ≥ 4`** — the abstract surgery applied to `petersen14` with the
+configuration `a = 0, b = 5, c = 7`: the edges `0–5` and `5–7` are
+triangle-free, `0 ≁ 7`, and all remaining hypotheses are `14`-vertex kernel
+checks.  No `15`-vertex graph is ever `decide`d. -/
+theorem four_le_minDegreeForC4_fifteen : 4 ≤ minDegreeForC4 15 := by
+  have hab : petersen14.Adj 0 5 := by decide
+  have hbc : petersen14.Adj 5 7 := by decide
+  have hac : ¬ petersen14.Adj 0 7 := by decide
+  have hane : (0 : Fin 14) ≠ 7 := by decide
+  have htriab : ∀ z, petersen14.Adj 0 z → petersen14.Adj 5 z → False := by decide
+  have htribc : ∀ z, petersen14.Adj 5 z → petersen14.Adj 7 z → False := by decide
+  have hcommon := surgery_common_le_one hab hbc hac hane htriab htribc
+    petersen14_common_le_one
+  have hC4 : ¬ containsC4 (Fin 15) (surgeryFin petersen14 0 5 7) :=
+    surgeryFin_not_containsC4 petersen14 0 5 7
+      (not_containsC4_of_forall_common_le_one hcommon)
+  have hdeg : 3 ≤ (surgeryFin petersen14 0 5 7).minDegree := by
+    apply SimpleGraph.le_minDegree_of_forall_le_degree
+    intro u
+    refine le_trans ?_ (surgeryFin_degree_ge petersen14 0 5 7 u)
+    rcases h : finSuccEquiv 14 u with _ | x
+    · exact surgery_degree_none (by decide) (by decide) (by decide)
+    · exact le_trans (petersen14_degree x)
+        (surgery_degree_some (by decide) x)
+  exact four_le_minDegreeForC4_of_witness (by norm_num)
+    (surgeryFin petersen14 0 5 7) hdeg hC4
+
+/-- **`f(15) ∈ {4, 5}`**: fifth surgery rung below, counting bound
+(`15 ≤ 5·4`) above.  `15` is not a tight point, so the friendship pinning
+does not extend. -/
+theorem minDegreeForC4_fifteen_mem :
+    minDegreeForC4 15 = 4 ∨ minDegreeForC4 15 = 5 := by
+  have hle : minDegreeForC4 15 ≤ 5 :=
+    minDegreeForC4_le_of_le_mul_pred (by norm_num) (by norm_num)
+  have hge := four_le_minDegreeForC4_fifteen
+  omega
+
+end Fifteen
+
+section Sixteen
+
+/-- The twenty-five edges of the `15`-vertex five-times-extended Petersen
+graph: `petersen14Edges` with the edge `(0, 5)` deleted and the new vertex
+`14` joined to `0`, `5`, and `7` — the `f(15)` surgery, materialised. -/
+def petersen15Edges : List (Fin 15 × Fin 15) :=
+  [(1,2), (3,4),
+   (5,7), (7,9), (9,6), (6,8), (8,5),
+   (1,6), (2,7), (3,8),
+   (10,0), (10,1), (10,6),
+   (11,2), (11,3), (11,8),
+   (12,4), (12,9), (12,7),
+   (13,0), (13,4), (13,3),
+   (14,0), (14,5), (14,7)]
+
+/-- **A `15`-vertex `C₄`-free graph of minimum degree `3`**: the Petersen
+graph after five vertex-adding surgeries. -/
+def petersen15 : SimpleGraph (Fin 15) where
+  Adj i j := (i, j) ∈ petersen15Edges ∨ (j, i) ∈ petersen15Edges
+  symm.symm := fun _ _ h => Or.symm h
+  loopless.irrefl := by decide
+
+instance : DecidableRel petersen15.Adj := fun i j =>
+  decidable_of_iff ((i, j) ∈ petersen15Edges ∨ (j, i) ∈ petersen15Edges) Iff.rfl
+
+/-- Every vertex of `petersen15` has degree at least `3` — a `15`-vertex
+kernel check. -/
+theorem petersen15_degree : ∀ v, 3 ≤ petersen15.degree v := by decide
+
+/-- **Every pair of distinct `petersen15` vertices has at most one common
+neighbour** — the `15 × 15` kernel check certifying `C₄`-freeness. -/
+theorem petersen15_common_le_one : ∀ x y : Fin 15, x ≠ y →
+    (petersen15.neighborFinset x ∩ petersen15.neighborFinset y).card ≤ 1 := by
+  decide
+
+/-- **`f(16) ≥ 4`** — the abstract surgery applied to `petersen15` with the
+configuration `a = 6, b = 8, c = 5`: the edges `6–8` and `8–5` are
+triangle-free, `6 ≁ 5`, and all remaining hypotheses are `15`-vertex kernel
+checks.  No `16`-vertex graph is ever `decide`d. -/
+theorem four_le_minDegreeForC4_sixteen : 4 ≤ minDegreeForC4 16 := by
+  have hab : petersen15.Adj 6 8 := by decide
+  have hbc : petersen15.Adj 8 5 := by decide
+  have hac : ¬ petersen15.Adj 6 5 := by decide
+  have hane : (6 : Fin 15) ≠ 5 := by decide
+  have htriab : ∀ z, petersen15.Adj 6 z → petersen15.Adj 8 z → False := by decide
+  have htribc : ∀ z, petersen15.Adj 8 z → petersen15.Adj 5 z → False := by decide
+  have hcommon := surgery_common_le_one hab hbc hac hane htriab htribc
+    petersen15_common_le_one
+  have hC4 : ¬ containsC4 (Fin 16) (surgeryFin petersen15 6 8 5) :=
+    surgeryFin_not_containsC4 petersen15 6 8 5
+      (not_containsC4_of_forall_common_le_one hcommon)
+  have hdeg : 3 ≤ (surgeryFin petersen15 6 8 5).minDegree := by
+    apply SimpleGraph.le_minDegree_of_forall_le_degree
+    intro u
+    refine le_trans ?_ (surgeryFin_degree_ge petersen15 6 8 5 u)
+    rcases h : finSuccEquiv 15 u with _ | x
+    · exact surgery_degree_none (by decide) (by decide) (by decide)
+    · exact le_trans (petersen15_degree x)
+        (surgery_degree_some (by decide) x)
+  exact four_le_minDegreeForC4_of_witness (by norm_num)
+    (surgeryFin petersen15 6 8 5) hdeg hC4
+
+/-- **`f(16) ∈ {4, 5}`**: sixth surgery rung below, counting bound
+(`16 ≤ 5·4`) above. -/
+theorem minDegreeForC4_sixteen_mem :
+    minDegreeForC4 16 = 4 ∨ minDegreeForC4 16 = 5 := by
+  have hle : minDegreeForC4 16 ≤ 5 :=
+    minDegreeForC4_le_of_le_mul_pred (by norm_num) (by norm_num)
+  have hge := four_le_minDegreeForC4_sixteen
+  omega
+
+end Sixteen
+
 end Erdos85

--- a/research/problems/erdos-85-wip-01/knowledge.md
+++ b/research/problems/erdos-85-wip-01/knowledge.md
@@ -642,3 +642,26 @@ EXACTLY. So the cherry double-count gives equality, and equality gives rigidity:
   Needs the numeric identities parameterized; friendship application unchanged.
 - f(14) ≥ 4 via surgery on a 13-vertex witness (lower-bound frontier continues);
   f(14) ≤ 5 from counting (14 ≤ 5·4).
+
+## S-f15f16 (researcher-2, 2026-07-24) — fifth and sixth surgery rungs
+
+Sections Fifteen + Sixteen in `Erdos85Problem.lean` (3151 → 3320 LOC, 0 ax /
+0 sorry, docker GREEN first try): `petersen14` / `petersen15` edge lists
+(previous surgeries materialised), kernel checks by `decide`,
+`four_le_minDegreeForC4_fifteen` (config `0-5-7` on petersen14),
+`four_le_minDegreeForC4_sixteen` (config `6-8-5` on petersen15),
+`minDegreeForC4_fifteen_mem` / `_sixteen_mem` : both `∈ {4, 5}`
+(counting bound `15, 16 ≤ 5·4`).
+
+Recipe notes (mirror of the f(14) rung, python-verified before writing):
+- petersen14Edges = petersen13Edges − (4,0) + (13,0),(13,4),(13,3);
+  triangles {1,6,10},{3,4,13},{3,8,11},{7,9,12}.
+- petersen15Edges = petersen14Edges − (0,5) + (14,0),(14,5),(14,7);
+  triangles += {5,7,14}.
+- petersen16 (NOT yet formalised) = petersen15Edges − (6,8) +
+  (15,6),(15,8),(15,5); triangles += {5,8,15}. Valid 16→17 configs
+  (python-enumerated): (10,0,13),(10,0,14),(13,0,14),(1,2,11),(1,2,7),
+  (7,2,11),(9,6,15). So f(17): materialise petersen16, use e.g. a=10,b=0,c=13.
+- Upper halves for 15..20 all stuck at 5 via counting (n ≤ 5·4 fails from
+  n=21; but 21 is tight → sharp there). Pinning f(n)=4 vs 5 for 14..20
+  still needs ex(n;C₄).

--- a/research/problems/erdos-85-wip-01/state.md
+++ b/research/problems/erdos-85-wip-01/state.md
@@ -1,5 +1,17 @@
 # Research State: erdos-85-wip-01
 
+> **S-f15f16 (2026-07-24, researcher-2): FIFTH + SIXTH SURGERY RUNGS —
+> `f(15), f(16) ∈ {4, 5}`, docker GREEN first try (0 ax / 0 sorry).**
+> Sections Fifteen + Sixteen: `petersen14` (= f(14) surgery 0-4-3
+> materialised) and `petersen15` (= f(15) surgery 0-5-7 materialised) as
+> explicit edge lists with kernel `decide` checks; abstract surgery configs
+> `0-5-7` and `6-8-5`; counting bound `15,16 ≤ 5·4` above. Python-verified
+> before writing (min degree, common ≤ 1, triangle-free path edges) — both
+> rungs compiled first try. f(17)..f(20) are cheap future rungs: petersen16
+> edge list + seven valid 16→17 configs pre-enumerated in knowledge.md.
+> Upper halves 14..20 remain blocked on ex(n;C₄); next tight point 21.
+> See PR (S-f15f16) and knowledge.md.
+
 ## Current State
 **Phase**: ORIENT
 **Path**: full

--- a/src/data/research/problems/erdos-85-wip-01.json
+++ b/src/data/research/problems/erdos-85-wip-01.json
@@ -21,7 +21,7 @@
     "phase": "ACT",
     "since": "2026-07-09T17:33:20-07:00",
     "iteration": 7,
-    "focus": "2026-07-23: ABSTRACT vertex-adding surgery formalized (section Surgery in Erdos85Problem.lean) — general lemma set replacing per-n whole-graph decides: surgery G a b c on Option V, degree preservation via uniform injection, common-neighbour <= 1 preservation (hypotheses: a~b, b~c, a-not-c, edges ab/bc triangle-free — corrects the girth-5-implicit note), generic four_le_minDegreeForC4_of_witness, finSuccEquiv comap transport. Applied to petersen12 (a=4,b=9,c=7): f(13) >= 4, so f(13) in {4,5} — first rung beyond the counting range. No 13-vertex decide anywhere.",
+    "focus": "S-f15f16 (researcher-2, 2026-07-24): fifth+sixth surgery rungs — f(15), f(16) both in {4,5} (petersen14/petersen15 edge lists materialised, kernel decides, configs 0-5-7 and 6-8-5; docker GREEN first try). Exact table 1..13, membership {4,5} for 14,15,16.",
     "blockers": [
       {
         "route": "RESOLVED 2026-07-22 (was: f(7)=3, then f(8)=3): handshake-parity boost proved f(7)=3; a LOCAL triangle-partition argument (no ex(n;C4) input) proved f(8)=3. Residual blocked part: upper-Beatty points beyond j=1 (n = s^2+s+j, j>=2), odd-s points, and f(9) still need ex(n;C4)-strength input.",
@@ -54,7 +54,7 @@
         "blockedAt": "2026-07-24"
       }
     ],
-    "nextAction": "Optional: chain surgery for f(15..19) lower rungs (materialise petersen14 edge list from the a=0,b=4,c=3 surgery, pick next config avoiding triangles 10-1-6, 11-3-8, 12-9-7, 13-4-3(new); cheap decides). Upper halves beyond n=13 need real ex(n;C4) input (blocked). Deep: KST asymptotics, monotonicity conjecture.",
+    "nextAction": "Optional: f(17)..f(20) rungs by the same recipe — materialise petersen16 (= petersen15Edges - (6,8) + vertex 15 ~ {6,8,5}), valid 16->17 configs already enumerated: (10,0,13),(10,0,14),(13,0,14),(1,2,11),(1,2,7),(7,2,11),(9,6,15). Upper halves for 14..20 blocked on ex(n;C4). Deep: monotonicity conjecture (the actual Erdos 85 question).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -112,7 +112,8 @@
       "common_le_one_of_not_containsC4 (converse criterion: no C4 => common neighbours <= 1) in Erdos85Problem.lean section Thirteen",
       "containsC4_of_thirteen_minDegree_four: 13 vertices, min degree >= 4, C4-free is impossible (cherry tightness + friendship theorem)",
       "minDegreeForC4_le_four_thirteen + minDegreeForC4_thirteen: f(13) = 4, the fourth exact value, first beyond the counting range",
-      "petersen13/petersen13_degree/petersen13_common_le_one + four_le_minDegreeForC4_fourteen + minDegreeForC4_fourteen_mem (section Fourteen, Erdos85Problem.lean)"
+      "petersen13/petersen13_degree/petersen13_common_le_one + four_le_minDegreeForC4_fourteen + minDegreeForC4_fourteen_mem (section Fourteen, Erdos85Problem.lean)",
+      "Sections Fifteen+Sixteen in Erdos85Problem.lean: petersen14/petersen15 edge-list witnesses + four_le_minDegreeForC4_fifteen/sixteen + fifteen_mem/sixteen_mem (both in {4,5})"
     ],
     "insights": [
       "Erdos85Problem.lean was a definitions-only stub (7 defs, 0 theorems). Asymptotics f(n)=(1+o(1))sqrt(n), f(4)=2, and the Ramsey reformulation need extremal graph theory beyond Mathlib; tractable axiom-free content is structural facts about C4, containsC4, and starGraph.",
@@ -156,7 +157,9 @@
       "Tight cherry count + injectivity = the friendship condition; Mathlib Archive friendship_theorem (Wiedijk #83) then produces a politician of degree n-1, contradicting regularity — a C4-free upper bound with NO edge-extremal (Reiman) input",
       "import Archive.Wiedijk100Theorems.FriendshipGraphs builds in this toolchain — the whole Mathlib Archive is usable as INPUT for gallery proofs",
       "Classical-instance-baked defs (Archive Friendship): prove the statement with the synthesized instance in a have, then convert h using 2 — Subsingleton.elim closes the Fintype instance mismatch; refine/rw/@-hole all fail on kernel defeq",
-      "f(14) rung landed: materialise the previous surgery result as an explicit edge list (petersen13), then apply the abstract surgery again — config a=0,b=4,c=3 (edges 0-4, 4-3 triangle-free; triangles of petersen13 are exactly 10-1-6, 11-3-8, 12-9-7, one per surgery vertex). Only 13-vertex kernel decides; no 14-vertex graph decided. f(14) ∈ {4,5}; pinning 4 blocked (14 not a tight point, friendship argument inapplicable)."
+      "f(14) rung landed: materialise the previous surgery result as an explicit edge list (petersen13), then apply the abstract surgery again — config a=0,b=4,c=3 (edges 0-4, 4-3 triangle-free; triangles of petersen13 are exactly 10-1-6, 11-3-8, 12-9-7, one per surgery vertex). Only 13-vertex kernel decides; no 14-vertex graph decided. f(14) ∈ {4,5}; pinning 4 blocked (14 not a tight point, friendship argument inapplicable).",
+      "Surgery-rung chaining is fully mechanical: python-verify edge list + config (min degree, common<=1, triangle-free path edges, a not~ c) before writing Lean — both new rungs compiled first try",
+      "petersen16 construction + seven valid 16->17 configs pre-enumerated (see knowledge.md) — f(17)..f(20) are cheap future rungs"
     ],
     "mathlibGaps": [
       "Fin n has NO global CommRing instance (only scoped Fin.instCommRing via `open Fin.CommRing`, gated on NeZero n); needed for ring/linear_combination on cycleGraph differences"
@@ -189,5 +192,6 @@
   "started": "2026-07-10T00:41:25.783Z",
   "lastUpdate": "2026-07-22",
   "significance": 7,
-  "tractability": 6
+  "tractability": 6,
+  "lastUpdatedAt": "2026-07-24"
 }


### PR DESCRIPTION
## Summary
Research session for `erdos-85-wip-01`: extends the C₄-free minimum-degree table with the fifth and sixth surgery rungs — `f(15) ∈ {4,5}` and `f(16) ∈ {4,5}` — by the registered recipe (materialise the previous surgery as an edge list, kernel-check it by `decide`, apply the abstract surgery with a triangle-free path configuration).

## Progress
- `proofs/Proofs/Erdos85Problem.lean` 3151 → 3320 LOC, **0 sorries / 0 axioms added**, docker build GREEN first try (8577 jobs; only pre-existing warnings).
- `petersen14` (f(14) surgery `0-4-3` materialised, 23 edges) and `petersen15` (f(15) surgery `0-5-7` materialised, 25 edges) with kernel checks: min degree ≥ 3 and all common neighbourhoods ≤ 1, both by `decide`.
- `four_le_minDegreeForC4_fifteen` (config `a=0, b=5, c=7`) and `four_le_minDegreeForC4_sixteen` (config `a=6, b=8, c=5`); no 15- or 16-vertex graph is ever decided.
- `minDegreeForC4_fifteen_mem` / `_sixteen_mem`: counting bound `15, 16 ≤ 5·4` pins both values in `{4, 5}`.

## Findings
- The rung chain is now fully mechanical: python-verifying the edge list and config (degrees, common ≤ 1, triangle-free path edges, `a ≁ c`) before writing Lean produced first-try green builds.
- Future rungs pre-staged in knowledge.md: petersen16's edge list and seven valid 16→17 configs are enumerated, so `f(17)..f(20)` are cheap follow-ups.
- Honesty: these are lower-bound rungs plus the generic counting upper bound. Pinning `f(n) = 4` vs `5` for `n = 14..20` still needs a genuine `ex(n; C₄)` mechanism (blocked); the actual Erdős #85 monotonicity question remains open and deep.

## Status
**Outcome**: progress
**Next Steps**: optional f(17)..f(20) rungs (recipe + configs recorded); upper halves blocked on ex(n;C₄).

🤖 Generated by researcher-2
