### PR TITLE
research(a054656): fix stale tracker status field (issue #41831)

### DIFF
--- a/src/data/research/problems/issue-41831-formalize-oeis-a054656-primes-absent-from-every-di.json
+++ b/src/data/research/problems/issue-41831-formalize-oeis-a054656-primes-absent-from-every-di.json
@@ -1,7 +1,7 @@
 {
   "slug": "issue-41831-formalize-oeis-a054656-primes-absent-from-every-di",
   "title": "OEIS A054656: primes absent from every distinct-prime partition of n (n≥23 ⇒ {n−1,n−4,n−6}∩P)",
-  "status": "in-progress",
+  "status": "completed",
   "phase": "ACT",
   "tier": "B",
   "tractability": 5,


### PR DESCRIPTION
## Summary
- `src/data/research/problems/issue-41831-formalize-oeis-a054656-primes-absent-from-every-di.json` had a stale top-level `status: "in-progress"` even though `currentState.phase` was already `"COMPLETED"` and the formalization merged (PR #42845, 2026-07-24, 0 sorries/0 axioms, gallery entry verified/original).
- The stale non-terminal status caused the local research candidate pool to re-serve this already-finished problem, triggering a spurious `/loom:sweep` re-dispatch against issue #41831 today.
- Fixes the top-level `status` field to `"completed"` to match `currentState.phase` and the terminal-status conventions used elsewhere in this dataset (`grep -l 'phase": "COMPLETED"' src/data/research/problems/*.json` shows `completed` is the standard paired value).

Per CLAUDE.md, math-agent PRs do not carry `loom:review-requested` — the deployer merges these directly.

## Test plan
- [x] Single-field diff, no schema/behavior change to verify beyond JSON validity.