### PR TITLE
chore(repo-skills): sync installed files to source c925fb2 (v0.7.0 line)

### DIFF
--- a/.claude/commands/repo/all.md
+++ b/.claude/commands/repo/all.md
@@ -50,14 +50,87 @@ report. This surfaces everything before anything is touched.
 Offer to fix gitignore findings here. Leave README, link, and documentation
 fixes for the Docs stage next — don't apply them twice.
 
-### 2. Docs (see [[docs]])
+### 2. Sync early, if and only if nothing can be lost (see [[reset]])
+
+[[reset]] is two separable halves, and only one of them is safe to move:
+
+- **Sync-and-switch** (reversible): `git fetch`, check out the default branch,
+  `git pull --ff-only`. Nothing is removed.
+- **Pruning** (gated): stash review, branch & worktree deletion. Can
+  permanently remove work, so it keeps its gates and stays last (stage 6).
+
+Running the whole of Reset last assumes the working branch is the right place
+for the later stages to be looking — which holds when it carries unpushed work
+those stages should see. When the branch is **fully pushed and behind the
+default branch** that assumption inverts: there is no local-only content to
+protect, and Docs/Tidy either report drift that is already fixed upstream or
+edit a copy that pollutes an open PR's diff and blocks the branch switch Reset
+performs at the end. So check the branch state here, before Docs runs:
+
+```bash
+current=$(git symbolic-ref --short HEAD 2>/dev/null) || current=""
+default=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
+git fetch origin --quiet
+
+eligible=no
+if [ -n "$current" ] && [ -n "$default" ] && [ "$current" != "$default" ] \
+   && [ -z "$(git status --porcelain)" ]; then
+  # "Fully pushed" = HEAD has an upstream AND is not ahead of it.
+  if git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
+    ahead_of_upstream=$(git rev-list --count '@{u}..HEAD')
+  else
+    ahead_of_upstream=""   # no upstream at all => never pushed, not eligible
+  fi
+  behind_default=$(git rev-list --count "HEAD..origin/$default" 2>/dev/null || echo 0)
+  if [ "$ahead_of_upstream" = "0" ] && [ "$behind_default" -gt 0 ]; then
+    eligible=yes
+  fi
+fi
+```
+
+Every condition must hold, and each one rules out a distinct way the early
+switch could lose work or fail:
+
+| Condition | Why it is required |
+|---|---|
+| On a branch (not detached), and it isn't already the default | Nothing to switch to; a detached HEAD has no upstream to reason about |
+| `origin/HEAD` resolves to a default branch | Without it there is no defensible switch target — leave the order alone |
+| Working tree clean (`git status --porcelain` empty) | A dirty tree would have to be stashed to switch, and this run ends on the default branch, so there is no natural point to pop it back |
+| Branch **has an upstream** and is **0 commits ahead of it** | This is the literal "no unpushed commits". A branch that was **never pushed** has no upstream and is **not** eligible — treat it exactly like unpushed commits |
+| Branch is behind `origin/<default>` by at least one commit | If it isn't behind, the checkout is already current and switching buys nothing |
+
+Being ahead of the *default branch* is **not** disqualifying — a pushed PR
+branch normally is. The unpushed-work test is against the branch's own
+upstream, which is a different axis; a branch that has diverged from the
+default branch is still eligible as long as everything on it is pushed.
+
+**If `eligible=yes`**, run only the sync-and-switch half now — [[reset]]'s
+step 4: `git fetch --all --prune`, then `git checkout "$default"` and `git pull
+--ff-only` — so Docs, Tidy, and Update tools all operate on a fresh
+default-branch checkout. Report it on one line as it happens:
+
+```
+Reset: synced early — feature/x was fully pushed and 6 commits behind main; switched before Docs
+```
+
+Under `--ask`, report the finding and get a yes before switching, like every
+other stage. If the checkout or the `--ff-only` pull fails (a diverged local
+default branch, say), change nothing, report why, and continue with the stage
+order unchanged — stage 6 will surface it again with [[reset]]'s own handling.
+
+**If `eligible=no`**, this stage is a no-op: say nothing, and run the remaining
+stages exactly as before, with Reset in full at the end. Unpushed work on the
+working branch, a dirty tree, and an already-on-default run all land here, and
+none of them behave any differently than they did before this check existed.
+
+### 3. Docs (see [[docs]])
 
 Bring the documentation back in line with reality: content accuracy (stale
 prose, out-of-date command/feature tables, CHANGELOG drift), README structure,
 and internal cross-references. This is the explicit, named home for the doc
 fixes the audit surfaced — apply the ones the user approves.
 
-### 3. Tidy (see [[tidy]])
+### 4. Tidy (see [[tidy]])
 
 Inventory filesystem clutter — build artifacts, caches, temp files, empty dirs
 — present it grouped with sizes, and delete the SAFE junk (OS droppings, merge
@@ -67,20 +140,31 @@ hygiene pass — deleting them just forces a costly rebuild — so this stage do
 Environments (`node_modules/`, virtualenvs) and other ASK items are never
 auto-removed here regardless.
 
-### 4. Update tools (see [[update-tools]])
+### 5. Update tools (see [[update-tools]])
 
 Check installed tool packages (Loom, Anvil, Repo itself, …) against their
 sources. Report what's behind and offer to update.
 
-### 5. Reset (see [[reset]])
+### 6. Reset (see [[reset]])
 
-Last, because it changes branch state and syncs with the remote. Run the
+Last, because this is where branch state can be permanently removed. Run the
 end-of-task baseline ritual: working-tree safety check, stash review, branch &
 worktree pruning, `git fetch --prune`, and return to the default branch. Pass
 `--prune` and `--ask` through if either was given to `/repo:all`.
 
-Do this stage last so the earlier scans and cleanup happen while you're still on
-the working branch, and you finish on a clean default branch.
+The **pruning half always runs here**, with its existing gates — which
+branches, worktrees, and stashes are safe to remove has nothing to do with
+which branch the earlier stages ran against, so stage 2 never moves it.
+
+If stage 2 already performed the sync-and-switch, run [[reset]] unchanged
+anyway — the checkout is a no-op and the fetch/pull still picks up anything
+the remote gained during the run — but **don't report the switch twice**. It
+was announced when it happened; here just report the resulting branch state
+along with the pruning outcome.
+
+Otherwise this stage behaves exactly as it always has: the earlier scans and
+cleanup happened while you were still on the working branch, and you finish on
+a clean default branch.
 
 ## Final Summary
 
@@ -101,9 +185,21 @@ Skipped:      remote (never part of /repo:all)
 List anything intentionally left behind — deferred findings, kept stashes,
 UNKNOWN branches — so the user knows exactly what state the repo is in.
 
+When stage 2's early sync-and-switch ran, the `Reset:` line still carries the
+pruning half's outcome — branches, worktrees, and stashes reviewed — and notes
+the switch **once**, as something already done, so the summary never reads as
+if the branch changed at the end of the run:
+
+```
+Reset:        synced early (feature/x → main, was 6 behind), tree clean, 4 branches deleted, 1 stash kept
+```
+
+Never drop the pruning reporting just because the switch moved earlier, and
+never describe the same switch in both places.
+
 ### Re-verify before printing
 
-A fix applied in stage 2 can be gone by the time this summary prints. A
+A fix applied in the Docs stage can be gone by the time this summary prints. A
 concurrent writer — another agent in the same clone, a background `git stash`
 or `git checkout --`, a Loom sweep quarantining the primary clone's working
 tree — reverts the working tree without touching this run, and the stage that

--- a/.claude/commands/repo/followups.md
+++ b/.claude/commands/repo/followups.md
@@ -112,12 +112,27 @@ restricts to a single discovered tool.
 ### 3. Dedup against existing open issues
 
 Before proposing to file, check each target repo for issues that already cover
-the candidate so nothing is re-filed:
+the candidate so nothing is re-filed. Query the **REST search** endpoint, not
+`gh issue list --search`:
 
 ```bash
-gh issue list --repo <slug> --state open --search "<key terms>" \
-  --json number,title,url
+gh api "search/issues?q=repo:<slug>+state:open+<key+terms>&per_page=30" \
+  --jq '.items[] | "#\(.number) \(.title) \(.html_url)"'
 ```
+
+Search result items already carry `number`, `title`, and `html_url`, so this is
+a straight replacement for the old `--json number,title,url` output shape — no
+second-pass mapping needed.
+
+Terms go into `q` as `+`-joined tokens; URL-encode anything that isn't
+alphanumeric, and quote the whole URL so the shell leaves it alone.
+
+**Why not `gh issue list --search`:** it goes through GitHub's GraphQL API,
+whose rate-limit bucket is separate from REST's and is routinely exhausted on a
+busy multi-agent host while the `core` budget sits nearly unused. `search/*` is
+a third bucket again (30 requests/minute authenticated), so deduping here costs
+nothing from the pool step 5 needs to actually file. Check live budgets with
+`gh api rate_limit --jq .resources` if either step starts failing.
 
 Classify each candidate against its target repo's open issues:
 
@@ -147,24 +162,57 @@ file. **If `--dry-run` was passed, stop here — file nothing.**
 
 ### 5. File the approved issues
 
-For each approved, non-UNKNOWN candidate:
+For each approved, non-UNKNOWN candidate, write the body to a scratch file and
+POST it through REST:
 
 ```bash
-gh issue create --repo <slug> \
-  --title "<title>" \
-  --body "$(cat <<'EOF'
-## Context
-<where this came up in the session / repro>
+BODY="${TMPDIR:-/tmp}/followup-body.md"
+PAYLOAD="${TMPDIR:-/tmp}/followup-payload.json"
 
-## Suggested acceptance criteria
-- [ ] …
-EOF
-)"
+# 1. Write the issue body to "$BODY" using your own file-write capability —
+#    NOT a shell heredoc (see below). Content is the usual shape:
+#      ## Context
+#      <where this came up in the session / repro>
+#
+#      ## Suggested acceptance criteria
+#      - [ ] …
+
+# 2. Build the create payload, then POST it (REST `core` pool, not GraphQL).
+jq -n --arg t "<title>" --rawfile b "$BODY" \
+  '{title: $t, body: $b, labels: []}' > "$PAYLOAD"
+
+gh api --method POST "repos/<slug>/issues" --input "$PAYLOAD" --jq '.html_url'
 ```
 
+Two reasons this is the documented form rather than
+`gh issue create --body "$(cat <<'EOF' … EOF)"`:
+
+- **Rate-limit pool.** `gh issue create` is GraphQL-backed; `POST
+  repos/…/issues` is REST. GraphQL exhausts first on a busy agent host, and
+  filing is the step you least want to lose — it runs *after* the user has
+  already approved the set.
+- **The body never re-enters the shell.** A heredoc body is still shell input:
+  a line containing `>=`, backticks, or `$(…)` gets tokenized by the shell and
+  by command-matching guards, which can deny the call outright. `jq --rawfile`
+  reads the file as one raw string and JSON-escapes it, so markdown checkboxes,
+  headings, and code fences survive verbatim.
+
+The payload's `labels` array is where labels would go if a variant ever needed
+them — applied atomically with creation, no create-then-label round trip. Leave
+it `[]` here, per the labeling note below.
+
 Print the resulting issue URLs. For near-matches the user chose to comment on
-instead of file, use `gh issue comment --repo <slug> <n>`. Leave UNKNOWN /
-skipped candidates unfiled and list them so nothing is silently lost.
+instead of file, use the same REST shape (`gh issue comment` is GraphQL-backed
+too):
+
+```bash
+jq -n --rawfile b "$BODY" '{body: $b}' > "$PAYLOAD"
+gh api --method POST "repos/<slug>/issues/<n>/comments" --input "$PAYLOAD" \
+  --jq '.html_url'
+```
+
+Leave UNKNOWN / skipped candidates unfiled and list them so nothing is silently
+lost.
 
 Filed issues are triaged like any other afterward — this command does not apply
 `loom:*` or other pipeline labels.
@@ -178,3 +226,8 @@ Filed issues are triaged like any other afterward — this command does not appl
 3. **Never guess a target repo** — unresolved or ambiguous targets are reported
    as UNKNOWN for the user to name, never filed to a guessed slug.
 4. **`--dry-run` files nothing** — pure proposal mode for review.
+5. **Reach the forge over REST** — dedup via `gh api search/issues`, file via
+   `gh api --method POST repos/<slug>/issues --input <payload>`, and pass issue
+   bodies as files (`--rawfile` / `--input`), never as inline heredocs. The
+   `gh issue list` / `gh issue create` forms are GraphQL-backed and fail on
+   exactly the busy multi-agent repos this command is most useful in.

--- a/.claude/commands/repo/release.md
+++ b/.claude/commands/repo/release.md
@@ -136,10 +136,10 @@ release tag), **[c]** continue and leave the gap, or **[a]** abort.
 
 Detect the host repo's bump mechanism. **First match wins**, in this order. An
 explicit `scripts/version.sh` is honored first; a plain `VERSION` file is the
-most-general fallback. Because `npm` is matched on `package.json` alone — before
-the `VERSION` fallback — the result is **provisional** whenever both files
-coexist: reconcile it against the root `VERSION` file (see *Cross-source
-reconciliation* below) before treating `VERSION_TOOL` as final.
+most-general fallback. Because `npm` is matched on any version-bearing
+`package.json` — before the `VERSION` fallback — the result is **provisional**
+whenever both files coexist: reconcile it against the root `VERSION` file (see
+*Cross-source reconciliation* below) before treating `VERSION_TOOL` as final.
 
 ```bash
 VERSION_TOOL="" ; WHY=""
@@ -157,7 +157,10 @@ elif command -v bump2version >/dev/null 2>&1 && [ -f .bumpversion.cfg ]; then
   VERSION_TOOL="bump2version"; WHY="bump2version + .bumpversion.cfg"
 elif command -v poetry >/dev/null 2>&1 && [ -f pyproject.toml ] && grep -q '\[tool.poetry\]' pyproject.toml; then
   VERSION_TOOL="poetry"; WHY="poetry + [tool.poetry]"
-elif command -v npm >/dev/null 2>&1 && [ -f package.json ]; then
+elif [ -f pyproject.toml ] && grep -qE '^\[project\]' pyproject.toml && \
+     awk '/^\[project\]/{f=1;next} /^\[/{f=0} f' pyproject.toml | grep -qE '^version[[:space:]]*='; then
+  VERSION_TOOL="pyproject"; WHY="pyproject.toml [project].version (PEP 621)"
+elif command -v npm >/dev/null 2>&1 && [ -f package.json ] && grep -q '"version"' package.json; then
   VERSION_TOOL="npm"; WHY="npm + package.json"
 elif [ -f VERSION ]; then
   VERSION_TOOL="version-file"; WHY="plain VERSION file at repo root"
@@ -165,18 +168,31 @@ fi
 echo "${VERSION_TOOL:-<none>} — ${WHY:-no tool detected}"
 ```
 
+Two branch details are load-bearing:
+
+- **`poetry` stays ahead of `pyproject`.** Modern poetry projects also carry a
+  `[project]` table, so ordering is what keeps `poetry version` (the correct
+  apply path for those repos) winning over a raw TOML edit.
+- **The PEP 621 check is scoped to the `[project]` table.** The `awk`
+  block-extractor feeds `grep` only the lines *inside* `[project]`, so an
+  unrelated `version = …` in e.g. `[tool.poetry.dependencies]` can't
+  false-positive the branch. Likewise `npm` now requires a `"version"` field
+  rather than the mere presence of `package.json` — a version-less scaffold
+  (`{"private": true}`) cannot be the version source, so it falls through the
+  chain instead of misdirecting the bump.
+
 **Surface the detected tool to the user.** If none is detected, do not proceed
 silently — offer: **[m]** manual (they edit manifests, you commit + tag), or
 **[a]** abort.
 
 ### Cross-source reconciliation (VERSION vs package.json)
 
-`npm` is matched on the mere presence of `package.json`, so a repo that keeps a
-plain root `VERSION` file **and** a `package.json` detects as `npm` even when
-`VERSION` is the maintained source of truth — a blind `npm version` would then
-bump and tag the wrong line. Whenever the provisional tool is `npm` **and** a
-root `VERSION` file also exists **and** `package.json` carries a `version` field,
-read both and reconcile before finalizing `VERSION_TOOL`:
+`npm` is matched on any `package.json` carrying a `version` field, so a repo that
+keeps a plain root `VERSION` file **and** a versioned `package.json` detects as
+`npm` even when `VERSION` is the maintained source of truth — a blind `npm
+version` would then bump and tag the wrong line. Whenever the provisional tool is
+`npm` **and** a root `VERSION` file also exists, read both and reconcile before
+finalizing `VERSION_TOOL`:
 
 ```bash
 # Runs only when detection landed on npm but a root VERSION file also coexists.
@@ -233,9 +249,12 @@ git diff "${last}..HEAD" --stat
 ```
 
 Read the current version per tool (`./scripts/version.sh`; `grep -m1 '^version'
-Cargo.toml`; `poetry version -s`; `node -p "require('./package.json').version"`;
-`cat VERSION`; …). If there are **zero** commits since the last tag, stop —
-nothing to release.
+Cargo.toml`; `poetry version -s`; `python3 -c "import tomllib;
+print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])"` for
+`pyproject` (Python 3.11+; on older Python fall back to the same
+`awk`-scoped-then-`sed` one-liner the Phase 2 branch uses); `node -p
+"require('./package.json').version"`; `cat VERSION`; …). If there are **zero**
+commits since the last tag, stop — nothing to release.
 
 Present a semver analysis (https://semver.org) against whatever public surface
 the repo exposes (API, CLI, protocol, config, file formats):
@@ -320,15 +339,35 @@ Once approved:
      bumpversion)       bumpversion <level> --tag --commit ;;
      bump2version)      bump2version <level> --tag --commit ;;
      poetry)            poetry version <level> ;;  # then commit + tag v$(poetry version -s)
+     pyproject)         python3 -c 'import re,sys;p="pyproject.toml";t=open(p).read();n=re.subn(r"(?ms)(^\[project\][^\n]*\n(?:(?!^\[)[^\n]*\n)*?version[ \t]*=[ \t]*)\"[^\"]*\"",lambda m:m.group(1)+f"\"{sys.argv[1]}\"",t,count=1);sys.exit("ERROR: no [project].version found in pyproject.toml") if n[1]==0 else open(p,"w").write(n[0])' "$NEW" && { [ -f uv.lock ] && command -v uv >/dev/null 2>&1 && uv lock || : ; } ;;  # then commit (with CHANGELOG) + tag v$NEW
      npm)               npm version <level> -m "chore: bump version to %s" ;;
      version-file)      printf '%s\n' "$NEW" > VERSION ;;  # then commit (with CHANGELOG) + tag v$NEW
    esac
    ```
 
    For tools that don't self-commit (`cargo-set-version`, `cargo-workspace`,
-   `poetry`, `version-file`), stage the bumped files **plus `CHANGELOG.md`**,
-   commit, and `git tag -a "v$NEW" -m "v$NEW"` — match the repo's existing
-   commit/tag convention (check `git log` and `git tag`).
+   `poetry`, `pyproject`, `version-file`), stage the bumped files **plus
+   `CHANGELOG.md`**, commit, and `git tag -a "v$NEW" -m "v$NEW"` — match the
+   repo's existing commit/tag convention (check `git log` and `git tag`).
+
+   The `pyproject` branch rewrites only the `version` line **inside** the
+   `[project]` table and leaves every other line byte-identical. Three details
+   are load-bearing, each guarding a failure this branch would otherwise cause:
+
+   - **Scoping is line-anchored** (`(?:(?!^\[)[^\n]*\n)*?`), matching lines up
+     to the next table *header*, rather than "any run of non-`[` characters".
+     The looser form silently matches nothing whenever a list-valued key
+     (`classifiers`, `dependencies`, `keywords`) appears before `version` in
+     `[project]` — a no-op bump that would still get committed and tagged.
+   - **A zero-substitution result is fatal**, not a no-op: the branch exits
+     non-zero with `ERROR: no [project].version found` so a mis-shaped
+     `pyproject.toml` fails the apply instead of tagging a stale version.
+   - **`uv.lock` is refreshed when present**, so `uv sync --locked` CI doesn't
+     break on the now-stale locked version. It's gated on both the lock file
+     existing and `uv` being on `PATH` (with a trailing `|| :` so a flit- or
+     setuptools-only PEP 621 repo with no lock file doesn't fail the branch on
+     the gate's own false status). Stage the regenerated `uv.lock` alongside
+     `pyproject.toml` and `CHANGELOG.md` in the version commit.
 3. **Verify**: re-read the version and confirm the tag exists
    (`git tag --sort=-v:refname | head -1`). For cargo, `cargo check --workspace`.
    Also confirm the `## Unreleased` fold (Phase 4) actually landed: grep the

--- a/.claude/commands/repo/reset.md
+++ b/.claude/commands/repo/reset.md
@@ -22,6 +22,25 @@ without an explicit opt-in and the permanent-loss check.
 /repo:reset --prune            # Also delete confirmed-safe branches/worktrees (after the loss check)
 ```
 
+## Two halves
+
+The steps below split cleanly in two, and naming the split matters because
+callers can schedule the halves separately:
+
+- **Sync-and-switch** (reversible — steps 1 and 4): the working-tree safety
+  check, `git fetch --all --prune`, and landing on an up-to-date default
+  branch. Nothing is removed.
+- **Pruning** (gated — steps 2 and 3): stash review and branch/worktree
+  review. These can permanently remove work, so they keep the explicit opt-in
+  and the [[branches]] permanent-loss check.
+
+Run standalone, `/repo:reset` always runs all four steps in order, exactly as
+documented — this split changes nothing here. It exists because [[all]] may run
+the **sync-and-switch half early** (before its Docs stage) when the current
+branch is fully pushed and behind the default branch, so that its doc stages
+don't edit a stale checkout; the pruning half still runs last there, with its
+gates intact.
+
 ## Steps
 
 ### 1. Working tree safety check

--- a/.claude/commands/repo/tidy.md
+++ b/.claude/commands/repo/tidy.md
@@ -22,12 +22,15 @@ call, never auto-deleted.
 /repo:tidy                    # Inventory, delete SAFE junk (caches kept), report; ASK items presented
 /repo:tidy --caches           # Also clear regenerable caches (__pycache__/, dist/, .mypy_cache/, …)
 /repo:tidy --ask              # Walk every category interactively before deleting anything
+/repo:tidy --sizes            # Also measure worktree root sizes (slow: du has no prune)
 /repo:tidy packages/core      # Scope to one subtree
 ```
 
 (`--apply` is accepted as a synonym for the default, for muscle memory. `--caches`
 composes with `--ask`: `--ask` still walks every category, `--caches` just moves
-the cache tier into the auto-delete set for the non-interactive default.)
+the cache tier into the auto-delete set for the non-interactive default.
+`--sizes` only adds the per-worktree size column described in step 1 — it never
+changes what is deleted.)
 
 ## Steps
 
@@ -43,14 +46,108 @@ git clean -ndX
 git clean -nd
 
 # Empty directories
-find . -type d -empty -not -path './.git/*'
+find . \( -path './.git' -o -name node_modules -o -name target \
+          -o -name dist -o -name .venv \) -prune \
+     -o -type d -empty -print
 
 # Large files in the working tree (>10 MB, tracked or not)
-find . -type f -size +10M -not -path './.git/*' -not -path './node_modules/*'
+find . \( -path './.git' -o -name node_modules -o -name target \
+          -o -name dist -o -name .venv \) -prune \
+     -o -type f -size +10M -print
 
-# Stale worktrees
-git worktree list
+# Git worktree roots — authoritative and tool-agnostic. RETAIN this output as a
+# path set for step 2's denylist; do not just print it. `--porcelain` gives one
+# `worktree <path>` line per entry, including worktrees that live outside this
+# repo root (`../repo-wt-fix123`, `/private/tmp/…`, `/private/var/folders/…`),
+# which `git clean` never sees.
+git worktree list --porcelain
+
+# The worktree paths alone, for step 3's WORKTREES block. Extract them with
+# `sed`, not `awk '{print $2}'`: awk splits on whitespace and would truncate
+# `/repos/my checkout/wt` to `/repos/my`. The `worktree ` prefix is fixed, so
+# stripping it with sed and reading whole lines keeps paths with spaces intact
+# (paths containing newlines need `git worktree list --porcelain -z`).
+git worktree list --porcelain | sed -n 's/^worktree //p'
+
+# Worktree SIZES ARE NOT COLLECTED BY DEFAULT — only when `--sizes` is passed.
+# See below for why. When it is passed, bound each root so a slow one degrades
+# the size column instead of stalling the step:
+git worktree list --porcelain | sed -n 's/^worktree //p' \
+  | while IFS= read -r wt; do
+      timeout 20 du -sh "$wt" 2>/dev/null \
+        || printf '%s\t%s\n' 'size unavailable' "$wt"
+    done
 ```
+
+Both `find` walks `-prune` the heavy trees rather than filtering them out with
+`-not -path`. `-not -path` only suppresses *printing* — `find` still descends
+into `.git/`, `node_modules/`, and every other excluded directory, which is why
+the inventory stalls on a repo with a multi-GB build tree. Pruning is a
+**traversal optimization only and must never change what is reported**: junk
+outside the pruned trees (an empty `build/`, an 11 MB file under `src/`) is
+still listed exactly as before, and `git clean -ndX`/`-nd` are unaffected since
+git does its own traversal. When editing the prune list:
+
+- **Keep both invocations' lists identical.** If they drift, one command
+  silently reintroduces the stall.
+- **Draw entries from the denylist and CACHE categories already named in step 2**
+  (`node_modules/`, `.venv/`, `dist/`, plus `target/` for Rust builds) instead
+  of growing a second, inconsistent list.
+- **Match by `-name`, not `-path`** (except `./.git`, which is unambiguously at
+  the root). `-name` prunes at any depth, so nested copies like
+  `packages/foo/node_modules/` are covered — the old
+  `-not -path './node_modules/*'` only ever matched the top-level one.
+- **Coordination roots (`.loom/`, `.anvil/`, `.wrangler/`) are deliberately not
+  pruned.** They are small, and step 2 needs to see their empty directories in
+  order to route them to ASK.
+
+**Worktree sizes are opt-in (`--sizes`); the default inventory reports count and
+paths only.** `du` has no `-prune`: sizing a worktree root re-enters the very
+`node_modules/`, `target/`, `dist/`, and `.venv/` trees the two `find` walks
+above were rewritten to skip, once per root — and the reported case that
+motivated all of this is 66 GB of worktrees inside a 94 GB tree, so sizing the
+roots is most of a `du` over the whole repo. The cost is bounded by inode count
+under those roots, not by the number of worktrees, so "there are only a handful
+of them" is not a bound at all. That makes an eager `du` the same unbounded walk
+that blew a 120-second timeout and stalled this step before.
+
+Making it a flag is the same call the command already makes for `--caches`:
+work whose *result* is useful but whose *cost* is high is presented, not
+performed, until asked for. It also keeps the fix for the failure this block
+exists to prevent — a report of "nothing to tidy" on a tree with tens of
+gigabytes in worktrees — because the count and the paths are what carry that
+signal, and they are free (`git worktree list` reads
+`.git/worktrees/`, it does not walk the trees). The size column is the
+refinement, not the point.
+
+When `--sizes` is passed, the sizes are **best-effort**: wrap each root in
+`timeout 20` and print `size unavailable` for any root that exceeds it rather
+than letting one enormous worktree hang the inventory. (`timeout` is GNU
+coreutils — on macOS it is `gtimeout` from `brew install coreutils`. If neither
+is available, report sizes as unavailable rather than running the walk
+unbounded.) Do not prune inside the `du`: an "excluding regenerable trees"
+number would understate exactly the footprint the operator is looking for. The
+honest choices are a bounded full number or none.
+
+The **first** `worktree` entry is the **main** working tree — always, regardless
+of where the command runs from. It is *not* necessarily
+`git rev-parse --show-toplevel`: from inside a linked worktree (which is where
+Loom agents run, e.g. `.loom/worktrees/issue-42`), `--show-toplevel` reports the
+linked worktree's own root while the first porcelain entry is still the main
+repo. Do not treat the two as the same path.
+
+What to drop from the list is **the tree being tidied** — the entry whose path
+equals `git rev-parse --show-toplevel` — since that is the repo this run is
+sweeping, not a worktree it is protecting from itself. Every remaining entry,
+including the main working tree when tidy is invoked from a linked worktree, is
+a live checkout to report and protect.
+
+`git worktree list --porcelain` is **authoritative**. A directory whose `.git`
+is a **file** (not a directory) containing `gitdir: …/.git/worktrees/…` is also
+a worktree root, and that check catches worktrees belonging to *other*
+checkouts of the same project; but where the two disagree — e.g. a stale `.git`
+pointer whose target is gone — trust `git worktree list --porcelain` and do not
+let a speculative `.git`-file scan fail the step.
 
 Also look for junk by pattern, wherever it lives:
 - OS/editor droppings: `.DS_Store`, `Thumbs.db`, `*~`, `*.swp`, `.#*`
@@ -96,6 +193,27 @@ overrides everything below, regardless of gitignore status):**
   stay in CACHE, so `--caches` still clears them. The discriminator is that a
   coordination root is one where *empty is the normal state*; a cache directory
   is one whose entire contents can be rebuilt by re-running the tool.)
+- Git worktree roots — **any** path listed by `git worktree list --porcelain`
+  in step 1, **or** any directory whose `.git` is a **file** (not a directory)
+  whose contents match `gitdir: .*/\.git/worktrees/.*`. A worktree root is a
+  live checkout that can hold uncommitted, unpushed, one-of-a-kind work; it is
+  never SAFE and never CACHE, regardless of gitignore status. This test is
+  **tool-agnostic and independent of the tool-scaffolding prefixes above** — it
+  is what covers `.claude/worktrees/`, `.codex/worktrees/`, and any other
+  tool's worktree cache dir that is not named in the `.loom/` / `.anvil/` /
+  `.wrangler/` list, as well as ad hoc worktrees under no dot-directory at all
+  (`git worktree add ../repo-wt-fix123`, `/private/tmp/…`,
+  `/private/var/folders/…`). Do not rely on the prefix match to reach these.
+  Emptiness never promotes a worktree root to SAFE either (safety rule 8) — a
+  checked-out worktree is not legitimately empty, and a parent directory that
+  *contains* worktrees still routes through the existing empty-directory rule.
+  A nested worktree shows up in `git clean -ndX` as `Would skip repository
+  <path>` — plain `git clean -fdX` leaves it alone, but `-ffdX` (double force)
+  deletes it outright, so never widen the force flag to make a listing "go
+  away". Report these (with their size when `--sizes` is passed — see below);
+  deciding which worktrees are *reclaimable* needs merge state and agent
+  liveness that `/repo:tidy` does not have, so it stays a report, never a
+  deletion.
 - Anything else that looks credential-like or holds unique local state
   (local SQLite DBs, local-only config, sample-data caches)
 
@@ -141,12 +259,19 @@ reserved for tracked files.
   - **Any empty directory whose path matches the denylist** (a `.loom/`,
     `.anvil/`, or `.wrangler/` coordination or runtime-state dir) — emptiness
     is that tool's normal state, so it lands here rather than in SAFE.
+  - **Any git worktree root** detected in step 1 — surfaced on its own
+    `worktree:` inventory line (see Report), never auto-deleted, whether or not
+    it is gitignored and whether or not it sits under a recognized tool
+    dot-directory.
   - **Any gitignored file that does not match the SAFE or CACHE allowlist** (a
     novel/unrecognized cache dir, unrecognized local state) — when in doubt, it
     lands here, not in SAFE or CACHE.
 
-  Stale worktrees, branches, and stashes are [[reset]]'s job — point there
-  instead of handling them here.
+  Deciding which worktrees, branches, and stashes are *stale* remains
+  [[reset]]'s job — point there instead of pruning them here. `/repo:tidy`'s
+  job with worktrees is only **visibility and protection**: report every root
+  (and its size under `--sizes`) so the operator can see the footprint, and
+  never delete one.
 - **KEEP** — flagged only as information: tracked files that look like they
   don't belong (build output that got committed — point to [[gitignore]]).
 
@@ -173,11 +298,48 @@ ASK:
   .wrangler/tmp/           gitignored, empty  ← tool runtime dir, empty between builds
   notes-scratch.md         untracked, 3 KB, modified today  ← might be real work
   sim-output-old/          untracked, 1.2 GB, untouched 60 days
-  worktree: ../repo-wt-fix123 (branch merged)
+
+WORKTREES (4 roots — never auto-deleted, listed for visibility; --sizes to measure):
+  worktree: .loom/worktrees/issue-42      ← live git worktree
+  worktree: .claude/worktrees/scratch-wt  ← live git worktree
+  worktree: ../repo-wt-fix123             ← live git worktree (outside repo root)
+  worktree: /private/tmp/wt-bisect        ← live git worktree (outside repo root)
+  Pruning stale worktrees is /repo:reset's call, not tidy's.
 
 KEEP (informational):
   assets/build.min.js      tracked but looks generated — see /repo:gitignore
 ```
+
+With `--sizes`, the same block gains a right-aligned size column and a total
+(`size unavailable` for any root that hit the `timeout`):
+
+```
+WORKTREES (66 GB across 4 roots — never auto-deleted, listed for visibility):
+  worktree: .loom/worktrees/issue-42       32 GB  ← live git worktree
+  worktree: .claude/worktrees/scratch-wt  3.1 GB  ← live git worktree
+  worktree: ../repo-wt-fix123              12 GB  ← live git worktree (outside repo root)
+  worktree: /private/tmp/wt-bisect         19 GB  ← live git worktree (outside repo root)
+  Pruning stale worktrees is /repo:reset's call, not tidy's.
+```
+
+The `WORKTREES` block is a **distinct inventory section**, not folded into the
+generic denylist ASK lines, and under `--sizes` its bytes are summed
+**separately** from the SAFE/CACHE/ASK totals (a worktree's contents are neither
+freed nor freeable by this command); roots whose size is unavailable are
+excluded from the total and the total is marked as a lower bound. Print the
+block whenever at least one worktree root exists — including on an
+otherwise-clean run and including without `--sizes`, so `/repo:tidy` never
+reports "nothing to tidy" on a tree where tens of gigabytes are sitting in
+worktrees with no hint of where the space went. The count and the paths are what
+carry that signal; the sizes only quantify it.
+
+If the repo documents its **own** worktree-management tooling — a script,
+`package.json` command, `Makefile` target, or binary the repo's own docs point
+at for this purpose — mention it after the block as a soft pointer (e.g.
+`Reclaimable worktrees: try 'loom-daemon clean --safe --dry-run'.`). Only
+whichever the repo actually documents; `/repo:tidy` has no reliable way to
+discover arbitrary third-party tooling, so **omit the line entirely rather than
+guessing** at a command that may not exist.
 
 ### 4. Apply
 
@@ -195,8 +357,8 @@ KEEP (informational):
 
 The default auto-delete is scoped to **SAFE-allowlisted paths only** (plus the
 CACHE allowlist when `--caches` is passed). Never pass a denylisted path
-(secrets, virtualenvs, `node_modules/`, tool-scaffolding roots — **including
-when it is empty**) or an unrecognized gitignored path to
+(secrets, virtualenvs, `node_modules/`, tool-scaffolding roots, git worktree
+roots — **including when it is empty**) or an unrecognized gitignored path to
 `git clean -fdX` — those are ASK items and require an explicit human call. Build
 the explicit `<paths>` list from the SAFE category (and CACHE under `--caches`)
 and nothing else; do **not** run a blanket `git clean -fdX` that would sweep
@@ -216,10 +378,10 @@ inventory to confirm and report bytes freed.
 5. When scoped to a subtree, do not delete anything outside it
 6. **Gitignored ≠ safe to delete** — the never-delete denylist (secrets like
    `.env`/`*.pem`/`*.key`, environments like `.venv/`/`venv/`/`env/` and
-   `node_modules/`, and tool-scaffolding roots like `.loom/`/`.anvil/`/
-   `.wrangler/`) always overrides SAFE and CACHE and routes to ASK, regardless
-   of what `git clean -ndX` lists. Unrecognized gitignored files fall through to
-   ASK, never SAFE or CACHE.
+   `node_modules/`, tool-scaffolding roots like `.loom/`/`.anvil/`/
+   `.wrangler/`, and git worktree roots) always overrides SAFE and CACHE and
+   routes to ASK, regardless of what `git clean -ndX` lists. Unrecognized
+   gitignored files fall through to ASK, never SAFE or CACHE.
 7. **Caches are opt-in** — the CACHE tier (`__pycache__/`, `dist/`, `.mypy_cache/`,
    and the other compilation/tool/build patterns) is never auto-deleted by
    default; it is cleared only when `--caches` is passed (or approved item-by-item
@@ -234,3 +396,14 @@ inventory to confirm and report bytes freed.
    as it does to files**: check the denylist before the empty-directory rule in
    SAFE. Emptiness never promotes a denylisted path into SAFE, and never
    bypasses the fall-through to ASK for unrecognized gitignored paths.
+9. **Never delete a git worktree root** — a worktree is a live checkout that
+   may hold uncommitted, unpushed work, and it is denylisted on the strength of
+   `git worktree list --porcelain` (or a `.git` **file** pointing at
+   `…/.git/worktrees/…`), *not* on where it happens to live. Do not infer
+   protection from a dot-directory prefix: `.claude/worktrees/`, a sibling
+   `../repo-wt-fix123`, and a worktree under `/private/tmp/` are all protected
+   by this rule and none of them are matched by rule 6's prefix list. Report
+   every root (see Report) even when nothing is deleted — the one thing worse
+   than deleting a worktree is telling the operator their 94 GB tree is clean.
+   Sizing those roots is a `du` with no `-prune`, so it is opt-in behind
+   `--sizes` and bounded per root; the report itself never is.

--- a/.claude/skills/repo/hooks/guard-destructive.sh
+++ b/.claude/skills/repo/hooks/guard-destructive.sh
@@ -965,9 +965,127 @@ function qsplit(s,   out, n, i, c, j, qc, ci, inner, SQ, DQ) {
 #     smuggled payload is never hidden behind an opening quote.
 #   - An unterminated quote copies the remainder verbatim (best-effort; never
 #     widens a deny into an allow).
+#
+# HEREDOC AWARENESS (#84)
+#
+# The lexer above tracked quote state only — it had no concept of heredoc syntax
+# (`<<WORD`, `<<-WORD`, `<<'WORD'`, `<<"WORD"`). A composite like
+#   gh issue create --body "$(cat <<'EOF'
+#   shutdown Iq is specified at ...
+#   EOF
+#   )"
+# therefore fell through to the default "a raw newline splits" rule (the outer
+# double-quoted span carries `$(`, so by the #3679 safety floor its separators
+# stay ACTIVE), and every heredoc BODY line became its own phantom top-level
+# segment. lifecycle_or_cloud_reason() then read `toks[1]` of that phantom
+# segment and hard-denied on the word `shutdown`; the same phantom segments
+# reach parse_force_ops() and extract_rm_targets(). Heredoc body lines are DATA,
+# never command boundaries, so:
+#   - A heredoc opener seen OUTSIDE any inert quoted span records its terminator
+#     word (quotes/backslash stripped) and the `<<-` leading-TAB-strip flag. The
+#     REST of the opener line is segmented normally, so `cat <<EOF | grep x`
+#     still splits at the pipe.
+#   - The newline that ends the opener line closes that segment (it IS a real
+#     command boundary), and the body lines through the terminator are then
+#     SKIPPED entirely — they are data, so they contribute no segment and no
+#     tokens. Normal segmentation resumes on the line after the terminator, so a
+#     real command following the terminator still gets its own segment and still
+#     denies.
+#   - Multiple heredocs on one line (`cmd <<A <<B`) consume body A in full before
+#     body B, matching real shell semantics.
+#   - An UNTERMINATED heredoc skips the remainder of the buffer — which is
+#     exactly what a real shell does with it (the rest of the input IS the body
+#     and never executes), and mirrors the unterminated-quote fallback above.
+#     Anything BEFORE the opener is still segmented normally.
+#   - SAFETY CARVE-OUT: a body attached to a BARE (unquoted) delimiter is still
+#     parameter/command-expanded by the shell, so if such a body carries `$(` or
+#     a backtick the whole pending-heredoc region reverts to the legacy
+#     separator-active treatment — the same #3679 floor the quoted-span branch
+#     applies. A quoted/escaped delimiter (`<<'EOF'`, `<<"EOF"`, `<<\EOF`)
+#     suppresses expansion, so its body is unconditionally inert.
+#   - `<<<` is a here-STRING, not a heredoc, and is deliberately not matched.
+#   - A `<<` inside a shell COMMENT (`echo hi # <<EOF`) is not an operator at
+#     all, so the opener probe is SUPPRESSED from a word-initial unquoted `#`
+#     through the end of that physical line. Without this, the phantom opener's
+#     terminator never appears and the unterminated-heredoc rule would skip the
+#     rest of the buffer — hiding a real command on the NEXT line from
+#     extract_rm_targets(), which parses raw $COMMAND rather than
+#     $COMMAND_NO_COMMENT. Only the probe is suppressed (the characters still
+#     flow through normal separator handling), because skipping to the newline
+#     would in turn hide a trailing `; <cmd>` after a `#` that sits inside a
+#     command-substitution-bearing quoted span.
+#   - A newline preceded by an ODD number of backslashes is a LINE CONTINUATION,
+#     not the end of the logical line, so the pending bodies do NOT start there
+#     (`cat <<EOF \` + newline + `&& <cmd>` really does run `<cmd>`). Such a
+#     newline falls through to the legacy separator handling, so the continued
+#     line is segmented as the real commands it is; the bodies then start at the
+#     first NON-continued newline, matching the shell.
+# Safety floor unchanged: the raw ALWAYS_BLOCK_PATTERNS catastrophic scan reads
+# the command string directly (never through ml_segment), so a `$(...)`-smuggled
+# payload inside a heredoc body still denies, and a GENUINE multi-line command
+# whose later real line is dangerous still yields a real segment and still denies.
 # =============================================================================
 _ML_QSPLIT_AWK='
-function ml_segment(buf, segs,   SQ, DQ, s, n, seg, segc, i, c, qc, ci, j, inner) {
+# Probe for a heredoc redirection operator at position i (the caller guarantees
+# substr(s, i, 2) is "<<"). On success fills out["delim"] (terminator word, with
+# any surrounding quotes/backslash stripped), out["strip"] (1 for the `<<-` form,
+# which strips leading TABs from the terminator line) and out["quoted"] (1 when
+# the delimiter was quoted or backslash-escaped, i.e. the body is NOT expanded)
+# and returns the index of the first character AFTER the operator. Returns 0 when
+# this is NOT a heredoc opener: a `<<<` here-string, a `<<` with no delimiter
+# word, or a delimiter whose opening quote is never closed.
+function hd_opener(s, n, i, out,   j, c, q, w, SQ, DQ) {
+    SQ = sprintf("%c", 39)   # single quote
+    DQ = sprintf("%c", 34)   # double quote
+    j = i + 2
+    if (substr(s, j, 1) == "<") return 0        # `<<<` here-string, not a heredoc
+    out["strip"] = 0
+    out["quoted"] = 0
+    if (substr(s, j, 1) == "-") { out["strip"] = 1; j++ }
+    while (j <= n && (substr(s, j, 1) == " " || substr(s, j, 1) == "\t")) j++
+    w = ""
+    c = substr(s, j, 1)
+    if (c == SQ || c == DQ) {
+        q = c
+        out["quoted"] = 1                       # no expansion inside the body
+        j++
+        while (j <= n && substr(s, j, 1) != q) { w = w substr(s, j, 1); j++ }
+        if (j > n) return 0                     # unterminated delimiter quote
+        j++                                     # consume the closing quote
+    } else {
+        if (c == "\\") { out["quoted"] = 1; j++ }   # `<<\EOF` (escaped, unexpanded)
+        while (j <= n) {
+            c = substr(s, j, 1)
+            if (c ~ /[A-Za-z0-9_.:@%+=\/-]/) { w = w c; j++ } else break
+        }
+    }
+    if (w == "") return 0
+    # Reject shapes that are far more likely to be an arithmetic left-shift than
+    # a heredoc, so `$((1 << 3))` / `(( x << 2 ))` are not misread as openers that
+    # would swallow the rest of the buffer:
+    #   - an all-digit BARE delimiter (`<< 3`) — real delimiters are words;
+    #   - a delimiter not followed by a redirection/separator/whitespace boundary
+    #     (`<< 3))` — a genuine opener is always followed by more redirections,
+    #     a separator, or end of line.
+    if (!out["quoted"] && w ~ /^[0-9]+$/) return 0
+    c = substr(s, j, 1)
+    if (j <= n && c != " " && c != "\t" && c != "\n" && c != ";" && c != "&" &&
+        c != "|" && c != "<" && c != ">") return 0
+    out["delim"] = w
+    return j
+}
+# A newline at position i is a LINE CONTINUATION when it is preceded by an ODD
+# number of backslashes (`\` + newline is removed by the shell; `\\` + newline is
+# a literal backslash followed by a REAL newline). A continued newline does not
+# end the logical line, so heredoc bodies must NOT start there.
+function cont_nl(s, i,   bs, p) {
+    bs = 0
+    for (p = i - 1; p >= 1 && substr(s, p, 1) == "\\"; p--) bs++
+    return (bs % 2)
+}
+function ml_segment(buf, segs,   SQ, DQ, s, n, seg, segc, i, c, qc, ci, j, inner,
+                    hdc, hddelim, hdstrip, hdquoted, hdo, hdnext, h, k, unsafe,
+                    arO, arC, eol, nexti, line, t, incmt, pc) {
     SQ = sprintf("%c", 39)   # single quote
     DQ = sprintf("%c", 34)   # double quote
     split("", segs)          # clear the caller-supplied out-array
@@ -975,6 +1093,8 @@ function ml_segment(buf, segs,   SQ, DQ, s, n, seg, segc, i, c, qc, ci, j, inner
     n = length(s)
     seg = ""
     segc = 0
+    hdc = 0                  # heredoc openers pending a body on the next line
+    incmt = 0                # a shell COMMENT is open on the current line
     i = 1
     while (i <= n) {
         c = substr(s, i, 1)
@@ -990,6 +1110,13 @@ function ml_segment(buf, segs,   SQ, DQ, s, n, seg, segc, i, c, qc, ci, j, inner
             inner = substr(s, i + 1, ci - i - 1)
             if (index(inner, "$(") == 0 && index(inner, "`") == 0) {
                 seg = seg substr(s, i, ci - i + 1)   # inert span: verbatim (newlines stay literal)
+                # NOTE: `incmt` is deliberately NOT cleared here even when the
+                # span carries a newline. A real comment ends at that newline, so
+                # leaving the flag set can only suppress the opener probe for
+                # LONGER than the shell would — and over-suppression is strictly
+                # narrowing (it just restores the legacy pre-#84 treatment).
+                # Clearing it here would re-enable the probe on text the shell may
+                # still regard as commented, which is the widening direction.
                 i = ci + 1
                 continue
             }
@@ -997,7 +1124,94 @@ function ml_segment(buf, segs,   SQ, DQ, s, n, seg, segc, i, c, qc, ci, j, inner
             i++
             continue
         }
+        # A `#` that STARTS a word opens a shell COMMENT that runs to the end of
+        # the physical line, so any `<<WORD` after it is TEXT, not an operator.
+        # A word starts at the beginning of the buffer or right after an unquoted
+        # blank or shell METACHARACTER (` ` \t \n ; & | ( ) < >) — the full set
+        # bash uses to delimit words, so `;#`, `&&#`, `|#` and `(cmd)#` are all
+        # comment starts. A `#` in any OTHER position is part of a word
+        # (`http://x#y`, `${#arr}`, `ab#cd`) and is correctly NOT a comment.
+        #
+        # Only the heredoc-opener PROBE is suppressed while the flag is set — the
+        # characters still flow through the normal separator handling below,
+        # because skipping to the newline here would hide a trailing `; <cmd>` in
+        # a shape like `echo "$(id) # x" ; <cmd>` (a `#` inside a
+        # command-substitution-bearing quoted span is walked by this loop, and
+        # bash really does run that command). Probe suppression is strictly
+        # NARROWING: it can only restore the legacy pre-#84 treatment, never
+        # widen a deny into an allow — which is why the metacharacter set is
+        # chosen as a SUPERSET of the shapes bash actually treats as comments.
+        if (c == "#" && !incmt) {
+            pc = (i == 1) ? "" : substr(s, i - 1, 1)
+            if (i == 1 || pc == " " || pc == "\t" || pc == "\n" || pc == ";" ||
+                pc == "&" || pc == "|" || pc == "(" || pc == ")" ||
+                pc == "<" || pc == ">") incmt = 1
+        }
+        if (c == "<" && i < n && substr(s, i + 1, 1) == "<" && !incmt) {
+            if (substr(s, i + 2, 1) == "<") {
+                # `<<<` is a here-STRING: consume the whole operator so its third
+                # `<` cannot be re-probed as the start of a `<< WORD` heredoc.
+                seg = seg substr(s, i, 3)
+                i += 3
+                continue
+            }
+            # Inside an unclosed arithmetic expansion (`$((` / `((`) a `<<` is a
+            # left-shift operator, never a heredoc — count the unbalanced opens
+            # in the segment so far and skip the probe when we are inside one.
+            t = seg; arO = gsub(/\(\(/, "", t)
+            t = seg; arC = gsub(/\)\)/, "", t)
+            hdnext = (arO > arC) ? 0 : hd_opener(s, n, i, hdo)
+            if (hdnext > 0) {
+                # Record the pending heredoc and copy the operator verbatim (this
+                # also consumes a quoted delimiter, so its quotes never open a
+                # phantom quoted span). The REST of this line segments normally.
+                seg = seg substr(s, i, hdnext - i)
+                hdc++
+                hddelim[hdc] = hdo["delim"]
+                hdstrip[hdc] = hdo["strip"]
+                hdquoted[hdc] = hdo["quoted"]
+                i = hdnext
+                continue
+            }
+        }
+        if (c == "\n" && hdc > 0 && !cont_nl(s, i)) {
+            # End of the opener line: the pending heredoc BODIES follow. Look
+            # ahead across every pending body, in opener order, to find where the
+            # last one ends — and whether any EXPANSION-CAPABLE body (bare
+            # delimiter) carries a command substitution, which a real shell WOULD
+            # execute. That case keeps the legacy separator-active treatment
+            # (same #3679 floor the quoted-span branch above applies), so a
+            # smuggled payload is never hidden behind a heredoc opener.
+            k = i + 1
+            unsafe = 0
+            for (h = 1; h <= hdc; h++) {
+                while (k <= n) {
+                    eol = index(substr(s, k), "\n")
+                    nexti = (eol == 0) ? n + 1 : k + eol
+                    line = substr(s, k, nexti - k)
+                    t = line
+                    sub(/\n$/, "", t)
+                    if (hdstrip[h]) sub(/^\t+/, "", t)
+                    k = nexti
+                    if (t == hddelim[h]) break        # terminator line, body done
+                    if (!hdquoted[h] && (index(line, "$(") > 0 || index(line, "`") > 0)) unsafe = 1
+                }
+            }
+            hdc = 0
+            if (!unsafe) {
+                # The opener line is a complete simple command; the body (through
+                # its terminator, or through end-of-buffer when unterminated) is
+                # inert DATA and contributes no segment at all.
+                segs[++segc] = seg
+                seg = ""
+                incmt = 0
+                i = k
+                continue
+            }
+            # else: fall through to the ordinary separator handling below.
+        }
         if (c == ";" || c == "&" || c == "|" || c == "\n") {
+            if (c == "\n") incmt = 0   # a comment ends at the physical newline
             segs[++segc] = seg; seg = ""; i++; continue
         }
         seg = seg c

--- a/.claude/skills/repo/install-metadata.json
+++ b/.claude/skills/repo/install-metadata.json
@@ -1,6 +1,6 @@
 {
   "version": "0.7.0",
-  "commit": "bc9fe24",
+  "commit": "c925fb2",
   "dev": false,
   "commands": ["all","audit","branches","deps","docs","followups","gitignore","handoff","help","host-optimize","links","orphans","readme","release","remote","reset","sudo","tidy","update-tools"]
 }


### PR DESCRIPTION
Restores the gitignored .install-local.json sidecar (deleted by a pull, rjwalters/repo#96) and commits the tracked-file deltas from the same sanctioned installer run: post-tag doc fixes for all/followups/release/reset/tidy plus a guard-destructive.sh update. Part of the /repo:all update-tools stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNqnwQi5KJhHV3hpQB1eU1