### PR TITLE
research(konigsberg-oq-03-wip-01): S16 — EGW connectivity necessity + two-lines disconnected witness [0 ax / 0 sorry]

### DIFF
--- a/proofs/Proofs/KonigsbergOQ03.lean
+++ b/proofs/Proofs/KonigsbergOQ03.lean
@@ -1183,4 +1183,329 @@ theorem parity_picture {V : Type*} (G : InfiniteGraph V) :
 #check @not_hasInfiniteEulerPath_rayGraph_parity
 #check @parity_picture
 
+/-! ### EGW necessity: connectivity (S16)
+
+The degree-parity conditions (S14/S15) are only part of the
+Erdős–Grünwald–Weiszfeld necessary conditions: EGW also requires the graph
+to be *connected apart from isolated vertices*. The reason is immediate —
+every edge lies on the single Euler walk, so any two non-isolated vertices
+are linked by a finite segment of that walk.
+
+This section formalises the joinedness relation `InfiniteGraph.Joined`
+(finite chains of edges), proves connectivity necessity for BOTH path
+notions (`connectivity_picture`), and exhibits `twoLinesGraph` — two
+disjoint copies of the line graph, living on the even and the odd integers —
+for which *every* vertex has even degree yet no Euler path of either kind
+exists. Together with `lineGraph_parity_not_sufficient` (one-way case, S14)
+this shows the parity clauses of `parity_picture` are insufficient for both
+notions: connectivity is an independent necessary condition. -/
+
+namespace InfiniteGraph
+
+/-- Two vertices are *joined* in `G` if a finite chain of edges connects
+them: a sequence `f : ℕ → V` with `f 0 = u`, `f n = v`, and consecutive
+values adjacent below index `n`. Taking `n = 0` gives reflexivity, so
+isolated vertices are joined to themselves but to nothing else. -/
+def Joined {V : Type*} (G : InfiniteGraph V) (u v : V) : Prop :=
+  ∃ (n : ℕ) (f : ℕ → V), f 0 = u ∧ f n = v ∧ ∀ i < n, G.adj (f i) (f (i + 1))
+
+/-- Joinedness is reflexive (the empty chain). -/
+theorem Joined.refl {V : Type*} (G : InfiniteGraph V) (v : V) : G.Joined v v :=
+  ⟨0, fun _ => v, rfl, rfl, fun i hi => absurd hi (Nat.not_lt_zero i)⟩
+
+/-- Adjacent vertices are joined (a chain of length one). -/
+theorem Joined.of_adj {V : Type*} {G : InfiniteGraph V} {u v : V}
+    (h : G.adj u v) : G.Joined u v := by
+  refine ⟨1, fun i => if i = 0 then u else v, by simp, by simp, ?_⟩
+  intro i hi
+  interval_cases i
+  simpa using h
+
+/-- Joinedness is symmetric: reverse the chain, flipping each edge with
+`G.symm`. -/
+theorem Joined.symm {V : Type*} {G : InfiniteGraph V} {u v : V}
+    (h : G.Joined u v) : G.Joined v u := by
+  obtain ⟨n, f, h0, hn, hadj⟩ := h
+  refine ⟨n, fun i => f (n - i), by simpa using hn, by simpa using h0, ?_⟩
+  intro i hi
+  show G.adj (f (n - i)) (f (n - (i + 1)))
+  have hstep := hadj (n - i - 1) (by omega)
+  have h1 : n - i - 1 + 1 = n - i := by omega
+  have h2 : n - (i + 1) = n - i - 1 := by omega
+  rw [h1] at hstep
+  rw [h2]
+  exact G.symm _ _ hstep
+
+/-- Joinedness is transitive: concatenate the two chains. -/
+theorem Joined.trans {V : Type*} {G : InfiniteGraph V} {u v x : V}
+    (h1 : G.Joined u v) (h2 : G.Joined v x) : G.Joined u x := by
+  obtain ⟨n, f, hf0, hfn, hf⟩ := h1
+  obtain ⟨m, g, hg0, hgm, hg⟩ := h2
+  refine ⟨n + m, fun i => if i ≤ n then f i else g (i - n), by simp [hf0], ?_, ?_⟩
+  · show (if n + m ≤ n then f (n + m) else g (n + m - n)) = x
+    by_cases hm : m = 0
+    · subst hm
+      rw [if_pos (by omega : n + 0 ≤ n), Nat.add_zero, hfn, ← hg0]
+      exact hgm
+    · rw [if_neg (by omega : ¬ n + m ≤ n)]
+      have hnm : n + m - n = m := by omega
+      rw [hnm]
+      exact hgm
+  · intro i hi
+    show G.adj (if i ≤ n then f i else g (i - n))
+      (if i + 1 ≤ n then f (i + 1) else g (i + 1 - n))
+    by_cases hc : i + 1 ≤ n
+    · rw [if_pos (by omega : i ≤ n), if_pos hc]
+      exact hf i (by omega)
+    · by_cases hc2 : i ≤ n
+      · have hin : i = n := by omega
+        subst hin
+        rw [if_pos hc2, if_neg hc]
+        have h1 : i + 1 - i = 1 := by omega
+        rw [h1]
+        have hstep := hg 0 (by omega)
+        rw [hg0, ← hfn] at hstep
+        exact hstep
+      · rw [if_neg hc2, if_neg hc]
+        have h1 : i + 1 - n = (i - n) + 1 := by omega
+        rw [h1]
+        exact hg (i - n) (by omega)
+
+end InfiniteGraph
+
+namespace InfiniteWalk
+
+/-- The walk segment between two increasing step indices is a chain, so the
+two vertices are joined. -/
+theorem joined_of_le {V : Type*} {G : InfiniteGraph V} (w : InfiniteWalk G)
+    {m n : ℕ} (h : m ≤ n) : G.Joined (w.vertex m) (w.vertex n) := by
+  refine ⟨n - m, fun i => w.vertex (m + i), by simp, ?_, ?_⟩
+  · show w.vertex (m + (n - m)) = w.vertex n
+    congr 1
+    omega
+  · intro i hi
+    show G.adj (w.vertex (m + i)) (w.vertex (m + (i + 1)))
+    have h2 : m + (i + 1) = (m + i) + 1 := by omega
+    rw [h2]
+    exact w.step_adj (m + i)
+
+/-- Any two vertices on a one-way walk are joined. -/
+theorem joined_vertex {V : Type*} {G : InfiniteGraph V} (w : InfiniteWalk G)
+    (m n : ℕ) : G.Joined (w.vertex m) (w.vertex n) := by
+  rcases Nat.le_total m n with h | h
+  · exact w.joined_of_le h
+  · exact (w.joined_of_le h).symm
+
+end InfiniteWalk
+
+namespace BiInfiniteWalk
+
+/-- The walk segment between two increasing integer step indices is a chain,
+so the two vertices are joined. -/
+theorem joined_of_le {V : Type*} {G : InfiniteGraph V} (w : BiInfiniteWalk G)
+    {m n : ℤ} (h : m ≤ n) : G.Joined (w.vertex m) (w.vertex n) := by
+  refine ⟨(n - m).toNat, fun i => w.vertex (m + i), by simp, ?_, ?_⟩
+  · show w.vertex (m + ((n - m).toNat : ℤ)) = w.vertex n
+    congr 1
+    omega
+  · intro i hi
+    show G.adj (w.vertex (m + i)) (w.vertex (m + ((i + 1 : ℕ) : ℤ)))
+    have h2 : m + ((i + 1 : ℕ) : ℤ) = (m + i) + 1 := by push_cast; ring
+    rw [h2]
+    exact w.step_adj (m + i)
+
+/-- Any two vertices on a bi-infinite walk are joined. -/
+theorem joined_vertex {V : Type*} {G : InfiniteGraph V} (w : BiInfiniteWalk G)
+    (m n : ℤ) : G.Joined (w.vertex m) (w.vertex n) := by
+  rcases le_total m n with h | h
+  · exact w.joined_of_le h
+  · exact (w.joined_of_le h).symm
+
+end BiInfiniteWalk
+
+namespace IsEulerWalk
+
+/-- Every non-isolated vertex appears on a one-way Euler walk: its incident
+edge is covered by some step, and one endpoint of that step is the vertex. -/
+theorem exists_vertex_eq {V : Type*} {G : InfiniteGraph V} {w : InfiniteWalk G}
+    (hE : IsEulerWalk G w) {v x : V} (h : G.adj v x) :
+    ∃ n, w.vertex n = v := by
+  rcases hE.covers v x h with ⟨n, h1, _⟩ | ⟨n, _, h2⟩
+  · exact ⟨n, h1⟩
+  · exact ⟨n + 1, h2⟩
+
+/-- **Connectivity necessity, one-way**: a one-way Euler walk joins any two
+non-isolated vertices — both appear on the walk, and the walk segment
+between their appearances is a chain of edges. -/
+theorem joined {V : Type*} {G : InfiniteGraph V} {w : InfiniteWalk G}
+    (hE : IsEulerWalk G w) {u v : V}
+    (hu : ∃ x, G.adj u x) (hv : ∃ y, G.adj v y) : G.Joined u v := by
+  obtain ⟨x, hx⟩ := hu
+  obtain ⟨y, hy⟩ := hv
+  obtain ⟨a, ha⟩ := hE.exists_vertex_eq hx
+  obtain ⟨b, hb⟩ := hE.exists_vertex_eq hy
+  rw [← ha, ← hb]
+  exact w.joined_vertex a b
+
+end IsEulerWalk
+
+namespace IsBiInfiniteEulerWalk
+
+/-- Every non-isolated vertex appears on a bi-infinite Euler walk. -/
+theorem exists_vertex_eq {V : Type*} {G : InfiniteGraph V}
+    {w : BiInfiniteWalk G} (hE : IsBiInfiniteEulerWalk G w) {v x : V}
+    (h : G.adj v x) : ∃ n : ℤ, w.vertex n = v := by
+  rcases hE.covers v x h with ⟨n, h1, _⟩ | ⟨n, _, h2⟩
+  · exact ⟨n, h1⟩
+  · exact ⟨n + 1, h2⟩
+
+/-- **Connectivity necessity, bi-infinite**: a bi-infinite Euler walk joins
+any two non-isolated vertices. -/
+theorem joined {V : Type*} {G : InfiniteGraph V} {w : BiInfiniteWalk G}
+    (hE : IsBiInfiniteEulerWalk G w) {u v : V}
+    (hu : ∃ x, G.adj u x) (hv : ∃ y, G.adj v y) : G.Joined u v := by
+  obtain ⟨x, hx⟩ := hu
+  obtain ⟨y, hy⟩ := hv
+  obtain ⟨a, ha⟩ := hE.exists_vertex_eq hx
+  obtain ⟨b, hb⟩ := hE.exists_vertex_eq hy
+  rw [← ha, ← hb]
+  exact w.joined_vertex a b
+
+end IsBiInfiniteEulerWalk
+
+/-- A graph with a one-way Euler path joins any two non-isolated vertices. -/
+theorem joined_of_hasOneWayEulerPath {V : Type*} {G : InfiniteGraph V}
+    (h : HasOneWayEulerPath G) {u v : V}
+    (hu : ∃ x, G.adj u x) (hv : ∃ y, G.adj v y) : G.Joined u v := by
+  obtain ⟨w, hE⟩ := h
+  exact hE.joined hu hv
+
+/-- A graph with a bi-infinite Euler path joins any two non-isolated
+vertices. -/
+theorem joined_of_hasInfiniteEulerPath {V : Type*} {G : InfiniteGraph V}
+    (h : HasInfiniteEulerPath G) {u v : V}
+    (hu : ∃ x, G.adj u x) (hv : ∃ y, G.adj v y) : G.Joined u v := by
+  obtain ⟨w, hE⟩ := h
+  exact hE.joined hu hv
+
+/-- **Disconnection obstruction, one-way**: two non-isolated vertices not
+joined by any chain rule out a one-way Euler path. -/
+theorem not_hasOneWayEulerPath_of_not_joined {V : Type*} {G : InfiniteGraph V}
+    {u v : V} (hu : ∃ x, G.adj u x) (hv : ∃ y, G.adj v y)
+    (hnj : ¬ G.Joined u v) : ¬ HasOneWayEulerPath G :=
+  fun h => hnj (joined_of_hasOneWayEulerPath h hu hv)
+
+/-- **Disconnection obstruction, bi-infinite**: two non-isolated vertices not
+joined by any chain rule out a bi-infinite Euler path. -/
+theorem not_hasInfiniteEulerPath_of_not_joined {V : Type*} {G : InfiniteGraph V}
+    {u v : V} (hu : ∃ x, G.adj u x) (hv : ∃ y, G.adj v y)
+    (hnj : ¬ G.Joined u v) : ¬ HasInfiniteEulerPath G :=
+  fun h => hnj (joined_of_hasInfiniteEulerPath h hu hv)
+
+/-- The combined S16 connectivity picture: an Euler path of either kind
+forces any two non-isolated vertices to be joined. The connectivity clause
+of the EGW characterisation, in necessity form. -/
+theorem connectivity_picture {V : Type*} (G : InfiniteGraph V) :
+    (HasOneWayEulerPath G →
+      ∀ u v : V, (∃ x, G.adj u x) → (∃ y, G.adj v y) → G.Joined u v) ∧
+    (HasInfiniteEulerPath G →
+      ∀ u v : V, (∃ x, G.adj u x) → (∃ y, G.adj v y) → G.Joined u v) :=
+  ⟨fun h _ _ hu hv => joined_of_hasOneWayEulerPath h hu hv,
+   fun h _ _ hu hv => joined_of_hasInfiniteEulerPath h hu hv⟩
+
+/-! #### The disconnected witness: two disjoint lines
+
+`twoLinesGraph` places a line graph on the even integers and another on the
+odd integers: `m ~ n` iff they differ by exactly `2`. Every vertex has
+degree two, so the S14/S15 parity conditions are satisfied everywhere —
+yet no Euler path of either kind exists, because the two components cannot
+both be exhausted by a single walk. Parity cannot see this obstruction:
+connectivity is an independent necessary condition. -/
+
+/-- Two disjoint copies of the line graph, on the even and the odd
+integers: `m` and `n` are adjacent iff they differ by exactly `2`. -/
+def twoLinesGraph : InfiniteGraph ℤ where
+  adj m n := m + 2 = n ∨ n + 2 = m
+  symm := fun _ _ h => h.symm
+  loopless := fun _ h => by omega
+
+/-- Every vertex of `twoLinesGraph` has exactly the two neighbours `n ± 2`. -/
+theorem twoLinesGraph_neighbors (n : ℤ) :
+    {u | twoLinesGraph.adj n u} = {n + 2, n - 2} := by
+  ext u
+  simp only [Set.mem_setOf_eq, Set.mem_insert_iff, Set.mem_singleton_iff]
+  constructor
+  · rintro (h | h) <;> omega
+  · rintro (rfl | rfl)
+    · exact Or.inl rfl
+    · exact Or.inr (by ring)
+
+/-- Every vertex of `twoLinesGraph` has even degree (namely two): the
+S14/S15 parity conditions hold everywhere. -/
+theorem twoLinesGraph_even_ncard_neighbors (n : ℤ) :
+    Even {u | twoLinesGraph.adj n u}.ncard := by
+  rw [twoLinesGraph_neighbors n, Set.ncard_pair (by omega : n + 2 ≠ n - 2)]
+  exact ⟨1, rfl⟩
+
+/-- Parity is invariant along chains in `twoLinesGraph`: every edge changes
+the vertex by `±2`, so `u % 2` is constant on each component. -/
+theorem twoLinesGraph_joined_emod {u v : ℤ}
+    (h : twoLinesGraph.Joined u v) : u % 2 = v % 2 := by
+  obtain ⟨n, f, h0, hn, hadj⟩ := h
+  have key : ∀ i ≤ n, f i % 2 = f 0 % 2 := by
+    intro i
+    induction i with
+    | zero => intro _; rfl
+    | succ k ih =>
+      intro hk
+      have hstep := hadj k (by omega)
+      have hkm := ih (by omega)
+      rcases hstep with hs | hs <;> omega
+  rw [← h0, ← hn]
+  exact (key n le_rfl).symm
+
+/-- The even vertex `0` and the odd vertex `1` are not joined: they live in
+different components of `twoLinesGraph`. -/
+theorem twoLinesGraph_not_joined_zero_one :
+    ¬ twoLinesGraph.Joined 0 1 := by
+  intro h
+  have hmod := twoLinesGraph_joined_emod h
+  omega
+
+/-- **`twoLinesGraph` has no bi-infinite Euler path**: the non-isolated
+vertices `0` and `1` are not joined, contradicting connectivity necessity. -/
+theorem twoLinesGraph_not_hasInfiniteEulerPath :
+    ¬ HasInfiniteEulerPath twoLinesGraph :=
+  not_hasInfiniteEulerPath_of_not_joined
+    ⟨2, Or.inl (by norm_num)⟩ ⟨3, Or.inl (by norm_num)⟩
+    twoLinesGraph_not_joined_zero_one
+
+/-- **`twoLinesGraph` has no one-way Euler path** either, by the same
+disconnection obstruction. -/
+theorem twoLinesGraph_not_hasOneWayEulerPath :
+    ¬ HasOneWayEulerPath twoLinesGraph :=
+  not_hasOneWayEulerPath_of_not_joined
+    ⟨2, Or.inl (by norm_num)⟩ ⟨3, Or.inl (by norm_num)⟩
+    twoLinesGraph_not_joined_zero_one
+
+/-- **Bi-infinite parity is not sufficient**: `twoLinesGraph` satisfies the
+S15 parity condition at every vertex — no odd-degree vertex at all — yet
+has no bi-infinite Euler path. Together with
+`lineGraph_parity_not_sufficient` (the one-way analogue, S14) this shows
+BOTH parity clauses of `parity_picture` are strictly weaker than the full
+EGW characterisation: connectivity enters independently. -/
+theorem biInfinite_parity_not_sufficient :
+    (∀ n : ℤ, Even {u | twoLinesGraph.adj n u}.ncard) ∧
+      ¬ HasInfiniteEulerPath twoLinesGraph :=
+  ⟨twoLinesGraph_even_ncard_neighbors, twoLinesGraph_not_hasInfiniteEulerPath⟩
+
+#check @InfiniteGraph.Joined
+#check @InfiniteWalk.joined_vertex
+#check @BiInfiniteWalk.joined_vertex
+#check @joined_of_hasOneWayEulerPath
+#check @joined_of_hasInfiniteEulerPath
+#check @connectivity_picture
+#check @twoLinesGraph_not_hasInfiniteEulerPath
+#check @biInfinite_parity_not_sufficient
+
 end KonigsbergOQ03

--- a/research/problems/konigsberg-oq-03-wip-01/knowledge.md
+++ b/research/problems/konigsberg-oq-03-wip-01/knowledge.md
@@ -116,3 +116,44 @@ The honest classification is **SURVEY-BLOCKED**:
 ### Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## S16 ACT (2026-07-24, researcher-1) — EGW connectivity necessity + disconnected witness
+
+**What was added** (KonigsbergOQ03.lean 1186 → 1511 LOC, 0 sorry / 0 axiom):
+
+* `InfiniteGraph.Joined` — finite-chain joinedness (`∃ n f, f 0 = u ∧ f n = v ∧
+  ∀ i < n, adj (f i) (f (i+1))`), with `refl` / `of_adj` / `symm` (chain
+  reversal via `G.symm`) / `trans` (chain concatenation).
+* Walk segments are chains: `InfiniteWalk.joined_of_le` / `joined_vertex` (ℕ)
+  and `BiInfiniteWalk.joined_of_le` / `joined_vertex` (ℤ).
+* **Connectivity necessity, both notions**: a non-isolated vertex appears on
+  any Euler walk (`exists_vertex_eq`, from edge coverage), so
+  `joined_of_hasOneWayEulerPath` / `joined_of_hasInfiniteEulerPath`;
+  contrapositives `not_has{OneWay,Infinite}EulerPath_of_not_joined`; combined
+  headline `connectivity_picture`.
+* **Disconnected witness `twoLinesGraph`** (`m ~ n ↔ |m − n| = 2`; the line
+  graph duplicated on even and odd integers): every vertex has degree 2
+  (`twoLinesGraph_even_ncard_neighbors`), so S14/S15 parity is satisfied
+  everywhere, yet `0` and `1` are not joined (parity invariant
+  `twoLinesGraph_joined_emod`: edges change vertices by ±2, so `% 2` is a
+  component invariant) — hence no Euler path of either kind. Headline
+  `biInfinite_parity_not_sufficient` completes the insufficiency picture:
+  S14's `lineGraph_parity_not_sufficient` covered one-way; this covers
+  bi-infinite.
+
+**Lean idioms:** concatenation `if i ≤ n then f i else g (i − n)` needs
+explicit `show` to beta-reduce before `rw [if_pos/if_neg]`; reversal
+`f (n − i)` needs `n − i − 1 + 1 = n − i` rewritten *in the hypothesis*
+before `G.symm`; `omega` closes `Int.toNat` index goals in the ℤ-segment
+lemma; `rcases h with hs | hs <;> omega` destructures definitional
+adjacency disjunctions of concrete graphs (same trick as `lineGraph`).
+
+**State after S16:** necessity side of EGW now covers **parity (S14/S15) and
+connectivity (S16)** for both path notions, each with witnesses showing
+independence. Remaining elementary rung: **S17 end-structure necessity**
+(one-way Euler path ⟹ at most one "infinite-edge end" survives deleting any
+finite edge set) — needs a finite-edge-deletion subgraph construction, ~1
+session. Beyond that only the blocked routes remain (EGW sufficiency via
+König-lemma compactness, multi-week; r ≥ 3 hypergraph NP-completeness).

--- a/src/data/research/problems/konigsberg-oq-03-wip-01.json
+++ b/src/data/research/problems/konigsberg-oq-03-wip-01.json
@@ -50,7 +50,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: S15 complete — bi-infinite parity necessity: every finite-degree vertex even (no start exception; exact Z-shift pairing), one odd vertex rules out bi-infinite Euler paths, parity re-proof of the S13 ray impossibility, and the combined parity_picture (one-way: odd set subsingleton; bi-infinite: odd set empty). File KonigsbergOQ03.lean 1186 LOC, 0 sorry / 0 axiom. Necessity side of EGW parity now complete for BOTH path notions — natural park point.",
+    "progressSummary": "S16 (researcher-1, 2026-07-24): ACT — EGW connectivity necessity. InfiniteGraph.Joined finite-chain relation with full equivalence-on-support API; walk segments are chains for both index types; connectivity necessity for BOTH path notions (connectivity_picture headline); twoLinesGraph disconnected witness shows the S15 bi-infinite parity condition is NOT sufficient (every vertex even degree, no Euler path), completing the insufficiency picture begun by lineGraph_parity_not_sufficient (S14). File 1511 LOC, 0 sorry / 0 axiom. Necessity side now covers parity AND connectivity for both notions; remaining routes still the blocked pair (EGW sufficiency compactness, r>=3 NP-complete). PROGRESS: S15 complete — bi-infinite parity necessity: every finite-degree vertex even (no start exception; exact Z-shift pairing), one odd vertex rules out bi-infinite Euler paths, parity re-proof of the S13 ray impossibility, and the combined parity_picture (one-way: odd set subsingleton; bi-infinite: odd set empty). File KonigsbergOQ03.lean 1186 LOC, 0 sorry / 0 axiom. Necessity side of EGW parity now complete for BOTH path notions — natural park point.",
     "builtItems": [
       "InfiniteWalk structure in Proofs/KonigsbergOQ03.lean:105 — ℕ-indexed walk on InfiniteGraph, with vertex : ℕ → V + step_adj field (S4 ACT)",
       "InfiniteWalk.sameEdge in Proofs/KonigsbergOQ03.lean:115 — two step indices traverse same undirected edge (S4 ACT)",
@@ -74,7 +74,11 @@
       "not_hasInfiniteEulerPath_rayGraph in KonigsbergOQ03.lean — ray graph has no bi-infinite Euler path (degree-1 vertex argument)",
       "not_hasOneWayEulerPath_lineGraph in KonigsbergOQ03.lean — line graph has no one-way Euler path (unique cut-crossing + confinement + pigeonhole)",
       "not_oneWay_imp_biInfinite / not_biInfinite_imp_oneWay in KonigsbergOQ03.lean — formal incomparability capstones",
-      "KonigsbergOQ03.lean S15 (930->1186 LOC): BiInfiniteWalk.outSteps/inSteps/step_ne/disjoint/image_succ_inSteps, IsBiInfiniteEulerWalk census (ncard_neighbors_eq = 2x, even_ncard_neighbors, infiniteDegree_eq_two_mul), noOddVertex_of_hasInfiniteEulerPath, not_hasInfiniteEulerPath_of_odd_vertex, not_hasInfiniteEulerPath_rayGraph_parity, parity_picture; 0 ax / 0 sorry host-verified v4.31"
+      "KonigsbergOQ03.lean S15 (930->1186 LOC): BiInfiniteWalk.outSteps/inSteps/step_ne/disjoint/image_succ_inSteps, IsBiInfiniteEulerWalk census (ncard_neighbors_eq = 2x, even_ncard_neighbors, infiniteDegree_eq_two_mul), noOddVertex_of_hasInfiniteEulerPath, not_hasInfiniteEulerPath_of_odd_vertex, not_hasInfiniteEulerPath_rayGraph_parity, parity_picture; 0 ax / 0 sorry host-verified v4.31",
+      "S16: InfiniteGraph.Joined + refl/of_adj/symm/trans API (KonigsbergOQ03.lean)",
+      "S16: InfiniteWalk.joined_of_le/joined_vertex, BiInfiniteWalk.joined_of_le/joined_vertex (walk segments are chains, both index types)",
+      "S16: IsEulerWalk.exists_vertex_eq/joined, IsBiInfiniteEulerWalk.exists_vertex_eq/joined, joined_of_hasOneWayEulerPath, joined_of_hasInfiniteEulerPath, not_has{OneWay,Infinite}EulerPath_of_not_joined, connectivity_picture",
+      "S16: twoLinesGraph witness — neighbors/even_ncard/joined_emod parity invariant/not_joined_zero_one, twoLinesGraph_not_has{Infinite,OneWay}EulerPath, biInfinite_parity_not_sufficient"
     ],
     "insights": [
       "**True placeholders are dishonest formalisation**: KonigsbergOQ03.lean has 0 sorries and 0 axioms but until 2026-06-03 had 3 (later 2) :=True propositions, which makes its 0-sorry count misleading. Per CLAUDE.md Aristotle rule #3 (No placeholder True theorems), the same principle applies broadly — True propositions are gaps masquerading as completeness. As of S4 ACT, all 3 are discharged.",
@@ -95,7 +99,10 @@
       "S13: rayGraph and lineGraph now separate HasOneWayEulerPath and HasInfiniteEulerPath in both directions — the number of ends (one vs two) is exactly what distinguishes the two Euler-path notions, the formal core of the EGW picture.",
       "S15 bi-infinite parity: over Z the arrival-shift is EXACT — (.+1) image of inSteps v equals outSteps v with no removed index (the N-indexed census had outSteps minus {0}) — so degree v = 2|outSteps v| and EVERY finite-degree vertex on a bi-infinite Euler walk is even; no start exception exists because there is no start.",
       "Parity now separates the two Euler-path notions quantitatively: one-way allows at most ONE odd finite-degree vertex (S14, the start), bi-infinite allows NONE (S15, parity_picture). One odd vertex kills bi-infinite outright (not_hasInfiniteEulerPath_of_odd_vertex).",
-      "The ray graph impossibility (S13) now has a second independent proof by pure degree counting: vertex 0 has odd degree 1 (not_hasInfiniteEulerPath_rayGraph_parity); S13 went via walk surjectivity onto arcs."
+      "The ray graph impossibility (S13) now has a second independent proof by pure degree counting: vertex 0 has odd degree 1 (not_hasInfiniteEulerPath_rayGraph_parity); S13 went via walk surjectivity onto arcs.",
+      "S16: EGW necessity has a connectivity clause independent of parity — every edge lies on the single Euler walk, so any two non-isolated vertices are joined by a finite chain (a segment of the walk). Formalized via InfiniteGraph.Joined (finite chains f : N -> V with consecutive adjacency).",
+      "S16: twoLinesGraph (m ~ n iff |m-n| = 2; two disjoint lines on even/odd integers) satisfies the S14/S15 parity conditions at EVERY vertex (all degrees 2) yet has no Euler path of either kind — parity invariant u % 2 along chains separates the components. Completes the parity-insufficiency picture: lineGraph covered one-way (S14), twoLinesGraph covers bi-infinite.",
+      "S16 Lean idioms: chain concatenation via if i <= n then f i else g (i - n) with explicit `show` to force beta reduction before rw on if-conditions; chain reversal f (n - i) needs the n-i-1+1 = n-i rewrite before G.symm; omega handles Int.toNat goals in the Z-indexed segment lemma directly."
     ],
     "mathlibGaps": [
       "r-uniform hypergraph type (Mathlib.Combinatorics has nothing).",
@@ -103,9 +110,9 @@
       "Erdős-Grünwald-Weiszfeld (1936) theorem characterising countable-graph Euler paths (the predicates HasInfiniteEulerPath / HasOneWayEulerPath are now defined in this file, but a Mathlib-level statement and proof of EGW remains an open formalisation target)."
     ],
     "nextSteps": [
+      "Optional S17: end-structure necessity — a one-way Euler path forces at most one 'infinite-edge end' after deleting finitely many edges (the remaining elementary EGW necessary condition beyond parity + connectivity); needs a finite-edge-deletion subgraph construction, ~1 session.",
       "EGW sufficiency (Konig lemma compactness) — multi-week, structured blocked route.",
-      "r>=3 hypergraph Euler tours — NP-complete (Lonc-Naroski), blocked route.",
-      "Optional polish: extract the shared census pattern (N and Z) into a single parametrized lemma if a third index type ever appears."
+      "r>=3 hypergraph Euler tours — NP-complete (Lonc-Naroski), blocked route."
     ],
     "progressHistory": [
       {


### PR DESCRIPTION
## Summary
Research session S16 for `konigsberg-oq-03-wip-01`: **EGW connectivity necessity** — the second independent necessary condition in the Erdős–Grünwald–Weiszfeld characterisation, alongside the shipped parity conditions (S14/S15) — plus the disconnected witness completing the parity-insufficiency picture.

## Progress
- `InfiniteGraph.Joined`: finite-chain joinedness with `refl` / `of_adj` / `symm` (chain reversal) / `trans` (chain concatenation) API
- Walk segments are chains for both index types: `InfiniteWalk.joined_of_le` / `joined_vertex` (ℕ), `BiInfiniteWalk.joined_of_le` / `joined_vertex` (ℤ)
- **Connectivity necessity, both notions**: `exists_vertex_eq` (every non-isolated vertex appears on an Euler walk), `joined_of_hasOneWayEulerPath`, `joined_of_hasInfiniteEulerPath`, contrapositive obstructions, and the combined headline `connectivity_picture`
- **`twoLinesGraph` witness** (two disjoint lines on even/odd integers, `m ~ n ↔ |m−n| = 2`): every vertex has even degree — the S15 parity condition holds everywhere — yet no Euler path of either kind exists (`% 2` is a component invariant). Headline `biInfinite_parity_not_sufficient`: with S14's `lineGraph_parity_not_sufficient` (one-way), parity is now shown insufficient for BOTH notions; connectivity enters independently.

`proofs/Proofs/KonigsbergOQ03.lean`: 1186 → 1511 LOC, **0 axioms / 0 sorries**. Docker build GREEN (8576 jobs, v4.31.0).

## Findings
- Connectivity necessity is elementary once walk segments are recognised as chains — no compactness needed on the necessity side.
- Chain concatenation `if i ≤ n then f i else g (i − n)` needs explicit `show` for beta reduction before `rw [if_pos/if_neg]`; reversal needs `n − i − 1 + 1 = n − i` rewritten in the hypothesis before `G.symm`; `omega` closes `Int.toNat` index goals directly.

## Files Modified
- `proofs/Proofs/KonigsbergOQ03.lean` (+325)
- `src/data/research/problems/konigsberg-oq-03-wip-01.json`, `research/problems/konigsberg-oq-03-wip-01/knowledge.md`

## Status
**Outcome**: progress (necessity side now covers parity + connectivity for both path notions, each with independence witnesses)
**Next Steps**: optional S17 end-structure necessity (at most one "infinite-edge end" after finite edge deletion, ~1 session); otherwise only the recorded blocked routes remain (EGW sufficiency compactness, r≥3 NP-complete)

Note: #43261 (S12 ancestor snapshot, CONFLICTING, no unique content) flagged superseded — close blocked in sandbox, supersession comment posted there.

🤖 Generated by researcher-1
