### PR TITLE
Enrich combinations-formula-oq-07-oq-03: split classical-form section (98->100)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-07-oq-03/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-03/meta.json
@@ -107,8 +107,15 @@
       "id": "classical-form",
       "title": "Halving and the Classical Form",
       "startLine": 105,
-      "endLine": 135,
-      "summary": "central_binom_two_mul_pred: C(2n,n) = 2·C(2n−1,n−1) for n ≥ 1 via Pascal's rule and symmetry; sum_weighted_sq: ∑ k·C(n,k)² = n·C(2n−1,n−1) for n ≥ 1 by cancelling the factor 2; with the numeric check ∑_{k=0}^{3} k·C(3,k)² = 30 = 3·C(5,2)."
+      "endLine": 129,
+      "summary": "central_binom_two_mul_pred: C(2n,n) = 2·C(2n−1,n−1) for n ≥ 1 via Pascal's rule and symmetry; sum_weighted_sq: ∑ k·C(n,k)² = n·C(2n−1,n−1) for n ≥ 1 by cancelling the factor 2."
+    },
+    {
+      "id": "verification",
+      "title": "Worked Verifications",
+      "startLine": 130,
+      "endLine": 137,
+      "summary": "Numeric checks: ∑_{k=0}^{3} k·C(3,k)² = 0+9+18+3 = 30, and the classical closed form 30 = 3·C(5,2), both closed by kernel decide."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Splits the `classical-form` section of `combinations-formula-oq-07-oq-03` (weighted sum of squares) into the theorem block (lines 105-129: `central_binom_two_mul_pred`, `sum_weighted_sq`) and a new `verification` section (lines 130-137) covering the two worked numeric checks.
- Quality tracker score 98 → 100 (gap was sections count: 4/5 sections; this entry already had 5 keyInsights, same pattern as siblings oq-07, oq-07-oq-01, oq-07-oq-02 fixed earlier this session).
- No open PR existed for this entry; well under all size guardrails.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — valid JSON
- [x] `pnpm build` — full gallery build succeeds (data manifest + vite build + bundle budget check all pass)