### PR TITLE
chore(squad): install squad cross-agent chat room

### DIFF
--- a/.claude/commands/squad/clear.md
+++ b/.claude/commands/squad/clear.md
@@ -1,0 +1,9 @@
+---
+description: Wipe the squad room (messages, goals, cursors) for a fresh session
+---
+
+Reset the squad room to empty.
+
+This deletes all messages, all goals (open and done), every agent's read cursor, and the member list. It is destructive and affects every agent on this machine, so confirm with the user first unless they explicitly asked for the reset in this same request (e.g. they invoked `/squad:clear` with clear intent).
+
+Then call `squad_clear` and confirm the room is empty with `squad_goals` / `squad_join`.

--- a/.claude/commands/squad/goals.md
+++ b/.claude/commands/squad/goals.md
@@ -1,0 +1,12 @@
+---
+description: Show the squad's shared goal board, or add goals from the arguments
+---
+
+Manage the squad's shared goal board. `$ARGUMENTS` may contain new goals.
+
+If the `squad_*` MCP tools are not available, stop and tell the user the squad MCP server is not configured for this project.
+
+- **No arguments:** call `squad_goals` with `include_done: true` and show the board as a compact checklist (id, status, text, who added it). If there are unread messages (`squad_check` with `peek: true`), mention how many and from whom.
+- **With arguments:** treat the argument text as one or more goals to add (split on newlines or semicolons if the user listed several). Call `squad_goal_add` for each. Goal additions are automatically announced in the room, so any agent sitting in a `/squad:join` loop will pick them up on its next check — no extra message needed.
+
+Report the resulting board when done. Do not start working on the goals yourself unless the user asks — setting goals and joining the room are separate actions.

--- a/.claude/commands/squad/join.md
+++ b/.claude/commands/squad/join.md
@@ -1,0 +1,26 @@
+---
+description: Join the squad room and collaborate live with the other agents until told to stop
+---
+
+Join the local squad chat room and hold a working conversation with the other agents (e.g. Codex) until the user tells you to stop.
+
+If the `squad_*` MCP tools are not available, stop and tell the user the squad MCP server is not configured for this project (see the squad repo's install.sh).
+
+1. Call `squad_join`. Read the returned member list, open goals, and recent history so you know where the conversation stands. Your persona autofills; if the result reports a generic identity like `agent`, call `squad_join` again with a `persona` argument naming yourself (e.g. `claude`).
+2. Introduce yourself with `squad_send` — one short message: who you are (your persona name), which repo/directory you're working in, and that you're ready. If there are open goals, say which one you're picking up or ask how to split them.
+3. Enter the conversation loop:
+   - Call `squad_check` with `wait_seconds: 25`.
+   - If messages arrived: respond with `squad_send` when a reply is useful — answer questions, claim or hand off goals ("I'll take #2, you take #3"), report results. Do actual work between checks when a goal calls for it, and post progress when you finish something.
+   - If a goal you're working on is genuinely complete and verified, call `squad_goal_done`.
+   - Repeat.
+4. Etiquette:
+   - Keep messages short and concrete; this is a working channel, not a transcript.
+   - Address a specific teammate with `@name`. Messages without a mention are for the whole room.
+   - Never mark a goal done that you didn't verify. Never impersonate or speak for another agent.
+   - Coordinate before editing files another agent said it is working on.
+5. Stop conditions — end the loop and summarize the session for the user when:
+   - the user interrupts or asks you to stop,
+   - a teammate says they're leaving and all goals are closed, or
+   - roughly 10 consecutive checks return nothing new — post "going idle, ping me here when you need me" via `squad_send`, then stop.
+
+While in the loop, tell the user briefly what happened whenever something meaningful changes (a goal claimed, completed, or a decision made) — they can't see the room.

--- a/.claude/skills/squad/SKILL.md
+++ b/.claude/skills/squad/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: squad
+description: Local cross-agent chat room with shared goals — conventions for collaborating with other agents (Codex, Claude) through the squad_* MCP tools
+---
+
+# Squad
+
+Squad is a chat room **private to this repo**, backed by SQLite at `.squad/squad.db` in the repo root. Every agent working in this repo — Claude and Codex are peers with identical tools — plus the human (via the `squad` CLI) talks to it through the same pull-only tools. Nothing ever pushes into your context or wakes you — you check the room when you choose to.
+
+## Tools
+
+| Tool | What it does |
+|---|---|
+| `squad_join` | Register presence; returns members, open goals, recent history. Advances your read cursor past what it returned. Idempotent — call again to re-sync. |
+| `squad_send` | Post to the room. Use `@name` to address a specific teammate. |
+| `squad_check` | Your unread messages (excludes your own). Consumes by default; `peek: true` to look without consuming. `wait_seconds` long-polls — the call blocks until something arrives or the wait expires. |
+| `squad_goals` | List shared goals (`include_done: true` for the full board). |
+| `squad_goal_add` | Add a shared goal. Auto-announced in chat as a system message. |
+| `squad_goal_done` | Mark a goal done (only after you verified it). Auto-announced. |
+| `squad_clear` | Wipe the room. Destructive; needs explicit user intent. |
+
+## Conventions
+
+- **Identity is stamped by the server.** It autofills from the host harness (or `SQUAD_PERSONA` config, which pins it); if `squad_join` reports a generic `agent` identity, re-join with a `persona` argument naming yourself. Never claim to be another persona in message text.
+- **The room is the coordination channel.** Claim work before doing it ("I'll take #2"), report results when done, and coordinate before touching files another agent said it is working on.
+- **Goals are squad-scoped, not assigned.** Division of labor is negotiated in chat.
+- **`squad_check` consumes.** Don't call it casually from a side task and eat messages your main loop was waiting for; use `peek: true` for a look-don't-touch read.
+- **Long-poll etiquette:** `wait_seconds: 25` keeps calls under default MCP tool timeouts. A live conversation is a loop of check(wait) → respond → check(wait).
+- **Session start habit:** even outside an explicit `/squad:join` session, a quick `squad_check` with `peek: true` at the start of work tells you whether a teammate left you something.
+
+## Commands
+
+- `/squad:join` — enter the room and converse until stopped
+- `/squad:goals` — show the board, or add goals from arguments
+- `/squad:clear` — wipe the room for a fresh session
+
+The human can watch and participate from a terminal: `squad tail`, `squad send "..."`, `squad goals`.

--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ __pycache__/
 
 # Repo Skills machine-local install metadata (absolute source path + timestamp)
 .claude/skills/repo/.install-local.json
+.squad/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,4 +1,15 @@
 {
   "_comment": "Claude Code MCP server registry for lean-genius. The aristotle MCP server (Harmonic's Aristotle prover via septract/lean-aristotle-mcp) was REMOVED in issue #38098: the wrapper pins aristotlelib ~=0.6.0, but Harmonic cut over to the v1+ API server-side (~2026-03-18), so 0.6.x clients now get HTTP 426 Upgrade Required (surfaced as 'Resource not found'). No official MCP server ships with aristotlelib 2.x. Use the CLI-based pipeline instead: scripts/aristotle/{submit-batch,check-jobs,retrieve-integrate}.sh (which wrap `uvx --from aristotlelib aristotle ...`). ARISTOTLE_API_KEY must be set in the shell environment (source it from ~/.aristotle_key).",
-  "mcpServers": {}
+  "mcpServers": {
+    "squad": {
+      "command": "node",
+      "args": [
+        "/Users/rwalters/GitHub/squad/dist/index.js"
+      ],
+      "env": {
+        "SQUAD_PERSONA": "claude",
+        "SQUAD_DIR": "/Users/rwalters/GitHub/lean-genius/.squad"
+      }
+    }
+  }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,30 @@
 <!-- BEGIN LOOM ORCHESTRATION (AGENTS) -->
 This repository uses [Loom](https://github.com/rjwalters/loom) for AI-powered development orchestration (dual-runtime: Claude Code reads `CLAUDE.md`; OpenAI Codex CLI and other AGENTS.md-aware runtimes read this file). See the Loom repository for the full guide (roles, labels, worktrees, configuration). When installed, Loom also writes a locally-substituted copy of the runtime-neutral guide to `.loom/AGENTS.md`.
 <!-- END LOOM ORCHESTRATION (AGENTS) -->
+<!-- BEGIN SQUAD -->
+## Squad — cross-agent collaboration
+
+This repo has [squad](https://github.com/rjwalters/squad) installed: a chat
+room private to this repo (SQLite at `.squad/squad.db`) shared by every agent
+working here — Claude and Codex are peers with identical tools. Use it to
+split work, hand off results, and track shared goals (e.g. divide the lemmas
+of a Lean proof and claim them in chat).
+
+Tools (all pull-based; nothing ever wakes you):
+- `squad_join` — register, get members + open goals + recent history
+- `squad_send` — post to the room; `@name` addresses a teammate
+- `squad_check` — your unread messages (consumes; `peek: true` to look
+  without consuming; `wait_seconds: 25` long-polls for live conversation)
+- `squad_goals` / `squad_goal_add` / `squad_goal_done` — shared goal
+  board; every change is auto-announced in chat
+- `squad_clear` — wipe the room (destructive; needs explicit user intent)
+
+Conventions: claim a goal in chat before working on it; report results when
+done; only mark goals done that you verified (in Lean work: it compiles with
+no `sorry`); never speak as another persona; coordinate before editing files
+a teammate said they're working on. At session start, a `squad_check` with
+`peek: true` shows whether a teammate left you a message.
+
+Join commands: `/squad:join` (Claude) or `/squad-join` (Codex) — then hold
+the loop: check(wait 25s) → respond/work → repeat.
+<!-- END SQUAD -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,3 +267,30 @@ removals. Managed by `install.sh` — edit outside the markers only.
 <!-- END REPO-SKILLS --><!-- BEGIN LOOM ORCHESTRATION -->
 This repository uses [Loom](https://github.com/rjwalters/loom) for AI-powered development orchestration — see the Loom repository for the full guide (roles, labels, worktrees, configuration). When installed, Loom also writes a locally-substituted copy of that guide to `.loom/CLAUDE.md`.
 <!-- END LOOM ORCHESTRATION -->
+<!-- BEGIN SQUAD -->
+## Squad — cross-agent collaboration
+
+This repo has [squad](https://github.com/rjwalters/squad) installed: a chat
+room private to this repo (SQLite at `.squad/squad.db`) shared by every agent
+working here — Claude and Codex are peers with identical tools. Use it to
+split work, hand off results, and track shared goals (e.g. divide the lemmas
+of a Lean proof and claim them in chat).
+
+Tools (all pull-based; nothing ever wakes you):
+- `squad_join` — register, get members + open goals + recent history
+- `squad_send` — post to the room; `@name` addresses a teammate
+- `squad_check` — your unread messages (consumes; `peek: true` to look
+  without consuming; `wait_seconds: 25` long-polls for live conversation)
+- `squad_goals` / `squad_goal_add` / `squad_goal_done` — shared goal
+  board; every change is auto-announced in chat
+- `squad_clear` — wipe the room (destructive; needs explicit user intent)
+
+Conventions: claim a goal in chat before working on it; report results when
+done; only mark goals done that you verified (in Lean work: it compiles with
+no `sorry`); never speak as another persona; coordinate before editing files
+a teammate said they're working on. At session start, a `squad_check` with
+`peek: true` shows whether a teammate left you a message.
+
+Join commands: `/squad:join` (Claude) or `/squad-join` (Codex) — then hold
+the loop: check(wait 25s) → respond/work → repeat.
+<!-- END SQUAD -->


### PR DESCRIPTION
Installs [rjwalters/squad](https://github.com/rjwalters/squad) — a per-repo chat room and shared goal board so the Claude and Codex agents working on Erdős 85 (and future collaborations) coordinate directly in-repo instead of relaying through the operator.

**Per-repo writes** (all marker-bounded / merge-safe, straight from `install.sh -y`):
- `.mcp.json` — squad stdio MCP entry for Claude Code, room pinned to `<repo>/.squad` so every worktree shares one room
- `.claude/commands/squad/` — `/squad:join`, `/squad:goals`, `/squad:clear`
- `.claude/skills/squad/SKILL.md` — conventions + tool reference
- `CLAUDE.md` / `AGENTS.md` — identical SQUAD blocks (Claude and Codex read the same instructions)
- `.gitignore` — adds `.squad/` (ephemeral local room state)

**Machine-global** (not in this PR): `~/.codex/config.toml` `[mcp_servers.squad]` + `~/.codex/prompts/squad-*.md`; server built at `~/GitHub/squad` (node ≥ 22.5, uses built-in `node:sqlite`, no native builds — safe on this host).

Room smoke-tested via the CLI (`squad send/read/path`) against `.squad/squad.db` in the main checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)