### PR TITLE
audit(tracker): record feuerbachs-theorem-oq-05 issues-fixed audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -18817,10 +18817,10 @@
       "result": "clean"
     },
     "feuerbachs-theorem-oq-05": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:39Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T19:07:18Z",
+      "result": "issues-fixed"
     },
     "fibonacci-divisibility-oq-07": {
       "auditCount": 3,


### PR DESCRIPTION
Tracker update for the audit resolved in #43584 (backwards sign claim + inconsistent theorem count in feuerbachs-theorem-oq-05's gallery metadata, fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)