### PR TITLE
security: remove infrastructure identifiers and real addresses from tracked files

### DIFF
--- a/.loom/docs/token-pool.md
+++ b/.loom/docs/token-pool.md
@@ -175,8 +175,8 @@ Behavior notes:
 - Only `is_active = 1` rows are imported; `expires_at` is **not** used as a filter
   (observed rows carry stale timestamps while still authenticating — health comes
   from `loom-daemon tokens check`).
-- Token filenames use the same derivation as `bootstrap` (`robb@2amlogic.com` →
-  `robb-2amlogic.token`), so an account keeps one identity across both paths and
+- Token filenames use the same derivation as `bootstrap` (`alice@example.com` →
+  `alice-example.token`), so an account keeps one identity across both paths and
   re-importing overwrites in place.
 - Idempotent: unchanged tokens are left untouched. `index.json` records
   `source: monitor-db` (distinct from the `monitor` snapshot) and, as always,

--- a/scripts/agents/check-token-registry.sh
+++ b/scripts/agents/check-token-registry.sh
@@ -9,7 +9,7 @@
 # claude-monitor migration (#41033/#41044/#41045) the PRIMARY source is
 # ~/.claude-monitor/accounts.env, which carries EMAIL + KEY only:
 #
-#     ACCOUNT_EMAIL_N       account email  (e.g. robb@2amlogic.com)
+#     ACCOUNT_EMAIL_N       account email  (e.g. alice@example.com)
 #     ACCOUNT_KEY_N         the OAuth token value                    (SECRET)
 #     ACCOUNT_TOKEN_FILE_N  OPTIONAL explicit token filename (legacy .env only)
 #
@@ -18,9 +18,9 @@
 # strip '.' and '-' from the email local-part, append '-<first-domain-label>',
 # lowercase, drop unsafe chars, then '.token'. Examples:
 #
-#     robb@2amlogic.com             -> robb-2amlogic.token
-#     r.j.walters@gmail.com         -> rjwalters-gmail.token
-#     robb@integratedplasmonics.com -> robb-integratedplasmonics.token
+#     alice@example.com             -> alice-example.token
+#     a.b.carol@example.net         -> abcarol-example.token
+#     dave@example.org              -> dave-example.token
 #     agent-1@2amlogic.com          -> agent1-2amlogic.token
 #     agent-2@2amlogic.com          -> agent2-2amlogic.token
 #

--- a/scripts/agents/sync-token-registry.sh
+++ b/scripts/agents/sync-token-registry.sh
@@ -10,9 +10,9 @@
 # the email local-part, append '-<first-domain-label>', lowercase, drop unsafe
 # chars, then '.token'. Examples:
 #
-#     robb@2amlogic.com             -> robb-2amlogic.token
-#     r.j.walters@gmail.com         -> rjwalters-gmail.token
-#     robb@integratedplasmonics.com -> robb-integratedplasmonics.token
+#     alice@example.com             -> alice-example.token
+#     a.b.carol@example.net         -> abcarol-example.token
+#     dave@example.org              -> dave-example.token
 #     agent-1@2amlogic.com          -> agent1-2amlogic.token
 #     agent-2@2amlogic.com          -> agent2-2amlogic.token
 #

--- a/scripts/deploy/check-account.sh
+++ b/scripts/deploy/check-account.sh
@@ -12,9 +12,25 @@
 
 set -euo pipefail
 
-EXPECTED_ACCOUNT_ID="251e6e8626d921603fdc3f0d75576bc6"
+# Pinned as a SHA-256 digest, not a literal: this is a public repo and an
+# account identifier does not need publishing. Reading it from the
+# environment would be weaker -- the guard exists to catch a wrong account
+# that is already logged in, so an expectation the environment can move is
+# one a wrong environment moves with it. 128 bits of hex, so not brute-forceable.
+EXPECTED_ACCOUNT_ID_SHA256="04e8eb2a99d37a555c87220b1d4cd1c018afbe5b65360bdd2224eb8e9f6b69c2"
 EXPECTED_ACCOUNT_NAME="Personal Account"
-EXPECTED_EMAIL="r.j.walters@gmail.com"
+
+# Portable sha256 (sha256sum on Linux, shasum on macOS).
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        printf '%s' "$1" | sha256sum | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
+    else
+        echo "ERROR: neither sha256sum nor shasum found - cannot verify account." >&2
+        exit 1
+    fi
+}
 
 usage() {
     cat <<EOF
@@ -24,9 +40,8 @@ Verify wrangler is authenticated to the Cloudflare account used for
 lean-genius deployments.
 
 Expected account:
-  Name:  $EXPECTED_ACCOUNT_NAME
-  Email: $EXPECTED_EMAIL
-  ID:    $EXPECTED_ACCOUNT_ID
+  Name:      $EXPECTED_ACCOUNT_NAME
+  ID sha256: $EXPECTED_ACCOUNT_ID_SHA256
 
 Options:
   --help, -h  Show this help message without running wrangler
@@ -61,17 +76,19 @@ fi
 CURRENT_ACCOUNT_ID=$(echo "$WHOAMI_OUTPUT" | grep -oE '[a-f0-9]{32}' | head -1)
 CURRENT_EMAIL=$(echo "$WHOAMI_OUTPUT" | grep -oE 'associated with the email [^ ]+' | sed 's/associated with the email //; s/[[:punct:]]$//')
 
-if [[ "$CURRENT_ACCOUNT_ID" != "$EXPECTED_ACCOUNT_ID" ]]; then
+CURRENT_ACCOUNT_SHA256=$(sha256_of "$CURRENT_ACCOUNT_ID")
+
+if [[ "$CURRENT_ACCOUNT_SHA256" != "$EXPECTED_ACCOUNT_ID_SHA256" ]]; then
     echo "============================================================" >&2
     echo "  DEPLOY BLOCKED: Wrong Cloudflare account!" >&2
     echo "============================================================" >&2
     echo "" >&2
-    echo "  Current:  $CURRENT_EMAIL ($CURRENT_ACCOUNT_ID)" >&2
-    echo "  Expected: $EXPECTED_EMAIL ($EXPECTED_ACCOUNT_ID)" >&2
+    echo "  Current  sha256: ${CURRENT_ACCOUNT_SHA256:0:12}..." >&2
+    echo "  Expected sha256: ${EXPECTED_ACCOUNT_ID_SHA256:0:12}..." >&2
     echo "" >&2
     echo "  Fix: wrangler login  (then select Personal Account)" >&2
     echo "============================================================" >&2
     exit 1
 fi
 
-echo "✓ Cloudflare account verified: $EXPECTED_EMAIL"
+echo "✓ Cloudflare account verified: $EXPECTED_ACCOUNT_NAME"

--- a/scripts/deploy/sync-and-deploy.sh
+++ b/scripts/deploy/sync-and-deploy.sh
@@ -1089,7 +1089,7 @@ deploy_website() {
     # Verify we have the account pinned
     if [[ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
         print_error "CLOUDFLARE_ACCOUNT_ID not set. Add it to .env to prevent wrong-account deploys."
-        print_info "Expected: 251e6e8626d921603fdc3f0d75576bc6 (Personal Account)"
+        print_info "Expected: the Personal Account (see scripts/deploy/check-account.sh)"
         return 1
     fi
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,7 +3,7 @@ name = "lean-genius"
 compatibility_date = "2024-01-01"
 pages_build_output_dir = "dist"
 
-# Deploy target: Personal Account (r.j.walters@gmail.com / 251e6e8626d921603fdc3f0d75576bc6)
+# Deploy target: Personal Account
 # The pre-deploy check in scripts/deploy/check-account.sh enforces this.
 
 # D1 Database for users, sessions, and comments


### PR DESCRIPTION
Found by a disclosure sweep across all 73 public repos (2AMLogic/2am#88 — private). Four leaks live at HEAD in this public repo:

- `scripts/deploy/check-account.sh` pinned the Cloudflare account ID **and** the account holder's personal email as literals, printing both on failure. This is the **third copy** of this guard in the estate (after 2AMLogic/klayout-tools and rjwalters/kicad-tools) — it propagated by copying, so the pattern may exist in repos not yet scanned.
- `scripts/deploy/sync-and-deploy.sh` printed the account ID in an error hint.
- `wrangler.toml` named the account ID and email in a comment.
- `scripts/agents/{check,sync}-token-registry.sh` used three real addresses as worked examples of the email→token-filename derivation.

## Approach

The account expectation is now a **SHA-256 digest**. Reading it from the environment would be the weaker fix: this guard exists to catch a wrong account that is *already logged in*, so an expectation the environment can move is one a wrong environment moves with it. The ID is 128 bits of hex, so the digest does not expose it. Failure output prints digest prefixes.

Token-registry examples become reserved `example.com/.net/.org` addresses, teaching the identical derivation rule.

## Verification

Used the script's own `WRANGLER_WHOAMI_OUTPUT` hook — correct account passes, wrong account exits 1, `--help` works. `bash -n` clean on all four scripts; `wrangler.toml` still parses.

An earlier pass renamed the variable without updating every reference, which under `set -u` failed with an unbound variable instead of comparing. Caught by running it, not by reading it.

## Deliberately unchanged

`wrangler.toml`'s D1 `database_id` (wrangler needs the literal to bind D1) and `SUBMISSION_EMAIL` (where the app actually sends submissions). Both are functional values, not incidental leaks, and are flagged for a separate decision.