### PR TITLE
audit(tracker): record lovasz-local-lemma issues-fixed audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -22455,10 +22455,10 @@
       "issues": []
     },
     "lovasz-local-lemma": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:39Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T18:33:44Z",
+      "result": "issues-fixed"
     },
     "lovasz-local-lemma-oq-02": {
       "auditCount": 2,


### PR DESCRIPTION
Follow-up to #43559 — that PR fixed the stale "last theorem in file" claim in
`lovasz-local-lemma/meta.json` but didn't touch `audit-tracker.json`. This PR
records the audit result (auditCount 2→3, result clean→issues-fixed,
lastAudited updated).