### PR TITLE
Research: sperner-ndim-mathlib-oq-02 - axiom-free Brouwer for n<=2 (S34)

### DIFF
--- a/proofs/Proofs/SpernerNDimMathlibOQ02.lean
+++ b/proofs/Proofs/SpernerNDimMathlibOQ02.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: RJ Walters
 -/
 import Mathlib
+import Proofs.SpernerFreudenthalSimplex
 
 /-!
 # Brouwer's Fixed-Point Theorem via Sperner's Lemma (OQ-02)
@@ -53,6 +54,10 @@ Since Σᵢ f(x*)ᵢ = 1 = Σᵢ x*ᵢ, all inequalities are equalities: f(x*) =
 * `SpernerBrouwer.sperner_panchromatic`: panchromatic tuple from Sperner (axiom)
 * `SpernerBrouwer.brouwer_from_panchromatic`: exact fixed point from panchromatic tuples
 * `SpernerBrouwer.brouwer_fixed_point_simplex`: **Brouwer's theorem for `Δⁿ`**
+* `SpernerBrouwer.brouwer_fixed_point_simplex_zero/_one/_two`: **axiom-free** Brouwer
+  for `Δ⁰`, `Δ¹`, `Δ²` — the `sperner_panchromatic` axiom is replaced by the fully
+  machine-checked instances `SpernerFreudSimp.sperner_panchromatic_zero/_one/_two`
+  (the n=2 case via the Type-1/Type-2 Freudenthal triangulation of `Δ²`)
 
 ## Tags
 
@@ -351,5 +356,59 @@ theorem brouwer_fixed_point_simplex {n : ℕ}
     ∃ x : Fin (n + 1) → ℝ, InSimplex x ∧ f x = x :=
   brouwer_from_panchromatic f hf_cont hf_map
     (fun N hN => sperner_panchromatic N hN f hf_map)
+
+-- ============================================================
+-- SECTION VI: Axiom-Free Instances (n = 0, 1, 2)
+-- ============================================================
+
+/-- The simplex-membership predicate used by `SpernerFreudenthalSimplex` agrees
+    definitionally with the one used here. -/
+lemma inSimplex_iff_freud {n : ℕ} (v : Fin (n + 1) → ℝ) :
+    SpernerFreudSimp.InSimplex v ↔ InSimplex v := Iff.rfl
+
+/-- **Brouwer's fixed-point theorem for `Δ⁰`, axiom-free**: the panchromatic input
+    is the fully proved `SpernerFreudSimp.sperner_panchromatic_zero`, so this
+    instance does not use the `sperner_panchromatic` axiom. -/
+theorem brouwer_fixed_point_simplex_zero
+    (f : (Fin 1 → ℝ) → Fin 1 → ℝ)
+    (hf_cont : Continuous f)
+    (hf_map : ∀ v, InSimplex v → InSimplex (f v)) :
+    ∃ x : Fin 1 → ℝ, InSimplex x ∧ f x = x :=
+  brouwer_from_panchromatic (n := 0) f hf_cont hf_map (fun N hN => by
+    obtain ⟨v, h1, h2, h3⟩ :=
+      SpernerFreudSimp.sperner_panchromatic_zero N hN f hf_map
+    exact ⟨v, h1, h2, fun i j l => by simpa using h3 i j l⟩)
+
+/-- **Brouwer's fixed-point theorem for `Δ¹`, axiom-free**: the panchromatic input
+    is the fully proved `SpernerFreudSimp.sperner_panchromatic_one` (discrete IVT
+    on the 1-dimensional grid), so this instance does not use the
+    `sperner_panchromatic` axiom. -/
+theorem brouwer_fixed_point_simplex_one
+    (f : (Fin 2 → ℝ) → Fin 2 → ℝ)
+    (hf_cont : Continuous f)
+    (hf_map : ∀ v, InSimplex v → InSimplex (f v)) :
+    ∃ x : Fin 2 → ℝ, InSimplex x ∧ f x = x :=
+  brouwer_from_panchromatic (n := 1) f hf_cont hf_map (fun N hN => by
+    obtain ⟨v, h1, h2, h3⟩ :=
+      SpernerFreudSimp.sperner_panchromatic_one N hN f hf_map
+    exact ⟨v, h1, h2, fun i j l => by simpa using h3 i j l⟩)
+
+/-- **Brouwer's fixed-point theorem for `Δ²`, axiom-free**: the panchromatic input
+    is the fully proved `SpernerFreudSimp.sperner_panchromatic_two` (Type-1/Type-2
+    Freudenthal triangulation of `Δ²` with odd boundary-door parity), so this
+    instance does not use the `sperner_panchromatic` axiom.
+
+    This upgrades the n=2 case of `brouwer_fixed_point_simplex` from
+    axiom-conditional to fully machine-checked:
+    `#print axioms` = `[propext, Classical.choice, Quot.sound]`. -/
+theorem brouwer_fixed_point_simplex_two
+    (f : (Fin 3 → ℝ) → Fin 3 → ℝ)
+    (hf_cont : Continuous f)
+    (hf_map : ∀ v, InSimplex v → InSimplex (f v)) :
+    ∃ x : Fin 3 → ℝ, InSimplex x ∧ f x = x :=
+  brouwer_from_panchromatic (n := 2) f hf_cont hf_map (fun N hN => by
+    obtain ⟨v, h1, h2, h3⟩ :=
+      SpernerFreudSimp.sperner_panchromatic_two N hN f hf_map
+    exact ⟨v, h1, h2, fun i j l => by simpa using h3 i j l⟩)
 
 end SpernerBrouwer

--- a/src/data/proofs/sperner-ndim-mathlib-oq-02/meta.json
+++ b/src/data/proofs/sperner-ndim-mathlib-oq-02/meta.json
@@ -21,7 +21,7 @@
     "sorries": 0,
     "axiomCount": 1,
     "lineCount": 355,
-    "assumptions": "One axiom: sperner_panchromatic — for each N>0, the Nth Freudenthal grid triangulation of Δⁿ with the Sperner coloring yields n+1 simplex vertices v₀,...,vₙ with f(vᵢ)ᵢ ≤ (vᵢ)ᵢ and diameter ≤ n/N. All other steps — Sperner coloring well-definedness, boundary condition, compactness convergence via panchromatic tuples — are fully proved with 0 sorries.",
+    "assumptions": "One axiom: sperner_panchromatic — for each N>0, the Nth Freudenthal grid triangulation of Δⁿ with the Sperner coloring yields n+1 simplex vertices v₀,...,vₙ with f(vᵢ)ᵢ ≤ (vᵢ)ᵢ and diameter ≤ n/N. All other steps — Sperner coloring well-definedness, boundary condition, compactness convergence via panchromatic tuples — are fully proved with 0 sorries. Update (2026-07-24): the axiom now gates only n >= 3 — brouwer_fixed_point_simplex_zero/_one/_two derive the n=0,1,2 instances axiom-free from the fully proved SpernerFreudSimp.sperner_panchromatic_zero/_one/_two.",
     "dateAdded": "2026-05-06",
     "mathlib_version": "4.31.0",
     "originalContributions": [

--- a/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
@@ -21,7 +21,7 @@
     "iteration": 31,
     "focus": "S30b STATE-SYNC (this PR, researcher-12, 2026-05-14): Docker-baseline of SpernerFreudenthalSimplex.lean on origin/main reveals 100+ errors (capped at 100 by maxErrors; 103 raw records; 56 distinct error lines spanning 73→1093). Parent file silently broken since ~2026-05-08; 20 merged + 3 open (build pending) PRs have accumulated on top of an unbuildable parent. STOP further PREP-on-PREP; ship error inventory for mechanic-agent consumption. No Lean ACT this session. Build log: .loom/logs/researcher-12-sperner-freud-baseline.log. Error inventory in sessions/2026-05-14-s30b-state-sync-...md (top 7 error classes by Mathlib v4.26.0 cause class).",
     "blockers": [],
-    "nextAction": "Mechanic-agent claim: parent-file repair of SpernerFreudenthalSimplex.lean per the S30b STATE-SYNC error inventory. Top 7 error classes: (1) Finset.sum_eq_zero linarith-fact-filter narrowing (line 73), (2) anonymous-lambda binder-type inference (line 77), (3) Finset.min'_mem placeholder-synthesis cascade (line 118 ×12), (4) Type mismatch (line 135), (5) rw-pattern-not-found ×3 (lines 171, 232, 234), (6) omega usable-constraints narrowing ×6 (lines 226, 227, 308, 310, 1068, 1085), (7) cases-motive cascade (line 348 ×6). Start at line 73; raise maxErrors ceiling temporarily; budget 2-3 Docker iterations. STOP further research PREPs on this slug until parent builds clean. 3 open (build pending) PRs (#17571, #17621, #17984) need rebase/repair post-mechanic.",
+    "nextAction": "n>=3 Freudenthal generalization in SpernerFreudenthalSimplex.lean; the stale S30b mechanic-repair nextAction is obsolete (parent builds GREEN since v4.31 migration, confirmed S33/S34).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -55,7 +55,7 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "S33 COMPLETED-MILESTONE (2026-07-24, researcher-1): sperner_panchromatic_two FULLY PROVED — sorry 1 -> 0 in SpernerFreudenthalSimplex.lean (docker-build GREEN, 8578 jobs). The v4.31 migration (epic #37508) had already repaired the parent (the S30b/S31 STOP-blocker was stale). New N2LastFaceAssembly section discharges the _hLastFace slot of Triangulation.boundary_doors_odd via Finset.card_bij between face-2 boundary doors and gDiag color changes (face2_path_odd_gDiag supplies oddness); Triangulation.sperner + spernerColor_le witness extraction close the theorem. Main file SpernerNDimMathlibOQ02.lean still carries the 1 general-n axiom sperner_panchromatic; next value is an axiom-free n=2 Brouwer corollary or the n>=3 Freudenthal generalization.",
+    "progressSummary": "S34 (2026-07-24, researcher-3): AXIOM-FREE LOW-DIM BROUWER — brouwer_fixed_point_simplex_zero/_one/_two added to SpernerNDimMathlibOQ02.lean (imports SpernerFreudenthalSimplex), deriving Brouwer for Δ⁰/Δ¹/Δ² from the fully proved sperner_panchromatic_zero/_one/_two instead of the general-n axiom. The sperner_panchromatic axiom now only gates n≥3. Remaining value: n≥3 Freudenthal generalization (base + permutation cells), then full axiom elimination.",
     "builtItems": [
       "InSimplex/supp predicates in SpernerNDimMathlibOQ02.lean",
       "supp_nonempty: support of any simplex point is nonempty (proved, 0 sorry)",
@@ -111,7 +111,8 @@
       "satDiagBases_endpoints_pair_face2_path_form in SpernerFreudenthalSimplex.lean",
       "N2DiagFaceCondition section (5 lemmas, 92 lines) in SpernerFreudenthalSimplex.lean: onFaceΔ2_diag, onFaceΔ2_strict_diag, cN2_total_diag_eq, cN2_diag_ne_two, cN2_total_diag_ne_two",
       "satDiag_self_drop_adj_none, satDiag_self_drop_endpoint_indices, satDiag_self_drop_isDoor_iff, lastFace_filter_extract, lastFace_card_eq, lastFace_odd in SpernerFreudenthalSimplex.lean N2LastFaceAssembly",
-      "sperner_panchromatic_two fully proved (end of SpernerFreudenthalSimplex.lean, section N2Panchromatic)"
+      "sperner_panchromatic_two fully proved (end of SpernerFreudenthalSimplex.lean, section N2Panchromatic)",
+      "S34: brouwer_fixed_point_simplex_zero/_one/_two + inSimplex_iff_freud in SpernerNDimMathlibOQ02.lean — axiom-free Brouwer for Δ⁰, Δ¹, Δ² (sperner_panchromatic axiom no longer needed for n≤2)"
     ],
     "insights": [
       "Sperner coloring well-definedness is purely algebraic: if fv_i > v_i for all i in supp(v), then sum fv > sum v = 1, contradiction. Proved using Finset.sum_lt_sum.",
@@ -154,16 +155,16 @@
       "S27-prep-diag-face (researcher-10, 2026-05-12, build pending): N2DiagFaceCondition section — 5 face-2/color lemmas at (k, N-k) diagonal vertices. Independent of in-flight S23 (PR #17571, CONFLICTING) and S25-prep (PR #17621, CONFLICTING).",
       "S33: the _hLastFace bijection maps a boundary-door pair (s,k) to the first coordinate of its DROPPED vertex — for saturating-diagonal t1 cells the dropped vertex IS the base b, so p ↦ (vertex p.1 p.2).1 lands on range N with gDiag b.1 ≠ gDiag (b.1+1) exactly at doors",
       "S33: Triangulation.vertex vs AbstractSimplicialData.vertexEnum are defeq but not syntactically equal — rw against a vertex-form goal fails; restate with show in vertexEnum form first",
-      "S33: SpernerFreudenthalSimplex had redundant nested namespace re-opens double-namespacing all late declarations; fixed to a single-level namespace running to EOF (all affected lemmas were private, SimplicialAdjFnHelper.* names unchanged)"
+      "S33: SpernerFreudenthalSimplex had redundant nested namespace re-opens double-namespacing all late declarations; fixed to a single-level namespace running to EOF (all affected lemmas were private, SimplicialAdjFnHelper.* names unchanged)",
+      "S34: The two InSimplex definitions (SpernerBrouwer in OQ02 vs SpernerFreudSimp in SpernerFreudenthalSimplex) are definitionally equal, so the proved sperner_panchromatic_zero/_one/_two plug directly into brouwer_from_panchromatic; only friction is the Nat-cast bound ((n:ℕ):ℝ)/N vs literal (0|1|2:ℝ)/N, closed by simpa"
     ],
     "mathlibGaps": [
       "Grid triangulation of Δⁿ as a CellComplex (needed for sperner_near_fixed_point axiom — significant work ~200 lines)",
       "Sequential compactness of stdSimplex in Lean 4 (needed for fixed_point_from_approx axiom)"
     ],
     "nextSteps": [
-      "Derive an axiom-free n=2 Brouwer fixed-point corollary in SpernerNDimMathlibOQ02.lean from sperner_panchromatic_two (replaces the axiom for the n=2 instance)",
       "Generalize the Type-1/Type-2 construction to n>=3 via Freudenthal triangulation (base + permutation cells; pseudomanifold proof scales linearly)",
-      "Optionally eliminate the general-n sperner_panchromatic axiom once the n>=3 triangulation lands"
+      "Eliminate the general-n sperner_panchromatic axiom once the n>=3 triangulation lands (n=0,1,2 already axiom-free via S34)"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session (S34) for sperner-ndim-mathlib-oq-02.

## Progress
- Added SECTION VI to `proofs/Proofs/SpernerNDimMathlibOQ02.lean`: `brouwer_fixed_point_simplex_zero/_one/_two`, deriving Brouwer's fixed-point theorem for Delta^0, Delta^1, Delta^2 from the fully proved `sperner_panchromatic_zero/_one/_two` (instead of the general-n `sperner_panchromatic` axiom)
- Added `inSimplex_iff_freud` bridge lemma (definitional agreement of the two `InSimplex` defs)
- Updated meta.json and research tracker for the axiom-free n<=2 Brouwer layer

## Findings
- Brouwer for n<=2 is now axiom-free on this route; only the general n>=3 case still rests on the `sperner_panchromatic` axiom (a big lift, tracked as the remaining open direction)

## Status
**Outcome**: progress
**Next Steps**: n>=3 panchromatic Sperner (large formalization lift); no further low-hanging rungs on this entry

Note: PR creation was delayed by a GitHub PR-create outage earlier today; branch content dates from that session.

🤖 Generated by researcher-3
