### PR TITLE
Fix: strip Lean comments before counting sorry/axiom in enrich-research (#43651)

### DIFF
--- a/scripts/research/enrich-research.ts
+++ b/scripts/research/enrich-research.ts
@@ -151,6 +151,60 @@ function scanLeanFiles(): Map<string, string> {
 }
 
 /**
+ * Blank out Lean comments while preserving line structure.
+ *
+ * Removes nested `/- ... -/` block comments (including `/-!` doc blocks) and
+ * `--`-to-EOL line comments, replacing their characters with spaces so that
+ * line count and per-line column anchors are preserved. This prevents `sorry`,
+ * `axiom`, etc. mentioned inside comments from being counted as real
+ * declarations (see issue #43651: Sqrt2MinpolyOQ03.lean has 0 real sorries but
+ * 4 `\bsorry\b` hits, all in comments).
+ */
+function stripLeanComments(content: string): string {
+  let result = ''
+  let i = 0
+  let blockDepth = 0
+  const n = content.length
+  while (i < n) {
+    const two = content.substr(i, 2)
+    if (blockDepth === 0) {
+      if (two === '--') {
+        // Line comment: blank to end of line, preserving the newline.
+        while (i < n && content[i] !== '\n') {
+          result += ' '
+          i++
+        }
+        continue
+      }
+      if (two === '/-') {
+        blockDepth++
+        result += '  '
+        i += 2
+        continue
+      }
+      result += content[i]
+      i++
+    } else {
+      if (two === '/-') {
+        blockDepth++
+        result += '  '
+        i += 2
+        continue
+      }
+      if (two === '-/') {
+        blockDepth--
+        result += '  '
+        i += 2
+        continue
+      }
+      result += content[i] === '\n' ? '\n' : ' '
+      i++
+    }
+  }
+  return result
+}
+
+/**
  * Extract metadata from a Lean file.
  */
 function extractLeanMetadata(filePath: string): LeanFileInfo {
@@ -164,7 +218,12 @@ function extractLeanMetadata(filePath: string): LeanFileInfo {
   let defCount = 0
   let sorryCount = 0
 
-  for (const line of lines) {
+  // Count declarations over a comment-stripped copy so that `sorry`/`axiom`
+  // mentioned only in comments are not counted (issue #43651). Line structure
+  // is preserved, so `lineCount` (from `lines`) and column anchors are intact.
+  const codeLines = stripLeanComments(content).split('\n')
+
+  for (const line of codeLines) {
     if (/^(theorem|lemma) /.test(line)) {
       theoremCount++
     }


### PR DESCRIPTION
## Problem

`scripts/research/enrich-research.ts` (`extractLeanMetadata`) counted `sorry` via a bare per-line `/\bsorry\b/g` (and `axiom` via `/^axiom /`) with **no comment stripping**. So `sorry`/`axiom` mentioned inside `/- ... -/` block comments or `--` line comments were counted as real declarations, and the computed `leanFiles` are written back into the research-problem JSON unconditionally.

Concrete regression (found in PR #43409 review): `proofs/Proofs/Sqrt2MinpolyOQ03.lean` has **0 real sorries but 4 `\bsorry\b` hits, all in comments**. The freshly-repaired `sqrt2-minpoly-oq-03.json` correctly records `sorryCount: 0` today, but the next `pnpm build` would overwrite it with `4`, silently re-poisoning the gallery metadata. This is the same comment-false-positive trap already documented for `native_decide` scans.

## Fix

Add `stripLeanComments()` — a nested-block-aware scanner that blanks `/- ... -/` (including `/-!` doc blocks) and `--`-to-EOL comments, replacing their characters with spaces while **preserving newlines** so `lineCount` and per-line column anchors are unchanged. Declaration counting (`theorem`/`axiom`/`def`/`sorry`) now runs over the stripped copy.

## Evidence (before / after)

`proofs/Proofs/Sqrt2MinpolyOQ03.lean`:
- before: `sorryCount = 4` (all comment mentions)
- after:  `sorryCount = 0`  — line count 654 → 654 unchanged

Regression sweep over `proofs/Proofs` (1113 `.lean` files):
- **930** files drop comment-only `sorry` mentions
- **183** files with real code sorries are **unchanged**
- partial reductions confirm precision, e.g. `AbelRuffiniGaloisExtensionsOQ04OQ03.lean` 7 → 3 (keeps the 3 real tactic `sorry`s at lines 165/168/216, drops 4 comment mentions)

## Acceptance criteria
- [x] `sorryCount` for `Sqrt2MinpolyOQ03.lean` computes 0
- [x] Comment-only `axiom` mentions likewise excluded (block-comment `axiom` at col 0 no longer matches)
- [x] Existing counts for files with real sorries unchanged (183 verified intact)

The algorithm was validated directly at runtime (Node) against the real Lean files; no full `pnpm build` was run to avoid regenerating gallery noise.

Closes #43651

🤖 Generated with [Claude Code](https://claude.com/claude-code)
