### PR TITLE
audit(tracker): record kummer-theorem-oq-03 issues-fixed audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21567,10 +21567,10 @@
       "issues": []
     },
     "kummer-theorem-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:39Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T18:48:17Z",
+      "result": "issues-fixed"
     },
     "kummer-theorem-oq-04": {
       "auditCount": 1,


### PR DESCRIPTION
Records the audit-tracker entry for kummer-theorem-oq-03. Found and fixed a badge misclassification (original→mathlib) in #43570.