### PR TITLE
chore(repo): hygiene pass — ignore .codex/worktrees/, fix stale docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@
 .claude/skills/repo/.install-local.json
 .claude/projects/
 .claude/worktrees/
+# Codex agent worktrees (same role as .claude/worktrees/ and .loom/worktrees/)
+.codex/worktrees/
 aristotle-results/llm-mapping-cache.json
 *.token
 
@@ -39,14 +41,10 @@ aristotle-results/llm-mapping-cache.json
 # host-local dev symlink to the loom-tools package source (see #43675)
 loom-tools
 research/*.pid
-research/*.log
-proofs/err.log
-scripts/enricher/*.log
 scripts/enricher/logs/
 
 # ── Build artifacts / caches ───────────────────────────────────────────
 .lake
-.lake/
 .build-cache/
 .erdos-cache/
 .wrangler/
@@ -113,9 +111,6 @@ proofs/data/knuth/tour-finder/Cargo.lock
 proofs/data/knuth/tour-finder/target/
 
 # Research runtime leftovers
-research/stub-claims/
-# Retired daemon-stop sentinel; the live signal is .loom/signals/stop-lean-daemon
-research/lean-stop-daemon
 proofs/Proofs/*.bak
 proofs/Proofs/*.lean.bak
 proofs/Proofs/*.backup
@@ -174,6 +169,4 @@ __pycache__/
 .loom/logs/
 # <<< loom-managed <<<
 
-# Repo Skills machine-local install metadata (absolute source path + timestamp)
-.claude/skills/repo/.install-local.json
 .squad/

--- a/README.md
+++ b/README.md
@@ -105,9 +105,11 @@ src/
 │   └── ui/           # Shared UI primitives
 ├── contexts/         # React contexts (auth)
 ├── data/proofs/      # Proof content (Lean source, annotations, metadata)
+├── hooks/            # Shared React hooks
 ├── lib/              # Utilities (Lean tokenizer, etc.)
 ├── pages/            # Route pages
-└── types/            # TypeScript types
+├── types/            # TypeScript types
+└── utils/            # Misc helpers
 
 proofs/
 ├── Proofs/           # Individual Lean proof files
@@ -122,9 +124,9 @@ scripts/              # Build, agent, and deployment scripts
 research/             # Research problem tracking and state
 infra/                # Infrastructure-as-code (unapplied Terraform skeleton)
 mcp-servers/          # MCP server implementations
-external/             # Vendored external artifacts
+external/             # Git submodules (erdosproblems, formal-conjectures)
 public/               # Build-generated static assets (gitignored)
-aristotle-results/    # Retrieved Aristotle proof-search output
+aristotle-results/    # Retrieved Aristotle proof-search output (gitignored)
 ```
 
 ## Working with Proofs

--- a/proofs/README.md
+++ b/proofs/README.md
@@ -9,6 +9,10 @@ Lean 4 mathematical proofs with Mathlib, integrated into the LeanGenius monorepo
 | ✅ Verified | Compiles without sorry/axioms |
 | ⚠️ WIP | Contains sorry or custom axioms |
 
+> The lists below cover only the original core proofs. The project now holds
+> 6,000+ Lean files (including 2,000+ Erdős problem formalizations); per-proof
+> status is tracked in the gallery metadata under `src/data/proofs/`.
+
 ### Verified Proofs
 - `Sqrt2.lean` - Basic √2 properties
 - `Sqrt2Irrational.lean` - √2 is irrational
@@ -68,10 +72,11 @@ This will:
      sorry
    ```
 
-2. Add import to `Proofs.lean`:
-   ```lean
-   import Proofs.MyTheorem
-   ```
+2. No import registration is needed — `lakefile.toml` uses
+   `globs = ["Proofs", "Proofs.*"]`, so every file under `Proofs/` is picked up
+   automatically. Do **not** add `import Proofs.MyTheorem` to `Proofs.lean`
+   (see the note at the top of that file — per-file imports there caused
+   constant merge conflicts).
 
 3. Build:
    ```bash
@@ -104,8 +109,14 @@ proofs/
 │   ├── Sqrt2Irrational.lean  # ✅ Verified
 │   ├── NavierStokes.lean     # ⚠️ WIP (axioms)
 │   └── ...
+├── bin/                 # Safety wrapper blocking direct `lake build`
+├── data/                # Supporting data (e.g. Knuth tour extraction)
 └── scripts/
     ├── setup.sh
+    ├── docker-build.sh          # REQUIRED build path (memory-limited)
+    ├── build-safe-subset.sh
+    ├── activate-safety.sh
+    ├── DOCKER-BUILD-RUNBOOK.md
     └── extract-proof-info.sh
 ```
 

--- a/proofs/bin/README.md
+++ b/proofs/bin/README.md
@@ -22,26 +22,26 @@ When `proofs/bin` is in your PATH (before `~/.elan/bin`), the `lake` wrapper scr
 
 ## Activation
 
-### Option 1: direnv (recommended)
+### Option 1: activation script (recommended)
 
-If you use [direnv](https://direnv.net/), the project's `.envrc` automatically adds this to your PATH:
-
-```bash
-# Already in .envrc:
-export PATH="$PWD/proofs/bin:$PATH"
-```
-
-Just run `direnv allow` in the project root.
-
-### Option 2: Manual activation
-
-Source the activation script:
+Source the activation script from the repo root:
 
 ```bash
 source ./proofs/scripts/activate-safety.sh
 ```
 
-Or add to your shell profile:
+### Option 2: direnv
+
+The repo does not ship an `.envrc` (it's a per-machine choice). If you use
+[direnv](https://direnv.net/), create one at the project root and run
+`direnv allow`:
+
+```bash
+# .envrc
+export PATH="$PWD/proofs/bin:$PATH"
+```
+
+### Option 3: Shell profile
 
 ```bash
 # In ~/.bashrc or ~/.zshrc

--- a/research/README.md
+++ b/research/README.md
@@ -54,7 +54,7 @@ npx tsx .lean/scripts/extract-problems.ts
 # research/problems/goldbach-weak/problem.md
 
 # Start the OODA loop
-/researcher
+/lean-research
 ```
 
 ### Option 3: Check Status
@@ -81,7 +81,10 @@ Problems are automatically extracted from the proof gallery:
 | **Hilbert** | 21 | Hilbert's 23 Problems |
 | **GitHub issues** | on demand | Human-filed problems tagged `research:queued` (see below) |
 
-**Total**: 427+ extractable open problems
+**Total**: the per-source counts above are an early snapshot and drift as the
+gallery grows — the live candidate pool (`.lean/state/candidate-pool.json`)
+currently holds ~4,200 candidates, and `research/problems/` tracks ~2,700
+worked problems.
 
 ### GitHub-issue intake (`research:queued`)
 
@@ -144,7 +147,7 @@ OBSERVE → ORIENT → DECIDE → ACT → VERIFY → LEARN
 
 ### Primary Role
 
-**Researcher** (`/researcher`): Drives the main OODA loop. Reads state, decides what phase to execute, performs the work, updates state.
+**Researcher** (`/lean-research`): Drives the main OODA loop. Reads state, decides what phase to execute, performs the work, updates state.
 
 ### Supporting Roles
 
@@ -152,8 +155,8 @@ OBSERVE → ORIENT → DECIDE → ACT → VERIFY → LEARN
 |------|---------|-----------|
 | **Scout** (`/lean-scout`) | Structured gallery, technique, and literature survey | ORIENT phase (auto-invoked by Researcher) |
 | **Seeker** (`/lean-seeker`) | Selects next research problem from candidate pool | Between research iterations (daemon-managed) |
-| **Adversary** (`/adversary`) | Attack proofs | VERIFY phase |
-| **Chronicler** (`/chronicler`) | Document learnings, update technique index | LEARN phase |
+| **Adversary** (no dedicated command — performed by the Researcher) | Attack proofs | VERIFY phase |
+| **Chronicler** (no dedicated command — performed by the Researcher) | Document learnings, update technique index | LEARN phase |
 
 ## Autonomous OODA Loop
 
@@ -181,8 +184,8 @@ Seeker selects next problem (loop repeats)
 ### Starting the Autonomous Loop
 
 ```bash
-# Start the full mathematical team with seeker
-/lean-daemon start --seeker 1 --researcher 1
+# Start the full mathematical team with seeker (see also: /lean)
+./scripts/lean/launch.sh start --seeker 1 --researcher 1
 
 # Or start individual agents
 /lean-seeker                    # Select next problem
@@ -263,9 +266,9 @@ research/
 │
 ├── knowledge/                # Cross-problem insights
 │   ├── technique-index.json  # Which techniques used on which problems
-│   ├── synthesis-report.md   # Auto-generated cross-problem report
 │   ├── patterns.md           # Cross-problem patterns
-│   └── techniques.md         # General learnings
+│   ├── tactics.md            # Tactic-level learnings
+│   └── theorems.md           # Reusable theorem catalog
 │
 └── problems/                 # Active research
     └── {problem-slug}/

--- a/research/VISION.md
+++ b/research/VISION.md
@@ -164,7 +164,7 @@ PROGRESS:
 
 ### How Users Contribute
 
-1. **Run research sessions**: `/research erdos-340-greedy-sidon`
+1. **Run research sessions**: `/lean-research` (after claiming a problem, e.g. erdos-340-greedy-sidon)
 2. **Donate compute**: Local Lean builds verify proofs
 3. **Share API access**: Aristotle jobs run on user's API key
 4. **Review and merge**: Human oversight on proof integration

--- a/scripts/annotations/README.md
+++ b/scripts/annotations/README.md
@@ -39,15 +39,19 @@ At build time, anchors are resolved to actual line numbers.
 
 ## File Structure
 
-For each proof:
+For a proof migrated to anchors:
 
 ```
 src/data/proofs/{proof-name}/
 ├── annotations.source.json   # Source: anchors (what you edit)
 ├── annotations.json          # Generated: line numbers (for frontend)
-├── meta.json
-└── index.ts
+└── meta.json
 ```
+
+Only a small fraction of proofs have been migrated (currently ~56 of ~4,800
+gallery entries have an `annotations.source.json`). The rest carry a
+hand-maintained line-based `annotations.json`, which the build checks via the
+legacy validation path below.
 
 ## Commands
 


### PR DESCRIPTION
## Summary

Safe fixes from a `/repo:all` hygiene audit (docs + gitignore only — no code changes).

**gitignore**
- Ignore `.codex/worktrees/` — a registered agent worktree (2.8 GB incl. its own `.lake`) sat unignored in the tree; `git add -A` would have staged it. Siblings `.claude/worktrees/` / `.loom/worktrees/` were already ignored.
- Remove dead rules (`research/stub-claims/`, retired `research/lean-stop-daemon`), dedupe `.lake` / duplicate `.install-local.json` line, drop per-dir `*.log` rules subsumed by the global `*.log`.

**docs**
- `proofs/README.md`: stop instructing per-file imports in `Proofs.lean` (contradicts the lakefile glob and Proofs.lean's own header); note the status tables list only original core proofs; fix the `scripts/` tree.
- `proofs/bin/README.md`: activation referenced a nonexistent `.envrc`; `activate-safety.sh` is now the documented primary path.
- `research/README.md`: fix dead slash commands (`/researcher` → `/lean-research`, `/lean-daemon` → `launch.sh`), correct `research/knowledge/` listing, mark early problem counts as a snapshot.
- `research/VISION.md`, `scripts/annotations/README.md`, root `README.md`: smaller accuracy fixes (submodules vs "vendored", gitignored annotations, anchor migration coverage ~56/4800).

## Deferred (surfaced by the audit, not fixed here)
- 9 of 10 `scripts/tests/*.test.sh` suites are wired to no runner/CI
- ~20 orphaned scripts and ~5 MB of regenerable Knuth debug PNGs
- ~3,900 stale local branches / 21 stashes (needs a gated prune)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
