### PR TITLE
Enrich combinations-formula-oq-07-oq-01: split absorption section (98->100)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-07-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-01/meta.json
@@ -99,9 +99,16 @@
     {
       "id": "absorption",
       "title": "Absorption / Committee-Chair Corollary",
-      "startLine": 111,
+      "startLine": 108,
+      "endLine": 118,
+      "summary": "mul_choose_eq: k·C(n,k) = n·C(n-1,k-1), the m=1 slice recovered with Nat.choose_one_right."
+    },
+    {
+      "id": "verification",
+      "title": "Worked Verifications",
+      "startLine": 120,
       "endLine": 129,
-      "summary": "mul_choose_eq: k·C(n,k) = n·C(n-1,k-1), the m=1 slice recovered with Nat.choose_one_right. Worked numeric checks C(5,3)·C(3,2) = C(5,2)·C(3,1) = 30 and 3·C(5,3) = 5·C(4,2) = 30."
+      "summary": "Numeric sanity checks: C(5,3)·C(3,2) = C(5,2)·C(3,1) = 30 (the headline identity) and 3·C(5,3) = 5·C(4,2) = 30 (absorption), both closed by kernel decide."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Splits the `absorption` section of `combinations-formula-oq-07-oq-01` (trinomial revision) into the theorem itself (lines 108-118) and a new `verification` section (lines 120-129) covering both worked numeric sanity checks (headline identity and absorption corollary), which were previously lumped into the theorem's section despite being distinct code blocks.
- Quality tracker score 98 → 100 (gap was sections count: 4/5 sections; this entry already had 5 keyInsights).
- No open PR existed for this entry; well under all size guardrails.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — valid JSON
- [x] `pnpm build` — full gallery build succeeds (data manifest + vite build + bundle budget check all pass)