### PR TITLE
fix: use Edit(/tmp/**) instead of Write(/tmp/**) in permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -92,7 +92,7 @@
       "Bash(shuf:*)",
       "WebSearch",
       "Read(/tmp/**)",
-      "Write(/tmp/**)"
+      "Edit(/tmp/**)"
     ]
   }
 }


### PR DESCRIPTION
Claude Code permission checks match `Edit(path)` rules for all file-editing tools (including Write); a `Write(path)` rule is never matched and silently does nothing.

Swaps the dead `Write(/tmp/**)` allow rule for `Edit(/tmp/**)`. Same change applied across the other repos in `~/GitHub`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)