### PR TITLE
audit(tracker): record sum-of-divisors issues-fixed audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25659,10 +25659,10 @@
       "result": "clean"
     },
     "sum-of-divisors": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T04:06:41Z",
-      "result": "clean"
+      "lastAudited": "2026-07-24T19:13:27Z",
+      "result": "issues-fixed"
     },
     "sum-of-divisors-oq-01": {
       "auditCount": 1,


### PR DESCRIPTION
Records the gallery audit of `sum-of-divisors` (result: issues-fixed).
See #43590 for the fix (stale openQuestions entry claiming Euler's
converse was unformalized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)