### PR TITLE
Enrich combinations-formula-oq-06-oq-03: add 5th keyInsight (98->100)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-06-oq-03/meta.json
+++ b/src/data/proofs/combinations-formula-oq-06-oq-03/meta.json
@@ -52,7 +52,8 @@
       "The parent's ∑_{m≤n} T_m = C(n+2,3) becomes a genuine closed form only once the tetrahedral point value C(n+2,3) = n(n+1)(n+2)/6 is supplied; composing the hockey-stick sum with the point closed form is what turns the running total into a polynomial in n.",
       "The running-total tower continues cleanly: peeling TWO vanishing head terms C(0,3) = C(1,3) = 0 with Finset.sum_range_succ' turns the column-3 hockey stick into ∑_{m≤n} Te_m = C(n+3,4), the sum of tetrahedral numbers equalling the pentatope number — the next rung the parent did not state.",
       "The point closed forms come here from the DESCENDING factorial, the mirror of the sibling oq-06-oq-02's ascending-factorial route: descFactorial = k!·choose composed with descFactorial = ∏(n-i) gives k!·C(n+k,k) = ∏_{i<k}(n+k-i) with no induction, and the two routes cross-check the same tetrahedral and pentatope values.",
-      "Every partial sum is exhibited twice — as a binomial coefficient (the running-total identity) and as a degree-(k+1) polynomial (the closed form) — making the Pythagorean 'each layer is the running total of the next' literal at both levels."
+      "Every partial sum is exhibited twice — as a binomial coefficient (the running-total identity) and as a degree-(k+1) polynomial (the closed form) — making the Pythagorean 'each layer is the running total of the next' literal at both levels.",
+      "The hockey-stick identity ∑_{m≤n} C(m,k) = C(n+1,k+1) is the discrete analogue of ∫ x^k dx = x^{k+1}/(k+1): C(n,k) plays the role of x^k/k! in finite-difference (umbral) calculus, since the forward difference ΔC(n,k) := C(n+1,k) − C(n,k) equals C(n,k−1) by Pascal's rule. Summing a degree-k 'discrete monomial' therefore raises the degree by one, which is exactly why the partial sums formalized here are honest degree-(k+2) polynomials rather than a coincidence to verify case by case."
     ]
   },
   "sections": [


### PR DESCRIPTION
## Summary
- Adds a 5th `overview.keyInsights` item to `combinations-formula-oq-06-oq-03` (hockey-stick partial-sum closed forms): frames the hockey-stick identity as the discrete/umbral-calculus analogue of ∫xᵏdx = xᵏ⁺¹/(k+1), noting C(n,k) plays the role of xᵏ/k! under the forward-difference operator (ΔC(n,k) = C(n,k−1) by Pascal's rule), explaining why the formalized partial sums are honest degree-(k+2) polynomials rather than a per-rung coincidence.
- Quality tracker score 98 → 100 (same gap pattern as sibling entries: 4/5 keyInsights buckets).
- No open PR existed for this entry; well under all size guardrails (13.2 KB meta.json, 7 annotations already at target depth).

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — valid JSON
- [x] `pnpm build` — full gallery build succeeds (data manifest + vite build + bundle budget check all pass)