### PR TITLE
Fix PreToolUse deny hook over-matching on gh-pr-merge substring

### DIFF
--- a/.loom/hooks/guard-loom-workflow.sh
+++ b/.loom/hooks/guard-loom-workflow.sh
@@ -115,10 +115,177 @@ ask() {
 }
 
 # =============================================================================
-# LOOM: Prefer merge-pr.sh over gh pr merge
+# LOOM: Prefer merge-pr.sh over gh pr merge (issue #43639)
+#
+# Detects a genuine `gh pr merge` INVOCATION -- the phrase anchored at a
+# command position (start of the command string, or immediately after one of
+# the shell command separators ; & && | || $( or a literal newline) -- not a
+# bare substring match anywhere in the command text. The original
+# `grep -qE 'gh\s+pr\s+merge'` matched the phrase ANYWHERE in the command
+# string, so it false-positived on read-only commands that merely MENTION the
+# phrase, e.g.:
+#   grep -n "auto|graphql|gh pr merge|gh api" ./.loom/scripts/merge-pr.sh
+#   echo "=== hook gh pr merge block ==="; gh api 'search/issues?...'
+# Both of those are read-only / unrelated to merging and must pass through
+# unblocked; only an actual `gh pr merge ...` invocation should deny.
+#
+# gh_pr_merge_invocation() runs two passes:
+#
+#   1. mask_heredocs(): a line-oriented pre-pass that blanks out heredoc
+#      BODY lines (e.g. `git commit -m "$(cat <<'EOF' ... EOF)"`, used
+#      constantly for commit messages / PR bodies). Without this, a commit
+#      message that merely prose-mentions "gh pr merge" would itself get
+#      denied, since heredoc body text is otherwise indistinguishable from
+#      real command lines to the per-line scan below (#43639 follow-up: this
+#      was caught by the fix's own commit message during testing). A heredoc
+#      whose delimiter is quoted (<<'EOF'/<<"EOF") never expands $(...) or
+#      backticks, so its body is unconditionally inert; an UNQUOTED
+#      delimiter (<<EOF) still expands substitutions, so a body line
+#      containing $( or a backtick is left in place (not blanked) so a
+#      smuggled `<<EOF` \n `$(gh pr merge 1)` \n `EOF` is still caught below.
+#
+#   2. check(), run per remaining line: a quote-aware command-position
+#      scanner (mirrors the qsplit() quote-tracking approach used for the
+#      same class of bug in guard-destructive.sh, #3755/#71). Each input
+#      line is its own scan (awk's default per-record split on \n already
+#      gives "start of a new line = a command position", which covers plain
+#      multi-line commands); within a line it walks character by character,
+#      tracking whether the current position is a command position (start of
+#      line, or right after ; & && | || $() and whether it is inside a
+#      quoted span. A quoted span with no $( or backtick inside is INERT --
+#      its contents (including any literal "gh pr merge" text used as a grep
+#      pattern or echo label) are skipped entirely and never checked. Only
+#      text sitting at an actual command position is tested against
+#      ^gh[ \t]+pr[ \t]+merge<boundary>. A quoted span that DOES carry a $(
+#      or backtick is walked char-by-char with separators kept active, so a
+#      merge smuggled inside command substitution (e.g.
+#      `echo "$(gh pr merge 1)"`) is still caught. Best-effort/fail-safe: an
+#      unterminated quote treats the remainder as inert text (never
+#      escalates a parse failure into a spurious deny).
 # =============================================================================
 
-if echo "$COMMAND" | grep -qE 'gh\s+pr\s+merge'; then
+gh_pr_merge_invocation() {
+    # Args: <command string>. Echoes "1" if a genuine `gh pr merge` invocation
+    # is found at a command position, "0" otherwise. Portable awk only.
+    printf '%s' "$1" | awk '
+    # Blank heredoc body lines so they cannot manufacture a phantom match or
+    # a phantom command-position boundary in the per-line scan below.
+    BEGIN {
+        SQ = sprintf("%c", 39)
+        DQ = sprintf("%c", 34)
+        in_hd = 0
+        delim = ""
+        quoted = 0
+    }
+    {
+        line = $0
+        if (!in_hd) {
+            idx = index(line, "<<")
+            if (idx > 0) {
+                rest = substr(line, idx + 2)
+                sub(/^-/, "", rest)          # <<- (tab-stripping variant)
+                sub(/^[ \t]+/, "", rest)
+                if (substr(rest, 1, 1) == DQ || substr(rest, 1, 1) == SQ) {
+                    q = substr(rest, 1, 1)
+                    rest2 = substr(rest, 2)
+                    ci = index(rest2, q)
+                    if (ci > 0) {
+                        delim = substr(rest2, 1, ci - 1)
+                        quoted = 1
+                        in_hd = (delim != "")
+                    }
+                } else if (match(rest, /^[A-Za-z_][A-Za-z0-9_]*/)) {
+                    delim = substr(rest, 1, RLENGTH)
+                    quoted = 0
+                    in_hd = 1
+                }
+            }
+            print line
+            next
+        }
+        check_line = line
+        sub(/^[ \t]+/, "", check_line)
+        if (check_line == delim) {
+            in_hd = 0
+            print line
+            next
+        }
+        if (!quoted && (index(line, "$(") > 0 || index(line, "`") > 0)) {
+            print line
+        } else {
+            print ""
+        }
+    }
+    ' | awk '
+    function check(s,    n, i, c, qc, j, ci, inner, at_start, rest, SQ, DQ) {
+        SQ = sprintf("%c", 39)   # single quote
+        DQ = sprintf("%c", 34)   # double quote
+        n = length(s)
+        i = 1
+        at_start = 1
+        while (i <= n) {
+            c = substr(s, i, 1)
+            if (c == DQ || c == SQ) {
+                qc = c
+                ci = 0
+                for (j = i + 1; j <= n; j++) {
+                    if (substr(s, j, 1) == qc) { ci = j; break }
+                }
+                if (ci == 0) {
+                    # Unterminated quote: treat remainder as inert text.
+                    return 0
+                }
+                inner = substr(s, i + 1, ci - i - 1)
+                if (index(inner, "$(") == 0 && index(inner, "`") == 0) {
+                    # Inert quoted span: skip entirely -- its contents are
+                    # argument text (grep pattern, echo label, ...), never a
+                    # command position.
+                    i = ci + 1
+                    at_start = 0
+                    continue
+                }
+                # Carries command substitution: keep separators ACTIVE by
+                # consuming only the opening quote and continuing the scan
+                # char-by-char, so a nested $( is still checked.
+                i++
+                at_start = 0
+                continue
+            }
+            if (c == ";") { at_start = 1; i++; continue }
+            if (c == "&") {
+                at_start = 1
+                if (i < n && substr(s, i + 1, 1) == "&") { i += 2 } else { i++ }
+                continue
+            }
+            if (c == "|") {
+                at_start = 1
+                if (i < n && substr(s, i + 1, 1) == "|") { i += 2 } else { i++ }
+                continue
+            }
+            if (c == "$" && i < n && substr(s, i + 1, 1) == "(") {
+                at_start = 1
+                i += 2
+                continue
+            }
+            if (c == " " || c == "\t") { i++; continue }
+            if (at_start) {
+                rest = substr(s, i)
+                if (rest ~ /^gh[ \t]+pr[ \t]+merge([ \t;&|)<>]|$)/) {
+                    return 1
+                }
+                at_start = 0
+            }
+            i++
+        }
+        return 0
+    }
+    { if (check($0)) found = 1 }
+    END { print (found ? "1" : "0") }
+    '
+}
+
+GH_PR_MERGE_MATCH=$(gh_pr_merge_invocation "$COMMAND" 2>/dev/null) || GH_PR_MERGE_MATCH=""
+if [[ "$GH_PR_MERGE_MATCH" == "1" ]]; then
     # Resolve the merge-pr.sh path for the current repo context. Prefer an
     # in-repo installed copy (./.loom/scripts/merge-pr.sh); fall back to the
     # loom-checkout copy under defaults/scripts/ (via $LOOM_HOME) when the repo

--- a/.loom/scripts/tests/test-guard-hook-schema.sh
+++ b/.loom/scripts/tests/test-guard-hook-schema.sh
@@ -130,6 +130,128 @@ assert_jq_true "$LW_DENY_OUT" '.hookSpecificOutput.hookEventName == "PreToolUse"
     "loom-workflow deny: hookEventName == PreToolUse"
 assert_jq_true "$LW_DENY_OUT" '.hookSpecificOutput.permissionDecision == "deny"' \
     "loom-workflow deny: permissionDecision == deny"
+assert_jq_true "$LW_DENY_OUT" '(.hookSpecificOutput.permissionDecisionReason // "") | contains("merge-pr.sh")' \
+    "loom-workflow deny: reason points at merge-pr.sh"
+echo ""
+
+# ---------------------------------------------------------------------------
+# guard-loom-workflow.sh — precision matching for gh pr merge (issue #43639)
+#
+# The original matcher (`grep -qE 'gh\s+pr\s+merge'`) matched the phrase as a
+# bare substring ANYWHERE in the command, so it false-positived on read-only
+# commands that merely MENTION the phrase (a grep pattern searching for it, an
+# echo section label). These cases assert the fix: the phrase must be
+# anchored at an actual command position to deny; quoted mentions of it must
+# pass through; and a genuine invocation at any command position (start,
+# after ;, after &&, after $() must still be denied.
+# ---------------------------------------------------------------------------
+echo "guard-loom-workflow.sh: precision matching (issue #43639)"
+
+lw_decision() {
+    # Args: <command>. Echoes the permissionDecision, or "allow" if the hook
+    # produced no output (the normal silent-allow contract).
+    local cmd="$1" input out decision
+    input=$(jq -n --arg cmd "$cmd" --arg cwd "$DEFAULTS_DIR" \
+        '{tool_input: {command: $cmd}, cwd: $cwd}')
+    out=$(printf '%s' "$input" | bash "$GUARD_LOOM_WORKFLOW" 2>/dev/null)
+    if [[ -z "$out" ]]; then
+        decision="allow"
+    else
+        decision=$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // "allow"' 2>/dev/null) || decision="<parse-error>"
+    fi
+    printf '%s' "$decision"
+}
+
+assert_lw_decision() {
+    local desc="$1" cmd="$2" expect="$3" got
+    got=$(lw_decision "$cmd")
+    if [[ "$got" == "$expect" ]]; then
+        pass "$desc"
+    else
+        fail "$desc" "expected decision=$expect got=$got; cmd=[$cmd]"
+    fi
+}
+
+# False positive #1 (issue #43639): grep searching for the phrase in the
+# merge script itself must pass through -- it's read-only and never invokes
+# `gh pr merge`.
+assert_lw_decision "grep pattern mentioning the phrase passes through" \
+    'grep -n "auto|graphql|gh pr merge|gh api" ./.loom/scripts/merge-pr.sh' \
+    "allow"
+
+# False positive #2 (issue #43639): an echo section label mentioning the
+# phrase inside a compound command must not block the whole command,
+# including the unrelated gh api call that follows it.
+assert_lw_decision "echo label mentioning the phrase in a compound command passes through" \
+    'echo "=== lean-genius: hook gh pr merge block ==="; gh api "search/issues?q=foo"' \
+    "allow"
+
+# A genuine invocation must still be blocked at every command position named
+# in the acceptance criteria.
+assert_lw_decision "genuine invocation at start of command is still denied" \
+    'gh pr merge 123' \
+    "deny"
+assert_lw_decision "genuine invocation after ; is still denied" \
+    'echo hi; gh pr merge 123' \
+    "deny"
+assert_lw_decision "genuine invocation after && is still denied" \
+    'true && gh pr merge 123' \
+    "deny"
+assert_lw_decision "genuine invocation after \$( is still denied" \
+    'echo "$(gh pr merge 123)"' \
+    "deny"
+
+# A quoted heredoc body (e.g. a commit message built with
+# `git commit -m "$(cat <<'EOF' ... EOF)"`) that merely PROSE-MENTIONS the
+# phrase must pass through -- heredoc body lines are otherwise
+# indistinguishable from real command lines to a per-line scan, and this
+# exact pattern is how this fix's own commit message was almost blocked by
+# an earlier draft of the matcher during development.
+LW_HEREDOC_PROSE=$(cat <<'HDEOF'
+git commit -m "$(cat <<'INNER'
+fix: anchor gh pr merge deny hook to command position, not substring
+INNER
+)"
+HDEOF
+)
+assert_lw_decision "quoted heredoc commit message mentioning the phrase passes through" \
+    "$LW_HEREDOC_PROSE" \
+    "allow"
+
+# A quoted heredoc body that literally contains invocation-looking text is
+# still inert (no expansion happens inside a quoted-delimiter heredoc) and
+# must pass through.
+LW_HEREDOC_LITERAL=$(cat <<'HDEOF'
+cat <<'HD'
+gh pr merge 999
+HD
+HDEOF
+)
+assert_lw_decision "quoted heredoc body containing literal invocation-looking text passes through" \
+    "$LW_HEREDOC_LITERAL" \
+    "allow"
+
+# An UNQUOTED heredoc delimiter still expands $(...) inside its body, so a
+# genuine invocation smuggled that way must still be denied.
+LW_HEREDOC_SMUGGLED=$(cat <<'HDEOF'
+cat <<HD
+$(gh pr merge 123)
+HD
+HDEOF
+)
+assert_lw_decision "unquoted heredoc body with smuggled invocation via \$(...) is still denied" \
+    "$LW_HEREDOC_SMUGGLED" \
+    "deny"
+
+# A genuine invocation on its own line (no heredoc involved) is still denied.
+LW_MULTILINE_GENUINE=$(cat <<'HDEOF'
+echo about to merge
+gh pr merge 123
+HDEOF
+)
+assert_lw_decision "genuine invocation on its own line is still denied" \
+    "$LW_MULTILINE_GENUINE" \
+    "deny"
 echo ""
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`guard-loom-workflow.sh`'s PreToolUse deny hook for the manual `gh pr merge` command matched the phrase as a bare **substring anywhere** in the Bash command string (`grep -qE 'gh\s+pr\s+merge'`), instead of matching an actual command invocation. That over-matched on read-only commands that merely mention the phrase:

1. A `grep` over the merge script itself:
   `grep -n "auto|graphql|gh pr merge|gh api" ./.loom/scripts/merge-pr.sh` → was blocked.
2. An `echo` section label inside a compound command:
   `echo "=== lean-genius: hook gh pr merge block ==="; gh api 'search/issues?...'` → blocked the entire compound command, including the unrelated `gh api` call.

This PR replaces the substring `grep` with a quote-aware, heredoc-aware, command-position scanner (`gh_pr_merge_invocation()`), mirroring the `qsplit()` quote-tracking approach already used for the same class of bug in `guard-destructive.sh` (#3755/#71):

- The phrase only denies when it sits at a genuine **command position** — start of the command/line, or immediately after `;`, `&`, `&&`, `|`, `||`, or `$(`.
- Text inside an **inert quoted span** (no `$(`/backtick inside) — e.g. a `grep` pattern argument or an `echo` label — is skipped entirely and never checked.
- A quoted span that *does* carry `$(`/backtick is scanned with separators kept active, so a merge smuggled via command substitution (e.g. `echo "$(gh pr merge 1)"`) is still caught.
- **Heredoc bodies are masked before scanning.** A quoted-delimiter heredoc (`<<'EOF'`) body is unconditionally inert (matches real bash semantics — no expansion happens inside it), so a commit message or PR body that merely *mentions* the phrase in prose passes through. An unquoted-delimiter heredoc (`<<EOF`) still expands `$(...)`, so a body line containing `$(` or a backtick is left in place and still triggers a deny. This was discovered mid-implementation: this fix's own first commit message (built via `git commit -m "$(cat <<'EOF' ... EOF)"`) tripped the pre-heredoc-fix version of the new matcher, since heredoc body lines were otherwise indistinguishable from real command lines to the per-line scan.
- A genuine `gh pr merge 123` at any of those command positions is still denied with the same `merge-pr.sh` guidance message.

## Test plan

Added regression coverage to `.loom/scripts/tests/test-guard-hook-schema.sh` (`guard-loom-workflow.sh: precision matching (issue #43639)` section) covering:
- [x] Both false-positive repros from the issue now pass through (`allow`)
- [x] A genuine invocation is still denied at every command position named in the acceptance criteria (start, after `;`, after `&&`, after `$(`)
- [x] Quoted-heredoc prose mentioning the phrase passes through
- [x] Quoted-heredoc body literally containing invocation-looking text passes through (inert data, matches bash semantics)
- [x] Unquoted-heredoc body smuggling a real invocation via `$(...)` is still denied
- [x] A genuine invocation on its own line (plain multi-line command, no heredoc) is still denied

Ran `bash .loom/scripts/tests/test-guard-hook-schema.sh`: 20/22 pass. The 2 remaining failures (`guard-destructive.sh: ask decision carries hookEventName`) are pre-existing and unrelated to this change — confirmed present on unmodified `origin/main` inside the same worktree (a worktree-branch-context-dependent flake in a completely different hook file that this PR does not touch).

Closes #43639
