### PR TITLE
Enrich combinations-formula-oq-07-oq-03-oq-01: split classical-form section (98->100)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-07-oq-03-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-03-oq-01/meta.json
@@ -99,10 +99,17 @@
     },
     {
       "id": "classical-form",
-      "title": "The Classical Form and Checks",
+      "title": "The Classical Form",
       "startLine": 103,
+      "endLine": 114,
+      "summary": "sum_sq_weighted_sq: ∑_{k=0}^{n} k²·C(n,k)² = n²·C(2n−2,n−1) for n ≥ 1, obtained from the subtraction-free form by substituting n = m+1 and simplifying the subtractions (omega)."
+    },
+    {
+      "id": "verification",
+      "title": "Worked Verifications",
+      "startLine": 116,
       "endLine": 123,
-      "summary": "sum_sq_weighted_sq: ∑_{k=0}^{n} k²·C(n,k)² = n²·C(2n−2,n−1) for n ≥ 1, obtained from the subtraction-free form by substituting n = m+1 and simplifying the subtractions (omega). Includes the numeric check ∑_{k=0}^{3} k²·C(3,k)² = 54 = 3²·C(4,2)."
+      "summary": "Numeric checks: ∑_{k=0}^{3} k²·C(3,k)² = 0+9+36+9 = 54, and the classical closed form 54 = 3²·C(4,2), both closed by kernel decide."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Splits the `classical-form` section of `combinations-formula-oq-07-oq-03-oq-01` (second moment of squared binomial coefficients) into the theorem block (lines 103-114: `sum_sq_weighted_sq`) and a new `verification` section (lines 116-123) covering the two worked numeric checks.
- Quality tracker score 98 → 100 (gap was sections count: 4/5 sections; this entry already had 5 keyInsights, same pattern as siblings oq-07, oq-07-oq-01/02/03 fixed earlier this session).
- No open PR existed for this entry; well under all size guardrails.

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` — valid JSON
- [x] `pnpm build` — full gallery build succeeds (data manifest + vite build + bundle budget check all pass)