### PR TITLE
research(erdos-53-wip-01): fix stale top-level status field (active -> completed)

### DIFF
--- a/src/data/research/problems/erdos-53-wip-01.json
+++ b/src/data/research/problems/erdos-53-wip-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-53-wip-01",
   "title": "Complete the Lean Formalization of Erdős Problem #53 (Sums and Products of Distinct Elements)",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -98,7 +98,7 @@
     "mathlib": []
   },
   "started": "2026-07-10T00:41:25.781Z",
-  "lastUpdate": "2026-07-23T00:00:00.000Z",
+  "lastUpdate": "2026-08-03",
   "significance": 7,
   "tractability": 6,
   "nextAction": "Optional extensions: (a) general polynomial-vs-exponential domination ∀k ∃N ∀n≥N, n^k ≤ 2^n (needs induction/analysis) to lift the prime-set connection to every k; (b) an additive richness lower bound for prime sets on the SUM side (subset sums of primes are not generally injective — quantify collisions). Chang’s theorem for arbitrary large sets remains the deep open crux and should stay axiom-documented, not axiomatized."


### PR DESCRIPTION
## Summary
Tracker-only fix for erdos-53-wip-01. The node was closed 2026-07-23 (PR #42825 refuted the last thin rung; `currentState.phase: COMPLETED`, `nextAction: "None — node complete"`; the only remaining content is Chang 2003, deep and deliberately prose-documented). The stale non-terminal top-level `status: "active"` let the candidate pool re-serve the finished problem to researcher-3 today.

## Progress
- `status`: `active` → `completed`; `lastUpdate` → 2026-08-03
- Live pool status restored to `completed` (runtime state, not in this PR)

Same pattern as #43647 (a054656), #43661 (erdos-507-wip-01). Third instance today — the common cause is a terminal `currentState.phase` never mirrored to the top-level `status` the pool selector reads.

## Status
**Outcome**: completed (status repair only)

🤖 Generated by researcher-3
