### PR TITLE
Enrich de-moivre-oq-06-oq-02: add 5th keyInsight (98->100)

### DIFF
--- a/src/data/proofs/de-moivre-oq-06-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-06-oq-02/meta.json
@@ -68,7 +68,8 @@
       "The blow-up of the pointwise Dirichlet bound at θ ∈ 2πℤ is the only obstruction to uniformity; excising a δ-neighbourhood of the singularities makes the bound uniform with an explicit δ-dependent constant",
       "sin(θ/2) ≥ sin(δ/2) on the arc is an endpoint-minimum fact: sin is concave on [0, π] with equal values sin(δ/2) at the two endpoints δ/2 and π−δ/2 of the half-angle range, so the minimum sits at the boundary",
       "The product identity sin x − sin y = 2 sin((x−y)/2) cos((x+y)/2) turns the monotonicity claim into a sign check on two factors, each pinned nonnegative purely by its argument lying in [0, π/2]",
-      "A single constant C = 1/sin(δ/2) governs both the cosine and sine families at once — the ∃ C, ∀ n θ shape is exactly the uniform-boundedness hypothesis of Dirichlet's test for the convergence of Fourier series"
+      "A single constant C = 1/sin(δ/2) governs both the cosine and sine families at once — the ∃ C, ∀ n θ shape is exactly the uniform-boundedness hypothesis of Dirichlet's test for the convergence of Fourier series",
+      "The constant is asymptotically sharp, not an artifact of a loose estimate: since sin(δ/2) ~ δ/2 as δ → 0⁺, the bound C = 1/sin(δ/2) blows up like 2/δ, quantifying exactly how much room the excised δ-neighbourhood must buy. This is why no finite constant can bound the Dirichlet kernel uniformly over the full punctured domain θ ∈ (0, 2π) — the arc hypothesis 0 < δ ≤ π is not a proof convenience but a genuine mathematical necessity."
     ],
     "prerequisites": [
       "Parent formalization de-moivre-oq-06 (pointwise Dirichlet kernel bounds)",


### PR DESCRIPTION
## Summary
- Adds a 5th `keyInsight` to `de-moivre-oq-06-oq-02`: the uniform constant C = 1/sin(delta/2) is asymptotically sharp, blowing up like 2/delta as delta -> 0+ (since sin(delta/2) ~ delta/2), which is why the arc hypothesis 0 < delta <= pi is a genuine mathematical necessity rather than a proof convenience.
- Closes the file's only remaining quality gap (keyInsights 4->5, quality score 98->100); all other buckets (annotations, mathContext, significance, historicalContext, conclusion, sections, crossRefs) were already at cap.
- File remains well under the 60 KB size guardrail (14.5 KB).

## Test plan
- [x] `python3 -c "import json; json.load(...)"` confirms valid JSON
- [x] `npx tsx scripts/enricher/find-targets.ts` confirms quality score 98 -> 100
- [x] Content is mathematically accurate: verified against the Lean source (`proofs/Proofs/DeMoivreOQ06OQ02.lean`), not invented