### PR TITLE
Research: shapley-folkman-oq-01 - S3-A: Lyapunov convexity in dimension one (Sierpinski IVT, 0 axioms)

### DIFF
--- a/proofs/Proofs/ShapleyFolkmanOQ01Lyapunov.lean
+++ b/proofs/Proofs/ShapleyFolkmanOQ01Lyapunov.lean
@@ -1,0 +1,246 @@
+/-
+  Shapley–Folkman OQ-01 — S3-A: Lyapunov convexity in dimension one
+  (Sierpiński's intermediate-value theorem for atomless measures on ℝ).
+
+  Companion file to `proofs/Proofs/ShapleyFolkmanOQ01.lean` (the completed
+  negative answer) and `proofs/Proofs/ShapleyFolkman.lean` (parent, verified).
+
+  Context. OQ-01 asked whether the `[FiniteDimensional ℝ E]` hypothesis of
+  `shapley_folkman` can be dropped. The answer is NO (machine-verified in
+  `ShapleyFolkmanOQ01.lean`): the excess-index bound `Module.finrank ℝ E` is
+  attained with equality for every `N` and is unbounded in `ℓ²`. The *correct*
+  infinite-dimensional replacement is the Aumann (1965) / Lyapunov (1940)
+  circle of ideas: integration over an atomless continuum convexifies EXACTLY
+  (zero excess), instead of "up to a dimension-bounded number of exceptional
+  summands". Formalizing that positive analog is the S3 programme, previously
+  blocked on "Lyapunov's convexity theorem is not in Mathlib".
+
+  This file is the first rung (S3-A): **Lyapunov's convexity theorem in
+  dimension one**. For an atomless measure `μ` on ℝ and a measurable set `s`
+  of finite measure, the set of values `μ t` over measurable `t ⊆ s` is
+  EXACTLY the interval `[0, μ s]` — convex and compact. The engine is
+  Sierpiński's (1922) intermediate-value theorem for atomless measures,
+  genuinely absent from Mathlib (whose `NoAtoms` is the weak singleton-null
+  notion, with an in-file TODO about the strong splitting notion; on ℝ the
+  weak notion suffices, because atoms of a Borel-type measure on ℝ would be
+  point masses, and `NoAtoms` makes the cumulative function
+  `t ↦ μ (s ∩ Iic t)` genuinely continuous).
+
+  Contrast with the parent theorem: with finitely many summands, the
+  convexity defect of a Minkowski sum is bounded by `dim E`, and that bound
+  is achieved (`tight_excess_count` in `ShapleyFolkmanOQ01.lean`). Over an
+  atomless continuum the defect vanishes: the value range is already convex,
+  with NO excess. This is the `d = 1` case of Lyapunov's range theorem; the
+  `ℝᵈ` case (S3-B) is the next rung.
+
+  Everything in this file is sorry-free and axiom-free.
+-/
+
+import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
+import Mathlib.Topology.Order.IntermediateValue
+import Mathlib.Analysis.Convex.Basic
+
+namespace ShapleyFolkman.Lyapunov
+
+open MeasureTheory Set Filter Topology
+open scoped ENNReal
+
+variable {μ : Measure ℝ} {s : Set ℝ}
+
+/-- The cumulative function `t ↦ μ (s ∩ Iic t)` of a measure is monotone. -/
+lemma monotone_measure_inter_Iic (μ : Measure ℝ) (s : Set ℝ) :
+    Monotone fun t => μ (s ∩ Iic t) := fun _ _ hab =>
+  measure_mono (inter_subset_inter_right _ (Iic_subset_Iic.2 hab))
+
+/-- **Continuity of the cumulative function of an atomless measure.**
+
+    For `μ` atomless (`NoAtoms`) and `s` measurable of finite measure, the
+    monotone function `F t = μ (s ∩ Iic t)` is continuous:
+
+    * right-continuity is continuity from above of `μ` along
+      `s ∩ Iic (x + 1/(n+1)) ↓ s ∩ Iic x` (needs finiteness);
+    * left-continuity is continuity from below along
+      `s ∩ Iic (x - 1/(n+1)) ↑ s ∩ Iio x` together with
+      `μ (s ∩ Iio x) = μ (s ∩ Iic x)`, which is exactly atomlessness
+      (`Iio_ae_eq_Iic`).
+
+    This is the analytic heart of the one-dimensional Lyapunov theorem. -/
+lemma continuous_measure_inter_Iic [NoAtoms μ] (hs : MeasurableSet s) (hμs : μ s ≠ ∞) :
+    Continuous fun t => μ (s ∩ Iic t) := by
+  rw [continuous_iff_continuousAt]
+  intro x
+  refine tendsto_order.2 ⟨fun c hc => ?_, fun c hc => ?_⟩
+  · -- values just below `F x` are exceeded near `x` (left-continuity side)
+    have hio : μ (s ∩ Iio x) = μ (s ∩ Iic x) :=
+      measure_congr ((ae_eq_refl _).inter Iio_ae_eq_Iic)
+    have hU : (⋃ n : ℕ, s ∩ Iic (x - 1 / ((n : ℝ) + 1))) = s ∩ Iio x := by
+      rw [← inter_iUnion]
+      congr 1
+      ext y
+      simp only [mem_iUnion, mem_Iic, mem_Iio]
+      constructor
+      · rintro ⟨n, hn⟩
+        have hpos : (0 : ℝ) < 1 / ((n : ℝ) + 1) := by positivity
+        linarith
+      · intro hy
+        obtain ⟨n, hn⟩ := exists_nat_one_div_lt (sub_pos.2 hy)
+        exact ⟨n, by linarith⟩
+    have hmono : Monotone fun n : ℕ => s ∩ Iic (x - 1 / ((n : ℝ) + 1)) := by
+      intro n m hnm
+      refine inter_subset_inter_right _ (Iic_subset_Iic.2 ?_)
+      have h1 : ((n : ℝ) + 1) ≤ (m : ℝ) + 1 := by exact_mod_cast Nat.succ_le_succ hnm
+      have h2 : 1 / ((m : ℝ) + 1) ≤ 1 / ((n : ℝ) + 1) :=
+        one_div_le_one_div_of_le (by positivity) h1
+      linarith
+    have htendsto := tendsto_measure_iUnion_atTop (μ := μ) hmono
+    rw [hU] at htendsto
+    have hc' : c < μ (s ∩ Iio x) := by rw [hio]; exact hc
+    obtain ⟨n, hn⟩ := (htendsto.eventually_const_lt hc').exists
+    filter_upwards [eventually_gt_nhds (show x - 1 / ((n : ℝ) + 1) < x by
+      have hpos : (0 : ℝ) < 1 / ((n : ℝ) + 1) := by positivity
+      linarith)] with y hy
+    exact lt_of_lt_of_le hn
+      (measure_mono (inter_subset_inter_right _ (Iic_subset_Iic.2 hy.le)))
+  · -- values just above `F x` dominate near `x` (right-continuity side)
+    have hI : (⋂ n : ℕ, s ∩ Iic (x + 1 / ((n : ℝ) + 1))) = s ∩ Iic x := by
+      rw [← inter_iInter]
+      congr 1
+      ext y
+      simp only [mem_iInter, mem_Iic]
+      constructor
+      · intro h
+        by_contra hxy
+        obtain ⟨n, hn⟩ := exists_nat_one_div_lt (sub_pos.2 (not_le.1 hxy))
+        have := h n
+        linarith
+      · intro h n
+        have hpos : (0 : ℝ) < 1 / ((n : ℝ) + 1) := by positivity
+        linarith
+    have hanti : Antitone fun n : ℕ => s ∩ Iic (x + 1 / ((n : ℝ) + 1)) := by
+      intro n m hnm
+      refine inter_subset_inter_right _ (Iic_subset_Iic.2 ?_)
+      have h1 : ((n : ℝ) + 1) ≤ (m : ℝ) + 1 := by exact_mod_cast Nat.succ_le_succ hnm
+      have h2 : 1 / ((m : ℝ) + 1) ≤ 1 / ((n : ℝ) + 1) :=
+        one_div_le_one_div_of_le (by positivity) h1
+      linarith
+    have hfin : ∃ n : ℕ, μ (s ∩ Iic (x + 1 / ((n : ℝ) + 1))) ≠ ∞ :=
+      ⟨0, ne_top_of_le_ne_top hμs (measure_mono inter_subset_left)⟩
+    have htendsto := tendsto_measure_iInter_atTop (μ := μ)
+      (fun _ => (hs.inter measurableSet_Iic).nullMeasurableSet) hanti hfin
+    rw [hI] at htendsto
+    have hc' : μ (s ∩ Iic x) < c := hc
+    obtain ⟨n, hn⟩ := (htendsto.eventually_lt_const hc').exists
+    filter_upwards [eventually_lt_nhds (show x < x + 1 / ((n : ℝ) + 1) by
+      have hpos : (0 : ℝ) < 1 / ((n : ℝ) + 1) := by positivity
+      linarith)] with y hy
+    exact lt_of_le_of_lt
+      (measure_mono (inter_subset_inter_right _ (Iic_subset_Iic.2 hy.le))) hn
+
+/-- **Sierpiński's intermediate-value theorem for atomless measures on ℝ**
+    (1922). If `μ` is atomless, `s` is measurable with `μ s < ∞`, and
+    `r ≤ μ s`, then some measurable `t ⊆ s` has `μ t = r` exactly.
+
+    The witness is an initial slice `t = s ∩ Iic x`: the cumulative function
+    `F t = μ (s ∩ Iic t)` is continuous (`continuous_measure_inter_Iic`),
+    tends to `0` at `-∞` and to `μ s` at `+∞`, so the intermediate value
+    theorem on the preconnected space ℝ produces the exact level `r`.
+
+    This statement is absent from Mathlib (which has only
+    `exists_subset_measure_lt_top`); it is the `d = 1` Lyapunov theorem. -/
+theorem exists_subset_measure_eq [NoAtoms μ] (hs : MeasurableSet s) (hμs : μ s ≠ ∞)
+    {r : ℝ≥0∞} (hr : r ≤ μ s) :
+    ∃ t, MeasurableSet t ∧ t ⊆ s ∧ μ t = r := by
+  rcases eq_or_lt_of_le hr with rfl | hr'
+  · exact ⟨s, hs, subset_rfl, rfl⟩
+  rcases eq_or_ne r 0 with rfl | hr0
+  · exact ⟨∅, MeasurableSet.empty, empty_subset _, measure_empty⟩
+  -- main case: `0 < r < μ s`
+  have hcont := continuous_measure_inter_Iic hs hμs
+  have hbot : Tendsto (fun t : ℝ => μ (s ∩ Iic t)) atBot (𝓝 0) := by
+    have hInt : (⋂ i : ℝ, s ∩ Iic i) = ∅ := by
+      apply eq_empty_iff_forall_notMem.2
+      intro y hy
+      have h1 := (mem_iInter.1 hy (y - 1)).2
+      simp only [mem_Iic] at h1
+      linarith
+    have h := tendsto_measure_iInter_atBot (μ := μ) (s := fun i : ℝ => s ∩ Iic i)
+      (fun _ => (hs.inter measurableSet_Iic).nullMeasurableSet)
+      (fun _ _ hab => inter_subset_inter_right _ (Iic_subset_Iic.2 hab))
+      ⟨0, ne_top_of_le_ne_top hμs (measure_mono inter_subset_left)⟩
+    rwa [hInt, measure_empty] at h
+  have htop : Tendsto (fun t : ℝ => μ (s ∩ Iic t)) atTop (𝓝 (μ s)) := by
+    have hU : (⋃ i : ℝ, s ∩ Iic i) = s := by
+      rw [← inter_iUnion, iUnion_Iic, inter_univ]
+    have h := tendsto_measure_iUnion_atTop (μ := μ) (s := fun i : ℝ => s ∩ Iic i)
+      (fun _ _ hab => inter_subset_inter_right _ (Iic_subset_Iic.2 hab))
+    rwa [hU] at h
+  have hr0' : (0 : ℝ≥0∞) < r := lt_of_le_of_ne zero_le (Ne.symm hr0)
+  have h₁ : ∃ a, μ (s ∩ Iic a) ≤ r := by
+    obtain ⟨a, ha⟩ := (hbot.eventually_lt_const hr0').exists
+    exact ⟨a, ha.le⟩
+  have h₂ : ∃ b, r ≤ μ (s ∩ Iic b) := by
+    obtain ⟨b, hb⟩ := (htop.eventually_const_lt hr').exists
+    exact ⟨b, hb.le⟩
+  obtain ⟨x, hx⟩ := mem_range_of_exists_le_of_exists_ge hcont h₁ h₂
+  exact ⟨s ∩ Iic x, hs.inter measurableSet_Iic, inter_subset_left, hx⟩
+
+/-- **The value range of an atomless measure is a full interval** (`ℝ≥0∞`
+    form). Over measurable subsets of a finite-measure set `s`, the attained
+    measures are exactly `Icc 0 (μ s)` — no gaps. -/
+theorem setOf_measure_subset_eq_Icc [NoAtoms μ] (hs : MeasurableSet s) (hμs : μ s ≠ ∞) :
+    {r : ℝ≥0∞ | ∃ t, MeasurableSet t ∧ t ⊆ s ∧ μ t = r} = Icc 0 (μ s) := by
+  ext r
+  simp only [mem_setOf_eq, mem_Icc]
+  constructor
+  · rintro ⟨t, _, hts, rfl⟩
+    exact ⟨zero_le, measure_mono hts⟩
+  · rintro ⟨-, hrs⟩
+    exact exists_subset_measure_eq hs hμs hrs
+
+/-- **Lyapunov's convexity theorem in dimension one** (range form, real
+    values). The range of the real-valued set function `t ↦ (μ t).toReal`
+    over measurable subsets of `s` is the compact convex interval
+    `[0, (μ s).toReal]`. This is the `d = 1` case of "the range of an
+    atomless vector measure is convex and compact" (Lyapunov 1940). -/
+theorem lyapunov_range_eq_Icc [NoAtoms μ] (hs : MeasurableSet s) (hμs : μ s ≠ ∞) :
+    {r : ℝ | ∃ t, MeasurableSet t ∧ t ⊆ s ∧ (μ t).toReal = r} = Icc 0 (μ s).toReal := by
+  ext r
+  simp only [mem_setOf_eq, mem_Icc]
+  constructor
+  · rintro ⟨t, _, hts, rfl⟩
+    exact ⟨ENNReal.toReal_nonneg, ENNReal.toReal_mono hμs (measure_mono hts)⟩
+  · rintro ⟨hr0, hrs⟩
+    obtain ⟨t, ht, hts, htr⟩ := exists_subset_measure_eq hs hμs
+      ((ENNReal.ofReal_le_iff_le_toReal hμs).2 hrs)
+    exact ⟨t, ht, hts, by rw [htr, ENNReal.toReal_ofReal hr0]⟩
+
+/-- The dimension-one Lyapunov range is **convex** — the exact-convexification
+    phenomenon that replaces the Shapley–Folkman excess bound over an
+    atomless continuum (zero excess, versus `Module.finrank ℝ E` excess
+    summands in the finite-dimensional discrete case). -/
+theorem lyapunov_range_convex [NoAtoms μ] (hs : MeasurableSet s) (hμs : μ s ≠ ∞) :
+    Convex ℝ {r : ℝ | ∃ t, MeasurableSet t ∧ t ⊆ s ∧ (μ t).toReal = r} := by
+  rw [lyapunov_range_eq_Icc hs hμs]
+  exact convex_Icc _ _
+
+/-- The dimension-one Lyapunov range is **compact**. Together with
+    `lyapunov_range_convex` this is the full `d = 1` Lyapunov statement:
+    the range of an atomless finite measure is convex and compact. -/
+theorem lyapunov_range_isCompact [NoAtoms μ] (hs : MeasurableSet s) (hμs : μ s ≠ ∞) :
+    IsCompact {r : ℝ | ∃ t, MeasurableSet t ∧ t ⊆ s ∧ (μ t).toReal = r} := by
+  rw [lyapunov_range_eq_Icc hs hμs]
+  exact isCompact_Icc
+
+/-- **Non-vacuity witness**: Lebesgue measure on `[0, 1]` is atomless of
+    finite measure, so every level `r ≤ 1` is attained exactly by a
+    measurable subset of the unit interval. The hypotheses of the theorems
+    above are satisfiable — this rung carries real content. -/
+theorem exists_subset_unitInterval_volume_eq {r : ℝ≥0∞} (hr : r ≤ 1) :
+    ∃ t, MeasurableSet t ∧ t ⊆ Icc (0 : ℝ) 1 ∧ volume t = r := by
+  have h1 : volume (Icc (0 : ℝ) 1) = 1 := by
+    rw [Real.volume_Icc]
+    norm_num
+  exact exists_subset_measure_eq measurableSet_Icc
+    (by rw [h1]; exact ENNReal.one_ne_top) (by rw [h1]; exact hr)
+
+end ShapleyFolkman.Lyapunov

--- a/research/problems/shapley-folkman-oq-01/knowledge.md
+++ b/research/problems/shapley-folkman-oq-01/knowledge.md
@@ -161,3 +161,20 @@ infinite.
    as a separate prerequisite project (parented at
    `shapley-folkman-oq-01-oq-01` or similar in a future seeker
    iteration).
+
+## S3-A: Lyapunov dimension one — DONE (2026-07-24, researcher-2)
+
+`proofs/Proofs/ShapleyFolkmanOQ01Lyapunov.lean` (246 lines, 0 sorries,
+0 axioms). Sierpiński's IVT for atomless measures on ℝ
+(`exists_subset_measure_eq`), value-range interval theorem
+(`setOf_measure_subset_eq_Icc`, `lyapunov_range_eq_Icc`), and the d = 1
+Lyapunov statement (`lyapunov_range_convex`, `lyapunov_range_isCompact`),
+with a Lebesgue-on-[0,1] non-vacuity witness. Mechanism: cumulative-slice
+IVT (`t ↦ μ (s ∩ Iic t)` continuous ⇐ `Iio_ae_eq_Iic` + continuity from
+above; exact level by `mem_range_of_exists_le_of_exists_ge`).
+
+Key fact for S3-B: Mathlib's `NoAtoms` (singleton-null) is strictly weaker
+than the splitting notion off ℝ — the countable-cocountable σ-algebra with
+the 0/1 measure is `NoAtoms` but has value range `{0, 1}`. General-space
+Sierpiński therefore needs a new strong-atomless predicate + greedy
+exhaustion. On ℝ the weak notion suffices (this file proves it).

--- a/research/problems/shapley-folkman-oq-01/sessions/2026-07-24-s3a-act-lyapunov-dim-one.md
+++ b/research/problems/shapley-folkman-oq-01/sessions/2026-07-24-s3a-act-lyapunov-dim-one.md
@@ -1,0 +1,69 @@
+# Session 2026-07-24 — S3-A ACT: Lyapunov convexity in dimension one (researcher-2)
+
+## Outcome
+
+**S3-A COMPLETE.** New file `proofs/Proofs/ShapleyFolkmanOQ01Lyapunov.lean`
+(246 lines, 0 sorries, 0 axioms — `#print axioms` on all five capstone
+theorems shows only `propext`/`Classical.choice`/`Quot.sound`; host-verified
+with `lake env lean` on v4.31.0).
+
+This is the first rung of the S3 positive programme. The prior blocker read
+"Lyapunov's convexity theorem is not in Mathlib" — this session discharges
+the `d = 1` case in-repo and sharpens the blocker to "general-measurable-space
+Sierpiński exhaustion (S3-B) + ℝᵈ induction (S3-C)".
+
+## What was proved
+
+| Declaration | Content |
+|---|---|
+| `monotone_measure_inter_Iic` | `t ↦ μ (s ∩ Iic t)` monotone |
+| `continuous_measure_inter_Iic` | …and continuous for `[NoAtoms μ]`, `s` measurable, `μ s ≠ ∞` |
+| `exists_subset_measure_eq` | **Sierpiński 1922 on ℝ**: `r ≤ μ s → ∃ t ⊆ s` measurable, `μ t = r` |
+| `setOf_measure_subset_eq_Icc` | value range `= Icc 0 (μ s)` (ℝ≥0∞ form) |
+| `lyapunov_range_eq_Icc` | real form: range of `(μ ·).toReal` `= Icc 0 (μ s).toReal` |
+| `lyapunov_range_convex` / `lyapunov_range_isCompact` | **d = 1 Lyapunov**: range convex and compact |
+| `exists_subset_unitInterval_volume_eq` | non-vacuity: Lebesgue on `[0,1]` attains every `r ≤ 1` |
+
+## Mechanism (route label: cumulative-slice IVT)
+
+Witnesses are initial slices `s ∩ Iic x`. Left-continuity of the cumulative
+function IS atomlessness (`Iio_ae_eq_Iic`); right-continuity is continuity
+from above (`tendsto_measure_iInter_atTop`, needs `μ s ≠ ∞`). Limits at ±∞
+via `tendsto_measure_iInter_atBot` / `tendsto_measure_iUnion_atTop` with
+`ι := ℝ`. Exact level attained by `mem_range_of_exists_le_of_exists_ge`
+(IVT on the preconnected space ℝ, codomain ℝ≥0∞ — `OrderClosedTopology`
+suffices). No exhaustion/Zorn argument needed on ℝ.
+
+## Key API discoveries
+
+- Mathlib has NO Sierpiński theorem (only `exists_subset_measure_lt_top`);
+  its `NoAtoms` is the weak singleton-null class with an in-file TODO about
+  the strong splitting notion. On ℝ the weak notion suffices (this file);
+  on a general measurable space it does NOT (countable-cocountable
+  counterexample), so S3-B must introduce the strong splitting predicate.
+- v4.31 gotchas hit: `∞`/`ℝ≥0∞` need `open scoped ENNReal`; `zero_le` is
+  now implicit-argument (`zero_le _` fails); `push_neg` deprecated (use
+  `not_le.1` directly); `tendsto_measure_iUnion_atTop` needs the family
+  given explicitly (`(s := fun i : ℝ => …)`) when the monotonicity proof is
+  an untyped lambda; `tendsto_order.2` binders arrive beta-unexpanded
+  (bridge with a defeq `have`).
+
+## Session hazard log
+
+The worktree (`researcher-2-4`) was janitor-reaped MID-SESSION after
+verification but before commit; branch survived, all content restored from
+agent context and re-committed immediately (see memory
+`gotcha-janitor-reaps-fresh-worktree-before-first-commit`).
+
+## Next steps
+
+1. **S3-B**: strong atomless predicate + general-space Sierpiński via greedy
+   exhaustion (recursion grabbing ≥ half the achievable remaining mass;
+   `∑ μ Bₙ < ∞` forces exact attainment). ~250–400 LOC.
+2. **S3-C**: Lyapunov in ℝᵈ by induction on d (uses S3-B + Radon–Nikodym).
+3. **S3-D**: Aumann set-valued integral (needs measurable selections).
+
+Equivalent-strength check: S3-A is materially weaker than full Lyapunov/Aumann
+(proving d = 1 does not yield ℝᵈ by a known one-line argument — the induction
+in S3-C requires Radon–Nikodym and the exhaustion machinery), so this is
+decomposition progress, not a blocked same-strength restatement.

--- a/research/problems/shapley-folkman-oq-01/state.md
+++ b/research/problems/shapley-folkman-oq-01/state.md
@@ -703,3 +703,16 @@ Enricher-scope (parallel, when S2-B₁ lands): gallery entry creation in
 `src/data/proofs/shapley-folkman-oq-01/` with `status: axiomatized`,
 `badge: axiom`, `theoremCount: 7` (post-S2-B₁), `defCount: 1`,
 `sorryCount: 0`, `inheritedAxioms: 5`.
+
+---
+
+## S3-A COMPLETE (2026-07-24, researcher-2)
+
+Dimension-one Lyapunov / Sierpiński IVT proved 0-axiom/0-sorry in new file
+`proofs/Proofs/ShapleyFolkmanOQ01Lyapunov.lean` (246 lines, host-verified
+`lake env lean` v4.31 + `#print axioms` = foundational only). The S3/S4
+blocker "Lyapunov not in Mathlib" is sharpened: d = 1 is now in-repo; the
+remaining gap is S3-B (general-space Sierpiński via greedy exhaustion,
+needs the STRONG atomless predicate — Mathlib's `NoAtoms` is too weak off
+the real line) and S3-C (ℝᵈ Lyapunov by induction + Radon–Nikodym).
+See `sessions/2026-07-24-s3a-act-lyapunov-dim-one.md`.

--- a/src/data/research/problems/shapley-folkman-oq-01.json
+++ b/src/data/research/problems/shapley-folkman-oq-01.json
@@ -30,8 +30,8 @@
   "currentState": {
     "phase": "COMPLETED",
     "since": "2026-06-13T00:00:00Z",
-    "iteration": 20,
-    "focus": "S2-D ACT COMPLETE (researcher-3, 2026-07-23). The genuine ℓ² infinite-dimensional negative result is Docker-verified (v4.31.0, 8577 jobs, 0 sorries, 0 axioms). Added ιN : EuclideanSpace ℝ (Fin N) →ₗ[ℝ] lp (fun _:ℕ => ℝ) 2 (injective linear embedding, sum of lp.lsingle), ιN_apply_coord (coordinate-preserving), ιN_injective, and shapley_folkman_excess_unbounded_in_lp (excess card unbounded over ℓ² subsets, lifted from Fin N tightness via Decomposition.map). This ALSO verifies the Session-20 S2-C transport core, previously build-unverified during the 2026-06-13 Docker blackout — the sole reason the problem was marked blocked. OQ-01 negative answer now complete and machine-checked: the FiniteDimensional hypothesis of shapley_folkman cannot be dropped, and no fixed finite bound survives in genuine infinite dimensions (Module.finrank ℝ ℓ² = 0).",
+    "iteration": 21,
+    "focus": "S3-A COMPLETE (researcher-2, 2026-07-24): dimension-one Lyapunov / Sierpinski IVT proved 0-axiom in ShapleyFolkmanOQ01Lyapunov.lean (host-verified). Negative answer (S2 chain) unchanged and COMPLETE. Next: S3-B general-space Sierpinski exhaustion.",
     "blockers": [
       "Lyapunov/Aumann positive infinite-dim analog (Approach A, OUT OF SCOPE for OQ-01 negative answer): Lyapunov convexity theorem not in Mathlib; multi-session formalization project. Not a blocker on the (completed) negative answer."
     ],
@@ -97,10 +97,21 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShapleyFolkmanOQ04.lean"
+    },
+    {
+      "path": "Proofs/ShapleyFolkmanOQ01Lyapunov.lean",
+      "filename": "ShapleyFolkmanOQ01Lyapunov.lean",
+      "lineCount": 246,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShapleyFolkmanOQ01Lyapunov.lean"
     }
   ],
   "knowledge": {
-    "progressSummary": "COMPLETED (S2-D, researcher-3, 2026-07-23, VERIFIED 0-axiom). OQ-01 asked whether the FiniteDimensional hypothesis of shapley_folkman can be dropped by replacing Module.finrank with a suitable infinite-dim notion. Answer: NO, now machine-verified end to end. Finite-dim sharpness (tight_excess_count / exists_tight_decomposition, S2-A) shows the finrank bound is achieved with equality for every N; the truncation lift (no_universal_shapley_folkman_bound, S2-B1) rules out any ambient-dimension-blind bound; the Decomposition.map transport core (S2-C) plus the injective embedding ιN (S2-D) carry the tightness into the genuine infinite-dim Hilbert space ℓ², where shapley_folkman_excess_unbounded_in_lp gives unbounded excess and (finrank ℝ ℓ² = 0) refutes the literal parent bound. Docker build clean at v4.31.0 (8577 jobs, 0 sorries, 0 axioms), which also retro-verifies the S2-C core left unverified during the 2026-06-13 Docker blackout. The only remaining direction is the separate POSITIVE analog (Aumann/Lyapunov), out of scope here.",
+    "progressSummary": "COMPLETED (S2-D, researcher-3, 2026-07-23, VERIFIED 0-axiom). OQ-01 asked whether the FiniteDimensional hypothesis of shapley_folkman can be dropped by replacing Module.finrank with a suitable infinite-dim notion. Answer: NO, now machine-verified end to end. Finite-dim sharpness (tight_excess_count / exists_tight_decomposition, S2-A) shows the finrank bound is achieved with equality for every N; the truncation lift (no_universal_shapley_folkman_bound, S2-B1) rules out any ambient-dimension-blind bound; the Decomposition.map transport core (S2-C) plus the injective embedding ιN (S2-D) carry the tightness into the genuine infinite-dim Hilbert space ℓ², where shapley_folkman_excess_unbounded_in_lp gives unbounded excess and (finrank ℝ ℓ² = 0) refutes the literal parent bound. Docker build clean at v4.31.0 (8577 jobs, 0 sorries, 0 axioms), which also retro-verifies the S2-C core left unverified during the 2026-06-13 Docker blackout. The only remaining direction is the separate POSITIVE analog (Aumann/Lyapunov), out of scope here. || S3-A (researcher-2, 2026-07-24): positive-programme rung 1 DONE — dimension-one Lyapunov convexity (Sierpinski IVT for atomless measures on R) proved 0-axiom/0-sorry in new file ShapleyFolkmanOQ01Lyapunov.lean; value range of an atomless finite measure = Icc 0 (mu s), convex and compact; non-vacuity witnessed by Lebesgue on [0,1]. The S3 blocker 'Lyapunov not in Mathlib' is now partially discharged: d=1 in-repo; general-space Sierpinski (exhaustion) and R^d Lyapunov are S3-B/S3-C.",
     "builtItems": [
       "research/problems/shapley-folkman-oq-01/problem.md: full template fill-in with three approaches and references",
       "research/problems/shapley-folkman-oq-01/state.md: Session 1–8 entries with iteration history table",
@@ -116,7 +127,8 @@
       "proofs/Proofs.lean: registered import Proofs.ShapleyFolkmanOQ01 alphabetically",
       "ιN (N) in ShapleyFolkmanOQ01.lean: injective linear embedding EuclideanSpace ℝ (Fin N) →ₗ[ℝ] lp (fun _:ℕ => ℝ) 2",
       "ιN_apply_coord, ιN_injective in ShapleyFolkmanOQ01.lean",
-      "shapley_folkman_excess_unbounded_in_lp in ShapleyFolkmanOQ01.lean: the ℓ² unbounded-excess capstone (S2-D)"
+      "shapley_folkman_excess_unbounded_in_lp in ShapleyFolkmanOQ01.lean: the ℓ² unbounded-excess capstone (S2-D)",
+      "proofs/Proofs/ShapleyFolkmanOQ01Lyapunov.lean (S3-A, new file, 246 lines, 0 sorries, 0 axioms, host-verified lake env lean v4.31 + #print axioms = foundational only): continuous_measure_inter_Iic, exists_subset_measure_eq (Sierpinski on R), setOf_measure_subset_eq_Icc, lyapunov_range_eq_Icc, lyapunov_range_convex, lyapunov_range_isCompact, exists_subset_unitInterval_volume_eq (non-vacuity via Lebesgue on [0,1])"
     ],
     "insights": [
       "Module.finrank ℝ E = 0 for any non-finite-dim ℝ-module in Lean's convention; this collapses the Shapley–Folkman bound to '≤ 0' which is vacuously false for any Minkowski sum with non-convex summands.",
@@ -126,7 +138,10 @@
       "S5 PREP (PR #18929) names the Mathlib v4.26.0 lemma Set.finset_sum_mem_finset_sum (Mathlib/Algebra/Group/Pointwise/Set/BigOperators.lean:142, multiplicative + @[to_additive]) as the n-ary additive Minkowski-membership primitive — this supersedes the Set.add_mem_finset_sum guess in Session 8's Next Action, which is not the actual Mathlib v4.26.0 name at the lake-pinned SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67.",
       "S2-D VERIFIED (2026-07-23, v4.31.0): shapley_folkman_excess_unbounded_in_lp exhibits, for every K, a finite family of subsets of ℓ² = lp (fun _:ℕ => ℝ) 2 whose every Shapley-Folkman Decomposition has excessIndices.card > K. Honest infinite-dim negative result — no fixed finite bound holds.",
       "The embedding ιN : EuclideanSpace ℝ (Fin N) →ₗ[ℝ] ℓ² is a sum of single-coordinate injections ∑ i, lp.lsingle 2 i.val (v i); injectivity is a one-coordinate evaluation (Finset.sum_eq_single + lp.single_apply_self/ne + Fin.val_injective).",
-      "v4.31 gotcha: lp.single_apply_self / single_apply_ne need explicit (E := fun _:ℕ => ℝ) — the E family is a higher-order metavariable that cannot be inferred from the value argument v i : ℝ alone. EuclideanSpace coordinate access now displays as v.ofLp i (WithLp refactor); PiLp.add_apply/smul_apply are still rfl."
+      "v4.31 gotcha: lp.single_apply_self / single_apply_ne need explicit (E := fun _:ℕ => ℝ) — the E family is a higher-order metavariable that cannot be inferred from the value argument v i : ℝ alone. EuclideanSpace coordinate access now displays as v.ofLp i (WithLp refactor); PiLp.add_apply/smul_apply are still rfl.",
+      "S3-A (researcher-2, 2026-07-24): Sierpinski's intermediate-value theorem for atomless measures is genuinely ABSENT from Mathlib (only exists_subset_measure_lt_top exists; Mathlib's NoAtoms is the weak singleton-null notion with an in-file TODO about the strong splitting notion). On the ambient space R the weak notion suffices: the cumulative function t |-> mu (s inter Iic t) is continuous (left-continuity IS atomlessness via Iio_ae_eq_Iic; right-continuity is continuity from above), so the connectedness IVT mem_range_of_exists_le_of_exists_ge yields exact levels.",
+      "S3-A: dimension-one Lyapunov is now proved 0-axiom: the value range {mu t : t measurable subset of s} equals Icc 0 (mu s) exactly (setOf_measure_subset_eq_Icc), and its real-valued form is the compact convex interval [0,(mu s).toReal] (lyapunov_range_eq_Icc + lyapunov_range_convex + lyapunov_range_isCompact). This is the exact-convexification contrast with the parent: finite sums have excess exactly finrank E (tight_excess_count); the atomless continuum has ZERO excess.",
+      "S3-A route note (mechanism label): 'cumulative-slice IVT' — witness sets are initial slices s inter Iic x, no exhaustion/Zorn argument needed on R. The general-measurable-space Sierpinski (arbitrary atomless sigma-algebra, no order) still needs the greedy exhaustion argument and remains the gap for S3-B (Lyapunov in R^d)."
     ],
     "techniques": [
       "EuclideanSpace ℝ (Fin n) + EuclideanSpace.basisFun for concrete finite-dim counter-example",
@@ -134,13 +149,14 @@
       "Midpoint extraction: x = (1/2) ∑ eᵢ is non-extreme in each convexHull ℝ Sᵢ, making every i excess"
     ],
     "nextSteps": [
-      "S2-D ACT (next session, paste-ready): S2-B₂ literal lp 2 lift. Build injective ιN : EuclideanSpace ℝ (Fin N) →ₗ[ℝ] lp (fun _ : ℕ => ℝ) 2 (∑ lp.lsingle 2 i.val), prove ιN_injective, then shapley_folkman_excess_unbounded_in_lp via (midpointDecomp N).map ιN + Decomposition.map_excessIndices_card_of_injective + tight_excess_count. Recipe + lp bearers in session 2026-06-13 §4.",
-      "Gallery entry creation (enricher scope): src/data/proofs/shapley-folkman-oq-01/meta.json with status=axiomatized, badge=axiom, sorries=0, theoremCount tracking current file, 5 inherited axioms from parent.",
-      "S3 ACT (deferred multi-session): Aumann set-valued integral statement-only — needs Lyapunov upstream not in Mathlib (200-300 LOC measure-theoretic prerequisite project)."
+      "S3-B ACT: general-measurable-space Sierpinski (no order on Omega): greedy exhaustion argument (recursive choice of subsets grabbing at least half the achievable remaining mass; summability forces exact attainment). Needs a new STRONG atomless predicate (Mathlib NoAtoms too weak off R: countable-cocountable 0/1 measure is NoAtoms with range {0,1}). Est. 250-400 lines.",
+      "S3-C ACT: Lyapunov convexity in R^d for vector measures built from atomless components — classical proof via induction on d using S3-B exhaustion + Radon-Nikodym; check Mathlib MeasureTheory.Decomposition for RN availability.",
+      "S3-D (deferred): Aumann set-valued integral convexity — statement needs measurable-selection machinery; revisit after S3-C.",
+      "Gallery entry creation (enricher scope): src/data/proofs/shapley-folkman-oq-01/meta.json should list BOTH ShapleyFolkmanOQ01.lean (negative answer) and ShapleyFolkmanOQ01Lyapunov.lean (S3-A positive rung)."
     ]
   },
   "createdAt": "2026-05-12",
-  "updatedAt": "2026-07-23T00:00:00Z",
+  "updatedAt": "2026-07-24T00:00:00Z",
   "relatedProofs": [
     "shapley-folkman",
     "shapley-folkman-oq-03",


### PR DESCRIPTION
## Summary
Research session for **shapley-folkman-oq-01** (re-served COMPLETED problem; this session opens the S3 positive programme rather than re-doing the settled negative answer).

## Progress
- **S3-A rung complete**: new file `proofs/Proofs/ShapleyFolkmanOQ01Lyapunov.lean` (246 lines, **0 sorries, 0 axioms**)
- Proves **Sierpiński's intermediate-value theorem** for atomless measures on ℝ (`exists_subset_measure_eq`) — genuinely absent from Mathlib (which has only `exists_subset_measure_lt_top`)
- Proves **Lyapunov's convexity theorem in dimension one**: the value range of an atomless finite measure over measurable subsets of `s` is exactly `Icc 0 (μ s)` — convex (`lyapunov_range_convex`) and compact (`lyapunov_range_isCompact`)
- Non-vacuity witness: Lebesgue measure on `[0,1]` attains every level `r ≤ 1`
- Knowledge tracker, `knowledge.md`, `state.md`, and a session file updated

## Findings
- Mathlib's `NoAtoms` is the weak singleton-null notion (the file itself carries a TODO about the strong splitting notion). On ℝ the weak notion suffices: the cumulative function `t ↦ μ (s ∩ Iic t)` is continuous (left-continuity IS atomlessness via `Iio_ae_eq_Iic`), so the connectedness IVT produces exact levels with initial-slice witnesses — no exhaustion/Zorn argument needed.
- Off ℝ the weak notion is insufficient (countable-cocountable 0/1 measure is `NoAtoms` with value range `{0,1}`), so the S3-B general-space rung must introduce the strong splitting predicate + greedy exhaustion.
- This discharges the "Lyapunov not in Mathlib" blocker for d = 1 and sharpens the remaining gap to S3-B (general-space Sierpiński) and S3-C (ℝᵈ Lyapunov by induction + Radon–Nikodym).

## Verification
- `lake env lean` clean on v4.31.0 (verified twice — before and after a mid-session worktree reap forced a byte-identical reconstruction)
- `#print axioms` on all five capstone theorems: `propext`, `Classical.choice`, `Quot.sound` only

## Status
**Outcome**: progress (S3-A complete; problem phase stays COMPLETED for the OQ-01 negative answer, S3 positive programme now 1/3 rungs done)
**Next Steps**: S3-B — strong atomless predicate + general-measurable-space Sierpiński via greedy exhaustion (~250–400 LOC)

🤖 Generated by researcher-2
