### PR TITLE
Research: konigsberg-oq-03-wip-01 - S15 bi-infinite parity: no odd vertex at all [0 ax / 0 sorry]

### DIFF
--- a/proofs/Proofs/KonigsbergOQ03.lean
+++ b/proofs/Proofs/KonigsbergOQ03.lean
@@ -927,4 +927,260 @@ theorem lineGraph_parity_not_sufficient :
       ¬ HasOneWayEulerPath lineGraph :=
   ⟨lineGraph_even_ncard_neighbors, not_hasOneWayEulerPath_lineGraph⟩
 
+/-! ### EGW necessity, bi-infinite case: NO odd vertex at all (S15)
+
+S14 established the one-way parity clause: along a ℕ-indexed Euler walk every
+finite-degree vertex has even degree *except possibly the start* (which is
+odd). A ℤ-indexed bi-infinite Euler walk has **no start**, and correspondingly
+no exception: shifting arrival steps forward by one identifies `w.inSteps v`
+with `w.outSteps v` *exactly* — over ℤ there is no unpaired index `0` — so
+
+`degree v = 2 · |outSteps v|`,
+
+and **every** finite-degree vertex is even. Headline: a single odd
+finite-degree vertex rules out a bi-infinite Euler path. Together with S14
+this completes the parity half of the incomparability picture:
+
+* one-way: at most ONE odd vertex (the start, S14);
+* bi-infinite: NO odd vertex (S15).
+
+Sanity: the ray graph's vertex `0` has degree `1` (odd), so the parity
+obstruction *re-proves* S13's `not_hasInfiniteEulerPath_rayGraph` by pure
+degree counting — the S13 proof went through walk surjectivity instead. -/
+
+namespace BiInfiniteWalk
+
+/-- The integer steps at which the bi-infinite walk departs from `v`. -/
+def outSteps {V : Type*} {G : InfiniteGraph V} (w : BiInfiniteWalk G) (v : V) :
+    Set ℤ :=
+  {n | w.vertex n = v}
+
+/-- The integer steps at which the bi-infinite walk arrives at `v`. -/
+def inSteps {V : Type*} {G : InfiniteGraph V} (w : BiInfiniteWalk G) (v : V) :
+    Set ℤ :=
+  {n | w.vertex (n + 1) = v}
+
+/-- Each step of a bi-infinite walk traverses a non-loop edge. -/
+theorem step_ne {V : Type*} {G : InfiniteGraph V}
+    (w : BiInfiniteWalk G) (n : ℤ) : w.vertex n ≠ w.vertex (n + 1) :=
+  fun h => G.loopless (w.vertex n) (h ▸ w.step_adj n)
+
+/-- No integer step both departs from and arrives at `v` (no loops). -/
+theorem disjoint_outSteps_inSteps {V : Type*} {G : InfiniteGraph V}
+    (w : BiInfiniteWalk G) (v : V) : Disjoint (w.outSteps v) (w.inSteps v) := by
+  rw [Set.disjoint_left]
+  intro n hn hn'
+  simp only [outSteps, inSteps, Set.mem_setOf_eq] at hn hn'
+  exact w.step_ne n (hn.trans hn'.symm)
+
+/-- **The bi-infinite pairing has no exception**: shifting arrival steps
+forward by one yields *exactly* the departure steps. Over ℤ every departure
+at time `m` is preceded by the step at time `m − 1` — there is no first
+index, hence no unpaired departure (contrast with the ℕ-indexed
+`InfiniteWalk.image_succ_inSteps`, whose image is `outSteps v \ {0}`). -/
+theorem image_succ_inSteps {V : Type*} {G : InfiniteGraph V}
+    (w : BiInfiniteWalk G) (v : V) :
+    (fun n : ℤ => n + 1) '' w.inSteps v = w.outSteps v := by
+  ext m
+  simp only [Set.mem_image, inSteps, outSteps, Set.mem_setOf_eq]
+  constructor
+  · rintro ⟨n, hn, rfl⟩
+    exact hn
+  · intro hm
+    exact ⟨m - 1, by simpa using hm, by ring⟩
+
+end BiInfiniteWalk
+
+namespace IsBiInfiniteEulerWalk
+
+/-- A bi-infinite Euler walk covers each adjacent pair. -/
+theorem covers {V : Type*} {G : InfiniteGraph V} {w : BiInfiniteWalk G}
+    (hE : IsBiInfiniteEulerWalk G w) (u v : V) (hadj : G.adj u v) :
+    w.CoversEdge u v :=
+  hE.1 u v hadj
+
+/-- Edge-injectivity of a bi-infinite Euler walk in the positive form used by
+the census: two step indices traversing the same undirected edge coincide. -/
+theorem injective {V : Type*} {G : InfiniteGraph V} {w : BiInfiniteWalk G}
+    (hE : IsBiInfiniteEulerWalk G w) (m n : ℤ)
+    (h : (w.vertex m = w.vertex n ∧ w.vertex (m + 1) = w.vertex (n + 1)) ∨
+      (w.vertex m = w.vertex (n + 1) ∧ w.vertex (m + 1) = w.vertex n)) :
+    m = n := by
+  by_contra hmn
+  exact hE.2 m n hmn h
+
+/-- The out-neighbours over departure steps and in-neighbours over arrival
+steps jointly exhaust the neighbour set of `v`. -/
+theorem image_outSteps_union_image_inSteps {V : Type*} {G : InfiniteGraph V}
+    {w : BiInfiniteWalk G} (hE : IsBiInfiniteEulerWalk G w) (v : V) :
+    ((fun n : ℤ => w.vertex (n + 1)) '' w.outSteps v) ∪
+      ((fun n : ℤ => w.vertex n) '' w.inSteps v) = {u | G.adj v u} := by
+  ext u
+  simp only [Set.mem_union, Set.mem_image, BiInfiniteWalk.outSteps,
+    BiInfiniteWalk.inSteps, Set.mem_setOf_eq]
+  constructor
+  · rintro (⟨n, hn, rfl⟩ | ⟨n, hn, rfl⟩)
+    · rw [← hn]
+      exact w.step_adj n
+    · have h := w.step_adj n
+      rw [hn] at h
+      exact G.symm _ _ h
+  · intro hu
+    rcases hE.covers v u hu with ⟨n, hn1, hn2⟩ | ⟨n, hn1, hn2⟩
+    · exact Or.inl ⟨n, hn1, hn2⟩
+    · exact Or.inr ⟨n, hn2, hn1⟩
+
+/-- Departure steps map injectively to out-neighbours. -/
+theorem injOn_vertex_succ_outSteps {V : Type*} {G : InfiniteGraph V}
+    {w : BiInfiniteWalk G} (hE : IsBiInfiniteEulerWalk G w) (v : V) :
+    Set.InjOn (fun n : ℤ => w.vertex (n + 1)) (w.outSteps v) := by
+  intro m hm n hn h
+  simp only [BiInfiniteWalk.outSteps, Set.mem_setOf_eq] at hm hn
+  exact hE.injective m n (Or.inl ⟨hm.trans hn.symm, h⟩)
+
+/-- Arrival steps map injectively to in-neighbours. -/
+theorem injOn_vertex_inSteps {V : Type*} {G : InfiniteGraph V}
+    {w : BiInfiniteWalk G} (hE : IsBiInfiniteEulerWalk G w) (v : V) :
+    Set.InjOn (fun n : ℤ => w.vertex n) (w.inSteps v) := by
+  intro m hm n hn h
+  simp only [BiInfiniteWalk.inSteps, Set.mem_setOf_eq] at hm hn
+  exact hE.injective m n (Or.inl ⟨h, hm.trans hn.symm⟩)
+
+/-- No neighbour of `v` is both an out-neighbour and an in-neighbour. -/
+theorem disjoint_image_outSteps_image_inSteps {V : Type*}
+    {G : InfiniteGraph V} {w : BiInfiniteWalk G}
+    (hE : IsBiInfiniteEulerWalk G w) (v : V) :
+    Disjoint ((fun n : ℤ => w.vertex (n + 1)) '' w.outSteps v)
+      ((fun n : ℤ => w.vertex n) '' w.inSteps v) := by
+  rw [Set.disjoint_left]
+  rintro u ⟨m, hm, rfl⟩ ⟨n, hn, hnm⟩
+  simp only [BiInfiniteWalk.outSteps, BiInfiniteWalk.inSteps,
+    Set.mem_setOf_eq] at hm hn
+  have hmn : m = n := hE.injective m n (Or.inr ⟨hm.trans hn.symm, hnm.symm⟩)
+  subst hmn
+  exact w.step_ne m (hm.trans hn.symm)
+
+/-- If `v` has finitely many neighbours, its departure steps are finite. -/
+theorem finite_outSteps {V : Type*} {G : InfiniteGraph V}
+    {w : BiInfiniteWalk G} (hE : IsBiInfiniteEulerWalk G w) {v : V}
+    (hfin : {u | G.adj v u}.Finite) : (w.outSteps v).Finite := by
+  refine Set.Finite.of_finite_image (hfin.subset ?_)
+    (hE.injOn_vertex_succ_outSteps v)
+  rw [← hE.image_outSteps_union_image_inSteps v]
+  exact Set.subset_union_left
+
+/-- If `v` has finitely many neighbours, its arrival steps are finite. -/
+theorem finite_inSteps {V : Type*} {G : InfiniteGraph V}
+    {w : BiInfiniteWalk G} (hE : IsBiInfiniteEulerWalk G w) {v : V}
+    (hfin : {u | G.adj v u}.Finite) : (w.inSteps v).Finite := by
+  refine Set.Finite.of_finite_image (hfin.subset ?_)
+    (hE.injOn_vertex_inSteps v)
+  rw [← hE.image_outSteps_union_image_inSteps v]
+  exact Set.subset_union_right
+
+/-- **Degree census along a bi-infinite Euler walk**: the neighbour count of
+a finite-degree vertex is exactly *twice* its number of departure steps —
+every departure at time `m` pairs with the arrival at time `m − 1`, with no
+exception (contrast the one-way census `InfiniteWalk` version, where step `0`
+is unpaired). -/
+theorem ncard_neighbors_eq {V : Type*} {G : InfiniteGraph V}
+    {w : BiInfiniteWalk G} (hE : IsBiInfiniteEulerWalk G w) (v : V)
+    (hfin : {u | G.adj v u}.Finite) :
+    {u | G.adj v u}.ncard = 2 * (w.outSteps v).ncard := by
+  have hOut : (w.outSteps v).Finite := hE.finite_outSteps hfin
+  have hIn : (w.inSteps v).Finite := hE.finite_inSteps hfin
+  have hshift : (w.inSteps v).ncard = (w.outSteps v).ncard := by
+    rw [← w.image_succ_inSteps v,
+      Set.ncard_image_of_injective _ (add_left_injective (1 : ℤ))]
+  calc {u | G.adj v u}.ncard
+      = (((fun n : ℤ => w.vertex (n + 1)) '' w.outSteps v) ∪
+          ((fun n : ℤ => w.vertex n) '' w.inSteps v)).ncard := by
+        rw [hE.image_outSteps_union_image_inSteps v]
+    _ = ((fun n : ℤ => w.vertex (n + 1)) '' w.outSteps v).ncard +
+          ((fun n : ℤ => w.vertex n) '' w.inSteps v).ncard :=
+        Set.ncard_union_eq (hE.disjoint_image_outSteps_image_inSteps v)
+          (hOut.image _) (hIn.image _)
+    _ = (w.outSteps v).ncard + (w.inSteps v).ncard := by
+        rw [(hE.injOn_vertex_succ_outSteps v).ncard_image,
+          (hE.injOn_vertex_inSteps v).ncard_image]
+    _ = 2 * (w.outSteps v).ncard := by
+        rw [hshift]
+        ring
+
+/-- **EGW necessity, bi-infinite case**: along a bi-infinite Euler walk,
+EVERY finite-degree vertex has an even number of neighbours — there is no
+start, hence no exception. -/
+theorem even_ncard_neighbors {V : Type*} {G : InfiniteGraph V}
+    {w : BiInfiniteWalk G} (hE : IsBiInfiniteEulerWalk G w) (v : V)
+    (hfin : {u | G.adj v u}.Finite) :
+    Even {u | G.adj v u}.ncard := by
+  rw [hE.ncard_neighbors_eq v hfin]
+  exact ⟨(w.outSteps v).ncard, by ring⟩
+
+/-- Degree form: the `infiniteDegree` of any finite-degree vertex along a
+bi-infinite Euler walk is `2 * k` for some `k : ℕ`. -/
+theorem infiniteDegree_eq_two_mul {V : Type*}
+    {G : InfiniteGraph V} {w : BiInfiniteWalk G}
+    (hE : IsBiInfiniteEulerWalk G w) {v : V}
+    (hfin : infiniteDegree G v ≠ ⊤) :
+    ∃ k : ℕ, infiniteDegree G v = 2 * k := by
+  have hf : {u | G.adj v u}.Finite := by
+    rwa [infiniteDegree, Set.encard_ne_top_iff] at hfin
+  obtain ⟨k, hk⟩ := hE.even_ncard_neighbors v hf
+  refine ⟨k, ?_⟩
+  rw [infiniteDegree, ← hf.cast_ncard_eq, hk]
+  push_cast
+  ring
+
+end IsBiInfiniteEulerWalk
+
+/-- **No odd vertex at all**: a graph with a bi-infinite Euler path has no
+finite-degree vertex of odd degree. Sharper than the one-way clause (S14
+allows one odd vertex, the start). -/
+theorem noOddVertex_of_hasInfiniteEulerPath {V : Type*}
+    {G : InfiniteGraph V} (h : HasInfiniteEulerPath G) :
+    ∀ v, {u | G.adj v u}.Finite → Even {u | G.adj v u}.ncard := by
+  obtain ⟨w, hE⟩ := h
+  exact fun v hf => hE.even_ncard_neighbors v hf
+
+/-- **EGW necessity, bi-infinite headline**: a single vertex of odd finite
+degree rules out a bi-infinite Euler path. -/
+theorem not_hasInfiniteEulerPath_of_odd_vertex {V : Type*}
+    {G : InfiniteGraph V} {v : V} (hf : {u | G.adj v u}.Finite)
+    (hodd : Odd {u | G.adj v u}.ncard) :
+    ¬ HasInfiniteEulerPath G :=
+  fun h => Nat.not_even_iff_odd.mpr hodd (noOddVertex_of_hasInfiniteEulerPath h v hf)
+
+/-- The parity obstruction *re-proves* S13's impossibility for the ray graph
+by pure degree counting: vertex `0` has degree `1` (odd), so no bi-infinite
+Euler path exists. (The S13 proof `not_hasInfiniteEulerPath_rayGraph` argued
+via walk surjectivity onto arcs instead — two independent mechanisms, one
+obstruction.) -/
+theorem not_hasInfiniteEulerPath_rayGraph_parity :
+    ¬ HasInfiniteEulerPath rayGraph :=
+  not_hasInfiniteEulerPath_of_odd_vertex
+    (by rw [rayGraph_neighbors_zero]; exact Set.finite_singleton 1)
+    rayGraph_odd_ncard_neighbors_zero
+
+/-- The combined S14+S15 parity picture, in one statement: a one-way Euler
+path allows at most one odd finite-degree vertex, a bi-infinite Euler path
+allows none. -/
+theorem parity_picture {V : Type*} (G : InfiniteGraph V) :
+    (HasOneWayEulerPath G →
+      {v | {u | G.adj v u}.Finite ∧ Odd {u | G.adj v u}.ncard}.Subsingleton) ∧
+    (HasInfiniteEulerPath G →
+      {v | {u | G.adj v u}.Finite ∧ Odd {u | G.adj v u}.ncard} = ∅) := by
+  refine ⟨oddVertices_subsingleton_of_hasOneWayEulerPath, fun h => ?_⟩
+  ext v
+  simp only [Set.mem_setOf_eq, Set.mem_empty_iff_false, iff_false, not_and]
+  intro hf hodd
+  exact Nat.not_even_iff_odd.mpr hodd (noOddVertex_of_hasInfiniteEulerPath h v hf)
+
+#check @BiInfiniteWalk.image_succ_inSteps
+#check @IsBiInfiniteEulerWalk.ncard_neighbors_eq
+#check @IsBiInfiniteEulerWalk.even_ncard_neighbors
+#check @not_hasInfiniteEulerPath_of_odd_vertex
+#check @not_hasInfiniteEulerPath_rayGraph_parity
+#check @parity_picture
+
 end KonigsbergOQ03

--- a/research/problems/konigsberg-oq-03-wip-01/state.md
+++ b/research/problems/konigsberg-oq-03-wip-01/state.md
@@ -553,3 +553,22 @@ separate claim.
 | S9 | 2026-06-13 | researcher-1 | BLOCKED | Flag BLOCKED: Docker still hung (`docker info` rc=124); S8 candidate menu is all new sorry-free Lean (unverifiable today) and the core OQ (EGW characterization / r≥3 NP-completeness) is multi-week open infrastructure. File already 0-sorry / 0-axiom; no urgency. Back-filled S6–S9 iteration rows. (this PR) |
 | S10 | 2026-06-14 | researcher-3 | STATE-SYNC | Propagated the S9 BLOCKED decision into the canonical JSON: it was still `status:"active"` / `phase:"STATE-SYNC"` / iter 8, so claim-random kept re-serving the slug during the blackout. Set `status:"blocked"` / `phase:"BLOCKED"` / iter 9, populated `blockers`, rewrote `nextAction` as the unblock plan, fixed `leanFiles.lineCount` 303→302 (`wc -l`=302), and back-filled `progressHistory` rows S5–S9 (canonical array had stopped at S4). Docker still down (`docker info` rc=124, confirmed). No Lean touched. (this PR) |
 | S11 | 2026-07-24 | researcher-1 | ACT | Docker recovered — unblocked. Shipped S8 menu item (b): `arcSet` def + 5 sorry-free finite-edge impossibility theorems (`InfiniteWalk.not_isEdgeInjective_of_finite_arcs` core + finite-arc and `[Finite V]` Euler-path corollaries), strictly generalizing the S5 no-edge and S7 single-edge results. 302 → 373 LOC, 11 → 16 theorems, 0 sorry / 0 axiom. Docker-GREEN under v4.31 (8576 jobs, 2.8s — first post-migration build of this slug). JSON un-blocked (`status:"active"`, EGW / r≥3 routes recorded as structured blockers). (this PR) |
+
+## S15 (researcher-3, 2026-07-24): bi-infinite parity — NO odd vertex at all
+
+The ℤ-indexed analogue of the S14 census, with the asymmetry GONE:
+`BiInfiniteWalk.image_succ_inSteps` gives `(·+1) '' inSteps v = outSteps v`
+EXACTLY (over ℤ every departure at time m pairs with the arrival at m−1 — no
+first index, no unpaired step; the ℕ version had `outSteps v \ {0}`). Census:
+`ncard_neighbors_eq : degree v = 2·|outSteps v|`; headline
+`even_ncard_neighbors` (EVERY finite-degree vertex even, no start exception),
+`not_hasInfiniteEulerPath_of_odd_vertex` (ONE odd vertex kills bi-infinite),
+`not_hasInfiniteEulerPath_rayGraph_parity` (parity RE-PROOF of the S13 ray
+impossibility — S13 argued via walk surjectivity; two mechanisms, one
+obstruction), and `parity_picture` (combined S14+S15: one-way ⟹ odd set
+subsingleton; bi-infinite ⟹ odd set empty). File 930 → 1186 LOC, 0 sorry /
+0 axiom, host-verified v4.31 exit 0, #print axioms = foundational trio.
+
+Next: EGW sufficiency (König's-lemma compactness, multi-week, blocked);
+r ≥ 3 hypergraph tours (NP-complete, blocked). The parity/ends story the
+file tells is now complete on the necessity side — a natural PARK point.

--- a/src/data/research/problems/konigsberg-oq-03-wip-01.json
+++ b/src/data/research/problems/konigsberg-oq-03-wip-01.json
@@ -50,7 +50,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: S13 complete — the two Euler-path predicates are formally incomparable. File KonigsbergOQ03.lean: 623 LOC, 27 theorems, 18 defs, 0 sorry / 0 axiom, Docker-GREEN. S12 witnesses (ray: one-way, line: bi-infinite) now paired with S13 impossibilities (ray: no bi-infinite, line: no one-way). Remaining open: EGW necessity/characterization (structural, multi-session), r>=3 hypergraph NP-completeness (blocked route).",
+    "progressSummary": "PROGRESS: S15 complete — bi-infinite parity necessity: every finite-degree vertex even (no start exception; exact Z-shift pairing), one odd vertex rules out bi-infinite Euler paths, parity re-proof of the S13 ray impossibility, and the combined parity_picture (one-way: odd set subsingleton; bi-infinite: odd set empty). File KonigsbergOQ03.lean 1186 LOC, 0 sorry / 0 axiom. Necessity side of EGW parity now complete for BOTH path notions — natural park point.",
     "builtItems": [
       "InfiniteWalk structure in Proofs/KonigsbergOQ03.lean:105 — ℕ-indexed walk on InfiniteGraph, with vertex : ℕ → V + step_adj field (S4 ACT)",
       "InfiniteWalk.sameEdge in Proofs/KonigsbergOQ03.lean:115 — two step indices traverse same undirected edge (S4 ACT)",
@@ -73,7 +73,8 @@
       "S12: rayGraph_arcSet_infinite / lineGraph_arcSet_infinite — witnesses paired with S11 finite-arc impossibility in contrapositive",
       "not_hasInfiniteEulerPath_rayGraph in KonigsbergOQ03.lean — ray graph has no bi-infinite Euler path (degree-1 vertex argument)",
       "not_hasOneWayEulerPath_lineGraph in KonigsbergOQ03.lean — line graph has no one-way Euler path (unique cut-crossing + confinement + pigeonhole)",
-      "not_oneWay_imp_biInfinite / not_biInfinite_imp_oneWay in KonigsbergOQ03.lean — formal incomparability capstones"
+      "not_oneWay_imp_biInfinite / not_biInfinite_imp_oneWay in KonigsbergOQ03.lean — formal incomparability capstones",
+      "KonigsbergOQ03.lean S15 (930->1186 LOC): BiInfiniteWalk.outSteps/inSteps/step_ne/disjoint/image_succ_inSteps, IsBiInfiniteEulerWalk census (ncard_neighbors_eq = 2x, even_ncard_neighbors, infiniteDegree_eq_two_mul), noOddVertex_of_hasInfiniteEulerPath, not_hasInfiniteEulerPath_of_odd_vertex, not_hasInfiniteEulerPath_rayGraph_parity, parity_picture; 0 ax / 0 sorry host-verified v4.31"
     ],
     "insights": [
       "**True placeholders are dishonest formalisation**: KonigsbergOQ03.lean has 0 sorries and 0 axioms but until 2026-06-03 had 3 (later 2) :=True propositions, which makes its 0-sorry count misleading. Per CLAUDE.md Aristotle rule #3 (No placeholder True theorems), the same principle applies broadly — True propositions are gaps masquerading as completeness. As of S4 ACT, all 3 are discharged.",
@@ -91,7 +92,10 @@
       "S13: a degree-1 vertex kills bi-infinite Euler paths LOCALLY — a Z-indexed walk must both enter and leave every visited vertex, so the unique incident edge repeats. No crossing/pigeonhole machinery needed (the S12 estimate of ~100+ LOC for the ray side collapsed to ~25 LOC).",
       "S13: for the line graph the one-way impossibility IS global: unique cut-edge traversal (edge-injectivity) + Nat.le_induction confinement traps the walk on one side; the abandoned side has infinitely many edges but only t+1 pre-crossing steps — choose + Set.infinite_of_injective_forall_mem + Set.finite_Iic closes it.",
       "S13: omega handles all vertex-value case analysis when w.vertex terms are kept as atoms (equalities like v i = -1 - k with Nat-to-Int casts); the only rewriting needed is index normalization t - 1 + 1 = t via rw [show ... from by ring] on Z-indices.",
-      "S13: rayGraph and lineGraph now separate HasOneWayEulerPath and HasInfiniteEulerPath in both directions — the number of ends (one vs two) is exactly what distinguishes the two Euler-path notions, the formal core of the EGW picture."
+      "S13: rayGraph and lineGraph now separate HasOneWayEulerPath and HasInfiniteEulerPath in both directions — the number of ends (one vs two) is exactly what distinguishes the two Euler-path notions, the formal core of the EGW picture.",
+      "S15 bi-infinite parity: over Z the arrival-shift is EXACT — (.+1) image of inSteps v equals outSteps v with no removed index (the N-indexed census had outSteps minus {0}) — so degree v = 2|outSteps v| and EVERY finite-degree vertex on a bi-infinite Euler walk is even; no start exception exists because there is no start.",
+      "Parity now separates the two Euler-path notions quantitatively: one-way allows at most ONE odd finite-degree vertex (S14, the start), bi-infinite allows NONE (S15, parity_picture). One odd vertex kills bi-infinite outright (not_hasInfiniteEulerPath_of_odd_vertex).",
+      "The ray graph impossibility (S13) now has a second independent proof by pure degree counting: vertex 0 has odd degree 1 (not_hasInfiniteEulerPath_rayGraph_parity); S13 went via walk surjectivity onto arcs."
     ],
     "mathlibGaps": [
       "r-uniform hypergraph type (Mathlib.Combinatorics has nothing).",
@@ -99,9 +103,9 @@
       "Erdős-Grünwald-Weiszfeld (1936) theorem characterising countable-graph Euler paths (the predicates HasInfiniteEulerPath / HasOneWayEulerPath are now defined in this file, but a Mathlib-level statement and proof of EGW remains an open formalisation target)."
     ],
     "nextSteps": [
-      "S14 (a): EGW necessity for locally finite graphs — one-way Euler path => at most 2 odd-degree vertices (degree counting over infiniteDegree).",
-      "S14 (b): extract the S13 cut-confinement mechanism into a reusable lemma for future EGW work.",
-      "EGW full characterization and r>=3 hypergraph Euler tours remain structured blocked routes (multi-week / NP-complete)."
+      "EGW sufficiency (Konig lemma compactness) — multi-week, structured blocked route.",
+      "r>=3 hypergraph Euler tours — NP-complete (Lonc-Naroski), blocked route.",
+      "Optional polish: extract the shared census pattern (N and Z) into a single parametrized lemma if a third index type ever appears."
     ],
     "progressHistory": [
       {


### PR DESCRIPTION
## Summary
S15 for konigsberg-oq-03-wip-01 (Eulerian paths in infinite graphs / EGW programme): the bi-infinite parity clause. `KonigsbergOQ03.lean` grows 930 → 1186 LOC, 0 axioms / 0 sorries, host-verified v4.31 exit 0, `#print axioms` = foundational trio.

## Progress
- **The ℤ-census has no exception**: `BiInfiniteWalk.image_succ_inSteps` shows the arrival-shift `(·+1) '' inSteps v = outSteps v` EXACTLY — over ℤ every departure at time m pairs with the arrival at m−1; there is no first index. (Contrast the S14 ℕ-version, whose image is `outSteps v \ {0}`.)
- **Census**: `IsBiInfiniteEulerWalk.ncard_neighbors_eq` — `degree v = 2·|outSteps v|` for finite-degree v.
- **Headlines**:
  - `even_ncard_neighbors` / `infiniteDegree_eq_two_mul` — EVERY finite-degree vertex on a bi-infinite Euler walk is even (no start exception, because there is no start)
  - `not_hasInfiniteEulerPath_of_odd_vertex` — a single odd finite-degree vertex rules out a bi-infinite Euler path
  - `not_hasInfiniteEulerPath_rayGraph_parity` — parity RE-PROOF of the S13 ray impossibility by pure degree counting (S13 argued via walk surjectivity; two independent mechanisms, one obstruction)
  - `parity_picture` — the combined S14+S15 statement: one-way ⟹ odd-vertex set is a subsingleton; bi-infinite ⟹ odd-vertex set is empty
- Also flagged stale PR #43261 (S12 ancestor snapshot, fully on main) as superseded.

## Findings
- Parity now separates the two Euler-path notions quantitatively (≤1 odd vs 0 odd), completing the necessity side of the EGW parity story for BOTH path notions — a natural park point for the file.
- Remaining routes stay blocked: EGW sufficiency (König's-lemma compactness, multi-week), r ≥ 3 hypergraph tours (NP-complete).

## Status
**Outcome**: progress (S15 complete; necessity side of EGW parity done)
**Next Steps**: park, or EGW sufficiency when a compactness mechanism lands.

🤖 Generated by researcher-3
