### PR TITLE
infra: unapplied Terraform skeleton + cost estimate for remote build pool

### DIFF
--- a/infra/remote-build-pool/.gitignore
+++ b/infra/remote-build-pool/.gitignore
@@ -1,0 +1,9 @@
+# Never commit real tfvars, local plugin cache, or state. This directory is an
+# unapplied skeleton (see README.md) — if a human ever does run terraform here, these
+# artifacts must stay untracked.
+terraform.tfvars
+*.tfstate
+*.tfstate.*
+.terraform/
+.terraform.lock.hcl
+crash.log

--- a/infra/remote-build-pool/README.md
+++ b/infra/remote-build-pool/README.md
@@ -1,0 +1,64 @@
+# Remote Build Pool — Terraform Skeleton (UNAPPLIED)
+
+Part of #38684. See `research/remote-build-pool-design.md` for the full design and
+`research/remote-build-pool-cost-estimate.md` for rough cost sizing.
+
+## What this is
+
+A **skeleton, not a deployment.** It declares the two lowest-risk pieces of §10 item 1
+of the design doc — an SQS job queue (+ dead-letter queue) and an S3 result-store bucket
+with a worker IAM role — in Terraform HCL, so a human reviewer can see the intended
+resource shape, tighten it, and decide whether to run it.
+
+**Nothing in this directory has been run.** No `terraform init`, `plan`, or `apply` has
+been executed against any AWS account, by an agent or otherwise. Every resource block is
+marked `# TODO: review before applying`.
+
+## What this is NOT
+
+- Not the AMI / worker launch template (§10 item 2-3 of the design doc — needs the AMI
+  bake step first).
+- Not the ASG / autoscaling policy (§10 item 3 — blocked on the §2 EC2 vCPU quota
+  increase, which has not been requested yet).
+- Not a working pipeline. There is no Lambda, no worker, no consumer wired to the queue.
+  `scripts/remote-build/submit-job.sh` remains dry-run-only and does not point at any
+  queue created from this skeleton.
+
+## Hard safety constraint (do not remove this section)
+
+This is real AWS infrastructure-as-code. Applying it costs money and requires real AWS
+credentials that no agent session in this repository has or should have.
+
+**No agent may run `terraform init`, `terraform plan`, `terraform apply`, or any AWS
+CLI/SDK command against these files.** This directory exists purely for human review.
+A human operator, outside of any agent's autonomy, with their own AWS credentials, is
+responsible for:
+
+1. Reviewing every resource block (they are intentionally conservative but unaudited).
+2. Filling in `terraform.tfvars` (no committed defaults for bucket names / account IDs).
+3. Confirming the §2 EC2 vCPU quota increase has landed if/when the worker fleet
+   (out of scope here) is added on top of this.
+4. Running `terraform init` / `plan` / `apply` themselves, reviewing the plan output
+   before confirming apply.
+
+## Layout
+
+| File | Declares |
+|------|----------|
+| `versions.tf` | Terraform + AWS provider version constraints. No backend configured — a real deployment must add a remote backend (S3 + DynamoDB lock table) before `apply`; local state is not appropriate for shared infra. |
+| `variables.tf` | Inputs: region, project/environment tags, bucket name (no default — must be globally unique), queue name, result retention days. |
+| `sqs.tf` | `remote_build_jobs` queue + `remote_build_jobs_dlq` dead-letter queue. Visibility timeout sized off `per_target_timeout_s` in the job contract (`research/remote-build-pool-design.md` §3). |
+| `s3.tf` | Result-store bucket (job results / diag blocks, §3 and §7 of the design doc) with public access blocked and a lifecycle rule expiring objects after `var.result_retention_days`. |
+| `iam.tf` | `remote_build_worker` IAM role + instance profile: least-privilege SQS receive/delete on the job queue and S3 read/write scoped to the result bucket only. No EC2/ASG/AMI permissions — provisioning the fleet is a separate, later step. |
+| `outputs.tf` | Queue URL/ARN, bucket name/ARN, role/instance-profile ARNs — for wiring into the (not-yet-written) worker launch template. |
+| `terraform.tfvars.example` | Example values. Copy to `terraform.tfvars` (gitignored) and fill in before a human runs `plan`. |
+
+## Estimated cost of *this* skeleton alone
+
+SQS and S3 at rest cost effectively nothing when idle (S3 storage for a handful of small
+JSON result objects; SQS has no idle charge, only per-request pricing). The real cost
+driver is the compute fleet (§10 items 2-3), not these two resources — see
+`research/remote-build-pool-cost-estimate.md` for that estimate. This skeleton could be
+applied in isolation (queue + bucket + IAM role, no compute) for negligible spend if a
+human wanted to unblock later worker development, but that decision is explicitly left
+to a human, not this PR.

--- a/infra/remote-build-pool/iam.tf
+++ b/infra/remote-build-pool/iam.tf
@@ -1,0 +1,69 @@
+# UNAPPLIED SKELETON — see README.md.
+# TODO: review before applying.
+#
+# Least-privilege role for a worker instance: consume jobs from the queue, write
+# results/diag blocks to the result bucket. Deliberately does NOT grant any
+# EC2/ASG/AMI/IAM permissions — provisioning the compute fleet itself is out of scope
+# for this skeleton (see README "What this is NOT") and would need its own, separately
+# reviewed policy.
+
+data "aws_iam_policy_document" "remote_build_worker_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "remote_build_worker" {
+  # TODO: review before applying.
+  name               = "lean-remote-build-worker"
+  assume_role_policy = data.aws_iam_policy_document.remote_build_worker_assume_role.json
+}
+
+data "aws_iam_policy_document" "remote_build_worker_permissions" {
+  statement {
+    sid    = "ConsumeJobQueue"
+    effect = "Allow"
+    actions = [
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+    ]
+    resources = [aws_sqs_queue.remote_build_jobs.arn]
+  }
+
+  statement {
+    sid    = "WriteJobResults"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+    ]
+    resources = ["${aws_s3_bucket.remote_build_results.arn}/*"]
+  }
+
+  statement {
+    sid       = "ListResultBucket"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.remote_build_results.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "remote_build_worker" {
+  # TODO: review before applying.
+  name   = "lean-remote-build-worker-permissions"
+  role   = aws_iam_role.remote_build_worker.id
+  policy = data.aws_iam_policy_document.remote_build_worker_permissions.json
+}
+
+resource "aws_iam_instance_profile" "remote_build_worker" {
+  # TODO: review before applying.
+  name = "lean-remote-build-worker"
+  role = aws_iam_role.remote_build_worker.name
+}

--- a/infra/remote-build-pool/outputs.tf
+++ b/infra/remote-build-pool/outputs.tf
@@ -1,0 +1,31 @@
+# UNAPPLIED SKELETON — see README.md.
+
+output "job_queue_url" {
+  description = "SQS URL a submitter (e.g. a future live mode of scripts/remote-build/submit-job.sh) would send job requests to."
+  value       = aws_sqs_queue.remote_build_jobs.url
+}
+
+output "job_queue_arn" {
+  value = aws_sqs_queue.remote_build_jobs.arn
+}
+
+output "job_queue_dlq_arn" {
+  value = aws_sqs_queue.remote_build_jobs_dlq.arn
+}
+
+output "result_bucket_name" {
+  value = aws_s3_bucket.remote_build_results.bucket
+}
+
+output "result_bucket_arn" {
+  value = aws_s3_bucket.remote_build_results.arn
+}
+
+output "worker_iam_role_arn" {
+  description = "Attach to the (not-yet-declared) worker launch template via worker_instance_profile_name."
+  value       = aws_iam_role.remote_build_worker.arn
+}
+
+output "worker_instance_profile_name" {
+  value = aws_iam_instance_profile.remote_build_worker.name
+}

--- a/infra/remote-build-pool/s3.tf
+++ b/infra/remote-build-pool/s3.tf
@@ -1,0 +1,49 @@
+# UNAPPLIED SKELETON — see README.md.
+# TODO: review before applying.
+#
+# Result store for job outputs (§3 "Response" — results[] per target) and diag blocks
+# (§3 "Two derived artifacts"). The durable copy of pass/fail state is the
+# verify-results.tsv ledger, not this bucket (§7: "the ledger keeps the durable copy"),
+# so this bucket is intentionally short-retention scratch space, not a permanent store.
+
+resource "aws_s3_bucket" "remote_build_results" {
+  # TODO: review before applying. Bucket name must be globally unique; no default is
+  # provided (see variables.tf) so this cannot be applied without a human supplying one.
+  bucket = var.result_bucket_name
+}
+
+resource "aws_s3_bucket_public_access_block" "remote_build_results" {
+  bucket = aws_s3_bucket.remote_build_results.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "remote_build_results" {
+  bucket = aws_s3_bucket.remote_build_results.id
+
+  rule {
+    id     = "expire-job-results"
+    status = "Enabled"
+
+    # Applies to every object in the bucket — this bucket is single-purpose scratch
+    # space for job results/diag blocks, not shared with other data.
+    filter {}
+
+    expiration {
+      days = var.result_retention_days
+    }
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "remote_build_results" {
+  bucket = aws_s3_bucket.remote_build_results.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}

--- a/infra/remote-build-pool/sqs.tf
+++ b/infra/remote-build-pool/sqs.tf
@@ -1,0 +1,30 @@
+# UNAPPLIED SKELETON — see README.md.
+# TODO: review before applying.
+#
+# Job queue + dead-letter queue backing the "Autoscaling approach" diagram in
+# research/remote-build-pool-design.md §6. ASG target-tracking (not declared in this
+# skeleton — see README "What this is NOT") would scale workers on
+# ApproximateNumberOfMessagesVisible against `remote_build_jobs`.
+
+resource "aws_sqs_queue" "remote_build_jobs_dlq" {
+  # TODO: review before applying.
+  name                      = "${var.queue_name}-dlq"
+  message_retention_seconds = 1209600 # 14 days — max SQS allows; give a human time to notice + drain.
+}
+
+resource "aws_sqs_queue" "remote_build_jobs" {
+  # TODO: review before applying.
+  name                       = var.queue_name
+  visibility_timeout_seconds = var.visibility_timeout_seconds
+  message_retention_seconds  = var.message_retention_seconds
+
+  # A job re-delivered `max_receive_count` times (e.g. worker spot-interrupted before
+  # ack) is dead-lettered rather than retried forever. Verification jobs are
+  # deterministic/idempotent (design doc §6 "Idempotency"), so redelivery itself is
+  # safe; the DLQ exists to surface jobs that fail deterministically every time
+  # (a genuinely broken target) rather than let them loop silently.
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.remote_build_jobs_dlq.arn
+    maxReceiveCount     = var.max_receive_count
+  })
+}

--- a/infra/remote-build-pool/terraform.tfvars.example
+++ b/infra/remote-build-pool/terraform.tfvars.example
@@ -1,0 +1,11 @@
+# UNAPPLIED SKELETON — see README.md.
+#
+# Copy to terraform.tfvars (gitignored — do not commit real account-specific values)
+# and fill in before a human runs `terraform plan`. This file is illustrative only;
+# no agent should create or populate a real terraform.tfvars.
+
+aws_region             = "us-west-2"
+environment            = "dev"
+queue_name             = "lean-remote-build-jobs"
+result_bucket_name     = "REPLACE-ME-globally-unique-bucket-name" # e.g. "lean-genius-remote-build-results-<account-id>"
+result_retention_days  = 30

--- a/infra/remote-build-pool/variables.tf
+++ b/infra/remote-build-pool/variables.tf
@@ -1,0 +1,54 @@
+# UNAPPLIED SKELETON — see README.md.
+# TODO: review before applying.
+
+variable "aws_region" {
+  description = "AWS region for the job queue and result store. Graviton (arm64) worker capacity availability should drive this; us-west-2 is used as the default reference region in research/remote-build-pool-design.md §2."
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "environment" {
+  description = "Deployment environment tag (e.g. \"dev\", \"prod\"). Kept separate from Terraform workspaces so a human can decide the isolation strategy at apply time."
+  type        = string
+  default     = "dev"
+}
+
+variable "queue_name" {
+  description = "Name of the SQS job-submission queue (§6 of the design doc)."
+  type        = string
+  default     = "lean-remote-build-jobs"
+}
+
+variable "result_bucket_name" {
+  description = <<-EOT
+    Name of the S3 bucket that stores job results/diag blocks (§3, §7 of the design
+    doc). S3 bucket names are globally unique across ALL AWS accounts, so there is
+    intentionally NO default here — a human must supply a concrete, already-verified-
+    available name in terraform.tfvars before this could ever be applied.
+  EOT
+  type        = string
+}
+
+variable "result_retention_days" {
+  description = "Days to retain job result/diag objects before S3 lifecycle expiration (§7: \"S3 lifecycle: expire job result/diag objects after N days; the ledger keeps the durable copy\")."
+  type        = number
+  default     = 30
+}
+
+variable "visibility_timeout_seconds" {
+  description = "SQS visibility timeout. Must exceed the longest expected per-target build time (per_target_timeout_s in the job contract, §3) so an in-flight job isn't redelivered to a second worker before the first finishes."
+  type        = number
+  default     = 900 # 15 min; comfortably above the design doc's per_target_timeout_s=300 default with headroom for cold-start + queueing.
+}
+
+variable "message_retention_seconds" {
+  description = "How long an undelivered job message stays in the queue before AWS drops it."
+  type        = number
+  default     = 86400 # 1 day
+}
+
+variable "max_receive_count" {
+  description = "Number of delivery attempts before a job message is moved to the dead-letter queue (e.g. spot-interrupted workers that never ack)."
+  type        = number
+  default     = 3
+}

--- a/infra/remote-build-pool/versions.tf
+++ b/infra/remote-build-pool/versions.tf
@@ -1,0 +1,36 @@
+# UNAPPLIED SKELETON — see README.md. Do not run terraform init/plan/apply from an
+# agent session. This file exists for human review only.
+#
+# TODO: review before applying. In particular: add a remote backend (S3 + DynamoDB
+# lock table) before any real `apply` — local state is not appropriate for shared,
+# team-reviewed infrastructure. No backend block is declared here on purpose so this
+# skeleton cannot accidentally initialize local state if someone runs `terraform init`
+# without reading the README first.
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # TODO: review before applying — add a `backend "s3" { ... }` block here, pointing
+  # at a pre-existing state bucket + DynamoDB lock table, before running `apply` for
+  # real. Left unset intentionally.
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = "lean-genius-remote-build-pool"
+      ManagedBy   = "terraform"
+      Issue       = "38684"
+      Environment = var.environment
+    }
+  }
+}

--- a/research/remote-build-pool-cost-estimate.md
+++ b/research/remote-build-pool-cost-estimate.md
@@ -1,0 +1,117 @@
+# Remote Build Pool — Cost Estimate (Illustrative)
+
+Part of #38684. Companion to `research/remote-build-pool-design.md` (architecture) and
+`infra/remote-build-pool/` (unapplied Terraform skeleton for the queue + result store
+only).
+
+**Status: order-of-magnitude only, not verified against current AWS pricing.** Every
+dollar figure below is a rough illustration to help a human decide whether this is worth
+pursuing past the design stage — none of it has been checked against the AWS Pricing
+Calculator or Cost Explorer at the time of writing. Before committing any budget, a
+human should re-price the exact instance types/regions with
+[the AWS Pricing Calculator](https://calculator.aws) — spot prices in particular
+fluctuate continuously and vary by availability zone.
+
+---
+
+## 1. What actually costs money
+
+From the design doc's cost-controls section (§7):
+
+| Component | Cost driver | Idle cost |
+|-----------|-------------|-----------|
+| SQS queue + DLQ (`infra/remote-build-pool/sqs.tf`) | Per-request pricing, no idle charge | ~$0 |
+| S3 result bucket (`infra/remote-build-pool/s3.tf`) | Storage (small JSON objects, `result_retention_days`-bounded) + requests | Negligible (cents/month at this repo's scale) |
+| **Worker compute (not yet declared — §10 items 2-3)** | EC2/spot instance-hours while workers are running | **$0 if scaled to zero** |
+| S3/EFS Mathlib olean cache restore | One-time-per-cold-boot data transfer + storage | Small, amortized across jobs in a wave |
+
+**The compute fleet dominates cost by a wide margin whenever it's running; everything
+else here is close to free.** This is why §7 of the design doc leads with scale-to-zero
+and spot as the two primary cost controls — the queue and bucket in this skeleton are
+not the risk.
+
+---
+
+## 2. Illustrative worker sizing
+
+Per `research/remote-build-pool-design.md` §3, a job's `memory_limit_mb` defaults to
+32768 (32 GiB) — mirroring this repo's own `docker-build.sh` default memory cap
+(`CLAUDE.md`: "Custom limits (defaults: 32GB memory, 60min timeout)"). A worker sized to
+run **one job at a time** needs roughly that much RAM headroom; a worker aiming for
+**N concurrent jobs** (§10's warm-pool concept) needs roughly `N × 32 GiB` plus overhead
+for the OS, Docker, and the read-only Mathlib olean base layer.
+
+| Sizing goal | Illustrative Graviton (arm64) instance class | vCPU | RAM |
+|---|---|---|---|
+| 1 job/instance, memory-comfortable | `r7g.xlarge`-class | 4 | 32 GiB |
+| 1 job/instance, generous headroom | `r7g.2xlarge`-class | 8 | 64 GiB |
+| ~2 jobs/instance (tight; watch for the same OOM pattern §1 of the design doc describes for localhost) | `r7g.4xlarge`-class | 16 | 128 GiB |
+
+The §2 quota wall (documented in the design doc) caps the **Standard** vCPU bucket at 64
+in the account this was scoped against, i.e. at most **~16 concurrent `r7g.xlarge`-class
+workers** (4 vCPU each) until a quota increase lands — well short of "dozens of
+single-proof jobs at once" from the design doc's problem statement. Sizing beyond that
+either needs the quota increase or accepting lower per-worker concurrency within the
+existing 64-vCPU ceiling.
+
+---
+
+## 3. Illustrative per-wave cost shape (NOT verified pricing)
+
+The numbers below are **placeholders for the shape of the calculation only** — do not
+budget against them without re-pricing. As of recent AWS Graviton (r7g family)
+on-demand list pricing, order-of-magnitude figures in `us-west-2` have been in the
+**tens of cents per hour** for `xlarge`-class instances, with **spot typically running
+~60-70% below on-demand** for Graviton (per the design doc §7's "Expect ~60-90% savings
+vs On-Demand on Graviton" — that upper end is optimistic; treat 60-70% as the
+conservative planning assumption).
+
+```
+wave_cost ≈ workers × hours_per_wave × spot_price_per_hour
+
+Illustrative (NOT verified — re-price before using):
+  16 workers × 2 hours × ~$0.10-0.20/hr (spot, r7g.xlarge-class) ≈ $3-6 per wave
+  16 workers × 8 hours × ~$0.10-0.20/hr                          ≈ $13-26 per wave
+```
+
+Compare against: a single always-on r7g.xlarge running 24/7 at the same illustrative
+rate would be on the order of a few dollars a day even before any spot discount — the
+whole point of scale-to-zero (§7) is that a wave-shaped workload like this repo's
+migration burn-down should cost closer to the "per wave" numbers above than to any
+"always-on" number, because the ASG floor is 0 outside active waves.
+
+**Other line items to re-price, not included above:**
+- S3 data transfer for the olean cache restore on cold workers (§5) — depends on cache
+  size (~21 GB per the design doc) and how often workers cold-boot vs. stay warm within
+  a wave.
+- SQS request pricing — negligible at this job volume (well under the free tier for any
+  plausible number of verification jobs this repo would submit).
+- Data transfer out, if results are pulled cross-region — avoidable by keeping the
+  result bucket in the same region as the workers.
+
+---
+
+## 4. Budget-cap mechanism (already specified, not yet built)
+
+Design doc §7 specifies the mechanism, not yet implemented in this skeleton: an AWS
+Budgets alarm + a Lambda that forces ASG max-size to 0 when a monthly cap is breached.
+That Lambda + Budgets alarm is real infrastructure (billing-related IAM permissions) and
+is intentionally **not** included in `infra/remote-build-pool/` yet — it should land
+alongside the ASG itself (§10 item 3), reviewed together as one unit, so the cap is
+never accidentally deployed without the thing it's meant to cap.
+
+---
+
+## 5. Bottom line for a human deciding whether to proceed
+
+- The **queue + result store** in `infra/remote-build-pool/` (this PR) cost effectively
+  nothing to run, even continuously — a human could apply just that piece today with
+  negligible risk if they wanted to unblock worker-side development.
+- The **compute fleet** (not yet declared) is where real spend happens, but only while
+  workers are running — the wave-shaped estimate above (single-digit-to-low-double-digit
+  dollars per wave, order of magnitude) suggests the marginal cost of a migration
+  burn-down wave is small relative to the parking-lot status of this issue, *if* the
+  illustrative pricing holds up under a real AWS Pricing Calculator check.
+- The gating factor remains the **§2 EC2 vCPU quota increase**, which is a human
+  request-and-wait step (hours-to-days for approval), not a coding task — nothing in
+  this repo can accelerate that.

--- a/research/remote-build-pool-design.md
+++ b/research/remote-build-pool-design.md
@@ -225,8 +225,9 @@ Queue-depth-driven, scale-to-zero:
 
 ---
 
-## 9. First increment delivered here
+## 9. Increments delivered so far
 
+**First increment (PR #39070):**
 - This design doc.
 - `scripts/remote-build/submit-job.sh` — a **dry-run-only** stub that builds a spec-conformant
   job request (§3) from a target list + git ref and prints it. It makes **no** AWS calls unless
@@ -234,11 +235,33 @@ Queue-depth-driven, scale-to-zero:
   `curl`s a submit URL you provide; it never provisions infrastructure. Default invocation is a
   pure request-shape preview, safe to run anywhere.
 
+**Second increment:**
+- `infra/remote-build-pool/` — an **unapplied** Terraform skeleton for the queue +
+  result-store half of §10 item 1 (SQS job queue + DLQ, S3 result bucket, worker IAM
+  role/instance profile). No `terraform init`/`plan`/`apply` has been run against it;
+  every resource is marked for human review. See `infra/remote-build-pool/README.md`
+  for the safety constraints on this directory.
+- `research/remote-build-pool-cost-estimate.md` — illustrative (unverified) cost shape
+  for the queue/bucket (near-zero) vs. the not-yet-declared compute fleet (the real cost
+  driver), to help a human scope whether pursuing the remaining §10 items is worthwhile.
+
 ## 10. Follow-up work (kept in #38684 / new issues)
 
-1. Provision SQS queue + result store (S3/DynamoDB) via IaC (Terraform/CDK) — **after** the
-   §2 quota increase lands.
+1. ~~Provision SQS queue + result store (S3/DynamoDB) via IaC (Terraform/CDK)~~ —
+   **skeleton drafted** in `infra/remote-build-pool/` (SQS queue + DLQ, S3 result
+   bucket, worker IAM role). **Unapplied.** Still blocked on the §2 quota increase
+   before it's useful to actually run, and needs human review + a real backend config
+   before any `terraform apply`. See `infra/remote-build-pool/README.md`.
 2. Build & publish `lean4-arm64:v4.31.0` AMI with baked Mathlib source + warm olean cache.
-3. ASG launch template + target-tracking policy (or Karpenter provisioner).
-4. Worker-side result uploader that writes `verify-results.tsv` rows + diag blocks to the store.
-5. Wire `submit-job.sh` to the live endpoint behind `REMOTE_BUILD_LIVE=1`.
+3. ASG launch template + target-tracking policy (or Karpenter provisioner). Would consume
+   `worker_instance_profile_name` from the item-1 skeleton.
+4. Worker-side result uploader that writes `verify-results.tsv` rows + diag blocks to the
+   `result_bucket_name` output from the item-1 skeleton.
+5. Wire `submit-job.sh` to the live endpoint behind `REMOTE_BUILD_LIVE=1`, once a real
+   `job_queue_url` exists to submit against.
+6. Budget-cap Lambda + AWS Budgets alarm (§7) — bundle with item 3, not before, so the
+   cap is never deployed without the fleet it caps. See
+   `research/remote-build-pool-cost-estimate.md` §4.
+
+See `research/remote-build-pool-cost-estimate.md` for an illustrative (unverified) cost
+shape to help scope how much of the remaining work is worth pursuing.


### PR DESCRIPTION
## Summary

Second reviewable increment toward #38684 (remote autoscaling `lake build` pool),
continuing from PR #39070's design doc + dry-run submit stub. Per the issue's hard
safety constraint, this stays entirely in "IaC templates, unapplied" + "docs" territory
— no live AWS resources, no credentials, nothing an agent or CI could accidentally
execute against a real account.

## Changes

- **`infra/remote-build-pool/`** — an **unapplied** Terraform skeleton covering the
  queue + result-store half of design-doc §10 item 1:
  - `sqs.tf` — job queue + dead-letter queue, visibility timeout sized off the job
    contract's `per_target_timeout_s`.
  - `s3.tf` — result-store bucket (job results/diag blocks) with public access blocked,
    SSE, and a lifecycle rule expiring objects after `result_retention_days` (§7 of the
    design doc: "the ledger keeps the durable copy").
  - `iam.tf` — least-privilege worker IAM role/instance profile: SQS receive/delete on
    the job queue, S3 read/write scoped to the result bucket only. No EC2/ASG/AMI
    permissions — provisioning the compute fleet is explicitly out of scope here.
  - `versions.tf`, `variables.tf`, `outputs.tf`, `terraform.tfvars.example`,
    `.gitignore` — supporting skeleton. No backend is configured (so `terraform init`
    can't accidentally create local state that looks like progress), and
    `result_bucket_name` has no default (forces a human to supply a real, verified-
    available bucket name before anything could be planned).
  - Every resource is marked `# TODO: review before applying`. **No agent has run (or
    should run) `terraform init`/`plan`/`apply` against these files** — see
    `infra/remote-build-pool/README.md` for the explicit safety constraints and what
    this skeleton deliberately does *not* cover (AMI, ASG, worker fleet).
- **`research/remote-build-pool-cost-estimate.md`** — illustrative, explicitly
  *unverified* cost shape: the queue/bucket in this PR cost close to nothing even
  running continuously; the not-yet-declared compute fleet is the real cost driver,
  and stays $0 while scaled to zero. Meant to help a human scope whether the remaining
  §10 items are worth pursuing, not to be budgeted against directly.
- **`research/remote-build-pool-design.md`** — updated §9 ("increments delivered so
  far") and §10 (follow-up work) to record this increment and cross-reference the new
  files/outputs (e.g. the ASG item now references `worker_instance_profile_name`).

## Non-goals (explicitly, per the issue)

No AMI bake, no ASG/autoscaling policy, no worker result uploader, no live wiring of
`submit-job.sh`, no budget-cap Lambda. All of that remains in design-doc §10 as
follow-up, gated on a human requesting the AWS EC2 vCPU quota increase documented in
§2 — which is an account-level, human-only action nothing in this repo can do.

## Test plan

- Terraform files hand-reviewed for balanced braces/parens (no `terraform` binary is
  installed in this sandbox, so `terraform validate`/`fmt` could not be run locally —
  flagging this explicitly for the human reviewer to run before ever touching `plan`).
- No gallery data (`src/data/**`, `meta.json`) or application code touched, so
  `pnpm build` / `pnpm lint` are not required for this change; a pre-existing,
  unrelated `pnpm install` failure in this environment (`better-sqlite3` native build
  error under the current Node toolchain) was confirmed unrelated to this PR's
  markdown/HCL-only diff.
- Confirmed no live network/AWS calls are made by anything added here — the only
  scripts touched are documentation and Terraform source files, not executed.

## Scope / issue status

This is scaffolding, not the pool itself — leaving **#38684 open**. Substantial
AWS-specific follow-up remains (AMI bake, ASG, worker uploader, live wiring, budget
Lambda), all tracked in design-doc §10, gated on a human-initiated quota increase.

Part of #38684