### PR TITLE
fix: worktree-root resolver falls back loudly when the resolved root is unreadable (closes #43644)

### DIFF
--- a/scripts/lib/worktree-root.sh
+++ b/scripts/lib/worktree-root.sh
@@ -45,6 +45,23 @@
 #     documented v1 limitation (see the issue), not a bug this helper guards.
 #   - This helper never creates directories; callers `mkdir -p` the parent as
 #     needed (git worktree add creates only the leaf).
+#   - LOCAL DIVERGENCE from the upstream helper (#43644): an override root
+#     that exists but cannot be read (macOS TCC denial on an external volume
+#     returns EPERM from readdir while stat still succeeds) is rejected with
+#     a loud stderr warning and the function falls back to the default root,
+#     instead of letting every agent die mid-session on an unreadable volume.
+
+# _loom_root_unreadable <dir>
+#
+# True (0) iff <dir> exists but its contents cannot be listed. In that state
+# `[[ -d ]]` and `stat` still succeed, so an actual readdir is the only
+# reliable probe. A nonexistent dir returns 1 (not-unreadable): callers may
+# legitimately `mkdir -p` it later.
+_loom_root_unreadable() {
+    local d="$1"
+    [[ -d "$d" ]] || return 1
+    ! command ls "$d" >/dev/null 2>&1
+}
 
 # loom_worktree_root <repo_root>
 #
@@ -56,7 +73,15 @@ loom_worktree_root() {
     # 1. Env var override — highest priority.
     if [[ -n "${LOOM_WORKTREE_ROOT:-}" ]]; then
         if [[ "$LOOM_WORKTREE_ROOT" == /* ]]; then
-            echo "${LOOM_WORKTREE_ROOT%/}/$(basename "$repo_root")"
+            local env_base="${LOOM_WORKTREE_ROOT%/}"
+            local env_resolved
+            env_resolved="$env_base/$(basename "$repo_root")"
+            if _loom_root_unreadable "$env_base" || _loom_root_unreadable "$env_resolved"; then
+                echo "loom_worktree_root: WARNING: worktree root '$env_resolved' exists but is UNREADABLE (EPERM — volume access lost? macOS TCC denial? see #43644); falling back to default $repo_root/.loom/worktrees" >&2
+                echo "$repo_root/.loom/worktrees"
+                return 0
+            fi
+            echo "$env_resolved"
             return 0
         fi
         echo "loom_worktree_root: LOOM_WORKTREE_ROOT must be an absolute path (got: '$LOOM_WORKTREE_ROOT'); falling back to default" >&2
@@ -72,7 +97,15 @@ loom_worktree_root() {
         cfg_root=$(jq -r '.worktree.root? // empty' "$config_file" 2>/dev/null)
         if [[ -n "$cfg_root" ]]; then
             if [[ "$cfg_root" == /* ]]; then
-                echo "${cfg_root%/}/$(basename "$repo_root")"
+                local cfg_base="${cfg_root%/}"
+                local cfg_resolved
+                cfg_resolved="$cfg_base/$(basename "$repo_root")"
+                if _loom_root_unreadable "$cfg_base" || _loom_root_unreadable "$cfg_resolved"; then
+                    echo "loom_worktree_root: WARNING: worktree root '$cfg_resolved' exists but is UNREADABLE (EPERM — volume access lost? macOS TCC denial? see #43644); falling back to default $repo_root/.loom/worktrees" >&2
+                    echo "$repo_root/.loom/worktrees"
+                    return 0
+                fi
+                echo "$cfg_resolved"
                 return 0
             fi
             echo "loom_worktree_root: worktree.root in .loom/config.json must be an absolute path (got: '$cfg_root'); falling back to default" >&2


### PR DESCRIPTION
## Summary

Closes #43644 (criterion 3 — criteria 1 and 2 were resolved on-host, see the issue comment).

On 2026-08-04, /Volumes/Stripe lost read access mid-session: a cached macOS TCC removable-volumes denial for Terminal.app made `readdir()` return EPERM while `stat`/`-d` kept succeeding and the mount stayed healthy. Every fleet agent whose worktree resolved there died mid-session, because nothing in the resolution path can detect this state — a `-d` existence check passes.

## Change

`scripts/lib/worktree-root.sh` gains a `_loom_root_unreadable` probe (an actual `ls` readdir, the only reliable test for this failure mode) and applies it to both override branches (env var and `.loom/config.json`). If the override base or its repo-namespaced subdir exists but cannot be read, the resolver warns loudly on stderr and falls back to the default `$repo_root/.loom/worktrees` instead of handing agents a dead path.

Behavior preserved:
- Default branch (no override): byte-for-byte unchanged.
- Nonexistent override root: passes through unchanged (callers `mkdir -p` later).
- Relative-path rejection: unchanged.

The local divergence from the upstream Loom helper (rjwalters/loom `defaults/scripts/lib/worktree-root.sh`) is documented in the file header; worth upstreaming.

## Testing

Exercised all branches in a bash harness: default, readable override, unreadable namespaced subdir (falls back + warns), nonexistent override (passes through), unreadable override base (falls back + warns), and the live config branch against the restored /Volumes/Stripe (returns `/Volumes/Stripe/lean-genius`). `shellcheck` clean, `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNqnwQi5KJhHV3hpQB1eU1
