### PR TITLE
chore(repo): hygiene pass — untrack .loom-managed (again), fix docs/gitignore/Makefile drift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,9 +28,12 @@ aristotle-results/llm-mapping-cache.json
 .loom/state/
 .loom/tmp/
 .loom/sweep-checkpoint/
+.loom/exit-codes/
 .loom/config.json
 .loom/model-config.env
 .loom-managed
+# host-local dev symlink to the loom-tools package source (see #43675)
+loom-tools
 research/*.pid
 research/*.log
 proofs/err.log
@@ -38,7 +41,6 @@ scripts/enricher/*.log
 scripts/enricher/logs/
 
 # ── Build artifacts / caches ───────────────────────────────────────────
-.lake
 .lake/
 .build-cache/
 .erdos-cache/
@@ -72,7 +74,6 @@ src/data/research/research-listings.json
 # .env.*, research/db/, research/claims/) are not repeated here.
 
 # Logs
-logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,0 @@
-# Loom-managed worktree marker
-# Created by .loom/scripts/worktree.sh
-# Issue: 41675
-# Branch: feature/issue-41675
-# Removing this file makes Loom treat the worktree as user-owned and refuse
-# to clean it up automatically.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,8 +98,8 @@ gh pr create --title "Research: <topic>" --body "Summary of findings..."
 | File Type | Purpose | Version Controlled |
 |-----------|---------|-------------------|
 | `src/data/research/problems/*.json` | Problem definitions, current knowledge | Yes |
-| `.lean/state/candidate-pool.json` | Problem registry and status | Yes |
-| `research/db/data/*.sql` | Historical sessions, detailed records | Yes |
+| `.lean/state/candidate-pool.json` | Problem registry and status | No (gitignored; lives in the main checkout) |
+| `research/db/data/*.sql` | Historical sessions, detailed records | No (gitignored; dir may not exist) |
 | `research/db/schema.sql` | Database schema | Yes |
 | `research/db/knowledge.db` | Local SQLite database | No (gitignored) |
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ help:
 	@echo "  make restart-aristotle - Restart aristotle if stopped"
 	@echo "  make restart-enhancers - Restart enhancer agents if stopped"
 	@echo ""
-	@echo "Options:
+	@echo "Options:"
 	@echo "  DEEP=1    - Enable deep cleaning (worktrees, branches, logs)"
 	@echo "  FORCE=1   - Non-interactive mode"
 	@echo "  DRY=1     - Dry-run mode (show what would be done)"
@@ -164,7 +164,7 @@ build:
 	pnpm build
 
 test:
-	pnpm test
+	pnpm test:oq-slug && pnpm test:oq-group
 
 lint:
 	pnpm lint

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ See [ROADMAP.md](ROADMAP.md) for current plans.
 
 | Metric | Count |
 |--------|-------|
-| Lean proof files | 2,400+ |
-| Gallery proofs | 2,000+ |
-| Erdos problems formalized | 1,200+ |
-| Research problems tracked | 1,100+ |
+| Lean proof files | 6,000+ |
+| Gallery proofs | 4,800+ |
+| Erdos problems formalized | 1,500+ |
+| Research problems tracked | 2,600+ |
 
 ### Infrastructure
 
@@ -120,6 +120,11 @@ shared/               # Shared code between frontend and backend
 drizzle/              # Database migrations
 scripts/              # Build, agent, and deployment scripts
 research/             # Research problem tracking and state
+infra/                # Infrastructure-as-code (unapplied Terraform skeleton)
+mcp-servers/          # MCP server implementations
+external/             # Vendored external artifacts
+public/               # Build-generated static assets (gitignored)
+aristotle-results/    # Retrieved Aristotle proof-search output
 ```
 
 ## Working with Proofs

--- a/STOP_WORK.md
+++ b/STOP_WORK.md
@@ -51,8 +51,12 @@ gh pr list --limit 20
 
 ```bash
 git status
-# If there are changes worth keeping:
-git add -A && git commit -m "chore: sync data" && git push
+# If there are changes worth keeping, commit them on a BRANCH and open a PR —
+# direct pushes to main are blocked by branch protection (see CLAUDE.md):
+git checkout -b chore/stop-work-sync
+git add -A && git commit -m "chore: sync data"
+git push -u origin chore/stop-work-sync
+gh pr create --fill
 ```
 
 ## 7. Summary Check
@@ -60,10 +64,6 @@ git add -A && git commit -m "chore: sync data" && git push
 ```bash
 # See final progress
 make status
-
-# Erdős enhancement progress
-enhanced=$(find src/data/proofs/erdos-* -name "annotations.json" -exec sh -c 'test $(wc -l < "$1") -ge 90 && echo 1' _ {} \; | wc -l)
-echo "Enhanced stubs: $enhanced / 821"
 
 # Research progress
 cat .lean/state/candidate-pool.json | jq '[.candidates[] | .status] | group_by(.) | map({status: .[0], count: length})'


### PR DESCRIPTION
## Summary

Safe fixes from the `/repo:all` hygiene audit (2026-08-04). One critical, the rest doc/config drift:

- **`.loom-managed` untracked from the index** — it regressed onto main after #43617; a tracked `.loom-managed` is the established root cause of fleet-wide worktree reaping. The ignore rule already exists, so this is the single-line completion of the original fix.
- `.gitignore`: `.loom/exit-codes/` (daemon sweep runtime state) and the host-local `loom-tools` symlink (#43675) now ignored; duplicate `.lake`/`logs` rules deduped.
- `README.md`: status table was 2–2.5× low across all four metrics; structure block missed five real top-level dirs.
- `Makefile`: `make help` had an unterminated quote; `make test` ran the nonexistent `pnpm test` — now runs the two real test scripts.
- `STOP_WORK.md`: step 6 told agents to push the current branch directly (blocked by branch protection) — now branches + PRs; retired `/821` stub counter removed.
- `CONTRIBUTING.md`: source-of-truth table claimed two gitignored paths were version-controlled.

Deferred (needs judgment, not included): `public/` over-broad ignore, README script-surface expansion, CLAUDE.md agent-table additions, ROADMAP/PROOFS_ROADMAP rewrites (~7 months stale), missing CHANGELOG, `selection-report.md` relocation, 24MB of gitignored db backups.

## Verification

`make -n help` parses; `make -n test` expands to the real scripts; `git ls-files -i -c --exclude-standard` returns empty after the untrack; all edits re-verified on disk before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNqnwQi5KJhHV3hpQB1eU1
