### PR TITLE
aristotle: add submission dedup guard (Part of #43033)

### DIFF
--- a/scripts/aristotle/find-candidates.sh
+++ b/scripts/aristotle/find-candidates.sh
@@ -44,6 +44,16 @@ JOBS_FILE="$PROJECT_ROOT/research/aristotle-jobs.json"
 OPEN_CONJ_REGISTRY="$PROJECT_ROOT/research/open-conjectures.json"
 ARISTOTLE_RUNS_DIR="$PROJECT_ROOT/research/aristotle-runs"
 
+# Repeat-submission dedup guard (issue #43033). A file submitted this many
+# times or more (any status, summed across the whole jobs.json history)
+# without ever reaching "integrated" is a repeat offender: further
+# resubmission is unlikely to make progress and just burns server capacity.
+# This is a backstop independent of get_submitted_files()/get_blocked_files()
+# above, which key off the *current* status of the *most recent* job(s) and
+# can be fooled by a jobs.json history that lost or never recorded
+# intermediate attempts (the root cause of #43006's 90-duplicate incident).
+ARISTOTLE_DEDUP_MAX_ATTEMPTS="${ARISTOTLE_DEDUP_MAX_ATTEMPTS:-3}"
+
 # Parse arguments
 COUNT_ONLY=false
 BEST_N=0
@@ -120,6 +130,23 @@ get_blocked_files() {
     done | sort -u
 }
 
+# Files submitted ARISTOTLE_DEDUP_MAX_ATTEMPTS+ times across all of jobs.json
+# history (any status) with no "integrated" job among them. Excluded from
+# candidate selection regardless of the current-status filters above.
+get_repeat_offender_files() {
+    if [[ ! -f "$JOBS_FILE" ]]; then
+        return
+    fi
+
+    jq -r --argjson max "$ARISTOTLE_DEDUP_MAX_ATTEMPTS" '
+        .jobs
+        | group_by(.file)
+        | map(select(length >= $max and all(.[]; .status != "integrated")))
+        | map(.[0].file)
+        | .[]
+    ' "$JOBS_FILE" 2>/dev/null | xargs -I{} basename {} .lean | sort -u
+}
+
 # Analyze a single file. Returns score -1 for hard rejects.
 # Args: file, tier (0, 1 or 2)
 analyze_file() {
@@ -165,7 +192,8 @@ collect_candidates() {
     local tier="$1"
     local submitted_files="$2"
     local blocked_files="$3"
-    shift 3
+    local repeat_offender_files="$4"
+    shift 4
     local files=("$@")
 
     for file in "${files[@]}"; do
@@ -180,6 +208,12 @@ collect_candidates() {
 
         # Skip if blocked (repeatedly failed, not modified)
         if echo "$blocked_files" | grep -q "^${basename}$"; then
+            continue
+        fi
+
+        # Skip repeat offenders (ARISTOTLE_DEDUP_MAX_ATTEMPTS+ submissions,
+        # never integrated) — see get_repeat_offender_files().
+        if echo "$repeat_offender_files" | grep -q "^${basename}$"; then
             continue
         fi
 
@@ -331,6 +365,9 @@ main() {
     local blocked_files
     blocked_files=$(get_blocked_files)
 
+    local repeat_offender_files
+    repeat_offender_files=$(get_repeat_offender_files)
+
     local candidate_data=()
 
     # Tier 0: StatementOnly files (*StatementOnly.lean) — Harmonic format
@@ -342,7 +379,7 @@ main() {
     if [[ ${#tier0_files[@]} -gt 0 ]]; then
         while IFS= read -r line; do
             [[ -n "$line" ]] && candidate_data+=("$line")
-        done < <(collect_candidates 0 "$submitted_files" "$blocked_files" "${tier0_files[@]}")
+        done < <(collect_candidates 0 "$submitted_files" "$blocked_files" "$repeat_offender_files" "${tier0_files[@]}")
     fi
 
     # Tier 1: Companion files (*Aristotle.lean)
@@ -354,7 +391,7 @@ main() {
     if [[ ${#tier1_files[@]} -gt 0 ]]; then
         while IFS= read -r line; do
             [[ -n "$line" ]] && candidate_data+=("$line")
-        done < <(collect_candidates 1 "$submitted_files" "$blocked_files" "${tier1_files[@]}")
+        done < <(collect_candidates 1 "$submitted_files" "$blocked_files" "$repeat_offender_files" "${tier1_files[@]}")
     fi
 
     # Tier 2: Regular proof files (unless --tier1-only).
@@ -380,7 +417,7 @@ main() {
         if [[ ${#tier2_files[@]} -gt 0 ]]; then
             while IFS= read -r line; do
                 [[ -n "$line" ]] && candidate_data+=("$line")
-            done < <(collect_candidates 2 "$submitted_files" "$blocked_files" "${tier2_files[@]}")
+            done < <(collect_candidates 2 "$submitted_files" "$blocked_files" "$repeat_offender_files" "${tier2_files[@]}")
         fi
     fi
 

--- a/scripts/tests/aristotle-dedup-guard.test.sh
+++ b/scripts/tests/aristotle-dedup-guard.test.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# Guards the repeat-submission dedup guard in
+# scripts/aristotle/find-candidates.sh (get_repeat_offender_files).
+#
+# Root cause (issue #43033): after research/aristotle-jobs.json tracking was
+# lost, the existing "already submitted" filters (which key off the *current*
+# status of the most recent job) had nothing to dedupe against, and the
+# candidate queue re-served the same top files every cycle — 90 of 100
+# recovered projects were duplicate submissions of just three files. This
+# test verifies the independent repeat-offender backstop: a file submitted
+# ARISTOTLE_DEDUP_MAX_ATTEMPTS+ times (any status, summed across all of
+# jobs.json history) with no "integrated" job among them is excluded from
+# candidate selection, regardless of what the status-based filters allow.
+#
+# Run: bash scripts/tests/aristotle-dedup-guard.test.sh
+# Exits non-zero if any assertion fails.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIND_CANDIDATES="$SCRIPT_DIR/../aristotle/find-candidates.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  ok: $1"; ((PASS++)); }
+fail() { echo "  FAIL: $1"; ((FAIL++)); }
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+JOBS_FILE="$TMPDIR_TEST/aristotle-jobs.json"
+
+# Extract get_repeat_offender_files() so it can be sourced in isolation
+# without pulling in main()'s side effects (it invokes `main` unconditionally
+# at the bottom of the real script).
+guard_src="$(awk '
+    /^get_repeat_offender_files\(\) \{/ { capture=1 }
+    capture { print }
+    capture && /^\}$/ { exit }
+' "$FIND_CANDIDATES")"
+
+if [[ -z "$guard_src" ]]; then
+    fail "could not locate get_repeat_offender_files() body in $FIND_CANDIDATES"
+    echo ""
+    echo "PASS=$PASS FAIL=$FAIL"
+    exit 1
+fi
+
+run_guard() {
+    local max="$1"
+    (
+        ARISTOTLE_DEDUP_MAX_ATTEMPTS="$max"
+        eval "$guard_src"
+        get_repeat_offender_files
+    )
+}
+
+# 1) A file submitted 3+ times with no "integrated" job is a repeat offender.
+cat > "$JOBS_FILE" <<'EOF'
+{"jobs": [
+  {"file": "proofs/Proofs/ChebyshevBounds.lean", "status": "failed"},
+  {"file": "proofs/Proofs/ChebyshevBounds.lean", "status": "expired"},
+  {"file": "proofs/Proofs/ChebyshevBounds.lean", "status": "submitted"}
+]}
+EOF
+out="$(run_guard 3)"
+if grep -qx "ChebyshevBounds" <<<"$out"; then
+    pass "3 non-integrated submissions -> flagged as repeat offender"
+else
+    fail "3 non-integrated submissions should be flagged (got: $out)"
+fi
+
+# 2) A file submitted 3+ times that eventually reached "integrated" is NOT
+#    excluded — the whole point of the guard is stopping unproductive churn,
+#    not permanently banning files that did eventually succeed.
+cat > "$JOBS_FILE" <<'EOF'
+{"jobs": [
+  {"file": "proofs/Proofs/SumOfOddsStatementOnly.lean", "status": "failed"},
+  {"file": "proofs/Proofs/SumOfOddsStatementOnly.lean", "status": "expired"},
+  {"file": "proofs/Proofs/SumOfOddsStatementOnly.lean", "status": "integrated"}
+]}
+EOF
+out="$(run_guard 3)"
+if grep -qx "SumOfOddsStatementOnly" <<<"$out"; then
+    fail "a file that eventually integrated must not be a permanent repeat offender (got: $out)"
+else
+    pass "file with an 'integrated' job in its history is never flagged"
+fi
+
+# 3) Below the threshold: 2 submissions with max=3 should not be flagged.
+cat > "$JOBS_FILE" <<'EOF'
+{"jobs": [
+  {"file": "proofs/Proofs/SchroederBernstein.lean", "status": "failed"},
+  {"file": "proofs/Proofs/SchroederBernstein.lean", "status": "expired"}
+]}
+EOF
+out="$(run_guard 3)"
+if [[ -z "$out" ]]; then
+    pass "2 submissions below default threshold (3) -> not flagged"
+else
+    fail "2 submissions should be below threshold (got: $out)"
+fi
+
+# 4) ARISTOTLE_DEDUP_MAX_ATTEMPTS is configurable: lowering it to 2 flags the
+#    same file from case 3.
+out="$(run_guard 2)"
+if grep -qx "SchroederBernstein" <<<"$out"; then
+    pass "ARISTOTLE_DEDUP_MAX_ATTEMPTS=2 flags a file at exactly 2 submissions"
+else
+    fail "ARISTOTLE_DEDUP_MAX_ATTEMPTS=2 should flag 2 submissions (got: $out)"
+fi
+
+# 5) Missing jobs.json -> no repeat offenders, no error.
+rm -f "$JOBS_FILE"
+out="$(run_guard 3)"
+if [[ -z "$out" ]]; then
+    pass "missing jobs.json -> empty result, no error"
+else
+    fail "missing jobs.json should produce empty output (got: $out)"
+fi
+
+echo ""
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Part of #43033 (Aristotle recovery follow-up). This PR closes item 4 (submission dedup guard) with tests; items 1, 2, and 3 are documented below with recommended next steps rather than force-completed, for reasons explained per item.

## Item 4 — submission dedup guard (done)

Root cause of the 90-duplicate incident: after `research/aristotle-jobs.json` tracking was lost, the existing "already submitted" filters (`get_submitted_files`/`get_blocked_files`), which key off the *current* status of the *most recent* job, had nothing to dedupe against.

- Added `get_repeat_offender_files()` to `scripts/aristotle/find-candidates.sh`: a file submitted `ARISTOTLE_DEDUP_MAX_ATTEMPTS`+ times (default 3, any status) across the whole jobs.json history with no `"integrated"` job among them is excluded from candidate selection — independent of, and a backstop for, the current-status filters.
- Verified against the live `research/aristotle-jobs.json`: correctly flags `ChebyshevBounds` and `SchroederBernstein` (the two repeat offenders from the incident) and does not flag `SumOfOddsStatementOnly` (which did eventually integrate).
- The other half of item 4 — excluding 0-sorry files from candidate selection — was already implemented in `collect_candidates()` (`total_sorry -eq 0 → skip`); no change needed there.
- New isolated unit test: `scripts/tests/aristotle-dedup-guard.test.sh` (5/5 passing), independent of the live proof corpus or a running Aristotle pipeline so it stays fast and deterministic. Run: `bash scripts/tests/aristotle-dedup-guard.test.sh`.

## Item 2 — verify SumOfOddsStatementOnly on v4.31 (deferred, not this PR)

Attempted but deferred: the host's Docker daemon was unresponsive (`docker info` timed out) under heavy concurrent load from other Loom sweep workers at the time of this session. Per CLAUDE.md, `lake build` must never run outside the Docker wrapper, so I did not force it. `research/aristotle-jobs.json` already correctly reflects this as `v431_verified: false`, `v431_verification: "pending"` (the script's own documented convention for a skipped gate) — no data was falsely marked verified. Follow-up: `./scripts/aristotle/verify-v431-build.sh Proofs.SumOfOddsStatementOnly` once Docker is healthy.

## Item 1 — triage of recovered results under `research/aristotle-runs/` (reviewed, no integration in this PR)

`research/aristotle-jobs-archive-recovered.json` already carries a full per-project triage classification from the #43006 recovery. I reviewed the 9 files still worth a look and confirmed/extended that record:

- `recovered-212b28eb-...lean` (`TractatusFunctionalCompletenessAristotle`, 0 sorries, self-contained, Mathlib-only) — genuinely new content, **not yet present** in `proofs/Proofs/` (checked: no `TractatusFunctionalCompleteness*` file exists). Ready for a Researcher/Enricher to add as a new proof once a build can be verified.
- `recovered-{1efa3c7d,57df7541,5d77873e,e203a760,298662ff}-...lean` (Tractatus Horn/Totality/NGeneration/Decidability/Expressibility family) — each still carries 1-2 unresolved sorries; these are exploratory leads toward the companion `rjwalters/tractatus` repo, not mergeable as-is. Left for research follow-up.
- `recovered-958405df-...lean` (Vahlen–Capelli) — target theorem `two_power_capelli_neg_square` still sorry; contains proved supporting lemmas (`quad_repr`, `quad_indep`, `descent`, `two_power_irred`). Mathematical-value judgment call for a Researcher, not made here.
- `recovered-3e8027f6-...lean` (trivial `probe_log_mul`) and `recovered-3705d2cc-...lean` (AM-GM OQ02, no improvement over target) — confirmed discardable, no action needed.

I did not add any new `.lean` files to `proofs/Proofs/` in this PR, since Docker was unavailable to verify a build (see item 2) and CLAUDE.md's Axiom Integrity Policy requires careful, verified gallery status assignment that a build failure would undermine.

## Item 3 — restart the live aristotle-agent (operator action, out of scope for a diff)

Not applicable to a code PR — restarting a running process is an operational action for whoever/whatever manages `aristotle-agent`, to be done after this PR merges (`./scripts/aristotle/launch-agent.sh --stop && ./scripts/aristotle/launch-agent.sh`).

## Item 5 — server backlog beyond newest 100

Per the issue body, no action required (submit-batch guard only inspects the newest 100; no overlap with previously downloaded results).

## Test plan

- [x] `bash scripts/tests/aristotle-dedup-guard.test.sh` — 5/5 passing
- [x] `bash -n scripts/aristotle/find-candidates.sh` — syntax OK
- [x] Manual jq check of the new query against the live `research/aristotle-jobs.json` — correctly identifies the two known repeat offenders and does not falsely flag the successfully-integrated file
- [ ] Full `./scripts/aristotle/find-candidates.sh --count` smoke test against the live 6000+ file corpus — started but did not finish within this session due to heavy host I/O contention (many concurrent Loom sweep workers); recommend a reviewer re-run if host load has settled
