### PR TITLE
Enrich combinations-formula-oq-07: split central-binom section (98->100)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-07/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07/meta.json
@@ -92,9 +92,16 @@
     {
       "id": "central-binom",
       "title": "Central Binomial Sum of Squares",
-      "startLine": 64,
+      "startLine": 62,
+      "endLine": 69,
+      "summary": "central_binom_eq_sum_sq: C(2n,n) = ∑_{i≤n} C(n,i)². Specializes the range form at m=n, k=n via two_mul, then a sum_congr with Nat.choose_symm collapses each term to a square."
+    },
+    {
+      "id": "verification",
+      "title": "Worked Verification",
+      "startLine": 71,
       "endLine": 76,
-      "summary": "central_binom_eq_sum_sq: C(2n,n) = ∑_{i≤n} C(n,i)². Specializes the range form at m=n, k=n via two_mul, then a sum_congr with Nat.choose_symm collapses each term to a square. Worked example: C(6,3) = 20."
+      "summary": "Sanity check: C(6,3) = 20, recovered from central_binom_eq_sum_sq 3 as ∑ C(3,i)² = 1+9+9+1, closed by kernel decide."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Splits the `central-binom` section of `combinations-formula-oq-07` (Vandermonde's convolution) into the theorem statement (lines 62-69) and a new `verification` section (lines 71-76) covering the worked sanity-check example — the annotations already treated these as distinct (`central-binom-theorem` vs `sanity-check-example`), sections had not caught up.
- Quality tracker score 98 → 100 (gap was sections count: 4/5 sections; this entry already had 5 keyInsights, unlike the sibling oq-06-* family enriched earlier this session).
- No open PR existed for this entry; well under all size guardrails (9.8 KB meta.json).

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — valid JSON
- [x] `pnpm build` — full gallery build succeeds (data manifest + vite build + bundle budget check all pass)