### PR TITLE
audit(tracker): record bezout-identity-oq-03-oq-04-oq-01 clean audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2781,9 +2781,9 @@
       "result": "clean"
     },
     "bezout-identity-oq-03-oq-04-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:38Z",
+      "lastAudited": "2026-07-24T19:00:18Z",
       "result": "clean"
     },
     "bezout-identity-oq-03-oq-04-oq-01-oq-01": {


### PR DESCRIPTION
## Summary
- Re-audited `bezout-identity-oq-03-oq-04-oq-01` (CRT for commutative rings via Bézout coefficients) during reserve-mode round-robin.
- Verified 0 sorries, 0 axioms, 6 theorems, 1 def — all match `meta.json`/`leanFile` counts exactly.
- `originalContributions` names (crtRing, crtRing_mod_m, crtRing_mod_n, crtRing_unique, crtRing_exists, crtRing_bezout) match actual declarations 1:1, no phantoms.
- Both `mathlibDependencies` entries (`IsCoprime`, `IsCoprime.mul_dvd`) are genuinely used and disclosed.
- Cross-references (parent `bezout-identity-oq-03-oq-04`, grandparent `bezout-identity`, sibling `bezout-identity-oq-03`) all resolve to existing gallery entries.
- Badge `original` is appropriate: the core existence construction is independently proved via `linear_combination`; only the uniqueness theorem delegates to a disclosed Mathlib lemma.
- Result: clean, no fix needed. Tracker-only diff.

## Test plan
- [x] Read meta.json and Lean source, cross-checked all counts and names
- [x] `gh pr list --search` confirmed no contested open PR for this slug