### PR TITLE
Enrich combinations-formula-oq-07-oq-02: split corollaries section (98->100)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-07-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-02/meta.json
@@ -97,8 +97,15 @@
       "id": "corollaries",
       "title": "Mixed Product and Central Cases",
       "startLine": 96,
-      "endLine": 116,
-      "summary": "sum_choose_mul_choose (r=0 mixed sum C(m+n,n) = ∑ C(m,i)·C(n,i)), central_sum_sq_shift (m=n shifted), and central_binom_eq_sum_sq (m=n, r=0 recovers the parent's diagonal C(2n,n) = ∑ C(n,i)²), with numeric checks."
+      "endLine": 105,
+      "summary": "sum_choose_mul_choose (r=0 mixed sum C(m+n,n) = ∑ C(m,i)·C(n,i)), central_sum_sq_shift (m=n shifted), and central_binom_eq_sum_sq (m=n, r=0 recovers the parent's diagonal C(2n,n) = ∑ C(n,i)²)."
+    },
+    {
+      "id": "verification",
+      "title": "Worked Verifications",
+      "startLine": 107,
+      "endLine": 118,
+      "summary": "Numeric checks: the shift r=1 case C(5,1) = ∑_{i≤2} C(2,i)·C(3,i+1) = 10, and the diagonal C(6,3) = 20 = 1+9+9+1, both closed by kernel decide."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Splits the `corollaries` section of `combinations-formula-oq-07-oq-02` (off-diagonal Vandermonde convolution) into the theorem block (lines 96-105: `sum_choose_mul_choose`, `central_sum_sq_shift`, `central_binom_eq_sum_sq`) and a new `verification` section (lines 107-118) covering the two worked numeric checks.
- Quality tracker score 98 → 100 (gap was sections count: 4/5 sections; this entry already had 5 keyInsights, same pattern as its siblings oq-07 and oq-07-oq-01 fixed earlier this session).
- No open PR existed for this entry; well under all size guardrails.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — valid JSON
- [x] `pnpm build` — full gallery build succeeds (data manifest + vite build + bundle budget check all pass)