### PR TITLE
Enrich compactness-finite-subcover-oq-01-oq-02-oq-02: split namespace/setup section (98->100)

### DIFF
--- a/src/data/proofs/compactness-finite-subcover-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-01-oq-02-oq-02/meta.json
@@ -106,6 +106,14 @@
       "mathContext": "Compact $s$, $F$ a filter with $F.\\mathrm{NeBot}$ and $F\\le\\mathcal P\\,s$ $\\Rightarrow\\exists x\\in s,\\ \\mathrm{ClusterPt}\\,x\\,F$."
     },
     {
+      "id": "setup",
+      "title": "Namespace and Ambient Hypotheses",
+      "startLine": 53,
+      "endLine": 58,
+      "summary": "Opens the namespace CompactnessFiniteSubcoverOq01Oq02Oq02, brings Set/Filter/Topology notation into scope, and fixes the ambient topological space X shared by all four theorems below.",
+      "mathContext": "Ambient $X$ with a $\\mathrm{TopologicalSpace}$ instance; no further hypotheses on $X$ are assumed."
+    },
+    {
       "id": "filter-form",
       "title": "The Cluster-Point Form, via the Finite-Intersection Dual",
       "startLine": 59,


### PR DESCRIPTION
## Summary
- Adds a 5th `sections` entry to `compactness-finite-subcover-oq-01-oq-02-oq-02`: a `setup` section covering lines 53-58 (namespace opening, `open Set Filter Topology`, and the ambient `variable {X : Type*} [TopologicalSpace X]`), which were previously uncovered between the module docstring (ends line 51) and the main theorem section (starts line 59).
- Quality tracker score 98 -> 100 (only gap was sections count: 4/5 buckets, 8/10 points).
- Well under all size guardrails (17.6 KB meta.json).

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` -- valid JSON
- [x] `pnpm build` -- full gallery build succeeds (data manifest + vite build + bundle budget check all pass)