### PR TITLE
fix(gallery): make search match slugs, diacritics and hyphenated tags

### DIFF
--- a/src/lib/gallery-search.ts
+++ b/src/lib/gallery-search.ts
@@ -38,19 +38,53 @@ export function compareTitles(a: string, b: string): number {
 }
 
 /**
- * Fold each entry's searchable fields into one pre-lowercased haystack string,
+ * Normalize text for search: strip diacritics, lowercase, and collapse every
+ * run of non-alphanumeric characters to a single space.
+ *
+ * Applied to BOTH the haystack fields and the query, so the two meet in the
+ * middle. Without it, three natural searches all returned nothing:
+ *
+ * - `erdos 85` — the title is `Erdős Problem #85`, so `erdos 85` never appears
+ *   as a contiguous run. Folding `ő`→`o` and turning `#` into a space makes it
+ *   one.
+ * - `erdos-85` — the slug, i.e. the identifier in the URL and the name people
+ *   actually use, normalizes to the same `erdos 85`.
+ * - `number theory` — previously only matched the literal spaced phrase, never
+ *   the `number-theory` *tag* carried by 1,641 entries.
+ *
+ * Punctuation is collapsed rather than deleted so `4-cycle` becomes `4 cycle`
+ * (two tokens) instead of `4cycle`. Matching stays a plain contiguous substring
+ * test, so a multi-word query is still a *phrase* search — `number theory` does
+ * not degenerate into "any entry containing both words somewhere".
+ *
+ * Uses the Unicode property escapes `\p{L}\p{N}` rather than `[a-z0-9]` so
+ * non-Latin scripts (Greek letters in mathematical titles, CJK) survive instead
+ * of being erased to an empty string.
+ */
+export function normalizeSearchText(value: string): string {
+  return value
+    .normalize('NFD')
+    // Strip combining marks left by NFD: ő -> o, é -> e, ü -> u.
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim()
+}
+
+/**
+ * Fold each entry's searchable fields into one normalized haystack string,
  * keyed by slug.
  *
- * Fields are joined with a newline, which no single-line search input can
- * contain — so a query can never match across a field boundary and the result
- * set is identical to per-field substring matching.
+ * Each field is normalized independently (see {@link normalizeSearchText}) and
+ * the results are joined with a newline. Normalization can never *produce* a
+ * newline, so a query can never match across a field boundary — the result set
+ * stays equivalent to per-field matching.
  *
  * `undefined`, `null` and empty fields are dropped. Numeric fields (e.g. an
- * Erdős problem number) are stringified, matching the previous
- * `.toString().includes(query)` behaviour.
+ * Erdős problem number) are stringified.
  *
  * Note that entries coming from the prebuilt search index are *already*
- * lowercased (`scripts/annotations/build.ts`); lowercasing again here is
+ * lowercased (`scripts/annotations/build.ts`); normalizing again here is
  * idempotent and costs nothing at steady state since this runs once per data
  * change.
  */
@@ -62,8 +96,9 @@ export function buildHaystacks<T extends { slug: string }>(
   for (const item of items) {
     const text = toFields(item)
       .filter((field): field is string | number => field !== null && field !== undefined && field !== '')
+      .map((field) => normalizeSearchText(String(field)))
+      .filter(Boolean)
       .join('\n')
-      .toLowerCase()
     haystacks.set(item.slug, text)
   }
   return haystacks

--- a/src/pages/ErdosPage.tsx
+++ b/src/pages/ErdosPage.tsx
@@ -11,7 +11,7 @@ import { Plus, Filter, ArrowUpDown, Search, Github, Share2, ExternalLink, Calend
 import { useDebouncedUrlState, useUrlState, serializers, useFetchedData, useLazyFetchedData, useIncrementalList } from '@/hooks'
 import { ErdosGalleryCard } from '@/components/proof'
 import { LoadMore } from '@/components/ui/load-more'
-import { buildHaystacks, buildSortKeys, compareTitles, sortKeysFor } from '@/lib/gallery-search'
+import { buildHaystacks, buildSortKeys, compareTitles, normalizeSearchText, sortKeysFor } from '@/lib/gallery-search'
 import type { ProofBadge as ProofBadgeType, ProofListing } from '@/types/proof'
 
 type SortOption = 'problem-number' | 'newest' | 'updated' | 'alphabetical'
@@ -88,6 +88,8 @@ export function ErdosPage() {
       searchIndex?.[listing.slug] ?? listing.description,
       ...listing.tags,
       listing.erdosNumber,
+      // Searchable slug: "erdos-85" normalizes to "erdos 85".
+      listing.slug,
     ]),
     [erdosListings, searchIndex]
   )
@@ -99,8 +101,8 @@ export function ErdosPage() {
   const erdosProofs = useMemo(() => {
     let filtered: ProofListing[] = erdosListings
 
-    if (searchQuery.trim()) {
-      const query = searchQuery.toLowerCase()
+    const query = normalizeSearchText(searchQuery)
+    if (query) {
       filtered = filtered.filter((listing) => haystacks.get(listing.slug)?.includes(query))
     }
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -12,7 +12,7 @@ import { groupListings } from '@/lib/oq-group'
 import { WIEDIJK_BADGE_INFO, HILBERT_BADGE_INFO, MILLENNIUM_BADGE_INFO, ERDOS_BADGE_INFO } from '@/types/proof'
 import { Plus, Filter, ArrowUpDown, Search, Github, Share2, Dices } from 'lucide-react'
 import { useDebouncedUrlState, useUrlState, serializers, useFetchedData, useLazyFetchedData, useIncrementalList } from '@/hooks'
-import { buildHaystacks, buildSortKeys, compareTitles, sortKeysFor } from '@/lib/gallery-search'
+import { buildHaystacks, buildSortKeys, compareTitles, normalizeSearchText, sortKeysFor } from '@/lib/gallery-search'
 import type { ProofBadge as ProofBadgeType, ProofListing } from '@/types/proof'
 
 type SortOption = 'newest' | 'oldest' | 'alphabetical' | 'updated'
@@ -71,6 +71,9 @@ export function HomePage() {
       listing.title,
       searchIndex?.[listing.slug] ?? listing.description,
       ...listing.tags,
+      // The slug is the identifier users see in the URL ("erdos-85"), so it
+      // must be searchable; normalization turns it into "erdos 85".
+      listing.slug,
     ]),
     [listings, searchIndex]
   )
@@ -82,8 +85,8 @@ export function HomePage() {
   const proofs = useMemo(() => {
     let filtered: ProofListing[] = listings ?? []
 
-    if (searchQuery.trim()) {
-      const query = searchQuery.toLowerCase()
+    const query = normalizeSearchText(searchQuery)
+    if (query) {
       filtered = filtered.filter((listing) => haystacks.get(listing.slug)?.includes(query))
     }
 

--- a/src/pages/ResearchPage.tsx
+++ b/src/pages/ResearchPage.tsx
@@ -10,7 +10,7 @@ import { ResearchCard, ContributeSection, RelatedToolsSection } from '@/componen
 import { PHASE_INFO, TIER_INFO } from '@/types/research'
 import { useDebouncedUrlState, useUrlState, serializers, useFetchedData, useLazyFetchedData, useIncrementalList } from '@/hooks'
 import { LoadMore } from '@/components/ui/load-more'
-import { buildHaystacks, compareTitles } from '@/lib/gallery-search'
+import { buildHaystacks, compareTitles, normalizeSearchText } from '@/lib/gallery-search'
 import type { ResearchPhase, ValueTier, ResearchStatus, ResearchListing } from '@/types/research'
 import {
   FlaskConical,
@@ -77,6 +77,8 @@ export function ResearchPage() {
       problem.title,
       searchIndex?.[problem.slug] ?? problem.description,
       ...(problem.tags ?? []),
+      // Searchable slug, consistent with the proof galleries.
+      problem.slug,
     ]),
     [researchListings, searchIndex]
   )
@@ -97,8 +99,8 @@ export function ResearchPage() {
   const problems = useMemo(() => {
     let filtered: ResearchListing[] = [...(researchListings ?? [])]
 
-    if (searchQuery.trim()) {
-      const query = searchQuery.toLowerCase()
+    const query = normalizeSearchText(searchQuery)
+    if (query) {
       filtered = filtered.filter((problem) => haystacks.get(problem.slug)?.includes(query))
     }
 


### PR DESCRIPTION
## Problem

Searching **`erdos 85` returns no hits.** So does `erdos-85` — the slug users see in the URL and the name people actually use for the entry.

This is **pre-existing, not a regression from #43695**. I verified the old and new predicates return identical sets for every probe query, including the failing ones.

The entry looks like this:

```
slug        : erdos-85
title       : 'Erdős Problem #85: Minimum Degree for 4-Cycles'
tags        : ['erdos', 'graph-theory', 'extremal', '4-cycle', ...]
erdosNumber : 85
```

Three independent causes:

1. **No separator normalization.** Matching is a raw substring test, so `erdos 85` must appear as one contiguous run. The title is `Erdős Problem #85` — it never does.
2. **Diacritics.** The title has `Erdős` (U+0151 `ő`); the query has `erdos`. The single-word query `erdos` only worked by luck, via the ASCII `erdos` *tag*.
3. **The slug was never searchable.** It isn't among the fields fed to the haystack.

## Fix

Add `normalizeSearchText()` — NFD, strip combining marks, lowercase, collapse every run of non-alphanumerics to a single space — and apply it to **both** the haystack fields and the query, so the two meet in the middle. Add `slug` to the searchable fields on all three gallery pages.

```
"Erdős Problem #85"  ->  "erdos problem 85"
"erdos-85"           ->  "erdos 85"
"number-theory"      ->  "number theory"
"π-approximation"    ->  "π approximation"
```

**Matching stays a contiguous substring test**, so a multi-word query is still a *phrase* search. I prototyped the obvious alternative — AND-tokenizing the query — and **rejected it**: it blew `number theory` up from 42 to **2,049** hits by matching both words anywhere in long descriptions, destroying phrase precision. Separator normalization fixes the reported bug without that cost.

Uses `\p{L}\p{N}` rather than `[a-z0-9]` so Greek letters in mathematical titles (and CJK) survive instead of being erased to an empty string.

## Verification (real data, 4,810 listings)

| query | old | new | `erdos-85` found |
|---|---|---|---|
| `erdos 85` | 0 | **12** | no → **yes** |
| `erdos-85` | 0 | **12** | no → **yes** |
| `erdős 85` | 0 | **12** | no → **yes** |
| `ERDOS 85` | 0 | **12** | no → **yes** |
| `sidon` | 46 | 46 | — |
| `graph` | 550 | 550 | — |
| `xyzzy` / `   ` / `---` | 0 | 0 | — |
| `number theory` | 42 | 1,710 | — |

The one large change is `number theory`, and it is **correct**: the tag `number-theory` is carried by **1,641 listings** and now matches the spaced query, which it never did before. Sampled hits are all genuinely number-theory entries (`abel-ruffini-oq-03`, `a054656-distinct-prime-partition`, …).

**Phrase-semantics guard** — a synthetic entry titled `Number of primes` with description `a theory of sets` still does **not** match `number theory`. Words must remain adjacent.

`tsc -b` and `eslint` clean on all four changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
