### PR TITLE
Research: minkowski-fundamental-theorem-oq-06 - S6 density rung (packing-density form of Minkowski-Hlawka)

### DIFF
--- a/proofs/Proofs/MinkowskiFundamentalTheoremOQ06.lean
+++ b/proofs/Proofs/MinkowskiFundamentalTheoremOQ06.lean
@@ -53,6 +53,12 @@ identity as an **explicit hypothesis** of the two main theorems — NOT as an `a
   `-v`), so the volume threshold doubles to `2·ζ(n)` with the SAME mean-value
   hypothesis — the classical route to `δₙ ≥ ζ(n)/2^(n-1)` (the residual
   `2^(1-n)` is ball-volume scaling, not averaging).
+* `hlawka_density_symm` — the **density rung** (S6): combining the doubled
+  threshold with the unconditional ball-volume bookkeeping
+  (`volume_ball_toReal`, `volume_ball_half_toReal`, `exists_radius_of_density`
+  — all pure Mathlib measure theory via `Measure.addHaar_ball`), every packing
+  density `d < ζ(n)/2^(n-1)` is realized by a lattice of the family: this is
+  the classical `δₙ ≥ ζ(n)/2^(n-1)` statement, staged only on `hMV`/`hInt`.
 
 **Honesty.** No `axiom` declarations, no sorries; the `hlawka_*` theorems are
 *conditional* on their `hMV` (mean-value) and `hInt` (integrability) hypotheses
@@ -481,6 +487,112 @@ theorem hlawka_ball_symm {n : ℕ} (hn : 2 ≤ n) {Ω : Type*}
   push Not at hlt
   exact hω w hwp (Metric.mem_ball.mpr (by simpa using hlt))
 
+/-! ## Density bookkeeping: ball-volume scaling (S6)
+
+The scaling law `vol(ball r) = rⁿ·vol(ball 1)` converts the doubled threshold
+`2·ζ(n)` of `hlawka_ball_symm` into the classical **packing-density** form of
+Minkowski–Hlawka: a covolume-1 lattice of minimum distance `≥ r` packs balls of
+radius `r/2` at density `vol(ball (r/2)) = vol(ball r)/2ⁿ` per unit covolume,
+so every density `d < ζ(n)/2^(n-1)` is realized by some lattice in the family.
+All new lemmas in this section are unconditional Mathlib measure theory
+(`Measure.addHaar_ball`); the headline `hlawka_density_symm` carries only the
+same `hMV`/`hInt` staging hypotheses as before, now quantified over radii. -/
+
+/-- The volume of the unit ball of `EuclideanSpace ℝ (Fin n)`, as a real. -/
+noncomputable def unitBallVol (n : ℕ) : ℝ :=
+  (volume (Metric.ball (0 : EuclideanSpace ℝ (Fin n)) 1)).toReal
+
+/-- Ball-volume scaling in real form: `vol(ball 0 r) = rⁿ · vol(ball 0 1)`.
+(The Haar-scaling identity `Measure.addHaar_ball`, pushed through `toReal`;
+the ball has finite volume, so nothing is lost.) -/
+theorem volume_ball_toReal {n : ℕ} (hn : 1 ≤ n) {r : ℝ} (hr : 0 ≤ r) :
+    (volume (Metric.ball (0 : EuclideanSpace ℝ (Fin n)) r)).toReal
+      = r ^ n * unitBallVol n := by
+  haveI : Nonempty (Fin n) := ⟨⟨0, hn⟩⟩
+  rw [Measure.addHaar_ball volume 0 hr, ENNReal.toReal_mul,
+    ENNReal.toReal_ofReal (by positivity), finrank_euclideanSpace_fin]
+  rfl
+
+/-- The unit ball has positive volume (`volume` is an open-positive Haar
+measure and the ball is finite by properness). -/
+theorem unitBallVol_pos {n : ℕ} (hn : 1 ≤ n) : 0 < unitBallVol n := by
+  haveI : Nonempty (Fin n) := ⟨⟨0, hn⟩⟩
+  exact ENNReal.toReal_pos
+    (Metric.measure_ball_pos volume (0 : EuclideanSpace ℝ (Fin n)) one_pos).ne'
+    measure_ball_lt_top.ne
+
+/-- Half-radius scaling: `vol(ball (r/2)) = vol(ball r) / 2ⁿ` — the exact
+`2^(1-n)` bookkeeping factor between the doubled avoidance threshold and the
+packing-density bound. -/
+theorem volume_ball_half_toReal {n : ℕ} (hn : 1 ≤ n) {r : ℝ} (hr : 0 ≤ r) :
+    (volume (Metric.ball (0 : EuclideanSpace ℝ (Fin n)) (r / 2))).toReal
+      = (volume (Metric.ball (0 : EuclideanSpace ℝ (Fin n)) r)).toReal / 2 ^ n := by
+  rw [volume_ball_toReal hn (by positivity), volume_ball_toReal hn hr, div_pow]
+  ring
+
+/-- Radius realization: every positive real `c` is the volume of some ball
+(`r = (c/vol(B₁))^(1/n)`, inverted through `Real.rpow`). -/
+theorem exists_radius_volume_eq {n : ℕ} (hn : 1 ≤ n) {c : ℝ} (hc : 0 < c) :
+    ∃ r : ℝ, 0 < r ∧
+      (volume (Metric.ball (0 : EuclideanSpace ℝ (Fin n)) r)).toReal = c := by
+  have hv := unitBallVol_pos (n := n) hn
+  have hbase : (0 : ℝ) < c / unitBallVol n := by positivity
+  refine ⟨(c / unitBallVol n) ^ ((n : ℝ)⁻¹), by positivity, ?_⟩
+  rw [volume_ball_toReal hn (by positivity),
+    Real.rpow_inv_natCast_pow hbase.le (by omega)]
+  field_simp
+
+/-- **Density bookkeeping (unconditional).** Every target density
+`0 < d < ζ(n)/2^(n-1)` arises as `vol(ball (r/2))` for a radius `r` whose ball
+clears the doubled avoidance threshold: `vol(ball r) < 2·ζ(n)`. -/
+theorem exists_radius_of_density {n : ℕ} (hn : 2 ≤ n) {d : ℝ} (hd : 0 < d)
+    (hdlt : d < zetaSum n / 2 ^ (n - 1)) :
+    ∃ r : ℝ, 0 < r ∧
+      (volume (Metric.ball (0 : EuclideanSpace ℝ (Fin n)) (r / 2))).toReal = d ∧
+      (volume (Metric.ball (0 : EuclideanSpace ℝ (Fin n)) r)).toReal
+        < 2 * zetaSum n := by
+  have hn1 : 1 ≤ n := le_trans one_le_two hn
+  obtain ⟨r, hr, hvol⟩ :=
+    exists_radius_volume_eq hn1 (c := 2 ^ n * d) (by positivity)
+  have h2 : (2 : ℝ) ^ n = 2 * 2 ^ (n - 1) := by
+    conv_lhs => rw [show n = (n - 1) + 1 by omega, pow_succ]
+    ring
+  refine ⟨r, hr, ?_, ?_⟩
+  · rw [volume_ball_half_toReal hn1 hr.le, hvol]
+    field_simp
+  · rw [hvol, h2, mul_assoc]
+    have := mul_lt_mul_of_pos_left hdlt
+      (show (0 : ℝ) < 2 ^ (n - 1) * 2 by positivity)
+    calc 2 * (2 ^ (n - 1) * d) = 2 ^ (n - 1) * 2 * d := by ring
+      _ < 2 ^ (n - 1) * 2 * (zetaSum n / 2 ^ (n - 1)) := this
+      _ = 2 * zetaSum n := by field_simp; ring
+
+/-- **Minkowski–Hlawka, packing-density form (staged, S6).** Under the
+primitive Siegel–Rogers staging hypotheses (`hMV`, `hInt` — quantified over
+all radii, as the true identity holds for every Borel set), every density
+`d < ζ(n)/2^(n-1)` is realized: there is a radius `r` with
+`vol(ball (r/2)) = d` and a lattice in the family of minimum distance `≥ r`,
+i.e. whose balls of radius `r/2` pack at density `d` per unit covolume. This
+is the classical density statement `δₙ ≥ ζ(n)/2^(n-1)`, with the sole missing
+input the Siegel–Rogers identity itself (the node's registry blocker). -/
+theorem hlawka_density_symm {n : ℕ} (hn : 2 ≤ n) {Ω : Type*}
+    [MeasurableSpace Ω] (μ : Measure Ω) [IsProbabilityMeasure μ]
+    (latticeOf : Ω → AddSubgroup (EuclideanSpace ℝ (Fin n)))
+    (r₀ : Ω → ℝ) (hr₀ : ∀ ω, 0 < r₀ ω)
+    (hdisc : ∀ ω, ∀ u ∈ latticeOf ω, u ≠ 0 → r₀ ω ≤ ‖u‖)
+    (hMV : ∀ r : ℝ, 0 < r →
+      ∫ ω, (primCount (latticeOf ω) (Metric.ball 0 r) : ℝ) ∂μ =
+        (volume (Metric.ball (0 : EuclideanSpace ℝ (Fin n)) r)).toReal / zetaSum n)
+    (hInt : ∀ r : ℝ, 0 < r →
+      Integrable (fun ω => (primCount (latticeOf ω) (Metric.ball 0 r) : ℝ)) μ)
+    {d : ℝ} (hd : 0 < d) (hdlt : d < zetaSum n / 2 ^ (n - 1)) :
+    ∃ r : ℝ, 0 < r ∧
+      (volume (Metric.ball (0 : EuclideanSpace ℝ (Fin n)) (r / 2))).toReal = d ∧
+      ∃ ω, ∀ v ∈ latticeOf ω, v ≠ 0 → r ≤ ‖v‖ := by
+  obtain ⟨r, hr, hhalf, hvol⟩ := exists_radius_of_density hn hd hdlt
+  exact ⟨r, hr, hhalf,
+    hlawka_ball_symm hn μ latticeOf r₀ hr₀ hdisc (hMV r hr) (hInt r hr) hvol⟩
+
 #check @zetaSum_summable
 #check @one_le_zetaSum
 #check @minimal_isPrimitive
@@ -497,5 +609,11 @@ theorem hlawka_ball_symm {n : ℕ} (hn : 2 ≤ n) {Ω : Type*}
 #check @two_le_primCount_of_symm_of_mem
 #check @hlawka_avoidance_symm
 #check @hlawka_ball_symm
+#check @volume_ball_toReal
+#check @unitBallVol_pos
+#check @volume_ball_half_toReal
+#check @exists_radius_volume_eq
+#check @exists_radius_of_density
+#check @hlawka_density_symm
 
 end MinkowskiFundamentalTheoremOQ06

--- a/src/data/research/problems/minkowski-fundamental-theorem-oq-06.json
+++ b/src/data/research/problems/minkowski-fundamental-theorem-oq-06.json
@@ -1,13 +1,13 @@
 {
   "slug": "minkowski-fundamental-theorem-oq-06",
-  "title": "The Minkowski–Hlawka Theorem",
+  "title": "The Minkowski\u2013Hlawka Theorem",
   "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
   "problemStatement": {
     "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formal mathematical investigation: The Minkowski–Hlawka Theorem.",
+    "plain": "Formal mathematical investigation: The Minkowski\u2013Hlawka Theorem.",
     "whyMatters": [
       "Research value"
     ]
@@ -23,7 +23,7 @@
     "iteration": 4,
     "focus": "S4 ACT (researcher-1, 2026-07-24): hFin staging hypothesis DISCHARGED (Docker-GREEN 8576 jobs, 0 sorry / 0 axiom). finite_inter_of_isBounded_of_uniform_discrete [ProperSpace E]: a bounded set meets a uniformly discrete subgroup finitely often (IsBounded.isCompact_closure -> IsCompact.totallyBounded -> Metric.totallyBounded_iff with eps = r0/3 -> Set.Finite.biUnion of per-ball subsingletons; no choose needed). Properness essential: Z-span of the orthonormal basis in l2 is uniformly discrete yet meets the 3/2-ball infinitely often (counterexample documented in file). New hlawka_avoidance_of_isBounded / hlawka_ball_of_discrete carry only the analytic staging hypotheses hMV (Siegel-Rogers primitive mean-value) + hInt.",
     "blockers": [],
-    "nextAction": "S5 menu: (1) +-/- pairing rung: for symmetric S the primitive count is even, so the avoidance threshold improves to 2*zeta(n) — the route to the classical zeta(n)/2^(n-1) packing constant. (2) Density-form assessment: from hlawka_ball_of_discrete min-distance r, pack balls of radius r/2 and formalize a packing-density statement. DEEP (blocked route): Siegel-Rogers primitive mean-value identity itself — Haar probability measure on SL_n(Z)\\SL_n(R) absent from Mathlib (>1000 LOC).",
+    "nextAction": "S5 menu: (1) +-/- pairing rung: for symmetric S the primitive count is even, so the avoidance threshold improves to 2*zeta(n) \u2014 the route to the classical zeta(n)/2^(n-1) packing constant. (2) Density-form assessment: from hlawka_ball_of_discrete min-distance r, pack balls of radius r/2 and formalize a packing-density statement. DEEP (blocked route): Siegel-Rogers primitive mean-value identity itself \u2014 Haar probability measure on SL_n(Z)\\SL_n(R) absent from Mathlib (>1000 LOC).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,32 +31,36 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: staged Minkowski-Hlawka skeleton complete with the finiteness hypothesis discharged. MinkowskiFundamentalTheoremOQ06.lean: 383 LOC, 18 theorems, 0 sorry / 0 axiom, Docker-GREEN. Unconditional: zeta-series bounds, primitivity descent bridge, better-than-average extraction, bounded-discrete finiteness. Staged on exactly two analytic hypotheses (hMV Siegel-Rogers primitive mean-value + hInt integrability); deep blocker unchanged (Haar measure on SL_n(Z)\\SL_n(R)).",
+    "progressSummary": "PROGRESS: S6 density rung complete. MinkowskiFundamentalTheoremOQ06.lean: 619 LOC, 0 sorry / 0 axiom, host-verified. Unconditional: zeta-series, primitivity descent bridge, extraction, hFin finiteness (S4), \u00b1-pairing 2*zeta(n) threshold (S5), ball-volume scaling bookkeeping (S6). hlawka_density_symm gives the classical packing-density form delta_n >= zeta(n)/2^(n-1) staged on exactly hMV (primitive Siegel-Rogers mean value, all radii) + hInt. Deep blocker unchanged: Haar measure on SL_n(Z)\\SL_n(R).",
     "builtItems": [
       "research/problems/minkowski-fundamental-theorem-oq-06/verify_minkowski_hlawka.py - durable sympy verification: (A) symmetric threshold 2*zeta(n) <-> density zeta(n)/2^(n-1); (B) hierarchy 2^-n <= MH <= delta_known; (C) improvement factor = 2*zeta(n). All pass.",
       "MinkowskiFundamentalTheoremOQ06.lean (NEW, 273 lines, 0 axioms, 0 sorries): zetaSum + summability/bounds, IsPrimitive, minimal_isPrimitive, exists_primitive_norm_le (descent bridge), no_nonzero_of_no_primitive_in_ball, exists_count_zero_of_integral_lt_one (better-than-average extraction), hlawka_avoidance + hlawka_ball (staged on Siegel-Rogers primitive mean-value hypothesis)",
-      "subsingleton_ball_inter_of_uniform_discrete in MinkowskiFundamentalTheoremOQ06.lean — r0/3-ball meets a uniformly discrete subgroup in at most one point",
-      "finite_inter_of_isBounded_of_uniform_discrete in MinkowskiFundamentalTheoremOQ06.lean — [ProperSpace] bounded set meets uniformly discrete subgroup finitely often",
-      "finite_primitive_inter_of_isBounded in MinkowskiFundamentalTheoremOQ06.lean — primitive-vector specialization discharging hFin",
-      "hlawka_avoidance_of_isBounded / hlawka_ball_of_discrete in MinkowskiFundamentalTheoremOQ06.lean — staged Minkowski-Hlawka with hFin discharged (only hMV + hInt remain)"
+      "subsingleton_ball_inter_of_uniform_discrete in MinkowskiFundamentalTheoremOQ06.lean \u2014 r0/3-ball meets a uniformly discrete subgroup in at most one point",
+      "finite_inter_of_isBounded_of_uniform_discrete in MinkowskiFundamentalTheoremOQ06.lean \u2014 [ProperSpace] bounded set meets uniformly discrete subgroup finitely often",
+      "finite_primitive_inter_of_isBounded in MinkowskiFundamentalTheoremOQ06.lean \u2014 primitive-vector specialization discharging hFin",
+      "hlawka_avoidance_of_isBounded / hlawka_ball_of_discrete in MinkowskiFundamentalTheoremOQ06.lean \u2014 staged Minkowski-Hlawka with hFin discharged (only hMV + hInt remain)",
+      "unitBallVol, volume_ball_toReal, unitBallVol_pos, volume_ball_half_toReal, exists_radius_volume_eq, exists_radius_of_density (all unconditional) in MinkowskiFundamentalTheoremOQ06.lean",
+      "hlawka_density_symm (staged S6 headline) in MinkowskiFundamentalTheoremOQ06.lean"
     ],
     "insights": [
       "Minkowski-Hlawka is the EXISTENCE complement to the gallery parent (which proves only the Minkowski convex-body OBSTRUCTION). Parent MinkowskiFundamentalTheorem.lean is sorry-free but proves a different theorem; Hlawka is absent from proofs/ (grep -i hlawka hits only Erdos997Problem.lean, unrelated).",
       "Correct symmetric normalization: if symmetric S has vol(S) < 2*zeta(n) then some unimodular lattice avoids S minus {0}; taking S = ball(radius 2r) gives lattice packing density delta_n >= zeta(n)/2^(n-1). The seed problem.md threshold vol(S) < zeta(n) is the star-body / plus-minus-identified convention; the symmetric-body threshold is 2*zeta(n). Statement<->density chain verified numerically (verify_minkowski_hlawka.py check A).",
       "Bound hierarchy verified for n in {2..8,24}: trivial saturation 2^-n <= zeta(n)/2^(n-1) <= delta_n^known (A2,D3,D4,D5,E6,E7,E8,Leech). MH is a VALID but very weak lower bound vs known optima (n=8: MH 0.00784 vs E8 0.2537).",
       "MH improves the elementary maximal-packing bound delta_n >= 2^-n by exactly a factor 2*zeta(n), which decreases to 2 as n grows. So the celebrated Hlawka improvement over the trivial saturation argument is asymptotically only a factor of 2; both bounds decay like 2^-n and the exponential gap to the (also exponential) Kabatiansky-Levenshtein upper bound is untouched by MH.",
-      "The zeta(n) factor in delta_n >= zeta(n)/2^(n-1) is the PRIMITIVE-vector (Siegel-Rogers) restriction, NOT the +/- pairing. ±-pairing gives only the factor 2; zeta(n) = sum_{m>=1} m^{-n} is the primitivity normalizer.",
+      "The zeta(n) factor in delta_n >= zeta(n)/2^(n-1) is the PRIMITIVE-vector (Siegel-Rogers) restriction, NOT the +/- pairing. \u00b1-pairing gives only the factor 2; zeta(n) = sum_{m>=1} m^{-n} is the primitivity normalizer.",
       "Two distinct mean-value identities on X_n=SL_n(Z)\\SL_n(R): Siegel (all nonzero v): integral = vol; Siegel-Rogers (primitive w only): integral = vol/zeta(n). The primitive one follows from Siegel by v=m*w factorization + scaling integral f(m.)=m^{-n} integral f, giving coefficient 1/sum_m m^{-n}=1/zeta(n).",
-      "CORRECTION for staged formalization (target #1): the hypothesis to assume is the PRIMITIVE mean-value identity, not the all-vectors Siegel identity. Assuming all-vectors + ±-pairing alone only reaches delta_n >= 1/2^(n-1), missing the zeta(n).",
+      "CORRECTION for staged formalization (target #1): the hypothesis to assume is the PRIMITIVE mean-value identity, not the all-vectors Siegel identity. Assuming all-vectors + \u00b1-pairing alone only reaches delta_n >= 1/2^(n-1), missing the zeta(n).",
       "Bridge lemma (Mathlib-tractable, unlike the mean-value identity): the shortest nonzero lattice vector is always primitive (v=m*w, m>=2 => ||w||<||v||). This lets 'no primitive vector in ball(2r)' imply 'min distance >= 2r' for the packing/ball case.",
       "Durable numeric witness (verify_primitive_mechanism.py, stdlib-only, all pass): Z^2 origin-visible (gcd=1) point fraction -> 6/pi^2 = 1/zeta(2); Z^3 -> 1/zeta(3); 13808/13808 integer 2x2 bases have a primitive shortest vector.",
       "Staged target #1 EXECUTED (researcher-3 2026-07-24): hlawka_avoidance + hlawka_ball take the PRIMITIVE mean-value identity as explicit hypothesis hMV (per the corrected mechanism note: primitive form, threshold zeta(n), NOT the all-vectors identity)",
-      "The bridge lemma is stronger than shortest-vector-primitive: exists_primitive_norm_le shows in a UNIFORMLY discrete subgroup, below every nonzero v sits a primitive w with |w| <= |v| — norm-halving descent, strong induction on ceil(|v|/r0); key step: 2|w| <= |v| <= (k+1)r0 and |w| >= r0 give |w| <= k*r0 (no case split)",
+      "The bridge lemma is stronger than shortest-vector-primitive: exists_primitive_norm_le shows in a UNIFORMLY discrete subgroup, below every nonzero v sits a primitive w with |w| <= |v| \u2014 norm-halving descent, strong induction on ceil(|v|/r0); key step: 2|w| <= |v| <= (k+1)r0 and |w| >= r0 give |w| <= k*r0 (no case split)",
       "Set.ncard junk-value trap: ncard of an infinite set is 0, so the staged theorems carry hFin explicitly; proving finiteness from uniform discreteness + boundedness is a real next rung (separated set in bounded region is finite)",
       "zetaSum over ALL of N works: the m=0 term is 1/0^n = 0 by div-zero convention, so no PNat reindexing needed; Real.summable_one_div_nat_pow gives summability for n >= 2",
       "S4: the hFin finiteness hypothesis of the staged Hlawka theorems is a THEOREM for bounded S: in a proper space a bounded set meets a uniformly discrete subgroup finitely often. Cover by r0/3-balls (totally bounded via compact closure); each ball holds at most one subgroup point (difference has norm < 2r0/3 < r0).",
-      "S4: properness is essential, not decorative — in l2 the subgroup generated by the orthonormal basis is uniformly discrete (nonzero elements have norm >= 1) yet the 3/2-ball contains all infinitely many basis vectors. The finite-dimensionality of EuclideanSpace R (Fin n) is doing real work in Minkowski-Hlawka.",
-      "S4 Lean: Set.Finite.biUnion over ball centers + Set.Subsingleton.finite avoids any choice-function pigeonhole; Bornology.IsBounded.isCompact_closure + TotallyBounded.subset subset_closure + Metric.totallyBounded_iff is the clean route from bounded to a finite eps-cover. Gotcha: r0 <= ||a-b|| < 2r0/3 alone only forces r0 < 0 — linarith additionally needs norm_nonneg."
+      "S4: properness is essential, not decorative \u2014 in l2 the subgroup generated by the orthonormal basis is uniformly discrete (nonzero elements have norm >= 1) yet the 3/2-ball contains all infinitely many basis vectors. The finite-dimensionality of EuclideanSpace R (Fin n) is doing real work in Minkowski-Hlawka.",
+      "S4 Lean: Set.Finite.biUnion over ball centers + Set.Subsingleton.finite avoids any choice-function pigeonhole; Bornology.IsBounded.isCompact_closure + TotallyBounded.subset subset_closure + Metric.totallyBounded_iff is the clean route from bounded to a finite eps-cover. Gotcha: r0 <= ||a-b|| < 2r0/3 alone only forces r0 < 0 \u2014 linarith additionally needs norm_nonneg.",
+      "S6 (density bookkeeping) DONE: the residual 2^(1-n) factor between the doubled avoidance threshold 2*zeta(n) and the classical density bound is pure ball-volume scaling \u2014 formalized unconditionally via Measure.addHaar_ball (vol(ball r)=r^n*vol(ball 1)), with radius realization through Real.rpow_inv_natCast_pow.",
+      "hlawka_density_symm states the classical delta_n >= zeta(n)/2^(n-1) as: every density d < zeta(n)/2^(n-1) equals vol(ball(r/2)) for a radius r at which the family contains a lattice of minimum distance >= r. hMV/hInt staging now quantified over all radii (the true Siegel-Rogers identity holds for every Borel set, so this is not a strengthening of the assumption)."
     ],
     "mathlibGaps": [
       "Mathlib pin 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67: GeometryOfNumbers.lean has ONLY Blichfeldt (exists_pair_mem_lattice_not_disjoint_vadd) + Minkowski convex-body (exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt/le_measure). No Hlawka.",
@@ -65,9 +69,8 @@
       "No packing-density notion (gh search packingDensity = 0). 'Minkowski-Hlawka theorem' appears in Mathlib docs/1000.yaml as a TITLE-ONLY entry (no decl:/author:), i.e. an UNMET target in the 1000-theorems project -> confirms not formalized upstream."
     ],
     "nextSteps": [
-      "Docker-up: stage target #1 with the PRIMITIVE Siegel-Rogers identity as the hypothesis (axiom/structure field), then prove better-than-average => existence => delta_n >= zeta(n)/2^(n-1). Badge=axiom.",
-      "Mathlib-only: formalize the 'shortest nonzero lattice vector is primitive' bridge lemma (Docker-gated but no missing upstream theory).",
-      "Elementary stepping stone: delta_n >= 2^(-n) via maximal packing + radius-doubling cover."
+      "Assess a packingDensity definition rung: with hlawka_density_symm in place the remaining gap to a literal 'delta_n >= zeta(n)/2^(n-1)' statement is only a definition of packing density for covolume-1 lattices (needs fundamental domain / covolume, ~Zspan API); assess Mathlib's Zspan/fundamentalDomain before attempting.",
+      "DEEP (registry blocker, stand down unless new Mathlib): the Siegel-Rogers primitive mean-value identity itself (finite Haar measure on SL_n(Z)\\SL_n(R))."
     ],
     "progressHistory": [
       {
@@ -75,7 +78,7 @@
         "date": "2026-07-24",
         "researcher": "researcher-1",
         "mode": "ACT",
-        "summary": "Discharged hFin: subsingleton_ball_inter_of_uniform_discrete + finite_inter_of_isBounded_of_uniform_discrete (ProperSpace; totally-bounded r0/3-cover, biUnion of subsingletons) + finite_primitive_inter_of_isBounded + hlawka_avoidance_of_isBounded / hlawka_ball_of_discrete. 273→383 LOC, 14→18 theorems (grep ^theorem), 0 sorry / 0 axiom, Docker-GREEN (8576 jobs). One repair: norm_nonneg needed by final linarith."
+        "summary": "Discharged hFin: subsingleton_ball_inter_of_uniform_discrete + finite_inter_of_isBounded_of_uniform_discrete (ProperSpace; totally-bounded r0/3-cover, biUnion of subsingletons) + finite_primitive_inter_of_isBounded + hlawka_avoidance_of_isBounded / hlawka_ball_of_discrete. 273\u2192383 LOC, 14\u219218 theorems (grep ^theorem), 0 sorry / 0 axiom, Docker-GREEN (8576 jobs). One repair: norm_nonneg needed by final linarith."
       }
     ]
   },


### PR DESCRIPTION
## Summary
Research session for minkowski-fundamental-theorem-oq-06 (S6 density rung). Recovered PR — branch was pushed at 12:17 but PR creation was blocked by a GitHub API outage; filed by the follow-up researcher-1 session.

## Progress
- `proofs/Proofs/MinkowskiFundamentalTheoremOQ06.lean`: +118 lines, 6 new theorems, 0 sorry / 0 axiom (host-verified, `lake env lean` exit 0)
- `src/data/research/problems/minkowski-fundamental-theorem-oq-06.json`: tracker update for S6

## Findings
- **Unconditional ball-volume bookkeeping** (pure Mathlib measure theory via `Measure.addHaar_ball`):
  - `volume_ball_toReal` — scaling law `vol(ball r) = r^n * vol(ball 1)` in real form
  - `unitBallVol_pos` — positivity of the unit-ball volume
  - `volume_ball_half_toReal` — half-radius scaling `vol(ball (r/2)) = vol(ball r)/2^n`, the exact `2^(1-n)` factor between the doubled avoidance threshold and the packing-density bound
  - `exists_radius_volume_eq` — every positive real is realized as a ball volume (`Real.rpow` inversion)
  - `exists_radius_of_density` — every target density `0 < d < ζ(n)/2^(n-1)` arises as `vol(ball (r/2))` with `vol(ball r) < 2·ζ(n)`
- **Headline** `hlawka_density_symm` — the classical packing-density form of Minkowski–Hlawka `δₙ ≥ ζ(n)/2^(n-1)`: staged only on the Siegel–Rogers mean-value/integrability hypotheses (`hMV`/`hInt`, now quantified over radii), composing the doubled threshold `hlawka_ball_symm` with the density bookkeeping.
- No `axiom` declarations; the `hlawka_*` theorems remain honestly conditional on their explicit `hMV`/`hInt` hypotheses (the node's registry blocker is the Siegel–Rogers identity itself).

## Status
**Outcome**: progress
**Next Steps**: The remaining gap is the Siegel–Rogers mean-value identity (`hMV`) — deep; the staged family is otherwise complete through the density form.

🤖 Generated by researcher-1
