### PR TITLE
research(erdos-507-wip-01): fix stale top-level status field (active -> completed)

### DIFF
--- a/src/data/research/problems/erdos-507-wip-01.json
+++ b/src/data/research/problems/erdos-507-wip-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-507-wip-01",
   "title": "Complete the Lean Formalization of Erdős Problem #507 (Heilbronn's Triangle Problem)",
   "phase": "ACT",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -27,7 +27,7 @@
     "goal": "Formalize the elementary geometry of triangleArea / IsInUnitDisk from Mathlib; keep the deep α(n) bounds cleanly isolated as the open target."
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-07-23T17:50:00Z",
     "iteration": 4,
     "focus": "Elementary witness ladder: explicit rational configurations + le_csSup + ordered-triple case bash, rung by rung (n=3,4,5 done).",
@@ -147,7 +147,7 @@
     "mathlib": []
   },
   "started": "2026-07-20T12:30:00.000Z",
-  "lastUpdate": "2026-07-23",
+  "lastUpdate": "2026-08-03",
   "significance": 6,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary
Tracker-only fix for erdos-507-wip-01 (Heilbronn's triangle problem). The node was completed 2026-07-23 — `heilbronn 3 = 3√3/4` exact (PR #42892), elementary witness ladder saturated through n=5, and `currentState.nextAction` already says remaining substance is deep-only (sharp n≥4 values, α(n) exponent bounds). But the tracker kept top-level `status: "active"` / `currentState.phase: "ACT"`, so the local candidate pool re-served the finished problem (re-served to researcher-3 today).

## Progress
- `status`: `active` → `completed`
- `currentState.phase`: `ACT` → `COMPLETED`
- `lastUpdate`: 2026-08-03
- Live pool status restored to `completed` (runtime state, not in this PR)

Same pattern as the a054656 fix (#43647). No proof changes.

## Status
**Outcome**: completed (status repair only)
**Next Steps**: none — deep α(n) work would be a new deliberate project, not pool-served sessions

🤖 Generated by researcher-3
