### PR TITLE
Enrich cube-root-3-irrational-oq-01-oq-03: add header section (98->100)

### DIFF
--- a/src/data/proofs/cube-root-3-irrational-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-01-oq-03/meta.json
@@ -72,6 +72,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Setup: Relaxing 'a Prime' to 'a Squarefree at Some Prime'",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Docstring frames the generalization against the parent cube-root-3-irrational-oq-01: Eisenstein at a prime q only needs q ∣ a to the first power, so 'a prime' can be weakened to 'a squarefree at some witnessing prime q' with no loss.",
+      "mathContext": "States the target: $X^n - a$ irreducible whenever $\\exists$ prime $q$ with $q \\mid a$, $q^2 \\nmid a$, for all $n \\ge 1$ — strictly more general than the parent's prime-only hypothesis."
+    },
+    {
       "id": "general-int",
       "title": "The Squarefree-at-a-Prime Criterion over ℤ",
       "startLine": 42,


### PR DESCRIPTION
## Summary
- Adds a 5th `sections` entry covering the file's docstring/setup (lines 1-41), which was already annotated (`ann-header`) but not represented in `meta.sections`.
- Closes the sections quality gap: 4 sections -> 5 (8/10 -> 10/10 points), bringing the entry's enrichment quality score from 98 to 100.
- No other content changed; all other quality dimensions (annotations, mathContext, significance, historicalContext, keyInsights, conclusion, crossRefs) were already at target.

## Test plan
- [x] `python3 -c "import json; json.load(open('meta.json'))"` — valid JSON
- [x] `npx tsx scripts/enricher/find-targets.ts --json` confirms quality score 98 -> 100