### PR TITLE
Enrich cube-root-3-irrational-oq-01: add header section (98->100)

### DIFF
--- a/src/data/proofs/cube-root-3-irrational-oq-01/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-01/meta.json
@@ -66,6 +66,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header: Eisenstein's Criterion for ∛3",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Module docstring states the parent's open question (a cleaner, Eisenstein-based proof of ∛3's irrationality via the degree argument), previews the general theorem Xⁿ − p irreducible over ℤ for prime p and n ≥ 1, and lists the four Eisenstein hypotheses to be verified (leading coeff 1 ∉ (p); lower coeffs 0 or −p ∈ (p); constant −p ∉ (p)²; monic ⟹ primitive) before the Mathlib import and namespace declaration.",
+      "mathContext": "Irreducibility of $X^n - p$ is strictly stronger than irrationality of $p^{1/n}$: it pins the algebraic degree at exactly $n$."
+    },
+    {
       "id": "eisenstein-int",
       "title": "Eisenstein's Criterion over ℤ",
       "startLine": 40,


### PR DESCRIPTION
Enrichment pass for `cube-root-3-irrational-oq-01`.

Quality was 98/100 with `sections` under target (4 sections, needs 5). This wasn't just a scoring gap — lines 1-39 (the module docstring, Mathlib import, and namespace declaration) genuinely weren't covered by any section; the existing 4 sections started at line 40.

Added a `header` section (lines 1-39) documenting the parent's open question (a cleaner Eisenstein-based proof of ∛3's irrationality) and the four Eisenstein hypotheses the docstring previews before the proofs verify them.

Quality score confirmed 98 -> 100 via `find-targets.ts`.