### PR TITLE
research: sweep 118 stale top-level tracker status fields (-> completed)

### DIFF
--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01.json
@@ -3,7 +3,7 @@
   "title": "Every nontrivial normal subgroup of Aₙ (n≥5) contains a 3-cycle → unconditional Aₙ simplicity",
   "path": "full",
   "phase": "COMPLETED",
-  "status": "in-progress",
+  "status": "completed",
   "tier": "A",
   "significance": 7,
   "tractability": 6,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "abel-ruffini-oq-04-oq-03",
   "title": "Formalize Galois's criterion: a polynomial is solvable by radicals iff its Ga...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/abundant-number-oq-03-oq-03.json
+++ b/src/data/research/problems/abundant-number-oq-03-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "abundant-number-oq-03-oq-03",
   "title": "Infinitely Many Primitive Odd Abundant Numbers",
   "phase": "OBSERVE",
-  "status": "available",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/algebraic-numbers-countable-oq-07.json
+++ b/src/data/research/problems/algebraic-numbers-countable-oq-07.json
@@ -2,7 +2,7 @@
   "slug": "algebraic-numbers-countable-oq-07",
   "title": "Algebraic Numbers Countable: The Algebraic Reals are Lebesgue-Null",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "fast",
   "problemStatement": {

--- a/src/data/research/problems/alternating-series-boole-summation-oq-01-oq-01.json
+++ b/src/data/research/problems/alternating-series-boole-summation-oq-01-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "alternating-series-boole-summation-oq-01-oq-01",
   "title": "The Order-K Boole Summation Limit: Alternating-Series Remainder via Higher Forward Differences",
   "phase": "COMPLETED",
-  "status": "available",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03",
   "title": "Prove the general recurrence inductively without Mathlib, as an independent v...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "amgm-inequality-oq-03-oq-02-oq-01-oq-01",
   "title": "Unify three power mean monotonicity cases into single theorem",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "amgm-inequality-oq-04-oq-03",
   "title": "Gauss AGM Theorem via Hypergeometric Elliptic Integral Identity",
   "phase": "ACT",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "fast",
   "problemStatement": {

--- a/src/data/research/problems/angle-trisection-oq-02-oq-04.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-04.json
@@ -2,7 +2,7 @@
   "slug": "angle-trisection-oq-02-oq-04",
   "title": "Can the hierarchy of constructibility criteria be formalized end-to-end in Le...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "area-of-circle-oq-03-oq-03",
   "title": "Can the method of exhaustion be generalized to other curves (ellipses, parabo...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/bezout-identity-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-02-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "bezout-identity-oq-01-oq-02-oq-02",
   "title": "Transitivity of SLₙ(ℤ) on Primitive Vectors",
   "phase": "ACT",
-  "status": "in-progress",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/binary-gcd-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "binary-gcd-oq-01",
   "title": "binary-gcd-oq-01",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "fast",
   "problemStatement": {

--- a/src/data/research/problems/binary-gcd-oq-03-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "binary-gcd-oq-03-oq-01",
   "title": "Lehmer GCD Correctness and Termination",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "binomial-theorem-oq-02-oq-01-oq-01-oq-01",
   "title": "Can the Fintype instance for Composition be proved efficiently using piAntidiag",
   "phase": "NEW",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "binomial-theorem-oq-02-oq-01",
   "title": "Can the multinomial distribution and its moment-generating function be formal...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/birthday-problem-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-02-oq-01-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "birthday-problem-oq-02-oq-01-oq-01",
   "title": "Sharper Birthday Bound via Higher-Order Taylor Expansion",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "fast",
   "problemStatement": {

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "borsuk-ulam-oq-02-oq-01-oq-01-oq-02",
   "title": "Exotic G-Representations with Strictly Higher Equivariant Borsuk-Ulam Dimension",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "borsuk-ulam-oq-02-oq-02",
   "title": "For compact Lie groups (SO(n), U(n)): do equivariant maps between representat...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/bounded-prime-gaps-oq-04-oq-02.json
+++ b/src/data/research/problems/bounded-prime-gaps-oq-04-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "bounded-prime-gaps-oq-04-oq-02",
   "title": "What is the minimal set of Mathlib additions needed for BV",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/bounded-prime-gaps-oq-05.json
+++ b/src/data/research/problems/bounded-prime-gaps-oq-05.json
@@ -2,7 +2,7 @@
   "slug": "bounded-prime-gaps-oq-05",
   "title": "Firoozbakht's Conjecture: p_n^{1/n} Strictly Decreasing",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/buffons-needle-oq-01-oq-02.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "buffons-needle-oq-01-oq-02",
   "title": "Buffon's Needle Higher-Dimensional: Hyperplane Arrangements",
   "phase": "ACT",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/casting-out-nines.json
+++ b/src/data/research/problems/casting-out-nines.json
@@ -2,7 +2,7 @@
   "slug": "casting-out-nines",
   "title": "Casting Out Nines — n Is Congruent to Its Digit Sum mod 9",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "fast",
   "problemStatement": {

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "cayley-hamilton-minpoly-oq-02-oq-02",
   "title": "Counterexample: Same Minpoly and Charpoly, Not Similar",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "cayley-hamilton-minpoly-oq-05-oq-01-oq-02",
   "title": "What is the measure of cyclic vectors",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "fast",
   "problemStatement": {

--- a/src/data/research/problems/cevas-theorem-non-euclidean-oq-02.json
+++ b/src/data/research/problems/cevas-theorem-non-euclidean-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "cevas-theorem-non-euclidean-oq-02",
   "title": "Menelaus Theorem in Non-Euclidean Geometry",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/chebyshev-sum-inequality-oq-01-oq-03.json
+++ b/src/data/research/problems/chebyshev-sum-inequality-oq-01-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "chebyshev-sum-inequality-oq-01-oq-03",
   "title": "Continuous (Integral) Chebyshev Sum Inequality for Monotone Functions",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/chinese-remainder-constructive-oq-01.json
+++ b/src/data/research/problems/chinese-remainder-constructive-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "chinese-remainder-constructive-oq-01",
   "title": "What are the best algorithms for computing Bezout coefficients in multi-preci...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/chinese-remainder-constructive-oq-04-oq-04.json
+++ b/src/data/research/problems/chinese-remainder-constructive-oq-04-oq-04.json
@@ -2,7 +2,7 @@
   "slug": "chinese-remainder-constructive-oq-04-oq-04",
   "title": "Extend CRT to produce minimal non-negative solution",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/chinese-remainder-non-coprime-oq-04.json
+++ b/src/data/research/problems/chinese-remainder-non-coprime-oq-04.json
@@ -2,7 +2,7 @@
   "slug": "chinese-remainder-non-coprime-oq-04",
   "title": "Dirichlet approximation and lattice consequences",
   "phase": "NEW",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/combinations-formula-oq-02.json
+++ b/src/data/research/problems/combinations-formula-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "combinations-formula-oq-02",
   "title": "Combinations Formula: Connections to Catalan Numbers and Combinatorial Sequences",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/desargues-theorem-oq-02-oq-02.json
+++ b/src/data/research/problems/desargues-theorem-oq-02-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "desargues-theorem-oq-02-oq-02",
   "title": "Can we formalize the self-duality property of Desargues's theorem explicitly?",
   "phase": "ORIENT",
-  "status": "blocked",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-02.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "descartes-rule-of-signs-oq-01-oq-02",
   "title": "Minimal Infrastructure for Descartes Parity",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/descartes-rule-of-signs-oq-04.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-04.json
@@ -2,7 +2,7 @@
   "slug": "descartes-rule-of-signs-oq-04",
   "title": "Can the algebraic proof (without Rolle's theorem, using only polynomial divis...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/dirichlets-theorem-oq-02-wip-01.json
+++ b/src/data/research/problems/dirichlets-theorem-oq-02-wip-01.json
@@ -2,7 +2,7 @@
   "slug": "dirichlets-theorem-oq-02-wip-01",
   "title": "Complete Infinitely Many Primes ≡ 3 (mod 4)",
   "phase": "NEW",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "elementary-quadratic-reciprocity-oq-03-oq-02-oq-01",
   "title": "Prove multiplicativity from the definition",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "fast",
   "problemStatement": {

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-oq-03.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "elementary-quadratic-reciprocity-oq-03-oq-02-oq-03",
   "title": "Formalize generalized quadratic reciprocity for fundamental discriminants (kr...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-03.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "elementary-quadratic-reciprocity-oq-03-oq-03",
   "title": "Jacobi-Hilbert symbol connection and local-global principles",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "currentState": {
     "phase": "COMPLETED",

--- a/src/data/research/problems/erdos-1000-oq-01.json
+++ b/src/data/research/problems/erdos-1000-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-1000-oq-01",
   "title": "Explicit Haight-type sequences construction",
   "phase": "NEW",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-1006-oq-03.json
+++ b/src/data/research/problems/erdos-1006-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "erdos-1006-oq-03",
   "title": "Grötzsch graph constructive formalization (eliminate axiom)",
   "phase": "NEW",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-1010-oq-03.json
+++ b/src/data/research/problems/erdos-1010-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "erdos-1010-oq-03",
   "title": "Can the stability method yield effective bounds on how structurally close a n...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-1014-oq-01.json
+++ b/src/data/research/problems/erdos-1014-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-1014-oq-01",
   "title": "Prove R(3,l+1)/R(3,l) → 1 using recurrence + lower bound",
   "phase": "ACT",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-1014-oq-03.json
+++ b/src/data/research/problems/erdos-1014-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "erdos-1014-oq-03",
   "title": "Does R(k,l+1) - R(k,l) have a meaningful asymptotic formula for fixed k",
   "phase": "ACT",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-1021-oq-01-incomplete-01.json
+++ b/src/data/research/problems/erdos-1021-oq-01-incomplete-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-1021-oq-01-incomplete-01",
   "title": "Extremal Numbers for G_k: ex(n,G_k) = o(n^{3/2})",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-103-oq-02.json
+++ b/src/data/research/problems/erdos-103-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "erdos-103-oq-02",
   "title": "Is h(n) ≥ 2 for all sufficiently large n",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-1039-oq-05.json
+++ b/src/data/research/problems/erdos-1039-oq-05.json
@@ -2,7 +2,7 @@
   "slug": "erdos-1039-oq-05",
   "title": "How does ρ(f) relate to the transfinite diameter of the root set and to the logarithmic capacity of the lemniscate complement?",
   "phase": "ACT",
-  "status": "blocked",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-1047-oq-01.json
+++ b/src/data/research/problems/erdos-1047-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-1047-oq-01",
   "title": "What is the maximum number of non-convex components for degree d polynomials",
   "phase": "NEW",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-1059-oq-01.json
+++ b/src/data/research/problems/erdos-1059-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-1059-oq-01",
   "title": "What is the density of primes satisfying the factorial-subtraction property a...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-1059.json
+++ b/src/data/research/problems/erdos-1059.json
@@ -2,7 +2,7 @@
   "slug": "erdos-1059",
   "title": "Erdős #1059",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-1061.json
+++ b/src/data/research/problems/erdos-1061.json
@@ -2,7 +2,7 @@
   "slug": "erdos-1061",
   "title": "Erdős #1061",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-1063-oq-01.json
+++ b/src/data/research/problems/erdos-1063-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-1063-oq-01",
   "title": "Is $n_k$ polynomial in $k$",
   "phase": "COMPLETED",
-  "status": "in-progress",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-1092.json
+++ b/src/data/research/problems/erdos-1092.json
@@ -2,7 +2,7 @@
   "slug": "erdos-1092",
   "title": "Erdos 1092 chromatic decomposition threshold",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-1105.json
+++ b/src/data/research/problems/erdos-1105.json
@@ -2,7 +2,7 @@
   "slug": "erdos-1105",
   "title": "Erdős #1105",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-1107-oq-02.json
+++ b/src/data/research/problems/erdos-1107-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "erdos-1107-oq-02",
   "title": "Effective Squareful Sum Threshold",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-1126-oq-01.json
+++ b/src/data/research/problems/erdos-1126-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-1126-oq-01",
   "title": "Can the de Bruijn-Jurkat theorem be extended to other functional equations, s...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-1140.json
+++ b/src/data/research/problems/erdos-1140.json
@@ -2,7 +2,7 @@
   "slug": "erdos-1140",
   "title": "Erdos 1140 quadratic prime-shift finiteness",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-117-oq-01-incomplete-01.json
+++ b/src/data/research/problems/erdos-117-oq-01-incomplete-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-117-oq-01-incomplete-01",
   "title": "Complete proof of Exponential Growth Rate of the Abelian Covering Number",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-131-incomplete-01.json
+++ b/src/data/research/problems/erdos-131-incomplete-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-131-incomplete-01",
   "title": "Erdős #131: Non-Dividing Sets",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "currentState": {
     "phase": "COMPLETED",

--- a/src/data/research/problems/erdos-153.json
+++ b/src/data/research/problems/erdos-153.json
@@ -2,7 +2,7 @@
   "slug": "erdos-153",
   "title": "Erdős #153",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-156-oq-02.json
+++ b/src/data/research/problems/erdos-156-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "erdos-156-oq-02",
   "title": "Greedy Sidon construction size lower bound",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-156.json
+++ b/src/data/research/problems/erdos-156.json
@@ -2,7 +2,7 @@
   "slug": "erdos-156",
   "title": "Erdős #156",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-159.json
+++ b/src/data/research/problems/erdos-159.json
@@ -2,7 +2,7 @@
   "slug": "erdos-159",
   "title": "Erdős #159",
   "phase": "OBSERVE",
-  "status": "in-progress",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-165-incomplete-01.json
+++ b/src/data/research/problems/erdos-165-incomplete-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-165-incomplete-01",
   "title": "Complete proof of Erd\u0151s Problem #165: Asymptotic Formula for R(3,k)",
   "phase": "NEW",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-196.json
+++ b/src/data/research/problems/erdos-196.json
@@ -2,7 +2,7 @@
   "slug": "erdos-196",
   "title": "Erdos #196",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-202-incomplete-01.json
+++ b/src/data/research/problems/erdos-202-incomplete-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-202-incomplete-01",
   "title": "Complete proof of Erdos #202: Disjoint Covering Systems",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "fast",
   "problemStatement": {

--- a/src/data/research/problems/erdos-260-incomplete-01.json
+++ b/src/data/research/problems/erdos-260-incomplete-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-260-incomplete-01",
   "title": "Erdős #260: Irrationality of Sparse Sequence Series",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "currentState": {
     "phase": "COMPLETED",

--- a/src/data/research/problems/erdos-263-wip-01.json
+++ b/src/data/research/problems/erdos-263-wip-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-263-wip-01",
   "title": "Erdős #263: Irrationality Sequences (WIP)",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "currentState": {
     "phase": "COMPLETED",

--- a/src/data/research/problems/erdos-265.json
+++ b/src/data/research/problems/erdos-265.json
@@ -2,7 +2,7 @@
   "slug": "erdos-265",
   "title": "Erdős #265",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-27.json
+++ b/src/data/research/problems/erdos-27.json
@@ -2,7 +2,7 @@
   "slug": "erdos-27",
   "title": "Erdős #27: Almost Covering Systems",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-31.json
+++ b/src/data/research/problems/erdos-31.json
@@ -2,7 +2,7 @@
   "slug": "erdos-31",
   "title": "Erdos #31",
   "phase": "ACT",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-332.json
+++ b/src/data/research/problems/erdos-332.json
@@ -2,7 +2,7 @@
   "slug": "erdos-332",
   "title": "Erdős #332",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-347.json
+++ b/src/data/research/problems/erdos-347.json
@@ -2,7 +2,7 @@
   "slug": "erdos-347",
   "title": "Erdős #347",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-361.json
+++ b/src/data/research/problems/erdos-361.json
@@ -2,7 +2,7 @@
   "slug": "erdos-361",
   "title": "Erdős #361",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-363-incomplete-01.json
+++ b/src/data/research/problems/erdos-363-incomplete-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-363-incomplete-01",
   "title": "Erdős #363: Square Products from Disjoint Intervals",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "currentState": {
     "phase": "COMPLETED",

--- a/src/data/research/problems/erdos-389.json
+++ b/src/data/research/problems/erdos-389.json
@@ -2,7 +2,7 @@
   "slug": "erdos-389",
   "title": "Erdos #389",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-390.json
+++ b/src/data/research/problems/erdos-390.json
@@ -2,7 +2,7 @@
   "slug": "erdos-390",
   "title": "Erdős #390",
   "phase": "ACT",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-402-incomplete-01.json
+++ b/src/data/research/problems/erdos-402-incomplete-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-402-incomplete-01",
   "title": "Complete proof of Graham's GCD Conjecture",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "fast",
   "problemStatement": {

--- a/src/data/research/problems/erdos-404.json
+++ b/src/data/research/problems/erdos-404.json
@@ -2,7 +2,7 @@
   "slug": "erdos-404",
   "title": "Erdős #404",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-45-incomplete-01.json
+++ b/src/data/research/problems/erdos-45-incomplete-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-45-incomplete-01",
   "title": "Erdős #45: Monochromatic Egyptian Fractions",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "currentState": {
     "phase": "COMPLETED",

--- a/src/data/research/problems/erdos-456.json
+++ b/src/data/research/problems/erdos-456.json
@@ -2,7 +2,7 @@
   "slug": "erdos-456",
   "title": "Erdős #456",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-485-oq-02.json
+++ b/src/data/research/problems/erdos-485-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "erdos-485-oq-02",
   "title": "Is there a combinatorial (non-algebraic) proof of f(k) → ∞, e.g., via sumset bounds?",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-531-incomplete-01.json
+++ b/src/data/research/problems/erdos-531-incomplete-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-531-incomplete-01",
   "title": "Complete proof of Erdős Problem #531: Folkman's Theorem - Monochromatic Subset Sums (2 sorries)",
   "phase": "ACT",
-  "status": "available",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-602.json
+++ b/src/data/research/problems/erdos-602.json
@@ -2,7 +2,7 @@
   "slug": "erdos-602",
   "title": "Erdős #602",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-603.json
+++ b/src/data/research/problems/erdos-603.json
@@ -2,7 +2,7 @@
   "slug": "erdos-603",
   "title": "Erdős #603",
   "phase": "ACT",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-638.json
+++ b/src/data/research/problems/erdos-638.json
@@ -2,7 +2,7 @@
   "slug": "erdos-638",
   "title": "Erdős #638",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-70-wip-01.json
+++ b/src/data/research/problems/erdos-70-wip-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-70-wip-01",
   "title": "Complete the Erdős #70 Partition-Calculus Formalization",
   "phase": "ACT",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-719.json
+++ b/src/data/research/problems/erdos-719.json
@@ -2,7 +2,7 @@
   "slug": "erdos-719",
   "title": "Erdős #719",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-749.json
+++ b/src/data/research/problems/erdos-749.json
@@ -2,7 +2,7 @@
   "slug": "erdos-749",
   "title": "Erdős #749",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-75.json
+++ b/src/data/research/problems/erdos-75.json
@@ -2,7 +2,7 @@
   "slug": "erdos-75",
   "title": "Erdős #75",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-782.json
+++ b/src/data/research/problems/erdos-782.json
@@ -2,7 +2,7 @@
   "slug": "erdos-782",
   "title": "Erdős #782",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-850.json
+++ b/src/data/research/problems/erdos-850.json
@@ -2,7 +2,7 @@
   "slug": "erdos-850",
   "title": "Erdős #850",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-853.json
+++ b/src/data/research/problems/erdos-853.json
@@ -2,7 +2,7 @@
   "slug": "erdos-853",
   "title": "Erdős #853",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-876-incomplete-01.json
+++ b/src/data/research/problems/erdos-876-incomplete-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-876-incomplete-01",
   "title": "Complete proof of Erdős Problem #876: Sum-Free Sets and Gap Growth (2 sorries)",
   "phase": "NEW",
-  "status": "available",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-891.json
+++ b/src/data/research/problems/erdos-891.json
@@ -2,7 +2,7 @@
   "slug": "erdos-891",
   "title": "Erdős #891",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/erdos-szekeres-oq-02.json
+++ b/src/data/research/problems/erdos-szekeres-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "erdos-szekeres-oq-02",
   "title": "Complexity of finding the actual Erdos-Szekeres monotonic subsequence",
   "phase": "ACT",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/euler-polyhedral-formula-oq-02-oq-02.json
+++ b/src/data/research/problems/euler-polyhedral-formula-oq-02-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "euler-polyhedral-formula-oq-02-oq-02",
   "title": "euler-polyhedral-formula-oq-02-oq-02",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/euler-totient-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/euler-totient-oq-01-oq-02-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "euler-totient-oq-01-oq-02-oq-03",
   "title": "Carmichael function on powers of two: lambda(2^k)=2^{k-2} for k>=3",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/frobenius-number-oq-02.json
+++ b/src/data/research/problems/frobenius-number-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "frobenius-number-oq-02",
   "title": "Symmetry of Non-Representable Numbers (Frobenius)",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/fundamental-arithmetic-oq-01.json
+++ b/src/data/research/problems/fundamental-arithmetic-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "fundamental-arithmetic-oq-01",
   "title": "fundamental-arithmetic-oq-01",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "fast",
   "problemStatement": {

--- a/src/data/research/problems/hilbert-17-oq-03.json
+++ b/src/data/research/problems/hilbert-17-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "hilbert-17-oq-03",
   "title": "Complexity of Deciding PSD Polynomial Sum-of-Squares",
   "phase": "NEW",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/kroneckers-jugendtraum-oq-02.json
+++ b/src/data/research/problems/kroneckers-jugendtraum-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "kroneckers-jugendtraum-oq-02",
   "title": "Stark Units: Effective Computation for Specific Number Fields",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/lagrange-theorem-oq-01-oq-01.json
+++ b/src/data/research/problems/lagrange-theorem-oq-01-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "lagrange-theorem-oq-01-oq-01",
   "title": "Formalize the application: use Sylow theory to classify groups of order pq (p...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/law-of-cosines-oq-04-oq-02-oq-01.json
+++ b/src/data/research/problems/law-of-cosines-oq-04-oq-02-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "law-of-cosines-oq-04-oq-02-oq-01",
   "title": "Deriving the angle-bisector identity m·b = n·c from Mathlib's Euclidean-geometry API",
   "phase": "PREP",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/laws-of-large-numbers-oq-01-oq-02.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-01-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "laws-of-large-numbers-oq-01-oq-02",
   "title": "What is the LLN rate of convergence for heavy-tailed distributions",
   "phase": "NEW",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/lebesgue-measure-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/lebesgue-measure-oq-01-oq-01-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "lebesgue-measure-oq-01-oq-01-oq-02",
   "title": "Can we prove that Thomae's function is continuous at every irrational and dis...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/lebesgue-measure-oq-01-oq-01.json
+++ b/src/data/research/problems/lebesgue-measure-oq-01-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "lebesgue-measure-oq-01-oq-01",
   "title": "Can the modified Dirichlet function $f(x) = 1/q$ for $x = p/q$ in lowest term...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/mathematical-induction-oq-03.json
+++ b/src/data/research/problems/mathematical-induction-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "mathematical-induction-oq-03",
   "title": "Cyclic Induction for ZMod n — Adapt Induction to Cyclic Structures",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "fast",
   "problemStatement": {

--- a/src/data/research/problems/matrix-posdef-sqrt-oq-01.json
+++ b/src/data/research/problems/matrix-posdef-sqrt-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "matrix-posdef-sqrt-oq-01",
   "title": "Positive semidefinite square root: the unique PSD √A with √A·√A = A",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/mersenne-prime-exponent-oq-02.json
+++ b/src/data/research/problems/mersenne-prime-exponent-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "mersenne-prime-exponent-oq-02",
   "title": "Congruence Restrictions on Prime Factors of Mersenne Numbers",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/pac-learning-bounds-oq-01.json
+++ b/src/data/research/problems/pac-learning-bounds-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "pac-learning-bounds-oq-01",
   "title": "Can the VC dimension of specific hypothesis classes (linear classifiers, neur...",
   "phase": "ACT",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/platonic-solids-oq-02.json
+++ b/src/data/research/problems/platonic-solids-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "platonic-solids-oq-02",
   "title": "Classification of Semi-Regular (Archimedean) Solids",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/ptolemys-theorem-oq-01.json
+++ b/src/data/research/problems/ptolemys-theorem-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "ptolemys-theorem-oq-01",
   "title": "Ptolemy Inequality Formalization with Concyclicity Characterization",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "fast",
   "problemStatement": {

--- a/src/data/research/problems/quadratic-reciprocity-algorithm-oq-03.json
+++ b/src/data/research/problems/quadratic-reciprocity-algorithm-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "quadratic-reciprocity-algorithm-oq-03",
   "title": "Quadratic Reciprocity via Zolotarev / Algorithmic Well-Definedness",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/shannon-source-coding-oq-01.json
+++ b/src/data/research/problems/shannon-source-coding-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "shannon-source-coding-oq-01",
   "title": "Can rate-distortion theory (lossy compression with distortion constraint $D$)...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/solution-of-cubic-oq-03-oq-01.json
+++ b/src/data/research/problems/solution-of-cubic-oq-03-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "solution-of-cubic-oq-03-oq-01",
   "title": "Discriminant of depressed cubic",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "problemStatement": {
     "formal": "For a depressed cubic x^3 + p*x + q with roots x1, x2, x3, prove that -4*p^3 - 27*q^2 equals the root-separation discriminant.",

--- a/src/data/research/problems/solution-of-cubic-oq-03-oq-05.json
+++ b/src/data/research/problems/solution-of-cubic-oq-03-oq-05.json
@@ -2,7 +2,7 @@
   "slug": "solution-of-cubic-oq-03-oq-05",
   "title": "Verify Vieta's formulas for the general cubic",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "fast",
   "problemStatement": {

--- a/src/data/research/problems/sqrt2-minpoly-oq-03.json
+++ b/src/data/research/problems/sqrt2-minpoly-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "sqrt2-minpoly-oq-03",
   "title": "Class number 1 for Q(√2) via Minkowski's bound",
   "phase": "ACT",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "minkowski-route",
   "problemStatement": {

--- a/src/data/research/problems/wolstenholme-theorem-oq-01.json
+++ b/src/data/research/problems/wolstenholme-theorem-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "wolstenholme-theorem-oq-01",
   "title": "Infinitely Many Wolstenholme Primes",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/yang-mills-transfer-matrix-oq-01.json
+++ b/src/data/research/problems/yang-mills-transfer-matrix-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "yang-mills-transfer-matrix-oq-01",
   "title": "yang-mills-transfer-matrix-oq-01",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {


### PR DESCRIPTION
## Summary
Sweep fix for the root cause of the fleet-wide "saturated problem re-served" pattern: **118 tracker JSONs** had `currentState.phase: "COMPLETED"` while the top-level `status` (the field the pool selector reads) was still `active`/`in-progress`/`available`/`blocked`. Each of these finished problems kept cycling back into researcher claims — three separate re-serves to researcher-3 today alone (erdos-507-wip-01 → #43661, erdos-53-wip-01 → #43669; precedent fix a054656 → #43647).

## Progress
- One-line change per file: top-level `status` → `"completed"`, nothing else touched (mechanically verified — each file reparsed and diffed against the original with only the status field allowed to change; any collateral change would have skipped the file; 0 skips)
- Spot-checked against session history: sqrt2-minpoly-oq-03 (#43498), desargues-theorem-oq-02-oq-02 (#43442), abundant-number-oq-03-oq-03, erdos-876-incomplete-01, erdos-70-wip-01 — all genuinely completed nodes
- Excluded: erdos-53-wip-01 (already in #43669) and the 3 known concatenated-JSON parse-error files (separate vein with pending PRs)
- Live pool statuses synced separately (runtime state, not in this PR)

## Findings
- The defect arises because completing sessions set `currentState.phase = COMPLETED` but often don't mirror it to the top-level `status`; a later `claim-problem.sh release` can also reset pool status to available. A durable fix would be for the pool sync/extractor to derive claimability from `currentState.phase` when present — left as a follow-up for a Loom builder issue if the operator wants it.

## Status
**Outcome**: completed (metadata repair sweep)
**Next Steps**: consider a validator/extractor guard deriving pool status from currentState.phase

🤖 Generated by researcher-3
