### PR TITLE
Research: erdos-659-oq-01-oq-02 - S11: (5,13) axis-vs-plane safety discharged

### DIFF
--- a/proofs/Proofs/Erdos659OQ01OQ02.lean
+++ b/proofs/Proofs/Erdos659OQ01OQ02.lean
@@ -874,4 +874,196 @@ theorem safe_C_5_7_holds :
 theorem safe_5_7_axis_vs_plane : SafePrimePair_AxisVsPlane 5 7 :=
   ⟨safe_A_5_7_holds, safe_B_5_7_holds, safe_C_5_7_holds⟩
 
+/-!
+### S11 ACT — `(5, 13)` axis-vs-plane safety (mixed-modulus discharge)
+
+Fifth member of the S2a safe-pair family
+`{(2,5), (2,13), (3,5), (5,7), (5,13), (7,13), (11,13)}`, following the
+mixed-modulus route pre-audited at the S10 close: equations A and C reduce
+**mod 5** — where `13 ≡ 3` lets them reuse the existing
+`zmod_5_a_sq_eq_three_b_sq_iff` (`3` is not a QR mod 5) — and only equation B
+reduces mod 13, needing the single new helper `zmod_13_a_sq_eq_five_b_sq_iff`
+(`5` is not a QR mod 13).
+-/
+
+/-- **(S11 ACT, mod-13 step for equation B on the prime pair `(5, 13)`)**
+    `a² ≡ 5 b² (mod 13)` iff both `a ≡ 0` and `b ≡ 0` in `ZMod 13`.
+    Equivalent to the assertion that `5` is not a square in `ZMod 13`
+    (squares mod 13 are `{0, 1, 3, 4, 9, 10, 12}`; `5` is not among them).
+    169-case `decide` check. -/
+lemma zmod_13_a_sq_eq_five_b_sq_iff (a b : ZMod 13) :
+    a ^ 2 = 5 * b ^ 2 ↔ a = 0 ∧ b = 0 := by
+  revert a b
+  decide
+
+/-- **(S11 ACT — axis-vs-plane equation A for `(p, q) = (5, 13)`).**
+    `13 c² = a² + 5 b²` has only `(0, 0, 0)`.
+
+    Infinite descent on `c.natAbs`, reducing **mod 5**: since `13 ≡ 3 (mod 5)`,
+    the equation collapses to `a² ≡ 3 c² (mod 5)` and
+    `zmod_5_a_sq_eq_three_b_sq_iff` forces `5 ∣ a`, `5 ∣ c`, then `5 ∣ b`. -/
+theorem safe_A_5_13_holds :
+    ∀ a b c : ℤ, (13 : ℤ) * c ^ 2 = a ^ 2 + 5 * b ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+  have key : ∀ n : ℕ, ∀ a b c : ℤ, c.natAbs = n →
+      (13 : ℤ) * c ^ 2 = a ^ 2 + 5 * b ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+    intro n
+    induction n using Nat.strong_induction_on with
+    | _ n ih =>
+      intro a b c hc heq
+      rcases Nat.eq_zero_or_pos n with hn0 | hnpos
+      · have hc0 : c = 0 := Int.natAbs_eq_zero.mp (by omega)
+        subst hc0
+        refine ⟨?_, ?_, rfl⟩
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg b]) (sq_nonneg a))
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg a]) (sq_nonneg b))
+      · have hz : (a : ZMod 5) ^ 2 = 3 * (c : ZMod 5) ^ 2 := by
+          have h : ((13 * c ^ 2 : ℤ) : ZMod 5) = ((a ^ 2 + 5 * b ^ 2 : ℤ) : ZMod 5) := by
+            rw [heq]
+          push_cast at h
+          rw [show (5 : ZMod 5) = 0 from by decide,
+              show (13 : ZMod 5) = 3 from by decide, zero_mul, add_zero] at h
+          exact h.symm
+        rw [zmod_5_a_sq_eq_three_b_sq_iff] at hz
+        have hda : (5 : ℤ) ∣ a := (ZMod.intCast_zmod_eq_zero_iff_dvd a 5).mp hz.1
+        have hdc : (5 : ℤ) ∣ c := (ZMod.intCast_zmod_eq_zero_iff_dvd c 5).mp hz.2
+        obtain ⟨a', rfl⟩ := hda
+        obtain ⟨c', rfl⟩ := hdc
+        have h5b : (5 : ℤ) * b ^ 2 = 5 * (5 * (13 * c' ^ 2 - a' ^ 2)) := by
+          linear_combination -heq
+        have hb2 : b ^ 2 = 5 * (13 * c' ^ 2 - a' ^ 2) :=
+          mul_left_cancel₀ (by norm_num : (5 : ℤ) ≠ 0) h5b
+        have hdb : (5 : ℤ) ∣ b := by
+          have hp : Prime (5 : ℤ) := by norm_num
+          exact hp.dvd_of_dvd_pow (⟨13 * c' ^ 2 - a' ^ 2, hb2⟩ : (5 : ℤ) ∣ b ^ 2)
+        obtain ⟨b', rfl⟩ := hdb
+        have heq' : (13 : ℤ) * c' ^ 2 = a' ^ 2 + 5 * b' ^ 2 := by
+          have h25 : (5 : ℤ) * (13 * c' ^ 2) = 5 * (a' ^ 2 + 5 * b' ^ 2) := by
+            linear_combination -hb2
+          exact mul_left_cancel₀ (by norm_num : (5 : ℤ) ≠ 0) h25
+        have hmeas : c'.natAbs < n := by
+          have h5nat : (5 : ℤ).natAbs = 5 := by decide
+          rw [Int.natAbs_mul, h5nat] at hc
+          omega
+        obtain ⟨ha0, hb0, hc0⟩ := ih c'.natAbs hmeas a' b' c' rfl heq'
+        subst ha0; subst hb0; subst hc0
+        refine ⟨by ring, by ring, by ring⟩
+  intro a b c heq
+  exact key c.natAbs a b c rfl heq
+
+/-- **(S11 ACT — axis-vs-plane equation B for `(p, q) = (5, 13)`).**
+    `5 b² = a² + 13 c²` has only `(0, 0, 0)`.
+
+    Infinite descent on `b.natAbs`: mod 13 (via the new
+    `zmod_13_a_sq_eq_five_b_sq_iff`) forces `13 ∣ a`, `13 ∣ b`, then `13 ∣ c`. -/
+theorem safe_B_5_13_holds :
+    ∀ a b c : ℤ, (5 : ℤ) * b ^ 2 = a ^ 2 + 13 * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+  have key : ∀ n : ℕ, ∀ a b c : ℤ, b.natAbs = n →
+      (5 : ℤ) * b ^ 2 = a ^ 2 + 13 * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+    intro n
+    induction n using Nat.strong_induction_on with
+    | _ n ih =>
+      intro a b c hb heq
+      rcases Nat.eq_zero_or_pos n with hn0 | hnpos
+      · have hb0 : b = 0 := Int.natAbs_eq_zero.mp (by omega)
+        subst hb0
+        refine ⟨?_, rfl, ?_⟩
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg c]) (sq_nonneg a))
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg a]) (sq_nonneg c))
+      · have hz : (a : ZMod 13) ^ 2 = 5 * (b : ZMod 13) ^ 2 := by
+          have h : ((5 * b ^ 2 : ℤ) : ZMod 13) = ((a ^ 2 + 13 * c ^ 2 : ℤ) : ZMod 13) := by
+            rw [heq]
+          push_cast at h
+          rw [show (13 : ZMod 13) = 0 from by decide, zero_mul, add_zero] at h
+          exact h.symm
+        rw [zmod_13_a_sq_eq_five_b_sq_iff] at hz
+        have hda : (13 : ℤ) ∣ a := (ZMod.intCast_zmod_eq_zero_iff_dvd a 13).mp hz.1
+        have hdb : (13 : ℤ) ∣ b := (ZMod.intCast_zmod_eq_zero_iff_dvd b 13).mp hz.2
+        obtain ⟨a', rfl⟩ := hda
+        obtain ⟨b', rfl⟩ := hdb
+        have h13c : (13 : ℤ) * c ^ 2 = 13 * (13 * (5 * b' ^ 2 - a' ^ 2)) := by
+          linear_combination -heq
+        have hc2 : c ^ 2 = 13 * (5 * b' ^ 2 - a' ^ 2) :=
+          mul_left_cancel₀ (by norm_num : (13 : ℤ) ≠ 0) h13c
+        have hdc : (13 : ℤ) ∣ c := by
+          have hp : Prime (13 : ℤ) := by norm_num
+          exact hp.dvd_of_dvd_pow (⟨5 * b' ^ 2 - a' ^ 2, hc2⟩ : (13 : ℤ) ∣ c ^ 2)
+        obtain ⟨c', rfl⟩ := hdc
+        have heq' : (5 : ℤ) * b' ^ 2 = a' ^ 2 + 13 * c' ^ 2 := by
+          have h169 : (13 : ℤ) * (5 * b' ^ 2) = 13 * (a' ^ 2 + 13 * c' ^ 2) := by
+            linear_combination -hc2
+          exact mul_left_cancel₀ (by norm_num : (13 : ℤ) ≠ 0) h169
+        have hmeas : b'.natAbs < n := by
+          have h13nat : (13 : ℤ).natAbs = 13 := by decide
+          rw [Int.natAbs_mul, h13nat] at hb
+          omega
+        obtain ⟨ha0, hb0, hc0⟩ := ih b'.natAbs hmeas a' b' c' rfl heq'
+        subst ha0; subst hb0; subst hc0
+        refine ⟨by ring, by ring, by ring⟩
+  intro a b c heq
+  exact key b.natAbs a b c rfl heq
+
+/-- **(S11 ACT — axis-vs-plane equation C for `(p, q) = (5, 13)`).**
+    `a² = 5 b² + 13 c²` has only `(0, 0, 0)`.
+
+    Infinite descent on `a.natAbs`, reducing **mod 5** (as for equation A):
+    `13 ≡ 3 (mod 5)` collapses the equation to `a² ≡ 3 c² (mod 5)`, and
+    `zmod_5_a_sq_eq_three_b_sq_iff` forces `5 ∣ a`, `5 ∣ c`, then `5 ∣ b`. -/
+theorem safe_C_5_13_holds :
+    ∀ a b c : ℤ, a ^ 2 = (5 : ℤ) * b ^ 2 + 13 * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+  have key : ∀ n : ℕ, ∀ a b c : ℤ, a.natAbs = n →
+      a ^ 2 = (5 : ℤ) * b ^ 2 + 13 * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+    intro n
+    induction n using Nat.strong_induction_on with
+    | _ n ih =>
+      intro a b c ha heq
+      rcases Nat.eq_zero_or_pos n with hn0 | hnpos
+      · have ha0 : a = 0 := Int.natAbs_eq_zero.mp (by omega)
+        subst ha0
+        refine ⟨rfl, ?_, ?_⟩
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg c]) (sq_nonneg b))
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg b]) (sq_nonneg c))
+      · have hz : (a : ZMod 5) ^ 2 = 3 * (c : ZMod 5) ^ 2 := by
+          have h : ((a ^ 2 : ℤ) : ZMod 5) = ((5 * b ^ 2 + 13 * c ^ 2 : ℤ) : ZMod 5) := by
+            rw [heq]
+          push_cast at h
+          rw [show (5 : ZMod 5) = 0 from by decide,
+              show (13 : ZMod 5) = 3 from by decide, zero_mul, zero_add] at h
+          exact h
+        rw [zmod_5_a_sq_eq_three_b_sq_iff] at hz
+        have hda : (5 : ℤ) ∣ a := (ZMod.intCast_zmod_eq_zero_iff_dvd a 5).mp hz.1
+        have hdc : (5 : ℤ) ∣ c := (ZMod.intCast_zmod_eq_zero_iff_dvd c 5).mp hz.2
+        obtain ⟨a', rfl⟩ := hda
+        obtain ⟨c', rfl⟩ := hdc
+        have h5b : (5 : ℤ) * b ^ 2 = 5 * (5 * (a' ^ 2 - 13 * c' ^ 2)) := by
+          linear_combination -heq
+        have hb2 : b ^ 2 = 5 * (a' ^ 2 - 13 * c' ^ 2) :=
+          mul_left_cancel₀ (by norm_num : (5 : ℤ) ≠ 0) h5b
+        have hdb : (5 : ℤ) ∣ b := by
+          have hp : Prime (5 : ℤ) := by norm_num
+          exact hp.dvd_of_dvd_pow (⟨a' ^ 2 - 13 * c' ^ 2, hb2⟩ : (5 : ℤ) ∣ b ^ 2)
+        obtain ⟨b', rfl⟩ := hdb
+        have heq' : a' ^ 2 = (5 : ℤ) * b' ^ 2 + 13 * c' ^ 2 := by
+          have h25 : (5 : ℤ) * a' ^ 2 = 5 * (5 * b' ^ 2 + 13 * c' ^ 2) := by
+            linear_combination -hb2
+          exact mul_left_cancel₀ (by norm_num : (5 : ℤ) ≠ 0) h25
+        have hmeas : a'.natAbs < n := by
+          have h5nat : (5 : ℤ).natAbs = 5 := by decide
+          rw [Int.natAbs_mul, h5nat] at ha
+          omega
+        obtain ⟨ha0, hb0, hc0⟩ := ih a'.natAbs hmeas a' b' c' rfl heq'
+        subst ha0; subst hb0; subst hc0
+        refine ⟨by ring, by ring, by ring⟩
+  intro a b c heq
+  exact key a.natAbs a b c rfl heq
+
+/-- **The main axis-vs-plane safety theorem for the prime pair `(p, q) = (5, 13)`.**
+
+    Fifth discharged member of the S2a safe-pair family, via the same
+    mixed-modulus route as `(5, 7)` (equations A and C mod 5 reusing
+    `zmod_5_a_sq_eq_three_b_sq_iff`, equation B mod 13 via the new
+    `zmod_13_a_sq_eq_five_b_sq_iff`).  The full-rank half is a separate future
+    axiomatisation per S2c PREP §6.1. -/
+theorem safe_5_13_axis_vs_plane : SafePrimePair_AxisVsPlane 5 13 :=
+  ⟨safe_A_5_13_holds, safe_B_5_13_holds, safe_C_5_13_holds⟩
+
 end Erdos659OQ01OQ02

--- a/research/problems/erdos-659-oq-01-oq-02/state.md
+++ b/research/problems/erdos-659-oq-01-oq-02/state.md
@@ -1,6 +1,51 @@
 # Current State
 
-**Status**: ACTIVE — S10 ACT LANDED (2026-07-24, researcher-1). The 2026-06-13 BLOCKED flag is cleared: Docker is no longer required (host `lake env lean` verification works), and the S9 PREP `(5, 7)` mixed-modulus recipe has been pasted and verified GREEN on the first try. 4 of 7 safe pairs discharged.
+**Status**: ACTIVE — S11 ACT LANDED (2026-07-24, researcher-2). 5 of 7 safe pairs discharged; `(5, 13)` done via the S10 pre-audit (one new helper, first-try GREEN on host `lake env lean`).
+
+**Phase**: ACT (S11 ACT — `(5, 13)` axis-vs-plane safety DISCHARGED)
+**Since**: 2026-07-24 (S11 ACT)
+**Iteration**: 18
+**Last Update**: 2026-07-24 (researcher-2) — S11 ACT: executed the S10 `(5, 13)` pre-audit in `proofs/Proofs/Erdos659OQ01OQ02.lean` (877 → 1069 LOC). +1 helper (`zmod_13_a_sq_eq_five_b_sq_iff`, 169-case decide), +3 descent theorems (`safe_{A,B,C}_5_13_holds`), +1 composite (`safe_5_13_axis_vs_plane`). 0 sorries / 0 axioms delta; host-verified v4.31 (`lake env lean` exit 0, first try; `#print axioms` = propext/Classical.choice/Quot.sound on all 4 new named declarations). The pre-audit held exactly: eqs A/C reduce mod 5 reusing `zmod_5_a_sq_eq_three_b_sq_iff` (13 ≡ 3 mod 5, 3 a non-residue), only eq B needed the new mod-13 helper (5 ∉ squares mod 13 = {0,1,3,4,9,10,12}). All `linear_combination` orientations mirror the `(5, 7)` template (`-heq` / `-hb2` / `-hc2`).
+
+## S11 ACT (researcher-2, 2026-07-24, host-verified GREEN)
+
+Pasted the `(5, 13)` mixed-modulus discharge, mirroring the S10 `(5, 7)` section
+1:1 with `7 → 13` and the mod-5 helper swapped from the "two" form to the
+"three" form:
+
+| Eq | mod | relation | helper | new? |
+|----|-----|----------|--------|------|
+| A `13c²=a²+5b²` | 5 | `a²≡3c²` | `zmod_5_a_sq_eq_three_b_sq_iff` | reuse |
+| B `5b²=a²+13c²` | 13 | `a²≡5b²` | `zmod_13_a_sq_eq_five_b_sq_iff` | **NEW** |
+| C `a²=5b²+13c²` | 5 | `a²≡3c²` | `zmod_5_a_sq_eq_three_b_sq_iff` | reuse |
+
+**Safe-pair scoreboard**: (2,5) ✓, (3,5) ✓, (2,13) ✓, (5,7) ✓, **(5,13) ✓ (this
+session)**; remaining: (7,13), (11,13).
+
+**Pre-audit for the remaining two pairs (QR tables hand-computed — squares
+mod 11 = {0,1,3,4,5,9}, mod 13 = {0,1,3,4,9,10,12} — verify via `decide` at
+paste time):**
+- **(7,13)**: mod-7 reduction fails for A (`−13 ≡ 1 (mod 7)` is a QR), so go
+  uniform **mod 13**: A `13c²=a²+7b²` gives `a² + 7b² ≡ 0` and `−7 ≡ 6 ∉`
+  squares ✓; B `7b²=a²+13c²` and C `a²=7b²+13c²` give `a² ≡ 7b²` with `7 ∉`
+  squares ✓. TWO new 169-case helpers: `zmod_13_a_sq_plus_7_b_sq_eq_zero_iff`
+  (A) and `zmod_13_a_sq_eq_seven_b_sq_iff` (B/C) — shape of the (2,13) session.
+- **(11,13)**: **mixed-modulus**, TWO new helpers. A `13c²=a²+11b²` mod 11:
+  `13 ≡ 2` and `2 ∉` squares mod 11 ✓ → NEW `zmod_11_a_sq_eq_two_b_sq_iff`;
+  B `11b²=a²+13c²` mod 11 fails (`−11·c²` form: `−2 ≡ 9 = 3²` is a QR), so
+  mod 13: `a² ≡ 11b²`, `11 ∉` squares ✓ → NEW
+  `zmod_13_a_sq_eq_eleven_b_sq_iff`; C `a²=11b²+13c²` mod 11: `a² ≡ 2c²` ✓
+  (reuses the new mod-11 helper).
+
+**Next actions**:
+1. **(7,13) ACT**: uniform mod-13 discharge, two new helpers (pre-audit above).
+2. **(11,13) ACT**: mixed-modulus discharge, two new helpers (mod 11 + mod 13).
+3. Blocked (unchanged): full-rank ternary Hasse–Minkowski safety; Θ(n^{2/3})
+   assembly.
+
+---
+
+**Status (S10, superseded)**: ACTIVE — S10 ACT LANDED (2026-07-24, researcher-1). The 2026-06-13 BLOCKED flag is cleared: Docker is no longer required (host `lake env lean` verification works), and the S9 PREP `(5, 7)` mixed-modulus recipe has been pasted and verified GREEN on the first try. 4 of 7 safe pairs discharged.
 
 **Phase**: ACT (S10 ACT — `(5, 7)` axis-vs-plane safety DISCHARGED)
 **Since**: 2026-07-24 (S10 ACT)

--- a/src/data/research/problems/erdos-659-oq-01-oq-02.json
+++ b/src/data/research/problems/erdos-659-oq-01-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-659-oq-01-oq-02",
   "title": "4-point-property distance bound in ℝ^d for d ≥ 3",
-  "phase": "PREP",
-  "status": "blocked",
+  "phase": "ACT",
+  "status": "active",
   "tier": "B",
   "path": "full",
   "parent": "erdos-659-oq-01",
@@ -59,7 +59,8 @@
       "S4 ACT: this completes only the axis-vs-plane half of L_{2,5} safety; full-rank (genuinely ternary) safety remains a future obligation (Mathlib lacks ternary Hasse-Minkowski at v4.26.0). The d≥3 distinct-distance OQ is NOT solved.",
       "(5,7) mixed-modulus discharge VERIFIED: eqs A/C reduce mod 5 (7 = 2 mod 5, reusing zmod_5_a_sq_eq_two_b_sq_iff), only eq B needs the new mod-7 helper. The S9 hand-derived recipe was correct in every sign/coefficient - it compiled first try, six weeks after being written blind (Docker down).",
       "Docker is NOT required for this file: host lake env lean verifies it (imports Mathlib only); the 2026-06-13 BLOCKED flag was stale. The 49-case ZMod 7 decide is instant.",
-      "(5,13) pre-audit for the next session: A/C reduce mod 5 via the EXISTING zmod_5_a_sq_eq_three_b_sq_iff (13 = 3 mod 5, 3 nonresidue); eq B reduces mod 13 needing new zmod_13_a_sq_eq_five_b_sq_iff (squares mod 13 = {0,1,3,4,9,10,12}, 5 not among). Again exactly ONE new helper."
+      "(5,13) pre-audit for the next session: A/C reduce mod 5 via the EXISTING zmod_5_a_sq_eq_three_b_sq_iff (13 = 3 mod 5, 3 nonresidue); eq B reduces mod 13 needing new zmod_13_a_sq_eq_five_b_sq_iff (squares mod 13 = {0,1,3,4,9,10,12}, 5 not among). Again exactly ONE new helper.",
+      "S11 (2026-07-24): (5,13) confirmed mixed-modulus like (5,7) — 13 = 3 mod 5 with 3 a non-residue kills A/C mod 5 via the EXISTING three-form helper; only B needs mod 13 (5 not in squares mod 13 = {0,1,3,4,9,10,12}). Pre-audits for the last two pairs: (7,13) is uniform mod-13 (mod 7 fails: -13 = 1 is a QR; needs plus-7 and eq-7 helpers), (11,13) is mixed (A/C mod 11 via 13 = 2, 2 not a square mod 11; B mod 13 via 11 not a square)."
     ],
     "builtItems": [
       "Wrote research/problems/erdos-659-oq-01-oq-02/problem.md (formal problem + Lean targets + S2-S6 plan).",
@@ -70,14 +71,15 @@
       "Erdos659OQ01OQ02.lean: 3 strategic sorries → 0, axioms 0, Docker build GREEN.",
       "zmod_7_a_sq_eq_five_b_sq_iff in Erdos659OQ01OQ02.lean",
       "safe_A_5_7_holds, safe_B_5_7_holds, safe_C_5_7_holds (mixed-modulus QR descent) in Erdos659OQ01OQ02.lean",
-      "safe_5_7_axis_vs_plane (4th of 7 safe pairs) in Erdos659OQ01OQ02.lean"
+      "safe_5_7_axis_vs_plane (4th of 7 safe pairs) in Erdos659OQ01OQ02.lean",
+      "S11 ACT (Erdos659OQ01OQ02.lean 877->1069 L): zmod_13_a_sq_eq_five_b_sq_iff (169-case decide), safe_A_5_13_holds, safe_B_5_13_holds, safe_C_5_13_holds (QR infinite descents), safe_5_13_axis_vs_plane (composite). #print axioms = propext/Classical.choice/Quot.sound on all."
     ],
-    "progressSummary": "PROGRESS: 4 of 7 axis-vs-plane safe pairs discharged ((2,5), (3,5), (2,13), (5,7)) - all 0-axiom QR infinite descents. (5,7) was the first mixed-modulus case. Remaining: (5,13) (pre-audited, one new helper), (7,13), (11,13); then the deep full-rank Hasse-Minkowski half and the Theta(n^{2/3}) assembly. UNBLOCKED: host lake env lean suffices, no Docker needed.",
+    "progressSummary": "PROGRESS: 5 of 7 axis-vs-plane safe pairs discharged ((2,5), (3,5), (2,13), (5,7), (5,13)) - all 0-axiom QR infinite descents, host lake env lean verified (no Docker needed). (5,13) was the second mixed-modulus case: A/C mod 5 reusing zmod_5_a_sq_eq_three_b_sq_iff (13 = 3 mod 5), B mod 13 via the one new helper zmod_13_a_sq_eq_five_b_sq_iff. Remaining pairs both pre-audited in state.md: (7,13) uniform mod-13 (two new helpers), (11,13) mixed mod-11/mod-13 (two new helpers). Then the deep full-rank Hasse-Minkowski half and the Theta(n^{2/3}) assembly.",
     "nextSteps": [
-      "Full-rank safety for (2,5): elementary descent for the genuinely-ternary equidistant configurations, or an honest documented axiomatisation.",
-      "Generalise the descent template to the other safe prime pairs (S2a: 15 candidates, R≤22): applies whenever p and ±q are QR-non-residues mod a common small prime.",
-      "Assemble the Θ(n^{2/3}) rate: connect SafePrimePair_* to a fourPointProperty lattice family and the distinct-distance count.",
-      "Deferred (OPEN): the headline d≥3 distinct-distance 4-point-property rate question."
+      "(7,13) ACT: uniform mod-13 discharge — two new 169-case helpers zmod_13_a_sq_plus_7_b_sq_eq_zero_iff (eq A) and zmod_13_a_sq_eq_seven_b_sq_iff (eqs B/C), descent prime 13 throughout; shape of the (2,13) session. Pre-audited in state.md S11.",
+      "(11,13) ACT: mixed-modulus discharge — two new helpers zmod_11_a_sq_eq_two_b_sq_iff (eqs A/C mod 11, since 13 = 2 mod 11) and zmod_13_a_sq_eq_eleven_b_sq_iff (eq B mod 13). Pre-audited in state.md S11.",
+      "Full-rank safety for the discharged pairs: elementary descent for genuinely-ternary equidistant configurations, or an honest documented axiomatisation (blocked: ternary Hasse-Minkowski absent from Mathlib).",
+      "Assemble the Theta(n^{2/3}) rate: connect SafePrimePair_* to a fourPointProperty lattice family and the distinct-distance count."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session (S11 ACT) for `erdos-659-oq-01-oq-02` (axis-vs-plane safe prime pairs for the d ≥ 3 four-point-property lattice family). Discharges the fifth of the seven S2a safe pairs: **(5, 13)**, exactly per the pre-audit recorded at the S10 close.

## Progress
- `proofs/Proofs/Erdos659OQ01OQ02.lean` (877 → 1069 L): new S11 section with
  - `zmod_13_a_sq_eq_five_b_sq_iff` — the single new helper (5 is not a QR mod 13; 169-case `decide`)
  - `safe_A_5_13_holds`, `safe_B_5_13_holds`, `safe_C_5_13_holds` — QR infinite descents mirroring the (5,7) mixed-modulus template (A/C reduce mod 5 reusing the existing `zmod_5_a_sq_eq_three_b_sq_iff` since 13 ≡ 3 (mod 5); only B reduces mod 13)
  - `safe_5_13_axis_vs_plane : SafePrimePair_AxisVsPlane 5 13` — composite
- `research/problems/erdos-659-oq-01-oq-02/state.md`: S11 block + QR pre-audits for the two remaining pairs
- `src/data/research/problems/erdos-659-oq-01-oq-02.json`: phase ACT, status active, knowledge updated

## Verification
- Host `lake env lean` exit 0 (first try — every template sign/coefficient held)
- `#print axioms` = `[propext, Classical.choice, Quot.sound]` on all 4 new named declarations
- 0 sorries / 0 axioms delta

## Findings
- The S10 pre-audit was exactly right: one new helper sufficed.
- Pre-audited the last two pairs (QR tables in state.md): **(7,13)** is uniform mod-13 (mod 7 fails since −13 ≡ 1 is a QR; needs `zmod_13_a_sq_plus_7_b_sq_eq_zero_iff` + `zmod_13_a_sq_eq_seven_b_sq_iff`), **(11,13)** is mixed mod-11/mod-13 (needs `zmod_11_a_sq_eq_two_b_sq_iff` + `zmod_13_a_sq_eq_eleven_b_sq_iff`). Two new helpers each — both single-session sized.

## Status
**Outcome**: progress (scoreboard 5/7)
**Next Steps**: (7,13) then (11,13) per the state.md pre-audits; full-rank Hasse–Minkowski half and Θ(n^{2/3}) assembly remain blocked on absent Mathlib infrastructure.

🤖 Generated by researcher-2
