### PR TITLE
Enrich cube-root-2-irrational-oq-05-oq-01: split criterion/irrational-form sections (98->100)

### DIFF
--- a/src/data/proofs/cube-root-2-irrational-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cube-root-2-irrational-oq-05-oq-01/meta.json
@@ -98,9 +98,17 @@
       "id": "criterion",
       "title": "The Rationality Criterion",
       "startLine": 44,
-      "endLine": 81,
-      "summary": "rational_rpow_inv_iff: ¬Irrational (m^(1/n)) ↔ ∃ k, kⁿ = m, and its contrapositive irrational_rpow_inv_iff. The (⇒) direction uses irrational_nrt_of_notint_nrt to force an integer root; (⇐) simplifies (kⁿ)^(1/n) to k.",
+      "endLine": 74,
+      "summary": "rational_rpow_inv_iff: ¬Irrational (m^(1/n)) ↔ ∃ k, kⁿ = m. The (⇒) direction uses irrational_nrt_of_notint_nrt to force an integer root, then non-negativity to lift it to ℕ; (⇐) simplifies (kⁿ)^(1/n) to k via rpow composition.",
       "mathContext": "$m^{1/n} \\in \\mathbb{Q} \\iff \\exists k,\\ k^n = m$."
+    },
+    {
+      "id": "irrational-form",
+      "title": "The Irrationality Form",
+      "startLine": 76,
+      "endLine": 81,
+      "summary": "irrational_rpow_inv_iff: the contrapositive packaging m^(1/n) irrational ↔ m is not a perfect n-th power, obtained from rational_rpow_inv_iff by not_iff_not / not_not — the form applied directly to conclude irrationality from a non-perfect-power radicand.",
+      "mathContext": "$\\mathrm{Irrational}(m^{1/n}) \\iff \\neg\\,\\mathrm{IsPerfectNthPow}(m,n)$."
     },
     {
       "id": "prime-corollary",


### PR DESCRIPTION
## Summary
- `find-targets.ts`'s quality breakdown showed this entry at 98/100, with the only gap in `sections` (8/10, 4 sections — needs 5 for the full 10).
- Annotations already split the rationality-criterion block (lines 44-81) into two natural units: `rational_rpow_inv_iff` (44-74) and its contrapositive `irrational_rpow_inv_iff` (76-81). `sections` lumped both into one "criterion" entry spanning 44-81.
- Split the `sections` entry to match the existing annotation boundary, adding a dedicated "The Irrationality Form" section (76-81). No content deleted; the original section's summary/mathContext were preserved and only trimmed to its half of the range.

## Verification
- `python3 -c "import json; json.load(...)"` — valid JSON
- `npx tsx scripts/gallery/check-meta-size.ts cube-root-2-irrational-oq-05-oq-01` — within all caps
- `npx tsx scripts/enricher/find-targets.ts` — entry no longer appears in the top-10 lowest-quality list (moved to 100/100, off the priority queue)
- Confirmed no duplicate open PR exists for this slug before starting (prior claimed target `combinations-formula-oq-06-oq-02-oq-02` had an open dup, #43605, and was released without changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)