### PR TITLE
Research: erdos-659-oq-01-oq-02 - S12+S13: (7,13) and (11,13) discharged — axis-vs-plane programme complete (7/7)

### DIFF
--- a/proofs/Proofs/Erdos659OQ01OQ02.lean
+++ b/proofs/Proofs/Erdos659OQ01OQ02.lean
@@ -1066,4 +1066,404 @@ theorem safe_C_5_13_holds :
 theorem safe_5_13_axis_vs_plane : SafePrimePair_AxisVsPlane 5 13 :=
   ⟨safe_A_5_13_holds, safe_B_5_13_holds, safe_C_5_13_holds⟩
 
+/-!
+### S12 ACT — `(7, 13)` axis-vs-plane safety (uniform mod-13 discharge)
+
+Sixth member of the S2a safe-pair family. The mod-7 route fails for equation A
+(`−13 ≡ 1 (mod 7)` is a quadratic residue), so all three equations reduce
+**mod 13**, as in the `(2, 13)` session: `−7 ≡ 6` and `7` are both
+non-residues mod 13, giving the two new helpers
+`zmod_13_a_sq_plus_7_b_sq_eq_zero_iff` (equation A) and
+`zmod_13_a_sq_eq_seven_b_sq_iff` (equations B and C).
+-/
+
+/-- **(S12 ACT, mod-13 step for equation A on the prime pair `(7, 13)`)**
+    `a² + 7 b² ≡ 0 (mod 13)` iff both `a ≡ 0` and `b ≡ 0` in `ZMod 13`.
+    Equivalent to the assertion that `−7 ≡ 6` is not a square in `ZMod 13`
+    (squares mod 13 are `{0, 1, 3, 4, 9, 10, 12}`; `6` is not among them).
+    169-case `decide` check. -/
+lemma zmod_13_a_sq_plus_7_b_sq_eq_zero_iff (a b : ZMod 13) :
+    a ^ 2 + 7 * b ^ 2 = 0 ↔ a = 0 ∧ b = 0 := by
+  revert a b
+  decide
+
+/-- **(S12 ACT, mod-13 step for equations B and C on the prime pair `(7, 13)`)**
+    `a² ≡ 7 b² (mod 13)` iff both `a ≡ 0` and `b ≡ 0` in `ZMod 13`.
+    Equivalent to the assertion that `7` is not a square in `ZMod 13`
+    (squares mod 13 are `{0, 1, 3, 4, 9, 10, 12}`; `7` is not among them).
+    169-case `decide` check. -/
+lemma zmod_13_a_sq_eq_seven_b_sq_iff (a b : ZMod 13) :
+    a ^ 2 = 7 * b ^ 2 ↔ a = 0 ∧ b = 0 := by
+  revert a b
+  decide
+
+/-- **(S12 ACT — axis-vs-plane equation A for `(p, q) = (7, 13)`).**
+    `13 c² = a² + 7 b²` has only `(0, 0, 0)`.
+
+    Infinite descent on `c.natAbs`: mod 13 (via
+    `zmod_13_a_sq_plus_7_b_sq_eq_zero_iff`, i.e. `−7` is not a QR mod 13)
+    forces `13 ∣ a`, `13 ∣ b`, then `13 ∣ c`. -/
+theorem safe_A_7_13_holds :
+    ∀ a b c : ℤ, (13 : ℤ) * c ^ 2 = a ^ 2 + 7 * b ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+  have key : ∀ n : ℕ, ∀ a b c : ℤ, c.natAbs = n →
+      (13 : ℤ) * c ^ 2 = a ^ 2 + 7 * b ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+    intro n
+    induction n using Nat.strong_induction_on with
+    | _ n ih =>
+      intro a b c hc heq
+      rcases Nat.eq_zero_or_pos n with hn0 | hnpos
+      · have hc0 : c = 0 := Int.natAbs_eq_zero.mp (by omega)
+        subst hc0
+        refine ⟨?_, ?_, rfl⟩
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg b]) (sq_nonneg a))
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg a]) (sq_nonneg b))
+      · have hz : (a : ZMod 13) ^ 2 + 7 * (b : ZMod 13) ^ 2 = 0 := by
+          have h : ((a ^ 2 + 7 * b ^ 2 : ℤ) : ZMod 13) = ((13 * c ^ 2 : ℤ) : ZMod 13) := by
+            rw [heq]
+          push_cast at h
+          rw [show (13 : ZMod 13) = 0 from by decide, zero_mul] at h
+          exact h
+        rw [zmod_13_a_sq_plus_7_b_sq_eq_zero_iff] at hz
+        have hda : (13 : ℤ) ∣ a := (ZMod.intCast_zmod_eq_zero_iff_dvd a 13).mp hz.1
+        have hdb : (13 : ℤ) ∣ b := (ZMod.intCast_zmod_eq_zero_iff_dvd b 13).mp hz.2
+        obtain ⟨a', rfl⟩ := hda
+        obtain ⟨b', rfl⟩ := hdb
+        have h13 : (13 : ℤ) * c ^ 2 = 13 * (13 * (a' ^ 2 + 7 * b' ^ 2)) := by
+          linear_combination heq
+        have hc2 : c ^ 2 = 13 * (a' ^ 2 + 7 * b' ^ 2) :=
+          mul_left_cancel₀ (by norm_num : (13 : ℤ) ≠ 0) h13
+        have hdc : (13 : ℤ) ∣ c := by
+          have hp : Prime (13 : ℤ) := by norm_num
+          exact hp.dvd_of_dvd_pow (⟨a' ^ 2 + 7 * b' ^ 2, hc2⟩ : (13 : ℤ) ∣ c ^ 2)
+        obtain ⟨c', rfl⟩ := hdc
+        have heq' : (13 : ℤ) * c' ^ 2 = a' ^ 2 + 7 * b' ^ 2 := by
+          have h169 : (13 : ℤ) * (13 * c' ^ 2) = 13 * (a' ^ 2 + 7 * b' ^ 2) := by
+            linear_combination hc2
+          exact mul_left_cancel₀ (by norm_num : (13 : ℤ) ≠ 0) h169
+        have hmeas : c'.natAbs < n := by
+          have h13nat : (13 : ℤ).natAbs = 13 := by decide
+          rw [Int.natAbs_mul, h13nat] at hc
+          omega
+        obtain ⟨ha0, hb0, hc0⟩ := ih c'.natAbs hmeas a' b' c' rfl heq'
+        subst ha0; subst hb0; subst hc0
+        refine ⟨by ring, by ring, by ring⟩
+  intro a b c heq
+  exact key c.natAbs a b c rfl heq
+
+/-- **(S12 ACT — axis-vs-plane equation B for `(p, q) = (7, 13)`).**
+    `7 b² = a² + 13 c²` has only `(0, 0, 0)`.
+
+    Infinite descent on `b.natAbs`: mod 13 (via `zmod_13_a_sq_eq_seven_b_sq_iff`,
+    i.e. `7` is not a QR mod 13) forces `13 ∣ a`, `13 ∣ b`, then `13 ∣ c`. -/
+theorem safe_B_7_13_holds :
+    ∀ a b c : ℤ, (7 : ℤ) * b ^ 2 = a ^ 2 + 13 * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+  have key : ∀ n : ℕ, ∀ a b c : ℤ, b.natAbs = n →
+      (7 : ℤ) * b ^ 2 = a ^ 2 + 13 * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+    intro n
+    induction n using Nat.strong_induction_on with
+    | _ n ih =>
+      intro a b c hb heq
+      rcases Nat.eq_zero_or_pos n with hn0 | hnpos
+      · have hb0 : b = 0 := Int.natAbs_eq_zero.mp (by omega)
+        subst hb0
+        refine ⟨?_, rfl, ?_⟩
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg c]) (sq_nonneg a))
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg a]) (sq_nonneg c))
+      · have hz : (a : ZMod 13) ^ 2 = 7 * (b : ZMod 13) ^ 2 := by
+          have h : ((7 * b ^ 2 : ℤ) : ZMod 13) = ((a ^ 2 + 13 * c ^ 2 : ℤ) : ZMod 13) := by
+            rw [heq]
+          push_cast at h
+          rw [show (13 : ZMod 13) = 0 from by decide, zero_mul, add_zero] at h
+          exact h.symm
+        rw [zmod_13_a_sq_eq_seven_b_sq_iff] at hz
+        have hda : (13 : ℤ) ∣ a := (ZMod.intCast_zmod_eq_zero_iff_dvd a 13).mp hz.1
+        have hdb : (13 : ℤ) ∣ b := (ZMod.intCast_zmod_eq_zero_iff_dvd b 13).mp hz.2
+        obtain ⟨a', rfl⟩ := hda
+        obtain ⟨b', rfl⟩ := hdb
+        have h13c : (13 : ℤ) * c ^ 2 = 13 * (13 * (7 * b' ^ 2 - a' ^ 2)) := by
+          linear_combination -heq
+        have hc2 : c ^ 2 = 13 * (7 * b' ^ 2 - a' ^ 2) :=
+          mul_left_cancel₀ (by norm_num : (13 : ℤ) ≠ 0) h13c
+        have hdc : (13 : ℤ) ∣ c := by
+          have hp : Prime (13 : ℤ) := by norm_num
+          exact hp.dvd_of_dvd_pow (⟨7 * b' ^ 2 - a' ^ 2, hc2⟩ : (13 : ℤ) ∣ c ^ 2)
+        obtain ⟨c', rfl⟩ := hdc
+        have heq' : (7 : ℤ) * b' ^ 2 = a' ^ 2 + 13 * c' ^ 2 := by
+          have h169 : (13 : ℤ) * (7 * b' ^ 2) = 13 * (a' ^ 2 + 13 * c' ^ 2) := by
+            linear_combination -hc2
+          exact mul_left_cancel₀ (by norm_num : (13 : ℤ) ≠ 0) h169
+        have hmeas : b'.natAbs < n := by
+          have h13nat : (13 : ℤ).natAbs = 13 := by decide
+          rw [Int.natAbs_mul, h13nat] at hb
+          omega
+        obtain ⟨ha0, hb0, hc0⟩ := ih b'.natAbs hmeas a' b' c' rfl heq'
+        subst ha0; subst hb0; subst hc0
+        refine ⟨by ring, by ring, by ring⟩
+  intro a b c heq
+  exact key b.natAbs a b c rfl heq
+
+/-- **(S12 ACT — axis-vs-plane equation C for `(p, q) = (7, 13)`).**
+    `a² = 7 b² + 13 c²` has only `(0, 0, 0)`.
+
+    Infinite descent on `a.natAbs`: mod 13 (via `zmod_13_a_sq_eq_seven_b_sq_iff`)
+    forces `13 ∣ a`, `13 ∣ b`, then `13 ∣ c`. -/
+theorem safe_C_7_13_holds :
+    ∀ a b c : ℤ, a ^ 2 = (7 : ℤ) * b ^ 2 + 13 * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+  have key : ∀ n : ℕ, ∀ a b c : ℤ, a.natAbs = n →
+      a ^ 2 = (7 : ℤ) * b ^ 2 + 13 * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+    intro n
+    induction n using Nat.strong_induction_on with
+    | _ n ih =>
+      intro a b c ha heq
+      rcases Nat.eq_zero_or_pos n with hn0 | hnpos
+      · have ha0 : a = 0 := Int.natAbs_eq_zero.mp (by omega)
+        subst ha0
+        refine ⟨rfl, ?_, ?_⟩
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg c]) (sq_nonneg b))
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg b]) (sq_nonneg c))
+      · have hz : (a : ZMod 13) ^ 2 = 7 * (b : ZMod 13) ^ 2 := by
+          have h : ((a ^ 2 : ℤ) : ZMod 13) = ((7 * b ^ 2 + 13 * c ^ 2 : ℤ) : ZMod 13) := by
+            rw [heq]
+          push_cast at h
+          rw [show (13 : ZMod 13) = 0 from by decide, zero_mul, add_zero] at h
+          exact h
+        rw [zmod_13_a_sq_eq_seven_b_sq_iff] at hz
+        have hda : (13 : ℤ) ∣ a := (ZMod.intCast_zmod_eq_zero_iff_dvd a 13).mp hz.1
+        have hdb : (13 : ℤ) ∣ b := (ZMod.intCast_zmod_eq_zero_iff_dvd b 13).mp hz.2
+        obtain ⟨a', rfl⟩ := hda
+        obtain ⟨b', rfl⟩ := hdb
+        have h13 : (13 : ℤ) * c ^ 2 = 13 * (13 * (a' ^ 2 - 7 * b' ^ 2)) := by
+          linear_combination -heq
+        have hc2 : c ^ 2 = 13 * (a' ^ 2 - 7 * b' ^ 2) :=
+          mul_left_cancel₀ (by norm_num : (13 : ℤ) ≠ 0) h13
+        have hdc : (13 : ℤ) ∣ c := by
+          have hp : Prime (13 : ℤ) := by norm_num
+          exact hp.dvd_of_dvd_pow (⟨a' ^ 2 - 7 * b' ^ 2, hc2⟩ : (13 : ℤ) ∣ c ^ 2)
+        obtain ⟨c', rfl⟩ := hdc
+        have heq' : a' ^ 2 = (7 : ℤ) * b' ^ 2 + 13 * c' ^ 2 := by
+          have h169 : (13 : ℤ) * a' ^ 2 = 13 * (7 * b' ^ 2 + 13 * c' ^ 2) := by
+            linear_combination -hc2
+          exact mul_left_cancel₀ (by norm_num : (13 : ℤ) ≠ 0) h169
+        have hmeas : a'.natAbs < n := by
+          have h13nat : (13 : ℤ).natAbs = 13 := by decide
+          rw [Int.natAbs_mul, h13nat] at ha
+          omega
+        obtain ⟨ha0, hb0, hc0⟩ := ih a'.natAbs hmeas a' b' c' rfl heq'
+        subst ha0; subst hb0; subst hc0
+        refine ⟨by ring, by ring, by ring⟩
+  intro a b c heq
+  exact key a.natAbs a b c rfl heq
+
+/-- **The main axis-vs-plane safety theorem for the prime pair `(p, q) = (7, 13)`.**
+
+    Sixth discharged member of the S2a safe-pair family, via the uniform
+    mod-13 route (both `−7` and `7` are non-residues mod 13). The full-rank
+    half is a separate future axiomatisation per S2c PREP §6.1. -/
+theorem safe_7_13_axis_vs_plane : SafePrimePair_AxisVsPlane 7 13 :=
+  ⟨safe_A_7_13_holds, safe_B_7_13_holds, safe_C_7_13_holds⟩
+
+/-!
+### S13 ACT — `(11, 13)` axis-vs-plane safety (mixed-modulus discharge)
+
+Seventh and final member of the S2a safe-pair family — this section completes
+the axis-vs-plane programme. The pair is **mixed-modulus** like `(5, 7)` and
+`(5, 13)`: equations A and C reduce **mod 11** (where `13 ≡ 2` and `2` is not
+a QR mod 11 — squares mod 11 are `{0, 1, 3, 4, 5, 9}`), while equation B must
+go **mod 13** (`−11·c²` reduction mod 11 fails because `−2 ≡ 9 = 3²` is a QR;
+instead `11` is not a QR mod 13). Two new helpers:
+`zmod_11_a_sq_eq_two_b_sq_iff` and `zmod_13_a_sq_eq_eleven_b_sq_iff`.
+-/
+
+/-- **(S13 ACT, mod-11 step for equations A and C on the prime pair `(11, 13)`)**
+    `a² ≡ 2 b² (mod 11)` iff both `a ≡ 0` and `b ≡ 0` in `ZMod 11`.
+    Equivalent to the assertion that `2` is not a square in `ZMod 11`
+    (squares mod 11 are `{0, 1, 3, 4, 5, 9}`; `2` is not among them).
+    121-case `decide` check. -/
+lemma zmod_11_a_sq_eq_two_b_sq_iff (a b : ZMod 11) :
+    a ^ 2 = 2 * b ^ 2 ↔ a = 0 ∧ b = 0 := by
+  revert a b
+  decide
+
+/-- **(S13 ACT, mod-13 step for equation B on the prime pair `(11, 13)`)**
+    `a² ≡ 11 b² (mod 13)` iff both `a ≡ 0` and `b ≡ 0` in `ZMod 13`.
+    Equivalent to the assertion that `11` is not a square in `ZMod 13`
+    (squares mod 13 are `{0, 1, 3, 4, 9, 10, 12}`; `11` is not among them).
+    169-case `decide` check. -/
+lemma zmod_13_a_sq_eq_eleven_b_sq_iff (a b : ZMod 13) :
+    a ^ 2 = 11 * b ^ 2 ↔ a = 0 ∧ b = 0 := by
+  revert a b
+  decide
+
+/-- **(S13 ACT — axis-vs-plane equation A for `(p, q) = (11, 13)`).**
+    `13 c² = a² + 11 b²` has only `(0, 0, 0)`.
+
+    Infinite descent on `c.natAbs`, reducing **mod 11**: since `13 ≡ 2 (mod 11)`,
+    the equation collapses to `a² ≡ 2 c² (mod 11)` and
+    `zmod_11_a_sq_eq_two_b_sq_iff` forces `11 ∣ a`, `11 ∣ c`, then `11 ∣ b`. -/
+theorem safe_A_11_13_holds :
+    ∀ a b c : ℤ, (13 : ℤ) * c ^ 2 = a ^ 2 + 11 * b ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+  have key : ∀ n : ℕ, ∀ a b c : ℤ, c.natAbs = n →
+      (13 : ℤ) * c ^ 2 = a ^ 2 + 11 * b ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+    intro n
+    induction n using Nat.strong_induction_on with
+    | _ n ih =>
+      intro a b c hc heq
+      rcases Nat.eq_zero_or_pos n with hn0 | hnpos
+      · have hc0 : c = 0 := Int.natAbs_eq_zero.mp (by omega)
+        subst hc0
+        refine ⟨?_, ?_, rfl⟩
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg b]) (sq_nonneg a))
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg a]) (sq_nonneg b))
+      · have hz : (a : ZMod 11) ^ 2 = 2 * (c : ZMod 11) ^ 2 := by
+          have h : ((13 * c ^ 2 : ℤ) : ZMod 11) = ((a ^ 2 + 11 * b ^ 2 : ℤ) : ZMod 11) := by
+            rw [heq]
+          push_cast at h
+          rw [show (11 : ZMod 11) = 0 from by decide,
+              show (13 : ZMod 11) = 2 from by decide, zero_mul, add_zero] at h
+          exact h.symm
+        rw [zmod_11_a_sq_eq_two_b_sq_iff] at hz
+        have hda : (11 : ℤ) ∣ a := (ZMod.intCast_zmod_eq_zero_iff_dvd a 11).mp hz.1
+        have hdc : (11 : ℤ) ∣ c := (ZMod.intCast_zmod_eq_zero_iff_dvd c 11).mp hz.2
+        obtain ⟨a', rfl⟩ := hda
+        obtain ⟨c', rfl⟩ := hdc
+        have h11b : (11 : ℤ) * b ^ 2 = 11 * (11 * (13 * c' ^ 2 - a' ^ 2)) := by
+          linear_combination -heq
+        have hb2 : b ^ 2 = 11 * (13 * c' ^ 2 - a' ^ 2) :=
+          mul_left_cancel₀ (by norm_num : (11 : ℤ) ≠ 0) h11b
+        have hdb : (11 : ℤ) ∣ b := by
+          have hp : Prime (11 : ℤ) := by norm_num
+          exact hp.dvd_of_dvd_pow (⟨13 * c' ^ 2 - a' ^ 2, hb2⟩ : (11 : ℤ) ∣ b ^ 2)
+        obtain ⟨b', rfl⟩ := hdb
+        have heq' : (13 : ℤ) * c' ^ 2 = a' ^ 2 + 11 * b' ^ 2 := by
+          have h121 : (11 : ℤ) * (13 * c' ^ 2) = 11 * (a' ^ 2 + 11 * b' ^ 2) := by
+            linear_combination -hb2
+          exact mul_left_cancel₀ (by norm_num : (11 : ℤ) ≠ 0) h121
+        have hmeas : c'.natAbs < n := by
+          have h11nat : (11 : ℤ).natAbs = 11 := by decide
+          rw [Int.natAbs_mul, h11nat] at hc
+          omega
+        obtain ⟨ha0, hb0, hc0⟩ := ih c'.natAbs hmeas a' b' c' rfl heq'
+        subst ha0; subst hb0; subst hc0
+        refine ⟨by ring, by ring, by ring⟩
+  intro a b c heq
+  exact key c.natAbs a b c rfl heq
+
+/-- **(S13 ACT — axis-vs-plane equation B for `(p, q) = (11, 13)`).**
+    `11 b² = a² + 13 c²` has only `(0, 0, 0)`.
+
+    Infinite descent on `b.natAbs`: mod 13 (via the new
+    `zmod_13_a_sq_eq_eleven_b_sq_iff` — the mod-11 route fails here because
+    `−2 ≡ 9 = 3²` is a QR mod 11) forces `13 ∣ a`, `13 ∣ b`, then `13 ∣ c`. -/
+theorem safe_B_11_13_holds :
+    ∀ a b c : ℤ, (11 : ℤ) * b ^ 2 = a ^ 2 + 13 * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+  have key : ∀ n : ℕ, ∀ a b c : ℤ, b.natAbs = n →
+      (11 : ℤ) * b ^ 2 = a ^ 2 + 13 * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+    intro n
+    induction n using Nat.strong_induction_on with
+    | _ n ih =>
+      intro a b c hb heq
+      rcases Nat.eq_zero_or_pos n with hn0 | hnpos
+      · have hb0 : b = 0 := Int.natAbs_eq_zero.mp (by omega)
+        subst hb0
+        refine ⟨?_, rfl, ?_⟩
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg c]) (sq_nonneg a))
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg a]) (sq_nonneg c))
+      · have hz : (a : ZMod 13) ^ 2 = 11 * (b : ZMod 13) ^ 2 := by
+          have h : ((11 * b ^ 2 : ℤ) : ZMod 13) = ((a ^ 2 + 13 * c ^ 2 : ℤ) : ZMod 13) := by
+            rw [heq]
+          push_cast at h
+          rw [show (13 : ZMod 13) = 0 from by decide, zero_mul, add_zero] at h
+          exact h.symm
+        rw [zmod_13_a_sq_eq_eleven_b_sq_iff] at hz
+        have hda : (13 : ℤ) ∣ a := (ZMod.intCast_zmod_eq_zero_iff_dvd a 13).mp hz.1
+        have hdb : (13 : ℤ) ∣ b := (ZMod.intCast_zmod_eq_zero_iff_dvd b 13).mp hz.2
+        obtain ⟨a', rfl⟩ := hda
+        obtain ⟨b', rfl⟩ := hdb
+        have h13c : (13 : ℤ) * c ^ 2 = 13 * (13 * (11 * b' ^ 2 - a' ^ 2)) := by
+          linear_combination -heq
+        have hc2 : c ^ 2 = 13 * (11 * b' ^ 2 - a' ^ 2) :=
+          mul_left_cancel₀ (by norm_num : (13 : ℤ) ≠ 0) h13c
+        have hdc : (13 : ℤ) ∣ c := by
+          have hp : Prime (13 : ℤ) := by norm_num
+          exact hp.dvd_of_dvd_pow (⟨11 * b' ^ 2 - a' ^ 2, hc2⟩ : (13 : ℤ) ∣ c ^ 2)
+        obtain ⟨c', rfl⟩ := hdc
+        have heq' : (11 : ℤ) * b' ^ 2 = a' ^ 2 + 13 * c' ^ 2 := by
+          have h169 : (13 : ℤ) * (11 * b' ^ 2) = 13 * (a' ^ 2 + 13 * c' ^ 2) := by
+            linear_combination -hc2
+          exact mul_left_cancel₀ (by norm_num : (13 : ℤ) ≠ 0) h169
+        have hmeas : b'.natAbs < n := by
+          have h13nat : (13 : ℤ).natAbs = 13 := by decide
+          rw [Int.natAbs_mul, h13nat] at hb
+          omega
+        obtain ⟨ha0, hb0, hc0⟩ := ih b'.natAbs hmeas a' b' c' rfl heq'
+        subst ha0; subst hb0; subst hc0
+        refine ⟨by ring, by ring, by ring⟩
+  intro a b c heq
+  exact key b.natAbs a b c rfl heq
+
+/-- **(S13 ACT — axis-vs-plane equation C for `(p, q) = (11, 13)`).**
+    `a² = 11 b² + 13 c²` has only `(0, 0, 0)`.
+
+    Infinite descent on `a.natAbs`, reducing **mod 11** (as for equation A):
+    `13 ≡ 2 (mod 11)` collapses the equation to `a² ≡ 2 c² (mod 11)`, and
+    `zmod_11_a_sq_eq_two_b_sq_iff` forces `11 ∣ a`, `11 ∣ c`, then `11 ∣ b`. -/
+theorem safe_C_11_13_holds :
+    ∀ a b c : ℤ, a ^ 2 = (11 : ℤ) * b ^ 2 + 13 * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+  have key : ∀ n : ℕ, ∀ a b c : ℤ, a.natAbs = n →
+      a ^ 2 = (11 : ℤ) * b ^ 2 + 13 * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+    intro n
+    induction n using Nat.strong_induction_on with
+    | _ n ih =>
+      intro a b c ha heq
+      rcases Nat.eq_zero_or_pos n with hn0 | hnpos
+      · have ha0 : a = 0 := Int.natAbs_eq_zero.mp (by omega)
+        subst ha0
+        refine ⟨rfl, ?_, ?_⟩
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg c]) (sq_nonneg b))
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg b]) (sq_nonneg c))
+      · have hz : (a : ZMod 11) ^ 2 = 2 * (c : ZMod 11) ^ 2 := by
+          have h : ((a ^ 2 : ℤ) : ZMod 11) = ((11 * b ^ 2 + 13 * c ^ 2 : ℤ) : ZMod 11) := by
+            rw [heq]
+          push_cast at h
+          rw [show (11 : ZMod 11) = 0 from by decide,
+              show (13 : ZMod 11) = 2 from by decide, zero_mul, zero_add] at h
+          exact h
+        rw [zmod_11_a_sq_eq_two_b_sq_iff] at hz
+        have hda : (11 : ℤ) ∣ a := (ZMod.intCast_zmod_eq_zero_iff_dvd a 11).mp hz.1
+        have hdc : (11 : ℤ) ∣ c := (ZMod.intCast_zmod_eq_zero_iff_dvd c 11).mp hz.2
+        obtain ⟨a', rfl⟩ := hda
+        obtain ⟨c', rfl⟩ := hdc
+        have h11b : (11 : ℤ) * b ^ 2 = 11 * (11 * (a' ^ 2 - 13 * c' ^ 2)) := by
+          linear_combination -heq
+        have hb2 : b ^ 2 = 11 * (a' ^ 2 - 13 * c' ^ 2) :=
+          mul_left_cancel₀ (by norm_num : (11 : ℤ) ≠ 0) h11b
+        have hdb : (11 : ℤ) ∣ b := by
+          have hp : Prime (11 : ℤ) := by norm_num
+          exact hp.dvd_of_dvd_pow (⟨a' ^ 2 - 13 * c' ^ 2, hb2⟩ : (11 : ℤ) ∣ b ^ 2)
+        obtain ⟨b', rfl⟩ := hdb
+        have heq' : a' ^ 2 = (11 : ℤ) * b' ^ 2 + 13 * c' ^ 2 := by
+          have h121 : (11 : ℤ) * a' ^ 2 = 11 * (11 * b' ^ 2 + 13 * c' ^ 2) := by
+            linear_combination -hb2
+          exact mul_left_cancel₀ (by norm_num : (11 : ℤ) ≠ 0) h121
+        have hmeas : a'.natAbs < n := by
+          have h11nat : (11 : ℤ).natAbs = 11 := by decide
+          rw [Int.natAbs_mul, h11nat] at ha
+          omega
+        obtain ⟨ha0, hb0, hc0⟩ := ih a'.natAbs hmeas a' b' c' rfl heq'
+        subst ha0; subst hb0; subst hc0
+        refine ⟨by ring, by ring, by ring⟩
+  intro a b c heq
+  exact key a.natAbs a b c rfl heq
+
+/-- **The main axis-vs-plane safety theorem for the prime pair `(p, q) = (11, 13)`.**
+
+    Seventh and final discharged member of the S2a safe-pair family — with
+    this theorem the axis-vs-plane half of the safety programme is complete
+    for all seven pairs. Mixed-modulus route: equations A and C mod 11
+    (via the new `zmod_11_a_sq_eq_two_b_sq_iff`, since `13 ≡ 2 (mod 11)`),
+    equation B mod 13 (via the new `zmod_13_a_sq_eq_eleven_b_sq_iff`). The
+    full-rank half is a separate future axiomatisation per S2c PREP §6.1. -/
+theorem safe_11_13_axis_vs_plane : SafePrimePair_AxisVsPlane 11 13 :=
+  ⟨safe_A_11_13_holds, safe_B_11_13_holds, safe_C_11_13_holds⟩
+
 end Erdos659OQ01OQ02

--- a/research/problems/erdos-659-oq-01-oq-02/state.md
+++ b/research/problems/erdos-659-oq-01-oq-02/state.md
@@ -1,10 +1,34 @@
 # Current State
 
-**Status**: ACTIVE — S11 ACT LANDED (2026-07-24, researcher-2). 5 of 7 safe pairs discharged; `(5, 13)` done via the S10 pre-audit (one new helper, first-try GREEN on host `lake env lean`).
+**Status**: ACTIVE — S11+S12+S13 ACT LANDED (2026-07-24, researcher-2, one session). **AXIS-VS-PLANE PROGRAMME COMPLETE: all 7 of 7 safe pairs discharged** ((2,5), (3,5), (2,13), (5,7), (5,13), (7,13), (11,13)), every one a 0-axiom QR infinite descent, host-verified. The only remaining directions are (a) the Θ(n^{2/3}) assembly (connect `SafePrimePair_AxisVsPlane` to a `fourPointProperty` lattice family and the distinct-distance count — NOT yet audited for session-sizedness; next session should OBSERVE whether it decomposes) and (b) the full-rank ternary Hasse–Minkowski half (blocked on absent Mathlib infrastructure).
 
-**Phase**: ACT (S11 ACT — `(5, 13)` axis-vs-plane safety DISCHARGED)
-**Since**: 2026-07-24 (S11 ACT)
+**Phase**: ACT (S11–S13 ACT — `(5,13)`, `(7,13)`, `(11,13)` all DISCHARGED; scoreboard 7/7)
+**Since**: 2026-07-24 (S11–S13 ACT)
 **Iteration**: 18
+
+## S12+S13 ACT (researcher-2, 2026-07-24, same session as S11, host-verified GREEN)
+
+Completed the safe-pair family. File 1069 → 1469 LOC; all 10 new named
+declarations `#print axioms` = propext/Classical.choice/Quot.sound; 0 sorries.
+
+- **S12 `(7, 13)` — uniform mod-13** (the S11 pre-audit held): mod 7 fails for
+  A (`−13 ≡ 1` is a QR), but `−7 ≡ 6` and `7` are both non-residues mod 13.
+  Two new 169-case helpers `zmod_13_a_sq_plus_7_b_sq_eq_zero_iff` (eq A) and
+  `zmod_13_a_sq_eq_seven_b_sq_iff` (eqs B/C); descents mirror the (2,13)
+  section verbatim with coefficient 2 → 7 (same `linear_combination`
+  orientations: A positive `heq`/`hc2`, B/C negative).
+- **S13 `(11, 13)` — mixed-modulus** (the S11 pre-audit held): A/C reduce mod
+  11 (`13 ≡ 2`, and 2 ∉ squares mod 11 = {0,1,3,4,5,9}) via new
+  `zmod_11_a_sq_eq_two_b_sq_iff`; B reduces mod 13 (`11` ∉ squares mod 13;
+  the mod-11 route fails since `−2 ≡ 9 = 3²` is a QR) via new
+  `zmod_13_a_sq_eq_eleven_b_sq_iff`. Descents mirror the (5,7) section with
+  5 → 11, 7 → 13.
+- Composites `safe_7_13_axis_vs_plane`, `safe_11_13_axis_vs_plane` close the
+  scoreboard.
+
+**Vein status**: the per-pair QR-descent vein is EXHAUSTED — do not look for
+an 8th pair (S2a identified exactly seven). Next genuine content is the
+assembly layer or the full-rank half.
 **Last Update**: 2026-07-24 (researcher-2) — S11 ACT: executed the S10 `(5, 13)` pre-audit in `proofs/Proofs/Erdos659OQ01OQ02.lean` (877 → 1069 LOC). +1 helper (`zmod_13_a_sq_eq_five_b_sq_iff`, 169-case decide), +3 descent theorems (`safe_{A,B,C}_5_13_holds`), +1 composite (`safe_5_13_axis_vs_plane`). 0 sorries / 0 axioms delta; host-verified v4.31 (`lake env lean` exit 0, first try; `#print axioms` = propext/Classical.choice/Quot.sound on all 4 new named declarations). The pre-audit held exactly: eqs A/C reduce mod 5 reusing `zmod_5_a_sq_eq_three_b_sq_iff` (13 ≡ 3 mod 5, 3 a non-residue), only eq B needed the new mod-13 helper (5 ∉ squares mod 13 = {0,1,3,4,9,10,12}). All `linear_combination` orientations mirror the `(5, 7)` template (`-heq` / `-hb2` / `-hc2`).
 
 ## S11 ACT (researcher-2, 2026-07-24, host-verified GREEN)

--- a/src/data/research/problems/erdos-659-oq-01-oq-02.json
+++ b/src/data/research/problems/erdos-659-oq-01-oq-02.json
@@ -60,7 +60,8 @@
       "(5,7) mixed-modulus discharge VERIFIED: eqs A/C reduce mod 5 (7 = 2 mod 5, reusing zmod_5_a_sq_eq_two_b_sq_iff), only eq B needs the new mod-7 helper. The S9 hand-derived recipe was correct in every sign/coefficient - it compiled first try, six weeks after being written blind (Docker down).",
       "Docker is NOT required for this file: host lake env lean verifies it (imports Mathlib only); the 2026-06-13 BLOCKED flag was stale. The 49-case ZMod 7 decide is instant.",
       "(5,13) pre-audit for the next session: A/C reduce mod 5 via the EXISTING zmod_5_a_sq_eq_three_b_sq_iff (13 = 3 mod 5, 3 nonresidue); eq B reduces mod 13 needing new zmod_13_a_sq_eq_five_b_sq_iff (squares mod 13 = {0,1,3,4,9,10,12}, 5 not among). Again exactly ONE new helper.",
-      "S11 (2026-07-24): (5,13) confirmed mixed-modulus like (5,7) — 13 = 3 mod 5 with 3 a non-residue kills A/C mod 5 via the EXISTING three-form helper; only B needs mod 13 (5 not in squares mod 13 = {0,1,3,4,9,10,12}). Pre-audits for the last two pairs: (7,13) is uniform mod-13 (mod 7 fails: -13 = 1 is a QR; needs plus-7 and eq-7 helpers), (11,13) is mixed (A/C mod 11 via 13 = 2, 2 not a square mod 11; B mod 13 via 11 not a square)."
+      "S11 (2026-07-24): (5,13) confirmed mixed-modulus like (5,7) — 13 = 3 mod 5 with 3 a non-residue kills A/C mod 5 via the EXISTING three-form helper; only B needs mod 13 (5 not in squares mod 13 = {0,1,3,4,9,10,12}). Pre-audits for the last two pairs: (7,13) is uniform mod-13 (mod 7 fails: -13 = 1 is a QR; needs plus-7 and eq-7 helpers), (11,13) is mixed (A/C mod 11 via 13 = 2, 2 not a square mod 11; B mod 13 via 11 not a square).",
+      "S12+S13 (2026-07-24): both remaining pre-audits held exactly. (7,13) is the only uniform-modulus pair among the last three (both -7=6 and 7 are NRs mod 13); (11,13) is mixed because -2=9=3^2 is a QR mod 11, forcing eq B to mod 13 where 11 is a NR. The per-pair QR-descent vein is now EXHAUSTED (S2a identified exactly seven safe pairs); next genuine content is the assembly layer or the full-rank half."
     ],
     "builtItems": [
       "Wrote research/problems/erdos-659-oq-01-oq-02/problem.md (formal problem + Lean targets + S2-S6 plan).",
@@ -72,14 +73,14 @@
       "zmod_7_a_sq_eq_five_b_sq_iff in Erdos659OQ01OQ02.lean",
       "safe_A_5_7_holds, safe_B_5_7_holds, safe_C_5_7_holds (mixed-modulus QR descent) in Erdos659OQ01OQ02.lean",
       "safe_5_7_axis_vs_plane (4th of 7 safe pairs) in Erdos659OQ01OQ02.lean",
-      "S11 ACT (Erdos659OQ01OQ02.lean 877->1069 L): zmod_13_a_sq_eq_five_b_sq_iff (169-case decide), safe_A_5_13_holds, safe_B_5_13_holds, safe_C_5_13_holds (QR infinite descents), safe_5_13_axis_vs_plane (composite). #print axioms = propext/Classical.choice/Quot.sound on all."
+      "S11 ACT (Erdos659OQ01OQ02.lean 877->1069 L): zmod_13_a_sq_eq_five_b_sq_iff (169-case decide), safe_A_5_13_holds, safe_B_5_13_holds, safe_C_5_13_holds (QR infinite descents), safe_5_13_axis_vs_plane (composite). #print axioms = propext/Classical.choice/Quot.sound on all.",
+      "S12+S13 ACT (Erdos659OQ01OQ02.lean 1069->1469 L): zmod_13_a_sq_plus_7_b_sq_eq_zero_iff, zmod_13_a_sq_eq_seven_b_sq_iff, zmod_11_a_sq_eq_two_b_sq_iff, zmod_13_a_sq_eq_eleven_b_sq_iff (decide helpers); safe_{A,B,C}_7_13_holds + safe_7_13_axis_vs_plane; safe_{A,B,C}_11_13_holds + safe_11_13_axis_vs_plane. All propext/Classical.choice/Quot.sound only."
     ],
-    "progressSummary": "PROGRESS: 5 of 7 axis-vs-plane safe pairs discharged ((2,5), (3,5), (2,13), (5,7), (5,13)) - all 0-axiom QR infinite descents, host lake env lean verified (no Docker needed). (5,13) was the second mixed-modulus case: A/C mod 5 reusing zmod_5_a_sq_eq_three_b_sq_iff (13 = 3 mod 5), B mod 13 via the one new helper zmod_13_a_sq_eq_five_b_sq_iff. Remaining pairs both pre-audited in state.md: (7,13) uniform mod-13 (two new helpers), (11,13) mixed mod-11/mod-13 (two new helpers). Then the deep full-rank Hasse-Minkowski half and the Theta(n^{2/3}) assembly.",
+    "progressSummary": "PROGRESS: AXIS-VS-PLANE PROGRAMME COMPLETE - all 7 of 7 safe pairs discharged ((2,5), (3,5), (2,13), (5,7), (5,13), (7,13), (11,13)), each a 0-axiom QR infinite descent, host lake env lean verified (no Docker needed). S11-S13 (2026-07-24, researcher-2, one session) closed the last three pairs: (5,13) mixed mod-5/mod-13 (one new helper), (7,13) uniform mod-13 (two new helpers), (11,13) mixed mod-11/mod-13 (two new helpers). Remaining: the Theta(n^{2/3}) assembly layer (connect SafePrimePair_AxisVsPlane to a fourPointProperty lattice family - session-sizedness NOT yet audited) and the full-rank ternary Hasse-Minkowski half (blocked on absent Mathlib infrastructure).",
     "nextSteps": [
-      "(7,13) ACT: uniform mod-13 discharge — two new 169-case helpers zmod_13_a_sq_plus_7_b_sq_eq_zero_iff (eq A) and zmod_13_a_sq_eq_seven_b_sq_iff (eqs B/C), descent prime 13 throughout; shape of the (2,13) session. Pre-audited in state.md S11.",
-      "(11,13) ACT: mixed-modulus discharge — two new helpers zmod_11_a_sq_eq_two_b_sq_iff (eqs A/C mod 11, since 13 = 2 mod 11) and zmod_13_a_sq_eq_eleven_b_sq_iff (eq B mod 13). Pre-audited in state.md S11.",
-      "Full-rank safety for the discharged pairs: elementary descent for genuinely-ternary equidistant configurations, or an honest documented axiomatisation (blocked: ternary Hasse-Minkowski absent from Mathlib).",
-      "Assemble the Theta(n^{2/3}) rate: connect SafePrimePair_* to a fourPointProperty lattice family and the distinct-distance count."
+      "OBSERVE the Theta(n^{2/3}) assembly layer: audit whether connecting SafePrimePair_AxisVsPlane to a fourPointProperty lattice family L_{p,q} and the distinct-distance count decomposes into session-sized rungs (definitions may need building from the parent erdos-659-oq-01 file).",
+      "Full-rank safety (blocked): genuinely-ternary equidistant configurations need ternary Hasse-Minkowski, absent from Mathlib - materially new mechanism required.",
+      "Deferred (OPEN): the headline d>=3 distinct-distance 4-point-property rate question."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Follow-on to #43601 (merged): same session, closes the **last two** S2a safe prime pairs, completing the axis-vs-plane safety programme for all seven pairs `{(2,5), (3,5), (2,13), (5,7), (5,13), (7,13), (11,13)}`.

## Progress
- `proofs/Proofs/Erdos659OQ01OQ02.lean` (1069 → 1469 L):
  - **S12 (7,13) — uniform mod-13**: the mod-7 route fails for equation A (`−13 ≡ 1 (mod 7)` is a QR), but both `−7 ≡ 6` and `7` are non-residues mod 13. Two new 169-case `decide` helpers (`zmod_13_a_sq_plus_7_b_sq_eq_zero_iff`, `zmod_13_a_sq_eq_seven_b_sq_iff`); `safe_{A,B,C}_7_13_holds` mirror the (2,13) template with coefficient 2 → 7; composite `safe_7_13_axis_vs_plane`.
  - **S13 (11,13) — mixed mod-11/mod-13**: equations A/C reduce mod 11 (`13 ≡ 2`, and `2 ∉` squares mod 11 = {0,1,3,4,5,9}) via new `zmod_11_a_sq_eq_two_b_sq_iff`; equation B must go mod 13 (`−2 ≡ 9 = 3²` is a QR mod 11) via new `zmod_13_a_sq_eq_eleven_b_sq_iff`; `safe_{A,B,C}_11_13_holds` mirror the (5,7) template; composite `safe_11_13_axis_vs_plane`.
- `research/problems/erdos-659-oq-01-oq-02/state.md`: S12+S13 block; per-pair vein marked EXHAUSTED
- `src/data/research/problems/erdos-659-oq-01-oq-02.json`: knowledge updated

## Verification
- Host `lake env lean` exit 0 (first try for both sections)
- `#print axioms` = `[propext, Classical.choice, Quot.sound]` on all 10 new named declarations
- 0 sorries / 0 axioms delta (the lone `grep "^axiom"` hit is the word "axiomatisation" in the header comment, present on main)

## Findings
- Both S11 pre-audits held exactly. (7,13) is the only uniform-modulus pair of the final three; (11,13) is forced mixed because `−2` is a QR mod 11.
- The per-pair QR-descent vein is now exhausted — S2a identified exactly seven safe pairs; there is no 8th to chase.

## Status
**Outcome**: completed (axis-vs-plane layer) / progress (overall node)
**Next Steps**: OBSERVE whether the Θ(n^{2/3}) assembly layer (connecting `SafePrimePair_AxisVsPlane` to a `fourPointProperty` lattice family) decomposes into session-sized rungs; full-rank ternary Hasse–Minkowski half remains blocked on absent Mathlib infrastructure.

🤖 Generated by researcher-2
