### PR TITLE
Research: sperner-ndim-mathlib-oq-02 - general-n Kuhn triangulation PREP layer (S35)

### DIFF
--- a/proofs/Proofs/SpernerFreudenthalNDim.lean
+++ b/proofs/Proofs/SpernerFreudenthalNDim.lean
@@ -1,0 +1,232 @@
+/-
+Copyright (c) 2026 RJ Walters. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: RJ Walters
+-/
+import Mathlib
+
+/-!
+# Kuhn/Freudenthal triangulation of the dilated n-simplex — general-n PREP layer
+
+Groundwork for eliminating the general-`n` `sperner_panchromatic` axiom in
+`SpernerNDimMathlibOQ02.lean` (n = 0, 1, 2 are already axiom-free via
+`SpernerFreudenthalSimplex.lean`).
+
+## Coordinates
+
+We work in *monotone partial-sum coordinates*: the dilated simplex `N·Δⁿ`
+(points `y : Fin (n+1) → ℝ` with `y ≥ 0`, `∑ y = N`) is affinely equivalent
+to the monotone region
+
+    K = { z : Fin n → ℝ  |  0 ≤ z 0 ≤ z 1 ≤ ⋯ ≤ z (n-1) ≤ N }
+
+via partial sums `z i = y 0 + ⋯ + y i` (and back via differences). Lattice
+points of `K` are monotone `z : Fin n → ℕ` with all coordinates `≤ N`
+(`IsGridPt` below).
+
+## Cells
+
+The Kuhn (Freudenthal) triangulation of the cube `[0,N]ⁿ` has top cells
+indexed by a base vertex `b` and a permutation `σ` of `Fin n`, with vertex
+chain
+
+    w 0 = b,   w (i+1) = w i + e_{σ i}
+
+(`kuhnVertex` below; vertex `w i` has incremented exactly the columns `j`
+with `σ⁻¹ j < i`). The induced triangulation of `K` — hence of `N·Δⁿ` —
+consists of exactly those cells whose `n+1` vertices all lie in `K`
+(`IsKuhnCell`).
+
+The main result of this file, `isKuhnCell_iff`, characterizes validity by a
+condition on the base alone (`BaseCompatible`):
+
+    (b, σ) is a cell of K  ↔  every `b j + 1 ≤ N`, and for `j < k`:
+      `b j ≤ b k`, strictly whenever `σ⁻¹ j < σ⁻¹ k`.
+
+Consistency check against the proven n = 2 development
+(`SpernerFreudenthalSimplex.lean`): for `n = 2` the two permutations give
+weakly monotone bases (`σ` with an inversion) and strictly monotone bases
+(`σ = id`) with `b j ≤ N - 1`, i.e. `C(N+1,2) + C(N,2) = N²` cells — exactly
+the Type-1/Type-2 cell count of the proven planar construction.
+
+## Status
+
+PREP layer only: definitions, vertex-chain structure lemmas, and the validity
+characterization, all sorry-free and axiom-free. Pseudomanifold adjacency
+(the pivot rules) and the Sperner parity argument are future sessions; the
+plan is recorded in `research/problems/sperner-ndim-mathlib-oq-02/`.
+-/
+
+namespace SpernerFreudNDim
+
+open Finset
+
+variable {n : ℕ}
+
+/-- Lattice point of the monotone region `K`: a monotone tuple with all
+coordinates `≤ N`. These are the vertices of the induced triangulation of
+the dilated simplex in partial-sum coordinates. -/
+def IsGridPt (N : ℕ) (z : Fin n → ℕ) : Prop :=
+  Monotone z ∧ ∀ j, z j ≤ N
+
+/-- Vertex `i` of the Kuhn cell with base `b` and permutation `σ`:
+`b` plus the sum of the unit vectors `e_{σ 0}, …, e_{σ (i-1)}` — i.e. column
+`j` has been incremented exactly when `σ⁻¹ j < i`. -/
+def kuhnVertex (b : Fin n → ℕ) (σ : Equiv.Perm (Fin n)) (i : Fin (n + 1)) :
+    Fin n → ℕ :=
+  fun j => b j + (if (σ.symm j : ℕ) < (i : ℕ) then 1 else 0)
+
+@[simp] theorem kuhnVertex_zero (b : Fin n → ℕ) (σ : Equiv.Perm (Fin n)) :
+    kuhnVertex b σ 0 = b := by
+  funext j
+  simp [kuhnVertex]
+
+@[simp] theorem kuhnVertex_last (b : Fin n → ℕ) (σ : Equiv.Perm (Fin n)) :
+    kuhnVertex b σ (Fin.last n) = fun j => b j + 1 := by
+  funext j
+  simp [kuhnVertex, Fin.val_last, (σ.symm j).isLt]
+
+/-- The vertex chain increments exactly one coordinate per step: passing from
+vertex `i` to vertex `i+1` adds `1` in column `σ i` and nothing elsewhere. -/
+theorem kuhnVertex_succ_apply (b : Fin n → ℕ) (σ : Equiv.Perm (Fin n))
+    (i : Fin n) (j : Fin n) :
+    kuhnVertex b σ i.succ j
+      = kuhnVertex b σ i.castSucc j + (if j = σ i then 1 else 0) := by
+  by_cases hj : j = σ i
+  · subst hj
+    simp only [kuhnVertex, Equiv.symm_apply_apply, Fin.val_succ,
+      Fin.val_castSucc]
+    rw [if_pos (Nat.lt_succ_self (i : ℕ)), if_neg (lt_irrefl (i : ℕ))]
+    simp
+  · have hne : σ.symm j ≠ i := fun h => hj (by
+      have h' := congrArg σ h
+      simpa using h')
+    have hval : (σ.symm j : ℕ) ≠ (i : ℕ) := fun h => hne (Fin.ext h)
+    simp only [kuhnVertex, Fin.val_succ, Fin.val_castSucc, if_neg hj, add_zero]
+    congr 1
+    by_cases hlt : (σ.symm j : ℕ) < (i : ℕ)
+    · rw [if_pos (by omega), if_pos hlt]
+    · rw [if_neg (by omega), if_neg hlt]
+
+/-- Vertices increase weakly along the chain, coordinatewise. -/
+theorem kuhnVertex_mono (b : Fin n → ℕ) (σ : Equiv.Perm (Fin n))
+    {i i' : Fin (n + 1)} (h : i ≤ i') (j : Fin n) :
+    kuhnVertex b σ i j ≤ kuhnVertex b σ i' j := by
+  have hv : (i : ℕ) ≤ (i' : ℕ) := Fin.le_iff_val_le_val.mp h
+  simp only [kuhnVertex]
+  split_ifs <;> omega
+
+/-- Coordinate sum of vertex `i`: base sum plus `i`. This pins the "level" of
+each vertex and is the engine behind vertex distinctness. -/
+theorem kuhnVertex_sum (b : Fin n → ℕ) (σ : Equiv.Perm (Fin n))
+    (i : Fin (n + 1)) :
+    (∑ j, kuhnVertex b σ i j) = (∑ j, b j) + (i : ℕ) := by
+  have hcomp :
+      (∑ j, (if (σ.symm j : ℕ) < (i : ℕ) then 1 else 0))
+        = ∑ t : Fin n, (if (t : ℕ) < (i : ℕ) then 1 else 0) :=
+    Equiv.sum_comp σ.symm (fun t => if (t : ℕ) < (i : ℕ) then 1 else 0)
+  have hcount :
+      (∑ t : Fin n, (if (t : ℕ) < (i : ℕ) then 1 else 0)) = (i : ℕ) := by
+    rw [Fin.sum_univ_eq_sum_range (fun m => if m < (i : ℕ) then 1 else 0) n]
+    have hgen : ∀ m, (∑ t ∈ Finset.range m, (if t < (i : ℕ) then 1 else 0))
+        = min m (i : ℕ) := by
+      intro m
+      induction m with
+      | zero => simp
+      | succ m ih =>
+        rw [Finset.sum_range_succ, ih]
+        by_cases hm : m < (i : ℕ)
+        · rw [if_pos hm]
+          omega
+        · rw [if_neg hm]
+          omega
+    rw [hgen n]
+    have := i.isLt
+    omega
+  calc (∑ j, kuhnVertex b σ i j)
+      = (∑ j, b j) + ∑ j, (if (σ.symm j : ℕ) < (i : ℕ) then 1 else 0) := by
+        simp [kuhnVertex, Finset.sum_add_distrib]
+    _ = (∑ j, b j) + (i : ℕ) := by rw [hcomp, hcount]
+
+/-- The `n+1` vertices of a Kuhn cell are pairwise distinct. -/
+theorem kuhnVertex_injective (b : Fin n → ℕ) (σ : Equiv.Perm (Fin n)) :
+    Function.Injective (kuhnVertex b σ) := by
+  intro i i' h
+  have hsum := congrArg (fun w => ∑ j, w j) h
+  simp only [kuhnVertex_sum] at hsum
+  exact Fin.ext (by omega)
+
+/-- `(b, σ)` is a cell of the induced triangulation of the monotone region:
+all `n+1` vertices are lattice points of `K`. -/
+def IsKuhnCell (N : ℕ) (b : Fin n → ℕ) (σ : Equiv.Perm (Fin n)) : Prop :=
+  ∀ i, IsGridPt N (kuhnVertex b σ i)
+
+/-- Base-compatibility: the condition on `(b, σ)` alone that characterizes
+cells of `K`. Column bound `b j + 1 ≤ N`, weak monotonicity of the base, and
+*strict* growth on exactly those pairs `j < k` whose increments arrive in
+order (`σ⁻¹ j < σ⁻¹ k`). -/
+def BaseCompatible (N : ℕ) (b : Fin n → ℕ) (σ : Equiv.Perm (Fin n)) : Prop :=
+  (∀ j, b j + 1 ≤ N) ∧
+    ∀ ⦃j k : Fin n⦄, j < k →
+      b j ≤ b k ∧ ((σ.symm j : ℕ) < (σ.symm k : ℕ) → b j + 1 ≤ b k)
+
+/-- **Validity characterization.** `(b, σ)` is a cell of the monotone region
+iff its base is compatible: all the geometry of "every vertex stays monotone
+and bounded" collapses to a finite family of pairwise conditions on `b`
+governed by the inversion pattern of `σ`.
+
+For `n = 2` this recovers the Type-1/Type-2 cell dichotomy of the proven
+planar construction (`σ` with an inversion ⟷ weakly monotone base, `σ`
+without ⟷ strictly monotone base). -/
+theorem isKuhnCell_iff (N : ℕ) (b : Fin n → ℕ) (σ : Equiv.Perm (Fin n)) :
+    IsKuhnCell N b σ ↔ BaseCompatible N b σ := by
+  constructor
+  · intro hcell
+    refine ⟨fun j => ?_, fun j k hjk => ?_⟩
+    · -- column bound, read off at the last vertex where every column has
+      -- been incremented
+      have hb := (hcell (Fin.last n)).2 j
+      simpa using hb
+    · constructor
+      · -- weak monotonicity, read off at vertex 0 (= the base itself)
+        have hb := (hcell 0).1 (le_of_lt hjk)
+        simpa using hb
+      · -- strictness, read off at the vertex just after the `j`-column
+        -- increment (where column `k` has not yet been incremented)
+        intro hσ
+        have hin : (σ.symm j : ℕ) + 1 < n + 1 := by
+          have := (σ.symm j).isLt; omega
+        have hmono := (hcell ⟨(σ.symm j : ℕ) + 1, hin⟩).1 (le_of_lt hjk)
+        simp only [kuhnVertex] at hmono
+        split_ifs at hmono <;> omega
+  · rintro ⟨hbound, hpair⟩ i
+    constructor
+    · -- every vertex is monotone
+      intro j k hjk
+      rcases eq_or_lt_of_le hjk with rfl | hlt
+      · exact le_rfl
+      · obtain ⟨hp1, hp2⟩ := hpair hlt
+        simp only [kuhnVertex]
+        by_cases hj : (σ.symm j : ℕ) < (i : ℕ) <;>
+          by_cases hk : (σ.symm k : ℕ) < (i : ℕ)
+        · rw [if_pos hj, if_pos hk]; omega
+        · -- column `j` incremented, column `k` not yet: the increments
+          -- necessarily arrive in order, so strict growth applies
+          rw [if_pos hj, if_neg hk]
+          have hs := hp2 (by omega)
+          omega
+        · rw [if_neg hj, if_pos hk]; omega
+        · rw [if_neg hj, if_neg hk]; omega
+    · -- every vertex is bounded, via the last vertex
+      intro j
+      have hm := kuhnVertex_mono b σ (Fin.le_last i) j
+      have hl : kuhnVertex b σ (Fin.last n) j = b j + 1 := by simp
+      have hb := hbound j
+      omega
+
+/-- The base of a valid cell is itself a grid point (vertex 0). -/
+theorem IsKuhnCell.base_isGridPt {N : ℕ} {b : Fin n → ℕ}
+    {σ : Equiv.Perm (Fin n)} (h : IsKuhnCell N b σ) : IsGridPt N b := by
+  simpa using h 0
+
+end SpernerFreudNDim

--- a/research/problems/sperner-ndim-mathlib-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-mathlib-oq-02/knowledge.md
@@ -1354,3 +1354,47 @@ the final assembly of `sperner_panchromatic_two`.
    generalization (base + permutation cells, pseudomanifold scales linearly).
 2. The gallery entry meta for sperner-ndim-mathlib-oq-02 is unchanged
    (its leanFile is the OQ02 file, axiom count still 1 — correct).
+
+## Session 2026-08-03 (researcher-3, S35) — general-n Kuhn PREP layer opened
+
+New self-contained file `proofs/Proofs/SpernerFreudenthalNDim.lean` (~230 lines,
+`import Mathlib` only, 0 axioms / 0 sorries, host-verified v4.31: `lake env lean`
+exit 0, `#print axioms` = standard trio on all main theorems).
+
+**Frame.** Monotone partial-sum coordinates: `N·Δⁿ ≅ K = {0 ≤ z₁ ≤ … ≤ zₙ ≤ N}`.
+The general-n triangulation is the restriction of the Kuhn/Freudenthal cube
+triangulation: cells `(b, σ)` with vertex chain `w₀ = b`, `w_{i+1} = w_i + e_{σ i}`
+(`kuhnVertex`), valid iff all `n+1` vertices lie in `K` (`IsKuhnCell`). This
+subsumes the proven n=2 Type-1/Type-2 construction and completely avoids the
+broken constant-miss FreudCell route (Sessions 8–9).
+
+**Main theorem `isKuhnCell_iff`.** Cell validity collapses to a condition on the
+base alone (`BaseCompatible`): `b j + 1 ≤ N` for every column, and for `j < k`
+weak monotonicity `b j ≤ b k`, strict exactly when `σ⁻¹ j < σ⁻¹ k` (increments
+arriving in order force a strict gap). Both directions proved. Consistency: for
+n=2 this yields weakly monotone bases for the inverted permutation and strictly
+monotone bases for `id` — i.e. `C(N+1,2) + C(N,2) = N²` cells, exactly the
+Type-1/Type-2 count of the proven planar development.
+
+**Supporting lemmas.** `kuhnVertex_zero/_last` (chain endpoints), `_succ_apply`
+(one increment per step, in column `σ i`), `_mono` (coordinatewise weak growth),
+`_sum` (coordinate sum of `w_i` = base sum + `i`, via `Equiv.sum_comp`
+reindexing), `_injective` (the n+1 vertices are pairwise distinct — the level
+function the pseudomanifold argument will key on), `IsKuhnCell.base_isGridPt`.
+
+**Also fixed**: stale top-level tracker `status: "blocked"` (S30b relic from
+2026-05-12; obsolete since the v4.31 migration repaired the parent, confirmed
+S33/S34) → `active`.
+
+**Next rungs (in order):** (1) face/adjacency pivot rules — interior facet
+shared by exactly two cells: permutation-swap pivots for interior vertex drops,
+base-shift pivots at chain ends, reflection at the boundary of the monotone
+region; (2) optional `#cells = Nⁿ` sanity count; (3) `AbstractSimplicialData`
+instance + pseudomanifold; (4) Sperner parity + diameter bound; (5) eliminate
+the general-n `sperner_panchromatic` axiom in `SpernerNDimMathlibOQ02.lean`.
+Rung (1) is the next session-sized target.
+
+Lean gotchas this session: `Fin.coe_castSucc` deprecated → `Fin.val_castSucc`;
+after `simp only [..., Equiv.symm_apply_apply]` a `σ i = σ i` if-condition is
+already `True` (use `simp`, not `if_pos rfl`); `Fin.val_mk` unnecessary — simp
+proj-reduction handles `(⟨a, h⟩ : Fin m).val`.

--- a/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "sperner-ndim-mathlib-oq-02",
   "title": "Use Sperner's lemma to prove Brouwer's fixed-point theorem in Lean 4",
   "phase": "BLOCKED",
-  "status": "blocked",
+  "status": "active",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-14",
-    "iteration": 31,
-    "focus": "S30b STATE-SYNC (this PR, researcher-12, 2026-05-14): Docker-baseline of SpernerFreudenthalSimplex.lean on origin/main reveals 100+ errors (capped at 100 by maxErrors; 103 raw records; 56 distinct error lines spanning 73→1093). Parent file silently broken since ~2026-05-08; 20 merged + 3 open (build pending) PRs have accumulated on top of an unbuildable parent. STOP further PREP-on-PREP; ship error inventory for mechanic-agent consumption. No Lean ACT this session. Build log: .loom/logs/researcher-12-sperner-freud-baseline.log. Error inventory in sessions/2026-05-14-s30b-state-sync-...md (top 7 error classes by Mathlib v4.26.0 cause class).",
+    "iteration": 32,
+    "focus": "S35 (researcher-3, 2026-08-03): general-n PREP layer STARTED — new self-contained file SpernerFreudenthalNDim.lean (import Mathlib only). Frame: monotone partial-sum coordinates (N*Delta^n ~ K = {0 <= z_1 <= ... <= z_n <= N}); cells = Kuhn (base b, permutation sigma) chains w_0 = b, w_{i+1} = w_i + e_{sigma(i)} whose n+1 vertices all lie in K. Main theorem isKuhnCell_iff: validity <=> base condition (b j + 1 <= N; b j <= b k for j < k, STRICT exactly when sigma^{-1} j < sigma^{-1} k). Consistency: for n=2 this reproduces the proven Type-1/Type-2 dichotomy and the C(N+1,2)+C(N,2)=N^2 cell count exactly. All host-verified v4.31 (lake env lean exit 0; #print axioms = propext/Classical.choice/Quot.sound). Also fixed the stale top-level status=blocked (from S30b 2026-05-12; obsolete per v4.31 migration, confirmed S33/S34).",
     "blockers": [],
-    "nextAction": "n>=3 Freudenthal generalization in SpernerFreudenthalSimplex.lean; the stale S30b mechanic-repair nextAction is obsolete (parent builds GREEN since v4.31 migration, confirmed S33/S34).",
+    "nextAction": "Next rung of the n>=3 lift, in order: (1) face/adjacency pivot rules for Kuhn cells in K (interior facet shared by exactly 2 cells: permutation-swap pivots for interior drops, base-shift pivots at chain ends, reflection at the monotone-region boundary); (2) counting lemma #cells = N^n (optional sanity); (3) AbstractSimplicialData instance + pseudomanifold; (4) Sperner parity + diameter bound; (5) axiom elimination in SpernerNDimMathlibOQ02.lean. Rung (1) is the next session-sized target.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -55,7 +55,7 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "S34 (2026-07-24, researcher-3): AXIOM-FREE LOW-DIM BROUWER — brouwer_fixed_point_simplex_zero/_one/_two added to SpernerNDimMathlibOQ02.lean (imports SpernerFreudenthalSimplex), deriving Brouwer for Δ⁰/Δ¹/Δ² from the fully proved sperner_panchromatic_zero/_one/_two instead of the general-n axiom. The sperner_panchromatic axiom now only gates n≥3. Remaining value: n≥3 Freudenthal generalization (base + permutation cells), then full axiom elimination.",
+    "progressSummary": "PROGRESS: n=0,1,2 axiom-free (sperner_panchromatic_zero/_one/_two + Brouwer corollaries); general-n sperner_panchromatic axiom gates only n>=3. S35 opened the n>=3 lift: SpernerFreudenthalNDim.lean defines the Kuhn (base, permutation) triangulation of N*Delta^n in monotone coordinates and proves the full cell-validity characterization isKuhnCell_iff (0 ax / 0 sorry, host-verified). Next: adjacency pivot rules, then pseudomanifold, then parity.",
     "builtItems": [
       "InSimplex/supp predicates in SpernerNDimMathlibOQ02.lean",
       "supp_nonempty: support of any simplex point is nonempty (proved, 0 sorry)",
@@ -112,7 +112,8 @@
       "N2DiagFaceCondition section (5 lemmas, 92 lines) in SpernerFreudenthalSimplex.lean: onFaceΔ2_diag, onFaceΔ2_strict_diag, cN2_total_diag_eq, cN2_diag_ne_two, cN2_total_diag_ne_two",
       "satDiag_self_drop_adj_none, satDiag_self_drop_endpoint_indices, satDiag_self_drop_isDoor_iff, lastFace_filter_extract, lastFace_card_eq, lastFace_odd in SpernerFreudenthalSimplex.lean N2LastFaceAssembly",
       "sperner_panchromatic_two fully proved (end of SpernerFreudenthalSimplex.lean, section N2Panchromatic)",
-      "S34: brouwer_fixed_point_simplex_zero/_one/_two + inSimplex_iff_freud in SpernerNDimMathlibOQ02.lean — axiom-free Brouwer for Δ⁰, Δ¹, Δ² (sperner_panchromatic axiom no longer needed for n≤2)"
+      "S34: brouwer_fixed_point_simplex_zero/_one/_two + inSimplex_iff_freud in SpernerNDimMathlibOQ02.lean — axiom-free Brouwer for Δ⁰, Δ¹, Δ² (sperner_panchromatic axiom no longer needed for n≤2)",
+      "SpernerFreudenthalNDim.lean (S35, self-contained, 0 axioms 0 sorries, host-verified v4.31): IsGridPt, kuhnVertex, kuhnVertex_zero/_last/_succ_apply/_mono/_sum/_injective, IsKuhnCell, BaseCompatible, isKuhnCell_iff (full characterization, both directions), IsKuhnCell.base_isGridPt"
     ],
     "insights": [
       "Sperner coloring well-definedness is purely algebraic: if fv_i > v_i for all i in supp(v), then sum fv > sum v = 1, contradiction. Proved using Finset.sum_lt_sum.",
@@ -156,7 +157,10 @@
       "S33: the _hLastFace bijection maps a boundary-door pair (s,k) to the first coordinate of its DROPPED vertex — for saturating-diagonal t1 cells the dropped vertex IS the base b, so p ↦ (vertex p.1 p.2).1 lands on range N with gDiag b.1 ≠ gDiag (b.1+1) exactly at doors",
       "S33: Triangulation.vertex vs AbstractSimplicialData.vertexEnum are defeq but not syntactically equal — rw against a vertex-form goal fails; restate with show in vertexEnum form first",
       "S33: SpernerFreudenthalSimplex had redundant nested namespace re-opens double-namespacing all late declarations; fixed to a single-level namespace running to EOF (all affected lemmas were private, SimplicialAdjFnHelper.* names unchanged)",
-      "S34: The two InSimplex definitions (SpernerBrouwer in OQ02 vs SpernerFreudSimp in SpernerFreudenthalSimplex) are definitionally equal, so the proved sperner_panchromatic_zero/_one/_two plug directly into brouwer_from_panchromatic; only friction is the Nat-cast bound ((n:ℕ):ℝ)/N vs literal (0|1|2:ℝ)/N, closed by simpa"
+      "S34: The two InSimplex definitions (SpernerBrouwer in OQ02 vs SpernerFreudSimp in SpernerFreudenthalSimplex) are definitionally equal, so the proved sperner_panchromatic_zero/_one/_two plug directly into brouwer_from_panchromatic; only friction is the Nat-cast bound ((n:ℕ):ℝ)/N vs literal (0|1|2:ℝ)/N, closed by simpa",
+      "GENERAL-n FRAME (S35): in monotone partial-sum coordinates the dilated simplex N*Delta^n is the region K = {0 <= z_1 <= ... <= z_n <= N}, and the correct general-n triangulation is the restriction of the Kuhn/Freudenthal cube triangulation: cells (b, sigma) whose whole vertex chain stays in K. This subsumes the n=2 Type-1/Type-2 construction and avoids the broken constant-miss FreudCell approach entirely.",
+      "Cell validity collapses to the base (isKuhnCell_iff): (b,sigma) is a cell of K iff b j + 1 <= N for all j and, for j < k, b j <= b k with STRICT inequality exactly when sigma^{-1} j < sigma^{-1} k (increments arriving in order force a strict gap). For n=2 this yields weak bases for the inverted permutation and strict bases for id — i.e. C(N+1,2) + C(N,2) = N^2 cells, matching the proven planar count exactly.",
+      "Vertex-chain structure: w_{i+1} = w_i + e_{sigma(i)} (kuhnVertex_succ_apply), coordinate sum of w_i = sum b + i (kuhnVertex_sum, via Equiv.sum_comp reindexing), hence the n+1 vertices are pairwise distinct (kuhnVertex_injective) — the level function that the eventual pseudomanifold argument will key on."
     ],
     "mathlibGaps": [
       "Grid triangulation of Δⁿ as a CellComplex (needed for sperner_near_fixed_point axiom — significant work ~200 lines)",
@@ -184,7 +188,7 @@
     "mathlib": []
   },
   "started": "2026-05-06T11:50:53.576Z",
-  "lastUpdate": "2026-05-12",
+  "lastUpdate": "2026-08-03",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary
Research session (S35, researcher-3) for sperner-ndim-mathlib-oq-02. Opens the n≥3 lift — the only remaining value on this slug (n=0,1,2 are axiom-free since S33/S34; the general-n `sperner_panchromatic` axiom gates only n≥3).

## Progress
- New self-contained `proofs/Proofs/SpernerFreudenthalNDim.lean` (~230 lines, `import Mathlib` only, **0 axioms / 0 sorries**, host-verified v4.31: `lake env lean` exit 0, `#print axioms` = `[propext, Classical.choice, Quot.sound]` on all main theorems)
- Frame: monotone partial-sum coordinates `N·Δⁿ ≅ K = {0 ≤ z₁ ≤ … ≤ zₙ ≤ N}`; the general-n triangulation is the Kuhn (base, permutation) cube triangulation restricted to cells whose whole vertex chain stays in `K`. This subsumes the proven n=2 Type-1/Type-2 construction and avoids the broken constant-miss FreudCell route (Sessions 8–9) entirely
- Main theorem `isKuhnCell_iff`: cell validity ⟺ base condition alone — column bound `b j + 1 ≤ N`, weakly monotone base, strict growth exactly at pairs whose increments arrive in σ-order (both directions proved)
- Supporting lemmas: chain endpoints, one-increment step (`kuhnVertex_succ_apply`), coordinatewise monotonicity, level function (`kuhnVertex_sum`), vertex distinctness (`kuhnVertex_injective`)
- Tracker: fixed stale top-level `status: "blocked"` (S30b relic from 2026-05-12, obsolete since the v4.31 migration per S33/S34) → `active`; S35 knowledge/state update

## Findings
- Consistency check: for n=2 the characterization yields weakly monotone bases (inverted σ) and strictly monotone bases (σ = id) with the column bound — i.e. `C(N+1,2) + C(N,2) = N²` cells, exactly the Type-1/Type-2 count of the proven planar development. Strong evidence this is the correct generalization
- The level function (vertex coordinate-sum = base sum + chain index) is the invariant the future pseudomanifold argument will key on

## Status
**Outcome**: progress
**Next Steps**: (1) face/adjacency pivot rules (permutation-swap interior pivots, base-shift end pivots, boundary reflection) — next session-sized target; then (2) optional `Nⁿ` cell count, (3) `AbstractSimplicialData` instance + pseudomanifold, (4) Sperner parity + diameter, (5) eliminate the general-n axiom in `SpernerNDimMathlibOQ02.lean`

🤖 Generated by researcher-3
