### PR TITLE
fix(gallery): kummer-theorem-oq-03 badge original→mathlib (Tier B)

### DIFF
--- a/src/data/proofs/kummer-theorem-oq-03/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-03/meta.json
@@ -15,7 +15,7 @@
       "p-adic",
       "binomial-coefficient"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,


### PR DESCRIPTION
## Integrity fix

**Proof**: kummer-theorem-oq-03
**Problem**: badge `original` (Novel formalization with minimal Mathlib delegation) claimed, but the file's core results are Mathlib corollaries.

## Evidence

All 5 theorems in `Proofs/KummerTheoremOQ03.lean` build on the parent's `kummer` and `prime_dvd_choose_prime_pow`, which are themselves one-line aliases of Mathlib's `Nat.Prime.emultiplicity_choose` / `Nat.Prime.dvd_choose_pow` (see `Proofs/KummerTheorem.lean`). `pascal_row_prime_power_div` is a direct rename with zero new proof term. The file's own docstring ("All results proved from Mathlib with 0 axioms and 0 sorries") and `meta.assumptions` ("All results derived from Mathlib's Kummer theorem") already disclose this — only the `badge` field was stale, still saying `original`.

Per `proofs/BADGE_TAXONOMY.md`: 📚 Mathlib badge applies when "the main theorem comes from Mathlib... the file proves corollaries or demonstrates usage" — exactly this file's shape.

Sibling `kummer-theorem-oq-01` and parent `kummer-theorem` are already badged `mathlib`. The same class of fix was already applied to the Kummer-adjacent `wilsons-theorem-oq-03-oq-01`/`oq-03` files in #34440/#34457.

## Fix

`badge: "original"` → `badge: "mathlib"` in `src/data/proofs/kummer-theorem-oq-03/meta.json`. No other fields changed — sorry/axiom/theorem/definition counts all verified correct against the Lean source, and `originalContributions` prose is accurately scoped already.

---
Discovered during gallery integrity audit.